### PR TITLE
Port precision_estimator.py's INT8 risk analysis to C++, wire into WASM UI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,7 @@ set(ONNXSIM_BLAKE3_COMPILE_DEFS
     BLAKE3_NO_SSE2 BLAKE3_NO_SSE41 BLAKE3_NO_AVX2 BLAKE3_NO_AVX512
     BLAKE3_USE_NEON=0)
 
-add_library(onnxsim onnxsim/onnxsim.cpp onnxsim/constant_folding.cpp onnxsim/partial_shape_eval.cpp onnxsim/model_prep.cpp onnxsim/quantize_entry.cpp onnxsim/contrib_schemas.cpp onnxsim/custom_optimizer_passes.cpp onnxsim/function_rewriter.cpp onnxsim/profiler.cpp onnxsim/model_info.cpp onnxsim/sym_expr.cpp onnxsim/sym_value_eval.cpp onnxsim/sym_shape_infer.cpp onnxsim/model_metrics.cpp onnxsim/tensor_pool.cpp onnxsim/tensor_pool_gguf.cpp onnxsim/tensor_pool_hash.cpp ${ONNXSIM_BLAKE3_SOURCES})
+add_library(onnxsim onnxsim/onnxsim.cpp onnxsim/constant_folding.cpp onnxsim/partial_shape_eval.cpp onnxsim/model_prep.cpp onnxsim/quantize_entry.cpp onnxsim/contrib_schemas.cpp onnxsim/custom_optimizer_passes.cpp onnxsim/function_rewriter.cpp onnxsim/profiler.cpp onnxsim/model_info.cpp onnxsim/sym_expr.cpp onnxsim/sym_value_eval.cpp onnxsim/sym_shape_infer.cpp onnxsim/model_metrics.cpp onnxsim/precision_estimator.cpp onnxsim/tensor_pool.cpp onnxsim/tensor_pool_gguf.cpp onnxsim/tensor_pool_hash.cpp ${ONNXSIM_BLAKE3_SOURCES})
 target_compile_definitions(onnxsim PRIVATE ${ONNXSIM_BLAKE3_COMPILE_DEFS})
 if (ONNXSIM_BUILTIN_ORT)
   # Both ways of obtaining ONNX Runtime ship/install headers flat under this
@@ -534,6 +534,14 @@ if (ONNXSIM_TESTS)
   target_link_libraries(tensor_pool_bridge_test onnxsim)
   onnxsim_add_ort_rpath(tensor_pool_bridge_test)
   add_test(NAME tensor_pool_bridge_test COMMAND tensor_pool_bridge_test)
+
+  # precision_estimator.{h,cpp} needs onnx (ModelProto/shape inference), like
+  # tensor_pool_bridge_test above -- links the fully-configured `onnxsim`
+  # target rather than building standalone.
+  add_executable(precision_estimator_test onnxsim/precision_estimator_test.cpp)
+  target_link_libraries(precision_estimator_test onnxsim)
+  onnxsim_add_ort_rpath(precision_estimator_test)
+  add_test(NAME precision_estimator_test COMMAND precision_estimator_test)
 
   # The ONNX<->GGML dtype mapping (gguf_dtype.h), mirroring
   # tensor_pool_dtype_test.cpp above for the same reason.

--- a/docs/precision-estimation.md
+++ b/docs/precision-estimation.md
@@ -2,19 +2,24 @@
 
 ## What this is
 
-`onnxsim.estimate_quantization_precision` is a pure-Python, read-only
-analysis (`onnxsim/precision_estimator.py`) that answers a narrower version of
-"is INT8 safe here?" than actually running the model: given only a node's
-**constant weight values** and its **shape hyperparameters** (the reduction
-depth for MatMul/Gemm, `Cin/groups * kernel-volume` for Conv, `num_heads` /
-`head_dim` for Attention), it estimates whether the INT8 scheme
-`onnxsim.quantize_dynamic`/`quantize_static` apply (see
-[dynamic-quantization.md](dynamic-quantization.md)) is numerically safe and
-well-resolved for that node — without executing the model or needing
-calibration data.
+`onnxsim.estimate_quantization_precision` is a read-only analysis that
+answers a narrower version of "is INT8 safe here?" than actually running the
+model: given only a node's **constant weight values** and its **shape
+hyperparameters** (the reduction depth for MatMul/Gemm, `Cin/groups *
+kernel-volume` for Conv, `num_heads` / `head_dim` for Attention), it
+estimates whether the INT8 scheme `onnxsim.quantize_dynamic`/`quantize_static`
+apply (see [dynamic-quantization.md](dynamic-quantization.md)) is numerically
+safe and well-resolved for that node — without executing the model or
+needing calibration data.
 
-It never modifies the model, has no C++/pybind component, and does not
-require building onnxsim's C++ extension.
+It never modifies the model. The analysis itself runs in C++
+(`onnxsim/precision_estimator.h`/`.cpp`) — the same implementation the WASM
+converter demo's "Check quantization risk" button calls into
+(`scripts/convertmodel/interface.cpp`), so the algorithm exists in exactly
+one place rather than a separate Python and C++ copy. `onnxsim/precision_estimator.py`
+is a thin wrapper that reconstructs the dataclasses documented below from the
+compiled extension's result, so this needs onnxsim's C++ extension built
+(the normal case for any `pip install onnxsim` / built-from-source install).
 
 ```python
 import onnx

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -14,7 +14,9 @@
 #include <nanobind/trampoline.h>
 
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <unordered_map>
@@ -28,6 +30,7 @@
 #include "onnx/proto_utils.h"
 #include "onnxoptimizer/optimize.h"
 #include "onnxsim.h"
+#include "precision_estimator.h"
 #include "tensor_pool.h"
 #include "tensor_pool_bridge.h"
 #include "tensor_pool_gguf_bridge.h"
@@ -882,6 +885,89 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
         return py::bytes(out.data(), out.size());
       },
       "model_bytes"_a, "format"_a = "e4m3", "keep_io_types"_a = true);
+
+  // Static, calibration-free INT8-quantization risk analysis -- the single
+  // C++ implementation (onnxsim/precision_estimator.{h,cpp}) that both this
+  // Python binding and the WASM UI (scripts/convertmodel/interface.cpp) call
+  // into, so the algorithm exists in exactly one place rather than two
+  // (Python used to carry its own parallel implementation). The Python-facing
+  // ``onnxsim.precision_estimator`` module is a thin wrapper that reconstructs
+  // its public dataclasses from the tuples returned here; see that module's
+  // docstring. Each weight-estimate tuple is (node_name, op_type,
+  // reduction_depth, num_channels, int32_accumulator_safe, float32_cast_exact,
+  // max_outlier_ratio, outlier_risk, activation_producer_op,
+  // activation_range_lo, activation_range_hi, recommendation) -- the last
+  // three fields are None together (no known range) or all present. Each
+  // attention-estimate tuple is (node_name, num_query_heads, num_kv_heads,
+  // head_dim, default_scale, actual_scale, scale_matches_default,
+  // recommendation).
+  m.def(
+      "_estimate_model_quantization_drop",
+      [](const py::bytes& model_proto_bytes) {
+        ONNX_NAMESPACE::ModelProto model;
+        ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
+                            model_proto_bytes.size());
+        const onnxsim::ModelQuantizationEstimate est =
+            onnxsim::EstimateModelQuantizationDrop(model);
+
+        using WeightTuple =
+            std::tuple<std::string, std::string, int64_t, int64_t, bool, bool,
+                       double, bool, std::optional<std::string>,
+                       std::optional<double>, std::optional<double>,
+                       std::string>;
+        std::vector<WeightTuple> weight_estimates;
+        weight_estimates.reserve(est.weight_estimates.size());
+        for (const auto& w : est.weight_estimates) {
+          weight_estimates.emplace_back(
+              w.node_name, w.op_type, w.reduction_depth, w.num_channels,
+              w.int32_accumulator_safe, w.float32_cast_exact,
+              w.max_outlier_ratio, w.outlier_risk,
+              w.activation_producer_op.empty()
+                  ? std::nullopt
+                  : std::optional<std::string>(w.activation_producer_op),
+              w.has_activation_range
+                  ? std::optional<double>(w.activation_range_lo)
+                  : std::nullopt,
+              w.has_activation_range
+                  ? std::optional<double>(w.activation_range_hi)
+                  : std::nullopt,
+              w.recommendation);
+        }
+
+        using AttentionTuple =
+            std::tuple<std::string, std::optional<int64_t>,
+                       std::optional<int64_t>, std::optional<int64_t>,
+                       std::optional<double>, std::optional<double>,
+                       std::optional<bool>, std::string>;
+        std::vector<AttentionTuple> attention_estimates;
+        attention_estimates.reserve(est.attention_estimates.size());
+        for (const auto& a : est.attention_estimates) {
+          attention_estimates.emplace_back(
+              a.node_name,
+              a.has_num_query_heads ? std::optional<int64_t>(a.num_query_heads)
+                                    : std::nullopt,
+              a.has_num_kv_heads ? std::optional<int64_t>(a.num_kv_heads)
+                                 : std::nullopt,
+              a.has_head_dim ? std::optional<int64_t>(a.head_dim)
+                             : std::nullopt,
+              std::isnan(a.default_scale)
+                  ? std::nullopt
+                  : std::optional<double>(a.default_scale),
+              std::isnan(a.actual_scale)
+                  ? std::nullopt
+                  : std::optional<double>(a.actual_scale),
+              a.scale_matches_default < 0
+                  ? std::nullopt
+                  : std::optional<bool>(a.scale_matches_default != 0),
+              a.recommendation);
+        }
+
+        return std::make_tuple(est.total_nodes_analyzed, est.unsafe_nodes,
+                               est.outlier_risk_nodes, est.worst_outlier_ratio,
+                               est.estimated_relative_error, est.risk_level,
+                               weight_estimates, attention_estimates);
+      },
+      "model_bytes"_a);
 
   m.def(
        "simplify",

--- a/onnxsim/precision_estimator.cpp
+++ b/onnxsim/precision_estimator.cpp
@@ -1,0 +1,602 @@
+#include "precision_estimator.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <optional>
+#include <sstream>
+#include <unordered_map>
+
+#include "dlpack_dtype.h"
+#include "onnx/shape_inference/implementation.h"
+
+namespace onnxsim {
+namespace {
+
+// INT32_MAX // (127 * 255) -- see precision_estimator.py's docstring, point
+// 1. A literal formula, not a hardcoded constant, so it stays obviously in
+// sync with passes/quantize_matmul_common.h's MaxSafeInt32ReductionDepth(),
+// which onnxsim.quantize_dynamic actually enforces -- exactly the same
+// reasoning the Python module gives for the same choice.
+constexpr int64_t MaxSafeInt32ReductionDepth() {
+  return (std::numeric_limits<int32_t>::max()) / (127 * 255);
+}
+
+// An 8-bit symmetric quantizer has floor(127) positive levels (scale =
+// max|w| / 127); a channel's max(|w|) / median(|w|) ratio past this leaves
+// its median-magnitude weight within one quantization step of zero.
+constexpr double kOutlierRatioThreshold = 127.0;
+
+// See precision_estimator.py's MAX_EXACT_FLOAT32_REDUCTION_DEPTH docstring.
+constexpr int64_t MaxExactFloat32ReductionDepth() {
+  return (int64_t{1} << 24) / (127 * 255);
+}
+
+// sqrt(12): see precision_estimator.py's _UNIFORM_QUANTIZER_NOISE_DIVISOR.
+const double kUniformQuantizerNoiseDivisor = 127.0 * std::sqrt(12.0);
+
+// Ops whose output range is fixed by the op itself, for any input -- not a
+// property of the data, so it needs no calibration run to know. See
+// precision_estimator.py's FIXED_ACTIVATION_RANGES.
+const std::unordered_map<std::string, std::pair<double, double>>&
+FixedActivationRanges() {
+  static const std::unordered_map<std::string, std::pair<double, double>> kMap = {
+      {"Sigmoid", {0.0, 1.0}},
+      {"HardSigmoid", {0.0, 1.0}},
+      {"Tanh", {-1.0, 1.0}},
+      {"Softmax", {0.0, 1.0}},
+  };
+  return kMap;
+}
+
+// Reads a FLOAT TensorProto's values into a flat, host-order vector,
+// regardless of whether it is stored as raw bytes (little-endian on the wire
+// regardless of host) or the typed float_data field (already host-order,
+// decoded by protobuf itself). Returns an empty vector for any other dtype.
+std::vector<float> ReadFloatTensorFlat(const onnx::TensorProto& t) {
+  if (t.data_type() != onnx::TensorProto_DataType_FLOAT) {
+    return {};
+  }
+  if (t.has_raw_data()) {
+    const std::string& raw = t.raw_data();
+    const size_t n = raw.size() / sizeof(float);
+    std::vector<float> out(n);
+    std::memcpy(out.data(), raw.data(), n * sizeof(float));
+    if constexpr (!onnxsim::dlpack::kRawDataIsHostOrder) {
+      onnxsim::dlpack::SwapElementBytes(
+          reinterpret_cast<uint8_t*>(out.data()), out.size() * sizeof(float),
+          sizeof(float));
+    }
+    return out;
+  }
+  return {t.float_data().begin(), t.float_data().end()};
+}
+
+int64_t GetAttrInt(const onnx::NodeProto& node, const std::string& name,
+                   int64_t dflt) {
+  for (const auto& attr : node.attribute()) {
+    if (attr.name() == name) {
+      return attr.i();
+    }
+  }
+  return dflt;
+}
+
+std::optional<double> GetAttrFloat(const onnx::NodeProto& node,
+                                   const std::string& name) {
+  for (const auto& attr : node.attribute()) {
+    if (attr.name() == name) {
+      return static_cast<double>(attr.f());
+    }
+  }
+  return std::nullopt;
+}
+
+// max(|w|) / median(|w|) over one channel's weights, ignoring zeros -- see
+// precision_estimator.py's _channel_outlier_ratio for why zeros are excluded
+// (a pruned channel's sparsity shouldn't read as an outlier). NaN when fewer
+// than two nonzero weights remain (the ratio isn't meaningful).
+double ChannelOutlierRatio(std::vector<float> abs_weights_for_channel) {
+  std::vector<float> nonzero;
+  nonzero.reserve(abs_weights_for_channel.size());
+  for (float v : abs_weights_for_channel) {
+    if (v > 0.0f) nonzero.push_back(v);
+  }
+  if (nonzero.size() < 2) {
+    return std::numeric_limits<double>::quiet_NaN();
+  }
+  const float peak = *std::max_element(nonzero.begin(), nonzero.end());
+  // np.median: sort and take the middle element(s), averaging the two
+  // central elements for an even count.
+  std::sort(nonzero.begin(), nonzero.end());
+  const size_t n = nonzero.size();
+  const double med = (n % 2 == 1)
+                         ? static_cast<double>(nonzero[n / 2])
+                         : (static_cast<double>(nonzero[n / 2 - 1]) +
+                            static_cast<double>(nonzero[n / 2])) /
+                               2.0;
+  if (med == 0.0) {
+    return std::numeric_limits<double>::quiet_NaN();
+  }
+  return static_cast<double>(peak) / med;
+}
+
+// Mirrors precision_estimator.py's _recommendation.
+std::string BuildRecommendation(bool safe, bool float32_exact,
+                                bool outlier_risk,
+                                const std::string& activation_producer_op,
+                                bool has_activation_range, double lo,
+                                double hi) {
+  if (!safe) {
+    return "reduction depth exceeds the int32-safe bound: "
+           "onnxsim.quantize_dynamic already skips this node; INT8 with a "
+           "wider (int64) accumulator, or splitting the reduction (blockwise "
+           "quantization), would be needed";
+  }
+  std::vector<std::string> notes;
+  if (!float32_exact) {
+    notes.push_back(
+        "the accumulator's Cast<float> is not bit-exact past this reduction "
+        "depth (float32's 24-bit mantissa), though the rounding involved "
+        "(~2**-24 relative) is far below INT8's own ~1/127 quantization "
+        "error and does not change the recommendation");
+  }
+  if (outlier_risk) {
+    notes.push_back(
+        "a channel's outliers dominate its scale: per-group quantization or "
+        "INT16 would preserve more resolution for this node's "
+        "typical-magnitude weights");
+  }
+  if (has_activation_range) {
+    std::ostringstream os;
+    os << "the activation input comes from " << activation_producer_op
+       << ", whose output is always in [" << lo << ", " << hi
+       << "] regardless of input data: a fixed static scale would quantize "
+          "it exactly, without calibration data or quantize_dynamic's "
+          "runtime DynamicQuantizeLinear";
+    notes.push_back(os.str());
+  }
+  if (notes.empty()) {
+    return "INT8 (onnxsim.quantize_dynamic's scheme) looks safe and "
+           "well-resolved";
+  }
+  std::ostringstream os;
+  os << "int32-safe, but ";
+  for (size_t i = 0; i < notes.size(); ++i) {
+    if (i > 0) os << "; ";
+    os << notes[i];
+  }
+  return os.str();
+}
+
+// The analytically-known output range of `producer`, if any. `initializers`
+// is used to resolve a Clip node's (opset >= 11) min/max inputs.
+bool ActivationRange(
+    const onnx::NodeProto* producer,
+    const std::unordered_map<std::string, const onnx::TensorProto*>&
+        initializers,
+    std::string* op_type, double* lo, double* hi) {
+  if (producer == nullptr) return false;
+  const auto& fixed = FixedActivationRanges();
+  auto it = fixed.find(producer->op_type());
+  if (it != fixed.end()) {
+    *op_type = producer->op_type();
+    *lo = it->second.first;
+    *hi = it->second.second;
+    return true;
+  }
+  if (producer->op_type() != "Clip") return false;
+  double clip_lo = -std::numeric_limits<double>::infinity();
+  double clip_hi = std::numeric_limits<double>::infinity();
+  for (const auto& attr : producer->attribute()) {  // opset < 11
+    if (attr.name() == "min") clip_lo = attr.f();
+    if (attr.name() == "max") clip_hi = attr.f();
+  }
+  auto read_scalar = [&](const std::string& name,
+                         double* out) -> bool {
+    auto init_it = initializers.find(name);
+    if (init_it == initializers.end()) return false;
+    std::vector<float> vals = ReadFloatTensorFlat(*init_it->second);
+    if (vals.empty()) return false;
+    *out = static_cast<double>(vals[0]);
+    return true;
+  };
+  if (producer->input_size() > 1 && !producer->input(1).empty()) {
+    read_scalar(producer->input(1), &clip_lo);  // opset >= 11
+  }
+  if (producer->input_size() > 2 && !producer->input(2).empty()) {
+    read_scalar(producer->input(2), &clip_hi);
+  }
+  if (std::isinf(clip_lo) || std::isinf(clip_hi)) return false;
+  *op_type = "Clip";
+  *lo = clip_lo;
+  *hi = clip_hi;
+  return true;
+}
+
+std::optional<WeightPrecisionEstimate> EstimateMatMulGemm(
+    const onnx::NodeProto& node,
+    const std::unordered_map<std::string, const onnx::TensorProto*>&
+        initializers,
+    const std::unordered_map<std::string, const onnx::NodeProto*>& producer) {
+  if (node.op_type() != "MatMul" && node.op_type() != "Gemm") return std::nullopt;
+  if (node.input_size() < 2) return std::nullopt;
+  auto init_it = initializers.find(node.input(1));
+  if (init_it == initializers.end()) return std::nullopt;
+  const onnx::TensorProto& w_t = *init_it->second;
+  if (w_t.data_type() != onnx::TensorProto_DataType_FLOAT ||
+      w_t.dims_size() != 2) {
+    return std::nullopt;
+  }
+
+  const bool transposed =
+      node.op_type() == "Gemm" && GetAttrInt(node, "transB", 0) != 0;
+  if (node.op_type() == "Gemm") {
+    const int64_t trans_a = GetAttrInt(node, "transA", 0);
+    const std::optional<double> alpha = GetAttrFloat(node, "alpha");
+    if (trans_a != 0 || (alpha.has_value() && *alpha != 1.0)) {
+      return std::nullopt;
+    }
+  }
+
+  const int64_t dim0 = w_t.dims(0);
+  const int64_t dim1 = w_t.dims(1);
+  const int64_t k = transposed ? dim1 : dim0;
+  const int64_t n = transposed ? dim0 : dim1;
+  const int channel_axis = transposed ? 0 : 1;
+
+  const std::vector<float> data = ReadFloatTensorFlat(w_t);
+  std::vector<double> finite_ratios;
+  for (int64_t c = 0; c < n; ++c) {
+    std::vector<float> channel;
+    if (channel_axis == 1) {
+      channel.reserve(static_cast<size_t>(dim0));
+      for (int64_t i = 0; i < dim0; ++i) {
+        channel.push_back(std::fabs(data[static_cast<size_t>(i * dim1 + c)]));
+      }
+    } else {
+      channel.reserve(static_cast<size_t>(dim1));
+      for (int64_t j = 0; j < dim1; ++j) {
+        channel.push_back(std::fabs(data[static_cast<size_t>(c * dim1 + j)]));
+      }
+    }
+    const double ratio = ChannelOutlierRatio(std::move(channel));
+    if (!std::isnan(ratio)) finite_ratios.push_back(ratio);
+  }
+  const double max_ratio = finite_ratios.empty()
+                                ? std::numeric_limits<double>::quiet_NaN()
+                                : *std::max_element(finite_ratios.begin(),
+                                                    finite_ratios.end());
+  const bool safe = k <= MaxSafeInt32ReductionDepth();
+  const bool float32_exact = k <= MaxExactFloat32ReductionDepth();
+  const bool outlier_risk =
+      !finite_ratios.empty() && max_ratio > kOutlierRatioThreshold;
+
+  const onnx::NodeProto* act_producer = nullptr;
+  if (node.input_size() > 0) {
+    auto p_it = producer.find(node.input(0));
+    if (p_it != producer.end()) act_producer = p_it->second;
+  }
+  std::string act_op;
+  double act_lo = 0.0, act_hi = 0.0;
+  const bool has_act_range =
+      ActivationRange(act_producer, initializers, &act_op, &act_lo, &act_hi);
+
+  WeightPrecisionEstimate est;
+  est.node_name = !node.name().empty()
+                      ? node.name()
+                      : (node.op_type() + "(" + node.input(1) + ")");
+  est.op_type = node.op_type();
+  est.reduction_depth = k;
+  est.num_channels = n;
+  est.int32_accumulator_safe = safe;
+  est.float32_cast_exact = float32_exact;
+  est.max_outlier_ratio = max_ratio;
+  est.outlier_risk = outlier_risk;
+  est.activation_producer_op = has_act_range ? act_op : "";
+  est.has_activation_range = has_act_range;
+  est.activation_range_lo = act_lo;
+  est.activation_range_hi = act_hi;
+  est.recommendation = BuildRecommendation(safe, float32_exact, outlier_risk,
+                                           act_op, has_act_range, act_lo,
+                                           act_hi);
+  return est;
+}
+
+std::optional<WeightPrecisionEstimate> EstimateConv(
+    const onnx::NodeProto& node,
+    const std::unordered_map<std::string, const onnx::TensorProto*>&
+        initializers,
+    const std::unordered_map<std::string, const onnx::NodeProto*>& producer) {
+  if (node.op_type() != "Conv") return std::nullopt;
+  if (node.input_size() < 2) return std::nullopt;
+  auto init_it = initializers.find(node.input(1));
+  if (init_it == initializers.end()) return std::nullopt;
+  const onnx::TensorProto& w_t = *init_it->second;
+  if (w_t.data_type() != onnx::TensorProto_DataType_FLOAT ||
+      w_t.dims_size() < 3) {
+    return std::nullopt;
+  }
+
+  const int64_t cout = w_t.dims(0);
+  int64_t inner = 1;
+  for (int i = 1; i < w_t.dims_size(); ++i) inner *= w_t.dims(i);
+  const std::vector<float> data = ReadFloatTensorFlat(w_t);
+
+  std::vector<double> finite_ratios;
+  for (int64_t c = 0; c < cout; ++c) {
+    std::vector<float> channel(static_cast<size_t>(inner));
+    for (int64_t j = 0; j < inner; ++j) {
+      channel[static_cast<size_t>(j)] =
+          std::fabs(data[static_cast<size_t>(c * inner + j)]);
+    }
+    const double ratio = ChannelOutlierRatio(std::move(channel));
+    if (!std::isnan(ratio)) finite_ratios.push_back(ratio);
+  }
+  const double max_ratio = finite_ratios.empty()
+                                ? std::numeric_limits<double>::quiet_NaN()
+                                : *std::max_element(finite_ratios.begin(),
+                                                    finite_ratios.end());
+  const bool safe = inner <= MaxSafeInt32ReductionDepth();
+  const bool float32_exact = inner <= MaxExactFloat32ReductionDepth();
+  const bool outlier_risk =
+      !finite_ratios.empty() && max_ratio > kOutlierRatioThreshold;
+
+  const onnx::NodeProto* act_producer = nullptr;
+  if (node.input_size() > 0) {
+    auto p_it = producer.find(node.input(0));
+    if (p_it != producer.end()) act_producer = p_it->second;
+  }
+  std::string act_op;
+  double act_lo = 0.0, act_hi = 0.0;
+  const bool has_act_range =
+      ActivationRange(act_producer, initializers, &act_op, &act_lo, &act_hi);
+
+  WeightPrecisionEstimate est;
+  est.node_name = !node.name().empty() ? node.name()
+                                       : ("Conv(" + node.input(1) + ")");
+  est.op_type = "Conv";
+  est.reduction_depth = inner;
+  est.num_channels = cout;
+  est.int32_accumulator_safe = safe;
+  est.float32_cast_exact = float32_exact;
+  est.max_outlier_ratio = max_ratio;
+  est.outlier_risk = outlier_risk;
+  est.activation_producer_op = has_act_range ? act_op : "";
+  est.has_activation_range = has_act_range;
+  est.activation_range_lo = act_lo;
+  est.activation_range_hi = act_hi;
+  est.recommendation = BuildRecommendation(safe, float32_exact, outlier_risk,
+                                           act_op, has_act_range, act_lo,
+                                           act_hi);
+  return est;
+}
+
+// A tensor's statically-known dims, one optional<int64_t> per dimension (a
+// dim_param or otherwise-unresolved dim reads as nullopt); nullopt for the
+// whole vector means the tensor's shape wasn't found at all.
+using StaticShape = std::vector<std::optional<int64_t>>;
+
+std::unordered_map<std::string, StaticShape> CollectStaticShapes(
+    const onnx::ModelProto& model) {
+  onnx::ModelProto inferred = model;
+  try {
+    onnx::shape_inference::InferShapes(inferred);
+  } catch (...) {
+    inferred = model;
+  }
+  std::unordered_map<std::string, StaticShape> shapes;
+  const onnx::GraphProto& graph = inferred.graph();
+  auto collect = [&](const auto& value_infos) {
+    for (const auto& vi : value_infos) {
+      if (!vi.type().has_tensor_type()) continue;
+      const auto& tt = vi.type().tensor_type();
+      if (!tt.has_shape()) continue;
+      StaticShape dims;
+      dims.reserve(static_cast<size_t>(tt.shape().dim_size()));
+      for (const auto& d : tt.shape().dim()) {
+        dims.push_back(d.has_dim_value() ? std::optional<int64_t>(d.dim_value())
+                                         : std::nullopt);
+      }
+      shapes[vi.name()] = std::move(dims);
+    }
+  };
+  collect(graph.input());
+  collect(graph.output());
+  collect(graph.value_info());
+  for (const auto& init : graph.initializer()) {
+    StaticShape dims;
+    dims.reserve(static_cast<size_t>(init.dims_size()));
+    for (int64_t d : init.dims()) dims.push_back(d);
+    shapes[init.name()] = std::move(dims);
+  }
+  return shapes;
+}
+
+std::optional<AttentionPrecisionEstimate> EstimateAttention(
+    const onnx::NodeProto& node,
+    const std::unordered_map<std::string, StaticShape>& shapes) {
+  if (node.op_type() != "Attention" || node.input_size() < 3) {
+    return std::nullopt;
+  }
+  const StaticShape* q_shape = nullptr;
+  const StaticShape* k_shape = nullptr;
+  {
+    auto it = shapes.find(node.input(0));
+    if (it != shapes.end()) q_shape = &it->second;
+  }
+  {
+    auto it = shapes.find(node.input(1));
+    if (it != shapes.end()) k_shape = &it->second;
+  }
+
+  std::optional<int64_t> q_heads;
+  {
+    const int64_t v = GetAttrInt(node, "q_num_heads", 0);
+    if (v != 0) q_heads = v;
+  }
+  std::optional<int64_t> kv_heads;
+  {
+    const int64_t v = GetAttrInt(node, "kv_num_heads", 0);
+    if (v != 0) kv_heads = v;
+  }
+  std::optional<int64_t> head_dim;
+
+  if (q_shape != nullptr && q_shape->size() == 4 && (*q_shape)[3].has_value()) {
+    if ((*q_shape)[1].has_value()) q_heads = (*q_shape)[1];
+    head_dim = (*q_shape)[3];
+    if (k_shape != nullptr && k_shape->size() == 4 &&
+        (*k_shape)[1].has_value()) {
+      kv_heads = (*k_shape)[1];
+    }
+  } else if (q_shape != nullptr && k_shape != nullptr && q_shape->size() == 3 &&
+            k_shape->size() == 3 && kv_heads.has_value() &&
+            (*k_shape)[2].has_value()) {
+    head_dim = *(*k_shape)[2] / *kv_heads;
+  }
+
+  const std::optional<double> default_scale =
+      head_dim.has_value() ? std::optional<double>(1.0 / std::sqrt(
+                                 static_cast<double>(*head_dim)))
+                           : std::nullopt;
+  const std::optional<double> actual_scale = GetAttrFloat(node, "scale");
+  int matches = -1;
+  if (default_scale.has_value() && actual_scale.has_value()) {
+    // math.isclose(..., rel_tol=1e-3)
+    const double a = *default_scale, b = *actual_scale;
+    matches = (std::fabs(a - b) <=
+              1e-3 * std::max(std::fabs(a), std::fabs(b)))
+                 ? 1
+                 : 0;
+  }
+
+  std::string recommendation;
+  if (!head_dim.has_value()) {
+    recommendation =
+        "head_dim could not be determined statically (dynamic/unknown shape "
+        "and no q_num_heads/kv_num_heads attributes) -- no estimate "
+        "available";
+  } else if (matches == 0) {
+    std::ostringstream os;
+    os << "scale=" << *actual_scale
+       << " attribute does not match the canonical 1/sqrt(head_dim)="
+       << *default_scale
+       << ": pre-softmax QK^T logits will grow unnormalized with head_dim, "
+          "risking saturation/overflow in a low-precision (e.g. fp16) "
+          "softmax";
+    recommendation = os.str();
+  } else {
+    recommendation =
+        "scale normalizes QK^T's head_dim-dependent growth as expected; no "
+        "int8 accumulator applies here since Q/K/V are runtime activations, "
+        "not a static weight";
+  }
+
+  AttentionPrecisionEstimate est;
+  est.node_name = !node.name().empty() ? node.name() : "Attention";
+  est.has_num_query_heads = q_heads.has_value();
+  est.num_query_heads = q_heads.value_or(0);
+  est.has_num_kv_heads = kv_heads.has_value();
+  est.num_kv_heads = kv_heads.value_or(0);
+  est.has_head_dim = head_dim.has_value();
+  est.head_dim = head_dim.value_or(0);
+  est.default_scale =
+      default_scale.value_or(std::numeric_limits<double>::quiet_NaN());
+  est.actual_scale =
+      actual_scale.value_or(std::numeric_limits<double>::quiet_NaN());
+  est.scale_matches_default = matches;
+  est.recommendation = recommendation;
+  return est;
+}
+
+}  // namespace
+
+void EstimateQuantizationPrecision(
+    const onnx::ModelProto& model,
+    std::vector<WeightPrecisionEstimate>* weight_estimates,
+    std::vector<AttentionPrecisionEstimate>* attention_estimates) {
+  weight_estimates->clear();
+  attention_estimates->clear();
+
+  std::unordered_map<std::string, const onnx::TensorProto*> initializers;
+  for (const auto& init : model.graph().initializer()) {
+    initializers[init.name()] = &init;
+  }
+  std::unordered_map<std::string, const onnx::NodeProto*> producer;
+  for (const auto& node : model.graph().node()) {
+    for (const auto& out : node.output()) {
+      if (!out.empty()) producer[out] = &node;
+    }
+  }
+
+  // Attention needs shape inference (for head_dim); only run it if the model
+  // actually has an Attention node, since it's the one non-trivial cost here.
+  bool has_attention = false;
+  for (const auto& node : model.graph().node()) {
+    if (node.op_type() == "Attention") {
+      has_attention = true;
+      break;
+    }
+  }
+  std::unordered_map<std::string, StaticShape> shapes;
+  if (has_attention) {
+    shapes = CollectStaticShapes(model);
+  }
+
+  for (const auto& node : model.graph().node()) {
+    if (node.op_type() == "MatMul" || node.op_type() == "Gemm") {
+      auto est = EstimateMatMulGemm(node, initializers, producer);
+      if (est.has_value()) weight_estimates->push_back(std::move(*est));
+    } else if (node.op_type() == "Conv") {
+      auto est = EstimateConv(node, initializers, producer);
+      if (est.has_value()) weight_estimates->push_back(std::move(*est));
+    } else if (node.op_type() == "Attention") {
+      auto est = EstimateAttention(node, shapes);
+      if (est.has_value()) attention_estimates->push_back(std::move(*est));
+    }
+  }
+}
+
+ModelQuantizationEstimate EstimateModelQuantizationDrop(
+    const onnx::ModelProto& model) {
+  ModelQuantizationEstimate out;
+  EstimateQuantizationPrecision(model, &out.weight_estimates,
+                                &out.attention_estimates);
+
+  std::vector<double> outlier_ratios;
+  double sum_squared_errors = 0.0;
+  for (const auto& est : out.weight_estimates) {
+    if (!est.int32_accumulator_safe) {
+      out.unsafe_nodes.push_back(est.node_name);
+      continue;
+    }
+    if (est.outlier_risk) {
+      out.outlier_risk_nodes.push_back(est.node_name);
+    }
+    const double ratio =
+        std::isnan(est.max_outlier_ratio) ? 1.0 : est.max_outlier_ratio;
+    if (!std::isnan(est.max_outlier_ratio)) {
+      outlier_ratios.push_back(est.max_outlier_ratio);
+    }
+    const double per_node_relative_error = ratio / kUniformQuantizerNoiseDivisor;
+    sum_squared_errors += per_node_relative_error * per_node_relative_error;
+  }
+
+  out.total_nodes_analyzed = static_cast<int64_t>(out.weight_estimates.size() +
+                                                   out.attention_estimates.size());
+  out.worst_outlier_ratio = outlier_ratios.empty()
+                                ? std::numeric_limits<double>::quiet_NaN()
+                                : *std::max_element(outlier_ratios.begin(),
+                                                    outlier_ratios.end());
+  if (!out.unsafe_nodes.empty()) {
+    out.risk_level = "unsafe";
+    out.estimated_relative_error = std::numeric_limits<double>::quiet_NaN();
+  } else {
+    out.risk_level = out.outlier_risk_nodes.empty() ? "safe" : "degraded";
+    out.estimated_relative_error = std::sqrt(sum_squared_errors);
+  }
+  return out;
+}
+
+}  // namespace onnxsim

--- a/onnxsim/precision_estimator.cpp
+++ b/onnxsim/precision_estimator.cpp
@@ -41,12 +41,13 @@ const double kUniformQuantizerNoiseDivisor = 127.0 * std::sqrt(12.0);
 // precision_estimator.py's FIXED_ACTIVATION_RANGES.
 const std::unordered_map<std::string, std::pair<double, double>>&
 FixedActivationRanges() {
-  static const std::unordered_map<std::string, std::pair<double, double>> kMap = {
-      {"Sigmoid", {0.0, 1.0}},
-      {"HardSigmoid", {0.0, 1.0}},
-      {"Tanh", {-1.0, 1.0}},
-      {"Softmax", {0.0, 1.0}},
-  };
+  static const std::unordered_map<std::string, std::pair<double, double>> kMap =
+      {
+          {"Sigmoid", {0.0, 1.0}},
+          {"HardSigmoid", {0.0, 1.0}},
+          {"Tanh", {-1.0, 1.0}},
+          {"Softmax", {0.0, 1.0}},
+      };
   return kMap;
 }
 
@@ -64,9 +65,9 @@ std::vector<float> ReadFloatTensorFlat(const onnx::TensorProto& t) {
     std::vector<float> out(n);
     std::memcpy(out.data(), raw.data(), n * sizeof(float));
     if constexpr (!onnxsim::dlpack::kRawDataIsHostOrder) {
-      onnxsim::dlpack::SwapElementBytes(
-          reinterpret_cast<uint8_t*>(out.data()), out.size() * sizeof(float),
-          sizeof(float));
+      onnxsim::dlpack::SwapElementBytes(reinterpret_cast<uint8_t*>(out.data()),
+                                        out.size() * sizeof(float),
+                                        sizeof(float));
     }
     return out;
   }
@@ -111,11 +112,10 @@ double ChannelOutlierRatio(std::vector<float> abs_weights_for_channel) {
   // central elements for an even count.
   std::sort(nonzero.begin(), nonzero.end());
   const size_t n = nonzero.size();
-  const double med = (n % 2 == 1)
-                         ? static_cast<double>(nonzero[n / 2])
-                         : (static_cast<double>(nonzero[n / 2 - 1]) +
-                            static_cast<double>(nonzero[n / 2])) /
-                               2.0;
+  const double med = (n % 2 == 1) ? static_cast<double>(nonzero[n / 2])
+                                  : (static_cast<double>(nonzero[n / 2 - 1]) +
+                                     static_cast<double>(nonzero[n / 2])) /
+                                        2.0;
   if (med == 0.0) {
     return std::numeric_limits<double>::quiet_NaN();
   }
@@ -193,8 +193,7 @@ bool ActivationRange(
     if (attr.name() == "min") clip_lo = attr.f();
     if (attr.name() == "max") clip_hi = attr.f();
   }
-  auto read_scalar = [&](const std::string& name,
-                         double* out) -> bool {
+  auto read_scalar = [&](const std::string& name, double* out) -> bool {
     auto init_it = initializers.find(name);
     if (init_it == initializers.end()) return false;
     std::vector<float> vals = ReadFloatTensorFlat(*init_it->second);
@@ -220,7 +219,8 @@ std::optional<WeightPrecisionEstimate> EstimateMatMulGemm(
     const std::unordered_map<std::string, const onnx::TensorProto*>&
         initializers,
     const std::unordered_map<std::string, const onnx::NodeProto*>& producer) {
-  if (node.op_type() != "MatMul" && node.op_type() != "Gemm") return std::nullopt;
+  if (node.op_type() != "MatMul" && node.op_type() != "Gemm")
+    return std::nullopt;
   if (node.input_size() < 2) return std::nullopt;
   auto init_it = initializers.find(node.input(1));
   if (init_it == initializers.end()) return std::nullopt;
@@ -264,10 +264,10 @@ std::optional<WeightPrecisionEstimate> EstimateMatMulGemm(
     const double ratio = ChannelOutlierRatio(std::move(channel));
     if (!std::isnan(ratio)) finite_ratios.push_back(ratio);
   }
-  const double max_ratio = finite_ratios.empty()
-                                ? std::numeric_limits<double>::quiet_NaN()
-                                : *std::max_element(finite_ratios.begin(),
-                                                    finite_ratios.end());
+  const double max_ratio =
+      finite_ratios.empty()
+          ? std::numeric_limits<double>::quiet_NaN()
+          : *std::max_element(finite_ratios.begin(), finite_ratios.end());
   const bool safe = k <= MaxSafeInt32ReductionDepth();
   const bool float32_exact = k <= MaxExactFloat32ReductionDepth();
   const bool outlier_risk =
@@ -298,9 +298,8 @@ std::optional<WeightPrecisionEstimate> EstimateMatMulGemm(
   est.has_activation_range = has_act_range;
   est.activation_range_lo = act_lo;
   est.activation_range_hi = act_hi;
-  est.recommendation = BuildRecommendation(safe, float32_exact, outlier_risk,
-                                           act_op, has_act_range, act_lo,
-                                           act_hi);
+  est.recommendation = BuildRecommendation(
+      safe, float32_exact, outlier_risk, act_op, has_act_range, act_lo, act_hi);
   return est;
 }
 
@@ -334,10 +333,10 @@ std::optional<WeightPrecisionEstimate> EstimateConv(
     const double ratio = ChannelOutlierRatio(std::move(channel));
     if (!std::isnan(ratio)) finite_ratios.push_back(ratio);
   }
-  const double max_ratio = finite_ratios.empty()
-                                ? std::numeric_limits<double>::quiet_NaN()
-                                : *std::max_element(finite_ratios.begin(),
-                                                    finite_ratios.end());
+  const double max_ratio =
+      finite_ratios.empty()
+          ? std::numeric_limits<double>::quiet_NaN()
+          : *std::max_element(finite_ratios.begin(), finite_ratios.end());
   const bool safe = inner <= MaxSafeInt32ReductionDepth();
   const bool float32_exact = inner <= MaxExactFloat32ReductionDepth();
   const bool outlier_risk =
@@ -354,8 +353,8 @@ std::optional<WeightPrecisionEstimate> EstimateConv(
       ActivationRange(act_producer, initializers, &act_op, &act_lo, &act_hi);
 
   WeightPrecisionEstimate est;
-  est.node_name = !node.name().empty() ? node.name()
-                                       : ("Conv(" + node.input(1) + ")");
+  est.node_name =
+      !node.name().empty() ? node.name() : ("Conv(" + node.input(1) + ")");
   est.op_type = "Conv";
   est.reduction_depth = inner;
   est.num_channels = cout;
@@ -367,9 +366,8 @@ std::optional<WeightPrecisionEstimate> EstimateConv(
   est.has_activation_range = has_act_range;
   est.activation_range_lo = act_lo;
   est.activation_range_hi = act_hi;
-  est.recommendation = BuildRecommendation(safe, float32_exact, outlier_risk,
-                                           act_op, has_act_range, act_lo,
-                                           act_hi);
+  est.recommendation = BuildRecommendation(
+      safe, float32_exact, outlier_risk, act_op, has_act_range, act_lo, act_hi);
   return est;
 }
 
@@ -451,24 +449,24 @@ std::optional<AttentionPrecisionEstimate> EstimateAttention(
       kv_heads = (*k_shape)[1];
     }
   } else if (q_shape != nullptr && k_shape != nullptr && q_shape->size() == 3 &&
-            k_shape->size() == 3 && kv_heads.has_value() &&
-            (*k_shape)[2].has_value()) {
+             k_shape->size() == 3 && kv_heads.has_value() &&
+             (*k_shape)[2].has_value()) {
     head_dim = *(*k_shape)[2] / *kv_heads;
   }
 
   const std::optional<double> default_scale =
-      head_dim.has_value() ? std::optional<double>(1.0 / std::sqrt(
-                                 static_cast<double>(*head_dim)))
-                           : std::nullopt;
+      head_dim.has_value()
+          ? std::optional<double>(1.0 /
+                                  std::sqrt(static_cast<double>(*head_dim)))
+          : std::nullopt;
   const std::optional<double> actual_scale = GetAttrFloat(node, "scale");
   int matches = -1;
   if (default_scale.has_value() && actual_scale.has_value()) {
     // math.isclose(..., rel_tol=1e-3)
     const double a = *default_scale, b = *actual_scale;
-    matches = (std::fabs(a - b) <=
-              1e-3 * std::max(std::fabs(a), std::fabs(b)))
-                 ? 1
-                 : 0;
+    matches = (std::fabs(a - b) <= 1e-3 * std::max(std::fabs(a), std::fabs(b)))
+                  ? 1
+                  : 0;
   }
 
   std::string recommendation;
@@ -579,16 +577,17 @@ ModelQuantizationEstimate EstimateModelQuantizationDrop(
     if (!std::isnan(est.max_outlier_ratio)) {
       outlier_ratios.push_back(est.max_outlier_ratio);
     }
-    const double per_node_relative_error = ratio / kUniformQuantizerNoiseDivisor;
+    const double per_node_relative_error =
+        ratio / kUniformQuantizerNoiseDivisor;
     sum_squared_errors += per_node_relative_error * per_node_relative_error;
   }
 
-  out.total_nodes_analyzed = static_cast<int64_t>(out.weight_estimates.size() +
-                                                   out.attention_estimates.size());
-  out.worst_outlier_ratio = outlier_ratios.empty()
-                                ? std::numeric_limits<double>::quiet_NaN()
-                                : *std::max_element(outlier_ratios.begin(),
-                                                    outlier_ratios.end());
+  out.total_nodes_analyzed = static_cast<int64_t>(
+      out.weight_estimates.size() + out.attention_estimates.size());
+  out.worst_outlier_ratio =
+      outlier_ratios.empty()
+          ? std::numeric_limits<double>::quiet_NaN()
+          : *std::max_element(outlier_ratios.begin(), outlier_ratios.end());
   if (!out.unsafe_nodes.empty()) {
     out.risk_level = "unsafe";
     out.estimated_relative_error = std::numeric_limits<double>::quiet_NaN();

--- a/onnxsim/precision_estimator.h
+++ b/onnxsim/precision_estimator.h
@@ -74,7 +74,7 @@ struct ModelQuantizationEstimate {
   int64_t total_nodes_analyzed = 0;
   std::vector<std::string> unsafe_nodes;
   std::vector<std::string> outlier_risk_nodes;
-  double worst_outlier_ratio = 0.0;      // NaN if no node had one
+  double worst_outlier_ratio = 0.0;       // NaN if no node had one
   double estimated_relative_error = 0.0;  // NaN if any unsafe_nodes
   std::string risk_level;                 // "unsafe" | "degraded" | "safe"
 };

--- a/onnxsim/precision_estimator.h
+++ b/onnxsim/precision_estimator.h
@@ -1,0 +1,99 @@
+#pragma once
+
+// C++ port of onnxsim/precision_estimator.py's static INT8-quantization
+// precision analysis for MatMul/Gemm/Conv/Attention -- see that module's
+// docstring for the full rationale (accumulator-overflow bound, outlier-ratio
+// resolution loss, float32-cast exactness, and analytically-known activation
+// ranges). Kept in sync with the Python implementation by design: every
+// threshold, formula and recommendation string here should read as a
+// line-for-line translation, not an independent reimplementation, so the two
+// never quietly drift apart. This exists (rather than reusing the Python
+// module) so the WASM build -- which has no Python runtime -- can offer the
+// same quantization-risk pre-check in the browser UI, entirely client-side
+// and before the user even runs a quantize pass.
+//
+// Like precision_estimator.py, this is read-only: it never modifies the
+// model.
+
+#include <onnx/onnx_pb.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace onnxsim {
+
+// Mirrors precision_estimator.py's MatMulGemmPrecisionEstimate and
+// ConvPrecisionEstimate -- identical field sets in Python (only the dataclass
+// name differs), so this C++ port unifies them into one struct with an
+// ``op_type`` discriminator ("MatMul" | "Gemm" | "Conv").
+struct WeightPrecisionEstimate {
+  std::string node_name;
+  std::string op_type;
+  int64_t reduction_depth = 0;
+  int64_t num_channels = 0;
+  bool int32_accumulator_safe = false;
+  bool float32_cast_exact = false;  // false just means routine float rounding
+  double max_outlier_ratio = 0.0;   // NaN if not computable (see .cpp)
+  bool outlier_risk = false;
+  std::string activation_producer_op;  // "" if not recognized
+  bool has_activation_range = false;
+  double activation_range_lo = 0.0;  // valid iff has_activation_range
+  double activation_range_hi = 0.0;
+  std::string recommendation;
+};
+
+// Mirrors precision_estimator.py's AttentionPrecisionEstimate. Every
+// "unknown" field (couldn't be determined statically) is flagged by its own
+// has_* bool rather than a sentinel, except max/default/actual scale, which
+// use NaN (mirroring Python's Optional[float] -> None there, since NaN
+// already is this module's "unknown float" convention elsewhere).
+struct AttentionPrecisionEstimate {
+  std::string node_name;
+  bool has_num_query_heads = false;
+  int64_t num_query_heads = 0;
+  bool has_num_kv_heads = false;
+  int64_t num_kv_heads = 0;
+  bool has_head_dim = false;
+  int64_t head_dim = 0;
+  double default_scale = 0.0;  // NaN if head_dim unknown
+  double actual_scale = 0.0;   // NaN if the node has no `scale` attribute
+  // -1 = unknown (default_scale or actual_scale unavailable), 0 = false,
+  // 1 = true -- mirrors Python's Optional[bool].
+  int scale_matches_default = -1;
+  std::string recommendation;
+};
+
+// Mirrors precision_estimator.py's ModelQuantizationEstimate: the whole-model
+// rollup of every analyzed node's estimate, plus the per-node detail so a
+// caller (e.g. the WASM UI) can render both a headline risk figure and a
+// drill-down table.
+struct ModelQuantizationEstimate {
+  std::vector<WeightPrecisionEstimate> weight_estimates;
+  std::vector<AttentionPrecisionEstimate> attention_estimates;
+  int64_t total_nodes_analyzed = 0;
+  std::vector<std::string> unsafe_nodes;
+  std::vector<std::string> outlier_risk_nodes;
+  double worst_outlier_ratio = 0.0;      // NaN if no node had one
+  double estimated_relative_error = 0.0;  // NaN if any unsafe_nodes
+  std::string risk_level;                 // "unsafe" | "degraded" | "safe"
+};
+
+// Per-node precision estimates for `model` -- see precision_estimator.py's
+// ``estimate_quantization_precision`` for the full algorithm. Only the
+// top-level graph is walked (subgraphs -- e.g. inside If/Loop/Scan -- are not
+// descended into), matching the Python version.
+void EstimateQuantizationPrecision(
+    const onnx::ModelProto& model,
+    std::vector<WeightPrecisionEstimate>* weight_estimates,
+    std::vector<AttentionPrecisionEstimate>* attention_estimates);
+
+// Aggregates EstimateQuantizationPrecision's per-node estimates into a single
+// whole-model INT8-quantization risk summary -- see
+// precision_estimator.py's ``estimate_model_quantization_drop`` for the full
+// risk_level / estimated_relative_error semantics, which this mirrors
+// exactly (same thresholds, same root-sum-square combination).
+ModelQuantizationEstimate EstimateModelQuantizationDrop(
+    const onnx::ModelProto& model);
+
+}  // namespace onnxsim

--- a/onnxsim/precision_estimator.py
+++ b/onnxsim/precision_estimator.py
@@ -171,7 +171,9 @@ class ModelQuantizationEstimate:
     per_node: List[PrecisionEstimate]
 
 
-def _weight_estimate_from_tuple(t) -> Union[MatMulGemmPrecisionEstimate, ConvPrecisionEstimate]:
+def _weight_estimate_from_tuple(
+    t,
+) -> Union[MatMulGemmPrecisionEstimate, ConvPrecisionEstimate]:
     (
         node_name,
         op_type,

--- a/onnxsim/precision_estimator.py
+++ b/onnxsim/precision_estimator.py
@@ -68,19 +68,21 @@ reports that expected scale against the node's actual ``scale`` attribute (or
 ai.onnx opset 23 Attention's own default) so a mismatch that would leave
 softmax's input un-normalized is visible statically.
 
-This module is read-only: it never modifies the model and has no C++/pybind
-component.
+This module is read-only: it never modifies the model. The actual analysis
+runs in C++ (``onnxsim/precision_estimator.h``/``.cpp``) -- the same
+implementation the WASM converter UI's "Check quantization risk" button
+calls into (``scripts/convertmodel/interface.cpp``) -- so the algorithm
+exists in exactly one place. This module is a thin wrapper that reconstructs
+the dataclasses below from the C++ extension's result; see that C++ module's
+own doc comment for the implementation itself.
 """
 
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
-import numpy as np
 import onnx
-from onnx import numpy_helper, shape_inference
 
 # INT32_MAX // (127 * 255) -- see this module's docstring, point 1. Kept as a
 # literal formula (not a hardcoded constant) so it stays obviously in sync
@@ -105,52 +107,6 @@ OUTLIER_RATIO_THRESHOLD = 127.0
 # quantization's own ~1/127 (~0.8%) relative error by design. Included so
 # "int32-safe" is never conflated with "exact end-to-end".
 MAX_EXACT_FLOAT32_REDUCTION_DEPTH = (2**24) // (127 * 255)
-
-# Ops whose output range is fixed by the op itself, for any input -- not a
-# property of the data, so it needs no calibration run to know. See this
-# module's docstring, point 4. LogSoftmax/Softplus/etc. are left out: they're
-# only bounded on one side, which isn't enough to pick a fixed scale.
-FIXED_ACTIVATION_RANGES: Dict[str, Tuple[float, float]] = {
-    "Sigmoid": (0.0, 1.0),
-    "HardSigmoid": (
-        0.0,
-        1.0,
-    ),  # max(0, min(1, alpha*x+beta)) -- bounded by construction
-    "Tanh": (-1.0, 1.0),
-    "Softmax": (0.0, 1.0),
-}
-
-
-def _clip_range(
-    node: onnx.NodeProto, initializers: Dict[str, onnx.TensorProto]
-) -> Optional[Tuple[float, float]]:
-    """Clip's static (min, max), or None if either bound isn't a constant."""
-    lo, hi = -math.inf, math.inf
-    for attr in node.attribute:  # opset < 11: min/max are attributes
-        if attr.name == "min":
-            lo = float(attr.f)
-        elif attr.name == "max":
-            hi = float(attr.f)
-    if len(node.input) > 1 and node.input[1] in initializers:  # opset >= 11
-        lo = float(numpy_helper.to_array(initializers[node.input[1]]).reshape(-1)[0])
-    if len(node.input) > 2 and node.input[2] in initializers:
-        hi = float(numpy_helper.to_array(initializers[node.input[2]]).reshape(-1)[0])
-    if math.isinf(lo) or math.isinf(hi):
-        return None
-    return (lo, hi)
-
-
-def _activation_range(
-    producer: Optional[onnx.NodeProto], initializers: Dict[str, onnx.TensorProto]
-) -> Optional[Tuple[float, float]]:
-    """The analytically-known output range of `producer`, or None."""
-    if producer is None:
-        return None
-    if producer.op_type in FIXED_ACTIVATION_RANGES:
-        return FIXED_ACTIVATION_RANGES[producer.op_type]
-    if producer.op_type == "Clip":
-        return _clip_range(producer, initializers)
-    return None
 
 
 @dataclass
@@ -201,313 +157,6 @@ PrecisionEstimate = Union[
 ]
 
 
-def _get_attr_int(node: onnx.NodeProto, name: str, default: int) -> int:
-    for attr in node.attribute:
-        if attr.name == name:
-            return int(attr.i)
-    return default
-
-
-def _get_attr_float(node: onnx.NodeProto, name: str) -> Optional[float]:
-    for attr in node.attribute:
-        if attr.name == name:
-            return float(attr.f)
-    return None
-
-
-def _channel_outlier_ratio(abs_weights_for_channel) -> float:
-    """max(|w|) / median(|w|) over one channel's weights, ignoring zeros.
-
-    Zeros are excluded because a channel legitimately containing many exact
-    zeros (e.g. after pruning) would otherwise report a spuriously enormous
-    ratio driven by sparsity, not by outlier magnitude among the weights that
-    actually carry information. Returns ``nan`` when fewer than two nonzero
-    weights remain (the ratio isn't meaningful).
-    """
-    nonzero = abs_weights_for_channel[abs_weights_for_channel > 0]
-    if nonzero.size < 2:
-        return math.nan
-    peak = float(nonzero.max())
-    med = float(np.median(nonzero))
-    if med == 0.0:
-        return math.nan
-    return peak / med
-
-
-def _recommendation(
-    safe: bool,
-    float32_exact: bool,
-    outlier_risk: bool,
-    activation_producer_op: Optional[str],
-    activation_range: Optional[Tuple[float, float]],
-) -> str:
-    if not safe:
-        return (
-            "reduction depth exceeds the int32-safe bound: onnxsim.quantize_dynamic "
-            "already skips this node; INT8 with a wider (int64) accumulator, or "
-            "splitting the reduction (blockwise quantization), would be needed"
-        )
-    notes = []
-    if not float32_exact:
-        notes.append(
-            "the accumulator's Cast<float> is not bit-exact past this reduction "
-            "depth (float32's 24-bit mantissa), though the rounding involved "
-            "(~2**-24 relative) is far below INT8's own ~1/127 quantization error "
-            "and does not change the recommendation"
-        )
-    if outlier_risk:
-        notes.append(
-            "a channel's outliers dominate its scale: per-group quantization or "
-            "INT16 would preserve more resolution for this node's typical-magnitude "
-            "weights"
-        )
-    if activation_range is not None:
-        lo, hi = activation_range
-        notes.append(
-            f"the activation input comes from {activation_producer_op}, whose output "
-            f"is always in [{lo:g}, {hi:g}] regardless of input data: a fixed static "
-            "scale would quantize it exactly, without calibration data or "
-            "quantize_dynamic's runtime DynamicQuantizeLinear"
-        )
-    if not notes:
-        return "INT8 (onnxsim.quantize_dynamic's scheme) looks safe and well-resolved"
-    return "int32-safe, but " + "; ".join(notes)
-
-
-def _estimate_matmul_gemm(
-    node: onnx.NodeProto,
-    initializers: Dict[str, onnx.TensorProto],
-    producer: Dict[str, onnx.NodeProto],
-) -> Optional[MatMulGemmPrecisionEstimate]:
-    if node.op_type not in ("MatMul", "Gemm"):
-        return None
-    if len(node.input) < 2 or node.input[1] not in initializers:
-        return None
-    w = numpy_helper.to_array(initializers[node.input[1]])
-    if w.dtype.kind != "f" or w.ndim != 2:
-        return None
-
-    transposed = node.op_type == "Gemm" and _get_attr_int(node, "transB", 0) != 0
-    if node.op_type == "Gemm" and (
-        _get_attr_int(node, "transA", 0) != 0
-        or _get_attr_float(node, "alpha") not in (None, 1.0)
-    ):
-        return None
-
-    k, n = (w.shape[1], w.shape[0]) if transposed else (w.shape[0], w.shape[1])
-    channel_axis = 0 if transposed else 1
-    abs_w = abs(w)
-
-    ratios = [
-        _channel_outlier_ratio(abs_w.take(c, axis=channel_axis)) for c in range(n)
-    ]
-    finite_ratios = [r for r in ratios if not math.isnan(r)]
-    max_ratio = max(finite_ratios) if finite_ratios else math.nan
-    safe = k <= MAX_SAFE_INT32_REDUCTION_DEPTH
-    float32_exact = k <= MAX_EXACT_FLOAT32_REDUCTION_DEPTH
-    outlier_risk = bool(finite_ratios) and max_ratio > OUTLIER_RATIO_THRESHOLD
-    act_producer = producer.get(node.input[0]) if node.input else None
-    act_range = _activation_range(act_producer, initializers)
-    act_producer_op = (
-        act_producer.op_type
-        if act_producer is not None and act_range is not None
-        else None
-    )
-
-    return MatMulGemmPrecisionEstimate(
-        node_name=node.name or f"{node.op_type}({node.input[1]})",
-        op_type=node.op_type,
-        reduction_depth=int(k),
-        num_channels=int(n),
-        int32_accumulator_safe=safe,
-        float32_cast_exact=float32_exact,
-        max_outlier_ratio=max_ratio,
-        outlier_risk=outlier_risk,
-        activation_producer_op=act_producer_op,
-        activation_range=act_range,
-        recommendation=_recommendation(
-            safe, float32_exact, outlier_risk, act_producer_op, act_range
-        ),
-    )
-
-
-def _estimate_conv(
-    node: onnx.NodeProto,
-    initializers: Dict[str, onnx.TensorProto],
-    producer: Dict[str, onnx.NodeProto],
-) -> Optional[ConvPrecisionEstimate]:
-    if node.op_type != "Conv":
-        return None
-    if len(node.input) < 2 or node.input[1] not in initializers:
-        return None
-    w = numpy_helper.to_array(initializers[node.input[1]])
-    if w.dtype.kind != "f" or w.ndim < 3:
-        return None
-
-    cout = w.shape[0]
-    k = int(w[0].size)  # (Cin / groups) * kernel volume
-    abs_w = abs(w).reshape(cout, -1)
-
-    ratios = [_channel_outlier_ratio(abs_w[c]) for c in range(cout)]
-    finite_ratios = [r for r in ratios if not math.isnan(r)]
-    max_ratio = max(finite_ratios) if finite_ratios else math.nan
-    safe = k <= MAX_SAFE_INT32_REDUCTION_DEPTH
-    float32_exact = k <= MAX_EXACT_FLOAT32_REDUCTION_DEPTH
-    outlier_risk = bool(finite_ratios) and max_ratio > OUTLIER_RATIO_THRESHOLD
-    act_producer = producer.get(node.input[0]) if node.input else None
-    act_range = _activation_range(act_producer, initializers)
-    act_producer_op = (
-        act_producer.op_type
-        if act_producer is not None and act_range is not None
-        else None
-    )
-
-    return ConvPrecisionEstimate(
-        node_name=node.name or f"Conv({node.input[1]})",
-        reduction_depth=k,
-        num_channels=int(cout),
-        int32_accumulator_safe=safe,
-        float32_cast_exact=float32_exact,
-        max_outlier_ratio=max_ratio,
-        outlier_risk=outlier_risk,
-        activation_producer_op=act_producer_op,
-        activation_range=act_range,
-        recommendation=_recommendation(
-            safe, float32_exact, outlier_risk, act_producer_op, act_range
-        ),
-    )
-
-
-def _static_dims(
-    shape_proto: Optional[onnx.TensorShapeProto],
-) -> Optional[List[Optional[int]]]:
-    if shape_proto is None:
-        return None
-    dims: List[Optional[int]] = []
-    for d in shape_proto.dim:
-        dims.append(d.dim_value if d.HasField("dim_value") else None)
-    return dims
-
-
-def _collect_static_shapes(model: onnx.ModelProto) -> Dict[str, List[Optional[int]]]:
-    try:
-        inferred = shape_inference.infer_shapes(model)
-    except Exception:
-        inferred = model
-    shapes: Dict[str, List[Optional[int]]] = {}
-    graph = inferred.graph
-    for coll in (graph.input, graph.output, graph.value_info):
-        for vi in coll:
-            if vi.type.HasField("tensor_type"):
-                dims = _static_dims(vi.type.tensor_type.shape)
-                if dims is not None:
-                    shapes[vi.name] = dims
-    for init in graph.initializer:
-        shapes[init.name] = list(init.dims)
-    return shapes
-
-
-def _estimate_attention(
-    node: onnx.NodeProto, shapes: Dict[str, List[Optional[int]]]
-) -> Optional[AttentionPrecisionEstimate]:
-    if node.op_type != "Attention" or len(node.input) < 3:
-        return None
-    q_shape = shapes.get(node.input[0])
-    k_shape = shapes.get(node.input[1])
-
-    q_heads = _get_attr_int(node, "q_num_heads", 0) or None
-    kv_heads = _get_attr_int(node, "kv_num_heads", 0) or None
-    head_dim: Optional[int] = None
-
-    if q_shape and len(q_shape) == 4 and q_shape[3] is not None:
-        q_heads = q_shape[1] if q_shape[1] is not None else q_heads
-        head_dim = q_shape[3]
-        if k_shape and len(k_shape) == 4:
-            kv_heads = k_shape[1] if k_shape[1] is not None else kv_heads
-    elif (
-        q_shape
-        and k_shape
-        and len(q_shape) == 3
-        and len(k_shape) == 3
-        and kv_heads
-        and k_shape[2] is not None
-    ):
-        head_dim = k_shape[2] // kv_heads
-
-    default_scale = 1.0 / math.sqrt(head_dim) if head_dim else None
-    actual_scale = _get_attr_float(node, "scale")
-    matches: Optional[bool] = None
-    if default_scale is not None and actual_scale is not None:
-        matches = math.isclose(default_scale, actual_scale, rel_tol=1e-3)
-
-    if head_dim is None:
-        recommendation = (
-            "head_dim could not be determined statically (dynamic/unknown shape "
-            "and no q_num_heads/kv_num_heads attributes) -- no estimate available"
-        )
-    elif matches is False:
-        recommendation = (
-            f"scale={actual_scale!r} attribute does not match the canonical "
-            f"1/sqrt(head_dim)={default_scale:.6g}: pre-softmax QK^T logits will "
-            "grow unnormalized with head_dim, risking saturation/overflow in a "
-            "low-precision (e.g. fp16) softmax"
-        )
-    else:
-        recommendation = (
-            "scale normalizes QK^T's head_dim-dependent growth as expected; "
-            "no int8 accumulator applies here since Q/K/V are runtime activations, "
-            "not a static weight"
-        )
-
-    return AttentionPrecisionEstimate(
-        node_name=node.name or "Attention",
-        num_query_heads=q_heads,
-        num_kv_heads=kv_heads,
-        head_dim=head_dim,
-        default_scale=default_scale,
-        actual_scale=actual_scale,
-        scale_matches_default=matches,
-        recommendation=recommendation,
-    )
-
-
-def estimate_quantization_precision(model: onnx.ModelProto) -> List[PrecisionEstimate]:
-    """Per-node INT8-quantization precision estimates for `model`.
-
-    Walks every MatMul, Gemm, Conv, and (ai.onnx opset 23+) Attention node in
-    the top-level graph (subgraphs -- e.g. inside If/Loop/Scan -- are not
-    descended into) and returns one estimate per node whose weight is a
-    top-level graph initializer (nodes whose weight comes from a Constant
-    node, a subgraph, or isn't a float MatMul-like/Conv shape are skipped).
-    This never modifies `model`.
-    """
-    initializers = {init.name: init for init in model.graph.initializer}
-    shapes = _collect_static_shapes(model)
-    producer = {out: node for node in model.graph.node for out in node.output if out}
-
-    estimates: List[PrecisionEstimate] = []
-    for node in model.graph.node:
-        est: Optional[PrecisionEstimate]
-        if node.op_type in ("MatMul", "Gemm"):
-            est = _estimate_matmul_gemm(node, initializers, producer)
-        elif node.op_type == "Conv":
-            est = _estimate_conv(node, initializers, producer)
-        elif node.op_type == "Attention":
-            est = _estimate_attention(node, shapes)
-        else:
-            est = None
-        if est is not None:
-            estimates.append(est)
-    return estimates
-
-
-# sqrt(12): the standard deviation, in units of the quantization step size Delta,
-# of a uniformly-distributed quantization error in [-Delta/2, Delta/2] -- the
-# textbook uniform-quantizer noise model this module's aggregate error estimate
-# below is built on.
-_UNIFORM_QUANTIZER_NOISE_DIVISOR = 127.0 * math.sqrt(12.0)
-
-
 @dataclass
 class ModelQuantizationEstimate:
     """A single, whole-model rollup of :func:`estimate_quantization_precision`'s
@@ -520,6 +169,105 @@ class ModelQuantizationEstimate:
     estimated_relative_error: float  # see docstring below; nan if any unsafe_nodes
     risk_level: str  # "unsafe" | "degraded" | "safe"
     per_node: List[PrecisionEstimate]
+
+
+def _weight_estimate_from_tuple(t) -> Union[MatMulGemmPrecisionEstimate, ConvPrecisionEstimate]:
+    (
+        node_name,
+        op_type,
+        reduction_depth,
+        num_channels,
+        int32_accumulator_safe,
+        float32_cast_exact,
+        max_outlier_ratio,
+        outlier_risk,
+        activation_producer_op,
+        activation_range_lo,
+        activation_range_hi,
+        recommendation,
+    ) = t
+    activation_range = (
+        (activation_range_lo, activation_range_hi)
+        if activation_range_lo is not None
+        else None
+    )
+    if op_type == "Conv":
+        return ConvPrecisionEstimate(
+            node_name=node_name,
+            reduction_depth=reduction_depth,
+            num_channels=num_channels,
+            int32_accumulator_safe=int32_accumulator_safe,
+            float32_cast_exact=float32_cast_exact,
+            max_outlier_ratio=max_outlier_ratio,
+            outlier_risk=outlier_risk,
+            activation_producer_op=activation_producer_op,
+            activation_range=activation_range,
+            recommendation=recommendation,
+        )
+    return MatMulGemmPrecisionEstimate(
+        node_name=node_name,
+        op_type=op_type,
+        reduction_depth=reduction_depth,
+        num_channels=num_channels,
+        int32_accumulator_safe=int32_accumulator_safe,
+        float32_cast_exact=float32_cast_exact,
+        max_outlier_ratio=max_outlier_ratio,
+        outlier_risk=outlier_risk,
+        activation_producer_op=activation_producer_op,
+        activation_range=activation_range,
+        recommendation=recommendation,
+    )
+
+
+def _attention_estimate_from_tuple(t) -> AttentionPrecisionEstimate:
+    (
+        node_name,
+        num_query_heads,
+        num_kv_heads,
+        head_dim,
+        default_scale,
+        actual_scale,
+        scale_matches_default,
+        recommendation,
+    ) = t
+    return AttentionPrecisionEstimate(
+        node_name=node_name,
+        num_query_heads=num_query_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        default_scale=default_scale,
+        actual_scale=actual_scale,
+        scale_matches_default=scale_matches_default,
+        recommendation=recommendation,
+    )
+
+
+def _call_estimator(model: onnx.ModelProto):
+    # Imported lazily so importing ``onnxsim.precision_estimator`` never forces
+    # the compiled extension at module load, and cannot form an import cycle
+    # with the extension -- mirrors onnxsim.model_info's own lazy import of
+    # the same extension module.
+    from onnxsim import onnxsim_cpp2py_export as _C
+
+    return _C._estimate_model_quantization_drop(model.SerializeToString())
+
+
+def estimate_quantization_precision(model: onnx.ModelProto) -> List[PrecisionEstimate]:
+    """Per-node INT8-quantization precision estimates for `model`.
+
+    Walks every MatMul, Gemm, Conv, and (ai.onnx opset 23+) Attention node in
+    the top-level graph (subgraphs -- e.g. inside If/Loop/Scan -- are not
+    descended into) and returns one estimate per node whose weight is a
+    top-level graph initializer (nodes whose weight comes from a Constant
+    node, a subgraph, or isn't a float MatMul-like/Conv shape are skipped).
+    This never modifies `model`.
+    """
+    _, _, _, _, _, _, weight_tuples, attention_tuples = _call_estimator(model)
+    estimates: List[PrecisionEstimate] = [
+        _weight_estimate_from_tuple(t) for t in weight_tuples
+    ]
+    estimates.extend(_attention_estimate_from_tuple(t) for t in attention_tuples)
+    return estimates
 
 
 def estimate_model_quantization_drop(
@@ -573,38 +321,26 @@ def estimate_model_quantization_drop(
     Attention nodes are excluded from this sum (no weight-quantization error
     term applies to them in this scheme -- see this module's docstring).
     """
-    per_node = estimate_quantization_precision(model)
-
-    unsafe_nodes = []
-    outlier_risk_nodes = []
-    outlier_ratios = []
-    squared_errors = []
-    for est in per_node:
-        if isinstance(est, AttentionPrecisionEstimate):
-            continue
-        if not est.int32_accumulator_safe:
-            unsafe_nodes.append(est.node_name)
-            continue
-        if est.outlier_risk:
-            outlier_risk_nodes.append(est.node_name)
-        if not math.isnan(est.max_outlier_ratio):
-            outlier_ratios.append(est.max_outlier_ratio)
-        ratio = est.max_outlier_ratio if not math.isnan(est.max_outlier_ratio) else 1.0
-        per_node_relative_error = ratio / _UNIFORM_QUANTIZER_NOISE_DIVISOR
-        squared_errors.append(per_node_relative_error**2)
-
-    if unsafe_nodes:
-        risk_level = "unsafe"
-        estimated_relative_error = math.nan
-    else:
-        risk_level = "degraded" if outlier_risk_nodes else "safe"
-        estimated_relative_error = math.sqrt(sum(squared_errors))
+    (
+        total_nodes_analyzed,
+        unsafe_nodes,
+        outlier_risk_nodes,
+        worst_outlier_ratio,
+        estimated_relative_error,
+        risk_level,
+        weight_tuples,
+        attention_tuples,
+    ) = _call_estimator(model)
+    per_node: List[PrecisionEstimate] = [
+        _weight_estimate_from_tuple(t) for t in weight_tuples
+    ]
+    per_node.extend(_attention_estimate_from_tuple(t) for t in attention_tuples)
 
     return ModelQuantizationEstimate(
-        total_nodes_analyzed=len(per_node),
-        unsafe_nodes=unsafe_nodes,
-        outlier_risk_nodes=outlier_risk_nodes,
-        worst_outlier_ratio=max(outlier_ratios) if outlier_ratios else math.nan,
+        total_nodes_analyzed=total_nodes_analyzed,
+        unsafe_nodes=list(unsafe_nodes),
+        outlier_risk_nodes=list(outlier_risk_nodes),
+        worst_outlier_ratio=worst_outlier_ratio,
         estimated_relative_error=estimated_relative_error,
         risk_level=risk_level,
         per_node=per_node,

--- a/onnxsim/precision_estimator_test.cpp
+++ b/onnxsim/precision_estimator_test.cpp
@@ -1,0 +1,533 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Exercises precision_estimator.{h,cpp} -- the C++ port of
+ * onnxsim/precision_estimator.py's static INT8-quantization risk analysis.
+ * Mirrors tests/test_precision_estimator.py's cases (same models, same
+ * expected values) so the two implementations are checked against the same
+ * ground truth. Needs onnx configured, so this links the fully-configured
+ * `onnxsim` CMake target rather than building standalone.
+ */
+#include "precision_estimator.h"
+
+#include <onnx/onnx_pb.h>
+
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <random>
+#include <string>
+#include <vector>
+
+using onnxsim::AttentionPrecisionEstimate;
+using onnxsim::EstimateModelQuantizationDrop;
+using onnxsim::EstimateQuantizationPrecision;
+using onnxsim::WeightPrecisionEstimate;
+
+namespace {
+
+int g_failures = 0;
+
+void Check(bool cond, const std::string& what) {
+  if (!cond) {
+    std::fprintf(stderr, "FAIL: %s\n", what.c_str());
+    ++g_failures;
+  }
+}
+
+void CheckClose(double a, double b, const std::string& what, double rtol = 1e-6) {
+  Check(std::fabs(a - b) <= rtol * std::max(std::fabs(a), std::fabs(b)), what);
+}
+
+// Same formulas precision_estimator.cpp itself uses (kept independent here,
+// as a from-scratch cross-check rather than importing the .cpp's private
+// constants).
+int64_t MaxSafeInt32ReductionDepth() {
+  return (int64_t{2147483647}) / (127 * 255);
+}
+int64_t MaxExactFloat32ReductionDepth() {
+  return (int64_t{1} << 24) / (127 * 255);
+}
+constexpr double kOutlierRatioThreshold = 127.0;
+
+onnx::TensorProto MakeFloatInitializer(const std::string& name,
+                                       const std::vector<int64_t>& dims,
+                                       const std::vector<float>& data,
+                                       bool raw) {
+  onnx::TensorProto t;
+  t.set_name(name);
+  t.set_data_type(onnx::TensorProto::FLOAT);
+  for (int64_t d : dims) t.add_dims(d);
+  if (raw) {
+    t.set_raw_data(std::string(reinterpret_cast<const char*>(data.data()),
+                               data.size() * sizeof(float)));
+  } else {
+    for (float v : data) t.add_float_data(v);
+  }
+  return t;
+}
+
+onnx::ValueInfoProto MakeValueInfo(const std::string& name,
+                                   const std::vector<int64_t>& dims) {
+  onnx::ValueInfoProto vi;
+  vi.set_name(name);
+  auto* tt = vi.mutable_type()->mutable_tensor_type();
+  tt->set_elem_type(onnx::TensorProto::FLOAT);
+  auto* shape = tt->mutable_shape();
+  for (int64_t d : dims) shape->add_dim()->set_dim_value(d);
+  return vi;
+}
+
+onnx::NodeProto MakeNode(const std::string& op_type,
+                         const std::vector<std::string>& inputs,
+                         const std::vector<std::string>& outputs) {
+  onnx::NodeProto n;
+  n.set_op_type(op_type);
+  for (const auto& i : inputs) n.add_input(i);
+  for (const auto& o : outputs) n.add_output(o);
+  return n;
+}
+
+void AddIntAttr(onnx::NodeProto& n, const std::string& name, int64_t v) {
+  auto* a = n.add_attribute();
+  a->set_name(name);
+  a->set_type(onnx::AttributeProto::INT);
+  a->set_i(v);
+}
+
+void AddFloatAttr(onnx::NodeProto& n, const std::string& name, float v) {
+  auto* a = n.add_attribute();
+  a->set_name(name);
+  a->set_type(onnx::AttributeProto::FLOAT);
+  a->set_f(v);
+}
+
+onnx::ModelProto MakeModel(const std::vector<onnx::NodeProto>& nodes,
+                           const std::vector<onnx::ValueInfoProto>& inputs,
+                           const std::vector<onnx::ValueInfoProto>& outputs,
+                           const std::vector<onnx::TensorProto>& initializers,
+                           int opset = 17) {
+  onnx::ModelProto m;
+  m.set_ir_version(10);
+  auto* opset_import = m.add_opset_import();
+  opset_import->set_domain("");
+  opset_import->set_version(opset);
+  auto* graph = m.mutable_graph();
+  graph->set_name("g");
+  for (const auto& n : nodes) *graph->add_node() = n;
+  for (const auto& i : inputs) *graph->add_input() = i;
+  for (const auto& o : outputs) *graph->add_output() = o;
+  for (const auto& t : initializers) *graph->add_initializer() = t;
+  return m;
+}
+
+std::vector<float> RandomVec(size_t n, float scale, uint32_t seed) {
+  std::mt19937 rng(seed);
+  std::normal_distribution<float> dist(0.0f, 1.0f);
+  std::vector<float> out(n);
+  for (auto& v : out) v = dist(rng) * scale;
+  return out;
+}
+
+void TestMatMulSmallReductionDepthSafeAndExact() {
+  const int64_t K = 16, N = 4;
+  auto w = MakeFloatInitializer("W", {K, N}, RandomVec(K * N, 0.1f, 0), true);
+  auto node = MakeNode("MatMul", {"X", "W"}, {"Y"});
+  auto model = MakeModel({node}, {MakeValueInfo("X", {1, K})},
+                         {MakeValueInfo("Y", {1, N})}, {w});
+
+  std::vector<WeightPrecisionEstimate> weights;
+  std::vector<AttentionPrecisionEstimate> attn;
+  EstimateQuantizationPrecision(model, &weights, &attn);
+  Check(weights.size() == 1, "matmul small: one estimate");
+  if (weights.size() == 1) {
+    const auto& est = weights[0];
+    Check(est.op_type == "MatMul", "matmul small: op_type");
+    Check(est.reduction_depth == K, "matmul small: reduction_depth");
+    Check(est.num_channels == N, "matmul small: num_channels");
+    Check(est.int32_accumulator_safe, "matmul small: int32 safe");
+    Check(est.float32_cast_exact, "matmul small: float32 exact");
+    Check(!est.outlier_risk, "matmul small: no outlier risk");
+  }
+}
+
+void TestMatMulPastInt32BoundIsUnsafe() {
+  const int64_t k = MaxSafeInt32ReductionDepth() + 1;
+  auto w = MakeFloatInitializer("W", {k, 1}, RandomVec(k, 0.01f, 1), true);
+  auto node = MakeNode("MatMul", {"X", "W"}, {"Y"});
+  auto model = MakeModel({node}, {MakeValueInfo("X", {1, k})},
+                         {MakeValueInfo("Y", {1, 1})}, {w});
+
+  std::vector<WeightPrecisionEstimate> weights;
+  std::vector<AttentionPrecisionEstimate> attn;
+  EstimateQuantizationPrecision(model, &weights, &attn);
+  Check(weights.size() == 1, "matmul unsafe: one estimate");
+  if (!weights.empty()) {
+    Check(!weights[0].int32_accumulator_safe, "matmul unsafe: flagged unsafe");
+    Check(weights[0].recommendation.find("int32-safe bound") !=
+              std::string::npos,
+          "matmul unsafe: recommendation mentions bound");
+  }
+}
+
+void TestMatMulPastFloat32ExactButInt32Safe() {
+  const int64_t k = MaxExactFloat32ReductionDepth() + 1;
+  Check(k <= MaxSafeInt32ReductionDepth(), "sanity: still int32-safe");
+  auto w = MakeFloatInitializer("W", {k, 1}, RandomVec(k, 0.01f, 2), true);
+  auto node = MakeNode("MatMul", {"X", "W"}, {"Y"});
+  auto model = MakeModel({node}, {MakeValueInfo("X", {1, k})},
+                         {MakeValueInfo("Y", {1, 1})}, {w});
+
+  std::vector<WeightPrecisionEstimate> weights;
+  std::vector<AttentionPrecisionEstimate> attn;
+  EstimateQuantizationPrecision(model, &weights, &attn);
+  Check(weights.size() == 1, "float32 exact: one estimate");
+  if (!weights.empty()) {
+    Check(weights[0].int32_accumulator_safe, "float32 exact: int32 safe");
+    Check(!weights[0].float32_cast_exact, "float32 exact: not exact");
+    Check(weights[0].recommendation.find("not bit-exact") != std::string::npos,
+          "float32 exact: recommendation mentions rounding");
+  }
+}
+
+void TestMatMulOutlierChannelIsFlagged() {
+  const int64_t K = 32, N = 2;
+  auto data = RandomVec(K * N, 0.05f, 3);
+  for (int64_t i = 0; i < K; ++i) data[static_cast<size_t>(i * N + 1)] = 0.01f;
+  data[1] = 10.0f;  // channel 1, row 0: extreme outlier
+  auto w = MakeFloatInitializer("W", {K, N}, data, true);
+  auto node = MakeNode("MatMul", {"X", "W"}, {"Y"});
+  auto model = MakeModel({node}, {MakeValueInfo("X", {1, K})},
+                         {MakeValueInfo("Y", {1, N})}, {w});
+
+  std::vector<WeightPrecisionEstimate> weights;
+  std::vector<AttentionPrecisionEstimate> attn;
+  EstimateQuantizationPrecision(model, &weights, &attn);
+  Check(weights.size() == 1, "outlier: one estimate");
+  if (!weights.empty()) {
+    Check(weights[0].outlier_risk, "outlier: flagged");
+    Check(weights[0].max_outlier_ratio > kOutlierRatioThreshold,
+          "outlier: ratio above threshold");
+  }
+}
+
+void TestGemmTransBUsesTransposedLayout() {
+  const int64_t N = 4, K = 20;
+  auto w = MakeFloatInitializer("W", {N, K}, RandomVec(N * K, 0.1f, 4), true);
+  auto node = MakeNode("Gemm", {"X", "W"}, {"Y"});
+  AddIntAttr(node, "transB", 1);
+  auto model = MakeModel({node}, {MakeValueInfo("X", {1, K})},
+                         {MakeValueInfo("Y", {1, N})}, {w});
+
+  std::vector<WeightPrecisionEstimate> weights;
+  std::vector<AttentionPrecisionEstimate> attn;
+  EstimateQuantizationPrecision(model, &weights, &attn);
+  Check(weights.size() == 1, "gemm transB: one estimate");
+  if (!weights.empty()) {
+    Check(weights[0].op_type == "Gemm", "gemm transB: op_type");
+    Check(weights[0].reduction_depth == K, "gemm transB: reduction_depth");
+    Check(weights[0].num_channels == N, "gemm transB: num_channels");
+  }
+}
+
+void TestConvReductionDepthIsCinTimesKernelVolume() {
+  const int64_t cout = 6, cin = 3, kh = 5, kw = 5;
+  auto w = MakeFloatInitializer("W", {cout, cin, kh, kw},
+                                RandomVec(cout * cin * kh * kw, 0.1f, 5), true);
+  auto node = MakeNode("Conv", {"X", "W"}, {"Y"});
+  auto model =
+      MakeModel({node}, {MakeValueInfo("X", {1, cin, 16, 16})},
+               {MakeValueInfo("Y", {1, cout, 12, 12})}, {w});
+
+  std::vector<WeightPrecisionEstimate> weights;
+  std::vector<AttentionPrecisionEstimate> attn;
+  EstimateQuantizationPrecision(model, &weights, &attn);
+  Check(weights.size() == 1, "conv: one estimate");
+  if (!weights.empty()) {
+    Check(weights[0].op_type == "Conv", "conv: op_type");
+    Check(weights[0].reduction_depth == cin * kh * kw,
+          "conv: reduction_depth");
+    Check(weights[0].num_channels == cout, "conv: num_channels");
+  }
+}
+
+void TestAttentionReportsHeadDimAndFlagsScaleMismatch() {
+  const int64_t q_heads = 4, kv_heads = 4, head_dim = 8, sq = 6, skv = 6;
+  auto node = MakeNode("Attention", {"Q", "K", "V"}, {"O"});
+  AddIntAttr(node, "q_num_heads", q_heads);
+  AddIntAttr(node, "kv_num_heads", kv_heads);
+  AddFloatAttr(node, "scale", 1.0f);  // deliberately not 1/sqrt(head_dim)
+  auto model = MakeModel(
+      {node},
+      {MakeValueInfo("Q", {1, sq, q_heads * head_dim}),
+       MakeValueInfo("K", {1, skv, kv_heads * head_dim}),
+       MakeValueInfo("V", {1, skv, kv_heads * head_dim})},
+      {MakeValueInfo("O", {1, sq, q_heads * head_dim})}, {}, 23);
+
+  std::vector<WeightPrecisionEstimate> weights;
+  std::vector<AttentionPrecisionEstimate> attn;
+  EstimateQuantizationPrecision(model, &weights, &attn);
+  Check(attn.size() == 1, "attention mismatch: one estimate");
+  if (!attn.empty()) {
+    Check(attn[0].head_dim == head_dim, "attention mismatch: head_dim");
+    Check(attn[0].num_query_heads == q_heads,
+          "attention mismatch: num_query_heads");
+    Check(attn[0].num_kv_heads == kv_heads,
+          "attention mismatch: num_kv_heads");
+    CheckClose(attn[0].default_scale, 1.0 / std::sqrt(double(head_dim)),
+              "attention mismatch: default_scale");
+    Check(attn[0].scale_matches_default == 0,
+          "attention mismatch: flagged mismatched");
+    Check(attn[0].recommendation.find("does not match") != std::string::npos,
+          "attention mismatch: recommendation");
+  }
+}
+
+void TestAttentionScaleMatchingDefaultIsNotFlagged() {
+  const int64_t q_heads = 2, kv_heads = 2, head_dim = 16, sq = 4, skv = 4;
+  auto node = MakeNode("Attention", {"Q", "K", "V"}, {"O"});
+  AddIntAttr(node, "q_num_heads", q_heads);
+  AddIntAttr(node, "kv_num_heads", kv_heads);
+  auto model = MakeModel(
+      {node},
+      {MakeValueInfo("Q", {1, sq, q_heads * head_dim}),
+       MakeValueInfo("K", {1, skv, kv_heads * head_dim}),
+       MakeValueInfo("V", {1, skv, kv_heads * head_dim})},
+      {MakeValueInfo("O", {1, sq, q_heads * head_dim})}, {}, 23);
+
+  std::vector<WeightPrecisionEstimate> weights;
+  std::vector<AttentionPrecisionEstimate> attn;
+  EstimateQuantizationPrecision(model, &weights, &attn);
+  Check(attn.size() == 1, "attention no-mismatch: one estimate");
+  if (!attn.empty()) {
+    Check(std::isnan(attn[0].actual_scale),
+          "attention no-mismatch: no actual_scale");
+    Check(attn[0].scale_matches_default == -1,
+          "attention no-mismatch: unknown (no actual scale to compare)");
+    Check(attn[0].recommendation.find("no int8 accumulator applies") !=
+              std::string::npos,
+          "attention no-mismatch: recommendation");
+  }
+}
+
+void TestMatMulFedBySoftmaxReportsKnownActivationRange() {
+  const int64_t K = 32, N = 4;
+  auto w = MakeFloatInitializer("W", {K, N}, RandomVec(K * N, 0.1f, 7), true);
+  auto softmax = MakeNode("Softmax", {"X"}, {"S"});
+  auto matmul = MakeNode("MatMul", {"S", "W"}, {"Y"});
+  auto model = MakeModel({softmax, matmul}, {MakeValueInfo("X", {1, K})},
+                         {MakeValueInfo("Y", {1, N})}, {w});
+
+  std::vector<WeightPrecisionEstimate> weights;
+  std::vector<AttentionPrecisionEstimate> attn;
+  EstimateQuantizationPrecision(model, &weights, &attn);
+  Check(weights.size() == 1, "softmax range: one estimate");
+  if (!weights.empty()) {
+    Check(weights[0].activation_producer_op == "Softmax",
+          "softmax range: producer op");
+    Check(weights[0].has_activation_range, "softmax range: has range");
+    Check(weights[0].activation_range_lo == 0.0 &&
+              weights[0].activation_range_hi == 1.0,
+          "softmax range: (0, 1)");
+    Check(weights[0].int32_accumulator_safe,
+          "softmax range: still int32 safe");
+    Check(weights[0].recommendation.find(
+              "fixed static scale would quantize it exactly") !=
+              std::string::npos,
+          "softmax range: recommendation");
+  }
+}
+
+void TestConvFedByClipWithConstantBoundsReportsRange() {
+  const int64_t cout = 3, cin = 2, kh = 3, kw = 3;
+  auto w = MakeFloatInitializer("W", {cout, cin, kh, kw},
+                                RandomVec(cout * cin * kh * kw, 0.1f, 8), true);
+  auto lo = MakeFloatInitializer("lo", {}, {0.0f}, true);
+  auto hi = MakeFloatInitializer("hi", {}, {6.0f}, true);
+  auto clip = MakeNode("Clip", {"X", "lo", "hi"}, {"C"});
+  auto conv = MakeNode("Conv", {"C", "W"}, {"Y"});
+  auto model =
+      MakeModel({clip, conv}, {MakeValueInfo("X", {1, cin, 8, 8})},
+               {MakeValueInfo("Y", {1, cout, 6, 6})}, {w, lo, hi});
+
+  std::vector<WeightPrecisionEstimate> weights;
+  std::vector<AttentionPrecisionEstimate> attn;
+  EstimateQuantizationPrecision(model, &weights, &attn);
+  Check(weights.size() == 1, "clip range: one estimate");
+  if (!weights.empty()) {
+    Check(weights[0].activation_producer_op == "Clip", "clip range: producer");
+    Check(weights[0].activation_range_lo == 0.0 &&
+              weights[0].activation_range_hi == 6.0,
+          "clip range: (0, 6)");
+  }
+}
+
+void TestClipWithNonConstantBoundIsNotReportedAsKnownRange() {
+  auto w = MakeFloatInitializer("W", {16, 4}, RandomVec(16 * 4, 0.1f, 9), true);
+  auto clip = MakeNode("Clip", {"X", "lo", "hi"}, {"C"});
+  auto matmul = MakeNode("MatMul", {"C", "W"}, {"Y"});
+  auto lo = MakeFloatInitializer("lo", {}, {0.0f}, true);
+  auto model = MakeModel({clip, matmul},
+                         {MakeValueInfo("X", {1, 16}), MakeValueInfo("hi", {})},
+                         {MakeValueInfo("Y", {1, 4})}, {w, lo});
+
+  std::vector<WeightPrecisionEstimate> weights;
+  std::vector<AttentionPrecisionEstimate> attn;
+  EstimateQuantizationPrecision(model, &weights, &attn);
+  Check(weights.size() == 1, "clip non-const: one estimate");
+  if (!weights.empty()) {
+    Check(weights[0].activation_producer_op.empty(),
+          "clip non-const: no producer reported");
+    Check(!weights[0].has_activation_range, "clip non-const: no range");
+  }
+}
+
+void TestNonConstantWeightIsSkipped() {
+  auto node = MakeNode("MatMul", {"X", "W"}, {"Y"});
+  auto model = MakeModel(
+      {node}, {MakeValueInfo("X", {1, 8}), MakeValueInfo("W", {8, 4})},
+      {MakeValueInfo("Y", {1, 4})}, {});
+
+  std::vector<WeightPrecisionEstimate> weights;
+  std::vector<AttentionPrecisionEstimate> attn;
+  EstimateQuantizationPrecision(model, &weights, &attn);
+  Check(weights.empty() && attn.empty(), "non-constant weight: skipped");
+}
+
+void TestModelDropSafeWithNoOutliers() {
+  const int64_t K = 16, N = 4;
+  std::vector<float> data(static_cast<size_t>(K * N));
+  for (int64_t i = 0; i < K; ++i) {
+    for (int64_t j = 0; j < N; ++j) {
+      data[static_cast<size_t>(i * N + j)] = (i % 2 == 0) ? 0.1f : -0.1f;
+    }
+  }
+  auto w = MakeFloatInitializer("W", {K, N}, data, true);
+  auto node = MakeNode("MatMul", {"X", "W"}, {"Y"});
+  auto model = MakeModel({node}, {MakeValueInfo("X", {1, K})},
+                         {MakeValueInfo("Y", {1, N})}, {w});
+
+  auto est = EstimateModelQuantizationDrop(model);
+  Check(est.total_nodes_analyzed == 1, "model drop safe: total nodes");
+  Check(est.unsafe_nodes.empty(), "model drop safe: no unsafe nodes");
+  Check(est.outlier_risk_nodes.empty(), "model drop safe: no outlier nodes");
+  Check(est.risk_level == "safe", "model drop safe: risk_level");
+  CheckClose(est.worst_outlier_ratio, 1.0, "model drop safe: worst ratio", 1e-9);
+  CheckClose(est.estimated_relative_error, 1.0 / (127.0 * std::sqrt(12.0)),
+            "model drop safe: estimated error", 1e-9);
+}
+
+void TestModelDropDegradedWhenOutlierChannelPresent() {
+  const int64_t K = 32, N = 2;
+  auto data = RandomVec(K * N, 0.05f, 21);
+  for (int64_t i = 0; i < K; ++i) data[static_cast<size_t>(i * N + 1)] = 0.01f;
+  data[1] = 10.0f;
+  auto w = MakeFloatInitializer("W", {K, N}, data, true);
+  auto node = MakeNode("MatMul", {"X", "W"}, {"Y"});
+  auto model = MakeModel({node}, {MakeValueInfo("X", {1, K})},
+                         {MakeValueInfo("Y", {1, N})}, {w});
+
+  auto est = EstimateModelQuantizationDrop(model);
+  Check(est.risk_level == "degraded", "model drop degraded: risk_level");
+  Check(est.unsafe_nodes.empty(), "model drop degraded: no unsafe nodes");
+  Check(est.outlier_risk_nodes.size() == 1,
+        "model drop degraded: one outlier node");
+  Check(est.worst_outlier_ratio > kOutlierRatioThreshold,
+        "model drop degraded: worst ratio above threshold");
+  Check(est.estimated_relative_error > 1.0 / (127.0 * std::sqrt(12.0)),
+        "model drop degraded: error above baseline");
+}
+
+void TestModelDropUnsafeReportsNanErrorAndListsTheNode() {
+  const int64_t k = MaxSafeInt32ReductionDepth() + 1;
+  auto w = MakeFloatInitializer("W", {k, 1}, RandomVec(k, 0.01f, 22), true);
+  auto node = MakeNode("MatMul", {"X", "W"}, {"Y"});
+  auto model = MakeModel({node}, {MakeValueInfo("X", {1, k})},
+                         {MakeValueInfo("Y", {1, 1})}, {w});
+
+  auto est = EstimateModelQuantizationDrop(model);
+  Check(est.risk_level == "unsafe", "model drop unsafe: risk_level");
+  Check(est.unsafe_nodes.size() == 1, "model drop unsafe: one unsafe node");
+  Check(std::isnan(est.estimated_relative_error),
+        "model drop unsafe: NaN error");
+}
+
+void TestModelDropMoreUnsafeNodesWidenTheAggregateError() {
+  const int64_t K = 16, N = 4;
+  auto w1 = MakeFloatInitializer("W1", {K, N}, RandomVec(K * N, 0.1f, 23), true);
+  auto w2 = MakeFloatInitializer("W2", {K, N}, RandomVec(K * N, 0.1f, 24), true);
+  auto n1 = MakeNode("MatMul", {"X", "W1"}, {"Y1"});
+  auto n2 = MakeNode("MatMul", {"X", "W2"}, {"Y2"});
+  auto model_two =
+      MakeModel({n1, n2}, {MakeValueInfo("X", {1, K})},
+               {MakeValueInfo("Y1", {1, N}), MakeValueInfo("Y2", {1, N})},
+               {w1, w2});
+  auto model_one = MakeModel({n1}, {MakeValueInfo("X", {1, K})},
+                             {MakeValueInfo("Y1", {1, N})}, {w1});
+
+  auto est_two = EstimateModelQuantizationDrop(model_two);
+  auto est_one = EstimateModelQuantizationDrop(model_one);
+  Check(est_two.total_nodes_analyzed == 2, "model drop widen: two nodes");
+  Check(est_two.estimated_relative_error > est_one.estimated_relative_error,
+        "model drop widen: two-node error exceeds one-node error");
+}
+
+void TestModelDropNoAnalyzableNodesIsSafeWithZeroError() {
+  auto node = MakeNode("Relu", {"X"}, {"Y"});
+  auto model = MakeModel({node}, {MakeValueInfo("X", {1, 4})},
+                         {MakeValueInfo("Y", {1, 4})}, {});
+
+  auto est = EstimateModelQuantizationDrop(model);
+  Check(est.total_nodes_analyzed == 0, "model drop empty: zero nodes");
+  Check(est.risk_level == "safe", "model drop empty: safe");
+  Check(est.estimated_relative_error == 0.0, "model drop empty: zero error");
+}
+
+// One case built via the typed float_data field instead of raw_data, to
+// exercise ReadFloatTensorFlat's other branch (see precision_estimator.cpp).
+void TestFloatDataFieldStorageIsReadCorrectly() {
+  const int64_t K = 16, N = 4;
+  auto w = MakeFloatInitializer("W", {K, N}, RandomVec(K * N, 0.1f, 30), false);
+  Check(!w.has_raw_data(), "float_data path: no raw_data set");
+  auto node = MakeNode("MatMul", {"X", "W"}, {"Y"});
+  auto model = MakeModel({node}, {MakeValueInfo("X", {1, K})},
+                         {MakeValueInfo("Y", {1, N})}, {w});
+
+  std::vector<WeightPrecisionEstimate> weights;
+  std::vector<AttentionPrecisionEstimate> attn;
+  EstimateQuantizationPrecision(model, &weights, &attn);
+  Check(weights.size() == 1, "float_data path: one estimate");
+  if (!weights.empty()) {
+    Check(weights[0].reduction_depth == K, "float_data path: reduction_depth");
+  }
+}
+
+}  // namespace
+
+int main() {
+  TestMatMulSmallReductionDepthSafeAndExact();
+  TestMatMulPastInt32BoundIsUnsafe();
+  TestMatMulPastFloat32ExactButInt32Safe();
+  TestMatMulOutlierChannelIsFlagged();
+  TestGemmTransBUsesTransposedLayout();
+  TestConvReductionDepthIsCinTimesKernelVolume();
+  TestAttentionReportsHeadDimAndFlagsScaleMismatch();
+  TestAttentionScaleMatchingDefaultIsNotFlagged();
+  TestMatMulFedBySoftmaxReportsKnownActivationRange();
+  TestConvFedByClipWithConstantBoundsReportsRange();
+  TestClipWithNonConstantBoundIsNotReportedAsKnownRange();
+  TestNonConstantWeightIsSkipped();
+  TestModelDropSafeWithNoOutliers();
+  TestModelDropDegradedWhenOutlierChannelPresent();
+  TestModelDropUnsafeReportsNanErrorAndListsTheNode();
+  TestModelDropMoreUnsafeNodesWidenTheAggregateError();
+  TestModelDropNoAnalyzableNodesIsSafeWithZeroError();
+  TestFloatDataFieldStorageIsReadCorrectly();
+
+  if (g_failures == 0) {
+    std::printf("precision_estimator_test: all checks passed\n");
+    return 0;
+  }
+  std::fprintf(stderr, "precision_estimator_test: %d failure(s)\n", g_failures);
+  return 1;
+}

--- a/onnxsim/precision_estimator_test.cpp
+++ b/onnxsim/precision_estimator_test.cpp
@@ -19,6 +19,8 @@
 #include <string>
 #include <vector>
 
+#include "dlpack_dtype.h"
+
 using onnxsim::AttentionPrecisionEstimate;
 using onnxsim::EstimateModelQuantizationDrop;
 using onnxsim::EstimateQuantizationPrecision;
@@ -60,8 +62,21 @@ onnx::TensorProto MakeFloatInitializer(const std::string& name,
   t.set_data_type(onnx::TensorProto::FLOAT);
   for (int64_t d : dims) t.add_dims(d);
   if (raw) {
-    t.set_raw_data(std::string(reinterpret_cast<const char*>(data.data()),
-                               data.size() * sizeof(float)));
+    // ONNX's raw_data wire format is little-endian on every host (see
+    // endian_read.h's doc comment and precision_estimator.cpp's
+    // ReadFloatTensorFlat, which this mirrors on the write side) -- so this
+    // must byte-swap on a big-endian host, not just memcpy the host-native
+    // float bytes verbatim, else this test builds a malformed raw_data blob
+    // that only happens to read back correctly on the little-endian hosts
+    // most CI runs on.
+    std::string bytes(reinterpret_cast<const char*>(data.data()),
+                      data.size() * sizeof(float));
+    if constexpr (!onnxsim::dlpack::kRawDataIsHostOrder) {
+      onnxsim::dlpack::SwapElementBytes(
+          reinterpret_cast<uint8_t*>(bytes.data()), bytes.size(),
+          sizeof(float));
+    }
+    t.set_raw_data(std::move(bytes));
   } else {
     for (float v : data) t.add_float_data(v);
   }

--- a/onnxsim/precision_estimator_test.cpp
+++ b/onnxsim/precision_estimator_test.cpp
@@ -35,7 +35,8 @@ void Check(bool cond, const std::string& what) {
   }
 }
 
-void CheckClose(double a, double b, const std::string& what, double rtol = 1e-6) {
+void CheckClose(double a, double b, const std::string& what,
+                double rtol = 1e-6) {
   Check(std::fabs(a - b) <= rtol * std::max(std::fabs(a), std::fabs(b)), what);
 }
 
@@ -164,9 +165,9 @@ void TestMatMulPastInt32BoundIsUnsafe() {
   Check(weights.size() == 1, "matmul unsafe: one estimate");
   if (!weights.empty()) {
     Check(!weights[0].int32_accumulator_safe, "matmul unsafe: flagged unsafe");
-    Check(weights[0].recommendation.find("int32-safe bound") !=
-              std::string::npos,
-          "matmul unsafe: recommendation mentions bound");
+    Check(
+        weights[0].recommendation.find("int32-safe bound") != std::string::npos,
+        "matmul unsafe: recommendation mentions bound");
   }
 }
 
@@ -235,9 +236,8 @@ void TestConvReductionDepthIsCinTimesKernelVolume() {
   auto w = MakeFloatInitializer("W", {cout, cin, kh, kw},
                                 RandomVec(cout * cin * kh * kw, 0.1f, 5), true);
   auto node = MakeNode("Conv", {"X", "W"}, {"Y"});
-  auto model =
-      MakeModel({node}, {MakeValueInfo("X", {1, cin, 16, 16})},
-               {MakeValueInfo("Y", {1, cout, 12, 12})}, {w});
+  auto model = MakeModel({node}, {MakeValueInfo("X", {1, cin, 16, 16})},
+                         {MakeValueInfo("Y", {1, cout, 12, 12})}, {w});
 
   std::vector<WeightPrecisionEstimate> weights;
   std::vector<AttentionPrecisionEstimate> attn;
@@ -245,8 +245,7 @@ void TestConvReductionDepthIsCinTimesKernelVolume() {
   Check(weights.size() == 1, "conv: one estimate");
   if (!weights.empty()) {
     Check(weights[0].op_type == "Conv", "conv: op_type");
-    Check(weights[0].reduction_depth == cin * kh * kw,
-          "conv: reduction_depth");
+    Check(weights[0].reduction_depth == cin * kh * kw, "conv: reduction_depth");
     Check(weights[0].num_channels == cout, "conv: num_channels");
   }
 }
@@ -257,12 +256,12 @@ void TestAttentionReportsHeadDimAndFlagsScaleMismatch() {
   AddIntAttr(node, "q_num_heads", q_heads);
   AddIntAttr(node, "kv_num_heads", kv_heads);
   AddFloatAttr(node, "scale", 1.0f);  // deliberately not 1/sqrt(head_dim)
-  auto model = MakeModel(
-      {node},
-      {MakeValueInfo("Q", {1, sq, q_heads * head_dim}),
-       MakeValueInfo("K", {1, skv, kv_heads * head_dim}),
-       MakeValueInfo("V", {1, skv, kv_heads * head_dim})},
-      {MakeValueInfo("O", {1, sq, q_heads * head_dim})}, {}, 23);
+  auto model =
+      MakeModel({node},
+                {MakeValueInfo("Q", {1, sq, q_heads * head_dim}),
+                 MakeValueInfo("K", {1, skv, kv_heads * head_dim}),
+                 MakeValueInfo("V", {1, skv, kv_heads * head_dim})},
+                {MakeValueInfo("O", {1, sq, q_heads * head_dim})}, {}, 23);
 
   std::vector<WeightPrecisionEstimate> weights;
   std::vector<AttentionPrecisionEstimate> attn;
@@ -272,10 +271,9 @@ void TestAttentionReportsHeadDimAndFlagsScaleMismatch() {
     Check(attn[0].head_dim == head_dim, "attention mismatch: head_dim");
     Check(attn[0].num_query_heads == q_heads,
           "attention mismatch: num_query_heads");
-    Check(attn[0].num_kv_heads == kv_heads,
-          "attention mismatch: num_kv_heads");
+    Check(attn[0].num_kv_heads == kv_heads, "attention mismatch: num_kv_heads");
     CheckClose(attn[0].default_scale, 1.0 / std::sqrt(double(head_dim)),
-              "attention mismatch: default_scale");
+               "attention mismatch: default_scale");
     Check(attn[0].scale_matches_default == 0,
           "attention mismatch: flagged mismatched");
     Check(attn[0].recommendation.find("does not match") != std::string::npos,
@@ -288,12 +286,12 @@ void TestAttentionScaleMatchingDefaultIsNotFlagged() {
   auto node = MakeNode("Attention", {"Q", "K", "V"}, {"O"});
   AddIntAttr(node, "q_num_heads", q_heads);
   AddIntAttr(node, "kv_num_heads", kv_heads);
-  auto model = MakeModel(
-      {node},
-      {MakeValueInfo("Q", {1, sq, q_heads * head_dim}),
-       MakeValueInfo("K", {1, skv, kv_heads * head_dim}),
-       MakeValueInfo("V", {1, skv, kv_heads * head_dim})},
-      {MakeValueInfo("O", {1, sq, q_heads * head_dim})}, {}, 23);
+  auto model =
+      MakeModel({node},
+                {MakeValueInfo("Q", {1, sq, q_heads * head_dim}),
+                 MakeValueInfo("K", {1, skv, kv_heads * head_dim}),
+                 MakeValueInfo("V", {1, skv, kv_heads * head_dim})},
+                {MakeValueInfo("O", {1, sq, q_heads * head_dim})}, {}, 23);
 
   std::vector<WeightPrecisionEstimate> weights;
   std::vector<AttentionPrecisionEstimate> attn;
@@ -329,8 +327,7 @@ void TestMatMulFedBySoftmaxReportsKnownActivationRange() {
     Check(weights[0].activation_range_lo == 0.0 &&
               weights[0].activation_range_hi == 1.0,
           "softmax range: (0, 1)");
-    Check(weights[0].int32_accumulator_safe,
-          "softmax range: still int32 safe");
+    Check(weights[0].int32_accumulator_safe, "softmax range: still int32 safe");
     Check(weights[0].recommendation.find(
               "fixed static scale would quantize it exactly") !=
               std::string::npos,
@@ -346,9 +343,8 @@ void TestConvFedByClipWithConstantBoundsReportsRange() {
   auto hi = MakeFloatInitializer("hi", {}, {6.0f}, true);
   auto clip = MakeNode("Clip", {"X", "lo", "hi"}, {"C"});
   auto conv = MakeNode("Conv", {"C", "W"}, {"Y"});
-  auto model =
-      MakeModel({clip, conv}, {MakeValueInfo("X", {1, cin, 8, 8})},
-               {MakeValueInfo("Y", {1, cout, 6, 6})}, {w, lo, hi});
+  auto model = MakeModel({clip, conv}, {MakeValueInfo("X", {1, cin, 8, 8})},
+                         {MakeValueInfo("Y", {1, cout, 6, 6})}, {w, lo, hi});
 
   std::vector<WeightPrecisionEstimate> weights;
   std::vector<AttentionPrecisionEstimate> attn;
@@ -412,9 +408,10 @@ void TestModelDropSafeWithNoOutliers() {
   Check(est.unsafe_nodes.empty(), "model drop safe: no unsafe nodes");
   Check(est.outlier_risk_nodes.empty(), "model drop safe: no outlier nodes");
   Check(est.risk_level == "safe", "model drop safe: risk_level");
-  CheckClose(est.worst_outlier_ratio, 1.0, "model drop safe: worst ratio", 1e-9);
+  CheckClose(est.worst_outlier_ratio, 1.0, "model drop safe: worst ratio",
+             1e-9);
   CheckClose(est.estimated_relative_error, 1.0 / (127.0 * std::sqrt(12.0)),
-            "model drop safe: estimated error", 1e-9);
+             "model drop safe: estimated error", 1e-9);
 }
 
 void TestModelDropDegradedWhenOutlierChannelPresent() {
@@ -454,14 +451,15 @@ void TestModelDropUnsafeReportsNanErrorAndListsTheNode() {
 
 void TestModelDropMoreUnsafeNodesWidenTheAggregateError() {
   const int64_t K = 16, N = 4;
-  auto w1 = MakeFloatInitializer("W1", {K, N}, RandomVec(K * N, 0.1f, 23), true);
-  auto w2 = MakeFloatInitializer("W2", {K, N}, RandomVec(K * N, 0.1f, 24), true);
+  auto w1 =
+      MakeFloatInitializer("W1", {K, N}, RandomVec(K * N, 0.1f, 23), true);
+  auto w2 =
+      MakeFloatInitializer("W2", {K, N}, RandomVec(K * N, 0.1f, 24), true);
   auto n1 = MakeNode("MatMul", {"X", "W1"}, {"Y1"});
   auto n2 = MakeNode("MatMul", {"X", "W2"}, {"Y2"});
-  auto model_two =
-      MakeModel({n1, n2}, {MakeValueInfo("X", {1, K})},
-               {MakeValueInfo("Y1", {1, N}), MakeValueInfo("Y2", {1, N})},
-               {w1, w2});
+  auto model_two = MakeModel(
+      {n1, n2}, {MakeValueInfo("X", {1, K})},
+      {MakeValueInfo("Y1", {1, N}), MakeValueInfo("Y2", {1, N})}, {w1, w2});
   auto model_one = MakeModel({n1}, {MakeValueInfo("X", {1, K})},
                              {MakeValueInfo("Y1", {1, N})}, {w1});
 

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -318,6 +318,17 @@ agraph (float[N] X) =&gt; (float[N] Y) {
                 <input type="radio" name="quantize-source" value="converted" id="quantize_source_converted">
                 <label for="quantize_source_converted" title="Runs the selected quantize method on the Convert section's own simplify/optimize output, so it applies to already-simplified graphs (e.g. fused Conv+BN, MatMul+Add -> Gemm) rather than the raw upload. Run Simplify/Optimize above first.">onnxsim-simplified (Convert section result)</label>
             </div>
+            <p class="tool-note">
+                Before picking a method, you can check whether INT8 (Dynamic /
+                Static / QOperator's scheme) looks numerically safe for this
+                model -- a static analysis of its own weights and shapes, no
+                execution or calibration data needed, so it runs instantly.
+            </p>
+            <div class="debug-actions">
+                <button id="quantize-risk-button" type="button">Check quantization risk</button>
+                <span id="quantize-risk-status" class="tool-note"></span>
+            </div>
+            <div id="quantize-risk-result" style="display: none; margin-top: 0.4em;"></div>
             <p class="tool-note">Pick a method:</p>
             <ul class="tool-note">
                 <li><b>Dynamic</b> -- MatMul/Gemm weights are quantized to INT8
@@ -415,6 +426,7 @@ agraph (float[N] X) =&gt; (float[N] Y) {
             </div>
         </div>
         <script type="module" src="./quantize_ui.mjs"></script>
+        <script type="module" src="./quantize_risk_estimate.mjs"></script>
         <h2 id="sec-visualize">Visualize with Netron (before / after)</h2>
         <p>
             Renders the model graph with a self-hosted

--- a/scripts/convertmodel/interface.cpp
+++ b/scripts/convertmodel/interface.cpp
@@ -1,5 +1,6 @@
 #include "onnxsim.h"
 #include "model_info.h"
+#include "precision_estimator.h"
 #include "onnxoptimizer/optimize.h"
 #include "onnx/checker.h"
 #include "onnx/defs/parser.h"
@@ -934,6 +935,99 @@ em::val onnxsim_quantize_fp8(const std::string& data, const std::string& format)
     }
 }
 
+em::val WeightPrecisionEstimateToVal(const onnxsim::WeightPrecisionEstimate& est) {
+    em::val out = em::val::object();
+    out.set("nodeName", est.node_name);
+    out.set("opType", est.op_type);
+    out.set("reductionDepth", static_cast<double>(est.reduction_depth));
+    out.set("numChannels", static_cast<double>(est.num_channels));
+    out.set("int32AccumulatorSafe", est.int32_accumulator_safe);
+    out.set("float32CastExact", est.float32_cast_exact);
+    out.set("maxOutlierRatio", est.max_outlier_ratio);
+    out.set("outlierRisk", est.outlier_risk);
+    out.set("activationProducerOp", est.activation_producer_op);
+    out.set("hasActivationRange", est.has_activation_range);
+    out.set("activationRangeLo", est.activation_range_lo);
+    out.set("activationRangeHi", est.activation_range_hi);
+    out.set("recommendation", est.recommendation);
+    return out;
+}
+
+em::val AttentionPrecisionEstimateToVal(const onnxsim::AttentionPrecisionEstimate& est) {
+    em::val out = em::val::object();
+    out.set("nodeName", est.node_name);
+    out.set("hasNumQueryHeads", est.has_num_query_heads);
+    out.set("numQueryHeads", static_cast<double>(est.num_query_heads));
+    out.set("hasNumKvHeads", est.has_num_kv_heads);
+    out.set("numKvHeads", static_cast<double>(est.num_kv_heads));
+    out.set("hasHeadDim", est.has_head_dim);
+    out.set("headDim", static_cast<double>(est.head_dim));
+    out.set("defaultScale", est.default_scale);
+    out.set("actualScale", est.actual_scale);
+    // -1 = unknown, 0 = false, 1 = true -- see AttentionPrecisionEstimate's
+    // doc comment in precision_estimator.h.
+    out.set("scaleMatchesDefault", est.scale_matches_default);
+    out.set("recommendation", est.recommendation);
+    return out;
+}
+
+// Static, calibration-free INT8-quantization risk pre-check -- see
+// precision_estimator.h (a C++ port of onnxsim/precision_estimator.py's
+// estimate_model_quantization_drop, kept in exact sync with it). Purely a
+// read-only analysis of the model's own weights and shapes: no execution and
+// no calibration data needed, so the page can run this the instant a model
+// loads -- before the user has picked a quantize method or run anything
+// through onnxruntime-web. Returns null on parse failure, else an object
+// mirroring onnxsim.ModelQuantizationEstimate: { totalNodesAnalyzed,
+// unsafeNodes, outlierRiskNodes, worstOutlierRatio, estimatedRelativeError,
+// riskLevel, weightEstimates: [...], attentionEstimates: [...] } (NaN fields
+// -- e.g. worstOutlierRatio when no node had a computable ratio, or
+// estimatedRelativeError when riskLevel is "unsafe" -- come through as the JS
+// value NaN, exactly like Python's math.nan does for the same fields).
+em::val onnxsim_estimate_quantization_drop(const std::string& data) {
+    onnx::ModelProto xmodel;
+    if (!xmodel.ParseFromArray(data.data(), data.size())) {
+        std::cerr << "Parse failed" << std::endl;
+        return em::val::null();
+    }
+    onnxsim::ModelQuantizationEstimate est;
+    try {
+        est = onnxsim::EstimateModelQuantizationDrop(xmodel);
+    } catch (const std::exception& e) {
+        std::cerr << "estimate_quantization_drop error: " << e.what() << std::endl;
+        return em::val::null();
+    }
+
+    em::val out = em::val::object();
+    out.set("totalNodesAnalyzed", static_cast<double>(est.total_nodes_analyzed));
+    em::val unsafe_nodes = em::val::array();
+    for (size_t i = 0; i < est.unsafe_nodes.size(); ++i) {
+        unsafe_nodes.set(i, est.unsafe_nodes[i]);
+    }
+    out.set("unsafeNodes", unsafe_nodes);
+    em::val outlier_nodes = em::val::array();
+    for (size_t i = 0; i < est.outlier_risk_nodes.size(); ++i) {
+        outlier_nodes.set(i, est.outlier_risk_nodes[i]);
+    }
+    out.set("outlierRiskNodes", outlier_nodes);
+    out.set("worstOutlierRatio", est.worst_outlier_ratio);
+    out.set("estimatedRelativeError", est.estimated_relative_error);
+    out.set("riskLevel", est.risk_level);
+
+    em::val weight_estimates = em::val::array();
+    for (size_t i = 0; i < est.weight_estimates.size(); ++i) {
+        weight_estimates.set(i, WeightPrecisionEstimateToVal(est.weight_estimates[i]));
+    }
+    out.set("weightEstimates", weight_estimates);
+
+    em::val attention_estimates = em::val::array();
+    for (size_t i = 0; i < est.attention_estimates.size(); ++i) {
+        attention_estimates.set(i, AttentionPrecisionEstimateToVal(est.attention_estimates[i]));
+    }
+    out.set("attentionEstimates", attention_estimates);
+    return out;
+}
+
 // Both list_* functions below are used by the page to discover which tensor
 // names to calibrate (run the model over sample inputs and record each
 // tensor's observed min/max) before calling quantize_static/quantize_qoperator.
@@ -1043,6 +1137,9 @@ EMSCRIPTEN_BINDINGS(module) {
     function("onnxsim_quantize_fp16", &onnxsim_quantize_fp16);
     function("onnxsim_quantize_bf16", &onnxsim_quantize_bf16);
     function("onnxsim_quantize_fp8", &onnxsim_quantize_fp8);
+    // Static, calibration-free INT8-quantization risk pre-check (see its own
+    // doc comment above).
+    em::function("onnxsim_estimate_quantization_drop", &onnxsim_estimate_quantization_drop);
     // Calibration-based quantization: list_* discovers which tensors to
     // calibrate, quantize_static/quantize_qoperator take the calibrated
     // ranges back as parallel [name] / [min0, max0, min1, max1, ...] arrays.

--- a/scripts/convertmodel/interface.cpp
+++ b/scripts/convertmodel/interface.cpp
@@ -1,11 +1,11 @@
-#include "onnxsim.h"
 #include "model_info.h"
-#include "precision_estimator.h"
-#include "onnxoptimizer/optimize.h"
 #include "onnx/checker.h"
 #include "onnx/defs/parser.h"
 #include "onnx/defs/schema.h"
 #include "onnx/inliner/inliner.h"
+#include "onnxoptimizer/optimize.h"
+#include "onnxsim.h"
+#include "precision_estimator.h"
 #include "tensor_pool.h"
 #include "tensor_pool_bridge.h"
 #include "tensor_pool_gguf_bridge.h"
@@ -45,7 +45,7 @@ namespace {
 // Where the C++ profiler writes its Chrome trace inside Emscripten's in-memory
 // filesystem when the page asks for a profile. Read back into a string and
 // removed by ReadAndClearProfileTrace() so nothing accumulates across runs.
-constexpr const char* kProfileTracePath = "onnxsim_profile.json";
+constexpr const char *kProfileTracePath = "onnxsim_profile.json";
 
 // Turn onnxsim's simplification profiler on for the next Simplify() call. The
 // profiler is driven by environment variables (so every binding gets it for
@@ -53,27 +53,27 @@ constexpr const char* kProfileTracePath = "onnxsim_profile.json";
 // std::getenv(). ONNXSIM_MERGE_ORT_PROFILE additionally folds ONNX Runtime's
 // per-session constant-folding profiles into the same trace.
 void EnableProfiling() {
-    setenv("ONNXSIM_PROFILE", kProfileTracePath, 1);
-    setenv("ONNXSIM_MERGE_ORT_PROFILE", "1", 1);
+  setenv("ONNXSIM_PROFILE", kProfileTracePath, 1);
+  setenv("ONNXSIM_MERGE_ORT_PROFILE", "1", 1);
 }
 
 void DisableProfiling() {
-    unsetenv("ONNXSIM_PROFILE");
-    unsetenv("ONNXSIM_MERGE_ORT_PROFILE");
+  unsetenv("ONNXSIM_PROFILE");
+  unsetenv("ONNXSIM_MERGE_ORT_PROFILE");
 }
 
 // Read the trace the profiler wrote (empty string if it is missing) and delete
 // the file so the MEMFS does not grow run over run.
 std::string ReadAndClearProfileTrace() {
-    std::string trace;
-    std::ifstream ifs(kProfileTracePath, std::ios::binary);
-    if (ifs) {
-        std::ostringstream ss;
-        ss << ifs.rdbuf();
-        trace = ss.str();
-    }
-    std::remove(kProfileTracePath);
-    return trace;
+  std::string trace;
+  std::ifstream ifs(kProfileTracePath, std::ios::binary);
+  if (ifs) {
+    std::ostringstream ss;
+    ss << ifs.rdbuf();
+    trace = ss.str();
+  }
+  std::remove(kProfileTracePath);
+  return trace;
 }
 
 // Where the standalone safetensors/gguf export/import functions below stage
@@ -85,41 +85,42 @@ std::string ReadAndClearProfileTrace() {
 // onnxsim's own loaders resolve the embedded model by pool name, not by this
 // path, so the mismatch with whatever name the browser saves the download
 // under (or the name of a file the user uploads for import) is harmless.
-constexpr const char* kSafetensorsArchivePath = "onnxsim_export.safetensors";
-constexpr const char* kGGUFArchivePath = "onnxsim_export.gguf";
+constexpr const char *kSafetensorsArchivePath = "onnxsim_export.safetensors";
+constexpr const char *kGGUFArchivePath = "onnxsim_export.gguf";
 
 // Read `path` back into a string and delete it, same pattern as
 // ReadAndClearProfileTrace above. Returns an empty string if the file could
 // not be opened.
-std::string ReadAndDeleteFile(const std::string& path) {
-    std::string data;
-    // Seek to measure the size and read directly into a pre-sized string,
-    // rather than streaming through an ostringstream (which grows its own
-    // internal buffer geometrically and copies out of it into the returned
-    // string on .str()) -- one read into the final buffer instead of several
-    // reallocate-and-copy passes. Matters here because a safetensors/gguf
-    // archive embeds the whole model and can be tens of MB.
-    std::ifstream ifs(path, std::ios::binary | std::ios::ate);
-    if (ifs) {
-        const std::streamoff size = ifs.tellg();
-        if (size > 0) {
-            data.resize(static_cast<size_t>(size));
-            ifs.seekg(0);
-            ifs.read(&data[0], size);
-        }
+std::string ReadAndDeleteFile(const std::string &path) {
+  std::string data;
+  // Seek to measure the size and read directly into a pre-sized string,
+  // rather than streaming through an ostringstream (which grows its own
+  // internal buffer geometrically and copies out of it into the returned
+  // string on .str()) -- one read into the final buffer instead of several
+  // reallocate-and-copy passes. Matters here because a safetensors/gguf
+  // archive embeds the whole model and can be tens of MB.
+  std::ifstream ifs(path, std::ios::binary | std::ios::ate);
+  if (ifs) {
+    const std::streamoff size = ifs.tellg();
+    if (size > 0) {
+      data.resize(static_cast<size_t>(size));
+      ifs.seekg(0);
+      ifs.read(&data[0], size);
     }
-    std::remove(path.c_str());
-    return data;
+  }
+  std::remove(path.c_str());
+  return data;
 }
 
 // Stage `data` at `path` inside the MEMFS, for the import functions below to
 // hand to a TensorPool loader that only knows how to read from a path.
 // Returns false (and leaves nothing behind) on a write failure.
-bool WriteFile(const std::string& path, const std::string& data) {
-    std::ofstream ofs(path, std::ios::binary | std::ios::trunc);
-    if (!ofs) return false;
-    ofs.write(data.data(), static_cast<std::streamsize>(data.size()));
-    return static_cast<bool>(ofs);
+bool WriteFile(const std::string &path, const std::string &data) {
+  std::ofstream ofs(path, std::ios::binary | std::ios::trunc);
+  if (!ofs)
+    return false;
+  ofs.write(data.data(), static_cast<std::streamsize>(data.size()));
+  return static_cast<bool>(ofs);
 }
 
 // Serialize `model` into the shared static buffer and hand JS a typed-memory
@@ -127,77 +128,82 @@ bool WriteFile(const std::string& path, const std::string& data) {
 // valid after this function returns; the worker copies it out immediately
 // (toBase64 / a fresh Uint8Array), and calls are sequential, so a single shared
 // buffer is safe -- matching how the other bindings here return model bytes.
-em::val SerializeModel(const onnx::ModelProto& model) {
-    static std::string result;
-    if (!model.SerializeToString(&result)) {
-        std::cerr << "Serialize failed" << std::endl;
-        return em::val::null();
-    }
-    return em::val(em::typed_memory_view(result.size(),
-                                         reinterpret_cast<uint8_t*>(result.data())));
+em::val SerializeModel(const onnx::ModelProto &model) {
+  static std::string result;
+  if (!model.SerializeToString(&result)) {
+    std::cerr << "Serialize failed" << std::endl;
+    return em::val::null();
+  }
+  return em::val(em::typed_memory_view(
+      result.size(), reinterpret_cast<uint8_t *>(result.data())));
 }
 
-// Materialize the raw little-endian bytes of `tensor` into `out`, reading either
-// its `raw_data` or the typed repeated fields (float_data/int64_data/...). The
-// wasm target is little-endian, so writing native bytes yields the
-// little-endian layout onnxruntime-web's typed arrays expect. Returns false for
-// a dtype we do not pack (STRING / COMPLEX / the narrow float variants stored
-// out of band); the caller reports it. The bridged dtypes match
-// CppModelExecutor / the ONNX backend node tests.
-bool TensorProtoToRawBytes(const onnx::TensorProto& tensor, std::string& out) {
-    using TP = onnx::TensorProto;
-    out.clear();
-    if (tensor.has_raw_data()) {
-        out = tensor.raw_data();
-        return true;
+// Materialize the raw little-endian bytes of `tensor` into `out`, reading
+// either its `raw_data` or the typed repeated fields
+// (float_data/int64_data/...). The wasm target is little-endian, so writing
+// native bytes yields the little-endian layout onnxruntime-web's typed arrays
+// expect. Returns false for a dtype we do not pack (STRING / COMPLEX / the
+// narrow float variants stored out of band); the caller reports it. The bridged
+// dtypes match CppModelExecutor / the ONNX backend node tests.
+bool TensorProtoToRawBytes(const onnx::TensorProto &tensor, std::string &out) {
+  using TP = onnx::TensorProto;
+  out.clear();
+  if (tensor.has_raw_data()) {
+    out = tensor.raw_data();
+    return true;
+  }
+  auto append = [&out](const void *p, size_t n) {
+    out.append(reinterpret_cast<const char *>(p), n);
+  };
+  switch (tensor.data_type()) {
+  case TP::FLOAT:
+    for (float v : tensor.float_data())
+      append(&v, sizeof(v));
+    return true;
+  case TP::DOUBLE:
+    for (double v : tensor.double_data())
+      append(&v, sizeof(v));
+    return true;
+  case TP::INT64:
+    for (int64_t v : tensor.int64_data())
+      append(&v, sizeof(v));
+    return true;
+  case TP::UINT64:
+    for (uint64_t v : tensor.uint64_data())
+      append(&v, sizeof(v));
+    return true;
+  case TP::INT32:
+    for (int32_t v : tensor.int32_data())
+      append(&v, sizeof(v));
+    return true;
+  case TP::UINT32:
+    // uint32 values live in uint64_data per the TensorProto encoding.
+    for (uint64_t v : tensor.uint64_data()) {
+      uint32_t w = static_cast<uint32_t>(v);
+      append(&w, sizeof(w));
     }
-    auto append = [&out](const void* p, size_t n) {
-        out.append(reinterpret_cast<const char*>(p), n);
-    };
-    switch (tensor.data_type()) {
-        case TP::FLOAT:
-            for (float v : tensor.float_data()) append(&v, sizeof(v));
-            return true;
-        case TP::DOUBLE:
-            for (double v : tensor.double_data()) append(&v, sizeof(v));
-            return true;
-        case TP::INT64:
-            for (int64_t v : tensor.int64_data()) append(&v, sizeof(v));
-            return true;
-        case TP::UINT64:
-            for (uint64_t v : tensor.uint64_data()) append(&v, sizeof(v));
-            return true;
-        case TP::INT32:
-            for (int32_t v : tensor.int32_data()) append(&v, sizeof(v));
-            return true;
-        case TP::UINT32:
-            // uint32 values live in uint64_data per the TensorProto encoding.
-            for (uint64_t v : tensor.uint64_data()) {
-                uint32_t w = static_cast<uint32_t>(v);
-                append(&w, sizeof(w));
-            }
-            return true;
-        case TP::INT16:
-        case TP::UINT16:
-        case TP::FLOAT16:
-        case TP::BFLOAT16:
-            // Stored widened in int32_data; pack the low 16 bits.
-            for (int32_t v : tensor.int32_data()) {
-                uint16_t w = static_cast<uint16_t>(v);
-                append(&w, sizeof(w));
-            }
-            return true;
-        case TP::INT8:
-        case TP::UINT8:
-        case TP::BOOL:
-            for (int32_t v : tensor.int32_data()) {
-                uint8_t b = static_cast<uint8_t>(v);
-                append(&b, sizeof(b));
-            }
-            return true;
-        default:
-            return false;
+    return true;
+  case TP::INT16:
+  case TP::UINT16:
+  case TP::FLOAT16:
+  case TP::BFLOAT16:
+    // Stored widened in int32_data; pack the low 16 bits.
+    for (int32_t v : tensor.int32_data()) {
+      uint16_t w = static_cast<uint16_t>(v);
+      append(&w, sizeof(w));
     }
+    return true;
+  case TP::INT8:
+  case TP::UINT8:
+  case TP::BOOL:
+    for (int32_t v : tensor.int32_data()) {
+      uint8_t b = static_cast<uint8_t>(v);
+      append(&b, sizeof(b));
+    }
+    return true;
+  default:
+    return false;
+  }
 }
 
 // Highest opset version this build supports for the default ONNX domain
@@ -205,216 +211,222 @@ bool TensorProtoToRawBytes(const onnx::TensorProto& tensor, std::string& out) {
 // somehow lacks the default domain. Used to give parsed graphs a sensible
 // default opset import.
 int HighestDefaultOpset() {
-    const auto& ranges =
-        onnx::OpSchemaRegistry::DomainToVersionRange::Instance().Map();
-    auto it = ranges.find("");  // "" is the default ONNX domain (ai.onnx)
-    int max_opset = (it != ranges.end()) ? it->second.second : 0;
-    return max_opset > 0 ? max_opset : 1;
+  const auto &ranges =
+      onnx::OpSchemaRegistry::DomainToVersionRange::Instance().Map();
+  auto it = ranges.find(""); // "" is the default ONNX domain (ai.onnx)
+  int max_opset = (it != ranges.end()) ? it->second.second : 0;
+  return max_opset > 0 ? max_opset : 1;
 }
 
 // Make sure `model` carries an opset import for the default ONNX domain and for
 // every domain its local functions live in, so a model assembled from parsed
-// text (which may omit the prolog, or reference local functions) still validates
-// and can be simplified / visualized. Existing opset imports are left untouched;
-// only missing domains are added. A local function's own domain is imported at
-// the version the function declares for that domain, defaulting to 1 for a
-// custom domain that declares none.
-void EnsureOpsetImports(onnx::ModelProto& model) {
-    std::set<std::string> present;
-    for (const auto& op : model.opset_import()) {
-        present.insert(op.domain());
+// text (which may omit the prolog, or reference local functions) still
+// validates and can be simplified / visualized. Existing opset imports are left
+// untouched; only missing domains are added. A local function's own domain is
+// imported at the version the function declares for that domain, defaulting to
+// 1 for a custom domain that declares none.
+void EnsureOpsetImports(onnx::ModelProto &model) {
+  std::set<std::string> present;
+  for (const auto &op : model.opset_import()) {
+    present.insert(op.domain());
+  }
+  if (!present.count("")) {
+    auto *op = model.add_opset_import();
+    op->set_domain(""); // default ONNX domain (ai.onnx)
+    op->set_version(HighestDefaultOpset());
+    present.insert("");
+  }
+  for (const auto &fn : model.functions()) {
+    const std::string &dom = fn.domain();
+    if (present.count(dom))
+      continue;
+    int64_t ver = 1;
+    for (const auto &op : fn.opset_import()) {
+      if (op.domain() == dom) {
+        ver = op.version();
+        break;
+      }
     }
-    if (!present.count("")) {
-        auto* op = model.add_opset_import();
-        op->set_domain("");  // default ONNX domain (ai.onnx)
-        op->set_version(HighestDefaultOpset());
-        present.insert("");
-    }
-    for (const auto& fn : model.functions()) {
-        const std::string& dom = fn.domain();
-        if (present.count(dom)) continue;
-        int64_t ver = 1;
-        for (const auto& op : fn.opset_import()) {
-            if (op.domain() == dom) {
-                ver = op.version();
-                break;
-            }
-        }
-        auto* op = model.add_opset_import();
-        op->set_domain(dom);
-        op->set_version(ver);
-        present.insert(dom);
-    }
+    auto *op = model.add_opset_import();
+    op->set_domain(dom);
+    op->set_version(ver);
+    present.insert(dom);
+  }
 }
 
-}  // namespace
+} // namespace
 
 // Returns an object { model: Uint8Array, trace: string }. `trace` is the
 // profiler's Chrome trace JSON when `profile` is true, otherwise "". Returning
 // an object (rather than the bare model view) lets the worker hand the trace to
 // the in-page flame-graph viewer without a second round-trip.
-em::val onnxsimplify_export(const std::string& data, em::val skip_optimizers, bool constant_folding, bool shape_inference, size_t tensor_size_threshold, int target_opset_version, bool profile, bool annotate, bool graph_diff) {
-    InitEnv();
+em::val onnxsimplify_export(const std::string &data, em::val skip_optimizers,
+                            bool constant_folding, bool shape_inference,
+                            size_t tensor_size_threshold,
+                            int target_opset_version, bool profile,
+                            bool annotate, bool graph_diff) {
+  InitEnv();
 
-    std::cerr << "LOG_THRESHOLD: " << std::getenv("LOG_THRESHOLD") << std::endl;
-    onnx::ModelProto xmodel;
-    std::cerr << "parsing message" << std::endl;
-    if (!xmodel.ParseFromArray(data.data(), data.size())) {
-        std::cerr << "Parse failed" << std::endl;
-        return em::val::null();
-    }
+  std::cerr << "LOG_THRESHOLD: " << std::getenv("LOG_THRESHOLD") << std::endl;
+  onnx::ModelProto xmodel;
+  std::cerr << "parsing message" << std::endl;
+  if (!xmodel.ParseFromArray(data.data(), data.size())) {
+    std::cerr << "Parse failed" << std::endl;
+    return em::val::null();
+  }
 
-    if (profile) {
-        EnableProfiling();
-    }
+  if (profile) {
+    EnableProfiling();
+  }
 
-    std::cerr << "simplify begin" << std::endl;
-    onnx::ModelProto optimized;
-    try {
-        optimized = Simplify(
+  std::cerr << "simplify begin" << std::endl;
+  onnx::ModelProto optimized;
+  try {
+    optimized = Simplify(
 #ifdef ONNXSIM_WASM_ORT_WEB
-            // Runs each fold group through the page's onnxruntime-web. Its Run
-            // blocks on a JS Promise, so this whole function is Asyncified and
-            // returns a Promise to JS (the worker awaits it).
-            *GetJsModelExecutor(),
+        // Runs each fold group through the page's onnxruntime-web. Its Run
+        // blocks on a JS Promise, so this whole function is Asyncified and
+        // returns a Promise to JS (the worker awaits it).
+        *GetJsModelExecutor(),
 #else
-            *GetBuiltinModelExecutor(),
+        *GetBuiltinModelExecutor(),
 #endif
-            xmodel,
-            em::vecFromJSArray<std::string>(skip_optimizers),
-            constant_folding,
-            shape_inference,
-            tensor_size_threshold,
-            // A target opset version of <= 0 means "leave the opset unchanged".
-            target_opset_version > 0
-                ? std::make_optional(target_opset_version)
-                : std::nullopt
-        );
-    } catch (const std::exception& e) {
-        std::cerr << "simplify error: " << e.what() << std::endl;
-        if (profile) {
-            DisableProfiling();
-            ReadAndClearProfileTrace();
-        }
-        return em::val::null();
-    }
-    std::cerr << "simplify end" << std::endl;
-
-    // Print the before/after diff (op counts + model size) to stdout so the page
-    // surfaces it in the log, mirroring the Python CLI's "here is the difference"
-    // output. std::cout is routed to the worker's `print` handler.
-    std::cout << "Finish! Here is the difference:\n"
-              << FormatSimplifyingInfo(xmodel, optimized) << std::flush;
-
-    // Optional, more detailed node/value-level diff -- which nodes/values were
-    // removed, added, or changed (matched by output tensor name). Off by
-    // default (it can be long for a big model), controlled by the page's
-    // "graph diff" toggle.
-    if (graph_diff) {
-        std::cout << FormatGraphDiff(xmodel, optimized) << std::flush;
-    }
-
-    // Collect the trace right after Simplify() (the profiler has flushed it by
-    // now) and turn profiling back off, so a later check/serialize failure
-    // cannot leave the environment armed for the next request.
-    std::string trace;
+        xmodel, em::vecFromJSArray<std::string>(skip_optimizers),
+        constant_folding, shape_inference, tensor_size_threshold,
+        // A target opset version of <= 0 means "leave the opset unchanged".
+        target_opset_version > 0 ? std::make_optional(target_opset_version)
+                                 : std::nullopt);
+  } catch (const std::exception &e) {
+    std::cerr << "simplify error: " << e.what() << std::endl;
     if (profile) {
-        DisableProfiling();
-        trace = ReadAndClearProfileTrace();
+      DisableProfiling();
+      ReadAndClearProfileTrace();
     }
+    return em::val::null();
+  }
+  std::cerr << "simplify end" << std::endl;
 
-    // Bake onnxsim's MAC/FLOP model-info metrics into the model's
-    // metadata_props (mirrors Python model_info.annotate_metadata) so the page's
-    // "Run inference" panel can read and display them. On by default.
-    if (annotate) {
-        try {
-            AnnotateModelInfo(optimized);
-        } catch (const std::exception& e) {
-            std::cerr << "annotate model info failed: " << e.what() << std::endl;
-        }
-    }
+  // Print the before/after diff (op counts + model size) to stdout so the page
+  // surfaces it in the log, mirroring the Python CLI's "here is the difference"
+  // output. std::cout is routed to the worker's `print` handler.
+  std::cout << "Finish! Here is the difference:\n"
+            << FormatSimplifyingInfo(xmodel, optimized) << std::flush;
 
+  // Optional, more detailed node/value-level diff -- which nodes/values were
+  // removed, added, or changed (matched by output tensor name). Off by
+  // default (it can be long for a big model), controlled by the page's
+  // "graph diff" toggle.
+  if (graph_diff) {
+    std::cout << FormatGraphDiff(xmodel, optimized) << std::flush;
+  }
+
+  // Collect the trace right after Simplify() (the profiler has flushed it by
+  // now) and turn profiling back off, so a later check/serialize failure
+  // cannot leave the environment armed for the next request.
+  std::string trace;
+  if (profile) {
+    DisableProfiling();
+    trace = ReadAndClearProfileTrace();
+  }
+
+  // Bake onnxsim's MAC/FLOP model-info metrics into the model's
+  // metadata_props (mirrors Python model_info.annotate_metadata) so the page's
+  // "Run inference" panel can read and display them. On by default.
+  if (annotate) {
     try {
-        std::cerr << "checking model" << std::endl;
-        onnx::checker::check_model(optimized);
-    } catch (const onnx::checker::ValidationError& e) {
-        std::cerr << "model check failed: " << e.what() << std::endl;
-        return em::val::null();
+      AnnotateModelInfo(optimized);
+    } catch (const std::exception &e) {
+      std::cerr << "annotate model info failed: " << e.what() << std::endl;
     }
+  }
 
-    std::cerr << "serializing model" << std::endl;
-    static std::string result;
-    if (!optimized.SerializeToString(&result)) {
-        std::cerr << "Serialize failed" << std::endl;
-        return em::val::null();
-    }
-    std::cerr << "model simplify ended" << std::endl;
-    em::val out = em::val::object();
-    out.set("model", em::val(em::typed_memory_view(result.size(), reinterpret_cast<uint8_t*>(result.data()))));
-    out.set("trace", em::val(trace));
-    return out;
+  try {
+    std::cerr << "checking model" << std::endl;
+    onnx::checker::check_model(optimized);
+  } catch (const onnx::checker::ValidationError &e) {
+    std::cerr << "model check failed: " << e.what() << std::endl;
+    return em::val::null();
+  }
+
+  std::cerr << "serializing model" << std::endl;
+  static std::string result;
+  if (!optimized.SerializeToString(&result)) {
+    std::cerr << "Serialize failed" << std::endl;
+    return em::val::null();
+  }
+  std::cerr << "model simplify ended" << std::endl;
+  em::val out = em::val::object();
+  out.set("model",
+          em::val(em::typed_memory_view(
+              result.size(), reinterpret_cast<uint8_t *>(result.data()))));
+  out.set("trace", em::val(trace));
+  return out;
 }
 
-em::val onnxoptimizer_optimize(const std::string& data, em::val passes_ary, bool annotate) {
-    std::vector<std::string> passes = em::vecFromJSArray<std::string>(passes_ary);
-    onnx::ModelProto xmodel;
-    std::cerr << "parsing message" << std::endl;
-    if (!xmodel.ParseFromArray(data.data(), data.size())) {
-        std::cerr << "Parse failed" << std::endl;
-        return em::val::null();
-    }
-    onnx::ModelProto optimized;
+em::val onnxoptimizer_optimize(const std::string &data, em::val passes_ary,
+                               bool annotate) {
+  std::vector<std::string> passes = em::vecFromJSArray<std::string>(passes_ary);
+  onnx::ModelProto xmodel;
+  std::cerr << "parsing message" << std::endl;
+  if (!xmodel.ParseFromArray(data.data(), data.size())) {
+    std::cerr << "Parse failed" << std::endl;
+    return em::val::null();
+  }
+  onnx::ModelProto optimized;
+  try {
+    optimized = onnx::optimization::Optimize(xmodel, passes);
+  } catch (const std::exception &e) {
+    std::cerr << "optimize error: " << e.what() << std::endl;
+    return em::val::null();
+  }
+  if (annotate) {
     try {
-        optimized = onnx::optimization::Optimize(xmodel, passes);
-    } catch (const std::exception& e) {
-        std::cerr << "optimize error: " << e.what() << std::endl;
-        return em::val::null();
+      AnnotateModelInfo(optimized);
+    } catch (const std::exception &e) {
+      std::cerr << "annotate model info failed: " << e.what() << std::endl;
     }
-    if (annotate) {
-        try {
-            AnnotateModelInfo(optimized);
-        } catch (const std::exception& e) {
-            std::cerr << "annotate model info failed: " << e.what() << std::endl;
-        }
-    }
-    std::cerr << "serializing model" << std::endl;
-    static std::string result;
-    if (!optimized.SerializeToString(&result)) {
-        std::cerr << "Serialize failed" << std::endl;
-        return em::val::null();
-    }
-    return em::val(em::typed_memory_view(result.size(), reinterpret_cast<uint8_t*>(result.data())));
+  }
+  std::cerr << "serializing model" << std::endl;
+  static std::string result;
+  if (!optimized.SerializeToString(&result)) {
+    std::cerr << "Serialize failed" << std::endl;
+    return em::val::null();
+  }
+  return em::val(em::typed_memory_view(
+      result.size(), reinterpret_cast<uint8_t *>(result.data())));
 }
 
-em::val onnxoptimizer_optimize_fixed(const std::string& data, em::val passes_ary, bool annotate) {
-    std::vector<std::string> passes = em::vecFromJSArray<std::string>(passes_ary);
-    onnx::ModelProto xmodel;
-    std::cerr << "parsing message" << std::endl;
-    if (!xmodel.ParseFromArray(data.data(), data.size())) {
-        std::cerr << "Parse failed" << std::endl;
-        return em::val::null();
-    }
-    onnx::ModelProto optimized;
+em::val onnxoptimizer_optimize_fixed(const std::string &data,
+                                     em::val passes_ary, bool annotate) {
+  std::vector<std::string> passes = em::vecFromJSArray<std::string>(passes_ary);
+  onnx::ModelProto xmodel;
+  std::cerr << "parsing message" << std::endl;
+  if (!xmodel.ParseFromArray(data.data(), data.size())) {
+    std::cerr << "Parse failed" << std::endl;
+    return em::val::null();
+  }
+  onnx::ModelProto optimized;
+  try {
+    optimized = onnx::optimization::OptimizeFixed(xmodel, passes);
+  } catch (const std::exception &e) {
+    std::cerr << "optimize error: " << e.what() << std::endl;
+    return em::val::null();
+  }
+  if (annotate) {
     try {
-        optimized = onnx::optimization::OptimizeFixed(xmodel, passes);
-    } catch (const std::exception& e) {
-        std::cerr << "optimize error: " << e.what() << std::endl;
-        return em::val::null();
+      AnnotateModelInfo(optimized);
+    } catch (const std::exception &e) {
+      std::cerr << "annotate model info failed: " << e.what() << std::endl;
     }
-    if (annotate) {
-        try {
-            AnnotateModelInfo(optimized);
-        } catch (const std::exception& e) {
-            std::cerr << "annotate model info failed: " << e.what() << std::endl;
-        }
-    }
-    std::cerr << "serializing model" << std::endl;
-    static std::string result;
-    if (!optimized.SerializeToString(&result)) {
-        std::cerr << "Serialize failed" << std::endl;
-        return em::val::null();
-    }
-    return em::val(em::typed_memory_view(result.size(), reinterpret_cast<uint8_t*>(result.data())));
+  }
+  std::cerr << "serializing model" << std::endl;
+  static std::string result;
+  if (!optimized.SerializeToString(&result)) {
+    std::cerr << "Serialize failed" << std::endl;
+    return em::val::null();
+  }
+  return em::val(em::typed_memory_view(
+      result.size(), reinterpret_cast<uint8_t *>(result.data())));
 }
 
 // Annotate a model's MAC/FLOP model-info metrics into its metadata_props
@@ -425,25 +437,26 @@ em::val onnxoptimizer_optimize_fixed(const std::string& data, em::val passes_ary
 // — only metadata_props are added — so the annotated bytes run identically.
 // Returns null on a parse/serialize failure (annotation itself is best-effort:
 // a model whose shapes cannot be inferred simply gains no metrics).
-em::val onnxsim_annotate_model_info(const std::string& data) {
-    onnx::ModelProto xmodel;
-    std::cerr << "parsing message" << std::endl;
-    if (!xmodel.ParseFromArray(data.data(), data.size())) {
-        std::cerr << "Parse failed" << std::endl;
-        return em::val::null();
-    }
-    try {
-        AnnotateModelInfo(xmodel);
-    } catch (const std::exception& e) {
-        std::cerr << "annotate model info failed: " << e.what() << std::endl;
-    }
-    std::cerr << "serializing model" << std::endl;
-    static std::string result;
-    if (!xmodel.SerializeToString(&result)) {
-        std::cerr << "Serialize failed" << std::endl;
-        return em::val::null();
-    }
-    return em::val(em::typed_memory_view(result.size(), reinterpret_cast<uint8_t*>(result.data())));
+em::val onnxsim_annotate_model_info(const std::string &data) {
+  onnx::ModelProto xmodel;
+  std::cerr << "parsing message" << std::endl;
+  if (!xmodel.ParseFromArray(data.data(), data.size())) {
+    std::cerr << "Parse failed" << std::endl;
+    return em::val::null();
+  }
+  try {
+    AnnotateModelInfo(xmodel);
+  } catch (const std::exception &e) {
+    std::cerr << "annotate model info failed: " << e.what() << std::endl;
+  }
+  std::cerr << "serializing model" << std::endl;
+  static std::string result;
+  if (!xmodel.SerializeToString(&result)) {
+    std::cerr << "Serialize failed" << std::endl;
+    return em::val::null();
+  }
+  return em::val(em::typed_memory_view(
+      result.size(), reinterpret_cast<uint8_t *>(result.data())));
 }
 
 // Export `data` (a serialized onnx::ModelProto) as a single standalone
@@ -454,55 +467,58 @@ em::val onnxsim_annotate_model_info(const std::string& data) {
 // the one file this returns is both the model's weights and its graph. Used
 // by the page's download-format selector for the ".onnx.safetensors" option.
 // Returns null on a parse/export failure.
-em::val onnxsim_export_safetensors(const std::string& data) {
-    onnx::ModelProto xmodel;
-    if (!xmodel.ParseFromArray(data.data(), data.size())) {
-        std::cerr << "Parse failed" << std::endl;
-        return em::val::null();
-    }
-    onnxsim::tensor_pool::TensorPool pool;
-    try {
-        onnxsim::tensor_pool::SaveModelAsSafetensorsStandalone(
-            xmodel, kSafetensorsArchivePath, pool);
-    } catch (const std::exception& e) {
-        std::cerr << "safetensors export failed: " << e.what() << std::endl;
-        std::remove(kSafetensorsArchivePath);
-        return em::val::null();
-    }
-    static std::string result;
-    result = ReadAndDeleteFile(kSafetensorsArchivePath);
-    if (result.empty()) {
-        std::cerr << "failed to read back the exported safetensors file" << std::endl;
-        return em::val::null();
-    }
-    return em::val(em::typed_memory_view(result.size(), reinterpret_cast<uint8_t*>(result.data())));
+em::val onnxsim_export_safetensors(const std::string &data) {
+  onnx::ModelProto xmodel;
+  if (!xmodel.ParseFromArray(data.data(), data.size())) {
+    std::cerr << "Parse failed" << std::endl;
+    return em::val::null();
+  }
+  onnxsim::tensor_pool::TensorPool pool;
+  try {
+    onnxsim::tensor_pool::SaveModelAsSafetensorsStandalone(
+        xmodel, kSafetensorsArchivePath, pool);
+  } catch (const std::exception &e) {
+    std::cerr << "safetensors export failed: " << e.what() << std::endl;
+    std::remove(kSafetensorsArchivePath);
+    return em::val::null();
+  }
+  static std::string result;
+  result = ReadAndDeleteFile(kSafetensorsArchivePath);
+  if (result.empty()) {
+    std::cerr << "failed to read back the exported safetensors file"
+              << std::endl;
+    return em::val::null();
+  }
+  return em::val(em::typed_memory_view(
+      result.size(), reinterpret_cast<uint8_t *>(result.data())));
 }
 
 // GGUF counterpart of onnxsim_export_safetensors above; see
 // tensor_pool_gguf_bridge.h's SaveModelAsGGUFStandalone. Used by the page's
 // download-format selector for the ".onnx.gguf" option.
-em::val onnxsim_export_gguf(const std::string& data) {
-    onnx::ModelProto xmodel;
-    if (!xmodel.ParseFromArray(data.data(), data.size())) {
-        std::cerr << "Parse failed" << std::endl;
-        return em::val::null();
-    }
-    onnxsim::tensor_pool::TensorPool pool;
-    try {
-        onnxsim::tensor_pool::SaveModelAsGGUFStandalone(xmodel, kGGUFArchivePath,
-                                                         pool);
-    } catch (const std::exception& e) {
-        std::cerr << "gguf export failed: " << e.what() << std::endl;
-        std::remove(kGGUFArchivePath);
-        return em::val::null();
-    }
-    static std::string result;
-    result = ReadAndDeleteFile(kGGUFArchivePath);
-    if (result.empty()) {
-        std::cerr << "failed to read back the exported gguf file" << std::endl;
-        return em::val::null();
-    }
-    return em::val(em::typed_memory_view(result.size(), reinterpret_cast<uint8_t*>(result.data())));
+em::val onnxsim_export_gguf(const std::string &data) {
+  onnx::ModelProto xmodel;
+  if (!xmodel.ParseFromArray(data.data(), data.size())) {
+    std::cerr << "Parse failed" << std::endl;
+    return em::val::null();
+  }
+  onnxsim::tensor_pool::TensorPool pool;
+  try {
+    onnxsim::tensor_pool::SaveModelAsGGUFStandalone(xmodel, kGGUFArchivePath,
+                                                    pool);
+  } catch (const std::exception &e) {
+    std::cerr << "gguf export failed: " << e.what() << std::endl;
+    std::remove(kGGUFArchivePath);
+    return em::val::null();
+  }
+  static std::string result;
+  result = ReadAndDeleteFile(kGGUFArchivePath);
+  if (result.empty()) {
+    std::cerr << "failed to read back the exported gguf file" << std::endl;
+    return em::val::null();
+  }
+  return em::val(em::typed_memory_view(
+      result.size(), reinterpret_cast<uint8_t *>(result.data())));
 }
 
 // Import counterpart of onnxsim_export_safetensors: `data` is the whole raw
@@ -517,30 +533,30 @@ em::val onnxsim_export_gguf(const std::string& data) {
 // ".onnx.safetensors" upload. Returns null if the archive has no embedded
 // model (e.g. a plain weights-only safetensors file with no onnxsim-authored
 // graph) or on any other stage/load/parse failure.
-em::val onnxsim_import_safetensors(const std::string& data) {
-    if (!WriteFile(kSafetensorsArchivePath, data)) {
-        std::cerr << "failed to stage the uploaded safetensors file" << std::endl;
-        return em::val::null();
-    }
-    onnx::ModelProto xmodel;
-    onnxsim::tensor_pool::TensorPool pool;
-    bool ok = false;
-    try {
-        ok = onnxsim::tensor_pool::LoadModelFromSafetensors(
-            kSafetensorsArchivePath, &xmodel, pool);
-    } catch (const std::exception& e) {
-        std::cerr << "safetensors import failed: " << e.what() << std::endl;
-        std::remove(kSafetensorsArchivePath);
-        return em::val::null();
-    }
+em::val onnxsim_import_safetensors(const std::string &data) {
+  if (!WriteFile(kSafetensorsArchivePath, data)) {
+    std::cerr << "failed to stage the uploaded safetensors file" << std::endl;
+    return em::val::null();
+  }
+  onnx::ModelProto xmodel;
+  onnxsim::tensor_pool::TensorPool pool;
+  bool ok = false;
+  try {
+    ok = onnxsim::tensor_pool::LoadModelFromSafetensors(kSafetensorsArchivePath,
+                                                        &xmodel, pool);
+  } catch (const std::exception &e) {
+    std::cerr << "safetensors import failed: " << e.what() << std::endl;
     std::remove(kSafetensorsArchivePath);
-    if (!ok) {
-        std::cerr << "safetensors file has no embedded onnxsim model (a plain "
-                     "weights-only archive is not importable as a graph)"
-                  << std::endl;
-        return em::val::null();
-    }
-    return SerializeModel(xmodel);
+    return em::val::null();
+  }
+  std::remove(kSafetensorsArchivePath);
+  if (!ok) {
+    std::cerr << "safetensors file has no embedded onnxsim model (a plain "
+                 "weights-only archive is not importable as a graph)"
+              << std::endl;
+    return em::val::null();
+  }
+  return SerializeModel(xmodel);
 }
 
 // GGUF counterpart of onnxsim_import_safetensors above; see
@@ -549,130 +565,130 @@ em::val onnxsim_import_safetensors(const std::string& data) {
 // tensors LoadModelFromGGUF could not hydrate, e.g. a quantized weight) is
 // logged rather than surfaced structurally -- best-effort, matching how the
 // rest of this file reports non-fatal issues via std::cerr.
-em::val onnxsim_import_gguf(const std::string& data) {
-    if (!WriteFile(kGGUFArchivePath, data)) {
-        std::cerr << "failed to stage the uploaded gguf file" << std::endl;
-        return em::val::null();
-    }
-    onnx::ModelProto xmodel;
-    onnxsim::tensor_pool::TensorPool pool;
-    bool ok = false;
-    std::vector<std::string> skipped;
-    try {
-        ok = onnxsim::tensor_pool::LoadModelFromGGUF(kGGUFArchivePath, &xmodel,
-                                                      pool, true, &skipped);
-    } catch (const std::exception& e) {
-        std::cerr << "gguf import failed: " << e.what() << std::endl;
-        std::remove(kGGUFArchivePath);
-        return em::val::null();
-    }
+em::val onnxsim_import_gguf(const std::string &data) {
+  if (!WriteFile(kGGUFArchivePath, data)) {
+    std::cerr << "failed to stage the uploaded gguf file" << std::endl;
+    return em::val::null();
+  }
+  onnx::ModelProto xmodel;
+  onnxsim::tensor_pool::TensorPool pool;
+  bool ok = false;
+  std::vector<std::string> skipped;
+  try {
+    ok = onnxsim::tensor_pool::LoadModelFromGGUF(kGGUFArchivePath, &xmodel,
+                                                 pool, true, &skipped);
+  } catch (const std::exception &e) {
+    std::cerr << "gguf import failed: " << e.what() << std::endl;
     std::remove(kGGUFArchivePath);
-    if (!ok) {
-        std::cerr << "gguf file has no embedded onnxsim model (a plain "
-                     "weights-only archive is not importable as a graph)"
-                  << std::endl;
-        return em::val::null();
-    }
-    if (!skipped.empty()) {
-        std::cerr << "gguf import: " << skipped.size()
-                  << " tensor(s) left un-hydrated (quantized/unsupported dtype)"
-                  << std::endl;
-    }
-    return SerializeModel(xmodel);
+    return em::val::null();
+  }
+  std::remove(kGGUFArchivePath);
+  if (!ok) {
+    std::cerr << "gguf file has no embedded onnxsim model (a plain "
+                 "weights-only archive is not importable as a graph)"
+              << std::endl;
+    return em::val::null();
+  }
+  if (!skipped.empty()) {
+    std::cerr << "gguf import: " << skipped.size()
+              << " tensor(s) left un-hydrated (quantized/unsupported dtype)"
+              << std::endl;
+  }
+  return SerializeModel(xmodel);
 }
 
 // Report the versions of the libraries baked into this module, for detailed
-// bug reports. onnxsim and onnx-optimizer come from CMake (their VERSION files);
-// onnx is reported as its max IR version + the highest opset it supports for the
-// default (ai.onnx) domain, both read from the linked onnx at runtime; protobuf
-// is decoded from GOOGLE_PROTOBUF_VERSION. Returns a plain JS object of strings.
+// bug reports. onnxsim and onnx-optimizer come from CMake (their VERSION
+// files); onnx is reported as its max IR version + the highest opset it
+// supports for the default (ai.onnx) domain, both read from the linked onnx at
+// runtime; protobuf is decoded from GOOGLE_PROTOBUF_VERSION. Returns a plain JS
+// object of strings.
 em::val onnxsim_versions() {
-    em::val out = em::val::object();
-    out.set("onnxsim", std::string(ONNXSIM_VERSION_STRING));
-    out.set("onnx_optimizer", std::string(ONNX_OPTIMIZER_VERSION_STRING));
+  em::val out = em::val::object();
+  out.set("onnxsim", std::string(ONNXSIM_VERSION_STRING));
+  out.set("onnx_optimizer", std::string(ONNX_OPTIMIZER_VERSION_STRING));
 
-    // onnx: IR version + highest supported opset for the default ONNX domain.
-    {
-        int max_opset = 0;
-        const auto& ranges =
-            onnx::OpSchemaRegistry::DomainToVersionRange::Instance().Map();
-        auto it = ranges.find("");  // "" is the default ONNX domain (ai.onnx)
-        if (it != ranges.end()) {
-            max_opset = it->second.second;
-        }
-        std::ostringstream os;
-        os << "IR v" << static_cast<int>(onnx::IR_VERSION) << ", opset "
-           << max_opset;
-        out.set("onnx", os.str());
+  // onnx: IR version + highest supported opset for the default ONNX domain.
+  {
+    int max_opset = 0;
+    const auto &ranges =
+        onnx::OpSchemaRegistry::DomainToVersionRange::Instance().Map();
+    auto it = ranges.find(""); // "" is the default ONNX domain (ai.onnx)
+    if (it != ranges.end()) {
+      max_opset = it->second.second;
     }
+    std::ostringstream os;
+    os << "IR v" << static_cast<int>(onnx::IR_VERSION) << ", opset "
+       << max_opset;
+    out.set("onnx", os.str());
+  }
 
-    // protobuf: GOOGLE_PROTOBUF_VERSION is major*1000000 + minor*1000 + patch.
+  // protobuf: GOOGLE_PROTOBUF_VERSION is major*1000000 + minor*1000 + patch.
 #ifdef GOOGLE_PROTOBUF_VERSION
-    {
-        int pv = GOOGLE_PROTOBUF_VERSION;
-        std::ostringstream os;
-        os << (pv / 1000000) << "." << (pv / 1000 % 1000) << "." << (pv % 1000);
-        out.set("protobuf", os.str());
-    }
+  {
+    int pv = GOOGLE_PROTOBUF_VERSION;
+    std::ostringstream os;
+    os << (pv / 1000000) << "." << (pv / 1000 % 1000) << "." << (pv % 1000);
+    out.set("protobuf", os.str());
+  }
 #else
-    out.set("protobuf", std::string("unknown"));
+  out.set("protobuf", std::string("unknown"));
 #endif
-    return out;
+  return out;
 }
 
-// Parse an ONNX *text* representation into a model and return its bytes. Accepts
-// either a whole-model text (with an `<ir_version: ..., opset_import: [...]>`
-// prolog) or a bare graph body -- the textual form onnx.parser.parse_graph /
-// parse_model accept. Local function definitions (one or more `<domain: ...>
-// name (...) => (...) {...}` blocks after the graph) are parsed too: the model
-// path captures them natively, and either path is normalized so the model
-// carries an opset import for the default ONNX domain and for every domain its
-// functions use, plus a valid ir_version -- so a graph that calls local
-// functions still validates and can be simplified / visualized / run like an
-// uploaded model. Returns { model: Uint8Array } on success or { error: string }
-// describing the parse failure(s).
-em::val onnxsim_parse_graph(const std::string& text) {
-    em::val out = em::val::object();
-    // Try whole-model text first: this is the only path that captures trailing
-    // FunctionProto definitions (GraphProto has no functions field), and it also
-    // accepts a bare graph because the `<...>` prolog is optional. Each
-    // OnnxParser consumes its input, so a fresh parser is constructed per attempt
-    // (the member Parse API is stable across onnx versions).
-    onnx::ModelProto model;
-    onnx::OnnxParser model_parser(text.c_str());
-    onnx::Common::Status model_st = model_parser.Parse(model);
-    if (!model_st.IsOK() || !model.has_graph()) {
-        // Fall back to graph-only text and wrap it into a model. This path has no
-        // functions (the graph syntax cannot carry them), so a model that needs
-        // local functions must go through the model path above.
-        onnx::GraphProto graph;
-        onnx::OnnxParser graph_parser(text.c_str());
-        onnx::Common::Status graph_st = graph_parser.Parse(graph);
-        if (!graph_st.IsOK()) {
-            out.set("error", std::string("failed to parse as a model (") +
-                                 model_st.ErrorMessage() +
-                                 ") and as a graph (" + graph_st.ErrorMessage() +
-                                 ")");
-            return out;
-        }
-        model.Clear();
-        *model.mutable_graph() = graph;
+// Parse an ONNX *text* representation into a model and return its bytes.
+// Accepts either a whole-model text (with an `<ir_version: ..., opset_import:
+// [...]>` prolog) or a bare graph body -- the textual form
+// onnx.parser.parse_graph / parse_model accept. Local function definitions (one
+// or more `<domain: ...> name (...) => (...) {...}` blocks after the graph) are
+// parsed too: the model path captures them natively, and either path is
+// normalized so the model carries an opset import for the default ONNX domain
+// and for every domain its functions use, plus a valid ir_version -- so a graph
+// that calls local functions still validates and can be simplified / visualized
+// / run like an uploaded model. Returns { model: Uint8Array } on success or {
+// error: string } describing the parse failure(s).
+em::val onnxsim_parse_graph(const std::string &text) {
+  em::val out = em::val::object();
+  // Try whole-model text first: this is the only path that captures trailing
+  // FunctionProto definitions (GraphProto has no functions field), and it also
+  // accepts a bare graph because the `<...>` prolog is optional. Each
+  // OnnxParser consumes its input, so a fresh parser is constructed per attempt
+  // (the member Parse API is stable across onnx versions).
+  onnx::ModelProto model;
+  onnx::OnnxParser model_parser(text.c_str());
+  onnx::Common::Status model_st = model_parser.Parse(model);
+  if (!model_st.IsOK() || !model.has_graph()) {
+    // Fall back to graph-only text and wrap it into a model. This path has no
+    // functions (the graph syntax cannot carry them), so a model that needs
+    // local functions must go through the model path above.
+    onnx::GraphProto graph;
+    onnx::OnnxParser graph_parser(text.c_str());
+    onnx::Common::Status graph_st = graph_parser.Parse(graph);
+    if (!graph_st.IsOK()) {
+      out.set("error", std::string("failed to parse as a model (") +
+                           model_st.ErrorMessage() + ") and as a graph (" +
+                           graph_st.ErrorMessage() + ")");
+      return out;
     }
-    // A bare graph (or a graph with local functions but no explicit prolog) parses
-    // without an ir_version or opset imports; fill in sensible defaults so the
-    // result validates. Local functions require IR v8+, and EnsureOpsetImports
-    // adds an opset import for each function's domain.
-    if (model.ir_version() == 0) {
-        model.set_ir_version(onnx::IR_VERSION);
-    }
-    EnsureOpsetImports(model);
-    em::val bytes = SerializeModel(model);
-    if (bytes.isNull()) {
-        out.set("error", std::string("failed to serialize the parsed model"));
-        return out;
-    }
-    out.set("model", bytes);
+    model.Clear();
+    *model.mutable_graph() = graph;
+  }
+  // A bare graph (or a graph with local functions but no explicit prolog)
+  // parses without an ir_version or opset imports; fill in sensible defaults so
+  // the result validates. Local functions require IR v8+, and
+  // EnsureOpsetImports adds an opset import for each function's domain.
+  if (model.ir_version() == 0) {
+    model.set_ir_version(onnx::IR_VERSION);
+  }
+  EnsureOpsetImports(model);
+  em::val bytes = SerializeModel(model);
+  if (bytes.isNull()) {
+    out.set("error", std::string("failed to serialize the parsed model"));
     return out;
+  }
+  out.set("model", bytes);
+  return out;
 }
 
 // Inline the model's local (model-defined) functions into its main graph: every
@@ -683,58 +699,58 @@ em::val onnxsim_parse_graph(const std::string& text) {
 // functions are left alone. Returns the inlined model bytes (null on failure);
 // `annotate` optionally bakes MAC/FLOP model info into metadata_props, matching
 // the other convert entry points.
-em::val onnxsim_inline_functions(const std::string& data, bool annotate) {
-    onnx::ModelProto xmodel;
-    std::cerr << "parsing message" << std::endl;
-    if (!xmodel.ParseFromArray(data.data(), data.size())) {
-        std::cerr << "Parse failed" << std::endl;
-        return em::val::null();
-    }
+em::val onnxsim_inline_functions(const std::string &data, bool annotate) {
+  onnx::ModelProto xmodel;
+  std::cerr << "parsing message" << std::endl;
+  if (!xmodel.ParseFromArray(data.data(), data.size())) {
+    std::cerr << "Parse failed" << std::endl;
+    return em::val::null();
+  }
+  try {
+    onnx::inliner::InlineLocalFunctions(xmodel);
+  } catch (const std::exception &e) {
+    std::cerr << "inline functions error: " << e.what() << std::endl;
+    return em::val::null();
+  }
+  if (annotate) {
     try {
-        onnx::inliner::InlineLocalFunctions(xmodel);
-    } catch (const std::exception& e) {
-        std::cerr << "inline functions error: " << e.what() << std::endl;
-        return em::val::null();
+      AnnotateModelInfo(xmodel);
+    } catch (const std::exception &e) {
+      std::cerr << "annotate model info failed: " << e.what() << std::endl;
     }
-    if (annotate) {
-        try {
-            AnnotateModelInfo(xmodel);
-        } catch (const std::exception& e) {
-            std::cerr << "annotate model info failed: " << e.what() << std::endl;
-        }
-    }
-    return SerializeModel(xmodel);
+  }
+  return SerializeModel(xmodel);
 }
 
 // Parse a serialized onnx.TensorProto (e.g. an input_N.pb / output_N.pb from an
 // ONNX backend test case) into a form onnxruntime-web can consume in JS.
 // Returns { dtype: int (TensorProto.DataType), name: string, dims: [int...],
 // data: Uint8Array (raw little-endian) } or { error: string }.
-em::val onnxsim_parse_tensor(const std::string& data) {
-    em::val out = em::val::object();
-    onnx::TensorProto tensor;
-    if (!tensor.ParseFromArray(data.data(), data.size())) {
-        out.set("error", std::string("failed to parse TensorProto"));
-        return out;
-    }
-    static std::string raw;
-    if (!TensorProtoToRawBytes(tensor, raw)) {
-        std::ostringstream os;
-        os << "unsupported tensor data type " << tensor.data_type()
-           << " (STRING / COMPLEX and similar are not bridged)";
-        out.set("error", os.str());
-        return out;
-    }
-    out.set("dtype", static_cast<int>(tensor.data_type()));
-    out.set("name", tensor.name());
-    em::val dims = em::val::array();
-    for (int i = 0; i < tensor.dims_size(); ++i) {
-        dims.set(i, static_cast<double>(tensor.dims(i)));
-    }
-    out.set("dims", dims);
-    out.set("data", em::val(em::typed_memory_view(
-                        raw.size(), reinterpret_cast<uint8_t*>(raw.data()))));
+em::val onnxsim_parse_tensor(const std::string &data) {
+  em::val out = em::val::object();
+  onnx::TensorProto tensor;
+  if (!tensor.ParseFromArray(data.data(), data.size())) {
+    out.set("error", std::string("failed to parse TensorProto"));
     return out;
+  }
+  static std::string raw;
+  if (!TensorProtoToRawBytes(tensor, raw)) {
+    std::ostringstream os;
+    os << "unsupported tensor data type " << tensor.data_type()
+       << " (STRING / COMPLEX and similar are not bridged)";
+    out.set("error", os.str());
+    return out;
+  }
+  out.set("dtype", static_cast<int>(tensor.data_type()));
+  out.set("name", tensor.name());
+  em::val dims = em::val::array();
+  for (int i = 0; i < tensor.dims_size(); ++i) {
+    dims.set(i, static_cast<double>(tensor.dims(i)));
+  }
+  out.set("dims", dims);
+  out.set("data", em::val(em::typed_memory_view(
+                      raw.size(), reinterpret_cast<uint8_t *>(raw.data()))));
+  return out;
 }
 
 // Run a single simplification building block once (not in the fixed point) for
@@ -743,78 +759,79 @@ em::val onnxsim_parse_tensor(const std::string& data) {
 // through the same executor Simplify uses -- in the ORT-web build that awaits
 // onnxruntime-web, so (like onnxsimplify_export) onnxsim_fold_constant is
 // Asyncified and returns a Promise the worker awaits.
-em::val onnxsim_infer_shapes(const std::string& data) {
-    InitEnv();
-    onnx::ModelProto xmodel;
-    if (!xmodel.ParseFromArray(data.data(), data.size())) {
-        std::cerr << "Parse failed" << std::endl;
-        return em::val::null();
-    }
-    try {
-        return SerializeModel(InferShapesOnce(xmodel));
-    } catch (const std::exception& e) {
-        std::cerr << "shape inference error: " << e.what() << std::endl;
-        return em::val::null();
-    }
+em::val onnxsim_infer_shapes(const std::string &data) {
+  InitEnv();
+  onnx::ModelProto xmodel;
+  if (!xmodel.ParseFromArray(data.data(), data.size())) {
+    std::cerr << "Parse failed" << std::endl;
+    return em::val::null();
+  }
+  try {
+    return SerializeModel(InferShapesOnce(xmodel));
+  } catch (const std::exception &e) {
+    std::cerr << "shape inference error: " << e.what() << std::endl;
+    return em::val::null();
+  }
 }
 
-em::val onnxsim_data_propagation(const std::string& data) {
-    InitEnv();
-    onnx::ModelProto xmodel;
-    if (!xmodel.ParseFromArray(data.data(), data.size())) {
-        std::cerr << "Parse failed" << std::endl;
-        return em::val::null();
-    }
-    try {
-        return SerializeModel(PropagateDataOnce(xmodel));
-    } catch (const std::exception& e) {
-        std::cerr << "data propagation error: " << e.what() << std::endl;
-        return em::val::null();
-    }
+em::val onnxsim_data_propagation(const std::string &data) {
+  InitEnv();
+  onnx::ModelProto xmodel;
+  if (!xmodel.ParseFromArray(data.data(), data.size())) {
+    std::cerr << "Parse failed" << std::endl;
+    return em::val::null();
+  }
+  try {
+    return SerializeModel(PropagateDataOnce(xmodel));
+  } catch (const std::exception &e) {
+    std::cerr << "data propagation error: " << e.what() << std::endl;
+    return em::val::null();
+  }
 }
 
-em::val onnxsim_fold_constant(const std::string& data, size_t tensor_size_threshold) {
-    InitEnv();
-    onnx::ModelProto xmodel;
-    if (!xmodel.ParseFromArray(data.data(), data.size())) {
-        std::cerr << "Parse failed" << std::endl;
-        return em::val::null();
-    }
-    try {
-        onnx::ModelProto folded = FoldConstantOnce(
+em::val onnxsim_fold_constant(const std::string &data,
+                              size_t tensor_size_threshold) {
+  InitEnv();
+  onnx::ModelProto xmodel;
+  if (!xmodel.ParseFromArray(data.data(), data.size())) {
+    std::cerr << "Parse failed" << std::endl;
+    return em::val::null();
+  }
+  try {
+    onnx::ModelProto folded = FoldConstantOnce(
 #ifdef ONNXSIM_WASM_ORT_WEB
-            *GetJsModelExecutor(),
+        *GetJsModelExecutor(),
 #else
-            *GetBuiltinModelExecutor(),
+        *GetBuiltinModelExecutor(),
 #endif
-            xmodel, tensor_size_threshold);
-        return SerializeModel(folded);
-    } catch (const std::exception& e) {
-        std::cerr << "constant folding error: " << e.what() << std::endl;
-        return em::val::null();
-    }
+        xmodel, tensor_size_threshold);
+    return SerializeModel(folded);
+  } catch (const std::exception &e) {
+    std::cerr << "constant folding error: " << e.what() << std::endl;
+    return em::val::null();
+  }
 }
 
 // True when this module was built to delegate constant folding to
-// onnxruntime-web (ONNXSIM_WASM_ORT_WEB). The worker uses this to decide whether
-// it must load onnxruntime-web and register a runner on the Module before
-// simplifying, and whether onnxsimplify_export returns a Promise (Asyncify) it
-// needs to await. In the default built-in-ORT build this is false and the
-// worker's behaviour is unchanged.
+// onnxruntime-web (ONNXSIM_WASM_ORT_WEB). The worker uses this to decide
+// whether it must load onnxruntime-web and register a runner on the Module
+// before simplifying, and whether onnxsimplify_export returns a Promise
+// (Asyncify) it needs to await. In the default built-in-ORT build this is false
+// and the worker's behaviour is unchanged.
 bool onnxsim_needs_ort_web() {
 #ifdef ONNXSIM_WASM_ORT_WEB
-    return true;
+  return true;
 #else
-    return false;
+  return false;
 #endif
 }
 
 std::vector<std::string> onnxoptimizer_passes() {
-    return onnx::optimization::GetAvailablePasses();
+  return onnx::optimization::GetAvailablePasses();
 }
 
 std::vector<std::string> onnxoptimizer_fuse_elimination_passes() {
-    return onnx::optimization::GetFuseAndEliminationPass();
+  return onnx::optimization::GetFuseAndEliminationPass();
 }
 
 // Converts parallel JS arrays -- ``names_ary`` (tensor names) and
@@ -826,149 +843,152 @@ std::vector<std::string> onnxoptimizer_fuse_elimination_passes() {
 // js_model_executor.cpp / docs/wasm_ort_web.md).
 std::unordered_map<std::string, std::pair<float, float>>
 ParseCalibrationRanges(em::val names_ary, em::val ranges_flat_ary) {
-    std::vector<std::string> names = em::vecFromJSArray<std::string>(names_ary);
-    std::vector<float> flat = em::vecFromJSArray<float>(ranges_flat_ary);
-    std::unordered_map<std::string, std::pair<float, float>> ranges;
-    ranges.reserve(names.size());
-    for (size_t i = 0; i < names.size() && 2 * i + 1 < flat.size(); ++i) {
-        ranges.emplace(names[i], std::make_pair(flat[2 * i], flat[2 * i + 1]));
-    }
-    return ranges;
+  std::vector<std::string> names = em::vecFromJSArray<std::string>(names_ary);
+  std::vector<float> flat = em::vecFromJSArray<float>(ranges_flat_ary);
+  std::unordered_map<std::string, std::pair<float, float>> ranges;
+  ranges.reserve(names.size());
+  for (size_t i = 0; i < names.size() && 2 * i + 1 < flat.size(); ++i) {
+    ranges.emplace(names[i], std::make_pair(flat[2 * i], flat[2 * i + 1]));
+  }
+  return ranges;
 }
 
-em::val onnxsim_quantize_dynamic(const std::string& data) {
-    onnx::ModelProto xmodel;
-    if (!xmodel.ParseFromArray(data.data(), data.size())) {
-        std::cerr << "Parse failed" << std::endl;
-        return em::val::null();
-    }
-    try {
-        return SerializeModel(QuantizeDynamic(xmodel));
-    } catch (const std::exception& e) {
-        std::cerr << "quantize_dynamic error: " << e.what() << std::endl;
-        return em::val::null();
-    }
+em::val onnxsim_quantize_dynamic(const std::string &data) {
+  onnx::ModelProto xmodel;
+  if (!xmodel.ParseFromArray(data.data(), data.size())) {
+    std::cerr << "Parse failed" << std::endl;
+    return em::val::null();
+  }
+  try {
+    return SerializeModel(QuantizeDynamic(xmodel));
+  } catch (const std::exception &e) {
+    std::cerr << "quantize_dynamic error: " << e.what() << std::endl;
+    return em::val::null();
+  }
 }
 
-em::val onnxsim_quantize_ternary(const std::string& data) {
-    onnx::ModelProto xmodel;
-    if (!xmodel.ParseFromArray(data.data(), data.size())) {
-        std::cerr << "Parse failed" << std::endl;
-        return em::val::null();
-    }
-    try {
-        return SerializeModel(QuantizeTernary(xmodel));
-    } catch (const std::exception& e) {
-        std::cerr << "quantize_ternary error: " << e.what() << std::endl;
-        return em::val::null();
-    }
+em::val onnxsim_quantize_ternary(const std::string &data) {
+  onnx::ModelProto xmodel;
+  if (!xmodel.ParseFromArray(data.data(), data.size())) {
+    std::cerr << "Parse failed" << std::endl;
+    return em::val::null();
+  }
+  try {
+    return SerializeModel(QuantizeTernary(xmodel));
+  } catch (const std::exception &e) {
+    std::cerr << "quantize_ternary error: " << e.what() << std::endl;
+    return em::val::null();
+  }
 }
 
-em::val onnxsim_quantize_weight_only(const std::string& data) {
-    onnx::ModelProto xmodel;
-    if (!xmodel.ParseFromArray(data.data(), data.size())) {
-        std::cerr << "Parse failed" << std::endl;
-        return em::val::null();
-    }
-    try {
-        return SerializeModel(QuantizeWeightOnly(xmodel));
-    } catch (const std::exception& e) {
-        std::cerr << "quantize_weight_only error: " << e.what() << std::endl;
-        return em::val::null();
-    }
+em::val onnxsim_quantize_weight_only(const std::string &data) {
+  onnx::ModelProto xmodel;
+  if (!xmodel.ParseFromArray(data.data(), data.size())) {
+    std::cerr << "Parse failed" << std::endl;
+    return em::val::null();
+  }
+  try {
+    return SerializeModel(QuantizeWeightOnly(xmodel));
+  } catch (const std::exception &e) {
+    std::cerr << "quantize_weight_only error: " << e.what() << std::endl;
+    return em::val::null();
+  }
 }
 
-em::val onnxsim_quantize_weight_only_int4(const std::string& data) {
-    onnx::ModelProto xmodel;
-    if (!xmodel.ParseFromArray(data.data(), data.size())) {
-        std::cerr << "Parse failed" << std::endl;
-        return em::val::null();
-    }
-    try {
-        return SerializeModel(QuantizeWeightOnlyInt4(xmodel));
-    } catch (const std::exception& e) {
-        std::cerr << "quantize_weight_only_int4 error: " << e.what() << std::endl;
-        return em::val::null();
-    }
+em::val onnxsim_quantize_weight_only_int4(const std::string &data) {
+  onnx::ModelProto xmodel;
+  if (!xmodel.ParseFromArray(data.data(), data.size())) {
+    std::cerr << "Parse failed" << std::endl;
+    return em::val::null();
+  }
+  try {
+    return SerializeModel(QuantizeWeightOnlyInt4(xmodel));
+  } catch (const std::exception &e) {
+    std::cerr << "quantize_weight_only_int4 error: " << e.what() << std::endl;
+    return em::val::null();
+  }
 }
 
-em::val onnxsim_quantize_fp16(const std::string& data) {
-    onnx::ModelProto xmodel;
-    if (!xmodel.ParseFromArray(data.data(), data.size())) {
-        std::cerr << "Parse failed" << std::endl;
-        return em::val::null();
-    }
-    try {
-        return SerializeModel(QuantizeFp16(xmodel));
-    } catch (const std::exception& e) {
-        std::cerr << "quantize_fp16 error: " << e.what() << std::endl;
-        return em::val::null();
-    }
+em::val onnxsim_quantize_fp16(const std::string &data) {
+  onnx::ModelProto xmodel;
+  if (!xmodel.ParseFromArray(data.data(), data.size())) {
+    std::cerr << "Parse failed" << std::endl;
+    return em::val::null();
+  }
+  try {
+    return SerializeModel(QuantizeFp16(xmodel));
+  } catch (const std::exception &e) {
+    std::cerr << "quantize_fp16 error: " << e.what() << std::endl;
+    return em::val::null();
+  }
 }
 
-em::val onnxsim_quantize_bf16(const std::string& data) {
-    onnx::ModelProto xmodel;
-    if (!xmodel.ParseFromArray(data.data(), data.size())) {
-        std::cerr << "Parse failed" << std::endl;
-        return em::val::null();
-    }
-    try {
-        return SerializeModel(QuantizeBf16(xmodel));
-    } catch (const std::exception& e) {
-        std::cerr << "quantize_bf16 error: " << e.what() << std::endl;
-        return em::val::null();
-    }
+em::val onnxsim_quantize_bf16(const std::string &data) {
+  onnx::ModelProto xmodel;
+  if (!xmodel.ParseFromArray(data.data(), data.size())) {
+    std::cerr << "Parse failed" << std::endl;
+    return em::val::null();
+  }
+  try {
+    return SerializeModel(QuantizeBf16(xmodel));
+  } catch (const std::exception &e) {
+    std::cerr << "quantize_bf16 error: " << e.what() << std::endl;
+    return em::val::null();
+  }
 }
 
 // `format` is "e4m3" or "e5m2" -- see QuantizeFp8 in onnxsim.h.
-em::val onnxsim_quantize_fp8(const std::string& data, const std::string& format) {
-    onnx::ModelProto xmodel;
-    if (!xmodel.ParseFromArray(data.data(), data.size())) {
-        std::cerr << "Parse failed" << std::endl;
-        return em::val::null();
-    }
-    try {
-        return SerializeModel(QuantizeFp8(xmodel, format));
-    } catch (const std::exception& e) {
-        std::cerr << "quantize_fp8 error: " << e.what() << std::endl;
-        return em::val::null();
-    }
+em::val onnxsim_quantize_fp8(const std::string &data,
+                             const std::string &format) {
+  onnx::ModelProto xmodel;
+  if (!xmodel.ParseFromArray(data.data(), data.size())) {
+    std::cerr << "Parse failed" << std::endl;
+    return em::val::null();
+  }
+  try {
+    return SerializeModel(QuantizeFp8(xmodel, format));
+  } catch (const std::exception &e) {
+    std::cerr << "quantize_fp8 error: " << e.what() << std::endl;
+    return em::val::null();
+  }
 }
 
-em::val WeightPrecisionEstimateToVal(const onnxsim::WeightPrecisionEstimate& est) {
-    em::val out = em::val::object();
-    out.set("nodeName", est.node_name);
-    out.set("opType", est.op_type);
-    out.set("reductionDepth", static_cast<double>(est.reduction_depth));
-    out.set("numChannels", static_cast<double>(est.num_channels));
-    out.set("int32AccumulatorSafe", est.int32_accumulator_safe);
-    out.set("float32CastExact", est.float32_cast_exact);
-    out.set("maxOutlierRatio", est.max_outlier_ratio);
-    out.set("outlierRisk", est.outlier_risk);
-    out.set("activationProducerOp", est.activation_producer_op);
-    out.set("hasActivationRange", est.has_activation_range);
-    out.set("activationRangeLo", est.activation_range_lo);
-    out.set("activationRangeHi", est.activation_range_hi);
-    out.set("recommendation", est.recommendation);
-    return out;
+em::val
+WeightPrecisionEstimateToVal(const onnxsim::WeightPrecisionEstimate &est) {
+  em::val out = em::val::object();
+  out.set("nodeName", est.node_name);
+  out.set("opType", est.op_type);
+  out.set("reductionDepth", static_cast<double>(est.reduction_depth));
+  out.set("numChannels", static_cast<double>(est.num_channels));
+  out.set("int32AccumulatorSafe", est.int32_accumulator_safe);
+  out.set("float32CastExact", est.float32_cast_exact);
+  out.set("maxOutlierRatio", est.max_outlier_ratio);
+  out.set("outlierRisk", est.outlier_risk);
+  out.set("activationProducerOp", est.activation_producer_op);
+  out.set("hasActivationRange", est.has_activation_range);
+  out.set("activationRangeLo", est.activation_range_lo);
+  out.set("activationRangeHi", est.activation_range_hi);
+  out.set("recommendation", est.recommendation);
+  return out;
 }
 
-em::val AttentionPrecisionEstimateToVal(const onnxsim::AttentionPrecisionEstimate& est) {
-    em::val out = em::val::object();
-    out.set("nodeName", est.node_name);
-    out.set("hasNumQueryHeads", est.has_num_query_heads);
-    out.set("numQueryHeads", static_cast<double>(est.num_query_heads));
-    out.set("hasNumKvHeads", est.has_num_kv_heads);
-    out.set("numKvHeads", static_cast<double>(est.num_kv_heads));
-    out.set("hasHeadDim", est.has_head_dim);
-    out.set("headDim", static_cast<double>(est.head_dim));
-    out.set("defaultScale", est.default_scale);
-    out.set("actualScale", est.actual_scale);
-    // -1 = unknown, 0 = false, 1 = true -- see AttentionPrecisionEstimate's
-    // doc comment in precision_estimator.h.
-    out.set("scaleMatchesDefault", est.scale_matches_default);
-    out.set("recommendation", est.recommendation);
-    return out;
+em::val AttentionPrecisionEstimateToVal(
+    const onnxsim::AttentionPrecisionEstimate &est) {
+  em::val out = em::val::object();
+  out.set("nodeName", est.node_name);
+  out.set("hasNumQueryHeads", est.has_num_query_heads);
+  out.set("numQueryHeads", static_cast<double>(est.num_query_heads));
+  out.set("hasNumKvHeads", est.has_num_kv_heads);
+  out.set("numKvHeads", static_cast<double>(est.num_kv_heads));
+  out.set("hasHeadDim", est.has_head_dim);
+  out.set("headDim", static_cast<double>(est.head_dim));
+  out.set("defaultScale", est.default_scale);
+  out.set("actualScale", est.actual_scale);
+  // -1 = unknown, 0 = false, 1 = true -- see AttentionPrecisionEstimate's
+  // doc comment in precision_estimator.h.
+  out.set("scaleMatchesDefault", est.scale_matches_default);
+  out.set("recommendation", est.recommendation);
+  return out;
 }
 
 // Static, calibration-free INT8-quantization risk pre-check -- see
@@ -984,69 +1004,73 @@ em::val AttentionPrecisionEstimateToVal(const onnxsim::AttentionPrecisionEstimat
 // -- e.g. worstOutlierRatio when no node had a computable ratio, or
 // estimatedRelativeError when riskLevel is "unsafe" -- come through as the JS
 // value NaN, exactly like Python's math.nan does for the same fields).
-em::val onnxsim_estimate_quantization_drop(const std::string& data) {
-    onnx::ModelProto xmodel;
-    if (!xmodel.ParseFromArray(data.data(), data.size())) {
-        std::cerr << "Parse failed" << std::endl;
-        return em::val::null();
-    }
-    onnxsim::ModelQuantizationEstimate est;
-    try {
-        est = onnxsim::EstimateModelQuantizationDrop(xmodel);
-    } catch (const std::exception& e) {
-        std::cerr << "estimate_quantization_drop error: " << e.what() << std::endl;
-        return em::val::null();
-    }
+em::val onnxsim_estimate_quantization_drop(const std::string &data) {
+  onnx::ModelProto xmodel;
+  if (!xmodel.ParseFromArray(data.data(), data.size())) {
+    std::cerr << "Parse failed" << std::endl;
+    return em::val::null();
+  }
+  onnxsim::ModelQuantizationEstimate est;
+  try {
+    est = onnxsim::EstimateModelQuantizationDrop(xmodel);
+  } catch (const std::exception &e) {
+    std::cerr << "estimate_quantization_drop error: " << e.what() << std::endl;
+    return em::val::null();
+  }
 
-    em::val out = em::val::object();
-    out.set("totalNodesAnalyzed", static_cast<double>(est.total_nodes_analyzed));
-    em::val unsafe_nodes = em::val::array();
-    for (size_t i = 0; i < est.unsafe_nodes.size(); ++i) {
-        unsafe_nodes.set(i, est.unsafe_nodes[i]);
-    }
-    out.set("unsafeNodes", unsafe_nodes);
-    em::val outlier_nodes = em::val::array();
-    for (size_t i = 0; i < est.outlier_risk_nodes.size(); ++i) {
-        outlier_nodes.set(i, est.outlier_risk_nodes[i]);
-    }
-    out.set("outlierRiskNodes", outlier_nodes);
-    out.set("worstOutlierRatio", est.worst_outlier_ratio);
-    out.set("estimatedRelativeError", est.estimated_relative_error);
-    out.set("riskLevel", est.risk_level);
+  em::val out = em::val::object();
+  out.set("totalNodesAnalyzed", static_cast<double>(est.total_nodes_analyzed));
+  em::val unsafe_nodes = em::val::array();
+  for (size_t i = 0; i < est.unsafe_nodes.size(); ++i) {
+    unsafe_nodes.set(i, est.unsafe_nodes[i]);
+  }
+  out.set("unsafeNodes", unsafe_nodes);
+  em::val outlier_nodes = em::val::array();
+  for (size_t i = 0; i < est.outlier_risk_nodes.size(); ++i) {
+    outlier_nodes.set(i, est.outlier_risk_nodes[i]);
+  }
+  out.set("outlierRiskNodes", outlier_nodes);
+  out.set("worstOutlierRatio", est.worst_outlier_ratio);
+  out.set("estimatedRelativeError", est.estimated_relative_error);
+  out.set("riskLevel", est.risk_level);
 
-    em::val weight_estimates = em::val::array();
-    for (size_t i = 0; i < est.weight_estimates.size(); ++i) {
-        weight_estimates.set(i, WeightPrecisionEstimateToVal(est.weight_estimates[i]));
-    }
-    out.set("weightEstimates", weight_estimates);
+  em::val weight_estimates = em::val::array();
+  for (size_t i = 0; i < est.weight_estimates.size(); ++i) {
+    weight_estimates.set(i,
+                         WeightPrecisionEstimateToVal(est.weight_estimates[i]));
+  }
+  out.set("weightEstimates", weight_estimates);
 
-    em::val attention_estimates = em::val::array();
-    for (size_t i = 0; i < est.attention_estimates.size(); ++i) {
-        attention_estimates.set(i, AttentionPrecisionEstimateToVal(est.attention_estimates[i]));
-    }
-    out.set("attentionEstimates", attention_estimates);
-    return out;
+  em::val attention_estimates = em::val::array();
+  for (size_t i = 0; i < est.attention_estimates.size(); ++i) {
+    attention_estimates.set(
+        i, AttentionPrecisionEstimateToVal(est.attention_estimates[i]));
+  }
+  out.set("attentionEstimates", attention_estimates);
+  return out;
 }
 
 // Both list_* functions below are used by the page to discover which tensor
 // names to calibrate (run the model over sample inputs and record each
 // tensor's observed min/max) before calling quantize_static/quantize_qoperator.
-std::vector<std::string> onnxsim_list_quantizable_activations(const std::string& data) {
-    onnx::ModelProto xmodel;
-    if (!xmodel.ParseFromArray(data.data(), data.size())) {
-        std::cerr << "Parse failed" << std::endl;
-        return {};
-    }
-    return ListQuantizableActivations(xmodel);
+std::vector<std::string>
+onnxsim_list_quantizable_activations(const std::string &data) {
+  onnx::ModelProto xmodel;
+  if (!xmodel.ParseFromArray(data.data(), data.size())) {
+    std::cerr << "Parse failed" << std::endl;
+    return {};
+  }
+  return ListQuantizableActivations(xmodel);
 }
 
-std::vector<std::string> onnxsim_list_qoperator_quantizable_outputs(const std::string& data) {
-    onnx::ModelProto xmodel;
-    if (!xmodel.ParseFromArray(data.data(), data.size())) {
-        std::cerr << "Parse failed" << std::endl;
-        return {};
-    }
-    return ListQOperatorQuantizableOutputs(xmodel);
+std::vector<std::string>
+onnxsim_list_qoperator_quantizable_outputs(const std::string &data) {
+  onnx::ModelProto xmodel;
+  if (!xmodel.ParseFromArray(data.data(), data.size())) {
+    std::cerr << "Parse failed" << std::endl;
+    return {};
+  }
+  return ListQOperatorQuantizableOutputs(xmodel);
 }
 
 // Appends a bare ValueInfoProto(name=name) graph output for every name in
@@ -1057,97 +1081,104 @@ std::vector<std::string> onnxsim_list_qoperator_quantizable_outputs(const std::s
 // sample inputs it feeds through. A bare ValueInfoProto with no type/shape is
 // a valid ONNX output (onnxruntime infers it from the run); this matches
 // calibrate()'s own onnx.ValueInfoProto(name=name) exactly.
-em::val onnxsim_add_graph_outputs(const std::string& data, em::val names_ary) {
-    onnx::ModelProto xmodel;
-    if (!xmodel.ParseFromArray(data.data(), data.size())) {
-        std::cerr << "Parse failed" << std::endl;
-        return em::val::null();
+em::val onnxsim_add_graph_outputs(const std::string &data, em::val names_ary) {
+  onnx::ModelProto xmodel;
+  if (!xmodel.ParseFromArray(data.data(), data.size())) {
+    std::cerr << "Parse failed" << std::endl;
+    return em::val::null();
+  }
+  std::vector<std::string> names = em::vecFromJSArray<std::string>(names_ary);
+  onnx::GraphProto *graph = xmodel.mutable_graph();
+  std::set<std::string> existing_outputs;
+  for (const auto &vi : graph->output()) {
+    existing_outputs.insert(vi.name());
+  }
+  for (const auto &name : names) {
+    if (existing_outputs.insert(name).second) {
+      graph->add_output()->set_name(name);
     }
-    std::vector<std::string> names = em::vecFromJSArray<std::string>(names_ary);
-    onnx::GraphProto* graph = xmodel.mutable_graph();
-    std::set<std::string> existing_outputs;
-    for (const auto& vi : graph->output()) {
-        existing_outputs.insert(vi.name());
-    }
-    for (const auto& name : names) {
-        if (existing_outputs.insert(name).second) {
-            graph->add_output()->set_name(name);
-        }
-    }
-    return SerializeModel(xmodel);
+  }
+  return SerializeModel(xmodel);
 }
 
-em::val onnxsim_quantize_static(const std::string& data, em::val names_ary, em::val ranges_flat_ary) {
-    onnx::ModelProto xmodel;
-    if (!xmodel.ParseFromArray(data.data(), data.size())) {
-        std::cerr << "Parse failed" << std::endl;
-        return em::val::null();
-    }
-    try {
-        return SerializeModel(QuantizeStatic(
-            xmodel, ParseCalibrationRanges(names_ary, ranges_flat_ary)));
-    } catch (const std::exception& e) {
-        std::cerr << "quantize_static error: " << e.what() << std::endl;
-        return em::val::null();
-    }
+em::val onnxsim_quantize_static(const std::string &data, em::val names_ary,
+                                em::val ranges_flat_ary) {
+  onnx::ModelProto xmodel;
+  if (!xmodel.ParseFromArray(data.data(), data.size())) {
+    std::cerr << "Parse failed" << std::endl;
+    return em::val::null();
+  }
+  try {
+    return SerializeModel(QuantizeStatic(
+        xmodel, ParseCalibrationRanges(names_ary, ranges_flat_ary)));
+  } catch (const std::exception &e) {
+    std::cerr << "quantize_static error: " << e.what() << std::endl;
+    return em::val::null();
+  }
 }
 
-em::val onnxsim_quantize_qoperator(const std::string& data, em::val names_ary, em::val ranges_flat_ary) {
-    onnx::ModelProto xmodel;
-    if (!xmodel.ParseFromArray(data.data(), data.size())) {
-        std::cerr << "Parse failed" << std::endl;
-        return em::val::null();
-    }
-    try {
-        return SerializeModel(QuantizeQOperator(
-            xmodel, ParseCalibrationRanges(names_ary, ranges_flat_ary)));
-    } catch (const std::exception& e) {
-        std::cerr << "quantize_qoperator error: " << e.what() << std::endl;
-        return em::val::null();
-    }
+em::val onnxsim_quantize_qoperator(const std::string &data, em::val names_ary,
+                                   em::val ranges_flat_ary) {
+  onnx::ModelProto xmodel;
+  if (!xmodel.ParseFromArray(data.data(), data.size())) {
+    std::cerr << "Parse failed" << std::endl;
+    return em::val::null();
+  }
+  try {
+    return SerializeModel(QuantizeQOperator(
+        xmodel, ParseCalibrationRanges(names_ary, ranges_flat_ary)));
+  } catch (const std::exception &e) {
+    std::cerr << "quantize_qoperator error: " << e.what() << std::endl;
+    return em::val::null();
+  }
 }
 
 EMSCRIPTEN_BINDINGS(module) {
-    function("onnxsimplify_export", &onnxsimplify_export);
-    function("onnxsim_annotate_model_info", &onnxsim_annotate_model_info);
-    function("onnxsim_export_safetensors", &onnxsim_export_safetensors);
-    function("onnxsim_export_gguf", &onnxsim_export_gguf);
-    function("onnxsim_import_safetensors", &onnxsim_import_safetensors);
-    function("onnxsim_import_gguf", &onnxsim_import_gguf);
-    function("onnxoptimizer_optimize", &onnxoptimizer_optimize);
-    function("onnxoptimizer_optimize_fixed", &onnxoptimizer_optimize_fixed);
-    em::function("onnxoptimizer_passes", &onnxoptimizer_passes);
-    em::function("onnxoptimizer_fuse_elimination_passes", &onnxoptimizer_fuse_elimination_passes);
-    em::function("onnxsim_needs_ort_web", &onnxsim_needs_ort_web);
-    // Version reporting, text-graph parsing, TensorProto parsing, and the
-    // single-pass debugging entry points (see the definitions above).
-    em::function("onnxsim_versions", &onnxsim_versions);
-    em::function("onnxsim_parse_graph", &onnxsim_parse_graph);
-    em::function("onnxsim_inline_functions", &onnxsim_inline_functions);
-    em::function("onnxsim_parse_tensor", &onnxsim_parse_tensor);
-    em::function("onnxsim_infer_shapes", &onnxsim_infer_shapes);
-    em::function("onnxsim_data_propagation", &onnxsim_data_propagation);
-    em::function("onnxsim_fold_constant", &onnxsim_fold_constant);
+  function("onnxsimplify_export", &onnxsimplify_export);
+  function("onnxsim_annotate_model_info", &onnxsim_annotate_model_info);
+  function("onnxsim_export_safetensors", &onnxsim_export_safetensors);
+  function("onnxsim_export_gguf", &onnxsim_export_gguf);
+  function("onnxsim_import_safetensors", &onnxsim_import_safetensors);
+  function("onnxsim_import_gguf", &onnxsim_import_gguf);
+  function("onnxoptimizer_optimize", &onnxoptimizer_optimize);
+  function("onnxoptimizer_optimize_fixed", &onnxoptimizer_optimize_fixed);
+  em::function("onnxoptimizer_passes", &onnxoptimizer_passes);
+  em::function("onnxoptimizer_fuse_elimination_passes",
+               &onnxoptimizer_fuse_elimination_passes);
+  em::function("onnxsim_needs_ort_web", &onnxsim_needs_ort_web);
+  // Version reporting, text-graph parsing, TensorProto parsing, and the
+  // single-pass debugging entry points (see the definitions above).
+  em::function("onnxsim_versions", &onnxsim_versions);
+  em::function("onnxsim_parse_graph", &onnxsim_parse_graph);
+  em::function("onnxsim_inline_functions", &onnxsim_inline_functions);
+  em::function("onnxsim_parse_tensor", &onnxsim_parse_tensor);
+  em::function("onnxsim_infer_shapes", &onnxsim_infer_shapes);
+  em::function("onnxsim_data_propagation", &onnxsim_data_propagation);
+  em::function("onnxsim_fold_constant", &onnxsim_fold_constant);
 
-    // Calibration-free quantization methods (no activation ranges needed).
-    function("onnxsim_quantize_dynamic", &onnxsim_quantize_dynamic);
-    function("onnxsim_quantize_ternary", &onnxsim_quantize_ternary);
-    function("onnxsim_quantize_weight_only", &onnxsim_quantize_weight_only);
-    function("onnxsim_quantize_weight_only_int4", &onnxsim_quantize_weight_only_int4);
-    function("onnxsim_quantize_fp16", &onnxsim_quantize_fp16);
-    function("onnxsim_quantize_bf16", &onnxsim_quantize_bf16);
-    function("onnxsim_quantize_fp8", &onnxsim_quantize_fp8);
-    // Static, calibration-free INT8-quantization risk pre-check (see its own
-    // doc comment above).
-    em::function("onnxsim_estimate_quantization_drop", &onnxsim_estimate_quantization_drop);
-    // Calibration-based quantization: list_* discovers which tensors to
-    // calibrate, quantize_static/quantize_qoperator take the calibrated
-    // ranges back as parallel [name] / [min0, max0, min1, max1, ...] arrays.
-    em::function("onnxsim_list_quantizable_activations", &onnxsim_list_quantizable_activations);
-    em::function("onnxsim_list_qoperator_quantizable_outputs", &onnxsim_list_qoperator_quantizable_outputs);
-    function("onnxsim_add_graph_outputs", &onnxsim_add_graph_outputs);
-    function("onnxsim_quantize_static", &onnxsim_quantize_static);
-    function("onnxsim_quantize_qoperator", &onnxsim_quantize_qoperator);
+  // Calibration-free quantization methods (no activation ranges needed).
+  function("onnxsim_quantize_dynamic", &onnxsim_quantize_dynamic);
+  function("onnxsim_quantize_ternary", &onnxsim_quantize_ternary);
+  function("onnxsim_quantize_weight_only", &onnxsim_quantize_weight_only);
+  function("onnxsim_quantize_weight_only_int4",
+           &onnxsim_quantize_weight_only_int4);
+  function("onnxsim_quantize_fp16", &onnxsim_quantize_fp16);
+  function("onnxsim_quantize_bf16", &onnxsim_quantize_bf16);
+  function("onnxsim_quantize_fp8", &onnxsim_quantize_fp8);
+  // Static, calibration-free INT8-quantization risk pre-check (see its own
+  // doc comment above).
+  em::function("onnxsim_estimate_quantization_drop",
+               &onnxsim_estimate_quantization_drop);
+  // Calibration-based quantization: list_* discovers which tensors to
+  // calibrate, quantize_static/quantize_qoperator take the calibrated
+  // ranges back as parallel [name] / [min0, max0, min1, max1, ...] arrays.
+  em::function("onnxsim_list_quantizable_activations",
+               &onnxsim_list_quantizable_activations);
+  em::function("onnxsim_list_qoperator_quantizable_outputs",
+               &onnxsim_list_qoperator_quantizable_outputs);
+  function("onnxsim_add_graph_outputs", &onnxsim_add_graph_outputs);
+  function("onnxsim_quantize_static", &onnxsim_quantize_static);
+  function("onnxsim_quantize_qoperator", &onnxsim_quantize_qoperator);
 
-    em::register_vector<std::string>("string_list");
+  em::register_vector<std::string>("string_list");
 }

--- a/scripts/convertmodel/package.json
+++ b/scripts/convertmodel/package.json
@@ -27,7 +27,8 @@
     "test:hfdata": "node test/hf_datasets.test.mjs",
     "test:sample": "node test/sample_inputs.test.mjs",
     "test:classify": "node test/classify_output.test.mjs",
-    "test:all": "npm run test:netron && npm run test:trace && npm run test:node-reduction && npm run test:macs && npm run test:shapes && npm run test:hf && npm run test:hftoken && npm run test:xet && npm run test:issue && npm run test:versions && npm run test:backend && npm run test:query && npm run test:webnn && npm run test:ortlog && npm run test:cdn && npm run test:fill && npm run test:tokenize && npm run test:hfdata && npm run test:sample && npm run test:classify && npm run test:inference && npm run test:compare",
+    "test:quantize-risk": "node test/quantize_risk_estimate.test.mjs",
+    "test:all": "npm run test:netron && npm run test:trace && npm run test:node-reduction && npm run test:macs && npm run test:shapes && npm run test:hf && npm run test:hftoken && npm run test:xet && npm run test:issue && npm run test:versions && npm run test:backend && npm run test:query && npm run test:webnn && npm run test:ortlog && npm run test:cdn && npm run test:fill && npm run test:tokenize && npm run test:hfdata && npm run test:sample && npm run test:classify && npm run test:quantize-risk && npm run test:inference && npm run test:compare",
     "coverage": "c8 npm run test:all"
   },
   "dependencies": {

--- a/scripts/convertmodel/quantize_risk_estimate.mjs
+++ b/scripts/convertmodel/quantize_risk_estimate.mjs
@@ -10,11 +10,15 @@
 // onnxruntime-web to actually run the models).
 //
 // Loaded as its own top-level module (a <script type="module"> tag right
-// after quantize_ui.mjs's own in index.html), not imported by it -- so this
-// can import resolveQuantizeInput/getRuntime from quantize_ui.mjs directly
-// with no circular-import concern.
-
-import { getRuntime, resolveQuantizeInput } from "./quantize_ui.mjs";
+// after quantize_ui.mjs's own in index.html), not imported by it.
+// resolveQuantizeInput/getRuntime are imported lazily, inside the click
+// handler below, rather than at module scope: quantize_ui.mjs pulls in
+// inference_browser.mjs, which touches `document` unconditionally at module
+// scope (no browser-environment guard), so a static top-level import here
+// would make this module -- and therefore its pure, DOM-free helpers below --
+// impossible to load under plain Node (see test/quantize_risk_estimate.test.mjs,
+// which imports only those helpers and needs this module's own top-level code
+// to run without a DOM).
 
 // Runs onnxsim_estimate_quantization_drop on `bytes` via `runtime` (the
 // page's WASM module) and returns the parsed result. Throws if the model
@@ -111,6 +115,7 @@ function initQuantizeRiskPanel() {
       resultEl.innerHTML = "";
     }
     try {
+      const { getRuntime, resolveQuantizeInput } = await import("./quantize_ui.mjs");
       setStatus("loading model…");
       const { bytes } = await resolveQuantizeInput(source, fileInput);
 
@@ -131,4 +136,6 @@ function initQuantizeRiskPanel() {
   });
 }
 
-initQuantizeRiskPanel();
+if (typeof window !== "undefined" && typeof document !== "undefined") {
+  initQuantizeRiskPanel();
+}

--- a/scripts/convertmodel/quantize_risk_estimate.mjs
+++ b/scripts/convertmodel/quantize_risk_estimate.mjs
@@ -1,0 +1,134 @@
+// Static, calibration-free INT8-quantization risk pre-check for the
+// "Quantize a model" panel (quantize_ui.mjs): runs onnxsim's
+// estimate_model_quantization_drop analysis -- a C++ port of
+// onnxsim.precision_estimator (onnxsim/precision_estimator.h/.cpp), kept in
+// exact sync with the Python module it mirrors -- entirely via the page's own
+// WASM module. No model execution and no calibration data are needed, so
+// this is available the instant a model is picked, before the user has even
+// chosen a quantize method or run anything through onnxruntime-web (unlike
+// quantize_metrics.mjs's post-quantize quality report, which does need
+// onnxruntime-web to actually run the models).
+//
+// Loaded as its own top-level module (a <script type="module"> tag right
+// after quantize_ui.mjs's own in index.html), not imported by it -- so this
+// can import resolveQuantizeInput/getRuntime from quantize_ui.mjs directly
+// with no circular-import concern.
+
+import { getRuntime, resolveQuantizeInput } from "./quantize_ui.mjs";
+
+// Runs onnxsim_estimate_quantization_drop on `bytes` via `runtime` (the
+// page's WASM module) and returns the parsed result. Throws if the model
+// fails to parse or the analysis otherwise fails (see the console for the
+// WASM module's own error message in that case).
+export function estimateQuantizationRisk(runtime, bytes) {
+  const buf = bytes.slice().buffer;
+  const result = runtime.onnxsim_estimate_quantization_drop(buf);
+  if (!result) {
+    throw new Error("quantization risk estimate failed (see console for details)");
+  }
+  return result;
+}
+
+const RISK_LABELS = {
+  safe: { text: "safe", color: "#2a9d3f" },
+  degraded: { text: "degraded", color: "#c98a10" },
+  unsafe: { text: "unsafe", color: "#c0392b" },
+};
+
+function esc(s) {
+  return String(s).replace(/[&<>"']/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c],
+  );
+}
+
+function nodeListHtml(names, max = 6) {
+  if (names.length === 0) return "none";
+  const shown = names.slice(0, max).map(esc).join(", ");
+  return names.length > max
+    ? `${shown}, … (+${names.length - max} more)`
+    : shown;
+}
+
+// Renders estimateQuantizationRisk()'s result as a small HTML summary (a
+// plain string -- the caller assigns it to an element's innerHTML).
+export function renderQuantizationRisk(est) {
+  const label = RISK_LABELS[est.riskLevel] || { text: est.riskLevel, color: "inherit" };
+  const errorText = Number.isFinite(est.estimatedRelativeError)
+    ? `${(est.estimatedRelativeError * 100).toFixed(2)}%`
+    : "n/a (accumulator overflow -- see unsafe nodes below)";
+
+  const rows = [
+    `<tr><td style="padding: 2px 0.8em 2px 0; color: var(--muted);">Estimated relative error</td><td>${errorText}</td></tr>`,
+  ];
+  if (Number.isFinite(est.worstOutlierRatio)) {
+    rows.push(
+      `<tr><td style="padding: 2px 0.8em 2px 0; color: var(--muted);">Worst channel outlier ratio</td><td>${est.worstOutlierRatio.toFixed(1)}×</td></tr>`,
+    );
+  }
+  if (est.unsafeNodes.length > 0) {
+    rows.push(
+      `<tr><td style="padding: 2px 0.8em 2px 0; color: var(--muted); vertical-align: top;">Unsafe (accumulator overflow)</td><td>${nodeListHtml(est.unsafeNodes)}</td></tr>`,
+    );
+  }
+  if (est.outlierRiskNodes.length > 0) {
+    rows.push(
+      `<tr><td style="padding: 2px 0.8em 2px 0; color: var(--muted); vertical-align: top;">Outlier-risk nodes</td><td>${nodeListHtml(est.outlierRiskNodes)}</td></tr>`,
+    );
+  }
+
+  return `
+    <p style="margin: 0.3em 0;"><b>INT8 quantization risk:</b>
+      <span style="color: ${label.color}; font-weight: 600;">${esc(label.text)}</span>
+      (${est.totalNodesAnalyzed} MatMul/Gemm/Conv/Attention node(s) analyzed)</p>
+    <table style="border-collapse: collapse; font-size: 0.85em;">${rows.join("")}</table>
+    <p class="tool-note" style="margin-top: 0.3em;">
+      Static analysis of this model's own weights and shapes -- no execution
+      or calibration data needed. This is a heuristic screening signal (a
+      whole-model rollup of onnxsim's per-node accumulator-overflow and
+      outlier-ratio checks), not a certified bound -- use "report result
+      quality" below after quantizing for a real, data-driven measurement on
+      this model.
+    </p>`;
+}
+
+function initQuantizeRiskPanel() {
+  const btn = document.getElementById("quantize-risk-button");
+  if (!btn) return;
+  const statusEl = document.getElementById("quantize-risk-status");
+  const resultEl = document.getElementById("quantize-risk-result");
+
+  const setStatus = (msg) => {
+    if (statusEl) statusEl.textContent = msg;
+  };
+
+  btn.addEventListener("click", async () => {
+    const sourceEl = document.querySelector('input[name="quantize-source"]:checked');
+    const source = sourceEl ? sourceEl.value : "original";
+    const fileInput = document.getElementById("file-input");
+    btn.disabled = true;
+    if (resultEl) {
+      resultEl.style.display = "none";
+      resultEl.innerHTML = "";
+    }
+    try {
+      setStatus("loading model…");
+      const { bytes } = await resolveQuantizeInput(source, fileInput);
+
+      setStatus("analyzing…");
+      const runtime = await getRuntime();
+      const est = estimateQuantizationRisk(runtime, bytes);
+
+      if (resultEl) {
+        resultEl.innerHTML = renderQuantizationRisk(est);
+        resultEl.style.display = "";
+      }
+      setStatus("done.");
+    } catch (err) {
+      setStatus("risk check error: " + (err && err.message ? err.message : err));
+    } finally {
+      btn.disabled = false;
+    }
+  });
+}
+
+initQuantizeRiskPanel();

--- a/scripts/convertmodel/quantize_ui.mjs
+++ b/scripts/convertmodel/quantize_ui.mjs
@@ -38,7 +38,7 @@ import { computeQuantizationQuality, renderQuantizationQuality } from "./quantiz
 // graph, where fused patterns (e.g. Conv+BN, MatMul+Add -> Gemm) match more
 // of what onnxsim's quantize passes look for. Throws a user-facing message
 // if "converted" is selected but nothing has been converted yet.
-async function resolveQuantizeInput(source, fileInput) {
+export async function resolveQuantizeInput(source, fileInput) {
   if (source === "converted") {
     const converted = window.__onnxsimConverted;
     if (!converted || !converted.bytes) {
@@ -53,7 +53,7 @@ async function resolveQuantizeInput(source, fileInput) {
 }
 
 // Resolve this page's WASM runtime (published by index.html's inline loader).
-function getRuntime() {
+export function getRuntime() {
   return window.__onnxsimRuntimePromise;
 }
 

--- a/scripts/convertmodel/test/quantize_risk_estimate.test.mjs
+++ b/scripts/convertmodel/test/quantize_risk_estimate.test.mjs
@@ -1,0 +1,106 @@
+// Unit tests for the pure helpers behind the "Check quantization risk" button
+// in the "Quantize a model" panel: the WASM-call wrapper's error handling and
+// the HTML summary renderer. No DOM or a real WASM module needed -- the
+// button's click-handler glue (initQuantizeRiskPanel) is browser-only,
+// exactly like quantize_ui.mjs's own init function.
+//
+// Usage:
+//   node test/quantize_risk_estimate.test.mjs
+
+import assert from "node:assert/strict";
+import {
+  estimateQuantizationRisk,
+  renderQuantizationRisk,
+} from "../quantize_risk_estimate.mjs";
+
+let passed = 0;
+function check(name, fn) {
+  fn();
+  passed += 1;
+  console.log("  ok -", name);
+}
+
+const fakeBytes = new Uint8Array([1, 2, 3, 4]);
+
+check("estimateQuantizationRisk passes the model bytes' buffer through and returns the runtime's result", () => {
+  let receivedBuf = null;
+  const fakeResult = { riskLevel: "safe" };
+  const runtime = {
+    onnxsim_estimate_quantization_drop(buf) {
+      receivedBuf = buf;
+      return fakeResult;
+    },
+  };
+  const result = estimateQuantizationRisk(runtime, fakeBytes);
+  assert.equal(result, fakeResult);
+  assert.ok(receivedBuf instanceof ArrayBuffer, "an ArrayBuffer was passed to the WASM call");
+});
+
+check("estimateQuantizationRisk throws when the WASM call returns null (parse failure)", () => {
+  const runtime = { onnxsim_estimate_quantization_drop: () => null };
+  assert.throws(
+    () => estimateQuantizationRisk(runtime, fakeBytes),
+    /quantization risk estimate failed/,
+  );
+});
+
+function baseEstimate(overrides) {
+  return {
+    riskLevel: "safe",
+    totalNodesAnalyzed: 3,
+    unsafeNodes: [],
+    outlierRiskNodes: [],
+    worstOutlierRatio: NaN,
+    estimatedRelativeError: 0.001234,
+    ...overrides,
+  };
+}
+
+check("renders a safe result with the estimated error and no node lists", () => {
+  const html = renderQuantizationRisk(baseEstimate());
+  assert.ok(html.includes("safe"), "risk level shown");
+  assert.ok(html.includes("3 MatMul/Gemm/Conv/Attention"), "node count shown");
+  assert.ok(html.includes("0.12%"), "estimated relative error formatted as a percent");
+  assert.ok(!html.includes("Unsafe (accumulator overflow)"), "no unsafe-node row when unsafeNodes is empty");
+  assert.ok(!html.includes("Outlier-risk nodes"), "no outlier-node row when outlierRiskNodes is empty");
+});
+
+check("renders the worst outlier ratio when finite", () => {
+  const html = renderQuantizationRisk(
+    baseEstimate({ riskLevel: "degraded", worstOutlierRatio: 250.4, outlierRiskNodes: ["Conv_1"] }),
+  );
+  assert.ok(html.includes("degraded"), "risk level shown");
+  assert.ok(html.includes("250.4"), "outlier ratio shown");
+  assert.ok(html.includes("Conv_1"), "outlier node name listed");
+});
+
+check("renders the unsafe-node list and an n/a error when NaN", () => {
+  const html = renderQuantizationRisk(
+    baseEstimate({
+      riskLevel: "unsafe",
+      estimatedRelativeError: NaN,
+      unsafeNodes: ["MatMul_0", "MatMul_1"],
+    }),
+  );
+  assert.ok(html.includes("unsafe"), "risk level shown");
+  assert.ok(html.includes("n/a"), "NaN error rendered as n/a, not literal NaN%");
+  assert.ok(html.includes("MatMul_0") && html.includes("MatMul_1"), "unsafe node names listed");
+});
+
+check("truncates a long node list with a '+N more' suffix", () => {
+  const many = Array.from({ length: 9 }, (_, i) => `Conv_${i}`);
+  const html = renderQuantizationRisk(baseEstimate({ riskLevel: "degraded", outlierRiskNodes: many }));
+  assert.ok(html.includes("Conv_0"), "first node shown");
+  assert.ok(html.includes("+3 more"), "truncation suffix for the remaining 3 (9 - 6 shown)");
+  assert.ok(!html.includes("Conv_8"), "9th node not individually listed");
+});
+
+check("HTML-escapes node names", () => {
+  const html = renderQuantizationRisk(
+    baseEstimate({ riskLevel: "unsafe", unsafeNodes: ['<script>alert(1)</script>'] }),
+  );
+  assert.ok(!html.includes("<script>alert"), "raw node name not injected verbatim");
+  assert.ok(html.includes("&lt;script&gt;"), "node name HTML-escaped");
+});
+
+console.log(`PASS: ${passed} checks`);

--- a/scripts/cross/build_s390x_extension.sh
+++ b/scripts/cross/build_s390x_extension.sh
@@ -219,14 +219,18 @@ cmake --build "${BUILD_DIR}" --target sym_expr_test model_metrics_test \
   sym_value_eval_test sym_shape_infer_test dlpack_dtype_test \
   tensor_pool_dtype_test tensor_pool_test tensor_pool_hash_test \
   gguf_dtype_test ggml_kquant_test tensor_pool_gguf_test -j "${JOBS}"
-# tensor_pool_bridge_test, tensor_pool_gguf_bridge_test, and
-# tensor_pool_archive_test are NOT dependency-free (they exercise the
-# onnx::TensorProto <-> TensorPool bridges), but the onnx/onnx-optimizer
-# static libraries they need are already built as a side effect of the
-# onnxsim_cpp2py_export target above, so they cost only their own link step
-# here rather than a second onnx build.
+# tensor_pool_bridge_test, tensor_pool_gguf_bridge_test,
+# tensor_pool_archive_test, and precision_estimator_test are NOT
+# dependency-free (they exercise onnx::ModelProto / the TensorProto <->
+# TensorPool bridges), but the onnx/onnx-optimizer static libraries they need
+# are already built as a side effect of the onnxsim_cpp2py_export target
+# above, so they cost only their own link step here rather than a second onnx
+# build. precision_estimator_test in particular is exactly the kind of test a
+# big-endian run needs: it exercises the raw_data byte-order handling
+# precision_estimator.cpp's ReadFloatTensorFlat does for real weight tensors.
 cmake --build "${BUILD_DIR}" --target tensor_pool_bridge_test \
-  tensor_pool_gguf_bridge_test tensor_pool_archive_test -j "${JOBS}"
+  tensor_pool_gguf_bridge_test tensor_pool_archive_test \
+  precision_estimator_test -j "${JOBS}"
 
 SO="$(find "${BUILD_DIR}" -name 'onnxsim_cpp2py_export*.so' -print -quit)"
 [[ -n "${SO}" ]] || { echo "no extension module produced"; exit 1; }


### PR DESCRIPTION
## Summary

- Ports `onnxsim/precision_estimator.py`'s static, calibration-free INT8-quantization risk analysis (accumulator-overflow bound, outlier-ratio resolution loss, float32-cast exactness, and analytically-known activation ranges for MatMul/Gemm/Conv/Attention) to C++ (`onnxsim/precision_estimator.h/.cpp`), as a line-for-line translation kept in exact sync with the Python module. It's read-only and needs no model execution or calibration data — it had no existing C++ or JS equivalent, and is a good fit for the WASM build, which has no Python runtime.
- Exposes it via a new `interface.cpp` embind binding (`onnxsim_estimate_quantization_drop`).
- Wires it into the "Quantize a model" panel: a new **"Check quantization risk"** button (`quantize_risk_estimate.mjs`) runs the analysis entirely client-side and shows the risk level, estimated relative error, and any unsafe/outlier-risk nodes — available instantly, before the user even picks a quantize method or runs anything through onnxruntime-web.

## Testing

- `onnxsim/precision_estimator_test.cpp`: 18 new cases mirroring `tests/test_precision_estimator.py`'s own test models and expected values line for line (int32-overflow bound, float32-cast-exactness bound, outlier-ratio detection, Gemm transB layout, Conv reduction depth, Attention scale mismatch/match, fixed-activation-range recognition via Softmax/Clip, whole-model risk-level rollup for safe/degraded/unsafe, root-sum-square error composition). Built against the full `onnxsim` CMake target (`-DONNXSIM_TESTS=ON`) and passing.
- `scripts/convertmodel/test/quantize_risk_estimate.test.mjs`: 7 new cases covering the WASM-call wrapper's error handling and the HTML summary renderer (risk level, formatted error percentage, outlier ratio, node-list truncation, HTML escaping). Also fixed `quantize_risk_estimate.mjs` to defer its `quantize_ui.mjs` import (which transitively touches `document` at module scope via `inference_browser.mjs`) so this module — and its pure helpers — can load under plain Node, matching `versions.mjs`'s existing pattern.
- The full wheel (`pip install --no-build-isolation -e .`) still builds cleanly with the new C++ file added to the main `onnxsim` CMake target.
- The actual WASM build itself isn't locally testable in this environment (no emscripten available) — CI's `static.yml` workflow builds and validates the wasm module end to end, so this PR should surface any embind/compile issues there.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_