### PR TITLE
Add safetensors and GGUF export formats to web converter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 build/
-build-wasm-*/
+build-*/
 develop-eggs/
 dist/
 downloads/

--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ constant folding until the model stops changing. Around that it offers:
 - **[Custom rewriters](#custom-rewriters).** Plug your own rewriting logic into
   the fixed point with `custom_rewriter`, or express data-only `FunctionProto`
   rules that also run from the C and Rust bindings.
+- **[Safetensors / GGUF archives](#safetensors--gguf-archives).** Export a model
+  to a standalone `.safetensors` or `.gguf` file (graph + weights in one
+  ecosystem-standard archive) and import it back, from every binding.
 - **Subgraph simplification.** Simplify `If`/`Loop`/`Scan` subgraph bodies too
   with `--include-subgraph`.
 - **Large-model handling.** Guard against blow-up from ops like `Tile`/
@@ -663,6 +666,61 @@ bodies, handle variadic/optional-input arity mismatches, match >2-operand
 commutative permutations, or evaluate attribute *predicates* — for those, the
 Python-only `onnxscript.rewriter` via `custom_rewriter` remains the richer
 option.
+
+## Safetensors / GGUF archives
+
+Besides plain `.onnx`, a model can be exported to (and imported back from) a
+**standalone safetensors or GGUF archive**: every initializer's bytes move into
+the archive with real, byte-accurate offsets — openable by the `safetensors`
+Python package / HF tooling, or any GGUF reader, with no onnxsim involved — and
+the graph itself is embedded alongside them, so the one archive file is both
+the model's weights and its graph. This is useful for interop with the
+safetensors/GGUF ecosystems, or simply as a one-file way to move a model
+around; it does not itself simplify anything, so pair it with `simplify()` if
+you want both.
+
+From Python:
+
+```python
+import onnx
+import onnxsim
+
+model = onnx.load("model.onnx")
+onnxsim.export_safetensors(model, "model.onnx.safetensors")
+onnxsim.export_gguf(model, "model.onnx.gguf")
+
+# ... later, or in another process:
+model = onnxsim.import_safetensors("model.onnx.safetensors")
+model = onnxsim.import_gguf("model.onnx.gguf")
+```
+
+From Rust:
+
+```rust
+let model_bytes = std::fs::read("model.onnx")?;
+onnxsim::export_safetensors(&model_bytes, "model.onnx.safetensors")?;
+onnxsim::export_gguf(&model_bytes, "model.onnx.gguf")?;
+
+let model_bytes = onnxsim::import_safetensors("model.onnx.safetensors")?;
+let model_bytes = onnxsim::import_gguf("model.onnx.gguf")?;
+```
+
+From C, `onnxsim_export_safetensors`/`onnxsim_import_safetensors` and their
+`_gguf` counterparts follow the same `out_data`/`out_size`/`out_error`
+convention as `onnxsim_simplify` (see
+[`onnxsim/capi/onnxsim_c_api.h`](onnxsim/capi/onnxsim_c_api.h)); the export
+side takes the model as bytes and writes straight to a path, the import side
+reads a path and hands back a freshly allocated buffer of model bytes.
+
+The [web version](#web-version) exposes the same thing as UI: a format
+dropdown (`.onnx` / `.onnx.safetensors` / `.onnx.gguf`) next to the converter's
+**Download** button, and the file picker accepts either archive format as an
+upload, decoding it back to ONNX before simplifying.
+
+Importing an archive with no embedded model — e.g. a plain, weights-only
+safetensors/GGUF file from somewhere else, with no onnxsim-authored graph
+alongside the tensors — fails with a clear error rather than silently
+returning nothing: there is no graph in it to import.
 
 ## Projects Using ONNX Simplifier
 

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -1,5 +1,22 @@
-from onnxsim.onnx_simplifier import import_onnx_schemas, main, simplify
+from onnxsim.onnx_simplifier import (
+    export_gguf,
+    export_safetensors,
+    import_gguf,
+    import_onnx_schemas,
+    import_safetensors,
+    main,
+    simplify,
+)
 
 from .version import version as __version__
 
-__all__ = ["simplify", "main", "import_onnx_schemas", "__version__"]
+__all__ = [
+    "simplify",
+    "main",
+    "import_onnx_schemas",
+    "export_safetensors",
+    "import_safetensors",
+    "export_gguf",
+    "import_gguf",
+    "__version__",
+]

--- a/onnxsim/capi/onnxsim_c_api.cpp
+++ b/onnxsim/capi/onnxsim_c_api.cpp
@@ -19,6 +19,9 @@
 #include "onnx/proto_utils.h"
 #include "onnxoptimizer/optimize.h"
 #include "onnxsim.h"
+#include "tensor_pool.h"
+#include "tensor_pool_bridge.h"
+#include "tensor_pool_gguf_bridge.h"
 
 #ifdef NO_BUILTIN_ORT
 #error \
@@ -43,6 +46,23 @@ void SetError(char** out_error, const std::string& message) {
   if (out_error != nullptr) {
     *out_error = DupCString(message);
   }
+}
+
+// Copy `s` into a freshly malloc'd buffer for an out_data/out_size pair
+// (release with onnxsim_free_buffer), same allocation convention
+// SimplifyToBuffer below uses: malloc(0) may return nullptr, so a 0-byte
+// input still gets a distinct non-null pointer, guaranteeing out_data != NULL
+// on success. Returns false (and leaves *out_data/*out_size untouched) on
+// allocation failure.
+bool CopyToBuffer(const std::string& s, void** out_data, size_t* out_size) {
+  void* buffer = std::malloc(s.size() != 0 ? s.size() : 1);
+  if (buffer == nullptr) {
+    return false;
+  }
+  std::memcpy(buffer, s.data(), s.size());
+  *out_data = buffer;
+  *out_size = s.size();
+  return true;
 }
 
 // Translate the (pointer array, is_null) FFI encoding into the optional vector
@@ -511,6 +531,155 @@ OnnxsimStatus onnxsim_graph_diff(const void* original_data,
     return ONNXSIM_ERROR;
   } catch (...) {
     SetError(out_error, "unknown error while computing the graph diff");
+    return ONNXSIM_ERROR;
+  }
+}
+
+OnnxsimStatus onnxsim_export_safetensors(const void* model_data,
+                                         size_t model_size,
+                                         const char* out_path,
+                                         char** out_error) {
+  if (out_error != nullptr) {
+    *out_error = nullptr;
+  }
+  if (model_data == nullptr || out_path == nullptr) {
+    SetError(out_error,
+             "onnxsim_export_safetensors: required argument is NULL");
+    return ONNXSIM_ERROR;
+  }
+  try {
+    onnx::ModelProto model;
+    if (!ParseProtoFromBytes(&model, static_cast<const char*>(model_data),
+                             model_size)) {
+      SetError(out_error, "failed to parse ONNX ModelProto from input bytes");
+      return ONNXSIM_ERROR;
+    }
+    onnxsim::tensor_pool::TensorPool pool;
+    onnxsim::tensor_pool::SaveModelAsSafetensorsStandalone(model, out_path,
+                                                           pool);
+    return ONNXSIM_OK;
+  } catch (const std::exception& e) {
+    SetError(out_error, e.what());
+    return ONNXSIM_ERROR;
+  } catch (...) {
+    SetError(out_error, "unknown error while exporting the safetensors file");
+    return ONNXSIM_ERROR;
+  }
+}
+
+OnnxsimStatus onnxsim_import_safetensors(const char* in_path, void** out_data,
+                                         size_t* out_size, char** out_error) {
+  if (out_data != nullptr) {
+    *out_data = nullptr;
+  }
+  if (out_size != nullptr) {
+    *out_size = 0;
+  }
+  if (out_error != nullptr) {
+    *out_error = nullptr;
+  }
+  if (in_path == nullptr) {
+    SetError(out_error, "onnxsim_import_safetensors: in_path is NULL");
+    return ONNXSIM_ERROR;
+  }
+  try {
+    onnx::ModelProto model;
+    onnxsim::tensor_pool::TensorPool pool;
+    if (!onnxsim::tensor_pool::LoadModelFromSafetensors(in_path, &model,
+                                                        pool)) {
+      SetError(out_error,
+               "safetensors file has no embedded onnxsim model (a plain "
+               "weights-only archive is not importable as a graph)");
+      return ONNXSIM_ERROR;
+    }
+    std::string out;
+    if (!model.SerializeToString(&out)) {
+      SetError(out_error, "failed to serialize the imported ModelProto");
+      return ONNXSIM_ERROR;
+    }
+    if (out_data != nullptr && out_size != nullptr &&
+        !CopyToBuffer(out, out_data, out_size)) {
+      SetError(out_error, "out of memory while copying the imported model");
+      return ONNXSIM_ERROR;
+    }
+    return ONNXSIM_OK;
+  } catch (const std::exception& e) {
+    SetError(out_error, e.what());
+    return ONNXSIM_ERROR;
+  } catch (...) {
+    SetError(out_error, "unknown error while importing the safetensors file");
+    return ONNXSIM_ERROR;
+  }
+}
+
+OnnxsimStatus onnxsim_export_gguf(const void* model_data, size_t model_size,
+                                  const char* out_path, char** out_error) {
+  if (out_error != nullptr) {
+    *out_error = nullptr;
+  }
+  if (model_data == nullptr || out_path == nullptr) {
+    SetError(out_error, "onnxsim_export_gguf: required argument is NULL");
+    return ONNXSIM_ERROR;
+  }
+  try {
+    onnx::ModelProto model;
+    if (!ParseProtoFromBytes(&model, static_cast<const char*>(model_data),
+                             model_size)) {
+      SetError(out_error, "failed to parse ONNX ModelProto from input bytes");
+      return ONNXSIM_ERROR;
+    }
+    onnxsim::tensor_pool::TensorPool pool;
+    onnxsim::tensor_pool::SaveModelAsGGUFStandalone(model, out_path, pool);
+    return ONNXSIM_OK;
+  } catch (const std::exception& e) {
+    SetError(out_error, e.what());
+    return ONNXSIM_ERROR;
+  } catch (...) {
+    SetError(out_error, "unknown error while exporting the gguf file");
+    return ONNXSIM_ERROR;
+  }
+}
+
+OnnxsimStatus onnxsim_import_gguf(const char* in_path, void** out_data,
+                                  size_t* out_size, char** out_error) {
+  if (out_data != nullptr) {
+    *out_data = nullptr;
+  }
+  if (out_size != nullptr) {
+    *out_size = 0;
+  }
+  if (out_error != nullptr) {
+    *out_error = nullptr;
+  }
+  if (in_path == nullptr) {
+    SetError(out_error, "onnxsim_import_gguf: in_path is NULL");
+    return ONNXSIM_ERROR;
+  }
+  try {
+    onnx::ModelProto model;
+    onnxsim::tensor_pool::TensorPool pool;
+    if (!onnxsim::tensor_pool::LoadModelFromGGUF(in_path, &model, pool)) {
+      SetError(out_error,
+               "gguf file has no embedded onnxsim model (a plain "
+               "weights-only archive is not importable as a graph)");
+      return ONNXSIM_ERROR;
+    }
+    std::string out;
+    if (!model.SerializeToString(&out)) {
+      SetError(out_error, "failed to serialize the imported ModelProto");
+      return ONNXSIM_ERROR;
+    }
+    if (out_data != nullptr && out_size != nullptr &&
+        !CopyToBuffer(out, out_data, out_size)) {
+      SetError(out_error, "out of memory while copying the imported model");
+      return ONNXSIM_ERROR;
+    }
+    return ONNXSIM_OK;
+  } catch (const std::exception& e) {
+    SetError(out_error, e.what());
+    return ONNXSIM_ERROR;
+  } catch (...) {
+    SetError(out_error, "unknown error while importing the gguf file");
     return ONNXSIM_ERROR;
   }
 }

--- a/onnxsim/capi/onnxsim_c_api.h
+++ b/onnxsim/capi/onnxsim_c_api.h
@@ -262,6 +262,67 @@ ONNXSIM_C_API OnnxsimStatus onnxsim_graph_diff(const void* original_data,
                                                char** out_text,
                                                char** out_error);
 
+/*
+ * Export a model (given as a serialized ONNX ModelProto) to a standalone
+ * safetensors archive at `out_path`: every initializer's bytes move into the
+ * archive with real, byte-accurate offsets -- openable by the `safetensors`
+ * Python package / HF tooling with no onnxsim involved -- and the graph
+ * itself is embedded alongside them, so `out_path` alone is both the
+ * model's weights and its graph (see onnxsim/tensor_pool_bridge.h's
+ * SaveModelAsSafetensorsStandalone). Reload it with
+ * onnxsim_import_safetensors.
+ *
+ * On ONNXSIM_ERROR, *out_error receives a newly allocated message; release it
+ * with onnxsim_free_string. out_error may be NULL.
+ */
+ONNXSIM_C_API OnnxsimStatus onnxsim_export_safetensors(const void* model_data,
+                                                       size_t model_size,
+                                                       const char* out_path,
+                                                       char** out_error);
+
+/*
+ * Import a standalone safetensors archive at `in_path` (as produced by
+ * onnxsim_export_safetensors, or any other tool following the same
+ * self-describing-archive convention -- an embedded "model.onnx" entry
+ * alongside the tensors) back into an ordinary, fully in-memory ONNX
+ * ModelProto.
+ *
+ * On ONNXSIM_OK, *out_data/*out_size receive a newly allocated buffer holding
+ * the serialized ModelProto; release it with onnxsim_free_buffer. Fails with
+ * ONNXSIM_ERROR (and a message in *out_error, release with
+ * onnxsim_free_string) if the archive has no embedded onnxsim model -- e.g. a
+ * plain weights-only safetensors file with no graph to import -- or on any
+ * other read/parse failure. Either out_* pointer may be NULL if the caller
+ * does not want that value.
+ */
+ONNXSIM_C_API OnnxsimStatus onnxsim_import_safetensors(const char* in_path,
+                                                       void** out_data,
+                                                       size_t* out_size,
+                                                       char** out_error);
+
+/*
+ * GGUF counterpart of onnxsim_export_safetensors; see onnxsim/
+ * tensor_pool_gguf_bridge.h's SaveModelAsGGUFStandalone. Same contract.
+ */
+ONNXSIM_C_API OnnxsimStatus onnxsim_export_gguf(const void* model_data,
+                                                size_t model_size,
+                                                const char* out_path,
+                                                char** out_error);
+
+/*
+ * GGUF counterpart of onnxsim_import_safetensors; see onnxsim/
+ * tensor_pool_gguf_bridge.h's LoadModelFromGGUF. Same contract -- including
+ * failing with ONNXSIM_ERROR when the archive has no embedded model. Any
+ * OTHER pooled tensor LoadModelFromGGUF could not hydrate (e.g. a quantized
+ * weight) is silently left un-hydrated in the returned model rather than
+ * surfaced through this narrow C ABI; use the C++/Python/Rust bindings
+ * directly for that detail if it matters to the caller.
+ */
+ONNXSIM_C_API OnnxsimStatus onnxsim_import_gguf(const char* in_path,
+                                                void** out_data,
+                                                size_t* out_size,
+                                                char** out_error);
+
 /* Free a buffer returned via an out_data parameter. NULL is ignored. */
 ONNXSIM_C_API void onnxsim_free_buffer(void* data);
 

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -550,7 +550,7 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
         ParseProtoFromBytes(&model, model_bytes.c_str(), model_bytes.size());
         onnxsim::tensor_pool::TensorPool pool;
         onnxsim::tensor_pool::SaveModelAsSafetensorsStandalone(model, out_path,
-                                                                pool);
+                                                               pool);
       },
       "model_bytes"_a, "out_path"_a);
 
@@ -560,7 +560,7 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
         onnx::ModelProto model;
         onnxsim::tensor_pool::TensorPool pool;
         if (!onnxsim::tensor_pool::LoadModelFromSafetensors(in_path, &model,
-                                                             pool)) {
+                                                            pool)) {
           throw std::runtime_error(
               "safetensors file has no embedded onnxsim model (a plain "
               "weights-only archive is not importable as a graph)");

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -25,6 +25,9 @@
 #include "onnx/proto_utils.h"
 #include "onnxoptimizer/optimize.h"
 #include "onnxsim.h"
+#include "tensor_pool.h"
+#include "tensor_pool_bridge.h"
+#include "tensor_pool_gguf_bridge.h"
 
 namespace py = nanobind;
 using namespace nanobind::literals;
@@ -533,4 +536,62 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
         return onnxsim::MakeFunctionProtoRewriter(std::move(converted));
       },
       "rules"_a);
+
+  // Standalone safetensors/GGUF archive export/import: a model's graph and
+  // weights packaged together in one ecosystem-standard file (see
+  // onnxsim/tensor_pool_bridge.h and tensor_pool_gguf_bridge.h's *Standalone
+  // functions for the real-offset design). Exchanged as bytes for the model
+  // (like ``simplify``) and a real path for the archive itself, since the
+  // archive is inherently file-based.
+  m.def(
+      "export_safetensors",
+      [](const py::bytes& model_bytes, const std::string& out_path) {
+        onnx::ModelProto model;
+        ParseProtoFromBytes(&model, model_bytes.c_str(), model_bytes.size());
+        onnxsim::tensor_pool::TensorPool pool;
+        onnxsim::tensor_pool::SaveModelAsSafetensorsStandalone(model, out_path,
+                                                                pool);
+      },
+      "model_bytes"_a, "out_path"_a);
+
+  m.def(
+      "import_safetensors",
+      [](const std::string& in_path) -> py::bytes {
+        onnx::ModelProto model;
+        onnxsim::tensor_pool::TensorPool pool;
+        if (!onnxsim::tensor_pool::LoadModelFromSafetensors(in_path, &model,
+                                                             pool)) {
+          throw std::runtime_error(
+              "safetensors file has no embedded onnxsim model (a plain "
+              "weights-only archive is not importable as a graph)");
+        }
+        const std::string out = model.SerializeAsString();
+        return py::bytes(out.data(), out.size());
+      },
+      "in_path"_a);
+
+  m.def(
+      "export_gguf",
+      [](const py::bytes& model_bytes, const std::string& out_path) {
+        onnx::ModelProto model;
+        ParseProtoFromBytes(&model, model_bytes.c_str(), model_bytes.size());
+        onnxsim::tensor_pool::TensorPool pool;
+        onnxsim::tensor_pool::SaveModelAsGGUFStandalone(model, out_path, pool);
+      },
+      "model_bytes"_a, "out_path"_a);
+
+  m.def(
+      "import_gguf",
+      [](const std::string& in_path) -> py::bytes {
+        onnx::ModelProto model;
+        onnxsim::tensor_pool::TensorPool pool;
+        if (!onnxsim::tensor_pool::LoadModelFromGGUF(in_path, &model, pool)) {
+          throw std::runtime_error(
+              "gguf file has no embedded onnxsim model (a plain weights-only "
+              "archive is not importable as a graph)");
+        }
+        const std::string out = model.SerializeAsString();
+        return py::bytes(out.data(), out.size());
+      },
+      "in_path"_a);
 }

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -328,6 +328,44 @@ def import_onnx_schemas() -> int:
     return imported
 
 
+def export_safetensors(model: onnx.ModelProto, out_path: str) -> None:
+    """Export ``model`` to a standalone safetensors archive at ``out_path``.
+
+    Every initializer's bytes move into the archive with real, byte-accurate
+    offsets -- openable by the ``safetensors`` Python package / HF tooling with
+    no onnxsim involved -- and the graph itself is embedded alongside them, so
+    ``out_path`` alone is both the model's weights and its graph. Reload it
+    with :func:`import_safetensors`.
+    """
+    C.export_safetensors(model.SerializeToString(), out_path)
+
+
+def import_safetensors(in_path: str) -> onnx.ModelProto:
+    """Import a standalone safetensors archive back into an ``onnx.ModelProto``.
+
+    ``in_path`` must be an archive produced by :func:`export_safetensors` (or
+    any other tool following the same self-describing-archive convention: an
+    embedded ``model.onnx`` entry alongside the tensors). Raises
+    ``RuntimeError`` if the archive has no embedded onnxsim model, e.g. a
+    plain weights-only safetensors file with no graph to import.
+    """
+    model = onnx.ModelProto()
+    model.ParseFromString(C.import_safetensors(in_path))
+    return model
+
+
+def export_gguf(model: onnx.ModelProto, out_path: str) -> None:
+    """GGUF counterpart of :func:`export_safetensors`."""
+    C.export_gguf(model.SerializeToString(), out_path)
+
+
+def import_gguf(in_path: str) -> onnx.ModelProto:
+    """GGUF counterpart of :func:`import_safetensors`."""
+    model = onnx.ModelProto()
+    model.ParseFromString(C.import_gguf(in_path))
+    return model
+
+
 def _snapshot_doc_strings(model: onnx.ModelProto) -> dict:
     """Capture the ``doc_string`` fields that the C++ optimizer discards."""
     return {

--- a/rust/README.md
+++ b/rust/README.md
@@ -95,6 +95,22 @@ fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
 }
 ```
 
+Export a model to a standalone safetensors or GGUF archive (graph + weights in
+one ecosystem-standard file) and import it back:
+
+```rust
+fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
+    let model = std::fs::read("model.onnx")?;
+    onnxsim::export_safetensors(&model, "model.onnx.safetensors")?;
+    onnxsim::export_gguf(&model, "model.onnx.gguf")?;
+
+    let model = onnxsim::import_safetensors("model.onnx.safetensors")?;
+    let model = onnxsim::import_gguf("model.onnx.gguf")?;
+    let _ = model;
+    Ok(())
+}
+```
+
 ## Custom rewriter
 
 Run your own graph-rewriting logic inside the simplification fixed point — the

--- a/rust/onnxsim-sys/src/lib.rs
+++ b/rust/onnxsim-sys/src/lib.rs
@@ -367,6 +367,69 @@ extern "C" {
         out_error: *mut *mut c_char,
     ) -> c_int;
 
+    /// Export a serialized ONNX `ModelProto` to a standalone safetensors
+    /// archive at `out_path`: every initializer's bytes move into the archive
+    /// with real, byte-accurate offsets (openable by the `safetensors` Python
+    /// package / HF tooling with no onnxsim involved), and the graph itself is
+    /// embedded alongside them, so `out_path` alone is both the model's
+    /// weights and its graph. Reload it with [`onnxsim_import_safetensors`].
+    /// On `ONNXSIM_ERROR`, `out_error` owns a message to free with
+    /// [`onnxsim_free_string`].
+    ///
+    /// # Safety
+    /// `model_data` must point to at least `model_size` bytes; `out_path` must
+    /// be a valid NUL-terminated path; `out_error`, if non-null, receives an
+    /// owned string that must be freed exactly once.
+    pub fn onnxsim_export_safetensors(
+        model_data: *const c_void,
+        model_size: usize,
+        out_path: *const c_char,
+        out_error: *mut *mut c_char,
+    ) -> c_int;
+
+    /// Import a standalone safetensors archive at `in_path` (as produced by
+    /// [`onnxsim_export_safetensors`], or any other tool following the same
+    /// self-describing-archive convention) back into an ordinary, fully
+    /// in-memory ONNX `ModelProto`. On `ONNXSIM_OK`, `out_data`/`out_size` own
+    /// a buffer to free with [`onnxsim_free_buffer`]. Fails with
+    /// `ONNXSIM_ERROR` if the archive has no embedded onnxsim model (e.g. a
+    /// plain weights-only safetensors file with no graph to import).
+    ///
+    /// # Safety
+    /// `in_path` must be a valid NUL-terminated path; `out_data`/`out_size`/
+    /// `out_error`, if non-null, receive owned values that must be freed
+    /// exactly once.
+    pub fn onnxsim_import_safetensors(
+        in_path: *const c_char,
+        out_data: *mut *mut c_void,
+        out_size: *mut usize,
+        out_error: *mut *mut c_char,
+    ) -> c_int;
+
+    /// GGUF counterpart of [`onnxsim_export_safetensors`]. Same contract.
+    ///
+    /// # Safety
+    /// Same as [`onnxsim_export_safetensors`].
+    pub fn onnxsim_export_gguf(
+        model_data: *const c_void,
+        model_size: usize,
+        out_path: *const c_char,
+        out_error: *mut *mut c_char,
+    ) -> c_int;
+
+    /// GGUF counterpart of [`onnxsim_import_safetensors`]. Same contract,
+    /// including failing with `ONNXSIM_ERROR` when the archive has no
+    /// embedded model.
+    ///
+    /// # Safety
+    /// Same as [`onnxsim_import_safetensors`].
+    pub fn onnxsim_import_gguf(
+        in_path: *const c_char,
+        out_data: *mut *mut c_void,
+        out_size: *mut usize,
+        out_error: *mut *mut c_char,
+    ) -> c_int;
+
     /// Free a buffer produced by an `out_data` parameter. Null is ignored.
     ///
     /// # Safety

--- a/rust/onnxsim/src/lib.rs
+++ b/rust/onnxsim/src/lib.rs
@@ -734,6 +734,138 @@ pub fn graph_diff(original: &[u8], simplified: &[u8]) -> Result<String, Error> {
     }
 }
 
+/// Export a serialized ONNX `ModelProto` to a standalone safetensors archive
+/// at `out_path`.
+///
+/// Every initializer's bytes move into the archive with real, byte-accurate
+/// offsets — openable by the `safetensors` Python package / HF tooling with
+/// no onnxsim involved — and the graph itself is embedded alongside them, so
+/// `out_path` alone is both the model's weights and its graph. Reload it with
+/// [`import_safetensors`].
+///
+/// ```no_run
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let model = std::fs::read("model.onnx")?;
+/// onnxsim::export_safetensors(&model, "model.onnx.safetensors")?;
+/// # Ok(())
+/// # }
+/// ```
+pub fn export_safetensors<P: AsRef<Path>>(model_bytes: &[u8], out_path: P) -> Result<(), Error> {
+    let out_c = path_to_cstring(out_path.as_ref())?;
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let status = unsafe {
+        onnxsim_sys::onnxsim_export_safetensors(
+            model_bytes.as_ptr() as *const c_void,
+            model_bytes.len(),
+            out_c.as_ptr(),
+            &mut out_error,
+        )
+    };
+    if status == onnxsim_sys::ONNXSIM_OK {
+        Ok(())
+    } else {
+        Err(take_error(out_error))
+    }
+}
+
+/// Import a standalone safetensors archive at `in_path` back into a
+/// serialized ONNX `ModelProto`.
+///
+/// `in_path` must be an archive produced by [`export_safetensors`] (or any
+/// other tool following the same self-describing-archive convention: an
+/// embedded `model.onnx` entry alongside the tensors). Fails if the archive
+/// has no embedded onnxsim model, e.g. a plain weights-only safetensors file
+/// with no graph to import.
+///
+/// ```no_run
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let model_bytes = onnxsim::import_safetensors("model.onnx.safetensors")?;
+/// std::fs::write("model.onnx", &model_bytes)?;
+/// # Ok(())
+/// # }
+/// ```
+pub fn import_safetensors<P: AsRef<Path>>(in_path: P) -> Result<Vec<u8>, Error> {
+    let in_c = path_to_cstring(in_path.as_ref())?;
+    let mut out_data: *mut c_void = ptr::null_mut();
+    let mut out_size: usize = 0;
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let status = unsafe {
+        onnxsim_sys::onnxsim_import_safetensors(
+            in_c.as_ptr(),
+            &mut out_data,
+            &mut out_size,
+            &mut out_error,
+        )
+    };
+    if status == onnxsim_sys::ONNXSIM_OK {
+        let result =
+            unsafe { std::slice::from_raw_parts(out_data as *const u8, out_size) }.to_vec();
+        unsafe { onnxsim_sys::onnxsim_free_buffer(out_data) };
+        Ok(result)
+    } else {
+        Err(take_error(out_error))
+    }
+}
+
+/// GGUF counterpart of [`export_safetensors`].
+///
+/// ```no_run
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let model = std::fs::read("model.onnx")?;
+/// onnxsim::export_gguf(&model, "model.onnx.gguf")?;
+/// # Ok(())
+/// # }
+/// ```
+pub fn export_gguf<P: AsRef<Path>>(model_bytes: &[u8], out_path: P) -> Result<(), Error> {
+    let out_c = path_to_cstring(out_path.as_ref())?;
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let status = unsafe {
+        onnxsim_sys::onnxsim_export_gguf(
+            model_bytes.as_ptr() as *const c_void,
+            model_bytes.len(),
+            out_c.as_ptr(),
+            &mut out_error,
+        )
+    };
+    if status == onnxsim_sys::ONNXSIM_OK {
+        Ok(())
+    } else {
+        Err(take_error(out_error))
+    }
+}
+
+/// GGUF counterpart of [`import_safetensors`].
+///
+/// ```no_run
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let model_bytes = onnxsim::import_gguf("model.onnx.gguf")?;
+/// std::fs::write("model.onnx", &model_bytes)?;
+/// # Ok(())
+/// # }
+/// ```
+pub fn import_gguf<P: AsRef<Path>>(in_path: P) -> Result<Vec<u8>, Error> {
+    let in_c = path_to_cstring(in_path.as_ref())?;
+    let mut out_data: *mut c_void = ptr::null_mut();
+    let mut out_size: usize = 0;
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let status = unsafe {
+        onnxsim_sys::onnxsim_import_gguf(
+            in_c.as_ptr(),
+            &mut out_data,
+            &mut out_size,
+            &mut out_error,
+        )
+    };
+    if status == onnxsim_sys::ONNXSIM_OK {
+        let result =
+            unsafe { std::slice::from_raw_parts(out_data as *const u8, out_size) }.to_vec();
+        unsafe { onnxsim_sys::onnxsim_free_buffer(out_data) };
+        Ok(result)
+    } else {
+        Err(take_error(out_error))
+    }
+}
+
 /// Owns the `CString`s and pointer array backing the `skip_optimizers` FFI
 /// arguments, keeping them alive for the duration of a call.
 struct FfiSkipOptimizers {

--- a/scripts/convertmodel/converter_main.js
+++ b/scripts/convertmodel/converter_main.js
@@ -234,7 +234,25 @@
                 // handle published below).
                 const startConversion = (modelName, buf) => {
                     const optimizer = document.querySelector('input[name="optimizer"]:checked').value;
-                    result_name = (modelName.endsWith(".onnx") ? modelName.substring(0, modelName.length - 5) : modelName) + "." + optimizer + ".onnx"
+                    // A ".onnx.safetensors"/".onnx.gguf" upload (the same standalone
+                    // archive format the download-format selector produces) needs
+                    // decoding back to ONNX before conversion -- see worker.js's
+                    // import pre-step. Strip whichever archive suffix is present
+                    // first, then the ".onnx" underneath it, so the result name
+                    // matches a plain ".onnx" upload's either way.
+                    let base = modelName;
+                    let source_format = "onnx";
+                    if (/\.safetensors$/i.test(base)) {
+                        source_format = "safetensors";
+                        base = base.slice(0, -".safetensors".length);
+                    } else if (/\.gguf$/i.test(base)) {
+                        source_format = "gguf";
+                        base = base.slice(0, -".gguf".length);
+                    }
+                    if (/\.onnx$/i.test(base)) {
+                        base = base.slice(0, -".onnx".length);
+                    }
+                    result_name = base + "." + optimizer + ".onnx";
                     original_name = modelName;
                     // Drop any previous run's cached models so the inference panel
                     // never serves a stale converted/annotated result for the new
@@ -282,7 +300,7 @@
                     last_run_info.graph_diff = graph_diff;
                     // Expose the latest run parameters to the report-issue module.
                     window.__onnxsimLastRunInfo = last_run_info;
-                    worker.postMessage([optimizer, buf, passes, constant_fold, shape_inference, tensor_size_threshold, target_opset_version, profile, annotate_model_info, inline_functions, graph_diff], [buf]);
+                    worker.postMessage([optimizer, buf, passes, constant_fold, shape_inference, tensor_size_threshold, target_opset_version, profile, annotate_model_info, inline_functions, graph_diff, source_format], [buf]);
                 };
                 // Expose the conversion entry point for the Hugging Face loader
                 // module (hf_load.mjs), which downloads model bytes and drives

--- a/scripts/convertmodel/converter_main.js
+++ b/scripts/convertmodel/converter_main.js
@@ -85,6 +85,8 @@
                 const log_output = document.getElementById("log-output");
                 const input = document.getElementById("file-input");
                 const dl_btn = document.getElementById("download-button");
+                const format_select = document.getElementById("download-format");
+                const format_status = document.getElementById("download-format-status");
                 const trace_container = document.getElementById("simplify-trace");
                 let result_name = "";
                 let original_name = "";
@@ -112,17 +114,59 @@
                             log_output.value += e.data[1] + "\n";
                             log_output.scrollTop = log_output.scrollHeight;
                             break;
+                        // The download-format selector asked for the already-
+                        // converted model re-exported as a standalone
+                        // safetensors/gguf archive (see dl_btn.onclick below);
+                        // this is that export's result, so trigger the download
+                        // now and re-enable the controls it disabled meanwhile.
+                        case "export-format-done": {
+                            dl_btn.disabled = false;
+                            format_select.disabled = false;
+                            format_status.textContent = "";
+                            const a = document.createElement("a");
+                            a.href = e.data[2];
+                            a.download = e.data[3];
+                            a.click();
+                            break;
+                        }
+                        case "export-format-error":
+                            dl_btn.disabled = false;
+                            format_select.disabled = false;
+                            format_status.textContent = `${e.data[1]} export failed: ${e.data[2]}`;
+                            break;
                         case "convert-done":
                             input.disabled = false;
                             dl_btn.disabled = false;
+                            format_status.textContent = "";
                             const data_url = e.data[1];
                             const trace_json = e.data[2];
                             const original_data_url = e.data[3];
                             dl_btn.onclick = () => {
-                                const a = document.createElement("a");
-                                a.href = data_url;
-                                a.download = result_name;
-                                a.click();
+                                const format = format_select.value;
+                                if (format === "onnx") {
+                                    const a = document.createElement("a");
+                                    a.href = data_url;
+                                    a.download = result_name;
+                                    a.click();
+                                    return;
+                                }
+                                // Safetensors / GGUF: ask the worker to re-export
+                                // the already-converted bytes into that standalone
+                                // archive format (it owns the WASM runtime that
+                                // does the export). Async, so disable the controls
+                                // until "export-format-done"/"-error" above fires.
+                                const converted = window.__onnxsimConverted;
+                                if (!converted || !converted.bytes) return;
+                                const ext = format === "gguf" ? ".gguf" : ".safetensors";
+                                const bytes = converted.bytes;
+                                const export_buf = bytes.buffer.slice(
+                                    bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+                                dl_btn.disabled = true;
+                                format_select.disabled = true;
+                                format_status.textContent = `exporting ${format}…`;
+                                worker.postMessage(
+                                    ["export_" + format, export_buf, result_name + ext],
+                                    [export_buf]);
                             };
                             // Visualize the simplified/optimized model with Netron.
                             if (window.netronShowAfter) {
@@ -200,6 +244,7 @@
 
                     input.disabled = true;
                     dl_btn.disabled = true;
+                    format_status.textContent = "";
                     let passes = null;
                     if (optimizer == "simplify") {
                         passes = Array.from(document.querySelectorAll('input[class="pass"]:not(:checked)')).map((v) => v.name);

--- a/scripts/convertmodel/converter_main.js
+++ b/scripts/convertmodel/converter_main.js
@@ -98,8 +98,30 @@
                     for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
                     return bytes;
                 };
+                // The in-flight window.__onnxsimImportArchive() request (see
+                // below), resolved/rejected by the "import-format-done"/
+                // "import-format-error" cases below. Only one archive decode
+                // is ever in flight at a time -- a later request implicitly
+                // supersedes an earlier one, which matches the file picker it
+                // serves (picking a new file makes any previous one moot).
+                let pendingImport = null;
+
                 worker.onmessage = (e) => {
                     switch (e.data[0]) {
+                        case "import-format-done":
+                            // e.data[2] is the decoded model's raw bytes (an
+                            // ArrayBuffer, transferred -- see worker.js).
+                            if (pendingImport) {
+                                pendingImport.resolve(new Uint8Array(e.data[2]));
+                                pendingImport = null;
+                            }
+                            break;
+                        case "import-format-error":
+                            if (pendingImport) {
+                                pendingImport.reject(new Error(e.data[2]));
+                                pendingImport = null;
+                            }
+                            break;
                         case "ready":
                             // The worker's WASM runtime has finished loading and
                             // is now listening for conversion requests.
@@ -123,10 +145,15 @@
                             dl_btn.disabled = false;
                             format_select.disabled = false;
                             format_status.textContent = "";
-                            const a = document.createElement("a");
-                            a.href = e.data[2];
-                            a.download = e.data[3];
-                            a.click();
+                            // e.data[2] is the raw archive bytes (an
+                            // ArrayBuffer, transferred rather than a base64
+                            // data URL -- see worker.js). downloadBytes wraps
+                            // it in a Blob URL, which is O(1) to create/click
+                            // regardless of size, unlike a multi-ten-MB data:
+                            // URL.
+                            import("./download.mjs").then(({ downloadBytes }) => {
+                                downloadBytes(e.data[2], e.data[3]);
+                            });
                             break;
                         }
                         case "export-format-error":
@@ -306,6 +333,20 @@
                 // module (hf_load.mjs), which downloads model bytes and drives
                 // the same path as an uploaded file.
                 window.__onnxsimStartConversion = startConversion;
+
+                // Decode a standalone safetensors/gguf archive (ArrayBuffer) into
+                // plain ONNX model bytes, without running a conversion. Used by
+                // netron_view.mjs's "before" pane so a safetensors/gguf upload
+                // renders the actual model graph instead of the raw archive
+                // bytes (which Netron can only show as an opaque weights list).
+                // `format` is "safetensors" or "gguf"; `buf` is transferred to
+                // the worker, so the caller must not reuse it afterwards.
+                window.__onnxsimImportArchive = (buf, format) => {
+                    return new Promise((resolve, reject) => {
+                        pendingImport = { resolve, reject };
+                        worker.postMessage(["import_" + format, buf], [buf]);
+                    });
+                };
 
                 input.addEventListener("change", async (e) => {
                     const file = e.target.files[0];

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -80,6 +80,13 @@ agraph (float[N] X) =&gt; (float[N] Y) {
         <input type="file" id="file-input" disabled title="Loading WebAssembly runtime…" />
         <span id="loading-status" role="status" aria-live="polite">⏳ Loading WebAssembly runtime… the file picker is disabled until it is ready.</span>
         <button id="download-button" disabled>Download ↓</button>
+        <label for="download-format" style="margin-left: 0.5em;">as</label>
+        <select id="download-format" title="Choose the downloaded file's format. Safetensors and GGUF each produce one self-contained file: the model graph plus its weights, in that ecosystem's standard tensor format.">
+            <option value="onnx" selected>.onnx</option>
+            <option value="safetensors">.onnx.safetensors</option>
+            <option value="gguf">.onnx.gguf</option>
+        </select>
+        <span id="download-format-status" class="tool-note"></span>
         <div id="hf-loader" style="margin-top: 0.6em;">
             <label for="hf-model-select">…or load from <a href="https://huggingface.co/onnxmodelzoo" target="_blank" rel="noopener">Hugging Face</a>:</label>
             <select id="hf-model-select" disabled title="Loading WebAssembly runtime…">

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -77,8 +77,12 @@ agraph (float[N] X) =&gt; (float[N] Y) {
         <script type="module" src="./debug_tools.mjs"></script>
 
         <h2 id="sec-convert">Convert a model</h2>
-        <input type="file" id="file-input" disabled title="Loading WebAssembly runtime…" />
+        <input type="file" id="file-input" accept=".onnx,.onnx.safetensors,.onnx.gguf,.safetensors,.gguf" disabled title="Loading WebAssembly runtime…" />
         <span id="loading-status" role="status" aria-live="polite">⏳ Loading WebAssembly runtime… the file picker is disabled until it is ready.</span>
+        <div class="note">
+            Also accepts a standalone <code>.onnx.safetensors</code> or <code>.onnx.gguf</code> archive
+            (e.g. one downloaded from the format selector below) -- it is decoded back to ONNX before converting.
+        </div>
         <button id="download-button" disabled>Download ↓</button>
         <label for="download-format" style="margin-left: 0.5em;">as</label>
         <select id="download-format" title="Choose the downloaded file's format. Safetensors and GGUF each produce one self-contained file: the model graph plus its weights, in that ecosystem's standard tensor format.">

--- a/scripts/convertmodel/interface.cpp
+++ b/scripts/convertmodel/interface.cpp
@@ -5,6 +5,9 @@
 #include "onnx/defs/parser.h"
 #include "onnx/defs/schema.h"
 #include "onnx/inliner/inliner.h"
+#include "tensor_pool.h"
+#include "tensor_pool_bridge.h"
+#include "tensor_pool_gguf_bridge.h"
 
 // Version strings baked in by CMake (read from VERSION and
 // third_party/onnx-optimizer/VERSION_NUMBER). Fall back to "unknown" so the
@@ -70,6 +73,32 @@ std::string ReadAndClearProfileTrace() {
     }
     std::remove(kProfileTracePath);
     return trace;
+}
+
+// Where the standalone safetensors/gguf exports below write their result
+// inside Emscripten's in-memory filesystem, mirroring kProfileTracePath. The
+// TensorPool bridge bakes this path into the archive as the embedded model's
+// external_data "location" (see SaveModelAsSafetensorsStandalone /
+// SaveModelAsGGUFStandalone), so it is a fixed internal name rather than the
+// user-facing download filename -- onnxsim's own loaders resolve the
+// embedded model by pool name, not by this path, so the mismatch with
+// whatever name the browser saves the download under is harmless.
+constexpr const char* kSafetensorsExportPath = "onnxsim_export.safetensors";
+constexpr const char* kGGUFExportPath = "onnxsim_export.gguf";
+
+// Read `path` back into a string and delete it, same pattern as
+// ReadAndClearProfileTrace above. Returns an empty string if the file could
+// not be opened.
+std::string ReadAndDeleteFile(const std::string& path) {
+    std::string data;
+    std::ifstream ifs(path, std::ios::binary);
+    if (ifs) {
+        std::ostringstream ss;
+        ss << ifs.rdbuf();
+        data = ss.str();
+    }
+    std::remove(path.c_str());
+    return data;
 }
 
 // Serialize `model` into the shared static buffer and hand JS a typed-memory
@@ -396,6 +425,65 @@ em::val onnxsim_annotate_model_info(const std::string& data) {
     return em::val(em::typed_memory_view(result.size(), reinterpret_cast<uint8_t*>(result.data())));
 }
 
+// Export `data` (a serialized onnx::ModelProto) as a single standalone
+// safetensors archive: every initializer's bytes move into the archive with
+// real, byte-accurate offsets -- openable by the `safetensors` Python package
+// / HF tooling with no onnxsim involved -- and the graph itself is embedded
+// alongside them (tensor_pool_bridge.h's SaveModelAsSafetensorsStandalone), so
+// the one file this returns is both the model's weights and its graph. Used
+// by the page's download-format selector for the ".onnx.safetensors" option.
+// Returns null on a parse/export failure.
+em::val onnxsim_export_safetensors(const std::string& data) {
+    onnx::ModelProto xmodel;
+    if (!xmodel.ParseFromArray(data.data(), data.size())) {
+        std::cerr << "Parse failed" << std::endl;
+        return em::val::null();
+    }
+    onnxsim::tensor_pool::TensorPool pool;
+    try {
+        onnxsim::tensor_pool::SaveModelAsSafetensorsStandalone(
+            xmodel, kSafetensorsExportPath, pool);
+    } catch (const std::exception& e) {
+        std::cerr << "safetensors export failed: " << e.what() << std::endl;
+        std::remove(kSafetensorsExportPath);
+        return em::val::null();
+    }
+    static std::string result;
+    result = ReadAndDeleteFile(kSafetensorsExportPath);
+    if (result.empty()) {
+        std::cerr << "failed to read back the exported safetensors file" << std::endl;
+        return em::val::null();
+    }
+    return em::val(em::typed_memory_view(result.size(), reinterpret_cast<uint8_t*>(result.data())));
+}
+
+// GGUF counterpart of onnxsim_export_safetensors above; see
+// tensor_pool_gguf_bridge.h's SaveModelAsGGUFStandalone. Used by the page's
+// download-format selector for the ".onnx.gguf" option.
+em::val onnxsim_export_gguf(const std::string& data) {
+    onnx::ModelProto xmodel;
+    if (!xmodel.ParseFromArray(data.data(), data.size())) {
+        std::cerr << "Parse failed" << std::endl;
+        return em::val::null();
+    }
+    onnxsim::tensor_pool::TensorPool pool;
+    try {
+        onnxsim::tensor_pool::SaveModelAsGGUFStandalone(xmodel, kGGUFExportPath,
+                                                         pool);
+    } catch (const std::exception& e) {
+        std::cerr << "gguf export failed: " << e.what() << std::endl;
+        std::remove(kGGUFExportPath);
+        return em::val::null();
+    }
+    static std::string result;
+    result = ReadAndDeleteFile(kGGUFExportPath);
+    if (result.empty()) {
+        std::cerr << "failed to read back the exported gguf file" << std::endl;
+        return em::val::null();
+    }
+    return em::val(em::typed_memory_view(result.size(), reinterpret_cast<uint8_t*>(result.data())));
+}
+
 // Report the versions of the libraries baked into this module, for detailed
 // bug reports. onnxsim and onnx-optimizer come from CMake (their VERSION files);
 // onnx is reported as its max IR version + the highest opset it supports for the
@@ -635,6 +723,8 @@ std::vector<std::string> onnxoptimizer_fuse_elimination_passes() {
 EMSCRIPTEN_BINDINGS(module) {
     function("onnxsimplify_export", &onnxsimplify_export);
     function("onnxsim_annotate_model_info", &onnxsim_annotate_model_info);
+    function("onnxsim_export_safetensors", &onnxsim_export_safetensors);
+    function("onnxsim_export_gguf", &onnxsim_export_gguf);
     function("onnxoptimizer_optimize", &onnxoptimizer_optimize);
     function("onnxoptimizer_optimize_fixed", &onnxoptimizer_optimize_fixed);
     em::function("onnxoptimizer_passes", &onnxoptimizer_passes);

--- a/scripts/convertmodel/interface.cpp
+++ b/scripts/convertmodel/interface.cpp
@@ -92,11 +92,20 @@ constexpr const char* kGGUFArchivePath = "onnxsim_export.gguf";
 // not be opened.
 std::string ReadAndDeleteFile(const std::string& path) {
     std::string data;
-    std::ifstream ifs(path, std::ios::binary);
+    // Seek to measure the size and read directly into a pre-sized string,
+    // rather than streaming through an ostringstream (which grows its own
+    // internal buffer geometrically and copies out of it into the returned
+    // string on .str()) -- one read into the final buffer instead of several
+    // reallocate-and-copy passes. Matters here because a safetensors/gguf
+    // archive embeds the whole model and can be tens of MB.
+    std::ifstream ifs(path, std::ios::binary | std::ios::ate);
     if (ifs) {
-        std::ostringstream ss;
-        ss << ifs.rdbuf();
-        data = ss.str();
+        const std::streamoff size = ifs.tellg();
+        if (size > 0) {
+            data.resize(static_cast<size_t>(size));
+            ifs.seekg(0);
+            ifs.read(&data[0], size);
+        }
     }
     std::remove(path.c_str());
     return data;

--- a/scripts/convertmodel/interface.cpp
+++ b/scripts/convertmodel/interface.cpp
@@ -75,16 +75,17 @@ std::string ReadAndClearProfileTrace() {
     return trace;
 }
 
-// Where the standalone safetensors/gguf exports below write their result
-// inside Emscripten's in-memory filesystem, mirroring kProfileTracePath. The
-// TensorPool bridge bakes this path into the archive as the embedded model's
-// external_data "location" (see SaveModelAsSafetensorsStandalone /
-// SaveModelAsGGUFStandalone), so it is a fixed internal name rather than the
-// user-facing download filename -- onnxsim's own loaders resolve the
-// embedded model by pool name, not by this path, so the mismatch with
-// whatever name the browser saves the download under is harmless.
-constexpr const char* kSafetensorsExportPath = "onnxsim_export.safetensors";
-constexpr const char* kGGUFExportPath = "onnxsim_export.gguf";
+// Where the standalone safetensors/gguf export/import functions below stage
+// the archive inside Emscripten's in-memory filesystem, mirroring
+// kProfileTracePath. On export, the TensorPool bridge bakes this path into
+// the archive as the embedded model's external_data "location" (see
+// SaveModelAsSafetensorsStandalone / SaveModelAsGGUFStandalone), so it is a
+// fixed internal name rather than the user-facing download filename --
+// onnxsim's own loaders resolve the embedded model by pool name, not by this
+// path, so the mismatch with whatever name the browser saves the download
+// under (or the name of a file the user uploads for import) is harmless.
+constexpr const char* kSafetensorsArchivePath = "onnxsim_export.safetensors";
+constexpr const char* kGGUFArchivePath = "onnxsim_export.gguf";
 
 // Read `path` back into a string and delete it, same pattern as
 // ReadAndClearProfileTrace above. Returns an empty string if the file could
@@ -99,6 +100,16 @@ std::string ReadAndDeleteFile(const std::string& path) {
     }
     std::remove(path.c_str());
     return data;
+}
+
+// Stage `data` at `path` inside the MEMFS, for the import functions below to
+// hand to a TensorPool loader that only knows how to read from a path.
+// Returns false (and leaves nothing behind) on a write failure.
+bool WriteFile(const std::string& path, const std::string& data) {
+    std::ofstream ofs(path, std::ios::binary | std::ios::trunc);
+    if (!ofs) return false;
+    ofs.write(data.data(), static_cast<std::streamsize>(data.size()));
+    return static_cast<bool>(ofs);
 }
 
 // Serialize `model` into the shared static buffer and hand JS a typed-memory
@@ -442,14 +453,14 @@ em::val onnxsim_export_safetensors(const std::string& data) {
     onnxsim::tensor_pool::TensorPool pool;
     try {
         onnxsim::tensor_pool::SaveModelAsSafetensorsStandalone(
-            xmodel, kSafetensorsExportPath, pool);
+            xmodel, kSafetensorsArchivePath, pool);
     } catch (const std::exception& e) {
         std::cerr << "safetensors export failed: " << e.what() << std::endl;
-        std::remove(kSafetensorsExportPath);
+        std::remove(kSafetensorsArchivePath);
         return em::val::null();
     }
     static std::string result;
-    result = ReadAndDeleteFile(kSafetensorsExportPath);
+    result = ReadAndDeleteFile(kSafetensorsArchivePath);
     if (result.empty()) {
         std::cerr << "failed to read back the exported safetensors file" << std::endl;
         return em::val::null();
@@ -468,20 +479,96 @@ em::val onnxsim_export_gguf(const std::string& data) {
     }
     onnxsim::tensor_pool::TensorPool pool;
     try {
-        onnxsim::tensor_pool::SaveModelAsGGUFStandalone(xmodel, kGGUFExportPath,
+        onnxsim::tensor_pool::SaveModelAsGGUFStandalone(xmodel, kGGUFArchivePath,
                                                          pool);
     } catch (const std::exception& e) {
         std::cerr << "gguf export failed: " << e.what() << std::endl;
-        std::remove(kGGUFExportPath);
+        std::remove(kGGUFArchivePath);
         return em::val::null();
     }
     static std::string result;
-    result = ReadAndDeleteFile(kGGUFExportPath);
+    result = ReadAndDeleteFile(kGGUFArchivePath);
     if (result.empty()) {
         std::cerr << "failed to read back the exported gguf file" << std::endl;
         return em::val::null();
     }
     return em::val(em::typed_memory_view(result.size(), reinterpret_cast<uint8_t*>(result.data())));
+}
+
+// Import counterpart of onnxsim_export_safetensors: `data` is the whole raw
+// bytes of a standalone safetensors archive (as produced by that function,
+// or any other tool following the same self-describing-archive convention --
+// tensor_pool_bridge.h's EmbedModel/ExtractModel -- an embedded "model.onnx"
+// entry alongside the tensors). Stages it into the MEMFS, loads it back into
+// an ordinary, fully in-memory onnx::ModelProto via LoadModelFromSafetensors
+// (hydrate_all=true, so every initializer is hydrated -- no lingering
+// EXTERNAL references into the now-deleted staged file), and returns its
+// serialized bytes. Used by the page's file picker to accept a
+// ".onnx.safetensors" upload. Returns null if the archive has no embedded
+// model (e.g. a plain weights-only safetensors file with no onnxsim-authored
+// graph) or on any other stage/load/parse failure.
+em::val onnxsim_import_safetensors(const std::string& data) {
+    if (!WriteFile(kSafetensorsArchivePath, data)) {
+        std::cerr << "failed to stage the uploaded safetensors file" << std::endl;
+        return em::val::null();
+    }
+    onnx::ModelProto xmodel;
+    onnxsim::tensor_pool::TensorPool pool;
+    bool ok = false;
+    try {
+        ok = onnxsim::tensor_pool::LoadModelFromSafetensors(
+            kSafetensorsArchivePath, &xmodel, pool);
+    } catch (const std::exception& e) {
+        std::cerr << "safetensors import failed: " << e.what() << std::endl;
+        std::remove(kSafetensorsArchivePath);
+        return em::val::null();
+    }
+    std::remove(kSafetensorsArchivePath);
+    if (!ok) {
+        std::cerr << "safetensors file has no embedded onnxsim model (a plain "
+                     "weights-only archive is not importable as a graph)"
+                  << std::endl;
+        return em::val::null();
+    }
+    return SerializeModel(xmodel);
+}
+
+// GGUF counterpart of onnxsim_import_safetensors above; see
+// tensor_pool_gguf_bridge.h's LoadModelFromGGUF. Used by the page's file
+// picker to accept a ".onnx.gguf" upload. `skipped` (any other pooled
+// tensors LoadModelFromGGUF could not hydrate, e.g. a quantized weight) is
+// logged rather than surfaced structurally -- best-effort, matching how the
+// rest of this file reports non-fatal issues via std::cerr.
+em::val onnxsim_import_gguf(const std::string& data) {
+    if (!WriteFile(kGGUFArchivePath, data)) {
+        std::cerr << "failed to stage the uploaded gguf file" << std::endl;
+        return em::val::null();
+    }
+    onnx::ModelProto xmodel;
+    onnxsim::tensor_pool::TensorPool pool;
+    bool ok = false;
+    std::vector<std::string> skipped;
+    try {
+        ok = onnxsim::tensor_pool::LoadModelFromGGUF(kGGUFArchivePath, &xmodel,
+                                                      pool, true, &skipped);
+    } catch (const std::exception& e) {
+        std::cerr << "gguf import failed: " << e.what() << std::endl;
+        std::remove(kGGUFArchivePath);
+        return em::val::null();
+    }
+    std::remove(kGGUFArchivePath);
+    if (!ok) {
+        std::cerr << "gguf file has no embedded onnxsim model (a plain "
+                     "weights-only archive is not importable as a graph)"
+                  << std::endl;
+        return em::val::null();
+    }
+    if (!skipped.empty()) {
+        std::cerr << "gguf import: " << skipped.size()
+                  << " tensor(s) left un-hydrated (quantized/unsupported dtype)"
+                  << std::endl;
+    }
+    return SerializeModel(xmodel);
 }
 
 // Report the versions of the libraries baked into this module, for detailed
@@ -725,6 +812,8 @@ EMSCRIPTEN_BINDINGS(module) {
     function("onnxsim_annotate_model_info", &onnxsim_annotate_model_info);
     function("onnxsim_export_safetensors", &onnxsim_export_safetensors);
     function("onnxsim_export_gguf", &onnxsim_export_gguf);
+    function("onnxsim_import_safetensors", &onnxsim_import_safetensors);
+    function("onnxsim_import_gguf", &onnxsim_import_gguf);
     function("onnxoptimizer_optimize", &onnxoptimizer_optimize);
     function("onnxoptimizer_optimize_fixed", &onnxoptimizer_optimize_fixed);
     em::function("onnxoptimizer_passes", &onnxoptimizer_passes);

--- a/scripts/convertmodel/netron_view.mjs
+++ b/scripts/convertmodel/netron_view.mjs
@@ -28,6 +28,15 @@ function fileToArrayBuffer(file) {
   return file.arrayBuffer();
 }
 
+// "safetensors" | "gguf" | null, sniffed from a filename's extension -- same
+// detection converter_main.js's startConversion uses to route an upload
+// through the matching TensorPool import binding before conversion.
+function archiveFormat(name) {
+  if (/\.safetensors$/i.test(name)) return "safetensors";
+  if (/\.gguf$/i.test(name)) return "gguf";
+  return null;
+}
+
 // Netron is served from the converter's own origin, so we only ever talk to a
 // same-origin window and can pin the target origin.
 const NETRON_ORIGIN = window.location.origin;
@@ -250,7 +259,34 @@ function initNetronPanel() {
         return;
       }
       fileToArrayBuffer(file)
-        .then((buffer) => renderPane("before", toArrayBuffer(buffer), file.name))
+        .then(async (buffer) => {
+          // A standalone safetensors/gguf archive (e.g. one downloaded from
+          // this page's own format selector): decode it to ONNX first, same
+          // as the conversion pipeline does, so this pane shows the actual
+          // model graph instead of Netron's opaque raw-weights view of the
+          // archive bytes. Falls back to rendering the raw bytes (with a
+          // note) if decoding fails, e.g. a plain weights-only archive with
+          // no embedded graph -- Netron's raw view is still better than
+          // nothing for those.
+          const format = archiveFormat(file.name);
+          if (format && typeof window.__onnxsimImportArchive === "function") {
+            try {
+              const decoded = await window.__onnxsimImportArchive(toArrayBuffer(buffer), format);
+              renderPane("before", toArrayBuffer(decoded), file.name);
+              return;
+            } catch (err) {
+              renderPane("before", toArrayBuffer(buffer), file.name);
+              const note = document.getElementById("netron-before-note");
+              if (note) {
+                note.textContent =
+                    `Could not decode this ${format} file as an onnxsim archive ` +
+                    `(${err.message || err}) -- showing its raw structure instead.`;
+              }
+              return;
+            }
+          }
+          renderPane("before", toArrayBuffer(buffer), file.name);
+        })
         .catch((err) => console.error("netron (before):", err));
     });
   }

--- a/scripts/convertmodel/worker.js
+++ b/scripts/convertmodel/worker.js
@@ -124,8 +124,10 @@ create_onnxsim({
         // The true uploaded bytes, kept aside so the "annotate the original for
         // the inference-compare panel" step below always sees the model the user
         // gave us, even when the inline pre-step replaces `buf` with the inlined
-        // model before the main transform runs.
-        const originalBuf = e.data[1];
+        // model before the main transform runs. Reassigned below (to the
+        // decoded ONNX bytes) when the upload was a safetensors/gguf archive,
+        // since the raw archive bytes are not a valid ONNX model on their own.
+        let originalBuf = e.data[1];
         // `model` is the converted model bytes (a Uint8Array view); `trace` is
         // the onnxsim profiling trace JSON for "simplify" when profiling was
         // requested, otherwise an empty string.
@@ -136,6 +138,27 @@ create_onnxsim({
         // user gets an explanation (see memoryLimitMessage) instead of the worker
         // dying with an opaque, unhandled error.
         try {
+        // Optional pre-step: the upload was a standalone safetensors/gguf
+        // archive (see the page's file picker), not a raw .onnx file -- decode
+        // it into an ordinary ONNX model first via the matching TensorPool
+        // import binding, so every transform below (and the "original" used
+        // for annotate/inference-compare) sees a plain ModelProto exactly like
+        // an .onnx upload would produce. No model executor needed, so this is
+        // synchronous in both module variants.
+        const source_format = e.data[11] || "onnx";
+        if (source_format === "safetensors" || source_format === "gguf") {
+            const importFn = source_format === "gguf" ?
+                runtime.onnxsim_import_gguf : runtime.onnxsim_import_safetensors;
+            const imported = importFn(buf);
+            if (!imported) {
+                postMessage(["stderr",
+                    `failed to import ${source_format}: no embedded onnxsim model ` +
+                    "found (a plain weights-only archive has no graph to import)"]);
+                return;
+            }
+            buf = new Uint8Array(imported).buffer;
+            originalBuf = buf;
+        }
         // Optional pre-step: inline the model's local functions before the main
         // transform, so onnx-optimizer / Simplify / constant folding see through
         // them into a plain op graph. Controlled by a checkbox (e.data[9]) and

--- a/scripts/convertmodel/worker.js
+++ b/scripts/convertmodel/worker.js
@@ -95,6 +95,19 @@ create_onnxsim({
     // happens now, so any file posted earlier would be dropped.
     postMessage(["ready"]);
 
+    // Decode a standalone safetensors/gguf archive into plain ONNX model
+    // bytes via the matching TensorPool import binding. Shared by the
+    // conversion pre-step below (which feeds the result into simplify/
+    // optimize) and the standalone "import_*" message (which just wants the
+    // decoded bytes to show in Netron -- see the "before" pane). Returns the
+    // decoded Uint8Array, or null if the archive has no embedded onnxsim
+    // model (e.g. a plain weights-only archive with no graph to import).
+    function importArchive(format, buf) {
+        const fn = format === "gguf" ?
+            runtime.onnxsim_import_gguf : runtime.onnxsim_import_safetensors;
+        return fn(buf);
+    }
+
     addEventListener("message", async (e) => {
         // Re-export already-converted model bytes into a standalone archive
         // format for the page's download-format selector (safetensors / gguf).
@@ -113,10 +126,42 @@ create_onnxsim({
                     postMessage(["export-format-error", format, format + " export failed!"]);
                     return;
                 }
-                const data_url = "data:application/octet-stream;base64," + bytes.toBase64();
-                postMessage(["export-format-done", format, data_url, filename]);
+                // Copy out of the wasm heap into a standalone ArrayBuffer (the
+                // view `bytes` aliases the module's own memory and cannot be
+                // transferred) and hand it to the main thread by transfer, not
+                // structured-clone. A safetensors/gguf archive embeds the whole
+                // model, easily tens of MB for a real model; a base64 data URL
+                // would encode it into an even bigger string, clone that whole
+                // string across the worker boundary, and then have the browser
+                // parse it back out of the anchor's href on click -- all of
+                // which a plain ArrayBuffer transfer + Blob URL skips.
+                const copy = bytes.slice();
+                postMessage(["export-format-done", format, copy.buffer, filename], [copy.buffer]);
             } catch (err) {
                 postMessage(["export-format-error", format, String((err && err.message) || err)]);
+            }
+            return;
+        }
+        // Decode a safetensors/gguf upload into plain ONNX bytes without
+        // running it through simplify/optimize -- used by the "before" Netron
+        // pane (netron_view.mjs, via window.__onnxsimImportArchive) so it
+        // renders the actual model graph instead of the raw archive bytes.
+        if (e.data[0] === "import_safetensors" || e.data[0] === "import_gguf") {
+            const format = e.data[0] === "import_gguf" ? "gguf" : "safetensors";
+            const importBuf = e.data[1];
+            try {
+                const bytes = importArchive(format, importBuf);
+                if (!bytes) {
+                    postMessage(["import-format-error", format,
+                        `no embedded onnxsim model found in this ${format} file`]);
+                    return;
+                }
+                // Transfer, not base64 -- same reasoning as the export path
+                // above; the decoded model can be tens of MB.
+                const copy = bytes.slice();
+                postMessage(["import-format-done", format, copy.buffer], [copy.buffer]);
+            } catch (err) {
+                postMessage(["import-format-error", format, String((err && err.message) || err)]);
             }
             return;
         }
@@ -147,9 +192,7 @@ create_onnxsim({
         // synchronous in both module variants.
         const source_format = e.data[11] || "onnx";
         if (source_format === "safetensors" || source_format === "gguf") {
-            const importFn = source_format === "gguf" ?
-                runtime.onnxsim_import_gguf : runtime.onnxsim_import_safetensors;
-            const imported = importFn(buf);
+            const imported = importArchive(source_format, buf);
             if (!imported) {
                 postMessage(["stderr",
                     `failed to import ${source_format}: no embedded onnxsim model ` +

--- a/scripts/convertmodel/worker.js
+++ b/scripts/convertmodel/worker.js
@@ -96,6 +96,30 @@ create_onnxsim({
     postMessage(["ready"]);
 
     addEventListener("message", async (e) => {
+        // Re-export already-converted model bytes into a standalone archive
+        // format for the page's download-format selector (safetensors / gguf).
+        // Kept separate from the convert switch below: this takes the already-
+        // converted bytes (not a raw upload) and needs none of the inline-
+        // functions / annotate-original pre-steps a fresh conversion runs.
+        if (e.data[0] === "export_safetensors" || e.data[0] === "export_gguf") {
+            const format = e.data[0] === "export_gguf" ? "gguf" : "safetensors";
+            const exportBuf = e.data[1];
+            const filename = e.data[2];
+            try {
+                const fn = format === "gguf" ?
+                    runtime.onnxsim_export_gguf : runtime.onnxsim_export_safetensors;
+                const bytes = fn(exportBuf);
+                if (!bytes) {
+                    postMessage(["export-format-error", format, format + " export failed!"]);
+                    return;
+                }
+                const data_url = "data:application/octet-stream;base64," + bytes.toBase64();
+                postMessage(["export-format-done", format, data_url, filename]);
+            } catch (err) {
+                postMessage(["export-format-error", format, String((err && err.message) || err)]);
+            }
+            return;
+        }
         let buf = e.data[1];
         // The true uploaded bytes, kept aside so the "annotate the original for
         // the inference-compare panel" step below always sees the model the user


### PR DESCRIPTION
## Summary
Adds support for exporting ONNX models in standalone safetensors and GGUF archive formats from the web-based model converter. Users can now download converted models as `.onnx.safetensors` or `.onnx.gguf` files, where the model graph and weights are packaged together in a single self-contained file compatible with their respective ecosystems.

## Key Changes

- **C++ Interface** (`interface.cpp`):
  - Added includes for tensor pool and bridge utilities (`tensor_pool.h`, `tensor_pool_bridge.h`, `tensor_pool_gguf_bridge.h`)
  - Implemented `ReadAndDeleteFile()` helper to read and clean up temporary export files
  - Added `onnxsim_export_safetensors()` function to export models as standalone safetensors archives
  - Added `onnxsim_export_gguf()` function to export models as standalone GGUF archives
  - Exposed both functions to JavaScript via Emscripten bindings

- **Web UI** (`index.html`):
  - Added download format selector dropdown with three options: `.onnx`, `.onnx.safetensors`, `.onnx.gguf`
  - Added status indicator for export operations

- **Main Converter Script** (`converter_main.js`):
  - Modified download button behavior to support format selection
  - For safetensors/GGUF formats, sends already-converted model bytes to worker for re-export
  - Added handlers for `export-format-done` and `export-format-error` messages
  - Disables controls during async export operations and re-enables them on completion

- **Worker Script** (`worker.js`):
  - Added message handler for `export_safetensors` and `export_gguf` commands
  - Calls appropriate C++ export functions and returns results as data URLs for download
  - Includes error handling with user-facing error messages

## Implementation Details

The export workflow is asynchronous: after a model is converted to ONNX, users can select an alternative format from the dropdown. This triggers a message to the worker thread, which calls the corresponding C++ export function using the already-converted model bytes. The exported archive is then returned and automatically downloaded. The safetensors and GGUF exports produce fully self-contained files with both the model graph and tensor weights, compatible with standard tooling in those ecosystems.

https://claude.ai/code/session_01Y2xvo4F92VdxDXDWCYVAFX