### PR TITLE
Add cross_layer_equalize: AIMET's data-free Cross-Layer Equalization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,7 @@ set(ONNXSIM_BLAKE3_COMPILE_DEFS
     BLAKE3_NO_SSE2 BLAKE3_NO_SSE41 BLAKE3_NO_AVX2 BLAKE3_NO_AVX512
     BLAKE3_USE_NEON=0)
 
-add_library(onnxsim onnxsim/onnxsim.cpp onnxsim/constant_folding.cpp onnxsim/partial_shape_eval.cpp onnxsim/model_prep.cpp onnxsim/quantize_entry.cpp onnxsim/contrib_schemas.cpp onnxsim/custom_optimizer_passes.cpp onnxsim/function_rewriter.cpp onnxsim/profiler.cpp onnxsim/model_info.cpp onnxsim/sym_expr.cpp onnxsim/sym_value_eval.cpp onnxsim/sym_shape_infer.cpp onnxsim/model_metrics.cpp onnxsim/precision_estimator.cpp onnxsim/tensor_pool.cpp onnxsim/tensor_pool_gguf.cpp onnxsim/tensor_pool_hash.cpp ${ONNXSIM_BLAKE3_SOURCES})
+add_library(onnxsim onnxsim/onnxsim.cpp onnxsim/constant_folding.cpp onnxsim/partial_shape_eval.cpp onnxsim/model_prep.cpp onnxsim/quantize_entry.cpp onnxsim/cross_layer_equalization_entry.cpp onnxsim/contrib_schemas.cpp onnxsim/custom_optimizer_passes.cpp onnxsim/function_rewriter.cpp onnxsim/profiler.cpp onnxsim/model_info.cpp onnxsim/sym_expr.cpp onnxsim/sym_value_eval.cpp onnxsim/sym_shape_infer.cpp onnxsim/model_metrics.cpp onnxsim/precision_estimator.cpp onnxsim/tensor_pool.cpp onnxsim/tensor_pool_gguf.cpp onnxsim/tensor_pool_hash.cpp ${ONNXSIM_BLAKE3_SOURCES})
 target_compile_definitions(onnxsim PRIVATE ${ONNXSIM_BLAKE3_COMPILE_DEFS})
 if (ONNXSIM_BUILTIN_ORT)
   # Both ways of obtaining ONNX Runtime ship/install headers flat under this

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -25,6 +25,7 @@ from onnxsim.calibration import (
     quantize_static_int16,
 )
 from onnxsim.onnx_simplifier import (
+    cross_layer_equalize,
     export_gguf,
     export_safetensors,
     import_gguf,
@@ -61,6 +62,7 @@ __all__ = [
     "quantize_auto",
     "QuantizationRecommendation",
     "DEFAULT_QUANTIZATION_CANDIDATES",
+    "cross_layer_equalize",
     "quantize_attention_dynamic",
     "quantize_dynamic",
     "quantize_dynamic_matmul_integer_to_float",

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -347,6 +347,23 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
       },
       "model_bytes"_a, "run_shape_inference"_a = true);
 
+  // Data-free Cross-Layer Equalization preprocessing (not itself a
+  // quantization scheme) -- see CrossLayerEqualize in onnxsim.h. Pure graph
+  // rewrite: no ModelExecutor or calibration data needed.
+  m.def(
+      "cross_layer_equalize",
+      [](const py::bytes& model_proto_bytes) -> py::bytes {
+        InitEnv();
+        ONNX_NAMESPACE::ModelProto model;
+        ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
+                            model_proto_bytes.size());
+        const auto result = CrossLayerEqualize(model);
+        std::string out;
+        result.SerializeToString(&out);
+        return py::bytes(out.data(), out.size());
+      },
+      "model_bytes"_a);
+
   // Dynamically quantizes MatMul/Gemm weights to INT8 (per output channel,
   // symmetric) and activations to uint8 at runtime via DynamicQuantizeLinear
   // -- see QuantizeDynamic in onnxsim.h. Pure graph rewrite: no ModelExecutor

--- a/onnxsim/cross_layer_equalization_entry.cpp
+++ b/onnxsim/cross_layer_equalization_entry.cpp
@@ -1,0 +1,18 @@
+#include "cross_layer_equalization_entry.h"
+
+#include <onnx/onnx_pb.h>
+
+#include <vector>
+
+#include "custom_optimizer_passes.h"
+#include "model_prep.h"
+#include "onnxoptimizer/optimize.h"
+
+onnx::ModelProto CrossLayerEqualize(const onnx::ModelProto& model) {
+  PrepareSchemasForDebug(model);
+  // Registers cross_layer_equalization (idempotent) into onnxoptimizer's
+  // registry so OptimizeFixed can find it by name below.
+  onnxsim::RegisterCustomOptimizerPasses();
+  return onnx::optimization::OptimizeFixed(
+      model, std::vector<std::string>{"cross_layer_equalization"});
+}

--- a/onnxsim/cross_layer_equalization_entry.h
+++ b/onnxsim/cross_layer_equalization_entry.h
@@ -1,0 +1,13 @@
+#pragma once
+
+// Single-call preprocessing entry point exposed to Python, mirroring
+// quantize_entry.h's own "one named custom_optimizer_passes.cpp pass,
+// standalone via OptimizeFixed" shape -- but for cross_layer_equalization,
+// which is not itself a quantization scheme (no Quantize/DequantizeLinear
+// node is ever introduced), so it does not belong in quantize_entry.h
+// alongside the actual Quantize* schemes. See onnxsim.h for the
+// documentation this mirrors.
+
+#include <onnx/onnx_pb.h>
+
+onnx::ModelProto CrossLayerEqualize(const onnx::ModelProto& model);

--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "onnxoptimizer/optimize.h"
+#include "passes/cross_layer_equalization.h"
 #include "passes/dynamic_quantize_attention.h"
 #include "passes/dynamic_quantize_matmul.h"
 #include "passes/dynamic_quantize_matmul_integer_to_float.h"
@@ -88,6 +89,7 @@ void RegisterCustomOptimizerPasses() {
     auto& registry = ONNX_NAMESPACE::optimization::Optimizer::passes;
 
     // onnxsim-only rewrites (no built-in of the same name today).
+    RegisterOrReplace<p::CrossLayerEqualization>(registry);
     RegisterOrReplace<p::DynamicQuantizeAttention>(registry);
     RegisterOrReplace<p::DynamicQuantizeMatMul>(registry);
     RegisterOrReplace<p::DynamicQuantizeMatMulIntegerToFloat>(registry);

--- a/onnxsim/custom_optimizer_passes.h
+++ b/onnxsim/custom_optimizer_passes.h
@@ -27,6 +27,7 @@ namespace onnxsim {
 //   - fuse_gelu
 //   - fuse_gqa
 //   - fuse_layer_norm
+//   - cross_layer_equalization
 //   - dynamic_quantize_attention
 //   - dynamic_quantize_matmul
 //   - dynamic_quantize_matmul_integer_to_float

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -416,6 +416,58 @@ def import_gguf_weights(
     return result, skipped
 
 
+def cross_layer_equalize(model: Union[str, onnx.ModelProto]) -> onnx.ModelProto:
+    """
+    Data-free Cross-Layer Equalization (CLE) -- the weight-equalization
+    preprocessing technique from "Data-Free Quantization Through Weight
+    Equalization and Bias Correction" (Nagel et al., 2019), also shipped as
+    part of Qualcomm's AIMET toolkit.
+
+    This is **not** a quantization scheme: no ``Quantize``/``DequantizeLinear``
+    node is ever introduced, and the model's computed function is unchanged
+    bit-for-bit -- only its internal weight *parameterization* changes. Run
+    it *before* one of onnxsim's ``quantize_*`` functions to make the
+    per-tensor or per-channel quantization that follows more accurate.
+
+    For every pair of adjacent Conv layers ``Conv1 -> [activation] -> Conv2``
+    where the activation (if any) is positive-homogeneous of degree 1 --
+    ``f(a*x) == a*f(x)`` for every ``a > 0``, true of ``Relu``/``PRelu``/
+    ``LeakyRelu`` and trivially true of "no activation at all" -- and both
+    convs have ``group == 1``, this rescales each shared channel ``c`` by
+    ``S[c] = sqrt(r1[c] / r2[c])`` (``r1``/``r2`` being Conv1's/Conv2's own
+    per-channel weight range): Conv1's weight/bias for channel ``c`` divided
+    by ``S[c]``, Conv2's weight for channel ``c`` multiplied by ``S[c]``.
+    This makes the two layers' per-channel weight ranges identical -- the
+    most balanced a fixed pair can be -- without changing the composed
+    function at all, since the activation's positive homogeneity is exactly
+    what lets ``S[c]`` and ``1/S[c]`` cancel across it. A single call already
+    equalizes a whole chain of layers, not just one adjacent pair: onnxsim
+    reruns this pass, along with every other registered pass, to a
+    network-wide fixed point.
+
+    Scope of this implementation (each just declines the match rather than
+    mishandling it -- not correctness bugs):
+
+    - Conv only (no ConvTranspose, no Gemm/MatMul-based fully-connected
+      equalization).
+    - ``group`` must be 1 on both convs.
+    - FLOAT32 weights/bias only.
+    - No "high-bias absorption" (AIMET's optional follow-up step for a
+      following BatchNorm's bias) -- plain BN folding (already part of
+      :func:`simplify`) upstream of this pass covers the common case fine on
+      its own.
+
+    This is a single, self-contained graph rewrite: unlike :func:`simplify`,
+    it does not run shape inference, constant folding, or any other pass.
+
+    :param model: onnx ModelProto object or file path
+    :returns: the equalized onnx ModelProto
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    return onnx.load_from_string(C.cross_layer_equalize(model.SerializeToString()))
+
+
 def quantize_dynamic(model: Union[str, onnx.ModelProto]) -> onnx.ModelProto:
     """
     Dynamically quantize every MatMul, and every "vanilla" Gemm (transA=0,

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -139,6 +139,38 @@ onnx::ModelProto FoldConstantOnce(const ModelExecutor& executor,
                                   size_t tensor_size_threshold,
                                   bool initializers_as_constants = true);
 
+// Cross-Layer Equalization (CLE) -- the data-free weight-equalization
+// preprocessing technique from "Data-Free Quantization Through Weight
+// Equalization and Bias Correction" (Nagel et al., 2019), also shipped as
+// part of Qualcomm's AIMET toolkit. This is NOT a quantization scheme --
+// no Quantize/DequantizeLinear node is ever introduced, and every value
+// this produces is bit-for-bit the same computation as the input model, just
+// reparameterized -- it is meant to run *before* a quantize_* function, to
+// make the per-tensor or per-channel quantization that follows more
+// accurate.
+//
+// For every pair of adjacent Conv layers Conv1 -> [activation] -> Conv2
+// where the activation (if any) is positive-homogeneous of degree 1 --
+// f(a*x) = a*f(x) for every a > 0, true of Relu/PRelu/LeakyRelu and
+// trivially true of "no activation at all" -- and both convs have `group`
+// == 1, rescales each shared channel c by S[c] = sqrt(r1[c] / r2[c])
+// (r1[c]/r2[c] being Conv1's/Conv2's own per-channel weight range):
+// Conv1's weight/bias for channel c divided by S[c], Conv2's weight for
+// channel c multiplied by S[c]. This makes the two layers' per-channel
+// weight ranges identical (the most balanced a fixed pair can be), without
+// changing the composed function at all -- the activation's positive
+// homogeneity is exactly what lets S[c] and 1/S[c] cancel across it. See
+// ``passes/cross_layer_equalization.h`` for the full derivation, the
+// documented scope limitations (Conv only, no ConvTranspose or Gemm/MatMul,
+// FLOAT32 only), and why one call already equalizes a whole chain of layers
+// (not just one adjacent pair) via onnxsim's fixed-point pass driver.
+//
+// Unlike ``Simplify``, this does not run shape inference, constant folding or
+// any other simplification pass -- it applies exactly this one rewrite,
+// repeated to a fixed point, to a copy of ``model`` (which is left
+// untouched) and returns the result.
+onnx::ModelProto CrossLayerEqualize(const onnx::ModelProto& model);
+
 // Dynamically quantizes every MatMul, and every "vanilla" Gemm (transA=0,
 // alpha=1, beta=1), whose weight is a constant 2-D float32 tensor: the weight
 // is quantized to INT8 ahead of time (per output channel, symmetric, from its

--- a/onnxsim/passes/cross_layer_equalization.h
+++ b/onnxsim/passes/cross_layer_equalization.h
@@ -1,0 +1,357 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+// Cross-Layer Equalization (CLE) -- the data-free weight-equalization
+// technique from "Data-Free Quantization Through Weight Equalization and
+// Bias Correction" (Nagel et al., 2019) and shipped as part of Qualcomm's
+// AIMET toolkit. It is a *preprocessing* step for quantization, not a
+// quantization scheme itself: run it before a quantize_* pass (this file has
+// no `_quantize_` in its own pass name and never introduces a
+// Quantize/DequantizeLinear node), to make the surrounding per-tensor or
+// per-channel quantization that follows more accurate.
+//
+// The problem it addresses: two adjacent Conv layers can have very different
+// per-channel weight magnitudes (e.g. one channel with a 100x larger range
+// than its neighbors), which forces a shared quantization scale to either
+// waste most of its resolution on the small channels or clip the large one.
+// CLE removes that imbalance losslessly, for a fixed pair of layers
+// Conv1 -> [activation] -> Conv2 where the activation (if any) is positive-
+// homogeneous of degree 1 -- f(a*x) = a*f(x) for every a > 0, true of Relu,
+// PRelu, and LeakyRelu (and trivially true of "no activation at all") --
+// by picking, per shared channel c, a scale
+//
+//   S[c] = sqrt(r1[c] / r2[c])
+//
+// where r1[c] = max(|Conv1's output-channel-c weights|) and
+// r2[c] = max(|Conv2's input-channel-c weights|), then rewriting
+//
+//   W1'[c, ...] = W1[c, ...] / S[c];  b1'[c] = b1[c] / S[c]
+//   W2'[:, c, ...] = W2[:, c, ...] * S[c]
+//
+// Because the activation between them commutes with a positive scale,
+// Conv1'(x) = Conv1(x) / S elementwise per channel, the activation passes
+// that /S through unchanged, and Conv2' undoes it exactly (* S) -- so the
+// composed function Conv1 -> activation -> Conv2 is *exactly* unchanged
+// (same as BatchNorm folding, not an approximation), while r1'[c] == r2'[c]
+// for every c: the two layers' per-channel ranges are now identical, which
+// is the most balanced a fixed pair can be made.
+//
+// Scope of this implementation (documented limitations, not correctness
+// bugs -- each just declines the match rather than mishandling it):
+//   - Conv only (no ConvTranspose, no Gemm/MatMul-based fully-connected
+//     equalization -- AIMET supports FC layers too, via the same math on a
+//     2-D weight; not implemented here).
+//   - `group` must be 1 on both convs -- a grouped/depthwise conv's input
+//     and output channels don't correspond 1:1, which this pass's channel
+//     bookkeeping assumes.
+//   - FLOAT32 weights/bias only (mirrors fuse_bn_into_conv.h's own
+//     "currently works for only DOUBLE, FLOAT32" scope, minus DOUBLE).
+//   - No "high-bias absorption" (AIMET's optional follow-up step that moves
+//     part of Conv1's post-activation bias forward into a following
+//     BatchNorm's bias when equalization alone leaves Conv1's activations
+//     with an unusually large bias). Plain BN folding (fuse_bn_into_conv)
+//     upstream of this pass covers the common case fine on its own.
+//
+// Iterates to a network-wide fixed point for free: onnxsim's
+// FixedPointPassManager reruns every registered pass, including this one,
+// until no pass reports a change (see custom_optimizer_passes.cpp), so
+// equalizing (Conv1, Conv2) and then, in the same fixed-point sweep,
+// (Conv2, Conv3) naturally propagates balance across a whole chain of
+// layers -- exactly what the paper's own multi-round equalization does --
+// without this file needing its own outer iteration loop.
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+#include "passes/quantize_conv_common.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+struct CrossLayerEqualization final : public PredicateBasedPass {
+  explicit CrossLayerEqualization()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+
+  std::string getPassName() const override {
+    return "cross_layer_equalization";
+  }
+
+  // A matched, fully-validated Conv1 -> [activation] -> Conv2 chain, ready
+  // for RescaleAndApply() below. `activation` is nullptr when Conv1 feeds
+  // Conv2 directly (also valid: the identity function is positive-
+  // homogeneous too).
+  struct Match {
+    Node* conv1 = nullptr;
+    Node* conv2 = nullptr;
+    Node* activation = nullptr;
+    const Tensor* w1 = nullptr;
+    const Tensor* w2 = nullptr;
+    const Tensor* b1 = nullptr;  // nullptr if conv1 has no bias input
+  };
+
+  static bool IsPassThroughActivation(Node* n) {
+    return CheckKind(n, "Relu") || CheckKind(n, "PRelu") ||
+           CheckKind(n, "LeakyRelu");
+  }
+
+  // Conv weight layout is [Cout, Cin/group, k...]; only group == 1 gives a
+  // clean 1:1 channel correspondence with the adjacent conv, which is what
+  // this pass's per-channel bookkeeping assumes throughout.
+  static bool HasSingleGroup(Node* conv) {
+    return GetValueFromAttrWithDefault(conv, "group", (int64_t)1) == 1;
+  }
+
+  // Validates `conv`'s weight (and bias, if present) are constant FLOAT32
+  // tensors of the right rank, filling `w_out`/`b_out`. Shared by both
+  // Conv1 and Conv2's checks below -- they need the identical validation,
+  // just applied to different nodes.
+  static bool ValidateConvWeights(Node* conv, const Tensor*& w_out,
+                                  const Tensor*& b_out) {
+    const size_t num_inputs = conv->inputs().size();
+    if (conv->kind() != kConv || (num_inputs != 2 && num_inputs != 3)) {
+      return false;
+    }
+    if (!HasSingleGroup(conv) || !IsConstantTensor(conv, 1)) {
+      return false;
+    }
+    const Tensor* w_t = FetchConstantTensor(conv->inputs()[1]);
+    if (w_t->elem_type() != TensorProto_DataType_FLOAT ||
+        w_t->sizes().size() < 2) {
+      return false;
+    }
+    const Tensor* b_t = nullptr;
+    if (num_inputs == 3) {
+      if (!IsConstantTensor(conv, 2)) {
+        return false;
+      }
+      b_t = FetchConstantTensor(conv->inputs()[2]);
+      if (b_t->elem_type() != TensorProto_DataType_FLOAT) {
+        return false;
+      }
+    }
+    w_out = w_t;
+    b_out = b_t;
+    return true;
+  }
+
+  // `conv2` is the node PredicateBasedPass's graph walk hands us; CLE always
+  // matches on the *second* conv of a pair and looks backward, the same
+  // shape as fuse_bn_into_conv.h matching on BatchNormalization and walking
+  // back to its producing Conv.
+  static bool TryMatch(Node* conv2, Match& m) {
+    const Tensor* w2_t = nullptr;
+    const Tensor* unused_b2 = nullptr;
+    if (!ValidateConvWeights(conv2, w2_t, unused_b2)) {
+      return false;
+    }
+
+    // conv2's activation input must have no other consumer -- otherwise
+    // rescaling what feeds conv2 would change that other consumer's input
+    // too, which is not this pass's to alter.
+    Value* feed = conv2->inputs()[0];
+    if (feed->uses().size() != 1) {
+      return false;
+    }
+    Node* producer = feed->node();
+    Node* activation = nullptr;
+    Node* conv1 = producer;
+    if (producer->kind() != kConv) {
+      if (!IsPassThroughActivation(producer) || producer->inputs().empty()) {
+        return false;
+      }
+      Value* act_in = producer->inputs()[0];
+      // Same reasoning as above, one hop further back: conv1's output must
+      // feed only this activation.
+      if (act_in->uses().size() != 1) {
+        return false;
+      }
+      activation = producer;
+      conv1 = act_in->node();
+    }
+
+    const Tensor* w1_t = nullptr;
+    const Tensor* b1_t = nullptr;
+    if (!ValidateConvWeights(conv1, w1_t, b1_t)) {
+      return false;
+    }
+
+    // Channel correspondence: conv1's output channels (w1's axis 0) are
+    // conv2's input channels (w2's axis 1, since group == 1 on both).
+    // Already implied by the graph being a valid ONNX model, but checked
+    // directly rather than assumed.
+    if (w1_t->sizes()[0] != w2_t->sizes()[1]) {
+      return false;
+    }
+
+    m.conv1 = conv1;
+    m.conv2 = conv2;
+    m.activation = activation;
+    m.w1 = w1_t;
+    m.w2 = w2_t;
+    m.b1 = b1_t;
+    return true;
+  }
+
+  // Computes the per-channel scale and, if any channel needs a meaningful
+  // rescale, rewrites conv1's weight/bias and conv2's weight in place.
+  // Returns false (no graph change) when the pair is already balanced --
+  // this is what lets the fixed-point driver converge instead of looping
+  // forever re-applying a no-op: a single application already makes
+  // r1'[c] == r2'[c] exactly for a fixed pair (see this file's own top
+  // comment), so a channel only needs rescaling again after a *different*
+  // pass application changed one of its neighbors.
+  static bool RescaleAndApply(const Match& m, Graph& graph) {
+    const auto& s1 = m.w1->sizes();  // [C, Cin1, k...]
+    const auto& s2 = m.w2->sizes();  // [Cout2, C, k...]
+    const int64_t C = s1[0];
+    int64_t inner1 = 1;
+    for (size_t i = 1; i < s1.size(); ++i) {
+      inner1 *= s1[i];
+    }
+    const int64_t outer2 = s2[0];
+    int64_t inner2 = 1;
+    for (size_t i = 2; i < s2.size(); ++i) {
+      inner2 *= s2[i];
+    }
+
+    std::vector<float> w1 = ReadFloatTensorFlat(*m.w1);
+    std::vector<float> w2 = ReadFloatTensorFlat(*m.w2);
+    std::vector<float> b1 =
+        m.b1 != nullptr ? ReadFloatTensorFlat(*m.b1) : std::vector<float>();
+
+    // r1[c] = max(|W1[c, ...]|) -- conv1's own per-output-channel range.
+    std::vector<float> r1(static_cast<size_t>(C), 0.0f);
+    for (int64_t c = 0; c < C; ++c) {
+      for (int64_t j = 0; j < inner1; ++j) {
+        r1[static_cast<size_t>(c)] =
+            std::max(r1[static_cast<size_t>(c)],
+                     std::fabs(w1[static_cast<size_t>(c * inner1 + j)]));
+      }
+    }
+    // r2[c] = max(|W2[:, c, ...]|) -- conv2's per-*input*-channel range.
+    std::vector<float> r2(static_cast<size_t>(C), 0.0f);
+    for (int64_t o = 0; o < outer2; ++o) {
+      for (int64_t c = 0; c < C; ++c) {
+        for (int64_t j = 0; j < inner2; ++j) {
+          const int64_t idx = o * C * inner2 + c * inner2 + j;
+          r2[static_cast<size_t>(c)] =
+              std::max(r2[static_cast<size_t>(c)],
+                       std::fabs(w2[static_cast<size_t>(idx)]));
+        }
+      }
+    }
+
+    // A channel with either range at 0 (a dead/all-zero weight slice) is
+    // left unscaled (S=1) -- there is no meaningful ratio to balance, and
+    // dividing by 0 would poison the whole channel with inf/NaN.
+    std::vector<float> s(static_cast<size_t>(C), 1.0f);
+    bool any_change = false;
+    constexpr float kConvergedTol = 1e-3f;
+    for (int64_t c = 0; c < C; ++c) {
+      const float r1c = r1[static_cast<size_t>(c)];
+      const float r2c = r2[static_cast<size_t>(c)];
+      if (r1c > 0.0f && r2c > 0.0f) {
+        const float sc = std::sqrt(r1c / r2c);
+        s[static_cast<size_t>(c)] = sc;
+        if (std::fabs(sc - 1.0f) > kConvergedTol) {
+          any_change = true;
+        }
+      }
+    }
+    if (!any_change) {
+      return false;
+    }
+
+    for (int64_t c = 0; c < C; ++c) {
+      const float sc = s[static_cast<size_t>(c)];
+      for (int64_t j = 0; j < inner1; ++j) {
+        w1[static_cast<size_t>(c * inner1 + j)] /= sc;
+      }
+      if (m.b1 != nullptr) {
+        b1[static_cast<size_t>(c)] /= sc;
+      }
+    }
+    for (int64_t o = 0; o < outer2; ++o) {
+      for (int64_t c = 0; c < C; ++c) {
+        const float sc = s[static_cast<size_t>(c)];
+        for (int64_t j = 0; j < inner2; ++j) {
+          const int64_t idx = o * C * inner2 + c * inner2 + j;
+          w2[static_cast<size_t>(idx)] *= sc;
+        }
+      }
+    }
+
+    Tensor w1_new;
+    w1_new.elem_type() = TensorProto_DataType_FLOAT;
+    w1_new.sizes() = s1;
+    w1_new.floats() = std::move(w1);
+    Value* w1_value = graph.addInitializerAndCreateValue(w1_new);
+    Value* old_w1_value = m.conv1->inputs()[1];
+    m.conv1->replaceInput(1, w1_value);
+    if (old_w1_value->uses().size() == 0) {
+      graph.eraseInitializerAndInput(old_w1_value);
+    }
+
+    if (m.b1 != nullptr) {
+      Tensor b1_new;
+      b1_new.elem_type() = TensorProto_DataType_FLOAT;
+      b1_new.sizes() = m.b1->sizes();
+      b1_new.floats() = std::move(b1);
+      Value* b1_value = graph.addInitializerAndCreateValue(b1_new);
+      Value* old_b1_value = m.conv1->inputs()[2];
+      m.conv1->replaceInput(2, b1_value);
+      if (old_b1_value->uses().size() == 0) {
+        graph.eraseInitializerAndInput(old_b1_value);
+      }
+    }
+
+    Tensor w2_new;
+    w2_new.elem_type() = TensorProto_DataType_FLOAT;
+    w2_new.sizes() = s2;
+    w2_new.floats() = std::move(w2);
+    Value* w2_value = graph.addInitializerAndCreateValue(w2_new);
+    Value* old_w2_value = m.conv2->inputs()[1];
+    m.conv2->replaceInput(1, w2_value);
+    if (old_w2_value->uses().size() == 0) {
+      graph.eraseInitializerAndInput(old_w2_value);
+    }
+
+    return true;
+  }
+
+  bool patternMatchPredicate(Node* n) override {
+    Match m;
+    return TryMatch(n, m);
+  }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    // Neither conv is ever destroyed -- only their weight/bias *inputs*
+    // change, same as fuse_mul_into_conv.h's own DestroyZero convention for
+    // an in-place rewrite that removes no node.
+    destroy_current = NodeDestroyType::DestroyZero;
+    Match m;
+    if (!TryMatch(n, m)) {
+      return false;
+    }
+    return RescaleAndApply(m, graph);
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/tests/test_cross_layer_equalization.py
+++ b/tests/test_cross_layer_equalization.py
@@ -1,0 +1,310 @@
+"""Tests for ``onnxsim.cross_layer_equalize`` (the ``cross_layer_equalization``
+C++ pass) -- the data-free weight-equalization preprocessing technique from
+"Data-Free Quantization Through Weight Equalization and Bias Correction"
+(Nagel et al., 2019), also shipped as part of Qualcomm's AIMET toolkit.
+
+Unlike this repo's quantize_* passes, CLE is supposed to be *exact*: it only
+reparameterizes a Conv1 -> [activation] -> Conv2 pair's weights, never
+changes the composed function. So these tests check near-bit-exact numeric
+equivalence (``np.testing.assert_allclose`` with a tight tolerance), not the
+lossy relative-L2 comparison this repo's quantize_* tests use, and directly
+check that channel ranges actually rebalance (not just "the output didn't
+change" -- a pass that declined to do anything would pass that check too).
+"""
+
+import collections
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+
+import onnxsim
+
+# A bare ``import onnxruntime`` would fail collection (not skip the test) on
+# platforms onnxruntime doesn't ship wheels for.
+ort = pytest.importorskip("onnxruntime")
+
+
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(np.asarray(array, dtype=np.float32), name)
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _op_counts(model):
+    return collections.Counter(n.op_type for n in model.graph.node)
+
+
+def _weight_by_name(model, name):
+    for t in model.graph.initializer:
+        if t.name == name:
+            return onnx.numpy_helper.to_array(t)
+    raise KeyError(name)
+
+
+def _conv_weight(model, output_name):
+    """The weight initializer feeding the Conv node whose output is
+    `output_name` -- resolved by name since cross_layer_equalize replaces
+    the initializer object (new name) but not the Conv node itself."""
+    for n in model.graph.node:
+        if n.op_type == "Conv" and n.output[0] == output_name:
+            return _weight_by_name(model, n.input[1])
+    raise KeyError(output_name)
+
+
+def _conv_chain_model(
+    activation="relu",
+    group2=1,
+    branch=False,
+    c1_out=8,
+    c1_in=4,
+    c2_out=4,
+    seed=0,
+    outlier_channels=(0,),
+    outlier_scale=30.0,
+    opset=13,
+):
+    """Conv1(c1_in -> c1_out) -> [activation] -> Conv2(c1_out -> c2_out),
+    with `outlier_channels` of Conv1's weight scaled up by `outlier_scale`
+    to create a channel-range imbalance for CLE to fix. `activation` is
+    "relu", "prelu", "clip" (NOT scale-invariant -- CLE must decline),
+    or None (direct Conv1 -> Conv2, still valid for CLE)."""
+    rng = np.random.default_rng(seed)
+    w1 = rng.standard_normal((c1_out, c1_in, 3, 3)).astype(np.float32) * 0.1
+    for c in outlier_channels:
+        w1[c] *= outlier_scale
+    b1 = rng.standard_normal(c1_out).astype(np.float32) * 0.01
+    w2 = rng.standard_normal((c2_out, c1_out // group2, 3, 3)).astype(np.float32) * 0.1
+    b2 = rng.standard_normal(c2_out).astype(np.float32) * 0.01
+
+    nodes = [
+        onnx.helper.make_node(
+            "Conv", ["x", "w1", "b1"], ["c1"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
+        )
+    ]
+    inits = [_f32(w1, "w1"), _f32(b1, "b1"), _f32(w2, "w2"), _f32(b2, "b2")]
+    feed = "c1"
+    if activation == "relu":
+        nodes.append(onnx.helper.make_node("Relu", ["c1"], ["act"]))
+        feed = "act"
+    elif activation == "prelu":
+        slope = np.full(c1_out, 0.1, dtype=np.float32)
+        inits.append(_f32(slope, "slope"))
+        nodes.append(onnx.helper.make_node("PRelu", ["c1", "slope"], ["act"]))
+        feed = "act"
+    elif activation == "clip":
+        inits.append(_f32(np.float32(0.0), "clip_min"))
+        inits.append(_f32(np.float32(6.0), "clip_max"))
+        nodes.append(
+            onnx.helper.make_node("Clip", ["c1", "clip_min", "clip_max"], ["act"])
+        )
+        feed = "act"
+    elif activation is not None:
+        raise ValueError(activation)
+
+    conv2_kwargs = {"kernel_shape": [3, 3], "pads": [1, 1, 1, 1]}
+    if group2 != 1:
+        conv2_kwargs["group"] = group2
+    nodes.append(
+        onnx.helper.make_node("Conv", [feed, "w2", "b2"], ["y"], **conv2_kwargs)
+    )
+    outputs = [_vi("y", [1, c2_out, 8, 8])]
+    if branch:
+        nodes.append(onnx.helper.make_node("Identity", [feed], ["branch_out"]))
+        outputs.append(_vi("branch_out", [1, c1_out, 8, 8]))
+
+    graph = onnx.helper.make_graph(
+        nodes, "g", [_vi("x", [1, c1_in, 8, 8])], outputs, inits
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=8
+    )
+    return model, w1
+
+
+def test_equalize_rebalances_channel_ranges_through_relu():
+    model, w1 = _conv_chain_model(activation="relu")
+    equalized = onnxsim.cross_layer_equalize(model)
+    onnx.checker.check_model(equalized)
+
+    new_w1 = _conv_weight(equalized, "c1")
+    new_w2 = _conv_weight(equalized, "y")
+    assert not np.allclose(w1, new_w1)  # actually rescaled, not a no-op
+
+    c1_out = w1.shape[0]
+    r1 = np.abs(new_w1).reshape(c1_out, -1).max(axis=1)
+    r2 = np.abs(new_w2).transpose(1, 0, 2, 3).reshape(c1_out, -1).max(axis=1)
+    np.testing.assert_allclose(r1, r2, rtol=1e-3)
+
+
+def test_equalize_preserves_model_output_through_relu():
+    model, _ = _conv_chain_model(activation="relu", seed=1)
+    equalized = onnxsim.cross_layer_equalize(model)
+    onnx.checker.check_model(equalized)
+
+    rng = np.random.default_rng(7)
+    x = rng.standard_normal((1, 4, 8, 8)).astype(np.float32)
+    (out_before,) = _run(model, {"x": x})
+    (out_after,) = _run(equalized, {"x": x})
+    np.testing.assert_allclose(out_before, out_after, rtol=1e-4, atol=1e-4)
+
+
+def test_equalize_preserves_model_output_through_prelu():
+    model, _ = _conv_chain_model(activation="prelu", seed=2)
+    equalized = onnxsim.cross_layer_equalize(model)
+    onnx.checker.check_model(equalized)
+
+    rng = np.random.default_rng(8)
+    x = rng.standard_normal((1, 4, 8, 8)).astype(np.float32)
+    (out_before,) = _run(model, {"x": x})
+    (out_after,) = _run(equalized, {"x": x})
+    np.testing.assert_allclose(out_before, out_after, rtol=1e-4, atol=1e-4)
+
+
+def test_equalize_handles_conv_directly_feeding_conv():
+    # No activation at all between the two convs is also a valid (trivially
+    # scale-invariant, "identity activation") case for CLE.
+    model, w1 = _conv_chain_model(activation=None, seed=3)
+    equalized = onnxsim.cross_layer_equalize(model)
+    onnx.checker.check_model(equalized)
+
+    new_w1 = _conv_weight(equalized, "c1")
+    assert not np.allclose(w1, new_w1)
+
+    rng = np.random.default_rng(9)
+    x = rng.standard_normal((1, 4, 8, 8)).astype(np.float32)
+    (out_before,) = _run(model, {"x": x})
+    (out_after,) = _run(equalized, {"x": x})
+    np.testing.assert_allclose(out_before, out_after, rtol=1e-4, atol=1e-4)
+
+
+def test_equalize_declines_clip_activation():
+    # Clip(0, 6) is not positive-homogeneous (the upper bound doesn't scale
+    # with the input) -- rescaling through it would change the function, so
+    # the pass must leave this pair untouched.
+    model, w1 = _conv_chain_model(activation="clip", seed=4)
+    equalized = onnxsim.cross_layer_equalize(model)
+    onnx.checker.check_model(equalized)
+    np.testing.assert_array_equal(w1, _conv_weight(equalized, "c1"))
+
+
+def test_equalize_declines_grouped_conv2():
+    model, w1 = _conv_chain_model(activation="relu", group2=2, seed=5)
+    equalized = onnxsim.cross_layer_equalize(model)
+    onnx.checker.check_model(equalized)
+    np.testing.assert_array_equal(w1, _conv_weight(equalized, "c1"))
+
+
+def test_equalize_declines_when_conv1_output_branches():
+    # Conv1's (post-activation) output also feeds something other than
+    # Conv2 -- rescaling it would change that other consumer's input too.
+    model, w1 = _conv_chain_model(activation="relu", branch=True, seed=6)
+    equalized = onnxsim.cross_layer_equalize(model)
+    onnx.checker.check_model(equalized)
+    np.testing.assert_array_equal(w1, _conv_weight(equalized, "c1"))
+
+
+def test_equalize_is_a_noop_on_a_model_with_no_matching_pattern():
+    x = _vi("x", [2, 4])
+    y = _vi("y", [2, 4])
+    w = _f32(np.random.default_rng(0).standard_normal((4, 4)), "w")
+    node = onnx.helper.make_node("MatMul", ["x", "w"], ["y"])
+    graph = onnx.helper.make_graph([node], "g", [x], [y], [w])
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 13)], ir_version=8
+    )
+
+    equalized = onnxsim.cross_layer_equalize(model)
+    assert _op_counts(equalized) == {"MatMul": 1}
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(model.graph.initializer[0]),
+        onnx.numpy_helper.to_array(equalized.graph.initializer[0]),
+    )
+
+
+def test_equalize_propagates_across_a_three_conv_chain():
+    # Fixed-point convergence across more than one adjacent pair: equalizing
+    # (Conv1, Conv2) changes Conv2's own weight, which the same pass call
+    # then re-equalizes against Conv3 in the same fixed-point sweep -- this
+    # is what lets a single cross_layer_equalize() call balance a whole
+    # chain of layers, not just the one pair it happens to match first. See
+    # cross_layer_equalization.h's own top comment for why no explicit outer
+    # iteration loop is needed here.
+    rng = np.random.default_rng(10)
+    channels = [4, 8, 8, 4]
+    weights, biases = [], []
+    for i in range(3):
+        w = (
+            rng.standard_normal((channels[i + 1], channels[i], 3, 3)).astype(np.float32)
+            * 0.1
+        )
+        w[0] *= 25.0
+        weights.append(w)
+        biases.append(rng.standard_normal(channels[i + 1]).astype(np.float32) * 0.01)
+
+    nodes = []
+    inits = []
+    feed = "x"
+    for i in range(3):
+        inits += [_f32(weights[i], f"w{i}"), _f32(biases[i], f"b{i}")]
+        nodes.append(
+            onnx.helper.make_node(
+                "Conv",
+                [feed, f"w{i}", f"b{i}"],
+                [f"c{i}"],
+                kernel_shape=[3, 3],
+                pads=[1, 1, 1, 1],
+            )
+        )
+        feed = f"c{i}"
+        if i < 2:
+            nodes.append(onnx.helper.make_node("Relu", [feed], [f"r{i}"]))
+            feed = f"r{i}"
+    nodes.append(onnx.helper.make_node("Identity", [feed], ["y"]))
+
+    graph = onnx.helper.make_graph(
+        nodes,
+        "g",
+        [_vi("x", [1, channels[0], 8, 8])],
+        [_vi("y", [1, channels[3], 8, 8])],
+        inits,
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 13)], ir_version=8
+    )
+    onnx.checker.check_model(model)
+
+    equalized = onnxsim.cross_layer_equalize(model)
+    onnx.checker.check_model(equalized)
+
+    # Conv1/Conv2's shared channel ranges (not just Conv0/Conv1's) should
+    # have moved from the pass also equalizing the (Conv1, Conv2) pair.
+    w1_before = weights[1]
+    w1_after = _conv_weight(equalized, "c1")
+    assert not np.allclose(w1_before, w1_after)
+
+    rng2 = np.random.default_rng(11)
+    x = rng2.standard_normal((1, channels[0], 8, 8)).astype(np.float32)
+    (out_before,) = _run(model, {"x": x})
+    (out_after,) = _run(equalized, {"x": x})
+    np.testing.assert_allclose(out_before, out_after, rtol=1e-4, atol=1e-4)
+
+
+def test_equalize_is_idempotent():
+    model, _ = _conv_chain_model(activation="relu", seed=12)
+    once = onnxsim.cross_layer_equalize(model)
+    twice = onnxsim.cross_layer_equalize(once)
+    np.testing.assert_allclose(
+        _conv_weight(once, "c1"), _conv_weight(twice, "c1"), rtol=1e-4, atol=1e-6
+    )


### PR DESCRIPTION
## Summary

Follow-up to "could you implement some quantization features of AIMET?" -- AIMET's quantization toolkit spans several very differently-shaped pieces (post-training equalization, bias correction, AdaRound's per-layer optimization, QAT range learning, AutoQuant). Given onnxsim's architecture (graph-rewrite passes, no training loop), Cross-Layer Equalization (CLE) is the best fit: a pure graph rewrite with no calibration data, training loop, or per-layer numeric optimization needed, so it drops directly into the existing `PredicateBasedPass` architecture.

**What it does**: implements the weight-equalization technique from ["Data-Free Quantization Through Weight Equalization and Bias Correction"](https://arxiv.org/abs/1906.04721) (Nagel et al., 2019), also shipped as part of Qualcomm's AIMET toolkit. It is a *preprocessing* step, not a quantization scheme -- run it before a `quantize_*` function to make the per-tensor/per-channel quantization that follows more accurate.

For every `Conv1 -> [Relu/PRelu/LeakyRelu or nothing] -> Conv2` pair (`group == 1` on both, FLOAT32 weights), it rescales each shared channel `c` by `S[c] = sqrt(r1[c] / r2[c])` (`r1`/`r2` being each conv's own per-channel weight range): Conv1's weight/bias divided by `S[c]`, Conv2's weight multiplied by `S[c]`. This makes the two layers' per-channel ranges identical -- the most balanced a fixed pair can be -- **without changing the composed function at all**: the activation's positive homogeneity (`f(a*x) == a*f(x)` for `a > 0`) is exactly what lets `S[c]` and `1/S[c]` cancel across it.

A single call already equalizes a whole chain of layers, not just one adjacent pair: onnxsim's `FixedPointPassManager` reruns every registered pass to convergence, so equalizing `(Conv1, Conv2)` and then, in the same sweep, `(Conv2, Conv3)` propagates balance across the chain -- exactly what the paper's own multi-round equalization does, with no extra iteration loop needed in this code.

**Scope** (documented limitations, each declines the match rather than mishandling it): Conv only (no ConvTranspose, no Gemm/MatMul), `group == 1` on both convs, FLOAT32 only, no "high-bias absorption" (AIMET's optional BatchNorm-bias follow-up -- plain BN folding, already part of `simplify()`, covers the common case).

## New files

- `onnxsim/passes/cross_layer_equalization.h` -- the pass
- `onnxsim/cross_layer_equalization_entry.{h,cpp}` -- standalone C++ entry point (kept separate from `quantize_entry.cpp` since this isn't a quantization scheme)
- `onnxsim/onnx_simplifier.py`'s `cross_layer_equalize()` -- the Python wrapper
- `tests/test_cross_layer_equalization.py`

## Test plan

- `tests/test_cross_layer_equalization.py` (10 new tests): channel-range rebalancing, numeric exactness (`np.testing.assert_allclose`, not the lossy relative-L2 check this repo's quantize tests use, since CLE is supposed to be exact) through Relu/PRelu/no-activation, declining a non-scale-invariant activation (Clip) / grouped Conv2 / a branching consumer, a clean no-op on a model with no matching pattern, propagation across a 3-Conv chain, and idempotency.
- `pytest tests/test_cross_layer_equalization.py tests/test_fusion_patterns.py tests/test_simple.py tests/test_weight_only_quantize.py tests/test_accuracy.py tests/test_quantize_fusion_composition.py` -> 104 passed (2 failures are a pre-existing missing optional `onnxscript` dependency in this sandbox, unrelated to this change and reproducing on `master` too).
- `ruff format --check` / `ruff check` clean; `mypy` shows no new errors in changed files; `clang-format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_