### PR TITLE
Fix onnx-optimizer's eliminate_duplicate_initializer being ~98% of simplify() time on large models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Local profiling traces (ONNXSIM_PROFILE=1)
+onnxsim_profile.json
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
## Summary

Bumps `third_party/onnx-optimizer` to pick up [onnxsim/optimizer#8](https://github.com/onnxsim/optimizer/pull/8), which fixes a major performance bug found while investigating #633.

## Background

While digging into #633 (onnxsim vs onnxslim speed gap), earlier work in this area suspected `Graph::isNameUnique()`'s O(n) linear scan as the culprit for a graph-native-optimize regression. Fresh profiling disproved that hypothesis outright — `isNameUnique`/`getNextUnique` account for under 1% of total time in every scenario measured.

Per-pass instrumentation of `Optimizer::optimize()` on `mixer_l16_224_in21k` (582 nodes, ~300MB of `raw_data` initializers, 53 outer fixed-point rounds) found the real cost: **`eliminate_duplicate_initializer` alone accounts for ~98% of all optimizer pass time** (up to 302s of 306s). It content-hashes every initializer from scratch on every round via `CSETensorHash`, and for `raw_data`-backed tensors that hash goes through `ParseTensorData<T>`, which makes two full copies of the tensor's bytes (one to un-const the string, one to convert to a typed vector) plus an element-by-element hash loop — repeated on the *same, largely-unchanged* initializer set, every round.

This is a pre-existing issue in onnx-optimizer's default pass list, not something introduced by onnxsim. It affects **every** `onnxsim.simplify()` call on models with sizeable `raw_data` initializers and multiple fixed-point rounds — not just any opt-in feature.

## Fix

See [onnxsim/optimizer#8](https://github.com/onnxsim/optimizer/pull/8) for the actual fix: a fast path in `CSETensorHash`/`CSETensorEqual` that hashes/compares `raw_data`-backed tensors' raw bytes directly (a zero-copy view via `Tensor::raw()`) instead of going through `ParseTensorData`. Safe because ONNX's `raw_data` is always little-endian on disk regardless of host byte order, so byte-identical `raw_data` always implies value-identical data — this can never produce a false-positive merge. See that PR's description for the full correctness argument and the (rare, non-correctness-affecting) edge case it accepts.

## Testing

- Hand-built model with two byte-identical raw-data initializers: still correctly merged to one, output verified bit-identical via onnxruntime.
- Full onnxsim Python test suite (`test_simple.py`, `test_backend.py`, `test_model_checking.py`, `test_constant_fold_determinism.py`, `test_moved_optimizer_passes.py`): 51 passed, 2 failed on an unrelated missing optional dependency (`onnxscript`), 0 regressions.
- `mixer_l16_224_in21k` end-to-end, before/after, on both the default (ModelProto) and opt-in graph-native optimize paths (see #637):
  - Default path: 268.7s → 111.0s (~2.4x)
  - Graph-native path: 342.6s → 85.1s (~4.0x)
  - Output node count identical (582) in every configuration — no change in simplification result, only speed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KeyLVmckEg2EdgUqCn9Cnv)_