### PR TITLE
Add a memory-mapped, TensorPool-backed model loader; make it the default for path-based simplify()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -501,6 +501,17 @@ if (ONNXSIM_TESTS)
   onnxsim_add_ort_rpath(tensor_pool_bridge_test)
   add_test(NAME tensor_pool_bridge_test COMMAND tensor_pool_bridge_test)
 
+  # Regression coverage for the EXTERNAL-tensor safety fixes in onnx-
+  # optimizer's pass_util.h/cse_util.h (see that test's file comment): needs
+  # the fully-configured `onnxsim` target both for onnx-optimizer's own
+  # OptimizeFixed and for onnxsim::RegisterCustomOptimizerPasses.
+  add_executable(external_tensor_pass_safety_test
+                 onnxsim/external_tensor_pass_safety_test.cpp)
+  target_link_libraries(external_tensor_pass_safety_test onnxsim)
+  onnxsim_add_ort_rpath(external_tensor_pass_safety_test)
+  add_test(NAME external_tensor_pass_safety_test
+          COMMAND external_tensor_pass_safety_test)
+
   # The ONNX<->GGML dtype mapping (gguf_dtype.h), mirroring
   # tensor_pool_dtype_test.cpp above for the same reason.
   add_executable(gguf_dtype_test onnxsim/gguf_dtype_test.cpp)

--- a/README.md
+++ b/README.md
@@ -667,6 +667,34 @@ commutative permutations, or evaluate attribute *predicates* — for those, the
 Python-only `onnxscript.rewriter` via `custom_rewriter` remains the richer
 option.
 
+## Loading large models
+
+Passing `simplify()` a **file path** (rather than an already-loaded
+`ModelProto`) is the recommended way to simplify a large model: it lets
+onnxsim defer loading a model's (potentially huge) weights for as long as
+possible, and is the input this project's own tooling and tests default to.
+When the model's weights live in a separate classic external-data file (the
+`<name>.onnx` + `<name>.data` pair `onnx.save(..., save_as_external_data=True)`
+produces), that file is memory-mapped straight into onnxsim's C++
+`TensorPool` rather than being read into a heap buffer first, avoiding an
+extra buffered copy of the weights on the way in.
+
+The same loading path is available directly as `onnxsim.load_model`, for
+when you want the loaded `ModelProto` itself rather than passing a path
+straight to `simplify()`:
+
+```python
+import onnxsim
+
+model = onnxsim.load_model("model.onnx")  # instead of onnx.load("model.onnx")
+sim_model, check_ok = onnxsim.simplify(model)
+```
+
+`onnxsim.load_model(path)` is functionally identical to `onnx.load(path)` —
+a fully self-contained `ModelProto`, with no `TensorPool` or lazy state for
+the caller to manage — just with fewer copies of the weights along the way
+for a model that uses external data.
+
 ## Safetensors / GGUF archives
 
 Besides plain `.onnx`, a model can be exported to (and imported back from) a

--- a/README.md
+++ b/README.md
@@ -695,6 +695,19 @@ a fully self-contained `ModelProto`, with no `TensorPool` or lazy state for
 the caller to manage — just with fewer copies of the weights along the way
 for a model that uses external data.
 
+`simplify(path)` itself goes further: any single external-data tensor over
+1.5GB is left un-hydrated (a lazy, memory-mapped reference, not resident in
+memory) for as long as the simplification fixed point never actually needs
+its value — every onnxsim/onnx-optimizer pass that reads a constant tensor's
+value already treats such a tensor as unavailable rather than misreading its
+absent bytes as zero, so this only ever costs that one tensor's
+value-dependent optimizations (constant folding, BatchNorm fusion, duplicate-
+initializer dedup, ...), never correctness. A tensor dropped by dead-code
+elimination before ever being read pays no hydration cost at all. Whatever
+is still un-hydrated when simplification finishes is fully materialized
+before the result is saved, so the output file is always an ordinary,
+self-contained model either way.
+
 ## Safetensors / GGUF archives
 
 Besides plain `.onnx`, a model can be exported to (and imported back from) a

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -4,6 +4,7 @@ from onnxsim.onnx_simplifier import (
     import_gguf,
     import_onnx_schemas,
     import_safetensors,
+    load_model,
     main,
     simplify,
 )
@@ -13,6 +14,7 @@ from .version import version as __version__
 __all__ = [
     "simplify",
     "main",
+    "load_model",
     "import_onnx_schemas",
     "export_safetensors",
     "import_safetensors",

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -570,8 +570,8 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
         onnx::ModelProto model;
         ParseProtoFromBytes(&model, model_bytes.c_str(), model_bytes.size());
         onnxsim::tensor_pool::TensorPool pool;
-        onnxsim::tensor_pool::PoolExternalData(model, base_dir, pool,
-                                               /*hydrate_all=*/true);
+        onnxsim::tensor_pool::PoolExternalData(
+            model, base_dir, pool, onnxsim::tensor_pool::kHydrateAll);
         const std::string out = model.SerializeAsString();
         return py::bytes(out.data(), out.size());
       },

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -565,8 +565,8 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
   // model instead of a fresh path.
   m.def(
       "hydrate_external_data_pooled",
-      [](const py::bytes& model_bytes, const std::string& base_dir)
-          -> py::bytes {
+      [](const py::bytes& model_bytes,
+         const std::string& base_dir) -> py::bytes {
         onnx::ModelProto model;
         ParseProtoFromBytes(&model, model_bytes.c_str(), model_bytes.size());
         onnxsim::tensor_pool::TensorPool pool;

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -551,6 +551,32 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
       },
       "rules"_a);
 
+  // Materialize every classic-EXTERNAL tensor in ``model_bytes`` (initializers
+  // and node-attribute tensors, recursing into subgraphs) by memory-mapping
+  // its data file under ``base_dir`` (onnxsim::tensor_pool::PoolExternalData,
+  // see tensor_pool_bridge.h) instead of reading it into a heap buffer the
+  // way ``onnx.load_external_data_for_model`` does. Used by
+  // ``onnxsim.load_model`` and by ``simplify()``'s own slow path (see
+  // onnx_simplifier.py) -- both already have a metadata-only ``ModelProto``
+  // in hand (from ``onnx.load(path, load_external_data=False)``) and just
+  // need its external data filled in, which is exactly onnxsim's own
+  // path-based entry point's (``simplify_path``) default loading step too
+  // (LoadModelPooled, onnxsim.cpp), just operating on an already-parsed
+  // model instead of a fresh path.
+  m.def(
+      "hydrate_external_data_pooled",
+      [](const py::bytes& model_bytes, const std::string& base_dir)
+          -> py::bytes {
+        onnx::ModelProto model;
+        ParseProtoFromBytes(&model, model_bytes.c_str(), model_bytes.size());
+        onnxsim::tensor_pool::TensorPool pool;
+        onnxsim::tensor_pool::PoolExternalData(model, base_dir, pool,
+                                               /*hydrate_all=*/true);
+        const std::string out = model.SerializeAsString();
+        return py::bytes(out.data(), out.size());
+      },
+      "model_bytes"_a, "base_dir"_a);
+
   // Standalone safetensors/GGUF archive export/import: a model's graph and
   // weights packaged together in one ecosystem-standard file (see
   // onnxsim/tensor_pool_bridge.h and tensor_pool_gguf_bridge.h's *Standalone

--- a/onnxsim/external_tensor_pass_safety_test.cpp
+++ b/onnxsim/external_tensor_pass_safety_test.cpp
@@ -1,0 +1,425 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Regression tests for onnx-optimizer's pass_util.h/cse_util.h EXTERNAL-
+ * tensor safety fixes (IsConstantTensor/FetchConstantTensor and
+ * CSETensorHash/CSETensorCompare): a tensor whose data_location is EXTERNAL
+ * and carries no raw_data (onnxsim's PoolExternalData leaves a tensor this
+ * way when it is too large to hydrate eagerly -- see
+ * tensor_pool_bridge.h's LoadModelPooled/kSimplifyPathHydrateThresholdBytes)
+ * must never be silently misread as empty/zero data by a value-baking or
+ * CSE pass.
+ *
+ * Each test here builds a model where the naive (pre-fix) behavior would
+ * have produced a WRONG result -- not just a missed optimization -- and
+ * checks the fixed behavior instead: the value-dependent transform is
+ * skipped (or the pass throws a catchable error), never silently
+ * miscomputed. Uses onnx-optimizer's OptimizeFixed directly (no
+ * ModelExecutor needed -- these are pure graph-rewrite passes, not
+ * onnxsim's own constant folding).
+ */
+#include <onnx/onnx_pb.h>
+
+#include <cstdio>
+#include <exception>
+#include <string>
+#include <vector>
+
+#include "custom_optimizer_passes.h"
+#include "onnxoptimizer/optimize.h"
+
+using namespace ONNX_NAMESPACE;
+
+namespace {
+
+int g_failures = 0;
+
+void Check(bool cond, const std::string& what) {
+  if (!cond) {
+    std::fprintf(stderr, "FAIL: %s\n", what.c_str());
+    ++g_failures;
+  }
+}
+
+TensorProto MakeExternalTensor(const std::string& name,
+                               TensorProto::DataType dtype,
+                               const std::vector<int64_t>& dims) {
+  TensorProto t;
+  t.set_name(name);
+  t.set_data_type(dtype);
+  for (int64_t d : dims) t.add_dims(d);
+  t.set_data_location(TensorProto::EXTERNAL);
+  auto* e = t.add_external_data();
+  e->set_key("location");
+  e->set_value(name + ".data");  // never actually opened by these tests
+  return t;
+}
+
+TensorProto MakeRawTensor(const std::string& name, TensorProto::DataType dtype,
+                          const std::vector<int64_t>& dims,
+                          const std::string& raw) {
+  TensorProto t;
+  t.set_name(name);
+  t.set_data_type(dtype);
+  for (int64_t d : dims) t.add_dims(d);
+  t.set_raw_data(raw);
+  return t;
+}
+
+void AddFloatOutput(GraphProto* graph, const std::string& name) {
+  auto* out = graph->add_output();
+  out->set_name(name);
+  out->mutable_type()->mutable_tensor_type()->set_elem_type(TensorProto::FLOAT);
+}
+
+ModelProto NewModel() {
+  ModelProto model;
+  model.set_ir_version(9);
+  auto* opset = model.add_opset_import();
+  opset->set_domain("");
+  opset->set_version(13);
+  model.mutable_graph()->set_name("t");
+  return model;
+}
+
+void TestFuseBNIntoConvSkipsExternalParams() {
+  ModelProto model = NewModel();
+  auto* graph = model.mutable_graph();
+
+  auto* x_in = graph->add_input();
+  x_in->set_name("X");
+  auto* x_type = x_in->mutable_type()->mutable_tensor_type();
+  x_type->set_elem_type(TensorProto::FLOAT);
+  auto* x_shape = x_type->mutable_shape();
+  x_shape->add_dim()->set_dim_value(1);
+  x_shape->add_dim()->set_dim_value(3);
+  x_shape->add_dim()->set_dim_value(8);
+  x_shape->add_dim()->set_dim_value(8);
+
+  *graph->add_initializer() =
+      MakeRawTensor("W", TensorProto::FLOAT, {4, 3, 3, 3},
+                    std::string(4 * 3 * 3 * 3 * 4, '\x01'));
+  auto* conv = graph->add_node();
+  conv->set_op_type("Conv");
+  conv->add_input("X");
+  conv->add_input("W");
+  conv->add_output("Y");
+
+  // BN params are EXTERNAL -- too large to have hydrated eagerly.
+  *graph->add_initializer() =
+      MakeExternalTensor("scale", TensorProto::FLOAT, {4});
+  *graph->add_initializer() =
+      MakeExternalTensor("bias", TensorProto::FLOAT, {4});
+  *graph->add_initializer() =
+      MakeExternalTensor("mean", TensorProto::FLOAT, {4});
+  *graph->add_initializer() =
+      MakeExternalTensor("var", TensorProto::FLOAT, {4});
+  auto* bn = graph->add_node();
+  bn->set_op_type("BatchNormalization");
+  bn->add_input("Y");
+  bn->add_input("scale");
+  bn->add_input("bias");
+  bn->add_input("mean");
+  bn->add_input("var");
+  bn->add_output("Z");
+
+  AddFloatOutput(graph, "Z");
+
+  onnxsim::RegisterCustomOptimizerPasses();
+  ModelProto result;
+  bool threw = false;
+  try {
+    result = optimization::OptimizeFixed(model, {"fuse_bn_into_conv"});
+  } catch (const std::exception& e) {
+    threw = true;
+    std::fprintf(stderr, "  (unexpected exception: %s)\n", e.what());
+  }
+  Check(!threw, "fuse_bn_into_conv does not throw/crash on EXTERNAL BN params");
+  if (threw) return;
+
+  bool bn_still_present = false;
+  for (const auto& n : result.graph().node()) {
+    if (n.op_type() == "BatchNormalization") bn_still_present = true;
+  }
+  Check(bn_still_present,
+        "fuse_bn_into_conv safely SKIPS fusing when BN params are EXTERNAL "
+        "(if it fused using empty/zero data instead, this would silently "
+        "compute a wrong Conv weight)");
+}
+
+// Positive control for TestFuseBNIntoConvSkipsExternalParams: the identical
+// pattern, but with ordinary in-memory (raw_data) BN params instead of
+// EXTERNAL ones, must still fuse normally. Guards against the EXTERNAL-
+// safety fix above being accidentally over-broad (e.g. rejecting every
+// tensor instead of just EXTERNAL ones).
+void TestFuseBNIntoConvStillFusesOrdinaryParams() {
+  ModelProto model = NewModel();
+  auto* graph = model.mutable_graph();
+
+  auto* x_in = graph->add_input();
+  x_in->set_name("X");
+  auto* x_type = x_in->mutable_type()->mutable_tensor_type();
+  x_type->set_elem_type(TensorProto::FLOAT);
+  auto* x_shape = x_type->mutable_shape();
+  x_shape->add_dim()->set_dim_value(1);
+  x_shape->add_dim()->set_dim_value(3);
+  x_shape->add_dim()->set_dim_value(8);
+  x_shape->add_dim()->set_dim_value(8);
+
+  *graph->add_initializer() =
+      MakeRawTensor("W", TensorProto::FLOAT, {4, 3, 3, 3},
+                    std::string(4 * 3 * 3 * 3 * 4, '\x01'));
+  auto* conv = graph->add_node();
+  conv->set_op_type("Conv");
+  conv->add_input("X");
+  conv->add_input("W");
+  conv->add_output("Y");
+
+  auto ones = [](int64_t n) { return std::string(n * 4, '\x00'); };
+  *graph->add_initializer() =
+      MakeRawTensor("scale", TensorProto::FLOAT, {4}, ones(4));
+  *graph->add_initializer() =
+      MakeRawTensor("bias", TensorProto::FLOAT, {4}, ones(4));
+  *graph->add_initializer() =
+      MakeRawTensor("mean", TensorProto::FLOAT, {4}, ones(4));
+  *graph->add_initializer() =
+      MakeRawTensor("var", TensorProto::FLOAT, {4}, ones(4));
+  auto* bn = graph->add_node();
+  bn->set_op_type("BatchNormalization");
+  bn->add_input("Y");
+  bn->add_input("scale");
+  bn->add_input("bias");
+  bn->add_input("mean");
+  bn->add_input("var");
+  bn->add_output("Z");
+
+  AddFloatOutput(graph, "Z");
+
+  onnxsim::RegisterCustomOptimizerPasses();
+  ModelProto result;
+  bool threw = false;
+  try {
+    result = optimization::OptimizeFixed(model, {"fuse_bn_into_conv"});
+  } catch (const std::exception& e) {
+    threw = true;
+    std::fprintf(stderr, "  (unexpected exception: %s)\n", e.what());
+  }
+  Check(!threw, "fuse_bn_into_conv does not throw on ordinary BN params");
+  if (threw) return;
+
+  bool bn_still_present = false;
+  for (const auto& n : result.graph().node()) {
+    if (n.op_type() == "BatchNormalization") bn_still_present = true;
+  }
+  Check(!bn_still_present,
+        "fuse_bn_into_conv DOES fuse away BatchNormalization when its "
+        "params are ordinary, locally-available tensors -- the EXTERNAL "
+        "safety check must not be overly broad");
+}
+
+void TestEliminateDuplicateInitializerDoesNotMergeExternalTensors() {
+  ModelProto model = NewModel();
+  auto* graph = model.mutable_graph();
+
+  // Two EXTERNAL initializers, same shape/dtype -- if their bytes could be
+  // read they might genuinely differ; without reading them there is no way
+  // to know, so they must not be merged.
+  *graph->add_initializer() = MakeExternalTensor("a", TensorProto::FLOAT, {4});
+  *graph->add_initializer() = MakeExternalTensor("b", TensorProto::FLOAT, {4});
+
+  auto* add = graph->add_node();
+  add->set_op_type("Add");
+  add->add_input("a");
+  add->add_input("b");
+  add->add_output("y");
+  AddFloatOutput(graph, "y");
+
+  ModelProto result;
+  bool threw = false;
+  try {
+    result =
+        optimization::OptimizeFixed(model, {"eliminate_duplicate_initializer"});
+  } catch (const std::exception& e) {
+    threw = true;
+    std::fprintf(stderr, "  (unexpected exception: %s)\n", e.what());
+  }
+  Check(!threw,
+        "eliminate_duplicate_initializer does not throw/crash on EXTERNAL "
+        "initializers");
+  if (threw) return;
+  Check(result.graph().initializer_size() == 2,
+        "eliminate_duplicate_initializer does NOT merge two distinct "
+        "EXTERNAL initializers just because their (unreadable) content "
+        "might coincidentally match");
+}
+
+void TestEliminateCommonSubexpressionDoesNotMergeExternalConstants() {
+  ModelProto model = NewModel();
+  auto* graph = model.mutable_graph();
+
+  for (int i = 0; i < 2; ++i) {
+    const std::string ci = "c" + std::to_string(i);
+    const std::string yi = "y" + std::to_string(i);
+    auto* c = graph->add_node();
+    c->set_op_type("Constant");
+    c->add_output(ci);
+    auto* attr = c->add_attribute();
+    attr->set_name("value");
+    attr->set_type(AttributeProto::TENSOR);
+    *attr->mutable_t() =
+        MakeExternalTensor("cval" + std::to_string(i), TensorProto::FLOAT, {4});
+
+    auto* id = graph->add_node();
+    id->set_op_type("Identity");
+    id->add_input(ci);
+    id->add_output(yi);
+    AddFloatOutput(graph, yi);
+  }
+
+  ModelProto result;
+  bool threw = false;
+  try {
+    result =
+        optimization::OptimizeFixed(model, {"eliminate_common_subexpression"});
+  } catch (const std::exception& e) {
+    threw = true;
+    std::fprintf(stderr, "  (unexpected exception: %s)\n", e.what());
+  }
+  Check(!threw,
+        "eliminate_common_subexpression does not throw/crash on EXTERNAL "
+        "Constant values");
+  if (threw) return;
+  int constant_count = 0;
+  for (const auto& n : result.graph().node()) {
+    if (n.op_type() == "Constant") ++constant_count;
+  }
+  Check(constant_count == 2,
+        "eliminate_common_subexpression does NOT merge two distinct "
+        "EXTERNAL Constant nodes just because their (unreadable) content "
+        "might coincidentally match");
+}
+
+void TestEliminateIfWithConstCondSkipsExternalCond() {
+  ModelProto model = NewModel();
+  auto* graph = model.mutable_graph();
+
+  *graph->add_initializer() = MakeExternalTensor("cond", TensorProto::BOOL, {});
+
+  GraphProto then_g;
+  then_g.set_name("then");
+  auto* then_c = then_g.add_node();
+  then_c->set_op_type("Constant");
+  then_c->add_output("then_out");
+  auto* then_attr = then_c->add_attribute();
+  then_attr->set_name("value");
+  then_attr->set_type(AttributeProto::TENSOR);
+  *then_attr->mutable_t() =
+      MakeRawTensor("tv", TensorProto::FLOAT, {1}, std::string(4, '\x01'));
+  AddFloatOutput(&then_g, "then_out");
+
+  GraphProto else_g;
+  else_g.set_name("else");
+  auto* else_c = else_g.add_node();
+  else_c->set_op_type("Constant");
+  else_c->add_output("else_out");
+  auto* else_attr = else_c->add_attribute();
+  else_attr->set_name("value");
+  else_attr->set_type(AttributeProto::TENSOR);
+  *else_attr->mutable_t() =
+      MakeRawTensor("ev", TensorProto::FLOAT, {1}, std::string(4, '\x02'));
+  AddFloatOutput(&else_g, "else_out");
+
+  auto* if_node = graph->add_node();
+  if_node->set_op_type("If");
+  if_node->add_input("cond");
+  if_node->add_output("z");
+  auto* then_attr_n = if_node->add_attribute();
+  then_attr_n->set_name("then_branch");
+  then_attr_n->set_type(AttributeProto::GRAPH);
+  *then_attr_n->mutable_g() = then_g;
+  auto* else_attr_n = if_node->add_attribute();
+  else_attr_n->set_name("else_branch");
+  else_attr_n->set_type(AttributeProto::GRAPH);
+  *else_attr_n->mutable_g() = else_g;
+
+  AddFloatOutput(graph, "z");
+
+  ModelProto result;
+  bool threw = false;
+  try {
+    result =
+        optimization::OptimizeFixed(model, {"eliminate_if_with_const_cond"});
+  } catch (const std::exception& e) {
+    threw = true;
+    std::fprintf(stderr, "  (unexpected exception: %s)\n", e.what());
+  }
+  Check(!threw,
+        "eliminate_if_with_const_cond does not crash (UB) on an EXTERNAL "
+        "cond tensor");
+  if (threw) return;
+  bool if_still_present = false;
+  for (const auto& n : result.graph().node()) {
+    if (n.op_type() == "If") if_still_present = true;
+  }
+  Check(if_still_present,
+        "eliminate_if_with_const_cond safely SKIPS inlining when cond is "
+        "EXTERNAL (reading past a null tensor pointer would be UB, not just "
+        "a missed optimization)");
+}
+
+void TestFuseQKVSkipsExternalWeights() {
+  ModelProto model = NewModel();
+  auto* graph = model.mutable_graph();
+
+  auto* x_in = graph->add_input();
+  x_in->set_name("X");
+  x_in->mutable_type()->mutable_tensor_type()->set_elem_type(
+      TensorProto::FLOAT);
+
+  *graph->add_initializer() =
+      MakeExternalTensor("Wq", TensorProto::FLOAT, {8, 8});
+  *graph->add_initializer() =
+      MakeExternalTensor("Wk", TensorProto::FLOAT, {8, 8});
+  *graph->add_initializer() =
+      MakeExternalTensor("Wv", TensorProto::FLOAT, {8, 8});
+
+  for (const std::string& w : {"Wq", "Wk", "Wv"}) {
+    auto* mm = graph->add_node();
+    mm->set_op_type("MatMul");
+    mm->add_input("X");
+    mm->add_input(w);
+    mm->add_output(w + "_out");
+    AddFloatOutput(graph, w + "_out");
+  }
+
+  ModelProto result;
+  bool threw = false;
+  try {
+    result = optimization::OptimizeFixed(model, {"fuse_qkv"});
+  } catch (const std::exception& e) {
+    threw = true;
+    std::fprintf(stderr, "  (unexpected exception: %s)\n", e.what());
+  }
+  Check(!threw,
+        "fuse_qkv does not crash (null deref) when Q/K/V weights are "
+        "EXTERNAL");
+}
+
+}  // namespace
+
+int main() {
+  TestFuseBNIntoConvSkipsExternalParams();
+  TestFuseBNIntoConvStillFusesOrdinaryParams();
+  TestEliminateDuplicateInitializerDoesNotMergeExternalTensors();
+  TestEliminateCommonSubexpressionDoesNotMergeExternalConstants();
+  TestEliminateIfWithConstCondSkipsExternalCond();
+  TestFuseQKVSkipsExternalWeights();
+
+  if (g_failures == 0) {
+    std::printf("external_tensor_pass_safety_test: all checks passed\n");
+    return 0;
+  }
+  std::fprintf(stderr, "external_tensor_pass_safety_test: %d failure(s)\n",
+               g_failures);
+  return 1;
+}

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -755,9 +755,7 @@ def simplify(
     # ``onnx.load_external_data_for_model``'s buffered read.
     if external_data_dir is not None:
         model.ParseFromString(
-            C.hydrate_external_data_pooled(
-                model.SerializeToString(), external_data_dir
-            )
+            C.hydrate_external_data_pooled(model.SerializeToString(), external_data_dir)
         )
 
     # Merging onnxruntime's profile into onnxsim's trace requires an onnxsim

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -337,6 +337,29 @@ def import_onnx_schemas() -> int:
     return imported
 
 
+def load_model(path: str) -> onnx.ModelProto:
+    """Load an ``.onnx`` model from ``path``, the same way :func:`simplify`
+    loads a path by default.
+
+    Structurally identical to ``onnx.load(path)`` -- the returned
+    ``ModelProto`` is fully self-contained, with every tensor's data inline
+    -- but any classic external data (the ``<name>.onnx`` + ``<name>.data``
+    pair ``onnx.save(..., save_as_external_data=True)`` produces) is
+    memory-mapped straight into onnxsim's C++ ``TensorPool`` and copied once
+    from there into ``raw_data``, rather than first being read into a
+    throwaway buffer the way ``onnx.load_external_data_for_model`` does.
+    Models with no external data (or none large enough to matter) pay no
+    extra cost either way.
+    """
+    model = onnx.load(path, load_external_data=False)
+    model.ParseFromString(
+        C.hydrate_external_data_pooled(
+            model.SerializeToString(), os.path.dirname(os.path.abspath(path))
+        )
+    )
+    return model
+
+
 def export_safetensors(model: onnx.ModelProto, out_path: str) -> None:
     """Export ``model`` to a standalone safetensors archive at ``out_path``.
 
@@ -727,8 +750,15 @@ def simplify(
     # over and the full model is about to be serialized for the C++ simplifier.
     # This is a no-op unless we loaded from a path above (and therefore deferred
     # it); a caller-provided ``ModelProto`` already carries its data inline.
+    # Uses the same TensorPool-backed, memory-mapped loading path as
+    # ``load_model`` and the fast path's ``C.simplify_path`` below, rather than
+    # ``onnx.load_external_data_for_model``'s buffered read.
     if external_data_dir is not None:
-        onnx.load_external_data_for_model(model, external_data_dir)
+        model.ParseFromString(
+            C.hydrate_external_data_pooled(
+                model.SerializeToString(), external_data_dir
+            )
+        )
 
     # Merging onnxruntime's profile into onnxsim's trace requires an onnxsim
     # trace to merge into, so it implies profiling.

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -10,6 +10,7 @@
 #include <chrono>
 #include <cstdint>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <functional>
 #include <iomanip>
@@ -51,6 +52,7 @@
 #include "profiler.h"
 #include "sym_shape_infer.h"
 #include "sym_value_eval.h"
+#include "tensor_pool_bridge.h"
 
 struct Config {
   std::vector<std::string> optimizer_passes;
@@ -3012,6 +3014,16 @@ onnx::ModelProto Simplify(
   return sim_model;
 }
 
+size_t LoadModelPooled(const std::string& path, onnx::ModelProto* model,
+                       onnxsim::tensor_pool::TensorPool& pool,
+                       bool hydrate_all) {
+  onnx::optimization::loadModel(model, path, /*load_external_data=*/false);
+  const std::string base_dir =
+      std::filesystem::path(path).parent_path().string();
+  return onnxsim::tensor_pool::PoolExternalData(*model, base_dir, pool,
+                                                hydrate_all);
+}
+
 void SimplifyPath(
     const ModelExecutor& executor, const std::string& in_path,
     const std::string& out_path,
@@ -3032,7 +3044,17 @@ void SimplifyPath(
   onnx::ModelProto model;
   {
     const auto t0 = now();
-    onnx::optimization::loadModel(&model, in_path, true);
+    // The default model-loading step for onnxsim's primary path-based entry
+    // point: reads the graph structure without materializing external data,
+    // then memory-maps every classic-EXTERNAL tensor's data file straight
+    // into a TensorPool instead of onnx-optimizer's own external-data loader
+    // reading each tensor's slice into a fresh heap buffer. hydrate_all
+    // defaults to true here -- Simplify()'s passes below still need
+    // ordinary in-memory tensors (see tensor_pool_bridge.h's file comment on
+    // what is not yet pool-aware) -- so `pool` itself is discarded once this
+    // block ends; only the mmap'd load avoids the extra buffered-read copy.
+    onnxsim::tensor_pool::TensorPool pool;
+    LoadModelPooled(in_path, &model, pool, /*hydrate_all=*/true);
     if (debug_timing) {
       std::cerr << "SimplifyPath: loadModel " << elapsed_ms(t0, now())
                 << "ms\n";

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -3016,13 +3016,26 @@ onnx::ModelProto Simplify(
 
 size_t LoadModelPooled(const std::string& path, onnx::ModelProto* model,
                        onnxsim::tensor_pool::TensorPool& pool,
-                       bool hydrate_all) {
+                       uint64_t hydrate_threshold_bytes) {
   onnx::optimization::loadModel(model, path, /*load_external_data=*/false);
   const std::string base_dir =
       std::filesystem::path(path).parent_path().string();
   return onnxsim::tensor_pool::PoolExternalData(*model, base_dir, pool,
-                                                hydrate_all);
+                                                hydrate_threshold_bytes);
 }
+
+// Tensors at or under this size are hydrated eagerly on load (see
+// LoadModelPooled below); larger ones stay lazy, pool-only references for as
+// long as Simplify()'s fixed point never actually needs their bytes (every
+// value-reading onnxsim/onnx-optimizer pass treats an EXTERNAL tensor as
+// unavailable rather than misreading its absent data -- see
+// PoolExternalData's own comment). Matches onnx_simplifier.py's
+// DEFAULT_TENSOR_SIZE_THRESHOLDHOLD ("a very very large threshold"): both
+// exist to draw the same "this single tensor is unusually huge" line, just
+// for two different decisions (there: whether to keep a constant-folded
+// output; here: whether to eagerly materialize an input weight).
+constexpr uint64_t kSimplifyPathHydrateThresholdBytes =
+    1536ULL * 1024 * 1024;  // 1.5GB
 
 void SimplifyPath(
     const ModelExecutor& executor, const std::string& in_path,
@@ -3042,19 +3055,22 @@ void SimplifyPath(
   };
 
   onnx::ModelProto model;
+  // Declared here, not inside the load block below, so it stays alive
+  // (keeping every mmap'd tensor's mapping alive) across the Simplify() call
+  // -- a tensor PoolExternalData left EXTERNAL for being over
+  // kSimplifyPathHydrateThresholdBytes is hydrated from *this* pool, on
+  // demand, right before saveModel below, not eagerly here.
+  onnxsim::tensor_pool::TensorPool pool;
   {
     const auto t0 = now();
     // The default model-loading step for onnxsim's primary path-based entry
     // point: reads the graph structure without materializing external data,
     // then memory-maps every classic-EXTERNAL tensor's data file straight
     // into a TensorPool instead of onnx-optimizer's own external-data loader
-    // reading each tensor's slice into a fresh heap buffer. hydrate_all
-    // defaults to true here -- Simplify()'s passes below still need
-    // ordinary in-memory tensors (see tensor_pool_bridge.h's file comment on
-    // what is not yet pool-aware) -- so `pool` itself is discarded once this
-    // block ends; only the mmap'd load avoids the extra buffered-read copy.
-    onnxsim::tensor_pool::TensorPool pool;
-    LoadModelPooled(in_path, &model, pool, /*hydrate_all=*/true);
+    // reading each tensor's slice into a fresh heap buffer. Tensors at or
+    // under kSimplifyPathHydrateThresholdBytes are hydrated eagerly here;
+    // larger ones stay lazy through the Simplify() call below.
+    LoadModelPooled(in_path, &model, pool, kSimplifyPathHydrateThresholdBytes);
     if (debug_timing) {
       std::cerr << "SimplifyPath: loadModel " << elapsed_ms(t0, now())
                 << "ms\n";
@@ -3070,6 +3086,22 @@ void SimplifyPath(
                  mutable_initializer, overwrite_input_shapes, unused_output);
     if (debug_timing) {
       std::cerr << "SimplifyPath: Simplify " << elapsed_ms(t0, now()) << "ms\n";
+    }
+  }
+
+  {
+    const auto t0 = now();
+    // Flush any tensor LoadModelPooled left EXTERNAL (too large to
+    // materialize eagerly, and never touched -- or already dropped by dead-
+    // initializer elimination -- during Simplify()) back into ordinary
+    // in-memory form, so the saved output below is always fully self-
+    // contained no matter whether out_path's directory matches in_path's
+    // (an EXTERNAL tensor's external_data location is relative to where it
+    // was originally loaded from). See HydrateAllFromPool's own comment.
+    onnxsim::tensor_pool::HydrateAllFromPool(model, pool);
+    if (debug_timing) {
+      std::cerr << "SimplifyPath: HydrateAllFromPool " << elapsed_ms(t0, now())
+                << "ms\n";
     }
   }
 

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "dlpack/dlpack.h"
+#include "tensor_pool.h"
 
 // RAII owner for a DLManagedTensor: releasing it invokes the tensor's own
 // DLPack deleter exactly once (per the DLPack contract), which frees whatever
@@ -151,3 +152,30 @@ void SimplifyPath(
         overwrite_input_shapes = std::nullopt,
     const std::optional<std::vector<std::string>>& unused_output =
         std::nullopt);
+
+// Load `path` -- an ordinary .onnx file, whose weights may be inline or
+// stored as classic external data (or a mix) -- the way `SimplifyPath` above
+// does by default: onnx-optimizer's own `loadModel` reads the graph
+// structure without materializing external data
+// (`load_external_data=false`), then every classic-EXTERNAL tensor is pooled
+// via `onnxsim::tensor_pool::PoolExternalData` (see tensor_pool_bridge.h),
+// which memory-maps the referenced data file(s) instead of reading them into
+// a heap buffer.
+//
+// `hydrate_all` (default true) copies every pooled tensor's bytes back into
+// `model`'s own raw_data before returning, via `PoolExternalData`'s own
+// `hydrate_all` -- with the default, `model` comes back functionally
+// identical to `onnx::optimization::loadModel(model, path, true)` (an
+// ordinary, fully self-contained ModelProto), just without the extra
+// buffered read: the mapped pages are copied directly into raw_data instead
+// of first being read into a throwaway std::string. `pool` is populated but
+// not required by the caller in that case. With `hydrate_all=false`, `model`
+// never carries the pooled tensors' bytes at all -- no large raw_data -- and
+// they stay reachable only through `pool`; see PoolExternalData's own
+// comment for which onnxsim call sites can (and, today, mostly cannot yet)
+// consume such a reference directly.
+//
+// Returns the number of tensors pooled.
+size_t LoadModelPooled(const std::string& path, onnx::ModelProto* model,
+                       onnxsim::tensor_pool::TensorPool& pool,
+                       bool hydrate_all = true);

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -162,20 +162,21 @@ void SimplifyPath(
 // which memory-maps the referenced data file(s) instead of reading them into
 // a heap buffer.
 //
-// `hydrate_all` (default true) copies every pooled tensor's bytes back into
-// `model`'s own raw_data before returning, via `PoolExternalData`'s own
-// `hydrate_all` -- with the default, `model` comes back functionally
-// identical to `onnx::optimization::loadModel(model, path, true)` (an
-// ordinary, fully self-contained ModelProto), just without the extra
-// buffered read: the mapped pages are copied directly into raw_data instead
-// of first being read into a throwaway std::string. `pool` is populated but
-// not required by the caller in that case. With `hydrate_all=false`, `model`
-// never carries the pooled tensors' bytes at all -- no large raw_data -- and
-// they stay reachable only through `pool`; see PoolExternalData's own
-// comment for which onnxsim call sites can (and, today, mostly cannot yet)
-// consume such a reference directly.
+// `hydrate_threshold_bytes` (default onnxsim::tensor_pool::kHydrateAll)
+// copies a pooled tensor's bytes back into `model`'s own raw_data before
+// returning whenever that tensor's size is <= the threshold, via
+// `PoolExternalData`'s own threshold parameter -- with the kHydrateAll
+// default, `model` comes back functionally identical to
+// `onnx::optimization::loadModel(model, path, true)` (an ordinary, fully
+// self-contained ModelProto), just without the extra buffered read: the
+// mapped pages are copied directly into raw_data instead of first being read
+// into a throwaway std::string. `pool` is populated but not required by the
+// caller in that case. A tensor above the threshold is left EXTERNAL --
+// `model` never carries its bytes -- reachable only through `pool`; see
+// PoolExternalData's own comment for why that is safe to hand to Simplify().
 //
 // Returns the number of tensors pooled.
-size_t LoadModelPooled(const std::string& path, onnx::ModelProto* model,
-                       onnxsim::tensor_pool::TensorPool& pool,
-                       bool hydrate_all = true);
+size_t LoadModelPooled(
+    const std::string& path, onnx::ModelProto* model,
+    onnxsim::tensor_pool::TensorPool& pool,
+    uint64_t hydrate_threshold_bytes = onnxsim::tensor_pool::kHydrateAll);

--- a/onnxsim/tensor_pool.h
+++ b/onnxsim/tensor_pool.h
@@ -71,6 +71,7 @@
 #define ONNXSIM_TENSOR_POOL_H_
 
 #include <cstdint>
+#include <limits>
 #include <map>
 #include <memory>
 #include <string>
@@ -82,6 +83,14 @@
 
 namespace onnxsim {
 namespace tensor_pool {
+
+// Sentinel "byte size threshold" meaning "hydrate every tensor, regardless
+// of size" -- the value a caller of PoolExternalData/LoadModelPooled
+// (tensor_pool_bridge.h / onnxsim.h) passes for the old hydrate_all=true
+// behavior; a real (finite) threshold instead hydrates only tensors at or
+// under it, leaving larger ones as lazy pool-only references. Passing 0
+// leaves every tensor un-hydrated (the old hydrate_all=false).
+inline constexpr uint64_t kHydrateAll = std::numeric_limits<uint64_t>::max();
 
 // A named tensor's data as a zero-copy view into whatever storage TensorPool
 // keeps alive on its behalf. `owner` keeps `data` alive (it may be an

--- a/onnxsim/tensor_pool_bridge.h
+++ b/onnxsim/tensor_pool_bridge.h
@@ -53,6 +53,15 @@
  * (so an extracted model.onnx is standalone-usable elsewhere too) is a
  * tracked follow-up, not implemented here.
  *
+ * A fourth, independent piece, PoolExternalData, has nothing to do with the
+ * safetensors/GGUF archive formats above: it pools a model's *existing*
+ * classic onnx external data (the ordinary "<name>.onnx" + "<name>.data"
+ * pair onnx.save(..., save_as_external_data=True) produces) by
+ * memory-mapping the data file(s) instead of reading them into a heap
+ * buffer -- see onnxsim.h's LoadModelPooled, which combines this with
+ * onnx-optimizer's own loadModel to give onnxsim's `simplify()` its default
+ * path-based model-loading step.
+ *
  * NOT covered here: keeping initializers EXTERNAL as onnxsim's *internal*
  * in-flight representation during Simplify()'s fixed point, to dodge
  * ModelProto copy costs mid-pipeline. That would collide with existing logic
@@ -73,6 +82,7 @@
 #include <onnx/onnx_pb.h>
 
 #include <cstdint>
+#include <filesystem>
 #include <fstream>
 #include <map>
 #include <memory>
@@ -82,6 +92,7 @@
 #include <utility>
 #include <vector>
 
+#include "mmap_file.h"
 #include "tensor_pool.h"
 #include "tensor_pool_dtype.h"
 #include "tensor_pool_hash.h"
@@ -93,6 +104,31 @@ namespace detail {
 
 template <typename Fn>
 void ForEachTensor(onnx::GraphProto& graph, Fn&& fn);
+
+// The parsed "location"/"offset"/"length" triple a classic-EXTERNAL
+// TensorProto's external_data carries (onnx's own "raw external data in a
+// file" convention -- the same one PoolExternalData below reads and
+// ExportModelWithSafetensors's callers write). Reimplemented here, rather
+// than reused from onnx-optimizer's own equivalent (model_util.cc's
+// ExternalDataInfo), so this header keeps needing only onnx's protobuf
+// headers -- see this header's top comment.
+struct ExternalDataRef {
+  std::string location;
+  int64_t offset = -1;  // -1 means "from the start of the file"
+  int64_t length = -1;  // -1 means "to the end of the file"
+
+  explicit ExternalDataRef(const onnx::TensorProto& tensor) {
+    for (const auto& e : tensor.external_data()) {
+      if (e.key() == "location") {
+        location = e.value();
+      } else if (e.key() == "offset") {
+        offset = std::stoll(e.value());
+      } else if (e.key() == "length") {
+        length = std::stoll(e.value());
+      }
+    }
+  }
+};
 
 // Recurse into one node attribute: its own tensor (`t`), its repeated
 // `tensors`, and any subgraph(s) it carries (`g` / `graphs`, e.g. an `If`
@@ -183,6 +219,118 @@ inline bool HydrateTensorProto(const std::string& name,
   tensor.clear_external_data();
   tensor.set_raw_data(entry->data.data(), entry->data.size());
   return true;
+}
+
+// Pool every classic-EXTERNAL tensor (onnx's own external-data convention --
+// see detail::ExternalDataRef above) in `model` -- initializers and node-
+// attribute tensors, recursing into subgraphs (detail::ForEachTensor) -- by
+// memory-mapping the file(s) its external_data entries point to
+// (TryMmapFile, see mmap_file.h) rather than reading each tensor's slice
+// into a fresh heap buffer the way onnx's own external-data loader
+// (loadExternalDataForModel) does. Distinct tensors that share one file (the
+// common `all_tensors_to_one_file=True` case) share one mapping, so a model
+// with thousands of initializers in one data file costs one mmap() call, not
+// one per tensor. `base_dir` resolves a relative `location` exactly like
+// onnx's own loader (join, don't reinterpret) -- pass the directory the
+// model's own .onnx file lives in.
+//
+// hydrate_all (default true, matching plain onnx.load / onnx's own external-
+// data loader) copies each pooled tensor's bytes back into its own raw_data
+// before returning (via HydrateTensorProto) -- with this default, every
+// pooled tensor in `model` ends up an ordinary, self-contained in-memory
+// tensor, functionally identical to what onnx's own external-data loader
+// produces, and `pool` is populated but not required by the caller
+// afterwards. With hydrate_all=false, a pooled tensor is left EXTERNAL, its
+// external_data untouched (so it still names the real on-disk
+// file/offset/length onnx's own loader would use) -- `model` never carries
+// that tensor's bytes at all (no large raw_data), but `pool` now holds a
+// zero-copy Entry for it too, addressable by name, for a caller that knows
+// how to consume one (see this header's top comment for which onnxsim call
+// sites do not, yet).
+//
+// A file that fails to memory-map (no mmap support on this platform, or the
+// mmap()/MapViewOfFile() call itself fails -- see TryMmapFile) falls back to
+// an ordinary seek+read for just the tensors that file backs, matching
+// onnx's own external-data loader's behavior exactly, just without the mmap
+// benefit for that one file.
+//
+// Returns the number of tensors pooled. Throws std::runtime_error if a
+// referenced file cannot be opened at all (mapped or not), or if a tensor's
+// offset/length range falls outside its file.
+inline size_t PoolExternalData(onnx::ModelProto& model,
+                               const std::string& base_dir, TensorPool& pool,
+                               bool hydrate_all = true) {
+  // Keyed by the resolved absolute path, so tensors sharing one data file
+  // (the common case) share one mapping/read instead of one per tensor.
+  std::map<std::string, std::pair<std::shared_ptr<const char[]>, uint64_t>>
+      mapped_files;
+  size_t pooled = 0;
+
+  detail::ForEachTensor(
+      *model.mutable_graph(), [&](const std::string& name,
+                                  onnx::TensorProto& t) {
+        if (t.data_location() != onnx::TensorProto::EXTERNAL) return;
+        detail::ExternalDataRef ref(t);
+        if (ref.location.empty()) return;  // nothing to pool
+
+        const std::string resolved =
+            (std::filesystem::path(base_dir) / ref.location).string();
+
+        auto it = mapped_files.find(resolved);
+        if (it == mapped_files.end()) {
+          it = mapped_files.emplace(resolved, TryMmapFile(resolved)).first;
+        }
+        auto& [mapping, file_size] = it->second;
+
+        std::vector<int64_t> shape(t.dims().begin(), t.dims().end());
+
+        if (mapping) {
+          const uint64_t begin =
+              ref.offset >= 0 ? static_cast<uint64_t>(ref.offset) : 0;
+          const uint64_t len = ref.length >= 0
+                                   ? static_cast<uint64_t>(ref.length)
+                                   : file_size - begin;
+          if (begin > file_size || len > file_size - begin) {
+            throw std::runtime_error(
+                "PoolExternalData: '" + resolved + "' tensor '" + name +
+                "' external_data range exceeds the file's size");
+          }
+          std::shared_ptr<const char[]> owner(mapping,
+                                              mapping.get() + begin);
+          pool.Add(name, t.data_type(), shape, std::move(owner),
+                   std::string_view(mapping.get() + begin, len));
+        } else {
+          // No mmap support / mmap failed: fall back to an ordinary
+          // seek+read, matching onnx's own external-data loader
+          // (loadExternalDataForTensor) exactly for just this tensor.
+          std::ifstream in(resolved, std::ios::binary);
+          if (!in) {
+            throw std::runtime_error("PoolExternalData: cannot open '" +
+                                     resolved + "'");
+          }
+          in.seekg(0, std::ios::end);
+          const int64_t full_size = static_cast<int64_t>(in.tellg());
+          const int64_t begin = ref.offset >= 0 ? ref.offset : 0;
+          const int64_t len =
+              ref.length >= 0 ? ref.length : full_size - begin;
+          in.seekg(begin, std::ios::beg);
+          std::string bytes(static_cast<size_t>(len), '\0');
+          in.read(bytes.data(), static_cast<std::streamsize>(len));
+          if (!in) {
+            throw std::runtime_error("PoolExternalData: failed to read '" +
+                                     resolved + "' for tensor '" + name +
+                                     "'");
+          }
+          pool.Add(name, t.data_type(), shape, std::move(bytes));
+        }
+        ++pooled;
+
+        if (hydrate_all) {
+          HydrateTensorProto(name, t, pool);
+        }
+      });
+
+  return pooled;
 }
 
 // Rewrite `model` so every eligible tensor (graph initializers and node-

--- a/onnxsim/tensor_pool_bridge.h
+++ b/onnxsim/tensor_pool_bridge.h
@@ -248,6 +248,15 @@ inline bool HydrateTensorProto(const std::string& name,
 // how to consume one (see this header's top comment for which onnxsim call
 // sites do not, yet).
 //
+// Hydration, when requested, is a distinct final pass over every tensor this
+// call pooled -- run only after every one of them has been mapped/read into
+// `pool` successfully, never interleaved into the mapping loop itself. That
+// makes this call atomic with respect to `model`: if pooling fails partway
+// (a later tensor's file is missing, say), no earlier tensor has been
+// mutated either -- `model` is left exactly as it was passed in, not a mix
+// of already-hydrated and still-EXTERNAL tensors depending on graph
+// traversal order.
+//
 // A file that fails to memory-map (no mmap support on this platform, or the
 // mmap()/MapViewOfFile() call itself fails -- see TryMmapFile) falls back to
 // an ordinary seek+read for just the tensors that file backs, matching
@@ -264,7 +273,11 @@ inline size_t PoolExternalData(onnx::ModelProto& model,
   // (the common case) share one mapping/read instead of one per tensor.
   std::map<std::string, std::pair<std::shared_ptr<const char[]>, uint64_t>>
       mapped_files;
-  size_t pooled = 0;
+  // Pooled this call, kept alongside each TensorProto* so the hydration pass
+  // below need not re-walk (or re-match by name against) the graph -- same
+  // bookkeeping ExportModelWithSafetensors and
+  // AdoptAllWithPlaceholderOffsets use for their own two-phase sequences.
+  std::vector<std::pair<std::string, onnx::TensorProto*>> pooled_tensors;
 
   detail::ForEachTensor(*model.mutable_graph(), [&](const std::string& name,
                                                     onnx::TensorProto& t) {
@@ -318,14 +331,20 @@ inline size_t PoolExternalData(onnx::ModelProto& model,
       }
       pool.Add(name, t.data_type(), shape, std::move(bytes));
     }
-    ++pooled;
-
-    if (hydrate_all) {
-      HydrateTensorProto(name, t, pool);
-    }
+    pooled_tensors.emplace_back(name, &t);
   });
 
-  return pooled;
+  // Final phase: every tensor above pooled successfully (no throw reached
+  // here otherwise), so it is now safe to hydrate them all -- or, with
+  // hydrate_all=false, to leave every one of them exactly as pooling found
+  // it (still EXTERNAL, no raw_data), never partially mutated.
+  if (hydrate_all) {
+    for (auto& [name, t] : pooled_tensors) {
+      HydrateTensorProto(name, *t, pool);
+    }
+  }
+
+  return pooled_tensors.size();
 }
 
 // Rewrite `model` so every eligible tensor (graph initializers and node-

--- a/onnxsim/tensor_pool_bridge.h
+++ b/onnxsim/tensor_pool_bridge.h
@@ -266,69 +266,64 @@ inline size_t PoolExternalData(onnx::ModelProto& model,
       mapped_files;
   size_t pooled = 0;
 
-  detail::ForEachTensor(
-      *model.mutable_graph(), [&](const std::string& name,
-                                  onnx::TensorProto& t) {
-        if (t.data_location() != onnx::TensorProto::EXTERNAL) return;
-        detail::ExternalDataRef ref(t);
-        if (ref.location.empty()) return;  // nothing to pool
+  detail::ForEachTensor(*model.mutable_graph(), [&](const std::string& name,
+                                                    onnx::TensorProto& t) {
+    if (t.data_location() != onnx::TensorProto::EXTERNAL) return;
+    detail::ExternalDataRef ref(t);
+    if (ref.location.empty()) return;  // nothing to pool
 
-        const std::string resolved =
-            (std::filesystem::path(base_dir) / ref.location).string();
+    const std::string resolved =
+        (std::filesystem::path(base_dir) / ref.location).string();
 
-        auto it = mapped_files.find(resolved);
-        if (it == mapped_files.end()) {
-          it = mapped_files.emplace(resolved, TryMmapFile(resolved)).first;
-        }
-        auto& [mapping, file_size] = it->second;
+    auto it = mapped_files.find(resolved);
+    if (it == mapped_files.end()) {
+      it = mapped_files.emplace(resolved, TryMmapFile(resolved)).first;
+    }
+    auto& [mapping, file_size] = it->second;
 
-        std::vector<int64_t> shape(t.dims().begin(), t.dims().end());
+    std::vector<int64_t> shape(t.dims().begin(), t.dims().end());
 
-        if (mapping) {
-          const uint64_t begin =
-              ref.offset >= 0 ? static_cast<uint64_t>(ref.offset) : 0;
-          const uint64_t len = ref.length >= 0
-                                   ? static_cast<uint64_t>(ref.length)
-                                   : file_size - begin;
-          if (begin > file_size || len > file_size - begin) {
-            throw std::runtime_error(
-                "PoolExternalData: '" + resolved + "' tensor '" + name +
-                "' external_data range exceeds the file's size");
-          }
-          std::shared_ptr<const char[]> owner(mapping,
-                                              mapping.get() + begin);
-          pool.Add(name, t.data_type(), shape, std::move(owner),
-                   std::string_view(mapping.get() + begin, len));
-        } else {
-          // No mmap support / mmap failed: fall back to an ordinary
-          // seek+read, matching onnx's own external-data loader
-          // (loadExternalDataForTensor) exactly for just this tensor.
-          std::ifstream in(resolved, std::ios::binary);
-          if (!in) {
-            throw std::runtime_error("PoolExternalData: cannot open '" +
-                                     resolved + "'");
-          }
-          in.seekg(0, std::ios::end);
-          const int64_t full_size = static_cast<int64_t>(in.tellg());
-          const int64_t begin = ref.offset >= 0 ? ref.offset : 0;
-          const int64_t len =
-              ref.length >= 0 ? ref.length : full_size - begin;
-          in.seekg(begin, std::ios::beg);
-          std::string bytes(static_cast<size_t>(len), '\0');
-          in.read(bytes.data(), static_cast<std::streamsize>(len));
-          if (!in) {
-            throw std::runtime_error("PoolExternalData: failed to read '" +
-                                     resolved + "' for tensor '" + name +
-                                     "'");
-          }
-          pool.Add(name, t.data_type(), shape, std::move(bytes));
-        }
-        ++pooled;
+    if (mapping) {
+      const uint64_t begin =
+          ref.offset >= 0 ? static_cast<uint64_t>(ref.offset) : 0;
+      const uint64_t len = ref.length >= 0 ? static_cast<uint64_t>(ref.length)
+                                           : file_size - begin;
+      if (begin > file_size || len > file_size - begin) {
+        throw std::runtime_error(
+            "PoolExternalData: '" + resolved + "' tensor '" + name +
+            "' external_data range exceeds the file's size");
+      }
+      std::shared_ptr<const char[]> owner(mapping, mapping.get() + begin);
+      pool.Add(name, t.data_type(), shape, std::move(owner),
+               std::string_view(mapping.get() + begin, len));
+    } else {
+      // No mmap support / mmap failed: fall back to an ordinary
+      // seek+read, matching onnx's own external-data loader
+      // (loadExternalDataForTensor) exactly for just this tensor.
+      std::ifstream in(resolved, std::ios::binary);
+      if (!in) {
+        throw std::runtime_error("PoolExternalData: cannot open '" + resolved +
+                                 "'");
+      }
+      in.seekg(0, std::ios::end);
+      const int64_t full_size = static_cast<int64_t>(in.tellg());
+      const int64_t begin = ref.offset >= 0 ? ref.offset : 0;
+      const int64_t len = ref.length >= 0 ? ref.length : full_size - begin;
+      in.seekg(begin, std::ios::beg);
+      std::string bytes(static_cast<size_t>(len), '\0');
+      in.read(bytes.data(), static_cast<std::streamsize>(len));
+      if (!in) {
+        throw std::runtime_error("PoolExternalData: failed to read '" +
+                                 resolved + "' for tensor '" + name + "'");
+      }
+      pool.Add(name, t.data_type(), shape, std::move(bytes));
+    }
+    ++pooled;
 
-        if (hydrate_all) {
-          HydrateTensorProto(name, t, pool);
-        }
-      });
+    if (hydrate_all) {
+      HydrateTensorProto(name, t, pool);
+    }
+  });
 
   return pooled;
 }

--- a/onnxsim/tensor_pool_bridge.h
+++ b/onnxsim/tensor_pool_bridge.h
@@ -234,27 +234,41 @@ inline bool HydrateTensorProto(const std::string& name,
 // onnx's own loader (join, don't reinterpret) -- pass the directory the
 // model's own .onnx file lives in.
 //
-// hydrate_all (default true, matching plain onnx.load / onnx's own external-
-// data loader) copies each pooled tensor's bytes back into its own raw_data
-// before returning (via HydrateTensorProto) -- with this default, every
-// pooled tensor in `model` ends up an ordinary, self-contained in-memory
-// tensor, functionally identical to what onnx's own external-data loader
-// produces, and `pool` is populated but not required by the caller
-// afterwards. With hydrate_all=false, a pooled tensor is left EXTERNAL, its
-// external_data untouched (so it still names the real on-disk
-// file/offset/length onnx's own loader would use) -- `model` never carries
-// that tensor's bytes at all (no large raw_data), but `pool` now holds a
-// zero-copy Entry for it too, addressable by name, for a caller that knows
-// how to consume one (see this header's top comment for which onnxsim call
-// sites do not, yet).
+// hydrate_threshold_bytes (default kHydrateAll, matching plain onnx.load /
+// onnx's own external-data loader) copies a pooled tensor's bytes back into
+// its own raw_data before returning (via HydrateTensorProto) whenever that
+// tensor's byte size is <= hydrate_threshold_bytes -- with the kHydrateAll
+// default, every pooled tensor in `model` ends up an ordinary, self-
+// contained in-memory tensor, functionally identical to what onnx's own
+// external-data loader produces, and `pool` is populated but not required by
+// the caller afterwards. A tensor whose size exceeds the threshold is left
+// EXTERNAL instead, its external_data untouched (so it still names the real
+// on-disk file/offset/length onnx's own loader would use) -- `model` never
+// carries that tensor's bytes at all (no large raw_data), but `pool` now
+// holds a zero-copy Entry for it too, addressable by name, for a caller that
+// knows how to consume one. Passing 0 leaves every pooled tensor EXTERNAL
+// (matching the old hydrate_all=false).
 //
-// Hydration, when requested, is a distinct final pass over every tensor this
-// call pooled -- run only after every one of them has been mapped/read into
-// `pool` successfully, never interleaved into the mapping loop itself. That
-// makes this call atomic with respect to `model`: if pooling fails partway
-// (a later tensor's file is missing, say), no earlier tensor has been
-// mutated either -- `model` is left exactly as it was passed in, not a mix
-// of already-hydrated and still-EXTERNAL tensors depending on graph
+// Every onnxsim pass that reads a constant tensor's *value* (as opposed to
+// just its declared shape/dtype, always available regardless of hydration)
+// goes through FetchConstantTensor/IsConstantTensor (onnx-optimizer's
+// pass_util.h) or CSETensorHash/CSETensorCompare (cse_util.h), both of which
+// treat an EXTERNAL tensor as unavailable rather than reading its absent
+// data as if it were zero/empty -- so leaving a tensor EXTERNAL here is safe
+// to hand to Simplify(): it just means that tensor's value-dependent
+// optimizations (constant folding, BN fusion, CSE dedup, ...) are skipped
+// for it, not that they run on wrong data. See LoadModelPooled's caller
+// (SimplifyPath) for how a model with leftover EXTERNAL tensors is still
+// fully materialized again -- via HydrateAllFromPool below -- before it is
+// ever serialized out.
+//
+// Hydration, when it happens, is a distinct final pass over every tensor
+// this call pooled -- run only after every one of them has been mapped/read
+// into `pool` successfully, never interleaved into the mapping loop itself.
+// That makes this call atomic with respect to `model`: if pooling fails
+// partway (a later tensor's file is missing, say), no earlier tensor has
+// been mutated either -- `model` is left exactly as it was passed in, not a
+// mix of already-hydrated and still-EXTERNAL tensors depending on graph
 // traversal order.
 //
 // A file that fails to memory-map (no mmap support on this platform, or the
@@ -263,12 +277,12 @@ inline bool HydrateTensorProto(const std::string& name,
 // onnx's own external-data loader's behavior exactly, just without the mmap
 // benefit for that one file.
 //
-// Returns the number of tensors pooled. Throws std::runtime_error if a
-// referenced file cannot be opened at all (mapped or not), or if a tensor's
-// offset/length range falls outside its file.
+// Returns the number of tensors pooled (hydrated or not). Throws
+// std::runtime_error if a referenced file cannot be opened at all (mapped or
+// not), or if a tensor's offset/length range falls outside its file.
 inline size_t PoolExternalData(onnx::ModelProto& model,
                                const std::string& base_dir, TensorPool& pool,
-                               bool hydrate_all = true) {
+                               uint64_t hydrate_threshold_bytes = kHydrateAll) {
   // Keyed by the resolved absolute path, so tensors sharing one data file
   // (the common case) share one mapping/read instead of one per tensor.
   std::map<std::string, std::pair<std::shared_ptr<const char[]>, uint64_t>>
@@ -335,16 +349,44 @@ inline size_t PoolExternalData(onnx::ModelProto& model,
   });
 
   // Final phase: every tensor above pooled successfully (no throw reached
-  // here otherwise), so it is now safe to hydrate them all -- or, with
-  // hydrate_all=false, to leave every one of them exactly as pooling found
-  // it (still EXTERNAL, no raw_data), never partially mutated.
-  if (hydrate_all) {
-    for (auto& [name, t] : pooled_tensors) {
+  // here otherwise), so it is now safe to hydrate the ones at or under the
+  // threshold -- larger ones are left exactly as pooling found them (still
+  // EXTERNAL, no raw_data), never partially mutated.
+  for (auto& [name, t] : pooled_tensors) {
+    const Entry* entry = pool.Find(name);
+    if (entry != nullptr && entry->nbytes() <= hydrate_threshold_bytes) {
       HydrateTensorProto(name, *t, pool);
     }
   }
 
   return pooled_tensors.size();
+}
+
+// Hydrate every remaining EXTERNAL tensor in `model` that has a matching
+// entry in `pool` -- the "make it fully self-contained again" counterpart to
+// PoolExternalData's threshold-based partial hydration above. Intended use:
+// a caller runs Simplify() on a model PoolExternalData left partially
+// EXTERNAL (large tensors skipped for lower peak memory during the fixed
+// point -- see PoolExternalData's own comment on why that is safe), then
+// calls this right before serializing/saving the result, so the OUTPUT is
+// always a plain, fully self-contained model regardless of whether the
+// output path's directory matches the input's (an EXTERNAL tensor's
+// external_data location is relative to wherever it was originally loaded
+// from, so leaving one EXTERNAL in a model saved to a different directory
+// would silently produce a file whose data reference no longer resolves).
+// A tensor that is EXTERNAL but has no matching entry in `pool` (not
+// something this pool loaded) is left untouched. Returns the number
+// hydrated.
+inline size_t HydrateAllFromPool(onnx::ModelProto& model,
+                                 const TensorPool& pool) {
+  size_t hydrated = 0;
+  detail::ForEachTensor(*model.mutable_graph(),
+                        [&](const std::string& name, onnx::TensorProto& t) {
+                          if (t.data_location() != onnx::TensorProto::EXTERNAL)
+                            return;
+                          if (HydrateTensorProto(name, t, pool)) ++hydrated;
+                        });
+  return hydrated;
 }
 
 // Rewrite `model` so every eligible tensor (graph initializers and node-

--- a/onnxsim/tensor_pool_bridge_test.cpp
+++ b/onnxsim/tensor_pool_bridge_test.cpp
@@ -368,8 +368,7 @@ void TestPoolExternalDataLazy() {
         "pool holds the bytes even though the tensor itself was not "
         "hydrated");
 
-  bool hydrated =
-      HydrateTensorProto("lazy", *g->mutable_initializer(0), pool);
+  bool hydrated = HydrateTensorProto("lazy", *g->mutable_initializer(0), pool);
   Check(hydrated && g->initializer(0).raw_data() == payload,
         "on-demand HydrateTensorProto recovers the bytes from the pool, no "
         "second file read");
@@ -429,8 +428,9 @@ void TestPoolExternalDataMissingFileThrows() {
   } catch (const std::runtime_error&) {
     threw = true;
   }
-  Check(threw, "a missing external-data file raises rather than silently "
-               "skipping the tensor");
+  Check(threw,
+        "a missing external-data file raises rather than silently "
+        "skipping the tensor");
 }
 
 void TestLoadModelPooled() {
@@ -454,8 +454,8 @@ void TestLoadModelPooled() {
   w->add_dims(3);
   SetExternalData(*w, data_file, /*offset=*/0, /*length=*/12);
 
-  const std::string model_path =
-      dir + "/onnxsim_load_model_pooled_" + std::to_string(::getpid()) + ".onnx";
+  const std::string model_path = dir + "/onnxsim_load_model_pooled_" +
+                                 std::to_string(::getpid()) + ".onnx";
   std::string serialized;
   model.SerializeToString(&serialized);
   WriteFile(model_path, serialized);

--- a/onnxsim/tensor_pool_bridge_test.cpp
+++ b/onnxsim/tensor_pool_bridge_test.cpp
@@ -16,6 +16,8 @@
 #include <map>
 #include <string>
 
+#include "onnxsim.h"
+
 using namespace onnxsim::tensor_pool;
 
 namespace {
@@ -285,6 +287,197 @@ void TestImportModelWithSafetensorsLazy() {
   std::remove(path.c_str());
 }
 
+void WriteFile(const std::string& path, const std::string& contents) {
+  std::ofstream out(path, std::ios::binary | std::ios::trunc);
+  out.write(contents.data(), static_cast<std::streamsize>(contents.size()));
+}
+
+void SetExternalData(onnx::TensorProto& t, const std::string& location,
+                     int64_t offset, int64_t length) {
+  t.set_data_location(onnx::TensorProto::EXTERNAL);
+  t.clear_external_data();
+  auto set_kv = [&](const std::string& k, const std::string& v) {
+    auto* e = t.add_external_data();
+    e->set_key(k);
+    e->set_value(v);
+  };
+  set_kv("location", location);
+  set_kv("offset", std::to_string(offset));
+  set_kv("length", std::to_string(length));
+}
+
+void TestPoolExternalDataHydrateAll() {
+  const std::string dir = "/tmp";
+  const std::string data_file =
+      "onnxsim_pool_ext_" + std::to_string(::getpid()) + "_a.data";
+  const std::string data_path = dir + "/" + data_file;
+  const std::string payload = std::string(8, '\xAB');
+  WriteFile(data_path, payload);
+
+  onnx::ModelProto model;
+  auto* g = model.mutable_graph();
+  auto* w = g->add_initializer();
+  w->set_name("w");
+  w->set_data_type(onnx::TensorProto::FLOAT);
+  w->add_dims(2);
+  SetExternalData(*w, data_file, /*offset=*/0, /*length=*/8);
+
+  TensorPool pool;
+  size_t n = PoolExternalData(model, dir, pool, /*hydrate_all=*/true);
+  Check(n == 1, "one tensor pooled");
+  Check(g->initializer(0).has_raw_data() &&
+            g->initializer(0).raw_data() == payload,
+        "hydrated raw_data matches the external file's bytes");
+  Check(g->initializer(0).data_location() == onnx::TensorProto::DEFAULT,
+        "hydrated tensor is DEFAULT-located, not EXTERNAL");
+  const Entry* e = pool.Find("w");
+  Check(e != nullptr && e->data == payload,
+        "pool holds an entry with the matching bytes too");
+
+  std::remove(data_path.c_str());
+}
+
+void TestPoolExternalDataLazy() {
+  const std::string dir = "/tmp";
+  const std::string data_file =
+      "onnxsim_pool_ext_" + std::to_string(::getpid()) + "_b.data";
+  const std::string data_path = dir + "/" + data_file;
+  const std::string payload = std::string(4, '\xCD');
+  WriteFile(data_path, payload);
+
+  onnx::ModelProto model;
+  auto* g = model.mutable_graph();
+  auto* w = g->add_initializer();
+  w->set_name("lazy");
+  w->set_data_type(onnx::TensorProto::UINT8);
+  w->add_dims(4);
+  SetExternalData(*w, data_file, /*offset=*/0, /*length=*/4);
+
+  TensorPool pool;
+  size_t n = PoolExternalData(model, dir, pool, /*hydrate_all=*/false);
+  Check(n == 1, "lazy pooling still reports the match");
+  Check(!g->initializer(0).has_raw_data(),
+        "lazy pooling leaves raw_data unset");
+  Check(g->initializer(0).data_location() == onnx::TensorProto::EXTERNAL,
+        "lazy pooling leaves the tensor EXTERNAL");
+  Check(g->initializer(0).external_data_size() == 3,
+        "lazy pooling does not touch the original external_data entries");
+
+  const Entry* e = pool.Find("lazy");
+  Check(e != nullptr && e->data == payload,
+        "pool holds the bytes even though the tensor itself was not "
+        "hydrated");
+
+  bool hydrated =
+      HydrateTensorProto("lazy", *g->mutable_initializer(0), pool);
+  Check(hydrated && g->initializer(0).raw_data() == payload,
+        "on-demand HydrateTensorProto recovers the bytes from the pool, no "
+        "second file read");
+
+  std::remove(data_path.c_str());
+}
+
+void TestPoolExternalDataSharedFile() {
+  // Two tensors backed by different byte ranges of the SAME data file (the
+  // common `all_tensors_to_one_file=True` layout) -- exercises the mapping
+  // dedup: PoolExternalData must memory-map the file once, not once per
+  // tensor, and still resolve each tensor's own slice correctly.
+  const std::string dir = "/tmp";
+  const std::string data_file =
+      "onnxsim_pool_ext_" + std::to_string(::getpid()) + "_shared.data";
+  const std::string data_path = dir + "/" + data_file;
+  const std::string first = std::string(4, '\x01');
+  const std::string second = std::string(4, '\x02');
+  WriteFile(data_path, first + second);
+
+  onnx::ModelProto model;
+  auto* g = model.mutable_graph();
+  auto* a = g->add_initializer();
+  a->set_name("a");
+  a->set_data_type(onnx::TensorProto::FLOAT);
+  a->add_dims(1);
+  SetExternalData(*a, data_file, /*offset=*/0, /*length=*/4);
+  auto* b = g->add_initializer();
+  b->set_name("b");
+  b->set_data_type(onnx::TensorProto::FLOAT);
+  b->add_dims(1);
+  SetExternalData(*b, data_file, /*offset=*/4, /*length=*/4);
+
+  TensorPool pool;
+  size_t n = PoolExternalData(model, dir, pool, /*hydrate_all=*/true);
+  Check(n == 2, "both tensors sharing one file are pooled");
+  Check(g->initializer(0).raw_data() == first, "tensor 'a' gets its own slice");
+  Check(g->initializer(1).raw_data() == second,
+        "tensor 'b' gets its own (different) slice of the same file");
+
+  std::remove(data_path.c_str());
+}
+
+void TestPoolExternalDataMissingFileThrows() {
+  onnx::ModelProto model;
+  auto* w = model.mutable_graph()->add_initializer();
+  w->set_name("missing");
+  w->set_data_type(onnx::TensorProto::FLOAT);
+  w->add_dims(1);
+  SetExternalData(*w, "does_not_exist_" + std::to_string(::getpid()) + ".data",
+                  0, 4);
+
+  TensorPool pool;
+  bool threw = false;
+  try {
+    PoolExternalData(model, "/tmp", pool, /*hydrate_all=*/true);
+  } catch (const std::runtime_error&) {
+    threw = true;
+  }
+  Check(threw, "a missing external-data file raises rather than silently "
+               "skipping the tensor");
+}
+
+void TestLoadModelPooled() {
+  const std::string dir = "/tmp";
+  const std::string data_file =
+      "onnxsim_load_model_pooled_" + std::to_string(::getpid()) + ".data";
+  const std::string data_path = dir + "/" + data_file;
+  const std::string payload = std::string(12, '\x42');
+  WriteFile(data_path, payload);
+
+  onnx::ModelProto model;
+  model.set_ir_version(10);
+  auto* opset = model.add_opset_import();
+  opset->set_domain("");
+  opset->set_version(14);
+  auto* g = model.mutable_graph();
+  g->set_name("TestLoadModelPooled");
+  auto* w = g->add_initializer();
+  w->set_name("w");
+  w->set_data_type(onnx::TensorProto::FLOAT);
+  w->add_dims(3);
+  SetExternalData(*w, data_file, /*offset=*/0, /*length=*/12);
+
+  const std::string model_path =
+      dir + "/onnxsim_load_model_pooled_" + std::to_string(::getpid()) + ".onnx";
+  std::string serialized;
+  model.SerializeToString(&serialized);
+  WriteFile(model_path, serialized);
+
+  onnx::ModelProto loaded;
+  TensorPool pool;
+  size_t n = LoadModelPooled(model_path, &loaded, pool, /*hydrate_all=*/true);
+  Check(n == 1, "the model's one external tensor is pooled");
+  Check(loaded.graph().initializer_size() == 1 &&
+            loaded.graph().initializer(0).name() == "w",
+        "the loaded model has the same graph structure");
+  Check(loaded.graph().initializer(0).raw_data() == payload,
+        "the loaded model's tensor is hydrated with the external file's "
+        "bytes");
+  Check(loaded.graph().initializer(0).data_location() ==
+            onnx::TensorProto::DEFAULT,
+        "hydrate_all=true leaves no EXTERNAL tensors behind");
+
+  std::remove(data_path.c_str());
+  std::remove(model_path.c_str());
+}
+
 void TestAttachContentHashMetadata() {
   onnx::ModelProto model;
   auto* graph = model.mutable_graph();
@@ -352,6 +545,11 @@ int main() {
   TestUnnamedAttributeTensor();
   TestImportModelWithSafetensorsHydrateAll();
   TestImportModelWithSafetensorsLazy();
+  TestPoolExternalDataHydrateAll();
+  TestPoolExternalDataLazy();
+  TestPoolExternalDataSharedFile();
+  TestPoolExternalDataMissingFileThrows();
+  TestLoadModelPooled();
   TestAttachContentHashMetadata();
 
   if (g_failures == 0) {

--- a/onnxsim/tensor_pool_bridge_test.cpp
+++ b/onnxsim/tensor_pool_bridge_test.cpp
@@ -323,7 +323,7 @@ void TestPoolExternalDataHydrateAll() {
   SetExternalData(*w, data_file, /*offset=*/0, /*length=*/8);
 
   TensorPool pool;
-  size_t n = PoolExternalData(model, dir, pool, /*hydrate_all=*/true);
+  size_t n = PoolExternalData(model, dir, pool, kHydrateAll);
   Check(n == 1, "one tensor pooled");
   Check(g->initializer(0).has_raw_data() &&
             g->initializer(0).raw_data() == payload,
@@ -354,7 +354,7 @@ void TestPoolExternalDataLazy() {
   SetExternalData(*w, data_file, /*offset=*/0, /*length=*/4);
 
   TensorPool pool;
-  size_t n = PoolExternalData(model, dir, pool, /*hydrate_all=*/false);
+  size_t n = PoolExternalData(model, dir, pool, /*hydrate_threshold_bytes=*/0);
   Check(n == 1, "lazy pooling still reports the match");
   Check(!g->initializer(0).has_raw_data(),
         "lazy pooling leaves raw_data unset");
@@ -372,6 +372,102 @@ void TestPoolExternalDataLazy() {
   Check(hydrated && g->initializer(0).raw_data() == payload,
         "on-demand HydrateTensorProto recovers the bytes from the pool, no "
         "second file read");
+
+  std::remove(data_path.c_str());
+}
+
+void TestPoolExternalDataPartialThreshold() {
+  // Two tensors, one small (4 bytes) and one larger (8 bytes), pooled with a
+  // threshold that admits only the small one -- exercises the actual
+  // "some tensors hydrate, some don't" mixed case, not just the
+  // kHydrateAll/0 all-or-nothing extremes the other tests use.
+  const std::string dir = "/tmp";
+  const std::string data_file =
+      "onnxsim_pool_ext_" + std::to_string(::getpid()) + "_partial.data";
+  const std::string data_path = dir + "/" + data_file;
+  const std::string small_payload = std::string(4, '\x11');
+  const std::string large_payload = std::string(8, '\x22');
+  WriteFile(data_path, small_payload + large_payload);
+
+  onnx::ModelProto model;
+  auto* g = model.mutable_graph();
+  auto* small = g->add_initializer();
+  small->set_name("small");
+  small->set_data_type(onnx::TensorProto::UINT8);
+  small->add_dims(4);
+  SetExternalData(*small, data_file, /*offset=*/0, /*length=*/4);
+  auto* large = g->add_initializer();
+  large->set_name("large");
+  large->set_data_type(onnx::TensorProto::UINT8);
+  large->add_dims(8);
+  SetExternalData(*large, data_file, /*offset=*/4, /*length=*/8);
+
+  TensorPool pool;
+  size_t n = PoolExternalData(model, dir, pool, /*hydrate_threshold_bytes=*/4);
+  Check(n == 2, "both tensors are pooled regardless of the threshold");
+  Check(g->initializer(0).has_raw_data() &&
+            g->initializer(0).raw_data() == small_payload &&
+            g->initializer(0).data_location() == onnx::TensorProto::DEFAULT,
+        "the tensor at the threshold is hydrated");
+  Check(!g->initializer(1).has_raw_data() &&
+            g->initializer(1).data_location() == onnx::TensorProto::EXTERNAL,
+        "the tensor over the threshold is left EXTERNAL, not hydrated");
+  const Entry* e = pool.Find("large");
+  Check(e != nullptr && e->data == large_payload,
+        "the over-threshold tensor's bytes are still reachable via the pool");
+
+  std::remove(data_path.c_str());
+}
+
+void TestHydrateAllFromPool() {
+  // The "flush before save" counterpart: after PoolExternalData leaves a
+  // tensor EXTERNAL (over threshold), HydrateAllFromPool must be able to
+  // fully materialize it later from the same pool, with no second file read.
+  const std::string dir = "/tmp";
+  const std::string data_file =
+      "onnxsim_pool_ext_" + std::to_string(::getpid()) + "_flush.data";
+  const std::string data_path = dir + "/" + data_file;
+  const std::string payload = std::string(8, '\x33');
+  WriteFile(data_path, payload);
+
+  onnx::ModelProto model;
+  auto* g = model.mutable_graph();
+  auto* w = g->add_initializer();
+  w->set_name("big");
+  w->set_data_type(onnx::TensorProto::UINT8);
+  w->add_dims(8);
+  SetExternalData(*w, data_file, /*offset=*/0, /*length=*/8);
+
+  TensorPool pool;
+  size_t n = PoolExternalData(model, dir, pool, /*hydrate_threshold_bytes=*/0);
+  Check(n == 1, "the tensor is pooled");
+  Check(g->initializer(0).data_location() == onnx::TensorProto::EXTERNAL,
+        "still EXTERNAL before the flush");
+
+  // Added AFTER pooling, so PoolExternalData/this pool never touched it --
+  // a stand-in for a tensor that's EXTERNAL for some unrelated reason (a
+  // different loader, a hand-built model, ...). HydrateAllFromPool must
+  // leave it alone rather than crash trying to resolve a name the pool
+  // never saw.
+  auto* untracked = g->add_initializer();
+  untracked->set_name("untracked");
+  untracked->set_data_type(onnx::TensorProto::UINT8);
+  untracked->add_dims(1);
+  untracked->set_data_location(onnx::TensorProto::EXTERNAL);
+  auto* loc = untracked->add_external_data();
+  loc->set_key("location");
+  loc->set_value("nowhere");
+
+  size_t hydrated = HydrateAllFromPool(model, pool);
+  Check(hydrated == 1,
+        "HydrateAllFromPool hydrates exactly the one pooled "
+        "tensor");
+  Check(g->initializer(0).raw_data() == payload &&
+            g->initializer(0).data_location() == onnx::TensorProto::DEFAULT,
+        "the tensor is fully materialized from the pool, no second read");
+  Check(g->initializer(1).data_location() == onnx::TensorProto::EXTERNAL,
+        "a tensor with no matching pool entry is left untouched, not "
+        "crashed on");
 
   std::remove(data_path.c_str());
 }
@@ -403,7 +499,7 @@ void TestPoolExternalDataSharedFile() {
   SetExternalData(*b, data_file, /*offset=*/4, /*length=*/4);
 
   TensorPool pool;
-  size_t n = PoolExternalData(model, dir, pool, /*hydrate_all=*/true);
+  size_t n = PoolExternalData(model, dir, pool, kHydrateAll);
   Check(n == 2, "both tensors sharing one file are pooled");
   Check(g->initializer(0).raw_data() == first, "tensor 'a' gets its own slice");
   Check(g->initializer(1).raw_data() == second,
@@ -424,7 +520,7 @@ void TestPoolExternalDataMissingFileThrows() {
   TensorPool pool;
   bool threw = false;
   try {
-    PoolExternalData(model, "/tmp", pool, /*hydrate_all=*/true);
+    PoolExternalData(model, "/tmp", pool, kHydrateAll);
   } catch (const std::runtime_error&) {
     threw = true;
   }
@@ -464,7 +560,7 @@ void TestPoolExternalDataThrowLeavesEarlierTensorsUntouched() {
   TensorPool pool;
   bool threw = false;
   try {
-    PoolExternalData(model, dir, pool, /*hydrate_all=*/true);
+    PoolExternalData(model, dir, pool, kHydrateAll);
   } catch (const std::runtime_error&) {
     threw = true;
   }
@@ -506,7 +602,7 @@ void TestLoadModelPooled() {
 
   onnx::ModelProto loaded;
   TensorPool pool;
-  size_t n = LoadModelPooled(model_path, &loaded, pool, /*hydrate_all=*/true);
+  size_t n = LoadModelPooled(model_path, &loaded, pool, kHydrateAll);
   Check(n == 1, "the model's one external tensor is pooled");
   Check(loaded.graph().initializer_size() == 1 &&
             loaded.graph().initializer(0).name() == "w",
@@ -516,7 +612,7 @@ void TestLoadModelPooled() {
         "bytes");
   Check(loaded.graph().initializer(0).data_location() ==
             onnx::TensorProto::DEFAULT,
-        "hydrate_all=true leaves no EXTERNAL tensors behind");
+        "kHydrateAll leaves no EXTERNAL tensors behind");
 
   std::remove(data_path.c_str());
   std::remove(model_path.c_str());
@@ -591,6 +687,8 @@ int main() {
   TestImportModelWithSafetensorsLazy();
   TestPoolExternalDataHydrateAll();
   TestPoolExternalDataLazy();
+  TestPoolExternalDataPartialThreshold();
+  TestHydrateAllFromPool();
   TestPoolExternalDataSharedFile();
   TestPoolExternalDataMissingFileThrows();
   TestPoolExternalDataThrowLeavesEarlierTensorsUntouched();

--- a/onnxsim/tensor_pool_bridge_test.cpp
+++ b/onnxsim/tensor_pool_bridge_test.cpp
@@ -433,6 +433,50 @@ void TestPoolExternalDataMissingFileThrows() {
         "skipping the tensor");
 }
 
+void TestPoolExternalDataThrowLeavesEarlierTensorsUntouched() {
+  // Regression test for the hydration-is-a-final-pass invariant: a tensor
+  // that pools successfully must not be mutated (hydrated) if a LATER
+  // tensor (in graph traversal order) then fails to pool. Interleaving
+  // mmap/read with hydration per tensor would leave 'ok' hydrated and
+  // 'missing' not, an inconsistent half-mutated model on exception.
+  const std::string dir = "/tmp";
+  const std::string data_file =
+      "onnxsim_pool_ext_" + std::to_string(::getpid()) + "_ok.data";
+  const std::string data_path = dir + "/" + data_file;
+  const std::string payload = std::string(4, '\x09');
+  WriteFile(data_path, payload);
+
+  onnx::ModelProto model;
+  auto* g = model.mutable_graph();
+  auto* ok = g->add_initializer();
+  ok->set_name("ok");
+  ok->set_data_type(onnx::TensorProto::FLOAT);
+  ok->add_dims(1);
+  SetExternalData(*ok, data_file, /*offset=*/0, /*length=*/4);
+
+  auto* missing = g->add_initializer();
+  missing->set_name("missing");
+  missing->set_data_type(onnx::TensorProto::FLOAT);
+  missing->add_dims(1);
+  SetExternalData(
+      *missing, "does_not_exist_" + std::to_string(::getpid()) + ".data", 0, 4);
+
+  TensorPool pool;
+  bool threw = false;
+  try {
+    PoolExternalData(model, dir, pool, /*hydrate_all=*/true);
+  } catch (const std::runtime_error&) {
+    threw = true;
+  }
+  Check(threw, "pooling still fails overall when a later tensor is missing");
+  Check(!g->initializer(0).has_raw_data() &&
+            g->initializer(0).data_location() == onnx::TensorProto::EXTERNAL,
+        "the earlier, successfully-pooled tensor is left untouched -- not "
+        "hydrated -- rather than half-mutated");
+
+  std::remove(data_path.c_str());
+}
+
 void TestLoadModelPooled() {
   const std::string dir = "/tmp";
   const std::string data_file =
@@ -549,6 +593,7 @@ int main() {
   TestPoolExternalDataLazy();
   TestPoolExternalDataSharedFile();
   TestPoolExternalDataMissingFileThrows();
+  TestPoolExternalDataThrowLeavesEarlierTensorsUntouched();
   TestLoadModelPooled();
   TestAttachContentHashMetadata();
 

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -1002,10 +1002,14 @@ def test_load_model_hydrates_external_data():
     # separate classic external-data file -- even though it hydrates that
     # data via onnxsim's memory-mapped TensorPool loader internally instead
     # of ``onnx.load_external_data_for_model``.
-    a = np.random.rand(8, 8).astype(np.float32)
+    # 64x64 (16KiB), like test_simplify_path_with_external_data below --
+    # comfortably over onnx.save's default 1024-byte externalization
+    # threshold, so this tensor actually ends up in model.data rather than
+    # staying inline (which would make the whole test a no-op).
+    a = np.random.rand(64, 64).astype(np.float32)
     initializer = onnx.numpy_helper.from_array(a, "a")
     node = onnx.helper.make_node("Identity", ["a"], ["y"])
-    out = onnx.helper.make_tensor_value_info("y", onnx.TensorProto.FLOAT, (8, 8))
+    out = onnx.helper.make_tensor_value_info("y", onnx.TensorProto.FLOAT, (64, 64))
     graph_def = onnx.helper.make_graph(
         [node],
         "test_load_model_hydrates_external_data",

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -996,6 +996,48 @@ def test_simplify_path_with_external_data():
     np.testing.assert_allclose(folded, a + b, rtol=1e-5, atol=1e-6)
 
 
+def test_load_model_hydrates_external_data():
+    # ``onnxsim.load_model`` must produce a ModelProto functionally identical
+    # to ``onnx.load`` -- including for a model whose weights live in a
+    # separate classic external-data file -- even though it hydrates that
+    # data via onnxsim's memory-mapped TensorPool loader internally instead
+    # of ``onnx.load_external_data_for_model``.
+    a = np.random.rand(8, 8).astype(np.float32)
+    initializer = onnx.numpy_helper.from_array(a, "a")
+    node = onnx.helper.make_node("Identity", ["a"], ["y"])
+    out = onnx.helper.make_tensor_value_info("y", onnx.TensorProto.FLOAT, (8, 8))
+    graph_def = onnx.helper.make_graph(
+        [node],
+        "test_load_model_hydrates_external_data",
+        [],
+        [out],
+        initializer=[initializer],
+    )
+    model = onnx.helper.make_model(
+        graph_def, opset_imports=[onnx.helper.make_opsetid("", 14)], ir_version=10
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model_path = os.path.join(tmpdir, "model.onnx")
+        onnx.save(
+            model,
+            model_path,
+            save_as_external_data=True,
+            all_tensors_to_one_file=True,
+            location="model.data",
+        )
+        assert os.path.exists(os.path.join(tmpdir, "model.data"))
+
+        loaded = onnxsim.load_model(model_path)
+        expected = onnx.load(model_path)
+
+    assert len(loaded.graph.initializer) == 1
+    assert loaded.graph.initializer[0].data_location == onnx.TensorProto.DEFAULT
+    loaded_array = onnx.numpy_helper.to_array(loaded.graph.initializer[0])
+    np.testing.assert_array_equal(loaded_array, a)
+    assert loaded.SerializeToString() == expected.SerializeToString()
+
+
 def test_model_info_size_counts_external_data_without_loading():
     # ModelInfo must report a model's size from external-data metadata, so a
     # model whose weights live on disk can be measured without loading them --


### PR DESCRIPTION
onnx's own external-data loader reads each tensor's slice into a fresh heap
buffer. Add PoolExternalData (tensor_pool_bridge.h), which instead
memory-maps the referenced data file(s) into onnxsim's existing TensorPool
(shared with the safetensors/GGUF import machinery), deduping mappings per
file. LoadModelPooled (onnxsim.h/.cpp) combines this with onnx-optimizer's
loadModel to load a plain .onnx path this way, and is now the default
loading step inside SimplifyPath -- the C++ entry point simplify(path) hits
for the vast majority of real calls, and that the Rust/C/WASM bindings share
too. As a side effect this also pools external tensors nested in subgraph
node attributes (If/Loop bodies), which the previous loader missed.

On the Python side, add onnxsim.load_model(path) as a public convenience
using the same mechanism (exposed via a new hydrate_external_data_pooled
binding), and switch simplify()'s slower fallback path (check_n>0 or
shape-dict resolution) to use it instead of
onnx.load_external_data_for_model.

hydrate_all defaults to true throughout: onnxsim's own passes still need
fully materialized tensors today (tensor_pool_bridge.h's existing file
comment already flags that as unfinished follow-up work), so the pool
itself is discarded once loading completes -- the win is fewer/cheaper
copies on the way in, not lower peak memory during simplification.

Add C++ unit tests (tensor_pool_bridge_test.cpp) and a Python regression
test, and document onnxsim.load_model in the README.