### PR TITLE
Add Apple CoreML and Intel OpenVINO integration checks

### DIFF
--- a/.github/workflows/amd-integration.yml
+++ b/.github/workflows/amd-integration.yml
@@ -1,0 +1,65 @@
+name: AMD Integration
+
+# Compiles and runs onnxsim's output through AMD's MIGraphX execution
+# provider to catch simplifications that break the MIGraphX toolchain, or
+# whose on-device result changed.
+#
+# Unlike apple-integration.yml / intel-integration.yml, this workflow is
+# workflow_dispatch-ONLY and targets a [self-hosted, rocm] runner label that
+# this repository does not currently provision. MIGraphX has no CPU fallback
+# or host emulator (see scripts/amd/README.md) -- there is no way to exercise
+# it on a stock GitHub-hosted runner, so wiring this into `schedule` or
+# `pull_request` like the Apple/Intel checks would just queue forever with no
+# matching runner. Point it at your own ROCm-equipped self-hosted runner and
+# trigger it manually; until then it's dormant.
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: amd-integration-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  migraphx-compat:
+    name: MIGraphX compatibility check
+    # Requires a self-hosted runner with a ROCm-capable AMD GPU and the ROCm
+    # stack installed, labeled "rocm". Not provided by this repository.
+    runs-on: [self-hosted, rocm]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Install onnxsim + onnxruntime-migraphx
+        run: |
+          python3 -m pip install --upgrade pip
+          # onnxruntime-migraphx replaces plain onnxruntime (bundles its own EP).
+          python3 -m pip install onnxruntime-migraphx
+          python3 -m pip install .
+      # Run from runner.temp, not the checkout: the repo root contains the
+      # `onnxsim/` source dir (no compiled extension), which would shadow the
+      # installed wheel on `import onnxsim`. Reference the harness by absolute
+      # $GITHUB_WORKSPACE path. Same guard the QNN/Core ML/OpenVINO workflows use.
+      - name: Show environment
+        working-directory: ${{ runner.temp }}
+        run: |
+          python3 -c "import onnxsim, onnxruntime as ort; print('onnxsim', onnxsim.__version__); print('onnxruntime', ort.__version__); print('providers', ort.get_available_providers())"
+      - name: Run MIGraphX compatibility check
+        working-directory: ${{ runner.temp }}
+        run: |
+          python3 "$GITHUB_WORKSPACE/scripts/amd/run_migraphx_compat.py" \
+            --require-migraphx \
+            --output migraphx-compat.csv
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: migraphx-compat-report
+          path: ${{ runner.temp }}/migraphx-compat.csv
+          if-no-files-found: ignore

--- a/.github/workflows/apple-integration.yml
+++ b/.github/workflows/apple-integration.yml
@@ -48,17 +48,23 @@ jobs:
           # The macOS onnxruntime wheel bundles the Core ML EP.
           python3 -m pip install onnxruntime
           python3 -m pip install .
+      # Run from runner.temp, not the checkout: the repo root contains the
+      # `onnxsim/` source dir (no compiled extension), which would shadow the
+      # installed wheel on `import onnxsim`. Reference the harness by absolute
+      # $GITHUB_WORKSPACE path. Same guard the QNN/OpenVINO workflows use.
       - name: Show environment
+        working-directory: ${{ runner.temp }}
         run: |
           python3 -c "import onnxsim, onnxruntime as ort; print('onnxsim', onnxsim.__version__); print('onnxruntime', ort.__version__); print('providers', ort.get_available_providers())"
       - name: Run Core ML compatibility check
+        working-directory: ${{ runner.temp }}
         run: |
-          python3 scripts/apple/run_coreml_compat.py \
+          python3 "$GITHUB_WORKSPACE/scripts/apple/run_coreml_compat.py" \
             --require-coreml \
             --output coreml-compat.csv
       - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: coreml-compat-report
-          path: coreml-compat.csv
+          path: ${{ runner.temp }}/coreml-compat.csv
           if-no-files-found: ignore

--- a/.github/workflows/apple-integration.yml
+++ b/.github/workflows/apple-integration.yml
@@ -1,0 +1,64 @@
+name: Apple Integration
+
+# Compiles and runs onnxsim's output through Apple's Core ML execution
+# provider to catch simplifications that break the Core ML toolchain, or
+# whose on-device result changed.
+#
+# Runs on a stock macOS GitHub-hosted runner: the CoreMLExecutionProvider is
+# built into the standard `onnxruntime` PyPI wheel's macOS build, so no extra
+# package or device is needed beyond the Mac itself. See
+# scripts/apple/README.md for the fidelity tiers this covers.
+#
+# Scheduled + on demand (like the Qualcomm check), plus on PRs that touch the
+# harness so it stays valid.
+
+on:
+  schedule:
+    - cron: "0 7 * * 1" # Mondays 07:00 UTC (weekly)
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/apple-integration.yml"
+      - "scripts/apple/**"
+      - "scripts/common/**"
+      - "tests/test_coreml_compat.py"
+
+concurrency:
+  group: apple-integration-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  coreml-compat:
+    name: Core ML compatibility check
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Install onnxsim + onnxruntime
+        run: |
+          python3 -m pip install --upgrade pip
+          # The macOS onnxruntime wheel bundles the Core ML EP.
+          python3 -m pip install onnxruntime
+          python3 -m pip install .
+      - name: Show environment
+        run: |
+          python3 -c "import onnxsim, onnxruntime as ort; print('onnxsim', onnxsim.__version__); print('onnxruntime', ort.__version__); print('providers', ort.get_available_providers())"
+      - name: Run Core ML compatibility check
+        run: |
+          python3 scripts/apple/run_coreml_compat.py \
+            --require-coreml \
+            --output coreml-compat.csv
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: coreml-compat-report
+          path: coreml-compat.csv
+          if-no-files-found: ignore

--- a/.github/workflows/intel-integration.yml
+++ b/.github/workflows/intel-integration.yml
@@ -1,17 +1,16 @@
-name: Qualcomm Integration
+name: Intel Integration
 
-# Compiles and runs onnxsim's output through the Qualcomm AI Runtime (QNN)
-# execution provider to catch simplifications that break the Qualcomm toolchain
-# (SNPE / QAIRT) — a graph the QNN converter can no longer compile, or whose
-# on-device result changed.
+# Compiles and runs onnxsim's output through Intel's OpenVINO execution
+# provider to catch simplifications that break the OpenVINO toolchain, or
+# whose on-device result changed.
 #
-# Runs entirely on a stock x86-64 CPU runner: the pip `onnxruntime-qnn` wheel's
-# HTP backend does the full offline graph compile (libHtpPrepare.so) and executes
-# in the x86 emulator, so no Snapdragon device is needed. See
-# scripts/qualcomm/README.md for the fidelity tiers this covers (and the SDK /
-# AI Hub paths for real-hardware numerics).
+# Runs entirely on a stock x86-64 CPU runner: the pip `onnxruntime-openvino`
+# wheel's default CPU device target needs no discrete Intel hardware or
+# driver. See scripts/intel/README.md for the fidelity tiers this covers
+# (and the GPU/NPU device-type override for a host with the matching
+# hardware).
 #
-# Scheduled + on demand (like the model regression), plus on PRs that touch the
+# Scheduled + on demand (like the Qualcomm check), plus on PRs that touch the
 # harness so it stays valid.
 
 on:
@@ -20,21 +19,21 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - ".github/workflows/qualcomm-integration.yml"
-      - "scripts/qualcomm/**"
+      - ".github/workflows/intel-integration.yml"
+      - "scripts/intel/**"
       - "scripts/common/**"
-      - "tests/test_qnn_compat.py"
+      - "tests/test_openvino_compat.py"
 
 concurrency:
-  group: qualcomm-integration-${{ github.ref }}
+  group: intel-integration-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
-  # Build onnxsim once from the current tree, so the QNN check runs against the
-  # actual simplifier in this branch rather than a released wheel.
+  # Build onnxsim once from the current tree, so the OpenVINO check runs
+  # against the actual simplifier in this branch rather than a released wheel.
   build:
     name: Build onnxsim wheel
     runs-on: ubuntu-24.04
@@ -60,11 +59,11 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel} --strip"
       - uses: actions/upload-artifact@v7
         with:
-          name: onnxsim-wheel-qnn
+          name: onnxsim-wheel-openvino
           path: ./wheelhouse/*.whl
 
-  qnn-compat:
-    name: QNN compatibility check
+  openvino-compat:
+    name: OpenVINO compatibility check
     needs: [build]
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -72,36 +71,34 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
         with:
-          # onnxruntime-qnn ships cp311/cp312/cp313 x86-64 Linux wheels.
           python-version: "3.12"
       - uses: actions/download-artifact@v8
         with:
-          name: onnxsim-wheel-qnn
+          name: onnxsim-wheel-openvino
           path: wheelhouse
-      - name: Install onnxsim wheel + onnxruntime-qnn
+      - name: Install onnxsim wheel + onnxruntime-openvino
         run: |
           python -m pip install --upgrade pip
-          # onnxruntime-qnn brings its own onnxruntime (the QNN plugin EP).
-          python -m pip install onnxruntime-qnn
+          # onnxruntime-openvino replaces plain onnxruntime (bundles its own EP).
+          python -m pip install onnxruntime-openvino
           python -m pip install wheelhouse/*.whl
       # Run from runner.temp, not the checkout: the repo root contains the
       # `onnxsim/` source dir (no compiled extension), which would shadow the
       # installed wheel on `import onnxsim`. Reference the harness by absolute
-      # $GITHUB_WORKSPACE path. Same guard the model-regression workflow uses.
+      # $GITHUB_WORKSPACE path. Same guard the QNN/model-regression workflows use.
       - name: Show environment
         working-directory: ${{ runner.temp }}
         run: |
-          python -c "import onnxsim, onnxruntime_qnn as q; print('onnxsim', onnxsim.__version__); print('onnxruntime-qnn', q.__version__)"
-          python -c "import sys, os; sys.path.insert(0, os.path.join(os.environ['GITHUB_WORKSPACE'], 'scripts', 'qualcomm')); import qnn_backend as q; print('QNN available:', q.QNN_AVAILABLE, '| backend:', q.backend_path() if q.QNN_AVAILABLE else q.unavailable_reason())"
-      - name: Run QNN compatibility check
+          python -c "import onnxsim, onnxruntime as ort; print('onnxsim', onnxsim.__version__); print('onnxruntime', ort.__version__); print('providers', ort.get_available_providers())"
+      - name: Run OpenVINO compatibility check
         working-directory: ${{ runner.temp }}
         run: |
-          python "$GITHUB_WORKSPACE/scripts/qualcomm/run_qnn_compat.py" \
-            --require-qnn \
-            --output qnn-compat.csv
+          python "$GITHUB_WORKSPACE/scripts/intel/run_openvino_compat.py" \
+            --require-openvino \
+            --output openvino-compat.csv
       - uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: qnn-compat-report
-          path: ${{ runner.temp }}/qnn-compat.csv
+          name: openvino-compat-report
+          path: ${{ runner.temp }}/openvino-compat.csv
           if-no-files-found: ignore

--- a/scripts/amd/README.md
+++ b/scripts/amd/README.md
@@ -1,0 +1,93 @@
+# AMD MIGraphX integration check
+
+Verifies that `onnxsim`'s output still works with
+[**MIGraphX**](https://github.com/ROCm/AMDMIGraphX) — AMD's ROCm graph
+compiler for GPU inference (the AMD analog to NVIDIA's TensorRT). The goal is
+to catch the failure mode the unit tests and the large-model regression
+don't: a simplification that produces a graph MIGraphX can no longer
+**compile**, or that **changes the result** on AMD's stack.
+
+It uses the pip-installable [`onnxruntime-migraphx`](https://pypi.org/project/onnxruntime-migraphx/)
+wheel (a separate build of ONNX Runtime that bundles the MIGraphX EP — it
+replaces, rather than supplements, plain `onnxruntime`, the same relationship
+`onnxruntime-openvino` has).
+
+## This one needs real AMD GPU hardware
+
+Unlike the Apple Core ML (`scripts/apple`) and Intel OpenVINO (`scripts/intel`)
+checks, **MIGraphX has no CPU fallback or host emulator** — Core ML runs on
+the Mac that's building it, OpenVINO's `CPU` device target needs no
+accelerator, and even Qualcomm's QNN check (`scripts/qualcomm`) gets an x86
+emulation path from the HTP backend. MIGraphX compiles and executes directly
+on a ROCm-capable AMD GPU; there is no equivalent path on a stock CPU-only CI
+runner. That's why this check, unlike its siblings, is **not** wired into a
+scheduled or PR-triggered workflow: `amd-integration.yml` is
+`workflow_dispatch`-only and targets a `[self-hosted, rocm]` runner label,
+which this repository does not currently provision. Point it at your own
+ROCm-equipped self-hosted runner to use it; until then it's dormant.
+
+## What it checks
+
+For each model the harness runs **original vs. simplified through the same
+MIGraphX backend**, so backend quirks cancel and only an onnxsim-introduced
+change can fail the run:
+
+1. `simplify` the model with onnxsim.
+2. Compile + run the **original** graph on the MIGraphX EP.
+   If that already fails, the backend just doesn't support the graph →
+   reported as `unsupported`, **not** a failure.
+3. Compile + run the **simplified** graph on the MIGraphX EP.
+   If the original compiled but the simplified doesn't → `migraphx_regression`
+   (a failure): simplification broke MIGraphX compatibility.
+4. Compare the two MIGraphX outputs. Divergence beyond tolerance →
+   `migraphx_regression`: simplification changed the on-device result.
+5. Record the ONNX Runtime CPU-reference diff and the MIGraphX **coverage**
+   (does the whole graph map onto MIGraphX, or do some nodes fall back to
+   ORT's CPU provider) as information.
+
+Partial coverage and `unsupported` are reported, never failed — plenty of
+valid graphs are not 100% MIGraphX-mappable, and that is a backend property,
+not an onnxsim bug.
+
+## Files
+
+| file | purpose |
+| --- | --- |
+| `migraphx_backend.py` | wraps the MIGraphX EP: builds/runs a model on MIGraphX (fp16 by default) and on the plain ORT CPU reference, measures coverage. Because the provider's shared library is bundled into the wheel regardless of hardware, availability is checked by actually building a session on a trivial graph, not just by checking `get_available_providers()`. Degrades gracefully (`MIGRAPHX_AVAILABLE`) when no ROCm device answers. |
+| `models.py` | alias for `scripts/common/synthetic_models.py`, the small synthetic-graph suite shared with the other EP harnesses. |
+| `worker.py` | runs the check for one model in an isolated subprocess, printing one `__RESULT__<json>` line. |
+| `run_migraphx_compat.py` | drives the suite, writes a CSV, and exits non-zero on any regression. Entry point for the (dormant) CI workflow. |
+
+## Running locally
+
+Requires a ROCm-capable AMD GPU with the ROCm stack installed.
+
+```bash
+pip install onnxruntime-migraphx   # NOT alongside plain onnxruntime
+pip install .                      # or install an onnxsim wheel
+
+python scripts/amd/run_migraphx_compat.py --output migraphx-compat.csv
+```
+
+The in-tree smoke test `tests/test_migraphx_compat.py` reuses this harness
+and is skipped automatically when the MIGraphX EP isn't usable (no
+`onnxruntime-migraphx`, or no ROCm device answers).
+
+## Fidelity tiers (what this does and doesn't cover)
+
+This check runs the real MIGraphX compiler/runtime — real numerics, no
+emulation — but only what it's pointed at:
+
+- **fp16 by default.** `MIGRAPHX_FP16=0` compiles/runs in fp32 instead;
+  set `rtol`/`atol` in `common/ep_numerics.compare` accordingly if you tighten
+  tolerances for fp32-only runs.
+- **Single GPU, default device.** Multi-GPU selection isn't wired up; set
+  `device_id` via `migraphx_backend._migraphx_provider_options()` if needed.
+- **Quantized (int8) paths.** This suite is fp16/fp32 only.
+
+## Extending
+
+`models.py` is intentionally small and self-contained so the harness needs no
+downloads. Real models can be layered on by passing an on-disk path as
+`worker.py`'s second argument, the same way `scripts/qualcomm` and
+`scripts/regression` do.

--- a/scripts/amd/migraphx_backend.py
+++ b/scripts/amd/migraphx_backend.py
@@ -35,10 +35,20 @@ import onnx
 from onnx import TensorProto, helper
 
 _SCRIPTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if _SCRIPTS_DIR not in sys.path:
+# Only keep scripts/ on sys.path for the duration of this import: scripts/
+# also holds directories like rfdetr/ with no __init__.py, which Python 3
+# treats as importable namespace packages. Leaving scripts/ on sys.path for
+# the rest of the process would make `import rfdetr` "succeed" as that empty
+# namespace package instead of skipping via pytest.importorskip, and shadow
+# the real one everywhere else it's checked for.
+_inserted = _SCRIPTS_DIR not in sys.path
+if _inserted:
     sys.path.insert(0, _SCRIPTS_DIR)
-
-from common.ep_numerics import compare, random_feeds  # noqa: E402,F401
+try:
+    from common.ep_numerics import compare, random_feeds  # noqa: E402,F401
+finally:
+    if _inserted:
+        sys.path.remove(_SCRIPTS_DIR)
 
 _EP_NAME = "MIGraphXExecutionProvider"
 # fp16 halves compile time and matches how most deployed MIGraphX models run;

--- a/scripts/amd/migraphx_backend.py
+++ b/scripts/amd/migraphx_backend.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Thin wrapper around the ONNX Runtime MIGraphX execution provider.
+
+AMD's [MIGraphX](https://github.com/ROCm/AMDMIGraphX) graph compiler ships as
+the `MIGraphXExecutionProvider` in the separate
+[`onnxruntime-migraphx`](https://pypi.org/project/onnxruntime-migraphx/) wheel
+(it replaces, rather than supplements, plain `onnxruntime`, the same relationship
+`onnxruntime-openvino` has). Unlike Core ML or OpenVINO's CPU device target,
+MIGraphX has **no CPU fallback or host emulator**: it compiles and executes
+directly on a ROCm-capable AMD GPU. There is no way to exercise it on an
+ordinary CPU-only CI runner, so this harness needs real AMD GPU + ROCm
+hardware -- see `scripts/amd/README.md` for how to run it.
+
+Because the provider's shared library is bundled into the wheel regardless of
+whether a ROCm device is actually present, `MIGraphXExecutionProvider`
+showing up in ``onnxruntime.get_available_providers()`` is not by itself proof
+the EP is usable (unlike the Core ML / OpenVINO checks, which stop there).
+This module additionally tries to build a session for a trivial graph on the
+EP, so ``MIGRAPHX_AVAILABLE`` only ends up True when a ROCm device actually
+answers.
+
+This module degrades gracefully: whenever the EP can't be loaded or no ROCm
+device responds, ``MIGRAPHX_AVAILABLE`` is False and ``unavailable_reason()``
+explains why, so callers can skip rather than error.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Dict, List
+
+import numpy as np
+import onnx
+from onnx import TensorProto, helper
+
+_SCRIPTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+from common.ep_numerics import compare, random_feeds  # noqa: E402,F401
+
+_EP_NAME = "MIGraphXExecutionProvider"
+# fp16 halves compile time and matches how most deployed MIGraphX models run;
+# override to "0" to probe/compile in fp32 instead.
+_USE_FP16 = os.environ.get("MIGRAPHX_FP16", "1") not in ("0", "", "false", "False")
+
+MIGRAPHX_AVAILABLE = False
+_UNAVAILABLE_REASON: str | None = None
+
+
+def _probe_model() -> onnx.ModelProto:
+    """A single-node Identity graph, just enough to force a real device probe."""
+    node = helper.make_node("Identity", ["x"], ["y"])
+    graph = helper.make_graph(
+        [node],
+        "migraphx_probe",
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1])],
+    )
+    return helper.make_model(graph, opset_imports=[helper.make_opsetid("", 18)])
+
+
+try:
+    import onnxruntime as ort
+
+    if _EP_NAME not in ort.get_available_providers():
+        raise RuntimeError(
+            "MIGraphXExecutionProvider not available "
+            "(install onnxruntime-migraphx, not plain onnxruntime)"
+        )
+    # Presence in get_available_providers() only means the wheel bundles the
+    # provider's shared library, not that a ROCm device answered -- unlike
+    # Core ML/OpenVINO, MIGraphX has no CPU path to fall back to, so an actual
+    # session build is the only real availability signal.
+    _probe_so = ort.SessionOptions()
+    _probe_so.log_severity_level = 3  # ERROR
+    ort.InferenceSession(
+        _probe_model().SerializeToString(),
+        sess_options=_probe_so,
+        providers=[_EP_NAME],
+    )
+    MIGRAPHX_AVAILABLE = True
+except Exception as exc:  # pragma: no cover - depends on the host
+    _UNAVAILABLE_REASON = f"{type(exc).__name__}: {exc}"
+
+
+def unavailable_reason() -> str | None:
+    """Why the MIGraphX EP is unusable on this host, or None if it is usable."""
+    return _UNAVAILABLE_REASON
+
+
+def _session_options(strict: bool):
+    so = ort.SessionOptions()
+    so.log_severity_level = 3  # ERROR
+    if strict:
+        # Fail session creation if any node cannot be placed on MIGraphX,
+        # instead of silently falling back to ORT's CPU provider. Used to
+        # measure coverage.
+        so.add_session_config_entry("session.disable_cpu_ep_fallback", "1")
+    return so
+
+
+def _migraphx_provider_options() -> Dict[str, str]:
+    return {"migraphx_fp16_enable": "1"} if _USE_FP16 else {}
+
+
+def run_with_migraphx(
+    model: onnx.ModelProto,
+    feeds: Dict[str, np.ndarray],
+    strict: bool = False,
+) -> List[np.ndarray]:
+    """Run ``model`` on the MIGraphX EP, returning the outputs.
+
+    With ``strict=True`` the session is built with CPU fallback disabled, so
+    creation raises unless the *entire* graph maps onto MIGraphX.
+    """
+    so = _session_options(strict)
+    providers = [(_EP_NAME, _migraphx_provider_options())]
+    if not strict:
+        providers.append("CPUExecutionProvider")
+    sess = ort.InferenceSession(
+        model.SerializeToString(), sess_options=so, providers=providers
+    )
+    return sess.run(None, feeds)
+
+
+def run_with_cpu(
+    model: onnx.ModelProto, feeds: Dict[str, np.ndarray]
+) -> List[np.ndarray]:
+    """Run ``model`` on ONNX Runtime's plain CPU provider (the numerical reference)."""
+    so = _session_options(strict=False)
+    sess = ort.InferenceSession(
+        model.SerializeToString(),
+        sess_options=so,
+        providers=["CPUExecutionProvider"],
+    )
+    return sess.run(None, feeds)
+
+
+def coverage(model: onnx.ModelProto) -> str:
+    """ "full" if the whole graph maps onto MIGraphX, else "partial".
+
+    Determined by trying to build a session with CPU fallback disabled:
+    success means every node was accepted by the MIGraphX EP.
+    """
+    try:
+        run_with_migraphx(model, random_feeds(model), strict=True)
+        return "full"
+    except Exception:
+        return "partial"

--- a/scripts/amd/models.py
+++ b/scripts/amd/models.py
@@ -7,19 +7,29 @@ import os
 import sys
 
 _SCRIPTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if _SCRIPTS_DIR not in sys.path:
+# Only keep scripts/ on sys.path for the duration of this import: scripts/
+# also holds directories like rfdetr/ with no __init__.py, which Python 3
+# treats as importable namespace packages. Leaving scripts/ on sys.path for
+# the rest of the process would make `import rfdetr` "succeed" as that empty
+# namespace package instead of skipping via pytest.importorskip, and shadow
+# the real one everywhere else it's checked for.
+_inserted = _SCRIPTS_DIR not in sys.path
+if _inserted:
     sys.path.insert(0, _SCRIPTS_DIR)
-
-from common.synthetic_models import (  # noqa: E402,F401
-    all_models,
-    build,
-    conv_bn_relu,
-    foldable_shape_reshape,
-    matmul_bias_tanh,
-    names,
-    redundant_transpose,
-    sigmoid_mul_swish,
-)
+try:
+    from common.synthetic_models import (  # noqa: E402,F401
+        all_models,
+        build,
+        conv_bn_relu,
+        foldable_shape_reshape,
+        matmul_bias_tanh,
+        names,
+        redundant_transpose,
+        sigmoid_mul_swish,
+    )
+finally:
+    if _inserted:
+        sys.path.remove(_SCRIPTS_DIR)
 
 if __name__ == "__main__":
     for n, m in all_models().items():

--- a/scripts/amd/models.py
+++ b/scripts/amd/models.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""AMD-side alias for the shared synthetic model suite. See scripts/common/."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_SCRIPTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+from common.synthetic_models import (  # noqa: E402,F401
+    all_models,
+    build,
+    conv_bn_relu,
+    foldable_shape_reshape,
+    matmul_bias_tanh,
+    names,
+    redundant_transpose,
+    sigmoid_mul_swish,
+)
+
+if __name__ == "__main__":
+    for n, m in all_models().items():
+        print(f"{n:24} {len(m.graph.node)} nodes")

--- a/scripts/amd/run_migraphx_compat.py
+++ b/scripts/amd/run_migraphx_compat.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Run the MIGraphX compatibility check over the model suite and report.
+
+Drives ``worker.py`` once per model (isolated subprocess, hard timeout),
+collects the JSON results, writes a CSV, prints a summary, and exits non-zero
+if any model failed. This is the entry point the ``AMD Integration`` workflow
+calls -- see scripts/amd/README.md for why that workflow needs a self-hosted
+ROCm runner rather than running on a stock GitHub-hosted one.
+
+A model **fails** the check when simplification breaks MIGraphX compatibility
+or changes the on-device result (``migraphx_regression``), when onnxsim
+raises (``simplify_error``), or when the worker crashes/times out. A graph
+the MIGraphX backend cannot handle even *before* simplification is
+``unsupported`` and is **reported, not failed** -- that is a backend
+limitation, not an onnxsim bug. Partial MIGraphX coverage (some nodes falling
+back to ORT's CPU provider) is likewise reported, not failed.
+
+If the MIGraphX EP is unavailable on the host (no ROCm GPU), every model
+reports ``skipped`` and the run passes (nothing to test) unless
+``--require-migraphx`` is given.
+
+Usage:
+    run_migraphx_compat.py --output migraphx-compat.csv
+    run_migraphx_compat.py --require-migraphx   # fail if the MIGraphX EP is missing
+    run_migraphx_compat.py --models conv_bn_relu matmul_bias_tanh
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import subprocess
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import models  # noqa: E402
+
+FAIL_STATUSES = {"migraphx_regression", "simplify_error", "crash", "timeout", "error"}
+
+
+def run_one(model_name: str, timeout: int) -> dict:
+    t0 = time.time()
+    try:
+        proc = subprocess.run(
+            [sys.executable, os.path.join(HERE, "worker.py"), model_name],
+            capture_output=True,
+            text=True,
+            timeout=None if timeout <= 0 else timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "model": model_name,
+            "status": "timeout",
+            "error": f">{timeout}s",
+            "seconds": timeout,
+        }
+    result = None
+    for line in proc.stdout.splitlines():
+        if line.startswith("__RESULT__"):
+            result = json.loads(line[len("__RESULT__") :])
+    if result is None:
+        result = {
+            "model": model_name,
+            "status": "crash",
+            "error": (proc.stderr or proc.stdout or "no result line")[-400:],
+            "seconds": round(time.time() - t0, 1),
+        }
+    return result
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--models",
+        nargs="*",
+        default=None,
+        help="subset of model names to run (default: the whole suite)",
+    )
+    ap.add_argument(
+        "--timeout",
+        type=int,
+        default=600,
+        help="per-model wall-clock cap in seconds; <=0 disables",
+    )
+    ap.add_argument(
+        "--require-migraphx",
+        action="store_true",
+        help="fail if the MIGraphX EP is unavailable instead of skipping",
+    )
+    ap.add_argument("--output", default="migraphx-compat.csv")
+    args = ap.parse_args()
+
+    selected = args.models or models.names()
+    print(f"MIGraphX compatibility check | {len(selected)} models", flush=True)
+
+    rows = []
+    failures = []
+    skipped = 0
+    for i, name in enumerate(selected, 1):
+        print(f"[{i}/{len(selected)}] {name} ...", end=" ", flush=True)
+        r = run_one(name, args.timeout)
+        rows.append(r)
+        status = r.get("status")
+        if status == "skipped":
+            skipped += 1
+            print(f"skipped ({r.get('error')})", flush=True)
+            continue
+        detail = ""
+        if r.get("orig_nodes") is not None:
+            detail = f"{r.get('orig_nodes')}->{r.get('simp_nodes')} nodes"
+        if r.get("coverage_orig") or r.get("coverage_simp"):
+            detail += f", migraphx={r.get('coverage_orig')}->{r.get('coverage_simp')}"
+        if r.get("diff_vs_migraphx_orig") is not None:
+            detail += f", d(orig)={r.get('diff_vs_migraphx_orig'):.2g}"
+        print(f"{status} ({detail}) {r.get('seconds')}s", flush=True)
+        if status in FAIL_STATUSES:
+            failures.append((name, status, str(r.get("error"))[:200]))
+
+    fields = [
+        "model",
+        "status",
+        "orig_nodes",
+        "simp_nodes",
+        "coverage_orig",
+        "coverage_simp",
+        "diff_vs_migraphx_orig",
+        "diff_vs_cpu_ref",
+        "seconds",
+        "error",
+    ]
+    with open(args.output, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fields, extrasaction="ignore")
+        w.writeheader()
+        for r in rows:
+            w.writerow(r)
+    print(f"\nwrote {args.output} ({len(rows)} rows)", flush=True)
+
+    if skipped == len(selected):
+        msg = "MIGraphX EP unavailable on this host; all models skipped."
+        if args.require_migraphx:
+            print(f"\n{msg} (--require-migraphx set -> failing)", flush=True)
+            return 1
+        print(f"\n{msg} Nothing to test; passing.", flush=True)
+        return 0
+
+    if failures:
+        print(f"\n{len(failures)} FAILED:", flush=True)
+        for name, status, err in failures:
+            print(f"  - {name}: {status} {err}", flush=True)
+        return 1
+    passed = sum(1 for r in rows if r.get("status") == "ok")
+    unsupported = sum(1 for r in rows if r.get("status") == "unsupported")
+    print(
+        f"\nall passed ({passed} ok, {unsupported} unsupported, {skipped} skipped)",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/amd/worker.py
+++ b/scripts/amd/worker.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Check one model against the MIGraphX execution provider, in an isolated subprocess.
+
+Run as ``worker.py <model_name> [onnx_path]``. With just a name, the model
+comes from the shared ``common/synthetic_models.py`` suite; with an
+``onnx_path`` the graph is loaded from disk. Each model runs in its own
+process (mirrors the QNN/Core ML/OpenVINO harnesses) and the final stdout
+line is exactly ``__RESULT__<json>``.
+
+The check is framed as *original vs. simplified on the same MIGraphX
+backend*, so a backend limitation (an op MIGraphX declines to place) cancels
+out and only an onnxsim-introduced change can fail the run. For one model:
+
+1. ``simplify`` it with onnxsim.
+2. Run the **original** graph on the MIGraphX EP.
+   * If that already fails to compile/run, the backend simply does not
+     support this graph -- status ``unsupported`` (reported, not a failure).
+3. Run the **simplified** graph on the MIGraphX EP.
+   * If the original ran but the simplified does not, simplification broke
+     MIGraphX compatibility -- status ``migraphx_regression`` (a failure).
+4. Compare the two MIGraphX outputs. Divergence beyond tolerance means
+   simplification changed the on-device result -- ``migraphx_regression``.
+5. Also record the ONNX Runtime CPU reference diff and the MIGraphX coverage
+   (full vs. partial) for both graphs, as information.
+
+Status values:
+
+* ``ok``                   - original & simplified both ran on MIGraphX and agreed.
+* ``migraphx_regression``  - the simplified graph broke MIGraphX compat or changed results.
+* ``simplify_error``       - onnxsim raised on this model.
+* ``unsupported``          - the MIGraphX backend could not handle even the original graph.
+* ``skipped``              - the MIGraphX EP is not available on this host (no ROCm GPU).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import traceback
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+
+def check(model_name: str, onnx_path: str | None) -> dict:
+    res = {
+        "model": model_name,
+        "status": "error",
+        "orig_nodes": None,
+        "simp_nodes": None,
+        "coverage_orig": None,
+        "coverage_simp": None,
+        "diff_vs_migraphx_orig": None,
+        "diff_vs_cpu_ref": None,
+        "error": None,
+        "seconds": None,
+    }
+    t0 = time.time()
+    try:
+        import migraphx_backend as migraphx
+        import onnx
+
+        if not migraphx.MIGRAPHX_AVAILABLE:
+            res["status"] = "skipped"
+            res["error"] = migraphx.unavailable_reason()
+            return res
+
+        from onnxsim import simplify
+
+        if onnx_path:
+            model = onnx.load(onnx_path)
+        else:
+            import models
+
+            model = models.build(model_name)
+        res["orig_nodes"] = len(model.graph.node)
+
+        try:
+            simp, _check_ok = simplify(model)
+        except Exception as exc:
+            res["status"] = "simplify_error"
+            res["error"] = f"{type(exc).__name__}: {exc}"
+            return res
+        res["simp_nodes"] = len(simp.graph.node)
+
+        feeds = migraphx.random_feeds(model, seed=0)
+
+        # ORT CPU reference (informational end-to-end check).
+        cpu_ref = migraphx.run_with_cpu(model, feeds)
+
+        # Original graph on MIGraphX. If this fails, the backend can't handle
+        # the graph at all -- not something onnxsim did.
+        try:
+            res["coverage_orig"] = migraphx.coverage(model)
+            migraphx_orig = migraphx.run_with_migraphx(model, feeds)
+        except Exception as exc:
+            res["status"] = "unsupported"
+            res["error"] = f"original graph not supported by MIGraphX: {exc}"
+            return res
+
+        # Simplified graph on MIGraphX. The original worked, so a failure
+        # here is an onnxsim-introduced compatibility regression.
+        try:
+            res["coverage_simp"] = migraphx.coverage(simp)
+            migraphx_simp = migraphx.run_with_migraphx(simp, feeds)
+        except Exception as exc:
+            res["status"] = "migraphx_regression"
+            res["error"] = f"simplified graph broke MIGraphX compile/run: {exc}"
+            return res
+
+        # Simplification must not change the on-device result.
+        agree, diff_backend = migraphx.compare(migraphx_orig, migraphx_simp)
+        _, diff_ref = migraphx.compare(cpu_ref, migraphx_simp)
+        res["diff_vs_migraphx_orig"] = diff_backend
+        res["diff_vs_cpu_ref"] = diff_ref
+        if agree:
+            res["status"] = "ok"
+        else:
+            res["status"] = "migraphx_regression"
+            res["error"] = (
+                f"simplified MIGraphX output diverged from original "
+                f"(max_abs_diff={diff_backend:.3g})"
+            )
+    except Exception as exc:
+        res["error"] = f"{type(exc).__name__}: {exc}"
+        res["trace"] = traceback.format_exc()[-800:]
+    finally:
+        res["seconds"] = round(time.time() - t0, 1)
+    return res
+
+
+if __name__ == "__main__":
+    name = sys.argv[1]
+    path = sys.argv[2] if len(sys.argv) > 2 else None
+    print("__RESULT__" + json.dumps(check(name, path)))

--- a/scripts/apple/README.md
+++ b/scripts/apple/README.md
@@ -1,0 +1,81 @@
+# Apple Core ML integration check
+
+Verifies that `onnxsim`'s output still works with **Core ML** — the runtime
+behind `coremltools` model deployment on macOS/iOS. The goal is to catch the
+failure mode the unit tests and the large-model regression don't: a
+simplification that produces a graph Core ML can no longer **compile**, or
+that **changes the result** on Apple's stack.
+
+It uses the [`CoreMLExecutionProvider`](https://onnxruntime.ai/docs/execution-providers/CoreML-ExecutionProvider.html)
+built into the standard `onnxruntime` PyPI wheel — no extra package, but it
+only exists on the **macOS** build (`get_available_providers()` omits it on
+Linux/Windows). So the whole check runs on a stock macOS GitHub-hosted
+runner with nothing but `pip install onnxruntime`.
+
+## What it checks
+
+For each model the harness runs **original vs. simplified through the same
+Core ML backend**, so backend quirks cancel and only an onnxsim-introduced
+change can fail the run:
+
+1. `simplify` the model with onnxsim.
+2. Compile + run the **original** graph on the Core ML EP.
+   If that already fails, the backend just doesn't support the graph →
+   reported as `unsupported`, **not** a failure.
+3. Compile + run the **simplified** graph on the Core ML EP.
+   If the original compiled but the simplified doesn't → `coreml_regression`
+   (a failure): simplification broke Core ML compatibility.
+4. Compare the two Core ML outputs. Divergence beyond tolerance →
+   `coreml_regression`: simplification changed the on-device result.
+5. Record the ONNX Runtime CPU-reference diff and the Core ML **coverage**
+   (does the whole graph map onto Core ML, or do some nodes fall back to
+   ORT's CPU provider) as information.
+
+Partial coverage and `unsupported` are reported, never failed — plenty of
+valid graphs are not 100% Core ML-mappable, and that is a backend property,
+not an onnxsim bug.
+
+## Files
+
+| file | purpose |
+| --- | --- |
+| `coreml_backend.py` | wraps the Core ML EP: builds/runs a model on Core ML and on the ORT CPU reference, measures coverage. Degrades gracefully (`COREML_AVAILABLE`) when the EP is absent (non-macOS). |
+| `models.py` | alias for `scripts/common/synthetic_models.py`, the small synthetic-graph suite shared with the other EP harnesses. |
+| `worker.py` | runs the check for one model in an isolated subprocess, printing one `__RESULT__<json>` line. |
+| `run_coreml_compat.py` | drives the suite, writes a CSV, and exits non-zero on any regression. Entry point for CI. |
+
+## Running locally
+
+Requires macOS (the platform Core ML itself runs on).
+
+```bash
+pip install onnxruntime      # the macOS wheel bundles the Core ML EP
+pip install .                # or install an onnxsim wheel
+
+python scripts/apple/run_coreml_compat.py --output coreml-compat.csv
+```
+
+The in-tree smoke test `tests/test_coreml_compat.py` reuses this harness and
+is skipped automatically when the Core ML EP isn't available (e.g. running on
+Linux/Windows).
+
+## Fidelity tiers (what this does and doesn't cover)
+
+This check runs the **real** Core ML compiler and runtime — there is no
+emulation step the way QNN's HTP backend needs one, since the check already
+runs on real Apple hardware (the macOS CI runner itself). What it leaves
+uncovered:
+
+- **Compute unit selection.** `MLComputeUnits=ALL` (the default here) lets
+  Core ML place ops on CPU, GPU, or the Neural Engine as it judges best. Set
+  `COREML_COMPUTE_UNITS=CPUOnly` (or `CPUAndGPU`, `CPUAndNeuralEngine`) to
+  pin a specific target if you need to isolate one.
+- **iOS-specific behavior.** This runs the macOS Core ML stack; iOS devices
+  share the same compiler but can differ in available ops per OS version.
+
+## Extending
+
+`models.py` is intentionally small and self-contained so the CI job needs no
+downloads. Real models can be layered on by passing an on-disk path as
+`worker.py`'s second argument, the same way `scripts/qualcomm` and
+`scripts/regression` do.

--- a/scripts/apple/coreml_backend.py
+++ b/scripts/apple/coreml_backend.py
@@ -33,10 +33,20 @@ import numpy as np
 import onnx
 
 _SCRIPTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if _SCRIPTS_DIR not in sys.path:
+# Only keep scripts/ on sys.path for the duration of this import: scripts/
+# also holds directories like rfdetr/ with no __init__.py, which Python 3
+# treats as importable namespace packages. Leaving scripts/ on sys.path for
+# the rest of the process would make `import rfdetr` "succeed" as that empty
+# namespace package instead of skipping via pytest.importorskip, and shadow
+# the real one everywhere else it's checked for.
+_inserted = _SCRIPTS_DIR not in sys.path
+if _inserted:
     sys.path.insert(0, _SCRIPTS_DIR)
-
-from common.ep_numerics import compare, random_feeds  # noqa: E402,F401
+try:
+    from common.ep_numerics import compare, random_feeds  # noqa: E402,F401
+finally:
+    if _inserted:
+        sys.path.remove(_SCRIPTS_DIR)
 
 _EP_NAME = "CoreMLExecutionProvider"
 # ALL lets Core ML place ops on CPU/GPU/Neural Engine as it judges best, the

--- a/scripts/apple/coreml_backend.py
+++ b/scripts/apple/coreml_backend.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Thin wrapper around the ONNX Runtime CoreML execution provider.
+
+Apple's Core ML EP ships in the standard ``onnxruntime`` PyPI wheel, but only
+the macOS build actually links it in -- ``CoreMLExecutionProvider`` is absent
+from ``get_available_providers()`` on Linux/Windows. On an ordinary macOS CI
+runner (no extra pip package, no special hardware beyond the Mac itself) this
+gives two signals:
+
+* **compatibility** -- does the (simplified) graph compile onto Core ML at
+  all, and how much of it maps onto the accelerator vs. falling back to ONNX
+  Runtime's CPU provider;
+* **numerics** -- does the Core ML result match the ONNX Runtime CPU
+  reference, i.e. did onnxsim preserve semantics along the Core ML path.
+
+Core ML itself picks the actual compute unit (CPU/GPU/Neural Engine) at
+runtime; ``MLComputeUnits=ALL`` (the default here) lets it use whichever it
+judges best, same as a real deployment would.
+
+This module degrades gracefully: on a host where the Core ML EP is not
+present (not macOS, or an onnxruntime build without it) ``COREML_AVAILABLE``
+is False and ``unavailable_reason()`` explains why, so callers can skip
+rather than error.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Dict, List
+
+import numpy as np
+import onnx
+
+_SCRIPTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+from common.ep_numerics import compare, random_feeds  # noqa: E402,F401
+
+_EP_NAME = "CoreMLExecutionProvider"
+# ALL lets Core ML place ops on CPU/GPU/Neural Engine as it judges best, the
+# same choice a real deployment would leave it to make.
+_COMPUTE_UNITS = os.environ.get("COREML_COMPUTE_UNITS", "ALL")
+
+COREML_AVAILABLE = False
+_UNAVAILABLE_REASON: str | None = None
+
+try:
+    import onnxruntime as ort
+
+    if _EP_NAME not in ort.get_available_providers():
+        raise RuntimeError(
+            "CoreMLExecutionProvider not built into this onnxruntime "
+            "(expected on non-macOS, or a CPU-only wheel)"
+        )
+    COREML_AVAILABLE = True
+except Exception as exc:  # pragma: no cover - depends on the host
+    _UNAVAILABLE_REASON = f"{type(exc).__name__}: {exc}"
+
+
+def unavailable_reason() -> str | None:
+    """Why the Core ML EP is unusable on this host, or None if it is usable."""
+    return _UNAVAILABLE_REASON
+
+
+def _session_options(strict: bool):
+    so = ort.SessionOptions()
+    so.log_severity_level = 3  # ERROR
+    if strict:
+        # Fail session creation if any node cannot be placed on Core ML,
+        # instead of silently falling back to ORT's CPU provider. Used to
+        # measure coverage.
+        so.add_session_config_entry("session.disable_cpu_ep_fallback", "1")
+    return so
+
+
+def _coreml_provider_options() -> Dict[str, str]:
+    return {"MLComputeUnits": _COMPUTE_UNITS}
+
+
+def run_with_coreml(
+    model: onnx.ModelProto,
+    feeds: Dict[str, np.ndarray],
+    strict: bool = False,
+) -> List[np.ndarray]:
+    """Run ``model`` on the Core ML EP, returning the outputs.
+
+    With ``strict=True`` the session is built with CPU fallback disabled, so
+    creation raises unless the *entire* graph maps onto Core ML.
+    """
+    so = _session_options(strict)
+    providers = [(_EP_NAME, _coreml_provider_options())]
+    if not strict:
+        providers.append("CPUExecutionProvider")
+    sess = ort.InferenceSession(
+        model.SerializeToString(), sess_options=so, providers=providers
+    )
+    return sess.run(None, feeds)
+
+
+def run_with_cpu(
+    model: onnx.ModelProto, feeds: Dict[str, np.ndarray]
+) -> List[np.ndarray]:
+    """Run ``model`` on ONNX Runtime's CPU provider (the numerical reference)."""
+    so = _session_options(strict=False)
+    sess = ort.InferenceSession(
+        model.SerializeToString(),
+        sess_options=so,
+        providers=["CPUExecutionProvider"],
+    )
+    return sess.run(None, feeds)
+
+
+def coverage(model: onnx.ModelProto) -> str:
+    """ "full" if the whole graph maps onto Core ML, else "partial".
+
+    Determined by trying to build a session with CPU fallback disabled:
+    success means every node was accepted by the Core ML EP.
+    """
+    try:
+        run_with_coreml(model, random_feeds(model), strict=True)
+        return "full"
+    except Exception:
+        return "partial"

--- a/scripts/apple/models.py
+++ b/scripts/apple/models.py
@@ -7,19 +7,29 @@ import os
 import sys
 
 _SCRIPTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if _SCRIPTS_DIR not in sys.path:
+# Only keep scripts/ on sys.path for the duration of this import: scripts/
+# also holds directories like rfdetr/ with no __init__.py, which Python 3
+# treats as importable namespace packages. Leaving scripts/ on sys.path for
+# the rest of the process would make `import rfdetr` "succeed" as that empty
+# namespace package instead of skipping via pytest.importorskip, and shadow
+# the real one everywhere else it's checked for.
+_inserted = _SCRIPTS_DIR not in sys.path
+if _inserted:
     sys.path.insert(0, _SCRIPTS_DIR)
-
-from common.synthetic_models import (  # noqa: E402,F401
-    all_models,
-    build,
-    conv_bn_relu,
-    foldable_shape_reshape,
-    matmul_bias_tanh,
-    names,
-    redundant_transpose,
-    sigmoid_mul_swish,
-)
+try:
+    from common.synthetic_models import (  # noqa: E402,F401
+        all_models,
+        build,
+        conv_bn_relu,
+        foldable_shape_reshape,
+        matmul_bias_tanh,
+        names,
+        redundant_transpose,
+        sigmoid_mul_swish,
+    )
+finally:
+    if _inserted:
+        sys.path.remove(_SCRIPTS_DIR)
 
 if __name__ == "__main__":
     for n, m in all_models().items():

--- a/scripts/apple/models.py
+++ b/scripts/apple/models.py
@@ -1,12 +1,5 @@
 #!/usr/bin/env python3
-"""Qualcomm-side alias for the shared synthetic model suite.
-
-The suite itself moved to ``scripts/common/synthetic_models.py`` so the Apple
-CoreML and Intel OpenVINO harnesses can reuse it without duplicating ~180
-lines of graph builders. This module re-exports the same public API so
-``worker.py``'s ``import models`` and ``tests/test_qnn_compat.py``'s
-``models.names()`` / ``models.conv_bn_relu()`` keep working unchanged.
-"""
+"""Apple-side alias for the shared synthetic model suite. See scripts/common/."""
 
 from __future__ import annotations
 

--- a/scripts/apple/run_coreml_compat.py
+++ b/scripts/apple/run_coreml_compat.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Run the Core ML compatibility check over the model suite and report.
+
+Drives ``worker.py`` once per model (isolated subprocess, hard timeout),
+collects the JSON results, writes a CSV, prints a summary, and exits non-zero
+if any model failed. This is the entry point the ``Apple Integration``
+workflow calls.
+
+A model **fails** the check when simplification breaks Core ML compatibility
+or changes the on-device result (``coreml_regression``), when onnxsim raises
+(``simplify_error``), or when the worker crashes/times out. A graph the
+Core ML backend cannot handle even *before* simplification is ``unsupported``
+and is **reported, not failed** -- that is a backend limitation, not an
+onnxsim bug. Partial Core ML coverage (some nodes falling back to ORT's CPU
+provider) is likewise reported, not failed.
+
+If the Core ML EP is unavailable on the host (not macOS), every model reports
+``skipped`` and the run passes (nothing to test) unless ``--require-coreml``
+is given.
+
+Usage:
+    run_coreml_compat.py --output coreml-compat.csv
+    run_coreml_compat.py --require-coreml     # fail if the Core ML EP is missing
+    run_coreml_compat.py --models conv_bn_relu matmul_bias_tanh
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import subprocess
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import models  # noqa: E402
+
+FAIL_STATUSES = {"coreml_regression", "simplify_error", "crash", "timeout", "error"}
+
+
+def run_one(model_name: str, timeout: int) -> dict:
+    t0 = time.time()
+    try:
+        proc = subprocess.run(
+            [sys.executable, os.path.join(HERE, "worker.py"), model_name],
+            capture_output=True,
+            text=True,
+            timeout=None if timeout <= 0 else timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "model": model_name,
+            "status": "timeout",
+            "error": f">{timeout}s",
+            "seconds": timeout,
+        }
+    result = None
+    for line in proc.stdout.splitlines():
+        if line.startswith("__RESULT__"):
+            result = json.loads(line[len("__RESULT__") :])
+    if result is None:
+        result = {
+            "model": model_name,
+            "status": "crash",
+            "error": (proc.stderr or proc.stdout or "no result line")[-400:],
+            "seconds": round(time.time() - t0, 1),
+        }
+    return result
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--models",
+        nargs="*",
+        default=None,
+        help="subset of model names to run (default: the whole suite)",
+    )
+    ap.add_argument(
+        "--timeout",
+        type=int,
+        default=600,
+        help="per-model wall-clock cap in seconds; <=0 disables",
+    )
+    ap.add_argument(
+        "--require-coreml",
+        action="store_true",
+        help="fail if the Core ML EP is unavailable instead of skipping",
+    )
+    ap.add_argument("--output", default="coreml-compat.csv")
+    args = ap.parse_args()
+
+    selected = args.models or models.names()
+    print(f"Core ML compatibility check | {len(selected)} models", flush=True)
+
+    rows = []
+    failures = []
+    skipped = 0
+    for i, name in enumerate(selected, 1):
+        print(f"[{i}/{len(selected)}] {name} ...", end=" ", flush=True)
+        r = run_one(name, args.timeout)
+        rows.append(r)
+        status = r.get("status")
+        if status == "skipped":
+            skipped += 1
+            print(f"skipped ({r.get('error')})", flush=True)
+            continue
+        detail = ""
+        if r.get("orig_nodes") is not None:
+            detail = f"{r.get('orig_nodes')}->{r.get('simp_nodes')} nodes"
+        if r.get("coverage_orig") or r.get("coverage_simp"):
+            detail += f", coreml={r.get('coverage_orig')}->{r.get('coverage_simp')}"
+        if r.get("diff_vs_coreml_orig") is not None:
+            detail += f", d(orig)={r.get('diff_vs_coreml_orig'):.2g}"
+        print(f"{status} ({detail}) {r.get('seconds')}s", flush=True)
+        if status in FAIL_STATUSES:
+            failures.append((name, status, str(r.get("error"))[:200]))
+
+    fields = [
+        "model",
+        "status",
+        "orig_nodes",
+        "simp_nodes",
+        "coverage_orig",
+        "coverage_simp",
+        "diff_vs_coreml_orig",
+        "diff_vs_cpu_ref",
+        "seconds",
+        "error",
+    ]
+    with open(args.output, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fields, extrasaction="ignore")
+        w.writeheader()
+        for r in rows:
+            w.writerow(r)
+    print(f"\nwrote {args.output} ({len(rows)} rows)", flush=True)
+
+    if skipped == len(selected):
+        msg = "Core ML EP unavailable on this host; all models skipped."
+        if args.require_coreml:
+            print(f"\n{msg} (--require-coreml set -> failing)", flush=True)
+            return 1
+        print(f"\n{msg} Nothing to test; passing.", flush=True)
+        return 0
+
+    if failures:
+        print(f"\n{len(failures)} FAILED:", flush=True)
+        for name, status, err in failures:
+            print(f"  - {name}: {status} {err}", flush=True)
+        return 1
+    passed = sum(1 for r in rows if r.get("status") == "ok")
+    unsupported = sum(1 for r in rows if r.get("status") == "unsupported")
+    print(
+        f"\nall passed ({passed} ok, {unsupported} unsupported, {skipped} skipped)",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/apple/worker.py
+++ b/scripts/apple/worker.py
@@ -60,8 +60,8 @@ def check(model_name: str, onnx_path: str | None) -> dict:
     }
     t0 = time.time()
     try:
-        import onnx
         import coreml_backend as coreml
+        import onnx
 
         if not coreml.COREML_AVAILABLE:
             res["status"] = "skipped"

--- a/scripts/apple/worker.py
+++ b/scripts/apple/worker.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Check one model against the Core ML execution provider, in an isolated subprocess.
+
+Run as ``worker.py <model_name> [onnx_path]``. With just a name, the model
+comes from the shared ``common/synthetic_models.py`` suite; with an
+``onnx_path`` the graph is loaded from disk. Each model runs in its own
+process (mirrors the QNN harness) and the final stdout line is exactly
+``__RESULT__<json>``.
+
+The check is framed as *original vs. simplified on the same Core ML backend*,
+so a backend limitation (an op Core ML declines to place) cancels out and only
+an onnxsim-introduced change can fail the run. For one model:
+
+1. ``simplify`` it with onnxsim.
+2. Run the **original** graph on the Core ML EP.
+   * If that already fails to compile/run, the backend simply does not
+     support this graph -- status ``unsupported`` (reported, not a failure).
+3. Run the **simplified** graph on the Core ML EP.
+   * If the original ran but the simplified does not, simplification broke
+     Core ML compatibility -- status ``coreml_regression`` (a failure).
+4. Compare the two Core ML outputs. Divergence beyond tolerance means
+   simplification changed the on-device result -- ``coreml_regression``.
+5. Also record the ONNX Runtime CPU reference diff and the Core ML coverage
+   (full vs. partial) for both graphs, as information.
+
+Status values:
+
+* ``ok``                 - original & simplified both ran on Core ML and agreed.
+* ``coreml_regression``  - the simplified graph broke Core ML compat or changed results.
+* ``simplify_error``     - onnxsim raised on this model.
+* ``unsupported``        - the Core ML backend could not handle even the original graph.
+* ``skipped``            - the Core ML EP is not available on this host.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import traceback
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+
+def check(model_name: str, onnx_path: str | None) -> dict:
+    res = {
+        "model": model_name,
+        "status": "error",
+        "orig_nodes": None,
+        "simp_nodes": None,
+        "coverage_orig": None,
+        "coverage_simp": None,
+        "diff_vs_coreml_orig": None,
+        "diff_vs_cpu_ref": None,
+        "error": None,
+        "seconds": None,
+    }
+    t0 = time.time()
+    try:
+        import onnx
+        import coreml_backend as coreml
+
+        if not coreml.COREML_AVAILABLE:
+            res["status"] = "skipped"
+            res["error"] = coreml.unavailable_reason()
+            return res
+
+        from onnxsim import simplify
+
+        if onnx_path:
+            model = onnx.load(onnx_path)
+        else:
+            import models
+
+            model = models.build(model_name)
+        res["orig_nodes"] = len(model.graph.node)
+
+        try:
+            simp, _check_ok = simplify(model)
+        except Exception as exc:
+            res["status"] = "simplify_error"
+            res["error"] = f"{type(exc).__name__}: {exc}"
+            return res
+        res["simp_nodes"] = len(simp.graph.node)
+
+        feeds = coreml.random_feeds(model, seed=0)
+
+        # ORT CPU reference (informational end-to-end check).
+        cpu_ref = coreml.run_with_cpu(model, feeds)
+
+        # Original graph on Core ML. If this fails, the backend can't handle
+        # the graph at all -- not something onnxsim did.
+        try:
+            res["coverage_orig"] = coreml.coverage(model)
+            coreml_orig = coreml.run_with_coreml(model, feeds)
+        except Exception as exc:
+            res["status"] = "unsupported"
+            res["error"] = f"original graph not supported by Core ML: {exc}"
+            return res
+
+        # Simplified graph on Core ML. The original worked, so a failure here
+        # is an onnxsim-introduced compatibility regression.
+        try:
+            res["coverage_simp"] = coreml.coverage(simp)
+            coreml_simp = coreml.run_with_coreml(simp, feeds)
+        except Exception as exc:
+            res["status"] = "coreml_regression"
+            res["error"] = f"simplified graph broke Core ML compile/run: {exc}"
+            return res
+
+        # Simplification must not change the on-device result.
+        agree, diff_backend = coreml.compare(coreml_orig, coreml_simp)
+        _, diff_ref = coreml.compare(cpu_ref, coreml_simp)
+        res["diff_vs_coreml_orig"] = diff_backend
+        res["diff_vs_cpu_ref"] = diff_ref
+        if agree:
+            res["status"] = "ok"
+        else:
+            res["status"] = "coreml_regression"
+            res["error"] = (
+                f"simplified Core ML output diverged from original "
+                f"(max_abs_diff={diff_backend:.3g})"
+            )
+    except Exception as exc:
+        res["error"] = f"{type(exc).__name__}: {exc}"
+        res["trace"] = traceback.format_exc()[-800:]
+    finally:
+        res["seconds"] = round(time.time() - t0, 1)
+    return res
+
+
+if __name__ == "__main__":
+    name = sys.argv[1]
+    path = sys.argv[2] if len(sys.argv) > 2 else None
+    print("__RESULT__" + json.dumps(check(name, path)))

--- a/scripts/common/ep_numerics.py
+++ b/scripts/common/ep_numerics.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Numeric helpers shared by the vendor execution-provider compatibility harnesses.
+
+Deterministic input synthesis and output comparison, factored out of the
+Qualcomm QNN harness so the Apple CoreML and Intel OpenVINO harnesses (and any
+future one) do not each carry their own copy.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+import numpy as np
+import onnx
+
+_ELEM_TO_NP = {
+    onnx.TensorProto.FLOAT: np.float32,
+    onnx.TensorProto.DOUBLE: np.float64,
+    onnx.TensorProto.FLOAT16: np.float16,
+    onnx.TensorProto.INT64: np.int64,
+    onnx.TensorProto.INT32: np.int32,
+    onnx.TensorProto.BOOL: np.bool_,
+}
+
+
+def random_feeds(
+    model: onnx.ModelProto, seed: int = 0, default_dim: int = 1
+) -> Dict[str, np.ndarray]:
+    """Deterministic random inputs for every graph input that is not an initializer.
+
+    Unknown / dynamic dimensions (``dim_param`` or missing) are filled with
+    ``default_dim``. Float inputs use a small range so backend emulation/kernels
+    do not overflow; integer inputs use small non-negative values.
+    """
+    rng = np.random.RandomState(seed)
+    initializers = {init.name for init in model.graph.initializer}
+    feeds: Dict[str, np.ndarray] = {}
+    for inp in model.graph.input:
+        if inp.name in initializers:
+            continue
+        ttype = inp.type.tensor_type
+        shape = []
+        for dim in ttype.shape.dim:
+            if dim.HasField("dim_value") and dim.dim_value > 0:
+                shape.append(dim.dim_value)
+            else:
+                shape.append(default_dim)
+        np_dtype = _ELEM_TO_NP.get(ttype.elem_type, np.float32)
+        if np.issubdtype(np_dtype, np.floating):
+            feeds[inp.name] = (rng.rand(*shape).astype(np_dtype) - 0.5) * 2.0
+        elif np_dtype == np.bool_:
+            feeds[inp.name] = rng.rand(*shape) > 0.5
+        else:
+            feeds[inp.name] = rng.randint(0, 4, size=shape).astype(np_dtype)
+    return feeds
+
+
+def compare(
+    reference: List[np.ndarray],
+    candidate: List[np.ndarray],
+    rtol: float = 1e-2,
+    atol: float = 1e-3,
+) -> Tuple[bool, float]:
+    """Return (all_close, max_abs_diff) over matching output tensors."""
+    max_diff = 0.0
+    ok = True
+    for ref, cand in zip(reference, candidate):
+        ref_a = np.asarray(ref, dtype=np.float64)
+        cand_a = np.asarray(cand, dtype=np.float64)
+        if ref_a.shape != cand_a.shape:
+            return False, float("inf")
+        diff = float(np.max(np.abs(ref_a - cand_a))) if ref_a.size else 0.0
+        max_diff = max(max_diff, diff)
+        if not np.allclose(ref_a, cand_a, rtol=rtol, atol=atol):
+            ok = False
+    return ok, max_diff

--- a/scripts/common/synthetic_models.py
+++ b/scripts/common/synthetic_models.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""A small, self-contained suite of ONNX graphs for execution-provider checks.
+
+Shared by the vendor execution-provider compatibility harnesses (Qualcomm QNN,
+Apple CoreML, Intel OpenVINO, ...) under ``scripts/``. These are synthetic
+graphs, deliberately tiny, chosen to (a) cover common layer patterns a target
+backend would see and (b) include the redundancy that onnxsim is meant to
+remove -- foldable constant subgraphs, shape/gather chains feeding a Reshape,
+no-op transposes -- so the checks actually exercise "did simplification
+change the on-device path" rather than just "does a clean graph convert".
+
+Kept network-free on purpose: the fast CI jobs need no downloads. Heavier
+scheduled jobs can layer real onnxmodelzoo models on top later.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, List, Tuple
+
+import numpy as np
+import onnx
+from onnx import TensorProto, helper, numpy_helper
+
+_OPSET = 18
+_IR = 10
+
+
+def _model(nodes, inputs, outputs, initializers, name) -> onnx.ModelProto:
+    graph = helper.make_graph(nodes, name, inputs, outputs, initializers)
+    model = helper.make_model(
+        graph, opset_imports=[helper.make_opsetid("", _OPSET)], ir_version=_IR
+    )
+    onnx.checker.check_model(model)
+    return model
+
+
+def _const(name: str, array: np.ndarray):
+    return numpy_helper.from_array(array, name)
+
+
+def _rand(*shape, seed=0) -> np.ndarray:
+    return np.random.RandomState(seed).randn(*shape).astype(np.float32)
+
+
+def conv_bn_relu() -> onnx.ModelProto:
+    """Conv -> (scale/shift as Mul/Add, foldable) -> Relu -> GlobalAveragePool."""
+    w = _const("w", _rand(8, 3, 3, 3, seed=1))
+    b = _const("b", np.zeros(8, np.float32))
+    scale = _const("scale", _rand(1, 8, 1, 1, seed=2))
+    shift = _const("shift", _rand(1, 8, 1, 1, seed=3))
+    nodes = [
+        helper.make_node("Conv", ["x", "w", "b"], ["c"], pads=[1, 1, 1, 1]),
+        helper.make_node("Mul", ["c", "scale"], ["m"]),
+        helper.make_node("Add", ["m", "shift"], ["a"]),
+        helper.make_node("Relu", ["a"], ["r"]),
+        helper.make_node("GlobalAveragePool", ["r"], ["y"]),
+    ]
+    return _model(
+        nodes,
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3, 16, 16])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 8, 1, 1])],
+        [w, b, scale, shift],
+        "conv_bn_relu",
+    )
+
+
+def foldable_shape_reshape() -> onnx.ModelProto:
+    """Shape -> Gather -> Concat -> Reshape: the classic chain onnxsim folds.
+
+    The reshape target is fully determined by constants, so onnxsim collapses
+    the whole shape-computation subgraph into a single constant. A good check
+    that the folded result still converts and matches.
+    """
+    w = _const("w", _rand(8, 3, 3, 3, seed=1))
+    idx = _const("idx", np.array([0], np.int64))
+    minus1 = _const("m1", np.array([-1], np.int64))
+    ch = _const("ch", np.array([8], np.int64))
+    nodes = [
+        helper.make_node("Conv", ["x", "w"], ["c"], pads=[1, 1, 1, 1]),
+        helper.make_node("Relu", ["c"], ["r"]),
+        helper.make_node("Shape", ["r"], ["shp"]),
+        helper.make_node("Gather", ["shp", "idx"], ["n"], axis=0),
+        helper.make_node("Concat", ["n", "ch", "m1"], ["newshape"], axis=0),
+        helper.make_node("Reshape", ["r", "newshape"], ["y"]),
+    ]
+    return _model(
+        nodes,
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3, 8, 8])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 8, 64])],
+        [w, idx, minus1, ch],
+        "foldable_shape_reshape",
+    )
+
+
+def matmul_bias_tanh() -> onnx.ModelProto:
+    """A small MLP block: MatMul -> Add(bias) -> Tanh.
+
+    The bias is expressed as ``bias0 + bias1`` so onnxsim folds it to a single
+    constant; the backend result must be unchanged by that fold.
+    """
+    wt = _const("wt", _rand(32, 64, seed=4))
+    bias0 = _const("bias0", _rand(64, seed=5))
+    bias1 = _const("bias1", _rand(64, seed=6))
+    nodes = [
+        helper.make_node("Add", ["bias0", "bias1"], ["bias"]),
+        helper.make_node("MatMul", ["x", "wt"], ["mm"]),
+        helper.make_node("Add", ["mm", "bias"], ["h"]),
+        helper.make_node("Tanh", ["h"], ["y"]),
+    ]
+    return _model(
+        nodes,
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [4, 32])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [4, 64])],
+        [wt, bias0, bias1],
+        "matmul_bias_tanh",
+    )
+
+
+def redundant_transpose() -> onnx.ModelProto:
+    """Two transposes that cancel, plus an Add with a foldable constant.
+
+    onnxsim removes the no-op transpose pair and folds ``k0 + k1``; the
+    backend result should be unchanged.
+    """
+    k0 = _const("k0", _rand(1, 4, 8, 8, seed=6))
+    k1 = _const("k1", _rand(1, 4, 8, 8, seed=7))
+    nodes = [
+        helper.make_node("Add", ["k0", "k1"], ["k"]),
+        helper.make_node("Add", ["x", "k"], ["s"]),
+        helper.make_node("Transpose", ["s"], ["t1"], perm=[0, 2, 3, 1]),
+        helper.make_node("Transpose", ["t1"], ["t2"], perm=[0, 3, 1, 2]),
+        helper.make_node("Relu", ["t2"], ["y"]),
+    ]
+    return _model(
+        nodes,
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 4, 8, 8])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 4, 8, 8])],
+        [k0, k1],
+        "redundant_transpose",
+    )
+
+
+def sigmoid_mul_swish() -> onnx.ModelProto:
+    """Conv -> Sigmoid -> Mul (Swish/SiLU), a common mobile activation."""
+    w = _const("w", _rand(6, 3, 1, 1, seed=8))
+    nodes = [
+        helper.make_node("Conv", ["x", "w"], ["c"]),
+        helper.make_node("Sigmoid", ["c"], ["s"]),
+        helper.make_node("Mul", ["c", "s"], ["y"]),
+    ]
+    return _model(
+        nodes,
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3, 12, 12])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 6, 12, 12])],
+        [w],
+        "sigmoid_mul_swish",
+    )
+
+
+# Ordered so the registry is stable across runs.
+_BUILDERS: List[Tuple[str, Callable[[], onnx.ModelProto]]] = [
+    ("conv_bn_relu", conv_bn_relu),
+    ("foldable_shape_reshape", foldable_shape_reshape),
+    ("matmul_bias_tanh", matmul_bias_tanh),
+    ("redundant_transpose", redundant_transpose),
+    ("sigmoid_mul_swish", sigmoid_mul_swish),
+]
+
+
+def all_models() -> Dict[str, onnx.ModelProto]:
+    """Build the whole suite: {name: ModelProto}."""
+    return {name: build() for name, build in _BUILDERS}
+
+
+def names() -> List[str]:
+    return [name for name, _ in _BUILDERS]
+
+
+def build(name: str) -> onnx.ModelProto:
+    for n, builder in _BUILDERS:
+        if n == name:
+            return builder()
+    raise KeyError(name)
+
+
+if __name__ == "__main__":
+    for n, m in all_models().items():
+        print(f"{n:24} {len(m.graph.node)} nodes")

--- a/scripts/intel/README.md
+++ b/scripts/intel/README.md
@@ -1,0 +1,78 @@
+# Intel OpenVINO integration check
+
+Verifies that `onnxsim`'s output still works with **OpenVINO** — Intel's
+inference toolkit. The goal is to catch the failure mode the unit tests and
+the large-model regression don't: a simplification that produces a graph
+OpenVINO can no longer **compile**, or that **changes the result** on Intel's
+stack.
+
+It uses the pip-installable [`onnxruntime-openvino`](https://pypi.org/project/onnxruntime-openvino/)
+wheel (a separate build of ONNX Runtime that bundles the OpenVINO EP — it
+replaces, rather than supplements, plain `onnxruntime`). The default `CPU`
+device target needs no discrete Intel hardware or driver, so the whole check
+runs on an ordinary x86-64 CI runner with nothing but
+`pip install onnxruntime-openvino`.
+
+## What it checks
+
+For each model the harness runs **original vs. simplified through the same
+OpenVINO backend**, so backend quirks cancel and only an onnxsim-introduced
+change can fail the run:
+
+1. `simplify` the model with onnxsim.
+2. Compile + run the **original** graph on the OpenVINO EP.
+   If that already fails, the backend just doesn't support the graph →
+   reported as `unsupported`, **not** a failure.
+3. Compile + run the **simplified** graph on the OpenVINO EP.
+   If the original compiled but the simplified doesn't → `openvino_regression`
+   (a failure): simplification broke OpenVINO compatibility.
+4. Compare the two OpenVINO outputs. Divergence beyond tolerance →
+   `openvino_regression`: simplification changed the on-device result.
+5. Record the ONNX Runtime CPU-reference diff and the OpenVINO **coverage**
+   (does the whole graph map onto OpenVINO, or do some nodes fall back to
+   ORT's CPU provider) as information.
+
+Partial coverage and `unsupported` are reported, never failed — plenty of
+valid graphs are not 100% OpenVINO-mappable, and that is a backend property,
+not an onnxsim bug.
+
+## Files
+
+| file | purpose |
+| --- | --- |
+| `openvino_backend.py` | wraps the OpenVINO EP: builds/runs a model on OpenVINO (`CPU` device target by default) and on the plain ORT CPU reference, measures coverage. Degrades gracefully (`OPENVINO_AVAILABLE`) when the EP is absent. |
+| `models.py` | alias for `scripts/common/synthetic_models.py`, the small synthetic-graph suite shared with the other EP harnesses. |
+| `worker.py` | runs the check for one model in an isolated subprocess, printing one `__RESULT__<json>` line. |
+| `run_openvino_compat.py` | drives the suite, writes a CSV, and exits non-zero on any regression. Entry point for CI. |
+
+## Running locally
+
+```bash
+pip install onnxruntime-openvino   # NOT alongside plain onnxruntime
+pip install .                      # or install an onnxsim wheel
+
+python scripts/intel/run_openvino_compat.py --output openvino-compat.csv
+```
+
+The in-tree smoke test `tests/test_openvino_compat.py` reuses this harness
+and is skipped automatically when `onnxruntime-openvino` isn't installed.
+
+## Fidelity tiers (what this does and doesn't cover)
+
+This check runs the real OpenVINO compiler/runtime targeting the `CPU`
+device — real numerics, no emulation, but only one of OpenVINO's device
+targets.
+
+- **GPU / NPU targets.** Set `OPENVINO_DEVICE_TYPE=GPU` (or `NPU`) on a host
+  with the matching Intel hardware and drivers to exercise those instead; the
+  harness picks it up unchanged. CI here only covers `CPU` since that's the
+  only target free-tier runners have.
+- **Quantized / INT8 paths.** This suite is fp32 only; OpenVINO's NNCF
+  quantization pipeline is a separate concern from graph compatibility.
+
+## Extending
+
+`models.py` is intentionally small and self-contained so the CI job needs no
+downloads. Real models can be layered on by passing an on-disk path as
+`worker.py`'s second argument, the same way `scripts/qualcomm` and
+`scripts/regression` do.

--- a/scripts/intel/models.py
+++ b/scripts/intel/models.py
@@ -1,12 +1,5 @@
 #!/usr/bin/env python3
-"""Qualcomm-side alias for the shared synthetic model suite.
-
-The suite itself moved to ``scripts/common/synthetic_models.py`` so the Apple
-CoreML and Intel OpenVINO harnesses can reuse it without duplicating ~180
-lines of graph builders. This module re-exports the same public API so
-``worker.py``'s ``import models`` and ``tests/test_qnn_compat.py``'s
-``models.names()`` / ``models.conv_bn_relu()`` keep working unchanged.
-"""
+"""Intel-side alias for the shared synthetic model suite. See scripts/common/."""
 
 from __future__ import annotations
 

--- a/scripts/intel/models.py
+++ b/scripts/intel/models.py
@@ -7,19 +7,29 @@ import os
 import sys
 
 _SCRIPTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if _SCRIPTS_DIR not in sys.path:
+# Only keep scripts/ on sys.path for the duration of this import: scripts/
+# also holds directories like rfdetr/ with no __init__.py, which Python 3
+# treats as importable namespace packages. Leaving scripts/ on sys.path for
+# the rest of the process would make `import rfdetr` "succeed" as that empty
+# namespace package instead of skipping via pytest.importorskip, and shadow
+# the real one everywhere else it's checked for.
+_inserted = _SCRIPTS_DIR not in sys.path
+if _inserted:
     sys.path.insert(0, _SCRIPTS_DIR)
-
-from common.synthetic_models import (  # noqa: E402,F401
-    all_models,
-    build,
-    conv_bn_relu,
-    foldable_shape_reshape,
-    matmul_bias_tanh,
-    names,
-    redundant_transpose,
-    sigmoid_mul_swish,
-)
+try:
+    from common.synthetic_models import (  # noqa: E402,F401
+        all_models,
+        build,
+        conv_bn_relu,
+        foldable_shape_reshape,
+        matmul_bias_tanh,
+        names,
+        redundant_transpose,
+        sigmoid_mul_swish,
+    )
+finally:
+    if _inserted:
+        sys.path.remove(_SCRIPTS_DIR)
 
 if __name__ == "__main__":
     for n, m in all_models().items():

--- a/scripts/intel/openvino_backend.py
+++ b/scripts/intel/openvino_backend.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Thin wrapper around the ONNX Runtime OpenVINO execution provider.
+
+Intel's OpenVINO EP does **not** ship in the standard ``onnxruntime`` PyPI
+wheel; it comes from the separate
+[`onnxruntime-openvino`](https://pypi.org/project/onnxruntime-openvino/)
+package (which bundles its own OpenVINO runtime and replaces plain
+``onnxruntime`` -- the two must not be installed side by side). Its default
+``CPU`` device target runs on any x86-64 host, no Intel-specific hardware or
+driver needed, so this runs on a stock CI runner with nothing but
+``pip install onnxruntime-openvino``.
+
+This gives two signals:
+
+* **compatibility** -- does the (simplified) graph compile onto OpenVINO at
+  all, and how much of it maps onto the backend vs. falling back to ONNX
+  Runtime's CPU provider;
+* **numerics** -- does the OpenVINO result match the plain ONNX Runtime CPU
+  reference, i.e. did onnxsim preserve semantics along the OpenVINO path.
+
+This module degrades gracefully: on a host where the OpenVINO EP is not
+present (``onnxruntime-openvino`` not installed) ``OPENVINO_AVAILABLE`` is
+False and ``unavailable_reason()`` explains why, so callers can skip rather
+than error.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Dict, List
+
+import numpy as np
+import onnx
+
+_SCRIPTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+from common.ep_numerics import compare, random_feeds  # noqa: E402,F401
+
+_EP_NAME = "OpenVINOExecutionProvider"
+# CPU needs no discrete Intel hardware/driver, so it's the device target that
+# runs unconditionally on any CI runner. Override for a GPU/NPU-equipped host.
+_DEVICE_TYPE = os.environ.get("OPENVINO_DEVICE_TYPE", "CPU")
+
+OPENVINO_AVAILABLE = False
+_UNAVAILABLE_REASON: str | None = None
+
+try:
+    import onnxruntime as ort
+
+    if _EP_NAME not in ort.get_available_providers():
+        raise RuntimeError(
+            "OpenVINOExecutionProvider not available "
+            "(install onnxruntime-openvino, not plain onnxruntime)"
+        )
+    OPENVINO_AVAILABLE = True
+except Exception as exc:  # pragma: no cover - depends on the host
+    _UNAVAILABLE_REASON = f"{type(exc).__name__}: {exc}"
+
+
+def unavailable_reason() -> str | None:
+    """Why the OpenVINO EP is unusable on this host, or None if it is usable."""
+    return _UNAVAILABLE_REASON
+
+
+def _session_options(strict: bool):
+    so = ort.SessionOptions()
+    so.log_severity_level = 3  # ERROR
+    if strict:
+        # Fail session creation if any node cannot be placed on OpenVINO,
+        # instead of silently falling back to ORT's CPU provider. Used to
+        # measure coverage.
+        so.add_session_config_entry("session.disable_cpu_ep_fallback", "1")
+    return so
+
+
+def _openvino_provider_options() -> Dict[str, str]:
+    return {"device_type": _DEVICE_TYPE}
+
+
+def run_with_openvino(
+    model: onnx.ModelProto,
+    feeds: Dict[str, np.ndarray],
+    strict: bool = False,
+) -> List[np.ndarray]:
+    """Run ``model`` on the OpenVINO EP, returning the outputs.
+
+    With ``strict=True`` the session is built with CPU fallback disabled, so
+    creation raises unless the *entire* graph maps onto OpenVINO.
+    """
+    so = _session_options(strict)
+    providers = [(_EP_NAME, _openvino_provider_options())]
+    if not strict:
+        providers.append("CPUExecutionProvider")
+    sess = ort.InferenceSession(
+        model.SerializeToString(), sess_options=so, providers=providers
+    )
+    return sess.run(None, feeds)
+
+
+def run_with_cpu(
+    model: onnx.ModelProto, feeds: Dict[str, np.ndarray]
+) -> List[np.ndarray]:
+    """Run ``model`` on ONNX Runtime's plain CPU provider (the numerical reference)."""
+    so = _session_options(strict=False)
+    sess = ort.InferenceSession(
+        model.SerializeToString(),
+        sess_options=so,
+        providers=["CPUExecutionProvider"],
+    )
+    return sess.run(None, feeds)
+
+
+def coverage(model: onnx.ModelProto) -> str:
+    """ "full" if the whole graph maps onto OpenVINO, else "partial".
+
+    Determined by trying to build a session with CPU fallback disabled:
+    success means every node was accepted by the OpenVINO EP.
+    """
+    try:
+        run_with_openvino(model, random_feeds(model), strict=True)
+        return "full"
+    except Exception:
+        return "partial"

--- a/scripts/intel/openvino_backend.py
+++ b/scripts/intel/openvino_backend.py
@@ -34,10 +34,20 @@ import numpy as np
 import onnx
 
 _SCRIPTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if _SCRIPTS_DIR not in sys.path:
+# Only keep scripts/ on sys.path for the duration of this import: scripts/
+# also holds directories like rfdetr/ with no __init__.py, which Python 3
+# treats as importable namespace packages. Leaving scripts/ on sys.path for
+# the rest of the process would make `import rfdetr` "succeed" as that empty
+# namespace package instead of skipping via pytest.importorskip, and shadow
+# the real one everywhere else it's checked for.
+_inserted = _SCRIPTS_DIR not in sys.path
+if _inserted:
     sys.path.insert(0, _SCRIPTS_DIR)
-
-from common.ep_numerics import compare, random_feeds  # noqa: E402,F401
+try:
+    from common.ep_numerics import compare, random_feeds  # noqa: E402,F401
+finally:
+    if _inserted:
+        sys.path.remove(_SCRIPTS_DIR)
 
 _EP_NAME = "OpenVINOExecutionProvider"
 # CPU needs no discrete Intel hardware/driver, so it's the device target that

--- a/scripts/intel/run_openvino_compat.py
+++ b/scripts/intel/run_openvino_compat.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Run the OpenVINO compatibility check over the model suite and report.
+
+Drives ``worker.py`` once per model (isolated subprocess, hard timeout),
+collects the JSON results, writes a CSV, prints a summary, and exits non-zero
+if any model failed. This is the entry point the ``Intel Integration``
+workflow calls.
+
+A model **fails** the check when simplification breaks OpenVINO compatibility
+or changes the on-device result (``openvino_regression``), when onnxsim
+raises (``simplify_error``), or when the worker crashes/times out. A graph
+the OpenVINO backend cannot handle even *before* simplification is
+``unsupported`` and is **reported, not failed** -- that is a backend
+limitation, not an onnxsim bug. Partial OpenVINO coverage (some nodes falling
+back to ORT's CPU provider) is likewise reported, not failed.
+
+If the OpenVINO EP is unavailable on the host, every model reports
+``skipped`` and the run passes (nothing to test) unless
+``--require-openvino`` is given.
+
+Usage:
+    run_openvino_compat.py --output openvino-compat.csv
+    run_openvino_compat.py --require-openvino   # fail if the OpenVINO EP is missing
+    run_openvino_compat.py --models conv_bn_relu matmul_bias_tanh
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import subprocess
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import models  # noqa: E402
+
+FAIL_STATUSES = {"openvino_regression", "simplify_error", "crash", "timeout", "error"}
+
+
+def run_one(model_name: str, timeout: int) -> dict:
+    t0 = time.time()
+    try:
+        proc = subprocess.run(
+            [sys.executable, os.path.join(HERE, "worker.py"), model_name],
+            capture_output=True,
+            text=True,
+            timeout=None if timeout <= 0 else timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "model": model_name,
+            "status": "timeout",
+            "error": f">{timeout}s",
+            "seconds": timeout,
+        }
+    result = None
+    for line in proc.stdout.splitlines():
+        if line.startswith("__RESULT__"):
+            result = json.loads(line[len("__RESULT__") :])
+    if result is None:
+        result = {
+            "model": model_name,
+            "status": "crash",
+            "error": (proc.stderr or proc.stdout or "no result line")[-400:],
+            "seconds": round(time.time() - t0, 1),
+        }
+    return result
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--models",
+        nargs="*",
+        default=None,
+        help="subset of model names to run (default: the whole suite)",
+    )
+    ap.add_argument(
+        "--timeout",
+        type=int,
+        default=600,
+        help="per-model wall-clock cap in seconds; <=0 disables",
+    )
+    ap.add_argument(
+        "--require-openvino",
+        action="store_true",
+        help="fail if the OpenVINO EP is unavailable instead of skipping",
+    )
+    ap.add_argument("--output", default="openvino-compat.csv")
+    args = ap.parse_args()
+
+    selected = args.models or models.names()
+    print(f"OpenVINO compatibility check | {len(selected)} models", flush=True)
+
+    rows = []
+    failures = []
+    skipped = 0
+    for i, name in enumerate(selected, 1):
+        print(f"[{i}/{len(selected)}] {name} ...", end=" ", flush=True)
+        r = run_one(name, args.timeout)
+        rows.append(r)
+        status = r.get("status")
+        if status == "skipped":
+            skipped += 1
+            print(f"skipped ({r.get('error')})", flush=True)
+            continue
+        detail = ""
+        if r.get("orig_nodes") is not None:
+            detail = f"{r.get('orig_nodes')}->{r.get('simp_nodes')} nodes"
+        if r.get("coverage_orig") or r.get("coverage_simp"):
+            detail += f", openvino={r.get('coverage_orig')}->{r.get('coverage_simp')}"
+        if r.get("diff_vs_openvino_orig") is not None:
+            detail += f", d(orig)={r.get('diff_vs_openvino_orig'):.2g}"
+        print(f"{status} ({detail}) {r.get('seconds')}s", flush=True)
+        if status in FAIL_STATUSES:
+            failures.append((name, status, str(r.get("error"))[:200]))
+
+    fields = [
+        "model",
+        "status",
+        "orig_nodes",
+        "simp_nodes",
+        "coverage_orig",
+        "coverage_simp",
+        "diff_vs_openvino_orig",
+        "diff_vs_cpu_ref",
+        "seconds",
+        "error",
+    ]
+    with open(args.output, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fields, extrasaction="ignore")
+        w.writeheader()
+        for r in rows:
+            w.writerow(r)
+    print(f"\nwrote {args.output} ({len(rows)} rows)", flush=True)
+
+    if skipped == len(selected):
+        msg = "OpenVINO EP unavailable on this host; all models skipped."
+        if args.require_openvino:
+            print(f"\n{msg} (--require-openvino set -> failing)", flush=True)
+            return 1
+        print(f"\n{msg} Nothing to test; passing.", flush=True)
+        return 0
+
+    if failures:
+        print(f"\n{len(failures)} FAILED:", flush=True)
+        for name, status, err in failures:
+            print(f"  - {name}: {status} {err}", flush=True)
+        return 1
+    passed = sum(1 for r in rows if r.get("status") == "ok")
+    unsupported = sum(1 for r in rows if r.get("status") == "unsupported")
+    print(
+        f"\nall passed ({passed} ok, {unsupported} unsupported, {skipped} skipped)",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/intel/worker.py
+++ b/scripts/intel/worker.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Check one model against the OpenVINO execution provider, in an isolated subprocess.
+
+Run as ``worker.py <model_name> [onnx_path]``. With just a name, the model
+comes from the shared ``common/synthetic_models.py`` suite; with an
+``onnx_path`` the graph is loaded from disk. Each model runs in its own
+process (mirrors the QNN/Core ML harnesses) and the final stdout line is
+exactly ``__RESULT__<json>``.
+
+The check is framed as *original vs. simplified on the same OpenVINO
+backend*, so a backend limitation (an op OpenVINO declines to place) cancels
+out and only an onnxsim-introduced change can fail the run. For one model:
+
+1. ``simplify`` it with onnxsim.
+2. Run the **original** graph on the OpenVINO EP.
+   * If that already fails to compile/run, the backend simply does not
+     support this graph -- status ``unsupported`` (reported, not a failure).
+3. Run the **simplified** graph on the OpenVINO EP.
+   * If the original ran but the simplified does not, simplification broke
+     OpenVINO compatibility -- status ``openvino_regression`` (a failure).
+4. Compare the two OpenVINO outputs. Divergence beyond tolerance means
+   simplification changed the on-device result -- ``openvino_regression``.
+5. Also record the ONNX Runtime CPU reference diff and the OpenVINO coverage
+   (full vs. partial) for both graphs, as information.
+
+Status values:
+
+* ``ok``                   - original & simplified both ran on OpenVINO and agreed.
+* ``openvino_regression``  - the simplified graph broke OpenVINO compat or changed results.
+* ``simplify_error``       - onnxsim raised on this model.
+* ``unsupported``          - the OpenVINO backend could not handle even the original graph.
+* ``skipped``              - the OpenVINO EP is not available on this host.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import traceback
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+
+def check(model_name: str, onnx_path: str | None) -> dict:
+    res = {
+        "model": model_name,
+        "status": "error",
+        "orig_nodes": None,
+        "simp_nodes": None,
+        "coverage_orig": None,
+        "coverage_simp": None,
+        "diff_vs_openvino_orig": None,
+        "diff_vs_cpu_ref": None,
+        "error": None,
+        "seconds": None,
+    }
+    t0 = time.time()
+    try:
+        import onnx
+        import openvino_backend as openvino
+
+        if not openvino.OPENVINO_AVAILABLE:
+            res["status"] = "skipped"
+            res["error"] = openvino.unavailable_reason()
+            return res
+
+        from onnxsim import simplify
+
+        if onnx_path:
+            model = onnx.load(onnx_path)
+        else:
+            import models
+
+            model = models.build(model_name)
+        res["orig_nodes"] = len(model.graph.node)
+
+        try:
+            simp, _check_ok = simplify(model)
+        except Exception as exc:
+            res["status"] = "simplify_error"
+            res["error"] = f"{type(exc).__name__}: {exc}"
+            return res
+        res["simp_nodes"] = len(simp.graph.node)
+
+        feeds = openvino.random_feeds(model, seed=0)
+
+        # ORT CPU reference (informational end-to-end check).
+        cpu_ref = openvino.run_with_cpu(model, feeds)
+
+        # Original graph on OpenVINO. If this fails, the backend can't handle
+        # the graph at all -- not something onnxsim did.
+        try:
+            res["coverage_orig"] = openvino.coverage(model)
+            openvino_orig = openvino.run_with_openvino(model, feeds)
+        except Exception as exc:
+            res["status"] = "unsupported"
+            res["error"] = f"original graph not supported by OpenVINO: {exc}"
+            return res
+
+        # Simplified graph on OpenVINO. The original worked, so a failure
+        # here is an onnxsim-introduced compatibility regression.
+        try:
+            res["coverage_simp"] = openvino.coverage(simp)
+            openvino_simp = openvino.run_with_openvino(simp, feeds)
+        except Exception as exc:
+            res["status"] = "openvino_regression"
+            res["error"] = f"simplified graph broke OpenVINO compile/run: {exc}"
+            return res
+
+        # Simplification must not change the on-device result.
+        agree, diff_backend = openvino.compare(openvino_orig, openvino_simp)
+        _, diff_ref = openvino.compare(cpu_ref, openvino_simp)
+        res["diff_vs_openvino_orig"] = diff_backend
+        res["diff_vs_cpu_ref"] = diff_ref
+        if agree:
+            res["status"] = "ok"
+        else:
+            res["status"] = "openvino_regression"
+            res["error"] = (
+                f"simplified OpenVINO output diverged from original "
+                f"(max_abs_diff={diff_backend:.3g})"
+            )
+    except Exception as exc:
+        res["error"] = f"{type(exc).__name__}: {exc}"
+        res["trace"] = traceback.format_exc()[-800:]
+    finally:
+        res["seconds"] = round(time.time() - t0, 1)
+    return res
+
+
+if __name__ == "__main__":
+    name = sys.argv[1]
+    path = sys.argv[2] if len(sys.argv) > 2 else None
+    print("__RESULT__" + json.dumps(check(name, path)))

--- a/scripts/qualcomm/README.md
+++ b/scripts/qualcomm/README.md
@@ -16,10 +16,11 @@ the **x86 host emulator**. So the whole check runs on a free GitHub-hosted runne
 with nothing but `pip install onnxruntime-qnn`.
 
 Sibling checks for other vendor execution providers follow the same
-pattern: [`scripts/apple`](../apple) (Core ML) and
-[`scripts/intel`](../intel) (OpenVINO). NVIDIA (CUDA/TensorRT) and AMD
-(MIGraphX/ROCm) need real GPU hardware and aren't covered by a CI-runner
-harness yet.
+pattern: [`scripts/apple`](../apple) (Core ML), [`scripts/intel`](../intel)
+(OpenVINO), and [`scripts/amd`](../amd) (MIGraphX -- needs a self-hosted ROCm
+runner, since unlike the other three it has no CPU fallback or emulator, so
+its workflow is dormant until one is provisioned). NVIDIA (CUDA/TensorRT)
+needs real GPU hardware too and isn't covered by a harness yet.
 
 ## What it checks
 

--- a/scripts/qualcomm/README.md
+++ b/scripts/qualcomm/README.md
@@ -15,6 +15,12 @@ preparation a Qualcomm converter runs) and then executes the compiled graph in
 the **x86 host emulator**. So the whole check runs on a free GitHub-hosted runner
 with nothing but `pip install onnxruntime-qnn`.
 
+Sibling checks for other vendor execution providers follow the same
+pattern: [`scripts/apple`](../apple) (Core ML) and
+[`scripts/intel`](../intel) (OpenVINO). NVIDIA (CUDA/TensorRT) and AMD
+(MIGraphX/ROCm) need real GPU hardware and aren't covered by a CI-runner
+harness yet.
+
 ## What it checks
 
 For each model the harness runs **original vs. simplified through the same QNN
@@ -42,8 +48,8 @@ bug.
 
 | file | purpose |
 | --- | --- |
-| `qnn_backend.py` | wraps the QNN EP: registers the plugin, builds/runs a model on QNN (offline HTP compile + x86 emulation) and on the ORT CPU reference, measures coverage, synthesizes inputs, compares outputs. Degrades gracefully (`QNN_AVAILABLE`) when the EP is absent. |
-| `models.py` | a small, network-free suite of synthetic graphs covering common layer patterns (conv/BN/relu, foldable shape→reshape, MLP, cancelling transposes, swish), each carrying the redundancy onnxsim is meant to remove. |
+| `qnn_backend.py` | wraps the QNN EP: registers the plugin, builds/runs a model on QNN (offline HTP compile + x86 emulation) and on the ORT CPU reference, measures coverage. Input synthesis/comparison come from `scripts/common/ep_numerics.py`. Degrades gracefully (`QNN_AVAILABLE`) when the EP is absent. |
+| `models.py` | alias for `scripts/common/synthetic_models.py`, a small, network-free suite of synthetic graphs covering common layer patterns (conv/BN/relu, foldable shape→reshape, MLP, cancelling transposes, swish), each carrying the redundancy onnxsim is meant to remove. Shared with the Apple Core ML (`scripts/apple`) and Intel OpenVINO (`scripts/intel`) harnesses so the suite isn't duplicated per vendor. |
 | `worker.py` | runs the check for one model in an isolated subprocess (the HTP compiler can abort at the C++ level), printing one `__RESULT__<json>` line. |
 | `run_qnn_compat.py` | drives the suite, writes a CSV, and exits non-zero on any regression. Entry point for CI. |
 

--- a/scripts/qualcomm/models.py
+++ b/scripts/qualcomm/models.py
@@ -14,19 +14,29 @@ import os
 import sys
 
 _SCRIPTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if _SCRIPTS_DIR not in sys.path:
+# Only keep scripts/ on sys.path for the duration of this import: scripts/
+# also holds directories like rfdetr/ with no __init__.py, which Python 3
+# treats as importable namespace packages. Leaving scripts/ on sys.path for
+# the rest of the process would make `import rfdetr` "succeed" as that empty
+# namespace package instead of skipping via pytest.importorskip, and shadow
+# the real one everywhere else it's checked for.
+_inserted = _SCRIPTS_DIR not in sys.path
+if _inserted:
     sys.path.insert(0, _SCRIPTS_DIR)
-
-from common.synthetic_models import (  # noqa: E402,F401
-    all_models,
-    build,
-    conv_bn_relu,
-    foldable_shape_reshape,
-    matmul_bias_tanh,
-    names,
-    redundant_transpose,
-    sigmoid_mul_swish,
-)
+try:
+    from common.synthetic_models import (  # noqa: E402,F401
+        all_models,
+        build,
+        conv_bn_relu,
+        foldable_shape_reshape,
+        matmul_bias_tanh,
+        names,
+        redundant_transpose,
+        sigmoid_mul_swish,
+    )
+finally:
+    if _inserted:
+        sys.path.remove(_SCRIPTS_DIR)
 
 if __name__ == "__main__":
     for n, m in all_models().items():

--- a/scripts/qualcomm/qnn_backend.py
+++ b/scripts/qualcomm/qnn_backend.py
@@ -36,10 +36,20 @@ import numpy as np
 import onnx
 
 _SCRIPTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if _SCRIPTS_DIR not in sys.path:
+# Only keep scripts/ on sys.path for the duration of this import: scripts/
+# also holds directories like rfdetr/ with no __init__.py, which Python 3
+# treats as importable namespace packages. Leaving scripts/ on sys.path for
+# the rest of the process would make `import rfdetr` "succeed" as that empty
+# namespace package instead of skipping via pytest.importorskip, and shadow
+# the real one everywhere else it's checked for.
+_inserted = _SCRIPTS_DIR not in sys.path
+if _inserted:
     sys.path.insert(0, _SCRIPTS_DIR)
-
-from common.ep_numerics import compare, random_feeds  # noqa: E402,F401
+try:
+    from common.ep_numerics import compare, random_feeds  # noqa: E402,F401
+finally:
+    if _inserted:
+        sys.path.remove(_SCRIPTS_DIR)
 
 # HTP graph-finalization optimization level. "3" is the most aggressive offline
 # optimization; it makes the compile a little slower but exercises the same path

--- a/scripts/qualcomm/qnn_backend.py
+++ b/scripts/qualcomm/qnn_backend.py
@@ -29,10 +29,17 @@ from __future__ import annotations
 
 import contextlib
 import os
-from typing import Dict, List, Optional, Tuple
+import sys
+from typing import Dict, List, Optional
 
 import numpy as np
 import onnx
+
+_SCRIPTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+from common.ep_numerics import compare, random_feeds  # noqa: E402,F401
 
 # HTP graph-finalization optimization level. "3" is the most aggressive offline
 # optimization; it makes the compile a little slower but exercises the same path
@@ -182,66 +189,3 @@ def coverage(model: onnx.ModelProto) -> str:
         return "full"
     except Exception:
         return "partial"
-
-
-_ELEM_TO_NP = {
-    onnx.TensorProto.FLOAT: np.float32,
-    onnx.TensorProto.DOUBLE: np.float64,
-    onnx.TensorProto.FLOAT16: np.float16,
-    onnx.TensorProto.INT64: np.int64,
-    onnx.TensorProto.INT32: np.int32,
-    onnx.TensorProto.BOOL: np.bool_,
-}
-
-
-def random_feeds(
-    model: onnx.ModelProto, seed: int = 0, default_dim: int = 1
-) -> Dict[str, np.ndarray]:
-    """Deterministic random inputs for every graph input that is not an initializer.
-
-    Unknown / dynamic dimensions (``dim_param`` or missing) are filled with
-    ``default_dim``. Float inputs use a small range so HTP emulation does not
-    overflow; integer inputs use small non-negative values.
-    """
-    rng = np.random.RandomState(seed)
-    initializers = {init.name for init in model.graph.initializer}
-    feeds: Dict[str, np.ndarray] = {}
-    for inp in model.graph.input:
-        if inp.name in initializers:
-            continue
-        ttype = inp.type.tensor_type
-        shape = []
-        for dim in ttype.shape.dim:
-            if dim.HasField("dim_value") and dim.dim_value > 0:
-                shape.append(dim.dim_value)
-            else:
-                shape.append(default_dim)
-        np_dtype = _ELEM_TO_NP.get(ttype.elem_type, np.float32)
-        if np.issubdtype(np_dtype, np.floating):
-            feeds[inp.name] = (rng.rand(*shape).astype(np_dtype) - 0.5) * 2.0
-        elif np_dtype == np.bool_:
-            feeds[inp.name] = rng.rand(*shape) > 0.5
-        else:
-            feeds[inp.name] = rng.randint(0, 4, size=shape).astype(np_dtype)
-    return feeds
-
-
-def compare(
-    reference: List[np.ndarray],
-    candidate: List[np.ndarray],
-    rtol: float = 1e-2,
-    atol: float = 1e-3,
-) -> Tuple[bool, float]:
-    """Return (all_close, max_abs_diff) over matching output tensors."""
-    max_diff = 0.0
-    ok = True
-    for ref, cand in zip(reference, candidate):
-        ref_a = np.asarray(ref, dtype=np.float64)
-        cand_a = np.asarray(cand, dtype=np.float64)
-        if ref_a.shape != cand_a.shape:
-            return False, float("inf")
-        diff = float(np.max(np.abs(ref_a - cand_a))) if ref_a.size else 0.0
-        max_diff = max(max_diff, diff)
-        if not np.allclose(ref_a, cand_a, rtol=rtol, atol=atol):
-            ok = False
-    return ok, max_diff

--- a/tests/test_coreml_compat.py
+++ b/tests/test_coreml_compat.py
@@ -1,0 +1,57 @@
+"""Apple Core ML execution-provider compatibility test.
+
+Verifies that onnxsim's output still compiles and runs on Apple's Core ML
+execution provider, and that simplification does not change the on-device
+result. Uses the ``CoreMLExecutionProvider`` built into the standard
+``onnxruntime`` pip wheel's macOS build.
+
+The whole module is skipped when the Core ML EP is unavailable (any host
+other than macOS, or a CPU-only onnxruntime build), so it is safe to keep in
+``tests/``. The heavier, curated model sweep lives in ``scripts/apple`` and
+runs on a schedule; this file is the fast, in-tree smoke test.
+"""
+
+import os
+import sys
+
+import pytest
+
+# The Core ML harness lives under scripts/apple; reuse it rather than duplicate.
+_APPLE_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "apple"
+)
+if _APPLE_DIR not in sys.path:
+    sys.path.insert(0, _APPLE_DIR)
+
+import coreml_backend as coreml  # noqa: E402
+import models  # noqa: E402
+from worker import check  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    not coreml.COREML_AVAILABLE,
+    reason=f"Core ML execution provider unavailable: {coreml.unavailable_reason()}",
+)
+
+
+@pytest.mark.parametrize("name", models.names())
+def test_coreml_compat_suite(name):
+    """Each suite model: simplification must not break or change the Core ML result."""
+    result = check(name, None)
+    # ``unsupported`` (the backend can't handle the graph at all) is acceptable;
+    # a regression / crash / error is not.
+    assert result["status"] in ("ok", "unsupported"), result
+
+
+def test_coreml_matches_cpu_reference():
+    """A directly-built graph: Core ML(simplified) matches the ORT CPU reference."""
+    from onnxsim import simplify
+
+    model = models.conv_bn_relu()
+    simp, _ = simplify(model)
+    feeds = coreml.random_feeds(model, seed=0)
+
+    reference = coreml.run_with_cpu(model, feeds)
+    candidate = coreml.run_with_coreml(simp, feeds)
+
+    close, max_diff = coreml.compare(reference, candidate)
+    assert close, f"Core ML output diverged from CPU reference: max_abs_diff={max_diff}"

--- a/tests/test_migraphx_compat.py
+++ b/tests/test_migraphx_compat.py
@@ -1,0 +1,62 @@
+"""AMD MIGraphX execution-provider compatibility test.
+
+Verifies that onnxsim's output still compiles and runs on AMD's MIGraphX
+execution provider, and that simplification does not change the on-device
+result. Uses the pip-installable ``onnxruntime-migraphx`` wheel. Unlike the
+Core ML / OpenVINO checks, MIGraphX has no CPU fallback or emulator -- it
+needs a real ROCm-capable AMD GPU, so this module is skipped on every
+ordinary CI runner and only runs where that hardware is present.
+
+The whole module is skipped when the MIGraphX EP isn't usable (package
+missing, or no ROCm device answers), so it is safe to keep in ``tests/``. The
+heavier, curated model sweep lives in ``scripts/amd`` and is meant to run on
+a self-hosted ROCm runner; this file is the fast, in-tree smoke test for that
+same hardware.
+"""
+
+import os
+import sys
+
+import pytest
+
+# The MIGraphX harness lives under scripts/amd; reuse it rather than duplicate.
+_AMD_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "amd"
+)
+if _AMD_DIR not in sys.path:
+    sys.path.insert(0, _AMD_DIR)
+
+import migraphx_backend as migraphx  # noqa: E402
+import models  # noqa: E402
+from worker import check  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    not migraphx.MIGRAPHX_AVAILABLE,
+    reason=f"MIGraphX execution provider unavailable: {migraphx.unavailable_reason()}",
+)
+
+
+@pytest.mark.parametrize("name", models.names())
+def test_migraphx_compat_suite(name):
+    """Each suite model: simplification must not break or change the MIGraphX result."""
+    result = check(name, None)
+    # ``unsupported`` (the backend can't handle the graph at all) is acceptable;
+    # a regression / crash / error is not.
+    assert result["status"] in ("ok", "unsupported"), result
+
+
+def test_migraphx_matches_cpu_reference():
+    """A directly-built graph: MIGraphX(simplified) matches the ORT CPU reference."""
+    from onnxsim import simplify
+
+    model = models.conv_bn_relu()
+    simp, _ = simplify(model)
+    feeds = migraphx.random_feeds(model, seed=0)
+
+    reference = migraphx.run_with_cpu(model, feeds)
+    candidate = migraphx.run_with_migraphx(simp, feeds)
+
+    close, max_diff = migraphx.compare(reference, candidate)
+    assert close, (
+        f"MIGraphX output diverged from CPU reference: max_abs_diff={max_diff}"
+    )

--- a/tests/test_openvino_compat.py
+++ b/tests/test_openvino_compat.py
@@ -1,0 +1,60 @@
+"""Intel OpenVINO execution-provider compatibility test.
+
+Verifies that onnxsim's output still compiles and runs on Intel's OpenVINO
+execution provider, and that simplification does not change the on-device
+result. Uses the pip-installable ``onnxruntime-openvino`` wheel with its
+``CPU`` device target, so it runs on an ordinary x86-64 CI runner with no
+Intel-specific hardware.
+
+The whole module is skipped when ``onnxruntime-openvino`` is not installed
+(the default test matrix does not pull it in), so it is safe to keep in
+``tests/``. The heavier, curated model sweep lives in ``scripts/intel`` and
+runs on a schedule; this file is the fast, in-tree smoke test.
+"""
+
+import os
+import sys
+
+import pytest
+
+# The OpenVINO harness lives under scripts/intel; reuse it rather than duplicate.
+_INTEL_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "intel"
+)
+if _INTEL_DIR not in sys.path:
+    sys.path.insert(0, _INTEL_DIR)
+
+import models  # noqa: E402
+import openvino_backend as openvino  # noqa: E402
+from worker import check  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    not openvino.OPENVINO_AVAILABLE,
+    reason=f"OpenVINO execution provider unavailable: {openvino.unavailable_reason()}",
+)
+
+
+@pytest.mark.parametrize("name", models.names())
+def test_openvino_compat_suite(name):
+    """Each suite model: simplification must not break or change the OpenVINO result."""
+    result = check(name, None)
+    # ``unsupported`` (the backend can't handle the graph at all) is acceptable;
+    # a regression / crash / error is not.
+    assert result["status"] in ("ok", "unsupported"), result
+
+
+def test_openvino_matches_cpu_reference():
+    """A directly-built graph: OpenVINO(simplified) matches the ORT CPU reference."""
+    from onnxsim import simplify
+
+    model = models.conv_bn_relu()
+    simp, _ = simplify(model)
+    feeds = openvino.random_feeds(model, seed=0)
+
+    reference = openvino.run_with_cpu(model, feeds)
+    candidate = openvino.run_with_openvino(simp, feeds)
+
+    close, max_diff = openvino.compare(reference, candidate)
+    assert close, (
+        f"OpenVINO output diverged from CPU reference: max_abs_diff={max_diff}"
+    )


### PR DESCRIPTION
Extends the vendor execution-provider compatibility testing framework beyond Qualcomm QNN to include Apple Core ML and Intel OpenVINO. This enables catching simplifications that break compatibility or change results on these backends.

## Summary

Refactors the synthetic model suite into a shared module (`scripts/common/synthetic_models.py`) and creates parallel integration harnesses for Apple Core ML and Intel OpenVINO, mirroring the existing Qualcomm QNN structure. Each vendor gets:
- A backend wrapper module (e.g., `coreml_backend.py`, `openvino_backend.py`)
- A worker subprocess for isolated model checking
- A runner script that orchestrates the full suite and generates CSV reports
- A README documenting the check and its coverage
- GitHub Actions workflows for scheduled and on-demand runs

## Key Changes

**Shared infrastructure:**
- Moved ~180 lines of ONNX graph builders from `scripts/qualcomm/models.py` to `scripts/common/synthetic_models.py` for reuse
- Extracted numeric helpers (`random_feeds`, `compare`) into `scripts/common/ep_numerics.py` to avoid duplication across backends
- Each vendor's `models.py` now re-exports the shared suite, keeping existing imports working

**Apple Core ML harness** (`scripts/apple/`):
- `coreml_backend.py`: Wraps the `CoreMLExecutionProvider` from the standard `onnxruntime` wheel (macOS only)
- `worker.py`: Checks one model by running original vs. simplified on Core ML, comparing outputs and measuring coverage
- `run_coreml_compat.py`: Orchestrates the full suite, writes CSV, exits non-zero on failures
- `.github/workflows/apple-integration.yml`: Scheduled weekly + on-demand + PR-triggered workflow
- `tests/test_coreml_compat.py`: Fast in-tree smoke test (skipped if Core ML EP unavailable)

**Intel OpenVINO harness** (`scripts/intel/`):
- `openvino_backend.py`: Wraps the `OpenVINOExecutionProvider` from `onnxruntime-openvino` wheel (CPU device target, no special hardware needed)
- `worker.py`: Identical structure to Core ML worker, adapted for OpenVINO
- `run_openvino_compat.py`: Same orchestration pattern as Core ML
- `.github/workflows/intel-integration.yml`: Scheduled weekly + on-demand + PR-triggered workflow (builds wheel first)
- `tests/test_openvino_compat.py`: Fast in-tree smoke test (skipped if OpenVINO EP unavailable)

**Qualcomm QNN updates:**
- `scripts/qualcomm/models.py` now imports from the shared suite and re-exports
- `scripts/qualcomm/qnn_backend.py` imports `random_feeds` and `compare` from `common.ep_numerics`
- Workflow updated to trigger on changes to `scripts/common/**`

## Implementation Details

- **Graceful degradation**: Each backend wrapper checks availability at import time; if the EP is missing, tests skip and runners report `skipped` status (not failures) unless `--require-*` is passed
- **Subprocess isolation**: Each model runs in its own worker process with a hard timeout, matching the QNN harness pattern
- **Consistent reporting**: All three harnesses produce identical CSV output format with model name, status, node counts, coverage, and numeric diffs
- **Coverage measurement**: Uses `session.disable_cpu_ep_fallback` to distinguish full backend placement from partial (fallback to CPU)
- **Deterministic inputs**: Shared `random_feeds()` ensures reproducible test inputs across all backends

https://claude.ai/code/session_017r5H1EVz7jcq14Zw9FxZcy