### PR TITLE
Fix static zero-length dimension handling in calibration

### DIFF
--- a/.github/workflows/pocket_tts.yml
+++ b/.github/workflows/pocket_tts.yml
@@ -1,0 +1,80 @@
+name: Pocket TTS regression test
+
+# Builds onnxsim from source and runs tests/test_pocket_tts.py, which
+# downloads the community ONNX export of Kyutai's Pocket TTS
+# (https://huggingface.co/KevinAHM/pocket-tts-onnx, a public mirror of the
+# gated https://huggingface.co/kyutai/pocket-tts weights) and simplifies
+# and quantizes each graph with onnxsim. This guards against onnxsim
+# regressions on Pocket TTS-style graphs -- see tests/test_pocket_tts.py's
+# module docstring for the real onnxsim bug this surfaced: a genuinely
+# static, zero-length input dimension (an empty KV-cache sentinel) was
+# silently promoted to 1 by generate_random_calibration_data, breaking
+# calibration/accuracy-drop measurement -- and recommend_quantization's
+# candidate loop -- on flow_lm_main.onnx and mimi_decoder.onnx. Fixed in
+# onnxsim/calibration.py.
+
+# Downloads real models over the network (~460MB total across all 5 graphs)
+# and, for flow_lm_main.onnx, takes well over a minute under check_n=3 --
+# too slow/network-dependent to run on every PR unconditionally. It always
+# runs weekly and on push to the default branch, and additionally runs on a
+# PR when the PR itself touches the files this test exists to guard (the
+# test itself, or the modules it exercises); use workflow_dispatch to
+# trigger it manually against a branch for any other change.
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    paths:
+      - tests/test_pocket_tts.py
+      - tests/test_static_quantize_matmul.py
+      - onnxsim/calibration.py
+      - onnxsim/accuracy.py
+      - onnxsim/autoquant.py
+      - .github/workflows/pocket_tts.yml
+  schedule:
+    - cron: '0 10 * * 1'  # weekly, Monday 10:00 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pocket_tts:
+    name: Pocket TTS (Hugging Face) -> onnxsim
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CMAKE_GENERATOR: Ninja
+      CMAKE_CXX_COMPILER_LAUNCHER: sccache
+      SCCACHE_GHA_ENABLED: 'on'
+      ACTIONS_CACHE_SERVICE_V2: 'on'
+      ONNXSIM_RUN_POCKET_TTS_TESTS: '1'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+      - uses: mozilla-actions/sccache-action@v0.0.11
+
+      - name: Install build tooling
+        run: pip install cmake ninja "setuptools>=77" sccache nanobind
+
+      - name: Install test dependencies
+        run: pip install pytest onnxruntime
+
+      # Build the onnxsim under test last so it wins over anything a dependency
+      # might have pulled. --no-build-isolation reuses the tooling installed above.
+      - name: Build onnxsim (editable)
+        run: pip install --no-build-isolation -ve .
+
+      - name: Verify onnxsim under test is the source build
+        run: python -c "import onnxsim, onnxsim.onnxsim_cpp2py_export; print('onnxsim', onnxsim.__version__, onnxsim.__file__)"
+
+      - name: Run Pocket TTS regression test
+        run: pytest -v tests/test_pocket_tts.py

--- a/onnxsim/calibration.py
+++ b/onnxsim/calibration.py
@@ -50,8 +50,15 @@ _ELEM_TYPE_TO_NP = {
 def _input_specs(model: onnx.ModelProto) -> List[Tuple[str, List[int], type]]:
     """(name, shape, np_dtype) for every graph input that is not an initializer.
 
-    Dynamic dimensions (including an unset/symbolic batch dimension) are
-    fixed to 1, so the returned shapes are always fully concrete.
+    Dynamic dimensions (a symbolic ``dim_param``, or no dimension value set
+    at all -- typically an unset/symbolic batch dimension) are fixed to 1,
+    so the returned shapes are always fully concrete. A dimension whose
+    ``dim_value`` is genuinely, statically 0 (e.g. an empty KV-cache
+    sentinel state some exporters emit) is kept as 0 rather than promoted
+    to 1: ``dim.dim_value`` reads back as 0 both when it was explicitly set
+    to 0 and when the field is unset entirely, so only ``HasField`` tells
+    the two apart (matches ``model_info.py``'s own ``HasField`` check for
+    the same ambiguity).
     """
     initializer_names = {i.name for i in model.graph.initializer}
     specs = []
@@ -59,7 +66,7 @@ def _input_specs(model: onnx.ModelProto) -> List[Tuple[str, List[int], type]]:
         if ipt.name in initializer_names:
             continue
         shape = [
-            dim.dim_value if dim.dim_value > 0 else 1
+            dim.dim_value if dim.HasField("dim_value") else 1
             for dim in ipt.type.tensor_type.shape.dim
         ]
         np_dtype = _ELEM_TYPE_TO_NP.get(ipt.type.tensor_type.elem_type, np.float32)

--- a/tests/test_pocket_tts.py
+++ b/tests/test_pocket_tts.py
@@ -1,0 +1,247 @@
+# Integration/regression test: onnxsim against Kyutai's Pocket TTS
+# (https://github.com/kyutai-labs/pocket-tts, "a TTS that fits in your CPU
+# (and pocket)"), a small streaming-state text-to-speech model. The upstream
+# checkpoints are gated, so this test targets the community ONNX export
+# published at https://huggingface.co/KevinAHM/pocket-tts-onnx (exported by
+# https://github.com/KevinAHM/pocket-tts-onnx-export from the real
+# ``kyutai/pocket-tts`` weights), a public, non-gated mirror of the same
+# graphs -- no HF auth needed to download.
+#
+# The bundle covers pocket-tts's whole pipeline and, between the five graphs,
+# exercises the streaming/stateful patterns onnxsim needs to handle
+# correctly:
+#
+#   * ``text_conditioner.onnx``  -- a single Gather-based token embedding.
+#   * ``mimi_encoder.onnx``      -- audio -> latent Conv/Transformer encoder.
+#   * ``flow_lm_flow.onnx``      -- the stateless flow-matching (Euler) step.
+#   * ``mimi_decoder.onnx``      -- latent -> audio streaming decoder: a
+#     Mod/ScatterND ring-buffer KV cache plus dozens of small Conv "previous
+#     frame" states, several of them ``bool`` flags.
+#   * ``flow_lm_main.onnx``      -- the transformer backbone: 18 KV-cache
+#     state tensors per call, including a genuinely **static, zero-length**
+#     dimension (``state_1``'s shape is ``(0,)``) used as an "empty so far"
+#     sentinel -- not a symbolic/dynamic dim defaulting to 0, an exported
+#     dim actually fixed at 0.
+#
+# That last detail is exactly what this test set was written to guard
+# against: ``onnxsim.generate_random_calibration_data`` (via its internal
+# ``_input_specs``) used to promote *any* non-positive ``dim_value`` to 1,
+# conflating "genuinely fixed to 0" with "unset/symbolic" -- so calibrating
+# or measuring accuracy drop on ``flow_lm_main.onnx``/``mimi_decoder.onnx``
+# built a shape ONNX Runtime rejected outright, and that exception was
+# silently swallowed by ``recommend_quantization``'s candidate loop, which
+# reported a generic "no candidate quantization scheme both applied to this
+# model and shrank it" instead of the real calibration failure. Fixed in
+# ``onnxsim/calibration.py`` by checking ``dim.HasField("dim_value")``
+# instead of ``dim.dim_value > 0`` (matching the pattern ``model_info.py``
+# already used for the same ambiguity); see
+# ``test_generate_random_calibration_data_keeps_static_zero_dim`` in
+# ``test_static_quantize_matmul.py`` for the minimal unit-level regression
+# test, and ``test_pocket_tts_flow_lm_main_quantize_weight_only`` below for
+# end-to-end coverage on the real model that surfaced it.
+#
+# Two more things worth knowing if you're using this test set as a
+# reference for quantizing similar exports:
+#
+#   * onnxsim's weight quantizers only recognize a MatMul/Gemm's weight
+#     input when it is *directly* a graph initializer. The legacy
+#     TorchScript ``torch.onnx.export`` path used by pocket-tts's exporter
+#     emits each ``nn.Linear`` as ``MatMul(x, Transpose(weight))`` --
+#     quantizing the raw export directly finds almost nothing to quantize.
+#     Running ``onnxsim.simplify()`` first folds ``Transpose(initializer)``
+#     into a plain pre-transposed initializer, which is what actually
+#     exposes the real Linear weights to every ``quantize_*`` function.
+#     Always simplify before quantizing.
+#   * ``quantize_weight_only_int4`` needs ONNX opset 21 for the native INT4
+#     tensor type and silently no-ops on pocket-tts's opset-14 export;
+#     ``onnxsim.simplify(model, target_opset_version=21)`` upgrades it in
+#     place before quantizing.
+#
+# Downloads real model weights (16-290MB per case, ~460MB total across all
+# 5) over the network and, for flow_lm_main.onnx, takes well over a minute
+# under check_n=3 -- too slow/network-dependent for every PR. It is opt-in
+# via ONNXSIM_RUN_POCKET_TTS_TESTS=1, set by the dedicated weekly
+# .github/workflows/pocket_tts.yml. To run it locally::
+#
+#     pip install onnxruntime
+#     pip install --force-reinstall --no-deps .   # the onnxsim under test
+#     ONNXSIM_RUN_POCKET_TTS_TESTS=1 pytest tests/test_pocket_tts.py -v
+
+import os
+import time
+import urllib.error
+import urllib.request
+
+import numpy as np
+import onnx
+import pytest
+
+# A bare ``import onnxruntime`` would fail collection (not skip the test) on
+# platforms onnxruntime doesn't ship wheels for, before the
+# ONNXSIM_RUN_POCKET_TTS_TESTS skipif below even gets a chance to apply.
+onnxruntime = pytest.importorskip("onnxruntime")
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("ONNXSIM_RUN_POCKET_TTS_TESTS") != "1",
+    reason="Set ONNXSIM_RUN_POCKET_TTS_TESTS=1 to run (downloads real models "
+    "from Hugging Face; flow_lm_main.onnx takes well over a minute).",
+)
+
+import onnxsim  # noqa: E402
+
+_HF_BASE = "https://huggingface.co/KevinAHM/pocket-tts-onnx/resolve/main/onnx"
+
+# filename -> (test_input_shapes, input_fill). Dims left out rely on
+# onnxsim's "dynamic dim[0] -> assume batch size 1" default -- true of every
+# input here except text_conditioner's token_ids and mimi_encoder's audio,
+# whose dynamic length sits at position 1/2 instead.
+_SIMPLE_CASES = {
+    "text_conditioner.onnx": ({"token_ids": [1, 20]}, "zeros"),  # valid vocab index 0
+    "mimi_encoder.onnx": ({"audio": [1, 1, 24000]}, "random"),
+    "flow_lm_flow.onnx": ({}, "random"),
+}
+
+# mimi_decoder.onnx and flow_lm_main.onnx carry dozens of stateful KV-cache
+# inputs of mixed dtype (float/int64/bool) and, for flow_lm_main.onnx, a
+# genuinely static zero-length dimension -- exactly the case
+# generate_random_calibration_data's own input-shape inference now handles
+# correctly (see the module docstring). Building their check_n input through
+# it, rather than onnxsim's CLI-level input_fill, both sidesteps hand-rolling
+# per-state shapes/dtypes and doubles as coverage for that fix on the real
+# model that surfaced it.
+_STATEFUL_CASES = ["mimi_decoder.onnx", "flow_lm_main.onnx"]
+
+
+@pytest.fixture(scope="module")
+def pocket_tts_model_dir(tmp_path_factory):
+    return tmp_path_factory.mktemp("pocket_tts_onnx")
+
+
+_DOWNLOAD_ATTEMPTS = 5
+
+
+def _download(filename: str, dest_dir) -> str:
+    dest = str(dest_dir / filename)
+    if os.path.exists(dest):
+        return dest
+    url = f"{_HF_BASE}/{filename}"
+    tmp_dest = f"{dest}.part"
+    last_error: Exception = RuntimeError("unreachable")
+    for attempt in range(_DOWNLOAD_ATTEMPTS):
+        try:
+            # flow_lm_main.onnx alone is ~290MB; a plain GET occasionally comes
+            # back truncated on a flaky connection. Download to a temp name and
+            # only rename into place on a fully successful transfer, so a
+            # partial file is never mistaken for a complete one on retry or by
+            # a later test run.
+            urllib.request.urlretrieve(url, tmp_dest)
+            os.replace(tmp_dest, dest)
+            return dest
+        except (urllib.error.URLError, OSError) as e:
+            last_error = e
+            if os.path.exists(tmp_dest):
+                os.remove(tmp_dest)
+            if attempt + 1 < _DOWNLOAD_ATTEMPTS:
+                time.sleep(3 * (attempt + 1))
+    pytest.skip(
+        f"Could not download {filename} from Hugging Face after "
+        f"{_DOWNLOAD_ATTEMPTS} attempts: {last_error}"
+    )
+
+
+@pytest.mark.parametrize("filename", sorted(_SIMPLE_CASES.keys()))
+def test_pocket_tts_model_simplify(pocket_tts_model_dir, filename):
+    test_input_shapes, input_fill = _SIMPLE_CASES[filename]
+    path = _download(filename, pocket_tts_model_dir)
+
+    nodes_before = len(onnx.load(path, load_external_data=False).graph.node)
+
+    model_opt, check_ok = onnxsim.simplify(
+        path,
+        check_n=3,
+        test_input_shapes=test_input_shapes or None,
+        input_fill=input_fill,
+    )
+    assert check_ok, f"{filename}: onnxsim numerical check failed"
+    assert len(model_opt.graph.node) <= nodes_before, (
+        f"{filename}: simplification must not increase node count"
+    )
+
+    # The simplified model must still load and run in onnxruntime.
+    onnxruntime.InferenceSession(model_opt.SerializeToString())
+
+
+@pytest.mark.parametrize("filename", _STATEFUL_CASES)
+def test_pocket_tts_stateful_model_simplify(pocket_tts_model_dir, filename):
+    path = _download(filename, pocket_tts_model_dir)
+    original = onnx.load(path, load_external_data=False)
+    nodes_before = len(original.graph.node)
+
+    # A single realistic batch, built the same way onnxsim's own calibration
+    # helpers do -- reused here (rather than hand-rolling ~20-60 per-state
+    # shapes/dtypes) both for convenience and because it exercises the exact
+    # zero-length-dim shape inference this test module exists to guard.
+    input_data = onnxsim.generate_random_calibration_data(
+        original, num_samples=1, seed=0
+    )[0]
+
+    # check_n=1: input_data is one fixed batch reused for every check_n
+    # trial, so repeating it further would just re-run the same comparison.
+    model_opt, check_ok = onnxsim.simplify(path, check_n=1, input_data=input_data)
+    assert check_ok, f"{filename}: onnxsim numerical check failed"
+    assert len(model_opt.graph.node) < nodes_before, (
+        f"{filename}: simplification must reduce node count "
+        f"(these graphs carry a lot of foldable RoPE/mask/state-index "
+        f"arithmetic)"
+    )
+
+    session = onnxruntime.InferenceSession(model_opt.SerializeToString())
+    outputs = session.run(None, {k: v for k, v in input_data.items()})
+    assert len(outputs) == len(original.graph.output)
+
+
+def test_pocket_tts_flow_lm_main_quantize_weight_only(pocket_tts_model_dir):
+    # Regression coverage, on the real model that surfaced it, for the
+    # generate_random_calibration_data zero-dim fix this test module's
+    # docstring describes: measure_accuracy_drop (called here through
+    # quantize_weight_only + measure_accuracy_drop directly, the same pair
+    # recommend_quantization uses internally) must not raise on
+    # flow_lm_main.onnx's genuinely-zero-length "state_1" input.
+    #
+    # Quantizing the raw export directly finds almost no Linear weights (see
+    # module docstring: torch.onnx's legacy exporter hides them behind a
+    # Transpose): simplify first to fold Transpose(initializer) into a plain
+    # initializer, exposing flow_lm_main's real ~226MB of Linear weights to
+    # the quantizer.
+    path = _download("flow_lm_main.onnx", pocket_tts_model_dir)
+    simplified, _ = onnxsim.simplify(path, check_n=0)  # check_n=0: no numerical check, just the fold
+
+    float_bytes = sum(
+        len(t.raw_data) if t.HasField("raw_data") else len(t.SerializeToString())
+        for t in simplified.graph.initializer
+    )
+
+    quantized = onnxsim.quantize_weight_only(simplified)  # int8, per-channel
+
+    report = onnxsim.measure_accuracy_drop(simplified, quantized, num_samples=4, seed=0)
+    assert report.all_finite, "quantized flow_lm_main.onnx produced non-finite output"
+    # ~0.03 observed; keep a wide margin -- this asserts "quantization is in
+    # the ballpark it should be", not a tight regression pin on the exact
+    # float value, since that would make the test flaky against unrelated
+    # onnxsim graph-optimization changes that shift constant-folding order.
+    assert report.worst_relative_l2 < 0.15
+
+    quantized_simplified, _ = onnxsim.simplify(quantized, check_n=0)
+    quant_bytes = sum(
+        len(t.raw_data) if t.HasField("raw_data") else len(t.SerializeToString())
+        for t in quantized_simplified.graph.initializer
+    )
+    # Re-simplifying after quantization is required to prune the now-unused
+    # float32 initializers quantize_weight_only leaves behind (it swaps each
+    # MatMul's weight input for a DequantizeLinear, but doesn't itself drop
+    # the now-orphaned original initializer) -- comparing sizes measured
+    # before/after that cleanup is a routine papercut, not a bug in either
+    # function individually.
+    assert quant_bytes < float_bytes * 0.5
+
+    onnxruntime.InferenceSession(quantized_simplified.SerializeToString())

--- a/tests/test_pocket_tts.py
+++ b/tests/test_pocket_tts.py
@@ -72,7 +72,6 @@ import time
 import urllib.error
 import urllib.request
 
-import numpy as np
 import onnx
 import pytest
 
@@ -214,7 +213,9 @@ def test_pocket_tts_flow_lm_main_quantize_weight_only(pocket_tts_model_dir):
     # initializer, exposing flow_lm_main's real ~226MB of Linear weights to
     # the quantizer.
     path = _download("flow_lm_main.onnx", pocket_tts_model_dir)
-    simplified, _ = onnxsim.simplify(path, check_n=0)  # check_n=0: no numerical check, just the fold
+    simplified, _ = onnxsim.simplify(
+        path, check_n=0
+    )  # check_n=0: no numerical check, just the fold
 
     float_bytes = sum(
         len(t.raw_data) if t.HasField("raw_data") else len(t.SerializeToString())

--- a/tests/test_static_quantize_matmul.py
+++ b/tests/test_static_quantize_matmul.py
@@ -155,9 +155,7 @@ def test_generate_random_calibration_data_keeps_static_zero_dim():
     nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
     # X's second dim is dynamic (symbolic "seq"); "state" has a real,
     # static empty dimension at index 1.
-    x_vi = onnx.helper.make_tensor_value_info(
-        "X", onnx.TensorProto.FLOAT, [2, "seq"]
-    )
+    x_vi = onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, [2, "seq"])
     state_vi = onnx.helper.make_tensor_value_info(
         "state", onnx.TensorProto.FLOAT, [1, 0, 4]
     )

--- a/tests/test_static_quantize_matmul.py
+++ b/tests/test_static_quantize_matmul.py
@@ -144,6 +144,32 @@ def test_generate_random_calibration_data_shapes():
         assert batch["X"].dtype == np.float32
 
 
+def test_generate_random_calibration_data_keeps_static_zero_dim():
+    # A genuinely static, zero-length dimension (e.g. an empty KV-cache
+    # sentinel some exporters emit -- see pocket-tts's flow_lm_main.onnx,
+    # whose "state_1" input is exactly this) must survive as 0, not get
+    # silently promoted to 1: `dim.dim_value` reads back as 0 both when a
+    # dim is genuinely fixed to 0 and when it's unset/symbolic, so telling
+    # them apart requires `HasField("dim_value")`, not a bare `> 0` check.
+    weight = _f32(np.random.randn(8, 4).astype(np.float32), "W")
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    # X's second dim is dynamic (symbolic "seq"); "state" has a real,
+    # static empty dimension at index 1.
+    x_vi = onnx.helper.make_tensor_value_info(
+        "X", onnx.TensorProto.FLOAT, [2, "seq"]
+    )
+    state_vi = onnx.helper.make_tensor_value_info(
+        "state", onnx.TensorProto.FLOAT, [1, 0, 4]
+    )
+    # "state" is unused by any node -- fine, only its declared shape matters
+    # for _input_specs, which looks at model.graph.input directly.
+    model = _model(nodes, [x_vi, state_vi], [_vi("Y", [2, 4])], [weight])
+
+    batches = onnxsim.generate_random_calibration_data(model, num_samples=1, seed=0)
+    assert batches[0]["X"].shape == (2, 1)  # symbolic dim -> defaults to 1
+    assert batches[0]["state"].shape == (1, 0, 4)  # static 0 dim -> stays 0
+
+
 def test_calibrate_returns_ranges_for_quantizable_tensors():
     weight = _f32(np.random.randn(8, 4).astype(np.float32), "W")
     nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]


### PR DESCRIPTION
## Summary

Fixes a bug in `generate_random_calibration_data` where genuinely static, zero-length dimensions (e.g., empty KV-cache sentinels) were silently promoted to 1, breaking calibration and accuracy-drop measurement on models like Pocket TTS's `flow_lm_main.onnx` and `mimi_decoder.onnx`.

## Key Changes

- **onnxsim/calibration.py**: Updated `_input_specs()` to distinguish between genuinely static zero-length dimensions and unset/symbolic dimensions using `dim.HasField("dim_value")` instead of `dim.dim_value > 0`. This matches the pattern already used in `model_info.py` for the same ambiguity.

- **tests/test_static_quantize_matmul.py**: Added `test_generate_random_calibration_data_keeps_static_zero_dim()` regression test to verify that static zero-length dimensions are preserved as 0 rather than promoted to 1.

- **tests/test_pocket_tts.py** (new): Comprehensive integration/regression test suite for Pocket TTS (a small streaming-state TTS model) that exercises the fixed behavior on real models. Tests simplification and quantization of five ONNX graphs covering various stateful patterns, with specific coverage for the zero-length dimension bug on `flow_lm_main.onnx` and `mimi_decoder.onnx`.

- **.github/workflows/pocket_tts.yml** (new): Weekly CI workflow that runs the Pocket TTS test suite. Triggered on push to main/master, on PRs touching relevant files, and manually via workflow_dispatch.

## Implementation Details

The root cause was that `dim.dim_value` reads back as 0 both when a dimension is explicitly set to 0 and when the field is unset (symbolic). The fix uses `HasField("dim_value")` to distinguish these cases:
- If `HasField("dim_value")` is true, use the actual `dim_value` (which may be 0)
- If false, the dimension is symbolic/unset, so default to 1

The Pocket TTS test suite serves as both regression coverage and a reference for quantizing similar streaming-state model exports. It includes notes on two practical considerations: (1) simplifying before quantizing to expose Linear weights hidden behind Transpose operations in legacy TorchScript exports, and (2) upgrading to opset 21 for INT4 quantization support.

https://claude.ai/code/session_015mzJB7wPsuf48MTgX1gonu