### PR TITLE
Add fuse_attention: fuse hand-written self-attention into com.microsoft Attention

### DIFF
--- a/onnxsim/contrib_schemas.cpp
+++ b/onnxsim/contrib_schemas.cpp
@@ -619,6 +619,92 @@ OpSchema MakeMatMulIntegerToFloatSchema() {
       });
 }
 
+// Real ONNX Runtime multi-head self-/cross-attention op (docs/
+// ContribOperators.md, onnxruntime/core/graph/contrib_ops/contrib_defs.cc).
+// Registered here so fuse_attention.h's fused output -- which only ever
+// emits inputs 0-2 (input, weights, bias) and attrs num_heads/scale/
+// qkv_hidden_sizes -- passes the ONNX checker and shape-inference sweeps the
+// rest of onnxsim's pipeline runs after any Fuse pass fires; the remaining
+// attrs/inputs (do_rotary, past/present KV cache, attention_bias,
+// mask_index, rotary_embedding_dim, past_present_share_buffer) are declared
+// for schema completeness/compatibility with externally-authored models,
+// not because this pass ever produces them.
+OpSchema MakeAttentionSchema() {
+  return OpSchema()
+      .SetName("Attention")
+      .SetDomain(kMSDomain)
+      .SinceVersion(1)
+      .SetDoc(
+          "Multi-Head Self/Cross Attention. Bias from input projection is "
+          "included.")
+      .Attr("num_heads", "Number of attention heads.",
+            onnx::AttributeProto::INT, /*required=*/true)
+      .Attr("scale",
+            "Custom scale will be used if specified. Default value is "
+            "1/sqrt(head_size).",
+            onnx::AttributeProto::FLOAT, /*required=*/false)
+      .Attr("unidirectional",
+            "Whether every token can only attend to previous tokens.",
+            onnx::AttributeProto::INT, static_cast<int64_t>(0))
+      .Attr("qkv_hidden_sizes",
+            "Hidden dimension of Q, K, V: hidden_size, hidden_size and "
+            "v_hidden_size.",
+            onnx::AttributeProto::INTS, /*required=*/false)
+      .Attr("mask_filter_value",
+            "The value to be filled in the attention mask. Default value "
+            "is -10000.0.",
+            onnx::AttributeProto::FLOAT, static_cast<float>(-10000.0f))
+      .Attr("do_rotary", "Whether to use rotary position embedding.",
+            onnx::AttributeProto::INT, static_cast<int64_t>(0))
+      .Attr("rotary_embedding_dim",
+            "Dimension of rotary embedding. Limited to 32, 64 or 128.",
+            onnx::AttributeProto::INT, /*required=*/false)
+      .Attr("past_present_share_buffer",
+            "Corresponding past and present are same tensor, its shape is "
+            "(2, batch_size, num_heads, max_sequence_length, head_size).",
+            onnx::AttributeProto::INT, /*required=*/false)
+      .Input(0, "input",
+             "Input tensor with shape (batch_size, sequence_length, "
+             "input_hidden_size).",
+             "T")
+      .Input(1, "weights",
+             "Merged Q/K/V weights with shape (input_hidden_size, "
+             "hidden_size + hidden_size + v_hidden_size).",
+             "T")
+      .Input(2, "bias",
+             "Bias tensor with shape (hidden_size + hidden_size + "
+             "v_hidden_size).",
+             "T", OpSchema::Optional)
+      .Input(3, "mask_index", "Attention mask.", "M", OpSchema::Optional)
+      .Input(4, "past",
+             "Past state for key and value with shape (2, batch_size, "
+             "num_heads, past_sequence_length, head_size).",
+             "T", OpSchema::Optional)
+      .Input(5, "attention_bias",
+             "Additional add to QxK' with shape broadcastable to "
+             "(batch_size, num_heads, sequence_length, "
+             "total_sequence_length).",
+             "T", OpSchema::Optional)
+      .Input(6, "past_sequence_length",
+             "When past_present_share_buffer is used, it is required to "
+             "specify past_sequence_length (could be 0).",
+             "M", OpSchema::Optional)
+      .Output(0, "output",
+              "3D output tensor with shape (batch_size, sequence_length, "
+              "v_hidden_size).",
+              "T")
+      .Output(1, "present",
+              "Present state for key and value with shape (2, batch_size, "
+              "num_heads, total_sequence_length, head_size).",
+              "T", OpSchema::Optional)
+      .TypeConstraint(
+          "T", {"tensor(float)", "tensor(float16)"},
+          "Constrain input and output to float tensors. (bfloat16 omitted "
+          "-- onnxsim's own float32-only fuse target never emits it.)")
+      .TypeConstraint("M", {"tensor(int32)"},
+                      "Constrain mask index to integer types.");
+}
+
 void RegisterAll() {
   // The custom domain must be known to the schema registry before any schema
   // in it can be registered.
@@ -641,6 +727,7 @@ void RegisterAll() {
   RegisterIfAbsent(MakeQLinearWhereSchema());
   RegisterIfAbsent(MakeQGemmSchema());
   RegisterIfAbsent(MakeMatMulIntegerToFloatSchema());
+  RegisterIfAbsent(MakeAttentionSchema());
 
   // Augment the standard Reshape schema with a data-propagation function so
   // shape tensors can flow through a Reshape during partial shape evaluation.

--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -15,6 +15,7 @@
 #include "passes/eliminate_nop_dropout.h"
 #include "passes/eliminate_reshape_around_elementwise.h"
 #include "passes/fuse_add_bias_into_conv.h"
+#include "passes/fuse_attention.h"
 #include "passes/fuse_bn_into_conv.h"
 #include "passes/fuse_consecutive_mul.h"
 #include "passes/fuse_consecutive_unsqueezes.h"
@@ -24,6 +25,7 @@
 #include "passes/fuse_mul_into_conv.h"
 #include "passes/fuse_pad_into_pool.h"
 #include "passes/fuse_preceding_mul_into_conv.h"
+#include "passes/fuse_qkv.h"
 #include "passes/fuse_rms_norm.h"
 #include "passes/qoperator_quantize_activation.h"
 #include "passes/qoperator_quantize_concat.h"
@@ -87,6 +89,7 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::DynamicQuantizeMatMulIntegerToFloat>(registry);
     RegisterOrReplace<p::DynamicQuantizeTernaryMatMul>(registry);
     RegisterOrReplace<p::EliminateReshapeAroundElementwise>(registry);
+    RegisterOrReplace<p::FuseAttention>(registry);
     RegisterOrReplace<p::FuseConsecutiveMul>(registry);
     RegisterOrReplace<p::FuseGelu>(registry);
     RegisterOrReplace<p::FuseLayerNorm>(registry);
@@ -129,6 +132,7 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::FuseBNIntoConv>(registry);
     RegisterOrReplace<p::FuseConsecutiveUnsqueezes>(registry);
     RegisterOrReplace<p::FusePadIntoPool>(registry);
+    RegisterOrReplace<p::FuseQKV>(registry);
   });
 }
 

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -242,7 +242,7 @@ onnx::ModelProto Simplify(
         overwrite_input_shapes,
     const std::optional<std::vector<std::string>>& unused_output) {
   // Register onnxsim's own optimizer passes into onnxoptimizer's registry
-  // before the pass list is built below: fuse_consecutive_mul,
+  // before the pass list is built below: fuse_attention, fuse_consecutive_mul,
   // fuse_mul_into_conv, fuse_preceding_mul_into_conv, fuse_rms_norm and
   // eliminate_reshape_around_elementwise are auto-selected via
   // GetFuseAndEliminationPass, and fuse_matmul_add_bias_into_gemm_batched is

--- a/onnxsim/passes/fuse_attention.h
+++ b/onnxsim/passes/fuse_attention.h
@@ -22,7 +22,17 @@
 //   Q = Reshape(Linear(X, Wq[, Bq]), [B,S,H,D]).Transpose([0,2,1,3])
 //   K = Reshape(Linear(X, Wk[, Bk]), [B,S,H,D]).Transpose([0,2,3,1])
 //   V = Reshape(Linear(X, Wv[, Bv]), [B,S,H,D]).Transpose([0,2,1,3])
-//   scores = (Q @ K) / sqrt(head_size)      -- or `* (1/sqrt(head_size))`
+//   scores = (Q @ K) / sqrt(head_size)      -- or `* (1/sqrt(head_size))`,
+//            or `(Q * sqrt(1/sqrt(head_size))) @ (K * sqrt(1/sqrt(head_size)))`
+//            -- see MatchScaledQKMatMul for why this third, pre-scaled shape
+//            is also handled: it is what `torch.nn.functional.
+//            scaled_dot_product_attention`'s own ONNX export decomposes
+//            into, in both PyTorch's legacy TorchScript and newer dynamo
+//            exporters, once the dynamic Shape/Slice/Cast/Sqrt/... chain
+//            computing that scale from Q's runtime shape is constant-folded
+//            (which happens automatically, earlier in the same simplify()
+//            fixed point this pass itself runs inside, whenever the model's
+//            shapes are static).
 //   attn   = Softmax(scores, axis=-1)
 //   ctx    = (attn @ V).Transpose([0,2,1,3]).Reshape([B,S,H*D])
 //   Y      = Linear(ctx, Wout[, Bout])
@@ -45,7 +55,13 @@
 // [0,2,3,1] (X.Transpose([0,2,1,3]) is the more common overall convention,
 // but the exact spelling of a *second*, standalone "swap the last two axes"
 // transpose that some exporters emit for K specifically is not matched --
-// only the single-transpose-straight-to-[0,2,3,1] form is; see MatchHeadSplit).
+// only the single-transpose-straight-to-[0,2,3,1] form is; see
+// MatchHeadSplit). This is why `scaled_dot_product_attention`'s *dynamo*
+// export (unlike its legacy TorchScript export, which does use the direct
+// [0,2,3,1] form) is not yet handled: it head-splits K the same way as Q/V
+// (perm [0,2,1,3]) and spells the "swap the last two axes for K^T" step
+// separately, as `Reshape -> Transpose -> Reshape` rather than folding it
+// into one 4-D permutation -- left as a follow-up.
 // Only self-attention (Q, K, V all reading the *same* source activation) with
 // no attention mask, no past/present KV cache, and a Softmax over the last
 // axis (`axis=-1` or the input's last dimension index -- both are safe here
@@ -57,6 +73,7 @@
 // Q@K^T dot product to be well-formed); V's hidden size may differ, per
 // `Attention`'s own documented `qkv_hidden_sizes` semantics.
 
+#include <cmath>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -174,6 +191,116 @@ inline bool FetchScalarAsDouble(Value* v, double& out) {
   return false;
 }
 
+// Matches `scores` (Softmax's sole input, already known single-use by the
+// caller) as a scaled Q@K^T dot product, in either of two shapes real
+// exporters produce:
+//
+//  - "post-scaled": scores = Div(QK, c) or Mul(QK, c), where QK is itself a
+//    plain MatMul -- the shape a hand-rolled `(Q @ K) / sqrt(head_size)`
+//    attention implementation emits.
+//  - "pre-scaled": scores = MatMul(Mul(q_side, c), Mul(k_side, c)), i.e. the
+//    same combined scale split as `sqrt(c)` onto each operand *before* the
+//    dot product rather than applied to its result once -- see this file's
+//    top-of-file doc comment for why this is `scaled_dot_product_attention`'s
+//    own decomposition. Both Muls' scalar operands must fetch to the same
+//    value (within a small relative tolerance, since real graphs sometimes
+//    compute the same folded constant via two syntactically distinct nodes
+//    rather than sharing one Value*); an asymmetric split isn't this shape.
+//
+// On success sets `q_side`/`k_side` to the two (not yet head-split-matched)
+// operands and `scale` to the *combined* scale factor (already squared back
+// up in the pre-scaled case, so the caller never needs to know which shape
+// matched). Every node this consumed -- the Div/Mul wrapper and the inner
+// MatMul in the post-scaled case, or the qk MatMul and its two Mul operands
+// in the pre-scaled case -- is appended to `dead_chain` **in a valid destroy
+// order** (each consumer before the producer(s) feeding it: `dead_chain`'s
+// own contract, since the two shapes need opposite relative orders here --
+// post-scaled destroys the Div/Mul *before* the MatMul it wraps, but
+// pre-scaled destroys the MatMul *before* the two Muls feeding *it* -- a
+// single fixed push order in the caller can't satisfy both, so this function
+// owns it instead of returning the qk MatMul node separately).
+inline bool MatchScaledQKMatMul(Value* scores, Value*& q_side, Value*& k_side,
+                                double& scale, std::vector<Node*>& dead_chain) {
+  Node* scores_node = scores->node();
+
+  Value* qk = nullptr;
+  if (CheckKind(scores_node, kDiv) && scores_node->inputs().size() == 2) {
+    double divisor = 0.0;
+    if (FetchScalarAsDouble(scores_node->input(1), divisor) && divisor != 0.0) {
+      qk = scores_node->input(0);
+      scale = 1.0 / divisor;
+    }
+  } else if (CheckKind(scores_node, kMul) &&
+             scores_node->inputs().size() == 2) {
+    for (int i = 0; i < 2; ++i) {
+      double mult = 0.0;
+      if (FetchScalarAsDouble(scores_node->input(1 - i), mult)) {
+        qk = scores_node->input(i);
+        scale = mult;
+        break;
+      }
+    }
+  }
+  if (qk != nullptr) {
+    if (qk->uses().size() != 1 || !CheckKind(qk, kMatMul)) {
+      return false;
+    }
+    Node* mm = qk->node();
+    if (mm->inputs().size() != 2) {
+      return false;
+    }
+    dead_chain.push_back(scores_node);  // consumer of mm's output: first.
+    dead_chain.push_back(mm);
+    q_side = mm->input(0);
+    k_side = mm->input(1);
+    return true;
+  }
+
+  if (!CheckKind(scores_node, kMatMul) || scores_node->inputs().size() != 2) {
+    return false;
+  }
+  double c[2] = {0.0, 0.0};
+  Value* operand[2] = {nullptr, nullptr};
+  Node* muls[2] = {nullptr, nullptr};
+  for (int i = 0; i < 2; ++i) {
+    Value* in = scores_node->input(i);
+    if (in->uses().size() != 1 || !CheckKind(in, kMul)) {
+      return false;
+    }
+    Node* mul = in->node();
+    if (mul->inputs().size() != 2) {
+      return false;
+    }
+    bool found = false;
+    for (int j = 0; j < 2; ++j) {
+      double v = 0.0;
+      if (FetchScalarAsDouble(mul->input(1 - j), v)) {
+        operand[i] = mul->input(j);
+        c[i] = v;
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      return false;
+    }
+    muls[i] = mul;
+  }
+  if (std::fabs(c[0] - c[1]) >
+      1e-6 * std::max(std::fabs(c[0]), std::fabs(c[1]))) {
+    return false;
+  }
+  // scores_node (the qk MatMul) consumes both muls' outputs: destroy it
+  // first, then its two (now-unused) producers.
+  dead_chain.push_back(scores_node);
+  dead_chain.push_back(muls[0]);
+  dead_chain.push_back(muls[1]);
+  q_side = operand[0];
+  k_side = operand[1];
+  scale = c[0] * c[1];
+  return true;
+}
+
 // Matches `transposed = Transpose(Reshape(proj_out, [B, S, num_heads,
 // head_size]), want_perm)`, both single-use, extracting num_heads/head_size
 // from the Reshape's constant target-shape input. Appends [transpose,
@@ -211,6 +338,57 @@ inline bool MatchAttentionHeadSplit(Value* transposed, int64_t& num_heads,
   chain.push_back(tr);
   chain.push_back(rs);
   return true;
+}
+
+// `Attention`'s schema requires a rank-3 X input ([batch_size,
+// sequence_length, input_hidden_size]). Q/K/V's shared source is usually
+// exactly the model's own rank-3 activation, but when an earlier fixed-point
+// iteration has already rewritten a MatMul+Add projection into Gemm (Gemm
+// requires 2-D operands, so onnx-optimizer's own fuse_matmul_add_into_gemm
+// flattens a batch/sequence-dim input to 2-D with a Reshape first) before
+// this pass gets its turn -- which for a `torch.nn.functional.
+// scaled_dot_product_attention` export is close to guaranteed: its own scale
+// computation needs an earlier constant-folding pass to resolve before
+// MatchScaledQKMatMul's pattern is even structurally satisfiable, so
+// Gemm-conversion (which has no such prerequisite) reliably wins that race
+// -- `input` ends up rank-2 instead of rank-3.
+//
+// Recovers the original rank-3 activation in that specific case: when
+// `input` is exactly `Reshape(x3, ...)` with `x3` rank-3 and the same
+// trailing (hidden-size) dimension `input` itself has, returns `x3`. This is
+// mathematically transparent to wire into Attention's X input in place of
+// `input` -- fuse_matmul_add_into_gemm's flattening Reshape only ever merges
+// the leading (batch/sequence) dims and keeps the last one, which is exactly
+// what both Gemm's row-wise application and Attention's own per-token QKV
+// projection already treat those leading dims as, so there is nothing to
+// numerically "correct for", just a different, already-live Value* for the
+// same quantity. Falls through to returning `input` unchanged -- rank-3,
+// rank-2, or otherwise -- whenever this specific shape isn't matched; the
+// caller still validates the final rank itself.
+inline Value* RecoverRank3AttentionInput(Value* input) {
+  if (input->has_sizes() && input->sizes().size() == 3) {
+    return input;
+  }
+  if (!input->has_sizes() || input->sizes().size() != 2 ||
+      !CheckKind(input, kReshape)) {
+    return input;
+  }
+  Node* rs = input->node();
+  if (rs->inputs().size() != 2) {
+    return input;
+  }
+  Value* x3 = rs->input(0);
+  if (!x3->has_sizes() || x3->sizes().size() != 3) {
+    return input;
+  }
+  const Dimension& last3 = x3->sizes()[2];
+  const Dimension& last2 = input->sizes()[1];
+  if (last3.is_int != last2.is_int ||
+      (last3.is_int && last3.dim != last2.dim) ||
+      (!last3.is_int && last3.param != last2.param)) {
+    return input;
+  }
+  return x3;
 }
 
 struct AttentionMatch {
@@ -291,45 +469,18 @@ inline bool MatchAttention(Node* n, AttentionMatch& m) {
     return false;
   }
 
-  Node* scores_node = scores->node();
-  Value* qk = nullptr;
-  if (CheckKind(scores_node, kDiv) && scores_node->inputs().size() == 2) {
-    double divisor = 0.0;
-    if (!FetchScalarAsDouble(scores_node->input(1), divisor) ||
-        divisor == 0.0) {
-      return false;
-    }
-    qk = scores_node->input(0);
-    m.scale = 1.0 / divisor;
-  } else if (CheckKind(scores_node, kMul) &&
-             scores_node->inputs().size() == 2) {
-    for (int i = 0; i < 2; ++i) {
-      double mult = 0.0;
-      if (FetchScalarAsDouble(scores_node->input(1 - i), mult)) {
-        qk = scores_node->input(i);
-        m.scale = mult;
-        break;
-      }
-    }
-    if (qk == nullptr) {
-      return false;
-    }
-  } else {
-    return false;
-  }
-  if (qk->uses().size() != 1 || !CheckKind(qk, kMatMul)) {
-    return false;
-  }
-  Node* qk_mm = qk->node();
-  if (qk_mm->inputs().size() != 2) {
+  Value* q_side = nullptr;
+  Value* k_side = nullptr;
+  std::vector<Node*> scale_chain;
+  if (!MatchScaledQKMatMul(scores, q_side, k_side, m.scale, scale_chain)) {
     return false;
   }
 
   std::vector<Node*> q_head_chain;
   Value* q_proj_out = nullptr;
   int64_t q_heads = 0, q_head_size = 0;
-  if (!MatchAttentionHeadSplit(qk_mm->input(0), q_heads, q_head_size,
-                               q_proj_out, {0, 2, 1, 3}, q_head_chain) ||
+  if (!MatchAttentionHeadSplit(q_side, q_heads, q_head_size, q_proj_out,
+                               {0, 2, 1, 3}, q_head_chain) ||
       !MatchAttentionProjection(q_proj_out, m.q)) {
     return false;
   }
@@ -337,8 +488,8 @@ inline bool MatchAttention(Node* n, AttentionMatch& m) {
   std::vector<Node*> k_head_chain;
   Value* k_proj_out = nullptr;
   int64_t k_heads = 0, k_head_size = 0;
-  if (!MatchAttentionHeadSplit(qk_mm->input(1), k_heads, k_head_size,
-                               k_proj_out, {0, 2, 3, 1}, k_head_chain) ||
+  if (!MatchAttentionHeadSplit(k_side, k_heads, k_head_size, k_proj_out,
+                               {0, 2, 3, 1}, k_head_chain) ||
       !MatchAttentionProjection(k_proj_out, m.k)) {
     return false;
   }
@@ -350,6 +501,16 @@ inline bool MatchAttention(Node* n, AttentionMatch& m) {
 
   if (m.q.input != m.k.input || m.q.input != m.v.input) {
     return false;  // Self-attention only: Q/K/V share the same source.
+  }
+  m.q.input = m.k.input = m.v.input = RecoverRank3AttentionInput(m.q.input);
+  // `Attention`'s schema requires a rank-3 X input ([batch_size,
+  // sequence_length, input_hidden_size]) -- if RecoverRank3AttentionInput
+  // could not find one (see its own doc comment for when/why this happens),
+  // firing anyway would emit a shape-invalid Attention node (rejected at
+  // load time by a real runtime) rather than a wrong-but-loadable one, so
+  // this declines conservatively instead of guessing further.
+  if (!m.q.input->has_sizes() || m.q.input->sizes().size() != 3) {
+    return false;
   }
 
   const bool any_bias =
@@ -365,8 +526,7 @@ inline bool MatchAttention(Node* n, AttentionMatch& m) {
   m.dead_chain.push_back(softmax);
   for (Node* nd : v_head_chain) m.dead_chain.push_back(nd);
   for (Node* nd : m.v.chain) m.dead_chain.push_back(nd);
-  m.dead_chain.push_back(scores_node);
-  m.dead_chain.push_back(qk_mm);
+  for (Node* nd : scale_chain) m.dead_chain.push_back(nd);
   for (Node* nd : q_head_chain) m.dead_chain.push_back(nd);
   for (Node* nd : m.q.chain) m.dead_chain.push_back(nd);
   for (Node* nd : k_head_chain) m.dead_chain.push_back(nd);
@@ -493,7 +653,10 @@ struct FuseAttention final : public PredicateBasedPass {
     attn->is_(Symbol("qkv_hidden_sizes"), std::vector<int64_t>{nq, nk, nv});
     attn->setDomain("com.microsoft");
     attn->insertBefore(n);
-    attn->output()->copyMetadata(n->output());
+    // No copyMetadata here: `attn`'s output is always rank-3
+    // ([batch_size, sequence_length, hidden_size], per Attention's own
+    // schema), which is not necessarily n's own shape -- see the Reshape
+    // built below. Left for the next shape-inference pass to (re)infer.
 
     bool has_ms_domain = false;
     for (const OpSetID& opset : graph.opset_versions_mutable()) {
@@ -506,12 +669,32 @@ struct FuseAttention final : public PredicateBasedPass {
       graph.opset_versions_mutable().emplace_back("com.microsoft", 1);
     }
 
-    // `n` (the ctx-producing Reshape) is fully replaced by `attn`'s output
-    // -- whatever consumed `ctx` (the untouched output projection) now
-    // reads straight from `attn` -- and destroyed by the pass driver below
+    // `n`'s own target shape (its second input) is reused, unchanged, to
+    // reshape `attn`'s raw output into whatever shape `n`'s consumers
+    // actually expect -- almost always identical to `attn`'s own natural
+    // [B,S,H*D] shape (a cheap identity reshape onnx-optimizer's own
+    // eliminate_nop_reshape prunes in a later fixed-point iteration), but
+    // when an earlier iteration has already collapsed `n`'s reshape target
+    // together with a downstream Gemm's own input-flattening reshape into
+    // one direct-to-2-D [B*S,H*D] target, substituting `attn`'s raw output
+    // for every use of `n` directly (the way this used to work) would
+    // silently mismatch that shape. Reusing `n`'s own target value here --
+    // rather than assuming it is always the "natural" 3-D one -- is correct
+    // either way, since it is simply whatever `n` already reshaped this same
+    // ctx data into.
+    Value* n_shape = n->input(1);
+    Node* reshape_out = graph.create(Symbol("Reshape"), 1);
+    reshape_out->addInput(attn->output());
+    reshape_out->addInput(n_shape);
+    reshape_out->insertBefore(n);
+    reshape_out->output()->copyMetadata(n->output());
+
+    // `n` is fully replaced by `reshape_out`'s output -- whatever consumed
+    // `ctx` (the untouched output projection) now reads straight from it --
+    // and `n` itself is destroyed by the pass driver below
     // (destroy_current = DestroyOne), the same idiom fuse_rms_norm.h and
     // fuse_add_bias_into_conv.h use for their own anchors.
-    if (!tryReplacingAllUsesWith(n, attn)) {
+    if (!tryReplacingAllUsesWith(n, reshape_out)) {
       return false;
     }
 

--- a/onnxsim/passes/fuse_attention.h
+++ b/onnxsim/passes/fuse_attention.h
@@ -1,0 +1,534 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+#pragma once
+
+// Fuses a "hand-written" multi-head self-attention block -- the pattern a
+// typical from-scratch eager attention implementation (e.g. a
+// HuggingFace-style `nn.Linear` Q/K/V projection + reshape/transpose +
+// scaled dot-product + softmax + `nn.Linear` output projection, *not*
+// PyTorch's built-in `nn.MultiheadAttention`, whose legacy TorchScript
+// export emits a very different ~70-node trace full of dynamic-shape
+// bookkeeping this pass does not attempt to recognize) -- into a single
+// ONNX Runtime "com.microsoft" contrib op, `Attention`.
+//
+// Before (Q/K/V bias optional; each projection may be a single Gemm(x, W,
+// B[, transB=1]) node or a bare MatMul(x, W) optionally followed by a
+// separate Add(B, .) node -- see MatchProjection):
+//   Q = Reshape(Linear(X, Wq[, Bq]), [B,S,H,D]).Transpose([0,2,1,3])
+//   K = Reshape(Linear(X, Wk[, Bk]), [B,S,H,D]).Transpose([0,2,3,1])
+//   V = Reshape(Linear(X, Wv[, Bv]), [B,S,H,D]).Transpose([0,2,1,3])
+//   scores = (Q @ K) / sqrt(head_size)      -- or `* (1/sqrt(head_size))`
+//   attn   = Softmax(scores, axis=-1)
+//   ctx    = (attn @ V).Transpose([0,2,1,3]).Reshape([B,S,H*D])
+//   Y      = Linear(ctx, Wout[, Bout])
+// After:
+//   Wqkv = Concat(Wq, Wk, Wv, axis=1)      -- computed once, here
+//   Bqkv = Concat(Bq, Bk, Bv)              -- only when Q/K/V all have bias
+//   Y = Attention(X, Wqkv[, Bqkv], num_heads=H, scale=1/sqrt(head_size),
+//                 qkv_hidden_sizes=[Nq, Nk, Nv])
+//   Y = Linear(Y, Wout[, Bout])            -- unchanged, not part of the fuse
+//
+// This collapses roughly a dozen shape/matmul/softmax nodes per attention
+// block into one `Attention` node (the output projection is left as its own
+// Linear -- `Attention`'s own schema only covers the QKV side). Unlike
+// `fuse_rms_norm.h`'s target (`RMSNormalization`, standard ONNX), `Attention`
+// is a "com.microsoft" contrib op, so this pass adds that domain (version 1)
+// to the model's opset imports the first time it fires, if not already
+// present, and the result needs a "com.microsoft"-aware runtime to execute.
+//
+// K's head-split transpose is required to land directly at permutation
+// [0,2,3,1] (X.Transpose([0,2,1,3]) is the more common overall convention,
+// but the exact spelling of a *second*, standalone "swap the last two axes"
+// transpose that some exporters emit for K specifically is not matched --
+// only the single-transpose-straight-to-[0,2,3,1] form is; see MatchHeadSplit).
+// Only self-attention (Q, K, V all reading the *same* source activation) with
+// no attention mask, no past/present KV cache, and a Softmax over the last
+// axis (`axis=-1` or the input's last dimension index -- both are safe here
+// regardless of the pre-/post-opset-13 Softmax axis-semantics split, since
+// the matched score tensor is always exactly rank 4 by construction, and
+// "flatten everything before the last axis" degenerates to the same
+// per-row reduction as "reduce the last axis in place" for a fixed rank)
+// is handled. Q and K must have the same per-head size (required for the
+// Q@K^T dot product to be well-formed); V's hidden size may differ, per
+// `Attention`'s own documented `qkv_hidden_sizes` semantics.
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+#include "passes/endian_read.h"
+#include "passes/quantize_matmul_common.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+// A single Q/K/V Linear-style projection matched feeding `out`. `out` is
+// always required to be single-use: every node this struct's `chain` records
+// is destroyed once the fusion fires, so nothing else may still depend on it.
+struct AttentionProjectionInfo {
+  Value* input = nullptr;
+  Value* weight = nullptr;  // constant 2-D float32
+  Value* bias = nullptr;    // constant 1-D float32, or nullptr
+  bool weight_transposed = false;
+  // Node(s) strictly between (input, weight[, bias]) and `out`, ordered
+  // innermost (closest to `out`'s consumer) first: just the standalone
+  // MatMul node when `out` is a separate bias-Add's own output (the Add
+  // node itself IS `out->node()`, so it is included too, ahead of the
+  // MatMul it consumes); a single entry (`out->node()` itself) when `out`
+  // is already the Gemm/MatMul.
+  std::vector<Node*> chain;
+};
+
+// Matches a Linear-style projection whose result is `out`: a vanilla Gemm(x,
+// W[, B]) or bare MatMul(x, W) node directly (`MatchMatMulLike`), or a
+// MatMul(x, W) followed by a separate Add(B, .) bias node (the shape a plain
+// `nn.Linear` exported via `MatMul` rather than `Gemm` produces). `weight`
+// and, if present, `bias` must be constant float32 tensors. `out` must be
+// single-use -- the caller is always going to tear down its producer chain.
+inline bool MatchAttentionProjection(Value* out,
+                                     AttentionProjectionInfo& info) {
+  if (out->uses().size() != 1) {
+    return false;
+  }
+  Node* node = out->node();
+  if (CheckKind(node, kAdd) && node->inputs().size() == 2) {
+    for (int i = 0; i < 2; ++i) {
+      Value* mm_out = node->input(i);
+      Value* bias = node->input(1 - i);
+      if (mm_out->uses().size() != 1 || !CheckKind(mm_out, kMatMul)) {
+        continue;
+      }
+      MatMulLikeInfo mm_info;
+      if (!MatchMatMulLike(mm_out->node(), mm_info)) {
+        continue;
+      }
+      const Tensor* bias_t = FetchConstantTensor(bias);
+      if (bias_t == nullptr ||
+          bias_t->elem_type() != TensorProto_DataType_FLOAT ||
+          bias_t->sizes().size() != 1) {
+        continue;
+      }
+      const Tensor* w_t = FetchConstantTensor(mm_info.w);
+      if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+          w_t->sizes().size() != 2) {
+        continue;
+      }
+      info.input = mm_info.x;
+      info.weight = mm_info.w;
+      info.bias = bias;
+      info.weight_transposed = false;  // kMatMul only, never transposed.
+      info.chain = {node, mm_out->node()};
+      return true;
+    }
+    return false;
+  }
+  MatMulLikeInfo mm_info;
+  if (!MatchMatMulLike(node, mm_info)) {
+    return false;
+  }
+  const Tensor* w_t = FetchConstantTensor(mm_info.w);
+  if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+      w_t->sizes().size() != 2) {
+    return false;
+  }
+  if (mm_info.bias != nullptr) {
+    const Tensor* bias_t = FetchConstantTensor(mm_info.bias);
+    if (bias_t == nullptr ||
+        bias_t->elem_type() != TensorProto_DataType_FLOAT ||
+        bias_t->sizes().size() != 1) {
+      return false;
+    }
+  }
+  info.input = mm_info.x;
+  info.weight = mm_info.w;
+  info.bias = mm_info.bias;
+  info.weight_transposed = mm_info.weight_transposed;
+  info.chain = {node};
+  return true;
+}
+
+// Reads a scalar constant as a double regardless of whether it is stored as
+// float32 or float64 -- FetchSoleValueOfTensor<T> requires an exact
+// elem_type match (see quantize_matmul_common.h/pass_util.h), and the
+// scaling constant a real export emits (e.g. `1/sqrt(head_size)`) is
+// ordinary float32, not double, so asking for T=double alone would always
+// silently fail. Mirrors fuse_rms_norm.h's own FetchScalarAsFloat.
+inline bool FetchScalarAsDouble(Value* v, double& out) {
+  if (FetchSoleValueOfTensor(v, out)) {
+    return true;
+  }
+  float f;
+  if (FetchSoleValueOfTensor(v, f)) {
+    out = static_cast<double>(f);
+    return true;
+  }
+  return false;
+}
+
+// Matches `transposed = Transpose(Reshape(proj_out, [B, S, num_heads,
+// head_size]), want_perm)`, both single-use, extracting num_heads/head_size
+// from the Reshape's constant target-shape input. Appends [transpose,
+// reshape] to `chain` (innermost/closest-to-consumer first).
+inline bool MatchAttentionHeadSplit(Value* transposed, int64_t& num_heads,
+                                    int64_t& head_size, Value*& proj_out,
+                                    const std::vector<int64_t>& want_perm,
+                                    std::vector<Node*>& chain) {
+  if (!CheckKind(transposed, kTranspose) || transposed->uses().size() != 1) {
+    return false;
+  }
+  Node* tr = transposed->node();
+  std::vector<int64_t> perm;
+  if (!GetValueFromAttr(tr, kperm, perm) || perm != want_perm) {
+    return false;
+  }
+  Value* reshaped = tr->input(0);
+  if (!CheckKind(reshaped, kReshape) || reshaped->uses().size() != 1) {
+    return false;
+  }
+  Node* rs = reshaped->node();
+  if (rs->inputs().size() != 2) {
+    return false;
+  }
+  std::vector<int64_t> shape;
+  if (!GetValueFromInput(rs->input(1), shape) || shape.size() != 4) {
+    return false;
+  }
+  num_heads = shape[2];
+  head_size = shape[3];
+  if (num_heads <= 0 || head_size <= 0) {
+    return false;
+  }
+  proj_out = rs->input(0);
+  chain.push_back(tr);
+  chain.push_back(rs);
+  return true;
+}
+
+struct AttentionMatch {
+  AttentionProjectionInfo q, k, v;
+  int64_t num_heads = 0;
+  double scale = 0.0;
+  // Every node strictly upstream of `n` (the ctx-producing Reshape the pass
+  // anchors on) down to, but not including, the QKV inputs/weights,
+  // ordered innermost (closest to `n`) first, so destroying them in this
+  // order always has a zero-use output to destroy. Does not include `n`
+  // itself -- `n` is fully replaced by the fused Attention node's output
+  // and destroyed by the pass driver instead (see FuseAttention::
+  // runTransform), the same idiom fuse_rms_norm.h uses for its own anchor.
+  std::vector<Node*> dead_chain;
+};
+
+// Anchors on `n` = the Reshape that produces `ctx` (the attention context,
+// [B,S,H*D]) -- i.e. Reshape(Transpose(V_mm_out, [0,2,1,3]), [B,S,H*D]) --
+// rather than on the (untouched, never matched or torn down) output
+// projection that consumes `ctx`. This keeps the output projection, whatever
+// shape it takes, entirely out of scope: only `n`'s own two inputs and
+// everything transitively upstream of the Transpose are examined.
+inline bool MatchAttention(Node* n, AttentionMatch& m) {
+  if (!CheckKind(n, kReshape) || n->inputs().size() != 2 ||
+      n->outputs().size() != 1) {
+    return false;
+  }
+  Value* transposed_back = n->input(0);
+  if (!CheckKind(transposed_back, kTranspose) ||
+      transposed_back->uses().size() != 1) {
+    return false;
+  }
+  Node* tr_back = transposed_back->node();
+  std::vector<int64_t> perm_back;
+  if (!GetValueFromAttr(tr_back, kperm, perm_back) ||
+      perm_back != std::vector<int64_t>{0, 2, 1, 3}) {
+    return false;
+  }
+  Value* v_matmul_out = tr_back->input(0);
+  if (!CheckKind(v_matmul_out, kMatMul) || v_matmul_out->uses().size() != 1) {
+    return false;
+  }
+  Node* v_mm = v_matmul_out->node();
+  if (v_mm->inputs().size() != 2) {
+    return false;
+  }
+  Value* softmax_out = nullptr;
+  Value* v_t = nullptr;
+  for (int i = 0; i < 2; ++i) {
+    if (CheckKind(v_mm->input(i), kSoftmax)) {
+      softmax_out = v_mm->input(i);
+      v_t = v_mm->input(1 - i);
+    }
+  }
+  if (softmax_out == nullptr || softmax_out->uses().size() != 1) {
+    return false;
+  }
+  Node* softmax = softmax_out->node();
+  if (softmax->inputs().size() != 1) {
+    return false;
+  }
+  const int64_t sm_axis =
+      GetValueFromAttrWithDefault(softmax, kaxis, int64_t(-1));
+  if (sm_axis != -1 && sm_axis != 3) {
+    return false;  // Must reduce the last of the 4 (B,H,S,S) axes.
+  }
+  Value* scores = softmax->input(0);
+  if (scores->uses().size() != 1) {
+    return false;
+  }
+
+  std::vector<Node*> v_head_chain;
+  Value* v_proj_out = nullptr;
+  int64_t v_heads = 0, v_head_size = 0;
+  if (!MatchAttentionHeadSplit(v_t, v_heads, v_head_size, v_proj_out,
+                               {0, 2, 1, 3}, v_head_chain) ||
+      !MatchAttentionProjection(v_proj_out, m.v)) {
+    return false;
+  }
+
+  Node* scores_node = scores->node();
+  Value* qk = nullptr;
+  if (CheckKind(scores_node, kDiv) && scores_node->inputs().size() == 2) {
+    double divisor = 0.0;
+    if (!FetchScalarAsDouble(scores_node->input(1), divisor) ||
+        divisor == 0.0) {
+      return false;
+    }
+    qk = scores_node->input(0);
+    m.scale = 1.0 / divisor;
+  } else if (CheckKind(scores_node, kMul) &&
+             scores_node->inputs().size() == 2) {
+    for (int i = 0; i < 2; ++i) {
+      double mult = 0.0;
+      if (FetchScalarAsDouble(scores_node->input(1 - i), mult)) {
+        qk = scores_node->input(i);
+        m.scale = mult;
+        break;
+      }
+    }
+    if (qk == nullptr) {
+      return false;
+    }
+  } else {
+    return false;
+  }
+  if (qk->uses().size() != 1 || !CheckKind(qk, kMatMul)) {
+    return false;
+  }
+  Node* qk_mm = qk->node();
+  if (qk_mm->inputs().size() != 2) {
+    return false;
+  }
+
+  std::vector<Node*> q_head_chain;
+  Value* q_proj_out = nullptr;
+  int64_t q_heads = 0, q_head_size = 0;
+  if (!MatchAttentionHeadSplit(qk_mm->input(0), q_heads, q_head_size,
+                               q_proj_out, {0, 2, 1, 3}, q_head_chain) ||
+      !MatchAttentionProjection(q_proj_out, m.q)) {
+    return false;
+  }
+
+  std::vector<Node*> k_head_chain;
+  Value* k_proj_out = nullptr;
+  int64_t k_heads = 0, k_head_size = 0;
+  if (!MatchAttentionHeadSplit(qk_mm->input(1), k_heads, k_head_size,
+                               k_proj_out, {0, 2, 3, 1}, k_head_chain) ||
+      !MatchAttentionProjection(k_proj_out, m.k)) {
+    return false;
+  }
+
+  if (q_heads != k_heads || q_heads != v_heads || q_head_size != k_head_size) {
+    return false;
+  }
+  m.num_heads = q_heads;
+
+  if (m.q.input != m.k.input || m.q.input != m.v.input) {
+    return false;  // Self-attention only: Q/K/V share the same source.
+  }
+
+  const bool any_bias =
+      m.q.bias != nullptr || m.k.bias != nullptr || m.v.bias != nullptr;
+  const bool all_bias =
+      m.q.bias != nullptr && m.k.bias != nullptr && m.v.bias != nullptr;
+  if (any_bias && !all_bias) {
+    return false;  // Attention has one merged bias input -- all or none.
+  }
+
+  m.dead_chain.push_back(tr_back);
+  m.dead_chain.push_back(v_mm);
+  m.dead_chain.push_back(softmax);
+  for (Node* nd : v_head_chain) m.dead_chain.push_back(nd);
+  for (Node* nd : m.v.chain) m.dead_chain.push_back(nd);
+  m.dead_chain.push_back(scores_node);
+  m.dead_chain.push_back(qk_mm);
+  for (Node* nd : q_head_chain) m.dead_chain.push_back(nd);
+  for (Node* nd : m.q.chain) m.dead_chain.push_back(nd);
+  for (Node* nd : k_head_chain) m.dead_chain.push_back(nd);
+  for (Node* nd : m.k.chain) m.dead_chain.push_back(nd);
+  return true;
+}
+
+// Reads `w_t` (a constant 2-D float32 tensor, [N, K] when `transposed` else
+// [K, N]) into a flat, row-major [K, N] host-byte-order buffer regardless of
+// storage layout -- `Attention`'s merged weight has no transpose attribute
+// of its own, so a Gemm(transB=1)-sourced weight must be physically
+// transposed here, unlike quantize_matmul_common.h's
+// QuantizeWeightPerChannelInPlace (which deliberately keeps the source
+// layout for a different rewrite).
+inline std::vector<float> ReadAttentionWeightAsKN(const Tensor& w_t,
+                                                  bool transposed, int64_t& K,
+                                                  int64_t& N) {
+  const auto& sizes = w_t.sizes();
+  const int64_t dim0 = sizes[0];
+  const int64_t dim1 = sizes[1];
+  K = transposed ? dim1 : dim0;
+  N = transposed ? dim0 : dim1;
+  const std::vector<float> data = ReadFloatMatrix(w_t);
+  std::vector<float> out(static_cast<size_t>(K * N));
+  for (int64_t k = 0; k < K; ++k) {
+    for (int64_t n = 0; n < N; ++n) {
+      out[static_cast<size_t>(k * N + n)] =
+          transposed ? data[static_cast<size_t>(n * K + k)]
+                     : data[static_cast<size_t>(k * N + n)];
+    }
+  }
+  return out;
+}
+
+// Reads a constant 1-D float32 tensor into a flat host-byte-order buffer.
+inline std::vector<float> ReadAttentionBiasVector(const Tensor& t) {
+  const int64_t numel = t.sizes()[0];
+  if (t.is_raw_data()) {
+    return ReadRawDataHostOrder<float>(t.data<float>(), numel);
+  }
+  return t.floats();
+}
+
+struct FuseAttention final : public PredicateBasedPass {
+  explicit FuseAttention()
+      : PredicateBasedPass(PassType::Fuse, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+  std::string getPassName() const override { return "fuse_attention"; }
+
+  bool patternMatchPredicate(Node* n) override {
+    AttentionMatch m;
+    return MatchAttention(n, m);
+  }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+    AttentionMatch m;
+    if (!MatchAttention(n, m)) {
+      return false;
+    }
+    ONNX_ASSERT(!m.dead_chain.empty());
+
+    const Tensor* wq_t = FetchConstantTensor(m.q.weight);
+    const Tensor* wk_t = FetchConstantTensor(m.k.weight);
+    const Tensor* wv_t = FetchConstantTensor(m.v.weight);
+    int64_t kq = 0, nq = 0, kk = 0, nk = 0, kv = 0, nv = 0;
+    const std::vector<float> wq =
+        ReadAttentionWeightAsKN(*wq_t, m.q.weight_transposed, kq, nq);
+    const std::vector<float> wk =
+        ReadAttentionWeightAsKN(*wk_t, m.k.weight_transposed, kk, nk);
+    const std::vector<float> wv =
+        ReadAttentionWeightAsKN(*wv_t, m.v.weight_transposed, kv, nv);
+    if (kq != kk || kq != kv) {
+      return false;  // Q/K/V must all read the same input_hidden_size.
+    }
+
+    Tensor merged_w;
+    merged_w.elem_type() = TensorProto_DataType_FLOAT;
+    merged_w.sizes() = {kq, nq + nk + nv};
+    merged_w.floats().resize(static_cast<size_t>(kq * (nq + nk + nv)));
+    for (int64_t k = 0; k < kq; ++k) {
+      float* row = merged_w.floats().data() + k * (nq + nk + nv);
+      std::copy(wq.begin() + k * nq, wq.begin() + (k + 1) * nq, row);
+      std::copy(wk.begin() + k * nk, wk.begin() + (k + 1) * nk, row + nq);
+      std::copy(wv.begin() + k * nv, wv.begin() + (k + 1) * nv, row + nq + nk);
+    }
+    Value* weights_v = graph.addInitializerAndCreateValue(merged_w);
+
+    // Always synthesize Attention's (schema-optional) bias input, even when
+    // Q/K/V have none, rather than omitting it: at least one real ONNX
+    // Runtime CPU build (1.29.0, verified directly against a minimal
+    // hand-built model, independent of this pass) segfaults executing its
+    // own `Attention` kernel with only 2 inputs -- a zero-filled bias is a
+    // no-op numerically and sidesteps that kernel path entirely.
+    Tensor merged_b;
+    merged_b.elem_type() = TensorProto_DataType_FLOAT;
+    merged_b.sizes() = {nq + nk + nv};
+    merged_b.floats().assign(static_cast<size_t>(nq + nk + nv), 0.0f);
+    if (m.q.bias != nullptr) {
+      const Tensor* bq_t = FetchConstantTensor(m.q.bias);
+      const Tensor* bk_t = FetchConstantTensor(m.k.bias);
+      const Tensor* bv_t = FetchConstantTensor(m.v.bias);
+      const std::vector<float> bq = ReadAttentionBiasVector(*bq_t);
+      const std::vector<float> bk = ReadAttentionBiasVector(*bk_t);
+      const std::vector<float> bv = ReadAttentionBiasVector(*bv_t);
+      if (static_cast<int64_t>(bq.size()) != nq ||
+          static_cast<int64_t>(bk.size()) != nk ||
+          static_cast<int64_t>(bv.size()) != nv) {
+        return false;
+      }
+      std::copy(bq.begin(), bq.end(), merged_b.floats().begin());
+      std::copy(bk.begin(), bk.end(), merged_b.floats().begin() + nq);
+      std::copy(bv.begin(), bv.end(), merged_b.floats().begin() + nq + nk);
+    }
+    Value* bias_v = graph.addInitializerAndCreateValue(merged_b);
+
+    Node* attn = graph.create(Symbol("Attention"), 1);
+    attn->addInput(m.q.input);
+    attn->addInput(weights_v);
+    attn->addInput(bias_v);
+    attn->i_(Symbol("num_heads"), m.num_heads);
+    attn->f_(Symbol("scale"), static_cast<float>(m.scale));
+    attn->is_(Symbol("qkv_hidden_sizes"), std::vector<int64_t>{nq, nk, nv});
+    attn->setDomain("com.microsoft");
+    attn->insertBefore(n);
+    attn->output()->copyMetadata(n->output());
+
+    bool has_ms_domain = false;
+    for (const OpSetID& opset : graph.opset_versions_mutable()) {
+      if (opset.domain() == "com.microsoft") {
+        has_ms_domain = true;
+        break;
+      }
+    }
+    if (!has_ms_domain) {
+      graph.opset_versions_mutable().emplace_back("com.microsoft", 1);
+    }
+
+    // `n` (the ctx-producing Reshape) is fully replaced by `attn`'s output
+    // -- whatever consumed `ctx` (the untouched output projection) now
+    // reads straight from `attn` -- and destroyed by the pass driver below
+    // (destroy_current = DestroyOne), the same idiom fuse_rms_norm.h and
+    // fuse_add_bias_into_conv.h use for their own anchors.
+    if (!tryReplacingAllUsesWith(n, attn)) {
+      return false;
+    }
+
+    // `n` still holds its own edge into the dead chain (its input(0), the
+    // Transpose's output) until we detach it here; only then does the dead
+    // chain's own destroy loop below see every node's output at zero uses
+    // exactly when it is destroyed, innermost (closest to `n`) first.
+    n->removeInput(0);
+    for (Node* dead : m.dead_chain) {
+      dead->destroy();
+    }
+
+    destroy_current = NodeDestroyType::DestroyOne;
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/fuse_qkv.h
+++ b/onnxsim/passes/fuse_qkv.h
@@ -1,0 +1,132 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+#pragma once
+
+// onnxsim's fixed version of onnx-optimizer's own `fuse_qkv` (see
+// third_party/onnx-optimizer/onnxoptimizer/passes/fuse_qkv.h): identical
+// except for one added guard (see `PrevNode(n, 0)` below). Overridden here
+// via RegisterOrReplace, the same "onnxsim's patched versions of built-in
+// onnxoptimizer passes" convention custom_optimizer_passes.cpp already uses
+// for fuse_add_bias_into_conv/fuse_bn_into_conv/etc.
+//
+// Bug: the original unconditionally does
+// `cat->insertAfter(PrevNode(n, 0))`, i.e. `n->input(0)->node()`, to anchor
+// the new Concat node right after whatever produces the shared Q/K/V input.
+// When that shared input is the *graph's own input* (the common case for
+// self-attention, where a Reshape-free `MatMul(X, Wq)` etc. all read the
+// graph input `X` directly -- exactly the pattern fuse_attention.h's own
+// research target produces, see fuse_attention.h) rather than a computed
+// value, `n->input(0)->node()` is the graph's `kParam` placeholder node,
+// which is never part of the node list `insertAfter` requires
+// (`Node::inGraphList()`) -- tripping its `ONNX_ASSERT(...n->inGraphList())`
+// and aborting the *entire* onnxsim pipeline outright (this is a
+// PredicateBasedPass whose failed runTransform is otherwise expected to
+// gracefully `return false`, not throw). Declining the match here instead
+// -- the same "graph input has no real anchor node" case
+// `fuse_add_bias_into_conv.h`'s `moveBefore` calls already special-case via
+// `orig_bias->node()->kind() != kParam` -- fixes it without changing any
+// other behavior.
+
+#include <numeric>
+
+#include "onnx/defs/tensor_util.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+// onnxsim's own passes live in this nested namespace so their class
+// names never collide (ODR) with the same-named passes compiled into
+// onnxoptimizer; RegisterOrReplace still keys them by getPassName().
+namespace onnxsim_passes {
+
+struct FuseQKV final : public PredicateBasedPass {
+  explicit FuseQKV()
+      : PredicateBasedPass(PassType::Fuse, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+  std::string getPassName() const override { return "fuse_qkv"; }
+
+  bool patternMatchPredicate(Node* node) override {
+    return CheckKind(node, kMatMul) && node->input(0)->uses().size() == 3;
+  }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+    // The shared Q/K/V input has no real producer node to anchor the fused
+    // Concat after when it is the graph's own input -- see the file
+    // comment above.
+    if (n->input(0)->node()->kind() == kParam) {
+      return false;
+    }
+    const auto uses = n->input(0)->uses();
+    for (const auto& use : uses) {
+      if (use.offset != 0 || !CheckKind(use.user, kMatMul) ||
+          use.user->output()->uses().size() != 1 ||
+          !IsConstantTensor(use.user, 1)) {
+        return false;
+      }
+    }
+    /// q k v not a one-to-one correspondence actually
+    Node* q = uses[0].user;
+    Node* k = uses[1].user;
+    Node* v = uses[2].user;
+
+    const Tensor* q_t = FetchConstantTensor(q->input(1));
+    const Tensor* k_t = FetchConstantTensor(k->input(1));
+    const Tensor* v_t = FetchConstantTensor(v->input(1));
+    if (q_t->sizes() != k_t->sizes() || q_t->sizes() != v_t->sizes()) {
+      return false;
+    }
+    Node* prev = PrevNode(n, 0);
+    Node* cat = graph.create(kConcat, 1);
+    cat->insertAfter(prev);
+    cat->addInput(q->input(1));
+    cat->addInput(k->input(1));
+    cat->addInput(v->input(1));
+    cat->i_(kaxis, q_t->sizes().size() - 1);
+    Node* matmul = graph.create(kMatMul, 1);
+    matmul->insertAfter(cat);
+    matmul->addInput(q->input(0));
+    matmul->addInput(cat->output());
+
+    Node* split = graph.create("Split"_sym, 3);
+    split->i_(kaxis, -1);
+    split->insertAfter(matmul);
+    split->addInput(matmul->output());
+    const auto opset_version = getOpsetVersion(graph);
+    if (opset_version >= 13) {
+      Tensor split_t;
+      split_t.sizes().push_back(3);
+      split_t.elem_type() = ONNX_NAMESPACE::TensorProto_DataType_INT64;
+      split_t.int64s().push_back(q_t->sizes().back());
+      split_t.int64s().push_back(k_t->sizes().back());
+      split_t.int64s().push_back(v_t->sizes().back());
+      split->addInput(graph.addInitializerAndCreateValue(split_t));
+    } else {
+      split->is_(ksplit,
+                 std::vector<int64_t>{q_t->sizes().back(), k_t->sizes().back(),
+                                      v_t->sizes().back()});
+    }
+    if (!tryReplacingAllUsesWith(q->output(), split->outputs()[0])) {
+      return false;
+    }
+    if (!tryReplacingAllUsesWith(k->output(), split->outputs()[1])) {
+      return false;
+    }
+    if (!tryReplacingAllUsesWith(v->output(), split->outputs()[2])) {
+      return false;
+    }
+    destroy_current = NodeDestroyType::DestroyOne;
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/tests/test_fuse_attention.py
+++ b/tests/test_fuse_attention.py
@@ -17,6 +17,7 @@ shape this targets, which was derived by tracing real PyTorch exports.
 """
 
 import collections
+import math
 
 import numpy as np
 import onnx
@@ -256,3 +257,237 @@ def test_fuse_attention_declines_cross_attention():
     _assert_close(
         _run(model, {"x": x, "mem": mem}), _run(simplified, {"x": x, "mem": mem})
     )
+
+
+# --------------------------------------------------------------------------- #
+# scaled_dot_product_attention's own decomposition -- MatchScaledQKMatMul's
+# "pre-scaled" shape: `scores = MatMul(Mul(Q_t, c), Mul(K_t, c))`, i.e. the
+# combined scale split as sqrt(scale) onto each operand *before* the dot
+# product, rather than applied to its result once. This is what
+# `torch.nn.functional.scaled_dot_product_attention`'s ONNX export
+# decomposes into (both PyTorch's legacy TorchScript and dynamo exporters),
+# once its own dynamic Shape/Slice/Cast/Sqrt/... scale computation is
+# constant-folded -- verified directly against real torch.onnx.export output
+# during development; these tests reproduce the resulting shape directly via
+# onnx.helper so they need no torch dependency.
+# --------------------------------------------------------------------------- #
+def _sdpa_prescaled_model(
+    B=2, S=5, H=32, NH=4, scale=None, k_scale=None, ctx_rank3=True, seed=10
+):
+    # Builds Y = Linear(ctx) where ctx is a self-attention context computed
+    # via the pre-scaled-QK shape above, optionally with an asymmetric
+    # (different) scale on the K side (`k_scale`) to exercise the decline
+    # path, and optionally with `ctx_rank3=False` to reproduce the *other*
+    # real-export wrinkle this pass handles: the context reshape collapsed
+    # directly to a 2-D [B*S, H] target (merged with the output projection's
+    # own Gemm-input flatten by an earlier fixed-point iteration) instead of
+    # the "natural" 3-D [B,S,H] one.
+    Dh = H // NH
+    scale = (Dh**-0.5) if scale is None else scale
+    c = math.sqrt(scale)
+    k_c = c if k_scale is None else math.sqrt(k_scale)
+    rng = np.random.default_rng(seed)
+    inits = []
+    nodes = []
+
+    shape_qkv = _i64([B, S, NH, Dh], "shape_qkv")
+    inits.append(shape_qkv)
+
+    q_nodes, q_inits, q_out = _linear_nodes(rng, "x", H, H, "q", True)
+    k_nodes, k_inits, k_out = _linear_nodes(rng, "x", H, H, "k", True)
+    v_nodes, v_inits, v_out = _linear_nodes(rng, "x", H, H, "v", True)
+    nodes += q_nodes + k_nodes + v_nodes
+    inits += q_inits + k_inits + v_inits
+
+    qh_nodes, q_t = _head_split_nodes(q_out, "shape_qkv", [0, 2, 1, 3], "q")
+    kh_nodes, k_t = _head_split_nodes(k_out, "shape_qkv", [0, 2, 3, 1], "k")
+    vh_nodes, v_t = _head_split_nodes(v_out, "shape_qkv", [0, 2, 1, 3], "v")
+    nodes += qh_nodes + kh_nodes + vh_nodes
+
+    c_init = _f32(np.array(c), "q_scale_c")
+    k_c_init = _f32(np.array(k_c), "k_scale_c")
+    inits += [c_init, k_c_init]
+    nodes.append(onnx.helper.make_node("Mul", [q_t, c_init.name], ["q_scaled"]))
+    nodes.append(onnx.helper.make_node("Mul", [k_t, k_c_init.name], ["k_scaled"]))
+    nodes.append(onnx.helper.make_node("MatMul", ["q_scaled", "k_scaled"], ["scores"]))
+    nodes.append(onnx.helper.make_node("Softmax", ["scores"], ["attn"], axis=-1))
+    nodes.append(onnx.helper.make_node("MatMul", ["attn", v_t], ["ctx0"]))
+    nodes.append(
+        onnx.helper.make_node("Transpose", ["ctx0"], ["ctx1"], perm=[0, 2, 1, 3])
+    )
+    ctx_shape = [B, S, H] if ctx_rank3 else [B * S, H]
+    shape_ctx = _i64(ctx_shape, "shape_ctx")
+    inits.append(shape_ctx)
+    nodes.append(onnx.helper.make_node("Reshape", ["ctx1", "shape_ctx"], ["ctx2"]))
+
+    if ctx_rank3:
+        out_nodes, out_inits, out_name = _linear_nodes(rng, "ctx2", H, H, "out", True)
+        nodes += out_nodes
+        inits += out_inits
+    else:
+        # Mirrors the real SDPA-export trace exactly: ctx2 is already 2-D, so
+        # the output projection is a plain Gemm reading it directly (no
+        # separate flattening Reshape -- ctx2's own target already merged
+        # that step in).
+        w = _f32(rng.standard_normal((H, H)) * 0.3, "out_w")
+        b = _f32(rng.standard_normal(H) * 0.1, "out_b")
+        inits += [w, b]
+        nodes.append(
+            onnx.helper.make_node("Gemm", ["ctx2", w.name, b.name], ["out_out"])
+        )
+        out_name = "out_out"
+    out_shape = [B, S, H] if ctx_rank3 else [B * S, H]
+    nodes.append(onnx.helper.make_node("Identity", [out_name], ["y"]))
+
+    graph = onnx.helper.make_graph(
+        nodes, "g", [_vi("x", [B, S, H])], [_vi("y", out_shape)], inits
+    )
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 17)], ir_version=10
+    )
+
+
+def test_fuse_attention_sdpa_prescaled_pattern():
+    B, S, H, NH = 2, 5, 32, 4
+    Dh = H // NH
+    scale = Dh**-0.5
+    model = _sdpa_prescaled_model(B=B, S=S, H=H, NH=NH, scale=scale)
+    simplified, ok = onnxsim.simplify(model)
+    assert ok
+    ops = _op_counts(simplified)
+    assert ops["Attention"] == 1
+    assert ops["Softmax"] == 0
+    attn = next(n for n in simplified.graph.node if n.op_type == "Attention")
+    got_scale = next(a for a in attn.attribute if a.name == "scale").f
+    assert math.isclose(got_scale, scale, rel_tol=1e-5)
+    onnx.checker.check_model(simplified)
+
+    rng = np.random.default_rng(42)
+    x = rng.standard_normal((B, S, H)).astype(np.float32)
+    _assert_close(_run(model, {"x": x}), _run(simplified, {"x": x}))
+
+
+def test_fuse_attention_declines_asymmetric_prescale():
+    # Q and K scaled by *different* constants before the dot product: not
+    # the sqrt(scale)-on-each-side decomposition MatchScaledQKMatMul expects,
+    # so this must decline (stay numerically correct, just unfused) rather
+    # than fusing with a wrong (e.g. geometric-mean-only-by-accident) scale.
+    B, S, H, NH = 2, 5, 32, 4
+    Dh = H // NH
+    scale = Dh**-0.5
+    model = _sdpa_prescaled_model(
+        B=B, S=S, H=H, NH=NH, scale=scale, k_scale=scale * 4.0
+    )
+    simplified, ok = onnxsim.simplify(model)
+    assert ok
+    assert _op_counts(simplified)["Attention"] == 0
+
+    rng = np.random.default_rng(43)
+    x = rng.standard_normal((B, S, H)).astype(np.float32)
+    _assert_close(_run(model, {"x": x}), _run(simplified, {"x": x}))
+
+
+def test_fuse_attention_handles_context_reshape_collapsed_to_2d():
+    # The context reshape's own target is already the *final* 2-D
+    # [B*S, H] shape (an earlier fixed-point iteration merged "reshape ctx
+    # to 3-D" with "flatten for the output projection's Gemm" into one
+    # Reshape) rather than the "natural" 3-D [B,S,H] one -- exactly what a
+    # real scaled_dot_product_attention export's own Gemm-conversion
+    # produces. Fusing must still succeed and reuse that 2-D target for
+    # Attention's own (always rank-3) output, rather than assuming it is
+    # always 3-D and mismatching the output projection's Gemm.
+    B, S, H, NH = 2, 5, 32, 4
+    Dh = H // NH
+    scale = Dh**-0.5
+    model = _sdpa_prescaled_model(B=B, S=S, H=H, NH=NH, scale=scale, ctx_rank3=False)
+    simplified, ok = onnxsim.simplify(model)
+    assert ok
+    ops = _op_counts(simplified)
+    assert ops["Attention"] == 1
+    # A Reshape must sit between Attention's rank-3 output and the (rank-2
+    # input) output-projection Gemm.
+    assert ops["Reshape"] >= 1
+    onnx.checker.check_model(simplified)
+
+    rng = np.random.default_rng(44)
+    x = rng.standard_normal((B, S, H)).astype(np.float32)
+    _assert_close(_run(model, {"x": x}), _run(simplified, {"x": x}))
+
+
+def test_fuse_attention_recovers_input_flattened_by_gemm_conversion():
+    # Simulates the state a real scaled_dot_product_attention export ends up
+    # in after onnx-optimizer's own fuse_matmul_add_into_gemm has already
+    # flattened Q/K/V's shared 3-D input to 2-D (Gemm requires 2-D operands)
+    # in an earlier fixed-point iteration -- see
+    # RecoverRank3AttentionInput's own doc comment in fuse_attention.h for
+    # why this reliably happens for a real SDPA export (its own scale
+    # computation needs constant folding to resolve first, so
+    # Gemm-conversion -- which has no such prerequisite -- reliably wins
+    # that race). Fusing must still succeed, using the recovered original
+    # rank-3 `x` as Attention's own X input rather than the rank-2 flattened
+    # value, or declining outright rather than emitting a shape-invalid
+    # Attention node.
+    B, S, H, NH = 2, 5, 32, 4
+    Dh = H // NH
+    rng = np.random.default_rng(20)
+    inits = []
+    nodes = []
+
+    shape_flat = _i64([B * S, H], "shape_flat")
+    inits.append(shape_flat)
+    nodes.append(onnx.helper.make_node("Reshape", ["x", "shape_flat"], ["x_flat"]))
+
+    def gemm_linear(prefix, in_name, in_dim, out_dim):
+        w = _f32(rng.standard_normal((in_dim, out_dim)) * 0.3, f"{prefix}_w")
+        b = _f32(rng.standard_normal(out_dim) * 0.1, f"{prefix}_b")
+        nodes.append(
+            onnx.helper.make_node("Gemm", [in_name, w.name, b.name], [f"{prefix}_out"])
+        )
+        inits.extend([w, b])
+        return f"{prefix}_out"
+
+    q_out = gemm_linear("q", "x_flat", H, H)
+    k_out = gemm_linear("k", "x_flat", H, H)
+    v_out = gemm_linear("v", "x_flat", H, H)
+
+    shape_qkv = _i64([B, S, NH, Dh], "shape_qkv")
+    inits.append(shape_qkv)
+    qh_nodes, q_t = _head_split_nodes(q_out, "shape_qkv", [0, 2, 1, 3], "q")
+    kh_nodes, k_t = _head_split_nodes(k_out, "shape_qkv", [0, 2, 3, 1], "k")
+    vh_nodes, v_t = _head_split_nodes(v_out, "shape_qkv", [0, 2, 1, 3], "v")
+    nodes += qh_nodes + kh_nodes + vh_nodes
+
+    divisor = _f32(np.array(float(Dh) ** 0.5), "divisor")
+    inits.append(divisor)
+    nodes.append(onnx.helper.make_node("MatMul", [q_t, k_t], ["qk"]))
+    nodes.append(onnx.helper.make_node("Div", ["qk", divisor.name], ["scores"]))
+    nodes.append(onnx.helper.make_node("Softmax", ["scores"], ["attn"], axis=-1))
+    nodes.append(onnx.helper.make_node("MatMul", ["attn", v_t], ["ctx0"]))
+    nodes.append(
+        onnx.helper.make_node("Transpose", ["ctx0"], ["ctx1"], perm=[0, 2, 1, 3])
+    )
+    shape_ctx = _i64([B, S, H], "shape_ctx")
+    inits.append(shape_ctx)
+    nodes.append(onnx.helper.make_node("Reshape", ["ctx1", "shape_ctx"], ["ctx2"]))
+    nodes.append(onnx.helper.make_node("Identity", ["ctx2"], ["y"]))
+
+    graph = onnx.helper.make_graph(
+        nodes, "g", [_vi("x", [B, S, H])], [_vi("y", [B, S, H])], inits
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 17)], ir_version=10
+    )
+
+    simplified, ok = onnxsim.simplify(model)
+    assert ok
+    ops = _op_counts(simplified)
+    assert ops["Attention"] == 1
+    attn = next(n for n in simplified.graph.node if n.op_type == "Attention")
+    # Attention's own X input must be the recovered rank-3 `x`, not the
+    # rank-2 flattened value Q/K/V's Gemms needed.
+    assert attn.input[0] == "x"
+    onnx.checker.check_model(simplified)
+
+    rng2 = np.random.default_rng(21)
+    x = rng2.standard_normal((B, S, H)).astype(np.float32)
+    _assert_close(_run(model, {"x": x}), _run(simplified, {"x": x}))

--- a/tests/test_fuse_attention.py
+++ b/tests/test_fuse_attention.py
@@ -1,0 +1,258 @@
+"""Tests for the ``fuse_attention`` C++ pass
+(``onnxsim/passes/fuse_attention.h``) -- pattern-matches a "hand-written"
+multi-head self-attention subgraph (separate Q/K/V ``nn.Linear``-style
+projections + reshape/transpose to heads + scaled dot-product + softmax +
+weighted sum) into a single ONNX Runtime "com.microsoft" contrib op,
+``Attention``. Unlike the ``quantize_*`` passes elsewhere in this test suite,
+this is a default-on graph-shape fusion (registered the same way
+``fuse_rms_norm``/``fuse_gelu``/``fuse_layer_norm`` are, see
+``custom_optimizer_passes.cpp``) -- it always runs as part of plain
+``onnxsim.simplify()``, with no separate Python entry point or CLI flag.
+
+Every model here is built directly with ``onnx.helper`` (no torch dependency)
+to mirror exactly what a real PyTorch export of a hand-rolled (eager, not
+``nn.MultiheadAttention``) attention module produces -- see
+``onnxsim/passes/fuse_attention.h``'s own file comment for the node-by-node
+shape this targets, which was derived by tracing real PyTorch exports.
+"""
+
+import collections
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+
+import onnxsim
+
+# A bare ``import onnxruntime`` would fail collection (not skip the test) on
+# platforms onnxruntime doesn't ship wheels for (e.g. s390x); the fused
+# output is a "com.microsoft" contrib op that only onnxruntime can execute.
+ort = pytest.importorskip("onnxruntime")
+
+
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _i64(array, name):
+    return onnx.numpy_helper.from_array(np.asarray(array, dtype=np.int64), name)
+
+
+def _linear_nodes(rng, x_name, in_dim, out_dim, prefix, bias):
+    # MatMul(x, W)[+ Add(., B)] -- the shape a plain ``nn.Linear`` exported via
+    # ``MatMul`` (not ``Gemm``) produces; matches fuse_attention.h's
+    # MatchAttentionProjection Add-branch.
+    w = _f32(rng.standard_normal((in_dim, out_dim)) * 0.3, f"{prefix}_w")
+    nodes = [onnx.helper.make_node("MatMul", [x_name, w.name], [f"{prefix}_mm"])]
+    inits = [w]
+    out_name = f"{prefix}_mm"
+    if bias:
+        b = _f32(rng.standard_normal(out_dim) * 0.1, f"{prefix}_b")
+        nodes.append(
+            onnx.helper.make_node("Add", [b.name, out_name], [f"{prefix}_out"])
+        )
+        inits.append(b)
+        out_name = f"{prefix}_out"
+    return nodes, inits, out_name
+
+
+def _head_split_nodes(x_name, shape_name, perm, prefix):
+    reshape_out = f"{prefix}_reshape"
+    transpose_out = f"{prefix}_transpose"
+    nodes = [
+        onnx.helper.make_node("Reshape", [x_name, shape_name], [reshape_out]),
+        onnx.helper.make_node("Transpose", [reshape_out], [transpose_out], perm=perm),
+    ]
+    return nodes, transpose_out
+
+
+def _attention_model(
+    B=2,
+    S=5,
+    H=32,
+    NH=4,
+    VH=None,
+    bias=True,
+    scale_op="Div",
+    kv_source="x",
+    seed=0,
+    opset=17,
+):
+    # Builds: Y = Linear(ctx, Wout[, Bout]) where ctx is the fused-away
+    # self-attention context -- see fuse_attention.h's own top-of-file
+    # comment for the exact node shape this mirrors.
+    rng = np.random.default_rng(seed)
+    VH = VH or H
+    Dh, Dv = H // NH, VH // NH
+    inits = []
+    nodes = []
+
+    shape_qk = _i64([B, S, NH, Dh], "shape_qk")
+    shape_v = _i64([B, S, NH, Dv], "shape_v")
+    inits += [shape_qk, shape_v]
+
+    q_nodes, q_inits, q_out = _linear_nodes(rng, "x", H, H, "q", bias)
+    k_nodes, k_inits, k_out = _linear_nodes(rng, kv_source, H, H, "k", bias)
+    v_nodes, v_inits, v_out = _linear_nodes(rng, kv_source, H, VH, "v", bias)
+    nodes += q_nodes + k_nodes + v_nodes
+    inits += q_inits + k_inits + v_inits
+
+    qh_nodes, q_t = _head_split_nodes(q_out, "shape_qk", [0, 2, 1, 3], "q")
+    kh_nodes, k_t = _head_split_nodes(k_out, "shape_qk", [0, 2, 3, 1], "k")
+    vh_nodes, v_t = _head_split_nodes(v_out, "shape_v", [0, 2, 1, 3], "v")
+    nodes += qh_nodes + kh_nodes + vh_nodes
+
+    nodes.append(onnx.helper.make_node("MatMul", [q_t, k_t], ["qk"]))
+    if scale_op == "Div":
+        divisor = _f32(np.array(float(Dh) ** 0.5), "divisor")
+        inits.append(divisor)
+        nodes.append(onnx.helper.make_node("Div", ["qk", divisor.name], ["scores"]))
+    else:
+        mult = _f32(np.array(float(Dh) ** -0.5), "mult")
+        inits.append(mult)
+        nodes.append(onnx.helper.make_node("Mul", ["qk", mult.name], ["scores"]))
+    nodes.append(onnx.helper.make_node("Softmax", ["scores"], ["attn"], axis=-1))
+    nodes.append(onnx.helper.make_node("MatMul", ["attn", v_t], ["ctx0"]))
+    nodes.append(
+        onnx.helper.make_node("Transpose", ["ctx0"], ["ctx1"], perm=[0, 2, 1, 3])
+    )
+    shape_ctx = _i64([B, S, NH * Dv], "shape_ctx")
+    inits.append(shape_ctx)
+    nodes.append(onnx.helper.make_node("Reshape", ["ctx1", "shape_ctx"], ["ctx2"]))
+
+    out_nodes, out_inits, out_name = _linear_nodes(rng, "ctx2", VH, H, "out", bias)
+    nodes += out_nodes
+    inits += out_inits
+    nodes.append(onnx.helper.make_node("Identity", [out_name], ["y"]))
+
+    graph_inputs = [_vi("x", [B, S, H])]
+    if kv_source != "x":
+        graph_inputs.append(_vi(kv_source, [B, S, H]))
+    graph = onnx.helper.make_graph(
+        nodes, "g", graph_inputs, [_vi("y", [B, S, H])], inits
+    )
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+    )
+
+
+def _op_counts(model):
+    return collections.Counter(n.op_type for n in model.graph.node)
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _assert_close(float_outputs, fused_outputs):
+    for f, q in zip(float_outputs, fused_outputs):
+        f = np.asarray(f, dtype=np.float64).ravel()
+        q = np.asarray(q, dtype=np.float64).ravel()
+        assert np.all(np.isfinite(q))
+        rel_l2 = np.linalg.norm(f - q) / max(np.linalg.norm(f), 1e-6)
+        assert rel_l2 < 1e-4, f"relative L2 error too large: {rel_l2:.6f}"
+
+
+def test_fuse_attention_basic():
+    B, S, H = 2, 5, 32
+    model = _attention_model(B=B, S=S, H=H, bias=True, scale_op="Div")
+    simplified, ok = onnxsim.simplify(model)
+    assert ok
+    ops = _op_counts(simplified)
+    assert ops["Attention"] == 1
+    # The whole Q/K/V/softmax/context subgraph collapses into the one
+    # Attention node; only the (untouched) output projection survives from
+    # the original 6 MatMuls -- as either MatMul or Gemm, depending on
+    # whether fuse_matmul_add_bias_into_gemm_batched also fires on it.
+    assert ops["MatMul"] + ops["Gemm"] == 1
+    assert ops["Softmax"] == 0
+    assert ops["Transpose"] == 0
+    domains = {o.domain for o in simplified.opset_import}
+    assert "com.microsoft" in domains
+    onnx.checker.check_model(simplified)
+
+    rng = np.random.default_rng(42)
+    x = rng.standard_normal((B, S, H)).astype(np.float32)
+    _assert_close(_run(model, {"x": x}), _run(simplified, {"x": x}))
+
+
+def test_fuse_attention_no_bias_synthesizes_zero_bias():
+    # Q/K/V/out all bias-free: the fusion must still emit a (zero-filled)
+    # bias input rather than omitting it -- see fuse_attention.h's own
+    # comment on why (at least one real ONNX Runtime CPU build segfaults on
+    # an Attention node with only 2 inputs).
+    B, S, H = 2, 5, 24
+    model = _attention_model(B=B, S=S, H=H, NH=4, bias=False, scale_op="Div")
+    simplified, ok = onnxsim.simplify(model)
+    assert ok
+    ops = _op_counts(simplified)
+    assert ops["Attention"] == 1
+    attn = next(n for n in simplified.graph.node if n.op_type == "Attention")
+    assert len(attn.input) == 3
+    bias_init = next(t for t in simplified.graph.initializer if t.name == attn.input[2])
+    assert np.all(onnx.numpy_helper.to_array(bias_init) == 0.0)
+    onnx.checker.check_model(simplified)
+
+    rng = np.random.default_rng(1)
+    x = rng.standard_normal((B, S, H)).astype(np.float32)
+    _assert_close(_run(model, {"x": x}), _run(simplified, {"x": x}))
+
+
+def test_fuse_attention_mul_scale():
+    # `scores * (1/sqrt(head_size))` instead of `scores / sqrt(head_size)`.
+    B, S, H = 2, 4, 16
+    model = _attention_model(B=B, S=S, H=H, NH=2, bias=True, scale_op="Mul")
+    simplified, ok = onnxsim.simplify(model)
+    assert ok
+    assert _op_counts(simplified)["Attention"] == 1
+    onnx.checker.check_model(simplified)
+
+    rng = np.random.default_rng(2)
+    x = rng.standard_normal((B, S, H)).astype(np.float32)
+    _assert_close(_run(model, {"x": x}), _run(simplified, {"x": x}))
+
+
+def test_fuse_attention_different_v_hidden_size():
+    # V's projection hidden size may differ from Q/K's, per Attention's own
+    # documented qkv_hidden_sizes semantics.
+    B, S, H, VH = 2, 5, 32, 16
+    model = _attention_model(B=B, S=S, H=H, NH=4, VH=VH, bias=True)
+    simplified, ok = onnxsim.simplify(model)
+    assert ok
+    ops = _op_counts(simplified)
+    assert ops["Attention"] == 1
+    attn = next(n for n in simplified.graph.node if n.op_type == "Attention")
+    qkv_sizes = next(a for a in attn.attribute if a.name == "qkv_hidden_sizes").ints
+    assert list(qkv_sizes) == [H, H, VH]
+    onnx.checker.check_model(simplified)
+
+    rng = np.random.default_rng(3)
+    x = rng.standard_normal((B, S, H)).astype(np.float32)
+    _assert_close(_run(model, {"x": x}), _run(simplified, {"x": x}))
+
+
+def test_fuse_attention_declines_cross_attention():
+    # Q reads a different source than K/V: fuse_attention.h only handles
+    # self-attention and must decline, leaving the graph numerically correct
+    # (just unfused) rather than misfiring.
+    B, S, H = 2, 5, 32
+    model = _attention_model(B=B, S=S, H=H, kv_source="mem")
+    simplified, ok = onnxsim.simplify(model)
+    assert ok
+    assert _op_counts(simplified)["Attention"] == 0
+
+    rng = np.random.default_rng(4)
+    x = rng.standard_normal((B, S, H)).astype(np.float32)
+    mem = rng.standard_normal((B, S, H)).astype(np.float32)
+    _assert_close(
+        _run(model, {"x": x, "mem": mem}), _run(simplified, {"x": x, "mem": mem})
+    )


### PR DESCRIPTION
## Summary

Adds `fuse_attention`, a new C++ pass (`onnxsim/passes/fuse_attention.h`) that pattern-matches a standard eager multi-head self-attention subgraph — separate Q/K/V `nn.Linear`-style projections, reshape/transpose to heads, scaled dot-product, softmax, weighted sum — into a single ONNX Runtime `com.microsoft` `Attention` contrib-op node. This is a prerequisite for a future `QAttention` quantization pass (planned as a separate follow-up, not part of this PR).

It's registered as a default-on `Fuse` pass the same way `fuse_rms_norm`/`fuse_gelu`/`fuse_layer_norm` are (`custom_optimizer_passes.cpp`, auto-selected via `GetFuseAndEliminationPass`), so it runs as part of plain `onnxsim.simplify()` with no separate Python entry point or CLI flag.

The real target shape was derived by tracing actual PyTorch exports rather than guessing: `nn.MultiheadAttention`'s legacy TorchScript export produces a ~70-node graph full of exporter-specific dynamic-shape bookkeeping unsuitable for robust matching, so a hand-rolled attention module (separate `nn.Linear` Q/K/V/out) was used instead — a clean, representative graph. The CPU float32 `Attention` kernel was confirmed to exist in `onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc` before implementing, and a real schema (sourced from ONNX Runtime's own `docs/ContribOperators.md`) is registered in `onnxsim/contrib_schemas.cpp` so the checker and shape-inference sweeps after any Fuse pass accept the fused output.

## Two pre-existing bugs found and fixed along the way

Validating against the real traced export surfaced two bugs unrelated to this pass's own logic, both fixed here since they'd otherwise block `fuse_attention` (and, in the first case, `simplify()` entirely) from ever firing on real attention blocks:

- **onnx-optimizer's own vendored `fuse_qkv` pass throws**, aborting the *entire* `simplify()` pipeline, when the shared Q/K/V input is the graph's own input rather than a computed value — exactly the common self-attention case. Root cause: `PrevNode(n, 0)` resolves to the graph's `kParam` placeholder node, which isn't in the node list `insertAfter`'s `ONNX_ASSERT` requires. Fixed by shipping an onnxsim-patched override (`onnxsim/passes/fuse_qkv.h`) that declines instead of throwing, following the same "onnxsim's patched versions of built-in onnxoptimizer passes" convention already used for `fuse_add_bias_into_conv`/`fuse_bn_into_conv`/etc.
- **At least one real ONNX Runtime CPU build (1.29.0) segfaults** executing its own `Attention` kernel when the (schema-optional) bias input is omitted entirely — verified directly against a minimal hand-built model, independent of this pass. `fuse_attention.h` now always synthesizes a zero-filled bias when the source Q/K/V projections have none, rather than omitting Attention's bias input.

## Test plan

- `tests/test_fuse_attention.py` (new, 5 tests): builds the target subgraph directly via `onnx.helper` (no torch dependency), covering bias/no-bias (including the synthesized-zero-bias case and its all-zero-value assertion), `Div`- and `Mul`-spelled scaling, a V hidden size that differs from Q/K's (`qkv_hidden_sizes` correctness), and a cross-attention graph (Q reading a different source than K/V) that must decline while remaining numerically correct. Each test executes both the pre- and post-fusion graphs through `onnxruntime.InferenceSession` and compares.
- Also manually verified end-to-end against real PyTorch-exported attention graphs (hand-rolled module, several hidden-size/head-count/bias/scale-spelling combinations) with exact (rel-err 0.0) before/after agreement.
- Full existing suite: `pytest tests/ --ignore=tests/test_gan.py --ignore=tests/test_python_api.py --ignore=tests/test_simple.py --ignore=tests/test_timm.py` → 356 passed, 57 skipped, no regressions (including `test_mnn_llm_export.py`, a real transformer export).
- `ruff check` / `ruff format --check` clean on the new/touched Python.
- `clang-format-18 --style=file:onnxsim/.clang-format --dry-run --Werror` clean on all touched/new C++ files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_