### PR TITLE
Add concurrency control to all GitHub Actions workflows

### DIFF
--- a/.github/workflows/audio8.yml
+++ b/.github/workflows/audio8.yml
@@ -30,6 +30,10 @@ on:
     - cron: '0 9 * * 1'  # weekly, Monday 09:00 UTC
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   audio8:
     name: Audio8 (Hugging Face) -> onnxsim

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,6 +9,10 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_wheels:
     env:

--- a/.github/workflows/convertmodel-inference.yml
+++ b/.github/workflows/convertmodel-inference.yml
@@ -12,6 +12,10 @@ on:
       - ".github/workflows/convertmodel-inference.yml"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   inference:
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # C++ + Python + JS coverage from a single pytest run plus the Node suite.
   # Emits Cobertura reports and hands them to the `report` job below rather than

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Format + lint + type-check the Python sources. Tools are pinned so a local
   # run reports exactly what CI does; bump the pins here to upgrade everywhere.

--- a/.github/workflows/rfdetr.yml
+++ b/.github/workflows/rfdetr.yml
@@ -22,6 +22,10 @@ on:
     - cron: '0 7 * * *'  # daily at 07:00 UTC
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   rfdetr:
     name: RF-DETR export -> onnxsim

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,10 @@ on:
     types: [published]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     working-directory: rust

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # A single instrumented build that runs AddressSanitizer and the alignment
   # UndefinedBehaviorSanitizer check together over the whole dependency tree

--- a/.github/workflows/voicevox.yml
+++ b/.github/workflows/voicevox.yml
@@ -32,6 +32,10 @@ on:
     - cron: '0 8 * * 1'  # weekly, Monday 08:00 UTC
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   voicevox:
     name: VOICEVOX sample.vvm -> onnxsim

--- a/.github/workflows/yolo.yml
+++ b/.github/workflows/yolo.yml
@@ -23,6 +23,10 @@ on:
     - cron: '0 6 * * *'  # daily at 06:00 UTC
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   yolo:
     name: YOLO export -> onnxsim


### PR DESCRIPTION
## Summary
Add concurrency configuration to all GitHub Actions workflows to prevent multiple runs of the same workflow on the same ref from executing simultaneously. This improves CI efficiency by canceling in-progress runs when new commits are pushed.

## Changes
- Added `concurrency` block to 10 workflow files:
  - `audio8.yml`
  - `build-and-test.yml`
  - `convertmodel-inference.yml`
  - `coverage.yml`
  - `lint.yml`
  - `rfdetr.yml`
  - `rust.yml`
  - `sanitizer.yml`
  - `voicevox.yml`
  - `yolo.yml`

Each workflow now includes:
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

## Details
This configuration ensures that:
- Only one run of each workflow executes per branch/tag at a time
- When a new commit is pushed, any in-progress run of the same workflow on that ref is automatically cancelled
- This reduces unnecessary CI resource consumption and provides faster feedback on the latest commit

https://claude.ai/code/session_01Dx2LKuxsp6VQphXC7tzQ2n