### PR TITLE
Add incremental shape inference caching for fixed-point loop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ endif()
 # configure onnx-optimizer after onnxruntime, because they both depend on onnx and onnxruntime has its own flags for onnx
 add_subdirectory(third_party/onnx-optimizer EXCLUDE_FROM_ALL)
 
-add_library(onnxsim onnxsim/onnxsim.cpp onnxsim/contrib_schemas.cpp onnxsim/custom_optimizer_passes.cpp onnxsim/function_rewriter.cpp onnxsim/profiler.cpp onnxsim/model_info.cpp onnxsim/sym_expr.cpp onnxsim/sym_value_eval.cpp onnxsim/sym_shape_infer.cpp onnxsim/model_metrics.cpp)
+add_library(onnxsim onnxsim/onnxsim.cpp onnxsim/contrib_schemas.cpp onnxsim/custom_optimizer_passes.cpp onnxsim/function_rewriter.cpp onnxsim/profiler.cpp onnxsim/model_info.cpp onnxsim/sym_expr.cpp onnxsim/sym_value_eval.cpp onnxsim/sym_shape_infer.cpp onnxsim/incremental_shape_infer.cpp onnxsim/model_metrics.cpp)
 if (ONNXSIM_BUILTIN_ORT)
   target_include_directories(onnxsim PRIVATE ${ONNXRUNTIME_INCLUDE_DIR})
   if (ONNXSIM_PREBUILT_ORT)
@@ -415,4 +415,13 @@ if (ONNXSIM_TESTS)
   add_executable(dlpack_dtype_test onnxsim/dlpack_dtype_test.cpp)
   target_include_directories(dlpack_dtype_test PRIVATE onnxsim third_party)
   add_test(NAME dlpack_dtype_test COMMAND dlpack_dtype_test)
+
+  # The incremental (per-node, memoized) shape inference driver exercises real
+  # ONNX schemas and inference functions, so -- unlike the dependency-free
+  # tests above -- it links against onnx.
+  add_executable(incremental_shape_infer_test onnxsim/incremental_shape_infer_test.cpp
+                                              onnxsim/incremental_shape_infer.cpp)
+  target_include_directories(incremental_shape_infer_test PRIVATE onnxsim third_party)
+  target_link_libraries(incremental_shape_infer_test PRIVATE onnx)
+  add_test(NAME incremental_shape_infer_test COMMAND incremental_shape_infer_test)
 endif()

--- a/onnxsim/incremental_shape_infer.cpp
+++ b/onnxsim/incremental_shape_infer.cpp
@@ -20,6 +20,7 @@ using onnx::ModelProto;
 using onnx::NodeProto;
 using onnx::OpSchema;
 using onnx::OpSchemaRegistry;
+using onnx::ShapeInferenceOptions;
 using onnx::SparseTensorProto;
 using onnx::TensorProto;
 using onnx::TypeProto;
@@ -29,7 +30,6 @@ using onnx::shape_inference::InferenceContextImpl;
 using onnx::shape_inference::MaterializeSymbolicShape;
 using onnx::shape_inference::mergeShapesAndTypes;
 using onnx::shape_inference::SymbolTableImpl;
-using onnx::ShapeInferenceOptions;
 using onnx::shape_inference::TraverseGraphsToAddExistingSymbols;
 
 // Appends `s` to `out` preceded by its byte length (8 raw bytes, native
@@ -58,15 +58,20 @@ std::string ReadLP(const std::string& bytes, size_t* pos) {
 
 bool HasGraphAttribute(const NodeProto& node) {
   for (const auto& attr : node.attribute()) {
-    if (attr.type() == AttributeProto::GRAPH || attr.type() == AttributeProto::GRAPHS) return true;
+    if (attr.type() == AttributeProto::GRAPH ||
+        attr.type() == AttributeProto::GRAPHS)
+      return true;
   }
   return false;
 }
 
 bool IsConstantWithSparseValue(const NodeProto& node) {
-  if (node.op_type() != "Constant" || !(node.domain().empty() || node.domain() == "ai.onnx")) return false;
+  if (node.op_type() != "Constant" ||
+      !(node.domain().empty() || node.domain() == "ai.onnx"))
+    return false;
   for (const auto& attr : node.attribute()) {
-    if (attr.name() == "value" && attr.type() == AttributeProto::SPARSE_TENSOR) return true;
+    if (attr.name() == "value" && attr.type() == AttributeProto::SPARSE_TENSOR)
+      return true;
   }
   return false;
 }
@@ -83,18 +88,22 @@ bool IsConstantWithSparseValue(const NodeProto& node) {
 // driver before this is used whenever a Constant carries one, via
 // IsConstantWithSparseValue.)
 template <typename T>
-void AddTemporaryConstant(const std::string& name, const std::vector<T>& v, bool scalar,
-                          std::unordered_map<std::string, TensorProto>& owned,
-                          std::unordered_map<std::string, const TensorProto*>& input_data_by_name) {
+void AddTemporaryConstant(
+    const std::string& name, const std::vector<T>& v, bool scalar,
+    std::unordered_map<std::string, TensorProto>& owned,
+    std::unordered_map<std::string, const TensorProto*>& input_data_by_name) {
   TensorProto t = onnx::ToTensor(v);
   if (!scalar) t.add_dims(static_cast<int64_t>(v.size()));
   owned[name] = std::move(t);
   input_data_by_name[name] = &owned[name];
 }
 
-void ProcessConstantNode(const NodeProto& n, std::unordered_map<std::string, TensorProto>& owned,
-                         std::unordered_map<std::string, const TensorProto*>& input_data_by_name) {
-  if (n.op_type() != "Constant" || !(n.domain().empty() || n.domain() == "ai.onnx") || n.output_size() != 1) return;
+void ProcessConstantNode(
+    const NodeProto& n, std::unordered_map<std::string, TensorProto>& owned,
+    std::unordered_map<std::string, const TensorProto*>& input_data_by_name) {
+  if (n.op_type() != "Constant" ||
+      !(n.domain().empty() || n.domain() == "ai.onnx") || n.output_size() != 1)
+    return;
   const std::string& output_name = n.output(0);
   for (const auto& attr : n.attribute()) {
     if (attr.name() == "value") {
@@ -106,18 +115,24 @@ void ProcessConstantNode(const NodeProto& n, std::unordered_map<std::string, Ten
     } else {
       switch (attr.type()) {
         case AttributeProto::INTS:
-          AddTemporaryConstant(output_name, std::vector<int64_t>(attr.ints().begin(), attr.ints().end()), false,
-                               owned, input_data_by_name);
+          AddTemporaryConstant(
+              output_name,
+              std::vector<int64_t>(attr.ints().begin(), attr.ints().end()),
+              false, owned, input_data_by_name);
           break;
         case AttributeProto::INT:
-          AddTemporaryConstant(output_name, std::vector<int64_t>{attr.i()}, true, owned, input_data_by_name);
+          AddTemporaryConstant(output_name, std::vector<int64_t>{attr.i()},
+                               true, owned, input_data_by_name);
           break;
         case AttributeProto::FLOATS:
-          AddTemporaryConstant(output_name, std::vector<float>(attr.floats().begin(), attr.floats().end()), false,
-                               owned, input_data_by_name);
+          AddTemporaryConstant(
+              output_name,
+              std::vector<float>(attr.floats().begin(), attr.floats().end()),
+              false, owned, input_data_by_name);
           break;
         case AttributeProto::FLOAT:
-          AddTemporaryConstant(output_name, std::vector<float>{attr.f()}, true, owned, input_data_by_name);
+          AddTemporaryConstant(output_name, std::vector<float>{attr.f()}, true,
+                               owned, input_data_by_name);
           break;
         default:
           break;
@@ -134,7 +149,9 @@ void ProcessConstantNode(const NodeProto& n, std::unordered_map<std::string, Ten
 // RegisterCustomDefaultDomainOpSchemas -- run before Simplify's fixed point
 // -- already give onnxsim's own ops and ORT's contrib ops direct C++
 // inference functions).
-bool HasUnmodeledNode(const GraphProto& graph, const std::unordered_map<std::string, int>& opset_imports) {
+bool HasUnmodeledNode(
+    const GraphProto& graph,
+    const std::unordered_map<std::string, int>& opset_imports) {
   if (graph.sparse_initializer_size() > 0) return true;
   for (const auto& n : graph.node()) {
     if (HasGraphAttribute(n) || IsConstantWithSparseValue(n)) return true;
@@ -142,9 +159,13 @@ bool HasUnmodeledNode(const GraphProto& graph, const std::unordered_map<std::str
     if (dit == opset_imports.end() && n.domain() == onnx::ONNX_DOMAIN) {
       dit = opset_imports.find(onnx::AI_ONNX_DOMAIN);
     }
-    if (dit == opset_imports.end()) continue;  // left to InferenceContextImpl below: no import, no inference.
-    const OpSchema* schema = OpSchemaRegistry::Instance()->GetSchema(n.op_type(), dit->second, n.domain());
-    if (schema && !schema->has_type_and_shape_inference_function() && schema->HasFunction()) return true;
+    if (dit == opset_imports.end())
+      continue;  // left to InferenceContextImpl below: no import, no inference.
+    const OpSchema* schema = OpSchemaRegistry::Instance()->GetSchema(
+        n.op_type(), dit->second, n.domain());
+    if (schema && !schema->has_type_and_shape_inference_function() &&
+        schema->HasFunction())
+      return true;
   }
   return false;
 }
@@ -155,14 +176,16 @@ void IncrementalShapeInferer::Run(ModelProto& model) {
   GraphProto& graph = *model.mutable_graph();
 
   std::unordered_map<std::string, int> opset_imports;
-  for (const auto& opset : model.opset_import()) opset_imports[opset.domain()] = static_cast<int>(opset.version());
+  for (const auto& opset : model.opset_import())
+    opset_imports[opset.domain()] = static_cast<int>(opset.version());
 
   if (model.functions_size() > 0 || HasUnmodeledNode(graph, opset_imports)) {
     onnx::shape_inference::InferShapes(model);
     return;
   }
 
-  const ShapeInferenceOptions options(/*check_type=*/false, /*error_mode=*/0, /*enable_data_propagation=*/false);
+  const ShapeInferenceOptions options(/*check_type=*/false, /*error_mode=*/0,
+                                      /*enable_data_propagation=*/false);
   SymbolTableImpl symbol_table;
   TraverseGraphsToAddExistingSymbols(graph, symbol_table);
   // Data propagation is off (`options.enable_data_propagation == false`), so
@@ -259,12 +282,15 @@ void IncrementalShapeInferer::Run(ModelProto& model) {
   const std::unordered_set<std::string> empty_unbound;
   auto invoke_inference = [&](NodeProto& node, const OpSchema& schema) {
     std::vector<TypeProto> out_types(static_cast<size_t>(node.output_size()));
-    InferenceContextImpl ctx(node, value_types_by_name, input_data_by_name, {}, options, &generated_shape_data,
+    InferenceContextImpl ctx(node, value_types_by_name, input_data_by_name, {},
+                             options, &generated_shape_data,
                              /*graphInferenceContext=*/nullptr, &empty_unbound);
     try {
       schema.GetTypeAndShapeInferenceFunction()(ctx);
       for (int i = 0; i < node.output_size(); ++i) {
-        if (!node.output(i).empty()) out_types[static_cast<size_t>(i)] = *ctx.getOutputType(static_cast<size_t>(i));
+        if (!node.output(i).empty())
+          out_types[static_cast<size_t>(i)] =
+              *ctx.getOutputType(static_cast<size_t>(i));
       }
     } catch (const std::exception&) {
       // error_mode == 0: onnx's own driver swallows node-level inference
@@ -280,7 +306,8 @@ void IncrementalShapeInferer::Run(ModelProto& model) {
       dit = opset_imports.find(onnx::AI_ONNX_DOMAIN);
     }
     const OpSchema* schema = dit != opset_imports.end()
-                                 ? OpSchemaRegistry::Instance()->GetSchema(n.op_type(), dit->second, n.domain())
+                                 ? OpSchemaRegistry::Instance()->GetSchema(
+                                       n.op_type(), dit->second, n.domain())
                                  : nullptr;
     if (!schema || !schema->has_type_and_shape_inference_function()) {
       // No opset import for the node's domain, or a genuinely unsupported
@@ -303,19 +330,27 @@ void IncrementalShapeInferer::Run(ModelProto& model) {
     AppendLP(key, n.domain());
     AppendLP(key, n.op_type());
     AppendLP(key, std::to_string(dit->second));
-    for (const auto& attr : n.attribute()) AppendLP(key, attr.SerializeAsString());
+    for (const auto& attr : n.attribute())
+      AppendLP(key, attr.SerializeAsString());
     for (const auto& input : n.input()) {
       if (input.empty()) {
-        AppendLP(key, "\x01" "absent");
+        AppendLP(key,
+                 "\x01"
+                 "absent");
         continue;
       }
       auto tit = value_types_by_name.find(input);
-      AppendLP(key, tit != value_types_by_name.end() ? tit->second->SerializeAsString()
-                                                     : std::string("\x01" "notype"));
+      AppendLP(key, tit != value_types_by_name.end()
+                        ? tit->second->SerializeAsString()
+                        : std::string("\x01"
+                                      "notype"));
       auto dit2 = input_data_by_name.find(input);
       if (dit2 == input_data_by_name.end()) {
-        AppendLP(key, "\x01" "novalue");
-      } else if (static_cast<size_t>(dit2->second->ByteSizeLong()) > kMaxCachedValueBytes) {
+        AppendLP(key,
+                 "\x01"
+                 "novalue");
+      } else if (static_cast<size_t>(dit2->second->ByteSizeLong()) >
+                 kMaxCachedValueBytes) {
         cacheable = false;
         break;
       } else {
@@ -333,12 +368,14 @@ void IncrementalShapeInferer::Run(ModelProto& model) {
     } else {
       out_types = invoke_inference(n, *schema);
       std::string serialized;
-      for (const auto& t : out_types) AppendLP(serialized, t.SerializeAsString());
+      for (const auto& t : out_types)
+        AppendLP(serialized, t.SerializeAsString());
       cache_.emplace(std::move(key), std::move(serialized));
     }
 
     for (int i = 0; i < n.output_size(); ++i) {
-      if (!n.output(i).empty()) update_type(n.output(i), &out_types[static_cast<size_t>(i)]);
+      if (!n.output(i).empty())
+        update_type(n.output(i), &out_types[static_cast<size_t>(i)]);
     }
     ProcessConstantNode(n, owned_constants, input_data_by_name);
   }

--- a/onnxsim/incremental_shape_infer.cpp
+++ b/onnxsim/incremental_shape_infer.cpp
@@ -3,7 +3,6 @@
 #include <cstdint>
 #include <cstring>
 #include <list>
-#include <unordered_set>
 #include <vector>
 
 #include "onnx/common/constants.h"
@@ -279,12 +278,17 @@ void IncrementalShapeInferer::Run(ModelProto& model) {
   // reads (only its type/shape, which the key already carries separately).
   constexpr size_t kMaxCachedValueBytes = 4096;
 
-  const std::unordered_set<std::string> empty_unbound;
   auto invoke_inference = [&](NodeProto& node, const OpSchema& schema) {
     std::vector<TypeProto> out_types(static_cast<size_t>(node.output_size()));
+    // Omits the trailing `unboundValueNames` argument (defaults to nullptr,
+    // meaning "no unbound names" -- correct here since this fast path never
+    // processes a function body, only top-level graph nodes): the onnx
+    // version vendored by the built-in ONNX Runtime build predates that
+    // parameter's addition, so passing it explicitly would fail to compile
+    // there even though it's optional on newer onnx.
     InferenceContextImpl ctx(node, value_types_by_name, input_data_by_name, {},
                              options, &generated_shape_data,
-                             /*graphInferenceContext=*/nullptr, &empty_unbound);
+                             /*graphInferenceContext=*/nullptr);
     try {
       schema.GetTypeAndShapeInferenceFunction()(ctx);
       for (int i = 0; i < node.output_size(); ++i) {

--- a/onnxsim/incremental_shape_infer.cpp
+++ b/onnxsim/incremental_shape_infer.cpp
@@ -1,0 +1,347 @@
+#include "incremental_shape_infer.h"
+
+#include <cstdint>
+#include <cstring>
+#include <list>
+#include <unordered_set>
+#include <vector>
+
+#include "onnx/common/constants.h"
+#include "onnx/defs/schema.h"
+#include "onnx/defs/tensor_proto_util.h"
+#include "onnx/shape_inference/implementation.h"
+
+namespace onnxsim {
+namespace {
+
+using onnx::AttributeProto;
+using onnx::GraphProto;
+using onnx::ModelProto;
+using onnx::NodeProto;
+using onnx::OpSchema;
+using onnx::OpSchemaRegistry;
+using onnx::SparseTensorProto;
+using onnx::TensorProto;
+using onnx::TypeProto;
+using onnx::shape_inference::checkShapesAndTypes;
+using onnx::shape_inference::DataValueMap;
+using onnx::shape_inference::InferenceContextImpl;
+using onnx::shape_inference::MaterializeSymbolicShape;
+using onnx::shape_inference::mergeShapesAndTypes;
+using onnx::shape_inference::SymbolTableImpl;
+using onnx::ShapeInferenceOptions;
+using onnx::shape_inference::TraverseGraphsToAddExistingSymbols;
+
+// Appends `s` to `out` preceded by its byte length (8 raw bytes, native
+// order). Concatenating several length-prefixed strings this way is
+// unambiguous for equality: two different sequences of strings never
+// serialize to the same bytes, which is all the cache key/value below ever
+// need (neither is ever parsed back apart field-by-field, only compared or,
+// for the value, split back into the same fixed list of outputs it was built
+// from).
+void AppendLP(std::string& out, const std::string& s) {
+  uint64_t n = s.size();
+  out.append(reinterpret_cast<const char*>(&n), sizeof(n));
+  out.append(s);
+}
+
+// Reads one length-prefixed string starting at `*pos` (as written by
+// AppendLP), advancing `*pos` past it.
+std::string ReadLP(const std::string& bytes, size_t* pos) {
+  uint64_t n = 0;
+  std::memcpy(&n, bytes.data() + *pos, sizeof(n));
+  *pos += sizeof(n);
+  std::string s = bytes.substr(*pos, n);
+  *pos += n;
+  return s;
+}
+
+bool HasGraphAttribute(const NodeProto& node) {
+  for (const auto& attr : node.attribute()) {
+    if (attr.type() == AttributeProto::GRAPH || attr.type() == AttributeProto::GRAPHS) return true;
+  }
+  return false;
+}
+
+bool IsConstantWithSparseValue(const NodeProto& node) {
+  if (node.op_type() != "Constant" || !(node.domain().empty() || node.domain() == "ai.onnx")) return false;
+  for (const auto& attr : node.attribute()) {
+    if (attr.name() == "value" && attr.type() == AttributeProto::SPARSE_TENSOR) return true;
+  }
+  return false;
+}
+
+// Mirrors ``ShapeInferenceImplBase::ProcessConstant``/``AddTemporaryConstant``
+// in onnx's shape_inference/implementation.cc: a node's *value*, not just its
+// type, can matter to a downstream op's shape inference function (Reshape
+// reads its target shape from a Constant's tensor, Squeeze reads its axes
+// from one, ...). Tracks the same two sources onnx's own driver does -- a
+// Constant node's `value` attribute, and any INT/INTS/FLOAT/FLOATS-typed
+// attribute of a Constant node (`value_int`/`value_ints`/`value_float`/
+// `value_floats`) -- into the shared input-data map InferenceContextImpl
+// reads from. (Sparse `value` is excluded: callers bail to the full onnx
+// driver before this is used whenever a Constant carries one, via
+// IsConstantWithSparseValue.)
+template <typename T>
+void AddTemporaryConstant(const std::string& name, const std::vector<T>& v, bool scalar,
+                          std::unordered_map<std::string, TensorProto>& owned,
+                          std::unordered_map<std::string, const TensorProto*>& input_data_by_name) {
+  TensorProto t = onnx::ToTensor(v);
+  if (!scalar) t.add_dims(static_cast<int64_t>(v.size()));
+  owned[name] = std::move(t);
+  input_data_by_name[name] = &owned[name];
+}
+
+void ProcessConstantNode(const NodeProto& n, std::unordered_map<std::string, TensorProto>& owned,
+                         std::unordered_map<std::string, const TensorProto*>& input_data_by_name) {
+  if (n.op_type() != "Constant" || !(n.domain().empty() || n.domain() == "ai.onnx") || n.output_size() != 1) return;
+  const std::string& output_name = n.output(0);
+  for (const auto& attr : n.attribute()) {
+    if (attr.name() == "value") {
+      if (attr.type() == AttributeProto::TENSOR && attr.has_t()) {
+        owned[output_name] = attr.t();
+        input_data_by_name[output_name] = &owned[output_name];
+      }
+      // SPARSE_TENSOR handled by the caller's upfront bail-out.
+    } else {
+      switch (attr.type()) {
+        case AttributeProto::INTS:
+          AddTemporaryConstant(output_name, std::vector<int64_t>(attr.ints().begin(), attr.ints().end()), false,
+                               owned, input_data_by_name);
+          break;
+        case AttributeProto::INT:
+          AddTemporaryConstant(output_name, std::vector<int64_t>{attr.i()}, true, owned, input_data_by_name);
+          break;
+        case AttributeProto::FLOATS:
+          AddTemporaryConstant(output_name, std::vector<float>(attr.floats().begin(), attr.floats().end()), false,
+                               owned, input_data_by_name);
+          break;
+        case AttributeProto::FLOAT:
+          AddTemporaryConstant(output_name, std::vector<float>{attr.f()}, true, owned, input_data_by_name);
+          break;
+        default:
+          break;
+      }
+    }
+  }
+}
+
+// True if any node needs handling this fast path does not implement, in
+// which case the caller falls back to the exact full onnx driver for the
+// whole model this round: a graph-valued attribute (If/Loop/Scan/...), a
+// Constant with a sparse tensor value, or a schema whose "inference" is
+// expanding a function body (rarer still, since RegisterContribOpSchemas/
+// RegisterCustomDefaultDomainOpSchemas -- run before Simplify's fixed point
+// -- already give onnxsim's own ops and ORT's contrib ops direct C++
+// inference functions).
+bool HasUnmodeledNode(const GraphProto& graph, const std::unordered_map<std::string, int>& opset_imports) {
+  if (graph.sparse_initializer_size() > 0) return true;
+  for (const auto& n : graph.node()) {
+    if (HasGraphAttribute(n) || IsConstantWithSparseValue(n)) return true;
+    auto dit = opset_imports.find(n.domain());
+    if (dit == opset_imports.end() && n.domain() == onnx::ONNX_DOMAIN) {
+      dit = opset_imports.find(onnx::AI_ONNX_DOMAIN);
+    }
+    if (dit == opset_imports.end()) continue;  // left to InferenceContextImpl below: no import, no inference.
+    const OpSchema* schema = OpSchemaRegistry::Instance()->GetSchema(n.op_type(), dit->second, n.domain());
+    if (schema && !schema->has_type_and_shape_inference_function() && schema->HasFunction()) return true;
+  }
+  return false;
+}
+
+}  // namespace
+
+void IncrementalShapeInferer::Run(ModelProto& model) {
+  GraphProto& graph = *model.mutable_graph();
+
+  std::unordered_map<std::string, int> opset_imports;
+  for (const auto& opset : model.opset_import()) opset_imports[opset.domain()] = static_cast<int>(opset.version());
+
+  if (model.functions_size() > 0 || HasUnmodeledNode(graph, opset_imports)) {
+    onnx::shape_inference::InferShapes(model);
+    return;
+  }
+
+  const ShapeInferenceOptions options(/*check_type=*/false, /*error_mode=*/0, /*enable_data_propagation=*/false);
+  SymbolTableImpl symbol_table;
+  TraverseGraphsToAddExistingSymbols(graph, symbol_table);
+  // Data propagation is off (`options.enable_data_propagation == false`), so
+  // this is never populated; InferenceContextImpl still wants a valid
+  // pointer, matching onnx's own driver (InferShapesImpl defaults it to an
+  // empty map rather than null).
+  DataValueMap generated_shape_data;
+
+  std::unordered_map<std::string, TypeProto*> value_types_by_name;
+  // Names declared (as a graph input/output/value_info) without a type,
+  // mapped to that declaration's TypeProto so a type resolved for them below
+  // is also written directly into it -- e.g. a graph output declared with no
+  // type gets its real inferred type written into graph.output() itself, not
+  // only recorded in a same-named value_info entry. Mirrors onnx's own
+  // ShapeInferenceImplBase::undefined_value_types_by_name exactly, including
+  // its one surprising side effect: calling `vi.mutable_type()` here flips
+  // `vi.has_type()` to true from this point on even if nothing is ever
+  // written into it (an unresolvable name stays serialized as an explicit
+  // empty `type {}` rather than an absent field) -- replicated so a model
+  // this pass leaves partly uninferred serializes identically to what the
+  // exact full onnx::shape_inference::InferShapes would have produced.
+  std::unordered_map<std::string, TypeProto*> undefined_value_types_by_name;
+  // Stable addresses for TypeProtos synthesized below (from initializers):
+  // std::list never invalidates existing elements on further push_back.
+  std::list<TypeProto> owned_types;
+  auto register_vi = [&](onnx::ValueInfoProto& vi) {
+    if (vi.has_type()) {
+      value_types_by_name[vi.name()] = vi.mutable_type();
+    } else {
+      undefined_value_types_by_name[vi.name()] = vi.mutable_type();
+    }
+  };
+  for (auto& vi : *graph.mutable_value_info()) register_vi(vi);
+  for (auto& vi : *graph.mutable_input()) register_vi(vi);
+  for (auto& vi : *graph.mutable_output()) register_vi(vi);
+
+  // Seeded with every initializer, then grown as Constant nodes are visited
+  // below (in topological order, so a node's inputs are already present by
+  // the time it is processed if they were produced by an earlier Constant).
+  std::unordered_map<std::string, const TensorProto*> input_data_by_name;
+  std::unordered_map<std::string, TensorProto> owned_constants;
+  for (const auto& tp : graph.initializer()) {
+    TypeProto t;
+    auto* tt = t.mutable_tensor_type();
+    tt->set_elem_type(tp.data_type());
+    auto* shape = tt->mutable_shape();
+    for (int64_t d : tp.dims()) shape->add_dim()->set_dim_value(d);
+    input_data_by_name[tp.name()] = &tp;
+    auto it = value_types_by_name.find(tp.name());
+    if (it != value_types_by_name.end()) {
+      // Same dual-role precedence as onnx's ProcessInitializer: an
+      // initializer that is also a graph input keeps the input's declared
+      // type, after checking the two agree.
+      checkShapesAndTypes(t, *it->second);
+    } else if (model.ir_version() >= 4) {
+      owned_types.push_back(std::move(t));
+      value_types_by_name[tp.name()] = &owned_types.back();
+    }
+  }
+
+  auto update_type = [&](const std::string& name, TypeProto* inferred) {
+    if (inferred->value_case() == TypeProto::VALUE_NOT_SET) return;
+    // Materializing here (rather than before caching, below) means a fresh
+    // symbol is assigned per point of use: two node instances that happen to
+    // share a cache key (identical op/attrs/input types/input values) can
+    // still sit at genuinely different, independently-unknown positions in
+    // the graph, so their unresolved output dims must not be merged into the
+    // same symbol just because the cache said so.
+    MaterializeSymbolicShape(inferred, symbol_table);
+    auto it = value_types_by_name.find(name);
+    if (it != value_types_by_name.end()) {
+      mergeShapesAndTypes(*inferred, it->second);
+    } else {
+      auto* vi = graph.add_value_info();
+      vi->set_name(name);
+      *vi->mutable_type() = *inferred;
+      value_types_by_name[name] = vi->mutable_type();
+      auto uit = undefined_value_types_by_name.find(name);
+      if (uit != undefined_value_types_by_name.end()) *uit->second = *inferred;
+    }
+  };
+
+  // Above this many bytes, a value is never included in a cache key (see the
+  // loop below): a shape-computing op's value-carrying inputs (Reshape's
+  // target, Slice's starts/ends/axes, Squeeze/Unsqueeze's axes, ...) are
+  // always tiny -- bounded by the output's rank, realistically a handful of
+  // int64s -- so this comfortably covers every legitimate case while
+  // excluding large data tensors (Conv/MatMul/Gemm weights, folded constant
+  // blobs, ...) that happen to reach InferenceContextImpl as `getInputData()`
+  // candidates but whose *value* no such op's inference function actually
+  // reads (only its type/shape, which the key already carries separately).
+  constexpr size_t kMaxCachedValueBytes = 4096;
+
+  const std::unordered_set<std::string> empty_unbound;
+  auto invoke_inference = [&](NodeProto& node, const OpSchema& schema) {
+    std::vector<TypeProto> out_types(static_cast<size_t>(node.output_size()));
+    InferenceContextImpl ctx(node, value_types_by_name, input_data_by_name, {}, options, &generated_shape_data,
+                             /*graphInferenceContext=*/nullptr, &empty_unbound);
+    try {
+      schema.GetTypeAndShapeInferenceFunction()(ctx);
+      for (int i = 0; i < node.output_size(); ++i) {
+        if (!node.output(i).empty()) out_types[static_cast<size_t>(i)] = *ctx.getOutputType(static_cast<size_t>(i));
+      }
+    } catch (const std::exception&) {
+      // error_mode == 0: onnx's own driver swallows node-level inference
+      // errors the same way (collected, never thrown); match that by leaving
+      // this node's outputs unset, same as an unsupported op.
+    }
+    return out_types;
+  };
+
+  for (NodeProto& n : *graph.mutable_node()) {
+    auto dit = opset_imports.find(n.domain());
+    if (dit == opset_imports.end() && n.domain() == onnx::ONNX_DOMAIN) {
+      dit = opset_imports.find(onnx::AI_ONNX_DOMAIN);
+    }
+    const OpSchema* schema = dit != opset_imports.end()
+                                 ? OpSchemaRegistry::Instance()->GetSchema(n.op_type(), dit->second, n.domain())
+                                 : nullptr;
+    if (!schema || !schema->has_type_and_shape_inference_function()) {
+      // No opset import for the node's domain, or a genuinely unsupported
+      // (e.g. custom) op: leave its output type unset, same as onnx's own
+      // driver does for these (`has_unsupported_op = true; return;`).
+      ProcessConstantNode(n, owned_constants, input_data_by_name);
+      continue;
+    }
+
+    // Cache key: every input InferenceContextImpl can observe for this node
+    // -- the operator version, its attributes, and each input's current type
+    // and (if known and small, see kMaxCachedValueBytes) constant value.
+    // Identical bytes guarantee InferenceContextImpl would see identical
+    // inputs and so recompute an identical result; this needs no notion of
+    // "the same node as a previous round" at all, which sidesteps the fact
+    // that onnx-optimizer passes rebuild the whole NodeProto list every round
+    // with no stable node identity across rounds.
+    std::string key;
+    bool cacheable = true;
+    AppendLP(key, n.domain());
+    AppendLP(key, n.op_type());
+    AppendLP(key, std::to_string(dit->second));
+    for (const auto& attr : n.attribute()) AppendLP(key, attr.SerializeAsString());
+    for (const auto& input : n.input()) {
+      if (input.empty()) {
+        AppendLP(key, "\x01" "absent");
+        continue;
+      }
+      auto tit = value_types_by_name.find(input);
+      AppendLP(key, tit != value_types_by_name.end() ? tit->second->SerializeAsString()
+                                                     : std::string("\x01" "notype"));
+      auto dit2 = input_data_by_name.find(input);
+      if (dit2 == input_data_by_name.end()) {
+        AppendLP(key, "\x01" "novalue");
+      } else if (static_cast<size_t>(dit2->second->ByteSizeLong()) > kMaxCachedValueBytes) {
+        cacheable = false;
+        break;
+      } else {
+        AppendLP(key, dit2->second->SerializeAsString());
+      }
+    }
+
+    std::vector<TypeProto> out_types;
+    if (!cacheable) {
+      out_types = invoke_inference(n, *schema);
+    } else if (auto cached = cache_.find(key); cached != cache_.end()) {
+      out_types.resize(static_cast<size_t>(n.output_size()));
+      size_t pos = 0;
+      for (auto& t : out_types) t.ParseFromString(ReadLP(cached->second, &pos));
+    } else {
+      out_types = invoke_inference(n, *schema);
+      std::string serialized;
+      for (const auto& t : out_types) AppendLP(serialized, t.SerializeAsString());
+      cache_.emplace(std::move(key), std::move(serialized));
+    }
+
+    for (int i = 0; i < n.output_size(); ++i) {
+      if (!n.output(i).empty()) update_type(n.output(i), &out_types[static_cast<size_t>(i)]);
+    }
+    ProcessConstantNode(n, owned_constants, input_data_by_name);
+  }
+}
+
+}  // namespace onnxsim

--- a/onnxsim/incremental_shape_infer.h
+++ b/onnxsim/incremental_shape_infer.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include "onnx/onnx_pb.h"
+
+namespace onnxsim {
+
+// onnxsim's fixed-point loop (see ``Simplify()`` in onnxsim.cpp) alternates
+// full-graph ONNX shape inference with an onnx-optimizer pass until the model
+// stops changing, which can take dozens of rounds on a large graph. Each round
+// re-derives shapes for *every* node from scratch via
+// ``onnx::shape_inference::InferShapes``, even though a typical optimizer pass
+// only rewrites a small, local part of the graph -- the rest is byte-for-byte
+// identical to the previous round.
+//
+// ``IncrementalShapeInferer`` drives the same per-node ONNX inference
+// functions (via ``onnx::shape_inference::InferenceContextImpl``, so the
+// actual shape math is untouched, first-party ONNX code) but memoizes each
+// node's result keyed by everything that can affect it: its op/domain/
+// version, its attributes, and each input's current type *and* known
+// constant value. A node whose op-signature and inputs are unchanged since a
+// previous round -- the common case once the fixed point is close to
+// converged -- is then a hash-map lookup instead of a re-invocation of the
+// operator's inference function, turning most rounds after the first into an
+// O(changed nodes) pass instead of O(all nodes).
+//
+// Falls back to the exact, unmodified ``onnx::shape_inference::InferShapes``
+// for the handful of graph shapes this fast path does not model: any node
+// with a graph-valued attribute (``If``/``Loop``/``Scan``/...), model-local
+// functions, sparse initializers, and schema-defined (function-body) op
+// inference. Those are rare in onnxsim's typical CNN/Transformer inputs, and
+// when present correctness fully wins over speed -- the cache built on other
+// calls simply goes unused that round.
+class IncrementalShapeInferer {
+ public:
+  // Mutates `model` in place, same contract as
+  // ``onnx::shape_inference::InferShapes(ModelProto&, ...)``.
+  void Run(onnx::ModelProto& model);
+
+  // Number of distinct node signatures memoized so far. Exposed for testing
+  // and observability only -- callers should not rely on its exact value,
+  // only on it staying flat across a Run() that changed nothing.
+  size_t CacheSize() const { return cache_.size(); }
+
+ private:
+  // Node signature (see Run()) -> its output TypeProtos, length-prefixed and
+  // concatenated. Persists across every Run() call on this instance, i.e. for
+  // the lifetime of one fixed-point loop.
+  std::unordered_map<std::string, std::string> cache_;
+};
+
+}  // namespace onnxsim

--- a/onnxsim/incremental_shape_infer_test.cpp
+++ b/onnxsim/incremental_shape_infer_test.cpp
@@ -1,0 +1,341 @@
+// Exercises IncrementalShapeInferer against real ONNX op schemas: every case
+// is checked both by running the driver and by cross-checking its result
+// against the exact, unmodified onnx::shape_inference::InferShapes on the
+// same starting model, so a divergence here means the fast path computed a
+// different answer than the real ONNX driver would have -- not just "some
+// answer".
+#include "incremental_shape_infer.h"
+
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "onnx/defs/schema.h"
+#include "onnx/shape_inference/implementation.h"
+
+namespace {
+
+using onnx::AttributeProto;
+using onnx::GraphProto;
+using onnx::ModelProto;
+using onnx::NodeProto;
+using onnx::TensorProto;
+using onnx::TypeProto;
+using onnx::ValueInfoProto;
+
+TypeProto TensorType(TensorProto::DataType dtype, std::vector<int64_t> dims) {
+  TypeProto t;
+  auto* tt = t.mutable_tensor_type();
+  tt->set_elem_type(dtype);
+  auto* shape = tt->mutable_shape();
+  for (int64_t d : dims) shape->add_dim()->set_dim_value(d);
+  return t;
+}
+
+ValueInfoProto ValueInfo(const std::string& name, const TypeProto& type) {
+  ValueInfoProto vi;
+  vi.set_name(name);
+  *vi.mutable_type() = type;
+  return vi;
+}
+
+// A graph output declared with no type at all (has_type() == false), so its
+// type must come entirely from inference. ValueInfo(name, TypeProto()) is
+// *not* equivalent: calling mutable_type() with an otherwise-default
+// TypeProto still flips has_type() to true (message-field presence is
+// tracked even in proto3), which both the driver and the real onnx
+// implementation.cc treat as "already known" and never overwrite once
+// inference fails to produce a value -- so a node whose inference is
+// expected to fail would misleadingly still report FindType() != nullptr.
+ValueInfoProto UntypedValueInfo(const std::string& name) {
+  ValueInfoProto vi;
+  vi.set_name(name);
+  return vi;
+}
+
+NodeProto Node(std::string op_type, std::vector<std::string> inputs, std::vector<std::string> outputs) {
+  NodeProto n;
+  n.set_op_type(std::move(op_type));
+  for (auto& i : inputs) n.add_input(i);
+  for (auto& o : outputs) n.add_output(o);
+  return n;
+}
+
+AttributeProto IntsAttr(const std::string& name, std::vector<int64_t> vals) {
+  AttributeProto a;
+  a.set_name(name);
+  a.set_type(AttributeProto::INTS);
+  for (int64_t v : vals) a.add_ints(v);
+  return a;
+}
+
+AttributeProto TensorAttr(const std::string& name, const TensorProto& t) {
+  AttributeProto a;
+  a.set_name(name);
+  a.set_type(AttributeProto::TENSOR);
+  *a.mutable_t() = t;
+  return a;
+}
+
+TensorProto Int64Tensor(const std::string& name, std::vector<int64_t> vals) {
+  TensorProto t;
+  t.set_name(name);
+  t.set_data_type(TensorProto::INT64);
+  t.add_dims(static_cast<int64_t>(vals.size()));
+  for (int64_t v : vals) t.add_int64_data(v);
+  return t;
+}
+
+ModelProto BaseModel() {
+  ModelProto m;
+  m.set_ir_version(8);
+  auto* opset = m.add_opset_import();
+  opset->set_domain("");
+  opset->set_version(17);
+  return m;
+}
+
+const TypeProto* FindType(const ModelProto& m, const std::string& name) {
+  for (const auto& vi : m.graph().value_info())
+    if (vi.name() == name) return &vi.type();
+  for (const auto& vi : m.graph().output())
+    if (vi.name() == name && vi.has_type()) return &vi.type();
+  for (const auto& vi : m.graph().input())
+    if (vi.name() == name && vi.has_type()) return &vi.type();
+  return nullptr;
+}
+
+bool TypesEqual(const ModelProto& a, const ModelProto& b, const std::string& name) {
+  const TypeProto* ta = FindType(a, name);
+  const TypeProto* tb = FindType(b, name);
+  if (!ta || !tb) return ta == tb;  // both-absent counts as equal
+  return ta->SerializeAsString() == tb->SerializeAsString();
+}
+
+int g_failures = 0;
+#define CHECK(cond)                                                                \
+  do {                                                                             \
+    if (!(cond)) {                                                                 \
+      std::cerr << "CHECK failed at " << __FILE__ << ":" << __LINE__ << ": " << #cond << "\n"; \
+      ++g_failures;                                                                \
+    }                                                                              \
+  } while (0)
+
+// A [1,3,8,8] input through Conv(W: [4,3,3,3]) -> Relu, output untyped.
+ModelProto ConvReluModel() {
+  ModelProto m = BaseModel();
+  GraphProto* g = m.mutable_graph();
+  *g->add_input() = ValueInfo("X", TensorType(TensorProto::FLOAT, {1, 3, 8, 8}));
+  *g->add_initializer() = [] {
+    TensorProto w;
+    w.set_name("W");
+    w.set_data_type(TensorProto::FLOAT);
+    for (int64_t d : {4, 3, 3, 3}) w.add_dims(d);
+    for (int i = 0; i < 4 * 3 * 3 * 3; ++i) w.add_float_data(0.f);
+    return w;
+  }();
+  *g->add_node() = Node("Conv", {"X", "W"}, {"conv_out"});
+  *g->add_node() = Node("Relu", {"conv_out"}, {"relu_out"});
+  *g->add_output() = UntypedValueInfo("relu_out");
+  return m;
+}
+
+void TestConvReluMatchesReference() {
+  ModelProto incremental = ConvReluModel();
+  ModelProto reference = ConvReluModel();
+
+  onnxsim::IncrementalShapeInferer inferer;
+  inferer.Run(incremental);
+  onnx::shape_inference::InferShapes(reference);
+
+  CHECK(FindType(incremental, "conv_out") != nullptr);
+  CHECK(TypesEqual(incremental, reference, "conv_out"));
+  CHECK(TypesEqual(incremental, reference, "relu_out"));
+  // Conv's output channel count comes from W's first dim (4); output spatial
+  // dims are 8x8 with a 3x3 kernel, stride 1, no padding -> 6x6.
+  const TypeProto* conv_out = FindType(incremental, "conv_out");
+  CHECK(conv_out->tensor_type().shape().dim(0).dim_value() == 1);
+  CHECK(conv_out->tensor_type().shape().dim(1).dim_value() == 4);
+  CHECK(conv_out->tensor_type().shape().dim(2).dim_value() == 6);
+  CHECK(conv_out->tensor_type().shape().dim(3).dim_value() == 6);
+}
+
+// Reshape's target shape comes from a Constant node's tensor value: only
+// resolvable if the driver tracks Constant-produced values the way onnx's
+// own driver does (ProcessConstantNode).
+void TestReshapeViaConstant() {
+  ModelProto incremental = BaseModel();
+  GraphProto* g = incremental.mutable_graph();
+  *g->add_input() = ValueInfo("X", TensorType(TensorProto::FLOAT, {2, 3, 4}));
+  {
+    NodeProto n = Node("Constant", {}, {"shape_const"});
+    *n.add_attribute() = TensorAttr("value", Int64Tensor("", {2, 12}));
+    *g->add_node() = n;
+  }
+  *g->add_node() = Node("Reshape", {"X", "shape_const"}, {"y"});
+  *g->add_output() = UntypedValueInfo("y");
+
+  ModelProto reference = incremental;
+  onnxsim::IncrementalShapeInferer inferer;
+  inferer.Run(incremental);
+  onnx::shape_inference::InferShapes(reference);
+
+  CHECK(TypesEqual(incremental, reference, "y"));
+  const TypeProto* y = FindType(incremental, "y");
+  CHECK(y != nullptr);
+  if (y) {
+    CHECK(y->tensor_type().shape().dim_size() == 2);
+    CHECK(y->tensor_type().shape().dim(0).dim_value() == 2);
+    CHECK(y->tensor_type().shape().dim(1).dim_value() == 12);
+  }
+}
+
+// Same, but the shape tensor is a graph initializer instead of a Constant
+// node's output (the other source InferenceContextImpl reads input data
+// from).
+void TestReshapeViaInitializer() {
+  ModelProto incremental = BaseModel();
+  GraphProto* g = incremental.mutable_graph();
+  *g->add_input() = ValueInfo("X", TensorType(TensorProto::FLOAT, {2, 3, 4}));
+  *g->add_initializer() = Int64Tensor("shape_init", {6, 4});
+  *g->add_node() = Node("Reshape", {"X", "shape_init"}, {"y"});
+  *g->add_output() = UntypedValueInfo("y");
+
+  ModelProto reference = incremental;
+  onnxsim::IncrementalShapeInferer inferer;
+  inferer.Run(incremental);
+  onnx::shape_inference::InferShapes(reference);
+
+  CHECK(TypesEqual(incremental, reference, "y"));
+  const TypeProto* y = FindType(incremental, "y");
+  CHECK(y != nullptr);
+  if (y) {
+    CHECK(y->tensor_type().shape().dim(0).dim_value() == 6);
+    CHECK(y->tensor_type().shape().dim(1).dim_value() == 4);
+  }
+}
+
+// A Conv whose weight initializer is larger than kMaxCachedValueBytes must
+// still infer correctly (falls back to direct, uncached inference for that
+// node -- see incremental_shape_infer.cpp) and, unlike the small-weight
+// ConvReluModel case, must not appear in the cache at all: caching a large
+// value the op's inference function never actually reads would only add
+// serialization cost for nothing, and skipping it costs no more than the
+// bypassed node's usual (cheap, type-only) recomputation.
+void TestLargeWeightBypassesCache() {
+  ModelProto m = BaseModel();
+  GraphProto* g = m.mutable_graph();
+  *g->add_input() = ValueInfo("X", TensorType(TensorProto::FLOAT, {1, 3, 40, 40}));
+  *g->add_initializer() = [] {
+    TensorProto w;
+    w.set_name("W");
+    w.set_data_type(TensorProto::FLOAT);
+    for (int64_t d : {8, 3, 20, 20}) w.add_dims(d);  // 8*3*20*20*4B ~= 38KB, well over 4KB
+    for (int i = 0; i < 8 * 3 * 20 * 20; ++i) w.add_float_data(0.f);
+    return w;
+  }();
+  *g->add_node() = Node("Conv", {"X", "W"}, {"conv_out"});
+  *g->add_node() = Node("Relu", {"conv_out"}, {"relu_out"});
+  *g->add_output() = UntypedValueInfo("relu_out");
+
+  ModelProto reference = m;
+  onnxsim::IncrementalShapeInferer inferer;
+  inferer.Run(m);
+  onnx::shape_inference::InferShapes(reference);
+
+  CHECK(TypesEqual(m, reference, "conv_out"));
+  CHECK(TypesEqual(m, reference, "relu_out"));
+  CHECK(inferer.CacheSize() == 1);  // Relu only; Conv's large weight bypassed caching
+}
+
+// An op with no registered schema: both the driver and the real onnx
+// inference must leave its output (and anything downstream of it) without an
+// actually-inferred type, rather than throwing -- matching onnx's own
+// error_mode==0 leniency. "Without an actually-inferred type" is checked via
+// value_case(), not has_type()/FindType()!=nullptr: onnx's own driver (and
+// this one, matching it -- see undefined_value_types_by_name above) flips
+// has_type() to true on every declared-but-unresolved input/output as a side
+// effect of registering it, even though its content stays empty.
+void TestUnsupportedOpLeavesTypeUnset() {
+  ModelProto incremental = BaseModel();
+  GraphProto* g = incremental.mutable_graph();
+  *g->add_input() = ValueInfo("X", TensorType(TensorProto::FLOAT, {2, 3}));
+  *g->add_node() = Node("TotallyMadeUpOp", {"X"}, {"mystery"});
+  *g->add_node() = Node("Relu", {"mystery"}, {"y"});
+  *g->add_output() = UntypedValueInfo("y");
+
+  ModelProto reference = incremental;
+  onnxsim::IncrementalShapeInferer inferer;
+  inferer.Run(incremental);
+  onnx::shape_inference::InferShapes(reference);
+
+  CHECK(FindType(incremental, "mystery") == nullptr);
+  CHECK(FindType(reference, "mystery") == nullptr);
+  const TypeProto* y = FindType(incremental, "y");
+  CHECK(y != nullptr && y->value_case() == TypeProto::VALUE_NOT_SET);
+  CHECK(TypesEqual(incremental, reference, "y"));
+}
+
+// Re-running the same (unmodified) graph through one IncrementalShapeInferer
+// instance must not grow its cache -- every node signature was already seen
+// -- while a graph containing one genuinely different node (different Conv
+// strides) grows it by two new entries: the strided Conv itself, and Relu
+// again under a *new* signature (its own attributes are unchanged, but its
+// input's type -- conv_out's now-smaller spatial shape -- is part of the
+// cache key too, correctly, since Relu's own output shape depends on it).
+// Either way the changed node's shape must come out correct, not the stale
+// cached one.
+void TestCacheReuseAndInvalidationBySignature() {
+  onnxsim::IncrementalShapeInferer inferer;
+
+  ModelProto round1 = ConvReluModel();
+  inferer.Run(round1);
+  const size_t size_after_round1 = inferer.CacheSize();
+  CHECK(size_after_round1 == 2);  // Conv, Relu
+
+  ModelProto round2 = ConvReluModel();  // structurally identical to round1
+  inferer.Run(round2);
+  CHECK(inferer.CacheSize() == size_after_round1);
+  CHECK(TypesEqual(round1, round2, "conv_out"));
+  CHECK(TypesEqual(round1, round2, "relu_out"));
+
+  ModelProto round3 = ConvReluModel();
+  for (NodeProto& n : *round3.mutable_graph()->mutable_node()) {
+    if (n.op_type() == "Conv") *n.add_attribute() = IntsAttr("strides", {2, 2});
+  }
+  inferer.Run(round3);
+  CHECK(inferer.CacheSize() == size_after_round1 + 2);  // strided Conv + Relu-on-new-input-shape
+
+  ModelProto reference3 = ConvReluModel();
+  for (NodeProto& n : *reference3.mutable_graph()->mutable_node()) {
+    if (n.op_type() == "Conv") *n.add_attribute() = IntsAttr("strides", {2, 2});
+  }
+  onnx::shape_inference::InferShapes(reference3);
+  CHECK(TypesEqual(round3, reference3, "conv_out"));
+  const TypeProto* conv_out = FindType(round3, "conv_out");
+  CHECK(conv_out != nullptr);
+  if (conv_out) {
+    // stride 2, 3x3 kernel, no padding, 8x8 input -> floor((8-3)/2)+1 = 3.
+    CHECK(conv_out->tensor_type().shape().dim(2).dim_value() == 3);
+    CHECK(conv_out->tensor_type().shape().dim(3).dim_value() == 3);
+  }
+}
+
+}  // namespace
+
+int main() {
+  TestConvReluMatchesReference();
+  TestLargeWeightBypassesCache();
+  TestReshapeViaConstant();
+  TestReshapeViaInitializer();
+  TestUnsupportedOpLeavesTypeUnset();
+  TestCacheReuseAndInvalidationBySignature();
+
+  if (g_failures == 0) {
+    std::cout << "incremental_shape_infer_test: all checks passed\n";
+    return 0;
+  }
+  std::cerr << "incremental_shape_infer_test: " << g_failures << " check(s) failed\n";
+  return 1;
+}

--- a/onnxsim/incremental_shape_infer_test.cpp
+++ b/onnxsim/incremental_shape_infer_test.cpp
@@ -54,7 +54,8 @@ ValueInfoProto UntypedValueInfo(const std::string& name) {
   return vi;
 }
 
-NodeProto Node(std::string op_type, std::vector<std::string> inputs, std::vector<std::string> outputs) {
+NodeProto Node(std::string op_type, std::vector<std::string> inputs,
+               std::vector<std::string> outputs) {
   NodeProto n;
   n.set_op_type(std::move(op_type));
   for (auto& i : inputs) n.add_input(i);
@@ -106,7 +107,8 @@ const TypeProto* FindType(const ModelProto& m, const std::string& name) {
   return nullptr;
 }
 
-bool TypesEqual(const ModelProto& a, const ModelProto& b, const std::string& name) {
+bool TypesEqual(const ModelProto& a, const ModelProto& b,
+                const std::string& name) {
   const TypeProto* ta = FindType(a, name);
   const TypeProto* tb = FindType(b, name);
   if (!ta || !tb) return ta == tb;  // both-absent counts as equal
@@ -114,19 +116,21 @@ bool TypesEqual(const ModelProto& a, const ModelProto& b, const std::string& nam
 }
 
 int g_failures = 0;
-#define CHECK(cond)                                                                \
-  do {                                                                             \
-    if (!(cond)) {                                                                 \
-      std::cerr << "CHECK failed at " << __FILE__ << ":" << __LINE__ << ": " << #cond << "\n"; \
-      ++g_failures;                                                                \
-    }                                                                              \
+#define CHECK(cond)                                                          \
+  do {                                                                       \
+    if (!(cond)) {                                                           \
+      std::cerr << "CHECK failed at " << __FILE__ << ":" << __LINE__ << ": " \
+                << #cond << "\n";                                            \
+      ++g_failures;                                                          \
+    }                                                                        \
   } while (0)
 
 // A [1,3,8,8] input through Conv(W: [4,3,3,3]) -> Relu, output untyped.
 ModelProto ConvReluModel() {
   ModelProto m = BaseModel();
   GraphProto* g = m.mutable_graph();
-  *g->add_input() = ValueInfo("X", TensorType(TensorProto::FLOAT, {1, 3, 8, 8}));
+  *g->add_input() =
+      ValueInfo("X", TensorType(TensorProto::FLOAT, {1, 3, 8, 8}));
   *g->add_initializer() = [] {
     TensorProto w;
     w.set_name("W");
@@ -226,12 +230,14 @@ void TestReshapeViaInitializer() {
 void TestLargeWeightBypassesCache() {
   ModelProto m = BaseModel();
   GraphProto* g = m.mutable_graph();
-  *g->add_input() = ValueInfo("X", TensorType(TensorProto::FLOAT, {1, 3, 40, 40}));
+  *g->add_input() =
+      ValueInfo("X", TensorType(TensorProto::FLOAT, {1, 3, 40, 40}));
   *g->add_initializer() = [] {
     TensorProto w;
     w.set_name("W");
     w.set_data_type(TensorProto::FLOAT);
-    for (int64_t d : {8, 3, 20, 20}) w.add_dims(d);  // 8*3*20*20*4B ~= 38KB, well over 4KB
+    for (int64_t d : {8, 3, 20, 20})
+      w.add_dims(d);  // 8*3*20*20*4B ~= 38KB, well over 4KB
     for (int i = 0; i < 8 * 3 * 20 * 20; ++i) w.add_float_data(0.f);
     return w;
   }();
@@ -246,7 +252,8 @@ void TestLargeWeightBypassesCache() {
 
   CHECK(TypesEqual(m, reference, "conv_out"));
   CHECK(TypesEqual(m, reference, "relu_out"));
-  CHECK(inferer.CacheSize() == 1);  // Relu only; Conv's large weight bypassed caching
+  CHECK(inferer.CacheSize() ==
+        1);  // Relu only; Conv's large weight bypassed caching
 }
 
 // An op with no registered schema: both the driver and the real onnx
@@ -305,7 +312,8 @@ void TestCacheReuseAndInvalidationBySignature() {
     if (n.op_type() == "Conv") *n.add_attribute() = IntsAttr("strides", {2, 2});
   }
   inferer.Run(round3);
-  CHECK(inferer.CacheSize() == size_after_round1 + 2);  // strided Conv + Relu-on-new-input-shape
+  CHECK(inferer.CacheSize() ==
+        size_after_round1 + 2);  // strided Conv + Relu-on-new-input-shape
 
   ModelProto reference3 = ConvReluModel();
   for (NodeProto& n : *reference3.mutable_graph()->mutable_node()) {
@@ -336,6 +344,7 @@ int main() {
     std::cout << "incremental_shape_infer_test: all checks passed\n";
     return 0;
   }
-  std::cerr << "incremental_shape_infer_test: " << g_failures << " check(s) failed\n";
+  std::cerr << "incremental_shape_infer_test: " << g_failures
+            << " check(s) failed\n";
   return 1;
 }

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -2092,14 +2092,17 @@ onnx::ModelProto Simplify(
   // It falls back to the exact, full ``onnx::shape_inference::InferShapes``
   // for the rare graphs it doesn't model (control-flow ops, model-local
   // functions, sparse initializers -- see incremental_shape_infer.h), so this
-  // is a performance-only change; ``ONNXSIM_DISABLE_INCREMENTAL_SHAPE_INFERENCE``
-  // reverts to always calling the full driver, for bisecting a regression.
+  // is a performance-only change;
+  // ``ONNXSIM_DISABLE_INCREMENTAL_SHAPE_INFERENCE`` reverts to always calling
+  // the full driver, for bisecting a regression.
   ModelFn InferShapes;
   if (shape_inference) {
     bool disable_incremental = false;
-    if (const char* env = std::getenv("ONNXSIM_DISABLE_INCREMENTAL_SHAPE_INFERENCE")) {
+    if (const char* env =
+            std::getenv("ONNXSIM_DISABLE_INCREMENTAL_SHAPE_INFERENCE")) {
       std::string v = env;
-      disable_incremental = !v.empty() && v != "0" && v != "false" && v != "off" && v != "no";
+      disable_incremental =
+          !v.empty() && v != "0" && v != "false" && v != "off" && v != "no";
     }
     if (disable_incremental) {
       InferShapes = _InferShapes;

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <fstream>
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <numeric>
 #include <set>
@@ -33,6 +34,7 @@
 #include "contrib_schemas.h"
 #include "custom_optimizer_passes.h"
 #include "dlpack_bridge.h"
+#include "incremental_shape_infer.h"
 #include "onnx/common/file_utils.h"
 #include "onnx/defs/printer.h"
 #include "onnx/defs/schema.h"
@@ -2083,7 +2085,31 @@ onnx::ModelProto Simplify(
   } else {
     FoldConstant = Identity;
   }
-  ModelFn InferShapes = shape_inference ? _InferShapes : Identity;
+  // The incremental driver (issue: partial per-node shape inference) caches
+  // each node's inferred type keyed by its op/attributes/input types/input
+  // values, so an unchanged node across fixed-point rounds is a hash-map
+  // lookup instead of a re-invocation of the operator's inference function.
+  // It falls back to the exact, full ``onnx::shape_inference::InferShapes``
+  // for the rare graphs it doesn't model (control-flow ops, model-local
+  // functions, sparse initializers -- see incremental_shape_infer.h), so this
+  // is a performance-only change; ``ONNXSIM_DISABLE_INCREMENTAL_SHAPE_INFERENCE``
+  // reverts to always calling the full driver, for bisecting a regression.
+  ModelFn InferShapes;
+  if (shape_inference) {
+    bool disable_incremental = false;
+    if (const char* env = std::getenv("ONNXSIM_DISABLE_INCREMENTAL_SHAPE_INFERENCE")) {
+      std::string v = env;
+      disable_incremental = !v.empty() && v != "0" && v != "false" && v != "off" && v != "no";
+    }
+    if (disable_incremental) {
+      InferShapes = _InferShapes;
+    } else {
+      auto inferer = std::make_shared<onnxsim::IncrementalShapeInferer>();
+      InferShapes = [inferer](onnx::ModelProto& model) { inferer->Run(model); };
+    }
+  } else {
+    InferShapes = Identity;
+  }
   // ``Optimize`` builds a fresh model (``OptimizeFixed`` returns a new proto),
   // so wrap it as an in-place transform that move-assigns the result back.
   // ``perform_optimization=False`` (skip_optimizers == nullopt) means the


### PR DESCRIPTION
## Summary

Introduces `IncrementalShapeInferer`, a memoized shape inference driver that caches per-node inference results across fixed-point simplification rounds. This significantly speeds up the typical case where most of the graph is unchanged between rounds, while maintaining full correctness by falling back to the exact ONNX shape inference for unsupported graph patterns.

## Key Changes

- **New `IncrementalShapeInferer` class** (`incremental_shape_infer.h/cpp`):
  - Memoizes node inference results keyed by node signature (op type, domain, version, attributes, input types, and small constant values)
  - Reuses cached results when a node's signature hasn't changed across fixed-point rounds
  - Falls back to `onnx::shape_inference::InferShapes` for graphs with control-flow ops, model-local functions, sparse initializers, or function-body-defined schemas
  - Handles Constant node value tracking (both tensor values and INT/INTS/FLOAT/FLOATS attributes) to support shape-computing ops like Reshape, Squeeze, and Unsqueeze
  - Excludes large tensor values (>4KB) from cache keys to avoid serialization overhead for weights that inference functions don't actually read

- **Integration into `Simplify()` loop** (`onnxsim.cpp`):
  - Replaces direct `onnx::shape_inference::InferShapes` calls with `IncrementalShapeInferer` when shape inference is enabled
  - Reuses the same inferer instance across all fixed-point rounds to accumulate cache hits
  - Adds `ONNXSIM_DISABLE_INCREMENTAL_SHAPE_INFERENCE` environment variable for regression bisection

- **Build system** (`CMakeLists.txt`):
  - Adds `incremental_shape_infer.cpp` to the onnxsim library

- **Comprehensive test suite** (`incremental_shape_infer_test.cpp`):
  - Validates correctness by cross-checking results against the exact ONNX driver on every test case
  - Tests Conv/Relu chains, Reshape via Constant and initializer, large weight bypass, unsupported ops, and cache reuse/invalidation by signature

## Implementation Details

- Cache keys use length-prefixed string serialization to ensure unambiguous equality without parsing
- Symbolic shapes are materialized per point of use to avoid incorrectly merging unresolved dimensions across different graph positions
- Undefined value types are tracked identically to ONNX's own driver to ensure identical serialization of partially-inferred models
- The fast path is transparent: identical results to the full ONNX driver, with fallback for any unsupported pattern

https://claude.ai/code/session_01YJiugYfSrXTzcvP9HSbb8u