### PR TITLE
Fix byte order handling in safetensors test data generation

### DIFF
--- a/tests/test_onnx_safetensors_input.py
+++ b/tests/test_onnx_safetensors_input.py
@@ -57,7 +57,15 @@ def _write_safetensors_like_onnx_safetensors(path, arrays):
     blobs = []
     cursor = 0
     for name, arr in arrays.items():
-        raw = arr.tobytes()
+        # Both safetensors and ONNX's raw_data/external_data are defined as
+        # little-endian on disk regardless of host byte order (see
+        # onnxsim/passes/endian_read.h's doc comment) -- `arr.tobytes()` would
+        # instead serialize in the host's native order, which is only
+        # correct by coincidence on little-endian hosts and produces
+        # byte-swapped garbage once a spec-compliant reader (onnx's own
+        # numpy_helper.to_array, or onnxsim's C++ loader) interprets it on a
+        # big-endian one.
+        raw = arr.astype(arr.dtype.newbyteorder("<")).tobytes()
         header[name] = {
             "dtype": _NUMPY_DTYPE_TO_SAFETENSORS[arr.dtype],
             "shape": list(arr.shape),


### PR DESCRIPTION
## Summary
Fix endianness handling when generating test data for safetensors/ONNX compatibility tests. The test helper was serializing arrays in the host's native byte order, which only worked correctly on little-endian systems and produced byte-swapped data on big-endian hosts.

## Changes
- Updated `_write_safetensors_like_onnx_safetensors()` to explicitly convert arrays to little-endian byte order before serialization
- Changed from `arr.tobytes()` to `arr.astype(arr.dtype.newbyteorder("<")).tobytes()` to ensure consistent little-endian encoding on disk, matching the safetensors and ONNX specifications
- Added detailed comment explaining the endianness requirement and why the previous approach was incorrect

## Implementation Details
Both safetensors and ONNX's `raw_data`/`external_data` formats specify little-endian byte order on disk regardless of host architecture. The previous code used `arr.tobytes()`, which serializes in the host's native byte order—this happened to work on little-endian systems but would produce corrupted data when read by spec-compliant readers (like ONNX's `numpy_helper.to_array` or onnxsim's C++ loader) on big-endian systems.

https://claude.ai/code/session_0193q1A3G9CSYxCRpw1fDCkm