### PR TITLE
fuse_matmul_add_bias_into_gemm_batched: batch fresh initializer names

### DIFF
--- a/onnxsim/passes/fuse_matmul_add_bias_into_gemm_batched.h
+++ b/onnxsim/passes/fuse_matmul_add_bias_into_gemm_batched.h
@@ -48,12 +48,27 @@ struct FuseMatMulAddBiasIntoGemmBatched final : public PredicateBasedPass {
     return "fuse_matmul_add_bias_into_gemm_batched";
   }
 
-  static Value* MakeInt64Constant(Graph& graph, std::vector<int64_t> data) {
+  // This pass instance is reused across every round of onnxsim's
+  // simplification fixed point, but a batch of reserved names is only valid
+  // for the graph state it was reserved against -- other passes/rounds can
+  // introduce new names in between. Drop any leftover reservation from a
+  // prior runPass() call so nextReservedName() always reserves fresh against
+  // the current graph (mirrors ExtractConstantToInitializer's own
+  // initializePass, same rationale).
+  bool initializePass(Graph&) override {
+    reserved_names_.clear();
+    reserved_used_ = 0;
+    return false;
+  }
+
+  static Value* MakeInt64Constant(Graph& graph, std::vector<int64_t> data,
+                                  std::string name) {
     Tensor t;
+    t.setName(std::move(name));
     t.sizes().push_back(static_cast<int64_t>(data.size()));
     t.elem_type() = TensorProto_DataType_INT64;
     t.int64s() = std::move(data);
-    return graph.addInitializerAndCreateValue(t);
+    return graph.addInitializerAndCreateValue(std::move(t));
   }
 
   // Add is commutative, so the MatMul may be either operand. Exporters differ:
@@ -150,7 +165,7 @@ struct FuseMatMulAddBiasIntoGemmBatched final : public PredicateBasedPass {
     // X2 = Reshape(X, [-1, K])
     Node* pre = graph.create(kReshape, 1);
     pre->addInput(x);
-    pre->addInput(MakeInt64Constant(graph, {-1, k}));
+    pre->addInput(MakeInt64Constant(graph, {-1, k}, nextReservedName(graph)));
 
     // G = Gemm(X2, W, bias)
     Node* gemm = graph.create(kGemm, 1);
@@ -183,7 +198,8 @@ struct FuseMatMulAddBiasIntoGemmBatched final : public PredicateBasedPass {
     if (leading_static) {
       std::vector<int64_t> out_shape = leading_dims;
       out_shape.push_back(out_n);
-      post->addInput(MakeInt64Constant(graph, std::move(out_shape)));
+      post->addInput(MakeInt64Constant(graph, std::move(out_shape),
+                                       nextReservedName(graph)));
     } else {
       // shape(X) -> slice off the last dim -> concat with [N]
       Node* shape = graph.create(Symbol("Shape"), 1);
@@ -192,14 +208,18 @@ struct FuseMatMulAddBiasIntoGemmBatched final : public PredicateBasedPass {
 
       Node* slice = graph.create(kSlice, 1);
       slice->addInput(shape->output());
-      slice->addInput(MakeInt64Constant(graph, {0}));         // starts
-      slice->addInput(MakeInt64Constant(graph, {rank - 1}));  // ends
-      slice->addInput(MakeInt64Constant(graph, {0}));         // axes
+      slice->addInput(
+          MakeInt64Constant(graph, {0}, nextReservedName(graph)));  // starts
+      slice->addInput(MakeInt64Constant(graph, {rank - 1},
+                                        nextReservedName(graph)));  // ends
+      slice->addInput(
+          MakeInt64Constant(graph, {0}, nextReservedName(graph)));  // axes
       slice->insertBefore(n);
 
       Node* concat = graph.create(kConcat, 1);
       concat->addInput(slice->output());
-      concat->addInput(MakeInt64Constant(graph, {out_n}));
+      concat->addInput(
+          MakeInt64Constant(graph, {out_n}, nextReservedName(graph)));
       concat->i_(kaxis, 0);
       concat->insertBefore(n);
 
@@ -217,6 +237,32 @@ struct FuseMatMulAddBiasIntoGemmBatched final : public PredicateBasedPass {
     // Destroy the Add; the now-dead MatMul is cleaned up by DCE.
     destroy_current = NodeDestroyType::DestroyOne;
     return true;
+  }
+
+ private:
+  // Each match mints up to 5 fresh initializer names (pre-reshape's shape,
+  // plus either the post-reshape's shape or -- on the dynamic-leading-dims
+  // path -- Slice's starts/ends/axes and Concat's [N]). Each of those,
+  // undrawn from a reservation, would go through
+  // Graph::addInitializerAndCreateValue -> getNextUniqueName(), and every
+  // such call pays a full graph (and subgraph) scan of its own -- on a
+  // transformer model with dozens of batched Linear layers this made the
+  // pass's modify-phase cost scale with matches * graph size instead of
+  // matches (see model-regression CI's pass-phase profiling: BERT showed
+  // ~1.4ms/match here despite patternMatchPredicate being ~0). Same fix as
+  // ExtractConstantToInitializer (onnxsim issue #651): draw from a batch
+  // reserved via Graph::reserveUniqueNames() (one scan per batch) instead of
+  // one scan per name.
+  static constexpr size_t kNameBatchSize = 256;
+  std::vector<std::string> reserved_names_;
+  size_t reserved_used_ = 0;
+
+  std::string nextReservedName(Graph& graph) {
+    if (reserved_used_ >= reserved_names_.size()) {
+      reserved_names_ = graph.reserveUniqueNames(kNameBatchSize);
+      reserved_used_ = 0;
+    }
+    return std::move(reserved_names_[reserved_used_++]);
   }
 };
 

--- a/tests/test_moved_optimizer_passes.py
+++ b/tests/test_moved_optimizer_passes.py
@@ -18,8 +18,9 @@ import onnx
 import onnxsim
 
 
-def _simplify(model):
-    sim_model, check_ok = onnxsim.simplify(model, check_n=3)
+def _simplify(model, **kwargs):
+    kwargs.setdefault("check_n", 3)
+    sim_model, check_ok = onnxsim.simplify(model, **kwargs)
     assert check_ok, "simplified model failed onnxsim's equivalence check"
     return sim_model, collections.Counter(n.op_type for n in sim_model.graph.node)
 
@@ -180,6 +181,41 @@ def test_fuse_matmul_add_bias_into_gemm_batched():
     sim, ops = _simplify(model)
     assert ops["Gemm"] >= 1
     assert "MatMul" not in ops
+
+
+def test_fuse_matmul_add_bias_into_gemm_batched_dynamic_many_matches():
+    # X has dynamic leading dims (symbolic "batch"/"seq"), so runTransform
+    # takes the Shape/Slice/Concat path (see the pass's own comment) instead
+    # of a plain Reshape-to-a-constant-shape -- that path mints up to 5 fresh
+    # initializer names per match instead of 2. Many independent linear
+    # layers over the same input force many such matches within one
+    # runPass() call, exercising FuseMatMulAddBiasIntoGemmBatched's batched
+    # name-reservation (nextReservedName/reserveUniqueNames): a bug in how it
+    # hands out/consumes reserved names would surface as a duplicate
+    # initializer name here, silently corrupting one layer's weights/bias
+    # with another's.
+    n_layers = 8
+    nodes = []
+    initializers = []
+    outputs = []
+    for i in range(n_layers):
+        w = _f32(np.random.randn(4, 5), f"W{i}")
+        b = _f32(np.random.randn(5), f"B{i}")
+        initializers += [w, b]
+        nodes += [
+            onnx.helper.make_node("MatMul", ["X", f"W{i}"], [f"Z{i}"]),
+            onnx.helper.make_node("Add", [f"Z{i}", f"B{i}"], [f"A{i}"]),
+        ]
+        outputs.append(_vi(f"A{i}", ("batch", "seq", 5)))
+    model = _model(
+        nodes, [_vi("X", ("batch", "seq", 4))], outputs, initializers, opset=13
+    )
+    sim, ops = _simplify(model, test_input_shapes={"X": (2, 3, 4)})
+    assert ops["Gemm"] >= n_layers
+    assert "MatMul" not in ops
+
+    names = [init.name for init in sim.graph.initializer]
+    assert len(names) == len(set(names)), "duplicate initializer name: reserved-name collision"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_moved_optimizer_passes.py
+++ b/tests/test_moved_optimizer_passes.py
@@ -215,7 +215,9 @@ def test_fuse_matmul_add_bias_into_gemm_batched_dynamic_many_matches():
     assert "MatMul" not in ops
 
     names = [init.name for init in sim.graph.initializer]
-    assert len(names) == len(set(names)), "duplicate initializer name: reserved-name collision"
+    assert len(names) == len(set(names)), (
+        "duplicate initializer name: reserved-name collision"
+    )
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

- `fuse_matmul_add_bias_into_gemm_batched`'s `runTransform` mints up to 5 fresh initializer names per match (the pre-reshape's shape, plus either the post-reshape's shape or -- on the dynamic-leading-dims path -- Slice's starts/ends/axes and Concat's `[N]`) via `MakeInt64Constant`, which left each `Tensor` unnamed. `Graph::addInitializerAndCreateValue`'s fallback for an unnamed tensor is `getNextUniqueName()`, and every such call pays a full graph (and subgraph) name scan -- so on a transformer model with many batched Linear layers, this made the pass's modify-phase cost scale with `matches * graph size` instead of `matches`. This is the same accidentally-quadratic bug class already fixed once in `extract_constant_to_initializer` (onnxsim issue #651), just never ported to this pass.
- Model-regression CI's pass-phase bottleneck summary (#721) flagged this pass as the second-highest aggregate cost across the 90-model set (dominant in 27/90 models). The finer match-vs-modify breakdown the profiler exposes (not currently surfaced by the CI summarizer) showed `patternMatchPredicate` was free (~0.15ms/3206 calls on `bert_Opset17`) while `runTransform` cost ~1.4ms/match -- pointing at the modify phase, not the matching.
- Fix: draw names from a batch reserved via `Graph::reserveUniqueNames()` (one scan per 256-name batch) instead of one scan per name, mirroring `ExtractConstantToInitializer`'s existing fix.

## Test plan

- [x] Real same-machine A/B on `onnxmodelzoo/bert_Opset17` (72 matches, dynamic batch/seq -> the 5-names-per-match path), repeated for consistency: modify-phase cost for this pass **101-108ms -> 72-75ms (~30%)**.
- [x] `pytest tests/` (excluding modules that fail to collect due to missing optional deps in this environment -- `torch`, `timm`): 447 passed (446 baseline + 1 new), 0 failed.
- [x] Added `test_fuse_matmul_add_bias_into_gemm_batched_dynamic_many_matches`: 8 independent linear layers over a dynamic-shape input, forcing many matches through the dynamic-path (5-names-per-match) route within one `runPass()` call, then asserts every initializer name in the simplified model is unique.
- [x] Adversarially verified the new test: temporarily broke `nextReservedName()` to hand out the same reserved name to every match. Rather than silently passing, the corrupted graph **segfaulted** -- confirming the test catches real corruption, not just a soft assertion. Reverted and confirmed the real fix passes cleanly.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4AHXs8oJU1UNbjs8LoQWu)_