### PR TITLE
rust: fix and automate crates.io publishing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -97,6 +97,7 @@ jobs:
     needs: [lint, build]
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    environment: cargo
     steps:
       - uses: actions/checkout@v7
       - name: Bump binding versions to the release tag

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -90,7 +90,11 @@ jobs:
   # published, gated on lint and build passing first. See "Publishing" in
   # rust/README.md for why --no-verify is required and why onnxsim-sys has to
   # land on the index before onnxsim (which depends on it by version) can
-  # publish.
+  # publish. Authenticates via crates.io Trusted Publishing (OIDC) instead of
+  # a long-lived CARGO_REGISTRY_TOKEN secret -- id-token: write lets
+  # crates-io-auth-action exchange this job's OIDC identity (repo + workflow +
+  # the `cargo` environment below, matching the trusted-publishing config on
+  # crates.io) for a short-lived token that's revoked when the job ends.
   publish:
     name: publish to crates.io
     if: ${{ github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v') }}
@@ -98,15 +102,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: cargo
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v7
       - name: Bump binding versions to the release tag
         working-directory: ${{ github.workspace }}
         run: ./scripts/bump_binding_versions.sh "${GITHUB_REF#refs/tags/}"
       - uses: dtolnay/rust-toolchain@stable
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
       - name: Publish onnxsim-sys
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: cargo publish -p onnxsim-sys --no-verify
       - name: Wait for onnxsim-sys to land on the crates.io index
         run: |
@@ -123,5 +133,5 @@ jobs:
           exit 1
       - name: Publish onnxsim
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: cargo publish -p onnxsim --no-verify

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,17 +25,15 @@ jobs:
       ONNXSIM_NO_BUILD: "1"
     steps:
       - uses: actions/checkout@v7
-      # No crates.io publish exists yet for this crate, but a release build
-      # should still validate against the tagged version: bump every binding
-      # manifest to the release tag (scripts/bump_binding_versions.sh -- the
-      # same script version-sync.yml's bump job and static.yml's npm build
+      # A release build should validate against the tagged version: bump every
+      # binding manifest to the release tag (scripts/bump_binding_versions.sh --
+      # the same script version-sync.yml's bump job and static.yml's npm build
       # already run) before clippy resolves the workspace, so this actually
       # exercises the tagged version's onnxsim-sys constraint instead of
       # whatever happened to be committed (this is exactly what broke #606:
       # the workspace version moved but rust/onnxsim/Cargo.toml's pinned
-      # onnxsim-sys dependency didn't, and cargo failed to resolve). Once
-      # crates.io publishing is added here, this is also where the version
-      # would need to be set before `cargo publish`.
+      # onnxsim-sys dependency didn't, and cargo failed to resolve). The publish
+      # job below does the same bump before `cargo publish`.
       - name: Bump binding versions to the release tag
         if: ${{ github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v') }}
         working-directory: ${{ github.workspace }}
@@ -65,8 +63,7 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
-      # See the matching step in the lint job above for why this runs even
-      # though nothing publishes the crate yet.
+      # See the matching step in the lint job above for why this runs.
       - name: Bump binding versions to the release tag
         if: ${{ github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v') }}
         working-directory: ${{ github.workspace }}
@@ -88,3 +85,42 @@ jobs:
         run: |
           cargo test --release --workspace
           cargo test --release -- --ignored list_optimizers_is_non_empty
+
+  # Publish onnxsim-sys and onnxsim to crates.io once a GitHub release is
+  # published, gated on lint and build passing first. See "Publishing" in
+  # rust/README.md for why --no-verify is required and why onnxsim-sys has to
+  # land on the index before onnxsim (which depends on it by version) can
+  # publish.
+  publish:
+    name: publish to crates.io
+    if: ${{ github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v') }}
+    needs: [lint, build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - name: Bump binding versions to the release tag
+        working-directory: ${{ github.workspace }}
+        run: ./scripts/bump_binding_versions.sh "${GITHUB_REF#refs/tags/}"
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Publish onnxsim-sys
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p onnxsim-sys --no-verify
+      - name: Wait for onnxsim-sys to land on the crates.io index
+        run: |
+          version="${GITHUB_REF#refs/tags/v}"
+          for i in $(seq 1 30); do
+            if curl -sf "https://crates.io/api/v1/crates/onnxsim-sys/${version}" > /dev/null; then
+              echo "onnxsim-sys ${version} is live"
+              exit 0
+            fi
+            echo "waiting for onnxsim-sys ${version} to appear on crates.io ($i/30)..."
+            sleep 10
+          done
+          echo "::error::onnxsim-sys ${version} did not appear on crates.io in time"
+          exit 1
+      - name: Publish onnxsim
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p onnxsim --no-verify

--- a/rust/README.md
+++ b/rust/README.md
@@ -275,10 +275,9 @@ run to validate against), then publishes `onnxsim-sys`, polls
 `https://crates.io/api/v1/crates/onnxsim-sys/<version>` until it lands on the
 index, and publishes `onnxsim`.
 
-It needs a `CARGO_REGISTRY_TOKEN` repository secret — a crates.io API token
-(Account Settings → API Tokens, scoped to `publish-new`/`publish-update` for
-both crates) — which isn't set by this change and must be added by a
-maintainer with crates.io publish rights before the job can run.
+It runs under the `cargo` GitHub Environment and needs a `CARGO_REGISTRY_TOKEN`
+secret there — a crates.io API token (Account Settings → API Tokens, scoped to
+`publish-new`/`publish-update` for both crates).
 
 ### Manual
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -275,9 +275,14 @@ run to validate against), then publishes `onnxsim-sys`, polls
 `https://crates.io/api/v1/crates/onnxsim-sys/<version>` until it lands on the
 index, and publishes `onnxsim`.
 
-It runs under the `cargo` GitHub Environment and needs a `CARGO_REGISTRY_TOKEN`
-secret there — a crates.io API token (Account Settings → API Tokens, scoped to
-`publish-new`/`publish-update` for both crates).
+It authenticates via crates.io [Trusted Publishing](https://crates.io/docs/trusted-publishing)
+(OIDC) rather than a long-lived API token: the job requests an `id-token`,
+[`rust-lang/crates-io-auth-action`](https://github.com/rust-lang/crates-io-auth-action)
+exchanges it for a short-lived (30-minute) crates.io token that's revoked when
+the job ends. This requires a trusted-publishing config on crates.io for both
+`onnxsim-sys` and `onnxsim` naming this repository, the `rust.yml` workflow,
+and the `cargo` environment (which the job runs under, matching that config)
+— no repository secret needed.
 
 ### Manual
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -251,6 +251,29 @@ summary and pull-request comment.
 The integration test in `onnxsim/tests/` is ignored by default because it needs
 the linked native library and an ONNX model; see the file header to enable it.
 
+## Publishing
+
+`onnxsim-sys` builds by shelling out to CMake against the onnxsim C++ source
+tree that lives outside the crate directory (`../..` from
+`rust/onnxsim-sys`), compiling ONNX Runtime, onnx, onnx-optimizer and
+protobuf from source. `cargo publish`'s default verification step packages
+the crate into an isolated directory with no monorepo around it, so that
+build can't succeed there — pass `--no-verify` to skip it:
+
+```sh
+cd rust
+cargo publish -p onnxsim-sys --no-verify
+# wait for crates.io's index to pick up onnxsim-sys, then:
+cargo publish -p onnxsim --no-verify
+```
+
+`onnxsim-sys` must publish first and be visible on the index before
+`onnxsim` (which depends on it by version) can publish. This does mean the
+crate isn't buildable from crates.io metadata alone: consumers need
+`ONNXSIM_SOURCE_DIR` pointed at a checkout of this monorepo (with
+submodules), or a pre-built library via `ONNXSIM_LIB_DIR` — see "Building the
+native library" above.
+
 ## License
 
 Apache-2.0, matching the parent project.

--- a/rust/README.md
+++ b/rust/README.md
@@ -258,7 +258,29 @@ tree that lives outside the crate directory (`../..` from
 `rust/onnxsim-sys`), compiling ONNX Runtime, onnx, onnx-optimizer and
 protobuf from source. `cargo publish`'s default verification step packages
 the crate into an isolated directory with no monorepo around it, so that
-build can't succeed there — pass `--no-verify` to skip it:
+build can't succeed there — every publish (automated or manual) has to pass
+`--no-verify` to skip it. This does mean the crate isn't buildable from
+crates.io metadata alone: consumers need `ONNXSIM_SOURCE_DIR` pointed at a
+checkout of this monorepo (with submodules), or a pre-built library via
+`ONNXSIM_LIB_DIR` — see "Building the native library" above.
+
+### Automated (GitHub Actions)
+
+The `publish` job in
+[`.github/workflows/rust.yml`](../.github/workflows/rust.yml) runs whenever a
+GitHub release is published (tag `vX.Y.Z`), after the `lint` and `build` jobs
+pass. It bumps every binding manifest to the release tag
+(`scripts/bump_binding_versions.sh`, the same script the `lint`/`build` jobs
+run to validate against), then publishes `onnxsim-sys`, polls
+`https://crates.io/api/v1/crates/onnxsim-sys/<version>` until it lands on the
+index, and publishes `onnxsim`.
+
+It needs a `CARGO_REGISTRY_TOKEN` repository secret — a crates.io API token
+(Account Settings → API Tokens, scoped to `publish-new`/`publish-update` for
+both crates) — which isn't set by this change and must be added by a
+maintainer with crates.io publish rights before the job can run.
+
+### Manual
 
 ```sh
 cd rust
@@ -268,11 +290,7 @@ cargo publish -p onnxsim --no-verify
 ```
 
 `onnxsim-sys` must publish first and be visible on the index before
-`onnxsim` (which depends on it by version) can publish. This does mean the
-crate isn't buildable from crates.io metadata alone: consumers need
-`ONNXSIM_SOURCE_DIR` pointed at a checkout of this monorepo (with
-submodules), or a pre-built library via `ONNXSIM_LIB_DIR` — see "Building the
-native library" above.
+`onnxsim` (which depends on it by version) can publish.
 
 ## License
 

--- a/rust/onnxsim/Cargo.toml
+++ b/rust/onnxsim/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 homepage.workspace = true
 authors.workspace = true
 rust-version.workspace = true
-readme = "README.md"
+readme = "../README.md"
 categories = ["api-bindings", "science"]
 keywords = ["onnx", "onnxsim", "simplifier", "machine-learning", "inference"]
 


### PR DESCRIPTION
## Summary
- Fix `rust/onnxsim/Cargo.toml`'s `readme` path — it pointed at `README.md`, which doesn't exist in `rust/onnxsim/` (the real Rust-binding readme lives one level up at `rust/README.md`). This broke `cargo package`/`cargo publish` outright.
- Document why `onnxsim-sys`'s CMake-based native build can't run inside `cargo publish`'s isolated verification sandbox, and that publishing (automated or manual) needs `--no-verify`.
- Add a `publish` job to `.github/workflows/rust.yml` that runs on GitHub release (`vX.Y.Z` tag), gated on `lint`/`build` passing: bumps binding versions to the release tag, publishes `onnxsim-sys`, polls the crates.io index until it lands, then publishes `onnxsim` (which depends on it by version).
- Authenticate via crates.io [Trusted Publishing](https://crates.io/docs/trusted-publishing) (OIDC) through `rust-lang/crates-io-auth-action`, so no long-lived `CARGO_REGISTRY_TOKEN` secret is needed — just `id-token: write` and the `cargo` GitHub Environment matching the trusted-publishing config on crates.io for both crates.

## Test plan
- [x] `cargo publish --dry-run --no-verify -p onnxsim-sys` and `-p onnxsim` package cleanly locally (confirms the readme fix)
- [x] `.github/workflows/rust.yml` YAML validated
- [ ] First real release (`vX.Y.Z` tag) exercises the `publish` job end-to-end against crates.io Trusted Publishing

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01CdJ1RknDVsVESyt87pJSHs