### PR TITLE
Pin measure_accuracy_drop's onnxruntime sessions to deterministic, single-threaded execution

### DIFF
--- a/onnxsim/accuracy.py
+++ b/onnxsim/accuracy.py
@@ -288,6 +288,15 @@ def measure_accuracy_drop(
     float model's -- an empirical measurement, not
     :func:`onnxsim.estimate_model_quantization_drop`'s static estimate.
 
+    Runs single-threaded with onnxruntime's ``use_deterministic_compute`` set
+    (see :func:`onnxsim.backend.run_model`'s ``single_threaded``/
+    ``deterministic`` parameters), at some performance cost: a measurement
+    that silently varies with the host's core count or SIMD capabilities
+    (e.g. AVX-512 vs. AVX2) isn't a trustworthy quality gate for CI or
+    anywhere else the same model+data might be measured on different
+    machines. This does not change *what* is measured -- only removes those
+    two axes of run-to-run variance from how it is measured.
+
     Assumes ``float_model`` and ``quantized_model`` declare the same output
     *names* and count -- true of every onnxsim ``quantize_*``/:func:`quantize`
     call, which never renames or adds/removes graph outputs. Per-output
@@ -329,11 +338,19 @@ def measure_accuracy_drop(
     all_finite = True
 
     for batch in calibration_data:
-        float_out = backend.run_model(float_model, batch, providers=providers)
+        float_out = backend.run_model(
+            float_model,
+            batch,
+            providers=providers,
+            single_threaded=True,
+            deterministic=True,
+        )
         quantized_out = backend.run_model(
             quantized_model,
             _cast_batch_to_model_inputs(quantized_model, batch),
             providers=providers,
+            single_threaded=True,
+            deterministic=True,
         )
         for name in output_names:
             f = np.asarray(float_out[name], dtype=np.float64).ravel()

--- a/onnxsim/backend.py
+++ b/onnxsim/backend.py
@@ -129,6 +129,7 @@ def _run_with_onnxruntime(
     custom_lib: Optional[str],
     providers: Optional[Sequence[Provider]] = None,
     single_threaded: bool = False,
+    deterministic: bool = False,
 ) -> "OrderedDict[str, np.ndarray]":
     if providers is None:
         providers = DEFAULT_PROVIDERS
@@ -146,6 +147,21 @@ def _run_with_onnxruntime(
     # planning buffer reuse across *repeated* Run() calls -- pays for itself
     # never. Disabling it removes that planning cost from every session.
     sess_options.enable_mem_pattern = False
+    if deterministic:
+        # onnxruntime's own documented switch for exactly this: steers CPU/
+        # CUDA/ROCM kernels (MatMul, reductions, etc.) away from any
+        # algorithm whose result can depend on the host's available CPU/GPU
+        # instruction set (e.g. MLAS choosing an AVX-512 vs. AVX2 vs. SSE
+        # kernel), at some performance cost. Without this, two hosts that
+        # differ only in SIMD width can silently diverge in a
+        # graph_optimization_level=0 session too, since that level only
+        # controls *graph rewrites*, not which low-level kernel a node's op
+        # dispatches to. Combine with single_threaded=True (below) to also
+        # remove thread-partitioning as a source of divergence -- both matter
+        # for a *measurement* like :func:`onnxsim.measure_accuracy_drop`,
+        # which is only meaningful if it reproduces regardless of which
+        # machine runs it.
+        sess_options.use_deterministic_compute = True
     if single_threaded:
         # Constant folding creates one throwaway session per fold-group, often
         # hundreds of times per model (once per batch of foldable nodes, per
@@ -228,6 +244,7 @@ def run_model(
     custom_lib: Optional[str] = None,
     providers: Optional[Sequence[Provider]] = None,
     single_threaded: bool = False,
+    deterministic: bool = False,
 ) -> "OrderedDict[str, np.ndarray]":
     """Run ``model`` on ``inputs`` and return an ordered ``{name: array}`` map.
 
@@ -245,9 +262,25 @@ def run_model(
             work; leave this ``False`` for a full-size model. Ignored by the
             pure-Python reference-evaluator fallback (no onnxruntime installed),
             which has no thread pool to configure.
+    :param deterministic: Set onnxruntime's ``use_deterministic_compute``
+            session option, which steers kernels (CPU, CUDA, ROCM) away from
+            any algorithm whose numerical result depends on the host's SIMD
+            capabilities (e.g. AVX-512 vs. AVX2 vs. SSE) rather than the model
+            and inputs alone -- at some performance cost. Used by
+            :func:`onnxsim.measure_accuracy_drop`, a *measurement* that should
+            reproduce across hosts; combine with ``single_threaded=True`` to
+            also remove thread-partitioning as a source of divergence. Ignored
+            by the pure-Python reference-evaluator fallback (already fully
+            deterministic, no SIMD dispatch of its own).
     """
     if _HAS_ONNXRUNTIME:
         return _run_with_onnxruntime(
-            model, inputs, output_names, custom_lib, providers, single_threaded
+            model,
+            inputs,
+            output_names,
+            custom_lib,
+            providers,
+            single_threaded,
+            deterministic,
         )
     return _run_with_reference(model, inputs, output_names, custom_lib, providers)


### PR DESCRIPTION
audio8.yml's quantization-quality gate compares onnxsim's quantize_dynamic
output against a published INT8 reference on an 8-layer autoregressive
KV-cache decoder. Locally this reproduces a stable, in-tolerance
worst_relative_l2 (~0.13, matching the published reference) across many
fresh processes and repeated in-process runs, but CI has been failing with
a wildly different (~0.91) result on the same commits -- including two
cases where the only diff between a passing and failing run was unrelated,
additive code, proving the divergence isn't in onnxsim's own (deterministic)
quantization math.

onnxruntime dispatches different low-level kernels (e.g. MLAS choosing
AVX-512 vs. AVX2 vs. SSE) depending on the host CPU, and partitions
reductions differently depending on thread count -- neither of which
graph_optimization_level=0 (already set) controls. For a numerically
sensitive recurrent model, small host-dependent differences here can
plausibly compound across 8 sequential decode steps into a large one.

Set onnxruntime's own use_deterministic_compute session option and pin to
a single thread for measure_accuracy_drop's sessions specifically, so the
measurement it reports depends only on the model and calibration data, not
on which machine happened to run it.