### PR TITLE
Add Float16/BFloat16/Float8 to the WASM UI's quantize panel

### DIFF
--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -341,6 +341,15 @@ agraph (float[N] X) =&gt; (float[N] Y) {
                     <code>QLinearMatMul</code>, computing directly in int8; also
                     needs a calibrated <i>output</i> range, not just the
                     activation. Needs calibration (below).</li>
+                <li><b>Float16</b> / <b>BFloat16</b> / <b>Float8</b> -- a
+                    different kind of "quantization": every weight (and, by
+                    default, every internal activation -- a boundary
+                    <code>Cast</code> keeps the model's own external
+                    input/output types float32) is simply rounded to a
+                    narrower floating-point format, not an integer scheme, so
+                    no calibration data is needed at all. Float16/BFloat16
+                    halve storage; Float8 (E4M3 or E5M2, below) quarters it,
+                    at the cost of the least precision of any format here.</li>
             </ul>
             <p class="tool-note">
                 <b>Calibration</b> (Static/QOperator only) runs the model over a
@@ -367,7 +376,19 @@ agraph (float[N] X) =&gt; (float[N] Y) {
                 <label for="quantize_static">Static (QDQ)</label>
                 <input type="radio" name="quantize-method" value="qoperator" id="quantize_qoperator">
                 <label for="quantize_qoperator">QOperator (QLinearMatMul)</label>
+                <input type="radio" name="quantize-method" value="fp16" id="quantize_fp16">
+                <label for="quantize_fp16">Float16</label>
+                <input type="radio" name="quantize-method" value="bf16" id="quantize_bf16">
+                <label for="quantize_bf16">BFloat16</label>
+                <input type="radio" name="quantize-method" value="fp8" id="quantize_fp8">
+                <label for="quantize_fp8">Float8</label>
             </div>
+            <label for="quantize-fp8-format">Float8 format</label>
+            <select id="quantize-fp8-format">
+                <option value="e4m3" selected>E4M3FN (max 448, typically weights)</option>
+                <option value="e5m2">E5M2 (max 57344, typically gradients)</option>
+            </select>
+            <br/>
             <label for="quantize-samples">calibration samples (Static / QOperator only)</label>
             <input type="number" id="quantize-samples" value="8" min="1" max="64" step="1" style="width: 4em;">
             <br/>

--- a/scripts/convertmodel/interface.cpp
+++ b/scripts/convertmodel/interface.cpp
@@ -891,6 +891,49 @@ em::val onnxsim_quantize_weight_only_int4(const std::string& data) {
     }
 }
 
+em::val onnxsim_quantize_fp16(const std::string& data) {
+    onnx::ModelProto xmodel;
+    if (!xmodel.ParseFromArray(data.data(), data.size())) {
+        std::cerr << "Parse failed" << std::endl;
+        return em::val::null();
+    }
+    try {
+        return SerializeModel(QuantizeFp16(xmodel));
+    } catch (const std::exception& e) {
+        std::cerr << "quantize_fp16 error: " << e.what() << std::endl;
+        return em::val::null();
+    }
+}
+
+em::val onnxsim_quantize_bf16(const std::string& data) {
+    onnx::ModelProto xmodel;
+    if (!xmodel.ParseFromArray(data.data(), data.size())) {
+        std::cerr << "Parse failed" << std::endl;
+        return em::val::null();
+    }
+    try {
+        return SerializeModel(QuantizeBf16(xmodel));
+    } catch (const std::exception& e) {
+        std::cerr << "quantize_bf16 error: " << e.what() << std::endl;
+        return em::val::null();
+    }
+}
+
+// `format` is "e4m3" or "e5m2" -- see QuantizeFp8 in onnxsim.h.
+em::val onnxsim_quantize_fp8(const std::string& data, const std::string& format) {
+    onnx::ModelProto xmodel;
+    if (!xmodel.ParseFromArray(data.data(), data.size())) {
+        std::cerr << "Parse failed" << std::endl;
+        return em::val::null();
+    }
+    try {
+        return SerializeModel(QuantizeFp8(xmodel, format));
+    } catch (const std::exception& e) {
+        std::cerr << "quantize_fp8 error: " << e.what() << std::endl;
+        return em::val::null();
+    }
+}
+
 // Both list_* functions below are used by the page to discover which tensor
 // names to calibrate (run the model over sample inputs and record each
 // tensor's observed min/max) before calling quantize_static/quantize_qoperator.
@@ -997,6 +1040,9 @@ EMSCRIPTEN_BINDINGS(module) {
     function("onnxsim_quantize_ternary", &onnxsim_quantize_ternary);
     function("onnxsim_quantize_weight_only", &onnxsim_quantize_weight_only);
     function("onnxsim_quantize_weight_only_int4", &onnxsim_quantize_weight_only_int4);
+    function("onnxsim_quantize_fp16", &onnxsim_quantize_fp16);
+    function("onnxsim_quantize_bf16", &onnxsim_quantize_bf16);
+    function("onnxsim_quantize_fp8", &onnxsim_quantize_fp8);
     // Calibration-based quantization: list_* discovers which tensors to
     // calibrate, quantize_static/quantize_qoperator take the calibrated
     // ranges back as parallel [name] / [min0, max0, min1, max1, ...] arrays.

--- a/scripts/convertmodel/quantize_ui.mjs
+++ b/scripts/convertmodel/quantize_ui.mjs
@@ -60,12 +60,18 @@ function getRuntime() {
 // Methods that quantize straight from a single WASM call -- the weight is
 // quantized from its own static values and the activation either isn't
 // touched (weight-only) or is quantized dynamically at inference time
-// (dynamic/ternary), so no calibration data is needed.
+// (dynamic/ternary), so no calibration data is needed. Float16/BFloat16 are
+// a different kind of "quantization" (a narrower floating-point format, not
+// an integer scheme) but need no calibration data either, so they fit the
+// same single-call shape; Float8 needs an extra "e4m3"/"e5m2" format
+// argument and is called separately below instead of through this map.
 const NO_CALIBRATION_METHODS = {
   dynamic: "onnxsim_quantize_dynamic",
   ternary: "onnxsim_quantize_ternary",
   weight_only: "onnxsim_quantize_weight_only",
   weight_only_int4: "onnxsim_quantize_weight_only_int4",
+  fp16: "onnxsim_quantize_fp16",
+  bf16: "onnxsim_quantize_bf16",
 };
 
 function toArray(vec) {
@@ -111,7 +117,12 @@ function initQuantizePanel() {
       const runtime = await getRuntime();
 
       let resultBuf;
-      if (method in NO_CALIBRATION_METHODS) {
+      if (method === "fp8") {
+        const formatEl = document.getElementById("quantize-fp8-format");
+        const format = formatEl ? formatEl.value : "e4m3";
+        setStatus(`quantizing (fp8, ${format})…`);
+        resultBuf = runtime.onnxsim_quantize_fp8(modelBuf, format);
+      } else if (method in NO_CALIBRATION_METHODS) {
         setStatus(`quantizing (${method})…`);
         resultBuf = runtime[NO_CALIBRATION_METHODS[method]](modelBuf);
       } else if (method === "static" || method === "qoperator") {


### PR DESCRIPTION
## Summary

- Wires the three narrow-floating-point quantization methods added in prior PRs (`quantize_fp16` #671, `quantize_bf16` #672, `quantize_fp8` #673) into the browser converter's "Quantize a model" panel (`scripts/convertmodel/`), alongside the existing Dynamic/Ternary/Weight-only/Weight-only INT4/Static/QOperator methods.
- `interface.cpp`: adds `onnxsim_quantize_fp16`/`onnxsim_quantize_bf16`/`onnxsim_quantize_fp8` wrapper functions and embind registrations, mirroring the four existing calibration-free `quantize_*` wrappers exactly (parse → call → `SerializeModel` → catch/log). `onnxsim_quantize_fp8` takes an extra `"e4m3"`/`"e5m2"` format argument.
- `index.html`: three new method radio buttons (`Float16`, `BFloat16`, `Float8`) plus a Float8-format `<select>` (E4M3FN default / E5M2), and a new description-list entry explaining these need no calibration data since they're floating-point formats, not integer schemes.
- `quantize_ui.mjs`: `fp16`/`bf16` fit the existing single-WASM-call `NO_CALIBRATION_METHODS` dispatch map; `fp8` gets its own branch to read the format `<select>` and pass it through as a second argument.

## Test plan

- [x] `node --check scripts/convertmodel/quantize_ui.mjs` — valid JS syntax.
- [x] Manual review of `interface.cpp`'s new functions/registrations against the four already-working `onnxsim_quantize_{dynamic,ternary,weight_only,weight_only_int4}` functions they mirror line-for-line in structure.
- [ ] **Not locally build-verified** — this environment has no `emsdk`/`emcc` toolchain available, and bootstrapping one from scratch is known to be slow/fragile here (per this repo's own `CLAUDE.md`/session notes). Relying on the `static.yml` CI job, which runs `build_wasm.sh` (a real `emcmake`/WASM build) on any PR touching `scripts/convertmodel/**`, to validate compilation — will fix if it reports an error.

https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU


---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_