### PR TITLE
Record dropped doc_string count in simplify() metadata

### DIFF
--- a/onnxsim/model_info.cpp
+++ b/onnxsim/model_info.cpp
@@ -623,6 +623,33 @@ void RecordCappedListMetadata(onnx::ModelProto& model, const std::string& key,
   SetMetadata(model, key, JoinCapped(items, limit));
 }
 
+// Counts top-level-graph nodes in `model_ori` that had a non-empty
+// doc_string but whose matched node in `model_opt` -- same output name(s),
+// the identity DiffGraphs itself matches nodes by -- carries none: either
+// the node was removed/fused away entirely, or whatever pass rebuilt it
+// didn't carry doc_string over (onnx-optimizer's fusion/elimination passes
+// generally don't). Reported as a plain count rather than the text itself:
+// doc_string is free-form prose, not a stable list of identifiers, so
+// there's no meaningful capped list to show here -- just how much was lost.
+static size_t CountDroppedDocStrings(const onnx::ModelProto& model_ori,
+                                     const onnx::ModelProto& model_opt) {
+  std::set<std::string> opt_keys_with_doc_string;
+  for (const auto& node : model_opt.graph().node()) {
+    if (!node.doc_string().empty()) {
+      opt_keys_with_doc_string.insert(OutputKey(MakeNodeDiffEntry(node)));
+    }
+  }
+
+  size_t dropped = 0;
+  for (const auto& node : model_ori.graph().node()) {
+    if (!node.doc_string().empty() &&
+        !opt_keys_with_doc_string.count(OutputKey(MakeNodeDiffEntry(node)))) {
+      ++dropped;
+    }
+  }
+  return dropped;
+}
+
 void RecordSimplifyDiffMetadata(onnx::ModelProto& sim_model,
                                 const onnx::ModelProto& model_ori,
                                 size_t limit) {
@@ -642,4 +669,6 @@ void RecordSimplifyDiffMetadata(onnx::ModelProto& sim_model,
   RecordCappedListMetadata(sim_model, "onnxsim.changed_nodes", changed, limit);
   RecordCappedListMetadata(sim_model, "onnxsim.removed_values",
                            diff.removed_values, limit);
+  SetMetadata(sim_model, "onnxsim.dropped_doc_strings",
+              std::to_string(CountDroppedDocStrings(model_ori, sim_model)));
 }

--- a/onnxsim/model_info.h
+++ b/onnxsim/model_info.h
@@ -138,14 +138,16 @@ std::string FormatGraphDiff(const onnx::ModelProto& model_ori,
 // Records a summary of what simplification changed structurally between
 // ``model_ori`` and ``sim_model`` -- nodes removed by fusion/elimination,
 // nodes changed in place under the same output name(s) (see ``DiffGraphs``),
-// and values that disappeared -- as ``metadata_props`` on ``sim_model``,
-// namespaced "onnxsim." like the rest of onnxsim's own metadata
-// (``AnnotateModelInfo``, ``RecordSimplifyOptionsMetadata``). This persists
-// the same diff ``FormatGraphDiff`` renders as a CLI report onto the model
-// itself, so a downstream consumer can see what was lost to fusion/constant
-// folding without needing the original model on hand. Each list is capped at
-// ``limit`` entries (with a paired ``*.count`` key holding the true total) to
-// keep the metadata compact on large graphs.
+// values that disappeared, and how many nodes' ``doc_string`` did not survive
+// (as a plain count: see ``CountDroppedDocStrings``'s doc comment for why a
+// capped list doesn't make sense for free-form prose) -- as ``metadata_props``
+// on ``sim_model``, namespaced "onnxsim." like the rest of onnxsim's own
+// metadata (``AnnotateModelInfo``, ``RecordSimplifyOptionsMetadata``). This
+// persists the same diff ``FormatGraphDiff`` renders as a CLI report onto the
+// model itself, so a downstream consumer can see what was lost to
+// fusion/constant folding without needing the original model on hand. Each
+// list is capped at ``limit`` entries (with a paired ``*.count`` key holding
+// the true total) to keep the metadata compact on large graphs.
 void RecordSimplifyDiffMetadata(onnx::ModelProto& sim_model,
                                 const onnx::ModelProto& model_ori,
                                 size_t limit = 20);


### PR DESCRIPTION
## Summary
Follow-up to #709. Rounds out the "lost information" metadata `simplify()` records on the output model: alongside removed/changed nodes, removed values, assigned node names and inlined functions, `onnxsim.dropped_doc_strings` now counts nodes whose `doc_string` didn't survive simplification.

## Details
- `CountDroppedDocStrings` (in `model_info.cpp`) counts top-level-graph nodes in the original model that had a non-empty `doc_string` but whose matched node in the simplified model — same output name(s), the identity `DiffGraphs` itself matches nodes by — has none. That covers both cases: the node was removed/fused away entirely, or the pass that rebuilt it (onnx-optimizer's fusion/elimination passes generally don't propagate `doc_string`) just didn't carry it over.
- Recorded as a plain count (`onnxsim.dropped_doc_strings`), not a capped list like the other categories: `doc_string` is free-form prose, not a stable list of identifiers, so there's nothing meaningful to enumerate — just how much was lost.
- Wired into `RecordSimplifyDiffMetadata` alongside the existing three categories.

https://claude.ai/code/session_01BESCq4Jvr1y1DfJojkYHL5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BESCq4Jvr1y1DfJojkYHL5)_