### PR TITLE
Skip RSS profiling on Emscripten/WASM targets

### DIFF
--- a/onnxsim/profiler.cpp
+++ b/onnxsim/profiler.cpp
@@ -22,7 +22,11 @@
 // Platform-specific resident-set-size readers. Everything degrades to 0 (peak
 // memory simply unreported) on platforms none of these branches cover, so the
 // timing side of the profiler keeps working regardless.
-#if defined(__linux__)
+#if defined(__EMSCRIPTEN__)
+// No branch needed: wasm has no RSS API, and calling getrusage() (the
+// fallback below) hits Emscripten's unimplemented __syscall_getrusage, which
+// logs "unsupported syscall" to the console on every profiler span.
+#elif defined(__linux__)
 #include <unistd.h>
 #elif defined(__APPLE__)
 #include <mach/mach.h>
@@ -42,7 +46,9 @@ namespace {
 // Current resident set size of this process, in bytes. Returns 0 when it cannot
 // be determined.
 size_t ReadCurrentRssBytes() {
-#if defined(__linux__)
+#if defined(__EMSCRIPTEN__)
+  return 0;
+#elif defined(__linux__)
   // /proc/self/statm reports memory in pages: "size resident shared ...".
   std::FILE* f = std::fopen("/proc/self/statm", "r");
   if (f == nullptr) {


### PR DESCRIPTION
## Summary
Add platform-specific handling to skip resident set size (RSS) memory profiling on Emscripten/WASM targets, where the RSS API is unavailable and calling the fallback `getrusage()` syscall logs spurious "unsupported syscall" warnings to the console.

## Changes
- Add `#if defined(__EMSCRIPTEN__)` branch before the existing `#if defined(__linux__)` check in the platform-specific includes section
- Add corresponding `#if defined(__EMSCRIPTEN__)` branch in `ReadCurrentRssBytes()` that returns 0, preventing any RSS measurement attempts on WASM
- Include explanatory comments noting that Emscripten has no RSS API and that the fallback syscall produces console warnings

## Details
The profiler's timing functionality remains fully operational on WASM targets; only the memory profiling component is disabled. This prevents console spam from unimplemented syscall warnings while maintaining graceful degradation on unsupported platforms.

https://claude.ai/code/session_01WuWyt8bqr824PnqnCLxMMM