### PR TITLE
Fix value_info UNDEFINED elem_type breaking ORT load; add Audio8 regression test

### DIFF
--- a/.github/workflows/audio8.yml
+++ b/.github/workflows/audio8.yml
@@ -1,0 +1,69 @@
+name: Audio8 regression test
+
+# Builds onnxsim from source and runs tests/test_audio8.py, which downloads
+# real ONNX exports from the Audio8 org on Hugging Face
+# (https://huggingface.co/Audio8 -- TTS/ASR models shipped with ONNX Runtime
+# deployment packages) and simplifies each with onnxsim. This guards against
+# onnxsim regressions on Audio8-style graphs -- see tests/test_audio8.py's
+# module docstring for the real onnxsim bug this surfaced (a malformed
+# value_info entry, shape known but elem_type left UNDEFINED, that made a
+# simplified model fail to load in onnxruntime).
+
+# Downloads real models over the network and, for the TTS cases, takes over a
+# minute per model under check_n=3 -- too slow/network-dependent to run on
+# every PR unconditionally. It always runs weekly and on push to the default
+# branch, and additionally runs on a PR when the PR itself touches the files
+# this test exists to guard (the test itself, or onnxsim.cpp, where
+# DropIncompleteValueInfo lives); use workflow_dispatch to trigger it
+# manually against a branch for any other change.
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    paths:
+      - tests/test_audio8.py
+      - onnxsim/onnxsim.cpp
+      - .github/workflows/audio8.yml
+  schedule:
+    - cron: '0 9 * * 1'  # weekly, Monday 09:00 UTC
+  workflow_dispatch:
+
+jobs:
+  audio8:
+    name: Audio8 (Hugging Face) -> onnxsim
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CMAKE_GENERATOR: Ninja
+      CMAKE_CXX_COMPILER_LAUNCHER: sccache
+      SCCACHE_GHA_ENABLED: 'on'
+      ACTIONS_CACHE_SERVICE_V2: 'on'
+      ONNXSIM_RUN_AUDIO8_TESTS: '1'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+      - uses: mozilla-actions/sccache-action@v0.0.11
+
+      - name: Install build tooling
+        run: pip install cmake ninja "setuptools>=77" sccache nanobind
+
+      - name: Install test dependencies
+        run: pip install pytest onnxruntime
+
+      # Build the onnxsim under test last so it wins over anything a dependency
+      # might have pulled. --no-build-isolation reuses the tooling installed above.
+      - name: Build onnxsim (editable)
+        run: pip install --no-build-isolation -ve .
+
+      - name: Verify onnxsim under test is the source build
+        run: python -c "import onnxsim, onnxsim.onnxsim_cpp2py_export; print('onnxsim', onnxsim.__version__, onnxsim.__file__)"
+
+      - name: Run Audio8 regression test
+        run: pytest -v tests/test_audio8.py

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,7 @@ jobs:
       # GITHUB_EVENT_NAME/GITHUB_REF are forwarded so tests/test_timm.py can tell
       # a master-branch push from a pull request inside the manylinux container.
       CIBW_ENVIRONMENT_PASS_LINUX: CI SCCACHE_GHA_ENABLED ACTIONS_RESULTS_URL ACTIONS_RUNTIME_TOKEN ACTIONS_CACHE_SERVICE_V2 ONNXSIM_RELEASE GITHUB_EVENT_NAME GITHUB_REF
-      CIBW_BEFORE_BUILD: "python3 -m pip install --break-system-packages cmake ninja setuptools sccache"
+      CIBW_BEFORE_BUILD: "python3 -m pip install --break-system-packages cmake ninja setuptools sccache nanobind"
       CIBW_TEST_REQUIRES: pytest flake8 onnxruntime onnxscript==0.6.2 timm==1.0.26 sympy onnxslim
       CIBW_BEFORE_TEST: pip install torch==2.10.0 torchvision==0.25.0 --index-url https://download.pytorch.org/whl/cpu/
       CIBW_TEST_COMMAND: pytest -v ${{ matrix.pytest_args }} {project}/tests && onnxsim -h && onnxsim --list-default-optimizers

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Install build + coverage tooling
       run: |
-        pip install cmake ninja "setuptools>=77" sccache
+        pip install cmake ninja "setuptools>=77" sccache nanobind
         pip install pytest pytest-cov gcovr
 
     # Kick the network-heavy, build-independent test-dependency install off in

--- a/.github/workflows/halide-integration.yml
+++ b/.github/workflows/halide-integration.yml
@@ -55,7 +55,7 @@ jobs:
           CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_ENVIRONMENT_PASS_LINUX: CI SCCACHE_GHA_ENABLED ACTIONS_RESULTS_URL ACTIONS_RUNTIME_TOKEN ACTIONS_CACHE_SERVICE_V2
-          CIBW_BEFORE_BUILD: "python3 -m pip install --break-system-packages cmake ninja setuptools sccache"
+          CIBW_BEFORE_BUILD: "python3 -m pip install --break-system-packages cmake ninja setuptools sccache nanobind"
           CIBW_ENVIRONMENT: CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=OFF" CMAKE_GENERATOR=Ninja CMAKE_CXX_COMPILER_LAUNCHER=sccache CMAKE_LINKER_TYPE=LLD
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel} --strip"
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/intel-integration.yml
+++ b/.github/workflows/intel-integration.yml
@@ -54,7 +54,7 @@ jobs:
           CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_ENVIRONMENT_PASS_LINUX: CI SCCACHE_GHA_ENABLED ACTIONS_RESULTS_URL ACTIONS_RUNTIME_TOKEN ACTIONS_CACHE_SERVICE_V2
-          CIBW_BEFORE_BUILD: "python3 -m pip install --break-system-packages cmake ninja setuptools sccache"
+          CIBW_BEFORE_BUILD: "python3 -m pip install --break-system-packages cmake ninja setuptools sccache nanobind"
           CIBW_ENVIRONMENT: CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=OFF" CMAKE_GENERATOR=Ninja CMAKE_CXX_COMPILER_LAUNCHER=sccache CMAKE_LINKER_TYPE=LLD
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel} --strip"
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/model-regression.yml
+++ b/.github/workflows/model-regression.yml
@@ -64,7 +64,7 @@ jobs:
           CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_ENVIRONMENT_PASS_LINUX: CI SCCACHE_GHA_ENABLED ACTIONS_RESULTS_URL ACTIONS_RUNTIME_TOKEN ACTIONS_CACHE_SERVICE_V2
-          CIBW_BEFORE_BUILD: "python3 -m pip install --break-system-packages cmake ninja setuptools sccache"
+          CIBW_BEFORE_BUILD: "python3 -m pip install --break-system-packages cmake ninja setuptools sccache nanobind"
           CIBW_ENVIRONMENT: CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=OFF" CMAKE_GENERATOR=Ninja CMAKE_CXX_COMPILER_LAUNCHER=sccache CMAKE_LINKER_TYPE=LLD
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel} --strip"
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/modelopt-integration.yml
+++ b/.github/workflows/modelopt-integration.yml
@@ -54,7 +54,7 @@ jobs:
           CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_ENVIRONMENT_PASS_LINUX: CI SCCACHE_GHA_ENABLED ACTIONS_RESULTS_URL ACTIONS_RUNTIME_TOKEN ACTIONS_CACHE_SERVICE_V2
-          CIBW_BEFORE_BUILD: "python3 -m pip install --break-system-packages cmake ninja setuptools sccache"
+          CIBW_BEFORE_BUILD: "python3 -m pip install --break-system-packages cmake ninja setuptools sccache nanobind"
           CIBW_ENVIRONMENT: CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=OFF" CMAKE_GENERATOR=Ninja CMAKE_CXX_COMPILER_LAUNCHER=sccache CMAKE_LINKER_TYPE=LLD
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel} --strip"
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/qualcomm-integration.yml
+++ b/.github/workflows/qualcomm-integration.yml
@@ -55,7 +55,7 @@ jobs:
           CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_ENVIRONMENT_PASS_LINUX: CI SCCACHE_GHA_ENABLED ACTIONS_RESULTS_URL ACTIONS_RUNTIME_TOKEN ACTIONS_CACHE_SERVICE_V2
-          CIBW_BEFORE_BUILD: "python3 -m pip install --break-system-packages cmake ninja setuptools sccache"
+          CIBW_BEFORE_BUILD: "python3 -m pip install --break-system-packages cmake ninja setuptools sccache nanobind"
           CIBW_ENVIRONMENT: CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=OFF" CMAKE_GENERATOR=Ninja CMAKE_CXX_COMPILER_LAUNCHER=sccache CMAKE_LINKER_TYPE=LLD
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel} --strip"
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/rfdetr.yml
+++ b/.github/workflows/rfdetr.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Install build tooling
-        run: pip install cmake ninja "setuptools>=77" sccache
+        run: pip install cmake ninja "setuptools>=77" sccache nanobind
 
       # Base rfdetr pulls torch/transformers but NOT onnxsim (that lives in its
       # [onnx] extra). Install CPU torch explicitly first so rfdetr reuses it.

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -55,7 +55,7 @@ jobs:
         python-version: '3.14'
     - uses: mozilla-actions/sccache-action@v0.0.11
 
-    - run: pip install cmake ninja setuptools sccache
+    - run: pip install cmake ninja setuptools sccache nanobind
 
     # Download/install the build-independent test dependencies (all prebuilt
     # wheels) in the background so they fetch while the instrumented build below

--- a/.github/workflows/tvm-integration.yml
+++ b/.github/workflows/tvm-integration.yml
@@ -54,7 +54,7 @@ jobs:
           CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_ENVIRONMENT_PASS_LINUX: CI SCCACHE_GHA_ENABLED ACTIONS_RESULTS_URL ACTIONS_RUNTIME_TOKEN ACTIONS_CACHE_SERVICE_V2
-          CIBW_BEFORE_BUILD: "python3 -m pip install --break-system-packages cmake ninja setuptools sccache"
+          CIBW_BEFORE_BUILD: "python3 -m pip install --break-system-packages cmake ninja setuptools sccache nanobind"
           CIBW_ENVIRONMENT: CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=OFF" CMAKE_GENERATOR=Ninja CMAKE_CXX_COMPILER_LAUNCHER=sccache CMAKE_LINKER_TYPE=LLD
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel} --strip"
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/voicevox.yml
+++ b/.github/workflows/voicevox.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Install build tooling
-        run: pip install cmake ninja "setuptools>=77" sccache
+        run: pip install cmake ninja "setuptools>=77" sccache nanobind
 
       - name: Install test dependencies
         run: pip install pytest onnxruntime

--- a/.github/workflows/x2paddle-regression.yml
+++ b/.github/workflows/x2paddle-regression.yml
@@ -57,7 +57,7 @@ jobs:
           CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_ENVIRONMENT_PASS_LINUX: CI SCCACHE_GHA_ENABLED ACTIONS_RESULTS_URL ACTIONS_RUNTIME_TOKEN ACTIONS_CACHE_SERVICE_V2
-          CIBW_BEFORE_BUILD: "python3 -m pip install --break-system-packages cmake ninja setuptools sccache"
+          CIBW_BEFORE_BUILD: "python3 -m pip install --break-system-packages cmake ninja setuptools sccache nanobind"
           CIBW_ENVIRONMENT: CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=OFF" CMAKE_GENERATOR=Ninja CMAKE_CXX_COMPILER_LAUNCHER=sccache CMAKE_LINKER_TYPE=LLD
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel} --strip"
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/yolo.yml
+++ b/.github/workflows/yolo.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Install build tooling
-        run: pip install cmake ninja "setuptools>=77" sccache
+        run: pip install cmake ninja "setuptools>=77" sccache nanobind
 
       # Install CPU torch explicitly first so ultralytics reuses it instead of
       # pulling a CUDA build.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,13 +362,23 @@ if (ONNXSIM_PYTHON)
 
   # nanobind ships its CMake package config inside its own pip-installed
   # wheel (not on any default CMake search path), so it must be located via
-  # its Python API and added to CMAKE_PREFIX_PATH before find_package(nanobind)
-  # can locate it -- this is nanobind's documented CMake integration pattern.
+  # its Python API before find_package(nanobind) can locate it -- this is
+  # nanobind's documented CMake integration pattern. Set nanobind_DIR
+  # directly to the directory --cmake_dir prints (which already *is* the
+  # directory containing nanobind-config.cmake) rather than only appending
+  # it to CMAKE_PREFIX_PATH: find_package's CONFIG-mode search additionally
+  # probes a "cmake/" suffix under each CMAKE_PREFIX_PATH entry, which -- on
+  # at least macOS cibuildwheel builds -- has been observed to resolve to a
+  # spurious nested ".../nanobind/cmake/cmake/nanobind-config.cmake",
+  # producing a doubled-up NB_DIR inside nanobind's own config script and a
+  # linker failure looking for ".../nanobind/cmake/cmake/darwin-ld-*.sym".
+  # Setting nanobind_DIR directly matches scripts/cross/build_windows_wheel.sh's
+  # already-proven -Dnanobind_DIR usage and sidesteps that ambiguity entirely.
   execute_process(
     COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE NB_DIR)
-  list(APPEND CMAKE_PREFIX_PATH "${NB_DIR}")
+  set(nanobind_DIR "${NB_DIR}" CACHE PATH "" FORCE)
   find_package(nanobind CONFIG REQUIRED)
 
   # FREE_THREADED marks the module Py_MOD_GIL_NOT_USED so free-threaded

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,18 @@ if (ONNXSIM_PYTHON)
     Python 3.10
     COMPONENTS Interpreter Development.Module REQUIRED
     OPTIONAL_COMPONENTS Development.SABIModule)
+
+  # nanobind ships its CMake package config inside its own pip-installed
+  # wheel (not on any default CMake search path), so it must be located via
+  # its Python API and added to CMAKE_PREFIX_PATH before find_package(nanobind)
+  # can locate it -- this is nanobind's documented CMake integration pattern.
+  execute_process(
+    COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE NB_DIR)
+  list(APPEND CMAKE_PREFIX_PATH "${NB_DIR}")
+  find_package(nanobind CONFIG REQUIRED)
+
   # FREE_THREADED marks the module Py_MOD_GIL_NOT_USED so free-threaded
   # interpreters (e.g. the cp314t wheel) keep the GIL disabled instead of
   # re-enabling it at import. nanobind ignores STABLE_ABI on free-threaded

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,21 +365,33 @@ if (ONNXSIM_PYTHON)
   # its Python API before find_package(nanobind) can locate it -- this is
   # nanobind's documented CMake integration pattern. Set nanobind_DIR
   # directly to the directory --cmake_dir prints (which already *is* the
-  # directory containing nanobind-config.cmake) rather than only appending
-  # it to CMAKE_PREFIX_PATH: find_package's CONFIG-mode search additionally
-  # probes a "cmake/" suffix under each CMAKE_PREFIX_PATH entry, which -- on
-  # at least macOS cibuildwheel builds -- has been observed to resolve to a
-  # spurious nested ".../nanobind/cmake/cmake/nanobind-config.cmake",
-  # producing a doubled-up NB_DIR inside nanobind's own config script and a
-  # linker failure looking for ".../nanobind/cmake/cmake/darwin-ld-*.sym".
-  # Setting nanobind_DIR directly matches scripts/cross/build_windows_wheel.sh's
-  # already-proven -Dnanobind_DIR usage and sidesteps that ambiguity entirely.
+  # directory containing nanobind-config.cmake).
+  #
+  # nanobind-config.cmake self-computes its OWN "NB_DIR" (nanobind's package
+  # root, used e.g. as "${NB_DIR}/cmake/darwin-ld-cpython.sym" for the macOS
+  # linker response file) via get_filename_component(... CMAKE_CURRENT_LIST_FILE
+  # ...) and caches it as NB_DIR CACHE INTERNAL. That collides by name with a
+  # local (non-cache) variable this block used to set for the very same
+  # --cmake_dir output -- on at least one macOS cibuildwheel build this left
+  # nanobind's own NB_DIR one directory level too deep (pointing at the
+  # cmake/ subdirectory instead of the package root), producing a doubled
+  # ".../nanobind/cmake/cmake/darwin-ld-cpython.sym" link failure. Use a
+  # differently-named local variable to avoid any chance of that collision,
+  # and force nanobind's own NB_DIR to the independently-known-correct value
+  # (one directory above --cmake_dir's output) as a defensive follow-up, in
+  # case a stale NB_DIR cache entry from an earlier configure attempt in the
+  # same build directory would otherwise have survived (plain `CACHE
+  # INTERNAL` sets, as nanobind's config script uses, only take effect the
+  # first time -- they do not overwrite an existing cache entry).
   execute_process(
     COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
     OUTPUT_STRIP_TRAILING_WHITESPACE
-    OUTPUT_VARIABLE NB_DIR)
-  set(nanobind_DIR "${NB_DIR}" CACHE PATH "" FORCE)
+    OUTPUT_VARIABLE ONNXSIM_NANOBIND_CMAKE_DIR)
+  set(nanobind_DIR "${ONNXSIM_NANOBIND_CMAKE_DIR}" CACHE PATH "" FORCE)
   find_package(nanobind CONFIG REQUIRED)
+  get_filename_component(ONNXSIM_NANOBIND_PACKAGE_ROOT
+                          "${ONNXSIM_NANOBIND_CMAKE_DIR}" DIRECTORY)
+  set(NB_DIR "${ONNXSIM_NANOBIND_PACKAGE_ROOT}" CACHE INTERNAL "" FORCE)
 
   # FREE_THREADED marks the module Py_MOD_GIL_NOT_USED so free-threaded
   # interpreters (e.g. the cp314t wheel) keep the GIL disabled instead of

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -2151,6 +2151,45 @@ void AssignMissingNodeNames(onnx::ModelProto& model) {
   AssignMissingNodeNames(*model.mutable_graph(), used_names, counter);
 }
 
+// Shape inference can leave behind a value_info entry that records a shape
+// but never resolved an element type (e.g. observed on a real-world model's
+// Reshape outputs inside attention blocks: graph_shape_inference.h's
+// InferShapesOnGraph propagated the target shape but left elem_type at its
+// default UNDEFINED). value_info is purely optional annotation -- nothing
+// reads it as ground truth -- but an entry with elem_type == UNDEFINED is a
+// malformed TypeProto, and onnx::checker::check_model does not reject it,
+// while onnxruntime's own model loader is stricter and refuses to load the
+// model at all with "Invalid tensor data type 0". Drop such entries instead
+// of leaving broken metadata in the output model; the same op's actual
+// output tensor is unaffected either way.
+// Recurses into subgraphs (If/Loop/Scan bodies) for the same reason
+// AssignMissingNodeNames does.
+void DropIncompleteValueInfo(onnx::GraphProto& graph) {
+  auto& value_info = *graph.mutable_value_info();
+  value_info.erase(
+      std::remove_if(value_info.begin(), value_info.end(),
+                      [](const onnx::ValueInfoProto& vi) {
+                        return vi.type().has_tensor_type() &&
+                               vi.type().tensor_type().elem_type() ==
+                                   onnx::TensorProto::UNDEFINED;
+                      }),
+      value_info.end());
+  for (auto& node : *graph.mutable_node()) {
+    for (auto& attr : *node.mutable_attribute()) {
+      if (attr.has_g()) {
+        DropIncompleteValueInfo(*attr.mutable_g());
+      }
+      for (auto& subgraph : *attr.mutable_graphs()) {
+        DropIncompleteValueInfo(subgraph);
+      }
+    }
+  }
+}
+
+void DropIncompleteValueInfo(onnx::ModelProto& model) {
+  DropIncompleteValueInfo(*model.mutable_graph());
+}
+
 void Check(const onnx::ModelProto& model) { onnx::checker::check_model(model); }
 
 // Return the opset version the model imports for the default ONNX domain
@@ -2996,6 +3035,7 @@ onnx::ModelProto Simplify(
   // name; assign unique names to them so downstream tools that key on node
   // names keep working (issue #269).
   AssignMissingNodeNames(sim_model);
+  DropIncompleteValueInfo(sim_model);
   RecordSimplifyOptionsMetadata(sim_model, skip_optimizers, constant_folding,
                                 shape_inference, tensor_size_threshold,
                                 target_opset_version, initializers_as_constants,

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -2168,11 +2168,11 @@ void DropIncompleteValueInfo(onnx::GraphProto& graph) {
   auto& value_info = *graph.mutable_value_info();
   value_info.erase(
       std::remove_if(value_info.begin(), value_info.end(),
-                      [](const onnx::ValueInfoProto& vi) {
-                        return vi.type().has_tensor_type() &&
-                               vi.type().tensor_type().elem_type() ==
-                                   onnx::TensorProto::UNDEFINED;
-                      }),
+                     [](const onnx::ValueInfoProto& vi) {
+                       return vi.type().has_tensor_type() &&
+                              vi.type().tensor_type().elem_type() ==
+                                  onnx::TensorProto::UNDEFINED;
+                     }),
       value_info.end());
   for (auto& node : *graph.mutable_node()) {
     for (auto& attr : *node.mutable_attribute()) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=77", "wheel"]
+requires = ["setuptools>=77", "wheel", "nanobind>=2.12.0"]
 build-backend = "setuptools.build_meta:__legacy__"
 
 [project]

--- a/tests/test_audio8.py
+++ b/tests/test_audio8.py
@@ -1,0 +1,216 @@
+# Integration/regression test: onnxsim against real ONNX exports from the
+# Audio8 org on Hugging Face (https://huggingface.co/Audio8), a set of
+# permissively-licensed TTS/ASR audio models shipped with ONNX Runtime
+# deployment packages. This guards against onnxsim regressions on the kind of
+# LLM-style, KV-cache-carrying, quantized graphs those packages ship:
+# ``com.microsoft`` weight-only INT4 ops (``MatMulNBits``,
+# ``GatherBlockQuantized``), ORT dynamic-quantization QOperator ops
+# (``DynamicQuantizeLinear``/``MatMulInteger``), fp16 Conv/ConvTranspose
+# codec stacks, and autoregressive decoder graphs with 8-16 parallel KV-cache
+# input/output pairs.
+#
+# One real onnxsim bug was found and fixed via this model set:
+# ``fast_ar_int4.onnx``'s attention blocks simplify to a model that fails to
+# load in onnxruntime with "Invalid tensor data type 0". Root cause: onnx's
+# Graph-native shape inference (``onnx::InferShapesOnGraph``) left a handful
+# of Reshape-output ``value_info`` entries with a shape but no resolved
+# element type (``elem_type == UNDEFINED``); ``onnx.checker.check_model``
+# tolerates that malformed TypeProto, but onnxruntime's model loader does
+# not. See ``DropIncompleteValueInfo`` in onnxsim.cpp, which strips such
+# entries (value_info is optional annotation; dropping an incomplete entry
+# cannot change model semantics) -- this test's ``fast_ar_int4.onnx`` case
+# guards against that regressing.
+#
+# Downloads real model weights (10-290MB per case, ~450MB total across all 6)
+# from Hugging Face and, for the larger TTS models, takes over a minute per
+# model under check_n=3 -- too slow/network-dependent for every PR. It is
+# opt-in via ONNXSIM_RUN_AUDIO8_TESTS=1, set by the dedicated weekly
+# .github/workflows/audio8.yml. To run it locally::
+#
+#     pip install onnxruntime
+#     pip install --force-reinstall --no-deps .   # the onnxsim under test
+#     ONNXSIM_RUN_AUDIO8_TESTS=1 pytest tests/test_audio8.py -v
+
+import os
+import time
+import urllib.error
+import urllib.request
+
+import onnx
+import pytest
+
+import onnxsim
+
+# A bare ``import onnxruntime`` would fail collection (not skip the test) on
+# platforms onnxruntime doesn't ship wheels for, before the
+# ONNXSIM_RUN_AUDIO8_TESTS skipif below even gets a chance to apply.
+onnxruntime = pytest.importorskip("onnxruntime")
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("ONNXSIM_RUN_AUDIO8_TESTS") != "1",
+    reason="Set ONNXSIM_RUN_AUDIO8_TESTS=1 to run (downloads real models "
+    "from Hugging Face; the TTS cases take over a minute each).",
+)
+
+_HF_BASE = "https://huggingface.co"
+
+
+# Pinned to a specific commit (rather than "main") for reproducibility, so an
+# upstream model update can't turn this test flaky -- bump deliberately if a
+# case ever needs to track a new upload.
+#
+# name -> (repo, revision, path, has_external_data, test_input_shapes,
+#           input_fill, check_tol)
+#
+# ``test_input_shapes`` fixes the one truly dynamic dim each model has;
+# dims left out rely on onnxsim's "dynamic dim[0] -> assume batch size 1"
+# default (matches every other input in these graphs, which are otherwise
+# fully static once batch is pinned). ``check_tol`` overrides onnxsim's
+# default (rtol=1e-4, atol=1e-5), which assumes fp32: codec_decoder_fp16.onnx
+# computes entirely in float16 (~3 decimal digits of precision), and its
+# near-zero waveform samples fail the fp32-tuned default by a few 1e-4 even
+# though the model is simplified correctly -- None keeps the default.
+CASES = {
+    # Audio8 TTS Preview 0.6B, DualAR architecture: weight-only INT4
+    # transformer step (MatMulNBits/GatherBlockQuantized) with 4 parallel
+    # KV-cache pairs and a bool "use_slow_hidden" gate input.
+    "fast_ar_int4.onnx": (
+        "Audio8/Audio8-TTS-Preview-0.6B-ONNX-INT4",
+        "818569c6b832118ad68d61bbd873abe250fcd68a",
+        "fast_ar_int4.onnx",
+        True,
+        None,
+        "random",
+        None,
+    ),
+    # Same package's fp16 neural audio codec decoder: Conv/ConvTranspose
+    # stack with LayerNormalization, Sin/Cos rotary embeddings, and a
+    # dynamic "frames" dim onnxsim must be told to fix for check_n.
+    "codec_decoder_fp16.onnx": (
+        "Audio8/Audio8-TTS-Preview-0.6B-ONNX-INT4",
+        "818569c6b832118ad68d61bbd873abe250fcd68a",
+        "codec_decoder_fp16.onnx",
+        True,
+        {"codes": [1, 10, 50]},
+        "random",
+        (1e-2, 2e-3),
+    ),
+    # Audio8 ASR 0.1B, decode step: a fully statically-shaped (fixed
+    # 512-token KV cache) INT4 transformer step -- no dynamic dims at all.
+    "lm_cache_decode_int4.onnx": (
+        "Audio8/Audio8-ASR-0.1B-onnx-runtime",
+        "5b6d058a54853700223dd23cb4fe466b86c8fece",
+        "model_bundle/lm_cache_decode_int4.onnx",
+        True,
+        None,
+        "random",
+        None,
+    ),
+    # Same package's prefill step: variable-length "sequence" dim across
+    # inputs_embeds/cache_position that onnxsim must propagate consistently.
+    "lm_cache_prefill_int4.onnx": (
+        "Audio8/Audio8-ASR-0.1B-onnx-runtime",
+        "5b6d058a54853700223dd23cb4fe466b86c8fece",
+        "model_bundle/lm_cache_prefill_int4.onnx",
+        True,
+        {"inputs_embeds": [1, 5, 512], "cache_position": [5]},
+        "random",
+        None,
+    ),
+    # ark-asr-0.6b's audio-feature adapter MLP: ORT dynamic quantization
+    # (DynamicQuantizeLinear/MatMulInteger), already minimal going in -- this
+    # case asserts onnxsim is a safe no-op rather than that it finds work.
+    "ark_asr_audio_encoder_adapter_int8.onnx": (
+        "Audio8/ark-asr-0.6b-int8-onnx",
+        "ced3e6c0cc45eda7f718b885e9fd9562ed3ec94d",
+        "audio_encoder_adapter_int8.onnx",
+        False,
+        {"merged_audio_features": [1, 50, 5120]},
+        "random",
+        None,
+    ),
+    # GPA-v1.5's sibling adapter model: same architecture/op set as the
+    # ark-asr case above from a related export pipeline, different weights.
+    "gpa_audio_encoder_adapter_int8.onnx": (
+        "Audio8/GPA-v1.5-onnx-runtime",
+        "b9f463b5a29461257d45bb734463edf41a297d86",
+        "model/audio_encoder_adapter_int8.onnx",
+        False,
+        {"merged_audio_features": [1, 50, 5120]},
+        "random",
+        None,
+    ),
+}
+
+
+@pytest.fixture(scope="module")
+def audio8_model_dir(tmp_path_factory):
+    return tmp_path_factory.mktemp("audio8_models")
+
+
+_DOWNLOAD_ATTEMPTS = 5
+
+
+def _download_one(url: str, dest: str) -> None:
+    if os.path.exists(dest):
+        return
+    tmp_dest = f"{dest}.part"
+    last_error: Exception = RuntimeError("unreachable")
+    for attempt in range(_DOWNLOAD_ATTEMPTS):
+        try:
+            # Some of these files are 100+MB; a plain GET occasionally comes
+            # back truncated on a flaky connection. Download to a temp name
+            # and only rename into place on a fully successful transfer, so a
+            # partial file is never mistaken for a complete one on retry or by
+            # a later test run.
+            urllib.request.urlretrieve(url, tmp_dest)
+            os.replace(tmp_dest, dest)
+            return
+        except (urllib.error.URLError, OSError) as e:
+            last_error = e
+            if os.path.exists(tmp_dest):
+                os.remove(tmp_dest)
+            if attempt + 1 < _DOWNLOAD_ATTEMPTS:
+                time.sleep(3 * (attempt + 1))
+    pytest.skip(f"Could not download {url} after {_DOWNLOAD_ATTEMPTS} attempts: {last_error}")
+
+
+def _download(filename: str, dest_dir) -> str:
+    repo, revision, path, has_external_data, _, _, _ = CASES[filename]
+    base_url = f"{_HF_BASE}/{repo}/resolve/{revision}/{path}"
+    dest = str(dest_dir / filename)
+    _download_one(base_url, dest)
+    if has_external_data:
+        # External-data tensors are referenced by filename relative to the
+        # .onnx file, so the sidecar must land next to it under the same name
+        # onnx.load() expects: "<file>.onnx.data".
+        _download_one(f"{base_url}.data", f"{dest}.data")
+    return dest
+
+
+@pytest.mark.parametrize("filename", sorted(CASES.keys()))
+def test_audio8_model_simplify(audio8_model_dir, filename):
+    _, _, _, _, test_input_shapes, input_fill, check_tol = CASES[filename]
+    path = _download(filename, audio8_model_dir)
+
+    nodes_before = len(onnx.load(path, load_external_data=False).graph.node)
+
+    check_rtol, check_atol = check_tol or (1e-4, 1e-5)
+    model_opt, check_ok = onnxsim.simplify(
+        path,
+        check_n=3,
+        test_input_shapes=test_input_shapes,
+        input_fill=input_fill,
+        check_rtol=check_rtol,
+        check_atol=check_atol,
+    )
+    assert check_ok, f"{filename}: onnxsim numerical check failed"
+    assert len(model_opt.graph.node) <= nodes_before, (
+        f"{filename}: simplification must not increase node count"
+    )
+
+    # The simplified model must still load in onnxruntime. This is the
+    # regression this test set caught: a malformed value_info (elem_type ==
+    # UNDEFINED) that onnx.checker.check_model tolerates but onnxruntime's
+    # loader rejects outright (see DropIncompleteValueInfo in onnxsim.cpp).
+    onnxruntime.InferenceSession(model_opt.SerializeToString())

--- a/tests/test_audio8.py
+++ b/tests/test_audio8.py
@@ -172,7 +172,9 @@ def _download_one(url: str, dest: str) -> None:
                 os.remove(tmp_dest)
             if attempt + 1 < _DOWNLOAD_ATTEMPTS:
                 time.sleep(3 * (attempt + 1))
-    pytest.skip(f"Could not download {url} after {_DOWNLOAD_ATTEMPTS} attempts: {last_error}")
+    pytest.skip(
+        f"Could not download {url} after {_DOWNLOAD_ATTEMPTS} attempts: {last_error}"
+    )
 
 
 def _download(filename: str, dest_dir) -> str:


### PR DESCRIPTION
## Summary

While evaluating onnxsim against real ONNX models from [huggingface.co/Audio8](https://huggingface.co/Audio8) (TTS/ASR models shipped with ONNX Runtime deployment packages), simplifying `fast_ar_int4.onnx` (an INT4 weight-quantized attention decoder step) produced a model that fails to load in onnxruntime:

```
onnxruntime.capi.onnxruntime_pybind11_state.InvalidArgument: [ONNXRuntimeError] : 2 : INVALID_ARGUMENT : Failed to load model with error: Invalid tensor data type 0.
```

**Root cause:** onnx's Graph-native shape inference (`InferShapesOnGraph`) left a handful of `Reshape`-output `value_info` entries — inside the model's attention blocks — with a shape but no resolved element type (`elem_type == UNDEFINED`). `onnx.checker.check_model` tolerates this malformed `TypeProto`, but onnxruntime's model loader does not. The original (pre-simplification) model has zero `value_info` entries at all, confirming these are introduced by onnxsim's own shape-inference pass, not inherited from the input.

**Fix:** `value_info` is optional annotation — nothing reads it as ground truth — so `DropIncompleteValueInfo` (`onnxsim/onnxsim.cpp`) strips any entry left with `elem_type == UNDEFINED` before finalizing the simplified model, recursing into subgraphs the same way `AssignMissingNodeNames` does. This can't change model semantics; it only removes broken metadata that was never going to be correct.

## Regression test

Added `tests/test_audio8.py` (opt-in via `ONNXSIM_RUN_AUDIO8_TESTS=1`, mirroring `test_voicevox.py`'s structure) covering 6 real ONNX exports across Audio8's TTS and ASR families, downloaded from pinned HF commits:

| Model | Covers |
|---|---|
| `fast_ar_int4.onnx` | weight-only INT4 attention step (`MatMulNBits`/`GatherBlockQuantized`), 4 parallel KV-cache pairs, bool gate input — the case that caught this bug |
| `codec_decoder_fp16.onnx` | fp16 Conv/ConvTranspose codec stack, dynamic "frames" dim |
| `lm_cache_decode_int4.onnx` | fully static-shaped (fixed 512-token KV cache) INT4 decode step |
| `lm_cache_prefill_int4.onnx` | variable-length "sequence" dim prefill step |
| `ark_asr_audio_encoder_adapter_int8.onnx` | ORT dynamic quantization (`DynamicQuantizeLinear`/`MatMulInteger`) |
| `gpa_audio_encoder_adapter_int8.onnx` | sibling adapter model, same op set |

Each case simplifies with `check_n=3`, asserts the numerical check passes, asserts node count doesn't increase, and asserts the simplified model loads in onnxruntime (the actual regression this set guards against). Added `.github/workflows/audio8.yml`, a dedicated weekly workflow matching `voicevox.yml`'s structure (also triggers on PRs touching `tests/test_audio8.py` or `onnxsim/onnxsim.cpp`).

## Test plan

- [x] `python3 -m pytest tests/test_model_checking.py tests/test_model_info.py tests/test_backend.py` — 68 passed
- [x] Full offline suite (`tests/`, excluding network-dependent/optional-integration files) — all passed in isolation (one flaky failure and one OOM kill observed under this sandbox's tight 15GB RAM limit on unrelated heavy torchvision/large-model tests; both pass individually and are unrelated to this change)
- [x] `ONNXSIM_RUN_AUDIO8_TESTS=1 pytest tests/test_audio8.py -v` — 6 passed
- [x] Manually verified `fast_ar_int4.onnx` fails to load in onnxruntime before the fix and loads + passes `check_n=5` after


---
_Generated by [Claude Code](https://claude.ai/code/session_01B2Ck3og3ZUVLkzaaCEmV7t)_