### PR TITLE
Add Hugging Face token support for gated/private repos

### DIFF
--- a/scripts/convertmodel/hf_load.mjs
+++ b/scripts/convertmodel/hf_load.mjs
@@ -18,6 +18,7 @@ import {
 } from "./hf_models.mjs";
 import { openXetCache, makeCachingFetch } from "./xet_cache.mjs";
 import { parseInputParams, applyOptionParams, syncInputUrl, syncUrlParam } from "./query_params.mjs";
+import { loadStoredToken, saveToken } from "./hf_token.mjs";
 
 const select = document.getElementById("hf-model-select");
 const refInput = document.getElementById("hf-model-input");
@@ -32,6 +33,57 @@ const cacheSizeEl = document.getElementById("hf-cache-size");
 const fileRow = document.getElementById("hf-file-row");
 const fileSelect = document.getElementById("hf-file-select");
 const fileNote = document.getElementById("hf-file-note");
+const tokenInput = document.getElementById("hf-token-input");
+const tokenToggle = document.getElementById("hf-token-toggle");
+const tokenRemember = document.getElementById("hf-token-remember");
+const tokenStatusEl = document.getElementById("hf-token-status");
+
+// The current token, trimmed to "" when blank -- passed to hf_models.mjs so it
+// can attach it as a Bearer token to Hugging Face requests only. Read fresh on
+// every call rather than cached, so an edit takes effect on the very next size
+// probe / load without extra wiring.
+function hfToken() {
+  return (tokenInput && tokenInput.value.trim()) || undefined;
+}
+
+// localStorage itself can throw just from being accessed (some sandboxed /
+// storage-disabled contexts), not only from get/setItem -- hf_token.mjs only
+// guards the latter, so this wrapper covers the former too.
+function safeLocalStorage() {
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+// Restore a remembered token (if any) from localStorage on load.
+if (tokenInput) {
+  const stored = loadStoredToken(safeLocalStorage());
+  if (stored) {
+    tokenInput.value = stored;
+    if (tokenRemember) tokenRemember.checked = true;
+  }
+}
+
+// "remember" persists (or, unchecked, forgets) the token in localStorage; it
+// is otherwise kept in page memory only and lost on reload.
+function syncTokenStorage() {
+  if (!tokenInput || !tokenRemember) return;
+  saveToken(safeLocalStorage(), tokenRemember.checked ? tokenInput.value.trim() : "");
+}
+if (tokenInput) tokenInput.addEventListener("change", syncTokenStorage);
+if (tokenRemember) tokenRemember.addEventListener("change", syncTokenStorage);
+
+// Plain show/hide toggle -- a token is easy to mistype, and password-masked
+// input makes that hard to catch.
+if (tokenToggle && tokenInput) {
+  tokenToggle.addEventListener("click", () => {
+    const showing = tokenInput.type === "text";
+    tokenInput.type = showing ? "password" : "text";
+    tokenToggle.textContent = showing ? "show" : "hide";
+  });
+}
 
 // parseRef throws on empty/garbage; this never does, for use in event handlers.
 function safeParse(ref) {
@@ -86,6 +138,19 @@ const log = (msg) => {
   logOutput.scrollTop = logOutput.scrollHeight;
 };
 
+// A 401/403 from the Hub almost always means "gated or private repo, no (or
+// the wrong) token" -- surface that next to the token field instead of making
+// the user infer it from a raw HTTP status in the console log.
+function noteAuthHint(e) {
+  if (!tokenStatusEl) return;
+  const msg = e && e.message ? e.message : String(e || "");
+  if (/\b(401|403)\b/.test(msg)) {
+    tokenStatusEl.textContent = hfToken()
+      ? "access denied — check the token has access to this repo"
+      : "access denied — this repo may be gated/private; add a token above";
+  }
+}
+
 // Curated model id -> download size (bytes), from models.json. Lets a dropdown
 // pick show its size instantly, with no network probe.
 const curatedSizes = new Map();
@@ -133,6 +198,7 @@ async function showSizeFor(ref, knownSize) {
   if (loading) return;
   ref = (ref || "").trim();
   const token = ++probeToken;
+  if (tokenStatusEl) tokenStatusEl.textContent = "";
   if (!ref) {
     if (statusEl) statusEl.textContent = "";
     return;
@@ -144,13 +210,14 @@ async function showSizeFor(ref, knownSize) {
   }
   if (statusEl) statusEl.textContent = "checking size…";
   try {
-    const { size, name } = await probeModelSize(ref);
+    const { size, name } = await probeModelSize(ref, hfToken());
     if (token !== probeToken) return; // a newer reference superseded this probe
     renderSize(size, name);
   } catch (e) {
     if (token !== probeToken) return;
     if (statusEl) statusEl.textContent = "size unavailable — see console output";
     log(`could not determine model size for "${ref}": ${e && e.message ? e.message : e}`);
+    noteAuthHint(e);
   }
 }
 
@@ -185,7 +252,7 @@ async function refreshFileList(repo, knownSize) {
   if (fileNote) fileNote.textContent = "listing files…";
   if (fileRow) fileRow.style.display = "";
   try {
-    const files = await listOnnxFiles(repo);
+    const files = await listOnnxFiles(repo, hfToken());
     if (token !== fileListToken || loading) return;
     if (!files.length) {
       hideFileRow();
@@ -289,6 +356,8 @@ async function doLoad() {
   loadBtn.disabled = true;
   if (fileInput) fileInput.disabled = true;
   if (statusEl) statusEl.textContent = "loading…";
+  if (tokenStatusEl) tokenStatusEl.textContent = "";
+  const token = hfToken();
   // Reflect this input in the address bar so the link is shareable/reproducible
   // (a Hugging Face repo id or a direct .onnx URL). Uploaded local files have no
   // URL and are handled by the file-input path, which does not call this.
@@ -384,6 +453,7 @@ async function doLoad() {
           onProgress,
           fetchImpl: cachingFetch,
           concurrency: xetConcurrency(),
+          token,
         }));
         if (hits > 0) log(`reused ${hits} cached chunk(s) (${humanBytes(hitBytes)})`);
       } catch (e) {
@@ -393,10 +463,10 @@ async function doLoad() {
         usedXet = false;
         speedFn = () => emaRate;
         resetProgress();
-        ({ bytes, name } = await fetchModelBytes(ref, log, onProgress));
+        ({ bytes, name } = await fetchModelBytes(ref, log, onProgress, token));
       }
     } else {
-      ({ bytes, name } = await fetchModelBytes(ref, log, onProgress));
+      ({ bytes, name } = await fetchModelBytes(ref, log, onProgress, token));
     }
     // Report the average download speed over the whole transfer. For Xet, the
     // honest figure is over the bytes that actually crossed the network — cached
@@ -448,6 +518,7 @@ async function doLoad() {
   } catch (e) {
     log("Hugging Face load failed: " + (e && e.message ? e.message : String(e)));
     if (statusEl) statusEl.textContent = "failed — see console output";
+    noteAuthHint(e);
     // The conversion never started, so re-enable the file picker here (normally
     // the worker's convert-done message does that).
     if (fileInput) fileInput.disabled = false;

--- a/scripts/convertmodel/hf_models.mjs
+++ b/scripts/convertmodel/hf_models.mjs
@@ -89,9 +89,19 @@ export function fileUrl(repo, file, revision = "main") {
   return `${HF}/${repo}/resolve/${revision}/${encoded}`;
 }
 
-// List a repo's files (with sizes) via the Hub API.
-async function repoSiblings(repo) {
-  const r = await fetch(`${HF}/api/models/${repo}?blobs=true`);
+// Build a fetch `headers` object carrying a Hub access token, or undefined when
+// no token is given, so every call below can just spread `authHeaders(token)`
+// without an if/else at each call site. The token is only ever sent to
+// huggingface.co (and its subdomains) — see fetchModelBytes / probeModelSize.
+function authHeaders(token) {
+  return token ? { Authorization: `Bearer ${token}` } : undefined;
+}
+
+// List a repo's files (with sizes) via the Hub API. `token` (a Hub access
+// token, "hf_…") is sent as a Bearer token so gated / private repos the token
+// has access to resolve like any other.
+async function repoSiblings(repo, token) {
+  const r = await fetch(`${HF}/api/models/${repo}?blobs=true`, { headers: authHeaders(token) });
   if (!r.ok) {
     throw new Error(`Hugging Face API returned HTTP ${r.status} for ${repo}`);
   }
@@ -113,8 +123,8 @@ function pickOnnxSibling(siblings, repo) {
 // let the user pick which file to convert instead of always taking the auto-
 // detected (largest) one. `size` is a byte count or null when undisclosed.
 // Returns [] when the repo has no .onnx file (the caller decides what to do).
-export async function listOnnxFiles(repo) {
-  const siblings = await repoSiblings(repo);
+export async function listOnnxFiles(repo, token) {
+  const siblings = await repoSiblings(repo, token);
   return siblings
     .filter((s) => s.rfilename && s.rfilename.endsWith(".onnx"))
     .map((s) => ({
@@ -127,8 +137,8 @@ export async function listOnnxFiles(repo) {
 // Pick the main .onnx file in a repo (largest, matching the regression workers)
 // and warn when the graph relies on external-data blobs the in-browser,
 // single-file converter can't load.
-async function findOnnxFile(repo, onLog) {
-  const siblings = await repoSiblings(repo);
+async function findOnnxFile(repo, onLog, token) {
+  const siblings = await repoSiblings(repo, token);
   const { sibling, count } = pickOnnxSibling(siblings, repo);
   const chosen = sibling.rfilename;
   if (count > 1) {
@@ -149,10 +159,12 @@ async function findOnnxFile(repo, onLog) {
 
 // Read a URL's byte size from its Content-Length via a HEAD request, without
 // downloading the body. Returns a positive integer, or null when the size can't
-// be determined (request failed, header absent, or CORS hid it).
-async function headContentLength(url) {
+// be determined (request failed, header absent, or CORS hid it). `token` is
+// only meaningful (and should only ever be passed) for a Hugging Face URL —
+// callers must not leak it to an arbitrary third-party host.
+async function headContentLength(url, token) {
   try {
-    const r = await fetch(url, { method: "HEAD" });
+    const r = await fetch(url, { method: "HEAD", headers: authHeaders(token) });
     if (!r.ok) return null;
     const n = Number(r.headers && r.headers.get("content-length"));
     return Number.isFinite(n) && n > 0 ? n : null;
@@ -168,8 +180,10 @@ async function headContentLength(url) {
 // HEAD request and reads Content-Length. Returns { size, name, repo?, file?,
 // url? }, where `size` is a byte count or null when it can't be determined.
 // Throws only when the reference itself can't be resolved (empty ref, or a repo
-// with no .onnx file).
-export async function probeModelSize(ref) {
+// with no .onnx file). `token` (a Hub access token) is sent only to
+// huggingface.co endpoints — never to a direct/non-Hub URL, since `parsed.url`
+// is an arbitrary third-party host.
+export async function probeModelSize(ref, token) {
   const parsed = parseRef(ref);
   if (parsed.url) {
     return { size: await headContentLength(parsed.url), name: parsed.name, url: parsed.url };
@@ -178,13 +192,13 @@ export async function probeModelSize(ref) {
   if (parsed.file) {
     const url = fileUrl(parsed.repo, parsed.file, revision);
     return {
-      size: await headContentLength(url),
+      size: await headContentLength(url, token),
       name: parsed.file.split("/").pop(),
       repo: parsed.repo,
       file: parsed.file,
     };
   }
-  const siblings = await repoSiblings(parsed.repo);
+  const siblings = await repoSiblings(parsed.repo, token);
   const { sibling } = pickOnnxSibling(siblings, parsed.repo);
   const size = Number.isFinite(sibling.size) && sibling.size > 0 ? sibling.size : null;
   return {
@@ -241,28 +255,32 @@ async function readWithProgress(resp, onProgress) {
 // Resolve a reference and download the model. Returns { bytes, name, repo }.
 // `onLog` receives progress lines for the page's console output; `onProgress`
 // receives { loaded, total } byte counts as the download streams, for a live
-// progress indicator.
-export async function fetchModelBytes(ref, onLog = () => {}, onProgress = () => {}) {
+// progress indicator. `token` (a Hub access token) is sent as a Bearer token
+// only when downloading from a Hugging Face repo — never to a direct URL,
+// which may point at an arbitrary third-party host.
+export async function fetchModelBytes(ref, onLog = () => {}, onProgress = () => {}, token) {
   const parsed = parseRef(ref);
 
   let url;
   let name;
+  let sendToken = false;
   if (parsed.url) {
     url = parsed.url;
     name = parsed.name;
   } else {
+    sendToken = true;
     const revision = parsed.revision || "main";
     let file = parsed.file;
     if (!file) {
       onLog(`querying Hugging Face for the .onnx file in ${parsed.repo}…`);
-      file = await findOnnxFile(parsed.repo, onLog);
+      file = await findOnnxFile(parsed.repo, onLog, token);
     }
     url = fileUrl(parsed.repo, file, revision);
     name = file.split("/").pop();
   }
 
   onLog(`downloading ${url}`);
-  const resp = await fetch(url);
+  const resp = await fetch(url, { headers: authHeaders(sendToken ? token : undefined) });
   if (!resp.ok) {
     throw new Error(`download failed: HTTP ${resp.status} ${resp.statusText}`);
   }
@@ -320,7 +338,7 @@ async function readBlobWithProgress(blob, onProgress) {
 // into byte-range shards ourselves.
 export async function fetchModelBytesXet(
   ref,
-  { onLog = () => {}, onProgress = () => {}, fetchImpl, concurrency = 1 } = {},
+  { onLog = () => {}, onProgress = () => {}, fetchImpl, concurrency = 1, token } = {},
 ) {
   const parsed = parseRef(ref);
   if (!parsed.repo) {
@@ -330,7 +348,7 @@ export async function fetchModelBytesXet(
   let file = parsed.file;
   if (!file) {
     onLog(`querying Hugging Face for the .onnx file in ${parsed.repo}…`);
-    file = await findOnnxFile(parsed.repo, onLog);
+    file = await findOnnxFile(parsed.repo, onLog, token);
   }
 
   const shards = Math.max(1, Math.floor(concurrency) || 1);
@@ -347,6 +365,9 @@ export async function fetchModelBytesXet(
     revision,
     fetch: fetchImpl,
     parallelDownloads,
+    // @huggingface/hub's CredentialsParams: pass accessToken only when set, so
+    // an anonymous load never sends `accessToken: undefined` through.
+    ...(token ? { accessToken: token } : {}),
   });
   if (!blob) throw new Error(`file not found: ${parsed.repo}/${file}`);
 

--- a/scripts/convertmodel/hf_token.mjs
+++ b/scripts/convertmodel/hf_token.mjs
@@ -1,0 +1,42 @@
+// Persistence for the optional Hugging Face access token the "Load from
+// Hugging Face" panel uses to reach gated / private repos.
+//
+// Kept pure (no DOM access, `storage` is injected) so it's unit-testable with a
+// plain in-memory fake; hf_load.mjs does the actual browser wiring against
+// window.localStorage. The token itself never touches the URL / shareable
+// link (see share_url.mjs / query_params.mjs, which only reflect the model
+// reference and conversion options) and is only ever attached, by hf_models.mjs,
+// to requests aimed at huggingface.co.
+
+const STORAGE_KEY = "onnxsim:hfToken";
+
+// Read the remembered token, or "" if none is stored / storage is unavailable
+// (private browsing, disabled storage, quota errors, …).
+export function loadStoredToken(storage) {
+  try {
+    return (storage && storage.getItem(STORAGE_KEY)) || "";
+  } catch {
+    return "";
+  }
+}
+
+// Persist (or, for an empty token, remove) the remembered token. Best-effort:
+// a storage failure must not break the page, so it's swallowed.
+export function saveToken(storage, token) {
+  try {
+    if (!storage) return;
+    if (token) storage.setItem(STORAGE_KEY, token);
+    else storage.removeItem(STORAGE_KEY);
+  } catch {
+    // storage unavailable — the token just won't persist across reloads
+  }
+}
+
+// Forget any remembered token (used when the user unchecks "remember").
+export function clearToken(storage) {
+  try {
+    if (storage) storage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -117,6 +117,31 @@ agraph (float[N] X) =&gt; (float[N] Y) {
                 one <code>.onnx</code>, the largest is auto-detected; use the
                 <b>file</b> selector to convert a different one.
             </div>
+            <div id="hf-token-row" style="margin-top: 0.4em;">
+                <label for="hf-token-input">Hugging Face token</label>
+                <input type="password" id="hf-token-input" size="38"
+                       placeholder="hf_… (only needed for gated / private repos)"
+                       autocomplete="off" spellcheck="false">
+                <button id="hf-token-toggle" type="button" title="Show/hide the token">show</button>
+                <input type="checkbox" id="hf-token-remember">
+                <label for="hf-token-remember">remember in this browser</label>
+                <span id="hf-token-status" class="note" style="margin-left: 0.3em;"></span>
+                <div class="note" style="margin-top: 0.2em;">
+                    Optional — only needed to load a <b>gated</b> or
+                    <b>private</b> repo you have access to; public repos (like
+                    <code>onnxmodelzoo</code>) don't need one. Create one at
+                    <a href="https://huggingface.co/settings/tokens" target="_blank" rel="noopener">huggingface.co/settings/tokens</a>
+                    ("read" access is enough). It is sent straight from your
+                    browser to <code>huggingface.co</code> as an
+                    <code>Authorization</code> header for size checks, file
+                    listing, and the download itself — never anywhere else, and
+                    never included in the "Copy shareable link" URL above. With
+                    <b>remember</b> off (the default) it lives only in this
+                    page's memory and is gone on reload; checking it saves the
+                    token in this browser's local storage (still local to your
+                    machine) so it survives a reload.
+                </div>
+            </div>
             <div class="note" style="margin-top: 0.25em;">
                 <b>Shareable link:</b> the input model and options can be set from
                 the URL — e.g.

--- a/scripts/convertmodel/package.json
+++ b/scripts/convertmodel/package.json
@@ -12,6 +12,7 @@
     "test:macs": "node test/macs.test.mjs",
     "test:shapes": "node test/shapes.test.mjs",
     "test:hf": "node test/hf_models.test.mjs",
+    "test:hftoken": "node test/hf_token.test.mjs",
     "test:xet": "node test/xet_cache.test.mjs",
     "test:issue": "node test/issue_report.test.mjs",
     "test:versions": "node test/versions.test.mjs",
@@ -25,7 +26,7 @@
     "test:hfdata": "node test/hf_datasets.test.mjs",
     "test:sample": "node test/sample_inputs.test.mjs",
     "test:classify": "node test/classify_output.test.mjs",
-    "test:all": "npm run test:netron && npm run test:trace && npm run test:macs && npm run test:shapes && npm run test:hf && npm run test:xet && npm run test:issue && npm run test:versions && npm run test:backend && npm run test:query && npm run test:webnn && npm run test:ortlog && npm run test:cdn && npm run test:fill && npm run test:tokenize && npm run test:hfdata && npm run test:sample && npm run test:classify && npm run test:inference && npm run test:compare",
+    "test:all": "npm run test:netron && npm run test:trace && npm run test:macs && npm run test:shapes && npm run test:hf && npm run test:hftoken && npm run test:xet && npm run test:issue && npm run test:versions && npm run test:backend && npm run test:query && npm run test:webnn && npm run test:ortlog && npm run test:cdn && npm run test:fill && npm run test:tokenize && npm run test:hfdata && npm run test:sample && npm run test:classify && npm run test:inference && npm run test:compare",
     "coverage": "c8 npm run test:all"
   },
   "dependencies": {

--- a/scripts/convertmodel/test/hf_models.test.mjs
+++ b/scripts/convertmodel/test/hf_models.test.mjs
@@ -32,9 +32,12 @@ async function acheck(name, fn) {
 //   { ok?, status?, statusText?, json?, arrayBuffer?, chunks?, contentLength? }
 // A `chunks` array (of Uint8Array) yields a streaming ReadableStream-style body
 // so the progress path can be exercised; otherwise only arrayBuffer() is served.
-function withFetch(routes, fn) {
+// Every call's (url, options) is recorded in `calls` (when passed in), so tests
+// can assert on what headers a given request carried.
+function withFetch(routes, fn, calls) {
   const saved = globalThis.fetch;
-  globalThis.fetch = async (url) => {
+  globalThis.fetch = async (url, options) => {
+    if (calls) calls.push({ url, options });
     const r = routes[url];
     if (!r) {
       return { ok: false, status: 404, statusText: "Not Found", headers: headersOf() };
@@ -339,6 +342,79 @@ await acheck("probeModelSize surfaces a repo with no .onnx", async () => {
       await assert.rejects(probeModelSize("empty"), /no \.onnx file found/);
     },
   );
+});
+
+await acheck("fetchModelBytes sends a Bearer token for a Hub repo download", async () => {
+  const api = "https://huggingface.co/api/models/o/gated?blobs=true";
+  const url = "https://huggingface.co/o/gated/resolve/main/m.onnx";
+  const calls = [];
+  await withFetch(
+    {
+      [api]: { json: { siblings: [{ rfilename: "m.onnx", size: 4 }] } },
+      [url]: { arrayBuffer: new Uint8Array([1, 2, 3, 4]).buffer },
+    },
+    () => fetchModelBytes("o/gated", () => {}, () => {}, "hf_secrettoken"),
+    calls,
+  );
+  const apiCall = calls.find((c) => c.url === api);
+  const downloadCall = calls.find((c) => c.url === url);
+  assert.equal(apiCall.options.headers.Authorization, "Bearer hf_secrettoken");
+  assert.equal(downloadCall.options.headers.Authorization, "Bearer hf_secrettoken");
+});
+
+await acheck("fetchModelBytes sends no Authorization header without a token", async () => {
+  const url = "https://huggingface.co/o/r/resolve/main/m.onnx";
+  const calls = [];
+  await withFetch(
+    { [url]: { arrayBuffer: new Uint8Array([1]).buffer } },
+    () => fetchModelBytes(url, () => {}, () => {}),
+    calls,
+  );
+  assert.equal(calls[0].options.headers, undefined);
+});
+
+await acheck("fetchModelBytes never sends a token to a non-Hub direct URL", async () => {
+  const url = "https://example.com/models/net.onnx";
+  const calls = [];
+  await withFetch(
+    { [url]: { arrayBuffer: new Uint8Array([1]).buffer } },
+    () => fetchModelBytes(url, () => {}, () => {}, "hf_secrettoken"),
+    calls,
+  );
+  assert.equal(calls[0].options.headers, undefined);
+});
+
+await acheck("probeModelSize sends a Bearer token for a Hub repo", async () => {
+  const api = "https://huggingface.co/api/models/o/gated?blobs=true";
+  const calls = [];
+  await withFetch(
+    { [api]: { json: { siblings: [{ rfilename: "m.onnx", size: 4 }] } } },
+    () => probeModelSize("o/gated", "hf_secrettoken"),
+    calls,
+  );
+  assert.equal(calls[0].options.headers.Authorization, "Bearer hf_secrettoken");
+});
+
+await acheck("probeModelSize never sends a token to a non-Hub direct URL", async () => {
+  const url = "https://example.com/models/net.onnx";
+  const calls = [];
+  await withFetch(
+    { [url]: { contentLength: 10 } },
+    () => probeModelSize(url, "hf_secrettoken"),
+    calls,
+  );
+  assert.equal(calls[0].options.headers, undefined);
+});
+
+await acheck("listOnnxFiles sends a Bearer token for a Hub repo", async () => {
+  const api = "https://huggingface.co/api/models/o/gated?blobs=true";
+  const calls = [];
+  await withFetch(
+    { [api]: { json: { siblings: [{ rfilename: "m.onnx", size: 4 }] } } },
+    () => listOnnxFiles("o/gated", "hf_secrettoken"),
+    calls,
+  );
+  assert.equal(calls[0].options.headers.Authorization, "Bearer hf_secrettoken");
 });
 
 console.log(`\n${passed} checks passed`);

--- a/scripts/convertmodel/test/hf_token.test.mjs
+++ b/scripts/convertmodel/test/hf_token.test.mjs
@@ -1,0 +1,83 @@
+// Unit test for the Hugging Face token storage helpers behind the converter
+// page's token field. No DOM/browser needed -- storage is a plain fake.
+//
+// Usage:
+//   node test/hf_token.test.mjs
+
+import assert from "node:assert/strict";
+import { loadStoredToken, saveToken, clearToken } from "../hf_token.mjs";
+
+let passed = 0;
+function check(name, fn) {
+  fn();
+  passed += 1;
+  console.log("  ok -", name);
+}
+
+// Minimal in-memory Storage stand-in.
+function fakeStorage() {
+  const map = new Map();
+  return {
+    getItem: (k) => (map.has(k) ? map.get(k) : null),
+    setItem: (k, v) => map.set(k, String(v)),
+    removeItem: (k) => map.delete(k),
+    _map: map,
+  };
+}
+
+check("loadStoredToken returns '' when nothing is stored", () => {
+  assert.equal(loadStoredToken(fakeStorage()), "");
+});
+
+check("loadStoredToken returns '' for a null/undefined storage", () => {
+  assert.equal(loadStoredToken(null), "");
+  assert.equal(loadStoredToken(undefined), "");
+});
+
+check("saveToken then loadStoredToken round-trips", () => {
+  const s = fakeStorage();
+  saveToken(s, "hf_abc123");
+  assert.equal(loadStoredToken(s), "hf_abc123");
+});
+
+check("saveToken with an empty token clears any stored value", () => {
+  const s = fakeStorage();
+  saveToken(s, "hf_abc123");
+  saveToken(s, "");
+  assert.equal(loadStoredToken(s), "");
+});
+
+check("saveToken on a null storage does not throw", () => {
+  assert.doesNotThrow(() => saveToken(null, "hf_abc123"));
+});
+
+check("clearToken removes a stored token", () => {
+  const s = fakeStorage();
+  saveToken(s, "hf_abc123");
+  clearToken(s);
+  assert.equal(loadStoredToken(s), "");
+});
+
+check("clearToken on a null storage does not throw", () => {
+  assert.doesNotThrow(() => clearToken(null));
+});
+
+check("a storage that throws on getItem is swallowed", () => {
+  const s = {
+    getItem: () => {
+      throw new Error("storage disabled");
+    },
+  };
+  assert.equal(loadStoredToken(s), "");
+});
+
+check("a storage that throws on setItem is swallowed", () => {
+  const s = {
+    setItem: () => {
+      throw new Error("quota exceeded");
+    },
+  };
+  assert.doesNotThrow(() => saveToken(s, "hf_abc123"));
+});
+
+console.log(`\n${passed} checks passed`);


### PR DESCRIPTION
Adds optional Hugging Face access token support to the model converter, enabling users to load gated and private repositories they have access to.

## Summary
This change introduces a token input field to the "Load from Hugging Face" panel that allows users to provide their Hugging Face API token for accessing gated or private repositories. The token is sent as a Bearer authorization header only to huggingface.co endpoints and never to arbitrary third-party URLs or included in shareable links.

## Key Changes

- **New module `hf_token.mjs`**: Pure token persistence helpers (`loadStoredToken`, `saveToken`, `clearToken`) that work with injected storage for testability
- **New test file `hf_token.test.mjs`**: Comprehensive unit tests for token storage with a fake in-memory storage implementation
- **Updated `hf_models.mjs`**: 
  - Added `authHeaders()` helper to build Bearer token headers
  - Modified `repoSiblings()`, `listOnnxFiles()`, `findOnnxFile()`, `headContentLength()`, `probeModelSize()`, and `fetchModelBytes()` to accept and use token parameter
  - Token is only sent to huggingface.co endpoints, never to direct/third-party URLs
  - Updated `fetchModelBytesXet()` to pass token to `@huggingface/hub` library
- **Updated `hf_load.mjs`**:
  - Added token input field UI elements and event handlers
  - Implemented token restoration from localStorage on page load
  - Added show/hide toggle for password-masked input
  - Added "remember in this browser" checkbox for localStorage persistence
  - Added `noteAuthHint()` to surface 401/403 errors with helpful context about gated repos
  - Pass token to all model size probing, file listing, and download functions
  - Clear token status messages on new operations
- **Updated `index.html`**: Added token input row with explanatory notes about usage, security, and where to create tokens
- **Updated `package.json`**: Added `test:hftoken` test script

## Implementation Details

- Token is read fresh on every operation (not cached) so edits take effect immediately
- Storage access is wrapped in try-catch to handle private browsing, disabled storage, and quota errors gracefully
- Token is never included in shareable URLs (handled by existing `query_params.mjs` / `share_url.mjs`)
- 401/403 HTTP errors are detected and a helpful message is shown next to the token field
- The token input uses `autocomplete="off"` and `spellcheck="false"` for better UX
- All new token-related code is thoroughly tested with unit tests covering edge cases (null storage, storage errors, round-trip persistence)

https://claude.ai/code/session_016FnNGSFbaGenL3GxQVMZzs