### PR TITLE
Add apply_low_rank_compensation and a workaround for an ONNX Runtime axis=0 fusion bug

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -36,6 +36,7 @@ from onnxsim.gguf_reconstruct import (
 from onnxsim.gptq import apply_gptq
 from onnxsim.hqq import quantize_weight_only_int4_hqq
 from onnxsim.llm_int8 import apply_llm_int8
+from onnxsim.low_rank_compensation import apply_low_rank_compensation
 from onnxsim.nf4 import NF4_CODEBOOK, quantize_weight_only_nf4
 from onnxsim.onnx_simplifier import (
     cross_layer_equalize,
@@ -90,6 +91,7 @@ __all__ = [
     "apply_gptq",
     "apply_smoothquant",
     "apply_llm_int8",
+    "apply_low_rank_compensation",
     "quantize_attention_dynamic",
     "quantize_dynamic",
     "quantize_dynamic_matmul_integer_to_float",

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -62,6 +62,7 @@ from onnxsim.onnx_simplifier import (
     read_gguf_metadata,
     simplify,
 )
+from onnxsim.ort_matmul_nbits_workaround import workaround_ort_matmul_nbits_axis0_bug
 from onnxsim.precision_estimator import (
     ModelQuantizationEstimate,
     estimate_model_quantization_drop,
@@ -92,6 +93,7 @@ __all__ = [
     "apply_smoothquant",
     "apply_llm_int8",
     "apply_low_rank_compensation",
+    "workaround_ort_matmul_nbits_axis0_bug",
     "quantize_attention_dynamic",
     "quantize_dynamic",
     "quantize_dynamic_matmul_integer_to_float",

--- a/onnxsim/low_rank_compensation.py
+++ b/onnxsim/low_rank_compensation.py
@@ -1,0 +1,156 @@
+"""Low-Rank Compensation (LoRC), from ZeroQuant-V2 (Yao et al., 2023,
+"ZeroQuant-V2: Exploring Post-training Quantization in LLMs from
+Comprehensive Study to Low Rank Compensation",
+https://arxiv.org/abs/2303.08302). onnxsim ports the algorithm, not any
+framework's code, per the same rationale as :mod:`onnxsim.awq`/
+:mod:`onnxsim.gptq` (DeepSpeed's own ZeroQuant implementation quantizes
+live PyTorch modules, with no ONNX export path).
+
+Every other refinement pass in onnxsim -- :mod:`onnxsim.adaround`,
+:mod:`onnxsim.awq`, :mod:`onnxsim.gptq` -- takes ``quantize_weight_only_int4``'s
+output and changes *how the weight itself gets quantized* (which bin each
+element rounds to, or a rescaling applied before quantizing). LoRC takes a
+different, much simpler angle: leave the existing INT4 quantization
+completely alone, and instead directly cancel out however much error it
+already has left over. For a quantized layer's own reconstruction error
+matrix (``float_weight - dequantized_weight``, exact and already fully
+known from the two weights -- no calibration data needed, unlike
+adaround/AWQ/GPTQ, which all need real activations), the Eckart-Young
+theorem says the best possible rank-``r`` approximation of any matrix
+(minimizing Frobenius-norm error, i.e. mean squared error) is given
+directly by that matrix's own truncated SVD -- keeping the ``r`` largest
+singular values/vectors and discarding the rest. This module computes
+that truncated SVD of each matched layer's error matrix once, offline, and
+adds the resulting rank-``r`` correction back as two small extra ``MatMul``
+nodes summed into the layer's output (``Y = X @ Wq_dequant + (X @ B) @ A``,
+``B`` shape ``[K, r]``, ``A`` shape ``[r, N]``) -- cheap relative to the
+layer's own ``O(N*K)`` matmul when ``r`` is small (the paper's own
+experiments use ``r`` on the order of a few tens), and, being a strict
+generalization (``r = min(N, K)`` recovers the exact float weight), a
+strictly-improving one: adding more rank can only reduce the compensated
+layer's reconstruction error, never increase it.
+"""
+
+from __future__ import annotations
+
+from typing import List, Union
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+
+from onnxsim.adaround import _find_int4_matmul_candidates, _node_outputs
+from onnxsim.bias_correction import _all_names, _unique_name
+
+
+def apply_low_rank_compensation(
+    float_model: Union[str, onnx.ModelProto],
+    quantized_model: Union[str, onnx.ModelProto],
+    rank: int = 8,
+) -> onnx.ModelProto:
+    """Adds a rank-``r`` low-rank correction to every
+    ``quantize_weight_only_int4``-quantized MatMul/Gemm layer present (by
+    node output name) in both ``float_model`` and ``quantized_model``,
+    canceling out that much of its existing quantization error. See this
+    module's own docstring for the technique. Needs no calibration data:
+    the correction is computed directly from the two weight tensors.
+
+    :param float_model: the original (unquantized) onnx ModelProto or file
+            path
+    :param quantized_model: a quantized version of ``float_model`` (onnx
+            ModelProto or file path), produced by
+            :func:`onnxsim.quantize_weight_only_int4`. Layers quantized by
+            any other scheme (or left unquantized) are left untouched.
+            Assumes ``quantized_model`` was produced from ``float_model``
+            without renaming any MatMul/Gemm node's own output tensor --
+            true of every onnxsim ``quantize_*`` function.
+    :param rank: the correction's rank ``r`` (clamped to
+            ``min(r, N, K)`` per layer); larger values recover more of the
+            layer's quantization error at the cost of two proportionally
+            larger extra ``MatMul`` nodes
+    :returns: ``quantized_model`` with every matched layer's output summed
+            with a new rank-``r`` correction term (two chained ``MatMul``
+            nodes plus an ``Add``); the layer's own existing INT4 weight
+            and scale are left completely untouched
+    """
+    if isinstance(float_model, str):
+        float_model = onnx.load(float_model, load_external_data=False)
+    if isinstance(quantized_model, str):
+        quantized_model = onnx.load(quantized_model, load_external_data=False)
+
+    candidates = _find_int4_matmul_candidates(float_model, quantized_model)
+    if not candidates:
+        return quantized_model
+
+    corrected = onnx.ModelProto()
+    corrected.CopyFrom(quantized_model)
+    graph = corrected.graph
+    q_init = {t.name: t for t in graph.initializer}
+    taken_names = _all_names(graph)
+    q_by_output = _node_outputs(graph)
+
+    for c in candidates:
+        wq_init = q_init[c.wq_name]
+        codes = onnx.numpy_helper.to_array(wq_init).astype(np.float64)
+        ws = onnx.numpy_helper.to_array(c.ws_init).astype(np.float64)
+        scale_full = np.repeat(ws, c.block_size, axis=c.axis)
+        slicer: List[slice] = [slice(None)] * codes.ndim
+        slicer[c.axis] = slice(0, codes.shape[c.axis])
+        w_dequant = codes * scale_full[tuple(slicer)]
+
+        w_float = onnx.numpy_helper.to_array(c.w_float_init).astype(np.float64)
+        residual = w_float - w_dequant  # original storage layout [dim0, dim1]
+        # Normalize to [K, N] -- ready for `X @ residual`, matching plain
+        # MatMul's own weight orientation -- regardless of whether the
+        # node stores its weight transposed.
+        residual_kn = residual if not c.weight_transposed else residual.T
+        k, n = residual_kn.shape
+        r = min(rank, k, n)
+        if r <= 0:
+            continue
+
+        u, s, vt = np.linalg.svd(residual_kn, full_matrices=False)
+        b_kn = (u[:, :r] * s[np.newaxis, :r]).astype(np.float32)  # [K, r]
+        a_rn = vt[:r, :].astype(np.float32)  # [r, N]
+
+        qn = q_by_output[c.output_name]
+        x_name = c.float_node.input[0]
+
+        prefix = f"{c.output_name}_lorc"
+        b_name = _unique_name(f"{prefix}_b", taken_names)
+        graph.initializer.append(onnx.numpy_helper.from_array(b_kn, name=b_name))
+        a_name = _unique_name(f"{prefix}_a", taken_names)
+        graph.initializer.append(onnx.numpy_helper.from_array(a_rn, name=a_name))
+
+        old_output = qn.output[0]
+        base_name = _unique_name(f"{prefix}_base", taken_names)
+        qn.output[0] = base_name
+
+        tmp_name = _unique_name(f"{prefix}_tmp", taken_names)
+        tmp_node = onnx.helper.make_node(
+            "MatMul",
+            [x_name, b_name],
+            [tmp_name],
+            name=_unique_name(f"{prefix}_matmul1_node", taken_names),
+        )
+        lowrank_name = _unique_name(f"{prefix}_lowrank", taken_names)
+        lowrank_node = onnx.helper.make_node(
+            "MatMul",
+            [tmp_name, a_name],
+            [lowrank_name],
+            name=_unique_name(f"{prefix}_matmul2_node", taken_names),
+        )
+        add_node = onnx.helper.make_node(
+            "Add",
+            [base_name, lowrank_name],
+            [old_output],
+            name=_unique_name(f"{prefix}_add_node", taken_names),
+        )
+
+        node_idx = next(i for i, nd in enumerate(graph.node) if nd is qn)
+        graph.node.insert(node_idx + 1, tmp_node)
+        graph.node.insert(node_idx + 2, lowrank_node)
+        graph.node.insert(node_idx + 3, add_node)
+
+    return corrected

--- a/onnxsim/ort_matmul_nbits_workaround.py
+++ b/onnxsim/ort_matmul_nbits_workaround.py
@@ -1,0 +1,194 @@
+"""Workaround for an ONNX Runtime graph-optimizer bug (reproduced against
+onnxruntime 1.29.0; not yet confirmed fixed in later releases -- check
+before assuming this module is still needed) that silently miscomputes
+``axis=0`` block-quantized ``DequantizeLinear`` feeding a plain (i.e. not
+``Gemm transB=1``) MatMul/Gemm, under ONNX Runtime's *default* graph
+optimization settings.
+
+Every onnxsim INT4 weight-only scheme built on ``DequantizeLinear`` +
+MatMul/Gemm -- :func:`onnxsim.quantize_weight_only_int4` itself, and
+everything that refines its output in place (:func:`onnxsim.apply_adaround`,
+:func:`onnxsim.apply_awq`, :func:`onnxsim.apply_gptq`,
+:func:`onnxsim.apply_autoround`), plus :func:`onnxsim.quantize_weight_only_int4_hqq`,
+which builds its own analogous ``DequantizeLinear`` -- picks
+``axis = 0`` for a *plain* (not ``transB=1``) MatMul/Gemm weight, keeping
+the weight in its natural ``[K, N]`` storage layout with no ``Transpose``
+node needed (see ``passes/weight_only_quantize_int4_matmul.h``'s own
+``channel_axis``/``reduction_axis`` comment). That choice is fully
+ONNX-spec-compliant -- ``DequantizeLinear``'s ``axis`` attribute is
+documented to support any axis -- but at ONNX Runtime's default graph
+optimization level (``ORT_ENABLE_EXTENDED``/``ORT_ENABLE_ALL``, i.e.
+level 2+), its ``MatMulNBitsFusion`` transformer fuses ``DequantizeLinear
++ MatMul`` into the ``com.microsoft.MatMulNBits`` contrib op *without
+checking the ``axis`` attribute first*. ``MatMulNBits`` has no ``axis``
+parameter of its own at all -- ONNX Runtime's own documentation describes
+it as equivalent to ``DequantizeLinear + Transpose + MatMul``, i.e. it
+only supports the ``axis = 1`` (one scale block per output row) layout.
+Fusing an ``axis = 0`` graph into it silently reinterprets the weight
+data as if it used that other layout, producing wrong results -- verified
+by comparing the same model run with ``ORT_DISABLE_ALL``/``ORT_ENABLE_BASIC``
+(correct, matches the float model almost exactly) against
+``ORT_ENABLE_EXTENDED``/``ORT_ENABLE_ALL`` (matches
+``ORT_DISABLE_ALL``'s number of blocks apart, i.e. wrong; the ``axis = 1``
+-- ``Gemm transB=1`` -- path is unaffected at every level).
+
+This module works around it by finding every ``axis = 0`` DequantizeLinear
+feeding a plain MatMul/Gemm and rewriting it to the ``axis = 1`` shape the
+fusion actually supports: transpose the (already-quantized, packed) INT4/
+UINT4 codes, scale, and optional zero-point tensors themselves -- an exact,
+lossless re-indexing, not a requantization -- into a new ``DequantizeLinear
+(axis=1)`` followed by an explicit ``Transpose`` back to the original
+layout, functionally identical to what a genuinely ``transB=1``-stored
+weight would already look like. Verified empirically that ONNX Runtime's
+optimizer no longer misfires ``MatMulNBitsFusion`` on this shape (a
+different, correct fusion -- folding the ``Transpose`` into the following
+MatMul -- applies instead), and that the result is numerically identical
+with graph optimizations enabled or disabled.
+
+This is deliberately a standalone, opt-in post-processing pass rather than
+a change to the underlying quantizers' own default output: it leaves
+every existing ``quantize_weight_only_int4``/AWQ/GPTQ/AdaRound/AutoRound/
+HQQ model's own emitted format untouched unless you explicitly call it,
+and is meant to be applied once, right before deployment, to any onnxsim
+INT4-quantized model that will be run under ONNX Runtime's default
+optimization settings.
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+
+from onnxsim.bias_correction import _all_names, _unique_name
+
+
+def _match_plain_weight_dequantize_linear(node: onnx.NodeProto):
+    """Returns the weight input's own name for a MatMul, or a Gemm with
+    ``transA=0``, ``alpha=1``, ``beta=1`` (if it has a bias) and
+    ``transB=0`` -- the "plain" (not already ``transB=1``-transposed)
+    layout that :func:`onnxsim.quantize_weight_only_int4` and friends
+    quantize with ``axis=0``. Returns ``None`` for anything else,
+    including an explicitly ``transB=1`` Gemm (that path uses ``axis=1``
+    already and isn't affected by the bug this module works around).
+    """
+    attrs = {a.name: a for a in node.attribute}
+    if node.op_type == "MatMul":
+        if len(node.input) != 2:
+            return None
+        return node.input[1]
+    if node.op_type == "Gemm":
+        num_inputs = len(node.input)
+        if num_inputs not in (2, 3):
+            return None
+        trans_a = attrs.get("transA")
+        if trans_a is not None and trans_a.i != 0:
+            return None
+        alpha = attrs.get("alpha")
+        if alpha is not None and alpha.f != 1.0:
+            return None
+        if num_inputs == 3:
+            beta = attrs.get("beta")
+            if beta is not None and beta.f != 1.0:
+                return None
+        trans_b = attrs.get("transB")
+        if trans_b is not None and trans_b.i:
+            return None  # already axis=1; not affected
+        return node.input[1]
+    return None
+
+
+def workaround_ort_matmul_nbits_axis0_bug(
+    model: Union[str, onnx.ModelProto],
+) -> onnx.ModelProto:
+    """Rewrites every ``axis=0`` block-quantized ``DequantizeLinear``
+    feeding a plain (not ``transB=1``) MatMul/Gemm into the ``axis=1``
+    form ONNX Runtime's ``MatMulNBitsFusion`` transformer actually
+    supports, avoiding the wrong results it silently produces for
+    ``axis=0`` under default graph optimization settings. See this
+    module's own docstring for the full story.
+
+    :param model: an onnx ModelProto or file path, already quantized by
+            :func:`onnxsim.quantize_weight_only_int4` (or anything built
+            on it: :func:`onnxsim.apply_adaround`, :func:`onnxsim.apply_awq`,
+            :func:`onnxsim.apply_gptq`, :func:`onnxsim.apply_autoround`,
+            :func:`onnxsim.quantize_weight_only_int4_hqq`)
+    :returns: ``model`` with every matched layer's weight input rewired to
+            a new, transposed ``DequantizeLinear(axis=1)`` followed by a
+            ``Transpose`` back to the original layout; the original
+            ``DequantizeLinear`` and its own Wq/Ws/Wz initializers are left
+            in place (unused, but not pruned, matching every onnxsim
+            ``quantize_*``/``apply_*`` pass's own convention of never
+            deleting a tensor it no longer needs). Layers whose weight
+            isn't fed by a 2- or 3-input ``axis=0`` blockwise
+            ``DequantizeLinear`` are left untouched.
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    graph = out.graph
+    initializer_map = {t.name: t for t in graph.initializer}
+    taken_names = _all_names(graph)
+    dq_by_output = {
+        n.output[0]: n for n in graph.node if n.op_type == "DequantizeLinear"
+    }
+
+    for node in list(graph.node):
+        w_name = _match_plain_weight_dequantize_linear(node)
+        if w_name is None:
+            continue
+        dq = dq_by_output.get(w_name)
+        if dq is None or len(dq.input) not in (2, 3):
+            continue
+        axis = next((a.i for a in dq.attribute if a.name == "axis"), None)
+        block_size = next((a.i for a in dq.attribute if a.name == "block_size"), None)
+        if axis != 0 or not block_size:
+            continue
+
+        transposed_inputs = []
+        for inp_name in dq.input:
+            t = initializer_map.get(inp_name)
+            if t is None:
+                break
+            arr = onnx.numpy_helper.to_array(t)
+            if arr.ndim != 2:
+                break
+            new_name = _unique_name(f"{inp_name}_axis1", taken_names)
+            graph.initializer.append(
+                onnx.numpy_helper.from_array(np.ascontiguousarray(arr.T), name=new_name)
+            )
+            transposed_inputs.append(new_name)
+        if len(transposed_inputs) != len(dq.input):
+            continue  # a required initializer was missing or not 2-D; skip
+
+        dq_out_nk = _unique_name(f"{w_name}_axis1_dq", taken_names)
+        new_dq = onnx.helper.make_node(
+            "DequantizeLinear",
+            transposed_inputs,
+            [dq_out_nk],
+            name=_unique_name(f"{w_name}_axis1_dq_node", taken_names),
+            axis=1,
+            block_size=block_size,
+        )
+        transposed_out = _unique_name(f"{w_name}_axis1_transposed", taken_names)
+        transpose_node = onnx.helper.make_node(
+            "Transpose",
+            [dq_out_nk],
+            [transposed_out],
+            name=_unique_name(f"{w_name}_axis1_transpose_node", taken_names),
+            perm=[1, 0],
+        )
+
+        node_idx = next(i for i, n in enumerate(graph.node) if n is node)
+        graph.node.insert(node_idx, new_dq)
+        graph.node.insert(node_idx + 1, transpose_node)
+        for i, inp in enumerate(node.input):
+            if inp == w_name:
+                node.input[i] = transposed_out
+
+    return out

--- a/tests/test_low_rank_compensation.py
+++ b/tests/test_low_rank_compensation.py
@@ -1,0 +1,166 @@
+"""Tests for ``onnxsim.apply_low_rank_compensation`` (LoRC, from
+ZeroQuant-V2, see ``onnxsim/low_rank_compensation.py``) -- adds a
+truncated-SVD rank-``r`` correction of a quantized layer's own existing
+reconstruction error (``float_weight - dequantized_weight``), computed
+directly from the two weights with no calibration data.
+"""
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _model(nodes, inputs, outputs, initializer, opset=21):
+    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+    )
+
+
+def _matmul_model(K=64, N=16, seed=0):
+    rng = np.random.default_rng(seed)
+    weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    return _model(
+        nodes, [_vi("X", ["batch", K])], [_vi("Y", ["batch", N])], [_f32(weight, "W")]
+    )
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
+
+
+def test_lorc_reduces_reconstruction_error():
+    model = _matmul_model(K=64, N=16, seed=0)
+    quant = onnxsim.quantize_weight_only_int4(model)
+    rng = np.random.default_rng(1)
+    x = rng.standard_normal((32, 64)).astype(np.float32)
+
+    lorc_model = onnxsim.apply_low_rank_compensation(model, quant, rank=8)
+    onnx.checker.check_model(lorc_model)
+
+    # A correction was actually inserted -- otherwise this is just
+    # re-testing plain RTN.
+    op_types = [n.op_type for n in lorc_model.graph.node]
+    assert op_types.count("MatMul") == 3  # base + the two correction matmuls
+
+    (float_y,) = _run(model, {"X": x})
+    (rtn_y,) = _run(quant, {"X": x})
+    (lorc_y,) = _run(lorc_model, {"X": x})
+    rtn_err = np.linalg.norm(float_y.astype(np.float64) - rtn_y.astype(np.float64))
+    lorc_err = np.linalg.norm(float_y.astype(np.float64) - lorc_y.astype(np.float64))
+    assert lorc_err < rtn_err
+
+
+def test_lorc_higher_rank_never_increases_error():
+    # Eckart-Young: a larger truncation rank can only capture more of the
+    # residual's own energy, never less -- so reconstruction error must be
+    # monotonically non-increasing as rank grows.
+    model = _matmul_model(K=64, N=16, seed=2)
+    quant = onnxsim.quantize_weight_only_int4(model)
+    rng = np.random.default_rng(3)
+    x = rng.standard_normal((32, 64)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x})
+
+    errors = []
+    for rank in (1, 4, 8, 16):
+        lorc_model = onnxsim.apply_low_rank_compensation(model, quant, rank=rank)
+        (y,) = _run(lorc_model, {"X": x})
+        errors.append(np.linalg.norm(float_y.astype(np.float64) - y.astype(np.float64)))
+
+    assert all(errors[i] >= errors[i + 1] - 1e-6 for i in range(len(errors) - 1))
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Not a bug in apply_low_rank_compensation: onnxruntime 1.29.0's "
+        "default graph optimization level (>= ORT_ENABLE_EXTENDED) "
+        "silently miscomputes axis=0 block-quantized DequantizeLinear "
+        "feeding a plain (non-transposed) MatMul, independent of this "
+        "module -- reproduces on quantize_weight_only_int4's own output "
+        "with no LoRC correction involved at all, and disappears with "
+        "graph optimizations disabled or on the axis=1 (Gemm transB=1) "
+        "path. See the PR discussion for the full repro."
+    ),
+    strict=False,
+)
+def test_lorc_exact_at_full_rank():
+    # rank = min(K, N) recovers the residual exactly, so the compensated
+    # layer should reproduce the float model almost exactly (up to
+    # fp32/SVD numerical precision) -- true when run with graph
+    # optimizations disabled; see the xfail reason above.
+    K, N = 32, 16
+    model = _matmul_model(K=K, N=N, seed=4)
+    quant = onnxsim.quantize_weight_only_int4(model)
+    rng = np.random.default_rng(5)
+    x = rng.standard_normal((16, K)).astype(np.float32)
+
+    lorc_model = onnxsim.apply_low_rank_compensation(model, quant, rank=min(K, N))
+    (float_y,) = _run(model, {"X": x})
+    (lorc_y,) = _run(lorc_model, {"X": x})
+    assert _rel_l2(float_y, lorc_y) < 1e-4
+
+
+def test_lorc_output_stays_close_to_float_via_onnxruntime():
+    model = _matmul_model(K=64, N=16, seed=6)
+    quant = onnxsim.quantize_weight_only_int4(model)
+    rng = np.random.default_rng(7)
+    x = rng.standard_normal((16, 64)).astype(np.float32)
+
+    lorc_model = onnxsim.apply_low_rank_compensation(model, quant, rank=8)
+    onnx.checker.check_model(lorc_model)
+
+    (float_y,) = _run(model, {"X": x})
+    (lorc_y,) = _run(lorc_model, {"X": x})
+    assert np.all(np.isfinite(lorc_y))
+    assert _rel_l2(float_y, lorc_y) < 0.25
+
+
+def test_lorc_gemm_transb():
+    rng = np.random.default_rng(8)
+    K, N = 48, 12
+    weight = rng.standard_normal((N, K)).astype(np.float32) * 0.5
+    nodes = [onnx.helper.make_node("Gemm", ["X", "W"], ["Y"], transB=1)]
+    model = _model(
+        nodes, [_vi("X", ["batch", K])], [_vi("Y", ["batch", N])], [_f32(weight, "W")]
+    )
+    quant = onnxsim.quantize_weight_only_int4(model)
+    onnx.checker.check_model(quant)
+
+    x = rng.standard_normal((8, K)).astype(np.float32)
+    lorc_model = onnxsim.apply_low_rank_compensation(model, quant, rank=6)
+    onnx.checker.check_model(lorc_model)
+
+    (float_y,) = _run(model, {"X": x})
+    (lorc_y,) = _run(lorc_model, {"X": x})
+    assert _rel_l2(float_y, lorc_y) < 0.25
+
+
+def test_lorc_noop_when_no_int4_matmul_present():
+    nodes = [onnx.helper.make_node("Relu", ["X"], ["Y"])]
+    model = _model(nodes, [_vi("X", [4, 4])], [_vi("Y", [4, 4])], [])
+    result = onnxsim.apply_low_rank_compensation(model, model, rank=4)
+    assert result.SerializeToString() == model.SerializeToString()

--- a/tests/test_low_rank_compensation.py
+++ b/tests/test_low_rank_compensation.py
@@ -94,24 +94,17 @@ def test_lorc_higher_rank_never_increases_error():
     assert all(errors[i] >= errors[i + 1] - 1e-6 for i in range(len(errors) - 1))
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Not a bug in apply_low_rank_compensation: onnxruntime 1.29.0's "
-        "default graph optimization level (>= ORT_ENABLE_EXTENDED) "
-        "silently miscomputes axis=0 block-quantized DequantizeLinear "
-        "feeding a plain (non-transposed) MatMul, independent of this "
-        "module -- reproduces on quantize_weight_only_int4's own output "
-        "with no LoRC correction involved at all, and disappears with "
-        "graph optimizations disabled or on the axis=1 (Gemm transB=1) "
-        "path. See the PR discussion for the full repro."
-    ),
-    strict=False,
-)
 def test_lorc_exact_at_full_rank():
     # rank = min(K, N) recovers the residual exactly, so the compensated
     # layer should reproduce the float model almost exactly (up to
-    # fp32/SVD numerical precision) -- true when run with graph
-    # optimizations disabled; see the xfail reason above.
+    # fp32/SVD numerical precision). Requires
+    # workaround_ort_matmul_nbits_axis0_bug: onnxruntime 1.29.0's default
+    # graph optimization level otherwise silently miscomputes axis=0
+    # block-quantized DequantizeLinear feeding a plain (non-transposed)
+    # MatMul -- a bug in quantize_weight_only_int4's own output, not in
+    # apply_low_rank_compensation, but one this exact-reconstruction
+    # property is precise enough to notice (see
+    # onnxsim/ort_matmul_nbits_workaround.py's own docstring).
     K, N = 32, 16
     model = _matmul_model(K=K, N=N, seed=4)
     quant = onnxsim.quantize_weight_only_int4(model)
@@ -119,8 +112,9 @@ def test_lorc_exact_at_full_rank():
     x = rng.standard_normal((16, K)).astype(np.float32)
 
     lorc_model = onnxsim.apply_low_rank_compensation(model, quant, rank=min(K, N))
+    fixed = onnxsim.workaround_ort_matmul_nbits_axis0_bug(lorc_model)
     (float_y,) = _run(model, {"X": x})
-    (lorc_y,) = _run(lorc_model, {"X": x})
+    (lorc_y,) = _run(fixed, {"X": x})
     assert _rel_l2(float_y, lorc_y) < 1e-4
 
 

--- a/tests/test_ort_matmul_nbits_workaround.py
+++ b/tests/test_ort_matmul_nbits_workaround.py
@@ -1,0 +1,186 @@
+"""Tests for ``onnxsim.workaround_ort_matmul_nbits_axis0_bug`` (see
+``onnxsim/ort_matmul_nbits_workaround.py``) -- rewrites an ``axis=0``
+block-quantized ``DequantizeLinear`` feeding a plain MatMul/Gemm into the
+``axis=1`` shape ONNX Runtime's ``MatMulNBitsFusion`` transformer actually
+supports, so it no longer silently miscomputes the layer under ONNX
+Runtime's default graph optimization settings.
+
+These tests specifically exercise *default* onnxruntime optimization
+(the whole point of the workaround), unlike every other onnxsim test file,
+which doesn't care about optimization level since it doesn't hit this bug.
+"""
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _model(nodes, inputs, outputs, initializer, opset=21):
+    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+    )
+
+
+def _matmul_model(K=32, N=16, seed=0):
+    rng = np.random.default_rng(seed)
+    weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    return _model(
+        nodes, [_vi("X", ["batch", K])], [_vi("Y", ["batch", N])], [_f32(weight, "W")]
+    )
+
+
+def _run(model, feeds, disable_optimizations=False):
+    so = ort.SessionOptions()
+    if disable_optimizations:
+        so.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL
+    sess = ort.InferenceSession(
+        model.SerializeToString(), sess_options=so, providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
+
+
+def test_workaround_fixes_default_optimization_for_plain_matmul():
+    K, N = 32, 16
+    model = _matmul_model(K=K, N=N, seed=0)
+    quant = onnxsim.quantize_weight_only_int4(model)
+
+    dq_node = next(n for n in quant.graph.node if n.op_type == "DequantizeLinear")
+    axis = next(a.i for a in dq_node.attribute if a.name == "axis")
+    assert axis == 0  # the vulnerable case this workaround targets
+
+    rng = np.random.default_rng(1)
+    x = rng.standard_normal((8, K)).astype(np.float32)
+
+    # The bug: same model, same weights, differs between default
+    # optimization and optimizations disabled -- this is the ground truth
+    # this test is guarding against, not a property of the fix itself.
+    (y_buggy_default,) = _run(quant, {"X": x})
+    (y_correct_reference,) = _run(quant, {"X": x}, disable_optimizations=True)
+    assert not np.allclose(y_buggy_default, y_correct_reference, rtol=0, atol=1e-3)
+
+    fixed = onnxsim.workaround_ort_matmul_nbits_axis0_bug(quant)
+    onnx.checker.check_model(fixed)
+    (y_fixed_default,) = _run(fixed, {"X": x})
+    assert np.allclose(
+        y_fixed_default.astype(np.float64),
+        y_correct_reference.astype(np.float64),
+        rtol=0,
+        atol=1e-4,
+    )
+
+
+def test_workaround_inserts_axis1_dequantize_and_transpose():
+    model = _matmul_model(K=32, N=16, seed=2)
+    quant = onnxsim.quantize_weight_only_int4(model)
+    fixed = onnxsim.workaround_ort_matmul_nbits_axis0_bug(quant)
+
+    dq_nodes = [n for n in fixed.graph.node if n.op_type == "DequantizeLinear"]
+    assert len(dq_nodes) == 2  # original (now unused) + the new axis=1 one
+    axes = [
+        n for n in dq_nodes if any(a.name == "axis" and a.i == 1 for a in n.attribute)
+    ]
+    assert len(axes) == 1
+    assert any(n.op_type == "Transpose" for n in fixed.graph.node)
+
+
+def test_workaround_noop_on_gemm_transb1():
+    # axis=1 already -- not affected by the bug, nothing to rewrite.
+    rng = np.random.default_rng(3)
+    K, N = 32, 12
+    weight = rng.standard_normal((N, K)).astype(np.float32) * 0.5
+    nodes = [onnx.helper.make_node("Gemm", ["X", "W"], ["Y"], transB=1)]
+    model = _model(
+        nodes, [_vi("X", ["batch", K])], [_vi("Y", ["batch", N])], [_f32(weight, "W")]
+    )
+    quant = onnxsim.quantize_weight_only_int4(model)
+    dq_node = next(n for n in quant.graph.node if n.op_type == "DequantizeLinear")
+    axis = next(a.i for a in dq_node.attribute if a.name == "axis")
+    assert axis == 1
+
+    fixed = onnxsim.workaround_ort_matmul_nbits_axis0_bug(quant)
+    assert fixed.SerializeToString() == quant.SerializeToString()
+
+
+def test_workaround_noop_when_no_matmul_present():
+    nodes = [onnx.helper.make_node("Relu", ["X"], ["Y"])]
+    model = _model(nodes, [_vi("X", [4, 4])], [_vi("Y", [4, 4])], [])
+    result = onnxsim.workaround_ort_matmul_nbits_axis0_bug(model)
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_workaround_handles_hqq_three_input_dequantize_linear():
+    # HQQ's DequantizeLinear has a zero-point (Wq, Ws, Wz) -- confirm all
+    # three tensors get transposed together, not just Wq/Ws.
+    K, N = 32, 8
+    model = _matmul_model(K=K, N=N, seed=4)
+    rng = np.random.default_rng(5)
+    x = rng.standard_normal((16, K)).astype(np.float32)
+
+    quant = onnxsim.quantize_weight_only_int4_hqq(model, block_size=32)
+    dq_node = next(n for n in quant.graph.node if n.op_type == "DequantizeLinear")
+    assert len(dq_node.input) == 3
+    axis = next(a.i for a in dq_node.attribute if a.name == "axis")
+    assert axis == 0
+
+    (y_buggy_default,) = _run(quant, {"X": x})
+    (y_correct_reference,) = _run(quant, {"X": x}, disable_optimizations=True)
+
+    fixed = onnxsim.workaround_ort_matmul_nbits_axis0_bug(quant)
+    onnx.checker.check_model(fixed)
+    (y_fixed_default,) = _run(fixed, {"X": x})
+    assert np.allclose(
+        y_fixed_default.astype(np.float64),
+        y_correct_reference.astype(np.float64),
+        rtol=0,
+        atol=1e-4,
+    )
+
+
+def test_workaround_applies_transparently_to_awq_refined_model():
+    # AWQ only rewrites Wq/Ws' own values, not the DequantizeLinear's axis
+    # -- confirm the workaround still finds and fixes it downstream.
+    K, N = 32, 16
+    model = _matmul_model(K=K, N=N, seed=6)
+    rng = np.random.default_rng(7)
+    x = rng.standard_normal((16, K)).astype(np.float32)
+    for c in (3, 7):
+        x[:, c] *= 20.0
+    calibration_data = [{"X": x}]
+
+    quant = onnxsim.quantize_weight_only_int4(model)
+    awq_model = onnxsim.apply_awq(model, quant, calibration_data=calibration_data)
+
+    (y_buggy_default,) = _run(awq_model, {"X": x})
+    (y_correct_reference,) = _run(awq_model, {"X": x}, disable_optimizations=True)
+
+    fixed = onnxsim.workaround_ort_matmul_nbits_axis0_bug(awq_model)
+    onnx.checker.check_model(fixed)
+    (y_fixed_default,) = _run(fixed, {"X": x})
+    assert np.allclose(
+        y_fixed_default.astype(np.float64),
+        y_correct_reference.astype(np.float64),
+        rtol=0,
+        atol=1e-4,
+    )


### PR DESCRIPTION
## Summary

Two things landed together on this branch:

1. **`apply_low_rank_compensation`** -- ports Low-Rank Compensation (LoRC) from ZeroQuant-V2 (Yao et al., 2023, ["ZeroQuant-V2"](https://arxiv.org/abs/2303.08302)).
2. **`workaround_ort_matmul_nbits_axis0_bug`** -- works around a real ONNX Runtime graph-optimizer bug discovered while validating (1).

## Part 1: `apply_low_rank_compensation`

Every other refinement pass in onnxsim (`apply_adaround`, `apply_awq`, `apply_gptq`) changes *how* a layer's existing INT4 quantization is computed. LoRC does something simpler: leave the quantization alone, and directly cancel out whatever reconstruction error (`float_weight - dequantized_weight`) it already has left over. That error matrix is exactly known (no calibration data needed, unlike adaround/AWQ/GPTQ), so by the Eckart-Young theorem, its own truncated SVD gives the *provably optimal* rank-`r` correction. This module computes that SVD once, offline, per layer, and adds the result back as two small extra `MatMul` nodes (`Y = X @ Wq_dequant + (X @ B) @ A`) -- cheap when `r` is small, and a strict generalization (`r = min(N,K)` recovers the exact float weight).

### Verification
- `test_lorc_higher_rank_never_increases_error`: confirms the Eckart-Young monotonicity property directly.
- `test_lorc_exact_at_full_rank`: confirms full-rank recovers the float model almost exactly (this is the test that surfaced the ORT bug below).
- Further tests cover `Gemm transB=1` and the no-op case.

## Part 2: `workaround_ort_matmul_nbits_axis0_bug`

While validating LoRC's "exact at full rank" property, I found the reconstruction was off by ~0.5% under default `onnxruntime` settings, even though the underlying math (verified independently in float64) was exact. Root cause, confirmed by dumping the post-optimization graph via `session_options.optimized_model_filepath`:

- `quantize_weight_only_int4` (and everything built on it: `apply_adaround`/`apply_awq`/`apply_gptq`/`apply_autoround`, plus `quantize_weight_only_int4_hqq`) uses `axis=0` block quantization for a plain (non-`transB=1`) MatMul/Gemm weight -- a legitimate, spec-compliant choice that keeps the weight in its natural `[K,N]` layout without needing a `Transpose` node.
- At ONNX Runtime's **default** graph optimization level (`ORT_ENABLE_EXTENDED`/`ORT_ENABLE_ALL`, i.e. level 2+), its `MatMulNBitsFusion` transformer fuses `DequantizeLinear + MatMul` into the `com.microsoft.MatMulNBits` contrib op *without checking the `axis` attribute*. `MatMulNBits` has no `axis` parameter at all -- ONNX Runtime's own docs describe it as equivalent to `DequantizeLinear + Transpose + MatMul`, i.e. it only supports `axis=1` (row-blocked) semantics. Fusing an `axis=0` graph silently reinterprets the weight under the wrong layout.
- Confirmed with a minimal repro (`DequantizeLinear(axis=0) -> MatMul -> Add`, no LoRC involved) that the discrepancy exists on `quantize_weight_only_int4`'s own output, appears exactly at optimization level `ORT_ENABLE_EXTENDED`, and disappears with optimizations disabled or on the `axis=1` (`Gemm transB=1`) path, which is unaffected at every level. Tested against onnxruntime 1.29.0.

`workaround_ort_matmul_nbits_axis0_bug` finds every `axis=0` `DequantizeLinear` feeding a plain MatMul/Gemm and losslessly transposes its packed INT4/UINT4 codes, scale, and optional zero-point (`onnx.numpy_helper.to_array`/`from_array` round-trip the special INT4/UINT4 dtypes cleanly, no manual bit-packing needed) into a new `DequantizeLinear(axis=1)` + `Transpose` -- the exact shape ORT's own docs say `MatMulNBits` is equivalent to. Verified: with this rewrite, `MatMulNBitsFusion` no longer misfires (a different, correct fusion -- folding the `Transpose` into the following MatMul -- applies instead), and the result is numerically identical with graph optimizations on or off.

This is a standalone, **opt-in** post-processing pass -- it doesn't change any existing quantizer's default output, only offers a fix-up callers can apply right before deployment if they're worried about default ORT settings.

### Verification
- `test_workaround_fixes_default_optimization_for_plain_matmul`: first proves the bug exists (default-optimized output differs from optimizations-disabled output on the *unfixed* model), then proves the workaround closes that gap.
- `test_workaround_handles_hqq_three_input_dequantize_linear`: confirms the 3-input (with zero-point) case is handled, not just plain symmetric INT4.
- `test_workaround_applies_transparently_to_awq_refined_model`: confirms it finds and fixes the pattern downstream of AWQ's own refinement, without needing AWQ-specific knowledge.
- `test_workaround_noop_on_gemm_transb1` / `test_workaround_noop_when_no_matmul_present`: no-op cases.
- `test_low_rank_compensation.py::test_lorc_exact_at_full_rank` now applies the workaround and passes for real (was previously `xfail` while this was under investigation).

### What this doesn't do
This doesn't change `quantize_weight_only_int4`'s own default output, and it's not a fix to ONNX Runtime itself -- that's a genuine upstream bug. Filing that report separately.

## Verification (both parts together)

Full regression sweep (`tests/`, `CI=1` to skip the repo's own multi-hundred-MB+ memory-gated tests, torch/timm-dependent modules not installed here excluded): **628 passed, 76 skipped, 0 failures caused by this change** (the only failures/errors present are pre-existing `ModuleNotFoundError: No module named 'onnxscript'` in unrelated test files). `ruff format` / `ruff check` / `mypy` clean (mypy's pre-existing 16 errors in other files are unchanged; neither new module introduces any).

## New files

- `onnxsim/low_rank_compensation.py`, `tests/test_low_rank_compensation.py` -- 6 tests
- `onnxsim/ort_matmul_nbits_workaround.py`, `tests/test_ort_matmul_nbits_workaround.py` -- 6 tests

## Test plan

- [x] `pytest tests/test_low_rank_compensation.py tests/test_ort_matmul_nbits_workaround.py -v`
- [x] Full `tests/` sweep with `CI=1`
- [x] `ruff format` / `ruff check` / `mypy`

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_