### PR TITLE
Fold/rewrite ops that resolve at simplify time (Sequence, Optional, ArgMax/ArgMin)

### DIFF
--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -17,6 +17,8 @@
 #include "passes/eliminate_loop_with_const_trip_count.h"
 #include "passes/eliminate_nop_dropout.h"
 #include "passes/eliminate_reshape_around_elementwise.h"
+#include "passes/eliminate_sequence_at_construct.h"
+#include "passes/eliminate_sequence_length_construct.h"
 #include "passes/fuse_add_bias_into_conv.h"
 #include "passes/fuse_attention.h"
 #include "passes/fuse_bn_into_conv.h"
@@ -99,6 +101,8 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::DynamicQuantizeTernaryMatMul>(registry);
     RegisterOrReplace<p::EliminateLoopWithConstTripCount>(registry);
     RegisterOrReplace<p::EliminateReshapeAroundElementwise>(registry);
+    RegisterOrReplace<p::EliminateSequenceAtConstruct>(registry);
+    RegisterOrReplace<p::EliminateSequenceLengthConstruct>(registry);
     RegisterOrReplace<p::FuseAttention>(registry);
     RegisterOrReplace<p::FuseConsecutiveMul>(registry);
     RegisterOrReplace<p::FuseGelu>(registry);

--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -16,6 +16,8 @@
 #include "passes/dynamic_quantize_ternary_matmul.h"
 #include "passes/eliminate_loop_with_const_trip_count.h"
 #include "passes/eliminate_nop_dropout.h"
+#include "passes/eliminate_optional_get_element.h"
+#include "passes/eliminate_optional_has_element.h"
 #include "passes/eliminate_reshape_around_elementwise.h"
 #include "passes/eliminate_sequence_at_construct.h"
 #include "passes/eliminate_sequence_length_construct.h"
@@ -100,6 +102,8 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::DynamicQuantizeMatMulIntegerToFloat>(registry);
     RegisterOrReplace<p::DynamicQuantizeTernaryMatMul>(registry);
     RegisterOrReplace<p::EliminateLoopWithConstTripCount>(registry);
+    RegisterOrReplace<p::EliminateOptionalGetElement>(registry);
+    RegisterOrReplace<p::EliminateOptionalHasElement>(registry);
     RegisterOrReplace<p::EliminateReshapeAroundElementwise>(registry);
     RegisterOrReplace<p::EliminateSequenceAtConstruct>(registry);
     RegisterOrReplace<p::EliminateSequenceLengthConstruct>(registry);

--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -49,6 +49,7 @@
 #include "passes/quantize_bf16.h"
 #include "passes/quantize_fp16.h"
 #include "passes/quantize_fp8.h"
+#include "passes/rewrite_arg_reduce_select_last_index.h"
 #include "passes/static_quantize_conv.h"
 #include "passes/static_quantize_int16_conv.h"
 #include "passes/static_quantize_int16_matmul.h"
@@ -129,6 +130,7 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::QuantizeBf16Pass>(registry);
     RegisterOrReplace<p::QuantizeFp16Pass>(registry);
     RegisterOrReplace<p::QuantizeFp8Pass>(registry);
+    RegisterOrReplace<p::RewriteArgReduceSelectLastIndex>(registry);
     RegisterOrReplace<p::StaticQuantizeConv>(registry);
     RegisterOrReplace<p::StaticQuantizeInt16Conv>(registry);
     RegisterOrReplace<p::StaticQuantizeInt16MatMul>(registry);

--- a/onnxsim/passes/eliminate_optional_get_element.h
+++ b/onnxsim/passes/eliminate_optional_get_element.h
@@ -1,0 +1,65 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+#pragma once
+
+#include <string>
+
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+// onnxsim's own passes live in this nested namespace so their class
+// names never collide (ODR) with the same-named passes compiled into
+// onnxoptimizer; RegisterOrReplace still keys them by getPassName().
+namespace onnxsim_passes {
+
+// Folds `OptionalGetElement(Optional(x))` -- an `Optional` node that wraps a
+// value -- straight to `x`, dropping the Optional indirection entirely. See
+// eliminate_optional_has_element.h's doc comment for why this matters
+// (Optional is a common `torch.jit.script` export artifact for
+// `Optional[Tensor]` arguments, and most ONNX consumers -- compilers such as
+// TVM's Relax ONNX frontend included -- have no support for it).
+//
+// `OptionalGetElement(Optional())` -- unwrapping an explicitly-empty
+// optional -- is undefined behavior per the ONNX spec, so it is deliberately
+// left unmatched rather than guessed at. Only an `Optional` producer is
+// handled; see eliminate_optional_has_element.h for why a plain
+// tensor/sequence producer (also allowed by newer opsets, and trivially an
+// identity in that case) is left alone too.
+struct EliminateOptionalGetElement final : public PredicateBasedPass {
+  explicit EliminateOptionalGetElement()
+      : PredicateBasedPass(PassType::Nop, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+
+  std::string getPassName() const override {
+    return "eliminate_optional_get_element";
+  }
+
+  bool patternMatchPredicate(Node* node) override {
+    if (node->kind() != Symbol("OptionalGetElement") ||
+        node->inputs().size() != 1) {
+      return false;
+    }
+    Node* producer = node->input(0)->node();
+    return producer->kind() == Symbol("Optional") &&
+           producer->inputs().size() == 1;
+  }
+
+  bool runTransform(Node* node, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    Node* producer = node->input(0)->node();
+    node->output()->replaceAllUsesWith(producer->input(0));
+    destroy_current = NodeDestroyType::DestroyOne;
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/eliminate_optional_has_element.h
+++ b/onnxsim/passes/eliminate_optional_has_element.h
@@ -1,0 +1,98 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+#pragma once
+
+#include <string>
+
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+// onnxsim's own passes live in this nested namespace so their class
+// names never collide (ODR) with the same-named passes compiled into
+// onnxoptimizer; RegisterOrReplace still keys them by getPassName().
+namespace onnxsim_passes {
+
+// Folds `OptionalHasElement` to a compile-time-constant bool whenever its
+// emptiness is already known at graph-simplification time:
+//
+//  - No input at all (the op's own input is itself optional-arity) always
+//    means "false" per the ONNX spec, regardless of anything else.
+//  - `OptionalHasElement(Optional(x))` -- an `Optional` node that wraps a
+//    value -- is always "true".
+//  - `OptionalHasElement(Optional())` -- an `Optional` node built with no
+//    input, i.e. an explicitly-empty optional -- is always "false".
+//
+// `Optional`/`OptionalHasElement`/`OptionalGetElement` are how ONNX
+// represents Python's `Optional[Tensor]` (e.g. a `torch.jit.script`-exported
+// function argument that may or may not be provided), but most ONNX
+// consumers -- this includes compilers such as TVM's Relax ONNX frontend --
+// have no support for the Optional type at all. When the optional's
+// emptiness is fixed by construction, as here, there is no need for the
+// Optional type to survive into the simplified graph.
+//
+// Only an `Optional` producer is handled (or no input, above); a value whose
+// producer is something else entirely -- including a plain tensor/sequence,
+// which newer opsets also allow as input here and always reads as "true" --
+// is left alone, since the internal graph representation this pass operates
+// on does not carry full ONNX type information (optional-vs-plain) to
+// distinguish that case from a genuinely unresolved optional-typed value.
+struct EliminateOptionalHasElement final : public PredicateBasedPass {
+  explicit EliminateOptionalHasElement()
+      : PredicateBasedPass(PassType::Nop, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+
+  std::string getPassName() const override {
+    return "eliminate_optional_has_element";
+  }
+
+  // -1: no input (always false). 0: Optional() with no input (empty, false).
+  // 1: Optional(x) (non-empty, true). -2: not a foldable shape.
+  static int Classify(Node* node) {
+    if (node->inputs().empty()) {
+      return -1;
+    }
+    if (node->inputs().size() != 1) {
+      return -2;
+    }
+    Node* producer = node->input(0)->node();
+    if (producer->kind() != Symbol("Optional")) {
+      return -2;
+    }
+    return producer->inputs().empty() ? 0 : 1;
+  }
+
+  bool patternMatchPredicate(Node* node) override {
+    return node->kind() == Symbol("OptionalHasElement") && Classify(node) != -2;
+  }
+
+  bool runTransform(Node* node, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    const int cls = Classify(node);
+    ONNX_ASSERT(cls != -2);
+    const bool has_element = cls == 1;
+
+    Node* bool_const = graph.create(kConstant, 1);
+    Tensor t;
+    t.elem_type() = TensorProto_DataType_BOOL;
+    t.int32s().push_back(has_element ? 1 : 0);
+    bool_const->t_(kvalue, t);
+    bool_const->output()->setElemType(TensorProto_DataType_BOOL);
+    bool_const->output()->setSizes({});
+    bool_const->insertBefore(node);
+
+    node->output()->replaceAllUsesWith(bool_const->output());
+    destroy_current = NodeDestroyType::DestroyOne;
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/eliminate_sequence_at_construct.h
+++ b/onnxsim/passes/eliminate_sequence_at_construct.h
@@ -1,0 +1,104 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+// onnxsim's own passes live in this nested namespace so their class
+// names never collide (ODR) with the same-named passes compiled into
+// onnxoptimizer; RegisterOrReplace still keys them by getPassName().
+namespace onnxsim_passes {
+
+// Folds `SequenceAt(SequenceConstruct(t0, ..., tn), position)` -- with a
+// compile-time-constant `position` -- straight to the indexed tensor `ti`,
+// dropping the sequence indirection entirely. `SequenceConstruct` is a common
+// PyTorch-export artifact for Python lists/tuples of tensors, and most ONNX
+// consumers (this includes compilers such as TVM's Relax ONNX frontend) have
+// little to no support for the Sequence type; when the index and the
+// sequence's construction are both statically known -- the common case, e.g.
+// indexing a fixed-size list -- there is no need for a Sequence value to ever
+// exist in the simplified graph.
+//
+// Only a `SequenceConstruct` producer is handled; a sequence built up via
+// `SequenceEmpty`/`SequenceInsert`, or produced by `SplitToSequence`, is left
+// alone (a reasonable follow-up, but each needs its own index-to-producer
+// resolution logic).
+struct EliminateSequenceAtConstruct final : public PredicateBasedPass {
+  explicit EliminateSequenceAtConstruct()
+      : PredicateBasedPass(PassType::Nop, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+
+  std::string getPassName() const override {
+    return "eliminate_sequence_at_construct";
+  }
+
+  // SequenceAt's `position` is tensor(int32) or tensor(int64); read it as a
+  // plain int64_t either way.
+  static bool GetScalarInt64(const Value* v, int64_t& out) {
+    const Tensor* t = FetchConstantTensor(v);
+    if (t == nullptr) {
+      return false;
+    }
+    if (t->elem_type() == TensorProto_DataType_INT64) {
+      const auto data = ParseTensorData<int64_t>(t);
+      if (data.empty()) return false;
+      out = data[0];
+      return true;
+    }
+    if (t->elem_type() == TensorProto_DataType_INT32) {
+      const auto data = ParseTensorData<int32_t>(t);
+      if (data.empty()) return false;
+      out = static_cast<int64_t>(data[0]);
+      return true;
+    }
+    return false;
+  }
+
+  bool patternMatchPredicate(Node* node) override {
+    if (node->kind() != Symbol("SequenceAt") || node->inputs().size() != 2) {
+      return false;
+    }
+    Node* construct = node->input(0)->node();
+    if (construct->kind() != Symbol("SequenceConstruct")) {
+      return false;
+    }
+    int64_t position;
+    if (!GetScalarInt64(node->input(1), position)) {
+      return false;
+    }
+    const int64_t n = static_cast<int64_t>(construct->inputs().size());
+    if (position < 0) {
+      position += n;
+    }
+    return position >= 0 && position < n;
+  }
+
+  bool runTransform(Node* node, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    Node* construct = node->input(0)->node();
+    int64_t position;
+    ONNX_ASSERT(GetScalarInt64(node->input(1), position));
+    const int64_t n = static_cast<int64_t>(construct->inputs().size());
+    if (position < 0) {
+      position += n;
+    }
+    node->output()->replaceAllUsesWith(construct->input(position));
+    destroy_current = NodeDestroyType::DestroyOne;
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/eliminate_sequence_length_construct.h
+++ b/onnxsim/passes/eliminate_sequence_length_construct.h
@@ -1,0 +1,73 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+// onnxsim's own passes live in this nested namespace so their class
+// names never collide (ODR) with the same-named passes compiled into
+// onnxoptimizer; RegisterOrReplace still keys them by getPassName().
+namespace onnxsim_passes {
+
+// Folds `SequenceLength(SequenceConstruct(t0, ..., tn))` to the compile-time
+// constant `n`. `SequenceConstruct` is a common PyTorch-export artifact for
+// Python lists/tuples of tensors; a `for i in range(len(seq)): ...` loop over
+// such a list exports as `SequenceLength` feeding a `Loop`'s trip count, so
+// folding it to a constant here is what lets
+// eliminate_loop_with_const_trip_count unroll that loop in turn -- together
+// the two passes remove the Sequence type and the Loop from a graph shape
+// most ONNX consumers (this includes compilers such as TVM's Relax ONNX
+// frontend) have little to no support for.
+//
+// Only a `SequenceConstruct` producer is handled; see
+// eliminate_sequence_at_construct.h for why `SequenceEmpty`/`SequenceInsert`
+// chains and `SplitToSequence` are left alone for now.
+struct EliminateSequenceLengthConstruct final : public PredicateBasedPass {
+  explicit EliminateSequenceLengthConstruct()
+      : PredicateBasedPass(PassType::Nop, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+
+  std::string getPassName() const override {
+    return "eliminate_sequence_length_construct";
+  }
+
+  bool patternMatchPredicate(Node* node) override {
+    return node->kind() == Symbol("SequenceLength") &&
+           node->inputs().size() == 1 &&
+           node->input(0)->node()->kind() == Symbol("SequenceConstruct");
+  }
+
+  bool runTransform(Node* node, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    const int64_t n =
+        static_cast<int64_t>(node->input(0)->node()->inputs().size());
+
+    Node* length_const = graph.create(kConstant, 1);
+    Tensor t;
+    t.elem_type() = TensorProto_DataType_INT64;
+    t.int64s().push_back(n);
+    length_const->t_(kvalue, t);
+    length_const->output()->setElemType(TensorProto_DataType_INT64);
+    length_const->output()->setSizes({});
+    length_const->insertBefore(node);
+
+    node->output()->replaceAllUsesWith(length_const->output());
+    destroy_current = NodeDestroyType::DestroyOne;
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/rewrite_arg_reduce_select_last_index.h
+++ b/onnxsim/passes/rewrite_arg_reduce_select_last_index.h
@@ -1,0 +1,166 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <string>
+
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+// onnxsim's own passes live in this nested namespace so their class
+// names never collide (ODR) with the same-named passes compiled into
+// onnxoptimizer; RegisterOrReplace still keys them by getPassName().
+namespace onnxsim_passes {
+
+// Rewrites `ArgMax`/`ArgMin` with `select_last_index=1` (added at opset 12)
+// into an equivalent computation that never needs the attribute at all:
+//
+//   ArgMax(x, axis, keepdims, select_last_index=1)
+//     == (dim_size_along_axis - 1) - ArgMax(Flip(x, axis), axis, keepdims)
+//
+// (`ArgMin` the same way.) Flipping the axis turns "last occurrence of the
+// extremum" into "first occurrence" -- select_last_index's default, 0 --
+// and the index just needs mapping back through the flip afterward. `Flip`
+// itself has no dedicated ONNX op; it's the standard `Slice(..., steps=-1)`
+// idiom, and `dim_size_along_axis` is read off `Shape(x)` at runtime rather
+// than assumed static, so this applies whether or not the axis's extent is
+// known at graph-simplification time.
+//
+// `select_last_index=1` is rarely used (the default, 0, is far more common,
+// so this pass fires on very few real graphs), but no runtime-behavior-
+// altering attribute is added: some downstream ONNX consumers -- this
+// includes compilers such as TVM's Relax ONNX frontend -- don't implement
+// `select_last_index` at all, and this rewrite needs nothing beyond `Shape`,
+// `Gather`, `Slice`, `Sub`, and the arg-reduce op itself, all of which are
+// far more consistently supported.
+struct RewriteArgReduceSelectLastIndex final : public PredicateBasedPass {
+  explicit RewriteArgReduceSelectLastIndex()
+      : PredicateBasedPass(PassType::Nop, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+
+  std::string getPassName() const override {
+    return "rewrite_arg_reduce_select_last_index";
+  }
+
+  static bool IsArgReduce(Node* node) {
+    return node->kind() == kArgMax || node->kind() == Symbol("ArgMin");
+  }
+
+  bool patternMatchPredicate(Node* node) override {
+    if (!IsArgReduce(node) || node->inputs().size() != 1) {
+      return false;
+    }
+    if (!node->hasAttribute(kselect_last_index) ||
+        node->i(kselect_last_index) == 0) {
+      return false;
+    }
+    // select_last_index was added at opset 12, well above Slice's own
+    // opset-10 minimum for the starts/ends/axes/steps-as-inputs form this
+    // rewrite relies on, but check explicitly rather than assume.
+    const int opset = getOpsetVersion(*node->owningGraph());
+    return opset == 0 || opset >= 12;
+  }
+
+  bool runTransform(Node* node, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    const int64_t axis = node->hasAttribute(kaxis) ? node->i(kaxis) : 0;
+    Value* data = node->input(0);
+
+    auto make_i64 = [&](int64_t v, bool rank1) -> Value* {
+      Node* c = graph.create(kConstant, 1);
+      Tensor t;
+      t.elem_type() = TensorProto_DataType_INT64;
+      if (rank1) {
+        t.sizes().push_back(1);
+      }
+      t.int64s().push_back(v);
+      c->t_(kvalue, t);
+      c->output()->setElemType(TensorProto_DataType_INT64);
+      if (rank1) {
+        c->output()->setSizes({Dimension{1}});
+      } else {
+        c->output()->setSizes({});
+      }
+      c->insertBefore(node);
+      return c->output();
+    };
+
+    // Flip(data, axis), the Slice(..., steps=-1) idiom: from the last
+    // element (starts=-1) back through (and clamped at) the first
+    // (ends=INT64_MIN, per the Slice spec's own clamping-to-bounds
+    // convention for an out-of-range end with a negative step).
+    Node* flip = graph.create(kSlice, 1);
+    flip->addInput(data);
+    flip->addInput(make_i64(-1, true));
+    flip->addInput(make_i64(std::numeric_limits<int64_t>::min(), true));
+    flip->addInput(make_i64(axis, true));
+    flip->addInput(make_i64(-1, true));
+    flip->insertBefore(node);
+    flip->output()->setElemType(data->elemType());
+
+    // ArgMax/ArgMin on the flipped data, with select_last_index reset to its
+    // default (0): the first occurrence of the extremum in the flipped
+    // tensor is the last occurrence in the original.
+    Node* arg_first = graph.create(node->kind(), 1);
+    arg_first->addInput(flip->output());
+    arg_first->copyAttributes(*node);
+    arg_first->i_(kselect_last_index, 0);
+    arg_first->insertBefore(node);
+    arg_first->output()->setElemType(TensorProto_DataType_INT64);
+
+    // dim_size = Gather(Shape(data), axis) -- `axis` may itself be negative;
+    // Gather's own negative-index wraparound (by data's rank, the length of
+    // Shape(data)) matches ArgMax/ArgMin's own axis convention exactly, so
+    // the same literal `axis` is reused unnormalized.
+    Node* shape = graph.create(Symbol("Shape"), 1);
+    shape->addInput(data);
+    shape->insertBefore(node);
+    shape->output()->setElemType(TensorProto_DataType_INT64);
+
+    Node* dim_size = graph.create(Symbol("Gather"), 1);
+    dim_size->addInput(shape->output());
+    dim_size->addInput(make_i64(axis, false));
+    dim_size->i_(kaxis, 0);
+    dim_size->insertBefore(node);
+    dim_size->output()->setElemType(TensorProto_DataType_INT64);
+
+    Node* dim_size_minus_1 = graph.create(kSub, 1);
+    dim_size_minus_1->addInput(dim_size->output());
+    dim_size_minus_1->addInput(make_i64(1, false));
+    dim_size_minus_1->insertBefore(node);
+    dim_size_minus_1->output()->setElemType(TensorProto_DataType_INT64);
+
+    // corrected = (dim_size - 1) - arg_first. `dim_size_minus_1` is a
+    // scalar; it broadcasts against `arg_first`'s output regardless of
+    // keepdims (a size-1 axis when keepdims=1, dropped entirely otherwise).
+    Node* corrected = graph.create(kSub, 1);
+    corrected->addInput(dim_size_minus_1->output());
+    corrected->addInput(arg_first->output());
+    corrected->insertBefore(node);
+    corrected->output()->setElemType(TensorProto_DataType_INT64);
+    if (!node->output()->sizes().empty()) {
+      corrected->output()->setSizes(node->output()->sizes());
+    }
+
+    const bool replacing_success =
+        tryReplacingAllUsesWith(node->output(), corrected->output());
+    if (!replacing_success) {
+      return false;
+    }
+    destroy_current = NodeDestroyType::DestroyOne;
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -786,6 +786,84 @@ def test_loop_with_const_trip_count_is_unrolled():
     assert all(n.op_type != "Loop" for n in sim_model.graph.node)
 
 
+def test_sequence_at_construct_is_folded():
+    # `SequenceAt(SequenceConstruct(a, b, c), i)` with a constant index -- a
+    # common PyTorch-export artifact for indexing a fixed-size Python list of
+    # tensors -- folds straight to the indexed tensor, dropping the Sequence
+    # type entirely. Downstream compilers (e.g. TVM's Relax ONNX frontend)
+    # generally have little to no support for Sequence.
+    a = helper.make_tensor_value_info("a", TensorProto.FLOAT, [2])
+    b = helper.make_tensor_value_info("b", TensorProto.FLOAT, [2])
+    c = helper.make_tensor_value_info("c", TensorProto.FLOAT, [2])
+    seq = helper.make_node("SequenceConstruct", ["a", "b", "c"], ["seq"])
+    idx = helper.make_tensor("idx", TensorProto.INT64, [], [1])
+    at = helper.make_node("SequenceAt", ["seq", "idx"], ["y"])
+    graph = helper.make_graph(
+        [seq, at],
+        "g",
+        [a, b, c],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [2])],
+        [idx],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    onnx.checker.check_model(model)
+
+    sim_model, check_ok = onnxsim.simplify(model)
+    assert check_ok
+    onnx.checker.check_model(sim_model)
+    assert all(
+        n.op_type not in ("Sequence", "SequenceConstruct", "SequenceAt")
+        for n in sim_model.graph.node
+    )
+
+
+def test_sequence_length_construct_folds_and_unrolls_loop():
+    # `SequenceLength(SequenceConstruct(...))` folds to a constant, which is
+    # exactly what a `for i in range(len(some_list)): ...` loop exports as: a
+    # Sequence feeding a Loop's trip count. Folding SequenceLength lets
+    # eliminate_loop_with_const_trip_count unroll the Loop in turn, so the
+    # whole pattern collapses to plain feed-forward ops.
+    a = helper.make_tensor_value_info("a", TensorProto.FLOAT, [2])
+    b = helper.make_tensor_value_info("b", TensorProto.FLOAT, [2])
+    c = helper.make_tensor_value_info("c", TensorProto.FLOAT, [2])
+    seq = helper.make_node("SequenceConstruct", ["a", "b", "c"], ["seq"])
+    length = helper.make_node("SequenceLength", ["seq"], ["n"])
+
+    step = helper.make_tensor("step", TensorProto.FLOAT, [2], [1.0, 1.0])
+    body = helper.make_graph(
+        [helper.make_node("Add", ["v_in", "step"], ["v_out"])],
+        "loop_body",
+        [
+            helper.make_tensor_value_info("iter", TensorProto.INT64, []),
+            helper.make_tensor_value_info("cond_in", TensorProto.BOOL, []),
+            helper.make_tensor_value_info("v_in", TensorProto.FLOAT, [2]),
+        ],
+        [
+            helper.make_tensor_value_info("cond_in", TensorProto.BOOL, []),
+            helper.make_tensor_value_info("v_out", TensorProto.FLOAT, [2]),
+        ],
+        [step],
+    )
+    loop_node = helper.make_node("Loop", ["n", "", "x"], ["y"], body=body)
+    graph = helper.make_graph(
+        [seq, length, loop_node],
+        "g",
+        [a, b, c, helper.make_tensor_value_info("x", TensorProto.FLOAT, [2])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [2])],
+        [],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    onnx.checker.check_model(model)
+
+    sim_model, check_ok = onnxsim.simplify(model)
+    assert check_ok
+    onnx.checker.check_model(sim_model)
+    op_types = [n.op_type for n in sim_model.graph.node]
+    assert "Loop" not in op_types
+    assert "SequenceConstruct" not in op_types
+    assert "SequenceLength" not in op_types
+
+
 def test_ir3_conv_bn_fuses():
     # IR version 3 models (e.g. the opset-8 ``resnet101-v1-7``) list every
     # initializer as a graph input too, which is required before IR 4. onnxsim

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -864,6 +864,79 @@ def test_sequence_length_construct_folds_and_unrolls_loop():
     assert "SequenceLength" not in op_types
 
 
+def test_optional_get_element_of_optional_is_folded():
+    # `OptionalGetElement(Optional(x))` -- a common `torch.jit.script`-export
+    # artifact for an `Optional[Tensor]` argument that is known to be present
+    # -- folds straight to `x`, dropping the Optional type entirely. Most
+    # ONNX consumers (this includes compilers such as TVM's Relax ONNX
+    # frontend) have little to no support for the Optional type.
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [2])
+    opt = helper.make_node("Optional", ["x"], ["opt"])
+    get = helper.make_node("OptionalGetElement", ["opt"], ["y"])
+    graph = helper.make_graph(
+        [opt, get],
+        "g",
+        [x],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [2])],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 18)])
+    onnx.checker.check_model(model)
+
+    sim_model, check_ok = onnxsim.simplify(model)
+    assert check_ok
+    onnx.checker.check_model(sim_model)
+    op_types = [n.op_type for n in sim_model.graph.node]
+    assert "Optional" not in op_types
+    assert "OptionalGetElement" not in op_types
+
+
+def test_optional_has_element_is_folded():
+    # `OptionalHasElement` folds to a constant bool whenever its emptiness is
+    # already known: true for `Optional(x)`, false for an explicitly-empty
+    # `Optional()` and for the op's own input being omitted entirely.
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [2])
+    opt = helper.make_node("Optional", ["x"], ["opt"])
+    opt_empty = helper.make_node(
+        "Optional",
+        [],
+        ["opt_empty"],
+        type=helper.make_tensor_type_proto(TensorProto.FLOAT, [2]),
+    )
+    has_present = helper.make_node("OptionalHasElement", ["opt"], ["h_present"])
+    has_empty = helper.make_node("OptionalHasElement", ["opt_empty"], ["h_empty"])
+    has_no_input = helper.make_node("OptionalHasElement", [], ["h_no_input"])
+    graph = helper.make_graph(
+        [opt, opt_empty, has_present, has_empty, has_no_input],
+        "g",
+        [x],
+        [
+            helper.make_tensor_value_info("h_present", TensorProto.BOOL, []),
+            helper.make_tensor_value_info("h_empty", TensorProto.BOOL, []),
+            helper.make_tensor_value_info("h_no_input", TensorProto.BOOL, []),
+        ],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 18)])
+    onnx.checker.check_model(model)
+
+    sim_model, check_ok = onnxsim.simplify(model, check_n=0)
+    assert check_ok
+    onnx.checker.check_model(sim_model)
+    assert all(n.op_type != "OptionalHasElement" for n in sim_model.graph.node)
+
+    values = {}
+    for init in sim_model.graph.initializer:
+        values[init.name] = numpy_helper.to_array(init)
+    for node in sim_model.graph.node:
+        if node.op_type == "Constant":
+            (attr,) = [a for a in node.attribute if a.name == "value"]
+            values[node.output[0]] = numpy_helper.to_array(attr.t)
+
+    out_names = [o.name for o in sim_model.graph.output]
+    assert bool(values[out_names[0]]) is True  # h_present
+    assert bool(values[out_names[1]]) is False  # h_empty
+    assert bool(values[out_names[2]]) is False  # h_no_input
+
+
 def test_ir3_conv_bn_fuses():
     # IR version 3 models (e.g. the opset-8 ``resnet101-v1-7``) list every
     # initializer as a graph input too, which is required before IR 4. onnxsim

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -937,6 +937,60 @@ def test_optional_has_element_is_folded():
     assert bool(values[out_names[2]]) is False  # h_no_input
 
 
+def test_arg_reduce_select_last_index_is_rewritten():
+    # `select_last_index=1` (added at opset 12) isn't implemented by some
+    # downstream ONNX consumers (e.g. TVM's Relax ONNX frontend). It's
+    # rewritten to an equivalent computation over `Shape`/`Gather`/`Slice`/
+    # `Sub`/`ArgMax` that never needs the attribute: flip the axis, take the
+    # *first* occurrence there (select_last_index's own default), and map
+    # the index back through the flip.
+    import numpy as np
+
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [4])
+    argmax = helper.make_node(
+        "ArgMax", ["x"], ["y"], axis=0, keepdims=1, select_last_index=1
+    )
+    graph = helper.make_graph(
+        [argmax],
+        "g",
+        [x],
+        [helper.make_tensor_value_info("y", TensorProto.INT64, [1])],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    onnx.checker.check_model(model)
+
+    sim_model, check_ok = onnxsim.simplify(model, check_n=0)
+    assert check_ok
+    onnx.checker.check_model(sim_model)
+    op_types = [n.op_type for n in sim_model.graph.node]
+    assert "ArgMax" in op_types  # rewritten, not eliminated
+    for node in sim_model.graph.node:
+        if node.op_type == "ArgMax":
+            select_last_index = [
+                a.i for a in node.attribute if a.name == "select_last_index"
+            ]
+            # Absent (defaults to 0) or explicitly reset to 0 -- either is
+            # fine, since the rewrite compensates by flipping the axis.
+            assert not select_last_index or select_last_index[0] == 0
+
+    # Numeric check on inputs with ties, where select_last_index actually
+    # changes the result relative to the default (first-occurrence) index.
+    sess_orig = onnxruntime.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    sess_sim = onnxruntime.InferenceSession(
+        sim_model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    for v in (
+        np.array([3, 5, 5, 2], dtype=np.float32),
+        np.array([4, 4, 4, 4], dtype=np.float32),
+        np.array([1, 2, 3, 4], dtype=np.float32),
+    ):
+        orig_out = sess_orig.run(None, {"x": v})[0]
+        sim_out = sess_sim.run(None, {"x": v})[0]
+        assert np.array_equal(orig_out, sim_out)
+
+
 def test_ir3_conv_bn_fuses():
     # IR version 3 models (e.g. the opset-8 ``resnet101-v1-7``) list every
     # initializer as a graph input too, which is required before IR 4. onnxsim


### PR DESCRIPTION
## Summary

Follow-up to #761 (`eliminate_loop_with_const_trip_count`), continuing the same theme: turning ONNX constructs most downstream compilers (TVM's Relax ONNX frontend included) have little to no support for into plain feed-forward ops once they're already resolvable at graph-simplification time — or, for `select_last_index`, into ops that are far more consistently supported.

Adds five onnxsim passes:

- **`eliminate_sequence_at_construct`**: `SequenceAt(SequenceConstruct(t0..tn), i)` with a constant index (positive or negative, Python-style) folds straight to `ti`.
- **`eliminate_sequence_length_construct`**: `SequenceLength(SequenceConstruct(...))` folds to a constant. This composes with `eliminate_loop_with_const_trip_count`: a `for i in range(len(seq)): ...` loop exports as `SequenceConstruct → SequenceLength → Loop(trip_count)`, so folding the length lets the Loop unroll in turn, collapsing the whole pattern to plain ops.
- **`eliminate_optional_get_element`**: `OptionalGetElement(Optional(x))` folds to `x`.
- **`eliminate_optional_has_element`**: `OptionalHasElement` folds to a constant bool — `true` for `Optional(x)`, `false` for an explicitly-empty `Optional()` or for the op's own input being omitted entirely.
- **`rewrite_arg_reduce_select_last_index`**: `ArgMax`/`ArgMin` with `select_last_index=1` (added at opset 12, and not implemented by every downstream consumer) is rewritten to `(dim_size_along_axis - 1) - ArgMax(Flip(x, axis), axis, keepdims)` — reading `dim_size_along_axis` off `Shape`/`Gather` at runtime, so it applies whether or not that axis's extent is static, using only `Shape`/`Gather`/`Slice`/`Sub` and the arg-reduce op itself.

The four `eliminate_*` passes are scoped narrowly and conservatively, matching `eliminate_loop_with_const_trip_count`'s and `eliminate_if_with_const_cond`'s style: only the directly-preceding-producer shape is handled (e.g. `SequenceConstruct`, not `SequenceEmpty`/`SequenceInsert` chains or `SplitToSequence`; `Optional`, not a plain tensor/sequence producer), and anything not confidently foldable is left untouched rather than guessed at. `rewrite_arg_reduce_select_last_index` only fires when `select_last_index` is explicitly set to a nonzero value, which is rare (the default is 0), so it touches very few real graphs.

## Test plan

- Added regression tests in `tests/test_simple.py`: `test_sequence_at_construct_is_folded`, `test_sequence_length_construct_folds_and_unrolls_loop` (verifies the Sequence+Loop composition end to end), `test_optional_get_element_of_optional_is_folded`, `test_optional_has_element_is_folded`, `test_arg_reduce_select_last_index_is_rewritten` (numeric cross-check against onnxruntime on tie-breaking inputs, plus a dynamic-shape/negative-axis/ArgMin case checked manually).
- Manually verified edge cases don't mis-fire: out-of-range `SequenceAt` index, a `SplitToSequence` producer, `OptionalGetElement` on a genuinely-empty `Optional()`, `OptionalHasElement` on a plain-tensor producer, and `select_last_index=0` (explicit or default) — all correctly left unmatched, no crash.
- Full `tests/test_simple.py` suite: no new failures (2 pre-existing failures from a missing, unrelated `onnxscript` dependency).
- `ruff format`, `ruff check`, `mypy`, and `clang-format --dry-run --Werror` all clean.

https://claude.ai/code/session_01TwY4Kx5PFkJwgpbgdr3CQf
