### PR TITLE
Fix crates.io API requests in release workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -105,6 +105,11 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    env:
+      # crates.io's API rejects requests with no descriptive User-Agent
+      # (https://crates.io/data-access), which used to make every curl check
+      # below fail regardless of whether the crate was actually published.
+      CRATES_IO_USER_AGENT: "onnxsim-release-workflow (https://github.com/onnxsim/onnxsim)"
     steps:
       - uses: actions/checkout@v7
       - name: Bump binding versions to the release tag
@@ -117,12 +122,18 @@ jobs:
       - name: Publish onnxsim-sys
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-        run: cargo publish -p onnxsim-sys --no-verify
+        run: |
+          version="${GITHUB_REF#refs/tags/v}"
+          if curl -sf -H "User-Agent: ${CRATES_IO_USER_AGENT}" "https://crates.io/api/v1/crates/onnxsim-sys/${version}" > /dev/null; then
+            echo "onnxsim-sys ${version} is already published, skipping"
+          else
+            cargo publish -p onnxsim-sys --no-verify
+          fi
       - name: Wait for onnxsim-sys to land on the crates.io index
         run: |
           version="${GITHUB_REF#refs/tags/v}"
           for i in $(seq 1 30); do
-            if curl -sf -H "User-Agent: onnxsim-release-workflow (https://github.com/onnxsim/onnxsim)" "https://crates.io/api/v1/crates/onnxsim-sys/${version}" > /dev/null; then
+            if curl -sf -H "User-Agent: ${CRATES_IO_USER_AGENT}" "https://crates.io/api/v1/crates/onnxsim-sys/${version}" > /dev/null; then
               echo "onnxsim-sys ${version} is live"
               exit 0
             fi
@@ -134,4 +145,10 @@ jobs:
       - name: Publish onnxsim
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-        run: cargo publish -p onnxsim --no-verify
+        run: |
+          version="${GITHUB_REF#refs/tags/v}"
+          if curl -sf -H "User-Agent: ${CRATES_IO_USER_AGENT}" "https://crates.io/api/v1/crates/onnxsim/${version}" > /dev/null; then
+            echo "onnxsim ${version} is already published, skipping"
+          else
+            cargo publish -p onnxsim --no-verify
+          fi

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -122,7 +122,7 @@ jobs:
         run: |
           version="${GITHUB_REF#refs/tags/v}"
           for i in $(seq 1 30); do
-            if curl -sf "https://crates.io/api/v1/crates/onnxsim-sys/${version}" > /dev/null; then
+            if curl -sf -H "User-Agent: onnxsim-release-workflow (https://github.com/onnxsim/onnxsim)" "https://crates.io/api/v1/crates/onnxsim-sys/${version}" > /dev/null; then
               echo "onnxsim-sys ${version} is live"
               exit 0
             fi


### PR DESCRIPTION
## Summary
Fixes the release workflow to properly handle crates.io API requests by adding a required User-Agent header and implementing idempotent publish steps that skip already-published crates.

## Key Changes
- Added `CRATES_IO_USER_AGENT` environment variable to the publish job, as crates.io's API rejects requests without a descriptive User-Agent header
- Updated the "Publish onnxsim-sys" step to check if the version is already published before attempting to publish, preventing failures on re-runs
- Updated the "Wait for onnxsim-sys to land on the crates.io index" step to include the User-Agent header in curl requests
- Updated the "Publish onnxsim" step to check if the version is already published before attempting to publish, matching the pattern used for onnxsim-sys

## Implementation Details
- The User-Agent header follows the format: `"onnxsim-release-workflow (https://github.com/onnxsim/onnxsim)"`
- Publish steps now query the crates.io API before publishing to determine if a version already exists
- If a version is already published, the step logs a message and skips the cargo publish command
- This makes the workflow idempotent and prevents failures when the workflow is re-run after a partial success

https://claude.ai/code/session_019bxFFfpYhNdBT2hmiuDNGJ