### PR TITLE
Port remaining model-parsing transforms to C++; record simplify() options as metadata

### DIFF
--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -9,12 +9,15 @@
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/tuple.h>
+#include <nanobind/stl/unordered_map.h>
 #include <nanobind/stl/vector.h>
 #include <nanobind/trampoline.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <string>
 #include <tuple>
+#include <unordered_map>
 #include <vector>
 
 #include "dlpack_bridge.h"
@@ -349,18 +352,22 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
           bool constant_folding, bool shape_inference,
           size_t tensor_size_threshold, std::optional<int> target_opset_version,
           std::shared_ptr<GraphRewriter> rewriter,
-          bool initializers_as_constants,
-          bool include_inline_functions) -> py::bytes {
+          bool initializers_as_constants, bool include_inline_functions,
+          bool mutable_initializer,
+          std::optional<std::unordered_map<std::string, std::vector<int64_t>>>
+              overwrite_input_shapes,
+          std::optional<std::vector<std::string>> unused_output) -> py::bytes {
          // force env initialization to register opset
          InitEnv();
          ONNX_NAMESPACE::ModelProto model;
          ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
                              model_proto_bytes.size());
-         auto const result =
-             Simplify(*executor, model, skip_optimizers, constant_folding,
-                      shape_inference, tensor_size_threshold,
-                      target_opset_version, rewriter.get(),
-                      initializers_as_constants, include_inline_functions);
+         auto const result = Simplify(
+             *executor, model, skip_optimizers, constant_folding,
+             shape_inference, tensor_size_threshold, target_opset_version,
+             rewriter.get(), initializers_as_constants,
+             include_inline_functions, mutable_initializer,
+             overwrite_input_shapes, unused_output);
          std::string out;
          result.SerializeToString(&out);
          return py::bytes(out.data(), out.size());
@@ -369,7 +376,8 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
        "constant_folding"_a = true, "shape_inference"_a = true,
        "tensor_size_threshold"_a, "target_opset_version"_a.none(),
        "rewriter"_a.none(), "initializers_as_constants"_a = true,
-       "include_inline_functions"_a = false)
+       "include_inline_functions"_a = false, "mutable_initializer"_a = true,
+       "overwrite_input_shapes"_a.none(), "unused_output"_a.none())
       .def(
           "simplify_path",
           [](std::shared_ptr<PyModelExecutor> executor,
@@ -380,21 +388,27 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
              std::optional<int> target_opset_version,
              std::shared_ptr<GraphRewriter> rewriter,
              bool initializers_as_constants, bool include_inline_functions,
-             bool mutable_initializer) -> bool {
+             bool mutable_initializer,
+             std::optional<
+                 std::unordered_map<std::string, std::vector<int64_t>>>
+                 overwrite_input_shapes,
+             std::optional<std::vector<std::string>> unused_output) -> bool {
             // force env initialization to register opset
             InitEnv();
             SimplifyPath(*executor, in_path, out_path, skip_optimizers,
                          constant_folding, shape_inference,
                          tensor_size_threshold, target_opset_version,
                          rewriter.get(), initializers_as_constants,
-                         include_inline_functions, mutable_initializer);
+                         include_inline_functions, mutable_initializer,
+                         overwrite_input_shapes, unused_output);
             return true;
           },
           "executor"_a, "in_path"_a, "out_path"_a, "skip_optimizers"_a.none(),
           "constant_folding"_a = true, "shape_inference"_a = true,
           "tensor_size_threshold"_a, "target_opset_version"_a.none(),
           "rewriter"_a.none(), "initializers_as_constants"_a = true,
-          "include_inline_functions"_a = false, "mutable_initializer"_a = true)
+          "include_inline_functions"_a = false, "mutable_initializer"_a = true,
+          "overwrite_input_shapes"_a.none(), "unused_output"_a.none())
       .def("_list_optimizers",
            []() {
              py::list ret;

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -375,7 +375,6 @@ def import_gguf(in_path: str) -> onnx.ModelProto:
     return model
 
 
-
 def simplify(
     model: Union[str, onnx.ModelProto],
     check_n: int = 0,
@@ -596,8 +595,12 @@ def simplify(
     )
 
     # Fast path: no ``check_n`` verification (which needs the original model
-    # loaded anyway to compare against) and no shape dict needing the model to
-    # resolve. A file path goes straight through the C++ core's native
+    # loaded anyway to compare against), no shape dict needing the model to
+    # resolve, and no onnxruntime-side session profiling requested (this
+    # function's ``ort_profile``/``merge_ort_profile`` handling below sets up
+    # ``ONNXSIM_ORT_PROFILE`` and merges the resulting traces into the onnxsim
+    # profile after simplification -- machinery the fast path does not
+    # replicate). A file path goes straight through the C++ core's native
     # path-based entry point (``C.simplify_path``), skipping the Python-level
     # parse-then-reserialize round trip a large model otherwise pays crossing
     # into C++ -- every initializer's bytes get materialized into a Python
@@ -613,7 +616,12 @@ def simplify(
     # (issue #348), which the C++ core already detects and works around
     # itself -- so this is never less correct than before, only sometimes not
     # faster.
-    if check_n == 0 and not _shapes_need_model:
+    if (
+        check_n == 0
+        and not _shapes_need_model
+        and ort_profile is None
+        and not merge_ort_profile
+    ):
         _fast_threshold_bytes = parse_size(tensor_size_threshold)
         if _fast_threshold_bytes <= 2**31 - 9999:
             _fast_prev_profile_env = None

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -375,33 +375,6 @@ def import_gguf(in_path: str) -> onnx.ModelProto:
     return model
 
 
-def _snapshot_doc_strings(model: onnx.ModelProto) -> dict:
-    """Capture the ``doc_string`` fields that the C++ optimizer discards."""
-    return {
-        "model": model.doc_string,
-        "graph": model.graph.doc_string,
-        "inputs": {i.name: i.doc_string for i in model.graph.input},
-        "outputs": {o.name: o.doc_string for o in model.graph.output},
-    }
-
-
-def _restore_doc_strings(model: onnx.ModelProto, snapshot: dict) -> None:
-    """Restore doc strings captured by :func:`_snapshot_doc_strings`.
-
-    Only fields that the optimizer left empty are restored, so any doc string
-    produced by the optimizer itself takes precedence.
-    """
-    if not model.doc_string and snapshot["model"]:
-        model.doc_string = snapshot["model"]
-    if not model.graph.doc_string and snapshot["graph"]:
-        model.graph.doc_string = snapshot["graph"]
-    for ipt in model.graph.input:
-        if not ipt.doc_string and snapshot["inputs"].get(ipt.name):
-            ipt.doc_string = snapshot["inputs"][ipt.name]
-    for opt in model.graph.output:
-        if not opt.doc_string and snapshot["outputs"].get(opt.name):
-            opt.doc_string = snapshot["outputs"][opt.name]
-
 
 def simplify(
     model: Union[str, onnx.ModelProto],
@@ -608,33 +581,39 @@ def simplify(
     if skip_fuse_bn and skipped_optimizers is not None:
         skipped_optimizers.append("fuse_bn_into_conv")
 
-    # Fast path: called with a file path and none of the Python-side-only
-    # transforms below requested (input-shape overwrite, unused-output
-    # removal), with no ``check_n`` verification (which needs the original
-    # model loaded anyway to compare against). Hands the file straight to
-    # the C++ core's native path-based entry point (``C.simplify_path``),
-    # skipping the Python-level parse-then-reserialize round trip a large
-    # model otherwise pays crossing into C++ -- every initializer's bytes
-    # get materialized into a Python ``ModelProto``, serialized back to a
-    # byte string, and reparsed on the C++ side, all before simplification
-    # even starts. On an 833MB model this dwarfs the actual simplification
-    # work (tens of seconds of marshalling for ~5 seconds of real work).
-    # Falls back to the standard path below on ANY exception -- e.g. a model
-    # whose tensors onnxoptimizer's CSE cannot hash (issue #348), which the
-    # standard path detects and works around in Python before ever calling
-    # into C++ -- so this is never less correct than before, only sometimes
-    # not faster. One accepted gap: ``doc_string`` fields (issue #428) are
-    # not preserved on this path, since preserving them requires the very
-    # Python-side parse this path exists to avoid; real exporters rarely
-    # populate ``doc_string`` in the first place.
-    if (
-        isinstance(model, str)
-        and check_n == 0
-        and not overwrite_input_shapes
-        and not test_input_shapes
-        and input_shapes is None
-        and unused_output is None
-    ):
+    # onnxsim's model transforms -- input-shape overwrite, unused-output
+    # removal, initializer-from-input folding, and the unhashable-tensor
+    # optimizer skip -- all run natively in C++ (Simplify()/SimplifyPath()),
+    # so this function never needs to parse the model into a Python object
+    # itself: it only marshals options through to the C++ core. The one
+    # exception is the deprecated "``None`` key means the model's single
+    # input" convenience on ``overwrite_input_shapes``/``test_input_shapes``
+    # (and the legacy ``input_shapes`` argument, which sets both) -- resolving
+    # it needs the model's own input names, so it is the one case that still
+    # requires loading the model up front.
+    _shapes_need_model = (input_shapes is not None) or any(
+        d and None in d for d in (overwrite_input_shapes, test_input_shapes)
+    )
+
+    # Fast path: no ``check_n`` verification (which needs the original model
+    # loaded anyway to compare against) and no shape dict needing the model to
+    # resolve. A file path goes straight through the C++ core's native
+    # path-based entry point (``C.simplify_path``), skipping the Python-level
+    # parse-then-reserialize round trip a large model otherwise pays crossing
+    # into C++ -- every initializer's bytes get materialized into a Python
+    # ``ModelProto``, serialized back to a byte string, and reparsed on the
+    # C++ side, all before simplification even starts. On an 833MB model this
+    # dwarfs the actual simplification work (tens of seconds of marshalling
+    # for ~5 seconds of real work). An in-memory ``ModelProto`` has no file to
+    # hand to C++, so it pays one unavoidable ``SerializeToString``/
+    # ``C.simplify`` bytes round trip -- still far cheaper than the removed
+    # Python-side transforms, which needed the model fully materialized and
+    # walked repeatedly. Falls back to the standard path below on ANY
+    # exception -- e.g. a model whose tensors onnxoptimizer's CSE cannot hash
+    # (issue #348), which the C++ core already detects and works around
+    # itself -- so this is never less correct than before, only sometimes not
+    # faster.
+    if check_n == 0 and not _shapes_need_model:
         _fast_threshold_bytes = parse_size(tensor_size_threshold)
         if _fast_threshold_bytes <= 2**31 - 9999:
             _fast_prev_profile_env = None
@@ -644,12 +623,33 @@ def simplify(
                 _fast_prev_profile_env = os.environ.get("ONNXSIM_PROFILE")
                 os.environ["ONNXSIM_PROFILE"] = _fast_profile_path
             try:
-                with tempfile.TemporaryDirectory() as tmpdirname:
-                    fast_out_path = os.path.join(tmpdirname, "opt.onnx")
-                    C.simplify_path(
+                if isinstance(model, str):
+                    with tempfile.TemporaryDirectory() as tmpdirname:
+                        fast_out_path = os.path.join(tmpdirname, "opt.onnx")
+                        C.simplify_path(
+                            _get_model_executor(providers),
+                            model,
+                            fast_out_path,
+                            skipped_optimizers,
+                            not skip_constant_folding,
+                            not skip_shape_inference,
+                            _fast_threshold_bytes,
+                            target_opset_version,
+                            rewriter,
+                            initializers_as_constants,
+                            inline_functions,
+                            mutable_initializer,
+                            overwrite_input_shapes,
+                            unused_output,
+                        )
+                        model_opt = onnx.load(fast_out_path)
+                else:
+                    model_bytes = model.SerializeToString()
+                    if len(model_bytes) >= 2 * 1024 * 1024 * 1024:
+                        raise EncodeError("Message larger than 2GiB")
+                    model_opt_bytes = C.simplify(
                         _get_model_executor(providers),
-                        model,
-                        fast_out_path,
+                        model_bytes,
                         skipped_optimizers,
                         not skip_constant_folding,
                         not skip_shape_inference,
@@ -659,8 +659,12 @@ def simplify(
                         initializers_as_constants,
                         inline_functions,
                         mutable_initializer,
+                        overwrite_input_shapes,
+                        unused_output,
                     )
-                    model_opt = onnx.load(fast_out_path)
+                    if len(model_opt_bytes) == 0:
+                        raise ValueError("Simplified model larger than 2GB")
+                    model_opt = onnx.load_from_string(model_opt_bytes)
                 check_ok = model_checking.compare(
                     model_opt,
                     None,
@@ -682,21 +686,17 @@ def simplify(
                     else:
                         os.environ["ONNXSIM_PROFILE"] = _fast_prev_profile_env
 
+    # Slow path: either check_n > 0 (needs the original model to compare
+    # against) or a shape dict uses the "None key" convenience (needs the
+    # model's own input names to resolve). The model transforms themselves
+    # still run natively in C++ (passed through as arguments below); this
+    # only loads the model for those two Python-side needs.
+    #
     # Track whether we own the in-memory model. When the caller passes a file
     # path we load it here, so the resulting ``ModelProto`` is private to this
     # function and may be mutated freely (e.g. saved as external data without a
     # defensive copy). When the caller passes their own ``ModelProto`` we must
     # not mutate it.
-    #
-    # When the caller passes a file path, defer loading the (potentially
-    # multi-GB) external tensor data until it is actually needed -- right before
-    # the model is serialized for the C++ simplifier. Every graph transformation
-    # in between (input-shape overwrite, unused-output/initializer pruning,
-    # unhashable-tensor detection, doc-string snapshotting) reads only tensor
-    # *metadata* -- names, shapes, element types -- never the raw bytes, so
-    # keeping the weights on disk through these phases lowers active memory use
-    # and avoids loading them at all when an earlier phase raises. The directory
-    # is remembered so the external data can be resolved later.
     external_data_dir: Optional[str] = None
     if isinstance(model, str):
         model_owned = True
@@ -710,57 +710,6 @@ def simplify(
         model, overwrite_input_shapes
     )
     test_input_shapes = check_and_update_input_shapes(model, test_input_shapes)
-
-    for name, input_shape in overwrite_input_shapes.items():
-        for ipt in model.graph.input:
-            if ipt.name == name:
-                for i, dim in enumerate(ipt.type.tensor_type.shape.dim):
-                    # A non-positive value means "keep the original (possibly
-                    # dynamic) dimension" rather than hardcoding an invalid size
-                    # such as 0, which would make the model impossible to run
-                    # (see GitHub issue #237).
-                    if input_shape[i] > 0:
-                        dim.dim_value = input_shape[i]
-    if unused_output is not None:
-        model = remove_unused_output(model, unused_output)
-    if not mutable_initializer:
-        # ``remove_initializer_from_input`` bumps IR<4 models to IR 4 so the
-        # freed initializers become foldable constants (previously gated on
-        # ``ir_version >= 4``, which left opset-8 graphs such as resnet101-v1-7
-        # completely unsimplified) -- except for opsets too old to encode the
-        # nodes those fusions insert, which it leaves untouched.
-        model = remove_initializer_from_input(model)
-
-    # onnxoptimizer's common-subexpression / duplicate-initializer passes hash
-    # tensor values and crash with "no supported data type: <N>" on element
-    # types they cannot hash, such as the float8 zero points produced by NVIDIA
-    # ModelOpt fp8 QDQ models (GitHub issue #348). When such a tensor is present
-    # we transparently skip those two passes so the rest of the simplification
-    # still runs, instead of failing outright. ``skipped_optimizers is None``
-    # means "skip every optimizer", so there is nothing to add in that case.
-    if skipped_optimizers is not None and _has_cse_unhashable_tensor(model):
-        added = [
-            opt
-            for opt in _TENSOR_VALUE_HASHING_OPTIMIZERS
-            if opt not in skipped_optimizers
-        ]
-        if added:
-            skipped_optimizers.extend(added)
-            print(
-                Text(
-                    "The model contains tensors with element types that "
-                    "onnxoptimizer cannot hash (e.g. float8/int4 in NVIDIA "
-                    "ModelOpt fp8 QDQ models). Skipping the optimizers "
-                    f"{added} to avoid a crash; all other simplifications "
-                    "still run.",
-                    style="bold magenta",
-                )
-            )
-
-    # The C++ optimizer re-serializes the graph and drops the `doc_string`
-    # fields on the model, graph and input/output value infos. Snapshot them
-    # here so they can be restored on the simplified model (GitHub issue #428).
-    doc_strings = _snapshot_doc_strings(model)
 
     tensor_size_threshold_bytes = parse_size(tensor_size_threshold)
     if tensor_size_threshold_bytes > 2**31 - 9999:
@@ -825,6 +774,9 @@ def simplify(
             rewriter,
             initializers_as_constants,
             inline_functions,
+            mutable_initializer,
+            overwrite_input_shapes,
+            unused_output,
         )
         # The serialized original (~1x model) is not needed once the C++
         # simplifier has consumed it -- the large-model fallback below
@@ -895,6 +847,9 @@ def simplify(
                 rewriter,
                 initializers_as_constants,
                 inline_functions,
+                mutable_initializer,
+                overwrite_input_shapes,
+                unused_output,
             )
             check_ok = model_checking.compare(
                 os.path.join(tmpdirname, "opt.onnx"),
@@ -931,7 +886,6 @@ def simplify(
                 pass
             finally:
                 shutil.rmtree(_ort_merge_dir, ignore_errors=True)
-    _restore_doc_strings(model_opt, doc_strings)
     return model_opt, check_ok
 
 

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -2201,6 +2201,136 @@ void RemoveInitializerFromInput(onnx::ModelProto& model) {
   }
 }
 
+// ONNX TensorProto element types onnxoptimizer's tensor-value hashing
+// (cse_util.h) knows how to hash. Any other type makes
+// eliminate_common_subexpression/eliminate_duplicate_initializer raise
+// "no supported data type: <N>". Enumerates the *supported* types (rather
+// than the unsupported ones) so an element type added to ONNX in the future
+// is treated as unhashable by default instead of silently crashing. Mirrors
+// onnx_simplifier.py's _CSE_HASHABLE_ELEM_TYPES.
+bool IsCSEHashableElemType(int32_t elem_type) {
+  switch (elem_type) {
+    case onnx::TensorProto::UNDEFINED:
+    case onnx::TensorProto::BOOL:
+    case onnx::TensorProto::INT8:
+    case onnx::TensorProto::INT16:
+    case onnx::TensorProto::INT32:
+    case onnx::TensorProto::INT64:
+    case onnx::TensorProto::UINT8:
+    case onnx::TensorProto::UINT16:
+    case onnx::TensorProto::UINT32:
+    case onnx::TensorProto::UINT64:
+    case onnx::TensorProto::FLOAT:
+    case onnx::TensorProto::DOUBLE:
+    case onnx::TensorProto::FLOAT16:
+    case onnx::TensorProto::BFLOAT16:
+    case onnx::TensorProto::COMPLEX64:
+    case onnx::TensorProto::COMPLEX128:
+    case onnx::TensorProto::STRING:
+      return true;
+    default:
+      return false;
+  }
+}
+
+// Mirrors onnx_simplifier.py's _has_cse_unhashable_tensor /
+// _iter_tensor_data_types: walks every tensor CSE might hash -- initializers,
+// t/ts node attributes, recursing into subgraphs -- looking for an element
+// type IsCSEHashableElemType rejects.
+bool GraphHasCSEUnhashableTensor(const onnx::GraphProto& graph) {
+  for (const auto& init : graph.initializer()) {
+    if (!IsCSEHashableElemType(init.data_type())) {
+      return true;
+    }
+  }
+  for (const auto& node : graph.node()) {
+    for (const auto& attr : node.attribute()) {
+      if (attr.has_t() && !IsCSEHashableElemType(attr.t().data_type())) {
+        return true;
+      }
+      for (const auto& t : attr.tensors()) {
+        if (!IsCSEHashableElemType(t.data_type())) {
+          return true;
+        }
+      }
+      if (attr.has_g() && GraphHasCSEUnhashableTensor(attr.g())) {
+        return true;
+      }
+      for (const auto& g : attr.graphs()) {
+        if (GraphHasCSEUnhashableTensor(g)) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+// Mirrors onnx_simplifier.py's overwrite_input_shapes loop: for each named
+// graph input, overwrite its shape's dims with the given values, skipping
+// any non-positive entry (which means "keep the original, possibly dynamic,
+// dimension" rather than hardcoding an invalid size such as 0 -- GitHub
+// issue #237). Throws std::runtime_error if a name isn't a graph input
+// (matching onnx_simplifier.py's RuntimeError for the same case).
+void ApplyInputShapeOverwrite(
+    onnx::ModelProto& model,
+    const std::unordered_map<std::string, std::vector<int64_t>>&
+        overwrite_input_shapes) {
+  for (const auto& [name, shape] : overwrite_input_shapes) {
+    bool found = false;
+    for (auto& input : *model.mutable_graph()->mutable_input()) {
+      if (input.name() != name) {
+        continue;
+      }
+      found = true;
+      auto* dims = input.mutable_type()
+                       ->mutable_tensor_type()
+                       ->mutable_shape()
+                       ->mutable_dim();
+      for (int i = 0; i < dims->size() && i < static_cast<int>(shape.size());
+           ++i) {
+        if (shape[i] > 0) {
+          dims->Mutable(i)->set_dim_value(shape[i]);
+        }
+      }
+    }
+    if (!found) {
+      throw std::runtime_error("The model doesn't have input named \"" + name +
+                               "\"");
+    }
+  }
+}
+
+// Mirrors onnx_simplifier.py's remove_unused_output: drops the named graph
+// outputs. Downstream dead-end elimination cleans up nodes that only fed
+// them. Throws std::runtime_error if a name isn't a graph output (matching
+// onnx_simplifier.py's RuntimeError for the same case).
+void RemoveUnusedOutputs(onnx::ModelProto& model,
+                         const std::vector<std::string>& unused_output) {
+  for (const auto& name : unused_output) {
+    bool found = false;
+    for (const auto& output : model.graph().output()) {
+      if (output.name() == name) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      throw std::runtime_error("The model doesn't have output named \"" + name +
+                               "\"");
+    }
+  }
+  auto* outputs = model.mutable_graph()->mutable_output();
+  google::protobuf::RepeatedPtrField<onnx::ValueInfoProto> kept;
+  for (auto& output : *outputs) {
+    if (std::find(unused_output.begin(), unused_output.end(), output.name()) ==
+        unused_output.end()) {
+      *kept.Add() = std::move(output);
+    }
+  }
+  outputs->Swap(&kept);
+}
+
 // Convert the default ONNX domain of the model to target_version using onnx's
 // own version converter. Only the default ONNX domain opset is changed;
 // custom/other-domain opset imports are left untouched. Returns the model
@@ -2261,12 +2391,99 @@ onnx::ModelProto FoldConstantOnce(const ModelExecutor& executor,
   return out;
 }
 
+// Records the options this Simplify() call actually used (skip_optimizers
+// reflects any auto-added unhashable-tensor protections) as string
+// key/value pairs in the model's metadata_props, namespaced under
+// "onnxsim:" so they cannot collide with the model's own metadata. Lets a
+// downstream consumer see how a model was simplified without having to have
+// kept the original call around. Replaces any pre-existing "onnxsim:*"
+// entries (e.g. left by a previous simplify() call) rather than
+// accumulating duplicates across repeated simplification.
+void RecordSimplifyOptionsMetadata(
+    onnx::ModelProto& model,
+    const std::optional<std::vector<std::string>>& skip_optimizers,
+    bool constant_folding, bool shape_inference, size_t tensor_size_threshold,
+    std::optional<int> target_opset_version, bool initializers_as_constants,
+    bool include_inline_functions, bool mutable_initializer,
+    const std::optional<std::unordered_map<std::string, std::vector<int64_t>>>&
+        overwrite_input_shapes,
+    const std::optional<std::vector<std::string>>& unused_output) {
+  auto join = [](const std::vector<std::string>& v) {
+    std::string out;
+    for (size_t i = 0; i < v.size(); ++i) {
+      if (i > 0) {
+        out += ",";
+      }
+      out += v[i];
+    }
+    return out;
+  };
+
+  std::vector<std::pair<std::string, std::string>> options;
+  options.emplace_back("onnxsim:skip_optimizers",
+                       skip_optimizers ? join(*skip_optimizers) : "<all>");
+  options.emplace_back("onnxsim:constant_folding",
+                       constant_folding ? "true" : "false");
+  options.emplace_back("onnxsim:shape_inference",
+                       shape_inference ? "true" : "false");
+  options.emplace_back("onnxsim:tensor_size_threshold",
+                       std::to_string(tensor_size_threshold));
+  options.emplace_back(
+      "onnxsim:target_opset_version",
+      target_opset_version ? std::to_string(*target_opset_version) : "");
+  options.emplace_back("onnxsim:initializers_as_constants",
+                       initializers_as_constants ? "true" : "false");
+  options.emplace_back("onnxsim:include_inline_functions",
+                       include_inline_functions ? "true" : "false");
+  options.emplace_back("onnxsim:mutable_initializer",
+                       mutable_initializer ? "true" : "false");
+  if (overwrite_input_shapes) {
+    std::string s;
+    bool first = true;
+    for (const auto& [name, shape] : *overwrite_input_shapes) {
+      if (!first) {
+        s += ";";
+      }
+      first = false;
+      s += name + ":";
+      for (size_t i = 0; i < shape.size(); ++i) {
+        if (i > 0) {
+          s += ",";
+        }
+        s += std::to_string(shape[i]);
+      }
+    }
+    options.emplace_back("onnxsim:overwrite_input_shapes", s);
+  }
+  if (unused_output) {
+    options.emplace_back("onnxsim:unused_output", join(*unused_output));
+  }
+
+  auto* props = model.mutable_metadata_props();
+  google::protobuf::RepeatedPtrField<onnx::StringStringEntryProto> kept;
+  for (auto& prop : *props) {
+    if (prop.key().rfind("onnxsim:", 0) != 0) {
+      *kept.Add() = std::move(prop);
+    }
+  }
+  props->Swap(&kept);
+  for (const auto& [key, value] : options) {
+    auto* entry = props->Add();
+    entry->set_key(key);
+    entry->set_value(value);
+  }
+}
+
 onnx::ModelProto Simplify(
     const ModelExecutor& executor, const onnx::ModelProto& model,
     std::optional<std::vector<std::string>> skip_optimizers,
     bool constant_folding, bool shape_inference, size_t tensor_size_threshold,
     std::optional<int> target_opset_version, const GraphRewriter* rewriter,
-    bool initializers_as_constants, bool include_inline_functions) {
+    bool initializers_as_constants, bool include_inline_functions,
+    bool mutable_initializer,
+    const std::optional<std::unordered_map<std::string, std::vector<int64_t>>>&
+        overwrite_input_shapes,
+    const std::optional<std::vector<std::string>>& unused_output) {
   // Register onnxsim's own optimizer passes into onnxoptimizer's registry
   // before the pass list is built below: fuse_consecutive_mul,
   // fuse_mul_into_conv, fuse_preceding_mul_into_conv and
@@ -2312,6 +2529,23 @@ onnx::ModelProto Simplify(
                         const std::string& pass) {
     return std::find(list.begin(), list.end(), pass) != list.end();
   };
+  // onnxoptimizer's common-subexpression / duplicate-initializer passes hash
+  // tensor values and crash with "no supported data type: <N>" on element
+  // types they cannot hash, such as the float8 zero points produced by
+  // NVIDIA ModelOpt fp8 QDQ models (GitHub issue #348). When such a tensor
+  // is present, transparently skip those two passes so the rest of
+  // simplification still runs, instead of crashing outright. Only relevant
+  // when some optimizer is actually going to run (skip_optimizers ==
+  // nullopt already disables all of them).
+  if (skip_optimizers && GraphHasCSEUnhashableTensor(model.graph())) {
+    static const std::vector<std::string> kTensorValueHashingOptimizers = {
+        "eliminate_common_subexpression", "eliminate_duplicate_initializer"};
+    for (const auto& opt : kTensorValueHashingOptimizers) {
+      if (!is_disabled(*skip_optimizers, opt)) {
+        skip_optimizers->push_back(opt);
+      }
+    }
+  }
   // skip_optimizers == nullopt means skiping all optimizers, so
   // config.optimizer_passes is empty
   if (skip_optimizers) {
@@ -2563,6 +2797,22 @@ onnx::ModelProto Simplify(
   // The fixed points mutate in place, so make one working copy of the (const)
   // input model and simplify it in place.
   onnx::ModelProto sim_model = model;
+  // Matches onnx_simplifier.py's default (mutable_initializer=False): fold
+  // initializers that also appear as graph inputs like any other constant.
+  if (!mutable_initializer) {
+    RemoveInitializerFromInput(sim_model);
+  }
+  // Overwrite named input shapes, if requested, before shape inference or
+  // any transform runs -- mirrors onnx_simplifier.py's overwrite_input_shapes
+  // loop, applied here instead of by the Python wrapper.
+  if (overwrite_input_shapes) {
+    ApplyInputShapeOverwrite(sim_model, *overwrite_input_shapes);
+  }
+  // Drop the named graph outputs, if requested, before the fixed point so
+  // dead-end elimination cleans up nodes that only fed them.
+  if (unused_output) {
+    RemoveUnusedOutputs(sim_model, *unused_output);
+  }
   // Optionally inline the model's local (model-defined) functions into the main
   // graph up front, so the optimizer, shape inference and constant folding
   // below see through them into a flat op graph. Done before the opset
@@ -2746,6 +2996,11 @@ onnx::ModelProto Simplify(
   // name; assign unique names to them so downstream tools that key on node
   // names keep working (issue #269).
   AssignMissingNodeNames(sim_model);
+  RecordSimplifyOptionsMetadata(sim_model, skip_optimizers, constant_folding,
+                                shape_inference, tensor_size_threshold,
+                                target_opset_version, initializers_as_constants,
+                                include_inline_functions, mutable_initializer,
+                                overwrite_input_shapes, unused_output);
   Check(sim_model);
   if (!converged) {
     std::cout << "WARNING: the simplification stopped because of timeout. "
@@ -2757,14 +3012,17 @@ onnx::ModelProto Simplify(
   return sim_model;
 }
 
-void SimplifyPath(const ModelExecutor& executor, const std::string& in_path,
-                  const std::string& out_path,
-                  std::optional<std::vector<std::string>> skip_optimizers,
-                  bool constant_folding, bool shape_inference,
-                  size_t tensor_size_threshold,
-                  std::optional<int> target_opset_version,
-                  const GraphRewriter* rewriter, bool initializers_as_constants,
-                  bool include_inline_functions, bool mutable_initializer) {
+void SimplifyPath(
+    const ModelExecutor& executor, const std::string& in_path,
+    const std::string& out_path,
+    std::optional<std::vector<std::string>> skip_optimizers,
+    bool constant_folding, bool shape_inference, size_t tensor_size_threshold,
+    std::optional<int> target_opset_version, const GraphRewriter* rewriter,
+    bool initializers_as_constants, bool include_inline_functions,
+    bool mutable_initializer,
+    const std::optional<std::unordered_map<std::string, std::vector<int64_t>>>&
+        overwrite_input_shapes,
+    const std::optional<std::vector<std::string>>& unused_output) {
   const bool debug_timing = std::getenv("ONNXSIM_DEBUG_PATH_TIMING") != nullptr;
   auto now = []() { return std::chrono::steady_clock::now(); };
   auto elapsed_ms = [](auto t0, auto t1) {
@@ -2781,22 +3039,13 @@ void SimplifyPath(const ModelExecutor& executor, const std::string& in_path,
     }
   }
 
-  // Matches onnx_simplifier.py's default (mutable_initializer=False): fold
-  // initializers that also appear as graph inputs like any other constant.
-  // Defaults to true (skip) so callers that predate this parameter (the C
-  // API, and Python's pre-existing >2GB fallback, which already applies the
-  // equivalent transform itself in Python before ever reaching this
-  // function) see no behavior change.
-  if (!mutable_initializer) {
-    RemoveInitializerFromInput(model);
-  }
-
   {
     const auto t0 = now();
     model =
         Simplify(executor, model, skip_optimizers, constant_folding,
                  shape_inference, tensor_size_threshold, target_opset_version,
-                 rewriter, initializers_as_constants, include_inline_functions);
+                 rewriter, initializers_as_constants, include_inline_functions,
+                 mutable_initializer, overwrite_input_shapes, unused_output);
     if (debug_timing) {
       std::cerr << "SimplifyPath: Simplify " << elapsed_ms(t0, now()) << "ms\n";
     }

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -4,6 +4,8 @@
 
 #include <memory>
 #include <optional>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "dlpack/dlpack.h"
@@ -94,6 +96,15 @@ std::shared_ptr<const ModelExecutor> GetBuiltinModelExecutor();
 // inference and constant folding can see through them; schema-defined
 // (built-in) functions are left alone. With the default the model's functions
 // are left untouched.
+// ``mutable_initializer`` (default true, i.e. skip) additionally folds an
+// initializer that also appears as a graph input, like any other constant,
+// when set to false -- see RemoveInitializerFromInput's own comment.
+// ``overwrite_input_shapes``, when set, overwrites the named graph inputs'
+// shape dims with the given values (a non-positive entry keeps the original,
+// possibly dynamic, dimension). ``unused_output``, when set, drops the named
+// graph outputs before simplification so dead-end elimination cleans up
+// nodes that only fed them. Both throw std::runtime_error if a name does
+// not match an existing graph input/output.
 onnx::ModelProto Simplify(
     const ModelExecutor& executor, const onnx::ModelProto& model,
     std::optional<std::vector<std::string>> skip_optimizers,
@@ -101,7 +112,11 @@ onnx::ModelProto Simplify(
     std::optional<int> target_opset_version = std::nullopt,
     const GraphRewriter* rewriter = nullptr,
     bool initializers_as_constants = true,
-    bool include_inline_functions = false);
+    bool include_inline_functions = false, bool mutable_initializer = true,
+    const std::optional<std::unordered_map<std::string, std::vector<int64_t>>>&
+        overwrite_input_shapes = std::nullopt,
+    const std::optional<std::vector<std::string>>& unused_output =
+        std::nullopt);
 
 // Debugging helpers: run a *single* one of the transforms that ``Simplify``
 // otherwise drives to a fixed point, once, on a copy of ``model``, and return
@@ -123,13 +138,16 @@ onnx::ModelProto FoldConstantOnce(const ModelExecutor& executor,
                                   size_t tensor_size_threshold,
                                   bool initializers_as_constants = true);
 
-void SimplifyPath(const ModelExecutor& executor, const std::string& in_path,
-                  const std::string& out_path,
-                  std::optional<std::vector<std::string>> skip_optimizers,
-                  bool constant_folding, bool shape_inference,
-                  size_t tensor_size_threshold,
-                  std::optional<int> target_opset_version = std::nullopt,
-                  const GraphRewriter* rewriter = nullptr,
-                  bool initializers_as_constants = true,
-                  bool include_inline_functions = false,
-                  bool mutable_initializer = true);
+void SimplifyPath(
+    const ModelExecutor& executor, const std::string& in_path,
+    const std::string& out_path,
+    std::optional<std::vector<std::string>> skip_optimizers,
+    bool constant_folding, bool shape_inference, size_t tensor_size_threshold,
+    std::optional<int> target_opset_version = std::nullopt,
+    const GraphRewriter* rewriter = nullptr,
+    bool initializers_as_constants = true,
+    bool include_inline_functions = false, bool mutable_initializer = true,
+    const std::optional<std::unordered_map<std::string, std::vector<int64_t>>>&
+        overwrite_input_shapes = std::nullopt,
+    const std::optional<std::vector<std::string>>& unused_output =
+        std::nullopt);


### PR DESCRIPTION
Stacked on #646 (unmerged) -- this branch is `claude/onnxsim-issue-633-454xyc` plus one new commit.

## Summary

- Move `overwrite_input_shapes` application, `unused_output` removal, and the unhashable-tensor CSE auto-skip out of Python and into `Simplify()`/`SimplifyPath()` in `onnxsim.cpp`. `simplify()`'s native fast path (introduced in #646 for file paths only) now also handles these natively, and is extended to in-memory `ModelProto` input as well (a single `SerializeToString`/`C.simplify` bytes round trip). `simplify()` now only falls back to the slower, fully-materialized Python path when `check_n > 0` or a shape dict uses the "`None` key" convenience that needs the model's own input names.
- `Simplify()`/`SimplifyPath()` gain three new trailing, defaulted parameters (`mutable_initializer`, `overwrite_input_shapes`, `unused_output`), threaded through unchanged to the C API, WASM interface, and standalone CLI callers.
- Record the *effective* `simplify()` options actually used -- including any optimizers auto-added by the unhashable-tensor CSE guard -- into the output model's `metadata_props`, under an `onnxsim:`-prefixed key. Repeated simplification replaces prior `onnxsim:*` entries rather than accumulating them.
- Delete `_snapshot_doc_strings`/`_restore_doc_strings`: empirical testing (round-tripping `doc_string` on model/graph/node/input/output via both the native fast path and the old object-based path) showed `doc_string` already survives correctly through the native C++ path alone, making this Python-side snapshot/restore mechanism dead code. The one real gap found -- intermediate (non-input/output) `value_info` entries being dropped -- reproduces identically with or without that code, i.e. it's a pre-existing, unrelated limitation, not something the fast path regressed (this corrects an "accepted gap" note from #646's own description, which had assumed the opposite).
- `remove_unused_output`, `remove_initializer_from_input`, and `_has_cse_unhashable_tensor` remain defined in `onnx_simplifier.py` (still exercised by direct unit tests in `tests/test_simple.py`) but are no longer called from `simplify()`'s main body, since the C++ core now performs the equivalent work.

## Test plan

- [x] `tests/test_simple.py`, `tests/test_constant_fold_determinism.py`, `tests/test_python_api.py`, `tests/test_function_rewriter_vs_onnxscript.py`: 64 passed, 1 skipped (excluding 3 pre-existing/environmental failures confirmed to reproduce identically on the unmodified base branch: 2x missing optional `onnxscript` dependency, 1x a pre-existing onnx-optimizer tensor-parsing assertion at the 2GB boundary, unrelated to this change)
- [x] All 6 torchvision end-to-end tests (`test_torchvision_fasterrcnn_fpn`, `test_torchvision_maskrcnn_fpn_opset11`, `test_torchvision_keypointrcnn_fpn`, `test_torchvision_shufflenet_v2`, `test_torchvision_mnasnet`, `test_torchvision_deeplabv3`), run individually: all pass
- [x] Direct C++-level tests of the new native options (`overwrite_input_shapes`, `unused_output`, `metadata_props` contents, bad-name error type) via `C.simplify_path`, bypassing the Python wrapper entirely: all pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01ADw2idu5qWKonBuaBcJEP4)_