### PR TITLE
Add LoRA (low-rank adaptation) support to onnx-finetune

### DIFF
--- a/tools/onnx-finetune/README.md
+++ b/tools/onnx-finetune/README.md
@@ -126,6 +126,48 @@ python3 scripts/generate_artifacts.py toy_model.onnx -o artifacts
 The toy task is learning `y = sum(x)` with a 2-layer MLP; loss should drop
 from roughly 5 to under 0.001 over the 20 epochs.
 
+## LoRA (low-rank adaptation)
+
+`--freeze-prefix` above still trains full-size parameter tensors, just fewer
+of them. For real LoRA -- freezing every original weight and training only a
+pair of small rank-decomposition matrices alongside each targeted layer --
+use `scripts/inject_lora.py` to do the graph surgery first, then point
+`generate_artifacts.py` at the resulting adapter manifest:
+
+```sh
+# 1. Graft a rank-4 adapter onto every eligible MatMul/Gemm weight (or use
+#    --target-contains to pick specific layers, e.g. --target-contains q_proj).
+python3 scripts/inject_lora.py model.onnx -o model_lora.onnx \
+  --rank 4 --params-out lora.json
+
+# 2. Generate training artifacts that train *only* the injected lora_A/lora_B
+#    tensors -- everything else (including the original weights) is frozen.
+python3 scripts/generate_artifacts.py model_lora.onnx -o artifacts \
+  --lora-params-file lora.json --loss cross-entropy --optimizer adamw
+
+# 3. Train as usual.
+./build/onnx-finetune --artifacts-dir artifacts ... --output-model finetuned.onnx --output-names output
+
+# 4. Pull just the trained adapter back out (a few KB, not the whole model).
+python3 scripts/extract_lora_adapter.py finetuned.onnx --params-file lora.json -o adapter.onnx
+
+# 5. Re-apply that adapter to any fresh copy of the base model, no retraining.
+python3 scripts/apply_lora_adapter.py model.onnx --adapter adapter.onnx \
+  --params-file lora.json -o finetuned2.onnx
+```
+
+`inject_lora.py` adds, per targeted weight `W`, a
+`(alpha/rank) * (X @ lora_A @ lora_B)` branch alongside that layer's existing
+output (`lora_A` Kaiming-normal, `lora_B` zero, so injecting is a no-op until
+trained). `adapter.onnx` from step 4 is not a runnable model by itself --
+it's a plain tensor container holding just the `lora_A`/`lora_B` initializers
+-- meant to be re-merged with `apply_lora_adapter.py`, not loaded directly
+into a session. This is a portable, ONNX-native adapter format built on
+these scripts; it is not the same binary format as ONNX Runtime GenAI's
+`.onnx_adapter` files (those come out of Olive's `convert-adapters`, for
+loading multiple adapters into one inference session via
+`Ort::LoraAdapter`/`RunOptions`).
+
 ## CLI reference
 
 | flag | required | description |
@@ -139,5 +181,5 @@ from roughly 5 to under 0.001 over the 20 epochs.
 | `--batch-size` | no (default 8) | |
 | `--epochs` | no (default 10) | |
 | `--lr` | no (default 1e-3) | |
-| `--save-checkpoint` | no | also save the post-training checkpoint (for resuming later, or LoRA-style adapter export) |
+| `--save-checkpoint` | no | also save the post-training checkpoint (for resuming training later) |
 | `--log-every` | no (default 50) | print loss every N steps; 0 disables |

--- a/tools/onnx-finetune/scripts/apply_lora_adapter.py
+++ b/tools/onnx-finetune/scripts/apply_lora_adapter.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Graft a previously trained LoRA adapter (extract_lora_adapter.py's output)
+onto a fresh copy of its base model, without retraining -- the point of
+keeping the adapter small and separate from the frozen base weights: one
+adapter file can be re-applied to as many copies of the base model as
+needed, or swapped for a different adapter trained the same way.
+"""
+
+import argparse
+import json
+
+import lora_surgery
+import onnx
+from onnx import numpy_helper
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "base_model", help="the original .onnx model inject_lora.py was run against"
+    )
+    p.add_argument("--adapter", required=True, help="output of extract_lora_adapter.py")
+    p.add_argument(
+        "--params-file", required=True, help="manifest written by inject_lora.py"
+    )
+    p.add_argument(
+        "-o",
+        "--output",
+        required=True,
+        help="where to write the ready-to-run inference model",
+    )
+    args = p.parse_args()
+
+    with open(args.params_file) as f:
+        manifest = json.load(f)
+
+    adapter_model = onnx.load(args.adapter)
+    values_by_name = {
+        i.name: numpy_helper.to_array(i) for i in adapter_model.graph.initializer
+    }
+
+    lora_values = {}
+    for a_name, b_name in manifest["pairs"]:
+        weight_name = a_name.rsplit(".lora_A", 1)[0]
+        lora_values[weight_name] = (values_by_name[a_name], values_by_name[b_name])
+
+    model = onnx.load(args.base_model)
+    lora_surgery.inject(
+        model,
+        None,
+        manifest["rank"],
+        manifest["alpha"],
+        lora_values=lora_values,
+        exact_names=set(lora_values.keys()),
+    )
+
+    onnx.checker.check_model(model)
+    onnx.save(model, args.output)
+    print(f"applied {len(lora_values)} adapter(s) from {args.adapter} -> {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/onnx-finetune/scripts/extract_lora_adapter.py
+++ b/tools/onnx-finetune/scripts/extract_lora_adapter.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Pull the trained LoRA adapter weights out of a fine-tuned inference model.
+
+onnx-finetune's --output-model is a full, standalone inference model (frozen
+base weights plus the trained lora_A/lora_B branches injected by
+inject_lora.py). This script copies out just the adapter initializers listed
+in inject_lora.py's manifest into a small standalone .onnx file -- not a
+runnable model, just a tensor container -- so the adapter can be shipped and
+applied on its own instead of the whole fine-tuned model. See
+apply_lora_adapter.py to graft it back onto a base model.
+"""
+
+import argparse
+import json
+
+import onnx
+from onnx import helper
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("finetuned_model", help="output of onnx-finetune --output-model")
+    p.add_argument(
+        "--params-file", required=True, help="manifest written by inject_lora.py"
+    )
+    p.add_argument(
+        "-o",
+        "--output",
+        required=True,
+        help="where to write the standalone adapter .onnx",
+    )
+    args = p.parse_args()
+
+    with open(args.params_file) as f:
+        manifest = json.load(f)
+    names = [n for pair in manifest["pairs"] for n in pair]
+
+    model = onnx.load(args.finetuned_model)
+    by_name = {i.name: i for i in model.graph.initializer}
+    missing = [n for n in names if n not in by_name]
+    if missing:
+        raise SystemExit(
+            f"error: adapter params missing from {args.finetuned_model}: {missing}"
+        )
+
+    graph = helper.make_graph(
+        nodes=[],
+        name="lora_adapter",
+        inputs=[],
+        outputs=[],
+        initializer=[by_name[n] for n in names],
+    )
+    adapter_model = helper.make_model(graph, opset_imports=model.opset_import)
+    adapter_model.ir_version = model.ir_version
+    onnx.save(adapter_model, args.output)
+    print(
+        f"wrote {len(names)} adapter tensor(s) (rank={manifest['rank']} alpha={manifest['alpha']}) -> {args.output}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/onnx-finetune/scripts/generate_artifacts.py
+++ b/tools/onnx-finetune/scripts/generate_artifacts.py
@@ -11,7 +11,9 @@ Requires a training-enabled onnxruntime build (`--enable_training_apis
 --enable_pybind --build_wheel`, or the future public wheel once one exists --
 `pip install onnxruntime` alone does not include this). See ../README.md.
 """
+
 import argparse
+import json
 import os
 import sys
 
@@ -32,13 +34,25 @@ OPTIM_TYPES = {
 def main():
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("model", help="input .onnx file")
-    p.add_argument("-o", "--output-dir", required=True, help="directory to write training artifacts into")
+    p.add_argument(
+        "-o",
+        "--output-dir",
+        required=True,
+        help="directory to write training artifacts into",
+    )
     p.add_argument(
         "--freeze-prefix",
         action="append",
         default=[],
         help="initializer name prefix to freeze (repeatable). Everything not matching a "
-        "given prefix is trainable. Omit to train the whole model.",
+        "given prefix is trainable. Omit to train the whole model. Ignored if "
+        "--lora-params-file is given.",
+    )
+    p.add_argument(
+        "--lora-params-file",
+        help="JSON adapter manifest from inject_lora.py -- trains exactly the LoRA lora_A/lora_B "
+        "params it lists and freezes every other initializer (the real low-rank LoRA recipe, as "
+        "opposed to --freeze-prefix's full-parameter subset training). Overrides --freeze-prefix.",
     )
     p.add_argument("--loss", choices=LOSS_TYPES, default="mse")
     p.add_argument("--optimizer", choices=OPTIM_TYPES, default="adamw")
@@ -46,14 +60,26 @@ def main():
 
     model = onnx.load(args.model)
     all_params = [i.name for i in model.graph.initializer]
-    if args.freeze_prefix:
-        frozen = [n for n in all_params if any(n.startswith(pfx) for pfx in args.freeze_prefix)]
+    if args.lora_params_file:
+        with open(args.lora_params_file) as f:
+            manifest = json.load(f)
+        trainable = [n for pair in manifest["pairs"] for n in pair]
+        frozen = [n for n in all_params if n not in trainable]
+    elif args.freeze_prefix:
+        frozen = [
+            n
+            for n in all_params
+            if any(n.startswith(pfx) for pfx in args.freeze_prefix)
+        ]
+        trainable = [n for n in all_params if n not in frozen]
     else:
         frozen = []
-    trainable = [n for n in all_params if n not in frozen]
+        trainable = list(all_params)
 
     if not trainable:
-        sys.exit("error: --freeze-prefix matched every initializer, nothing left to train")
+        sys.exit(
+            "error: --freeze-prefix matched every initializer, nothing left to train"
+        )
 
     print(f"trainable ({len(trainable)}):", ", ".join(trainable))
     if frozen:

--- a/tools/onnx-finetune/scripts/inject_lora.py
+++ b/tools/onnx-finetune/scripts/inject_lora.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Inject trainable LoRA (low-rank adaptation) branches into a bare .onnx
+model, in place of full-parameter fine-tuning.
+
+Every targeted MatMul/Gemm weight stays frozen; a small
+`(alpha/rank) * (X @ lora_A @ lora_B)` branch is added alongside its output
+(lora_A Kaiming-normal, lora_B zero, so the model is numerically unchanged
+until trained). Feed the output to generate_artifacts.py --lora-params-file
+to train only the injected adapter weights.
+"""
+
+import argparse
+import json
+import sys
+
+import lora_surgery
+import onnx
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("model", help="input .onnx file")
+    p.add_argument(
+        "-o",
+        "--output",
+        required=True,
+        help="where to write the LoRA-injected .onnx model",
+    )
+    p.add_argument("--rank", type=int, default=4, help="adapter rank (default 4)")
+    p.add_argument(
+        "--alpha",
+        type=float,
+        default=None,
+        help="LoRA scaling numerator, delta is scaled by alpha/rank (default: equal to --rank, i.e. scale 1.0)",
+    )
+    p.add_argument(
+        "--target-contains",
+        action="append",
+        default=[],
+        help="only target MatMul/Gemm nodes whose 2-D weight initializer name contains this "
+        "substring (repeatable). Omit to target every eligible node.",
+    )
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument(
+        "--params-out",
+        required=True,
+        help="where to write the JSON adapter manifest (rank/alpha/param names), needed by "
+        "generate_artifacts.py --lora-params-file and extract_lora_adapter.py",
+    )
+    args = p.parse_args()
+
+    alpha = args.alpha if args.alpha is not None else float(args.rank)
+
+    model = onnx.load(args.model)
+    added = lora_surgery.inject(
+        model, args.target_contains, args.rank, alpha, seed=args.seed
+    )
+    if not added:
+        sys.exit(
+            "error: no eligible MatMul/Gemm targets matched (2-D weight initializer, non-transposed input)"
+        )
+
+    onnx.checker.check_model(model)
+    onnx.save(model, args.output)
+    with open(args.params_out, "w") as f:
+        json.dump({"rank": args.rank, "alpha": alpha, "pairs": added}, f, indent=2)
+
+    print(
+        f"injected {len(added)} LoRA adapter(s), rank={args.rank} alpha={alpha} -> {args.output}"
+    )
+    print(f"wrote adapter manifest -> {args.params_out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/onnx-finetune/scripts/lora_surgery.py
+++ b/tools/onnx-finetune/scripts/lora_surgery.py
@@ -1,0 +1,140 @@
+"""Shared LoRA graph-surgery helpers used by inject_lora.py and
+apply_lora_adapter.py.
+
+Grafts a low-rank adapter branch onto a frozen MatMul/Gemm weight without
+touching the original node or any downstream consumer:
+
+    Y = base_linear(X, W)                      # unchanged, W stays frozen
+    Y += (alpha / rank) * (X @ lora_A @ lora_B) # new, small, trainable
+
+lora_A is Kaiming-normal, lora_B is zero, so injecting is a no-op until the
+adapter is actually trained -- the standard LoRA initialization.
+"""
+
+import numpy as np
+from onnx import helper, numpy_helper
+
+
+def find_targets(model, name_contains=None, exact_names=None):
+    """Eligible MatMul/Gemm nodes: op has a 2-D initializer as input[1], and
+    (for Gemm) does not transpose input[0]. Returns [(node, initializer,
+    transB)]. `exact_names` (exact initializer name match) takes precedence
+    over `name_contains` (substring match, empty/None means "match all")."""
+    initializers = {i.name: i for i in model.graph.initializer}
+    targets = []
+    for node in model.graph.node:
+        if node.op_type not in ("MatMul", "Gemm") or len(node.input) < 2:
+            continue
+        init = initializers.get(node.input[1])
+        if init is None or len(init.dims) != 2:
+            continue
+        if exact_names is not None:
+            if init.name not in exact_names:
+                continue
+        elif name_contains and not any(s in init.name for s in name_contains):
+            continue
+        transA, transB = False, False
+        for attr in node.attribute:
+            if attr.name == "transA":
+                transA = bool(attr.i)
+            elif attr.name == "transB":
+                transB = bool(attr.i)
+        if transA:
+            continue  # unusual for a linear layer; skip rather than guess
+        targets.append((node, init, transB))
+    return targets
+
+
+def lora_param_names(weight_name):
+    return f"{weight_name}.lora_A", f"{weight_name}.lora_B"
+
+
+def inject(
+    model, name_contains, rank, alpha, lora_values=None, seed=0, exact_names=None
+):
+    """Add a LoRA branch to every targeted node.
+
+    lora_values, when given, maps weight name -> (A, B) numpy arrays to use
+    verbatim (grafting a trained adapter); otherwise A/B are freshly
+    initialized (preparing a model for training).
+
+    Returns the list of (lora_A_name, lora_B_name) pairs added, one per
+    targeted weight.
+    """
+    rng = np.random.default_rng(seed)
+    targets = find_targets(model, name_contains, exact_names)
+
+    added = []
+    for node, init, transB in targets:
+        w = numpy_helper.to_array(init)
+        dtype = w.dtype
+        in_dim, out_dim = (
+            (w.shape[1], w.shape[0]) if transB else (w.shape[0], w.shape[1])
+        )
+        a_name, b_name = lora_param_names(init.name)
+
+        if lora_values is not None:
+            a = np.asarray(lora_values[init.name][0], dtype=dtype)
+            b = np.asarray(lora_values[init.name][1], dtype=dtype)
+        else:
+            a = (rng.standard_normal((in_dim, rank)) / np.sqrt(in_dim)).astype(dtype)
+            b = np.zeros((rank, out_dim), dtype=dtype)
+
+        model.graph.initializer.append(numpy_helper.from_array(a, a_name))
+        model.graph.initializer.append(numpy_helper.from_array(b, b_name))
+
+        x_name = node.input[0]
+        orig_out = node.output[0]
+        base_out_name = f"{init.name}.lora_base_out"
+        h_name = f"{init.name}.lora_h"
+        delta_name = f"{init.name}.lora_delta"
+
+        # Redirect the original node's output to an intermediate tensor and
+        # add the low-rank delta back under the original tensor name, so
+        # every downstream consumer sees the same output name as before.
+        node.output[0] = base_out_name
+
+        new_nodes = [
+            helper.make_node(
+                "MatMul", [x_name, a_name], [h_name], name=f"{init.name}/lora_A_matmul"
+            ),
+            helper.make_node(
+                "MatMul",
+                [h_name, b_name],
+                [delta_name],
+                name=f"{init.name}/lora_B_matmul",
+            ),
+        ]
+        scale = alpha / rank
+        add_input = delta_name
+        if scale != 1.0:
+            scale_name = f"{init.name}.lora_scale"
+            model.graph.initializer.append(
+                numpy_helper.from_array(np.array(scale, dtype=dtype), scale_name)
+            )
+            scaled_name = f"{init.name}.lora_scaled"
+            new_nodes.append(
+                helper.make_node(
+                    "Mul",
+                    [delta_name, scale_name],
+                    [scaled_name],
+                    name=f"{init.name}/lora_scale_mul",
+                )
+            )
+            add_input = scaled_name
+        new_nodes.append(
+            helper.make_node(
+                "Add",
+                [base_out_name, add_input],
+                [orig_out],
+                name=f"{init.name}/lora_add",
+            )
+        )
+
+        insert_at = list(model.graph.node).index(node) + 1
+        for offset, n in enumerate(new_nodes):
+            model.graph.node.insert(insert_at + offset, n)
+
+        added.append((a_name, b_name))
+
+    return added


### PR DESCRIPTION
## Summary

Adds complete LoRA (low-rank adaptation) support to onnx-finetune, enabling efficient fine-tuning by freezing base model weights and training only small rank-decomposed adapter matrices. This includes graph surgery utilities, injection/extraction scripts, and integration with the training pipeline.

## Key Changes

- **`lora_surgery.py`** (new): Core graph-surgery utilities shared by LoRA scripts
  - `find_targets()`: Identifies eligible MatMul/Gemm nodes with 2-D weight initializers
  - `inject()`: Grafts `(alpha/rank) * (X @ lora_A @ lora_B)` branches onto frozen weights
  - Supports both fresh initialization (Kaiming-normal A, zero B) and loading pre-trained adapters

- **`inject_lora.py`** (new): CLI tool to inject trainable LoRA branches into a base model
  - Configurable rank, alpha scaling, and layer targeting (by name substring)
  - Outputs modified model and JSON manifest with adapter metadata
  - Initializes adapters as no-ops until training begins

- **`extract_lora_adapter.py`** (new): Extracts trained adapter weights from fine-tuned models
  - Produces lightweight standalone `.onnx` files containing only lora_A/lora_B tensors
  - Enables portable adapter distribution without shipping full base model

- **`apply_lora_adapter.py`** (new): Re-applies trained adapters to fresh base model copies
  - Loads adapter manifest and weights, grafts them onto base model
  - Enables adapter reuse across multiple base model instances without retraining

- **`generate_artifacts.py`** (modified): Integrated LoRA support
  - New `--lora-params-file` flag to specify adapter manifest from `inject_lora.py`
  - When provided, trains only the listed lora_A/lora_B parameters (true LoRA recipe)
  - Overrides `--freeze-prefix` for cleaner LoRA-specific workflows

- **`README.md`** (modified): Added comprehensive LoRA usage guide
  - Step-by-step workflow from injection through adapter extraction and reapplication
  - Clarifies that extracted adapters are tensor containers, not runnable models
  - Notes distinction from ONNX Runtime GenAI's `.onnx_adapter` format

## Implementation Details

- LoRA branches are inserted as intermediate nodes in the computation graph, leaving original weights and downstream consumers unchanged
- Adapter manifest (JSON) tracks rank, alpha, and parameter name pairs for reproducibility
- Graph surgery preserves model structure: original MatMul/Gemm output is redirected to intermediate tensor, then recombined with scaled delta under original output name
- Supports both transposed and non-transposed weight matrices (skips transA cases as unusual)

https://claude.ai/code/session_01AJeZY2AcG5x4vaQAnjVFjj