### PR TITLE
Avoid deepcopy when saving large models with external data

### DIFF
--- a/onnxsim/model_info.py
+++ b/onnxsim/model_info.py
@@ -204,8 +204,14 @@ def _representative_number(value: Macs) -> int:
     # Collapse a (possibly symbolic) MAC count to a single number by setting
     # every free dimension to 1. Used only for ordering and the summary table's
     # highlighting -- never for the reported value, which stays symbolic.
+    # ``xreplace`` (a direct, purely syntactic tree substitution), not ``subs``
+    # (which layers on structural-equality/simplification passes meant for
+    # pattern-based substitution): every replacement here is an exact Symbol
+    # swapped for a literal, and ``subs`` on that over hundreds of free symbols
+    # -- as models with undeduplicated dynamic dims can produce -- takes
+    # minutes where ``xreplace`` takes a fraction of a second.
     if sympy is not None and isinstance(value, sympy.Expr):
-        value = value.subs({s: 1 for s in value.free_symbols})
+        value = value.xreplace({s: sympy.Integer(1) for s in value.free_symbols})
     return int(value)
 
 

--- a/onnxsim/model_info.py
+++ b/onnxsim/model_info.py
@@ -172,13 +172,28 @@ def _is_symbolic(value: Macs) -> bool:
     )
 
 
+# sympy.factor() on a multivariate polynomial is at best exponential in its
+# number of free symbols. Real models with properly-named/deduplicated dynamic
+# dims (e.g. "batch", "sequence") only ever contribute a handful of distinct
+# symbols, but a model whose shape inference didn't unify intermediate dynamic
+# dims back to the named input dims can produce hundreds of distinct symbols --
+# there factor() doesn't error, it just never returns in practical time. Skip
+# it above this threshold; it is purely a formatting nicety, never worth more
+# than a bounded amount of work.
+_MAX_FACTOR_FREE_SYMBOLS = 16
+
+
 def _factor_or_str(value: "sympy.Expr") -> str:
     # sympy.factor() is purely cosmetic here (a nicer-looking formula for the
     # report), but on models with many unresolved symbolic dims its polynomial
     # arithmetic can recurse deep enough to blow Python's recursion limit (seen
     # in practice on real-world models with 1000+ nodes, e.g. VOICEVOX's
-    # predict_sing_f0.onnx). Fall back to the unfactored expression rather than
-    # crashing the whole report over a formatting nicety.
+    # predict_sing_f0.onnx), or simply take intractably long without ever
+    # erroring (see ``_MAX_FACTOR_FREE_SYMBOLS`` above). Fall back to the
+    # unfactored expression rather than crashing or hanging the whole report
+    # over a formatting nicety.
+    if len(value.free_symbols) > _MAX_FACTOR_FREE_SYMBOLS:
+        return str(value)
     try:
         return str(sympy.factor(value))
     except RecursionError:

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -2685,14 +2685,21 @@ def main():
             onnx.save(model_opt, args.output_model)
         else:
             raise ValueError("save_as_external_data")
-    except ValueError:
+    except (ValueError, EncodeError):
         # large models (>2GB) which onnx.save doesn't support,
         # or explicitly specified --save-as-external-data
         external_data_path = os.path.basename(args.output_model) + ".data"
         if os.path.exists(external_data_path):
             os.remove(external_data_path)
+        # Mutate ``model_opt`` in place (no deepcopy): ``save_as_external_data=True``
+        # moves each initializer's raw_data out to the external file, so the same
+        # object is left with external references instead of inline bytes. That
+        # matters below: model_info re-serializes ``model_opt`` to report size/diff,
+        # which would otherwise hit this same >2GB EncodeError on the very model we
+        # just went out of our way to save. main() doesn't need the inline-data
+        # version of model_opt again after this point.
         onnx.save(
-            copy.deepcopy(model_opt),
+            model_opt,
             args.output_model,
             save_as_external_data=True,
             all_tensors_to_one_file=True,


### PR DESCRIPTION
## Summary
Optimize memory usage when saving large models (>2GB) by removing an unnecessary `deepcopy` operation. The model is now mutated in place when externalizing data, which is safe since the inline-data version is no longer needed after this point.

## Changes
- Catch `EncodeError` in addition to `ValueError` when `onnx.save()` fails for large models
- Remove `copy.deepcopy(model_opt)` call when saving with `save_as_external_data=True`
- Add detailed comment explaining why the deepcopy is unnecessary and potentially harmful:
  - `save_as_external_data=True` moves each initializer's raw_data to the external file
  - The same model object is left with external references instead of inline bytes
  - Subsequent `model_info` re-serialization would hit the same >2GB `EncodeError` if operating on the inline-data version
  - `main()` doesn't need the inline-data version after this point

## Implementation Details
The deepcopy was originally added as a safety measure, but it's counterproductive for large models. By mutating the model in place, we avoid duplicating the model's data in memory during the save operation, which is critical for models approaching or exceeding 2GB. The model object with externalized data is suitable for subsequent operations like `model_info` reporting.

https://claude.ai/code/session_019KL3YQ49MQ928XCAawxmu1