### PR TITLE
Add quantize_weight_only_int4_hqq: calibration-free HQQ quantization

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -30,6 +30,7 @@ from onnxsim.calibration import (
     quantize_static_int16,
 )
 from onnxsim.gptq import apply_gptq
+from onnxsim.hqq import quantize_weight_only_int4_hqq
 from onnxsim.onnx_simplifier import (
     cross_layer_equalize,
     export_gguf,
@@ -84,6 +85,7 @@ __all__ = [
     "quantize_ternary",
     "quantize_weight_only",
     "quantize_weight_only_int4",
+    "quantize_weight_only_int4_hqq",
     "quantize_weight_only_matmul_nbits",
     "quantize_weight_only_int8_block",
     "quantize_weight_only_int16",

--- a/onnxsim/hqq.py
+++ b/onnxsim/hqq.py
@@ -1,0 +1,268 @@
+"""HQQ -- Half-Quadratic Quantization (Badri & Shaji, 2023, "Half-Quadratic
+Quantization of Large Machine Learning Models",
+https://mobiusml.github.io/hqq_blog/). One of the notable weight-only PTQ
+techniques ``torchao`` implements (its ``Int4WeightOnlyConfig`` offers
+``int4_choose_qparams_algorithm="hqq"`` as an alternative to plain min/max --
+onnxsim ports the *algorithm*, not that code, per the same rationale as
+:mod:`onnxsim.awq`/:mod:`onnxsim.gptq` -- torchao has no ONNX export path).
+
+Unlike every other onnxsim-native PTQ technique so far
+(:mod:`onnxsim.adaround`, :mod:`onnxsim.awq`, :mod:`onnxsim.gptq`,
+:mod:`onnxsim.autoround`), HQQ needs **no calibration data at all** -- it
+never runs the model, only looks at each weight tensor's own values. Its
+angle: a block's naive min/max-derived quantization range is set by
+whichever one or two elements happen to be the most extreme, so a couple of
+outliers can force a scale wide enough to blur every other, "normal"
+element in that block down toward a handful of coarse levels. HQQ instead
+picks the affine quantization parameters (scale, zero-point) to minimize a
+**robust** loss -- an ``Lp`` norm with ``p < 1`` on the reconstruction
+residual, which (unlike the ordinary ``L2``/mean-squared-error a naive
+min/max range implicitly optimizes) tolerates a few large residuals on
+outlier elements in exchange for a tighter, more accurate fit on the
+majority.
+
+This module optimizes the affine zero-point via **Iteratively Reweighted
+Least Squares (IRLS)** -- a standard, textbook algorithm for minimizing an
+``Lp`` (``p < 2``) loss by alternating (a) reweighting each element
+inversely by its own current residual magnitude raised to the ``p - 2``
+power, so elements with large residuals count for less in the next step,
+and (b) re-solving the now-ordinary weighted-least-squares problem for the
+zero-point in closed form. This converges to the same *kind* of solution
+HQQ's own paper describes (a robust fit that downweights outliers) and
+optimizes the same objective (:math:`\\sum_k |w_k - \\hat w_k|^p`); it is
+not a line-for-line reproduction of the paper's own half-quadratic-splitting
+solver, which this module does not claim to replicate exactly, only to
+solve the same problem via a different, independently-verifiable classical
+method.
+
+The scale itself is set once from each block's own min/max range (the
+standard affine-quantization initialization) and held fixed -- only the
+zero-point is refined by IRLS, matching typical HQQ implementations, which
+report most of the benefit comes from the zero-point fit.
+
+Since ``quantize_weight_only_int4``'s own scheme is symmetric (zero-point
+always 0 -- see ``weight_only_quantize_int4_matmul.h``), and HQQ's whole
+premise is an *asymmetric* (nonzero zero-point) affine fit, this module
+produces its own standalone quantization -- unlike
+:mod:`onnxsim.adaround`/:mod:`onnxsim.awq`/:mod:`onnxsim.gptq` (which refine
+an already-``quantize_weight_only_int4``-quantized model in place), this
+takes the plain float model and quantizes it directly into a
+``DequantizeLinear(Wq, Ws, Wz, axis=..., block_size=...)`` structure of its
+own -- unsigned 4-bit codes and zero-point (``[0, 15]``), the natural
+representation for an affine (as opposed to symmetric) quantizer.
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+
+from onnxsim.bias_correction import _all_names, _unique_name
+
+_UINT4 = onnx.TensorProto.UINT4
+
+
+def _match_matmul_like(node: onnx.NodeProto):
+    """Mirrors ``MatchMatMulLike`` (``passes/quantize_matmul_common.h``):
+    a MatMul, or a Gemm with ``transA=0``, ``alpha=1`` and (when it has a
+    bias) ``beta=1``. Returns ``(x_name, w_name, weight_transposed)`` or
+    ``None``.
+    """
+    attrs = {a.name: a for a in node.attribute}
+    if node.op_type == "MatMul":
+        if len(node.input) != 2:
+            return None
+        return node.input[0], node.input[1], False
+    if node.op_type == "Gemm":
+        num_inputs = len(node.input)
+        if num_inputs not in (2, 3):
+            return None
+        trans_a = attrs.get("transA")
+        if trans_a is not None and trans_a.i != 0:
+            return None
+        alpha = attrs.get("alpha")
+        if alpha is not None and alpha.f != 1.0:
+            return None
+        if num_inputs == 3:
+            beta = attrs.get("beta")
+            if beta is not None and beta.f != 1.0:
+                return None
+        trans_b = attrs.get("transB")
+        weight_transposed = bool(trans_b is not None and trans_b.i)
+        return node.input[0], node.input[1], weight_transposed
+    return None
+
+
+def _irls_affine_quantize_blockwise(
+    w_nk: np.ndarray, block_size: int, num_iterations: int, lp_norm: float
+) -> "tuple[np.ndarray, np.ndarray, np.ndarray]":
+    """Returns ``(codes_nk, scale_blocks, zero_blocks)`` for ``w_nk``
+    ([N, K], output channel first): unsigned 4-bit codes in ``[0, 15]``, a
+    scale and (IRLS-refined) zero-point per ``(output channel, block-of-K)``
+    group, each shape ``[N, K // block_size]``. Assumes ``K % block_size ==
+    0``.
+    """
+    n, k = w_nk.shape
+    num_blocks = k // block_size
+    blocks = w_nk.reshape(n, num_blocks, block_size)
+
+    lo = blocks.min(axis=2)
+    hi = blocks.max(axis=2)
+    scale = np.maximum((hi - lo) / 15.0, 1e-12)  # [N, num_blocks]
+    scale3 = scale[:, :, np.newaxis]
+    zero = -lo / scale  # [N, num_blocks]; code 0 maps back to the block min
+
+    eps = 1e-8
+    for _ in range(num_iterations):
+        zero3 = zero[:, :, np.newaxis]
+        code = np.round(blocks / scale3 + zero3)
+        d = blocks - scale3 * code  # residual before the zero-point term
+        dequant = scale3 * (code - zero3)
+        resid = blocks - dequant
+        # IRLS reweighting: elements with a larger current residual count
+        # for less in the next weighted-least-squares solve, the mechanism
+        # by which this converges toward an Lp<2 (robust) fit instead of
+        # the ordinary L2 one a single unweighted solve would give.
+        weight = np.power(np.abs(resid) + eps, lp_norm - 2.0)
+        # Closed-form weighted-least-squares solution for a shared additive
+        # zero-point per block, minimizing sum(weight * (d + scale*zero)^2).
+        zero = -np.sum(weight * d, axis=2) / (scale * np.sum(weight, axis=2) + eps)
+
+    zero = np.clip(np.round(zero), 0.0, 15.0)
+    zero3 = zero[:, :, np.newaxis]
+    codes = np.clip(np.round(blocks / scale3 + zero3), 0.0, 15.0)
+    return codes.reshape(n, k), scale, zero
+
+
+def _pack_uint4(codes: np.ndarray) -> bytes:
+    # Low-nibble-first, matching ONNX's documented UINT4/INT4 raw_data
+    # packing (byte[i] = code[2i] | (code[2i+1] << 4)); codes here are
+    # already unsigned [0, 15], so no sign-bit handling is needed.
+    flat = codes.astype(np.int64).ravel()
+    nibbles = (flat & 0xF).astype(np.uint8)
+    lo = nibbles[0::2]
+    hi = nibbles[1::2]
+    packed = (lo | (hi << 4)).astype(np.uint8)
+    return packed.tobytes()
+
+
+def quantize_weight_only_int4_hqq(
+    model: Union[str, onnx.ModelProto],
+    block_size: int = 32,
+    num_iterations: int = 10,
+    lp_norm: float = 0.7,
+) -> onnx.ModelProto:
+    """Quantizes every MatMul/vanilla-Gemm layer with a constant 2-D
+    float32 weight (whose reduction dimension ``K`` is evenly divisible by
+    ``block_size``) into HQQ-style asymmetric block-wise INT4 -- see this
+    module's own docstring for the technique. Needs no calibration data:
+    every quantization decision comes from the weight tensor's own values.
+
+    :param model: the original (unquantized) onnx ModelProto or file path
+    :param block_size: elements per (output-channel, block) quantization
+            group along the reduction dimension
+    :param num_iterations: IRLS reweighting steps refining each block's
+            zero-point
+    :param lp_norm: the robust loss exponent IRLS targets (``p < 2``; the
+            HQQ paper's own typical default, ``0.7``, favors tolerating a
+            few large residuals over spreading error evenly -- lower values
+            downweight outliers more aggressively, ``p = 2`` would recover
+            an ordinary (non-robust) least-squares fit)
+    :returns: ``model`` with every matched layer's weight replaced by
+            ``DequantizeLinear(Wq, Ws, Wz, axis=<reduction axis>,
+            block_size=block_size)`` feeding the original MatMul/Gemm node;
+            layers with a non-constant, non-2-D, or non-block-divisible
+            weight are left untouched
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    graph = out.graph
+    initializer_map = {t.name: t for t in graph.initializer}
+    taken_names = _all_names(graph)
+
+    opset_ge_21 = any(
+        o.domain in ("", "ai.onnx") and o.version >= 21 for o in out.opset_import
+    )
+    if not opset_ge_21:
+        return (
+            model  # UINT4 tensors and DequantizeLinear's block_size both need opset 21+
+        )
+
+    nodes = list(graph.node)
+    for node in nodes:
+        match = _match_matmul_like(node)
+        if match is None:
+            continue
+        x_name, w_name, weight_transposed = match
+        w_init = initializer_map.get(w_name)
+        if (
+            w_init is None
+            or w_init.data_type != onnx.TensorProto.FLOAT
+            or len(w_init.dims) != 2
+        ):
+            continue
+
+        w = onnx.numpy_helper.to_array(w_init).astype(np.float64)
+        dim0, dim1 = w.shape
+        w_nk = w if weight_transposed else w.T  # [N, K]
+        k = w_nk.shape[1]
+        if k % block_size != 0:
+            continue
+
+        codes_nk, scale_blocks, zero_blocks = _irls_affine_quantize_blockwise(
+            w_nk, block_size, num_iterations, lp_norm
+        )
+        codes_orig = codes_nk if weight_transposed else codes_nk.T
+        scale_orig = scale_blocks if weight_transposed else scale_blocks.T
+        zero_orig = zero_blocks if weight_transposed else zero_blocks.T
+        assert codes_orig.shape == (dim0, dim1)
+
+        wq = onnx.TensorProto()
+        wq.name = _unique_name(f"{w_name}_hqq_q", taken_names)
+        wq.data_type = _UINT4
+        wq.dims.extend(codes_orig.shape)
+        wq.raw_data = _pack_uint4(codes_orig)
+        graph.initializer.append(wq)
+
+        ws = onnx.numpy_helper.from_array(
+            scale_orig.astype(np.float32),
+            name=_unique_name(f"{w_name}_hqq_scale", taken_names),
+        )
+        graph.initializer.append(ws)
+
+        wz = onnx.TensorProto()
+        wz.name = _unique_name(f"{w_name}_hqq_zero", taken_names)
+        wz.data_type = _UINT4
+        wz.dims.extend(zero_orig.shape)
+        wz.raw_data = _pack_uint4(zero_orig)
+        graph.initializer.append(wz)
+
+        # w_nk normalizes to [N, K] (K = axis 1); transposing codes/scale
+        # back to the original storage layout puts K on axis 1 when the
+        # weight was already stored [N, K] (weight_transposed), else K
+        # lands on axis 0 (MatMul's own untransposed [K, N] layout).
+        reduction_axis = 1 if weight_transposed else 0
+        dq_out = _unique_name(f"{w_name}_hqq_dq", taken_names)
+        dq_node = onnx.helper.make_node(
+            "DequantizeLinear",
+            [wq.name, ws.name, wz.name],
+            [dq_out],
+            name=_unique_name(f"{w_name}_hqq_dequant", taken_names),
+            axis=reduction_axis,
+            block_size=block_size,
+        )
+        graph.node.insert(
+            next(i for i, n in enumerate(graph.node) if n is node), dq_node
+        )
+        for i, inp in enumerate(node.input):
+            if inp == w_name:
+                node.input[i] = dq_out
+
+    return out

--- a/tests/test_hqq.py
+++ b/tests/test_hqq.py
@@ -1,0 +1,209 @@
+"""Tests for ``onnxsim.quantize_weight_only_int4_hqq`` (HQQ, see
+``onnxsim/hqq.py``) -- calibration-free, asymmetric block-wise INT4
+quantization that fits each block's zero-point via IRLS to minimize a
+robust (Lp, p<2) reconstruction loss instead of the ordinary least-squares
+fit a naive min/max range implicitly targets.
+"""
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _model(nodes, inputs, outputs, initializer, opset=21):
+    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+    )
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
+
+
+def _matmul_model(K=64, N=16, weight=None, seed=0):
+    if weight is None:
+        rng = np.random.default_rng(seed)
+        weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    return _model(
+        nodes, [_vi("X", ["batch", K])], [_vi("Y", ["batch", N])], [_f32(weight, "W")]
+    )
+
+
+def _dequantize_hqq(model):
+    dq_node = next(n for n in model.graph.node if n.op_type == "DequantizeLinear")
+    wq = next(t for t in model.graph.initializer if t.name == dq_node.input[0])
+    ws = next(t for t in model.graph.initializer if t.name == dq_node.input[1])
+    wz = next(t for t in model.graph.initializer if t.name == dq_node.input[2])
+    block_size = next(a.i for a in dq_node.attribute if a.name == "block_size")
+    axis = next((a.i for a in dq_node.attribute if a.name == "axis"), 1)
+
+    def _unpack_uint4(t):
+        dims = list(t.dims)
+        numel = int(np.prod(dims))
+        raw = np.frombuffer(t.raw_data, dtype=np.uint8)
+        lo = (raw & 0x0F).astype(np.int64)
+        hi = ((raw >> 4) & 0x0F).astype(np.int64)
+        codes = np.empty(numel, dtype=np.int64)
+        codes[0::2] = lo[: (numel + 1) // 2]
+        codes[1::2] = hi[: numel // 2]
+        return codes.reshape(dims).astype(np.float64)
+
+    codes = _unpack_uint4(wq)
+    zero = _unpack_uint4(wz)
+    scale = onnx.numpy_helper.to_array(ws).astype(np.float64)
+
+    scale_full = np.repeat(scale, block_size, axis=axis)
+    zero_full = np.repeat(zero, block_size, axis=axis)
+    slicer = [slice(None)] * codes.ndim
+    slicer[axis] = slice(0, codes.shape[axis])
+    scale_full = scale_full[tuple(slicer)]
+    zero_full = zero_full[tuple(slicer)]
+    return (codes - zero_full) * scale_full
+
+
+def test_hqq_quantizes_matmul_to_dequantize_linear():
+    model = _matmul_model(K=64, N=16, seed=0)
+    hqq_model = onnxsim.quantize_weight_only_int4_hqq(model)
+    onnx.checker.check_model(hqq_model)
+
+    op_types = [n.op_type for n in hqq_model.graph.node]
+    assert op_types.count("DequantizeLinear") == 1
+    assert "MatMul" in op_types
+
+    (dq_node,) = [n for n in hqq_model.graph.node if n.op_type == "DequantizeLinear"]
+    assert (
+        len(dq_node.input) == 3
+    )  # Wq, Ws, Wz -- asymmetric, unlike quantize_weight_only_int4
+
+    wq = next(t for t in hqq_model.graph.initializer if t.name == dq_node.input[0])
+    assert wq.data_type == onnx.TensorProto.UINT4
+    wz = next(t for t in hqq_model.graph.initializer if t.name == dq_node.input[2])
+    assert wz.data_type == onnx.TensorProto.UINT4
+
+
+def test_hqq_output_stays_close_to_float_via_onnxruntime():
+    model = _matmul_model(K=64, N=16, seed=1)
+    hqq_model = onnxsim.quantize_weight_only_int4_hqq(model)
+    onnx.checker.check_model(hqq_model)
+
+    rng = np.random.default_rng(2)
+    x = rng.standard_normal((8, 64)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x})
+    (hqq_y,) = _run(hqq_model, {"X": x})
+    assert np.all(np.isfinite(hqq_y))
+    assert _rel_l2(float_y, hqq_y) < 0.25
+
+
+def test_hqq_beats_naive_minmax_on_outlier_heavy_weights():
+    # HQQ's own motivating scenario: a block whose naive min/max range is
+    # dominated by a couple of outlier elements, forcing a scale so wide
+    # that the bulk of "normal" elements lose most of their precision. A
+    # robust (Lp<2) fit should recover a tighter, more accurate zero-point
+    # for the bulk at the cost of clipping the outliers -- net lower
+    # reconstruction error on the block as a whole.
+    rng = np.random.default_rng(3)
+    K, N = 32, 8
+    weight = rng.standard_normal((K, N)).astype(np.float32) * 0.1
+    # Inject a couple of large outliers into one block (all of K=32 here,
+    # i.e. one block at the default block_size=32).
+    weight[0, :] += 5.0
+    weight[1, :] += 5.0
+
+    model = _matmul_model(K=K, N=N, weight=weight)
+    hqq_model = onnxsim.quantize_weight_only_int4_hqq(model)
+    w_hqq = _dequantize_hqq(hqq_model)  # [K, N]
+
+    # Naive min/max affine quantization (p=2, i.e. plain least squares --
+    # what a naive min/max range effectively targets) for comparison:
+    # asymmetric codes derived directly from min/max with no IRLS refinement.
+    w = weight.astype(np.float64)
+    mn, mx = w.min(axis=0, keepdims=True), w.max(axis=0, keepdims=True)
+    scale_naive = np.maximum((mx - mn) / 15.0, 1e-12)
+    zero_naive = np.clip(np.round(-mn / scale_naive), 0, 15)
+    codes_naive = np.clip(np.round(w / scale_naive + zero_naive), 0, 15)
+    w_naive = (codes_naive - zero_naive) * scale_naive
+
+    # Restrict the comparison to the *non-outlier* bulk (rows 2:), where
+    # HQQ's robust fit should show its benefit most clearly.
+    err_hqq = np.linalg.norm(w_hqq[2:] - w[2:])
+    err_naive = np.linalg.norm(w_naive[2:] - w[2:])
+    assert err_hqq < err_naive
+
+
+def test_hqq_gemm_transb():
+    rng = np.random.default_rng(4)
+    K, N = 96, 12
+    weight = rng.standard_normal((N, K)).astype(np.float32) * 0.5
+    nodes = [onnx.helper.make_node("Gemm", ["X", "W"], ["Y"], transB=1)]
+    model = _model(
+        nodes, [_vi("X", ["batch", K])], [_vi("Y", ["batch", N])], [_f32(weight, "W")]
+    )
+    hqq_model = onnxsim.quantize_weight_only_int4_hqq(model)
+    onnx.checker.check_model(hqq_model)
+
+    x = rng.standard_normal((4, K)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x})
+    (hqq_y,) = _run(hqq_model, {"X": x})
+    assert _rel_l2(float_y, hqq_y) < 0.25
+
+
+def test_hqq_codes_and_zero_stay_in_range():
+    rng = np.random.default_rng(5)
+    weight = rng.standard_normal((32, 8)).astype(np.float32) * 3
+    model = _matmul_model(K=32, N=8, weight=weight)
+    hqq_model = onnxsim.quantize_weight_only_int4_hqq(model)
+
+    dq_node = next(n for n in hqq_model.graph.node if n.op_type == "DequantizeLinear")
+    for name in (dq_node.input[0], dq_node.input[2]):
+        t = next(t for t in hqq_model.graph.initializer if t.name == name)
+        numel = int(np.prod(list(t.dims)))
+        raw = np.frombuffer(t.raw_data, dtype=np.uint8)
+        lo = raw & 0x0F
+        hi = (raw >> 4) & 0x0F
+        codes = np.empty(numel, dtype=np.uint8)
+        codes[0::2] = lo[: (numel + 1) // 2]
+        codes[1::2] = hi[: numel // 2]
+        assert np.all(codes <= 15)
+
+
+def test_hqq_skips_non_block_divisible_k():
+    # K=48 is not a multiple of the default block_size=32.
+    model = _matmul_model(K=48, N=8, seed=6)
+    hqq_model = onnxsim.quantize_weight_only_int4_hqq(model)
+    assert hqq_model.SerializeToString() == model.SerializeToString()
+
+
+def test_hqq_skips_non_constant_weight():
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(
+        nodes, [_vi("X", [4, 64]), _vi("W", [64, 4])], [_vi("Y", [4, 4])], []
+    )
+    hqq_model = onnxsim.quantize_weight_only_int4_hqq(model)
+    op_types = [n.op_type for n in hqq_model.graph.node]
+    assert op_types.count("MatMul") == 1
+    assert "DequantizeLinear" not in op_types


### PR DESCRIPTION
## Summary

Ports **HQQ** (Badri & Shaji, 2023, ["Half-Quadratic Quantization of Large Machine Learning Models"](https://mobiusml.github.io/hqq_blog/)) -- one of the notable weight-only PTQ techniques `torchao` implements (its `Int4WeightOnlyConfig` offers `int4_choose_qparams_algorithm="hqq"` as an alternative to plain min/max; onnxsim ports the *algorithm*, not that code, per the same rationale as `apply_awq`/`apply_gptq` -- torchao has no ONNX export path).

## Why this is genuinely different from the other three

Unlike every other onnxsim-native PTQ technique so far (`adaround.py`, `awq.py`, `gptq.py`, `autoround.py`), **HQQ needs no calibration data at all** -- it never runs the model, only looks at each weight tensor's own values.

Its angle: a block's naive min/max-derived quantization range is set by whichever one or two elements happen to be the most extreme, so a couple of outliers can force a scale wide enough to blur every other, "normal" element in that block down toward a handful of coarse levels. HQQ instead picks the affine quantization parameters (scale, zero-point) to minimize a **robust** loss (an `Lp` norm with `p < 1`) on the reconstruction residual, which tolerates a few large residuals on outlier elements in exchange for a tighter, more accurate fit on the majority.

## Implementation

Uses **Iteratively Reweighted Least Squares (IRLS)** -- a standard, textbook algorithm for minimizing an `Lp` (`p < 2`) loss by alternating reweighting (elements with larger current residuals count for less) and re-solving the now-ordinary weighted-least-squares problem for the zero-point in closed form. This converges to the same *kind* of solution HQQ's own paper describes and optimizes the same objective; **it is explicitly not a line-for-line reproduction of the paper's own half-quadratic-splitting solver** (documented as such in the module docstring) -- reproducing that solver's exact update equations from memory risked a subtly wrong implementation, so this solves the identical problem via a different, independently-verifiable classical method instead. Scale is set once from each block's own min/max range and held fixed; only the zero-point is refined by IRLS, matching typical HQQ implementations.

Since `quantize_weight_only_int4`'s own scheme is symmetric (zero-point always 0) and HQQ's whole premise is an asymmetric affine fit, this produces its own standalone `DequantizeLinear(Wq, Ws, Wz)` structure (unsigned 4-bit codes and zero-point) rather than refining an already-quantized model in place like the other three techniques.

## A real bug caught during testing

The `reduction_axis` formula was initially inverted (backwards relative to the actual `w_nk`/`scale_orig` layout the rest of the module builds) -- caught immediately by `onnxruntime`'s own `DequantizeLinear` shape validation ("x_scale and x must have the same shape despite the quantize axis"). Fixed by swapping the formula; verified by the full test suite passing afterward, including a hand-decoded outlier-robustness comparison that would have been silently wrong under the original bug.

## Verification

- A dedicated test builds a deliberately **outlier-heavy weight tensor** (a couple of large-magnitude elements in one block) and confirms HQQ's reconstruction error on the non-outlier bulk is measurably lower than a naive min/max affine fit computed and hand-decoded **independently** of this module's own internals.
- Further tests cover `Gemm` with `transB=1`, codes/zero-point staying within `[0, 15]`, end-to-end `onnxruntime` execution, and graceful no-ops for non-constant weights and non-block-divisible `K`.
- Full regression sweep: `tests/` (excluding torch/timm-dependent modules not installed in this environment) -- **473 passed, 76 skipped, 0 failed**.
- `ruff format` / `ruff check` / `mypy` clean.

## New files

- `onnxsim/hqq.py`
- `tests/test_hqq.py` -- 7 tests

## Test plan

- [x] `pytest tests/test_hqq.py -v`
- [x] Full `tests/` sweep (torch/timm-dependent modules excluded, not installed in this environment)
- [x] `ruff format` / `ruff check` / `mypy`

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_