### PR TITLE
Add apply_gptq: GPTQ sequential Hessian-compensated quantization

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -28,6 +28,7 @@ from onnxsim.calibration import (
     quantize_static,
     quantize_static_int16,
 )
+from onnxsim.gptq import apply_gptq
 from onnxsim.onnx_simplifier import (
     cross_layer_equalize,
     export_gguf,
@@ -73,6 +74,7 @@ __all__ = [
     "auto_quantize_int4",
     "AutoQuantResult",
     "apply_awq",
+    "apply_gptq",
     "quantize_attention_dynamic",
     "quantize_dynamic",
     "quantize_dynamic_matmul_integer_to_float",

--- a/onnxsim/gptq.py
+++ b/onnxsim/gptq.py
@@ -1,0 +1,239 @@
+"""GPTQ (Frantar et al., 2022, "GPTQ: Accurate Post-Training Quantization for
+Generative Pre-trained Transformers", https://arxiv.org/abs/2210.17323) --
+one of the notable weight-only PTQ techniques ``torchao`` implements
+(``torchao/prototype/gptq/``, prototype status there; onnxsim ports the
+*algorithm*, not that code -- see :mod:`onnxsim.awq`'s own docstring for why:
+torchao has no ONNX export path). Third onnxsim-native PTQ technique
+alongside :mod:`onnxsim.adaround` and :mod:`onnxsim.awq`, each pulling a
+different lever on the exact same target scheme
+(:func:`onnxsim.quantize_weight_only_int4`'s block-wise symmetric INT4):
+AdaRound jointly optimizes every element's own rounding via gradient
+descent; AWQ rescales whole input channels before quantizing; GPTQ instead
+quantizes input channels **one at a time**, and after each one, propagates
+its rounding error into every *not-yet-quantized* channel so their own
+rounding can compensate for it -- a second-order (Hessian-based), greedy but
+exact-per-step algorithm, not an iterative optimization.
+
+The mechanism: for a layer's weight ``W`` ([N, K], output channel first) and
+its calibration activations ``X`` ([samples, K]), the Hessian of the
+layer's own squared reconstruction error with respect to ``W`` is
+``H = X^T X`` (a ``[K, K]`` matrix, independent of ``W`` -- every output row
+shares the same ``H``). Processing input channels left to right: quantize
+channel ``i`` to its nearest grid point (using the same per-block scale
+:func:`onnxsim.quantize_weight_only_int4` already computed), then charge the
+resulting error to every remaining channel ``j > i`` in proportion to
+``H^{-1}[i, j] / H^{-1}[i, i]`` -- the correction an optimal-brain-surgeon-
+style argument shows exactly cancels that error's contribution to the
+*layer's* reconstruction error, not just channel ``i``'s own. This module
+uses the same Cholesky-based reformulation the GPTQ paper itself introduces
+for efficiency (one ``H^{-1}`` Cholesky factorization up front, reused via
+slicing for every column and block, rather than re-deriving a shrinking
+inverse at every step) -- plain numpy, no framework dependency, matching
+:mod:`onnxsim.adaround`/:mod:`onnxsim.awq`'s "post-hoc adjustment from real
+activations" style.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Sequence, Union
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+
+from onnxsim import backend
+from onnxsim.adaround import _find_int4_matmul_candidates, _pack_int4
+from onnxsim.bias_correction import _add_probe_outputs
+from onnxsim.calibration import Tensors, generate_random_calibration_data
+
+
+def _inverse_hessian_cholesky(h: np.ndarray, percdamp: float) -> np.ndarray:
+    """Returns the upper-triangular Cholesky factor ``U`` of ``h``'s
+    inverse (``inverse(h) == U.T @ U``) -- the GPTQ paper's own efficient
+    reformulation, computed once per layer and reused (via slicing) for
+    every column and block instead of re-deriving a shrinking inverse at
+    each step. Channels ``h`` never saw any calibration activation for
+    (an all-zero diagonal entry, i.e. a "dead" channel) get a fixed
+    diagonal of 1 first, the standard GPTQ trick to keep ``h`` invertible
+    without giving those channels any (meaningless, since nothing
+    correlates with them) influence over other channels' corrections.
+    """
+    k = h.shape[0]
+    diag = np.arange(k)
+    dead = h[diag, diag] == 0.0
+    h = h.copy()
+    h[dead, dead] = 1.0
+    damp = max(percdamp * float(np.mean(h[diag, diag])), 1e-8)
+    h[diag, diag] += damp
+    h_inv = np.linalg.inv(h)
+    return np.linalg.cholesky(h_inv).T
+
+
+def _gptq_quantize_columns(
+    w_nk: np.ndarray,
+    scale_blocks: np.ndarray,
+    quant_block_size: int,
+    h: np.ndarray,
+    percdamp: float,
+    proc_block_size: int,
+) -> np.ndarray:
+    """Returns GPTQ-optimized integer codes for ``w_nk`` ([N, K], output
+    channel first), reusing ``scale_blocks``' existing per-(output channel,
+    quantization group) scale (shape ``[N, K // quant_block_size]`` --
+    unchanged from what :func:`onnxsim.quantize_weight_only_int4` already
+    computed; GPTQ only changes which integer each element rounds to, never
+    the scale). ``proc_block_size`` is GPTQ's own processing granularity
+    (unrelated to ``quant_block_size``, the scale's granularity) -- how many
+    columns' errors get propagated locally before a full cross-block
+    update; larger values trade memory for fewer full-width updates, with
+    no effect on the result other than floating-point summation order.
+    """
+    n, k = w_nk.shape
+    hinv = _inverse_hessian_cholesky(h, percdamp)
+
+    codes_nk = np.zeros((n, k), dtype=np.float64)
+    w_work = w_nk.copy()
+
+    for block_start in range(0, k, proc_block_size):
+        block_end = min(block_start + proc_block_size, k)
+        bs = block_end - block_start
+        w1 = w_work[:, block_start:block_end].copy()
+        err1 = np.zeros_like(w1)
+        hinv1 = hinv[block_start:block_end, block_start:block_end]
+
+        for i in range(bs):
+            k_abs = block_start + i
+            group = k_abs // quant_block_size
+            s = scale_blocks[:, group]  # [N]
+            w_col = w1[:, i]
+            code_col = np.clip(np.round(w_col / s), -7.0, 7.0)
+            codes_nk[:, k_abs] = code_col
+            d = hinv1[i, i]
+            err = (w_col - code_col * s) / d
+            err1[:, i] = err
+            if i + 1 < bs:
+                w1[:, i + 1 :] -= np.outer(err, hinv1[i, i + 1 :])
+
+        if block_end < k:
+            w_work[:, block_end:] -= err1 @ hinv[block_start:block_end, block_end:]
+
+    return codes_nk
+
+
+def apply_gptq(
+    float_model: Union[str, onnx.ModelProto],
+    quantized_model: Union[str, onnx.ModelProto],
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_samples: int = 8,
+    seed: int = 0,
+    percdamp: float = 0.01,
+    proc_block_size: int = 128,
+    providers: Optional[Sequence[str]] = None,
+) -> onnx.ModelProto:
+    """Optimizes GPTQ-style sequential, Hessian-compensated rounding for
+    every ``quantize_weight_only_int4``-quantized MatMul/Gemm layer present
+    (by node output name) in both ``float_model`` and ``quantized_model``,
+    using real activations captured from ``float_model``. See this module's
+    own docstring for the technique.
+
+    :param float_model: the original (unquantized) onnx ModelProto or file
+            path
+    :param quantized_model: a quantized version of ``float_model`` (onnx
+            ModelProto or file path), produced by
+            :func:`onnxsim.quantize_weight_only_int4`. Layers quantized by
+            any other scheme (or left unquantized), or whose activation
+            input isn't a plain 2-D tensor, are left untouched. Assumes
+            ``quantized_model`` was produced from ``float_model`` without
+            renaming any MatMul/Gemm node's own output tensor -- true of
+            every onnxsim ``quantize_*`` function.
+    :param calibration_data: representative input batches to compute each
+            layer's Hessian from. Each batch is a
+            ``{input_name: np.ndarray}`` dict matching ``float_model``'s
+            graph inputs -- see
+            :func:`onnxsim.generate_random_calibration_data` (the default
+            when omitted) and
+            :func:`onnxsim.load_huggingface_calibration_data` (real data, a
+            much more representative Hessian than random input).
+    :param num_samples: random batches to generate when
+            ``calibration_data`` is omitted
+    :param seed: seed for the random calibration data (ignored if
+            ``calibration_data`` is supplied)
+    :param percdamp: Hessian damping factor (fraction of the mean diagonal
+            added to every diagonal entry before inversion), matching the
+            GPTQ paper's own default -- keeps the inversion numerically
+            stable when calibration data doesn't fully activate (or
+            correlates too tightly across) a layer's input channels
+    :param proc_block_size: GPTQ's own column-processing block size (not
+            the quantization scale's own block size, which this always
+            reuses unchanged from ``quantized_model``) -- see
+            :func:`_gptq_quantize_columns`
+    :param providers: onnxruntime execution providers to run ``float_model``
+            on when capturing calibration activations
+    :returns: ``quantized_model`` with every matched layer's INT4 weight
+            initializer rewritten to its GPTQ-optimized codes (same shape,
+            dtype, and scale -- only which integer each element rounds to
+            changes)
+    """
+    if isinstance(float_model, str):
+        float_model = onnx.load(float_model, load_external_data=False)
+    if isinstance(quantized_model, str):
+        quantized_model = onnx.load(quantized_model, load_external_data=False)
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            float_model, num_samples=num_samples, seed=seed
+        )
+
+    candidates = _find_int4_matmul_candidates(float_model, quantized_model)
+    if not candidates:
+        return quantized_model
+
+    probe_names = [c.float_node.input[0] for c in candidates]
+    float_probe = _add_probe_outputs(float_model, probe_names)
+
+    activations: Dict[str, List[np.ndarray]] = {name: [] for name in probe_names}
+    for batch in calibration_data:
+        out = backend.run_model(float_probe, batch, providers=providers)
+        for name in probe_names:
+            activations[name].append(np.asarray(out[name], dtype=np.float64))
+
+    optimized: Dict[str, np.ndarray] = {}
+    for c in candidates:
+        acts = [a for a in activations[c.float_node.input[0]] if a.ndim == 2]
+        if not acts:
+            continue  # not a plain 2-D activation; skip
+        x = np.concatenate(acts, axis=0)
+
+        w = onnx.numpy_helper.to_array(c.w_float_init).astype(np.float64)
+        scale = onnx.numpy_helper.to_array(c.ws_init).astype(np.float64)
+        dim0, dim1 = w.shape
+
+        if c.weight_transposed:
+            w_nk = w  # already [N, K]
+            scale_blocks = scale  # already [N, K / block_size]
+        else:
+            w_nk = w.T  # [K, N] -> [N, K]
+            scale_blocks = scale.T  # [K / block_size, N] -> [N, K / block_size]
+        if x.shape[1] != w_nk.shape[1]:
+            continue  # activation's feature dim doesn't match K; skip
+
+        h = x.T @ x
+        codes_nk = _gptq_quantize_columns(
+            w_nk, scale_blocks, c.block_size, h, percdamp, proc_block_size
+        )
+
+        codes_orig = codes_nk if c.weight_transposed else codes_nk.T
+        assert codes_orig.shape == (dim0, dim1)
+        optimized[c.wq_name] = codes_orig.astype(np.int8)
+
+    if not optimized:
+        return quantized_model
+
+    corrected = onnx.ModelProto()
+    corrected.CopyFrom(quantized_model)
+    for t in corrected.graph.initializer:
+        codes = optimized.get(t.name)
+        if codes is None:
+            continue
+        t.raw_data = _pack_int4(codes)
+
+    return corrected

--- a/tests/test_adaround.py
+++ b/tests/test_adaround.py
@@ -66,15 +66,13 @@ def _dequantize_int4(quant_model):
     # Feed a zero/one probe matrix through the model's own DequantizeLinear
     # node isn't directly possible without extracting it into its own
     # session, so instead this decodes by hand from the initializer bytes.
-    wq = next(
-        t for t in quant_model.graph.initializer if t.data_type == onnx.TensorProto.INT4
-    )
-    ws = next(
-        t
-        for t in quant_model.graph.initializer
-        if t.data_type == onnx.TensorProto.FLOAT
-    )
     dq_node = next(n for n in quant_model.graph.node if n.op_type == "DequantizeLinear")
+    # Fetch Wq/Ws by the DequantizeLinear node's own input names, not by
+    # scanning for "some tensor of this dtype": quantize_weight_only_int4
+    # never prunes the original (now-dead) float32 weight initializer, so a
+    # dtype-only scan can silently grab that instead of the real scale.
+    wq = next(t for t in quant_model.graph.initializer if t.name == dq_node.input[0])
+    ws = next(t for t in quant_model.graph.initializer if t.name == dq_node.input[1])
     block_size = next(a.i for a in dq_node.attribute if a.name == "block_size")
     axis = next((a.i for a in dq_node.attribute if a.name == "axis"), 1)
 
@@ -147,22 +145,20 @@ def test_adaround_preserves_scale_and_shape():
     rng = np.random.default_rng(6)
     calibration_data = [{"X": rng.standard_normal((4, 32)).astype(np.float32)}]
 
+    quant_dq = next(
+        n for n in quant_model.graph.node if n.op_type == "DequantizeLinear"
+    )
     before_scale = onnx.numpy_helper.to_array(
-        next(
-            t
-            for t in quant_model.graph.initializer
-            if t.data_type == onnx.TensorProto.FLOAT
-        )
+        next(t for t in quant_model.graph.initializer if t.name == quant_dq.input[1])
     )
     adaround_model = onnxsim.apply_adaround(
         float_model, quant_model, calibration_data=calibration_data, num_iterations=50
     )
+    ada_dq = next(
+        n for n in adaround_model.graph.node if n.op_type == "DequantizeLinear"
+    )
     after_scale = onnx.numpy_helper.to_array(
-        next(
-            t
-            for t in adaround_model.graph.initializer
-            if t.data_type == onnx.TensorProto.FLOAT
-        )
+        next(t for t in adaround_model.graph.initializer if t.name == ada_dq.input[1])
     )
     np.testing.assert_array_equal(before_scale, after_scale)
 

--- a/tests/test_awq.py
+++ b/tests/test_awq.py
@@ -67,13 +67,13 @@ def _salient_channel_calibration(K=64, num_samples=32, salient_channels=(3, 7), 
 
 
 def _dequantize_int4(model):
-    wq = next(
-        t for t in model.graph.initializer if t.data_type == onnx.TensorProto.INT4
-    )
-    ws = next(
-        t for t in model.graph.initializer if t.data_type == onnx.TensorProto.FLOAT
-    )
     dq_node = next(n for n in model.graph.node if n.op_type == "DequantizeLinear")
+    # Fetch Wq/Ws by the DequantizeLinear node's own input names, not by
+    # scanning for "some tensor of this dtype": quantize_weight_only_int4
+    # never prunes the original (now-dead) float32 weight initializer, so a
+    # dtype-only scan can silently grab that instead of the real scale.
+    wq = next(t for t in model.graph.initializer if t.name == dq_node.input[0])
+    ws = next(t for t in model.graph.initializer if t.name == dq_node.input[1])
     block_size = next(a.i for a in dq_node.attribute if a.name == "block_size")
     axis = next((a.i for a in dq_node.attribute if a.name == "axis"), 1)
 

--- a/tests/test_gptq.py
+++ b/tests/test_gptq.py
@@ -1,0 +1,235 @@
+"""Tests for ``onnxsim.apply_gptq`` (GPTQ, see ``onnxsim/gptq.py``) --
+sequentially quantizes each INT4-quantized MatMul/Gemm layer's input
+channels one at a time, propagating each channel's rounding error into the
+not-yet-quantized channels via the layer's own (calibration-data-derived)
+Hessian, so correlated channels can compensate for each other's error
+instead of rounding independently.
+"""
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _model(nodes, inputs, outputs, initializer, opset=21):
+    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+    )
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
+
+
+def _matmul_model(K=64, N=16, seed=0):
+    rng = np.random.default_rng(seed)
+    weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    return _model(
+        nodes, [_vi("X", ["batch", K])], [_vi("Y", ["batch", N])], [_f32(weight, "W")]
+    )
+
+
+def _correlated_calibration(K=64, num_samples=64, rank=6, seed=1):
+    # GPTQ's own motivating scenario: input channels that are *correlated*
+    # (here, every channel is a linear combination of a handful of latent
+    # factors) -- independent per-element or per-channel rounding can't
+    # compensate for one channel's error using another's, but GPTQ's
+    # off-diagonal Hessian terms (which capture exactly this correlation)
+    # can.
+    rng = np.random.default_rng(seed)
+    latent = rng.standard_normal((num_samples, rank)).astype(np.float32)
+    projection = rng.standard_normal((rank, K)).astype(np.float32)
+    x = latent @ projection
+    x += rng.standard_normal((num_samples, K)).astype(np.float32) * 0.05
+    return x
+
+
+def _dequantize_int4(model):
+    dq_node = next(n for n in model.graph.node if n.op_type == "DequantizeLinear")
+    # Fetch Wq/Ws by the DequantizeLinear node's own input names, not by
+    # scanning for "some tensor of this dtype": quantize_weight_only_int4
+    # never prunes the original (now-dead) float32 weight initializer, so a
+    # dtype-only scan can silently grab that instead of the real scale.
+    wq = next(t for t in model.graph.initializer if t.name == dq_node.input[0])
+    ws = next(t for t in model.graph.initializer if t.name == dq_node.input[1])
+    block_size = next(a.i for a in dq_node.attribute if a.name == "block_size")
+    axis = next((a.i for a in dq_node.attribute if a.name == "axis"), 1)
+
+    dims = list(wq.dims)
+    numel = int(np.prod(dims))
+    raw = np.frombuffer(wq.raw_data, dtype=np.uint8)
+    lo = (raw & 0x0F).astype(np.int8)
+    hi = ((raw >> 4) & 0x0F).astype(np.int8)
+    lo = np.where(lo >= 8, lo - 16, lo)
+    hi = np.where(hi >= 8, hi - 16, hi)
+    codes = np.empty(numel, dtype=np.int8)
+    codes[0::2] = lo[: (numel + 1) // 2]
+    codes[1::2] = hi[: numel // 2]
+    codes = codes.reshape(dims).astype(np.float64)
+
+    scale = onnx.numpy_helper.to_array(ws).astype(np.float64)
+    scale_full = np.repeat(scale, block_size, axis=axis)
+    slicer = [slice(None)] * codes.ndim
+    slicer[axis] = slice(0, codes.shape[axis])
+    return codes * scale_full[tuple(slicer)]
+
+
+def test_gptq_reduces_reconstruction_error_with_correlated_channels():
+    model = _matmul_model(K=64, N=16, seed=0)
+    x = _correlated_calibration(K=64, num_samples=64, seed=1)
+    calibration_data = [{"X": x}]
+
+    quant = onnxsim.quantize_weight_only_int4(model)
+    w_float = onnx.numpy_helper.to_array(model.graph.initializer[0]).astype(np.float64)
+    w_rtn = _dequantize_int4(quant)
+    y_float = x.astype(np.float64) @ w_float
+    y_rtn = x.astype(np.float64) @ w_rtn
+    rtn_err = np.linalg.norm(y_float - y_rtn)
+
+    gptq_model = onnxsim.apply_gptq(model, quant, calibration_data=calibration_data)
+    onnx.checker.check_model(gptq_model)
+    w_gptq = _dequantize_int4(gptq_model)
+    y_gptq = x.astype(np.float64) @ w_gptq
+    gptq_err = np.linalg.norm(y_float - y_gptq)
+
+    assert gptq_err < rtn_err
+
+
+def test_gptq_output_stays_close_to_float_via_onnxruntime():
+    model = _matmul_model(K=64, N=16, seed=2)
+    x = _correlated_calibration(K=64, num_samples=32, seed=3)
+    calibration_data = [{"X": x}]
+
+    gptq_model = onnxsim.apply_gptq(
+        model,
+        onnxsim.quantize_weight_only_int4(model),
+        calibration_data=calibration_data,
+    )
+    onnx.checker.check_model(gptq_model)
+
+    (float_y,) = _run(model, {"X": x})
+    (gptq_y,) = _run(gptq_model, {"X": x})
+    assert np.all(np.isfinite(gptq_y))
+    assert _rel_l2(float_y, gptq_y) < 0.25
+
+
+def test_gptq_preserves_scale_and_shape():
+    model = _matmul_model(K=32, N=8, seed=4)
+    x = _correlated_calibration(K=32, num_samples=16, rank=3, seed=5)
+    calibration_data = [{"X": x}]
+
+    quant = onnxsim.quantize_weight_only_int4(model)
+    quant_dq = next(n for n in quant.graph.node if n.op_type == "DequantizeLinear")
+    before_scale = onnx.numpy_helper.to_array(
+        next(t for t in quant.graph.initializer if t.name == quant_dq.input[1])
+    )
+    gptq_model = onnxsim.apply_gptq(model, quant, calibration_data=calibration_data)
+    gptq_dq = next(n for n in gptq_model.graph.node if n.op_type == "DequantizeLinear")
+    after_scale = onnx.numpy_helper.to_array(
+        next(t for t in gptq_model.graph.initializer if t.name == gptq_dq.input[1])
+    )
+    np.testing.assert_array_equal(before_scale, after_scale)
+
+    wq = next(
+        t for t in gptq_model.graph.initializer if t.data_type == onnx.TensorProto.INT4
+    )
+    assert list(wq.dims) == [32, 8]
+
+
+def test_gptq_codes_stay_in_range():
+    model = _matmul_model(K=32, N=8, seed=6)
+    x = _correlated_calibration(K=32, num_samples=16, rank=2, seed=7) * 3
+    calibration_data = [{"X": x}]
+
+    quant = onnxsim.quantize_weight_only_int4(model)
+    gptq_model = onnxsim.apply_gptq(model, quant, calibration_data=calibration_data)
+    wq = next(
+        t for t in gptq_model.graph.initializer if t.data_type == onnx.TensorProto.INT4
+    )
+    numel = int(np.prod(list(wq.dims)))
+    raw = np.frombuffer(wq.raw_data, dtype=np.uint8)
+    lo = (raw & 0x0F).astype(np.int8)
+    hi = ((raw >> 4) & 0x0F).astype(np.int8)
+    lo = np.where(lo >= 8, lo - 16, lo)
+    hi = np.where(hi >= 8, hi - 16, hi)
+    codes = np.empty(numel, dtype=np.int8)
+    codes[0::2] = lo[: (numel + 1) // 2]
+    codes[1::2] = hi[: numel // 2]
+    assert np.all(codes >= -7) and np.all(codes <= 7)
+
+
+def test_gptq_gemm_transb_with_small_processing_block():
+    # proc_block_size smaller than K exercises the cross-block error
+    # propagation path (not just the within-block one every other test
+    # here incidentally covers via K <= the default proc_block_size=128).
+    rng = np.random.default_rng(8)
+    K, N = 96, 12
+    weight = rng.standard_normal((N, K)).astype(np.float32) * 0.5
+    nodes = [onnx.helper.make_node("Gemm", ["X", "W"], ["Y"], transB=1)]
+    model = _model(
+        nodes, [_vi("X", ["batch", K])], [_vi("Y", ["batch", N])], [_f32(weight, "W")]
+    )
+    quant = onnxsim.quantize_weight_only_int4(model)
+    onnx.checker.check_model(quant)
+
+    x = _correlated_calibration(K=K, num_samples=32, rank=8, seed=9)
+    calibration_data = [{"X": x}]
+
+    gptq_model = onnxsim.apply_gptq(
+        model, quant, calibration_data=calibration_data, proc_block_size=32
+    )
+    onnx.checker.check_model(gptq_model)
+
+    (float_y,) = _run(model, {"X": x})
+    (gptq_y,) = _run(gptq_model, {"X": x})
+    assert _rel_l2(float_y, gptq_y) < 0.25
+
+
+def test_gptq_handles_dead_input_channel():
+    # A channel with zero variance in the calibration data (H's diagonal is
+    # exactly 0 there) must not blow up the Hessian inversion.
+    model = _matmul_model(K=32, N=8, seed=10)
+    x = _correlated_calibration(K=32, num_samples=16, rank=3, seed=12)
+    x[:, 5] = 0.0  # dead channel
+    calibration_data = [{"X": x}]
+
+    quant = onnxsim.quantize_weight_only_int4(model)
+    gptq_model = onnxsim.apply_gptq(model, quant, calibration_data=calibration_data)
+    onnx.checker.check_model(gptq_model)
+
+    (gptq_y,) = _run(gptq_model, {"X": x})
+    assert np.all(np.isfinite(gptq_y))
+
+
+def test_gptq_noop_when_no_int4_matmul_present():
+    nodes = [onnx.helper.make_node("Relu", ["X"], ["Y"])]
+    model = _model(nodes, [_vi("X", [4, 4])], [_vi("Y", [4, 4])], [])
+    result = onnxsim.apply_gptq(
+        model, model, calibration_data=[{"X": np.zeros((4, 4), dtype=np.float32)}]
+    )
+    assert result.SerializeToString() == model.SerializeToString()


### PR DESCRIPTION
## Summary

Ports **GPTQ** (Frantar et al., 2022, ["GPTQ: Accurate Post-Training Quantization for Generative Pre-trained Transformers"](https://arxiv.org/abs/2210.17323)) -- one of the notable weight-only PTQ techniques `torchao` implements (`torchao/prototype/gptq/`, prototype status there; onnxsim ports the *algorithm*, not that code, per the same rationale as `apply_awq` -- torchao has no ONNX export path).

Third onnxsim-native PTQ technique alongside `adaround.py` and `awq.py`, each pulling a different lever on the exact same target scheme (`quantize_weight_only_int4`'s block-wise symmetric INT4):
- **AdaRound**: jointly optimizes every element's own rounding via gradient descent.
- **AWQ**: rescales whole input channels before quantizing.
- **GPTQ**: quantizes input channels one at a time, propagating each one's rounding error into every not-yet-quantized channel via the layer's own Hessian -- a second-order, greedy but exact-per-step algorithm, not an iterative optimization.

## How it works

For a layer's weight and calibration activations, the Hessian of the layer's own squared reconstruction error is `H = X^T X`. Processing input channels left to right: quantize channel `i` to its nearest grid point (reusing the same per-block scale `quantize_weight_only_int4` already computed -- GPTQ never changes the scale, only which integer each element rounds to), then charge the resulting error to every remaining channel in proportion to `H^-1[i,j] / H^-1[i,i]` -- the correction that provably cancels that error's contribution to the *layer's* reconstruction error, not just channel `i`'s own.

Uses the GPTQ paper's own Cholesky-based reformulation for efficiency: one inverse-Hessian Cholesky factorization computed once per layer, sliced (not recomputed) for every column and processing block.

## Verification

- **Cross-checked against a naive reference**: recomputing the remaining-columns' submatrix inverse explicitly at every single step (the textbook-slow-but-obviously-correct formulation) on random data gives bit-identical results to the Cholesky-factor-slicing implementation -- confirms the efficient reformulation is implemented correctly, not just plausible-looking.
- A dedicated test builds a deliberately **correlated calibration scenario** (input channels expressed as noisy linear combinations of a handful of latent factors -- GPTQ's own motivating case) and confirms GPTQ's reconstruction error is measurably and reliably lower than plain round-to-nearest's (checked via a sweep across data/rank/noise variations before finalizing the test scenario).
- A dead-input-channel test confirms Hessian damping keeps inversion stable when a channel never activates.
- Full regression sweep: `tests/` (excluding torch/timm-dependent modules not installed in this environment) -- **456 passed, 68 skipped, 0 failed**.

## Bonus fix: a real bug in shared test infrastructure

While debugging the correlated-channel test, found and fixed a genuine pre-existing bug in the `_dequantize_int4` test-helper pattern copy-pasted into `test_adaround.py`, `test_awq.py`, and this PR's `test_gptq.py`: it located the scale tensor by scanning for "the first FLOAT32 initializer", which silently matched `quantize_weight_only_int4`'s own now-dead original float32 weight (never pruned) instead of the real per-block scale, whenever it happened to sort first in the initializer list -- **which it always does**. This didn't affect `apply_adaround`/`apply_awq`'s actual (correct) behavior, only the *verification* those two already-merged PRs' tests performed -- their specific assertions happened to still hold by coincidence. GPTQ's true improvement margin was fragile enough for the bug to flip an assertion's sign, which is what surfaced it. Fixed all three by deriving Wq/Ws from the `DequantizeLinear` node's own input names instead of scanning by dtype. All 19 tests across the three files still pass after the fix, now for real reasons.

## New files

- `onnxsim/gptq.py`
- `tests/test_gptq.py` -- 7 tests

## Modified

- `tests/test_adaround.py`, `tests/test_awq.py` -- the `_dequantize_int4` fix above; no production code changes

## Test plan

- [x] `pytest tests/test_gptq.py tests/test_adaround.py tests/test_awq.py -v`
- [x] Full `tests/` sweep (torch/timm-dependent modules excluded, not installed in this environment)
- [x] `ruff format` / `ruff check` / `mypy`

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_