### PR TITLE
Add quantize_qoperator_elementwise (QLinearAdd/QLinearMul contrib-op quantization)

### DIFF
--- a/docs/qoperator-quantize-elementwise.md
+++ b/docs/qoperator-quantize-elementwise.md
@@ -1,0 +1,109 @@
+# QOperator elementwise quantization (`quantize_qoperator_elementwise`)
+
+## What this is
+
+`onnxsim.quantize_qoperator_elementwise` is a self-contained C++ graph
+rewrite (`onnxsim/passes/qoperator_quantize_elementwise.h`) that statically
+(calibration-based) quantizes every elementwise `Add`/`Mul` node whose two
+inputs are both **non-constant** float32 tensors -- a residual connection, an
+elementwise gate between two activations, and similar shapes -- into ONNX
+Runtime's **`com.microsoft`** contrib ops `QLinearAdd`/`QLinearMul`: the
+elementwise analogue of `quantize_qoperator`'s `QLinearMatMul`/`QLinearConv`
+rewrite.
+
+```
+Before (illustrated for Add; Mul is identical but for the op/QLinear* name):
+  Z = Add(A, B)                                          # A, B: both runtime float32 tensors
+
+After:
+  Aq = QuantizeLinear(A, As, Azp)                         # As/Azp: CALIBRATED
+  Bq = QuantizeLinear(B, Bs, Bzp)                         # Bs/Bzp: CALIBRATED
+  Zq = QLinearAdd(Aq, As, Azp, Bq, Bs, Bzp, Zs, Zzp)      # true int8 compute
+  Z  = DequantizeLinear(Zq, Zs, Zzp)                      # Zs/Zzp: CALIBRATED
+```
+
+## Why this is a contrib op, not standard ONNX
+
+Standard ONNX has no quantized elementwise-binary operator at all: only
+`QLinearMatMul`/`QLinearConv`, and both are constrained to a
+weight-times-activation shape, not two arbitrary runtime tensors. ONNX
+Runtime fills that gap with its own `com.microsoft` domain contrib ops
+`QLinearAdd`/`QLinearMul`. This is the only `quantize_*` function in onnxsim
+whose output is not portable standard ONNX: the quantized model needs a
+`com.microsoft`-aware runtime (ONNX Runtime itself, or another runtime
+importing the same contrib schemas) to execute. `quantize_qoperator_elementwise`
+adds `com.microsoft` (version 1) to the model's opset imports the first time
+it rewrites a node.
+
+## Why both operands need a calibrated range
+
+Unlike `quantize_qoperator`'s `QLinearMatMul`/`QLinearConv` (one calibrated
+activation, one weight quantized ahead of time from its own static values),
+`QLinearAdd`/`QLinearMul` treat both operands identically -- there is no
+"weight" role at all. So **both** `A` and `B` need a calibrated range, on top
+of the output `Z`'s (QOperator format computes directly in int8, so the
+output must be quantized too -- the same reason `QLinearMatMul`'s `Y` needs
+one; see `docs/qoperator-quantization.md`).
+
+`list_qoperator_elementwise_quantizable_tensors` reports all three tensor
+names (both operands plus the output) for every qualifying node;
+`calibrate()`'s `extra_tensor_names` parameter is how they get folded into
+the same calibration run -- `quantize_qoperator_elementwise` (the Python
+wrapper in `onnxsim/calibration.py`) does this automatically.
+
+## Why a constant operand is left alone
+
+A node with one constant operand -- e.g. a per-channel bias or a learned
+embedding added elementwise -- is **not** rewritten by this pass, even
+though `QLinearAdd`/`QLinearMul`'s own schema would accept it. A constant is
+better quantized from its own static values (the same per-channel scheme
+`quantize_static`'s weight handling uses) than force-fed through the runtime
+calibration harness as if it varied at inference time. This pass only
+targets the genuinely dynamic case: both operands are runtime activations.
+
+## Scope
+
+Handled:
+- `Add(A, B)` or `Mul(A, B)`, both inputs float32, **neither a constant**.
+
+Left untouched (safe no-op, node passes through as-is):
+- A constant operand, non-float32 operands, or a node whose operands and/or
+  output tensor has no calibrated range.
+- A node consuming *another* rewritten node's output in the same
+  quantization call: this pass (like `qoperator_quantize_matmul.h`/
+  `qoperator_quantize_conv.h`) replaces the matched node with a fresh output
+  Value, so a downstream node's calibrated-range lookup (keyed by the
+  *original* tensor name) won't find an entry for that edge afterwards --
+  a pre-existing characteristic of the whole QOperator rewrite family, not
+  specific to elementwise ops.
+
+## End-to-end: simplify -> quantize -> deploy
+
+### CLI
+
+```bash
+onnxsim model.onnx model.quant.onnx --qoperator-quantize-elementwise
+```
+
+### Python API
+
+```python
+import onnx
+import onnxruntime as ort
+import onnxsim
+
+model = onnx.load("model.onnx")
+model, check_ok = onnxsim.simplify(model)
+assert check_ok
+
+model = onnxsim.quantize_qoperator_elementwise(model)
+onnx.save(model, "model.quant.onnx")
+
+sess = ort.InferenceSession("model.quant.onnx", providers=["CPUExecutionProvider"])
+outputs = sess.run(None, {"input": your_input_array})
+```
+
+`tests/test_qoperator_quantize_elementwise.py` runs this simplify -> quantize
+-> deploy sequence on small `Add`/`Mul` models (including a broadcasting
+case), executing both the float and quantized graphs through
+`onnxruntime.InferenceSession`.

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -3,6 +3,7 @@ from onnxsim.calibration import (
     generate_random_calibration_data,
     load_huggingface_calibration_data,
     quantize_qoperator,
+    quantize_qoperator_elementwise,
     quantize_static,
     quantize_static_int16,
 )
@@ -39,6 +40,7 @@ __all__ = [
     "quantize_static",
     "quantize_static_int16",
     "quantize_qoperator",
+    "quantize_qoperator_elementwise",
     "quantize_fp16",
     "quantize_bf16",
     "quantize_fp8",

--- a/onnxsim/calibration.py
+++ b/onnxsim/calibration.py
@@ -643,3 +643,76 @@ def quantize_qoperator(
         extra_tensor_names=extra_names,
     )
     return onnx.load_from_string(C.quantize_qoperator(model_bytes, ranges))
+
+
+def quantize_qoperator_elementwise(
+    model: Union[str, onnx.ModelProto],
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_calibration_samples: int = 8,
+    seed: int = 0,
+    providers: Optional[Sequence[str]] = None,
+    method: str = "minmax",
+) -> onnx.ModelProto:
+    """
+    Statically (calibration-based) quantize every elementwise Add/Mul node
+    whose two inputs are both non-constant float32 tensors (e.g. a residual
+    connection, or an elementwise gate between two activations) into ONNX
+    Runtime's "com.microsoft" contrib ops ``QLinearAdd``/``QLinearMul`` -- the
+    elementwise, "QOperator"-format analogue of :func:`quantize_qoperator`'s
+    ``QLinearMatMul`` rewrite.
+
+    Unlike every other ``quantize_*`` function in this module, the result is
+    **not** portable standard ONNX: ``QLinearAdd``/``QLinearMul`` are ONNX
+    Runtime contrib ops (standard ONNX has no quantized elementwise-binary
+    op), so the quantized model needs a "com.microsoft"-aware runtime --
+    ONNX Runtime itself, or another runtime importing the same contrib
+    schemas -- to execute. A node with a constant operand (e.g. a per-channel
+    bias or embedding added elementwise) is left alone -- that operand is
+    better quantized from its own static values than force-fed through
+    calibration as if it varied at inference time.
+
+    Like :func:`quantize_qoperator`, this needs a calibrated range for the
+    node's *output* on top of its inputs, since QLinearAdd/QLinearMul compute
+    directly in int8 with no float intermediate -- but unlike
+    :func:`quantize_qoperator` (one calibrated activation, one weight
+    quantized from its own static values), QLinearAdd/QLinearMul have no
+    "weight" role at all, so *both* operands need a calibrated range too
+    (:func:`calibrate` is called with ``extra_tensor_names`` set to
+    ``onnxsim_cpp2py_export.list_qoperator_elementwise_quantizable_tensors``'
+    result for this reason).
+
+    :param model: onnx ModelProto object or file path
+    :param calibration_data: representative input batches to calibrate
+            operand/output ranges from. Each batch is a
+            ``{input_name: np.ndarray}`` dict matching the model's graph
+            inputs -- see :func:`generate_random_calibration_data` (the
+            default, a quick smoke test) and
+            :func:`load_huggingface_calibration_data` (real data, a much
+            better calibration source for real deployment).
+    :param num_calibration_samples: number of random batches to generate when
+            ``calibration_data`` is not supplied
+    :param seed: seed for the random calibration data (ignored if
+            ``calibration_data`` is supplied)
+    :param providers: onnxruntime execution providers to run calibration on
+    :param method: calibration range method, passed through to
+            :func:`calibrate` -- ``"minmax"`` (default) or ``"entropy"``
+            (KL-divergence calibration; see that function for the tradeoff
+            and its extra data requirement).
+    :returns: the quantized onnx ModelProto
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            model, num_samples=num_calibration_samples, seed=seed
+        )
+    model_bytes = model.SerializeToString()
+    extra_names = C.list_qoperator_elementwise_quantizable_tensors(model_bytes)
+    ranges = calibrate(
+        model,
+        calibration_data,
+        providers=providers,
+        method=method,
+        extra_tensor_names=extra_names,
+    )
+    return onnx.load_from_string(C.quantize_qoperator_elementwise(model_bytes, ranges))

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -547,6 +547,43 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
       },
       "model_bytes"_a, "activation_ranges"_a);
 
+  // Lists the tensor names quantize_qoperator_elementwise could quantize --
+  // both operands and the output of every qualifying Add/Mul node -- see
+  // ListQOperatorElementwiseQuantizableTensors in onnxsim.h.
+  m.def(
+      "list_qoperator_elementwise_quantizable_tensors",
+      [](const py::bytes& model_proto_bytes) -> std::vector<std::string> {
+        InitEnv();
+        ONNX_NAMESPACE::ModelProto model;
+        ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
+                            model_proto_bytes.size());
+        return ListQOperatorElementwiseQuantizableTensors(model);
+      },
+      "model_bytes"_a);
+
+  // Statically (calibration-based) quantizes elementwise Add/Mul into ONNX
+  // Runtime's "com.microsoft" QLinearAdd/QLinearMul contrib ops -- needs a
+  // calibrated range for both operands and the node's own output (see
+  // list_qoperator_elementwise_quantizable_tensors) since these compute
+  // directly in int8, with no float intermediate -- see
+  // QuantizeQOperatorElementwise in onnxsim.h.
+  m.def(
+      "quantize_qoperator_elementwise",
+      [](const py::bytes& model_proto_bytes,
+         const std::unordered_map<std::string, std::pair<float, float>>&
+             activation_ranges) -> py::bytes {
+        InitEnv();
+        ONNX_NAMESPACE::ModelProto model;
+        ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
+                            model_proto_bytes.size());
+        const auto result =
+            QuantizeQOperatorElementwise(model, activation_ranges);
+        std::string out;
+        result.SerializeToString(&out);
+        return py::bytes(out.data(), out.size());
+      },
+      "model_bytes"_a, "activation_ranges"_a);
+
   // Converts every float32 weight (and, by default, every internal
   // activation) to float16 -- no calibration data needed, since float16 is
   // still a floating-point format, not an integer scheme. With

--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -25,6 +25,7 @@
 #include "passes/fuse_preceding_mul_into_conv.h"
 #include "passes/fuse_rms_norm.h"
 #include "passes/qoperator_quantize_conv.h"
+#include "passes/qoperator_quantize_elementwise.h"
 #include "passes/qoperator_quantize_matmul.h"
 #include "passes/quantize_bf16.h"
 #include "passes/quantize_fp16.h"
@@ -86,6 +87,7 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::FusePrecedingMulIntoConv>(registry);
     RegisterOrReplace<p::FuseRMSNorm>(registry);
     RegisterOrReplace<p::QOperatorQuantizeConv>(registry);
+    RegisterOrReplace<p::QOperatorQuantizeElementwise>(registry);
     RegisterOrReplace<p::QOperatorQuantizeMatMul>(registry);
     RegisterOrReplace<p::QuantizeBf16Pass>(registry);
     RegisterOrReplace<p::QuantizeFp16Pass>(registry);

--- a/onnxsim/custom_optimizer_passes.h
+++ b/onnxsim/custom_optimizer_passes.h
@@ -41,6 +41,7 @@ namespace onnxsim {
 //   - weight_only_quantize_int8_block_conv
 //   - qoperator_quantize_matmul
 //   - qoperator_quantize_conv
+//   - qoperator_quantize_elementwise
 //   - quantize_fp16
 //   - quantize_bf16
 //   - quantize_fp8

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -1787,27 +1787,41 @@ def main():
         action="store_true",
     )
     parser.add_argument(
+        "--qoperator-quantize-elementwise",
+        help="After simplifying, statically (calibration-based) quantize "
+        "elementwise Add/Mul nodes (both inputs non-constant, e.g. a "
+        "residual connection) into ONNX Runtime's 'com.microsoft' contrib "
+        "ops QLinearAdd/QLinearMul, with a fixed scale/zero-point "
+        "calibrated from --calibration-dataset if given, else from random "
+        "data. Unlike the other --*-quantize flags, the result needs a "
+        "com.microsoft-aware runtime (e.g. ONNX Runtime) to execute -- see "
+        "onnxsim.quantize_qoperator_elementwise.",
+        action="store_true",
+    )
+    parser.add_argument(
         "--calibration-dataset",
         help="Hugging Face Hub dataset id (e.g. 'mnist') to pull "
         "--calibration-samples real examples from for --static-quantize's, "
-        "--static-quantize-int16's, or --qoperator-quantize's calibration, "
-        "instead of random data. See "
-        "onnxsim.load_huggingface_calibration_data (needs the optional "
-        "'datasets' package: pip install datasets).",
+        "--static-quantize-int16's, --qoperator-quantize's, or "
+        "--qoperator-quantize-elementwise's calibration, instead of random "
+        "data. See onnxsim.load_huggingface_calibration_data (needs the "
+        "optional 'datasets' package: pip install datasets).",
         type=str,
         default=None,
     )
     parser.add_argument(
         "--calibration-samples",
-        help="Number of calibration batches/examples for --static-quantize "
-        "or --qoperator-quantize (default: 8).",
+        help="Number of calibration batches/examples for --static-quantize, "
+        "--qoperator-quantize, or --qoperator-quantize-elementwise "
+        "(default: 8).",
         type=int,
         default=8,
     )
     parser.add_argument(
         "--calibration-method",
-        help="Calibration range method for --static-quantize or "
-        "--qoperator-quantize: 'minmax' "
+        help="Calibration range method for --static-quantize, "
+        "--qoperator-quantize, or --qoperator-quantize-elementwise: "
+        "'minmax' "
         "(default) uses each tensor's observed min/max directly; 'entropy' "
         "instead searches for the clip threshold minimizing KL divergence "
         "between the observed and simulated-quantized distributions "
@@ -2142,6 +2156,31 @@ def main():
             "(QOperator format)..."
         )
         model_opt = calibration.quantize_qoperator(
+            model_opt, calibration_data=calibration_data, method=args.calibration_method
+        )
+
+    if args.qoperator_quantize_elementwise:
+        from . import calibration
+
+        if args.calibration_dataset:
+            print(
+                f'Calibrating from Hugging Face dataset "{args.calibration_dataset}"...'
+            )
+            calibration_data = calibration.load_huggingface_calibration_data(
+                args.calibration_dataset,
+                model_opt,
+                num_samples=args.calibration_samples,
+            )
+        else:
+            print("Calibrating from random data...")
+            calibration_data = calibration.generate_random_calibration_data(
+                model_opt, num_samples=args.calibration_samples
+            )
+        print(
+            "Statically quantizing elementwise Add/Mul nodes (QOperator "
+            "format, com.microsoft contrib ops)..."
+        )
+        model_opt = calibration.quantize_qoperator_elementwise(
             model_opt, calibration_data=calibration_data, method=args.calibration_method
         )
 

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -401,6 +401,46 @@ onnx::ModelProto QuantizeQOperator(
     const std::unordered_map<std::string, std::pair<float, float>>&
         activation_ranges);
 
+// Lists the tensor names ``QuantizeQOperatorElementwise`` could quantize in
+// ``model``: for every Add/Mul node with exactly 2 float32 inputs, neither a
+// constant, one entry per operand plus one for the node's own output (three
+// entries per qualifying node, since QLinearAdd/QLinearMul -- unlike
+// QLinearMatMul/QLinearConv -- have no "weight" operand pre-quantized from
+// its own static values; both operands are treated as calibrated
+// activations). A caller preparing to call ``QuantizeQOperatorElementwise``
+// should calibrate this list (there is no separate
+// ``ListQuantizableActivations``-style overlap to union it with, since
+// MatMul/Conv activation names and Add/Mul operand names never coincide).
+std::vector<std::string> ListQOperatorElementwiseQuantizableTensors(
+    const onnx::ModelProto& model);
+
+// Statically (calibration-based) quantizes every elementwise Add/Mul node
+// whose two inputs are both non-constant float32 tensors, and whose two
+// input names *and* whose own output name are all keys of
+// ``activation_ranges``, into ONNX Runtime's "com.microsoft" contrib ops
+// ``QLinearAdd``/``QLinearMul`` -- the elementwise, "QOperator"-format
+// analogue of ``QuantizeQOperator``'s ``QLinearMatMul``/``QLinearConv``
+// rewrite. Unlike every other ``Quantize*`` entry point in this header,
+// QLinearAdd/QLinearMul are not standard ONNX ops -- they are ONNX Runtime
+// contrib ops, so the emitted model needs a "com.microsoft"-aware runtime
+// (ONNX Runtime itself, or another runtime importing the same contrib
+// schemas) to execute; this function adds "com.microsoft" (version 1) to
+// the model's opset imports the first time it rewrites a node. See
+// ``ListQOperatorElementwiseQuantizableTensors`` to discover which tensors
+// to calibrate, and ``passes/qoperator_quantize_elementwise.h`` for the
+// rewrite itself and its doc comment on why a constant operand is left
+// alone.
+//
+// Unlike ``Simplify``, this does not run shape inference, constant folding
+// or any other simplification pass -- it applies exactly this rewrite, once,
+// to a copy of ``model`` (which is left untouched) and returns the result.
+// Nodes that do not match, or whose operands/output have no entry in
+// ``activation_ranges``, are left as-is.
+onnx::ModelProto QuantizeQOperatorElementwise(
+    const onnx::ModelProto& model,
+    const std::unordered_map<std::string, std::pair<float, float>>&
+        activation_ranges);
+
 // Converts every float32 weight (and, by default, every internal activation)
 // in ``model`` to float16 -- a different kind of "quantization" from every
 // other ``Quantize*`` function here: float16 is still a floating-point

--- a/onnxsim/passes/qoperator_quantize_elementwise.h
+++ b/onnxsim/passes/qoperator_quantize_elementwise.h
@@ -124,19 +124,16 @@ struct QOperatorQuantizeElementwise final : public PredicateBasedPass {
 
     float a_scale_f = 1.0f;
     int32_t a_zp_i = 0;
-    ComputeAsymmetricUint8QuantParams(a_range_it->second.first,
-                                      a_range_it->second.second, a_scale_f,
-                                      a_zp_i);
+    ComputeAsymmetricUint8QuantParams(
+        a_range_it->second.first, a_range_it->second.second, a_scale_f, a_zp_i);
     float b_scale_f = 1.0f;
     int32_t b_zp_i = 0;
-    ComputeAsymmetricUint8QuantParams(b_range_it->second.first,
-                                      b_range_it->second.second, b_scale_f,
-                                      b_zp_i);
+    ComputeAsymmetricUint8QuantParams(
+        b_range_it->second.first, b_range_it->second.second, b_scale_f, b_zp_i);
     float z_scale_f = 1.0f;
     int32_t z_zp_i = 0;
-    ComputeAsymmetricUint8QuantParams(z_range_it->second.first,
-                                      z_range_it->second.second, z_scale_f,
-                                      z_zp_i);
+    ComputeAsymmetricUint8QuantParams(
+        z_range_it->second.first, z_range_it->second.second, z_scale_f, z_zp_i);
 
     Tensor a_scale_t;
     a_scale_t.elem_type() = TensorProto_DataType_FLOAT;

--- a/onnxsim/passes/qoperator_quantize_elementwise.h
+++ b/onnxsim/passes/qoperator_quantize_elementwise.h
@@ -1,0 +1,236 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+// Statically (calibration-based) quantizes elementwise Add/Mul between two
+// runtime (non-constant) float32 tensors into ONNX Runtime's "com.microsoft"
+// contrib ops QLinearAdd/QLinearMul -- the elementwise analogue of
+// qoperator_quantize_matmul.h's QLinearMatMul rewrite. Unlike every other
+// quantization pass in onnxsim, QLinearAdd/QLinearMul are NOT standard ONNX:
+// standard ONNX has no quantized elementwise-binary op at all -- only
+// QLinearMatMul/QLinearConv, both constrained to a weight-times-activation
+// shape (see contrib_schemas.cpp's doc comment on why QLinearAdd/QLinearMul
+// exist as contrib ops in the first place). The resulting model needs a
+// com.microsoft-aware runtime (ONNX Runtime itself, or another runtime that
+// imports the same contrib schemas) to execute, not just any ONNX Runtime.
+//
+// Before (illustrated for Add; Mul is identical but for the op/QLinear* name):
+//   Z = Add(A, B)             A, B: both runtime float32 tensors
+// After:
+//   Aq = QuantizeLinear(A, As, Azp)                     -- As/Azp: CALIBRATED
+//   Bq = QuantizeLinear(B, Bs, Bzp)                     -- Bs/Bzp: CALIBRATED
+//   Zq = QLinearAdd(Aq, As, Azp, Bq, Bs, Bzp, Zs, Zzp)  -- true int8 compute
+//   Z  = DequantizeLinear(Zq, Zs, Zzp)                  -- Zs/Zzp: CALIBRATED
+//
+// Unlike qoperator_quantize_matmul.h (one calibrated activation, one
+// statically-quantized-from-its-own-values constant weight), QLinearAdd/
+// QLinearMul have no "weight" role at all -- the schema treats both operands
+// identically -- so BOTH A and B need a calibrated range, on top of the
+// output Z's (QOperator format computes directly in int8, so its output must
+// be quantized too, same reason QLinearMatMul's Y needs one -- see that
+// file's doc comment). Only a node whose *both* inputs are non-constant is
+// matched: a constant operand (e.g. a per-channel bias/embedding added
+// elementwise) is better quantized from its own static values than
+// force-fed through the runtime calibration harness as if it varied at
+// inference time, so this pass leaves that case alone -- the matching
+// pattern is deliberately narrower than QLinearAdd/QLinearMul's own schema,
+// which allows either operand to be anything.
+//
+// A rewritten node is only reachable through ONNX Runtime's "com.microsoft"
+// contrib domain, so this pass also adds that domain (version 1) to the
+// model's opset imports the first time it fires, if not already present.
+//
+// Only Add/Mul with exactly 2 inputs, both float32, neither a constant
+// value, are matched; a node is only rewritten when both its inputs' names
+// and its own output's name have a calibrated range (set via
+// StaticQuantizationCalibrationRanges(), see QuantizeQOperatorElementwise in
+// onnxsim.h).
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+#include "passes/static_quantize_matmul.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+struct QOperatorQuantizeElementwise final : public PredicateBasedPass {
+  explicit QOperatorQuantizeElementwise()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+  std::string getPassName() const override {
+    return "qoperator_quantize_elementwise";
+  }
+
+  bool patternMatchPredicate(Node* n) override {
+    if (n->kind() != kAdd && n->kind() != kMul) {
+      return false;
+    }
+    if (n->inputs().size() != 2) {
+      return false;
+    }
+    Value* a = n->inputs()[0];
+    Value* b = n->inputs()[1];
+    if (a->elemType() != TensorProto_DataType_FLOAT ||
+        b->elemType() != TensorProto_DataType_FLOAT) {
+      return false;
+    }
+    if (FetchConstantTensor(a) != nullptr ||
+        FetchConstantTensor(b) != nullptr) {
+      return false;  // Constant operand: quantize from its own values instead.
+    }
+    const auto& ranges = StaticQuantizationCalibrationRanges();
+    return ranges.count(a->uniqueName()) != 0 &&
+           ranges.count(b->uniqueName()) != 0 &&
+           ranges.count(n->output()->uniqueName()) != 0;
+  }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+    if (n->kind() != kAdd && n->kind() != kMul) {
+      return false;
+    }
+    if (n->inputs().size() != 2) {
+      return false;
+    }
+    Value* a = n->inputs()[0];
+    Value* b = n->inputs()[1];
+    if (a->elemType() != TensorProto_DataType_FLOAT ||
+        b->elemType() != TensorProto_DataType_FLOAT) {
+      return false;
+    }
+    if (FetchConstantTensor(a) != nullptr ||
+        FetchConstantTensor(b) != nullptr) {
+      return false;
+    }
+    const auto& ranges = StaticQuantizationCalibrationRanges();
+    const auto a_range_it = ranges.find(a->uniqueName());
+    const auto b_range_it = ranges.find(b->uniqueName());
+    const auto z_range_it = ranges.find(n->output()->uniqueName());
+    if (a_range_it == ranges.end() || b_range_it == ranges.end() ||
+        z_range_it == ranges.end()) {
+      return false;
+    }
+
+    float a_scale_f = 1.0f;
+    int32_t a_zp_i = 0;
+    ComputeAsymmetricUint8QuantParams(a_range_it->second.first,
+                                      a_range_it->second.second, a_scale_f,
+                                      a_zp_i);
+    float b_scale_f = 1.0f;
+    int32_t b_zp_i = 0;
+    ComputeAsymmetricUint8QuantParams(b_range_it->second.first,
+                                      b_range_it->second.second, b_scale_f,
+                                      b_zp_i);
+    float z_scale_f = 1.0f;
+    int32_t z_zp_i = 0;
+    ComputeAsymmetricUint8QuantParams(z_range_it->second.first,
+                                      z_range_it->second.second, z_scale_f,
+                                      z_zp_i);
+
+    Tensor a_scale_t;
+    a_scale_t.elem_type() = TensorProto_DataType_FLOAT;
+    a_scale_t.floats() = {a_scale_f};
+    Tensor a_zp_t;
+    a_zp_t.elem_type() = TensorProto_DataType_UINT8;
+    a_zp_t.int32s() = {a_zp_i};
+    Value* a_scale_v = graph.addInitializerAndCreateValue(a_scale_t);
+    Value* a_zp_v = graph.addInitializerAndCreateValue(a_zp_t);
+
+    Tensor b_scale_t;
+    b_scale_t.elem_type() = TensorProto_DataType_FLOAT;
+    b_scale_t.floats() = {b_scale_f};
+    Tensor b_zp_t;
+    b_zp_t.elem_type() = TensorProto_DataType_UINT8;
+    b_zp_t.int32s() = {b_zp_i};
+    Value* b_scale_v = graph.addInitializerAndCreateValue(b_scale_t);
+    Value* b_zp_v = graph.addInitializerAndCreateValue(b_zp_t);
+
+    Tensor z_scale_t;
+    z_scale_t.elem_type() = TensorProto_DataType_FLOAT;
+    z_scale_t.floats() = {z_scale_f};
+    Tensor z_zp_t;
+    z_zp_t.elem_type() = TensorProto_DataType_UINT8;
+    z_zp_t.int32s() = {z_zp_i};
+    Value* z_scale_v = graph.addInitializerAndCreateValue(z_scale_t);
+    Value* z_zp_v = graph.addInitializerAndCreateValue(z_zp_t);
+
+    // Aq = QuantizeLinear(A, As, Azp)
+    Node* aq = graph.create(Symbol("QuantizeLinear"), 1);
+    aq->addInput(a);
+    aq->addInput(a_scale_v);
+    aq->addInput(a_zp_v);
+    aq->insertBefore(n);
+    aq->output()->setElemType(TensorProto_DataType_UINT8);
+
+    // Bq = QuantizeLinear(B, Bs, Bzp)
+    Node* bq = graph.create(Symbol("QuantizeLinear"), 1);
+    bq->addInput(b);
+    bq->addInput(b_scale_v);
+    bq->addInput(b_zp_v);
+    bq->insertBefore(n);
+    bq->output()->setElemType(TensorProto_DataType_UINT8);
+
+    // Zq = QLinear{Add,Mul}(Aq, As, Azp, Bq, Bs, Bzp, Zs, Zzp), a
+    // "com.microsoft" contrib op -- see QLinearBinaryShapeInference in
+    // contrib_schemas.cpp for its output-type/broadcast convention, which
+    // matches this input order (A at index 0, B at index 3).
+    const bool is_add = n->kind() == kAdd;
+    Node* qlop = graph.create(Symbol(is_add ? "QLinearAdd" : "QLinearMul"), 1);
+    qlop->addInput(aq->output());
+    qlop->addInput(a_scale_v);
+    qlop->addInput(a_zp_v);
+    qlop->addInput(bq->output());
+    qlop->addInput(b_scale_v);
+    qlop->addInput(b_zp_v);
+    qlop->addInput(z_scale_v);
+    qlop->addInput(z_zp_v);
+    qlop->setDomain("com.microsoft");
+    qlop->insertBefore(n);
+    qlop->output()->setElemType(TensorProto_DataType_UINT8);
+
+    // Z = DequantizeLinear(Zq, Zs, Zzp)
+    Node* dq = graph.create(Symbol("DequantizeLinear"), 1);
+    dq->addInput(qlop->output());
+    dq->addInput(z_scale_v);
+    dq->addInput(z_zp_v);
+    dq->insertBefore(n);
+    dq->output()->setElemType(TensorProto_DataType_FLOAT);
+    if (n->output()->sizes().size() > 0) {
+      dq->output()->setSizes(n->output()->sizes());
+    }
+
+    bool has_ms_domain = false;
+    for (const OpSetID& opset : graph.opset_versions_mutable()) {
+      if (opset.domain() == "com.microsoft") {
+        has_ms_domain = true;
+        break;
+      }
+    }
+    if (!has_ms_domain) {
+      graph.opset_versions_mutable().emplace_back("com.microsoft", 1);
+    }
+
+    const bool replacing_success =
+        tryReplacingAllUsesWith(n->output(), dq->output());
+    if (!replacing_success) {
+      return false;
+    }
+    destroy_current = NodeDestroyType::DestroyOne;
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/quantize_entry.cpp
+++ b/onnxsim/quantize_entry.cpp
@@ -245,6 +245,64 @@ onnx::ModelProto QuantizeQOperator(
                                       "qoperator_quantize_conv"});
 }
 
+std::vector<std::string> ListQOperatorElementwiseQuantizableTensors(
+    const onnx::ModelProto& model) {
+  PrepareSchemasForDebug(model);
+  std::shared_ptr<onnx::Graph> g(onnx::ImportModelProto(model));
+  if (g.get() == nullptr) {
+    return {};
+  }
+  std::vector<std::string> names;
+  std::unordered_set<std::string> seen;
+  auto add_name = [&](const std::string& name) {
+    if (seen.insert(name).second) {
+      names.push_back(name);
+    }
+  };
+  for (auto* node : g->nodes()) {
+    if (node->kind() != onnx::kAdd && node->kind() != onnx::kMul) {
+      continue;
+    }
+    if (node->inputs().size() != 2) {
+      continue;
+    }
+    onnx::Value* a = node->inputs()[0];
+    onnx::Value* b = node->inputs()[1];
+    if (a->elemType() != onnx::TensorProto_DataType_FLOAT ||
+        b->elemType() != onnx::TensorProto_DataType_FLOAT) {
+      continue;
+    }
+    if (onnx::optimization::FetchConstantTensor(a) != nullptr ||
+        onnx::optimization::FetchConstantTensor(b) != nullptr) {
+      continue;
+    }
+    add_name(a->uniqueName());
+    add_name(b->uniqueName());
+    add_name(node->output()->uniqueName());
+  }
+  return names;
+}
+
+onnx::ModelProto QuantizeQOperatorElementwise(
+    const onnx::ModelProto& model,
+    const std::unordered_map<std::string, std::pair<float, float>>&
+        activation_ranges) {
+  PrepareSchemasForDebug(model);
+  // Registers qoperator_quantize_elementwise (idempotent) into
+  // onnxoptimizer's registry so OptimizeFixed can find it by name below.
+  onnxsim::RegisterCustomOptimizerPasses();
+  // qoperator_quantize_elementwise reads the same calibration-ranges global
+  // every other static/QOperator pass does (see
+  // StaticQuantizationCalibrationRanges's doc comment) -- keyed by tensor
+  // name, both operands' and the output's, so sharing the map is safe as
+  // long as only one Quantize* entry point runs per call, which
+  // OptimizeFixed's single pass-name list here ensures.
+  onnx::optimization::onnxsim_passes::StaticQuantizationCalibrationRanges() =
+      activation_ranges;
+  return onnx::optimization::OptimizeFixed(
+      model, std::vector<std::string>{"qoperator_quantize_elementwise"});
+}
+
 onnx::ModelProto QuantizeFp16(const onnx::ModelProto& model,
                               bool keep_io_types) {
   PrepareSchemasForDebug(model);

--- a/onnxsim/quantize_entry.h
+++ b/onnxsim/quantize_entry.h
@@ -41,6 +41,14 @@ onnx::ModelProto QuantizeQOperator(
     const std::unordered_map<std::string, std::pair<float, float>>&
         activation_ranges);
 
+std::vector<std::string> ListQOperatorElementwiseQuantizableTensors(
+    const onnx::ModelProto& model);
+
+onnx::ModelProto QuantizeQOperatorElementwise(
+    const onnx::ModelProto& model,
+    const std::unordered_map<std::string, std::pair<float, float>>&
+        activation_ranges);
+
 onnx::ModelProto QuantizeFp16(const onnx::ModelProto& model,
                               bool keep_io_types);
 onnx::ModelProto QuantizeBf16(const onnx::ModelProto& model,

--- a/tests/test_qoperator_quantize_elementwise.py
+++ b/tests/test_qoperator_quantize_elementwise.py
@@ -1,0 +1,197 @@
+"""Tests for ``onnxsim.quantize_qoperator_elementwise`` (the
+``qoperator_quantize_elementwise`` C++ pass) -- the elementwise Add/Mul
+analogue of ``test_qoperator_quantize_matmul.py``'s ``QLinearMatMul``
+coverage, using ONNX Runtime's "com.microsoft" contrib ops ``QLinearAdd``/
+``QLinearMul`` instead.
+"""
+
+import collections
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+
+import onnxsim
+
+# A bare ``import onnxruntime`` would fail collection (not skip the test) on
+# platforms onnxruntime doesn't ship wheels for (e.g. s390x).
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(nodes, inputs, outputs, initializer, opset=13):
+    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+    )
+
+
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _op_counts(model):
+    return collections.Counter(n.op_type for n in model.graph.node)
+
+
+def _assert_close(float_outputs, quant_outputs, rel_l2_tol=0.1):
+    for f, q in zip(float_outputs, quant_outputs):
+        f = np.asarray(f, dtype=np.float64).ravel()
+        q = np.asarray(q, dtype=np.float64).ravel()
+        assert np.all(np.isfinite(q))
+        rel_l2 = np.linalg.norm(f - q) / max(np.linalg.norm(f), 1e-6)
+        assert rel_l2 < rel_l2_tol, f"relative L2 error too large: {rel_l2:.4f}"
+
+
+def test_quantize_add():
+    rng = np.random.default_rng(0)
+    nodes = [onnx.helper.make_node("Add", ["A", "B"], ["C"])]
+    model = _model(nodes, [_vi("A", [4, 8]), _vi("B", [4, 8])], [_vi("C", [4, 8])], [])
+
+    quant = onnxsim.quantize_qoperator_elementwise(
+        model, num_calibration_samples=16, seed=0
+    )
+    onnx.checker.check_model(quant)
+    ops = _op_counts(quant)
+    assert ops["Add"] == 0
+    assert ops["QLinearAdd"] == 1
+    assert ops["QuantizeLinear"] == 2  # one for A, one for B
+    assert ops["DequantizeLinear"] == 1  # one for the output
+    domains = {o.domain for o in quant.opset_import}
+    assert "com.microsoft" in domains
+
+    a = rng.standard_normal((4, 8)).astype(np.float32)
+    b = rng.standard_normal((4, 8)).astype(np.float32)
+    _assert_close(_run(model, {"A": a, "B": b}), _run(quant, {"A": a, "B": b}))
+
+
+def test_quantize_mul():
+    rng = np.random.default_rng(1)
+    nodes = [onnx.helper.make_node("Mul", ["A", "B"], ["C"])]
+    model = _model(nodes, [_vi("A", [4, 8]), _vi("B", [4, 8])], [_vi("C", [4, 8])], [])
+
+    quant = onnxsim.quantize_qoperator_elementwise(
+        model, num_calibration_samples=16, seed=1
+    )
+    onnx.checker.check_model(quant)
+    ops = _op_counts(quant)
+    assert ops["Mul"] == 0
+    assert ops["QLinearMul"] == 1
+    assert ops["QuantizeLinear"] == 2
+    assert ops["DequantizeLinear"] == 1
+
+    a = rng.standard_normal((4, 8)).astype(np.float32)
+    b = rng.standard_normal((4, 8)).astype(np.float32)
+    _assert_close(_run(model, {"A": a, "B": b}), _run(quant, {"A": a, "B": b}))
+
+
+def test_quantize_broadcast():
+    # QLinearAdd/QLinearMul support the same bidirectional broadcasting as
+    # plain Add/Mul (see QLinearBinaryShapeInference in contrib_schemas.cpp).
+    rng = np.random.default_rng(2)
+    nodes = [onnx.helper.make_node("Add", ["A", "B"], ["C"])]
+    model = _model(nodes, [_vi("A", [4, 8]), _vi("B", [1, 8])], [_vi("C", [4, 8])], [])
+
+    quant = onnxsim.quantize_qoperator_elementwise(
+        model, num_calibration_samples=16, seed=2
+    )
+    onnx.checker.check_model(quant)
+    assert _op_counts(quant)["QLinearAdd"] == 1
+
+    a = rng.standard_normal((4, 8)).astype(np.float32)
+    b = rng.standard_normal((1, 8)).astype(np.float32)
+    _assert_close(_run(model, {"A": a, "B": b}), _run(quant, {"A": a, "B": b}))
+
+
+def test_quantize_multiple_independent_nodes():
+    # Two unrelated elementwise Adds in the same graph (distinct operands,
+    # not chained through each other) should both be quantized. A node
+    # consuming *another* rewritten node's output is a separate, pre-existing
+    # QOperator-family limitation (see qoperator_quantize_matmul.h/_conv.h,
+    # which have the same characteristic): the rewrite replaces the node
+    # with a fresh Value carrying an auto-generated name, so a downstream
+    # node's activation-range lookup (keyed by the *original* tensor name)
+    # no longer finds an entry -- not exercised here.
+    rng = np.random.default_rng(3)
+    nodes = [
+        onnx.helper.make_node("Add", ["A", "B"], ["T1"]),
+        onnx.helper.make_node("Add", ["C", "D"], ["T2"]),
+        onnx.helper.make_node("Concat", ["T1", "T2"], ["E"], axis=0),
+    ]
+    model = _model(
+        nodes,
+        [_vi("A", [4, 8]), _vi("B", [4, 8]), _vi("C", [4, 8]), _vi("D", [4, 8])],
+        [_vi("E", [8, 8])],
+        [],
+    )
+
+    quant = onnxsim.quantize_qoperator_elementwise(
+        model, num_calibration_samples=16, seed=3
+    )
+    onnx.checker.check_model(quant)
+    assert _op_counts(quant)["QLinearAdd"] == 2
+
+    a = rng.standard_normal((4, 8)).astype(np.float32)
+    b = rng.standard_normal((4, 8)).astype(np.float32)
+    c = rng.standard_normal((4, 8)).astype(np.float32)
+    d = rng.standard_normal((4, 8)).astype(np.float32)
+    feeds = {"A": a, "B": b, "C": c, "D": d}
+    _assert_close(_run(model, feeds), _run(quant, feeds))
+
+
+def test_quantize_skips_constant_operand():
+    # A constant operand (e.g. a per-channel bias/embedding) is left alone --
+    # it should be quantized from its own static values, not force-fed
+    # through the calibration harness.
+    bias = _f32(np.random.default_rng(4).standard_normal(8), "B")
+    nodes = [onnx.helper.make_node("Add", ["A", "B"], ["C"])]
+    model = _model(nodes, [_vi("A", [4, 8])], [_vi("C", [4, 8])], [bias])
+    import onnxsim.onnxsim_cpp2py_export as C
+
+    names = C.list_qoperator_elementwise_quantizable_tensors(model.SerializeToString())
+    assert names == []
+
+    quant = onnxsim.quantize_qoperator_elementwise(model)
+    assert _op_counts(quant)["Add"] == 1
+    assert _op_counts(quant)["QLinearAdd"] == 0
+
+
+def test_quantize_skips_non_float():
+    nodes = [onnx.helper.make_node("Add", ["A", "B"], ["C"])]
+    graph = onnx.helper.make_graph(
+        nodes,
+        "g",
+        [
+            onnx.helper.make_tensor_value_info("A", onnx.TensorProto.INT64, [4]),
+            onnx.helper.make_tensor_value_info("B", onnx.TensorProto.INT64, [4]),
+        ],
+        [onnx.helper.make_tensor_value_info("C", onnx.TensorProto.INT64, [4])],
+        [],
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 13)], ir_version=10
+    )
+    quant = onnxsim.quantize_qoperator_elementwise(model)
+    assert _op_counts(quant)["Add"] == 1
+    assert _op_counts(quant)["QLinearAdd"] == 0
+
+
+def test_list_qoperator_elementwise_quantizable_tensors():
+    nodes = [onnx.helper.make_node("Add", ["A", "B"], ["C"])]
+    model = _model(nodes, [_vi("A", [4, 8]), _vi("B", [4, 8])], [_vi("C", [4, 8])], [])
+    import onnxsim.onnxsim_cpp2py_export as C
+
+    names = C.list_qoperator_elementwise_quantizable_tensors(model.SerializeToString())
+    assert set(names) == {"A", "B", "C"}


### PR DESCRIPTION
## Summary

- Extends QOperator-format static quantization to elementwise `Add`/`Mul` nodes whose two inputs are both non-constant float32 tensors (e.g. residual connections), using ONNX Runtime's `com.microsoft` contrib ops `QLinearAdd`/`QLinearMul` — standard ONNX has no quantized elementwise-binary op (only `QLinearMatMul`/`QLinearConv`, both weight-shaped).
- New C++ pass `qoperator_quantize_elementwise` (`onnxsim/passes/qoperator_quantize_elementwise.h`), entry points `QuantizeQOperatorElementwise`/`ListQOperatorElementwiseQuantizableTensors`, nanobind bindings, Python wrapper `onnxsim.quantize_qoperator_elementwise`, CLI flag `--qoperator-quantize-elementwise`.
- Unlike every other `quantize_*` in this codebase, `QLinearAdd`/`QLinearMul` have no "weight" operand — both inputs *and* the output need a calibrated range, and the pass adds `com.microsoft` (version 1) to the model's opset imports on first rewrite. The result needs a `com.microsoft`-aware runtime (e.g. ONNX Runtime) to execute.
- A node with a constant operand (e.g. a per-channel bias/embedding) is deliberately left untouched — better quantized from its own static values than force-fed through calibration.

## Test plan

- [x] Verified ORT's `CPUExecutionProvider` actually executes `QLinearAdd`/`QLinearMul` kernels via a standalone smoke test before committing to this design.
- [x] New `tests/test_qoperator_quantize_elementwise.py`: real `onnxruntime.InferenceSession` execution (Add, Mul, broadcasting, multiple independent nodes), `onnx.checker.check_model` passes on the quantized output, plus constant-operand/non-float skip coverage and the new `list_qoperator_elementwise_quantizable_tensors` listing.
- [x] Full test suite (`pytest tests/`, excluding pre-existing torch/timm-dependent modules unrelated to this change): 289 passed, 65 skipped.
- [x] `ruff check` / `ruff format --check` clean.
- [x] CLI smoke test: `onnxsim model.onnx out.onnx --qoperator-quantize-elementwise` produces `QuantizeLinear`/`QLinearAdd`/`DequantizeLinear` with `com.microsoft` in `opset_import`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_