### PR TITLE
Close the loop to a real micropip-installable wheel

### DIFF
--- a/docs/wasm_pyodide.md
+++ b/docs/wasm_pyodide.md
@@ -227,10 +227,60 @@ What the demo runs instead is real: several bindings in
 bytes using onnxsim's own *statically-linked* copy of onnx/onnx-optimizer/
 protobuf, and need no Python `onnx` package at all.
 
-**Hosting is provisional**: the page fetches `./onnxsim_cpp2py_export.abi3.so`
-as a same-directory relative path. That `.so` is not committed (like every
+**Hosting**: the page fetches `./onnxsim_cpp2py_export.abi3.so` as a
+same-directory relative path. That `.so` is not committed (like every
 other `*.so` in this repo, it's gitignored) -- get one via the CI artifact
-or a local build, as above. It is not yet wired into this repo's GitHub
-Pages deployment (`static.yml`, which currently deploys the unrelated
-ORT-web/JS convertmodel demo) -- doing that is a real follow-up, not
-attempted here.
+or a local build, as above. `static.yml` stages this demo (both the page
+and a freshly-built `.so`, imported as a cross-workflow artifact from
+`pyodide-wasm.yml`) at `pyodide-demo/` alongside its existing ORT-web/JS
+convertmodel deploy, on every production deploy and `/preview` -- see its
+"Pyodide demo" step for exactly how, including the fallback it uses when
+the exact commit being deployed has no matching `pyodide-wasm.yml` run of
+its own (most commits don't, since that workflow is path-filtered).
+
+## Distributable wheel (experimental, hand-verified once)
+
+`build_wasm_pyodide.sh` produces a loose `.so`, not something `micropip`
+can install directly. Closing that gap needs two things: (1) `setup.py`'s
+`build_ext` step doing the same manual `em++ -sSIDE_MODULE=2` relink
+`build_wasm_pyodide.sh` does (CMake alone still can't produce a real side
+module -- see above), and (2) assembling that relinked `.so` plus onnxsim's
+pure-Python files into an actual wheel with the right Pyodide platform tag.
+
+**(1) is now real and committed**, gated behind an explicit opt-in env var
+so it has zero effect on the normal native wheel build:
+
+```sh
+ONNXSIM_WASM_SIDE_MODULE_RELINK=1 <the rest of a normal `pip wheel .` /
+  `python setup.py build_ext` invocation, run under an activated emsdk>
+```
+
+When set, `build_ext` performs the exact relink `build_wasm_pyodide.sh`
+does (same object-file/archive discovery, same `-sEXPORTED_FUNCTIONS`
+entry-symbol handling) on CMake's output before copying it into the wheel,
+so whatever packages the wheel afterward picks up a genuine dynamic module
+instead of a static archive. Unset (the default), this code path is never
+even evaluated.
+
+**(2) is not yet automated** -- `pyodide build`'s own `pywasmcross`
+compiler-wrapping does NOT solve the `SIDE_MODULE` problem on its own
+(confirmed directly: it wraps individual `em++`/`emcc` invocations, but
+never CMake's own generator-level choice of link rule, which is what's
+actually blocked by `TARGET_SUPPORTS_SHARED_LIBS=FALSE`). A real wheel
+was hand-assembled for validation -- same `onnxsim/onnxsim_cpp2py_export.abi3.so`
+`build_wasm_pyodide.sh` produces (after the `ONNXSIM_WASM_SIDE_MODULE_RELINK=1`
+relink), onnxsim's pure-Python modules, and a hand-written `.dist-info/`
+(`METADATA`/`WHEEL`/`RECORD`) tagged `cp312-abi3-pyodide_2026_0_wasm32`
+(matching Pyodide 314.0.5's `PYODIDE_ABI_VERSION`, confirmed live inside
+that runtime) -- zipped together, no `pyodide build`/`bdist_wheel`
+involved. Wiring `pyodide build` through to produce this automatically is
+a real follow-up, not done here.
+
+**Verified working**: `micropip.install(<url to the hand-assembled wheel>,
+deps=False)` (`deps=False` because full dependency resolution hits the
+same `onnx` ABI-epoch gap described above -- a separate, already-documented
+issue, not a flaw in the wheel itself) installed cleanly in a real Pyodide
+314.0.5 runtime, and importing the *installed* module from its real
+site-packages path (not a hand-copied FS write, unlike the demo page)
+succeeded, with `_list_optimizers()` again confirming it's genuinely
+functional, not just importable.

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,22 @@ DEBUG = bool(os.getenv('DEBUG'))
 COVERAGE = bool(os.getenv('COVERAGE'))
 VERSION_FILE = os.path.join(TOP_DIR, 'VERSION')
 
+# Opt-in only -- see docs/wasm_pyodide.md. When building under `pyodide build`
+# (pywasmcross-wrapped compilers targeting wasm32-emscripten), CMake's own
+# MODULE/SHARED library support is unavailable (Emscripten's CMake toolchain
+# file hardcodes TARGET_SUPPORTS_SHARED_LIBS=FALSE), so the
+# onnxsim_cpp2py_export target CMake produces is a static ar archive, not a
+# loadable Pyodide side module -- byte-identical to the dead end
+# build_wasm_pyodide.sh's manual em++ relink step already works around.
+# This flag makes build_ext perform that exact same manual relink, in place,
+# before the artifact is copied into the wheel. It does nothing (and this
+# whole code path is not even imported/evaluated beyond this flag check)
+# unless explicitly set -- a normal `pip install .` / native wheel build is
+# completely unaffected. Deliberately an explicit env var rather than
+# auto-detection, so this never silently changes native-build behavior.
+ONNXSIM_WASM_SIDE_MODULE_RELINK = bool(
+    os.getenv('ONNXSIM_WASM_SIDE_MODULE_RELINK') == '1')
+
 try:
     version = subprocess.check_output(['git', 'describe', '--tags', '--abbrev=0'],
                                       cwd=TOP_DIR).decode('ascii').strip()
@@ -219,6 +235,85 @@ class develop(setuptools.command.develop.develop):
         setuptools.command.develop.develop.run(self)
 
 
+def _relink_wasm_side_module(build_dir, so_path):
+    """Re-link `so_path` (a CMake-produced static ar archive containing only
+    onnxsim_cpp2py_export's own object file, under Emscripten's CMake
+    toolchain -- see ONNXSIM_WASM_SIDE_MODULE_RELINK above) into a genuine
+    Pyodide side module, in place.
+
+    Exact same approach as build_wasm_pyodide.sh's manual link step: reuses
+    the object file and every dependency archive (abseil/protobuf/onnx/
+    onnx-optimizer/onnxsim/nanobind) CMake already built under `build_dir`,
+    discovering both at run time rather than hand-maintaining a list. See
+    docs/wasm_pyodide.md for why this manual step is necessary at all.
+    """
+    em_plus_plus = shutil.which('em++')
+    if not em_plus_plus:
+        raise RuntimeError(
+            'ONNXSIM_WASM_SIDE_MODULE_RELINK=1 but no em++ on PATH -- '
+            'activate the emsdk (or run under pyodide build, which puts a '
+            'pywasmcross-wrapped em++ on PATH) before building.')
+
+    module_name = 'onnxsim_cpp2py_export'
+    obj = None
+    for root, _dirs, files in os.walk(
+            os.path.join(build_dir, 'CMakeFiles', f'{module_name}.dir')):
+        for f in files:
+            if f == 'cpp2py_export.cc.o':
+                obj = os.path.join(root, f)
+                break
+        if obj:
+            break
+    if not obj:
+        raise RuntimeError(
+            f'ONNXSIM_WASM_SIDE_MODULE_RELINK=1: could not find '
+            f'cpp2py_export.cc.o under {build_dir}/CMakeFiles/'
+            f'{module_name}.dir (did the CMake build actually run?)')
+
+    archives = []
+    for root, _dirs, files in os.walk(build_dir):
+        for f in files:
+            if f.endswith('.a'):
+                archives.append(os.path.join(root, f))
+    archives.sort()
+    if not archives:
+        raise RuntimeError(
+            f'ONNXSIM_WASM_SIDE_MODULE_RELINK=1: no .a archives found under '
+            f'{build_dir} -- expected dependency archives '
+            f'(abseil/protobuf/onnx/onnx-optimizer/onnxsim/nanobind) to '
+            f'already be built at this point.')
+
+    # Discover the real entry symbol (PyInit_<module name>, per CPython's
+    # extension-module ABI) from the object file via llvm-nm rather than
+    # assuming it matches module_name, so a future module rename doesn't
+    # silently produce a link missing its only real entry point.
+    entry_symbol = None
+    llvm_nm = shutil.which('llvm-nm')
+    if llvm_nm:
+        out = subprocess.run([llvm_nm, obj], capture_output=True, text=True)
+        for line in out.stdout.splitlines():
+            parts = line.split()
+            if len(parts) >= 3 and parts[1] == 'T' and parts[2].startswith('PyInit_'):
+                entry_symbol = parts[2]
+                break
+    if not entry_symbol:
+        entry_symbol = f'PyInit_{module_name}'
+
+    # -sEXPORTED_FUNCTIONS is required: without an explicit root symbol, the
+    # linker's dead-code elimination strips the module down to a couple KB,
+    # since nothing else in this standalone link references the nanobind
+    # entry point (there's no main()/other symbol pulling it in, unlike
+    # inside Pyodide's real loader).
+    cmd = [
+        em_plus_plus, '-O2', '-sSIDE_MODULE=2',
+        f'-sEXPORTED_FUNCTIONS=_{entry_symbol}',
+        '-o', so_path, obj,
+    ] + archives
+    print(f'ONNXSIM_WASM_SIDE_MODULE_RELINK=1: relinking wasm side module: '
+          f'{" ".join(cmd[:6])} ... (+{len(archives)} archives)')
+    subprocess.check_call(cmd)
+
+
 class build_ext(setuptools.command.build_ext.build_ext):
     def run(self):
         self.run_command('cmake_build')
@@ -238,6 +333,8 @@ class build_ext(setuptools.command.build_ext.build_ext):
                 elif os.path.exists(release_lib_dir):
                     lib_path = release_lib_dir
             src = os.path.join(lib_path, filename)
+            if ONNXSIM_WASM_SIDE_MODULE_RELINK:
+                _relink_wasm_side_module(lib_path, src)
             dst_dir = os.path.join(os.path.realpath(
                 self.build_lib), "onnxsim")
             dst = os.path.join(dst_dir, filename)


### PR DESCRIPTION
## Summary

`build_wasm_pyodide.sh` (from #696) produces a loose `onnxsim_cpp2py_export.abi3.so` — genuinely working, but not something `micropip` can install, since nothing packages it into a real wheel.

Adds `ONNXSIM_WASM_SIDE_MODULE_RELINK`, an explicit opt-in env var that makes `build_ext` perform the same manual `em++ -sSIDE_MODULE=2` relink `build_wasm_pyodide.sh` already does (CMake alone can only produce a static archive here — Emscripten's own CMake toolchain hardcodes `TARGET_SUPPORTS_SHARED_LIBS=FALSE`), in place, before the artifact is copied into the wheel build dir. **Zero effect unless set** — a normal `pip install .` / native wheel build never evaluates this code path at all.

## What was checked, not assumed

**Does `pyodide build`'s own `pywasmcross` compiler-wrapping solve `SIDE_MODULE` automatically, making this moot?** No — confirmed directly. It wraps individual `em++`/`emcc` invocations, but never touches CMake's own generator-level choice of link rule, which is what `TARGET_SUPPORTS_SHARED_LIBS=FALSE` actually blocks. A plain `pyodide build` would still ship a misnamed static archive.

**Does the relinked module actually work when installed as a real wheel, not just written into Pyodide's FS by hand (the existing demo page's approach)?** Yes — verified end-to-end: hand-assembled a real wheel (the relinked `.so` + onnxsim's pure-Python files + a real `.dist-info/METADATA`/`WHEEL`/`RECORD`, tagged `cp312-abi3-pyodide_2026_0_wasm32` matching Pyodide 314.0.5's own `PYODIDE_ABI_VERSION`), then `micropip.install(url, deps=False)` in a real Pyodide 314.0.5 runtime — installed cleanly, and the *installed* module (imported from its real site-packages path) ran correctly (`_list_optimizers()` returned real data, not a stub). `deps=False` because full dependency resolution hits the already-documented `onnx` wasm-wheel ABI-epoch gap, unrelated to this wheel itself.

Also fixes a stale line in `docs/wasm_pyodide.md`'s Browser demo section claiming the demo "is not yet wired into" `static.yml`'s Pages deployment — that shipped in #696, the doc just never caught up.

## Not done here

Automating the wheel assembly itself (getting `pyodide build`'s `bdist_wheel` to produce this directly, rather than hand-assembling one for validation) is a real follow-up — documented as such in `docs/wasm_pyodide.md`'s new "Distributable wheel" section, not attempted in this PR.

## Test plan

- [x] `ONNXSIM_WASM_SIDE_MODULE_RELINK=1` build_ext relink reproduces the exact same working `.abi3.so` `build_wasm_pyodide.sh`'s manual step produces (`file`: WebAssembly binary, `dylink.0` present, exports `PyInit_onnxsim_cpp2py_export`)
- [x] Hand-assembled wheel installs via real `micropip.install()` in a live Pyodide 314.0.5 runtime; installed module imports from its real site-packages path and runs correctly
- [x] Confirmed unset (default) behavior is completely unaffected — the new code path is gated behind an explicit env var, not auto-detection
- [ ] Not done: automating `pyodide build`/`bdist_wheel` to produce the wheel directly (documented as a follow-up)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AbnrxXsnAUeEjqcjdMF1Tn)_