### PR TITLE
Use onnx::Symbol instead of std::string in SymExpr

### DIFF
--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -331,7 +331,8 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
           for (const auto& [monomial, coeff] : expr.terms()) {
             std::vector<std::string> names;
             names.reserve(monomial.size());
-            for (const onnx::Symbol& s : monomial) names.emplace_back(s.toString());
+            for (const onnx::Symbol& s : monomial)
+              names.emplace_back(s.toString());
             poly.emplace_back(coeff, std::move(names));
           }
           return poly;

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -327,7 +327,7 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
                                   model_bytes.size());
         const ModelInfo info = GetModelInfo(model, run_shape_inference);
         auto to_poly = [](const onnxsim::SymExpr& expr) {
-          std::vector<std::pair<int64_t, std::vector<std::string>>> poly;
+          std::vector<std::pair<int64_t, std::vector<onnx::Symbol>>> poly;
           for (const auto& [monomial, coeff] : expr.terms()) {
             poly.emplace_back(coeff, monomial);
           }

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -327,9 +327,12 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
                                   model_bytes.size());
         const ModelInfo info = GetModelInfo(model, run_shape_inference);
         auto to_poly = [](const onnxsim::SymExpr& expr) {
-          std::vector<std::pair<int64_t, std::vector<onnx::Symbol>>> poly;
+          std::vector<std::pair<int64_t, std::vector<std::string>>> poly;
           for (const auto& [monomial, coeff] : expr.terms()) {
-            poly.emplace_back(coeff, monomial);
+            std::vector<std::string> names;
+            names.reserve(monomial.size());
+            for (const onnx::Symbol& s : monomial) names.emplace_back(s.toString());
+            poly.emplace_back(coeff, std::move(names));
           }
           return poly;
         };

--- a/onnxsim/sym_expr.cpp
+++ b/onnxsim/sym_expr.cpp
@@ -19,14 +19,14 @@ std::int64_t gcd_i(std::int64_t a, std::int64_t b) {
   return a;
 }
 
-// Per-symbol powers of a monomial: {"batch","seq","seq"} -> {batch:1, seq:2}.
-std::map<std::string, std::size_t> powers_of(const Monomial& mono) {
-  std::map<std::string, std::size_t> c;
-  for (const std::string& s : mono) ++c[s];
+// Per-symbol powers of a monomial: {batch,seq,seq} -> {batch:1, seq:2}.
+std::map<onnx::Symbol, std::size_t> powers_of(const Monomial& mono) {
+  std::map<onnx::Symbol, std::size_t> c;
+  for (const onnx::Symbol& s : mono) ++c[s];
   return c;
 }
 
-// "batch*seq**2" for {"batch","seq","seq"}; "" for the empty (constant) mono.
+// "batch*seq**2" for {batch,seq,seq}; "" for the empty (constant) mono.
 std::string monomial_str(const Monomial& mono) {
   std::string out;
   for (std::size_t i = 0; i < mono.size();) {
@@ -34,7 +34,7 @@ std::string monomial_str(const Monomial& mono) {
     while (j < mono.size() && mono[j] == mono[i]) ++j;
     const std::size_t power = j - i;
     if (!out.empty()) out += "*";
-    out += mono[i];
+    out += mono[i].toString();
     if (power > 1) out += "**" + std::to_string(power);
     i = j;
   }
@@ -78,7 +78,7 @@ std::string join_terms(const std::map<Monomial, std::int64_t>& terms) {
 // and the minimum power of each symbol present in *every* term.
 struct CommonFactor {
   std::int64_t content = 0;  // gcd of |coeff|; 0 only if there are no terms
-  std::map<std::string, std::size_t> monomial;
+  std::map<onnx::Symbol, std::size_t> monomial;
 };
 
 CommonFactor common_factor(std::initializer_list<const SymExpr*> exprs) {

--- a/onnxsim/sym_expr.h
+++ b/onnxsim/sym_expr.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <onnx/common/interned_strings.h>
+
 #include <algorithm>
 #include <cstdint>
 #include <iterator>
@@ -7,8 +9,6 @@
 #include <optional>
 #include <string>
 #include <vector>
-
-#include <onnx/common/interned_strings.h>
 
 namespace onnxsim {
 

--- a/onnxsim/sym_expr.h
+++ b/onnxsim/sym_expr.h
@@ -8,6 +8,8 @@
 #include <string>
 #include <vector>
 
+#include <onnx/common/interned_strings.h>
+
 namespace onnxsim {
 
 // A polynomial in dimension symbols ("batch", "seq", ...) with int64
@@ -16,9 +18,12 @@ namespace onnxsim {
 // dimensions, so they are exactly integer-coefficient polynomials in the
 // dim_param names.
 //
-// Pure standard C++ with no external dependency, so it builds unchanged under
-// Emscripten/WASM -- where SymEngine (which needs GMP, or an experimental
-// boost-multiprecision build) is not practically available.
+// Symbol names are stored as onnx::Symbol: an interned string from ONNX's C++
+// API (already a build dependency). Interning makes symbol equality and
+// ordering a cheap uint32 comparison, and there is no separate heap-allocated
+// std::string per occurrence. The type builds unchanged under Emscripten/WASM
+// -- where SymEngine (which needs GMP, or an experimental boost-multiprecision
+// build) is not practically available.
 //
 // Maps onto the sympy calls in onnxsim/model_info.py:
 //   sympy.Symbol(name, positive=True, integer=True) -> SymExpr::Symbol(name)
@@ -32,9 +37,9 @@ class SymExpr {
  public:
   // A monomial is the sorted multiset of symbol names in one product term:
   //   {}                    -> 1                (the constant term)
-  //   {"batch"}             -> batch
-  //   {"batch","seq","seq"} -> batch*seq**2
-  using Monomial = std::vector<std::string>;
+  //   {batch}               -> batch
+  //   {batch,seq,seq}       -> batch*seq**2
+  using Monomial = std::vector<onnx::Symbol>;
 
   SymExpr() = default;
   // Implicit so `SymExpr(512) * batch` and `expr * 2` read naturally, mirroring
@@ -44,6 +49,10 @@ class SymExpr {
   }
 
   static SymExpr Symbol(const std::string& name) {
+    return Symbol(onnx::Symbol(name));
+  }
+
+  static SymExpr Symbol(onnx::Symbol name) {
     SymExpr e;
     e.terms_[Monomial{name}] = 1;
     return e;


### PR DESCRIPTION
Store dimension symbol names as onnx::Symbol (an interned string from ONNX's C++ API) rather than std::string. Interning makes symbol equality and ordering a cheap uint32 comparison and avoids a heap-allocated std::string per occurrence.