### PR TITLE
Make graph-native shape inference and optimization the default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Local profiling traces (ONNXSIM_PROFILE=1)
+onnxsim_profile.json
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -40,8 +40,12 @@
 #include "custom_optimizer_passes.h"
 #include "dlpack_bridge.h"
 #include "onnx/common/file_utils.h"
-#include "onnx/common/graph_shape_inference.h"
 #include "onnx/common/ir_pb_converter.h"
+#ifdef NO_BUILTIN_ORT
+// Only present in onnxsim's own onnx fork, not ONNX Runtime's bundled,
+// unpatched onnx copy -- see the NO_BUILTIN_ORT block below that uses it.
+#include "onnx/common/graph_shape_inference.h"
+#endif
 #include "onnx/defs/printer.h"
 #include "onnx/defs/schema.h"
 #include "onnx/inliner/inliner.h"

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -40,6 +40,8 @@
 #include "custom_optimizer_passes.h"
 #include "dlpack_bridge.h"
 #include "onnx/common/file_utils.h"
+#include "onnx/common/graph_shape_inference.h"
+#include "onnx/common/ir_pb_converter.h"
 #include "onnx/defs/printer.h"
 #include "onnx/defs/schema.h"
 #include "onnx/inliner/inliner.h"
@@ -2451,6 +2453,77 @@ onnx::ModelProto Simplify(
       "OptAndShape",
       FixedPointFn(Profiled("InferShapes", InferShapes),
                    Profiled("Optimize", OptimizeInPlace), fixed_point_iters));
+#endif
+#ifdef NO_BUILTIN_ORT
+  // Opt-in (env-gated; not yet the default) fully Graph-resident OptAndShape,
+  // built on onnx::InferShapesOnGraph (onnx/common/graph_shape_inference.h)
+  // and onnx-optimizer's OptimizeGraphFixed (onnxoptimizer/optimize.h): both
+  // now run directly against one onnx::Graph held for the whole inner fixed
+  // point, so -- unlike the ModelProto-based OptAndShape above, which still
+  // does one Import+Export per round even with #634's move-based fix -- this
+  // does exactly one Import and one Export for the *entire* fixed point,
+  // however many rounds it takes to converge. This is onnxsim issue #633's
+  // "remaining option 2" (eliminating the round trip itself, not just its
+  // per-round cost).
+  //
+  // Gated behind an env var rather than replacing the default while its
+  // coverage is still being validated against the existing test/regression
+  // suites:
+  //  - InferShapesOnGraph's own v1 scope leaves control-flow ops (If/Loop/
+  //    Scan) and function-body ops uninferred (safe: exactly as if they had
+  //    no registered schema, never wrong -- see that function's doc
+  //    comment), which can converge to less complete shape info than the
+  //    ModelProto path for models using those ops.
+  //  - EliminateZeroRnnInitialState (issue #314) is ModelProto-based and is
+  //    not run on this path, so that one dead-initial-state cleanup is
+  //    skipped for RNN models that would otherwise hit it -- a completeness
+  //    gap, not a correctness one.
+  if (std::getenv("ONNXSIM_GRAPH_NATIVE_SHAPE_INFERENCE")) {
+    OptAndShape = Profiled(
+        "OptAndShape",
+        [optimize, shape_inference, fixed_point_iters](onnx::ModelProto& model) {
+          std::shared_ptr<onnx::Graph> g(onnx::ImportModelProto(model));
+          if (g.get() == nullptr) {
+            // Same fallback as Optimizer::optimize(): if we can't parse the
+            // model, leave it untouched.
+            return;
+          }
+          using GraphFnChanged = std::function<bool(onnx::Graph&)>;
+          GraphFnChanged InferShapesOnGraphChanged =
+              shape_inference
+                  ? GraphFnChanged([](onnx::Graph& graph) {
+                      return onnx::InferShapesOnGraph(graph);
+                    })
+                  : GraphFnChanged([](onnx::Graph&) { return false; });
+          GraphFnChanged OptimizeGraphChanged = [](onnx::Graph& graph) {
+            onnxsim::RegisterCustomOptimizerPasses();
+            const bool prev = onnx::optimization::InitializersAsConstants();
+            onnx::optimization::SetInitializersAsConstants(
+                config.initializers_as_constants);
+            std::map<std::string, unsigned int> report;
+            onnx::optimization::OptimizeGraphFixed(
+                graph, config.optimizer_passes, &report);
+            onnx::optimization::SetInitializersAsConstants(prev);
+            for (const auto& pass_count : report) {
+              if (pass_count.second != 0) {
+                return true;
+              }
+            }
+            return false;
+          };
+          FixedPointFn(InferShapesOnGraphChanged, OptimizeGraphChanged,
+                       fixed_point_iters)(*g);
+          onnx::ModelProto out = onnx::PrepareOutput(model);
+          onnx::ExportModelProto(&out, g, /*consume_tensor_data=*/true);
+          // OptimizeGraphFixed never sees model-local functions (they live
+          // on ModelProto, not Graph), so carry them over unchanged --
+          // mirroring Optimizer::optimize()'s own AddFunctionsToModel.
+          for (const auto& function_proto : model.functions()) {
+            *out.add_functions() = function_proto;
+          }
+          model = std::move(out);
+        });
+  }
 #endif
   bool converged = false;
   ModelFn Pipeline;

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -2479,9 +2479,9 @@ onnx::ModelProto Simplify(
   //    skipped for RNN models that would otherwise hit it -- a completeness
   //    gap, not a correctness one.
   if (std::getenv("ONNXSIM_GRAPH_NATIVE_SHAPE_INFERENCE")) {
-    OptAndShape = Profiled(
-        "OptAndShape",
-        [optimize, shape_inference, fixed_point_iters](onnx::ModelProto& model) {
+    OptAndShape =
+        Profiled("OptAndShape", [optimize, shape_inference,
+                                 fixed_point_iters](onnx::ModelProto& model) {
           std::shared_ptr<onnx::Graph> g(onnx::ImportModelProto(model));
           if (g.get() == nullptr) {
             // Same fallback as Optimizer::optimize(): if we can't parse the

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -1521,15 +1521,15 @@ bool IsAllZeroTensor(const onnx::Tensor& tensor) {
     return std::all_of(field.begin(), field.end(),
                        [](auto value) { return value == 0; });
   };
-  const size_t element_count = tensor.floats().size() + tensor.int32s().size() +
-                               tensor.int64s().size() + tensor.doubles().size() +
-                               tensor.uint64s().size();
+  const size_t element_count =
+      tensor.floats().size() + tensor.int32s().size() + tensor.int64s().size() +
+      tensor.doubles().size() + tensor.uint64s().size();
   if (element_count == 0) {
     return false;
   }
   return all_zero(tensor.floats()) && all_zero(tensor.int32s()) &&
-        all_zero(tensor.int64s()) && all_zero(tensor.doubles()) &&
-        all_zero(tensor.uint64s());
+         all_zero(tensor.int64s()) && all_zero(tensor.doubles()) &&
+         all_zero(tensor.uint64s());
 }
 
 // Graph-native port of IsAllZeroValue above, walking onnx::Value/Node instead
@@ -1610,28 +1610,26 @@ bool IsAllZeroGraphValue(
                                             [](int64_t i) { return i == 0; });
     }
   } else if (kind == kConstantOfShape) {
-    result = !producer->hasAttribute(kValue) ||
-             IsAllZeroTensor(producer->t(kValue));
+    result =
+        !producer->hasAttribute(kValue) || IsAllZeroTensor(producer->t(kValue));
   } else if (kind == kCast || kind == kCastLike) {
     const bool to_string = producer->hasAttribute(kTo) &&
                            producer->i(kTo) == onnx::TensorProto::STRING;
     result = !to_string && IsAllZeroGraphValue(producer->inputs()[0],
                                                initializer_by_name, memo);
   } else if (kind == kIdentity || kind == kReshape || kind == kTranspose ||
-            kind == kSqueeze || kind == kUnsqueeze || kind == kFlatten ||
-            kind == kTile || kind == kExpand || kind == kSlice ||
-            kind == kSplit || kind == kGather || kind == kGatherElements ||
-            kind == kGatherND) {
-    result = IsAllZeroGraphValue(producer->inputs()[0], initializer_by_name,
-                                 memo);
+             kind == kSqueeze || kind == kUnsqueeze || kind == kFlatten ||
+             kind == kTile || kind == kExpand || kind == kSlice ||
+             kind == kSplit || kind == kGather || kind == kGatherElements ||
+             kind == kGatherND) {
+    result =
+        IsAllZeroGraphValue(producer->inputs()[0], initializer_by_name, memo);
   } else if (kind == kConcat) {
     const auto& inputs = producer->inputs();
     result = !inputs.empty() &&
-             std::all_of(inputs.begin(), inputs.end(),
-                        [&](onnx::Value* input) {
-                          return IsAllZeroGraphValue(input,
-                                                     initializer_by_name, memo);
-                        });
+             std::all_of(inputs.begin(), inputs.end(), [&](onnx::Value* input) {
+               return IsAllZeroGraphValue(input, initializer_by_name, memo);
+             });
   }
 
   memo[value] = result;
@@ -1697,8 +1695,8 @@ void EliminateZeroRnnInitialState(onnx::Graph& graph) {
     }
 
     const auto& inputs = node->inputs();
-    for (int i = 5; i <= last_state_index && i < static_cast<int>(inputs.size());
-        i++) {
+    for (int i = 5;
+         i <= last_state_index && i < static_cast<int>(inputs.size()); i++) {
       if (IsAllZeroGraphValue(inputs[i], initializer_by_name, memo)) {
         if (undefined == nullptr) {
           undefined = FindUndefinedGraphValue(graph);
@@ -1709,7 +1707,7 @@ void EliminateZeroRnnInitialState(onnx::Graph& graph) {
     // Trailing empty inputs carry no information; drop them so the node ends
     // up in the same shape a converter would have emitted without the state.
     while (!node->inputs().empty() &&
-          node->inputs().back()->node()->kind() == onnx::kUndefined) {
+           node->inputs().back()->node()->kind() == onnx::kUndefined) {
       node->removeInput(node->inputs().size() - 1);
     }
   }
@@ -2597,9 +2595,9 @@ onnx::ModelProto Simplify(
   // function's doc comment), which can converge to less complete shape info
   // than a from-scratch protobuf InferShapes call for models using those
   // ops.
-  ModelFn OptAndShape =
-      Profiled("OptAndShape", [optimize, shape_inference,
-                               fixed_point_iters](onnx::ModelProto& model) {
+  ModelFn OptAndShape = Profiled(
+      "OptAndShape",
+      [optimize, shape_inference, fixed_point_iters](onnx::ModelProto& model) {
         std::shared_ptr<onnx::Graph> g(onnx::ImportModelProto(model));
         if (g.get() == nullptr) {
           // Same fallback as Optimizer::optimize(): if we can't parse the
@@ -2630,8 +2628,8 @@ onnx::ModelProto Simplify(
           onnx::optimization::SetInitializersAsConstants(
               config.initializers_as_constants);
           std::map<std::string, unsigned int> report;
-          onnx::optimization::OptimizeGraphFixed(
-              graph, config.optimizer_passes, &report);
+          onnx::optimization::OptimizeGraphFixed(graph, config.optimizer_passes,
+                                                 &report);
           onnx::optimization::SetInitializersAsConstants(prev);
           for (const auto& pass_count : report) {
             if (pass_count.second != 0) {

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -2492,10 +2492,12 @@ onnx::ModelProto Simplify(
           GraphFnChanged InferShapesOnGraphChanged =
               shape_inference
                   ? GraphFnChanged([](onnx::Graph& graph) {
+                      onnxsim::ProfiledScope scope("InferShapes");
                       return onnx::InferShapesOnGraph(graph);
                     })
                   : GraphFnChanged([](onnx::Graph&) { return false; });
           GraphFnChanged OptimizeGraphChanged = [](onnx::Graph& graph) {
+            onnxsim::ProfiledScope scope("Optimize");
             onnxsim::RegisterCustomOptimizerPasses();
             const bool prev = onnx::optimization::InitializersAsConstants();
             onnx::optimization::SetInitializersAsConstants(

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -759,32 +759,6 @@ void _InferShapes(onnx::ModelProto& model) {
   onnx::shape_inference::InferShapes(model);
 }
 
-// Same as ``_InferShapes``, but also reports whether shape inference actually
-// inferred or updated any value's type/shape this call (``onnx::onnx``'s
-// InferShapes optionally counts this itself, so no extra pass over the model
-// is needed). Used by OptAndShape's fast-path fixed point below to tell
-// whether this round changed anything without hashing the whole model.
-//
-// Only available under NO_BUILTIN_ORT (the Python wheel build, where
-// third_party/onnx is guaranteed to be onnxsim's own patched onnx fork that
-// added the trailing ``num_inferred_values`` out-param). When
-// ONNXSIM_BUILTIN_ORT is ON instead (standalone C++/WASM/Rust builds), the
-// ``onnx`` CMake target comes from onnxruntime's own vendored, unpatched
-// onnx copy (see CMakeLists.txt), which does not have this parameter -- the
-// fast path below falls back to the original Fingerprint-based fixed point
-// there.
-#ifdef NO_BUILTIN_ORT
-void _InferShapes(onnx::ModelProto& model, bool* changed) {
-  size_t num_inferred_values = 0;
-  onnx::shape_inference::InferShapes(
-      model, onnx::OpSchemaRegistry::Instance(), onnx::ShapeInferenceOptions(),
-      /*generated_shape_data_by_name=*/nullptr, &num_inferred_values);
-  if (changed) {
-    *changed = num_inferred_values > 0;
-  }
-}
-#endif  // NO_BUILTIN_ORT
-
 // Build a lookup from tensor name to its type, gathering shapes from every
 // place a shape can be declared: value_info (populated by shape inference),
 // graph inputs and graph outputs. Pointers reference `model`, so the map must
@@ -1527,6 +1501,221 @@ void EliminateZeroRnnInitialState(onnx::ModelProto& model) {
   EliminateZeroRnnInitialState(*model.mutable_graph());
 }
 
+#ifdef NO_BUILTIN_ORT
+// Graph-native port of IsAllZeroTensor above, for onnx::Tensor (the C++ IR's
+// tensor type) instead of onnx::TensorProto. See that function's comment for
+// the zero-detection logic itself; this only translates the storage API.
+bool IsAllZeroTensor(const onnx::Tensor& tensor) {
+  if (tensor.data_location() == onnx::TensorProto_DataLocation_EXTERNAL) {
+    return false;
+  }
+  if (tensor.elem_type() == onnx::TensorProto::STRING ||
+      tensor.elem_type() == onnx::TensorProto::UNDEFINED) {
+    return false;
+  }
+  if (tensor.is_raw_data()) {
+    const std::string& raw = tensor.raw();
+    return std::all_of(raw.begin(), raw.end(), [](char c) { return c == 0; });
+  }
+  auto all_zero = [](const auto& field) {
+    return std::all_of(field.begin(), field.end(),
+                       [](auto value) { return value == 0; });
+  };
+  const size_t element_count = tensor.floats().size() + tensor.int32s().size() +
+                               tensor.int64s().size() + tensor.doubles().size() +
+                               tensor.uint64s().size();
+  if (element_count == 0) {
+    return false;
+  }
+  return all_zero(tensor.floats()) && all_zero(tensor.int32s()) &&
+        all_zero(tensor.int64s()) && all_zero(tensor.doubles()) &&
+        all_zero(tensor.uint64s());
+}
+
+// Graph-native port of IsAllZeroValue above, walking onnx::Value/Node instead
+// of TensorProto/NodeProto names. ``value``'s producer being the graph's
+// single kUndefined placeholder node (see ir_pb_converter.cc) is the IR's
+// direct equivalent of the ModelProto version's "name.empty()" check: both
+// mean "this optional input was not provided".
+bool IsAllZeroGraphValue(
+    onnx::Value* value,
+    const std::unordered_map<std::string, const onnx::Tensor*>&
+        initializer_by_name,
+    std::unordered_map<const onnx::Value*, bool>& memo) {
+  if (value->node()->kind() == onnx::kUndefined) {
+    return false;
+  }
+  auto memo_iter = memo.find(value);
+  if (memo_iter != memo.end()) {
+    return memo_iter->second;
+  }
+  // Insert a pessimistic answer up front: it both memoizes the miss and
+  // breaks any cycle a malformed graph might contain.
+  memo.emplace(value, false);
+
+  auto init_iter = initializer_by_name.find(value->uniqueName());
+  if (init_iter != initializer_by_name.end()) {
+    const bool result = IsAllZeroTensor(*init_iter->second);
+    memo[value] = result;
+    return result;
+  }
+
+  onnx::Node* producer = value->node();
+  if (producer->has_domain() && !producer->domain().empty() &&
+      producer->domain() != "ai.onnx") {
+    return false;
+  }
+
+  static const onnx::Symbol kConstant("Constant");
+  static const onnx::Symbol kConstantOfShape("ConstantOfShape");
+  static const onnx::Symbol kCast("Cast");
+  static const onnx::Symbol kCastLike("CastLike");
+  static const onnx::Symbol kIdentity("Identity");
+  static const onnx::Symbol kReshape("Reshape");
+  static const onnx::Symbol kTranspose("Transpose");
+  static const onnx::Symbol kSqueeze("Squeeze");
+  static const onnx::Symbol kUnsqueeze("Unsqueeze");
+  static const onnx::Symbol kFlatten("Flatten");
+  static const onnx::Symbol kTile("Tile");
+  static const onnx::Symbol kExpand("Expand");
+  static const onnx::Symbol kSlice("Slice");
+  static const onnx::Symbol kSplit("Split");
+  static const onnx::Symbol kGather("Gather");
+  static const onnx::Symbol kGatherElements("GatherElements");
+  static const onnx::Symbol kGatherND("GatherND");
+  static const onnx::Symbol kConcat("Concat");
+  static const onnx::Symbol kValue("value");
+  static const onnx::Symbol kValueFloat("value_float");
+  static const onnx::Symbol kValueInt("value_int");
+  static const onnx::Symbol kValueFloats("value_floats");
+  static const onnx::Symbol kValueInts("value_ints");
+  static const onnx::Symbol kTo("to");
+
+  bool result = false;
+  const onnx::Symbol kind = producer->kind();
+  if (kind == kConstant) {
+    if (producer->hasAttribute(kValue)) {
+      result = IsAllZeroTensor(producer->t(kValue));
+    } else if (producer->hasAttribute(kValueFloat)) {
+      result = producer->f(kValueFloat) == 0;
+    } else if (producer->hasAttribute(kValueInt)) {
+      result = producer->i(kValueInt) == 0;
+    } else if (producer->hasAttribute(kValueFloats)) {
+      const auto& floats = producer->fs(kValueFloats);
+      result = !floats.empty() && std::all_of(floats.begin(), floats.end(),
+                                              [](double f) { return f == 0; });
+    } else if (producer->hasAttribute(kValueInts)) {
+      const auto& ints = producer->is(kValueInts);
+      result = !ints.empty() && std::all_of(ints.begin(), ints.end(),
+                                            [](int64_t i) { return i == 0; });
+    }
+  } else if (kind == kConstantOfShape) {
+    result = !producer->hasAttribute(kValue) ||
+             IsAllZeroTensor(producer->t(kValue));
+  } else if (kind == kCast || kind == kCastLike) {
+    const bool to_string = producer->hasAttribute(kTo) &&
+                           producer->i(kTo) == onnx::TensorProto::STRING;
+    result = !to_string && IsAllZeroGraphValue(producer->inputs()[0],
+                                               initializer_by_name, memo);
+  } else if (kind == kIdentity || kind == kReshape || kind == kTranspose ||
+            kind == kSqueeze || kind == kUnsqueeze || kind == kFlatten ||
+            kind == kTile || kind == kExpand || kind == kSlice ||
+            kind == kSplit || kind == kGather || kind == kGatherElements ||
+            kind == kGatherND) {
+    result = IsAllZeroGraphValue(producer->inputs()[0], initializer_by_name,
+                                 memo);
+  } else if (kind == kConcat) {
+    const auto& inputs = producer->inputs();
+    result = !inputs.empty() &&
+             std::all_of(inputs.begin(), inputs.end(),
+                        [&](onnx::Value* input) {
+                          return IsAllZeroGraphValue(input,
+                                                     initializer_by_name, memo);
+                        });
+  }
+
+  memo[value] = result;
+  return result;
+}
+
+// The graph's single placeholder Value standing in for "this optional input
+// was not provided" (see ir_pb_converter.cc) -- every kUndefined-producer
+// input aliases this same Value. Only scanned when actually needed (an
+// all-zero RNN initial state was found), so the common case of a graph with
+// no LSTM/RNN/GRU nodes pays nothing for it.
+onnx::Value* FindUndefinedGraphValue(onnx::Graph& graph) {
+  for (onnx::Node* node : graph.nodes()) {
+    if (node->kind() == onnx::kUndefined) {
+      return node->outputs()[0];
+    }
+  }
+  return nullptr;
+}
+
+// Graph-native port of EliminateZeroRnnInitialState(GraphProto&) above; see
+// that function's comment for the full rationale (issue #314).
+void EliminateZeroRnnInitialState(onnx::Graph& graph) {
+  std::unordered_map<std::string, const onnx::Tensor*> initializer_by_name;
+  const auto& initializers = graph.initializers();
+  const auto& initializer_names = graph.initializer_names();
+  initializer_by_name.reserve(initializers.size());
+  for (size_t i = 0; i < initializers.size(); ++i) {
+    initializer_by_name[initializer_names[i]] = &initializers[i];
+  }
+  std::unordered_map<const onnx::Value*, bool> memo;
+  onnx::Value* undefined = nullptr;
+
+  static const onnx::Symbol kLSTM("LSTM");
+  static const onnx::Symbol kRNN("RNN");
+  static const onnx::Symbol kGRU("GRU");
+
+  for (onnx::Node* node : graph.nodes()) {
+    // Recurse first, so recurrent ops inside If/Loop/Scan bodies are handled
+    // too.
+    for (onnx::Symbol attr : node->attributeNames()) {
+      if (node->kindOf(attr) == onnx::AttributeKind::g) {
+        EliminateZeroRnnInitialState(*node->g(attr));
+      } else if (node->kindOf(attr) == onnx::AttributeKind::gs) {
+        for (const auto& subgraph : node->gs(attr)) {
+          EliminateZeroRnnInitialState(*subgraph);
+        }
+      }
+    }
+
+    if (node->has_domain() && !node->domain().empty() &&
+        node->domain() != "ai.onnx") {
+      continue;
+    }
+    const onnx::Symbol kind = node->kind();
+    int last_state_index;
+    if (kind == kLSTM) {
+      last_state_index = 6;
+    } else if (kind == kRNN || kind == kGRU) {
+      last_state_index = 5;
+    } else {
+      continue;
+    }
+
+    const auto& inputs = node->inputs();
+    for (int i = 5; i <= last_state_index && i < static_cast<int>(inputs.size());
+        i++) {
+      if (IsAllZeroGraphValue(inputs[i], initializer_by_name, memo)) {
+        if (undefined == nullptr) {
+          undefined = FindUndefinedGraphValue(graph);
+        }
+        node->replaceInput(i, undefined);
+      }
+    }
+    // Trailing empty inputs carry no information; drop them so the node ends
+    // up in the same shape a converter would have emitted without the state.
+    while (!node->inputs().empty() &&
+          node->inputs().back()->node()->kind() == onnx::kUndefined) {
+      node->removeInput(node->inputs().size() - 1);
+    }
+  }
+}
+#endif  // NO_BUILTIN_ORT
+
 // Estimate the number of bytes the outputs of `node` occupy once materialized,
 // using shapes gathered by shape inference (`vi_map` maps a tensor name to its
 // value_info). Outputs whose dtype or shape is not fully known contribute
@@ -1712,31 +1901,21 @@ onnx::ModelProto _FoldConstant(const ModelExecutor& executor,
   }
 }
 
-// ``changed``, if non-null, is set to whether onnx-optimizer's own internal
-// fixed point (``OptimizeFixed`` already runs every pass to convergence
-// itself) modified the graph at all this call: it sums the per-pass
-// transform counts from the optional report onnx-optimizer can produce. Every
-// pass reachable through onnxsim's default pass list (built from
-// ``GetFuseAndEliminationPass()``, see onnxsim/optimizer's transform_counts
-// reporting) is count-based, so this sum is an accurate "did anything
-// change" signal, not just a hint -- used by OptAndShape's fast-path fixed
-// point below to skip hashing the whole model when it is false.
-// ``model`` is ``onnx::ModelProto&`` (not const) under NO_BUILTIN_ORT: both
-// call sites below pass a mutable lvalue that is about to be move-assigned
-// over (``model = Optimize(model, ...)``), so its pre-call contents are dead
-// once this returns. That lets OptimizeFixed move each initializer's raw
-// bytes through the ModelProto<->Graph round trip instead of copying them --
-// the dominant cost of this call for weight-heavy models (onnxsim issue
-// #633) -- via the moving ImportModelProto/ExportModelProto overloads added
-// to onnxsim's onnx fork. Those overloads only exist on onnxsim's own fork,
-// not onnxruntime's bundled, unpatched onnx copy, so the non-NO_BUILTIN_ORT
-// build (standalone C++/WASM/Rust, which links ORT's onnx -- see the
-// InferShapes split above) keeps the original const-ref/copying signature.
+// ``model`` is ``onnx::ModelProto&`` (not const) under NO_BUILTIN_ORT: the
+// call site below passes a mutable lvalue that is about to be move-assigned
+// over (``model = Optimize(model)``), so its pre-call contents are dead once
+// this returns. That lets OptimizeFixed move each initializer's raw bytes
+// through the ModelProto<->Graph round trip instead of copying them -- the
+// dominant cost of this call for weight-heavy models (onnxsim issue #633) --
+// via the moving ImportModelProto/ExportModelProto overloads added to
+// onnxsim's onnx fork. Those overloads only exist on onnxsim's own fork, not
+// onnxruntime's bundled, unpatched onnx copy, so the non-NO_BUILTIN_ORT build
+// (standalone C++/WASM/Rust, which links ORT's onnx -- see the InferShapes
+// split above) keeps the original const-ref/copying signature.
 #ifdef NO_BUILTIN_ORT
-onnx::ModelProto Optimize(onnx::ModelProto& model, bool* changed = nullptr) {
+onnx::ModelProto Optimize(onnx::ModelProto& model) {
 #else
-onnx::ModelProto Optimize(const onnx::ModelProto& model,
-                          bool* changed = nullptr) {
+onnx::ModelProto Optimize(const onnx::ModelProto& model) {
 #endif
   // Make onnxsim's own optimizer passes available to onnxoptimizer's registry
   // (idempotent) so config.optimizer_passes may name them.
@@ -1747,19 +1926,9 @@ onnx::ModelProto Optimize(const onnx::ModelProto& model,
   const bool prev = onnx::optimization::InitializersAsConstants();
   onnx::optimization::SetInitializersAsConstants(
       config.initializers_as_constants);
-  std::map<std::string, unsigned int> report;
-  auto result = onnx::optimization::OptimizeFixed(
-      model, config.optimizer_passes, changed ? &report : nullptr);
+  auto result =
+      onnx::optimization::OptimizeFixed(model, config.optimizer_passes);
   onnx::optimization::SetInitializersAsConstants(prev);
-  if (changed) {
-    *changed = false;
-    for (const auto& pass_count : report) {
-      if (pass_count.second != 0) {
-        *changed = true;
-        break;
-      }
-    }
-  }
   return result;
 }
 
@@ -2336,42 +2505,12 @@ onnx::ModelProto Simplify(
   // which relies on dead-end elimination to clean up behind it -- runs with the
   // optimizer or not at all.
   const bool optimize = skip_optimizers.has_value();
-#ifdef NO_BUILTIN_ORT
-  // Bool-returning counterparts of InferShapes/Optimize, used to build
-  // OptAndShape's fast-path fixed point below (see the
-  // ``std::function<bool(T&)>`` overload of ``FixedPointFn``): each reports
-  // whether it actually changed the model, so that inner loop can skip
-  // Fingerprint hashing entirely. Only available under NO_BUILTIN_ORT; see
-  // ``_InferShapes(model, bool*)``'s comment for why.
-  using ModelFnChanged = std::function<bool(onnx::ModelProto&)>;
-  ModelFnChanged InferShapesReportingChange =
-      shape_inference ? ModelFnChanged([](onnx::ModelProto& model) {
-        bool changed = false;
-        _InferShapes(model, &changed);
-        return changed;
-      })
-                      : ModelFnChanged([](onnx::ModelProto&) { return false; });
-  // ``Optimize`` builds a fresh model (``OptimizeFixed`` returns a new proto),
-  // so wrap it as an in-place transform that move-assigns the result back.
-  ModelFnChanged OptimizeInPlaceReportingChange =
-      [optimize](onnx::ModelProto& model) {
-        if (optimize) {
-          // Unset all-zero recurrent initial states (issue #314) so the
-          // subgraph computing them becomes dead and the passes below can
-          // remove it. Not reflected in Optimize()'s own change signal, but
-          // that is safe: see FixedPointFn's bool-returning overload comment.
-          EliminateZeroRnnInitialState(model);
-        }
-        bool changed = false;
-        model = Optimize(model, &changed);
-        return changed;
-      };
-#else
+#ifndef NO_BUILTIN_ORT
   // ONNXSIM_BUILTIN_ORT builds (standalone C++/WASM/Rust) link onnxruntime's
   // own vendored, unpatched onnx copy rather than onnxsim's fork (see
-  // CMakeLists.txt), so the InferShapes change-count out-param used above is
-  // not available here. Fall back to the original Fingerprint-based fixed
-  // point for OptAndShape -- correct, just without the fast-path skip.
+  // CMakeLists.txt), so the Graph-native fixed point below (which needs
+  // onnxsim's own onnx/onnx-optimizer forks) is not available here. Fall
+  // back to the original ModelProto-based fixed point for OptAndShape.
   ModelFn InferShapes = shape_inference ? _InferShapes : Identity;
   ModelFn OptimizeInPlace = [optimize](onnx::ModelProto& model) {
     if (optimize) {
@@ -2435,101 +2574,84 @@ onnx::ModelProto Simplify(
       fn(model);
     };
   };
-#ifdef NO_BUILTIN_ORT
-  auto ProfiledChanged = [](const char* name,
-                            ModelFnChanged fn) -> ModelFnChanged {
-    if (!onnxsim::Profiler::Instance().enabled()) {
-      return fn;
-    }
-    return [name, fn = std::move(fn)](onnx::ModelProto& model) {
-      onnxsim::ProfiledScope scope(name);
-      return fn(model);
-    };
-  };
-
-  ModelFn OptAndShape = Profiled(
-      "OptAndShape",
-      FixedPointFn(ProfiledChanged("InferShapes", InferShapesReportingChange),
-                   ProfiledChanged("Optimize", OptimizeInPlaceReportingChange),
-                   fixed_point_iters));
-#else
+#ifndef NO_BUILTIN_ORT
   ModelFn OptAndShape = Profiled(
       "OptAndShape",
       FixedPointFn(Profiled("InferShapes", InferShapes),
                    Profiled("Optimize", OptimizeInPlace), fixed_point_iters));
-#endif
-#ifdef NO_BUILTIN_ORT
-  // Opt-in (env-gated; not yet the default) fully Graph-resident OptAndShape,
-  // built on onnx::InferShapesOnGraph (onnx/common/graph_shape_inference.h)
-  // and onnx-optimizer's OptimizeGraphFixed (onnxoptimizer/optimize.h): both
-  // now run directly against one onnx::Graph held for the whole inner fixed
-  // point, so -- unlike the ModelProto-based OptAndShape above, which still
-  // does one Import+Export per round even with #634's move-based fix -- this
-  // does exactly one Import and one Export for the *entire* fixed point,
-  // however many rounds it takes to converge. This is onnxsim issue #633's
-  // "remaining option 2" (eliminating the round trip itself, not just its
-  // per-round cost).
+#else
+  // Fully Graph-resident OptAndShape, built on onnx::InferShapesOnGraph
+  // (onnx/common/graph_shape_inference.h) and onnx-optimizer's
+  // OptimizeGraphFixed (onnxoptimizer/optimize.h): both run directly against
+  // one onnx::Graph held for the whole inner fixed point, so this does
+  // exactly one Import and one Export for the *entire* fixed point, however
+  // many rounds it takes to converge -- instead of one Import+Export per
+  // round. This is onnxsim issue #633's "remaining option 2" (eliminating
+  // the round trip itself, not just its per-round cost); see #637 and #638
+  // for the validation, profiling and follow-up fix that took this from
+  // opt-in to the default.
   //
-  // Gated behind an env var rather than replacing the default while its
-  // coverage is still being validated against the existing test/regression
-  // suites:
-  //  - InferShapesOnGraph's own v1 scope leaves control-flow ops (If/Loop/
-  //    Scan) and function-body ops uninferred (safe: exactly as if they had
-  //    no registered schema, never wrong -- see that function's doc
-  //    comment), which can converge to less complete shape info than the
-  //    ModelProto path for models using those ops.
-  //  - EliminateZeroRnnInitialState (issue #314) is ModelProto-based and is
-  //    not run on this path, so that one dead-initial-state cleanup is
-  //    skipped for RNN models that would otherwise hit it -- a completeness
-  //    gap, not a correctness one.
-  if (std::getenv("ONNXSIM_GRAPH_NATIVE_SHAPE_INFERENCE")) {
-    OptAndShape =
-        Profiled("OptAndShape", [optimize, shape_inference,
-                                 fixed_point_iters](onnx::ModelProto& model) {
-          std::shared_ptr<onnx::Graph> g(onnx::ImportModelProto(model));
-          if (g.get() == nullptr) {
-            // Same fallback as Optimizer::optimize(): if we can't parse the
-            // model, leave it untouched.
-            return;
+  // Remaining known scope gap: InferShapesOnGraph's own v1 scope leaves
+  // control-flow ops (If/Loop/Scan) and function-body ops uninferred (safe:
+  // exactly as if they had no registered schema, never wrong -- see that
+  // function's doc comment), which can converge to less complete shape info
+  // than a from-scratch protobuf InferShapes call for models using those
+  // ops.
+  ModelFn OptAndShape =
+      Profiled("OptAndShape", [optimize, shape_inference,
+                               fixed_point_iters](onnx::ModelProto& model) {
+        std::shared_ptr<onnx::Graph> g(onnx::ImportModelProto(model));
+        if (g.get() == nullptr) {
+          // Same fallback as Optimizer::optimize(): if we can't parse the
+          // model, leave it untouched.
+          return;
+        }
+        using GraphFnChanged = std::function<bool(onnx::Graph&)>;
+        GraphFnChanged InferShapesOnGraphChanged =
+            shape_inference
+                ? GraphFnChanged([](onnx::Graph& graph) {
+                    onnxsim::ProfiledScope scope("InferShapes");
+                    return onnx::InferShapesOnGraph(graph);
+                  })
+                : GraphFnChanged([](onnx::Graph&) { return false; });
+        GraphFnChanged OptimizeGraphChanged = [optimize](onnx::Graph& graph) {
+          onnxsim::ProfiledScope scope("Optimize");
+          onnxsim::RegisterCustomOptimizerPasses();
+          if (optimize) {
+            // Unset all-zero recurrent initial states (issue #314) so the
+            // subgraph computing them becomes dead and the passes below can
+            // remove it. Not reflected in the "changed" signal below, but
+            // that is safe: see FixedPointFn's bool-returning overload
+            // comment -- any resulting dead-end elimination is itself
+            // reflected in the report.
+            EliminateZeroRnnInitialState(graph);
           }
-          using GraphFnChanged = std::function<bool(onnx::Graph&)>;
-          GraphFnChanged InferShapesOnGraphChanged =
-              shape_inference
-                  ? GraphFnChanged([](onnx::Graph& graph) {
-                      onnxsim::ProfiledScope scope("InferShapes");
-                      return onnx::InferShapesOnGraph(graph);
-                    })
-                  : GraphFnChanged([](onnx::Graph&) { return false; });
-          GraphFnChanged OptimizeGraphChanged = [](onnx::Graph& graph) {
-            onnxsim::ProfiledScope scope("Optimize");
-            onnxsim::RegisterCustomOptimizerPasses();
-            const bool prev = onnx::optimization::InitializersAsConstants();
-            onnx::optimization::SetInitializersAsConstants(
-                config.initializers_as_constants);
-            std::map<std::string, unsigned int> report;
-            onnx::optimization::OptimizeGraphFixed(
-                graph, config.optimizer_passes, &report);
-            onnx::optimization::SetInitializersAsConstants(prev);
-            for (const auto& pass_count : report) {
-              if (pass_count.second != 0) {
-                return true;
-              }
+          const bool prev = onnx::optimization::InitializersAsConstants();
+          onnx::optimization::SetInitializersAsConstants(
+              config.initializers_as_constants);
+          std::map<std::string, unsigned int> report;
+          onnx::optimization::OptimizeGraphFixed(
+              graph, config.optimizer_passes, &report);
+          onnx::optimization::SetInitializersAsConstants(prev);
+          for (const auto& pass_count : report) {
+            if (pass_count.second != 0) {
+              return true;
             }
-            return false;
-          };
-          FixedPointFn(InferShapesOnGraphChanged, OptimizeGraphChanged,
-                       fixed_point_iters)(*g);
-          onnx::ModelProto out = onnx::PrepareOutput(model);
-          onnx::ExportModelProto(&out, g, /*consume_tensor_data=*/true);
-          // OptimizeGraphFixed never sees model-local functions (they live
-          // on ModelProto, not Graph), so carry them over unchanged --
-          // mirroring Optimizer::optimize()'s own AddFunctionsToModel.
-          for (const auto& function_proto : model.functions()) {
-            *out.add_functions() = function_proto;
           }
-          model = std::move(out);
-        });
-  }
+          return false;
+        };
+        FixedPointFn(InferShapesOnGraphChanged, OptimizeGraphChanged,
+                     fixed_point_iters)(*g);
+        onnx::ModelProto out = onnx::PrepareOutput(model);
+        onnx::ExportModelProto(&out, g, /*consume_tensor_data=*/true);
+        // OptimizeGraphFixed never sees model-local functions (they live
+        // on ModelProto, not Graph), so carry them over unchanged --
+        // mirroring Optimizer::optimize()'s own AddFunctionsToModel.
+        for (const auto& function_proto : model.functions()) {
+          *out.add_functions() = function_proto;
+        }
+        model = std::move(out);
+      });
 #endif
   bool converged = false;
   ModelFn Pipeline;


### PR DESCRIPTION
## Summary

Adds `onnx::InferShapesOnGraph` (in the onnx fork), which runs ONNX type-and-shape inference directly against the C++ IR (`ir.h`'s `Graph`), reusing every op's existing schema-registered inference function unmodified via `shape_inference::InferenceContextImpl` — no op's inference formula is reimplemented, only the driving loop (walk the graph, build each node's `InferenceContext`, merge results back with onnx's own `mergeShapesAndTypes`) is new.

This wires it, plus #635's `OptimizeGraphFixed`, into a fully Graph-resident `OptAndShape`: Import once, alternate `InferShapesOnGraph`/`OptimizeGraphFixed` directly on that one `Graph` for as many rounds as convergence takes, Export once — instead of one Import+Export per round. **This is now the default** for the Python wheel build (`NO_BUILTIN_ORT`); the `ONNXSIM_GRAPH_NATIVE_SHAPE_INFERENCE` env-var gate and the old ModelProto-based fast path it used to select between have been removed.

## History (this PR went through three real bug fixes to get here)

1. **Initial finding**: `mixer_l16` looked like a regression (354.5s vs 285.5s baseline), hypothesized to be `Graph::isNameUnique()`'s O(n) scan. Disproven by profiling — under 1% of total time everywhere.
2. **Real bottleneck**: onnx-optimizer's `eliminate_duplicate_initializer` re-hashing every initializer's full bytes every round — ~98% of pass time. Fixed in [onnxsim/optimizer#8](https://github.com/onnxsim/optimizer/pull/8) / [onnxsim/onnxsim#638](https://github.com/onnxsim/onnxsim/pull/638) (merged). With that fix: default 268.7s → 111.0s, graph-native 342.6s → 85.1s — graph-native now ~23% faster than default.
3. **Making it the default** surfaced three more real bugs, found via onnxsim's own existing test suite (three torchvision detection models — Faster/Mask/Keypoint R-CNN — which use `If` for NMS):
   - `InferShapesOnGraph` skipped If/Loop/Scan subgraphs entirely (documented v1 gap) → now extended to infer through them, by exporting the subgraph attribute to a real `GraphProto` and delegating to onnx's own existing `GraphInferencerImpl`/`InferShapesImpl` recursion.
   - No `SymbolTable` was threaded through, so unknown dimensions never got stable names — two independently-unknown dims were indistinguishable, which downstream merges and ONNX Runtime's own reference inference do *not* treat as equivalent. Added a Graph-IR-native `SymbolTable`.
   - `Value::copyMetadata` (core `ir.h`, pre-existing, not introduced by this PR) unconditionally copied `sizes()` even when the source had no known rank, silently corrupting "unknown rank" into "rank 0" — exposed by graph-native making "unknown rank" a much more common intermediate state. Fixed to match the conditional-copy pattern already used by the rest of that function.
   - Also ported `EliminateZeroRnnInitialState` (issue #314) to operate on `Graph` directly, so the default flip doesn't regress LSTM/RNN/GRU zero-initial-state handling.

## Validated

- Correctness: identical output to the previous default on hand-built models and real models (`cait_xxs36_224`, `mixer_l16_224_in21k`).
- Full onnxsim Python test suite (`test_simple.py`, `test_backend.py`, `test_model_checking.py`, `test_constant_fold_determinism.py`, `test_moved_optimizer_passes.py`, `test_python_api.py` minus the >2GB memory-bound test): all green, 0 regressions — including the three previously-failing R-CNN tests, and the RNN zero-initial-state regression tests (`test_eliminate_zero_lstm_initial_state`, `test_eliminate_zero_gru_initial_state_from_constant_of_shape`, `test_keep_nonzero_lstm_initial_state`).
- `InferShapesOnGraph` itself is consistently negligible (well under 1% of total time) in every measurement.
- `mixer_l16_224_in21k`: ~85s end-to-end, matching the best opt-in measurement (no regression from the If/Loop/Scan or SymbolTable additions on a model that doesn't use them).

### CI and model-regression sweeps (post-review, all green on `1f9dfea`)

- All 33 PR CI checks passing, including sanitizers, coverage, and cross-platform wheel builds (Linux/macOS/Windows, incl. s390x big-endian).
- `tvm-integration`, `halide-integration`, and `modelopt-integration` workflows (auto-triggered by the `onnxsim.cpp` change): all green.
- Manually dispatched the model-regression suites that only run on push/schedule (not gated to this PR by path filters), against this branch: **YOLO** (yolo26n detect/seg, yolo12n detect, yolo11n-pose), **RF-DETR** (ViT backbone + deformable-attention decoder + DETR heads), and **VOICEVOX** (the real downloaded-model suite whose own docstring notes it previously caught two real onnxsim bugs) — all passed.
- Manually dispatched the full `model-regression.yml` sweep (90 real models from the onnxmodelzoo set, weekly/on-demand only): **90/90 passed**, 0 blocking failures. Also compared against onnxslim on the same set (non-gating): onnxsim was strictly more robust (90/90 ok vs. onnxslim's 84/90, with 2 onnxslim crashes and 4 unvalidated outputs that onnxsim handled cleanly), simplified slightly more aggressively (21.4% vs 20.0% median node reduction), and was markedly faster with lower peak memory (median 1.9s/1312 MiB vs onnxslim's 3.8s/1471 MiB).

## Remaining known scope gap

Function-body inference (`schema->HasFunction()`, ops defined as an onnx function rather than a native op) is still not implemented — same *safe* fallback as any unrecognized op (outputs left as-is, never wrong).

https://claude.ai/code/session_01KeyLVmckEg2EdgUqCn9Cnv