### PR TITLE
rust.yml: bump binding versions to the release tag too

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,8 @@ on:
       - main
       - master
   pull_request:
+  release:
+    types: [published]
   workflow_dispatch:
 
 defaults:
@@ -23,6 +25,21 @@ jobs:
       ONNXSIM_NO_BUILD: "1"
     steps:
       - uses: actions/checkout@v7
+      # No crates.io publish exists yet for this crate, but a release build
+      # should still validate against the tagged version: bump every binding
+      # manifest to the release tag (scripts/bump_binding_versions.sh -- the
+      # same script version-sync.yml's bump job and static.yml's npm build
+      # already run) before clippy resolves the workspace, so this actually
+      # exercises the tagged version's onnxsim-sys constraint instead of
+      # whatever happened to be committed (this is exactly what broke #606:
+      # the workspace version moved but rust/onnxsim/Cargo.toml's pinned
+      # onnxsim-sys dependency didn't, and cargo failed to resolve). Once
+      # crates.io publishing is added here, this is also where the version
+      # would need to be set before `cargo publish`.
+      - name: Bump binding versions to the release tag
+        if: ${{ github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v') }}
+        working-directory: ${{ github.workspace }}
+        run: ./scripts/bump_binding_versions.sh "${GITHUB_REF#refs/tags/}"
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
@@ -48,6 +65,12 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+      # See the matching step in the lint job above for why this runs even
+      # though nothing publishes the crate yet.
+      - name: Bump binding versions to the release tag
+        if: ${{ github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v') }}
+        working-directory: ${{ github.workspace }}
+        run: ./scripts/bump_binding_versions.sh "${GITHUB_REF#refs/tags/}"
       - uses: mozilla-actions/sccache-action@v0.0.11
       - uses: dtolnay/rust-toolchain@stable
       - name: Install build tools


### PR DESCRIPTION
Follow-up to #607, which fixed the npm/WASM side of this (a release build could read a stale committed version instead of the release tag). There's no crates.io publish step for the Rust crate yet, so there's no place where a stale version would leak into a *published* artifact the way it did for npm. But both `rust.yml` jobs still resolve the Cargo workspace (`clippy` in `lint`, `cargo build`/`cargo test` in `build`), so a release build is still a useful early check that the tagged version's manifests actually `cargo`-resolve — which is exactly the class of bug that broke #606: the workspace version moved to 0.7.2 but `rust/onnxsim/Cargo.toml`'s pinned `onnxsim-sys` dependency constraint didn't, and `cargo` failed to resolve.

Adds a `release: types: [published]` trigger and, in both jobs, a step that runs `scripts/bump_binding_versions.sh` on the release tag before the workspace gets resolved — the same script `version-sync.yml`'s bump job and `static.yml`'s npm build already use. Both steps are gated to `github.event_name == 'release'`, so push/pull_request/workflow_dispatch runs are unaffected. Also leaves a note for wherever a future `cargo publish` step gets added, since that's where the version would actually need to be set before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HnpyTx9jqmqxiQ81iAmgWG)_