### PR TITLE
Add block-wise INT8 weight-only quantization (quantize_weight_only_int8_block)

### DIFF
--- a/docs/int8-block-quantization.md
+++ b/docs/int8-block-quantization.md
@@ -1,0 +1,130 @@
+# Block-wise INT8 weight-only quantization (`quantize_weight_only_int8_block`)
+
+## What this is
+
+`onnxsim.quantize_weight_only_int8_block` is a pair of single, self-contained
+C++ graph rewrites (`onnxsim/passes/weight_only_quantize_int8_block_matmul.h`,
+`onnxsim/passes/weight_only_quantize_int8_block_conv.h`) that block-wise
+quantize every `MatMul`, every "vanilla" `Gemm` (`transA=0`, `alpha=1`,
+`beta=1`), and every `Conv`, whose weight is a constant float32 tensor whose
+flattened reduction size is evenly divisible by 32 -- `K` for MatMul/Gemm;
+`Cin/groups * prod(kernel dims)` for Conv, exactly the same "flatten Conv's
+non-output-channel axes into one sequence" scheme
+`quantize_weight_only_int4` uses (see that doc's "Conv's flattened
+reduction" section -- it applies identically here).
+
+It sits between `quantize_weight_only` (INT8, one scale per output channel)
+and `quantize_weight_only_int4` (INT4, one scale per 32-element block): the
+**same INT8 bit width** as the former, at the **same block granularity** as
+the latter.
+
+- The **weight** is quantized to INT8 (values in `[-127, 127]`), with a
+  **separate symmetric scale per 32-element block of the reduction, per
+  output channel** -- identical granularity to `quantize_weight_only_int4`,
+  just with INT8's much wider 255-level code range instead of INT4's 15.
+- The **activation is never touched** -- same as every other weight-only
+  pass here: no calibration data, no runtime quantize/dequantize cost on
+  the activation path.
+
+```
+Before:
+  Y = MatMul(X, W)                                    # W constant, [K, N], float32
+
+After:
+  Wq  = <int8, per-(block, column) symmetric>          # computed once, here
+  Ws  = <float32, [K/32, N]>                            # one scale per block per column
+  Wdq = DequantizeLinear(Wq, Ws, axis=0, block_size=32) # float32
+  Y   = MatMul(X, Wdq)                                  # X is exactly as it was
+```
+
+This uses **ONNX opset 21's `DequantizeLinear` `block_size` attribute** --
+standard ONNX, not a contrib op -- the same requirement
+`quantize_weight_only_int4` has, even though plain INT8 itself is much
+older (opset 13 is enough for `quantize_weight_only`'s per-channel scheme).
+
+## Why this exists alongside the per-channel and INT4 schemes
+
+`quantize_weight_only`'s single per-channel scale is set by that channel's
+single largest-magnitude element; a channel with a wide dynamic range (a few
+much-larger-magnitude weights than the rest) under-resolves its
+smaller-magnitude weights as a result -- the same effective-resolution
+problem `docs/int16-quantization.md` describes for `quantize_weight_only_int16`.
+Block-wise scales fix this a different way: instead of widening the *type*
+(INT16), they narrow the *scope* each scale has to cover, so an outlier in
+one block no longer drags down every other block's resolution.
+
+Doing this at INT8 rather than INT4 keeps the per-element code range wide
+(255 levels vs. 15), so the *only* change from `quantize_weight_only` is
+where the resolution loss can hide -- not how much of it there is to begin
+with. The cost is almost entirely in the scale tensor: INT8 codes are still
+1 byte each either way, so `quantize_weight_only_int8_block`'s total size is
+only marginally larger than `quantize_weight_only`'s (one extra float per
+block instead of per channel) for meaningfully better resolution on
+outlier-heavy channels.
+
+## Scope
+
+Handled:
+- `MatMul(X, W)` with `W` a constant 2-D float32 tensor whose reduction
+  dimension (`K`) is a multiple of 32.
+- `Gemm(X, W[, B])` with `transA=0`, `alpha=1`, `beta=1` (when `B` is
+  present), same weight constraint. `transB` may be 0 or 1.
+- `Conv(X, W[, B])` with `W` a constant float32 tensor, rank >= 3, whose
+  flattened `Cin/groups * prod(k...)` is a multiple of 32.
+- Opsets >= 21.
+
+Left untouched (safe no-op, node passes through as-is):
+- A reduction size that is not a multiple of 32 -- a ragged last block is
+  left to a future extension rather than approximated, matching
+  `quantize_weight_only_int4`.
+- Non-constant or unsupported-rank weights, non-default Gemm attributes,
+  non-float32 operands, or an opset older than 21.
+
+## End-to-end: simplify -> quantize -> deploy
+
+### CLI
+
+```bash
+onnxsim model.onnx model.quant.onnx --weight-only-quantize-int8-block
+```
+
+### Python API
+
+```python
+import onnx
+import onnxruntime as ort
+import onnxsim
+
+model = onnx.load("model.onnx")
+model, check_ok = onnxsim.simplify(model)
+assert check_ok
+
+model = onnxsim.quantize_weight_only_int8_block(model)
+onnx.save(model, "model.quant.onnx")
+
+sess = ort.InferenceSession("model.quant.onnx", providers=["CPUExecutionProvider"])
+outputs = sess.run(None, {"input": your_input_array})
+```
+
+`tests/test_weight_only_quantize_int8_block.py` runs this simplify ->
+quantize -> deploy sequence on small `MatMul`/`Gemm`/`Conv` models, executing
+both the float and quantized graphs through `onnxruntime.InferenceSession`,
+plus a direct comparison against `quantize_weight_only`'s per-channel scheme
+on an outlier-heavy weight confirming the block-wise scheme resolves it more
+closely.
+
+## Relationship to onnxsim's other weight-only schemes
+
+| | Bits | Scale granularity | Typical compression |
+|---|---|---|---|
+| `quantize_weight_only` | INT8 | one scale per output channel | ~4x |
+| `quantize_weight_only_int8_block` | INT8 | one scale per 32-element block, per output channel | ~4x (marginally more scale-tensor overhead) |
+| `quantize_weight_only_int16` | INT16 | one scale per output channel | ~2x |
+| `quantize_weight_only_int4` | INT4 | one scale per 32-element block, per output channel | ~7-8x |
+
+All four leave the activation untouched and need no calibration data. Pick
+`quantize_weight_only_int8_block` over plain `quantize_weight_only` when a
+weight has outlier-heavy channels but INT4's narrower code range (or
+INT16's larger footprint) isn't the right tradeoff -- it keeps INT8's
+storage and accuracy profile while fixing the specific resolution problem a
+single per-channel scale has on that kind of weight.

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -19,6 +19,7 @@ from onnxsim.onnx_simplifier import (
     quantize_ternary,
     quantize_weight_only,
     quantize_weight_only_int4,
+    quantize_weight_only_int8_block,
     quantize_weight_only_int16,
     simplify,
 )
@@ -32,6 +33,7 @@ __all__ = [
     "quantize_ternary",
     "quantize_weight_only",
     "quantize_weight_only_int4",
+    "quantize_weight_only_int8_block",
     "quantize_weight_only_int16",
     "quantize_static",
     "quantize_qoperator",

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -436,6 +436,26 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
       },
       "model_bytes"_a);
 
+  // Block-wise INT8 weight-only quantizes MatMul/Gemm/Conv weights (one
+  // symmetric scale per 32-element block of the flattened reduction
+  // dimension, per output channel) via a single DequantizeLinear(axis=...,
+  // block_size=32) -- activations are never touched, so no calibration data
+  // or ModelExecutor is needed. See QuantizeWeightOnlyInt8Block in
+  // onnxsim.h.
+  m.def(
+      "quantize_weight_only_int8_block",
+      [](const py::bytes& model_proto_bytes) -> py::bytes {
+        InitEnv();
+        ONNX_NAMESPACE::ModelProto model;
+        ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
+                            model_proto_bytes.size());
+        const auto result = QuantizeWeightOnlyInt8Block(model);
+        std::string out;
+        result.SerializeToString(&out);
+        return py::bytes(out.data(), out.size());
+      },
+      "model_bytes"_a);
+
   // Lists the activation tensor names quantize_static could quantize --
   // see ListQuantizableActivations in onnxsim.h.
   m.def(

--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -36,6 +36,8 @@
 #include "passes/weight_only_quantize_int16_matmul.h"
 #include "passes/weight_only_quantize_int4_conv.h"
 #include "passes/weight_only_quantize_int4_matmul.h"
+#include "passes/weight_only_quantize_int8_block_conv.h"
+#include "passes/weight_only_quantize_int8_block_matmul.h"
 #include "passes/weight_only_quantize_matmul.h"
 
 namespace onnxsim {
@@ -93,6 +95,8 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::WeightOnlyQuantizeInt16MatMul>(registry);
     RegisterOrReplace<p::WeightOnlyQuantizeInt4Conv>(registry);
     RegisterOrReplace<p::WeightOnlyQuantizeInt4MatMul>(registry);
+    RegisterOrReplace<p::WeightOnlyQuantizeInt8BlockConv>(registry);
+    RegisterOrReplace<p::WeightOnlyQuantizeInt8BlockMatMul>(registry);
     RegisterOrReplace<p::WeightOnlyQuantizeMatMul>(registry);
 
     // onnxsim's patched versions of built-in onnxoptimizer passes. These

--- a/onnxsim/custom_optimizer_passes.h
+++ b/onnxsim/custom_optimizer_passes.h
@@ -35,6 +35,8 @@ namespace onnxsim {
 //   - weight_only_quantize_int4_conv
 //   - weight_only_quantize_int16_matmul
 //   - weight_only_quantize_int16_conv
+//   - weight_only_quantize_int8_block_matmul
+//   - weight_only_quantize_int8_block_conv
 //   - qoperator_quantize_matmul
 //   - qoperator_quantize_conv
 //   - quantize_fp16

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -562,6 +562,55 @@ def quantize_weight_only_int16(model: Union[str, onnx.ModelProto]) -> onnx.Model
     )
 
 
+def quantize_weight_only_int8_block(
+    model: Union[str, onnx.ModelProto],
+) -> onnx.ModelProto:
+    """
+    Block-wise INT8 weight-only quantize every MatMul, every "vanilla" Gemm
+    (transA=0, alpha=1, beta=1), and every Conv, whose weight is a constant
+    float32 tensor whose flattened reduction size -- ``K`` for MatMul/Gemm;
+    ``Cin/groups * prod(kernel dims)`` for Conv -- is evenly divisible by 32.
+
+    The weight is quantized to INT8 (values in ``[-127, 127]``) with a
+    separate symmetric scale per 32-element block of that reduction, per
+    output channel -- the same block-wise granularity
+    :func:`quantize_weight_only_int4` uses, just at INT8's wider code range
+    -- inserting a single ``DequantizeLinear(..., block_size=32)`` in its
+    place (Conv's weight is flattened to 2-D for this, then a ``Reshape``
+    restores its original shape). Like :func:`quantize_weight_only`, the
+    activation is never touched: no calibration data, no runtime
+    quantize/dequantize cost on the activation path.
+
+    This sits between :func:`quantize_weight_only`'s single per-channel INT8
+    scale (coarser, no block overhead) and
+    :func:`quantize_weight_only_int4`'s block-wise INT4 (finer blocks, but
+    only 15 representable codes per block): the same storage as
+    :func:`quantize_weight_only` (INT8 codes are still 1 byte each; only the
+    scale tensor grows, from one float per channel to one float per (block,
+    channel) pair), with resolution closer to a per-block scheme. Uses ONNX
+    opset 21's ``DequantizeLinear`` ``block_size`` attribute -- standard
+    ONNX, not a contrib op -- the same opset floor as
+    :func:`quantize_weight_only_int4`, even though plain INT8 itself needs
+    only opset 13.
+
+    This is a single, self-contained graph rewrite: unlike :func:`simplify`,
+    it does not run shape inference, constant folding, or any other pass.
+    Nodes that do not match (dynamic or unsupported-rank weights, a
+    reduction size not divisible by 32, non-default Gemm attributes,
+    non-float32 operands, an opset older than 21) are left untouched.
+    Consider calling :func:`simplify` before and/or after to clean up the
+    graph.
+
+    :param model: onnx ModelProto object or file path
+    :returns: the quantized onnx ModelProto
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    return onnx.load_from_string(
+        C.quantize_weight_only_int8_block(model.SerializeToString())
+    )
+
+
 def quantize_fp16(
     model: Union[str, onnx.ModelProto], keep_io_types: bool = True
 ) -> onnx.ModelProto:
@@ -1638,6 +1687,19 @@ def main():
         action="store_true",
     )
     parser.add_argument(
+        "--weight-only-quantize-int8-block",
+        help="After simplifying, block-wise INT8 weight-only quantize "
+        "MatMul/Gemm/Conv weights (one symmetric scale per 32-element block "
+        "of the flattened reduction dimension, per output channel, values "
+        "in [-127, 127]), inserting a single "
+        "DequantizeLinear(block_size=32) per weight. Activations are never "
+        "touched. Same storage as --weight-only-quantize's INT8, but "
+        "resolution closer to --weight-only-quantize-int4's block-wise "
+        "scheme. Needs opset >= 21. See "
+        "onnxsim.quantize_weight_only_int8_block.",
+        action="store_true",
+    )
+    parser.add_argument(
         "--fp16-quantize",
         help="After simplifying, convert every float32 weight (and, by "
         "default, every internal activation) to float16 -- no calibration "
@@ -1948,6 +2010,10 @@ def main():
     if args.weight_only_quantize_int16:
         print("INT16 weight-only quantizing MatMul/Gemm/Conv weights...")
         model_opt = quantize_weight_only_int16(model_opt)
+
+    if args.weight_only_quantize_int8_block:
+        print("Block-wise INT8 weight-only quantizing MatMul/Gemm/Conv weights...")
+        model_opt = quantize_weight_only_int8_block(model_opt)
 
     if args.fp16_quantize:
         print("Converting float32 weights/activations to float16...")

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -256,6 +256,39 @@ onnx::ModelProto QuantizeWeightOnlyInt4(const onnx::ModelProto& model);
 // are left as-is.
 onnx::ModelProto QuantizeWeightOnlyInt16(const onnx::ModelProto& model);
 
+// Block-wise INT8 weight-only quantizes every MatMul, every "vanilla" Gemm
+// (transA=0, alpha=1, beta=1), and every Conv, whose weight is a constant
+// float32 tensor whose flattened reduction size (K for MatMul/Gemm --
+// transposed [N, K] or not; Cin/groups * prod(kernel dims) for Conv) is
+// evenly divisible by 32: the weight is quantized to INT8 (values in
+// [-127, 127]) with a separate symmetric scale per 32-element block of that
+// reduction, per output channel, inserting a single
+// ``DequantizeLinear(axis=..., block_size=32)`` in its place (Conv's weight
+// is flattened to 2-D for this, then a ``Reshape`` restores its original
+// shape -- see ``passes/weight_only_quantize_int8_block_conv.h``). Sits
+// between ``QuantizeWeightOnly``'s single per-channel INT8 scale (coarser,
+// no block overhead) and ``QuantizeWeightOnlyInt4``'s block-wise INT4
+// (finer blocks, but only 15 representable codes per block): the same
+// storage as ``QuantizeWeightOnly`` (INT8 codes are still 1 byte each; only
+// the scale tensor grows, from one float per channel to one float per
+// (block, channel) pair) with resolution closer to a per-block scheme.
+// Like ``QuantizeWeightOnly``, the activation is never touched -- no
+// calibration data, no runtime quantize/dequantize cost on the activation
+// path. Uses ONNX opset 21's ``DequantizeLinear`` `block_size` attribute
+// (standard ONNX, not a contrib op) -- the same opset floor as
+// ``QuantizeWeightOnlyInt4``, even though plain INT8 itself needs only
+// opset 13. See ``passes/weight_only_quantize_int8_block_matmul.h`` and
+// ``passes/weight_only_quantize_int8_block_conv.h`` for the rewrites
+// themselves.
+//
+// Unlike ``Simplify``, this does not run shape inference, constant folding or
+// any other simplification pass -- it applies exactly these rewrites, once
+// each, to a copy of ``model`` (which is left untouched) and returns the
+// result. Nodes that do not match (dynamic or unsupported-rank weights, a
+// reduction size not divisible by 32, non-default Gemm attributes,
+// non-float32 operands, an opset older than 21) are left as-is.
+onnx::ModelProto QuantizeWeightOnlyInt8Block(const onnx::ModelProto& model);
+
 // Lists the activation tensor names that ``QuantizeStatic`` could quantize in
 // ``model`` -- the first input of every MatMul, every "vanilla" Gemm
 // (transA=0, alpha=1, beta=1), and every Conv, whose weight is a constant

--- a/onnxsim/passes/quantize_conv_common.h
+++ b/onnxsim/passes/quantize_conv_common.h
@@ -241,6 +241,62 @@ inline bool TryQuantizeConvWeightBlockwiseInt4Flat(const Tensor& w_t,
   return true;
 }
 
+// Same flatten-then-block scheme as TryQuantizeConvWeightBlockwiseInt4Flat,
+// but INT8 (values in [-127, 127], scale = max(|w|) / 127 per block) instead
+// of INT4 -- see TryQuantizeWeightBlockwiseInt8InPlace in
+// quantize_matmul_common.h for why this exists alongside the per-channel
+// INT8 scheme (QuantizeConvWeightPerOutputChannel) and the INT4 block-wise
+// one. Used by weight_only_quantize_int8_block_conv.h. `q_out`/`scale_out`
+// are 2-D ([C, inner] and [C, inner / block_size]) even though `w_t` is not
+// -- like the INT4 version, the caller reshapes the DequantizeLinear output
+// back to `w_t`'s original shape.
+inline bool TryQuantizeConvWeightBlockwiseInt8Flat(const Tensor& w_t,
+                                                   int64_t block_size,
+                                                   Tensor& q_out,
+                                                   Tensor& scale_out) {
+  const auto& sizes = w_t.sizes();
+  const int64_t C = sizes[0];
+  int64_t inner = 1;
+  for (size_t i = 1; i < sizes.size(); ++i) {
+    inner *= sizes[i];
+  }
+  if (block_size <= 0 || inner % block_size != 0) {
+    return false;
+  }
+  const int64_t num_blocks = inner / block_size;
+
+  const std::vector<float> data = ReadFloatTensorFlat(w_t);
+
+  std::vector<float> scale(static_cast<size_t>(C * num_blocks), 0.0f);
+  for (int64_t c = 0; c < C; ++c) {
+    for (int64_t j = 0; j < inner; ++j) {
+      float& s = scale[static_cast<size_t>(c * num_blocks + j / block_size)];
+      s = std::max(s, std::fabs(data[static_cast<size_t>(c * inner + j)]));
+    }
+  }
+  for (float& s : scale) {
+    s = s > 0.0f ? s / 127.0f : 1.0f;
+  }
+
+  q_out.elem_type() = TensorProto_DataType_INT8;
+  q_out.sizes() = {C, inner};
+  q_out.int32s().resize(static_cast<size_t>(C * inner));
+  for (int64_t c = 0; c < C; ++c) {
+    for (int64_t j = 0; j < inner; ++j) {
+      const float s =
+          scale[static_cast<size_t>(c * num_blocks + j / block_size)];
+      const float q = std::round(data[static_cast<size_t>(c * inner + j)] / s);
+      q_out.int32s()[c * inner + j] =
+          static_cast<int32_t>(std::clamp(q, -127.0f, 127.0f));
+    }
+  }
+
+  scale_out.elem_type() = TensorProto_DataType_FLOAT;
+  scale_out.sizes() = {C, num_blocks};
+  scale_out.floats() = std::move(scale);
+  return true;
+}
+
 }  // namespace onnxsim_passes
 }  // namespace optimization
 }  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/quantize_matmul_common.h
+++ b/onnxsim/passes/quantize_matmul_common.h
@@ -427,6 +427,75 @@ inline bool TryQuantizeWeightBlockwiseInt4InPlace(const Tensor& w_t,
   return true;
 }
 
+// Same block-wise scheme as TryQuantizeWeightBlockwiseInt4InPlace, but INT8
+// (values in [-127, 127], scale = max(|w|) / 127 per block) instead of
+// INT4 -- a middle ground between QuantizeWeightPerChannelInPlace's single
+// per-channel INT8 scale (coarser, no block overhead) and INT4's block-wise
+// scheme (finer, but a much narrower 4-bit code range): the same per-channel
+// bit width as quantize_weight_only, with block-wise quantization's better
+// resolution for channels a single per-channel scale would under-resolve.
+// Used by weight_only_quantize_int8_block_matmul.h.
+//
+// Unlike INT4, INT8 has no dedicated typed field in TensorProto either, but
+// (like INT8/UINT8/INT16/etc. generally) it lives in `int32_data`/
+// `Tensor::int32s()`, not raw_data -- see ConvertFloatTensorToFp16's comment
+// in quantize_fp16.h for the general rule this follows, and contrast with
+// TryQuantizeWeightBlockwiseInt4InPlace's raw_data nibble-packing, which INT8
+// does not need.
+inline bool TryQuantizeWeightBlockwiseInt8InPlace(const Tensor& w_t,
+                                                  int64_t channel_axis,
+                                                  int64_t block_size,
+                                                  Tensor& q_out,
+                                                  Tensor& scale_out) {
+  const auto& sizes = w_t.sizes();
+  const int64_t dim0 = sizes[0];
+  const int64_t dim1 = sizes[1];
+  const int64_t reduction_axis = 1 - channel_axis;
+  const int64_t K = reduction_axis == 0 ? dim0 : dim1;
+  if (block_size <= 0 || K % block_size != 0) {
+    return false;
+  }
+  const int64_t num_blocks = K / block_size;
+
+  const std::vector<float> data = ReadFloatMatrix(w_t);
+  auto at = [&](int64_t i, int64_t j) { return data[i * dim1 + j]; };
+  const int64_t scale_dim0 = reduction_axis == 0 ? num_blocks : dim0;
+  const int64_t scale_dim1 = reduction_axis == 1 ? num_blocks : dim1;
+  auto scale_index = [&](int64_t i, int64_t j) {
+    const int64_t si = reduction_axis == 0 ? i / block_size : i;
+    const int64_t sj = reduction_axis == 1 ? j / block_size : j;
+    return si * scale_dim1 + sj;
+  };
+
+  std::vector<float> scale(static_cast<size_t>(scale_dim0 * scale_dim1), 0.0f);
+  for (int64_t i = 0; i < dim0; ++i) {
+    for (int64_t j = 0; j < dim1; ++j) {
+      float& s = scale[static_cast<size_t>(scale_index(i, j))];
+      s = std::max(s, std::fabs(at(i, j)));
+    }
+  }
+  for (float& s : scale) {
+    s = s > 0.0f ? s / 127.0f : 1.0f;
+  }
+
+  q_out.elem_type() = TensorProto_DataType_INT8;
+  q_out.sizes() = {dim0, dim1};
+  q_out.int32s().resize(static_cast<size_t>(dim0 * dim1));
+  for (int64_t i = 0; i < dim0; ++i) {
+    for (int64_t j = 0; j < dim1; ++j) {
+      const float s = scale[static_cast<size_t>(scale_index(i, j))];
+      const float q = std::round(at(i, j) / s);
+      q_out.int32s()[i * dim1 + j] =
+          static_cast<int32_t>(std::clamp(q, -127.0f, 127.0f));
+    }
+  }
+
+  scale_out.elem_type() = TensorProto_DataType_FLOAT;
+  scale_out.sizes() = {scale_dim0, scale_dim1};
+  scale_out.floats() = std::move(scale);
+  return true;
+}
+
 }  // namespace onnxsim_passes
 }  // namespace optimization
 }  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/weight_only_quantize_int8_block_conv.h
+++ b/onnxsim/passes/weight_only_quantize_int8_block_conv.h
@@ -1,0 +1,169 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+// Block-wise INT8 weight-only quantization for Conv, mirroring
+// weight_only_quantize_int8_block_matmul.h's rationale (no activation
+// quantization, no calibration data, INT8's usual code range at INT4-style
+// block granularity) the same way weight_only_quantize_int4_conv.h mirrors
+// weight_only_quantize_int4_matmul.h. The only real difference is Conv's
+// weight shape: unlike MatMul/Gemm, whose weight has one clean reduction
+// axis (K) to block along, Conv's weight ([Cout, Cin/groups, k...]) has no
+// single such axis -- every one of Cin/groups and the kernel spatial dims
+// contributes to one output pixel's sum. So instead of blocking one of
+// Conv's own axes directly (which would put an independent scale on every
+// kernel spatial position -- little compression benefit for, say, a 3x3
+// kernel), this flattens everything but the output channel into one
+// sequence and blocks *that* (TryQuantizeConvWeightBlockwiseInt8Flat), then
+// reshapes the dequantized result back to Conv's expected weight shape:
+//
+// inner = Cin/groups * prod(k...)
+//
+// Before:
+//   Y = Conv(X, W)             W constant, float32, [Cout, Cin/groups, k...]
+// After:
+//   Wq_flat  = <int8, [Cout, inner]>
+//   Ws_flat  = <float32, [Cout, inner / kBlockSize]>
+//   Wdq_flat = DequantizeLinear(Wq_flat, Ws_flat, axis=1,
+//                                block_size=kBlockSize)
+//   Wdq      = Reshape(Wdq_flat, [Cout, Cin/groups, k...])
+//   Y        = Conv(X, Wdq)
+//
+// Only Conv's `W` input is quantized; its activation, optional bias (a
+// third input, left untouched), and kernel/stride/pad/dilation/group/
+// auto_pad attributes are unchanged.
+//
+// Only the common, unambiguous shape is handled: a Conv whose weight (input
+// 1) is a constant float32 tensor, rank >= 3, whose flattened
+// Cin/groups * prod(k...) is evenly divisible by kBlockSize, and whose
+// activation (input 0) is float32. Everything else -- non-constant weights,
+// an `inner` not divisible by kBlockSize, non-float32 operands, an opset
+// older than 21 (DequantizeLinear's `block_size` attribute requires it) --
+// is left alone.
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+#include "passes/quantize_conv_common.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+struct WeightOnlyQuantizeInt8BlockConv final : public PredicateBasedPass {
+  // Same default as weight_only_quantize_int8_block_matmul.h -- see that
+  // file's doc comment for the rationale.
+  static constexpr int64_t kBlockSize = 32;
+
+  explicit WeightOnlyQuantizeInt8BlockConv()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+  std::string getPassName() const override {
+    return "weight_only_quantize_int8_block_conv";
+  }
+
+  static int64_t InnerSize(const std::vector<int64_t>& sizes) {
+    int64_t inner = 1;
+    for (size_t i = 1; i < sizes.size(); ++i) {
+      inner *= sizes[i];
+    }
+    return inner;
+  }
+
+  bool patternMatchPredicate(Node* n) override {
+    ConvInfo info;
+    if (!MatchConv(n, info)) {
+      return false;
+    }
+    const int opset = getOpsetVersion(*n->owningGraph());
+    if (opset != 0 && opset < 21) {
+      // DequantizeLinear's `block_size` attribute needs opset >= 21.
+      return false;
+    }
+    if (info.x->elemType() != TensorProto_DataType_FLOAT) {
+      return false;
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+        w_t->sizes().size() < 3) {
+      return false;
+    }
+    return InnerSize(w_t->sizes()) % kBlockSize == 0;
+  }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+    ConvInfo info;
+    if (!MatchConv(n, info)) {
+      return false;
+    }
+    if (info.x->elemType() != TensorProto_DataType_FLOAT) {
+      return false;
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+        w_t->sizes().size() < 3) {
+      return false;
+    }
+
+    Tensor w_q;
+    Tensor w_scale;
+    if (!TryQuantizeConvWeightBlockwiseInt8Flat(*w_t, kBlockSize, w_q,
+                                                w_scale)) {
+      return false;
+    }
+
+    Value* w_q_v = graph.addInitializerAndCreateValue(w_q);
+    Value* w_scale_v = graph.addInitializerAndCreateValue(w_scale);
+
+    // Wdq_flat = DequantizeLinear(Wq_flat, Ws_flat, axis=1,
+    // block_size=kBlockSize) -- zero_point omitted (symmetric, i.e. always
+    // 0).
+    Node* wdq = graph.create(Symbol("DequantizeLinear"), 1);
+    wdq->addInput(w_q_v);
+    wdq->addInput(w_scale_v);
+    wdq->i_(kaxis, 1);
+    wdq->i_(Symbol("block_size"), kBlockSize);
+    wdq->insertBefore(n);
+    wdq->output()->setElemType(TensorProto_DataType_FLOAT);
+    // Value::setSizes takes vector<Dimension>, not Tensor::sizes()'s
+    // vector<int64_t> -- Dimension(int64_t) is an explicit converting
+    // constructor, so a range-construction from the int64 shape works.
+    wdq->output()->setSizes(
+        std::vector<Dimension>(w_q.sizes().begin(), w_q.sizes().end()));
+
+    // Wdq = Reshape(Wdq_flat, W's original [Cout, Cin/groups, k...] shape).
+    Tensor shape_t;
+    shape_t.elem_type() = TensorProto_DataType_INT64;
+    shape_t.sizes().push_back(static_cast<int64_t>(w_t->sizes().size()));
+    shape_t.int64s() = w_t->sizes();
+    Value* shape_v = graph.addInitializerAndCreateValue(shape_t);
+
+    Node* reshape = graph.create(kReshape, 1);
+    reshape->addInput(wdq->output());
+    reshape->addInput(shape_v);
+    reshape->insertBefore(n);
+    reshape->output()->setElemType(TensorProto_DataType_FLOAT);
+    reshape->output()->setSizes(
+        std::vector<Dimension>(w_t->sizes().begin(), w_t->sizes().end()));
+
+    // Conv and its activation input are left untouched; only the weight
+    // input changes, to its dequantized (and reshaped-back) counterpart.
+    // Its optional bias (input 2) is untouched.
+    n->replaceInput(1, reshape->output());
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/weight_only_quantize_int8_block_matmul.h
+++ b/onnxsim/passes/weight_only_quantize_int8_block_matmul.h
@@ -1,0 +1,150 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+// Block-wise INT8 weight-only quantization: like weight_only_quantize_matmul.h,
+// only the constant weight is quantized and the activation is left exactly as
+// it was -- no calibration data, no runtime quantize/dequantize cost on the
+// activation path. The difference from that pass is granularity, not bit
+// width: a separate scale per (block-of-K, output-channel) group instead of
+// one scale per output channel, the same block-wise scheme
+// weight_only_quantize_int4_matmul.h uses, just at INT8's wider code range.
+//
+// This sits between quantize_weight_only's INT8 (one scale per channel --
+// no block overhead, but a channel with a wide value range under-resolves
+// its smaller-magnitude weights) and quantize_weight_only_int4's INT4
+// (finer blocks, but only 15 representable codes per block): the same
+// storage as the plain INT8 pass (INT8 codes are still 1 byte each; only the
+// scale tensor grows, from one float per channel to one float per
+// (block, channel) pair), with resolution closer to a per-block scheme.
+//
+// Before (illustrated for MatMul; a "vanilla" Gemm -- transA=0, alpha=1,
+// beta=1 -- is handled the same way, its bias C left untouched):
+//   Y = MatMul(X, W)         W constant, 2-D, float32, [K, N]
+// After:
+//   Wdq = DequantizeLinear(Wq, Ws, axis=<K's axis>, block_size=kBlockSize)
+//   Y   = MatMul(X, Wdq)
+//
+// Wq (int8, values in [-127, 127]) and Ws (float32, one scale per (block,
+// output channel) pair) are computed once, here, from W's static values --
+// see TryQuantizeWeightBlockwiseInt8InPlace. This uses ONNX opset 21's
+// DequantizeLinear `block_size` attribute (standard ONNX, not a contrib
+// op) -- INT8 itself is much older, but the blocked form needs the same
+// opset 21 floor as weight_only_quantize_int4_matmul.h's INT4 scheme.
+//
+// Only the common, unambiguous shape is handled: a MatMul, or a Gemm with
+// transA=0, alpha=1 and beta=1 (transB may be 0 or 1), whose weight (input 1)
+// is a constant 2-D float32 tensor whose reduction dimension K is evenly
+// divisible by kBlockSize, and whose activation (input 0) is float32.
+// Everything else -- non-constant or non-2-D weights, a K not divisible by
+// kBlockSize, non-default Gemm attributes, non-float32 operands, an opset
+// older than 21 -- is left alone.
+
+#pragma once
+
+#include <cstdint>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+#include "passes/quantize_matmul_common.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+struct WeightOnlyQuantizeInt8BlockMatMul final : public PredicateBasedPass {
+  // Same default as weight_only_quantize_int4_matmul.h -- see that file's
+  // doc comment for the rationale (32 favors accuracy over the scale-tensor
+  // overhead a larger block would save).
+  static constexpr int64_t kBlockSize = 32;
+
+  explicit WeightOnlyQuantizeInt8BlockMatMul()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+  std::string getPassName() const override {
+    return "weight_only_quantize_int8_block_matmul";
+  }
+
+  bool patternMatchPredicate(Node* n) override {
+    MatMulLikeInfo info;
+    if (!MatchMatMulLike(n, info)) {
+      return false;
+    }
+    const int opset = getOpsetVersion(*n->owningGraph());
+    if (opset != 0 && opset < 21) {
+      // DequantizeLinear's `block_size` attribute needs opset >= 21.
+      return false;
+    }
+    if (info.x->elemType() != TensorProto_DataType_FLOAT) {
+      return false;
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+        w_t->sizes().size() != 2) {
+      return false;
+    }
+    const int64_t channel_axis = info.weight_transposed ? 0 : 1;
+    const int64_t K = w_t->sizes()[1 - channel_axis];
+    return K % kBlockSize == 0;
+  }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    // This pass only ever replaces `n`'s weight input, never `n` itself.
+    destroy_current = NodeDestroyType::DestroyZero;
+    MatMulLikeInfo info;
+    if (!MatchMatMulLike(n, info)) {
+      return false;
+    }
+    if (info.x->elemType() != TensorProto_DataType_FLOAT) {
+      return false;
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+        w_t->sizes().size() != 2) {
+      return false;
+    }
+
+    // W's output-channel axis in its own (untransposed) layout: axis 0 when
+    // Gemm's transB made W [N, K], else axis 1 ([K, N], MatMul's own layout).
+    // The reduction axis (the one blocked) is the other one.
+    const int64_t channel_axis = info.weight_transposed ? 0 : 1;
+    const int64_t reduction_axis = 1 - channel_axis;
+    Tensor w_q;
+    Tensor w_scale;
+    if (!TryQuantizeWeightBlockwiseInt8InPlace(*w_t, channel_axis, kBlockSize,
+                                               w_q, w_scale)) {
+      return false;
+    }
+
+    Value* w_q_v = graph.addInitializerAndCreateValue(w_q);
+    Value* w_scale_v = graph.addInitializerAndCreateValue(w_scale);
+
+    // Wdq = DequantizeLinear(Wq, Ws, axis=reduction_axis,
+    // block_size=kBlockSize) -- zero_point omitted (symmetric, i.e. always
+    // 0).
+    Node* wdq = graph.create(Symbol("DequantizeLinear"), 1);
+    wdq->addInput(w_q_v);
+    wdq->addInput(w_scale_v);
+    wdq->i_(kaxis, reduction_axis);
+    wdq->i_(Symbol("block_size"), kBlockSize);
+    wdq->insertBefore(n);
+    wdq->output()->setElemType(TensorProto_DataType_FLOAT);
+    if (info.w->sizes().size() > 0) {
+      wdq->output()->setSizes(info.w->sizes());
+    }
+
+    // The MatMul/Gemm node and its activation input are left untouched; only
+    // the weight input changes, to its dequantized counterpart.
+    n->replaceInput(1, wdq->output());
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/quantize_entry.cpp
+++ b/onnxsim/quantize_entry.cpp
@@ -65,6 +65,17 @@ onnx::ModelProto QuantizeWeightOnlyInt16(const onnx::ModelProto& model) {
                                       "weight_only_quantize_int16_conv"});
 }
 
+onnx::ModelProto QuantizeWeightOnlyInt8Block(const onnx::ModelProto& model) {
+  PrepareSchemasForDebug(model);
+  // Registers weight_only_quantize_int8_block_matmul/_conv (idempotent)
+  // into onnxoptimizer's registry so OptimizeFixed can find them by name
+  // below.
+  onnxsim::RegisterCustomOptimizerPasses();
+  return onnx::optimization::OptimizeFixed(
+      model, std::vector<std::string>{"weight_only_quantize_int8_block_matmul",
+                                      "weight_only_quantize_int8_block_conv"});
+}
+
 std::vector<std::string> ListQuantizableActivations(
     const onnx::ModelProto& model) {
   PrepareSchemasForDebug(model);

--- a/onnxsim/quantize_entry.h
+++ b/onnxsim/quantize_entry.h
@@ -18,6 +18,7 @@ onnx::ModelProto QuantizeTernary(const onnx::ModelProto& model);
 onnx::ModelProto QuantizeWeightOnly(const onnx::ModelProto& model);
 onnx::ModelProto QuantizeWeightOnlyInt4(const onnx::ModelProto& model);
 onnx::ModelProto QuantizeWeightOnlyInt16(const onnx::ModelProto& model);
+onnx::ModelProto QuantizeWeightOnlyInt8Block(const onnx::ModelProto& model);
 
 std::vector<std::string> ListQuantizableActivations(
     const onnx::ModelProto& model);

--- a/tests/test_weight_only_quantize_int8_block.py
+++ b/tests/test_weight_only_quantize_int8_block.py
@@ -1,0 +1,247 @@
+"""Tests for ``onnxsim.quantize_weight_only_int8_block`` (the
+``weight_only_quantize_int8_block_matmul``/
+``weight_only_quantize_int8_block_conv`` C++ passes).
+
+Structurally identical to ``test_weight_only_quantize_int4.py``'s block-shape
+coverage (scale-shape check, block-size-mismatch skip, pointwise vs. spatial
+Conv) and ``test_weight_only_quantize_int16.py``'s real-execution/precision
+comparisons -- just checking INT8's wider code range at INT4's block-wise
+granularity instead. Needs opset 21 for DequantizeLinear's block_size
+attribute (INT8 itself needs only opset 13, but the blocked form shares
+INT4's opset floor).
+"""
+
+import collections
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+
+import onnxsim
+
+# A bare ``import onnxruntime`` would fail collection (not skip the test) on
+# platforms onnxruntime doesn't ship wheels for (e.g. s390x).
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(nodes, inputs, outputs, initializer, opset=21):
+    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+    )
+
+
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _op_counts(model):
+    return collections.Counter(n.op_type for n in model.graph.node)
+
+
+def _assert_close(float_outputs, quant_outputs, rel_l2_tol=0.1):
+    for f, q in zip(float_outputs, quant_outputs):
+        f = np.asarray(f, dtype=np.float64).ravel()
+        q = np.asarray(q, dtype=np.float64).ravel()
+        assert np.all(np.isfinite(q))
+        rel_l2 = np.linalg.norm(f - q) / max(np.linalg.norm(f), 1e-6)
+        assert rel_l2 < rel_l2_tol, f"relative L2 error too large: {rel_l2:.4f}"
+
+
+def test_quantize_matmul():
+    rng = np.random.default_rng(0)
+    K, N = 64, 16
+    weight = _f32(rng.standard_normal((K, N)) * 0.5, "W")
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [4, K])], [_vi("Y", [4, N])], [weight])
+
+    quant = onnxsim.quantize_weight_only_int8_block(model)
+    onnx.checker.check_model(quant)
+    ops = _op_counts(quant)
+    assert ops["MatMul"] == 1
+    assert ops["DequantizeLinear"] == 1
+
+    w_init = next(t for t in quant.graph.initializer if t.name != "W")
+    assert w_init.data_type == onnx.TensorProto.INT8
+
+    x = rng.standard_normal((4, K)).astype(np.float32)
+    _assert_close(_run(model, {"X": x}), _run(quant, {"X": x}))
+
+
+def test_quantize_more_precise_than_per_channel_int8():
+    # A weight with one dominant-outlier row should resolve noticeably
+    # better under block-wise scales (each block's own scale, not one scale
+    # for the whole channel dragged up by the outlier) than
+    # quantize_weight_only's single per-channel scale.
+    rng = np.random.default_rng(8)
+    K, N = 64, 8
+    w = rng.standard_normal((K, N)).astype(np.float32) * 0.1
+    w[0, :] = 50.0  # one outlier row blows a per-channel scale
+    weight = _f32(w, "W")
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [4, K])], [_vi("Y", [4, N])], [weight])
+
+    quant_per_channel = onnxsim.quantize_weight_only(model)
+    quant_block = onnxsim.quantize_weight_only_int8_block(model)
+
+    x = rng.standard_normal((4, K)).astype(np.float32)
+    float_out = _run(model, {"X": x})[0]
+    out_per_channel = _run(quant_per_channel, {"X": x})[0]
+    out_block = _run(quant_block, {"X": x})[0]
+
+    err_per_channel = np.linalg.norm(float_out - out_per_channel)
+    err_block = np.linalg.norm(float_out - out_block)
+    assert err_block < err_per_channel
+
+
+def test_quantize_gemm_transb_with_bias():
+    # PyTorch's nn.Linear layout: weight is [out_features, in_features], i.e.
+    # [N, K], exported as Gemm(X, W, B, transB=1) -- the common real-world case.
+    rng = np.random.default_rng(1)
+    K, N = 96, 12
+    weight = _f32(rng.standard_normal((N, K)) * 0.5, "W")
+    bias = _f32(rng.standard_normal(N), "B")
+    nodes = [onnx.helper.make_node("Gemm", ["X", "W", "B"], ["Y"], transB=1)]
+    model = _model(nodes, [_vi("X", [3, K])], [_vi("Y", [3, N])], [weight, bias])
+
+    quant = onnxsim.quantize_weight_only_int8_block(model)
+    onnx.checker.check_model(quant)
+    ops = _op_counts(quant)
+    assert ops["Gemm"] == 1
+    assert ops["DequantizeLinear"] == 1
+
+    x = rng.standard_normal((3, K)).astype(np.float32)
+    _assert_close(_run(model, {"X": x}), _run(quant, {"X": x}))
+
+
+def test_quantize_scale_shape_matches_block_count():
+    # K=64 with the pass's block_size=32 gives 2 blocks; the scale
+    # initializer must be [2, N] (block axis 0, matching MatMul's own [K, N]
+    # weight layout).
+    rng = np.random.default_rng(2)
+    K, N = 64, 8
+    weight = _f32(rng.standard_normal((K, N)) * 0.5, "W")
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [1, K])], [_vi("Y", [1, N])], [weight])
+
+    quant = onnxsim.quantize_weight_only_int8_block(model)
+    scale_init = next(
+        t
+        for t in quant.graph.initializer
+        if t.name != "W" and t.data_type == onnx.TensorProto.FLOAT
+    )
+    assert list(scale_init.dims) == [2, N]
+
+
+def test_quantize_skips_k_not_divisible_by_block_size():
+    # K=48 is not a multiple of the pass's block_size=32.
+    rng = np.random.default_rng(3)
+    K, N = 48, 8
+    weight = _f32(rng.standard_normal((K, N)) * 0.5, "W")
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [1, K])], [_vi("Y", [1, N])], [weight])
+
+    quant = onnxsim.quantize_weight_only_int8_block(model)
+    assert _op_counts(quant)["MatMul"] == 1
+    assert _op_counts(quant)["DequantizeLinear"] == 0
+
+
+def test_quantize_conv_pointwise():
+    # A 1x1 (pointwise) Conv: inner = Cin/groups * kH * kW = Cin * 1 * 1, so
+    # Cin=32 gives exactly one block -- the simplest Conv case, structurally
+    # equivalent to a per-pixel MatMul.
+    rng = np.random.default_rng(5)
+    cout, cin = 16, 32
+    weight = _f32(rng.standard_normal((cout, cin, 1, 1)) * 0.5, "W")
+    nodes = [onnx.helper.make_node("Conv", ["X", "W"], ["Y"], kernel_shape=[1, 1])]
+    model = _model(
+        nodes, [_vi("X", [1, cin, 8, 8])], [_vi("Y", [1, cout, 8, 8])], [weight]
+    )
+
+    quant = onnxsim.quantize_weight_only_int8_block(model)
+    onnx.checker.check_model(quant)
+    ops = _op_counts(quant)
+    assert ops["Conv"] == 1
+    assert ops["DequantizeLinear"] == 1
+    assert ops["Reshape"] == 1
+
+    w_init = next(
+        t for t in quant.graph.initializer if t.data_type == onnx.TensorProto.INT8
+    )
+    assert list(w_init.dims) == [cout, cin]  # flattened [Cout, inner]
+
+    x = rng.standard_normal((1, cin, 8, 8)).astype(np.float32)
+    _assert_close(_run(model, {"X": x}), _run(quant, {"X": x}))
+
+
+def test_quantize_conv_spatial_kernel_with_bias():
+    # kernel_shape=[2, 2], Cin=8 -> inner = 8 * 2 * 2 = 32: the flattening
+    # spans both the channel and spatial dims, unlike the pointwise case.
+    rng = np.random.default_rng(6)
+    cout, cin = 4, 8
+    weight = _f32(rng.standard_normal((cout, cin, 2, 2)) * 0.5, "W")
+    bias = _f32(rng.standard_normal(cout), "B")
+    nodes = [onnx.helper.make_node("Conv", ["X", "W", "B"], ["Y"], kernel_shape=[2, 2])]
+    model = _model(
+        nodes, [_vi("X", [1, cin, 8, 8])], [_vi("Y", [1, cout, 7, 7])], [weight, bias]
+    )
+
+    quant = onnxsim.quantize_weight_only_int8_block(model)
+    onnx.checker.check_model(quant)
+    ops = _op_counts(quant)
+    assert ops["Conv"] == 1
+    assert ops["DequantizeLinear"] == 1
+    assert ops["Reshape"] == 1
+
+    x = rng.standard_normal((1, cin, 8, 8)).astype(np.float32)
+    _assert_close(_run(model, {"X": x}), _run(quant, {"X": x}))
+
+
+def test_quantize_conv_skips_inner_not_divisible_by_block_size():
+    # inner = Cin * kH * kW = 4 * 3 * 3 = 36, not a multiple of 32.
+    rng = np.random.default_rng(7)
+    cout, cin = 4, 4
+    weight = _f32(rng.standard_normal((cout, cin, 3, 3)) * 0.5, "W")
+    nodes = [onnx.helper.make_node("Conv", ["X", "W"], ["Y"], kernel_shape=[3, 3])]
+    model = _model(
+        nodes,
+        [_vi("X", [1, cin, 8, 8])],
+        [_vi("Y", [1, cout, 6, 6])],
+        [weight],
+    )
+
+    quant = onnxsim.quantize_weight_only_int8_block(model)
+    assert _op_counts(quant)["Conv"] == 1
+    assert _op_counts(quant)["DequantizeLinear"] == 0
+
+
+def test_quantize_skips_non_constant_weight():
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(
+        nodes, [_vi("X", [4, 64]), _vi("W", [64, 4])], [_vi("Y", [4, 4])], []
+    )
+    quant = onnxsim.quantize_weight_only_int8_block(model)
+    assert _op_counts(quant)["MatMul"] == 1
+
+
+def test_quantize_skips_old_opset():
+    # DequantizeLinear's block_size attribute needs opset >= 21.
+    weight = _f32(np.random.default_rng(4).standard_normal((64, 4)), "W")
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [4, 64])], [_vi("Y", [4, 4])], [weight], opset=20)
+    quant = onnxsim.quantize_weight_only_int8_block(model)
+    assert _op_counts(quant)["MatMul"] == 1
+    assert _op_counts(quant)["DequantizeLinear"] == 0


### PR DESCRIPTION
## Summary

- Adds `quantize_weight_only_int8_block`, sitting between `quantize_weight_only`'s INT8 (one scale per output channel) and `quantize_weight_only_int4`'s block-wise INT4 (one scale per 32-element block, 15 representable codes): the same INT8 bit width as the former, at the same block granularity as the latter.
- Fixes the specific resolution problem a single per-channel scale has on outlier-heavy channels (dominated by one large-magnitude weight) without narrowing the code range the way INT4 does — total size is only marginally larger than plain `quantize_weight_only` (INT8 codes are still 1 byte each; only the scale tensor grows, from one float per channel to one float per (block, channel) pair).
- Adds `TryQuantizeWeightBlockwiseInt8InPlace` / `TryQuantizeConvWeightBlockwiseInt8Flat` (`quantize_matmul_common.h` / `quantize_conv_common.h`, mirroring the existing INT4 block-wise helpers exactly, just with INT8's wider clamp/scale-divisor constant and `int32s()`-based storage instead of INT4's `raw_data` nibble-packing) and two new passes (`weight_only_quantize_int8_block_matmul.h` / `_conv.h`), structurally identical to the existing INT4 block-wise passes.
- Needs opset >= 21 for `DequantizeLinear`'s `block_size` attribute — the same floor as `quantize_weight_only_int4`'s scheme, even though plain INT8 itself needs only opset 13.
- Wired through the full stack: `onnxsim.h`/`quantize_entry.{h,cpp}` entry point (`QuantizeWeightOnlyInt8Block`), nanobind binding, Python wrapper (`onnxsim.quantize_weight_only_int8_block`) + `--weight-only-quantize-int8-block` CLI flag, pass registration, tests, and docs (`docs/int8-block-quantization.md`).

## Test plan

- [x] `pytest tests/test_weight_only_quantize_int8_block.py -v` — 10 new tests pass: real MatMul/Gemm(transB+bias)/Conv(pointwise+spatial+bias) quantization executed end-to-end through `onnxruntime.InferenceSession`, a scale-shape check, block-size-mismatch skip coverage (MatMul K and Conv's flattened `Cin/groups*kernel`), the usual skip-condition coverage (non-constant weight, opset < 21), and a direct comparison against `quantize_weight_only`'s per-channel scheme on an outlier-heavy weight confirming the block-wise scheme resolves it more closely.
- [x] Full test suite (`pytest tests/` minus pre-existing torch/timm-dependent modules unrelated to this change): 272 passed, 64 skipped, no regressions.
- [x] `ruff format --check` / `ruff check` clean on touched Python files.
- [x] `clang-format --dry-run --Werror` clean on touched C++ files.
- [x] Manual CLI smoke test: `onnxsim model.onnx model.quant.onnx --weight-only-quantize-int8-block` produces a valid model with `DequantizeLinear`/`MatMul` and an `INT8` initializer.

https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU


---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_