### PR TITLE
Add reconstruct_gguf_graph: build+hydrate an ONNX graph from GGUF architecture

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -29,6 +29,10 @@ from onnxsim.calibration import (
     quantize_static,
     quantize_static_int16,
 )
+from onnxsim.gguf_reconstruct import (
+    UnsupportedArchitectureError,
+    reconstruct_gguf_graph,
+)
 from onnxsim.gptq import apply_gptq
 from onnxsim.onnx_simplifier import (
     cross_layer_equalize,
@@ -117,5 +121,7 @@ __all__ = [
     "import_gguf",
     "import_gguf_weights",
     "read_gguf_metadata",
+    "reconstruct_gguf_graph",
+    "UnsupportedArchitectureError",
     "__version__",
 ]

--- a/onnxsim/gguf_reconstruct.py
+++ b/onnxsim/gguf_reconstruct.py
@@ -1,0 +1,528 @@
+"""Reconstructs an ONNX graph *and* its weights directly from a GGUF LLM
+checkpoint, for a small set of recognized decoder-only transformer
+architectures (currently the Llama family: Llama/Llama2/Llama3, Mistral, and
+Qwen2, which all share the same block shape -- RMSNorm, rotary position
+embeddings, grouped-query attention, SwiGLU FFN -- differing only in things
+:func:`read_gguf_metadata` already reports: head counts, RoPE base, whether
+q/k/v projections carry a bias, and whether the LM head is tied to the token
+embedding).
+
+This is deliberately the "known architecture template" approach, not a
+generic GGUF/ggml graph-structure reconstructor: vLLM and SGLang's own GGUF
+support works the same way (match ``general.architecture`` against a
+maintained, hand-written model implementation; fail clearly -- "architecture
+X is not supported yet" -- rather than guess when it isn't recognized), and
+their own issue trackers show that's a deliberate, load-bearing choice, not
+a shortcut: coupling to a generic-but-unstable source (llama.cpp's internal,
+non-public compute-graph construction, revised on nearly every commit) is a
+worse tradeoff than a curated, explicit template per architecture family.
+
+:func:`read_gguf_metadata` supplies everything this needs to know -- which
+architecture, its hyperparameters, and its tensors' names/shapes -- without
+reading any tensor byte data; :func:`import_gguf_weights` (reused here
+unmodified) supplies the actual values, including its existing K-quant
+(Q4_K/Q5_K/Q6_K/Q8_0) decode.
+
+Scope note on shapes: the returned graph's ``batch_size``/``seq_len`` are
+concrete, caller-chosen static dimensions, not dynamic axes. Real llama.cpp
+inference builds a *different* concrete compute graph per call anyway (see
+this feature's design discussion for why a cache-free, single-shape forward
+graph is the right starting point at all) -- generalizing this to dynamic
+axes, and to KV-cache-aware incremental decoding, is future work, not
+something this first slice claims to solve.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+
+from onnxsim.onnx_simplifier import import_gguf_weights, read_gguf_metadata
+
+# Opset 17: modern enough for everything this builder needs (Trilu has been
+# available since opset 14), while ReduceMean's reduction axes are still an
+# *attribute* rather than an input (that migration happened at opset 18) --
+# picking 17 avoids threading yet another small int64 constant through every
+# RMSNorm call for no benefit here.
+_OPSET = 17
+
+# Mirrors onnxsim/gguf_dtype.h's GgmlType enum and ToOnnx/IsKQuant mapping --
+# duplicated here rather than exposed through a new C++ binding, the same
+# choice tests/test_import_gguf_weights.py already made for its own small,
+# stable GGML_TYPE_* constants. See gguf_dtype.h's file comment: GGML never
+# reassigns an existing type ID, so this mapping does not drift.
+_GGML_RAW_TO_ONNX = {
+    0: onnx.TensorProto.FLOAT,  # F32
+    1: onnx.TensorProto.FLOAT16,  # F16
+    24: onnx.TensorProto.INT8,  # I8
+    25: onnx.TensorProto.INT16,  # I16
+    26: onnx.TensorProto.INT32,  # I32
+    27: onnx.TensorProto.INT64,  # I64
+    28: onnx.TensorProto.DOUBLE,  # F64
+    30: onnx.TensorProto.BFLOAT16,  # BF16
+}
+# Q8_0, Q4_K, Q5_K, Q6_K -- import_gguf_weights forces these to FLOAT
+# regardless of what the initializer previously declared (see
+# tensor_pool_gguf_bridge.h's HydrateTensorProtoFromGGUF), so that is what
+# must be declared here too.
+_GGML_KQUANT_TYPES = {8, 12, 13, 14}
+
+_ONNX_DTYPE_ITEMSIZE = {
+    onnx.TensorProto.FLOAT: 4,
+    onnx.TensorProto.FLOAT16: 2,
+    onnx.TensorProto.BFLOAT16: 2,
+    onnx.TensorProto.DOUBLE: 8,
+    onnx.TensorProto.INT8: 1,
+    onnx.TensorProto.INT16: 2,
+    onnx.TensorProto.INT32: 4,
+    onnx.TensorProto.INT64: 8,
+}
+
+# general.architecture values this builder recognizes -- all share the same
+# block shape (RMSNorm/RoPE/GQA/SwiGLU); see the module docstring.
+_SUPPORTED_ARCHITECTURES = ("llama", "qwen2", "mistral")
+
+
+class UnsupportedArchitectureError(NotImplementedError):
+    """Raised for a GGUF checkpoint whose ``general.architecture`` (or a
+    quantization format among the tensors this graph needs) this builder
+    does not have a template for -- mirrors vLLM/SGLang's own "architecture
+    X is not supported yet" failure mode: fail clearly rather than guess."""
+
+
+class _Builder:
+    """Accumulates nodes/initializers for one ONNX graph. Not reusable
+    across graphs -- one instance per :func:`reconstruct_gguf_graph` call."""
+
+    def __init__(self):
+        self.nodes: List[onnx.NodeProto] = []
+        self.initializers: List[onnx.TensorProto] = []
+        self._counter = 0
+        self._const_cache: Dict[Tuple, str] = {}
+
+    def _name(self, prefix: str) -> str:
+        self._counter += 1
+        return f"{prefix}.{self._counter}"
+
+    def op(self, op_type: str, inputs: List[str], prefix: str, **attrs) -> str:
+        out = self._name(prefix)
+        self.nodes.append(onnx.helper.make_node(op_type, inputs, [out], **attrs))
+        return out
+
+    def placeholder_weight(self, name: str, shape: List[int], onnx_dtype: int) -> None:
+        """A zero-filled initializer with `name`'s exact GGUF-reported shape
+        and the ONNX dtype import_gguf_weights will actually write into it
+        (see _GGML_RAW_TO_ONNX/_GGML_KQUANT_TYPES) -- its *values* come from
+        import_gguf_weights right after the graph this builds is assembled,
+        but its declared dims/data_type must already be correct: hydration
+        overwrites raw_data only (see tensor_pool_gguf_bridge.h's
+        HydrateTensorProto/HydrateTensorProtoFromGGUF), never dims, and
+        never data_type on the plain-raw-dtype path."""
+        nbytes = _ONNX_DTYPE_ITEMSIZE[onnx_dtype]
+        for d in shape:
+            nbytes *= d
+        t = onnx.helper.make_tensor(
+            name, onnx_dtype, shape, vals=b"\x00" * nbytes, raw=True
+        )
+        self.initializers.append(t)
+
+    def const(self, array: np.ndarray, prefix: str = "const") -> str:
+        """A constant initializer from a numpy array this builder computed
+        itself (RoPE's inv_freq, a causal mask, a reshape's target shape,
+        ...) -- distinct from placeholder_weight, whose values come from the
+        GGUF file, not from Python. Small integer-shape constants (Reshape
+        targets, Slice bounds) recur often enough across layers to dedupe by
+        value."""
+        key = (array.shape, array.dtype.str, array.tobytes())
+        cached = self._const_cache.get(key)
+        if cached is not None:
+            return cached
+        name = self._name(prefix)
+        self.initializers.append(onnx.numpy_helper.from_array(array, name=name))
+        self._const_cache[key] = name
+        return name
+
+    def shape_const(self, dims: List[int]) -> str:
+        return self.const(np.array(dims, dtype=np.int64), prefix="shape")
+
+
+def _unsqueeze(b: _Builder, x: str, axes: List[int], prefix: str) -> str:
+    # Unsqueeze's `axes` has been a second *input*, not an attribute, since
+    # opset 13 -- unlike Concat's `axis` (always an attribute) or
+    # ReduceMean's `axes` (still an attribute until opset 18, which _OPSET
+    # predates).
+    axes_c = b.const(np.array(axes, dtype=np.int64), prefix="unsqueeze_axes")
+    return b.op("Unsqueeze", [x, axes_c], prefix)
+
+
+def _linear(
+    b: _Builder,
+    x: str,
+    weight_name: str,
+    bias_name: Optional[str],
+    prefix: str,
+) -> str:
+    """``x @ weight.T (+ bias)`` -- nn.Linear semantics. `weight_name` is a
+    GGUF tensor already declared (via placeholder_weight) with its ORIGINAL
+    [out_features, in_features] shape (GGUF/ggml round-trips a PyTorch
+    nn.Linear.weight's shape unchanged -- see read_gguf_metadata's own
+    dimension-order note), so this transposes at graph-build time via an
+    explicit Transpose node rather than pre-transposing the (not-yet-known)
+    weight values. A later `onnxsim.simplify()` constant-folds that
+    Transpose away for free once the weight is actually hydrated."""
+    wt = b.op("Transpose", [weight_name], f"{prefix}.wt", perm=[1, 0])
+    out = b.op("MatMul", [x, wt], f"{prefix}.matmul")
+    if bias_name is not None:
+        out = b.op("Add", [out, bias_name], f"{prefix}.bias")
+    return out
+
+
+def _rmsnorm(b: _Builder, x: str, weight_name: str, eps: float, prefix: str) -> str:
+    eps_c = b.const(np.array(eps, dtype=np.float32), prefix="eps")
+    x2 = b.op("Mul", [x, x], f"{prefix}.sq")
+    mean = b.op("ReduceMean", [x2], f"{prefix}.mean", axes=[-1], keepdims=1)
+    var_eps = b.op("Add", [mean, eps_c], f"{prefix}.var_eps")
+    rms = b.op("Sqrt", [var_eps], f"{prefix}.rms")
+    normed = b.op("Div", [x, rms], f"{prefix}.normed")
+    return b.op("Mul", [normed, weight_name], f"{prefix}.scaled")
+
+
+def _slice_last_dim(b: _Builder, x: str, start: int, end: int, prefix: str) -> str:
+    starts = b.const(np.array([start], dtype=np.int64), prefix="slice_start")
+    ends = b.const(np.array([end], dtype=np.int64), prefix="slice_end")
+    axes = b.const(np.array([-1], dtype=np.int64), prefix="slice_axis")
+    return b.op("Slice", [x, starts, ends, axes], prefix)
+
+
+def _rotate_half(b: _Builder, x: str, head_dim: int, prefix: str) -> str:
+    half = head_dim // 2
+    x1 = _slice_last_dim(b, x, 0, half, f"{prefix}.x1")
+    x2 = _slice_last_dim(b, x, half, head_dim, f"{prefix}.x2")
+    neg_x2 = b.op("Neg", [x2], f"{prefix}.negx2")
+    return b.op("Concat", [neg_x2, x1], prefix, axis=-1)
+
+
+def _apply_rope(
+    b: _Builder, x: str, cos: str, sin: str, head_dim: int, prefix: str
+) -> str:
+    rotated = _rotate_half(b, x, head_dim, f"{prefix}.rot")
+    a = b.op("Mul", [x, cos], f"{prefix}.a")
+    c = b.op("Mul", [rotated, sin], f"{prefix}.c")
+    return b.op("Add", [a, c], prefix)
+
+
+def _reconstruct_llama_family(
+    meta: dict, batch_size: int, seq_len: int
+) -> onnx.GraphProto:
+    kv = meta["kv"]
+    tensors = {t["name"]: t for t in meta["tensors"]}
+    arch = kv["general.architecture"]
+
+    def key(suffix: str):
+        return f"{arch}.{suffix}"
+
+    n_embd = int(kv[key("embedding_length")])
+    n_layer = int(kv[key("block_count")])
+    n_ff = int(kv[key("feed_forward_length")])
+    n_head = int(kv[key("attention.head_count")])
+    n_head_kv = int(kv.get(key("attention.head_count_kv"), n_head))
+    eps = float(
+        kv.get(
+            key("attention.layer_norm_rms_epsilon"),
+            kv.get(key("attention.layer_norm_epsilon"), 1e-5),
+        )
+    )
+    freq_base = float(kv.get(key("rope.freq_base"), 10000.0))
+
+    if n_embd % n_head != 0:
+        raise UnsupportedArchitectureError(
+            f"{key('embedding_length')}={n_embd} is not divisible by "
+            f"{key('attention.head_count')}={n_head}"
+        )
+    head_dim = n_embd // n_head
+    if n_head % n_head_kv != 0:
+        raise UnsupportedArchitectureError(
+            f"{key('attention.head_count')}={n_head} is not a multiple of "
+            f"{key('attention.head_count_kv')}={n_head_kv} (grouped-query "
+            "attention requires an integer head-repeat factor)"
+        )
+    n_rep = n_head // n_head_kv
+
+    rope_dims = kv.get(key("rope.dimension_count"))
+    if rope_dims is not None and int(rope_dims) != head_dim:
+        raise UnsupportedArchitectureError(
+            f"{key('rope.dimension_count')}={rope_dims} != head_dim={head_dim} "
+            "(partial rotary embeddings are not implemented)"
+        )
+
+    def require(name: str) -> dict:
+        info = tensors.get(name)
+        if info is None:
+            raise UnsupportedArchitectureError(
+                f"checkpoint is missing required tensor '{name}' for "
+                f"architecture '{arch}'"
+            )
+        return info
+
+    def optional(name: str) -> Optional[dict]:
+        return tensors.get(name)
+
+    b = _Builder()
+
+    def declare(name: str, expected_shape: List[int]) -> str:
+        info = require(name)
+        if info["shape"] != expected_shape:
+            raise UnsupportedArchitectureError(
+                f"tensor '{name}' has shape {info['shape']}, expected "
+                f"{expected_shape} for architecture '{arch}' with "
+                f"embedding_length={n_embd}, feed_forward_length={n_ff}, "
+                f"head_count={n_head}, head_count_kv={n_head_kv}"
+            )
+        ggml_type = info["ggml_type"]
+        if ggml_type in _GGML_KQUANT_TYPES:
+            onnx_dtype = onnx.TensorProto.FLOAT
+        elif ggml_type in _GGML_RAW_TO_ONNX:
+            onnx_dtype = _GGML_RAW_TO_ONNX[ggml_type]
+        else:
+            raise UnsupportedArchitectureError(
+                f"tensor '{name}' uses ggml_type {ggml_type}, which "
+                "import_gguf_weights cannot decode (only F32/F16/BF16/F64/"
+                "I8/I16/I32/I64 and the Q4_K/Q5_K/Q6_K/Q8_0 K-quant family "
+                "are supported)"
+            )
+        b.placeholder_weight(name, expected_shape, onnx_dtype)
+        return name
+
+    def declare_optional(name: str, expected_shape: List[int]) -> Optional[str]:
+        return declare(name, expected_shape) if optional(name) is not None else None
+
+    token_embd_info = require("token_embd.weight")
+    if len(token_embd_info["shape"]) != 2 or token_embd_info["shape"][1] != n_embd:
+        raise UnsupportedArchitectureError(
+            f"token_embd.weight shape {token_embd_info['shape']} does not "
+            f"match {key('embedding_length')}={n_embd}"
+        )
+    vocab_size = token_embd_info["shape"][0]
+    token_embd = declare("token_embd.weight", [vocab_size, n_embd])
+
+    input_ids = "input_ids"
+    position_ids = "position_ids"
+    graph_inputs = [
+        onnx.helper.make_tensor_value_info(
+            input_ids, onnx.TensorProto.INT64, [batch_size, seq_len]
+        ),
+        onnx.helper.make_tensor_value_info(
+            position_ids, onnx.TensorProto.INT64, [batch_size, seq_len]
+        ),
+    ]
+
+    x = b.op("Gather", [token_embd, input_ids], "embed", axis=0)
+
+    # RoPE cos/sin: identical across every layer (same position_ids, same
+    # freq_base/head_dim), so computed once here rather than per layer.
+    inv_freq = 1.0 / (
+        freq_base ** (np.arange(0, head_dim, 2, dtype=np.float64) / head_dim)
+    )
+    inv_freq_c = b.const(
+        inv_freq.reshape(1, 1, -1).astype(np.float32), prefix="inv_freq"
+    )
+    pos_f = b.op("Cast", [position_ids], "pos_f", to=onnx.TensorProto.FLOAT)
+    pos_unsq = _unsqueeze(b, pos_f, [-1], "pos_unsq")
+    freqs = b.op("Mul", [pos_unsq, inv_freq_c], "freqs")
+    emb = b.op("Concat", [freqs, freqs], "rope_emb", axis=-1)
+    cos = b.op("Cos", [emb], "rope_cos")
+    sin = b.op("Sin", [emb], "rope_sin")
+    # [B, S, D] -> [B, 1, S, D], broadcasting over both the H-head and the
+    # HKV-head cases uniformly (dim 1 has size 1 either way).
+    cos_b = _unsqueeze(b, cos, [1], "rope_cos_b")
+    sin_b = _unsqueeze(b, sin, [1], "rope_sin_b")
+
+    causal_mask = np.triu(np.full((seq_len, seq_len), -1e9, dtype=np.float32), k=1)
+    mask_c = b.const(causal_mask, prefix="causal_mask")
+    inv_sqrt_d = b.const(
+        np.array(1.0 / math.sqrt(head_dim), dtype=np.float32), prefix="inv_sqrt_d"
+    )
+
+    def reshape(t: str, dims: List[int], prefix: str) -> str:
+        return b.op("Reshape", [t, b.shape_const(dims)], prefix)
+
+    n_embd_gqa = n_head_kv * head_dim
+    for i in range(n_layer):
+        p = f"blk.{i}"
+        resid = x
+        h = _rmsnorm(
+            b, x, declare(f"{p}.attn_norm.weight", [n_embd]), eps, f"{p}.attn_norm"
+        )
+
+        q = _linear(
+            b,
+            h,
+            declare(f"{p}.attn_q.weight", [n_embd, n_embd]),
+            declare_optional(f"{p}.attn_q.bias", [n_embd]),
+            f"{p}.q_proj",
+        )
+        k = _linear(
+            b,
+            h,
+            declare(f"{p}.attn_k.weight", [n_embd_gqa, n_embd]),
+            declare_optional(f"{p}.attn_k.bias", [n_embd_gqa]),
+            f"{p}.k_proj",
+        )
+        v = _linear(
+            b,
+            h,
+            declare(f"{p}.attn_v.weight", [n_embd_gqa, n_embd]),
+            declare_optional(f"{p}.attn_v.bias", [n_embd_gqa]),
+            f"{p}.v_proj",
+        )
+
+        q = reshape(q, [batch_size, seq_len, n_head, head_dim], f"{p}.q_r")
+        q = b.op("Transpose", [q], f"{p}.q_t", perm=[0, 2, 1, 3])
+        k = reshape(k, [batch_size, seq_len, n_head_kv, head_dim], f"{p}.k_r")
+        k = b.op("Transpose", [k], f"{p}.k_t", perm=[0, 2, 1, 3])
+        v = reshape(v, [batch_size, seq_len, n_head_kv, head_dim], f"{p}.v_r")
+        v = b.op("Transpose", [v], f"{p}.v_t", perm=[0, 2, 1, 3])
+
+        q = _apply_rope(b, q, cos_b, sin_b, head_dim, f"{p}.q_rope")
+        k = _apply_rope(b, k, cos_b, sin_b, head_dim, f"{p}.k_rope")
+
+        # Grouped-query attention via broadcasting, not an explicit
+        # repeat/tile of k/v: split q's H heads into [HKV, REP] and give k/v
+        # a size-1 REP axis, so MatMul's own batch-dimension broadcasting
+        # does the repeat implicitly. See the module docstring's design note
+        # and this function's own comment on _linear for the same
+        # "let a later onnxsim.simplify() fold what it can" philosophy.
+        q5 = reshape(q, [batch_size, n_head_kv, n_rep, seq_len, head_dim], f"{p}.q5")
+        k5 = _unsqueeze(b, k, [2], f"{p}.k5")
+        v5 = _unsqueeze(b, v, [2], f"{p}.v5")
+
+        k5t = b.op("Transpose", [k5], f"{p}.k5t", perm=[0, 1, 2, 4, 3])
+        scores = b.op("MatMul", [q5, k5t], f"{p}.scores")
+        scores = b.op("Mul", [scores, inv_sqrt_d], f"{p}.scores_scaled")
+        scores = b.op("Add", [scores, mask_c], f"{p}.scores_masked")
+        attn = b.op("Softmax", [scores], f"{p}.softmax", axis=-1)
+        out5 = b.op("MatMul", [attn, v5], f"{p}.attn_out5")
+
+        out = reshape(out5, [batch_size, n_head, seq_len, head_dim], f"{p}.out_r")
+        out = b.op("Transpose", [out], f"{p}.out_t", perm=[0, 2, 1, 3])
+        out = reshape(out, [batch_size, seq_len, n_embd], f"{p}.out_flat")
+        out = _linear(
+            b,
+            out,
+            declare(f"{p}.attn_output.weight", [n_embd, n_embd]),
+            declare_optional(f"{p}.attn_output.bias", [n_embd]),
+            f"{p}.o_proj",
+        )
+        x = b.op("Add", [resid, out], f"{p}.attn_resid")
+
+        resid = x
+        h = _rmsnorm(
+            b, x, declare(f"{p}.ffn_norm.weight", [n_embd]), eps, f"{p}.ffn_norm"
+        )
+        gate = _linear(
+            b,
+            h,
+            declare(f"{p}.ffn_gate.weight", [n_ff, n_embd]),
+            declare_optional(f"{p}.ffn_gate.bias", [n_ff]),
+            f"{p}.gate_proj",
+        )
+        up = _linear(
+            b,
+            h,
+            declare(f"{p}.ffn_up.weight", [n_ff, n_embd]),
+            declare_optional(f"{p}.ffn_up.bias", [n_ff]),
+            f"{p}.up_proj",
+        )
+        silu = b.op("Sigmoid", [gate], f"{p}.silu_sig")
+        silu = b.op("Mul", [gate, silu], f"{p}.silu")
+        act = b.op("Mul", [silu, up], f"{p}.act")
+        down = _linear(
+            b,
+            act,
+            declare(f"{p}.ffn_down.weight", [n_embd, n_ff]),
+            declare_optional(f"{p}.ffn_down.bias", [n_embd]),
+            f"{p}.down_proj",
+        )
+        x = b.op("Add", [resid, down], f"{p}.ffn_resid")
+
+    x = _rmsnorm(b, x, declare("output_norm.weight", [n_embd]), eps, "output_norm")
+
+    if optional("output.weight") is not None:
+        lm_head = declare("output.weight", [vocab_size, n_embd])
+    else:
+        # Tied embeddings: some Llama-family checkpoints (small models
+        # especially) have no separate LM head tensor at all and reuse
+        # token_embd.weight for both -- token_embd was already declared
+        # above, so there is nothing new to hydrate here.
+        lm_head = token_embd
+    logits = _linear(b, x, lm_head, None, "lm_head")
+
+    graph = onnx.helper.make_graph(
+        b.nodes,
+        f"gguf_{arch}",
+        graph_inputs,
+        [
+            onnx.helper.make_tensor_value_info(
+                logits, onnx.TensorProto.FLOAT, [batch_size, seq_len, vocab_size]
+            )
+        ],
+        initializer=b.initializers,
+    )
+    return graph
+
+
+def reconstruct_gguf_graph(
+    gguf_path: str, batch_size: int = 1, seq_len: int = 8
+) -> Tuple[onnx.ModelProto, List[str]]:
+    """
+    Build a runnable ONNX graph -- structure *and* weights -- directly from
+    a GGUF checkpoint, for a recognized architecture (currently the Llama
+    family: ``llama``, ``qwen2``, ``mistral`` -- see the module docstring).
+
+    Unlike :func:`import_gguf_weights`, which only ever fills in an
+    existing graph's initializer *values*, this constructs the graph
+    itself from the checkpoint's own declared hyperparameters
+    (:func:`read_gguf_metadata`), then calls ``import_gguf_weights``
+    internally to hydrate it -- so it reuses that function's existing
+    K-quant (Q4_K/Q5_K/Q6_K/Q8_0) decode unchanged.
+
+    :param gguf_path: path to the GGUF checkpoint
+    :param batch_size: static batch dimension baked into the returned
+            graph's input/output shapes (see the module docstring's scope
+            note: this is not a dynamic axis)
+    :param seq_len: static sequence-length dimension, likewise baked in
+    :returns: ``(model, skipped)`` -- the constructed, hydrated model
+            (inputs ``input_ids``/``position_ids``, both
+            ``int64[batch_size, seq_len]``; output ``logits``,
+            ``float32[batch_size, seq_len, vocab_size]``), and the names of
+            any GGUF tensors present in the file but left un-hydrated
+            (always empty in practice: every tensor this graph references
+            is validated against the supported dtype set before the graph
+            is even built, and ``import_gguf_weights`` never touches a
+            tensor that is not present in ``model``'s initializers).
+    :raises UnsupportedArchitectureError: if ``general.architecture`` is not
+            one this builder has a template for, a required tensor is
+            missing, or a required tensor's quantization format has no
+            decoder (see :func:`import_gguf_weights`'s own scope note).
+    """
+    meta = read_gguf_metadata(gguf_path)
+    arch = meta["kv"].get("general.architecture")
+    if arch not in _SUPPORTED_ARCHITECTURES:
+        raise UnsupportedArchitectureError(
+            f"general.architecture={arch!r} has no graph template here -- "
+            f"supported: {', '.join(_SUPPORTED_ARCHITECTURES)}"
+        )
+
+    graph = _reconstruct_llama_family(meta, batch_size, seq_len)
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", _OPSET)]
+    )
+    model.ir_version = onnx.IR_VERSION
+
+    model, skipped = import_gguf_weights(model, gguf_path)
+    return model, skipped

--- a/onnxsim/gguf_reconstruct.py
+++ b/onnxsim/gguf_reconstruct.py
@@ -50,6 +50,14 @@ from onnxsim.onnx_simplifier import import_gguf_weights, read_gguf_metadata
 # picking 17 avoids threading yet another small int64 constant through every
 # RMSNorm call for no benefit here.
 _OPSET = 17
+# The IR version opset 17 actually requires (see onnx.helper.VERSION_TABLE --
+# opset 17 first shipped in onnx 1.12.0, IR version 8), NOT
+# onnx.IR_VERSION/onnx.helper.make_model's own default, which is whatever IR
+# version the *installed* onnx package's newest opset needs regardless of
+# what opset_imports says -- setting it that way declares a model far newer
+# than this graph's actual opset, which older onnxruntime builds (bundled
+# with e.g. a cross-compiled wheel's smoke test) then refuse to load at all.
+_IR_VERSION = 8
 
 # Mirrors onnxsim/gguf_dtype.h's GgmlType enum and ToOnnx/IsKQuant mapping --
 # duplicated here rather than exposed through a new C++ binding, the same
@@ -522,7 +530,7 @@ def reconstruct_gguf_graph(
     model = onnx.helper.make_model(
         graph, opset_imports=[onnx.helper.make_opsetid("", _OPSET)]
     )
-    model.ir_version = onnx.IR_VERSION
+    model.ir_version = _IR_VERSION
 
     model, skipped = import_gguf_weights(model, gguf_path)
     return model, skipped

--- a/tests/test_gguf_reconstruct.py
+++ b/tests/test_gguf_reconstruct.py
@@ -1,0 +1,343 @@
+"""Tests for ``onnxsim.reconstruct_gguf_graph`` -- building an ONNX graph
+*and* hydrating its weights directly from a GGUF checkpoint's own declared
+architecture (see onnxsim/gguf_reconstruct.py's module docstring for the
+design).
+
+The core claim under test: the graph this builds computes the same function
+a Llama-family transformer described by the same hyperparameters does. That
+is checked by an *independent* from-scratch numpy implementation of the
+same tiny transformer (not a reuse of anything in gguf_reconstruct.py), run
+against the identical hand-written GGUF checkpoint and compared to the
+ONNX graph's own output via ``onnx.reference.ReferenceEvaluator`` --
+mirroring test_import_gguf_weights.py's own "compute the expected result
+independently, don't reuse the decoder under test" rigor.
+"""
+
+import struct
+
+import numpy as np
+import onnx
+import pytest
+from onnx.reference import ReferenceEvaluator
+
+import onnxsim
+from onnxsim.gguf_reconstruct import UnsupportedArchitectureError
+
+GGUF_MAGIC = 0x46554747
+GGUF_VERSION = 3
+
+GGUF_METADATA_VALUE_TYPE_UINT32 = 4
+GGUF_METADATA_VALUE_TYPE_FLOAT32 = 6
+GGUF_METADATA_VALUE_TYPE_STRING = 8
+
+GGML_TYPE_F32 = 0
+
+
+def _string_bytes(s):
+    b = s.encode("utf-8")
+    return struct.pack("<Q", len(b)) + b
+
+
+def _kv_string(key, value):
+    return (
+        _string_bytes(key)
+        + struct.pack("<I", GGUF_METADATA_VALUE_TYPE_STRING)
+        + _string_bytes(value)
+    )
+
+
+def _kv_uint32(key, value):
+    return (
+        _string_bytes(key)
+        + struct.pack("<I", GGUF_METADATA_VALUE_TYPE_UINT32)
+        + struct.pack("<I", value)
+    )
+
+
+def _kv_float32(key, value):
+    return (
+        _string_bytes(key)
+        + struct.pack("<I", GGUF_METADATA_VALUE_TYPE_FLOAT32)
+        + struct.pack("<f", value)
+    )
+
+
+def _align_up(n, align=32):
+    rem = n % align
+    return n if rem == 0 else n + (align - rem)
+
+
+def _write_gguf(path, kv_chunks, weights):
+    """``weights``: dict of name -> numpy array, ONNX-shape order (already
+    the order read_gguf_metadata reports -- see its own reversed-``ne``
+    note). Every tensor is written as plain F32, matching GGML's
+    innermost-dimension-first ``ne`` (the reverse of the array's own
+    shape) over the SAME contiguous row-major bytes, exactly like
+    tensor_pool_gguf.cpp's LoadGGUF/SaveGGUF reversal."""
+    infos = b""
+    data_chunks = []
+    offset = 0
+    for name, arr in weights.items():
+        ne = list(reversed(arr.shape))
+        raw = arr.astype(np.float32).tobytes()
+        infos += _string_bytes(name)
+        infos += struct.pack("<I", len(ne))
+        for d in ne:
+            infos += struct.pack("<Q", d)
+        infos += struct.pack("<I", GGML_TYPE_F32)
+        infos += struct.pack("<Q", offset)
+        data_chunks.append((offset, raw))
+        offset = _align_up(offset + len(raw))
+
+    header = struct.pack(
+        "<IIQQ", GGUF_MAGIC, GGUF_VERSION, len(weights), len(kv_chunks)
+    )
+    body = b"".join(kv_chunks)
+    header_end = len(header) + len(body) + len(infos)
+    data_section_start = _align_up(header_end)
+
+    with open(path, "wb") as f:
+        f.write(header)
+        f.write(body)
+        f.write(infos)
+        f.write(b"\x00" * (data_section_start - header_end))
+        pos = data_section_start
+        for rel_offset, raw in data_chunks:
+            abs_offset = data_section_start + rel_offset
+            f.write(b"\x00" * (abs_offset - pos))
+            f.write(raw)
+            pos = abs_offset + len(raw)
+
+
+def _rmsnorm(x, w, eps):
+    var = np.mean(x * x, axis=-1, keepdims=True)
+    return x / np.sqrt(var + eps) * w
+
+
+def _rotate_half(x):
+    half = x.shape[-1] // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return np.concatenate([-x2, x1], axis=-1)
+
+
+def _silu(x):
+    return x / (1.0 + np.exp(-x))
+
+
+def _build_tiny_llama_checkpoint(
+    tmp_path, arch, n_head, n_head_kv, tie_embeddings, seed=0
+):
+    """A hand-built, real GGUF v3 file for a tiny (2-layer) Llama-family
+    checkpoint, plus the config dict and weight dict needed to compute an
+    independent numpy reference forward pass for it."""
+    rng = np.random.default_rng(seed)
+    n_embd = 8
+    head_dim = n_embd // n_head
+    n_layer = 2
+    n_ff = 16
+    vocab = 12
+    eps = 1e-5
+    freq_base = 10000.0
+
+    def rand(*shape):
+        return rng.standard_normal(shape).astype(np.float32) * 0.1
+
+    weights = {"token_embd.weight": rand(vocab, n_embd)}
+    for i in range(n_layer):
+        p = f"blk.{i}"
+        weights[f"{p}.attn_norm.weight"] = rand(n_embd) + 1.0
+        weights[f"{p}.attn_q.weight"] = rand(n_embd, n_embd)
+        weights[f"{p}.attn_q.bias"] = rand(n_embd)
+        weights[f"{p}.attn_k.weight"] = rand(n_head_kv * head_dim, n_embd)
+        weights[f"{p}.attn_k.bias"] = rand(n_head_kv * head_dim)
+        weights[f"{p}.attn_v.weight"] = rand(n_head_kv * head_dim, n_embd)
+        weights[f"{p}.attn_v.bias"] = rand(n_head_kv * head_dim)
+        weights[f"{p}.attn_output.weight"] = rand(n_embd, n_embd)  # no bias
+        weights[f"{p}.ffn_norm.weight"] = rand(n_embd) + 1.0
+        weights[f"{p}.ffn_gate.weight"] = rand(n_ff, n_embd)
+        weights[f"{p}.ffn_up.weight"] = rand(n_ff, n_embd)
+        weights[f"{p}.ffn_down.weight"] = rand(n_embd, n_ff)  # no bias
+    weights["output_norm.weight"] = rand(n_embd) + 1.0
+    if not tie_embeddings:
+        weights["output.weight"] = rand(vocab, n_embd)
+
+    kv_chunks = [
+        _kv_string("general.architecture", arch),
+        _kv_uint32(f"{arch}.block_count", n_layer),
+        _kv_uint32(f"{arch}.embedding_length", n_embd),
+        _kv_uint32(f"{arch}.feed_forward_length", n_ff),
+        _kv_uint32(f"{arch}.attention.head_count", n_head),
+        _kv_uint32(f"{arch}.attention.head_count_kv", n_head_kv),
+        _kv_float32(f"{arch}.attention.layer_norm_rms_epsilon", eps),
+        _kv_float32(f"{arch}.rope.freq_base", freq_base),
+    ]
+    path = str(tmp_path / "tiny.gguf")
+    _write_gguf(path, kv_chunks, weights)
+
+    config = dict(
+        n_embd=n_embd,
+        head_dim=head_dim,
+        n_layer=n_layer,
+        n_ff=n_ff,
+        vocab=vocab,
+        eps=eps,
+        freq_base=freq_base,
+        n_head=n_head,
+        n_head_kv=n_head_kv,
+        tie_embeddings=tie_embeddings,
+    )
+    return path, weights, config
+
+
+def _reference_forward(weights, config, input_ids, position_ids):
+    """Independent from-scratch numpy implementation of the same tiny
+    Llama-family transformer -- deliberately not sharing any code with
+    onnxsim/gguf_reconstruct.py, so agreement between the two is a real
+    correctness check, not a tautology."""
+    n_embd, head_dim = config["n_embd"], config["head_dim"]
+    n_head, n_head_kv = config["n_head"], config["n_head_kv"]
+    n_layer, eps, freq_base = config["n_layer"], config["eps"], config["freq_base"]
+    seq = input_ids.shape[1]
+
+    x = weights["token_embd.weight"][input_ids]
+
+    inv_freq = 1.0 / (freq_base ** (np.arange(0, head_dim, 2) / head_dim))
+    freqs = position_ids[..., None].astype(np.float64) * inv_freq[None, None, :]
+    emb = np.concatenate([freqs, freqs], axis=-1)
+    cos = np.cos(emb).astype(np.float32)[:, None, :, :]
+    sin = np.sin(emb).astype(np.float32)[:, None, :, :]
+
+    n_rep = n_head // n_head_kv
+    causal_mask = np.triu(np.full((seq, seq), -1e9, dtype=np.float32), k=1)
+    batch = x.shape[0]
+
+    for i in range(n_layer):
+        p = f"blk.{i}"
+        resid = x
+        h = _rmsnorm(x, weights[f"{p}.attn_norm.weight"], eps)
+
+        q = h @ weights[f"{p}.attn_q.weight"].T + weights[f"{p}.attn_q.bias"]
+        k = h @ weights[f"{p}.attn_k.weight"].T + weights[f"{p}.attn_k.bias"]
+        v = h @ weights[f"{p}.attn_v.weight"].T + weights[f"{p}.attn_v.bias"]
+
+        q = q.reshape(batch, seq, n_head, head_dim).transpose(0, 2, 1, 3)
+        k = k.reshape(batch, seq, n_head_kv, head_dim).transpose(0, 2, 1, 3)
+        v = v.reshape(batch, seq, n_head_kv, head_dim).transpose(0, 2, 1, 3)
+
+        q = q * cos + _rotate_half(q) * sin
+        k = k * cos + _rotate_half(k) * sin
+
+        k_rep = np.repeat(k, n_rep, axis=1)
+        v_rep = np.repeat(v, n_rep, axis=1)
+
+        scores = q @ k_rep.transpose(0, 1, 3, 2) / np.sqrt(head_dim)
+        scores = scores + causal_mask
+        attn = np.exp(scores - scores.max(axis=-1, keepdims=True))
+        attn = attn / attn.sum(axis=-1, keepdims=True)
+        out = attn @ v_rep
+
+        out = out.transpose(0, 2, 1, 3).reshape(batch, seq, n_embd)
+        out = out @ weights[f"{p}.attn_output.weight"].T
+        x = resid + out
+
+        resid = x
+        h = _rmsnorm(x, weights[f"{p}.ffn_norm.weight"], eps)
+        gate = h @ weights[f"{p}.ffn_gate.weight"].T
+        up = h @ weights[f"{p}.ffn_up.weight"].T
+        act = _silu(gate) * up
+        down = act @ weights[f"{p}.ffn_down.weight"].T
+        x = resid + down
+
+    x = _rmsnorm(x, weights["output_norm.weight"], eps)
+    lm_head = (
+        weights["output.weight"]
+        if not config["tie_embeddings"]
+        else weights["token_embd.weight"]
+    )
+    return x @ lm_head.T
+
+
+@pytest.mark.parametrize("arch", ["llama", "qwen2", "mistral"])
+@pytest.mark.parametrize("n_head,n_head_kv", [(2, 2), (2, 1)], ids=["mha", "gqa"])
+@pytest.mark.parametrize("tie_embeddings", [False, True], ids=["untied", "tied"])
+def test_reconstructed_graph_matches_independent_reference(
+    tmp_path, arch, n_head, n_head_kv, tie_embeddings
+):
+    path, weights, config = _build_tiny_llama_checkpoint(
+        tmp_path, arch, n_head, n_head_kv, tie_embeddings
+    )
+    batch, seq = 1, 5
+
+    model, skipped = onnxsim.reconstruct_gguf_graph(path, batch_size=batch, seq_len=seq)
+    assert skipped == []
+    onnx.checker.check_model(model)
+
+    rng = np.random.default_rng(1)
+    input_ids = rng.integers(0, config["vocab"], size=(batch, seq)).astype(np.int64)
+    position_ids = np.arange(seq, dtype=np.int64)[None, :].repeat(batch, axis=0)
+
+    sess = ReferenceEvaluator(model)
+    (onnx_logits,) = sess.run(
+        None, {"input_ids": input_ids, "position_ids": position_ids}
+    )
+    ref_logits = _reference_forward(weights, config, input_ids, position_ids)
+
+    assert onnx_logits.shape == (batch, seq, config["vocab"])
+    np.testing.assert_allclose(onnx_logits, ref_logits, atol=1e-3, rtol=1e-3)
+
+
+def test_simplify_folds_weight_transposes(tmp_path):
+    """A weight's Transpose (see gguf_reconstruct.py's _linear) is constant
+    -- once import_gguf_weights hydrates it, onnxsim.simplify should fold
+    it away, leaving only the genuine runtime (q/k/v/out) transposes."""
+    path, _, _ = _build_tiny_llama_checkpoint(
+        tmp_path, "llama", 2, 1, tie_embeddings=False
+    )
+    model, _ = onnxsim.reconstruct_gguf_graph(path, batch_size=1, seq_len=5)
+    before = sum(1 for n in model.graph.node if n.op_type == "Transpose")
+
+    simplified, check_ok = onnxsim.simplify(model)
+
+    assert check_ok
+    after = sum(1 for n in simplified.graph.node if n.op_type == "Transpose")
+    assert after < before
+
+
+def test_unrecognized_architecture_raises(tmp_path):
+    path = str(tmp_path / "gpt2.gguf")
+    _write_gguf(path, [_kv_string("general.architecture", "gpt2")], {})
+    with pytest.raises(UnsupportedArchitectureError, match="gpt2"):
+        onnxsim.reconstruct_gguf_graph(path)
+
+
+def test_missing_required_tensor_raises(tmp_path):
+    path = str(tmp_path / "no_tensors.gguf")
+    kv_chunks = [
+        _kv_string("general.architecture", "llama"),
+        _kv_uint32("llama.block_count", 1),
+        _kv_uint32("llama.embedding_length", 8),
+        _kv_uint32("llama.feed_forward_length", 16),
+        _kv_uint32("llama.attention.head_count", 2),
+    ]
+    _write_gguf(path, kv_chunks, {})
+    with pytest.raises(UnsupportedArchitectureError, match="token_embd.weight"):
+        onnxsim.reconstruct_gguf_graph(path)
+
+
+def test_tensor_shape_mismatch_raises(tmp_path):
+    """token_embd.weight's declared embedding dim (7) disagrees with
+    llama.embedding_length (8) -- a corrupt/inconsistent checkpoint must be
+    rejected up front, not silently built into a graph with wrong shapes."""
+    path = str(tmp_path / "bad_shape.gguf")
+    kv_chunks = [
+        _kv_string("general.architecture", "llama"),
+        _kv_uint32("llama.block_count", 1),
+        _kv_uint32("llama.embedding_length", 8),
+        _kv_uint32("llama.feed_forward_length", 16),
+        _kv_uint32("llama.attention.head_count", 2),
+    ]
+    _write_gguf(
+        path, kv_chunks, {"token_embd.weight": np.zeros((12, 7), dtype=np.float32)}
+    )
+    with pytest.raises(UnsupportedArchitectureError, match="embedding_length"):
+        onnxsim.reconstruct_gguf_graph(path)


### PR DESCRIPTION
## Summary

- Adds `onnxsim.reconstruct_gguf_graph(gguf_path, batch_size, seq_len)`, which builds an ONNX graph *and* hydrates its weights directly from a GGUF checkpoint, for the Llama architecture family (`llama`/`qwen2`/`mistral`: RMSNorm, RoPE, grouped-query attention, SwiGLU FFN — one block shape, differing only in hyperparameters `read_gguf_metadata` (merged in #732) already reports).
- This is the "known architecture template" approach, not a generic GGUF/ggml graph-structure reconstructor: vLLM and SGLang's own GGUF support works the same way (match `general.architecture` against a maintained, hand-written model implementation; fail clearly rather than guess when unrecognized).
- Reuses `import_gguf_weights` unmodified to hydrate the constructed graph's initializers, including its existing K-quant (Q4_K/Q5_K/Q6_K/Q8_0) decode.

## Key changes

- **`onnxsim/gguf_reconstruct.py`** (new): the graph builder. Declares each weight initializer with the exact ONNX dtype `import_gguf_weights` will hydrate it to (raw dtypes map 1:1; K-quant types always become `FLOAT`), builds the per-layer attention/FFN graph via `onnx.helper`, then calls `import_gguf_weights` to fill in real values.
  - Grouped-query attention via broadcasting (reshape Q into `[B, HKV, REP, S, D]`, give K/V a size-1 REP axis) rather than an explicit repeat/tile of K/V.
  - Every declared tensor's shape is validated against the checkpoint's own hyperparameters up front — a shape mismatch, missing required tensor, unrecognized architecture, or unsupported quantization format all raise `UnsupportedArchitectureError` before any graph is built, rather than silently producing a wrong one.
  - A weight's `Transpose` node (GGUF/ggml round-trips `nn.Linear.weight`'s `[out, in]` shape unchanged, so this transposes at graph-build time rather than pre-transposing not-yet-known values) is constant-foldable by a later `onnxsim.simplify()` call.
- **`onnxsim/__init__.py`**: exports `reconstruct_gguf_graph` and `UnsupportedArchitectureError`.
- **`tests/test_gguf_reconstruct.py`** (new): correctness is checked against an independent, from-scratch numpy implementation of the same tiny transformer (no shared code with the builder under test), run against real hand-built GGUF files and compared via `onnx.reference.ReferenceEvaluator` — covering both MHA and GQA, tied and untied embeddings, and all three recognized architecture names (16 parametrized cases), plus a test that `onnxsim.simplify()` actually folds the constant-weight `Transpose` nodes, and error-path tests (unrecognized architecture, missing tensor, shape mismatch).

## Scope note

The returned graph's `batch_size`/`seq_len` are concrete, caller-chosen static dimensions, not dynamic axes — a deliberate first-slice tradeoff (documented in the module docstring). Generalizing to dynamic axes and KV-cache-aware incremental decoding is future work.

## Test plan

- [x] `python3 -m pytest tests/test_gguf_reconstruct.py -q` — 16 passed
- [x] `python3 -m pytest tests/test_read_gguf_metadata.py tests/test_import_gguf_weights.py -q` — no regressions
- [x] `ruff check` / `ruff format --diff` clean on all changed files
- [x] `mypy onnxsim/gguf_reconstruct.py` — no issues
- [x] Confirmed independently against a from-scratch numpy reference forward pass (max abs diff ~1e-7)
- [x] Confirmed `onnxsim.simplify()` folds the reconstructed graph's constant-weight `Transpose` nodes (25→10 in the test model)

https://claude.ai/code/session_017QTQWXaoD3PMyT6gHwfrYL

---
_Generated by [Claude Code](https://claude.ai/code/session_017QTQWXaoD3PMyT6gHwfrYL)_