### PR TITLE
onnx-deploy: thread an INT8 KV cache through KvCachePipeline

### DIFF
--- a/.github/workflows/onnx-deploy.yml
+++ b/.github/workflows/onnx-deploy.yml
@@ -15,7 +15,11 @@ name: onnx-deploy
 # generated token sequence is exactly right and identical either way. See
 # that script's docstring for why the toy model's output is a direct
 # witness of the KV-cache threading being correct, not just "did it not
-# crash".
+# crash". A second toy export (scripts/make_toy_int8_kv_decoder.py) repeats
+# this against an INT8 KV cache -- the same graph shape
+# onnxsim.quantize_kv_cache produces -- proving detail::BorrowView's INT8
+# case in kv_cache_pipeline.h threads a quantized cache across many decode
+# steps, not just the original fp32/int64 tensors.
 #
 # Also checks execution-provider selection fails cleanly on this GPU-less
 # runner, rather than crashing: native --execution-provider cuda/webgpu
@@ -126,6 +130,32 @@ jobs:
           out=$(./build/onnx-deploy --libort "${{ env.ORT_NEWER_HOME }}/lib/libonnxruntime.so" /tmp/toy_seq2seq 3,4 --max-new-tokens 8)
           echo "$out"
           echo "$out" | grep -qF "generated 8 token(s): 0 1 2 3 4 5 6 0"
+
+      - name: Generate the toy INT8 KV-cache decoder export and compute the expected sequence
+        working-directory: tools/onnx-deploy
+        run: |
+          python3 scripts/make_toy_int8_kv_decoder.py -o /tmp/toy_int8_kv --vocab-size 7 --decoder-start-token-id 2
+          python3 -c "
+          import sys; sys.path.insert(0, 'scripts')
+          from make_toy_int8_kv_decoder import compute_expected_ids
+          expected = compute_expected_ids(2, 7, 10)
+          print('expected:', expected)
+          assert expected == [2, 4, 1, 2, 4, 1, 2, 4, 1, 2], expected
+          "
+
+      - name: Run the CLI against the INT8 KV-cache export (${{ env.ORT_VERSION_OLDER }}) -- proves detail::BorrowView's INT8 case (onnxsim.quantize_kv_cache's output shape) threads through Generate() across many steps
+        working-directory: tools/onnx-deploy
+        run: |
+          out=$(./build/onnx-deploy --libort "${{ env.ORT_OLDER_HOME }}/lib/libonnxruntime.so" /tmp/toy_int8_kv 2 --max-new-tokens 10)
+          echo "$out"
+          echo "$out" | grep -qF "generated 10 token(s): 2 4 1 2 4 1 2 4 1 2"
+
+      - name: Swap the INT8 KV-cache export to ORT ${{ env.ORT_VERSION_NEWER }} at runtime -- same binary, no rebuild
+        working-directory: tools/onnx-deploy
+        run: |
+          out=$(./build/onnx-deploy --libort "${{ env.ORT_NEWER_HOME }}/lib/libonnxruntime.so" /tmp/toy_int8_kv 2 --max-new-tokens 10)
+          echo "$out"
+          echo "$out" | grep -qF "generated 10 token(s): 2 4 1 2 4 1 2 4 1 2"
 
       - name: Early-stop at eos_token_id
         working-directory: tools/onnx-deploy

--- a/docs/kv-cache-quantization.md
+++ b/docs/kv-cache-quantization.md
@@ -126,10 +126,21 @@ KVQuant's own finding says matter most.
 A model quantized this way needs a caller that actually stores its
 `past_*`/`present_*` tensors as INT8 across decode steps to see any real
 memory benefit -- `tools/onnx-deploy`'s `KvCachePipeline`
-(`include/onnx_deploy/kv_cache_pipeline.h`) does not yet do this
-(`BorrowView` there currently only handles fp32/int64 tensors), so wiring
-this quantizer's output through that pipeline end-to-end is a natural
-follow-up, not something this module does on its own.
+(`include/onnx_deploy/kv_cache_pipeline.h`) supports this:
+`detail::BorrowView` handles INT8 tensors (alongside the original fp32/
+int64) and threads them through `Generate()`'s decode loop exactly like any
+other cache dtype, verified end-to-end by
+`tools/onnx-deploy/scripts/make_toy_int8_kv_decoder.py` and
+`.github/workflows/onnx-deploy.yml` against a real, growing INT8 cache
+across many steps and two different ONNX Runtime releases. Note that a real
+multi-file `optimum-onnx`-style export needs `decoder_model.onnx` (the
+"no past" first step) quantized consistently with `decoder_with_past_model.onnx`
+for the same cache stream too, since both files share the same
+`present.*`/`past_key_values.*` dtype contract; `quantize_kv_cache` only
+matches graphs with a `Concat(past, new)` pattern (present in the "with
+past" file, absent in the first-step file, which has no past to concat),
+so quantizing both files of a real pipeline consistently is left to the
+caller for now.
 
 `tests/test_kv_cache_quantization.py` verifies this end-to-end with a
 genuine two-step round trip (an empty starting cache, then feeding the

--- a/tools/onnx-deploy/README.md
+++ b/tools/onnx-deploy/README.md
@@ -309,9 +309,20 @@ checkout, on every change under `tools/onnx-deploy/`:
    just a design note.
 6. Repeats the same swap test through `onnx_deploy_py` (fresh Python
    process per ORT build).
-7. Checks that a bad model directory and a bad `--libort` path both fail
+7. Generates a second toy export, `scripts/make_toy_int8_kv_decoder.py`
+   (decoder-only, no encoder): its `past_key_values.0.key`/`present.0.key`
+   are INT8 from the start -- the same graph shape
+   `onnxsim.quantize_kv_cache` produces (see
+   `docs/kv-cache-quantization.md` in the main package) -- and its `Concat`
+   genuinely grows the cache every step rather than overwriting a single
+   slot, so `logits` at each step is a function of the *whole* cache
+   history, not just the latest token. Runs it against both ORT releases
+   the same way as steps 4-5, proving `detail::BorrowView`'s INT8 case
+   (`kv_cache_pipeline.h`) threads a quantized cache through `Generate()`
+   correctly across many steps, not just fp32/int64.
+8. Checks that a bad model directory and a bad `--libort` path both fail
    cleanly (`ONNX_DEPLOY_ERROR` / exit 1 with a message), not a crash.
-8. Checks that `--execution-provider cuda`, `--execution-provider webgpu`
+9. Checks that `--execution-provider cuda`, `--execution-provider webgpu`
    (ORT's native EP -- no GPU/CUDA- or WebGPU-enabled ORT build on this
    runner), and an unknown provider name all fail cleanly the same way --
    see "Execution providers" above for what this does and doesn't prove.

--- a/tools/onnx-deploy/include/onnx_deploy/kv_cache_pipeline.h
+++ b/tools/onnx-deploy/include/onnx_deploy/kv_cache_pipeline.h
@@ -134,9 +134,12 @@ inline std::vector<const char*> AsCStrs(const std::vector<std::string>& v) {
 // onnxsim/dlpack_bridge.h's BorrowAsOrtValue, just against an existing
 // Ort::Value instead of a DLManagedTensor.
 //
-// Sketch-level limitation: only fp32/int64 tensors are handled, since that
-// covers a plain (non-fp16) optimum-onnx export. A real deployment of an
-// fp16-weight model needs this switch extended.
+// Sketch-level limitation: only fp32/int64/int8 tensors are handled -- fp32
+// and int64 cover a plain (non-fp16) optimum-onnx export, and int8 covers a
+// KV cache quantized by onnxsim.quantize_kv_cache
+// (onnxsim/kv_cache_quantization.py), whose past_key_values.*/present.*
+// tensors are INT8 by construction. A real deployment of an fp16-weight
+// model needs this switch extended further.
 inline Ort::Value BorrowView(const Ort::Value& src) {
   auto info = src.GetTensorTypeAndShapeInfo();
   std::vector<int64_t> shape = info.GetShape();
@@ -149,6 +152,10 @@ inline Ort::Value BorrowView(const Ort::Value& src) {
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64: {
       auto* data = const_cast<int64_t*>(src.GetTensorData<int64_t>());
       return Ort::Value::CreateTensor<int64_t>(mem_info, data, info.GetElementCount(), shape.data(), shape.size());
+    }
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8: {
+      auto* data = const_cast<int8_t*>(src.GetTensorData<int8_t>());
+      return Ort::Value::CreateTensor<int8_t>(mem_info, data, info.GetElementCount(), shape.data(), shape.size());
     }
     default:
       throw std::runtime_error("BorrowView: unsupported dtype (extend for fp16/bf16 models)");

--- a/tools/onnx-deploy/scripts/make_toy_int8_kv_decoder.py
+++ b/tools/onnx-deploy/scripts/make_toy_int8_kv_decoder.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Builds a tiny, hand-crafted decoder-only export (decoder_model.onnx +
+decoder_with_past_model.onnx, no encoder_model.onnx -- the causal-LM shape,
+per README.md's "What optimum-onnx actually exports") whose KV cache is
+INT8 from the start, WITHOUT needing torch/transformers/optimum -- just the
+`onnx` package, mirroring make_toy_seq2seq.py's role for the float case.
+
+This exists specifically to regression-test detail::BorrowView's INT8 case
+(kv_cache_pipeline.h) end to end through the real KvCachePipeline/CLI: an
+onnxsim.quantize_kv_cache-quantized model has an INT8 past_key_values.*/
+present.* stream, and nothing previously exercised that path through this
+tool's own C++ (the Python-side numerics are already covered by
+tests/test_kv_cache_quantization.py in the main onnxsim package -- this
+script is deliberately *not* built by running that quantizer over a real
+export, so it can isolate the C++ pipeline's own INT8 tensor threading from
+the Python quantizer's calibration/scale logic).
+
+The model (single stream, no real attention -- just enough structure to
+exercise Concat-growing an INT8 cache across many steps):
+
+  decoder_model.onnx (step 0, no past):
+    present.0.key = Cast(input_ids, INT8)               -- seeds the cache
+    logits = OneHot(Mod(ReduceSum(Cast(present.0.key, INT64)), vocab_size),
+                     vocab_size)
+
+  decoder_with_past_model.onnx (every step after):
+    new_key = Cast(input_ids, INT8)
+    present.0.key = Concat(past_key_values.0.key, new_key, axis=1)  -- INT8,
+      genuinely grows every step (unlike make_toy_seq2seq.py's single-slot
+      Identity cache) -- exactly the shape onnxsim.quantize_kv_cache
+      produces and detail::BorrowView needs to thread across Run() calls.
+    logits = OneHot(Mod(ReduceSum(Cast(present.0.key, INT64)), vocab_size),
+                     vocab_size)
+
+Since `logits` at every step is a deterministic function of the *entire*
+cache's own token history (not just the latest token, unlike
+make_toy_seq2seq.py's "always +1" trick), a pipeline that fails to thread
+the INT8 cache correctly across steps -- drops it, re-feeds a stale or
+zeroed buffer, or corrupts it during the borrow/move dance -- changes the
+generated sequence, not just its performance. See compute_expected_ids()
+for the independent reference.
+
+Usage:
+    python3 make_toy_int8_kv_decoder.py -o toy_int8_kv --vocab-size 7 \\
+        --decoder-start-token-id 2
+"""
+
+import argparse
+import os
+
+import onnx
+from onnx import TensorProto, checker, helper
+
+
+def _cache_sum_logits_subgraph(prefix, cache_name, vocab_size):
+    """Nodes computing
+    logits = OneHot(Mod(ReduceSum(Cast(cache_name, INT64)), vocab_size), vocab_size),
+    reshaped to [1, 1, vocab_size] -- cache_name is an INT8 tensor of any
+    rank/length (the whole KV cache so far). Returns (nodes, initializers,
+    logits_name).
+    """
+    cache_i64 = f"{prefix}_cache_i64"
+    total = f"{prefix}_total"
+    idx0 = f"{prefix}_idx0"
+    idx2d = f"{prefix}_idx2d"
+    logits = "logits"
+    nodes = [
+        helper.make_node("Cast", [cache_name], [cache_i64], to=TensorProto.INT64),
+        helper.make_node("ReduceSum", [cache_i64], [total], keepdims=0),
+        helper.make_node("Mod", [total, f"{prefix}_vocab_size"], [idx0]),
+        helper.make_node("Reshape", [idx0, f"{prefix}_shape_1x1"], [idx2d]),
+        helper.make_node(
+            "OneHot",
+            [idx2d, f"{prefix}_depth", f"{prefix}_onehot_values"],
+            [logits],
+            axis=-1,
+        ),
+    ]
+    initializers = [
+        helper.make_tensor(f"{prefix}_vocab_size", TensorProto.INT64, [], [vocab_size]),
+        helper.make_tensor(f"{prefix}_shape_1x1", TensorProto.INT64, [2], [1, 1]),
+        helper.make_tensor(f"{prefix}_depth", TensorProto.INT64, [], [vocab_size]),
+        helper.make_tensor(
+            f"{prefix}_onehot_values", TensorProto.FLOAT, [2], [0.0, 1.0]
+        ),
+    ]
+    return nodes, initializers, logits
+
+
+def make_decoder_model(vocab_size):
+    input_ids = helper.make_tensor_value_info("input_ids", TensorProto.INT64, [1, 1])
+    nodes = [
+        helper.make_node("Cast", ["input_ids"], ["present.0.key"], to=TensorProto.INT8),
+    ]
+    onehot_nodes, onehot_inits, logits_name = _cache_sum_logits_subgraph(
+        "d0", "present.0.key", vocab_size
+    )
+    nodes += onehot_nodes
+    assert logits_name == "logits"
+
+    outputs = [
+        helper.make_tensor_value_info("logits", TensorProto.FLOAT, [1, 1, vocab_size]),
+        helper.make_tensor_value_info("present.0.key", TensorProto.INT8, [1, 1]),
+    ]
+    graph = helper.make_graph(
+        nodes, "toy_decoder", [input_ids], outputs, initializer=onehot_inits
+    )
+    return helper.make_model(
+        graph, opset_imports=[helper.make_opsetid("", 17)], ir_version=9
+    )
+
+
+def make_decoder_with_past_model(vocab_size):
+    input_ids = helper.make_tensor_value_info("input_ids", TensorProto.INT64, [1, 1])
+    past_key = helper.make_tensor_value_info(
+        "past_key_values.0.key", TensorProto.INT8, [1, "seq_past"]
+    )
+    nodes = [
+        helper.make_node("Cast", ["input_ids"], ["new_key"], to=TensorProto.INT8),
+        helper.make_node(
+            "Concat", ["past_key_values.0.key", "new_key"], ["present.0.key"], axis=1
+        ),
+    ]
+    onehot_nodes, onehot_inits, logits_name = _cache_sum_logits_subgraph(
+        "dp0", "present.0.key", vocab_size
+    )
+    nodes += onehot_nodes
+    assert logits_name == "logits"
+
+    outputs = [
+        helper.make_tensor_value_info("logits", TensorProto.FLOAT, [1, 1, vocab_size]),
+        helper.make_tensor_value_info(
+            "present.0.key", TensorProto.INT8, [1, "seq_present"]
+        ),
+    ]
+    graph = helper.make_graph(
+        nodes,
+        "toy_decoder_with_past",
+        [input_ids, past_key],
+        outputs,
+        initializer=onehot_inits,
+    )
+    return helper.make_model(
+        graph, opset_imports=[helper.make_opsetid("", 17)], ir_version=9
+    )
+
+
+def compute_expected_ids(
+    decoder_start_token_id, vocab_size, max_new_tokens, eos_token_id=None
+):
+    """Reference implementation of the toy model's math, independent of ONNX
+    Runtime: at every step, the generated token is the running sum of every
+    token in the cache so far (including itself once generated), mod
+    vocab_size -- see this module's own docstring for the derivation.
+    """
+    cache = [decoder_start_token_id]
+    generated = []
+    for _ in range(max_new_tokens):
+        token = sum(cache) % vocab_size
+        generated.append(token)
+        cache.append(token)
+        if eos_token_id is not None and token == eos_token_id:
+            break
+    return generated
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("-o", "--output-dir", required=True)
+    parser.add_argument("--vocab-size", type=int, default=7)
+    parser.add_argument("--decoder-start-token-id", type=int, default=2)
+    args = parser.parse_args()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    models = {
+        "decoder_model.onnx": make_decoder_model(args.vocab_size),
+        "decoder_with_past_model.onnx": make_decoder_with_past_model(args.vocab_size),
+    }
+    for name, model in models.items():
+        checker.check_model(model)
+        onnx.save(model, os.path.join(args.output_dir, name))
+        print(f"wrote {name}")
+
+    print(
+        f"decoder_start_token_id={args.decoder_start_token_id} vocab_size={args.vocab_size}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Follows up on `onnxsim.quantize_kv_cache` (#759): its output is an INT8
`past_key_values.*`/`present.*` KV cache, but `tools/onnx-deploy`'s
`KvCachePipeline` -- the one place in this repo that actually drives a
multi-file decoder export end to end -- had no way to consume it.
`detail::BorrowView` (`kv_cache_pipeline.h`) only handled fp32/int64
tensors, so a quantized model would throw `"unsupported dtype"` the moment
the pipeline tried to borrow a cache entry across decode steps: the graph
rewrite was correct in isolation but had no real consumer.

## What changed

- `detail::BorrowView` now also handles `ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8`,
  the same non-owning-view pattern already used for float/int64.
- New toy export generator, `scripts/make_toy_int8_kv_decoder.py`
  (decoder-only, no encoder): its KV cache is INT8 from the start and
  genuinely **grows every step via `Concat`** (unlike
  `make_toy_seq2seq.py`'s single-slot `Identity` cache) -- exactly the
  graph shape `quantize_kv_cache` produces. `logits` at each step is a
  deterministic function of the *whole* cache history (`sum(cache) % vocab`),
  not just the latest token, so a broken INT8 handoff changes the generated
  sequence, not just performance -- see the script's own docstring for the
  derivation.
- Wired into `.github/workflows/onnx-deploy.yml`'s existing job: runs the
  new toy model through both ONNX Runtime releases (1.18.1 and 1.19.2, same
  compiled binary, no rebuild), asserting the exact expected sequence
  either way.
- `README.md` and `docs/kv-cache-quantization.md` updated to match.

## Verified locally (this build has no gtest-style unit tests -- verification is the CLI + toy model, per the tool's own convention)

- Reproduced the *original* failure first: reverted the fix, rebuilt, ran
  the new toy model -- got exactly `BorrowView: unsupported dtype` as
  expected.
- With the fix: `onnx-deploy --libort <1.19.2> toy_int8_kv 2 --max-new-tokens 10`
  → `2 4 1 2 4 1 2 4 1 2`, matching `compute_expected_ids(2, 7, 10)`.
- Same result rebuilding against 1.18.1 headers and swapping `--libort`
  between both releases on the identical compiled binary (mirrors CI's own
  "build old, swap to new" direction).
- Confirmed the pre-existing seq2seq toy model (`make_toy_seq2seq.py`)
  still produces its own correct sequence -- no regression.
- Workflow YAML parses cleanly (`yaml.safe_load`); `kv_cache_pipeline.h` is
  under `tools/onnx-deploy/`, outside the repo's `clang-format` CI job's
  scope (`onnxsim/**` only), so no formatting gate applies to it.

## Known remaining gap (documented, not fixed here)

A genuine multi-file `optimum-onnx` pipeline needs `decoder_model.onnx`
(the first, "no past" step) quantized *consistently* with
`decoder_with_past_model.onnx` for the same cache stream, since
`quantize_kv_cache` only matches the `Concat(past, new)` pattern present in
the latter (the first-step file has no past to concat, so nothing there
currently gets touched). Left to the caller for now, noted in
`docs/kv-cache-quantization.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_