### PR TITLE
Add regression tests for the >2GB CLI save fallback and symbolic metric perf fixes

### DIFF
--- a/tests/test_model_info.py
+++ b/tests/test_model_info.py
@@ -296,6 +296,64 @@ def test_print_simplifying_info_factor_recursion_error_falls_back(monkeypatch):
     assert human_readable_density(9472 * batch) == f"{9472 * batch} FLOP/Byte"
 
 
+def test_factor_skipped_above_max_free_symbols(monkeypatch):
+    # A model whose shape inference doesn't deduplicate dynamic dims back to a
+    # handful of named input dims (reproduced exporting a real multi-submodule
+    # TTS model to ONNX) can produce formulas with hundreds of distinct free
+    # symbols. sympy.factor() over that many variables doesn't raise -- it just
+    # never returns -- so it must be skipped by symbol count, not just guarded
+    # against RecursionError. Prove it's skipped (not merely fast) by making
+    # factor() itself blow up if it's ever called.
+    sympy = pytest.importorskip("sympy")
+
+    def _must_not_be_called(_expr):
+        raise AssertionError("sympy.factor() must be skipped above the threshold")
+
+    monkeypatch.setattr(sympy, "factor", _must_not_be_called)
+
+    symbols = sympy.symbols(
+        f"s0:{model_info._MAX_FACTOR_FREE_SYMBOLS + 1}", positive=True, integer=True
+    )
+    expr = sum(symbols)
+    assert model_info._factor_or_str(expr) == str(expr)
+
+
+def test_factor_still_applied_within_threshold():
+    # Below the threshold, factoring must still run (it is a real formatting
+    # nicety for the common, well-named-dims case) -- confirm it actually
+    # changes the printed form rather than always falling back.
+    sympy = pytest.importorskip("sympy")
+    a, b, c = sympy.symbols("a b c", positive=True, integer=True)
+    expr = 2 * a * b + 4 * a * c
+    factored = model_info._factor_or_str(expr)
+    assert factored != str(expr)
+    # Re-parse against the *same* symbol objects: sympify() would otherwise
+    # mint fresh, assumption-less a/b/c that don't cancel against the
+    # positive-integer ones above.
+    reparsed = sympy.sympify(factored, locals={"a": a, "b": b, "c": c})
+    assert sympy.simplify(reparsed - expr) == 0
+
+
+def test_representative_number_does_not_use_subs(monkeypatch):
+    # _representative_number collapses every free symbol to 1 via xreplace, a
+    # direct syntactic substitution. subs() additionally runs structural-
+    # equality/simplification passes meant for pattern-based substitution, and
+    # over hundreds of undeduplicated dynamic-dim symbols (see above) that took
+    # minutes instead of milliseconds. Prove xreplace (not subs) is used by
+    # making subs() itself blow up if it's ever called.
+    sympy = pytest.importorskip("sympy")
+
+    def _must_not_be_called(self, *args, **kwargs):
+        raise AssertionError("Expr.subs() must not be used here; use xreplace")
+
+    monkeypatch.setattr(sympy.Expr, "subs", _must_not_be_called)
+
+    n = 300
+    symbols = sympy.symbols(f"s0:{n}", positive=True, integer=True)
+    expr = sum(symbols)
+    assert model_info._representative_number(expr) == n
+
+
 def test_dynamic_dim_without_sympy_assumes_one(monkeypatch):
     # With sympy unavailable, dynamic dims are assumed 1 (per-sample MACs).
     monkeypatch.setattr(model_info, "sympy", None)

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -293,6 +293,92 @@ def test_model_larger_than_2gb():
     assert sim_model.graph.node[0].op_type == "Add"
 
 
+def test_cli_large_model_save_fallback_mutates_in_place():
+    # Regression test for the CLI's >2GB save fallback in onnx_simplifier.main()
+    # (GitHub PR #730), reproduced exporting a real multi-gigabyte TTS model. Two
+    # distinct bugs lived in the same try/except:
+    #
+    # 1. onnx.save() raises google.protobuf.message.EncodeError (not ValueError)
+    #    once the serialized proto exceeds 2GB, so the external-data fallback
+    #    never triggered and the crash propagated straight out of main().
+    # 2. The fallback used to save a deepcopy of model_opt as external data while
+    #    leaving the original model_opt (with data still inline) around for the
+    #    subsequent model_info diff-printing step, which re-serializes model_opt
+    #    and would hit that same EncodeError on the very model just saved.
+    #
+    # Both are exercised here without needing an actual >2GB fixture: onnx.save
+    # is mocked to raise EncodeError on its first call (matching the real >2GB
+    # failure mode), and model_info.print_simplifying_info is wrapped to capture
+    # the exact model_opt object it receives so its data_location can be
+    # inspected afterward.
+    import sys
+
+    from google.protobuf.message import EncodeError
+
+    from onnxsim import model_info, onnx_simplifier
+
+    # A weight large enough (4 MiB) to actually be moved to external storage --
+    # onnx.save's external-data conversion leaves tensors below its size
+    # threshold inline regardless of save_as_external_data, which would make
+    # the data_location assertion below meaningless.
+    x = onnx.helper.make_tensor_value_info("x", onnx.TensorProto.FLOAT, [4, 1024])
+    y = onnx.helper.make_tensor_value_info("y", onnx.TensorProto.FLOAT, [4, 1024])
+    w = onnx.numpy_helper.from_array(
+        np.random.rand(1024, 1024).astype(np.float32), name="w"
+    )
+    node = onnx.helper.make_node("MatMul", ["x", "w"], ["y"])
+    model = onnx.helper.make_model(
+        onnx.helper.make_graph([node], "g", [x], [y], [w]),
+        opset_imports=[onnx.helper.make_opsetid("", 17)],
+    )
+    onnx.checker.check_model(model)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        input_path = os.path.join(tmpdir, "in.onnx")
+        output_path = os.path.join(tmpdir, "out.onnx")
+        onnx.save(model, input_path)
+
+        real_save = onnx.save
+        call_count = 0
+
+        def fake_save(proto, path, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # The exact failure onnx.save raises past the 2GB protobuf
+                # limit -- simulated here so the test stays fast and small.
+                raise EncodeError("Message larger than 2GiB")
+            return real_save(proto, path, *args, **kwargs)
+
+        captured = {}
+        real_print = model_info.print_simplifying_info
+
+        def capturing_print(ori, opt):
+            captured["opt"] = opt
+            return real_print(ori, opt)
+
+        argv = sys.argv
+        try:
+            onnx_simplifier.onnx.save = fake_save
+            onnx_simplifier.model_info.print_simplifying_info = capturing_print
+            sys.argv = ["onnxsim", input_path, output_path]
+            onnx_simplifier.main()  # must not raise EncodeError (bug 1)
+        finally:
+            onnx_simplifier.onnx.save = real_save
+            onnx_simplifier.model_info.print_simplifying_info = real_print
+            sys.argv = argv
+
+        assert call_count == 2  # the initial attempt, then the external-data save
+        assert os.path.exists(output_path)
+        assert os.path.exists(output_path + ".data")
+
+        # model_opt was mutated in place, not deep-copied (bug 2): the object
+        # model_info was handed after the fallback already carries external
+        # data references rather than inline bytes.
+        opt = captured["opt"]
+        assert opt.graph.initializer[0].data_location == onnx.TensorProto.EXTERNAL
+
+
 def test_unset_optional_input():
     fmap = []
     nodes = []


### PR DESCRIPTION
## Summary

PR #730 fixed three bugs found while exporting a real multi-gigabyte model
(a multi-submodule TTS model) through the CLI, but landed without tests.
This adds regression coverage for all three:

- `onnx_simplifier.main()`'s `>2GB` save fallback only caught `ValueError`,
  but `onnx.save()` actually raises `google.protobuf.message.EncodeError`
  once the serialized proto exceeds 2GB, so the fallback never triggered.
- That same fallback saved a `deepcopy` of `model_opt` as external data
  while leaving the original `model_opt` (still holding inline data) around
  for the subsequent `model_info` diff-printing step, which re-serializes
  it and would hit the identical `EncodeError` on the very model the
  fallback had just gone out of its way to save.
- `model_info`'s symbolic MAC/memory-access formatting called
  `sympy.factor()` and `.subs()`, whose costs are worse than linear in the
  number of distinct free symbols. A model whose shape inference doesn't
  deduplicate dynamic dims back to a handful of named input dims can
  produce formulas with hundreds of free symbols, where `factor()` never
  returns and `.subs()` takes minutes.

## Changes

- `tests/test_python_api.py`: `test_cli_large_model_save_fallback_mutates_in_place`
  drives the real CLI `main()` end-to-end, mocking `onnx.save` to raise
  `EncodeError` on its first call (matching the real `>2GB` failure mode
  without needing an actual multi-gigabyte fixture) and capturing the
  `model_opt` object handed to `model_info.print_simplifying_info` to
  assert it was mutated in place (`data_location == EXTERNAL`) rather than
  left with inline data from an untouched deep copy.
- `tests/test_model_info.py`: three tests for the symbolic-formatting fix —
  `sympy.factor()` is proven *skipped* (not just fast) above the free-symbol
  threshold by making `factor()` itself raise if called, factoring is
  proven to still run below the threshold, and `_representative_number` is
  proven to use `xreplace` rather than `subs` the same way.

Each new test was verified against the pre-fix code (by temporarily
reverting the relevant lines locally) to confirm it actually fails without
the fix, then reverted back.

## Test plan

- [x] `pytest tests/test_model_info.py` — 60 passed
- [x] `pytest tests/test_python_api.py::test_cli_large_model_save_fallback_mutates_in_place` — passed
- [x] `ruff check` / `ruff format --check` on both modified files — clean
- [x] Confirmed each new assertion fails against the pre-#730 code paths (reverted locally, reran, reverted back)


---
_Generated by [Claude Code](https://claude.ai/code/session_019KL3YQ49MQ928XCAawxmu1)_