### PR TITLE
Bump third_party/onnx from onnxsim/onnx fork to official onnx/onnx

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/onnxsim/optimizer.git
 [submodule "third_party/onnx"]
 	path = third_party/onnx
-	url = https://github.com/onnxsim/onnx.git
+	url = https://github.com/onnx/onnx.git


### PR DESCRIPTION
## Summary

The `third_party/onnx` submodule previously tracked the `onnxsim/onnx` fork. This switches it to the upstream `https://github.com/onnx/onnx` repository.

The performance optimizations the fork carried (O(1) `Graph::isNameUnique()`, non-allocating subgraph walk in `forSelfAndEachSubGraphImpl`) have since been upstreamed as onnx PR [onnx/onnx#8310](https://github.com/onnx/onnx/pull/8310), so no local patches are needed. The submodule now points at upstream `main` (`bde53407`), which already contains them.

- `.gitmodules`: `third_party/onnx` URL -> `https://github.com/onnx/onnx.git`
- Submodule pointer moved from fork commit `a2ef58c` to upstream `bde5340`

The build consumes the top-level `third_party/onnx` target (`CMakeLists.txt:122`); onnx-optimizer's nested copy is skipped via `add_subdirectory_if_no_target()`, so this is the onnx that actually gets compiled.

## Note

The nested `third_party/onnx-optimizer/third_party/onnx` (owned by the `onnxsim/optimizer` fork) still references the fork. It is only a fallback and is never compiled (the top-level target wins), but bumping it cleanly would require a separate update to the `onnxsim/optimizer` fork. Left as a follow-up.

## Test plan

- [ ] C++ / WASM build still configures and compiles against upstream onnx
- [ ] onnxsim simplification output unchanged (round-trip correctness)