### PR TITLE
Add apply_awq: Activation-aware Weight Quantization (AWQ)

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -11,6 +11,7 @@ from onnxsim.accuracy import (
 )
 from onnxsim.adaround import apply_adaround
 from onnxsim.autoquant import AutoQuantResult, auto_quantize_int4
+from onnxsim.awq import apply_awq
 from onnxsim.bias_correction import correct_bias
 from onnxsim.calibration import (
     calibrate,
@@ -71,6 +72,7 @@ __all__ = [
     "apply_adaround",
     "auto_quantize_int4",
     "AutoQuantResult",
+    "apply_awq",
     "quantize_attention_dynamic",
     "quantize_dynamic",
     "quantize_dynamic_matmul_integer_to_float",

--- a/onnxsim/awq.py
+++ b/onnxsim/awq.py
@@ -1,0 +1,282 @@
+"""AWQ -- Activation-aware Weight Quantization (Lin et al., 2023, "AWQ:
+Activation-aware Weight Quantization for LLM Compression and Acceleration",
+https://arxiv.org/abs/2306.00978). Originally implemented for PyTorch/CUDA
+LLM deployment (most visibly as part of Meta's ``torchao`` -- see this
+repository's own research into whether ``torchao``/``mslk`` have any real
+ONNX interop point, which they do not: they quantize live PyTorch
+``nn.Module``s with runtime-only tensor subclasses, with no ONNX export
+path). AWQ's *algorithm*, unlike its PyTorch implementation, is entirely
+portable: it needs nothing but a weight tensor, a round-to-nearest
+block-wise integer quantizer, and real calibration activations -- exactly
+:func:`onnxsim.quantize_weight_only_int4`'s own scheme and
+:mod:`onnxsim.adaround`'s own "post-hoc adjustment from real activations"
+style. This module ports the algorithm, not any framework's code.
+
+AWQ's key empirical observation: not every weight element matters equally to
+a layer's output -- a weight column feeding a large-magnitude *activation*
+channel dominates that channel's contribution to the output, so quantization
+error there costs more than an equal-sized error on a column whose
+activation is small. Round-to-nearest (what :func:`quantize_weight_only_int4`
+does) treats every element identically regardless of this, and per-element
+optimization of *which way* to round (:func:`onnxsim.apply_adaround`) never
+touches the weight's own magnitude, only which quantization bin it lands in.
+AWQ instead rescales entire input-channel *columns* of the weight upward in
+proportion to that channel's own average activation magnitude before
+quantizing -- inflating a salient column's share of its block's dynamic
+range so round-to-nearest's fixed per-block step size costs it
+proportionally less -- and applies the exact inverse scale to the
+activation, via a new ``Mul`` node inserted right before the layer, so the
+transformation is a no-op on the *unquantized* function and only changes how
+much quantization error each column ends up absorbing.
+
+For every :func:`onnxsim.quantize_weight_only_int4`-quantized MatMul/Gemm
+present (by node output name) in both ``float_model`` and ``quantized_model``
+(the same matching :mod:`onnxsim.adaround` uses -- see
+``weight_only_quantize_int4_matmul.h``'s scheme this targets): measures each
+input channel's average activation magnitude from real calibration data,
+then grid-searches a single scalar exponent ``alpha`` (the per-channel scale
+is ``activation_magnitude ** alpha``, geometric-mean-normalized to keep the
+compensating activation scale well-conditioned) to minimize the layer's own
+reconstruction error, re-quantizing the rescaled weight from scratch at each
+candidate ``alpha`` and measuring it against real activations -- the same
+grid search the AWQ paper itself uses, not a closed-form guarantee. ``alpha
+= 0`` (uniform scale 1, i.e. plain round-to-nearest) is always one of the
+candidates, so a layer AWQ can't improve keeps its original quantization and
+gets no inserted node at all.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Set, Union
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+
+from onnxsim import backend
+from onnxsim.adaround import _find_int4_matmul_candidates, _node_outputs, _pack_int4
+from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.calibration import Tensors, generate_random_calibration_data
+
+
+@dataclass
+class _AwqRewrite:
+    output_name: str  # the MatMul/Gemm node's own output name
+    activation_name: str  # that node's activation input name
+    wq_name: str
+    ws_name: str
+    codes: np.ndarray  # int8, original (Wq's) layout/shape
+    scale: np.ndarray  # float32, original (Ws's) layout/shape
+    channel_scale: Optional[np.ndarray]  # None means "no Mul needed" (alpha == 0)
+
+
+def _quantize_blockwise_int4(
+    w_nk: np.ndarray, block_size: int
+) -> "tuple[np.ndarray, np.ndarray]":
+    """Fresh round-to-nearest block-wise INT4 quantization of ``w_nk``
+    ([N, K], output channel first), matching
+    ``TryQuantizeWeightBlockwiseInt4InPlace``'s own scheme (one scale per
+    ``(output channel, block-of-K)`` group, ``scale = max(|w| in block) /
+    7``, codes clamped to ``[-7, 7]``). Returns ``(codes_nk, scale_blocks)``
+    with ``scale_blocks`` shape ``[N, K // block_size]``. Assumes ``K %
+    block_size == 0`` (true of every candidate this module matches, since
+    ``block_size`` is read from the existing DequantizeLinear node that
+    already quantized this same weight).
+    """
+    n, k = w_nk.shape
+    num_blocks = k // block_size
+    blocks = w_nk.reshape(n, num_blocks, block_size)
+    scale_blocks = np.maximum(np.abs(blocks).max(axis=2), 1e-12) / 7.0
+    scale_full = np.repeat(scale_blocks, block_size, axis=1)
+    codes_nk = np.clip(np.round(w_nk / scale_full), -7.0, 7.0)
+    return codes_nk, scale_blocks
+
+
+def apply_awq(
+    float_model: Union[str, onnx.ModelProto],
+    quantized_model: Union[str, onnx.ModelProto],
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_samples: int = 8,
+    seed: int = 0,
+    num_alpha_steps: int = 20,
+    providers: Optional[Sequence[str]] = None,
+) -> onnx.ModelProto:
+    """Applies AWQ-style activation-aware per-channel weight rescaling to
+    every ``quantize_weight_only_int4``-quantized MatMul/Gemm layer present
+    (by node output name) in both ``float_model`` and ``quantized_model``,
+    using real activations captured from ``float_model``. See this module's
+    own docstring for the technique.
+
+    :param float_model: the original (unquantized) onnx ModelProto or file
+            path
+    :param quantized_model: a quantized version of ``float_model`` (onnx
+            ModelProto or file path), produced by
+            :func:`onnxsim.quantize_weight_only_int4`. Layers quantized by
+            any other scheme (or left unquantized), or whose activation
+            input isn't a plain 2-D tensor, are left untouched. Assumes
+            ``quantized_model`` was produced from ``float_model`` without
+            renaming any MatMul/Gemm node's own output tensor -- true of
+            every onnxsim ``quantize_*`` function.
+    :param calibration_data: representative input batches to search and
+            measure the rescaling on. Each batch is a
+            ``{input_name: np.ndarray}`` dict matching ``float_model``'s
+            graph inputs -- see
+            :func:`onnxsim.generate_random_calibration_data` (the default
+            when omitted) and
+            :func:`onnxsim.load_huggingface_calibration_data` (real data, a
+            much more representative search than random input).
+    :param num_samples: random batches to generate when
+            ``calibration_data`` is omitted
+    :param seed: seed for the random calibration data (ignored if
+            ``calibration_data`` is supplied)
+    :param num_alpha_steps: grid points for the per-channel scale exponent
+            ``alpha``, evenly spaced over ``[0, 1]`` inclusive (matching the
+            AWQ paper's own grid search); higher values search more finely
+            at proportionally more cost (one full re-quantization and
+            reconstruction-error measurement per candidate, per layer)
+    :param providers: onnxruntime execution providers to run ``float_model``
+            on when capturing calibration activations
+    :returns: ``quantized_model`` with every layer AWQ measurably improved
+            rewritten: its INT4 weight and scale initializers replaced with
+            the rescaled-and-requantized versions, and a new ``Mul`` node
+            inserted before it applying the compensating inverse channel
+            scale to its activation input. A layer AWQ found no improvement
+            for (``alpha = 0`` best) is left completely untouched.
+    """
+    if isinstance(float_model, str):
+        float_model = onnx.load(float_model, load_external_data=False)
+    if isinstance(quantized_model, str):
+        quantized_model = onnx.load(quantized_model, load_external_data=False)
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            float_model, num_samples=num_samples, seed=seed
+        )
+
+    candidates = _find_int4_matmul_candidates(float_model, quantized_model)
+    if not candidates:
+        return quantized_model
+
+    probe_names = [c.float_node.input[0] for c in candidates]
+    float_probe = _add_probe_outputs(float_model, probe_names)
+
+    activations: Dict[str, List[np.ndarray]] = {name: [] for name in probe_names}
+    for batch in calibration_data:
+        out = backend.run_model(float_probe, batch, providers=providers)
+        for name in probe_names:
+            activations[name].append(np.asarray(out[name], dtype=np.float64))
+
+    alphas = np.linspace(0.0, 1.0, num_alpha_steps)
+
+    rewrites: List[_AwqRewrite] = []
+    for c in candidates:
+        acts = [a for a in activations[c.float_node.input[0]] if a.ndim == 2]
+        if not acts:
+            continue  # not a plain 2-D activation; skip
+        x = np.concatenate(acts, axis=0)
+
+        w = onnx.numpy_helper.to_array(c.w_float_init).astype(np.float64)
+        dim0, dim1 = w.shape
+        w_nk = w if c.weight_transposed else w.T  # [N, K], output channel first
+        if x.shape[1] != w_nk.shape[1]:
+            continue  # activation's feature dim doesn't match K; skip
+
+        y_float = x @ w_nk.T
+        # AWQ's own saliency signal: each input channel's average activation
+        # magnitude across the calibration set.
+        act_magnitude = np.maximum(np.abs(x).mean(axis=0), 1e-12)  # [K]
+
+        # alpha == 0 (uniform scale 1, i.e. plain round-to-nearest) is
+        # always a candidate and always the grid's first point -- evaluate
+        # it first so best_* below never needs an Optional/None sentinel.
+        best_channel_scale = np.ones_like(act_magnitude)
+        best_codes_nk, best_scale_blocks = _quantize_blockwise_int4(w_nk, c.block_size)
+        best_scale_full = np.repeat(best_scale_blocks, c.block_size, axis=1)
+        best_err = float(
+            np.mean((y_float - x @ (best_codes_nk * best_scale_full).T) ** 2)
+        )
+        best_alpha = 0.0
+
+        for alpha in alphas[1:]:
+            raw = act_magnitude**alpha
+            # Geometric-mean normalization keeps the scale (and its inverse,
+            # applied to the activation) centered around 1 -- standard AWQ
+            # practice, and here purely for numerical hygiene since
+            # weight-only quantization has no activation dynamic-range
+            # constraint to respect.
+            channel_scale = raw / np.exp(np.mean(np.log(raw)))
+            w_scaled_nk = w_nk * channel_scale[np.newaxis, :]
+            codes_nk, scale_blocks = _quantize_blockwise_int4(w_scaled_nk, c.block_size)
+            scale_full = np.repeat(scale_blocks, c.block_size, axis=1)
+            w_hat_nk = codes_nk * scale_full
+            y_hat = (x / channel_scale[np.newaxis, :]) @ w_hat_nk.T
+            err = float(np.mean((y_float - y_hat) ** 2))
+            if err < best_err:
+                best_err = err
+                best_alpha = alpha
+                best_codes_nk = codes_nk
+                best_scale_blocks = scale_blocks
+                best_channel_scale = channel_scale
+
+        codes_orig = best_codes_nk if c.weight_transposed else best_codes_nk.T
+        scale_orig = best_scale_blocks if c.weight_transposed else best_scale_blocks.T
+        assert codes_orig.shape == (dim0, dim1)
+        rewrites.append(
+            _AwqRewrite(
+                output_name=c.output_name,
+                # quantize_weight_only_int4 only ever replaces a node's
+                # weight input (index 1), never its activation input (index
+                # 0) or the node's own identity -- so the quantized graph's
+                # matching node still has this exact activation input name.
+                activation_name=c.float_node.input[0],
+                wq_name=c.wq_name,
+                ws_name=c.ws_init.name,
+                codes=codes_orig.astype(np.int8),
+                scale=scale_orig.astype(np.float32),
+                channel_scale=None if best_alpha == 0.0 else best_channel_scale,
+            )
+        )
+
+    if not rewrites:
+        return quantized_model
+
+    corrected = onnx.ModelProto()
+    corrected.CopyFrom(quantized_model)
+
+    codes_by_name = {r.wq_name: r.codes for r in rewrites}
+    scale_by_name = {
+        r.ws_name: r.scale for r in rewrites if r.channel_scale is not None
+    }
+    for t in corrected.graph.initializer:
+        codes = codes_by_name.get(t.name)
+        if codes is not None:
+            t.raw_data = _pack_int4(codes)
+        scale = scale_by_name.get(t.name)
+        if scale is not None:
+            t.CopyFrom(onnx.numpy_helper.from_array(scale, name=t.name))
+
+    taken_names: Set[str] = _all_names(corrected.graph)
+    q_by_output = _node_outputs(corrected.graph)
+    for r in rewrites:
+        if r.channel_scale is None:
+            continue
+        qn = q_by_output[r.output_name]
+        act_input = r.activation_name
+        inv_scale = (1.0 / r.channel_scale).astype(np.float32)
+
+        scale_name = _unique_name(f"{act_input}_awq_inv_scale", taken_names)
+        corrected.graph.initializer.append(
+            onnx.numpy_helper.from_array(inv_scale, name=scale_name)
+        )
+        scaled_name = _unique_name(f"{act_input}_awq_scaled", taken_names)
+        mul_node = onnx.helper.make_node(
+            "Mul",
+            [act_input, scale_name],
+            [scaled_name],
+            name=_unique_name(f"{act_input}_awq_mul", taken_names),
+        )
+        node_idx = next(i for i, n in enumerate(corrected.graph.node) if n is qn)
+        corrected.graph.node.insert(node_idx, mul_node)
+        qn.input[0] = scaled_name
+
+    return corrected

--- a/tests/test_awq.py
+++ b/tests/test_awq.py
@@ -1,0 +1,212 @@
+"""Tests for ``onnxsim.apply_awq`` (AWQ -- Activation-aware Weight
+Quantization, see ``onnxsim/awq.py``) -- rescales each INT4-quantized
+MatMul/Gemm layer's weight columns in proportion to their own input
+channel's average activation magnitude before re-quantizing, protecting
+"salient" channels' relative precision, with a compensating ``Mul`` inserted
+on the activation so the transformation is exact pre-quantization.
+"""
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _model(nodes, inputs, outputs, initializer, opset=21):
+    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+    )
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
+
+
+def _matmul_model(K=64, N=16, seed=0):
+    rng = np.random.default_rng(seed)
+    weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    return _model(
+        nodes, [_vi("X", ["batch", K])], [_vi("Y", ["batch", N])], [_f32(weight, "W")]
+    )
+
+
+def _salient_channel_calibration(K=64, num_samples=32, salient_channels=(3, 7), seed=1):
+    # A calibration set with a handful of channels carrying much larger
+    # activation magnitude than the rest -- AWQ's own motivating scenario:
+    # quantization error on those channels' weight columns costs the
+    # output disproportionately, so protecting them should measurably help.
+    rng = np.random.default_rng(seed)
+    x = rng.standard_normal((num_samples, K)).astype(np.float32)
+    for c in salient_channels:
+        x[:, c] *= 20.0
+    return x
+
+
+def _dequantize_int4(model):
+    wq = next(
+        t for t in model.graph.initializer if t.data_type == onnx.TensorProto.INT4
+    )
+    ws = next(
+        t for t in model.graph.initializer if t.data_type == onnx.TensorProto.FLOAT
+    )
+    dq_node = next(n for n in model.graph.node if n.op_type == "DequantizeLinear")
+    block_size = next(a.i for a in dq_node.attribute if a.name == "block_size")
+    axis = next((a.i for a in dq_node.attribute if a.name == "axis"), 1)
+
+    dims = list(wq.dims)
+    numel = int(np.prod(dims))
+    raw = np.frombuffer(wq.raw_data, dtype=np.uint8)
+    lo = (raw & 0x0F).astype(np.int8)
+    hi = ((raw >> 4) & 0x0F).astype(np.int8)
+    lo = np.where(lo >= 8, lo - 16, lo)
+    hi = np.where(hi >= 8, hi - 16, hi)
+    codes = np.empty(numel, dtype=np.int8)
+    codes[0::2] = lo[: (numel + 1) // 2]
+    codes[1::2] = hi[: numel // 2]
+    codes = codes.reshape(dims).astype(np.float64)
+
+    scale = onnx.numpy_helper.to_array(ws).astype(np.float64)
+    scale_full = np.repeat(scale, block_size, axis=axis)
+    slicer = [slice(None)] * codes.ndim
+    slicer[axis] = slice(0, codes.shape[axis])
+    return codes * scale_full[tuple(slicer)]
+
+
+def test_awq_reduces_reconstruction_error_with_salient_channels():
+    model = _matmul_model(K=64, N=16, seed=0)
+    x = _salient_channel_calibration(K=64, num_samples=64, seed=1)
+    calibration_data = [{"X": x}]
+
+    quant = onnxsim.quantize_weight_only_int4(model)
+    w_float = onnx.numpy_helper.to_array(model.graph.initializer[0]).astype(np.float64)
+    w_rtn = _dequantize_int4(quant)
+    y_float = x.astype(np.float64) @ w_float
+    y_rtn = x.astype(np.float64) @ w_rtn
+    rtn_err = np.linalg.norm(y_float - y_rtn)
+
+    awq_model = onnxsim.apply_awq(model, quant, calibration_data=calibration_data)
+    onnx.checker.check_model(awq_model)
+
+    # AWQ must have actually inserted its compensating Mul -- otherwise
+    # this is just re-testing plain RTN.
+    assert any(n.op_type == "Mul" for n in awq_model.graph.node)
+
+    (float_y,) = _run(model, {"X": x.astype(np.float32)})
+    (awq_y,) = _run(awq_model, {"X": x.astype(np.float32)})
+    awq_err = np.linalg.norm(y_float - awq_y.astype(np.float64))
+    assert awq_err < rtn_err
+
+
+def test_awq_output_stays_close_to_float_via_onnxruntime():
+    model = _matmul_model(K=64, N=16, seed=2)
+    x = _salient_channel_calibration(K=64, num_samples=32, seed=3)
+    calibration_data = [{"X": x}]
+
+    awq_model = onnxsim.apply_awq(
+        model,
+        onnxsim.quantize_weight_only_int4(model),
+        calibration_data=calibration_data,
+    )
+    onnx.checker.check_model(awq_model)
+
+    (float_y,) = _run(model, {"X": x})
+    (awq_y,) = _run(awq_model, {"X": x})
+    assert np.all(np.isfinite(awq_y))
+    assert _rel_l2(float_y, awq_y) < 0.25
+
+
+def test_awq_preserves_function_when_alpha_zero_is_best():
+    # Uniform activation magnitude across channels -- no channel is more
+    # "salient" than any other, so AWQ's own alpha=0 grid point (plain RTN,
+    # no rescaling) should win, and the model should come back completely
+    # untouched (no Mul inserted, same INT4 codes as plain RTN).
+    model = _matmul_model(K=32, N=8, seed=4)
+    rng = np.random.default_rng(5)
+    x = rng.standard_normal((16, 32)).astype(np.float32)  # no salient channels
+    calibration_data = [{"X": x}]
+
+    quant = onnxsim.quantize_weight_only_int4(model)
+    awq_model = onnxsim.apply_awq(model, quant, calibration_data=calibration_data)
+
+    assert awq_model.SerializeToString() == quant.SerializeToString()
+
+
+def test_awq_gemm_transb():
+    rng = np.random.default_rng(6)
+    K, N = 96, 12
+    weight = rng.standard_normal((N, K)).astype(np.float32) * 0.5
+    nodes = [onnx.helper.make_node("Gemm", ["X", "W"], ["Y"], transB=1)]
+    model = _model(
+        nodes, [_vi("X", ["batch", K])], [_vi("Y", ["batch", N])], [_f32(weight, "W")]
+    )
+    quant = onnxsim.quantize_weight_only_int4(model)
+    onnx.checker.check_model(quant)
+
+    x = _salient_channel_calibration(
+        K=K, num_samples=32, salient_channels=(10, 50), seed=7
+    )
+    calibration_data = [{"X": x}]
+
+    awq_model = onnxsim.apply_awq(model, quant, calibration_data=calibration_data)
+    onnx.checker.check_model(awq_model)
+
+    (float_y,) = _run(model, {"X": x})
+    (awq_y,) = _run(awq_model, {"X": x})
+    assert _rel_l2(float_y, awq_y) < 0.25
+
+
+def test_awq_codes_stay_in_range():
+    model = _matmul_model(K=32, N=8, seed=8)
+    x = _salient_channel_calibration(
+        K=32, num_samples=16, salient_channels=(1,), seed=9
+    )
+    calibration_data = [{"X": x}]
+
+    quant = onnxsim.quantize_weight_only_int4(model)
+    awq_model = onnxsim.apply_awq(model, quant, calibration_data=calibration_data)
+    wq = next(
+        t for t in awq_model.graph.initializer if t.data_type == onnx.TensorProto.INT4
+    )
+    numel = int(np.prod(list(wq.dims)))
+    raw = np.frombuffer(wq.raw_data, dtype=np.uint8)
+    lo = (raw & 0x0F).astype(np.int8)
+    hi = ((raw >> 4) & 0x0F).astype(np.int8)
+    lo = np.where(lo >= 8, lo - 16, lo)
+    hi = np.where(hi >= 8, hi - 16, hi)
+    codes = np.empty(numel, dtype=np.int8)
+    codes[0::2] = lo[: (numel + 1) // 2]
+    codes[1::2] = hi[: numel // 2]
+    assert np.all(codes >= -7) and np.all(codes <= 7)
+
+
+def test_awq_noop_when_no_int4_matmul_present():
+    nodes = [onnx.helper.make_node("Relu", ["X"], ["Y"])]
+    model = _model(nodes, [_vi("X", [4, 4])], [_vi("Y", [4, 4])], [])
+    result = onnxsim.apply_awq(
+        model, model, calibration_data=[{"X": np.zeros((4, 4), dtype=np.float32)}]
+    )
+    assert result.SerializeToString() == model.SerializeToString()


### PR DESCRIPTION
## Summary

Ports **AWQ** (Lin et al., 2023, ["AWQ: Activation-aware Weight Quantization for LLM Compression and Acceleration"](https://arxiv.org/abs/2306.00978)) -- an onnxsim-native reimplementation of the *algorithm*, not any framework's code.

## Why this, and not a `pytorch/ao`/MSLK integration

Following up on `pytorch/ao` (torchao) as a possible next vendor target: research into torchao itself, and into `meta-pytorch/MSLK` (the closed-form kernel library torchao's own int4 path delegates to), both turned up **no real ONNX interop point**. Both quantize live PyTorch `nn.Module`s with runtime-only tensor subclasses/CUDA kernels, with no ONNX export path (a related `pytorch/ao` issue asking for one was closed "not planned"; MSLK has zero "onnx" hits anywhere in its repo).

AWQ's *algorithm* itself, unlike either framework's implementation, needs nothing but a weight tensor, a round-to-nearest block-wise integer quantizer, and real calibration activations -- exactly `quantize_weight_only_int4`'s own scheme and `adaround.py`'s own "post-hoc adjustment from real activations" style. So it ports cleanly on that basis alone, independent of whether the frameworks that popularized it have any ONNX story.

## How it works

AWQ's key empirical observation: not every weight element matters equally to a layer's output -- a weight column feeding a large-magnitude *activation* channel dominates that channel's contribution to the output, so quantization error there costs more than an equal-sized error on a column whose activation is small. Round-to-nearest treats every element identically regardless of this, and AdaRound's per-element rounding optimization never touches a weight's own magnitude, only which quantization bin it lands in -- both a different lever than what AWQ pulls.

AWQ instead rescales entire input-channel columns of the weight upward in proportion to that channel's own average activation magnitude before quantizing -- inflating a salient column's share of its block's dynamic range so round-to-nearest's fixed per-block step size costs it proportionally less -- and applies the exact inverse scale to the activation via a new `Mul` node inserted right before the layer, so the transformation is a no-op on the *unquantized* function.

Implemented as a pure-Python post-hoc pass (`onnxsim/awq.py`), reusing `adaround.py`'s own MatMul/Gemm candidate-matching and INT4 packing helpers (same target scheme). For every `quantize_weight_only_int4`-quantized layer: grid-searches a scalar exponent `alpha` (matching the AWQ paper's own grid search, not a closed-form guarantee) for the per-channel scale, re-quantizing the rescaled weight from scratch at each candidate and measuring real reconstruction error. `alpha=0` (plain round-to-nearest) is always a candidate, so a layer AWQ can't improve keeps its original quantization untouched with no inserted node at all.

## Verification

- A dedicated test builds a deliberately salient-channel calibration scenario (a few input channels carrying much larger activation magnitude than the rest -- AWQ's own motivating case) and confirms AWQ's measured reconstruction error is strictly lower than plain round-to-nearest's on the same data.
- A second test uses uniform activation magnitude (no channel more salient than any other) and confirms the `alpha=0` no-op path produces a **byte-identical** model to plain `quantize_weight_only_int4`, with no `Mul` inserted -- proving AWQ never makes things worse when there's nothing to gain.
- Further tests cover `Gemm` with `transB=1`, codes staying within the scheme's `[-7, 7]` range, and end-to-end `onnxruntime` execution.
- Full regression sweep: `tests/` (excluding torch/timm-dependent modules not installed in this environment) -- **449 passed, 68 skipped, 0 failed**.
- `ruff format` / `ruff check` / `mypy` clean.

## New files

- `onnxsim/awq.py`
- `tests/test_awq.py` -- 6 tests

## Test plan

- [x] `pytest tests/test_awq.py -v`
- [x] `pytest tests/test_adaround.py tests/test_bias_correction.py tests/test_weight_only_quantize_int4.py -q`
- [x] Full `tests/` sweep (torch/timm-dependent modules excluded, not installed in this environment)
- [x] `ruff format` / `ruff check` / `mypy`

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_