### PR TITLE
Formalize quantization parameters and accuracy drop

### DIFF
--- a/docs/accuracy-drop.md
+++ b/docs/accuracy-drop.md
@@ -1,0 +1,92 @@
+# Measuring accuracy drop (`measure_accuracy_drop`)
+
+## What this is
+
+`onnxsim.measure_accuracy_drop` (`onnxsim/accuracy.py`) runs a float model
+and a quantized version of it on the same input data and reports how far
+the quantized model's outputs actually drift from the float model's — an
+**empirical measurement**, not an estimate. It complements
+[precision-estimation.md](precision-estimation.md#whole-model-rollup-estimate_model_quantization_drop)'s
+`estimate_model_quantization_drop`, which is fast and needs no data or
+execution but is only a heuristic; this function is slower (it runs both
+models, once per calibration sample) but gives ground truth for the
+specific model and data you measure it on.
+
+```python
+import onnx
+import onnxsim
+
+model = onnx.load("model.onnx")
+quantized = onnxsim.quantize_dynamic(model)  # or any quantize_*/quantize() call
+
+report = onnxsim.measure_accuracy_drop(model, quantized)
+print("worst relative L2 error:", report.worst_relative_l2)
+for name, stats in report.per_output.items():
+    print(name, stats.relative_l2, stats.cosine_similarity)
+```
+
+Both models are executed through `onnxsim.backend.run_model` — onnxruntime
+when it's installed, the pure-Python reference evaluator otherwise (see
+`onnxsim/backend.py`); no separate onnxruntime dependency is required to use
+this function, though it is a much faster backend when present.
+
+## What it reports
+
+`AccuracyDropReport`:
+
+| Field | Meaning |
+| --- | --- |
+| `num_samples` | how many calibration batches were run |
+| `per_output` | `{output_name: OutputAccuracyStats}` |
+| `worst_relative_l2` | max `relative_l2` over every output and sample |
+| `worst_cosine_distance` | `1 - min(cosine_similarity)` over every output and sample |
+| `all_finite` | `False` if the quantized model ever produced NaN/Inf where the float model didn't |
+
+`OutputAccuracyStats` (one per graph output, **worst case across samples**,
+not an average — the point of measuring accuracy drop is to know the worst
+a deployment might see, not to average it away):
+
+| Field | Meaning |
+| --- | --- |
+| `relative_l2` | `\|\|float - quantized\|\| / \|\|float\|\|` |
+| `max_abs_error` | `max(\|float - quantized\|)` |
+| `cosine_similarity` | `dot(float, quantized) / (\|\|float\|\| * \|\|quantized\|\|)` |
+
+## Calibration / input data
+
+Same convention as `quantize_static` and friends: pass `calibration_data`
+(a list of `{input_name: np.ndarray}` dicts) for real, representative data —
+see `onnxsim.load_huggingface_calibration_data` — or leave it unset to fall
+back to `onnxsim.generate_random_calibration_data` (`num_samples`, `seed`).
+Random data is a reasonable smoke test that the quantization pipeline
+produces sane, finite output, but is a poor proxy for a real model's actual
+accuracy drop on real inputs — use real calibration data before trusting
+this measurement for a deployment decision.
+
+## `keep_io_types=False` and non-float32 inputs
+
+A `quantize_fp16`/`quantize_bf16`/`quantize_fp8` call made with
+`keep_io_types=False` redeclares the quantized model's own graph inputs in
+the narrow target format directly (see
+[fp16-quantization.md](fp16-quantization.md)), so the same float32
+calibration data used against the original model can't be fed to it
+unmodified. `measure_accuracy_drop` auto-casts each calibration batch's
+arrays to the quantized model's own declared input dtype before running it,
+for float16 (numpy has a native dtype). bfloat16 and float8 have no native
+numpy dtype (they need `ml_dtypes`), so those two are **not** auto-cast --
+pre-cast `calibration_data` yourself with `ml_dtypes` before calling
+`measure_accuracy_drop` on a `keep_io_types=False` bfloat16/float8 model, or
+the run will fail with a type-mismatch error.
+
+## Relationship to `estimate_model_quantization_drop`
+
+|  | `estimate_model_quantization_drop` | `measure_accuracy_drop` |
+| --- | --- | --- |
+| Needs execution/data? | No | Yes |
+| Speed | Fast (static analysis) | Slower (runs both models) |
+| What it produces | A heuristic *estimate* from weights/shapes alone | An actual *measurement* on real output data |
+| Best for | A quick pre-check before quantizing, or screening many candidate models | Verifying a specific quantized model's real-world accuracy before shipping it |
+
+Use the static estimate first to catch outright-unsafe nodes (accumulator
+overflow) cheaply, then measure the actual drop on the quantized model you
+intend to ship, with real calibration data, before deploying it.

--- a/docs/bf16-quantization.md
+++ b/docs/bf16-quantization.md
@@ -95,7 +95,12 @@ exactly this one rewrite, once, to a copy of the model (which is left
 untouched) and returns the result. The old float32 initializer a converted
 weight replaces is left orphaned in the model rather than pruned; call
 `onnxsim.simplify()` afterward (or before, or both) to clean the graph up
-and drop it.
+and drop it. If the model already carries `value_info` for its interior
+activations (e.g. because `simplify()` ran on it first, as the recommended
+flow below does), this pass clears the now-stale float32 declarations those
+tensors no longer have -- rather than leaving a *wrong* type in the exported
+model, which ONNX Runtime's own load-time type-checking rejects outright,
+unlike a merely absent value_info entry, which it infers fresh.
 
 ## End-to-end: simplify -> quantize -> deploy
 

--- a/docs/fp16-quantization.md
+++ b/docs/fp16-quantization.md
@@ -78,7 +78,12 @@ exactly this one rewrite, once, to a copy of the model (which is left
 untouched) and returns the result. The old float32 initializer a converted
 weight replaces is left orphaned in the model rather than pruned; call
 `onnxsim.simplify()` afterward (or before, or both) to clean the graph up
-and drop it.
+and drop it. If the model already carries `value_info` for its interior
+activations (e.g. because `simplify()` ran on it first, as the recommended
+flow below does), this pass clears the now-stale float32 declarations those
+tensors no longer have -- rather than leaving a *wrong* type in the exported
+model, which ONNX Runtime's own load-time type-checking rejects outright,
+unlike a merely absent value_info entry, which it infers fresh.
 
 ## End-to-end: simplify -> quantize -> deploy
 

--- a/docs/fp8-quantization.md
+++ b/docs/fp8-quantization.md
@@ -102,7 +102,12 @@ exactly this one rewrite, once, to a copy of the model (which is left
 untouched) and returns the result. The old float32 initializer a converted
 weight replaces is left orphaned in the model rather than pruned; call
 `onnxsim.simplify()` afterward (or before, or both) to clean the graph up
-and drop it.
+and drop it. If the model already carries `value_info` for its interior
+activations (e.g. because `simplify()` ran on it first, as the recommended
+flow below does), this pass clears the now-stale float32 declarations those
+tensors no longer have -- rather than leaving a *wrong* type in the exported
+model, which ONNX Runtime's own load-time type-checking rejects outright,
+unlike a merely absent value_info entry, which it infers fresh.
 
 **Needs opset >= 19** -- the first opset where ONNX's `Cast` op supports
 float8 types.

--- a/docs/precision-estimation.md
+++ b/docs/precision-estimation.md
@@ -111,6 +111,59 @@ quantization or INT16 would preserve more resolution for this node's
 typical-magnitude weights
 ```
 
+## Whole-model rollup (`estimate_model_quantization_drop`)
+
+`estimate_quantization_precision`'s per-node estimates answer "is this one
+node safe?" — `onnxsim.estimate_model_quantization_drop` rolls all of them
+into a single whole-model risk summary and one *estimated relative error*
+number, still purely from the model's static weights and shapes:
+
+```python
+est = onnxsim.estimate_model_quantization_drop(model)
+print(est.risk_level, est.estimated_relative_error)
+```
+
+It returns a `ModelQuantizationEstimate`:
+
+| Field | Meaning |
+| --- | --- |
+| `total_nodes_analyzed` | how many MatMul/Gemm/Conv/Attention nodes were recognized |
+| `unsafe_nodes` | node names that fail the int32-accumulator-safe check |
+| `outlier_risk_nodes` | node names with `outlier_risk=True` |
+| `worst_outlier_ratio` | max `max(\|w\|)/median(\|w\|)` over nodes that had one computable |
+| `estimated_relative_error` | see below; `nan` whenever `unsafe_nodes` is non-empty |
+| `risk_level` | `"unsafe"` \| `"degraded"` \| `"safe"` |
+| `per_node` | the same list `estimate_quantization_precision` returns |
+
+`risk_level` is `"unsafe"` if any node overflows its int32 accumulator (a
+real correctness bug — `estimated_relative_error` is `nan` in this case,
+since an overflowing accumulator's output isn't bounded by any small error
+term); `"degraded"` if none overflow but at least one has an outlier-driven
+resolution loss; `"safe"` otherwise.
+
+`estimated_relative_error` comes from the standard **uniform-quantizer
+noise model**: a symmetric INT8 quantizer with step `Δ = max(|w|) / 127` has
+quantization error uniformly distributed in `[-Δ/2, Δ/2]`, whose RMS is
+`Δ / sqrt(12)`. Relative to a channel's *typical* (median-magnitude, not
+peak) weight, that RMS error scales by the channel's own outlier ratio `r`
+(1 when no ratio was computable):
+
+```
+per_node_relative_error = r / (127 * sqrt(12))
+```
+
+The whole-model figure combines every analyzed node's
+`per_node_relative_error` in root-sum-square — the standard back-of-envelope
+combination for independent noise sources. This is a **heuristic screening
+signal, not a certified bound**: it assumes each node's quantization error
+behaves as an independent perturbation that neither compounds
+multiplicatively through the network's depth nor cancels out, which real
+networks only approximate. Use it to rank/screen models or compare
+candidate schemes quickly, with no data required — for an actual,
+data-driven measurement of a specific quantized model's real accuracy drop,
+see [accuracy-drop.md](accuracy-drop.md)'s `measure_accuracy_drop`, the
+ground-truth counterpart to this estimate.
+
 ## Scope and limitations
 
 - Only the top-level graph is walked — nodes inside `If`/`Loop`/`Scan`

--- a/docs/quantization-config.md
+++ b/docs/quantization-config.md
@@ -1,0 +1,80 @@
+# Unified quantization config (`QuantizationConfig` / `quantize`)
+
+## What this is
+
+onnxsim ships more than a dozen `quantize_*` functions
+(`quantize_dynamic`, `quantize_static`, `quantize_weight_only_int4`, ...),
+each documenting and exposing its own scheme's specific parameters — see the
+other docs in this directory for each one directly. `onnxsim.QuantizationConfig`
+and `onnxsim.quantize` (`onnxsim/accuracy.py`) add a second, unified way to
+reach all of them: describe *what* quantization you want as one typed
+config object, and let `quantize` dispatch to the right underlying function.
+
+This doesn't replace any existing `quantize_*` function — call those
+directly when you already know which scheme you want. `quantize` is for code
+that picks a scheme *programmatically*: a sweep over configs to compare
+accuracy/size tradeoffs, a scheme read from a config file or CLI flag, or
+any caller that wants one call site regardless of which scheme ends up
+selected.
+
+```python
+import onnx
+import onnxsim
+
+model = onnx.load("model.onnx")
+config = onnxsim.QuantizationConfig(scheme="weight_only", dtype="int4")
+quantized = onnxsim.quantize(model, config)
+onnx.save(quantized, "model.int4.onnx")
+```
+
+## The scheme / dtype / granularity matrix
+
+| `scheme` | `dtype` | `granularity` | Calls |
+| --- | --- | --- | --- |
+| `"dynamic"` | `"int8"` | `"per_channel"` | `quantize_dynamic` |
+| `"dynamic_fused"` | `"int8"` | `"per_channel"` | `quantize_dynamic_matmul_integer_to_float` |
+| `"ternary"` | `"int8"` | `"per_channel"` | `quantize_ternary` |
+| `"weight_only"` | `"int8"` | `"per_channel"` | `quantize_weight_only` |
+| `"weight_only"` | `"int8"` | `"per_block"` | `quantize_weight_only_int8_block` |
+| `"weight_only"` | `"int16"` | `"per_channel"` | `quantize_weight_only_int16` |
+| `"weight_only"` | `"int4"` | `"per_block"` (only option) | `quantize_weight_only_int4` |
+| `"static"` | `"int8"` | `"per_channel"` | `quantize_static` |
+| `"static_int16"` | `"int16"` | `"per_channel"` | `quantize_static_int16` |
+| `"qoperator"` | `"int8"` | `"per_channel"` | `quantize_qoperator` |
+| `"float"` | `"float16"` | n/a | `quantize_fp16` |
+| `"float"` | `"bfloat16"` | n/a | `quantize_bf16` |
+| `"float"` | `"float8_e4m3"` | n/a | `quantize_fp8(format="e4m3")` |
+| `"float"` | `"float8_e5m2"` | n/a | `quantize_fp8(format="e5m2")` |
+
+`granularity` is only consulted for `scheme="weight_only", dtype="int8"` —
+every other row has exactly one granularity onnxsim implements today, and
+the field is ignored for those. Follow the linked docs above (or each
+function's own docstring) for what each scheme actually does numerically;
+this page only covers the dispatch layer.
+
+An unknown `scheme`, a `dtype` not valid for that `scheme`, or an invalid
+`granularity` for `weight_only`/`int8` all raise `ValueError` with a message
+naming the valid options — `quantize` never silently guesses at a
+misconfigured request.
+
+## Other `QuantizationConfig` fields
+
+- `calibration_data`, `num_calibration_samples`, `seed`, `providers`,
+  `calibration_method` — forwarded as-is to `quantize_static`/
+  `quantize_static_int16`/`quantize_qoperator` for the three calibration-based
+  schemes; ignored otherwise. See
+  [dynamic-quantization.md](dynamic-quantization.md) and
+  [qoperator-quantization.md](qoperator-quantization.md) for what calibration
+  data is and how to supply real (not random) data via
+  `onnxsim.load_huggingface_calibration_data`.
+- `keep_io_types` — forwarded to `quantize_fp16`/`quantize_bf16`/`quantize_fp8`
+  for `scheme="float"`; ignored otherwise. See
+  [fp16-quantization.md](fp16-quantization.md).
+
+## Measuring what a config actually costs
+
+Picking a `QuantizationConfig` is only half the question — how much accuracy
+it costs is the other half. See
+[precision-estimation.md](precision-estimation.md#whole-model-rollup-estimate_model_quantization_drop)
+for a fast, data-free estimate, and [accuracy-drop.md](accuracy-drop.md) for
+an actual, data-driven measurement of a specific quantized model.

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -1,3 +1,10 @@
+from onnxsim.accuracy import (
+    AccuracyDropReport,
+    OutputAccuracyStats,
+    QuantizationConfig,
+    measure_accuracy_drop,
+    quantize,
+)
 from onnxsim.calibration import (
     calibrate,
     generate_random_calibration_data,
@@ -33,12 +40,18 @@ from onnxsim.onnx_simplifier import (
     quantize_weight_only_int16,
     simplify,
 )
-from onnxsim.precision_estimator import estimate_quantization_precision
+from onnxsim.precision_estimator import (
+    ModelQuantizationEstimate,
+    estimate_model_quantization_drop,
+    estimate_quantization_precision,
+)
 
 from .version import version as __version__
 
 __all__ = [
     "simplify",
+    "quantize",
+    "QuantizationConfig",
     "quantize_dynamic",
     "quantize_dynamic_matmul_integer_to_float",
     "quantize_ternary",
@@ -63,6 +76,11 @@ __all__ = [
     "generate_random_calibration_data",
     "load_huggingface_calibration_data",
     "estimate_quantization_precision",
+    "ModelQuantizationEstimate",
+    "estimate_model_quantization_drop",
+    "measure_accuracy_drop",
+    "AccuracyDropReport",
+    "OutputAccuracyStats",
     "main",
     "import_onnx_schemas",
     "export_safetensors",

--- a/onnxsim/accuracy.py
+++ b/onnxsim/accuracy.py
@@ -1,0 +1,373 @@
+"""A unified, typed entry point over onnxsim's quantization schemes
+(:class:`QuantizationConfig` / :func:`quantize`), and a data-driven
+measurement of a specific quantized model's actual accuracy drop
+(:func:`measure_accuracy_drop`).
+
+onnxsim ships more than a dozen ``quantize_*`` functions
+(:func:`onnxsim.quantize_dynamic`, :func:`onnxsim.quantize_static`,
+:func:`onnxsim.quantize_weight_only_int4`, ...), each its own scheme with its
+own parameter surface, documented and callable directly as always. This
+module adds a second, unified way to reach all of them: describe *what*
+quantization you want (scheme, dtype, granularity, calibration settings) as
+one :class:`QuantizationConfig`, and let :func:`quantize` dispatch to the
+right underlying function -- useful for code that picks a scheme
+programmatically (a sweep over configs, a config file, a CLI flag) rather
+than calling a specific ``quantize_*`` function by name.
+
+For how much accuracy a given quantization actually costs, two tools, at two
+different price points:
+
+- :func:`onnxsim.estimate_model_quantization_drop` (in
+  ``precision_estimator.py``) -- static, no execution or data needed, an
+  *estimate* from the model's weights and shapes alone. Fast pre-check.
+- :func:`measure_accuracy_drop`, here -- runs the float and quantized models
+  through ONNX Runtime (or the reference evaluator, see ``backend.py``) on
+  the same input data and reports actual output differences. Slower (needs
+  data and two full model runs per sample), but it's a measurement, not an
+  estimate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Sequence, Union
+
+import numpy as np
+import onnx
+
+from onnxsim import backend
+from onnxsim.calibration import (
+    _ELEM_TYPE_TO_NP,
+    Tensors,
+    generate_random_calibration_data,
+    quantize_qoperator,
+    quantize_static,
+    quantize_static_int16,
+)
+from onnxsim.onnx_simplifier import (
+    quantize_bf16,
+    quantize_dynamic,
+    quantize_dynamic_matmul_integer_to_float,
+    quantize_fp8,
+    quantize_fp16,
+    quantize_ternary,
+    quantize_weight_only,
+    quantize_weight_only_int4,
+    quantize_weight_only_int8_block,
+    quantize_weight_only_int16,
+)
+
+# scheme -> the dtypes it accepts for QuantizationConfig.dtype.
+_SCHEME_DTYPES = {
+    "dynamic": {"int8"},
+    "dynamic_fused": {"int8"},
+    "ternary": {"int8"},
+    "weight_only": {"int8", "int16", "int4"},
+    "static": {"int8"},
+    "static_int16": {"int16"},
+    "qoperator": {"int8"},
+    "float": {"float16", "bfloat16", "float8_e4m3", "float8_e5m2"},
+}
+_CALIBRATION_SCHEMES = {"static", "static_int16", "qoperator"}
+
+
+@dataclass
+class QuantizationConfig:
+    """Describes one onnxsim quantization scheme and its parameters, for
+    :func:`quantize` to dispatch on. Every field not relevant to ``scheme``
+    is simply ignored (e.g. ``calibration_data`` for ``scheme="dynamic"``,
+    which needs none) -- see :func:`quantize`'s docstring for the full
+    scheme/dtype/granularity matrix and which onnxsim function each maps to.
+
+    :param scheme: one of ``"dynamic"``, ``"dynamic_fused"``, ``"ternary"``,
+            ``"weight_only"``, ``"static"``, ``"static_int16"``,
+            ``"qoperator"``, ``"float"``.
+    :param dtype: the quantized representation. Meaning depends on
+            ``scheme`` -- see :func:`quantize`.
+    :param granularity: ``"per_channel"`` (default) or ``"per_block"``.
+            Only ``scheme="weight_only"`` currently offers a choice (its
+            ``dtype="int8"`` case); every other scheme/dtype combination has
+            exactly one granularity onnxsim implements today, and this field
+            is ignored for them.
+    :param calibration_data: representative input batches for the
+            calibration-based schemes (``"static"``, ``"static_int16"``,
+            ``"qoperator"``) -- see :func:`onnxsim.generate_random_calibration_data`
+            (the default when omitted) and
+            :func:`onnxsim.load_huggingface_calibration_data`.
+    :param num_calibration_samples: random calibration batches to generate
+            when ``calibration_data`` is omitted (calibration-based schemes
+            only).
+    :param seed: seed for the random calibration data (calibration-based
+            schemes only; ignored if ``calibration_data`` is supplied).
+    :param providers: onnxruntime execution providers to calibrate on
+            (calibration-based schemes only).
+    :param calibration_method: ``"minmax"`` (default) or ``"entropy"``,
+            passed through to :func:`onnxsim.calibrate` (calibration-based
+            schemes only).
+    :param keep_io_types: for ``scheme="float"`` only -- keep the model's
+            external input/output types at float32 (inserting boundary
+            ``Cast`` nodes) instead of redeclaring them in the target
+            format. Default ``True``.
+    """
+
+    scheme: str
+    dtype: str = "int8"
+    granularity: str = "per_channel"
+    calibration_data: Optional[Sequence[Tensors]] = None
+    num_calibration_samples: int = 8
+    seed: int = 0
+    providers: Optional[Sequence[str]] = None
+    calibration_method: str = "minmax"
+    keep_io_types: bool = True
+
+
+def quantize(
+    model: Union[str, onnx.ModelProto], config: QuantizationConfig
+) -> onnx.ModelProto:
+    """Quantizes ``model`` according to ``config``, dispatching to the
+    matching onnxsim ``quantize_*`` function. The scheme/dtype/granularity
+    matrix:
+
+    ================  ===============  ==============  ===========================================
+    scheme            dtype            granularity     onnxsim function
+    ================  ===============  ==============  ===========================================
+    dynamic           int8             per_channel      :func:`onnxsim.quantize_dynamic`
+    dynamic_fused     int8             per_channel      :func:`onnxsim.quantize_dynamic_matmul_integer_to_float`
+    ternary           int8             per_channel      :func:`onnxsim.quantize_ternary`
+    weight_only       int8             per_channel      :func:`onnxsim.quantize_weight_only`
+    weight_only       int8             per_block        :func:`onnxsim.quantize_weight_only_int8_block`
+    weight_only       int16            per_channel      :func:`onnxsim.quantize_weight_only_int16`
+    weight_only       int4             per_block        :func:`onnxsim.quantize_weight_only_int4`
+    static            int8             per_channel      :func:`onnxsim.quantize_static`
+    static_int16      int16            per_channel      :func:`onnxsim.quantize_static_int16`
+    qoperator         int8             per_channel      :func:`onnxsim.quantize_qoperator`
+    float              float16          n/a             :func:`onnxsim.quantize_fp16`
+    float              bfloat16         n/a             :func:`onnxsim.quantize_bf16`
+    float              float8_e4m3      n/a             :func:`onnxsim.quantize_fp8` (format="e4m3")
+    float              float8_e5m2      n/a             :func:`onnxsim.quantize_fp8` (format="e5m2")
+    ================  ===============  ==============  ===========================================
+
+    ``weight_only``/``int4`` is always block-wise (block_size=32, the only
+    granularity :func:`onnxsim.quantize_weight_only_int4` implements) --
+    ``granularity`` is not consulted for it, and likewise for every other
+    row with exactly one implemented granularity.
+
+    Raises :class:`ValueError` for an unknown ``scheme``, a ``dtype`` not
+    valid for that ``scheme``, or (``scheme="weight_only"``, ``dtype="int8"``)
+    with a ``granularity`` other than ``"per_channel"``/``"per_block"``.
+
+    :param model: onnx ModelProto object or file path
+    :param config: the quantization scheme and its parameters
+    :returns: the quantized onnx ModelProto
+    """
+    scheme = config.scheme
+    valid_dtypes = _SCHEME_DTYPES.get(scheme)
+    if valid_dtypes is None:
+        raise ValueError(
+            f"unknown QuantizationConfig.scheme {scheme!r}; expected one of "
+            f"{sorted(_SCHEME_DTYPES)}"
+        )
+    if config.dtype not in valid_dtypes:
+        raise ValueError(
+            f"scheme={scheme!r} does not support dtype={config.dtype!r}; "
+            f"expected one of {sorted(valid_dtypes)}"
+        )
+
+    if scheme == "dynamic":
+        return quantize_dynamic(model)
+    if scheme == "dynamic_fused":
+        return quantize_dynamic_matmul_integer_to_float(model)
+    if scheme == "ternary":
+        return quantize_ternary(model)
+
+    if scheme == "weight_only":
+        if config.dtype == "int16":
+            return quantize_weight_only_int16(model)
+        if config.dtype == "int4":
+            return quantize_weight_only_int4(model)
+        # dtype == "int8": the one scheme/dtype pair with a granularity choice.
+        if config.granularity == "per_channel":
+            return quantize_weight_only(model)
+        if config.granularity == "per_block":
+            return quantize_weight_only_int8_block(model)
+        raise ValueError(
+            "scheme='weight_only', dtype='int8' supports granularity "
+            f"'per_channel' or 'per_block', got {config.granularity!r}"
+        )
+
+    if scheme in _CALIBRATION_SCHEMES:
+        fn = {
+            "static": quantize_static,
+            "static_int16": quantize_static_int16,
+            "qoperator": quantize_qoperator,
+        }[scheme]
+        return fn(
+            model,
+            calibration_data=config.calibration_data,
+            num_calibration_samples=config.num_calibration_samples,
+            seed=config.seed,
+            providers=config.providers,
+            method=config.calibration_method,
+        )
+
+    # scheme == "float"
+    if config.dtype == "float16":
+        return quantize_fp16(model, keep_io_types=config.keep_io_types)
+    if config.dtype == "bfloat16":
+        return quantize_bf16(model, keep_io_types=config.keep_io_types)
+    fp8_format = "e4m3" if config.dtype == "float8_e4m3" else "e5m2"
+    return quantize_fp8(model, format=fp8_format, keep_io_types=config.keep_io_types)
+
+
+def _cast_batch_to_model_inputs(model: onnx.ModelProto, batch: Tensors) -> Tensors:
+    """Casts each array in `batch` to the graph input's own declared dtype,
+    for a floating-point mismatch only -- e.g. a ``keep_io_types=False``
+    float16 quantization (see :func:`onnxsim.quantize_fp16`) redeclares
+    graph inputs in the narrow format directly, so the same float32
+    calibration data used against the original model needs casting before
+    it can feed the quantized one. Integer/bool inputs, and bfloat16/float8
+    targets (no native numpy dtype in ``_ELEM_TYPE_TO_NP``; pre-cast
+    ``calibration_data`` yourself with ``ml_dtypes`` for those), are left
+    untouched.
+    """
+    elem_type_by_name = {
+        i.name: i.type.tensor_type.elem_type for i in model.graph.input
+    }
+    out = {}
+    for name, arr in batch.items():
+        elem_type = elem_type_by_name.get(name)
+        np_dtype = _ELEM_TYPE_TO_NP.get(elem_type) if elem_type is not None else None
+        if (
+            np_dtype is not None
+            and np.issubdtype(np_dtype, np.floating)
+            and arr.dtype != np_dtype
+        ):
+            arr = arr.astype(np_dtype)
+        out[name] = arr
+    return out
+
+
+@dataclass
+class OutputAccuracyStats:
+    """Worst-case-over-samples accuracy stats for one model output -- see
+    :func:`measure_accuracy_drop`."""
+
+    output_name: str
+    relative_l2: float  # ||float - quantized|| / ||float||, worst over samples
+    max_abs_error: float  # max(|float - quantized|), worst over samples
+    cosine_similarity: (
+        float  # dot(float, quantized) / (||float|| * ||quantized||), worst over samples
+    )
+
+
+@dataclass
+class AccuracyDropReport:
+    """Measured (not estimated) accuracy drop between a float model and a
+    quantized version of it -- see :func:`measure_accuracy_drop`."""
+
+    num_samples: int
+    per_output: Dict[str, OutputAccuracyStats] = field(default_factory=dict)
+    worst_relative_l2: float = float("nan")  # max over every output/sample
+    worst_cosine_distance: float = float("nan")  # 1 - min cosine_similarity
+    all_finite: bool = True  # False if the quantized model ever produced NaN/Inf
+
+
+def measure_accuracy_drop(
+    float_model: Union[str, onnx.ModelProto],
+    quantized_model: Union[str, onnx.ModelProto],
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_samples: int = 8,
+    seed: int = 0,
+    providers: Optional[Sequence[str]] = None,
+) -> AccuracyDropReport:
+    """Runs ``float_model`` and ``quantized_model`` on the same input data
+    (through :func:`onnxsim.backend.run_model` -- onnxruntime when
+    installed, the pure-Python reference evaluator otherwise) and reports
+    how far each of the quantized model's outputs actually drifts from the
+    float model's -- an empirical measurement, not
+    :func:`onnxsim.estimate_model_quantization_drop`'s static estimate.
+
+    Assumes ``float_model`` and ``quantized_model`` declare the same output
+    *names* and count -- true of every onnxsim ``quantize_*``/:func:`quantize`
+    call, which never renames or adds/removes graph outputs. Per-output
+    stats are the **worst case across samples**, not an average: the point
+    of measuring accuracy drop is to know the worst a deployment might see,
+    not to average it away.
+
+    :param float_model: the original (unquantized) onnx ModelProto or file path
+    :param quantized_model: a quantized version of ``float_model`` (onnx
+            ModelProto or file path), e.g. from :func:`quantize` or any
+            ``quantize_*`` function
+    :param calibration_data: representative input batches to measure on.
+            Each batch is a ``{input_name: np.ndarray}`` dict matching
+            ``float_model``'s graph inputs -- see
+            :func:`onnxsim.generate_random_calibration_data` (the default
+            when omitted) and :func:`onnxsim.load_huggingface_calibration_data`
+            (real data, a much more representative measurement than random
+            input for a real deployment).
+    :param num_samples: number of random batches to generate when
+            ``calibration_data`` is not supplied
+    :param seed: seed for the random calibration data (ignored if
+            ``calibration_data`` is supplied)
+    :param providers: onnxruntime execution providers to run both models on
+    :returns: the measured accuracy-drop report
+    """
+    if isinstance(float_model, str):
+        float_model = onnx.load(float_model, load_external_data=False)
+    if isinstance(quantized_model, str):
+        quantized_model = onnx.load(quantized_model, load_external_data=False)
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            float_model, num_samples=num_samples, seed=seed
+        )
+
+    output_names = [o.name for o in float_model.graph.output]
+    per_output_l2: Dict[str, List[float]] = {name: [] for name in output_names}
+    per_output_abs: Dict[str, List[float]] = {name: [] for name in output_names}
+    per_output_cos: Dict[str, List[float]] = {name: [] for name in output_names}
+    all_finite = True
+
+    for batch in calibration_data:
+        float_out = backend.run_model(float_model, batch, providers=providers)
+        quantized_out = backend.run_model(
+            quantized_model,
+            _cast_batch_to_model_inputs(quantized_model, batch),
+            providers=providers,
+        )
+        for name in output_names:
+            f = np.asarray(float_out[name], dtype=np.float64).ravel()
+            q = np.asarray(quantized_out[name], dtype=np.float64).ravel()
+            if not np.all(np.isfinite(q)):
+                all_finite = False
+            f_norm = float(np.linalg.norm(f))
+            q_norm = float(np.linalg.norm(q))
+            rel_l2 = float(np.linalg.norm(f - q)) / max(f_norm, 1e-12)
+            max_abs = float(np.max(np.abs(f - q))) if f.size else 0.0
+            denom = f_norm * q_norm
+            cos_sim = float(np.dot(f, q) / denom) if denom > 0 else float("nan")
+            per_output_l2[name].append(rel_l2)
+            per_output_abs[name].append(max_abs)
+            per_output_cos[name].append(cos_sim)
+
+    per_output: Dict[str, OutputAccuracyStats] = {}
+    for name in output_names:
+        per_output[name] = OutputAccuracyStats(
+            output_name=name,
+            relative_l2=max(per_output_l2[name]),
+            max_abs_error=max(per_output_abs[name]),
+            cosine_similarity=min(per_output_cos[name]),
+        )
+
+    worst_relative_l2 = max(
+        (s.relative_l2 for s in per_output.values()), default=float("nan")
+    )
+    worst_cosine_similarity = min(
+        (s.cosine_similarity for s in per_output.values()), default=1.0
+    )
+    return AccuracyDropReport(
+        num_samples=len(calibration_data),
+        per_output=per_output,
+        worst_relative_l2=worst_relative_l2,
+        worst_cosine_distance=1.0 - worst_cosine_similarity,
+        all_finite=all_finite,
+    )

--- a/onnxsim/passes/endian_read.h
+++ b/onnxsim/passes/endian_read.h
@@ -23,6 +23,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <string>
 #include <vector>
 
 #include "dlpack_dtype.h"
@@ -42,6 +43,36 @@ inline std::vector<T> ReadRawDataHostOrder(const T* raw, int64_t numel) {
   if constexpr (!onnxsim::dlpack::kRawDataIsHostOrder) {
     onnxsim::dlpack::SwapElementBytes(reinterpret_cast<uint8_t*>(out.data()),
                                       out.size() * sizeof(T), sizeof(T));
+  }
+  return out;
+}
+
+// The write-side counterpart of ReadRawDataHostOrder: packs a host-order
+// vector<T> into a little-endian-on-wire byte string, suitable for
+// Tensor::set_raw_data(). Every onnxsim quantization pass that builds a small
+// (1/2-byte-per-element) integer or float-bit-pattern tensor -- INT8/UINT8/
+// INT16/UINT16, or FLOAT16/BFLOAT16/FLOAT8's raw bit patterns -- should
+// prefer this over Tensor::int32s(): ONNX's wire format allows either
+// (TensorProto.int32_data is a valid, spec-legal field for all of these
+// types, and onnxsim's own ir_pb_converter serializes whichever one the
+// in-memory Tensor is carrying -- see is_raw_data() there), but int32_data is
+// a `repeated int32` protobuf field, individually varint-encoded: every
+// value takes at least 1 byte, values needing the sign bit (anything
+// negative, since this is a plain `int32` field, not zigzag-coded `sint32`)
+// take the full 10 bytes every such value's varint encoding requires,
+// regardless of the logical type's own width. raw_data instead packs each
+// element at its true byte width with no per-element framing, matching what
+// onnx's own reference tensor builder (onnx.numpy_helper.from_array, which
+// always uses raw_data, INT8 and FLOAT16 included) produces. A plain memcpy
+// on a little-endian host, byte-swapped on a big-endian one -- the same
+// convention ReadRawDataHostOrder uses in reverse.
+template <typename T>
+inline std::string WriteRawDataLittleEndian(const std::vector<T>& values) {
+  std::string out(values.size() * sizeof(T), '\0');
+  std::memcpy(out.data(), values.data(), out.size());
+  if constexpr (!onnxsim::dlpack::kRawDataIsHostOrder) {
+    onnxsim::dlpack::SwapElementBytes(reinterpret_cast<uint8_t*>(out.data()),
+                                      out.size(), sizeof(T));
   }
   return out;
 }

--- a/onnxsim/passes/quantize_bf16.h
+++ b/onnxsim/passes/quantize_bf16.h
@@ -149,6 +149,31 @@ struct QuantizeBf16Pass final : public FullGraphBasedPass {
       tryReplacingAllUsesWith(old_v, new_v);
     }
 
+    // 1.5. Clear stale float32 elemType/shape metadata on every existing
+    // node's output (except graph outputs, which step 3 below still needs
+    // to see as FLOAT to decide whether to convert/cast them, and sets
+    // explicitly itself either way) -- see quantize_fp16.h's own step 1.5
+    // for the full rationale: this pass never re-runs shape inference, so a
+    // stale float32 declaration left over from an earlier pass (e.g.
+    // ``simplify()``) would otherwise round-trip into the exported model's
+    // value_info as a wrong type for a tensor now actually bfloat16, which
+    // ONNX Runtime's own load-time type-checking rejects outright. A
+    // cleared (omitted) value_info entry is always safe -- inferred fresh
+    // by any conformant consumer -- unlike a wrong one.
+    std::unordered_set<std::string> graph_output_names;
+    for (Value* v : graph.outputs()) {
+      graph_output_names.insert(v->uniqueName());
+    }
+    for (Node* n : graph.nodes()) {
+      for (Value* out : n->outputs()) {
+        if (out->elemType() == TensorProto_DataType_FLOAT &&
+            graph_output_names.count(out->uniqueName()) == 0) {
+          out->setElemType(TensorProto_DataType_UNDEFINED);
+          out->wipeSizes();
+        }
+      }
+    }
+
     // 2. Graph inputs.
     for (Value* value : graph.inputs()) {
       if (initializer_names.count(value->uniqueName()) > 0 ||

--- a/onnxsim/passes/quantize_bf16.h
+++ b/onnxsim/passes/quantize_bf16.h
@@ -84,19 +84,20 @@ inline uint16_t FloatToBFloat16Bits(float value) {
 
 // Converts a constant float32 tensor of any rank/shape to bfloat16, keeping
 // the same shape. Like float16, bfloat16 has no dedicated typed field in
-// TensorProto -- its values live in `int32_data`/`Tensor::int32s()`, each
-// entry the 16-bit bit pattern zero-extended to int32 (see
-// third_party/onnx-optimizer/third_party/onnx/onnx/common/ir_pb_converter.cc,
-// where BFLOAT16 is handled identically to FLOAT16).
+// TensorProto -- see ConvertFloatTensorToFp16's comment in quantize_fp16.h
+// for why this packs the bit patterns into raw_data (via
+// WriteRawDataLittleEndian, endian_read.h) rather than the far less compact
+// typed `int32_data` field ONNX's wire format also allows for it.
 inline Tensor ConvertFloatTensorToBf16(const Tensor& t) {
   const std::vector<float> data = ReadFloatTensorFlat(t);
   Tensor out;
   out.elem_type() = TensorProto_DataType_BFLOAT16;
   out.sizes() = t.sizes();
-  out.int32s().resize(data.size());
+  std::vector<uint16_t> bits(data.size());
   for (size_t i = 0; i < data.size(); ++i) {
-    out.int32s()[i] = static_cast<int32_t>(FloatToBFloat16Bits(data[i]));
+    bits[i] = FloatToBFloat16Bits(data[i]);
   }
+  out.set_raw_data(WriteRawDataLittleEndian(bits));
   return out;
 }
 

--- a/onnxsim/passes/quantize_conv_common.h
+++ b/onnxsim/passes/quantize_conv_common.h
@@ -99,14 +99,17 @@ inline void QuantizeConvWeightPerOutputChannel(const Tensor& w_t, Tensor& q_out,
 
   q_out.elem_type() = TensorProto_DataType_INT8;
   q_out.sizes() = sizes;
-  q_out.int32s().resize(static_cast<size_t>(C * inner));
+  // raw_data, not int32s() -- see WriteRawDataLittleEndian's doc comment in
+  // endian_read.h for why.
+  std::vector<int8_t> codes(static_cast<size_t>(C * inner));
   for (int64_t c = 0; c < C; ++c) {
     for (int64_t j = 0; j < inner; ++j) {
       const float q = std::round(data[c * inner + j] / scale[c]);
-      q_out.int32s()[c * inner + j] =
-          static_cast<int32_t>(std::clamp(q, -127.0f, 127.0f));
+      codes[c * inner + j] =
+          static_cast<int8_t>(std::clamp(q, -127.0f, 127.0f));
     }
   }
+  q_out.set_raw_data(WriteRawDataLittleEndian(codes));
 
   scale_out.elem_type() = TensorProto_DataType_FLOAT;
   scale_out.sizes() = {C};
@@ -140,14 +143,17 @@ inline void QuantizeConvWeightPerOutputChannelInt16(const Tensor& w_t,
 
   q_out.elem_type() = TensorProto_DataType_INT16;
   q_out.sizes() = sizes;
-  q_out.int32s().resize(static_cast<size_t>(C * inner));
+  // raw_data, not int32s() -- see WriteRawDataLittleEndian's doc comment in
+  // endian_read.h for why.
+  std::vector<int16_t> codes(static_cast<size_t>(C * inner));
   for (int64_t c = 0; c < C; ++c) {
     for (int64_t j = 0; j < inner; ++j) {
       const float q = std::round(data[c * inner + j] / scale[c]);
-      q_out.int32s()[c * inner + j] =
-          static_cast<int32_t>(std::clamp(q, -32767.0f, 32767.0f));
+      codes[c * inner + j] =
+          static_cast<int16_t>(std::clamp(q, -32767.0f, 32767.0f));
     }
   }
+  q_out.set_raw_data(WriteRawDataLittleEndian(codes));
 
   scale_out.elem_type() = TensorProto_DataType_FLOAT;
   scale_out.sizes() = {C};
@@ -280,16 +286,19 @@ inline bool TryQuantizeConvWeightBlockwiseInt8Flat(const Tensor& w_t,
 
   q_out.elem_type() = TensorProto_DataType_INT8;
   q_out.sizes() = {C, inner};
-  q_out.int32s().resize(static_cast<size_t>(C * inner));
+  // raw_data, not int32s() -- see WriteRawDataLittleEndian's doc comment in
+  // endian_read.h for why.
+  std::vector<int8_t> codes(static_cast<size_t>(C * inner));
   for (int64_t c = 0; c < C; ++c) {
     for (int64_t j = 0; j < inner; ++j) {
       const float s =
           scale[static_cast<size_t>(c * num_blocks + j / block_size)];
       const float q = std::round(data[static_cast<size_t>(c * inner + j)] / s);
-      q_out.int32s()[c * inner + j] =
-          static_cast<int32_t>(std::clamp(q, -127.0f, 127.0f));
+      codes[c * inner + j] =
+          static_cast<int8_t>(std::clamp(q, -127.0f, 127.0f));
     }
   }
+  q_out.set_raw_data(WriteRawDataLittleEndian(codes));
 
   scale_out.elem_type() = TensorProto_DataType_FLOAT;
   scale_out.sizes() = {C, num_blocks};

--- a/onnxsim/passes/quantize_fp16.h
+++ b/onnxsim/passes/quantize_fp16.h
@@ -148,21 +148,23 @@ inline uint16_t FloatToFloat16Bits(float value) {
 }
 
 // Converts a constant float32 tensor of any rank/shape to float16, keeping
-// the same shape. float16 has no dedicated typed field in TensorProto (like
-// INT8/UINT8/etc., its values live in `int32_data`/`Tensor::int32s()`, each
-// entry the 16-bit bit pattern zero-extended to int32 -- see
-// third_party/onnx-optimizer/third_party/onnx/onnx/common/ir_pb_converter.cc's
-// FLOAT16 handling), unlike INT4, which needs the raw_data workaround other
-// onnxsim passes use.
+// the same shape. float16 has no dedicated typed field in TensorProto --
+// like INT8/UINT8/etc., ONNX's wire format allows storing its values in
+// `int32_data`/`Tensor::int32s()` too, each entry the 16-bit bit pattern
+// zero-extended to int32 -- but that costs up to 5x float16's own 2
+// bytes/element (see WriteRawDataLittleEndian's doc comment in
+// endian_read.h), so this packs the bit patterns into raw_data instead, the
+// same as INT4/INT8 do.
 inline Tensor ConvertFloatTensorToFp16(const Tensor& t) {
   const std::vector<float> data = ReadFloatTensorFlat(t);
   Tensor out;
   out.elem_type() = TensorProto_DataType_FLOAT16;
   out.sizes() = t.sizes();
-  out.int32s().resize(data.size());
+  std::vector<uint16_t> bits(data.size());
   for (size_t i = 0; i < data.size(); ++i) {
-    out.int32s()[i] = static_cast<int32_t>(FloatToFloat16Bits(data[i]));
+    bits[i] = FloatToFloat16Bits(data[i]);
   }
+  out.set_raw_data(WriteRawDataLittleEndian(bits));
   return out;
 }
 

--- a/onnxsim/passes/quantize_fp16.h
+++ b/onnxsim/passes/quantize_fp16.h
@@ -215,6 +215,49 @@ struct QuantizeFp16Pass final : public FullGraphBasedPass {
       tryReplacingAllUsesWith(old_v, new_v);
     }
 
+    // 1.5. Every *interior* activation value (every existing node's output --
+    // not yet the boundary Cast nodes steps 2/3 below add, which set their
+    // own output's type explicitly and correctly) now silently computes in
+    // float16 as a side effect of step 1's retyped weights/constants,
+    // exactly as this file's own header comment describes -- but its
+    // declared elemType/shape metadata is whatever an *earlier* pass (e.g.
+    // onnxsim's own shape inference, if this model went through
+    // ``simplify()`` first) set it to, still float32, and this pass never
+    // re-runs shape inference itself to correct it (see the header comment).
+    // Left alone, that stale metadata round-trips into the exported model's
+    // value_info as an outright *wrong* declaration (still float32) for a
+    // tensor the graph now actually produces as float16 -- unlike a merely
+    // *missing* value_info entry, which every conformant consumer (ONNX
+    // Runtime included) is expected to -- and does -- infer for itself, a
+    // wrong one is exactly the kind of type mismatch ONNX Runtime's own
+    // stricter load-time type-checking rejects outright. Clear it rather
+    // than guess a replacement: this pass doesn't model individual ops'
+    // real type-propagation rules (e.g. `Cast`'s output type depends only on
+    // its own `to` attribute, never its input, so blindly relabeling every
+    // float32-declared output float16 here would just trade one wrong
+    // declaration for another), so wiping the stale metadata for every
+    // existing node's float32-declared output is the only *always-correct*
+    // move available without doing full type inference -- whatever
+    // eventually reads this model performs it fresh instead.
+    //
+    // Graph outputs are skipped here even when they coincide with a node's
+    // output (the common case): step 3 below still needs to see each one's
+    // *original* elemType()==FLOAT to decide whether to convert/cast it, and
+    // sets its final type explicitly itself either way.
+    std::unordered_set<std::string> graph_output_names;
+    for (Value* v : graph.outputs()) {
+      graph_output_names.insert(v->uniqueName());
+    }
+    for (Node* n : graph.nodes()) {
+      for (Value* out : n->outputs()) {
+        if (out->elemType() == TensorProto_DataType_FLOAT &&
+            graph_output_names.count(out->uniqueName()) == 0) {
+          out->setElemType(TensorProto_DataType_UNDEFINED);
+          out->wipeSizes();
+        }
+      }
+    }
+
     // 2. Graph inputs.
     for (Value* value : graph.inputs()) {
       if (initializer_names.count(value->uniqueName()) > 0 ||

--- a/onnxsim/passes/quantize_fp8.h
+++ b/onnxsim/passes/quantize_fp8.h
@@ -199,20 +199,20 @@ inline TensorProto_DataType Float8ElemType(Float8Format format) {
 
 // Converts a constant float32 tensor of any rank/shape to `format`, keeping
 // the same shape. Like float16/bfloat16, float8 has no dedicated typed field
-// in TensorProto -- its values live in `int32_data`/`Tensor::int32s()`, each
-// entry the 8-bit bit pattern zero-extended to int32 (see
-// third_party/onnx-optimizer/third_party/onnx/onnx/common/ir_pb_converter.cc,
-// where FLOAT8E4M3FN/FLOAT8E5M2 are handled identically to FLOAT16/
-// BFLOAT16).
+// in TensorProto -- see ConvertFloatTensorToFp16's comment in
+// quantize_fp16.h for why this packs the bit patterns into raw_data (via
+// WriteRawDataLittleEndian, endian_read.h) rather than the far less compact
+// typed `int32_data` field ONNX's wire format also allows for it.
 inline Tensor ConvertFloatTensorToFp8(const Tensor& t, Float8Format format) {
   const std::vector<float> data = ReadFloatTensorFlat(t);
   Tensor out;
   out.elem_type() = Float8ElemType(format);
   out.sizes() = t.sizes();
-  out.int32s().resize(data.size());
+  std::vector<uint8_t> bits(data.size());
   for (size_t i = 0; i < data.size(); ++i) {
-    out.int32s()[i] = static_cast<int32_t>(FloatToFloat8Bits(data[i], format));
+    bits[i] = FloatToFloat8Bits(data[i], format);
   }
+  out.set_raw_data(WriteRawDataLittleEndian(bits));
   return out;
 }
 

--- a/onnxsim/passes/quantize_fp8.h
+++ b/onnxsim/passes/quantize_fp8.h
@@ -267,6 +267,31 @@ struct QuantizeFp8Pass final : public FullGraphBasedPass {
       tryReplacingAllUsesWith(old_v, new_v);
     }
 
+    // 1.5. Clear stale float32 elemType/shape metadata on every existing
+    // node's output (except graph outputs, which step 3 below still needs
+    // to see as FLOAT to decide whether to convert/cast them, and sets
+    // explicitly itself either way) -- see quantize_fp16.h's own step 1.5
+    // for the full rationale: this pass never re-runs shape inference, so a
+    // stale float32 declaration left over from an earlier pass (e.g.
+    // ``simplify()``) would otherwise round-trip into the exported model's
+    // value_info as a wrong type for a tensor now actually `format`, which
+    // ONNX Runtime's own load-time type-checking rejects outright. A
+    // cleared (omitted) value_info entry is always safe -- inferred fresh
+    // by any conformant consumer -- unlike a wrong one.
+    std::unordered_set<std::string> graph_output_names;
+    for (Value* v : graph.outputs()) {
+      graph_output_names.insert(v->uniqueName());
+    }
+    for (Node* n : graph.nodes()) {
+      for (Value* out : n->outputs()) {
+        if (out->elemType() == TensorProto_DataType_FLOAT &&
+            graph_output_names.count(out->uniqueName()) == 0) {
+          out->setElemType(TensorProto_DataType_UNDEFINED);
+          out->wipeSizes();
+        }
+      }
+    }
+
     // 2. Graph inputs.
     for (Value* value : graph.inputs()) {
       if (initializer_names.count(value->uniqueName()) > 0 ||

--- a/onnxsim/passes/quantize_matmul_common.h
+++ b/onnxsim/passes/quantize_matmul_common.h
@@ -152,8 +152,7 @@ inline void QuantizeWeightPerChannelKN(const Tensor& w_t, bool transposed,
   for (int64_t k = 0; k < K; ++k) {
     for (int64_t n = 0; n < N; ++n) {
       const float q = std::round(at(k, n) / scale[n]);
-      codes[k * N + n] =
-          static_cast<int8_t>(std::clamp(q, -127.0f, 127.0f));
+      codes[k * N + n] = static_cast<int8_t>(std::clamp(q, -127.0f, 127.0f));
     }
   }
   q_out.set_raw_data(WriteRawDataLittleEndian(codes));
@@ -205,8 +204,7 @@ inline void QuantizeWeightPerChannelInPlace(const Tensor& w_t,
     for (int64_t j = 0; j < dim1; ++j) {
       const int64_t c = channel_of(i, j);
       const float q = std::round(at(i, j) / scale[c]);
-      codes[i * dim1 + j] =
-          static_cast<int8_t>(std::clamp(q, -127.0f, 127.0f));
+      codes[i * dim1 + j] = static_cast<int8_t>(std::clamp(q, -127.0f, 127.0f));
     }
   }
   q_out.set_raw_data(WriteRawDataLittleEndian(codes));
@@ -504,8 +502,7 @@ inline bool TryQuantizeWeightBlockwiseInt8InPlace(const Tensor& w_t,
     for (int64_t j = 0; j < dim1; ++j) {
       const float s = scale[static_cast<size_t>(scale_index(i, j))];
       const float q = std::round(at(i, j) / s);
-      codes[i * dim1 + j] =
-          static_cast<int8_t>(std::clamp(q, -127.0f, 127.0f));
+      codes[i * dim1 + j] = static_cast<int8_t>(std::clamp(q, -127.0f, 127.0f));
     }
   }
   q_out.set_raw_data(WriteRawDataLittleEndian(codes));

--- a/onnxsim/passes/quantize_matmul_common.h
+++ b/onnxsim/passes/quantize_matmul_common.h
@@ -146,14 +146,17 @@ inline void QuantizeWeightPerChannelKN(const Tensor& w_t, bool transposed,
 
   q_out.elem_type() = TensorProto_DataType_INT8;
   q_out.sizes() = {K, N};
-  q_out.int32s().resize(static_cast<size_t>(K * N));
+  // raw_data, not int32s() -- see WriteRawDataLittleEndian's doc comment in
+  // endian_read.h for why.
+  std::vector<int8_t> codes(static_cast<size_t>(K * N));
   for (int64_t k = 0; k < K; ++k) {
     for (int64_t n = 0; n < N; ++n) {
       const float q = std::round(at(k, n) / scale[n]);
-      q_out.int32s()[k * N + n] =
-          static_cast<int32_t>(std::clamp(q, -127.0f, 127.0f));
+      codes[k * N + n] =
+          static_cast<int8_t>(std::clamp(q, -127.0f, 127.0f));
     }
   }
+  q_out.set_raw_data(WriteRawDataLittleEndian(codes));
 
   scale_out.elem_type() = TensorProto_DataType_FLOAT;
   scale_out.sizes() = {N};
@@ -195,15 +198,18 @@ inline void QuantizeWeightPerChannelInPlace(const Tensor& w_t,
 
   q_out.elem_type() = TensorProto_DataType_INT8;
   q_out.sizes() = {dim0, dim1};
-  q_out.int32s().resize(static_cast<size_t>(dim0 * dim1));
+  // raw_data, not int32s() -- see WriteRawDataLittleEndian's doc comment in
+  // endian_read.h for why.
+  std::vector<int8_t> codes(static_cast<size_t>(dim0 * dim1));
   for (int64_t i = 0; i < dim0; ++i) {
     for (int64_t j = 0; j < dim1; ++j) {
       const int64_t c = channel_of(i, j);
       const float q = std::round(at(i, j) / scale[c]);
-      q_out.int32s()[i * dim1 + j] =
-          static_cast<int32_t>(std::clamp(q, -127.0f, 127.0f));
+      codes[i * dim1 + j] =
+          static_cast<int8_t>(std::clamp(q, -127.0f, 127.0f));
     }
   }
+  q_out.set_raw_data(WriteRawDataLittleEndian(codes));
 
   scale_out.elem_type() = TensorProto_DataType_FLOAT;
   scale_out.sizes() = {C};
@@ -243,15 +249,18 @@ inline void QuantizeWeightPerChannelInPlaceInt16(const Tensor& w_t,
 
   q_out.elem_type() = TensorProto_DataType_INT16;
   q_out.sizes() = {dim0, dim1};
-  q_out.int32s().resize(static_cast<size_t>(dim0 * dim1));
+  // raw_data, not int32s() -- see WriteRawDataLittleEndian's doc comment in
+  // endian_read.h for why.
+  std::vector<int16_t> codes(static_cast<size_t>(dim0 * dim1));
   for (int64_t i = 0; i < dim0; ++i) {
     for (int64_t j = 0; j < dim1; ++j) {
       const int64_t c = channel_of(i, j);
       const float q = std::round(at(i, j) / scale[c]);
-      q_out.int32s()[i * dim1 + j] =
-          static_cast<int32_t>(std::clamp(q, -32767.0f, 32767.0f));
+      codes[i * dim1 + j] =
+          static_cast<int16_t>(std::clamp(q, -32767.0f, 32767.0f));
     }
   }
+  q_out.set_raw_data(WriteRawDataLittleEndian(codes));
 
   scale_out.elem_type() = TensorProto_DataType_FLOAT;
   scale_out.sizes() = {C};
@@ -304,9 +313,11 @@ inline bool TryQuantizeWeightTernaryKN(const Tensor& w_t, bool transposed,
     }
   }
 
-  q_out.elem_type() = TensorProto_DataType_INT8;
-  q_out.sizes() = {K, N};
-  q_out.int32s().resize(static_cast<size_t>(K * N));
+  // raw_data, not int32s() -- see WriteRawDataLittleEndian's doc comment in
+  // endian_read.h for why. Built into a local vector first (rather than
+  // q_out directly) so a not-ternary bail-out below leaves q_out completely
+  // untouched, not just its int32_data half-populated.
+  std::vector<int8_t> codes(static_cast<size_t>(K * N));
   for (int64_t k = 0; k < K; ++k) {
     for (int64_t n = 0; n < N; ++n) {
       const float normalized = at(k, n) / scale[n];
@@ -314,9 +325,13 @@ inline bool TryQuantizeWeightTernaryKN(const Tensor& w_t, bool transposed,
       if (std::fabs(code) > 1.0f || std::fabs(normalized - code) > rtol) {
         return false;  // Not ternary: bail before mutating the caller's q_out.
       }
-      q_out.int32s()[k * N + n] = static_cast<int32_t>(code);
+      codes[k * N + n] = static_cast<int8_t>(code);
     }
   }
+
+  q_out.elem_type() = TensorProto_DataType_INT8;
+  q_out.sizes() = {K, N};
+  q_out.set_raw_data(WriteRawDataLittleEndian(codes));
 
   scale_out.elem_type() = TensorProto_DataType_FLOAT;
   scale_out.sizes() = {N};
@@ -383,15 +398,16 @@ inline bool TryQuantizeWeightBlockwiseInt4InPlace(const Tensor& w_t,
     s = s > 0.0f ? s / 7.0f : 1.0f;
   }
 
-  // Unlike INT8 (whose q_out.int32s() the pb-converter serializes verbatim
-  // into TensorProto.int32_data, one slot per element), ONNX's wire format
-  // packs INT4 two values per byte in raw_data -- low nibble first, i.e.
-  // byte[i] = (code[2i] & 0xF) | ((code[2i+1] & 0xF) << 4), matching
-  // onnx.numpy_helper's _pack_4bitx2 -- and onnxsim's vendored onnx-optimizer
-  // ir_pb_converter has no INT4-aware packing path of its own for the typed
-  // int32_data field, so this builds the packed bytes directly and hands
-  // them to the Tensor via set_raw_data() rather than going through
-  // int32s(). `K % block_size == 0` (checked above) makes `dim0 * dim1`
+  // Unlike INT8 (which, like this function, now also goes to raw_data via
+  // WriteRawDataLittleEndian -- see endian_read.h -- just one whole byte per
+  // element instead of a nibble), ONNX's wire format packs INT4 two values
+  // per byte in raw_data -- low nibble first, i.e. byte[i] = (code[2i] &
+  // 0xF) | ((code[2i+1] & 0xF) << 4), matching onnx.numpy_helper's
+  // _pack_4bitx2 -- and onnxsim's vendored onnx-optimizer ir_pb_converter has
+  // no INT4-aware packing path of its own for the typed int32_data field, so
+  // this builds the packed bytes directly instead of going through a
+  // whole-byte-per-element helper. `K % block_size == 0` (checked above)
+  // makes `dim0 * dim1`
   // always even here (block_size is even), so no odd-count padding byte is
   // needed.
   const int64_t numel = dim0 * dim1;
@@ -436,12 +452,13 @@ inline bool TryQuantizeWeightBlockwiseInt4InPlace(const Tensor& w_t,
 // resolution for channels a single per-channel scale would under-resolve.
 // Used by weight_only_quantize_int8_block_matmul.h.
 //
-// Unlike INT4, INT8 has no dedicated typed field in TensorProto either, but
-// (like INT8/UINT8/INT16/etc. generally) it lives in `int32_data`/
-// `Tensor::int32s()`, not raw_data -- see ConvertFloatTensorToFp16's comment
-// in quantize_fp16.h for the general rule this follows, and contrast with
-// TryQuantizeWeightBlockwiseInt4InPlace's raw_data nibble-packing, which INT8
-// does not need.
+// Like INT4, this packs into raw_data (one whole byte per element, via
+// WriteRawDataLittleEndian -- see endian_read.h) rather than the typed
+// int32_data field, which -- though `int32_data` is a spec-legal field for
+// INT8/UINT8/INT16/etc. too -- costs far more than 1 byte per element there
+// (every varint-encoded entry needing the sign bit takes the field's full 10
+// bytes). Unlike INT4's nibble-packing, INT8 needs no bit-packing of its
+// own: each code is already a whole byte.
 inline bool TryQuantizeWeightBlockwiseInt8InPlace(const Tensor& w_t,
                                                   int64_t channel_axis,
                                                   int64_t block_size,
@@ -480,15 +497,18 @@ inline bool TryQuantizeWeightBlockwiseInt8InPlace(const Tensor& w_t,
 
   q_out.elem_type() = TensorProto_DataType_INT8;
   q_out.sizes() = {dim0, dim1};
-  q_out.int32s().resize(static_cast<size_t>(dim0 * dim1));
+  // raw_data, not int32s() -- see WriteRawDataLittleEndian's doc comment in
+  // endian_read.h for why.
+  std::vector<int8_t> codes(static_cast<size_t>(dim0 * dim1));
   for (int64_t i = 0; i < dim0; ++i) {
     for (int64_t j = 0; j < dim1; ++j) {
       const float s = scale[static_cast<size_t>(scale_index(i, j))];
       const float q = std::round(at(i, j) / s);
-      q_out.int32s()[i * dim1 + j] =
-          static_cast<int32_t>(std::clamp(q, -127.0f, 127.0f));
+      codes[i * dim1 + j] =
+          static_cast<int8_t>(std::clamp(q, -127.0f, 127.0f));
     }
   }
+  q_out.set_raw_data(WriteRawDataLittleEndian(codes));
 
   scale_out.elem_type() = TensorProto_DataType_FLOAT;
   scale_out.sizes() = {scale_dim0, scale_dim1};

--- a/onnxsim/precision_estimator.py
+++ b/onnxsim/precision_estimator.py
@@ -499,3 +499,113 @@ def estimate_quantization_precision(model: onnx.ModelProto) -> List[PrecisionEst
         if est is not None:
             estimates.append(est)
     return estimates
+
+
+# sqrt(12): the standard deviation, in units of the quantization step size Delta,
+# of a uniformly-distributed quantization error in [-Delta/2, Delta/2] -- the
+# textbook uniform-quantizer noise model this module's aggregate error estimate
+# below is built on.
+_UNIFORM_QUANTIZER_NOISE_DIVISOR = 127.0 * math.sqrt(12.0)
+
+
+@dataclass
+class ModelQuantizationEstimate:
+    """A single, whole-model rollup of :func:`estimate_quantization_precision`'s
+    per-node estimates -- see :func:`estimate_model_quantization_drop`."""
+
+    total_nodes_analyzed: int
+    unsafe_nodes: List[str]  # node names failing the int32-accumulator-safe check
+    outlier_risk_nodes: List[str]  # node names flagged outlier_risk=True
+    worst_outlier_ratio: float  # max over all analyzed nodes; nan if none had one
+    estimated_relative_error: float  # see docstring below; nan if any unsafe_nodes
+    risk_level: str  # "unsafe" | "degraded" | "safe"
+    per_node: List[PrecisionEstimate]
+
+
+def estimate_model_quantization_drop(
+    model: onnx.ModelProto,
+) -> ModelQuantizationEstimate:
+    """Aggregates :func:`estimate_quantization_precision`'s per-node estimates
+    into a single whole-model INT8-quantization risk summary and an
+    *estimated* relative-error figure -- purely from the model's static
+    weights and shapes, no execution or calibration data needed. For an
+    actual, data-driven measurement of a specific quantized model's real
+    accuracy drop, see :func:`onnxsim.accuracy.measure_accuracy_drop` instead
+    -- this function is the fast, no-data pre-check; that one is the ground
+    truth.
+
+    ``risk_level``:
+
+    - ``"unsafe"``: at least one MatMul/Gemm/Conv node's reduction depth
+      exceeds the int32-accumulator-safe bound (see this module's docstring,
+      point 1) -- a real correctness bug, not a precision tradeoff.
+      ``estimated_relative_error`` is ``nan`` in this case: an overflowing
+      accumulator's output isn't bounded by any small error term, so no
+      single number would honestly describe it.
+    - ``"degraded"``: no unsafe nodes, but at least one node has a
+      ``max(|w|) / median(|w|)`` outlier ratio past
+      :data:`OUTLIER_RATIO_THRESHOLD` -- INT8 quantization is safe but loses
+      meaningful resolution on that node's typical-magnitude weights.
+    - ``"safe"``: neither of the above.
+
+    ``estimated_relative_error`` (only meaningful when ``risk_level`` is not
+    ``"unsafe"``): a per-node relative RMS quantization-noise estimate, from
+    the standard uniform-quantizer noise model -- a symmetric INT8 quantizer
+    with step ``Delta = max(|w|) / 127`` has quantization error uniformly
+    distributed in ``[-Delta/2, Delta/2]``, whose RMS is ``Delta / sqrt(12)``.
+    Relative to a channel's *typical* (median-magnitude, not peak-magnitude)
+    weight, that RMS error scales by the channel's own outlier ratio ``r =
+    max(|w|) / median(|w|)`` (``r = 1`` when no outlier ratio was computable,
+    e.g. a channel with fewer than two nonzero weights):
+
+        per_node_relative_error = r / (127 * sqrt(12))
+
+    Whole-model ``estimated_relative_error`` combines every analyzed
+    MatMul/Gemm/Conv node's ``per_node_relative_error`` in root-sum-square --
+    the standard back-of-envelope combination for independent noise sources
+    -- as a **heuristic**, not a guarantee: it assumes each node's
+    quantization error behaves as an independent random perturbation that
+    neither compounds multiplicatively through the network's depth nor
+    cancels out, which real networks only approximate. Treat this as a
+    relative ranking/screening signal (worse models get a bigger number),
+    not a certified error bound -- :func:`onnxsim.accuracy.measure_accuracy_drop`
+    is the tool for an actual bound on a specific model and dataset.
+    Attention nodes are excluded from this sum (no weight-quantization error
+    term applies to them in this scheme -- see this module's docstring).
+    """
+    per_node = estimate_quantization_precision(model)
+
+    unsafe_nodes = []
+    outlier_risk_nodes = []
+    outlier_ratios = []
+    squared_errors = []
+    for est in per_node:
+        if isinstance(est, AttentionPrecisionEstimate):
+            continue
+        if not est.int32_accumulator_safe:
+            unsafe_nodes.append(est.node_name)
+            continue
+        if est.outlier_risk:
+            outlier_risk_nodes.append(est.node_name)
+        if not math.isnan(est.max_outlier_ratio):
+            outlier_ratios.append(est.max_outlier_ratio)
+        ratio = est.max_outlier_ratio if not math.isnan(est.max_outlier_ratio) else 1.0
+        per_node_relative_error = ratio / _UNIFORM_QUANTIZER_NOISE_DIVISOR
+        squared_errors.append(per_node_relative_error**2)
+
+    if unsafe_nodes:
+        risk_level = "unsafe"
+        estimated_relative_error = math.nan
+    else:
+        risk_level = "degraded" if outlier_risk_nodes else "safe"
+        estimated_relative_error = math.sqrt(sum(squared_errors))
+
+    return ModelQuantizationEstimate(
+        total_nodes_analyzed=len(per_node),
+        unsafe_nodes=unsafe_nodes,
+        outlier_risk_nodes=outlier_risk_nodes,
+        worst_outlier_ratio=max(outlier_ratios) if outlier_ratios else math.nan,
+        estimated_relative_error=estimated_relative_error,
+        risk_level=risk_level,
+        per_node=per_node,
+    )

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -1,0 +1,204 @@
+"""Tests for ``onnxsim.accuracy`` -- the unified ``QuantizationConfig``/
+``quantize()`` dispatcher and the empirical ``measure_accuracy_drop`` tool.
+
+Models are built directly with ``onnx.helper``. ``measure_accuracy_drop``
+and the ``quantize()``-dispatched calibration-based schemes execute the
+model (through ``onnxsim.backend``, onnxruntime when installed), so this
+mirrors ``test_dynamic_quantize_matmul_integer_to_float.py``'s
+``pytest.importorskip("onnxruntime")`` guard -- a bare ``import
+onnxruntime`` would fail *collection* (not skip the test) on a platform
+onnxruntime doesn't ship wheels for.
+"""
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+
+import onnxsim
+from onnxsim.accuracy import AccuracyDropReport, OutputAccuracyStats
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(np.asarray(array, dtype=np.float32), name)
+
+
+def _linear_model(K=64, N=32, opset=21, seed=0):
+    rng = np.random.default_rng(seed)
+    w = _f32(rng.standard_normal((K, N)) * 0.3, "W")
+    b = _f32(rng.standard_normal(N) * 0.1, "B")
+    nodes = [
+        onnx.helper.make_node("MatMul", ["X", "W"], ["mm"]),
+        onnx.helper.make_node("Add", ["mm", "B"], ["Y"]),
+    ]
+    graph = onnx.helper.make_graph(
+        nodes, "g", [_vi("X", [4, K])], [_vi("Y", [4, N])], [w, b]
+    )
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+    )
+
+
+# --------------------------------------------------------------------------- #
+# QuantizationConfig / quantize() dispatcher
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "config,expected_new_op",
+    [
+        (onnxsim.QuantizationConfig(scheme="dynamic"), "DynamicQuantizeLinear"),
+        (
+            onnxsim.QuantizationConfig(scheme="dynamic_fused"),
+            "MatMulIntegerToFloat",
+        ),
+        (
+            onnxsim.QuantizationConfig(scheme="weight_only", dtype="int8"),
+            "DequantizeLinear",
+        ),
+        (
+            onnxsim.QuantizationConfig(
+                scheme="weight_only", dtype="int8", granularity="per_block"
+            ),
+            "DequantizeLinear",
+        ),
+        (
+            onnxsim.QuantizationConfig(scheme="weight_only", dtype="int16"),
+            "DequantizeLinear",
+        ),
+        (
+            onnxsim.QuantizationConfig(scheme="weight_only", dtype="int4"),
+            "DequantizeLinear",
+        ),
+        (onnxsim.QuantizationConfig(scheme="static"), "QuantizeLinear"),
+        (
+            onnxsim.QuantizationConfig(scheme="static_int16", dtype="int16"),
+            "QuantizeLinear",
+        ),
+        (onnxsim.QuantizationConfig(scheme="qoperator"), "QLinearMatMul"),
+        (onnxsim.QuantizationConfig(scheme="float", dtype="float16"), "Cast"),
+        (onnxsim.QuantizationConfig(scheme="float", dtype="bfloat16"), "Cast"),
+        (onnxsim.QuantizationConfig(scheme="float", dtype="float8_e4m3"), "Cast"),
+        (onnxsim.QuantizationConfig(scheme="float", dtype="float8_e5m2"), "Cast"),
+    ],
+)
+def test_quantize_dispatches_every_scheme(config, expected_new_op):
+    # weight_only/int4 needs a reduction depth divisible by 32; every other
+    # scheme is happy with the same K=64.
+    model = _linear_model(K=64, N=32)
+    quantized = onnxsim.quantize(model, config)
+    onnx.checker.check_model(quantized)
+    ops = {n.op_type for n in quantized.graph.node}
+    assert expected_new_op in ops
+
+
+def test_quantize_ternary_scheme_dispatches_and_is_a_noop_on_non_ternary_weight():
+    model = _linear_model(K=64, N=32)
+    quantized = onnxsim.quantize(model, onnxsim.QuantizationConfig(scheme="ternary"))
+    onnx.checker.check_model(quantized)
+    # The weight isn't structurally ternary, so the pass declines -- still a
+    # valid dispatch, just a no-op rewrite.
+    assert {n.op_type for n in quantized.graph.node} == {"MatMul", "Add"}
+
+
+def test_quantize_unknown_scheme_raises_value_error():
+    model = _linear_model()
+    with pytest.raises(ValueError, match="unknown QuantizationConfig.scheme"):
+        onnxsim.quantize(model, onnxsim.QuantizationConfig(scheme="not-a-scheme"))
+
+
+def test_quantize_invalid_dtype_for_scheme_raises_value_error():
+    model = _linear_model()
+    with pytest.raises(ValueError, match="does not support dtype"):
+        onnxsim.quantize(
+            model, onnxsim.QuantizationConfig(scheme="dynamic", dtype="int16")
+        )
+
+
+def test_quantize_invalid_granularity_raises_value_error():
+    model = _linear_model()
+    with pytest.raises(ValueError, match="granularity"):
+        onnxsim.quantize(
+            model,
+            onnxsim.QuantizationConfig(
+                scheme="weight_only", dtype="int8", granularity="bogus"
+            ),
+        )
+
+
+def test_quantize_static_passes_through_calibration_settings():
+    model = _linear_model(K=8, N=4)
+    rng = np.random.default_rng(5)
+    calibration_data = [{"X": rng.standard_normal((4, 8)).astype(np.float32)}]
+    quantized = onnxsim.quantize(
+        model,
+        onnxsim.QuantizationConfig(
+            scheme="static",
+            calibration_data=calibration_data,
+            calibration_method="minmax",
+        ),
+    )
+    onnx.checker.check_model(quantized)
+    assert "QuantizeLinear" in {n.op_type for n in quantized.graph.node}
+
+
+# --------------------------------------------------------------------------- #
+# measure_accuracy_drop
+# --------------------------------------------------------------------------- #
+def test_measure_accuracy_drop_reports_small_but_nonzero_error_for_int8():
+    model = _linear_model(K=64, N=32)
+    quantized = onnxsim.quantize_dynamic(model)
+
+    report = onnxsim.measure_accuracy_drop(model, quantized, num_samples=16, seed=1)
+    assert isinstance(report, AccuracyDropReport)
+    assert report.num_samples == 16
+    assert set(report.per_output) == {"Y"}
+    stats = report.per_output["Y"]
+    assert isinstance(stats, OutputAccuracyStats)
+    # INT8 quantization is lossy but should stay well within a coarse bound
+    # for a small, well-conditioned random matrix.
+    assert 0.0 < report.worst_relative_l2 < 0.2
+    assert report.worst_cosine_distance < 0.1
+    assert report.all_finite
+
+
+def test_measure_accuracy_drop_identity_quantization_is_exact():
+    # "Quantizing" with fp16 keep_io_types=True and then immediately casting
+    # back is not exact, but comparing a model against *itself* must report
+    # exactly zero error -- a basic sanity check on the metric plumbing.
+    model = _linear_model(K=16, N=4)
+    report = onnxsim.measure_accuracy_drop(model, model, num_samples=4, seed=2)
+    assert report.worst_relative_l2 == 0.0
+    assert report.worst_cosine_distance == 0.0
+    assert report.all_finite
+
+
+def test_measure_accuracy_drop_casts_inputs_for_keep_io_types_false():
+    # fp16 with keep_io_types=False redeclares the graph's own inputs as
+    # float16 -- the float32 calibration data must be auto-cast to match, or
+    # the quantized model's session would reject it outright.
+    model = _linear_model(K=16, N=4)
+    quantized = onnxsim.quantize_fp16(model, keep_io_types=False)
+    assert quantized.graph.input[0].type.tensor_type.elem_type == (
+        onnx.TensorProto.FLOAT16
+    )
+
+    report = onnxsim.measure_accuracy_drop(model, quantized, num_samples=4, seed=3)
+    assert report.worst_relative_l2 < 0.01
+    assert report.all_finite
+
+
+def test_measure_accuracy_drop_uses_supplied_calibration_data():
+    model = _linear_model(K=8, N=4)
+    quantized = onnxsim.quantize_dynamic(model)
+    calibration_data = [{"X": np.ones((4, 8), dtype=np.float32)}]
+
+    report = onnxsim.measure_accuracy_drop(
+        model, quantized, calibration_data=calibration_data
+    )
+    assert report.num_samples == 1

--- a/tests/test_precision_estimator.py
+++ b/tests/test_precision_estimator.py
@@ -16,6 +16,7 @@ import onnxsim
 from onnxsim.precision_estimator import (
     MAX_EXACT_FLOAT32_REDUCTION_DEPTH,
     MAX_SAFE_INT32_REDUCTION_DEPTH,
+    OUTLIER_RATIO_THRESHOLD,
     AttentionPrecisionEstimate,
     ConvPrecisionEstimate,
     MatMulGemmPrecisionEstimate,
@@ -254,3 +255,94 @@ def test_never_modifies_the_model():
     before = model.SerializeToString()
     onnxsim.estimate_quantization_precision(model)
     assert model.SerializeToString() == before
+
+
+# --------------------------------------------------------------------------- #
+# estimate_model_quantization_drop -- whole-model aggregate
+# --------------------------------------------------------------------------- #
+def test_model_drop_safe_with_no_outliers():
+    # Every weight has the exact same magnitude (alternating sign), so each
+    # channel's max(|w|)/median(|w|) outlier ratio is exactly 1 -- the
+    # uniform-quantizer-noise baseline case, with no outlier-driven penalty.
+    K, N = 16, 4
+    weight = np.tile([0.1, -0.1], (K // 2, N)).astype(np.float32)
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [1, K])], [_vi("Y", [1, N])], [_f32(weight, "W")])
+
+    est = onnxsim.estimate_model_quantization_drop(model)
+    assert est.total_nodes_analyzed == 1
+    assert est.unsafe_nodes == []
+    assert est.outlier_risk_nodes == []
+    assert est.risk_level == "safe"
+    assert math.isclose(est.worst_outlier_ratio, 1.0, rel_tol=1e-9)
+    # The uniform-quantizer-noise baseline (ratio=1): a single analyzed
+    # node's relative error is exactly 1 / (127 * sqrt(12)).
+    assert math.isclose(
+        est.estimated_relative_error, 1.0 / (127.0 * math.sqrt(12.0)), rel_tol=1e-9
+    )
+
+
+def test_model_drop_degraded_when_outlier_channel_present():
+    K, N = 32, 2
+    rng = np.random.default_rng(21)
+    weight = rng.standard_normal((K, N)).astype(np.float32) * 0.05
+    weight[:, 1] = 0.01
+    weight[0, 1] = 10.0  # channel 1: a single extreme outlier
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [1, K])], [_vi("Y", [1, N])], [_f32(weight, "W")])
+
+    est = onnxsim.estimate_model_quantization_drop(model)
+    assert est.risk_level == "degraded"
+    assert est.outlier_risk_nodes == [est.per_node[0].node_name]
+    assert est.unsafe_nodes == []
+    assert est.worst_outlier_ratio > OUTLIER_RATIO_THRESHOLD
+    # A node with a big outlier ratio must dominate the aggregate error over
+    # the safe/no-outlier baseline case.
+    assert est.estimated_relative_error > 1.0 / (127.0 * math.sqrt(12.0))
+
+
+def test_model_drop_unsafe_reports_nan_error_and_lists_the_node():
+    k = MAX_SAFE_INT32_REDUCTION_DEPTH + 1
+    weight = _f32(np.random.default_rng(22).standard_normal((k, 1)) * 0.01, "W")
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [1, k])], [_vi("Y", [1, 1])], [weight])
+
+    est = onnxsim.estimate_model_quantization_drop(model)
+    assert est.risk_level == "unsafe"
+    assert est.unsafe_nodes == [est.per_node[0].node_name]
+    assert math.isnan(est.estimated_relative_error)
+
+
+def test_model_drop_more_unsafe_nodes_widen_the_aggregate_error():
+    # Two safe nodes (independent noise, root-sum-square) must report a
+    # bigger aggregate error than either alone.
+    rng = np.random.default_rng(23)
+    K, N = 16, 4
+    w1 = _f32(rng.standard_normal((K, N)) * 0.1, "W1")
+    w2 = _f32(rng.standard_normal((K, N)) * 0.1, "W2")
+    nodes = [
+        onnx.helper.make_node("MatMul", ["X", "W1"], ["Y1"]),
+        onnx.helper.make_node("MatMul", ["X", "W2"], ["Y2"]),
+    ]
+    model = _model(
+        nodes, [_vi("X", [1, K])], [_vi("Y1", [1, N]), _vi("Y2", [1, N])], [w1, w2]
+    )
+    one_node_model = _model([nodes[0]], [_vi("X", [1, K])], [_vi("Y1", [1, N])], [w1])
+
+    est_two = onnxsim.estimate_model_quantization_drop(model)
+    est_one = onnxsim.estimate_model_quantization_drop(one_node_model)
+    assert est_two.total_nodes_analyzed == 2
+    assert est_two.estimated_relative_error > est_one.estimated_relative_error
+
+
+def test_model_drop_no_analyzable_nodes_is_safe_with_zero_error():
+    model = _model(
+        [onnx.helper.make_node("Relu", ["X"], ["Y"])],
+        [_vi("X", [1, 4])],
+        [_vi("Y", [1, 4])],
+        [],
+    )
+    est = onnxsim.estimate_model_quantization_drop(model)
+    assert est.total_nodes_analyzed == 0
+    assert est.risk_level == "safe"
+    assert est.estimated_relative_error == 0.0

--- a/tests/test_quantize_bf16.py
+++ b/tests/test_quantize_bf16.py
@@ -28,6 +28,7 @@ import numpy as np
 import onnx
 import onnx.helper
 import onnx.numpy_helper
+import onnx.shape_inference
 import pytest
 
 import onnxsim
@@ -206,6 +207,28 @@ def test_quantize_bf16_skips_optional_input_default_initializer():
     onnx.checker.check_model(quant)
     w_init = quant.graph.initializer[0]
     assert w_init.data_type == onnx.TensorProto.FLOAT  # untouched
+
+
+def test_quantize_bf16_clears_stale_value_info_on_already_shape_inferred_model():
+    # Same regression as test_quantize_fp16.py's identically-named test: a
+    # model that already went through shape inference has its interior
+    # activations' value_info pre-populated float32, and quantize_bf16 (like
+    # quantize_fp16) doesn't re-run shape inference itself, so it must not
+    # leave that now-wrong float32 declaration in place -- a real bug found
+    # via a real torchvision model. No onnxruntime.InferenceSession run here
+    # (CPU EP has no bfloat16 MatMul/Relu kernel, see this file's module
+    # docstring) -- the value_info correctness itself is the check.
+    model, rng, k, n2 = _two_matmul_model()
+    model = onnx.shape_inference.infer_shapes(model)
+    h_before = next(vi for vi in model.graph.value_info if vi.name == "H")
+    assert h_before.type.tensor_type.elem_type == onnx.TensorProto.FLOAT
+
+    quant = onnxsim.quantize_bf16(model)
+    onnx.checker.check_model(quant)
+
+    h_after = next((vi for vi in quant.graph.value_info if vi.name == "H"), None)
+    if h_after is not None:
+        assert h_after.type.tensor_type.elem_type != onnx.TensorProto.FLOAT
 
 
 def test_quantize_bf16_boundary_casts_execute():

--- a/tests/test_quantize_fp16.py
+++ b/tests/test_quantize_fp16.py
@@ -14,6 +14,7 @@ import numpy as np
 import onnx
 import onnx.helper
 import onnx.numpy_helper
+import onnx.shape_inference
 import pytest
 
 import onnxsim
@@ -203,3 +204,37 @@ def test_quantize_fp16_skips_optional_input_default_initializer():
     onnx.checker.check_model(quant)
     w_init = quant.graph.initializer[0]
     assert w_init.data_type == onnx.TensorProto.FLOAT  # untouched
+
+
+def test_quantize_fp16_clears_stale_value_info_on_already_shape_inferred_model():
+    # A model that already went through shape inference (e.g. onnxsim's own
+    # simplify(), or just onnx.shape_inference.infer_shapes() directly, as
+    # here) has its interior activations' value_info pre-populated float32.
+    # quantize_fp16 doesn't re-run shape inference itself (see the file's own
+    # doc comment), so it must not leave that now-wrong float32 declaration
+    # in place for a tensor the graph actually produces as float16 -- ONNX
+    # Runtime's own load-time type-checking rejects a model with a *wrong*
+    # value_info outright (unlike a merely absent one, which every conformant
+    # consumer infers fresh). This was a real bug: found by running a real
+    # torchvision model (already simplify()'d) through quantize_fp16 and
+    # onnxruntime.InferenceSession.
+    model, rng, k, n2 = _two_matmul_model()
+    model = onnx.shape_inference.infer_shapes(model)
+    # Sanity: shape inference actually populated a float32 value_info for the
+    # interior activation "H" (or this test would not exercise the bug).
+    h_before = next(vi for vi in model.graph.value_info if vi.name == "H")
+    assert h_before.type.tensor_type.elem_type == onnx.TensorProto.FLOAT
+
+    quant = onnxsim.quantize_fp16(model)
+    onnx.checker.check_model(quant)
+
+    # No value_info entry for "H" may declare it float32 anymore -- either
+    # it's absent (cleared, the expected outcome) or correctly float16.
+    h_after = next((vi for vi in quant.graph.value_info if vi.name == "H"), None)
+    if h_after is not None:
+        assert h_after.type.tensor_type.elem_type != onnx.TensorProto.FLOAT
+
+    # The real regression check: ONNX Runtime must actually load and run the
+    # quantized model, not just pass the (more lenient) checker.
+    x = rng.standard_normal((4, k)).astype(np.float32)
+    _assert_close(_run(model, {"X": x}), _run(quant, {"X": x}))

--- a/tests/test_quantize_fp8.py
+++ b/tests/test_quantize_fp8.py
@@ -32,6 +32,7 @@ import numpy as np
 import onnx
 import onnx.helper
 import onnx.numpy_helper
+import onnx.shape_inference
 import pytest
 
 import onnxsim
@@ -267,6 +268,29 @@ def test_quantize_fp8_skips_optional_input_default_initializer():
     onnx.checker.check_model(quant)
     w_init = quant.graph.initializer[0]
     assert w_init.data_type == onnx.TensorProto.FLOAT  # untouched
+
+
+def test_quantize_fp8_clears_stale_value_info_on_already_shape_inferred_model():
+    # Same regression as test_quantize_fp16.py's identically-named test: a
+    # model that already went through shape inference has its interior
+    # activations' value_info pre-populated float32, and quantize_fp8 (like
+    # quantize_fp16/quantize_bf16) doesn't re-run shape inference itself, so
+    # it must not leave that now-wrong float32 declaration in place -- a real
+    # bug found via a real torchvision model. No onnxruntime.InferenceSession
+    # run here (float8 compute kernel coverage on CPUExecutionProvider is
+    # narrow, see this file's module docstring) -- the value_info correctness
+    # itself is the check.
+    model, rng, k, n2 = _two_matmul_model()
+    model = onnx.shape_inference.infer_shapes(model)
+    h_before = next(vi for vi in model.graph.value_info if vi.name == "H")
+    assert h_before.type.tensor_type.elem_type == onnx.TensorProto.FLOAT
+
+    quant = onnxsim.quantize_fp8(model)
+    onnx.checker.check_model(quant)
+
+    h_after = next((vi for vi in quant.graph.value_info if vi.name == "H"), None)
+    if h_after is not None:
+        assert h_after.type.tensor_type.elem_type != onnx.TensorProto.FLOAT
 
 
 def test_quantize_fp8_boundary_casts_execute():


### PR DESCRIPTION
## Summary

Adds two complementary pieces of "formalized" quantization tooling, per user request:

**Unified quantization parameters** — `onnxsim.QuantizationConfig` / `onnxsim.quantize` (new `onnxsim/accuracy.py`): a single typed config dataclass (`scheme`, `dtype`, `granularity`, calibration settings) that dispatches to the right one of onnxsim's dozen-plus existing `quantize_*` functions. This doesn't replace any of those — each remains directly callable and documented as before — it adds a second, unified entry point for code that picks a scheme programmatically (a sweep over configs, a config file, a CLI flag) rather than calling a specific function by name. See `docs/quantization-config.md` for the full scheme/dtype/granularity matrix.

**Formalized accuracy drop**, at two layers (per user's "both, layered" preference):
- `onnxsim.estimate_model_quantization_drop` (extends `precision_estimator.py`): rolls up the existing `estimate_quantization_precision`'s per-node estimates into a single whole-model `risk_level` (`unsafe`/`degraded`/`safe`) and an `estimated_relative_error` figure, from the standard uniform-quantizer noise model (RMS error = Δ/√12) combined in root-sum-square across nodes. No execution or data needed — documented explicitly as a heuristic screening signal, not a certified bound.
- `onnxsim.measure_accuracy_drop` (new, in `accuracy.py`): actually runs a float model and a quantized version of it on the same input data (via the existing `onnxsim.backend.run_model`) and reports worst-case-over-samples relative L2 error, max abs error, and cosine similarity per output — the data-driven ground truth counterpart to the static estimate.

Both accuracy tools are pure Python with no C++/pybind component, built entirely on existing infrastructure (`backend.run_model`, `generate_random_calibration_data`) — no C++ rebuild needed to use or test them.

## Test plan

- `tests/test_accuracy.py` (new): covers every scheme/dtype/granularity combination the dispatcher supports (14 parametrized cases), invalid-combo error messages (unknown scheme, wrong dtype for scheme, invalid granularity), calibration-setting pass-through, and `measure_accuracy_drop` (including its `keep_io_types=False` input auto-cast, an identity-quantization sanity check, and supplied-vs-generated calibration data).
- `tests/test_precision_estimator.py`: adds coverage for the new aggregate's three risk levels (safe/degraded/unsafe) and its root-sum-square error composition (more analyzed nodes widen the aggregate error).
- Full existing suite: `pytest tests/ --ignore=tests/test_gan.py --ignore=tests/test_python_api.py --ignore=tests/test_simple.py --ignore=tests/test_timm.py` → 369 passed, 65 skipped, no regressions.
- `ruff check` / `ruff format --check` clean on all touched/new Python.
- `mypy onnxsim` shows the same 11 pre-existing errors (all in unrelated files) and zero new errors in `accuracy.py`/`precision_estimator.py`.
- Manually verified end-to-end against a real model: all 14 scheme/dtype/granularity combos produce checker-passing models; the static aggregate and empirical measurement both produce sensible, mutually-consistent numbers (e.g. INT8 dynamic quantization measuring ~1.1% relative L2 error vs. fp16's ~0.05%, as expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_