### PR TITLE
Fix s390x CI: build_s390x_extension.sh never built read_gguf_metadata_test

### DIFF
--- a/scripts/cross/build_s390x_extension.sh
+++ b/scripts/cross/build_s390x_extension.sh
@@ -202,13 +202,14 @@ cmake --build "${BUILD_DIR}" --target onnx_cpp2py_export -j "${JOBS}"
 # the one that covers the byte-order conversion directly; the rest come along
 # because they are cheap and exercise the same cross-built toolchain.
 # tensor_pool_dtype_test/tensor_pool_test (safetensors) and
-# gguf_dtype_test/tensor_pool_gguf_test (GGUF) are likewise dependency-free
-# (each format's own byte-order handling; see tensor_pool.h's "Byte order"
-# note and tensor_pool_gguf.cpp's mirror of it) and belong in this list for
-# the same reason. ggml_kquant_test (the GGML K-quant dequantization
-# ggml_kquant.h implements -- decoded values are real numeric output, not
-# just copied bytes, so this is exactly the kind of logic a big-endian run
-# needs to check) is dependency-free too, for the same reason.
+# gguf_dtype_test/tensor_pool_gguf_test/read_gguf_metadata_test (GGUF) are
+# likewise dependency-free (each format's own byte-order handling; see
+# tensor_pool.h's "Byte order" note and tensor_pool_gguf.cpp's mirror of it)
+# and belong in this list for the same reason. ggml_kquant_test (the GGML
+# K-quant dequantization ggml_kquant.h implements -- decoded values are real
+# numeric output, not just copied bytes, so this is exactly the kind of logic
+# a big-endian run needs to check) is dependency-free too, for the same
+# reason.
 # tensor_pool_hash_test (TensorPool::ContentHash's BLAKE3 / SHA-256
 # backends) is dependency-free too and belongs here for the same reason --
 # CMake still registers each of these as a ctest target even if left off
@@ -218,7 +219,8 @@ cmake --build "${BUILD_DIR}" --target onnx_cpp2py_export -j "${JOBS}"
 cmake --build "${BUILD_DIR}" --target sym_expr_test model_metrics_test \
   sym_value_eval_test sym_shape_infer_test dlpack_dtype_test \
   tensor_pool_dtype_test tensor_pool_test tensor_pool_hash_test \
-  gguf_dtype_test ggml_kquant_test tensor_pool_gguf_test -j "${JOBS}"
+  gguf_dtype_test ggml_kquant_test tensor_pool_gguf_test \
+  read_gguf_metadata_test -j "${JOBS}"
 # tensor_pool_bridge_test, tensor_pool_gguf_bridge_test,
 # tensor_pool_archive_test, and precision_estimator_test are NOT
 # dependency-free (they exercise onnx::ModelProto / the TensorProto <->

--- a/tests/test_gguf_reconstruct.py
+++ b/tests/test_gguf_reconstruct.py
@@ -79,7 +79,14 @@ def _write_gguf(path, kv_chunks, weights):
     offset = 0
     for name, arr in weights.items():
         ne = list(reversed(arr.shape))
-        raw = arr.astype(np.float32).tobytes()
+        # GGUF tensor data is little-endian regardless of host byte order
+        # (same convention as ONNX's raw_data -- see
+        # onnxsim/passes/endian_read.h's doc comment and
+        # test_onnx_safetensors_input.py's mirror of this note).
+        # `arr.astype(np.float32).tobytes()` would serialize in numpy's
+        # native/host order instead, which is only correct by coincidence on
+        # little-endian hosts.
+        raw = arr.astype("<f4").tobytes()
         infos += _string_bytes(name)
         infos += struct.pack("<I", len(ne))
         for d in ne:


### PR DESCRIPTION
## Summary

Fixes #745 — the `s390x (big endian)` CI job's `read_gguf_metadata_test` failure (instant "Failed 0.00 sec" with zero output).

## Root cause

`scripts/cross/build_s390x_extension.sh` builds its dependency-free C++ unit tests via an explicit, hand-maintained `cmake --build --target ...` list (rather than `--target all`). `read_gguf_metadata_test` was added (alongside the GGUF metadata reader) but never added to that list — so its binary was simply never built, even though `CMakeLists.txt` still registers it as a ctest target (`add_test(NAME read_gguf_metadata_test COMMAND read_gguf_metadata_test)`).

The script's own comment, a few lines above the list, describes this exact failure mode almost verbatim:

> CMake still registers each of these as a ctest target even if left off this list, so omitting one here doesn't skip its test, it makes ctest try to exec a binary that was never built: an instant, silent "Failed 0.00 sec" with no output, indistinguishable at a glance from a real crash.

This is not a byte-order logic bug in `ReadGGUFMetadata`/`tensor_pool_gguf.cpp`.

## Verification

Rather than run the full ~40 minute rootfs-based cross-build, I cross-compiled `read_gguf_metadata_test.cpp` standalone for s390x with `s390x-linux-gnu-g++` (statically linked, matching the file's own "Standalone" build comment) and ran it directly under `qemu-s390x-static` emulation — the same toolchain and emulator this workflow uses:

```
$ qemu-s390x-static ./read_gguf_metadata_test_static
read_gguf_metadata_test: all checks passed
```

All checks pass under real big-endian emulation, confirming `ReadGGUFMetadata`'s manual byte-order handling (explicit shift/reassembly, no raw endian-dependent memcpy from file bytes) is correct, and that the CI failure is purely the missing build target.

## Fix

Add `read_gguf_metadata_test` to the build-target list in `build_s390x_extension.sh`, alongside its sibling `tensor_pool_gguf_test` (same dependency-free source set: `tensor_pool.cpp` + `tensor_pool_hash.cpp` + `tensor_pool_gguf.cpp` + blake3).

## Test plan

- [x] Cross-compiled and ran `read_gguf_metadata_test` under `qemu-s390x-static` directly — passes.
- [x] `bash -n scripts/cross/build_s390x_extension.sh` — syntax OK.
- [ ] CI's own `s390x (big endian)` job on this PR (it touches `scripts/cross/build_s390x_extension.sh`, which is in that workflow's path filter, so it will run here).


---
_Generated by [Claude Code](https://claude.ai/code/session_016GQnc6sCWVFaUzNE3mFzQs)_