### PR TITLE
Remove debug console.log statements from conversion scripts

### DIFF
--- a/scripts/convertmodel/converter_main.js
+++ b/scripts/convertmodel/converter_main.js
@@ -200,7 +200,6 @@
 
                     input.disabled = true;
                     dl_btn.disabled = true;
-                    console.log("sending: ", modelName);
                     let passes = null;
                     if (optimizer == "simplify") {
                         passes = Array.from(document.querySelectorAll('input[class="pass"]:not(:checked)')).map((v) => v.name);

--- a/scripts/convertmodel/worker.js
+++ b/scripts/convertmodel/worker.js
@@ -71,11 +71,9 @@ create_onnxsim({
         runtime.ENV.LOG_THRESHOLD = "-1";
     }],
     print: (str) => {
-        console.log("stdout:", str);
         postMessage(["stdout", str]);
     },
     printErr: (str) => {
-        console.error("stderr:", [str]);
         postMessage(["stderr", str]);
         // Augment the raw Emscripten OOM abort line with a human-readable hint.
         if (typeof str === "string" && str.includes("Cannot enlarge memory")) {
@@ -98,7 +96,6 @@ create_onnxsim({
     postMessage(["ready"]);
 
     addEventListener("message", async (e) => {
-        console.log(e.data);
         let buf = e.data[1];
         // The true uploaded bytes, kept aside so the "annotate the original for
         // the inference-compare panel" step below always sees the model the user
@@ -220,9 +217,7 @@ create_onnxsim({
             postMessage(["stderr", e.data[0] + " failed!"]);
             return;
         }
-        console.log("to data url start")
         const data_url = "data:application/octet-stream;base64," + model.toBase64();
-        console.log("to data url end")
         // When "annotate model info" is on, also bake the MAC/FLOP metrics into
         // the *original* uploaded model so the "Run inference" panel can report
         // its throughput too — letting the user compare original vs converted


### PR DESCRIPTION
## Summary
Removes debug `console.log()` and `console.error()` statements that were left in the model conversion worker and main converter scripts. These statements were cluttering the console output and are no longer needed.

## Changes
- **worker.js**: Removed 4 debug log statements:
  - Removed `console.log("stdout:", str)` from the print handler
  - Removed `console.error("stderr:", [str])` from the printErr handler
  - Removed `console.log(e.data)` from the message event listener
  - Removed `console.log("to data url start")` and `console.log("to data url end")` around the base64 conversion

- **converter_main.js**: Removed 1 debug log statement:
  - Removed `console.log("sending: ", modelName)` before sending the model to the worker

## Notes
The postMessage calls that send output to the parent thread are retained, as these are the intended communication mechanism. Only the redundant console logging is removed.

https://claude.ai/code/session_014SpitoEiQPvzth3XgqHFpv