### PR TITLE
Add static W8A16 quantization (quantize_static_int16)

### DIFF
--- a/docs/static-quantize-int16.md
+++ b/docs/static-quantize-int16.md
@@ -1,0 +1,120 @@
+# Static "W8A16" quantization (`quantize_static_int16`)
+
+## What this is
+
+`onnxsim.quantize_static_int16` is a pair of single, self-contained C++
+graph rewrites (`onnxsim/passes/static_quantize_int16_matmul.h`,
+`onnxsim/passes/static_quantize_int16_conv.h`) that statically
+(calibration-based) quantize every `MatMul`, every "vanilla" `Gemm`
+(`transA=0`, `alpha=1`, `beta=1`), and every `Conv`, whose weight is a
+constant float32 tensor -- the exact same QDQ scheme `onnxsim.quantize_static`
+uses, with one change: the **activation** is quantized to uint16 instead of
+uint8, while the **weight stays INT8**. This is sometimes called a "W8A16"
+scheme (8-bit weight, 16-bit activation).
+
+```
+Before:
+  Y = MatMul(X, W)                                   # W constant, [K, N], float32
+
+After (QDQ format -- the MatMul/Gemm/Conv node itself is untouched, only its
+inputs change):
+  Xq  = QuantizeLinear(X, Xs, Xzp)     -- Xs/Xzp: CALIBRATED, fixed, uint16
+  Xdq = DequantizeLinear(Xq, Xs, Xzp)
+  Wdq = DequantizeLinear(Wq, Ws, axis=1)              -- Wq: int8, per-channel
+  Y   = MatMul(Xdq, Wdq)
+```
+
+## Why only the activation gets the finer type
+
+The graph still computes in float32 either way -- QDQ format never replaces
+`MatMul`/`Gemm`/`Conv` with an integer kernel directly, it just brackets the
+float op with a `Cast`-like `QuantizeLinear`/`DequantizeLinear` round trip
+that a QDQ-aware runtime can later fuse. So the only thing a wider
+activation type changes is how much rounding error that round trip
+introduces on `X` before it reaches the (still-float32) op -- the weight's
+own INT8 precision is completely unaffected by the activation's type. Widening
+the weight too would cost real storage for no matching accuracy benefit,
+since the weight's precision was never the bottleneck this pass targets.
+
+This is aimed at activations a QDQ round trip is unusually sensitive to:
+
+- A tensor whose calibrated range is wide relative to its typical
+  value -- uint8's coarser step (1/255 relative) rounds most of that
+  tensor's actual values to a small handful of representable levels.
+- Post-softmax attention scores, or any other activation feeding a
+  downstream computation where small per-element errors compound across
+  many terms.
+
+uint16's ~8x finer step (1/65535 relative vs uint8's 1/255) resolves both
+cases while keeping the weight's INT8 compression exactly as-is.
+
+## Scope
+
+Handled: identical to `quantize_static` -- see its own scope description
+(mirrored by `onnxsim.list_quantizable_activations`) -- with one difference:
+
+- **Opsets >= 21** -- uint16 is a `QuantizeLinear`/`DequantizeLinear` type
+  only from opset 21 onward, unlike `quantize_static`'s uint8 scheme, which
+  only needs opset 13. An opset in `[13, 21)` is old for this pass even
+  though it would be fine for the uint8 one.
+
+Like `quantize_static`, a node is only rewritten when its activation's
+tensor name has a calibrated `(min, max)` entry -- this pass reads the same
+calibration-ranges data `quantize_static` does, so any calibration you
+already ran for `quantize_static` works unchanged here.
+
+## End-to-end: calibrate -> quantize -> deploy
+
+### CLI
+
+```bash
+onnxsim model.onnx model.quant.onnx --static-quantize-int16 \
+  --calibration-dataset mnist --calibration-samples 32
+```
+
+(Omit `--calibration-dataset` to calibrate from random data instead.)
+
+### Python API
+
+```python
+import onnx
+import onnxruntime as ort
+import onnxsim
+
+model = onnx.load("model.onnx")
+model, check_ok = onnxsim.simplify(model)
+assert check_ok
+
+# calibration_data defaults to onnxsim.generate_random_calibration_data;
+# pass real representative data (e.g. via onnxsim.load_huggingface_calibration_data)
+# for a tighter, more accurate calibration.
+model = onnxsim.quantize_static_int16(model)
+onnx.save(model, "model.quant.onnx")
+
+sess = ort.InferenceSession("model.quant.onnx", providers=["CPUExecutionProvider"])
+outputs = sess.run(None, {"input": your_input_array})
+```
+
+`tests/test_static_quantize_int16.py` runs this calibrate -> quantize ->
+deploy sequence on small `MatMul`/`Gemm`/`Conv` models, executing both the
+float and quantized graphs through `onnxruntime.InferenceSession`, plus a
+direct comparison against `quantize_static`'s uint8 scheme on the same
+calibrated activation confirming the uint16 round trip tracks the float
+baseline more closely.
+
+## Relationship to onnxsim's other quantization methods
+
+| | Weight | Activation | Calibration data | Opset floor |
+|---|---|---|---|---|
+| `quantize_static` | INT8, per-channel | uint8, calibrated QDQ | required | 13 |
+| `quantize_static_int16` | INT8, per-channel | uint16, calibrated QDQ | required | 21 |
+| `quantize_qoperator` | INT8, per-channel | uint8, calibrated, `QLinearMatMul` | required | 13 |
+| `quantize_dynamic` | INT8, per-channel | uint8, computed at runtime | none | 13 |
+| `quantize_weight_only` | INT8, per-channel | untouched | none | 13 |
+
+Pick `quantize_static_int16` over plain `quantize_static` when calibration
+shows a specific activation's range is unusually wide, or when the model's
+overall accuracy is more sensitive to activation rounding than its weight
+size -- otherwise `quantize_static`'s uint8 scheme is the better default,
+since it works on any opset >= 13 runtime and both formats need the same
+calibration data either way.

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -4,6 +4,7 @@ from onnxsim.calibration import (
     load_huggingface_calibration_data,
     quantize_qoperator,
     quantize_static,
+    quantize_static_int16,
 )
 from onnxsim.onnx_simplifier import (
     export_gguf,
@@ -36,6 +37,7 @@ __all__ = [
     "quantize_weight_only_int8_block",
     "quantize_weight_only_int16",
     "quantize_static",
+    "quantize_static_int16",
     "quantize_qoperator",
     "quantize_fp16",
     "quantize_bf16",

--- a/onnxsim/calibration.py
+++ b/onnxsim/calibration.py
@@ -531,6 +531,57 @@ def quantize_static(
     return onnx.load_from_string(C.quantize_static(model.SerializeToString(), ranges))
 
 
+def quantize_static_int16(
+    model: Union[str, onnx.ModelProto],
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_calibration_samples: int = 8,
+    seed: int = 0,
+    providers: Optional[Sequence[str]] = None,
+    method: str = "minmax",
+) -> onnx.ModelProto:
+    """
+    Same as :func:`quantize_static`, but a "W8A16" scheme: the weight stays
+    INT8 (identical per-output-channel symmetric scheme), while the
+    activation is quantized to uint16 instead of uint8 -- an 8x finer
+    calibrated affine step (1/65535 relative vs uint8's 1/255).
+
+    Useful for activations a QDQ round trip is unusually sensitive to (e.g.
+    post-softmax attention scores, or a tensor whose calibrated range is wide
+    relative to its typical value), without giving up INT8's weight
+    compression the way widening the weight too would. Needs opset >= 21
+    (uint16 QuantizeLinear/DequantizeLinear support), unlike
+    :func:`quantize_static`'s uint8 scheme, which only needs opset 13.
+
+    :param model: onnx ModelProto object or file path
+    :param calibration_data: representative input batches to calibrate
+            activation ranges from. Each batch is a ``{input_name: np.ndarray}``
+            dict matching the model's graph inputs -- see
+            :func:`generate_random_calibration_data` (the default, a quick
+            smoke test) and :func:`load_huggingface_calibration_data` (real
+            data, a much better calibration source for real deployment).
+    :param num_calibration_samples: number of random batches to generate when
+            ``calibration_data`` is not supplied
+    :param seed: seed for the random calibration data (ignored if
+            ``calibration_data`` is supplied)
+    :param providers: onnxruntime execution providers to run calibration on
+    :param method: calibration range method, passed through to
+            :func:`calibrate` -- ``"minmax"`` (default) or ``"entropy"``
+            (KL-divergence calibration; see that function for the tradeoff
+            and its extra data requirement).
+    :returns: the quantized onnx ModelProto
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            model, num_samples=num_calibration_samples, seed=seed
+        )
+    ranges = calibrate(model, calibration_data, providers=providers, method=method)
+    return onnx.load_from_string(
+        C.quantize_static_int16(model.SerializeToString(), ranges)
+    )
+
+
 def quantize_qoperator(
     model: Union[str, onnx.ModelProto],
     calibration_data: Optional[Sequence[Tensors]] = None,

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -492,6 +492,25 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
       },
       "model_bytes"_a, "activation_ranges"_a);
 
+  // Same as quantize_static, but a "W8A16" scheme: the weight stays INT8,
+  // while the activation is quantized to uint16 instead of uint8 (an 8x
+  // finer calibrated affine step) -- see QuantizeStaticInt16 in onnxsim.h.
+  m.def(
+      "quantize_static_int16",
+      [](const py::bytes& model_proto_bytes,
+         const std::unordered_map<std::string, std::pair<float, float>>&
+             activation_ranges) -> py::bytes {
+        InitEnv();
+        ONNX_NAMESPACE::ModelProto model;
+        ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
+                            model_proto_bytes.size());
+        const auto result = QuantizeStaticInt16(model, activation_ranges);
+        std::string out;
+        result.SerializeToString(&out);
+        return py::bytes(out.data(), out.size());
+      },
+      "model_bytes"_a, "activation_ranges"_a);
+
   // Lists the *output* tensor names quantize_qoperator could additionally
   // quantize, on top of list_quantizable_activations' input names -- see
   // ListQOperatorQuantizableOutputs in onnxsim.h.

--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -30,6 +30,8 @@
 #include "passes/quantize_fp16.h"
 #include "passes/quantize_fp8.h"
 #include "passes/static_quantize_conv.h"
+#include "passes/static_quantize_int16_conv.h"
+#include "passes/static_quantize_int16_matmul.h"
 #include "passes/static_quantize_matmul.h"
 #include "passes/weight_only_quantize_conv.h"
 #include "passes/weight_only_quantize_int16_conv.h"
@@ -89,6 +91,8 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::QuantizeFp16Pass>(registry);
     RegisterOrReplace<p::QuantizeFp8Pass>(registry);
     RegisterOrReplace<p::StaticQuantizeConv>(registry);
+    RegisterOrReplace<p::StaticQuantizeInt16Conv>(registry);
+    RegisterOrReplace<p::StaticQuantizeInt16MatMul>(registry);
     RegisterOrReplace<p::StaticQuantizeMatMul>(registry);
     RegisterOrReplace<p::WeightOnlyQuantizeConv>(registry);
     RegisterOrReplace<p::WeightOnlyQuantizeInt16Conv>(registry);

--- a/onnxsim/custom_optimizer_passes.h
+++ b/onnxsim/custom_optimizer_passes.h
@@ -29,6 +29,8 @@ namespace onnxsim {
 //   - dynamic_quantize_ternary_matmul
 //   - static_quantize_matmul
 //   - static_quantize_conv
+//   - static_quantize_int16_matmul
+//   - static_quantize_int16_conv
 //   - weight_only_quantize_matmul
 //   - weight_only_quantize_conv
 //   - weight_only_quantize_int4_matmul

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -1751,6 +1751,15 @@ def main():
         action="store_true",
     )
     parser.add_argument(
+        "--static-quantize-int16",
+        help="Same as --static-quantize, but a 'W8A16' scheme: weights stay "
+        "INT8, while activations are quantized to uint16 instead of uint8 "
+        "(an 8x finer calibrated step) -- useful for activations a QDQ "
+        "round trip is unusually sensitive to. Needs opset >= 21. See "
+        "onnxsim.quantize_static_int16.",
+        action="store_true",
+    )
+    parser.add_argument(
         "--qoperator-quantize",
         help="After simplifying, statically (calibration-based) quantize "
         "MatMul/Gemm weights and activations to INT8/uint8 into the "
@@ -1763,8 +1772,9 @@ def main():
     parser.add_argument(
         "--calibration-dataset",
         help="Hugging Face Hub dataset id (e.g. 'mnist') to pull "
-        "--calibration-samples real examples from for --static-quantize's "
-        "or --qoperator-quantize's calibration, instead of random data. See "
+        "--calibration-samples real examples from for --static-quantize's, "
+        "--static-quantize-int16's, or --qoperator-quantize's calibration, "
+        "instead of random data. See "
         "onnxsim.load_huggingface_calibration_data (needs the optional "
         "'datasets' package: pip install datasets).",
         type=str,
@@ -2048,6 +2058,31 @@ def main():
             )
         print("Statically quantizing MatMul/Gemm/Conv weights and activations...")
         model_opt = calibration.quantize_static(
+            model_opt, calibration_data=calibration_data, method=args.calibration_method
+        )
+
+    if args.static_quantize_int16:
+        from . import calibration
+
+        if args.calibration_dataset:
+            print(
+                f'Calibrating from Hugging Face dataset "{args.calibration_dataset}"...'
+            )
+            calibration_data = calibration.load_huggingface_calibration_data(
+                args.calibration_dataset,
+                model_opt,
+                num_samples=args.calibration_samples,
+            )
+        else:
+            print("Calibrating from random data...")
+            calibration_data = calibration.generate_random_calibration_data(
+                model_opt, num_samples=args.calibration_samples
+            )
+        print(
+            "Statically quantizing MatMul/Gemm/Conv weights (INT8) and "
+            "activations (uint16)..."
+        )
+        model_opt = calibration.quantize_static_int16(
             model_opt, calibration_data=calibration_data, method=args.calibration_method
         )
 

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -331,6 +331,30 @@ onnx::ModelProto QuantizeStatic(
     const std::unordered_map<std::string, std::pair<float, float>>&
         activation_ranges);
 
+// Same as ``QuantizeStatic``, but a "W8A16" scheme: the weight stays INT8
+// (identical per-output-channel symmetric scheme), while the activation is
+// quantized to UINT16 instead of UINT8 -- an 8x finer calibrated affine step
+// (1/65535 relative vs UINT8's 1/255). Useful for activations a QDQ round
+// trip is unusually sensitive to (e.g. post-softmax attention scores, or a
+// tensor whose calibrated range is wide relative to its typical value),
+// without giving up INT8's weight compression the way widening the weight
+// too would. Uses the same ``activation_ranges`` shape and
+// ``ListQuantizableActivations`` to discover candidate tensors as
+// ``QuantizeStatic``. See ``passes/static_quantize_int16_matmul.h`` and
+// ``passes/static_quantize_int16_conv.h`` for the rewrites themselves.
+// Needs opset >= 21 (UINT16 QuantizeLinear/DequantizeLinear support),
+// unlike ``QuantizeStatic``'s UINT8 scheme, which only needs opset 13.
+//
+// Unlike ``Simplify``, this does not run shape inference, constant folding or
+// any other simplification pass -- it applies exactly these rewrites, once
+// each, to a copy of ``model`` (which is left untouched) and returns the
+// result. Nodes that do not match, whose activation has no entry in
+// ``activation_ranges``, or whose opset is older than 21, are left as-is.
+onnx::ModelProto QuantizeStaticInt16(
+    const onnx::ModelProto& model,
+    const std::unordered_map<std::string, std::pair<float, float>>&
+        activation_ranges);
+
 // Lists the *output* tensor names that ``QuantizeQOperator`` could quantize
 // in ``model``, on top of the input tensor names ``ListQuantizableActivations``
 // already reports -- one entry per MatMul/"vanilla" Gemm/Conv whose weight

--- a/onnxsim/passes/static_quantize_int16_conv.h
+++ b/onnxsim/passes/static_quantize_int16_conv.h
@@ -1,0 +1,162 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+// Statically (calibration-based) quantizes Conv with a finer **activation**
+// quantization step, exactly mirroring static_quantize_int16_matmul.h's
+// MatMul/Gemm rewrite -- see that file's doc comment for the "W8A16"
+// rationale (weight stays INT8, only the activation widens to UINT16) and
+// the calibration-range global/quant-param helper both passes share
+// (StaticQuantizationCalibrationRanges / ComputeAsymmetricUint16QuantParams,
+// both defined in static_quantize_matmul.h). The only real difference from
+// the MatMul/Gemm version is the weight's per-output-channel axis: Conv's
+// weight layout ([Cout, Cin/groups, k...]) always puts the output channel on
+// axis 0, so unlike Gemm there is no transposed-layout case to pick between
+// -- the same relationship static_quantize_conv.h has to
+// static_quantize_matmul.h.
+//
+// Before:
+//   Y = Conv(X, W)            W constant, float32, rank >= 3
+// After (Conv itself is untouched, only its inputs change):
+//   Xq  = QuantizeLinear(X, Xs, Xzp)        -- Xs/Xzp: CALIBRATED, fixed,
+//   uint16 Xdq = DequantizeLinear(Xq, Xs, Xzp) Wdq = DequantizeLinear(Wq, Ws,
+//   axis=0)  -- Wq: int8 Y   = Conv(Xdq, Wdq)
+//
+// Only Conv's ``X`` and ``W`` inputs are quantized; its optional bias (a
+// third input, added back untouched) and its kernel/stride/pad/dilation/
+// group/auto_pad attributes are left exactly as they were. Needs opset >= 21
+// (UINT16 QuantizeLinear/DequantizeLinear support), unlike
+// static_quantize_conv.h's UINT8 scheme, which only needs opset 13.
+
+#pragma once
+
+#include <cstdint>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+#include "passes/quantize_conv_common.h"
+#include "passes/static_quantize_matmul.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+struct StaticQuantizeInt16Conv final : public PredicateBasedPass {
+  explicit StaticQuantizeInt16Conv()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+  std::string getPassName() const override {
+    return "static_quantize_int16_conv";
+  }
+
+  bool patternMatchPredicate(Node* n) override {
+    ConvInfo info;
+    if (!MatchConv(n, info)) {
+      return false;
+    }
+    const int opset = getOpsetVersion(*n->owningGraph());
+    if (opset != 0 && opset < 21) {
+      return false;  // UINT16 QuantizeLinear/DequantizeLinear needs opset
+                     // >= 21.
+    }
+    if (info.x->elemType() != TensorProto_DataType_FLOAT) {
+      return false;
+    }
+    if (StaticQuantizationCalibrationRanges().count(info.x->uniqueName()) ==
+        0) {
+      return false;  // No calibrated range for this activation.
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    return w_t != nullptr && w_t->elem_type() == TensorProto_DataType_FLOAT &&
+           w_t->sizes().size() >= 3;
+  }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+    ConvInfo info;
+    if (!MatchConv(n, info)) {
+      return false;
+    }
+    if (info.x->elemType() != TensorProto_DataType_FLOAT) {
+      return false;
+    }
+    const auto& ranges = StaticQuantizationCalibrationRanges();
+    const auto range_it = ranges.find(info.x->uniqueName());
+    if (range_it == ranges.end()) {
+      return false;
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+        w_t->sizes().size() < 3) {
+      return false;
+    }
+
+    float x_scale_f = 1.0f;
+    int32_t x_zp_i = 0;
+    ComputeAsymmetricUint16QuantParams(
+        range_it->second.first, range_it->second.second, x_scale_f, x_zp_i);
+
+    Tensor w_q;
+    Tensor w_scale;
+    QuantizeConvWeightPerOutputChannel(*w_t, w_q, w_scale);
+
+    Tensor x_scale_t;
+    x_scale_t.elem_type() = TensorProto_DataType_FLOAT;
+    x_scale_t.floats() = {x_scale_f};
+    Tensor x_zp_t;
+    x_zp_t.elem_type() = TensorProto_DataType_UINT16;
+    x_zp_t.int32s() = {x_zp_i};
+    Value* x_scale_v = graph.addInitializerAndCreateValue(x_scale_t);
+    Value* x_zp_v = graph.addInitializerAndCreateValue(x_zp_t);
+
+    // Xq = QuantizeLinear(X, Xs, Xzp)
+    Node* ql = graph.create(Symbol("QuantizeLinear"), 1);
+    ql->addInput(info.x);
+    ql->addInput(x_scale_v);
+    ql->addInput(x_zp_v);
+    ql->insertBefore(n);
+    ql->output()->setElemType(TensorProto_DataType_UINT16);
+
+    // Xdq = DequantizeLinear(Xq, Xs, Xzp)
+    Node* xdq = graph.create(Symbol("DequantizeLinear"), 1);
+    xdq->addInput(ql->output());
+    xdq->addInput(x_scale_v);
+    xdq->addInput(x_zp_v);
+    xdq->insertBefore(n);
+    xdq->output()->setElemType(TensorProto_DataType_FLOAT);
+    if (info.x->sizes().size() > 0) {
+      xdq->output()->setSizes(info.x->sizes());
+    }
+
+    Value* w_q_v = graph.addInitializerAndCreateValue(w_q);
+    Value* w_scale_v = graph.addInitializerAndCreateValue(w_scale);
+
+    // Wdq = DequantizeLinear(Wq, Ws, axis=0) -- zero_point omitted
+    // (symmetric, i.e. always 0).
+    Node* wdq = graph.create(Symbol("DequantizeLinear"), 1);
+    wdq->addInput(w_q_v);
+    wdq->addInput(w_scale_v);
+    wdq->i_(kaxis, 0);
+    wdq->insertBefore(n);
+    wdq->output()->setElemType(TensorProto_DataType_FLOAT);
+    if (info.w->sizes().size() > 0) {
+      wdq->output()->setSizes(info.w->sizes());
+    }
+
+    // Conv itself is left in place; only its activation and weight inputs
+    // change, to their dequantized (QDQ) counterparts. Its optional bias
+    // (input 2) is untouched.
+    n->replaceInput(0, xdq->output());
+    n->replaceInput(1, wdq->output());
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/static_quantize_int16_matmul.h
+++ b/onnxsim/passes/static_quantize_int16_matmul.h
@@ -1,0 +1,179 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+// Statically (calibration-based) quantizes MatMul/Gemm with a finer
+// **activation** quantization step than static_quantize_matmul.h's: this is
+// a "W8A16" scheme -- the weight stays INT8 (the same per-output-channel
+// symmetric scheme every onnxsim static/dynamic pass uses), but the
+// activation is quantized to UINT16 instead of UINT8, an 8x finer
+// calibrated affine step (1/65535 relative vs UINT8's 1/255).
+//
+// Before (illustrated for MatMul; a "vanilla" Gemm -- transA=0, alpha=1,
+// beta=1 -- is handled the same way, its bias C left untouched):
+//   Y = MatMul(X, W)         W constant, 2-D, float32
+// After (QDQ format: the MatMul/Gemm node itself is untouched, only its
+// inputs change):
+//   Xq  = QuantizeLinear(X, Xs, Xzp)        -- Xs/Xzp: CALIBRATED, fixed,
+//   uint16 Xdq = DequantizeLinear(Xq, Xs, Xzp) Wdq = DequantizeLinear(Wq, Ws,
+//   axis=<W's output-channel axis>)  -- Wq: int8 Y   = MatMul(Xdq, Wdq)
+//
+// Why the activation gets the finer type and not the weight: this pass's
+// only real difference from static_quantize_matmul.h is how much rounding
+// error the QuantizeLinear -> DequantizeLinear round trip introduces on the
+// activation before it reaches the (still-float32) MatMul -- the weight's
+// own INT8 precision is unaffected either way. So this targets exactly the
+// activations most sensitive to that round trip (e.g. post-softmax
+// attention scores, or any tensor whose calibrated range is unusually wide
+// relative to its typical value), without giving up INT8's weight
+// compression the way widening the weight too would.
+//
+// See static_quantize_matmul.h for the calibration-range global
+// (StaticQuantizationCalibrationRanges) and ComputeAsymmetricUint16QuantParams
+// this pass shares with static_quantize_int16_conv.h.
+//
+// Only the common, unambiguous shape is handled -- see
+// dynamic_quantize_matmul.h's doc comment, which applies identically here --
+// plus: opsets older than 21 (UINT16 QuantizeLinear/DequantizeLinear support
+// requires opset 21, unlike static_quantize_matmul.h's UINT8 scheme, which
+// only needs opset 13) are left alone, and a MatMul/Gemm is only rewritten
+// when its activation input's name has a calibrated range (set via
+// StaticQuantizationCalibrationRanges(), see QuantizeStaticInt16 in
+// onnxsim.h).
+
+#pragma once
+
+#include <cstdint>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+#include "passes/quantize_matmul_common.h"
+#include "passes/static_quantize_matmul.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+struct StaticQuantizeInt16MatMul final : public PredicateBasedPass {
+  explicit StaticQuantizeInt16MatMul()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+  std::string getPassName() const override {
+    return "static_quantize_int16_matmul";
+  }
+
+  bool patternMatchPredicate(Node* n) override {
+    MatMulLikeInfo info;
+    if (!MatchMatMulLike(n, info)) {
+      return false;
+    }
+    const int opset = getOpsetVersion(*n->owningGraph());
+    if (opset != 0 && opset < 21) {
+      return false;  // UINT16 QuantizeLinear/DequantizeLinear needs opset
+                     // >= 21.
+    }
+    if (info.x->elemType() != TensorProto_DataType_FLOAT) {
+      return false;
+    }
+    if (StaticQuantizationCalibrationRanges().count(info.x->uniqueName()) ==
+        0) {
+      return false;  // No calibrated range for this activation.
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    return w_t != nullptr && w_t->elem_type() == TensorProto_DataType_FLOAT &&
+           w_t->sizes().size() == 2;
+  }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    // Unlike dynamic_quantize_matmul.h, this pass never replaces `n` itself
+    // -- only its inputs -- so it never needs to destroy the current node.
+    destroy_current = NodeDestroyType::DestroyZero;
+    MatMulLikeInfo info;
+    if (!MatchMatMulLike(n, info)) {
+      return false;
+    }
+    if (info.x->elemType() != TensorProto_DataType_FLOAT) {
+      return false;
+    }
+    const auto& ranges = StaticQuantizationCalibrationRanges();
+    const auto range_it = ranges.find(info.x->uniqueName());
+    if (range_it == ranges.end()) {
+      return false;
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+        w_t->sizes().size() != 2) {
+      return false;
+    }
+
+    float x_scale_f = 1.0f;
+    int32_t x_zp_i = 0;
+    ComputeAsymmetricUint16QuantParams(
+        range_it->second.first, range_it->second.second, x_scale_f, x_zp_i);
+
+    // W's output-channel axis in its own (untransposed) layout: axis 0 when
+    // Gemm's transB made W [N, K], else axis 1 ([K, N], MatMul's own layout).
+    const int64_t channel_axis = info.weight_transposed ? 0 : 1;
+    Tensor w_q;
+    Tensor w_scale;
+    QuantizeWeightPerChannelInPlace(*w_t, channel_axis, w_q, w_scale);
+
+    Tensor x_scale_t;
+    x_scale_t.elem_type() = TensorProto_DataType_FLOAT;
+    x_scale_t.floats() = {x_scale_f};
+    Tensor x_zp_t;
+    x_zp_t.elem_type() = TensorProto_DataType_UINT16;
+    x_zp_t.int32s() = {x_zp_i};
+    Value* x_scale_v = graph.addInitializerAndCreateValue(x_scale_t);
+    Value* x_zp_v = graph.addInitializerAndCreateValue(x_zp_t);
+
+    // Xq = QuantizeLinear(X, Xs, Xzp)
+    Node* ql = graph.create(Symbol("QuantizeLinear"), 1);
+    ql->addInput(info.x);
+    ql->addInput(x_scale_v);
+    ql->addInput(x_zp_v);
+    ql->insertBefore(n);
+    ql->output()->setElemType(TensorProto_DataType_UINT16);
+
+    // Xdq = DequantizeLinear(Xq, Xs, Xzp)
+    Node* xdq = graph.create(Symbol("DequantizeLinear"), 1);
+    xdq->addInput(ql->output());
+    xdq->addInput(x_scale_v);
+    xdq->addInput(x_zp_v);
+    xdq->insertBefore(n);
+    xdq->output()->setElemType(TensorProto_DataType_FLOAT);
+    if (info.x->sizes().size() > 0) {
+      xdq->output()->setSizes(info.x->sizes());
+    }
+
+    Value* w_q_v = graph.addInitializerAndCreateValue(w_q);
+    Value* w_scale_v = graph.addInitializerAndCreateValue(w_scale);
+
+    // Wdq = DequantizeLinear(Wq, Ws, axis=channel_axis) -- zero_point
+    // omitted (symmetric, i.e. always 0).
+    Node* wdq = graph.create(Symbol("DequantizeLinear"), 1);
+    wdq->addInput(w_q_v);
+    wdq->addInput(w_scale_v);
+    wdq->i_(kaxis, channel_axis);
+    wdq->insertBefore(n);
+    wdq->output()->setElemType(TensorProto_DataType_FLOAT);
+    if (info.w->sizes().size() > 0) {
+      wdq->output()->setSizes(info.w->sizes());
+    }
+
+    // The MatMul/Gemm node itself is left in place; only its activation and
+    // weight inputs change, to their dequantized (QDQ) counterparts.
+    n->replaceInput(0, xdq->output());
+    n->replaceInput(1, wdq->output());
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/static_quantize_matmul.h
+++ b/onnxsim/passes/static_quantize_matmul.h
@@ -93,6 +93,27 @@ inline void ComputeAsymmetricUint8QuantParams(float min_val, float max_val,
   zero_point = static_cast<int32_t>(std::clamp(zp, 0.0f, 255.0f));
 }
 
+// Same as ComputeAsymmetricUint8QuantParams, but UINT16 (65536 codes instead
+// of 256) -- used by static_quantize_int16_matmul.h/_conv.h for a finer
+// activation quantization step (1/65535 relative vs UINT8's 1/255) while the
+// weight stays at the ordinary INT8 per-channel scheme (a "W8A16" scheme:
+// finer activation precision, same weight compression) -- useful for
+// activations a QDQ round trip is unusually sensitive to (e.g. attention
+// softmax outputs feeding a subsequent MatMul), where UINT8's coarser step
+// costs more accuracy than its extra compression is worth.
+inline void ComputeAsymmetricUint16QuantParams(float min_val, float max_val,
+                                               float& scale,
+                                               int32_t& zero_point) {
+  float lo = std::min(0.0f, min_val);
+  float hi = std::max(0.0f, max_val);
+  if (hi <= lo) {
+    hi = lo + 1.0f;  // Degenerate calibration range (e.g. all-zero data).
+  }
+  scale = (hi - lo) / 65535.0f;
+  const float zp = std::round(-lo / scale);
+  zero_point = static_cast<int32_t>(std::clamp(zp, 0.0f, 65535.0f));
+}
+
 struct StaticQuantizeMatMul final : public PredicateBasedPass {
   explicit StaticQuantizeMatMul()
       : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,

--- a/onnxsim/quantize_entry.cpp
+++ b/onnxsim/quantize_entry.cpp
@@ -142,6 +142,26 @@ onnx::ModelProto QuantizeStatic(
                                       "static_quantize_conv"});
 }
 
+onnx::ModelProto QuantizeStaticInt16(
+    const onnx::ModelProto& model,
+    const std::unordered_map<std::string, std::pair<float, float>>&
+        activation_ranges) {
+  PrepareSchemasForDebug(model);
+  // Registers static_quantize_int16_matmul/_conv (idempotent) into
+  // onnxoptimizer's registry so OptimizeFixed can find them by name below.
+  onnxsim::RegisterCustomOptimizerPasses();
+  // Reads/writes the same calibration-ranges global QuantizeStatic uses --
+  // safe as long as only one of QuantizeStatic/QuantizeStaticInt16/
+  // QuantizeQOperator runs per call, which OptimizeFixed's single
+  // pass-name list here ensures (see QuantizeQOperator's own comment on
+  // this).
+  onnx::optimization::onnxsim_passes::StaticQuantizationCalibrationRanges() =
+      activation_ranges;
+  return onnx::optimization::OptimizeFixed(
+      model, std::vector<std::string>{"static_quantize_int16_matmul",
+                                      "static_quantize_int16_conv"});
+}
+
 std::vector<std::string> ListQOperatorQuantizableOutputs(
     const onnx::ModelProto& model) {
   PrepareSchemasForDebug(model);

--- a/onnxsim/quantize_entry.h
+++ b/onnxsim/quantize_entry.h
@@ -28,6 +28,11 @@ onnx::ModelProto QuantizeStatic(
     const std::unordered_map<std::string, std::pair<float, float>>&
         activation_ranges);
 
+onnx::ModelProto QuantizeStaticInt16(
+    const onnx::ModelProto& model,
+    const std::unordered_map<std::string, std::pair<float, float>>&
+        activation_ranges);
+
 std::vector<std::string> ListQOperatorQuantizableOutputs(
     const onnx::ModelProto& model);
 

--- a/tests/test_static_quantize_int16.py
+++ b/tests/test_static_quantize_int16.py
@@ -1,0 +1,173 @@
+"""Tests for ``onnxsim.quantize_static_int16`` (the
+``static_quantize_int16_matmul``/``static_quantize_int16_conv`` C++ passes)
+and their reuse of ``onnxsim.calibration``'s helpers.
+
+Structurally identical to ``test_static_quantize_matmul.py``'s coverage --
+same models, same real ``onnxruntime.InferenceSession`` execution -- just
+checking the "W8A16" scheme's uint16 activation quantization (and its
+opset >= 21 requirement, unlike ``quantize_static``'s opset >= 13) instead.
+"""
+
+import collections
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+
+import onnxsim
+
+# A bare ``import onnxruntime`` would fail collection (not skip the test) on
+# platforms onnxruntime doesn't ship wheels for (e.g. s390x).
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(nodes, inputs, outputs, initializer, opset=21):
+    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+    )
+
+
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _op_counts(model):
+    return collections.Counter(n.op_type for n in model.graph.node)
+
+
+def _assert_close(float_outputs, quant_outputs, rel_l2_tol=0.1):
+    for f, q in zip(float_outputs, quant_outputs):
+        f = np.asarray(f, dtype=np.float64).ravel()
+        q = np.asarray(q, dtype=np.float64).ravel()
+        assert np.all(np.isfinite(q))
+        rel_l2 = np.linalg.norm(f - q) / max(np.linalg.norm(f), 1e-6)
+        assert rel_l2 < rel_l2_tol, f"relative L2 error too large: {rel_l2:.4f}"
+
+
+def test_quantize_matmul():
+    rng = np.random.default_rng(0)
+    K, N = 32, 16
+    weight = _f32(rng.standard_normal((K, N)) * 0.5, "W")
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [4, K])], [_vi("Y", [4, N])], [weight])
+
+    quant = onnxsim.quantize_static_int16(model, num_calibration_samples=16, seed=0)
+    onnx.checker.check_model(quant)
+    ops = _op_counts(quant)
+    assert ops["MatMul"] == 1  # the MatMul node itself is kept (QDQ format)
+    assert ops["QuantizeLinear"] == 1
+    assert ops["DequantizeLinear"] == 2  # one for X, one for W
+
+    x = rng.standard_normal((4, K)).astype(np.float32)
+    _assert_close(_run(model, {"X": x}), _run(quant, {"X": x}))
+
+
+def test_quantize_more_precise_than_uint8():
+    # A uint16 QDQ round trip should track the float baseline noticeably
+    # more closely than quantize_static's uint8 scheme, for the same
+    # calibrated activation range.
+    rng = np.random.default_rng(4)
+    K, N = 32, 16
+    weight = _f32(rng.standard_normal((K, N)) * 0.5, "W")
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [4, K])], [_vi("Y", [4, N])], [weight], opset=13)
+
+    quant8 = onnxsim.quantize_static(model, num_calibration_samples=16, seed=0)
+    model21 = _model(nodes, [_vi("X", [4, K])], [_vi("Y", [4, N])], [weight])
+    quant16 = onnxsim.quantize_static_int16(model21, num_calibration_samples=16, seed=0)
+
+    x = rng.standard_normal((4, K)).astype(np.float32)
+    float_out = _run(model, {"X": x})[0]
+    out8 = _run(quant8, {"X": x})[0]
+    out16 = _run(quant16, {"X": x})[0]
+
+    err8 = np.linalg.norm(float_out - out8)
+    err16 = np.linalg.norm(float_out - out16)
+    assert err16 < err8
+
+
+def test_quantize_gemm_transb_with_bias():
+    # PyTorch's nn.Linear layout: weight is [out_features, in_features], i.e.
+    # [N, K], exported as Gemm(X, W, B, transB=1) -- the common real-world case.
+    rng = np.random.default_rng(1)
+    K, N = 24, 12
+    weight = _f32(rng.standard_normal((N, K)) * 0.5, "W")
+    bias = _f32(rng.standard_normal(N), "B")
+    nodes = [onnx.helper.make_node("Gemm", ["X", "W", "B"], ["Y"], transB=1)]
+    model = _model(nodes, [_vi("X", [3, K])], [_vi("Y", [3, N])], [weight, bias])
+
+    quant = onnxsim.quantize_static_int16(model, num_calibration_samples=16, seed=1)
+    onnx.checker.check_model(quant)
+    ops = _op_counts(quant)
+    assert ops["Gemm"] == 1
+    assert ops["QuantizeLinear"] == 1
+    assert ops["DequantizeLinear"] == 2
+
+    x = rng.standard_normal((3, K)).astype(np.float32)
+    _assert_close(_run(model, {"X": x}), _run(quant, {"X": x}))
+
+
+def test_quantize_conv():
+    rng = np.random.default_rng(2)
+    cout, cin = 8, 3
+    weight = _f32(rng.standard_normal((cout, cin, 3, 3)) * 0.5, "W")
+    nodes = [
+        onnx.helper.make_node(
+            "Conv", ["X", "W"], ["Y"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
+        )
+    ]
+    model = _model(
+        nodes, [_vi("X", [1, cin, 16, 16])], [_vi("Y", [1, cout, 16, 16])], [weight]
+    )
+
+    quant = onnxsim.quantize_static_int16(model, num_calibration_samples=16, seed=2)
+    onnx.checker.check_model(quant)
+    ops = _op_counts(quant)
+    assert ops["Conv"] == 1
+    assert ops["QuantizeLinear"] == 1
+    assert ops["DequantizeLinear"] == 2
+
+    x = rng.standard_normal((1, cin, 16, 16)).astype(np.float32)
+    _assert_close(_run(model, {"X": x}), _run(quant, {"X": x}))
+
+
+def test_quantize_skips_non_constant_weight():
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [4, 8]), _vi("W", [8, 4])], [_vi("Y", [4, 4])], [])
+    quant = onnxsim.quantize_static_int16(model)
+    assert _op_counts(quant)["MatMul"] == 1
+
+
+def test_quantize_skips_non_default_gemm_attrs():
+    # alpha != 1 falls outside the "vanilla" Gemm shape this pass handles.
+    weight = _f32(np.random.randn(8, 4).astype(np.float32), "W")
+    nodes = [onnx.helper.make_node("Gemm", ["X", "W"], ["Y"], alpha=2.0)]
+    model = _model(nodes, [_vi("X", [4, 8])], [_vi("Y", [4, 4])], [weight])
+    quant = onnxsim.quantize_static_int16(model)
+    assert _op_counts(quant)["Gemm"] == 1
+
+
+def test_quantize_skips_old_opset():
+    # uint16 QuantizeLinear/DequantizeLinear needs opset >= 21 -- unlike
+    # quantize_static's opset >= 13, an opset in [13, 21) is old for this
+    # pass even though it would be fine for the uint8 one.
+    weight = _f32(np.random.randn(8, 4).astype(np.float32), "W")
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [4, 8])], [_vi("Y", [4, 4])], [weight], opset=13)
+    quant = onnxsim.quantize_static_int16(model)
+    assert _op_counts(quant)["MatMul"] == 1
+    assert _op_counts(quant)["QuantizeLinear"] == 0


### PR DESCRIPTION
## Summary

- Adds `quantize_static_int16`, a "W8A16" scheme: the same INT8 per-channel weight quantization as `quantize_static`, but the activation is quantized to uint16 instead of uint8 — an 8x finer calibrated affine step (1/65535 relative vs uint8's 1/255).
- Since QDQ format still computes in float32 either way (`MatMul`/`Gemm`/`Conv` is never replaced with an integer kernel directly), only the activation's `QuantizeLinear`→`DequantizeLinear` round-trip rounding error changes between this and `quantize_static` — the weight's own INT8 precision is unaffected either way, so widening the weight too would cost storage for no matching accuracy benefit. Targets activations a QDQ round trip is unusually sensitive to: a wide calibrated range relative to typical value, or a downstream computation where small per-element errors compound (e.g. post-softmax attention scores).
- Adds `ComputeAsymmetricUint16QuantParams` (`static_quantize_matmul.h`, mirroring the existing UINT8 helper exactly) and two new passes (`static_quantize_int16_matmul.h`/`_conv.h`), reusing the same `StaticQuantizationCalibrationRanges` global and INT8 weight-quantization helpers the UINT8 passes already use — only the activation's target type and opset floor (21, for UINT16 `QuantizeLinear`/`DequantizeLinear` support) differ.
- Wired through the full stack: `onnxsim.h`/`quantize_entry.{h,cpp}` entry point (`QuantizeStaticInt16`), nanobind binding, Python wrapper in `calibration.py` (reusing `calibrate()`/`generate_random_calibration_data` unchanged) + `--static-quantize-int16` CLI flag, pass registration, tests, and docs (`docs/static-quantize-int16.md`).

## Test plan

- [x] `pytest tests/test_static_quantize_int16.py -v` — 7 new tests pass: MatMul/Gemm(transB+bias)/Conv quantization executed end-to-end through `onnxruntime.InferenceSession`, a direct comparison against `quantize_static`'s uint8 scheme on the same calibrated activation confirming the uint16 round trip tracks the float baseline more closely, and the usual skip-condition coverage (non-constant weight, non-default Gemm attrs, opset < 21).
- [x] Full test suite (`pytest tests/` minus pre-existing torch/timm-dependent modules unrelated to this change): 279 passed, 64 skipped, no regressions.
- [x] `ruff format --check` / `ruff check` clean on touched Python files.
- [x] `clang-format --dry-run --Werror` clean on touched C++ files.
- [x] Manual CLI smoke test: `onnxsim model.onnx model.quant.onnx --static-quantize-int16` produces a valid model with `QuantizeLinear`/`DequantizeLinear`/`MatMul` and a `UINT16` zero_point initializer.

https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU


---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_