### PR TITLE
Add quantize_weight_only_aqlm: additive (multi-codebook) quantization

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -10,6 +10,7 @@ from onnxsim.accuracy import (
     recommend_quantization,
 )
 from onnxsim.adaround import apply_adaround
+from onnxsim.aqlm import quantize_weight_only_aqlm
 from onnxsim.autoquant import AutoQuantResult, auto_quantize_int4
 from onnxsim.autoround import apply_autoround
 from onnxsim.awq import apply_awq
@@ -106,6 +107,7 @@ __all__ = [
     "quantize_weight_only_nf4",
     "NF4_CODEBOOK",
     "quantize_weight_only_squeezellm",
+    "quantize_weight_only_aqlm",
     "quantize_weight_only_matmul_nbits",
     "quantize_weight_only_int8_block",
     "quantize_weight_only_int16",

--- a/onnxsim/aqlm.py
+++ b/onnxsim/aqlm.py
@@ -1,0 +1,295 @@
+"""AQLM (Egiazarian et al., 2024, "Extreme Compression of Large Language
+Models via Additive Quantization", https://arxiv.org/abs/2401.06118).
+onnxsim ports the algorithm, not any framework's code, per the same
+rationale as :mod:`onnxsim.awq`/:mod:`onnxsim.gptq`/:mod:`onnxsim.hqq`
+(AQLM's own reference implementation quantizes live PyTorch weights via a
+custom calibration-aware beam-search optimizer, with no ONNX export path).
+
+Every other codebook-based scheme in onnxsim (:mod:`onnxsim.nf4`'s one
+*fixed* global codebook, :mod:`onnxsim.squeezellm`'s one *fit-per-group*
+codebook) represents each weight element (NF4) or each small group of
+elements (SqueezeLLM) as a single lookup into a single codebook. AQLM's
+own idea, **additive** (a.k.a. residual) **quantization**: represent each
+group instead as the *sum* of ``M`` lookups, one from each of ``M``
+separate codebooks shared across every group in the layer:
+
+    ŵ_group = C_1[i_1] + C_2[i_2] + ... + C_M[i_M]
+
+With ``M`` codebooks of ``codebook_size`` entries each, this can represent
+up to ``codebook_size ** M`` distinct group values while storing only
+``M`` small codebooks plus ``M`` per-group indices -- far more
+representational richness per stored bit than a single codebook of the
+same total size, the same reason residual/product quantization is a
+classical, well-established technique in the vector quantization
+literature AQLM's own paper builds on and cites.
+
+Fitting the ``M`` codebooks: this module uses the classical **greedy
+residual k-means** strategy -- fit codebook 1 with ordinary k-means
+(Lloyd's algorithm) to every group's own raw values (each of the many
+groups in a layer treated as one point in ``group_dim``-dimensional
+space, all sharing the *same* fitted codebook, unlike
+:mod:`onnxsim.squeezellm`'s independent per-group codebooks), subtract
+what it reconstructs, fit codebook 2 to *that residual*, and so on --
+rather than AQLM's own more sophisticated joint beam-search code
+assignment calibrated against a Hessian-weighted objective. Greedy
+residual fitting is the textbook baseline additive/residual quantization
+is built on, independently verifiable (see this module's own tests: more
+codebooks can only reduce reconstruction error, since each new codebook
+targets exactly the error the previous stages left over), and needs no
+calibration data at all -- consistent with :mod:`onnxsim.hqq`/
+:mod:`onnxsim.nf4`/:mod:`onnxsim.quip_sharp`'s own choice to solve the
+same representational problem via a classical technique rather than risk
+an unverifiable reproduction of a paper's own bespoke calibrated
+optimizer.
+
+Dequantization is ``M`` ordinary ``Gather`` operations (one per codebook,
+exactly :mod:`onnxsim.nf4`'s own pattern, since every group shares the
+same global codebook per stage -- no per-group indexing like
+:mod:`onnxsim.squeezellm`'s ``GatherND`` is needed) followed by ``M - 1``
+``Add`` nodes summing the stages together. No custom op or contrib
+domain, and no opset requirement beyond ordinary ``Gather``/``Add``.
+"""
+
+from __future__ import annotations
+
+from typing import List, Union
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+
+from onnxsim.bias_correction import _all_names, _unique_name
+
+
+def _match_matmul_like(node: onnx.NodeProto):
+    """Mirrors ``MatchMatMulLike`` (``passes/quantize_matmul_common.h``):
+    a MatMul, or a Gemm with ``transA=0``, ``alpha=1`` and (when it has a
+    bias) ``beta=1``. Returns ``(x_name, w_name, weight_transposed)`` or
+    ``None``.
+    """
+    attrs = {a.name: a for a in node.attribute}
+    if node.op_type == "MatMul":
+        if len(node.input) != 2:
+            return None
+        return node.input[0], node.input[1], False
+    if node.op_type == "Gemm":
+        num_inputs = len(node.input)
+        if num_inputs not in (2, 3):
+            return None
+        trans_a = attrs.get("transA")
+        if trans_a is not None and trans_a.i != 0:
+            return None
+        alpha = attrs.get("alpha")
+        if alpha is not None and alpha.f != 1.0:
+            return None
+        if num_inputs == 3:
+            beta = attrs.get("beta")
+            if beta is not None and beta.f != 1.0:
+                return None
+        trans_b = attrs.get("transB")
+        weight_transposed = bool(trans_b is not None and trans_b.i)
+        return node.input[0], node.input[1], weight_transposed
+    return None
+
+
+def _fit_kmeans_codebook(
+    data: np.ndarray, codebook_size: int, num_iterations: int, rng: np.random.Generator
+) -> "tuple[np.ndarray, np.ndarray]":
+    """Ordinary (unweighted) Lloyd's-algorithm k-means: fits
+    ``codebook_size`` centroids (``[codebook_size, dim]``) shared across
+    every row of ``data`` (``[num_points, dim]``), returning
+    ``(centroids, assignment)`` with ``assignment`` (``[num_points]``) the
+    index of each row's nearest centroid. Centroids are initialized from a
+    random sample of ``data``'s own rows (padding by repeating the last
+    sampled point if ``data`` has fewer rows than ``codebook_size``); an
+    empty cluster keeps its previous centroid rather than going undefined.
+    """
+    num_points = data.shape[0]
+    k = min(codebook_size, num_points)
+    init_idx = rng.choice(num_points, size=k, replace=False)
+    centroids = data[init_idx].copy()
+    if k < codebook_size:
+        pad = np.tile(centroids[-1:], (codebook_size - k, 1))
+        centroids = np.vstack([centroids, pad])
+
+    assignment = np.zeros(num_points, dtype=np.int64)
+    for _ in range(num_iterations):
+        dist = np.sum(
+            (data[:, np.newaxis, :] - centroids[np.newaxis, :, :]) ** 2, axis=2
+        )
+        assignment = np.argmin(dist, axis=1)
+        new_centroids = centroids.copy()
+        for c in range(codebook_size):
+            mask = assignment == c
+            if np.any(mask):
+                new_centroids[c] = data[mask].mean(axis=0)
+        centroids = new_centroids
+
+    dist = np.sum((data[:, np.newaxis, :] - centroids[np.newaxis, :, :]) ** 2, axis=2)
+    assignment = np.argmin(dist, axis=1)
+    return centroids, assignment
+
+
+def quantize_weight_only_aqlm(
+    model: Union[str, onnx.ModelProto],
+    group_dim: int = 8,
+    num_codebooks: int = 2,
+    codebook_size: int = 256,
+    num_iterations: int = 10,
+    seed: int = 0,
+) -> onnx.ModelProto:
+    """Quantizes every MatMul/vanilla-Gemm layer with a constant 2-D
+    float32 weight (whose reduction dimension ``K`` is evenly divisible by
+    ``group_dim``) into AQLM-style additive (multi-codebook) quantization
+    -- see this module's own docstring for the technique. Needs no
+    calibration data: every codebook is fit directly to the weight's own
+    values.
+
+    :param model: the original (unquantized) onnx ModelProto or file path
+    :param group_dim: elements per group (each ``group_dim``-element chunk
+            of a row gets its own set of ``num_codebooks`` indices, one
+            per codebook)
+    :param num_codebooks: number of additive codebook stages ``M`` (the
+            paper's own typical range is 1-2 for its most extreme
+            compression settings, with more codebooks trading additional
+            stored bits for lower reconstruction error)
+    :param codebook_size: entries per codebook (2^8 = 256 is a typical
+            choice, matching one byte per stored index)
+    :param num_iterations: Lloyd's-algorithm iterations refining each
+            stage's codebook
+    :param seed: seed for the k-means centroid initialization (a fresh
+            ``numpy.random.Generator`` is derived per matched layer, in
+            graph node order, so results are deterministic and
+            reproducible for a given model and seed)
+    :returns: ``model`` with every matched layer's weight replaced by
+            ``M`` ``Gather`` lookups (one per codebook) summed via
+            ``Add`` and reshaped back to the weight's own shape, feeding
+            the original MatMul/Gemm node; layers with a non-constant,
+            non-2-D, or non-group-divisible weight are left untouched
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    graph = out.graph
+    initializer_map = {t.name: t for t in graph.initializer}
+    taken_names = _all_names(graph)
+
+    nodes = list(graph.node)
+    candidates = []
+    for node in nodes:
+        match = _match_matmul_like(node)
+        if match is None:
+            continue
+        x_name, w_name, weight_transposed = match
+        w_init = initializer_map.get(w_name)
+        if (
+            w_init is None
+            or w_init.data_type != onnx.TensorProto.FLOAT
+            or len(w_init.dims) != 2
+        ):
+            continue
+        candidates.append((node, w_name, weight_transposed))
+
+    if not candidates:
+        return out
+
+    rng = np.random.default_rng(seed)
+
+    for node, w_name, weight_transposed in candidates:
+        w_init = initializer_map[w_name]
+        w = onnx.numpy_helper.to_array(w_init).astype(np.float64)
+        dim0, dim1 = w.shape
+        w_nk = w if weight_transposed else w.T  # [N, K], output channel first
+        n, k = w_nk.shape
+        if k % group_dim != 0:
+            continue
+
+        num_groups = n * (k // group_dim)
+        groups = w_nk.reshape(num_groups, group_dim)
+        residual = groups.copy()
+
+        codebooks: List[np.ndarray] = []
+        codes: List[np.ndarray] = []
+        for _ in range(num_codebooks):
+            centroids, assignment = _fit_kmeans_codebook(
+                residual, codebook_size, num_iterations, rng
+            )
+            codebooks.append(centroids)
+            codes.append(assignment)
+            residual = residual - centroids[assignment]
+
+        prefix = f"{w_name}_aqlm"
+        stage_outputs = []
+        new_nodes: List[onnx.NodeProto] = []
+        for m in range(num_codebooks):
+            codebook_name = _unique_name(f"{prefix}_codebook{m}", taken_names)
+            graph.initializer.append(
+                onnx.numpy_helper.from_array(
+                    codebooks[m].astype(np.float32), name=codebook_name
+                )
+            )
+            codes_name = _unique_name(f"{prefix}_codes{m}", taken_names)
+            graph.initializer.append(
+                onnx.numpy_helper.from_array(codes[m].astype(np.int64), name=codes_name)
+            )
+            stage_out = _unique_name(f"{prefix}_stage{m}", taken_names)
+            gather_node = onnx.helper.make_node(
+                "Gather",
+                [codebook_name, codes_name],
+                [stage_out],
+                name=_unique_name(f"{prefix}_gather{m}_node", taken_names),
+                axis=0,
+            )
+            new_nodes.append(gather_node)
+            stage_outputs.append(stage_out)
+
+        combined = stage_outputs[0]
+        for m in range(1, num_codebooks):
+            add_out = _unique_name(f"{prefix}_sum{m}", taken_names)
+            add_node = onnx.helper.make_node(
+                "Add",
+                [combined, stage_outputs[m]],
+                [add_out],
+                name=_unique_name(f"{prefix}_add{m}_node", taken_names),
+            )
+            new_nodes.append(add_node)
+            combined = add_out
+
+        shape_name = _unique_name(f"{prefix}_shape", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(
+                np.array([n, k], dtype=np.int64), name=shape_name
+            )
+        )
+        unblocked_name = _unique_name(f"{prefix}_unblocked", taken_names)
+        reshape_node = onnx.helper.make_node(
+            "Reshape",
+            [combined, shape_name],
+            [unblocked_name],
+            name=_unique_name(f"{prefix}_reshape_node", taken_names),
+        )
+        new_nodes.append(reshape_node)
+
+        final_name = unblocked_name
+        if not weight_transposed:
+            final_name = _unique_name(f"{prefix}_transposed", taken_names)
+            transpose_node = onnx.helper.make_node(
+                "Transpose",
+                [unblocked_name],
+                [final_name],
+                name=_unique_name(f"{prefix}_transpose_node", taken_names),
+                perm=[1, 0],
+            )
+            new_nodes.append(transpose_node)
+
+        node_idx = next(i for i, n in enumerate(graph.node) if n is node)
+        for offset, new_node in enumerate(new_nodes):
+            graph.node.insert(node_idx + offset, new_node)
+        for i, inp in enumerate(node.input):
+            if inp == w_name:
+                node.input[i] = final_name
+
+    return out

--- a/tests/test_aqlm.py
+++ b/tests/test_aqlm.py
@@ -1,0 +1,200 @@
+"""Tests for ``onnxsim.quantize_weight_only_aqlm`` (AQLM, see
+``onnxsim/aqlm.py``) -- greedy residual k-means fits ``M`` codebooks
+shared across every group in a layer, each group represented as the sum
+of one lookup per codebook.
+"""
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _model(nodes, inputs, outputs, initializer, opset=13):
+    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=8
+    )
+
+
+def _matmul_model(K=64, N=16, weight=None, seed=0):
+    if weight is None:
+        rng = np.random.default_rng(seed)
+        weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    return _model(
+        nodes, [_vi("X", ["batch", K])], [_vi("Y", ["batch", N])], [_f32(weight, "W")]
+    )
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
+
+
+def _dequantize_aqlm_by_hand(model, w_name, num_codebooks):
+    """Independent reference decode: reads the codebook/codes initializers
+    directly and reconstructs via numpy, without using any of this
+    module's own internal functions or the ops it inserts. Returns the
+    ``[num_groups, group_dim]`` sum of all additive stages -- reshaping
+    back to the weight's own ``[N, K]``/original layout is the caller's
+    job, since only the caller knows which.
+    """
+    stages = []
+    for m in range(num_codebooks):
+        codebook = onnx.numpy_helper.to_array(
+            next(
+                t
+                for t in model.graph.initializer
+                if t.name == f"{w_name}_aqlm_codebook{m}"
+            )
+        ).astype(np.float64)
+        codes = onnx.numpy_helper.to_array(
+            next(
+                t
+                for t in model.graph.initializer
+                if t.name == f"{w_name}_aqlm_codes{m}"
+            )
+        )
+        stages.append(codebook[codes])
+    return sum(stages)
+
+
+def test_aqlm_output_stays_close_to_float_via_onnxruntime():
+    model = _matmul_model(K=64, N=16, seed=0)
+    q = onnxsim.quantize_weight_only_aqlm(model, group_dim=8, seed=0)
+    onnx.checker.check_model(q)
+
+    op_types = {n.op_type for n in q.graph.node}
+    assert "Gather" in op_types
+    assert "Add" in op_types
+
+    rng = np.random.default_rng(1)
+    x = rng.standard_normal((8, 64)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x})
+    (q_y,) = _run(q, {"X": x})
+    assert np.all(np.isfinite(q_y))
+    assert _rel_l2(float_y, q_y) < 0.3
+
+
+def test_aqlm_dequantized_values_match_hand_decoded_reference():
+    K, N = 32, 8
+    rng = np.random.default_rng(2)
+    weight = rng.standard_normal((K, N)).astype(np.float32) * 0.3
+    model = _matmul_model(K=K, N=N, weight=weight)
+    q = onnxsim.quantize_weight_only_aqlm(model, group_dim=8, num_codebooks=2, seed=1)
+
+    combined = _dequantize_aqlm_by_hand(q, "W", num_codebooks=2)
+    w_hand_nk = combined.reshape(N, K)
+    w_hand = w_hand_nk.T  # back to original [K, N] storage
+
+    matmul_node = next(n for n in q.graph.node if n.op_type == "MatMul")
+    weight_tensor_name = matmul_node.input[1]
+    probe_model = onnx.ModelProto()
+    probe_model.CopyFrom(q)
+    probe_model.graph.output.append(onnx.ValueInfoProto(name=weight_tensor_name))
+    rng2 = np.random.default_rng(3)
+    x = rng2.standard_normal((4, K)).astype(np.float32)
+    (w_graph,) = _run(probe_model, {"X": x})[len(q.graph.output) :]
+
+    assert np.allclose(w_hand, w_graph.astype(np.float64), rtol=0, atol=1e-5)
+
+
+def test_aqlm_more_codebooks_never_increases_error():
+    # Each additive stage fits its own codebook to exactly the residual
+    # the previous stages left over, so adding more codebooks can only
+    # reduce (never increase) the layer's own reconstruction error.
+    K, N = 32, 8
+    rng = np.random.default_rng(4)
+    weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    model = _matmul_model(K=K, N=N, weight=weight)
+    w_float = weight.astype(np.float64)
+
+    errors = []
+    for m in (1, 2, 3):
+        q = onnxsim.quantize_weight_only_aqlm(
+            model, group_dim=8, num_codebooks=m, codebook_size=8, seed=5
+        )
+        matmul_node = next(n for n in q.graph.node if n.op_type == "MatMul")
+        weight_tensor_name = matmul_node.input[1]
+        probe_model = onnx.ModelProto()
+        probe_model.CopyFrom(q)
+        probe_model.graph.output.append(onnx.ValueInfoProto(name=weight_tensor_name))
+        rng2 = np.random.default_rng(6)
+        x = rng2.standard_normal((4, K)).astype(np.float32)
+        (w_graph,) = _run(probe_model, {"X": x})[len(q.graph.output) :]
+        errors.append(np.sum((w_graph.astype(np.float64) - w_float) ** 2))
+
+    assert all(errors[i] >= errors[i + 1] - 1e-6 for i in range(len(errors) - 1))
+
+
+def test_aqlm_gemm_transb():
+    rng = np.random.default_rng(7)
+    K, N = 64, 12
+    weight = rng.standard_normal((N, K)).astype(np.float32) * 0.5
+    nodes = [onnx.helper.make_node("Gemm", ["X", "W"], ["Y"], transB=1)]
+    model = _model(
+        nodes, [_vi("X", ["batch", K])], [_vi("Y", ["batch", N])], [_f32(weight, "W")]
+    )
+    q = onnxsim.quantize_weight_only_aqlm(model, group_dim=8, seed=2)
+    onnx.checker.check_model(q)
+
+    x = rng.standard_normal((4, K)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x})
+    (q_y,) = _run(q, {"X": x})
+    assert _rel_l2(float_y, q_y) < 0.3
+
+
+def test_aqlm_codes_stay_in_codebook_range():
+    model = _matmul_model(K=32, N=8, seed=8)
+    q = onnxsim.quantize_weight_only_aqlm(
+        model, group_dim=8, num_codebooks=2, codebook_size=16, seed=3
+    )
+    for m in range(2):
+        codes = onnx.numpy_helper.to_array(
+            next(t for t in q.graph.initializer if t.name == f"W_aqlm_codes{m}")
+        )
+        assert np.all(codes >= 0) and np.all(codes < 16)
+
+
+def test_aqlm_skips_non_group_divisible_k():
+    model = _matmul_model(K=20, N=4, seed=9)  # 20 is not a multiple of 8
+    q = onnxsim.quantize_weight_only_aqlm(model, group_dim=8)
+    assert q.SerializeToString() == model.SerializeToString()
+
+
+def test_aqlm_skips_non_constant_weight():
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(
+        nodes, [_vi("X", [4, 32]), _vi("W", [32, 4])], [_vi("Y", [4, 4])], []
+    )
+    q = onnxsim.quantize_weight_only_aqlm(model)
+    assert q.SerializeToString() == model.SerializeToString()
+
+
+def test_aqlm_noop_when_no_matmul_present():
+    nodes = [onnx.helper.make_node("Relu", ["X"], ["Y"])]
+    model = _model(nodes, [_vi("X", [4, 4])], [_vi("Y", [4, 4])], [])
+    result = onnxsim.quantize_weight_only_aqlm(model)
+    assert result.SerializeToString() == model.SerializeToString()


### PR DESCRIPTION
## Summary

Ports **AQLM** (Egiazarian et al., 2024, ["Extreme Compression of Large Language Models via Additive Quantization"](https://arxiv.org/abs/2401.06118)) -- the second of the two remaining notable PTQ techniques flagged after AdaRound/AWQ/GPTQ/HQQ/AutoRound/NF4/SmoothQuant/LLM.int8()/SqueezeLLM/LoRC/QuIP#/OmniQuant.

## Additive (residual) multi-codebook quantization

Every other codebook-based scheme in onnxsim (`onnxsim.quantize_weight_only_nf4`'s one *fixed* global codebook, `onnxsim.quantize_weight_only_squeezellm`'s one *fit-per-group* codebook) represents each weight element or small group as a single lookup into a single codebook. AQLM's own idea: represent each group instead as the **sum** of `M` lookups, one from each of `M` separate codebooks shared across every group in the layer:

    ŵ_group = C_1[i_1] + C_2[i_2] + ... + C_M[i_M]

With `M` codebooks of `codebook_size` entries each, this represents up to `codebook_size ** M` distinct group values while storing only `M` small codebooks plus `M` per-group indices.

## Fit via classical greedy residual k-means, not AQLM's own calibration-aware beam search

AQLM's own reference implementation quantizes live PyTorch weights via a custom calibration-aware beam-search optimizer, with no ONNX export path -- onnxsim ports the *algorithm*, per the same rationale as every technique in this series. This module fits codebook 1 with ordinary k-means (Lloyd's algorithm) to every group's own raw values, subtracts what it reconstructs, fits codebook 2 to *that residual*, and so on -- the textbook baseline additive/residual quantization is built on, independently verifiable, and (consistent with `onnxsim.quantize_weight_only_hqq`/`onnxsim.quantize_weight_only_nf4`/`onnxsim.apply_quip_sharp`'s own choice of a classical technique over an unverifiable reproduction of a paper's own bespoke optimizer) needs no calibration data at all.

Dequantization is `M` ordinary `Gather` operations (one per codebook, exactly `onnxsim.quantize_weight_only_nf4`'s own pattern, since every group shares the same global codebook per stage) followed by `M - 1` `Add` nodes summing the stages. No custom op or contrib domain, no opset requirement beyond ordinary `Gather`/`Add`.

## Verification

- `test_aqlm_output_stays_close_to_float_via_onnxruntime`: end-to-end relative error vs. the float model via ONNX Runtime.
- `test_aqlm_dequantized_values_match_hand_decoded_reference`: probes the graph's own actual reconstructed-weight tensor and compares against an independent numpy-only hand decode of the stored codebook/codes initializers.
- `test_aqlm_more_codebooks_never_increases_error`: since each additive stage fits its own codebook to exactly the residual the previous stages left over, 1→2→3 codebooks is verified monotonically non-increasing in reconstruction error.
- Further tests cover `Gemm transB=1`, codes staying within `[0, codebook_size)`, skipping non-group-divisible `K`, skipping non-constant weights, and the no-op case with no MatMul/Gemm present.
- Full regression sweep (`tests/`, `CI=1` to skip the repo's own multi-hundred-MB+ memory-gated tests, torch/timm-dependent modules excluded): **656 passed, 76 skipped, 0 failures caused by this change** (only pre-existing `ModuleNotFoundError: No module named 'onnxscript'` in unrelated test files).
- `ruff format` / `ruff check` / `mypy` clean (mypy's pre-existing 16 errors in other files are unchanged; `aqlm.py` itself introduces none).

## New files

- `onnxsim/aqlm.py`
- `tests/test_aqlm.py` -- 8 tests

## Test plan

- [x] `pytest tests/test_aqlm.py -v`
- [x] Full `tests/` sweep with `CI=1`
- [x] `ruff format` / `ruff check` / `mypy`

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_