### PR TITLE
Capture WebGPU device uncaptured errors in diagnostics

### DIFF
--- a/scripts/convertmodel/inference_browser.mjs
+++ b/scripts/convertmodel/inference_browser.mjs
@@ -627,12 +627,15 @@ export function initInferencePanel() {
     if (traceContainer) traceContainer.innerHTML = "";
     if (macsContainer) macsContainer.innerHTML = "";
     if (sampleIoContainer) sampleIoContainer.innerHTML = "";
-    // Mirror onnxruntime-web's own console diagnostics and unhandled WebNN/ORT
-    // promise rejections into this panel's log for the duration of the run —
-    // e.g. "WebNN backend does not support data type: int64", which ORT throws
-    // on an internal promise that bypasses the try/catch below and otherwise
-    // only shows in devtools. restoreOrtLogs() is called in finally.
-    const restoreOrtLogs = captureOrtDiagnostics({ log });
+    // Mirror onnxruntime-web's own console diagnostics, unhandled WebNN/ORT
+    // promise rejections, and uncaptured WebGPU device errors into this
+    // panel's log for the duration of the run — e.g. "WebNN backend does not
+    // support data type: int64" (thrown on an internal promise that bypasses
+    // the try/catch below) or a WebGPU storage-buffer-limit validation error
+    // (logged by the browser straight to devtools, never through
+    // console.error). Without this, all three only show in devtools.
+    // restoreOrtLogs() is called in finally.
+    let restoreOrtLogs = () => {};
     try {
       const source = sourceSelect ? sourceSelect.value : "original";
       const iterations = Math.max(1, parseInt(itersInput.value, 10) || 5);
@@ -644,6 +647,17 @@ export function initInferencePanel() {
       const epValue = epSelect.value;
       const { providers, needWebnn } = providersForEp(epValue);
       const profile = !profileChk || profileChk.checked;
+      // Load onnxruntime-web (cached by variant, so runOnModel/runCompare's own
+      // loadOrt() below is a no-op fetch) here first so, on a WebGPU run, the
+      // device error listener is armed before session creation compiles the
+      // first compute pipeline. Only wired for a WebGPU-EP run — reading
+      // env.webgpu.device this early would otherwise ask the backend to spin
+      // up a GPUDevice for a plain wasm/WebNN run that never needs one.
+      const ort = await loadOrt(needWebnn ? "all" : "default");
+      restoreOrtLogs = captureOrtDiagnostics({
+        log,
+        ort: providers.includes("webgpu") ? ort : null,
+      });
       // How the auto-generated inputs are valued: one of input_fill.mjs's
       // synthetic modes, or "sample" (real image/tokenized-text data — see
       // sample_inputs.mjs). Guard against an unexpected value so a

--- a/scripts/convertmodel/ort_log_capture.mjs
+++ b/scripts/convertmodel/ort_log_capture.mjs
@@ -10,12 +10,19 @@
 //     int64") are thrown on an internal ORT promise that isn't chained to the
 //     awaited session.run(), so they surface as an *uncaught* promise rejection
 //     rather than rejecting the run the panel awaits.
+//   * WebGPU validation errors that no error scope captures (e.g. a kernel
+//     needing more storage buffers than the device's per-stage limit, as with
+//     a wide `Concat`) are logged by the browser straight to the DevTools
+//     protocol — they never pass through the page's `console.error`, so the
+//     wrap above can't see them. The only page-visible signal is the
+//     `GPUDevice`'s own `uncapturederror` event.
 //
-// captureOrtDiagnostics() wraps console.warn/console.error and listens for
-// unhandledrejection while a run is active, forwarding the onnxruntime/WebNN
-// ones to a provided sink (the panel log). The console output is preserved, so
-// devtools still shows everything it did before. The pure pieces take injected
-// console/target so they can be unit-tested under Node.
+// captureOrtDiagnostics() wraps console.warn/console.error, listens for
+// unhandledrejection, and (given the `ort` module) listens for the active
+// WebGPU device's `uncapturederror` event while a run is active, forwarding
+// matches to a provided sink (the panel log). The console output is
+// preserved, so devtools still shows everything it did before. The pure
+// pieces take injected console/target so they can be unit-tested under Node.
 
 // onnxruntime-web tags these messages with the library or backend name; match on
 // that so unrelated page logging (or another library's console noise) is not
@@ -46,8 +53,9 @@ export function formatLogArgs(args) {
   return (args || []).map(valueToText).join(" ");
 }
 
-// Install console.warn/console.error wrappers and an unhandledrejection listener
-// that forward onnxruntime-web's own diagnostics to `log`. Returns a restore()
+// Install console.warn/console.error wrappers, an unhandledrejection listener,
+// and (when `ort` is given) a WebGPU device `uncapturederror` listener, all
+// forwarding onnxruntime-web's own diagnostics to `log`. Returns a restore()
 // that removes every hook; call it in a finally so the global console/handlers
 // are always put back. `con`/`target` are injectable for testing (default to the
 // page's console and window).
@@ -55,6 +63,7 @@ export function captureOrtDiagnostics({
   log,
   con = typeof console !== "undefined" ? console : undefined,
   target = typeof window !== "undefined" ? window : undefined,
+  ort = null,
 } = {}) {
   const restores = [];
 
@@ -85,6 +94,32 @@ export function captureOrtDiagnostics({
     restores.push(() =>
       target.removeEventListener("unhandledrejection", onRejection),
     );
+  }
+
+  // `ort.env.webgpu.device` is a Promise that resolves once the WebGPU backend
+  // has created its GPUDevice — before any session exists if it's read early
+  // (the getter is valid "before or after the first WebGPU inference session
+  // is created"), so wiring this up here catches errors from the very first
+  // compute pipeline the run compiles. Resolves to undefined and is silently
+  // skipped when the page never touches WebGPU (wasm-only run) or the loaded
+  // onnxruntime-web build predates this property.
+  if (ort && ort.env && ort.env.webgpu) {
+    let device = null;
+    const onUncaptured = (event) => {
+      const reason = event && event.error;
+      const text = reason && reason.message ? reason.message : String(reason);
+      log(`WebGPU uncaptured error: ${text}`);
+    };
+    Promise.resolve(ort.env.webgpu.device)
+      .then((d) => {
+        if (!d || typeof d.addEventListener !== "function") return;
+        device = d;
+        device.addEventListener("uncapturederror", onUncaptured);
+      })
+      .catch(() => {});
+    restores.push(() => {
+      if (device) device.removeEventListener("uncapturederror", onUncaptured);
+    });
   }
 
   return () => {

--- a/scripts/convertmodel/test/ort_log_capture.test.mjs
+++ b/scripts/convertmodel/test/ort_log_capture.test.mjs
@@ -123,6 +123,62 @@ check("captureOrtDiagnostics mirrors unhandled WebNN rejections", () => {
   restore();
 });
 
+// Node has no global GPUDevice; a fakeTarget() stub (already used for
+// `window` above) has the same addEventListener/removeEventListener shape, so
+// it doubles as a fake device here.
+async function checkAsync(name, fn) {
+  await fn();
+  passed += 1;
+  console.log("  ok -", name);
+}
+
+await checkAsync(
+  "captureOrtDiagnostics mirrors an uncaptured WebGPU device error",
+  async () => {
+    const target = fakeTarget();
+    const device = fakeTarget();
+    const ort = { env: { webgpu: { device: Promise.resolve(device) } } };
+    const logged = [];
+    const restore = captureOrtDiagnostics({
+      log: (m) => logged.push(m),
+      con: fakeConsole(),
+      target,
+      ort,
+    });
+
+    // The device promise resolves asynchronously; give it a tick to attach.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert.equal(device.count("uncapturederror"), 1);
+    device.dispatch("uncapturederror", {
+      error: { message: "storage buffers (9) ... exceeds ... limit (8)" },
+    });
+    assert.equal(logged.length, 1);
+    assert.match(logged[0], /^WebGPU uncaptured error: /);
+    assert.match(logged[0], /storage buffers/);
+
+    restore();
+    assert.equal(device.count("uncapturederror"), 0);
+  },
+);
+
+await checkAsync(
+  "captureOrtDiagnostics without `ort` never touches a device",
+  async () => {
+    const target = fakeTarget();
+    const logged = [];
+    const restore = captureOrtDiagnostics({
+      log: (m) => logged.push(m),
+      con: fakeConsole(),
+      target,
+    });
+    await Promise.resolve();
+    restore(); // must not throw with no device ever attached
+    assert.equal(logged.length, 0);
+  },
+);
+
 check("restore() removes console wrappers and the rejection listener", () => {
   const con = fakeConsole();
   const target = fakeTarget();


### PR DESCRIPTION
## Summary
Extends the ORT diagnostics capture system to listen for WebGPU device `uncapturederror` events, which surface validation errors that bypass the page's console and error scopes (e.g., storage buffer limit exceeded).

## Changes
- **ort_log_capture.mjs**: Added WebGPU device error listener
  - Accepts optional `ort` parameter to access the WebGPU device promise
  - Listens for `uncapturederror` events on the resolved device and logs them with "WebGPU uncaptured error:" prefix
  - Properly cleans up the listener in the restore function
  - Updated module documentation to explain the three error sources now captured

- **ort_log_capture.test.mjs**: Added test coverage
  - `checkAsync()` helper for async test functions
  - Test verifying uncaptured WebGPU errors are captured and logged
  - Test verifying the code safely handles missing `ort` parameter

- **inference_browser.mjs**: Integrated WebGPU error capture into the inference panel
  - Loads onnxruntime-web early (before session creation) so the device listener is armed before the first compute pipeline compiles
  - Passes `ort` to `captureOrtDiagnostics()` only for WebGPU-EP runs to avoid unnecessary device initialization
  - Updated comments to document all three error sources now captured

## Implementation Details
- The WebGPU device is accessed via `ort.env.webgpu.device` Promise, which resolves once the backend creates its GPUDevice
- The listener is armed before any session exists, catching errors from the very first compute pipeline
- Gracefully handles cases where the device promise never resolves or the property doesn't exist (older onnxruntime-web builds or wasm-only runs)
- The device listener is only wired for WebGPU-EP runs to avoid spinning up a GPUDevice unnecessarily for wasm/WebNN runs

https://claude.ai/code/session_01QjmWDeaHNuDxY8HgGZBemR