### PR TITLE
Add TensorPool: zero-copy safetensors support for weights

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ endif()
 # configure onnx-optimizer after onnxruntime, because they both depend on onnx and onnxruntime has its own flags for onnx
 add_subdirectory(third_party/onnx-optimizer EXCLUDE_FROM_ALL)
 
-add_library(onnxsim onnxsim/onnxsim.cpp onnxsim/contrib_schemas.cpp onnxsim/custom_optimizer_passes.cpp onnxsim/function_rewriter.cpp onnxsim/profiler.cpp onnxsim/model_info.cpp onnxsim/sym_expr.cpp onnxsim/sym_value_eval.cpp onnxsim/sym_shape_infer.cpp onnxsim/model_metrics.cpp onnxsim/tensor_pool.cpp)
+add_library(onnxsim onnxsim/onnxsim.cpp onnxsim/contrib_schemas.cpp onnxsim/custom_optimizer_passes.cpp onnxsim/function_rewriter.cpp onnxsim/profiler.cpp onnxsim/model_info.cpp onnxsim/sym_expr.cpp onnxsim/sym_value_eval.cpp onnxsim/sym_shape_infer.cpp onnxsim/model_metrics.cpp onnxsim/tensor_pool.cpp onnxsim/tensor_pool_gguf.cpp)
 if (ONNXSIM_BUILTIN_ORT)
   target_include_directories(onnxsim PRIVATE ${ONNXRUNTIME_INCLUDE_DIR})
   if (ONNXSIM_PREBUILT_ORT)
@@ -436,4 +436,27 @@ if (ONNXSIM_TESTS)
   add_executable(tensor_pool_bridge_test onnxsim/tensor_pool_bridge_test.cpp)
   target_link_libraries(tensor_pool_bridge_test onnxsim)
   add_test(NAME tensor_pool_bridge_test COMMAND tensor_pool_bridge_test)
+
+  # The ONNX<->GGML dtype mapping (gguf_dtype.h), mirroring
+  # tensor_pool_dtype_test.cpp above for the same reason.
+  add_executable(gguf_dtype_test onnxsim/gguf_dtype_test.cpp)
+  target_include_directories(gguf_dtype_test PRIVATE onnxsim)
+  add_test(NAME gguf_dtype_test COMMAND gguf_dtype_test)
+
+  # TensorPool's GGUF read/write (tensor_pool_gguf.cpp) depends only on
+  # tensor_pool.{h,cpp} and gguf_dtype.h, so it too builds and runs
+  # standalone without ONNX / ONNX Runtime configured.
+  add_executable(tensor_pool_gguf_test onnxsim/tensor_pool_gguf_test.cpp
+                                       onnxsim/tensor_pool.cpp
+                                       onnxsim/tensor_pool_gguf.cpp)
+  target_include_directories(tensor_pool_gguf_test PRIVATE onnxsim)
+  add_test(NAME tensor_pool_gguf_test COMMAND tensor_pool_gguf_test)
+
+  # tensor_pool_gguf_bridge.h needs onnx, same reason as
+  # tensor_pool_bridge_test above.
+  add_executable(tensor_pool_gguf_bridge_test
+                onnxsim/tensor_pool_gguf_bridge_test.cpp)
+  target_link_libraries(tensor_pool_gguf_bridge_test onnxsim)
+  add_test(NAME tensor_pool_gguf_bridge_test
+          COMMAND tensor_pool_gguf_bridge_test)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ endif()
 # configure onnx-optimizer after onnxruntime, because they both depend on onnx and onnxruntime has its own flags for onnx
 add_subdirectory(third_party/onnx-optimizer EXCLUDE_FROM_ALL)
 
-add_library(onnxsim onnxsim/onnxsim.cpp onnxsim/contrib_schemas.cpp onnxsim/custom_optimizer_passes.cpp onnxsim/function_rewriter.cpp onnxsim/profiler.cpp onnxsim/model_info.cpp onnxsim/sym_expr.cpp onnxsim/sym_value_eval.cpp onnxsim/sym_shape_infer.cpp onnxsim/model_metrics.cpp)
+add_library(onnxsim onnxsim/onnxsim.cpp onnxsim/contrib_schemas.cpp onnxsim/custom_optimizer_passes.cpp onnxsim/function_rewriter.cpp onnxsim/profiler.cpp onnxsim/model_info.cpp onnxsim/sym_expr.cpp onnxsim/sym_value_eval.cpp onnxsim/sym_shape_infer.cpp onnxsim/model_metrics.cpp onnxsim/tensor_pool.cpp)
 if (ONNXSIM_BUILTIN_ORT)
   target_include_directories(onnxsim PRIVATE ${ONNXRUNTIME_INCLUDE_DIR})
   if (ONNXSIM_PREBUILT_ORT)
@@ -415,4 +415,25 @@ if (ONNXSIM_TESTS)
   add_executable(dlpack_dtype_test onnxsim/dlpack_dtype_test.cpp)
   target_include_directories(dlpack_dtype_test PRIVATE onnxsim third_party)
   add_test(NAME dlpack_dtype_test COMMAND dlpack_dtype_test)
+
+  # The ONNX<->safetensors dtype mapping (tensor_pool_dtype.h) is likewise
+  # pure and dependency-free, mirroring dlpack_dtype_test.cpp above.
+  add_executable(tensor_pool_dtype_test onnxsim/tensor_pool_dtype_test.cpp)
+  target_include_directories(tensor_pool_dtype_test PRIVATE onnxsim)
+  add_test(NAME tensor_pool_dtype_test COMMAND tensor_pool_dtype_test)
+
+  # TensorPool's storage and safetensors read/write (tensor_pool.{h,cpp})
+  # depend only on tensor_pool_dtype.h, so this too builds and runs
+  # standalone without ONNX / ONNX Runtime configured.
+  add_executable(tensor_pool_test onnxsim/tensor_pool_test.cpp
+                                  onnxsim/tensor_pool.cpp)
+  target_include_directories(tensor_pool_test PRIVATE onnxsim)
+  add_test(NAME tensor_pool_test COMMAND tensor_pool_test)
+
+  # tensor_pool_bridge.h is the one piece that DOES need onnx (it converts
+  # onnx::TensorProto <-> TensorPool), so its test links the fully-configured
+  # `onnxsim` target rather than building standalone like the tests above.
+  add_executable(tensor_pool_bridge_test onnxsim/tensor_pool_bridge_test.cpp)
+  target_link_libraries(tensor_pool_bridge_test onnxsim)
+  add_test(NAME tensor_pool_bridge_test COMMAND tensor_pool_bridge_test)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -459,4 +459,13 @@ if (ONNXSIM_TESTS)
   target_link_libraries(tensor_pool_gguf_bridge_test onnxsim)
   add_test(NAME tensor_pool_gguf_bridge_test
           COMMAND tensor_pool_gguf_bridge_test)
+
+  # The self-describing single-file archive functions (EmbedModel/
+  # ExtractModel and their Save/LoadModelAs* wrappers) span both bridge
+  # headers, so this one test exercises both the safetensors and the GGUF
+  # archive path; needs onnx for the same reason as the two tests above.
+  add_executable(tensor_pool_archive_test
+                onnxsim/tensor_pool_archive_test.cpp)
+  target_link_libraries(tensor_pool_archive_test onnxsim)
+  add_test(NAME tensor_pool_archive_test COMMAND tensor_pool_archive_test)
 endif()

--- a/onnxsim/gguf_dtype.h
+++ b/onnxsim/gguf_dtype.h
@@ -1,0 +1,204 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Pure, dependency-free mapping between ONNX tensor element types and GGML
+ * tensor types (https://github.com/ggml-org/ggml/blob/master/docs/gguf.md),
+ * plus the small set of GGUF wire-format constants (magic, version,
+ * alignment, metadata value-type codes) needed to read/write the container
+ * itself. Operates on the *integer* ONNX dtype codes and the *integer* GGML
+ * type codes, not the onnx headers, so tensor_pool_gguf.cpp builds and unit-
+ * tests on its own -- mirrors tensor_pool_dtype.h's split for safetensors,
+ * for the same reason.
+ *
+ * IMPORTANT SCOPE NOTE: only GGML's plain, unquantized element types map to
+ * an ONNX dtype (F32, F16, BF16, F64, I8, I16, I32, I64 -- storage where one
+ * element is one fixed-width value, exactly what onnx::TensorProto::raw_data
+ * and safetensors both assume). GGML's block-quantized types (Q4_0, Q4_K,
+ * Q6_K, every IQ*_ variant, ...) -- which is what most real-world .gguf
+ * files (quantized LLM checkpoints) actually store almost all of their
+ * tensors as -- have NO onnx raw-data equivalent: each "element" is really a
+ * shared block of packed sub-byte codes plus one or more scale/zero-point
+ * values, decoded by dequantization math this mapping does not implement.
+ * ToOnnx() rejects them (returns false) rather than guess; TensorPool's GGUF
+ * loader (tensor_pool_gguf.cpp) skips such tensors and reports them, rather
+ * than materializing garbage bytes as if they were raw floats. Practically,
+ * loading a quantized LLM's .gguf through this pool will pool only its
+ * unquantized tensors (typically norm scale/bias, RoPE frequencies, biases
+ * -- a small minority of the file), not its weight matrices.
+ */
+#ifndef ONNXSIM_GGUF_DTYPE_H_
+#define ONNXSIM_GGUF_DTYPE_H_
+
+#include <cstddef>
+#include <cstdint>
+
+namespace onnxsim {
+namespace tensor_pool {
+namespace gguf {
+
+// --- container format constants -------------------------------------------
+
+inline constexpr uint32_t kMagic =
+    0x46554747;  // "GGUF" read as a little-endian u32
+// Only version 3 (the current format, and what every actively-maintained
+// GGUF writer -- llama.cpp included -- has produced since 2023) is
+// supported. Version 1 used 32-bit tensor/metadata counts and a different
+// string encoding; version 2 is functionally version 3 minus a couple of
+// later-added metadata conventions this reader doesn't depend on anyway, but
+// is rare enough in the wild that it isn't worth the extra branch -- treated
+// as unsupported alongside version 1.
+inline constexpr uint32_t kSupportedVersion = 3;
+inline constexpr uint64_t kDefaultAlignment = 32;
+
+// gguf_metadata_value_type.
+enum MetadataValueType : uint32_t {
+  GGUF_METADATA_VALUE_TYPE_UINT8 = 0,
+  GGUF_METADATA_VALUE_TYPE_INT8 = 1,
+  GGUF_METADATA_VALUE_TYPE_UINT16 = 2,
+  GGUF_METADATA_VALUE_TYPE_INT16 = 3,
+  GGUF_METADATA_VALUE_TYPE_UINT32 = 4,
+  GGUF_METADATA_VALUE_TYPE_INT32 = 5,
+  GGUF_METADATA_VALUE_TYPE_FLOAT32 = 6,
+  GGUF_METADATA_VALUE_TYPE_BOOL = 7,
+  GGUF_METADATA_VALUE_TYPE_STRING = 8,
+  GGUF_METADATA_VALUE_TYPE_ARRAY = 9,
+  GGUF_METADATA_VALUE_TYPE_UINT64 = 10,
+  GGUF_METADATA_VALUE_TYPE_INT64 = 11,
+  GGUF_METADATA_VALUE_TYPE_FLOAT64 = 12,
+};
+
+// ggml_type -- only the stable low IDs this mapping cares about are named;
+// every other value (the quantized/k-quant/IQ* family, and any type newer
+// than this list) is handled generically as "unsupported" by ToOnnx/IsRaw
+// below without needing its own enumerator. GGML never reassigns an existing
+// ID (only appends and occasionally retires one), so these are stable across
+// ggml/llama.cpp versions.
+enum GgmlType : uint32_t {
+  GGML_TYPE_F32 = 0,
+  GGML_TYPE_F16 = 1,
+  GGML_TYPE_I8 = 24,
+  GGML_TYPE_I16 = 25,
+  GGML_TYPE_I32 = 26,
+  GGML_TYPE_I64 = 27,
+  GGML_TYPE_F64 = 28,
+  GGML_TYPE_BF16 = 30,
+};
+
+// --- ONNX dtype <-> ggml_type (raw types only; see the file comment) ------
+
+// Stable ONNX TensorProto::DataType wire numbers, duplicated (not shared via
+// an #include) so this header stays independent of tensor_pool_dtype.h and
+// buildable on its own, exactly like that header is independent of
+// dlpack_dtype.h's copy of the same numbers.
+enum OnnxDtype : int32_t {
+  ONNX_UNDEFINED = 0,
+  ONNX_FLOAT = 1,
+  ONNX_INT8 = 3,
+  ONNX_INT16 = 5,
+  ONNX_INT32 = 6,
+  ONNX_INT64 = 7,
+  ONNX_FLOAT16 = 10,
+  ONNX_DOUBLE = 11,
+  ONNX_BFLOAT16 = 16,
+};
+
+// Bytes of one element. 0 for a ggml_type this mapping doesn't cover
+// (quantized types report 0 here too -- computing their true per-block size
+// isn't needed since they're never pooled, only skipped).
+inline size_t ElementSize(uint32_t ggml_type) {
+  switch (ggml_type) {
+    case GGML_TYPE_I8:
+      return 1;
+    case GGML_TYPE_F16:
+    case GGML_TYPE_BF16:
+    case GGML_TYPE_I16:
+      return 2;
+    case GGML_TYPE_F32:
+    case GGML_TYPE_I32:
+      return 4;
+    case GGML_TYPE_F64:
+    case GGML_TYPE_I64:
+      return 8;
+    default:
+      return 0;
+  }
+}
+
+// True for a ggml_type with a fixed-width, unquantized, one-value-per-
+// element layout -- the only kind TensorPool can pool (see the file
+// comment). False for every quantized/k-quant/IQ* type and anything this
+// mapping doesn't recognize.
+inline bool IsRaw(uint32_t ggml_type) { return ElementSize(ggml_type) != 0; }
+
+// Map a ggml_type to its ONNX dtype code. Returns false (leaving `*out`
+// untouched) for a quantized type or one this mapping doesn't recognize.
+inline bool ToOnnx(uint32_t ggml_type, int32_t* out) {
+  switch (ggml_type) {
+    case GGML_TYPE_F32:
+      *out = ONNX_FLOAT;
+      return true;
+    case GGML_TYPE_F16:
+      *out = ONNX_FLOAT16;
+      return true;
+    case GGML_TYPE_BF16:
+      *out = ONNX_BFLOAT16;
+      return true;
+    case GGML_TYPE_F64:
+      *out = ONNX_DOUBLE;
+      return true;
+    case GGML_TYPE_I8:
+      *out = ONNX_INT8;
+      return true;
+    case GGML_TYPE_I16:
+      *out = ONNX_INT16;
+      return true;
+    case GGML_TYPE_I32:
+      *out = ONNX_INT32;
+      return true;
+    case GGML_TYPE_I64:
+      *out = ONNX_INT64;
+      return true;
+    default:
+      return false;
+  }
+}
+
+// Inverse of ToOnnx. Returns false for an ONNX dtype with no raw ggml_type
+// counterpart (STRING, COMPLEX64/128, UNDEFINED, the unsigned int family --
+// ggml has no unsigned integer types at all, quantized or otherwise).
+inline bool FromOnnx(int32_t onnx_dtype, uint32_t* out) {
+  switch (onnx_dtype) {
+    case ONNX_FLOAT:
+      *out = GGML_TYPE_F32;
+      return true;
+    case ONNX_FLOAT16:
+      *out = GGML_TYPE_F16;
+      return true;
+    case ONNX_BFLOAT16:
+      *out = GGML_TYPE_BF16;
+      return true;
+    case ONNX_DOUBLE:
+      *out = GGML_TYPE_F64;
+      return true;
+    case ONNX_INT8:
+      *out = GGML_TYPE_I8;
+      return true;
+    case ONNX_INT16:
+      *out = GGML_TYPE_I16;
+      return true;
+    case ONNX_INT32:
+      *out = GGML_TYPE_I32;
+      return true;
+    case ONNX_INT64:
+      *out = GGML_TYPE_I64;
+      return true;
+    default:
+      return false;
+  }
+}
+
+}  // namespace gguf
+}  // namespace tensor_pool
+}  // namespace onnxsim
+
+#endif  // ONNXSIM_GGUF_DTYPE_H_

--- a/onnxsim/gguf_dtype_test.cpp
+++ b/onnxsim/gguf_dtype_test.cpp
@@ -1,0 +1,86 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Standalone: g++ -std=c++17 gguf_dtype_test.cpp -o t && ./t
+ *
+ * Dependency-free unit test for the ONNX<->GGML dtype mapping, mirroring
+ * tensor_pool_dtype_test.cpp.
+ */
+#include "gguf_dtype.h"
+
+#include <cstdio>
+#include <string>
+
+using namespace onnxsim::tensor_pool::gguf;
+
+namespace {
+
+int g_failures = 0;
+
+void Check(bool cond, const std::string& what) {
+  if (!cond) {
+    std::fprintf(stderr, "FAIL: %s\n", what.c_str());
+    ++g_failures;
+  }
+}
+
+struct Row {
+  int32_t onnx;
+  uint32_t ggml;
+  size_t bytes;
+};
+
+}  // namespace
+
+int main() {
+  const Row rows[] = {
+      {ONNX_FLOAT, GGML_TYPE_F32, 4},     {ONNX_FLOAT16, GGML_TYPE_F16, 2},
+      {ONNX_BFLOAT16, GGML_TYPE_BF16, 2}, {ONNX_DOUBLE, GGML_TYPE_F64, 8},
+      {ONNX_INT8, GGML_TYPE_I8, 1},       {ONNX_INT16, GGML_TYPE_I16, 2},
+      {ONNX_INT32, GGML_TYPE_I32, 4},     {ONNX_INT64, GGML_TYPE_I64, 8},
+  };
+
+  for (const auto& row : rows) {
+    uint32_t ggml = 0xFFFFFFFF;
+    Check(FromOnnx(row.onnx, &ggml) && ggml == row.ggml,
+          "FromOnnx(" + std::to_string(row.onnx) +
+              ") == " + std::to_string(row.ggml));
+    Check(ElementSize(row.ggml) == row.bytes,
+          "ElementSize(" + std::to_string(row.ggml) +
+              ") == " + std::to_string(row.bytes));
+    Check(IsRaw(row.ggml), "IsRaw(" + std::to_string(row.ggml) + ")");
+    int32_t onnx = -1;
+    Check(ToOnnx(row.ggml, &onnx) && onnx == row.onnx,
+          "ToOnnx(FromOnnx(" + std::to_string(row.onnx) + "))) round-trips");
+  }
+
+  // Quantized / unrecognized ggml types are rejected, not guessed at.
+  const uint32_t quantized[] = {2,  3,  6,  7,  8,  9,  10, 11,
+                                12, 13, 14, 15, 16, 20, 29, 9999};
+  for (uint32_t q : quantized) {
+    int32_t onnx = -1;
+    Check(!ToOnnx(q, &onnx),
+          "ToOnnx rejects quantized/unknown type " + std::to_string(q));
+    Check(!IsRaw(q),
+          "IsRaw is false for quantized/unknown type " + std::to_string(q));
+    Check(ElementSize(q) == 0,
+          "ElementSize is 0 for quantized/unknown type " + std::to_string(q));
+  }
+
+  // ONNX dtypes with no raw ggml counterpart (unsigned ints, BOOL, STRING,
+  // UNDEFINED -- ggml has no unsigned or bool tensor type at all).
+  const int32_t unsupported_onnx[] = {2 /*UINT8*/, 4 /*UINT16*/, 9 /*BOOL*/,
+                                      8 /*STRING*/, ONNX_UNDEFINED};
+  for (int32_t d : unsupported_onnx) {
+    uint32_t ggml = 0;
+    Check(!FromOnnx(d, &ggml),
+          "FromOnnx rejects unsupported ONNX dtype " + std::to_string(d));
+  }
+
+  if (g_failures == 0) {
+    std::printf("gguf_dtype_test: all checks passed\n");
+    return 0;
+  }
+  std::fprintf(stderr, "gguf_dtype_test: %d failure(s)\n", g_failures);
+  return 1;
+}

--- a/onnxsim/tensor_pool.cpp
+++ b/onnxsim/tensor_pool.cpp
@@ -323,18 +323,17 @@ class HeaderParser {
       }
     } else if (c == 't' || c == 'f' || c == 'n') {
       // true / false / null
-      while (pos_ < s_.size() && std::isalpha(static_cast<unsigned char>(
-                                     s_[pos_]))) {
+      while (pos_ < s_.size() &&
+             std::isalpha(static_cast<unsigned char>(s_[pos_]))) {
         ++pos_;
       }
     } else {
       // number
       size_t start = pos_;
-      while (pos_ < s_.size() && (std::isdigit(static_cast<unsigned char>(
-                                      s_[pos_])) ||
-                                  s_[pos_] == '-' || s_[pos_] == '+' ||
-                                  s_[pos_] == '.' || s_[pos_] == 'e' ||
-                                  s_[pos_] == 'E')) {
+      while (pos_ < s_.size() &&
+             (std::isdigit(static_cast<unsigned char>(s_[pos_])) ||
+              s_[pos_] == '-' || s_[pos_] == '+' || s_[pos_] == '.' ||
+              s_[pos_] == 'e' || s_[pos_] == 'E')) {
         ++pos_;
       }
       if (pos_ == start) Fail("unexpected character while skipping value");
@@ -354,8 +353,7 @@ void TensorPool::Add(const std::string& name, int32_t dtype,
   // its storage originated from a std::string (here) or a plain read buffer
   // (LoadSafetensors below).
   std::shared_ptr<const char[]> aliased(owner, view.data());
-  entries_[name] =
-      Entry{dtype, std::move(shape), std::move(aliased), view};
+  entries_[name] = Entry{dtype, std::move(shape), std::move(aliased), view};
 }
 
 void TensorPool::Add(const std::string& name, int32_t dtype,
@@ -385,10 +383,10 @@ void TensorPool::SaveSafetensors(
   for (const auto& [name, entry] : entries_) {
     std::string_view dt = ToSafetensors(entry.dtype);
     if (dt.empty()) {
-      throw std::runtime_error(
-          "TensorPool::SaveSafetensors: tensor '" + name +
-          "' has an ONNX dtype (" + std::to_string(entry.dtype) +
-          ") with no safetensors representation");
+      throw std::runtime_error("TensorPool::SaveSafetensors: tensor '" + name +
+                               "' has an ONNX dtype (" +
+                               std::to_string(entry.dtype) +
+                               ") with no safetensors representation");
     }
     if (!first) header += ',';
     first = false;
@@ -454,9 +452,8 @@ void TensorPool::LoadSafetensors(const std::string& path) {
   in.seekg(0, std::ios::beg);
   uint64_t header_len = ReadU64LE(in);
   if (!in || header_len > static_cast<uint64_t>(file_size) - 8) {
-    throw std::runtime_error(
-        "TensorPool::LoadSafetensors: '" + path +
-        "' has an invalid header length");
+    throw std::runtime_error("TensorPool::LoadSafetensors: '" + path +
+                             "' has an invalid header length");
   }
 
   std::string header(header_len, '\0');

--- a/onnxsim/tensor_pool.cpp
+++ b/onnxsim/tensor_pool.cpp
@@ -1,0 +1,521 @@
+#include "tensor_pool.h"
+
+#include <cctype>
+#include <cstdio>
+#include <fstream>
+#include <stdexcept>
+
+#include "tensor_pool_dtype.h"
+
+namespace onnxsim {
+namespace tensor_pool {
+
+namespace {
+
+// The file's 8-byte header-length field is little-endian by spec regardless
+// of host byte order (see tensor_pool.h's "Byte order" note), so it is
+// written/read one byte at a time rather than via a host uint64_t
+// reinterpret_cast, which would be wrong on a big-endian host.
+void WriteU64LE(std::ostream& out, uint64_t v) {
+  char buf[8];
+  for (int i = 0; i < 8; ++i) {
+    buf[i] = static_cast<char>(v & 0xFF);
+    v >>= 8;
+  }
+  out.write(buf, 8);
+}
+
+uint64_t ReadU64LE(std::istream& in) {
+  unsigned char buf[8];
+  in.read(reinterpret_cast<char*>(buf), 8);
+  uint64_t v = 0;
+  for (int i = 7; i >= 0; --i) v = (v << 8) | buf[i];
+  return v;
+}
+
+void AppendJsonEscaped(std::string& out, std::string_view s) {
+  for (unsigned char c : s) {
+    switch (c) {
+      case '"':
+        out += "\\\"";
+        break;
+      case '\\':
+        out += "\\\\";
+        break;
+      case '\n':
+        out += "\\n";
+        break;
+      case '\r':
+        out += "\\r";
+        break;
+      case '\t':
+        out += "\\t";
+        break;
+      default:
+        if (c < 0x20) {
+          char buf[8];
+          std::snprintf(buf, sizeof(buf), "\\u%04x", c);
+          out += buf;
+        } else {
+          out += static_cast<char>(c);
+        }
+    }
+  }
+}
+
+// A minimal recursive-descent parser for exactly the shape a safetensors
+// header takes: a flat JSON object whose values are either a tensor
+// descriptor object ({"dtype", "shape", "data_offsets"}) or, for the single
+// "__metadata__" key, an arbitrary value this pool ignores. It is not a
+// general-purpose JSON parser -- SkipValue() below only needs to skip
+// whatever "__metadata__" (or an unrecognized key inside a tensor
+// descriptor) contains, well-formed or not.
+class HeaderParser {
+ public:
+  explicit HeaderParser(std::string_view s) : s_(s) {}
+
+  struct TensorHeader {
+    std::string name;
+    std::string dtype;
+    std::vector<int64_t> shape;
+    uint64_t begin = 0;
+    uint64_t end = 0;
+  };
+
+  std::vector<TensorHeader> Parse() {
+    std::vector<TensorHeader> out;
+    SkipWs();
+    Expect('{');
+    SkipWs();
+    if (Peek() == '}') {
+      Next();
+      return out;
+    }
+    while (true) {
+      SkipWs();
+      std::string key = ParseString();
+      SkipWs();
+      Expect(':');
+      SkipWs();
+      if (key == "__metadata__") {
+        SkipValue();
+      } else {
+        out.push_back(ParseTensorHeader(key));
+      }
+      SkipWs();
+      char c = Next();
+      if (c == ',') continue;
+      if (c == '}') break;
+      Fail("expected ',' or '}'");
+    }
+    return out;
+  }
+
+ private:
+  std::string_view s_;
+  size_t pos_ = 0;
+
+  [[noreturn]] void Fail(const std::string& what) {
+    throw std::runtime_error(
+        "tensor_pool: malformed safetensors header at byte " +
+        std::to_string(pos_) + ": " + what);
+  }
+
+  char Peek() {
+    if (pos_ >= s_.size()) Fail("unexpected end of header");
+    return s_[pos_];
+  }
+
+  char Next() {
+    char c = Peek();
+    ++pos_;
+    return c;
+  }
+
+  void Expect(char c) {
+    if (Next() != c) {
+      Fail(std::string("expected '") + c + "'");
+    }
+  }
+
+  void SkipWs() {
+    while (pos_ < s_.size() &&
+           std::isspace(static_cast<unsigned char>(s_[pos_]))) {
+      ++pos_;
+    }
+  }
+
+  std::string ParseString() {
+    Expect('"');
+    std::string out;
+    while (true) {
+      char c = Next();
+      if (c == '"') break;
+      if (c == '\\') {
+        char e = Next();
+        switch (e) {
+          case '"':
+            out += '"';
+            break;
+          case '\\':
+            out += '\\';
+            break;
+          case '/':
+            out += '/';
+            break;
+          case 'n':
+            out += '\n';
+            break;
+          case 't':
+            out += '\t';
+            break;
+          case 'r':
+            out += '\r';
+            break;
+          case 'u': {
+            // Header keys/dtype strings never contain non-ASCII escapes in
+            // practice (tensor names are protobuf identifiers); decode only
+            // the common case of a plain BMP code point being re-encoded as
+            // ASCII when it fits, otherwise fall back to '?' rather than
+            // implementing full UTF-16 surrogate pairing.
+            if (pos_ + 4 > s_.size()) Fail("truncated \\u escape");
+            unsigned cp = 0;
+            for (int i = 0; i < 4; ++i) {
+              char h = s_[pos_ + i];
+              cp <<= 4;
+              if (h >= '0' && h <= '9')
+                cp |= static_cast<unsigned>(h - '0');
+              else if (h >= 'a' && h <= 'f')
+                cp |= static_cast<unsigned>(h - 'a' + 10);
+              else if (h >= 'A' && h <= 'F')
+                cp |= static_cast<unsigned>(h - 'A' + 10);
+              else
+                Fail("invalid \\u escape");
+            }
+            pos_ += 4;
+            out += (cp < 0x80) ? static_cast<char>(cp) : '?';
+            break;
+          }
+          default:
+            Fail("invalid escape");
+        }
+      } else {
+        out += c;
+      }
+    }
+    return out;
+  }
+
+  int64_t ParseInt() {
+    size_t start = pos_;
+    if (pos_ < s_.size() && (s_[pos_] == '-' || s_[pos_] == '+')) ++pos_;
+    while (pos_ < s_.size() &&
+           std::isdigit(static_cast<unsigned char>(s_[pos_]))) {
+      ++pos_;
+    }
+    if (pos_ == start) Fail("expected integer");
+    // Header ints (shape dims, data_offsets) are always plain integers, never
+    // fractional/exponential, per the safetensors spec.
+    return std::stoll(std::string(s_.substr(start, pos_ - start)));
+  }
+
+  std::vector<int64_t> ParseIntArray() {
+    std::vector<int64_t> out;
+    Expect('[');
+    SkipWs();
+    if (Peek() == ']') {
+      Next();
+      return out;
+    }
+    while (true) {
+      SkipWs();
+      out.push_back(ParseInt());
+      SkipWs();
+      char c = Next();
+      if (c == ',') continue;
+      if (c == ']') break;
+      Fail("expected ',' or ']' in array");
+    }
+    return out;
+  }
+
+  TensorHeader ParseTensorHeader(std::string name) {
+    TensorHeader th;
+    th.name = std::move(name);
+    bool have_offsets = false;
+    Expect('{');
+    SkipWs();
+    if (Peek() == '}') {
+      Next();
+      Fail("tensor descriptor missing dtype/shape/data_offsets");
+    }
+    while (true) {
+      SkipWs();
+      std::string key = ParseString();
+      SkipWs();
+      Expect(':');
+      SkipWs();
+      if (key == "dtype") {
+        th.dtype = ParseString();
+      } else if (key == "shape") {
+        th.shape = ParseIntArray();
+      } else if (key == "data_offsets") {
+        auto off = ParseIntArray();
+        if (off.size() != 2 || off[0] < 0 || off[1] < off[0]) {
+          Fail("data_offsets must be a [begin, end] pair with begin <= end");
+        }
+        th.begin = static_cast<uint64_t>(off[0]);
+        th.end = static_cast<uint64_t>(off[1]);
+        have_offsets = true;
+      } else {
+        SkipValue();
+      }
+      SkipWs();
+      char c = Next();
+      if (c == ',') continue;
+      if (c == '}') break;
+      Fail("expected ',' or '}' in tensor descriptor");
+    }
+    if (th.dtype.empty() || !have_offsets) {
+      Fail("tensor descriptor missing dtype or data_offsets");
+    }
+    return th;
+  }
+
+  void SkipValue() {
+    SkipWs();
+    char c = Peek();
+    if (c == '"') {
+      ParseString();
+    } else if (c == '{') {
+      Next();
+      SkipWs();
+      if (Peek() == '}') {
+        Next();
+        return;
+      }
+      while (true) {
+        SkipWs();
+        ParseString();
+        SkipWs();
+        Expect(':');
+        SkipValue();
+        SkipWs();
+        char cc = Next();
+        if (cc == ',') continue;
+        if (cc == '}') break;
+        Fail("expected ',' or '}' while skipping object");
+      }
+    } else if (c == '[') {
+      Next();
+      SkipWs();
+      if (Peek() == ']') {
+        Next();
+        return;
+      }
+      while (true) {
+        SkipValue();
+        SkipWs();
+        char cc = Next();
+        if (cc == ',') continue;
+        if (cc == ']') break;
+        Fail("expected ',' or ']' while skipping array");
+      }
+    } else if (c == 't' || c == 'f' || c == 'n') {
+      // true / false / null
+      while (pos_ < s_.size() && std::isalpha(static_cast<unsigned char>(
+                                     s_[pos_]))) {
+        ++pos_;
+      }
+    } else {
+      // number
+      size_t start = pos_;
+      while (pos_ < s_.size() && (std::isdigit(static_cast<unsigned char>(
+                                      s_[pos_])) ||
+                                  s_[pos_] == '-' || s_[pos_] == '+' ||
+                                  s_[pos_] == '.' || s_[pos_] == 'e' ||
+                                  s_[pos_] == 'E')) {
+        ++pos_;
+      }
+      if (pos_ == start) Fail("unexpected character while skipping value");
+    }
+  }
+};
+
+}  // namespace
+
+void TensorPool::Add(const std::string& name, int32_t dtype,
+                     std::vector<int64_t> shape, std::string&& bytes) {
+  auto owner = std::make_shared<std::string>(std::move(bytes));
+  std::string_view view(*owner);
+  // Aliasing constructor: shares `owner`'s control block (so the string
+  // outlives every Entry referencing it) but points at its raw buffer,
+  // giving Entry a uniform shared_ptr<const char[]> regardless of whether
+  // its storage originated from a std::string (here) or a plain read buffer
+  // (LoadSafetensors below).
+  std::shared_ptr<const char[]> aliased(owner, view.data());
+  entries_[name] =
+      Entry{dtype, std::move(shape), std::move(aliased), view};
+}
+
+void TensorPool::Add(const std::string& name, int32_t dtype,
+                     std::vector<int64_t> shape,
+                     std::shared_ptr<const char[]> owner,
+                     std::string_view data) {
+  entries_[name] = Entry{dtype, std::move(shape), std::move(owner), data};
+}
+
+const Entry* TensorPool::Find(const std::string& name) const {
+  auto it = entries_.find(name);
+  return it == entries_.end() ? nullptr : &it->second;
+}
+
+bool TensorPool::Erase(const std::string& name) {
+  return entries_.erase(name) != 0;
+}
+
+void TensorPool::SaveSafetensors(
+    const std::string& path,
+    std::map<std::string, std::pair<uint64_t, uint64_t>>* data_offsets_out)
+    const {
+  std::string header = "{";
+  uint64_t offset = 0;
+  bool first = true;
+  if (data_offsets_out != nullptr) data_offsets_out->clear();
+  for (const auto& [name, entry] : entries_) {
+    std::string_view dt = ToSafetensors(entry.dtype);
+    if (dt.empty()) {
+      throw std::runtime_error(
+          "TensorPool::SaveSafetensors: tensor '" + name +
+          "' has an ONNX dtype (" + std::to_string(entry.dtype) +
+          ") with no safetensors representation");
+    }
+    if (!first) header += ',';
+    first = false;
+    header += '"';
+    AppendJsonEscaped(header, name);
+    header += "\":{\"dtype\":\"";
+    header += dt;
+    header += "\",\"shape\":[";
+    for (size_t i = 0; i < entry.shape.size(); ++i) {
+      if (i != 0) header += ',';
+      header += std::to_string(entry.shape[i]);
+    }
+    uint64_t begin = offset;
+    uint64_t end = offset + entry.nbytes();
+    header += "],\"data_offsets\":[";
+    header += std::to_string(begin);
+    header += ',';
+    header += std::to_string(end);
+    header += "]}";
+    offset = end;
+    if (data_offsets_out != nullptr) {
+      (*data_offsets_out)[name] = {begin, end};
+    }
+  }
+  header += '}';
+  // The reference (Rust) safetensors writer pads the header with trailing
+  // spaces (valid, semantically-inert JSON whitespace) so the data segment
+  // starts 8-byte aligned -- friendlier to an mmap-based reader. Match that
+  // convention for interop even though this reader doesn't require it.
+  while (header.size() % 8 != 0) header += ' ';
+
+  std::ofstream out(path, std::ios::binary | std::ios::trunc);
+  if (!out) {
+    throw std::runtime_error("TensorPool::SaveSafetensors: cannot open '" +
+                             path + "' for writing");
+  }
+  WriteU64LE(out, header.size());
+  out.write(header.data(), static_cast<std::streamsize>(header.size()));
+  for (const auto& [name, entry] : entries_) {
+    if (!entry.data.empty()) {
+      out.write(entry.data.data(),
+                static_cast<std::streamsize>(entry.data.size()));
+    }
+  }
+  if (!out) {
+    throw std::runtime_error("TensorPool::SaveSafetensors: write failed for '" +
+                             path + "'");
+  }
+}
+
+void TensorPool::LoadSafetensors(const std::string& path) {
+  std::ifstream in(path, std::ios::binary);
+  if (!in) {
+    throw std::runtime_error("TensorPool::LoadSafetensors: cannot open '" +
+                             path + "'");
+  }
+  in.seekg(0, std::ios::end);
+  std::streamoff file_size = in.tellg();
+  if (file_size < 8) {
+    throw std::runtime_error("TensorPool::LoadSafetensors: '" + path +
+                             "' is too small to be a safetensors file");
+  }
+  in.seekg(0, std::ios::beg);
+  uint64_t header_len = ReadU64LE(in);
+  if (!in || header_len > static_cast<uint64_t>(file_size) - 8) {
+    throw std::runtime_error(
+        "TensorPool::LoadSafetensors: '" + path +
+        "' has an invalid header length");
+  }
+
+  std::string header(header_len, '\0');
+  in.read(header.data(), static_cast<std::streamsize>(header_len));
+  if (!in) {
+    throw std::runtime_error("TensorPool::LoadSafetensors: '" + path +
+                             "' truncated while reading the header");
+  }
+
+  auto tensor_headers = HeaderParser(header).Parse();
+
+  // Single read of the whole data segment: every Entry below aliases this
+  // one buffer (via the shared_ptr aliasing constructor), so this is the
+  // pool's only tensor-data copy, however many tensors the file holds.
+  uint64_t data_size = static_cast<uint64_t>(file_size) - 8 - header_len;
+  auto buffer = std::make_shared<std::string>(data_size, '\0');
+  if (data_size > 0) {
+    in.read(buffer->data(), static_cast<std::streamsize>(data_size));
+    if (!in) {
+      throw std::runtime_error("TensorPool::LoadSafetensors: '" + path +
+                               "' truncated while reading tensor data");
+    }
+  }
+
+  entries_.clear();
+  for (auto& th : tensor_headers) {
+    if (th.end > data_size) {
+      throw std::runtime_error(
+          "TensorPool::LoadSafetensors: '" + path + "' tensor '" + th.name +
+          "' data_offsets [" + std::to_string(th.begin) + ", " +
+          std::to_string(th.end) + ") exceed the file's data segment (" +
+          std::to_string(data_size) + " bytes)");
+    }
+    int32_t dtype = FromSafetensors(th.dtype);
+    if (dtype == ONNX_UNDEFINED) {
+      throw std::runtime_error("TensorPool::LoadSafetensors: '" + path +
+                               "' tensor '" + th.name +
+                               "' has unsupported dtype '" + th.dtype + "'");
+    }
+    std::shared_ptr<const char[]> owner(buffer, buffer->data() + th.begin);
+    std::string_view data(buffer->data() + th.begin, th.end - th.begin);
+    entries_[th.name] =
+        Entry{dtype, std::move(th.shape), std::move(owner), data};
+  }
+}
+
+uint64_t HeaderPrefixSize(const std::string& path) {
+  std::ifstream in(path, std::ios::binary);
+  if (!in) {
+    throw std::runtime_error("tensor_pool::HeaderPrefixSize: cannot open '" +
+                             path + "'");
+  }
+  uint64_t header_len = ReadU64LE(in);
+  if (!in) {
+    throw std::runtime_error("tensor_pool::HeaderPrefixSize: '" + path +
+                             "' is too small to be a safetensors file");
+  }
+  return 8 + header_len;
+}
+
+}  // namespace tensor_pool
+}  // namespace onnxsim

--- a/onnxsim/tensor_pool.h
+++ b/onnxsim/tensor_pool.h
@@ -141,6 +141,53 @@ class TensorPool {
   // malformed header, or a tensor whose data_offsets fall outside the file.
   void LoadSafetensors(const std::string& path);
 
+  // --- GGUF (https://github.com/ggml-org/ggml/blob/master/docs/gguf.md)
+  // format, version 3 -- implemented in tensor_pool_gguf.cpp, a separate
+  // translation unit from the safetensors codec above, since the two file
+  // formats share nothing but the TensorPool storage they read into/from.
+  // See gguf_dtype.h's file comment for an important scope note: GGUF's
+  // block-quantized types (most of what a real quantized-LLM .gguf's
+  // tensors actually are) have no ONNX raw-data equivalent and are never
+  // pooled -- LoadGGUF skips and reports them rather than writing garbage.
+
+  // Write every entry to a GGUF file at `path`. Every dtype TensorPool can
+  // hold has a raw ggml_type counterpart (see gguf_dtype.h), so -- unlike
+  // LoadGGUF -- this never has to skip an entry; it throws instead if some
+  // future dtype addition broke that invariant. `string_metadata` is
+  // written verbatim as top-level GGUF string metadata entries (e.g.
+  // {"general.architecture", "onnxsim"}); pass {} for none.
+  //
+  // When `data_offsets_out` is non-null, it is filled with each written
+  // tensor's [begin, end) byte range *relative to the start of the tensor-
+  // data section* (GGUF's own per-tensor "offset" field, plus nbytes).
+  // When `data_section_start_out` is non-null, it receives that section's
+  // absolute byte offset from the start of the file. Together they're
+  // enough for a caller (see tensor_pool_gguf_bridge.h) to point a
+  // TensorProto's external_data straight at the file, the same way
+  // SaveSafetensors's data_offsets_out plus HeaderPrefixSize does for
+  // safetensors. Throws std::runtime_error on I/O failure.
+  void SaveGGUF(const std::string& path,
+                const std::map<std::string, std::string>& string_metadata = {},
+                std::map<std::string, std::pair<uint64_t, uint64_t>>*
+                    data_offsets_out = nullptr,
+                uint64_t* data_section_start_out = nullptr) const;
+
+  // Replace this pool's contents with every tensor in the GGUF file at
+  // `path` whose ggml_type is a *raw*, unquantized type this pool can
+  // represent -- typically a small minority of tensors in a real quantized-
+  // LLM .gguf (embeddings/attention/FFN weights are usually quantized;
+  // norm scale/bias and similar small tensors are usually not). Unlike
+  // LoadSafetensors, this does NOT read the whole file into memory: only
+  // the (small) header/metadata/tensor-info section is read up front, and
+  // each *included* tensor's bytes are read with their own targeted seek +
+  // read -- loading a large quantized checkpoint this way costs only the
+  // bytes of the few tensors this pool can actually use, not the whole
+  // file. Returns the names of tensors that were present in the file but
+  // skipped because their ggml_type has no ONNX raw-data equivalent (empty
+  // if every tensor was loaded). Throws std::runtime_error on I/O failure,
+  // an unrecognized magic/version, or a malformed header.
+  std::vector<std::string> LoadGGUF(const std::string& path);
+
  private:
   std::map<std::string, Entry> entries_;
 };

--- a/onnxsim/tensor_pool.h
+++ b/onnxsim/tensor_pool.h
@@ -129,10 +129,9 @@ class TensorPool {
   // need the tensor's *absolute* file offset (e.g. to fill in a
   // TensorProto's external_data, as tensor_pool_bridge.h's
   // ExportModelWithSafetensors does) add HeaderPrefixSize(path)'s result.
-  void SaveSafetensors(
-      const std::string& path,
-      std::map<std::string, std::pair<uint64_t, uint64_t>>* data_offsets_out =
-          nullptr) const;
+  void SaveSafetensors(const std::string& path,
+                       std::map<std::string, std::pair<uint64_t, uint64_t>>*
+                           data_offsets_out = nullptr) const;
 
   // Replace this pool's contents with every tensor described by the
   // .safetensors file at `path`. Reads the whole file into one owned buffer

--- a/onnxsim/tensor_pool.h
+++ b/onnxsim/tensor_pool.h
@@ -1,0 +1,159 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * TensorPool: a ref-counted, name-keyed store of tensor byte buffers, with a
+ * HuggingFace safetensors (https://github.com/huggingface/safetensors) file
+ * as its serialization format.
+ *
+ * Motivation (reducing onnx::TensorProto data copies): onnx::TensorProto
+ * physically owns its `raw_data` bytes as a plain std::string, so ordinary
+ * protobuf copies (ModelProto assignment, onnx-optimizer's Import/Export
+ * round trip, a Python trampoline hop) each deep-copy every initializer's
+ * payload -- see onnxsim.cpp's OptimizeFixed move-through-the-round-trip fix
+ * for issue #633, which works around exactly this for one specific call
+ * site. TensorPool generalizes the same idea for the two places a real copy
+ * is otherwise unavoidable:
+ *
+ *   1. Loading weights from disk: onnx's own external-data loader (and a
+ *      naive safetensors reader) memcpy's each tensor's slice out of the
+ *      file into a fresh TensorProto.raw_data. LoadSafetensors instead reads
+ *      the file into ONE owned buffer and hands out std::shared_ptr-aliased
+ *      views into it -- one copy total (the disk read), not one per tensor,
+ *      and every Entry a caller Finds() shares that same buffer for free.
+ *   2. Saving weights back out: SaveSafetensors writes each entry straight
+ *      from its own buffer -- it never concatenates the pool into one
+ *      in-memory blob first.
+ *
+ * TensorPool itself is dependency-free of onnx/protobuf (only the *integer*
+ * ONNX dtype codes from tensor_pool_dtype.h), so it builds and unit-tests
+ * standalone -- mirrors the dlpack_dtype.h / dlpack_bridge.h split. The
+ * onnx::TensorProto <-> TensorPool glue lives in tensor_pool_bridge.h; see
+ * that header's comment for how (and where) it's safe to plug a pool into
+ * onnxsim's existing passes -- notably, several of them (onnxsim.cpp's
+ * IsAllZeroTensor and integer-tensor extraction, dlpack_bridge.h's
+ * FromTensorProtoBorrowing) already special-case and skip
+ * onnx::TensorProto::EXTERNAL tensors, so a pool reference is only safe to
+ * hand them once it has been hydrated back to an ordinary in-memory tensor.
+ *
+ * File format (https://github.com/huggingface/safetensors#format):
+ *   [8 bytes] header length N, u64 little-endian
+ *   [N bytes] UTF-8 JSON header: a flat object of
+ *     {"<name>": {"dtype": "<code>", "shape": [...],
+ *                 "data_offsets": [begin, end]}, ...},
+ *     plus an optional "__metadata__" entry (arbitrary string->string map,
+ *     skipped by this reader)
+ *   [rest of file] raw tensor bytes, concatenated at the offsets the header
+ *     describes, relative to the end of the header
+ * This is onnx's own "raw external data in a file" layout with a JSON
+ * manifest bolted on: a tensor is addressed the same way (an offset + length
+ * range in a file), just keyed by name via the header instead of by
+ * per-tensor location/offset/length entries living in the TensorProto
+ * itself. That means a TensorPool's file is BOTH a standard safetensors file
+ * (openable by the `safetensors` Python package, HF `transformers`/
+ * `diffusers`, etc., with no onnxsim involved) AND usable, unmodified, as the
+ * backing file for onnx's own classic external-data mechanism, by pointing
+ * each TensorProto's external_data offset past the header (see
+ * tensor_pool_bridge.h's ExportModelWithSafetensors).
+ *
+ * Byte order: like onnx::TensorProto::raw_data (which ONNX's spec fixes to
+ * little-endian on every host) and every safetensors file actually produced
+ * in the wild, an Entry's `data` is *always* little-endian bytes, regardless
+ * of host byte order. TensorPool never interprets or swaps them -- only the
+ * file's own 8-byte header-length prefix, which this pool reads/writes byte
+ * by byte, needs (and gets) explicit little-endian handling for correctness
+ * on a big-endian host (this repo tests on s390x; see dlpack_dtype.h's
+ * kRawDataIsHostOrder for the *other* boundary, where such bytes are
+ * eventually swapped into host order for arithmetic).
+ */
+#ifndef ONNXSIM_TENSOR_POOL_H_
+#define ONNXSIM_TENSOR_POOL_H_
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace onnxsim {
+namespace tensor_pool {
+
+// A named tensor's data as a zero-copy view into whatever storage TensorPool
+// keeps alive on its behalf. `owner` keeps `data` alive (it may be an
+// aliasing shared_ptr into a much larger buffer, e.g. one Entry per tensor in
+// a loaded safetensors file all alias the same underlying read); copying an
+// Entry is a shared_ptr refcount bump, never a byte copy.
+struct Entry {
+  int32_t dtype = 0;  // an OnnxDtype from tensor_pool_dtype.h
+  std::vector<int64_t> shape;
+  std::shared_ptr<const char[]> owner;
+  std::string_view data;  // dtype's raw little-endian bytes; aliases *owner
+
+  size_t nbytes() const { return data.size(); }
+};
+
+class TensorPool {
+ public:
+  // Store `bytes` under `name`, taking ownership without copying (the string
+  // is moved in and becomes the pool's sole owner of that allocation).
+  // Overwrites any existing entry of the same name.
+  void Add(const std::string& name, int32_t dtype, std::vector<int64_t> shape,
+           std::string&& bytes);
+
+  // Store bytes already owned elsewhere via a shared_ptr -- e.g. a view
+  // produced by another pool's LoadSafetensors, or a sub-range of an entry
+  // this pool already holds. No copy either way.
+  void Add(const std::string& name, int32_t dtype, std::vector<int64_t> shape,
+           std::shared_ptr<const char[]> owner, std::string_view data);
+
+  const Entry* Find(const std::string& name) const;
+  bool Erase(const std::string& name);
+  size_t size() const { return entries_.size(); }
+  bool empty() const { return entries_.empty(); }
+
+  auto begin() const { return entries_.begin(); }
+  auto end() const { return entries_.end(); }
+
+  // Write every entry to a .safetensors file at `path`, in the pool's
+  // iteration (name-sorted) order. Each tensor is written straight from its
+  // own Entry::data -- never concatenated into one in-memory blob first --
+  // so saving performs no tensor-data copies of its own beyond the OS's
+  // ordinary write() buffering. Throws std::runtime_error if any pooled
+  // dtype has no safetensors representation (see tensor_pool_dtype.h), or on
+  // I/O failure.
+  //
+  // When `data_offsets_out` is non-null, it is filled with each written
+  // tensor's [begin, end) byte range *relative to the end of the header*
+  // (exactly the file's own "data_offsets" header field) -- callers that
+  // need the tensor's *absolute* file offset (e.g. to fill in a
+  // TensorProto's external_data, as tensor_pool_bridge.h's
+  // ExportModelWithSafetensors does) add HeaderPrefixSize(path)'s result.
+  void SaveSafetensors(
+      const std::string& path,
+      std::map<std::string, std::pair<uint64_t, uint64_t>>* data_offsets_out =
+          nullptr) const;
+
+  // Replace this pool's contents with every tensor described by the
+  // .safetensors file at `path`. Reads the whole file into one owned buffer
+  // and gives every Entry a std::shared_ptr that aliases *that one buffer*
+  // (via shared_ptr's aliasing constructor) -- one copy total (the disk
+  // read), not one per tensor. Throws std::runtime_error on I/O failure, a
+  // malformed header, or a tensor whose data_offsets fall outside the file.
+  void LoadSafetensors(const std::string& path);
+
+ private:
+  std::map<std::string, Entry> entries_;
+};
+
+// Bytes of `path`'s safetensors preamble (the 8-byte length prefix plus the
+// JSON header itself) -- i.e. where the raw tensor data segment begins, and
+// so what SaveSafetensors's per-tensor data_offsets are relative to. Reads
+// only the 8-byte length prefix, not the whole file. Throws
+// std::runtime_error on I/O failure.
+uint64_t HeaderPrefixSize(const std::string& path);
+
+}  // namespace tensor_pool
+}  // namespace onnxsim
+
+#endif  // ONNXSIM_TENSOR_POOL_H_

--- a/onnxsim/tensor_pool_archive_test.cpp
+++ b/onnxsim/tensor_pool_archive_test.cpp
@@ -3,16 +3,18 @@
  *
  * Exercises the self-describing single-file archive functions
  * (EmbedModel/ExtractModel in tensor_pool_bridge.h, and the format-specific
- * SaveModelAsSafetensors/LoadModelFromSafetensors there plus
- * SaveModelAsGGUF/LoadModelFromGGUF in tensor_pool_gguf_bridge.h). Needs
- * onnx configured, so it's built against the fully-configured `onnxsim`
- * CMake target, same as tensor_pool_bridge_test.cpp and
- * tensor_pool_gguf_bridge_test.cpp.
+ * SaveModelAsSafetensors/LoadModelFromSafetensors and their *Standalone
+ * (real, byte-accurate offset) counterparts there, plus SaveModelAsGGUF/
+ * LoadModelFromGGUF and SaveModelAsGGUFStandalone in
+ * tensor_pool_gguf_bridge.h). Needs onnx configured, so it's built against
+ * the fully-configured `onnxsim` CMake target, same as
+ * tensor_pool_bridge_test.cpp and tensor_pool_gguf_bridge_test.cpp.
  */
 #include <onnx/onnx_pb.h>
 #include <unistd.h>
 
 #include <cstdio>
+#include <fstream>
 #include <string>
 #include <vector>
 
@@ -46,6 +48,15 @@ onnx::TensorProto MakeInitializer(const std::string& name,
   for (int64_t d : dims) t.add_dims(d);
   t.set_raw_data(raw);
   return t;
+}
+
+std::string ReadFileRange(const std::string& path, uint64_t offset,
+                          uint64_t length) {
+  std::ifstream in(path, std::ios::binary);
+  in.seekg(static_cast<std::streamoff>(offset));
+  std::string out(length, '\0');
+  in.read(out.data(), static_cast<std::streamsize>(length));
+  return out;
 }
 
 void TestSafetensorsRoundTrip() {
@@ -150,12 +161,145 @@ void TestLazyExtract() {
   std::remove(path.c_str());
 }
 
+// The key property SaveModelAsSafetensorsStandalone adds over plain
+// SaveModelAsSafetensors: simulates a "vanilla external tool" that has ONLY
+// the extracted model.onnx bytes (no TensorPool, no name lookup) and
+// follows its initializers' external_data offset/length directly into the
+// archive file, exactly like a real onnx loader would.
+void TestSafetensorsStandaloneRealOffsets() {
+  onnx::ModelProto model;
+  auto* g = model.mutable_graph();
+  *g->add_initializer() = MakeInitializer("w1", onnx::TensorProto::FLOAT, {2},
+                                          std::string(8, '\x11'));
+  *g->add_initializer() = MakeInitializer("w2", onnx::TensorProto::INT64, {1},
+                                          std::string(8, '\x22'));
+  // Sorts AFTER "model.onnx" alphabetically -- specifically to catch a bug
+  // where offsets are computed assuming the model blob sorts last in the
+  // pool's (name-ordered) iteration.
+  *g->add_initializer() = MakeInitializer(
+      "zzz_weight", onnx::TensorProto::FLOAT, {1}, std::string(4, '\x55'));
+
+  std::string path = TempPath("_standalone.safetensors");
+  TensorPool save_pool;
+  SaveModelAsSafetensorsStandalone(model, path, save_pool);
+
+  const Entry* blob = save_pool.Find(kEmbeddedModelKey);
+  Check(blob != nullptr, "model blob present");
+
+  onnx::ModelProto extracted;
+  Check(extracted.ParseFromArray(blob->data.data(),
+                                 static_cast<int>(blob->data.size())),
+        "extracted bytes parse as a valid ModelProto on their own");
+  Check(extracted.graph().initializer_size() == 3,
+        "all 3 initializers present");
+
+  for (int i = 0; i < extracted.graph().initializer_size(); ++i) {
+    const auto& t = extracted.graph().initializer(i);
+    Check(t.data_location() == onnx::TensorProto::EXTERNAL,
+          t.name() + ": is EXTERNAL");
+    Check(!t.has_raw_data(), t.name() + ": no inline raw_data");
+    std::string location, offset_str, length_str;
+    for (const auto& e : t.external_data()) {
+      if (e.key() == "location") location = e.value();
+      if (e.key() == "offset") offset_str = e.value();
+      if (e.key() == "length") length_str = e.value();
+    }
+    Check(location == path, t.name() + ": location points at the archive");
+    Check(offset_str.size() == static_cast<size_t>(kOffsetFieldWidth),
+          t.name() + ": offset is fixed-width");
+    Check(length_str.size() == static_cast<size_t>(kOffsetFieldWidth),
+          t.name() + ": length is fixed-width");
+
+    std::string on_disk =
+        ReadFileRange(path, std::stoull(offset_str), std::stoull(length_str));
+    std::string expected = (t.name() == "w1")   ? std::string(8, '\x11')
+                           : (t.name() == "w2") ? std::string(8, '\x22')
+                                                : std::string(4, '\x55');
+    Check(on_disk == expected,
+          t.name() +
+              ": bytes at the byte-accurate offset match, via raw "
+              "file access alone -- no onnxsim involved");
+  }
+
+  // onnxsim's own loader still works fine on the same file, unaffected by
+  // which save variant produced it (it never looks at offset/length).
+  TensorPool load_pool;
+  onnx::ModelProto loaded;
+  Check(LoadModelFromSafetensors(path, &loaded, load_pool),
+        "LoadModelFromSafetensors still works on a Standalone-saved archive");
+  Check(loaded.graph().initializer(0).raw_data() == std::string(8, '\x11'),
+        "and hydrates correctly");
+
+  std::remove(path.c_str());
+}
+
+void TestGGUFStandaloneRealOffsets() {
+  onnx::ModelProto model;
+  *model.mutable_graph()->add_initializer() = MakeInitializer(
+      "w1", onnx::TensorProto::FLOAT, {3}, std::string(12, '\x33'));
+
+  std::string path = TempPath("_standalone.gguf");
+  TensorPool save_pool;
+  SaveModelAsGGUFStandalone(model, path, save_pool);
+
+  const Entry* blob = save_pool.Find(kEmbeddedModelKey);
+  onnx::ModelProto extracted;
+  Check(extracted.ParseFromArray(blob->data.data(),
+                                 static_cast<int>(blob->data.size())),
+        "extracted bytes parse");
+  const auto& t = extracted.graph().initializer(0);
+  std::string offset_str, length_str;
+  for (const auto& e : t.external_data()) {
+    if (e.key() == "offset") offset_str = e.value();
+    if (e.key() == "length") length_str = e.value();
+  }
+  Check(ReadFileRange(path, std::stoull(offset_str), std::stoull(length_str)) ==
+            std::string(12, '\x33'),
+        "GGUF: byte-accurate offset resolves to the right bytes directly");
+
+  std::remove(path.c_str());
+}
+
+void TestCollisionIsRejected() {
+  // A real initializer literally named "model.onnx" must be rejected, not
+  // silently clobbered by the embedded-model blob -- both for the
+  // Standalone path and plain EmbedModel/SaveModelAsSafetensors.
+  std::string path = TempPath("_collision.safetensors");
+
+  onnx::ModelProto model;
+  *model.mutable_graph()->add_initializer() = MakeInitializer(
+      kEmbeddedModelKey, onnx::TensorProto::FLOAT, {1}, std::string(4, '\0'));
+  TensorPool pool;
+  bool threw = false;
+  try {
+    SaveModelAsSafetensorsStandalone(model, path, pool);
+  } catch (const std::runtime_error&) {
+    threw = true;
+  }
+  Check(threw, "SaveModelAsSafetensorsStandalone rejects the collision");
+
+  onnx::ModelProto model2;
+  *model2.mutable_graph()->add_initializer() = MakeInitializer(
+      kEmbeddedModelKey, onnx::TensorProto::FLOAT, {1}, std::string(4, '\0'));
+  TensorPool pool2;
+  bool threw2 = false;
+  try {
+    SaveModelAsSafetensors(model2, path, pool2);
+  } catch (const std::runtime_error&) {
+    threw2 = true;
+  }
+  Check(threw2, "SaveModelAsSafetensors (symbolic) rejects it too");
+}
+
 }  // namespace
 
 int main() {
   TestSafetensorsRoundTrip();
   TestGGUFRoundTrip();
   TestLazyExtract();
+  TestSafetensorsStandaloneRealOffsets();
+  TestGGUFStandaloneRealOffsets();
+  TestCollisionIsRejected();
 
   if (g_failures == 0) {
     std::printf("tensor_pool_archive_test: all checks passed\n");

--- a/onnxsim/tensor_pool_archive_test.cpp
+++ b/onnxsim/tensor_pool_archive_test.cpp
@@ -1,0 +1,166 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Exercises the self-describing single-file archive functions
+ * (EmbedModel/ExtractModel in tensor_pool_bridge.h, and the format-specific
+ * SaveModelAsSafetensors/LoadModelFromSafetensors there plus
+ * SaveModelAsGGUF/LoadModelFromGGUF in tensor_pool_gguf_bridge.h). Needs
+ * onnx configured, so it's built against the fully-configured `onnxsim`
+ * CMake target, same as tensor_pool_bridge_test.cpp and
+ * tensor_pool_gguf_bridge_test.cpp.
+ */
+#include <onnx/onnx_pb.h>
+#include <unistd.h>
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include "tensor_pool_gguf_bridge.h"
+
+using namespace onnxsim::tensor_pool;
+
+namespace {
+
+int g_failures = 0;
+
+void Check(bool cond, const std::string& what) {
+  if (!cond) {
+    std::fprintf(stderr, "FAIL: %s\n", what.c_str());
+    ++g_failures;
+  }
+}
+
+std::string TempPath(const std::string& suffix) {
+  return "/tmp/onnxsim_tensor_pool_archive_test_" + std::to_string(::getpid()) +
+         suffix;
+}
+
+onnx::TensorProto MakeInitializer(const std::string& name,
+                                  onnx::TensorProto::DataType dtype,
+                                  const std::vector<int64_t>& dims,
+                                  const std::string& raw) {
+  onnx::TensorProto t;
+  t.set_name(name);
+  t.set_data_type(dtype);
+  for (int64_t d : dims) t.add_dims(d);
+  t.set_raw_data(raw);
+  return t;
+}
+
+void TestSafetensorsRoundTrip() {
+  onnx::ModelProto model;
+  auto* g = model.mutable_graph();
+  *g->add_initializer() = MakeInitializer("w1", onnx::TensorProto::FLOAT, {2},
+                                          std::string(8, '\x11'));
+  *g->add_initializer() = MakeInitializer("w2", onnx::TensorProto::INT64, {1},
+                                          std::string(8, '\x22'));
+
+  std::string path = TempPath(".safetensors");
+  TensorPool save_pool;
+  SaveModelAsSafetensors(model, path, save_pool);
+
+  // The archive holds the weights AND the embedded model blob, all under
+  // one path -- no separate .onnx file involved anywhere in this test.
+  Check(save_pool.Find("w1") != nullptr, "w1 pooled");
+  Check(save_pool.Find("w2") != nullptr, "w2 pooled");
+  Check(save_pool.Find(kEmbeddedModelKey) != nullptr, "model blob pooled");
+
+  TensorPool load_pool;
+  onnx::ModelProto loaded;
+  bool ok = LoadModelFromSafetensors(path, &loaded, load_pool);
+  Check(ok, "LoadModelFromSafetensors succeeds");
+  Check(loaded.graph().initializer_size() == 2, "both initializers present");
+  Check(loaded.graph().initializer(0).name() == "w1" &&
+            loaded.graph().initializer(0).has_raw_data() &&
+            loaded.graph().initializer(0).raw_data() == std::string(8, '\x11'),
+        "w1 hydrated with correct bytes");
+  Check(loaded.graph().initializer(1).name() == "w2" &&
+            loaded.graph().initializer(1).raw_data() == std::string(8, '\x22'),
+        "w2 hydrated with correct bytes");
+  Check(loaded.graph().initializer(0).data_location() ==
+            onnx::TensorProto::DEFAULT,
+        "hydrated tensor is DEFAULT-located, not left EXTERNAL");
+
+  // A plain weights-only file (no archive on top) has no embedded model --
+  // must report false, not throw or silently return an empty model.
+  TensorPool bare_pool;
+  bare_pool.Add("just_a_tensor", ONNX_FLOAT, {1}, std::string(4, '\0'));
+  std::string bare_path = TempPath("_bare.safetensors");
+  bare_pool.SaveSafetensors(bare_path);
+  TensorPool p2;
+  onnx::ModelProto m2;
+  Check(!LoadModelFromSafetensors(bare_path, &m2, p2),
+        "a plain weights-only file has no embedded model -> false");
+
+  std::remove(path.c_str());
+  std::remove(bare_path.c_str());
+}
+
+void TestGGUFRoundTrip() {
+  onnx::ModelProto model;
+  *model.mutable_graph()->add_initializer() = MakeInitializer(
+      "w1", onnx::TensorProto::FLOAT, {3}, std::string(12, '\x33'));
+
+  std::string path = TempPath(".gguf");
+  TensorPool save_pool;
+  SaveModelAsGGUF(model, path, save_pool,
+                  {{"general.architecture", "onnxsim-test"}});
+
+  TensorPool load_pool;
+  onnx::ModelProto loaded;
+  std::vector<std::string> skipped;
+  bool ok = LoadModelFromGGUF(path, &loaded, load_pool, true, &skipped);
+  Check(ok, "LoadModelFromGGUF succeeds");
+  Check(skipped.empty(),
+        "nothing skipped -- the model blob is a raw I8 "
+        "entry, never quantized");
+  Check(loaded.graph().initializer_size() == 1, "initializer present");
+  Check(loaded.graph().initializer(0).raw_data() == std::string(12, '\x33'),
+        "w1 hydrated with correct bytes");
+
+  std::remove(path.c_str());
+}
+
+void TestLazyExtract() {
+  // hydrate_all=false: the extracted model keeps EmbedModel's own symbolic
+  // EXTERNAL markers (location-only, no offset/length -- see
+  // tensor_pool_bridge.h's top comment on why), resolved on demand.
+  onnx::ModelProto model;
+  *model.mutable_graph()->add_initializer() = MakeInitializer(
+      "lazy", onnx::TensorProto::FLOAT, {1}, std::string(4, '\x44'));
+  std::string path = TempPath("_lazy.safetensors");
+  TensorPool save_pool;
+  SaveModelAsSafetensors(model, path, save_pool);
+
+  TensorPool load_pool;
+  onnx::ModelProto loaded;
+  LoadModelFromSafetensors(path, &loaded, load_pool, /*hydrate_all=*/false);
+  Check(!loaded.graph().initializer(0).has_raw_data(),
+        "lazy extract leaves raw_data unset");
+  Check(loaded.graph().initializer(0).data_location() ==
+            onnx::TensorProto::EXTERNAL,
+        "lazy extract leaves the symbolic EXTERNAL marker in place");
+
+  bool hydrated = HydrateTensorProto(
+      "lazy", *loaded.mutable_graph()->mutable_initializer(0), load_pool);
+  Check(hydrated &&
+            loaded.graph().initializer(0).raw_data() == std::string(4, '\x44'),
+        "on-demand HydrateTensorProto still recovers the bytes afterwards");
+  std::remove(path.c_str());
+}
+
+}  // namespace
+
+int main() {
+  TestSafetensorsRoundTrip();
+  TestGGUFRoundTrip();
+  TestLazyExtract();
+
+  if (g_failures == 0) {
+    std::printf("tensor_pool_archive_test: all checks passed\n");
+    return 0;
+  }
+  std::fprintf(stderr, "tensor_pool_archive_test: %d failure(s)\n", g_failures);
+  return 1;
+}

--- a/onnxsim/tensor_pool_bridge.h
+++ b/onnxsim/tensor_pool_bridge.h
@@ -99,8 +99,7 @@ template <typename Fn>
 void ForEachTensor(onnx::GraphProto& graph, Fn&& fn) {
   for (int i = 0; i < graph.initializer_size(); ++i) {
     auto* init = graph.mutable_initializer(i);
-    fn(init->name().empty() ? "initializer" + std::to_string(i)
-                            : init->name(),
+    fn(init->name().empty() ? "initializer" + std::to_string(i) : init->name(),
        *init);
   }
   for (int ni = 0; ni < graph.node_size(); ++ni) {

--- a/onnxsim/tensor_pool_bridge.h
+++ b/onnxsim/tensor_pool_bridge.h
@@ -1,0 +1,242 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Bridges onnx::TensorProto <-> TensorPool, and ties TensorPool's
+ * safetensors file format to onnx's own external-data mechanism
+ * (TensorProto's data_location/external_data fields) so a model's weights
+ * can live in one canonical, ecosystem-standard .safetensors file instead of
+ * being embedded in the .onnx file itself or dumped in onnx's ad hoc raw
+ * external-data format.
+ *
+ * Two directions:
+ *   * ExportModelWithSafetensors -- turns an ordinary, fully in-memory model
+ *     into one whose initializers are EXTERNAL references into a
+ *     freshly-written safetensors file. Each initializer's raw_data is moved
+ *     into the pool via TensorProto::release_raw_data() (no copy), then
+ *     every reference is patched with the real, absolute file offset/length
+ *     the tensor's bytes ended up at -- so the result is simultaneously a
+ *     valid safetensors file (openable by the `safetensors` Python package,
+ *     HF transformers/diffusers, etc. with no onnxsim involved) AND correct,
+ *     spec-compliant classic onnx external data (openable by vanilla
+ *     onnx/onnxruntime, which only look at offset/length and don't care
+ *     what bytes -- here, the JSON header -- precede them in the file).
+ *   * ImportModelWithSafetensors -- the reverse: loads a .safetensors file
+ *     into a pool (one read, zero-copy views; see tensor_pool.h) and, by
+ *     default, hydrates every matching initializer back to an ordinary
+ *     in-memory (non-EXTERNAL) TensorProto, so the resulting model works
+ *     with every existing onnxsim pass with no caveats. Hydration is one
+ *     copy per tensor -- unavoidable, because onnx::TensorProto physically
+ *     owns raw_data as a plain std::string (no borrowed/Cord-backed bytes
+ *     type) -- but it's the *only* copy: the pool itself loads zero-copy,
+ *     and only the tensors a caller actually asks to hydrate ever pay it
+ *     (pass hydrate_all=false to leave the rest as lazy EXTERNAL pool
+ *     references and hydrate individual ones on demand via
+ *     HydrateTensorProto -- see that function's caveat first, though).
+ *
+ * NOT covered here: keeping initializers EXTERNAL as onnxsim's *internal*
+ * in-flight representation during Simplify()'s fixed point, to dodge
+ * ModelProto copy costs mid-pipeline. That would collide with existing logic
+ * that already treats EXTERNAL as "we don't have the bytes, skip this
+ * tensor" -- onnxsim.cpp's IsAllZeroTensor and its integer-tensor extraction
+ * helper, and dlpack_bridge.h's FromTensorProtoBorrowing, all bail out on
+ * EXTERNAL tensors today. Using TensorPool as a lazy, on-demand backing
+ * store for those call sites (hydrate a tensor from the pool only when a
+ * pass actually needs its bytes, instead of skipping it outright) is a
+ * natural follow-up, but it means auditing and updating each of those call
+ * sites, not just adding a pool -- so hydrate_all=false below is a low-level
+ * building block for that future work, not something to wire into Simplify()
+ * as-is.
+ */
+#ifndef ONNXSIM_TENSOR_POOL_BRIDGE_H_
+#define ONNXSIM_TENSOR_POOL_BRIDGE_H_
+
+#include <onnx/onnx_pb.h>
+
+#include <map>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "tensor_pool.h"
+
+namespace onnxsim {
+namespace tensor_pool {
+
+namespace detail {
+
+template <typename Fn>
+void ForEachTensor(onnx::GraphProto& graph, Fn&& fn);
+
+// Recurse into one node attribute: its own tensor (`t`), its repeated
+// `tensors`, and any subgraph(s) it carries (`g` / `graphs`, e.g. an `If`
+// branch or a `Loop` body). `path` is a stable, human-readable fallback name
+// stem for tensors that have no `.name()` of their own (attribute tensors
+// frequently don't).
+template <typename Fn>
+void ForEachTensorInAttr(onnx::AttributeProto& attr, const std::string& path,
+                         Fn&& fn) {
+  if (attr.has_t()) {
+    auto* t = attr.mutable_t();
+    fn(t->name().empty() ? path + "/t" : t->name(), *t);
+  }
+  for (int i = 0; i < attr.tensors_size(); ++i) {
+    auto* t = attr.mutable_tensors(i);
+    fn(t->name().empty() ? path + "/tensors" + std::to_string(i) : t->name(),
+       *t);
+  }
+  if (attr.has_g()) ForEachTensor(*attr.mutable_g(), fn);
+  for (auto& g : *attr.mutable_graphs()) ForEachTensor(g, fn);
+}
+
+// Recurse into every TensorProto a graph carries -- initializers and node
+// attribute tensors, recursively through subgraphs -- calling fn(name,
+// tensor) for each. `name` is the tensor's own `.name()` when non-empty,
+// else a positional fallback, so every tensor gets a distinct pool key even
+// when unnamed.
+template <typename Fn>
+void ForEachTensor(onnx::GraphProto& graph, Fn&& fn) {
+  for (int i = 0; i < graph.initializer_size(); ++i) {
+    auto* init = graph.mutable_initializer(i);
+    fn(init->name().empty() ? "initializer" + std::to_string(i)
+                            : init->name(),
+       *init);
+  }
+  for (int ni = 0; ni < graph.node_size(); ++ni) {
+    auto* node = graph.mutable_node(ni);
+    std::string node_path =
+        node->name().empty() ? "node" + std::to_string(ni) : node->name();
+    for (int ai = 0; ai < node->attribute_size(); ++ai) {
+      ForEachTensorInAttr(*node->mutable_attribute(ai),
+                          node_path + "/attr" + std::to_string(ai), fn);
+    }
+  }
+}
+
+}  // namespace detail
+
+// Move `tensor`'s inline raw_data into `pool` under `name` via
+// TensorProto::release_raw_data() (no copy). Returns false, leaving `tensor`
+// untouched, when there's nothing eligible to move: no raw_data (a typed
+// repeated field, or an empty tensor), already EXTERNAL, or STRING (no raw
+// byte layout at all).
+//
+// CAUTION: on success, `tensor` is left in an intermediate, not-yet-
+// externalized state -- its bytes are gone but data_location is still
+// DEFAULT, not EXTERNAL -- because the pool doesn't know the tensor's final
+// file offset until the whole pool has been written (offsets depend on every
+// other tensor's size too). Callers must follow up by marking it EXTERNAL
+// with the real location/offset/length once that's known; do not leave (or
+// serialize) a model with tensors in this half-adopted state.
+// ExportModelWithSafetensors below does this correctly; use it rather than
+// calling AdoptFromTensorProto directly unless you need to compose your own
+// export sequence.
+inline bool AdoptFromTensorProto(const std::string& name,
+                                 onnx::TensorProto& tensor, TensorPool& pool) {
+  if (tensor.data_location() == onnx::TensorProto::EXTERNAL) return false;
+  if (tensor.data_type() == onnx::TensorProto::STRING) return false;
+  if (!tensor.has_raw_data()) return false;
+
+  std::vector<int64_t> shape(tensor.dims().begin(), tensor.dims().end());
+  std::unique_ptr<std::string> bytes(tensor.release_raw_data());
+  pool.Add(name, tensor.data_type(), std::move(shape), std::move(*bytes));
+  return true;
+}
+
+// Fill `tensor`'s raw_data by copying `name`'s bytes out of `pool` (this copy
+// is unavoidable: onnx::TensorProto physically owns raw_data as a plain
+// std::string) and clear any EXTERNAL / external_data state, so the result is
+// an ordinary, self-contained in-memory tensor safe for every existing
+// onnxsim pass. Returns false, leaving `tensor` untouched, if `name` isn't in
+// `pool`.
+inline bool HydrateTensorProto(const std::string& name,
+                               onnx::TensorProto& tensor,
+                               const TensorPool& pool) {
+  const Entry* entry = pool.Find(name);
+  if (entry == nullptr) return false;
+  tensor.set_data_location(onnx::TensorProto::DEFAULT);
+  tensor.clear_external_data();
+  tensor.set_raw_data(entry->data.data(), entry->data.size());
+  return true;
+}
+
+// Rewrite `model` so every eligible tensor (graph initializers and node-
+// attribute tensors, recursing through subgraphs) becomes an EXTERNAL
+// reference into a freshly-written `safetensors_path`, and write that file.
+// Returns the number of tensors externalized. `pool` is an out-parameter: it
+// ends up holding every externalized tensor, so a caller can inspect or
+// reuse them (e.g. across several models sharing weights) without re-reading
+// the file this just wrote.
+inline size_t ExportModelWithSafetensors(onnx::ModelProto& model,
+                                         const std::string& safetensors_path,
+                                         TensorPool& pool) {
+  // Keyed by the *pool key* ForEachTensor assigned (name, or a positional
+  // fallback for an unnamed attribute tensor) -- NOT by `t->name()`, which
+  // may be empty. Using t->name() to look the tensor back up after pooling
+  // would silently drop every unnamed attribute tensor: it'd be adopted (its
+  // bytes moved into the pool) but never re-marked EXTERNAL, leaving it
+  // half-adopted (see AdoptFromTensorProto's caution note).
+  std::vector<std::pair<std::string, onnx::TensorProto*>> exported;
+  detail::ForEachTensor(*model.mutable_graph(),
+                        [&](const std::string& name, onnx::TensorProto& t) {
+                          if (AdoptFromTensorProto(name, t, pool)) {
+                            exported.emplace_back(name, &t);
+                          }
+                        });
+
+  std::map<std::string, std::pair<uint64_t, uint64_t>> offsets;
+  pool.SaveSafetensors(safetensors_path, &offsets);
+  const uint64_t prefix = HeaderPrefixSize(safetensors_path);
+
+  for (auto& [pool_key, t] : exported) {
+    const auto& [begin, end] = offsets.at(pool_key);
+    t->set_data_location(onnx::TensorProto::EXTERNAL);
+    t->clear_external_data();
+    auto set_kv = [&](const std::string& k, const std::string& v) {
+      auto* e = t->add_external_data();
+      e->set_key(k);
+      e->set_value(v);
+    };
+    set_kv("location", safetensors_path);
+    set_kv("offset", std::to_string(prefix + begin));
+    set_kv("length", std::to_string(end - begin));
+  }
+  return exported.size();
+}
+
+// Load `safetensors_path` into `pool` and, for every graph initializer whose
+// name matches a pooled tensor, either hydrate it in place (hydrate_all, the
+// default -- an ordinary in-memory tensor ready for any onnxsim pass) or
+// leave it as a lazy EXTERNAL reference (hydrate_all=false) for a caller
+// that will call HydrateTensorProto itself on just the tensors it ends up
+// needing. See this header's top comment for why hydrate_all=false is not
+// yet safe to feed straight into onnxsim's Simplify(). Returns the number of
+// initializers matched.
+inline size_t ImportModelWithSafetensors(onnx::ModelProto& model,
+                                         const std::string& safetensors_path,
+                                         TensorPool& pool,
+                                         bool hydrate_all = true) {
+  pool.LoadSafetensors(safetensors_path);
+  size_t matched = 0;
+  for (auto& init : *model.mutable_graph()->mutable_initializer()) {
+    const Entry* entry = pool.Find(init.name());
+    if (entry == nullptr) continue;
+    ++matched;
+    if (hydrate_all) {
+      HydrateTensorProto(init.name(), init, pool);
+    } else {
+      init.set_data_location(onnx::TensorProto::EXTERNAL);
+      init.clear_external_data();
+      auto* e = init.add_external_data();
+      e->set_key("location");
+      e->set_value(safetensors_path);
+    }
+  }
+  return matched;
+}
+
+}  // namespace tensor_pool
+}  // namespace onnxsim
+
+#endif  // ONNXSIM_TENSOR_POOL_BRIDGE_H_

--- a/onnxsim/tensor_pool_bridge.h
+++ b/onnxsim/tensor_pool_bridge.h
@@ -33,6 +33,26 @@
  *     references and hydrate individual ones on demand via
  *     HydrateTensorProto -- see that function's caveat first, though).
  *
+ * A third pair, EmbedModel/ExtractModel plus the format-specific
+ * SaveModelAsSafetensors/LoadModelFromSafetensors below, goes one step
+ * further: instead of a small .onnx file with EXTERNAL references pointing
+ * at a separate weights file, the graph ITSELF is embedded inside the
+ * weights file too, as one more pooled entry (name "model.onnx", a raw
+ * byte blob) alongside the tensors -- one self-describing archive, not two
+ * files. The embedded copy's own initializers use a SYMBOLIC EXTERNAL
+ * reference (location = the archive path, no offset/length -- the same
+ * convention hydrate_all=false above already uses), resolved by name
+ * lookup into the archive's own pool, not by byte offset. That sidesteps a
+ * real chicken-and-egg problem real offsets would have here (the model's
+ * serialized size depends on the offsets, which depend on where the model
+ * blob itself lands in the file, which depends on the model's serialized
+ * size) at the cost of the extracted blob not being standalone-loadable by
+ * a vanilla onnx tool on its own -- only onnxsim's own
+ * LoadModelFromSafetensors/LoadModelFromGGUF (via ExtractModel) know to
+ * resolve it. Giving the embedded copy real, byte-accurate offsets instead
+ * (so an extracted model.onnx is standalone-usable elsewhere too) is a
+ * tracked follow-up, not implemented here.
+ *
  * NOT covered here: keeping initializers EXTERNAL as onnxsim's *internal*
  * in-flight representation during Simplify()'s fixed point, to dodge
  * ModelProto copy costs mid-pipeline. That would collide with existing logic
@@ -52,14 +72,17 @@
 
 #include <onnx/onnx_pb.h>
 
+#include <cstdint>
 #include <map>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <utility>
 #include <vector>
 
 #include "tensor_pool.h"
+#include "tensor_pool_dtype.h"
 
 namespace onnxsim {
 namespace tensor_pool {
@@ -233,6 +256,85 @@ inline size_t ImportModelWithSafetensors(onnx::ModelProto& model,
     }
   }
   return matched;
+}
+
+// --- self-describing single-file archives (see this header's top comment) -
+
+// Pool key under which a self-describing archive's own graph is stored.
+inline const std::string kEmbeddedModelKey = "model.onnx";  // NOLINT
+
+// Move every eligible tensor's bytes out of `model` into `pool` (as
+// AdoptFromTensorProto does), mark each as a symbolic EXTERNAL reference
+// into `archive_path`, then serialize the now-byte-free `model` and add
+// those bytes to `pool` under kEmbeddedModelKey. After this, `pool` (once
+// saved to `archive_path`) is a complete, self-describing archive; `model`
+// itself is mutated into the same byte-free, symbolically-external state
+// AdoptFromTensorProto leaves individual tensors in -- reload it via
+// ExtractModel/LoadModelFromSafetensors/LoadModelFromGGUF rather than using
+// `model` directly afterwards.
+inline void EmbedModel(onnx::ModelProto& model, const std::string& archive_path,
+                       TensorPool& pool) {
+  detail::ForEachTensor(*model.mutable_graph(),
+                        [&](const std::string& name, onnx::TensorProto& t) {
+                          if (!AdoptFromTensorProto(name, t, pool)) return;
+                          t.set_data_location(onnx::TensorProto::EXTERNAL);
+                          t.clear_external_data();
+                          auto* e = t.add_external_data();
+                          e->set_key("location");
+                          e->set_value(archive_path);
+                        });
+
+  std::string bytes;
+  if (!model.SerializeToString(&bytes)) {
+    throw std::runtime_error(
+        "TensorPool: EmbedModel: failed to serialize the model");
+  }
+  int64_t nbytes = static_cast<int64_t>(bytes.size());
+  pool.Add(kEmbeddedModelKey, ONNX_INT8, {nbytes}, std::move(bytes));
+}
+
+// Reverse of EmbedModel: find kEmbeddedModelKey in `pool`, parse it into
+// `*model`, and hydrate its initializers from `pool` by name (or, with
+// hydrate_all=false, leave them as the symbolic EXTERNAL references
+// EmbedModel wrote, for on-demand HydrateTensorProto -- same caveat as
+// ImportModelWithSafetensors's hydrate_all=false). Returns false, leaving
+// `*model` untouched, if `pool` has no embedded model. Throws
+// std::runtime_error if the embedded bytes aren't a valid ModelProto.
+inline bool ExtractModel(const TensorPool& pool, onnx::ModelProto* model,
+                         bool hydrate_all = true) {
+  const Entry* blob = pool.Find(kEmbeddedModelKey);
+  if (blob == nullptr) return false;
+  if (!model->ParseFromArray(blob->data.data(),
+                             static_cast<int>(blob->data.size()))) {
+    throw std::runtime_error("TensorPool: ExtractModel: embedded '" +
+                             kEmbeddedModelKey +
+                             "' is not a valid serialized ModelProto");
+  }
+  if (hydrate_all) {
+    for (auto& init : *model->mutable_graph()->mutable_initializer()) {
+      HydrateTensorProto(init.name(), init, pool);
+    }
+  }
+  return true;
+}
+
+// Convenience wrapper: EmbedModel then pool.SaveSafetensors(path). `model`
+// ends up mutated exactly as EmbedModel leaves it (see that function's
+// note) -- reload with LoadModelFromSafetensors rather than reusing `model`.
+inline void SaveModelAsSafetensors(onnx::ModelProto& model,
+                                   const std::string& path, TensorPool& pool) {
+  EmbedModel(model, path, pool);
+  pool.SaveSafetensors(path);
+}
+
+// Convenience wrapper: pool.LoadSafetensors(path) then ExtractModel. Returns
+// false if `path`'s pool has no embedded model (e.g. it's a plain weights-
+// only safetensors file with no onnxsim-authored archive on top).
+inline bool LoadModelFromSafetensors(const std::string& path,
+                                     onnx::ModelProto* model, TensorPool& pool,
+                                     bool hydrate_all = true) {
+  pool.LoadSafetensors(path);
+  return ExtractModel(pool, model, hydrate_all);
 }
 
 }  // namespace tensor_pool

--- a/onnxsim/tensor_pool_bridge.h
+++ b/onnxsim/tensor_pool_bridge.h
@@ -73,6 +73,7 @@
 #include <onnx/onnx_pb.h>
 
 #include <cstdint>
+#include <fstream>
 #include <map>
 #include <memory>
 #include <stdexcept>
@@ -263,6 +264,22 @@ inline size_t ImportModelWithSafetensors(onnx::ModelProto& model,
 // Pool key under which a self-describing archive's own graph is stored.
 inline const std::string kEmbeddedModelKey = "model.onnx";  // NOLINT
 
+// TensorPool::Add silently overwrites an existing entry of the same name,
+// which would be actively dangerous here: a model with a real initializer
+// named "model.onnx" (unlikely, but not forbidden by the ONNX spec) would
+// have that weight silently clobbered by the embedded-model blob with no
+// error. Call this right before adding kEmbeddedModelKey and it throws
+// instead.
+inline void CheckNoEmbeddedModelKeyCollision(const TensorPool& pool) {
+  if (pool.Find(kEmbeddedModelKey) != nullptr) {
+    throw std::runtime_error(
+        "TensorPool: a tensor is already named '" + kEmbeddedModelKey +
+        "', which collides with the reserved key this archive format "
+        "embeds the graph itself under; rename that tensor before "
+        "embedding");
+  }
+}
+
 // Move every eligible tensor's bytes out of `model` into `pool` (as
 // AdoptFromTensorProto does), mark each as a symbolic EXTERNAL reference
 // into `archive_path`, then serialize the now-byte-free `model` and add
@@ -272,6 +289,11 @@ inline const std::string kEmbeddedModelKey = "model.onnx";  // NOLINT
 // AdoptFromTensorProto leaves individual tensors in -- reload it via
 // ExtractModel/LoadModelFromSafetensors/LoadModelFromGGUF rather than using
 // `model` directly afterwards.
+//
+// The embedded copy's EXTERNAL references are symbolic (see this header's
+// top comment) -- for real, byte-accurate offsets that make the extracted
+// model.onnx blob standalone-loadable elsewhere, use
+// SaveModelAsSafetensorsStandalone / SaveModelAsGGUFStandalone instead.
 inline void EmbedModel(onnx::ModelProto& model, const std::string& archive_path,
                        TensorPool& pool) {
   detail::ForEachTensor(*model.mutable_graph(),
@@ -283,6 +305,7 @@ inline void EmbedModel(onnx::ModelProto& model, const std::string& archive_path,
                           e->set_key("location");
                           e->set_value(archive_path);
                         });
+  CheckNoEmbeddedModelKeyCollision(pool);
 
   std::string bytes;
   if (!model.SerializeToString(&bytes)) {
@@ -335,6 +358,167 @@ inline bool LoadModelFromSafetensors(const std::string& path,
                                      bool hydrate_all = true) {
   pool.LoadSafetensors(path);
   return ExtractModel(pool, model, hydrate_all);
+}
+
+// --- standalone archives: real, byte-accurate self-referencing offsets ----
+//
+// EmbedModel's embedded copy is symbolic -- fine for onnxsim's own
+// round-trip (ExtractModel resolves by name, never touches offset/length),
+// but useless to a vanilla onnx/onnxruntime given just the extracted
+// model.onnx blob. Making the embedded copy's offsets byte-accurate has a
+// real chicken-and-egg problem: the model's serialized size depends on the
+// digit-string offset/length values patched into it, which depend on where
+// the model blob itself ends up in the archive, which depends on the
+// model's serialized size.
+//
+// Broken with a fixed-width field: every offset/length value is written as
+// exactly kOffsetFieldWidth decimal digits (zero-padded -- ordinary decimal
+// parsers, including onnx's own external-data reader, skip leading zeros
+// with no issue), so re-patching the *real* value in later never changes
+// the model's serialized byte length versus an all-zero placeholder. That
+// makes the whole thing a single clean pass: adopt tensors with placeholder
+// offsets -> serialize -> pool it -> ask TensorPool for the real layout ->
+// patch the *same-length* real values in -> re-serialize (guaranteed
+// identical length) -> overwrite just the already-written model blob's
+// bytes in place. Every weight tensor is still written to disk exactly
+// once; only the small model blob is touched twice.
+
+inline constexpr int kOffsetFieldWidth = 20;  // covers up to ~10**20 bytes
+
+inline std::string FixedWidthDecimal(uint64_t v) {
+  std::string s = std::to_string(v);
+  if (s.size() > static_cast<size_t>(kOffsetFieldWidth)) {
+    throw std::runtime_error("TensorPool: offset/length " + s +
+                             " exceeds the reserved field width (" +
+                             std::to_string(kOffsetFieldWidth) + " digits)");
+  }
+  return std::string(static_cast<size_t>(kOffsetFieldWidth) - s.size(), '0') +
+         s;
+}
+
+// First half of the standalone-embed algorithm: adopt every eligible
+// tensor's bytes into `pool` and mark each EXTERNAL with `archive_path` and
+// fixed-width placeholder (all-zero) offset/length, ready for
+// PatchStandaloneOffsets once the pool's real layout is known. Returns
+// each adopted tensor's pool key alongside its TensorProto*, exactly like
+// ExportModelWithSafetensors's internal bookkeeping, so the second half can
+// find and re-patch them without a second graph traversal.
+inline std::vector<std::pair<std::string, onnx::TensorProto*>>
+AdoptAllWithPlaceholderOffsets(onnx::ModelProto& model,
+                               const std::string& archive_path,
+                               TensorPool& pool) {
+  std::vector<std::pair<std::string, onnx::TensorProto*>> adopted;
+  detail::ForEachTensor(*model.mutable_graph(), [&](const std::string& name,
+                                                    onnx::TensorProto& t) {
+    if (!AdoptFromTensorProto(name, t, pool)) return;
+    t.set_data_location(onnx::TensorProto::EXTERNAL);
+    t.clear_external_data();
+    auto set_kv = [&](const std::string& k, const std::string& v) {
+      auto* e = t.add_external_data();
+      e->set_key(k);
+      e->set_value(v);
+    };
+    set_kv("location", archive_path);
+    set_kv("offset", FixedWidthDecimal(0));
+    set_kv("length", FixedWidthDecimal(0));
+    adopted.emplace_back(name, &t);
+  });
+  return adopted;
+}
+
+// Second half: overwrite each adopted tensor's placeholder offset/length
+// (in place, same field width) with its real value from `offsets`
+// (relative to the data section) and `data_section_start` (absolute) --
+// both exactly what TensorPool::SaveSafetensors's/SaveGGUF's own
+// data_offsets_out/data_section_start_out out-params provide.
+inline void PatchStandaloneOffsets(
+    std::vector<std::pair<std::string, onnx::TensorProto*>>& adopted,
+    const std::map<std::string, std::pair<uint64_t, uint64_t>>& offsets,
+    uint64_t data_section_start) {
+  for (auto& [name, t] : adopted) {
+    const auto& [begin, end] = offsets.at(name);
+    for (auto& e : *t->mutable_external_data()) {
+      if (e.key() == "offset") {
+        e.set_value(FixedWidthDecimal(data_section_start + begin));
+      } else if (e.key() == "length") {
+        e.set_value(FixedWidthDecimal(end - begin));
+      }
+    }
+  }
+}
+
+// Overwrite `bytes.size()` bytes of the already-written file at `path`,
+// starting at absolute byte `offset`, without touching anything else in the
+// file (no truncation, no resize) -- the final step of the standalone-embed
+// algorithm, patching the model blob's placeholder bytes with the real,
+// offset-patched serialization in place.
+inline void PatchFileBytes(const std::string& path, uint64_t offset,
+                           const std::string& bytes) {
+  std::fstream out(path, std::ios::in | std::ios::out | std::ios::binary);
+  if (!out) {
+    throw std::runtime_error("TensorPool: cannot reopen '" + path +
+                             "' to patch the embedded model's bytes");
+  }
+  out.seekp(static_cast<std::streamoff>(offset));
+  out.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+  if (!out) {
+    throw std::runtime_error(
+        "TensorPool: failed to patch the embedded model's bytes into '" + path +
+        "'");
+  }
+}
+
+// Standalone counterpart of SaveModelAsSafetensors: same one-file result,
+// but the embedded copy's initializers carry real, byte-accurate
+// external_data offset/length into `path` -- extracting the "model.onnx"
+// tensor's bytes and saving them separately produces an ordinary, fully
+// standalone .onnx file loadable by vanilla onnx/onnxruntime, no onnxsim
+// involved. Every weight tensor is written to disk exactly once; the model
+// blob itself is written, then patched in place (same algorithm as
+// SaveModelAsGGUFStandalone) -- see this section's top comment.
+inline void SaveModelAsSafetensorsStandalone(onnx::ModelProto& model,
+                                             const std::string& path,
+                                             TensorPool& pool) {
+  auto adopted = AdoptAllWithPlaceholderOffsets(model, path, pool);
+  CheckNoEmbeddedModelKeyCollision(pool);
+
+  std::string placeholder_bytes;
+  if (!model.SerializeToString(&placeholder_bytes)) {
+    throw std::runtime_error(
+        "TensorPool: SaveModelAsSafetensorsStandalone: failed to serialize "
+        "the model");
+  }
+  pool.Add(kEmbeddedModelKey, ONNX_INT8,
+           {static_cast<int64_t>(placeholder_bytes.size())},
+           std::string(placeholder_bytes));
+
+  std::map<std::string, std::pair<uint64_t, uint64_t>> offsets;
+  pool.SaveSafetensors(path, &offsets);
+  uint64_t data_section_start = HeaderPrefixSize(path);
+
+  PatchStandaloneOffsets(adopted, offsets, data_section_start);
+
+  std::string final_bytes;
+  if (!model.SerializeToString(&final_bytes)) {
+    throw std::runtime_error(
+        "TensorPool: SaveModelAsSafetensorsStandalone: failed to "
+        "re-serialize the model");
+  }
+  if (final_bytes.size() != placeholder_bytes.size()) {
+    // Should be unreachable given FixedWidthDecimal's fixed width; a hard
+    // check rather than a silently-corrupt file if the invariant ever
+    // breaks (e.g. a future edit to what EmbedModel-style code patches).
+    throw std::runtime_error(
+        "TensorPool: SaveModelAsSafetensorsStandalone: internal error -- "
+        "re-serializing with real offsets changed the model's size (" +
+        std::to_string(placeholder_bytes.size()) + " -> " +
+        std::to_string(final_bytes.size()) + " bytes)");
+  }
+
+  const auto& model_range = offsets.at(kEmbeddedModelKey);
+  PatchFileBytes(path, data_section_start + model_range.first, final_bytes);
+  pool.Add(kEmbeddedModelKey, ONNX_INT8,
+           {static_cast<int64_t>(final_bytes.size())}, std::move(final_bytes));
 }
 
 }  // namespace tensor_pool

--- a/onnxsim/tensor_pool_bridge_test.cpp
+++ b/onnxsim/tensor_pool_bridge_test.cpp
@@ -9,11 +9,11 @@
 #include "tensor_pool_bridge.h"
 
 #include <onnx/onnx_pb.h>
+#include <unistd.h>
 
 #include <cstdio>
 #include <fstream>
 #include <string>
-#include <unistd.h>
 
 using namespace onnxsim::tensor_pool;
 
@@ -29,8 +29,8 @@ void Check(bool cond, const std::string& what) {
 }
 
 std::string TempPath(const std::string& suffix) {
-  return "/tmp/onnxsim_tensor_pool_bridge_test_" +
-        std::to_string(::getpid()) + suffix;
+  return "/tmp/onnxsim_tensor_pool_bridge_test_" + std::to_string(::getpid()) +
+         suffix;
 }
 
 std::string ReadFileRange(const std::string& path, uint64_t offset,
@@ -61,24 +61,24 @@ void TestAdoptAndHydrateSingleTensor() {
   bool adopted = AdoptFromTensorProto("w", t, pool);
   Check(adopted, "AdoptFromTensorProto succeeds for an inline-raw_data tensor");
   Check(!t.has_raw_data(),
-       "raw_data is gone from the TensorProto after adopting (moved, not "
-       "copied)");
+        "raw_data is gone from the TensorProto after adopting (moved, not "
+        "copied)");
   const Entry* e = pool.Find("w");
   Check(e != nullptr && e->nbytes() == 8, "pool holds the adopted bytes");
 
   // Adopting an already-adopted (raw_data-less) tensor is a no-op.
   Check(!AdoptFromTensorProto("w", t, pool),
-       "re-adopting a tensor with no raw_data returns false");
+        "re-adopting a tensor with no raw_data returns false");
 
   bool hydrated = HydrateTensorProto("w", t, pool);
   Check(hydrated, "HydrateTensorProto succeeds");
   Check(t.has_raw_data() && t.raw_data() == std::string(8, 'x'),
-       "hydrated raw_data matches the original bytes exactly");
+        "hydrated raw_data matches the original bytes exactly");
   Check(t.data_location() == onnx::TensorProto::DEFAULT,
-       "hydrated tensor is DEFAULT-located, not EXTERNAL");
+        "hydrated tensor is DEFAULT-located, not EXTERNAL");
 
   Check(!HydrateTensorProto("missing", t, pool),
-       "hydrating an unpooled name returns false");
+        "hydrating an unpooled name returns false");
 }
 
 void TestStringTensorIsNotAdopted() {
@@ -88,7 +88,7 @@ void TestStringTensorIsNotAdopted() {
   t.add_string_data("hello");
   TensorPool pool;
   Check(!AdoptFromTensorProto("s", t, pool),
-       "STRING tensors are never adopted (no raw byte layout)");
+        "STRING tensors are never adopted (no raw byte layout)");
   Check(pool.empty(), "pool stays empty");
 }
 
@@ -97,8 +97,8 @@ void TestExportModelWithSafetensors() {
   auto* graph = model.mutable_graph();
   *graph->add_initializer() = MakeInitializer(
       "weight", onnx::TensorProto::FLOAT, {2, 2}, std::string(16, '\x11'));
-  *graph->add_initializer() =
-      MakeInitializer("bias", onnx::TensorProto::INT64, {2}, std::string(16, '\x22'));
+  *graph->add_initializer() = MakeInitializer("bias", onnx::TensorProto::INT64,
+                                              {2}, std::string(16, '\x22'));
 
   // A node-attribute tensor (e.g. as Constant's `value` attribute uses) --
   // exercises the recursion into node attributes, not just top-level
@@ -107,9 +107,8 @@ void TestExportModelWithSafetensors() {
   node->set_name("const_node");
   auto* attr = node->add_attribute();
   attr->set_name("value");
-  *attr->mutable_t() =
-      MakeInitializer("const_tensor", onnx::TensorProto::UINT8, {4},
-                      std::string(4, '\x33'));
+  *attr->mutable_t() = MakeInitializer("const_tensor", onnx::TensorProto::UINT8,
+                                       {4}, std::string(4, '\x33'));
 
   std::string path = TempPath("_export.safetensors");
   TensorPool pool;
@@ -127,9 +126,9 @@ void TestExportModelWithSafetensors() {
     Check(t != nullptr, std::string(name) + ": found in model");
     if (t == nullptr) continue;
     Check(t->data_location() == onnx::TensorProto::EXTERNAL,
-         std::string(name) + ": is EXTERNAL after export");
+          std::string(name) + ": is EXTERNAL after export");
     Check(!t->has_raw_data(),
-         std::string(name) + ": no inline raw_data left after export");
+          std::string(name) + ": no inline raw_data left after export");
 
     std::string location, offset_str, length_str;
     for (const auto& e : t->external_data()) {
@@ -137,18 +136,19 @@ void TestExportModelWithSafetensors() {
       if (e.key() == "offset") offset_str = e.value();
       if (e.key() == "length") length_str = e.value();
     }
-    Check(location == path, std::string(name) + ": location == safetensors path");
+    Check(location == path,
+          std::string(name) + ": location == safetensors path");
     Check(!offset_str.empty() && !length_str.empty(),
-         std::string(name) + ": offset/length are set");
+          std::string(name) + ": offset/length are set");
 
     uint64_t offset = std::stoull(offset_str);
     uint64_t length = std::stoull(length_str);
     std::string on_disk = ReadFileRange(path, offset, length);
     const Entry* pooled = pool.Find(name);
     Check(pooled != nullptr && on_disk == pooled->data,
-         std::string(name) +
-             ": bytes at the recorded external_data offset match the pool "
-             "(and so the original tensor)");
+          std::string(name) +
+              ": bytes at the recorded external_data offset match the pool "
+              "(and so the original tensor)");
   }
 
   // The file this wrote is a valid, standalone safetensors file too -- a
@@ -156,7 +156,7 @@ void TestExportModelWithSafetensors() {
   TensorPool reloaded;
   reloaded.LoadSafetensors(path);
   Check(reloaded.size() == 3,
-       "the exported file is independently loadable as safetensors");
+        "the exported file is independently loadable as safetensors");
 
   std::remove(path.c_str());
 }
@@ -186,7 +186,7 @@ void TestUnnamedAttributeTensor() {
 
   const auto& exported_t = model.graph().node(0).attribute(0).t();
   Check(exported_t.data_location() == onnx::TensorProto::EXTERNAL,
-       "unnamed attribute tensor is EXTERNAL after export");
+        "unnamed attribute tensor is EXTERNAL after export");
   std::string location, offset_str, length_str;
   for (const auto& e : exported_t.external_data()) {
     if (e.key() == "location") location = e.value();
@@ -194,13 +194,13 @@ void TestUnnamedAttributeTensor() {
     if (e.key() == "length") length_str = e.value();
   }
   Check(!location.empty() && !offset_str.empty() && !length_str.empty(),
-       "unnamed attribute tensor got real location/offset/length, not left "
-       "half-adopted");
+        "unnamed attribute tensor got real location/offset/length, not left "
+        "half-adopted");
   if (!offset_str.empty() && !length_str.empty()) {
-    std::string on_disk = ReadFileRange(path, std::stoull(offset_str),
-                                        std::stoull(length_str));
+    std::string on_disk =
+        ReadFileRange(path, std::stoull(offset_str), std::stoull(length_str));
     Check(on_disk == std::string(4, '\x77'),
-         "bytes at the recorded offset match the original tensor");
+          "bytes at the recorded offset match the original tensor");
   }
   std::remove(path.c_str());
 }
@@ -210,10 +210,10 @@ void TestImportModelWithSafetensorsHydrateAll() {
   // but round-tripping all the way back through import.
   onnx::ModelProto original;
   auto* g = original.mutable_graph();
-  *g->add_initializer() = MakeInitializer(
-      "w1", onnx::TensorProto::FLOAT, {3}, std::string(12, '\x44'));
-  *g->add_initializer() = MakeInitializer(
-      "w2", onnx::TensorProto::INT32, {2}, std::string(8, '\x55'));
+  *g->add_initializer() = MakeInitializer("w1", onnx::TensorProto::FLOAT, {3},
+                                          std::string(12, '\x44'));
+  *g->add_initializer() = MakeInitializer("w2", onnx::TensorProto::INT32, {2},
+                                          std::string(8, '\x55'));
 
   std::string path = TempPath("_import.safetensors");
   TensorPool export_pool;
@@ -238,13 +238,13 @@ void TestImportModelWithSafetensorsHydrateAll() {
   Check(matched == 2, "both initializers matched on import");
 
   Check(fg->initializer(0).has_raw_data() &&
-           fg->initializer(0).raw_data() == std::string(12, '\x44'),
-       "w1 hydrated to the original bytes");
+            fg->initializer(0).raw_data() == std::string(12, '\x44'),
+        "w1 hydrated to the original bytes");
   Check(fg->initializer(0).data_location() == onnx::TensorProto::DEFAULT,
-       "w1 is DEFAULT-located after hydration");
+        "w1 is DEFAULT-located after hydration");
   Check(fg->initializer(1).has_raw_data() &&
-           fg->initializer(1).raw_data() == std::string(8, '\x55'),
-       "w2 hydrated to the original bytes");
+            fg->initializer(1).raw_data() == std::string(8, '\x55'),
+        "w2 hydrated to the original bytes");
 
   std::remove(path.c_str());
 }
@@ -264,22 +264,22 @@ void TestImportModelWithSafetensorsLazy() {
   init->add_dims(1);
 
   TensorPool import_pool;
-  size_t matched =
-      ImportModelWithSafetensors(fresh, path, import_pool, /*hydrate_all=*/false);
+  size_t matched = ImportModelWithSafetensors(fresh, path, import_pool,
+                                              /*hydrate_all=*/false);
   Check(matched == 1, "lazy import still reports the match");
   Check(!fresh.graph().initializer(0).has_raw_data(),
-       "lazy import leaves raw_data unset");
+        "lazy import leaves raw_data unset");
   Check(fresh.graph().initializer(0).data_location() ==
-           onnx::TensorProto::EXTERNAL,
-       "lazy import marks the tensor EXTERNAL for on-demand hydration");
+            onnx::TensorProto::EXTERNAL,
+        "lazy import marks the tensor EXTERNAL for on-demand hydration");
 
   // The caller can still hydrate it explicitly, on demand, straight from the
   // already-loaded pool -- no second file read.
   bool hydrated = HydrateTensorProto(
       "lazy", *fresh.mutable_graph()->mutable_initializer(0), import_pool);
-  Check(hydrated && fresh.graph().initializer(0).raw_data() ==
-                       std::string(4, '\x66'),
-       "on-demand HydrateTensorProto recovers the bytes");
+  Check(hydrated &&
+            fresh.graph().initializer(0).raw_data() == std::string(4, '\x66'),
+        "on-demand HydrateTensorProto recovers the bytes");
 
   std::remove(path.c_str());
 }
@@ -298,7 +298,6 @@ int main() {
     std::printf("tensor_pool_bridge_test: all checks passed\n");
     return 0;
   }
-  std::fprintf(stderr, "tensor_pool_bridge_test: %d failure(s)\n",
-              g_failures);
+  std::fprintf(stderr, "tensor_pool_bridge_test: %d failure(s)\n", g_failures);
   return 1;
 }

--- a/onnxsim/tensor_pool_bridge_test.cpp
+++ b/onnxsim/tensor_pool_bridge_test.cpp
@@ -1,0 +1,304 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Exercises tensor_pool_bridge.h's onnx::TensorProto <-> TensorPool glue and
+ * its safetensors export/import round trip. Needs onnx configured (unlike
+ * tensor_pool_test.cpp / tensor_pool_dtype_test.cpp), so it's built against
+ * the fully-configured `onnxsim` CMake target rather than standalone.
+ */
+#include "tensor_pool_bridge.h"
+
+#include <onnx/onnx_pb.h>
+
+#include <cstdio>
+#include <fstream>
+#include <string>
+#include <unistd.h>
+
+using namespace onnxsim::tensor_pool;
+
+namespace {
+
+int g_failures = 0;
+
+void Check(bool cond, const std::string& what) {
+  if (!cond) {
+    std::fprintf(stderr, "FAIL: %s\n", what.c_str());
+    ++g_failures;
+  }
+}
+
+std::string TempPath(const std::string& suffix) {
+  return "/tmp/onnxsim_tensor_pool_bridge_test_" +
+        std::to_string(::getpid()) + suffix;
+}
+
+std::string ReadFileRange(const std::string& path, uint64_t offset,
+                          uint64_t length) {
+  std::ifstream in(path, std::ios::binary);
+  in.seekg(static_cast<std::streamoff>(offset));
+  std::string out(length, '\0');
+  in.read(out.data(), static_cast<std::streamsize>(length));
+  return out;
+}
+
+onnx::TensorProto MakeInitializer(const std::string& name,
+                                  onnx::TensorProto::DataType dtype,
+                                  const std::vector<int64_t>& dims,
+                                  const std::string& raw) {
+  onnx::TensorProto t;
+  t.set_name(name);
+  t.set_data_type(dtype);
+  for (int64_t d : dims) t.add_dims(d);
+  t.set_raw_data(raw);
+  return t;
+}
+
+void TestAdoptAndHydrateSingleTensor() {
+  onnx::TensorProto t =
+      MakeInitializer("w", onnx::TensorProto::FLOAT, {2}, std::string(8, 'x'));
+  TensorPool pool;
+  bool adopted = AdoptFromTensorProto("w", t, pool);
+  Check(adopted, "AdoptFromTensorProto succeeds for an inline-raw_data tensor");
+  Check(!t.has_raw_data(),
+       "raw_data is gone from the TensorProto after adopting (moved, not "
+       "copied)");
+  const Entry* e = pool.Find("w");
+  Check(e != nullptr && e->nbytes() == 8, "pool holds the adopted bytes");
+
+  // Adopting an already-adopted (raw_data-less) tensor is a no-op.
+  Check(!AdoptFromTensorProto("w", t, pool),
+       "re-adopting a tensor with no raw_data returns false");
+
+  bool hydrated = HydrateTensorProto("w", t, pool);
+  Check(hydrated, "HydrateTensorProto succeeds");
+  Check(t.has_raw_data() && t.raw_data() == std::string(8, 'x'),
+       "hydrated raw_data matches the original bytes exactly");
+  Check(t.data_location() == onnx::TensorProto::DEFAULT,
+       "hydrated tensor is DEFAULT-located, not EXTERNAL");
+
+  Check(!HydrateTensorProto("missing", t, pool),
+       "hydrating an unpooled name returns false");
+}
+
+void TestStringTensorIsNotAdopted() {
+  onnx::TensorProto t;
+  t.set_name("s");
+  t.set_data_type(onnx::TensorProto::STRING);
+  t.add_string_data("hello");
+  TensorPool pool;
+  Check(!AdoptFromTensorProto("s", t, pool),
+       "STRING tensors are never adopted (no raw byte layout)");
+  Check(pool.empty(), "pool stays empty");
+}
+
+void TestExportModelWithSafetensors() {
+  onnx::ModelProto model;
+  auto* graph = model.mutable_graph();
+  *graph->add_initializer() = MakeInitializer(
+      "weight", onnx::TensorProto::FLOAT, {2, 2}, std::string(16, '\x11'));
+  *graph->add_initializer() =
+      MakeInitializer("bias", onnx::TensorProto::INT64, {2}, std::string(16, '\x22'));
+
+  // A node-attribute tensor (e.g. as Constant's `value` attribute uses) --
+  // exercises the recursion into node attributes, not just top-level
+  // initializers.
+  auto* node = graph->add_node();
+  node->set_name("const_node");
+  auto* attr = node->add_attribute();
+  attr->set_name("value");
+  *attr->mutable_t() =
+      MakeInitializer("const_tensor", onnx::TensorProto::UINT8, {4},
+                      std::string(4, '\x33'));
+
+  std::string path = TempPath("_export.safetensors");
+  TensorPool pool;
+  size_t n = ExportModelWithSafetensors(model, path, pool);
+  Check(n == 3, "all three tensors (2 initializers + 1 attribute) exported");
+
+  for (const auto& name : {"weight", "bias", "const_tensor"}) {
+    const onnx::TensorProto* t = nullptr;
+    for (const auto& init : graph->initializer()) {
+      if (init.name() == name) t = &init;
+    }
+    if (t == nullptr && graph->node(0).attribute(0).t().name() == name) {
+      t = &graph->node(0).attribute(0).t();
+    }
+    Check(t != nullptr, std::string(name) + ": found in model");
+    if (t == nullptr) continue;
+    Check(t->data_location() == onnx::TensorProto::EXTERNAL,
+         std::string(name) + ": is EXTERNAL after export");
+    Check(!t->has_raw_data(),
+         std::string(name) + ": no inline raw_data left after export");
+
+    std::string location, offset_str, length_str;
+    for (const auto& e : t->external_data()) {
+      if (e.key() == "location") location = e.value();
+      if (e.key() == "offset") offset_str = e.value();
+      if (e.key() == "length") length_str = e.value();
+    }
+    Check(location == path, std::string(name) + ": location == safetensors path");
+    Check(!offset_str.empty() && !length_str.empty(),
+         std::string(name) + ": offset/length are set");
+
+    uint64_t offset = std::stoull(offset_str);
+    uint64_t length = std::stoull(length_str);
+    std::string on_disk = ReadFileRange(path, offset, length);
+    const Entry* pooled = pool.Find(name);
+    Check(pooled != nullptr && on_disk == pooled->data,
+         std::string(name) +
+             ": bytes at the recorded external_data offset match the pool "
+             "(and so the original tensor)");
+  }
+
+  // The file this wrote is a valid, standalone safetensors file too -- a
+  // fresh TensorPool can load it with no onnxsim/onnx involvement.
+  TensorPool reloaded;
+  reloaded.LoadSafetensors(path);
+  Check(reloaded.size() == 3,
+       "the exported file is independently loadable as safetensors");
+
+  std::remove(path.c_str());
+}
+
+void TestUnnamedAttributeTensor() {
+  // Regression test: an attribute tensor with no .name() of its own must
+  // still round-trip through export, keyed by ForEachTensor's positional
+  // fallback rather than being silently dropped (see
+  // ExportModelWithSafetensors's comment on why it tracks pool keys
+  // alongside each TensorProto* instead of re-deriving the key from
+  // t->name() after the fact).
+  onnx::ModelProto model;
+  auto* node = model.mutable_graph()->add_node();
+  node->set_name("n0");
+  auto* attr = node->add_attribute();
+  attr->set_name("value");
+  auto* t = attr->mutable_t();
+  t->set_data_type(onnx::TensorProto::FLOAT);
+  t->add_dims(1);
+  t->set_raw_data(std::string(4, '\x77'));
+  // t->name() is deliberately left empty.
+
+  std::string path = TempPath("_unnamed_attr.safetensors");
+  TensorPool pool;
+  size_t n = ExportModelWithSafetensors(model, path, pool);
+  Check(n == 1, "the unnamed attribute tensor is exported");
+
+  const auto& exported_t = model.graph().node(0).attribute(0).t();
+  Check(exported_t.data_location() == onnx::TensorProto::EXTERNAL,
+       "unnamed attribute tensor is EXTERNAL after export");
+  std::string location, offset_str, length_str;
+  for (const auto& e : exported_t.external_data()) {
+    if (e.key() == "location") location = e.value();
+    if (e.key() == "offset") offset_str = e.value();
+    if (e.key() == "length") length_str = e.value();
+  }
+  Check(!location.empty() && !offset_str.empty() && !length_str.empty(),
+       "unnamed attribute tensor got real location/offset/length, not left "
+       "half-adopted");
+  if (!offset_str.empty() && !length_str.empty()) {
+    std::string on_disk = ReadFileRange(path, std::stoull(offset_str),
+                                        std::stoull(length_str));
+    Check(on_disk == std::string(4, '\x77'),
+         "bytes at the recorded offset match the original tensor");
+  }
+  std::remove(path.c_str());
+}
+
+void TestImportModelWithSafetensorsHydrateAll() {
+  // Build and export a small model, matching TestExportModelWithSafetensors
+  // but round-tripping all the way back through import.
+  onnx::ModelProto original;
+  auto* g = original.mutable_graph();
+  *g->add_initializer() = MakeInitializer(
+      "w1", onnx::TensorProto::FLOAT, {3}, std::string(12, '\x44'));
+  *g->add_initializer() = MakeInitializer(
+      "w2", onnx::TensorProto::INT32, {2}, std::string(8, '\x55'));
+
+  std::string path = TempPath("_import.safetensors");
+  TensorPool export_pool;
+  ExportModelWithSafetensors(original, path, export_pool);
+
+  // A fresh model with the same initializer names/dtypes/shapes but no
+  // bytes -- the situation a real loader would be in after reading a
+  // .onnx whose initializers are external_data placeholders.
+  onnx::ModelProto fresh;
+  auto* fg = fresh.mutable_graph();
+  auto* w1 = fg->add_initializer();
+  w1->set_name("w1");
+  w1->set_data_type(onnx::TensorProto::FLOAT);
+  w1->add_dims(3);
+  auto* w2 = fg->add_initializer();
+  w2->set_name("w2");
+  w2->set_data_type(onnx::TensorProto::INT32);
+  w2->add_dims(2);
+
+  TensorPool import_pool;
+  size_t matched = ImportModelWithSafetensors(fresh, path, import_pool);
+  Check(matched == 2, "both initializers matched on import");
+
+  Check(fg->initializer(0).has_raw_data() &&
+           fg->initializer(0).raw_data() == std::string(12, '\x44'),
+       "w1 hydrated to the original bytes");
+  Check(fg->initializer(0).data_location() == onnx::TensorProto::DEFAULT,
+       "w1 is DEFAULT-located after hydration");
+  Check(fg->initializer(1).has_raw_data() &&
+           fg->initializer(1).raw_data() == std::string(8, '\x55'),
+       "w2 hydrated to the original bytes");
+
+  std::remove(path.c_str());
+}
+
+void TestImportModelWithSafetensorsLazy() {
+  onnx::ModelProto original;
+  *original.mutable_graph()->add_initializer() = MakeInitializer(
+      "lazy", onnx::TensorProto::FLOAT, {1}, std::string(4, '\x66'));
+  std::string path = TempPath("_lazy.safetensors");
+  TensorPool export_pool;
+  ExportModelWithSafetensors(original, path, export_pool);
+
+  onnx::ModelProto fresh;
+  auto* init = fresh.mutable_graph()->add_initializer();
+  init->set_name("lazy");
+  init->set_data_type(onnx::TensorProto::FLOAT);
+  init->add_dims(1);
+
+  TensorPool import_pool;
+  size_t matched =
+      ImportModelWithSafetensors(fresh, path, import_pool, /*hydrate_all=*/false);
+  Check(matched == 1, "lazy import still reports the match");
+  Check(!fresh.graph().initializer(0).has_raw_data(),
+       "lazy import leaves raw_data unset");
+  Check(fresh.graph().initializer(0).data_location() ==
+           onnx::TensorProto::EXTERNAL,
+       "lazy import marks the tensor EXTERNAL for on-demand hydration");
+
+  // The caller can still hydrate it explicitly, on demand, straight from the
+  // already-loaded pool -- no second file read.
+  bool hydrated = HydrateTensorProto(
+      "lazy", *fresh.mutable_graph()->mutable_initializer(0), import_pool);
+  Check(hydrated && fresh.graph().initializer(0).raw_data() ==
+                       std::string(4, '\x66'),
+       "on-demand HydrateTensorProto recovers the bytes");
+
+  std::remove(path.c_str());
+}
+
+}  // namespace
+
+int main() {
+  TestAdoptAndHydrateSingleTensor();
+  TestStringTensorIsNotAdopted();
+  TestExportModelWithSafetensors();
+  TestUnnamedAttributeTensor();
+  TestImportModelWithSafetensorsHydrateAll();
+  TestImportModelWithSafetensorsLazy();
+
+  if (g_failures == 0) {
+    std::printf("tensor_pool_bridge_test: all checks passed\n");
+    return 0;
+  }
+  std::fprintf(stderr, "tensor_pool_bridge_test: %d failure(s)\n",
+              g_failures);
+  return 1;
+}

--- a/onnxsim/tensor_pool_dtype.h
+++ b/onnxsim/tensor_pool_dtype.h
@@ -1,0 +1,140 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Pure, dependency-free mapping between ONNX tensor element types and the
+ * safetensors on-disk dtype strings
+ * (https://github.com/huggingface/safetensors#format). Operates on the
+ * *integer* ONNX dtype codes (the stable wire numbers of
+ * onnx::TensorProto::DataType) rather than the onnx headers, so tensor_pool.h
+ * / tensor_pool.cpp build and unit-test on their own -- including under
+ * Emscripten and in the wheel build -- without configuring ONNX. Mirrors
+ * dlpack_dtype.h's split (pure dtype mapping vs. the onnx::TensorProto glue
+ * in tensor_pool_bridge.h) for the same reason.
+ *
+ * Supported set: BOOL, all signed/unsigned 8/16/32/64-bit ints, FLOAT16,
+ * BFLOAT16, FLOAT, DOUBLE -- the dtypes with a fixed-width, raw, contiguous
+ * layout AND a safetensors dtype string. safetensors has no encoding for
+ * STRING, COMPLEX64/128, or UNDEFINED, so those are rejected here; a
+ * TensorPool can't pool a STRING tensor.
+ */
+#ifndef ONNXSIM_TENSOR_POOL_DTYPE_H_
+#define ONNXSIM_TENSOR_POOL_DTYPE_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+
+namespace onnxsim {
+namespace tensor_pool {
+
+// Stable ONNX TensorProto::DataType wire numbers, mirrored so this header
+// does not need the onnx protobuf headers. Kept in sync with onnx/onnx.proto3
+// (see dlpack_dtype.h's identical OnnxDtype, which this duplicates rather
+// than depends on so the two dtype mappings stay independently buildable).
+enum OnnxDtype : int32_t {
+  ONNX_UNDEFINED = 0,
+  ONNX_FLOAT = 1,
+  ONNX_UINT8 = 2,
+  ONNX_INT8 = 3,
+  ONNX_UINT16 = 4,
+  ONNX_INT16 = 5,
+  ONNX_INT32 = 6,
+  ONNX_INT64 = 7,
+  ONNX_STRING = 8,
+  ONNX_BOOL = 9,
+  ONNX_FLOAT16 = 10,
+  ONNX_DOUBLE = 11,
+  ONNX_UINT32 = 12,
+  ONNX_UINT64 = 13,
+  ONNX_COMPLEX64 = 14,
+  ONNX_COMPLEX128 = 15,
+  ONNX_BFLOAT16 = 16,
+};
+
+// Bytes of one element of `onnx_dtype`. 0 for a dtype with no fixed-width
+// element size, or one ToSafetensors rejects.
+inline size_t ElementSize(int32_t onnx_dtype) {
+  switch (onnx_dtype) {
+    case ONNX_BOOL:
+    case ONNX_INT8:
+    case ONNX_UINT8:
+      return 1;
+    case ONNX_INT16:
+    case ONNX_UINT16:
+    case ONNX_FLOAT16:
+    case ONNX_BFLOAT16:
+      return 2;
+    case ONNX_INT32:
+    case ONNX_UINT32:
+    case ONNX_FLOAT:
+      return 4;
+    case ONNX_INT64:
+    case ONNX_UINT64:
+    case ONNX_DOUBLE:
+      return 8;
+    default:
+      return 0;
+  }
+}
+
+// Map an ONNX dtype code to its safetensors header dtype string. Returns ""
+// for a dtype safetensors cannot represent (STRING, COMPLEX64/128,
+// UNDEFINED, or one of onnx's newer sub-byte/float8 encodings this mapping
+// does not (yet) cover).
+inline std::string_view ToSafetensors(int32_t onnx_dtype) {
+  switch (onnx_dtype) {
+    case ONNX_BOOL:
+      return "BOOL";
+    case ONNX_UINT8:
+      return "U8";
+    case ONNX_INT8:
+      return "I8";
+    case ONNX_INT16:
+      return "I16";
+    case ONNX_UINT16:
+      return "U16";
+    case ONNX_INT32:
+      return "I32";
+    case ONNX_UINT32:
+      return "U32";
+    case ONNX_INT64:
+      return "I64";
+    case ONNX_UINT64:
+      return "U64";
+    case ONNX_FLOAT16:
+      return "F16";
+    case ONNX_BFLOAT16:
+      return "BF16";
+    case ONNX_FLOAT:
+      return "F32";
+    case ONNX_DOUBLE:
+      return "F64";
+    default:
+      return {};
+  }
+}
+
+// Inverse of ToSafetensors. Returns ONNX_UNDEFINED for a name this mapping
+// doesn't recognize -- including safetensors' F8_* family, which has no
+// onnx raw-data equivalent this pool handles.
+inline int32_t FromSafetensors(std::string_view dtype) {
+  if (dtype == "BOOL") return ONNX_BOOL;
+  if (dtype == "U8") return ONNX_UINT8;
+  if (dtype == "I8") return ONNX_INT8;
+  if (dtype == "I16") return ONNX_INT16;
+  if (dtype == "U16") return ONNX_UINT16;
+  if (dtype == "I32") return ONNX_INT32;
+  if (dtype == "U32") return ONNX_UINT32;
+  if (dtype == "I64") return ONNX_INT64;
+  if (dtype == "U64") return ONNX_UINT64;
+  if (dtype == "F16") return ONNX_FLOAT16;
+  if (dtype == "BF16") return ONNX_BFLOAT16;
+  if (dtype == "F32") return ONNX_FLOAT;
+  if (dtype == "F64") return ONNX_DOUBLE;
+  return ONNX_UNDEFINED;
+}
+
+}  // namespace tensor_pool
+}  // namespace onnxsim
+
+#endif  // ONNXSIM_TENSOR_POOL_DTYPE_H_

--- a/onnxsim/tensor_pool_dtype_test.cpp
+++ b/onnxsim/tensor_pool_dtype_test.cpp
@@ -1,0 +1,83 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Standalone: g++ -std=c++17 tensor_pool_dtype_test.cpp -o t && ./t
+ *
+ * Dependency-free unit test for the ONNX<->safetensors dtype mapping. Like
+ * dlpack_dtype_test.cpp, it builds and runs standalone (no ONNX / ONNX
+ * Runtime), so it is wired into the ONNXSIM_TESTS target and runnable under
+ * Emscripten.
+ */
+#include "tensor_pool_dtype.h"
+
+#include <cstdio>
+#include <string>
+
+using namespace onnxsim::tensor_pool;
+
+namespace {
+
+int g_failures = 0;
+
+void Check(bool cond, const std::string& what) {
+  if (!cond) {
+    std::fprintf(stderr, "FAIL: %s\n", what.c_str());
+    ++g_failures;
+  }
+}
+
+struct Row {
+  int32_t onnx;
+  const char* safetensors;
+  size_t bytes;
+};
+
+}  // namespace
+
+int main() {
+  const Row rows[] = {
+      {ONNX_BOOL, "BOOL", 1},   {ONNX_UINT8, "U8", 1},
+      {ONNX_INT8, "I8", 1},     {ONNX_INT16, "I16", 2},
+      {ONNX_UINT16, "U16", 2},  {ONNX_FLOAT16, "F16", 2},
+      {ONNX_BFLOAT16, "BF16", 2}, {ONNX_INT32, "I32", 4},
+      {ONNX_UINT32, "U32", 4}, {ONNX_FLOAT, "F32", 4},
+      {ONNX_INT64, "I64", 8},  {ONNX_UINT64, "U64", 8},
+      {ONNX_DOUBLE, "F64", 8},
+  };
+
+  for (const auto& row : rows) {
+    std::string_view mapped = ToSafetensors(row.onnx);
+    Check(mapped == row.safetensors,
+         "ToSafetensors(" + std::to_string(row.onnx) +
+             ") == " + row.safetensors);
+    Check(ElementSize(row.onnx) == row.bytes,
+         "ElementSize(" + std::to_string(row.onnx) +
+             ") == " + std::to_string(row.bytes));
+    // Round trip: onnx -> safetensors -> onnx recovers the same code.
+    Check(FromSafetensors(mapped) == row.onnx,
+         std::string("FromSafetensors(ToSafetensors(") +
+             std::to_string(row.onnx) + ")) round-trips");
+  }
+
+  // Types safetensors cannot represent map to an empty string / UNDEFINED.
+  Check(ToSafetensors(ONNX_STRING).empty(), "STRING has no safetensors dtype");
+  Check(ToSafetensors(ONNX_COMPLEX64).empty(),
+       "COMPLEX64 has no safetensors dtype");
+  Check(ToSafetensors(ONNX_COMPLEX128).empty(),
+       "COMPLEX128 has no safetensors dtype");
+  Check(ToSafetensors(ONNX_UNDEFINED).empty(),
+       "UNDEFINED has no safetensors dtype");
+  Check(ElementSize(ONNX_STRING) == 0, "STRING has no fixed element size");
+
+  Check(FromSafetensors("F8_E4M3") == ONNX_UNDEFINED,
+       "unrecognized safetensors dtype maps to UNDEFINED");
+  Check(FromSafetensors("bogus") == ONNX_UNDEFINED,
+       "garbage safetensors dtype maps to UNDEFINED");
+
+  if (g_failures == 0) {
+    std::printf("tensor_pool_dtype_test: all checks passed\n");
+    return 0;
+  }
+  std::fprintf(stderr, "tensor_pool_dtype_test: %d failure(s)\n", g_failures);
+  return 1;
+}

--- a/onnxsim/tensor_pool_dtype_test.cpp
+++ b/onnxsim/tensor_pool_dtype_test.cpp
@@ -36,43 +36,43 @@ struct Row {
 
 int main() {
   const Row rows[] = {
-      {ONNX_BOOL, "BOOL", 1},   {ONNX_UINT8, "U8", 1},
-      {ONNX_INT8, "I8", 1},     {ONNX_INT16, "I16", 2},
-      {ONNX_UINT16, "U16", 2},  {ONNX_FLOAT16, "F16", 2},
+      {ONNX_BOOL, "BOOL", 1},     {ONNX_UINT8, "U8", 1},
+      {ONNX_INT8, "I8", 1},       {ONNX_INT16, "I16", 2},
+      {ONNX_UINT16, "U16", 2},    {ONNX_FLOAT16, "F16", 2},
       {ONNX_BFLOAT16, "BF16", 2}, {ONNX_INT32, "I32", 4},
-      {ONNX_UINT32, "U32", 4}, {ONNX_FLOAT, "F32", 4},
-      {ONNX_INT64, "I64", 8},  {ONNX_UINT64, "U64", 8},
+      {ONNX_UINT32, "U32", 4},    {ONNX_FLOAT, "F32", 4},
+      {ONNX_INT64, "I64", 8},     {ONNX_UINT64, "U64", 8},
       {ONNX_DOUBLE, "F64", 8},
   };
 
   for (const auto& row : rows) {
     std::string_view mapped = ToSafetensors(row.onnx);
-    Check(mapped == row.safetensors,
-         "ToSafetensors(" + std::to_string(row.onnx) +
-             ") == " + row.safetensors);
+    Check(mapped == row.safetensors, "ToSafetensors(" +
+                                         std::to_string(row.onnx) +
+                                         ") == " + row.safetensors);
     Check(ElementSize(row.onnx) == row.bytes,
-         "ElementSize(" + std::to_string(row.onnx) +
-             ") == " + std::to_string(row.bytes));
+          "ElementSize(" + std::to_string(row.onnx) +
+              ") == " + std::to_string(row.bytes));
     // Round trip: onnx -> safetensors -> onnx recovers the same code.
     Check(FromSafetensors(mapped) == row.onnx,
-         std::string("FromSafetensors(ToSafetensors(") +
-             std::to_string(row.onnx) + ")) round-trips");
+          std::string("FromSafetensors(ToSafetensors(") +
+              std::to_string(row.onnx) + ")) round-trips");
   }
 
   // Types safetensors cannot represent map to an empty string / UNDEFINED.
   Check(ToSafetensors(ONNX_STRING).empty(), "STRING has no safetensors dtype");
   Check(ToSafetensors(ONNX_COMPLEX64).empty(),
-       "COMPLEX64 has no safetensors dtype");
+        "COMPLEX64 has no safetensors dtype");
   Check(ToSafetensors(ONNX_COMPLEX128).empty(),
-       "COMPLEX128 has no safetensors dtype");
+        "COMPLEX128 has no safetensors dtype");
   Check(ToSafetensors(ONNX_UNDEFINED).empty(),
-       "UNDEFINED has no safetensors dtype");
+        "UNDEFINED has no safetensors dtype");
   Check(ElementSize(ONNX_STRING) == 0, "STRING has no fixed element size");
 
   Check(FromSafetensors("F8_E4M3") == ONNX_UNDEFINED,
-       "unrecognized safetensors dtype maps to UNDEFINED");
+        "unrecognized safetensors dtype maps to UNDEFINED");
   Check(FromSafetensors("bogus") == ONNX_UNDEFINED,
-       "garbage safetensors dtype maps to UNDEFINED");
+        "garbage safetensors dtype maps to UNDEFINED");
 
   if (g_failures == 0) {
     std::printf("tensor_pool_dtype_test: all checks passed\n");

--- a/onnxsim/tensor_pool_gguf.cpp
+++ b/onnxsim/tensor_pool_gguf.cpp
@@ -1,0 +1,402 @@
+// GGUF codec for TensorPool. See tensor_pool.h's declarations of
+// SaveGGUF/LoadGGUF and gguf_dtype.h's file comment (dtype scope, notably
+// that quantized types are never pooled) for the design rationale; this file
+// is "just" the wire-format read/write.
+#include <algorithm>
+#include <cstdint>
+#include <fstream>
+#include <optional>
+#include <stdexcept>
+
+#include "gguf_dtype.h"
+#include "tensor_pool.h"
+
+namespace onnxsim {
+namespace tensor_pool {
+
+// This file is entirely GGUF-specific, so bring gguf::'s names (kMagic,
+// GGUF_METADATA_VALUE_TYPE_*, ToOnnx/FromOnnx, ...) into scope for the whole
+// translation unit -- both the helpers in the anonymous namespace below and
+// the TensorPool::SaveGGUF/LoadGGUF definitions after it, which are siblings
+// of that anonymous namespace, not nested inside it, so a `using` directive
+// placed inside the anonymous namespace would not have reached them.
+using namespace gguf;  // NOLINT
+
+namespace {
+
+uint64_t AlignUp(uint64_t v, uint64_t align) {
+  if (align == 0) return v;
+  uint64_t rem = v % align;
+  return rem == 0 ? v : v + (align - rem);
+}
+
+// --- little-endian primitive readers/writers -------------------------------
+// Duplicated locally rather than shared with tensor_pool.cpp's safetensors
+// codec's WriteU64LE/ReadU64LE, mirroring gguf_dtype.h's choice to duplicate
+// (not #include) tensor_pool_dtype.h's ONNX dtype numbers: keeps the two
+// format codecs independently readable and buildable, at the cost of a few
+// duplicated lines.
+
+void WriteU32LE(std::ostream& out, uint32_t v) {
+  char buf[4];
+  for (int i = 0; i < 4; ++i) {
+    buf[i] = static_cast<char>(v & 0xFF);
+    v >>= 8;
+  }
+  out.write(buf, 4);
+}
+
+void WriteU64LE(std::ostream& out, uint64_t v) {
+  char buf[8];
+  for (int i = 0; i < 8; ++i) {
+    buf[i] = static_cast<char>(v & 0xFF);
+    v >>= 8;
+  }
+  out.write(buf, 8);
+}
+
+void WriteGGUFString(std::ostream& out, const std::string& s) {
+  WriteU64LE(out, s.size());
+  out.write(s.data(), static_cast<std::streamsize>(s.size()));
+}
+
+[[noreturn]] void FailRead(const std::string& path, const std::string& what) {
+  throw std::runtime_error("TensorPool::LoadGGUF: '" + path + "': " + what);
+}
+
+uint32_t ReadU32LE(std::istream& in, const std::string& path) {
+  unsigned char buf[4];
+  in.read(reinterpret_cast<char*>(buf), 4);
+  if (!in) FailRead(path, "unexpected end of file");
+  uint32_t v = 0;
+  for (int i = 3; i >= 0; --i) v = (v << 8) | buf[i];
+  return v;
+}
+
+uint64_t ReadU64LE(std::istream& in, const std::string& path) {
+  unsigned char buf[8];
+  in.read(reinterpret_cast<char*>(buf), 8);
+  if (!in) FailRead(path, "unexpected end of file");
+  uint64_t v = 0;
+  for (int i = 7; i >= 0; --i) v = (v << 8) | buf[i];
+  return v;
+}
+
+// A single GGUF string is length-prefixed with no cap of its own; bound it
+// generously so a corrupt/malicious length (e.g. near UINT64_MAX) fails fast
+// with a clear error instead of attempting a huge allocation.
+constexpr uint64_t kMaxStringLen = 1ull << 30;  // 1 GiB
+
+std::string ReadGGUFString(std::istream& in, const std::string& path) {
+  uint64_t len = ReadU64LE(in, path);
+  if (len > kMaxStringLen) {
+    FailRead(path, "implausibly long string (len=" + std::to_string(len) +
+                       "), file is likely corrupt");
+  }
+  std::string s(len, '\0');
+  if (len > 0) {
+    in.read(s.data(), static_cast<std::streamsize>(len));
+    if (!in) FailRead(path, "unexpected end of file while reading a string");
+  }
+  return s;
+}
+
+size_t FixedMetadataScalarSize(uint32_t value_type) {
+  switch (value_type) {
+    case GGUF_METADATA_VALUE_TYPE_UINT8:
+    case GGUF_METADATA_VALUE_TYPE_INT8:
+    case GGUF_METADATA_VALUE_TYPE_BOOL:
+      return 1;
+    case GGUF_METADATA_VALUE_TYPE_UINT16:
+    case GGUF_METADATA_VALUE_TYPE_INT16:
+      return 2;
+    case GGUF_METADATA_VALUE_TYPE_UINT32:
+    case GGUF_METADATA_VALUE_TYPE_INT32:
+    case GGUF_METADATA_VALUE_TYPE_FLOAT32:
+      return 4;
+    case GGUF_METADATA_VALUE_TYPE_UINT64:
+    case GGUF_METADATA_VALUE_TYPE_INT64:
+    case GGUF_METADATA_VALUE_TYPE_FLOAT64:
+      return 8;
+    default:
+      return 0;  // STRING / ARRAY: no fixed size, handled by the caller
+  }
+}
+
+// Skip one metadata value of `value_type` (the tag itself already consumed
+// by the caller). TensorPool doesn't model GGUF's arbitrary metadata, so
+// every value is discarded -- except an unsigned integer scalar's numeric
+// value is decoded and returned, the one piece SaveGGUF... no, LoadGGUF's
+// "general.alignment" probe below needs.
+std::optional<uint64_t> SkipMetadataValue(std::istream& in,
+                                          const std::string& path,
+                                          uint32_t value_type) {
+  if (value_type == GGUF_METADATA_VALUE_TYPE_STRING) {
+    ReadGGUFString(in, path);
+    return std::nullopt;
+  }
+  if (value_type == GGUF_METADATA_VALUE_TYPE_ARRAY) {
+    uint32_t elem_type = ReadU32LE(in, path);
+    uint64_t len = ReadU64LE(in, path);
+    if (elem_type == GGUF_METADATA_VALUE_TYPE_ARRAY) {
+      FailRead(path, "nested metadata arrays are not supported");
+    }
+    if (elem_type == GGUF_METADATA_VALUE_TYPE_STRING) {
+      for (uint64_t i = 0; i < len; ++i) ReadGGUFString(in, path);
+    } else {
+      size_t elem_size = FixedMetadataScalarSize(elem_type);
+      if (elem_size == 0) {
+        FailRead(path, "unknown metadata array element type " +
+                           std::to_string(elem_type));
+      }
+      in.seekg(static_cast<std::streamoff>(elem_size * len), std::ios::cur);
+      if (!in) FailRead(path, "truncated metadata array");
+    }
+    return std::nullopt;
+  }
+  size_t size = FixedMetadataScalarSize(value_type);
+  if (size == 0) {
+    FailRead(path, "unknown metadata value type " + std::to_string(value_type));
+  }
+  unsigned char buf[8] = {};
+  in.read(reinterpret_cast<char*>(buf), static_cast<std::streamsize>(size));
+  if (!in) FailRead(path, "truncated metadata value");
+  switch (value_type) {
+    case GGUF_METADATA_VALUE_TYPE_UINT8:
+      return static_cast<uint64_t>(buf[0]);
+    case GGUF_METADATA_VALUE_TYPE_UINT16:
+      return static_cast<uint64_t>(buf[0]) |
+             (static_cast<uint64_t>(buf[1]) << 8);
+    case GGUF_METADATA_VALUE_TYPE_UINT32: {
+      uint64_t v = 0;
+      for (int i = 3; i >= 0; --i) v = (v << 8) | buf[i];
+      return v;
+    }
+    case GGUF_METADATA_VALUE_TYPE_UINT64: {
+      uint64_t v = 0;
+      for (int i = 7; i >= 0; --i) v = (v << 8) | buf[i];
+      return v;
+    }
+    default:
+      return std::nullopt;  // signed ints / floats / bool: value not needed
+  }
+}
+
+struct TensorInfo {
+  std::string name;
+  std::vector<uint64_t> ne;  // ggml order: ne[0] is the innermost dimension
+  uint32_t ggml_type = 0;
+  uint64_t offset = 0;  // relative to the start of the tensor-data section
+};
+
+// Implausible-but-cheap-to-check bounds on counts read from the file,
+// rejected before any loop/allocation sized by them -- a corrupt or
+// adversarial file shouldn't be able to make this reader allocate or loop
+// proportionally to an attacker-chosen 64-bit count.
+constexpr uint64_t kMaxTensorCount = 10'000'000;
+constexpr uint64_t kMaxMetadataCount = 10'000'000;
+constexpr uint32_t kMaxDims =
+    8;  // ggml's own GGML_MAX_DIMS is 4; generous slack
+
+}  // namespace
+
+void TensorPool::SaveGGUF(
+    const std::string& path,
+    const std::map<std::string, std::string>& string_metadata,
+    std::map<std::string, std::pair<uint64_t, uint64_t>>* data_offsets_out,
+    uint64_t* data_section_start_out) const {
+  if (data_offsets_out != nullptr) data_offsets_out->clear();
+
+  // Validate every entry's dtype up front so a partially-written file is
+  // never left behind on a rejected tensor (mirrors SaveSafetensors).
+  for (const auto& [name, entry] : entries_) {
+    uint32_t ggml_type;
+    if (!gguf::FromOnnx(entry.dtype, &ggml_type)) {
+      throw std::runtime_error("TensorPool::SaveGGUF: tensor '" + name +
+                               "' has an ONNX dtype (" +
+                               std::to_string(entry.dtype) +
+                               ") with no raw ggml_type representation");
+    }
+  }
+
+  // Each tensor's [begin, end) relative to the data section's start. This
+  // depends only on entries_ (name-sorted iteration order and each entry's
+  // byte length), not on anything written yet, so it can be computed in one
+  // pure pass before any I/O.
+  std::map<std::string, std::pair<uint64_t, uint64_t>> offsets;
+  {
+    uint64_t running = 0;
+    for (const auto& [name, entry] : entries_) {
+      running = AlignUp(running, kDefaultAlignment);
+      uint64_t begin = running;
+      uint64_t end = begin + entry.nbytes();
+      offsets[name] = {begin, end};
+      running = end;
+    }
+  }
+
+  std::ofstream out(path, std::ios::binary | std::ios::trunc);
+  if (!out) {
+    throw std::runtime_error("TensorPool::SaveGGUF: cannot open '" + path +
+                             "' for writing");
+  }
+
+  WriteU32LE(out, kMagic);
+  WriteU32LE(out, kSupportedVersion);
+  WriteU64LE(out, entries_.size());
+  WriteU64LE(out, string_metadata.size());
+  for (const auto& [key, value] : string_metadata) {
+    WriteGGUFString(out, key);
+    WriteU32LE(out, GGUF_METADATA_VALUE_TYPE_STRING);
+    WriteGGUFString(out, value);
+  }
+
+  for (const auto& [name, entry] : entries_) {
+    uint32_t ggml_type = 0;
+    gguf::FromOnnx(entry.dtype, &ggml_type);  // already validated above
+    WriteGGUFString(out, name);
+    WriteU32LE(out, static_cast<uint32_t>(entry.shape.size()));
+    // GGML's ne[] wants the innermost dimension first -- the reverse of
+    // onnx's row-major, outermost-first shape order (see LoadGGUF's mirror
+    // comment on the way back).
+    for (auto it = entry.shape.rbegin(); it != entry.shape.rend(); ++it) {
+      WriteU64LE(out, static_cast<uint64_t>(*it));
+    }
+    WriteU32LE(out, ggml_type);
+    WriteU64LE(out, offsets.at(name).first);
+  }
+
+  static const char kZeroBuf[64] = {};
+  auto write_padding = [&](uint64_t n) {
+    while (n > 0) {
+      uint64_t chunk = std::min<uint64_t>(n, sizeof(kZeroBuf));
+      out.write(kZeroBuf, static_cast<std::streamsize>(chunk));
+      n -= chunk;
+    }
+  };
+
+  uint64_t header_end = static_cast<uint64_t>(out.tellp());
+  uint64_t data_section_start = AlignUp(header_end, kDefaultAlignment);
+  write_padding(data_section_start - header_end);
+
+  uint64_t write_pos = 0;  // relative to data_section_start
+  for (const auto& [name, entry] : entries_) {
+    const auto& [begin, end] = offsets.at(name);
+    write_padding(begin - write_pos);
+    if (!entry.data.empty()) {
+      out.write(entry.data.data(),
+                static_cast<std::streamsize>(entry.data.size()));
+    }
+    write_pos = end;
+  }
+
+  if (!out) {
+    throw std::runtime_error("TensorPool::SaveGGUF: write failed for '" + path +
+                             "'");
+  }
+
+  if (data_offsets_out != nullptr) *data_offsets_out = std::move(offsets);
+  if (data_section_start_out != nullptr) {
+    *data_section_start_out = data_section_start;
+  }
+}
+
+std::vector<std::string> TensorPool::LoadGGUF(const std::string& path) {
+  std::ifstream in(path, std::ios::binary);
+  if (!in) {
+    throw std::runtime_error("TensorPool::LoadGGUF: cannot open '" + path +
+                             "'");
+  }
+
+  uint32_t magic = ReadU32LE(in, path);
+  if (magic != kMagic) {
+    FailRead(path, "not a GGUF file (bad magic)");
+  }
+  uint32_t version = ReadU32LE(in, path);
+  if (version != kSupportedVersion) {
+    FailRead(path, "GGUF version " + std::to_string(version) +
+                       " is not supported (only version " +
+                       std::to_string(kSupportedVersion) + " is)");
+  }
+  uint64_t tensor_count = ReadU64LE(in, path);
+  uint64_t metadata_kv_count = ReadU64LE(in, path);
+  if (tensor_count > kMaxTensorCount) {
+    FailRead(path, "implausible tensor_count (" + std::to_string(tensor_count) +
+                       "), likely corrupt");
+  }
+  if (metadata_kv_count > kMaxMetadataCount) {
+    FailRead(path, "implausible metadata_kv_count (" +
+                       std::to_string(metadata_kv_count) + "), likely corrupt");
+  }
+
+  uint64_t alignment = kDefaultAlignment;
+  for (uint64_t i = 0; i < metadata_kv_count; ++i) {
+    std::string key = ReadGGUFString(in, path);
+    uint32_t value_type = ReadU32LE(in, path);
+    std::optional<uint64_t> numeric = SkipMetadataValue(in, path, value_type);
+    if (key == "general.alignment" && numeric.has_value() && *numeric != 0) {
+      alignment = *numeric;
+    }
+  }
+
+  std::vector<TensorInfo> infos;
+  infos.reserve(tensor_count);
+  for (uint64_t i = 0; i < tensor_count; ++i) {
+    TensorInfo info;
+    info.name = ReadGGUFString(in, path);
+    uint32_t n_dims = ReadU32LE(in, path);
+    if (n_dims > kMaxDims) {
+      FailRead(path, "tensor '" + info.name +
+                         "' has an implausible dimension count (" +
+                         std::to_string(n_dims) + ")");
+    }
+    info.ne.resize(n_dims);
+    for (uint32_t d = 0; d < n_dims; ++d) info.ne[d] = ReadU64LE(in, path);
+    info.ggml_type = ReadU32LE(in, path);
+    info.offset = ReadU64LE(in, path);
+    infos.push_back(std::move(info));
+  }
+
+  uint64_t header_end = static_cast<uint64_t>(in.tellg());
+  uint64_t data_section_start = AlignUp(header_end, alignment);
+
+  in.seekg(0, std::ios::end);
+  uint64_t file_size = static_cast<uint64_t>(in.tellg());
+
+  entries_.clear();
+  std::vector<std::string> skipped;
+  for (const auto& info : infos) {
+    int32_t onnx_dtype;
+    if (!gguf::ToOnnx(info.ggml_type, &onnx_dtype)) {
+      skipped.push_back(info.name);
+      continue;
+    }
+    size_t elem_size = gguf::ElementSize(info.ggml_type);
+    uint64_t nelems = 1;
+    for (uint64_t d : info.ne) nelems *= d;
+    uint64_t nbytes = nelems * elem_size;
+    uint64_t abs_offset = data_section_start + info.offset;
+    if (abs_offset > file_size || nbytes > file_size - abs_offset) {
+      FailRead(path, "tensor '" + info.name +
+                         "' data range extends past the end of the file");
+    }
+
+    std::string bytes(nbytes, '\0');
+    if (nbytes > 0) {
+      in.seekg(static_cast<std::streamoff>(abs_offset));
+      in.read(bytes.data(), static_cast<std::streamsize>(nbytes));
+      if (!in) {
+        FailRead(path, "truncated while reading tensor '" + info.name + "'");
+      }
+    }
+
+    // Reverse of SaveGGUF's reversal: ggml's ne[] is innermost-dimension-
+    // first, onnx's shape is outermost-first, for the same contiguous bytes.
+    std::vector<int64_t> shape(info.ne.rbegin(), info.ne.rend());
+    Add(info.name, onnx_dtype, std::move(shape), std::move(bytes));
+  }
+  return skipped;
+}
+
+}  // namespace tensor_pool
+}  // namespace onnxsim

--- a/onnxsim/tensor_pool_gguf_bridge.h
+++ b/onnxsim/tensor_pool_gguf_bridge.h
@@ -142,6 +142,52 @@ inline bool LoadModelFromGGUF(const std::string& path, onnx::ModelProto* model,
   return ExtractModel(pool, model, hydrate_all);
 }
 
+// GGUF counterpart of tensor_pool_bridge.h's SaveModelAsSafetensorsStandalone
+// -- see that function's comment (and the "standalone archives" section
+// above it) for the real-offset design and why every weight tensor is still
+// written to disk exactly once despite the model blob needing two passes.
+inline void SaveModelAsGGUFStandalone(
+    onnx::ModelProto& model, const std::string& path, TensorPool& pool,
+    const std::map<std::string, std::string>& string_metadata = {}) {
+  auto adopted = AdoptAllWithPlaceholderOffsets(model, path, pool);
+  CheckNoEmbeddedModelKeyCollision(pool);
+
+  std::string placeholder_bytes;
+  if (!model.SerializeToString(&placeholder_bytes)) {
+    throw std::runtime_error(
+        "TensorPool: SaveModelAsGGUFStandalone: failed to serialize the "
+        "model");
+  }
+  pool.Add(kEmbeddedModelKey, ONNX_INT8,
+           {static_cast<int64_t>(placeholder_bytes.size())},
+           std::string(placeholder_bytes));
+
+  std::map<std::string, std::pair<uint64_t, uint64_t>> offsets;
+  uint64_t data_section_start = 0;
+  pool.SaveGGUF(path, string_metadata, &offsets, &data_section_start);
+
+  PatchStandaloneOffsets(adopted, offsets, data_section_start);
+
+  std::string final_bytes;
+  if (!model.SerializeToString(&final_bytes)) {
+    throw std::runtime_error(
+        "TensorPool: SaveModelAsGGUFStandalone: failed to re-serialize the "
+        "model");
+  }
+  if (final_bytes.size() != placeholder_bytes.size()) {
+    throw std::runtime_error(
+        "TensorPool: SaveModelAsGGUFStandalone: internal error -- "
+        "re-serializing with real offsets changed the model's size (" +
+        std::to_string(placeholder_bytes.size()) + " -> " +
+        std::to_string(final_bytes.size()) + " bytes)");
+  }
+
+  const auto& model_range = offsets.at(kEmbeddedModelKey);
+  PatchFileBytes(path, data_section_start + model_range.first, final_bytes);
+  pool.Add(kEmbeddedModelKey, ONNX_INT8,
+           {static_cast<int64_t>(final_bytes.size())}, std::move(final_bytes));
+}
+
 }  // namespace tensor_pool
 }  // namespace onnxsim
 

--- a/onnxsim/tensor_pool_gguf_bridge.h
+++ b/onnxsim/tensor_pool_gguf_bridge.h
@@ -113,6 +113,35 @@ inline size_t ImportModelWithGGUF(
   return matched;
 }
 
+// GGUF counterparts of tensor_pool_bridge.h's SaveModelAsSafetensors /
+// LoadModelFromSafetensors -- see that header's top comment for the
+// self-describing-archive design (EmbedModel/ExtractModel, which these
+// reuse unchanged; embedding a model doesn't care which codec eventually
+// serializes the pool).
+
+// Convenience wrapper: EmbedModel then pool.SaveGGUF(path, string_metadata).
+// `model` ends up mutated exactly as EmbedModel leaves it -- reload with
+// LoadModelFromGGUF rather than reusing `model`.
+inline void SaveModelAsGGUF(
+    onnx::ModelProto& model, const std::string& path, TensorPool& pool,
+    const std::map<std::string, std::string>& string_metadata = {}) {
+  EmbedModel(model, path, pool);
+  pool.SaveGGUF(path, string_metadata);
+}
+
+// Convenience wrapper: pool.LoadGGUF(path) then ExtractModel. Returns false
+// if `path`'s pool has no embedded model. `skipped_out`, when non-null,
+// receives the names of any OTHER pooled tensors skipped as quantized/
+// unsupported (kEmbeddedModelKey itself is always a raw I8 blob, so it is
+// never one of them) -- same meaning as ImportModelWithGGUF's.
+inline bool LoadModelFromGGUF(const std::string& path, onnx::ModelProto* model,
+                              TensorPool& pool, bool hydrate_all = true,
+                              std::vector<std::string>* skipped_out = nullptr) {
+  std::vector<std::string> skipped = pool.LoadGGUF(path);
+  if (skipped_out != nullptr) *skipped_out = std::move(skipped);
+  return ExtractModel(pool, model, hydrate_all);
+}
+
 }  // namespace tensor_pool
 }  // namespace onnxsim
 

--- a/onnxsim/tensor_pool_gguf_bridge.h
+++ b/onnxsim/tensor_pool_gguf_bridge.h
@@ -1,0 +1,119 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * GGUF counterpart of tensor_pool_bridge.h's ExportModelWithSafetensors /
+ * ImportModelWithSafetensors -- same design, a different container format.
+ * See that header's top comment for the shared rationale (moving an
+ * initializer's raw_data into a pool with no copy, then patching in a real,
+ * spec-compliant onnx EXTERNAL reference once the file's offsets are known)
+ * and its NOT-covered-here note, which applies equally: this is meant for
+ * the load/save boundary, not as onnxsim's internal in-flight
+ * representation during Simplify().
+ *
+ * The GGUF-specific thing worth calling out here is gguf_dtype.h's scope
+ * limit: GGUF's block-quantized types (most of a real quantized-LLM
+ * checkpoint's tensors) have no ONNX raw-data equivalent, so
+ * ImportModelWithGGUF's `skipped_out` matters more here than
+ * ImportModelWithSafetensors's equivalent ever would in practice -- loading
+ * an actual quantized .gguf will leave most of a model's initializers
+ * un-hydrated, and a caller needs to know which, rather than silently
+ * getting a model that's missing most of its weights.
+ */
+#ifndef ONNXSIM_TENSOR_POOL_GGUF_BRIDGE_H_
+#define ONNXSIM_TENSOR_POOL_GGUF_BRIDGE_H_
+
+#include <onnx/onnx_pb.h>
+
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "tensor_pool.h"
+// Reuses AdoptFromTensorProto / HydrateTensorProto / detail::ForEachTensor --
+// none of that is safetensors-specific, so there is nothing GGUF-specific to
+// redefine here.
+#include "tensor_pool_bridge.h"
+
+namespace onnxsim {
+namespace tensor_pool {
+
+// Rewrite `model` so every eligible tensor becomes an EXTERNAL reference into
+// a freshly-written `gguf_path`, and write that file. Returns the number of
+// tensors externalized. `pool` ends up holding every externalized tensor.
+// `string_metadata` is forwarded to TensorPool::SaveGGUF verbatim (e.g.
+// {"general.architecture", "onnxsim"}).
+inline size_t ExportModelWithGGUF(
+    onnx::ModelProto& model, const std::string& gguf_path, TensorPool& pool,
+    const std::map<std::string, std::string>& string_metadata = {}) {
+  // See ExportModelWithSafetensors's identical comment: keyed by the pool
+  // key ForEachTensor assigned, not by t->name(), which may be empty for an
+  // unnamed attribute tensor.
+  std::vector<std::pair<std::string, onnx::TensorProto*>> exported;
+  detail::ForEachTensor(*model.mutable_graph(),
+                        [&](const std::string& name, onnx::TensorProto& t) {
+                          if (AdoptFromTensorProto(name, t, pool)) {
+                            exported.emplace_back(name, &t);
+                          }
+                        });
+
+  std::map<std::string, std::pair<uint64_t, uint64_t>> offsets;
+  uint64_t data_section_start = 0;
+  pool.SaveGGUF(gguf_path, string_metadata, &offsets, &data_section_start);
+
+  for (auto& [pool_key, t] : exported) {
+    const auto& [begin, end] = offsets.at(pool_key);
+    t->set_data_location(onnx::TensorProto::EXTERNAL);
+    t->clear_external_data();
+    auto set_kv = [&](const std::string& k, const std::string& v) {
+      auto* e = t->add_external_data();
+      e->set_key(k);
+      e->set_value(v);
+    };
+    set_kv("location", gguf_path);
+    set_kv("offset", std::to_string(data_section_start + begin));
+    set_kv("length", std::to_string(end - begin));
+  }
+  return exported.size();
+}
+
+// Load `gguf_path` into `pool` and, for every graph initializer whose name
+// matches a pooled (i.e. raw-dtype) tensor, either hydrate it in place
+// (hydrate_all, the default) or leave it as a lazy EXTERNAL reference
+// (hydrate_all=false; see tensor_pool_bridge.h's caveat on this mode).
+// Returns the number of initializers matched (hydrated or marked lazy).
+//
+// When `skipped_out` is non-null, it receives the names of GGUF tensors
+// that were present in the file but skipped because their ggml_type is
+// quantized/unrecognized (TensorPool::LoadGGUF's own return value, passed
+// through) -- check this against your model's initializer names to find out
+// which weights this import could NOT bring in, rather than discovering it
+// only when a later pass trips over an initializer that's still empty.
+inline size_t ImportModelWithGGUF(
+    onnx::ModelProto& model, const std::string& gguf_path, TensorPool& pool,
+    bool hydrate_all = true, std::vector<std::string>* skipped_out = nullptr) {
+  std::vector<std::string> skipped = pool.LoadGGUF(gguf_path);
+  if (skipped_out != nullptr) *skipped_out = std::move(skipped);
+
+  size_t matched = 0;
+  for (auto& init : *model.mutable_graph()->mutable_initializer()) {
+    const Entry* entry = pool.Find(init.name());
+    if (entry == nullptr) continue;
+    ++matched;
+    if (hydrate_all) {
+      HydrateTensorProto(init.name(), init, pool);
+    } else {
+      init.set_data_location(onnx::TensorProto::EXTERNAL);
+      init.clear_external_data();
+      auto* e = init.add_external_data();
+      e->set_key("location");
+      e->set_value(gguf_path);
+    }
+  }
+  return matched;
+}
+
+}  // namespace tensor_pool
+}  // namespace onnxsim
+
+#endif  // ONNXSIM_TENSOR_POOL_GGUF_BRIDGE_H_

--- a/onnxsim/tensor_pool_gguf_bridge_test.cpp
+++ b/onnxsim/tensor_pool_gguf_bridge_test.cpp
@@ -1,0 +1,335 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Exercises tensor_pool_gguf_bridge.h's onnx::TensorProto <-> TensorPool GGUF
+ * glue, mirroring tensor_pool_bridge_test.cpp. Needs onnx configured, so it's
+ * built against the fully-configured `onnxsim` CMake target rather than
+ * standalone (same as tensor_pool_bridge_test.cpp).
+ */
+#include "tensor_pool_gguf_bridge.h"
+
+#include <onnx/onnx_pb.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <bit>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include "gguf_dtype.h"
+
+using namespace onnxsim::tensor_pool;
+using namespace onnxsim::tensor_pool::gguf;
+
+namespace {
+
+int g_failures = 0;
+
+void Check(bool cond, const std::string& what) {
+  if (!cond) {
+    std::fprintf(stderr, "FAIL: %s\n", what.c_str());
+    ++g_failures;
+  }
+}
+
+std::string TempPath(const std::string& suffix) {
+  return "/tmp/onnxsim_tensor_pool_gguf_bridge_test_" +
+         std::to_string(::getpid()) + suffix;
+}
+
+std::string ReadFileRange(const std::string& path, uint64_t offset,
+                          uint64_t length) {
+  std::ifstream in(path, std::ios::binary);
+  in.seekg(static_cast<std::streamoff>(offset));
+  std::string out(length, '\0');
+  in.read(out.data(), static_cast<std::streamsize>(length));
+  return out;
+}
+
+template <typename T>
+void WriteLE(std::ostream& out, T v) {
+  static_assert(std::is_trivially_copyable_v<T>);
+  unsigned char raw[sizeof(T)];
+  std::memcpy(raw, &v, sizeof(T));
+  if constexpr (std::endian::native == std::endian::big) {
+    std::reverse(std::begin(raw), std::end(raw));
+  }
+  out.write(reinterpret_cast<const char*>(raw), sizeof(T));
+}
+
+onnx::TensorProto MakeInitializer(const std::string& name,
+                                  onnx::TensorProto::DataType dtype,
+                                  const std::vector<int64_t>& dims,
+                                  const std::string& raw) {
+  onnx::TensorProto t;
+  t.set_name(name);
+  t.set_data_type(dtype);
+  for (int64_t d : dims) t.add_dims(d);
+  t.set_raw_data(raw);
+  return t;
+}
+
+void TestExportModelWithGGUF() {
+  onnx::ModelProto model;
+  auto* graph = model.mutable_graph();
+  // Non-square shape, same reasoning as tensor_pool_gguf_test.cpp's
+  // TestRoundTrip: catches a ne[]-vs-shape order bug that byte comparison
+  // alone would miss.
+  *graph->add_initializer() = MakeInitializer(
+      "weight", onnx::TensorProto::FLOAT, {2, 3}, std::string(24, '\x11'));
+  *graph->add_initializer() = MakeInitializer("bias", onnx::TensorProto::INT64,
+                                              {2}, std::string(16, '\x22'));
+
+  auto* node = graph->add_node();
+  node->set_name("const_node");
+  auto* attr = node->add_attribute();
+  attr->set_name("value");
+  *attr->mutable_t() = MakeInitializer("const_tensor", onnx::TensorProto::INT8,
+                                       {4}, std::string(4, '\x33'));
+
+  std::string path = TempPath("_export.gguf");
+  TensorPool pool;
+  size_t n = ExportModelWithGGUF(model, path, pool,
+                                 {{"general.architecture", "onnxsim-test"}});
+  Check(n == 3, "all three tensors exported");
+
+  for (const auto& name : {"weight", "bias", "const_tensor"}) {
+    const onnx::TensorProto* t = nullptr;
+    for (const auto& init : graph->initializer()) {
+      if (init.name() == name) t = &init;
+    }
+    if (t == nullptr && graph->node(0).attribute(0).t().name() == name) {
+      t = &graph->node(0).attribute(0).t();
+    }
+    Check(t != nullptr, std::string(name) + ": found in model");
+    if (t == nullptr) continue;
+    Check(t->data_location() == onnx::TensorProto::EXTERNAL,
+          std::string(name) + ": is EXTERNAL after export");
+    Check(!t->has_raw_data(),
+          std::string(name) + ": no inline raw_data left after export");
+
+    std::string location, offset_str, length_str;
+    for (const auto& e : t->external_data()) {
+      if (e.key() == "location") location = e.value();
+      if (e.key() == "offset") offset_str = e.value();
+      if (e.key() == "length") length_str = e.value();
+    }
+    Check(location == path, std::string(name) + ": location == gguf path");
+    Check(!offset_str.empty() && !length_str.empty(),
+          std::string(name) + ": offset/length are set");
+
+    uint64_t offset = std::stoull(offset_str);
+    uint64_t length = std::stoull(length_str);
+    std::string on_disk = ReadFileRange(path, offset, length);
+    const Entry* pooled = pool.Find(name);
+    Check(pooled != nullptr && on_disk == pooled->data,
+          std::string(name) +
+              ": bytes at the recorded external_data offset match the pool");
+  }
+
+  // Independently loadable as GGUF with no onnxsim/onnx involvement.
+  TensorPool reloaded;
+  Check(reloaded.LoadGGUF(path).empty() && reloaded.size() == 3,
+        "the exported file is independently loadable as GGUF");
+  const Entry* w = reloaded.Find("weight");
+  Check(w != nullptr && w->shape == std::vector<int64_t>({2, 3}),
+        "the reloaded 'weight' tensor kept its shape (not transposed)");
+
+  std::remove(path.c_str());
+}
+
+void TestUnnamedAttributeTensor() {
+  // Same regression as tensor_pool_bridge_test.cpp's test of the same name:
+  // an attribute tensor with no .name() must still round-trip, keyed by
+  // ForEachTensor's positional fallback.
+  onnx::ModelProto model;
+  auto* node = model.mutable_graph()->add_node();
+  node->set_name("n0");
+  auto* attr = node->add_attribute();
+  attr->set_name("value");
+  auto* t = attr->mutable_t();
+  t->set_data_type(onnx::TensorProto::FLOAT);
+  t->add_dims(1);
+  t->set_raw_data(std::string(4, '\x77'));
+
+  std::string path = TempPath("_unnamed_attr.gguf");
+  TensorPool pool;
+  size_t n = ExportModelWithGGUF(model, path, pool);
+  Check(n == 1, "the unnamed attribute tensor is exported");
+
+  const auto& exported_t = model.graph().node(0).attribute(0).t();
+  Check(exported_t.data_location() == onnx::TensorProto::EXTERNAL,
+        "unnamed attribute tensor is EXTERNAL after export");
+  bool has_offset = false, has_length = false;
+  for (const auto& e : exported_t.external_data()) {
+    has_offset |= (e.key() == "offset" && !e.value().empty());
+    has_length |= (e.key() == "length" && !e.value().empty());
+  }
+  Check(has_offset && has_length,
+        "unnamed attribute tensor got real offset/length, not left "
+        "half-adopted");
+  std::remove(path.c_str());
+}
+
+void TestImportModelWithGGUFHydrateAll() {
+  onnx::ModelProto original;
+  auto* g = original.mutable_graph();
+  *g->add_initializer() = MakeInitializer("w1", onnx::TensorProto::FLOAT, {3},
+                                          std::string(12, '\x44'));
+  *g->add_initializer() = MakeInitializer("w2", onnx::TensorProto::INT32, {2},
+                                          std::string(8, '\x55'));
+
+  std::string path = TempPath("_import.gguf");
+  TensorPool export_pool;
+  ExportModelWithGGUF(original, path, export_pool);
+
+  onnx::ModelProto fresh;
+  auto* fg = fresh.mutable_graph();
+  auto* w1 = fg->add_initializer();
+  w1->set_name("w1");
+  w1->set_data_type(onnx::TensorProto::FLOAT);
+  w1->add_dims(3);
+  auto* w2 = fg->add_initializer();
+  w2->set_name("w2");
+  w2->set_data_type(onnx::TensorProto::INT32);
+  w2->add_dims(2);
+
+  TensorPool import_pool;
+  std::vector<std::string> skipped;
+  size_t matched =
+      ImportModelWithGGUF(fresh, path, import_pool, true, &skipped);
+  Check(matched == 2, "both initializers matched on import");
+  Check(skipped.empty(), "nothing skipped -- every tensor was a raw dtype");
+
+  Check(fg->initializer(0).has_raw_data() &&
+            fg->initializer(0).raw_data() == std::string(12, '\x44'),
+        "w1 hydrated to the original bytes");
+  Check(fg->initializer(0).data_location() == onnx::TensorProto::DEFAULT,
+        "w1 is DEFAULT-located after hydration");
+  Check(fg->initializer(1).has_raw_data() &&
+            fg->initializer(1).raw_data() == std::string(8, '\x55'),
+        "w2 hydrated to the original bytes");
+
+  std::remove(path.c_str());
+}
+
+void TestImportModelWithGGUFLazy() {
+  onnx::ModelProto original;
+  *original.mutable_graph()->add_initializer() = MakeInitializer(
+      "lazy", onnx::TensorProto::FLOAT, {1}, std::string(4, '\x66'));
+  std::string path = TempPath("_lazy.gguf");
+  TensorPool export_pool;
+  ExportModelWithGGUF(original, path, export_pool);
+
+  onnx::ModelProto fresh;
+  auto* init = fresh.mutable_graph()->add_initializer();
+  init->set_name("lazy");
+  init->set_data_type(onnx::TensorProto::FLOAT);
+  init->add_dims(1);
+
+  TensorPool import_pool;
+  size_t matched = ImportModelWithGGUF(fresh, path, import_pool,
+                                       /*hydrate_all=*/false);
+  Check(matched == 1, "lazy import still reports the match");
+  Check(!fresh.graph().initializer(0).has_raw_data(),
+        "lazy import leaves raw_data unset");
+  Check(fresh.graph().initializer(0).data_location() ==
+            onnx::TensorProto::EXTERNAL,
+        "lazy import marks the tensor EXTERNAL for on-demand hydration");
+
+  bool hydrated = HydrateTensorProto(
+      "lazy", *fresh.mutable_graph()->mutable_initializer(0), import_pool);
+  Check(hydrated &&
+            fresh.graph().initializer(0).raw_data() == std::string(4, '\x66'),
+        "on-demand HydrateTensorProto recovers the bytes");
+
+  std::remove(path.c_str());
+}
+
+// Hand-builds a GGUF file with one raw F32 tensor ("w1") and one Q4_0
+// (quantized) tensor ("w2"), then imports it against a model declaring both
+// as initializers -- the scenario a real quantized-LLM checkpoint puts a
+// caller in for nearly every weight.
+void TestImportModelWithGGUFSkipsQuantized() {
+  std::string path = TempPath("_quantized.gguf");
+  {
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    auto write_string = [&](const std::string& s) {
+      WriteLE<uint64_t>(out, s.size());
+      out.write(s.data(), static_cast<std::streamsize>(s.size()));
+    };
+    WriteLE<uint32_t>(out, kMagic);
+    WriteLE<uint32_t>(out, kSupportedVersion);
+    WriteLE<uint64_t>(out, 2);  // tensor_count
+    WriteLE<uint64_t>(out, 0);  // metadata_kv_count
+
+    write_string("w1");
+    WriteLE<uint32_t>(out, 1);
+    WriteLE<uint64_t>(out, 2);  // ne[0]
+    WriteLE<uint32_t>(out, GGML_TYPE_F32);
+    WriteLE<uint64_t>(out, 0);  // offset
+
+    write_string("w2");
+    WriteLE<uint32_t>(out, 1);
+    WriteLE<uint64_t>(out, 32);  // ne[0]
+    WriteLE<uint32_t>(out, 2);   // GGML_TYPE_Q4_0
+    WriteLE<uint64_t>(out, kDefaultAlignment);
+
+    uint64_t header_end = static_cast<uint64_t>(out.tellp());
+    uint64_t data_start = (header_end + kDefaultAlignment - 1) /
+                          kDefaultAlignment * kDefaultAlignment;
+    for (uint64_t i = header_end; i < data_start; ++i) out.put('\0');
+    WriteLE<float>(out, 1.5f);
+    WriteLE<float>(out, -2.5f);
+    uint64_t cur = static_cast<uint64_t>(out.tellp()) - data_start;
+    for (uint64_t i = cur; i < kDefaultAlignment; ++i) out.put('\0');
+    for (int i = 0; i < 18; ++i) out.put('\xAB');
+  }
+
+  onnx::ModelProto model;
+  auto* w1 = model.mutable_graph()->add_initializer();
+  w1->set_name("w1");
+  w1->set_data_type(onnx::TensorProto::FLOAT);
+  w1->add_dims(2);
+  auto* w2 = model.mutable_graph()->add_initializer();
+  w2->set_name("w2");
+  w2->set_data_type(onnx::TensorProto::FLOAT);  // placeholder; never filled
+  w2->add_dims(32);
+
+  TensorPool pool;
+  std::vector<std::string> skipped;
+  size_t matched = ImportModelWithGGUF(model, path, pool, true, &skipped);
+  Check(matched == 1, "only w1 (the raw tensor) is matched");
+  Check(skipped.size() == 1 && skipped[0] == "w2",
+        "w2 is reported as skipped, so a caller can tell it's missing "
+        "weights rather than silently getting a half-loaded model");
+  Check(model.graph().initializer(0).has_raw_data(), "w1 was hydrated");
+  Check(!model.graph().initializer(1).has_raw_data(),
+        "w2 was left untouched -- definitely not filled with garbage bytes "
+        "reinterpreted from its quantized encoding");
+
+  std::remove(path.c_str());
+}
+
+}  // namespace
+
+int main() {
+  TestExportModelWithGGUF();
+  TestUnnamedAttributeTensor();
+  TestImportModelWithGGUFHydrateAll();
+  TestImportModelWithGGUFLazy();
+  TestImportModelWithGGUFSkipsQuantized();
+
+  if (g_failures == 0) {
+    std::printf("tensor_pool_gguf_bridge_test: all checks passed\n");
+    return 0;
+  }
+  std::fprintf(stderr, "tensor_pool_gguf_bridge_test: %d failure(s)\n",
+               g_failures);
+  return 1;
+}

--- a/onnxsim/tensor_pool_gguf_test.cpp
+++ b/onnxsim/tensor_pool_gguf_test.cpp
@@ -1,0 +1,294 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Standalone: g++ -std=c++20 tensor_pool_gguf_test.cpp tensor_pool.cpp \
+ *               tensor_pool_gguf.cpp -o t && ./t
+ *
+ * Dependency-free unit test for TensorPool's GGUF read/write
+ * (tensor_pool_gguf.cpp), mirroring tensor_pool_test.cpp's safetensors
+ * coverage plus GGUF-specific cases: ne[] dimension order, alignment
+ * padding, and skipping quantized/unsupported tensor types.
+ */
+#include <unistd.h>
+
+#include <algorithm>
+#include <bit>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <type_traits>
+
+#include "gguf_dtype.h"
+#include "tensor_pool.h"
+
+using namespace onnxsim::tensor_pool;
+using namespace onnxsim::tensor_pool::gguf;
+
+namespace {
+
+int g_failures = 0;
+
+void Check(bool cond, const std::string& what) {
+  if (!cond) {
+    std::fprintf(stderr, "FAIL: %s\n", what.c_str());
+    ++g_failures;
+  }
+}
+
+std::string TempPath(const std::string& suffix) {
+  return "/tmp/onnxsim_tensor_pool_gguf_test_" + std::to_string(::getpid()) +
+         suffix;
+}
+
+template <typename T>
+void WriteLE(std::ostream& out, T v) {
+  static_assert(std::is_trivially_copyable_v<T>);
+  unsigned char raw[sizeof(T)];
+  std::memcpy(raw, &v, sizeof(T));
+  if constexpr (std::endian::native == std::endian::big) {
+    std::reverse(std::begin(raw), std::end(raw));
+  }
+  out.write(reinterpret_cast<const char*>(raw), sizeof(T));
+}
+
+void TestRoundTrip() {
+  TensorPool pool;
+  // A non-square 2x3 tensor specifically to catch a dimension-order bug:
+  // ggml's ne[] is innermost-dimension-first, the reverse of onnx's
+  // outermost-first shape, and getting that backwards wouldn't corrupt the
+  // bytes (still contiguous) but would silently transpose the logical shape.
+  pool.Add("weight", ONNX_FLOAT, {2, 3}, std::string(24, '\x11'));
+  pool.Add("bias", ONNX_INT64, {4}, std::string(32, '\x22'));
+  pool.Add("scalar", ONNX_INT8, {}, std::string(1, '\x33'));
+
+  std::string path = TempPath("_roundtrip.gguf");
+  std::map<std::string, std::string> metadata = {
+      {"general.architecture", "onnxsim-test"}};
+  pool.SaveGGUF(path, metadata);
+
+  TensorPool loaded;
+  auto skipped = loaded.LoadGGUF(path);
+  Check(skipped.empty(), "nothing skipped for an all-raw-dtype pool");
+  Check(loaded.size() == 3, "all three tensors loaded");
+
+  const Entry* w = loaded.Find("weight");
+  Check(w != nullptr, "weight present");
+  if (w != nullptr) {
+    Check(w->dtype == ONNX_FLOAT, "weight dtype round-trips");
+    Check(w->shape == std::vector<int64_t>({2, 3}),
+          "weight shape round-trips in the RIGHT order (not transposed to "
+          "{3, 2})");
+    Check(w->data == std::string(24, '\x11'), "weight bytes round-trip");
+  }
+
+  const Entry* b = loaded.Find("bias");
+  Check(b != nullptr && b->dtype == ONNX_INT64 &&
+            b->shape == std::vector<int64_t>({4}) &&
+            b->data == std::string(32, '\x22'),
+        "bias round-trips");
+
+  const Entry* s = loaded.Find("scalar");
+  Check(s != nullptr && s->shape.empty() && s->data == std::string(1, '\x33'),
+        "rank-0 (scalar) tensor round-trips");
+
+  std::remove(path.c_str());
+}
+
+void TestEmptyMetadataOmitted() {
+  // No `string_metadata` argument at all -- must still produce a loadable
+  // file with metadata_kv_count == 0, not e.g. write a garbage/absent count.
+  TensorPool pool;
+  pool.Add("x", ONNX_FLOAT, {1}, std::string(4, '\0'));
+  std::string path = TempPath("_no_metadata.gguf");
+  pool.SaveGGUF(path);
+  TensorPool loaded;
+  Check(loaded.LoadGGUF(path).empty() && loaded.size() == 1,
+        "a file saved with no metadata still loads correctly");
+  std::remove(path.c_str());
+}
+
+void TestAlignmentPadding() {
+  // Two tensors whose sizes are not multiples of the default 32-byte
+  // alignment -- exercises the inter-tensor padding path, not just the
+  // header-to-data-section padding every other test already exercises.
+  TensorPool pool;
+  pool.Add("a", ONNX_INT8, {5}, std::string(5, 'a'));  // 5 bytes, not aligned
+  pool.Add("b", ONNX_INT8, {7}, std::string(7, 'b'));  // 7 bytes, not aligned
+  std::string path = TempPath("_align.gguf");
+  std::map<std::string, std::pair<uint64_t, uint64_t>> offsets;
+  uint64_t data_section_start = 0;
+  pool.SaveGGUF(path, {}, &offsets, &data_section_start);
+
+  Check(data_section_start % kDefaultAlignment == 0,
+        "data section starts aligned");
+  Check(offsets.at("a").first % kDefaultAlignment == 0,
+        "tensor 'a' starts aligned");
+  Check(offsets.at("b").first % kDefaultAlignment == 0,
+        "tensor 'b' starts aligned (after 'a's unaligned 5-byte length)");
+  Check(offsets.at("a").second - offsets.at("a").first == 5,
+        "'a' spans exactly its 5 bytes, not the alignment padding");
+
+  TensorPool loaded;
+  Check(loaded.LoadGGUF(path).empty(), "nothing skipped");
+  const Entry* a = loaded.Find("a");
+  const Entry* b = loaded.Find("b");
+  Check(a != nullptr && a->data == std::string(5, 'a'), "'a' round-trips");
+  Check(b != nullptr && b->data == std::string(7, 'b'), "'b' round-trips");
+  std::remove(path.c_str());
+}
+
+// Writes a minimal, hand-built GGUF v3 file with one raw F32 tensor and one
+// tensor of a made-up "quantized" ggml_type (id 2 == GGML_TYPE_Q4_0) this
+// pool cannot represent, to exercise LoadGGUF's skip-and-report path -- the
+// case that matters most in practice, since a real quantized LLM's .gguf is
+// mostly tensors like this.
+void TestSkipsUnsupportedDtype() {
+  std::string path = TempPath("_quantized.gguf");
+  {
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    auto write_string = [&](const std::string& s) {
+      WriteLE<uint64_t>(out, s.size());
+      out.write(s.data(), static_cast<std::streamsize>(s.size()));
+    };
+
+    WriteLE<uint32_t>(out, kMagic);
+    WriteLE<uint32_t>(out, kSupportedVersion);
+    WriteLE<uint64_t>(out, 2);  // tensor_count
+    WriteLE<uint64_t>(out, 0);  // metadata_kv_count
+
+    // Tensor 0: "raw", F32, ne=[2] (8 bytes), offset 0.
+    write_string("raw");
+    WriteLE<uint32_t>(out, 1);              // n_dimensions
+    WriteLE<uint64_t>(out, 2);              // ne[0]
+    WriteLE<uint32_t>(out, GGML_TYPE_F32);  // type
+    WriteLE<uint64_t>(out, 0);              // offset
+
+    // Tensor 1: "quant", ggml_type 2 (Q4_0), ne=[32] -- offset chosen past
+    // 'raw's aligned 32-byte slot. This test never decodes its bytes (can't
+    // -- that's the whole point), so the payload content doesn't matter.
+    write_string("quant");
+    WriteLE<uint32_t>(out, 1);                  // n_dimensions
+    WriteLE<uint64_t>(out, 32);                 // ne[0]
+    WriteLE<uint32_t>(out, 2);                  // GGML_TYPE_Q4_0
+    WriteLE<uint64_t>(out, kDefaultAlignment);  // offset (aligned)
+
+    // Pad to the data section (header ends right here; align up to 32).
+    uint64_t header_end = static_cast<uint64_t>(out.tellp());
+    uint64_t data_start = (header_end + kDefaultAlignment - 1) /
+                          kDefaultAlignment * kDefaultAlignment;
+    for (uint64_t i = header_end; i < data_start; ++i) out.put('\0');
+
+    // 'raw' tensor data: 2 x F32 = 8 bytes.
+    WriteLE<float>(out, 1.5f);
+    WriteLE<float>(out, -2.5f);
+    // Pad up to the 'quant' tensor's offset (kDefaultAlignment from
+    // data_start).
+    uint64_t cur = static_cast<uint64_t>(out.tellp()) - data_start;
+    for (uint64_t i = cur; i < kDefaultAlignment; ++i) out.put('\0');
+    // 'quant' tensor's Q4_0 block data: 18 bytes/block * 1 block for 32
+    // elements (block size 32) -- exact bytes don't matter, just presence.
+    for (int i = 0; i < 18; ++i) out.put('\xAB');
+  }
+
+  TensorPool pool;
+  auto skipped = pool.LoadGGUF(path);
+  Check(skipped.size() == 1 && skipped[0] == "quant",
+        "the quantized tensor is skipped and reported by name");
+  Check(pool.size() == 1, "only the raw tensor made it into the pool");
+  const Entry* raw = pool.Find("raw");
+  Check(raw != nullptr && raw->dtype == ONNX_FLOAT &&
+            raw->shape == std::vector<int64_t>({2}),
+        "the raw tensor itself loaded correctly despite its sibling being "
+        "skipped");
+  if (raw != nullptr) {
+    float v0, v1;
+    std::memcpy(&v0, raw->data.data(), 4);
+    std::memcpy(&v1, raw->data.data() + 4, 4);
+    if constexpr (std::endian::native == std::endian::big) {
+      auto swap4 = [](float f) {
+        unsigned char b[4];
+        std::memcpy(b, &f, 4);
+        std::reverse(std::begin(b), std::end(b));
+        std::memcpy(&f, b, 4);
+        return f;
+      };
+      v0 = swap4(v0);
+      v1 = swap4(v1);
+    }
+    Check(v0 == 1.5f && v1 == -2.5f, "the raw tensor's bytes are correct");
+  }
+  Check(pool.Find("quant") == nullptr,
+        "the skipped tensor is definitely not silently present with garbage "
+        "data");
+  std::remove(path.c_str());
+}
+
+void TestRejectsBadMagicAndVersion() {
+  {
+    std::string path = TempPath("_bad_magic.gguf");
+    std::ofstream out(path, std::ios::binary);
+    WriteLE<uint32_t>(out, 0xDEADBEEF);
+    WriteLE<uint32_t>(out, kSupportedVersion);
+    out.close();
+    TensorPool pool;
+    bool threw = false;
+    try {
+      pool.LoadGGUF(path);
+    } catch (const std::runtime_error&) {
+      threw = true;
+    }
+    Check(threw, "bad magic is rejected");
+    std::remove(path.c_str());
+  }
+  {
+    std::string path = TempPath("_bad_version.gguf");
+    std::ofstream out(path, std::ios::binary);
+    WriteLE<uint32_t>(out, kMagic);
+    WriteLE<uint32_t>(out, 1);  // unsupported version
+    out.close();
+    TensorPool pool;
+    bool threw = false;
+    try {
+      pool.LoadGGUF(path);
+    } catch (const std::runtime_error&) {
+      threw = true;
+    }
+    Check(threw, "unsupported version is rejected");
+    std::remove(path.c_str());
+  }
+}
+
+void TestRejectsUnrepresentableDtype() {
+  // TensorPool never actually holds a dtype gguf can't represent (see
+  // gguf_dtype.h), so this exercises SaveGGUF's defensive check via a
+  // dtype value that isn't a real OnnxDtype at all.
+  TensorPool pool;
+  pool.Add("bad", 8 /* ONNX STRING */, {1}, std::string("x"));
+  std::string path = TempPath("_bad_dtype.gguf");
+  bool threw = false;
+  try {
+    pool.SaveGGUF(path);
+  } catch (const std::runtime_error&) {
+    threw = true;
+  }
+  Check(threw, "saving a dtype with no raw ggml_type throws");
+}
+
+}  // namespace
+
+int main() {
+  TestRoundTrip();
+  TestEmptyMetadataOmitted();
+  TestAlignmentPadding();
+  TestSkipsUnsupportedDtype();
+  TestRejectsBadMagicAndVersion();
+  TestRejectsUnrepresentableDtype();
+
+  if (g_failures == 0) {
+    std::printf("tensor_pool_gguf_test: all checks passed\n");
+    return 0;
+  }
+  std::fprintf(stderr, "tensor_pool_gguf_test: %d failure(s)\n", g_failures);
+  return 1;
+}

--- a/onnxsim/tensor_pool_test.cpp
+++ b/onnxsim/tensor_pool_test.cpp
@@ -33,18 +33,17 @@ void Check(bool cond, const std::string& what) {
 }
 
 std::string TempPath(const std::string& suffix) {
-  return "/tmp/onnxsim_tensor_pool_test_" + std::to_string(::getpid()) +
-        suffix;
+  return "/tmp/onnxsim_tensor_pool_test_" + std::to_string(::getpid()) + suffix;
 }
 
 void TestRoundTrip() {
   TensorPool pool;
   pool.Add("weight.0", ONNX_FLOAT, {2, 3},
-          std::string("\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b"
+           std::string("\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b"
                        "\x0c\x0d\x0d\x0d\x0e\x0e\x0e\x0e\x0f\x0f\x0f\x0f",
                        24));
   pool.Add("bias", ONNX_INT64, {3},
-          std::string(24, '\x2a'));  // 3 int64 elements, arbitrary bytes
+           std::string(24, '\x2a'));  // 3 int64 elements, arbitrary bytes
   pool.Add("scalar", ONNX_BOOL, {}, std::string(1, '\x01'));
   pool.Add("empty", ONNX_FLOAT, {0}, std::string());
 
@@ -62,24 +61,23 @@ void TestRoundTrip() {
   if (w != nullptr) {
     Check(w->dtype == ONNX_FLOAT, "weight.0 dtype round-trips");
     Check(w->shape == std::vector<int64_t>({2, 3}),
-         "weight.0 shape round-trips");
+          "weight.0 shape round-trips");
     Check(w->nbytes() == 24, "weight.0 byte length round-trips");
-    Check(w->data ==
-             std::string_view(
-                 "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b"
-                 "\x0c\x0d\x0d\x0d\x0e\x0e\x0e\x0e\x0f\x0f\x0f\x0f",
-                 24),
-         "weight.0 bytes round-trip exactly");
+    Check(w->data == std::string_view(
+                         "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b"
+                         "\x0c\x0d\x0d\x0d\x0e\x0e\x0e\x0e\x0f\x0f\x0f\x0f",
+                         24),
+          "weight.0 bytes round-trip exactly");
   }
 
   const Entry* b = loaded.Find("bias");
   Check(b != nullptr && b->dtype == ONNX_INT64 &&
-           b->shape == std::vector<int64_t>({3}) && b->nbytes() == 24,
-       "bias round-trips");
+            b->shape == std::vector<int64_t>({3}) && b->nbytes() == 24,
+        "bias round-trips");
 
   const Entry* s = loaded.Find("scalar");
   Check(s != nullptr && s->shape.empty() && s->nbytes() == 1,
-       "scalar (rank-0) tensor round-trips");
+        "scalar (rank-0) tensor round-trips");
 
   const Entry* e = loaded.Find("empty");
   Check(e != nullptr && e->nbytes() == 0, "zero-size tensor round-trips");
@@ -111,16 +109,16 @@ void TestAliasingIsZeroCopyPerTensor() {
     // own base address for each entry, and both entries' owning control
     // block use_count should reflect a shared buffer.
     Check(static_cast<const void*>(ea->owner.get()) == ea->data.data(),
-         "a: owner aliases its own data pointer");
+          "a: owner aliases its own data pointer");
     Check(static_cast<const void*>(eb->owner.get()) == eb->data.data(),
-         "b: owner aliases its own data pointer");
+          "b: owner aliases its own data pointer");
     // The gap between the two views should exactly equal 'a's length,
     // confirming they were carved out of one contiguous buffer at the
     // offsets the header describes (rather than, say, two heap allocations
     // that happen to be adjacent by luck).
     Check(eb->data.data() - ea->data.data() ==
-             static_cast<ptrdiff_t>(ea->nbytes()),
-         "a and b are adjacent views into one contiguous buffer");
+              static_cast<ptrdiff_t>(ea->nbytes()),
+          "a and b are adjacent views into one contiguous buffer");
   }
   std::remove(path.c_str());
 }
@@ -137,7 +135,7 @@ void TestHeaderPrefixSize() {
   in.seekg(0, std::ios::end);
   uint64_t file_size = static_cast<uint64_t>(in.tellg());
   Check(prefix + offsets.at("x").second == file_size,
-       "HeaderPrefixSize + last tensor's end offset == file size");
+        "HeaderPrefixSize + last tensor's end offset == file size");
   std::remove(path.c_str());
 }
 
@@ -192,7 +190,7 @@ void TestSkipsMetadata() {
   Check(pool.size() == 1, "__metadata__ is skipped, not loaded as a tensor");
   Check(pool.Find("t") != nullptr, "the real tensor is still loaded");
   Check(pool.Find("__metadata__") == nullptr,
-       "__metadata__ itself is not exposed as an entry");
+        "__metadata__ itself is not exposed as an entry");
   std::remove(path.c_str());
 }
 

--- a/onnxsim/tensor_pool_test.cpp
+++ b/onnxsim/tensor_pool_test.cpp
@@ -1,0 +1,215 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Standalone: g++ -std=c++17 tensor_pool_test.cpp tensor_pool.cpp -o t && ./t
+ *
+ * Dependency-free unit test for TensorPool and its safetensors read/write
+ * (no ONNX / ONNX Runtime -- see tensor_pool.h's top comment). The
+ * onnx::TensorProto <-> TensorPool glue in tensor_pool_bridge.h is tested
+ * separately (tensor_pool_bridge_test.cpp), since that one does need onnx.
+ */
+#include "tensor_pool.h"
+
+#include <unistd.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+
+#include "tensor_pool_dtype.h"
+
+using namespace onnxsim::tensor_pool;
+
+namespace {
+
+int g_failures = 0;
+
+void Check(bool cond, const std::string& what) {
+  if (!cond) {
+    std::fprintf(stderr, "FAIL: %s\n", what.c_str());
+    ++g_failures;
+  }
+}
+
+std::string TempPath(const std::string& suffix) {
+  return "/tmp/onnxsim_tensor_pool_test_" + std::to_string(::getpid()) +
+        suffix;
+}
+
+void TestRoundTrip() {
+  TensorPool pool;
+  pool.Add("weight.0", ONNX_FLOAT, {2, 3},
+          std::string("\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b"
+                       "\x0c\x0d\x0d\x0d\x0e\x0e\x0e\x0e\x0f\x0f\x0f\x0f",
+                       24));
+  pool.Add("bias", ONNX_INT64, {3},
+          std::string(24, '\x2a'));  // 3 int64 elements, arbitrary bytes
+  pool.Add("scalar", ONNX_BOOL, {}, std::string(1, '\x01'));
+  pool.Add("empty", ONNX_FLOAT, {0}, std::string());
+
+  Check(pool.size() == 4, "pool holds 4 entries before save");
+
+  std::string path = TempPath("_roundtrip.safetensors");
+  pool.SaveSafetensors(path);
+
+  TensorPool loaded;
+  loaded.LoadSafetensors(path);
+  Check(loaded.size() == 4, "loaded pool holds 4 entries");
+
+  const Entry* w = loaded.Find("weight.0");
+  Check(w != nullptr, "weight.0 present after load");
+  if (w != nullptr) {
+    Check(w->dtype == ONNX_FLOAT, "weight.0 dtype round-trips");
+    Check(w->shape == std::vector<int64_t>({2, 3}),
+         "weight.0 shape round-trips");
+    Check(w->nbytes() == 24, "weight.0 byte length round-trips");
+    Check(w->data ==
+             std::string_view(
+                 "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b"
+                 "\x0c\x0d\x0d\x0d\x0e\x0e\x0e\x0e\x0f\x0f\x0f\x0f",
+                 24),
+         "weight.0 bytes round-trip exactly");
+  }
+
+  const Entry* b = loaded.Find("bias");
+  Check(b != nullptr && b->dtype == ONNX_INT64 &&
+           b->shape == std::vector<int64_t>({3}) && b->nbytes() == 24,
+       "bias round-trips");
+
+  const Entry* s = loaded.Find("scalar");
+  Check(s != nullptr && s->shape.empty() && s->nbytes() == 1,
+       "scalar (rank-0) tensor round-trips");
+
+  const Entry* e = loaded.Find("empty");
+  Check(e != nullptr && e->nbytes() == 0, "zero-size tensor round-trips");
+
+  Check(loaded.Find("nope") == nullptr, "missing name returns nullptr");
+
+  std::remove(path.c_str());
+}
+
+void TestAliasingIsZeroCopyPerTensor() {
+  // Every Entry loaded from one file shares the SAME underlying allocation
+  // (LoadSafetensors reads the file once, into one buffer) -- verify that
+  // property directly rather than just trusting the doc comment: two
+  // entries' data pointers must fall within one contiguous span whose size
+  // matches the file's data segment, not two independent allocations.
+  TensorPool pool;
+  pool.Add("a", ONNX_UINT8, {4}, std::string(4, 'a'));
+  pool.Add("b", ONNX_UINT8, {4}, std::string(4, 'b'));
+  std::string path = TempPath("_alias.safetensors");
+  pool.SaveSafetensors(path);
+
+  TensorPool loaded;
+  loaded.LoadSafetensors(path);
+  const Entry* ea = loaded.Find("a");
+  const Entry* eb = loaded.Find("b");
+  Check(ea != nullptr && eb != nullptr, "both tensors present");
+  if (ea != nullptr && eb != nullptr) {
+    // owner.get() (the aliasing shared_ptr's stored pointer) equals data's
+    // own base address for each entry, and both entries' owning control
+    // block use_count should reflect a shared buffer.
+    Check(static_cast<const void*>(ea->owner.get()) == ea->data.data(),
+         "a: owner aliases its own data pointer");
+    Check(static_cast<const void*>(eb->owner.get()) == eb->data.data(),
+         "b: owner aliases its own data pointer");
+    // The gap between the two views should exactly equal 'a's length,
+    // confirming they were carved out of one contiguous buffer at the
+    // offsets the header describes (rather than, say, two heap allocations
+    // that happen to be adjacent by luck).
+    Check(eb->data.data() - ea->data.data() ==
+             static_cast<ptrdiff_t>(ea->nbytes()),
+         "a and b are adjacent views into one contiguous buffer");
+  }
+  std::remove(path.c_str());
+}
+
+void TestHeaderPrefixSize() {
+  TensorPool pool;
+  pool.Add("x", ONNX_FLOAT, {1}, std::string(4, '\0'));
+  std::string path = TempPath("_prefix.safetensors");
+  std::map<std::string, std::pair<uint64_t, uint64_t>> offsets;
+  pool.SaveSafetensors(path, &offsets);
+
+  uint64_t prefix = HeaderPrefixSize(path);
+  std::ifstream in(path, std::ios::binary);
+  in.seekg(0, std::ios::end);
+  uint64_t file_size = static_cast<uint64_t>(in.tellg());
+  Check(prefix + offsets.at("x").second == file_size,
+       "HeaderPrefixSize + last tensor's end offset == file size");
+  std::remove(path.c_str());
+}
+
+void TestRejectsUnrepresentableDtype() {
+  TensorPool pool;
+  pool.Add("s", ONNX_STRING, {1}, std::string("x"));
+  std::string path = TempPath("_bad_dtype.safetensors");
+  bool threw = false;
+  try {
+    pool.SaveSafetensors(path);
+  } catch (const std::runtime_error&) {
+    threw = true;
+  }
+  Check(threw, "saving a STRING-dtype tensor throws");
+}
+
+void TestRejectsMalformedFile() {
+  std::string path = TempPath("_malformed.safetensors");
+  {
+    std::ofstream out(path, std::ios::binary);
+    out << "not a safetensors file";
+  }
+  TensorPool pool;
+  bool threw = false;
+  try {
+    pool.LoadSafetensors(path);
+  } catch (const std::runtime_error&) {
+    threw = true;
+  }
+  Check(threw, "loading a non-safetensors file throws");
+  std::remove(path.c_str());
+}
+
+void TestSkipsMetadata() {
+  // __metadata__ is a valid, common safetensors header entry (arbitrary
+  // string->string map, e.g. {"format": "pt"}) that this reader must skip
+  // rather than mistake for a tensor descriptor.
+  std::string path = TempPath("_metadata.safetensors");
+  std::string header =
+      R"({"__metadata__":{"format":"pt","note":"hello \"world\""},)"
+      R"("t":{"dtype":"F32","shape":[1],"data_offsets":[0,4]}})";
+  {
+    std::ofstream out(path, std::ios::binary);
+    uint64_t len = header.size();
+    out.write(reinterpret_cast<const char*>(&len), 8);
+    out.write(header.data(), static_cast<std::streamsize>(header.size()));
+    float v = 1.5f;
+    out.write(reinterpret_cast<const char*>(&v), 4);
+  }
+  TensorPool pool;
+  pool.LoadSafetensors(path);
+  Check(pool.size() == 1, "__metadata__ is skipped, not loaded as a tensor");
+  Check(pool.Find("t") != nullptr, "the real tensor is still loaded");
+  Check(pool.Find("__metadata__") == nullptr,
+       "__metadata__ itself is not exposed as an entry");
+  std::remove(path.c_str());
+}
+
+}  // namespace
+
+int main() {
+  TestRoundTrip();
+  TestAliasingIsZeroCopyPerTensor();
+  TestHeaderPrefixSize();
+  TestRejectsUnrepresentableDtype();
+  TestRejectsMalformedFile();
+  TestSkipsMetadata();
+
+  if (g_failures == 0) {
+    std::printf("tensor_pool_test: all checks passed\n");
+    return 0;
+  }
+  std::fprintf(stderr, "tensor_pool_test: %d failure(s)\n", g_failures);
+  return 1;
+}

--- a/onnxsim/tensor_pool_test.cpp
+++ b/onnxsim/tensor_pool_test.cpp
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Standalone: g++ -std=c++17 tensor_pool_test.cpp tensor_pool.cpp -o t && ./t
+ * Standalone: g++ -std=c++20 tensor_pool_test.cpp tensor_pool.cpp -o t && ./t
  *
  * Dependency-free unit test for TensorPool and its safetensors read/write
  * (no ONNX / ONNX Runtime -- see tensor_pool.h's top comment). The
@@ -12,10 +12,14 @@
 
 #include <unistd.h>
 
+#include <algorithm>
+#include <bit>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <fstream>
 #include <string>
+#include <type_traits>
 
 #include "tensor_pool_dtype.h"
 
@@ -169,6 +173,26 @@ void TestRejectsMalformedFile() {
   std::remove(path.c_str());
 }
 
+// Writes bytes explicitly little-endian, regardless of host byte order --
+// required here because this test hand-constructs a raw safetensors file
+// (rather than going through TensorPool::SaveSafetensors, which already
+// gets this right; see tensor_pool.h's "Byte order" note). A prior version
+// of this helper used reinterpret_cast<const char*> on a host uint64_t/
+// float directly, which happened to match the spec on a little-endian host
+// but produced a file with a garbage header length -- and, on the tensor
+// payload below, a garbage float -- on a big-endian one (caught by this
+// repo's s390x CI job).
+template <typename T>
+void WriteLE(std::ostream& out, T v) {
+  static_assert(std::is_trivially_copyable_v<T>);
+  unsigned char raw[sizeof(T)];
+  std::memcpy(raw, &v, sizeof(T));
+  if constexpr (std::endian::native == std::endian::big) {
+    std::reverse(std::begin(raw), std::end(raw));
+  }
+  out.write(reinterpret_cast<const char*>(raw), sizeof(T));
+}
+
 void TestSkipsMetadata() {
   // __metadata__ is a valid, common safetensors header entry (arbitrary
   // string->string map, e.g. {"format": "pt"}) that this reader must skip
@@ -179,11 +203,9 @@ void TestSkipsMetadata() {
       R"("t":{"dtype":"F32","shape":[1],"data_offsets":[0,4]}})";
   {
     std::ofstream out(path, std::ios::binary);
-    uint64_t len = header.size();
-    out.write(reinterpret_cast<const char*>(&len), 8);
+    WriteLE<uint64_t>(out, header.size());
     out.write(header.data(), static_cast<std::streamsize>(header.size()));
-    float v = 1.5f;
-    out.write(reinterpret_cast<const char*>(&v), 4);
+    WriteLE<float>(out, 1.5f);
   }
   TensorPool pool;
   pool.LoadSafetensors(path);

--- a/scripts/cross/build_s390x_extension.sh
+++ b/scripts/cross/build_s390x_extension.sh
@@ -201,18 +201,23 @@ cmake --build "${BUILD_DIR}" --target onnx_cpp2py_export -j "${JOBS}"
 # The dependency-free unit tests (ONNXSIM_TESTS=ON above). dlpack_dtype_test is
 # the one that covers the byte-order conversion directly; the rest come along
 # because they are cheap and exercise the same cross-built toolchain.
-# tensor_pool_dtype_test and tensor_pool_test are likewise dependency-free
-# (safetensors's own byte-order handling; see tensor_pool.h's "Byte order"
-# note) and belong in this list for the same reason.
+# tensor_pool_dtype_test/tensor_pool_test (safetensors) and
+# gguf_dtype_test/tensor_pool_gguf_test (GGUF) are likewise dependency-free
+# (each format's own byte-order handling; see tensor_pool.h's "Byte order"
+# note and tensor_pool_gguf.cpp's mirror of it) and belong in this list for
+# the same reason.
 cmake --build "${BUILD_DIR}" --target sym_expr_test model_metrics_test \
   sym_value_eval_test sym_shape_infer_test dlpack_dtype_test \
-  tensor_pool_dtype_test tensor_pool_test -j "${JOBS}"
-# tensor_pool_bridge_test is NOT dependency-free (it exercises the
-# onnx::TensorProto <-> TensorPool bridge), but the onnx/onnx-optimizer
-# static libraries it needs are already built as a side effect of the
-# onnxsim_cpp2py_export target above, so it costs only its own link step
-# here rather than a second onnx build.
-cmake --build "${BUILD_DIR}" --target tensor_pool_bridge_test -j "${JOBS}"
+  tensor_pool_dtype_test tensor_pool_test \
+  gguf_dtype_test tensor_pool_gguf_test -j "${JOBS}"
+# tensor_pool_bridge_test and tensor_pool_gguf_bridge_test are NOT
+# dependency-free (they exercise the onnx::TensorProto <-> TensorPool
+# bridges), but the onnx/onnx-optimizer static libraries they need are
+# already built as a side effect of the onnxsim_cpp2py_export target above,
+# so they cost only their own link step here rather than a second onnx
+# build.
+cmake --build "${BUILD_DIR}" --target tensor_pool_bridge_test \
+  tensor_pool_gguf_bridge_test -j "${JOBS}"
 
 SO="$(find "${BUILD_DIR}" -name 'onnxsim_cpp2py_export*.so' -print -quit)"
 [[ -n "${SO}" ]] || { echo "no extension module produced"; exit 1; }

--- a/scripts/cross/build_s390x_extension.sh
+++ b/scripts/cross/build_s390x_extension.sh
@@ -210,14 +210,14 @@ cmake --build "${BUILD_DIR}" --target sym_expr_test model_metrics_test \
   sym_value_eval_test sym_shape_infer_test dlpack_dtype_test \
   tensor_pool_dtype_test tensor_pool_test \
   gguf_dtype_test tensor_pool_gguf_test -j "${JOBS}"
-# tensor_pool_bridge_test and tensor_pool_gguf_bridge_test are NOT
-# dependency-free (they exercise the onnx::TensorProto <-> TensorPool
-# bridges), but the onnx/onnx-optimizer static libraries they need are
-# already built as a side effect of the onnxsim_cpp2py_export target above,
-# so they cost only their own link step here rather than a second onnx
-# build.
+# tensor_pool_bridge_test, tensor_pool_gguf_bridge_test, and
+# tensor_pool_archive_test are NOT dependency-free (they exercise the
+# onnx::TensorProto <-> TensorPool bridges), but the onnx/onnx-optimizer
+# static libraries they need are already built as a side effect of the
+# onnxsim_cpp2py_export target above, so they cost only their own link step
+# here rather than a second onnx build.
 cmake --build "${BUILD_DIR}" --target tensor_pool_bridge_test \
-  tensor_pool_gguf_bridge_test -j "${JOBS}"
+  tensor_pool_gguf_bridge_test tensor_pool_archive_test -j "${JOBS}"
 
 SO="$(find "${BUILD_DIR}" -name 'onnxsim_cpp2py_export*.so' -print -quit)"
 [[ -n "${SO}" ]] || { echo "no extension module produced"; exit 1; }

--- a/scripts/cross/build_s390x_extension.sh
+++ b/scripts/cross/build_s390x_extension.sh
@@ -201,8 +201,18 @@ cmake --build "${BUILD_DIR}" --target onnx_cpp2py_export -j "${JOBS}"
 # The dependency-free unit tests (ONNXSIM_TESTS=ON above). dlpack_dtype_test is
 # the one that covers the byte-order conversion directly; the rest come along
 # because they are cheap and exercise the same cross-built toolchain.
+# tensor_pool_dtype_test and tensor_pool_test are likewise dependency-free
+# (safetensors's own byte-order handling; see tensor_pool.h's "Byte order"
+# note) and belong in this list for the same reason.
 cmake --build "${BUILD_DIR}" --target sym_expr_test model_metrics_test \
-  sym_value_eval_test sym_shape_infer_test dlpack_dtype_test -j "${JOBS}"
+  sym_value_eval_test sym_shape_infer_test dlpack_dtype_test \
+  tensor_pool_dtype_test tensor_pool_test -j "${JOBS}"
+# tensor_pool_bridge_test is NOT dependency-free (it exercises the
+# onnx::TensorProto <-> TensorPool bridge), but the onnx/onnx-optimizer
+# static libraries it needs are already built as a side effect of the
+# onnxsim_cpp2py_export target above, so it costs only its own link step
+# here rather than a second onnx build.
+cmake --build "${BUILD_DIR}" --target tensor_pool_bridge_test -j "${JOBS}"
 
 SO="$(find "${BUILD_DIR}" -name 'onnxsim_cpp2py_export*.so' -print -quit)"
 [[ -n "${SO}" ]] || { echo "no extension module produced"; exit 1; }


### PR DESCRIPTION
## Summary

Introduces `TensorPool`, a new zero-copy tensor storage system backed by the HuggingFace safetensors file format. This enables efficient weight management by eliminating redundant copies during model loading/saving and provides interoperability with the ecosystem-standard safetensors format.

## Key Changes

- **New `tensor_pool.h/cpp`**: Core `TensorPool` class that stores named tensors with ref-counted, zero-copy views into shared buffers. Implements safetensors file format read/write with a minimal recursive-descent JSON parser for the header.

- **New `tensor_pool_dtype.h`**: Pure, dependency-free mapping between ONNX tensor element types (integer codes) and safetensors dtype strings. Supports BOOL, all signed/unsigned 8/16/32/64-bit ints, FLOAT16, BFLOAT16, FLOAT, and DOUBLE. Rejects STRING, COMPLEX, and UNDEFINED types.

- **New `tensor_pool_bridge.h/cpp`**: Bridges `onnx::TensorProto` ↔ `TensorPool` via:
  - `AdoptFromTensorProto()`: Moves tensor bytes from protobuf into the pool (no copy)
  - `HydrateTensorProto()`: Copies tensor bytes from pool back into protobuf
  - `ExportModelWithSafetensors()`: Exports a model's initializers to a safetensors file, marking them EXTERNAL with real file offsets
  - `ImportModelWithSafetensors()`: Loads a safetensors file into the pool and optionally hydrates initializers back to in-memory tensors

- **Comprehensive test coverage**:
  - `tensor_pool_dtype_test.cpp`: Standalone dtype mapping tests (no ONNX dependency)
  - `tensor_pool_test.cpp`: Standalone safetensors round-trip tests (no ONNX dependency)
  - `tensor_pool_bridge_test.cpp`: Integration tests with `onnx::TensorProto` and model export/import

- **CMakeLists.txt**: Updated to include new source files in the `onnxsim` library target

## Implementation Details

- **Zero-copy loading**: `LoadSafetensors()` reads the entire file into one buffer; all tensor entries alias views into this single allocation via `shared_ptr` aliasing constructor, eliminating per-tensor copies.

- **Safetensors format**: Implements the standard format (8-byte little-endian header length + JSON header + raw tensor bytes), compatible with the `safetensors` Python package and HuggingFace ecosystem tools.

- **Byte order handling**: Explicit little-endian handling for the file header prefix on all hosts (including big-endian); tensor data itself is always little-endian per ONNX spec.

- **JSON parser**: Minimal recursive-descent parser tailored to safetensors headers (not general-purpose), with proper error reporting and support for the optional `__metadata__` entry.

- **ONNX integration**: The bridge layer allows models to be exported with weights in a single canonical safetensors file while remaining valid ONNX external-data files (compatible with vanilla onnxruntime).

https://claude.ai/code/session_01BSAmR41tt5QeRwnmufFrwG