### PR TITLE
Add apply_smoothquant: SmoothQuant activation/weight range migration

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -65,6 +65,7 @@ from onnxsim.precision_estimator import (
     estimate_model_quantization_drop,
     estimate_quantization_precision,
 )
+from onnxsim.smoothquant import apply_smoothquant
 from onnxsim.transformers_export import export_transformers_model
 
 from .version import version as __version__
@@ -85,6 +86,7 @@ __all__ = [
     "AutoQuantResult",
     "apply_awq",
     "apply_gptq",
+    "apply_smoothquant",
     "quantize_attention_dynamic",
     "quantize_dynamic",
     "quantize_dynamic_matmul_integer_to_float",

--- a/onnxsim/smoothquant.py
+++ b/onnxsim/smoothquant.py
@@ -1,0 +1,225 @@
+"""SmoothQuant (Xiao et al., 2022, "SmoothQuant: Accurate and Efficient
+Post-Training Quantization for Large Language Models",
+https://arxiv.org/abs/2211.10438). The technique behind ``llm-compressor``'s
+``SmoothQuantModifier`` -- onnxsim ports the *algorithm*, not that code, per
+the same rationale as :mod:`onnxsim.awq`/:mod:`onnxsim.gptq`/:mod:`onnxsim.hqq`
+(``llm-compressor`` quantizes live PyTorch models with no ONNX export path).
+
+Every weight-only technique already in onnxsim (``quantize_weight_only_int4``
+and everything built on it, plus :mod:`onnxsim.hqq`, :mod:`onnxsim.nf4`)
+leaves activations in float -- only the weight is ever quantized. Quantizing
+*activations* too (W8A8, as ``quantize_static``/``quantize_qoperator_gemm``
+already do) hits a problem weight-only quantization never sees: in
+transformer activations, a handful of feature channels can be an order of
+magnitude larger than the rest, consistently, across tokens and inputs. A
+single per-tensor (or even per-token) activation quantization range has to
+cover those outlier channels, so it wastes most of its resolution on the
+sea of ordinary channels below them. Weights, by contrast, are comparatively
+flat and easy to quantize.
+
+SmoothQuant's insight: this difficulty can be *migrated* rather than
+endured. For a MatMul/Gemm ``Y = X @ W``, scaling one input channel of ``X``
+down by ``s_j`` and the matching row of ``W`` up by the same ``s_j`` leaves
+``Y`` mathematically unchanged (``(X / s) @ (W * s) == X @ W``) while
+moving quantization difficulty between the two operands -- a large ``s_j``
+shrinks that channel's activation range (easier to quantize) at the cost of
+expanding the corresponding weight row's range (harder, but weights have
+range to spare). Per-channel, the paper sets
+
+    s_j = max(|X_j|) ** alpha / max(|W_j|) ** (1 - alpha)
+
+where ``X_j``/``W_j`` are channel ``j``'s values across the calibration set
+and the reduction dimension respectively, and ``alpha`` (the paper's
+"migration strength", typically ``0.5``) trades off how much of the
+difficulty moves: ``alpha -> 1`` pushes activations to a uniform, trivially
+quantizable range at the weight's expense; ``alpha -> 0`` does the reverse.
+Unlike :mod:`onnxsim.awq` (which grid-searches its own analogous per-channel
+scale against measured INT4 reconstruction error), SmoothQuant's ``alpha``
+is not searched here -- it is a single fixed global hyperparameter, matching
+the paper's own practice of picking one value per model family from a light
+validation sweep, not optimizing it per layer.
+
+This module only performs the *migration* (:func:`apply_smoothquant`
+returns a float model, provably equivalent to the input up to floating-point
+rounding -- no quantization happens here at all): it multiplies every
+matched MatMul/Gemm's weight columns by ``s`` in place, and inserts a new
+``Mul`` node dividing that layer's activation input by the same ``s`` right
+before it. The result is meant to be fed to a W8A8 quantizer afterwards
+(e.g. :func:`onnxsim.quantize_static`/:func:`onnxsim.quantize_qoperator_gemm`)
+-- exactly how the SmoothQuant paper's own reference implementation is used,
+as a pre-conditioning pass ahead of a separate, ordinary PTQ quantizer.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Sequence, Union
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+
+from onnxsim import backend
+from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.calibration import Tensors, generate_random_calibration_data
+
+
+def _match_matmul_like(node: onnx.NodeProto):
+    """Mirrors ``MatchMatMulLike`` (``passes/quantize_matmul_common.h``):
+    a MatMul, or a Gemm with ``transA=0``, ``alpha=1`` and (when it has a
+    bias) ``beta=1``. Returns ``(x_name, w_name, weight_transposed)`` or
+    ``None``.
+    """
+    attrs = {a.name: a for a in node.attribute}
+    if node.op_type == "MatMul":
+        if len(node.input) != 2:
+            return None
+        return node.input[0], node.input[1], False
+    if node.op_type == "Gemm":
+        num_inputs = len(node.input)
+        if num_inputs not in (2, 3):
+            return None
+        trans_a = attrs.get("transA")
+        if trans_a is not None and trans_a.i != 0:
+            return None
+        alpha = attrs.get("alpha")
+        if alpha is not None and alpha.f != 1.0:
+            return None
+        if num_inputs == 3:
+            beta = attrs.get("beta")
+            if beta is not None and beta.f != 1.0:
+                return None
+        trans_b = attrs.get("transB")
+        weight_transposed = bool(trans_b is not None and trans_b.i)
+        return node.input[0], node.input[1], weight_transposed
+    return None
+
+
+def apply_smoothquant(
+    model: Union[str, onnx.ModelProto],
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_samples: int = 8,
+    seed: int = 0,
+    alpha: float = 0.5,
+    epsilon: float = 1e-5,
+    providers: Optional[Sequence[str]] = None,
+) -> onnx.ModelProto:
+    """Migrates activation quantization difficulty into the weight for
+    every MatMul/vanilla-Gemm layer with a constant 2-D float32 weight and a
+    plain 2-D activation input, using real calibration activations. See
+    this module's own docstring for the technique. Returns a float model --
+    pass the result to a W8A8 quantizer (e.g. :func:`onnxsim.quantize_static`)
+    to actually quantize it.
+
+    :param model: the original (unquantized) onnx ModelProto or file path
+    :param calibration_data: representative input batches to measure each
+            input channel's activation range on. Each batch is a
+            ``{input_name: np.ndarray}`` dict matching ``model``'s graph
+            inputs -- see :func:`onnxsim.generate_random_calibration_data`
+            (the default when omitted) and
+            :func:`onnxsim.load_huggingface_calibration_data` (real data, a
+            much more representative migration than random input).
+    :param num_samples: random batches to generate when
+            ``calibration_data`` is omitted
+    :param seed: seed for the random calibration data (ignored if
+            ``calibration_data`` is supplied)
+    :param alpha: the migration strength (paper's own default, ``0.5``,
+            splits difficulty evenly on a log scale; ``1.0`` pushes it
+            entirely onto the weight, ``0.0`` entirely onto the activation)
+    :param epsilon: floor applied to every per-channel activation/weight
+            max-abs value before computing ``s``, avoiding a divide-by-zero
+            on an all-zero channel
+    :param providers: onnxruntime execution providers to run ``model`` on
+            when capturing calibration activations
+    :returns: ``model`` with every matched layer's weight columns rescaled
+            by ``s`` in place and a new ``Mul`` node inserted before it
+            applying ``1 / s`` to its activation input; layers with a
+            non-constant, non-2-D weight, or whose activation input isn't a
+            plain 2-D tensor matching the weight's reduction dimension, are
+            left untouched
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            model, num_samples=num_samples, seed=seed
+        )
+
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    graph = out.graph
+    initializer_map = {t.name: t for t in graph.initializer}
+    taken_names = _all_names(graph)
+
+    nodes = list(graph.node)
+    candidates = []
+    for node in nodes:
+        match = _match_matmul_like(node)
+        if match is None:
+            continue
+        x_name, w_name, weight_transposed = match
+        w_init = initializer_map.get(w_name)
+        if (
+            w_init is None
+            or w_init.data_type != onnx.TensorProto.FLOAT
+            or len(w_init.dims) != 2
+        ):
+            continue
+        candidates.append((node, x_name, w_name, weight_transposed))
+
+    if not candidates:
+        return out
+
+    probe_names = sorted({x_name for _, x_name, _, _ in candidates})
+    probe_model = _add_probe_outputs(out, probe_names)
+
+    act_absmax: Dict[str, np.ndarray] = {}
+    for batch in calibration_data:
+        result = backend.run_model(probe_model, batch, providers=providers)
+        for name in probe_names:
+            x = np.asarray(result[name], dtype=np.float64)
+            if x.ndim != 2:
+                continue
+            m = np.abs(x).max(axis=0)
+            act_absmax[name] = (
+                m if name not in act_absmax else np.maximum(act_absmax[name], m)
+            )
+
+    for node, x_name, w_name, weight_transposed in candidates:
+        acts = act_absmax.get(x_name)
+        if acts is None:
+            continue  # never observed as a plain 2-D tensor; skip
+
+        w_init = initializer_map[w_name]
+        w = onnx.numpy_helper.to_array(w_init).astype(np.float64)
+        dim0, dim1 = w.shape
+        w_nk = w if weight_transposed else w.T  # [N, K], output channel first
+        k = w_nk.shape[1]
+        if acts.shape[0] != k:
+            continue  # activation's feature dim doesn't match K; skip
+
+        act_channel = np.maximum(acts, epsilon)
+        weight_channel = np.maximum(np.abs(w_nk).max(axis=0), epsilon)  # [K]
+        s = (act_channel**alpha) / (weight_channel ** (1.0 - alpha))
+        s = np.maximum(s, epsilon)
+
+        w_smooth_nk = w_nk * s[np.newaxis, :]
+        w_new = w_smooth_nk if weight_transposed else w_smooth_nk.T
+        w_new = w_new.reshape(dim0, dim1).astype(np.float32)
+        w_init.CopyFrom(onnx.numpy_helper.from_array(w_new, name=w_name))
+
+        inv_s = (1.0 / s).astype(np.float32)
+        scale_name = _unique_name(f"{x_name}_smoothquant_inv_scale", taken_names)
+        graph.initializer.append(onnx.numpy_helper.from_array(inv_s, name=scale_name))
+        scaled_name = _unique_name(f"{x_name}_smoothquant_scaled", taken_names)
+        mul_node = onnx.helper.make_node(
+            "Mul",
+            [x_name, scale_name],
+            [scaled_name],
+            name=_unique_name(f"{x_name}_smoothquant_mul", taken_names),
+        )
+        node_idx = next(i for i, n in enumerate(graph.node) if n is node)
+        graph.node.insert(node_idx, mul_node)
+        node.input[0] = scaled_name
+
+    return out

--- a/tests/test_smoothquant.py
+++ b/tests/test_smoothquant.py
@@ -1,0 +1,219 @@
+"""Tests for ``onnxsim.apply_smoothquant`` (SmoothQuant, see
+``onnxsim/smoothquant.py``) -- migrates per-channel quantization difficulty
+between a MatMul/Gemm's activation and its weight (``s_j = max(|X_j|)**alpha
+/ max(|W_j|)**(1-alpha)``, dividing the activation and multiplying the
+weight by the same ``s``), a lossless pre-conditioning transform meant to run
+ahead of a separate W8A8 quantizer.
+"""
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _model(nodes, inputs, outputs, initializer, opset=13):
+    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=8
+    )
+
+
+def _matmul_model(K=64, N=16, weight=None, seed=0):
+    if weight is None:
+        rng = np.random.default_rng(seed)
+        weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    return _model(
+        nodes, [_vi("X", ["batch", K])], [_vi("Y", ["batch", N])], [_f32(weight, "W")]
+    )
+
+
+def _run(model, feeds, output_names=None):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    names = output_names or [o.name for o in sess.get_outputs()]
+    return dict(zip(names, sess.run(names, feeds)))
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
+
+
+def _outlier_channel_calibration(K=64, num_samples=64, outlier_channels=(3, 7), seed=1):
+    # SmoothQuant's own motivating scenario: a few activation channels
+    # consistently much larger than the rest.
+    rng = np.random.default_rng(seed)
+    x = rng.standard_normal((num_samples, K)).astype(np.float32)
+    for i, c in enumerate(outlier_channels):
+        x[:, c] *= 20.0 + 10.0 * i
+    return x
+
+
+def _with_extra_output(model, name):
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    existing = {o.name for o in out.graph.output}
+    if name not in existing:
+        out.graph.output.append(onnx.ValueInfoProto(name=name))
+    return out
+
+
+def test_smoothquant_output_matches_float_almost_exactly():
+    # Unlike every other onnxsim PTQ technique, SmoothQuant does not
+    # quantize anything itself -- the migration is exact real-number math,
+    # so its own output should match the float model far more tightly than
+    # any lossy INT4/INT8 scheme's tolerance.
+    model = _matmul_model(K=64, N=16, seed=0)
+    x = _outlier_channel_calibration(K=64, num_samples=64, seed=1)
+    calibration_data = [{"X": x}]
+
+    sq_model = onnxsim.apply_smoothquant(model, calibration_data=calibration_data)
+    onnx.checker.check_model(sq_model)
+    assert any(n.op_type == "Mul" for n in sq_model.graph.node)
+
+    float_out = _run(model, {"X": x})
+    sq_out = _run(sq_model, {"X": x}, output_names=["Y"])
+    assert np.all(np.isfinite(sq_out["Y"]))
+    assert _rel_l2(float_out["Y"], sq_out["Y"]) < 1e-4
+
+
+def test_smoothquant_alpha_one_normalizes_activation_channels():
+    # alpha=1 sets s_j = max(|X_j|) exactly, so the smoothed activation
+    # (the inserted Mul's own output) should have per-channel max-abs == 1.
+    K = 32
+    model = _matmul_model(K=K, N=8, seed=2)
+    x = _outlier_channel_calibration(
+        K=K, num_samples=32, outlier_channels=(1, 5, 20), seed=3
+    )
+    calibration_data = [{"X": x}]
+
+    sq_model = onnxsim.apply_smoothquant(
+        model, calibration_data=calibration_data, alpha=1.0
+    )
+    mul_node = next(n for n in sq_model.graph.node if n.op_type == "Mul")
+    probe_model = _with_extra_output(sq_model, mul_node.output[0])
+    result = _run(probe_model, {"X": x}, output_names=[mul_node.output[0]])
+    smoothed = result[mul_node.output[0]]
+    assert np.allclose(np.abs(smoothed).max(axis=0), 1.0, atol=1e-3)
+
+
+def test_smoothquant_alpha_zero_normalizes_weight_columns():
+    # alpha=0 sets s_j = 1 / max(|W_j|) exactly, so every rescaled weight
+    # column's own max-abs should become 1.
+    K = 32
+    rng = np.random.default_rng(4)
+    weight = rng.standard_normal((K, 8)).astype(np.float32) * rng.uniform(
+        0.1, 5.0, size=(1, 8)
+    ).astype(np.float32)
+    model = _matmul_model(K=K, N=8, weight=weight)
+    x = _outlier_channel_calibration(K=K, num_samples=16, outlier_channels=(2,), seed=5)
+    calibration_data = [{"X": x}]
+
+    sq_model = onnxsim.apply_smoothquant(
+        model, calibration_data=calibration_data, alpha=0.0
+    )
+    w_new = onnx.numpy_helper.to_array(sq_model.graph.initializer[0])
+    # Weight is stored [K, N] (plain MatMul, not transposed): the alpha=0
+    # invariant holds per input channel K (axis 0), reduced over N (axis 1).
+    assert np.allclose(np.abs(w_new).max(axis=1), 1.0, atol=1e-3)
+
+
+def test_smoothquant_reduces_activation_dynamic_range_on_outlier_channels():
+    K = 64
+    model = _matmul_model(K=K, N=16, seed=6)
+    x = _outlier_channel_calibration(
+        K=K, num_samples=64, outlier_channels=(3, 7), seed=7
+    )
+    calibration_data = [{"X": x}]
+
+    sq_model = onnxsim.apply_smoothquant(model, calibration_data=calibration_data)
+    mul_node = next(n for n in sq_model.graph.node if n.op_type == "Mul")
+    probe_model = _with_extra_output(sq_model, mul_node.output[0])
+    result = _run(probe_model, {"X": x}, output_names=[mul_node.output[0]])
+    smoothed = result[mul_node.output[0]]
+
+    float_range = np.abs(x.astype(np.float64)).max(axis=0)
+    smoothed_range = np.abs(smoothed).max(axis=0)
+    # The overall spread between the largest and smallest channel range
+    # should shrink -- the entire point of migrating the outlier channels'
+    # difficulty into the weight.
+    assert (smoothed_range.max() / smoothed_range.min()) < (
+        float_range.max() / float_range.min()
+    )
+
+
+def test_smoothquant_gemm_transb():
+    rng = np.random.default_rng(8)
+    K, N = 96, 12
+    weight = rng.standard_normal((N, K)).astype(np.float32) * 0.5
+    nodes = [onnx.helper.make_node("Gemm", ["X", "W"], ["Y"], transB=1)]
+    model = _model(
+        nodes, [_vi("X", ["batch", K])], [_vi("Y", ["batch", N])], [_f32(weight, "W")]
+    )
+    x = _outlier_channel_calibration(
+        K=K, num_samples=32, outlier_channels=(10, 50), seed=9
+    )
+    calibration_data = [{"X": x}]
+
+    sq_model = onnxsim.apply_smoothquant(model, calibration_data=calibration_data)
+    onnx.checker.check_model(sq_model)
+
+    float_out = _run(model, {"X": x})
+    sq_out = _run(sq_model, {"X": x}, output_names=["Y"])
+    assert _rel_l2(float_out["Y"], sq_out["Y"]) < 1e-4
+
+
+def test_smoothquant_noop_when_no_matmul_present():
+    nodes = [onnx.helper.make_node("Relu", ["X"], ["Y"])]
+    model = _model(nodes, [_vi("X", [4, 4])], [_vi("Y", [4, 4])], [])
+    result = onnxsim.apply_smoothquant(
+        model, calibration_data=[{"X": np.zeros((4, 4), dtype=np.float32)}]
+    )
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_smoothquant_skips_non_constant_weight():
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(
+        nodes, [_vi("X", [4, 64]), _vi("W", [64, 4])], [_vi("Y", [4, 4])], []
+    )
+    result = onnxsim.apply_smoothquant(
+        model, calibration_data=[{"X": np.zeros((4, 64), dtype=np.float32)}]
+    )
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_smoothquant_skips_non_2d_activation():
+    # A 3-D activation (e.g. [batch, seq, hidden], typical of an
+    # ONNX-exported transformer) isn't a plain 2-D tensor -- matches this
+    # module's own documented scope, same as onnxsim.apply_awq.
+    K, N = 16, 8
+    rng = np.random.default_rng(10)
+    weight = rng.standard_normal((K, N)).astype(np.float32)
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(
+        nodes,
+        [_vi("X", ["batch", "seq", K])],
+        [_vi("Y", ["batch", "seq", N])],
+        [_f32(weight, "W")],
+    )
+    x = rng.standard_normal((2, 3, K)).astype(np.float32)
+    result = onnxsim.apply_smoothquant(model, calibration_data=[{"X": x}])
+    assert result.SerializeToString() == model.SerializeToString()


### PR DESCRIPTION
## Summary

Ports **SmoothQuant** (Xiao et al., 2022, ["SmoothQuant: Accurate and Efficient Post-Training Quantization for Large Language Models"](https://arxiv.org/abs/2211.10438)) -- the technique behind `llm-compressor`'s `SmoothQuantModifier`. This completes the llm-compressor/bitsandbytes/llama-quantize trio requested as a follow-up to the Unsloth research (#726, #729, #735, #738): llama-quantize's K-quant family was already covered on import (`onnxsim/gguf_reconstruct.py`), bitsandbytes' NF4 landed in #738, and this PR covers llm-compressor's flagship technique.

## Why this is a different kind of technique from everything already ported

Every weight-only PTQ technique already in onnxsim (`quantize_weight_only_int4` and everything built on it, plus `onnxsim/hqq.py`, `onnxsim/nf4.py`) only ever quantizes the *weight* -- activations stay in float. Quantizing activations too (W8A8, which `quantize_static`/`quantize_qoperator_gemm` already support) runs into a problem weight-only quantization never sees: transformer activations routinely have a handful of feature channels that are consistently an order of magnitude larger than the rest, across tokens and inputs. A single quantization range has to cover those outliers, wasting most of its resolution on the ordinary channels underneath them.

SmoothQuant's insight: this difficulty can be *migrated*, not just endured. For `Y = X @ W`, scaling one input channel of `X` down by `s_j` and the matching row of `W` up by the same `s_j` leaves `Y` unchanged (`(X / s) @ (W * s) == X @ W`) while moving quantization difficulty between the two operands. The per-channel scale is `s_j = max(|X_j|)**alpha / max(|W_j|)**(1-alpha)`, with `alpha` (default `0.5`, the paper's own default) as a fixed global "migration strength" -- unlike `onnxsim.apply_awq`'s own analogous per-channel scale, this isn't grid-searched per layer; it's a single hyperparameter, matching the paper's own practice.

## Scope: migration only, not quantization

`apply_smoothquant` performs only the *migration* step and returns a **float model**, provably equivalent to the input up to floating-point rounding -- no quantization happens in this module at all. It multiplies every matched MatMul/Gemm's weight columns by `s` in place and inserts a new `Mul` node dividing that layer's activation input by the same `s`. The result is meant to be fed to a separate W8A8 quantizer afterwards (e.g. `onnxsim.quantize_static`), exactly how the SmoothQuant paper's own reference implementation is used -- a pre-conditioning pass ahead of an ordinary PTQ quantizer, not a quantizer itself.

## Verification

- `test_smoothquant_output_matches_float_almost_exactly`: since the migration is exact real-number math (not a lossy approximation like every other onnxsim PTQ technique), checks the output matches the float model far more tightly (`< 1e-4` relative L2) than any INT4/INT8 scheme's own tolerance.
- `test_smoothquant_alpha_one_normalizes_activation_channels` / `test_smoothquant_alpha_zero_normalizes_weight_columns`: independent, closed-form checks at the two boundary values of `alpha`, where the smoothed activation/weight channel max-abs must equal exactly 1 -- verifies the actual per-channel math, not just that the graph runs.
- `test_smoothquant_reduces_activation_dynamic_range_on_outlier_channels`: confirms the outlier/non-outlier channel range ratio actually shrinks after smoothing, SmoothQuant's whole motivating premise.
- Further tests cover `Gemm` with `transB=1`, no-ops for non-constant weights and non-2-D activations (e.g. a 3-D `[batch, seq, hidden]` activation, matching `onnxsim.apply_awq`'s own scoping), and no-op when no MatMul/Gemm is present.
- Full regression sweep (`tests/`, excluding torch/timm-dependent modules not installed in this environment, and two known memory-heavy large-model tests that OOM in this sandbox regardless of this diff): **598 passed, 68 skipped, 0 failures caused by this change** (the only failures/errors present are pre-existing `ModuleNotFoundError: No module named 'onnxscript'` in unrelated test files, from an optional dependency not installed here).
- `ruff format` / `ruff check` / `mypy` clean (mypy's pre-existing 15 errors in other files are unchanged; `smoothquant.py` itself introduces none).

## New files

- `onnxsim/smoothquant.py`
- `tests/test_smoothquant.py` -- 8 tests

## Test plan

- [x] `pytest tests/test_smoothquant.py -v`
- [x] Full `tests/` sweep (torch/timm-dependent modules and two known OOM-prone large-model tests excluded)
- [x] `ruff format` / `ruff check` / `mypy`

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_