### PR TITLE
Add operator re-fusion survey benchmarks for transformer models

### DIFF
--- a/bench/RESULTS_refusion.md
+++ b/bench/RESULTS_refusion.md
@@ -300,8 +300,34 @@ cards:
 | `ort(sim_safe)` — `Attention=12` | 16.87 / **5.59** | 8.09 / 5.38 |
 
 (fp32 ms / fp16 ms.  The 5050 fp32 column is TF32 — ORT's default on Ampere and
-newer — while the 2060 has no TF32 at all, so the fp32 columns are *not* the same
-arithmetic across cards.  The fp16 columns are directly comparable.)
+newer — while the 2060 has no TF32 at all.  A separate `--tf32 off` run pins that
+down; see below.)
+
+Re-running the 5050 with `--tf32 off` gives the true-fp32 column and makes the
+two cards comparable:
+
+| RTX 5050 | fp32 (TF32, ORT default) | fp32 (`--tf32 off`) | fp16 |
+| --- | --- | --- | --- |
+| `raw` | 7.97 | 12.91 | 5.22 |
+| `ort(sim_nogemm)` — no Attention | 7.82 | 12.72 | **4.98** |
+| `ort(sim_safe)` — `Attention=12` | 8.09 | 12.96 | 5.39 |
+
+Three things fall out of that column:
+
+* **TF32 is worth 1.62× on this card** (12.91 → 7.97 ms), and it is on by
+  default.  That, not the architecture's raw speed, is most of why the 5050's
+  fp32 row looked so much faster than the 2060's.  In true fp32 the 5050 is only
+  1.30× the 2060 (12.91 vs 16.73 ms); in fp16 both cards gain about the same
+  multiple over their own true-fp32 baseline (2.5× and 2.4×).
+* **The sign of the attention-fusion effect does not depend on TF32.**  On the
+  5050 the fused model is 1.02× the time in true fp32 and 1.03× with TF32 — the
+  same small penalty either way — while in fp16 it is 1.08×.  So Finding 7's
+  fp32 line is a property of the fused kernel selection, not an artefact of
+  Ampere-and-newer default arithmetic.
+* The harness's numerical check sees TF32 plainly: `ort(raw)` fp32 differs from
+  the unfused fp32 reference by 2.2e-03 with TF32 on and 3.2e-06 with it off.
+  Worth knowing before reading any `max_abs_diff` from an Ampere-or-newer card as
+  an accuracy statement about the graph rewrite.
 
 `ort(sim_nogemm)` vs `ort(sim_safe)` again isolates exactly one pass
 (`fuse_consecutive_unsqueezes`, i.e. whether ORT could build `Attention=12`):
@@ -309,7 +335,7 @@ arithmetic across cards.  The fp16 columns are directly comparable.)
 | | fp32 | fp16 |
 | --- | --- | --- |
 | RTX 2060 | Attention 1.02× the time (no gain) | Attention **0.82×** — the fusion saves 18 % |
-| RTX 5050 | Attention 1.03× the time | Attention **1.08×** — the fusion *costs* 8 % |
+| RTX 5050 | Attention 1.03× (TF32) / 1.02× (true fp32) | Attention **1.08×** — the fusion *costs* 8 % |
 | CPU (same host) | 0.95×–1.05× across two runs — inside the noise | — |
 
 **The sign of the effect is not a property of the graph; it is a property of the

--- a/bench/RESULTS_refusion.md
+++ b/bench/RESULTS_refusion.md
@@ -348,6 +348,17 @@ fuse_matmul_add_bias_into_gemm_batched  recovers SkipLayerNormalization=24, Bias
 fuse_consecutive_unsqueezes             recovers Attention=12
 ```
 
+A third vendor was attempted and is worth recording as a negative result.  On a
+**Radeon 8060S** (RDNA 3.5, gfx1151) there is currently no ONNX Runtime GPU path
+to measure at all: the ROCm EP was removed from onnxruntime in 1.23, AMD's
+replacement MIGraphX EP needs a wheel that is not on PyPI, and the ONNX Runtime
++ MIGraphX combination on gfx1151 is reported broken in current ROCm.  A machine
+of that class runs these models on the CPU EP today.  That is the same lesson
+the two NVIDIA cards teach, in a starker form -- whether a fused contrib op is a
+good idea depends on a runtime-and-hardware combination that onnxsim cannot see
+at simplification time, and here there is not even a fused path to have an
+opinion about.
+
 The 5050 numbers above were reproduced by a second full run on the same host:
 every variant landed within 0.5 % of the table (e.g. `ort(sim_nogemm)` fp16
 4.975 → 4.986 ms, `ort(sim_safe)` fp16 5.381 → 5.381 ms), so the sign flip is

--- a/bench/RESULTS_refusion.md
+++ b/bench/RESULTS_refusion.md
@@ -24,8 +24,10 @@ onnxsim built from this branch (`claude/operator-refusion-survey-ve7ee6`, at
 `5db7370`) and, where noted, onnxsim 0.7.0 from PyPI for comparison.
 
 Findings 1–6 are graph-level and come from that CPU run.  Finding 7 is the
-latency measurement, from a GeForce RTX 2060 at the `bert-base` preset; it is
-what turns the fused-op censuses below into milliseconds.
+latency measurement, from a GeForce RTX 2060 (Turing) and a GeForce RTX 5050
+(Blackwell) at the `bert-base` preset; it is what turns the fused-op censuses
+below into milliseconds — and shows that the milliseconds do not point the same
+way on both cards.
 
 ## How it is measured
 
@@ -262,11 +264,14 @@ Python rewriter or a matcher extension.
    `bench/refusion_survey.py` already computes it; wiring "ORT recovers the same
    fused-op census before and after `simplify`" into CI would have caught
    Finding 2 the day the pass landed.  The census — not a timing — has to be the
-   check: Finding 7 shows the regression is invisible in fp32 and nearly
-   invisible on a CPU, so a wall-clock guard on CI hardware would never fire.
+   check, and Finding 7 is why: the wall-clock consequence of the same graph
+   change is +18 % on one GPU, −8 % on another and inside the noise on a CPU, so
+   no timing-based guard on CI hardware could encode it.
 4. **Reconsider `fuse_consecutive_unsqueezes` (and the batched-Gemm pass) in the
-   default set.**  Both trade a node or two for a rewrite the runtime would
-   rather do itself — ORT does its own `MatMul+Add → Gemm` at session level
+   default set.**  Note the argument is predictability, not a guaranteed speedup
+   — Finding 7 shows the fused path is the faster one on Turing and the slower
+   one on Blackwell.  Both passes trade a node or two for a rewrite the runtime
+   would rather do itself — ORT does its own `MatMul+Add → Gemm` at session level
    anyway (`Gemm=12` appears in the session-level census of the *raw* model).
    Either drop them from the defaults, or gate them behind a
    `--target-runtime`-style switch for users who really want a Gemm-centric
@@ -278,64 +283,75 @@ Python rewriter or a matcher extension.
    `RMSNormalization`) and measuring the payoff with this harness before
    attempting `Attention`.
 
-## Finding 7 — the lost Attention fusion costs 18 % of GPU inference time, but only in fp16
+## Finding 7 — the fusion's *value* is hardware-dependent; on Blackwell it is currently negative
 
-Measured on a **GeForce RTX 2060** (Turing, sm75, 6 GB, driver 610.57.04),
-CUDAExecutionProvider, onnxruntime 1.28.0, `--preset bert-base` (12 layers,
-hidden 768, 12 heads, seq 384, batch 1), median of 100 runs.  fp16 rows are the
-same graph converted with fp32 graph I/O; each row's `fp16_initializers` count
-in the JSON confirms the conversion actually happened.
+Measured at `--preset bert-base` (12 layers, hidden 768, 12 heads, seq 384,
+batch 1), CUDAExecutionProvider, onnxruntime 1.28.0, median of 100 runs, on two
+cards:
 
-| variant | fused ops ORT runs | fp32 ms | fp16 ms |
-| --- | --- | --- | --- |
-| `raw` | `Gemm=72, FusedMatMul=12, SkipLayerNormalization=24, Gelu=12` | 16.73 | 7.07 |
-| `sim` (default) | *does not load* | — | — |
-| `sim_nogemm` | same as `raw` | 16.71 | 7.14 |
-| `sim_safe` | same as `raw` | 16.85 | 7.14 |
-| `ort(raw)` | **`Attention=12`**`, SkipLayerNormalization=24, BiasGelu=12` | 16.87 | **5.55** |
-| `ort(sim)` | *does not load* | — | — |
-| `ort(sim_nogemm)` | `SkipLayerNormalization=24, BiasGelu=12` (no Attention) | 16.47 | 6.84 |
-| `ort(sim_safe)` | **`Attention=12`**`, SkipLayerNormalization=24, BiasGelu=12` | 16.87 | **5.59** |
+| | RTX 2060 (Turing sm75) | RTX 5050 (Blackwell sm120) |
+| --- | --- | --- |
+| `raw` | 16.73 / 7.07 | 7.97 / 5.22 |
+| `sim` (default) | *does not load* | *does not load* |
+| `sim_nogemm` | 16.71 / 7.14 | 7.96 / 5.22 |
+| `sim_safe` | 16.85 / 7.14 | 7.97 / 5.22 |
+| `ort(raw)` — `Attention=12` | 16.87 / **5.55** | 8.09 / 5.38 |
+| `ort(sim_nogemm)` — no Attention | 16.47 / 6.84 | 7.82 / **4.97** |
+| `ort(sim_safe)` — `Attention=12` | 16.87 / **5.59** | 8.09 / 5.38 |
 
-`ort(sim_nogemm)` and `ort(sim_safe)` differ only in whether
-`fuse_consecutive_unsqueezes` merged the mask's `Unsqueeze` pair, so that pair
-isolates the cost of Finding 2:
+(fp32 ms / fp16 ms.  The 5050 fp32 column is TF32 — ORT's default on Ampere and
+newer — while the 2060 has no TF32 at all, so the fp32 columns are *not* the same
+arithmetic across cards.  The fp16 columns are directly comparable.)
 
-* **fp16: 6.84 ms → 5.59 ms, a 1.22× slowdown — 18 % of inference time** given
-  away to save one node out of 414.
-* **fp32: 16.47 ms → 16.87 ms — the fused model is 2 % *slower*.**
-* CPU (same machine, same preset): 49.7 ms → 47.5 ms, 1.05×.
+`ort(sim_nogemm)` vs `ort(sim_safe)` again isolates exactly one pass
+(`fuse_consecutive_unsqueezes`, i.e. whether ORT could build `Attention=12`):
 
-The precision split is the interesting part.  ONNX Runtime's fast fused-attention
-kernels on Turing are fp16 tensor-core paths (the TRT fused attention and
-memory-efficient attention kernels); in fp32 the CUDA EP falls back to an
-implementation that is no better than the unfused graph, so `Attention=12` buys
-nothing.  Two consequences:
+| | fp32 | fp16 |
+| --- | --- | --- |
+| RTX 2060 | Attention 1.02× the time (no gain) | Attention **0.82×** — the fusion saves 18 % |
+| RTX 5050 | Attention 1.03× the time | Attention **1.08×** — the fusion *costs* 8 % |
+| CPU (same host) | 0.95×–1.05× across two runs — inside the noise | — |
 
-* **The fusion is only worth fighting for in fp16** — which is how transformers
-  are actually deployed on this class of card.  fp16 alone is 2.4× over fp32
-  (`raw` 16.73 → 7.07 ms); fp16 *plus* the attention fusion is 3.0×
-  (16.73 → 5.55 ms).  Breaking the fusion throws away the last third of that.
-* **A CPU-only or fp32-only benchmark cannot see this regression at all.**  Any
-  CI guard against it has to look at the fused-op census (which the survey
-  script reports) rather than at wall-clock on the machine running the tests.
+**The sign of the effect is not a property of the graph; it is a property of the
+card.**  On Turing, `com.microsoft.Attention` in fp16 is the fast path and losing
+it costs 18 % of inference time.  On Blackwell with ORT 1.28 the same fused node
+is *slower* than letting the unfused graph run — the fastest configuration
+measured on the 5050 is `ort(sim_nogemm)` fp16 at 4.97 ms, a model with **no**
+attention fusion at all, beating the fused `ort(raw)` at 5.38 ms.  The likely
+cause is fused-attention kernel coverage for sm120 in this ORT version, but that
+is unverified here; what the data supports is the observation, not the mechanism.
 
-The decoder fixture has no attention fusion to lose, and onnxsim is a small win
-in fp16 (`raw` 9.28 ms → `sim` 9.05 ms, 2.5 %) and neutral in fp32 (22.0 vs
-22.2 ms).  Both already-fused fixtures stay fused end to end in both precisions.
+What this does *not* change: onnxsim still silently removes the runtime's
+*ability* to fuse, on every card, and it still emits a model that does not load
+(Finding 1) on both.  What it does change is the argument for fixing it.  The
+case is not "the fusion is always faster" — it plainly is not.  The case is:
 
-Running `--bisect` on that machine reproduced the two culprit passes exactly, at
-12-layer scale, for both BERT fixtures:
+* **Predictability.** A one-node rewrite that saves nothing measurable should not
+  decide, silently and per-architecture, which kernel the runtime gets to use.
+  Users who want the Gemm-centric or unfused shape can ask for it.
+* **The user is the one who can measure.**  onnxsim cannot know the deployment
+  target; ORT's own optimizer, run by the user on their hardware, can be
+  benchmarked both ways.  Foreclosing that choice at simplification time is the
+  problem, not the direction of today's benchmark on today's driver.
+
+Both cards agree on everything else: fp16 is the large, reliable win (2.4× on the
+2060, 1.5× on the 5050 over its own TF32 baseline); the decoder fixture has no
+attention fusion to lose and onnxsim is neutral-to-slightly-positive on it
+(5050: `raw` 6.68 ms → `ort(sim_safe)` 6.52 ms in fp16); and both already-fused
+fixtures stay fused end to end in both precisions on both cards.
+
+`--bisect` on both machines named the same two culprit passes at 12-layer scale,
+for both BERT fixtures:
 
 ```
 fuse_matmul_add_bias_into_gemm_batched  recovers SkipLayerNormalization=24, BiasGelu=12
 fuse_consecutive_unsqueezes             recovers Attention=12
 ```
 
-One caveat on the CPU latency column of that run: it is noisy (the
-`llama_layer_gqa` variants range 58–129 ms across variants that produce
-identical graphs). Read the CPU numbers as fusion censuses, not timings; the GPU
-timings are tight, with p90 within ~1 % of the median.
+One caveat on the CPU latency columns: they are noisy on this host (`ort(sim_safe)`
+came in at 47.5 ms in one run and 50.0 ms in the next, and `llama_layer_gqa`
+variants with identical graphs ranged 58–129 ms). Read the CPU numbers as fusion
+censuses, not timings; the GPU timings are tight, with p90 within ~1 % of median.
 
 ## Running it yourself
 

--- a/bench/RESULTS_refusion.md
+++ b/bench/RESULTS_refusion.md
@@ -348,6 +348,11 @@ fuse_matmul_add_bias_into_gemm_batched  recovers SkipLayerNormalization=24, Bias
 fuse_consecutive_unsqueezes             recovers Attention=12
 ```
 
+The 5050 numbers above were reproduced by a second full run on the same host:
+every variant landed within 0.5 % of the table (e.g. `ort(sim_nogemm)` fp16
+4.975 → 4.986 ms, `ort(sim_safe)` fp16 5.381 → 5.381 ms), so the sign flip is
+not run-to-run noise.
+
 One caveat on the CPU latency columns: they are noisy on this host (`ort(sim_safe)`
 came in at 47.5 ms in one run and 50.0 ms in the next, and `llama_layer_gqa`
 variants with identical graphs ranged 58–129 ms). Read the CPU numbers as fusion

--- a/bench/RESULTS_refusion.md
+++ b/bench/RESULTS_refusion.md
@@ -23,6 +23,10 @@ CPUExecutionProvider, `--preset tiny` (2 layers, hidden 256, 4 heads, seq 128),
 onnxsim built from this branch (`claude/operator-refusion-survey-ve7ee6`, at
 `5db7370`) and, where noted, onnxsim 0.7.0 from PyPI for comparison.
 
+Findings 1–6 are graph-level and come from that CPU run.  Finding 7 is the
+latency measurement, from a GeForce RTX 2060 at the `bert-base` preset; it is
+what turns the fused-op censuses below into milliseconds.
+
 ## How it is measured
 
 Each fixture is a hand-built ONNX graph with the topology real exporters emit
@@ -272,19 +276,67 @@ Python rewriter or a matcher extension.
    `RMSNormalization`) and measuring the payoff with this harness before
    attempting `Attention`.
 
-## What the GPU run adds
+## Finding 7 — on a GPU, the lost Attention fusion costs 23 % of inference time
 
-Everything above is a *graph* measurement; on a CPU the fused kernels are worth
-little, and the latency column in the CPU survey is dominated by noise (a shared
-container, ±40 % between repeats).  On an NVIDIA GPU the same census turns into
-real time: the CUDA EP's fused attention kernels (and, in fp16 on Turing, the
-TensorRT fused-attention path) are the reason `com.microsoft.Attention` exists.
+Measured on a **GeForce RTX 2060** (Turing, sm75, 6 GB, driver 610.57.04),
+CUDAExecutionProvider, onnxruntime 1.28.0, `--preset bert-base` (12 layers,
+hidden 768, 12 heads, seq 384, batch 1), median of 100 runs:
 
-`bench/refusion_gpu_bench.py` times every variant on the CUDA EP in fp32 and
-fp16, and dumps the session-level fused-op census per variant, so the cost of
-Finding 2 can be read directly as milliseconds.  See "Running it on a GPU" in
-`bench/refusion_gpu_run.sh` — on an RTX 2060 (Turing, sm75, 6 GB) the
-`bert-base` preset fits comfortably.
+| variant | nodes | fused ops ORT runs | median ms | vs `raw` |
+| --- | --- | --- | --- | --- |
+| `raw` | 414 | `Gemm=72, FusedMatMul=12, SkipLayerNormalization=24, Gelu=12` | 7.07 | 1.00× |
+| `sim` (default) | 388 | *does not load* | — | — |
+| `sim_nogemm` | 412 | same as `raw` | 7.14 | 0.99× |
+| `sim_safe` | 413 | same as `raw` | 7.11 | 0.99× |
+| `ort(raw)` | 87 | **`Attention=12`**`, SkipLayerNormalization=24, BiasGelu=12` | **5.54** | **1.28×** |
+| `ort(sim)` | 340 | *does not load* | — | — |
+| `ort(sim_nogemm)` | 304 | `SkipLayerNormalization=24, BiasGelu=12` (no Attention) | 6.83 | 1.04× |
+| `ort(sim_safe)` | 88 | **`Attention=12`**`, SkipLayerNormalization=24, BiasGelu=12` | **5.57** | 1.27× |
 
-Results from that run are not included here — this survey was produced on a
-CPU-only machine.
+Reading the two middle rows against each other isolates the cost of Finding 2:
+`ort(sim_nogemm)` and `ort(sim_safe)` differ only in whether
+`fuse_consecutive_unsqueezes` merged the mask's `Unsqueeze` pair, and that is
+**6.83 ms vs 5.57 ms — a 1.23× slowdown, 18 % of total inference time** given
+away to save one node.  On the CPU leg of the same run the same pair is 52.3 ms
+vs 50.2 ms (1.04×), which is why this has to be measured on an accelerator: the
+fused attention kernel is worth ~5× more on the GPU than on the CPU.
+
+Note also what the `raw` row shows: ORT's **session-level** optimizer never
+produces `Attention` on its own, on either provider.  Only the Python
+`onnxruntime.transformers.optimizer` pass does.  So the fusion at stake is one
+users have to opt into — and one onnxsim can silently make impossible.
+
+The decoder fixture behaves as on the CPU: no attention fusion exists to lose,
+onnxsim is a small win (`raw` 9.23 ms, `sim` 9.00 ms, `ort(sim)` 8.86 ms), and
+the norm fusions survive simplification intact.  The two already-fused fixtures
+stay fused end to end, with latencies flat inside noise (1.7–1.9 ms, dominated
+by launch overhead at that size).
+
+### Caveat on precision in this run
+
+The RTX 2060 numbers above were produced by
+`bench/refusion_gpu_bench.py` before a bug in its fp16 leg was fixed:
+`OnnxModel` wraps a ModelProto *by reference*, so `to_fp16()` converted each
+variant in place before the "fp32" row was timed, and **every row in that run is
+the fp16 graph** (visible in the JSON as 416 nodes for `bert_layer` where the
+fp32 fixture has 414 — the two extra `Cast` nodes fp16 conversion inserts).  The
+comparison between variants is unaffected, since every variant got the same
+treatment, so the 1.23× above stands as an fp16 measurement on Turing.  A true
+fp32-vs-fp16 split needs a re-run with the fixed script, which now also records
+`fp16_initializers` per row so the leg cannot silently mislabel itself again.
+
+The same aliasing explains the `max_abs_diff` values in that run: `ort(raw)`
+differs from the reference by 0.63 max-abs, which is fp16 accumulated across 12
+layers of random (untrained) weights along a different kernel path, not an fp32
+accuracy claim.  The CPU leg of the same run, in fp32, shows 4.3e-06 for the
+same comparison.
+
+## Running it yourself
+
+```bash
+bash bench/refusion_gpu_run.sh            # setup + CPU survey (--bisect) + CUDA run
+bash bench/refusion_gpu_run.sh --quick    # tiny model, fast smoke test
+```
+
+It writes `refusion_cpu_<host>.json` and `refusion_gpu_<host>.json` with every
+number above.

--- a/bench/RESULTS_refusion.md
+++ b/bench/RESULTS_refusion.md
@@ -1,0 +1,290 @@
+# Re-fusion of compute-dominant operators (Attention & friends)
+
+A transformer's runtime is almost entirely the attention block and the two FFN
+GEMMs.  Every serious runtime therefore *re-fuses* the exported node soup back
+into single kernels -- ONNX Runtime rewrites the block into
+`com.microsoft.Attention` / `MultiHeadAttention`, `SkipLayerNormalization`,
+`BiasGelu`; TensorRT does the same inside its own builder.  Those rewrites are
+**pattern matches on the exact node sequence the exporter emitted**.
+
+That makes "simplification" and "fusability" pull against each other: a graph
+rewrite that removes one node but perturbs the pattern can cost the model an
+entire fused attention kernel.  This survey measures which way onnxsim pulls.
+
+Everything here is reproducible with the two scripts in this directory:
+
+```bash
+python bench/refusion_survey.py --preset tiny --bisect      # pattern-level, CPU
+bash   bench/refusion_gpu_run.sh                            # latency, CUDA EP
+```
+
+Environment for the numbers below: onnx 1.22.0, onnxruntime 1.28.0,
+CPUExecutionProvider, `--preset tiny` (2 layers, hidden 256, 4 heads, seq 128),
+onnxsim built from this branch (`claude/operator-refusion-survey-ve7ee6`, at
+`5db7370`) and, where noted, onnxsim 0.7.0 from PyPI for comparison.
+
+## How it is measured
+
+Each fixture is a hand-built ONNX graph with the topology real exporters emit
+(`bench/refusion_fixtures.py`), and is run through this matrix:
+
+| variant | meaning |
+| --- | --- |
+| `raw` | the exported graph |
+| `sim` | `onnxsim.simplify` with default settings |
+| `sim_nogemm` | `simplify` with `fuse_matmul_add_bias_into_gemm_batched` skipped |
+| `ort(raw)` | ONNX Runtime's transformer fusion on the export — the ceiling |
+| `ort(sim)` | ORT fusion *after* onnxsim — **the re-fusion question** |
+| `sim(ort(raw))` | onnxsim on an already-fused model — **the preservation question** |
+
+Two independent fusion measures are reported: `onnxruntime.transformers`
+(`opt_level=0`, pure pattern matching, so every fused op came from a matcher
+walking that exact graph) and ORT's own session-level optimizer
+(`ORT_ENABLE_ALL`, which is what actually runs, and is execution-provider
+dependent).
+
+---
+
+## Finding 1 — onnxsim currently produces a **broken model** for a standard attention block
+
+On this branch, the default pipeline turns the BERT fixture into a model that
+ONNX Runtime refuses to run:
+
+```
+Node (layer0.attn/PV) Op (MatMul) [ShapeInferenceError] Incompatible dimensions
+Reshape 'layer0.attn.k/Reshape': input shape {128,256}, requested shape {128,256,4,64}
+```
+
+Minimal reproduction — three nodes, no attention required:
+
+```python
+# x[1,8,16] -> MatMul(W[16,16]) -> Add(b[16]) -> Reshape([0,0,4,4]) -> y[1,8,4,4]
+sim, _ = onnxsim.simplify(model)      # default settings
+# -> Reshape(x,[-1,16]) -> Gemm -> Reshape(·,[0,0,4,4])   ... which cannot run
+```
+
+Two passes combine to produce it:
+
+1. `fuse_matmul_add_bias_into_gemm_batched` (opted into by default in
+   `onnxsim.cpp`) rewrites the rank-3 `MatMul+Add` of every Q/K/V projection
+   into `Reshape → Gemm → Reshape(restore rank)`.
+2. `eliminate_consecutive_idempotent_ops` (upstream onnx-optimizer) then treats
+   `Reshape(Reshape(x, s1), s2)` as `Reshape(x, s2)`.  That identity is **false
+   whenever `s2` contains a `0`**: with the default `allowzero=0`, a `0` means
+   "copy the corresponding dimension *of this node's input*", and the rewrite
+   changes what that input is.  The pass does not check for zeros:
+   `third_party/onnx-optimizer/onnxoptimizer/passes/eliminate_consecutive_idempotent_ops.h`
+   only checks `uses().size() == 1`.
+
+Exporters emit `Reshape` shapes with `0` constantly (`x.view(B, S, H, D)` traces
+to `[0, 0, 4, 64]`), and the head-splitting reshape directly follows the Q/K/V
+projection — so *every* attention block hits this.
+
+Severity notes:
+
+* **It is silent.** Both `simplify(model)` and the `onnxsim in.onnx out.onnx`
+  CLI default to `check_n=0`, so nothing verifies the result.  With `check_n=3`
+  onnxsim does catch it (it raises while running the check).
+* The zero-dim `Reshape`-fusion bug is **not new** — onnxsim 0.7.0 from PyPI
+  mis-simplifies the two-consecutive-`Reshape` repro identically.  What is new
+  on this branch is that the default pipeline now *creates* that node pair on
+  every transformer linear layer, so ordinary models now trip over it.
+* `simplify(..., skipped_optimizers=["fuse_matmul_add_bias_into_gemm_batched"])`
+  or `["eliminate_consecutive_idempotent_ops"]` both avoid it.
+
+## Finding 2 — a one-node rewrite costs the model its Attention fusion
+
+Comparing against `sim_nogemm` (the variant that still runs):
+
+| variant | nodes | fused ops ORT can recover |
+| --- | --- | --- |
+| `raw` | 74 | `Attention=2, BiasGelu=2, SkipLayerNormalization=4` |
+| `sim` (default) | 68 | model does not load |
+| `sim_nogemm` | 72 | `BiasGelu=2, SkipLayerNormalization=4` |
+| `sim_safe` (both culprit passes skipped) | 73 | `Attention=2, BiasGelu=2, SkipLayerNormalization=4` |
+
+`--bisect` names both culprits on its own:
+
+```
+optimizer passes that cost the model a downstream fusion:
+  fuse_matmul_add_bias_into_gemm_batched  recovers BiasGelu=2, SkipLayerNormalization=4
+  fuse_consecutive_unsqueezes             recovers Attention=2
+```
+
+(the first "recovers" everything because skipping it is what makes the model
+load at all — Finding 1).  With both skipped, `ort(sim_safe)` reaches ORT's
+ceiling exactly: 16 nodes, `Attention=2, BiasGelu=2, SkipLayerNormalization=4`,
+one node *fewer* than `ort(raw)`'s 17 — simplification and fusability are not
+actually in conflict here, the default pass set just gives up the fusion for
+nothing.  The same holds for the decomposed-LayerNorm export
+(`bert_layer_decomposed_ln`, 106 nodes): `ort(sim_safe)` again lands on 16 nodes
+with the full fused census, so onnxsim's rewrites do not hurt ORT's
+`LayerNormFusion`.
+
+The entire difference is `fuse_consecutive_unsqueezes` (an onnxsim-specific
+pass, `onnxsim/passes/fuse_consecutive_unsqueezes.h`).  HuggingFace's attention
+mask is exported as
+
+```
+mask[B,S] → Unsqueeze → Unsqueeze → Cast → Sub(1-m) → Mul(-10000) → Add(scores)
+```
+
+and ORT's `FusionAttention` walks exactly
+`["Mul", "Sub", "Cast", "Unsqueeze", "Unsqueeze"]` back to the 2-D mask input to
+build the `mask_index` input of `com.microsoft.Attention`
+(`onnxruntime/transformers/fusion_attention.py`).  Merging the two `Unsqueeze`
+nodes into one saves **one node out of 74** and costs **two fused attention
+kernels**.
+
+The `--bisect` mode of the survey script finds this automatically: it re-runs
+`simplify` with one more pass skipped each round (greedily, because some fusions
+are gated on others — attention fusion anchors on a `LayerNormalization` node)
+and reports the passes whose removal restores a fusion.
+
+## Finding 3 — already-fused operators *are* preserved
+
+Good news, and it is worth keeping it that way with a regression test.  onnxsim
+leaves fused compute-dominant ops alone in both domains:
+
+| fixture | `raw` | after `simplify` |
+| --- | --- | --- |
+| `fused_onnx_attention` (ai.onnx opset 23) | `Attention=1, RMSNormalization=1, RotaryEmbedding=2` (17 nodes) | unchanged, 15 nodes |
+| `fused_contrib_mha` (`com.microsoft`) | `MultiHeadAttention=1, SkipLayerNormalization=1, FastGelu=1` (16 nodes) | unchanged, 18 nodes |
+| `sim(ort(raw))` on the BERT fixture | — | `Attention=2, BiasGelu=2, SkipLayerNormalization=4` kept, 17 → 16 nodes |
+
+Shape inference flows through them (onnxsim registers the `com.microsoft`
+contrib schemas), constant folding does not try to evaluate them, and the opset
+23 `Attention` is not inlined into its schema-defined function body.
+
+Two caveats:
+
+* On `fused_contrib_mha` the node count goes **up**, 16 → 18: the batched-Gemm
+  rewrite converts three `MatMul+Add` pairs into `Reshape+Gemm` and ORT then
+  fuses fewer `Gemm`s of its own (`Gemm=4` after `ort(sim)` vs `Gemm=6` from the
+  raw model's own session-level optimization).
+* onnxsim's shape inference emits `The model contains custom operator(s)
+  ['SimplifiedLayerNormalization'] in the default ONNX domain` for ORT-fused
+  decoder models — ORT writes some contrib ops without a domain.  They are
+  passed through unchanged, which is the right behaviour.
+
+## Finding 4 — onnxsim rejects ONNX Runtime's own optimized models
+
+Feeding an ORT-optimized model straight back into onnxsim fails outright:
+
+```
+RuntimeError: No opset import for domain 'com.microsoft'
+==> Context: Bad node spec for node. Name: Attention_0 OpType: Attention
+```
+
+ORT's transformer optimizer emits `com.microsoft` nodes **without** adding the
+matching entry to `opset_import` (verified: the fused model's `opset_import` is
+`[("", 17)]` while its nodes use both `""` and `"com.microsoft"`).  That model is
+invalid ONNX, so onnx's checker — and therefore onnxsim — rejects it, even
+though ORT itself loads it happily.
+
+`optimize → simplify` is a natural pipeline (fuse what ORT knows, then clean up
+around it), and it is currently blocked by one missing line of metadata.  onnxsim
+already registers `com.microsoft` schemas internally, so tolerating (or
+auto-adding) an opset import for a domain whose schemas it knows would unblock
+it; the survey script works around it in `ensure_opset_imports()`.
+
+## Finding 5 — decoder models: there is no attention re-fusion to lose (yet)
+
+For the LLaMA-style fixture (RMSNorm + rotary embeddings + SwiGLU), ORT recovers
+only the norm fusions, both before and after onnxsim:
+
+| variant | fused ops |
+| --- | --- |
+| `ort(raw)` | `SimplifiedLayerNormalization=1, SkipSimplifiedLayerNormalization=4` |
+| `ort(sim)` | `SimplifiedLayerNormalization=1, SkipSimplifiedLayerNormalization=4` |
+| `sim(ort(raw))` | same, preserved |
+
+No `MultiHeadAttention`/`GroupQueryAttention` appears in either — ORT's
+`FusionRotaryAttention` needs the rotary embedding to already be a
+`com.microsoft.RotaryEmbedding` node, and `FusionRotaryEmbeddings` only builds
+one from (a) a torch-exported local *function* named `RotaryEmbedding`, or
+(b) a decomposed RoPE that still carries its **dynamic shape scaffolding**
+(`Slice` bounds fed by `Unsqueeze ← Div ← Gather ← Shape`, cos/sin sliced by a
+`position_ids` gather).  A plain export with constant slice bounds matches
+neither.
+
+Two consequences worth flagging, both untested here and worth a follow-up:
+
+* Case (a) is directly at risk from `inline_functions=True` — inlining the
+  `RotaryEmbedding` function is exactly what removes ORT's handle on it.
+* Case (b) is directly at risk from onnxsim's constant folding, whose whole job
+  is to collapse `Shape → Gather → Div → Unsqueeze` chains into constants.
+
+So for decoder models the current answer is "onnxsim costs nothing because there
+is nothing to lose", and that stops being true as soon as the export carries
+either form.
+
+## Finding 6 — onnxsim cannot re-fuse anything itself
+
+onnxsim's pass set only ever *removes* or *flattens*: there is no pass that
+recognises a decomposed block and emits a fused operator.  The nine
+onnxsim-specific passes in `onnxsim/passes/` are conv/bias/reshape rewrites;
+onnx-optimizer has no attention, layer-norm or GELU fusion.  Every fused op seen
+in this survey came either from the exporter or from ONNX Runtime.
+
+That is a gap worth closing *in standard ONNX*, not in a vendor domain: opset 17
+has `LayerNormalization`, opset 20 has `Gelu`, opset 23 has `Attention`,
+`RMSNormalization` and `RotaryEmbedding`.  Emitting those helps every runtime,
+not just ORT, and it makes the pattern-fragility problem moot — a model that
+already says `Attention` cannot have its `Attention` pattern broken.
+
+onnxsim already has the machinery: `function_rewrite_rules` takes data-only
+`(pattern, replacement)` `FunctionProto` pairs and runs them inside the fixed
+point (`onnxsim/function_rewriter.cpp`), and `custom_rewriter` takes arbitrary
+Python.  The simple shapes (erf-GELU → `Gelu`, decomposed RMSNorm →
+`RMSNormalization`) fit the current matcher; full attention needs attribute
+derivation (`num_heads` from a reshape constant) and so needs either the
+Python rewriter or a matcher extension.
+
+---
+
+## Recommendations, in priority order
+
+1. **Fix the correctness bug (Finding 1).**  Guard
+   `eliminate_consecutive_idempotent_ops` for `Reshape`: only compose when the
+   second shape tensor is a constant with no `0` entries (or when
+   `allowzero=1`).  onnxsim already shadows nine onnx-optimizer passes via
+   `RegisterOrReplace` in `onnxsim/custom_optimizer_passes.cpp`, so a guarded
+   copy fits the existing pattern; the fix belongs upstream too.
+2. **Add a regression test that the fixtures still run** (`check_n=3` over the
+   transformer fixtures).  The existing suite never exercised a `Reshape` with
+   `0` dims after a batched-Gemm rewrite.
+3. **Treat downstream fusability as a first-class metric.**  `--bisect` in
+   `bench/refusion_survey.py` already computes it; wiring "ORT recovers the same
+   fused-op census before and after `simplify`" into CI would have caught
+   Finding 2 the day the pass landed.
+4. **Reconsider `fuse_consecutive_unsqueezes` (and the batched-Gemm pass) in the
+   default set.**  Both trade a node or two for a rewrite the runtime would
+   rather do itself — ORT does its own `MatMul+Add → Gemm` at session level
+   anyway (`Gemm=12` appears in the session-level census of the *raw* model).
+   Either drop them from the defaults, or gate them behind a
+   `--target-runtime`-style switch for users who really want a Gemm-centric
+   graph.
+5. **Accept ORT-optimized models** (Finding 4): auto-add an opset import for a
+   custom domain whose schemas onnxsim has registered, instead of failing.
+6. **Ship re-fusion rules** (Finding 6), starting with the two that fit the
+   existing `FunctionProto` rewriter (erf-GELU → `Gelu`, decomposed RMSNorm →
+   `RMSNormalization`) and measuring the payoff with this harness before
+   attempting `Attention`.
+
+## What the GPU run adds
+
+Everything above is a *graph* measurement; on a CPU the fused kernels are worth
+little, and the latency column in the CPU survey is dominated by noise (a shared
+container, ±40 % between repeats).  On an NVIDIA GPU the same census turns into
+real time: the CUDA EP's fused attention kernels (and, in fp16 on Turing, the
+TensorRT fused-attention path) are the reason `com.microsoft.Attention` exists.
+
+`bench/refusion_gpu_bench.py` times every variant on the CUDA EP in fp32 and
+fp16, and dumps the session-level fused-op census per variant, so the cost of
+Finding 2 can be read directly as milliseconds.  See "Running it on a GPU" in
+`bench/refusion_gpu_run.sh` — on an RTX 2060 (Turing, sm75, 6 GB) the
+`bert-base` preset fits comfortably.
+
+Results from that run are not included here — this survey was produced on a
+CPU-only machine.

--- a/bench/RESULTS_refusion.md
+++ b/bench/RESULTS_refusion.md
@@ -261,7 +261,9 @@ Python rewriter or a matcher extension.
 3. **Treat downstream fusability as a first-class metric.**  `--bisect` in
    `bench/refusion_survey.py` already computes it; wiring "ORT recovers the same
    fused-op census before and after `simplify`" into CI would have caught
-   Finding 2 the day the pass landed.
+   Finding 2 the day the pass landed.  The census — not a timing — has to be the
+   check: Finding 7 shows the regression is invisible in fp32 and nearly
+   invisible on a CPU, so a wall-clock guard on CI hardware would never fire.
 4. **Reconsider `fuse_consecutive_unsqueezes` (and the batched-Gemm pass) in the
    default set.**  Both trade a node or two for a rewrite the runtime would
    rather do itself — ORT does its own `MatMul+Add → Gemm` at session level
@@ -276,60 +278,64 @@ Python rewriter or a matcher extension.
    `RMSNormalization`) and measuring the payoff with this harness before
    attempting `Attention`.
 
-## Finding 7 — on a GPU, the lost Attention fusion costs 23 % of inference time
+## Finding 7 — the lost Attention fusion costs 18 % of GPU inference time, but only in fp16
 
 Measured on a **GeForce RTX 2060** (Turing, sm75, 6 GB, driver 610.57.04),
 CUDAExecutionProvider, onnxruntime 1.28.0, `--preset bert-base` (12 layers,
-hidden 768, 12 heads, seq 384, batch 1), median of 100 runs:
+hidden 768, 12 heads, seq 384, batch 1), median of 100 runs.  fp16 rows are the
+same graph converted with fp32 graph I/O; each row's `fp16_initializers` count
+in the JSON confirms the conversion actually happened.
 
-| variant | nodes | fused ops ORT runs | median ms | vs `raw` |
-| --- | --- | --- | --- | --- |
-| `raw` | 414 | `Gemm=72, FusedMatMul=12, SkipLayerNormalization=24, Gelu=12` | 7.07 | 1.00× |
-| `sim` (default) | 388 | *does not load* | — | — |
-| `sim_nogemm` | 412 | same as `raw` | 7.14 | 0.99× |
-| `sim_safe` | 413 | same as `raw` | 7.11 | 0.99× |
-| `ort(raw)` | 87 | **`Attention=12`**`, SkipLayerNormalization=24, BiasGelu=12` | **5.54** | **1.28×** |
-| `ort(sim)` | 340 | *does not load* | — | — |
-| `ort(sim_nogemm)` | 304 | `SkipLayerNormalization=24, BiasGelu=12` (no Attention) | 6.83 | 1.04× |
-| `ort(sim_safe)` | 88 | **`Attention=12`**`, SkipLayerNormalization=24, BiasGelu=12` | **5.57** | 1.27× |
+| variant | fused ops ORT runs | fp32 ms | fp16 ms |
+| --- | --- | --- | --- |
+| `raw` | `Gemm=72, FusedMatMul=12, SkipLayerNormalization=24, Gelu=12` | 16.73 | 7.07 |
+| `sim` (default) | *does not load* | — | — |
+| `sim_nogemm` | same as `raw` | 16.71 | 7.14 |
+| `sim_safe` | same as `raw` | 16.85 | 7.14 |
+| `ort(raw)` | **`Attention=12`**`, SkipLayerNormalization=24, BiasGelu=12` | 16.87 | **5.55** |
+| `ort(sim)` | *does not load* | — | — |
+| `ort(sim_nogemm)` | `SkipLayerNormalization=24, BiasGelu=12` (no Attention) | 16.47 | 6.84 |
+| `ort(sim_safe)` | **`Attention=12`**`, SkipLayerNormalization=24, BiasGelu=12` | 16.87 | **5.59** |
 
-Reading the two middle rows against each other isolates the cost of Finding 2:
 `ort(sim_nogemm)` and `ort(sim_safe)` differ only in whether
-`fuse_consecutive_unsqueezes` merged the mask's `Unsqueeze` pair, and that is
-**6.83 ms vs 5.57 ms — a 1.23× slowdown, 18 % of total inference time** given
-away to save one node.  On the CPU leg of the same run the same pair is 52.3 ms
-vs 50.2 ms (1.04×), which is why this has to be measured on an accelerator: the
-fused attention kernel is worth ~5× more on the GPU than on the CPU.
+`fuse_consecutive_unsqueezes` merged the mask's `Unsqueeze` pair, so that pair
+isolates the cost of Finding 2:
 
-Note also what the `raw` row shows: ORT's **session-level** optimizer never
-produces `Attention` on its own, on either provider.  Only the Python
-`onnxruntime.transformers.optimizer` pass does.  So the fusion at stake is one
-users have to opt into — and one onnxsim can silently make impossible.
+* **fp16: 6.84 ms → 5.59 ms, a 1.22× slowdown — 18 % of inference time** given
+  away to save one node out of 414.
+* **fp32: 16.47 ms → 16.87 ms — the fused model is 2 % *slower*.**
+* CPU (same machine, same preset): 49.7 ms → 47.5 ms, 1.05×.
 
-The decoder fixture behaves as on the CPU: no attention fusion exists to lose,
-onnxsim is a small win (`raw` 9.23 ms, `sim` 9.00 ms, `ort(sim)` 8.86 ms), and
-the norm fusions survive simplification intact.  The two already-fused fixtures
-stay fused end to end, with latencies flat inside noise (1.7–1.9 ms, dominated
-by launch overhead at that size).
+The precision split is the interesting part.  ONNX Runtime's fast fused-attention
+kernels on Turing are fp16 tensor-core paths (the TRT fused attention and
+memory-efficient attention kernels); in fp32 the CUDA EP falls back to an
+implementation that is no better than the unfused graph, so `Attention=12` buys
+nothing.  Two consequences:
 
-### Caveat on precision in this run
+* **The fusion is only worth fighting for in fp16** — which is how transformers
+  are actually deployed on this class of card.  fp16 alone is 2.4× over fp32
+  (`raw` 16.73 → 7.07 ms); fp16 *plus* the attention fusion is 3.0×
+  (16.73 → 5.55 ms).  Breaking the fusion throws away the last third of that.
+* **A CPU-only or fp32-only benchmark cannot see this regression at all.**  Any
+  CI guard against it has to look at the fused-op census (which the survey
+  script reports) rather than at wall-clock on the machine running the tests.
 
-The RTX 2060 numbers above were produced by
-`bench/refusion_gpu_bench.py` before a bug in its fp16 leg was fixed:
-`OnnxModel` wraps a ModelProto *by reference*, so `to_fp16()` converted each
-variant in place before the "fp32" row was timed, and **every row in that run is
-the fp16 graph** (visible in the JSON as 416 nodes for `bert_layer` where the
-fp32 fixture has 414 — the two extra `Cast` nodes fp16 conversion inserts).  The
-comparison between variants is unaffected, since every variant got the same
-treatment, so the 1.23× above stands as an fp16 measurement on Turing.  A true
-fp32-vs-fp16 split needs a re-run with the fixed script, which now also records
-`fp16_initializers` per row so the leg cannot silently mislabel itself again.
+The decoder fixture has no attention fusion to lose, and onnxsim is a small win
+in fp16 (`raw` 9.28 ms → `sim` 9.05 ms, 2.5 %) and neutral in fp32 (22.0 vs
+22.2 ms).  Both already-fused fixtures stay fused end to end in both precisions.
 
-The same aliasing explains the `max_abs_diff` values in that run: `ort(raw)`
-differs from the reference by 0.63 max-abs, which is fp16 accumulated across 12
-layers of random (untrained) weights along a different kernel path, not an fp32
-accuracy claim.  The CPU leg of the same run, in fp32, shows 4.3e-06 for the
-same comparison.
+Running `--bisect` on that machine reproduced the two culprit passes exactly, at
+12-layer scale, for both BERT fixtures:
+
+```
+fuse_matmul_add_bias_into_gemm_batched  recovers SkipLayerNormalization=24, BiasGelu=12
+fuse_consecutive_unsqueezes             recovers Attention=12
+```
+
+One caveat on the CPU latency column of that run: it is noisy (the
+`llama_layer_gqa` variants range 58–129 ms across variants that produce
+identical graphs). Read the CPU numbers as fusion censuses, not timings; the GPU
+timings are tight, with p90 within ~1 % of the median.
 
 ## Running it yourself
 

--- a/bench/refusion_fixtures.py
+++ b/bench/refusion_fixtures.py
@@ -1,0 +1,810 @@
+"""Transformer fixtures for the operator re-fusion survey.
+
+The models here are built with ``onnx.helper`` only (no torch / transformers
+dependency) but their graph topology is the one real exporters emit, so they
+exercise the same pattern matchers that ONNX Runtime's fusion passes use:
+
+``bert_layer``
+    Post-LayerNorm BERT encoder layers, attention spelled out as
+    ``MatMul+Add`` projections -> ``Reshape`` -> ``Transpose`` -> ``MatMul`` ->
+    ``Div`` -> ``Add`` (mask) -> ``Softmax`` -> ``MatMul`` -> ``Transpose`` ->
+    ``Reshape`` -> ``MatMul+Add``, an erf ``Gelu`` written out, and
+    ``LayerNormalization`` nodes.  This is what ORT's ``AttentionFusion`` /
+    ``SkipLayerNormalization`` / ``BiasGelu`` passes expect.
+
+``bert_layer_decomposed_ln``
+    Same, with LayerNormalization itself decomposed
+    (``ReduceMean``/``Sub``/``Pow``/``ReduceMean``/``Add``/``Sqrt``/``Div``),
+    the shape opset<17 exporters produce.  Tests whether onnxsim keeps that
+    subgraph in a form ORT's ``LayerNormFusion`` still recognises -- LayerNorm
+    fusion is the gateway to attention fusion, which starts its pattern walk at
+    a LayerNormalization node.
+
+``llama_layer``
+    LLaMA-style decoder layer: decomposed RMSNorm, rotary embeddings applied to
+    Q and K, additive causal mask, SwiGLU MLP, no biases.
+
+``fused_onnx``
+    ai.onnx opset 23 ``Attention`` + ``RMSNormalization`` + ``RotaryEmbedding``
+    (the standardised fused ops).
+
+``fused_contrib``
+    ``com.microsoft`` ``MultiHeadAttention`` + ``SkipLayerNormalization`` +
+    ``FastGelu`` -- what ORT's own optimizer emits, i.e. what a model looks like
+    when a user hands an *already fused* model to onnxsim.
+
+Every builder returns ``(ModelProto, {input_name: numpy array})``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import onnx
+from onnx import TensorProto, helper, numpy_helper
+
+BATCH = 1
+SEQ = 128
+HIDDEN = 256
+HEADS = 4
+HEAD_DIM = HIDDEN // HEADS
+FFN = 4 * HIDDEN
+LAYERS = 2
+
+_RNG = np.random.default_rng(0)
+
+# Named sizes.  The default is deliberately tiny so the CPU survey runs in
+# seconds; ``bert-base`` is the size worth timing on a GPU.
+PRESETS = {
+    "tiny": dict(batch=1, seq=128, hidden=256, heads=4, layers=2),
+    "bert-base": dict(batch=1, seq=384, hidden=768, heads=12, layers=12),
+    "bert-large": dict(batch=1, seq=384, hidden=1024, heads=16, layers=24),
+}
+
+
+def configure(batch=None, seq=None, hidden=None, heads=None, layers=None, preset=None):
+    """Resize the fixtures (globals are read at build time, not import time)."""
+    global BATCH, SEQ, HIDDEN, HEADS, HEAD_DIM, FFN, LAYERS
+    if preset:
+        values = dict(PRESETS[preset])
+        values.update(
+            {
+                k: v
+                for k, v in dict(
+                    batch=batch, seq=seq, hidden=hidden, heads=heads, layers=layers
+                ).items()
+                if v is not None
+            }
+        )
+    else:
+        values = dict(
+            batch=batch if batch is not None else BATCH,
+            seq=seq if seq is not None else SEQ,
+            hidden=hidden if hidden is not None else HIDDEN,
+            heads=heads if heads is not None else HEADS,
+            layers=layers if layers is not None else LAYERS,
+        )
+    BATCH, SEQ, HIDDEN, HEADS, LAYERS = (
+        values["batch"],
+        values["seq"],
+        values["hidden"],
+        values["heads"],
+        values["layers"],
+    )
+    HEAD_DIM = HIDDEN // HEADS
+    FFN = 4 * HIDDEN
+    for name in NUM_HEADS:
+        NUM_HEADS[name] = HEADS
+        HIDDEN_SIZE[name] = HIDDEN
+    return values
+
+
+def describe() -> str:
+    return (
+        f"batch={BATCH} seq={SEQ} hidden={HIDDEN} heads={HEADS} "
+        f"head_dim={HEAD_DIM} ffn={FFN} layers={LAYERS}"
+    )
+
+
+def _f32(array, name):
+    # Keep rank-0 scalars rank-0 (np.ascontiguousarray would promote them to
+    # rank 1): exporters emit scalar epsilons/scales, and ORT's fusion passes
+    # read them with ``float()``, which rejects a shape-(1,) array on numpy 2.
+    array = np.asarray(array, dtype=np.float32)
+    if array.ndim:
+        array = np.ascontiguousarray(array)
+    return numpy_helper.from_array(array, name)
+
+
+def _i64(array, name):
+    return numpy_helper.from_array(np.asarray(array, dtype=np.int64), name)
+
+
+def _vi(name, shape, dtype=TensorProto.FLOAT):
+    return helper.make_tensor_value_info(name, dtype, shape)
+
+
+def _weight(shape, name, inits, scale=0.02):
+    inits.append(_f32(_RNG.standard_normal(shape) * scale, name))
+    return name
+
+
+def _const(value, name, inits):
+    inits.append(_f32(np.asarray(value, dtype=np.float32), name))
+    return name
+
+
+def _model(nodes, inputs, outputs, inits, opset=17, extra_opsets=()):
+    graph = helper.make_graph(nodes, "g", inputs, outputs, inits)
+    opset_imports = [helper.make_opsetid("", opset)]
+    opset_imports += [helper.make_opsetid(d, v) for d, v in extra_opsets]
+    model = helper.make_model(graph, opset_imports=opset_imports, ir_version=10)
+    return model
+
+
+def _linear(nodes, inits, x, in_dim, out_dim, prefix, bias=True):
+    """MatMul (+ Add bias) -- how exporters spell ``nn.Linear``."""
+    w = _weight((in_dim, out_dim), f"{prefix}.weight", inits)
+    out = f"{prefix}.matmul"
+    nodes.append(helper.make_node("MatMul", [x, w], [out], name=f"{prefix}/MatMul"))
+    if not bias:
+        return out
+    b = _weight((out_dim,), f"{prefix}.bias", inits, scale=0.01)
+    biased = f"{prefix}.out"
+    nodes.append(helper.make_node("Add", [out, b], [biased], name=f"{prefix}/Add"))
+    return biased
+
+
+def _layer_norm(nodes, inits, x, prefix, decomposed=False, eps=1e-5):
+    # Trained norm weights are near 1 but never exactly 1: an all-ones gamma
+    # would make ``Mul(x, gamma)`` a no-op that onnxsim legitimately deletes,
+    # which is a property of the fixture rather than of real models.
+    w = f"{prefix}.gamma"
+    inits.append(_f32(1.0 + 0.02 * _RNG.standard_normal(HIDDEN), w))
+    b = _weight((HIDDEN,), f"{prefix}.beta", inits, scale=0.01)
+    out = f"{prefix}.out"
+    if not decomposed:
+        nodes.append(
+            helper.make_node(
+                "LayerNormalization",
+                [x, w, b],
+                [out],
+                axis=-1,
+                epsilon=eps,
+                name=f"{prefix}/LN",
+            )
+        )
+        return out
+    # The pre-opset-17 spelling every exporter used to emit.
+    two = _const(2.0, f"{prefix}.two", inits)
+    epsv = _const(eps, f"{prefix}.eps", inits)
+    n = lambda op, i, o, **kw: nodes.append(  # noqa: E731
+        helper.make_node(op, i, o, name=f"{prefix}/{op}_{o[0]}", **kw)
+    )
+    # opset 17: ReduceMean takes `axes` as an attribute (it became an input in 18).
+    n("ReduceMean", [x], [f"{prefix}.mean"], axes=[-1], keepdims=1)
+    n("Sub", [x, f"{prefix}.mean"], [f"{prefix}.d"])
+    n("Pow", [f"{prefix}.d", two], [f"{prefix}.d2"])
+    n("ReduceMean", [f"{prefix}.d2"], [f"{prefix}.var"], axes=[-1], keepdims=1)
+    n("Add", [f"{prefix}.var", epsv], [f"{prefix}.vare"])
+    n("Sqrt", [f"{prefix}.vare"], [f"{prefix}.std"])
+    n("Div", [f"{prefix}.d", f"{prefix}.std"], [f"{prefix}.norm"])
+    n("Mul", [f"{prefix}.norm", w], [f"{prefix}.scaled"])
+    n("Add", [f"{prefix}.scaled", b], [out])
+    return out
+
+
+def _gelu_erf(nodes, inits, x, prefix):
+    """The erf spelling of GELU (ORT fuses it into BiasGelu/FastGelu)."""
+    half = _const(0.5, f"{prefix}.half", inits)
+    one = _const(1.0, f"{prefix}.one", inits)
+    sqrt2 = _const(1.4142135381698608, f"{prefix}.sqrt2", inits)
+    nodes += [
+        helper.make_node("Div", [x, sqrt2], [f"{prefix}.div"], name=f"{prefix}/Div"),
+        helper.make_node(
+            "Erf", [f"{prefix}.div"], [f"{prefix}.erf"], name=f"{prefix}/Erf"
+        ),
+        helper.make_node(
+            "Add", [f"{prefix}.erf", one], [f"{prefix}.a"], name=f"{prefix}/Add"
+        ),
+        helper.make_node(
+            "Mul", [x, f"{prefix}.a"], [f"{prefix}.m"], name=f"{prefix}/Mul"
+        ),
+        helper.make_node(
+            "Mul", [f"{prefix}.m", half], [f"{prefix}.out"], name=f"{prefix}/Mul2"
+        ),
+    ]
+    return f"{prefix}.out"
+
+
+def _mha_decomposed(nodes, inits, x, mask, prefix, heads=None, kv_heads=None):
+    """Multi-head attention written out node by node, exporter style."""
+    heads = heads or HEADS
+    kv_heads = kv_heads or heads
+    head_dim = HIDDEN // heads
+    q = _linear(nodes, inits, x, HIDDEN, heads * head_dim, f"{prefix}.q_proj")
+    k = _linear(nodes, inits, x, HIDDEN, kv_heads * head_dim, f"{prefix}.k_proj")
+    v = _linear(nodes, inits, x, HIDDEN, kv_heads * head_dim, f"{prefix}.v_proj")
+
+    inits.append(_i64([0, 0, heads, head_dim], f"{prefix}.qshape"))
+    inits.append(_i64([0, 0, kv_heads, head_dim], f"{prefix}.kvshape"))
+    inits.append(_i64([0, 0, heads * head_dim], f"{prefix}.oshape"))
+
+    def split_heads(t, name, shape_init, perm):
+        nodes.append(
+            helper.make_node(
+                "Reshape", [t, shape_init], [f"{name}.r"], name=f"{name}/Reshape"
+            )
+        )
+        nodes.append(
+            helper.make_node(
+                "Transpose",
+                [f"{name}.r"],
+                [f"{name}.t"],
+                perm=perm,
+                name=f"{name}/Transpose",
+            )
+        )
+        return f"{name}.t"
+
+    qh = split_heads(q, f"{prefix}.q", f"{prefix}.qshape", [0, 2, 1, 3])
+    kh = split_heads(k, f"{prefix}.k", f"{prefix}.kvshape", [0, 2, 3, 1])
+    vh = split_heads(v, f"{prefix}.v", f"{prefix}.kvshape", [0, 2, 1, 3])
+
+    scale = _const(float(np.sqrt(head_dim)), f"{prefix}.scale", inits)
+    nodes += [
+        helper.make_node("MatMul", [qh, kh], [f"{prefix}.qk"], name=f"{prefix}/QK"),
+        helper.make_node(
+            "Div", [f"{prefix}.qk", scale], [f"{prefix}.qks"], name=f"{prefix}/Scale"
+        ),
+        helper.make_node(
+            "Add", [f"{prefix}.qks", mask], [f"{prefix}.qkm"], name=f"{prefix}/Mask"
+        ),
+        helper.make_node(
+            "Softmax",
+            [f"{prefix}.qkm"],
+            [f"{prefix}.p"],
+            axis=-1,
+            name=f"{prefix}/Softmax",
+        ),
+        helper.make_node(
+            "MatMul", [f"{prefix}.p", vh], [f"{prefix}.ctx"], name=f"{prefix}/PV"
+        ),
+        helper.make_node(
+            "Transpose",
+            [f"{prefix}.ctx"],
+            [f"{prefix}.ctxt"],
+            perm=[0, 2, 1, 3],
+            name=f"{prefix}/CtxTranspose",
+        ),
+        helper.make_node(
+            "Reshape",
+            [f"{prefix}.ctxt", f"{prefix}.oshape"],
+            [f"{prefix}.merged"],
+            name=f"{prefix}/CtxReshape",
+        ),
+    ]
+    return _linear(
+        nodes, inits, f"{prefix}.merged", heads * head_dim, HIDDEN, f"{prefix}.o_proj"
+    )
+
+
+def _hf_extended_mask(nodes, inits, seq):
+    """HuggingFace's ``get_extended_attention_mask`` as exporters emit it.
+
+    ``mask[B, S]`` (int64) -> Unsqueeze -> Unsqueeze -> Cast -> ``1 - m`` ->
+    ``* -10000`` -> additive mask ``[B, 1, 1, S]``.
+
+    ORT's ``FusionAttention`` only fuses attention when it can walk this exact
+    chain back to a 2-D graph input -- it needs the raw 2-D mask to build the
+    ``mask_index`` input of ``com.microsoft.Attention``.  Any rewrite of these
+    five nodes costs the model its Attention fusion, which is why the fixture
+    spells them out instead of feeding a ready-made additive mask.
+    """
+    inits.append(_i64([1], "mask.axes1"))
+    inits.append(_i64([2], "mask.axes2"))
+    _const(1.0, "mask.one", inits)
+    _const(-10000.0, "mask.neg", inits)
+    nodes += [
+        helper.make_node(
+            "Unsqueeze", ["mask", "mask.axes1"], ["mask.u1"], name="mask/Unsqueeze1"
+        ),
+        helper.make_node(
+            "Unsqueeze", ["mask.u1", "mask.axes2"], ["mask.u2"], name="mask/Unsqueeze2"
+        ),
+        helper.make_node(
+            "Cast", ["mask.u2"], ["mask.cast"], to=TensorProto.FLOAT, name="mask/Cast"
+        ),
+        helper.make_node(
+            "Sub", ["mask.one", "mask.cast"], ["mask.sub"], name="mask/Sub"
+        ),
+        helper.make_node(
+            "Mul", ["mask.sub", "mask.neg"], ["mask.add"], name="mask/Mul"
+        ),
+    ]
+    return "mask.add"
+
+
+def bert_layer(layers=None, decomposed_ln=False, seq=None):
+    layers, seq = layers or LAYERS, seq or SEQ
+    """Post-LayerNorm BERT encoder layers (the classic fusable shape)."""
+    nodes, inits = [], []
+    x = "hidden"
+    mask = _hf_extended_mask(nodes, inits, seq)
+    for i in range(layers):
+        p = f"layer{i}"
+        attn = _mha_decomposed(nodes, inits, x, mask, f"{p}.attn")
+        nodes.append(
+            helper.make_node("Add", [attn, x], [f"{p}.res0"], name=f"{p}/Residual0")
+        )
+        ln0 = _layer_norm(nodes, inits, f"{p}.res0", f"{p}.ln0", decomposed_ln)
+        ff = _linear(nodes, inits, ln0, HIDDEN, FFN, f"{p}.ffn.up")
+        act = _gelu_erf(nodes, inits, ff, f"{p}.ffn.act")
+        down = _linear(nodes, inits, act, FFN, HIDDEN, f"{p}.ffn.down")
+        nodes.append(
+            helper.make_node("Add", [down, ln0], [f"{p}.res1"], name=f"{p}/Residual1")
+        )
+        x = _layer_norm(nodes, inits, f"{p}.res1", f"{p}.ln1", decomposed_ln)
+
+    nodes.append(helper.make_node("Identity", [x], ["output"], name="out"))
+    model = _model(
+        nodes,
+        [
+            _vi("hidden", [BATCH, seq, HIDDEN]),
+            _vi("mask", [BATCH, seq], TensorProto.INT64),
+        ],
+        [_vi("output", [BATCH, seq, HIDDEN])],
+        inits,
+    )
+    mask_values = np.ones((BATCH, seq), dtype=np.int64)
+    mask_values[:, seq // 2 :] = 0  # half the sequence padded, as in a real batch
+    feed = {
+        "hidden": _RNG.standard_normal((BATCH, seq, HIDDEN)).astype(np.float32),
+        "mask": mask_values,
+    }
+    return model, feed
+
+
+def bert_layer_decomposed_ln():
+    return bert_layer(decomposed_ln=True)
+
+
+def _rope_caches(inits, seq, head_dim):
+    """The shared ``cos_cache``/``sin_cache`` initializers, ``[S, D]``."""
+    if any(init.name == "rope.cos_cache" for init in inits):
+        return "rope.cos_cache", "rope.sin_cache"
+    pos = np.arange(seq)[:, None]
+    inv = 1.0 / (10000 ** (np.arange(0, head_dim, 2) / head_dim))
+    emb = np.concatenate([pos * inv[None, :]] * 2, axis=-1)
+    inits.append(_f32(np.cos(emb), "rope.cos_cache"))
+    inits.append(_f32(np.sin(emb), "rope.sin_cache"))
+    return "rope.cos_cache", "rope.sin_cache"
+
+
+def _rope(nodes, inits, x, prefix, seq=None, head_dim=None):
+    """Rotary embedding on a ``[B, H, S, D]`` tensor, HuggingFace export shape.
+
+    ``cos = cos_cache[position_ids].unsqueeze(1)``,
+    ``x_embed = x * cos + rotate_half(x) * sin`` with ``rotate_half`` spelled as
+    ``Slice``/``Neg``/``Concat`` -- the node sequence ORT's
+    ``FusionRotaryEmbeddings`` looks for.
+    """
+    cos_cache, sin_cache = _rope_caches(inits, seq, head_dim)
+    half = head_dim // 2
+    if not any(init.name == "rope.zero" for init in inits):
+        inits.append(_i64([0], "rope.zero"))
+        inits.append(_i64([half], "rope.half"))
+        inits.append(_i64([head_dim], "rope.dim"))
+        inits.append(_i64([-1], "rope.last_axis"))
+        inits.append(_i64([1], "rope.unsq_axis"))
+    for name, cache in (("cos", cos_cache), ("sin", sin_cache)):
+        if any(n.output and n.output[0] == f"rope.{name}" for n in nodes):
+            continue
+        nodes += [
+            helper.make_node(
+                "Gather",
+                [cache, "position_ids"],
+                [f"rope.{name}.g"],
+                axis=0,
+                name=f"rope/{name}Gather",
+            ),
+            helper.make_node(
+                "Unsqueeze",
+                [f"rope.{name}.g", "rope.unsq_axis"],
+                [f"rope.{name}"],
+                name=f"rope/{name}Unsqueeze",
+            ),
+        ]
+    nodes += [
+        helper.make_node(
+            "Slice",
+            [x, "rope.zero", "rope.half", "rope.last_axis"],
+            [f"{prefix}.x1"],
+            name=f"{prefix}/Slice1",
+        ),
+        helper.make_node(
+            "Slice",
+            [x, "rope.half", "rope.dim", "rope.last_axis"],
+            [f"{prefix}.x2"],
+            name=f"{prefix}/Slice2",
+        ),
+        helper.make_node(
+            "Neg", [f"{prefix}.x2"], [f"{prefix}.nx2"], name=f"{prefix}/Neg"
+        ),
+        helper.make_node(
+            "Concat",
+            [f"{prefix}.nx2", f"{prefix}.x1"],
+            [f"{prefix}.rot"],
+            axis=-1,
+            name=f"{prefix}/Concat",
+        ),
+        helper.make_node(
+            "Mul", [x, "rope.cos"], [f"{prefix}.mc"], name=f"{prefix}/MulCos"
+        ),
+        helper.make_node(
+            "Mul",
+            [f"{prefix}.rot", "rope.sin"],
+            [f"{prefix}.ms"],
+            name=f"{prefix}/MulSin",
+        ),
+        helper.make_node(
+            "Add",
+            [f"{prefix}.mc", f"{prefix}.ms"],
+            [f"{prefix}.out"],
+            name=f"{prefix}/AddRope",
+        ),
+    ]
+    return f"{prefix}.out"
+
+
+def _rms_norm(nodes, inits, x, prefix, eps=1e-6):
+    w = f"{prefix}.weight"
+    inits.append(_f32(1.0 + 0.02 * _RNG.standard_normal(HIDDEN), w))
+    two = _const(2.0, f"{prefix}.two", inits)
+    epsv = _const(eps, f"{prefix}.eps", inits)
+    n = lambda op, i, o: nodes.append(  # noqa: E731
+        helper.make_node(op, i, o, name=f"{prefix}/{op}_{o[0]}")
+    )
+    n("Pow", [x, two], [f"{prefix}.sq"])
+    nodes.append(
+        helper.make_node(
+            "ReduceMean",
+            [f"{prefix}.sq"],
+            [f"{prefix}.var"],
+            axes=[-1],
+            keepdims=1,
+            name=f"{prefix}/RM",
+        )
+    )
+    n("Add", [f"{prefix}.var", epsv], [f"{prefix}.vare"])
+    nodes.append(
+        helper.make_node(
+            "Sqrt", [f"{prefix}.vare"], [f"{prefix}.std"], name=f"{prefix}/Sqrt"
+        )
+    )
+    n("Div", [x, f"{prefix}.std"], [f"{prefix}.norm"])
+    n("Mul", [f"{prefix}.norm", w], [f"{prefix}.out"])
+    return f"{prefix}.out"
+
+
+def llama_layer(layers=None, seq=None, kv_heads=None):
+    layers, seq = layers or LAYERS, seq or SEQ
+    kv_heads = kv_heads or HEADS
+    """LLaMA-style decoder layers: RMSNorm + RoPE attention + SwiGLU."""
+    nodes, inits = [], []
+    x = "hidden"
+    head_dim = HEAD_DIM
+    for i in range(layers):
+        p = f"layer{i}"
+        norm = _rms_norm(nodes, inits, x, f"{p}.input_norm")
+        q = _linear(nodes, inits, norm, HIDDEN, HIDDEN, f"{p}.attn.q_proj", bias=False)
+        k = _linear(
+            nodes,
+            inits,
+            norm,
+            HIDDEN,
+            kv_heads * head_dim,
+            f"{p}.attn.k_proj",
+            bias=False,
+        )
+        v = _linear(
+            nodes,
+            inits,
+            norm,
+            HIDDEN,
+            kv_heads * head_dim,
+            f"{p}.attn.v_proj",
+            bias=False,
+        )
+        inits.append(_i64([0, 0, HEADS, head_dim], f"{p}.qshape"))
+        inits.append(_i64([0, 0, kv_heads, head_dim], f"{p}.kvshape"))
+        inits.append(_i64([0, 0, HIDDEN], f"{p}.oshape"))
+
+        def heads(t, name, shape_init, perm=(0, 2, 1, 3)):
+            nodes.append(
+                helper.make_node(
+                    "Reshape", [t, shape_init], [f"{name}.r"], name=f"{name}/R"
+                )
+            )
+            nodes.append(
+                helper.make_node(
+                    "Transpose",
+                    [f"{name}.r"],
+                    [f"{name}.t"],
+                    perm=list(perm),
+                    name=f"{name}/T",
+                )
+            )
+            return f"{name}.t"
+
+        qh = heads(q, f"{p}.q", f"{p}.qshape")
+        kh = heads(k, f"{p}.k", f"{p}.kvshape")
+        vh = heads(v, f"{p}.v", f"{p}.kvshape")
+        qr = _rope(nodes, inits, qh, f"{p}.q_rope", seq, head_dim)
+        kr = _rope(nodes, inits, kh, f"{p}.k_rope", seq, head_dim)
+        if kv_heads != HEADS:
+            # HuggingFace's ``repeat_kv``: Unsqueeze -> Expand -> Reshape.
+            rep = HEADS // kv_heads
+            inits.append(_i64([2], f"{p}.rep_axis"))
+            inits.append(_i64([BATCH, kv_heads, rep, seq, head_dim], f"{p}.rep_shape"))
+            inits.append(_i64([BATCH, HEADS, seq, head_dim], f"{p}.rep_out"))
+            expanded = []
+            for name, t in (("k", kr), ("v", vh)):
+                nodes += [
+                    helper.make_node(
+                        "Unsqueeze",
+                        [t, f"{p}.rep_axis"],
+                        [f"{p}.{name}.u"],
+                        name=f"{p}/{name}RepUnsqueeze",
+                    ),
+                    helper.make_node(
+                        "Expand",
+                        [f"{p}.{name}.u", f"{p}.rep_shape"],
+                        [f"{p}.{name}.e"],
+                        name=f"{p}/{name}RepExpand",
+                    ),
+                    helper.make_node(
+                        "Reshape",
+                        [f"{p}.{name}.e", f"{p}.rep_out"],
+                        [f"{p}.{name}.rep"],
+                        name=f"{p}/{name}RepReshape",
+                    ),
+                ]
+                expanded.append(f"{p}.{name}.rep")
+            kr, vh = expanded
+        nodes.append(
+            helper.make_node(
+                "Transpose", [kr], [f"{p}.kt"], perm=[0, 1, 3, 2], name=f"{p}/KT"
+            )
+        )
+        scale = _const(float(np.sqrt(head_dim)), f"{p}.scale", inits)
+        nodes += [
+            helper.make_node("MatMul", [qr, f"{p}.kt"], [f"{p}.qk"], name=f"{p}/QK"),
+            helper.make_node(
+                "Div", [f"{p}.qk", scale], [f"{p}.qks"], name=f"{p}/Scale"
+            ),
+            helper.make_node(
+                "Add", [f"{p}.qks", "mask"], [f"{p}.qkm"], name=f"{p}/Mask"
+            ),
+            helper.make_node(
+                "Softmax", [f"{p}.qkm"], [f"{p}.prob"], axis=-1, name=f"{p}/Softmax"
+            ),
+            helper.make_node("MatMul", [f"{p}.prob", vh], [f"{p}.ctx"], name=f"{p}/PV"),
+            helper.make_node(
+                "Transpose",
+                [f"{p}.ctx"],
+                [f"{p}.ctxt"],
+                perm=[0, 2, 1, 3],
+                name=f"{p}/CT",
+            ),
+            helper.make_node(
+                "Reshape", [f"{p}.ctxt", f"{p}.oshape"], [f"{p}.merged"], name=f"{p}/CR"
+            ),
+        ]
+        o = _linear(
+            nodes, inits, f"{p}.merged", HIDDEN, HIDDEN, f"{p}.attn.o_proj", bias=False
+        )
+        nodes.append(helper.make_node("Add", [x, o], [f"{p}.res0"], name=f"{p}/Res0"))
+
+        pn = _rms_norm(nodes, inits, f"{p}.res0", f"{p}.post_norm")
+        gate = _linear(nodes, inits, pn, HIDDEN, FFN, f"{p}.mlp.gate", bias=False)
+        up = _linear(nodes, inits, pn, HIDDEN, FFN, f"{p}.mlp.up", bias=False)
+        nodes += [
+            helper.make_node("Sigmoid", [gate], [f"{p}.sig"], name=f"{p}/Sigmoid"),
+            helper.make_node(
+                "Mul", [gate, f"{p}.sig"], [f"{p}.silu"], name=f"{p}/SiLU"
+            ),
+            helper.make_node(
+                "Mul", [f"{p}.silu", up], [f"{p}.swiglu"], name=f"{p}/SwiGLU"
+            ),
+        ]
+        down = _linear(
+            nodes, inits, f"{p}.swiglu", FFN, HIDDEN, f"{p}.mlp.down", bias=False
+        )
+        x = f"{p}.res1"
+        nodes.append(
+            helper.make_node("Add", [f"{p}.res0", down], [x], name=f"{p}/Res1")
+        )
+
+    final = _rms_norm(nodes, inits, x, "final_norm")
+    nodes.append(helper.make_node("Identity", [final], ["output"], name="out"))
+    model = _model(
+        nodes,
+        [
+            _vi("hidden", [BATCH, seq, HIDDEN]),
+            _vi("mask", [BATCH, 1, seq, seq]),
+            _vi("position_ids", [BATCH, seq], TensorProto.INT64),
+        ],
+        [_vi("output", [BATCH, seq, HIDDEN])],
+        inits,
+    )
+    causal = np.triu(np.full((seq, seq), -1e4, dtype=np.float32), k=1)
+    feed = {
+        "hidden": _RNG.standard_normal((BATCH, seq, HIDDEN)).astype(np.float32) * 0.1,
+        "mask": causal[None, None].repeat(1, axis=0),
+        "position_ids": np.arange(seq, dtype=np.int64)[None].repeat(BATCH, axis=0),
+    }
+    return model, feed
+
+
+def llama_layer_gqa():
+    """LLaMA layer with grouped-query attention (kv_heads < heads)."""
+    return llama_layer(kv_heads=max(1, HEADS // 2))
+
+
+def fused_onnx(seq=None):
+    seq = seq or SEQ
+    """ai.onnx opset 23 fused ops: Attention + RMSNormalization + RotaryEmbedding."""
+    nodes, inits = [], []
+    inits.append(_f32(1.0 + 0.02 * _RNG.standard_normal(HIDDEN), "rms.weight"))
+    nodes.append(
+        helper.make_node(
+            "RMSNormalization",
+            ["hidden", "rms.weight"],
+            ["normed"],
+            axis=-1,
+            epsilon=1e-6,
+        )
+    )
+    q = _linear(nodes, inits, "normed", HIDDEN, HIDDEN, "q_proj", bias=False)
+    k = _linear(nodes, inits, "normed", HIDDEN, HIDDEN, "k_proj", bias=False)
+    v = _linear(nodes, inits, "normed", HIDDEN, HIDDEN, "v_proj", bias=False)
+    inits.append(_i64([0, 0, HEADS, HEAD_DIM], "qkv_shape"))
+    for name, t in (("q", q), ("k", k), ("v", v)):
+        nodes += [
+            helper.make_node("Reshape", [t, "qkv_shape"], [f"{name}.r"]),
+            helper.make_node(
+                "Transpose", [f"{name}.r"], [f"{name}.h"], perm=[0, 2, 1, 3]
+            ),
+        ]
+    pos = np.arange(seq)[:, None]
+    inv = 1.0 / (10000 ** (np.arange(0, HEAD_DIM, 2) / HEAD_DIM))
+    ang = pos * inv[None, :]
+    inits += [_f32(np.cos(ang), "rope.cos"), _f32(np.sin(ang), "rope.sin")]
+    inits.append(_i64(np.arange(seq)[None], "position_ids"))
+    for name in ("q", "k"):
+        nodes.append(
+            helper.make_node(
+                "RotaryEmbedding",
+                [f"{name}.h", "rope.cos", "rope.sin", "position_ids"],
+                [f"{name}.rope"],
+            )
+        )
+    nodes.append(
+        helper.make_node(
+            "Attention",
+            ["q.rope", "k.rope", "v.h"],
+            ["attn"],
+            q_num_heads=HEADS,
+            kv_num_heads=HEADS,
+        )
+    )
+    inits.append(_i64([0, 0, HIDDEN], "merge_shape"))
+    nodes += [
+        helper.make_node("Transpose", ["attn"], ["attn.t"], perm=[0, 2, 1, 3]),
+        helper.make_node("Reshape", ["attn.t", "merge_shape"], ["merged"]),
+    ]
+    out = _linear(nodes, inits, "merged", HIDDEN, HIDDEN, "o_proj", bias=False)
+    nodes.append(helper.make_node("Identity", [out], ["output"]))
+    for i, node in enumerate(nodes):
+        if not node.name:
+            node.name = f"node_{i}"
+    model = _model(
+        nodes,
+        [_vi("hidden", [BATCH, seq, HIDDEN])],
+        [_vi("output", [BATCH, seq, HIDDEN])],
+        inits,
+        opset=23,
+    )
+    feed = {
+        "hidden": _RNG.standard_normal((BATCH, seq, HIDDEN)).astype(np.float32) * 0.1
+    }
+    return model, feed
+
+
+def fused_contrib(seq=None):
+    seq = seq or SEQ
+    """com.microsoft fused ops: MultiHeadAttention + SkipLayerNormalization + FastGelu."""
+    nodes, inits = [], []
+    q = _linear(nodes, inits, "hidden", HIDDEN, HIDDEN, "q_proj")
+    k = _linear(nodes, inits, "hidden", HIDDEN, HIDDEN, "k_proj")
+    v = _linear(nodes, inits, "hidden", HIDDEN, HIDDEN, "v_proj")
+    nodes.append(
+        helper.make_node(
+            "MultiHeadAttention",
+            [q, k, v],
+            ["attn"],
+            num_heads=HEADS,
+            domain="com.microsoft",
+            name="mha",
+        )
+    )
+    o = _linear(nodes, inits, "attn", HIDDEN, HIDDEN, "o_proj")
+    inits.append(_f32(1.0 + 0.02 * _RNG.standard_normal(HIDDEN), "ln.gamma"))
+    inits.append(_f32(0.01 * _RNG.standard_normal(HIDDEN), "ln.beta"))
+    nodes.append(
+        helper.make_node(
+            "SkipLayerNormalization",
+            [o, "hidden", "ln.gamma", "ln.beta"],
+            ["ln"],
+            epsilon=1e-5,
+            domain="com.microsoft",
+            name="skipln",
+        )
+    )
+    ff = _linear(nodes, inits, "ln", HIDDEN, FFN, "ffn.up")
+    nodes.append(
+        helper.make_node(
+            "FastGelu", [ff], ["act"], domain="com.microsoft", name="fastgelu"
+        )
+    )
+    down = _linear(nodes, inits, "act", FFN, HIDDEN, "ffn.down")
+    nodes.append(helper.make_node("Identity", [down], ["output"], name="out"))
+    model = _model(
+        nodes,
+        [_vi("hidden", [BATCH, seq, HIDDEN])],
+        [_vi("output", [BATCH, seq, HIDDEN])],
+        inits,
+        extra_opsets=[("com.microsoft", 1)],
+    )
+    feed = {
+        "hidden": _RNG.standard_normal((BATCH, seq, HIDDEN)).astype(np.float32) * 0.1
+    }
+    return model, feed
+
+
+FIXTURES = {
+    "bert_layer": bert_layer,
+    "bert_layer_decomposed_ln": bert_layer_decomposed_ln,
+    "llama_layer": llama_layer,
+    "llama_layer_gqa": llama_layer_gqa,
+    "fused_onnx_attention": fused_onnx,
+    "fused_contrib_mha": fused_contrib,
+}
+
+# ORT's transformer optimizer needs to know which fusion set to try.
+MODEL_TYPE = {
+    "bert_layer": "bert",
+    "bert_layer_decomposed_ln": "bert",
+    "llama_layer": "gpt2",
+    "llama_layer_gqa": "gpt2",
+    "fused_onnx_attention": "bert",
+    "fused_contrib_mha": "bert",
+}
+
+NUM_HEADS = {name: HEADS for name in FIXTURES}
+HIDDEN_SIZE = {name: HIDDEN for name in FIXTURES}
+
+
+def build(name):
+    model, feed = FIXTURES[name]()
+    onnx.checker.check_model(model, full_check=False)
+    return model, feed
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke test
+    import collections
+
+    for name in FIXTURES:
+        model, feed = build(name)
+        ops = collections.Counter(n.op_type for n in model.graph.node)
+        print(f"{name}: {sum(ops.values())} nodes, {dict(ops)}")

--- a/bench/refusion_gpu_bench.py
+++ b/bench/refusion_gpu_bench.py
@@ -1,11 +1,11 @@
-"""GPU leg of the operator re-fusion survey (NVIDIA / CUDA execution provider).
+"""GPU leg of the operator re-fusion survey (CUDA by default; see ``--ep``).
 
 The CPU survey (``bench/refusion_survey.py``) answers *"is the attention pattern
 still recognisable after onnxsim?"*.  This script answers the question that
 actually matters on an accelerator: **what does it cost in milliseconds?**
 
-It builds the same variants, runs each one on the CUDA execution provider in
-fp32 and fp16, and reports:
+It builds the same variants, runs each one on the selected execution provider
+(``--ep cuda|rocm|migraphx|dml|webgpu``) in fp32 and fp16, and reports:
 
 * median / p90 latency and speed-up versus the un-simplified export,
 * the fused-operator census of the graph as *ONNX Runtime runs it* -- the CUDA
@@ -34,6 +34,10 @@ Run::
     # add the TensorRT EP too, if the wheel has it
     python bench/refusion_gpu_bench.py --preset bert-base --trt
 
+    # a non-NVIDIA EP; --strict-ep turns a silent per-node CPU fallback (for a
+    # com.microsoft op the EP has no kernel for) into a visible session error
+    python bench/refusion_gpu_bench.py --ep rocm --preset bert-base --strict-ep
+
 ``--json`` writes every number this prints; that file is the thing worth sharing.
 """
 
@@ -57,6 +61,25 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import refusion_fixtures as fixtures  # noqa: E402
 import refusion_survey as survey  # noqa: E402
 
+# Accelerator execution providers this benchmark knows how to drive.  Which of
+# them exist depends entirely on which onnxruntime build is installed.
+EP_PROVIDERS = {
+    "cuda": "CUDAExecutionProvider",
+    "rocm": "ROCMExecutionProvider",
+    "migraphx": "MIGraphXExecutionProvider",
+    "dml": "DmlExecutionProvider",
+    "webgpu": "WebGpuExecutionProvider",
+    "cpu": "CPUExecutionProvider",
+}
+
+EP_INSTALL_HINT = {
+    "cuda": "Install the GPU build:  pip install onnxruntime-gpu",
+    "rocm": "Needs a ROCm build of onnxruntime (AMD publishes wheels; not on PyPI).",
+    "migraphx": "Needs a ROCm/MIGraphX build of onnxruntime.",
+    "dml": "Needs onnxruntime-directml (Windows only).",
+    "webgpu": "Needs an onnxruntime build with the WebGPU EP enabled.",
+}
+
 
 def gpu_info() -> Dict[str, str]:
     info = {"platform": platform.platform(), "python": sys.version.split()[0]}
@@ -75,6 +98,18 @@ def gpu_info() -> Dict[str, str]:
             info["gpu"] = out.stdout.strip()
     except Exception:
         pass
+    if "gpu" not in info:
+        try:
+            out = subprocess.run(
+                ["rocm-smi", "--showproductname", "--csv"],
+                capture_output=True,
+                text=True,
+                timeout=20,
+            )
+            if out.returncode == 0:
+                info["gpu"] = " | ".join(out.stdout.split())[:200]
+        except Exception:
+            pass
     return info
 
 
@@ -200,6 +235,23 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument("--warmup", type=int, default=20)
     parser.add_argument("--no-fp16", action="store_true", help="skip the fp16 leg")
     parser.add_argument("--trt", action="store_true", help="also time the TensorRT EP")
+    parser.add_argument(
+        "--ep",
+        choices=list(EP_PROVIDERS),
+        default="cuda",
+        help="execution provider to benchmark (default cuda). Use 'rocm' or "
+        "'migraphx' for AMD, 'dml' for DirectML on Windows, 'webgpu' for the "
+        "WebGPU EP. Whether the fused com.microsoft ops have kernels on the "
+        "chosen EP is exactly what this measures: ops the EP cannot run fall "
+        "back to the CPU EP, which shows up as a large slowdown.",
+    )
+    parser.add_argument(
+        "--strict-ep",
+        action="store_true",
+        help="do not append the CPU EP as a fallback. Session creation then "
+        "fails outright for any op the chosen EP cannot run, which turns a "
+        "silent per-node CPU fallback into a visible error.",
+    )
     parser.add_argument("--cpu", action="store_true", help="run on CPU (debugging)")
     parser.add_argument(
         "--tf32",
@@ -217,22 +269,31 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     ort.set_default_logger_severity(3)
     available = ort.get_available_providers()
+    ep_name = EP_PROVIDERS[args.ep]
     if args.cpu:
+        args.ep = "cpu"
+        ep_name = "CPUExecutionProvider"
+    if ep_name not in available:
+        print(
+            f"{ep_name} is not available.\n"
+            f"available: {available}\n"
+            f"{EP_INSTALL_HINT.get(args.ep, '')}\n"
+            "(or pass --cpu to run this script on the CPU)"
+        )
+        return 2
+    if args.ep == "cpu":
         providers = ["CPUExecutionProvider"]
-    else:
-        if "CUDAExecutionProvider" not in available:
-            print(
-                "CUDAExecutionProvider is not available.\n"
-                f"available: {available}\n"
-                "Install the GPU build:  pip install onnxruntime-gpu\n"
-                "(or pass --cpu to run this script on the CPU)"
-            )
-            return 2
+    elif args.ep == "cuda":
+        # use_tf32 is a CUDA-only provider option.
         providers = [
-            ("CUDAExecutionProvider", {"use_tf32": 1 if args.tf32 == "on" else 0}),
+            (ep_name, {"use_tf32": 1 if args.tf32 == "on" else 0}),
             "CPUExecutionProvider",
         ]
-    use_gpu = not args.cpu
+    else:
+        providers = [ep_name, "CPUExecutionProvider"]
+    if args.strict_ep and args.ep != "cpu":
+        providers = [providers[0]]
+    use_gpu = args.ep != "cpu"
 
     fixtures.configure(
         preset=args.preset,
@@ -251,7 +312,9 @@ def main(argv: Optional[List[str]] = None) -> int:
             # On Ampere and newer the CUDA EP runs fp32 matmuls as TF32 unless
             # this is off, so the fp32 leg is only comparable across cards when
             # this value is known.
-            "use_tf32": args.tf32,
+            "use_tf32": args.tf32 if args.ep == "cuda" else "n/a",
+            "ep": args.ep,
+            "strict_ep": bool(args.strict_ep),
             "preset": args.preset,
         }
     )

--- a/bench/refusion_gpu_bench.py
+++ b/bench/refusion_gpu_bench.py
@@ -79,11 +79,18 @@ def gpu_info() -> Dict[str, str]:
 
 
 def to_fp16(model: onnx.ModelProto) -> Optional[onnx.ModelProto]:
-    """fp16 cast with fp32 graph I/O (what ORT's transformer optimizer emits)."""
+    """fp16 cast with fp32 graph I/O (what ORT's transformer optimizer emits).
+
+    ``OnnxModel`` wraps the ModelProto **by reference** and converts it in
+    place, so the caller's fp32 model must be copied first -- otherwise the
+    fp32 leg silently ends up timing the fp16 graph too.
+    """
     try:
         from onnxruntime.transformers.onnx_model import OnnxModel
 
-        wrapper = OnnxModel(model)
+        clone = onnx.ModelProto()
+        clone.CopyFrom(model)
+        wrapper = OnnxModel(clone)
         wrapper.convert_float_to_float16(keep_io_types=True)
         return wrapper.model
     except Exception as exc:  # pragma: no cover - version dependent
@@ -266,6 +273,13 @@ def main(argv: Optional[List[str]] = None) -> int:
                             "precision": precision,
                             "ep": leg_name,
                             "nodes": len(variant_model.graph.node),
+                            # Guard against a silently-not-converted fp16 leg:
+                            # a genuine fp16 graph has fp16 (dtype 10) weights.
+                            "fp16_initializers": sum(
+                                1
+                                for init in variant_model.graph.initializer
+                                if init.data_type == onnx.TensorProto.FLOAT16
+                            ),
                             "fused": survey.fused_census(variant_model),
                             "session_fused": {
                                 k: v

--- a/bench/refusion_gpu_bench.py
+++ b/bench/refusion_gpu_bench.py
@@ -201,6 +201,15 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument("--no-fp16", action="store_true", help="skip the fp16 leg")
     parser.add_argument("--trt", action="store_true", help="also time the TensorRT EP")
     parser.add_argument("--cpu", action="store_true", help="run on CPU (debugging)")
+    parser.add_argument(
+        "--tf32",
+        choices=["on", "off"],
+        default="on",
+        help="CUDA EP use_tf32 setting for the fp32 leg (default 'on', which is "
+        "also ORT's default). Only affects Ampere and newer -- on those cards "
+        "'fp32' silently means TF32, so pass 'off' for a true fp32 comparison "
+        "against a pre-Ampere card.",
+    )
     parser.add_argument("--json", help="write all measurements here")
     args = parser.parse_args(argv)
 
@@ -219,8 +228,11 @@ def main(argv: Optional[List[str]] = None) -> int:
                 "(or pass --cpu to run this script on the CPU)"
             )
             return 2
-        providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
-    use_gpu = "CUDAExecutionProvider" in providers
+        providers = [
+            ("CUDAExecutionProvider", {"use_tf32": 1 if args.tf32 == "on" else 0}),
+            "CPUExecutionProvider",
+        ]
+    use_gpu = not args.cpu
 
     fixtures.configure(
         preset=args.preset,
@@ -232,7 +244,17 @@ def main(argv: Optional[List[str]] = None) -> int:
     )
 
     env = gpu_info()
-    env.update({"onnx": onnx.__version__, "onnxruntime": ort.__version__})
+    env.update(
+        {
+            "onnx": onnx.__version__,
+            "onnxruntime": ort.__version__,
+            # On Ampere and newer the CUDA EP runs fp32 matmuls as TF32 unless
+            # this is off, so the fp32 leg is only comparable across cards when
+            # this value is known.
+            "use_tf32": args.tf32,
+            "preset": args.preset,
+        }
+    )
     print(json.dumps(env, indent=2))
     print(f"model size: {fixtures.describe()}")
     print(f"providers: {providers}")

--- a/bench/refusion_gpu_bench.py
+++ b/bench/refusion_gpu_bench.py
@@ -1,0 +1,323 @@
+"""GPU leg of the operator re-fusion survey (NVIDIA / CUDA execution provider).
+
+The CPU survey (``bench/refusion_survey.py``) answers *"is the attention pattern
+still recognisable after onnxsim?"*.  This script answers the question that
+actually matters on an accelerator: **what does it cost in milliseconds?**
+
+It builds the same variants, runs each one on the CUDA execution provider in
+fp32 and fp16, and reports:
+
+* median / p90 latency and speed-up versus the un-simplified export,
+* the fused-operator census of the graph as *ONNX Runtime runs it* -- the CUDA
+  EP's own ``AttentionFusion``/``SkipLayerNormFusion``/``GeluFusion`` run inside
+  session creation, so this is what the GPU really executes,
+* whether every variant still produces the same numbers.
+
+Tested target: **GeForce RTX 2060** (Turing, sm75, 6 GB).  fp16 matters on this
+card: Turing has fp16 tensor cores, and ORT's fused attention kernels
+(``TRT fused attention``, ``MemoryEfficientAttention``) only kick in for fp16.
+
+Setup (CUDA 12.x + cuDNN 9 wheels, no system CUDA install needed)::
+
+    python -m venv .venv && . .venv/bin/activate
+    pip install "onnxruntime-gpu" onnx numpy sympy coloredlogs packaging
+    pip install .            # onnxsim, from the repo root
+
+Run::
+
+    # quick smoke test (tiny model, ~1 minute)
+    python bench/refusion_gpu_bench.py --preset tiny
+
+    # the real measurement (BERT-base sized, fp32 + fp16)
+    python bench/refusion_gpu_bench.py --preset bert-base --json rtx2060.json
+
+    # add the TensorRT EP too, if the wheel has it
+    python bench/refusion_gpu_bench.py --preset bert-base --trt
+
+``--json`` writes every number this prints; that file is the thing worth sharing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import statistics
+import subprocess
+import sys
+import time
+from typing import Dict, List, Optional, Sequence
+
+import numpy as np
+import onnx
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import refusion_fixtures as fixtures  # noqa: E402
+import refusion_survey as survey  # noqa: E402
+
+
+def gpu_info() -> Dict[str, str]:
+    info = {"platform": platform.platform(), "python": sys.version.split()[0]}
+    try:
+        out = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=name,driver_version,memory.total",
+                "--format=csv,noheader",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        if out.returncode == 0:
+            info["gpu"] = out.stdout.strip()
+    except Exception:
+        pass
+    return info
+
+
+def to_fp16(model: onnx.ModelProto) -> Optional[onnx.ModelProto]:
+    """fp16 cast with fp32 graph I/O (what ORT's transformer optimizer emits)."""
+    try:
+        from onnxruntime.transformers.onnx_model import OnnxModel
+
+        wrapper = OnnxModel(model)
+        wrapper.convert_float_to_float16(keep_io_types=True)
+        return wrapper.model
+    except Exception as exc:  # pragma: no cover - version dependent
+        print(f"  (fp16 conversion failed: {str(exc)[:120]})")
+        return None
+
+
+def timed(
+    model: onnx.ModelProto,
+    feed,
+    providers: Sequence,
+    warmup: int,
+    iters: int,
+) -> Dict[str, Optional[float]]:
+    import onnxruntime as ort
+
+    try:
+        sess = ort.InferenceSession(
+            model.SerializeToString(), providers=list(providers)
+        )
+    except Exception as exc:
+        return {"error": str(exc)[:200]}
+    used = sess.get_providers()
+    names = {i.name for i in sess.get_inputs()}
+    types = {i.name: i.type for i in sess.get_inputs()}
+    inputs = {}
+    for name, value in feed.items():
+        if name not in names:
+            continue
+        if "float16" in types[name] and value.dtype == np.float32:
+            value = value.astype(np.float16)
+        inputs[name] = value
+    for _ in range(warmup):
+        sess.run(None, inputs)
+    samples = []
+    for _ in range(iters):
+        start = time.perf_counter()
+        sess.run(None, inputs)
+        samples.append((time.perf_counter() - start) * 1e3)
+    samples.sort()
+    outputs = sess.run(None, inputs)
+    return {
+        "median_ms": statistics.median(samples),
+        "p90_ms": samples[int(0.9 * (len(samples) - 1))],
+        "min_ms": samples[0],
+        "providers": used,
+        "_outputs": outputs,
+    }
+
+
+def build_variants(name: str, use_gpu: bool) -> "Dict[str, onnx.ModelProto]":
+    model, feed = fixtures.build(name)
+    model_type = fixtures.MODEL_TYPE[name]
+    heads = fixtures.NUM_HEADS[name]
+    hidden = fixtures.HIDDEN_SIZE[name]
+
+    variants = {"raw": model}
+    print(f"  simplifying {name} ...", flush=True)
+    sim, _ = survey.simplify(model)
+    variants["sim"] = sim
+    sim_nogemm, _ = survey.simplify(
+        model, skipped_optimizers=[survey.BATCHED_GEMM_PASS]
+    )
+    variants["sim_nogemm"] = sim_nogemm
+    # The same simplification with the fusion-hostile passes turned off, i.e.
+    # what onnxsim could deliver today with a different default pass set.
+    sim_safe, _ = survey.simplify(
+        model, skipped_optimizers=survey.FUSION_HOSTILE_PASSES
+    )
+    variants["sim_safe"] = sim_safe
+
+    print("  running ONNX Runtime transformer fusion ...", flush=True)
+    for label, src in (
+        ("ort(raw)", model),
+        ("ort(sim)", sim),
+        ("ort(sim_nogemm)", sim_nogemm),
+        ("ort(sim_safe)", sim_safe),
+    ):
+        fused, stats = survey.ort_fuse(src, model_type, heads, hidden, use_gpu=use_gpu)
+        if fused is not None:
+            variants[label] = fused
+        else:
+            print(f"  {label}: fusion failed ({stats.get('error')})")
+    return variants, feed
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--fixtures",
+        nargs="*",
+        default=[
+            "bert_layer",
+            "llama_layer",
+            "fused_contrib_mha",
+            "fused_onnx_attention",
+        ],
+        choices=list(fixtures.FIXTURES),
+    )
+    parser.add_argument("--preset", default="bert-base", choices=list(fixtures.PRESETS))
+    parser.add_argument("--batch", type=int)
+    parser.add_argument("--seq", type=int)
+    parser.add_argument("--hidden", type=int)
+    parser.add_argument("--heads", type=int)
+    parser.add_argument("--layers", type=int)
+    parser.add_argument("--iters", type=int, default=100)
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--no-fp16", action="store_true", help="skip the fp16 leg")
+    parser.add_argument("--trt", action="store_true", help="also time the TensorRT EP")
+    parser.add_argument("--cpu", action="store_true", help="run on CPU (debugging)")
+    parser.add_argument("--json", help="write all measurements here")
+    args = parser.parse_args(argv)
+
+    import onnxruntime as ort
+
+    ort.set_default_logger_severity(3)
+    available = ort.get_available_providers()
+    if args.cpu:
+        providers = ["CPUExecutionProvider"]
+    else:
+        if "CUDAExecutionProvider" not in available:
+            print(
+                "CUDAExecutionProvider is not available.\n"
+                f"available: {available}\n"
+                "Install the GPU build:  pip install onnxruntime-gpu\n"
+                "(or pass --cpu to run this script on the CPU)"
+            )
+            return 2
+        providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    use_gpu = "CUDAExecutionProvider" in providers
+
+    fixtures.configure(
+        preset=args.preset,
+        batch=args.batch,
+        seq=args.seq,
+        hidden=args.hidden,
+        heads=args.heads,
+        layers=args.layers,
+    )
+
+    env = gpu_info()
+    env.update({"onnx": onnx.__version__, "onnxruntime": ort.__version__})
+    print(json.dumps(env, indent=2))
+    print(f"model size: {fixtures.describe()}")
+    print(f"providers: {providers}")
+
+    results = []
+    for name in args.fixtures:
+        print(f"\n### {name}")
+        variants, feed = build_variants(name, use_gpu)
+        reference = None
+        rows = []
+        legs = [("fp32", providers)]
+        if args.trt and "TensorrtExecutionProvider" in available:
+            legs.append(("trt", ["TensorrtExecutionProvider"] + providers))
+        for label, model in variants.items():
+            candidates = [(label, model, "fp32")]
+            if not args.no_fp16 and use_gpu:
+                half = to_fp16(model)
+                if half is not None:
+                    candidates.append((f"{label} fp16", half, "fp16"))
+            for leg_name, leg_providers in legs:
+                for variant_label, variant_model, precision in candidates:
+                    tag = (
+                        variant_label
+                        if leg_name == "fp32"
+                        else f"{variant_label} [trt]"
+                    )
+                    result = timed(
+                        variant_model, feed, leg_providers, args.warmup, args.iters
+                    )
+                    outputs = result.pop("_outputs", None)
+                    if reference is None and outputs is not None:
+                        reference = outputs
+                    diff = survey.max_abs_diff(reference, outputs) if outputs else None
+                    session_ops = survey.ort_session_ops(variant_model, leg_providers)
+                    rows.append(
+                        {
+                            "variant": tag,
+                            "precision": precision,
+                            "ep": leg_name,
+                            "nodes": len(variant_model.graph.node),
+                            "fused": survey.fused_census(variant_model),
+                            "session_fused": {
+                                k: v
+                                for k, v in session_ops.items()
+                                if k in survey.FUSED_OPS or k == "error"
+                            },
+                            "max_abs_diff": diff,
+                            **result,
+                        }
+                    )
+                    lat = result.get("median_ms")
+                    status = (
+                        "%.3f ms" % lat
+                        if lat
+                        else "does not run: " + result.get("error", "-")[:50]
+                    )
+                    print(
+                        f"  {tag:<24} {status:>16}"
+                        f"   {survey._fmt_counts(rows[-1]['session_fused'])}"
+                    )
+        base = next(
+            (
+                r["median_ms"]
+                for r in rows
+                if r["variant"] == "raw" and r.get("median_ms")
+            ),
+            None,
+        )
+        if base:
+            for row in rows:
+                if row.get("median_ms"):
+                    row["speedup_vs_raw"] = base / row["median_ms"]
+        results.append({"fixture": name, "rows": rows, "env": env})
+
+        print(
+            f"\n  {'variant':<24}{'median ms':>10}{'p90 ms':>9}{'speedup':>9}  maxdiff"
+        )
+        for row in rows:
+            if not row.get("median_ms"):
+                continue
+            print(
+                f"  {row['variant']:<24}{row['median_ms']:>10.3f}{row['p90_ms']:>9.3f}"
+                f"{row.get('speedup_vs_raw', float('nan')):>9.2f}x"
+                f"  {row['max_abs_diff'] if row['max_abs_diff'] is not None else '-'}"
+            )
+
+    if args.json:
+        with open(args.json, "w") as f:
+            json.dump(results, f, indent=2, default=str)
+        print(f"\nwrote {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/refusion_gpu_bench.py
+++ b/bench/refusion_gpu_bench.py
@@ -35,8 +35,10 @@ Run::
     python bench/refusion_gpu_bench.py --preset bert-base --trt
 
     # a non-NVIDIA EP; --strict-ep turns a silent per-node CPU fallback (for a
-    # com.microsoft op the EP has no kernel for) into a visible session error
-    python bench/refusion_gpu_bench.py --ep rocm --preset bert-base --strict-ep
+    # com.microsoft op the EP has no kernel for) into a visible session error.
+    # NOTE for AMD: the ROCm EP was removed from onnxruntime in 1.23, so on any
+    # current release the AMD path is --ep migraphx with an AMD-built wheel.
+    python bench/refusion_gpu_bench.py --ep migraphx --preset bert-base --strict-ep
 
 ``--json`` writes every number this prints; that file is the thing worth sharing.
 """
@@ -74,8 +76,17 @@ EP_PROVIDERS = {
 
 EP_INSTALL_HINT = {
     "cuda": "Install the GPU build:  pip install onnxruntime-gpu",
-    "rocm": "Needs a ROCm build of onnxruntime (AMD publishes wheels; not on PyPI).",
-    "migraphx": "Needs a ROCm/MIGraphX build of onnxruntime.",
+    "rocm": (
+        "The ROCm EP was REMOVED from onnxruntime in 1.23 -- no 1.23+ build has "
+        "it, whatever wheel you install. Use --ep migraphx (AMD's replacement), "
+        "or an onnxruntime <= 1.22 ROCm wheel from "
+        "https://repo.radeon.com/rocm/manylinux/ ."
+    ),
+    "migraphx": (
+        "Needs an AMD-built onnxruntime with the MIGraphX EP -- wheels live at "
+        "https://repo.radeon.com/rocm/manylinux/ (pip install onnxruntime-rocm "
+        "-f <that index>) or in the rocm/onnxruntime container. Not on PyPI."
+    ),
     "dml": "Needs onnxruntime-directml (Windows only).",
     "webgpu": "Needs an onnxruntime build with the WebGPU EP enabled.",
 }
@@ -277,9 +288,18 @@ def main(argv: Optional[List[str]] = None) -> int:
         print(
             f"{ep_name} is not available.\n"
             f"available: {available}\n"
+            f"onnxruntime {ort.__version__}\n"
             f"{EP_INSTALL_HINT.get(args.ep, '')}\n"
             "(or pass --cpu to run this script on the CPU)"
         )
+        if args.ep == "rocm" and tuple(
+            int(part) for part in ort.__version__.split(".")[:2]
+        ) >= (1, 23):
+            print(
+                "\nThis onnxruntime is 1.23 or newer, so the ROCm EP does not "
+                "exist in it at all -- installing a different 1.23+ wheel cannot "
+                "help. Try --ep migraphx."
+            )
         return 2
     if args.ep == "cpu":
         providers = ["CPUExecutionProvider"]

--- a/bench/refusion_gpu_run.sh
+++ b/bench/refusion_gpu_run.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # Run the re-fusion survey on an NVIDIA GPU (developed against an RTX 2060).
 #
-#   bash bench/refusion_gpu_run.sh            # set up + run everything
-#   bash bench/refusion_gpu_run.sh --quick    # tiny model, fast smoke test
+#   bash bench/refusion_gpu_run.sh                 # set up + run everything
+#   bash bench/refusion_gpu_run.sh --quick         # tiny model, fast smoke test
+#   bash bench/refusion_gpu_run.sh --tf32 off      # any other flag is forwarded
+#                                                  # to refusion_gpu_bench.py
 #
 # It creates .venv-refusion/, installs onnxruntime-gpu and builds onnxsim from
 # this checkout, then writes two JSON files in the repo root:
@@ -14,7 +16,17 @@
 set -euo pipefail
 
 QUICK=0
-[[ "${1:-}" == "--quick" ]] && QUICK=1
+# --quick is handled here; every other argument is passed through to
+# refusion_gpu_bench.py, so flags like `--tf32 off`, `--ep rocm` or
+# `--strict-ep` work from this wrapper instead of being silently dropped.
+GPU_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --quick) QUICK=1 ;;
+    *) GPU_ARGS+=("$1") ;;
+  esac
+  shift
+done
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
@@ -57,11 +69,12 @@ python bench/refusion_survey.py \
   --bisect \
   --json "refusion_cpu_${HOST}.json"
 
-echo "==> GPU survey on the CUDA execution provider (preset=$PRESET)"
+echo "==> GPU survey (preset=$PRESET)${GPU_ARGS[0]+, extra args: ${GPU_ARGS[*]}}"
 python bench/refusion_gpu_bench.py \
   --preset "$PRESET" \
   --iters "$ITERS" \
-  --json "refusion_gpu_${HOST}.json"
+  --json "refusion_gpu_${HOST}.json" \
+  ${GPU_ARGS[0]+"${GPU_ARGS[@]}"}
 
 echo
 echo "done -- share these two files:"

--- a/bench/refusion_gpu_run.sh
+++ b/bench/refusion_gpu_run.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Run the re-fusion survey on an NVIDIA GPU (developed against an RTX 2060).
+#
+#   bash bench/refusion_gpu_run.sh            # set up + run everything
+#   bash bench/refusion_gpu_run.sh --quick    # tiny model, fast smoke test
+#
+# It creates .venv-refusion/, installs onnxruntime-gpu and builds onnxsim from
+# this checkout, then writes two JSON files in the repo root:
+#
+#   refusion_cpu_<host>.json   -- pattern-level survey (fusion counts)
+#   refusion_gpu_<host>.json   -- CUDA EP latency, fp32 + fp16
+#
+# Those two files are the result; everything else is progress output.
+set -euo pipefail
+
+QUICK=0
+[[ "${1:-}" == "--quick" ]] && QUICK=1
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+VENV="$REPO_ROOT/.venv-refusion"
+HOST="$(hostname -s 2>/dev/null || echo host)"
+
+if [[ ! -d "$VENV" ]]; then
+  echo "==> creating $VENV"
+  python3 -m venv "$VENV"
+fi
+# shellcheck disable=SC1091
+source "$VENV/bin/activate"
+
+echo "==> installing dependencies"
+pip install -q --upgrade pip
+# onnxruntime-gpu ships the CUDA 12 / cuDNN 9 kernels; no system CUDA needed.
+# The CPU onnxruntime package must NOT be installed alongside it.
+pip uninstall -q -y onnxruntime 2>/dev/null || true
+pip install -q onnxruntime-gpu onnx numpy sympy coloredlogs packaging psutil
+
+echo "==> building onnxsim from this checkout (a few minutes the first time)"
+git submodule update --init --recursive
+pip install -q .
+
+nvidia-smi --query-gpu=name,driver_version,memory.total --format=csv || true
+
+if [[ "$QUICK" == "1" ]]; then
+  PRESET=tiny
+  ITERS=20
+else
+  PRESET=bert-base
+  ITERS=100
+fi
+
+echo "==> CPU / pattern survey (preset=$PRESET)"
+python bench/refusion_survey.py \
+  --preset "$PRESET" \
+  --json "refusion_cpu_${HOST}.json"
+
+echo "==> GPU survey on the CUDA execution provider (preset=$PRESET)"
+python bench/refusion_gpu_bench.py \
+  --preset "$PRESET" \
+  --iters "$ITERS" \
+  --json "refusion_gpu_${HOST}.json"
+
+echo
+echo "done -- share these two files:"
+ls -la "refusion_cpu_${HOST}.json" "refusion_gpu_${HOST}.json"

--- a/bench/refusion_gpu_run.sh
+++ b/bench/refusion_gpu_run.sh
@@ -50,8 +50,11 @@ else
 fi
 
 echo "==> CPU / pattern survey (preset=$PRESET)"
+# --bisect names the optimizer pass behind any fusion the simplified model lost;
+# it re-runs simplify once per default pass, so it is the slow part of this run.
 python bench/refusion_survey.py \
   --preset "$PRESET" \
+  --bisect \
   --json "refusion_cpu_${HOST}.json"
 
 echo "==> GPU survey on the CUDA execution provider (preset=$PRESET)"

--- a/bench/refusion_survey.py
+++ b/bench/refusion_survey.py
@@ -1,0 +1,570 @@
+"""Survey: what happens to *fused, compute-dominant* operators (Attention and
+friends) when a model goes through onnxsim.
+
+Two questions, measured rather than argued:
+
+1. **Re-fusion** -- after onnxsim rewrites a decomposed attention block, can the
+   downstream runtime still recognise it and fuse it back into a single kernel
+   (``com.microsoft.Attention`` / ``MultiHeadAttention`` / ``SkipLayerNormalization``
+   / ``BiasGelu`` ...)?  If simplification makes the pattern unrecognisable, a
+   "simplified" model is *slower*, because attention is where all the time goes.
+2. **Preservation** -- if the model already contains fused ops (``ai.onnx``
+   ``Attention``, ``com.microsoft.MultiHeadAttention``, ...), does onnxsim keep
+   them intact?
+
+For each fixture the script builds these variants and compares them:
+
+===========================  ============================================
+variant                      meaning
+===========================  ============================================
+``raw``                      the exported graph
+``sim``                      ``onnxsim.simplify`` with default settings
+``sim_nogemm``               ``simplify`` with ``fuse_matmul_add_bias_into_gemm_batched`` skipped
+``ort(raw)``                 ORT transformer fusion on the exported graph (the ceiling)
+``ort(sim)``                 ORT transformer fusion *after* onnxsim -- the re-fusion question
+``ort(sim_nogemm)``          same, with the batched-Gemm rewrite skipped
+``sim_safe``/``ort(sim_safe)``  ``--bisect`` only: simplify with the passes that were
+                             destroying a fusion skipped
+``sim(ort(raw))``            onnxsim on an already-fused model -- the preservation question
+===========================  ============================================
+
+and reports, per variant: node counts, the fused-op census, whether ONNX
+Runtime's *own* session-level optimizer (``ORT_ENABLE_ALL``, on the selected
+execution provider) fuses it, numerical agreement with ``raw``, and latency.
+
+Usage::
+
+    python bench/refusion_survey.py                       # CPU
+    python bench/refusion_survey.py --bisect              # + name the guilty passes
+    python bench/refusion_survey.py --providers CUDAExecutionProvider CPUExecutionProvider
+    python bench/refusion_survey.py --fixtures bert_layer --json out.json
+
+``bench/refusion_gpu_bench.py`` is the GPU-side driver (CUDA EP, fp16, TensorRT).
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import contextlib
+import json
+import os
+import statistics
+import sys
+import tempfile
+import time
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+import onnx
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import refusion_fixtures as fixtures  # noqa: E402
+
+# Ops that mean "one kernel does the whole compute-dominant block".
+FUSED_OPS = (
+    # ai.onnx (opset 23+)
+    "Attention",
+    "RMSNormalization",
+    "RotaryEmbedding",
+    "LayerNormalization",
+    "Gelu",
+    # com.microsoft
+    "MultiHeadAttention",
+    "GroupQueryAttention",
+    "PackedAttention",
+    "SkipLayerNormalization",
+    "SkipSimplifiedLayerNormalization",
+    "SimplifiedLayerNormalization",
+    "EmbedLayerNormalization",
+    "BiasGelu",
+    "FastGelu",
+    "QuickGelu",
+    "BiasSplitGelu",
+    "FusedMatMul",
+    "Gemm",
+)
+
+BATCHED_GEMM_PASS = "fuse_matmul_add_bias_into_gemm_batched"
+
+# The default passes this survey found to be hostile to downstream fusion on
+# transformer graphs -- see bench/RESULTS_refusion.md.  ``fuse_consecutive_
+# unsqueezes`` merges the attention mask's Unsqueeze pair, which is the exact
+# node sequence ORT's FusionAttention walks; the batched-Gemm rewrite turns the
+# Q/K/V ``MatMul+Add`` into ``Reshape+Gemm`` (and, combined with
+# ``eliminate_consecutive_idempotent_ops``, currently produces a model that does
+# not load at all).
+FUSION_HOSTILE_PASSES = [
+    BATCHED_GEMM_PASS,
+    "fuse_consecutive_unsqueezes",
+]
+
+
+def op_counts(model: onnx.ModelProto) -> Dict[str, int]:
+    return dict(collections.Counter(n.op_type for n in model.graph.node))
+
+
+def fused_census(model: onnx.ModelProto) -> Dict[str, int]:
+    counts = op_counts(model)
+    return {op: counts[op] for op in FUSED_OPS if counts.get(op)}
+
+
+@contextlib.contextmanager
+def _tmp_model(model: onnx.ModelProto):
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "model.onnx")
+        onnx.save(model, path)
+        yield path
+
+
+def ensure_opset_imports(model: onnx.ModelProto) -> bool:
+    """Add opset imports for domains the graph uses but does not declare.
+
+    ONNX Runtime's transformer optimizer emits ``com.microsoft`` nodes *without*
+    adding the matching opset import, which makes the model invalid ONNX -- the
+    onnx checker (and therefore ``onnxsim.simplify``) rejects it with
+    ``No opset import for domain 'com.microsoft'``.  Returns True if the model
+    had to be patched.
+    """
+    declared = {entry.domain for entry in model.opset_import}
+    used = {node.domain for node in model.graph.node if node.domain}
+    missing = used - declared
+    for domain in sorted(missing):
+        model.opset_import.append(onnx.helper.make_opsetid(domain, 1))
+    return bool(missing)
+
+
+def simplify(model: onnx.ModelProto, skipped_optimizers=None):
+    import onnxsim
+
+    simplified, ok = onnxsim.simplify(
+        model, check_n=0, skipped_optimizers=skipped_optimizers
+    )
+    return simplified, ok
+
+
+def default_optimizers() -> List[str]:
+    """The onnx-optimizer passes onnxsim runs by default."""
+    import onnxsim.onnxsim_cpp2py_export as C
+
+    passes = list(C._list_optimizers())
+    if BATCHED_GEMM_PASS not in passes:
+        # Opted into explicitly by onnxsim (registered as PassType::Other, so it
+        # is not part of onnx-optimizer's default fuse/elimination list).
+        passes.append(BATCHED_GEMM_PASS)
+    return passes
+
+
+def find_fusion_breaking_passes(
+    model: onnx.ModelProto, model_type: str, num_heads: int, hidden_size: int
+) -> Dict[str, Dict[str, int]]:
+    """Which optimizer pass costs the model a downstream fusion?
+
+    Runs ``simplify`` once per default pass with only that pass skipped and
+    reports the passes whose removal *increases* the number of fused ops ORT can
+    recover -- i.e. the passes that were destroying a fusion.
+    """
+
+    def loadable(candidate) -> bool:
+        import onnxruntime as ort
+
+        try:
+            ort.InferenceSession(
+                candidate.SerializeToString(), providers=["CPUExecutionProvider"]
+            )
+        except Exception:
+            return False
+        return True
+
+    def census_after(skip):
+        try:
+            candidate, _ = simplify(model, skipped_optimizers=skip)
+        except Exception:
+            return None
+        # A simplified model that no longer loads has lost every fusion there is.
+        if not loadable(candidate):
+            return {}
+        try:
+            recovered, _ = ort_fuse(candidate, model_type, num_heads, hidden_size)
+        except Exception:
+            return None
+        return fused_census(recovered) if recovered is not None else None
+
+    baseline_fused, _ = ort_fuse(model, model_type, num_heads, hidden_size)
+    reference = fused_census(baseline_fused) if baseline_fused is not None else {}
+
+    def total(census):
+        # Score only against the fusions the un-simplified model achieved, so
+        # incidental extra ops (a Gemm the rewrite introduced) cannot look like
+        # a gain.
+        return sum(min(count, census.get(op, 0)) for op, count in reference.items())
+
+    current = census_after(None) or {}
+    if total(current) >= total(reference):
+        return {}
+
+    # Greedy: some fusions are gated on others (attention fusion anchors on a
+    # LayerNormalization node), so a single skipped pass may recover nothing
+    # until another one is skipped too.  Keep adding the pass with the biggest
+    # gain until nothing improves.
+    culprits: Dict[str, Dict[str, int]] = {}
+    skipped: List[str] = []
+    remaining = default_optimizers()
+    while total(current) < total(reference):
+        best = None
+        for pass_name in remaining:
+            census = census_after(skipped + [pass_name])
+            if census is None or total(census) <= total(current):
+                continue
+            if best is None or total(census) > total(best[1]):
+                best = (pass_name, census)
+        if best is None:
+            break
+        pass_name, census = best
+        culprits[pass_name] = {
+            op: census[op] - current.get(op, 0)
+            for op in census
+            if census[op] > current.get(op, 0)
+        }
+        skipped.append(pass_name)
+        remaining = [p for p in remaining if p != pass_name]
+        current = census
+    return culprits
+
+
+def ort_fuse(
+    model: onnx.ModelProto,
+    model_type: str,
+    num_heads: int,
+    hidden_size: int,
+    use_gpu: bool = False,
+    float16: bool = False,
+) -> Tuple[Optional[onnx.ModelProto], Dict[str, int]]:
+    """Run ONNX Runtime's transformer fusion passes (the python ones).
+
+    ``opt_level=0`` disables ORT's C++ graph optimizations so the result
+    measures *pattern recognisability* only: every fused op in the output was
+    produced by a python pattern matcher walking this exact graph.
+    """
+    from onnxruntime.transformers import optimizer
+
+    with _tmp_model(model) as path:
+        try:
+            optimized = optimizer.optimize_model(
+                path,
+                model_type=model_type,
+                num_heads=num_heads,
+                hidden_size=hidden_size,
+                opt_level=0,
+                use_gpu=use_gpu,
+            )
+        except Exception as exc:  # pragma: no cover - depends on ORT version
+            return None, {"error": str(exc)[:200]}
+    if float16:
+        optimized.convert_float_to_float16(keep_io_types=True)
+    return optimized.model, dict(optimized.get_fused_operator_statistics())
+
+
+def ort_session_ops(model: onnx.ModelProto, providers: Sequence[str]) -> Dict[str, int]:
+    """Op census of the model *as ONNX Runtime actually runs it*.
+
+    Runs the session with ``ORT_ENABLE_ALL`` and dumps the optimized graph, so
+    the counts include ORT's own C++ fusions (``AttentionFusion``,
+    ``SkipLayerNormFusion``, ``GeluFusion``, ...) for the selected execution
+    provider.  This is EP-dependent: the CUDA EP fuses more than the CPU EP.
+    """
+    import onnxruntime as ort
+
+    with tempfile.TemporaryDirectory() as d:
+        src = os.path.join(d, "in.onnx")
+        dst = os.path.join(d, "opt.onnx")
+        onnx.save(model, src)
+        so = ort.SessionOptions()
+        so.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
+        so.optimized_model_filepath = dst
+        try:
+            ort.InferenceSession(src, so, providers=list(providers))
+        except Exception as exc:
+            return {"error": str(exc)[:200]}
+        if not os.path.exists(dst):
+            return {}
+        return op_counts(onnx.load(dst))
+
+
+def run(model: onnx.ModelProto, feed, providers: Sequence[str]):
+    import onnxruntime as ort
+
+    sess = ort.InferenceSession(model.SerializeToString(), providers=list(providers))
+    names = {i.name for i in sess.get_inputs()}
+    return sess.run(None, {k: v for k, v in feed.items() if k in names})
+
+
+def latency_ms(
+    model: onnx.ModelProto,
+    feed,
+    providers: Sequence[str],
+    warmup: int = 10,
+    iters: int = 50,
+) -> Optional[float]:
+    import onnxruntime as ort
+
+    try:
+        sess = ort.InferenceSession(
+            model.SerializeToString(), providers=list(providers)
+        )
+    except Exception:
+        return None
+    names = {i.name for i in sess.get_inputs()}
+    inputs = {k: v for k, v in feed.items() if k in names}
+    dtypes = {i.name: i.type for i in sess.get_inputs()}
+    for name, value in list(inputs.items()):
+        if "float16" in dtypes.get(name, "") and value.dtype == np.float32:
+            inputs[name] = value.astype(np.float16)
+    for _ in range(warmup):
+        sess.run(None, inputs)
+    samples = []
+    for _ in range(iters):
+        start = time.perf_counter()
+        sess.run(None, inputs)
+        samples.append((time.perf_counter() - start) * 1e3)
+    return statistics.median(samples)
+
+
+def max_abs_diff(a, b) -> Optional[float]:
+    if a is None or b is None or len(a) != len(b):
+        return None
+    return max(
+        float(np.max(np.abs(x.astype(np.float64) - y.astype(np.float64))))
+        for x, y in zip(a, b)
+    )
+
+
+def survey_fixture(
+    name: str,
+    providers: Sequence[str],
+    iters: int,
+    do_latency: bool = True,
+    float16: bool = False,
+    bisect: bool = False,
+) -> dict:
+    model, feed = fixtures.build(name)
+    model_type = fixtures.MODEL_TYPE[name]
+    heads = fixtures.NUM_HEADS[name]
+    hidden = fixtures.HIDDEN_SIZE[name]
+    use_gpu = any("CUDA" in p or "Tensorrt" in p for p in providers)
+
+    variants: "collections.OrderedDict[str, onnx.ModelProto]" = (
+        collections.OrderedDict()
+    )
+    fusion_stats: Dict[str, Dict[str, int]] = {}
+
+    variants["raw"] = model
+    sim, _ = simplify(model)
+    variants["sim"] = sim
+    sim_nogemm, _ = simplify(model, skipped_optimizers=[BATCHED_GEMM_PASS])
+    variants["sim_nogemm"] = sim_nogemm
+
+    culprits: Dict[str, Dict[str, int]] = {}
+    if bisect:
+        culprits = find_fusion_breaking_passes(model, model_type, heads, hidden)
+        if culprits:
+            safe, _ = simplify(model, skipped_optimizers=sorted(culprits))
+            variants["sim_safe"] = safe
+
+    fusion_sources = [
+        ("ort(raw)", model),
+        ("ort(sim)", sim),
+        ("ort(sim_nogemm)", sim_nogemm),
+    ]
+    if "sim_safe" in variants:
+        fusion_sources.append(("ort(sim_safe)", variants["sim_safe"]))
+
+    for label, src in fusion_sources:
+        fused, stats = ort_fuse(src, model_type, heads, hidden, use_gpu, float16)
+        fusion_stats[label] = stats
+        if fused is not None:
+            variants[label] = fused
+
+    notes: List[str] = []
+    if "ort(raw)" in variants:
+        # onnxsim on an already-fused model.  ORT leaves the com.microsoft opset
+        # import out of its own output, so try it as produced first and record
+        # what happens before patching the model up.
+        fused_model = variants["ort(raw)"]
+        try:
+            resim, _ = simplify(fused_model)
+        except Exception as exc:
+            notes.append(
+                f"simplify(ort(raw)) raised as produced by ORT: {str(exc)[:120]}"
+            )
+            patched = onnx.ModelProto()
+            patched.CopyFrom(fused_model)
+            if ensure_opset_imports(patched):
+                notes.append("retried after adding the missing opset import")
+            try:
+                resim, _ = simplify(patched)
+            except Exception as exc2:
+                notes.append(f"still fails: {str(exc2)[:120]}")
+                resim = None
+        if resim is not None:
+            variants["sim(ort(raw))"] = resim
+
+    reference = run(model, feed, providers)
+    rows = []
+    for label, variant in variants.items():
+        try:
+            outputs = run(variant, feed, providers)
+            err = max_abs_diff(reference, outputs)
+        except Exception as exc:
+            outputs, err = None, None
+            runnable = str(exc)[:160]
+        else:
+            runnable = "ok"
+        rows.append(
+            {
+                "variant": label,
+                "nodes": len(variant.graph.node),
+                "ops": op_counts(variant),
+                "fused": fused_census(variant),
+                "ort_fusion_stats": fusion_stats.get(label),
+                "ort_session_ops": ort_session_ops(variant, providers),
+                "runs": runnable,
+                "max_abs_diff": err,
+                "latency_ms": latency_ms(variant, feed, providers, iters=iters)
+                if do_latency
+                else None,
+            }
+        )
+    return {
+        "fixture": name,
+        "providers": list(providers),
+        "variants": rows,
+        "notes": notes,
+        "fusion_breaking_passes": culprits,
+    }
+
+
+def _fmt_counts(counts: Optional[Dict[str, int]], keys=None) -> str:
+    if counts is None:
+        return "-"
+    if "error" in counts:
+        return f"error: {counts['error'][:60]}"
+    items = [
+        (k, v) for k, v in sorted(counts.items()) if v and (keys is None or k in keys)
+    ]
+    return ", ".join(f"{k}={v}" for k, v in items) or "-"
+
+
+def print_report(result: dict) -> None:
+    print()
+    print("=" * 100)
+    print(f"fixture: {result['fixture']}   providers: {', '.join(result['providers'])}")
+    print("=" * 100)
+    header = f"{'variant':<18}{'nodes':>6}  {'lat(ms)':>8}  {'maxdiff':>9}  fused ops in the graph"
+    print(header)
+    print("-" * 100)
+    for row in result["variants"]:
+        lat = f"{row['latency_ms']:.3f}" if row["latency_ms"] is not None else "-"
+        diff = f"{row['max_abs_diff']:.2e}" if row["max_abs_diff"] is not None else "-"
+        print(
+            f"{row['variant']:<18}{row['nodes']:>6}  {lat:>8}  {diff:>9}  "
+            f"{_fmt_counts(row['fused'])}"
+        )
+    print()
+    print(
+        "ONNX Runtime session-level optimization (ORT_ENABLE_ALL) -- fused ops it produces:"
+    )
+    for row in result["variants"]:
+        print(
+            f"  {row['variant']:<18}{_fmt_counts({k: v for k, v in (row['ort_session_ops'] or {}).items() if k in FUSED_OPS or k == 'error'})}"
+        )
+    print()
+    print(
+        "onnxruntime.transformers fusion statistics (opt_level=0, pattern matching only):"
+    )
+    for row in result["variants"]:
+        if row["ort_fusion_stats"] is not None:
+            print(f"  {row['variant']:<18}{_fmt_counts(row['ort_fusion_stats'])}")
+    if result.get("fusion_breaking_passes"):
+        print("optimizer passes that cost the model a downstream fusion:")
+        for pass_name, gained in result["fusion_breaking_passes"].items():
+            print(f"  {pass_name:<40}recovers {_fmt_counts(gained)}")
+        print()
+    for note in result.get("notes", []):
+        print(f"  note: {note}")
+    failures = [r for r in result["variants"] if r["runs"] != "ok"]
+    for row in failures:
+        print(f"  !! {row['variant']} does not run: {row['runs']}")
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--fixtures",
+        nargs="*",
+        default=list(fixtures.FIXTURES),
+        choices=list(fixtures.FIXTURES),
+    )
+    parser.add_argument("--providers", nargs="*", default=["CPUExecutionProvider"])
+    parser.add_argument(
+        "--preset", default="tiny", choices=list(fixtures.PRESETS), help="model size"
+    )
+    parser.add_argument("--batch", type=int)
+    parser.add_argument("--seq", type=int)
+    parser.add_argument("--hidden", type=int)
+    parser.add_argument("--heads", type=int)
+    parser.add_argument("--layers", type=int)
+    parser.add_argument("--iters", type=int, default=50)
+    parser.add_argument("--no-latency", action="store_true")
+    parser.add_argument(
+        "--bisect",
+        action="store_true",
+        help="find which optimizer pass destroys a downstream fusion "
+        "(re-runs simplify once per default pass)",
+    )
+    parser.add_argument(
+        "--float16",
+        action="store_true",
+        help="convert the ORT-fused variants to fp16 (GPU tensor cores)",
+    )
+    parser.add_argument("--json", help="write the full result table to this path")
+    args = parser.parse_args(argv)
+
+    import onnxruntime as ort
+
+    ort.set_default_logger_severity(3)
+    fixtures.configure(
+        preset=args.preset,
+        batch=args.batch,
+        seq=args.seq,
+        hidden=args.hidden,
+        heads=args.heads,
+        layers=args.layers,
+    )
+    print(f"onnx {onnx.__version__}, onnxruntime {ort.__version__}")
+    print(f"available providers: {ort.get_available_providers()}")
+    print(f"model size: {fixtures.describe()}")
+
+    results = []
+    for name in args.fixtures:
+        result = survey_fixture(
+            name,
+            args.providers,
+            args.iters,
+            do_latency=not args.no_latency,
+            float16=args.float16,
+            bisect=args.bisect,
+        )
+        print_report(result)
+        results.append(result)
+
+    if args.json:
+        with open(args.json, "w") as f:
+            json.dump(results, f, indent=2)
+        print(f"\nwrote {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds a comprehensive benchmarking suite to measure how ONNX simplification affects the fusability of compute-dominant operators (attention, layer normalization, activation functions) in transformer models. The survey quantifies the trade-off between graph simplification and the ability of downstream runtimes (ONNX Runtime, TensorRT) to recognize and fuse patterns back into single kernels.

## Key Changes

- **`bench/refusion_fixtures.py`** (810 lines): Hand-built ONNX graph fixtures representing real exporter topologies:
  - `bert_layer`: Post-LayerNorm BERT encoder with decomposed attention, GELU, and layer normalization
  - `bert_layer_decomposed_ln`: Same with pre-opset-17 decomposed LayerNormalization
  - `llama_layer`: LLaMA-style decoder with RMSNorm, rotary embeddings, and SwiGLU
  - `fused_onnx`: ai.onnx opset 23 standardized fused operators
  - `fused_contrib`: com.microsoft contrib ops (what ORT's optimizer emits)
  - Configurable sizing (presets: tiny, bert-base, bert-large) with runtime configuration

- **`bench/refusion_survey.py`** (570 lines): CPU-side pattern-level analysis:
  - Builds multiple variants of each fixture (raw, simplified, with selective pass skipping)
  - Measures ONNX Runtime's transformer fusion recovery via `onnxruntime.transformers.optimizer`
  - Implements `--bisect` mode to identify which optimizer passes break downstream fusion
  - Reports node counts, fused operator census, numerical correctness, and latency
  - Detects and handles models with missing opset imports (ORT's transformer optimizer issue)

- **`bench/refusion_gpu_bench.py`** (323 lines): GPU-side latency measurement:
  - Times the same variants on NVIDIA CUDA execution provider
  - Measures both fp32 and fp16 performance
  - Reports median/p90 latency and speedup versus baseline
  - Includes TensorRT EP support
  - Validates numerical correctness across variants

- **`bench/refusion_gpu_run.sh`** (65 lines): Automated GPU benchmark harness:
  - Sets up isolated venv with onnxruntime-gpu
  - Builds onnxsim from checkout
  - Runs both CPU and GPU surveys, outputs JSON results

- **`bench/RESULTS_refusion.md`** (290 lines): Detailed findings document:
  - Documents three critical findings about onnxsim's current behavior
  - Finding 1: Default pipeline produces broken models (Reshape with zero dims)
  - Finding 2: Single-node rewrites (`fuse_consecutive_unsqueezes`) cost attention fusion
  - Finding 3: Already-fused operators are preserved through simplification
  - Includes reproducible examples and severity analysis

## Notable Implementation Details

- Fixtures use `onnx.helper` only (no torch/transformers dependency) but emit the exact node topologies real exporters produce, ensuring pattern matchers see realistic graphs
- The survey measures two independent fusion metrics: ORT's Python pattern matchers (`opt_level=0`) and ORT's session-level C++ optimizations (`ORT_ENABLE_ALL`)
- `--bisect` mode uses greedy search to find minimal sets of passes that restore fusion, accounting for gated dependencies (e.g., attention fusion anchors on LayerNormalization)
- GPU benchmarks handle dtype conversion (fp32→fp16) and validate that all variants produce numerically identical results
- The survey detects and works around ORT's transformer optimizer emitting invalid ONNX (missing opset imports for com.microsoft domain)

https://claude.ai/code/session_015xmYJ963hchTEC9KErt6a6