### PR TITLE
Add quantize_weight_only_squeezellm: dense-and-sparse non-uniform quantization

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -67,6 +67,7 @@ from onnxsim.precision_estimator import (
     estimate_quantization_precision,
 )
 from onnxsim.smoothquant import apply_smoothquant
+from onnxsim.squeezellm import quantize_weight_only_squeezellm
 from onnxsim.transformers_export import export_transformers_model
 
 from .version import version as __version__
@@ -98,6 +99,7 @@ __all__ = [
     "quantize_weight_only_int4_hqq",
     "quantize_weight_only_nf4",
     "NF4_CODEBOOK",
+    "quantize_weight_only_squeezellm",
     "quantize_weight_only_matmul_nbits",
     "quantize_weight_only_int8_block",
     "quantize_weight_only_int16",

--- a/onnxsim/squeezellm.py
+++ b/onnxsim/squeezellm.py
@@ -1,0 +1,351 @@
+"""SqueezeLLM (Kim et al., 2023, "SqueezeLLM: Dense-and-Sparse
+Quantization", https://arxiv.org/abs/2306.07629). onnxsim ports the
+algorithm, not any framework's code, per the same rationale as
+:mod:`onnxsim.awq`/:mod:`onnxsim.gptq`/:mod:`onnxsim.hqq` (SqueezeLLM's own
+reference implementation quantizes live PyTorch ``nn.Linear`` weights, with
+no ONNX export path).
+
+Every weight-only INT4 scheme already in onnxsim (``quantize_weight_only_int4``
+and everything built on it, plus :mod:`onnxsim.hqq`) quantizes onto a
+*uniform* integer grid -- one scale (and, for HQQ, one zero-point) per
+group, evenly spaced codes. SqueezeLLM instead lets each group pick its own
+small set of arbitrary values (a per-group codebook, not an arithmetic
+sequence), fit directly to that group's own weight distribution -- so a
+group whose values cluster tightly around a couple of modes gets levels
+concentrated there, rather than spread evenly across the group's full
+range as a uniform grid would. Two ideas combine to decide *where* those
+per-group levels land:
+
+- **Sensitivity-weighted k-means.** A weight element's effect on the
+  layer's output scales with its input activation's own second moment (the
+  same diagonal-Hessian/Fisher approximation :mod:`onnxsim.gptq` computes
+  in full -- here only the diagonal, ``mean(x_k ** 2)`` per input channel
+  ``k``, is needed). Each group's codebook is fit by ordinary Lloyd's-
+  algorithm k-means, except each element's contribution to a centroid's
+  update is weighted by that sensitivity -- so a centroid drifts to sit
+  closer to elements the layer's output is more sensitive to, and the
+  overall codebook is a weighted-least-squares-optimal fit to the group's
+  actual distribution, not a fixed shape guessed in advance (e.g. NF4's
+  fixed Gaussian-quantile codebook).
+- **Dense-and-sparse decomposition.** A small fraction of weight elements
+  (the paper's own default, ``0.45%``, by magnitude across the whole
+  tensor) are excluded from the k-means fit entirely (so a handful of huge
+  outliers can't drag a group's codebook toward them at the expense of
+  every other element) and instead corrected back to their *exact* original
+  value by a separate additive term. Unlike :mod:`onnxsim.llm_int8`
+  (which excludes activation outlier *channels* from an INT8 matmul and
+  computes the excluded part in float), this decomposition is on the
+  *weight*, and the correction here is represented as an ordinary dense
+  float32 initializer that is zero everywhere except at outlier positions
+  -- exact, and expressible with a plain ``Add``, at the cost of not
+  getting genuine sparse storage/compute savings (a real sparse-matrix
+  deployment format is a separate, downstream concern this module does not
+  address, matching :mod:`onnxsim.nf4`'s own choice to trade deployment
+  compactness for a graph expressible in ordinary ONNX ops).
+
+Dequantization is expressed with ``GatherND(codebook, codes, batch_dims=1)``
+-- a per-group codebook lookup, unlike :mod:`onnxsim.nf4`'s plain ``Gather``
+against one *global* fixed codebook -- followed by ``Reshape`` to unblock,
+an ``Add`` of the sparse correction, and (when the weight was not already
+stored transposed) a ``Transpose`` back to the node's own layout. No custom
+op or contrib domain is needed, only ``GatherND``'s ``batch_dims`` support
+(opset 12+).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Sequence, Union
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+
+from onnxsim import backend
+from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.calibration import Tensors, generate_random_calibration_data
+
+
+def _match_matmul_like(node: onnx.NodeProto):
+    """Mirrors ``MatchMatMulLike`` (``passes/quantize_matmul_common.h``):
+    a MatMul, or a Gemm with ``transA=0``, ``alpha=1`` and (when it has a
+    bias) ``beta=1``. Returns ``(x_name, w_name, weight_transposed)`` or
+    ``None``.
+    """
+    attrs = {a.name: a for a in node.attribute}
+    if node.op_type == "MatMul":
+        if len(node.input) != 2:
+            return None
+        return node.input[0], node.input[1], False
+    if node.op_type == "Gemm":
+        num_inputs = len(node.input)
+        if num_inputs not in (2, 3):
+            return None
+        trans_a = attrs.get("transA")
+        if trans_a is not None and trans_a.i != 0:
+            return None
+        alpha = attrs.get("alpha")
+        if alpha is not None and alpha.f != 1.0:
+            return None
+        if num_inputs == 3:
+            beta = attrs.get("beta")
+            if beta is not None and beta.f != 1.0:
+                return None
+        trans_b = attrs.get("transB")
+        weight_transposed = bool(trans_b is not None and trans_b.i)
+        return node.input[0], node.input[1], weight_transposed
+    return None
+
+
+def _weighted_kmeans_quantize_groups(
+    values: np.ndarray, weights: np.ndarray, num_levels: int, num_iterations: int
+) -> "tuple[np.ndarray, np.ndarray]":
+    """Returns ``(codes, centroids)`` for ``values``/``weights`` (each
+    ``[num_groups, group_size]``): ``codes`` in ``[0, num_levels)`` and one
+    ``num_levels``-entry codebook per group, fit by sensitivity-weighted
+    Lloyd's-algorithm k-means (see this module's own docstring). A group's
+    centroids are initialized from evenly-spaced quantiles of its own
+    (unweighted) sorted values -- a reasonable per-group spread with no
+    randomness needed beyond the calibration data itself.
+    """
+    num_groups, group_size = values.shape
+    sorted_vals = np.sort(values, axis=1)
+    init_idx = np.linspace(0, group_size - 1, num_levels).round().astype(np.int64)
+    centroids = sorted_vals[:, init_idx]  # [G, L]
+
+    for _ in range(num_iterations):
+        dist = (values[:, :, np.newaxis] - centroids[:, np.newaxis, :]) ** 2
+        codes = np.argmin(dist, axis=2)  # [G, group_size]
+        new_centroids = centroids.copy()
+        for level in range(num_levels):
+            mask = codes == level
+            wsum = np.sum(weights * mask, axis=1)
+            vsum = np.sum(weights * values * mask, axis=1)
+            safe = wsum > 1e-12
+            new_centroids[safe, level] = vsum[safe] / wsum[safe]
+        centroids = new_centroids
+
+    dist = (values[:, :, np.newaxis] - centroids[:, np.newaxis, :]) ** 2
+    codes = np.argmin(dist, axis=2)
+    return codes.astype(np.int64), centroids.astype(np.float32)
+
+
+def quantize_weight_only_squeezellm(
+    model: Union[str, onnx.ModelProto],
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_samples: int = 8,
+    seed: int = 0,
+    block_size: int = 32,
+    bits: int = 4,
+    outlier_fraction: float = 0.0045,
+    num_kmeans_iterations: int = 20,
+    providers: Optional[Sequence[str]] = None,
+) -> onnx.ModelProto:
+    """Quantizes every MatMul/vanilla-Gemm layer with a constant 2-D
+    float32 weight (whose reduction dimension ``K`` is evenly divisible by
+    ``block_size``) and a plain 2-D activation input into SqueezeLLM-style
+    dense-and-sparse non-uniform quantization -- see this module's own
+    docstring for the technique.
+
+    :param model: the original (unquantized) onnx ModelProto or file path
+    :param calibration_data: representative input batches to measure each
+            input channel's sensitivity (``mean(x_k ** 2)``) on. Each batch
+            is a ``{input_name: np.ndarray}`` dict matching ``model``'s
+            graph inputs -- see :func:`onnxsim.generate_random_calibration_data`
+            (the default when omitted) and
+            :func:`onnxsim.load_huggingface_calibration_data` (real data, a
+            much more representative sensitivity estimate than random
+            input).
+    :param num_samples: random batches to generate when
+            ``calibration_data`` is omitted
+    :param seed: seed for the random calibration data (ignored if
+            ``calibration_data`` is supplied)
+    :param block_size: elements per ``(output channel, block)`` codebook
+            group along the reduction dimension
+    :param bits: codebook size is ``2 ** bits`` centroids per group (the
+            paper's own default, ``4``, i.e. 16 centroids)
+    :param outlier_fraction: fraction of weight elements (by magnitude,
+            across the whole tensor) excluded from the k-means fit and
+            corrected back to their exact original value instead (the
+            paper's own default, ``0.0045``, i.e. 0.45%)
+    :param num_kmeans_iterations: weighted Lloyd's-algorithm iterations
+            refining each group's codebook
+    :param providers: onnxruntime execution providers to run ``model`` on
+            when capturing calibration activations
+    :returns: ``model`` with every matched layer's weight replaced by
+            ``GatherND(codebook, codes, batch_dims=1)`` (per-group
+            codebook lookup) followed by ``Reshape``, an ``Add`` of the
+            sparse outlier correction, and (when needed) a ``Transpose``,
+            feeding the original MatMul/Gemm node; layers with a
+            non-constant, non-2-D, non-block-divisible, or activation-less
+            weight are left untouched
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            model, num_samples=num_samples, seed=seed
+        )
+
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    graph = out.graph
+
+    opset_ge_12 = any(
+        o.domain in ("", "ai.onnx") and o.version >= 12 for o in out.opset_import
+    )
+    if not opset_ge_12:
+        return out  # GatherND's batch_dims needs opset >= 12
+
+    initializer_map = {t.name: t for t in graph.initializer}
+    taken_names = _all_names(graph)
+
+    nodes = list(graph.node)
+    candidates = []
+    for node in nodes:
+        match = _match_matmul_like(node)
+        if match is None:
+            continue
+        x_name, w_name, weight_transposed = match
+        w_init = initializer_map.get(w_name)
+        if (
+            w_init is None
+            or w_init.data_type != onnx.TensorProto.FLOAT
+            or len(w_init.dims) != 2
+        ):
+            continue
+        candidates.append((node, x_name, w_name, weight_transposed))
+
+    if not candidates:
+        return out
+
+    probe_names = sorted({x_name for _, x_name, _, _ in candidates})
+    probe_model = _add_probe_outputs(out, probe_names)
+
+    act_sensitivity: Dict[str, "tuple[np.ndarray, int]"] = {}
+    for batch in calibration_data:
+        result = backend.run_model(probe_model, batch, providers=providers)
+        for name in probe_names:
+            x = np.asarray(result[name], dtype=np.float64)
+            if x.ndim != 2:
+                continue
+            sq_sum = np.sum(x**2, axis=0)
+            count = x.shape[0]
+            if name in act_sensitivity:
+                prev_sum, prev_count = act_sensitivity[name]
+                act_sensitivity[name] = (prev_sum + sq_sum, prev_count + count)
+            else:
+                act_sensitivity[name] = (sq_sum, count)
+
+    num_levels = 2**bits
+
+    for node, x_name, w_name, weight_transposed in candidates:
+        entry = act_sensitivity.get(x_name)
+        if entry is None:
+            continue  # never observed as a plain 2-D tensor; skip
+        sq_sum, count = entry
+        sensitivity_k = sq_sum / count  # [K], mean(x_k ** 2)
+
+        w_init = initializer_map[w_name]
+        w = onnx.numpy_helper.to_array(w_init).astype(np.float64)
+        dim0, dim1 = w.shape
+        w_nk = w if weight_transposed else w.T  # [N, K], output channel first
+        n, k = w_nk.shape
+        if sensitivity_k.shape[0] != k:
+            continue  # activation's feature dim doesn't match K; skip
+        if k % block_size != 0:
+            continue
+
+        threshold = np.quantile(np.abs(w_nk), 1.0 - outlier_fraction)
+        outlier_mask_nk = np.abs(w_nk) > threshold
+
+        num_blocks = k // block_size
+        num_groups = n * num_blocks
+        values = w_nk.reshape(num_groups, block_size)
+        weights = (
+            np.broadcast_to(
+                sensitivity_k.reshape(num_blocks, block_size),
+                (n, num_blocks, block_size),
+            )
+            .reshape(num_groups, block_size)
+            .copy()
+        )
+        outlier_mask_flat = outlier_mask_nk.reshape(num_groups, block_size)
+        weights[outlier_mask_flat] = 0.0  # outliers don't skew the codebook fit
+
+        codes, codebook = _weighted_kmeans_quantize_groups(
+            values, weights, num_levels, num_kmeans_iterations
+        )
+        dequant_nk = codebook[np.arange(num_groups)[:, np.newaxis], codes].reshape(n, k)
+        sparse_diff_nk = np.where(outlier_mask_nk, w_nk - dequant_nk, 0.0).astype(
+            np.float32
+        )
+
+        prefix = f"{w_name}_squeezellm"
+        codebook_name = _unique_name(f"{prefix}_codebook", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(codebook, name=codebook_name)
+        )
+        codes_name = _unique_name(f"{prefix}_codes", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(
+                codes.reshape(num_groups, block_size, 1), name=codes_name
+            )
+        )
+        sparse_diff_name = _unique_name(f"{prefix}_sparse_diff", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(sparse_diff_nk, name=sparse_diff_name)
+        )
+
+        gathered_name = _unique_name(f"{prefix}_gathered", taken_names)
+        gather_node = onnx.helper.make_node(
+            "GatherND",
+            [codebook_name, codes_name],
+            [gathered_name],
+            name=_unique_name(f"{prefix}_gathernd_node", taken_names),
+            batch_dims=1,
+        )
+
+        unblocked_name = _unique_name(f"{prefix}_unblocked", taken_names)
+        shape_name = _unique_name(f"{prefix}_shape", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(
+                np.array([n, k], dtype=np.int64), name=shape_name
+            )
+        )
+        reshape_node = onnx.helper.make_node(
+            "Reshape",
+            [gathered_name, shape_name],
+            [unblocked_name],
+            name=_unique_name(f"{prefix}_reshape_node", taken_names),
+        )
+
+        corrected_name = _unique_name(f"{prefix}_corrected", taken_names)
+        add_node = onnx.helper.make_node(
+            "Add",
+            [unblocked_name, sparse_diff_name],
+            [corrected_name],
+            name=_unique_name(f"{prefix}_add_node", taken_names),
+        )
+
+        new_nodes = [gather_node, reshape_node, add_node]
+        final_name = corrected_name
+        if not weight_transposed:
+            final_name = _unique_name(f"{prefix}_transposed", taken_names)
+            transpose_node = onnx.helper.make_node(
+                "Transpose",
+                [corrected_name],
+                [final_name],
+                name=_unique_name(f"{prefix}_transpose_node", taken_names),
+                perm=[1, 0],
+            )
+            new_nodes.append(transpose_node)
+
+        node_idx = next(i for i, n in enumerate(graph.node) if n is node)
+        for offset, new_node in enumerate(new_nodes):
+            graph.node.insert(node_idx + offset, new_node)
+        for i, inp in enumerate(node.input):
+            if inp == w_name:
+                node.input[i] = final_name
+
+    return out

--- a/tests/test_squeezellm.py
+++ b/tests/test_squeezellm.py
@@ -1,0 +1,285 @@
+"""Tests for ``onnxsim.quantize_weight_only_squeezellm`` (SqueezeLLM, see
+``onnxsim/squeezellm.py``) -- sensitivity-weighted k-means fits a small
+per-group codebook (arbitrary values, not a uniform grid) to each group's
+own weight distribution, with a handful of outlier elements excluded from
+the fit and corrected back to their exact original value via a dense
+sparse-position correction.
+"""
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _model(nodes, inputs, outputs, initializer, opset=13):
+    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=8
+    )
+
+
+def _matmul_model(K=64, N=16, weight=None, seed=0, opset=13):
+    if weight is None:
+        rng = np.random.default_rng(seed)
+        weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    return _model(
+        nodes,
+        [_vi("X", ["batch", K])],
+        [_vi("Y", ["batch", N])],
+        [_f32(weight, "W")],
+        opset=opset,
+    )
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
+
+
+def _dequantize_squeezellm_by_hand(model, w_name, block_size, weight_transposed):
+    """Independent reference decode: reads the codebook/codes/sparse-diff
+    initializers directly and reconstructs via numpy, without using any of
+    this module's own internal functions or the ops it inserts -- checks
+    actual values, not just that the graph runs.
+    """
+    codebook = onnx.numpy_helper.to_array(
+        next(
+            t
+            for t in model.graph.initializer
+            if t.name == f"{w_name}_squeezellm_codebook"
+        )
+    )
+    codes = onnx.numpy_helper.to_array(
+        next(
+            t for t in model.graph.initializer if t.name == f"{w_name}_squeezellm_codes"
+        )
+    ).reshape(-1, block_size)
+    sparse_diff = onnx.numpy_helper.to_array(
+        next(
+            t
+            for t in model.graph.initializer
+            if t.name == f"{w_name}_squeezellm_sparse_diff"
+        )
+    )
+    n, k = sparse_diff.shape
+    num_groups = codes.shape[0]
+    dequant_nk = (
+        codebook[np.arange(num_groups)[:, np.newaxis], codes].reshape(n, k)
+        + sparse_diff
+    )
+    return dequant_nk if weight_transposed else dequant_nk.T
+
+
+def _varied_calibration(K=64, num_samples=64, seed=1):
+    rng = np.random.default_rng(seed)
+    return rng.standard_normal((num_samples, K)).astype(np.float32)
+
+
+def test_squeezellm_output_stays_close_to_float_via_onnxruntime():
+    model = _matmul_model(K=64, N=16, seed=0)
+    x = _varied_calibration(K=64, num_samples=64, seed=1)
+    calibration_data = [{"X": x}]
+
+    q_model = onnxsim.quantize_weight_only_squeezellm(
+        model, calibration_data=calibration_data
+    )
+    onnx.checker.check_model(q_model)
+
+    op_types = {n.op_type for n in q_model.graph.node}
+    assert "GatherND" in op_types
+
+    (float_y,) = _run(model, {"X": x})
+    (q_y,) = _run(q_model, {"X": x})
+    assert np.all(np.isfinite(q_y))
+    assert _rel_l2(float_y, q_y) < 0.3
+
+
+def test_squeezellm_dequantized_values_match_hand_decoded_reference():
+    # Probes the graph's own reconstructed-weight tensor (the node feeding
+    # the MatMul's weight input) via onnxruntime and checks it against an
+    # independent numpy decode of the raw codebook/codes/sparse-diff
+    # initializers -- a real per-element correctness check of both this
+    # module's own graph construction and the hand-decode helper the other
+    # tests below rely on, not just "the graph runs".
+    K, N, block_size = 32, 8, 32
+    rng = np.random.default_rng(2)
+    weight = rng.standard_normal((K, N)).astype(np.float32) * 0.3
+    model = _matmul_model(K=K, N=N, weight=weight)
+    x = _varied_calibration(K=K, num_samples=32, seed=3)
+    calibration_data = [{"X": x}]
+
+    q_model = onnxsim.quantize_weight_only_squeezellm(
+        model, calibration_data=calibration_data, block_size=block_size
+    )
+    w_hand = _dequantize_squeezellm_by_hand(
+        q_model, "W", block_size, weight_transposed=False
+    )
+
+    matmul_node = next(n for n in q_model.graph.node if n.op_type == "MatMul")
+    weight_tensor_name = matmul_node.input[1]
+    probe_model = onnx.ModelProto()
+    probe_model.CopyFrom(q_model)
+    probe_model.graph.output.append(onnx.ValueInfoProto(name=weight_tensor_name))
+    (w_graph,) = _run(probe_model, {"X": x})[len(q_model.graph.output) :]
+
+    assert np.allclose(w_hand, w_graph.astype(np.float64), rtol=0, atol=1e-5)
+
+
+def test_squeezellm_sparse_correction_is_exact_at_outlier_positions():
+    K, N, block_size = 32, 4, 32
+    rng = np.random.default_rng(4)
+    weight = rng.standard_normal((K, N)).astype(np.float32) * 0.1
+    # A handful of extreme values that should be captured as outliers and
+    # corrected back exactly, whatever the k-means codebook alone would
+    # have reconstructed them as.
+    weight[0, 0] = 50.0
+    weight[5, 2] = -37.0
+    model = _matmul_model(K=K, N=N, weight=weight)
+    x = _varied_calibration(K=K, num_samples=32, seed=5)
+    calibration_data = [{"X": x}]
+
+    q_model = onnxsim.quantize_weight_only_squeezellm(
+        model,
+        calibration_data=calibration_data,
+        block_size=block_size,
+        outlier_fraction=0.02,
+    )
+    w_hand = _dequantize_squeezellm_by_hand(
+        q_model, "W", block_size, weight_transposed=False
+    )
+    assert np.isclose(w_hand[0, 0], 50.0, atol=1e-3)
+    assert np.isclose(w_hand[5, 2], -37.0, atol=1e-3)
+
+
+def test_squeezellm_codebook_beats_naive_uniform_on_multimodal_weights():
+    # A single block whose values cluster tightly around two far-apart
+    # modes: a naive uniform grid spanning the block's full min/max wastes
+    # most of its levels on the empty gap between the modes, while a
+    # sensitivity-weighted (here, uniform-sensitivity) codebook fit
+    # directly to the data should concentrate levels at the two modes and
+    # reconstruct far more accurately at the same bit width.
+    K, N, block_size, bits = 32, 1, 32, 2  # 4 levels
+    rng = np.random.default_rng(6)
+    weight = np.concatenate(
+        [
+            rng.normal(-1.0, 0.02, K // 2),
+            rng.normal(1.0, 0.02, K - K // 2),
+        ]
+    ).astype(np.float32)[:, np.newaxis]
+    model = _matmul_model(K=K, N=N, weight=weight)
+    x = _varied_calibration(K=K, num_samples=16, seed=7)
+    calibration_data = [{"X": x}]
+
+    q_model = onnxsim.quantize_weight_only_squeezellm(
+        model, calibration_data=calibration_data, block_size=block_size, bits=bits
+    )
+    w_hand = _dequantize_squeezellm_by_hand(
+        q_model, "W", block_size, weight_transposed=False
+    )
+    squeezellm_mse = float(np.mean((w_hand - weight) ** 2))
+
+    lo, hi = weight.min(), weight.max()
+    scale = (hi - lo) / (2**bits - 1)
+    naive_codes = np.round((weight - lo) / scale)
+    naive_dequant = naive_codes * scale + lo
+    naive_mse = float(np.mean((naive_dequant - weight) ** 2))
+
+    assert squeezellm_mse < naive_mse
+
+
+def test_squeezellm_codes_stay_in_range():
+    K, N, bits = 32, 8, 3
+    weight_rng = np.random.default_rng(8)
+    weight = weight_rng.standard_normal((K, N)).astype(np.float32)
+    model = _matmul_model(K=K, N=N, weight=weight)
+    x = _varied_calibration(K=K, num_samples=16, seed=9)
+    calibration_data = [{"X": x}]
+
+    q_model = onnxsim.quantize_weight_only_squeezellm(
+        model, calibration_data=calibration_data, block_size=32, bits=bits
+    )
+    codes = onnx.numpy_helper.to_array(
+        next(t for t in q_model.graph.initializer if t.name == "W_squeezellm_codes")
+    )
+    assert np.all(codes >= 0) and np.all(codes < 2**bits)
+
+
+def test_squeezellm_gemm_transb():
+    rng = np.random.default_rng(10)
+    K, N = 64, 12
+    weight = rng.standard_normal((N, K)).astype(np.float32) * 0.5
+    nodes = [onnx.helper.make_node("Gemm", ["X", "W"], ["Y"], transB=1)]
+    model = _model(
+        nodes, [_vi("X", ["batch", K])], [_vi("Y", ["batch", N])], [_f32(weight, "W")]
+    )
+    x = _varied_calibration(K=K, num_samples=32, seed=11)
+    calibration_data = [{"X": x}]
+
+    q_model = onnxsim.quantize_weight_only_squeezellm(
+        model, calibration_data=calibration_data, block_size=32
+    )
+    onnx.checker.check_model(q_model)
+
+    (float_y,) = _run(model, {"X": x})
+    (q_y,) = _run(q_model, {"X": x})
+    assert _rel_l2(float_y, q_y) < 0.3
+
+
+def test_squeezellm_skips_non_block_divisible_k():
+    model = _matmul_model(K=48, N=8, seed=12)  # 48 is not a multiple of 64
+    x = _varied_calibration(K=48, num_samples=16, seed=13)
+    q_model = onnxsim.quantize_weight_only_squeezellm(
+        model, calibration_data=[{"X": x}], block_size=64
+    )
+    assert q_model.SerializeToString() == model.SerializeToString()
+
+
+def test_squeezellm_skips_non_constant_weight():
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(
+        nodes, [_vi("X", [4, 64]), _vi("W", [64, 4])], [_vi("Y", [4, 4])], []
+    )
+    q_model = onnxsim.quantize_weight_only_squeezellm(
+        model, calibration_data=[{"X": np.zeros((4, 64), dtype=np.float32)}]
+    )
+    assert q_model.SerializeToString() == model.SerializeToString()
+
+
+def test_squeezellm_noop_when_no_matmul_present():
+    nodes = [onnx.helper.make_node("Relu", ["X"], ["Y"])]
+    model = _model(nodes, [_vi("X", [4, 4])], [_vi("Y", [4, 4])], [])
+    result = onnxsim.quantize_weight_only_squeezellm(
+        model, calibration_data=[{"X": np.zeros((4, 4), dtype=np.float32)}]
+    )
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_squeezellm_noop_on_old_opset():
+    # GatherND's batch_dims needs opset >= 12.
+    model = _matmul_model(K=32, N=8, seed=14, opset=11)
+    x = _varied_calibration(K=32, num_samples=16, seed=15)
+    result = onnxsim.quantize_weight_only_squeezellm(model, calibration_data=[{"X": x}])
+    assert result.SerializeToString() == model.SerializeToString()


### PR DESCRIPTION
## Summary

Ports **SqueezeLLM** (Kim et al., 2023, ["SqueezeLLM: Dense-and-Sparse Quantization"](https://arxiv.org/abs/2306.07629)) -- suggested as a follow-up candidate after completing the llm-compressor/bitsandbytes/llama-quantize trio (#738 NF4, #740 SmoothQuant, #743 LLM.int8()).

## Why this is a different kind of technique from everything already ported

Every uniform-grid INT4 scheme already in onnxsim (`quantize_weight_only_int4` and everything built on it, plus `onnxsim/hqq.py`'s affine scale+zero-point) quantizes onto an *arithmetic* sequence of evenly-spaced codes. SqueezeLLM instead lets each group pick its own small set of *arbitrary* values -- a per-group codebook fit directly to that group's own weight distribution, so a group whose values cluster around a couple of modes gets levels concentrated there rather than spread evenly across its full range. Two ideas combine to decide where those levels land:

- **Sensitivity-weighted k-means.** A weight element's effect on the layer's output scales with its input activation's own second moment -- the same diagonal-Hessian/Fisher approximation `onnxsim.apply_gptq` computes in full, but here only the diagonal (`mean(x_k ** 2)` per input channel) is needed. Each group's codebook is fit by Lloyd's-algorithm k-means where a centroid's update is weighted by that sensitivity, so it drifts toward elements the layer's output is more sensitive to -- a weighted-least-squares-optimal fit to the group's actual distribution, not a fixed shape guessed in advance (e.g. NF4's fixed Gaussian-quantile codebook).
- **Dense-and-sparse decomposition.** A small fraction of weight elements (the paper's own default, 0.45% by magnitude) are excluded from the k-means fit entirely -- so a handful of huge outliers can't drag a group's codebook off target -- and corrected back to their *exact* original value via a separate additive term. Unlike `onnxsim.apply_llm_int8` (which excludes activation outlier *channels* from an INT8 matmul), this decomposition is on the *weight*, represented as an ordinary dense float32 initializer that's zero everywhere except at outlier positions -- exact, expressible with a plain `Add`, at the cost of not getting genuine sparse storage/compute savings (a real sparse-matrix deployment format is a separate concern, matching `onnxsim.quantize_weight_only_nf4`'s own choice to trade deployment compactness for a graph expressible in ordinary ONNX ops).

## Representation

Dequantization is `GatherND(codebook, codes, batch_dims=1)` -- a genuine per-group codebook lookup, unlike NF4's plain `Gather` against one *global* fixed codebook -- followed by `Reshape` to unblock, an `Add` of the sparse correction, and (when the weight isn't already stored transposed) a `Transpose` back to the node's own layout. No custom op or contrib domain, only `GatherND`'s `batch_dims` support (opset 12+).

## Verification

- `test_squeezellm_dequantized_values_match_hand_decoded_reference`: probes the graph's own reconstructed-weight tensor via onnxruntime and checks it against an independent numpy decode of the raw codebook/codes/sparse-diff initializers -- a real per-element correctness check of both the graph construction and the hand-decode helper the other tests rely on.
- `test_squeezellm_codebook_beats_naive_uniform_on_multimodal_weights`: a dedicated test constructing a bimodal weight block, confirming the fitted non-uniform codebook reconstructs it with lower MSE at the same bit width than a naive uniform min/max grid -- the technique's whole premise.
- `test_squeezellm_sparse_correction_is_exact_at_outlier_positions`: injects extreme weight values and confirms they decode back exactly, whatever the codebook alone would have reconstructed them as.
- Further tests cover `Gemm` with `transB=1`, codes staying in `[0, 2**bits)`, and no-ops for non-block-divisible `K`, non-constant weights, no MatMul/Gemm present, and opsets below 12.
- Full regression sweep (`tests/`, excluding torch/timm-dependent modules not installed here and two known memory-heavy large-model tests that OOM in this sandbox regardless of this diff): **617 passed, 68 skipped, 0 failures caused by this change** (the only failures/errors present are pre-existing `ModuleNotFoundError: No module named 'onnxscript'` in unrelated test files).
- `ruff format` / `ruff check` / `mypy` clean (mypy's pre-existing 15 errors in other files are unchanged; `squeezellm.py` itself introduces none).

## New files

- `onnxsim/squeezellm.py`
- `tests/test_squeezellm.py` -- 10 tests

## Test plan

- [x] `pytest tests/test_squeezellm.py -v`
- [x] Full `tests/` sweep (torch/timm-dependent modules and two known OOM-prone large-model tests excluded)
- [x] `ruff format` / `ruff check` / `mypy`

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_