### PR TITLE
Add optional onnx-shape-inference backend for better shape inference

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,7 +28,7 @@ jobs:
       # a master-branch push from a pull request inside the manylinux container.
       CIBW_ENVIRONMENT_PASS_LINUX: CI SCCACHE_GHA_ENABLED ACTIONS_RESULTS_URL ACTIONS_RUNTIME_TOKEN ACTIONS_CACHE_SERVICE_V2 ONNXSIM_RELEASE GITHUB_EVENT_NAME GITHUB_REF
       CIBW_BEFORE_BUILD: "python3 -m pip install --break-system-packages cmake ninja setuptools sccache nanobind"
-      CIBW_TEST_REQUIRES: pytest flake8 onnxruntime onnxscript==0.6.2 timm==1.0.26 sympy onnxslim onnx_safetensors
+      CIBW_TEST_REQUIRES: pytest flake8 onnxruntime onnxscript==0.6.2 timm==1.0.26 sympy onnx-shape-inference onnxslim onnx_safetensors
       CIBW_BEFORE_TEST: pip install torch==2.10.0 torchvision==0.25.0 --index-url https://download.pytorch.org/whl/cpu/
       CIBW_TEST_COMMAND: pytest -v ${{ matrix.pytest_args }} {project}/tests && onnxsim -h && onnxsim --list-default-optimizers
       # Only build on Python 3 and skip 32-bit or musl builds

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -60,7 +60,7 @@ jobs:
       background: true
       run: |
         pip install torch==2.10.0 torchvision==0.25.0 --index-url https://download.pytorch.org/whl/cpu/
-        pip install flake8 onnxruntime onnxscript==0.6.2 timm==1.0.26
+        pip install flake8 onnxruntime onnxscript==0.6.2 timm==1.0.26 sympy onnx-shape-inference
 
     - name: Build instrumented extension (editable)
       run: pip install --no-build-isolation -ve .

--- a/onnxsim/model_info.py
+++ b/onnxsim/model_info.py
@@ -34,6 +34,13 @@ try:
 except ImportError:  # onnx.inliner was added in onnx 1.14; see ModelInfo.__init__.
     onnx_inliner = None
 
+try:
+    import onnx_ir
+    from onnx_shape_inference import infer_symbolic_shapes
+except ImportError:  # optional dependency; see ModelInfo._infer_shapes below.
+    onnx_ir = None
+    infer_symbolic_shapes = None
+
 
 __all__ = [
     "ModelInfo",
@@ -557,7 +564,11 @@ class ModelInfo:
     3. MACs / FLOPs of the compute-dominant operators: Conv, ConvTranspose,
        Gemm, MatMul, Attention, and the quantized twins (ConvInteger,
        QLinearConv, MatMulInteger, QLinearMatMul). Shapes come from ONNX shape
-       inference; nodes whose shapes cannot be inferred contribute 0. Dynamic
+       inference -- or, when the optional ``onnx-shape-inference`` package
+       (https://github.com/justinchuby/onnx-shape-inference) is installed, its
+       symbolic shape inference, which resolves more shapes via data
+       propagation through chains like Shape -> Slice -> Concat -> Reshape;
+       nodes whose shapes still cannot be inferred contribute 0. Dynamic
        dimensions (``dim_param``, e.g. "batch") become sympy symbols when sympy
        is installed, so ``macs`` / ``flops`` may be a symbolic formula; without
        sympy they are assumed 1 (per-sample MACs). Function ops are expanded
@@ -684,6 +695,22 @@ class ModelInfo:
     def _infer_shapes(
         model: onnx.ModelProto, data_prop: bool = False
     ) -> onnx.ModelProto:
+        # onnx-shape-inference (https://github.com/justinchuby/onnx-shape-inference),
+        # when installed, resolves more shapes than onnx's own shape_inference: it
+        # always does data propagation and tracks values through chains like
+        # Shape -> Slice -> Concat -> Reshape, so dynamic reshapes that onnx leaves
+        # unknown often still get a shape here. Its dim_param names for dynamic
+        # dims are still picked up as sympy symbols by _tensor_shape below.
+        if infer_symbolic_shapes is not None:
+            try:
+                inferred = infer_symbolic_shapes(onnx_ir.from_proto(model))
+                return onnx_ir.to_proto(inferred)
+            except Exception as e:
+                warnings.warn(
+                    f"onnx-shape-inference failed ({e}); falling back to "
+                    "onnx.shape_inference.",
+                    stacklevel=2,
+                )
         try:
             return shape_inference.infer_shapes(model, data_prop=data_prop)
         except Exception as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,12 @@ onnxruntime = ["onnxruntime >= 1.6.0"]
 # sympy lets the MACs/FLOPs report keep dynamic dimensions (dim_param, e.g.
 # "batch") as symbols and produce a formula instead of assuming them to be 1.
 symbolic = ["sympy"]
+# onnx-shape-inference (https://github.com/justinchuby/onnx-shape-inference) is
+# used by ModelInfo (the MACs/FLOPs/memory report) as a drop-in replacement for
+# onnx.shape_inference when installed: it resolves more shapes via symbolic
+# data propagation, so fewer nodes fall back to contributing 0. Falls back to
+# onnx.shape_inference when it is not installed.
+shape-inference = ["onnx-shape-inference"]
 # Needed by onnxsim.profile_plot.plot_node_reduction() / --node-reduction-plot,
 # which renders the "NodeCount" events in a simplify(..., profile=...) trace.
 plot = ["matplotlib"]

--- a/tests/test_model_info.py
+++ b/tests/test_model_info.py
@@ -367,6 +367,74 @@ def test_dynamic_dim_without_sympy_assumes_one(monkeypatch):
 
 
 # --------------------------------------------------------------------------- #
+# onnx-shape-inference backend (onnxsim[shape-inference])
+# --------------------------------------------------------------------------- #
+def test_infer_shapes_uses_onnx_shape_inference_when_installed():
+    # onnx-shape-inference (https://github.com/justinchuby/onnx-shape-inference)
+    # does data propagation through a Shape -> Gather -> Concat -> Reshape chain
+    # that onnx.shape_inference, called without data_prop (as ModelInfo does by
+    # default), cannot see through -- it should recover "y"'s shape as
+    # ["batch", 2, 3] instead of leaving it unknown.
+    pytest.importorskip("onnx_shape_inference")
+    x = _vi("x", ["batch", 6])
+    y = _vi("y", None)
+    idx = helper.make_tensor("idx", TensorProto.INT64, [], [0])
+    axes = helper.make_tensor("axes", TensorProto.INT64, [1], [0])
+    two = helper.make_tensor("two", TensorProto.INT64, [1], [2])
+    three = helper.make_tensor("three", TensorProto.INT64, [1], [3])
+    nodes = [
+        helper.make_node("Shape", ["x"], ["x_shape"]),
+        helper.make_node("Gather", ["x_shape", "idx"], ["batch_dim"], axis=0),
+        helper.make_node("Unsqueeze", ["batch_dim", "axes"], ["batch_dim_1"]),
+        helper.make_node(
+            "Concat", ["batch_dim_1", "two", "three"], ["new_shape"], axis=0
+        ),
+        helper.make_node("Reshape", ["x", "new_shape"], ["y"]),
+    ]
+    model = _model(nodes, [x], [y], [idx, axes, two, three])
+    inferred = ModelInfo._infer_shapes(model)
+    (out,) = [o for o in inferred.graph.output if o.name == "y"]
+    dims = list(out.type.tensor_type.shape.dim)
+    assert dims[0].dim_param == "batch"
+    assert dims[1].dim_value == 2
+    assert dims[2].dim_value == 3
+
+
+def test_infer_shapes_falls_back_without_onnx_shape_inference(monkeypatch):
+    # With the optional onnx-shape-inference backend unavailable, _infer_shapes
+    # must still work via onnx's own shape_inference.
+    monkeypatch.setattr(model_info, "infer_symbolic_shapes", None)
+    x = _vi("x", [1, 3, 8, 8])
+    w = _weight("w", [4, 3, 3, 3])
+    y = _vi("y", [1, 4, 8, 8])
+    node = helper.make_node(
+        "Conv", ["x", "w"], ["y"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
+    )
+    inferred = model_info.ModelInfo._infer_shapes(_model([node], [x], [y], [w]))
+    assert any(vi.name == "y" for vi in inferred.graph.output)
+
+
+def test_infer_shapes_falls_back_when_onnx_shape_inference_raises(monkeypatch):
+    # A failure in the optional backend (e.g. an unsupported op) must degrade to
+    # onnx.shape_inference with a warning, not propagate.
+    pytest.importorskip("onnx_shape_inference")
+
+    def _raise(_ir_model):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(model_info, "infer_symbolic_shapes", _raise)
+    x = _vi("x", [1, 3, 8, 8])
+    w = _weight("w", [4, 3, 3, 3])
+    y = _vi("y", [1, 4, 8, 8])
+    node = helper.make_node(
+        "Conv", ["x", "w"], ["y"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
+    )
+    with pytest.warns(UserWarning, match="onnx-shape-inference failed"):
+        inferred = ModelInfo._infer_shapes(_model([node], [x], [y], [w]))
+    assert any(vi.name == "y" for vi in inferred.graph.output)
+
+
+# --------------------------------------------------------------------------- #
 # Formatting helpers
 # --------------------------------------------------------------------------- #
 def test_human_readable_num_units():

--- a/tests/test_model_info.py
+++ b/tests/test_model_info.py
@@ -710,6 +710,10 @@ def test_warns_when_shape_inference_fails(monkeypatch):
         raise RuntimeError("boom")
 
     monkeypatch.setattr(model_info.shape_inference, "infer_shapes", boom)
+    # Disable the optional onnx-shape-inference backend so this exercises the
+    # plain onnx.shape_inference path (and its failure) regardless of whether
+    # onnx-shape-inference happens to be installed.
+    monkeypatch.setattr(model_info, "infer_symbolic_shapes", None)
     x = _vi("x", [1, 4])
     y = _vi("y", [1, 4])
     node = helper.make_node("Relu", ["x"], ["y"])


### PR DESCRIPTION
## Summary

Adds support for the optional `onnx-shape-inference` package as a drop-in replacement for ONNX's built-in shape inference in `ModelInfo`. This enables resolution of more dynamic shapes through symbolic data propagation, improving MACs/FLOPs accuracy for models with complex reshape operations.

## Key Changes

- **Shape inference backend selection** (`model_info.py`):
  - Imports `onnx-shape-inference` as an optional dependency
  - `ModelInfo._infer_shapes()` now attempts to use `infer_symbolic_shapes()` when available
  - Falls back gracefully to `onnx.shape_inference` if the optional package is unavailable or raises an exception
  - Logs a warning when fallback occurs, helping users understand shape inference behavior

- **Documentation updates** (`model_info.py`):
  - Updated `ModelInfo` docstring to explain the optional backend and its benefits
  - Notes that symbolic shape inference resolves shapes through chains like `Shape -> Slice -> Concat -> Reshape` that standard ONNX inference cannot handle

- **Dependency configuration** (`pyproject.toml`):
  - Added new optional dependency group `shape-inference` with `onnx-shape-inference`
  - Documented the purpose and fallback behavior

- **Test coverage** (`test_model_info.py`):
  - `test_infer_shapes_uses_onnx_shape_inference_when_installed()`: Verifies that the optional backend correctly infers shapes through a `Shape -> Gather -> Concat -> Reshape` chain
  - `test_infer_shapes_falls_back_without_onnx_shape_inference()`: Ensures graceful fallback when the package is unavailable
  - `test_infer_shapes_falls_back_when_onnx_shape_inference_raises()`: Verifies error handling and warning when the backend fails

- **CI/CD updates**:
  - Added `onnx-shape-inference` to test dependencies in build workflows

## Implementation Details

The implementation uses a try-except pattern to handle the optional dependency gracefully. When `infer_symbolic_shapes` is available, it converts the ONNX model to the `onnx_ir` representation, performs symbolic shape inference, and converts back to protobuf format. Any exceptions during this process trigger a fallback to standard ONNX shape inference with a user warning, ensuring robustness across different model types and ONNX operations.

https://claude.ai/code/session_01SSuhLYRER5HozPqfy3Ph1Z