### PR TITLE
Add static (calibration-based) INT8 quantization pass for MatMul/Gemm

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -1,3 +1,9 @@
+from onnxsim.calibration import (
+    calibrate,
+    generate_random_calibration_data,
+    load_huggingface_calibration_data,
+    quantize_static,
+)
 from onnxsim.onnx_simplifier import (
     export_gguf,
     export_safetensors,
@@ -14,6 +20,10 @@ from .version import version as __version__
 __all__ = [
     "simplify",
     "quantize_dynamic",
+    "quantize_static",
+    "calibrate",
+    "generate_random_calibration_data",
+    "load_huggingface_calibration_data",
     "main",
     "import_onnx_schemas",
     "export_safetensors",

--- a/onnxsim/calibration.py
+++ b/onnxsim/calibration.py
@@ -1,0 +1,332 @@
+"""Calibration data generation and static (calibration-based) quantization.
+
+``onnxsim.quantize_dynamic`` needs no calibration data: it defers the
+activation's quantization range to a ``DynamicQuantizeLinear`` computed fresh
+on every inference. Static quantization instead *fixes* that range ahead of
+time, from representative data -- usually a better trade (no per-inference
+range computation) but only as good as the calibration data it is given.
+
+This module provides two calibration data sources, meant to be used in order
+as a model moves from a quick smoke test towards real deployment:
+
+- :func:`generate_random_calibration_data` -- synthetic random data. Works
+  out of the box with no external dependency or dataset to find, so
+  :func:`quantize_static` falls back to it automatically. Good for checking
+  the quantization pipeline itself works; a poor proxy for a real model's
+  actual activation statistics.
+- :func:`load_huggingface_calibration_data` -- real examples pulled from a
+  Hugging Face Hub dataset (needs the optional ``datasets`` package). Gives
+  calibration ranges that actually reflect deployment-time data, at the cost
+  of needing a dataset whose columns can be matched to the model's inputs.
+
+:func:`calibrate` runs the float model over either data source through
+ONNX Runtime to produce the ``{tensor_name: (min, max)}`` ranges
+:func:`onnxsim.quantize_static` (this module's main entry point) needs.
+"""
+
+import itertools
+from typing import Dict, List, Optional, Sequence, Tuple, Union
+
+import numpy as np
+import onnx
+
+import onnxsim.onnxsim_cpp2py_export as C
+
+Tensors = Dict[str, np.ndarray]
+
+_ELEM_TYPE_TO_NP = {
+    onnx.TensorProto.FLOAT: np.float32,
+    onnx.TensorProto.DOUBLE: np.float64,
+    onnx.TensorProto.FLOAT16: np.float16,
+    onnx.TensorProto.INT64: np.int64,
+    onnx.TensorProto.INT32: np.int32,
+    onnx.TensorProto.INT16: np.int16,
+    onnx.TensorProto.INT8: np.int8,
+    onnx.TensorProto.UINT8: np.uint8,
+    onnx.TensorProto.BOOL: np.bool_,
+}
+
+
+def _input_specs(model: onnx.ModelProto) -> List[Tuple[str, List[int], type]]:
+    """(name, shape, np_dtype) for every graph input that is not an initializer.
+
+    Dynamic dimensions (including an unset/symbolic batch dimension) are
+    fixed to 1, so the returned shapes are always fully concrete.
+    """
+    initializer_names = {i.name for i in model.graph.initializer}
+    specs = []
+    for ipt in model.graph.input:
+        if ipt.name in initializer_names:
+            continue
+        shape = [
+            dim.dim_value if dim.dim_value > 0 else 1
+            for dim in ipt.type.tensor_type.shape.dim
+        ]
+        np_dtype = _ELEM_TYPE_TO_NP.get(ipt.type.tensor_type.elem_type, np.float32)
+        specs.append((ipt.name, shape, np_dtype))
+    return specs
+
+
+def generate_random_calibration_data(
+    model: Union[str, onnx.ModelProto],
+    num_samples: int = 8,
+    seed: int = 0,
+) -> List[Tensors]:
+    """
+    Generate ``num_samples`` batches of random input data matching ``model``'s
+    input shapes/dtypes: a calibration data source that works with no
+    external dependency, for a first pass through the static quantization
+    pipeline before wiring up real representative data (e.g.
+    :func:`load_huggingface_calibration_data`).
+
+    Floating-point inputs are drawn from a standard normal distribution (a
+    closer proxy for typical activation/feature statistics than a uniform
+    [0, 1) draw); integer and boolean inputs are filled with zeros, a safe
+    default when random values are unlikely to be valid indices (e.g. token
+    ids) -- pass your own calibration data for a model whose behavior
+    actually depends on integer input values.
+
+    :param model: onnx ModelProto object or file path
+    :param num_samples: number of calibration batches to generate
+    :param seed: seed for reproducibility
+    :returns: a list of ``{input_name: np.ndarray}`` dicts, one per batch
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    specs = _input_specs(model)
+    rng = np.random.default_rng(seed)
+    batches = []
+    for _ in range(num_samples):
+        batch = {}
+        for name, shape, np_dtype in specs:
+            if np.issubdtype(np_dtype, np.floating):
+                batch[name] = rng.standard_normal(shape).astype(np_dtype)
+            else:
+                batch[name] = np.zeros(shape, dtype=np_dtype)
+        batches.append(batch)
+    return batches
+
+
+# A short list of common Hugging Face dataset column names for each of a few
+# common ONNX input names, tried (after `field_map` and an exact name match)
+# by load_huggingface_calibration_data before giving up on an input.
+_COMMON_COLUMN_ALIASES = {
+    "pixel_values": ["pixel_values", "image", "img"],
+    "input_ids": ["input_ids", "input_id", "tokens", "text"],
+    "attention_mask": ["attention_mask", "mask"],
+    "input_values": ["input_values", "audio", "speech"],
+}
+
+
+def load_huggingface_calibration_data(
+    dataset: str,
+    model: Union[str, onnx.ModelProto],
+    num_samples: int = 8,
+    split: str = "train",
+    field_map: Optional[Dict[str, str]] = None,
+    seed: int = 0,
+) -> List[Tensors]:
+    """
+    Best-effort loader that pulls ``num_samples`` real examples from a
+    Hugging Face ``datasets`` dataset and adapts them into calibration
+    batches for ``model``. Requires the optional ``datasets`` package
+    (``pip install datasets``).
+
+    Matching a dataset's columns to a model's ONNX input names is inherently
+    ambiguous -- there is no schema linking the two -- so this only handles
+    the common case. For each input, in order: an explicit ``field_map``
+    entry, a same-named column, then a short list of common aliases (e.g.
+    ONNX input "pixel_values" matches a dataset column named "image"). If an
+    input still cannot be matched, this raises ``ValueError`` naming it
+    rather than silently feeding it random or zero data -- pass ``field_map``
+    to resolve the mismatch, or fall back to
+    :func:`generate_random_calibration_data` (or your own preprocessing
+    pipeline, feeding its output directly to :func:`quantize_static` /
+    :func:`calibrate` as ``calibration_data``) instead of this loader.
+
+    A matched column's values are converted to a numpy array and cast to the
+    target input's dtype; this only handles a column that is already a plain
+    (optionally ragged, single-example) tensor, so a variable-length sequence
+    column (e.g. un-padded tokenized text) needs its own tokenizer/padding
+    step before it can be used here.
+
+    :param dataset: a Hugging Face Hub dataset id, e.g. "mnist" or "cifar10"
+    :param model: onnx ModelProto object or file path
+    :param num_samples: number of examples to pull from the dataset
+    :param split: dataset split to sample from
+    :param field_map: optional explicit ``{onnx_input_name: dataset_column_name}``
+            overrides, for a dataset whose columns don't already match by
+            name or common alias
+    :param seed: seed used to shuffle the dataset before sampling
+    :returns: a list of ``{input_name: np.ndarray}`` dicts, one per example
+    """
+    try:
+        import datasets as hf_datasets
+    except ImportError as e:
+        raise ImportError(
+            "load_huggingface_calibration_data needs the optional 'datasets' "
+            "package: pip install datasets"
+        ) from e
+
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    specs = _input_specs(model)
+
+    ds = hf_datasets.load_dataset(dataset, split=split, streaming=True)
+    ds = ds.shuffle(seed=seed, buffer_size=max(num_samples * 4, 64))
+    examples = list(itertools.islice(ds, num_samples))
+    if not examples:
+        raise ValueError(f'Dataset "{dataset}" split "{split}" yielded no examples.')
+    columns = set(examples[0].keys())
+
+    resolved: Dict[str, str] = {}
+    unmatched: List[str] = []
+    for name, _shape, _np_dtype in specs:
+        if field_map and name in field_map:
+            resolved[name] = field_map[name]
+            continue
+        candidates = [name] + _COMMON_COLUMN_ALIASES.get(name, [])
+        match = next((c for c in candidates if c in columns), None)
+        if match is None:
+            match = next((c for c in columns if c.lower() == name.lower()), None)
+        if match is None:
+            unmatched.append(name)
+        else:
+            resolved[name] = match
+
+    if unmatched:
+        raise ValueError(
+            'Could not match onnx input(s) {} to any column of dataset "{}" '
+            "(columns: {}). Pass field_map={{onnx_input_name: "
+            "dataset_column_name}} to resolve manually.".format(
+                unmatched, dataset, sorted(columns)
+            )
+        )
+
+    batches = []
+    for example in examples:
+        batch = {}
+        for name, shape, np_dtype in specs:
+            arr = np.asarray(example[resolved[name]], dtype=np_dtype)
+            if arr.shape != tuple(shape):
+                if arr.size != int(np.prod(shape)):
+                    raise ValueError(
+                        f'Dataset "{dataset}" column "{resolved[name]}" has '
+                        f"{arr.size} elements per example, which does not "
+                        f'match onnx input "{name}"\'s shape {shape} '
+                        f"({int(np.prod(shape))} elements). Pass your own "
+                        "preprocessing pipeline's output as calibration_data "
+                        "instead."
+                    )
+                arr = arr.reshape(shape)
+            batch[name] = arr
+        batches.append(batch)
+    return batches
+
+
+def calibrate(
+    model: Union[str, onnx.ModelProto],
+    calibration_data: Sequence[Tensors],
+    providers: Optional[Sequence[str]] = None,
+) -> Dict[str, Tuple[float, float]]:
+    """
+    Run the float ``model`` over every batch in ``calibration_data`` through
+    ONNX Runtime, recording each quantizable activation's observed (min, max)
+    range across all batches -- the calibration ranges
+    :func:`onnxsim.quantize_static` needs.
+
+    :param model: onnx ModelProto object or file path
+    :param calibration_data: representative input batches, e.g. from
+            :func:`generate_random_calibration_data` or
+            :func:`load_huggingface_calibration_data`
+    :param providers: onnxruntime execution providers to run calibration on
+            (defaults to onnxruntime's own default provider selection)
+    :returns: ``{tensor_name: (min, max)}`` for every tensor
+            ``onnxsim_cpp2py_export.list_quantizable_activations`` reports
+    """
+    import onnxruntime as ort
+
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    model_bytes = model.SerializeToString()
+    tensor_names = set(C.list_quantizable_activations(model_bytes))
+    if not tensor_names:
+        return {}
+
+    # Expose every candidate tensor as an extra graph output, so onnxruntime
+    # computes (and returns) it without the graph itself needing to change.
+    calib_model = onnx.ModelProto()
+    calib_model.CopyFrom(model)
+    existing_outputs = {o.name for o in calib_model.graph.output}
+    for name in tensor_names:
+        if name not in existing_outputs:
+            calib_model.graph.output.append(onnx.ValueInfoProto(name=name))
+
+    sess = ort.InferenceSession(
+        calib_model.SerializeToString(),
+        providers=list(providers) if providers else None,
+    )
+    output_names = [o.name for o in sess.get_outputs()]
+
+    ranges: Dict[str, Tuple[float, float]] = {}
+    for batch in calibration_data:
+        outputs = sess.run(output_names, batch)
+        for name, value in zip(output_names, outputs):
+            if name not in tensor_names:
+                continue
+            arr = np.asarray(value)
+            if arr.size == 0:
+                continue
+            batch_min = float(arr.min())
+            batch_max = float(arr.max())
+            if name in ranges:
+                prev_min, prev_max = ranges[name]
+                ranges[name] = (min(prev_min, batch_min), max(prev_max, batch_max))
+            else:
+                ranges[name] = (batch_min, batch_max)
+    return ranges
+
+
+def quantize_static(
+    model: Union[str, onnx.ModelProto],
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_calibration_samples: int = 8,
+    seed: int = 0,
+    providers: Optional[Sequence[str]] = None,
+) -> onnx.ModelProto:
+    """
+    Statically (calibration-based) quantize every MatMul, and every "vanilla"
+    Gemm (transA=0, alpha=1, beta=1), whose weight is a constant 2-D float32
+    tensor.
+
+    Unlike :func:`onnxsim.quantize_dynamic`, the activation's quantization
+    range is *calibrated*: fixed ahead of time from ``calibration_data``
+    (falling back to :func:`generate_random_calibration_data` when omitted)
+    rather than recomputed on every inference. A
+    QuantizeLinear/DequantizeLinear pair is inserted around each quantized
+    tensor (the "QDQ" format): the graph still computes in float32, ready for
+    a QDQ-aware runtime to fuse the pattern into a true integer kernel at
+    load time.
+
+    :param model: onnx ModelProto object or file path
+    :param calibration_data: representative input batches to calibrate
+            activation ranges from. Each batch is a ``{input_name: np.ndarray}``
+            dict matching the model's graph inputs -- see
+            :func:`generate_random_calibration_data` (the default, a quick
+            smoke test) and :func:`load_huggingface_calibration_data` (real
+            data, a much better calibration source for real deployment).
+    :param num_calibration_samples: number of random batches to generate when
+            ``calibration_data`` is not supplied
+    :param seed: seed for the random calibration data (ignored if
+            ``calibration_data`` is supplied)
+    :param providers: onnxruntime execution providers to run calibration on
+    :returns: the quantized onnx ModelProto
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            model, num_samples=num_calibration_samples, seed=seed
+        )
+    ranges = calibrate(model, calibration_data, providers=providers)
+    return onnx.load_from_string(C.quantize_static(model.SerializeToString(), ranges))

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -9,6 +9,7 @@
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/tuple.h>
+#include <nanobind/stl/unordered_map.h>
 #include <nanobind/stl/vector.h>
 #include <nanobind/trampoline.h>
 
@@ -358,6 +359,41 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
         return py::bytes(out.data(), out.size());
       },
       "model_bytes"_a);
+
+  // Lists the activation tensor names quantize_static could quantize --
+  // see ListQuantizableActivations in onnxsim.h.
+  m.def(
+      "list_quantizable_activations",
+      [](const py::bytes& model_proto_bytes) -> std::vector<std::string> {
+        InitEnv();
+        ONNX_NAMESPACE::ModelProto model;
+        ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
+                            model_proto_bytes.size());
+        return ListQuantizableActivations(model);
+      },
+      "model_bytes"_a);
+
+  // Statically (calibration-based) quantizes MatMul/Gemm: weights to INT8
+  // (per output channel, symmetric, ahead of time) and activations to uint8
+  // via a QuantizeLinear/DequantizeLinear pair with a *fixed* scale/zero-point
+  // derived from `activation_ranges` (tensor name -> (min, max), typically
+  // from list_quantizable_activations plus running the float model over
+  // calibration data) -- see QuantizeStatic in onnxsim.h.
+  m.def(
+      "quantize_static",
+      [](const py::bytes& model_proto_bytes,
+         const std::unordered_map<std::string, std::pair<float, float>>&
+             activation_ranges) -> py::bytes {
+        InitEnv();
+        ONNX_NAMESPACE::ModelProto model;
+        ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
+                            model_proto_bytes.size());
+        const auto result = QuantizeStatic(model, activation_ranges);
+        std::string out;
+        result.SerializeToString(&out);
+        return py::bytes(out.data(), out.size());
+      },
+      "model_bytes"_a, "activation_ranges"_a);
 
   m.def(
        "simplify",

--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -20,6 +20,7 @@
 #include "passes/fuse_mul_into_conv.h"
 #include "passes/fuse_pad_into_pool.h"
 #include "passes/fuse_preceding_mul_into_conv.h"
+#include "passes/static_quantize_matmul.h"
 
 namespace onnxsim {
 
@@ -60,6 +61,7 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::FuseMatMulAddBiasIntoGemmBatched>(registry);
     RegisterOrReplace<p::FuseMulIntoConv>(registry);
     RegisterOrReplace<p::FusePrecedingMulIntoConv>(registry);
+    RegisterOrReplace<p::StaticQuantizeMatMul>(registry);
 
     // onnxsim's patched versions of built-in onnxoptimizer passes. These
     // overwrite the registry entries the submodule registers under the same

--- a/onnxsim/custom_optimizer_passes.h
+++ b/onnxsim/custom_optimizer_passes.h
@@ -23,6 +23,7 @@ namespace onnxsim {
 //   - fuse_matmul_add_bias_into_gemm_batched
 //   - eliminate_reshape_around_elementwise
 //   - dynamic_quantize_matmul
+//   - static_quantize_matmul
 //
 // The registration runs at most once per process and is safe to call from any
 // simplification entry point. It MUST run before the pass list is built (a

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -1221,6 +1221,32 @@ def main():
         action="store_true",
     )
     parser.add_argument(
+        "--static-quantize",
+        help="After simplifying, statically (calibration-based) quantize "
+        "MatMul/Gemm weights and activations to INT8/uint8, inserting a "
+        "QuantizeLinear/DequantizeLinear pair (QDQ format) with a fixed "
+        "scale/zero-point calibrated from --calibration-dataset if given, "
+        "else from random data. See onnxsim.quantize_static.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--calibration-dataset",
+        help="Hugging Face Hub dataset id (e.g. 'mnist') to pull "
+        "--calibration-samples real examples from for --static-quantize's "
+        "calibration, instead of random data. See "
+        "onnxsim.load_huggingface_calibration_data (needs the optional "
+        "'datasets' package: pip install datasets).",
+        type=str,
+        default=None,
+    )
+    parser.add_argument(
+        "--calibration-samples",
+        help="Number of calibration batches/examples for --static-quantize "
+        "(default: 8).",
+        type=int,
+        default=8,
+    )
+    parser.add_argument(
         "-v", "--version", action="version", version="onnxsim " + version.version
     )
 
@@ -1422,6 +1448,28 @@ def main():
     if args.dynamic_quantize:
         print("Dynamically quantizing MatMul/Gemm weights to INT8...")
         model_opt = quantize_dynamic(model_opt)
+
+    if args.static_quantize:
+        from . import calibration
+
+        if args.calibration_dataset:
+            print(
+                f'Calibrating from Hugging Face dataset "{args.calibration_dataset}"...'
+            )
+            calibration_data = calibration.load_huggingface_calibration_data(
+                args.calibration_dataset,
+                model_opt,
+                num_samples=args.calibration_samples,
+            )
+        else:
+            print("Calibrating from random data...")
+            calibration_data = calibration.generate_random_calibration_data(
+                model_opt, num_samples=args.calibration_samples
+            )
+        print("Statically quantizing MatMul/Gemm weights and activations...")
+        model_opt = calibration.quantize_static(
+            model_opt, calibration_data=calibration_data
+        )
 
     try:
         if not args.save_as_external_data:

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -47,6 +47,8 @@
 #include "onnxoptimizer/optimize.h"
 #include "onnxoptimizer/passes/cse_util.h"
 #include "onnxoptimizer/passes/logging.h"
+#include "passes/quantize_matmul_common.h"
+#include "passes/static_quantize_matmul.h"
 #include "profiler.h"
 #include "sym_shape_infer.h"
 #include "sym_value_eval.h"
@@ -2203,6 +2205,53 @@ onnx::ModelProto QuantizeDynamic(const onnx::ModelProto& model) {
   onnxsim::RegisterCustomOptimizerPasses();
   return onnx::optimization::OptimizeFixed(
       model, std::vector<std::string>{"dynamic_quantize_matmul"});
+}
+
+std::vector<std::string> ListQuantizableActivations(
+    const onnx::ModelProto& model) {
+  PrepareSchemasForDebug(model);
+  std::shared_ptr<onnx::Graph> g(onnx::ImportModelProto(model));
+  if (g.get() == nullptr) {
+    return {};
+  }
+  std::vector<std::string> names;
+  std::unordered_set<std::string> seen;
+  for (auto* node : g->nodes()) {
+    onnx::optimization::onnxsim_passes::MatMulLikeInfo info;
+    if (!onnx::optimization::onnxsim_passes::MatchMatMulLike(node, info)) {
+      continue;
+    }
+    if (info.x->elemType() != onnx::TensorProto_DataType_FLOAT) {
+      continue;
+    }
+    const onnx::Tensor* w_t = onnx::optimization::FetchConstantTensor(info.w);
+    if (w_t == nullptr ||
+        w_t->elem_type() != onnx::TensorProto_DataType_FLOAT ||
+        w_t->sizes().size() != 2) {
+      continue;
+    }
+    if (seen.insert(info.x->uniqueName()).second) {
+      names.push_back(info.x->uniqueName());
+    }
+  }
+  return names;
+}
+
+onnx::ModelProto QuantizeStatic(
+    const onnx::ModelProto& model,
+    const std::unordered_map<std::string, std::pair<float, float>>&
+        activation_ranges) {
+  PrepareSchemasForDebug(model);
+  // Registers static_quantize_matmul (idempotent) into onnxoptimizer's
+  // registry so OptimizeFixed can find it by name below.
+  onnxsim::RegisterCustomOptimizerPasses();
+  // static_quantize_matmul reads this global, the same way onnxsim's other
+  // passes read `config` -- see StaticQuantizationCalibrationRanges's doc
+  // comment.
+  onnx::optimization::onnxsim_passes::StaticQuantizationCalibrationRanges() =
+      activation_ranges;
+  return onnx::optimization::OptimizeFixed(
+      model, std::vector<std::string>{"static_quantize_matmul"});
 }
 
 onnx::ModelProto Simplify(

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -4,6 +4,9 @@
 
 #include <memory>
 #include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "dlpack/dlpack.h"
@@ -139,6 +142,44 @@ onnx::ModelProto FoldConstantOnce(const ModelExecutor& executor,
 // Nodes that do not match (dynamic or non-2-D weights, non-default Gemm
 // attributes, non-float32 operands, an opset older than 11) are left as-is.
 onnx::ModelProto QuantizeDynamic(const onnx::ModelProto& model);
+
+// Lists the activation tensor names that ``QuantizeStatic`` could quantize in
+// ``model`` -- the first input of every MatMul, and every "vanilla" Gemm
+// (transA=0, alpha=1, beta=1), whose weight is a constant 2-D float32 tensor
+// and whose activation is float32 -- so a caller can calibrate exactly (and
+// only) the tensors that matter, by running the model over representative
+// data and recording each listed tensor's observed (min, max). Names are
+// deduplicated and given in no particular order; the opset-version check
+// ``QuantizeStatic``'s pass applies is not repeated here, since calibrating a
+// tensor that then turns out to be unusable (opset < 13) is harmless -- the
+// pass simply ignores its entry in ``activation_ranges``.
+std::vector<std::string> ListQuantizableActivations(
+    const onnx::ModelProto& model);
+
+// Statically (calibration-based) quantizes every MatMul, and every "vanilla"
+// Gemm (transA=0, alpha=1, beta=1), whose weight is a constant 2-D float32
+// tensor and whose activation's tensor name is a key of
+// ``activation_ranges``: the weight is quantized to INT8 ahead of time (per
+// output channel, symmetric, from its static values -- same as
+// ``QuantizeDynamic``), and the activation is quantized to uint8 using a
+// *fixed* (scale, zero_point) derived from its calibrated (min, max) range in
+// ``activation_ranges`` (see ``ListQuantizableActivations`` to discover which
+// tensors to calibrate). The rewrite inserts a QuantizeLinear/DequantizeLinear
+// pair around each quantized tensor (the "QDQ" format) rather than replacing
+// the MatMul/Gemm itself, so the graph still computes in float32 -- a
+// QDQ-aware runtime fuses the pattern into a true integer kernel at load
+// time. See ``passes/static_quantize_matmul.h`` for the rewrite itself, and
+// ``QuantizeDynamic`` for the no-calibration alternative.
+//
+// Unlike ``Simplify``, this does not run shape inference, constant folding or
+// any other simplification pass -- it applies exactly this one rewrite, once,
+// to a copy of ``model`` (which is left untouched) and returns the result.
+// Nodes that do not match, or whose activation has no entry in
+// ``activation_ranges``, are left as-is.
+onnx::ModelProto QuantizeStatic(
+    const onnx::ModelProto& model,
+    const std::unordered_map<std::string, std::pair<float, float>>&
+        activation_ranges);
 
 void SimplifyPath(const ModelExecutor& executor, const std::string& in_path,
                   const std::string& out_path,

--- a/onnxsim/passes/dynamic_quantize_matmul.h
+++ b/onnxsim/passes/dynamic_quantize_matmul.h
@@ -36,15 +36,13 @@
 // attributes, non-float32 operands, opsets older than 11 (DynamicQuantizeLinear
 // requires opset 11) -- is left alone.
 
-#include <algorithm>
-#include <cmath>
-#include <cstdint>
 #include <string>
 #include <vector>
 
 #include "onnx/common/assertions.h"
 #include "onnxoptimizer/pass.h"
 #include "onnxoptimizer/passes/pass_util.h"
+#include "passes/quantize_matmul_common.h"
 
 namespace ONNX_NAMESPACE {
 namespace optimization {
@@ -58,106 +56,6 @@ struct DynamicQuantizeMatMul final : public PredicateBasedPass {
       : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
                            PassOptimizationType::Compute) {}
   std::string getPassName() const override { return "dynamic_quantize_matmul"; }
-
-  // The pieces of a MatMul/vanilla-Gemm node this pass cares about.
-  struct MatMulLikeInfo {
-    Value* x = nullptr;     // activation (not required to be constant)
-    Value* w = nullptr;     // weight; must be a constant 2-D float32 tensor
-    Value* bias = nullptr;  // Gemm's optional C input; nullptr for MatMul
-    bool weight_transposed = false;  // Gemm transB == 1: W stored as [N, K]
-  };
-
-  // Recognizes a MatMul, or a Gemm with transA=0 and (when it has a bias)
-  // beta=1 and always alpha=1, filling `info`. Attributes are read with
-  // ONNX's documented defaults when absent.
-  static bool MatchMatMulLike(Node* n, MatMulLikeInfo& info) {
-    if (n->kind() == kMatMul) {
-      if (n->inputs().size() != 2) {
-        return false;
-      }
-      info.x = n->inputs()[0];
-      info.w = n->inputs()[1];
-      return true;
-    }
-    if (n->kind() == kGemm) {
-      const size_t num_inputs = n->inputs().size();
-      if (num_inputs != 2 && num_inputs != 3) {
-        return false;
-      }
-      const int64_t transA =
-          GetValueFromAttrWithDefault(n, ktransA, int64_t(0));
-      const int64_t transB =
-          GetValueFromAttrWithDefault(n, ktransB, int64_t(0));
-      const double alpha = GetValueFromAttrWithDefault(n, kalpha, 1.0);
-      const double beta = GetValueFromAttrWithDefault(n, kbeta, 1.0);
-      if (transA != 0 || alpha != 1.0) {
-        return false;
-      }
-      if (num_inputs == 3) {
-        if (beta != 1.0) {
-          return false;
-        }
-        info.bias = n->inputs()[2];
-      }
-      info.x = n->inputs()[0];
-      info.w = n->inputs()[1];
-      info.weight_transposed = transB != 0;
-      return true;
-    }
-    return false;
-  }
-
-  // Quantizes `w_t` (a 2-D float32 constant, laid out as [N, K] when
-  // `transposed` else [K, N]) per output channel: `q_out` holds the weight in
-  // the non-transposed [K, N] layout MatMulInteger's B operand needs, and
-  // `scale_out`[j] is the symmetric INT8 scale for output channel j
-  // (max(|w[:, j]|) / 127, or 1.0 for an all-zero channel so no scale is 0).
-  static void QuantizeWeightPerChannel(const Tensor& w_t, bool transposed,
-                                       Tensor& q_out, Tensor& scale_out) {
-    const auto& sizes = w_t.sizes();
-    const int64_t dim0 = sizes[0];
-    const int64_t dim1 = sizes[1];
-    const int64_t K = transposed ? dim1 : dim0;
-    const int64_t N = transposed ? dim0 : dim1;
-
-    std::vector<float> data;
-    if (w_t.is_raw_data()) {
-      const float* raw = w_t.data<float>();
-      data.assign(raw, raw + static_cast<size_t>(dim0 * dim1));
-    } else {
-      data = w_t.floats();
-    }
-    // element (k, n) of the logical [K, N] weight, regardless of storage
-    // layout.
-    auto at = [&](int64_t k, int64_t n) {
-      return transposed ? data[n * K + k] : data[k * N + n];
-    };
-
-    std::vector<float> scale(static_cast<size_t>(N), 0.0f);
-    for (int64_t k = 0; k < K; ++k) {
-      for (int64_t n = 0; n < N; ++n) {
-        scale[n] = std::max(scale[n], std::fabs(at(k, n)));
-      }
-    }
-    for (float& s : scale) {
-      s = s > 0.0f ? s / 127.0f : 1.0f;
-    }
-
-    q_out.elem_type() = TensorProto_DataType_INT8;
-    q_out.sizes() = {K, N};
-    q_out.int32s().resize(static_cast<size_t>(K * N));
-    for (int64_t k = 0; k < K; ++k) {
-      for (int64_t n = 0; n < N; ++n) {
-        const float q = std::round(at(k, n) / scale[n]);
-        q_out.int32s()[k * N + n] =
-            static_cast<int32_t>(std::clamp(q, -127.0f, 127.0f));
-      }
-    }
-
-    scale_out.elem_type() = TensorProto_DataType_FLOAT;
-    scale_out.sizes() = {N};
-    scale_out.floats() = std::move(scale);
-  }
 
   bool patternMatchPredicate(Node* n) override {
     MatMulLikeInfo info;
@@ -194,7 +92,7 @@ struct DynamicQuantizeMatMul final : public PredicateBasedPass {
 
     Tensor w_q;
     Tensor w_scale;
-    QuantizeWeightPerChannel(*w_t, info.weight_transposed, w_q, w_scale);
+    QuantizeWeightPerChannelKN(*w_t, info.weight_transposed, w_q, w_scale);
 
     // Xq, Xs, Xzp = DynamicQuantizeLinear(X)
     Node* dql = graph.create(Symbol("DynamicQuantizeLinear"), 3);

--- a/onnxsim/passes/quantize_matmul_common.h
+++ b/onnxsim/passes/quantize_matmul_common.h
@@ -142,8 +142,8 @@ inline void QuantizeWeightPerChannelKN(const Tensor& w_t, bool transposed,
 // expects of its weight input) is left untouched, unlike the dynamic pass's
 // MatMulInteger replacement.
 inline void QuantizeWeightPerChannelInPlace(const Tensor& w_t,
-                                            int64_t channel_axis,
-                                            Tensor& q_out, Tensor& scale_out) {
+                                            int64_t channel_axis, Tensor& q_out,
+                                            Tensor& scale_out) {
   const auto& sizes = w_t.sizes();
   const int64_t dim0 = sizes[0];
   const int64_t dim1 = sizes[1];

--- a/onnxsim/passes/quantize_matmul_common.h
+++ b/onnxsim/passes/quantize_matmul_common.h
@@ -1,0 +1,188 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+// Node-matching and weight-quantization helpers shared by
+// dynamic_quantize_matmul.h and static_quantize_matmul.h: both passes target
+// the same MatMul / "vanilla" Gemm shape and quantize the constant weight to
+// INT8 per output channel from its static values; they differ only in how
+// the *activation* is quantized (a runtime-computed DynamicQuantizeLinear vs.
+// a calibrated, fixed QuantizeLinear/DequantizeLinear pair) and, downstream
+// of that, in the rest of the graph they build.
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+// The pieces of a MatMul/vanilla-Gemm node these passes care about.
+struct MatMulLikeInfo {
+  Value* x = nullptr;     // activation (not required to be constant)
+  Value* w = nullptr;     // weight; must be a constant 2-D float32 tensor
+  Value* bias = nullptr;  // Gemm's optional C input; nullptr for MatMul
+  bool weight_transposed = false;  // Gemm transB == 1: W stored as [N, K]
+};
+
+// Recognizes a MatMul, or a Gemm with transA=0 and (when it has a bias)
+// beta=1 and always alpha=1, filling `info`. Attributes are read with ONNX's
+// documented defaults when absent.
+inline bool MatchMatMulLike(Node* n, MatMulLikeInfo& info) {
+  if (n->kind() == kMatMul) {
+    if (n->inputs().size() != 2) {
+      return false;
+    }
+    info.x = n->inputs()[0];
+    info.w = n->inputs()[1];
+    return true;
+  }
+  if (n->kind() == kGemm) {
+    const size_t num_inputs = n->inputs().size();
+    if (num_inputs != 2 && num_inputs != 3) {
+      return false;
+    }
+    const int64_t transA = GetValueFromAttrWithDefault(n, ktransA, int64_t(0));
+    const int64_t transB = GetValueFromAttrWithDefault(n, ktransB, int64_t(0));
+    const double alpha = GetValueFromAttrWithDefault(n, kalpha, 1.0);
+    const double beta = GetValueFromAttrWithDefault(n, kbeta, 1.0);
+    if (transA != 0 || alpha != 1.0) {
+      return false;
+    }
+    if (num_inputs == 3) {
+      if (beta != 1.0) {
+        return false;
+      }
+      info.bias = n->inputs()[2];
+    }
+    info.x = n->inputs()[0];
+    info.w = n->inputs()[1];
+    info.weight_transposed = transB != 0;
+    return true;
+  }
+  return false;
+}
+
+// Reads `w_t` (a 2-D float32 constant) into a flat row-major float buffer,
+// regardless of whether it is stored as raw bytes or a typed float array.
+inline std::vector<float> ReadFloatMatrix(const Tensor& w_t) {
+  const auto& sizes = w_t.sizes();
+  const int64_t numel = sizes[0] * sizes[1];
+  if (w_t.is_raw_data()) {
+    const float* raw = w_t.data<float>();
+    return std::vector<float>(raw, raw + static_cast<size_t>(numel));
+  }
+  return w_t.floats();
+}
+
+// Quantizes `w_t` (a 2-D float32 constant, laid out as [N, K] when
+// `transposed` else [K, N]) per output channel: `q_out` holds the weight in
+// the non-transposed [K, N] layout MatMulInteger's B operand needs, and
+// `scale_out`[j] is the symmetric INT8 scale for output channel j
+// (max(|w[:, j]|) / 127, or 1.0 for an all-zero channel so no scale is 0).
+// Used by the dynamic-quantization pass, whose replacement MatMulInteger
+// always consumes B in [K, N] layout.
+inline void QuantizeWeightPerChannelKN(const Tensor& w_t, bool transposed,
+                                       Tensor& q_out, Tensor& scale_out) {
+  const auto& sizes = w_t.sizes();
+  const int64_t dim0 = sizes[0];
+  const int64_t dim1 = sizes[1];
+  const int64_t K = transposed ? dim1 : dim0;
+  const int64_t N = transposed ? dim0 : dim1;
+
+  const std::vector<float> data = ReadFloatMatrix(w_t);
+  // element (k, n) of the logical [K, N] weight, regardless of storage
+  // layout.
+  auto at = [&](int64_t k, int64_t n) {
+    return transposed ? data[n * K + k] : data[k * N + n];
+  };
+
+  std::vector<float> scale(static_cast<size_t>(N), 0.0f);
+  for (int64_t k = 0; k < K; ++k) {
+    for (int64_t n = 0; n < N; ++n) {
+      scale[n] = std::max(scale[n], std::fabs(at(k, n)));
+    }
+  }
+  for (float& s : scale) {
+    s = s > 0.0f ? s / 127.0f : 1.0f;
+  }
+
+  q_out.elem_type() = TensorProto_DataType_INT8;
+  q_out.sizes() = {K, N};
+  q_out.int32s().resize(static_cast<size_t>(K * N));
+  for (int64_t k = 0; k < K; ++k) {
+    for (int64_t n = 0; n < N; ++n) {
+      const float q = std::round(at(k, n) / scale[n]);
+      q_out.int32s()[k * N + n] =
+          static_cast<int32_t>(std::clamp(q, -127.0f, 127.0f));
+    }
+  }
+
+  scale_out.elem_type() = TensorProto_DataType_FLOAT;
+  scale_out.sizes() = {N};
+  scale_out.floats() = std::move(scale);
+}
+
+// Quantizes `w_t` (a 2-D float32 constant) per output channel *in its own
+// layout* (no transpose): `channel_axis` (0 or 1) is the axis of `w_t` that
+// indexes the output channel. `q_out` has the SAME shape as `w_t`, and
+// `scale_out`[j] is the symmetric INT8 scale for channel j. Used by the
+// static-quantization pass, whose DequantizeLinear replaces the weight input
+// in place -- the surrounding MatMul/Gemm node (and therefore the layout it
+// expects of its weight input) is left untouched, unlike the dynamic pass's
+// MatMulInteger replacement.
+inline void QuantizeWeightPerChannelInPlace(const Tensor& w_t,
+                                            int64_t channel_axis,
+                                            Tensor& q_out, Tensor& scale_out) {
+  const auto& sizes = w_t.sizes();
+  const int64_t dim0 = sizes[0];
+  const int64_t dim1 = sizes[1];
+  const int64_t C = channel_axis == 0 ? dim0 : dim1;
+
+  const std::vector<float> data = ReadFloatMatrix(w_t);
+  auto at = [&](int64_t i, int64_t j) { return data[i * dim1 + j]; };
+  auto channel_of = [&](int64_t i, int64_t j) {
+    return channel_axis == 0 ? i : j;
+  };
+
+  std::vector<float> scale(static_cast<size_t>(C), 0.0f);
+  for (int64_t i = 0; i < dim0; ++i) {
+    for (int64_t j = 0; j < dim1; ++j) {
+      const int64_t c = channel_of(i, j);
+      scale[c] = std::max(scale[c], std::fabs(at(i, j)));
+    }
+  }
+  for (float& s : scale) {
+    s = s > 0.0f ? s / 127.0f : 1.0f;
+  }
+
+  q_out.elem_type() = TensorProto_DataType_INT8;
+  q_out.sizes() = {dim0, dim1};
+  q_out.int32s().resize(static_cast<size_t>(dim0 * dim1));
+  for (int64_t i = 0; i < dim0; ++i) {
+    for (int64_t j = 0; j < dim1; ++j) {
+      const int64_t c = channel_of(i, j);
+      const float q = std::round(at(i, j) / scale[c]);
+      q_out.int32s()[i * dim1 + j] =
+          static_cast<int32_t>(std::clamp(q, -127.0f, 127.0f));
+    }
+  }
+
+  scale_out.elem_type() = TensorProto_DataType_FLOAT;
+  scale_out.sizes() = {C};
+  scale_out.floats() = std::move(scale);
+}
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/static_quantize_matmul.h
+++ b/onnxsim/passes/static_quantize_matmul.h
@@ -145,9 +145,8 @@ struct StaticQuantizeMatMul final : public PredicateBasedPass {
 
     float x_scale_f = 1.0f;
     int32_t x_zp_i = 0;
-    ComputeAsymmetricUint8QuantParams(range_it->second.first,
-                                      range_it->second.second, x_scale_f,
-                                      x_zp_i);
+    ComputeAsymmetricUint8QuantParams(
+        range_it->second.first, range_it->second.second, x_scale_f, x_zp_i);
 
     // W's output-channel axis in its own (untransposed) layout: axis 0 when
     // Gemm's transB made W [N, K], else axis 1 ([K, N], MatMul's own layout).

--- a/onnxsim/passes/static_quantize_matmul.h
+++ b/onnxsim/passes/static_quantize_matmul.h
@@ -1,0 +1,212 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+// Before (illustrated for MatMul; a "vanilla" Gemm -- transA=0, alpha=1,
+// beta=1 -- is handled the same way, its bias C left untouched):
+//   Y = MatMul(X, W)         W constant, 2-D, float32
+// After (QDQ -- "quantize/dequantize" -- format: the MatMul/Gemm node itself
+// is untouched, only its inputs change):
+//   Xq  = QuantizeLinear(X, Xs, Xzp)        -- Xs/Xzp: CALIBRATED, fixed
+//   Xdq = DequantizeLinear(Xq, Xs, Xzp)
+//   Wdq = DequantizeLinear(Wq, Ws, axis=<W's output-channel axis>)
+//   Y   = MatMul(Xdq, Wdq)
+//
+// Wq (int8) and Ws (float32, one scale per output channel) are computed once,
+// here, from W's static values -- the same per-output-channel symmetric INT8
+// quantization dynamic_quantize_matmul.h uses. Xs/Xzp (X's scale and
+// zero-point) are *calibrated*: unlike dynamic quantization, which defers X's
+// quantization parameters to a DynamicQuantizeLinear computed fresh on every
+// run, this pass bakes in a single, fixed (scale, zero_point) pair --
+// supplied by the caller as one (min, max) activation range per quantized
+// tensor, ordinarily obtained by running the float model over representative
+// calibration data and recording each candidate tensor's observed range (see
+// QuantizeStatic / the Python `quantize_static` wrapper). X's range is
+// asymmetric uint8, widened to include 0 (the standard affine-quantization
+// convention, since a zero activation must be exactly representable).
+//
+// This mirrors ONNX Runtime's "static quantization" in its QDQ format (the
+// now-preferred format over the older QOperator/QLinearMatMul one): the graph
+// still computes in float32 -- MatMul is untouched -- but a QDQ-aware runtime
+// recognizes the bracketing Q/DQ pair and fuses it into a true integer kernel
+// at load time. See `passes/dynamic_quantize_matmul.h` for the no-calibration
+// alternative.
+//
+// Only the common, unambiguous shape is handled -- see
+// dynamic_quantize_matmul.h's doc comment, which applies identically here --
+// plus: opsets older than 13 (DequantizeLinear's per-channel `axis` attribute
+// requires opset 13) are left alone, and a MatMul/Gemm is only rewritten when
+// its activation input's name has a calibrated range (set via
+// StaticQuantizationCalibrationRanges(), see QuantizeStatic in onnxsim.h).
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+#include "passes/quantize_matmul_common.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+// The calibrated (min, max) activation range for every tensor name the last
+// QuantizeStatic call wants quantized, consulted by StaticQuantizeMatMul.
+// QuantizeStatic (onnxsim.cpp) overwrites this immediately before running the
+// pass, the same way onnxsim's global `config` feeds ordinary passes --
+// see that function's doc comment. A function-local static in an `inline`
+// function is one shared instance across every translation unit that
+// includes this header (unlike a plain header-defined global), so this is
+// safe to call from both this pass (compiled into custom_optimizer_passes.cpp)
+// and QuantizeStatic (compiled into onnxsim.cpp).
+inline std::unordered_map<std::string, std::pair<float, float>>&
+StaticQuantizationCalibrationRanges() {
+  static std::unordered_map<std::string, std::pair<float, float>> ranges;
+  return ranges;
+}
+
+// Computes the (scale, zero_point) of an asymmetric uint8 affine quantization
+// covering [min_val, max_val], widened to include 0 so a zero activation
+// value is exactly representable (the standard convention -- and the common
+// case for a post-ReLU/post-Softmax activation, whose calibrated range is
+// often one-sided).
+inline void ComputeAsymmetricUint8QuantParams(float min_val, float max_val,
+                                              float& scale,
+                                              int32_t& zero_point) {
+  float lo = std::min(0.0f, min_val);
+  float hi = std::max(0.0f, max_val);
+  if (hi <= lo) {
+    hi = lo + 1.0f;  // Degenerate calibration range (e.g. all-zero data).
+  }
+  scale = (hi - lo) / 255.0f;
+  const float zp = std::round(-lo / scale);
+  zero_point = static_cast<int32_t>(std::clamp(zp, 0.0f, 255.0f));
+}
+
+struct StaticQuantizeMatMul final : public PredicateBasedPass {
+  explicit StaticQuantizeMatMul()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+  std::string getPassName() const override { return "static_quantize_matmul"; }
+
+  bool patternMatchPredicate(Node* n) override {
+    MatMulLikeInfo info;
+    if (!MatchMatMulLike(n, info)) {
+      return false;
+    }
+    const int opset = getOpsetVersion(*n->owningGraph());
+    if (opset != 0 && opset < 13) {
+      return false;  // DequantizeLinear's per-channel `axis` needs opset >= 13.
+    }
+    if (info.x->elemType() != TensorProto_DataType_FLOAT) {
+      return false;
+    }
+    if (StaticQuantizationCalibrationRanges().count(info.x->uniqueName()) ==
+        0) {
+      return false;  // No calibrated range for this activation.
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    return w_t != nullptr && w_t->elem_type() == TensorProto_DataType_FLOAT &&
+           w_t->sizes().size() == 2;
+  }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    // Unlike dynamic_quantize_matmul.h, this pass never replaces `n` itself
+    // -- only its inputs -- so it never needs to destroy the current node.
+    destroy_current = NodeDestroyType::DestroyZero;
+    MatMulLikeInfo info;
+    if (!MatchMatMulLike(n, info)) {
+      return false;
+    }
+    if (info.x->elemType() != TensorProto_DataType_FLOAT) {
+      return false;
+    }
+    const auto& ranges = StaticQuantizationCalibrationRanges();
+    const auto range_it = ranges.find(info.x->uniqueName());
+    if (range_it == ranges.end()) {
+      return false;
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+        w_t->sizes().size() != 2) {
+      return false;
+    }
+
+    float x_scale_f = 1.0f;
+    int32_t x_zp_i = 0;
+    ComputeAsymmetricUint8QuantParams(range_it->second.first,
+                                      range_it->second.second, x_scale_f,
+                                      x_zp_i);
+
+    // W's output-channel axis in its own (untransposed) layout: axis 0 when
+    // Gemm's transB made W [N, K], else axis 1 ([K, N], MatMul's own layout).
+    const int64_t channel_axis = info.weight_transposed ? 0 : 1;
+    Tensor w_q;
+    Tensor w_scale;
+    QuantizeWeightPerChannelInPlace(*w_t, channel_axis, w_q, w_scale);
+
+    Tensor x_scale_t;
+    x_scale_t.elem_type() = TensorProto_DataType_FLOAT;
+    x_scale_t.floats() = {x_scale_f};
+    Tensor x_zp_t;
+    x_zp_t.elem_type() = TensorProto_DataType_UINT8;
+    x_zp_t.int32s() = {x_zp_i};
+    Value* x_scale_v = graph.addInitializerAndCreateValue(x_scale_t);
+    Value* x_zp_v = graph.addInitializerAndCreateValue(x_zp_t);
+
+    // Xq = QuantizeLinear(X, Xs, Xzp)
+    Node* ql = graph.create(Symbol("QuantizeLinear"), 1);
+    ql->addInput(info.x);
+    ql->addInput(x_scale_v);
+    ql->addInput(x_zp_v);
+    ql->insertBefore(n);
+    ql->output()->setElemType(TensorProto_DataType_UINT8);
+
+    // Xdq = DequantizeLinear(Xq, Xs, Xzp)
+    Node* xdq = graph.create(Symbol("DequantizeLinear"), 1);
+    xdq->addInput(ql->output());
+    xdq->addInput(x_scale_v);
+    xdq->addInput(x_zp_v);
+    xdq->insertBefore(n);
+    xdq->output()->setElemType(TensorProto_DataType_FLOAT);
+    if (info.x->sizes().size() > 0) {
+      xdq->output()->setSizes(info.x->sizes());
+    }
+
+    Value* w_q_v = graph.addInitializerAndCreateValue(w_q);
+    Value* w_scale_v = graph.addInitializerAndCreateValue(w_scale);
+
+    // Wdq = DequantizeLinear(Wq, Ws, axis=channel_axis) -- zero_point
+    // omitted (symmetric, i.e. always 0).
+    Node* wdq = graph.create(Symbol("DequantizeLinear"), 1);
+    wdq->addInput(w_q_v);
+    wdq->addInput(w_scale_v);
+    wdq->i_(kaxis, channel_axis);
+    wdq->insertBefore(n);
+    wdq->output()->setElemType(TensorProto_DataType_FLOAT);
+    if (info.w->sizes().size() > 0) {
+      wdq->output()->setSizes(info.w->sizes());
+    }
+
+    // The MatMul/Gemm node itself is left in place; only its activation and
+    // weight inputs change, to their dequantized (QDQ) counterparts.
+    n->replaceInput(0, xdq->output());
+    n->replaceInput(1, wdq->output());
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/tests/test_static_quantize_matmul.py
+++ b/tests/test_static_quantize_matmul.py
@@ -1,0 +1,155 @@
+"""Tests for ``onnxsim.quantize_static`` (the ``static_quantize_matmul`` C++
+pass) and its calibration-data helpers in ``onnxsim.calibration``.
+
+Each model is built directly with ``onnx.helper`` (no torch dependency),
+calibrated with random data, quantized, and then actually run through ONNX
+Runtime -- both before and after quantization -- so these tests double as a
+minimal end-to-end calibrate/quantize/deploy check: the quantized graph must
+load and execute under a real inference engine, and its outputs must stay
+close to the float baseline.
+"""
+
+import collections
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+
+import onnxsim
+
+# A bare ``import onnxruntime`` would fail collection (not skip the test) on
+# platforms onnxruntime doesn't ship wheels for (e.g. s390x).
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(nodes, inputs, outputs, initializer, opset=13):
+    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
+    # Pin a low IR version so the model loads under older onnxruntime builds
+    # (which cap at IR version 11), matching test_fusion_patterns.py.
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+    )
+
+
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _op_counts(model):
+    return collections.Counter(n.op_type for n in model.graph.node)
+
+
+def _assert_close(float_outputs, quant_outputs):
+    # INT8/uint8 quantization is lossy by design; see
+    # test_dynamic_quantize_matmul.py's identically-named helper for why this
+    # checks aggregate relative L2 error rather than a tight per-element bound.
+    for f, q in zip(float_outputs, quant_outputs):
+        f = np.asarray(f, dtype=np.float64).ravel()
+        q = np.asarray(q, dtype=np.float64).ravel()
+        assert np.all(np.isfinite(q))
+        rel_l2 = np.linalg.norm(f - q) / max(np.linalg.norm(f), 1e-6)
+        assert rel_l2 < 0.1, f"relative L2 error too large: {rel_l2:.4f}"
+
+
+def test_quantize_matmul():
+    rng = np.random.default_rng(0)
+    K, N = 32, 16
+    weight = _f32(rng.standard_normal((K, N)) * 0.5, "W")
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [4, K])], [_vi("Y", [4, N])], [weight])
+
+    quant = onnxsim.quantize_static(model, num_calibration_samples=16, seed=0)
+    onnx.checker.check_model(quant)
+    ops = _op_counts(quant)
+    assert ops["MatMul"] == 1  # the MatMul node itself is kept (QDQ format)
+    assert ops["QuantizeLinear"] == 1
+    assert ops["DequantizeLinear"] == 2  # one for X, one for W
+
+    x = rng.standard_normal((4, K)).astype(np.float32)
+    _assert_close(_run(model, {"X": x}), _run(quant, {"X": x}))
+
+
+def test_quantize_gemm_transb_with_bias():
+    # PyTorch's nn.Linear layout: weight is [out_features, in_features], i.e.
+    # [N, K], exported as Gemm(X, W, B, transB=1) -- the common real-world case.
+    rng = np.random.default_rng(1)
+    K, N = 24, 12
+    weight = _f32(rng.standard_normal((N, K)) * 0.5, "W")
+    bias = _f32(rng.standard_normal(N), "B")
+    nodes = [onnx.helper.make_node("Gemm", ["X", "W", "B"], ["Y"], transB=1)]
+    model = _model(nodes, [_vi("X", [3, K])], [_vi("Y", [3, N])], [weight, bias])
+
+    quant = onnxsim.quantize_static(model, num_calibration_samples=16, seed=1)
+    onnx.checker.check_model(quant)
+    ops = _op_counts(quant)
+    # The Gemm node itself (bias included) is kept; only its X/W inputs are
+    # rerouted through QDQ pairs.
+    assert ops["Gemm"] == 1
+    assert ops["QuantizeLinear"] == 1
+    assert ops["DequantizeLinear"] == 2
+
+    x = rng.standard_normal((3, K)).astype(np.float32)
+    _assert_close(_run(model, {"X": x}), _run(quant, {"X": x}))
+
+
+def test_quantize_skips_non_constant_weight():
+    # Both MatMul operands are graph inputs (neither is a constant), so there
+    # is nothing to quantize ahead of time.
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [4, 8]), _vi("W", [8, 4])], [_vi("Y", [4, 4])], [])
+    quant = onnxsim.quantize_static(model)
+    assert _op_counts(quant)["MatMul"] == 1
+
+
+def test_quantize_skips_non_default_gemm_attrs():
+    # alpha != 1 falls outside the "vanilla" Gemm shape this pass handles.
+    weight = _f32(np.random.randn(8, 4).astype(np.float32), "W")
+    nodes = [onnx.helper.make_node("Gemm", ["X", "W"], ["Y"], alpha=2.0)]
+    model = _model(nodes, [_vi("X", [4, 8])], [_vi("Y", [4, 4])], [weight])
+    quant = onnxsim.quantize_static(model)
+    assert _op_counts(quant)["Gemm"] == 1
+
+
+def test_quantize_skips_old_opset():
+    # DequantizeLinear's per-channel `axis` attribute needs opset >= 13.
+    weight = _f32(np.random.randn(8, 4).astype(np.float32), "W")
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [4, 8])], [_vi("Y", [4, 4])], [weight], opset=12)
+    quant = onnxsim.quantize_static(model)
+    assert _op_counts(quant)["MatMul"] == 1
+
+
+def test_generate_random_calibration_data_shapes():
+    weight = _f32(np.random.randn(8, 4).astype(np.float32), "W")
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [2, 8])], [_vi("Y", [2, 4])], [weight])
+    batches = onnxsim.generate_random_calibration_data(model, num_samples=3, seed=0)
+    assert len(batches) == 3
+    for batch in batches:
+        assert set(batch.keys()) == {"X"}
+        assert batch["X"].shape == (2, 8)
+        assert batch["X"].dtype == np.float32
+
+
+def test_calibrate_returns_ranges_for_quantizable_tensors():
+    weight = _f32(np.random.randn(8, 4).astype(np.float32), "W")
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [2, 8])], [_vi("Y", [2, 4])], [weight])
+    data = onnxsim.generate_random_calibration_data(model, num_samples=4, seed=0)
+    ranges = onnxsim.calibrate(model, data)
+    assert set(ranges.keys()) == {"X"}
+    lo, hi = ranges["X"]
+    assert lo < hi


### PR DESCRIPTION
## Summary

Stacked on #648 (dynamic quantization) -- this PR's diff is scoped to the incremental static-quantization work; once #648 merges, GitHub will retarget this PR's base to `master` and the diff will shrink to just what's below.

Adds `onnxsim.quantize_static`: calibration-based INT8 quantization for MatMul and vanilla Gemm, using the QDQ (QuantizeLinear/DequantizeLinear) format. Unlike `quantize_dynamic` (#648), the activation's quantization range is *calibrated* ahead of time from representative data rather than computed fresh on every inference.

## Key changes

- **New C++ pass** (`onnxsim/passes/static_quantize_matmul.h`): weights are quantized to INT8 per output channel (same scheme as the dynamic pass); activations get a QuantizeLinear/DequantizeLinear pair with a **fixed** scale/zero-point derived from a calibrated `(min, max)` range. The MatMul/Gemm node itself is left in place (only its inputs are rerouted) -- a QDQ-aware runtime fuses the whole pattern into a true integer kernel at load time.
- **Shared helpers** (`onnxsim/passes/quantize_matmul_common.h`): the MatMul/Gemm-matching logic and per-channel weight quantization, refactored out of `dynamic_quantize_matmul.h` so both passes share one implementation (mechanical, no behavior change to the dynamic pass -- covered by its existing tests).
- **Calibration pipeline** (`onnxsim/calibration.py`):
  - `generate_random_calibration_data`: synthetic random inputs matching the model's shapes, works with no external dependency -- the default calibration source.
  - `load_huggingface_calibration_data`: best-effort loader that pulls real examples from a Hugging Face Hub dataset (needs the optional `datasets` package) and maps columns to ONNX inputs by name/common alias/explicit `field_map`.
  - `calibrate`: runs either data source through onnxruntime, recording each quantizable activation's observed range.
- **CLI**: `--static-quantize`, `--calibration-dataset <hf_dataset_id>`, `--calibration-samples`.
- **Tests** (`tests/test_static_quantize_matmul.py`): build models with `onnx.helper`, calibrate with random data, quantize, and verify outputs stay close to the float baseline through real onnxruntime inference (aggregate relative-L2 check, same rationale as #648's tolerance fix), plus the non-matching skip cases (non-constant weight, non-default Gemm attrs, opset < 13).

## Verification

Built the extension from source and ran everything for real:
- All 7 new tests pass; stress-tested the tolerance over 200 random seeds (worst relative L2 error ~0.013, well under the 0.1 threshold).
- Existing `test_dynamic_quantize_matmul.py` + `test_fusion_patterns.py` + broader torch-free suite (131 tests): all pass, confirming the shared-helper refactor didn't regress the dynamic pass.
- `ruff format`/`ruff check`/mypy (in a clean env matching CI, no third-party deps installed) all clean; `clang-format` clean.
- CLI smoke test (`onnxsim ... --static-quantize`) and a direct onnxruntime run: quantized model loads and its output matches the float baseline (relative L2 ≈ 0.006, even tighter than dynamic quantization's ≈ 0.02 on the same model, as expected from calibrated vs. per-run-computed activation ranges).

https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_