### PR TITLE
Add quantize_weight_only_matmul_nbits: ORT's vendor-specific MatMulNBits INT4 format

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -45,6 +45,7 @@ from onnxsim.onnx_simplifier import (
     quantize_weight_only_int4,
     quantize_weight_only_int8_block,
     quantize_weight_only_int16,
+    quantize_weight_only_matmul_nbits,
     simplify,
 )
 from onnxsim.precision_estimator import (
@@ -71,6 +72,7 @@ __all__ = [
     "quantize_ternary",
     "quantize_weight_only",
     "quantize_weight_only_int4",
+    "quantize_weight_only_matmul_nbits",
     "quantize_weight_only_int8_block",
     "quantize_weight_only_int16",
     "quantize_static",

--- a/onnxsim/contrib_schemas.cpp
+++ b/onnxsim/contrib_schemas.cpp
@@ -793,6 +793,74 @@ OpSchema MakeQAttentionSchema() {
                       "Constrain mask index to integer types.");
 }
 
+// ONNX Runtime's block-wise N-bit weight-only quantized MatMul (ORT GenAI's
+// own INT4 weight compression path for LLM/ASR deployment -- distinct from
+// onnxsim's own opset-21-native weight_only_quantize_int4_matmul.h, which
+// targets any conformant runtime instead of ORT specifically). Registered
+// here so weight_only_quantize_matmul_nbits.h's fused output -- which only
+// ever emits inputs 0-2 (A, B, scales) and attrs K/N/bits/block_size --
+// passes the ONNX checker and shape-inference sweeps the rest of onnxsim's
+// pipeline runs; the remaining inputs/attrs (zero_points, g_idx, bias,
+// weight_prepacked, accuracy_level) are declared for schema
+// completeness/compatibility with externally-authored models, not because
+// this pass ever produces them.
+OpSchema MakeMatMulNBitsSchema() {
+  return OpSchema()
+      .SetName("MatMulNBits")
+      .SetDomain(kMSDomain)
+      .SinceVersion(1)
+      .SetDoc(
+          "MatMulNBits performs a matrix multiplication where the "
+          "right-hand-side matrix (weights) is quantized to N bits.")
+      .Attr("K", "Size of the input feature dimension.",
+            onnx::AttributeProto::INT, /*required=*/true)
+      .Attr("N", "Size of the output feature dimension.",
+            onnx::AttributeProto::INT, /*required=*/true)
+      .Attr("block_size",
+            "Number of weight values quantized together along the K "
+            "dimension. Must be a power of 2 and >= 16.",
+            onnx::AttributeProto::INT, /*required=*/true)
+      .Attr("bits", "Number of bits used to quantize each weight value.",
+            onnx::AttributeProto::INT, static_cast<int64_t>(4))
+      .Attr("accuracy_level",
+            "Optional accuracy level hint for the internal computation.",
+            onnx::AttributeProto::INT, /*required=*/false)
+      .Attr("weight_prepacked",
+            "Whether B is prepacked into a runtime-specific layout.",
+            onnx::AttributeProto::INT, static_cast<int64_t>(0))
+      .Input(0, "A", "The input tensor, not quantized.", "T1")
+      .Input(1, "B",
+             "Packed uint8 tensor of shape (N, k_blocks, blob_size), "
+             "k_blocks = ceil(K / block_size), blob_size = block_size * "
+             "bits / 8, bit-packed low-nibble-first along K within each "
+             "block.",
+             "T2")
+      .Input(2, "scales",
+             "Per-block scaling factors with shape (N, k_blocks), same "
+             "type as A.",
+             "T1")
+      .Input(3, "zero_points",
+             "Per-block zero point. Packed (uint8, shape (N, "
+             "ceil(k_blocks * bits / 8))) or unpacked (same type as A, "
+             "shape (N, k_blocks)). Defaults to 2^(bits-1) when omitted.",
+             "T3", OpSchema::Optional)
+      .Input(4, "g_idx", "Deprecated group index input.", "T4",
+             OpSchema::Optional)
+      .Input(5, "bias", "Bias to add to the result, shape [N].", "T1",
+             OpSchema::Optional)
+      .Output(0, "Y", "The output tensor.", "T1")
+      .TypeConstraint("T1",
+                      {"tensor(float)", "tensor(float16)", "tensor(bfloat16)"},
+                      "Constrain A, scales, bias, and output to float tensors.")
+      .TypeConstraint("T2", {"tensor(uint8)"}, "Constrain B to uint8.")
+      .TypeConstraint("T3",
+                      {"tensor(uint8)", "tensor(float16)", "tensor(float)",
+                       "tensor(bfloat16)"},
+                      "Constrain zero_points to uint8 (packed) or a float type "
+                      "(unpacked).")
+      .TypeConstraint("T4", {"tensor(int32)"}, "Constrain g_idx to int32.");
+}
+
 void RegisterAll() {
   // The custom domain must be known to the schema registry before any schema
   // in it can be registered.
@@ -817,6 +885,7 @@ void RegisterAll() {
   RegisterIfAbsent(MakeMatMulIntegerToFloatSchema());
   RegisterIfAbsent(MakeAttentionSchema());
   RegisterIfAbsent(MakeQAttentionSchema());
+  RegisterIfAbsent(MakeMatMulNBitsSchema());
 
   // Augment the standard Reshape schema with a data-propagation function so
   // shape tensors can flow through a Reshape during partial shape evaluation.

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -476,6 +476,24 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
       },
       "model_bytes"_a);
 
+  // Block-wise INT4 weight-only quantizes MatMul/Gemm weights into ONNX
+  // Runtime's own com.microsoft::MatMulNBits contrib op -- a vendor-specific
+  // (ORT-only) counterpart to quantize_weight_only_int4's portable standard-
+  // ONNX output. See QuantizeWeightOnlyMatMulNBits in onnxsim.h.
+  m.def(
+      "quantize_weight_only_matmul_nbits",
+      [](const py::bytes& model_proto_bytes) -> py::bytes {
+        InitEnv();
+        ONNX_NAMESPACE::ModelProto model;
+        ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
+                            model_proto_bytes.size());
+        const auto result = QuantizeWeightOnlyMatMulNBits(model);
+        std::string out;
+        result.SerializeToString(&out);
+        return py::bytes(out.data(), out.size());
+      },
+      "model_bytes"_a);
+
   // INT16 weight-only quantizes MatMul/Gemm/Conv weights (one symmetric
   // scale per output channel, INT16's finer step than INT8's) -- activations
   // are never touched, so no calibration data or ModelExecutor is needed.

--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -55,6 +55,7 @@
 #include "passes/weight_only_quantize_int8_block_conv.h"
 #include "passes/weight_only_quantize_int8_block_matmul.h"
 #include "passes/weight_only_quantize_matmul.h"
+#include "passes/weight_only_quantize_matmul_nbits.h"
 
 namespace onnxsim {
 
@@ -129,6 +130,7 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::WeightOnlyQuantizeInt8BlockConv>(registry);
     RegisterOrReplace<p::WeightOnlyQuantizeInt8BlockMatMul>(registry);
     RegisterOrReplace<p::WeightOnlyQuantizeMatMul>(registry);
+    RegisterOrReplace<p::WeightOnlyQuantizeMatMulNBits>(registry);
 
     // onnxsim's patched versions of built-in onnxoptimizer passes. These
     // overwrite the registry entries the submodule registers under the same

--- a/onnxsim/custom_optimizer_passes.h
+++ b/onnxsim/custom_optimizer_passes.h
@@ -37,6 +37,7 @@ namespace onnxsim {
 //   - static_quantize_int16_matmul
 //   - static_quantize_int16_conv
 //   - weight_only_quantize_matmul
+//   - weight_only_quantize_matmul_nbits
 //   - weight_only_quantize_conv
 //   - weight_only_quantize_int4_matmul
 //   - weight_only_quantize_int4_conv

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -689,6 +689,53 @@ def quantize_weight_only_int4(model: Union[str, onnx.ModelProto]) -> onnx.ModelP
     return onnx.load_from_string(C.quantize_weight_only_int4(model.SerializeToString()))
 
 
+def quantize_weight_only_matmul_nbits(
+    model: Union[str, onnx.ModelProto],
+) -> onnx.ModelProto:
+    """
+    Block-wise INT4 weight-only quantize every MatMul, and every "vanilla"
+    Gemm (transA=0, alpha=1, beta=1), whose weight is a constant 2-D
+    float32 tensor, into ONNX Runtime's own ``com.microsoft::MatMulNBits``
+    contrib op.
+
+    This is a **vendor-specific** counterpart to
+    :func:`quantize_weight_only_int4`: same INT4 precision, same 32-element
+    block-wise scale, but packed into ONNX Runtime's own single fused op --
+    the format ORT's own GenAI/quantization tooling (Olive,
+    ``onnxruntime.quantization``'s ``matmul_4bits_quantizer``, ...) emits
+    for LLM/ASR weight compression -- instead of
+    :func:`quantize_weight_only_int4`'s portable, standard-ONNX
+    INT4-tensor-plus-``DequantizeLinear`` pair. Smaller and faster on ONNX
+    Runtime specifically, at the cost of needing ORT (or another runtime
+    implementing this contrib op) to run at all: unlike every other
+    ``quantize_*`` function in onnxsim, the result does **not** load on an
+    arbitrary conformant ONNX runtime.
+
+    Unlike :func:`quantize_weight_only_int4` (which needs opset 21 for
+    ONNX's own native INT4 tensor type and ``DequantizeLinear``'s
+    ``block_size`` attribute), this needs no minimum standard opset --
+    ``MatMulNBits`` is a self-contained contrib op -- and, unlike that
+    function, does not require the reduction dimension to be evenly
+    divisible by the 32-element block size: ``MatMulNBits`` itself defines
+    ``k_blocks = ceil(K / block_size)``, so a ragged last block is
+    quantized exactly like every other one instead of being declined.
+
+    This is a single, self-contained graph rewrite: unlike :func:`simplify`,
+    it does not run shape inference, constant folding, or any other pass.
+    Nodes that do not match (dynamic or non-2-D weights, non-default Gemm
+    attributes, non-float32 operands) are left untouched. Consider calling
+    :func:`simplify` before and/or after to clean up the graph.
+
+    :param model: onnx ModelProto object or file path
+    :returns: the quantized onnx ModelProto
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    return onnx.load_from_string(
+        C.quantize_weight_only_matmul_nbits(model.SerializeToString())
+    )
+
+
 def quantize_weight_only_int16(model: Union[str, onnx.ModelProto]) -> onnx.ModelProto:
     """
     INT16 weight-only quantize every MatMul, every "vanilla" Gemm (transA=0,

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -303,6 +303,28 @@ onnx::ModelProto QuantizeWeightOnly(const onnx::ModelProto& model);
 // non-float32 operands, an opset older than 21) are left as-is.
 onnx::ModelProto QuantizeWeightOnlyInt4(const onnx::ModelProto& model);
 
+// Weight-only quantizes every MatMul, and every "vanilla" Gemm (transA=0,
+// alpha=1, beta=1), whose weight is a constant 2-D float32 tensor, to ONNX
+// Runtime's ``com.microsoft::MatMulNBits`` contrib op -- a *vendor-specific*
+// counterpart to ``QuantizeWeightOnlyInt4``: same INT4, same 32-element
+// block-wise scale, but packed into ORT's own single fused op (the format
+// ORT's own GenAI/quantization tooling emits for LLM/ASR weight
+// compression) instead of ``QuantizeWeightOnlyInt4``'s portable, standard
+// ONNX opset-21 INT4-tensor-plus-``DequantizeLinear`` pair. Smaller and
+// faster on ONNX Runtime specifically, at the cost of needing ORT (or
+// another runtime implementing this contrib op) to run at all -- unlike
+// every other ``Quantize*`` function here, the result does not load on an
+// arbitrary conformant ONNX runtime. See
+// ``passes/weight_only_quantize_matmul_nbits.h`` for the rewrite itself,
+// including the exact bit-packing format.
+//
+// Unlike ``Simplify``, this does not run shape inference, constant folding or
+// any other simplification pass -- it applies exactly this one rewrite, once,
+// to a copy of ``model`` (which is left untouched) and returns the result.
+// Nodes that do not match (dynamic or non-2-D weights, non-default Gemm
+// attributes, non-float32 operands) are left as-is.
+onnx::ModelProto QuantizeWeightOnlyMatMulNBits(const onnx::ModelProto& model);
+
 // INT16 weight-only quantizes every MatMul, every "vanilla" Gemm (transA=0,
 // alpha=1, beta=1), and every Conv, whose weight is a constant float32
 // tensor: the weight is quantized to INT16 (per output channel, symmetric,

--- a/onnxsim/passes/weight_only_quantize_matmul_nbits.h
+++ b/onnxsim/passes/weight_only_quantize_matmul_nbits.h
@@ -1,0 +1,258 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+// Weight-only quantization to ONNX Runtime's "com.microsoft::MatMulNBits"
+// contrib op -- a *vendor-specific* counterpart to
+// weight_only_quantize_int4_matmul.h's own portable, standard-ONNX INT4
+// scheme (opset 21's native INT4 tensor type + DequantizeLinear's
+// `block_size` attribute). Where that pass produces a result any conformant
+// opset-21+ runtime can load, this one produces the single fused op ORT's
+// own GenAI/quantization tooling (Olive, onnxruntime.quantization's
+// matmul_4bits_quantizer, ...) emits for LLM/ASR weight compression --
+// smaller and faster on ORT specifically, at the cost of needing ORT (or
+// another runtime that implements this contrib op) to run at all. Neither
+// scheme supersedes the other; pick this one when the deployment target is
+// known to be ONNX Runtime and the smaller single-op footprint matters,
+// weight_only_quantize_int4_matmul.h's otherwise.
+//
+// Before (illustrated for MatMul; a "vanilla" Gemm -- transA=0, alpha=1,
+// beta=1 -- is handled the same way, its bias C passed through as
+// MatMulNBits' own optional bias input):
+//   Y = MatMul(X, W)         W constant, 2-D, float32, [K, N] (or [N, K]
+//                            for a transB=1 Gemm)
+// After:
+//   Y = com.microsoft::MatMulNBits(X, Wq, Ws, K=K, N=N, bits=4,
+//                                  block_size=kBlockSize)
+//
+// Wq (packed uint8, shape [N, k_blocks, blob_size]) and Ws (float32, shape
+// [N, k_blocks]) are computed once, here, from W's static values -- see
+// QuantizeWeightForMatMulNBits below. Unlike
+// weight_only_quantize_int4_matmul.h, K need not be evenly divisible by
+// kBlockSize: MatMulNBits' own `k_blocks = ceil(K / block_size)` already
+// accounts for a ragged last (shorter) block, so this quantizes it exactly
+// like every other block instead of declining the whole match.
+//
+// zero_points (input 3) is omitted -- MatMulNBits' own documented default,
+// 2^(bits-1) = 8 for 4-bit, is exactly the symmetric-around-8 code this
+// pass quantizes to (`code = round(w / scale) + 8`, clamped to [0, 15]), so
+// there is nothing an explicit zero_points tensor would add.
+//
+// Only the common, unambiguous shape is handled: a MatMul, or a Gemm with
+// transA=0, alpha=1 and beta=1 (transB may be 0 or 1), whose weight (input
+// 1) is a constant 2-D float32 tensor, and whose activation (input 0) is
+// float32. Everything else -- non-constant or non-2-D weights, non-default
+// Gemm attributes, non-float32 operands -- is left alone.
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+#include "passes/quantize_matmul_common.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+// Quantizes `w_t` (a 2-D float32 constant, laid out as [N, K] when
+// `transposed` else [K, N]) into MatMulNBits' own 4-bit block format:
+// `b_out` (uint8, shape [N, k_blocks, blob_size]) packs two codes per byte,
+// low nibble first, matching the op's documented packing; `scale_out`
+// (float32, shape [N, k_blocks]) holds one scale per (output channel,
+// block). `block_size` must be a power of 2 and >= 16, matching the op's
+// own documented constraint; returns false (nothing written) otherwise.
+//
+// Each block's `block_size` values are quantized symmetrically around the
+// op's own default zero point (2^(bits-1) = 8 for 4-bit): `code =
+// round(w / scale) + 8`, clamped to [0, 15]. A block's tail past K (when K
+// is not evenly divisible by block_size, i.e. the last block is short)
+// packs the fixed zero-point code 8 -- dequantizing to exactly 0 -- since
+// MatMulNBits itself never reads those positions (K is a real attribute
+// the kernel bounds its own reduction by), but every byte still needs a
+// defined value to keep the initializer's contents well-defined.
+inline bool QuantizeWeightForMatMulNBits(const Tensor& w_t, bool transposed,
+                                         int64_t block_size, Tensor& b_out,
+                                         Tensor& scale_out) {
+  if (block_size < 16 || (block_size & (block_size - 1)) != 0) {
+    return false;
+  }
+  const auto& sizes = w_t.sizes();
+  const int64_t dim0 = sizes[0];
+  const int64_t dim1 = sizes[1];
+  const int64_t K = transposed ? dim1 : dim0;
+  const int64_t N = transposed ? dim0 : dim1;
+  const int64_t k_blocks = (K + block_size - 1) / block_size;
+  const int64_t blob_size = block_size / 2;  // bits == 4, block_size even
+
+  const std::vector<float> data = ReadFloatMatrix(w_t);
+  // element (k, n) of the logical [K, N] weight, regardless of storage
+  // layout.
+  auto at = [&](int64_t k, int64_t n) {
+    return transposed ? data[n * K + k] : data[k * N + n];
+  };
+
+  std::vector<float> scale(static_cast<size_t>(N * k_blocks), 0.0f);
+  for (int64_t n = 0; n < N; ++n) {
+    for (int64_t kb = 0; kb < k_blocks; ++kb) {
+      const int64_t k0 = kb * block_size;
+      const int64_t k1 = std::min(K, k0 + block_size);
+      float m = 0.0f;
+      for (int64_t k = k0; k < k1; ++k) {
+        m = std::max(m, std::fabs(at(k, n)));
+      }
+      scale[static_cast<size_t>(n * k_blocks + kb)] =
+          m > 0.0f ? m / 7.0f : 1.0f;
+    }
+  }
+
+  auto code_at = [&](int64_t k, int64_t n, float s) -> uint8_t {
+    if (k >= K) {
+      return 8;  // Past the real weight: fixed zero-point code (dequantizes
+                 // to 0), never read by the kernel (bounded by K).
+    }
+    const float q = std::round(at(k, n) / s);
+    return static_cast<uint8_t>(std::clamp(q, -8.0f, 7.0f) + 8.0f);
+  };
+
+  std::string packed(static_cast<size_t>(N * k_blocks * blob_size), '\0');
+  for (int64_t n = 0; n < N; ++n) {
+    for (int64_t kb = 0; kb < k_blocks; ++kb) {
+      const float s = scale[static_cast<size_t>(n * k_blocks + kb)];
+      const int64_t k0 = kb * block_size;
+      for (int64_t j = 0; j < blob_size; ++j) {
+        const uint8_t lo = code_at(k0 + 2 * j, n, s);
+        const uint8_t hi = code_at(k0 + 2 * j + 1, n, s);
+        const int64_t byte_idx = (n * k_blocks + kb) * blob_size + j;
+        packed[static_cast<size_t>(byte_idx)] =
+            static_cast<char>((lo & 0x0F) | ((hi & 0x0F) << 4));
+      }
+    }
+  }
+
+  b_out.elem_type() = TensorProto_DataType_UINT8;
+  b_out.sizes() = {N, k_blocks, blob_size};
+  b_out.set_raw_data(std::move(packed));
+
+  scale_out.elem_type() = TensorProto_DataType_FLOAT;
+  scale_out.sizes() = {N, k_blocks};
+  scale_out.floats() = std::move(scale);
+  return true;
+}
+
+struct WeightOnlyQuantizeMatMulNBits final : public PredicateBasedPass {
+  // Matches weight_only_quantize_int4_matmul.h's own default: 32 favors
+  // accuracy (more scales, smaller quantization groups) over the
+  // scale-tensor overhead a larger block would save.
+  static constexpr int64_t kBlockSize = 32;
+
+  explicit WeightOnlyQuantizeMatMulNBits()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+  std::string getPassName() const override {
+    return "weight_only_quantize_matmul_nbits";
+  }
+
+  bool patternMatchPredicate(Node* n) override {
+    MatMulLikeInfo info;
+    if (!MatchMatMulLike(n, info)) {
+      return false;
+    }
+    if (info.x->elemType() != TensorProto_DataType_FLOAT) {
+      return false;
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    return w_t != nullptr && w_t->elem_type() == TensorProto_DataType_FLOAT &&
+           w_t->sizes().size() == 2;
+  }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+    MatMulLikeInfo info;
+    if (!MatchMatMulLike(n, info)) {
+      return false;
+    }
+    if (info.x->elemType() != TensorProto_DataType_FLOAT) {
+      return false;
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+        w_t->sizes().size() != 2) {
+      return false;
+    }
+
+    const auto& sizes = w_t->sizes();
+    const int64_t K = info.weight_transposed ? sizes[1] : sizes[0];
+    const int64_t N = info.weight_transposed ? sizes[0] : sizes[1];
+
+    Tensor b_q;
+    Tensor b_scale;
+    if (!QuantizeWeightForMatMulNBits(*w_t, info.weight_transposed, kBlockSize,
+                                      b_q, b_scale)) {
+      return false;
+    }
+
+    Value* b_q_v = graph.addInitializerAndCreateValue(b_q);
+    Value* b_scale_v = graph.addInitializerAndCreateValue(b_scale);
+
+    Node* nbits = graph.create(Symbol("MatMulNBits"), 1);
+    nbits->addInput(info.x);
+    nbits->addInput(b_q_v);
+    nbits->addInput(b_scale_v);
+    if (info.bias != nullptr) {
+      // MatMulNBits' bias is input index 5 -- zero_points (3) and g_idx (4)
+      // are both skipped via an Undefined placeholder, the standard ONNX
+      // IR mechanism for a skipped *middle* optional input (see
+      // dynamic_quantize_attention.h's own use of the same mechanism for
+      // QAttention's mask_index).
+      Node* undef_zp = graph.create(kUndefined, 1);
+      undef_zp->insertBefore(n);
+      undef_zp->output()->setUniqueName("");
+      Node* undef_gidx = graph.create(kUndefined, 1);
+      undef_gidx->insertBefore(n);
+      undef_gidx->output()->setUniqueName("");
+      nbits->addInput(undef_zp->output());
+      nbits->addInput(undef_gidx->output());
+      nbits->addInput(info.bias);
+    }
+    nbits->i_(Symbol("K"), K);
+    nbits->i_(Symbol("N"), N);
+    nbits->i_(Symbol("bits"), static_cast<int64_t>(4));
+    nbits->i_(Symbol("block_size"), kBlockSize);
+    nbits->insertBefore(n);
+    nbits->setDomain("com.microsoft");
+    nbits->output()->setElemType(TensorProto_DataType_FLOAT);
+    nbits->output()->copyMetadata(n->output());
+
+    bool has_ms_domain = false;
+    for (const OpSetID& opset : graph.opset_versions_mutable()) {
+      if (opset.domain() == "com.microsoft") {
+        has_ms_domain = true;
+        break;
+      }
+    }
+    if (!has_ms_domain) {
+      graph.opset_versions_mutable().emplace_back("com.microsoft", 1);
+    }
+
+    if (!tryReplacingAllUsesWith(n, nbits)) {
+      return false;
+    }
+    destroy_current = NodeDestroyType::DestroyOne;
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/quantize_entry.cpp
+++ b/onnxsim/quantize_entry.cpp
@@ -80,6 +80,15 @@ onnx::ModelProto QuantizeWeightOnlyInt4(const onnx::ModelProto& model) {
                                       "weight_only_quantize_int4_conv"});
 }
 
+onnx::ModelProto QuantizeWeightOnlyMatMulNBits(const onnx::ModelProto& model) {
+  PrepareSchemasForDebug(model);
+  // Registers weight_only_quantize_matmul_nbits (idempotent) into
+  // onnxoptimizer's registry so OptimizeFixed can find it by name below.
+  onnxsim::RegisterCustomOptimizerPasses();
+  return onnx::optimization::OptimizeFixed(
+      model, std::vector<std::string>{"weight_only_quantize_matmul_nbits"});
+}
+
 onnx::ModelProto QuantizeWeightOnlyInt16(const onnx::ModelProto& model) {
   PrepareSchemasForDebug(model);
   // Registers weight_only_quantize_int16_matmul/_conv (idempotent) into

--- a/onnxsim/quantize_entry.h
+++ b/onnxsim/quantize_entry.h
@@ -17,6 +17,7 @@ onnx::ModelProto QuantizeDynamic(const onnx::ModelProto& model);
 onnx::ModelProto QuantizeTernary(const onnx::ModelProto& model);
 onnx::ModelProto QuantizeWeightOnly(const onnx::ModelProto& model);
 onnx::ModelProto QuantizeWeightOnlyInt4(const onnx::ModelProto& model);
+onnx::ModelProto QuantizeWeightOnlyMatMulNBits(const onnx::ModelProto& model);
 onnx::ModelProto QuantizeWeightOnlyInt16(const onnx::ModelProto& model);
 onnx::ModelProto QuantizeWeightOnlyInt8Block(const onnx::ModelProto& model);
 

--- a/tests/test_weight_only_quantize_matmul_nbits.py
+++ b/tests/test_weight_only_quantize_matmul_nbits.py
@@ -1,0 +1,238 @@
+"""Tests for ``onnxsim.quantize_weight_only_matmul_nbits`` (the
+``weight_only_quantize_matmul_nbits`` C++ pass) -- weight-only INT4
+quantization into ONNX Runtime's own ``com.microsoft::MatMulNBits`` contrib
+op, a *vendor-specific* counterpart to
+``onnxsim.quantize_weight_only_int4``'s portable standard-ONNX output (see
+``passes/weight_only_quantize_matmul_nbits.h``).
+
+Each model is built directly with ``onnx.helper`` (no torch dependency),
+quantized, and then actually run through ONNX Runtime -- both before and
+after quantization -- so these tests double as a minimal end-to-end
+simplify/quantize/deploy check: the quantized graph must load and execute
+under a real inference engine (which, being a com.microsoft contrib op,
+only ONNX Runtime itself can do), and its outputs must stay close to the
+float baseline. A dedicated test also decodes ``B``'s raw bit-packed bytes
+directly and checks them against a from-scratch reference dequantization,
+independent of ONNX Runtime -- MatMulNBits' packing format (low-nibble-
+first, zero-point-8 symmetric codes) is intricate enough that "the model
+runs and the output is close" alone would not catch every possible packing
+mistake (e.g. one that happens to preserve aggregate accuracy).
+"""
+
+import collections
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+
+import onnxsim
+
+# A bare ``import onnxruntime`` would fail collection (not skip the test) on
+# platforms onnxruntime doesn't ship wheels for (e.g. s390x).
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(nodes, inputs, outputs, initializer, opset=17):
+    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=8
+    )
+
+
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _op_counts(model):
+    return collections.Counter((n.op_type, n.domain) for n in model.graph.node)
+
+
+def _assert_close(float_outputs, quant_outputs, rel_l2_tol=0.25):
+    # Same lossiness class, and same tolerance rationale, as
+    # test_weight_only_quantize_int4.py's identically-named helper: 16
+    # levels per block, no calibration, round-to-nearest on random Gaussian
+    # weights lands in the ~0.07-0.16 range on its own.
+    for f, q in zip(float_outputs, quant_outputs):
+        f = np.asarray(f, dtype=np.float64).ravel()
+        q = np.asarray(q, dtype=np.float64).ravel()
+        assert np.all(np.isfinite(q))
+        rel_l2 = np.linalg.norm(f - q) / max(np.linalg.norm(f), 1e-6)
+        assert rel_l2 < rel_l2_tol, f"relative L2 error too large: {rel_l2:.4f}"
+
+
+def _find(model, pred):
+    return next(t for t in model.graph.initializer if pred(t))
+
+
+def test_quantize_matmul():
+    rng = np.random.default_rng(0)
+    K, N = 64, 16
+    weight = _f32(rng.standard_normal((K, N)) * 0.5, "W")
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [4, K])], [_vi("Y", [4, N])], [weight])
+
+    quant = onnxsim.quantize_weight_only_matmul_nbits(model)
+    onnx.checker.check_model(quant)
+    ops = _op_counts(quant)
+    assert ops[("MatMulNBits", "com.microsoft")] == 1
+    assert ("MatMul", "") not in ops
+    assert any(o.domain == "com.microsoft" for o in quant.opset_import)
+
+    b_init = _find(quant, lambda t: t.data_type == onnx.TensorProto.UINT8)
+    assert list(b_init.dims) == [N, 2, 16]  # k_blocks=64/32=2, blob_size=32/2=16
+
+    x = rng.standard_normal((4, K)).astype(np.float32)
+    _assert_close(_run(model, {"X": x}), _run(quant, {"X": x}))
+
+
+def test_quantize_gemm_transb_with_bias():
+    # PyTorch's nn.Linear layout: weight is [out_features, in_features], i.e.
+    # [N, K], exported as Gemm(X, W, B, transB=1) -- the common real-world case.
+    rng = np.random.default_rng(1)
+    K, N = 96, 12
+    weight = _f32(rng.standard_normal((N, K)) * 0.5, "W")
+    bias = _f32(rng.standard_normal(N), "B")
+    nodes = [onnx.helper.make_node("Gemm", ["X", "W", "B"], ["Y"], transB=1)]
+    model = _model(nodes, [_vi("X", [3, K])], [_vi("Y", [3, N])], [weight, bias])
+
+    quant = onnxsim.quantize_weight_only_matmul_nbits(model)
+    onnx.checker.check_model(quant)
+    (nbits_node,) = [n for n in quant.graph.node if n.op_type == "MatMulNBits"]
+    # A, B, scales, zero_points (skipped), g_idx (skipped), bias.
+    assert len(nbits_node.input) == 6
+    assert nbits_node.input[0] == "X"
+    assert nbits_node.input[1] and nbits_node.input[1] not in ("X", "B")
+    assert nbits_node.input[2] and nbits_node.input[2] not in ("X", "B")
+    assert nbits_node.input[3] == ""
+    assert nbits_node.input[4] == ""
+    assert nbits_node.input[5] == "B"
+
+    x = rng.standard_normal((3, K)).astype(np.float32)
+    _assert_close(_run(model, {"X": x}), _run(quant, {"X": x}))
+
+
+def test_quantize_scale_shape_matches_block_count():
+    # K=64 with the pass's block_size=32 gives k_blocks=2; MatMulNBits'
+    # scales shape is (N, k_blocks) -- output channel first, unlike
+    # quantize_weight_only_int4's DequantizeLinear-oriented (k_blocks, N).
+    rng = np.random.default_rng(2)
+    K, N = 64, 8
+    weight = _f32(rng.standard_normal((K, N)) * 0.5, "W")
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [1, K])], [_vi("Y", [1, N])], [weight])
+
+    quant = onnxsim.quantize_weight_only_matmul_nbits(model)
+    scale_init = _find(
+        quant, lambda t: t.data_type == onnx.TensorProto.FLOAT and t.name != "W"
+    )
+    assert list(scale_init.dims) == [N, 2]
+
+
+def test_quantize_handles_k_not_divisible_by_block_size():
+    # K=48 is not a multiple of the pass's block_size=32 -- unlike
+    # quantize_weight_only_int4 (which declines this case entirely),
+    # MatMulNBits' own k_blocks = ceil(K / block_size) already defines a
+    # ragged last block, so this quantizes it instead of skipping.
+    rng = np.random.default_rng(3)
+    K, N = 48, 8
+    weight = _f32(rng.standard_normal((K, N)) * 0.5, "W")
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [1, K])], [_vi("Y", [1, N])], [weight])
+
+    quant = onnxsim.quantize_weight_only_matmul_nbits(model)
+    onnx.checker.check_model(quant)
+    ops = _op_counts(quant)
+    assert ops[("MatMulNBits", "com.microsoft")] == 1
+    b_init = _find(quant, lambda t: t.data_type == onnx.TensorProto.UINT8)
+    assert list(b_init.dims) == [N, 2, 16]  # k_blocks = ceil(48/32) = 2
+
+    x = rng.standard_normal((1, K)).astype(np.float32)
+    _assert_close(_run(model, {"X": x}), _run(quant, {"X": x}))
+
+
+def test_quantize_works_at_low_opset():
+    # Unlike quantize_weight_only_int4 (needs opset >= 21 for ONNX's own
+    # native INT4 tensor type and DequantizeLinear's block_size attribute),
+    # MatMulNBits is a self-contained contrib op with no minimum standard
+    # opset of its own.
+    rng = np.random.default_rng(4)
+    K, N = 32, 4
+    weight = _f32(rng.standard_normal((K, N)) * 0.5, "W")
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [1, K])], [_vi("Y", [1, N])], [weight], opset=11)
+
+    quant = onnxsim.quantize_weight_only_matmul_nbits(model)
+    onnx.checker.check_model(quant)
+    assert _op_counts(quant)[("MatMulNBits", "com.microsoft")] == 1
+
+    x = rng.standard_normal((1, K)).astype(np.float32)
+    _assert_close(_run(model, {"X": x}), _run(quant, {"X": x}))
+
+
+def test_quantize_skips_non_constant_weight():
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(
+        nodes, [_vi("X", [4, 64]), _vi("W", [64, 4])], [_vi("Y", [4, 4])], []
+    )
+    quant = onnxsim.quantize_weight_only_matmul_nbits(model)
+    assert _op_counts(quant)[("MatMul", "")] == 1
+
+
+def test_quantize_bit_packing_matches_reference_dequantization():
+    # Independent of ONNX Runtime: decode B's raw bit-packed bytes by hand
+    # (low nibble first, code - 8 per MatMulNBits' documented default zero
+    # point) and check the result matches the float weight to within one
+    # quantization step -- catches a packing-order or zero-point mistake
+    # that happened to still produce a plausible-looking aggregate error.
+    rng = np.random.default_rng(5)
+    K, N = 40, 3  # a ragged last block (40 = 32 + 8)
+    weight = rng.standard_normal((K, N)).astype(np.float32) * 0.3
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(nodes, [_vi("X", [1, K])], [_vi("Y", [1, N])], [_f32(weight, "W")])
+    quant = onnxsim.quantize_weight_only_matmul_nbits(model)
+
+    b_init = _find(quant, lambda t: t.data_type == onnx.TensorProto.UINT8)
+    scale_init = _find(
+        quant, lambda t: t.data_type == onnx.TensorProto.FLOAT and t.name != "W"
+    )
+    b_packed = onnx.numpy_helper.to_array(b_init)  # [N, k_blocks, blob_size]
+    scales = onnx.numpy_helper.to_array(scale_init)  # [N, k_blocks]
+    _, k_blocks, blob_size = b_packed.shape
+    block_size = 32
+
+    dequant = np.zeros((N, K), dtype=np.float32)
+    for n in range(N):
+        for kb in range(k_blocks):
+            s = scales[n, kb]
+            k0 = kb * block_size
+            for j in range(blob_size):
+                byte = int(b_packed[n, kb, j])
+                lo, hi = byte & 0x0F, (byte >> 4) & 0x0F
+                if k0 + 2 * j < K:
+                    dequant[n, k0 + 2 * j] = (lo - 8) * s
+                if k0 + 2 * j + 1 < K:
+                    dequant[n, k0 + 2 * j + 1] = (hi - 8) * s
+
+    weight_nk = weight.T  # [K, N] -> [N, K]
+    # Every element's quantization error must be within half a code step
+    # (the maximum possible round-to-nearest error), not just close on
+    # aggregate.
+    for n in range(N):
+        for kb in range(k_blocks):
+            k0, k1 = kb * block_size, min(K, (kb + 1) * block_size)
+            step = scales[n, kb]
+            err = np.abs(weight_nk[n, k0:k1] - dequant[n, k0:k1])
+            assert np.all(err <= step / 2 + 1e-6)


### PR DESCRIPTION
## Summary

Adds `quantize_weight_only_matmul_nbits`, a new C++ optimizer pass + Python API that quantizes `MatMul`/`Gemm` nodes with a constant 2-D float32 weight into ONNX Runtime's own `com.microsoft::MatMulNBits` contrib op -- the single fused weight-only INT4 op ORT's GenAI/quantization tooling (Olive, `onnxruntime.quantization`'s `matmul_4bits_quantizer`, ...) emits for LLM/ASR weight compression.

This is a genuinely **vendor-specific** counterpart to the existing `quantize_weight_only_int4` pass, which targets opset 21's *portable*, standard-ONNX INT4 tensor type + `DequantizeLinear`'s `block_size` attribute. Neither scheme supersedes the other:

| | `quantize_weight_only_int4` | `quantize_weight_only_matmul_nbits` (new) |
|---|---|---|
| Output | Standard ONNX (opset 21+) | `com.microsoft` contrib op |
| Runtime | Any conformant opset-21+ engine | ONNX Runtime (or another engine implementing this op) |
| Requires K % block_size == 0 | Yes (declines otherwise) | No -- ragged last block is quantized like every other |
| Minimum opset | 21 | None (self-contained contrib op) |

## Technical details

- Matches a `MatMul`, or a vanilla `Gemm` (`transA=0`, `alpha=1`, `beta=1`; `transB` may be 0 or 1), with a constant 2-D float32 weight and float32 activation.
- Computes `MatMulNBits`' packed uint8 weight blob (`[N, k_blocks, blob_size]`, two 4-bit codes per byte, low-nibble-first) and per-`(output-channel, block)` float32 scales directly from the static weight values, quantizing symmetrically around the op's documented default zero point (`2^(bits-1) = 8` for 4-bit).
- `K` need not be evenly divisible by the block size (default 32) -- `MatMulNBits`' own `k_blocks = ceil(K / block_size)` already defines a ragged last block, so this quantizes it exactly like every other block instead of declining the whole match.
- When the source node had a bias, it's threaded through as `MatMulNBits`' own optional bias input, with `zero_points`/`g_idx` skipped via the standard ONNX IR mechanism for a skipped middle optional input (`Undefined` placeholder nodes -- the same idiom `dynamic_quantize_attention.h` uses for `QAttention`'s `mask_index`).
- Registers the `MatMulNBits` op schema in `contrib_schemas.cpp`, the Python-wheel build's manually-maintained schema fallback that provides ONNX checker / shape-inference support for contrib ops onnxsim's own passes emit, for when a real ONNX Runtime isn't linked in (per `CLAUDE.md`, the wheel build never compiles ONNX Runtime itself -- `ONNXSIM_BUILTIN_ORT=OFF`).

## Verification

- Cross-checked the entire packing + dequantization scheme against a live `onnxruntime` CPU session with a hand-rolled numpy reference before writing any C++ (max abs diff ~4.8e-7).
- End-to-end tests run the emitted graph through a real `onnxruntime.InferenceSession` across three shape variants: plain `MatMul`, `Gemm` with `transB=1` + bias, and a ragged-`K` case (`K=48`, block size 32).
- A dedicated test independently decodes `B`'s raw bit-packed bytes by hand (low-nibble-first, zero-point-8 symmetric codes) and checks every element's dequantization error is within half a quantization step of the true float weight -- catches a packing-order or zero-point mistake that might not show up in aggregate output error alone.
- Full regression sweep: `tests/` (excluding torch/timm-dependent modules not installed in this environment) -- **427 passed, 68 skipped, 0 failed**. No regressions from the shared-file edits (`contrib_schemas.cpp`, `custom_optimizer_passes.{h,cpp}`).
- `ruff format` / `ruff check` clean on all modified/new Python files; `clang-format` produced no diff on any modified/new C++ file (already matched repo style).

## New files

- `onnxsim/passes/weight_only_quantize_matmul_nbits.h` -- the pass itself
- `tests/test_weight_only_quantize_matmul_nbits.py` -- 7 tests

## Test plan

- [x] `pytest tests/test_weight_only_quantize_matmul_nbits.py -v`
- [x] `pytest tests/test_weight_only_quantize_int4.py tests/test_accuracy.py tests/test_cross_layer_equalization.py tests/test_bias_correction.py -q`
- [x] Full `tests/` sweep (torch/timm-dependent modules excluded, not installed in this environment)
- [x] `ruff format` / `ruff check`
- [x] `clang-format` (no diff)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_