### PR TITLE
Add Conv support to static (calibration-based) quantization

### DIFF
--- a/onnxsim/calibration.py
+++ b/onnxsim/calibration.py
@@ -295,9 +295,10 @@ def quantize_static(
     providers: Optional[Sequence[str]] = None,
 ) -> onnx.ModelProto:
     """
-    Statically (calibration-based) quantize every MatMul, and every "vanilla"
-    Gemm (transA=0, alpha=1, beta=1), whose weight is a constant 2-D float32
-    tensor.
+    Statically (calibration-based) quantize every MatMul, every "vanilla"
+    Gemm (transA=0, alpha=1, beta=1), and every Conv, whose weight is a
+    constant float32 tensor (2-D for MatMul/Gemm, rank >= 3 -- [Cout,
+    Cin/groups, k...] -- for Conv).
 
     Unlike :func:`onnxsim.quantize_dynamic`, the activation's quantization
     range is *calibrated*: fixed ahead of time from ``calibration_data``

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -375,7 +375,8 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
       },
       "model_bytes"_a);
 
-  // Statically (calibration-based) quantizes MatMul/Gemm: weights to INT8
+  // Statically (calibration-based) quantizes MatMul/Gemm/Conv: weights to
+  // INT8
   // (per output channel, symmetric, ahead of time) and activations to uint8
   // via a QuantizeLinear/DequantizeLinear pair with a *fixed* scale/zero-point
   // derived from `activation_ranges` (tensor name -> (min, max), typically

--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -20,6 +20,7 @@
 #include "passes/fuse_mul_into_conv.h"
 #include "passes/fuse_pad_into_pool.h"
 #include "passes/fuse_preceding_mul_into_conv.h"
+#include "passes/static_quantize_conv.h"
 #include "passes/static_quantize_matmul.h"
 
 namespace onnxsim {
@@ -61,6 +62,7 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::FuseMatMulAddBiasIntoGemmBatched>(registry);
     RegisterOrReplace<p::FuseMulIntoConv>(registry);
     RegisterOrReplace<p::FusePrecedingMulIntoConv>(registry);
+    RegisterOrReplace<p::StaticQuantizeConv>(registry);
     RegisterOrReplace<p::StaticQuantizeMatMul>(registry);
 
     // onnxsim's patched versions of built-in onnxoptimizer passes. These

--- a/onnxsim/custom_optimizer_passes.h
+++ b/onnxsim/custom_optimizer_passes.h
@@ -24,6 +24,7 @@ namespace onnxsim {
 //   - eliminate_reshape_around_elementwise
 //   - dynamic_quantize_matmul
 //   - static_quantize_matmul
+//   - static_quantize_conv
 //
 // The registration runs at most once per process and is safe to call from any
 // simplification entry point. It MUST run before the pass list is built (a

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -1261,7 +1261,7 @@ def main():
     parser.add_argument(
         "--static-quantize",
         help="After simplifying, statically (calibration-based) quantize "
-        "MatMul/Gemm weights and activations to INT8/uint8, inserting a "
+        "MatMul/Gemm/Conv weights and activations to INT8/uint8, inserting a "
         "QuantizeLinear/DequantizeLinear pair (QDQ format) with a fixed "
         "scale/zero-point calibrated from --calibration-dataset if given, "
         "else from random data. See onnxsim.quantize_static.",
@@ -1504,7 +1504,7 @@ def main():
             calibration_data = calibration.generate_random_calibration_data(
                 model_opt, num_samples=args.calibration_samples
             )
-        print("Statically quantizing MatMul/Gemm weights and activations...")
+        print("Statically quantizing MatMul/Gemm/Conv weights and activations...")
         model_opt = calibration.quantize_static(
             model_opt, calibration_data=calibration_data
         )

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -48,6 +48,7 @@
 #include "onnxoptimizer/optimize.h"
 #include "onnxoptimizer/passes/cse_util.h"
 #include "onnxoptimizer/passes/logging.h"
+#include "passes/quantize_conv_common.h"
 #include "passes/quantize_matmul_common.h"
 #include "passes/static_quantize_matmul.h"
 #include "profiler.h"
@@ -2468,6 +2469,24 @@ std::vector<std::string> ListQuantizableActivations(
       names.push_back(info.x->uniqueName());
     }
   }
+  for (auto* node : g->nodes()) {
+    onnx::optimization::onnxsim_passes::ConvInfo info;
+    if (!onnx::optimization::onnxsim_passes::MatchConv(node, info)) {
+      continue;
+    }
+    if (info.x->elemType() != onnx::TensorProto_DataType_FLOAT) {
+      continue;
+    }
+    const onnx::Tensor* w_t = onnx::optimization::FetchConstantTensor(info.w);
+    if (w_t == nullptr ||
+        w_t->elem_type() != onnx::TensorProto_DataType_FLOAT ||
+        w_t->sizes().size() < 3) {
+      continue;
+    }
+    if (seen.insert(info.x->uniqueName()).second) {
+      names.push_back(info.x->uniqueName());
+    }
+  }
   return names;
 }
 
@@ -2485,7 +2504,8 @@ onnx::ModelProto QuantizeStatic(
   onnx::optimization::onnxsim_passes::StaticQuantizationCalibrationRanges() =
       activation_ranges;
   return onnx::optimization::OptimizeFixed(
-      model, std::vector<std::string>{"static_quantize_matmul"});
+      model, std::vector<std::string>{"static_quantize_matmul",
+                                      "static_quantize_conv"});
 }
 
 // Records the options this Simplify() call actually used (skip_optimizers

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -157,37 +157,41 @@ onnx::ModelProto FoldConstantOnce(const ModelExecutor& executor,
 onnx::ModelProto QuantizeDynamic(const onnx::ModelProto& model);
 
 // Lists the activation tensor names that ``QuantizeStatic`` could quantize in
-// ``model`` -- the first input of every MatMul, and every "vanilla" Gemm
-// (transA=0, alpha=1, beta=1), whose weight is a constant 2-D float32 tensor
-// and whose activation is float32 -- so a caller can calibrate exactly (and
-// only) the tensors that matter, by running the model over representative
-// data and recording each listed tensor's observed (min, max). Names are
-// deduplicated and given in no particular order; the opset-version check
-// ``QuantizeStatic``'s pass applies is not repeated here, since calibrating a
-// tensor that then turns out to be unusable (opset < 13) is harmless -- the
-// pass simply ignores its entry in ``activation_ranges``.
+// ``model`` -- the first input of every MatMul, every "vanilla" Gemm
+// (transA=0, alpha=1, beta=1), and every Conv, whose weight is a constant
+// float32 tensor (2-D for MatMul/Gemm, rank >= 3 -- [Cout, Cin/groups, k...]
+// -- for Conv) and whose activation is float32 -- so a caller can calibrate
+// exactly (and only) the tensors that matter, by running the model over
+// representative data and recording each listed tensor's observed (min,
+// max). Names are deduplicated and given in no particular order; the
+// opset-version check ``QuantizeStatic``'s passes apply is not repeated
+// here, since calibrating a tensor that then turns out to be unusable
+// (opset < 13) is harmless -- the pass simply ignores its entry in
+// ``activation_ranges``.
 std::vector<std::string> ListQuantizableActivations(
     const onnx::ModelProto& model);
 
-// Statically (calibration-based) quantizes every MatMul, and every "vanilla"
-// Gemm (transA=0, alpha=1, beta=1), whose weight is a constant 2-D float32
-// tensor and whose activation's tensor name is a key of
-// ``activation_ranges``: the weight is quantized to INT8 ahead of time (per
-// output channel, symmetric, from its static values -- same as
-// ``QuantizeDynamic``), and the activation is quantized to uint8 using a
-// *fixed* (scale, zero_point) derived from its calibrated (min, max) range in
-// ``activation_ranges`` (see ``ListQuantizableActivations`` to discover which
-// tensors to calibrate). The rewrite inserts a QuantizeLinear/DequantizeLinear
-// pair around each quantized tensor (the "QDQ" format) rather than replacing
-// the MatMul/Gemm itself, so the graph still computes in float32 -- a
+// Statically (calibration-based) quantizes every MatMul, every "vanilla"
+// Gemm (transA=0, alpha=1, beta=1), and every Conv, whose weight is a
+// constant float32 tensor (2-D for MatMul/Gemm, rank >= 3 for Conv) and
+// whose activation's tensor name is a key of ``activation_ranges``: the
+// weight is quantized to INT8 ahead of time (per output channel, symmetric,
+// from its static values -- same as ``QuantizeDynamic``), and the activation
+// is quantized to uint8 using a *fixed* (scale, zero_point) derived from its
+// calibrated (min, max) range in ``activation_ranges`` (see
+// ``ListQuantizableActivations`` to discover which tensors to calibrate).
+// The rewrite inserts a QuantizeLinear/DequantizeLinear pair around each
+// quantized tensor (the "QDQ" format) rather than replacing the
+// MatMul/Gemm/Conv itself, so the graph still computes in float32 -- a
 // QDQ-aware runtime fuses the pattern into a true integer kernel at load
-// time. See ``passes/static_quantize_matmul.h`` for the rewrite itself, and
-// ``QuantizeDynamic`` for the no-calibration alternative.
+// time. See ``passes/static_quantize_matmul.h`` and
+// ``passes/static_quantize_conv.h`` for the rewrites themselves, and
+// ``QuantizeDynamic`` for the no-calibration alternative (MatMul/Gemm only).
 //
 // Unlike ``Simplify``, this does not run shape inference, constant folding or
-// any other simplification pass -- it applies exactly this one rewrite, once,
-// to a copy of ``model`` (which is left untouched) and returns the result.
-// Nodes that do not match, or whose activation has no entry in
+// any other simplification pass -- it applies exactly these rewrites, once
+// each, to a copy of ``model`` (which is left untouched) and returns the
+// result. Nodes that do not match, or whose activation has no entry in
 // ``activation_ranges``, are left as-is.
 onnx::ModelProto QuantizeStatic(
     const onnx::ModelProto& model,

--- a/onnxsim/passes/quantize_conv_common.h
+++ b/onnxsim/passes/quantize_conv_common.h
@@ -22,6 +22,7 @@
 #include "onnx/common/assertions.h"
 #include "onnxoptimizer/pass.h"
 #include "onnxoptimizer/passes/pass_util.h"
+#include "passes/endian_read.h"
 
 namespace ONNX_NAMESPACE {
 namespace optimization {
@@ -54,16 +55,18 @@ inline bool MatchConv(Node* n, ConvInfo& info) {
   return true;
 }
 
-// Reads `t` (a float32 constant of any rank) into a flat row-major buffer,
-// regardless of whether it is stored as raw bytes or a typed float array.
+// Reads `t` (a float32 constant of any rank) into a flat row-major,
+// host-byte-order buffer, regardless of whether it is stored as raw bytes
+// (which are little-endian on the wire regardless of host -- see
+// endian_read.h) or a typed float array (already host-order, decoded by
+// protobuf itself).
 inline std::vector<float> ReadFloatTensorFlat(const Tensor& t) {
   int64_t numel = 1;
   for (const auto& s : t.sizes()) {
     numel *= s;
   }
   if (t.is_raw_data()) {
-    const float* raw = t.data<float>();
-    return std::vector<float>(raw, raw + static_cast<size_t>(numel));
+    return ReadRawDataHostOrder<float>(t.data<float>(), numel);
   }
   return t.floats();
 }

--- a/onnxsim/passes/quantize_conv_common.h
+++ b/onnxsim/passes/quantize_conv_common.h
@@ -1,0 +1,114 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+// Node-matching and weight-quantization helpers for Conv, mirroring
+// quantize_matmul_common.h's role for MatMul/Gemm: both quantize a constant
+// weight to INT8 per output channel from its static values. Conv's weight
+// layout ([Cout, Cin/groups, k...]) always puts the output channel on axis 0
+// (unlike MatMul/Gemm, whose weight can be transposed), so there is no
+// transposed-layout case to handle here.
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+// The pieces of a Conv node these passes care about.
+struct ConvInfo {
+  Value* x = nullptr;     // activation (not required to be constant)
+  Value* w = nullptr;     // weight; must be a constant float32 tensor, rank
+                          // >= 3 ([Cout, Cin/groups, k...])
+  Value* bias = nullptr;  // Conv's optional B input; nullptr if absent
+};
+
+// Recognizes a Conv node, filling `info`. Kernel/stride/pad/dilation/group/
+// auto_pad attributes are untouched by the caller -- Conv itself is never
+// replaced, so they need no special handling.
+inline bool MatchConv(Node* n, ConvInfo& info) {
+  if (n->kind() != kConv) {
+    return false;
+  }
+  const size_t num_inputs = n->inputs().size();
+  if (num_inputs != 2 && num_inputs != 3) {
+    return false;
+  }
+  info.x = n->input(0);
+  info.w = n->input(1);
+  if (num_inputs == 3) {
+    info.bias = n->input(2);
+  }
+  return true;
+}
+
+// Reads `t` (a float32 constant of any rank) into a flat row-major buffer,
+// regardless of whether it is stored as raw bytes or a typed float array.
+inline std::vector<float> ReadFloatTensorFlat(const Tensor& t) {
+  int64_t numel = 1;
+  for (const auto& s : t.sizes()) {
+    numel *= s;
+  }
+  if (t.is_raw_data()) {
+    const float* raw = t.data<float>();
+    return std::vector<float>(raw, raw + static_cast<size_t>(numel));
+  }
+  return t.floats();
+}
+
+// Quantizes `w_t` (a constant float32 Conv weight, [Cout, Cin/groups, k...])
+// per output channel (axis 0 -- Conv's layout gives no other choice):
+// `q_out` has the same shape as `w_t`, and `scale_out`[c] is the symmetric
+// INT8 scale for output channel c (max(|w[c, ...]|) / 127, or 1.0 for an
+// all-zero channel so no scale is 0).
+inline void QuantizeConvWeightPerOutputChannel(const Tensor& w_t, Tensor& q_out,
+                                               Tensor& scale_out) {
+  const auto& sizes = w_t.sizes();
+  const int64_t C = sizes[0];
+  int64_t inner = 1;
+  for (size_t i = 1; i < sizes.size(); ++i) {
+    inner *= sizes[i];
+  }
+  const std::vector<float> data = ReadFloatTensorFlat(w_t);
+
+  std::vector<float> scale(static_cast<size_t>(C), 0.0f);
+  for (int64_t c = 0; c < C; ++c) {
+    for (int64_t j = 0; j < inner; ++j) {
+      scale[c] = std::max(scale[c], std::fabs(data[c * inner + j]));
+    }
+  }
+  for (float& s : scale) {
+    s = s > 0.0f ? s / 127.0f : 1.0f;
+  }
+
+  q_out.elem_type() = TensorProto_DataType_INT8;
+  q_out.sizes() = sizes;
+  q_out.int32s().resize(static_cast<size_t>(C * inner));
+  for (int64_t c = 0; c < C; ++c) {
+    for (int64_t j = 0; j < inner; ++j) {
+      const float q = std::round(data[c * inner + j] / scale[c]);
+      q_out.int32s()[c * inner + j] =
+          static_cast<int32_t>(std::clamp(q, -127.0f, 127.0f));
+    }
+  }
+
+  scale_out.elem_type() = TensorProto_DataType_FLOAT;
+  scale_out.sizes() = {C};
+  scale_out.floats() = std::move(scale);
+}
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/static_quantize_conv.h
+++ b/onnxsim/passes/static_quantize_conv.h
@@ -1,0 +1,153 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+// Statically (calibration-based) quantizes Conv, exactly mirroring
+// static_quantize_matmul.h's MatMul/Gemm rewrite -- see that file's doc
+// comment for the QDQ format and the calibration-range global both passes
+// share (StaticQuantizationCalibrationRanges, defined there). The only real
+// difference is the weight's per-output-channel axis: Conv's weight layout
+// ([Cout, Cin/groups, k...]) always puts the output channel on axis 0, so
+// unlike Gemm there is no transposed-layout case to pick between.
+//
+// Before:
+//   Y = Conv(X, W)            W constant, float32, rank >= 3
+// After (Conv itself is untouched, only its inputs change):
+//   Xq  = QuantizeLinear(X, Xs, Xzp)        -- Xs/Xzp: CALIBRATED, fixed
+//   Xdq = DequantizeLinear(Xq, Xs, Xzp)
+//   Wdq = DequantizeLinear(Wq, Ws, axis=0)
+//   Y   = Conv(Xdq, Wdq)
+//
+// Only Conv's ``X`` and ``W`` inputs are quantized; its optional bias (a
+// third input, added back untouched) and its kernel/stride/pad/dilation/
+// group/auto_pad attributes are left exactly as they were.
+
+#pragma once
+
+#include <cstdint>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+#include "passes/quantize_conv_common.h"
+#include "passes/static_quantize_matmul.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+struct StaticQuantizeConv final : public PredicateBasedPass {
+  explicit StaticQuantizeConv()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+  std::string getPassName() const override { return "static_quantize_conv"; }
+
+  bool patternMatchPredicate(Node* n) override {
+    ConvInfo info;
+    if (!MatchConv(n, info)) {
+      return false;
+    }
+    const int opset = getOpsetVersion(*n->owningGraph());
+    if (opset != 0 && opset < 13) {
+      return false;  // DequantizeLinear's per-channel `axis` needs opset >= 13.
+    }
+    if (info.x->elemType() != TensorProto_DataType_FLOAT) {
+      return false;
+    }
+    if (StaticQuantizationCalibrationRanges().count(info.x->uniqueName()) ==
+        0) {
+      return false;  // No calibrated range for this activation.
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    return w_t != nullptr && w_t->elem_type() == TensorProto_DataType_FLOAT &&
+           w_t->sizes().size() >= 3;
+  }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+    ConvInfo info;
+    if (!MatchConv(n, info)) {
+      return false;
+    }
+    if (info.x->elemType() != TensorProto_DataType_FLOAT) {
+      return false;
+    }
+    const auto& ranges = StaticQuantizationCalibrationRanges();
+    const auto range_it = ranges.find(info.x->uniqueName());
+    if (range_it == ranges.end()) {
+      return false;
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+        w_t->sizes().size() < 3) {
+      return false;
+    }
+
+    float x_scale_f = 1.0f;
+    int32_t x_zp_i = 0;
+    ComputeAsymmetricUint8QuantParams(
+        range_it->second.first, range_it->second.second, x_scale_f, x_zp_i);
+
+    Tensor w_q;
+    Tensor w_scale;
+    QuantizeConvWeightPerOutputChannel(*w_t, w_q, w_scale);
+
+    Tensor x_scale_t;
+    x_scale_t.elem_type() = TensorProto_DataType_FLOAT;
+    x_scale_t.floats() = {x_scale_f};
+    Tensor x_zp_t;
+    x_zp_t.elem_type() = TensorProto_DataType_UINT8;
+    x_zp_t.int32s() = {x_zp_i};
+    Value* x_scale_v = graph.addInitializerAndCreateValue(x_scale_t);
+    Value* x_zp_v = graph.addInitializerAndCreateValue(x_zp_t);
+
+    // Xq = QuantizeLinear(X, Xs, Xzp)
+    Node* ql = graph.create(Symbol("QuantizeLinear"), 1);
+    ql->addInput(info.x);
+    ql->addInput(x_scale_v);
+    ql->addInput(x_zp_v);
+    ql->insertBefore(n);
+    ql->output()->setElemType(TensorProto_DataType_UINT8);
+
+    // Xdq = DequantizeLinear(Xq, Xs, Xzp)
+    Node* xdq = graph.create(Symbol("DequantizeLinear"), 1);
+    xdq->addInput(ql->output());
+    xdq->addInput(x_scale_v);
+    xdq->addInput(x_zp_v);
+    xdq->insertBefore(n);
+    xdq->output()->setElemType(TensorProto_DataType_FLOAT);
+    if (info.x->sizes().size() > 0) {
+      xdq->output()->setSizes(info.x->sizes());
+    }
+
+    Value* w_q_v = graph.addInitializerAndCreateValue(w_q);
+    Value* w_scale_v = graph.addInitializerAndCreateValue(w_scale);
+
+    // Wdq = DequantizeLinear(Wq, Ws, axis=0) -- zero_point omitted
+    // (symmetric, i.e. always 0).
+    Node* wdq = graph.create(Symbol("DequantizeLinear"), 1);
+    wdq->addInput(w_q_v);
+    wdq->addInput(w_scale_v);
+    wdq->i_(kaxis, 0);
+    wdq->insertBefore(n);
+    wdq->output()->setElemType(TensorProto_DataType_FLOAT);
+    if (info.w->sizes().size() > 0) {
+      wdq->output()->setSizes(info.w->sizes());
+    }
+
+    // Conv itself is left in place; only its activation and weight inputs
+    // change, to their dequantized (QDQ) counterparts. Its optional bias
+    // (input 2) is untouched.
+    n->replaceInput(0, xdq->output());
+    n->replaceInput(1, wdq->output());
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/tests/test_static_quantize_conv.py
+++ b/tests/test_static_quantize_conv.py
@@ -1,0 +1,155 @@
+"""Tests for ``onnxsim.quantize_static``'s Conv coverage (the
+``static_quantize_conv`` C++ pass).
+
+Mirrors ``test_static_quantize_matmul.py``: each model is built directly with
+``onnx.helper``, calibrated with random data, quantized, and then actually
+run through ONNX Runtime -- both before and after quantization -- so the
+quantized graph must load and execute under a real inference engine, and its
+outputs must stay close to the float baseline.
+"""
+
+import collections
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+
+import onnxsim
+
+# A bare ``import onnxruntime`` would fail collection (not skip the test) on
+# platforms onnxruntime doesn't ship wheels for (e.g. s390x).
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(nodes, inputs, outputs, initializer, opset=13):
+    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
+    # Pin a low IR version so the model loads under older onnxruntime builds
+    # (which cap at IR version 11), matching test_fusion_patterns.py.
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+    )
+
+
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _op_counts(model):
+    return collections.Counter(n.op_type for n in model.graph.node)
+
+
+def _assert_close(float_outputs, quant_outputs):
+    # INT8/uint8 quantization is lossy by design; see
+    # test_dynamic_quantize_matmul.py's identically-named helper for why this
+    # checks aggregate relative L2 error rather than a tight per-element bound.
+    for f, q in zip(float_outputs, quant_outputs):
+        f = np.asarray(f, dtype=np.float64).ravel()
+        q = np.asarray(q, dtype=np.float64).ravel()
+        assert np.all(np.isfinite(q))
+        rel_l2 = np.linalg.norm(f - q) / max(np.linalg.norm(f), 1e-6)
+        assert rel_l2 < 0.1, f"relative L2 error too large: {rel_l2:.4f}"
+
+
+def test_quantize_conv():
+    rng = np.random.default_rng(0)
+    cout, cin = 8, 3
+    weight = _f32(rng.standard_normal((cout, cin, 3, 3)) * 0.5, "W")
+    nodes = [
+        onnx.helper.make_node(
+            "Conv", ["X", "W"], ["Y"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
+        )
+    ]
+    model = _model(
+        nodes, [_vi("X", [1, cin, 16, 16])], [_vi("Y", [1, cout, 16, 16])], [weight]
+    )
+
+    quant = onnxsim.quantize_static(model, num_calibration_samples=16, seed=0)
+    onnx.checker.check_model(quant)
+    ops = _op_counts(quant)
+    assert ops["Conv"] == 1  # the Conv node itself is kept (QDQ format)
+    assert ops["QuantizeLinear"] == 1
+    assert ops["DequantizeLinear"] == 2  # one for X, one for W
+
+    x = rng.standard_normal((1, cin, 16, 16)).astype(np.float32)
+    _assert_close(_run(model, {"X": x}), _run(quant, {"X": x}))
+
+
+def test_quantize_conv_with_bias():
+    rng = np.random.default_rng(1)
+    cout, cin = 4, 2
+    weight = _f32(rng.standard_normal((cout, cin, 3, 3)) * 0.5, "W")
+    bias = _f32(rng.standard_normal(cout), "B")
+    nodes = [
+        onnx.helper.make_node(
+            "Conv", ["X", "W", "B"], ["Y"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
+        )
+    ]
+    model = _model(
+        nodes,
+        [_vi("X", [2, cin, 8, 8])],
+        [_vi("Y", [2, cout, 8, 8])],
+        [weight, bias],
+    )
+
+    quant = onnxsim.quantize_static(model, num_calibration_samples=16, seed=1)
+    onnx.checker.check_model(quant)
+    ops = _op_counts(quant)
+    # The Conv node itself (bias included) is kept; only its X/W inputs are
+    # rerouted through QDQ pairs.
+    assert ops["Conv"] == 1
+    assert ops["QuantizeLinear"] == 1
+    assert ops["DequantizeLinear"] == 2
+
+    x = rng.standard_normal((2, cin, 8, 8)).astype(np.float32)
+    _assert_close(_run(model, {"X": x}), _run(quant, {"X": x}))
+
+
+def test_quantize_skips_non_constant_conv_weight():
+    # Both Conv operands are graph inputs (neither is a constant), so there
+    # is nothing to quantize ahead of time.
+    nodes = [onnx.helper.make_node("Conv", ["X", "W"], ["Y"], kernel_shape=[3, 3])]
+    model = _model(
+        nodes,
+        [_vi("X", [1, 3, 8, 8]), _vi("W", [4, 3, 3, 3])],
+        [_vi("Y", [1, 4, 6, 6])],
+        [],
+    )
+    quant = onnxsim.quantize_static(model)
+    assert _op_counts(quant)["Conv"] == 1
+    assert _op_counts(quant)["QuantizeLinear"] == 0
+
+
+def test_quantize_skips_old_opset_conv():
+    # DequantizeLinear's per-channel `axis` attribute needs opset >= 13.
+    weight = _f32(np.random.randn(4, 3, 3, 3).astype(np.float32), "W")
+    nodes = [onnx.helper.make_node("Conv", ["X", "W"], ["Y"], kernel_shape=[3, 3])]
+    model = _model(
+        nodes, [_vi("X", [1, 3, 8, 8])], [_vi("Y", [1, 4, 6, 6])], [weight], opset=12
+    )
+    quant = onnxsim.quantize_static(model)
+    assert _op_counts(quant)["Conv"] == 1
+    assert _op_counts(quant)["QuantizeLinear"] == 0
+
+
+def test_calibrate_includes_conv_activation():
+    weight = _f32(np.random.randn(4, 3, 3, 3).astype(np.float32), "W")
+    nodes = [onnx.helper.make_node("Conv", ["X", "W"], ["Y"], kernel_shape=[3, 3])]
+    model = _model(nodes, [_vi("X", [1, 3, 8, 8])], [_vi("Y", [1, 4, 6, 6])], [weight])
+    data = onnxsim.generate_random_calibration_data(model, num_samples=4, seed=0)
+    ranges = onnxsim.calibrate(model, data)
+    assert set(ranges.keys()) == {"X"}
+    lo, hi = ranges["X"]
+    assert lo < hi


### PR DESCRIPTION
## Summary

Stacked on #648 (which now also carries #649's merged static-quantization work) -- this PR's diff is scoped to the incremental Conv work; once #648 merges, GitHub will retarget this PR's base to `master` and the diff will shrink to just what's below.

Extends `onnxsim.quantize_static` (and `list_quantizable_activations`) to also cover `Conv`, alongside the existing MatMul/Gemm support from #649.

## Key changes

- **New C++ pass** (`onnxsim/passes/static_quantize_conv.h`): mirrors `static_quantize_matmul.h`'s QDQ rewrite almost exactly -- the weight is quantized to INT8 per output channel (from its static values), and the activation gets a calibrated, fixed-scale `QuantizeLinear`/`DequantizeLinear` pair. `Conv` itself is left in place; only its `X`/`W` inputs are rerouted, so its optional bias and its `kernel_shape`/`strides`/`pads`/`dilations`/`group`/`auto_pad` attributes are untouched.
- **Shared helpers** (`onnxsim/passes/quantize_conv_common.h`): `MatchConv` and `QuantizeConvWeightPerOutputChannel`, generalized to Conv's `[Cout, Cin/groups, k...]` weight layout (arbitrary rank, always channel-axis-0 -- unlike Gemm, Conv has no transposed-weight case to pick between).
- **`ListQuantizableActivations`/`QuantizeStatic`** (`onnxsim.cpp`/`.h`): now also walk/rewrite Conv nodes, so a caller calibrating with `list_quantizable_activations` + `calibrate` picks up Conv's activations too, and `quantize_static` runs both `static_quantize_matmul` and `static_quantize_conv`.
- **Tests** (`tests/test_static_quantize_conv.py`): plain Conv, Conv+bias, and the non-matching skip cases (non-constant weight, opset < 13), each verified end-to-end through real ONNX Runtime inference (aggregate relative-L2 check, same convention as the MatMul/Gemm tests), plus a calibration-coverage check.

## Verification

- Built the extension from source and ran the new tests directly: all 5 pass, and a manual smoke test (8x3x3x3 Conv, random weights) showed relative L2 error ≈0.009 between the float and quantized outputs.
- Ran the full non-torch test suite (146 passed, 62 skipped, 1 pre-existing xfail -- the skips are torch/timm-dependent modules) to confirm no regression to the existing MatMul/Gemm quantization passes or anything else.
- `ruff format`/`ruff check` and `clang-format` clean on every changed file.

https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_