### PR TITLE
Add QOperator format quantization (quantize_qoperator)

### DIFF
--- a/docs/qoperator-quantization.md
+++ b/docs/qoperator-quantization.md
@@ -1,0 +1,118 @@
+# QOperator format quantization (`quantize_qoperator`)
+
+## What this is
+
+`onnxsim.quantize_qoperator` is a single, self-contained C++ graph rewrite
+(`onnxsim/passes/qoperator_quantize_matmul.h`) that statically
+(calibration-based) quantizes every `MatMul` and every "vanilla" `Gemm`
+(`transA=0`, `alpha=1`, `beta=1`), whose weight is a constant 2-D float32
+tensor, into the **"QOperator" format** -- `QLinearMatMul`, ONNX's
+directly-quantized matmul op -- rather than `quantize_static`'s **QDQ**
+format (`QuantizeLinear`/`DequantizeLinear` wrapping a float `MatMul`).
+
+Both are standard ONNX operators, and both need the same kind of calibrated
+activation range `quantize_static` does. The difference is what the rewrite
+produces:
+
+```
+Before:
+  Y = MatMul(X, W)                                       # W constant, [K, N], float32
+
+After (QOperator format):
+  Xq = QuantizeLinear(X, Xs, Xzp)                         # Xs/Xzp: CALIBRATED
+  Yq = QLinearMatMul(Xq, Xs, Xzp, Wq, Ws, Wzp, Ys, Yzp)   # true int8 compute
+  Y  = DequantizeLinear(Yq, Ys, Yzp)                      # Ys/Yzp: CALIBRATED
+```
+
+versus QDQ format's:
+
+```
+After (QDQ format, quantize_static):
+  Xdq = DequantizeLinear(QuantizeLinear(X, Xs, Xzp), Xs, Xzp)
+  Wdq = DequantizeLinear(Wq, Ws)
+  Y   = MatMul(Xdq, Wdq)          # MatMul itself is untouched
+```
+
+`Wq`/`Ws` are the same per-output-channel symmetric INT8 weight
+quantization every other onnxsim quantization pass uses.
+
+## Why this needs an extra calibration step
+
+QDQ format's `MatMul` still computes in float32 -- only a QDQ-aware runtime
+recognizes the bracketing pattern and fuses it into an integer kernel at
+load time, so the graph's *declared* dtypes stay float until that fusion
+happens. `QLinearMatMul` has no such deferral: it computes directly in int8,
+so its output `Y` is quantized *in the graph itself* -- there is no float
+`MatMul` left anywhere. That means the rewrite needs a calibrated range for
+the node's **output**, not just its activation input, which QDQ format never
+required (its `DequantizeLinear` can hand back float and let whatever
+consumes it worry about its own range later).
+
+`list_qoperator_quantizable_outputs` (used internally by
+`quantize_qoperator`) reports exactly those output tensor names, on top of
+`list_quantizable_activations`' input names; `calibrate()`'s
+`extra_tensor_names` parameter is how they get folded into the same
+calibration run.
+
+## Why QDQ is usually preferred, and when QOperator still matters
+
+QDQ is ONNX Runtime's (and most modern runtimes') preferred format today
+because it composes: when several quantized ops chain together, a QDQ-aware
+optimizer can fuse the whole chain into integer kernels and drop every
+intermediate float round-trip, whereas QOperator format commits to int8 (or
+back to float, via an explicit `DequantizeLinear`) at every single node
+individually. For one isolated `MatMul` in an otherwise-float graph -- what
+this pass handles -- both formats end up inserting a comparable number of
+nodes.
+
+QOperator format still matters for runtimes/toolchains whose int8 kernels
+key off `QLinearMatMul` specifically rather than recognizing the QDQ
+pattern, or for older deployment pipelines that predate QDQ's adoption as
+the default.
+
+## Scope
+
+Handled:
+- `MatMul(X, W)` with `W` a constant 2-D float32 tensor.
+- `Gemm(X, W[, B])` with `transA=0`, `alpha=1`, `beta=1` (when `B` is
+  present), same weight constraint. `transB` may be 0 or 1. `B`, if present,
+  is added back in float after dequantization (`QLinearMatMul` has no bias
+  input).
+- Opsets >= 10 (`QLinearMatMul`'s own minimum).
+
+Left untouched (safe no-op, node passes through as-is):
+- Non-constant or non-2-D weights, non-default Gemm attributes, non-float32
+  operands, an opset older than 10, or a node whose activation and/or output
+  tensor has no calibrated range.
+- `Conv` -- not yet covered (`QLinearConv` is a natural, still-open
+  follow-up with the same shape as this pass).
+
+## End-to-end: simplify -> quantize -> deploy
+
+### CLI
+
+```bash
+onnxsim model.onnx model.quant.onnx --qoperator-quantize
+```
+
+### Python API
+
+```python
+import onnx
+import onnxruntime as ort
+import onnxsim
+
+model = onnx.load("model.onnx")
+model, check_ok = onnxsim.simplify(model)
+assert check_ok
+
+model = onnxsim.quantize_qoperator(model)
+onnx.save(model, "model.quant.onnx")
+
+sess = ort.InferenceSession("model.quant.onnx", providers=["CPUExecutionProvider"])
+outputs = sess.run(None, {"input": your_input_array})
+```
+
+`tests/test_qoperator_quantize_matmul.py` runs this simplify -> quantize ->
+deploy sequence on small `MatMul`/`Gemm` models, executing both the float and
+quantized graphs through `onnxruntime.InferenceSession`.

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -2,6 +2,7 @@ from onnxsim.calibration import (
     calibrate,
     generate_random_calibration_data,
     load_huggingface_calibration_data,
+    quantize_qoperator,
     quantize_static,
 )
 from onnxsim.onnx_simplifier import (
@@ -28,6 +29,7 @@ __all__ = [
     "quantize_weight_only",
     "quantize_weight_only_int4",
     "quantize_static",
+    "quantize_qoperator",
     "calibrate",
     "generate_random_calibration_data",
     "load_huggingface_calibration_data",

--- a/onnxsim/calibration.py
+++ b/onnxsim/calibration.py
@@ -370,6 +370,7 @@ def calibrate(
     method: str = "minmax",
     num_bins: int = 2048,
     num_quantized_bins: int = 128,
+    extra_tensor_names: Optional[Sequence[str]] = None,
 ) -> Dict[str, Tuple[float, float]]:
     """
     Run the float ``model`` over every batch in ``calibration_data`` through
@@ -383,6 +384,12 @@ def calibrate(
             :func:`load_huggingface_calibration_data`
     :param providers: onnxruntime execution providers to run calibration on
             (defaults to onnxruntime's own default provider selection)
+    :param extra_tensor_names: additional tensor names to calibrate on top of
+            ``onnxsim_cpp2py_export.list_quantizable_activations``' own list --
+            :func:`quantize_qoperator` passes its *output* tensor names here,
+            since QOperator format needs a calibrated range for a quantized
+            node's output too, not just its activation (see
+            ``onnxsim_cpp2py_export.list_qoperator_quantizable_outputs``).
     :param method: ``"minmax"`` (default) uses each tensor's observed
             ``(min, max)`` directly -- simple, and enough calibration data to
             cover the real range is all it needs. ``"entropy"`` instead finds,
@@ -406,7 +413,8 @@ def calibrate(
             regardless of onnxsim's own uint8 range, matching the standard
             entropy-calibration convention this implements.
     :returns: ``{tensor_name: (min, max)}`` for every tensor
-            ``onnxsim_cpp2py_export.list_quantizable_activations`` reports
+            ``onnxsim_cpp2py_export.list_quantizable_activations`` reports,
+            plus ``extra_tensor_names`` if given
     """
     import onnxruntime as ort
 
@@ -417,6 +425,8 @@ def calibrate(
         model = onnx.load(model, load_external_data=False)
     model_bytes = model.SerializeToString()
     tensor_names = set(C.list_quantizable_activations(model_bytes))
+    if extra_tensor_names:
+        tensor_names |= set(extra_tensor_names)
     if not tensor_names:
         return {}
 
@@ -519,3 +529,66 @@ def quantize_static(
         )
     ranges = calibrate(model, calibration_data, providers=providers, method=method)
     return onnx.load_from_string(C.quantize_static(model.SerializeToString(), ranges))
+
+
+def quantize_qoperator(
+    model: Union[str, onnx.ModelProto],
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_calibration_samples: int = 8,
+    seed: int = 0,
+    providers: Optional[Sequence[str]] = None,
+    method: str = "minmax",
+) -> onnx.ModelProto:
+    """
+    Statically (calibration-based) quantize every MatMul and every "vanilla"
+    Gemm (transA=0, alpha=1, beta=1), whose weight is a constant 2-D float32
+    tensor, into the "QOperator" format -- ``QLinearMatMul``, ONNX's
+    directly-quantized matmul op -- rather than :func:`quantize_static`'s QDQ
+    (QuantizeLinear/DequantizeLinear wrapping a float MatMul) format. Both are
+    standard ONNX; QOperator format is the older, still-standard alternative
+    some runtimes' int8 kernels key off of specifically, while QDQ is the
+    now-preferred, more composable format when several quantized ops chain
+    together.
+
+    Unlike QDQ format, ``QLinearMatMul`` computes directly in int8 -- there is
+    no float MatMul left in the graph at all -- so this needs a calibrated
+    range for each quantized node's *output* too, not just its activation
+    (:func:`calibrate` is called with ``extra_tensor_names`` set to
+    ``onnxsim_cpp2py_export.list_qoperator_quantizable_outputs``' result for
+    this reason).
+
+    :param model: onnx ModelProto object or file path
+    :param calibration_data: representative input batches to calibrate
+            activation/output ranges from. Each batch is a
+            ``{input_name: np.ndarray}`` dict matching the model's graph
+            inputs -- see :func:`generate_random_calibration_data` (the
+            default, a quick smoke test) and
+            :func:`load_huggingface_calibration_data` (real data, a much
+            better calibration source for real deployment).
+    :param num_calibration_samples: number of random batches to generate when
+            ``calibration_data`` is not supplied
+    :param seed: seed for the random calibration data (ignored if
+            ``calibration_data`` is supplied)
+    :param providers: onnxruntime execution providers to run calibration on
+    :param method: calibration range method, passed through to
+            :func:`calibrate` -- ``"minmax"`` (default) or ``"entropy"``
+            (KL-divergence calibration; see that function for the tradeoff
+            and its extra data requirement).
+    :returns: the quantized onnx ModelProto
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            model, num_samples=num_calibration_samples, seed=seed
+        )
+    model_bytes = model.SerializeToString()
+    extra_names = C.list_qoperator_quantizable_outputs(model_bytes)
+    ranges = calibrate(
+        model,
+        calibration_data,
+        providers=providers,
+        method=method,
+        extra_tensor_names=extra_names,
+    )
+    return onnx.load_from_string(C.quantize_qoperator(model_bytes, ranges))

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -454,6 +454,42 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
       },
       "model_bytes"_a, "activation_ranges"_a);
 
+  // Lists the *output* tensor names quantize_qoperator could additionally
+  // quantize, on top of list_quantizable_activations' input names -- see
+  // ListQOperatorQuantizableOutputs in onnxsim.h.
+  m.def(
+      "list_qoperator_quantizable_outputs",
+      [](const py::bytes& model_proto_bytes) -> std::vector<std::string> {
+        InitEnv();
+        ONNX_NAMESPACE::ModelProto model;
+        ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
+                            model_proto_bytes.size());
+        return ListQOperatorQuantizableOutputs(model);
+      },
+      "model_bytes"_a);
+
+  // Statically (calibration-based) quantizes MatMul/Gemm into the
+  // "QOperator" format (QLinearMatMul) rather than quantize_static's QDQ
+  // format -- needs a calibrated range for both the activation and the
+  // node's own output (see list_qoperator_quantizable_outputs) since
+  // QLinearMatMul computes directly in int8, with no float intermediate --
+  // see QuantizeQOperator in onnxsim.h.
+  m.def(
+      "quantize_qoperator",
+      [](const py::bytes& model_proto_bytes,
+         const std::unordered_map<std::string, std::pair<float, float>>&
+             activation_ranges) -> py::bytes {
+        InitEnv();
+        ONNX_NAMESPACE::ModelProto model;
+        ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
+                            model_proto_bytes.size());
+        const auto result = QuantizeQOperator(model, activation_ranges);
+        std::string out;
+        result.SerializeToString(&out);
+        return py::bytes(out.data(), out.size());
+      },
+      "model_bytes"_a, "activation_ranges"_a);
+
   m.def(
        "simplify",
        [](std::shared_ptr<PyModelExecutor> executor,

--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -24,6 +24,7 @@
 #include "passes/fuse_pad_into_pool.h"
 #include "passes/fuse_preceding_mul_into_conv.h"
 #include "passes/fuse_rms_norm.h"
+#include "passes/qoperator_quantize_matmul.h"
 #include "passes/static_quantize_conv.h"
 #include "passes/static_quantize_matmul.h"
 #include "passes/weight_only_quantize_conv.h"
@@ -74,6 +75,7 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::FuseMulIntoConv>(registry);
     RegisterOrReplace<p::FusePrecedingMulIntoConv>(registry);
     RegisterOrReplace<p::FuseRMSNorm>(registry);
+    RegisterOrReplace<p::QOperatorQuantizeMatMul>(registry);
     RegisterOrReplace<p::StaticQuantizeConv>(registry);
     RegisterOrReplace<p::StaticQuantizeMatMul>(registry);
     RegisterOrReplace<p::WeightOnlyQuantizeConv>(registry);

--- a/onnxsim/custom_optimizer_passes.h
+++ b/onnxsim/custom_optimizer_passes.h
@@ -33,6 +33,7 @@ namespace onnxsim {
 //   - weight_only_quantize_conv
 //   - weight_only_quantize_int4_matmul
 //   - weight_only_quantize_int4_conv
+//   - qoperator_quantize_matmul
 //
 // The registration runs at most once per process and is safe to call from any
 // simplification entry point. It MUST run before the pass list is built (a

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -1415,10 +1415,20 @@ def main():
         action="store_true",
     )
     parser.add_argument(
+        "--qoperator-quantize",
+        help="After simplifying, statically (calibration-based) quantize "
+        "MatMul/Gemm weights and activations to INT8/uint8 into the "
+        "'QOperator' format (QLinearMatMul) rather than --static-quantize's "
+        "QDQ format, with a fixed scale/zero-point calibrated from "
+        "--calibration-dataset if given, else from random data. See "
+        "onnxsim.quantize_qoperator.",
+        action="store_true",
+    )
+    parser.add_argument(
         "--calibration-dataset",
         help="Hugging Face Hub dataset id (e.g. 'mnist') to pull "
         "--calibration-samples real examples from for --static-quantize's "
-        "calibration, instead of random data. See "
+        "or --qoperator-quantize's calibration, instead of random data. See "
         "onnxsim.load_huggingface_calibration_data (needs the optional "
         "'datasets' package: pip install datasets).",
         type=str,
@@ -1427,13 +1437,14 @@ def main():
     parser.add_argument(
         "--calibration-samples",
         help="Number of calibration batches/examples for --static-quantize "
-        "(default: 8).",
+        "or --qoperator-quantize (default: 8).",
         type=int,
         default=8,
     )
     parser.add_argument(
         "--calibration-method",
-        help="Calibration range method for --static-quantize: 'minmax' "
+        help="Calibration range method for --static-quantize or "
+        "--qoperator-quantize: 'minmax' "
         "(default) uses each tensor's observed min/max directly; 'entropy' "
         "instead searches for the clip threshold minimizing KL divergence "
         "between the observed and simulated-quantized distributions "
@@ -1679,6 +1690,31 @@ def main():
             )
         print("Statically quantizing MatMul/Gemm/Conv weights and activations...")
         model_opt = calibration.quantize_static(
+            model_opt, calibration_data=calibration_data, method=args.calibration_method
+        )
+
+    if args.qoperator_quantize:
+        from . import calibration
+
+        if args.calibration_dataset:
+            print(
+                f'Calibrating from Hugging Face dataset "{args.calibration_dataset}"...'
+            )
+            calibration_data = calibration.load_huggingface_calibration_data(
+                args.calibration_dataset,
+                model_opt,
+                num_samples=args.calibration_samples,
+            )
+        else:
+            print("Calibrating from random data...")
+            calibration_data = calibration.generate_random_calibration_data(
+                model_opt, num_samples=args.calibration_samples
+            )
+        print(
+            "Statically quantizing MatMul/Gemm weights and activations "
+            "(QOperator format)..."
+        )
+        model_opt = calibration.quantize_qoperator(
             model_opt, calibration_data=calibration_data, method=args.calibration_method
         )
 

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -2537,6 +2537,57 @@ onnx::ModelProto QuantizeStatic(
                                       "static_quantize_conv"});
 }
 
+std::vector<std::string> ListQOperatorQuantizableOutputs(
+    const onnx::ModelProto& model) {
+  PrepareSchemasForDebug(model);
+  std::shared_ptr<onnx::Graph> g(onnx::ImportModelProto(model));
+  if (g.get() == nullptr) {
+    return {};
+  }
+  std::vector<std::string> names;
+  std::unordered_set<std::string> seen;
+  for (auto* node : g->nodes()) {
+    onnx::optimization::onnxsim_passes::MatMulLikeInfo info;
+    if (!onnx::optimization::onnxsim_passes::MatchMatMulLike(node, info)) {
+      continue;
+    }
+    if (info.x->elemType() != onnx::TensorProto_DataType_FLOAT) {
+      continue;
+    }
+    const onnx::Tensor* w_t = onnx::optimization::FetchConstantTensor(info.w);
+    if (w_t == nullptr ||
+        w_t->elem_type() != onnx::TensorProto_DataType_FLOAT ||
+        w_t->sizes().size() != 2) {
+      continue;
+    }
+    if (seen.insert(node->output()->uniqueName()).second) {
+      names.push_back(node->output()->uniqueName());
+    }
+  }
+  return names;
+}
+
+onnx::ModelProto QuantizeQOperator(
+    const onnx::ModelProto& model,
+    const std::unordered_map<std::string, std::pair<float, float>>&
+        activation_ranges) {
+  PrepareSchemasForDebug(model);
+  // Registers qoperator_quantize_matmul (idempotent) into onnxoptimizer's
+  // registry so OptimizeFixed can find it by name below.
+  onnxsim::RegisterCustomOptimizerPasses();
+  // qoperator_quantize_matmul reads the same calibration-ranges global
+  // static_quantize_matmul does (see StaticQuantizationCalibrationRanges's
+  // doc comment) -- both are keyed by tensor name, and QOperator format's
+  // ranges are a superset (activation names plus output names) of QDQ
+  // format's, so sharing the map is safe as long as only one of
+  // QuantizeStatic/QuantizeQOperator runs per call, which OptimizeFixed's
+  // single pass-name list here ensures.
+  onnx::optimization::onnxsim_passes::StaticQuantizationCalibrationRanges() =
+      activation_ranges;
+  return onnx::optimization::OptimizeFixed(
+      model, std::vector<std::string>{"qoperator_quantize_matmul"});
+}
+
 // Records the options this Simplify() call actually used (skip_optimizers
 // reflects any auto-added unhashable-tensor protections) as string
 // key/value pairs in the model's metadata_props, namespaced under

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -269,6 +269,44 @@ onnx::ModelProto QuantizeStatic(
     const std::unordered_map<std::string, std::pair<float, float>>&
         activation_ranges);
 
+// Lists the *output* tensor names that ``QuantizeQOperator`` could quantize
+// in ``model``, on top of the input tensor names ``ListQuantizableActivations``
+// already reports -- one entry per MatMul/"vanilla" Gemm whose weight
+// qualifies (same shape ``ListQuantizableActivations`` checks). QOperator
+// format's ``QLinearMatMul`` computes directly in int8 with no float
+// intermediate, so it needs a calibrated range for the node's *output* too,
+// unlike QDQ format (``QuantizeStatic``), whose DequantizeLinear can leave
+// the result in float. A caller preparing to call ``QuantizeQOperator``
+// should calibrate the union of this and ``ListQuantizableActivations``.
+std::vector<std::string> ListQOperatorQuantizableOutputs(
+    const onnx::ModelProto& model);
+
+// Statically (calibration-based) quantizes every MatMul and every "vanilla"
+// Gemm (transA=0, alpha=1, beta=1), whose weight is a constant 2-D float32
+// tensor, whose activation's tensor name *and* whose own output's tensor
+// name are both keys of ``activation_ranges``: the weight is quantized to
+// INT8 ahead of time (per output channel, symmetric, from its static values
+// -- same as ``QuantizeStatic``), and both the activation and the output are
+// quantized to uint8 using *fixed* (scale, zero_point) pairs derived from
+// their calibrated (min, max) ranges (see ``ListQuantizableActivations`` and
+// ``ListQOperatorQuantizableOutputs`` to discover which tensors to
+// calibrate). Unlike ``QuantizeStatic``'s QDQ format, this replaces the
+// MatMul/Gemm itself with ``QLinearMatMul`` -- ONNX's directly-quantized
+// matmul op (the "QOperator" format) -- so the graph computes in true int8
+// with no float MatMul left in it. See ``passes/qoperator_quantize_matmul.h``
+// for the rewrite itself and its doc comment for the QDQ-vs-QOperator
+// tradeoff.
+//
+// Unlike ``Simplify``, this does not run shape inference, constant folding or
+// any other simplification pass -- it applies exactly this one rewrite, once,
+// to a copy of ``model`` (which is left untouched) and returns the result.
+// Nodes that do not match, or whose activation/output has no entry in
+// ``activation_ranges``, are left as-is.
+onnx::ModelProto QuantizeQOperator(
+    const onnx::ModelProto& model,
+    const std::unordered_map<std::string, std::pair<float, float>>&
+        activation_ranges);
+
 void SimplifyPath(
     const ModelExecutor& executor, const std::string& in_path,
     const std::string& out_path,

--- a/onnxsim/passes/qoperator_quantize_matmul.h
+++ b/onnxsim/passes/qoperator_quantize_matmul.h
@@ -31,12 +31,19 @@
 // which output tensors need calibrating, on top of
 // ListQuantizableActivations' input tensors.
 //
-// Wq/Ws (int8, per-output-channel symmetric) are the same weight
-// quantization every other onnxsim quantization pass uses; Wzp is an
-// explicit all-zero tensor of the same shape as Ws (QLinearMatMul, unlike
-// DequantizeLinear, has no optional-zero-point convention -- all 8 inputs
-// are required). X and Y both use a single (scalar) scale/zero-point rather
-// than QLinearMatMul's per-row/per-column option, matching
+// Wq/Ws (int8, per-output-channel symmetric) use the same per-channel
+// quantization math every other onnxsim quantization pass uses, but --
+// unlike static_quantize_matmul.h's QDQ rewrite, which keeps the original
+// Gemm node (transB attribute and all) and so can leave W in its own
+// storage layout -- QLinearMatMul has no transpose attribute of its own: it
+// is a strict numpy.matmul-style op that requires its B operand already in
+// [K, N] layout. So W is always transposed into [K, N] first (see
+// QuantizeWeightPerChannelKN), the same helper dynamic_quantize_matmul.h
+// uses for MatMulInteger, another transpose-attribute-free replacement op.
+// Wzp is an explicit all-zero tensor of the same shape as Ws (QLinearMatMul,
+// unlike DequantizeLinear, has no optional-zero-point convention -- all 8
+// inputs are required). X and Y both use a single (scalar) scale/zero-point
+// rather than QLinearMatMul's per-row/per-column option, matching
 // static_quantize_matmul.h's activation convention.
 //
 // Only the common, unambiguous shape is handled -- see
@@ -117,21 +124,24 @@ struct QOperatorQuantizeMatMul final : public PredicateBasedPass {
 
     float x_scale_f = 1.0f;
     int32_t x_zp_i = 0;
-    ComputeAsymmetricUint8QuantParams(x_range_it->second.first,
-                                      x_range_it->second.second, x_scale_f,
-                                      x_zp_i);
+    ComputeAsymmetricUint8QuantParams(
+        x_range_it->second.first, x_range_it->second.second, x_scale_f, x_zp_i);
     float y_scale_f = 1.0f;
     int32_t y_zp_i = 0;
-    ComputeAsymmetricUint8QuantParams(y_range_it->second.first,
-                                      y_range_it->second.second, y_scale_f,
-                                      y_zp_i);
+    ComputeAsymmetricUint8QuantParams(
+        y_range_it->second.first, y_range_it->second.second, y_scale_f, y_zp_i);
 
-    // W's output-channel axis in its own (untransposed) layout: axis 0 when
-    // Gemm's transB made W [N, K], else axis 1 ([K, N], MatMul's own layout).
-    const int64_t channel_axis = info.weight_transposed ? 0 : 1;
+    // Unlike static_quantize_matmul.h's QDQ rewrite (which keeps the
+    // original Gemm node, transB attribute and all, so the weight can stay
+    // in its own storage layout), QLinearMatMul has no transpose attribute
+    // of its own -- it is a strict numpy.matmul-style op expecting its B
+    // operand already in [K, N] layout. So this needs
+    // QuantizeWeightPerChannelKN (which transposes when `weight_transposed`
+    // is set), the same helper dynamic_quantize_matmul.h uses for
+    // MatMulInteger, another transpose-attribute-free replacement op.
     Tensor w_q;
     Tensor w_scale;
-    QuantizeWeightPerChannelInPlace(*w_t, channel_axis, w_q, w_scale);
+    QuantizeWeightPerChannelKN(*w_t, info.weight_transposed, w_q, w_scale);
     // QLinearMatMul (unlike DequantizeLinear) has no optional-zero-point
     // convention -- b_zero_point is required, so an explicit all-zero tensor
     // (symmetric quantization) of w_scale's shape is needed.

--- a/onnxsim/passes/qoperator_quantize_matmul.h
+++ b/onnxsim/passes/qoperator_quantize_matmul.h
@@ -1,0 +1,219 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+// Statically (calibration-based) quantizes MatMul/Gemm into the "QOperator"
+// format -- ``QLinearMatMul``, ONNX's directly-quantized matmul op -- rather
+// than static_quantize_matmul.h's QDQ (QuantizeLinear/DequantizeLinear
+// wrapping a float MatMul) format. Both are standard ONNX, and both need the
+// same calibrated activation range; QOperator format is the older,
+// still-standard alternative some runtimes' int8 kernels key off of
+// specifically (QDQ is the now-preferred, more composable format when
+// several quantized ops chain together -- see that file's doc comment).
+//
+// Before (illustrated for MatMul; a "vanilla" Gemm -- transA=0, alpha=1,
+// beta=1 -- is handled the same way, its bias C added back in float):
+//   Y = MatMul(X, W)         W constant, 2-D, float32
+// After:
+//   Xq = QuantizeLinear(X, Xs, Xzp)                    -- Xs/Xzp: CALIBRATED
+//   Yq = QLinearMatMul(Xq, Xs, Xzp, Wq, Ws, Wzp, Ys, Yzp)  -- true int8 compute
+//   Y  = DequantizeLinear(Yq, Ys, Yzp)                 -- Ys/Yzp: CALIBRATED
+//
+// Unlike QDQ format, QLinearMatMul computes in int8 directly -- there is no
+// float MatMul left in the graph at all -- so it needs a calibrated range for
+// the *output* Y too, not just the activation X (QDQ's DequantizeLinear can
+// leave Y in float and let whatever consumes it worry about its own range;
+// QLinearMatMul cannot, since Y itself is quantized). See
+// ListQOperatorQuantizableOutputs in onnxsim.h for how a caller discovers
+// which output tensors need calibrating, on top of
+// ListQuantizableActivations' input tensors.
+//
+// Wq/Ws (int8, per-output-channel symmetric) are the same weight
+// quantization every other onnxsim quantization pass uses; Wzp is an
+// explicit all-zero tensor of the same shape as Ws (QLinearMatMul, unlike
+// DequantizeLinear, has no optional-zero-point convention -- all 8 inputs
+// are required). X and Y both use a single (scalar) scale/zero-point rather
+// than QLinearMatMul's per-row/per-column option, matching
+// static_quantize_matmul.h's activation convention.
+//
+// Only the common, unambiguous shape is handled -- see
+// dynamic_quantize_matmul.h's doc comment, which applies identically here --
+// plus: opsets older than 10 (QLinearMatMul's own minimum) are left alone,
+// and a MatMul/Gemm is only rewritten when both its activation input's name
+// and its own output's name have a calibrated range (set via
+// StaticQuantizationCalibrationRanges(), see QuantizeQOperator in
+// onnxsim.h).
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+#include "passes/quantize_matmul_common.h"
+#include "passes/static_quantize_matmul.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+struct QOperatorQuantizeMatMul final : public PredicateBasedPass {
+  explicit QOperatorQuantizeMatMul()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+  std::string getPassName() const override {
+    return "qoperator_quantize_matmul";
+  }
+
+  bool patternMatchPredicate(Node* n) override {
+    MatMulLikeInfo info;
+    if (!MatchMatMulLike(n, info)) {
+      return false;
+    }
+    const int opset = getOpsetVersion(*n->owningGraph());
+    if (opset != 0 && opset < 10) {
+      return false;  // QLinearMatMul needs opset >= 10.
+    }
+    if (info.x->elemType() != TensorProto_DataType_FLOAT) {
+      return false;
+    }
+    const auto& ranges = StaticQuantizationCalibrationRanges();
+    if (ranges.count(info.x->uniqueName()) == 0 ||
+        ranges.count(n->output()->uniqueName()) == 0) {
+      return false;  // No calibrated range for the activation and/or output.
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    return w_t != nullptr && w_t->elem_type() == TensorProto_DataType_FLOAT &&
+           w_t->sizes().size() == 2;
+  }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+    MatMulLikeInfo info;
+    if (!MatchMatMulLike(n, info)) {
+      return false;
+    }
+    if (info.x->elemType() != TensorProto_DataType_FLOAT) {
+      return false;
+    }
+    const auto& ranges = StaticQuantizationCalibrationRanges();
+    const auto x_range_it = ranges.find(info.x->uniqueName());
+    const auto y_range_it = ranges.find(n->output()->uniqueName());
+    if (x_range_it == ranges.end() || y_range_it == ranges.end()) {
+      return false;
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+        w_t->sizes().size() != 2) {
+      return false;
+    }
+
+    float x_scale_f = 1.0f;
+    int32_t x_zp_i = 0;
+    ComputeAsymmetricUint8QuantParams(x_range_it->second.first,
+                                      x_range_it->second.second, x_scale_f,
+                                      x_zp_i);
+    float y_scale_f = 1.0f;
+    int32_t y_zp_i = 0;
+    ComputeAsymmetricUint8QuantParams(y_range_it->second.first,
+                                      y_range_it->second.second, y_scale_f,
+                                      y_zp_i);
+
+    // W's output-channel axis in its own (untransposed) layout: axis 0 when
+    // Gemm's transB made W [N, K], else axis 1 ([K, N], MatMul's own layout).
+    const int64_t channel_axis = info.weight_transposed ? 0 : 1;
+    Tensor w_q;
+    Tensor w_scale;
+    QuantizeWeightPerChannelInPlace(*w_t, channel_axis, w_q, w_scale);
+    // QLinearMatMul (unlike DequantizeLinear) has no optional-zero-point
+    // convention -- b_zero_point is required, so an explicit all-zero tensor
+    // (symmetric quantization) of w_scale's shape is needed.
+    Tensor w_zp;
+    w_zp.elem_type() = TensorProto_DataType_INT8;
+    w_zp.sizes() = w_scale.sizes();
+    w_zp.int32s().assign(w_scale.floats().size(), 0);
+
+    Tensor x_scale_t;
+    x_scale_t.elem_type() = TensorProto_DataType_FLOAT;
+    x_scale_t.floats() = {x_scale_f};
+    Tensor x_zp_t;
+    x_zp_t.elem_type() = TensorProto_DataType_UINT8;
+    x_zp_t.int32s() = {x_zp_i};
+    Value* x_scale_v = graph.addInitializerAndCreateValue(x_scale_t);
+    Value* x_zp_v = graph.addInitializerAndCreateValue(x_zp_t);
+
+    Tensor y_scale_t;
+    y_scale_t.elem_type() = TensorProto_DataType_FLOAT;
+    y_scale_t.floats() = {y_scale_f};
+    Tensor y_zp_t;
+    y_zp_t.elem_type() = TensorProto_DataType_UINT8;
+    y_zp_t.int32s() = {y_zp_i};
+    Value* y_scale_v = graph.addInitializerAndCreateValue(y_scale_t);
+    Value* y_zp_v = graph.addInitializerAndCreateValue(y_zp_t);
+
+    Value* w_q_v = graph.addInitializerAndCreateValue(w_q);
+    Value* w_scale_v = graph.addInitializerAndCreateValue(w_scale);
+    Value* w_zp_v = graph.addInitializerAndCreateValue(w_zp);
+
+    // Xq = QuantizeLinear(X, Xs, Xzp)
+    Node* ql = graph.create(Symbol("QuantizeLinear"), 1);
+    ql->addInput(info.x);
+    ql->addInput(x_scale_v);
+    ql->addInput(x_zp_v);
+    ql->insertBefore(n);
+    ql->output()->setElemType(TensorProto_DataType_UINT8);
+
+    // Yq = QLinearMatMul(Xq, Xs, Xzp, Wq, Ws, Wzp, Ys, Yzp)
+    Node* qlmm = graph.create(Symbol("QLinearMatMul"), 1);
+    qlmm->addInput(ql->output());
+    qlmm->addInput(x_scale_v);
+    qlmm->addInput(x_zp_v);
+    qlmm->addInput(w_q_v);
+    qlmm->addInput(w_scale_v);
+    qlmm->addInput(w_zp_v);
+    qlmm->addInput(y_scale_v);
+    qlmm->addInput(y_zp_v);
+    qlmm->insertBefore(n);
+    qlmm->output()->setElemType(TensorProto_DataType_UINT8);
+
+    // Y = DequantizeLinear(Yq, Ys, Yzp)
+    Node* dq = graph.create(Symbol("DequantizeLinear"), 1);
+    dq->addInput(qlmm->output());
+    dq->addInput(y_scale_v);
+    dq->addInput(y_zp_v);
+    dq->insertBefore(n);
+    dq->output()->setElemType(TensorProto_DataType_FLOAT);
+
+    Value* result = dq->output();
+    if (info.bias != nullptr) {
+      Node* add = graph.create(kAdd, 1);
+      add->addInput(dq->output());
+      add->addInput(info.bias);
+      add->insertBefore(n);
+      add->output()->setElemType(TensorProto_DataType_FLOAT);
+      result = add->output();
+    }
+
+    if (n->output()->sizes().size() > 0) {
+      result->setSizes(n->output()->sizes());
+    }
+
+    const bool replacing_success = tryReplacingAllUsesWith(n->output(), result);
+    if (!replacing_success) {
+      return false;
+    }
+    destroy_current = NodeDestroyType::DestroyOne;
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/tests/test_qoperator_quantize_matmul.py
+++ b/tests/test_qoperator_quantize_matmul.py
@@ -1,0 +1,161 @@
+"""Tests for ``onnxsim.quantize_qoperator`` (the ``qoperator_quantize_matmul``
+C++ pass) and its output-range calibration helper.
+
+Each model is built directly with ``onnx.helper`` (no torch dependency),
+calibrated with random data, quantized, and then actually run through ONNX
+Runtime -- both before and after quantization -- so these tests double as a
+minimal end-to-end calibrate/quantize/deploy check: the quantized graph must
+load and execute under a real inference engine, and its outputs must stay
+close to the float baseline.
+"""
+
+import collections
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+
+import onnxsim
+
+# A bare ``import onnxruntime`` would fail collection (not skip the test) on
+# platforms onnxruntime doesn't ship wheels for (e.g. s390x).
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(nodes, inputs, outputs, initializer, opset=13):
+    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
+    # Pin a low IR version so the model loads under older onnxruntime builds
+    # (which cap at IR version 11), matching test_fusion_patterns.py.
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+    )
+
+
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _op_counts(model):
+    return collections.Counter(n.op_type for n in model.graph.node)
+
+
+def _assert_close(float_outputs, quant_outputs):
+    # INT8/uint8 quantization is lossy by design; see
+    # test_dynamic_quantize_matmul.py's identically-named helper for why this
+    # checks aggregate relative L2 error rather than a tight per-element bound.
+    for f, q in zip(float_outputs, quant_outputs):
+        f = np.asarray(f, dtype=np.float64).ravel()
+        q = np.asarray(q, dtype=np.float64).ravel()
+        assert np.all(np.isfinite(q))
+        rel_l2 = np.linalg.norm(f - q) / max(np.linalg.norm(f), 1e-6)
+        assert rel_l2 < 0.1, f"relative L2 error too large: {rel_l2:.4f}"
+
+
+def test_quantize_matmul():
+    rng = np.random.default_rng(0)
+    K, N = 32, 16
+    weight = _f32(rng.standard_normal((K, N)) * 0.5, "W")
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [4, K])], [_vi("Y", [4, N])], [weight])
+
+    quant = onnxsim.quantize_qoperator(model, num_calibration_samples=16, seed=0)
+    onnx.checker.check_model(quant)
+    ops = _op_counts(quant)
+    # Unlike quantize_static's QDQ format, the MatMul node itself is replaced
+    # by QLinearMatMul -- no float MatMul is left in the graph.
+    assert ops["MatMul"] == 0
+    assert ops["QLinearMatMul"] == 1
+    assert ops["QuantizeLinear"] == 1
+    assert ops["DequantizeLinear"] == 1
+
+    x = rng.standard_normal((4, K)).astype(np.float32)
+    _assert_close(_run(model, {"X": x}), _run(quant, {"X": x}))
+
+
+def test_quantize_gemm_transb_with_bias():
+    # PyTorch's nn.Linear layout: weight is [out_features, in_features], i.e.
+    # [N, K], exported as Gemm(X, W, B, transB=1) -- the common real-world case.
+    # QLinearMatMul has no bias input, so the bias is added back in float
+    # after dequantization, like dynamic_quantize_matmul.h does.
+    rng = np.random.default_rng(1)
+    K, N = 24, 12
+    weight = _f32(rng.standard_normal((N, K)) * 0.5, "W")
+    bias = _f32(rng.standard_normal(N), "B")
+    nodes = [onnx.helper.make_node("Gemm", ["X", "W", "B"], ["Y"], transB=1)]
+    model = _model(nodes, [_vi("X", [3, K])], [_vi("Y", [3, N])], [weight, bias])
+
+    quant = onnxsim.quantize_qoperator(model, num_calibration_samples=16, seed=1)
+    onnx.checker.check_model(quant)
+    ops = _op_counts(quant)
+    assert ops["Gemm"] == 0
+    assert ops["QLinearMatMul"] == 1
+    assert ops["QuantizeLinear"] == 1
+    assert ops["DequantizeLinear"] == 1
+    assert ops["Add"] == 1
+
+    x = rng.standard_normal((3, K)).astype(np.float32)
+    _assert_close(_run(model, {"X": x}), _run(quant, {"X": x}))
+
+
+def test_quantize_skips_non_constant_weight():
+    # Both MatMul operands are graph inputs (neither is a constant), so there
+    # is nothing to quantize ahead of time.
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [4, 8]), _vi("W", [8, 4])], [_vi("Y", [4, 4])], [])
+    quant = onnxsim.quantize_qoperator(model)
+    assert _op_counts(quant)["MatMul"] == 1
+    assert _op_counts(quant)["QLinearMatMul"] == 0
+
+
+def test_quantize_skips_non_default_gemm_attrs():
+    # alpha != 1 falls outside the "vanilla" Gemm shape this pass handles.
+    weight = _f32(np.random.randn(8, 4).astype(np.float32), "W")
+    nodes = [onnx.helper.make_node("Gemm", ["X", "W"], ["Y"], alpha=2.0)]
+    model = _model(nodes, [_vi("X", [4, 8])], [_vi("Y", [4, 4])], [weight])
+    quant = onnxsim.quantize_qoperator(model)
+    assert _op_counts(quant)["Gemm"] == 1
+    assert _op_counts(quant)["QLinearMatMul"] == 0
+
+
+def test_quantize_skips_old_opset():
+    # QLinearMatMul needs opset >= 10.
+    weight = _f32(np.random.randn(8, 4).astype(np.float32), "W")
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [4, 8])], [_vi("Y", [4, 4])], [weight], opset=9)
+    quant = onnxsim.quantize_qoperator(model)
+    assert _op_counts(quant)["MatMul"] == 1
+    assert _op_counts(quant)["QLinearMatMul"] == 0
+
+
+def test_list_qoperator_quantizable_outputs_includes_matmul_output():
+    weight = _f32(np.random.randn(8, 4).astype(np.float32), "W")
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [2, 8])], [_vi("Y", [2, 4])], [weight])
+    import onnxsim.onnxsim_cpp2py_export as C
+
+    names = C.list_qoperator_quantizable_outputs(model.SerializeToString())
+    assert set(names) == {"Y"}
+
+
+def test_calibrate_with_extra_tensor_names_includes_output():
+    weight = _f32(np.random.randn(8, 4).astype(np.float32), "W")
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [2, 8])], [_vi("Y", [2, 4])], [weight])
+    data = onnxsim.generate_random_calibration_data(model, num_samples=4, seed=0)
+    ranges = onnxsim.calibrate(model, data, extra_tensor_names=["Y"])
+    assert set(ranges.keys()) == {"X", "Y"}
+    lo, hi = ranges["Y"]
+    assert lo < hi


### PR DESCRIPTION
## Summary

- Adds `onnxsim.quantize_qoperator`, a calibration-based static quantization pass that rewrites `MatMul`/"vanilla" `Gemm` (constant, 2-D float32 weight) into ONNX's **QOperator** format (`QLinearMatMul`) rather than `quantize_static`'s **QDQ** format (`QuantizeLinear`/`DequantizeLinear` wrapping an untouched float op).
- New C++ pass `onnxsim/passes/qoperator_quantize_matmul.h` (`qoperator_quantize_matmul`), registered through the existing `custom_optimizer_passes` registry, plus `ListQOperatorQuantizableOutputs`/`QuantizeQOperator` entry points in `onnxsim.h`/`onnxsim.cpp` and nanobind bindings in `cpp2py_export.cc`.
- `calibration.py`: `calibrate()` gains an `extra_tensor_names` parameter, and a new `quantize_qoperator()` wrapper, because QOperator format — unlike QDQ — needs a calibrated range for the node's **output**, not just its activation input (`QLinearMatMul` computes directly in int8, leaving no float op in the graph to defer range concerns to).
- New `--qoperator-quantize` CLI flag in `onnx_simplifier.py`, wired the same way as `--static-quantize`.
- `docs/qoperator-quantization.md` explains the QOperator vs. QDQ tradeoff, why output calibration is required, and current scope.
- `tests/test_qoperator_quantize_matmul.py` (7 tests, `onnx.helper`-built models, no torch): quantizes `MatMul` and `Gemm(transB=1)` (PyTorch `nn.Linear`'s export layout) with a bias, runs both float and quantized graphs through real `onnxruntime.InferenceSession`, and checks the various skip conditions (non-constant weight, non-default Gemm attrs, opset < 10).

### Bug fixed during development

`QLinearMatMul` has no transpose attribute of its own — unlike the QDQ rewrite (which keeps the original `Gemm` node, `transB` and all, so the weight can stay in its own storage layout), `QLinearMatMul` is a strict `numpy.matmul`-style op requiring its `B` operand already in `[K, N]` layout. The pass now uses `QuantizeWeightPerChannelKN` (which transposes into `[K, N]` when needed) instead of `QuantizeWeightPerChannelInPlace`, the same helper `dynamic_quantize_matmul.h` already uses for `MatMulInteger` — another transpose-attribute-free replacement op. Verified against a `transB=1` + bias test case that previously failed ONNX Runtime shape inference.

## Scope

Handled: `MatMul`/vanilla `Gemm` with a constant 2-D float32 weight, opset >= 10 (`QLinearMatMul`'s own minimum). `Conv`/`QLinearConv` is left as a follow-up, noted in the docs.

## Test plan

- [x] `pytest tests/test_qoperator_quantize_matmul.py -v` — 7/7 passed, including the `transB=1` + bias case that failed before the `QuantizeWeightPerChannelKN` fix
- [x] `pytest tests/ --ignore=tests/test_bitnet.py --continue-on-collection-errors` — 223 passed, 63 skipped (no torch), 4 pre-existing collection errors unrelated to this change (missing `torch`/`timm`)
- [x] `ruff format --check` / `ruff check` clean on changed Python files
- [x] `clang-format --dry-run --Werror` clean on changed C++ files
- [x] Full local rebuild (`pip install --no-build-isolation -e .`), verified 0 compiler errors and new symbols present in the compiled extension

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_