### PR TITLE
Use adaptive parallel downloads in XetBlob instead of manual sharding

### DIFF
--- a/scripts/convertmodel/cdn.mjs
+++ b/scripts/convertmodel/cdn.mjs
@@ -36,7 +36,14 @@ export const ORT_BASE = `https://cdn.jsdelivr.net/npm/onnxruntime-web@${ORT_VERS
 // --- @huggingface/hub ------------------------------------------------------
 // Pinned build for the experimental Xet download path, loaded lazily (only when
 // the Xet toggle is used) via dynamic import.
-export const HF_HUB_VERSION = "2.14.4";
+//
+// >=2.15.0 adds adaptive parallel downloads to XetBlob/downloadFile itself
+// (huggingface/huggingface.js#2350): it fetches multiple xorb entries at once
+// and tunes the connection count from measured throughput, instead of the
+// single serial connection earlier versions were limited to. hf_models.mjs
+// passes `parallelDownloads` through to `downloadFile` rather than working
+// around the old serial-only behavior with manual byte-range sharding.
+export const HF_HUB_VERSION = "2.15.0";
 export const HF_HUB_ESM = `https://esm.sh/@huggingface/hub@${HF_HUB_VERSION}`;
 
 // --- Perfetto UI -----------------------------------------------------------

--- a/scripts/convertmodel/hf_load.mjs
+++ b/scripts/convertmodel/hf_load.mjs
@@ -48,9 +48,9 @@ function isPlainRepo(parsed) {
   return !!(parsed && parsed.repo && !parsed.file && !parsed.url);
 }
 
-// How many parallel byte-range shards to read a Xet download in. XetBlob fetches
-// serially, so >1 shard is what actually parallelizes the transfer. Clamped to a
-// sane range; past ~10 the returns fade and the Hub may throttle.
+// Ceiling on parallel connections XetBlob may open for a Xet download (it tunes
+// the actual count adaptively from measured throughput). Clamped to a sane
+// range; past ~10 the returns fade and the Hub may throttle.
 const XET_CONCURRENCY_MAX = 16;
 function xetConcurrency() {
   const n = parseInt(xetConcurrencyInput && xetConcurrencyInput.value, 10);

--- a/scripts/convertmodel/hf_models.mjs
+++ b/scripts/convertmodel/hf_models.mjs
@@ -304,70 +304,20 @@ async function readBlobWithProgress(blob, onProgress) {
   return bytes;
 }
 
-// Read a Blob in `concurrency` parallel shards, into one preallocated buffer.
-//
-// The in-browser Xet client (@huggingface/hub's XetBlob) fetches a file's
-// reconstruction terms strictly serially, so a single read never uses more than
-// one connection. But `blob.slice(a, b)` re-fetches reconstruction scoped to
-// `bytes=a-(b-1)`, so a sliced blob downloads only its sub-range — reading N
-// non-overlapping, contiguous slices concurrently gives N-way parallelism while
-// reusing all of XetBlob's reconstruction + decompression. Each shard streams
-// its range in order, so writing at a running offset from the shard's start
-// reassembles the file with no ordering logic; shards write disjoint regions of
-// `out`. Blocks straddling a shard boundary may be fetched by both neighbors —
-// a little redundant transfer, deduplicated by the chunk cache when keys line up.
-// Exported for unit testing (browser-only in practice).
-export async function readBlobSharded(blob, concurrency, onProgress = () => {}) {
-  const total = blob.size || 0;
-  const out = new Uint8Array(total);
-  const shardCount = Math.min(concurrency, total);
-  const step = Math.ceil(total / shardCount);
-  const loadedPerShard = [];
-  const report = () => {
-    let loaded = 0;
-    for (const n of loadedPerShard) loaded += n;
-    onProgress({ loaded, total });
-  };
-  const tasks = [];
-  for (let start = 0; start < total; start += step) {
-    const end = Math.min(start + step, total);
-    const idx = loadedPerShard.length;
-    loadedPerShard.push(0);
-    tasks.push(
-      (async () => {
-        const part = blob.slice(start, end);
-        if (typeof part.stream !== "function") {
-          const buf = new Uint8Array(await part.arrayBuffer());
-          out.set(buf, start);
-          loadedPerShard[idx] = buf.length;
-          report();
-          return;
-        }
-        const reader = part.stream().getReader();
-        let offset = start;
-        for (;;) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          out.set(value, offset);
-          offset += value.length;
-          loadedPerShard[idx] = offset - start;
-          report();
-        }
-      })(),
-    );
-  }
-  await Promise.all(tasks);
-  return out;
-}
-
 // EXPERIMENTAL: download a model over the Hugging Face Xet protocol via
 // @huggingface/hub's downloadFile, which reconstructs the file from
 // content-addressed blocks. Pass `fetchImpl` (e.g. the caching fetch from
-// xet_cache.mjs) to persist those blocks across loads. `concurrency` > 1 reads
-// the reconstructed file in that many parallel byte-range shards (see
-// readBlobSharded) to work around XetBlob's serial fetching. Only Hub repos are
+// xet_cache.mjs) to persist those blocks across loads. Only Hub repos are
 // supported (not arbitrary URLs). Returns { bytes, name, repo }; the caller is
 // expected to fall back to fetchModelBytes() on any failure (CORS, unsupported).
+//
+// `concurrency` sets the ceiling on parallel connections XetBlob may open
+// while reconstructing the file. >=2.15.0 of @huggingface/hub does this
+// adaptively itself (huggingface/huggingface.js#2350) -- it fetches several
+// xorb entries at once and tunes the connection count from measured
+// throughput -- so this just forwards the ceiling as `parallelDownloads`
+// rather than working around a serial-only XetBlob by re-slicing the blob
+// into byte-range shards ourselves.
 export async function fetchModelBytesXet(
   ref,
   { onLog = () => {}, onProgress = () => {}, fetchImpl, concurrency = 1 } = {},
@@ -383,25 +333,25 @@ export async function fetchModelBytesXet(
     file = await findOnnxFile(parsed.repo, onLog);
   }
 
-  onLog(`downloading ${file} from ${parsed.repo} via Xet…`);
+  const shards = Math.max(1, Math.floor(concurrency) || 1);
+  const parallelDownloads = shards > 1 ? { maxConcurrency: shards } : false;
+  onLog(
+    shards > 1
+      ? `downloading ${file} from ${parsed.repo} via Xet (up to ${shards} parallel connections)…`
+      : `downloading ${file} from ${parsed.repo} via Xet…`,
+  );
   const { downloadFile } = await import(/* @vite-ignore */ HF_HUB_ESM);
   const blob = await downloadFile({
     repo: parsed.repo,
     path: file,
     revision,
     fetch: fetchImpl,
+    parallelDownloads,
   });
   if (!blob) throw new Error(`file not found: ${parsed.repo}/${file}`);
 
   const name = file.split("/").pop();
-  // Shard only when it can help: more than one shard requested, a known size to
-  // split on, and a sliceable blob. Otherwise fall back to a single stream.
-  const shards = Math.max(1, Math.floor(concurrency) || 1);
-  const canShard = shards > 1 && blob.size > 0 && typeof blob.slice === "function";
-  if (canShard) onLog(`reading via Xet in ${Math.min(shards, blob.size)} parallel shards…`);
-  const bytes = canShard
-    ? await readBlobSharded(blob, shards, onProgress)
-    : await readBlobWithProgress(blob, onProgress);
+  const bytes = await readBlobWithProgress(blob, onProgress);
   onLog(`downloaded ${name} (${bytes.length.toLocaleString()} bytes via Xet)`);
   return { bytes, name, repo: parsed.repo };
 }

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -145,10 +145,10 @@ agraph (float[N] X) =&gt; (float[N] Y) {
                     Use <a href="https://huggingface.co/docs/xet/en/index" target="_blank" rel="noopener">Xet</a>
                     protocol (default; falls back to a direct download)
                 </label>
-                <label for="hf-xet-concurrency" style="margin-left: 0.6em;">parallel shards</label>
+                <label for="hf-xet-concurrency" style="margin-left: 0.6em;">max connections</label>
                 <input type="number" id="hf-xet-concurrency" value="8" min="1" max="16" step="1"
                        style="width: 3.5em;"
-                       title="How many parallel byte-range shards to read a Xet download in. XetBlob fetches serially, so this is what parallelizes the transfer; ~10 or fewer is usually best.">
+                       title="Ceiling on parallel connections for a Xet download. XetBlob tunes the actual count adaptively from measured throughput, up to this limit; ~10 or fewer is usually best.">
                 <button id="hf-clear-cache" type="button">clear chunk cache</button>
                 <span id="hf-cache-size" class="note" style="margin-left: 0.4em;"></span>
                 <div class="note" style="margin-top: 0.2em;">
@@ -160,11 +160,12 @@ agraph (float[N] X) =&gt; (float[N] Y) {
                     <br>
                     The in-browser Xet client
                     (<a href="https://github.com/huggingface/huggingface.js/blob/main/packages/hub/src/utils/XetBlob.ts" target="_blank" rel="noopener"><code>XetBlob</code></a>)
-                    fetches a file <i>serially</i>, so <b>parallel shards</b> reads
-                    it in that many concurrent byte-range slices to saturate your
-                    link — this is what makes Xet fast enough to be the default
-                    (~10 or fewer is usually best; <code>1</code> disables
-                    sharding). Xet also gives chunk dedup / cache reuse across
+                    fetches multiple content-addressed blocks at once and adapts
+                    the connection count to measured throughput, up to
+                    <b>max connections</b>, to saturate your link — this is what
+                    makes Xet fast enough to be the default (~10 or fewer is
+                    usually best; <code>1</code> forces a single serial
+                    connection). Xet also gives chunk dedup / cache reuse across
                     repeated or overlapping loads.
                 </div>
             </div>

--- a/scripts/convertmodel/test/hf_models.test.mjs
+++ b/scripts/convertmodel/test/hf_models.test.mjs
@@ -12,7 +12,6 @@ import {
   fetchModelBytes,
   probeModelSize,
   listOnnxFiles,
-  readBlobSharded,
   humanBytes,
 } from "../hf_models.mjs";
 
@@ -340,59 +339,6 @@ await acheck("probeModelSize surfaces a repo with no .onnx", async () => {
       await assert.rejects(probeModelSize("empty"), /no \.onnx file found/);
     },
   );
-});
-
-// A minimal Blob-like whose slice(a,b) streams that sub-range in small chunks,
-// mirroring how XetBlob.slice() yields only its byte range.
-function fakeBlob(bytes, chunk = 3) {
-  const make = (buf) => ({
-    size: buf.length,
-    stream() {
-      let i = 0;
-      return {
-        getReader: () => ({
-          read: async () => {
-            if (i >= buf.length) return { done: true, value: undefined };
-            const value = buf.slice(i, i + chunk);
-            i += value.length;
-            return { done: false, value };
-          },
-        }),
-      };
-    },
-  });
-  return {
-    size: bytes.length,
-    slice: (start, end) => make(bytes.slice(start, end)),
-  };
-}
-
-await acheck("readBlobSharded reassembles shards in order", async () => {
-  const data = new Uint8Array(20);
-  for (let i = 0; i < data.length; i++) data[i] = i;
-  for (const k of [1, 3, 4, 7, 100]) {
-    const progress = [];
-    const out = await readBlobSharded(fakeBlob(data), k, (p) => progress.push(p));
-    assert.equal(out.length, data.length);
-    assert.deepEqual(Array.from(out), Array.from(data), `k=${k}`);
-    // Progress ends at the full size, never exceeding it.
-    const last = progress[progress.length - 1];
-    assert.deepEqual(last, { loaded: data.length, total: data.length }, `k=${k} progress`);
-    assert.ok(progress.every((p) => p.loaded <= p.total));
-  }
-});
-
-await acheck("readBlobSharded falls back to arrayBuffer without a stream", async () => {
-  const data = new Uint8Array([5, 6, 7, 8, 9]);
-  const blob = {
-    size: data.length,
-    slice: (start, end) => ({
-      size: end - start,
-      arrayBuffer: async () => data.slice(start, end).buffer,
-    }),
-  };
-  const out = await readBlobSharded(blob, 2);
-  assert.deepEqual(Array.from(out), Array.from(data));
 });
 
 console.log(`\n${passed} checks passed`);


### PR DESCRIPTION
## Summary

Upgrade @huggingface/hub to v2.15.0 and refactor the Xet download path to leverage its new adaptive parallel download support, removing the manual byte-range sharding workaround that was previously needed.

## Changes

- **Removed `readBlobSharded()` function** and its unit tests: This function manually split downloads into parallel byte-range shards to work around XetBlob's serial-only fetching in earlier versions. With v2.15.0's adaptive parallel downloads, this workaround is no longer needed.

- **Simplified `fetchModelBytesXet()`**: Now passes `parallelDownloads` (with `maxConcurrency`) directly to `downloadFile()` instead of manually sharding the blob. The library now handles connection pooling and throughput-based tuning internally.

- **Updated @huggingface/hub version**: Bumped from 2.14.4 to 2.15.0 in `cdn.mjs` to access the new adaptive parallel download feature.

- **Updated UI and documentation**: 
  - Changed label from "parallel shards" to "max connections" to reflect the new semantics
  - Updated tooltips and help text to explain that XetBlob now adaptively tunes connection count based on measured throughput, rather than requiring manual byte-range slicing
  - Updated comments in `hf_load.mjs` to clarify the new behavior

## Implementation Details

The v2.15.0 release of @huggingface/hub adds adaptive parallel downloads to XetBlob/downloadFile itself (huggingface/huggingface.js#2350). Instead of fetching a single xorb entry serially, it now fetches multiple entries concurrently and tunes the connection count from measured throughput. This eliminates the need for the client-side workaround of re-slicing the blob into byte-range shards.

The `concurrency` parameter is now passed through as `maxConcurrency` in the `parallelDownloads` option, setting a ceiling on connections rather than dictating the exact number of shards to create.

https://claude.ai/code/session_01GgybPzcixpSW52TNoeB9zS