### PR TITLE
Add TVM integration tests and CI workflow

### DIFF
--- a/.github/workflows/tvm-integration.yml
+++ b/.github/workflows/tvm-integration.yml
@@ -1,0 +1,93 @@
+name: TVM Integration
+
+# End-to-end regression test that feeds onnxsim's simplified output into Apache
+# TVM's Relax ONNX importer + compiler (tests/test_tvm_integration.py).
+# docs/dlpack-executor.md names TVM explicitly as one of the "embeddability"
+# targets the DLPack executor boundary was designed for; this workflow is the
+# regression test for that claim on the Python side.
+#
+# apache-tvm is a ~100MB wheel and not part of onnxsim's test requirements, so
+# this runs in its own workflow instead of the build-and-test matrix. Runs on
+# PRs that touch the harness or the simplifier, on a daily schedule to catch
+# new TVM releases, and on demand.
+
+on:
+  schedule:
+    - cron: "0 7 * * *" # Daily 07:00 UTC
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "tests/test_tvm_integration.py"
+      - ".github/workflows/tvm-integration.yml"
+      - "onnxsim/onnx_simplifier.py"
+      - "onnxsim/onnxsim.cpp"
+      - "docs/dlpack-executor.md"
+
+concurrency:
+  group: tvm-integration-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Build onnxsim once from the current tree, exactly like the model-regression
+  # workflow, and hand the wheel to the test job so it exercises this branch's
+  # code rather than a PyPI release.
+  build:
+    name: Build onnxsim wheel
+    runs-on: ubuntu-24.04
+    env:
+      SCCACHE_GHA_ENABLED: "on"
+      ACTIONS_CACHE_SERVICE_V2: "on"
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - uses: mozilla-actions/sccache-action@v0.0.11
+      - name: Build cp312 wheel
+        uses: pypa/cibuildwheel@v4.2.0
+        env:
+          CIBW_BUILD: "cp312-manylinux_x86_64"
+          CIBW_ARCHS: native
+          CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_ENVIRONMENT_PASS_LINUX: CI SCCACHE_GHA_ENABLED ACTIONS_RESULTS_URL ACTIONS_RUNTIME_TOKEN ACTIONS_CACHE_SERVICE_V2
+          CIBW_BEFORE_BUILD: "python3 -m pip install --break-system-packages cmake ninja setuptools sccache"
+          CIBW_ENVIRONMENT: CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=OFF" CMAKE_GENERATOR=Ninja CMAKE_CXX_COMPILER_LAUNCHER=sccache CMAKE_LINKER_TYPE=LLD
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel} --strip"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: onnxsim-wheel-tvm
+          path: ./wheelhouse/*.whl
+
+  test:
+    name: Simplify and run on TVM
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - uses: actions/download-artifact@v8
+        with:
+          name: onnxsim-wheel-tvm
+          path: wheelhouse
+      - name: Install onnxsim wheel + apache-tvm
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest apache-tvm
+          python -m pip install wheelhouse/*.whl
+      - name: Verify the installed wheel is used (not the source tree)
+        working-directory: ${{ runner.temp }}
+        run: |
+          python -c "import onnxsim, onnxsim.onnxsim_cpp2py_export as m; print(onnxsim.__version__, m.__file__)"
+          python -c "import tvm; print('tvm', tvm.__version__)"
+      # Run from a neutral directory so the repo root's ./onnxsim source package
+      # (without the compiled extension) does not shadow the installed wheel.
+      - name: Run TVM integration tests
+        working-directory: ${{ runner.temp }}
+        run: pytest -v "$GITHUB_WORKSPACE/tests/test_tvm_integration.py"

--- a/docs/dlpack-executor.md
+++ b/docs/dlpack-executor.md
@@ -190,6 +190,10 @@ Consequences for the design:
 - `onnxsim/cpp2py_export.cc` — `PyModelExecutor` adapts DLPack ↔ bytes.
 - `onnxsim/capi/onnxsim_c_api.{h,cpp}` — `OnnxsimExecuteFn` +
   `onnxsim_simplify_with_executor`.
+- `tests/test_tvm_integration.py` (+ `.github/workflows/tvm-integration.yml`) —
+  regression test for the TVM embeddability claim above: feeds onnxsim's
+  simplified output into Apache TVM's Relax ONNX importer and checks it still
+  compiles and computes the same result.
 
 ## Rust binding
 

--- a/tests/test_tvm_integration.py
+++ b/tests/test_tvm_integration.py
@@ -1,0 +1,229 @@
+"""Apache TVM integration test.
+
+``docs/dlpack-executor.md`` names TVM explicitly as one of the "another
+ONNX-based compiler or runtime stack" targets the DLPack executor boundary was
+designed to make onnxsim embeddable into. This module is the regression test
+for that claim on the *Python* side: it feeds onnxsim's simplified output into
+Apache TVM's Relax ONNX importer + compiler (``tvm.relax.frontend.onnx``,
+TVM's current, non-legacy ONNX ingestion path) and checks two things:
+
+1. Simplification must not make a graph *harder* to compile: whatever TVM
+   accepted before simplification, it must still accept after.
+2. Simplification must not change what TVM computes.
+
+A third, more interesting case is also covered: the classic
+``Shape -> Gather -> Concat -> Reshape`` chain that ships fully-constant
+dimensions is rejected outright by TVM's ONNX frontend (it insists the
+``Reshape`` target be a compile-time ``Shape``, not a runtime tensor), but
+compiles fine once onnxsim constant-folds the chain to a literal shape. So for
+TVM, onnxsim is not just "does no harm" -- it is sometimes the difference
+between a graph TVM can ingest and one it can't.
+
+``apache-tvm`` is heavy (~100MB wheel) and not part of onnxsim's test
+requirements, so the whole module is skipped when it is not installed. The
+dedicated ``tvm-integration`` CI workflow installs it and runs these tests;
+the regular build-and-test matrix skips them.
+"""
+
+import numpy as np
+import onnx
+import pytest
+from onnx import TensorProto, helper, numpy_helper
+
+tvm = pytest.importorskip("tvm", reason="apache-tvm is not installed")
+onnx_frontend = pytest.importorskip(
+    "tvm.relax.frontend.onnx", reason="apache-tvm is not installed"
+)
+from tvm import relax  # noqa: E402  (only valid once the importorskip above passed)
+
+import onnxsim  # noqa: E402  (imported after the tvm availability check)
+
+_OPSET = 17
+_IR_VERSION = 8
+
+
+def _model(nodes, inputs, outputs, initializers, name) -> onnx.ModelProto:
+    graph = helper.make_graph(nodes, name, inputs, outputs, initializers)
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", _OPSET)])
+    model.ir_version = _IR_VERSION
+    onnx.checker.check_model(model)
+    return model
+
+
+def _rand(*shape, seed=0) -> np.ndarray:
+    return np.random.RandomState(seed).randn(*shape).astype(np.float32)
+
+
+def _conv_bn_relu() -> onnx.ModelProto:
+    """Conv -> Mul(scale) -> Add(shift) -> Relu: onnxsim fuses scale/shift into Conv."""
+    w = numpy_helper.from_array(_rand(8, 3, 3, 3, seed=1), "w")
+    scale = numpy_helper.from_array(_rand(1, 8, 1, 1, seed=2), "scale")
+    shift = numpy_helper.from_array(_rand(1, 8, 1, 1, seed=3), "shift")
+    nodes = [
+        helper.make_node("Conv", ["x", "w"], ["c"], pads=[1, 1, 1, 1]),
+        helper.make_node("Mul", ["c", "scale"], ["m"]),
+        helper.make_node("Add", ["m", "shift"], ["a"]),
+        helper.make_node("Relu", ["a"], ["y"]),
+    ]
+    return _model(
+        nodes,
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3, 8, 8])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 8, 8, 8])],
+        [w, scale, shift],
+        "conv_bn_relu",
+    )
+
+
+def _redundant_transpose() -> onnx.ModelProto:
+    """An identity Transpose (perm=[0,1,2,3]) that onnxsim removes outright."""
+    w = numpy_helper.from_array(_rand(8, 3, 3, 3, seed=1), "w")
+    nodes = [
+        helper.make_node("Transpose", ["x"], ["t"], perm=[0, 1, 2, 3]),
+        helper.make_node("Conv", ["t", "w"], ["c"], pads=[1, 1, 1, 1]),
+        helper.make_node("Relu", ["c"], ["y"]),
+    ]
+    return _model(
+        nodes,
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3, 8, 8])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 8, 8, 8])],
+        [w],
+        "redundant_transpose",
+    )
+
+
+def _foldable_shape_reshape() -> onnx.ModelProto:
+    """Shape -> Gather -> Concat -> Reshape, fully determined by constants.
+
+    TVM's Relax ONNX frontend requires a ``Reshape``'s target shape to be a
+    compile-time ``Shape`` value, not a runtime tensor, so it rejects this
+    graph as-is (see module docstring). onnxsim folds the whole chain into a
+    literal target shape, which TVM then imports fine.
+    """
+    w = numpy_helper.from_array(_rand(8, 3, 3, 3, seed=1), "w")
+    idx = numpy_helper.from_array(np.array([0], np.int64), "idx")
+    minus1 = numpy_helper.from_array(np.array([-1], np.int64), "m1")
+    ch = numpy_helper.from_array(np.array([8], np.int64), "ch")
+    nodes = [
+        helper.make_node("Conv", ["x", "w"], ["c"], pads=[1, 1, 1, 1]),
+        helper.make_node("Relu", ["c"], ["r"]),
+        helper.make_node("Shape", ["r"], ["shp"]),
+        helper.make_node("Gather", ["shp", "idx"], ["n"], axis=0),
+        helper.make_node("Concat", ["n", "ch", "m1"], ["newshape"], axis=0),
+        helper.make_node("Reshape", ["r", "newshape"], ["y"]),
+    ]
+    return _model(
+        nodes,
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3, 8, 8])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 8, 64])],
+        [w, idx, minus1, ch],
+        "foldable_shape_reshape",
+    )
+
+
+_MODELS = {
+    "conv_bn_relu": _conv_bn_relu,
+    "redundant_transpose": _redundant_transpose,
+    "foldable_shape_reshape": _foldable_shape_reshape,
+}
+
+
+def _random_feeds(model: onnx.ModelProto, seed: int = 0):
+    """Deterministic random float32 input for every non-initializer graph input."""
+    rng = np.random.RandomState(seed)
+    initializer_names = {init.name for init in model.graph.initializer}
+    feeds = {}
+    for inp in model.graph.input:
+        if inp.name in initializer_names:
+            continue
+        shape = [d.dim_value for d in inp.type.tensor_type.shape.dim]
+        feeds[inp.name] = (rng.rand(*shape).astype(np.float32) - 0.5) * 2.0
+    return feeds
+
+
+def _compile_and_run_with_tvm(model: onnx.ModelProto, feeds):
+    """Import ``model`` with the Relax ONNX frontend, build it, and run it on CPU."""
+    shape_dict = {name: list(arr.shape) for name, arr in feeds.items()}
+    mod = onnx_frontend.from_onnx(model, shape_dict=shape_dict)
+    mod = relax.transform.LegalizeOps()(mod)
+    executable = relax.build(mod, target="llvm")
+    vm = relax.VirtualMachine(executable, tvm.cpu())
+    # Graph inputs are single-input in every model here; feeds preserves the
+    # same graph.input order the frontend used to build the function's params.
+    args = [tvm.runtime.tensor(value) for value in feeds.values()]
+    result = vm["main"](*args)
+    if isinstance(result, tvm.runtime.Tensor):
+        return [result.numpy()]
+    return [r.numpy() for r in result]
+
+
+@pytest.mark.parametrize("name", sorted(_MODELS))
+def test_simplified_model_compiles_and_runs_on_tvm(name):
+    """The simplified graph must always import, compile, and run on TVM."""
+    model = _MODELS[name]()
+    simplified, check_ok = onnxsim.simplify(model)
+    assert check_ok
+
+    feeds = _random_feeds(model, seed=0)
+    simplified_out = _compile_and_run_with_tvm(simplified, feeds)
+
+    # Whatever TVM did with the original graph, it must still accept the
+    # simplified one -- and if it also accepted the original, the two must
+    # agree numerically (simplification must be semantics-preserving on TVM).
+    try:
+        original_out = _compile_and_run_with_tvm(model, feeds)
+    except Exception:
+        return
+    for orig, simp in zip(original_out, simplified_out):
+        np.testing.assert_allclose(orig, simp, rtol=1e-3, atol=1e-4)
+
+
+def test_simplify_is_bit_exact_on_tvm():
+    """Removing a redundant (identity) Transpose must not change the TVM result."""
+    model = _redundant_transpose()
+    simplified, check_ok = onnxsim.simplify(model)
+    assert check_ok
+    assert len(simplified.graph.node) < len(model.graph.node)
+
+    feeds = _random_feeds(model, seed=1)
+    original_out = _compile_and_run_with_tvm(model, feeds)
+    simplified_out = _compile_and_run_with_tvm(simplified, feeds)
+    for orig, simp in zip(original_out, simplified_out):
+        np.testing.assert_allclose(orig, simp, rtol=0, atol=0)
+
+
+def test_tvm_output_matches_onnx_reference():
+    """The TVM result for a simplified model must match onnx's own reference evaluator."""
+    model = _conv_bn_relu()
+    simplified, check_ok = onnxsim.simplify(model)
+    assert check_ok
+
+    feeds = _random_feeds(model, seed=2)
+    tvm_out = _compile_and_run_with_tvm(simplified, feeds)
+
+    from onnx.reference import ReferenceEvaluator
+
+    evaluator = ReferenceEvaluator(simplified)
+    reference_out = evaluator.run(None, feeds)
+    for ref, cand in zip(reference_out, tvm_out):
+        np.testing.assert_allclose(ref, cand, rtol=1e-3, atol=1e-4)
+
+
+def test_simplify_is_required_for_tvm_import():
+    """Regression guard for the constant-fold-enables-import case.
+
+    If a future onnxsim change stops folding this chain, or a future TVM
+    release starts accepting it unfolded, this test's assumptions should be
+    revisited -- it deliberately pins today's behavior on both sides.
+    """
+    model = _foldable_shape_reshape()
+    simplified, check_ok = onnxsim.simplify(model)
+    assert check_ok
+    # The whole Shape/Gather/Concat chain collapses into the Reshape's target.
+    assert len(simplified.graph.node) < len(model.graph.node)
+
+    feeds = _random_feeds(model, seed=3)
+    with pytest.raises(Exception):
+        _compile_and_run_with_tvm(model, feeds)
+
+    # The simplified graph must import and run cleanly.
+    _compile_and_run_with_tvm(simplified, feeds)


### PR DESCRIPTION
## Summary

Add comprehensive regression tests for onnxsim's embeddability into Apache TVM's Relax ONNX importer, along with a dedicated CI workflow to validate the integration.

## Key Changes

- **`tests/test_tvm_integration.py`** — New test module with three test cases:
  - `test_simplified_model_compiles_and_runs_on_tvm()` — Validates that simplified graphs remain compilable by TVM and produce numerically equivalent results
  - `test_simplify_is_bit_exact_on_tvm()` — Ensures removing redundant operations (e.g., identity transposes) doesn't change TVM's output
  - `test_tvm_output_matches_onnx_reference()` — Cross-validates TVM results against ONNX's reference evaluator
  - `test_simplify_is_required_for_tvm_import()` — Regression guard for the key use case: constant-folding a `Shape → Gather → Concat → Reshape` chain that TVM's ONNX frontend would otherwise reject

  The module includes three representative model builders (`_conv_bn_relu`, `_redundant_transpose`, `_foldable_shape_reshape`) and helper functions for deterministic test data generation and TVM compilation/execution.

- **`.github/workflows/tvm-integration.yml`** — New CI workflow that:
  - Builds an onnxsim wheel from the current branch (ensuring tests exercise the PR's code)
  - Installs apache-tvm alongside the wheel
  - Runs the integration tests in isolation from the main test matrix
  - Triggers on PRs touching the test file, simplifier, or DLPack executor documentation; runs daily to catch TVM release incompatibilities; supports manual dispatch

- **`docs/dlpack-executor.md`** — Updated to reference the new test module and workflow as the regression test validating TVM embeddability claims.

## Implementation Details

- Tests are skipped gracefully when apache-tvm is not installed (using `pytest.importorskip`), so they don't block the regular build-and-test matrix
- The workflow builds only a cp312 wheel on manylinux to keep CI time reasonable while still validating the integration
- Test models use opset 17 and IR version 8 for compatibility with current TVM releases
- Numerical assertions use relaxed tolerances (rtol=1e-3, atol=1e-4) for TVM vs. reference comparisons, but strict bit-exact matching (rtol=0, atol=0) for redundant-operation removal to catch unintended side effects

https://claude.ai/code/session_01DTkxGzYjnNiwZuULpY1r4J