### PR TITLE
Add nncase integration test

### DIFF
--- a/.github/workflows/nncase-integration.yml
+++ b/.github/workflows/nncase-integration.yml
@@ -1,0 +1,105 @@
+name: nncase Integration
+
+# End-to-end regression test that feeds onnxsim's simplified output into nncase
+# (tests/test_nncase_integration.py). nncase is the model compiler for the
+# Kendryte K230 / K510 processors (and a generic cpu target); it imports an
+# ONNX ModelProto directly, compiles it, and can evaluate the compiled module,
+# so it is a genuine, independent ONNX backend we use to confirm simplification
+# is semantics-preserving outside of onnxruntime. Every op the test models use
+# is drawn from nncase's supported-ops list
+# (https://github.com/kendryte/nncase/blob/master/docs/onnx_ops.md).
+#
+# nncase is a .NET application (it bundles Nncase.Compiler.dll and needs the
+# .NET 7.0 runtime) and is not part of onnxsim's test requirements, so this
+# runs in its own workflow instead of the build-and-test matrix. Runs on PRs
+# that touch the harness or the simplifier, on a daily schedule to catch new
+# nncase releases, and on demand.
+
+on:
+  schedule:
+    - cron: "0 7 * * *" # Daily 07:00 UTC
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "tests/test_nncase_integration.py"
+      - ".github/workflows/nncase-integration.yml"
+      - "onnxsim/onnx_simplifier.py"
+      - "onnxsim/onnxsim.cpp"
+
+concurrency:
+  group: nncase-integration-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Build onnxsim once from the current tree, exactly like the model-regression
+  # workflow, and hand the wheel to the test job so it exercises this branch's
+  # code rather than a PyPI release.
+  build:
+    name: Build onnxsim wheel
+    runs-on: ubuntu-24.04
+    env:
+      SCCACHE_GHA_ENABLED: "on"
+      ACTIONS_CACHE_SERVICE_V2: "on"
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - uses: mozilla-actions/sccache-action@v0.0.11
+      - name: Build cp312 wheel
+        uses: pypa/cibuildwheel@v4.2.0
+        env:
+          CIBW_BUILD: "cp312-manylinux_x86_64"
+          CIBW_ARCHS: native
+          CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_ENVIRONMENT_PASS_LINUX: CI SCCACHE_GHA_ENABLED ACTIONS_RESULTS_URL ACTIONS_RUNTIME_TOKEN ACTIONS_CACHE_SERVICE_V2
+          CIBW_BEFORE_BUILD: "python3 -m pip install --break-system-packages cmake ninja setuptools sccache"
+          CIBW_ENVIRONMENT: CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=OFF" CMAKE_GENERATOR=Ninja CMAKE_CXX_COMPILER_LAUNCHER=sccache CMAKE_LINKER_TYPE=LLD
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel} --strip"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: onnxsim-wheel-nncase
+          path: ./wheelhouse/*.whl
+
+  test:
+    name: Simplify and run on nncase
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - uses: actions/download-artifact@v8
+        with:
+          name: onnxsim-wheel-nncase
+          path: wheelhouse
+      # nncase is a .NET application and needs the .NET 7.0 runtime to load
+      # Nncase.Compiler.dll (hostfxr is found via DOTNET_ROOT).
+      - name: Install .NET 7.0 runtime
+        run: |
+          curl -sSL https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
+          chmod +x dotnet-install.sh
+          ./dotnet-install.sh --runtime dotnet --channel 7.0 --install-dir "$HOME/.dotnet"
+          echo "DOTNET_ROOT=$HOME/.dotnet" >> "$GITHUB_ENV"
+          echo "$HOME/.dotnet" >> "$GITHUB_PATH"
+      - name: Install onnxsim wheel + nncase
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest nncase
+          python -m pip install wheelhouse/*.whl
+      - name: Verify the installed wheel is used (not the source tree)
+        working-directory: ${{ runner.temp }}
+        run: |
+          python -c "import onnxsim, onnxsim.onnxsim_cpp2py_export as m; print(onnxsim.__version__, m.__file__)"
+          python -c "import nncase; print('nncase', nncase.__file__)"
+      # Run from a neutral directory so the repo root's ./onnxsim source package
+      # (without the compiled extension) does not shadow the installed wheel.
+      - name: Run nncase integration tests
+        working-directory: ${{ runner.temp }}
+        run: pytest -v "$GITHUB_WORKSPACE/tests/test_nncase_integration.py"

--- a/docs/dlpack-executor.md
+++ b/docs/dlpack-executor.md
@@ -200,6 +200,15 @@ Consequences for the design:
   so the test ships a small ONNX-subset-to-Halide lowering and checks that
   onnxsim's simplified output still lowers, compiles, and computes the same
   result as onnx's reference evaluator.
+- `tests/test_nncase_integration.py` (+ `.github/workflows/nncase-integration.yml`) —
+  the same embeddability claim exercised against
+  [nncase](https://github.com/kendryte/nncase), the model compiler for the
+  Kendryte K230 / K510 processors (and a generic `cpu` target). nncase imports
+  an ONNX `ModelProto` directly, compiles it, and can evaluate the compiled
+  module, so the test feeds onnxsim's simplified output into nncase and checks
+  it still imports, compiles, and computes the same result. Every op the test
+  models use is drawn from nncase's supported-ops list
+  (<https://github.com/kendryte/nncase/blob/master/docs/onnx_ops.md>).
 
 ## Rust binding
 

--- a/tests/test_nncase_integration.py
+++ b/tests/test_nncase_integration.py
@@ -1,0 +1,253 @@
+"""nncase integration test.
+
+nncase <https://github.com/kendryte/nncase>`_ is a model compiler for the
+Kendryte K230 / K510 application processors (and a generic ``cpu`` target). It
+imports an ONNX ``ModelProto`` directly, compiles it to a chosen target, and can
+evaluate the compiled module on the host -- so it is a genuine, independent ONNX
+backend we can use to double check that onnxsim's simplifications are
+semantics-preserving outside of onnxruntime.
+
+nncase's supported ONNX ops are listed in
+``https://github.com/kendryte/nncase/blob/master/docs/onnx_ops.md``. Every op
+used by the models below is taken from that supported set (Conv,
+BatchNormalization, Relu, Transpose, Shape, Gather, Concat, Reshape, ...).
+
+This module feeds onnxsim's simplified output into nncase and checks two things:
+
+1. Simplification must not make a graph *harder* to compile: whatever nncase
+   accepted before simplification, it must still accept after.
+2. Simplification must not change what nncase computes: the original and
+   simplified graphs must agree numerically on nncase's own compiler/evaluator.
+
+A third, more interesting case is also covered: the classic
+``Shape -> Gather -> Concat -> Reshape`` chain that ships fully-constant
+dimensions. onnxsim constant-folds the whole chain into a literal ``Reshape``
+target shape, which nncase ingests fine and which keeps the graph from carrying
+a runtime-computed shape that a fixed-shape compiler would rather not see.
+
+nncase is a .NET application (it bundles ``Nncase.Compiler.dll`` and needs the
+.NET runtime) and is not part of onnxsim's test requirements, so the whole
+module is skipped when it is not installed. The dedicated
+``nncase-integration`` CI workflow installs it and runs these tests; the regular
+build-and-test matrix skips them.
+"""
+
+import numpy as np
+import onnx
+import pytest
+from onnx import TensorProto, helper, numpy_helper
+
+nncase = pytest.importorskip("nncase", reason="nncase is not installed")
+from nncase import CompileOptions, Compiler, ImportOptions, RuntimeTensor  # noqa: E402
+
+import onnxsim  # noqa: E402  (imported after the nncase availability check)
+
+_OPSET = 17
+_IR_VERSION = 8
+
+
+def _model(nodes, inputs, outputs, initializers, name) -> onnx.ModelProto:
+    graph = helper.make_graph(nodes, name, inputs, outputs, initializers)
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", _OPSET)])
+    model.ir_version = _IR_VERSION
+    onnx.checker.check_model(model)
+    return model
+
+
+def _rand(*shape, seed=0) -> np.ndarray:
+    return np.random.RandomState(seed).randn(*shape).astype(np.float32)
+
+
+def _conv_bn_relu() -> onnx.ModelProto:
+    """Conv -> BatchNormalization -> Relu: onnxsim folds BN into the Conv."""
+    w = numpy_helper.from_array(_rand(8, 3, 3, 3, seed=1), "w")
+    scale = numpy_helper.from_array(_rand(8, seed=2), "scale")
+    shift = numpy_helper.from_array(_rand(8, seed=3), "shift")
+    mean = numpy_helper.from_array(_rand(8, seed=4), "mean")
+    var = numpy_helper.from_array(np.abs(_rand(8, seed=5)) + 1.0, "var")
+    nodes = [
+        helper.make_node("Conv", ["x", "w"], ["c"], pads=[1, 1, 1, 1]),
+        helper.make_node(
+            "BatchNormalization", ["c", "scale", "shift", "mean", "var"], ["bn"]
+        ),
+        helper.make_node("Relu", ["bn"], ["y"]),
+    ]
+    return _model(
+        nodes,
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3, 8, 8])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 8, 8, 8])],
+        [w, scale, shift, mean, var],
+        "conv_bn_relu",
+    )
+
+
+def _redundant_transpose() -> onnx.ModelProto:
+    """An identity Transpose (perm=[0,1,2,3]) that onnxsim removes outright."""
+    w = numpy_helper.from_array(_rand(8, 3, 3, 3, seed=1), "w")
+    nodes = [
+        helper.make_node("Transpose", ["x"], ["t"], perm=[0, 1, 2, 3]),
+        helper.make_node("Conv", ["t", "w"], ["c"], pads=[1, 1, 1, 1]),
+        helper.make_node("Relu", ["c"], ["y"]),
+    ]
+    return _model(
+        nodes,
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3, 8, 8])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 8, 8, 8])],
+        [w],
+        "redundant_transpose",
+    )
+
+
+def _foldable_shape_reshape() -> onnx.ModelProto:
+    """Shape -> Gather -> Concat -> Reshape, fully determined by constants.
+
+    onnxsim folds the whole chain into the ``Reshape``'s literal target shape,
+    which nncase ingests cleanly and keeps a fixed-shape compiler from having to
+    materialize a runtime-computed shape.
+    """
+    w = numpy_helper.from_array(_rand(8, 3, 3, 3, seed=1), "w")
+    idx = numpy_helper.from_array(np.array([0], np.int64), "idx")
+    minus1 = numpy_helper.from_array(np.array([-1], np.int64), "m1")
+    ch = numpy_helper.from_array(np.array([8], np.int64), "ch")
+    nodes = [
+        helper.make_node("Conv", ["x", "w"], ["c"], pads=[1, 1, 1, 1]),
+        helper.make_node("Relu", ["c"], ["r"]),
+        helper.make_node("Shape", ["r"], ["shp"]),
+        helper.make_node("Gather", ["shp", "idx"], ["n"], axis=0),
+        helper.make_node("Concat", ["n", "ch", "m1"], ["newshape"], axis=0),
+        helper.make_node("Reshape", ["r", "newshape"], ["y"]),
+    ]
+    return _model(
+        nodes,
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3, 8, 8])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 8, 64])],
+        [w, idx, minus1, ch],
+        "foldable_shape_reshape",
+    )
+
+
+_MODELS = {
+    "conv_bn_relu": _conv_bn_relu,
+    "redundant_transpose": _redundant_transpose,
+    "foldable_shape_reshape": _foldable_shape_reshape,
+}
+
+
+def _random_feeds(model: onnx.ModelProto, seed: int = 0):
+    """Deterministic random float32 input for every non-initializer graph input."""
+    rng = np.random.RandomState(seed)
+    initializer_names = {init.name for init in model.graph.initializer}
+    feeds = {}
+    for inp in model.graph.input:
+        if inp.name in initializer_names:
+            continue
+        shape = [d.dim_value for d in inp.type.tensor_type.shape.dim]
+        feeds[inp.name] = (rng.rand(*shape).astype(np.float32) - 0.5) * 2.0
+    return feeds
+
+
+def _compile_and_run_with_nncase(model: onnx.ModelProto, feeds):
+    """Import ``model`` into nncase, compile for the cpu target, and evaluate it."""
+    compile_options = CompileOptions()
+    compile_options.target = "cpu"
+    # These dumps only write files; turn them off so the test leaves no clutter.
+    compile_options.dump_asm = False
+    compile_options.dump_ir = False
+
+    compiler = Compiler(compile_options)
+    compiler.import_onnx(model.SerializeToString(), ImportOptions())
+    compiler.compile()
+
+    evaluator = compiler.create_evaluator(0)
+    initializer_names = {init.name for init in model.graph.initializer}
+    input_names = [
+        inp.name for inp in model.graph.input if inp.name not in initializer_names
+    ]
+    for i, name in enumerate(input_names):
+        evaluator.set_input_tensor(i, RuntimeTensor.from_numpy(feeds[name]))
+    evaluator.run()
+
+    return [
+        evaluator.get_output_tensor(i).to_numpy() for i in range(evaluator.outputs_size)
+    ]
+
+
+@pytest.mark.parametrize("name", sorted(_MODELS))
+def test_simplified_model_compiles_and_runs_on_nncase(name):
+    """The simplified graph must always import, compile, and run on nncase."""
+    model = _MODELS[name]()
+    simplified, check_ok = onnxsim.simplify(model)
+    assert check_ok
+
+    feeds = _random_feeds(model, seed=0)
+    simplified_out = _compile_and_run_with_nncase(simplified, feeds)
+
+    # Whatever nncase did with the original graph, it must still accept the
+    # simplified one -- and if it also accepted the original, the two must
+    # agree numerically (simplification must be semantics-preserving on nncase).
+    try:
+        original_out = _compile_and_run_with_nncase(model, feeds)
+    except Exception:
+        return
+    for orig, simp in zip(original_out, simplified_out):
+        np.testing.assert_allclose(orig, simp, rtol=1e-3, atol=1e-4)
+
+
+def test_simplify_is_bit_exact_on_nncase():
+    """Removing a redundant (identity) Transpose must not change the nncase result.
+
+    onnxsim removes the ``Transpose`` node entirely, so the simplified graph is
+    exactly the same arithmetic the original compiled to -- nncase's output must
+    be bit-identical.
+    """
+    model = _redundant_transpose()
+    simplified, check_ok = onnxsim.simplify(model)
+    assert check_ok
+    assert len(simplified.graph.node) < len(model.graph.node)
+
+    feeds = _random_feeds(model, seed=1)
+    original_out = _compile_and_run_with_nncase(model, feeds)
+    simplified_out = _compile_and_run_with_nncase(simplified, feeds)
+    for orig, simp in zip(original_out, simplified_out):
+        np.testing.assert_array_equal(orig, simp)
+
+
+def test_nncase_output_matches_onnx_reference():
+    """The nncase result for a simplified model must match onnx's reference evaluator."""
+    model = _conv_bn_relu()
+    simplified, check_ok = onnxsim.simplify(model)
+    assert check_ok
+
+    feeds = _random_feeds(model, seed=2)
+    nncase_out = _compile_and_run_with_nncase(simplified, feeds)
+
+    from onnx.reference import ReferenceEvaluator
+
+    evaluator = ReferenceEvaluator(simplified)
+    reference_out = evaluator.run(None, feeds)
+    for ref, cand in zip(reference_out, nncase_out):
+        np.testing.assert_allclose(ref, cand, rtol=1e-3, atol=1e-4)
+
+
+def test_simplify_constant_folds_shape_reshape_chain():
+    """Regression guard for the constant-fold-Shapes-into-Reshape case.
+
+    onnxsim must collapse the ``Shape -> Gather -> Concat -> Reshape`` chain
+    into a literal ``Reshape`` target so a fixed-shape compiler like nncase
+    ingests it cleanly.
+    """
+    model = _foldable_shape_reshape()
+    simplified, check_ok = onnxsim.simplify(model)
+    assert check_ok
+    # The whole Shape/Gather/Concat chain collapses into the Reshape's target.
+    assert len(simplified.graph.node) < len(model.graph.node)
+
+    feeds = _random_feeds(model, seed=3)
+    simplified_out = _compile_and_run_with_nncase(simplified, feeds)
+
+    # The simplified graph must match the original nncase computation. Even if a
+    # future nncase release ingests the unfolded chain too, the simplified graph
+    # must still be numerically equivalent to the original.
+    original_out = _compile_and_run_with_nncase(model, feeds)
+    for orig, simp in zip(original_out, simplified_out):
+        np.testing.assert_allclose(orig, simp, rtol=1e-3, atol=1e-4)


### PR DESCRIPTION
Feed onnxsim's simplified output into nncase's real ONNX importer + cpu evaluator and check that simplification stays semantics-preserving outside of onnxruntime. Models use only ops from nncase's supported-ops set (https://github.com/kendryte/nncase/blob/master/docs/onnx_ops.md). A dedicated CI workflow installs nncase plus the .NET 7.0 runtime it needs.