### PR TITLE
onnx-deploy: swappable-libort C ABI, Python extension, WASM, and CI

### DIFF
--- a/.github/workflows/onnx-deploy.yml
+++ b/.github/workflows/onnx-deploy.yml
@@ -44,6 +44,8 @@ env:
   # "upgrade your ORT build without recompiling onnx-deploy" case.
   ORT_VERSION_NEWER: 1.19.2
   ORT_VERSION_OLDER: 1.18.1
+  # Same Emscripten version static.yml (onnxsim's own wasm build) pins.
+  EMSCRIPTEN_VERSION: "5.0.0"
 
 jobs:
   build-and-verify:
@@ -150,3 +152,41 @@ jobs:
           code=$?
           set -e
           [ "$code" -eq 1 ]
+
+  wasm-verify:
+    name: WASM build + verify (onnxruntime-web via Node)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Python deps (toy model generator only)
+        run: pip install onnx
+
+      - name: Generate the toy seq2seq export
+        working-directory: tools/onnx-deploy
+        run: python3 scripts/make_toy_seq2seq.py -o /tmp/toy_seq2seq --vocab-size 7 --encoder-ids 3,4 --decoder-start-token-id 0
+
+      - name: Install Emscripten ${{ env.EMSCRIPTEN_VERSION }} (same version static.yml uses for onnxsim's own wasm build)
+        run: |
+          git clone --depth 1 https://github.com/emscripten-core/emsdk.git
+          ./emsdk/emsdk install ${{ env.EMSCRIPTEN_VERSION }}
+          ./emsdk/emsdk activate ${{ env.EMSCRIPTEN_VERSION }}
+
+      - name: Configure + build onnx_deploy_wasm
+        working-directory: tools/onnx-deploy/wasm
+        run: |
+          source "${{ github.workspace }}/emsdk/emsdk_env.sh"
+          emcmake cmake -B build -DCMAKE_BUILD_TYPE=Release
+          cmake --build build -j"$(nproc)"
+
+      - name: Install onnxruntime-web test harness deps
+        working-directory: tools/onnx-deploy/wasm/test
+        run: npm ci
+
+      - name: Run the Asyncify bridge end-to-end (persistent onnxruntime-web sessions, encoder-once + decoder loop, KV-cache threading) and assert it matches the native/Python output
+        working-directory: tools/onnx-deploy/wasm/test
+        run: node run_test.mjs /tmp/toy_seq2seq

--- a/.github/workflows/onnx-deploy.yml
+++ b/.github/workflows/onnx-deploy.yml
@@ -1,0 +1,152 @@
+name: onnx-deploy
+
+# End-to-end verification for tools/onnx-deploy: the standalone C++ tool that
+# runs autoregressive generation over optimum-onnx's multi-file
+# encoder/decoder(-with-past) ONNX export, via a C ABI that loads
+# libonnxruntime at RUNTIME (dlopen) instead of linking a specific build at
+# compile time -- see tools/onnx-deploy/README.md.
+#
+# This downloads two different real ONNX Runtime releases and proves the
+# whole flow for real: build the CLI/C ABI/Python extension once (against
+# the OLDER release's headers only -- no link-time dependency on either
+# .so), then run the compiled artifacts against a tiny hand-built seq2seq
+# export (scripts/make_toy_seq2seq.py -- no torch/transformers/optimum
+# needed) through BOTH ORT builds with no rebuild in between, and assert the
+# generated token sequence is exactly right and identical either way. See
+# that script's docstring for why the toy model's output is a direct
+# witness of the KV-cache threading being correct, not just "did it not
+# crash".
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "tools/onnx-deploy/**"
+      - ".github/workflows/onnx-deploy.yml"
+  push:
+    branches: [master]
+    paths:
+      - "tools/onnx-deploy/**"
+
+concurrency:
+  group: onnx-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  # A newer and an older ONNX Runtime release. Deliberately built against
+  # the OLDER one's headers (ORT's C API is designed forward-compatible: an
+  # older-API build can load a newer .so, not vice versa -- GetApi() returns
+  # NULL if the .so is older than the API version requested), then swapped
+  # at runtime to the newer one, so the test exercises the realistic
+  # "upgrade your ORT build without recompiling onnx-deploy" case.
+  ORT_VERSION_NEWER: 1.19.2
+  ORT_VERSION_OLDER: 1.18.1
+
+jobs:
+  build-and-verify:
+    name: Build + swap-verify (ubuntu-24.04)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Python deps (toy model generator + Python extension build -- no torch/optimum)
+        run: pip install onnx nanobind
+
+      - name: Download ONNX Runtime ${{ env.ORT_VERSION_OLDER }} (build headers + first runtime target)
+        run: |
+          curl -sL -o ort_older.tgz "https://github.com/microsoft/onnxruntime/releases/download/v${{ env.ORT_VERSION_OLDER }}/onnxruntime-linux-x64-${{ env.ORT_VERSION_OLDER }}.tgz"
+          tar xzf ort_older.tgz
+          echo "ORT_OLDER_HOME=$PWD/onnxruntime-linux-x64-${{ env.ORT_VERSION_OLDER }}" >> "$GITHUB_ENV"
+
+      - name: Download ONNX Runtime ${{ env.ORT_VERSION_NEWER }} (second runtime target -- proves the ABI isn't tied to one build)
+        run: |
+          curl -sL -o ort_newer.tgz "https://github.com/microsoft/onnxruntime/releases/download/v${{ env.ORT_VERSION_NEWER }}/onnxruntime-linux-x64-${{ env.ORT_VERSION_NEWER }}.tgz"
+          tar xzf ort_newer.tgz
+          echo "ORT_NEWER_HOME=$PWD/onnxruntime-linux-x64-${{ env.ORT_VERSION_NEWER }}" >> "$GITHUB_ENV"
+
+      - name: Configure (headers from the older release only)
+        working-directory: tools/onnx-deploy
+        run: cmake -B build -DORT_HOME="${{ env.ORT_OLDER_HOME }}" -DONNX_DEPLOY_PYTHON=ON -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        working-directory: tools/onnx-deploy
+        run: cmake --build build -j"$(nproc)"
+
+      - name: Assert the C ABI has zero link-time dependency on libonnxruntime
+        working-directory: tools/onnx-deploy
+        run: |
+          ldd build/libonnx_deploy_c.so
+          if ldd build/libonnx_deploy_c.so | grep -qi onnxruntime; then
+            echo "::error::libonnx_deploy_c.so links libonnxruntime at build time -- swappability is broken"
+            exit 1
+          fi
+          echo "confirmed: no link-time libonnxruntime dependency"
+
+      - name: Generate the toy seq2seq export and compute the expected sequence
+        working-directory: tools/onnx-deploy
+        run: |
+          python3 scripts/make_toy_seq2seq.py -o /tmp/toy_seq2seq --vocab-size 7 --encoder-ids 3,4 --decoder-start-token-id 0
+          python3 -c "
+          import sys; sys.path.insert(0, 'scripts')
+          from make_toy_seq2seq import compute_expected_ids
+          expected = compute_expected_ids([3, 4], 0, 7, 8)
+          print('expected:', expected)
+          assert expected == [0, 1, 2, 3, 4, 5, 6, 0], expected
+          "
+
+      - name: Run the CLI against the build's own ORT (${{ env.ORT_VERSION_OLDER }})
+        working-directory: tools/onnx-deploy
+        run: |
+          out=$(./build/onnx-deploy --libort "${{ env.ORT_OLDER_HOME }}/lib/libonnxruntime.so" /tmp/toy_seq2seq 3,4 --max-new-tokens 8)
+          echo "$out"
+          echo "$out" | grep -qF "generated 8 token(s): 0 1 2 3 4 5 6 0"
+
+      - name: Swap to ORT ${{ env.ORT_VERSION_NEWER }} at runtime -- same binary, no rebuild
+        working-directory: tools/onnx-deploy
+        run: |
+          out=$(./build/onnx-deploy --libort "${{ env.ORT_NEWER_HOME }}/lib/libonnxruntime.so" /tmp/toy_seq2seq 3,4 --max-new-tokens 8)
+          echo "$out"
+          echo "$out" | grep -qF "generated 8 token(s): 0 1 2 3 4 5 6 0"
+
+      - name: Early-stop at eos_token_id
+        working-directory: tools/onnx-deploy
+        run: |
+          out=$(./build/onnx-deploy --libort "${{ env.ORT_OLDER_HOME }}/lib/libonnxruntime.so" /tmp/toy_seq2seq 3,4 --max-new-tokens 20 --eos-token-id 6)
+          echo "$out"
+          echo "$out" | grep -qF "generated 7 token(s): 0 1 2 3 4 5 6"
+
+      - name: Test the Python extension against both ORT builds (fresh process per build)
+        working-directory: tools/onnx-deploy
+        run: |
+          for libort in "${{ env.ORT_OLDER_HOME }}/lib/libonnxruntime.so" "${{ env.ORT_NEWER_HOME }}/lib/libonnxruntime.so"; do
+            PYTHONPATH=build/python python3 -c "
+          import onnx_deploy_py as od
+          od.load_ort('$libort')
+          p = od.Pipeline('/tmp/toy_seq2seq')
+          assert p.is_seq2seq
+          ids = p.generate([3, 4], max_new_tokens=8)
+          assert ids == [0, 1, 2, 3, 4, 5, 6, 0], ids
+          print('OK:', '$libort', ids)
+          "
+          done
+
+      - name: Error-path smoke test (bad model dir / bad libort must fail cleanly, not crash)
+        working-directory: tools/onnx-deploy
+        run: |
+          set +e
+          ./build/onnx-deploy --libort "${{ env.ORT_OLDER_HOME }}/lib/libonnxruntime.so" /tmp/does-not-exist 3,4
+          code=$?
+          set -e
+          [ "$code" -eq 1 ]
+          set +e
+          ./build/onnx-deploy --libort /tmp/does-not-exist.so /tmp/toy_seq2seq 3,4
+          code=$?
+          set -e
+          [ "$code" -eq 1 ]

--- a/tools/onnx-deploy/.gitignore
+++ b/tools/onnx-deploy/.gitignore
@@ -1,1 +1,2 @@
 build/
+node_modules/

--- a/tools/onnx-deploy/CMakeLists.txt
+++ b/tools/onnx-deploy/CMakeLists.txt
@@ -6,29 +6,50 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # Unlike tools/onnx-finetune (which needs a training-enabled from-source ORT
-# build), this tool only calls the ordinary inference C++ API, so any plain
-# ONNX Runtime distribution works: the official prebuilt release tarball
-# (github.com/microsoft/onnxruntime/releases,
-# onnxruntime-<platform>-<version>.tgz) or a `pip install onnxruntime`'s
-# bundled headers/lib. Point ORT_HOME at a prefix containing
-# include/onnxruntime_cxx_api.h and lib/libonnxruntime.{so,dylib}:
+# build), this project never links against libonnxruntime at build time at
+# all -- see include/onnx_deploy/kv_cache_pipeline.h's ORT_API_MANUAL_INIT
+# usage and src/onnx_deploy_c_api.cpp's dlopen-based onnx_deploy_load_ort().
+# ORT_HOME only needs to point at *some* ONNX Runtime distribution's headers
+# (any recent version works -- the ORT C API is stable/backward-compatible);
+# the actual libonnxruntime to run against is chosen at *runtime* via
+# onnx_deploy_load_ort()/--libort, and can be swapped without rebuilding.
 #   cmake -B build -DORT_HOME=/path/to/onnxruntime-linux-x64-1.19.2
 if(NOT ORT_HOME)
-  message(FATAL_ERROR "ORT_HOME is not set -- point it at an extracted ONNX Runtime release (contains include/onnxruntime_cxx_api.h and lib/). See README.md.")
+  message(FATAL_ERROR "ORT_HOME is not set -- point it at any extracted ONNX Runtime release (only its include/ is used at build time). See README.md.")
 endif()
 
+# The swappable-libort C ABI: builds and links with zero dependency on any
+# specific libonnxruntime -- only ${CMAKE_DL_LIBS} (dlopen/dlsym) plus the
+# headers from ORT_HOME. This is the one artifact every other consumer
+# (the CLI below, a Python/Rust/Go/etc. binding, a future WASM build) is
+# meant to link against or dlopen itself.
+add_library(onnx_deploy_c SHARED src/onnx_deploy_c_api.cpp)
+target_include_directories(onnx_deploy_c PRIVATE include ${ORT_HOME}/include)
+target_link_libraries(onnx_deploy_c PRIVATE ${CMAKE_DL_LIBS})
+set_target_properties(onnx_deploy_c PROPERTIES
+  PUBLIC_HEADER "include/onnx_deploy/onnx_deploy_c_api.h"
+)
+
+# CLI demo: a thin consumer of the C ABI above (see src/main.cpp), included
+# to double as an executable smoke test of the ABI itself, not just of the
+# C++ core it wraps.
 add_executable(onnx-deploy src/main.cpp)
-
-target_include_directories(onnx-deploy PRIVATE
-  include
-  ${ORT_HOME}/include
-)
-
-find_library(ORT_LIBRARY onnxruntime PATHS ${ORT_HOME}/lib REQUIRED NO_DEFAULT_PATH)
-target_link_libraries(onnx-deploy PRIVATE ${ORT_LIBRARY})
+target_include_directories(onnx-deploy PRIVATE include)
+target_link_libraries(onnx-deploy PRIVATE onnx_deploy_c)
 set_target_properties(onnx-deploy PROPERTIES
-  BUILD_RPATH ${ORT_HOME}/lib
-  INSTALL_RPATH ${ORT_HOME}/lib
+  BUILD_RPATH "$ORIGIN"
+  INSTALL_RPATH "$ORIGIN"
 )
+
+# Optional nanobind Python extension (tools/onnx-deploy/python/), following
+# the same nanobind convention as onnxsim's own onnxsim/cpp2py_export.cc.
+# Off by default since it needs Python dev headers + `pip install nanobind`;
+# turn on explicitly:
+#   cmake -B build -DORT_HOME=... -DONNX_DEPLOY_PYTHON=ON
+option(ONNX_DEPLOY_PYTHON "Build the onnx_deploy_py nanobind extension" OFF)
+if(ONNX_DEPLOY_PYTHON)
+  add_subdirectory(python)
+endif()

--- a/tools/onnx-deploy/README.md
+++ b/tools/onnx-deploy/README.md
@@ -7,10 +7,9 @@ generation pipeline, entirely in C++/Python -- no `optimum`, no `torch`, no
 Python required at all for the C++ side.
 
 **Status: built and CI-verified** (`.github/workflows/onnx-deploy.yml`) for
-the native CLI, the C ABI, and the Python extension -- see "Verifying the
-flow" below for exactly what that CI proves and how to reproduce it
-locally. The WASM target described near the end is a design writeup only,
-not yet built.
+the native CLI, the C ABI, the Python extension, and the WASM module -- see
+"Verifying the flow" and the "WASM" section below for exactly what CI proves
+and how to reproduce it locally.
 
 ## The question this answers
 
@@ -135,6 +134,12 @@ The ABI's shape mirrors onnxsim's own C ABI conventions
   it has no ONNX Runtime header dependency of its own), following the same
   nanobind convention as onnxsim's own `onnxsim/cpp2py_export.cc`. See "Why
   a Python extension at all" below.
+- **`wasm/src/onnx_deploy_wasm.cpp`** -- a from-scratch WASM port of the same
+  algorithm (not the C ABI or `kv_cache_pipeline.h` reused verbatim -- see
+  "WASM" below for why), reached from JS through one Asyncify-awaited
+  `generate()` call, with ONNX Runtime itself swapped in via
+  [onnxruntime-web](https://github.com/microsoft/onnxruntime) instead of a
+  native `libonnxruntime`.
 
 ## Why a Python extension at all, when `optimum.onnxruntime` already does this in Python
 
@@ -244,22 +249,62 @@ To reproduce locally: download any two ONNX Runtime releases from
 et al.), then run the same `cmake`/`make_toy_seq2seq.py`/`onnx-deploy`
 sequence the workflow does.
 
-## WASM (design only -- not yet built)
+## WASM
 
-Not implemented here: this repo's existing WASM/ONNX Runtime bridge
-(`JsModelExecutor`, `scripts/convertmodel/js_model_executor.cpp`, see
-`docs/wasm_ort_web.md`) is an Asyncify bridge for exactly **one** awaited JS
-call per `Run()` -- built for onnxsim's single constant-fold call, not a
-multi-step decode loop. Reusing it for `KvCachePipeline::Generate()` (encoder
-once, decoder N times, cache threaded between awaited calls) needs an
-embind class that keeps an `ort.InferenceSession` (or two -- encoder and
-decoder) alive JS-side across the whole loop, rather than the current
-per-call session pattern -- `docs/wasm_ort_web.md` already flags
-per-call `InferenceSession.create` as a likely bottleneck for exactly this
-reason. "Swappable libort" in WASM terms would mean the JS host chooses
-which onnxruntime-web build/execution-provider backs that session, mirroring
-the native dlopen swap at the JS/wasm boundary instead of the OS loader.
-This needs real design + implementation + browser/Node test infrastructure
-beyond what fits here; flagging the shape of the work rather than shipping
-unverified code for it (this sandbox has no `emcc` to even compile-check
-a WASM attempt against).
+This repo's existing WASM/ONNX Runtime bridge (`JsModelExecutor`,
+`scripts/convertmodel/js_model_executor.cpp`, see `docs/wasm_ort_web.md`) is
+an Asyncify bridge for exactly **one** awaited JS call per `Run()` -- built
+for onnxsim's single constant-fold call, not a multi-step decode loop.
+`wasm/src/onnx_deploy_wasm.cpp` is a fresh implementation for the
+"persistent sessions across many awaited calls" case that bridge doesn't
+cover: it holds onnxruntime-web `InferenceSession`s (encoder, decoder,
+decoder-with-past) alive JS-side across the whole `generate()` loop, the
+same `docs/wasm_ort_web.md` already flags per-call `InferenceSession.create`
+as a likely bottleneck for exactly this reason.
+
+**Why a separate implementation instead of reusing `kv_cache_pipeline.h` or
+the C ABI:** both are built on `Ort::Value`/`Ort::Session`, ORT's native C++
+types -- there is no native ORT at all on the WASM side of this bridge
+(every tensor computation happens in JS/onnxruntime-web), so there is
+nothing for those types to wrap. `onnx_deploy_wasm.cpp` re-implements the
+same two design decisions instead (`present.*` -> `past_key_values.*`
+renamed by string substitution alone; a cache entry not re-output by a call
+stays valid for the next one) against a plain `WasmTensor` struct
+(`{dtype, shape, data}`, `data` always `std::vector<double>`) that crosses
+the JS boundary as a plain object.
+
+**"Swappable libort" in WASM terms** means the JS host chooses which
+onnxruntime-web build/version/execution-provider implements
+`Module.onnxDeployRunSession` -- see `wasm/test/ort_web_runtime.mjs` for the
+reference implementation -- mirroring the native side's `dlopen(libort_path)`
+swap at the JS/wasm boundary instead of the OS loader. There is zero ORT C/
+C++ code or dependency in `wasm/CMakeLists.txt`/`onnx_deploy_wasm.cpp` at
+all -- unlike `tools/onnx-finetune/wasm` (which statically compiles ONNX
+Runtime from source into its module), this target doesn't link ORT into
+wasm in any form.
+
+**Scope note:** this exposes one async entry point, `generate()` (create
+sessions, run the whole decode loop, return), rather than a reusable
+class wrapping multiple `generate()` calls without re-creating sessions
+each time -- enough to prove the persistent-session-across-many-awaited-
+calls mechanism works end-to-end (this repo's only prior Asyncify bridge is
+single-call), not a full session-lifecycle API. That's a natural follow-up.
+
+Build and test locally (mirrors the `wasm-verify` CI job):
+
+```sh
+# Install Emscripten once (any recent version; CI pins the same one
+# static.yml uses for onnxsim's own wasm build):
+git clone https://github.com/emscripten-core/emsdk.git
+./emsdk/emsdk install 5.0.0 && ./emsdk/emsdk activate 5.0.0
+source ./emsdk/emsdk_env.sh
+
+cd tools/onnx-deploy/wasm
+emcmake cmake -B build && cmake --build build
+
+python3 ../scripts/make_toy_seq2seq.py -o /tmp/toy_seq2seq --vocab-size 7 --encoder-ids 3,4 --decoder-start-token-id 0
+cd test && npm install && node run_test.mjs /tmp/toy_seq2seq
+# -> generate(max_new_tokens=8, eos=-1): [0, 1, 2, 3, 4, 5, 6, 0]
+#    generate(max_new_tokens=20, eos_token_id=6): [0, 1, 2, 3, 4, 5, 6]
+#    OK: onnx_deploy_wasm matches the native pipeline's expected output.
+```

--- a/tools/onnx-deploy/README.md
+++ b/tools/onnx-deploy/README.md
@@ -1,41 +1,41 @@
-# onnx-deploy (design sketch)
+# onnx-deploy
 
-**Status: design sketch / skeleton, not a shipped tool.** It is not wired into
-the top-level build, has not been compiled or run against a real model in
-this environment (no ONNX Runtime dev package was available here), and is
-not covered by CI. Treat the header/CLI below as a concrete starting point
-for the missing piece described here, not a finished library.
+A standalone C++ tool (own `CMakeLists.txt`, no dependency on onnxsim's own
+build -- see the repo's `CLAUDE.md`) that glues together the multiple `.onnx`
+files `optimum-onnx` exports for one model into a single autoregressive
+generation pipeline, entirely in C++/Python -- no `optimum`, no `torch`, no
+Python required at all for the C++ side.
+
+**Status: built and CI-verified** (`.github/workflows/onnx-deploy.yml`) for
+the native CLI, the C ABI, and the Python extension -- see "Verifying the
+flow" below for exactly what that CI proves and how to reproduce it
+locally. The WASM target described near the end is a design writeup only,
+not yet built.
 
 ## The question this answers
 
 *Is there a C++ library in this repo that glues together the multiple `.onnx`
 files `optimum-onnx` exports for one model, so they can be deployed as a
-single autoregressive-generation pipeline?*
+single autoregressive-generation pipeline -- and can it be built as a
+dynamic library / WASM module where the actual ONNX Runtime binary is
+swapped at runtime instead of baked in at build time?*
 
-No. Today that gluing only exists in Python, via `optimum.onnxruntime`'s
-`ORTModelForSeq2SeqLM` / `ORTModelForCausalLM` (see the "Transformers export"
-section of the top-level `README.md` and `tests/test_optimum_export_deploy.py`,
-which drives exactly that Python class end-to-end against onnxsim's output).
-onnxsim's own C++ core (`onnxsim/`) is a graph simplifier -- it takes one
-`onnx::ModelProto` in and produces a simplified one out. Its only use of the
-ONNX Runtime C++ API is `onnxsim/dlpack_bridge.h`'s single-model,
-single-call `ModelExecutor::Run()`, used internally for constant folding
-during simplification (see `docs/dlpack-executor.md`). It has no notion of
-multiple persistent sessions, a KV-cache loop, or tensors flowing from one
-model into another -- there is nothing in this repo to build a C++-only
-deployment on top of except that low-level executor seam.
-
-This directory sketches what a real one would look like, as an independent
-tool (own `CMakeLists.txt`, own binary) in the same spirit as
-`tools/onnx-finetune/`: it consumes plain ONNX files, has no dependency on
-onnxsim's own build, and is not part of the Python wheel (see the repo's
-`CLAUDE.md` note that the wheel never builds or links ONNX Runtime).
+Not before this directory. That gluing previously only existed in Python,
+via `optimum.onnxruntime`'s `ORTModelForSeq2SeqLM` / `ORTModelForCausalLM`
+(see the "Transformers export" section of the top-level `README.md` and
+`tests/test_optimum_export_deploy.py`, which drives exactly that Python
+class end-to-end against onnxsim's output). onnxsim's own C++ core
+(`onnxsim/`) is a graph simplifier -- it takes one `onnx::ModelProto` in and
+produces a simplified one out. Its only use of the ONNX Runtime C++ API is
+`onnxsim/dlpack_bridge.h`'s single-model, single-call `ModelExecutor::Run()`,
+used internally for constant folding during simplification (see
+`docs/dlpack-executor.md`) -- it has no notion of multiple persistent
+sessions, a KV-cache loop, or a runtime-swappable ONNX Runtime binary.
 
 ## What optimum-onnx actually exports
 
-`optimum.exporters.onnx.main_export(..., task="text2text-generation-with-past")`
-(or `main_export(..., no_post_process=True)`, which is what this repo's own
-test uses -- see below) writes a *directory*, not one file:
+`optimum.exporters.onnx.main_export(..., task="text2text-generation-with-past",
+no_post_process=True)` writes a *directory*, not one file:
 
 ```
 encoder_model.onnx             # seq2seq only (T5, BART, Whisper, ...)
@@ -50,129 +50,216 @@ Decoder-only causal LMs (GPT-2, Llama, ...) export the same
 
 By default, recent `optimum-onnx` merges the two decoder files into one
 `decoder_model_merged.onnx` with a top-level `If` node switching branches on
-a boolean `use_cache_branch` input. **This sketch deliberately targets the
+a boolean `use_cache_branch` input. **This tool deliberately targets the
 plain three-file split instead** (`no_post_process=True`), for the same
 reason `tests/test_optimum_export_deploy.py` does: as of this writing,
 onnxsim simplifying the merged file's `If` branches produces a model that
 fails at runtime with an ONNX Runtime broadcast error in cross-attention --
-see that test's docstring. The split shape is also simply easier to drive
-from C++: two ordinary sessions and an `if (step == 0)` in the host loop,
-instead of one session where the same branch selection has to happen
-*inside* the graph via an extra input tensor. Supporting the merged shape
-later is a matter of adding one more input (`use_cache_branch`, a length-1
-bool tensor) to `RunDecoderStep` and pointing both "sessions" at the same
-`Ort::Session` -- noted as a follow-up below.
+see that test's docstring. Supporting the merged shape later is a matter of
+adding one more input (`use_cache_branch`, a length-1 bool tensor) to
+`KvCachePipeline::RunDecoderStep` and pointing both "sessions" at the same
+`Ort::Session` -- not done here.
 
 ## Design
 
-### The actual "glue": renaming `present.*` outputs into `past_key_values.*` inputs
+### Layer 1: the KV-cache glue (`include/onnx_deploy/kv_cache_pipeline.h`)
 
 Every decode step after the first, ONNX Runtime hands back cache tensors
 named `present.{i}.key` / `present.{i}.value` (plus, for seq2seq models,
-`present.{i}.encoder.key` / `.value` for cross-attention, alongside
+`present.{i}.encoder.key` / `.value` for cross-attention alongside
 `present.{i}.decoder.key` / `.value` for self-attention). The *next* call
 needs those same tensors fed back in as `past_key_values.{i}.key` /
-`.value` (`.decoder.`/`.encoder.` likewise). That rename is 100% positional
-by naming convention -- no shapes, dtypes, or model architecture need to be
-known to do it -- so the pipeline never hardcodes layer counts or head
-dims; it just maps every output whose name starts with `present.` to the
-input name with `past_key_values.` substituted in, for however many such
-outputs the loaded graph actually has (`HarvestPresentIntoCache` in the
-header below).
+`.value`. `KvCachePipeline::HarvestPresentIntoCache` does that rename by
+string substitution alone -- no shapes, dtypes, or layer/head counts are
+ever hardcoded, so the same code drives any architecture that follows the
+naming convention. Because `Ort::Value` is move-only and owns (or borrows)
+its own buffer, the rename is a pointer/ownership move, not a tensor copy.
 
-Because `Ort::Value` is move-only and owns (or borrows) its own buffer, this
-rename is a pointer/ownership move, not a tensor copy: the previous
-`Run()` call's output buffer becomes the next call's input directly, with no
-round trip through host arrays.
+A subtlety this actually needs to get right (and the toy model below is
+specifically built to catch a regression in): some architectures' cache
+entries (T5-style cross-attention) are computed once at step 0 and never
+re-output by `decoder_with_past_model.onnx` afterward. `RunDecoderStep`
+therefore always *borrows* a view of a cache entry for a `Run()` call
+(`detail::BorrowView`) rather than moving it out -- an entry that isn't
+refreshed by that call's outputs stays owned in the cache, valid for the
+next step too.
 
-### Two sessions, one host-side loop
+Two sessions, one host-side loop: encoder once (seq2seq only), then
+`decoder_model.onnx` for step 0, then `decoder_with_past_model.onnx` in a
+loop with the cache fed back each time, greedy-argmax over `logits` each
+step, until `eos_token_id` or `max_new_tokens`.
 
-```
-                 ┌───────────────────┐
-input_ids ─────▶ │ encoder_model.onnx│──▶ encoder_hidden_states  (seq2seq only,
-                 └───────────────────┘                            run once)
-                            │
-                            ▼
-      ┌─────────────────────────────────────────────┐
-      │ step 0: decoder_model.onnx                   │
-      │   in : decoder_start_token, enc_hidden_states│
-      │   out: logits, present.*                     │──┐
-      └─────────────────────────────────────────────┘   │ present.* renamed to
-                            │                             │ past_key_values.* for
-                            ▼                             │ every step after
-      ┌─────────────────────────────────────────────┐   │
-      │ step i>0: decoder_with_past_model.onnx       │◀──┘
-      │   in : last_token, enc_hidden_states,        │
-      │        past_key_values.* (from cache)         │
-      │   out: logits, present.* ──────────────────────┐
-      └─────────────────────────────────────────────┘   │ loop back in
-                            │  argmax(logits) -> token   │
-                            ▼                             │
-                     append to output ◀───────────────────┘
-                     stop at eos_token_id / max_new_tokens
-```
+### Layer 2: the swappable-libort C ABI (`onnx_deploy_c_api.h` / `.cpp`)
 
-A decoder-only export runs the same loop with no encoder step and no
-`encoder_hidden_states`/`.encoder.` cache entries -- `is_seq2seq()` on the
-pipeline just reflects whether `encoder_model.onnx` was found in the
-directory, and `RunDecoderStep` skips the encoder-only inputs when absent.
+`kv_cache_pipeline.h` builds against ONNX Runtime's C++ API with
+`ORT_API_MANUAL_INIT` defined, which means the ORT function table
+(`Ort::Global<void>::api_`) is **not** resolved at static-init time by a
+linked `OrtGetApiBase()` call -- nothing in this header, or in
+`onnx_deploy_c_api.cpp`, references any symbol from libonnxruntime at link
+time at all. `onnx_deploy_load_ort(libort_path)` resolves the real thing at
+*runtime*: `dlopen`/`LoadLibrary` the given `libonnxruntime.so`/`.dylib`/
+`.dll`, `dlsym`/`GetProcAddress` its `OrtGetApiBase` export, call
+`GetApi(ORT_API_VERSION)`, and hand the resulting `OrtApi*` to
+`Ort::InitApi()`. This is ONNX Runtime's own documented mechanism for
+"custom operator libraries that are not linked to onnxruntime" (see the
+comment above `Ort::InitApi(const OrtApi*)` in `onnxruntime_cxx_api.h`),
+applied to the whole pipeline instead of just a custom op.
 
-### What is deliberately out of scope here
+The payoff: `libonnx_deploy_c.so` builds and links with **zero** dependency
+on any specific ONNX Runtime binary -- `ldd` on it shows only libstdc++/
+libgcc_s/libc/libm, confirmed in CI (see below). The same compiled artifact
+can be pointed at a CPU build, a GPU/EP-specific build, or a newer/older
+version, by passing a different path to `onnx_deploy_load_ort` -- no
+recompile. (ORT's C API is itself only forward-compatible in the
+"newer .so serves an older API version request" direction, not the other
+way around -- see "Verifying the flow" below.)
 
-- **Tokenization.** The pipeline's `Generate()` takes and returns `int64_t`
-  token ids, not strings. Wiring up a real tokenizer (`tokenizer.json`) is a
-  separate, orthogonal concern -- see e.g.
-  [`mlc-ai/tokenizers-cpp`](https://github.com/mlc-ai/tokenizers-cpp) (a C++
-  wrapper over Hugging Face's Rust `tokenizers` crate) as the natural thing
-  to link in front of this. Keeping it out lets this stay a small,
-  dependency-free header.
-- **Sampling strategies.** `ArgmaxLastToken` is greedy-only. Top-k/top-p/
+The ABI's shape mirrors onnxsim's own C ABI conventions
+(`onnxsim/capi/onnxsim_c_api.h`): every fallible call returns an
+`OnnxDeployStatus`, takes a nullable `char** out_error` for a freshly
+`malloc`'d message on failure, and no C++ exception ever crosses the
+`extern "C"` boundary.
+
+### Layer 3: consumers
+
+- **`src/main.cpp`** (`onnx-deploy` CLI) -- a thin consumer of the C ABI
+  above, included specifically so building/running it is also an
+  executable smoke test of the ABI itself, not just of the C++ core it
+  wraps: `onnx-deploy --libort PATH <export_dir> <id1,id2,...>
+  [--max-new-tokens N] [--eos-token-id N] [--decoder-start-token-id N]`. No
+  tokenizer -- pipe in ids you got from `AutoTokenizer` separately, the same
+  "simplest possible format" choice `tools/onnx-finetune` makes for its raw
+  float32 training data.
+- **`python/onnx_deploy_py.cc`** -- a compiled [nanobind](https://github.com/wjakob/nanobind)
+  extension over the same C ABI (not over `kv_cache_pipeline.h` directly, so
+  it has no ONNX Runtime header dependency of its own), following the same
+  nanobind convention as onnxsim's own `onnxsim/cpp2py_export.cc`. See "Why
+  a Python extension at all" below.
+
+## Why a Python extension at all, when `optimum.onnxruntime` already does this in Python
+
+`optimum.onnxruntime.ORTModelForSeq2SeqLM`/`ORTModelForCausalLM` is pure
+Python calling `onnxruntime`'s Python bindings: the encoder/decoder session
+objects, the KV-cache dict, and the `generate()` loop are all live Python
+objects and bytecode, importable, `inspect`-able, and monkeypatchable at
+runtime, and the `.onnx` files it reads sit on disk as plain files next to
+it. A compiled extension like `onnx_deploy_py` moves the loop, the
+cache-tensor threading, and the session lifetime entirely into compiled
+machine code reachable from Python only through the four calls
+`onnx_deploy_py` exports (`load_ort`, `Pipeline`, `.generate`,
+`.is_seq2seq`) -- there's no Python-level loop to monkeypatch, no
+`ORTModelForSeq2SeqLM.generate` to trace through with `inspect`/`dis`, and
+nothing about the decode loop's logic visible to `pip show`/source-reading
+the way `optimum`'s own `.py` files are. In that narrow sense, yes: a
+compiled extension is more opaque than the pure-Python glue, and if the
+goal is specifically "make the *generation loop* harder to casually read or
+patch," this is a real step up from `optimum`.
+
+Two things it deliberately does **not** do, worth being clear about before
+reaching for it as an "obfuscation" tool:
+
+- **It doesn't protect the model weights themselves.** The `.onnx` files
+  (and their external-data weight files) still sit on disk, in plain ONNX
+  format, next to the extension -- `onnx_deploy_py.Pipeline("some_dir")`
+  loads them exactly the same way `optimum` would. Anyone with the
+  directory can open them with `onnx.load()`/Netron regardless of which
+  loop code drives inference. If the actual goal is hiding *weights*, that
+  needs something this tool doesn't have: e.g. weights baked into the
+  extension as encrypted/obfuscated data and decrypted only into
+  ONNX Runtime's in-memory buffers at load time -- a meaningfully bigger
+  feature, not implemented here.
+- **It's not a security boundary against a motivated reverse engineer.**
+  Compiled C++ is slower and more annoying to read than Python, not opaque
+  to it -- a `.so` full of `Ort::Session`/`std::map<std::string, Ort::Value>`
+  calls disassembles and Ghidra/IDA-analyzes just fine, and every ABI call
+  is a stable, documented, exported symbol by design (that's what makes it
+  usable from Python/Rust/Go/etc. in the first place). Treat this as
+  "raises the floor of casual inspection," not "DRM."
+
+So: more flexible than the pure-Python glue for keeping the *loop logic*
+out of easily-read/patched Python, genuinely (that's `onnx_deploy_py`,
+added here) -- but not a substitute for actually protecting model weights
+if that's the real requirement.
+
+## What is deliberately out of scope
+
+- **Tokenization.** `Generate()`/`.generate()` take and return `int64_t`
+  token ids, not strings. See e.g.
+  [`mlc-ai/tokenizers-cpp`](https://github.com/mlc-ai/tokenizers-cpp) as the
+  natural thing to link in front of this.
+- **Sampling strategies.** Greedy-only (`ArgmaxLastToken`). Top-k/top-p/
   temperature sampling is a small, independent change to that one function.
-- **`config.json` parsing.** Generation parameters (`eos_token_id`,
-  `decoder_start_token_id`, `max_new_tokens`) are passed in explicitly via
-  `GenerationConfig` rather than read from `generation_config.json`, so this
-  header has no JSON dependency at all. A CLI wrapper that does want to read
-  them from the export directory can add a small JSON library (e.g.
-  vendored `nlohmann/json`, single header) without touching the pipeline
-  itself -- everything the pipeline needs to know about tensor shapes and
-  layer count it already gets for free from the loaded `Ort::Session`s'
-  own input/output metadata, not from `config.json`.
-- **Batch size > 1** and **beam search**. The sketch's KV-cache map is keyed
-  purely by tensor name, so batching would mainly be a matter of building
-  wider input tensors and growing the attention mask per batch row; beam
-  search needs an actual reorder-cache-by-beam-index step this sketch
-  doesn't have.
+- **`config.json` parsing.** Generation parameters are passed in explicitly
+  (`GenerationConfig`/CLI flags/Python kwargs) rather than read from
+  `generation_config.json`, so there is no JSON dependency anywhere in this
+  tool -- everything about tensor shapes and layer count comes from the
+  loaded `Ort::Session`s' own input/output metadata.
+- **Batch size > 1** and **beam search**.
 - **The merged `decoder_model_merged.onnx` shape** (see above).
+- **Weight obfuscation/encryption** (see previous section).
 
-## Files
-
-- `include/onnx_deploy/kv_cache_pipeline.h` -- the pipeline itself:
-  `KvCachePipeline` loads whichever of `encoder_model.onnx` /
-  `decoder_model.onnx` / `decoder_with_past_model.onnx` exist in a directory,
-  and exposes `Generate(input_ids, config) -> vector<int64_t>`.
-- `src/main.cpp` -- a minimal CLI: `onnx-deploy <export_dir> <id1,id2,...>
-  [--max-new-tokens N] [--eos-token-id N] [--decoder-start-token-id N]`,
-  prints the generated token ids. No tokenizer -- pipe in ids you got from
-  `AutoTokenizer` separately, the same "simplest possible format" choice
-  `tools/onnx-finetune` makes for its raw float32 training data.
-- `CMakeLists.txt` -- builds against a plain ONNX Runtime C++ package (the
-  official prebuilt release tarball, or a `pip install onnxruntime`'s
-  bundled headers/lib both work here -- unlike `onnx-finetune`, this does
-  *not* need a training-enabled from-source build, since generation only
-  needs the ordinary inference C++ API).
-
-## Building (once ONNX Runtime is available)
+## Building
 
 ```sh
-# Point at an extracted onnxruntime-linux-x64-<ver>.tgz release, or any
-# prefix containing include/onnxruntime_cxx_api.h and lib/libonnxruntime.so
+# ORT_HOME only needs to point at *some* ONNX Runtime distribution's headers
+# (any recent release works -- the ORT C API is stable). The libonnxruntime
+# actually run against is chosen separately, at runtime, via --libort /
+# onnx_deploy_load_ort() / onnx_deploy_py.load_ort() -- see below.
 cmake -B build -DORT_HOME=/path/to/onnxruntime-linux-x64-1.19.2
 cmake --build build
-
-python3 -c "
-import optimum.exporters.onnx as e
-e.main_export('hf-internal-testing/tiny-random-t5', output='t5_export',
-               task='text2text-generation-with-past', no_post_process=True)
-"
-./build/onnx-deploy t5_export 0,100 --max-new-tokens 8 --eos-token-id 1
 ```
+
+Add `-DONNX_DEPLOY_PYTHON=ON` (needs `pip install nanobind`) to also build
+`onnx_deploy_py` under `build/python/`.
+
+## Verifying the flow
+
+CI (`.github/workflows/onnx-deploy.yml`) does exactly this, from a clean
+checkout, on every change under `tools/onnx-deploy/`:
+
+1. Downloads two different real ONNX Runtime releases (1.18.1 and 1.19.2).
+2. Configures and builds `onnx_deploy_c`/`onnx-deploy`/`onnx_deploy_py`
+   against **only the older release's headers** -- and asserts
+   `ldd build/libonnx_deploy_c.so` shows no `libonnxruntime` dependency.
+3. Generates a tiny hand-built seq2seq export with
+   `scripts/make_toy_seq2seq.py` (`onnx` package only -- no
+   torch/transformers/optimum). It is not a real language model: see that
+   script's docstring for the exact math, chosen so the correct output
+   sequence is fully hand-computable (`compute_expected_ids()`) and so a
+   broken KV-cache handoff -- including the "cache entry not re-output every
+   step" subtlety above -- changes the output instead of just not crashing.
+4. Runs `onnx-deploy` against the toy export with `--libort` pointed at the
+   **older** release, asserts the exact expected token sequence.
+5. **Swaps `--libort` to the newer release, no rebuild, on the same
+   compiled binary**, and asserts the identical expected sequence again --
+   this is the actual "swappable at runtime" claim, exercised for real, not
+   just a design note.
+6. Repeats the same swap test through `onnx_deploy_py` (fresh Python
+   process per ORT build).
+7. Checks that a bad model directory and a bad `--libort` path both fail
+   cleanly (`ONNX_DEPLOY_ERROR` / exit 1 with a message), not a crash.
+
+To reproduce locally: download any two ONNX Runtime releases from
+<https://github.com/microsoft/onnxruntime/releases> (`onnxruntime-linux-x64-*.tgz`
+et al.), then run the same `cmake`/`make_toy_seq2seq.py`/`onnx-deploy`
+sequence the workflow does.
+
+## WASM (design only -- not yet built)
+
+Not implemented here: this repo's existing WASM/ONNX Runtime bridge
+(`JsModelExecutor`, `scripts/convertmodel/js_model_executor.cpp`, see
+`docs/wasm_ort_web.md`) is an Asyncify bridge for exactly **one** awaited JS
+call per `Run()` -- built for onnxsim's single constant-fold call, not a
+multi-step decode loop. Reusing it for `KvCachePipeline::Generate()` (encoder
+once, decoder N times, cache threaded between awaited calls) needs an
+embind class that keeps an `ort.InferenceSession` (or two -- encoder and
+decoder) alive JS-side across the whole loop, rather than the current
+per-call session pattern -- `docs/wasm_ort_web.md` already flags
+per-call `InferenceSession.create` as a likely bottleneck for exactly this
+reason. "Swappable libort" in WASM terms would mean the JS host chooses
+which onnxruntime-web build/execution-provider backs that session, mirroring
+the native dlopen swap at the JS/wasm boundary instead of the OS loader.
+This needs real design + implementation + browser/Node test infrastructure
+beyond what fits here; flagging the shape of the work rather than shipping
+unverified code for it (this sandbox has no `emcc` to even compile-check
+a WASM attempt against).

--- a/tools/onnx-deploy/include/onnx_deploy/kv_cache_pipeline.h
+++ b/tools/onnx-deploy/include/onnx_deploy/kv_cache_pipeline.h
@@ -1,18 +1,29 @@
 // onnx_deploy/kv_cache_pipeline.h
 //
-// Design sketch: generic C++ glue for the multi-file ONNX export shape that
-// `optimum-onnx` produces for autoregressive generation --
+// Generic C++ glue for the multi-file ONNX export shape that `optimum-onnx`
+// produces for autoregressive generation --
 //   encoder_model.onnx            (optional -- absent for decoder-only LMs)
 //   decoder_model.onnx            (no KV-cache inputs; first decode step)
 //   decoder_with_past_model.onnx  (KV-cache in and out; every step after)
 // -- with no Python/torch dependency. See ../../README.md for the design
 // writeup, the naming-convention assumptions this relies on, and what is
 // deliberately left out (tokenization, sampling beyond greedy, batching,
-// the merged decoder_model_merged.onnx shape). Not compiled/tested in this
-// environment -- read it with that in mind.
+// the merged decoder_model_merged.onnx shape).
+//
+// Usage contract: this header builds against ONNX Runtime's C++ API with
+// ORT_API_MANUAL_INIT (see the block below), so the ORT function table is
+// NOT resolved at static-init time and this header does not require linking
+// against libonnxruntime at all. The embedder must call `Ort::InitApi(api)`
+// with an `OrtApi*` obtained however it likes -- linked directly
+// (`OrtGetApiBase()->GetApi(ORT_API_VERSION)`), or resolved at runtime from
+// a dlopen'd/LoadLibrary'd libonnxruntime (see onnx_deploy_c_api.cpp, the
+// swappable-libort C ABI built on top of this header) -- exactly once,
+// before constructing any Ort::* object, including KvCachePipeline.
 #pragma once
 
+#define ORT_API_MANUAL_INIT
 #include <onnxruntime_cxx_api.h>
+#undef ORT_API_MANUAL_INIT
 
 #include <cstdint>
 #include <filesystem>
@@ -85,11 +96,11 @@ inline Ort::Value BorrowView(const Ort::Value& src) {
   std::vector<int64_t> shape = info.GetShape();
   static Ort::MemoryInfo mem_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
   switch (info.GetElementType()) {
-    case ONNX_TENSOR_ELEMENT_TYPE_FLOAT: {
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT: {
       auto* data = const_cast<float*>(src.GetTensorData<float>());
       return Ort::Value::CreateTensor<float>(mem_info, data, info.GetElementCount(), shape.data(), shape.size());
     }
-    case ONNX_TENSOR_ELEMENT_TYPE_INT64: {
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64: {
       auto* data = const_cast<int64_t*>(src.GetTensorData<int64_t>());
       return Ort::Value::CreateTensor<int64_t>(mem_info, data, info.GetElementCount(), shape.data(), shape.size());
     }
@@ -277,7 +288,9 @@ class KvCachePipeline {
     for (size_t i = 0; i < output_names.size(); ++i) {
       const std::string& name = output_names[i];
       if (name.rfind(kPresentPrefix, 0) != 0) continue;
-      cache[kPastPrefix + name.substr(kPresentPrefix.size())] = std::move(outputs[i]);
+      // std::map::operator[] would default-construct a Value first (it has
+      // no default constructor), so insert_or_assign instead.
+      cache.insert_or_assign(kPastPrefix + name.substr(kPresentPrefix.size()), std::move(outputs[i]));
     }
   }
 

--- a/tools/onnx-deploy/include/onnx_deploy/onnx_deploy_c_api.h
+++ b/tools/onnx-deploy/include/onnx_deploy/onnx_deploy_c_api.h
@@ -1,0 +1,114 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * A minimal, stable C ABI over onnx_deploy::KvCachePipeline (see
+ * kv_cache_pipeline.h), mirroring onnxsim's own C ABI conventions
+ * (onnxsim/capi/onnxsim_c_api.h): every fallible entry point returns an
+ * OnnxDeployStatus and takes a nullable char** out_error for a freshly
+ * allocated, NUL-terminated message on failure.
+ *
+ * The one thing this ABI adds beyond "call into KvCachePipeline": libort
+ * (libonnxruntime.so/.dylib/.dll) is loaded and wired up at RUNTIME via
+ * onnx_deploy_load_ort(), not linked at build time. This library builds and
+ * links with zero dependency on any specific ONNX Runtime binary -- only its
+ * headers, for the Ort::* C++ wrapper types kv_cache_pipeline.h uses -- so a
+ * single compiled onnx_deploy_c.so/.dylib/.dll works against whichever
+ * libonnxruntime build the caller points it at (CPU/GPU/version/EP mix),
+ * swapped by passing a different path, no recompile. See ../../README.md.
+ */
+#ifndef ONNX_DEPLOY_C_API_H_
+#define ONNX_DEPLOY_C_API_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(_WIN32)
+#if defined(ONNX_DEPLOY_C_API_BUILD)
+#define ONNX_DEPLOY_C_API __declspec(dllexport)
+#else
+#define ONNX_DEPLOY_C_API __declspec(dllimport)
+#endif
+#else
+#define ONNX_DEPLOY_C_API __attribute__((visibility("default")))
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Return codes for every fallible entry point. */
+typedef enum OnnxDeployStatus {
+  ONNX_DEPLOY_OK = 0,
+  ONNX_DEPLOY_ERROR = 1,
+} OnnxDeployStatus;
+
+/*
+ * Loads libort_path (a libonnxruntime shared library -- an official prebuilt
+ * release's lib/libonnxruntime.so, a pip-installed onnxruntime's bundled
+ * .so, a GPU/EP-specific build, whatever the caller wants to run against)
+ * via dlopen/LoadLibrary, resolves its OrtGetApiBase export, and wires the
+ * result up as the ONNX Runtime implementation every other onnx_deploy_*
+ * call in this process uses from then on.
+ *
+ * Must be called exactly once, before any onnx_deploy_create call. Not
+ * thread-safe with itself or with other onnx_deploy_* calls (call it once,
+ * up front, before spawning any pipeline). Calling it a second time with a
+ * different path re-points the process at a different libort -- existing
+ * OnnxDeployPipeline handles created against the previous one become
+ * invalid; this is "swappable" at the process level (restart-to-swap), not
+ * a promise that two different libort builds can be live in the same
+ * process at once.
+ *
+ * Returns ONNX_DEPLOY_OK on success. On ONNX_DEPLOY_ERROR, *out_error
+ * receives a newly allocated, NUL-terminated message (if out_error is
+ * non-NULL); release it with onnx_deploy_free_string.
+ */
+ONNX_DEPLOY_C_API OnnxDeployStatus onnx_deploy_load_ort(const char* libort_path, char** out_error);
+
+/* Opaque handle over a loaded optimum-onnx export directory's sessions. */
+typedef struct OnnxDeployPipeline OnnxDeployPipeline;
+
+/*
+ * Loads model_dir (see ../../README.md for the expected optimum-onnx
+ * no_post_process=True export shape). onnx_deploy_load_ort must have
+ * succeeded first. Returns NULL on failure, with *out_error set the same
+ * way as onnx_deploy_load_ort (out_error may be NULL).
+ */
+ONNX_DEPLOY_C_API OnnxDeployPipeline* onnx_deploy_create(const char* model_dir, char** out_error);
+
+/* Releases a pipeline created by onnx_deploy_create. NULL is ignored. */
+ONNX_DEPLOY_C_API void onnx_deploy_destroy(OnnxDeployPipeline* pipeline);
+
+/* Nonzero if `pipeline` loaded an encoder_model.onnx (seq2seq export). */
+ONNX_DEPLOY_C_API int onnx_deploy_is_seq2seq(const OnnxDeployPipeline* pipeline);
+
+/*
+ * Greedy-decodes up to max_new_tokens token ids (batch size 1), stopping
+ * early if a generated id equals eos_token_id (pass -1 to disable early
+ * stop). `input_ids`/`num_input_ids` is the encoder input for a seq2seq
+ * pipeline, or the decoder prompt for a decoder-only one.
+ * decoder_start_token_id is only used for seq2seq pipelines.
+ *
+ * On success, returns ONNX_DEPLOY_OK and sets *out_ids to a freshly
+ * allocated array of *out_count int64_t token ids (the newly generated
+ * ids, not including the prompt); release it with onnx_deploy_free_ids.
+ * On ONNX_DEPLOY_ERROR, *out_error is set the same way as
+ * onnx_deploy_load_ort (out_error may be NULL); *out_ids/*out_count are
+ * left untouched.
+ */
+ONNX_DEPLOY_C_API OnnxDeployStatus onnx_deploy_generate(OnnxDeployPipeline* pipeline, const int64_t* input_ids,
+                                                         size_t num_input_ids, int64_t max_new_tokens,
+                                                         int64_t eos_token_id, int64_t decoder_start_token_id,
+                                                         int64_t** out_ids, size_t* out_count, char** out_error);
+
+/* Free an array returned via an out_ids parameter. NULL is ignored. */
+ONNX_DEPLOY_C_API void onnx_deploy_free_ids(int64_t* ids);
+
+/* Free a string returned via an out_error parameter. NULL is ignored. */
+ONNX_DEPLOY_C_API void onnx_deploy_free_string(char* data);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ONNX_DEPLOY_C_API_H_ */

--- a/tools/onnx-deploy/python/CMakeLists.txt
+++ b/tools/onnx-deploy/python/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Builds onnx_deploy_py, a compiled nanobind extension over the onnx_deploy_c
+# ABI (see ../include/onnx_deploy/onnx_deploy_c_api.h and onnx_deploy_py.cc).
+# Only configured when the parent CMakeLists is run with -DONNX_DEPLOY_PYTHON=ON;
+# see ../README.md for why this exists (a compiled alternative to
+# optimum.onnxruntime's pure-Python generate() loop) and its scope.
+#
+# Follows the same nanobind CMake integration pattern as onnxsim's own
+# top-level CMakeLists.txt (onnxsim_cpp2py_export): nanobind ships its CMake
+# package config inside its own pip-installed wheel, so it must be located
+# via `python -m nanobind --cmake_dir` before find_package(nanobind) works.
+find_package(Python 3.10 COMPONENTS Interpreter Development.Module REQUIRED)
+
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  OUTPUT_VARIABLE ONNX_DEPLOY_NANOBIND_CMAKE_DIR)
+set(nanobind_DIR "${ONNX_DEPLOY_NANOBIND_CMAKE_DIR}" CACHE PATH "" FORCE)
+find_package(nanobind CONFIG REQUIRED)
+
+nanobind_add_module(onnx_deploy_py onnx_deploy_py.cc)
+target_include_directories(onnx_deploy_py PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+target_link_libraries(onnx_deploy_py PRIVATE onnx_deploy_c)
+set_target_properties(onnx_deploy_py PROPERTIES
+  BUILD_RPATH "$ORIGIN"
+  INSTALL_RPATH "$ORIGIN"
+)

--- a/tools/onnx-deploy/python/onnx_deploy_py.cc
+++ b/tools/onnx-deploy/python/onnx_deploy_py.cc
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Compiled nanobind binding over the onnx_deploy C ABI (onnx_deploy_c_api.h)
+// -- not over kv_cache_pipeline.h directly, so this file has no ORT header
+// dependency at all; it only needs the plain-C onnx_deploy_c_api.h and links
+// against the already-built onnx_deploy_c shared library. See ../README.md
+// for why this exists: a compiled, opaque alternative to
+// optimum.onnxruntime's pure-Python encoder/decoder/KV-cache generate() loop.
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "onnx_deploy/onnx_deploy_c_api.h"
+
+namespace nb = nanobind;
+
+namespace {
+
+[[noreturn]] void ThrowFromError(const char* what, char* err) {
+  std::string msg = std::string(what) + ": " + (err ? err : "(no message)");
+  onnx_deploy_free_string(err);
+  throw std::runtime_error(msg);
+}
+
+void LoadOrt(const std::string& libort_path) {
+  char* err = nullptr;
+  if (onnx_deploy_load_ort(libort_path.c_str(), &err) != ONNX_DEPLOY_OK) ThrowFromError("load_ort", err);
+}
+
+class Pipeline {
+ public:
+  explicit Pipeline(const std::string& model_dir) {
+    char* err = nullptr;
+    handle_ = onnx_deploy_create(model_dir.c_str(), &err);
+    if (!handle_) ThrowFromError("Pipeline", err);
+  }
+  ~Pipeline() { onnx_deploy_destroy(handle_); }
+  Pipeline(const Pipeline&) = delete;
+  Pipeline& operator=(const Pipeline&) = delete;
+
+  bool is_seq2seq() const { return onnx_deploy_is_seq2seq(handle_) != 0; }
+
+  std::vector<int64_t> generate(const std::vector<int64_t>& input_ids, int64_t max_new_tokens, int64_t eos_token_id,
+                                 int64_t decoder_start_token_id) {
+    int64_t* out_ids = nullptr;
+    size_t out_count = 0;
+    char* err = nullptr;
+    OnnxDeployStatus status = onnx_deploy_generate(handle_, input_ids.data(), input_ids.size(), max_new_tokens,
+                                                    eos_token_id, decoder_start_token_id, &out_ids, &out_count, &err);
+    if (status != ONNX_DEPLOY_OK) ThrowFromError("generate", err);
+    std::vector<int64_t> result(out_ids, out_ids + out_count);
+    onnx_deploy_free_ids(out_ids);
+    return result;
+  }
+
+ private:
+  OnnxDeployPipeline* handle_ = nullptr;
+};
+
+}  // namespace
+
+NB_MODULE(onnx_deploy_py, m) {
+  m.doc() =
+      "Compiled Python binding over onnx_deploy's C ABI: the same "
+      "swappable-libort encoder/decoder KV-cache generation pipeline the "
+      "onnx-deploy CLI uses, callable from Python without going through "
+      "optimum.onnxruntime's pure-Python generate() loop.";
+
+  m.def("load_ort", &LoadOrt, nb::arg("libort_path"),
+        "Load libonnxruntime from libort_path (via dlopen/LoadLibrary) and wire it "
+        "up for every Pipeline in this process. Call once, before constructing any "
+        "Pipeline.");
+
+  nb::class_<Pipeline>(m, "Pipeline")
+      .def(nb::init<const std::string&>(), nb::arg("model_dir"),
+           "Loads an optimum-onnx export directory (see ../README.md for the expected "
+           "file shape). load_ort() must have already succeeded.")
+      .def_prop_ro("is_seq2seq", &Pipeline::is_seq2seq)
+      .def("generate", &Pipeline::generate, nb::arg("input_ids"), nb::arg("max_new_tokens") = 32,
+           nb::arg("eos_token_id") = -1, nb::arg("decoder_start_token_id") = 0,
+           "Greedy-decode up to max_new_tokens ids (batch size 1), stopping early if a "
+           "generated id equals eos_token_id (-1 disables early stop). Returns the newly "
+           "generated ids, not including the prompt.");
+}

--- a/tools/onnx-deploy/scripts/make_toy_seq2seq.py
+++ b/tools/onnx-deploy/scripts/make_toy_seq2seq.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Builds a tiny, hand-crafted seq2seq export matching optimum-onnx's
+no_post_process=True file shape (encoder_model.onnx / decoder_model.onnx /
+decoder_with_past_model.onnx) and I/O naming convention, WITHOUT needing
+torch/transformers/optimum -- just the `onnx` package, mirroring
+tools/onnx-finetune/scripts/make_toy_model.py's role for that tool.
+
+This is not a real language model: the "logits" are a deterministic,
+hand-computable function of the encoder input and step count, specifically
+chosen so a correct KvCachePipeline run has one and only one possible output
+sequence -- see compute_expected_ids() below and README.md's "Verifying the
+flow" section for the derivation. It exists to give tools/onnx-deploy an
+end-to-end regression test with no heavy ML-framework dependency.
+
+Model (single "layer", hidden dim 1):
+  encoder_hidden_states = Cast(encoder input_ids, float), one scalar per
+    encoder position, unsqueezed to [1, enc_seq, 1].
+  decoder_model.onnx (step 0, no past):
+    self_state  = Cast(decoder input_ids[0], float)      -- seeds the
+      self-attention cache from the decoder start token.
+    cross_state = ReduceSum(encoder_hidden_states)        -- the "encoder
+      cache": computed once here, reused unchanged every step after (this
+      graph is the only one that outputs present.0.encoder.*).
+    present.0.decoder.{key,value} = self_state
+    present.0.encoder.{key,value} = cross_state
+    logits = OneHot(Mod(self_state + cross_state, vocab_size), vocab_size)
+  decoder_with_past_model.onnx (every step after):
+    new_self = past_key_values.0.decoder.key + 1          -- deliberately
+      ignores the fed input_ids and just increments, so the generated
+      sequence directly reflects whether the self-attention cache is really
+      being threaded from one Run() call to the next (a broken pipeline
+      that always re-feeds a zeroed/empty cache would produce a different,
+      non-incrementing sequence instead).
+    cross = past_key_values.0.encoder.key                 -- passed through
+      from the cache untouched; this graph does NOT re-output
+      present.0.encoder.* (matching real T5-style cross-attention caches),
+      which is exactly the case that requires KvCachePipeline to keep an
+      unrefreshed cache entry alive across steps instead of dropping it
+      once it isn't part of one call's outputs.
+    present.0.decoder.{key,value} = new_self
+    logits = OneHot(Mod(new_self + cross, vocab_size), vocab_size)
+
+Usage:
+    python3 make_toy_seq2seq.py -o toy_seq2seq --vocab-size 7 \\
+        --encoder-ids 3,4 --decoder-start-token-id 0
+"""
+
+import argparse
+import os
+
+import numpy as np
+import onnx
+from onnx import TensorProto, checker, helper
+
+
+def _onehot_logits_subgraph(builder_prefix, state_name, vocab_size):
+    """Nodes computing logits = OneHot(Mod(Cast(state, int64), vocab_size), vocab_size),
+    where `state_name` is a float [1, 1, 1] tensor. Returns (nodes, logits_name)."""
+    state_i64 = f"{builder_prefix}_state_i64"
+    index3 = f"{builder_prefix}_index3"
+    index2 = f"{builder_prefix}_index2"
+    logits = "logits"
+    nodes = [
+        helper.make_node("Cast", [state_name], [state_i64], to=TensorProto.INT64),
+        helper.make_node("Mod", [state_i64, f"{builder_prefix}_vocab_size"], [index3]),
+        helper.make_node("Squeeze", [index3, f"{builder_prefix}_axis2"], [index2]),
+        helper.make_node(
+            "OneHot", [index2, f"{builder_prefix}_depth", f"{builder_prefix}_onehot_values"], [logits], axis=-1
+        ),
+    ]
+    initializers = [
+        helper.make_tensor(f"{builder_prefix}_vocab_size", TensorProto.INT64, [1, 1, 1], [vocab_size] * 1),
+        helper.make_tensor(f"{builder_prefix}_axis2", TensorProto.INT64, [1], [2]),
+        helper.make_tensor(f"{builder_prefix}_depth", TensorProto.INT64, [], [vocab_size]),
+        helper.make_tensor(f"{builder_prefix}_onehot_values", TensorProto.FLOAT, [2], [0.0, 1.0]),
+    ]
+    return nodes, initializers, logits
+
+
+def make_encoder_model(enc_seq_len):
+    input_ids = helper.make_tensor_value_info("input_ids", TensorProto.INT64, [1, enc_seq_len])
+    attention_mask = helper.make_tensor_value_info("attention_mask", TensorProto.INT64, [1, enc_seq_len])
+    encoder_hidden_states = helper.make_tensor_value_info(
+        "encoder_hidden_states", TensorProto.FLOAT, [1, enc_seq_len, 1]
+    )
+    nodes = [
+        helper.make_node("Cast", ["input_ids"], ["ids_f"], to=TensorProto.FLOAT),
+        helper.make_node("Unsqueeze", ["ids_f", "axis_neg1"], ["encoder_hidden_states"]),
+    ]
+    initializers = [helper.make_tensor("axis_neg1", TensorProto.INT64, [1], [-1])]
+    graph = helper.make_graph(
+        nodes, "toy_encoder", [input_ids, attention_mask], [encoder_hidden_states], initializer=initializers
+    )
+    return helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)], ir_version=9)
+
+
+def make_decoder_model(enc_seq_len, vocab_size):
+    input_ids = helper.make_tensor_value_info("input_ids", TensorProto.INT64, [1, 1])
+    encoder_attention_mask = helper.make_tensor_value_info(
+        "encoder_attention_mask", TensorProto.INT64, [1, enc_seq_len]
+    )
+    encoder_hidden_states = helper.make_tensor_value_info(
+        "encoder_hidden_states", TensorProto.FLOAT, [1, enc_seq_len, 1]
+    )
+
+    nodes = [
+        helper.make_node("Cast", ["input_ids"], ["ids_f"], to=TensorProto.FLOAT),
+        helper.make_node("Unsqueeze", ["ids_f", "axis_neg1"], ["self_state"]),
+        helper.make_node("ReduceSum", ["encoder_hidden_states", "axis1"], ["cross_state"], keepdims=1),
+        helper.make_node("Identity", ["self_state"], ["present.0.decoder.key"]),
+        helper.make_node("Identity", ["self_state"], ["present.0.decoder.value"]),
+        helper.make_node("Identity", ["cross_state"], ["present.0.encoder.key"]),
+        helper.make_node("Identity", ["cross_state"], ["present.0.encoder.value"]),
+        helper.make_node("Add", ["self_state", "cross_state"], ["accumulated"]),
+    ]
+    initializers = [
+        helper.make_tensor("axis_neg1", TensorProto.INT64, [1], [-1]),
+        helper.make_tensor("axis1", TensorProto.INT64, [1], [1]),
+    ]
+    onehot_nodes, onehot_inits, logits_name = _onehot_logits_subgraph("d0", "accumulated", vocab_size)
+    nodes += onehot_nodes
+    initializers += onehot_inits
+    assert logits_name == "logits"
+
+    outputs = [
+        helper.make_tensor_value_info("logits", TensorProto.FLOAT, [1, 1, vocab_size]),
+        helper.make_tensor_value_info("present.0.decoder.key", TensorProto.FLOAT, [1, 1, 1]),
+        helper.make_tensor_value_info("present.0.decoder.value", TensorProto.FLOAT, [1, 1, 1]),
+        helper.make_tensor_value_info("present.0.encoder.key", TensorProto.FLOAT, [1, 1, 1]),
+        helper.make_tensor_value_info("present.0.encoder.value", TensorProto.FLOAT, [1, 1, 1]),
+    ]
+    graph = helper.make_graph(
+        nodes,
+        "toy_decoder",
+        [input_ids, encoder_attention_mask, encoder_hidden_states],
+        outputs,
+        initializer=initializers,
+    )
+    return helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)], ir_version=9)
+
+
+def make_decoder_with_past_model(enc_seq_len, vocab_size):
+    input_ids = helper.make_tensor_value_info("input_ids", TensorProto.INT64, [1, 1])
+    encoder_attention_mask = helper.make_tensor_value_info(
+        "encoder_attention_mask", TensorProto.INT64, [1, enc_seq_len]
+    )
+    past_decoder_key = helper.make_tensor_value_info("past_key_values.0.decoder.key", TensorProto.FLOAT, [1, 1, 1])
+    past_decoder_value = helper.make_tensor_value_info(
+        "past_key_values.0.decoder.value", TensorProto.FLOAT, [1, 1, 1]
+    )
+    past_encoder_key = helper.make_tensor_value_info("past_key_values.0.encoder.key", TensorProto.FLOAT, [1, 1, 1])
+    past_encoder_value = helper.make_tensor_value_info(
+        "past_key_values.0.encoder.value", TensorProto.FLOAT, [1, 1, 1]
+    )
+
+    nodes = [
+        # Deliberately ignores input_ids for the increment -- see module
+        # docstring: this makes the generated sequence a direct witness of
+        # whether the self-attention cache is threaded correctly.
+        helper.make_node("Add", ["past_key_values.0.decoder.key", "one_const"], ["new_self"]),
+        helper.make_node("Identity", ["new_self"], ["present.0.decoder.key"]),
+        helper.make_node("Identity", ["new_self"], ["present.0.decoder.value"]),
+        # NOT re-output as present.0.encoder.* -- exercises KvCachePipeline
+        # keeping this cache entry alive across steps on its own.
+        helper.make_node("Identity", ["past_key_values.0.encoder.key"], ["cross"]),
+        helper.make_node("Add", ["new_self", "cross"], ["accumulated"]),
+    ]
+    initializers = [helper.make_tensor("one_const", TensorProto.FLOAT, [1, 1, 1], [1.0])]
+    onehot_nodes, onehot_inits, logits_name = _onehot_logits_subgraph("dp0", "accumulated", vocab_size)
+    nodes += onehot_nodes
+    initializers += onehot_inits
+    assert logits_name == "logits"
+
+    outputs = [
+        helper.make_tensor_value_info("logits", TensorProto.FLOAT, [1, 1, vocab_size]),
+        helper.make_tensor_value_info("present.0.decoder.key", TensorProto.FLOAT, [1, 1, 1]),
+        helper.make_tensor_value_info("present.0.decoder.value", TensorProto.FLOAT, [1, 1, 1]),
+    ]
+    graph = helper.make_graph(
+        nodes,
+        "toy_decoder_with_past",
+        [input_ids, encoder_attention_mask, past_decoder_key, past_decoder_value, past_encoder_key, past_encoder_value],
+        outputs,
+        initializer=initializers,
+    )
+    return helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)], ir_version=9)
+
+
+def compute_expected_ids(encoder_ids, decoder_start_token_id, vocab_size, max_new_tokens, eos_token_id=None):
+    """Reference implementation of the toy model's math, independent of ONNX
+    Runtime, for asserting against KvCachePipeline's actual output."""
+    cross = float(sum(encoder_ids))
+    self_state = float(decoder_start_token_id)
+    generated = []
+    for step in range(max_new_tokens):
+        if step > 0:
+            self_state = self_state + 1.0
+        accumulated = self_state + cross
+        token = int(accumulated) % vocab_size
+        generated.append(token)
+        if eos_token_id is not None and token == eos_token_id:
+            break
+    return generated
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("-o", "--output-dir", required=True)
+    parser.add_argument("--vocab-size", type=int, default=7)
+    parser.add_argument("--encoder-ids", default="3,4", help="comma-separated encoder input token ids")
+    parser.add_argument("--decoder-start-token-id", type=int, default=0)
+    args = parser.parse_args()
+
+    encoder_ids = [int(x) for x in args.encoder_ids.split(",")]
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    models = {
+        "encoder_model.onnx": make_encoder_model(len(encoder_ids)),
+        "decoder_model.onnx": make_decoder_model(len(encoder_ids), args.vocab_size),
+        "decoder_with_past_model.onnx": make_decoder_with_past_model(len(encoder_ids), args.vocab_size),
+    }
+    for name, model in models.items():
+        checker.check_model(model)
+        onnx.save(model, os.path.join(args.output_dir, name))
+        print(f"wrote {name}")
+
+    print(f"encoder_ids={encoder_ids} decoder_start_token_id={args.decoder_start_token_id} "
+          f"vocab_size={args.vocab_size}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/onnx-deploy/src/main.cpp
+++ b/tools/onnx-deploy/src/main.cpp
@@ -1,7 +1,8 @@
 // onnx-deploy: drive an optimum-onnx export directory's encoder/decoder(-with-past)
-// ONNX files through a greedy autoregressive generate() loop, in plain C++
-// via onnx_deploy::KvCachePipeline. No tokenizer -- pass/receive token ids
-// directly (get them from transformers.AutoTokenizer separately). See
+// ONNX files through a greedy autoregressive generate() loop, in plain C++,
+// via the onnx_deploy C ABI (onnx_deploy_c_api.h) -- the same swappable-libort
+// interface any other language would use. No tokenizer -- pass/receive token
+// ids directly (get them from transformers.AutoTokenizer separately). See
 // ../README.md for the design and its scope.
 
 #include <cstdio>
@@ -10,11 +11,12 @@
 #include <string>
 #include <vector>
 
-#include "onnx_deploy/kv_cache_pipeline.h"
+#include "onnx_deploy/onnx_deploy_c_api.h"
 
 namespace {
 
 struct Args {
+  std::string libort_path;
   std::string model_dir;
   std::vector<int64_t> input_ids;
   int64_t max_new_tokens = 32;
@@ -24,8 +26,11 @@ struct Args {
 
 [[noreturn]] void Usage(const char* prog) {
   std::fprintf(stderr,
-      "usage: %s <export_dir> <id1,id2,...> [--max-new-tokens N]\n"
+      "usage: %s --libort PATH <export_dir> <id1,id2,...> [--max-new-tokens N]\n"
       "          [--eos-token-id N] [--decoder-start-token-id N]\n\n"
+      "--libort PATH points at the libonnxruntime shared library to load at\n"
+      "runtime (e.g. an extracted onnxruntime-linux-x64-*.tgz's lib/libonnxruntime.so) --\n"
+      "any build works, nothing about this tool is compiled against a specific one.\n\n"
       "<export_dir> must contain decoder_model.onnx + decoder_with_past_model.onnx\n"
       "(and encoder_model.onnx for seq2seq models) -- the optimum-onnx\n"
       "no_post_process=True export shape. <id1,id2,...> are token ids (from a\n"
@@ -43,28 +48,38 @@ std::vector<int64_t> ParseIds(const std::string& csv) {
 }
 
 Args ParseArgs(int argc, char** argv) {
-  if (argc < 3) Usage(argv[0]);
   Args a;
-  a.model_dir = argv[1];
-  a.input_ids = ParseIds(argv[2]);
+  std::vector<std::string> positional;
 
   auto need = [&](int& i) -> std::string {
     if (i + 1 >= argc) Usage(argv[0]);
     return argv[++i];
   };
-  for (int i = 3; i < argc; ++i) {
+  for (int i = 1; i < argc; ++i) {
     std::string arg = argv[i];
-    if (arg == "--max-new-tokens") a.max_new_tokens = std::stoll(need(i));
+    if (arg == "--libort") a.libort_path = need(i);
+    else if (arg == "--max-new-tokens") a.max_new_tokens = std::stoll(need(i));
     else if (arg == "--eos-token-id") a.eos_token_id = std::stoll(need(i));
     else if (arg == "--decoder-start-token-id") a.decoder_start_token_id = std::stoll(need(i));
     else if (arg == "-h" || arg == "--help") Usage(argv[0]);
-    else {
+    else if (!arg.empty() && arg[0] == '-') {
       std::fprintf(stderr, "unknown argument: %s\n", arg.c_str());
       Usage(argv[0]);
+    } else {
+      positional.push_back(arg);
     }
   }
+  if (a.libort_path.empty() || positional.size() != 2) Usage(argv[0]);
+  a.model_dir = positional[0];
+  a.input_ids = ParseIds(positional[1]);
   if (a.input_ids.empty()) Usage(argv[0]);
   return a;
+}
+
+[[noreturn]] void Die(const char* what, char* err) {
+  std::fprintf(stderr, "error: %s: %s\n", what, err ? err : "(no message)");
+  onnx_deploy_free_string(err);
+  std::exit(1);
 }
 
 }  // namespace
@@ -72,27 +87,29 @@ Args ParseArgs(int argc, char** argv) {
 int main(int argc, char** argv) {
   Args args = ParseArgs(argc, argv);
 
-  Ort::Env env(ORT_LOGGING_LEVEL_WARNING, "onnx-deploy");
+  char* err = nullptr;
+  if (onnx_deploy_load_ort(args.libort_path.c_str(), &err) != ONNX_DEPLOY_OK) Die("onnx_deploy_load_ort", err);
 
-  try {
-    onnx_deploy::KvCachePipeline pipeline(env, args.model_dir);
-    std::printf("loaded %s pipeline from %s\n", pipeline.is_seq2seq() ? "seq2seq" : "decoder-only",
-                args.model_dir.c_str());
+  OnnxDeployPipeline* pipeline = onnx_deploy_create(args.model_dir.c_str(), &err);
+  if (!pipeline) Die("onnx_deploy_create", err);
+  std::printf("loaded %s pipeline from %s (via %s)\n", onnx_deploy_is_seq2seq(pipeline) ? "seq2seq" : "decoder-only",
+              args.model_dir.c_str(), args.libort_path.c_str());
 
-    onnx_deploy::GenerationConfig config;
-    config.max_new_tokens = args.max_new_tokens;
-    config.eos_token_id = args.eos_token_id;
-    config.decoder_start_token_id = args.decoder_start_token_id;
-
-    std::vector<int64_t> generated = pipeline.Generate(args.input_ids, config);
-
-    std::printf("generated %zu token(s):", generated.size());
-    for (int64_t id : generated) std::printf(" %lld", static_cast<long long>(id));
-    std::printf("\n");
-  } catch (const std::exception& e) {
-    std::fprintf(stderr, "error: %s\n", e.what());
-    return 1;
+  int64_t* out_ids = nullptr;
+  size_t out_count = 0;
+  OnnxDeployStatus status =
+      onnx_deploy_generate(pipeline, args.input_ids.data(), args.input_ids.size(), args.max_new_tokens,
+                            args.eos_token_id, args.decoder_start_token_id, &out_ids, &out_count, &err);
+  if (status != ONNX_DEPLOY_OK) {
+    onnx_deploy_destroy(pipeline);
+    Die("onnx_deploy_generate", err);
   }
 
+  std::printf("generated %zu token(s):", out_count);
+  for (size_t i = 0; i < out_count; ++i) std::printf(" %lld", static_cast<long long>(out_ids[i]));
+  std::printf("\n");
+
+  onnx_deploy_free_ids(out_ids);
+  onnx_deploy_destroy(pipeline);
   return 0;
 }

--- a/tools/onnx-deploy/src/onnx_deploy_c_api.cpp
+++ b/tools/onnx-deploy/src/onnx_deploy_c_api.cpp
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Implements onnx_deploy_c_api.h: the swappable-libort C ABI over
+// onnx_deploy::KvCachePipeline. See that header for the contract and
+// ../../README.md for the design. Built with zero link-time dependency on
+// libonnxruntime -- see onnx_deploy_load_ort below.
+
+#define ONNX_DEPLOY_C_API_BUILD
+#include "onnx_deploy/onnx_deploy_c_api.h"
+
+#include "onnx_deploy/kv_cache_pipeline.h"
+
+#include <cstring>
+#include <exception>
+#include <string>
+#include <vector>
+
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
+
+namespace {
+
+char* DupCString(const std::string& s) {
+  char* out = static_cast<char*>(std::malloc(s.size() + 1));
+  if (!out) return nullptr;
+  std::memcpy(out, s.data(), s.size());
+  out[s.size()] = '\0';
+  return out;
+}
+
+void SetError(char** out_error, const std::string& msg) {
+  if (out_error) *out_error = DupCString(msg);
+}
+
+// Resolves libonnxruntime's OrtGetApiBase export at runtime and wires the
+// result into Ort::* (see kv_cache_pipeline.h's ORT_API_MANUAL_INIT usage
+// contract). This is the whole "swappable libort" mechanism: no symbol in
+// this file, or in kv_cache_pipeline.h, is resolved against libonnxruntime
+// at link time -- only header type/inline-wrapper definitions are used, so
+// nothing here requires -lonnxruntime at all.
+using OrtGetApiBaseFn = const OrtApiBase* (*)();
+
+}  // namespace
+
+extern "C" OnnxDeployStatus onnx_deploy_load_ort(const char* libort_path, char** out_error) {
+  try {
+    OrtGetApiBaseFn get_api_base = nullptr;
+#if defined(_WIN32)
+    HMODULE handle = ::LoadLibraryA(libort_path);
+    if (!handle) {
+      SetError(out_error, std::string("LoadLibrary failed for ") + libort_path);
+      return ONNX_DEPLOY_ERROR;
+    }
+    get_api_base = reinterpret_cast<OrtGetApiBaseFn>(::GetProcAddress(handle, "OrtGetApiBase"));
+#else
+    void* handle = dlopen(libort_path, RTLD_NOW | RTLD_GLOBAL);
+    if (!handle) {
+      SetError(out_error, std::string("dlopen failed for ") + libort_path + ": " + dlerror());
+      return ONNX_DEPLOY_ERROR;
+    }
+    get_api_base = reinterpret_cast<OrtGetApiBaseFn>(dlsym(handle, "OrtGetApiBase"));
+#endif
+    if (!get_api_base) {
+      SetError(out_error, std::string(libort_path) + " has no OrtGetApiBase export -- not a libonnxruntime build?");
+      return ONNX_DEPLOY_ERROR;
+    }
+    const OrtApiBase* api_base = get_api_base();
+    if (!api_base) {
+      SetError(out_error, "OrtGetApiBase() returned NULL");
+      return ONNX_DEPLOY_ERROR;
+    }
+    const OrtApi* api = api_base->GetApi(ORT_API_VERSION);
+    if (!api) {
+      SetError(out_error,
+               "OrtApiBase::GetApi(ORT_API_VERSION=" + std::to_string(ORT_API_VERSION) +
+                   ") returned NULL -- this header's ORT_API_VERSION is newer than what libort_path implements");
+      return ONNX_DEPLOY_ERROR;
+    }
+    Ort::InitApi(api);
+    return ONNX_DEPLOY_OK;
+  } catch (const std::exception& e) {
+    SetError(out_error, e.what());
+    return ONNX_DEPLOY_ERROR;
+  } catch (...) {
+    SetError(out_error, "unknown error in onnx_deploy_load_ort");
+    return ONNX_DEPLOY_ERROR;
+  }
+}
+
+struct OnnxDeployPipeline {
+  Ort::Env env;
+  onnx_deploy::KvCachePipeline pipeline;
+  explicit OnnxDeployPipeline(const std::string& model_dir)
+      : env(ORT_LOGGING_LEVEL_WARNING, "onnx-deploy"), pipeline(env, model_dir) {}
+};
+
+extern "C" OnnxDeployPipeline* onnx_deploy_create(const char* model_dir, char** out_error) {
+  try {
+    return new OnnxDeployPipeline(model_dir ? model_dir : "");
+  } catch (const std::exception& e) {
+    SetError(out_error, e.what());
+    return nullptr;
+  } catch (...) {
+    SetError(out_error, "unknown error in onnx_deploy_create");
+    return nullptr;
+  }
+}
+
+extern "C" void onnx_deploy_destroy(OnnxDeployPipeline* pipeline) { delete pipeline; }
+
+extern "C" int onnx_deploy_is_seq2seq(const OnnxDeployPipeline* pipeline) {
+  return (pipeline && pipeline->pipeline.is_seq2seq()) ? 1 : 0;
+}
+
+extern "C" OnnxDeployStatus onnx_deploy_generate(OnnxDeployPipeline* pipeline, const int64_t* input_ids,
+                                                  size_t num_input_ids, int64_t max_new_tokens, int64_t eos_token_id,
+                                                  int64_t decoder_start_token_id, int64_t** out_ids,
+                                                  size_t* out_count, char** out_error) {
+  if (!pipeline || !input_ids || !out_ids || !out_count) {
+    SetError(out_error, "onnx_deploy_generate: null argument");
+    return ONNX_DEPLOY_ERROR;
+  }
+  try {
+    onnx_deploy::GenerationConfig config;
+    config.max_new_tokens = max_new_tokens;
+    config.eos_token_id = eos_token_id;
+    config.decoder_start_token_id = decoder_start_token_id;
+
+    std::vector<int64_t> ids(input_ids, input_ids + num_input_ids);
+    std::vector<int64_t> generated = pipeline->pipeline.Generate(ids, config);
+
+    int64_t* buf = generated.empty() ? nullptr : static_cast<int64_t*>(std::malloc(generated.size() * sizeof(int64_t)));
+    if (!generated.empty() && !buf) {
+      SetError(out_error, "onnx_deploy_generate: allocation failure");
+      return ONNX_DEPLOY_ERROR;
+    }
+    if (buf) std::memcpy(buf, generated.data(), generated.size() * sizeof(int64_t));
+    *out_ids = buf;
+    *out_count = generated.size();
+    return ONNX_DEPLOY_OK;
+  } catch (const std::exception& e) {
+    SetError(out_error, e.what());
+    return ONNX_DEPLOY_ERROR;
+  } catch (...) {
+    SetError(out_error, "unknown error in onnx_deploy_generate");
+    return ONNX_DEPLOY_ERROR;
+  }
+}
+
+extern "C" void onnx_deploy_free_ids(int64_t* ids) { std::free(ids); }
+
+extern "C" void onnx_deploy_free_string(char* data) { std::free(data); }

--- a/tools/onnx-deploy/wasm/CMakeLists.txt
+++ b/tools/onnx-deploy/wasm/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.18)
+project(onnx-deploy-wasm CXX)
+
+if(NOT EMSCRIPTEN)
+  message(FATAL_ERROR "Configure this with an Emscripten toolchain, e.g.:\n  emcmake cmake -B build\n  cmake --build build\nSee ../README.md's WASM section.")
+endif()
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
+# No ONNX Runtime dependency at all here -- unlike tools/onnx-finetune/wasm
+# (which statically compiles ONNX Runtime from source into the module), this
+# target has zero ORT C/C++ code: every tensor computation happens in JS via
+# onnxruntime-web, reached through src/onnx_deploy_wasm.cpp's Asyncify calls.
+# "Swappable libort" here means the JS host picks which onnxruntime-web
+# build/version/execution-provider implements Module.onnxDeployRunSession --
+# see ../test/ort_web_runtime.mjs for the reference implementation.
+add_executable(onnx_deploy_wasm src/onnx_deploy_wasm.cpp)
+target_link_options(onnx_deploy_wasm PRIVATE
+  "-lembind"
+  "-sASYNCIFY=1"
+  "-sMODULARIZE=1"
+  "-sEXPORT_ES6=1"
+  "-sEXPORT_NAME=createOnnxDeployWasmModule"
+  "-sALLOW_MEMORY_GROWTH=1"
+  "-sENVIRONMENT=web,node"
+)

--- a/tools/onnx-deploy/wasm/src/onnx_deploy_wasm.cpp
+++ b/tools/onnx-deploy/wasm/src/onnx_deploy_wasm.cpp
@@ -1,0 +1,244 @@
+// onnx_deploy_wasm.cpp
+//
+// WASM port of onnx_deploy::KvCachePipeline's algorithm (see
+// ../../include/onnx_deploy/kv_cache_pipeline.h and ../../README.md), driven
+// through JS/onnxruntime-web instead of a native Ort::Session, so "swappable
+// libort" in the browser means the JS host picking which onnxruntime-web
+// build/version/execution-provider backs Module.onnxDeployRunSession --
+// there is no ONNX Runtime C/C++ dependency in this file or its CMakeLists.txt
+// at all.
+//
+// This reuses the SAME two design decisions as the native pipeline --
+// present.* -> past_key_values.* renamed purely by string substitution, and
+// a cache entry not re-output by a call stays valid for later calls -- but
+// against a much simpler tensor representation (WasmTensor, data always as
+// std::vector<double>) instead of Ort::Value, since there is no native ORT
+// here to hand real typed buffers to. int64 tensor values (token ids, small
+// counts) round-trip through `double` exactly for anything under 2^53; this
+// is fine for what this pipeline actually carries (ids, KV-cache tensors of
+// modest size) and is called out here rather than silently assumed.
+//
+// The JS/C++ boundary (see ../test/ort_web_runtime.mjs for the reference
+// implementation, and Emscripten's ASYNCIFY docs for the val::await()
+// mechanism this relies on):
+//   Module.onnxDeployCreateSession(modelBytes: Uint8Array)
+//     -> Promise<{handle: number, inputNames: string[], outputNames: string[]}>
+//   Module.onnxDeployRunSession(handle: number, inputs: TensorObj[], outputNames: string[])
+//     -> Promise<TensorObj[]>   // one entry per outputNames, same order
+//   where TensorObj = {name: string, dtype: "int64"|"float32", shape: number[], data: number[]}
+//
+// Scope note: unlike the native/Python layers (a KvCachePipeline object you
+// can call .generate() on repeatedly), this exposes ONE async entry point,
+// generate(), that creates sessions, runs the whole decode loop, and returns
+// -- proving persistent sessions held across many Asyncify-awaited calls
+// works (this repo's only prior Asyncify bridge, JsModelExecutor, is
+// single-call), without also building a stateful class-lifetime API on top.
+// A reusable Pipeline class wrapping multiple generate() calls without
+// re-creating sessions each time is a natural follow-up, not done here.
+
+#include <emscripten/bind.h>
+#include <emscripten/val.h>
+
+#include <cstdint>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using emscripten::val;
+
+namespace {
+
+struct WasmTensor {
+  std::string dtype;         // "int64" or "float32"
+  std::vector<double> shape;
+  std::vector<double> data;  // row-major, flattened
+};
+
+val TensorToVal(const std::string& name, const WasmTensor& t) {
+  val obj = val::object();
+  obj.set("name", name);
+  obj.set("dtype", t.dtype);
+  obj.set("shape", val::array(t.shape.begin(), t.shape.end()));
+  obj.set("data", val::array(t.data.begin(), t.data.end()));
+  return obj;
+}
+
+WasmTensor ValToTensor(const val& obj) {
+  WasmTensor t;
+  t.dtype = obj["dtype"].as<std::string>();
+  t.shape = emscripten::vecFromJSArray<double>(obj["shape"]);
+  t.data = emscripten::vecFromJSArray<double>(obj["data"]);
+  return t;
+}
+
+WasmTensor MakeIdsTensor(const std::vector<int64_t>& ids) {
+  WasmTensor t;
+  t.dtype = "int64";
+  t.shape = {1, static_cast<double>(ids.size())};
+  t.data.assign(ids.begin(), ids.end());
+  return t;
+}
+
+WasmTensor MakeMaskTensor(size_t len) {
+  WasmTensor t;
+  t.dtype = "int64";
+  t.shape = {1, static_cast<double>(len)};
+  t.data.assign(len, 1.0);
+  return t;
+}
+
+struct Session {
+  double handle = -1;
+  std::vector<std::string> input_names;
+  std::vector<std::string> output_names;
+};
+
+// Awaits Module.onnxDeployCreateSession(bytes) and records the returned
+// handle + the graph's actual input/output names (mirrors
+// kv_cache_pipeline.h's detail::InputNames/OutputNames, which read them off
+// a native Ort::Session -- here they come back from the JS-side
+// ort.InferenceSession instead).
+Session CreateSession(const val& bytes) {
+  val result = val::module_property("onnxDeployCreateSession")(bytes).await();
+  Session s;
+  s.handle = result["handle"].as<double>();
+  s.input_names = emscripten::vecFromJSArray<std::string>(result["inputNames"]);
+  s.output_names = emscripten::vecFromJSArray<std::string>(result["outputNames"]);
+  return s;
+}
+
+// Awaits Module.onnxDeployRunSession(handle, inputs, outputNames), returning
+// one WasmTensor per requested output name, same order.
+std::vector<WasmTensor> RunSession(const Session& session, const std::map<std::string, WasmTensor>& named_inputs) {
+  val inputs_arr = val::array();
+  for (const auto& name : session.input_names) {
+    auto it = named_inputs.find(name);
+    if (it == named_inputs.end()) throw std::runtime_error("RunSession: no value supplied for input " + name);
+    inputs_arr.call<void>("push", TensorToVal(name, it->second));
+  }
+  val output_names_arr = val::array(session.output_names.begin(), session.output_names.end());
+
+  val result = val::module_property("onnxDeployRunSession")(session.handle, inputs_arr, output_names_arr).await();
+  std::vector<WasmTensor> outputs;
+  outputs.reserve(session.output_names.size());
+  for (size_t i = 0; i < session.output_names.size(); ++i) outputs.push_back(ValToTensor(result[i]));
+  return outputs;
+}
+
+// Builds the named-input map for one decoder Run() call, exactly mirroring
+// kv_cache_pipeline.h's RunDecoderStep dispatch (same input-name
+// conventions), then harvests present.* into `cache` the same way
+// HarvestPresentIntoCache does. Returns the logits tensor.
+WasmTensor RunDecoderStep(const Session& session, const std::vector<int64_t>& step_input_ids,
+                           const WasmTensor* encoder_hidden_states, size_t encoder_seq_len, size_t total_len,
+                           std::map<std::string, WasmTensor>& cache) {
+  std::map<std::string, WasmTensor> named_inputs;
+  for (const auto& name : session.input_names) {
+    if (name == "input_ids") {
+      named_inputs[name] = MakeIdsTensor(step_input_ids);
+    } else if (name == "attention_mask") {
+      named_inputs[name] = MakeMaskTensor(total_len);
+    } else if (name == "encoder_attention_mask") {
+      named_inputs[name] = MakeMaskTensor(encoder_seq_len);
+    } else if (name == "encoder_hidden_states") {
+      if (!encoder_hidden_states) throw std::runtime_error("decoder graph wants encoder_hidden_states but no encoder ran");
+      named_inputs[name] = *encoder_hidden_states;
+    } else if (name.rfind("past_key_values.", 0) == 0) {
+      auto it = cache.find(name);
+      if (it == cache.end()) throw std::runtime_error("missing cache entry for " + name);
+      named_inputs[name] = it->second;  // WasmTensor copies its (small) data vector -- no move-only constraint here
+    } else {
+      throw std::runtime_error("unrecognized decoder input: " + name);
+    }
+  }
+
+  std::vector<WasmTensor> outputs = RunSession(session, named_inputs);
+
+  static const std::string kPresentPrefix = "present.";
+  static const std::string kPastPrefix = "past_key_values.";
+  const WasmTensor* logits = nullptr;
+  for (size_t i = 0; i < session.output_names.size(); ++i) {
+    const std::string& name = session.output_names[i];
+    if (name == "logits") {
+      logits = &outputs[i];
+    } else if (name.rfind(kPresentPrefix, 0) == 0) {
+      cache[kPastPrefix + name.substr(kPresentPrefix.size())] = outputs[i];
+    }
+  }
+  if (!logits) throw std::runtime_error("decoder graph has no 'logits' output");
+  return *logits;
+}
+
+int64_t ArgmaxLastToken(const WasmTensor& logits) {
+  size_t vocab = static_cast<size_t>(logits.shape.back());
+  size_t seq = logits.shape.size() >= 2 ? static_cast<size_t>(logits.shape[logits.shape.size() - 2]) : 1;
+  size_t offset = (seq - 1) * vocab;
+  size_t best = 0;
+  double best_val = -1e300;
+  for (size_t v = 0; v < vocab; ++v) {
+    double x = logits.data[offset + v];
+    if (x > best_val) {
+      best_val = x;
+      best = v;
+    }
+  }
+  return static_cast<int64_t>(best);
+}
+
+// Mirrors KvCachePipeline::Generate. `encoder_bytes` may be val::undefined()/
+// val::null() for a decoder-only (causal LM) pipeline.
+val Generate(val encoder_bytes, val decoder_bytes, val decoder_past_bytes, val input_ids_val, double max_new_tokens,
+             double eos_token_id, double decoder_start_token_id) {
+  bool is_seq2seq = !(encoder_bytes.isUndefined() || encoder_bytes.isNull());
+  std::vector<double> input_ids_d = emscripten::vecFromJSArray<double>(input_ids_val);
+  std::vector<int64_t> input_ids(input_ids_d.begin(), input_ids_d.end());
+
+  Session decoder_session = CreateSession(decoder_bytes);
+  Session decoder_past_session = CreateSession(decoder_past_bytes);
+
+  WasmTensor encoder_hidden_states;
+  size_t encoder_seq_len = 0;
+  bool have_encoder_hidden_states = false;
+  if (is_seq2seq) {
+    Session encoder_session = CreateSession(encoder_bytes);
+    encoder_seq_len = input_ids.size();
+    std::map<std::string, WasmTensor> enc_inputs;
+    for (const auto& name : encoder_session.input_names) {
+      if (name == "input_ids") enc_inputs[name] = MakeIdsTensor(input_ids);
+      else if (name == "attention_mask") enc_inputs[name] = MakeMaskTensor(input_ids.size());
+      else throw std::runtime_error("unrecognized encoder input: " + name);
+    }
+    std::vector<WasmTensor> enc_outputs = RunSession(encoder_session, enc_inputs);
+    encoder_hidden_states = enc_outputs.front();  // last_hidden_state is the encoder's only output
+    have_encoder_hidden_states = true;
+  }
+
+  std::map<std::string, WasmTensor> cache;
+  std::vector<int64_t> decoder_tokens =
+      is_seq2seq ? std::vector<int64_t>{static_cast<int64_t>(decoder_start_token_id)} : input_ids;
+  std::vector<int64_t> generated;
+  bool use_past = false;
+  int64_t eos = static_cast<int64_t>(eos_token_id);
+
+  for (int64_t step = 0; step < static_cast<int64_t>(max_new_tokens); ++step) {
+    std::vector<int64_t> step_input = use_past ? std::vector<int64_t>{decoder_tokens.back()} : decoder_tokens;
+    size_t total_len = decoder_tokens.size();
+
+    const Session& session = use_past ? decoder_past_session : decoder_session;
+    WasmTensor logits = RunDecoderStep(session, step_input, have_encoder_hidden_states ? &encoder_hidden_states : nullptr,
+                                        encoder_seq_len, total_len, cache);
+    int64_t next_token = ArgmaxLastToken(logits);
+    generated.push_back(next_token);
+    decoder_tokens.push_back(next_token);
+    use_past = true;
+
+    if (eos_token_id >= 0 && next_token == eos) break;
+  }
+
+  return val::array(generated.begin(), generated.end());
+}
+
+}  // namespace
+
+EMSCRIPTEN_BINDINGS(onnx_deploy_wasm) { emscripten::function("generate", &Generate); }

--- a/tools/onnx-deploy/wasm/test/ort_web_runtime.mjs
+++ b/tools/onnx-deploy/wasm/test/ort_web_runtime.mjs
@@ -1,0 +1,53 @@
+// Reference implementation of the Module.onnxDeployCreateSession /
+// Module.onnxDeployRunSession functions onnx_deploy_wasm.cpp calls via
+// Asyncify -- see that file's header comment for the exact contract. Backed
+// by onnxruntime-web, so swapping this file (or its `ort` import) for a
+// different onnxruntime-web build/version/execution-provider is the whole
+// "swappable libort" story on the WASM side, mirroring the native side's
+// dlopen(libort_path) swap at the JS/wasm boundary instead of the OS loader.
+//
+// installRuntime(moduleConfig) mutates and returns the Emscripten module
+// config object (the one passed to createOnnxDeployWasmModule({...})),
+// adding these two functions to it -- they must be present before any
+// exported wasm function that calls them runs.
+
+import * as ort from "onnxruntime-web";
+
+export function installRuntime(moduleConfig) {
+  const sessions = new Map();
+  let nextHandle = 1;
+
+  moduleConfig.onnxDeployCreateSession = async (bytes) => {
+    const session = await ort.InferenceSession.create(bytes);
+    const handle = nextHandle++;
+    sessions.set(handle, session);
+    return { handle, inputNames: session.inputNames, outputNames: session.outputNames };
+  };
+
+  moduleConfig.onnxDeployRunSession = async (handle, inputs, outputNames) => {
+    const session = sessions.get(handle);
+    if (!session) throw new Error(`onnxDeployRunSession: unknown session handle ${handle}`);
+
+    const feeds = {};
+    for (const t of inputs) {
+      const dims = t.shape.map((d) => Number(d));
+      if (t.dtype === "int64") {
+        feeds[t.name] = new ort.Tensor("int64", BigInt64Array.from(t.data.map((v) => BigInt(Math.trunc(v)))), dims);
+      } else if (t.dtype === "float32") {
+        feeds[t.name] = new ort.Tensor("float32", Float32Array.from(t.data), dims);
+      } else {
+        throw new Error(`onnxDeployRunSession: unsupported dtype ${t.dtype} for input ${t.name}`);
+      }
+    }
+
+    const results = await session.run(feeds, outputNames);
+
+    return outputNames.map((name) => {
+      const t = results[name];
+      const data = t.type === "int64" ? Array.from(t.data, (v) => Number(v)) : Array.from(t.data);
+      return { name, dtype: t.type === "int64" ? "int64" : "float32", shape: Array.from(t.dims), data };
+    });
+  };
+
+  return moduleConfig;
+}

--- a/tools/onnx-deploy/wasm/test/package-lock.json
+++ b/tools/onnx-deploy/wasm/test/package-lock.json
@@ -1,0 +1,152 @@
+{
+  "name": "onnx-deploy-wasm-test",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "onnx-deploy-wasm-test",
+      "dependencies": {
+        "onnxruntime-web": "^1.19.2"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@types/node": {
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
+      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.29.0.tgz",
+      "integrity": "sha512-/F63/e2VJoaVXGGNu6S5QH7jivBThGO95OzAVXXQ8hTta/b1QxI8udHa6cI3+3mAb5WWIIaMMwfZw01oivjJ1g==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.29.0.tgz",
+      "integrity": "sha512-LuQlpX6MFLJZu756erwUeb1mNfoJGbs1kzDwJGNlf5RvfYMdqhcY3vNpDPK40CUV2HoWTkIj+uS0o36GFHjeYw==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.29.0",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.6.tgz",
+      "integrity": "sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
+    }
+  }
+}

--- a/tools/onnx-deploy/wasm/test/package.json
+++ b/tools/onnx-deploy/wasm/test/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "onnx-deploy-wasm-test",
+  "private": true,
+  "type": "module",
+  "description": "Node-based end-to-end test for onnx_deploy_wasm.cpp: proves the Asyncify bridge (persistent onnxruntime-web sessions held across many awaited calls, encoder-once + decoder-loop, KV-cache present.*->past_key_values.* threading) produces the same output as the native onnx-deploy CLI against the same toy model. See run_test.mjs and ../../README.md's WASM section.",
+  "scripts": {
+    "test": "node run_test.mjs"
+  },
+  "dependencies": {
+    "onnxruntime-web": "^1.19.2"
+  }
+}

--- a/tools/onnx-deploy/wasm/test/run_test.mjs
+++ b/tools/onnx-deploy/wasm/test/run_test.mjs
@@ -1,0 +1,45 @@
+// End-to-end test for the onnx_deploy_wasm module: loads the compiled
+// ../build/onnx_deploy_wasm.js, wires up the onnxruntime-web-backed runtime
+// (ort_web_runtime.mjs), runs generate() against the same hand-built toy
+// seq2seq export ../../scripts/make_toy_seq2seq.py produces (see that
+// script's docstring for why its output is fully hand-computable), and
+// asserts the exact same token sequence the native CLI/Python extension
+// produce for the same inputs (see ../../README.md's "Verifying the flow").
+//
+// Usage: node run_test.mjs <toy_model_dir>
+//   (run ../../scripts/make_toy_seq2seq.py -o <toy_model_dir> first)
+
+import { readFileSync } from "node:fs";
+import { strict as assert } from "node:assert";
+import path from "node:path";
+
+import { installRuntime } from "./ort_web_runtime.mjs";
+import createOnnxDeployWasmModule from "../build/onnx_deploy_wasm.js";
+
+const modelDir = process.argv[2];
+if (!modelDir) {
+  console.error("usage: node run_test.mjs <toy_model_dir>");
+  process.exit(1);
+}
+
+const encoderBytes = new Uint8Array(readFileSync(path.join(modelDir, "encoder_model.onnx")));
+const decoderBytes = new Uint8Array(readFileSync(path.join(modelDir, "decoder_model.onnx")));
+const decoderPastBytes = new Uint8Array(readFileSync(path.join(modelDir, "decoder_with_past_model.onnx")));
+
+const moduleConfig = installRuntime({});
+const Module = await createOnnxDeployWasmModule(moduleConfig);
+
+async function run(maxNewTokens, eosTokenId) {
+  const result = await Module.generate(encoderBytes, decoderBytes, decoderPastBytes, [3, 4], maxNewTokens, eosTokenId, 0);
+  return Array.from(result, (v) => Number(v));
+}
+
+const full = await run(8, -1);
+console.log("generate(max_new_tokens=8, eos=-1):", full);
+assert.deepEqual(full, [0, 1, 2, 3, 4, 5, 6, 0], "full 8-token sequence mismatch");
+
+const early = await run(20, 6);
+console.log("generate(max_new_tokens=20, eos_token_id=6):", early);
+assert.deepEqual(early, [0, 1, 2, 3, 4, 5, 6], "eos_token_id early-stop mismatch");
+
+console.log("OK: onnx_deploy_wasm matches the native pipeline's expected output.");


### PR DESCRIPTION
## Summary

PR #748 added `tools/onnx-deploy` as a design sketch, but only its first (unbuilt, untested) commit was merged — the follow-up commit that actually built, fixed, and CI-verified it never landed in `master`. This PR restores that work and adds the WASM target on top.

- **Native swappable-libort C ABI** (`onnx_deploy_c_api.h`/`.cpp`): `kv_cache_pipeline.h` now builds with `ORT_API_MANUAL_INIT`, so nothing resolves an ORT symbol at link time. `onnx_deploy_load_ort()` `dlopen`s/`LoadLibrary`s a caller-chosen `libonnxruntime` at *runtime* and wires it up via `Ort::InitApi()`. `libonnx_deploy_c.so` links with **zero** build-time dependency on any ONNX Runtime binary (`ldd` shows only libstdc++/libgcc_s/libc/libm) — the same compiled artifact runs against any ORT build/version you point it at.
- **`onnx-deploy` CLI**: now a thin consumer of that C ABI (`--libort PATH`), doubling as an executable smoke test of the ABI itself.
- **`onnx_deploy_py`**: a compiled [nanobind](https://github.com/wjakob/nanobind) Python extension over the same C ABI, following `onnxsim/cpp2py_export.cc`'s convention — a compiled alternative to `optimum.onnxruntime`'s pure-Python generate() loop. README explains what this does and doesn't buy you (opacity for the loop logic, not weight protection or a real security boundary).
- **WASM** (`tools/onnx-deploy/wasm/`): a from-scratch Asyncify bridge holding onnxruntime-web `InferenceSession`s alive across the whole decode loop — the repo's existing `JsModelExecutor` bridge only covers one awaited call per `Run()`, not a persistent multi-step loop. "Swappable libort" here means the JS host picks which onnxruntime-web build/version/EP backs `Module.onnxDeployRunSession`.
- **`scripts/make_toy_seq2seq.py`**: a hand-built seq2seq export (no torch/transformers/optimum) whose output is fully hand-computable, specifically designed so a broken KV-cache handoff — including the cross-attention-cache-not-re-output-every-step subtlety — produces a *wrong answer*, not just a crash.
- **`.github/workflows/onnx-deploy.yml`**: downloads two different real ONNX Runtime releases and proves the actual runtime swap (same compiled binary/Python module, both ORT builds, no rebuild) against the toy model; a second job builds and runs the WASM module under Node with onnxruntime-web.

Two real bugs were caught by actually compiling and running this (not possible when PR #748 was authored — no ORT dev package was available then): wrong `ONNX_TENSOR_ELEMENT_TYPE_*` enum names in `BorrowView`, and `std::map::operator[]` requiring `Ort::Value` to be default-constructible in `HarvestPresentIntoCache` (it isn't — switched to `insert_or_assign`).

All three layers (native CLI, Python extension, WASM/Node) were run locally against real ONNX Runtime / onnxruntime-web builds and produce identical, correct output before being encoded into CI.

## Test plan

- [x] `cmake -B build -DORT_HOME=... -DONNX_DEPLOY_PYTHON=ON && cmake --build build` — clean build
- [x] `ldd build/libonnx_deploy_c.so` — no `libonnxruntime` dependency
- [x] Same compiled `onnx-deploy` binary run against ONNX Runtime 1.18.1 and 1.19.2 (no rebuild) — identical correct output
- [x] `onnx_deploy_py` (nanobind) tested against both ORT builds — identical correct output
- [x] `eos_token_id` early-stop and bad-input error paths (exit 1, clean message, no crash)
- [x] WASM module built with Emscripten 5.0.0, run under Node with `onnxruntime-web` — identical correct output, including early-stop
- [x] `.github/workflows/onnx-deploy.yml` encodes all of the above as two CI jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBK5GXi6P88tL2H6Cv16vi)_