### PR TITLE
Re-fusion coverage: dynamo SDPA K-transpose, RoPE, GQA/MQA

### DIFF
--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -27,6 +27,7 @@
 #include "passes/fuse_preceding_mul_into_conv.h"
 #include "passes/fuse_qkv.h"
 #include "passes/fuse_rms_norm.h"
+#include "passes/fuse_rope.h"
 #include "passes/qoperator_quantize_activation.h"
 #include "passes/qoperator_quantize_concat.h"
 #include "passes/qoperator_quantize_conv.h"
@@ -97,6 +98,7 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::FuseMulIntoConv>(registry);
     RegisterOrReplace<p::FusePrecedingMulIntoConv>(registry);
     RegisterOrReplace<p::FuseRMSNorm>(registry);
+    RegisterOrReplace<p::FuseRope>(registry);
     RegisterOrReplace<p::QOperatorQuantizeActivation>(registry);
     RegisterOrReplace<p::QOperatorQuantizeConcat>(registry);
     RegisterOrReplace<p::QOperatorQuantizeConv>(registry);

--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -20,6 +20,7 @@
 #include "passes/fuse_consecutive_mul.h"
 #include "passes/fuse_consecutive_unsqueezes.h"
 #include "passes/fuse_gelu.h"
+#include "passes/fuse_gqa.h"
 #include "passes/fuse_layer_norm.h"
 #include "passes/fuse_matmul_add_bias_into_gemm_batched.h"
 #include "passes/fuse_mul_into_conv.h"
@@ -93,6 +94,7 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::FuseAttention>(registry);
     RegisterOrReplace<p::FuseConsecutiveMul>(registry);
     RegisterOrReplace<p::FuseGelu>(registry);
+    RegisterOrReplace<p::FuseGQA>(registry);
     RegisterOrReplace<p::FuseLayerNorm>(registry);
     RegisterOrReplace<p::FuseMatMulAddBiasIntoGemmBatched>(registry);
     RegisterOrReplace<p::FuseMulIntoConv>(registry);

--- a/onnxsim/custom_optimizer_passes.h
+++ b/onnxsim/custom_optimizer_passes.h
@@ -23,6 +23,7 @@ namespace onnxsim {
 //   - fuse_matmul_add_bias_into_gemm_batched
 //   - eliminate_reshape_around_elementwise
 //   - fuse_rms_norm
+//   - fuse_rope
 //   - fuse_gelu
 //   - fuse_layer_norm
 //   - dynamic_quantize_matmul

--- a/onnxsim/custom_optimizer_passes.h
+++ b/onnxsim/custom_optimizer_passes.h
@@ -25,6 +25,7 @@ namespace onnxsim {
 //   - fuse_rms_norm
 //   - fuse_rope
 //   - fuse_gelu
+//   - fuse_gqa
 //   - fuse_layer_norm
 //   - dynamic_quantize_matmul
 //   - dynamic_quantize_matmul_integer_to_float

--- a/onnxsim/passes/fuse_attention.h
+++ b/onnxsim/passes/fuse_attention.h
@@ -51,17 +51,20 @@
 // to the model's opset imports the first time it fires, if not already
 // present, and the result needs a "com.microsoft"-aware runtime to execute.
 //
-// K's head-split transpose is required to land directly at permutation
-// [0,2,3,1] (X.Transpose([0,2,1,3]) is the more common overall convention,
-// but the exact spelling of a *second*, standalone "swap the last two axes"
-// transpose that some exporters emit for K specifically is not matched --
-// only the single-transpose-straight-to-[0,2,3,1] form is; see
-// MatchHeadSplit). This is why `scaled_dot_product_attention`'s *dynamo*
-// export (unlike its legacy TorchScript export, which does use the direct
-// [0,2,3,1] form) is not yet handled: it head-splits K the same way as Q/V
-// (perm [0,2,1,3]) and spells the "swap the last two axes for K^T" step
-// separately, as `Reshape -> Transpose -> Reshape` rather than folding it
-// into one 4-D permutation -- left as a follow-up.
+// K's head-split transpose usually lands directly at permutation [0,2,3,1]
+// (X.Transpose([0,2,1,3]) is the more common overall convention, but K
+// additionally needs its last two axes swapped for the Q@K^T dot product to
+// be well-formed, and most exporters -- including SDPA's legacy TorchScript
+// export -- fold that swap directly into K's own head-split Transpose rather
+// than emitting a separate one; see MatchAttentionHeadSplit). SDPA's *dynamo*
+// export instead head-splits K the same way as Q/V (perm [0,2,1,3]) and
+// spells the "swap the last two axes for K^T" step separately, as a
+// standalone `Reshape -> Transpose([0,2,1]) -> Reshape` 3-D round trip
+// (collapse batch/head into one leading dim, swap the remaining two, restore
+// the 4-D shape) rather than folding it into one 4-D permutation --
+// MatchKTransposeSwapChain recognizes this alternate spelling, verifying it
+// is shape-equivalent to the direct form via shape inference rather than by
+// decoding the two Reshapes' (possibly dynamic) target-shape computations.
 // Only self-attention (Q, K, V all reading the *same* source activation) with
 // no attention mask, no past/present KV cache, and a Softmax over the last
 // axis (`axis=-1` or the input's last dimension index -- both are safe here
@@ -340,6 +343,102 @@ inline bool MatchAttentionHeadSplit(Value* transposed, int64_t& num_heads,
   return true;
 }
 
+// Matches the alternate spelling `scaled_dot_product_attention`'s *dynamo*
+// exporter uses for K's "swap the last two (seq, head_size) axes" step:
+// rather than a single 4-D Transpose straight to perm [0,2,3,1] (the direct
+// form MatchAttentionHeadSplit's own want_perm looks for), it head-splits K
+// exactly like Q/V (Transpose perm [0,2,1,3]) and then swaps the last two
+// axes as a *separate* step that round-trips through 3-D:
+//   Reshape(Transpose(Reshape(headsplit_out, [B*H,S,D]), [0,2,1]), [B,H,D,S])
+// which is mathematically identical to `Transpose(headsplit_out, [0,1,3,2])`
+// -- and, composed with headsplit_out's own [0,2,1,3] transpose from
+// proj_out, to `Transpose(proj_out, [0,2,3,1])` directly, i.e. exactly what
+// the direct form already looks for. Rather than re-deriving that arithmetic
+// from the two Reshapes' target-shape inputs (which may themselves be
+// dynamic, Shape-derived values rather than literal constants), this
+// confirms the same identity a cheaper way: shape inference -- run earlier
+// in the same fixed-point loop this pass itself runs inside -- has already
+// resolved every intermediate value's static sizes whenever they're static
+// at all, so directly comparing them is sufficient regardless of how the two
+// Reshapes computed their target shapes internally. Two independent shape
+// checks are both required, not just the final one: a row-major Reshape's
+// semantics are only pinned down uniquely by which *trailing* dimensions it
+// leaves untouched, so this checks that the first Reshape's output keeps
+// `headsplit_out`'s own last two dims (S, D) unchanged in its own last two
+// positions (proving the merged leading dimension can only be B*H, in that
+// order -- the standard row-major flatten of exactly those two axes and no
+// other grouping, e.g. not S folded in instead) *and* that the final
+// Reshape's output exactly matches `headsplit_out`'s shape with its last two
+// dims exchanged (proving the corresponding unmerge/split recovers B and H
+// individually, in the same order, rather than some other factorization of
+// the same product). Checking only the final shape is not enough on its
+// own: a chain that merges a *different* pair of leading dims (or merges in
+// the opposite order) can still land on the same final 4-D shape by
+// coincidence while actually computing a different permutation of the
+// underlying data. Declines (rather than guessing) whenever any shape isn't
+// statically known.
+inline bool MatchKTransposeSwapChain(Value* k_side, int64_t& num_heads,
+                                     int64_t& head_size, Value*& proj_out,
+                                     std::vector<Node*>& chain) {
+  if (!CheckKind(k_side, kReshape) || k_side->uses().size() != 1) {
+    return false;
+  }
+  Node* outer_rs = k_side->node();
+  if (outer_rs->inputs().size() != 2) {
+    return false;
+  }
+  Value* swapped = outer_rs->input(0);
+  if (!CheckKind(swapped, kTranspose) || swapped->uses().size() != 1) {
+    return false;
+  }
+  Node* swap_tr = swapped->node();
+  std::vector<int64_t> swap_perm;
+  if (!GetValueFromAttr(swap_tr, kperm, swap_perm) ||
+      swap_perm != std::vector<int64_t>{0, 2, 1}) {
+    return false;
+  }
+  Value* flattened = swap_tr->input(0);
+  if (!CheckKind(flattened, kReshape) || flattened->uses().size() != 1) {
+    return false;
+  }
+  Node* inner_rs = flattened->node();
+  if (inner_rs->inputs().size() != 2) {
+    return false;
+  }
+  Value* headsplit_out = inner_rs->input(0);
+  std::vector<Node*> headsplit_chain;
+  if (!MatchAttentionHeadSplit(headsplit_out, num_heads, head_size, proj_out,
+                               {0, 2, 1, 3}, headsplit_chain)) {
+    return false;
+  }
+  if (!headsplit_out->has_sizes() || !flattened->has_sizes() ||
+      !k_side->has_sizes() || headsplit_out->sizes().size() != 4 ||
+      flattened->sizes().size() != 3 || k_side->sizes().size() != 4) {
+    return false;
+  }
+  const auto& h_sizes = headsplit_out->sizes();
+  const auto& f_sizes = flattened->sizes();
+  const auto& k_sizes = k_side->sizes();
+  auto same_dim = [](const Dimension& a, const Dimension& b) {
+    return a.is_int == b.is_int &&
+           (a.is_int ? a.dim == b.dim : a.param == b.param);
+  };
+  // First Reshape must merge exactly headsplit_out's leading two dims,
+  // leaving (S, D) as-is in the trailing two positions.
+  if (!same_dim(h_sizes[2], f_sizes[1]) || !same_dim(h_sizes[3], f_sizes[2])) {
+    return false;
+  }
+  if (!same_dim(h_sizes[0], k_sizes[0]) || !same_dim(h_sizes[1], k_sizes[1]) ||
+      !same_dim(h_sizes[2], k_sizes[3]) || !same_dim(h_sizes[3], k_sizes[2])) {
+    return false;
+  }
+  chain.push_back(outer_rs);
+  chain.push_back(swap_tr);
+  chain.push_back(inner_rs);
+  for (Node* nd : headsplit_chain) chain.push_back(nd);
+  return true;
+}
+
 // `Attention`'s schema requires a rank-3 X input ([batch_size,
 // sequence_length, input_hidden_size]). Q/K/V's shared source is usually
 // exactly the model's own rank-3 activation, but when an earlier fixed-point
@@ -488,8 +587,11 @@ inline bool MatchAttention(Node* n, AttentionMatch& m) {
   std::vector<Node*> k_head_chain;
   Value* k_proj_out = nullptr;
   int64_t k_heads = 0, k_head_size = 0;
-  if (!MatchAttentionHeadSplit(k_side, k_heads, k_head_size, k_proj_out,
-                               {0, 2, 3, 1}, k_head_chain) ||
+  const bool k_direct_split = MatchAttentionHeadSplit(
+      k_side, k_heads, k_head_size, k_proj_out, {0, 2, 3, 1}, k_head_chain);
+  if ((!k_direct_split &&
+       !MatchKTransposeSwapChain(k_side, k_heads, k_head_size, k_proj_out,
+                                 k_head_chain)) ||
       !MatchAttentionProjection(k_proj_out, m.k)) {
     return false;
   }

--- a/onnxsim/passes/fuse_gqa.h
+++ b/onnxsim/passes/fuse_gqa.h
@@ -1,0 +1,524 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+#pragma once
+
+// Fuses a "hand-written" causal grouped-query/multi-query attention block
+// (fewer K/V heads than Q heads, each K/V head shared by a contiguous group
+// of Q heads via the standard HuggingFace `repeat_kv` -- Unsqueeze->Expand->
+// Reshape -- broadcast, plus an additive causal mask) into ONNX Runtime's
+// "com.microsoft" `GroupQueryAttention` contrib op.
+//
+// Before (Q/K/V bias optional, matched via MatchAttentionProjection; K/V's
+// repeat_kv wrapping matched via MatchRepeatKV; see fuse_attention.h for the
+// non-GQA sibling this reuses several matchers from):
+//   Q = Reshape(Linear(X, Wq[, Bq]), [B,S,NH,D]).Transpose([0,2,1,3])
+//   K0 = Reshape(Linear(X, Wk[, Bk]), [B,S,NKV,D]).Transpose([0,2,1,3])
+//   V0 = Reshape(Linear(X, Wv[, Bv]), [B,S,NKV,D]).Transpose([0,2,1,3])
+//   K = Reshape(Expand(Unsqueeze(K0, 2), [B,NKV,n_rep,S,D]), [B,NH,S,D])
+//   V = Reshape(Expand(Unsqueeze(V0, 2), [B,NKV,n_rep,S,D]), [B,NH,S,D])
+//   scores = (Q @ K.Transpose([0,1,3,2])) / sqrt(head_size)   -- or the
+//            pre-scaled MatchScaledQKMatMul shape; see fuse_attention.h
+//   masked = scores + causal_mask     -- causal_mask a *constant* tensor
+//            (see VerifyCausalMaskConstant for why this must be provable,
+//            not merely assumed, and what that costs in practical coverage)
+//   attn   = Softmax(masked, axis=-1)
+//   ctx    = (attn @ V).Transpose([0,2,1,3]).Reshape([B,S,NH*D])
+//   Y      = Linear(ctx, Wout[, Bout])
+// After:
+//   Y = GroupQueryAttention(Linear(X,Wq[,Bq]), Linear(X,Wk[,Bk]),
+//                           Linear(X,Wv[,Bv]), <skipped>, <skipped>,
+//                           seqlens_k, total_sequence_length,
+//                           num_heads=NH, kv_num_heads=NKV,
+//                           scale=1/sqrt(head_size))
+//   Y = Linear(Y, Wout[, Bout])            -- unchanged, not part of the fuse
+//
+// Unlike `Attention` (fuse_attention.h's own target), `GroupQueryAttention`'s
+// `query`/`key`/`value` inputs are each already-projected, rank-3
+// `[batch, seq, hidden]` tensors -- the op does its own internal head-split
+// and repeat-broadcast -- so this fusion feeds it the Q/K/V *projection*
+// outputs directly (no weight merging needed, and Q/K/V's own projection
+// chain -- MatMul[+Add] -- is left completely alone) and tears down
+// everything from the head-split onward instead.
+//
+// **`GroupQueryAttention` always applies causal masking internally** (its
+// own schema doc: "implements causal grouped-query attention"; confirmed
+// empirically -- its output matches a manual causal-masked reference to
+// float32 precision and diverges by ~3 from a manual *bidirectional*
+// reference on the same random inputs). There is no attribute to disable
+// this. Consequently:
+//   - A bidirectional (unmasked, or non-causal-masked) GQA/MQA block cannot
+//     be fused by this pass at all -- no ONNX Runtime contrib op supports
+//     that combination (`Attention`/`MultiHeadAttention` both require equal
+//     Q/K/V head counts; verified `MultiHeadAttention` rejects mismatched
+//     hidden sizes at runtime). This pass simply never matches such a block.
+//   - Because a real GQA export's causal mask is essentially always a
+//     *runtime* input (built from `position_ids`/padding at inference time,
+//     not a compile-time constant), and because wiring a mask through as
+//     `attention_bias` on top of `GroupQueryAttention`'s own unconditional
+//     causal masking would be a genuine *decline*-vs-*guess* judgment call
+//     this pass declines rather than makes (an insufficiently-restrictive
+//     runtime mask could be silently overridden by the stricter built-in
+//     causal masking), this pass only fires when the additive mask is a
+//     provable **constant** matching the causal pattern exactly (see
+//     VerifyCausalMaskConstant). This is a real, deliberate scope
+//     narrowing versus most real-world exports -- left as a documented
+//     follow-up (recognizing a standard causal-mask-*construction*
+//     subgraph, rather than requiring the mask already be folded to a
+//     constant, would widen this considerably).
+//   - `seqlens_k`/`total_sequence_length` (mandatory KV-cache bookkeeping
+//     inputs `GroupQueryAttention`'s schema requires even for a plain,
+//     no-cache forward pass) are synthesized here as constants (`S-1` per
+//     batch row, and `S`), which requires `batch_size`/`sequence_length` to
+//     be statically known -- declines otherwise.
+//
+// Only self-attention (Q, K, V all reading the *same* source activation),
+// equal Q/K/V head_size, and Q's own head count an exact positive multiple
+// of K/V's (the `repeat_kv` structural precondition) is handled.
+
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+#include "passes/endian_read.h"
+#include "passes/fuse_attention.h"
+#include "passes/quantize_conv_common.h"
+#include "passes/quantize_matmul_common.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+// Matches `wrapped` as the HuggingFace `repeat_kv` broadcast of `raw`:
+//   wrapped = Reshape(Expand(Unsqueeze(raw, axes=[2]), shape), merge_shape)
+// `raw` (shape [B, NKV, S, D]) is duplicated `n_rep` times along a freshly
+// inserted axis and flattened back into the heads axis, producing `wrapped`
+// (shape [B, NKV*n_rep, S, D]) -- exactly HuggingFace's own reference
+// `repeat_kv(x, n_rep) = x[:,:,None].expand(B,NKV,n_rep,S,D).reshape(B,
+// NKV*n_rep,S,D)`, which is what `GroupQueryAttention`'s own internal
+// broadcast semantics assume (each of the NKV raw heads maps to a
+// *contiguous* run of `n_rep` heads in `wrapped`, not an interleaved/tiled
+// one). `n_rep` is derived from shape metadata (wrapped's heads dim divided
+// by raw's), not decoded from the Expand/Reshape's own (possibly dynamic)
+// target-shape inputs -- see MatchKTransposeSwapChain in fuse_attention.h
+// for why comparing shapes this way is sufficient and this file's own
+// top comment for why static shapes are required here regardless.
+inline bool MatchRepeatKV(Value* wrapped, Value*& raw, int64_t& n_rep,
+                          std::vector<Node*>& chain) {
+  if (!CheckKind(wrapped, kReshape) || wrapped->uses().size() != 1) {
+    return false;
+  }
+  Node* merge_rs = wrapped->node();
+  if (merge_rs->inputs().size() != 2) {
+    return false;
+  }
+  Value* expanded = merge_rs->input(0);
+  if (!CheckKind(expanded, "Expand") || expanded->uses().size() != 1) {
+    return false;
+  }
+  Node* expand_n = expanded->node();
+  if (expand_n->inputs().size() != 2) {
+    return false;
+  }
+  Value* unsq_out = expand_n->input(0);
+  if (!CheckKind(unsq_out, kUnsqueeze) || unsq_out->uses().size() != 1) {
+    return false;
+  }
+  Node* unsq_n = unsq_out->node();
+  if (unsq_n->inputs().size() < 2) {
+    return false;
+  }
+  std::vector<int64_t> axes;
+  if (!GetValueFromInput(unsq_n->input(1), axes) ||
+      axes != std::vector<int64_t>{2}) {
+    return false;
+  }
+  raw = unsq_n->input(0);
+  if (!raw->has_sizes() || !wrapped->has_sizes() || raw->sizes().size() != 4 ||
+      wrapped->sizes().size() != 4) {
+    return false;
+  }
+  const auto& r = raw->sizes();
+  const auto& w = wrapped->sizes();
+  auto same_dim = [](const Dimension& a, const Dimension& b) {
+    return a.is_int == b.is_int &&
+           (a.is_int ? a.dim == b.dim : a.param == b.param);
+  };
+  if (!same_dim(r[0], w[0]) || !same_dim(r[2], w[2]) || !same_dim(r[3], w[3])) {
+    return false;
+  }
+  if (!r[1].is_int || !w[1].is_int || r[1].dim <= 0 ||
+      w[1].dim % r[1].dim != 0) {
+    return false;
+  }
+  n_rep = w[1].dim / r[1].dim;
+  if (n_rep < 1) {
+    return false;
+  }
+  chain.push_back(merge_rs);
+  chain.push_back(expand_n);
+  chain.push_back(unsq_n);
+  return true;
+}
+
+// Verifies `mask` is a *constant* float32 tensor of shape [1, 1, seq_len,
+// seq_len] matching the standard additive causal pattern exactly: 0.0 on
+// and below the diagonal (position j can attend to position i for j <= i),
+// a very large negative value strictly above it. `GroupQueryAttention`
+// already applies exactly this masking internally and unconditionally (see
+// this file's top comment), so a real causal mask is redundant to pass
+// through explicitly -- but *some* mask must be present and provably
+// exactly this pattern for the fusion to be sound, since a graph with no
+// mask at all (bidirectional) or a differently-shaped one must not be
+// silently reinterpreted as causal.
+inline bool VerifyCausalMaskConstant(Value* mask, int64_t seq_len) {
+  const Tensor* t = FetchConstantTensor(mask);
+  if (t == nullptr || t->elem_type() != TensorProto_DataType_FLOAT) {
+    return false;
+  }
+  const auto& sizes = t->sizes();
+  if (sizes.size() != 4 || sizes[0] != 1 || sizes[1] != 1 ||
+      sizes[2] != seq_len || sizes[3] != seq_len) {
+    return false;
+  }
+  const std::vector<float> data = ReadFloatTensorFlat(*t);
+  if (static_cast<int64_t>(data.size()) != seq_len * seq_len) {
+    return false;
+  }
+  constexpr float kMaskedThreshold = -1e30f;
+  for (int64_t i = 0; i < seq_len; ++i) {
+    for (int64_t j = 0; j < seq_len; ++j) {
+      const float v = data[static_cast<size_t>(i * seq_len + j)];
+      if (j <= i) {
+        if (v != 0.0f) {
+          return false;
+        }
+      } else if (v > kMaskedThreshold) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+struct GQAMatch {
+  AttentionProjectionInfo q, k, v;
+  // Q/K/V's own projection *output* Values (rank 3, [B,S,hidden]) --
+  // GroupQueryAttention's query/key/value inputs, wired in directly.
+  Value* q_proj_out = nullptr;
+  Value* k_proj_out = nullptr;
+  Value* v_proj_out = nullptr;
+  int64_t num_heads = 0;     // Q's head count.
+  int64_t kv_num_heads = 0;  // K/V's (shared) head count; num_heads must be
+                             // an exact positive multiple of this.
+  double scale = 0.0;
+  int64_t batch_size = 0;
+  int64_t seq_len = 0;
+  // Every node strictly upstream of `n` down to, but not including, the
+  // QKV *projection outputs* (unlike fuse_attention.h's own dead_chain,
+  // which also consumes the projections themselves into a merged weight,
+  // GroupQueryAttention reads each projection's output directly, so
+  // MatchAttentionProjection's own `chain` for q/k/v is deliberately never
+  // added here), ordered innermost (closest to `n`) first.
+  std::vector<Node*> dead_chain;
+};
+
+inline bool MatchGQA(Node* n, GQAMatch& m) {
+  if (!CheckKind(n, kReshape) || n->inputs().size() != 2 ||
+      n->outputs().size() != 1) {
+    return false;
+  }
+  Value* transposed_back = n->input(0);
+  if (!CheckKind(transposed_back, kTranspose) ||
+      transposed_back->uses().size() != 1) {
+    return false;
+  }
+  Node* tr_back = transposed_back->node();
+  std::vector<int64_t> perm_back;
+  if (!GetValueFromAttr(tr_back, kperm, perm_back) ||
+      perm_back != std::vector<int64_t>{0, 2, 1, 3}) {
+    return false;
+  }
+  Value* v_matmul_out = tr_back->input(0);
+  if (!CheckKind(v_matmul_out, kMatMul) || v_matmul_out->uses().size() != 1) {
+    return false;
+  }
+  Node* v_mm = v_matmul_out->node();
+  if (v_mm->inputs().size() != 2) {
+    return false;
+  }
+  Value* softmax_out = nullptr;
+  Value* v_t = nullptr;
+  for (int i = 0; i < 2; ++i) {
+    if (CheckKind(v_mm->input(i), kSoftmax)) {
+      softmax_out = v_mm->input(i);
+      v_t = v_mm->input(1 - i);
+    }
+  }
+  if (softmax_out == nullptr || softmax_out->uses().size() != 1) {
+    return false;
+  }
+  Node* softmax = softmax_out->node();
+  if (softmax->inputs().size() != 1) {
+    return false;
+  }
+  const int64_t sm_axis =
+      GetValueFromAttrWithDefault(softmax, kaxis, int64_t(-1));
+  if (sm_axis != -1 && sm_axis != 3) {
+    return false;
+  }
+
+  // V-side: unwrap repeat_kv first (required -- if this doesn't match,
+  // there's no GQA/MQA broadcast here and fuse_attention.h's plain
+  // Attention fusion, if applicable, is the right pass instead).
+  std::vector<Node*> v_repeat_chain;
+  Value* v_raw = nullptr;
+  int64_t v_n_rep = 0;
+  if (!MatchRepeatKV(v_t, v_raw, v_n_rep, v_repeat_chain)) {
+    return false;
+  }
+  std::vector<Node*> v_head_chain;
+  int64_t v_heads = 0, v_head_size = 0;
+  if (!MatchAttentionHeadSplit(v_raw, v_heads, v_head_size, m.v_proj_out,
+                               {0, 2, 1, 3}, v_head_chain) ||
+      !MatchAttentionProjection(m.v_proj_out, m.v)) {
+    return false;
+  }
+
+  // scores = softmax's input, but wrapped in an additive causal mask:
+  // masked = Add(unmasked_scores, causal_mask).
+  Value* masked = softmax->input(0);
+  if (masked->uses().size() != 1 || !CheckKind(masked, kAdd)) {
+    return false;
+  }
+  Node* mask_add = masked->node();
+  if (mask_add->inputs().size() != 2) {
+    return false;
+  }
+  Value* q_side = nullptr;
+  Value* k_side = nullptr;
+  std::vector<Node*> scale_chain;
+  Value* causal_mask = nullptr;
+  bool scores_matched = false;
+  for (int i = 0; i < 2; ++i) {
+    Value* scores_candidate = mask_add->input(i);
+    Value* mask_candidate = mask_add->input(1 - i);
+    if (scores_candidate->uses().size() != 1) {
+      continue;
+    }
+    std::vector<Node*> candidate_scale_chain;
+    Value* q_candidate = nullptr;
+    Value* k_candidate = nullptr;
+    double scale_candidate = 0.0;
+    if (!MatchScaledQKMatMul(scores_candidate, q_candidate, k_candidate,
+                             scale_candidate, candidate_scale_chain)) {
+      continue;
+    }
+    q_side = q_candidate;
+    k_side = k_candidate;
+    m.scale = scale_candidate;
+    scale_chain = candidate_scale_chain;
+    causal_mask = mask_candidate;
+    scores_matched = true;
+    break;
+  }
+  if (!scores_matched) {
+    return false;
+  }
+
+  std::vector<Node*> q_head_chain;
+  int64_t q_heads = 0, q_head_size = 0;
+  if (!MatchAttentionHeadSplit(q_side, q_heads, q_head_size, m.q_proj_out,
+                               {0, 2, 1, 3}, q_head_chain) ||
+      !MatchAttentionProjection(m.q_proj_out, m.q)) {
+    return false;
+  }
+
+  // K-side: the QK^T matmul needs K^T, i.e. K's last two axes swapped --
+  // here that's a single direct Transpose([0,1,3,2]) over the *already
+  // repeat_kv-wrapped* K (unlike fuse_attention.h's non-GQA K matching,
+  // where the swap is fused directly into K's own head-split transpose).
+  if (!CheckKind(k_side, kTranspose) || k_side->uses().size() != 1) {
+    return false;
+  }
+  Node* k_swap = k_side->node();
+  std::vector<int64_t> k_swap_perm;
+  if (!GetValueFromAttr(k_swap, kperm, k_swap_perm) ||
+      k_swap_perm != std::vector<int64_t>{0, 1, 3, 2}) {
+    return false;
+  }
+  Value* k_repeated = k_swap->input(0);
+  std::vector<Node*> k_repeat_chain;
+  Value* k_raw = nullptr;
+  int64_t k_n_rep = 0;
+  if (!MatchRepeatKV(k_repeated, k_raw, k_n_rep, k_repeat_chain)) {
+    return false;
+  }
+  std::vector<Node*> k_head_chain;
+  int64_t k_heads = 0, k_head_size = 0;
+  if (!MatchAttentionHeadSplit(k_raw, k_heads, k_head_size, m.k_proj_out,
+                               {0, 2, 1, 3}, k_head_chain) ||
+      !MatchAttentionProjection(m.k_proj_out, m.k)) {
+    return false;
+  }
+
+  if (k_heads != v_heads || k_n_rep != v_n_rep || q_head_size != k_head_size ||
+      q_head_size != v_head_size) {
+    return false;
+  }
+  if (q_heads != k_heads * k_n_rep) {
+    return false;  // Should be implied by MatchRepeatKV's own arithmetic,
+                   // but verify explicitly rather than trust it silently.
+  }
+  m.num_heads = q_heads;
+  m.kv_num_heads = k_heads;
+
+  if (m.q.input != m.k.input || m.q.input != m.v.input) {
+    return false;  // Self-attention only.
+  }
+  // Unlike fuse_attention.h's own Attention fusion, GroupQueryAttention
+  // reads q_proj_out/k_proj_out/v_proj_out directly (never `m.q.input`
+  // itself), so no rank-3-recovery on `m.q.input` is needed here -- only
+  // q_proj_out's own (always rank-3, by MatchAttentionProjection's own
+  // contract) shape matters, for reading batch_size/sequence_length.
+  if (!m.q_proj_out->has_sizes() || m.q_proj_out->sizes().size() != 3) {
+    return false;
+  }
+  const auto& qp_sizes = m.q_proj_out->sizes();
+  if (!qp_sizes[0].is_int || !qp_sizes[1].is_int || qp_sizes[0].dim <= 0 ||
+      qp_sizes[1].dim <= 0) {
+    return false;  // batch_size/sequence_length must be statically known --
+                   // seqlens_k/total_sequence_length are synthesized as
+                   // compile-time constants below.
+  }
+  m.batch_size = qp_sizes[0].dim;
+  m.seq_len = qp_sizes[1].dim;
+
+  if (!VerifyCausalMaskConstant(causal_mask, m.seq_len)) {
+    return false;
+  }
+
+  const bool any_bias =
+      m.q.bias != nullptr || m.k.bias != nullptr || m.v.bias != nullptr;
+  const bool all_bias =
+      m.q.bias != nullptr && m.k.bias != nullptr && m.v.bias != nullptr;
+  if (any_bias && !all_bias) {
+    return false;  // Not required by the op, but keeps this consistent with
+                   // fuse_attention.h's own Attention fusion; an all/none
+                   // mismatch is unusual enough to not be worth a further
+                   // special case here.
+  }
+
+  m.dead_chain.push_back(tr_back);
+  m.dead_chain.push_back(v_mm);
+  m.dead_chain.push_back(softmax);
+  m.dead_chain.push_back(mask_add);
+  for (Node* nd : v_repeat_chain) m.dead_chain.push_back(nd);
+  for (Node* nd : v_head_chain) m.dead_chain.push_back(nd);
+  for (Node* nd : scale_chain) m.dead_chain.push_back(nd);
+  for (Node* nd : q_head_chain) m.dead_chain.push_back(nd);
+  m.dead_chain.push_back(k_swap);
+  for (Node* nd : k_repeat_chain) m.dead_chain.push_back(nd);
+  for (Node* nd : k_head_chain) m.dead_chain.push_back(nd);
+  return true;
+}
+
+struct FuseGQA final : public PredicateBasedPass {
+  explicit FuseGQA()
+      : PredicateBasedPass(PassType::Fuse, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+  std::string getPassName() const override { return "fuse_gqa"; }
+
+  bool patternMatchPredicate(Node* n) override {
+    GQAMatch m;
+    return MatchGQA(n, m);
+  }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+    GQAMatch m;
+    if (!MatchGQA(n, m)) {
+      return false;
+    }
+    ONNX_ASSERT(!m.dead_chain.empty());
+
+    Tensor seqlens_k_t;
+    seqlens_k_t.elem_type() = TensorProto_DataType_INT32;
+    seqlens_k_t.sizes() = {m.batch_size};
+    seqlens_k_t.int32s().assign(static_cast<size_t>(m.batch_size),
+                                static_cast<int32_t>(m.seq_len - 1));
+    Value* seqlens_k_v = graph.addInitializerAndCreateValue(seqlens_k_t);
+
+    Tensor total_seq_t;
+    total_seq_t.elem_type() = TensorProto_DataType_INT32;
+    total_seq_t.sizes() = {};
+    total_seq_t.int32s().assign(1, static_cast<int32_t>(m.seq_len));
+    Value* total_seq_v = graph.addInitializerAndCreateValue(total_seq_t);
+
+    // past_key/past_value are skipped (this fusion never has a KV cache to
+    // carry over -- see this file's top comment): ONNX represents a skipped
+    // *middle* optional input as an edge from a dedicated kUndefined-kind
+    // node, which the encoder serializes back to an empty input name
+    // regardless of where in the node list it sits.
+    Node* undef = graph.create(kUndefined, 1);
+    undef->insertBefore(n);
+    undef->output()->setUniqueName("");
+
+    Node* gqa = graph.create(Symbol("GroupQueryAttention"), 1);
+    gqa->addInput(m.q_proj_out);
+    gqa->addInput(m.k_proj_out);
+    gqa->addInput(m.v_proj_out);
+    gqa->addInput(undef->output());  // past_key (unused)
+    gqa->addInput(undef->output());  // past_value (unused)
+    gqa->addInput(seqlens_k_v);
+    gqa->addInput(total_seq_v);
+    gqa->insertBefore(n);
+    gqa->i_(Symbol("num_heads"), m.num_heads);
+    gqa->i_(Symbol("kv_num_heads"), m.kv_num_heads);
+    gqa->f_(Symbol("scale"), static_cast<float>(m.scale));
+    gqa->setDomain("com.microsoft");
+
+    bool has_ms_domain = false;
+    for (const OpSetID& opset : graph.opset_versions_mutable()) {
+      if (opset.domain() == "com.microsoft") {
+        has_ms_domain = true;
+        break;
+      }
+    }
+    if (!has_ms_domain) {
+      graph.opset_versions_mutable().emplace_back("com.microsoft", 1);
+    }
+
+    Value* n_shape = n->input(1);
+    Node* reshape_out = graph.create(Symbol("Reshape"), 1);
+    reshape_out->addInput(gqa->output());
+    reshape_out->addInput(n_shape);
+    reshape_out->insertBefore(n);
+    reshape_out->output()->copyMetadata(n->output());
+
+    if (!tryReplacingAllUsesWith(n, reshape_out)) {
+      return false;
+    }
+
+    n->removeInput(0);
+    for (Node* dead : m.dead_chain) {
+      dead->destroy();
+    }
+
+    destroy_current = NodeDestroyType::DestroyOne;
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/fuse_gqa.h
+++ b/onnxsim/passes/fuse_gqa.h
@@ -473,7 +473,13 @@ struct FuseGQA final : public PredicateBasedPass {
     undef->insertBefore(n);
     undef->output()->setUniqueName("");
 
-    Node* gqa = graph.create(Symbol("GroupQueryAttention"), 1);
+    // GroupQueryAttention's schema requires at least 3 outputs (output,
+    // present_key, present_value) even though only "output" is used here --
+    // creating it with just 1 fails ONNX Runtime's own schema validation
+    // ("has output size 1 not in range [min=3, max=4]"), caught by CI on a
+    // real run rather than by the checker (which didn't flag it). The two
+    // extra outputs are simply left unused; nothing references them.
+    Node* gqa = graph.create(Symbol("GroupQueryAttention"), 3);
     gqa->addInput(m.q_proj_out);
     gqa->addInput(m.k_proj_out);
     gqa->addInput(m.v_proj_out);
@@ -500,7 +506,7 @@ struct FuseGQA final : public PredicateBasedPass {
 
     Value* n_shape = n->input(1);
     Node* reshape_out = graph.create(Symbol("Reshape"), 1);
-    reshape_out->addInput(gqa->output());
+    reshape_out->addInput(gqa->outputs()[0]);
     reshape_out->addInput(n_shape);
     reshape_out->insertBefore(n);
     reshape_out->output()->copyMetadata(n->output());

--- a/onnxsim/passes/fuse_rope.h
+++ b/onnxsim/passes/fuse_rope.h
@@ -1,0 +1,429 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+#pragma once
+
+// Fuses the "rotate_half" rotary position embedding (RoPE) application --
+// the pattern HuggingFace-style LLaMA/Mistral/Qwen-family exports apply to Q
+// and K separately, right after their head-split and before the QK^T
+// matmul (see test_mnn_llm_export.py's `_Attention` for a real traced
+// example) -- into a single standard ONNX `RotaryEmbedding` node (opset 23,
+// onnx/defs/nn/defs.cc; see fuse_rms_norm.h for the sibling native-op fusion
+// this mirrors).
+//
+// Before, for each of Q and K independently (`X` stands for whichever; both
+// sides share the same `cos`/`sin`, computed once):
+//   def rotate_half(x):
+//       x1, x2 = x[..., :D/2], x[..., D/2:]
+//       return concat([-x2, x1], axis=-1)
+//   emb = concat([angle, angle], axis=-1)   -- `angle` duplicated, once
+//   cos, sin = emb.cos()[:, None], emb.sin()[:, None]   -- broadcast over heads
+//   X_embed = X * cos + rotate_half(X) * sin
+// After, for each of Q and K:
+//   cos_half = Cos(angle)          -- half-width, computed once per side here
+//   sin_half = Sin(angle)          --   (a later eliminate_common_subexpression
+//                                        pass merges Q's and K's copies)
+//   X_embed = RotaryEmbedding(X, cos_half, sin_half)
+//
+// `RotaryEmbedding`'s own reference algorithm (see its schema doc) computes
+// exactly `x1*cos_half - x2*sin_half` / `x2*cos_half + x1*sin_half`
+// concatenated back together, which is only equal to the hand-rolled
+// `X*cos_full + rotate_half(X)*sin_full` above when `cos_full`/`sin_full`
+// are genuinely `concat([cos_half, cos_half])`/`concat([sin_half,
+// sin_half])` -- i.e. when `cos = Cos(concat([angle, angle]))` and `sin =
+// Sin(concat([angle, angle]))` share the *same* `angle` Value on both sides
+// of the duplicating Concat (checked by reference-identity, not just
+// structural shape), which is exactly what a real trace of the HuggingFace
+// formula above produces (`emb = torch.cat((angle, angle), dim=-1)`). If
+// this can't be confirmed, the match declines rather than guessing --
+// wiring an ordinary (non-duplicated) `cos`/`sin` into `RotaryEmbedding`
+// would silently compute something else.
+//
+// `cos`/`sin`'s own `[:, None]` broadcast-over-heads unsqueeze (axis 1, to
+// broadcast against X's rank-4 `[B, num_heads, S, D]` shape) is matched and
+// discarded rather than carried into the fused node: `RotaryEmbedding`'s own
+// reference algorithm already broadcasts a rank-3 `[B, S, D/2]` cos/sin
+// cache over X's head axis internally when X is rank 4, which is exactly
+// this same broadcast, so the pre-existing Unsqueeze would just be
+// redundant on the new cos_half/sin_half (rank 3, matching `angle`'s own
+// shape) -- unsqueezing to any *other* axis is a different broadcast this
+// pass does not attempt to reproduce and declines on.
+//
+// Q's and K's applications are matched and fused independently (each
+// anchored on its own outer Add), but since they read the same shared
+// cos/sin/Concat/angle chain, whichever of the two is transformed second in
+// a given pass sweep also tears down that now-fully-unused shared chain --
+// see MaybeAppendSharedChain's own comment for why leaving it for a later
+// dead-code-elimination pass to notice is not reliable within
+// onnx-optimizer's fixed-point loop (mirrors fuse_rms_norm.h's own note on
+// the same concern for its unrelated chain).
+//
+// Only fires at opset >= 23 (RotaryEmbedding's introducing version); pass
+// `target_opset_version=23` (or higher) to onnxsim to upgrade first if the
+// exported model predates it -- true of essentially all LLM exports today.
+//
+// Does not match `interleaved=1`-style RoPE (alternating elements rather
+// than first/second half), partial rotation (`rotary_embedding_dim` <
+// head_size), or the position_ids-indexed cache-table form (`cos`/`sin`
+// gathered by `position_ids` from a precomputed table rather than computed
+// fresh per call) -- left for follow-up.
+
+#include <cstdint>
+#include <vector>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+// Matches `sliced` as one half of `rotate_half`'s split: `Slice(x, start,
+// end, axis=-1[, step=1])` where `x`'s own last dimension is known (via
+// shape inference) and even. `want_first_half` selects which half: the first
+// half must be exactly `[0, D/2)`; the second half must start at `D/2` and
+// extend at least through `D` (real exporters commonly over-shoot with
+// `end=INT64_MAX` rather than `D` exactly, which Slice's own semantics clip
+// to the actual dimension size, so this accepts any `end >= D`).
+inline bool MatchRopeHalfSlice(Value* sliced, Value*& x, bool want_first_half,
+                               int64_t& head_size, std::vector<Node*>& chain) {
+  if (!CheckKind(sliced, kSlice) || sliced->uses().size() != 1) {
+    return false;
+  }
+  Node* sl = sliced->node();
+  if (sl->inputs().size() < 4) {
+    return false;
+  }
+  Value* data = sl->input(0);
+  if (!data->has_sizes() || data->sizes().empty()) {
+    return false;
+  }
+  const int64_t rank = static_cast<int64_t>(data->sizes().size());
+  const Dimension& last_dim = data->sizes()[static_cast<size_t>(rank - 1)];
+  if (!last_dim.is_int || last_dim.dim <= 0 || last_dim.dim % 2 != 0) {
+    return false;
+  }
+  head_size = last_dim.dim;
+  const int64_t half = head_size / 2;
+
+  int64_t start = 0, end = 0, axis = 0;
+  if (!GetValueFromInput(sl, 1, start, 0) ||
+      !GetValueFromInput(sl, 2, end, 0) || !GetValueFromInput(sl, 3, axis, 0)) {
+    return false;
+  }
+  if (axis < 0) {
+    axis += rank;
+  }
+  if (axis != rank - 1) {
+    return false;
+  }
+  if (sl->inputs().size() >= 5) {
+    int64_t step = 1;
+    if (!GetValueFromInput(sl, 4, step, 0) || step != 1) {
+      return false;
+    }
+  }
+  if (want_first_half) {
+    if (start != 0 || end != half) {
+      return false;
+    }
+  } else {
+    if (start != half || end < head_size) {
+      return false;
+    }
+  }
+  x = data;
+  chain.push_back(sl);
+  return true;
+}
+
+// Matches `rotated` as `rotate_half(x) = Concat([Neg(x2), x1], axis=-1)`
+// where `x1`/`x2` are the first/second-half `Slice`s of the *same* `x` (see
+// MatchRopeHalfSlice). Appends [concat, neg, slice_x2, slice_x1] to `chain`
+// (innermost/closest-to-consumer first, so this order is always a valid
+// destroy order given each node here is single-use by construction).
+inline bool MatchRotateHalf(Value* rotated, Value*& x,
+                            std::vector<Node*>& chain) {
+  if (!CheckKind(rotated, kConcat) || rotated->uses().size() != 1) {
+    return false;
+  }
+  Node* concat_n = rotated->node();
+  if (concat_n->inputs().size() != 2) {
+    return false;
+  }
+  Value* neg_out = concat_n->input(0);
+  Value* x1_out = concat_n->input(1);
+  if (!CheckKind(neg_out, kNeg) || neg_out->uses().size() != 1) {
+    return false;
+  }
+  Node* neg_n = neg_out->node();
+  if (neg_n->inputs().size() != 1) {
+    return false;
+  }
+  Value* x2_out = neg_n->input(0);
+
+  Value* x_from_x1 = nullptr;
+  Value* x_from_x2 = nullptr;
+  int64_t head_size1 = 0, head_size2 = 0;
+  std::vector<Node*> x1_chain, x2_chain;
+  if (!MatchRopeHalfSlice(x1_out, x_from_x1, /*want_first_half=*/true,
+                          head_size1, x1_chain) ||
+      !MatchRopeHalfSlice(x2_out, x_from_x2, /*want_first_half=*/false,
+                          head_size2, x2_chain)) {
+    return false;
+  }
+  if (x_from_x1 != x_from_x2 || head_size1 != head_size2) {
+    return false;
+  }
+  x = x_from_x1;
+  chain.push_back(concat_n);
+  chain.push_back(neg_n);
+  for (Node* nd : x2_chain) chain.push_back(nd);
+  for (Node* nd : x1_chain) chain.push_back(nd);
+  return true;
+}
+
+// Matches `cos_bcast`/`sin_bcast` (the two operands actually multiplied
+// against X and rotate_half(X)) back to a shared, once-computed `angle`:
+//   cos_bcast = Unsqueeze(Cos(Concat([angle, angle], axis=-1)), axes=[1])
+//   sin_bcast = Unsqueeze(Sin(Concat([angle, angle], axis=-1)), axes=[1])
+// with the Concat's two inputs required to be the *same* Value (reference
+// identity, not just equal shapes) -- see this file's top comment for why
+// that specific check is what makes the fusion mathematically exact. Unlike
+// every other Match* here, `cos_bcast`/`sin_bcast`/their producers are NOT
+// required to be single-use: they are shared between Q's and K's
+// independent RoPE applications by construction, and this pass tears them
+// down itself once both sides no longer need them (MaybeAppendSharedChain).
+inline bool MatchRopeCosSin(Value* cos_bcast, Value* sin_bcast, Value*& angle,
+                            Node*& cos_unsq, Node*& sin_unsq, Node*& cos_n,
+                            Node*& sin_n, Node*& concat_n) {
+  if (!CheckKind(cos_bcast, kUnsqueeze) || !CheckKind(sin_bcast, kUnsqueeze)) {
+    return false;
+  }
+  cos_unsq = cos_bcast->node();
+  sin_unsq = sin_bcast->node();
+  if (cos_unsq->inputs().size() < 2 || sin_unsq->inputs().size() < 2) {
+    return false;
+  }
+  std::vector<int64_t> cos_axes, sin_axes;
+  if (!GetValueFromInput(cos_unsq->input(1), cos_axes) ||
+      cos_axes != std::vector<int64_t>{1}) {
+    return false;
+  }
+  if (!GetValueFromInput(sin_unsq->input(1), sin_axes) ||
+      sin_axes != std::vector<int64_t>{1}) {
+    return false;
+  }
+  Value* cos_full = cos_unsq->input(0);
+  Value* sin_full = sin_unsq->input(0);
+  if (!CheckKind(cos_full, "Cos") || !CheckKind(sin_full, "Sin")) {
+    return false;
+  }
+  cos_n = cos_full->node();
+  sin_n = sin_full->node();
+  if (cos_n->inputs().size() != 1 || sin_n->inputs().size() != 1) {
+    return false;
+  }
+  Value* concat_a = cos_n->input(0);
+  Value* concat_b = sin_n->input(0);
+  if (concat_a != concat_b || !CheckKind(concat_a, kConcat)) {
+    return false;
+  }
+  concat_n = concat_a->node();
+  if (concat_n->inputs().size() != 2 ||
+      concat_n->input(0) != concat_n->input(1)) {
+    return false;  // Must be a literal self-duplicate: concat([h, h]).
+  }
+  angle = concat_n->input(0);
+  return true;
+}
+
+struct RopeMatch {
+  Value* x = nullptr;      // Q or K's pre-rotation activation, rank-4.
+  Value* angle = nullptr;  // Shared half-width angle: concat([angle,angle])
+                           // is what Cos/Sin actually read.
+  Node* cos_unsq = nullptr;
+  Node* sin_unsq = nullptr;
+  Node* cos_n = nullptr;
+  Node* sin_n = nullptr;
+  Node* concat_n = nullptr;
+  // Everything strictly between (x, cos_bcast, sin_bcast) and `n` (the outer
+  // Add), ordered innermost (closest to `n`) first -- does not include `n`
+  // itself (destroyed by the pass driver, matching every other fuse pass in
+  // this codebase) and does not include the shared cos/sin/Concat chain
+  // (see MaybeAppendSharedChain).
+  std::vector<Node*> dead_chain;
+};
+
+// One side's full match: `n = Add(Mul(x, cos_bcast), Mul(rotate_half(x),
+// sin_bcast))`, in either operand order, with the two Muls in either operand
+// order internally too.
+inline bool MatchRopeApply(Node* n, RopeMatch& m) {
+  if (!CheckKind(n, kAdd) || n->inputs().size() != 2) {
+    return false;
+  }
+  for (int i = 0; i < 2; ++i) {
+    Value* mul_a = n->input(i);
+    Value* mul_b = n->input(1 - i);
+    if (!CheckKind(mul_a, kMul) || mul_a->uses().size() != 1 ||
+        !CheckKind(mul_b, kMul) || mul_b->uses().size() != 1) {
+      continue;
+    }
+    Node* mul_a_n = mul_a->node();
+    Node* mul_b_n = mul_b->node();
+    if (mul_a_n->inputs().size() != 2 || mul_b_n->inputs().size() != 2) {
+      continue;
+    }
+    for (int j = 0; j < 2; ++j) {
+      Value* rotated_candidate = mul_b_n->input(j);
+      Value* sin_bcast = mul_b_n->input(1 - j);
+      Value* x_from_rotate = nullptr;
+      std::vector<Node*> rotate_chain;
+      if (!MatchRotateHalf(rotated_candidate, x_from_rotate, rotate_chain)) {
+        continue;
+      }
+      for (int k = 0; k < 2; ++k) {
+        Value* x_candidate = mul_a_n->input(k);
+        Value* cos_bcast = mul_a_n->input(1 - k);
+        if (x_candidate != x_from_rotate) {
+          continue;
+        }
+        Value* angle = nullptr;
+        Node *cos_unsq = nullptr, *sin_unsq = nullptr;
+        Node *cos_n = nullptr, *sin_n = nullptr, *concat_n = nullptr;
+        if (!MatchRopeCosSin(cos_bcast, sin_bcast, angle, cos_unsq, sin_unsq,
+                             cos_n, sin_n, concat_n)) {
+          continue;
+        }
+        // `RotaryEmbedding`'s schema needs `num_heads` for a 3-D X, which
+        // this pass never sets (it always emits the 4-D form). X is
+        // virtually always already rank 4 here in practice -- RoPE applies
+        // right after Q/K's own head-split transpose -- but decline rather
+        // than emit an underspecified node on the off chance it isn't.
+        if (!x_candidate->has_sizes() || x_candidate->sizes().size() != 4) {
+          continue;
+        }
+        m.x = x_candidate;
+        m.angle = angle;
+        m.cos_unsq = cos_unsq;
+        m.sin_unsq = sin_unsq;
+        m.cos_n = cos_n;
+        m.sin_n = sin_n;
+        m.concat_n = concat_n;
+        m.dead_chain.push_back(mul_a_n);
+        m.dead_chain.push_back(mul_b_n);
+        for (Node* nd : rotate_chain) m.dead_chain.push_back(nd);
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+// Appends the shared cos/sin/Concat chain to `dead_chain` if -- after this
+// match's own mul_a_n/mul_b_n are destroyed -- it has no other remaining
+// consumer, i.e. this side is the *last* of (at most) two RoPE applications
+// (Q's and K's) reading it. Checked via live use counts, not match order:
+// whichever of Q's/K's Add nodes this pass transforms second in a given
+// sweep is the one that observes the other side's Mul(s) already gone and
+// tears the shared chain down. This explicit handling -- rather than
+// leaving the now-dead chain for a later dead-code-elimination pass to
+// notice -- mirrors fuse_rms_norm.h's own reasoning: onnx-optimizer's
+// FixedPointPassManager only re-sweeps the full pass list (giving
+// eliminate_deadend another look) when some *other* pass in the list
+// reports Partial-efficiency work in the same round, so a Complete-efficiency
+// fuse pass' own orphaned nodes can otherwise survive in the "simplified"
+// output for an extra iteration, or indefinitely if nothing else in the
+// default pass set happens to fire that round.
+inline void MaybeAppendSharedChain(const RopeMatch& m,
+                                   std::vector<Node*>& dead_chain) {
+  Value* cos_bcast = m.cos_unsq->output();
+  Value* sin_bcast = m.sin_unsq->output();
+  auto sole_use_is = [](Value* v, Node* only_user) {
+    return v->uses().size() == 1 && v->uses()[0].user == only_user;
+  };
+  const bool cos_now_unused = sole_use_is(cos_bcast, m.dead_chain[0]);
+  const bool sin_now_unused = sole_use_is(sin_bcast, m.dead_chain[1]);
+  if (!cos_now_unused || !sin_now_unused) {
+    return;
+  }
+  dead_chain.push_back(m.cos_unsq);
+  dead_chain.push_back(m.sin_unsq);
+  Value* cos_full = m.cos_n->output();
+  Value* sin_full = m.sin_n->output();
+  if (!sole_use_is(cos_full, m.cos_unsq) ||
+      !sole_use_is(sin_full, m.sin_unsq)) {
+    return;
+  }
+  dead_chain.push_back(m.cos_n);
+  dead_chain.push_back(m.sin_n);
+  dead_chain.push_back(m.concat_n);
+}
+
+struct FuseRope final : public PredicateBasedPass {
+  explicit FuseRope()
+      : PredicateBasedPass(PassType::Fuse, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+  std::string getPassName() const override { return "fuse_rope"; }
+
+  bool patternMatchPredicate(Node* n) override {
+    if (getOpsetVersion(*n->owningGraph()) < 23) {
+      return false;
+    }
+    RopeMatch m;
+    return MatchRopeApply(n, m);
+  }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+    RopeMatch m;
+    if (!MatchRopeApply(n, m)) {
+      return false;
+    }
+    ONNX_ASSERT(!m.dead_chain.empty());
+    MaybeAppendSharedChain(m, m.dead_chain);
+
+    Node* cos_half = graph.create(Symbol("Cos"), 1);
+    cos_half->addInput(m.angle);
+    cos_half->insertBefore(n);
+
+    Node* sin_half = graph.create(Symbol("Sin"), 1);
+    sin_half->addInput(m.angle);
+    sin_half->insertBefore(n);
+
+    Node* rope = graph.create(Symbol("RotaryEmbedding"), 1);
+    rope->addInput(m.x);
+    rope->addInput(cos_half->output());
+    rope->addInput(sin_half->output());
+    rope->insertBefore(n);
+    rope->output()->copyMetadata(n->output());
+
+    if (!tryReplacingAllUsesWith(n, rope)) {
+      return false;
+    }
+
+    // `n` (the outer Add) still holds its own two input edges into
+    // dead_chain[0]/[1] (mul_a_n/mul_b_n) until detached here -- unlike
+    // fuse_attention.h/fuse_rms_norm.h's own anchors, BOTH of `n`'s inputs
+    // are part of the dead chain here (neither is an untouched, reused
+    // value), so both must be dropped before the destroy loop below can
+    // reach them at zero uses.
+    n->removeAllInputs();
+    for (Node* dead : m.dead_chain) {
+      dead->destroy();
+    }
+
+    destroy_current = NodeDestroyType::DestroyOne;
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/tests/test_fuse_attention.py
+++ b/tests/test_fuse_attention.py
@@ -491,3 +491,137 @@ def test_fuse_attention_recovers_input_flattened_by_gemm_conversion():
     rng2 = np.random.default_rng(21)
     x = rng2.standard_normal((B, S, H)).astype(np.float32)
     _assert_close(_run(model, {"x": x}), _run(simplified, {"x": x}))
+
+
+# --------------------------------------------------------------------------- #
+# scaled_dot_product_attention's *dynamo* export spells K's "swap the last
+# two axes for K^T" step differently from every other exporter this pass
+# handles: instead of folding it directly into K's own head-split Transpose
+# (perm [0,2,3,1], the "direct" form every other test above relies on), it
+# head-splits K exactly like Q/V (perm [0,2,1,3]) and then swaps the last two
+# axes as a *separate*, 3-D-round-tripping step: Reshape -> Transpose([0,2,1])
+# -> Reshape. See MatchKTransposeSwapChain in fuse_attention.h.
+# --------------------------------------------------------------------------- #
+def _k_transpose_swap_chain_nodes(
+    k_headsplit_out, B, NH, S, Dh, prefix, final_shape=None, flat_shape=None
+):
+    flat_shape = flat_shape if flat_shape is not None else [B * NH, S, Dh]
+    flat_shape = _i64(flat_shape, f"{prefix}_flat_shape")
+    final_shape = final_shape if final_shape is not None else [B, NH, Dh, S]
+    final_shape_init = _i64(final_shape, f"{prefix}_final_shape")
+    nodes = [
+        onnx.helper.make_node(
+            "Reshape", [k_headsplit_out, flat_shape.name], [f"{prefix}_flat"]
+        ),
+        onnx.helper.make_node(
+            "Transpose", [f"{prefix}_flat"], [f"{prefix}_swapped"], perm=[0, 2, 1]
+        ),
+        onnx.helper.make_node(
+            "Reshape", [f"{prefix}_swapped", final_shape_init.name], [f"{prefix}_kt"]
+        ),
+    ]
+    return nodes, [flat_shape, final_shape_init], f"{prefix}_kt"
+
+
+def _dynamo_style_k_model(
+    B=2, S=5, H=32, NH=4, bias=True, seed=30, k_final_shape=None, k_flat_shape=None
+):
+    Dh = H // NH
+    rng = np.random.default_rng(seed)
+    inits = []
+    nodes = []
+
+    shape_qkv = _i64([B, S, NH, Dh], "shape_qkv")
+    inits.append(shape_qkv)
+
+    q_nodes, q_inits, q_out = _linear_nodes(rng, "x", H, H, "q", bias)
+    k_nodes, k_inits, k_out = _linear_nodes(rng, "x", H, H, "k", bias)
+    v_nodes, v_inits, v_out = _linear_nodes(rng, "x", H, H, "v", bias)
+    nodes += q_nodes + k_nodes + v_nodes
+    inits += q_inits + k_inits + v_inits
+
+    qh_nodes, q_t = _head_split_nodes(q_out, "shape_qkv", [0, 2, 1, 3], "q")
+    # Unlike every other test above, K is head-split with the *same* perm as
+    # Q/V (not the direct-to-[0,2,3,1] form) -- the swap happens afterward.
+    kh_nodes, k_headsplit = _head_split_nodes(k_out, "shape_qkv", [0, 2, 1, 3], "k")
+    vh_nodes, v_t = _head_split_nodes(v_out, "shape_qkv", [0, 2, 1, 3], "v")
+    nodes += qh_nodes + kh_nodes + vh_nodes
+
+    kswap_nodes, kswap_inits, k_t = _k_transpose_swap_chain_nodes(
+        k_headsplit,
+        B,
+        NH,
+        S,
+        Dh,
+        "kswap",
+        final_shape=k_final_shape,
+        flat_shape=k_flat_shape,
+    )
+    nodes += kswap_nodes
+    inits += kswap_inits
+
+    divisor = _f32(np.array(float(Dh) ** 0.5), "divisor")
+    inits.append(divisor)
+    nodes.append(onnx.helper.make_node("MatMul", [q_t, k_t], ["qk"]))
+    nodes.append(onnx.helper.make_node("Div", ["qk", divisor.name], ["scores"]))
+    nodes.append(onnx.helper.make_node("Softmax", ["scores"], ["attn"], axis=-1))
+    nodes.append(onnx.helper.make_node("MatMul", ["attn", v_t], ["ctx0"]))
+    nodes.append(
+        onnx.helper.make_node("Transpose", ["ctx0"], ["ctx1"], perm=[0, 2, 1, 3])
+    )
+    shape_ctx = _i64([B, S, H], "shape_ctx")
+    inits.append(shape_ctx)
+    nodes.append(onnx.helper.make_node("Reshape", ["ctx1", "shape_ctx"], ["ctx2"]))
+
+    out_nodes, out_inits, out_name = _linear_nodes(rng, "ctx2", H, H, "out", bias)
+    nodes += out_nodes
+    inits += out_inits
+    nodes.append(onnx.helper.make_node("Identity", [out_name], ["y"]))
+
+    graph = onnx.helper.make_graph(
+        nodes, "g", [_vi("x", [B, S, H])], [_vi("y", [B, S, H])], inits
+    )
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 17)], ir_version=10
+    )
+
+
+def test_fuse_attention_handles_dynamo_k_transpose_reshape_chain():
+    # K's Reshape -> Transpose([0,2,1]) -> Reshape "swap last two axes" spelling
+    # (what scaled_dot_product_attention's dynamo exporter emits) must be
+    # recognized as equivalent to the direct perm-[0,2,3,1] form every other
+    # test above relies on.
+    B, S, H, NH = 2, 6, 32, 4
+    model = _dynamo_style_k_model(B=B, S=S, H=H, NH=NH)
+    simplified, ok = onnxsim.simplify(model)
+    assert ok
+    ops = _op_counts(simplified)
+    assert ops["Attention"] == 1
+    assert ops["Softmax"] == 0
+    onnx.checker.check_model(simplified)
+
+    rng = np.random.default_rng(31)
+    x = rng.standard_normal((B, S, H)).astype(np.float32)
+    _assert_close(_run(model, {"x": x}), _run(simplified, {"x": x}))
+
+
+def test_fuse_attention_declines_mismatched_k_transpose_reshape_chain():
+    # The first Reshape merges NH and S together ([B, NH*S, Dh]) instead of
+    # merging headsplit_out's actual leading two dims ([B*NH, S, Dh]) --
+    # coincidentally landing on the *same* final 4-D shape ([B, NH, Dh, S])
+    # as the genuine "swap the last two axes" chain despite computing a
+    # different permutation of the underlying data entirely. Checking only
+    # the final Reshape's shape (as an earlier, less careful version of
+    # MatchKTransposeSwapChain did) would wrongly accept this as equivalent
+    # and fuse it into a numerically wrong Attention node; the intermediate
+    # shape check must catch it and decline instead.
+    B, S, H, NH = 2, 6, 32, 4
+    Dh = H // NH
+    model = _dynamo_style_k_model(B=B, S=S, H=H, NH=NH, k_flat_shape=[B, NH * S, Dh])
+    simplified, ok = onnxsim.simplify(model)
+    assert ok
+    assert _op_counts(simplified)["Attention"] == 0
+
+    rng = np.random.default_rng(32)
+    x = rng.standard_normal((B, S, H)).astype(np.float32)
+    _assert_close(_run(model, {"x": x}), _run(simplified, {"x": x}))

--- a/tests/test_fuse_gqa.py
+++ b/tests/test_fuse_gqa.py
@@ -1,0 +1,243 @@
+"""Tests for the ``fuse_gqa`` C++ pass (``onnxsim/passes/fuse_gqa.h``) --
+pattern-matches a causal grouped-query/multi-query attention block (fewer K/V
+heads than Q heads, broadcast via HuggingFace's standard ``repeat_kv``, plus
+an additive causal mask) into a single ONNX Runtime "com.microsoft" contrib
+op, ``GroupQueryAttention``. Like ``fuse_attention``, this is a default-on
+graph-shape fusion that always runs as part of plain ``onnxsim.simplify()``.
+
+Every model here is built directly with ``onnx.helper`` (no torch dependency)
+to mirror what a real traced ``repeat_kv``-based GQA export produces -- see
+``fuse_gqa.h``'s own top-of-file comment for the exact node shape this
+targets and, importantly, why it only fires when the additive mask is a
+*provable constant* matching the causal pattern exactly (``GroupQueryAttention``
+always applies causal masking internally and unconditionally -- confirmed
+during development by comparing its output against manual bidirectional vs.
+causal references on the same random inputs).
+"""
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+
+import onnxsim
+
+# A bare ``import onnxruntime`` would fail collection (not skip the test) on
+# platforms onnxruntime doesn't ship wheels for; the fused output is a
+# "com.microsoft" contrib op that only onnxruntime can execute.
+ort = pytest.importorskip("onnxruntime")
+
+
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(np.asarray(array, dtype=np.float32), name)
+
+
+def _i64(array, name):
+    return onnx.numpy_helper.from_array(np.asarray(array, dtype=np.int64), name)
+
+
+def _causal_mask(seq_len):
+    mask = np.zeros((1, 1, seq_len, seq_len), dtype=np.float32)
+    mask[0, 0][np.triu_indices(seq_len, k=1)] = -3.0e38
+    return mask
+
+
+def _gqa_model(B=2, S=6, NH=8, NKV=2, Dh=16, mask=None, mask_is_input=False):
+    # Builds Y = Linear(ctx) where ctx is a causal GQA/MQA self-attention
+    # context: separate Q/K/V nn.Linear-style (bias-free) projections,
+    # head-split, K/V's repeat_kv broadcast up to Q's head count, scaled
+    # dot-product, an additive mask, softmax, weighted sum -- see
+    # fuse_gqa.h's own top comment for the exact shape this mirrors.
+    n_rep = NH // NKV
+    H = NH * Dh
+    HKV = NKV * Dh
+    rng = np.random.default_rng(0)
+
+    inits = [
+        _f32(rng.standard_normal((H, H)) * 0.1, "wq"),
+        _f32(rng.standard_normal((H, HKV)) * 0.1, "wk"),
+        _f32(rng.standard_normal((H, HKV)) * 0.1, "wv"),
+        _f32(rng.standard_normal((H, H)) * 0.1, "wo"),
+        _i64([B, S, NH, Dh], "shape_q"),
+        _i64([B, S, NKV, Dh], "shape_kv"),
+        _i64([2], "unsq_axes"),
+        _i64([B, NKV, n_rep, S, Dh], "expand_shape"),
+        _i64([B, NH, S, Dh], "merge_shape"),
+        _f32(np.array(float(Dh) ** 0.5), "sqrt_dh"),
+        _i64([B, S, H], "shape_ctx"),
+    ]
+
+    def repeat_kv_nodes(raw_name, prefix):
+        return [
+            onnx.helper.make_node(
+                "Unsqueeze", [raw_name, "unsq_axes"], [f"{prefix}_unsq"]
+            ),
+            onnx.helper.make_node(
+                "Expand", [f"{prefix}_unsq", "expand_shape"], [f"{prefix}_exp"]
+            ),
+            onnx.helper.make_node(
+                "Reshape", [f"{prefix}_exp", "merge_shape"], [f"{prefix}_rep"]
+            ),
+        ]
+
+    nodes = [
+        onnx.helper.make_node("MatMul", ["x", "wq"], ["q_mm"]),
+        onnx.helper.make_node("Reshape", ["q_mm", "shape_q"], ["q_r"]),
+        onnx.helper.make_node("Transpose", ["q_r"], ["q_t"], perm=[0, 2, 1, 3]),
+        onnx.helper.make_node("MatMul", ["x", "wk"], ["k_mm"]),
+        onnx.helper.make_node("Reshape", ["k_mm", "shape_kv"], ["k_r"]),
+        onnx.helper.make_node("Transpose", ["k_r"], ["k_raw"], perm=[0, 2, 1, 3]),
+        *repeat_kv_nodes("k_raw", "k"),
+        onnx.helper.make_node("Transpose", ["k_rep"], ["k_t"], perm=[0, 1, 3, 2]),
+        onnx.helper.make_node("MatMul", ["x", "wv"], ["v_mm"]),
+        onnx.helper.make_node("Reshape", ["v_mm", "shape_kv"], ["v_r"]),
+        onnx.helper.make_node("Transpose", ["v_r"], ["v_raw"], perm=[0, 2, 1, 3]),
+        *repeat_kv_nodes("v_raw", "v"),
+        onnx.helper.make_node("MatMul", ["q_t", "k_t"], ["qk"]),
+        onnx.helper.make_node("Div", ["qk", "sqrt_dh"], ["scores"]),
+    ]
+
+    graph_inputs = [_vi("x", [B, S, H])]
+    if mask is None:
+        softmax_input = "scores"
+    elif mask_is_input:
+        nodes.append(onnx.helper.make_node("Add", ["scores", "mask"], ["masked"]))
+        graph_inputs.append(_vi("mask", [1, 1, S, S]))
+        softmax_input = "masked"
+    else:
+        inits.append(_f32(mask, "mask"))
+        nodes.append(onnx.helper.make_node("Add", ["scores", "mask"], ["masked"]))
+        softmax_input = "masked"
+
+    nodes += [
+        onnx.helper.make_node("Softmax", [softmax_input], ["probs"], axis=-1),
+        onnx.helper.make_node("MatMul", ["probs", "v_rep"], ["ctx0"]),
+        onnx.helper.make_node("Transpose", ["ctx0"], ["ctx1"], perm=[0, 2, 1, 3]),
+        onnx.helper.make_node("Reshape", ["ctx1", "shape_ctx"], ["ctx2"]),
+        onnx.helper.make_node("MatMul", ["ctx2", "wo"], ["y"]),
+    ]
+
+    graph = onnx.helper.make_graph(
+        nodes, "g", graph_inputs, [_vi("y", [B, S, H])], inits
+    )
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 17)], ir_version=10
+    )
+
+
+def _op_counts(model):
+    import collections
+
+    return collections.Counter(n.op_type for n in model.graph.node)
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _assert_close(float_outputs, fused_outputs):
+    for f, q in zip(float_outputs, fused_outputs):
+        f = np.asarray(f, dtype=np.float64).ravel()
+        q = np.asarray(q, dtype=np.float64).ravel()
+        assert np.all(np.isfinite(q))
+        rel_l2 = np.linalg.norm(f - q) / max(np.linalg.norm(f), 1e-6)
+        assert rel_l2 < 1e-4, f"relative L2 error too large: {rel_l2:.6f}"
+
+
+def test_fuse_gqa_basic():
+    B, S, NH, NKV, Dh = 2, 6, 8, 2, 16
+    model = _gqa_model(B=B, S=S, NH=NH, NKV=NKV, Dh=Dh, mask=_causal_mask(S))
+    simplified, ok = onnxsim.simplify(model)
+    assert ok
+    ops = _op_counts(simplified)
+    assert ops["GroupQueryAttention"] == 1
+    assert ops["Softmax"] == 0
+    gqa = next(n for n in simplified.graph.node if n.op_type == "GroupQueryAttention")
+    num_heads = next(a for a in gqa.attribute if a.name == "num_heads").i
+    kv_num_heads = next(a for a in gqa.attribute if a.name == "kv_num_heads").i
+    assert num_heads == NH
+    assert kv_num_heads == NKV
+    domains = {o.domain for o in simplified.opset_import}
+    assert "com.microsoft" in domains
+    onnx.checker.check_model(simplified)
+
+    rng = np.random.default_rng(42)
+    x = rng.standard_normal((B, S, NH * Dh)).astype(np.float32)
+    _assert_close(_run(model, {"x": x}), _run(simplified, {"x": x}))
+
+
+def test_fuse_gqa_multi_query():
+    # MQA: a single shared K/V head (NKV=1) is the extreme case of GQA.
+    B, S, NH, NKV, Dh = 2, 5, 4, 1, 8
+    model = _gqa_model(B=B, S=S, NH=NH, NKV=NKV, Dh=Dh, mask=_causal_mask(S))
+    simplified, ok = onnxsim.simplify(model)
+    assert ok
+    ops = _op_counts(simplified)
+    assert ops["GroupQueryAttention"] == 1
+    onnx.checker.check_model(simplified)
+
+    rng = np.random.default_rng(7)
+    x = rng.standard_normal((B, S, NH * Dh)).astype(np.float32)
+    _assert_close(_run(model, {"x": x}), _run(simplified, {"x": x}))
+
+
+def test_fuse_gqa_declines_without_mask():
+    # Bidirectional (no additive mask at all): GroupQueryAttention always
+    # applies causal masking internally with no way to disable it, so this
+    # must decline rather than silently turn a bidirectional block causal.
+    B, S, NH, NKV, Dh = 2, 6, 8, 2, 16
+    model = _gqa_model(B=B, S=S, NH=NH, NKV=NKV, Dh=Dh, mask=None)
+    simplified, ok = onnxsim.simplify(model)
+    assert ok
+    assert _op_counts(simplified)["GroupQueryAttention"] == 0
+
+    rng = np.random.default_rng(1)
+    x = rng.standard_normal((B, S, NH * Dh)).astype(np.float32)
+    _assert_close(_run(model, {"x": x}), _run(simplified, {"x": x}))
+
+
+def test_fuse_gqa_declines_non_causal_mask():
+    # A mask that's present but numerically not the standard causal pattern
+    # (all zeros here -- i.e. no actual masking) must not be assumed causal.
+    B, S, NH, NKV, Dh = 2, 6, 8, 2, 16
+    model = _gqa_model(
+        B=B, S=S, NH=NH, NKV=NKV, Dh=Dh, mask=np.zeros((1, 1, S, S), dtype=np.float32)
+    )
+    simplified, ok = onnxsim.simplify(model)
+    assert ok
+    assert _op_counts(simplified)["GroupQueryAttention"] == 0
+
+    rng = np.random.default_rng(2)
+    x = rng.standard_normal((B, S, NH * Dh)).astype(np.float32)
+    _assert_close(_run(model, {"x": x}), _run(simplified, {"x": x}))
+
+
+def test_fuse_gqa_declines_runtime_mask():
+    # A mask that's present, causal-shaped, and would numerically pass
+    # VerifyCausalMaskConstant -- but is a runtime graph *input*, not a
+    # compile-time constant. Real GQA exports almost always pass their mask
+    # this way; this pass deliberately declines rather than trust an
+    # un-provable runtime tensor is exactly causal-shaped (see fuse_gqa.h's
+    # own top comment for why).
+    B, S, NH, NKV, Dh = 2, 6, 8, 2, 16
+    model = _gqa_model(
+        B=B, S=S, NH=NH, NKV=NKV, Dh=Dh, mask=_causal_mask(S), mask_is_input=True
+    )
+    simplified, ok = onnxsim.simplify(model)
+    assert ok
+    assert _op_counts(simplified)["GroupQueryAttention"] == 0
+
+    rng = np.random.default_rng(3)
+    x = rng.standard_normal((B, S, NH * Dh)).astype(np.float32)
+    mask = _causal_mask(S)
+    _assert_close(
+        _run(model, {"x": x, "mask": mask}), _run(simplified, {"x": x, "mask": mask})
+    )

--- a/tests/test_fusion_patterns.py
+++ b/tests/test_fusion_patterns.py
@@ -290,6 +290,178 @@ def test_fuse_rms_norm_below_opset_23_untouched():
     assert ops["Mul"] == 2
 
 
+# --------------------------------------------------------------------------- #
+# fuse_rope -- HuggingFace-style "rotate_half" rotary position embedding
+# application (see fuse_rope.h's own top comment and test_mnn_llm_export.py's
+# ``_Attention`` for a real traced example) collapsed into a single standard
+# ONNX ``RotaryEmbedding`` node (opset 23). Q's and K's applications share one
+# ``cos``/``sin``/``Concat`` computation (``emb = concat([angle, angle])``);
+# both must be recognized as reading the *same* ``angle`` Value for the
+# fusion to be numerically exact -- see MatchRopeCosSin's own doc comment.
+# --------------------------------------------------------------------------- #
+def _rope_apply_nodes(x_name, cos_bcast_name, sin_bcast_name, prefix, half):
+    # x_embed = x * cos_bcast + rotate_half(x) * sin_bcast
+    return [
+        onnx.helper.make_node("Mul", [x_name, cos_bcast_name], [f"{prefix}_a"]),
+        onnx.helper.make_node(
+            "Slice",
+            [x_name, "slice_start0", f"slice_end{half}", "slice_axism1"],
+            [f"{prefix}_x1"],
+        ),
+        onnx.helper.make_node(
+            "Slice",
+            [x_name, f"slice_start{half}", "slice_end_max", "slice_axism1"],
+            [f"{prefix}_x2"],
+        ),
+        onnx.helper.make_node("Neg", [f"{prefix}_x2"], [f"{prefix}_neg_x2"]),
+        onnx.helper.make_node(
+            "Concat",
+            [f"{prefix}_neg_x2", f"{prefix}_x1"],
+            [f"{prefix}_rotated"],
+            axis=-1,
+        ),
+        onnx.helper.make_node(
+            "Mul", [f"{prefix}_rotated", sin_bcast_name], [f"{prefix}_b"]
+        ),
+        onnx.helper.make_node(
+            "Add", [f"{prefix}_a", f"{prefix}_b"], [f"{prefix}_embed"]
+        ),
+    ]
+
+
+def _rope_model(B=2, NH=4, S=6, Dh=8, share_angle=True, opset=23):
+    half = Dh // 2
+    inits = [
+        _i64([0], "slice_start0"),
+        _i64([half], f"slice_end{half}"),
+        _i64([half], f"slice_start{half}"),
+        _i64([np.iinfo(np.int64).max], "slice_end_max"),
+        _i64([-1], "slice_axism1"),
+        _i64([1], "unsq_axis1"),
+    ]
+    angle2 = "angle" if share_angle else "angle2"
+    nodes = [
+        onnx.helper.make_node("Concat", ["angle", angle2], ["emb"], axis=-1),
+        onnx.helper.make_node("Cos", ["emb"], ["cos_full"]),
+        onnx.helper.make_node("Sin", ["emb"], ["sin_full"]),
+        onnx.helper.make_node("Unsqueeze", ["cos_full", "unsq_axis1"], ["cos_bcast"]),
+        onnx.helper.make_node("Unsqueeze", ["sin_full", "unsq_axis1"], ["sin_bcast"]),
+    ]
+    nodes += _rope_apply_nodes("q", "cos_bcast", "sin_bcast", "q", half)
+    nodes += _rope_apply_nodes("k", "cos_bcast", "sin_bcast", "k", half)
+
+    graph_inputs = [
+        _vi("q", [B, NH, S, Dh]),
+        _vi("k", [B, NH, S, Dh]),
+        _vi("angle", [B, S, half]),
+    ]
+    if not share_angle:
+        # A second, independent (shape-identical but not the same Value, and
+        # not foldable back to `angle`) input: the duplicating Concat's two
+        # inputs are then genuinely different, so fuse_rope must decline
+        # rather than assume this is duplication.
+        graph_inputs.append(_vi("angle2", [B, S, half]))
+    graph = onnx.helper.make_graph(
+        nodes,
+        "g",
+        graph_inputs,
+        [_vi("q_embed", [B, NH, S, Dh]), _vi("k_embed", [B, NH, S, Dh])],
+        inits,
+    )
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=11
+    )
+
+
+def test_fuse_rope():
+    model = _rope_model()
+    _, ops = _simplify(model)
+    assert ops["RotaryEmbedding"] == 2
+    # The whole shared cos/sin/Concat/Unsqueeze chain, and each side's own
+    # Slice/Neg/Concat/Mul/Add chain, must be fully torn down -- not just
+    # left as dead code (see fuse_rope.h's MaybeAppendSharedChain).
+    assert ops["Concat"] == 0
+    assert ops["Slice"] == 0
+    assert ops["Neg"] == 0
+    assert ops["Unsqueeze"] == 0
+    assert ops["Mul"] == 0
+    assert ops["Add"] == 0
+
+
+def test_fuse_rope_below_opset_23_untouched():
+    # Below opset 23, RotaryEmbedding does not exist yet: the pass must not
+    # fire, leaving the decomposition intact.
+    model = _rope_model(opset=17)
+    model.ir_version = 10
+    _, ops = _simplify(model)
+    assert ops["RotaryEmbedding"] == 0
+    assert ops["Concat"] == 3  # shared emb + each side's rotate_half Concat
+
+
+def test_fuse_rope_declines_non_shared_angle():
+    # cos/sin are computed from concat([angle, angle2]) where angle2 is a
+    # *different* Value from angle (even though shape-identical) rather than
+    # literally the same one -- MatchRopeCosSin's reference-identity check on
+    # the Concat's two inputs must catch this and decline, since wiring a
+    # non-duplicated cos/sin into RotaryEmbedding would compute something
+    # else entirely.
+    model = _rope_model(share_angle=False)
+    _, ops = _simplify(model)
+    assert ops["RotaryEmbedding"] == 0
+
+
+def test_fuse_rope_partial_match_preserves_shared_chain():
+    # Only Q's side matches the rotate_half pattern; K instead just multiplies
+    # by cos_bcast directly (a stand-in for "some other, unmatched use").
+    # fuse_rope must still fuse Q, and must NOT tear down the shared
+    # cos/sin/Concat chain (K still reads it) -- MaybeAppendSharedChain's own
+    # live-use-count check should correctly see cos_bcast/sin_bcast still
+    # have a remaining consumer and leave them alone.
+    B, NH, S, Dh = 2, 4, 6, 8
+    half = Dh // 2
+    inits = [
+        _i64([0], "slice_start0"),
+        _i64([half], f"slice_end{half}"),
+        _i64([half], f"slice_start{half}"),
+        _i64([np.iinfo(np.int64).max], "slice_end_max"),
+        _i64([-1], "slice_axism1"),
+        _i64([1], "unsq_axis1"),
+    ]
+    nodes = [
+        onnx.helper.make_node("Concat", ["angle", "angle"], ["emb"], axis=-1),
+        onnx.helper.make_node("Cos", ["emb"], ["cos_full"]),
+        onnx.helper.make_node("Sin", ["emb"], ["sin_full"]),
+        onnx.helper.make_node("Unsqueeze", ["cos_full", "unsq_axis1"], ["cos_bcast"]),
+        onnx.helper.make_node("Unsqueeze", ["sin_full", "unsq_axis1"], ["sin_bcast"]),
+    ]
+    nodes += _rope_apply_nodes("q", "cos_bcast", "sin_bcast", "q", half)
+    # K: deliberately NOT the rotate_half pattern -- just k * cos_bcast.
+    nodes.append(onnx.helper.make_node("Mul", ["k", "cos_bcast"], ["k_embed"]))
+
+    graph = onnx.helper.make_graph(
+        nodes,
+        "g",
+        [
+            _vi("q", [B, NH, S, Dh]),
+            _vi("k", [B, NH, S, Dh]),
+            _vi("angle", [B, S, half]),
+        ],
+        [_vi("q_embed", [B, NH, S, Dh]), _vi("k_embed", [B, NH, S, Dh])],
+        inits,
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 23)], ir_version=11
+    )
+    simplified, ops = _simplify(model)
+    assert ops["RotaryEmbedding"] == 1
+    # K's own Mul(k, cos_bcast) must still resolve correctly -- proving the
+    # shared cos_bcast (and everything upstream of it) was left intact.
+    k_embed = next(o for o in simplified.graph.output if o.name == "k_embed")
+    assert k_embed is not None
+    remaining_muls = [n for n in simplified.graph.node if n.op_type == "Mul"]
+    assert any("k" in n.input for n in remaining_muls)
+
+
 def test_fuse_concat_into_reshape():
     # A Concat of constant shape pieces feeding a Reshape is folded into a single
     # Reshape with a constant target shape (fuse_concat_into_reshape).


### PR DESCRIPTION
## Summary

Follow-up to #692, which added SDPA (`torch.nn.functional.scaled_dot_product_attention`) support for `fuse_attention`'s pre-scaled QK pattern but deliberately left the *dynamo* exporter's (`torch.onnx.export(..., dynamo=True)`) alternate K-transpose spelling as a documented follow-up (declined safely, not misfired, but not fused).

`torch.onnx.export(..., dynamo=True)`'s SDPA export head-splits K the same way as Q/V (`Transpose` perm `[0,2,1,3]`) and spells the "swap the last two axes for K^T" step as a *separate*, 3-D-round-tripping chain — `Reshape -> Transpose([0,2,1]) -> Reshape` — rather than folding it into one direct 4-D `Transpose(perm=[0,2,3,1])` the way the legacy exporter and hand-rolled patterns do. `MatchKTransposeSwapChain` (new, in `onnxsim/passes/fuse_attention.h`) recognizes this alternate spelling.

Rather than decoding the two Reshapes' (possibly dynamic) target-shape computations, the match confirms shape-equivalence to the direct form via shape inference: the intermediate Reshape's output must keep the head-split output's own last two dims unchanged in the same trailing positions (pinning the merge to be exactly the leading two dims, in order — not some other grouping that could coincidentally reshape to the same final shape), and the final Reshape's output must exactly match the head-split output's shape with its last two dims exchanged. **Both checks are required**: an earlier version of this only checked the final shape, which `test_fuse_attention_declines_mismatched_k_transpose_reshape_chain` demonstrated is insufficient — a chain merging a *different* pair of leading dims can land on the same final shape while actually computing a different permutation of the data, which would have silently corrupted the fused result.

## Test plan

- `tests/test_fuse_attention.py`: 2 new tests (11 total now) — a positive case building the exact Reshape/Transpose/Reshape K spelling via `onnx.helper`, and the shape-loophole decline case described above. Both verify numeric correctness (before/after `onnxruntime` execution) in addition to structural node counts.
- Manually verified end-to-end against a real traced `torch.onnx.export(dynamo=True)` SDPA export: 24 nodes → 4 nodes (`Attention`, `Reshape`, `Gemm`, `Reshape`), exact (0.0 max-abs-diff) numeric agreement.
- `pytest tests/test_fuse_attention.py tests/test_fusion_patterns.py tests/test_mnn_llm_export.py` → 41 passed, 1 skipped, no regressions.
- `clang-format --dry-run --Werror` / `ruff format --check` / `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_