### PR TITLE
Add memory-mapped safetensors loader (LoadSafetensorsMmap)

### DIFF
--- a/onnxsim/mmap_file.h
+++ b/onnxsim/mmap_file.h
@@ -1,0 +1,135 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Read-only whole-file memory-mapping, shared by tensor_pool.cpp's
+ * LoadSafetensorsMmap and tensor_pool_gguf.cpp's LoadGGUFMmap: both need the
+ * exact same platform mapping/RAII-unmap mechanics regardless of which wire
+ * format is being read afterwards, unlike the two codecs' actual parsing
+ * logic, which stays deliberately separate (see tensor_pool_gguf.cpp's file
+ * comment on why the two codecs otherwise duplicate rather than share).
+ */
+#ifndef ONNXSIM_MMAP_FILE_H_
+#define ONNXSIM_MMAP_FILE_H_
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+
+// Platform-specific file-memory-mapping. Everything falls back to an
+// ordinary read on a platform none of these branches cover (mirrors
+// profiler.cpp's ReadCurrentRssBytes pattern), so callers keep working --
+// just without the mmap benefit -- on wasm/Emscripten, which has no real
+// demand-paged file mapping.
+#if defined(__EMSCRIPTEN__)
+// No mapping support: TryMmapFile below always reports failure.
+#elif defined(_WIN32)
+// clang-format off
+#include <windows.h>
+// clang-format on
+#else
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+namespace onnxsim {
+namespace tensor_pool {
+
+#if defined(_WIN32)
+// Owns the Windows handles/view backing a mapping; unmapped/closed together
+// once the last owner referencing it (via the aliasing shared_ptr TryMmapFile
+// returns) is dropped.
+struct FileMapping {
+  HANDLE file = INVALID_HANDLE_VALUE;
+  HANDLE mapping = nullptr;
+  void* view = nullptr;
+  ~FileMapping() {
+    if (view != nullptr) ::UnmapViewOfFile(view);
+    if (mapping != nullptr) ::CloseHandle(mapping);
+    if (file != INVALID_HANDLE_VALUE) ::CloseHandle(file);
+  }
+};
+
+// Memory-maps `path` read-only. Returns {nullptr, 0} on any failure --
+// missing file, zero-length file (CreateFileMapping/MapViewOfFile reject
+// those), or any other OS-level error -- so callers can fall back to an
+// ordinary read.
+inline std::pair<std::shared_ptr<const char[]>, uint64_t> TryMmapFile(
+    const std::string& path) {
+  HANDLE file =
+      ::CreateFileA(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
+                    OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+  if (file == INVALID_HANDLE_VALUE) return {nullptr, 0};
+  LARGE_INTEGER size;
+  if (!::GetFileSizeEx(file, &size) || size.QuadPart <= 0) {
+    ::CloseHandle(file);
+    return {nullptr, 0};
+  }
+  HANDLE mapping =
+      ::CreateFileMappingA(file, nullptr, PAGE_READONLY, 0, 0, nullptr);
+  if (mapping == nullptr) {
+    ::CloseHandle(file);
+    return {nullptr, 0};
+  }
+  void* view = ::MapViewOfFile(mapping, FILE_MAP_READ, 0, 0, 0);
+  if (view == nullptr) {
+    ::CloseHandle(mapping);
+    ::CloseHandle(file);
+    return {nullptr, 0};
+  }
+  auto state = std::make_shared<FileMapping>();
+  state->file = file;
+  state->mapping = mapping;
+  state->view = view;
+  std::shared_ptr<const char[]> owner(state, static_cast<const char*>(view));
+  return {owner, static_cast<uint64_t>(size.QuadPart)};
+}
+#elif !defined(__EMSCRIPTEN__)
+// Owns the POSIX mapping; munmap'd once the last owner referencing it (via
+// the aliasing shared_ptr TryMmapFile returns) is dropped.
+struct FileMapping {
+  void* addr = MAP_FAILED;
+  size_t length = 0;
+  ~FileMapping() {
+    if (addr != MAP_FAILED && length > 0) ::munmap(addr, length);
+  }
+};
+
+// Memory-maps `path` read-only. Returns {nullptr, 0} on any failure --
+// missing file, zero-length file (mmap() rejects a zero length), or any
+// other OS-level error -- so callers can fall back to an ordinary read.
+inline std::pair<std::shared_ptr<const char[]>, uint64_t> TryMmapFile(
+    const std::string& path) {
+  int fd = ::open(path.c_str(), O_RDONLY);
+  if (fd < 0) return {nullptr, 0};
+  struct stat st {};
+  if (::fstat(fd, &st) != 0 || st.st_size <= 0) {
+    ::close(fd);
+    return {nullptr, 0};
+  }
+  size_t length = static_cast<size_t>(st.st_size);
+  void* addr = ::mmap(nullptr, length, PROT_READ, MAP_PRIVATE, fd, 0);
+  // The mapping keeps the file's data reachable independent of the fd once
+  // established, so the fd itself needn't (and, on some platforms, shouldn't)
+  // outlive this call.
+  ::close(fd);
+  if (addr == MAP_FAILED) return {nullptr, 0};
+  auto state = std::make_shared<FileMapping>();
+  state->addr = addr;
+  state->length = length;
+  std::shared_ptr<const char[]> owner(state, static_cast<const char*>(addr));
+  return {owner, static_cast<uint64_t>(length)};
+}
+#else
+inline std::pair<std::shared_ptr<const char[]>, uint64_t> TryMmapFile(
+    const std::string&) {
+  return {nullptr, 0};
+}
+#endif
+
+}  // namespace tensor_pool
+}  // namespace onnxsim
+
+#endif  // ONNXSIM_MMAP_FILE_H_

--- a/onnxsim/tensor_pool.cpp
+++ b/onnxsim/tensor_pool.cpp
@@ -83,9 +83,9 @@ struct FileMapping {
 // back to an ordinary read.
 std::pair<std::shared_ptr<const char[]>, uint64_t> TryMmapFile(
     const std::string& path) {
-  HANDLE file = ::CreateFileA(path.c_str(), GENERIC_READ, FILE_SHARE_READ,
-                              nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL,
-                              nullptr);
+  HANDLE file =
+      ::CreateFileA(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
+                    OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
   if (file == INVALID_HANDLE_VALUE) return {nullptr, 0};
   LARGE_INTEGER size;
   if (!::GetFileSizeEx(file, &size) || size.QuadPart <= 0) {
@@ -130,7 +130,7 @@ std::pair<std::shared_ptr<const char[]>, uint64_t> TryMmapFile(
     const std::string& path) {
   int fd = ::open(path.c_str(), O_RDONLY);
   if (fd < 0) return {nullptr, 0};
-  struct stat st{};
+  struct stat st {};
   if (::fstat(fd, &st) != 0 || st.st_size <= 0) {
     ::close(fd);
     return {nullptr, 0};
@@ -677,8 +677,8 @@ void TensorPool::LoadSafetensorsMmap(const std::string& path) {
   for (auto& th : tensor_headers) {
     if (th.end > data_size) {
       throw std::runtime_error(
-          "TensorPool::LoadSafetensorsMmap: '" + path + "' tensor '" +
-          th.name + "' data_offsets [" + std::to_string(th.begin) + ", " +
+          "TensorPool::LoadSafetensorsMmap: '" + path + "' tensor '" + th.name +
+          "' data_offsets [" + std::to_string(th.begin) + ", " +
           std::to_string(th.end) + ") exceed the file's data segment (" +
           std::to_string(data_size) + " bytes)");
     }

--- a/onnxsim/tensor_pool.cpp
+++ b/onnxsim/tensor_pool.cpp
@@ -4,8 +4,27 @@
 #include <cstdio>
 #include <fstream>
 #include <stdexcept>
+#include <utility>
 
 #include "tensor_pool_dtype.h"
+
+// Platform-specific file-memory-mapping for LoadSafetensorsMmap. Everything
+// falls back to LoadSafetensors's ordinary read on a platform none of these
+// branches cover (mirrors profiler.cpp's ReadCurrentRssBytes pattern), so
+// LoadSafetensorsMmap keeps working -- just without the mmap benefit -- on
+// wasm/Emscripten, which has no real demand-paged file mapping.
+#if defined(__EMSCRIPTEN__)
+// No mapping support: TryMmapFile below always reports failure.
+#elif defined(_WIN32)
+// clang-format off
+#include <windows.h>
+// clang-format on
+#else
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
 
 namespace onnxsim {
 namespace tensor_pool {
@@ -32,6 +51,109 @@ uint64_t ReadU64LE(std::istream& in) {
   for (int i = 7; i >= 0; --i) v = (v << 8) | buf[i];
   return v;
 }
+
+// Same decode as ReadU64LE, for the mmap path, which has no istream to read
+// from -- just the mapped bytes themselves.
+uint64_t DecodeU64LE(const char* buf) {
+  uint64_t v = 0;
+  for (int i = 7; i >= 0; --i) {
+    v = (v << 8) | static_cast<unsigned char>(buf[i]);
+  }
+  return v;
+}
+
+#if defined(_WIN32)
+// Owns the Windows handles/view backing a mapping; unmapped/closed together
+// once the last Entry referencing it (via the aliasing shared_ptr below) is
+// dropped.
+struct FileMapping {
+  HANDLE file = INVALID_HANDLE_VALUE;
+  HANDLE mapping = nullptr;
+  void* view = nullptr;
+  ~FileMapping() {
+    if (view != nullptr) ::UnmapViewOfFile(view);
+    if (mapping != nullptr) ::CloseHandle(mapping);
+    if (file != INVALID_HANDLE_VALUE) ::CloseHandle(file);
+  }
+};
+
+// Memory-maps `path` read-only. Returns {nullptr, 0} on any failure --
+// missing file, zero-length file (CreateFileMapping/MapViewOfFile reject
+// those), or any other OS-level error -- so LoadSafetensorsMmap can fall
+// back to an ordinary read.
+std::pair<std::shared_ptr<const char[]>, uint64_t> TryMmapFile(
+    const std::string& path) {
+  HANDLE file = ::CreateFileA(path.c_str(), GENERIC_READ, FILE_SHARE_READ,
+                              nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL,
+                              nullptr);
+  if (file == INVALID_HANDLE_VALUE) return {nullptr, 0};
+  LARGE_INTEGER size;
+  if (!::GetFileSizeEx(file, &size) || size.QuadPart <= 0) {
+    ::CloseHandle(file);
+    return {nullptr, 0};
+  }
+  HANDLE mapping =
+      ::CreateFileMappingA(file, nullptr, PAGE_READONLY, 0, 0, nullptr);
+  if (mapping == nullptr) {
+    ::CloseHandle(file);
+    return {nullptr, 0};
+  }
+  void* view = ::MapViewOfFile(mapping, FILE_MAP_READ, 0, 0, 0);
+  if (view == nullptr) {
+    ::CloseHandle(mapping);
+    ::CloseHandle(file);
+    return {nullptr, 0};
+  }
+  auto state = std::make_shared<FileMapping>();
+  state->file = file;
+  state->mapping = mapping;
+  state->view = view;
+  std::shared_ptr<const char[]> owner(state, static_cast<const char*>(view));
+  return {owner, static_cast<uint64_t>(size.QuadPart)};
+}
+#elif !defined(__EMSCRIPTEN__)
+// Owns the POSIX mapping; munmap'd once the last Entry referencing it (via
+// the aliasing shared_ptr below) is dropped.
+struct FileMapping {
+  void* addr = MAP_FAILED;
+  size_t length = 0;
+  ~FileMapping() {
+    if (addr != MAP_FAILED && length > 0) ::munmap(addr, length);
+  }
+};
+
+// Memory-maps `path` read-only. Returns {nullptr, 0} on any failure --
+// missing file, zero-length file (mmap() rejects a zero length), or any
+// other OS-level error -- so LoadSafetensorsMmap can fall back to an
+// ordinary read.
+std::pair<std::shared_ptr<const char[]>, uint64_t> TryMmapFile(
+    const std::string& path) {
+  int fd = ::open(path.c_str(), O_RDONLY);
+  if (fd < 0) return {nullptr, 0};
+  struct stat st{};
+  if (::fstat(fd, &st) != 0 || st.st_size <= 0) {
+    ::close(fd);
+    return {nullptr, 0};
+  }
+  size_t length = static_cast<size_t>(st.st_size);
+  void* addr = ::mmap(nullptr, length, PROT_READ, MAP_PRIVATE, fd, 0);
+  // The mapping keeps the file's data reachable independent of the fd once
+  // established, so the fd itself needn't (and, on some platforms, shouldn't)
+  // outlive this call.
+  ::close(fd);
+  if (addr == MAP_FAILED) return {nullptr, 0};
+  auto state = std::make_shared<FileMapping>();
+  state->addr = addr;
+  state->length = length;
+  std::shared_ptr<const char[]> owner(state, static_cast<const char*>(addr));
+  return {owner, static_cast<uint64_t>(length)};
+}
+#else
+std::pair<std::shared_ptr<const char[]>, uint64_t> TryMmapFile(
+    const std::string&) {
+  return {nullptr, 0};
+}
+#endif
 
 void AppendJsonEscaped(std::string& out, std::string_view s) {
   for (unsigned char c : s) {
@@ -515,6 +637,60 @@ void TensorPool::LoadSafetensors(const std::string& path) {
     }
     std::shared_ptr<const char[]> owner(buffer, buffer->data() + th.begin);
     std::string_view data(buffer->data() + th.begin, th.end - th.begin);
+    entries_[th.name] =
+        Entry{dtype, std::move(th.shape), std::move(owner), data};
+  }
+}
+
+void TensorPool::LoadSafetensorsMmap(const std::string& path) {
+  auto [mapped, file_size] = TryMmapFile(path);
+  if (!mapped) {
+    // No mapping support on this platform, or the mmap()/MapViewOfFile()
+    // call itself failed -- fall back to the ordinary one-copy read rather
+    // than surfacing a spurious failure for what may be a perfectly valid
+    // file.
+    LoadSafetensors(path);
+    return;
+  }
+
+  if (file_size < 8) {
+    throw std::runtime_error("TensorPool::LoadSafetensorsMmap: '" + path +
+                             "' is too small to be a safetensors file");
+  }
+  uint64_t header_len = DecodeU64LE(mapped.get());
+  if (header_len > file_size - 8) {
+    throw std::runtime_error("TensorPool::LoadSafetensorsMmap: '" + path +
+                             "' has an invalid header length");
+  }
+
+  // Unlike LoadSafetensors, the header itself doesn't need copying into a
+  // std::string first -- HeaderParser only ever reads through a
+  // std::string_view, and the mapped bytes already outlive this call via
+  // `mapped`.
+  std::string_view header(mapped.get() + 8, header_len);
+  auto tensor_headers = HeaderParser(header).Parse();
+
+  uint64_t data_start = 8 + header_len;
+  uint64_t data_size = file_size - data_start;
+
+  entries_.clear();
+  for (auto& th : tensor_headers) {
+    if (th.end > data_size) {
+      throw std::runtime_error(
+          "TensorPool::LoadSafetensorsMmap: '" + path + "' tensor '" +
+          th.name + "' data_offsets [" + std::to_string(th.begin) + ", " +
+          std::to_string(th.end) + ") exceed the file's data segment (" +
+          std::to_string(data_size) + " bytes)");
+    }
+    int32_t dtype = FromSafetensors(th.dtype);
+    if (dtype == ONNX_UNDEFINED) {
+      throw std::runtime_error("TensorPool::LoadSafetensorsMmap: '" + path +
+                               "' tensor '" + th.name +
+                               "' has unsupported dtype '" + th.dtype + "'");
+    }
+    const char* base = mapped.get() + data_start + th.begin;
+    std::shared_ptr<const char[]> owner(mapped, base);
+    std::string_view data(base, th.end - th.begin);
     entries_[th.name] =
         Entry{dtype, std::move(th.shape), std::move(owner), data};
   }

--- a/onnxsim/tensor_pool.cpp
+++ b/onnxsim/tensor_pool.cpp
@@ -6,25 +6,8 @@
 #include <stdexcept>
 #include <utility>
 
+#include "mmap_file.h"
 #include "tensor_pool_dtype.h"
-
-// Platform-specific file-memory-mapping for LoadSafetensorsMmap. Everything
-// falls back to LoadSafetensors's ordinary read on a platform none of these
-// branches cover (mirrors profiler.cpp's ReadCurrentRssBytes pattern), so
-// LoadSafetensorsMmap keeps working -- just without the mmap benefit -- on
-// wasm/Emscripten, which has no real demand-paged file mapping.
-#if defined(__EMSCRIPTEN__)
-// No mapping support: TryMmapFile below always reports failure.
-#elif defined(_WIN32)
-// clang-format off
-#include <windows.h>
-// clang-format on
-#else
-#include <fcntl.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#endif
 
 namespace onnxsim {
 namespace tensor_pool {
@@ -61,99 +44,6 @@ uint64_t DecodeU64LE(const char* buf) {
   }
   return v;
 }
-
-#if defined(_WIN32)
-// Owns the Windows handles/view backing a mapping; unmapped/closed together
-// once the last Entry referencing it (via the aliasing shared_ptr below) is
-// dropped.
-struct FileMapping {
-  HANDLE file = INVALID_HANDLE_VALUE;
-  HANDLE mapping = nullptr;
-  void* view = nullptr;
-  ~FileMapping() {
-    if (view != nullptr) ::UnmapViewOfFile(view);
-    if (mapping != nullptr) ::CloseHandle(mapping);
-    if (file != INVALID_HANDLE_VALUE) ::CloseHandle(file);
-  }
-};
-
-// Memory-maps `path` read-only. Returns {nullptr, 0} on any failure --
-// missing file, zero-length file (CreateFileMapping/MapViewOfFile reject
-// those), or any other OS-level error -- so LoadSafetensorsMmap can fall
-// back to an ordinary read.
-std::pair<std::shared_ptr<const char[]>, uint64_t> TryMmapFile(
-    const std::string& path) {
-  HANDLE file =
-      ::CreateFileA(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
-                    OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
-  if (file == INVALID_HANDLE_VALUE) return {nullptr, 0};
-  LARGE_INTEGER size;
-  if (!::GetFileSizeEx(file, &size) || size.QuadPart <= 0) {
-    ::CloseHandle(file);
-    return {nullptr, 0};
-  }
-  HANDLE mapping =
-      ::CreateFileMappingA(file, nullptr, PAGE_READONLY, 0, 0, nullptr);
-  if (mapping == nullptr) {
-    ::CloseHandle(file);
-    return {nullptr, 0};
-  }
-  void* view = ::MapViewOfFile(mapping, FILE_MAP_READ, 0, 0, 0);
-  if (view == nullptr) {
-    ::CloseHandle(mapping);
-    ::CloseHandle(file);
-    return {nullptr, 0};
-  }
-  auto state = std::make_shared<FileMapping>();
-  state->file = file;
-  state->mapping = mapping;
-  state->view = view;
-  std::shared_ptr<const char[]> owner(state, static_cast<const char*>(view));
-  return {owner, static_cast<uint64_t>(size.QuadPart)};
-}
-#elif !defined(__EMSCRIPTEN__)
-// Owns the POSIX mapping; munmap'd once the last Entry referencing it (via
-// the aliasing shared_ptr below) is dropped.
-struct FileMapping {
-  void* addr = MAP_FAILED;
-  size_t length = 0;
-  ~FileMapping() {
-    if (addr != MAP_FAILED && length > 0) ::munmap(addr, length);
-  }
-};
-
-// Memory-maps `path` read-only. Returns {nullptr, 0} on any failure --
-// missing file, zero-length file (mmap() rejects a zero length), or any
-// other OS-level error -- so LoadSafetensorsMmap can fall back to an
-// ordinary read.
-std::pair<std::shared_ptr<const char[]>, uint64_t> TryMmapFile(
-    const std::string& path) {
-  int fd = ::open(path.c_str(), O_RDONLY);
-  if (fd < 0) return {nullptr, 0};
-  struct stat st {};
-  if (::fstat(fd, &st) != 0 || st.st_size <= 0) {
-    ::close(fd);
-    return {nullptr, 0};
-  }
-  size_t length = static_cast<size_t>(st.st_size);
-  void* addr = ::mmap(nullptr, length, PROT_READ, MAP_PRIVATE, fd, 0);
-  // The mapping keeps the file's data reachable independent of the fd once
-  // established, so the fd itself needn't (and, on some platforms, shouldn't)
-  // outlive this call.
-  ::close(fd);
-  if (addr == MAP_FAILED) return {nullptr, 0};
-  auto state = std::make_shared<FileMapping>();
-  state->addr = addr;
-  state->length = length;
-  std::shared_ptr<const char[]> owner(state, static_cast<const char*>(addr));
-  return {owner, static_cast<uint64_t>(length)};
-}
-#else
-std::pair<std::shared_ptr<const char[]>, uint64_t> TryMmapFile(
-    const std::string&) {
-  return {nullptr, 0};
-}
-#endif
 
 void AppendJsonEscaped(std::string& out, std::string_view s) {
   for (unsigned char c : s) {

--- a/onnxsim/tensor_pool.h
+++ b/onnxsim/tensor_pool.h
@@ -243,6 +243,32 @@ class TensorPool {
   // an unrecognized magic/version, or a malformed header.
   std::vector<std::string> LoadGGUF(const std::string& path);
 
+  // Like LoadGGUF, but memory-maps `path` (mmap() on POSIX, MapViewOfFile()
+  // on Windows -- the same TryMmapFile helper LoadSafetensorsMmap uses, see
+  // mmap_file.h) instead of doing its own seek + read per included tensor.
+  // The header/metadata/tensor-info section is still parsed exactly as
+  // LoadGGUF parses it (just from the mapped bytes instead of an ifstream);
+  // only what happens per tensor differs: an *included* tensor's Entry
+  // becomes a direct view into the mapped file via the usual shared_ptr-
+  // aliasing scheme (see Entry::owner) rather than a copied std::string, and
+  // a *skipped* tensor's bytes are never even faulted into memory, since
+  // mapping the file only reserves address space -- pages are faulted in
+  // lazily, on first touch, so an untouched skipped tensor's pages are
+  // simply never read at all (better than LoadGGUF's own already-selective
+  // seek + read, which at least issues no I/O for skipped tensors but still
+  // pays a syscall per included one).
+  //
+  // Falls back to an ordinary LoadGGUF call -- silently, with no memory-
+  // mapping benefit but identical results -- when this platform has no
+  // memory-mapping support (e.g. Emscripten/wasm) or the underlying mmap()/
+  // MapViewOfFile() call fails. Returns the same skipped-tensor-names list,
+  // and throws under the same conditions, as LoadGGUF.
+  //
+  // Same caveat as LoadSafetensorsMmap: the mapped bytes alias `path` on
+  // disk for as long as the mapping lives, so modifying or truncating the
+  // file out from under a live mapping is undefined behavior.
+  std::vector<std::string> LoadGGUFMmap(const std::string& path);
+
  private:
   std::map<std::string, Entry> entries_;
   HashAlgorithm hash_algorithm_ = HashAlgorithm::kBlake3;

--- a/onnxsim/tensor_pool.h
+++ b/onnxsim/tensor_pool.h
@@ -168,6 +168,34 @@ class TensorPool {
   // malformed header, or a tensor whose data_offsets fall outside the file.
   void LoadSafetensors(const std::string& path);
 
+  // Like LoadSafetensors, but memory-maps `path` (mmap() on POSIX,
+  // MapViewOfFile() on Windows) instead of reading it into a heap buffer:
+  // every Entry's data is a direct view into the OS page cache backing the
+  // file, so this makes *zero* tensor-data copies -- not even
+  // LoadSafetensors's one whole-file read -- and pages are faulted in
+  // lazily, on first touch, rather than the whole file being made resident
+  // up front. The mapping itself is kept alive by the same shared_ptr-
+  // aliasing scheme as LoadSafetensors (see Entry::owner): it lives for as
+  // long as any Entry (or view derived from one) this call produced is
+  // reachable, and is unmapped automatically once the last one is dropped.
+  //
+  // Falls back to an ordinary LoadSafetensors call -- silently, with no
+  // memory-mapping benefit but identical results -- when this platform has
+  // no memory-mapping support (e.g. Emscripten/wasm) or the underlying
+  // mmap()/MapViewOfFile() call fails (e.g. `path` is empty, or isn't a
+  // regular seekable file). Throws std::runtime_error on I/O failure, a
+  // malformed header, or a tensor whose data_offsets fall outside the file
+  // -- same as LoadSafetensors.
+  //
+  // Caveat inherent to memory-mapping, unlike LoadSafetensors's own private
+  // copy: the mapped bytes alias `path` on disk for as long as the mapping
+  // lives. Modifying or truncating the file out from under a live mapping is
+  // undefined behavior (a SIGBUS on POSIX if a mapped page is truncated
+  // away; stale or torn bytes if its content is rewritten in place) -- only
+  // use this for a file this process (or a well-behaved peer) won't mutate
+  // while the pool is alive.
+  void LoadSafetensorsMmap(const std::string& path);
+
   // --- GGUF (https://github.com/ggml-org/ggml/blob/master/docs/gguf.md)
   // format, version 3 -- implemented in tensor_pool_gguf.cpp, a separate
   // translation unit from the safetensors codec above, since the two file

--- a/onnxsim/tensor_pool_gguf.cpp
+++ b/onnxsim/tensor_pool_gguf.cpp
@@ -5,10 +5,13 @@
 #include <algorithm>
 #include <cstdint>
 #include <fstream>
+#include <istream>
 #include <optional>
 #include <stdexcept>
+#include <streambuf>
 
 #include "gguf_dtype.h"
+#include "mmap_file.h"
 #include "tensor_pool.h"
 
 namespace onnxsim {
@@ -197,6 +200,55 @@ constexpr uint64_t kMaxTensorCount = 10'000'000;
 constexpr uint64_t kMaxMetadataCount = 10'000'000;
 constexpr uint32_t kMaxDims =
     8;  // ggml's own GGML_MAX_DIMS is 4; generous slack
+
+// A read-only std::streambuf backed directly by mapped file bytes, so
+// LoadGGUFMmap can reuse every header/metadata/tensor-info parsing helper
+// above (ReadU32LE, ReadGGUFString, SkipMetadataValue, ...) unchanged --
+// they only need a std::istream, not specifically an ifstream. Unlike the
+// default std::streambuf, this overrides seekoff/seekpos: LoadGGUF's parsing
+// relies on in.tellg() (to find where the tensor-info section ends) working
+// correctly, which the base class does not support on its own.
+class MemStreamBuf : public std::streambuf {
+ public:
+  MemStreamBuf(const char* base, size_t size)
+      : begin_(base), end_(base + size) {
+    char* p = const_cast<char*>(begin_);
+    setg(p, p, const_cast<char*>(end_));
+  }
+
+ protected:
+  pos_type seekoff(off_type off, std::ios_base::seekdir dir,
+                   std::ios_base::openmode which) override {
+    if ((which & std::ios_base::in) == 0) return pos_type(off_type(-1));
+    const char* base;
+    switch (dir) {
+      case std::ios_base::beg:
+        base = begin_;
+        break;
+      case std::ios_base::cur:
+        base = gptr();
+        break;
+      case std::ios_base::end:
+        base = end_;
+        break;
+      default:
+        return pos_type(off_type(-1));
+    }
+    const char* new_pos = base + off;
+    if (new_pos < begin_ || new_pos > end_) return pos_type(off_type(-1));
+    setg(const_cast<char*>(begin_), const_cast<char*>(new_pos),
+         const_cast<char*>(end_));
+    return pos_type(new_pos - begin_);
+  }
+
+  pos_type seekpos(pos_type pos, std::ios_base::openmode which) override {
+    return seekoff(off_type(pos), std::ios_base::beg, which);
+  }
+
+ private:
+  const char* begin_;
+  const char* end_;
+};
 
 }  // namespace
 
@@ -394,6 +446,101 @@ std::vector<std::string> TensorPool::LoadGGUF(const std::string& path) {
     // first, onnx's shape is outermost-first, for the same contiguous bytes.
     std::vector<int64_t> shape(info.ne.rbegin(), info.ne.rend());
     Add(info.name, onnx_dtype, std::move(shape), std::move(bytes));
+  }
+  return skipped;
+}
+
+std::vector<std::string> TensorPool::LoadGGUFMmap(const std::string& path) {
+  auto [mapped, file_size] = TryMmapFile(path);
+  if (!mapped) {
+    // No mapping support on this platform, or the mmap()/MapViewOfFile()
+    // call itself failed -- fall back to the ordinary seek + read path
+    // rather than surfacing a spurious failure for what may be a perfectly
+    // valid file.
+    return LoadGGUF(path);
+  }
+
+  MemStreamBuf buf(mapped.get(), static_cast<size_t>(file_size));
+  std::istream in(&buf);
+
+  uint32_t magic = ReadU32LE(in, path);
+  if (magic != kMagic) {
+    FailRead(path, "not a GGUF file (bad magic)");
+  }
+  uint32_t version = ReadU32LE(in, path);
+  if (version != kSupportedVersion) {
+    FailRead(path, "GGUF version " + std::to_string(version) +
+                       " is not supported (only version " +
+                       std::to_string(kSupportedVersion) + " is)");
+  }
+  uint64_t tensor_count = ReadU64LE(in, path);
+  uint64_t metadata_kv_count = ReadU64LE(in, path);
+  if (tensor_count > kMaxTensorCount) {
+    FailRead(path, "implausible tensor_count (" + std::to_string(tensor_count) +
+                       "), likely corrupt");
+  }
+  if (metadata_kv_count > kMaxMetadataCount) {
+    FailRead(path, "implausible metadata_kv_count (" +
+                       std::to_string(metadata_kv_count) + "), likely corrupt");
+  }
+
+  uint64_t alignment = kDefaultAlignment;
+  for (uint64_t i = 0; i < metadata_kv_count; ++i) {
+    std::string key = ReadGGUFString(in, path);
+    uint32_t value_type = ReadU32LE(in, path);
+    std::optional<uint64_t> numeric = SkipMetadataValue(in, path, value_type);
+    if (key == "general.alignment" && numeric.has_value() && *numeric != 0) {
+      alignment = *numeric;
+    }
+  }
+
+  std::vector<TensorInfo> infos;
+  infos.reserve(tensor_count);
+  for (uint64_t i = 0; i < tensor_count; ++i) {
+    TensorInfo info;
+    info.name = ReadGGUFString(in, path);
+    uint32_t n_dims = ReadU32LE(in, path);
+    if (n_dims > kMaxDims) {
+      FailRead(path, "tensor '" + info.name +
+                         "' has an implausible dimension count (" +
+                         std::to_string(n_dims) + ")");
+    }
+    info.ne.resize(n_dims);
+    for (uint32_t d = 0; d < n_dims; ++d) info.ne[d] = ReadU64LE(in, path);
+    info.ggml_type = ReadU32LE(in, path);
+    info.offset = ReadU64LE(in, path);
+    infos.push_back(std::move(info));
+  }
+
+  uint64_t header_end = static_cast<uint64_t>(in.tellg());
+  uint64_t data_section_start = AlignUp(header_end, alignment);
+
+  entries_.clear();
+  std::vector<std::string> skipped;
+  for (const auto& info : infos) {
+    int32_t onnx_dtype;
+    if (!gguf::ToOnnx(info.ggml_type, &onnx_dtype)) {
+      skipped.push_back(info.name);
+      continue;
+    }
+    size_t elem_size = gguf::ElementSize(info.ggml_type);
+    uint64_t nelems = 1;
+    for (uint64_t d : info.ne) nelems *= d;
+    uint64_t nbytes = nelems * elem_size;
+    uint64_t abs_offset = data_section_start + info.offset;
+    if (abs_offset > file_size || nbytes > file_size - abs_offset) {
+      FailRead(path, "tensor '" + info.name +
+                         "' data range extends past the end of the file");
+    }
+
+    const char* base = mapped.get() + abs_offset;
+    std::shared_ptr<const char[]> owner(mapped, base);
+    std::string_view data(base, nbytes);
+
+    // Reverse of SaveGGUF's reversal: ggml's ne[] is innermost-dimension-
+    // first, onnx's shape is outermost-first, for the same contiguous bytes.
+    std::vector<int64_t> shape(info.ne.rbegin(), info.ne.rend());
+    Add(info.name, onnx_dtype, std::move(shape), std::move(owner), data);
   }
   return skipped;
 }

--- a/onnxsim/tensor_pool_gguf_test.cpp
+++ b/onnxsim/tensor_pool_gguf_test.cpp
@@ -224,6 +224,136 @@ void TestSkipsUnsupportedDtype() {
   std::remove(path.c_str());
 }
 
+void TestLoadGGUFMmapRoundTrip() {
+  // Mirrors TestRoundTrip, but through the mmap-backed loader -- same
+  // dimension-order and byte-content checks, to confirm the mapped path
+  // parses identically to the seek+read path, not just that it doesn't
+  // crash.
+  TensorPool pool;
+  pool.Add("weight", ONNX_FLOAT, {2, 3}, std::string(24, '\x11'));
+  pool.Add("bias", ONNX_INT64, {4}, std::string(32, '\x22'));
+  pool.Add("scalar", ONNX_INT8, {}, std::string(1, '\x33'));
+
+  std::string path = TempPath("_mmap_roundtrip.gguf");
+  pool.SaveGGUF(path, {{"general.architecture", "onnxsim-test"}});
+
+  TensorPool loaded;
+  auto skipped = loaded.LoadGGUFMmap(path);
+  Check(skipped.empty(), "mmap: nothing skipped for an all-raw-dtype pool");
+  Check(loaded.size() == 3, "mmap: all three tensors loaded");
+
+  const Entry* w = loaded.Find("weight");
+  Check(w != nullptr, "mmap: weight present");
+  if (w != nullptr) {
+    Check(w->dtype == ONNX_FLOAT, "mmap: weight dtype round-trips");
+    Check(w->shape == std::vector<int64_t>({2, 3}),
+          "mmap: weight shape round-trips in the RIGHT order (not "
+          "transposed to {3, 2})");
+    Check(w->data == std::string(24, '\x11'), "mmap: weight bytes round-trip");
+  }
+
+  const Entry* b = loaded.Find("bias");
+  Check(b != nullptr && b->dtype == ONNX_INT64 &&
+            b->shape == std::vector<int64_t>({4}) &&
+            b->data == std::string(32, '\x22'),
+        "mmap: bias round-trips");
+
+  const Entry* s = loaded.Find("scalar");
+  Check(s != nullptr && s->shape.empty() && s->data == std::string(1, '\x33'),
+        "mmap: rank-0 (scalar) tensor round-trips");
+
+  std::remove(path.c_str());
+}
+
+void TestLoadGGUFMmapSkipsUnsupportedDtype() {
+  // Same hand-built file as TestSkipsUnsupportedDtype (one raw F32 tensor,
+  // one made-up quantized type this pool can't represent), loaded through
+  // LoadGGUFMmap -- confirms the mapped path skips-and-reports exactly like
+  // the seek+read path rather than e.g. faulting trying to decode it.
+  std::string path = TempPath("_mmap_quantized.gguf");
+  {
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    auto write_string = [&](const std::string& s) {
+      WriteLE<uint64_t>(out, s.size());
+      out.write(s.data(), static_cast<std::streamsize>(s.size()));
+    };
+
+    WriteLE<uint32_t>(out, kMagic);
+    WriteLE<uint32_t>(out, kSupportedVersion);
+    WriteLE<uint64_t>(out, 2);  // tensor_count
+    WriteLE<uint64_t>(out, 0);  // metadata_kv_count
+
+    write_string("raw");
+    WriteLE<uint32_t>(out, 1);
+    WriteLE<uint64_t>(out, 2);
+    WriteLE<uint32_t>(out, GGML_TYPE_F32);
+    WriteLE<uint64_t>(out, 0);
+
+    write_string("quant");
+    WriteLE<uint32_t>(out, 1);
+    WriteLE<uint64_t>(out, 32);
+    WriteLE<uint32_t>(out, 2);  // GGML_TYPE_Q4_0
+    WriteLE<uint64_t>(out, kDefaultAlignment);
+
+    uint64_t header_end = static_cast<uint64_t>(out.tellp());
+    uint64_t data_start = (header_end + kDefaultAlignment - 1) /
+                          kDefaultAlignment * kDefaultAlignment;
+    for (uint64_t i = header_end; i < data_start; ++i) out.put('\0');
+
+    WriteLE<float>(out, 1.5f);
+    WriteLE<float>(out, -2.5f);
+    uint64_t cur = static_cast<uint64_t>(out.tellp()) - data_start;
+    for (uint64_t i = cur; i < kDefaultAlignment; ++i) out.put('\0');
+    for (int i = 0; i < 18; ++i) out.put('\xAB');
+  }
+
+  TensorPool pool;
+  auto skipped = pool.LoadGGUFMmap(path);
+  Check(skipped.size() == 1 && skipped[0] == "quant",
+        "mmap: the quantized tensor is skipped and reported by name");
+  Check(pool.size() == 1, "mmap: only the raw tensor made it into the pool");
+  const Entry* raw = pool.Find("raw");
+  Check(raw != nullptr && raw->dtype == ONNX_FLOAT &&
+            raw->shape == std::vector<int64_t>({2}),
+        "mmap: the raw tensor itself loaded correctly despite its sibling "
+        "being skipped");
+  Check(pool.Find("quant") == nullptr,
+        "mmap: the skipped tensor is definitely not silently present with "
+        "garbage data");
+  std::remove(path.c_str());
+}
+
+void TestLoadGGUFMmapRejectsBadMagic() {
+  std::string path = TempPath("_mmap_bad_magic.gguf");
+  std::ofstream out(path, std::ios::binary);
+  WriteLE<uint32_t>(out, 0xDEADBEEF);
+  WriteLE<uint32_t>(out, kSupportedVersion);
+  out.close();
+  TensorPool pool;
+  bool threw = false;
+  try {
+    pool.LoadGGUFMmap(path);
+  } catch (const std::runtime_error&) {
+    threw = true;
+  }
+  Check(threw, "mmap: bad magic is rejected");
+  std::remove(path.c_str());
+}
+
+void TestLoadGGUFMmapMissingFileFallsBackAndThrows() {
+  // No such file: TryMmapFile fails, so this exercises the fallback to
+  // LoadGGUF, which should throw its own "cannot open" error rather than
+  // silently succeeding.
+  TensorPool pool;
+  bool threw = false;
+  try {
+    pool.LoadGGUFMmap(TempPath("_mmap_missing.gguf"));
+  } catch (const std::runtime_error&) {
+    threw = true;
+  }
+  Check(threw, "mmap: loading a missing file throws (via read fallback)");
+}
+
 void TestRejectsBadMagicAndVersion() {
   {
     std::string path = TempPath("_bad_magic.gguf");
@@ -284,6 +414,10 @@ int main() {
   TestSkipsUnsupportedDtype();
   TestRejectsBadMagicAndVersion();
   TestRejectsUnrepresentableDtype();
+  TestLoadGGUFMmapRoundTrip();
+  TestLoadGGUFMmapSkipsUnsupportedDtype();
+  TestLoadGGUFMmapRejectsBadMagic();
+  TestLoadGGUFMmapMissingFileFallsBackAndThrows();
 
   if (g_failures == 0) {
     std::printf("tensor_pool_gguf_test: all checks passed\n");

--- a/onnxsim/tensor_pool_test.cpp
+++ b/onnxsim/tensor_pool_test.cpp
@@ -128,6 +128,107 @@ void TestAliasingIsZeroCopyPerTensor() {
   std::remove(path.c_str());
 }
 
+void TestLoadSafetensorsMmapRoundTrip() {
+  // Same round trip as TestRoundTrip, but through the mmap-backed loader --
+  // confirms it parses the header and carves out entries identically to the
+  // read-based path, not just that it doesn't crash.
+  TensorPool pool;
+  pool.Add("weight.0", ONNX_FLOAT, {2, 3},
+           std::string("\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b"
+                       "\x0c\x0d\x0d\x0d\x0e\x0e\x0e\x0e\x0f\x0f\x0f\x0f",
+                       24));
+  pool.Add("bias", ONNX_INT64, {3}, std::string(24, '\x2a'));
+  pool.Add("scalar", ONNX_BOOL, {}, std::string(1, '\x01'));
+  pool.Add("empty", ONNX_FLOAT, {0}, std::string());
+
+  std::string path = TempPath("_mmap_roundtrip.safetensors");
+  pool.SaveSafetensors(path);
+
+  TensorPool loaded;
+  loaded.LoadSafetensorsMmap(path);
+  Check(loaded.size() == 4, "mmap-loaded pool holds 4 entries");
+
+  const Entry* w = loaded.Find("weight.0");
+  Check(w != nullptr, "weight.0 present after mmap load");
+  if (w != nullptr) {
+    Check(w->dtype == ONNX_FLOAT, "weight.0 dtype round-trips via mmap");
+    Check(w->shape == std::vector<int64_t>({2, 3}),
+          "weight.0 shape round-trips via mmap");
+    Check(w->data == std::string_view(
+                         "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b"
+                         "\x0c\x0d\x0d\x0d\x0e\x0e\x0e\x0e\x0f\x0f\x0f\x0f",
+                         24),
+          "weight.0 bytes round-trip exactly via mmap");
+  }
+
+  const Entry* b = loaded.Find("bias");
+  Check(b != nullptr && b->dtype == ONNX_INT64 &&
+            b->shape == std::vector<int64_t>({3}) && b->nbytes() == 24,
+        "bias round-trips via mmap");
+
+  const Entry* e = loaded.Find("empty");
+  Check(e != nullptr && e->nbytes() == 0,
+        "zero-size tensor round-trips via mmap");
+
+  std::remove(path.c_str());
+}
+
+void TestLoadSafetensorsMmapAliasingIsSharedMapping() {
+  // Mirrors TestAliasingIsZeroCopyPerTensor: every Entry from one mmap load
+  // should be a view into the same mapping, at adjacent offsets, not
+  // independent allocations.
+  TensorPool pool;
+  pool.Add("a", ONNX_UINT8, {4}, std::string(4, 'a'));
+  pool.Add("b", ONNX_UINT8, {4}, std::string(4, 'b'));
+  std::string path = TempPath("_mmap_alias.safetensors");
+  pool.SaveSafetensors(path);
+
+  TensorPool loaded;
+  loaded.LoadSafetensorsMmap(path);
+  const Entry* ea = loaded.Find("a");
+  const Entry* eb = loaded.Find("b");
+  Check(ea != nullptr && eb != nullptr, "both tensors present via mmap");
+  if (ea != nullptr && eb != nullptr) {
+    Check(static_cast<const void*>(ea->owner.get()) == ea->data.data(),
+          "a: owner aliases its own data pointer (mmap)");
+    Check(eb->data.data() - ea->data.data() ==
+              static_cast<ptrdiff_t>(ea->nbytes()),
+          "a and b are adjacent views into one mmap'd region");
+  }
+  std::remove(path.c_str());
+}
+
+void TestLoadSafetensorsMmapRejectsMalformedFile() {
+  std::string path = TempPath("_mmap_malformed.safetensors");
+  {
+    std::ofstream out(path, std::ios::binary);
+    out << "not a safetensors file";
+  }
+  TensorPool pool;
+  bool threw = false;
+  try {
+    pool.LoadSafetensorsMmap(path);
+  } catch (const std::runtime_error&) {
+    threw = true;
+  }
+  Check(threw, "mmap-loading a non-safetensors file throws");
+  std::remove(path.c_str());
+}
+
+void TestLoadSafetensorsMmapMissingFileFallsBackAndThrows() {
+  // No such file: TryMmapFile fails, so this exercises the fallback to
+  // LoadSafetensors, which should throw its own "cannot open" error rather
+  // than silently succeeding.
+  TensorPool pool;
+  bool threw = false;
+  try {
+    pool.LoadSafetensorsMmap(TempPath("_mmap_missing.safetensors"));
+  } catch (const std::runtime_error&) {
+    threw = true;
+  }
+  Check(threw, "mmap-loading a missing file throws (via read fallback)");
+}
+
 void TestHeaderPrefixSize() {
   TensorPool pool;
   pool.Add("x", ONNX_FLOAT, {1}, std::string(4, '\0'));
@@ -261,6 +362,10 @@ void TestContentHash() {
 int main() {
   TestRoundTrip();
   TestAliasingIsZeroCopyPerTensor();
+  TestLoadSafetensorsMmapRoundTrip();
+  TestLoadSafetensorsMmapAliasingIsSharedMapping();
+  TestLoadSafetensorsMmapRejectsMalformedFile();
+  TestLoadSafetensorsMmapMissingFileFallsBackAndThrows();
   TestHeaderPrefixSize();
   TestRejectsUnrepresentableDtype();
   TestRejectsMalformedFile();


### PR DESCRIPTION
Implement a zero-copy memory-mapped safetensors file loader that uses platform-specific APIs (mmap on POSIX, MapViewOfFile on Windows) to avoid reading tensor data into heap buffers.

## Summary

This change adds `TensorPool::LoadSafetensorsMmap()`, which memory-maps safetensors files instead of reading them entirely into memory. Tensor data is accessed as direct views into the OS page cache, enabling lazy page faulting and eliminating the whole-file read copy that `LoadSafetensors()` performs. The mapping lifetime is managed via the same `shared_ptr`-aliasing scheme as the existing loader, so it's automatically unmapped when all derived Entry objects are dropped.

## Key Changes

- **Platform-specific mmap support**: Conditional compilation for Windows (`MapViewOfFile`), POSIX (`mmap`), and Emscripten (no-op fallback)
  - Windows: `FileMapping` struct owns `HANDLE` objects; destructor closes them
  - POSIX: `FileMapping` struct owns mapped region; destructor calls `munmap()`
  - Emscripten: `TryMmapFile()` always returns failure, triggering fallback to `LoadSafetensors()`

- **New utility function `DecodeU64LE()`**: Decodes little-endian 64-bit integers directly from mapped bytes (mirrors `ReadU64LE()` for the istream-based path)

- **`TryMmapFile()` implementation**: Returns `{nullptr, 0}` on any failure (missing file, zero-length file, OS errors), allowing graceful fallback to ordinary read-based loading

- **`LoadSafetensorsMmap()` method**: 
  - Attempts to memory-map the file; falls back to `LoadSafetensors()` if mapping fails
  - Parses header from mapped bytes (no copy needed)
  - Creates Entry objects with `shared_ptr`-aliased owners pointing into the mapped region
  - Validates header length and tensor data offsets before creating entries

- **Comprehensive test coverage**:
  - Round-trip test verifying mmap-loaded tensors match saved data exactly
  - Aliasing test confirming all entries share the same underlying mapping
  - Malformed file rejection test
  - Missing file fallback test

## Implementation Details

- Uses `std::shared_ptr` aliasing constructor to bind Entry ownership to the mapped region while allowing data views to point into it
- Header parsing reuses existing `HeaderParser` logic; only the data source differs
- Graceful degradation: platforms without mmap support or failed mmap calls silently fall back to `LoadSafetensors()` with identical semantics
- No changes to existing `LoadSafetensors()` or file format handling; this is purely an alternative loading path

https://claude.ai/code/session_01FHKfWpwrXTp4pu6QDgGdAW