### PR TITLE
Add Conv coverage to quantize_weight_only_int4

### DIFF
--- a/docs/int4-weight-only-quantization.md
+++ b/docs/int4-weight-only-quantization.md
@@ -2,11 +2,14 @@
 
 ## What this is
 
-`onnxsim.quantize_weight_only_int4` is a single, self-contained C++ graph
-rewrite (`onnxsim/passes/weight_only_quantize_int4_matmul.h`) that
-block-wise quantizes every `MatMul`, and every "vanilla" `Gemm` (`transA=0`,
-`alpha=1`, `beta=1`), whose weight is a constant 2-D float32 tensor whose
-reduction dimension `K` is evenly divisible by 32.
+`onnxsim.quantize_weight_only_int4` is a pair of single, self-contained C++
+graph rewrites (`onnxsim/passes/weight_only_quantize_int4_matmul.h`,
+`onnxsim/passes/weight_only_quantize_int4_conv.h`) that block-wise quantize
+every `MatMul`, every "vanilla" `Gemm` (`transA=0`, `alpha=1`, `beta=1`), and
+every `Conv`, whose weight is a constant float32 tensor whose flattened
+reduction size is evenly divisible by 32 -- `K` for MatMul/Gemm; `Cin/groups
+* prod(kernel dims)` for Conv, since Conv has no single reduction axis the
+way MatMul does (see "Conv's flattened reduction" below).
 
 It extends `quantize_weight_only` (INT8, one scale per output channel) with
 a smaller data type and finer granularity:
@@ -55,6 +58,36 @@ error low, without so many blocks that the scale tensor's own storage
 overhead erodes the compression this pass exists to provide (a fixed
 constant for now -- see Scope).
 
+## Conv's flattened reduction
+
+Conv's weight (`[Cout, Cin/groups, k...]`) has no single axis that plays
+`K`'s role the way MatMul/Gemm's weight does -- every one of `Cin/groups`
+and the kernel's spatial dims contributes to one output pixel's sum.
+Blocking one of Conv's own axes directly (say, `Cin/groups`) would put an
+*independent* scale on every kernel spatial position, which for a 3x3 kernel
+means 9x the scale-tensor overhead for little accuracy benefit, since each
+of those 9 positions would get its own scale regardless of block size.
+
+Instead, `weight_only_quantize_int4_conv.h` flattens everything but the
+output channel into one sequence (`inner = Cin/groups * prod(k...)`) and
+blocks *that*, exactly as MatMul's `K` is blocked:
+
+```
+Before:
+  Y = Conv(X, W)              # W constant, [Cout, Cin/groups, k...], float32
+
+After:
+  Wq_flat  = <int4, [Cout, inner]>                        # inner = Cin/groups * prod(k...)
+  Ws_flat  = <float32, [Cout, inner / 32]>
+  Wdq_flat = DequantizeLinear(Wq_flat, Ws_flat, axis=1, block_size=32)
+  Wdq      = Reshape(Wdq_flat, [Cout, Cin/groups, k...])   # restore Conv's expected shape
+  Y        = Conv(X, Wdq)
+```
+
+The extra `Reshape` is the only structural difference from the MatMul/Gemm
+rewrite; the quantization scheme itself (symmetric INT4, block-local scale)
+is identical.
+
 ## Scope
 
 Handled:
@@ -62,15 +95,15 @@ Handled:
   dimension (`K`) is a multiple of 32.
 - `Gemm(X, W[, B])` with `transA=0`, `alpha=1`, `beta=1` (when `B` is
   present), same weight constraint. `transB` may be 0 or 1.
+- `Conv(X, W[, B])` with `W` a constant float32 tensor, rank >= 3, whose
+  flattened `Cin/groups * prod(k...)` is a multiple of 32.
 - Opsets >= 21.
 
 Left untouched (safe no-op, node passes through as-is):
-- A `K` that is not a multiple of 32 -- a ragged last block is left to a
-  future extension rather than approximated.
-- Non-constant or non-2-D weights, non-default Gemm attributes, non-float32
-  operands, or an opset older than 21.
-- `Conv` -- not yet covered by this pass (unlike `quantize_weight_only`,
-  which does cover it); a natural, still-open follow-up.
+- A reduction size that is not a multiple of 32 -- a ragged last block is
+  left to a future extension rather than approximated.
+- Non-constant or unsupported-rank weights, non-default Gemm attributes,
+  non-float32 operands, or an opset older than 21.
 
 ## End-to-end: simplify -> quantize -> deploy
 
@@ -99,8 +132,8 @@ outputs = sess.run(None, {"input": your_input_array})
 ```
 
 `tests/test_weight_only_quantize_int4.py` runs this simplify -> quantize ->
-deploy sequence on small `MatMul`/`Gemm` models, executing both the float and
-quantized graphs through `onnxruntime.InferenceSession`.
+deploy sequence on small `MatMul`/`Gemm`/`Conv` models, executing both the
+float and quantized graphs through `onnxruntime.InferenceSession`.
 
 ## Relationship to `quantize_weight_only`
 

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -399,11 +399,11 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
       },
       "model_bytes"_a);
 
-  // Block-wise INT4 weight-only quantizes MatMul/Gemm weights (one symmetric
-  // scale per 32-element block of the reduction dimension, per output
-  // channel) via a single DequantizeLinear(block_size=32) -- activations are
-  // never touched, so no calibration data or ModelExecutor is needed. See
-  // QuantizeWeightOnlyInt4 in onnxsim.h.
+  // Block-wise INT4 weight-only quantizes MatMul/Gemm/Conv weights (one
+  // symmetric scale per 32-element block of the reduction dimension, per
+  // output channel) via a single DequantizeLinear(block_size=32) --
+  // activations are never touched, so no calibration data or ModelExecutor
+  // is needed. See QuantizeWeightOnlyInt4 in onnxsim.h.
   m.def(
       "quantize_weight_only_int4",
       [](const py::bytes& model_proto_bytes) -> py::bytes {

--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -27,6 +27,7 @@
 #include "passes/static_quantize_conv.h"
 #include "passes/static_quantize_matmul.h"
 #include "passes/weight_only_quantize_conv.h"
+#include "passes/weight_only_quantize_int4_conv.h"
 #include "passes/weight_only_quantize_int4_matmul.h"
 #include "passes/weight_only_quantize_matmul.h"
 
@@ -76,6 +77,7 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::StaticQuantizeConv>(registry);
     RegisterOrReplace<p::StaticQuantizeMatMul>(registry);
     RegisterOrReplace<p::WeightOnlyQuantizeConv>(registry);
+    RegisterOrReplace<p::WeightOnlyQuantizeInt4Conv>(registry);
     RegisterOrReplace<p::WeightOnlyQuantizeInt4MatMul>(registry);
     RegisterOrReplace<p::WeightOnlyQuantizeMatMul>(registry);
 

--- a/onnxsim/custom_optimizer_passes.h
+++ b/onnxsim/custom_optimizer_passes.h
@@ -32,6 +32,7 @@ namespace onnxsim {
 //   - weight_only_quantize_matmul
 //   - weight_only_quantize_conv
 //   - weight_only_quantize_int4_matmul
+//   - weight_only_quantize_int4_conv
 //
 // The registration runs at most once per process and is safe to call from any
 // simplification entry point. It MUST run before the pass list is built (a

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -482,30 +482,33 @@ def quantize_weight_only(model: Union[str, onnx.ModelProto]) -> onnx.ModelProto:
 
 def quantize_weight_only_int4(model: Union[str, onnx.ModelProto]) -> onnx.ModelProto:
     """
-    Block-wise INT4 weight-only quantize every MatMul, and every "vanilla"
-    Gemm (transA=0, alpha=1, beta=1), whose weight is a constant 2-D float32
-    tensor whose reduction dimension (K) is evenly divisible by 32.
+    Block-wise INT4 weight-only quantize every MatMul, every "vanilla" Gemm
+    (transA=0, alpha=1, beta=1), and every Conv, whose weight is a constant
+    float32 tensor whose flattened reduction size -- ``K`` for MatMul/Gemm;
+    ``Cin/groups * prod(kernel dims)`` for Conv -- is evenly divisible by 32.
 
     The weight is quantized to INT4 (values in ``[-7, 7]``) with a separate
-    symmetric scale per 32-element block of ``K``, per output channel --
-    the GPTQ/AWQ-style block quantization real weight-heavy LLM/ASR
-    deployments increasingly ship -- inserting a single
-    ``DequantizeLinear(axis=<K's axis>, block_size=32)`` in its place. Like
-    :func:`quantize_weight_only`, the activation is never touched: no
-    calibration data, no runtime quantize/dequantize cost on the activation
-    path. Storage is roughly half of :func:`quantize_weight_only`'s INT8
-    scheme for a comparable accuracy cost, since block-local scales absorb
-    most of what a single wider per-channel range would otherwise lose. Uses
-    ONNX opset 21's INT4 tensor type and ``DequantizeLinear``'s
+    symmetric scale per 32-element block of that reduction, per output
+    channel -- the GPTQ/AWQ-style block quantization real weight-heavy
+    LLM/ASR deployments increasingly ship -- inserting a single
+    ``DequantizeLinear(..., block_size=32)`` in its place (Conv's weight is
+    flattened to 2-D for this, then a ``Reshape`` restores its original
+    shape). Like :func:`quantize_weight_only`, the activation is never
+    touched: no calibration data, no runtime quantize/dequantize cost on the
+    activation path. Storage is roughly half of :func:`quantize_weight_only`'s
+    INT8 scheme for a comparable accuracy cost, since block-local scales
+    absorb most of what a single wider per-channel range would otherwise
+    lose. Uses ONNX opset 21's INT4 tensor type and ``DequantizeLinear``'s
     ``block_size`` attribute -- standard ONNX, not a contrib op, so the
     result loads on any conformant opset-21+ runtime.
 
     This is a single, self-contained graph rewrite: unlike :func:`simplify`,
     it does not run shape inference, constant folding, or any other pass.
-    Nodes that do not match (dynamic or non-2-D weights, a reduction
-    dimension not divisible by 32, non-default Gemm attributes, non-float32
-    operands, an opset older than 21) are left untouched. Consider calling
-    :func:`simplify` before and/or after to clean up the graph.
+    Nodes that do not match (dynamic or unsupported-rank weights, a
+    reduction size not divisible by 32, non-default Gemm attributes,
+    non-float32 operands, an opset older than 21) are left untouched.
+    Consider calling :func:`simplify` before and/or after to clean up the
+    graph.
 
     :param model: onnx ModelProto object or file path
     :returns: the quantized onnx ModelProto
@@ -1395,11 +1398,11 @@ def main():
     parser.add_argument(
         "--weight-only-quantize-int4",
         help="After simplifying, block-wise INT4 weight-only quantize "
-        "MatMul/Gemm weights (one symmetric scale per 32-element block of "
-        "the reduction dimension, per output channel), inserting a single "
-        "DequantizeLinear(block_size=32) per weight. Activations are never "
-        "touched. Needs opset >= 21 (INT4 tensors, DequantizeLinear's "
-        "block_size). See onnxsim.quantize_weight_only_int4.",
+        "MatMul/Gemm/Conv weights (one symmetric scale per 32-element block "
+        "of the flattened reduction dimension, per output channel), "
+        "inserting a single DequantizeLinear(block_size=32) per weight. "
+        "Activations are never touched. Needs opset >= 21 (INT4 tensors, "
+        "DequantizeLinear's block_size). See onnxsim.quantize_weight_only_int4.",
         action="store_true",
     )
     parser.add_argument(
@@ -1654,7 +1657,7 @@ def main():
         model_opt = quantize_weight_only(model_opt)
 
     if args.weight_only_quantize_int4:
-        print("Block-wise INT4 weight-only quantizing MatMul/Gemm weights...")
+        print("Block-wise INT4 weight-only quantizing MatMul/Gemm/Conv weights...")
         model_opt = quantize_weight_only_int4(model_opt)
 
     if args.static_quantize:

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -2463,11 +2463,12 @@ onnx::ModelProto QuantizeWeightOnly(const onnx::ModelProto& model) {
 
 onnx::ModelProto QuantizeWeightOnlyInt4(const onnx::ModelProto& model) {
   PrepareSchemasForDebug(model);
-  // Registers weight_only_quantize_int4_matmul (idempotent) into
-  // onnxoptimizer's registry so OptimizeFixed can find it by name below.
+  // Registers weight_only_quantize_int4_matmul/_conv (idempotent) into
+  // onnxoptimizer's registry so OptimizeFixed can find them by name below.
   onnxsim::RegisterCustomOptimizerPasses();
   return onnx::optimization::OptimizeFixed(
-      model, std::vector<std::string>{"weight_only_quantize_int4_matmul"});
+      model, std::vector<std::string>{"weight_only_quantize_int4_matmul",
+                                      "weight_only_quantize_int4_conv"});
 }
 
 std::vector<std::string> ListQuantizableActivations(

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -200,27 +200,31 @@ onnx::ModelProto QuantizeTernary(const onnx::ModelProto& model);
 // are left as-is.
 onnx::ModelProto QuantizeWeightOnly(const onnx::ModelProto& model);
 
-// Block-wise INT4 weight-only quantizes every MatMul, and every "vanilla"
-// Gemm (transA=0, alpha=1, beta=1), whose weight is a constant 2-D float32
-// tensor whose reduction dimension (K) is evenly divisible by 32: the weight
-// is quantized to INT4 (values in [-7, 7]) with a separate symmetric scale
-// per 32-element block of K, per output channel, inserting a single
-// ``DequantizeLinear(axis=<K's axis>, block_size=32)`` in its place. Like
+// Block-wise INT4 weight-only quantizes every MatMul, every "vanilla" Gemm
+// (transA=0, alpha=1, beta=1), and every Conv, whose weight is a constant
+// float32 tensor whose flattened reduction size (K for MatMul/Gemm --
+// transposed [N, K] or not; Cin/groups * prod(kernel dims) for Conv) is
+// evenly divisible by 32: the weight is quantized to INT4 (values in
+// [-7, 7]) with a separate symmetric scale per 32-element block of that
+// reduction, per output channel, inserting a single
+// ``DequantizeLinear(axis=..., block_size=32)`` in its place (Conv's weight
+// is flattened to 2-D for this, then a ``Reshape`` restores its original
+// shape -- see ``passes/weight_only_quantize_int4_conv.h``). Like
 // ``QuantizeWeightOnly``, the activation is never touched -- no calibration
 // data, no runtime quantize/dequantize cost on the activation path -- but at
 // roughly half the storage for a comparable accuracy cost, since block-local
 // scales absorb most of what a single wider INT8 per-channel range would
 // otherwise lose. Uses ONNX opset 21's INT4 tensor type and
 // DequantizeLinear's `block_size` attribute (standard ONNX, not a contrib
-// op). See ``passes/weight_only_quantize_int4_matmul.h`` for the rewrite
-// itself.
+// op). See ``passes/weight_only_quantize_int4_matmul.h`` and
+// ``passes/weight_only_quantize_int4_conv.h`` for the rewrites themselves.
 //
 // Unlike ``Simplify``, this does not run shape inference, constant folding or
-// any other simplification pass -- it applies exactly this one rewrite, once,
-// to a copy of ``model`` (which is left untouched) and returns the result.
-// Nodes that do not match (dynamic or non-2-D weights, a reduction dimension
-// not divisible by 32, non-default Gemm attributes, non-float32 operands, an
-// opset older than 21) are left as-is.
+// any other simplification pass -- it applies exactly these rewrites, once
+// each, to a copy of ``model`` (which is left untouched) and returns the
+// result. Nodes that do not match (dynamic or unsupported-rank weights, a
+// reduction size not divisible by 32, non-default Gemm attributes,
+// non-float32 operands, an opset older than 21) are left as-is.
 onnx::ModelProto QuantizeWeightOnlyInt4(const onnx::ModelProto& model);
 
 // Lists the activation tensor names that ``QuantizeStatic`` could quantize in

--- a/onnxsim/passes/quantize_conv_common.h
+++ b/onnxsim/passes/quantize_conv_common.h
@@ -132,9 +132,9 @@ inline void QuantizeConvWeightPerOutputChannel(const Tensor& w_t, Tensor& q_out,
 // `block_size` -- the common, unambiguous case only, matching the MatMul
 // version.
 inline bool TryQuantizeConvWeightBlockwiseInt4Flat(const Tensor& w_t,
-                                                    int64_t block_size,
-                                                    Tensor& q_out,
-                                                    Tensor& scale_out) {
+                                                   int64_t block_size,
+                                                   Tensor& q_out,
+                                                   Tensor& scale_out) {
   const auto& sizes = w_t.sizes();
   const int64_t C = sizes[0];
   int64_t inner = 1;
@@ -170,7 +170,8 @@ inline bool TryQuantizeConvWeightBlockwiseInt4Flat(const Tensor& w_t,
   std::vector<int8_t> codes(static_cast<size_t>(numel));
   for (int64_t c = 0; c < C; ++c) {
     for (int64_t j = 0; j < inner; ++j) {
-      const float s = scale[static_cast<size_t>(c * num_blocks + j / block_size)];
+      const float s =
+          scale[static_cast<size_t>(c * num_blocks + j / block_size)];
       const float q = std::round(data[static_cast<size_t>(c * inner + j)] / s);
       codes[static_cast<size_t>(c * inner + j)] =
           static_cast<int8_t>(std::clamp(q, -7.0f, 7.0f));
@@ -178,8 +179,10 @@ inline bool TryQuantizeConvWeightBlockwiseInt4Flat(const Tensor& w_t,
   }
   std::string packed(static_cast<size_t>((numel + 1) / 2), '\0');
   for (int64_t i = 0; i < numel; ++i) {
-    const uint8_t nibble = static_cast<uint8_t>(codes[static_cast<size_t>(i)]) & 0x0F;
-    uint8_t& byte = reinterpret_cast<uint8_t&>(packed[static_cast<size_t>(i / 2)]);
+    const uint8_t nibble =
+        static_cast<uint8_t>(codes[static_cast<size_t>(i)]) & 0x0F;
+    uint8_t& byte =
+        reinterpret_cast<uint8_t&>(packed[static_cast<size_t>(i / 2)]);
     if (i % 2 == 0) {
       byte = nibble;
     } else {

--- a/onnxsim/passes/quantize_conv_common.h
+++ b/onnxsim/passes/quantize_conv_common.h
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <string>
 #include <vector>
 
 #include "onnx/common/assertions.h"
@@ -110,6 +111,90 @@ inline void QuantizeConvWeightPerOutputChannel(const Tensor& w_t, Tensor& q_out,
   scale_out.elem_type() = TensorProto_DataType_FLOAT;
   scale_out.sizes() = {C};
   scale_out.floats() = std::move(scale);
+}
+
+// Block-wise INT4 quantization of `w_t` (a constant float32 Conv weight,
+// [Cout, Cin/groups, k...]), mirroring
+// quantize_matmul_common.h's TryQuantizeWeightBlockwiseInt4InPlace but for
+// Conv's multi-axis weight: Conv has no single reduction axis the way
+// MatMul/Gemm does (every one of ``Cin/groups`` and the kernel dims
+// contributes to one output pixel's sum), so instead of blocking along one
+// of Conv's own axes (which would put an independent scale on every kernel
+// spatial position -- little compression benefit when the kernel is, say,
+// 3x3), this flattens everything but the output channel into one sequence
+// of length `inner = Cin/groups * prod(k...)` and blocks *that*, exactly
+// like a MatMul weight would be. `q_out`/`scale_out` are therefore 2-D
+// ([Cout, inner] and [Cout, inner / block_size]) even though `w_t` is not --
+// the caller reshapes `q_out`'s DequantizeLinear output back to `w_t`'s
+// original shape (see weight_only_quantize_int4_conv.h).
+//
+// Returns false (nothing written) when `inner` is not evenly divisible by
+// `block_size` -- the common, unambiguous case only, matching the MatMul
+// version.
+inline bool TryQuantizeConvWeightBlockwiseInt4Flat(const Tensor& w_t,
+                                                    int64_t block_size,
+                                                    Tensor& q_out,
+                                                    Tensor& scale_out) {
+  const auto& sizes = w_t.sizes();
+  const int64_t C = sizes[0];
+  int64_t inner = 1;
+  for (size_t i = 1; i < sizes.size(); ++i) {
+    inner *= sizes[i];
+  }
+  if (block_size <= 0 || inner % block_size != 0) {
+    return false;
+  }
+  const int64_t num_blocks = inner / block_size;
+
+  const std::vector<float> data = ReadFloatTensorFlat(w_t);
+
+  std::vector<float> scale(static_cast<size_t>(C * num_blocks), 0.0f);
+  for (int64_t c = 0; c < C; ++c) {
+    for (int64_t j = 0; j < inner; ++j) {
+      float& s = scale[static_cast<size_t>(c * num_blocks + j / block_size)];
+      s = std::max(s, std::fabs(data[static_cast<size_t>(c * inner + j)]));
+    }
+  }
+  for (float& s : scale) {
+    s = s > 0.0f ? s / 7.0f : 1.0f;
+  }
+
+  // Pack two int4 codes per byte, low nibble first -- see
+  // TryQuantizeWeightBlockwiseInt4InPlace's identical packing for why this
+  // bypasses q_out.int32s() (ONNX's wire format for INT4 packs raw_data;
+  // onnxsim's vendored onnx-optimizer has no INT4-aware packing for the
+  // typed int32_data field). `inner % block_size == 0` with an even
+  // block_size makes `C * inner` always even, so no odd-count padding byte
+  // is needed.
+  const int64_t numel = C * inner;
+  std::vector<int8_t> codes(static_cast<size_t>(numel));
+  for (int64_t c = 0; c < C; ++c) {
+    for (int64_t j = 0; j < inner; ++j) {
+      const float s = scale[static_cast<size_t>(c * num_blocks + j / block_size)];
+      const float q = std::round(data[static_cast<size_t>(c * inner + j)] / s);
+      codes[static_cast<size_t>(c * inner + j)] =
+          static_cast<int8_t>(std::clamp(q, -7.0f, 7.0f));
+    }
+  }
+  std::string packed(static_cast<size_t>((numel + 1) / 2), '\0');
+  for (int64_t i = 0; i < numel; ++i) {
+    const uint8_t nibble = static_cast<uint8_t>(codes[static_cast<size_t>(i)]) & 0x0F;
+    uint8_t& byte = reinterpret_cast<uint8_t&>(packed[static_cast<size_t>(i / 2)]);
+    if (i % 2 == 0) {
+      byte = nibble;
+    } else {
+      byte = static_cast<uint8_t>(byte | (nibble << 4));
+    }
+  }
+
+  q_out.elem_type() = TensorProto_DataType_INT4;
+  q_out.sizes() = {C, inner};
+  q_out.set_raw_data(std::move(packed));
+
+  scale_out.elem_type() = TensorProto_DataType_FLOAT;
+  scale_out.sizes() = {C, num_blocks};
+  scale_out.floats() = std::move(scale);
+  return true;
 }
 
 }  // namespace onnxsim_passes

--- a/onnxsim/passes/weight_only_quantize_int4_conv.h
+++ b/onnxsim/passes/weight_only_quantize_int4_conv.h
@@ -44,6 +44,7 @@
 #pragma once
 
 #include <cstdint>
+#include <vector>
 
 #include "onnx/common/assertions.h"
 #include "onnxoptimizer/pass.h"
@@ -132,7 +133,11 @@ struct WeightOnlyQuantizeInt4Conv final : public PredicateBasedPass {
     wdq->i_(Symbol("block_size"), kBlockSize);
     wdq->insertBefore(n);
     wdq->output()->setElemType(TensorProto_DataType_FLOAT);
-    wdq->output()->setSizes(w_q.sizes());
+    // Value::setSizes takes vector<Dimension>, not Tensor::sizes()'s
+    // vector<int64_t> -- Dimension(int64_t) is an explicit converting
+    // constructor, so a range-construction from the int64 shape works.
+    wdq->output()->setSizes(
+        std::vector<Dimension>(w_q.sizes().begin(), w_q.sizes().end()));
 
     // Wdq = Reshape(Wdq_flat, W's original [Cout, Cin/groups, k...] shape).
     Tensor shape_t;
@@ -146,7 +151,8 @@ struct WeightOnlyQuantizeInt4Conv final : public PredicateBasedPass {
     reshape->addInput(shape_v);
     reshape->insertBefore(n);
     reshape->output()->setElemType(TensorProto_DataType_FLOAT);
-    reshape->output()->setSizes(w_t->sizes());
+    reshape->output()->setSizes(
+        std::vector<Dimension>(w_t->sizes().begin(), w_t->sizes().end()));
 
     // Conv and its activation input are left untouched; only the weight
     // input changes, to its dequantized (and reshaped-back) counterpart.

--- a/onnxsim/passes/weight_only_quantize_int4_conv.h
+++ b/onnxsim/passes/weight_only_quantize_int4_conv.h
@@ -20,12 +20,15 @@
 // (TryQuantizeConvWeightBlockwiseInt4Flat), then reshapes the dequantized
 // result back to Conv's expected weight shape:
 //
+// inner = Cin/groups * prod(k...)
+//
 // Before:
 //   Y = Conv(X, W)             W constant, float32, [Cout, Cin/groups, k...]
 // After:
-//   Wq_flat  = <int4, [Cout, inner]>              inner = Cin/groups * prod(k...)
+//   Wq_flat  = <int4, [Cout, inner]>
 //   Ws_flat  = <float32, [Cout, inner / kBlockSize]>
-//   Wdq_flat = DequantizeLinear(Wq_flat, Ws_flat, axis=1, block_size=kBlockSize)
+//   Wdq_flat = DequantizeLinear(Wq_flat, Ws_flat, axis=1,
+//                                block_size=kBlockSize)
 //   Wdq      = Reshape(Wdq_flat, [Cout, Cin/groups, k...])
 //   Y        = Conv(X, Wdq)
 //

--- a/onnxsim/passes/weight_only_quantize_int4_conv.h
+++ b/onnxsim/passes/weight_only_quantize_int4_conv.h
@@ -1,0 +1,161 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+// Block-wise INT4 weight-only quantization for Conv, mirroring
+// weight_only_quantize_int4_matmul.h's rationale (no activation
+// quantization, no calibration data, ONNX opset 21's native INT4 type and
+// DequantizeLinear's block_size attribute -- not a contrib op). The only
+// real difference is Conv's weight shape: unlike MatMul/Gemm, whose weight
+// has one clean reduction axis (K) to block along, Conv's weight
+// ([Cout, Cin/groups, k...]) has no single such axis -- every one of
+// Cin/groups and the kernel spatial dims contributes to one output pixel's
+// sum. So instead of blocking one of Conv's own axes directly (which would
+// put an independent scale on every kernel spatial position -- little
+// compression benefit for, say, a 3x3 kernel), this flattens everything but
+// the output channel into one sequence and blocks *that*
+// (TryQuantizeConvWeightBlockwiseInt4Flat), then reshapes the dequantized
+// result back to Conv's expected weight shape:
+//
+// Before:
+//   Y = Conv(X, W)             W constant, float32, [Cout, Cin/groups, k...]
+// After:
+//   Wq_flat  = <int4, [Cout, inner]>              inner = Cin/groups * prod(k...)
+//   Ws_flat  = <float32, [Cout, inner / kBlockSize]>
+//   Wdq_flat = DequantizeLinear(Wq_flat, Ws_flat, axis=1, block_size=kBlockSize)
+//   Wdq      = Reshape(Wdq_flat, [Cout, Cin/groups, k...])
+//   Y        = Conv(X, Wdq)
+//
+// Only Conv's `W` input is quantized; its activation, optional bias (a
+// third input, left untouched), and kernel/stride/pad/dilation/group/
+// auto_pad attributes are unchanged.
+//
+// Only the common, unambiguous shape is handled: a Conv whose weight (input
+// 1) is a constant float32 tensor, rank >= 3, whose flattened
+// Cin/groups * prod(k...) is evenly divisible by kBlockSize, and whose
+// activation (input 0) is float32. Everything else -- non-constant weights,
+// an `inner` not divisible by kBlockSize, non-float32 operands, an opset
+// older than 21 (INT4 tensors and DequantizeLinear's `block_size` both
+// require it) -- is left alone.
+
+#pragma once
+
+#include <cstdint>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+#include "passes/quantize_conv_common.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+struct WeightOnlyQuantizeInt4Conv final : public PredicateBasedPass {
+  // Same default as weight_only_quantize_int4_matmul.h -- see that file's
+  // doc comment for the rationale.
+  static constexpr int64_t kBlockSize = 32;
+
+  explicit WeightOnlyQuantizeInt4Conv()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+  std::string getPassName() const override {
+    return "weight_only_quantize_int4_conv";
+  }
+
+  static int64_t InnerSize(const std::vector<int64_t>& sizes) {
+    int64_t inner = 1;
+    for (size_t i = 1; i < sizes.size(); ++i) {
+      inner *= sizes[i];
+    }
+    return inner;
+  }
+
+  bool patternMatchPredicate(Node* n) override {
+    ConvInfo info;
+    if (!MatchConv(n, info)) {
+      return false;
+    }
+    const int opset = getOpsetVersion(*n->owningGraph());
+    if (opset != 0 && opset < 21) {
+      // INT4 tensors and DequantizeLinear's `block_size` attribute both need
+      // opset >= 21.
+      return false;
+    }
+    if (info.x->elemType() != TensorProto_DataType_FLOAT) {
+      return false;
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+        w_t->sizes().size() < 3) {
+      return false;
+    }
+    return InnerSize(w_t->sizes()) % kBlockSize == 0;
+  }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+    ConvInfo info;
+    if (!MatchConv(n, info)) {
+      return false;
+    }
+    if (info.x->elemType() != TensorProto_DataType_FLOAT) {
+      return false;
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+        w_t->sizes().size() < 3) {
+      return false;
+    }
+
+    Tensor w_q;
+    Tensor w_scale;
+    if (!TryQuantizeConvWeightBlockwiseInt4Flat(*w_t, kBlockSize, w_q,
+                                                w_scale)) {
+      return false;
+    }
+
+    Value* w_q_v = graph.addInitializerAndCreateValue(w_q);
+    Value* w_scale_v = graph.addInitializerAndCreateValue(w_scale);
+
+    // Wdq_flat = DequantizeLinear(Wq_flat, Ws_flat, axis=1,
+    // block_size=kBlockSize) -- zero_point omitted (symmetric, i.e. always
+    // 0).
+    Node* wdq = graph.create(Symbol("DequantizeLinear"), 1);
+    wdq->addInput(w_q_v);
+    wdq->addInput(w_scale_v);
+    wdq->i_(kaxis, 1);
+    wdq->i_(Symbol("block_size"), kBlockSize);
+    wdq->insertBefore(n);
+    wdq->output()->setElemType(TensorProto_DataType_FLOAT);
+    wdq->output()->setSizes(w_q.sizes());
+
+    // Wdq = Reshape(Wdq_flat, W's original [Cout, Cin/groups, k...] shape).
+    Tensor shape_t;
+    shape_t.elem_type() = TensorProto_DataType_INT64;
+    shape_t.sizes().push_back(static_cast<int64_t>(w_t->sizes().size()));
+    shape_t.int64s() = w_t->sizes();
+    Value* shape_v = graph.addInitializerAndCreateValue(shape_t);
+
+    Node* reshape = graph.create(kReshape, 1);
+    reshape->addInput(wdq->output());
+    reshape->addInput(shape_v);
+    reshape->insertBefore(n);
+    reshape->output()->setElemType(TensorProto_DataType_FLOAT);
+    reshape->output()->setSizes(w_t->sizes());
+
+    // Conv and its activation input are left untouched; only the weight
+    // input changes, to its dequantized (and reshaped-back) counterpart.
+    // Its optional bias (input 2) is untouched.
+    n->replaceInput(1, reshape->output());
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/tests/test_weight_only_quantize_int4.py
+++ b/tests/test_weight_only_quantize_int4.py
@@ -165,7 +165,9 @@ def test_quantize_conv_pointwise():
     assert ops["DequantizeLinear"] == 1
     assert ops["Reshape"] == 1
 
-    w_init = next(t for t in quant.graph.initializer if t.data_type == onnx.TensorProto.INT4)
+    w_init = next(
+        t for t in quant.graph.initializer if t.data_type == onnx.TensorProto.INT4
+    )
     assert list(w_init.dims) == [cout, cin]  # flattened [Cout, inner]
 
     x = rng.standard_normal((1, cin, 8, 8)).astype(np.float32)
@@ -179,9 +181,7 @@ def test_quantize_conv_spatial_kernel_with_bias():
     cout, cin = 4, 8
     weight = _f32(rng.standard_normal((cout, cin, 2, 2)) * 0.5, "W")
     bias = _f32(rng.standard_normal(cout), "B")
-    nodes = [
-        onnx.helper.make_node("Conv", ["X", "W", "B"], ["Y"], kernel_shape=[2, 2])
-    ]
+    nodes = [onnx.helper.make_node("Conv", ["X", "W", "B"], ["Y"], kernel_shape=[2, 2])]
     model = _model(
         nodes, [_vi("X", [1, cin, 8, 8])], [_vi("Y", [1, cout, 7, 7])], [weight, bias]
     )

--- a/tests/test_weight_only_quantize_int4.py
+++ b/tests/test_weight_only_quantize_int4.py
@@ -1,5 +1,6 @@
 """Tests for ``onnxsim.quantize_weight_only_int4`` (the
-``weight_only_quantize_int4_matmul`` C++ pass).
+``weight_only_quantize_int4_matmul``/``weight_only_quantize_int4_conv`` C++
+passes).
 
 Each model is built directly with ``onnx.helper`` (no torch dependency),
 quantized, and then actually run through ONNX Runtime -- both before and
@@ -142,6 +143,75 @@ def test_quantize_skips_k_not_divisible_by_block_size():
 
     quant = onnxsim.quantize_weight_only_int4(model)
     assert _op_counts(quant)["MatMul"] == 1
+    assert _op_counts(quant)["DequantizeLinear"] == 0
+
+
+def test_quantize_conv_pointwise():
+    # A 1x1 (pointwise) Conv: inner = Cin/groups * kH * kW = Cin * 1 * 1, so
+    # Cin=32 gives exactly one block -- the simplest Conv case, structurally
+    # equivalent to a per-pixel MatMul.
+    rng = np.random.default_rng(5)
+    cout, cin = 16, 32
+    weight = _f32(rng.standard_normal((cout, cin, 1, 1)) * 0.5, "W")
+    nodes = [onnx.helper.make_node("Conv", ["X", "W"], ["Y"], kernel_shape=[1, 1])]
+    model = _model(
+        nodes, [_vi("X", [1, cin, 8, 8])], [_vi("Y", [1, cout, 8, 8])], [weight]
+    )
+
+    quant = onnxsim.quantize_weight_only_int4(model)
+    onnx.checker.check_model(quant)
+    ops = _op_counts(quant)
+    assert ops["Conv"] == 1
+    assert ops["DequantizeLinear"] == 1
+    assert ops["Reshape"] == 1
+
+    w_init = next(t for t in quant.graph.initializer if t.data_type == onnx.TensorProto.INT4)
+    assert list(w_init.dims) == [cout, cin]  # flattened [Cout, inner]
+
+    x = rng.standard_normal((1, cin, 8, 8)).astype(np.float32)
+    _assert_close(_run(model, {"X": x}), _run(quant, {"X": x}))
+
+
+def test_quantize_conv_spatial_kernel_with_bias():
+    # kernel_shape=[2, 2], Cin=8 -> inner = 8 * 2 * 2 = 32: the flattening
+    # spans both the channel and spatial dims, unlike the pointwise case.
+    rng = np.random.default_rng(6)
+    cout, cin = 4, 8
+    weight = _f32(rng.standard_normal((cout, cin, 2, 2)) * 0.5, "W")
+    bias = _f32(rng.standard_normal(cout), "B")
+    nodes = [
+        onnx.helper.make_node("Conv", ["X", "W", "B"], ["Y"], kernel_shape=[2, 2])
+    ]
+    model = _model(
+        nodes, [_vi("X", [1, cin, 8, 8])], [_vi("Y", [1, cout, 7, 7])], [weight, bias]
+    )
+
+    quant = onnxsim.quantize_weight_only_int4(model)
+    onnx.checker.check_model(quant)
+    ops = _op_counts(quant)
+    assert ops["Conv"] == 1
+    assert ops["DequantizeLinear"] == 1
+    assert ops["Reshape"] == 1
+
+    x = rng.standard_normal((1, cin, 8, 8)).astype(np.float32)
+    _assert_close(_run(model, {"X": x}), _run(quant, {"X": x}))
+
+
+def test_quantize_conv_skips_inner_not_divisible_by_block_size():
+    # inner = Cin * kH * kW = 4 * 3 * 3 = 36, not a multiple of 32.
+    rng = np.random.default_rng(7)
+    cout, cin = 4, 4
+    weight = _f32(rng.standard_normal((cout, cin, 3, 3)) * 0.5, "W")
+    nodes = [onnx.helper.make_node("Conv", ["X", "W"], ["Y"], kernel_shape=[3, 3])]
+    model = _model(
+        nodes,
+        [_vi("X", [1, cin, 8, 8])],
+        [_vi("Y", [1, cout, 6, 6])],
+        [weight],
+    )
+
+    quant = onnxsim.quantize_weight_only_int4(model)
+    assert _op_counts(quant)["Conv"] == 1
     assert _op_counts(quant)["DequantizeLinear"] == 0
 
 


### PR DESCRIPTION
## Summary

Extends **`onnxsim.quantize_weight_only_int4`** (#664, MatMul/Gemm only) to also cover **Conv**, completing parity with `quantize_weight_only`'s INT8 scheme, which already covers all three op types.

## Why Conv needed a different approach than MatMul/Gemm

Conv's weight (`[Cout, Cin/groups, k...]`) has no single reduction axis the way MatMul/Gemm's `K` does -- every one of `Cin/groups` and the kernel's spatial dims contributes to one output pixel's sum. Blocking one of Conv's own axes directly (e.g. `Cin/groups`) would put an *independent* scale on every kernel spatial position -- for a 3x3 kernel, 9x the scale-tensor overhead for little accuracy benefit, since ONNX's `DequantizeLinear` block_size only coarsens the *one* axis it's given, leaving every other axis at full resolution.

Instead, `TryQuantizeConvWeightBlockwiseInt4Flat` (`quantize_conv_common.h`) flattens everything but the output channel into one sequence (`inner = Cin/groups * prod(k...)`) and blocks *that*, exactly like MatMul's `K` is blocked. Since the weight fed to `DequantizeLinear` is therefore 2-D (`[Cout, inner]`) rather than Conv's real rank, `weight_only_quantize_int4_conv.h` adds one `Reshape` node after `DequantizeLinear` to restore Conv's expected `[Cout, Cin/groups, k...]` shape before it reaches the `Conv` node.

`QuantizeWeightOnlyInt4` / `quantize_weight_only_int4` / `--weight-only-quantize-int4` now run both the MatMul/Gemm and Conv passes together under the one existing entry point (matching `quantize_weight_only`'s own MatMul+Conv coverage), rather than adding a separate Conv-only API.

## A build mistake worth flagging (fixed before this PR opened)

`Value::setSizes()` takes `std::vector<Dimension>`; `Tensor::sizes()` returns `std::vector<int64_t>` -- same method name, different type, on different classes. My first attempt passed a `Tensor::sizes()` result straight into `setSizes()` and it doesn't compile. Fixed by range-constructing `vector<Dimension>` from the int64 shape (`Dimension(int64_t)` is an explicit converting constructor) -- the same pattern `ir_pb_converter.cc` itself uses. Caught this the slow way: an earlier build in this environment had silently left a *stale* compiled extension in the source tree from before this change, which Python's import kept shadowing the fresh (failed) build with, so `onnxsim.quantize_weight_only_int4` looked like it was missing an attribute rather than reporting the real compile error -- worth remembering that a `.so` sitting directly under `onnxsim/` can outlive a failed rebuild and silently mask it.

## Files

- **`onnxsim/passes/quantize_conv_common.h`**: `TryQuantizeConvWeightBlockwiseInt4Flat`.
- **`onnxsim/passes/weight_only_quantize_int4_conv.h`**: the Conv pass (`weight_only_quantize_int4_conv`).
- `tests/test_weight_only_quantize_int4.py`: 3 new tests -- a pointwise (1x1) Conv, a spatial-kernel Conv with bias, and the inner-not-divisible-by-32 skip case.
- `docs/int4-weight-only-quantization.md` updated (scope table, a new "Conv's flattened reduction" section explaining the design).

## Verification

- Built from source (after finding and fixing the `setSizes` compile error above) and ran the full non-torch/timm test suite: 216 passed, 63 skipped, no regressions.
- `ruff format`/`ruff check` and `clang-format` clean on every changed file.
- New Conv tests execute both the float and quantized graphs through real `onnxruntime.InferenceSession` (CPU EP).

https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_