### PR TITLE
Add read_gguf_metadata: cheap GGUF header parsing without tensor data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -567,6 +567,17 @@ if (ONNXSIM_TESTS)
   target_compile_definitions(tensor_pool_gguf_test PRIVATE ${ONNXSIM_BLAKE3_COMPILE_DEFS})
   add_test(NAME tensor_pool_gguf_test COMMAND tensor_pool_gguf_test)
 
+  # ReadGGUFMetadata (tensor_pool_gguf.cpp) -- same standalone-buildable
+  # dependency footprint as tensor_pool_gguf_test above.
+  add_executable(read_gguf_metadata_test onnxsim/read_gguf_metadata_test.cpp
+                                         onnxsim/tensor_pool.cpp
+                                         onnxsim/tensor_pool_hash.cpp
+                                         onnxsim/tensor_pool_gguf.cpp
+                                         ${ONNXSIM_BLAKE3_SOURCES})
+  target_include_directories(read_gguf_metadata_test PRIVATE onnxsim third_party)
+  target_compile_definitions(read_gguf_metadata_test PRIVATE ${ONNXSIM_BLAKE3_COMPILE_DEFS})
+  add_test(NAME read_gguf_metadata_test COMMAND read_gguf_metadata_test)
+
   # tensor_pool_gguf_bridge.h needs onnx, same reason as
   # tensor_pool_bridge_test above.
   add_executable(tensor_pool_gguf_bridge_test

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -50,6 +50,7 @@ from onnxsim.onnx_simplifier import (
     quantize_weight_only_int8_block,
     quantize_weight_only_int16,
     quantize_weight_only_matmul_nbits,
+    read_gguf_metadata,
     simplify,
 )
 from onnxsim.precision_estimator import (
@@ -113,5 +114,6 @@ __all__ = [
     "export_gguf",
     "import_gguf",
     "import_gguf_weights",
+    "read_gguf_metadata",
     "__version__",
 ]

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -1315,4 +1315,58 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
         return {py::bytes(out.data(), out.size()), std::move(skipped)};
       },
       "model_bytes"_a, "gguf_path"_a);
+
+  // Reads a GGUF file's architecture hyperparameters (general.architecture,
+  // <arch>.block_count, <arch>.attention.head_count, <arch>.rope.freq_base,
+  // ...) and per-tensor name/shape/ggml_type list, WITHOUT reading any
+  // tensor byte data -- see tensor_pool.h's GGUFMetadata/ReadGGUFMetadata
+  // doc comments. This is the piece TensorPool::LoadGGUF/import_gguf_weights
+  // above never surfaced: they parse the same header section but only ever
+  // look at general.alignment before moving on to loading tensor *values*.
+  // Returns {"kv": {key: int|float|str|bool, ...},
+  //          "tensors": [{"name": str, "shape": [int, ...],
+  //                       "ggml_type": int}, ...]}. ARRAY-typed metadata
+  // values (e.g. tokenizer.ggml.tokens) are omitted from "kv" entirely --
+  // see GGUFMetadata's doc comment for why.
+  m.def(
+      "read_gguf_metadata",
+      [](const std::string& path) -> py::dict {
+        onnxsim::tensor_pool::GGUFMetadata meta =
+            onnxsim::tensor_pool::ReadGGUFMetadata(path);
+
+        py::dict kv;
+        for (const auto& [key, value] : meta.kv) {
+          switch (value.kind) {
+            case onnxsim::tensor_pool::GGUFMetadataValue::Kind::kInt:
+              kv[key.c_str()] = value.int_value;
+              break;
+            case onnxsim::tensor_pool::GGUFMetadataValue::Kind::kFloat:
+              kv[key.c_str()] = value.float_value;
+              break;
+            case onnxsim::tensor_pool::GGUFMetadataValue::Kind::kString:
+              kv[key.c_str()] = value.string_value;
+              break;
+            case onnxsim::tensor_pool::GGUFMetadataValue::Kind::kBool:
+              kv[key.c_str()] = value.bool_value;
+              break;
+          }
+        }
+
+        py::list tensors;
+        for (const auto& t : meta.tensors) {
+          py::dict entry;
+          entry["name"] = t.name;
+          py::list shape;
+          for (int64_t d : t.shape) shape.append(d);
+          entry["shape"] = shape;
+          entry["ggml_type"] = t.ggml_type;
+          tensors.append(entry);
+        }
+
+        py::dict out;
+        out["kv"] = kv;
+        out["tensors"] = tensors;
+        return out;
+      },
+      "path"_a);
 }

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -416,6 +416,34 @@ def import_gguf_weights(
     return result, skipped
 
 
+def read_gguf_metadata(path: str) -> dict:
+    """
+    Read a GGUF file's architecture hyperparameters and per-tensor
+    name/shape/dtype list, without reading any tensor byte data -- cheap
+    even against a multi-gigabyte real checkpoint.
+
+    This is the piece :func:`import_gguf_weights` never surfaces: both
+    functions parse the same GGUF header section, but ``import_gguf_weights``
+    only ever looks at the ``general.alignment`` key before moving on to
+    loading tensor *values* into an existing graph's initializers. Use this
+    instead when what you need is the checkpoint's own description of its
+    architecture -- e.g. ``general.architecture``, ``<arch>.block_count``,
+    ``<arch>.attention.head_count``, ``<arch>.rope.freq_base`` -- to decide
+    *what graph structure* to build in the first place (``import_gguf_weights``
+    only ever fills in the values of a graph you already have).
+
+    :param path: path to the GGUF file to read
+    :returns: ``{"kv": {key: int | float | str | bool, ...},
+            "tensors": [{"name": str, "shape": [int, ...],
+            "ggml_type": int}, ...]}``. ``ggml_type`` is the raw GGML type
+            code (see ``onnxsim/gguf_dtype.h``); an ARRAY-typed metadata
+            value (e.g. ``tokenizer.ggml.tokens``, which alone can hold
+            >100k strings in a real checkpoint) is omitted from ``"kv"``
+            entirely rather than decoded.
+    """
+    return C.read_gguf_metadata(path)
+
+
 def cross_layer_equalize(model: Union[str, onnx.ModelProto]) -> onnx.ModelProto:
     """
     Data-free Cross-Layer Equalization (CLE) -- the weight-equalization

--- a/onnxsim/read_gguf_metadata_test.cpp
+++ b/onnxsim/read_gguf_metadata_test.cpp
@@ -1,0 +1,282 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Standalone: g++ -std=c++20 read_gguf_metadata_test.cpp tensor_pool.cpp \
+ *               tensor_pool_gguf.cpp -o t && ./t
+ *
+ * Dependency-free unit test for ReadGGUFMetadata (tensor_pool_gguf.cpp) --
+ * the metadata-KV + tensor-info reader TensorPool::LoadGGUF itself does NOT
+ * provide (LoadGGUF parses that very same header section but only ever
+ * looks at general.alignment). Mirrors tensor_pool_gguf_test.cpp's
+ * hand-built-bytes style, but exercises every GGUF metadata value type
+ * (unsigned/signed ints of every width, both float widths, bool, string)
+ * plus confirms ARRAY values are skipped correctly -- not surfaced, and not
+ * mistaken for a truncated/misaligned read of whatever follows.
+ */
+#include <unistd.h>
+
+#include <algorithm>
+#include <bit>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include "gguf_dtype.h"
+#include "tensor_pool.h"
+
+using namespace onnxsim::tensor_pool;
+using namespace onnxsim::tensor_pool::gguf;
+
+namespace {
+
+int g_failures = 0;
+
+void Check(bool cond, const std::string& what) {
+  if (!cond) {
+    std::fprintf(stderr, "FAIL: %s\n", what.c_str());
+    ++g_failures;
+  }
+}
+
+std::string TempPath(const std::string& suffix) {
+  return "/tmp/onnxsim_read_gguf_metadata_test_" + std::to_string(::getpid()) +
+         suffix;
+}
+
+template <typename T>
+void WriteLE(std::ostream& out, T v) {
+  static_assert(std::is_trivially_copyable_v<T>);
+  unsigned char raw[sizeof(T)];
+  std::memcpy(raw, &v, sizeof(T));
+  if constexpr (std::endian::native == std::endian::big) {
+    std::reverse(std::begin(raw), std::end(raw));
+  }
+  out.write(reinterpret_cast<const char*>(raw), sizeof(T));
+}
+
+void WriteGGUFString(std::ostream& out, const std::string& s) {
+  WriteLE<uint64_t>(out, s.size());
+  out.write(s.data(), static_cast<std::streamsize>(s.size()));
+}
+
+void WriteStringKV(std::ostream& out, const std::string& key,
+                   const std::string& value) {
+  WriteGGUFString(out, key);
+  WriteLE<uint32_t>(out, GGUF_METADATA_VALUE_TYPE_STRING);
+  WriteGGUFString(out, value);
+}
+
+template <typename T>
+void WriteScalarKV(std::ostream& out, const std::string& key,
+                   uint32_t value_type, T value) {
+  WriteGGUFString(out, key);
+  WriteLE<uint32_t>(out, value_type);
+  WriteLE<T>(out, value);
+}
+
+void WriteBoolKV(std::ostream& out, const std::string& key, bool value) {
+  WriteGGUFString(out, key);
+  WriteLE<uint32_t>(out, GGUF_METADATA_VALUE_TYPE_BOOL);
+  WriteLE<uint8_t>(out, value ? 1 : 0);
+}
+
+// A UINT32 array -- checks that ReadGGUFMetadata skips PAST an array's whole
+// payload (not just its length prefix), so whatever comes after it in the
+// file is read from the right offset.
+void WriteUint32ArrayKV(std::ostream& out, const std::string& key,
+                        const std::vector<uint32_t>& values) {
+  WriteGGUFString(out, key);
+  WriteLE<uint32_t>(out, GGUF_METADATA_VALUE_TYPE_ARRAY);
+  WriteLE<uint32_t>(out, GGUF_METADATA_VALUE_TYPE_UINT32);  // element type
+  WriteLE<uint64_t>(out, values.size());
+  for (uint32_t v : values) WriteLE<uint32_t>(out, v);
+}
+
+// Same, but a STRING array -- a different skip path (per-element
+// length-prefixed strings, not a fixed elem_size * len seek).
+void WriteStringArrayKV(std::ostream& out, const std::string& key,
+                        const std::vector<std::string>& values) {
+  WriteGGUFString(out, key);
+  WriteLE<uint32_t>(out, GGUF_METADATA_VALUE_TYPE_ARRAY);
+  WriteLE<uint32_t>(out, GGUF_METADATA_VALUE_TYPE_STRING);  // element type
+  WriteLE<uint64_t>(out, values.size());
+  for (const auto& s : values) WriteGGUFString(out, s);
+}
+
+// Every scalar type (including a negative signed case per width), both
+// array-skip paths, and a two-entry tensor-info section -- with NO tensor
+// data at all following it. A file this short would fail any attempt to
+// read real tensor bytes, so successfully parsing to the end proves
+// ReadGGUFMetadata truly never touches the data section.
+void TestFullMetadataDecodeNoTensorDataNeeded() {
+  std::string path = TempPath("_full.gguf");
+  {
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    WriteLE<uint32_t>(out, kMagic);
+    WriteLE<uint32_t>(out, kSupportedVersion);
+    WriteLE<uint64_t>(out, 2);   // tensor_count
+    WriteLE<uint64_t>(out, 14);  // metadata_kv_count
+
+    WriteStringKV(out, "general.architecture", "llama");
+    WriteScalarKV<uint8_t>(out, "u8", GGUF_METADATA_VALUE_TYPE_UINT8, 200);
+    WriteScalarKV<uint16_t>(out, "u16", GGUF_METADATA_VALUE_TYPE_UINT16, 40000);
+    WriteScalarKV<uint32_t>(out, "llama.block_count",
+                            GGUF_METADATA_VALUE_TYPE_UINT32, 32);
+    WriteScalarKV<uint64_t>(out, "u64", GGUF_METADATA_VALUE_TYPE_UINT64,
+                            9876543210ULL);
+    WriteScalarKV<int8_t>(out, "i8_neg", GGUF_METADATA_VALUE_TYPE_INT8, -5);
+    WriteScalarKV<int16_t>(out, "i16_neg", GGUF_METADATA_VALUE_TYPE_INT16,
+                           static_cast<int16_t>(-1000));
+    WriteScalarKV<int32_t>(out, "i32_neg", GGUF_METADATA_VALUE_TYPE_INT32,
+                           -70000);
+    WriteScalarKV<int64_t>(out, "i64_neg", GGUF_METADATA_VALUE_TYPE_INT64,
+                           -5000000000LL);
+    WriteScalarKV<float>(out, "llama.rope.freq_base",
+                         GGUF_METADATA_VALUE_TYPE_FLOAT32, 10000.0f);
+    WriteScalarKV<double>(out, "f64", GGUF_METADATA_VALUE_TYPE_FLOAT64, -0.125);
+    WriteBoolKV(out, "llama.attention.use_bias", true);
+    WriteUint32ArrayKV(out, "some.int.array", {10, 20, 30});
+    WriteStringArrayKV(out, "tokenizer.ggml.tokens", {"a", "bb", "ccc"});
+
+    // Tensor 0: "tok_embeddings.weight", F32, ne=[8, 4] (ggml order --
+    // reversed to onnx's [4, 8] on decode). Offset is 0 but never followed.
+    WriteGGUFString(out, "tok_embeddings.weight");
+    WriteLE<uint32_t>(out, 2);              // n_dimensions
+    WriteLE<uint64_t>(out, 8);              // ne[0]
+    WriteLE<uint64_t>(out, 4);              // ne[1]
+    WriteLE<uint32_t>(out, GGML_TYPE_F32);  // type
+    WriteLE<uint64_t>(out, 0);              // offset (never read)
+
+    // Tensor 1: a K-quant tensor (Q4_K) -- proves ReadGGUFMetadata reports
+    // its ggml_type as-is (12) rather than trying to interpret/skip it, and
+    // proves the *previous* tensor's info was consumed at the right length
+    // even though this one is a different element count/rank.
+    WriteGGUFString(out, "blk.0.attn_q.weight");
+    WriteLE<uint32_t>(out, 1);               // n_dimensions
+    WriteLE<uint64_t>(out, 256);             // ne[0]
+    WriteLE<uint32_t>(out, GGML_TYPE_Q4_K);  // type
+    WriteLE<uint64_t>(out, 12345);           // offset (never read)
+
+    // Deliberately NOT writing any tensor data -- ReadGGUFMetadata must
+    // never seek/read past this point.
+  }
+
+  GGUFMetadata meta = ReadGGUFMetadata(path);
+
+  Check(meta.kv.size() == 12,
+        "12 scalar KV entries decoded (2 arrays correctly excluded)");
+  Check(meta.kv.at("general.architecture").kind ==
+                GGUFMetadataValue::Kind::kString &&
+            meta.kv.at("general.architecture").string_value == "llama",
+        "STRING value decodes");
+  Check(meta.kv.at("u8").kind == GGUFMetadataValue::Kind::kInt &&
+            meta.kv.at("u8").int_value == 200,
+        "UINT8 value decodes");
+  Check(meta.kv.at("u16").int_value == 40000, "UINT16 value decodes");
+  Check(meta.kv.at("llama.block_count").int_value == 32,
+        "UINT32 value decodes");
+  Check(meta.kv.at("u64").int_value == 9876543210LL, "UINT64 value decodes");
+  Check(meta.kv.at("i8_neg").int_value == -5,
+        "INT8 negative value sign-extends correctly");
+  Check(meta.kv.at("i16_neg").int_value == -1000,
+        "INT16 negative value sign-extends correctly");
+  Check(meta.kv.at("i32_neg").int_value == -70000,
+        "INT32 negative value sign-extends correctly");
+  Check(meta.kv.at("i64_neg").int_value == -5000000000LL,
+        "INT64 negative value round-trips");
+  Check(meta.kv.at("llama.rope.freq_base").kind ==
+                GGUFMetadataValue::Kind::kFloat &&
+            meta.kv.at("llama.rope.freq_base").float_value == 10000.0,
+        "FLOAT32 value decodes exactly (10000.0 has an exact float32 repr)");
+  Check(meta.kv.at("f64").float_value == -0.125,
+        "FLOAT64 value decodes exactly (-0.125 has an exact float64 repr)");
+  Check(meta.kv.at("llama.attention.use_bias").kind ==
+                GGUFMetadataValue::Kind::kBool &&
+            meta.kv.at("llama.attention.use_bias").bool_value == true,
+        "BOOL value decodes");
+  Check(meta.kv.find("some.int.array") == meta.kv.end(),
+        "an int ARRAY value is omitted from kv, not surfaced");
+  Check(meta.kv.find("tokenizer.ggml.tokens") == meta.kv.end(),
+        "a string ARRAY value is omitted from kv, not surfaced");
+
+  Check(meta.tensors.size() == 2, "both tensor-info entries decoded");
+  if (meta.tensors.size() == 2) {
+    Check(meta.tensors[0].name == "tok_embeddings.weight",
+          "tensor 0 name decodes");
+    Check(meta.tensors[0].shape == std::vector<int64_t>({4, 8}),
+          "tensor 0 shape is reversed from ggml's ne[] to onnx order");
+    Check(meta.tensors[0].ggml_type == GGML_TYPE_F32,
+          "tensor 0 ggml_type decodes");
+    Check(meta.tensors[1].name == "blk.0.attn_q.weight",
+          "tensor 1 name decodes (correctly offset past tensor 0's info)");
+    Check(meta.tensors[1].shape == std::vector<int64_t>({256}),
+          "tensor 1 (rank 1) shape decodes");
+    Check(meta.tensors[1].ggml_type == GGML_TYPE_Q4_K,
+          "tensor 1's K-quant ggml_type is reported as-is, uninterpreted");
+  }
+
+  std::remove(path.c_str());
+}
+
+void TestEmptyMetadataAndNoTensors() {
+  std::string path = TempPath("_empty.gguf");
+  {
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    WriteLE<uint32_t>(out, kMagic);
+    WriteLE<uint32_t>(out, kSupportedVersion);
+    WriteLE<uint64_t>(out, 0);  // tensor_count
+    WriteLE<uint64_t>(out, 0);  // metadata_kv_count
+  }
+  GGUFMetadata meta = ReadGGUFMetadata(path);
+  Check(meta.kv.empty(), "no metadata entries");
+  Check(meta.tensors.empty(), "no tensor entries");
+  std::remove(path.c_str());
+}
+
+void TestRejectsBadMagic() {
+  std::string path = TempPath("_badmagic.gguf");
+  {
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    WriteLE<uint32_t>(out, 0xDEADBEEF);
+    WriteLE<uint32_t>(out, kSupportedVersion);
+    WriteLE<uint64_t>(out, 0);
+    WriteLE<uint64_t>(out, 0);
+  }
+  bool threw = false;
+  try {
+    ReadGGUFMetadata(path);
+  } catch (const std::runtime_error&) {
+    threw = true;
+  }
+  Check(threw, "bad magic throws");
+  std::remove(path.c_str());
+}
+
+void TestMissingFileThrows() {
+  bool threw = false;
+  try {
+    ReadGGUFMetadata(TempPath("_does_not_exist.gguf"));
+  } catch (const std::runtime_error&) {
+    threw = true;
+  }
+  Check(threw, "a missing file throws rather than returning empty metadata");
+}
+
+}  // namespace
+
+int main() {
+  TestFullMetadataDecodeNoTensorDataNeeded();
+  TestEmptyMetadataAndNoTensors();
+  TestRejectsBadMagic();
+  TestMissingFileThrows();
+
+  if (g_failures == 0) {
+    std::printf("read_gguf_metadata_test: all checks passed\n");
+    return 0;
+  }
+  std::fprintf(stderr, "read_gguf_metadata_test: %d failure(s)\n", g_failures);
+  return 1;
+}

--- a/onnxsim/tensor_pool.h
+++ b/onnxsim/tensor_pool.h
@@ -308,6 +308,57 @@ class TensorPool {
 // std::runtime_error on I/O failure.
 uint64_t HeaderPrefixSize(const std::string& path);
 
+// One decoded GGUF metadata value (see
+// https://github.com/ggml-org/ggml/blob/master/docs/gguf.md's KV section).
+// Every integer width (u8..u64, i8..i64) collapses to int64_t and every
+// float width (f32/f64) to double -- GGUF architecture hyperparameters
+// (layer counts, head counts, RoPE base, norm epsilon, ...) always fit
+// comfortably in either, and this saves ReadGGUFMetadata's callers from
+// switching on eight numeric widths. `kind` says which field is meaningful.
+struct GGUFMetadataValue {
+  enum class Kind { kInt, kFloat, kString, kBool };
+  Kind kind = Kind::kInt;
+  int64_t int_value = 0;
+  double float_value = 0.0;
+  std::string string_value;
+  bool bool_value = false;
+};
+
+// One tensor's header-section entry: name, ONNX-order shape (outermost
+// dimension first -- already reversed from GGUF's own ne[], the same
+// reversal LoadGGUF/LoadGGUFMmap apply to the tensors they actually pool),
+// and raw ggml_type code (see gguf_dtype.h's IsKQuant/IsRaw/ToOnnx to
+// interpret it). No tensor byte data is read -- see ReadGGUFMetadata below.
+struct GGUFTensorInfo {
+  std::string name;
+  std::vector<int64_t> shape;
+  uint32_t ggml_type = 0;
+};
+
+struct GGUFMetadata {
+  // ARRAY-typed metadata values (e.g. tokenizer.ggml.tokens, which alone can
+  // hold >100k strings in a real checkpoint) are intentionally omitted from
+  // `kv` rather than decoded -- this is meant to be a cheap read of a
+  // checkpoint's scalar architecture hyperparameters
+  // (general.architecture, <arch>.block_count,
+  // <arch>.attention.head_count, <arch>.rope.freq_base, ...), not a general
+  // GGUF metadata dump.
+  std::map<std::string, GGUFMetadataValue> kv;
+  std::vector<GGUFTensorInfo> tensors;
+};
+
+// Parses a GGUF file's header + metadata-KV + tensor-info sections at
+// `path` and returns them decoded -- unlike TensorPool::LoadGGUF/
+// LoadGGUFMmap, this never reads the (potentially huge, and for K-quant
+// tensors, differently-packed) tensor *data* section, so it stays cheap
+// even against a multi-gigabyte real checkpoint. This is how a caller
+// recovers the architecture hyperparameters TensorPool::LoadGGUF itself
+// discards while parsing the very same header section (it only ever looks
+// at general.alignment). Throws std::runtime_error on I/O failure, an
+// unrecognized magic/version, or a malformed header -- same conditions as
+// LoadGGUF.
+GGUFMetadata ReadGGUFMetadata(const std::string& path);
+
 }  // namespace tensor_pool
 }  // namespace onnxsim
 

--- a/onnxsim/tensor_pool_gguf.cpp
+++ b/onnxsim/tensor_pool_gguf.cpp
@@ -4,6 +4,7 @@
 // is "just" the wire-format read/write.
 #include <algorithm>
 #include <cstdint>
+#include <cstring>
 #include <fstream>
 #include <istream>
 #include <optional>
@@ -184,6 +185,117 @@ std::optional<uint64_t> SkipMetadataValue(std::istream& in,
     default:
       return std::nullopt;  // signed ints / floats / bool: value not needed
   }
+}
+
+// Full decode of one scalar (non-STRING, non-ARRAY) metadata value,
+// already positioned just after its `value_type` tag. Unlike
+// SkipMetadataValue above (which only cares about unsigned-int scalars, for
+// the general.alignment probe), this handles every scalar type GGUF has:
+// signed integers are sign-extended from their actual width, and
+// FLOAT32/FLOAT64 are bit-reinterpreted (via the same little-endian byte
+// assembly ReadU32LE/ReadU64LE use, then memcpy into the native float/
+// double -- NOT a raw memcpy straight from the file bytes, which would be
+// wrong on a big-endian host; onnxsim supports s390x, see
+// scripts/cross/build_s390x_extension.sh, so this matters).
+GGUFMetadataValue DecodeScalarMetadataValue(std::istream& in,
+                                            const std::string& path,
+                                            uint32_t value_type) {
+  size_t size = FixedMetadataScalarSize(value_type);
+  if (size == 0) {
+    FailRead(path, "unknown metadata value type " + std::to_string(value_type));
+  }
+  unsigned char buf[8] = {};
+  in.read(reinterpret_cast<char*>(buf), static_cast<std::streamsize>(size));
+  if (!in) FailRead(path, "truncated metadata value");
+  uint64_t raw = 0;
+  for (size_t i = size; i-- > 0;) raw = (raw << 8) | buf[i];
+
+  GGUFMetadataValue v;
+  switch (value_type) {
+    case GGUF_METADATA_VALUE_TYPE_BOOL:
+      v.kind = GGUFMetadataValue::Kind::kBool;
+      v.bool_value = (raw != 0);
+      return v;
+    case GGUF_METADATA_VALUE_TYPE_FLOAT32: {
+      uint32_t bits = static_cast<uint32_t>(raw);
+      float f;
+      std::memcpy(&f, &bits, sizeof(f));
+      v.kind = GGUFMetadataValue::Kind::kFloat;
+      v.float_value = static_cast<double>(f);
+      return v;
+    }
+    case GGUF_METADATA_VALUE_TYPE_FLOAT64: {
+      double d;
+      std::memcpy(&d, &raw, sizeof(d));
+      v.kind = GGUFMetadataValue::Kind::kFloat;
+      v.float_value = d;
+      return v;
+    }
+    case GGUF_METADATA_VALUE_TYPE_INT8:
+      v.kind = GGUFMetadataValue::Kind::kInt;
+      v.int_value = static_cast<int8_t>(raw);
+      return v;
+    case GGUF_METADATA_VALUE_TYPE_INT16:
+      v.kind = GGUFMetadataValue::Kind::kInt;
+      v.int_value = static_cast<int16_t>(raw);
+      return v;
+    case GGUF_METADATA_VALUE_TYPE_INT32:
+      v.kind = GGUFMetadataValue::Kind::kInt;
+      v.int_value = static_cast<int32_t>(raw);
+      return v;
+    case GGUF_METADATA_VALUE_TYPE_INT64:
+      v.kind = GGUFMetadataValue::Kind::kInt;
+      v.int_value = static_cast<int64_t>(raw);
+      return v;
+    case GGUF_METADATA_VALUE_TYPE_UINT8:
+    case GGUF_METADATA_VALUE_TYPE_UINT16:
+    case GGUF_METADATA_VALUE_TYPE_UINT32:
+    case GGUF_METADATA_VALUE_TYPE_UINT64:
+      v.kind = GGUFMetadataValue::Kind::kInt;
+      v.int_value = static_cast<int64_t>(raw);
+      return v;
+    default:
+      FailRead(path, "DecodeScalarMetadataValue: unexpected value_type " +
+                         std::to_string(value_type));
+  }
+}
+
+// Reads one metadata value, already positioned just after its `value_type`
+// tag (the caller has already consumed that). Decodes STRING and every
+// scalar type fully; an ARRAY value is skipped (mirroring
+// SkipMetadataValue's own ARRAY handling exactly -- duplicated rather than
+// shared since the two functions need different return shapes) and
+// std::nullopt is returned instead, per GGUFMetadata's own doc comment on
+// why arrays are out of scope here.
+std::optional<GGUFMetadataValue> ReadOneMetadataValue(std::istream& in,
+                                                      const std::string& path,
+                                                      uint32_t value_type) {
+  if (value_type == GGUF_METADATA_VALUE_TYPE_STRING) {
+    GGUFMetadataValue v;
+    v.kind = GGUFMetadataValue::Kind::kString;
+    v.string_value = ReadGGUFString(in, path);
+    return v;
+  }
+  if (value_type == GGUF_METADATA_VALUE_TYPE_ARRAY) {
+    uint32_t elem_type = ReadU32LE(in, path);
+    uint64_t len = ReadU64LE(in, path);
+    if (elem_type == GGUF_METADATA_VALUE_TYPE_ARRAY) {
+      FailRead(path, "nested metadata arrays are not supported");
+    }
+    if (elem_type == GGUF_METADATA_VALUE_TYPE_STRING) {
+      for (uint64_t i = 0; i < len; ++i) ReadGGUFString(in, path);
+    } else {
+      size_t elem_size = FixedMetadataScalarSize(elem_type);
+      if (elem_size == 0) {
+        FailRead(path, "unknown metadata array element type " +
+                           std::to_string(elem_type));
+      }
+      in.seekg(static_cast<std::streamoff>(elem_size * len), std::ios::cur);
+      if (!in) FailRead(path, "truncated metadata array");
+    }
+    return std::nullopt;
+  }
+  return DecodeScalarMetadataValue(in, path, value_type);
 }
 
 struct TensorInfo {
@@ -572,6 +684,75 @@ bool TensorPool::DequantizeToFloat(const std::string& name,
   return DequantizeGgmlKQuant(
       reinterpret_cast<const uint8_t*>(entry->data.data()), entry->data.size(),
       ggml_type, numel, out);
+}
+
+// Mirrors LoadGGUF's header-parsing loop (magic/version check, then the
+// metadata-KV loop, then the tensor-info loop) structurally -- the two are
+// kept in sync deliberately, so a future GGUF version bump or header-layout
+// change needs both updated together. They can't share the loop bodies
+// directly: LoadGGUF's metadata loop only probes for general.alignment and
+// otherwise discards every value (SkipMetadataValue), while this one
+// decodes every scalar value it sees (ReadOneMetadataValue) into the
+// returned map; LoadGGUF's tensor loop also seeks into the data section to
+// read each tensor's bytes, which this one -- by design, see
+// GGUFMetadata's doc comment -- never does at all.
+GGUFMetadata ReadGGUFMetadata(const std::string& path) {
+  std::ifstream in(path, std::ios::binary);
+  if (!in) FailRead(path, "cannot open file");
+
+  uint32_t magic = ReadU32LE(in, path);
+  if (magic != kMagic) {
+    FailRead(path, "not a GGUF file (bad magic)");
+  }
+  uint32_t version = ReadU32LE(in, path);
+  if (version != kSupportedVersion) {
+    FailRead(path, "GGUF version " + std::to_string(version) +
+                       " is not supported (only version " +
+                       std::to_string(kSupportedVersion) + " is)");
+  }
+  uint64_t tensor_count = ReadU64LE(in, path);
+  uint64_t metadata_kv_count = ReadU64LE(in, path);
+  if (tensor_count > kMaxTensorCount) {
+    FailRead(path, "implausible tensor_count (" + std::to_string(tensor_count) +
+                       "), likely corrupt");
+  }
+  if (metadata_kv_count > kMaxMetadataCount) {
+    FailRead(path, "implausible metadata_kv_count (" +
+                       std::to_string(metadata_kv_count) + "), likely corrupt");
+  }
+
+  GGUFMetadata result;
+  for (uint64_t i = 0; i < metadata_kv_count; ++i) {
+    std::string key = ReadGGUFString(in, path);
+    uint32_t value_type = ReadU32LE(in, path);
+    std::optional<GGUFMetadataValue> value =
+        ReadOneMetadataValue(in, path, value_type);
+    if (value.has_value()) {
+      result.kv[key] = std::move(*value);
+    }
+  }
+
+  result.tensors.reserve(tensor_count);
+  for (uint64_t i = 0; i < tensor_count; ++i) {
+    GGUFTensorInfo info;
+    info.name = ReadGGUFString(in, path);
+    uint32_t n_dims = ReadU32LE(in, path);
+    if (n_dims > kMaxDims) {
+      FailRead(path, "tensor '" + info.name +
+                         "' has an implausible dimension count (" +
+                         std::to_string(n_dims) + ")");
+    }
+    std::vector<uint64_t> ne(n_dims);
+    for (uint32_t d = 0; d < n_dims; ++d) ne[d] = ReadU64LE(in, path);
+    info.ggml_type = ReadU32LE(in, path);
+    ReadU64LE(in, path);  // per-tensor data offset -- irrelevant, no data read
+    // Reverse of ggml's innermost-first ne[] to onnx's outermost-first shape
+    // -- same convention LoadGGUF/LoadGGUFMmap use for the tensors they
+    // actually pool.
+    info.shape.assign(ne.rbegin(), ne.rend());
+    result.tensors.push_back(std::move(info));
+  }
+  return result;
 }
 
 }  // namespace tensor_pool

--- a/scripts/fetch_llama_cpp.sh
+++ b/scripts/fetch_llama_cpp.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Fetches a pinned, prebuilt llama.cpp release (llama-cli + the ggml CPU
+# backend) for use as an *external reference oracle* -- e.g. running a real
+# GGUF checkpoint through actual llama.cpp inference to check logits against
+# whatever onnxsim reconstructs from the same file.
+#
+# This is deliberately NOT how onnxsim gets llama.cpp: there is no
+# third_party/llama.cpp submodule and nothing here is a build dependency of
+# the CMake project or the Python wheel (see CLAUDE.md's ONNXSIM_BUILTIN_ORT
+# note for the same philosophy re: ONNX Runtime -- optional tooling stays
+# out-of-tree and is fetched on demand, never compiled into onnxsim itself).
+# Test code that wants this oracle should invoke this script (or call
+# llama_cpp_bin_dir() below) and skip gracefully if it exits non-zero.
+#
+# llama.cpp has no semver -- every commit to master bumps a monotonic build
+# tag ("b12345"). LLAMA_CPP_VERSION pins us to one specific, previously
+# verified tag; bump it deliberately (and re-verify), never silently track
+# "latest".
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+LLAMA_CPP_VERSION="${LLAMA_CPP_VERSION:-b10642}"
+CACHE_DIR="${LLAMA_CPP_CACHE_DIR:-${REPO_ROOT}/.cache/llama-cpp}"
+DEST_DIR="${CACHE_DIR}/${LLAMA_CPP_VERSION}"
+
+# Exit code 2 means "no prebuilt asset for this platform" -- callers (tests)
+# should treat that as skip-the-oracle, not a hard failure. Everything else
+# non-zero is a real error (download/extract failure).
+EXIT_UNSUPPORTED_PLATFORM=2
+
+detect_asset() {
+  local os arch
+  os="$(uname -s)"
+  arch="$(uname -m)"
+  case "${os}" in
+    Linux)
+      case "${arch}" in
+        x86_64) echo "llama-${LLAMA_CPP_VERSION}-bin-ubuntu-x64.tar.gz" ;;
+        aarch64 | arm64) echo "llama-${LLAMA_CPP_VERSION}-bin-ubuntu-arm64.tar.gz" ;;
+        s390x) echo "llama-${LLAMA_CPP_VERSION}-bin-ubuntu-s390x.tar.gz" ;;
+        *) return 1 ;;
+      esac
+      ;;
+    Darwin)
+      case "${arch}" in
+        arm64) echo "llama-${LLAMA_CPP_VERSION}-bin-macos-arm64.tar.gz" ;;
+        x86_64) echo "llama-${LLAMA_CPP_VERSION}-bin-macos-x64.tar.gz" ;;
+        *) return 1 ;;
+      esac
+      ;;
+    *)
+      # Windows (MSYS/Git Bash/etc.) ships as .zip, not .tar.gz, and this
+      # script only knows how to unpack tar.gz below -- treat as unsupported
+      # here rather than half-handling it.
+      return 1
+      ;;
+  esac
+}
+
+# Prints the directory containing llama-cli (and friends) on stdout,
+# downloading/extracting first if needed. Exits EXIT_UNSUPPORTED_PLATFORM if
+# this host has no matching prebuilt asset.
+llama_cpp_bin_dir() {
+  local asset
+  if ! asset="$(detect_asset)"; then
+    echo "fetch_llama_cpp.sh: no prebuilt ${LLAMA_CPP_VERSION} asset for" \
+      "$(uname -s)/$(uname -m) -- skip the llama.cpp reference oracle" >&2
+    return "${EXIT_UNSUPPORTED_PLATFORM}"
+  fi
+
+  local bin_dir="${DEST_DIR}/build/bin"
+  if [[ -x "${bin_dir}/llama-cli" ]]; then
+    echo "${bin_dir}"
+    return 0
+  fi
+
+  local url="https://github.com/ggml-org/llama.cpp/releases/download/${LLAMA_CPP_VERSION}/${asset}"
+  mkdir -p "${DEST_DIR}"
+  local archive="${DEST_DIR}/${asset}"
+
+  echo "fetch_llama_cpp.sh: downloading ${url}" >&2
+  curl -fL --retry 3 --retry-connrefused -o "${archive}.part" "${url}"
+  mv "${archive}.part" "${archive}"
+
+  echo "fetch_llama_cpp.sh: extracting ${archive}" >&2
+  tar -xzf "${archive}" -C "${DEST_DIR}"
+  rm -f "${archive}"
+
+  # The release tarball's top-level entries are named llama-<tag>/... (see
+  # ggml-org/llama.cpp's release workflow, e.g. "-s ,^\.,llama-<tag>," in its
+  # `tar` invocation), not "build/bin/..." -- normalize so callers always
+  # find the binaries at the same DEST_DIR/build/bin path regardless of the
+  # exact archive layout for this release.
+  if [[ ! -x "${bin_dir}/llama-cli" ]]; then
+    local extracted
+    extracted="$(find "${DEST_DIR}" -maxdepth 2 -name 'llama-cli' -print -quit)"
+    if [[ -z "${extracted}" ]]; then
+      echo "fetch_llama_cpp.sh: llama-cli not found after extracting ${archive}" >&2
+      return 1
+    fi
+    mkdir -p "${bin_dir}"
+    ln -sf "$(dirname "${extracted}")"/* "${bin_dir}/"
+  fi
+
+  echo "${bin_dir}"
+}
+
+# Only run as a driver when executed directly (`./fetch_llama_cpp.sh`), not
+# when sourced by test code that just wants the llama_cpp_bin_dir function.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  llama_cpp_bin_dir
+fi

--- a/tests/test_read_gguf_metadata.py
+++ b/tests/test_read_gguf_metadata.py
@@ -1,0 +1,177 @@
+"""Tests for ``onnxsim.read_gguf_metadata`` -- reading a GGUF checkpoint's
+architecture hyperparameters (``general.architecture``, ``<arch>.block_count``,
+``<arch>.attention.head_count``, ...) and per-tensor name/shape/dtype list,
+without reading any tensor byte data.
+
+``onnxsim.import_gguf_weights`` (see test_import_gguf_weights.py) parses this
+very same GGUF header section but only ever looks at ``general.alignment``
+before moving on to loading tensor *values* into an existing graph's
+initializers -- it has no way to answer "what architecture is this
+checkpoint, and what shape are its tensors?". ``read_gguf_metadata`` is that
+other half: the input a from-scratch ONNX graph *builder* would need to
+decide what graph structure to construct in the first place, before
+``import_gguf_weights`` can fill in its values.
+
+The C++-level decode logic (every scalar value type, sign extension, float
+bit-reinterpretation, array skipping) is exhaustively covered by
+onnxsim/read_gguf_metadata_test.cpp; this suite instead focuses on the
+Python-facing contract: the returned dict's shape, a realistic
+architecture-metadata checkpoint, and error behavior.
+"""
+
+import struct
+
+import pytest
+
+import onnxsim
+
+GGUF_MAGIC = 0x46554747
+GGUF_VERSION = 3
+
+GGUF_METADATA_VALUE_TYPE_UINT32 = 4
+GGUF_METADATA_VALUE_TYPE_FLOAT32 = 6
+GGUF_METADATA_VALUE_TYPE_BOOL = 7
+GGUF_METADATA_VALUE_TYPE_STRING = 8
+GGUF_METADATA_VALUE_TYPE_ARRAY = 9
+
+GGML_TYPE_F32 = 0
+GGML_TYPE_Q4_K = 12
+
+
+def _string_bytes(s):
+    b = s.encode("utf-8")
+    return struct.pack("<Q", len(b)) + b
+
+
+def _kv_string(key, value):
+    return (
+        _string_bytes(key)
+        + struct.pack("<I", GGUF_METADATA_VALUE_TYPE_STRING)
+        + _string_bytes(value)
+    )
+
+
+def _kv_uint32(key, value):
+    return (
+        _string_bytes(key)
+        + struct.pack("<I", GGUF_METADATA_VALUE_TYPE_UINT32)
+        + struct.pack("<I", value)
+    )
+
+
+def _kv_float32(key, value):
+    return (
+        _string_bytes(key)
+        + struct.pack("<I", GGUF_METADATA_VALUE_TYPE_FLOAT32)
+        + struct.pack("<f", value)
+    )
+
+
+def _kv_bool(key, value):
+    return (
+        _string_bytes(key)
+        + struct.pack("<I", GGUF_METADATA_VALUE_TYPE_BOOL)
+        + struct.pack("<B", 1 if value else 0)
+    )
+
+
+def _kv_string_array(key, values):
+    body = struct.pack("<I", GGUF_METADATA_VALUE_TYPE_STRING) + struct.pack(
+        "<Q", len(values)
+    )
+    for v in values:
+        body += _string_bytes(v)
+    return _string_bytes(key) + struct.pack("<I", GGUF_METADATA_VALUE_TYPE_ARRAY) + body
+
+
+def _tensor_info(name, ggml_type, ne):
+    """``ne`` in GGML's own innermost-dimension-first order (the reverse of
+    the ONNX shape ``read_gguf_metadata`` reports for it)."""
+    info = _string_bytes(name)
+    info += struct.pack("<I", len(ne))
+    for d in ne:
+        info += struct.pack("<Q", d)
+    info += struct.pack("<I", ggml_type)
+    info += struct.pack("<Q", 0)  # offset -- never read by read_gguf_metadata
+    return info
+
+
+def _write_gguf(path, kv_chunks, tensor_chunks):
+    header = struct.pack(
+        "<IIQQ", GGUF_MAGIC, GGUF_VERSION, len(tensor_chunks), len(kv_chunks)
+    )
+    with open(path, "wb") as f:
+        f.write(header)
+        for c in kv_chunks:
+            f.write(c)
+        for c in tensor_chunks:
+            f.write(c)
+        # Deliberately no tensor-data section at all: read_gguf_metadata must
+        # never need one.
+
+
+def test_realistic_llama_architecture_metadata(tmp_path):
+    path = str(tmp_path / "model.gguf")
+    kv = [
+        _kv_string("general.architecture", "llama"),
+        _kv_uint32("llama.block_count", 32),
+        _kv_uint32("llama.embedding_length", 4096),
+        _kv_uint32("llama.attention.head_count", 32),
+        _kv_uint32("llama.attention.head_count_kv", 8),
+        _kv_float32("llama.rope.freq_base", 500000.0),
+        _kv_float32("llama.attention.layer_norm_rms_epsilon", 1e-5),
+        _kv_bool("llama.attention.use_bias", False),
+        # A large-ish string array (the shape tokenizer.ggml.tokens really
+        # takes) must not surface in "kv" -- see the module docstring.
+        _kv_string_array("tokenizer.ggml.tokens", ["<unk>", "<s>", "</s>", "hello"]),
+    ]
+    tensors = [
+        _tensor_info("token_embd.weight", GGML_TYPE_F32, [4096, 32000]),
+        _tensor_info("blk.0.attn_q.weight", GGML_TYPE_Q4_K, [4096, 4096]),
+    ]
+    _write_gguf(path, kv, tensors)
+
+    meta = onnxsim.read_gguf_metadata(path)
+
+    assert meta["kv"]["general.architecture"] == "llama"
+    assert meta["kv"]["llama.block_count"] == 32
+    assert meta["kv"]["llama.embedding_length"] == 4096
+    assert meta["kv"]["llama.attention.head_count"] == 32
+    assert meta["kv"]["llama.attention.head_count_kv"] == 8
+    assert meta["kv"]["llama.rope.freq_base"] == pytest.approx(500000.0)
+    assert meta["kv"]["llama.attention.layer_norm_rms_epsilon"] == pytest.approx(1e-5)
+    assert meta["kv"]["llama.attention.use_bias"] is False
+    assert "tokenizer.ggml.tokens" not in meta["kv"]
+
+    assert meta["tensors"] == [
+        {
+            "name": "token_embd.weight",
+            "shape": [32000, 4096],
+            "ggml_type": GGML_TYPE_F32,
+        },
+        {
+            "name": "blk.0.attn_q.weight",
+            "shape": [4096, 4096],
+            "ggml_type": GGML_TYPE_Q4_K,
+        },
+    ]
+
+
+def test_empty_file_has_no_kv_or_tensors(tmp_path):
+    path = str(tmp_path / "empty.gguf")
+    _write_gguf(path, [], [])
+    meta = onnxsim.read_gguf_metadata(path)
+    assert meta == {"kv": {}, "tensors": []}
+
+
+def test_missing_file_raises(tmp_path):
+    with pytest.raises(RuntimeError):
+        onnxsim.read_gguf_metadata(str(tmp_path / "does_not_exist.gguf"))
+
+
+def test_bad_magic_raises(tmp_path):
+    path = str(tmp_path / "bad_magic.gguf")
+    with open(path, "wb") as f:
+        f.write(struct.pack("<IIQQ", 0xDEADBEEF, GGUF_VERSION, 0, 0))
+    with pytest.raises(RuntimeError):
+        onnxsim.read_gguf_metadata(path)


### PR DESCRIPTION
## Summary

Adds `read_gguf_metadata()` function to parse GGUF file headers (architecture hyperparameters and per-tensor metadata) without reading any tensor byte data. This complements `import_gguf_weights()`, which loads tensor values but discards the architecture metadata. The new function enables callers to inspect a checkpoint's structure before deciding what graph to build.

## Key Changes

- **New C++ implementation** (`tensor_pool_gguf.cpp`):
  - `DecodeScalarMetadataValue()`: Decodes all GGUF scalar metadata types (int8/16/32/64, uint8/16/32/64, float32/64, bool) with proper sign-extension and float bit-reinterpretation
  - `ReadOneMetadataValue()`: Handles STRING and ARRAY metadata values; arrays are skipped (not surfaced) per design
  - `ReadGGUFMetadata()`: Main entry point mirroring `LoadGGUF`'s header parsing structure (magic/version check, metadata-KV loop, tensor-info loop) but never touches the data section

- **Python bindings** (`cpp2py_export.cc`):
  - Exports `read_gguf_metadata(path)` returning `{"kv": {key: int|float|str|bool, ...}, "tensors": [{"name": str, "shape": [int, ...], "ggml_type": int}, ...]}`
  - Converts C++ types to Python equivalents; ARRAY metadata values intentionally omitted from `kv`

- **Python API** (`onnx_simplifier.py`, `__init__.py`):
  - Public `read_gguf_metadata(path: str) -> dict` function with docstring explaining use case and return format

- **Comprehensive testing**:
  - C++ unit test (`read_gguf_metadata_test.cpp`): Exhaustively tests every scalar metadata type, sign extension, float bit-reinterpretation, and array skipping with hand-built GGUF bytes
  - Python tests (`test_read_gguf_metadata.py`): Validates realistic llama architecture metadata, shape reversal (GGML innermost-first to ONNX outermost-first), and error handling
  - CMake integration for standalone C++ test build

- **Build infrastructure**:
  - Added `scripts/fetch_llama_cpp.sh`: Downloads prebuilt llama.cpp releases for use as external reference oracle in integration tests (optional, not a build dependency)

## Implementation Details

- **Design**: ARRAY metadata values (e.g., `tokenizer.ggml.tokens` with >100k strings) are intentionally skipped and omitted from results—this is a cheap read of scalar architecture hyperparameters, not a general GGUF metadata dump
- **Endianness**: Properly handles big-endian hosts (s390x) via little-endian byte assembly and `std::memcpy` for float bit-reinterpretation
- **Tensor shape**: Reverses GGML's innermost-first `ne[]` order to ONNX's outermost-first shape convention, matching `LoadGGUF`/`LoadGGUFMmap` behavior
- **Error handling**: Throws `std::runtime_error` on I/O failure, bad magic/version, or malformed headers (same as `LoadGGUF`)
- **Structural sync**: `ReadGGUFMetadata` mirrors `LoadGGUF`'s header parsing loop structure so future GGUF version bumps update both together

https://claude.ai/code/session_017QTQWXaoD3PMyT6gHwfrYL