### PR TITLE
Add weight quantization error measurement for static quantization

### DIFF
--- a/onnxsim/model_info.py
+++ b/onnxsim/model_info.py
@@ -1192,6 +1192,9 @@ class WeightQuantizationError:
     relative_l2: float  # ||w - dequant||_2 / ||w||_2
     cosine_similarity: float
     sqnr_db: float  # 20*log10(||w||_2 / ||w - dequant||_2); +inf if exact
+    enob_bits: float  # (sqnr_db - 1.76) / 6.02 -- SQNR re-expressed as "effective bits"
+    psnr_db: float  # 20*log10(max|w| / rmse); the peak- rather than energy-normalized twin of sqnr_db
+    histogram_js_divergence: float  # Jensen-Shannon divergence (nats) between w's and dequant's value histograms -- a *distributional* check, complementing the element-wise metrics above
     per_channel_relative_l2: List[float]  # one entry per channel along `axis`
 
 
@@ -1225,12 +1228,46 @@ def _broadcast_along_axis(values: np.ndarray, ndim: int, axis: int) -> np.ndarra
     return values.reshape(shape)
 
 
+def _histogram_js_divergence(
+    a: np.ndarray, b: np.ndarray, num_bins: int = 256
+) -> float:
+    """Jensen-Shannon divergence (nats; 0 = identical histograms, ``ln(2)`` =
+    disjoint) between ``a``'s and ``b``'s value histograms over their shared
+    range -- unlike the element-wise metrics in :func:`_tensor_error_metrics`
+    (which compare ``a[i]`` against ``b[i]``), this compares the *shape* of the
+    two distributions, so it can catch distortion (e.g. many distinct values
+    collapsing onto one quantization level) that averages out of the
+    element-wise metrics.
+
+    Unlike plain KL divergence, JS needs no epsilon-smoothing for empty bins:
+    the mixture ``m = (p + q) / 2`` is positive everywhere either input is, so
+    ``p * log(p / m)`` never divides by zero.
+    """
+    lo = float(min(a.min(), b.min()))
+    hi = float(max(a.max(), b.max()))
+    if hi <= lo:
+        return 0.0  # every value (in both arrays) is identical
+
+    p, _ = np.histogram(a, bins=num_bins, range=(lo, hi))
+    q, _ = np.histogram(b, bins=num_bins, range=(lo, hi))
+    p = p.astype(np.float64) / max(p.sum(), 1)
+    q = q.astype(np.float64) / max(q.sum(), 1)
+    m = 0.5 * (p + q)
+
+    def _kl(x: np.ndarray, y: np.ndarray) -> float:
+        mask = x > 0
+        return float(np.sum(x[mask] * np.log(x[mask] / y[mask])))
+
+    return 0.5 * _kl(p, m) + 0.5 * _kl(q, m)
+
+
 def _tensor_error_metrics(
     original: np.ndarray, dequantized: np.ndarray, axis: int
-) -> Tuple[float, float, float, float, float, List[float]]:
-    """``(mse, max_abs_error, relative_l2, cosine_similarity, sqnr_db,
-    per_channel_relative_l2)`` between ``original`` and ``dequantized`` (same
-    shape), the last computed per channel along ``axis``.
+) -> Tuple[float, float, float, float, float, float, float, float, List[float]]:
+    """``(mse, max_abs_error, relative_l2, cosine_similarity, sqnr_db, enob_bits,
+    psnr_db, histogram_js_divergence, per_channel_relative_l2)`` between
+    ``original`` and ``dequantized`` (same shape), the last computed per channel
+    along ``axis``.
     """
     orig = original.astype(np.float64)
     deq = dequantized.astype(np.float64)
@@ -1259,6 +1296,20 @@ def _tensor_error_metrics(
         float(np.dot(orig.ravel(), deq.ravel()) / denom) if denom > 0 else 1.0
     )
 
+    # ENOB re-expresses SQNR in "effective bits" (the standard ADC/DSP
+    # conversion); +-inf propagates through the arithmetic unchanged.
+    enob_bits = (sqnr_db - 1.76) / 6.02
+
+    peak_orig = float(np.max(np.abs(orig))) if orig.size else 0.0
+    if mse == 0.0:
+        psnr_db = math.inf
+    elif peak_orig == 0.0:
+        psnr_db = -math.inf
+    else:
+        psnr_db = 20.0 * math.log10(peak_orig / math.sqrt(mse))
+
+    histogram_js_divergence = _histogram_js_divergence(orig, deq)
+
     moved_orig = np.moveaxis(orig, axis, 0)
     moved_deq = np.moveaxis(deq, axis, 0)
     per_channel_relative_l2 = []
@@ -1276,6 +1327,9 @@ def _tensor_error_metrics(
         relative_l2,
         cosine_similarity,
         sqnr_db,
+        enob_bits,
+        psnr_db,
+        histogram_js_divergence,
         per_channel_relative_l2,
     )
 
@@ -1379,6 +1433,9 @@ def weight_quantization_error(
             relative_l2,
             cosine_similarity,
             sqnr_db,
+            enob_bits,
+            psnr_db,
+            histogram_js_divergence,
             per_channel_relative_l2,
         ) = _tensor_error_metrics(w_orig, w_dequant, axis)
 
@@ -1393,6 +1450,9 @@ def weight_quantization_error(
                 relative_l2=relative_l2,
                 cosine_similarity=cosine_similarity,
                 sqnr_db=sqnr_db,
+                enob_bits=enob_bits,
+                psnr_db=psnr_db,
+                histogram_js_divergence=histogram_js_divergence,
                 per_channel_relative_l2=per_channel_relative_l2,
             )
         )
@@ -1406,6 +1466,12 @@ def print_weight_quantization_error(
     worst (highest relative L2 error) weight first, capped at ``limit`` rows (with
     a "... and N more" line) so a large model's report stays readable.
     """
+
+    def _fmt(value: float) -> str:
+        if math.isinf(value):
+            return "inf" if value > 0 else "-inf"
+        return f"{value:.1f}"
+
     table = Table()
     table.add_column("Node")
     table.add_column("Weight")
@@ -1415,6 +1481,9 @@ def print_weight_quantization_error(
     table.add_column("Relative L2")
     table.add_column("Cosine Sim.")
     table.add_column("SQNR (dB)")
+    table.add_column("ENOB (bits)")
+    table.add_column("PSNR (dB)")
+    table.add_column("JS Div.")
 
     ordered = sorted(results, key=lambda r: r.relative_l2, reverse=True)
     for r in ordered[:limit]:
@@ -1426,7 +1495,10 @@ def print_weight_quantization_error(
             f"{r.max_abs_error:.3e}",
             f"{r.relative_l2:.4f}",
             f"{r.cosine_similarity:.6f}",
-            "inf" if math.isinf(r.sqnr_db) else f"{r.sqnr_db:.1f}",
+            _fmt(r.sqnr_db),
+            _fmt(r.enob_bits),
+            _fmt(r.psnr_db),
+            f"{r.histogram_js_divergence:.4f}",
         )
     print(table)
     if len(ordered) > limit:

--- a/onnxsim/model_info.py
+++ b/onnxsim/model_info.py
@@ -1,5 +1,6 @@
 import copy
 import dataclasses
+import math
 import warnings
 from collections import defaultdict
 from typing import (
@@ -15,8 +16,9 @@ from typing import (
     Union,
 )
 
+import numpy as np
 import onnx
-from onnx import defs, helper, shape_inference
+from onnx import defs, helper, numpy_helper, shape_inference
 from onnx.external_data_helper import ExternalDataInfo, uses_external_data
 from rich import print
 from rich.table import Table
@@ -42,6 +44,9 @@ __all__ = [
     "NodeDiffEntry",
     "diff_graphs",
     "print_graph_diff",
+    "WeightQuantizationError",
+    "weight_quantization_error",
+    "print_weight_quantization_error",
 ]
 
 # metadata_props keys written by ``annotate_metadata`` are namespaced with this
@@ -433,9 +438,11 @@ def _schema_function_body(
     if any(name and types.get(name) is None for name in node.input):
         return None
     input_types = [
-        types[name].SerializeToString()
-        if name
-        else onnx.TypeProto().SerializeToString()
+        (
+            types[name].SerializeToString()
+            if name
+            else onnx.TypeProto().SerializeToString()
+        )
         for name in node.input
     ]
     try:
@@ -1162,3 +1169,265 @@ def annotate_metadata(
     for key in ("macs", "flops", "mem_access"):
         _set_metadata(work.graph, prefix + key, _metric_str(totals[key]))
     return work
+
+
+# --------------------------------------------------------------------------- #
+# Weight quantization error: original float weight vs. its dequantized
+# (quantize -> dequantize round-trip) reconstruction
+# --------------------------------------------------------------------------- #
+@dataclasses.dataclass(frozen=True)
+class WeightQuantizationError:
+    """Accuracy metrics for one weight quantized by :func:`onnxsim.quantize_static`,
+    comparing the original float weight against ``(w_q - zero_point) * scale`` --
+    the inverse of the quantize step, i.e. rematerializing the weight through its
+    own quantization parameters -- computed by :func:`weight_quantization_error`.
+    """
+
+    node: str  # the quantized node's name, or its output name(s) if unnamed
+    weight_name: str  # the original float weight's initializer/tensor name
+    shape: Tuple[int, ...]
+    axis: int  # the per-channel quantization axis
+    mse: float
+    max_abs_error: float
+    relative_l2: float  # ||w - dequant||_2 / ||w||_2
+    cosine_similarity: float
+    sqnr_db: float  # 20*log10(||w||_2 / ||w - dequant||_2); +inf if exact
+    per_channel_relative_l2: List[float]  # one entry per channel along `axis`
+
+
+def _resolve_constant(graph: onnx.GraphProto, name: str) -> Optional[onnx.TensorProto]:
+    """The constant ``TensorProto`` backing value ``name`` -- an initializer, or a
+    ``Constant`` node's ``value`` attribute -- or ``None`` if ``name`` is not
+    constant (or not found).
+    """
+    for initializer in graph.initializer:
+        if initializer.name == name:
+            return initializer
+    for node in graph.node:
+        if node.op_type == "Constant" and node.output and node.output[0] == name:
+            for attr in node.attribute:
+                if attr.name == "value" and attr.HasField("t"):
+                    return attr.t
+    return None
+
+
+def _broadcast_along_axis(values: np.ndarray, ndim: int, axis: int) -> np.ndarray:
+    """Reshape a per-channel 1-D array (or a scalar) so it broadcasts against an
+    ``ndim``-D array along ``axis`` -- turns ``DequantizeLinear``'s ``scale`` /
+    ``zero_point`` (one value per channel, or a single scalar for per-tensor
+    quantization) into the shape numpy needs to apply it channel-wise.
+    """
+    values = np.asarray(values, dtype=np.float64)
+    if values.ndim == 0:
+        return values
+    shape = [1] * ndim
+    shape[axis] = values.shape[0]
+    return values.reshape(shape)
+
+
+def _tensor_error_metrics(
+    original: np.ndarray, dequantized: np.ndarray, axis: int
+) -> Tuple[float, float, float, float, float, List[float]]:
+    """``(mse, max_abs_error, relative_l2, cosine_similarity, sqnr_db,
+    per_channel_relative_l2)`` between ``original`` and ``dequantized`` (same
+    shape), the last computed per channel along ``axis``.
+    """
+    orig = original.astype(np.float64)
+    deq = dequantized.astype(np.float64)
+    diff = deq - orig
+
+    mse = float(np.mean(diff**2)) if diff.size else 0.0
+    max_abs_error = float(np.max(np.abs(diff))) if diff.size else 0.0
+
+    norm_orig = float(np.linalg.norm(orig))
+    norm_diff = float(np.linalg.norm(diff))
+    if norm_orig > 0:
+        relative_l2 = norm_diff / norm_orig
+        sqnr_db = (
+            math.inf if norm_diff == 0 else 20.0 * math.log10(norm_orig / norm_diff)
+        )
+    else:
+        # An all-zero original weight: any reconstruction error is undefined as a
+        # *relative* quantity, so report exact-zero as perfect and anything else
+        # as unbounded rather than dividing by zero.
+        relative_l2 = 0.0 if norm_diff == 0 else math.inf
+        sqnr_db = math.inf if norm_diff == 0 else -math.inf
+
+    norm_deq = float(np.linalg.norm(deq))
+    denom = norm_orig * norm_deq
+    cosine_similarity = (
+        float(np.dot(orig.ravel(), deq.ravel()) / denom) if denom > 0 else 1.0
+    )
+
+    moved_orig = np.moveaxis(orig, axis, 0)
+    moved_deq = np.moveaxis(deq, axis, 0)
+    per_channel_relative_l2 = []
+    for c in range(moved_orig.shape[0]):
+        c_norm_orig = float(np.linalg.norm(moved_orig[c]))
+        c_norm_diff = float(np.linalg.norm(moved_deq[c] - moved_orig[c]))
+        if c_norm_orig > 0:
+            per_channel_relative_l2.append(c_norm_diff / c_norm_orig)
+        else:
+            per_channel_relative_l2.append(0.0 if c_norm_diff == 0 else math.inf)
+
+    return (
+        mse,
+        max_abs_error,
+        relative_l2,
+        cosine_similarity,
+        sqnr_db,
+        per_channel_relative_l2,
+    )
+
+
+def weight_quantization_error(
+    model_before: onnx.ModelProto, model_after: onnx.ModelProto
+) -> List[WeightQuantizationError]:
+    """Measure how much each weight :func:`onnxsim.quantize_static` (the QDQ,
+    calibration-based pass) perturbed, by rematerializing every quantized weight
+    through its ``DequantizeLinear`` -- ``w_dequant = (w_q - zero_point) * scale``,
+    the inverse of the quantize step -- and diffing that reconstruction against
+    the original float weight from ``model_before``.
+
+    ``model_after`` must be the direct result of running
+    :func:`onnxsim.quantize_static` on ``model_before`` (or on a simplified copy
+    of it -- node *identity*, not exact byte content, is what matters here): a
+    ``Conv``/``MatMul``/``Gemm`` node is matched between the two models by its
+    output name, since ``quantize_static`` never renames or removes these nodes,
+    only rewires their ``X``/``W`` inputs (see
+    ``onnxsim/passes/static_quantize_matmul.h`` and ``static_quantize_conv.h``).
+    A match is only reported when the matched node's weight input traces back to
+    a ``DequantizeLinear`` whose inputs are a constant int8/uint8 tensor and a
+    constant float scale -- i.e. only where ``quantize_static`` actually
+    quantized that weight.
+
+    Not applicable to :func:`onnxsim.quantize_dynamic`: that pass replaces the
+    MatMul/Gemm node itself with ``MatMulInteger`` rather than dequantizing the
+    weight back to float in the graph, so there is no ``DequantizeLinear`` to
+    walk back through here. Its quantized weight and per-channel scale are still
+    plain initializers though (the ``B`` input of the ``MatMulInteger`` node, and
+    the constant operand of the ``Mul`` that combines it with the activation's
+    runtime-computed scale) -- extract them by name and feed
+    ``(w_q * w_scale)`` through the same reconstruction by hand if needed.
+
+    :param model_before: the float model, before quantization
+    :param model_after: ``onnxsim.quantize_static(model_before, ...)``'s result
+    :returns: one :class:`WeightQuantizationError` per matched weight, in the
+            order its node appears in ``model_after``
+    """
+    graph_before = model_before.graph
+    graph_after = model_after.graph
+    nodes_before = {tuple(n.output): n for n in graph_before.node if n.output}
+
+    results: List[WeightQuantizationError] = []
+    for node in graph_after.node:
+        if node.op_type not in ("Conv", "MatMul", "Gemm") or len(node.input) < 2:
+            continue
+        before_node = nodes_before.get(tuple(node.output))
+        if before_node is None or before_node.op_type != node.op_type:
+            continue
+
+        dq = next(
+            (
+                n
+                for n in graph_after.node
+                if n.op_type == "DequantizeLinear"
+                and n.output
+                and n.output[0] == node.input[1]
+            ),
+            None,
+        )
+        if dq is None or len(dq.input) < 2:
+            continue
+
+        wq_t = _resolve_constant(graph_after, dq.input[0])
+        ws_t = _resolve_constant(graph_after, dq.input[1])
+        w_orig_t = _resolve_constant(graph_before, before_node.input[1])
+        if wq_t is None or ws_t is None or w_orig_t is None:
+            continue
+        if wq_t.data_type not in (
+            onnx.TensorProto.INT8,
+            onnx.TensorProto.UINT8,
+        ):
+            continue
+
+        wq = numpy_helper.to_array(wq_t)
+        w_orig = numpy_helper.to_array(w_orig_t)
+        if wq.shape != w_orig.shape:
+            continue  # unexpected shape mismatch; skip rather than guess
+
+        axis = 1
+        for attr in dq.attribute:
+            if attr.name == "axis":
+                axis = attr.i
+        axis %= wq.ndim
+
+        zero_point = np.array(0.0)
+        if len(dq.input) >= 3 and dq.input[2]:
+            zp_t = _resolve_constant(graph_after, dq.input[2])
+            if zp_t is not None:
+                zero_point = numpy_helper.to_array(zp_t)
+
+        ws = numpy_helper.to_array(ws_t)
+        w_dequant = (
+            wq.astype(np.float64) - _broadcast_along_axis(zero_point, wq.ndim, axis)
+        ) * _broadcast_along_axis(ws, wq.ndim, axis)
+
+        (
+            mse,
+            max_abs_error,
+            relative_l2,
+            cosine_similarity,
+            sqnr_db,
+            per_channel_relative_l2,
+        ) = _tensor_error_metrics(w_orig, w_dequant, axis)
+
+        results.append(
+            WeightQuantizationError(
+                node=before_node.name or "/".join(before_node.output),
+                weight_name=before_node.input[1],
+                shape=tuple(w_orig.shape),
+                axis=axis,
+                mse=mse,
+                max_abs_error=max_abs_error,
+                relative_l2=relative_l2,
+                cosine_similarity=cosine_similarity,
+                sqnr_db=sqnr_db,
+                per_channel_relative_l2=per_channel_relative_l2,
+            )
+        )
+    return results
+
+
+def print_weight_quantization_error(
+    results: List[WeightQuantizationError], limit: int = 50
+) -> None:
+    """Pretty-print :func:`weight_quantization_error`'s results as a table,
+    worst (highest relative L2 error) weight first, capped at ``limit`` rows (with
+    a "... and N more" line) so a large model's report stays readable.
+    """
+    table = Table()
+    table.add_column("Node")
+    table.add_column("Weight")
+    table.add_column("Shape")
+    table.add_column("MSE")
+    table.add_column("Max |Δ|")
+    table.add_column("Relative L2")
+    table.add_column("Cosine Sim.")
+    table.add_column("SQNR (dB)")
+
+    ordered = sorted(results, key=lambda r: r.relative_l2, reverse=True)
+    for r in ordered[:limit]:
+        table.add_row(
+            r.node,
+            r.weight_name,
+            "x".join(str(d) for d in r.shape),
+            f"{r.mse:.3e}",
+            f"{r.max_abs_error:.3e}",
+            f"{r.relative_l2:.4f}",
+            f"{r.cosine_similarity:.6f}",
+            "inf" if math.isinf(r.sqnr_db) else f"{r.sqnr_db:.1f}",
+        )
+    print(table)
+    if len(ordered) > limit:
+        print(Text(f"... and {len(ordered) - limit} more", style="dim"))

--- a/tests/test_weight_quantization_error.py
+++ b/tests/test_weight_quantization_error.py
@@ -1,0 +1,182 @@
+"""Tests for ``onnxsim.model_info.weight_quantization_error``: the before/after
+weight accuracy metrics computed by rematerializing a ``quantize_static``-quantized
+weight through its ``DequantizeLinear`` and diffing it against the original float
+weight it was quantized from.
+"""
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+
+import onnxsim
+from onnxsim.model_info import (
+    WeightQuantizationError,
+    print_weight_quantization_error,
+    weight_quantization_error,
+)
+
+# quantize_static's default (random) calibration data needs onnxruntime to run
+# the float model; skip (not fail collection) where onnxruntime has no wheel.
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(nodes, inputs, outputs, initializer, opset=13):
+    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+    )
+
+
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _matmul_model(K=32, N=16, seed=0):
+    rng = np.random.default_rng(seed)
+    weight = _f32(rng.standard_normal((K, N)) * 0.5, "W")
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    return _model(nodes, [_vi("X", [4, K])], [_vi("Y", [4, N])], [weight])
+
+
+def _conv_model(seed=0):
+    rng = np.random.default_rng(seed)
+    weight = _f32(rng.standard_normal((6, 3, 3, 3)), "W")
+    nodes = [onnx.helper.make_node("Conv", ["X", "W"], ["Y"], kernel_shape=[3, 3])]
+    return _model(nodes, [_vi("X", [1, 3, 8, 8])], [_vi("Y", [1, 6, 6, 6])], [weight])
+
+
+def test_matmul_weight_quantization_error():
+    model = _matmul_model(K=32, N=16, seed=0)
+    quant = onnxsim.quantize_static(model, num_calibration_samples=16, seed=0)
+
+    results = weight_quantization_error(model, quant)
+    assert len(results) == 1
+    r = results[0]
+    assert isinstance(r, WeightQuantizationError)
+    assert r.weight_name == "W"
+    assert r.shape == (32, 16)
+    assert r.axis == 1  # MatMul's un-transposed weight: output channel is axis 1
+    assert len(r.per_channel_relative_l2) == 16
+
+    # INT8 per-channel symmetric quantization of ~N(0, 0.5) data: a real bug
+    # (wrong scale, wrong axis, transposed reconstruction, ...) would blow this
+    # up far past a quantization step's worth of noise.
+    assert 0.0 <= r.relative_l2 < 0.05
+    assert r.cosine_similarity > 0.999
+    assert r.sqnr_db > 20.0
+    assert all(0.0 <= e < 0.2 for e in r.per_channel_relative_l2)
+
+
+def test_gemm_transb_weight_quantization_error():
+    # PyTorch's nn.Linear layout: weight stored [N, K], transB=1 -- the output
+    # channel is then axis 0 of W's own (untransposed) storage.
+    rng = np.random.default_rng(1)
+    K, N = 24, 12
+    weight = _f32(rng.standard_normal((N, K)) * 0.5, "W")
+    bias = _f32(rng.standard_normal(N), "B")
+    nodes = [onnx.helper.make_node("Gemm", ["X", "W", "B"], ["Y"], transB=1)]
+    model = _model(nodes, [_vi("X", [3, K])], [_vi("Y", [3, N])], [weight, bias])
+    quant = onnxsim.quantize_static(model, num_calibration_samples=16, seed=1)
+
+    results = weight_quantization_error(model, quant)
+    assert len(results) == 1
+    r = results[0]
+    assert r.shape == (N, K)
+    assert r.axis == 0
+    assert len(r.per_channel_relative_l2) == N
+    assert r.relative_l2 < 0.05
+
+
+def test_conv_weight_quantization_error():
+    model = _conv_model()
+    quant = onnxsim.quantize_static(model, num_calibration_samples=16, seed=2)
+
+    results = weight_quantization_error(model, quant)
+    assert len(results) == 1
+    r = results[0]
+    assert r.shape == (6, 3, 3, 3)
+    assert r.axis == 0  # Conv's output channel is always axis 0
+    assert len(r.per_channel_relative_l2) == 6
+    assert r.relative_l2 < 0.1
+
+
+def test_exact_reconstruction_is_zero_error():
+    # A weight whose per-channel max already sits on a clean INT8 step
+    # reconstructs exactly: mse/relative_l2 should be exactly 0 and cosine
+    # similarity exactly 1, not just "close".
+    K, N = 4, 2
+    w = np.zeros((K, N), dtype=np.float32)
+    w[:, 0] = np.array([127, -127, 64, -64], dtype=np.float32)  # scale=1
+    w[:, 1] = np.array([254, -254, 128, -128], dtype=np.float32)  # scale=2
+    weight = _f32(w, "W")
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [1, K])], [_vi("Y", [1, N])], [weight])
+    quant = onnxsim.quantize_static(model, num_calibration_samples=4, seed=0)
+
+    results = weight_quantization_error(model, quant)
+    assert len(results) == 1
+    r = results[0]
+    assert r.mse == 0.0
+    assert r.relative_l2 == 0.0
+    assert r.cosine_similarity == pytest.approx(1.0)
+    assert r.sqnr_db == float("inf")
+    assert all(e == 0.0 for e in r.per_channel_relative_l2)
+
+
+def test_no_results_when_weight_not_constant():
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [4, 8]), _vi("W", [8, 4])], [_vi("Y", [4, 4])], [])
+    quant = onnxsim.quantize_static(model)
+    assert weight_quantization_error(model, quant) == []
+
+
+def test_no_results_on_unquantized_model():
+    # model_after == model_before: no DequantizeLinear on any weight input, so
+    # nothing is reported rather than a spurious zero-error match.
+    model = _matmul_model()
+    assert weight_quantization_error(model, model) == []
+
+
+def test_dynamic_quantization_yields_no_results():
+    # quantize_dynamic replaces MatMul/Gemm with MatMulInteger rather than
+    # dequantizing the weight back to float in the graph, so there is no
+    # DequantizeLinear for this function to walk -- see its docstring.
+    model = _matmul_model()
+    quant = onnxsim.quantize_dynamic(model)
+    assert weight_quantization_error(model, quant) == []
+
+
+def test_print_weight_quantization_error_does_not_raise(capsys):
+    model = _matmul_model()
+    quant = onnxsim.quantize_static(model, num_calibration_samples=16, seed=0)
+    results = weight_quantization_error(model, quant)
+    print_weight_quantization_error(results)
+    captured = capsys.readouterr()
+    assert "W" in captured.out
+
+
+def test_print_weight_quantization_error_caps_output(capsys):
+    results = [
+        WeightQuantizationError(
+            node=f"n{i}",
+            weight_name=f"W{i}",
+            shape=(2, 2),
+            axis=1,
+            mse=0.0,
+            max_abs_error=0.0,
+            relative_l2=float(i),
+            cosine_similarity=1.0,
+            sqnr_db=float("inf"),
+            per_channel_relative_l2=[0.0, 0.0],
+        )
+        for i in range(5)
+    ]
+    print_weight_quantization_error(results, limit=2)
+    captured = capsys.readouterr()
+    assert "... and 3 more" in captured.out

--- a/tests/test_weight_quantization_error.py
+++ b/tests/test_weight_quantization_error.py
@@ -72,6 +72,14 @@ def test_matmul_weight_quantization_error():
     assert r.sqnr_db > 20.0
     assert all(0.0 <= e < 0.2 for e in r.per_channel_relative_l2)
 
+    # ENOB is just SQNR re-expressed in bits -- must track it exactly.
+    assert r.enob_bits == pytest.approx((r.sqnr_db - 1.76) / 6.02)
+    # PSNR is peak- rather than energy-normalized, so it never falls below SQNR.
+    assert r.psnr_db >= r.sqnr_db
+    # A close element-wise reconstruction should also leave the value
+    # histogram's shape close to unchanged.
+    assert 0.0 <= r.histogram_js_divergence < 0.05
+
 
 def test_gemm_transb_weight_quantization_error():
     # PyTorch's nn.Linear layout: weight stored [N, K], transB=1 -- the output
@@ -126,7 +134,32 @@ def test_exact_reconstruction_is_zero_error():
     assert r.relative_l2 == 0.0
     assert r.cosine_similarity == pytest.approx(1.0)
     assert r.sqnr_db == float("inf")
+    assert r.enob_bits == float("inf")
+    assert r.psnr_db == float("inf")
+    assert r.histogram_js_divergence == 0.0
     assert all(e == 0.0 for e in r.per_channel_relative_l2)
+
+
+def test_outlier_channel_increases_histogram_js_divergence():
+    # A single large per-channel outlier forces a coarse scale (scale =
+    # max|w| / 127), crushing the rest of the channel's continuous-looking
+    # values down into just a handful of discrete INT8 levels -- a
+    # distributional collapse the histogram JS divergence should flag even
+    # though the element-wise relative L2 error stays fairly small.
+    rng = np.random.default_rng(3)
+    K, N = 300, 1
+    w = (rng.standard_normal((K, N)) * 0.01).astype(np.float32)
+    w[0, 0] = 1.0  # the outlier
+    weight = _f32(w, "W")
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [1, K])], [_vi("Y", [1, N])], [weight])
+    quant = onnxsim.quantize_static(model, num_calibration_samples=4, seed=3)
+
+    results = weight_quantization_error(model, quant)
+    assert len(results) == 1
+    r = results[0]
+    assert r.relative_l2 < 0.1  # element-wise error alone looks unremarkable
+    assert r.histogram_js_divergence > 0.1  # but the distribution shape moved
 
 
 def test_no_results_when_weight_not_constant():
@@ -173,6 +206,9 @@ def test_print_weight_quantization_error_caps_output(capsys):
             relative_l2=float(i),
             cosine_similarity=1.0,
             sqnr_db=float("inf"),
+            enob_bits=float("inf"),
+            psnr_db=float("inf"),
+            histogram_js_divergence=0.0,
             per_channel_relative_l2=[0.0, 0.0],
         )
         for i in range(5)


### PR DESCRIPTION
## Summary
Adds functionality to measure and report the accuracy impact of static quantization on model weights by comparing original float weights against their dequantized reconstructions (quantize → dequantize round-trip).

## Key Changes
- **New `WeightQuantizationError` dataclass**: Captures comprehensive accuracy metrics for each quantized weight, including:
  - MSE, max absolute error, relative L2 norm
  - Cosine similarity and SQNR (Signal-to-Quantization-Noise Ratio) in dB
  - Per-channel relative L2 errors for per-channel quantization analysis

- **`weight_quantization_error()` function**: Analyzes before/after models from `quantize_static()` by:
  - Matching Conv/MatMul/Gemm nodes between models by output name
  - Tracing weight inputs back through `DequantizeLinear` nodes
  - Extracting quantized weights, scales, and zero-points from constant initializers
  - Computing dequantized reconstruction: `(w_q - zero_point) * scale`
  - Computing error metrics relative to original float weights
  - Handling per-channel quantization with proper axis tracking

- **`print_weight_quantization_error()` function**: Pretty-prints results as a sorted table (worst first) with configurable row limit

- **Helper utilities**:
  - `_resolve_constant()`: Resolves constant values from initializers or Constant nodes
  - `_broadcast_along_axis()`: Reshapes per-channel scales/zero-points for broadcasting
  - `_tensor_error_metrics()`: Computes all error metrics including per-channel analysis

- **Comprehensive test suite** (`test_weight_quantization_error.py`):
  - Tests MatMul, Gemm (with transB), and Conv quantization
  - Validates exact reconstruction detection (zero error)
  - Verifies behavior with non-constant weights and unquantized models
  - Confirms dynamic quantization yields no results (expected, as it uses MatMulInteger)
  - Tests output formatting and limiting

## Implementation Details
- Only reports results for weights actually quantized by `quantize_static` (those with `DequantizeLinear` in the graph)
- Handles edge cases: all-zero weights, scalar vs. per-channel quantization, missing zero-points
- Per-channel metrics computed by moving the quantization axis to position 0 for efficient slicing
- SQNR reported as `inf` for exact reconstructions, `-inf` for all-zero originals with non-zero error
- Results sorted by relative L2 error (worst first) for easy identification of problematic weights

https://claude.ai/code/session_01Ww5eKgJovZsbz7g5pL4kGr