### PR TITLE
Add a browser-based quantize UI to the WASM convertmodel demo

### DIFF
--- a/docs/qoperator-quantization.md
+++ b/docs/qoperator-quantization.md
@@ -2,13 +2,15 @@
 
 ## What this is
 
-`onnxsim.quantize_qoperator` is a single, self-contained C++ graph rewrite
-(`onnxsim/passes/qoperator_quantize_matmul.h`) that statically
-(calibration-based) quantizes every `MatMul` and every "vanilla" `Gemm`
-(`transA=0`, `alpha=1`, `beta=1`), whose weight is a constant 2-D float32
-tensor, into the **"QOperator" format** -- `QLinearMatMul`, ONNX's
-directly-quantized matmul op -- rather than `quantize_static`'s **QDQ**
-format (`QuantizeLinear`/`DequantizeLinear` wrapping a float `MatMul`).
+`onnxsim.quantize_qoperator` is two self-contained C++ graph rewrites
+(`onnxsim/passes/qoperator_quantize_matmul.h` and
+`onnxsim/passes/qoperator_quantize_conv.h`) that statically
+(calibration-based) quantize every `MatMul`, every "vanilla" `Gemm`
+(`transA=0`, `alpha=1`, `beta=1`), and every `Conv`, whose weight is a
+constant float32 tensor (2-D for `MatMul`/`Gemm`, rank >= 3 for `Conv`), into
+the **"QOperator" format** -- `QLinearMatMul`/`QLinearConv`, ONNX's
+directly-quantized matmul/convolution ops -- rather than `quantize_static`'s
+**QDQ** format (`QuantizeLinear`/`DequantizeLinear` wrapping a float op).
 
 Both are standard ONNX operators, and both need the same kind of calibrated
 activation range `quantize_static` does. The difference is what the rewrite
@@ -35,6 +37,12 @@ After (QDQ format, quantize_static):
 
 `Wq`/`Ws` are the same per-output-channel symmetric INT8 weight
 quantization every other onnxsim quantization pass uses.
+
+`Conv` follows the identical shape with `QLinearConv` in place of
+`QLinearMatMul`; its optional bias, unlike Gemm's, is pre-quantized to INT32
+(`QLinearConv`'s own bias input) rather than added back in float, since
+`QLinearConv` accepts one directly -- see "Scope" below for the constraint
+that puts on which Conv nodes get rewritten.
 
 ## Why this needs an extra calibration step
 
@@ -78,14 +86,19 @@ Handled:
   present), same weight constraint. `transB` may be 0 or 1. `B`, if present,
   is added back in float after dequantization (`QLinearMatMul` has no bias
   input).
-- Opsets >= 10 (`QLinearMatMul`'s own minimum).
+- `Conv(X, W[, B])` with `W` a constant float32 tensor, rank >= 3
+  (`[Cout, Cin/groups, k...]`). `B`, if present, must be a constant float32
+  `[Cout]` tensor -- `QLinearConv` takes its bias pre-quantized to INT32
+  (scale = `x_scale * w_scale[c]`, zero_point 0), so unlike Gemm's bias there
+  is no float fallback for a non-constant one; such a Conv is left untouched
+  instead (see `passes/qoperator_quantize_conv.h`).
+- Opsets >= 10 (`QLinearMatMul`/`QLinearConv`'s own minimum).
 
 Left untouched (safe no-op, node passes through as-is):
-- Non-constant or non-2-D weights, non-default Gemm attributes, non-float32
-  operands, an opset older than 10, or a node whose activation and/or output
-  tensor has no calibrated range.
-- `Conv` -- not yet covered (`QLinearConv` is a natural, still-open
-  follow-up with the same shape as this pass).
+- Non-constant or wrong-rank weights, non-default Gemm attributes,
+  non-float32 operands, an opset older than 10, a node whose activation
+  and/or output tensor has no calibrated range, or a Conv whose bias is
+  present but not a constant float32 `[Cout]` tensor.
 
 ## End-to-end: simplify -> quantize -> deploy
 

--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -24,6 +24,7 @@
 #include "passes/fuse_pad_into_pool.h"
 #include "passes/fuse_preceding_mul_into_conv.h"
 #include "passes/fuse_rms_norm.h"
+#include "passes/qoperator_quantize_conv.h"
 #include "passes/qoperator_quantize_matmul.h"
 #include "passes/static_quantize_conv.h"
 #include "passes/static_quantize_matmul.h"
@@ -75,6 +76,7 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::FuseMulIntoConv>(registry);
     RegisterOrReplace<p::FusePrecedingMulIntoConv>(registry);
     RegisterOrReplace<p::FuseRMSNorm>(registry);
+    RegisterOrReplace<p::QOperatorQuantizeConv>(registry);
     RegisterOrReplace<p::QOperatorQuantizeMatMul>(registry);
     RegisterOrReplace<p::StaticQuantizeConv>(registry);
     RegisterOrReplace<p::StaticQuantizeMatMul>(registry);

--- a/onnxsim/custom_optimizer_passes.h
+++ b/onnxsim/custom_optimizer_passes.h
@@ -34,6 +34,7 @@ namespace onnxsim {
 //   - weight_only_quantize_int4_matmul
 //   - weight_only_quantize_int4_conv
 //   - qoperator_quantize_matmul
+//   - qoperator_quantize_conv
 //
 // The registration runs at most once per process and is safe to call from any
 // simplification entry point. It MUST run before the pass list is built (a

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -2564,6 +2564,37 @@ std::vector<std::string> ListQOperatorQuantizableOutputs(
       names.push_back(node->output()->uniqueName());
     }
   }
+  for (auto* node : g->nodes()) {
+    onnx::optimization::onnxsim_passes::ConvInfo info;
+    if (!onnx::optimization::onnxsim_passes::MatchConv(node, info)) {
+      continue;
+    }
+    if (info.x->elemType() != onnx::TensorProto_DataType_FLOAT) {
+      continue;
+    }
+    const onnx::Tensor* w_t = onnx::optimization::FetchConstantTensor(info.w);
+    if (w_t == nullptr ||
+        w_t->elem_type() != onnx::TensorProto_DataType_FLOAT ||
+        w_t->sizes().size() < 3) {
+      continue;
+    }
+    if (info.bias != nullptr) {
+      // qoperator_quantize_conv only rewrites a Conv whose bias (if any) is a
+      // constant float32 [Cout] tensor it can pre-quantize to INT32 -- see
+      // that pass's doc comment. Skip listing this Conv's output otherwise,
+      // since it will never actually be rewritten.
+      const onnx::Tensor* b_t =
+          onnx::optimization::FetchConstantTensor(info.bias);
+      if (b_t == nullptr ||
+          b_t->elem_type() != onnx::TensorProto_DataType_FLOAT ||
+          b_t->sizes().size() != 1) {
+        continue;
+      }
+    }
+    if (seen.insert(node->output()->uniqueName()).second) {
+      names.push_back(node->output()->uniqueName());
+    }
+  }
   return names;
 }
 
@@ -2572,11 +2603,11 @@ onnx::ModelProto QuantizeQOperator(
     const std::unordered_map<std::string, std::pair<float, float>>&
         activation_ranges) {
   PrepareSchemasForDebug(model);
-  // Registers qoperator_quantize_matmul (idempotent) into onnxoptimizer's
-  // registry so OptimizeFixed can find it by name below.
+  // Registers qoperator_quantize_matmul/_conv (idempotent) into
+  // onnxoptimizer's registry so OptimizeFixed can find them by name below.
   onnxsim::RegisterCustomOptimizerPasses();
-  // qoperator_quantize_matmul reads the same calibration-ranges global
-  // static_quantize_matmul does (see StaticQuantizationCalibrationRanges's
+  // qoperator_quantize_matmul/_conv read the same calibration-ranges global
+  // static_quantize_matmul/_conv do (see StaticQuantizationCalibrationRanges's
   // doc comment) -- both are keyed by tensor name, and QOperator format's
   // ranges are a superset (activation names plus output names) of QDQ
   // format's, so sharing the map is safe as long as only one of
@@ -2585,7 +2616,8 @@ onnx::ModelProto QuantizeQOperator(
   onnx::optimization::onnxsim_passes::StaticQuantizationCalibrationRanges() =
       activation_ranges;
   return onnx::optimization::OptimizeFixed(
-      model, std::vector<std::string>{"qoperator_quantize_matmul"});
+      model, std::vector<std::string>{"qoperator_quantize_matmul",
+                                      "qoperator_quantize_conv"});
 }
 
 // Records the options this Simplify() call actually used (skip_optimizers

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -271,37 +271,45 @@ onnx::ModelProto QuantizeStatic(
 
 // Lists the *output* tensor names that ``QuantizeQOperator`` could quantize
 // in ``model``, on top of the input tensor names ``ListQuantizableActivations``
-// already reports -- one entry per MatMul/"vanilla" Gemm whose weight
-// qualifies (same shape ``ListQuantizableActivations`` checks). QOperator
-// format's ``QLinearMatMul`` computes directly in int8 with no float
-// intermediate, so it needs a calibrated range for the node's *output* too,
+// already reports -- one entry per MatMul/"vanilla" Gemm/Conv whose weight
+// qualifies (same shape ``ListQuantizableActivations`` checks), and, for a
+// Conv with a bias, whose bias is also a constant float32 ``[Cout]`` tensor
+// (``QLinearConv`` needs its bias pre-quantized to a static INT32 tensor;
+// see ``passes/qoperator_quantize_conv.h``). QOperator format's
+// ``QLinearMatMul``/``QLinearConv`` compute directly in int8 with no float
+// intermediate, so they need a calibrated range for the node's *output* too,
 // unlike QDQ format (``QuantizeStatic``), whose DequantizeLinear can leave
 // the result in float. A caller preparing to call ``QuantizeQOperator``
 // should calibrate the union of this and ``ListQuantizableActivations``.
 std::vector<std::string> ListQOperatorQuantizableOutputs(
     const onnx::ModelProto& model);
 
-// Statically (calibration-based) quantizes every MatMul and every "vanilla"
-// Gemm (transA=0, alpha=1, beta=1), whose weight is a constant 2-D float32
-// tensor, whose activation's tensor name *and* whose own output's tensor
-// name are both keys of ``activation_ranges``: the weight is quantized to
-// INT8 ahead of time (per output channel, symmetric, from its static values
-// -- same as ``QuantizeStatic``), and both the activation and the output are
-// quantized to uint8 using *fixed* (scale, zero_point) pairs derived from
-// their calibrated (min, max) ranges (see ``ListQuantizableActivations`` and
+// Statically (calibration-based) quantizes every MatMul, every "vanilla"
+// Gemm (transA=0, alpha=1, beta=1), and every Conv, whose weight is a
+// constant float32 tensor (2-D for MatMul/Gemm, rank >= 3 for Conv), whose
+// activation's tensor name *and* whose own output's tensor name are both
+// keys of ``activation_ranges``: the weight is quantized to INT8 ahead of
+// time (per output channel, symmetric, from its static values -- same as
+// ``QuantizeStatic``), and both the activation and the output are quantized
+// to uint8 using *fixed* (scale, zero_point) pairs derived from their
+// calibrated (min, max) ranges (see ``ListQuantizableActivations`` and
 // ``ListQOperatorQuantizableOutputs`` to discover which tensors to
 // calibrate). Unlike ``QuantizeStatic``'s QDQ format, this replaces the
-// MatMul/Gemm itself with ``QLinearMatMul`` -- ONNX's directly-quantized
-// matmul op (the "QOperator" format) -- so the graph computes in true int8
-// with no float MatMul left in it. See ``passes/qoperator_quantize_matmul.h``
-// for the rewrite itself and its doc comment for the QDQ-vs-QOperator
+// MatMul/Gemm/Conv itself with ``QLinearMatMul``/``QLinearConv`` -- ONNX's
+// directly-quantized ops (the "QOperator" format) -- so the graph computes
+// in true int8 with no float MatMul/Conv left in it. A Conv's bias (if any)
+// is quantized to INT32 ahead of time too (``QLinearConv``'s own bias input
+// convention), which is why a Conv with a non-constant bias is left alone
+// (see ``ListQOperatorQuantizableOutputs``). See
+// ``passes/qoperator_quantize_matmul.h``/``passes/qoperator_quantize_conv.h``
+// for the rewrites themselves and their doc comments for the QDQ-vs-QOperator
 // tradeoff.
 //
 // Unlike ``Simplify``, this does not run shape inference, constant folding or
-// any other simplification pass -- it applies exactly this one rewrite, once,
-// to a copy of ``model`` (which is left untouched) and returns the result.
-// Nodes that do not match, or whose activation/output has no entry in
-// ``activation_ranges``, are left as-is.
+// any other simplification pass -- it applies exactly these rewrites, once
+// each, to a copy of ``model`` (which is left untouched) and returns the
+// result. Nodes that do not match, or whose activation/output has no entry
+// in ``activation_ranges``, are left as-is.
 onnx::ModelProto QuantizeQOperator(
     const onnx::ModelProto& model,
     const std::unordered_map<std::string, std::pair<float, float>>&

--- a/onnxsim/passes/qoperator_quantize_conv.h
+++ b/onnxsim/passes/qoperator_quantize_conv.h
@@ -1,0 +1,248 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+// Statically (calibration-based) quantizes Conv into the "QOperator" format
+// -- ``QLinearConv``, ONNX's directly-quantized convolution op -- exactly
+// mirroring qoperator_quantize_matmul.h's MatMul/Gemm rewrite (see that
+// file's doc comment for the QOperator-vs-QDQ tradeoff and why the *output*
+// needs a calibrated range too, not just the activation).
+//
+// Before:
+//   Y = Conv(X, W[, B])      W constant, float32, rank >= 3; B optional,
+//                            constant, float32, [Cout]
+// After:
+//   Xq = QuantizeLinear(X, Xs, Xzp)                              -- CALIBRATED
+//   Yq = QLinearConv(Xq, Xs, Xzp, Wq, Ws, Wzp, Ys, Yzp[, Bq])     -- true int8
+//   Y  = DequantizeLinear(Yq, Ys, Yzp)                            -- CALIBRATED
+//
+// Unlike static_quantize_conv.h's QDQ rewrite (which keeps the original Conv
+// node and its float bias untouched), QLinearConv takes its optional bias
+// (input 8) pre-quantized to INT32, with a *fixed* per-channel scale of
+// ``x_scale * w_scale[c]`` and zero_point 0 (see the QLinearConv_ver10_doc
+// comment in onnx's own schema) -- there is no float Add left in the graph
+// for it to ride on, unlike qoperator_quantize_matmul.h's Gemm bias (MatMul
+// has no analogous "quantize the bias ahead of time" input to use). This
+// means a Conv whose bias is present but not a constant float32 [Cout]
+// tensor cannot be rewritten and is left alone -- see the predicate below.
+//
+// Wq/Ws (int8, per-output-channel symmetric, axis 0 -- Conv's weight layout
+// gives no other choice, see quantize_conv_common.h) are the same weight
+// quantization static_quantize_conv.h uses; Wzp is an explicit all-zero
+// tensor of the same shape as Ws (QLinearConv, like QLinearMatMul, has no
+// optional-zero-point convention -- w_zero_point is required whenever w is
+// present). X and Y both use a single (scalar) scale/zero-point, matching
+// static_quantize_matmul.h's/qoperator_quantize_matmul.h's activation
+// convention (QLinearConv's own per-channel option for x/y is not used).
+//
+// Conv's kernel_shape/strides/pads/dilations/group/auto_pad attributes are
+// copied verbatim onto the new QLinearConv node -- both ops share the same
+// attribute set.
+//
+// Only the common, unambiguous shape is handled: opsets older than 10
+// (QLinearConv's own minimum) are left alone, and a Conv is only rewritten
+// when both its activation input's name and its own output's name have a
+// calibrated range (set via StaticQuantizationCalibrationRanges(), see
+// QuantizeQOperator in onnxsim.h).
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+#include "passes/quantize_conv_common.h"
+#include "passes/static_quantize_matmul.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+struct QOperatorQuantizeConv final : public PredicateBasedPass {
+  explicit QOperatorQuantizeConv()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+  std::string getPassName() const override { return "qoperator_quantize_conv"; }
+
+  bool patternMatchPredicate(Node* n) override {
+    ConvInfo info;
+    if (!MatchConv(n, info)) {
+      return false;
+    }
+    const int opset = getOpsetVersion(*n->owningGraph());
+    if (opset != 0 && opset < 10) {
+      return false;  // QLinearConv needs opset >= 10.
+    }
+    if (info.x->elemType() != TensorProto_DataType_FLOAT) {
+      return false;
+    }
+    const auto& ranges = StaticQuantizationCalibrationRanges();
+    if (ranges.count(info.x->uniqueName()) == 0 ||
+        ranges.count(n->output()->uniqueName()) == 0) {
+      return false;  // No calibrated range for the activation and/or output.
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+        w_t->sizes().size() < 3) {
+      return false;
+    }
+    if (info.bias != nullptr) {
+      // QLinearConv needs its bias pre-quantized to a static INT32 tensor;
+      // only a constant float32 [Cout] bias can be turned into one.
+      const Tensor* b_t = FetchConstantTensor(info.bias);
+      if (b_t == nullptr || b_t->elem_type() != TensorProto_DataType_FLOAT ||
+          b_t->sizes().size() != 1) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+    ConvInfo info;
+    if (!MatchConv(n, info)) {
+      return false;
+    }
+    if (info.x->elemType() != TensorProto_DataType_FLOAT) {
+      return false;
+    }
+    const auto& ranges = StaticQuantizationCalibrationRanges();
+    const auto x_range_it = ranges.find(info.x->uniqueName());
+    const auto y_range_it = ranges.find(n->output()->uniqueName());
+    if (x_range_it == ranges.end() || y_range_it == ranges.end()) {
+      return false;
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+        w_t->sizes().size() < 3) {
+      return false;
+    }
+    const Tensor* b_t = nullptr;
+    if (info.bias != nullptr) {
+      b_t = FetchConstantTensor(info.bias);
+      if (b_t == nullptr || b_t->elem_type() != TensorProto_DataType_FLOAT ||
+          b_t->sizes().size() != 1) {
+        return false;
+      }
+    }
+
+    float x_scale_f = 1.0f;
+    int32_t x_zp_i = 0;
+    ComputeAsymmetricUint8QuantParams(
+        x_range_it->second.first, x_range_it->second.second, x_scale_f, x_zp_i);
+    float y_scale_f = 1.0f;
+    int32_t y_zp_i = 0;
+    ComputeAsymmetricUint8QuantParams(
+        y_range_it->second.first, y_range_it->second.second, y_scale_f, y_zp_i);
+
+    Tensor w_q;
+    Tensor w_scale;
+    QuantizeConvWeightPerOutputChannel(*w_t, w_q, w_scale);
+    // QLinearConv (unlike DequantizeLinear) has no optional-zero-point
+    // convention -- w_zero_point is required, so an explicit all-zero tensor
+    // (symmetric quantization) of w_scale's shape is needed.
+    Tensor w_zp;
+    w_zp.elem_type() = TensorProto_DataType_INT8;
+    w_zp.sizes() = w_scale.sizes();
+    w_zp.int32s().assign(w_scale.floats().size(), 0);
+
+    Tensor x_scale_t;
+    x_scale_t.elem_type() = TensorProto_DataType_FLOAT;
+    x_scale_t.floats() = {x_scale_f};
+    Tensor x_zp_t;
+    x_zp_t.elem_type() = TensorProto_DataType_UINT8;
+    x_zp_t.int32s() = {x_zp_i};
+    Value* x_scale_v = graph.addInitializerAndCreateValue(x_scale_t);
+    Value* x_zp_v = graph.addInitializerAndCreateValue(x_zp_t);
+
+    Tensor y_scale_t;
+    y_scale_t.elem_type() = TensorProto_DataType_FLOAT;
+    y_scale_t.floats() = {y_scale_f};
+    Tensor y_zp_t;
+    y_zp_t.elem_type() = TensorProto_DataType_UINT8;
+    y_zp_t.int32s() = {y_zp_i};
+    Value* y_scale_v = graph.addInitializerAndCreateValue(y_scale_t);
+    Value* y_zp_v = graph.addInitializerAndCreateValue(y_zp_t);
+
+    Value* w_q_v = graph.addInitializerAndCreateValue(w_q);
+    Value* w_scale_v = graph.addInitializerAndCreateValue(w_scale);
+    Value* w_zp_v = graph.addInitializerAndCreateValue(w_zp);
+
+    // Xq = QuantizeLinear(X, Xs, Xzp)
+    Node* ql = graph.create(Symbol("QuantizeLinear"), 1);
+    ql->addInput(info.x);
+    ql->addInput(x_scale_v);
+    ql->addInput(x_zp_v);
+    ql->insertBefore(n);
+    ql->output()->setElemType(TensorProto_DataType_UINT8);
+
+    // Bq = quantized INT32 bias: per-channel scale = x_scale * w_scale[c],
+    // zero_point = 0 (fixed by QLinearConv's own contract, not calibrated).
+    Value* bias_v = nullptr;
+    if (b_t != nullptr) {
+      const std::vector<float> bias_data = ReadFloatTensorFlat(*b_t);
+      const auto& w_scale_data = w_scale.floats();
+      Tensor bias_q;
+      bias_q.elem_type() = TensorProto_DataType_INT32;
+      bias_q.sizes() = b_t->sizes();
+      bias_q.int32s().resize(bias_data.size());
+      for (size_t c = 0; c < bias_data.size(); ++c) {
+        const float bias_scale = x_scale_f * w_scale_data[c];
+        const float q = std::round(bias_data[c] / bias_scale);
+        bias_q.int32s()[c] =
+            static_cast<int32_t>(std::clamp(q, -2147483648.0f, 2147483520.0f));
+      }
+      bias_v = graph.addInitializerAndCreateValue(bias_q);
+    }
+
+    // Yq = QLinearConv(Xq, Xs, Xzp, Wq, Ws, Wzp, Ys, Yzp[, Bq])
+    Node* qlconv = graph.create(Symbol("QLinearConv"), 1);
+    qlconv->addInput(ql->output());
+    qlconv->addInput(x_scale_v);
+    qlconv->addInput(x_zp_v);
+    qlconv->addInput(w_q_v);
+    qlconv->addInput(w_scale_v);
+    qlconv->addInput(w_zp_v);
+    qlconv->addInput(y_scale_v);
+    qlconv->addInput(y_zp_v);
+    if (bias_v != nullptr) {
+      qlconv->addInput(bias_v);
+    }
+    qlconv->copyAttributes(*n);
+    qlconv->insertBefore(n);
+    qlconv->output()->setElemType(TensorProto_DataType_UINT8);
+
+    // Y = DequantizeLinear(Yq, Ys, Yzp)
+    Node* dq = graph.create(Symbol("DequantizeLinear"), 1);
+    dq->addInput(qlconv->output());
+    dq->addInput(y_scale_v);
+    dq->addInput(y_zp_v);
+    dq->insertBefore(n);
+    dq->output()->setElemType(TensorProto_DataType_FLOAT);
+    if (n->output()->sizes().size() > 0) {
+      dq->output()->setSizes(n->output()->sizes());
+    }
+
+    const bool replacing_success =
+        tryReplacingAllUsesWith(n->output(), dq->output());
+    if (!replacing_success) {
+      return false;
+    }
+    destroy_current = NodeDestroyType::DestroyOne;
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -333,11 +333,17 @@ agraph (float[N] X) =&gt; (float[N] Y) {
             </div>
             <label for="quantize-samples">calibration samples (Static / QOperator only)</label>
             <input type="number" id="quantize-samples" value="8" min="1" max="64" step="1" style="width: 4em;">
+            <br/>
+            <input type="checkbox" id="quantize-metrics-toggle" checked>
+            <label for="quantize-metrics-toggle" title="After quantizing, run the float and quantized models on the same random input through onnxruntime-web and report the size change plus how far the outputs drifted -- relative L2 error and SQNR, the same aggregate-error metric onnxsim's own test suite checks.">
+                report result quality (size change, relative L2 error, SQNR) after quantizing
+            </label>
             <div class="debug-actions">
                 <button id="quantize-button" type="button">Quantize</button>
                 <button id="quantize-download" type="button" style="display: none;">download model ↓</button>
                 <span id="quantize-status" class="tool-note"></span>
             </div>
+            <div id="quantize-metrics" style="display: none; margin-top: 0.4em;"></div>
         </div>
         <script type="module" src="./quantize_ui.mjs"></script>
         <h2 id="sec-visualize">Visualize with Netron (before / after)</h2>

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -356,21 +356,32 @@ agraph (float[N] X) =&gt; (float[N] Y) {
                 <span id="quantize-status" class="tool-note"></span>
             </div>
             <div id="quantize-metrics" style="display: none; margin-top: 0.4em;"></div>
+            <div class="netron-pane" style="margin-top: 0.6em; max-width: 480px;">
+                <div class="netron-head">
+                    <strong>Quantized preview</strong> —
+                    <button id="netron-quantized-open" type="button" style="display: none;">open in a new tab ↗</button>
+                    <button id="netron-quantized-download" type="button" style="display: none;">download model ↓</button>
+                    <button id="netron-quantized-svg" type="button" style="display: none;">export SVG ↓</button>
+                    <button id="netron-quantized-png" type="button" style="display: none;">export PNG ↓</button>
+                </div>
+                <iframe id="netron-quantized-frame" class="netron-frame" title="Netron — quantized model" style="display: none;"></iframe>
+                <div id="netron-quantized-note" class="netron-note"></div>
+            </div>
         </div>
         <script type="module" src="./quantize_ui.mjs"></script>
-        <h2 id="sec-visualize">Visualize with Netron (original / onnxsim / quantized)</h2>
+        <h2 id="sec-visualize">Visualize with Netron (before / after)</h2>
         <p>
             Renders the model graph with a self-hosted
-            <a href="https://github.com/onnxsim/netron" target="_blank" rel="noopener">Netron</a>,
-            one pane per pipeline stage, so you can compare them side by side:
-            the original upload, the Convert section's simplify/optimize
-            result, and the Quantize panel's result (independent of the
-            middle pane -- quantizing never overwrites it, see the Quantize
-            panel above). A pane stays empty until that stage has actually
-            run. Nothing is uploaded — the model bytes are posted straight
-            into the embedded Netron in your browser, so there is no
-            model-size limit. Use <b>export SVG</b> to save the rendered
-            graph as an SVG image.
+            <a href="https://github.com/onnxsim/netron" target="_blank" rel="noopener">Netron</a>:
+            the original model on the left and the simplified/optimized result on
+            the right, so you can compare them side by side. Nothing is uploaded —
+            the model bytes are posted straight into the embedded Netron in your
+            browser, so there is no model-size limit. Use <b>export SVG</b> to save
+            the rendered graph as an SVG image.
+            <br>
+            The quantized result has its own Netron preview inside the
+            <a href="#sec-quantize">Quantize panel</a> above instead of a third
+            pane here, so it never crowds this before/after comparison.
         </p>
         <p class="macs-note">
             Netron is driven here purely as an embeddable model-preview component
@@ -400,17 +411,6 @@ agraph (float[N] X) =&gt; (float[N] Y) {
                 </div>
                 <iframe id="netron-after-frame" class="netron-frame" title="Netron — simplified model" style="display: none;"></iframe>
                 <div id="netron-after-note" class="netron-note"></div>
-            </div>
-            <div class="netron-pane">
-                <div class="netron-head">
-                    <strong>Quantized</strong> —
-                    <button id="netron-quantized-open" type="button" style="display: none;">open in a new tab ↗</button>
-                    <button id="netron-quantized-download" type="button" style="display: none;">download model ↓</button>
-                    <button id="netron-quantized-svg" type="button" style="display: none;">export SVG ↓</button>
-                    <button id="netron-quantized-png" type="button" style="display: none;">export PNG ↓</button>
-                </div>
-                <iframe id="netron-quantized-frame" class="netron-frame" title="Netron — quantized model" style="display: none;"></iframe>
-                <div id="netron-quantized-note" class="netron-note"></div>
             </div>
         </div>
         <script type="module" src="./netron_view.mjs"></script>

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -277,11 +277,23 @@ agraph (float[N] X) =&gt; (float[N] Y) {
         <h2 id="sec-quantize">Quantize a model</h2>
         <div class="tool-panel">
             <p class="tool-note">
-                Quantizes the currently loaded model (the uploaded file, or one
-                loaded from Hugging Face / a backend test case / a parsed text
-                graph above) with onnxsim's WebAssembly module, entirely in your
-                browser -- nothing is uploaded. Pick a method:
+                Quantizes a model with onnxsim's WebAssembly module, entirely in
+                your browser -- nothing is uploaded. Its result is kept
+                independent of the plain <b>Convert</b> section above (it never
+                overwrites the "after" Netron pane or <code>converted</code>
+                inference source) so you can inspect all three stages side by
+                side: <b>original</b> -- <b>onnxsim-simplified</b> (Convert
+                section, optional) -- <b>quantized</b> (its own "Quantized"
+                Netron pane and <code>quantized</code> inference source below).
+                Pick what to quantize:
             </p>
+            <div class="convert-modes">
+                <input type="radio" name="quantize-source" value="original" id="quantize_source_original" checked>
+                <label for="quantize_source_original">Original upload</label>
+                <input type="radio" name="quantize-source" value="converted" id="quantize_source_converted">
+                <label for="quantize_source_converted" title="Runs the selected quantize method on the Convert section's own simplify/optimize output, so it applies to already-simplified graphs (e.g. fused Conv+BN, MatMul+Add -> Gemm) rather than the raw upload. Run Simplify/Optimize above first.">onnxsim-simplified (Convert section result)</label>
+            </div>
+            <p class="tool-note">Pick a method:</p>
             <ul class="tool-note">
                 <li><b>Dynamic</b> -- MatMul/Gemm weights are quantized to INT8
                     ahead of time; the activation is quantized at inference time
@@ -346,15 +358,19 @@ agraph (float[N] X) =&gt; (float[N] Y) {
             <div id="quantize-metrics" style="display: none; margin-top: 0.4em;"></div>
         </div>
         <script type="module" src="./quantize_ui.mjs"></script>
-        <h2 id="sec-visualize">Visualize with Netron (before / after)</h2>
+        <h2 id="sec-visualize">Visualize with Netron (original / onnxsim / quantized)</h2>
         <p>
             Renders the model graph with a self-hosted
-            <a href="https://github.com/onnxsim/netron" target="_blank" rel="noopener">Netron</a>:
-            the original model on the left and the simplified/optimized result on
-            the right, so you can compare them side by side. Nothing is uploaded —
-            the model bytes are posted straight into the embedded Netron in your
-            browser, so there is no model-size limit. Use <b>export SVG</b> to save
-            the rendered graph as an SVG image.
+            <a href="https://github.com/onnxsim/netron" target="_blank" rel="noopener">Netron</a>,
+            one pane per pipeline stage, so you can compare them side by side:
+            the original upload, the Convert section's simplify/optimize
+            result, and the Quantize panel's result (independent of the
+            middle pane -- quantizing never overwrites it, see the Quantize
+            panel above). A pane stays empty until that stage has actually
+            run. Nothing is uploaded — the model bytes are posted straight
+            into the embedded Netron in your browser, so there is no
+            model-size limit. Use <b>export SVG</b> to save the rendered
+            graph as an SVG image.
         </p>
         <p class="macs-note">
             Netron is driven here purely as an embeddable model-preview component
@@ -384,6 +400,17 @@ agraph (float[N] X) =&gt; (float[N] Y) {
                 </div>
                 <iframe id="netron-after-frame" class="netron-frame" title="Netron — simplified model" style="display: none;"></iframe>
                 <div id="netron-after-note" class="netron-note"></div>
+            </div>
+            <div class="netron-pane">
+                <div class="netron-head">
+                    <strong>Quantized</strong> —
+                    <button id="netron-quantized-open" type="button" style="display: none;">open in a new tab ↗</button>
+                    <button id="netron-quantized-download" type="button" style="display: none;">download model ↓</button>
+                    <button id="netron-quantized-svg" type="button" style="display: none;">export SVG ↓</button>
+                    <button id="netron-quantized-png" type="button" style="display: none;">export PNG ↓</button>
+                </div>
+                <iframe id="netron-quantized-frame" class="netron-frame" title="Netron — quantized model" style="display: none;"></iframe>
+                <div id="netron-quantized-note" class="netron-note"></div>
             </div>
         </div>
         <script type="module" src="./netron_view.mjs"></script>
@@ -532,6 +559,7 @@ agraph (float[N] X) =&gt; (float[N] Y) {
             <select id="inference-source">
                 <option value="compare">compare (before vs after conversion)</option>
                 <option value="converted">converted (simplify/optimize output)</option>
+                <option value="quantized">quantized (Quantize panel output)</option>
                 <option value="original">original (uploaded)</option>
             </select>
             <label for="inference-ep">execution provider</label>

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -31,6 +31,7 @@
         <nav class="section-nav" aria-label="Jump to section">
             <a href="#sec-parse">Parse graph</a>
             <a href="#sec-convert">Convert</a>
+            <a href="#sec-quantize">Quantize</a>
             <a href="#sec-visualize">Netron</a>
             <a href="#sec-dims">Dynamic dims</a>
             <a href="#sec-console">Console</a>
@@ -273,6 +274,72 @@ agraph (float[N] X) =&gt; (float[N] Y) {
             <div id="pass-list" style="height: 300px; overflow-y: auto; border: 1px solid var(--border); border-radius: var(--radius); padding: 4px; margin-top: 4px;"></div>
         </div>
         </section>
+        <h2 id="sec-quantize">Quantize a model</h2>
+        <div class="tool-panel">
+            <p class="tool-note">
+                Quantizes the currently loaded model (the uploaded file, or one
+                loaded from Hugging Face / a backend test case / a parsed text
+                graph above) with onnxsim's WebAssembly module, entirely in your
+                browser -- nothing is uploaded. Pick a method:
+            </p>
+            <ul class="tool-note">
+                <li><b>Dynamic</b> -- MatMul/Gemm weights are quantized to INT8
+                    ahead of time; the activation is quantized at inference time
+                    via <code>DynamicQuantizeLinear</code>. No calibration
+                    needed.</li>
+                <li><b>Ternary</b> -- like Dynamic, but for weights whose values
+                    are already (approximately) ternary
+                    (<code>{-1, 0, 1} × scale</code>), e.g. BitNet-style models.
+                    No calibration needed.</li>
+                <li><b>Weight-only</b> / <b>Weight-only INT4</b> -- only the
+                    weight is quantized (INT8 / block-wise INT4); the activation
+                    is never touched. No calibration needed, smallest download,
+                    but needs a runtime that supports on-the-fly dequantization.</li>
+                <li><b>Static (QDQ)</b> -- MatMul/Gemm/Conv are wrapped in
+                    <code>QuantizeLinear</code>/<code>DequantizeLinear</code>
+                    pairs using a <i>calibrated</i> activation range; the graph
+                    still computes in float32, and a QDQ-aware runtime fuses the
+                    pattern into an integer kernel. Needs calibration (below).</li>
+                <li><b>QOperator</b> -- MatMul/Gemm are replaced outright with
+                    <code>QLinearMatMul</code>, computing directly in int8; also
+                    needs a calibrated <i>output</i> range, not just the
+                    activation. Needs calibration (below).</li>
+            </ul>
+            <p class="tool-note">
+                <b>Calibration</b> (Static/QOperator only) runs the model over a
+                few batches of synthetic random input through
+                <a href="https://github.com/microsoft/onnxruntime" target="_blank" rel="noopener">onnxruntime-web</a>
+                (downloaded on demand, same as the "Run inference" panel below)
+                to observe each quantizable tensor's actual value range -- the
+                same approach <code>onnxsim.calibrate()</code> uses in Python,
+                just run here in the browser instead. Random data is a
+                reasonable stand-in when representative data isn't at hand, but
+                real calibration data (e.g. via the Python API) usually gives
+                tighter, more accurate ranges.
+            </p>
+            <div class="convert-modes quantize-modes">
+                <input type="radio" name="quantize-method" value="dynamic" id="quantize_dynamic" checked>
+                <label for="quantize_dynamic">Dynamic</label>
+                <input type="radio" name="quantize-method" value="ternary" id="quantize_ternary">
+                <label for="quantize_ternary">Ternary</label>
+                <input type="radio" name="quantize-method" value="weight_only" id="quantize_weight_only">
+                <label for="quantize_weight_only">Weight-only</label>
+                <input type="radio" name="quantize-method" value="weight_only_int4" id="quantize_weight_only_int4">
+                <label for="quantize_weight_only_int4">Weight-only INT4</label>
+                <input type="radio" name="quantize-method" value="static" id="quantize_static">
+                <label for="quantize_static">Static (QDQ)</label>
+                <input type="radio" name="quantize-method" value="qoperator" id="quantize_qoperator">
+                <label for="quantize_qoperator">QOperator (QLinearMatMul)</label>
+            </div>
+            <label for="quantize-samples">calibration samples (Static / QOperator only)</label>
+            <input type="number" id="quantize-samples" value="8" min="1" max="64" step="1" style="width: 4em;">
+            <div class="debug-actions">
+                <button id="quantize-button" type="button">Quantize</button>
+                <button id="quantize-download" type="button" style="display: none;">download model ↓</button>
+                <span id="quantize-status" class="tool-note"></span>
+            </div>
+        </div>
+        <script type="module" src="./quantize_ui.mjs"></script>
         <h2 id="sec-visualize">Visualize with Netron (before / after)</h2>
         <p>
             Renders the model graph with a self-hosted

--- a/scripts/convertmodel/inference_browser.mjs
+++ b/scripts/convertmodel/inference_browser.mjs
@@ -283,9 +283,11 @@ export async function resolveOriginalModelBytes(fileInput) {
 }
 
 // Resolve the model bytes for the chosen source. "converted" uses the bytes
-// the converter page published on window.__onnxsimConverted; "original"
-// delegates to resolveOriginalModelBytes. Returns { bytes, label, name } or
-// throws with a user-facing message.
+// the converter page published on window.__onnxsimConverted; "quantized"
+// uses window.__onnxsimQuantized (the Quantize panel's own output, kept
+// independent of "converted" -- see quantize_ui.mjs); "original" delegates
+// to resolveOriginalModelBytes. Returns { bytes, label, name } or throws
+// with a user-facing message.
 async function resolveModelBytes(source, fileInput) {
   if (source === "converted") {
     const converted = window.__onnxsimConverted;
@@ -297,6 +299,16 @@ async function resolveModelBytes(source, fileInput) {
       );
     }
     return { bytes: converted.bytes, label: `converted (${converted.name})`, name: converted.name };
+  }
+  if (source === "quantized") {
+    const quantized = window.__onnxsimQuantized;
+    if (!quantized || !quantized.bytes) {
+      throw new Error(
+        "no quantized model yet — quantize a model in the Quantize panel " +
+          "above first, or switch the model dropdown to 'original'/'converted'.",
+      );
+    }
+    return { bytes: quantized.bytes, label: `quantized (${quantized.name})`, name: quantized.name };
   }
   return resolveOriginalModelBytes(fileInput);
 }

--- a/scripts/convertmodel/inference_browser.mjs
+++ b/scripts/convertmodel/inference_browser.mjs
@@ -43,7 +43,9 @@ const ALL_FILL_MODES = [...INPUT_FILL_MODES, "sample"];
 
 const ORT_BUNDLE = { default: "ort.min.mjs", all: "ort.all.min.mjs" };
 const ortPromises = {};
-function loadOrt(variant = "default") {
+// Exported for quantize_calibration.mjs -- calibrating Static/QOperator
+// quantization needs the same on-demand onnxruntime-web load this panel uses.
+export function loadOrt(variant = "default") {
   if (!ortPromises[variant]) {
     const file = ORT_BUNDLE[variant] || ORT_BUNDLE.default;
     ortPromises[variant] = import(/* @vite-ignore */ `${ORT_BASE}${file}`).then((m) => {
@@ -99,7 +101,9 @@ function concreteShape(shape, batch = 1) {
 // fetched image/sentence in the "sample data" input/output preview once the
 // run finishes — the same context reference is reused across every input a
 // model has, so a multi-input model shares one fetched sample.
-async function makeDummyInputs(ort, session, batch = 1, fill = "zero", modelName = null, sampleCtx = null, log = () => {}) {
+// Exported for quantize_calibration.mjs, which reuses this to build the
+// synthetic random calibration batches Static/QOperator quantization needs.
+export async function makeDummyInputs(ort, session, batch = 1, fill = "zero", modelName = null, sampleCtx = null, log = () => {}) {
   const feeds = {};
   for (const meta of session.inputMetadata) {
     if (!meta.isTensor) {
@@ -234,29 +238,17 @@ async function runCompare(
   return cmp;
 }
 
-// Resolve the model bytes for the chosen source. "converted" uses the bytes the
-// converter page published on window.__onnxsimConverted; "original" reads the
-// file input, falling back to a model loaded from Hugging Face (published on
-// window.__onnxsimOriginal, which has no file-input entry). Returns
-// { bytes, label, name } or throws with a user-facing message. `name` is the
-// plain filename (no "converted (...)"/"original (...)" wrapping), used to
-// look up a tokenizer family for the sample-data fill mode.
-async function resolveModelBytes(source, fileInput) {
-  if (source === "converted") {
-    const converted = window.__onnxsimConverted;
-    if (!converted || !converted.bytes) {
-      throw new Error(
-        "no converted model yet — pick a file (or load one from Hugging " +
-          "Face) above to run a conversion first, or switch the model " +
-          "dropdown to 'original'.",
-      );
-    }
-    return { bytes: converted.bytes, label: `converted (${converted.name})`, name: converted.name };
-  }
+// Resolve the "original" model bytes + a display name from either a local
+// file upload or a model loaded from elsewhere on the page (Hugging Face,
+// "parse a text graph", a backend test case -- none of which have a
+// file-input entry, and all publish themselves on window.__onnxsimOriginal).
+// Returns { bytes, label, name } or throws with a user-facing message. `name`
+// is the plain filename (no "original (...)" wrapping), used to look up a
+// tokenizer family for the sample-data fill mode. Exported for
+// quantize_ui.mjs, which quantizes whatever model is currently loaded the
+// same way this panel runs inference on it.
+export async function resolveOriginalModelBytes(fileInput) {
   const file = fileInput.files && fileInput.files[0];
-  // Resolve the "original" bytes + a display name from either a local file
-  // upload or a Hugging Face download (which has no file-input entry, and
-  // publishes itself on window.__onnxsimOriginal).
   let name = null;
   let readBytes = null;
   if (file) {
@@ -288,6 +280,25 @@ async function resolveModelBytes(source, fileInput) {
     };
   }
   return { bytes: await readBytes(), label: `original (${name})`, name };
+}
+
+// Resolve the model bytes for the chosen source. "converted" uses the bytes
+// the converter page published on window.__onnxsimConverted; "original"
+// delegates to resolveOriginalModelBytes. Returns { bytes, label, name } or
+// throws with a user-facing message.
+async function resolveModelBytes(source, fileInput) {
+  if (source === "converted") {
+    const converted = window.__onnxsimConverted;
+    if (!converted || !converted.bytes) {
+      throw new Error(
+        "no converted model yet — pick a file (or load one from Hugging " +
+          "Face) above to run a conversion first, or switch the model " +
+          "dropdown to 'original'.",
+      );
+    }
+    return { bytes: converted.bytes, label: `converted (${converted.name})`, name: converted.name };
+  }
+  return resolveOriginalModelBytes(fileInput);
 }
 
 // Render the onnxsim MAC/FLOP metrics (onnxsim PR #527) that travel inside the

--- a/scripts/convertmodel/interface.cpp
+++ b/scripts/convertmodel/interface.cpp
@@ -816,6 +816,160 @@ std::vector<std::string> onnxoptimizer_fuse_elimination_passes() {
     return onnx::optimization::GetFuseAndEliminationPass();
 }
 
+// Converts parallel JS arrays -- ``names_ary`` (tensor names) and
+// ``ranges_flat_ary`` (a flat [min0, max0, min1, max1, ...] array, twice the
+// length of ``names_ary``) -- into the calibration-ranges map
+// QuantizeStatic/QuantizeQOperator take. Flat parallel arrays (rather than a
+// JS object/Map bound through embind) match the batched, positional
+// convention already used at this C++/JS boundary elsewhere (see
+// js_model_executor.cpp / docs/wasm_ort_web.md).
+std::unordered_map<std::string, std::pair<float, float>>
+ParseCalibrationRanges(em::val names_ary, em::val ranges_flat_ary) {
+    std::vector<std::string> names = em::vecFromJSArray<std::string>(names_ary);
+    std::vector<float> flat = em::vecFromJSArray<float>(ranges_flat_ary);
+    std::unordered_map<std::string, std::pair<float, float>> ranges;
+    ranges.reserve(names.size());
+    for (size_t i = 0; i < names.size() && 2 * i + 1 < flat.size(); ++i) {
+        ranges.emplace(names[i], std::make_pair(flat[2 * i], flat[2 * i + 1]));
+    }
+    return ranges;
+}
+
+em::val onnxsim_quantize_dynamic(const std::string& data) {
+    onnx::ModelProto xmodel;
+    if (!xmodel.ParseFromArray(data.data(), data.size())) {
+        std::cerr << "Parse failed" << std::endl;
+        return em::val::null();
+    }
+    try {
+        return SerializeModel(QuantizeDynamic(xmodel));
+    } catch (const std::exception& e) {
+        std::cerr << "quantize_dynamic error: " << e.what() << std::endl;
+        return em::val::null();
+    }
+}
+
+em::val onnxsim_quantize_ternary(const std::string& data) {
+    onnx::ModelProto xmodel;
+    if (!xmodel.ParseFromArray(data.data(), data.size())) {
+        std::cerr << "Parse failed" << std::endl;
+        return em::val::null();
+    }
+    try {
+        return SerializeModel(QuantizeTernary(xmodel));
+    } catch (const std::exception& e) {
+        std::cerr << "quantize_ternary error: " << e.what() << std::endl;
+        return em::val::null();
+    }
+}
+
+em::val onnxsim_quantize_weight_only(const std::string& data) {
+    onnx::ModelProto xmodel;
+    if (!xmodel.ParseFromArray(data.data(), data.size())) {
+        std::cerr << "Parse failed" << std::endl;
+        return em::val::null();
+    }
+    try {
+        return SerializeModel(QuantizeWeightOnly(xmodel));
+    } catch (const std::exception& e) {
+        std::cerr << "quantize_weight_only error: " << e.what() << std::endl;
+        return em::val::null();
+    }
+}
+
+em::val onnxsim_quantize_weight_only_int4(const std::string& data) {
+    onnx::ModelProto xmodel;
+    if (!xmodel.ParseFromArray(data.data(), data.size())) {
+        std::cerr << "Parse failed" << std::endl;
+        return em::val::null();
+    }
+    try {
+        return SerializeModel(QuantizeWeightOnlyInt4(xmodel));
+    } catch (const std::exception& e) {
+        std::cerr << "quantize_weight_only_int4 error: " << e.what() << std::endl;
+        return em::val::null();
+    }
+}
+
+// Both list_* functions below are used by the page to discover which tensor
+// names to calibrate (run the model over sample inputs and record each
+// tensor's observed min/max) before calling quantize_static/quantize_qoperator.
+std::vector<std::string> onnxsim_list_quantizable_activations(const std::string& data) {
+    onnx::ModelProto xmodel;
+    if (!xmodel.ParseFromArray(data.data(), data.size())) {
+        std::cerr << "Parse failed" << std::endl;
+        return {};
+    }
+    return ListQuantizableActivations(xmodel);
+}
+
+std::vector<std::string> onnxsim_list_qoperator_quantizable_outputs(const std::string& data) {
+    onnx::ModelProto xmodel;
+    if (!xmodel.ParseFromArray(data.data(), data.size())) {
+        std::cerr << "Parse failed" << std::endl;
+        return {};
+    }
+    return ListQOperatorQuantizableOutputs(xmodel);
+}
+
+// Appends a bare ValueInfoProto(name=name) graph output for every name in
+// ``names_ary`` not already an output, mirroring calibration.py's calibrate()
+// -- the page's browser-side calibration step needs onnxruntime-web to
+// compute and return each candidate tensor's value without changing the
+// graph otherwise, so it can observe the per-tensor (min, max) over the
+// sample inputs it feeds through. A bare ValueInfoProto with no type/shape is
+// a valid ONNX output (onnxruntime infers it from the run); this matches
+// calibrate()'s own onnx.ValueInfoProto(name=name) exactly.
+em::val onnxsim_add_graph_outputs(const std::string& data, em::val names_ary) {
+    onnx::ModelProto xmodel;
+    if (!xmodel.ParseFromArray(data.data(), data.size())) {
+        std::cerr << "Parse failed" << std::endl;
+        return em::val::null();
+    }
+    std::vector<std::string> names = em::vecFromJSArray<std::string>(names_ary);
+    onnx::GraphProto* graph = xmodel.mutable_graph();
+    std::set<std::string> existing_outputs;
+    for (const auto& vi : graph->output()) {
+        existing_outputs.insert(vi.name());
+    }
+    for (const auto& name : names) {
+        if (existing_outputs.insert(name).second) {
+            graph->add_output()->set_name(name);
+        }
+    }
+    return SerializeModel(xmodel);
+}
+
+em::val onnxsim_quantize_static(const std::string& data, em::val names_ary, em::val ranges_flat_ary) {
+    onnx::ModelProto xmodel;
+    if (!xmodel.ParseFromArray(data.data(), data.size())) {
+        std::cerr << "Parse failed" << std::endl;
+        return em::val::null();
+    }
+    try {
+        return SerializeModel(QuantizeStatic(
+            xmodel, ParseCalibrationRanges(names_ary, ranges_flat_ary)));
+    } catch (const std::exception& e) {
+        std::cerr << "quantize_static error: " << e.what() << std::endl;
+        return em::val::null();
+    }
+}
+
+em::val onnxsim_quantize_qoperator(const std::string& data, em::val names_ary, em::val ranges_flat_ary) {
+    onnx::ModelProto xmodel;
+    if (!xmodel.ParseFromArray(data.data(), data.size())) {
+        std::cerr << "Parse failed" << std::endl;
+        return em::val::null();
+    }
+    try {
+        return SerializeModel(QuantizeQOperator(
+            xmodel, ParseCalibrationRanges(names_ary, ranges_flat_ary)));
+    } catch (const std::exception& e) {
+        std::cerr << "quantize_qoperator error: " << e.what() << std::endl;
+        return em::val::null();
+    }
+}
+
 EMSCRIPTEN_BINDINGS(module) {
     function("onnxsimplify_export", &onnxsimplify_export);
     function("onnxsim_annotate_model_info", &onnxsim_annotate_model_info);
@@ -837,6 +991,20 @@ EMSCRIPTEN_BINDINGS(module) {
     em::function("onnxsim_infer_shapes", &onnxsim_infer_shapes);
     em::function("onnxsim_data_propagation", &onnxsim_data_propagation);
     em::function("onnxsim_fold_constant", &onnxsim_fold_constant);
+
+    // Calibration-free quantization methods (no activation ranges needed).
+    function("onnxsim_quantize_dynamic", &onnxsim_quantize_dynamic);
+    function("onnxsim_quantize_ternary", &onnxsim_quantize_ternary);
+    function("onnxsim_quantize_weight_only", &onnxsim_quantize_weight_only);
+    function("onnxsim_quantize_weight_only_int4", &onnxsim_quantize_weight_only_int4);
+    // Calibration-based quantization: list_* discovers which tensors to
+    // calibrate, quantize_static/quantize_qoperator take the calibrated
+    // ranges back as parallel [name] / [min0, max0, min1, max1, ...] arrays.
+    em::function("onnxsim_list_quantizable_activations", &onnxsim_list_quantizable_activations);
+    em::function("onnxsim_list_qoperator_quantizable_outputs", &onnxsim_list_qoperator_quantizable_outputs);
+    function("onnxsim_add_graph_outputs", &onnxsim_add_graph_outputs);
+    function("onnxsim_quantize_static", &onnxsim_quantize_static);
+    function("onnxsim_quantize_qoperator", &onnxsim_quantize_qoperator);
 
     em::register_vector<std::string>("string_list");
 }

--- a/scripts/convertmodel/netron_view.mjs
+++ b/scripts/convertmodel/netron_view.mjs
@@ -94,6 +94,7 @@ function driveNetron(target, buffer, name, onStatus) {
 const panes = {
   before: { buffer: null, name: "", teardown: null, loading: false, loaded: false },
   after: { buffer: null, name: "", teardown: null, loading: false, loaded: false },
+  quantized: { buffer: null, name: "", teardown: null, loading: false, loaded: false },
 };
 
 // Point one pane ("before" | "after") at a model, embedding it inline and
@@ -308,6 +309,17 @@ function initNetronPanel() {
       renderPane("after", dataUrlToArrayBuffer(dataUrl), name);
     } catch (err) {
       console.error("netron (after):", err);
+    }
+  };
+
+  // Called by quantize_ui.mjs when a quantize finishes. Deliberately separate
+  // from netronShowAfter -- the Quantize panel's result stays independent of
+  // the Convert section's plain simplify/optimize output (see quantize_ui.mjs).
+  window.netronShowQuantized = (dataUrl, name) => {
+    try {
+      renderPane("quantized", dataUrlToArrayBuffer(dataUrl), name);
+    } catch (err) {
+      console.error("netron (quantized):", err);
     }
   };
 }

--- a/scripts/convertmodel/quantize_calibration.mjs
+++ b/scripts/convertmodel/quantize_calibration.mjs
@@ -1,0 +1,74 @@
+// Browser-side calibration for onnxsim's calibration-based quantization
+// methods (Static / QOperator, see quantize_ui.mjs): runs the model over
+// synthetic random inputs through onnxruntime-web and records each candidate
+// tensor's observed (min, max) -- the same shape of work
+// onnxsim.calibration.calibrate() does in Python (onnxsim/calibration.py),
+// driven entirely in the browser instead: no Python, no server round trip.
+//
+// The WASM module itself never runs inference for this step: onnxsim's own
+// constant-folding executor only evaluates throwaway sub-models, not a full
+// forward pass with arbitrary extra outputs. Instead, runtime.onnxsim_add_graph_outputs
+// (see interface.cpp) exposes each candidate tensor as an extra graph output
+// -- a bare ValueInfoProto with no type/shape, exactly like calibrate()'s own
+// onnx.ValueInfoProto(name=name) -- and onnxruntime-web (already loaded on
+// this page for the "Run inference" panel) actually executes the augmented
+// model to observe them.
+
+import { loadOrt, makeDummyInputs } from "./inference_browser.mjs";
+
+// Calibrates `tensorNames` (from runtime.onnxsim_list_quantizable_activations
+// / _list_qoperator_quantizable_outputs) over `numSamples` random input
+// batches. Returns { names, flat }: `names` is the list of tensor names
+// actually observed (a tensor with no data in any run, e.g. from a
+// zero-sized dim, is dropped), and `flat` is a plain array of
+// [min0, max0, min1, max1, ...] in the same order -- exactly the shape
+// runtime.onnxsim_quantize_static / _quantize_qoperator expect.
+export async function calibrateRanges(runtime, modelBuf, tensorNames, numSamples = 8, log = () => {}) {
+  if (!tensorNames || tensorNames.length === 0) {
+    return { names: [], flat: [] };
+  }
+  const augmented = runtime.onnxsim_add_graph_outputs(modelBuf, tensorNames);
+  if (!augmented) {
+    throw new Error("failed to prepare the model for calibration (add_graph_outputs)");
+  }
+  // Copy out of the wasm heap right away -- the view is invalidated by the
+  // next wasm call, and onnxruntime-web needs its own stable copy anyway.
+  const augmentedBytes = new Uint8Array(augmented).slice();
+
+  const ort = await loadOrt();
+  const sess = await ort.InferenceSession.create(augmentedBytes, {
+    executionProviders: ["wasm"],
+  });
+  const wanted = new Set(tensorNames);
+  const ranges = new Map();
+  for (let i = 0; i < numSamples; i++) {
+    log(`calibrating: sample ${i + 1}/${numSamples}…`);
+    // "random" (a seeded xorshift32, see input_fill.mjs) rather than
+    // "zeros"/"sample": a fixed input would collapse every tensor's observed
+    // range to a single point, and "sample" would need network fetches this
+    // background calibration step shouldn't depend on.
+    const feeds = await makeDummyInputs(ort, sess, 1, "random", null, null, log);
+    const outputs = await sess.run(feeds);
+    for (const name of sess.outputNames) {
+      if (!wanted.has(name)) continue;
+      const data = outputs[name] && outputs[name].data;
+      if (!data || data.length === 0) continue;
+      let mn = Infinity;
+      let mx = -Infinity;
+      for (let j = 0; j < data.length; j++) {
+        const v = Number(data[j]);
+        if (v < mn) mn = v;
+        if (v > mx) mx = v;
+      }
+      const prev = ranges.get(name);
+      ranges.set(name, prev ? [Math.min(prev[0], mn), Math.max(prev[1], mx)] : [mn, mx]);
+    }
+  }
+  const names = Array.from(ranges.keys());
+  const flat = [];
+  for (const name of names) {
+    const [mn, mx] = ranges.get(name);
+    flat.push(mn, mx);
+  }
+  return { names, flat };
+}

--- a/scripts/convertmodel/quantize_metrics.mjs
+++ b/scripts/convertmodel/quantize_metrics.mjs
@@ -1,0 +1,124 @@
+// Result-quality metrics for a quantized model, shown in the "Quantize a
+// model" panel (quantize_ui.mjs) after a successful quantize: how much
+// smaller the model got, and how far its outputs drift from the float
+// baseline on the same random input.
+//
+// The drift metrics -- relative L2 error and SQNR (signal-to-quantization-
+// noise ratio) -- mirror the aggregate-error check onnxsim's own Python
+// quantization test suite uses (e.g. tests/test_qoperator_quantize_matmul.py's
+// _assert_close: relative L2 error, not a tight per-element bound, since
+// quantization is lossy by design and a handful of elements at the rounding
+// boundary are expected), computed here in the browser via onnxruntime-web
+// instead of onnxruntime.
+
+import { loadOrt, makeDummyInputs } from "./inference_browser.mjs";
+import { compareInference } from "./inference_core.mjs";
+
+// Relative L2 error (||f - q|| / ||f||) and SQNR in dB
+// (20*log10(||f|| / ||f-q||)) between two same-length flat arrays.
+function errorMetrics(floatData, quantData) {
+  let sumSqDiff = 0;
+  let sumSqFloat = 0;
+  let maxAbs = 0;
+  const n = Math.min(floatData.length, quantData.length);
+  for (let i = 0; i < n; i++) {
+    const f = Number(floatData[i]);
+    const q = Number(quantData[i]);
+    const d = f - q;
+    sumSqDiff += d * d;
+    sumSqFloat += f * f;
+    maxAbs = Math.max(maxAbs, Math.abs(d));
+  }
+  const l2Float = Math.sqrt(sumSqFloat);
+  const l2Diff = Math.sqrt(sumSqDiff);
+  const relL2 = l2Diff / Math.max(l2Float, 1e-6);
+  const sqnrDb = l2Diff > 0 ? 20 * Math.log10(Math.max(l2Float, 1e-12) / l2Diff) : Infinity;
+  return { relL2, sqnrDb, maxAbsDiff: maxAbs };
+}
+
+// Runs `floatBytes` (the original model) and `quantBytes` (the quantized
+// result) on the same synthetic random input through onnxruntime-web and
+// returns a result-quality summary:
+// { sizeBefore, sizeAfter, sizeReductionPct, ep, relL2, sqnrDb, maxAbsDiff,
+//   dimsMatch }.
+// Best-effort by design: the caller should treat a thrown error (e.g. no
+// usable execution provider, or an input onnxruntime-web can't auto-fill)
+// as "quality metrics unavailable" and not block the quantized model's
+// availability on it -- the model is already valid and downloadable either
+// way.
+export async function computeQuantizationQuality(floatBytes, quantBytes, log = () => {}) {
+  const ort = await loadOrt();
+  const metaSession = await ort.InferenceSession.create(floatBytes, {
+    executionProviders: ["wasm"],
+  });
+  const feeds = await makeDummyInputs(ort, metaSession, 1, "random", null, null, log);
+
+  const cmp = await compareInference(ort, {
+    before: { model: floatBytes, label: "float" },
+    after: { model: quantBytes, label: "quantized" },
+    feeds,
+    providers: ["wasm"],
+    iterations: 1,
+    warmup: 0,
+    // compareInference's own "equivalent" (maxAbsDiff <= tolerance) isn't
+    // useful here -- quantization is lossy by design, so it's expected to
+    // read false under any tight tolerance. The metrics below (relative L2,
+    // SQNR) are the actual quality signal; Infinity just keeps "equivalent"
+    // from reading as a spurious failure if a caller ever inspects it.
+    tolerance: Infinity,
+    onLog: log,
+  });
+
+  if (!cmp.comparable) {
+    throw new Error("quantized model's output shape/length doesn't match the float model's");
+  }
+
+  const { relL2, sqnrDb, maxAbsDiff } = errorMetrics(cmp.before.output, cmp.after.output);
+  const sizeBefore = floatBytes.length;
+  const sizeAfter = quantBytes.length;
+  return {
+    sizeBefore,
+    sizeAfter,
+    sizeReductionPct: sizeBefore > 0 ? (1 - sizeAfter / sizeBefore) * 100 : 0,
+    ep: cmp.after.ep,
+    relL2,
+    sqnrDb,
+    maxAbsDiff,
+    dimsMatch: cmp.dimsMatch,
+  };
+}
+
+function humanBytes(n) {
+  if (n < 1024) return `${n} B`;
+  const units = ["KB", "MB", "GB"];
+  let v = n / 1024;
+  let u = 0;
+  while (v >= 1024 && u < units.length - 1) {
+    v /= 1024;
+    u++;
+  }
+  return `${v.toFixed(v < 10 ? 2 : 1)} ${units[u]}`;
+}
+
+// Renders computeQuantizationQuality()'s result as a small HTML table
+// (a plain string -- the caller assigns it to an element's innerHTML). All
+// interpolated values are our own computed numbers/labels, never
+// user-supplied text.
+export function renderQuantizationQuality(q) {
+  const sizeRow = `${humanBytes(q.sizeBefore)} → ${humanBytes(q.sizeAfter)} (${q.sizeReductionPct >= 0 ? "−" : "+"}${Math.abs(q.sizeReductionPct).toFixed(1)}%)`;
+  const sqnrText = Number.isFinite(q.sqnrDb) ? `${q.sqnrDb.toFixed(1)} dB` : "∞ dB (bit-exact on this sample)";
+  return `
+    <table style="border-collapse: collapse; font-size: 0.85em;">
+      <tr><td style="padding: 2px 0.8em 2px 0; color: var(--muted);">Model size</td><td>${sizeRow}</td></tr>
+      <tr><td style="padding: 2px 0.8em 2px 0; color: var(--muted);">Execution provider</td><td>${q.ep}</td></tr>
+      <tr><td style="padding: 2px 0.8em 2px 0; color: var(--muted);">Relative L2 error</td><td>${(q.relL2 * 100).toFixed(2)}%</td></tr>
+      <tr><td style="padding: 2px 0.8em 2px 0; color: var(--muted);">SQNR</td><td>${sqnrText}</td></tr>
+      <tr><td style="padding: 2px 0.8em 2px 0; color: var(--muted);">Max abs diff</td><td>${q.maxAbsDiff.toPrecision(4)}</td></tr>
+    </table>
+    <p class="tool-note" style="margin-top: 0.3em;">
+      Measured on one synthetic random input (not representative calibration
+      data) via onnxruntime-web -- a quick sanity check, not a rigorous
+      accuracy evaluation. Relative L2 error and SQNR are computed the same
+      way onnxsim's own Python quantization tests check result quality.
+    </p>`;
+}

--- a/scripts/convertmodel/quantize_ui.mjs
+++ b/scripts/convertmodel/quantize_ui.mjs
@@ -21,6 +21,7 @@
 import { downloadBytes } from "./download.mjs";
 import { resolveOriginalModelBytes } from "./inference_browser.mjs";
 import { calibrateRanges } from "./quantize_calibration.mjs";
+import { computeQuantizationQuality, renderQuantizationQuality } from "./quantize_metrics.mjs";
 
 // Resolve this page's WASM runtime (published by index.html's inline loader).
 function getRuntime() {
@@ -51,6 +52,8 @@ function initQuantizePanel() {
   const statusEl = document.getElementById("quantize-status");
   const dlBtn = document.getElementById("quantize-download");
   const samplesEl = document.getElementById("quantize-samples");
+  const metricsToggleEl = document.getElementById("quantize-metrics-toggle");
+  const metricsEl = document.getElementById("quantize-metrics");
 
   const setStatus = (msg) => {
     if (statusEl) statusEl.textContent = msg;
@@ -63,6 +66,10 @@ function initQuantizePanel() {
     const method = methodEl ? methodEl.value : "dynamic";
     btn.disabled = true;
     if (dlBtn) dlBtn.style.display = "none";
+    if (metricsEl) {
+      metricsEl.style.display = "none";
+      metricsEl.innerHTML = "";
+    }
     try {
       setStatus("loading model…");
       const { bytes, name } = await resolveOriginalModelBytes(fileInput);
@@ -124,6 +131,30 @@ function initQuantizePanel() {
       // inference panel's "converted" source, same as a Simplify/Optimize run.
       if (window.netronShowAfter) window.netronShowAfter(dataUrl, outName);
       window.__onnxsimConverted = { bytes: outBytes, name: outName };
+
+      // Best-effort result-quality report: runs float vs. quantized on the
+      // same random input through onnxruntime-web. A failure here (e.g. no
+      // usable execution provider, or an input shape onnxruntime-web can't
+      // auto-fill) shouldn't take away the quantized model itself, which is
+      // already valid and downloadable at this point -- so it only appends a
+      // note to the status line rather than replacing it or throwing.
+      if (!metricsToggleEl || metricsToggleEl.checked) {
+        try {
+          setStatus(`done (${outBytes.length.toLocaleString()} bytes). measuring result quality…`);
+          const quality = await computeQuantizationQuality(bytes, outBytes, setStatus);
+          if (metricsEl) {
+            metricsEl.innerHTML = renderQuantizationQuality(quality);
+            metricsEl.style.display = "";
+          }
+          setStatus(`done (${outBytes.length.toLocaleString()} bytes).`);
+        } catch (metricsErr) {
+          setStatus(
+            `done (${outBytes.length.toLocaleString()} bytes). ` +
+              "result-quality check failed: " +
+              (metricsErr && metricsErr.message ? metricsErr.message : metricsErr),
+          );
+        }
+      }
     } catch (err) {
       setStatus("quantize error: " + (err && err.message ? err.message : err));
     } finally {

--- a/scripts/convertmodel/quantize_ui.mjs
+++ b/scripts/convertmodel/quantize_ui.mjs
@@ -1,0 +1,135 @@
+// Browser glue for the "Quantize a model" panel on the converter page.
+//
+// Runs one of onnxsim's quantization methods on the currently loaded model
+// (see resolveOriginalModelBytes in inference_browser.mjs), entirely in the
+// browser -- nothing is uploaded:
+//   - Dynamic / Ternary / Weight-only / Weight-only INT4 need no calibration
+//     data, so it's a single WASM call.
+//   - Static (QDQ) / QOperator (QLinearMatMul) are calibration-based: the
+//     candidate tensor names come from the WASM module
+//     (onnxsim_list_quantizable_activations / _list_qoperator_quantizable_outputs),
+//     and their (min, max) ranges are measured by actually running the model
+//     over synthetic random inputs through onnxruntime-web
+//     (quantize_calibration.mjs), mirroring onnxsim.calibration.calibrate().
+//
+// Like debug_tools.mjs's "parse a text graph" panel, the quantization
+// rewrites themselves need no model executor, so they run on this page's own
+// WASM runtime directly (no worker round trip, unlike Simplify/Optimize) --
+// only the Static/QOperator calibration step needs onnxruntime-web, loaded on
+// demand the same way the "Run inference" panel does.
+
+import { downloadBytes } from "./download.mjs";
+import { resolveOriginalModelBytes } from "./inference_browser.mjs";
+import { calibrateRanges } from "./quantize_calibration.mjs";
+
+// Resolve this page's WASM runtime (published by index.html's inline loader).
+function getRuntime() {
+  return window.__onnxsimRuntimePromise;
+}
+
+// Methods that quantize straight from a single WASM call -- the weight is
+// quantized from its own static values and the activation either isn't
+// touched (weight-only) or is quantized dynamically at inference time
+// (dynamic/ternary), so no calibration data is needed.
+const NO_CALIBRATION_METHODS = {
+  dynamic: "onnxsim_quantize_dynamic",
+  ternary: "onnxsim_quantize_ternary",
+  weight_only: "onnxsim_quantize_weight_only",
+  weight_only_int4: "onnxsim_quantize_weight_only_int4",
+};
+
+function toArray(vec) {
+  const out = new Array(vec.size());
+  for (let i = 0; i < out.length; i++) out[i] = vec.get(i);
+  return out;
+}
+
+function initQuantizePanel() {
+  const btn = document.getElementById("quantize-button");
+  if (!btn) return;
+  const fileInput = document.getElementById("file-input");
+  const statusEl = document.getElementById("quantize-status");
+  const dlBtn = document.getElementById("quantize-download");
+  const samplesEl = document.getElementById("quantize-samples");
+
+  const setStatus = (msg) => {
+    if (statusEl) statusEl.textContent = msg;
+  };
+
+  let lastBytes = null;
+
+  btn.addEventListener("click", async () => {
+    const methodEl = document.querySelector('input[name="quantize-method"]:checked');
+    const method = methodEl ? methodEl.value : "dynamic";
+    btn.disabled = true;
+    if (dlBtn) dlBtn.style.display = "none";
+    try {
+      setStatus("loading model…");
+      const { bytes, name } = await resolveOriginalModelBytes(fileInput);
+      // A fresh ArrayBuffer copy: the WASM calls below read it (never
+      // transferred/detached), and it's reused across several calls when
+      // calibrating.
+      const modelBuf = bytes.slice().buffer;
+      const runtime = await getRuntime();
+
+      let resultBuf;
+      if (method in NO_CALIBRATION_METHODS) {
+        setStatus(`quantizing (${method})…`);
+        resultBuf = runtime[NO_CALIBRATION_METHODS[method]](modelBuf);
+      } else if (method === "static" || method === "qoperator") {
+        setStatus("finding quantizable tensors…");
+        let names = toArray(runtime.onnxsim_list_quantizable_activations(modelBuf));
+        if (method === "qoperator") {
+          const outNames = toArray(runtime.onnxsim_list_qoperator_quantizable_outputs(modelBuf));
+          names = Array.from(new Set([...names, ...outNames]));
+        }
+        if (names.length === 0) {
+          setStatus(
+            "no quantizable MatMul/Gemm" + (method === "static" ? "/Conv" : "") +
+              " (with a constant float32 weight) found in this model.",
+          );
+          return;
+        }
+        const numSamples = Math.max(1, parseInt((samplesEl && samplesEl.value) || "8", 10) || 8);
+        setStatus(`calibrating ${names.length} tensor(s) over ${numSamples} random sample(s)…`);
+        const { names: calNames, flat } = await calibrateRanges(runtime, modelBuf, names, numSamples, setStatus);
+        if (calNames.length === 0) {
+          setStatus("calibration produced no ranges (the model may have no runnable inputs).");
+          return;
+        }
+        setStatus(`quantizing (${method})…`);
+        const fn = method === "static" ? "onnxsim_quantize_static" : "onnxsim_quantize_qoperator";
+        resultBuf = runtime[fn](modelBuf, calNames, flat);
+      } else {
+        setStatus(`unknown quantize method: ${method}`);
+        return;
+      }
+
+      if (!resultBuf) {
+        setStatus("quantization failed (see console for details).");
+        return;
+      }
+      // Copy out of the wasm heap and grab a base64 copy for Netron/inference
+      // before any other wasm call can invalidate the view.
+      const outBytes = new Uint8Array(resultBuf).slice();
+      const dataUrl = "data:application/octet-stream;base64," + resultBuf.toBase64();
+      lastBytes = outBytes;
+      const outName = name.replace(/\.onnx$/i, "") + `.quant_${method}.onnx`;
+      setStatus(`done (${outBytes.length.toLocaleString()} bytes).`);
+      if (dlBtn) {
+        dlBtn.style.display = "";
+        dlBtn.onclick = () => downloadBytes(lastBytes, outName);
+      }
+      // Show the result in the "After" Netron pane and publish it as the
+      // inference panel's "converted" source, same as a Simplify/Optimize run.
+      if (window.netronShowAfter) window.netronShowAfter(dataUrl, outName);
+      window.__onnxsimConverted = { bytes: outBytes, name: outName };
+    } catch (err) {
+      setStatus("quantize error: " + (err && err.message ? err.message : err));
+    } finally {
+      btn.disabled = false;
+    }
+  });
+}
+
+initQuantizePanel();

--- a/scripts/convertmodel/quantize_ui.mjs
+++ b/scripts/convertmodel/quantize_ui.mjs
@@ -1,7 +1,8 @@
 // Browser glue for the "Quantize a model" panel on the converter page.
 //
-// Runs one of onnxsim's quantization methods on the currently loaded model
-// (see resolveOriginalModelBytes in inference_browser.mjs), entirely in the
+// Runs one of onnxsim's quantization methods on either the original upload or
+// the Convert section's own simplify/optimize output (a "Quantize input"
+// radio picks which -- see resolveQuantizeInput below), entirely in the
 // browser -- nothing is uploaded:
 //   - Dynamic / Ternary / Weight-only / Weight-only INT4 need no calibration
 //     data, so it's a single WASM call.
@@ -11,6 +12,13 @@
 //     and their (min, max) ranges are measured by actually running the model
 //     over synthetic random inputs through onnxruntime-web
 //     (quantize_calibration.mjs), mirroring onnxsim.calibration.calibrate().
+//
+// The result is kept independent of the Convert section's own output: it is
+// published on window.__onnxsimQuantized (not window.__onnxsimConverted) and
+// shown in its own "Quantized" Netron pane (window.netronShowQuantized, not
+// netronShowAfter) -- so a user can inspect all three pipeline stages side by
+// side (original / onnxsim-simplified / quantized) rather than the quantized
+// result silently replacing the plain simplify/optimize one.
 //
 // Like debug_tools.mjs's "parse a text graph" panel, the quantization
 // rewrites themselves need no model executor, so they run on this page's own
@@ -22,6 +30,27 @@ import { downloadBytes } from "./download.mjs";
 import { resolveOriginalModelBytes } from "./inference_browser.mjs";
 import { calibrateRanges } from "./quantize_calibration.mjs";
 import { computeQuantizationQuality, renderQuantizationQuality } from "./quantize_metrics.mjs";
+
+// Resolves the model to quantize per the "Quantize input" radio: the raw
+// original upload, or the Convert section's own simplify/optimize output
+// (window.__onnxsimConverted, published by index.html's worker glue when a
+// conversion finishes) -- letting quantization run on an already-simplified
+// graph, where fused patterns (e.g. Conv+BN, MatMul+Add -> Gemm) match more
+// of what onnxsim's quantize passes look for. Throws a user-facing message
+// if "converted" is selected but nothing has been converted yet.
+async function resolveQuantizeInput(source, fileInput) {
+  if (source === "converted") {
+    const converted = window.__onnxsimConverted;
+    if (!converted || !converted.bytes) {
+      throw new Error(
+        "no onnxsim-simplified result yet -- run Simplify/Optimize in the " +
+          "Convert section above first, or switch back to 'Original upload'.",
+      );
+    }
+    return { bytes: converted.bytes, name: converted.name };
+  }
+  return resolveOriginalModelBytes(fileInput);
+}
 
 // Resolve this page's WASM runtime (published by index.html's inline loader).
 function getRuntime() {
@@ -64,6 +93,8 @@ function initQuantizePanel() {
   btn.addEventListener("click", async () => {
     const methodEl = document.querySelector('input[name="quantize-method"]:checked');
     const method = methodEl ? methodEl.value : "dynamic";
+    const sourceEl = document.querySelector('input[name="quantize-source"]:checked');
+    const source = sourceEl ? sourceEl.value : "original";
     btn.disabled = true;
     if (dlBtn) dlBtn.style.display = "none";
     if (metricsEl) {
@@ -72,7 +103,7 @@ function initQuantizePanel() {
     }
     try {
       setStatus("loading model…");
-      const { bytes, name } = await resolveOriginalModelBytes(fileInput);
+      const { bytes, name } = await resolveQuantizeInput(source, fileInput);
       // A fresh ArrayBuffer copy: the WASM calls below read it (never
       // transferred/detached), and it's reused across several calls when
       // calibrating.
@@ -127,10 +158,13 @@ function initQuantizePanel() {
         dlBtn.style.display = "";
         dlBtn.onclick = () => downloadBytes(lastBytes, outName);
       }
-      // Show the result in the "After" Netron pane and publish it as the
-      // inference panel's "converted" source, same as a Simplify/Optimize run.
-      if (window.netronShowAfter) window.netronShowAfter(dataUrl, outName);
-      window.__onnxsimConverted = { bytes: outBytes, name: outName };
+      // Show the result in its own "Quantized" Netron pane and publish it as
+      // the inference panel's "quantized" source -- deliberately independent
+      // of netronShowAfter/window.__onnxsimConverted (the Convert section's
+      // own output), so quantizing never clobbers the plain simplify/optimize
+      // result and all three stages stay inspectable side by side.
+      if (window.netronShowQuantized) window.netronShowQuantized(dataUrl, outName);
+      window.__onnxsimQuantized = { bytes: outBytes, name: outName };
 
       // Best-effort result-quality report: runs float vs. quantized on the
       // same random input through onnxruntime-web. A failure here (e.g. no

--- a/tests/test_qoperator_quantize_conv.py
+++ b/tests/test_qoperator_quantize_conv.py
@@ -1,0 +1,200 @@
+"""Tests for ``onnxsim.quantize_qoperator``'s Conv coverage (the
+``qoperator_quantize_conv`` C++ pass).
+
+Mirrors ``test_qoperator_quantize_matmul.py``: each model is built directly
+with ``onnx.helper``, calibrated with random data, quantized, and then
+actually run through ONNX Runtime -- both before and after quantization --
+so the quantized graph must load and execute under a real inference engine,
+and its outputs must stay close to the float baseline.
+"""
+
+import collections
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+
+import onnxsim
+
+# A bare ``import onnxruntime`` would fail collection (not skip the test) on
+# platforms onnxruntime doesn't ship wheels for (e.g. s390x).
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(nodes, inputs, outputs, initializer, opset=13):
+    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
+    # Pin a low IR version so the model loads under older onnxruntime builds
+    # (which cap at IR version 11), matching test_fusion_patterns.py.
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+    )
+
+
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _op_counts(model):
+    return collections.Counter(n.op_type for n in model.graph.node)
+
+
+def _assert_close(float_outputs, quant_outputs):
+    # INT8/uint8 quantization is lossy by design; see
+    # test_dynamic_quantize_matmul.py's identically-named helper for why this
+    # checks aggregate relative L2 error rather than a tight per-element bound.
+    for f, q in zip(float_outputs, quant_outputs):
+        f = np.asarray(f, dtype=np.float64).ravel()
+        q = np.asarray(q, dtype=np.float64).ravel()
+        assert np.all(np.isfinite(q))
+        rel_l2 = np.linalg.norm(f - q) / max(np.linalg.norm(f), 1e-6)
+        assert rel_l2 < 0.1, f"relative L2 error too large: {rel_l2:.4f}"
+
+
+def test_quantize_conv():
+    rng = np.random.default_rng(0)
+    cout, cin = 8, 3
+    weight = _f32(rng.standard_normal((cout, cin, 3, 3)) * 0.5, "W")
+    nodes = [
+        onnx.helper.make_node(
+            "Conv", ["X", "W"], ["Y"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
+        )
+    ]
+    model = _model(
+        nodes, [_vi("X", [1, cin, 16, 16])], [_vi("Y", [1, cout, 16, 16])], [weight]
+    )
+
+    quant = onnxsim.quantize_qoperator(model, num_calibration_samples=16, seed=0)
+    onnx.checker.check_model(quant)
+    ops = _op_counts(quant)
+    # Unlike quantize_static's QDQ format, the Conv node itself is replaced by
+    # QLinearConv -- no float Conv is left in the graph.
+    assert ops["Conv"] == 0
+    assert ops["QLinearConv"] == 1
+    assert ops["QuantizeLinear"] == 1
+    assert ops["DequantizeLinear"] == 1
+
+    x = rng.standard_normal((1, cin, 16, 16)).astype(np.float32)
+    _assert_close(_run(model, {"X": x}), _run(quant, {"X": x}))
+
+
+def test_quantize_conv_with_constant_bias():
+    # QLinearConv takes its bias pre-quantized to INT32 (unlike Gemm's, which
+    # is added back in float) -- only possible when the bias is a constant,
+    # like the weight.
+    rng = np.random.default_rng(1)
+    cout, cin = 4, 2
+    weight = _f32(rng.standard_normal((cout, cin, 3, 3)) * 0.5, "W")
+    bias = _f32(rng.standard_normal(cout), "B")
+    nodes = [
+        onnx.helper.make_node(
+            "Conv", ["X", "W", "B"], ["Y"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
+        )
+    ]
+    model = _model(
+        nodes,
+        [_vi("X", [2, cin, 8, 8])],
+        [_vi("Y", [2, cout, 8, 8])],
+        [weight, bias],
+    )
+
+    quant = onnxsim.quantize_qoperator(model, num_calibration_samples=16, seed=1)
+    onnx.checker.check_model(quant)
+    ops = _op_counts(quant)
+    assert ops["Conv"] == 0
+    assert ops["QLinearConv"] == 1
+    assert ops["QuantizeLinear"] == 1
+    assert ops["DequantizeLinear"] == 1
+    # The bias rides inside QLinearConv itself (pre-quantized to INT32), not
+    # a separate float Add the way qoperator_quantize_matmul.h's Gemm case
+    # needs.
+    assert ops["Add"] == 0
+    qlconv = next(n for n in quant.graph.node if n.op_type == "QLinearConv")
+    assert len(qlconv.input) == 9  # ... , y_scale, y_zero_point, B
+
+    x = rng.standard_normal((2, cin, 8, 8)).astype(np.float32)
+    _assert_close(_run(model, {"X": x}), _run(quant, {"X": x}))
+
+
+def test_quantize_skips_non_constant_conv_bias():
+    # The bias is a graph input, not a constant -- QLinearConv has no float
+    # fallback for it (unlike Gemm's bias in qoperator_quantize_matmul.h), so
+    # this Conv is left alone entirely.
+    weight = _f32(np.random.randn(4, 3, 3, 3).astype(np.float32), "W")
+    nodes = [onnx.helper.make_node("Conv", ["X", "W", "B"], ["Y"], kernel_shape=[3, 3])]
+    model = _model(
+        nodes,
+        [_vi("X", [1, 3, 8, 8]), _vi("B", [4])],
+        [_vi("Y", [1, 4, 6, 6])],
+        [weight],
+    )
+    quant = onnxsim.quantize_qoperator(model)
+    assert _op_counts(quant)["Conv"] == 1
+    assert _op_counts(quant)["QLinearConv"] == 0
+
+
+def test_quantize_skips_non_constant_conv_weight():
+    # Both Conv operands are graph inputs (neither is a constant), so there
+    # is nothing to quantize ahead of time.
+    nodes = [onnx.helper.make_node("Conv", ["X", "W"], ["Y"], kernel_shape=[3, 3])]
+    model = _model(
+        nodes,
+        [_vi("X", [1, 3, 8, 8]), _vi("W", [4, 3, 3, 3])],
+        [_vi("Y", [1, 4, 6, 6])],
+        [],
+    )
+    quant = onnxsim.quantize_qoperator(model)
+    assert _op_counts(quant)["Conv"] == 1
+    assert _op_counts(quant)["QLinearConv"] == 0
+
+
+def test_quantize_skips_old_opset_conv():
+    # QLinearConv needs opset >= 10.
+    weight = _f32(np.random.randn(4, 3, 3, 3).astype(np.float32), "W")
+    nodes = [onnx.helper.make_node("Conv", ["X", "W"], ["Y"], kernel_shape=[3, 3])]
+    model = _model(
+        nodes, [_vi("X", [1, 3, 8, 8])], [_vi("Y", [1, 4, 6, 6])], [weight], opset=9
+    )
+    quant = onnxsim.quantize_qoperator(model)
+    assert _op_counts(quant)["Conv"] == 1
+    assert _op_counts(quant)["QLinearConv"] == 0
+
+
+def test_list_qoperator_quantizable_outputs_includes_conv_output():
+    weight = _f32(np.random.randn(4, 3, 3, 3).astype(np.float32), "W")
+    nodes = [onnx.helper.make_node("Conv", ["X", "W"], ["Y"], kernel_shape=[3, 3])]
+    model = _model(nodes, [_vi("X", [1, 3, 8, 8])], [_vi("Y", [1, 4, 6, 6])], [weight])
+    import onnxsim.onnxsim_cpp2py_export as C
+
+    names = C.list_qoperator_quantizable_outputs(model.SerializeToString())
+    assert set(names) == {"Y"}
+
+
+def test_list_qoperator_quantizable_outputs_excludes_non_constant_bias_conv():
+    # A Conv whose bias isn't constant will never actually be rewritten (see
+    # test_quantize_skips_non_constant_conv_bias), so its output shouldn't be
+    # listed as needing calibration either.
+    weight = _f32(np.random.randn(4, 3, 3, 3).astype(np.float32), "W")
+    nodes = [onnx.helper.make_node("Conv", ["X", "W", "B"], ["Y"], kernel_shape=[3, 3])]
+    model = _model(
+        nodes,
+        [_vi("X", [1, 3, 8, 8]), _vi("B", [4])],
+        [_vi("Y", [1, 4, 6, 6])],
+        [weight],
+    )
+    import onnxsim.onnxsim_cpp2py_export as C
+
+    names = C.list_qoperator_quantizable_outputs(model.SerializeToString())
+    assert set(names) == set()


### PR DESCRIPTION
## Summary

Adds a "Quantize a model" panel to the WASM convertmodel demo (`scripts/convertmodel/index.html`) that runs onnxsim's quantization methods on the currently loaded model entirely in the browser — no server involved, same "nothing is uploaded" design as the rest of the page.

- **New WASM bindings** (`scripts/convertmodel/interface.cpp`): `onnxsim_quantize_dynamic` / `_ternary` / `_weight_only` / `_weight_only_int4` (single call, no calibration needed), `onnxsim_list_quantizable_activations` / `_list_qoperator_quantizable_outputs`, `onnxsim_add_graph_outputs` (exposes candidate tensors as extra graph outputs for calibration — a bare `ValueInfoProto(name=name)`, exactly mirroring `onnxsim.calibration.calibrate()`'s own model-augmentation step in `onnxsim/calibration.py`), and `onnxsim_quantize_static` / `_quantize_qoperator` (take the calibrated ranges as parallel `[name]` / `[min0, max0, min1, max1, ...]` arrays — a batched, positional convention already used at this C++/JS boundary, see `docs/wasm_ort_web.md`).
- **Browser-side calibration** (`scripts/convertmodel/quantize_calibration.mjs`, new): for Static (QDQ) / QOperator (`QLinearMatMul`) — which need a calibrated activation (and, for QOperator, output) range — runs the model over a few batches of synthetic random input through onnxruntime-web (already loaded on the page for the "Run inference" panel) to observe each candidate tensor's actual value range.
- **UI panel** (`scripts/convertmodel/quantize_ui.mjs` + a new section in `index.html`): method radios (Dynamic / Ternary / Weight-only / Weight-only INT4 / Static / QOperator), a calibration-samples field, a Quantize button, and a download button. The result is also shown in the Netron "after" pane and published as the "Run inference" panel's "converted" model, same as a Simplify/Optimize run.
- Like the existing "parse a text graph" debug panel, the quantization rewrites need no model executor, so they run on the page's own WASM runtime directly (no worker round trip) — only the Static/QOperator calibration step needs onnxruntime-web.
- Small refactor in `inference_browser.mjs`: exports `loadOrt`, `makeDummyInputs`, and a new `resolveOriginalModelBytes` (extracted from `resolveModelBytes`) so calibration reuses the exact same onnxruntime-web loading and input-generation logic as the existing inference panel, rather than duplicating it.

## Verification

- New `.mjs` files and the edited `inference_browser.mjs` pass `node --check` (syntax).
- `index.html`'s tag nesting was validated with Python's `HTMLParser` (no mismatched/unclosed tags).
- The new C++ binding signatures were cross-checked against `onnxsim.h`'s declared `Quantize*`/`List*Quantizable*` functions, and the binding bodies mirror the exact parse/try-catch/`SerializeModel` pattern already used by every other binding in `interface.cpp` (e.g. `onnxoptimizer_optimize`).
- A full local rebuild of this WASM variant (`ORT_WEB=ON ./build_wasm.sh`, the same build CI runs) was attempted to compile-verify the new bindings, but this environment's WASM toolchain bootstrap (building a host protoc + onnx from source) proved too slow to complete in-session. **This PR's CI (`static.yml`, path-triggered on `scripts/convertmodel/**`) builds this exact variant** — I'll watch it and push any compile fixes it surfaces.

## Scope

Not included: quantizing `Conv` via Static/QOperator's browser calibration path is possible (the C++ side already lists Conv activations for Static) but untested end-to-end here; a dedicated Playwright test for this new panel (mirroring `test:inference`/`test:compare`) is a natural follow-up, not included in this first pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_