### PR TITLE
Add correct_bias: AIMET's empirical Bias Correction

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -9,6 +9,7 @@ from onnxsim.accuracy import (
     quantize_auto,
     recommend_quantization,
 )
+from onnxsim.bias_correction import correct_bias
 from onnxsim.calibration import (
     calibrate,
     generate_random_calibration_data,
@@ -63,6 +64,7 @@ __all__ = [
     "QuantizationRecommendation",
     "DEFAULT_QUANTIZATION_CANDIDATES",
     "cross_layer_equalize",
+    "correct_bias",
     "quantize_attention_dynamic",
     "quantize_dynamic",
     "quantize_dynamic_matmul_integer_to_float",

--- a/onnxsim/bias_correction.py
+++ b/onnxsim/bias_correction.py
@@ -1,0 +1,241 @@
+"""Empirical Bias Correction -- the data-driven half of "Data-Free
+Quantization Through Weight Equalization and Bias Correction" (Nagel et al.,
+2019), also shipped as part of Qualcomm's AIMET toolkit. Its sibling
+technique, Cross-Layer Equalization, is :func:`onnxsim.cross_layer_equalize`.
+
+Quantizing a layer's weight is not a zero-mean operation in general: the
+rounding error correlates with the weight distribution (e.g. clipped/
+asymmetric distributions round more one direction than the other), so a
+quantized Conv/Gemm/MatMul's output picks up a systematic *mean* shift per
+output channel on top of the expected per-element quantization noise.
+:func:`onnxsim.cross_layer_equalize` and every ``quantize_*`` scheme leave
+this shift uncorrected -- it is a real, measurable bias, not something
+either of them targets. :func:`correct_bias` measures it directly (the
+"empirical" variant of the paper's Bias Correction -- the "analytic"
+variant, which estimates the same shift from BatchNorm statistics instead
+of running real data through the model, is not implemented here) and
+cancels it.
+
+For every Conv/Gemm/MatMul node present (by output tensor name) in both
+``float_model`` and ``quantized_model``, this runs both models on the same
+calibration data, measures each such layer's own per-output-channel mean
+error (``float_output - quantized_output``, independent of any other
+layer's correction -- not chained through progressively-corrected
+activations), and adds that as a constant per-channel offset right after
+the layer in ``quantized_model``. Adding a constant to an affine layer's
+output is exactly equivalent to folding it into that layer's bias, whatever
+internal shape the ``quantize_*`` scheme that produced it happens to use
+(a straight Conv/Gemm/MatMul weight-only rewrite, a multi-node dynamic-
+quantization chain, ...) -- so this needs no scheme-specific knowledge of
+where a bias tensor lives internally, only that the layer's own output
+tensor kept its original name, which every onnxsim ``quantize_*`` pass
+guarantees (downstream consumers are never rewired by name).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Sequence, Set, Union
+
+import numpy as np
+import onnx
+
+from onnxsim import backend
+from onnxsim.calibration import Tensors, generate_random_calibration_data
+
+# op_type -> the axis its own output tensor's "channel" dimension sits on.
+# Conv is always NCHW-style (batch, channel, spatial...), so channel is
+# axis 1 regardless of spatial rank. Gemm/MatMul put the output feature
+# dimension last regardless of transpose attributes (Gemm's output shape is
+# always [M, N] whatever transA/transB are; MatMul has no transpose
+# attributes at all), so channel is axis -1.
+_CORRECTABLE_OPS: Dict[str, int] = {"Conv": 1, "Gemm": -1, "MatMul": -1}
+
+
+def _all_names(graph: onnx.GraphProto) -> Set[str]:
+    names: Set[str] = set()
+    for t in graph.initializer:
+        names.add(t.name)
+    for vi in list(graph.input) + list(graph.output) + list(graph.value_info):
+        names.add(vi.name)
+    for n in graph.node:
+        if n.name:
+            names.add(n.name)
+        names.update(n.input)
+        names.update(n.output)
+    return names
+
+
+def _unique_name(base: str, taken: Set[str]) -> str:
+    name = base
+    i = 0
+    while name in taken:
+        i += 1
+        name = f"{base}_{i}"
+    taken.add(name)
+    return name
+
+
+def _add_probe_outputs(model: onnx.ModelProto, names: Sequence[str]) -> onnx.ModelProto:
+    # Same technique as calibration.py's calibrate(): expose intermediate
+    # tensors as extra graph outputs so the backend computes (and returns)
+    # them without the graph's own computation changing at all.
+    probe = onnx.ModelProto()
+    probe.CopyFrom(model)
+    existing = {o.name for o in probe.graph.output}
+    for name in names:
+        if name not in existing:
+            probe.graph.output.append(onnx.ValueInfoProto(name=name))
+            existing.add(name)
+    return probe
+
+
+def correct_bias(
+    float_model: Union[str, onnx.ModelProto],
+    quantized_model: Union[str, onnx.ModelProto],
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_samples: int = 8,
+    seed: int = 0,
+    providers: Optional[Sequence[str]] = None,
+    correction_threshold: float = 1e-12,
+) -> onnx.ModelProto:
+    """Empirically corrects the per-channel output bias
+    ``quantized_model``'s Conv/Gemm/MatMul layers picked up from their own
+    weight quantization, using real calibration data run through both
+    models. See this module's own docstring for the technique.
+
+    :param float_model: the original (unquantized) onnx ModelProto or file
+            path
+    :param quantized_model: a quantized version of ``float_model`` (onnx
+            ModelProto or file path), e.g. from :func:`onnxsim.quantize` or
+            any ``quantize_*`` function. Assumes ``quantized_model`` was
+            produced from ``float_model`` without renaming any
+            Conv/Gemm/MatMul node's own output tensor -- true of every
+            onnxsim ``quantize_*`` function.
+    :param calibration_data: representative input batches to measure the
+            correction on. Each batch is a ``{input_name: np.ndarray}``
+            dict matching ``float_model``'s graph inputs -- see
+            :func:`onnxsim.generate_random_calibration_data` (the default
+            when omitted) and
+            :func:`onnxsim.load_huggingface_calibration_data` (real data,
+            a much more representative correction than random input).
+    :param num_samples: random batches to generate when
+            ``calibration_data`` is omitted
+    :param seed: seed for the random calibration data (ignored if
+            ``calibration_data`` is supplied)
+    :param providers: onnxruntime execution providers to run both models on
+    :param correction_threshold: skip correcting a layer whose measured
+            per-channel error never exceeds this (in absolute value) --
+            avoids inserting a numerically-pointless zero-offset node for a
+            layer ``quantized_model`` left untouched (e.g. a scheme that
+            declined to quantize it). Not an accuracy knob: even the
+            default, near-zero threshold only filters out true no-ops.
+    :returns: ``quantized_model`` with a per-channel correction applied
+            after every measurably-biased Conv/Gemm/MatMul layer
+    """
+    if isinstance(float_model, str):
+        float_model = onnx.load(float_model, load_external_data=False)
+    if isinstance(quantized_model, str):
+        quantized_model = onnx.load(quantized_model, load_external_data=False)
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            float_model, num_samples=num_samples, seed=seed
+        )
+
+    quantized_outputs: Set[str] = set()
+    for n in quantized_model.graph.node:
+        quantized_outputs.update(n.output)
+
+    candidates = []  # (output_name, channel_axis)
+    for n in float_model.graph.node:
+        axis = _CORRECTABLE_OPS.get(n.op_type)
+        if axis is None or not n.output or n.output[0] not in quantized_outputs:
+            continue
+        candidates.append((n.output[0], axis))
+    if not candidates:
+        return quantized_model
+
+    candidate_names = [name for name, _ in candidates]
+    float_probe = _add_probe_outputs(float_model, candidate_names)
+    quantized_probe = _add_probe_outputs(quantized_model, candidate_names)
+
+    sums: Dict[str, np.ndarray] = {}
+    counts: Dict[str, int] = {}
+    ranks: Dict[str, int] = {}
+    for batch in calibration_data:
+        float_out = backend.run_model(float_probe, batch, providers=providers)
+        quantized_out = backend.run_model(quantized_probe, batch, providers=providers)
+        for name, axis in candidates:
+            f = np.asarray(float_out[name], dtype=np.float64)
+            q = np.asarray(quantized_out[name], dtype=np.float64)
+            if f.shape != q.shape or f.ndim == 0:
+                continue
+            ch_axis = axis if axis >= 0 else f.ndim + axis
+            diff = f - q
+            reduce_axes = tuple(i for i in range(diff.ndim) if i != ch_axis)
+            channel_sum = diff.sum(axis=reduce_axes) if reduce_axes else diff
+            channel_count = diff.size // diff.shape[ch_axis]
+            if name in sums:
+                sums[name] = sums[name] + channel_sum
+                counts[name] += channel_count
+            else:
+                sums[name] = channel_sum
+                counts[name] = channel_count
+                ranks[name] = f.ndim
+
+    corrected = onnx.ModelProto()
+    corrected.CopyFrom(quantized_model)
+    taken_names = _all_names(corrected.graph)
+    axis_by_name = dict(candidates)
+
+    for name, total in sums.items():
+        correction = (total / counts[name]).astype(np.float32)
+        if np.max(np.abs(correction)) <= correction_threshold:
+            continue
+        _apply_correction(
+            corrected, name, axis_by_name[name], ranks[name], correction, taken_names
+        )
+
+    return corrected
+
+
+def _apply_correction(
+    model: onnx.ModelProto,
+    output_name: str,
+    axis: int,
+    rank: int,
+    correction: np.ndarray,
+    taken_names: Set[str],
+) -> None:
+    producer_idx = None
+    output_index = None
+    for idx, n in enumerate(model.graph.node):
+        for oi, out in enumerate(n.output):
+            if out == output_name:
+                producer_idx, output_index = idx, oi
+                break
+        if producer_idx is not None:
+            break
+    if producer_idx is None:
+        return  # shouldn't happen -- output_name came from this same graph
+
+    pre_correction_name = _unique_name(
+        f"{output_name}_bias_correction_pre", taken_names
+    )
+    model.graph.node[producer_idx].output[output_index] = pre_correction_name
+
+    ch_axis = axis if axis >= 0 else rank + axis
+    broadcast_shape = [1] * rank
+    broadcast_shape[ch_axis] = correction.shape[0]
+    scale_name = _unique_name(f"{output_name}_bias_correction", taken_names)
+    scale_tensor = onnx.numpy_helper.from_array(
+        correction.reshape(broadcast_shape), name=scale_name
+    )
+    model.graph.initializer.append(scale_tensor)
+
+    add_node = onnx.helper.make_node(
+        "Add",
+        [pre_correction_name, scale_name],
+        [output_name],
+        name=_unique_name(f"{output_name}_bias_correction_add", taken_names),
+    )
+    model.graph.node.insert(producer_idx + 1, add_node)

--- a/tests/test_bias_correction.py
+++ b/tests/test_bias_correction.py
@@ -1,0 +1,219 @@
+"""Tests for ``onnxsim.correct_bias`` (``onnxsim/bias_correction.py``) --
+AIMET's empirical Bias Correction.
+
+The most important test here isn't against a realistic quantized model --
+real per-channel symmetric weight quantization tends to round fairly
+symmetrically already, so the bias it leaves behind can be too small to
+distinguish from measurement noise in a small hand-built test. Instead,
+``test_correct_bias_recovers_known_injected_gemm_bias`` (and its Conv
+counterpart) fabricate a "quantized" model that is the float model with a
+*known* per-channel bias error injected directly, and check that
+``correct_bias`` recovers it almost exactly -- a precise check of the
+measurement-and-graph-surgery mechanism itself, independent of whether any
+particular quantize_* scheme happens to leave a large enough bias to see.
+"""
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+
+import onnxsim
+from onnxsim import backend
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(np.asarray(array, dtype=np.float32), name)
+
+
+def _gemm_model(w, b, K, N, batch=4):
+    nodes = [onnx.helper.make_node("Gemm", ["x", "w", "b"], ["y"])]
+    inits = [_f32(w, "w"), _f32(b, "b")]
+    graph = onnx.helper.make_graph(
+        nodes, "g", [_vi("x", [batch, K])], [_vi("y", [batch, N])], inits
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 17)], ir_version=8
+    )
+    onnx.checker.check_model(model)
+    return model
+
+
+def _conv_model(w, b, c_in, c_out, batch=1, spatial=8):
+    nodes = [
+        onnx.helper.make_node(
+            "Conv", ["x", "w", "b"], ["y"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
+        )
+    ]
+    inits = [_f32(w, "w"), _f32(b, "b")]
+    graph = onnx.helper.make_graph(
+        nodes,
+        "g",
+        [_vi("x", [batch, c_in, spatial, spatial])],
+        [_vi("y", [batch, c_out, spatial, spatial])],
+        inits,
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 13)], ir_version=8
+    )
+    onnx.checker.check_model(model)
+    return model
+
+
+def test_correct_bias_recovers_known_injected_gemm_bias():
+    rng = np.random.default_rng(0)
+    K, N = 16, 8
+    w = rng.standard_normal((K, N)).astype(np.float32) * 0.3
+    b = rng.standard_normal(N).astype(np.float32) * 0.05
+    injected_error = np.array(
+        [0.5, -0.3, 0.2, 0.1, -0.4, 0.05, 0.15, -0.1], dtype=np.float32
+    )
+    float_model = _gemm_model(w, b, K, N)
+    fake_quantized = _gemm_model(w, (b + injected_error).astype(np.float32), K, N)
+
+    rng2 = np.random.default_rng(1)
+    calib = [{"x": rng2.standard_normal((4, K)).astype(np.float32)} for _ in range(8)]
+
+    corrected = onnxsim.correct_bias(
+        float_model, fake_quantized, calibration_data=calib
+    )
+    onnx.checker.check_model(corrected)
+    assert [n.op_type for n in corrected.graph.node] == ["Gemm", "Add"]
+
+    before = onnxsim.measure_accuracy_drop(
+        float_model, fake_quantized, calibration_data=calib
+    )
+    after = onnxsim.measure_accuracy_drop(
+        float_model, corrected, calibration_data=calib
+    )
+    assert after.worst_relative_l2 < before.worst_relative_l2 * 0.01
+    assert after.worst_relative_l2 < 1e-5
+
+
+def test_correct_bias_recovers_known_injected_conv_bias():
+    rng = np.random.default_rng(2)
+    c_in, c_out = 4, 6
+    w = rng.standard_normal((c_out, c_in, 3, 3)).astype(np.float32) * 0.1
+    b = rng.standard_normal(c_out).astype(np.float32) * 0.02
+    injected_error = np.array([0.3, -0.2, 0.15, -0.1, 0.25, -0.05], dtype=np.float32)
+    float_model = _conv_model(w, b, c_in, c_out)
+    fake_quantized = _conv_model(
+        w, (b + injected_error).astype(np.float32), c_in, c_out
+    )
+
+    rng2 = np.random.default_rng(3)
+    calib = [
+        {"x": rng2.standard_normal((1, c_in, 8, 8)).astype(np.float32)}
+        for _ in range(8)
+    ]
+
+    corrected = onnxsim.correct_bias(
+        float_model, fake_quantized, calibration_data=calib
+    )
+    onnx.checker.check_model(corrected)
+    assert [n.op_type for n in corrected.graph.node] == ["Conv", "Add"]
+
+    before = onnxsim.measure_accuracy_drop(
+        float_model, fake_quantized, calibration_data=calib
+    )
+    after = onnxsim.measure_accuracy_drop(
+        float_model, corrected, calibration_data=calib
+    )
+    assert after.worst_relative_l2 < before.worst_relative_l2 * 0.01
+    assert after.worst_relative_l2 < 1e-5
+
+
+def test_correct_bias_end_to_end_with_real_quantization():
+    rng = np.random.default_rng(4)
+    K, N = 64, 32
+    w = rng.standard_normal((K, N)).astype(np.float32) * 0.3
+    b = rng.standard_normal(N).astype(np.float32) * 0.05
+    float_model = _gemm_model(w, b, K, N, batch=8)
+    quantized = onnxsim.quantize_weight_only(float_model)
+    onnx.checker.check_model(quantized)
+
+    rng2 = np.random.default_rng(5)
+    calib = [{"x": rng2.standard_normal((8, K)).astype(np.float32)} for _ in range(16)]
+
+    corrected = onnxsim.correct_bias(float_model, quantized, calibration_data=calib)
+    onnx.checker.check_model(corrected)
+
+    before = onnxsim.measure_accuracy_drop(
+        float_model, quantized, calibration_data=calib
+    )
+    after = onnxsim.measure_accuracy_drop(
+        float_model, corrected, calibration_data=calib
+    )
+    # A correction fit to this exact calibration data should never make the
+    # measured-on-the-same-data error worse.
+    assert after.worst_relative_l2 <= before.worst_relative_l2 + 1e-9
+
+
+def test_correct_bias_is_a_noop_when_quantized_model_is_identical():
+    rng = np.random.default_rng(6)
+    K, N = 8, 4
+    w = rng.standard_normal((K, N)).astype(np.float32)
+    b = rng.standard_normal(N).astype(np.float32)
+    model = _gemm_model(w, b, K, N)
+
+    corrected = onnxsim.correct_bias(model, model)
+    assert [n.op_type for n in corrected.graph.node] == ["Gemm"]
+
+
+def test_correct_bias_is_a_noop_on_a_model_with_no_candidate_ops():
+    x = _vi("x", [2, 4])
+    y = _vi("y", [2, 4])
+    node = onnx.helper.make_node("Relu", ["x"], ["y"])
+    graph = onnx.helper.make_graph([node], "g", [x], [y], [])
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 13)], ir_version=8
+    )
+
+    corrected = onnxsim.correct_bias(model, model)
+    assert [n.op_type for n in corrected.graph.node] == ["Relu"]
+
+
+def test_correct_bias_generates_calibration_data_when_omitted():
+    rng = np.random.default_rng(7)
+    K, N = 8, 4
+    w = rng.standard_normal((K, N)).astype(np.float32) * 0.3
+    b = rng.standard_normal(N).astype(np.float32) * 0.02
+    float_model = _gemm_model(w, b, K, N)
+    fake_quantized = _gemm_model(w, (b + np.full(N, 0.4, dtype=np.float32)), K, N)
+
+    corrected = onnxsim.correct_bias(float_model, fake_quantized, num_samples=8, seed=0)
+    onnx.checker.check_model(corrected)
+    assert [n.op_type for n in corrected.graph.node] == ["Gemm", "Add"]
+
+
+def test_correct_bias_preserves_existing_graph_output():
+    # The corrected node's output is also a genuine graph output (not just
+    # an intermediate) -- the correction Add node must take over that name
+    # so the graph output still resolves to the corrected value.
+    rng = np.random.default_rng(8)
+    K, N = 8, 4
+    w = rng.standard_normal((K, N)).astype(np.float32) * 0.3
+    b = rng.standard_normal(N).astype(np.float32) * 0.02
+    injected_error = np.full(N, 0.6, dtype=np.float32)
+    float_model = _gemm_model(w, b, K, N)
+    fake_quantized = _gemm_model(w, (b + injected_error).astype(np.float32), K, N)
+    assert fake_quantized.graph.output[0].name == "y"
+
+    rng2 = np.random.default_rng(9)
+    calib = [{"x": rng2.standard_normal((4, K)).astype(np.float32)} for _ in range(8)]
+    corrected = onnxsim.correct_bias(
+        float_model, fake_quantized, calibration_data=calib
+    )
+    onnx.checker.check_model(corrected)
+    assert corrected.graph.output[0].name == "y"
+
+    (out,) = backend.run_model(corrected, calib[0]).values()
+    (expected,) = backend.run_model(float_model, calib[0]).values()
+    np.testing.assert_allclose(out, expected, rtol=1e-4, atol=1e-5)


### PR DESCRIPTION
## Summary

Second AIMET technique, following `cross_layer_equalize` (#708): the data-driven half of ["Data-Free Quantization Through Weight Equalization and Bias Correction"](https://arxiv.org/abs/1906.04721) (Nagel et al., 2019).

Quantizing a layer's weight is not a zero-mean operation in general -- the rounding error correlates with the weight distribution (e.g. clipped/asymmetric distributions round more one direction than the other), so a quantized Conv/Gemm/MatMul's output picks up a systematic *mean* shift per output channel on top of the expected per-element quantization noise. Neither `cross_layer_equalize` nor any `quantize_*` scheme corrects this -- it's a real, measurable bias, not something either targets.

`correct_bias(float_model, quantized_model, calibration_data=...)` runs both models on the same calibration data, measures each Conv/Gemm/MatMul layer's own per-output-channel mean error **independently** (not chained through other layers' corrections -- this is the paper's *empirical* variant; the *analytic* variant, which estimates the same shift from BatchNorm statistics instead of running real data through the model, is not implemented here), and adds that as a constant per-channel offset right after the layer in `quantized_model`.

Adding a constant to an affine layer's output is exactly equivalent to folding it into that layer's bias, whatever internal shape the `quantize_*` scheme that produced it uses (a straight weight-only rewrite, a multi-node dynamic-quantization chain, ...) -- so this needs **no scheme-specific knowledge** of where a bias tensor lives internally, only that the layer's own output tensor kept its original name, which every onnxsim `quantize_*` pass guarantees (downstream consumers are never rewired by name).

## Verification

The most important check isn't against a realistic quantized model -- per-channel symmetric weight quantization tends to round fairly symmetrically already, so its natural bias can be too small to distinguish from noise in a small test (consistent with the paper's own finding that this technique's biggest wins are on outlier-heavy/asymmetric distributions, the same case `cross_layer_equalize` targets). Instead, two tests fabricate a "quantized" model that's the float model with a **known** per-channel bias error injected directly (for both Gemm's last-axis-channel and Conv's axis-1-channel layouts), and confirm `correct_bias` recovers it from ~30% relative error down to ~1e-7 -- a precise check of the measurement-and-graph-surgery mechanism itself.

## New files

- `onnxsim/bias_correction.py` -- `correct_bias()`
- `tests/test_bias_correction.py`

## Test plan

- `tests/test_bias_correction.py` (7 new tests): known-bias recovery for Gemm and Conv, a real `quantize_weight_only` end-to-end check (valid output, never regresses), a no-op when the quantized model has nothing to correct, a no-op on a model with no Conv/Gemm/MatMul, default calibration-data generation, and preserving an existing graph output's name through the correction.
- `pytest tests/test_bias_correction.py tests/test_accuracy.py tests/test_cross_layer_equalization.py tests/test_weight_only_quantize.py tests/test_dynamic_quantize_matmul.py` -> 60 passed.
- `ruff format --check` / `ruff check` clean; `mypy` shows no new errors in `bias_correction.py` (pure Python, no C++ changes in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_