### PR TITLE
Record structural changes from simplification in model metadata

### DIFF
--- a/onnxsim/model_info.cpp
+++ b/onnxsim/model_info.cpp
@@ -599,8 +599,6 @@ std::string FormatGraphDiff(const onnx::ModelProto& model_ori,
   return out;
 }
 
-namespace {
-
 // Joins up to `limit` entries of `items` with ", ", appending a "... (+N
 // more)" marker when there were more. The metadata_props-value counterpart of
 // ``AppendCapped``: that one writes one line per entry into a multi-line
@@ -618,7 +616,12 @@ std::string JoinCapped(const std::vector<std::string>& items, size_t limit) {
   return out;
 }
 
-}  // namespace
+void RecordCappedListMetadata(onnx::ModelProto& model, const std::string& key,
+                              const std::vector<std::string>& items,
+                              size_t limit) {
+  SetMetadata(model, key + ".count", std::to_string(items.size()));
+  SetMetadata(model, key, JoinCapped(items, limit));
+}
 
 void RecordSimplifyDiffMetadata(onnx::ModelProto& sim_model,
                                 const onnx::ModelProto& model_ori,
@@ -635,14 +638,8 @@ void RecordSimplifyDiffMetadata(onnx::ModelProto& sim_model,
     changed.push_back(NodeLabel(before) + " -> " + NodeLabel(after));
   }
 
-  SetMetadata(sim_model, "onnxsim.removed_nodes.count",
-              std::to_string(diff.removed_nodes.size()));
-  SetMetadata(sim_model, "onnxsim.removed_nodes", JoinCapped(removed, limit));
-  SetMetadata(sim_model, "onnxsim.changed_nodes.count",
-              std::to_string(diff.changed_nodes.size()));
-  SetMetadata(sim_model, "onnxsim.changed_nodes", JoinCapped(changed, limit));
-  SetMetadata(sim_model, "onnxsim.removed_values.count",
-              std::to_string(diff.removed_values.size()));
-  SetMetadata(sim_model, "onnxsim.removed_values",
-              JoinCapped(diff.removed_values, limit));
+  RecordCappedListMetadata(sim_model, "onnxsim.removed_nodes", removed, limit);
+  RecordCappedListMetadata(sim_model, "onnxsim.changed_nodes", changed, limit);
+  RecordCappedListMetadata(sim_model, "onnxsim.removed_values",
+                           diff.removed_values, limit);
 }

--- a/onnxsim/model_info.cpp
+++ b/onnxsim/model_info.cpp
@@ -598,3 +598,51 @@ std::string FormatGraphDiff(const onnx::ModelProto& model_ori,
 
   return out;
 }
+
+namespace {
+
+// Joins up to `limit` entries of `items` with ", ", appending a "... (+N
+// more)" marker when there were more. The metadata_props-value counterpart of
+// ``AppendCapped``: that one writes one line per entry into a multi-line
+// report, but a metadata_props value is a single flat string, so this stays
+// on one line.
+std::string JoinCapped(const std::vector<std::string>& items, size_t limit) {
+  std::string out;
+  for (size_t i = 0; i < items.size() && i < limit; ++i) {
+    if (i > 0) out += ", ";
+    out += items[i];
+  }
+  if (items.size() > limit) {
+    out += ", ... (+" + std::to_string(items.size() - limit) + " more)";
+  }
+  return out;
+}
+
+}  // namespace
+
+void RecordSimplifyDiffMetadata(onnx::ModelProto& sim_model,
+                                const onnx::ModelProto& model_ori,
+                                size_t limit) {
+  const GraphDiff diff = DiffGraphs(model_ori, sim_model);
+
+  std::vector<std::string> removed;
+  removed.reserve(diff.removed_nodes.size());
+  for (const auto& n : diff.removed_nodes) removed.push_back(NodeLabel(n));
+
+  std::vector<std::string> changed;
+  changed.reserve(diff.changed_nodes.size());
+  for (const auto& [before, after] : diff.changed_nodes) {
+    changed.push_back(NodeLabel(before) + " -> " + NodeLabel(after));
+  }
+
+  SetMetadata(sim_model, "onnxsim.removed_nodes.count",
+             std::to_string(diff.removed_nodes.size()));
+  SetMetadata(sim_model, "onnxsim.removed_nodes", JoinCapped(removed, limit));
+  SetMetadata(sim_model, "onnxsim.changed_nodes.count",
+             std::to_string(diff.changed_nodes.size()));
+  SetMetadata(sim_model, "onnxsim.changed_nodes", JoinCapped(changed, limit));
+  SetMetadata(sim_model, "onnxsim.removed_values.count",
+             std::to_string(diff.removed_values.size()));
+  SetMetadata(sim_model, "onnxsim.removed_values",
+             JoinCapped(diff.removed_values, limit));
+}

--- a/onnxsim/model_info.cpp
+++ b/onnxsim/model_info.cpp
@@ -636,13 +636,13 @@ void RecordSimplifyDiffMetadata(onnx::ModelProto& sim_model,
   }
 
   SetMetadata(sim_model, "onnxsim.removed_nodes.count",
-             std::to_string(diff.removed_nodes.size()));
+              std::to_string(diff.removed_nodes.size()));
   SetMetadata(sim_model, "onnxsim.removed_nodes", JoinCapped(removed, limit));
   SetMetadata(sim_model, "onnxsim.changed_nodes.count",
-             std::to_string(diff.changed_nodes.size()));
+              std::to_string(diff.changed_nodes.size()));
   SetMetadata(sim_model, "onnxsim.changed_nodes", JoinCapped(changed, limit));
   SetMetadata(sim_model, "onnxsim.removed_values.count",
-             std::to_string(diff.removed_values.size()));
+              std::to_string(diff.removed_values.size()));
   SetMetadata(sim_model, "onnxsim.removed_values",
-             JoinCapped(diff.removed_values, limit));
+              JoinCapped(diff.removed_values, limit));
 }

--- a/onnxsim/model_info.h
+++ b/onnxsim/model_info.h
@@ -149,3 +149,22 @@ std::string FormatGraphDiff(const onnx::ModelProto& model_ori,
 void RecordSimplifyDiffMetadata(onnx::ModelProto& sim_model,
                                 const onnx::ModelProto& model_ori,
                                 size_t limit = 20);
+
+// Joins up to `limit` entries of `items` with ", ", appending a "... (+N
+// more)" marker when there were more -- a single-line summary suitable for
+// one metadata_props value (as opposed to ``FormatGraphDiff``'s multi-line
+// report). Shared by ``RecordSimplifyDiffMetadata`` above and by other
+// metadata-recording call sites (e.g. onnxsim.cpp's node-naming and
+// function-inlining metadata) that need the same "capped list, one line"
+// shape.
+std::string JoinCapped(const std::vector<std::string>& items, size_t limit);
+
+// Writes ``key`` (``JoinCapped(items, limit)``) and ``key + ".count"``
+// (``items.size()``, uncapped) into ``model``'s metadata_props, overwriting
+// any existing entries under those two keys. This is the common "capped
+// list plus its true count" shape used by every list-valued onnxsim.*
+// metadata entry -- ``RecordSimplifyDiffMetadata``'s three categories below,
+// and onnxsim.cpp's own node-naming / function-inlining metadata.
+void RecordCappedListMetadata(onnx::ModelProto& model, const std::string& key,
+                              const std::vector<std::string>& items,
+                              size_t limit);

--- a/onnxsim/model_info.h
+++ b/onnxsim/model_info.h
@@ -134,3 +134,18 @@ GraphDiff DiffGraphs(const onnx::ModelProto& model_ori,
 std::string FormatGraphDiff(const onnx::ModelProto& model_ori,
                             const onnx::ModelProto& model_opt,
                             size_t limit = 50);
+
+// Records a summary of what simplification changed structurally between
+// ``model_ori`` and ``sim_model`` -- nodes removed by fusion/elimination,
+// nodes changed in place under the same output name(s) (see ``DiffGraphs``),
+// and values that disappeared -- as ``metadata_props`` on ``sim_model``,
+// namespaced "onnxsim." like the rest of onnxsim's own metadata
+// (``AnnotateModelInfo``, ``RecordSimplifyOptionsMetadata``). This persists
+// the same diff ``FormatGraphDiff`` renders as a CLI report onto the model
+// itself, so a downstream consumer can see what was lost to fusion/constant
+// folding without needing the original model on hand. Each list is capped at
+// ``limit`` entries (with a paired ``*.count`` key holding the true total) to
+// keep the metadata compact on large graphs.
+void RecordSimplifyDiffMetadata(onnx::ModelProto& sim_model,
+                                const onnx::ModelProto& model_ori,
+                                size_t limit = 20);

--- a/onnxsim/model_prep.cpp
+++ b/onnxsim/model_prep.cpp
@@ -239,8 +239,8 @@ void CollectNodeNames(const onnx::GraphProto& graph,
 // graph (including names generated earlier in this pass). Subgraphs are handled
 // recursively so nodes inside If/Loop/Scan bodies are named too.
 void AssignMissingNodeNames(onnx::GraphProto& graph,
-                            std::set<std::string>& used_names,
-                            size_t& counter) {
+                            std::set<std::string>& used_names, size_t& counter,
+                            std::vector<std::string>& assigned) {
   for (auto& node : *graph.mutable_node()) {
     if (node.name().empty()) {
       std::string name;
@@ -249,24 +249,28 @@ void AssignMissingNodeNames(onnx::GraphProto& graph,
       } while (used_names.count(name) > 0);
       used_names.insert(name);
       node.set_name(name);
+      assigned.push_back(name);
     }
     for (auto& attr : *node.mutable_attribute()) {
       if (attr.has_g()) {
-        AssignMissingNodeNames(*attr.mutable_g(), used_names, counter);
+        AssignMissingNodeNames(*attr.mutable_g(), used_names, counter,
+                               assigned);
       }
       for (auto& subgraph : *attr.mutable_graphs()) {
-        AssignMissingNodeNames(subgraph, used_names, counter);
+        AssignMissingNodeNames(subgraph, used_names, counter, assigned);
       }
     }
   }
 }
 
 // Assign names to any nodes left nameless after simplification (issue #269).
-void AssignMissingNodeNames(onnx::ModelProto& model) {
+std::vector<std::string> AssignMissingNodeNames(onnx::ModelProto& model) {
   std::set<std::string> used_names;
   CollectNodeNames(model.graph(), used_names);
   size_t counter = 0;
-  AssignMissingNodeNames(*model.mutable_graph(), used_names, counter);
+  std::vector<std::string> assigned;
+  AssignMissingNodeNames(*model.mutable_graph(), used_names, counter, assigned);
+  return assigned;
 }
 
 // Shape inference can leave behind a value_info entry that records a shape

--- a/onnxsim/model_prep.h
+++ b/onnxsim/model_prep.h
@@ -171,7 +171,9 @@ void Identity(onnx::ModelProto&);
 void RegisterCustomDefaultDomainOpSchemas(const onnx::ModelProto& model);
 
 // Assign names to any nodes left nameless after simplification (issue #269).
-void AssignMissingNodeNames(onnx::ModelProto& model);
+// Returns the names generated, in assignment order, so a caller can record
+// which nodes had no author-given name (e.g. as metadata_props).
+std::vector<std::string> AssignMissingNodeNames(onnx::ModelProto& model);
 
 // Drop value_info entries left with an UNDEFINED element type (see this
 // function's own doc comment in model_prep.cpp for why).

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -28,6 +28,7 @@
 #include "constant_folding.h"
 #include "contrib_schemas.h"
 #include "custom_optimizer_passes.h"
+#include "model_info.h"
 #include "model_prep.h"
 #include "onnx/common/file_utils.h"
 #include "onnx/common/graph_shape_inference.h"
@@ -79,11 +80,16 @@ onnx::ModelProto FoldConstantOnce(const ModelExecutor& executor,
 // Records the options this Simplify() call actually used (skip_optimizers
 // reflects any auto-added unhashable-tensor protections) as string
 // key/value pairs in the model's metadata_props, namespaced under
-// "onnxsim:" so they cannot collide with the model's own metadata. Lets a
-// downstream consumer see how a model was simplified without having to have
-// kept the original call around. Replaces any pre-existing "onnxsim:*"
-// entries (e.g. left by a previous simplify() call) rather than
-// accumulating duplicates across repeated simplification.
+// "onnxsim." -- the same dotted convention as the rest of onnxsim's own
+// metadata (AnnotateModelInfo's "onnxsim.macs" and friends, and the Python
+// side's ``model_info.METADATA_PREFIX``) -- so they cannot collide with the
+// model's own metadata. Lets a downstream consumer see how a model was
+// simplified without having to have kept the original call around. Replaces
+// any pre-existing entries under these exact keys (e.g. left by a previous
+// simplify() call) rather than accumulating duplicates across repeated
+// simplification; unlike a prefix wipe, this leaves other "onnxsim.*"
+// entries (compute metrics, the structural diff recorded by
+// RecordSimplifyDiffMetadata) untouched.
 void RecordSimplifyOptionsMetadata(
     onnx::ModelProto& model,
     const std::optional<std::vector<std::string>>& skip_optimizers,
@@ -105,22 +111,22 @@ void RecordSimplifyOptionsMetadata(
   };
 
   std::vector<std::pair<std::string, std::string>> options;
-  options.emplace_back("onnxsim:skip_optimizers",
+  options.emplace_back("onnxsim.skip_optimizers",
                        skip_optimizers ? join(*skip_optimizers) : "<all>");
-  options.emplace_back("onnxsim:constant_folding",
+  options.emplace_back("onnxsim.constant_folding",
                        constant_folding ? "true" : "false");
-  options.emplace_back("onnxsim:shape_inference",
+  options.emplace_back("onnxsim.shape_inference",
                        shape_inference ? "true" : "false");
-  options.emplace_back("onnxsim:tensor_size_threshold",
+  options.emplace_back("onnxsim.tensor_size_threshold",
                        std::to_string(tensor_size_threshold));
   options.emplace_back(
-      "onnxsim:target_opset_version",
+      "onnxsim.target_opset_version",
       target_opset_version ? std::to_string(*target_opset_version) : "");
-  options.emplace_back("onnxsim:initializers_as_constants",
+  options.emplace_back("onnxsim.initializers_as_constants",
                        initializers_as_constants ? "true" : "false");
-  options.emplace_back("onnxsim:include_inline_functions",
+  options.emplace_back("onnxsim.include_inline_functions",
                        include_inline_functions ? "true" : "false");
-  options.emplace_back("onnxsim:mutable_initializer",
+  options.emplace_back("onnxsim.mutable_initializer",
                        mutable_initializer ? "true" : "false");
   if (overwrite_input_shapes) {
     std::string s;
@@ -138,16 +144,28 @@ void RecordSimplifyOptionsMetadata(
         s += std::to_string(shape[i]);
       }
     }
-    options.emplace_back("onnxsim:overwrite_input_shapes", s);
+    options.emplace_back("onnxsim.overwrite_input_shapes", s);
   }
   if (unused_output) {
-    options.emplace_back("onnxsim:unused_output", join(*unused_output));
+    options.emplace_back("onnxsim.unused_output", join(*unused_output));
   }
+
+  // Every key this function could ever write, not just the ones present in
+  // `options` this call -- ``overwrite_input_shapes``/``unused_output`` are
+  // conditional, so a stale value one of them left behind on a previous
+  // simplify() call (that did set it) must still be cleared on a later call
+  // that doesn't, or it would look like it's still in effect.
+  static const std::unordered_set<std::string> known_option_keys = {
+      "onnxsim.skip_optimizers",           "onnxsim.constant_folding",
+      "onnxsim.shape_inference",           "onnxsim.tensor_size_threshold",
+      "onnxsim.target_opset_version",      "onnxsim.initializers_as_constants",
+      "onnxsim.include_inline_functions",  "onnxsim.mutable_initializer",
+      "onnxsim.overwrite_input_shapes",    "onnxsim.unused_output"};
 
   auto* props = model.mutable_metadata_props();
   google::protobuf::RepeatedPtrField<onnx::StringStringEntryProto> kept;
   for (auto& prop : *props) {
-    if (prop.key().rfind("onnxsim:", 0) != 0) {
+    if (!known_option_keys.count(prop.key())) {
       *kept.Add() = std::move(prop);
     }
   }
@@ -798,6 +816,7 @@ onnx::ModelProto Simplify(
                                 target_opset_version, initializers_as_constants,
                                 include_inline_functions, mutable_initializer,
                                 overwrite_input_shapes, unused_output);
+  RecordSimplifyDiffMetadata(sim_model, model);
   Check(sim_model);
   if (!converged) {
     std::cout << "WARNING: the simplification stopped because of timeout. "

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -633,8 +633,34 @@ onnx::ModelProto Simplify(
   // conversion and fixed point so everything downstream operates on the inlined
   // graph; schema-defined functions are left untouched. Off by default, so a
   // model with functions is otherwise simplified exactly as before.
+  //
+  // Before inlining, tally how many top-level-graph nodes call each function
+  // (matched by (domain, op_type) against the function's own (domain, name)) so
+  // RecordSimplifyDiffMetadata's block below can record which functions
+  // disappeared and how many call sites each had -- InlineLocalFunctions clears
+  // model.functions() entirely, so this is the last point that information is
+  // available. Calls inside subgraphs or other functions are not counted, only
+  // the top-level graph (matching DiffGraphs' own top-level-only scope).
+  std::vector<std::string> inlined_function_labels;
   if (include_inline_functions) {
+    std::unordered_map<std::string, size_t> call_counts;
+    for (const auto& fn : sim_model.functions()) {
+      call_counts.emplace(fn.domain() + "::" + fn.name(), 0);
+    }
+    if (!call_counts.empty()) {
+      for (const auto& node : sim_model.graph().node()) {
+        auto it = call_counts.find(node.domain() + "::" + node.op_type());
+        if (it != call_counts.end()) {
+          ++it->second;
+        }
+      }
+    }
     onnx::inliner::InlineLocalFunctions(sim_model);
+    inlined_function_labels.reserve(call_counts.size());
+    for (const auto& [label, count] : call_counts) {
+      inlined_function_labels.push_back(label + ":" + std::to_string(count));
+    }
+    std::sort(inlined_function_labels.begin(), inlined_function_labels.end());
   }
   // Optionally convert the model to a different opset version (of the default
   // ONNX domain) first, so the simplification below can clean up any redundant
@@ -809,7 +835,8 @@ onnx::ModelProto Simplify(
   // Simplification (and some onnx-optimizer passes) can leave nodes without a
   // name; assign unique names to them so downstream tools that key on node
   // names keep working (issue #269).
-  AssignMissingNodeNames(sim_model);
+  const std::vector<std::string> assigned_node_names =
+      AssignMissingNodeNames(sim_model);
   DropIncompleteValueInfo(sim_model);
   RecordSimplifyOptionsMetadata(sim_model, skip_optimizers, constant_folding,
                                 shape_inference, tensor_size_threshold,
@@ -817,6 +844,15 @@ onnx::ModelProto Simplify(
                                 include_inline_functions, mutable_initializer,
                                 overwrite_input_shapes, unused_output);
   RecordSimplifyDiffMetadata(sim_model, model);
+  // Nodes onnxsim itself had to name (no author-given name survived), and
+  // functions inlined away (see the tally taken just before
+  // InlineLocalFunctions, above) -- two more places a name or a structural
+  // grouping present in the input model is gone from the output, alongside
+  // the fusion/folding changes RecordSimplifyDiffMetadata already covers.
+  RecordCappedListMetadata(sim_model, "onnxsim.assigned_node_names",
+                           assigned_node_names, 20);
+  RecordCappedListMetadata(sim_model, "onnxsim.inlined_functions",
+                           inlined_function_labels, 20);
   Check(sim_model);
   if (!converged) {
     std::cout << "WARNING: the simplification stopped because of timeout. "

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -156,11 +156,11 @@ void RecordSimplifyOptionsMetadata(
   // simplify() call (that did set it) must still be cleared on a later call
   // that doesn't, or it would look like it's still in effect.
   static const std::unordered_set<std::string> known_option_keys = {
-      "onnxsim.skip_optimizers",           "onnxsim.constant_folding",
-      "onnxsim.shape_inference",           "onnxsim.tensor_size_threshold",
-      "onnxsim.target_opset_version",      "onnxsim.initializers_as_constants",
-      "onnxsim.include_inline_functions",  "onnxsim.mutable_initializer",
-      "onnxsim.overwrite_input_shapes",    "onnxsim.unused_output"};
+      "onnxsim.skip_optimizers",          "onnxsim.constant_folding",
+      "onnxsim.shape_inference",          "onnxsim.tensor_size_threshold",
+      "onnxsim.target_opset_version",     "onnxsim.initializers_as_constants",
+      "onnxsim.include_inline_functions", "onnxsim.mutable_initializer",
+      "onnxsim.overwrite_input_shapes",   "onnxsim.unused_output"};
 
   auto* props = model.mutable_metadata_props();
   google::protobuf::RepeatedPtrField<onnx::StringStringEntryProto> kept;


### PR DESCRIPTION
## Summary
Persists a summary of what `simplify()` structurally changed or dropped as `metadata_props` on the output model itself, so a downstream consumer can see what was lost to fusion/constant-folding/renaming/function-inlining without needing the original model around.

## Metadata namespace consistency
`RecordSimplifyOptionsMetadata` previously used a one-off `"onnxsim:"` (colon) prefix for the run-options it records, while everything else onnxsim writes into `metadata_props` (`AnnotateModelInfo`'s `onnxsim.macs`/`onnxsim.flops`/etc, and the Python side's `model_info.METADATA_PREFIX`) uses `"onnxsim."` (dot). Switched to the dot form, and replaced the previous prefix-wipe (safe only while it was the sole `"onnxsim:"` writer) with an exact-key wipe against a fixed allowlist, so it no longer clobbers unrelated `onnxsim.*` metadata now that the prefix is shared.

## New metadata: what simplification lost
- **`onnxsim.removed_nodes(.count)` / `onnxsim.changed_nodes(.count)` / `onnxsim.removed_values(.count)`** — `RecordSimplifyDiffMetadata` persists `DiffGraphs`'s node/value diff (previously only rendered as `FormatGraphDiff`'s CLI report) onto the simplified model.
- **`onnxsim.assigned_node_names(.count)`** — `AssignMissingNodeNames` now returns the names it invented for nodes that survived simplification with no author-given name; recorded so a consumer can tell which node names are onnxsim's own invention vs. traceable to the input model.
- **`onnxsim.inlined_functions(.count)`** — before `InlineLocalFunctions` clears a model's local function definitions (`include_inline_functions=True`), tallies how many top-level graph nodes called each one and records `domain::name:call_count` pairs. This is the case a `torch.onnx.export(dynamo=True)` model hits most: higher-level ops emitted as local ONNX functions collapse into their bodies with the grouping gone.

Every list-valued entry is capped (default 20) with a paired `*.count` key holding the true total, via a shared `RecordCappedListMetadata` helper, so metadata stays compact on large graphs.

https://claude.ai/code/session_01BESCq4Jvr1y1DfJojkYHL5