### PR TITLE
Add quantize_kv_cache: static per-channel INT8 KV-cache quantization

### DIFF
--- a/docs/kv-cache-quantization.md
+++ b/docs/kv-cache-quantization.md
@@ -1,0 +1,138 @@
+# KV-cache quantization (`quantize_kv_cache`)
+
+## What this is
+
+`onnxsim.quantize_kv_cache` finds every autoregressive decoder KV-cache
+stream in a model -- a graph input (`past_key`/`past_key_values.{i}.key`,
+...) concatenated with this step's freshly computed key or value along the
+sequence axis, feeding a graph output (`present_key`/`present.{i}.key`,
+...) that a caller feeds back in as next step's `past_*` input, exactly the
+shape `tools/onnx-deploy`'s own `KvCachePipeline` and
+`tests/test_symexpr_kv_cache_consistency.py`'s toy model both use -- and
+quantizes it to INT8, symmetric, one scale per channel (the head-dim axis),
+calibrated once from representative data and shared by every cached token
+for that stream's whole lifetime.
+
+Every other quantizer in onnxsim compresses a **weight**: something
+computed once, offline, before the model ever runs. A KV cache is the
+opposite -- an **activation** that keeps growing for the entire lifetime of
+one generation, one new key/value vector appended per decode step. That is
+exactly why it is worth quantizing at all: it is the part of an LLM's
+memory footprint that scales with sequence length, unlike the weights.
+
+```
+Before:
+  past_key: graph input, float32 [..., seq_past, head_dim]
+  new_key:  float32 [..., seq_new, head_dim]         -- this step's own K/V
+  present_key = Concat(past_key, new_key, axis=seq)  -- graph output,
+                and consumed by the attention math (QK^T / softmax@V)
+
+After:
+  past_key: graph input, INT8 [..., seq_past, head_dim]    -- dtype changed
+  key_scale: initializer, float32 [head_dim]                 -- per-channel
+  key_zero_point: initializer, INT8 [head_dim], all zero     -- symmetric
+  new_key_q = QuantizeLinear(new_key, key_scale, key_zero_point, axis=-1)
+  present_key = Concat(past_key, new_key_q, axis=seq)   -- INT8 graph output
+  present_key_f = DequantizeLinear(present_key, key_scale, key_zero_point,
+                                    axis=-1)             -- float32
+  <every other consumer of the old float present_key now reads present_key_f>
+```
+
+Concatenating `past_key` (already int8) with `new_key_q` (freshly quantized
+with the *same* per-channel scale) along the sequence axis is lossless with
+respect to what was already stored -- the scale never changes step to step,
+so there is no compounding requantization error the way there would be if
+the whole growing cache were dequantized and requantized with a fresh scale
+every step. Only this step's new tokens are ever quantized, so the cost per
+decode step stays constant as the sequence grows, and the graph's own
+`present_*` output is genuinely compressed (roughly 4x smaller than
+float32) the whole way through a caller's decode loop -- not just an
+internal round-trip that still stores float32 everywhere.
+
+## Where this comes from
+
+Two published techniques quantize the KV cache well: **KIVI** (Liu et al.,
+ICML 2024, <https://arxiv.org/abs/2402.02750>) and **KVQuant** (Hooper et
+al., NeurIPS 2024, <https://arxiv.org/abs/2401.18079>). Both share the same
+core empirical finding: Key activations have a handful of channels with
+persistently large magnitude across the *whole* sequence, so quantizing Key
+**per channel** (one scale shared by every cached token) preserves far more
+accuracy than quantizing it per token. `quantize_kv_cache` reproduces that
+part of both papers.
+
+What it does **not** reproduce:
+
+- **KIVI's per-token Value quantization** (a fresh scale per cached token,
+  rather than one static per-channel scale). Per-token quantization would
+  need the scale itself to be a second, parallel growing KV-cache stream
+  (one scale per cached row, concatenated alongside the codes every step) --
+  a real increase in I/O surface this module's MVP scope skips, applying
+  the same static per-channel scheme to Value too. This matches what many
+  serving engines' plain "int8/fp8 KV cache" flag already does in
+  production, even though it is a documented simplification relative to
+  KIVI's own per-token scheme for Value specifically.
+- **KIVI's residual-window bookkeeping** (the most recent `R` tokens kept
+  in full precision, only finalized into low-bit once they age out of that
+  window). Deciding which tokens have "aged out" and need finalizing is
+  cross-step, host-side state -- not something one exported ONNX graph can
+  express on its own. It belongs in
+  `tools/onnx-deploy/include/onnx_deploy/kv_cache_pipeline.h` (which
+  already owns exactly this kind of cross-step cache state across decode
+  steps) as a follow-up, not here.
+- **KVQuant's non-uniform codebook and dense-and-sparse outlier isolation**
+  -- both add real complexity (a fitted, non-uniform datatype; per-vector
+  outlier separation) for a further accuracy gain past plain per-channel
+  INT8; not implemented here, a natural next step if calibrated INT8 alone
+  turns out not to be enough for a given model.
+
+## Scope
+
+Handled:
+
+- A `Concat(past, new, axis=seq)` node whose `past` operand is a float32
+  graph input consumed *only* by that Concat, and whose own output is
+  directly a graph output. No assumption is made about tensor names -- this
+  matches `past_key`/`present_key` as well as `optimum-onnx`'s own
+  `past_key_values.{i}.key`/`present.{i}.key` convention.
+- Opsets >= 13 (`QuantizeLinear`/`DequantizeLinear`'s per-channel `axis`
+  needs opset 13).
+
+Left untouched (safe no-op, node passes through as-is):
+
+- A `past` operand with any other consumer besides the Concat (declining
+  rather than silently breaking that other use).
+- A Concat whose axis *is* the last (channel) axis -- no distinct axis is
+  left to quantize per-channel on.
+- A model with no matching Concat pattern, or an opset older than 13.
+
+## Usage
+
+```python
+import onnx
+import onnxsim
+
+model = onnx.load("decoder_with_past_model.onnx")
+quantized = onnxsim.quantize_kv_cache(model, num_samples=32)
+onnx.save(quantized, "decoder_with_past_model.kv_int8.onnx")
+```
+
+`calibration_data` defaults to `onnxsim.generate_random_calibration_data`
+(random input, no external dependency); pass real representative batches
+(e.g. via `onnxsim.load_huggingface_calibration_data`) for a tighter
+calibrated scale, since a per-channel scale that under-covers a real
+model's activation range clips outliers on exactly the channels KIVI/
+KVQuant's own finding says matter most.
+
+A model quantized this way needs a caller that actually stores its
+`past_*`/`present_*` tensors as INT8 across decode steps to see any real
+memory benefit -- `tools/onnx-deploy`'s `KvCachePipeline`
+(`include/onnx_deploy/kv_cache_pipeline.h`) does not yet do this
+(`BorrowView` there currently only handles fp32/int64 tensors), so wiring
+this quantizer's output through that pipeline end-to-end is a natural
+follow-up, not something this module does on its own.
+
+`tests/test_kv_cache_quantization.py` verifies this end-to-end with a
+genuine two-step round trip (an empty starting cache, then feeding the
+first step's own INT8 `present_key` output back in as the second step's
+`past_key` input -- exactly what a real pipeline does), comparing the
+dequantized cache tensor against the float model's own output.

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -36,6 +36,7 @@ from onnxsim.gguf_reconstruct import (
 )
 from onnxsim.gptq import apply_gptq
 from onnxsim.hqq import quantize_weight_only_int4_hqq
+from onnxsim.kv_cache_quantization import quantize_kv_cache
 from onnxsim.llm_int8 import apply_llm_int8
 from onnxsim.low_rank_compensation import apply_low_rank_compensation
 from onnxsim.nf4 import NF4_CODEBOOK, quantize_weight_only_nf4
@@ -110,6 +111,7 @@ __all__ = [
     "NF4_CODEBOOK",
     "quantize_weight_only_squeezellm",
     "quantize_weight_only_aqlm",
+    "quantize_kv_cache",
     "quantize_weight_only_matmul_nbits",
     "quantize_weight_only_int8_block",
     "quantize_weight_only_int16",

--- a/onnxsim/kv_cache_quantization.py
+++ b/onnxsim/kv_cache_quantization.py
@@ -1,0 +1,328 @@
+"""KV-cache quantization for autoregressive decoder graphs -- see
+``docs/kv-cache-quantization.md`` for the full survey (KIVI, KVQuant) this
+module implements the recommendation of, and usage examples.
+
+Every quantizer elsewhere in onnxsim compresses a *weight* -- something
+computed once, offline, before the model ever runs. A KV cache is the
+opposite: it is an *activation* that keeps growing for the whole lifetime of
+one autoregressive generation, one new key/value vector appended per decode
+step, which is exactly why quantizing it is worth doing at all (it is the
+part of an LLM's memory footprint that scales with sequence length, unlike
+the weights).
+
+Two published techniques quantize the KV cache well: KIVI (Liu et al., ICML
+2024, https://arxiv.org/abs/2402.02750) and KVQuant (Hooper et al., NeurIPS
+2024, https://arxiv.org/abs/2401.18079). Both share the same core empirical
+finding -- Key activations have a handful of channels with persistently
+large magnitude across the *whole* sequence, so quantizing Key **per
+channel** (one scale shared by every cached token, along the head-dim axis)
+preserves far more accuracy than quantizing it per token. This module
+reproduces that part of both papers: a **static, per-channel (head-dim
+axis) scale**, calibrated once from representative data, applied to
+whichever of the graph's ``Concat(past, new)`` KV-cache patterns it finds --
+the same op shape ``tools/onnx-deploy``'s own pipeline and this repo's own
+``tests/test_symexpr_kv_cache_consistency.py`` toy model use for a decoder's
+cache: a graph input (``past_key``/``past_key_values.{i}.key``, ...) and a
+freshly computed activation, concatenated along the sequence axis, feeding a
+graph output (``present_key``/``present.{i}.key``, ...) that the caller
+feeds back in as next step's ``past_*`` input.
+
+What this module does **not** reproduce: KIVI's own per-token Value
+quantization (a fresh scale per cached token, rather than one static
+per-channel scale) and its residual-window bookkeeping (the most recent
+``R`` tokens kept in full precision, only finalized into low-bit once they
+age out of that window). Per-token Value quantization would need the scale
+itself to be a second, parallel growing KV-cache stream (one scale per
+cached row, concatenated alongside the codes every step) -- a real
+increase in I/O surface this module's MVP scope skips, applying the same
+static per-channel scheme (calibrated once, shared across every cached
+token) to Value too, matching what many serving engines' plain "int8/fp8 KV
+cache" flag already does in production. KIVI's residual window is inherently
+cross-step, host-side bookkeeping -- deciding which tokens have "aged out"
+and need finalizing is not something one exported ONNX graph can express on
+its own -- and belongs in ``tools/onnx-deploy/include/onnx_deploy/kv_cache_pipeline.h``
+(which already owns exactly this kind of cross-step cache state) as a
+follow-up, not here.
+
+Graph rewrite, per matched ``Concat(past, new, axis=seq)`` cache stream:
+
+    Before:
+      past_key: graph input, float32 [..., seq_past, head_dim]
+      new_key:  float32 [..., seq_new, head_dim]        -- this step's own K/V
+      present_key = Concat(past_key, new_key, axis=seq)  -- graph output,
+                    and consumed by the attention math (QK^T / softmax@V)
+
+    After:
+      past_key: graph input, INT8 [..., seq_past, head_dim]   -- dtype changed
+      key_scale: initializer, float32 [head_dim]                -- per-channel
+      key_zero_point: initializer, INT8 [head_dim], all zero    -- symmetric
+      new_key_q = QuantizeLinear(new_key, key_scale, key_zero_point, axis=-1)
+      present_key = Concat(past_key, new_key_q, axis=seq)   -- INT8 graph output
+      present_key_f = DequantizeLinear(present_key, key_scale, key_zero_point,
+                                        axis=-1)             -- float32
+      <every other consumer of the old float present_key now reads present_key_f>
+
+Concatenating ``past_key`` (already int8) with ``new_key_q`` (freshly
+quantized with the *same* per-channel scale) along the sequence axis is
+lossless with respect to what was already stored -- the scale never changes
+step to step, so there is no compounding requantization error the way there
+would be if the whole growing cache were dequantized and requantized with a
+fresh scale every step. Only this step's new tokens are ever quantized; the
+cost per decode step stays constant as the sequence grows, and the graph's
+own ``present_*`` output is genuinely compressed (roughly 4x smaller than
+float32) the whole way through a caller's decode loop -- not just an
+internal round-trip that still stores float32 everywhere.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Set, Union
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+
+from onnxsim import backend
+from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.calibration import Tensors, generate_random_calibration_data
+
+
+@dataclass
+class _KvCacheCandidate:
+    past_name: str  # graph input name (e.g. "past_key", "past_key_values.0.key")
+    present_name: str  # graph output name (Concat's own output, unchanged)
+    concat_node: onnx.NodeProto
+    new_name: str  # the freshly-computed operand of Concat (not the cache)
+    new_is_first_input: bool
+    seq_axis: int  # resolved (non-negative) Concat axis
+    channel_axis: int  # resolved (non-negative) quantization axis -- last axis
+
+
+def _resolve_axis(axis: int, rank: int) -> int:
+    return axis if axis >= 0 else axis + rank
+
+
+def _find_kv_cache_candidates(graph: onnx.GraphProto) -> List[_KvCacheCandidate]:
+    """Structurally matches ``Concat(past, new, axis=seq)`` where ``past`` is
+    a float32 graph input consumed *only* by this Concat, and the Concat's
+    own output is directly a graph output -- exactly the shape
+    ``tools/onnx-deploy``'s ``KvCachePipeline`` and
+    ``tests/test_symexpr_kv_cache_consistency.py``'s toy model both use, and
+    make no assumption about tensor names (works for ``past_key``/
+    ``present_key`` as well as ``optimum-onnx``'s own
+    ``past_key_values.{i}.key``/``present.{i}.key`` convention).
+    """
+    output_names = {o.name for o in graph.output}
+    float_inputs: Dict[str, int] = {}  # name -> rank
+    for inp in graph.input:
+        if inp.type.tensor_type.elem_type != onnx.TensorProto.FLOAT:
+            continue
+        float_inputs[inp.name] = len(inp.type.tensor_type.shape.dim)
+
+    consumer_count: Dict[str, int] = {}
+    for node in graph.node:
+        for inp in node.input:
+            consumer_count[inp] = consumer_count.get(inp, 0) + 1
+
+    candidates = []
+    for node in graph.node:
+        if node.op_type != "Concat" or len(node.input) != 2:
+            continue
+        if len(node.output) != 1 or node.output[0] not in output_names:
+            continue
+        a, b = node.input
+        if a in float_inputs and consumer_count.get(a, 0) == 1:
+            past_name, new_name, new_is_first = a, b, False
+        elif b in float_inputs and consumer_count.get(b, 0) == 1:
+            past_name, new_name, new_is_first = b, a, True
+        else:
+            continue
+        axis_attr = next((attr for attr in node.attribute if attr.name == "axis"), None)
+        if axis_attr is None:
+            continue
+        rank = float_inputs[past_name]
+        seq_axis = _resolve_axis(axis_attr.i, rank)
+        channel_axis = rank - 1
+        if seq_axis == channel_axis:
+            continue  # no distinct channel axis left to quantize per-channel on
+        candidates.append(
+            _KvCacheCandidate(
+                past_name=past_name,
+                present_name=node.output[0],
+                concat_node=node,
+                new_name=new_name,
+                new_is_first_input=new_is_first,
+                seq_axis=seq_axis,
+                channel_axis=channel_axis,
+            )
+        )
+    return candidates
+
+
+def _per_channel_absmax(
+    candidates: Sequence[_KvCacheCandidate],
+    model: onnx.ModelProto,
+    calibration_data: Sequence[Tensors],
+    providers: Optional[Sequence[str]],
+) -> Dict[str, np.ndarray]:
+    probe = _add_probe_outputs(model, [c.new_name for c in candidates])
+    absmax: Dict[str, np.ndarray] = {}
+    for batch in calibration_data:
+        outputs = backend.run_model(probe, batch, providers=providers)
+        for c in candidates:
+            arr = np.asarray(outputs[c.new_name], dtype=np.float64)
+            if arr.ndim == 0:
+                continue
+            flat = arr.reshape(-1, arr.shape[-1])
+            channel_max = np.abs(flat).max(axis=0)
+            if c.new_name in absmax:
+                absmax[c.new_name] = np.maximum(absmax[c.new_name], channel_max)
+            else:
+                absmax[c.new_name] = channel_max
+    return absmax
+
+
+def quantize_kv_cache(
+    model: Union[str, onnx.ModelProto],
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_samples: int = 8,
+    seed: int = 0,
+    providers: Optional[Sequence[str]] = None,
+) -> onnx.ModelProto:
+    """Quantizes every ``Concat(past, new, axis=seq)`` KV-cache stream this
+    module can find (see this module's own docstring for the exact pattern
+    and graph rewrite) to INT8, symmetric, one scale per channel (the last
+    axis -- head-dim), calibrated once from representative data and shared
+    by every cached token for that stream's whole lifetime.
+
+    :param model: the original (unquantized) onnx ModelProto or file path
+    :param calibration_data: representative input batches (each a
+            ``{input_name: np.ndarray}`` dict matching ``model``'s graph
+            inputs) to calibrate the per-channel scale on -- see
+            :func:`onnxsim.generate_random_calibration_data` (the default
+            when omitted) and :func:`onnxsim.load_huggingface_calibration_data`
+            (real data, a more representative calibration than random
+            input). A ``past_key``/``past_key_values.*`` input with a
+            genuinely empty (statically zero) sequence-length dimension in
+            ``model``'s own declared shape is filled in as an empty tensor
+            by :func:`onnxsim.generate_random_calibration_data` automatically
+            -- calibration only ever measures this step's own freshly
+            computed activation, never the cache's prior content, so an
+            empty starting cache calibrates identically to a populated one.
+    :param num_samples: random batches to generate when ``calibration_data``
+            is omitted
+    :param seed: seed for the random calibration data (ignored if
+            ``calibration_data`` is supplied)
+    :param providers: onnxruntime execution providers to calibrate on
+    :returns: ``model`` with every matched KV-cache stream's ``past_*``
+            graph input and ``present_*`` graph output changed to INT8, and
+            a ``QuantizeLinear``/``DequantizeLinear`` pair inserted around
+            it (see the module docstring's diagram); a model with no
+            matching Concat pattern, or an opset older than 13
+            (``QuantizeLinear``/``DequantizeLinear``'s per-channel ``axis``
+            needs opset 13), is returned unchanged
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+
+    if not any(
+        o.domain in ("", "ai.onnx") and o.version >= 13 for o in model.opset_import
+    ):
+        return model
+
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    graph = out.graph
+
+    candidates = _find_kv_cache_candidates(graph)
+    if not candidates:
+        return out
+
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            model, num_samples=num_samples, seed=seed
+        )
+
+    absmax = _per_channel_absmax(candidates, model, calibration_data, providers)
+    taken_names: Set[str] = _all_names(graph)
+    input_by_name = {i.name: i for i in graph.input}
+    output_by_name = {o.name: o for o in graph.output}
+
+    for c in candidates:
+        if c.new_name not in absmax:
+            continue  # this stream's activation never appeared in any batch
+        channel_absmax = np.maximum(absmax[c.new_name], 1e-12)
+        scale = (channel_absmax / 127.0).astype(np.float32)
+        num_channels = scale.shape[0]
+
+        scale_name = _unique_name(f"{c.present_name}_kv_scale", taken_names)
+        zp_name = _unique_name(f"{c.present_name}_kv_zero_point", taken_names)
+        graph.initializer.append(onnx.numpy_helper.from_array(scale, name=scale_name))
+        zp = np.zeros(num_channels, dtype=np.int8)
+        graph.initializer.append(onnx.numpy_helper.from_array(zp, name=zp_name))
+
+        # past_key/past_key_values.*: FLOAT -> INT8 (same shape).
+        past_input = input_by_name[c.past_name]
+        past_input.type.tensor_type.elem_type = onnx.TensorProto.INT8
+
+        # new_key_q = QuantizeLinear(new_key, scale, zero_point, axis=channel_axis)
+        new_q_name = _unique_name(f"{c.new_name}_kv_q", taken_names)
+        quantize_node = onnx.helper.make_node(
+            "QuantizeLinear",
+            [c.new_name, scale_name, zp_name],
+            [new_q_name],
+            name=_unique_name(f"{c.new_name}_kv_quantize_node", taken_names),
+            axis=c.channel_axis,
+        )
+
+        # Rewire Concat's "new" input to the now-quantized tensor; the
+        # "past" input already reads the (now INT8) graph input as-is, so
+        # Concat's own output is INT8 -- exactly present_key's new dtype.
+        if c.new_is_first_input:
+            c.concat_node.input[0] = new_q_name
+        else:
+            c.concat_node.input[1] = new_q_name
+
+        present_output = output_by_name[c.present_name]
+        present_output.type.tensor_type.elem_type = onnx.TensorProto.INT8
+
+        # present_key_f = DequantizeLinear(present_key, scale, zero_point,
+        # axis=channel_axis) -- every *node* consumer of the old float
+        # present_key (the attention math) is rewired to this; the graph
+        # output binding itself is untouched, so it keeps resolving to
+        # Concat's own (now INT8) output tensor by name, unchanged.
+        dequant_name = _unique_name(f"{c.present_name}_kv_f", taken_names)
+        dequant_node = onnx.helper.make_node(
+            "DequantizeLinear",
+            [c.present_name, scale_name, zp_name],
+            [dequant_name],
+            name=_unique_name(f"{c.present_name}_kv_dequantize_node", taken_names),
+            axis=c.channel_axis,
+        )
+
+        # Rewire every *existing* consumer of present_name (everything
+        # except Concat itself) to the dequantized tensor now, before
+        # quantize_node/dequant_node are inserted below -- graph.node is a
+        # protobuf repeated field, and RepeatedCompositeFieldContainer.insert()
+        # copies the given message into a freshly allocated element rather
+        # than storing the object itself, so an `is quantize_node`/
+        # `is dequant_node` identity check taken *after* inserting them would
+        # never match anything actually in the container (silently leaving
+        # them out of the loop's exclusion and making dequant_node consume
+        # its own output). Doing the rewiring first sidesteps that: neither
+        # new node exists in graph.node yet, so there is nothing to
+        # incorrectly self-reference.
+        for node in graph.node:
+            if node is c.concat_node:
+                continue
+            for i, inp in enumerate(node.input):
+                if inp == c.present_name:
+                    node.input[i] = dequant_name
+
+        concat_idx = next(i for i, n in enumerate(graph.node) if n is c.concat_node)
+        graph.node.insert(concat_idx, quantize_node)
+        graph.node.insert(concat_idx + 2, dequant_node)
+
+    return out

--- a/tests/test_kv_cache_quantization.py
+++ b/tests/test_kv_cache_quantization.py
@@ -1,0 +1,190 @@
+"""Tests for ``onnxsim.quantize_kv_cache`` -- see ``onnxsim/kv_cache_quantization.py``
+for the technique (static, per-channel INT8 quantization of a decoder's
+``Concat(past, new, axis=seq)`` KV-cache stream).
+"""
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _vi(name, shape, dtype=onnx.TensorProto.FLOAT):
+    return onnx.helper.make_tensor_value_info(name, dtype, shape)
+
+
+def _kv_cache_model(batch=1, heads=2, head_dim=4, opset=13, symbolic_seq=True):
+    # new_key is deliberately routed through an Identity node rather than
+    # being a bare graph input: a real exported decoder's "new" K/V is
+    # always a freshly computed activation (the current step's projection
+    # output), never a raw model input -- and keeping the test model that
+    # way avoids a genuine ambiguity the matcher can't resolve from
+    # structure alone (nothing distinguishes "the persistent cache" from
+    # "this step's fresh token" if *both* Concat operands are plain graph
+    # inputs with a single consumer).
+    seq_past = "seq_past" if symbolic_seq else 3
+    seq_present = "seq_present" if symbolic_seq else 4
+    nodes = [
+        onnx.helper.make_node("Identity", ["new_key_raw"], ["new_key"]),
+        onnx.helper.make_node(
+            "Concat", ["past_key", "new_key"], ["present_key"], axis=2
+        ),
+        onnx.helper.make_node("ReduceSum", ["present_key"], ["summary"], keepdims=0),
+    ]
+    graph = onnx.helper.make_graph(
+        nodes,
+        "g",
+        [
+            _vi("past_key", [batch, heads, seq_past, head_dim]),
+            _vi("new_key_raw", [batch, heads, 1, head_dim]),
+        ],
+        [
+            _vi("present_key", [batch, heads, seq_present, head_dim]),
+            _vi("summary", []),
+        ],
+        [],
+    )
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=8
+    )
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
+
+
+def test_kv_cache_quantization_changes_input_and_output_to_int8():
+    model = _kv_cache_model()
+    q = onnxsim.quantize_kv_cache(model, num_samples=4, seed=0)
+    onnx.checker.check_model(q)
+
+    past_vi = next(i for i in q.graph.input if i.name == "past_key")
+    present_vi = next(o for o in q.graph.output if o.name == "present_key")
+    assert past_vi.type.tensor_type.elem_type == onnx.TensorProto.INT8
+    assert present_vi.type.tensor_type.elem_type == onnx.TensorProto.INT8
+    # new_key_raw/the Identity's "new_key" output are untouched float --
+    # only Concat's own operand is rewired to a freshly quantized tensor.
+    new_vi = next(i for i in q.graph.input if i.name == "new_key_raw")
+    assert new_vi.type.tensor_type.elem_type == onnx.TensorProto.FLOAT
+    quantize_node = next(n for n in q.graph.node if n.op_type == "QuantizeLinear")
+    assert quantize_node.input[0] == "new_key"
+
+
+def test_kv_cache_quantization_inserts_quantize_dequantize_around_concat():
+    model = _kv_cache_model()
+    q = onnxsim.quantize_kv_cache(model, num_samples=4, seed=0)
+    op_types = [n.op_type for n in q.graph.node]
+    assert op_types.count("QuantizeLinear") == 1
+    assert op_types.count("DequantizeLinear") == 1
+    assert "Concat" in op_types
+    # ReduceSum (the "attention math" stand-in) must consume the
+    # dequantized float tensor, not the raw int8 Concat output.
+    reduce_node = next(n for n in q.graph.node if n.op_type == "ReduceSum")
+    dequant_node = next(n for n in q.graph.node if n.op_type == "DequantizeLinear")
+    assert reduce_node.input[0] == dequant_node.output[0]
+
+
+def test_kv_cache_quantization_two_step_round_trip_close_to_float():
+    # Mirrors how tools/onnx-deploy's KvCachePipeline actually drives a
+    # decoder: step 0 starts from an empty cache, step 1 feeds step 0's own
+    # "present" output straight back in as "past" -- for the quantized
+    # model, that output is already INT8, exactly as a real pipeline would
+    # receive it, with no manual conversion by the caller.
+    #
+    # Compared against the *dequantized cache tensor itself* (all 24
+    # elements), not the downstream ReduceSum scalar: summing so few
+    # elements to one number lets ordinary cancellation inflate the
+    # relative error on the sum far past the actual per-element
+    # quantization error, which is what this test is really checking.
+    batch, heads, head_dim = 1, 2, 6
+    model = _kv_cache_model(batch=batch, heads=heads, head_dim=head_dim)
+    q = onnxsim.quantize_kv_cache(model, num_samples=64, seed=1)
+    dequant_node = next(n for n in q.graph.node if n.op_type == "DequantizeLinear")
+    q_probe = onnx.ModelProto()
+    q_probe.CopyFrom(q)
+    q_probe.graph.output.append(onnx.ValueInfoProto(name=dequant_node.output[0]))
+
+    rng = np.random.default_rng(3)
+    empty_past = np.zeros((batch, heads, 0, head_dim), dtype=np.float32)
+    new0 = rng.standard_normal((batch, heads, 1, head_dim)).astype(np.float32)
+    new1 = rng.standard_normal((batch, heads, 1, head_dim)).astype(np.float32)
+
+    float_present0, _ = _run(model, {"past_key": empty_past, "new_key_raw": new0})
+    float_present1, _ = _run(model, {"past_key": float_present0, "new_key_raw": new1})
+
+    empty_past_q = np.zeros((batch, heads, 0, head_dim), dtype=np.int8)
+    q_present0, _ = _run(q, {"past_key": empty_past_q, "new_key_raw": new0})
+    assert q_present0.dtype == np.int8
+    q_present1, _, q_present1_f = _run(
+        q_probe, {"past_key": q_present0, "new_key_raw": new1}
+    )
+    assert q_present1.dtype == np.int8
+
+    # A generous bound, not a tight one: with a small (64-sample) random
+    # calibration set, this step's own random draw occasionally lands an
+    # element past the calibrated per-channel max, clipping it -- a real,
+    # expected property of any calibrated int8 scheme, not a bug in this
+    # module. Matches the tolerance other onnxsim quantizers use for a
+    # small random-data end-to-end check (e.g. AQLM's own 0.3).
+    assert _rel_l2(float_present1, q_present1_f) < 0.2
+
+
+def test_kv_cache_quantization_declines_when_past_has_other_consumers():
+    nodes = [
+        onnx.helper.make_node("Identity", ["new_key_raw"], ["new_key"]),
+        onnx.helper.make_node(
+            "Concat", ["past_key", "new_key"], ["present_key"], axis=2
+        ),
+        onnx.helper.make_node("ReduceSum", ["present_key"], ["summary"], keepdims=0),
+        # A second, direct consumer of past_key -- the pattern must decline
+        # rather than silently break this other use.
+        onnx.helper.make_node("ReduceSum", ["past_key"], ["past_summary"], keepdims=0),
+    ]
+    graph = onnx.helper.make_graph(
+        nodes,
+        "g",
+        [_vi("past_key", [1, 2, 3, 4]), _vi("new_key_raw", [1, 2, 1, 4])],
+        [
+            _vi("present_key", [1, 2, 4, 4]),
+            _vi("summary", []),
+            _vi("past_summary", []),
+        ],
+        [],
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 13)], ir_version=8
+    )
+    q = onnxsim.quantize_kv_cache(model)
+    assert q.SerializeToString() == model.SerializeToString()
+
+
+def test_kv_cache_quantization_noop_without_kv_cache_pattern():
+    nodes = [onnx.helper.make_node("Relu", ["x"], ["y"])]
+    graph = onnx.helper.make_graph(
+        nodes, "g", [_vi("x", [4, 4])], [_vi("y", [4, 4])], []
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 13)], ir_version=8
+    )
+    result = onnxsim.quantize_kv_cache(model)
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_kv_cache_quantization_noop_below_opset13():
+    model = _kv_cache_model(opset=12)
+    result = onnxsim.quantize_kv_cache(model)
+    assert result.SerializeToString() == model.SerializeToString()


### PR DESCRIPTION
## Summary

Adds `onnxsim.quantize_kv_cache`, following up on the KV-cache quantization
survey (`docs/kv-cache-quantization.md`): unlike every other quantizer in
this project, which compresses a *weight* computed once offline, a KV cache
is an *activation* that keeps growing for the whole lifetime of one
autoregressive generation -- the part of an LLM's memory footprint that
actually scales with sequence length.

## What it does

Reproduces the core empirical finding shared by **KIVI** (Liu et al., ICML
2024) and **KVQuant** (Hooper et al., NeurIPS 2024): Key activations have a
handful of channels with persistently large magnitude across the whole
sequence, so quantizing **per channel** (one scale shared by every cached
token) preserves far more accuracy than quantizing per token.

The pass finds every `Concat(past, new, axis=seq)` KV-cache stream by
structure (a float32 graph input consumed only by that Concat, feeding a
graph output) -- no name assumptions, so it matches both a plain
`past_key`/`present_key` convention and `optimum-onnx`'s own
`past_key_values.{i}.key`/`present.{i}.key` -- and rewrites it so the
`Concat` itself runs in the INT8 domain:

```
past_key: graph input, INT8 [..., seq_past, head_dim]
new_key_q = QuantizeLinear(new_key, key_scale, key_zero_point, axis=-1)
present_key = Concat(past_key, new_key_q, axis=seq)   -- INT8 graph output
present_key_f = DequantizeLinear(present_key, key_scale, key_zero_point, axis=-1)
```

Only this step's new token is ever quantized (the already-int8 past cache
concatenates in directly, at constant per-step cost), and the graph's own
`present_*` output stays genuinely compressed across a caller's decode
loop -- not just an internal round-trip that still stores float32
everywhere.

## Deliberately out of scope (see docs for why)

- KIVI's own **per-token** Value quantization (would need a second, parallel
  growing scale stream) -- this module applies the same static per-channel
  scheme to Value too, matching what several serving engines' plain
  "int8/fp8 KV cache" flag already does in production.
- KIVI's **residual-window** bookkeeping (most recent `R` tokens kept full
  precision) -- inherently cross-step, host-side state that belongs in
  `tools/onnx-deploy`'s `KvCachePipeline`, not a single-step ONNX graph
  rewrite.
- KVQuant's non-uniform codebook / dense-and-sparse outlier isolation.

## Verification

- `test_kv_cache_quantization_two_step_round_trip_close_to_float`: a
  genuine two-step round trip -- empty starting cache, then feeding step
  0's own INT8 `present_key` output back in as step 1's `past_key` input,
  exactly what a real pipeline does -- compared against the float model's
  dequantized cache tensor.
- Structural tests: input/output dtype changes to INT8, `QuantizeLinear`/
  `DequantizeLinear` inserted correctly, downstream consumers rewired to
  the dequantized tensor.
- Declines safely: a `past` operand with another consumer besides the
  Concat, no matching pattern, opset < 13.
- Full regression sweep (`tests/`, `CI=1`): 662 passed, 76 skipped, 0
  failures caused by this change (only pre-existing `onnxscript`
  `ModuleNotFoundError` in unrelated files).
- `ruff format` / `ruff check` / `mypy` clean (mypy's pre-existing 16
  errors in other files are unchanged; this module introduces none).

## New files

- `onnxsim/kv_cache_quantization.py`
- `docs/kv-cache-quantization.md`
- `tests/test_kv_cache_quantization.py` -- 6 tests

## Test plan

- [x] `pytest tests/test_kv_cache_quantization.py -v`
- [x] Full `tests/` sweep with `CI=1`
- [x] `ruff format` / `ruff check` / `mypy`

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_