### PR TITLE
Add Gelu and LayerNorm subgraph fusion passes

### DIFF
--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -15,6 +15,8 @@
 #include "passes/fuse_bn_into_conv.h"
 #include "passes/fuse_consecutive_mul.h"
 #include "passes/fuse_consecutive_unsqueezes.h"
+#include "passes/fuse_gelu.h"
+#include "passes/fuse_layer_norm.h"
 #include "passes/fuse_matmul_add_bias_into_gemm_batched.h"
 #include "passes/fuse_mul_into_conv.h"
 #include "passes/fuse_pad_into_pool.h"
@@ -55,6 +57,8 @@ void RegisterCustomOptimizerPasses() {
     // onnxsim-only rewrites (no built-in of the same name today).
     RegisterOrReplace<p::EliminateReshapeAroundElementwise>(registry);
     RegisterOrReplace<p::FuseConsecutiveMul>(registry);
+    RegisterOrReplace<p::FuseGelu>(registry);
+    RegisterOrReplace<p::FuseLayerNorm>(registry);
     RegisterOrReplace<p::FuseMatMulAddBiasIntoGemmBatched>(registry);
     RegisterOrReplace<p::FuseMulIntoConv>(registry);
     RegisterOrReplace<p::FusePrecedingMulIntoConv>(registry);

--- a/onnxsim/custom_optimizer_passes.h
+++ b/onnxsim/custom_optimizer_passes.h
@@ -22,6 +22,8 @@ namespace onnxsim {
 //   - fuse_consecutive_mul
 //   - fuse_matmul_add_bias_into_gemm_batched
 //   - eliminate_reshape_around_elementwise
+//   - fuse_gelu
+//   - fuse_layer_norm
 //
 // The registration runs at most once per process and is safe to call from any
 // simplification entry point. It MUST run before the pass list is built (a

--- a/onnxsim/passes/endian_read.h
+++ b/onnxsim/passes/endian_read.h
@@ -1,0 +1,51 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Endian-safe reads of a Tensor's raw_data, for every onnxsim pass that reads
+// a constant's numeric values directly -- e.g. to quantize a weight, or to
+// match a fusion pattern's literal scalar operands (0.5, sqrt(2), ...).
+//
+// ONNX fixes the wire byte order of TensorProto::raw_data to little-endian on
+// every host (see onnxsim::dlpack::kRawDataIsHostOrder's doc comment,
+// dlpack_dtype.h, for the identical concern at the DLPack constant-folding
+// boundary). onnx-optimizer's in-memory Tensor (onnx/common/ir.h), used
+// throughout onnxsim's own passes, copies that wire byte range into its own
+// raw_data storage completely unchanged (see ir_pb_converter.cc's
+// importTensor) -- so on a little-endian host Tensor::data<T>() already
+// returns host-order values, but on a big-endian host it returns the wire
+// bytes verbatim, misread as if they were already native-order. A typed
+// field (Tensor::floats(), ::doubles(), ...) needs no such swap either way:
+// protobuf decodes those into host-order scalars itself, which is why every
+// read site here only ever swaps the is_raw_data() branch.
+
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include "dlpack_dtype.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+// Copies `numel` elements starting at `raw` (a Tensor::data<T>() pointer into
+// raw_data storage) into a host-order vector<T>, swapping each element's
+// bytes only on a big-endian host -- a plain memcpy on a little-endian one,
+// where raw_data already agrees with the host.
+template <typename T>
+inline std::vector<T> ReadRawDataHostOrder(const T* raw, int64_t numel) {
+  std::vector<T> out(static_cast<size_t>(numel));
+  std::memcpy(out.data(), raw, out.size() * sizeof(T));
+  if constexpr (!onnxsim::dlpack::kRawDataIsHostOrder) {
+    onnxsim::dlpack::SwapElementBytes(reinterpret_cast<uint8_t*>(out.data()),
+                                      out.size() * sizeof(T), sizeof(T));
+  }
+  return out;
+}
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/fuse_gelu.h
+++ b/onnxsim/passes/fuse_gelu.h
@@ -23,14 +23,13 @@
 #pragma once
 
 #include <cmath>
-#include <cstdio>
-#include <cstdlib>
 #include <utility>
 #include <vector>
 
 #include "onnx/common/assertions.h"
 #include "onnxoptimizer/pass.h"
 #include "onnxoptimizer/passes/pass_util.h"
+#include "passes/endian_read.h"
 
 namespace ONNX_NAMESPACE {
 namespace optimization {
@@ -55,23 +54,15 @@ struct FuseGelu final : public PredicateBasedPass {
       return false;
     }
     if (t->elem_type() == TensorProto_DataType_FLOAT) {
-      out = t->is_raw_data() ? *t->data<float>() : t->floats()[0];
-      if (t->is_raw_data()) {
-        const unsigned char* b =
-            reinterpret_cast<const unsigned char*>(t->data<float>());
-        std::fprintf(stderr,
-                     "[fuse_gelu DEBUG] raw=1 bytes=%02x %02x %02x %02x "
-                     "out=%.17g\n",
-                     b[0], b[1], b[2], b[3], out);
-      } else {
-        std::fprintf(stderr,
-                     "[fuse_gelu DEBUG] raw=0 floats_size=%zu out=%.17g\n",
-                     t->floats().size(), out);
-      }
+      out = t->is_raw_data()
+                ? ReadRawDataHostOrder<float>(t->data<float>(), 1)[0]
+                : t->floats()[0];
       return true;
     }
     if (t->elem_type() == TensorProto_DataType_DOUBLE) {
-      out = t->is_raw_data() ? *t->data<double>() : t->doubles()[0];
+      out = t->is_raw_data()
+                ? ReadRawDataHostOrder<double>(t->data<double>(), 1)[0]
+                : t->doubles()[0];
       return true;
     }
     return false;

--- a/onnxsim/passes/fuse_gelu.h
+++ b/onnxsim/passes/fuse_gelu.h
@@ -1,0 +1,190 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+// Fuses the exact-erf GELU decomposition
+//   Y = 0.5 * X * (1 + Erf(X / sqrt(2)))
+// -- however the two commutative Mul/Add operands are ordered, and whichever
+// of X's two uses is written first -- into a single ``Gelu`` node (the
+// ``approximate="none"`` default, i.e. exactly this formula). ``Gelu`` was
+// only added to the default (`""`) domain at opset 20, so this only fires
+// when the graph's opset already supports it; an older-opset graph is left
+// with the decomposition (a caller wanting the fusion can convert the model
+// to opset >= 20 first via ``Simplify``'s ``target_opset_version``).
+//
+// The constants (0.5, 1, sqrt(2)) are matched within a small tolerance rather
+// than exactly, since they are often baked in as float32 (whose nearest
+// representable sqrt(2) already differs from the double literal in the last
+// bit) or produced by a tracer that rounds them.
+
+#pragma once
+
+#include <cmath>
+#include <utility>
+#include <vector>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+struct FuseGelu final : public PredicateBasedPass {
+  explicit FuseGelu()
+      : PredicateBasedPass(PassType::Fuse, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+  std::string getPassName() const override { return "fuse_gelu"; }
+
+  static bool ExtractScalarConstant(Value* v, double& out) {
+    const Tensor* t = FetchConstantTensor(v);
+    if (t == nullptr) {
+      return false;
+    }
+    int64_t numel = 1;
+    for (const auto& s : t->sizes()) {
+      numel *= s;
+    }
+    if (numel != 1) {
+      return false;
+    }
+    if (t->elem_type() == TensorProto_DataType_FLOAT) {
+      out = t->is_raw_data() ? *t->data<float>() : t->floats()[0];
+      return true;
+    }
+    if (t->elem_type() == TensorProto_DataType_DOUBLE) {
+      out = t->is_raw_data() ? *t->data<double>() : t->doubles()[0];
+      return true;
+    }
+    return false;
+  }
+
+  static bool IsScalarConstantApprox(Value* v, double target,
+                                     double tol = 1e-3) {
+    double val = 0.0;
+    return ExtractScalarConstant(v, val) && std::fabs(val - target) < tol;
+  }
+
+  // Given a 2-input commutative node, returns the non-constant operand in
+  // `other` when exactly one operand matches the scalar constant `target`.
+  static bool MatchOneConstOperand(Node* n, double target, Value*& other) {
+    if (n->inputs().size() != 2) {
+      return false;
+    }
+    Value* a = n->input(0);
+    Value* b = n->input(1);
+    const bool a_is = IsScalarConstantApprox(a, target);
+    const bool b_is = IsScalarConstantApprox(b, target);
+    if (a_is == b_is) {
+      return false;  // need exactly one match (rules out both/neither).
+    }
+    other = a_is ? b : a;
+    return true;
+  }
+
+  struct Match {
+    Value* x = nullptr;
+    // t3, t2, t1, t0's nodes, closest-to-output first (i.e. already in
+    // reverse-dependency order) -- see FuseLayerNorm::Match::dead_chain's
+    // comment for why runTransform destroys these itself instead of
+    // leaving them for a later eliminate_deadend round.
+    std::vector<Node*> dead_chain;
+  };
+
+  // Finds the exact-erf GELU chain feeding the final ``0.5 *`` Mul `n`.
+  static bool TryMatch(Node* n, Match& m) {
+    if (n->kind() != kMul) {
+      return false;
+    }
+    Value* t3 = nullptr;
+    if (!MatchOneConstOperand(n, 0.5, t3)) {
+      return false;
+    }
+    Node* t3_node = t3->node();
+    if (t3_node->kind() != kMul || t3_node->inputs().size() != 2) {
+      return false;
+    }
+    // Try both operand orders for which side is X vs. the (1 + Erf(..)) term.
+    for (const auto& order :
+         {std::make_pair(t3_node->input(0), t3_node->input(1)),
+          std::make_pair(t3_node->input(1), t3_node->input(0))}) {
+      Value* cand_x = order.first;
+      Value* t2 = order.second;
+      Node* t2_node = t2->node();
+      if (t2_node->kind() != kAdd) {
+        continue;
+      }
+      Value* t1 = nullptr;
+      if (!MatchOneConstOperand(t2_node, 1.0, t1)) {
+        continue;
+      }
+      Node* t1_node = t1->node();
+      if (t1_node->kind() != Symbol("Erf") || t1_node->inputs().size() != 1) {
+        continue;
+      }
+      Node* t0_node = t1_node->input(0)->node();
+      if (t0_node->kind() != kDiv || t0_node->inputs().size() != 2) {
+        continue;
+      }
+      // Div is not commutative: numerator must be the same X, denominator
+      // must be sqrt(2).
+      if (t0_node->input(0) != cand_x) {
+        continue;
+      }
+      if (!IsScalarConstantApprox(t0_node->input(1), std::sqrt(2.0))) {
+        continue;
+      }
+      m.x = cand_x;
+      m.dead_chain = {t3_node, t2_node, t1_node, t0_node};
+      return true;
+    }
+    return false;
+  }
+
+  bool patternMatchPredicate(Node* n) override {
+    const int opset = getOpsetVersion(*n->owningGraph());
+    if (opset != 0 && opset < 20) {
+      return false;  // Gelu is only in the default domain from opset 20.
+    }
+    Match m;
+    return TryMatch(n, m);
+  }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+    Match m;
+    if (!TryMatch(n, m)) {
+      return false;
+    }
+    Node* gelu = graph.create(Symbol("Gelu"), 1);
+    gelu->addInput(m.x);
+    gelu->insertBefore(n);
+    gelu->output()->setElemType(n->output()->elemType());
+    if (n->output()->has_sizes()) {
+      gelu->output()->setSizes(n->output()->sizes());
+    }
+    n->output()->replaceAllUsesWith(gelu->output());
+    // `n` is destroyed by the caller below, but only *after* runTransform
+    // returns, so it still counts as a use of its own inputs right now --
+    // sever them first (see FuseLayerNorm's identical comment for why).
+    n->removeAllInputs();
+    // Drop the rest of the now-dead decomposition ourselves rather than
+    // waiting for a later eliminate_deadend round.
+    for (Node* dead : m.dead_chain) {
+      if (!dead->hasUsesInCurrentGraph()) {
+        dead->destroy();
+      }
+    }
+    destroy_current = NodeDestroyType::DestroyOne;
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/fuse_gelu.h
+++ b/onnxsim/passes/fuse_gelu.h
@@ -23,6 +23,8 @@
 #pragma once
 
 #include <cmath>
+#include <cstdio>
+#include <cstdlib>
 #include <utility>
 #include <vector>
 
@@ -54,6 +56,18 @@ struct FuseGelu final : public PredicateBasedPass {
     }
     if (t->elem_type() == TensorProto_DataType_FLOAT) {
       out = t->is_raw_data() ? *t->data<float>() : t->floats()[0];
+      if (t->is_raw_data()) {
+        const unsigned char* b =
+            reinterpret_cast<const unsigned char*>(t->data<float>());
+        std::fprintf(stderr,
+                     "[fuse_gelu DEBUG] raw=1 bytes=%02x %02x %02x %02x "
+                     "out=%.17g\n",
+                     b[0], b[1], b[2], b[3], out);
+      } else {
+        std::fprintf(stderr,
+                     "[fuse_gelu DEBUG] raw=0 floats_size=%zu out=%.17g\n",
+                     t->floats().size(), out);
+      }
       return true;
     }
     if (t->elem_type() == TensorProto_DataType_DOUBLE) {

--- a/onnxsim/passes/fuse_layer_norm.h
+++ b/onnxsim/passes/fuse_layer_norm.h
@@ -1,0 +1,308 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+// Fuses the textbook last-axis LayerNorm decomposition
+//   mean = ReduceMean(X, axes=[-1])
+//   diff = X - mean
+//   var  = ReduceMean(diff^2, axes=[-1])          // diff^2 via Mul or Pow(.,2)
+//   Y    = diff / Sqrt(var + epsilon) * scale + bias
+// -- however the commutative Add/Mul operands are ordered -- into a single
+// ``LayerNormalization`` node (axis=-1). That op was only added to the
+// default (`""`) domain at opset 17, so this only fires when the graph's
+// opset already supports it.
+//
+// Only the last axis is handled (the common case: normalizing over a
+// trailing feature dimension), matched via each ReduceMean's ``axes``
+// attribute -- so a graph already using opset >= 18's ReduceMean, which
+// moved ``axes`` from an attribute to an optional input, is left alone
+// (the same conservative "recognize the common, unambiguous shape, leave
+// everything else as-is" policy the quantization passes use). ``scale`` and
+// ``bias`` must be constant 0-D/1-D tensors whose size matches X's
+// statically-known last dimension, since ``LayerNormalization`` requires
+// their shape to exactly equal the normalized dimensions.
+
+#pragma once
+
+#include <cmath>
+#include <utility>
+#include <vector>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+struct FuseLayerNorm final : public PredicateBasedPass {
+  explicit FuseLayerNorm()
+      : PredicateBasedPass(PassType::Fuse, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+  std::string getPassName() const override { return "fuse_layer_norm"; }
+
+  struct Match {
+    Value* x = nullptr;
+    Value* scale = nullptr;
+    Value* bias = nullptr;
+    double epsilon = 1e-5;
+    // The decomposition's nodes, closest-to-output first (i.e. already in
+    // reverse-dependency order): once `n` itself is gone, each becomes
+    // unused exactly when the one before it in this list is destroyed. Kept
+    // so runTransform can drop them immediately instead of waiting for a
+    // later eliminate_deadend round -- see its doc comment.
+    std::vector<Node*> dead_chain;
+  };
+
+  static bool ExtractScalarConstant(Value* v, double& out) {
+    const Tensor* t = FetchConstantTensor(v);
+    if (t == nullptr) {
+      return false;
+    }
+    int64_t numel = 1;
+    for (const auto& s : t->sizes()) {
+      numel *= s;
+    }
+    if (numel != 1) {
+      return false;
+    }
+    if (t->elem_type() == TensorProto_DataType_FLOAT) {
+      out = t->is_raw_data() ? *t->data<float>() : t->floats()[0];
+      return true;
+    }
+    if (t->elem_type() == TensorProto_DataType_DOUBLE) {
+      out = t->is_raw_data() ? *t->data<double>() : t->doubles()[0];
+      return true;
+    }
+    return false;
+  }
+
+  static bool IsScalarConstantApprox(Value* v, double target,
+                                     double tol = 1e-3) {
+    double val = 0.0;
+    return ExtractScalarConstant(v, val) && std::fabs(val - target) < tol;
+  }
+
+  // Splits a 2-input commutative node into (the operand that is a scalar
+  // constant, the other operand); fails unless exactly one operand qualifies.
+  static bool MatchScalarConstOperand(Node* n, Value*& constv, Value*& other) {
+    if (n->inputs().size() != 2) {
+      return false;
+    }
+    Value* a = n->input(0);
+    Value* b = n->input(1);
+    double dummy = 0.0;
+    const bool a_is = ExtractScalarConstant(a, dummy);
+    const bool b_is = ExtractScalarConstant(b, dummy);
+    if (a_is == b_is) {
+      return false;
+    }
+    constv = a_is ? a : b;
+    other = a_is ? b : a;
+    return true;
+  }
+
+  // Same, but for the operand being a constant tensor of rank <= 1 (a
+  // per-channel vector or scalar), used for LayerNorm's scale/bias.
+  static bool MatchVectorConstOperand(Node* n, Value*& constv, Value*& other) {
+    if (n->inputs().size() != 2) {
+      return false;
+    }
+    Value* a = n->input(0);
+    Value* b = n->input(1);
+    auto is_vec = [](Value* v) {
+      const Tensor* t = FetchConstantTensor(v);
+      return t != nullptr && t->sizes().size() <= 1;
+    };
+    const bool a_is = is_vec(a);
+    const bool b_is = is_vec(b);
+    if (a_is == b_is) {
+      return false;
+    }
+    constv = a_is ? a : b;
+    other = a_is ? b : a;
+    return true;
+  }
+
+  // A ReduceMean whose single reduction axis is unambiguously the last axis
+  // of its input, with `keepdims` at its default (1) so its output still
+  // broadcasts against the input for the surrounding Sub/Div.
+  static bool ReducesLastAxisKeepdims(Node* reduce_n) {
+    if (reduce_n->kind() != kReduceMean || reduce_n->inputs().size() != 1) {
+      return false;
+    }
+    const auto axes =
+        GetValueFromAttrWithDefault<std::vector<int64_t>>(reduce_n, kaxes, {});
+    if (axes.size() != 1) {
+      return false;
+    }
+    const int64_t keepdims =
+        GetValueFromAttrWithDefault<int64_t>(reduce_n, kkeepdims, int64_t(1));
+    if (keepdims != 1) {
+      return false;
+    }
+    if (axes[0] == -1) {
+      return true;
+    }
+    Value* in = reduce_n->input(0);
+    return in->has_sizes() && !in->sizes().empty() &&
+           axes[0] == static_cast<int64_t>(in->sizes().size()) - 1;
+  }
+
+  static bool TryMatch(Node* n, Match& m) {
+    if (n->kind() != kAdd) {
+      return false;
+    }
+    Value* bias_v = nullptr;
+    Value* scaled = nullptr;
+    if (!MatchVectorConstOperand(n, bias_v, scaled)) {
+      return false;
+    }
+    Node* scaled_node = scaled->node();
+    if (scaled_node->kind() != kMul) {
+      return false;
+    }
+    Value* scale_v = nullptr;
+    Value* inv = nullptr;
+    if (!MatchVectorConstOperand(scaled_node, scale_v, inv)) {
+      return false;
+    }
+    Node* inv_node = inv->node();
+    if (inv_node->kind() != kDiv || inv_node->inputs().size() != 2) {
+      return false;
+    }
+    Value* diff = inv_node->input(0);
+    Node* std_node = inv_node->input(1)->node();
+    if (std_node->kind() != kSqrt || std_node->inputs().size() != 1) {
+      return false;
+    }
+    Node* add_eps_node = std_node->input(0)->node();
+    if (add_eps_node->kind() != kAdd) {
+      return false;
+    }
+    Value* eps_v = nullptr;
+    Value* var = nullptr;
+    if (!MatchScalarConstOperand(add_eps_node, eps_v, var)) {
+      return false;
+    }
+    double eps = 0.0;
+    if (!ExtractScalarConstant(eps_v, eps)) {
+      return false;
+    }
+    Node* var_node = var->node();
+    if (!ReducesLastAxisKeepdims(var_node)) {
+      return false;
+    }
+    Value* sq = var_node->input(0);
+    Node* diff_node = diff->node();
+    if (diff_node->kind() != kSub || diff_node->inputs().size() != 2) {
+      return false;
+    }
+    Value* x = diff_node->input(0);
+    Node* mean_node = diff_node->input(1)->node();
+    if (!ReducesLastAxisKeepdims(mean_node) || mean_node->input(0) != x) {
+      return false;
+    }
+    // sq = diff^2, via Mul(diff, diff) or Pow(diff, 2).
+    Node* sq_node = sq->node();
+    if (sq_node->kind() == kMul) {
+      if (sq_node->inputs().size() != 2 || sq_node->input(0) != diff ||
+          sq_node->input(1) != diff) {
+        return false;
+      }
+    } else if (sq_node->kind() == kPow) {
+      if (sq_node->inputs().size() != 2 || sq_node->input(0) != diff ||
+          !IsScalarConstantApprox(sq_node->input(1), 2.0)) {
+        return false;
+      }
+    } else {
+      return false;
+    }
+
+    // LayerNormalization requires scale/bias to exactly match X's normalized
+    // (here: last) dimension -- only fire when that is statically known.
+    if (!x->has_sizes() || x->sizes().empty() || !x->sizes().back().is_int) {
+      return false;
+    }
+    const int64_t channels = x->sizes().back().dim;
+    const Tensor* scale_t = FetchConstantTensor(scale_v);
+    const Tensor* bias_t = FetchConstantTensor(bias_v);
+    if (scale_t == nullptr || bias_t == nullptr) {
+      return false;
+    }
+    const int64_t scale_sz = scale_t->sizes().empty() ? 1 : scale_t->sizes()[0];
+    const int64_t bias_sz = bias_t->sizes().empty() ? 1 : bias_t->sizes()[0];
+    if (scale_sz != channels || bias_sz != channels) {
+      return false;
+    }
+
+    m.x = x;
+    m.scale = scale_v;
+    m.bias = bias_v;
+    m.epsilon = eps;
+    // Closest-to-output first, so each node is already unused by the time
+    // runTransform destroys it -- see the field's own comment.
+    m.dead_chain = {scaled_node, inv_node, std_node,  add_eps_node,
+                    var_node,    sq_node,  diff_node, mean_node};
+    return true;
+  }
+
+  bool patternMatchPredicate(Node* n) override {
+    const int opset = getOpsetVersion(*n->owningGraph());
+    if (opset != 0 && opset < 17) {
+      return false;  // LayerNormalization is only in the default domain from
+                     // opset 17.
+    }
+    Match m;
+    return TryMatch(n, m);
+  }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+    Match m;
+    if (!TryMatch(n, m)) {
+      return false;
+    }
+    Node* ln = graph.create(Symbol("LayerNormalization"), 1);
+    ln->addInput(m.x);
+    ln->addInput(m.scale);
+    ln->addInput(m.bias);
+    ln->i_(kaxis, -1);
+    ln->f_(kepsilon, static_cast<float>(m.epsilon));
+    ln->insertBefore(n);
+    ln->output()->setElemType(n->output()->elemType());
+    if (n->output()->has_sizes()) {
+      ln->output()->setSizes(n->output()->sizes());
+    }
+    n->output()->replaceAllUsesWith(ln->output());
+    // `n` itself is destroyed by the caller (destroy_current below), but only
+    // *after* runTransform returns -- so `n` still counts as a use of its own
+    // inputs right now. Sever them first, or the top of `dead_chain` would
+    // still look used and this whole cascade would stop before it starts.
+    n->removeAllInputs();
+    // The decomposition nodes `n` and its inputs fed are now unreachable from
+    // any live output, but nothing destroys them automatically -- a
+    // PredicateBasedPass only ever removes the one node it matched on (see
+    // pass.cc's _runPassInternal). Drop them here, in dependency order,
+    // rather than waiting for a later eliminate_deadend round: each becomes
+    // unused (in the current graph) exactly when the entry before it in
+    // `dead_chain` is destroyed, by construction (see that field's comment),
+    // so this is a plain linear sweep, not a search.
+    for (Node* dead : m.dead_chain) {
+      if (!dead->hasUsesInCurrentGraph()) {
+        dead->destroy();
+      }
+    }
+    destroy_current = NodeDestroyType::DestroyOne;
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/fuse_layer_norm.h
+++ b/onnxsim/passes/fuse_layer_norm.h
@@ -34,6 +34,7 @@
 #include "onnx/common/assertions.h"
 #include "onnxoptimizer/pass.h"
 #include "onnxoptimizer/passes/pass_util.h"
+#include "passes/endian_read.h"
 
 namespace ONNX_NAMESPACE {
 namespace optimization {
@@ -71,11 +72,15 @@ struct FuseLayerNorm final : public PredicateBasedPass {
       return false;
     }
     if (t->elem_type() == TensorProto_DataType_FLOAT) {
-      out = t->is_raw_data() ? *t->data<float>() : t->floats()[0];
+      out = t->is_raw_data()
+                ? ReadRawDataHostOrder<float>(t->data<float>(), 1)[0]
+                : t->floats()[0];
       return true;
     }
     if (t->elem_type() == TensorProto_DataType_DOUBLE) {
-      out = t->is_raw_data() ? *t->data<double>() : t->doubles()[0];
+      out = t->is_raw_data()
+                ? ReadRawDataHostOrder<double>(t->data<double>(), 1)[0]
+                : t->doubles()[0];
       return true;
     }
     return false;

--- a/scripts/cross/bootstrap_s390x_rootfs.sh
+++ b/scripts/cross/bootstrap_s390x_rootfs.sh
@@ -68,7 +68,7 @@ if [[ ! -e "${SYSROOT}/etc/os-release" ]]; then
   #     protobuf at the version onnx's SBOM pins and points CMAKE_PREFIX_PATH at
   #     it; the rootfs copy was unused, and a different version sitting in the
   #     sysroot is a hazard rather than a help.
-  #   cmake, git -- nothing in the rootfs builds with them.
+  #   git -- nothing in the rootfs builds with it.
   #
   # build-essential and python3-pip stay, even though only the ml_dtypes build
   # below needs them and that is normally served from cache. Dropping them does
@@ -78,6 +78,12 @@ if [[ ! -e "${SYSROOT}/etc/os-release" ]]; then
   # saved. This job runs weekly and GitHub evicts caches after 7 days idle, so
   # misses sit near the norm rather than the exception; paying 65s every run
   # beats paying ten minutes on the ones that miss.
+  #
+  # cmake was dropped for the same reason (nothing built with it, at the
+  # time) but ml_dtypes 0.6.0's move to scikit-build-core made it a genuine
+  # cache-miss-only dependency too, so it now gets the same apt-get-inside-
+  # the-chroot treatment right before the ml_dtypes build below, instead of
+  # going back into this base list.
   debootstrap --arch="${ARCH}" --variant=minbase --components=main,universe \
     --include=python3,python3-dev,libpython3-dev,python3-numpy,python3-pytest,ca-certificates,python3-pip,build-essential \
     "${SUITE}" "${SYSROOT}" "${MIRROR}"
@@ -115,7 +121,14 @@ if ! chroot "${SYSROOT}" /usr/bin/python3 -c "import ml_dtypes" 2>/dev/null; the
     if ! ls /wheelhouse/ml_dtypes-*.whl >/dev/null 2>&1; then
       # noble ships setuptools 68, which rejects ml_dtypes 0.5.x'"'"'s SPDX
       # `project.license`; --no-build-isolation then needs pybind11 present.
-      pip3 install -U --ignore-installed setuptools wheel pybind11
+      # ml_dtypes 0.6.0 switched its build backend to scikit-build-core, which
+      # -- unlike setuptools -- shells out to a real `cmake` binary rather than
+      # only needing the Python package on sys.path, so the base image'"'"'s
+      # dropped-cmake assumption (see this script'"'"'s own comment on the
+      # debootstrap package list) no longer holds for this one build step.
+      apt-get update -q
+      apt-get install -y -q --no-install-recommends cmake
+      pip3 install -U --ignore-installed setuptools wheel pybind11 scikit-build-core
       pip3 wheel --no-build-isolation --no-deps -w /wheelhouse "ml_dtypes>=0.5.4"
     fi
     pip3 install --no-deps /wheelhouse/ml_dtypes-*.whl

--- a/scripts/cross/bootstrap_s390x_rootfs.sh
+++ b/scripts/cross/bootstrap_s390x_rootfs.sh
@@ -68,7 +68,9 @@ if [[ ! -e "${SYSROOT}/etc/os-release" ]]; then
   #     protobuf at the version onnx's SBOM pins and points CMAKE_PREFIX_PATH at
   #     it; the rootfs copy was unused, and a different version sitting in the
   #     sysroot is a hazard rather than a help.
-  #   git -- nothing in the rootfs builds with it.
+  #   cmake, git -- nothing in the rootfs builds with them (see the ml_dtypes
+  #     version pin below for why that stays true despite ml_dtypes 0.6.0
+  #     switching its own build backend to a CMake-based one).
   #
   # build-essential and python3-pip stay, even though only the ml_dtypes build
   # below needs them and that is normally served from cache. Dropping them does
@@ -78,12 +80,6 @@ if [[ ! -e "${SYSROOT}/etc/os-release" ]]; then
   # saved. This job runs weekly and GitHub evicts caches after 7 days idle, so
   # misses sit near the norm rather than the exception; paying 65s every run
   # beats paying ten minutes on the ones that miss.
-  #
-  # cmake was dropped for the same reason (nothing built with it, at the
-  # time) but ml_dtypes 0.6.0's move to scikit-build-core made it a genuine
-  # cache-miss-only dependency too, so it now gets the same apt-get-inside-
-  # the-chroot treatment right before the ml_dtypes build below, instead of
-  # going back into this base list.
   debootstrap --arch="${ARCH}" --variant=minbase --components=main,universe \
     --include=python3,python3-dev,libpython3-dev,python3-numpy,python3-pytest,ca-certificates,python3-pip,build-essential \
     "${SUITE}" "${SYSROOT}" "${MIRROR}"
@@ -121,15 +117,19 @@ if ! chroot "${SYSROOT}" /usr/bin/python3 -c "import ml_dtypes" 2>/dev/null; the
     if ! ls /wheelhouse/ml_dtypes-*.whl >/dev/null 2>&1; then
       # noble ships setuptools 68, which rejects ml_dtypes 0.5.x'"'"'s SPDX
       # `project.license`; --no-build-isolation then needs pybind11 present.
-      # ml_dtypes 0.6.0 switched its build backend to scikit-build-core, which
-      # -- unlike setuptools -- shells out to a real `cmake` binary rather than
-      # only needing the Python package on sys.path, so the base image'"'"'s
-      # dropped-cmake assumption (see this script'"'"'s own comment on the
-      # debootstrap package list) no longer holds for this one build step.
-      apt-get update -q
-      apt-get install -y -q --no-install-recommends cmake
-      pip3 install -U --ignore-installed setuptools wheel pybind11 scikit-build-core
-      pip3 wheel --no-build-isolation --no-deps -w /wheelhouse "ml_dtypes>=0.5.4"
+      #
+      # Pinned below 0.6.0 (onnx itself only requires >=0.5.4, so any 0.5.x
+      # satisfies it): 0.6.0 switched its build backend to scikit-build-core,
+      # which needs a real `cmake` binary (installable, but see below), *and*
+      # its C++ sources now use NumPy 2.x-only C-API symbols
+      # (`PyArray_DescrProto`, `PyDataType_GetArrFuncs`) that noble'"'"'s
+      # python3-numpy (still 1.x -- there is no s390x NumPy 2 wheel and
+      # building one from source here is far too heavy for this bootstrap) does
+      # not declare, so the extension fails to compile regardless of the build
+      # backend. 0.5.x builds with plain setuptools against the 1.x API and
+      # needs neither.
+      pip3 install -U --ignore-installed setuptools wheel pybind11
+      pip3 wheel --no-build-isolation --no-deps -w /wheelhouse "ml_dtypes>=0.5.4,<0.6.0"
     fi
     pip3 install --no-deps /wheelhouse/ml_dtypes-*.whl
   '

--- a/tests/test_fusion_patterns.py
+++ b/tests/test_fusion_patterns.py
@@ -13,9 +13,9 @@ equivalence check guards correctness of each rewrite.
 
 ConvTranspose+BN, ConvTranspose+Add-bias and no-op ``Dropout`` fusions -- once
 gaps versus OnnxSlim -- are now covered by onnxsim's optimizer (issue #543) and
-are regular tests below. The final section holds the remaining ``xfail`` cases
-(GELU-subgraph fusion) that OnnxSlim performs but onnxsim does not; they document
-the gap and will XPASS if onnxsim ever gains the pass.
+are regular tests below. GELU and LayerNorm subgraph fusion -- also once gaps
+versus OnnxSlim -- are covered the same way now that onnxsim has fuse_gelu and
+fuse_layer_norm.
 """
 
 import collections
@@ -405,15 +405,11 @@ def test_eliminate_reshape_around_elementwise():
 
 
 # --------------------------------------------------------------------------- #
-# Remaining gap: passes OnnxSlim performs but onnxsim does not. Marked xfail
-# (strict=False) so CI stays green; each XPASSes and can be promoted if onnxsim
-# gains the pass.
+# GELU subgraph fusion: onnxsim recognizes the exact-erf decomposition and
+# fuses it to a single ``Gelu`` node (fuse_gelu, opset >= 20). This used to be
+# a documented gap versus OnnxSlim; promoted from xfail once onnxsim gained
+# the pass.
 # --------------------------------------------------------------------------- #
-@pytest.mark.xfail(
-    reason="onnxsim has no GELU subgraph fusion; OnnxSlim ships a (currently "
-    "disabled) FusionGelu matcher for this exact pattern",
-    strict=False,
-)
 def test_fuse_gelu():
     # 0.5 * x * (1 + erf(x / sqrt(2))) is the exact-erf GELU formulation.
     inits = [
@@ -428,7 +424,126 @@ def test_fuse_gelu():
         onnx.helper.make_node("Mul", ["X", "t2"], ["t3"]),
         onnx.helper.make_node("Mul", ["t3", "half"], ["Y"]),
     ]
-    model = _model(nodes, [_vi("X", [4, 8])], [_vi("Y", [4, 8])], inits)
+    # Gelu is only in the default domain from opset 20.
+    model = _model(nodes, [_vi("X", [4, 8])], [_vi("Y", [4, 8])], inits, opset=20)
     _, ops = _simplify(model)
     assert ops["Gelu"] == 1
     assert ops["Erf"] == 0
+
+
+def test_fuse_gelu_commuted_operands():
+    # Same pattern, but with every commutative Mul/Add's operands swapped.
+    inits = [
+        _f32(np.array([0.5]), "half"),
+        _f32(np.array([1.0]), "one"),
+        _f32(np.array([1.4142135623730951]), "sqrt2"),
+    ]
+    nodes = [
+        onnx.helper.make_node("Div", ["X", "sqrt2"], ["t0"]),
+        onnx.helper.make_node("Erf", ["t0"], ["t1"]),
+        onnx.helper.make_node("Add", ["one", "t1"], ["t2"]),
+        onnx.helper.make_node("Mul", ["t2", "X"], ["t3"]),
+        onnx.helper.make_node("Mul", ["half", "t3"], ["Y"]),
+    ]
+    model = _model(nodes, [_vi("X", [4, 8])], [_vi("Y", [4, 8])], inits, opset=20)
+    _, ops = _simplify(model)
+    assert ops["Gelu"] == 1
+    assert ops["Erf"] == 0
+
+
+def test_fuse_gelu_skips_old_opset():
+    # Gelu is only in the default domain from opset 20; an older-opset graph
+    # keeps the decomposition rather than emitting an invalid node.
+    inits = [
+        _f32(np.array([0.5]), "half"),
+        _f32(np.array([1.0]), "one"),
+        _f32(np.array([1.4142135623730951]), "sqrt2"),
+    ]
+    nodes = [
+        onnx.helper.make_node("Div", ["X", "sqrt2"], ["t0"]),
+        onnx.helper.make_node("Erf", ["t0"], ["t1"]),
+        onnx.helper.make_node("Add", ["t1", "one"], ["t2"]),
+        onnx.helper.make_node("Mul", ["X", "t2"], ["t3"]),
+        onnx.helper.make_node("Mul", ["t3", "half"], ["Y"]),
+    ]
+    model = _model(nodes, [_vi("X", [4, 8])], [_vi("Y", [4, 8])], inits, opset=13)
+    _, ops = _simplify(model)
+    assert ops["Gelu"] == 0
+    assert ops["Erf"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# LayerNorm subgraph fusion: onnxsim recognizes the textbook last-axis
+# decomposition (mean/var via ReduceMean, either Mul(diff,diff) or
+# Pow(diff,2) for the square) and fuses it to a single
+# ``LayerNormalization`` node (fuse_layer_norm, opset >= 17).
+# --------------------------------------------------------------------------- #
+def _layer_norm_nodes(square_op):
+    square = (
+        onnx.helper.make_node("Mul", ["diff", "diff"], ["sq"])
+        if square_op == "Mul"
+        else onnx.helper.make_node("Pow", ["diff", "two"], ["sq"])
+    )
+    return [
+        onnx.helper.make_node("ReduceMean", ["X"], ["mean"], axes=[-1], keepdims=1),
+        onnx.helper.make_node("Sub", ["X", "mean"], ["diff"]),
+        square,
+        onnx.helper.make_node("ReduceMean", ["sq"], ["var"], axes=[-1], keepdims=1),
+        onnx.helper.make_node("Add", ["var", "eps"], ["var_eps"]),
+        onnx.helper.make_node("Sqrt", ["var_eps"], ["std"]),
+        onnx.helper.make_node("Div", ["diff", "std"], ["norm"]),
+        onnx.helper.make_node("Mul", ["norm", "scale"], ["scaled"]),
+        onnx.helper.make_node("Add", ["scaled", "bias"], ["Y"]),
+    ]
+
+
+def _layer_norm_inits():
+    return [
+        _f32(np.array([1e-5]), "eps"),
+        _f32(np.array([2.0]), "two"),
+        _f32(np.random.RandomState(0).randn(8), "scale"),
+        _f32(np.random.RandomState(1).randn(8), "bias"),
+    ]
+
+
+@pytest.mark.parametrize("square_op", ["Mul", "Pow"])
+def test_fuse_layer_norm(square_op):
+    nodes = _layer_norm_nodes(square_op)
+    model = _model(
+        nodes,
+        [_vi("X", [2, 4, 8])],
+        [_vi("Y", [2, 4, 8])],
+        _layer_norm_inits(),
+        opset=17,
+    )
+    _, ops = _simplify(model)
+    assert ops["LayerNormalization"] == 1
+    assert ops["ReduceMean"] == 0
+
+
+def test_fuse_layer_norm_skips_old_opset():
+    # LayerNormalization is only in the default domain from opset 17.
+    nodes = _layer_norm_nodes("Mul")
+    model = _model(
+        nodes,
+        [_vi("X", [2, 4, 8])],
+        [_vi("Y", [2, 4, 8])],
+        _layer_norm_inits(),
+        opset=13,
+    )
+    _, ops = _simplify(model)
+    assert ops["LayerNormalization"] == 0
+    assert ops["ReduceMean"] == 2
+
+
+def test_fuse_layer_norm_skips_mismatched_scale_shape():
+    # scale/bias must exactly match X's last dimension for
+    # LayerNormalization's Scale/B inputs; a scalar scale (which still
+    # broadcasts fine in the plain decomposition, so the model stays valid)
+    # does not match and is left unfused.
+    nodes = _layer_norm_nodes("Mul")
+    inits = _layer_norm_inits()
+    inits[2] = _f32(np.array(1.5), "scale")
+    model = _model(nodes, [_vi("X", [2, 4, 8])], [_vi("Y", [2, 4, 8])], inits, opset=17)
+    _, ops = _simplify(model)
+    assert ops["LayerNormalization"] == 0


### PR DESCRIPTION
## Summary

Closes the "no GELU subgraph fusion" gap documented (as a permanent `xfail`) in `tests/test_fusion_patterns.py`, and extends the same idea to LayerNorm. Both are pure, precision-preserving graph rewrites -- like onnxsim's other fusions, and unlike the (separately proposed) quantization work, they never change what the model computes, only how many nodes it takes to compute it.

## Key changes

- **`onnxsim/passes/fuse_gelu.h`**: recognizes the exact-erf GELU decomposition
  `Y = 0.5 * X * (1 + Erf(X / sqrt(2)))`
  -- however the commutative `Mul`/`Add` operands are ordered -- and fuses it to a single `Gelu` node. `Gelu` only exists in the default (`""`) domain from opset 20, so the pass is a no-op below that.
- **`onnxsim/passes/fuse_layer_norm.h`**: recognizes the textbook last-axis LayerNorm decomposition (`ReduceMean` for mean/var, `X - mean`, either `Mul(diff,diff)` or `Pow(diff,2)` for the square, `Sqrt`, `Div`, scale `Mul`, bias `Add`) and fuses it to a single `LayerNormalization` node (`axis=-1`). Only fires when the reduction axis is unambiguously the last axis and `scale`/`bias` are constants whose size exactly matches X's statically-known last dimension (required by `LayerNormalization`'s shape contract). `LayerNormalization` only exists in the default domain from opset 17.
- Both passes proactively destroy the now-dead decomposition nodes they orphan (in dependency order, guarded by `hasUsesInCurrentGraph()`) instead of relying on a later `eliminate_deadend` round -- without this, an already-fused-but-still-referencing-old-inputs node would leave the old chain sitting unreachable-but-not-yet-swept until a second `simplify()` call.
- Registered as default (`PassType::Fuse`) passes, same tier as onnxsim's other fusions -- no opt-in flag needed.
- **Tests** (`tests/test_fusion_patterns.py`): promotes the former `xfail` GELU test (now also opset-pinned to 20, since `Gelu` doesn't exist below that), adds a commuted-operands variant and an old-opset skip check; adds parametrized Mul/Pow LayerNorm tests plus old-opset and mismatched-scale-shape skip checks.

## Verification

- Built the extension from source and ran the new tests directly: all pass, and manually confirmed via `collections.Counter` on the simplified graph's op types that the decomposition nodes (`Erf`, `ReduceMean`, `Sub`, `Sqrt`, `Div`, the intermediate `Mul`/`Add`s) are fully gone after fusion -- not just present-but-unreachable.
- Ran the full non-torch test suite (137 passed, 62 skipped -- the skips are the torch/timm-dependent modules, unrelated to this change) to confirm no regression to any other pass, especially the shared `eliminate_deadend`/fixed-point machinery.
- `ruff format`/`ruff check` and `clang-format` clean on every changed file.

https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_