### PR TITLE
Add auto_quantize_int4: AIMET's AutoQuant escalating PTQ pipeline

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -10,6 +10,7 @@ from onnxsim.accuracy import (
     recommend_quantization,
 )
 from onnxsim.adaround import apply_adaround
+from onnxsim.autoquant import AutoQuantResult, auto_quantize_int4
 from onnxsim.bias_correction import correct_bias
 from onnxsim.calibration import (
     calibrate,
@@ -68,6 +69,8 @@ __all__ = [
     "cross_layer_equalize",
     "correct_bias",
     "apply_adaround",
+    "auto_quantize_int4",
+    "AutoQuantResult",
     "quantize_attention_dynamic",
     "quantize_dynamic",
     "quantize_dynamic_matmul_integer_to_float",

--- a/onnxsim/autoquant.py
+++ b/onnxsim/autoquant.py
@@ -1,0 +1,227 @@
+"""AIMET's AutoQuant -- Qualcomm AIMET's automated, escalating pipeline that
+strings its own PTQ techniques together and stops as soon as a model's
+accuracy is good enough, instead of applying every technique regardless of
+whether it's needed. The last of AIMET's four flagship PTQ techniques ported
+to onnxsim, after Cross-Layer Equalization
+(:func:`onnxsim.cross_layer_equalize`), empirical Bias Correction
+(:func:`onnxsim.correct_bias`), and AdaRound (:func:`onnxsim.apply_adaround`).
+
+AIMET's own AutoQuant targets a fixed W8A8 baseline and escalates through
+CLE+BC, then AdaRound, when a user-supplied eval function reports the
+baseline isn't accurate enough. onnxsim has no notion of a downstream eval
+function (no labels, no task-specific metric) -- :func:`auto_quantize_int4`
+instead escalates against :func:`onnxsim.measure_accuracy_drop`'s
+model-agnostic relative-L2 comparison against the float model, matching
+:func:`onnxsim.recommend_quantization`'s own accuracy-budget convention. It
+targets :func:`onnxsim.quantize_weight_only_int4` specifically (rather than
+searching bit widths/schemes the way :func:`onnxsim.recommend_quantization`
+does) because AdaRound -- the strongest of the three refinements, and the
+one this pipeline saves for last -- only optimizes that scheme's own output;
+see :mod:`onnxsim.adaround`.
+
+The escalation, cheapest and least invasive first, each stage strictly
+cumulative on the last:
+
+1. **Baseline**: :func:`onnxsim.quantize_weight_only_int4` alone.
+2. **+ Cross-Layer Equalization**: :func:`onnxsim.cross_layer_equalize` the
+   float model first (data-free, changes nothing but weight
+   parameterization -- see its own docstring), then re-quantize the
+   equalized model.
+3. **+ AdaRound**: :func:`onnxsim.apply_adaround` on top of stage 2's
+   quantized output, using real calibration data.
+4. **+ Bias Correction**: :func:`onnxsim.correct_bias` on top of stage 3's
+   quantized output, using the same calibration data.
+
+AdaRound runs before Bias Correction, not after: :func:`onnxsim.correct_bias`
+renames its corrected layer's own output node (inserting an ``Add`` right
+after it to reclaim the original name -- see its own docstring) and
+:func:`onnxsim.apply_adaround` matches a MatMul/Gemm between the float and
+quantized graphs *by that same output name*, so a Bias-Correction-then-
+AdaRound order would make every corrected layer invisible to AdaRound's own
+candidate search. Running AdaRound first, while every layer still has its
+original name, avoids the problem entirely -- and reads naturally besides:
+optimize each layer's own rounding first, then correct whatever per-channel
+bias is still left over once the rounding is already as good as it gets.
+
+Stops and returns as soon as a stage's measured accuracy meets
+``accuracy_budget``; if none do, returns the least-lossy stage reached
+(``meets_budget=False``), same fallback convention as
+:func:`onnxsim.recommend_quantization`. Every stage after the baseline is
+strictly more expensive than the last (CLE is cheap and data-free; Bias
+Correction and AdaRound both run real calibration data through the model,
+AdaRound by far the most expensive of the three -- a per-layer gradient
+optimization), so stopping early is not just an accuracy convenience but a
+real cost saving, exactly AIMET AutoQuant's own point.
+
+This module implements no actual *quantization-aware training* (QAT) --
+onnxsim is a graph-transformation tool with no training loop, optimizer, or
+labeled data of its own, and grafting one on would be a different, far
+larger project than the rest of this PTQ-technique port. AIMET's own
+AutoQuant is itself PTQ-only (it falls back to recommending the user try QAT
+separately when even AdaRound doesn't meet the target) -- this module
+matches that scope exactly, it does not fall short of it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Union
+
+import onnx
+
+from onnxsim.accuracy import AccuracyDropReport, measure_accuracy_drop
+from onnxsim.adaround import apply_adaround
+from onnxsim.bias_correction import correct_bias
+from onnxsim.calibration import Tensors, generate_random_calibration_data
+from onnxsim.onnx_simplifier import cross_layer_equalize, quantize_weight_only_int4
+
+
+@dataclass
+class AutoQuantResult:
+    """One :func:`auto_quantize_int4` result: the quantized model reached,
+    which AIMET refinement techniques were layered on top of the baseline
+    INT4 weight-only quantization to reach it (in application order --
+    ``[]`` means the unrefined baseline already met budget, a prefix of
+    ``["cross_layer_equalization", "bias_correction", "adaround"]``
+    otherwise), its measured accuracy drop, and whether it met
+    ``accuracy_budget``.
+    """
+
+    quantized_model: onnx.ModelProto
+    report: AccuracyDropReport
+    techniques_applied: List[str]
+    meets_budget: bool
+
+
+def auto_quantize_int4(
+    model: Union[str, onnx.ModelProto],
+    accuracy_budget: float = 0.1,
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_samples: int = 8,
+    seed: int = 0,
+    providers: Optional[Sequence[str]] = None,
+    num_adaround_iterations: int = 300,
+) -> AutoQuantResult:
+    """Quantizes ``model`` to INT4 weight-only (see
+    :func:`onnxsim.quantize_weight_only_int4`), escalating through AIMET's
+    Cross-Layer Equalization, Bias Correction, and AdaRound refinements one
+    at a time until the measured accuracy (see
+    :func:`onnxsim.measure_accuracy_drop`) meets ``accuracy_budget`` or every
+    refinement has been tried. See this module's own docstring for the full
+    escalation order and rationale.
+
+    Every stage is measured against the *original* ``model``, not the
+    previous stage, so accuracy numbers are always directly comparable to
+    each other and to a plain :func:`onnxsim.quantize_weight_only_int4` call.
+    ``accuracy_budget``'s default (``0.1``) is looser than
+    :func:`onnxsim.recommend_quantization`'s (``0.02``): INT4 weight-only
+    quantization is considerably lossier than the 8/16-bit schemes that
+    function searches over (see ``test_weight_only_quantize_int4.py``'s own
+    ~0.07-0.16 untuned baseline range), so a comparably tight budget would
+    make even AdaRound-refined INT4 fail it on most models.
+
+    :param model: the original (unquantized) onnx ModelProto or file path
+    :param accuracy_budget: maximum acceptable worst-case relative L2 error
+            (see :attr:`onnxsim.AccuracyDropReport.worst_relative_l2`) for a
+            stage to be accepted
+    :param calibration_data: representative input batches, used by every
+            data-driven stage (Bias Correction, AdaRound) and to measure
+            each stage's accuracy drop. Each batch is a
+            ``{input_name: np.ndarray}`` dict matching ``model``'s graph
+            inputs -- see :func:`onnxsim.generate_random_calibration_data`
+            (the default when omitted) and
+            :func:`onnxsim.load_huggingface_calibration_data` (real data, a
+            much more representative search than random input).
+    :param num_samples: random batches to generate when ``calibration_data``
+            is omitted
+    :param seed: seed for the random calibration data (ignored if
+            ``calibration_data`` is supplied)
+    :param providers: onnxruntime execution providers to calibrate/run on
+    :param num_adaround_iterations: ``num_iterations`` forwarded to
+            :func:`onnxsim.apply_adaround`, only reached if every earlier
+            stage misses ``accuracy_budget``
+    :returns: the best stage reached -- ``meets_budget=True`` as soon as one
+            does, otherwise the least-lossy stage after all four have been
+            tried
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            model, num_samples=num_samples, seed=seed
+        )
+
+    def _measure(quantized: onnx.ModelProto) -> AccuracyDropReport:
+        return measure_accuracy_drop(
+            model,
+            quantized,
+            calibration_data=calibration_data,
+            num_samples=num_samples,
+            seed=seed,
+            providers=providers,
+        )
+
+    def _meets(report: AccuracyDropReport) -> bool:
+        return report.all_finite and report.worst_relative_l2 < accuracy_budget
+
+    def _better(a: AccuracyDropReport, b: AccuracyDropReport) -> bool:
+        # Whether report `a` should replace best-so-far report `b`.
+        if a.all_finite and not b.all_finite:
+            return True
+        if not a.all_finite:
+            return False
+        return a.worst_relative_l2 < b.worst_relative_l2
+
+    baseline = quantize_weight_only_int4(model)
+    baseline_report = _measure(baseline)
+    best = AutoQuantResult(baseline, baseline_report, [], _meets(baseline_report))
+    if best.meets_budget:
+        return best
+
+    float_cle = cross_layer_equalize(model)
+
+    cle_quantized = quantize_weight_only_int4(float_cle)
+    cle_report = _measure(cle_quantized)
+    cle_result = AutoQuantResult(
+        cle_quantized, cle_report, ["cross_layer_equalization"], _meets(cle_report)
+    )
+    if _better(cle_report, best.report):
+        best = cle_result
+    if cle_result.meets_budget:
+        return cle_result
+
+    ada_quantized = apply_adaround(
+        float_cle,
+        cle_quantized,
+        calibration_data=calibration_data,
+        providers=providers,
+        num_iterations=num_adaround_iterations,
+    )
+    ada_report = _measure(ada_quantized)
+    ada_result = AutoQuantResult(
+        ada_quantized,
+        ada_report,
+        ["cross_layer_equalization", "adaround"],
+        _meets(ada_report),
+    )
+    if _better(ada_report, best.report):
+        best = ada_result
+    if ada_result.meets_budget:
+        return ada_result
+
+    bc_quantized = correct_bias(
+        float_cle,
+        ada_quantized,
+        calibration_data=calibration_data,
+        providers=providers,
+    )
+    bc_report = _measure(bc_quantized)
+    bc_result = AutoQuantResult(
+        bc_quantized,
+        bc_report,
+        ["cross_layer_equalization", "adaround", "bias_correction"],
+        _meets(bc_report),
+    )
+    if _better(bc_report, best.report):
+        best = bc_result
+    return best

--- a/tests/test_autoquant.py
+++ b/tests/test_autoquant.py
@@ -1,0 +1,202 @@
+"""Tests for ``onnxsim.auto_quantize_int4`` (AIMET's AutoQuant, see
+``onnxsim/autoquant.py``) -- the escalating baseline -> CLE -> AdaRound ->
+Bias Correction pipeline built on top of the three previously-ported AIMET
+techniques and ``onnxsim.quantize_weight_only_int4``.
+"""
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import onnx.shape_inference
+import pytest
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(np.asarray(array, dtype=np.float32), name)
+
+
+def _model(nodes, inputs, outputs, initializer, opset=21):
+    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+    )
+    # weight_only_quantize_int4_matmul.h declines a MatMul/Gemm whose
+    # activation input's elem_type isn't known -- true for an intermediate
+    # tensor (e.g. Flatten's output) with no declared value_info, which
+    # onnx.helper.make_graph never infers on its own.
+    return onnx.shape_inference.infer_shapes(model)
+
+
+def _gemm_model(K=64, N=16, batch=8, seed=0):
+    rng = np.random.default_rng(seed)
+    weight = rng.standard_normal((N, K)).astype(np.float32) * 0.5
+    bias = rng.standard_normal(N).astype(np.float32) * 0.1
+    nodes = [onnx.helper.make_node("Gemm", ["X", "W", "B"], ["Y"], transB=1)]
+    return _model(
+        nodes,
+        [_vi("X", [batch, K])],
+        [_vi("Y", [batch, N])],
+        [_f32(weight, "W"), _f32(bias, "B")],
+    )
+
+
+def _conv_and_gemm_model(seed=0):
+    # Conv1 -> Relu -> Conv2 (CLE has real work to do: an outlier channel
+    # unbalances Conv1/Conv2's per-channel weight ranges), then flattened
+    # into a Gemm (AdaRound has real work to do: only MatMul/Gemm are
+    # AdaRound candidates, see adaround.py).
+    rng = np.random.default_rng(seed)
+    w1 = rng.standard_normal((8, 4, 3, 3)).astype(np.float32) * 0.1
+    w1[0] *= 30.0  # outlier channel, matching test_cross_layer_equalization.py
+    b1 = rng.standard_normal(8).astype(np.float32) * 0.01
+    w2 = rng.standard_normal((4, 8, 3, 3)).astype(np.float32) * 0.1
+    b2 = rng.standard_normal(4).astype(np.float32) * 0.01
+    wg = rng.standard_normal((4, 4 * 8 * 8)).astype(np.float32) * 0.05
+    bg = rng.standard_normal(4).astype(np.float32) * 0.01
+
+    nodes = [
+        onnx.helper.make_node(
+            "Conv", ["X", "W1", "B1"], ["C1"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
+        ),
+        onnx.helper.make_node("Relu", ["C1"], ["R1"]),
+        onnx.helper.make_node(
+            "Conv", ["R1", "W2", "B2"], ["C2"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
+        ),
+        onnx.helper.make_node("Flatten", ["C2"], ["F"]),
+        onnx.helper.make_node("Gemm", ["F", "WG", "BG"], ["Y"], transB=1),
+    ]
+    return _model(
+        nodes,
+        [_vi("X", [2, 4, 8, 8])],
+        [_vi("Y", [2, 4])],
+        [
+            _f32(w1, "W1"),
+            _f32(b1, "B1"),
+            _f32(w2, "W2"),
+            _f32(b2, "B2"),
+            _f32(wg, "WG"),
+            _f32(bg, "BG"),
+        ],
+    )
+
+
+def test_auto_quantize_returns_baseline_immediately_when_budget_is_loose():
+    model = _gemm_model(seed=1)
+    rng = np.random.default_rng(2)
+    calibration_data = [{"X": rng.standard_normal((8, 64)).astype(np.float32)}]
+
+    result = onnxsim.auto_quantize_int4(
+        model, accuracy_budget=1.0, calibration_data=calibration_data
+    )
+    assert result.techniques_applied == []
+    assert result.meets_budget
+    onnx.checker.check_model(result.quantized_model)
+
+
+def test_auto_quantize_exhausts_every_stage_when_budget_is_unreachable():
+    model = _conv_and_gemm_model(seed=3)
+    rng = np.random.default_rng(4)
+    calibration_data = [{"X": rng.standard_normal((2, 4, 8, 8)).astype(np.float32)}]
+
+    result = onnxsim.auto_quantize_int4(
+        model,
+        accuracy_budget=0.0,  # unreachable -- every stage must be tried
+        calibration_data=calibration_data,
+        num_adaround_iterations=100,
+    )
+    # accuracy_budget=0.0 means no stage can ever *meet* budget, so all four
+    # are attempted -- but the returned result is the best *reached* across
+    # them (never regressing versus an earlier stage, matching
+    # recommend_quantization's own least-lossy-fallback convention), which
+    # need not be the final stage if an earlier one already did best.
+    valid_prefixes = [
+        [],
+        ["cross_layer_equalization"],
+        ["cross_layer_equalization", "adaround"],
+        ["cross_layer_equalization", "adaround", "bias_correction"],
+    ]
+    assert result.techniques_applied in valid_prefixes
+    # For this model/seed, AdaRound and Bias Correction each measurably
+    # improve on the stage before them (verified independently), so the
+    # pipeline should reach further than the untouched baseline.
+    assert result.techniques_applied != []
+    assert not result.meets_budget
+    onnx.checker.check_model(result.quantized_model)
+
+    sess = ort.InferenceSession(
+        result.quantized_model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    (y,) = sess.run(None, calibration_data[0])
+    assert np.all(np.isfinite(y))
+
+
+def test_auto_quantize_escalates_to_meet_a_budget_baseline_misses():
+    model = _gemm_model(K=64, N=16, batch=32, seed=5)
+    rng = np.random.default_rng(6)
+    calibration_data = [{"X": rng.standard_normal((32, 64)).astype(np.float32)}]
+
+    # Measure the baseline's own error first, then pick a budget the
+    # baseline provably misses but that the full pipeline (whose final
+    # stage's error this test does not otherwise assume the exact value of)
+    # has a real chance to reach -- avoids a hand-tuned magic threshold.
+    baseline = onnxsim.quantize_weight_only_int4(model)
+    baseline_report = onnxsim.measure_accuracy_drop(
+        model, baseline, calibration_data=calibration_data
+    )
+    budget = baseline_report.worst_relative_l2 * 0.98
+
+    result = onnxsim.auto_quantize_int4(
+        model,
+        accuracy_budget=budget,
+        calibration_data=calibration_data,
+        num_adaround_iterations=200,
+    )
+    assert result.techniques_applied != []
+    assert result.report.worst_relative_l2 <= baseline_report.worst_relative_l2
+
+
+def test_auto_quantize_report_matches_returned_model():
+    model = _gemm_model(seed=7)
+    rng = np.random.default_rng(8)
+    calibration_data = [{"X": rng.standard_normal((8, 64)).astype(np.float32)}]
+
+    result = onnxsim.auto_quantize_int4(
+        model,
+        accuracy_budget=0.0,
+        calibration_data=calibration_data,
+        num_adaround_iterations=50,
+    )
+    recomputed = onnxsim.measure_accuracy_drop(
+        model, result.quantized_model, calibration_data=calibration_data
+    )
+    assert recomputed.worst_relative_l2 == pytest.approx(
+        result.report.worst_relative_l2
+    )
+
+
+def test_auto_quantize_never_regresses_versus_baseline():
+    model = _conv_and_gemm_model(seed=9)
+    rng = np.random.default_rng(10)
+    calibration_data = [{"X": rng.standard_normal((2, 4, 8, 8)).astype(np.float32)}]
+
+    baseline = onnxsim.quantize_weight_only_int4(model)
+    baseline_report = onnxsim.measure_accuracy_drop(
+        model, baseline, calibration_data=calibration_data
+    )
+
+    result = onnxsim.auto_quantize_int4(
+        model,
+        accuracy_budget=0.0,
+        calibration_data=calibration_data,
+        num_adaround_iterations=100,
+    )
+    assert result.report.worst_relative_l2 <= baseline_report.worst_relative_l2 + 1e-9


### PR DESCRIPTION
## Summary

Adds `auto_quantize_int4`, implementing AIMET's **AutoQuant** -- the last of AIMET's four flagship PTQ techniques ported to onnxsim, after Cross-Layer Equalization (#708), empirical Bias Correction (#712), and AdaRound (#718).

AutoQuant strings those three techniques (plus plain `quantize_weight_only_int4`) together into a single escalating pipeline that stops as soon as a model's measured accuracy is good enough, instead of always paying for every technique regardless of whether it's needed.

## Design

onnxsim has no notion of a downstream eval function the way AIMET's own AutoQuant does (no labels, no task-specific metric) -- this escalates against `measure_accuracy_drop`'s model-agnostic relative-L2 comparison, matching `recommend_quantization`'s own accuracy-budget convention. It targets `quantize_weight_only_int4` specifically (rather than searching bit widths/schemes the way `recommend_quantization` does) because AdaRound -- the strongest of the three refinements -- only optimizes that scheme's own output.

Escalation order, cheapest and least invasive first:

1. **Baseline**: `quantize_weight_only_int4` alone.
2. **+ Cross-Layer Equalization**: data-free, equalizes the float model first.
3. **+ AdaRound**: optimizes each layer's own weight rounding against real calibration data.
4. **+ Bias Correction**: corrects whatever per-channel bias is left over.

Every stage tracks the best (never-regressing) result across the whole run, so the returned model is never worse than an earlier stage even if a later refinement happens not to help -- same fallback convention `recommend_quantization` already uses.

**AdaRound runs before Bias Correction, not after** -- a real bug I hit and fixed during testing: `correct_bias` renames its corrected layer's own output node (inserting an `Add` to reclaim the original name), and `apply_adaround` matches a MatMul/Gemm between the float and quantized graphs *by that same output name*. A Bias-Correction-then-AdaRound order silently made every corrected layer invisible to AdaRound's own candidate search (0 candidates found, confirmed via a debug script). Running AdaRound first avoids the problem entirely -- and reads naturally besides: optimize each layer's own rounding first, then correct whatever per-channel bias is left over once the rounding is already as good as it gets.

This module implements no actual *quantization-aware training* (QAT) -- onnxsim is a graph-transformation tool with no training loop, optimizer, or labeled data of its own. AIMET's own AutoQuant is itself PTQ-only (it recommends the user try QAT separately when even AdaRound misses the target); this matches that scope exactly.

## Verification

- Tested with a Gemm-only model (baseline/budget-driven escalation) and a **Conv-chain-into-Gemm model** that exercises all four stages together -- CLE has real work to do on the Conv chain (an outlier channel), AdaRound/Bias Correction have real work to do on the Gemm.
- The AdaRound-before-BiasCorrection bug above was caught precisely because this integration test used a non-trivial graph (`Flatten -> Gemm`, not just single-node models) -- worth calling out since it's the kind of bug a narrower test suite would have missed entirely.
- Full regression sweep: `tests/` (excluding torch/timm-dependent modules not installed in this environment) -- **438 passed, 68 skipped, 0 failed**. No regressions.
- `ruff format` / `ruff check` clean.

## New files

- `onnxsim/autoquant.py`
- `tests/test_autoquant.py` -- 5 tests

## Test plan

- [x] `pytest tests/test_autoquant.py -v`
- [x] `pytest tests/test_adaround.py tests/test_bias_correction.py tests/test_cross_layer_equalization.py tests/test_weight_only_quantize_int4.py tests/test_accuracy.py -q`
- [x] Full `tests/` sweep (torch/timm-dependent modules excluded, not installed in this environment)
- [x] `ruff format` / `ruff check`

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_