### PR TITLE
Add standalone package build test for Rust crates

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -123,14 +123,15 @@ jobs:
             --model scripts/convertmodel/test/model.onnx
 
   # Publish onnxsim-sys and onnxsim to crates.io once a GitHub release is
-  # published, gated on lint and build passing first. See "Publishing" in
-  # rust/README.md for why --no-verify is required and why onnxsim-sys has to
-  # land on the index before onnxsim (which depends on it by version) can
-  # publish. Authenticates via crates.io Trusted Publishing (OIDC) instead of
-  # a long-lived CARGO_REGISTRY_TOKEN secret -- id-token: write lets
-  # crates-io-auth-action exchange this job's OIDC identity (repo + workflow +
-  # the `cargo` environment below, matching the trusted-publishing config on
-  # crates.io) for a short-lived token that's revoked when the job ends.
+  # published, gated on the lint, package and build jobs passing first. See
+  # "Publishing" in rust/README.md for why --no-verify is required and why
+  # onnxsim-sys has to land on the index before onnxsim (which depends on it
+  # by version) can publish. Authenticates via crates.io Trusted Publishing
+  # (OIDC) instead of a long-lived CARGO_REGISTRY_TOKEN secret -- id-token:
+  # write lets crates-io-auth-action exchange this job's OIDC identity (repo +
+  # workflow + the `cargo` environment below, matching the trusted-publishing
+  # config on crates.io) for a short-lived token that's revoked when the job
+  # ends.
   publish:
     name: publish to crates.io
     if: ${{ github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,6 +46,30 @@ jobs:
       - name: clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+  # Builds the crates as a downstream consumer gets them: `cargo package`, then
+  # unpack the archives outside the repository and compile against the unpacked
+  # copies. Because `cargo publish` has to run with --no-verify (see
+  # "Publishing" in rust/README.md), nothing else in CI ever compiles what
+  # actually ships -- a file missing from the package, or a build script that
+  # assumes the onnxsim C++ tree sits two directories up, only breaks there.
+  # No native build, so this stays as quick as the lint job.
+  package:
+    name: standalone package build (no native build)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      # See the matching step in the lint job above for why this runs.
+      - name: Bump binding versions to the release tag
+        if: ${{ github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v') }}
+        working-directory: ${{ github.workspace }}
+        run: ./scripts/bump_binding_versions.sh "${GITHUB_REF#refs/tags/}"
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Package and build the crates outside the source tree
+        working-directory: ${{ github.workspace }}
+        # RUNNER_TEMP is outside the checkout, which is what the test needs.
+        run: ./scripts/test_rust_package_standalone.sh --workdir "${RUNNER_TEMP}/rust-standalone"
+
   # Full build that compiles the C API and links it against onnxsim.
   build:
     name: build + smoke test (native)
@@ -85,6 +109,18 @@ jobs:
         run: |
           cargo test --release --workspace
           cargo test --release -- --ignored list_optimizers_is_non_empty
+      # Same standalone package test as the `package` job, but linking the
+      # native library this job just built (--lib-dir auto finds it under
+      # rust/target), so the packaged crates are linked and executed outside
+      # the source tree rather than only type-checked. Reusing the existing
+      # build tree keeps this to seconds instead of another native build.
+      - name: Standalone package build against the native library
+        working-directory: ${{ github.workspace }}
+        run: |
+          ./scripts/test_rust_package_standalone.sh \
+            --workdir "${RUNNER_TEMP}/rust-standalone-native" \
+            --lib-dir auto \
+            --model scripts/convertmodel/test/model.onnx
 
   # Publish onnxsim-sys and onnxsim to crates.io once a GitHub release is
   # published, gated on lint and build passing first. See "Publishing" in
@@ -98,7 +134,7 @@ jobs:
   publish:
     name: publish to crates.io
     if: ${{ github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v') }}
-    needs: [lint, build]
+    needs: [lint, package, build]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: cargo

--- a/rust/README.md
+++ b/rust/README.md
@@ -179,6 +179,13 @@ three modes:
    (docs.rs sets `DOCS_RS` automatically). The crate type-checks but cannot be
    linked into a runnable binary.
 
+Mode 1 is the default only *inside* this repository, where the C++ sources sit
+two directories above the crate. The published crate ships without them, so a
+build from crates.io stops immediately with a message pointing at the three
+modes rather than attempting a source build that cannot work; pick mode 2 or 3
+there. [The standalone package build test](#standalone-package-build-test)
+covers exactly that situation.
+
 ### Environment variables
 
 | Variable             | Effect                                                        |
@@ -250,6 +257,50 @@ summary and pull-request comment.
 
 The integration test in `onnxsim/tests/` is ignored by default because it needs
 the linked native library and an ONNX model; see the file header to enable it.
+
+## Standalone package build test
+
+`cargo publish --no-verify` (see [Publishing](#publishing)) means the archive
+that actually ships is never compiled by the in-tree build: `cargo build` in
+`rust/` always has the C++ sources, the submodules and the sibling crate next
+to it, and the published crate has none of that. Anything that only breaks
+there — a file missing from the package, a path dependency that stops resolving
+once cargo rewrites it to a registry dependency, a build script that assumes the
+onnxsim source tree is two directories up — would otherwise surface as a broken
+release on crates.io.
+
+[`scripts/test_rust_package_standalone.sh`](../scripts/test_rust_package_standalone.sh)
+closes that gap. It runs `cargo package`, unpacks both `.crate` archives into a
+directory **outside** this repository, patches `onnxsim`'s registry dependency
+on `onnxsim-sys` back to the freshly unpacked sibling, and builds the unpacked
+crates plus a throwaway downstream crate against them:
+
+```sh
+# Check-only (no native build, ~a minute): type-checks the unpacked crates and
+# a consumer of them, and asserts that a build with no mode selected fails fast
+# with an actionable message.
+scripts/test_rust_package_standalone.sh
+
+# Link and run the packaged crates against a native library. `--lib-dir auto`
+# reuses whatever a previous `cargo build` in rust/ already produced; pass an
+# explicit `dir[:dir...]` for a library built elsewhere.
+scripts/test_rust_package_standalone.sh --lib-dir auto --model model.onnx
+
+# Or build the native library from source against a checkout (slow):
+ONNXSIM_PREBUILT_ORT=1 scripts/test_rust_package_standalone.sh --source-dir "$PWD"
+```
+
+Useful options: `--workdir DIR` to unpack somewhere specific (it must be outside
+the repository, or the build script would find the C++ sources after all),
+`--keep` to leave the unpacked tree and the generated consumer crate around for
+inspection, and `--model PATH` to have the consumer actually simplify a model
+once the native library is linked.
+
+In CI this runs as the `package` job in
+[`.github/workflows/rust.yml`](../.github/workflows/rust.yml) (check-only, on
+every PR) and again at the end of the `build` job with `--lib-dir auto`, which
+links the packaged crates against the native library that job just built and
+runs them.
 
 ## Publishing
 

--- a/rust/onnxsim-sys/build.rs
+++ b/rust/onnxsim-sys/build.rs
@@ -20,6 +20,11 @@ use std::process::Command;
 /// ONNX Runtime version onnxsim builds against; must match `cmake/build_ort.cmake`.
 const ONNXRUNTIME_VERSION: &str = "1.28.0";
 
+/// C API implementation file, relative to the onnxsim source root. Used both as
+/// a rebuild trigger and as the marker that a directory really is an onnxsim
+/// checkout.
+const CAPI_SOURCE: &str = "onnxsim/capi/onnxsim_c_api.cpp";
+
 fn main() {
     println!("cargo:rerun-if-env-changed=ONNXSIM_NO_BUILD");
     println!("cargo:rerun-if-env-changed=ONNXSIM_LIB_DIR");
@@ -46,13 +51,14 @@ fn main() {
 
     // Mode 3: build from source with CMake.
     let source_dir = source_dir();
+    verify_source_dir(&source_dir);
     println!(
         "cargo:rerun-if-changed={}",
         source_dir.join("CMakeLists.txt").display()
     );
     println!(
         "cargo:rerun-if-changed={}",
-        source_dir.join("onnxsim/capi/onnxsim_c_api.cpp").display()
+        source_dir.join(CAPI_SOURCE).display()
     );
 
     // ONNXSIM_PREBUILT_ORT swaps the from-source ONNX Runtime build for an
@@ -103,6 +109,37 @@ fn main() {
     // Expose where the shared libraries live so downstream crates / test
     // harnesses can set LD_LIBRARY_PATH if needed.
     println!("cargo:root={}", build_dir.display());
+}
+
+/// Fail fast, with an actionable message, when the onnxsim C++ sources are not
+/// where the from-source build expects them.
+///
+/// This is what a consumer of the *published* crate hits: `cargo package` ships
+/// only the crate directory, so a build outside this repository has no C++
+/// source tree two levels up and must pick one of the other modes. Without this
+/// check the build would download the ONNX Runtime tarball into an unrelated
+/// directory and then hand CMake a path with no `CMakeLists.txt`, failing much
+/// later with a far less obvious error.
+fn verify_source_dir(dir: &Path) {
+    if dir.join("CMakeLists.txt").is_file() && dir.join(CAPI_SOURCE).is_file() {
+        return;
+    }
+    let hint = if env::var_os("ONNXSIM_SOURCE_DIR").is_some() {
+        "ONNXSIM_SOURCE_DIR is set but does not point at an onnxsim checkout"
+    } else {
+        "onnxsim-sys was not built from inside the onnxsim repository, so the \
+         C++ sources it compiles by default are not available"
+    };
+    panic!(
+        "cannot build the native onnxsim_c library from source: {hint} \
+         (looked for CMakeLists.txt and {CAPI_SOURCE} under {}).\n\
+         Pick one of:\n  \
+         * ONNXSIM_LIB_DIR=<dir>    link a pre-built onnxsim_c (and its dependencies)\n  \
+         * ONNXSIM_SOURCE_DIR=<dir> point at an onnxsim checkout with submodules initialized\n  \
+         * ONNXSIM_NO_BUILD=1       skip the native build entirely (type-check only)\n\
+         See https://github.com/onnxsim/onnxsim/blob/master/rust/README.md#building-the-native-library",
+        dir.display()
+    );
 }
 
 /// Ensure the ONNX Runtime source tree exists at

--- a/scripts/test_rust_package_standalone.sh
+++ b/scripts/test_rust_package_standalone.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# Build-test the Rust crates the way a downstream consumer sees them: package
+# them with `cargo package`, unpack the archives *outside* this repository, and
+# build a throwaway crate against the unpacked copies.
+#
+# Why this exists: `cargo publish --no-verify` (see "Publishing" in
+# rust/README.md) means nothing in CI ever compiles what actually ships. The
+# packaged crate is just the crate directory -- no C++ sources, no submodules,
+# no monorepo around it -- so a mistake that only shows up there (a file missing
+# from the package, a path dependency that does not resolve once rewritten to a
+# registry dependency, a build script that assumes ../.. is the onnxsim source
+# tree) is invisible to the in-tree `cargo build` the `build` job runs.
+#
+# Usage:
+#   scripts/test_rust_package_standalone.sh [options]
+#
+# Options:
+#   --lib-dir DIR[:DIR...]  Link a pre-built onnxsim_c from these directories
+#                           (ONNXSIM_LIB_DIR mode) and *run* the consumer, so
+#                           the packaged crates are linked and executed, not
+#                           just type-checked. "auto" searches this repo's
+#                           rust/target for a library left by a previous
+#                           `cargo build`.
+#   --source-dir DIR        Build the native library from source with CMake
+#                           against the onnxsim checkout at DIR
+#                           (ONNXSIM_SOURCE_DIR mode) and run the consumer.
+#                           Slow; honors ONNXSIM_PREBUILT_ORT=1.
+#   --model PATH            Also simplify this ONNX model from the consumer
+#                           binary (only used when the native library is
+#                           linked).
+#   --workdir DIR           Unpack into DIR instead of a fresh mktemp -d.
+#                           Must be outside this repository.
+#   --keep                  Do not delete the work directory on exit.
+#
+# With neither --lib-dir nor --source-dir the script runs in check-only mode:
+# it type-checks the unpacked crates with ONNXSIM_NO_BUILD=1 (no native build,
+# ~a minute) and asserts that a build with no mode selected fails fast with an
+# actionable message instead of trying to compile the C++ stack from a
+# directory that does not contain it.
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+ROOT_DIR=$(cd -- "$SCRIPT_DIR/.." &> /dev/null && pwd)
+RUST_DIR="$ROOT_DIR/rust"
+
+LIB_DIR=""
+SOURCE_DIR=""
+MODEL=""
+WORKDIR=""
+KEEP=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --lib-dir) LIB_DIR="${2:?--lib-dir needs a value}"; shift 2 ;;
+    --source-dir) SOURCE_DIR="${2:?--source-dir needs a value}"; shift 2 ;;
+    --model) MODEL="${2:?--model needs a value}"; shift 2 ;;
+    --workdir) WORKDIR="${2:?--workdir needs a value}"; shift 2 ;;
+    --keep) KEEP=1; shift ;;
+    -h|--help) sed -n '2,40p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+# The consumer binary runs from the work directory, so a relative model path
+# would resolve against the wrong directory once it gets there.
+if [ -n "$MODEL" ]; then
+  [ -f "$MODEL" ] || { echo "error: model $MODEL does not exist" >&2; exit 2; }
+  MODEL=$(cd -- "$(dirname -- "$MODEL")" &> /dev/null && pwd)/$(basename -- "$MODEL")
+fi
+
+if [ -n "$LIB_DIR" ] && [ -n "$SOURCE_DIR" ]; then
+  echo "error: --lib-dir and --source-dir are mutually exclusive" >&2
+  exit 2
+fi
+
+# `auto`: reuse whatever a previous in-tree `cargo build` already produced, so
+# CI can link against the native library it just spent an hour compiling
+# instead of building it a second time.
+if [ "$LIB_DIR" = "auto" ]; then
+  # cargo leaves one build directory per build-script run, and only the one
+  # that actually built the library has it, so take the first that does.
+  build_root=""
+  while IFS= read -r candidate; do
+    if [ -n "$(find "$candidate" \( -name 'libonnxsim_c.*' -o -name 'onnxsim_c.dll' \) -print -quit 2>/dev/null)" ]; then
+      build_root="$candidate"
+      break
+    fi
+  done < <(find "$RUST_DIR/target" -type d -path '*/onnxsim-sys-*/out/build' 2>/dev/null)
+
+  if [ -z "$build_root" ]; then
+    echo "error: --lib-dir auto found no built onnxsim_c under $RUST_DIR/target;" >&2
+    echo "       run a native \`cargo build\` in rust/ first, or pass an explicit --lib-dir" >&2
+    exit 1
+  fi
+
+  # onnxsim_c links against ONNX Runtime & friends, which sit in sibling
+  # directories of the same build tree; list every directory holding a shared
+  # library so both the linker and the loader can resolve them too.
+  LIB_DIR=$(find "$build_root" \( -name '*.so' -o -name '*.so.*' -o -name '*.dylib' -o -name '*.dll' \) 2>/dev/null |
+            xargs -r -n1 dirname | sort -u | paste -sd: -)
+  echo "--lib-dir auto resolved to $LIB_DIR"
+fi
+
+VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' "$RUST_DIR/Cargo.toml" | head -n 1)
+if [ -z "$VERSION" ]; then
+  echo "error: could not read the workspace version from $RUST_DIR/Cargo.toml" >&2
+  exit 1
+fi
+
+if [ -n "$WORKDIR" ]; then
+  mkdir -p "$WORKDIR"
+  WORKDIR=$(cd -- "$WORKDIR" &> /dev/null && pwd)
+else
+  WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/onnxsim-rust-standalone.XXXXXX")
+fi
+
+# The whole point is to build with no onnxsim source tree around; a work
+# directory inside the repository would silently defeat that (the build script
+# walks up from the crate directory to find the C++ sources).
+case "$WORKDIR/" in
+  "$ROOT_DIR"/*) echo "error: work directory $WORKDIR is inside $ROOT_DIR" >&2; exit 2 ;;
+esac
+
+cleanup() {
+  if [ "$KEEP" -eq 0 ]; then
+    rm -rf "$WORKDIR"
+  else
+    echo "kept work directory: $WORKDIR"
+  fi
+}
+trap cleanup EXIT
+
+echo "=== packaging onnxsim-sys $VERSION and onnxsim $VERSION ==="
+# Drop any archive left by an earlier run so a stale (or half-written) .crate
+# can never be what gets tested.
+rm -f "$RUST_DIR/target/package/onnxsim-sys-$VERSION.crate" \
+      "$RUST_DIR/target/package/onnxsim-$VERSION.crate"
+# --no-verify for the same reason `cargo publish` needs it: the verification
+# build happens in a sandbox with no C++ sources. That build is what this
+# script replaces, in a way that actually works. ONNXSIM_NO_BUILD keeps any
+# incidental build-script run from starting a native build.
+(
+  cd "$RUST_DIR"
+  ONNXSIM_NO_BUILD=1 cargo package --no-verify --allow-dirty -p onnxsim-sys -p onnxsim
+)
+
+for crate in "onnxsim-sys-$VERSION" "onnxsim-$VERSION"; do
+  archive="$RUST_DIR/target/package/$crate.crate"
+  [ -f "$archive" ] || { echo "error: $archive was not produced" >&2; exit 1; }
+  tar xzf "$archive" -C "$WORKDIR"
+  [ -d "$WORKDIR/$crate" ] || { echo "error: $archive did not unpack to $crate" >&2; exit 1; }
+done
+
+# Sanity check the premise: nothing that looks like an onnxsim checkout is
+# visible from the unpacked crates, so the build script cannot fall back to it.
+for marker in "$WORKDIR/CMakeLists.txt" "$WORKDIR/onnxsim"; do
+  if [ -e "$marker" ]; then
+    echo "error: $marker exists; $WORKDIR is not a source-tree-free environment" >&2
+    exit 1
+  fi
+done
+
+# `cargo package` rewrites onnxsim's path dependency on onnxsim-sys into a
+# registry dependency, so a plain build of the unpacked crate would pull
+# onnxsim-sys from crates.io -- the published copy, not the one being tested.
+# Patch it back to the freshly unpacked sibling. Putting the patch in
+# .cargo/config.toml (rather than a manifest) applies it to every cargo
+# invocation below, including ones run inside the unpacked crates themselves.
+mkdir -p "$WORKDIR/.cargo"
+cat > "$WORKDIR/.cargo/config.toml" <<EOF
+[patch.crates-io]
+onnxsim-sys = { path = "$WORKDIR/onnxsim-sys-$VERSION" }
+EOF
+
+# A downstream crate that depends on onnxsim exactly as the README documents.
+mkdir -p "$WORKDIR/consumer/src"
+cat > "$WORKDIR/consumer/Cargo.toml" <<EOF
+[package]
+name = "onnxsim-standalone-consumer"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+onnxsim = { path = "$WORKDIR/onnxsim-$VERSION", version = "$VERSION" }
+
+# Not a member of any surrounding workspace.
+[workspace]
+EOF
+
+cat > "$WORKDIR/consumer/src/main.rs" <<'EOF'
+//! Smoke test for the packaged crates, from the outside.
+//!
+//! Type-checks against the public API in check-only mode; when the native
+//! library is linked it also calls into it (and simplifies a model if one is
+//! passed as an argument).
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let optimizers = onnxsim::list_optimizers();
+    println!("list_optimizers() -> {} passes", optimizers.len());
+    assert!(!optimizers.is_empty(), "expected a non-empty optimizer list");
+
+    // Exercise a little of the safe API that does not need a model.
+    let _opts = onnxsim::Options::new()
+        .shape_inference(true)
+        .skip_optimizer(optimizers[0].clone())
+        .tensor_size_threshold(1024 * 1024);
+
+    if let Some(path) = std::env::args().nth(1) {
+        let model = std::fs::read(&path)?;
+        let simplified = onnxsim::simplify(&model)?;
+        assert!(!simplified.is_empty(), "simplify() returned no model");
+        print!("{}", onnxsim::model_info_diff(&model, &simplified)?);
+        println!("simplified {path}: {} -> {} bytes", model.len(), simplified.len());
+    }
+    Ok(())
+}
+EOF
+
+if [ -n "$LIB_DIR" ] || [ -n "$SOURCE_DIR" ]; then
+  if [ -n "$LIB_DIR" ]; then
+    echo "=== native mode: linking pre-built onnxsim_c from $LIB_DIR ==="
+    export ONNXSIM_LIB_DIR="$LIB_DIR"
+    # rpath is emitted by the build script, but keep the loader happy on
+    # platforms/configurations where it is not honored.
+    export LD_LIBRARY_PATH="$LIB_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+    export DYLD_FALLBACK_LIBRARY_PATH="$LIB_DIR${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
+  else
+    SOURCE_DIR=$(cd -- "$SOURCE_DIR" &> /dev/null && pwd)
+    echo "=== native mode: building onnxsim_c from source at $SOURCE_DIR ==="
+    export ONNXSIM_SOURCE_DIR="$SOURCE_DIR"
+  fi
+
+  echo "--- running the consumer binary ---"
+  (
+    cd "$WORKDIR/consumer"
+    if [ -n "$MODEL" ]; then
+      cargo run --release -- "$MODEL"
+    else
+      cargo run --release
+    fi
+  )
+
+  echo "--- running the packaged crate's own tests ---"
+  (
+    cd "$WORKDIR/onnxsim-$VERSION"
+    cargo test --release
+    cargo test --release -- --ignored list_optimizers_is_non_empty
+  )
+else
+  echo "=== check-only mode (ONNXSIM_NO_BUILD=1, no native build) ==="
+  echo "--- type-checking the unpacked crates (lib, examples, tests) ---"
+  (
+    cd "$WORKDIR/onnxsim-$VERSION"
+    ONNXSIM_NO_BUILD=1 cargo check --all-targets
+  )
+  echo "--- type-checking a downstream consumer of the unpacked crate ---"
+  (
+    cd "$WORKDIR/consumer"
+    ONNXSIM_NO_BUILD=1 cargo check
+  )
+
+  # With no mode selected there is no way to produce the native library out
+  # here, so the build script must say so immediately. Before it did this, it
+  # downloaded the ONNX Runtime source into whatever directory happened to sit
+  # above the crate and only failed once CMake was handed a path with no
+  # CMakeLists.txt.
+  echo "--- asserting an unconfigured build fails fast with an actionable error ---"
+  log="$WORKDIR/unconfigured-build.log"
+  if (cd "$WORKDIR/consumer" && cargo check --offline) > "$log" 2>&1; then
+    echo "error: a build with no ONNXSIM_* mode selected unexpectedly succeeded" >&2
+    exit 1
+  fi
+  for expected in ONNXSIM_LIB_DIR ONNXSIM_SOURCE_DIR ONNXSIM_NO_BUILD; do
+    grep -q "$expected" "$log" || {
+      echo "error: the failure message does not mention $expected:" >&2
+      cat "$log" >&2
+      exit 1
+    }
+  done
+  # ...and it must not have started fetching ONNX Runtime into the work dir.
+  if [ -e "$WORKDIR/third_party" ]; then
+    echo "error: the failed build created $WORKDIR/third_party" >&2
+    exit 1
+  fi
+fi
+
+echo "=== standalone package build test passed (onnxsim $VERSION) ==="


### PR DESCRIPTION
## Summary

Add a comprehensive test that validates the Rust crates (`onnxsim-sys` and `onnxsim`) as downstream consumers receive them: packaged with `cargo package`, unpacked outside the repository, and built against the unpacked copies. This closes a critical gap where `cargo publish --no-verify` means the actual shipped archives are never compiled in CI.

## Key Changes

- **New script `scripts/test_rust_package_standalone.sh`**: A 287-line bash script that:
  - Packages both crates with `cargo package --no-verify`
  - Unpacks the `.crate` archives outside the source tree
  - Patches the registry dependency back to the freshly unpacked sibling
  - Builds a throwaway downstream consumer crate against the unpacked copies
  - Supports three modes:
    - **Check-only** (default): Type-checks with `ONNXSIM_NO_BUILD=1`, validates that unconfigured builds fail fast with actionable errors
    - **Pre-built library** (`--lib-dir`): Links against a pre-built `onnxsim_c` and runs the consumer binary
    - **Source build** (`--source-dir`): Builds the native library from source with CMake

- **Updated `rust/onnxsim-sys/build.rs`**:
  - Added `verify_source_dir()` function that fails fast with an actionable message when C++ sources are missing
  - Extracted `CAPI_SOURCE` constant for use as both a rebuild trigger and source verification marker
  - Provides clear guidance on the three build modes when the default mode cannot proceed

- **Updated `.github/workflows/rust.yml`**:
  - Added new `package` job that runs the check-only test on every PR (~1 minute, no native build)
  - Extended `build` job to run the standalone test with `--lib-dir auto` after the native build, reusing the compiled library to validate the packaged crates are linked and executed outside the source tree
  - Updated `publish` job dependencies to include the new `package` job

- **Updated `rust/README.md`**:
  - Documented the three build modes and clarified that mode 1 (default) only works inside the repository
  - Added comprehensive "Standalone package build test" section explaining the motivation, usage, and CI integration

## Implementation Details

The script detects several failure modes that would otherwise ship broken:
- Files missing from the package
- Path dependencies that stop resolving once rewritten to registry dependencies
- Build scripts that assume the onnxsim source tree is two directories up

The `--lib-dir auto` feature intelligently reuses the native library built by the `build` job, avoiding a second compilation while still validating that the packaged crates work outside the source tree.

The check-only mode validates that builds without an explicit mode fail immediately with guidance on `ONNXSIM_LIB_DIR`, `ONNXSIM_SOURCE_DIR`, or `ONNXSIM_NO_BUILD`, rather than attempting a source build that cannot work.

https://claude.ai/code/session_01XTbVSKrQtmoxtD78M62DQi