### PR TITLE
Fix select_last_index IR version; add extra_optimizers API; add defuse_matmul_integer_to_float pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ constant folding until the model stops changing. Around that it offers:
 - **Graph optimization passes.** Runs onnx-optimizer's fusions and eliminations
   (e.g. fuse BatchNorm into Conv). List them with
   `onnxsim --list-default-optimizers`; skip all or some with
-  `--skip-optimization [pass ...]`.
+  `--skip-optimization [pass ...]`. A pass not in the default set (typically a
+  graph-shape rewrite rather than a pure node reduction, e.g. a defusion) can
+  be requested explicitly with `--enable-optimization pass [pass ...]`
+  (Python: `extra_optimizers=`); list those with `--list-other-optimizers`.
 - **Shape inference.** Propagates tensor shapes through the graph — including
   partial shape evaluation via ONNX data propagation — to unlock more folding.
 - **Correctness checking.** Optionally validates the simplified model against the

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -20,8 +20,10 @@
 #include <string>
 #include <tuple>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
+#include "custom_optimizer_passes.h"
 #include "dlpack_bridge.h"
 #include "function_rewriter.h"
 #include "model_info.h"
@@ -1035,7 +1037,9 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
           bool mutable_initializer,
           std::optional<std::unordered_map<std::string, std::vector<int64_t>>>
               overwrite_input_shapes,
-          std::optional<std::vector<std::string>> unused_output) -> py::bytes {
+          std::optional<std::vector<std::string>> unused_output,
+          std::optional<std::vector<std::string>> extra_optimizers)
+           -> py::bytes {
          // force env initialization to register opset
          InitEnv();
          ONNX_NAMESPACE::ModelProto model;
@@ -1052,7 +1056,7 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
              shape_inference, tensor_size_threshold, target_opset_version,
              rewriter.get(), initializers_as_constants,
              include_inline_functions, mutable_initializer,
-             overwrite_input_shapes, unused_output);
+             overwrite_input_shapes, unused_output, extra_optimizers);
          std::string out;
          result.SerializeToString(&out);
          return py::bytes(out.data(), out.size());
@@ -1062,7 +1066,8 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
        "tensor_size_threshold"_a, "target_opset_version"_a.none(),
        "rewriter"_a.none(), "initializers_as_constants"_a = true,
        "include_inline_functions"_a = false, "mutable_initializer"_a = true,
-       "overwrite_input_shapes"_a.none(), "unused_output"_a.none())
+       "overwrite_input_shapes"_a.none(), "unused_output"_a.none(),
+       "extra_optimizers"_a.none())
       .def(
           "simplify_path",
           [](std::shared_ptr<PyModelExecutor> executor,
@@ -1077,15 +1082,16 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
              std::optional<
                  std::unordered_map<std::string, std::vector<int64_t>>>
                  overwrite_input_shapes,
-             std::optional<std::vector<std::string>> unused_output) -> bool {
+             std::optional<std::vector<std::string>> unused_output,
+             std::optional<std::vector<std::string>> extra_optimizers) -> bool {
             // force env initialization to register opset
             InitEnv();
-            SimplifyPath(*executor, in_path, out_path, skip_optimizers,
-                         constant_folding, shape_inference,
-                         tensor_size_threshold, target_opset_version,
-                         rewriter.get(), initializers_as_constants,
-                         include_inline_functions, mutable_initializer,
-                         overwrite_input_shapes, unused_output);
+            SimplifyPath(
+                *executor, in_path, out_path, skip_optimizers, constant_folding,
+                shape_inference, tensor_size_threshold, target_opset_version,
+                rewriter.get(), initializers_as_constants,
+                include_inline_functions, mutable_initializer,
+                overwrite_input_shapes, unused_output, extra_optimizers);
             return true;
           },
           "executor"_a, "in_path"_a, "out_path"_a, "skip_optimizers"_a.none(),
@@ -1093,13 +1099,35 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
           "tensor_size_threshold"_a, "target_opset_version"_a.none(),
           "rewriter"_a.none(), "initializers_as_constants"_a = true,
           "include_inline_functions"_a = false, "mutable_initializer"_a = true,
-          "overwrite_input_shapes"_a.none(), "unused_output"_a.none())
+          "overwrite_input_shapes"_a.none(), "unused_output"_a.none(),
+          "extra_optimizers"_a.none())
       .def("_list_optimizers",
            []() {
              py::list ret;
              for (const auto& p :
                   onnx::optimization::GetFuseAndEliminationPass()) {
                ret.append(p);
+             }
+             return ret;
+           })
+      // The counterpart to _list_optimizers: pass names valid for
+      // extra_optimizers specifically -- registered but not already part of
+      // the default fuse/elimination set (typically PassType::Other, e.g.
+      // fuse_matmul_add_bias_into_gemm_batched). Registers onnxsim's own
+      // custom passes first so this is accurate even if called before any
+      // simplify()/simplify_path() call has done so.
+      .def("_list_other_optimizers",
+           []() {
+             onnxsim::RegisterCustomOptimizerPasses();
+             const auto default_passes =
+                 onnx::optimization::GetFuseAndEliminationPass();
+             const std::unordered_set<std::string> default_set(
+                 default_passes.begin(), default_passes.end());
+             py::list ret;
+             for (const auto& p : onnx::optimization::GetAvailablePasses()) {
+               if (!default_set.count(p)) {
+                 ret.append(p);
+               }
              }
              return ret;
            })

--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -10,6 +10,7 @@
 
 #include "onnxoptimizer/optimize.h"
 #include "passes/cross_layer_equalization.h"
+#include "passes/defuse_matmul_integer_to_float.h"
 #include "passes/dynamic_quantize_attention.h"
 #include "passes/dynamic_quantize_matmul.h"
 #include "passes/dynamic_quantize_matmul_integer_to_float.h"
@@ -98,6 +99,7 @@ void RegisterCustomOptimizerPasses() {
 
     // onnxsim-only rewrites (no built-in of the same name today).
     RegisterOrReplace<p::CrossLayerEqualization>(registry);
+    RegisterOrReplace<p::DefuseMatMulIntegerToFloat>(registry);
     RegisterOrReplace<p::DynamicQuantizeAttention>(registry);
     RegisterOrReplace<p::DynamicQuantizeMatMul>(registry);
     RegisterOrReplace<p::DynamicQuantizeMatMulIntegerToFloat>(registry);

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -1056,6 +1056,7 @@ def simplify(
     import_custom_schemas: bool = True,
     input_shapes=None,
     target_opset_version: Optional[int] = None,
+    extra_optimizers: Optional[List[str]] = None,
     custom_rewriter: Optional[ModelRewriter] = None,
     function_rewrite_rules: Optional[Sequence[FunctionRewriteRule]] = None,
     check_rtol: float = 1e-4,
@@ -1107,6 +1108,17 @@ def simplify(
             before simplifying, using onnx's version converter (run inside the C++ core so every
             binding shares the behavior). This can be used to upgrade (or downgrade) the model's
             opset during simplification. When None (the default), the opset version is left unchanged.
+    :param extra_optimizers: The counterpart to ``skipped_optimizers``: run these named onnx-optimizer
+            passes in addition to the default fuse/elimination set, rather than excluding some of it.
+            This is how a pass registered as ``PassType::Other`` -- excluded from the default set
+            because it is a graph-shape rewrite rather than a pure node reduction or fusion (e.g. a
+            defusion that trades a backend-specific op for a more portable but larger equivalent) --
+            gets opted into, without changing what runs by default for every other caller. List valid
+            names with ``onnxsim --list-other-optimizers`` (``--list-default-optimizers`` lists the
+            ones already on by default, which do not need naming here). Has no effect when
+            ``perform_optimization`` is ``False``. An unknown name raises, since -- unlike a typo in
+            ``skipped_optimizers``, which just means nothing new is skipped -- a typo here means the
+            pass you asked for silently never runs.
     :param custom_rewriter: An optional callable ``ModelProto -> Optional[ModelProto]`` run as an extra
             stage inside onnxsim's simplification fixed point, interleaved with the built-in optimizer,
             shape inference and constant folding so a rewrite can unlock further simplification and vice
@@ -1364,6 +1376,7 @@ def simplify(
                             mutable_initializer,
                             overwrite_input_shapes,
                             unused_output,
+                            extra_optimizers,
                         )
                         check_ok = model_checking.compare(
                             output_path,
@@ -1395,6 +1408,7 @@ def simplify(
                             mutable_initializer,
                             overwrite_input_shapes,
                             unused_output,
+                            extra_optimizers,
                         )
                         # check_n == 0 is guaranteed on this path (the fast-path
                         # gate above requires it), so compare() only needs
@@ -1433,6 +1447,7 @@ def simplify(
                         mutable_initializer,
                         overwrite_input_shapes,
                         unused_output,
+                        extra_optimizers,
                     )
                     if len(model_opt_bytes) == 0:
                         raise ValueError("Simplified model larger than 2GB")
@@ -1567,6 +1582,7 @@ def simplify(
             mutable_initializer,
             overwrite_input_shapes,
             unused_output,
+            extra_optimizers,
         )
         # The serialized original (~1x model) is not needed once the C++
         # simplifier has consumed it -- the large-model fallback below
@@ -1644,6 +1660,7 @@ def simplify(
                 mutable_initializer,
                 overwrite_input_shapes,
                 unused_output,
+                extra_optimizers,
             )
             check_ok = model_checking.compare(
                 os.path.join(tmpdirname, "opt.onnx"),
@@ -1844,6 +1861,12 @@ def main():
         help="Skip all ONNX optimizers or some of them. To skip all optimizers, use `onnxsim a.onnx b.onnx --skip-optimization`. To skip some of optimizers, use something like `onnxsim a.onnx b.onnx --skip-optimization fuse_bn_into_conv fuse_pad_into_pool`.",
         type=str,
         nargs="*",
+    )
+    parser.add_argument(
+        "--enable-optimization",
+        help="The counterpart to --skip-optimization: run these named optimizer passes in addition to the default set, rather than excluding some of it. Use for a pass not already on by default (see --list-other-optimizers for valid names), for example `onnxsim a.onnx b.onnx --enable-optimization fuse_matmul_add_bias_into_gemm_batched`.",
+        type=str,
+        nargs="+",
     )
     parser.add_argument(
         "--skip-constant-folding", help="Skip constant folding", action="store_true"
@@ -2338,6 +2361,19 @@ def main():
         action=ListOptimizers,
     )
 
+    class ListOtherOptimizers(argparse.Action):
+        def __call__(self, parser, ns, v, option_string=None):
+            for p in C._list_other_optimizers():
+                print(p)
+            parser.exit()
+
+    parser.add_argument(
+        "--list-other-optimizers",
+        help="List optimizer pass names valid for --enable-optimization (i.e. registered but not already part of the default set listed by --list-default-optimizers)",
+        nargs=0,
+        action=ListOtherOptimizers,
+    )
+
     args = parser.parse_args()
 
     if args.enable_fuse_bn:
@@ -2517,6 +2553,7 @@ def main():
         inline_functions=args.inline_functions,
         import_custom_schemas=not args.skip_schema_import,
         target_opset_version=args.target_opset,
+        extra_optimizers=args.enable_optimization,
         check_rtol=args.check_rtol,
         check_atol=args.check_atol,
         input_fill=args.input_fill,

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -99,7 +99,8 @@ void RecordSimplifyOptionsMetadata(
     bool include_inline_functions, bool mutable_initializer,
     const std::optional<std::unordered_map<std::string, std::vector<int64_t>>>&
         overwrite_input_shapes,
-    const std::optional<std::vector<std::string>>& unused_output) {
+    const std::optional<std::vector<std::string>>& unused_output,
+    const std::optional<std::vector<std::string>>& extra_optimizers) {
   auto join = [](const std::vector<std::string>& v) {
     std::string out;
     for (size_t i = 0; i < v.size(); ++i) {
@@ -150,18 +151,23 @@ void RecordSimplifyOptionsMetadata(
   if (unused_output) {
     options.emplace_back("onnxsim.unused_output", join(*unused_output));
   }
+  if (extra_optimizers) {
+    options.emplace_back("onnxsim.extra_optimizers", join(*extra_optimizers));
+  }
 
   // Every key this function could ever write, not just the ones present in
-  // `options` this call -- ``overwrite_input_shapes``/``unused_output`` are
-  // conditional, so a stale value one of them left behind on a previous
-  // simplify() call (that did set it) must still be cleared on a later call
-  // that doesn't, or it would look like it's still in effect.
+  // `options` this call -- ``overwrite_input_shapes``/``unused_output``/
+  // ``extra_optimizers`` are conditional, so a stale value one of them left
+  // behind on a previous simplify() call (that did set it) must still be
+  // cleared on a later call that doesn't, or it would look like it's still
+  // in effect.
   static const std::unordered_set<std::string> known_option_keys = {
       "onnxsim.skip_optimizers",          "onnxsim.constant_folding",
       "onnxsim.shape_inference",          "onnxsim.tensor_size_threshold",
       "onnxsim.target_opset_version",     "onnxsim.initializers_as_constants",
       "onnxsim.include_inline_functions", "onnxsim.mutable_initializer",
-      "onnxsim.overwrite_input_shapes",   "onnxsim.unused_output"};
+      "onnxsim.overwrite_input_shapes",   "onnxsim.unused_output",
+      "onnxsim.extra_optimizers"};
 
   auto* props = model.mutable_metadata_props();
   google::protobuf::RepeatedPtrField<onnx::StringStringEntryProto> kept;
@@ -269,7 +275,8 @@ static onnx::ModelProto SimplifyImpl(
     bool mutable_initializer,
     const std::optional<std::unordered_map<std::string, std::vector<int64_t>>>&
         overwrite_input_shapes,
-    const std::optional<std::vector<std::string>>& unused_output) {
+    const std::optional<std::vector<std::string>>& unused_output,
+    const std::optional<std::vector<std::string>>& extra_optimizers) {
   // Register onnxsim's own optimizer passes into onnxoptimizer's registry
   // before the pass list is built below: fuse_attention, fuse_consecutive_mul,
   // fuse_mul_into_conv, fuse_preceding_mul_into_conv, fuse_rms_norm and
@@ -359,6 +366,26 @@ static onnx::ModelProto SimplifyImpl(
     if (!is_disabled(*skip_optimizers, batched_gemm) &&
         !is_disabled(always_disabled_passes, batched_gemm)) {
       passes.push_back(batched_gemm);
+    }
+    // extra_optimizers is the general form of the batched_gemm carve-out
+    // above: a caller-named pass -- typically PassType::Other, since
+    // GetFuseAndEliminationPass already covers every Fuse/Nop pass -- runs in
+    // addition to the default set. skip_optimizers/always_disabled_passes
+    // still apply, so an explicit --skip-optimization wins, and a name
+    // already present (e.g. the caller redundantly names a default-set pass)
+    // is not duplicated. An unknown name is deliberately not filtered out
+    // here: OptimizeGraphFixed's Optimizer construction looks every entry of
+    // ``passes`` up in the global pass registry and throws on one that does
+    // not exist, which is the desired behavior -- see extra_optimizers' own
+    // doc comment in onnxsim.h.
+    if (extra_optimizers) {
+      for (const auto& pass : *extra_optimizers) {
+        if (!is_disabled(*skip_optimizers, pass) &&
+            !is_disabled(always_disabled_passes, pass) &&
+            std::find(passes.begin(), passes.end(), pass) == passes.end()) {
+          passes.push_back(pass);
+        }
+      }
     }
     config.optimizer_passes = passes;
   }
@@ -882,11 +909,11 @@ static onnx::ModelProto SimplifyImpl(
   const std::vector<std::string> assigned_node_names =
       AssignMissingNodeNames(sim_model);
   DropIncompleteValueInfo(sim_model);
-  RecordSimplifyOptionsMetadata(sim_model, skip_optimizers, constant_folding,
-                                shape_inference, tensor_size_threshold,
-                                target_opset_version, initializers_as_constants,
-                                include_inline_functions, mutable_initializer,
-                                overwrite_input_shapes, unused_output);
+  RecordSimplifyOptionsMetadata(
+      sim_model, skip_optimizers, constant_folding, shape_inference,
+      tensor_size_threshold, target_opset_version, initializers_as_constants,
+      include_inline_functions, mutable_initializer, overwrite_input_shapes,
+      unused_output, extra_optimizers);
   RecordSimplifyDiffMetadata(sim_model, model);
   // Nodes onnxsim itself had to name (no author-given name survived), and
   // functions inlined away (see the tally taken just before
@@ -917,13 +944,14 @@ onnx::ModelProto Simplify(
     bool mutable_initializer,
     const std::optional<std::unordered_map<std::string, std::vector<int64_t>>>&
         overwrite_input_shapes,
-    const std::optional<std::vector<std::string>>& unused_output) {
+    const std::optional<std::vector<std::string>>& unused_output,
+    const std::optional<std::vector<std::string>>& extra_optimizers) {
   return SimplifyImpl(executor, model, /*mutable_model=*/nullptr,
                       skip_optimizers, constant_folding, shape_inference,
                       tensor_size_threshold, target_opset_version, rewriter,
                       initializers_as_constants, include_inline_functions,
                       mutable_initializer, overwrite_input_shapes,
-                      unused_output);
+                      unused_output, extra_optimizers);
 }
 
 onnx::ModelProto SimplifyConsumeInput(
@@ -935,13 +963,14 @@ onnx::ModelProto SimplifyConsumeInput(
     bool mutable_initializer,
     const std::optional<std::unordered_map<std::string, std::vector<int64_t>>>&
         overwrite_input_shapes,
-    const std::optional<std::vector<std::string>>& unused_output) {
+    const std::optional<std::vector<std::string>>& unused_output,
+    const std::optional<std::vector<std::string>>& extra_optimizers) {
   return SimplifyImpl(executor, model, /*mutable_model=*/&model,
                       skip_optimizers, constant_folding, shape_inference,
                       tensor_size_threshold, target_opset_version, rewriter,
                       initializers_as_constants, include_inline_functions,
                       mutable_initializer, overwrite_input_shapes,
-                      unused_output);
+                      unused_output, extra_optimizers);
 }
 
 void SimplifyPath(
@@ -954,7 +983,8 @@ void SimplifyPath(
     bool mutable_initializer,
     const std::optional<std::unordered_map<std::string, std::vector<int64_t>>>&
         overwrite_input_shapes,
-    const std::optional<std::vector<std::string>>& unused_output) {
+    const std::optional<std::vector<std::string>>& unused_output,
+    const std::optional<std::vector<std::string>>& extra_optimizers) {
   const bool debug_timing = std::getenv("ONNXSIM_DEBUG_PATH_TIMING") != nullptr;
   auto now = []() { return std::chrono::steady_clock::now(); };
   auto elapsed_ms = [](auto t0, auto t1) {
@@ -985,7 +1015,8 @@ void SimplifyPath(
         executor, model, skip_optimizers, constant_folding, shape_inference,
         tensor_size_threshold, target_opset_version, rewriter,
         initializers_as_constants, include_inline_functions,
-        mutable_initializer, overwrite_input_shapes, unused_output);
+        mutable_initializer, overwrite_input_shapes, unused_output,
+        extra_optimizers);
     if (debug_timing) {
       std::cerr << "SimplifyPath: Simplify " << elapsed_ms(t0, now()) << "ms\n";
     }

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -106,6 +106,19 @@ std::shared_ptr<const ModelExecutor> GetBuiltinModelExecutor();
 // graph outputs before simplification so dead-end elimination cleans up
 // nodes that only fed them. Both throw std::runtime_error if a name does
 // not match an existing graph input/output.
+// ``extra_optimizers``, when set, runs the named onnx-optimizer passes in
+// addition to the default fuse/elimination set -- the counterpart to
+// ``skip_optimizers``. This is how a pass registered as ``PassType::Other``
+// (excluded from the default set because it is a graph-shape rewrite rather
+// than a pure node reduction or fusion, e.g. a defusion that trades a
+// backend-specific op for a more portable but larger equivalent) gets
+// opted into, without changing what runs by default for every other caller.
+// Has no effect when ``skip_optimizers`` is ``std::nullopt`` (which disables
+// optimization entirely). An unknown pass name throws (surfaced from
+// onnx-optimizer's own pass registry lookup) rather than being silently
+// ignored, since -- unlike a typo in ``skip_optimizers``, which just means
+// nothing new is skipped -- a typo here means the caller's requested pass
+// silently never runs.
 onnx::ModelProto Simplify(
     const ModelExecutor& executor, const onnx::ModelProto& model,
     std::optional<std::vector<std::string>> skip_optimizers,
@@ -116,7 +129,8 @@ onnx::ModelProto Simplify(
     bool include_inline_functions = false, bool mutable_initializer = true,
     const std::optional<std::unordered_map<std::string, std::vector<int64_t>>>&
         overwrite_input_shapes = std::nullopt,
-    const std::optional<std::vector<std::string>>& unused_output =
+    const std::optional<std::vector<std::string>>& unused_output = std::nullopt,
+    const std::optional<std::vector<std::string>>& extra_optimizers =
         std::nullopt);
 
 // Same as ``Simplify`` above, except ``model`` is taken by mutable reference
@@ -144,7 +158,8 @@ onnx::ModelProto SimplifyConsumeInput(
     bool include_inline_functions = false, bool mutable_initializer = true,
     const std::optional<std::unordered_map<std::string, std::vector<int64_t>>>&
         overwrite_input_shapes = std::nullopt,
-    const std::optional<std::vector<std::string>>& unused_output =
+    const std::optional<std::vector<std::string>>& unused_output = std::nullopt,
+    const std::optional<std::vector<std::string>>& extra_optimizers =
         std::nullopt);
 
 // Debugging helpers: run a *single* one of the transforms that ``Simplify``
@@ -861,5 +876,6 @@ void SimplifyPath(
     bool include_inline_functions = false, bool mutable_initializer = true,
     const std::optional<std::unordered_map<std::string, std::vector<int64_t>>>&
         overwrite_input_shapes = std::nullopt,
-    const std::optional<std::vector<std::string>>& unused_output =
+    const std::optional<std::vector<std::string>>& unused_output = std::nullopt,
+    const std::optional<std::vector<std::string>>& extra_optimizers =
         std::nullopt);

--- a/onnxsim/passes/defuse_matmul_integer_to_float.h
+++ b/onnxsim/passes/defuse_matmul_integer_to_float.h
@@ -1,0 +1,269 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+#pragma once
+
+// The exact inverse of dynamic_quantize_matmul.h's rewrite: folds a
+// DynamicQuantizeLinear + MatMulInteger + Cast<float> + Mul + Mul (+ Add)
+// dequantization chain back into a single plain MatMul (+ Add for the
+// optional bias), by dequantizing the constant INT8 weight to float once,
+// here, at pass-transform time.
+//
+// Before (the exact shape dynamic_quantize_matmul.h emits):
+//   Xq, Xs, Xzp = DynamicQuantizeLinear(X)
+//   Acc         = MatMulInteger(Xq, Wq, Xzp)          // int32, Wq int8 [K,N]
+//   Y           = Cast<float>(Acc) * (Xs * Ws)        // Ws float32 [N]
+//   [Y = Y + Bias]                                    // optional
+// After:
+//   Y = MatMul(X, Dequant(Wq, Ws))    // Dequant(Wq, Ws)[k,n] = Wq[k,n]*Ws[n]
+//   [Y = Y + Bias]
+//
+// This is a pure, data-independent graph transform: W is already a
+// compile-time constant, so its dequantized float value can be computed once
+// here rather than left as a runtime DequantizeLinear node.
+//
+// It exists for consumers of onnxsim's output (e.g. compiler frontends) that
+// do not support MatMulInteger / DynamicQuantizeLinear and would rather see
+// the original plain-float MatMul than fail to import the model at all --
+// accepting the loss of the quantized model's actual runtime benefit
+// (smaller weights, integer compute) in exchange for portability. Because
+// that tradeoff is a deliberate, model-changing choice only the caller can
+// make, this pass is PassType::Other and is never in onnxsim's default pass
+// set: it only runs when explicitly requested, via
+// `extra_optimizers=["defuse_matmul_integer_to_float"]` (Python) or
+// `--enable-optimization defuse_matmul_integer_to_float` (CLI).
+//
+// Only the exact shape dynamic_quantize_matmul.h produces is recognized: a
+// MatMulInteger with exactly 3 inputs (no explicit b_zero_point -- symmetric,
+// implicit 0), whose quantized-activation and zero-point inputs come from
+// the same DynamicQuantizeLinear node as the scale multiplicand's
+// activation-scale operand, and whose weight is a constant 2-D INT8 tensor
+// paired with a constant 1-D float32 per-column scale of matching length.
+// Anything else -- statically-quantized (QuantizeLinear/DequantizeLinear)
+// matmuls, an explicit w_zero_point, ONNX Runtime's fused
+// "MatMulIntegerToFloat" contrib op (see
+// dynamic_quantize_matmul_integer_to_float.h), a scale computed some other
+// way -- is left alone.
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+#include "passes/quantize_matmul_common.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+struct MatMulIntegerDequantInfo {
+  Value* x = nullptr;               // original float32 activation
+  const Tensor* w_q = nullptr;      // constant INT8 [K, N]
+  const Tensor* w_scale = nullptr;  // constant FLOAT [N]
+};
+
+// Recognizes `dequant_mul` as the "Y = Cast<float>(Acc) * (Xs * Ws)" node of
+// dynamic_quantize_matmul.h's output pattern, filling `info`. See the file
+// comment above for the exact shape matched.
+inline bool MatchMatMulIntegerDequant(Node* dequant_mul,
+                                      MatMulIntegerDequantInfo& info) {
+  if (dequant_mul->kind() != kMul || dequant_mul->inputs().size() != 2) {
+    return false;
+  }
+  const Symbol matmul_integer = Symbol("MatMulInteger");
+  const Symbol dynamic_quantize_linear = Symbol("DynamicQuantizeLinear");
+  for (size_t i = 0; i < 2; ++i) {
+    Value* cast_out = dequant_mul->inputs()[i];
+    Value* scale_out = dequant_mul->inputs()[1 - i];
+    Node* cast = cast_out->node();
+    if (cast->kind() != kCast || cast->inputs().size() != 1 ||
+        cast->output() != cast_out) {
+      continue;
+    }
+    if (GetValueFromAttrWithDefault(cast, kto, int64_t(0)) !=
+        TensorProto_DataType_FLOAT) {
+      continue;
+    }
+
+    Node* mmi = cast->inputs()[0]->node();
+    if (mmi->kind() != matmul_integer || mmi->inputs().size() != 3 ||
+        mmi->output() != cast->inputs()[0]) {
+      continue;
+    }
+    Value* x_q = mmi->inputs()[0];
+    Value* w_q_val = mmi->inputs()[1];
+    Value* x_zp = mmi->inputs()[2];
+
+    Node* dql = x_q->node();
+    if (dql->kind() != dynamic_quantize_linear || dql->inputs().size() != 1 ||
+        dql->outputs().size() != 3 || dql->outputs()[0] != x_q ||
+        dql->outputs()[2] != x_zp) {
+      continue;
+    }
+    Value* x_scale = dql->outputs()[1];
+
+    Node* scale_mul = scale_out->node();
+    if (scale_mul->kind() != kMul || scale_mul->inputs().size() != 2 ||
+        scale_mul->output() != scale_out) {
+      continue;
+    }
+    Value* w_scale_val = nullptr;
+    bool found_x_scale = false;
+    for (Value* v : scale_mul->inputs()) {
+      if (v == x_scale) {
+        found_x_scale = true;
+      } else {
+        w_scale_val = v;
+      }
+    }
+    if (!found_x_scale || w_scale_val == nullptr) {
+      continue;
+    }
+
+    const Tensor* w_q_t = FetchConstantTensor(w_q_val);
+    if (w_q_t == nullptr || w_q_t->elem_type() != TensorProto_DataType_INT8 ||
+        w_q_t->sizes().size() != 2) {
+      continue;
+    }
+    const Tensor* w_scale_t = FetchConstantTensor(w_scale_val);
+    if (w_scale_t == nullptr ||
+        w_scale_t->elem_type() != TensorProto_DataType_FLOAT ||
+        w_scale_t->sizes().size() != 1 ||
+        w_scale_t->sizes()[0] != w_q_t->sizes()[1]) {
+      continue;
+    }
+
+    info.x = dql->inputs()[0];
+    info.w_q = w_q_t;
+    info.w_scale = w_scale_t;
+    return true;
+  }
+  return false;
+}
+
+// Dequantizes `w_q` (INT8, [K, N]) with `w_scale` ([N]) into a FLOAT [K, N]
+// Tensor: out[k, n] = w_q[k, n] * w_scale[n].
+inline Tensor DequantizeWeightKN(const Tensor& w_q, const Tensor& w_scale) {
+  const int64_t K = w_q.sizes()[0];
+  const int64_t N = w_q.sizes()[1];
+  const std::vector<int8_t> codes = ReadInt8Matrix(w_q);
+
+  // w_scale is 1-D ([N]); ReadFloatMatrix (quantize_matmul_common.h) requires
+  // rank 2, so its raw/typed dispatch is inlined here instead of reused.
+  std::vector<float> scale_flat;
+  if (w_scale.is_raw_data()) {
+    scale_flat = ReadRawDataHostOrder<float>(w_scale.data<float>(), N);
+  } else {
+    scale_flat = w_scale.floats();
+  }
+
+  std::vector<float> dequant(static_cast<size_t>(K * N));
+  for (int64_t k = 0; k < K; ++k) {
+    for (int64_t n = 0; n < N; ++n) {
+      dequant[static_cast<size_t>(k * N + n)] =
+          static_cast<float>(codes[static_cast<size_t>(k * N + n)]) *
+          scale_flat[static_cast<size_t>(n)];
+    }
+  }
+
+  Tensor out;
+  out.elem_type() = TensorProto_DataType_FLOAT;
+  out.sizes() = {K, N};
+  out.set_raw_data(WriteRawDataLittleEndian(dequant));
+  return out;
+}
+
+struct DefuseMatMulIntegerToFloat final : public PredicateBasedPass {
+  explicit DefuseMatMulIntegerToFloat()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+  std::string getPassName() const override {
+    return "defuse_matmul_integer_to_float";
+  }
+
+  bool patternMatchPredicate(Node* n) override {
+    MatMulIntegerDequantInfo info;
+    if (n->kind() == kMul) {
+      return MatchMatMulIntegerDequant(n, info);
+    }
+    if (n->kind() == kAdd && n->inputs().size() == 2) {
+      // v->node() can be a multi-output pseudo-node for a graph input or
+      // initializer (e.g. the bias itself), so MatchMatMulIntegerDequant's
+      // own kind() == kMul check -- not an unconditional output() call,
+      // which asserts exactly one output -- must run first.
+      for (Value* v : n->inputs()) {
+        if (MatchMatMulIntegerDequant(v->node(), info)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+
+    MatMulIntegerDequantInfo info;
+    Value* bias = nullptr;
+    if (n->kind() == kMul) {
+      if (!MatchMatMulIntegerDequant(n, info)) {
+        return false;
+      }
+    } else if (n->kind() == kAdd && n->inputs().size() == 2) {
+      bool found = false;
+      for (Value* v : n->inputs()) {
+        if (MatchMatMulIntegerDequant(v->node(), info)) {
+          bias = (v == n->inputs()[0]) ? n->inputs()[1] : n->inputs()[0];
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        return false;
+      }
+    } else {
+      return false;
+    }
+
+    Tensor w_dequant = DequantizeWeightKN(*info.w_q, *info.w_scale);
+    Value* w_dequant_value = graph.addInitializerAndCreateValue(w_dequant);
+
+    Node* matmul = graph.create(kMatMul, 1);
+    matmul->addInput(info.x);
+    matmul->addInput(w_dequant_value);
+    matmul->insertBefore(n);
+    matmul->output()->setElemType(TensorProto_DataType_FLOAT);
+
+    Value* result = matmul->output();
+    if (bias != nullptr) {
+      Node* add = graph.create(kAdd, 1);
+      add->addInput(matmul->output());
+      add->addInput(bias);
+      add->insertBefore(n);
+      add->output()->setElemType(TensorProto_DataType_FLOAT);
+      result = add->output();
+    }
+
+    if (n->output()->sizes().size() > 0) {
+      result->setSizes(n->output()->sizes());
+    }
+
+    const bool replacing_success = tryReplacingAllUsesWith(n->output(), result);
+    if (!replacing_success) {
+      return false;
+    }
+    destroy_current = NodeDestroyType::DestroyOne;
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/quantize_matmul_common.h
+++ b/onnxsim/passes/quantize_matmul_common.h
@@ -11,7 +11,9 @@
 // INT8 per output channel from its static values; they differ only in how
 // the *activation* is quantized (a runtime-computed DynamicQuantizeLinear vs.
 // a calibrated, fixed QuantizeLinear/DequantizeLinear pair) and, downstream
-// of that, in the rest of the graph they build.
+// of that, in the rest of the graph they build. ReadInt8Matrix is also used
+// by defuse_matmul_integer_to_float.h, which reads back a weight one of
+// these passes quantized.
 
 #pragma once
 
@@ -110,6 +112,28 @@ inline std::vector<float> ReadFloatMatrix(const Tensor& w_t) {
     return ReadRawDataHostOrder<float>(w_t.data<float>(), numel);
   }
   return w_t.floats();
+}
+
+// Reads `q_t` (a 2-D INT8 constant) into a flat row-major vector<int8_t>,
+// regardless of whether it is stored as raw bytes (int8_t has no
+// byte-order concerns, but this still goes through ReadRawDataHostOrder for
+// consistency with every other raw_data read site -- see endian_read.h) or
+// ONNX's typed field for sub-32-bit integer types, which is int32_data (a
+// signed 8-bit code always round-trips through it unchanged).
+inline std::vector<int8_t> ReadInt8Matrix(const Tensor& q_t) {
+  const auto& sizes = q_t.sizes();
+  const int64_t numel = sizes[0] * sizes[1];
+  if (q_t.is_raw_data()) {
+    return ReadRawDataHostOrder<int8_t>(
+        reinterpret_cast<const int8_t*>(q_t.raw().data()), numel);
+  }
+  const std::vector<int32_t>& codes = q_t.int32s();
+  std::vector<int8_t> out(static_cast<size_t>(numel));
+  for (int64_t i = 0; i < numel; ++i) {
+    out[static_cast<size_t>(i)] =
+        static_cast<int8_t>(codes[static_cast<size_t>(i)]);
+  }
+  return out;
 }
 
 // Quantizes `w_t` (a 2-D float32 constant, laid out as [N, K] when

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -957,6 +957,11 @@ def test_arg_reduce_select_last_index_is_rewritten():
         [helper.make_tensor_value_info("y", TensorProto.INT64, [1])],
     )
     model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    # Pinned rather than left at helper.make_model's default (the currently
+    # installed onnx package's latest IR version): this test runs the raw
+    # model through onnxruntime directly, and CI's bundled onnxruntime build
+    # doesn't necessarily support the newest IR version.
+    model.ir_version = 10
     onnx.checker.check_model(model)
 
     sim_model, check_ok = onnxsim.simplify(model, check_n=0)

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1057,6 +1057,168 @@ def test_extra_optimizers_has_no_effect_when_optimization_disabled():
     assert [n.op_type for n in sim.graph.node] == ["Einsum"]
 
 
+def _matmul_weight_data():
+    return [
+        1.0,
+        -2.0,
+        0.5,
+        3.0,
+        0.25,
+        -1.5,
+        -0.75,
+        2.5,
+        1.0,
+        0.1,
+        -0.2,
+        4.0,
+    ]  # [4, 3]
+
+
+def _matmul_model():
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [2, 4])
+    w = helper.make_tensor("w", TensorProto.FLOAT, [4, 3], _matmul_weight_data())
+    node = helper.make_node("MatMul", ["x", "w"], ["y"])
+    graph = helper.make_graph(
+        [node],
+        "g",
+        [x],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [2, 3])],
+        initializer=[w],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 10
+    onnx.checker.check_model(model)
+    return model
+
+
+def _gemm_with_bias_model():
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [2, 4])
+    w = helper.make_tensor("w", TensorProto.FLOAT, [4, 3], _matmul_weight_data())
+    b = helper.make_tensor("b", TensorProto.FLOAT, [3], [0.1, -0.2, 0.3])
+    node = helper.make_node("Gemm", ["x", "w", "b"], ["y"])
+    graph = helper.make_graph(
+        [node],
+        "g",
+        [x],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [2, 3])],
+        initializer=[w, b],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 10
+    onnx.checker.check_model(model)
+    return model
+
+
+def _matmul_test_input():
+    import numpy as np
+
+    return np.array([[1.0, 2.0, 3.0, 4.0], [0.5, -1.0, 2.0, -3.0]], dtype=np.float32)
+
+
+def test_defuse_matmul_integer_to_float_undoes_dynamic_quantize_matmul():
+    # defuse_matmul_integer_to_float is the exact inverse of
+    # dynamic_quantize_matmul: it folds the DynamicQuantizeLinear +
+    # MatMulInteger + Cast + Mul + Mul chain that pass builds back into a
+    # single plain MatMul, for consumers that cannot import the quantized
+    # ops at all. Both passes are PassType::Other, off by default.
+    import numpy as np
+
+    from onnxsim.onnx_simplifier import C
+
+    model = _matmul_model()
+
+    assert "dynamic_quantize_matmul" not in C._list_optimizers()
+    assert "dynamic_quantize_matmul" in C._list_other_optimizers()
+    assert "defuse_matmul_integer_to_float" not in C._list_optimizers()
+    assert "defuse_matmul_integer_to_float" in C._list_other_optimizers()
+
+    sim_q, ok_q = onnxsim.simplify(
+        model, check_n=0, extra_optimizers=["dynamic_quantize_matmul"]
+    )
+    assert ok_q
+    assert set(n.op_type for n in sim_q.graph.node) == {
+        "DynamicQuantizeLinear",
+        "MatMulInteger",
+        "Cast",
+        "Mul",
+    }
+
+    sim_d, ok_d = onnxsim.simplify(
+        sim_q, check_n=0, extra_optimizers=["defuse_matmul_integer_to_float"]
+    )
+    assert ok_d
+    assert [n.op_type for n in sim_d.graph.node] == ["MatMul"]
+
+    sess_orig = onnxruntime.InferenceSession(model.SerializeToString())
+    sess_defused = onnxruntime.InferenceSession(sim_d.SerializeToString())
+    x = _matmul_test_input()
+    y_orig = sess_orig.run(None, {"x": x})[0]
+    y_defused = sess_defused.run(None, {"x": x})[0]
+    # Only W went through lossy INT8 quantization (X stays float, unlike the
+    # actual quantized graph), so this should be close, not bitwise equal.
+    np.testing.assert_allclose(y_defused, y_orig, atol=0.05)
+
+
+def test_defuse_matmul_integer_to_float_with_bias():
+    import numpy as np
+
+    from onnxsim.onnx_simplifier import C
+
+    model = _gemm_with_bias_model()
+
+    # The forward pass's Gemm(+bias) handling, combined with the full default
+    # pass set, has an unrelated pre-existing flakiness on some weight
+    # values; run it alone (skip every default pass) to build a
+    # deterministic quantized fixture.
+    sim_q, ok_q = onnxsim.simplify(
+        model,
+        check_n=0,
+        skipped_optimizers=list(C._list_optimizers()),
+        extra_optimizers=["dynamic_quantize_matmul"],
+    )
+    assert ok_q
+    assert "Add" in [n.op_type for n in sim_q.graph.node]
+
+    sim_d, ok_d = onnxsim.simplify(
+        sim_q, check_n=0, extra_optimizers=["defuse_matmul_integer_to_float"]
+    )
+    assert ok_d
+    # The default pass set is still active alongside the extra one, so the
+    # MatMul + Add(bias) this pass emits is immediately re-fused into a
+    # single Gemm by fuse_matmul_add_bias_into_gemm -- also a correct
+    # result, just a more idiomatic one.
+    assert [n.op_type for n in sim_d.graph.node] == ["Gemm"]
+
+    sess_orig = onnxruntime.InferenceSession(model.SerializeToString())
+    sess_defused = onnxruntime.InferenceSession(sim_d.SerializeToString())
+    x = _matmul_test_input()
+    y_orig = sess_orig.run(None, {"x": x})[0]
+    y_defused = sess_defused.run(None, {"x": x})[0]
+    np.testing.assert_allclose(y_defused, y_orig, atol=0.05)
+
+
+def test_defuse_matmul_integer_to_float_is_off_by_default():
+    model = _matmul_model()
+    sim_q, ok_q = onnxsim.simplify(
+        model, check_n=0, extra_optimizers=["dynamic_quantize_matmul"]
+    )
+    assert ok_q
+    quantized_ops = set(n.op_type for n in sim_q.graph.node)
+
+    sim_default, ok_default = onnxsim.simplify(sim_q, check_n=0)
+    assert ok_default
+    assert set(n.op_type for n in sim_default.graph.node) == quantized_ops
+
+
+def test_defuse_matmul_integer_to_float_leaves_plain_matmul_alone():
+    model = _matmul_model()
+    sim, ok = onnxsim.simplify(
+        model, check_n=0, extra_optimizers=["defuse_matmul_integer_to_float"]
+    )
+    assert ok
+    assert [n.op_type for n in sim.graph.node] == ["MatMul"]
+
+
 def test_ir3_conv_bn_fuses():
     # IR version 3 models (e.g. the opset-8 ``resnet101-v1-7``) list every
     # initializer as a graph input too, which is required before IR 4. onnxsim

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 import onnx
 import onnxruntime
+import pytest
 import torch
 from onnx import TensorProto, helper, numpy_helper
 
@@ -994,6 +995,66 @@ def test_arg_reduce_select_last_index_is_rewritten():
         orig_out = sess_orig.run(None, {"x": v})[0]
         sim_out = sess_sim.run(None, {"x": v})[0]
         assert np.array_equal(orig_out, sim_out)
+
+
+def _einsum_matmul_model():
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [2, 3])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [3, 4])
+    einsum = helper.make_node("Einsum", ["x", "y"], ["z"], equation="ij,jk->ik")
+    graph = helper.make_graph(
+        [einsum],
+        "g",
+        [x, y],
+        [helper.make_tensor_value_info("z", TensorProto.FLOAT, [2, 4])],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    onnx.checker.check_model(model)
+    return model
+
+
+def test_extra_optimizers_opts_into_an_off_by_default_pass():
+    # extra_optimizers is the counterpart to skipped_optimizers: it runs a
+    # named pass in addition to the default fuse/elimination set.
+    # replace_einsum_with_matmul is a real onnx-optimizer pass that is not
+    # part of that default set (confirmed via the second assertion below), so
+    # it only fires when named explicitly.
+    model = _einsum_matmul_model()
+
+    sim_default, ok_default = onnxsim.simplify(model, check_n=0)
+    assert ok_default
+    assert [n.op_type for n in sim_default.graph.node] == ["Einsum"]
+
+    from onnxsim.onnx_simplifier import C
+
+    assert "replace_einsum_with_matmul" not in C._list_optimizers()
+    assert "replace_einsum_with_matmul" in C._list_other_optimizers()
+
+    sim_extra, ok_extra = onnxsim.simplify(
+        model, check_n=0, extra_optimizers=["replace_einsum_with_matmul"]
+    )
+    assert ok_extra
+    assert [n.op_type for n in sim_extra.graph.node] == ["MatMul"]
+
+
+def test_extra_optimizers_unknown_name_raises():
+    model = _einsum_matmul_model()
+    with pytest.raises(Exception):
+        onnxsim.simplify(model, check_n=0, extra_optimizers=["not_a_real_pass"])
+
+
+def test_extra_optimizers_has_no_effect_when_optimization_disabled():
+    # perform_optimization=False means skipped_optimizers=None internally,
+    # which already disables the whole default pass set; extra_optimizers is
+    # documented to have no effect in that case either.
+    model = _einsum_matmul_model()
+    sim, ok = onnxsim.simplify(
+        model,
+        check_n=0,
+        perform_optimization=False,
+        extra_optimizers=["replace_einsum_with_matmul"],
+    )
+    assert ok
+    assert [n.op_type for n in sim.graph.node] == ["Einsum"]
 
 
 def test_ir3_conv_bn_fuses():


### PR DESCRIPTION
## Summary

Three changes, landed together on this branch:

1. **Fix**, follow-up to #766 which merged before this landed: `test_arg_reduce_select_last_index_is_rewritten` constructs an `onnxruntime.InferenceSession` directly on a raw `helper.make_model(...)` model. That helper stamps the currently-installed `onnx` package's latest IR version (13 in the failing CI run), but CI's bundled `onnxruntime` only supports IR version ≤ 11, so the test failed with:
   ```
   onnxruntime.capi.onnxruntime_pybind11_state.Fail: [ONNXRuntimeError] : 1 : FAIL : .../model.cc:181 ... Unsupported model IR version: 13, max supported IR version: 11
   ```
   Pins `model.ir_version = 10`, matching the same workaround already used elsewhere in this file (`test_simple.py:563,654`).

2. **New feature: `extra_optimizers`**, the general counterpart to `skip_optimizers`. A caller can now name onnx-optimizer passes to run *in addition to* the default fuse/elimination set, rather than only being able to exclude some of it. This is the real mechanism the ad-hoc `fuse_matmul_add_bias_into_gemm_batched` carve-out in `onnxsim.cpp` already needed — until now, a pass registered outside the default set (typically `PassType::Other`, since it's a graph-shape rewrite rather than a pure node reduction or fusion) had no way to be requested at all short of hardcoding it the same way.

   Threaded through:
   - **C++ core**: `Simplify`/`SimplifyConsumeInput`/`SimplifyPath` gain a trailing `extra_optimizers` parameter (`onnxsim.h`/`.cpp`). An unknown pass name throws rather than being silently ignored.
   - **Python**: `simplify(extra_optimizers=...)`; new `_list_other_optimizers()` binding in `cpp2py_export.cc`.
   - **CLI**: `--enable-optimization` and `--list-other-optimizers`.
   - **README**: documented alongside the existing optimizer-pass bullet.

   Scoped out of the C API and Rust wrapper for now — a natural follow-up, not needed to unlock the Python/CLI path.

3. **New pass: `defuse_matmul_integer_to_float`**, the first real consumer of `extra_optimizers`. It is the exact inverse of the existing `dynamic_quantize_matmul` pass: it folds a `DynamicQuantizeLinear` + `MatMulInteger` + `Cast` + `Mul` + `Mul` (+ `Add` for a bias) dequantization chain back into a single plain `MatMul` (+ `Add`), by dequantizing the constant INT8 weight to float once at transform time. It exists for consumers of onnxsim's output (e.g. compiler frontends such as TVM, whose ONNX importer has limited/no `MatMulInteger` support — see the TVM/onnxsim gap survey earlier in this session) that would rather see a plain float `MatMul` than fail to import a dynamically-quantized model at all. Like `dynamic_quantize_matmul`, it is `PassType::Other` and only runs when named via `extra_optimizers=["defuse_matmul_integer_to_float"]` — this tradeoff (losing the quantized model's runtime benefit for portability) is opt-in only, per an explicit product decision made earlier in this session.

   Also adds `ReadInt8Matrix` to `quantize_matmul_common.h` (the read-side counterpart to `QuantizeWeightPerChannelKN`'s INT8 write). Along the way, found and fixed a real crash: matching the bias-`Add` case called `Node::output()` (asserts exactly one output) on an arbitrary input `Value`'s producer, unsafe when that producer is a multi-output pseudo-node (e.g. a graph input/initializer such as the bias itself); removed, since `MatchMatMulIntegerDequant`'s own `kind() == kMul` check already makes it redundant.

## Test plan

- New tests: `test_extra_optimizers_opts_into_an_off_by_default_pass`, `test_extra_optimizers_unknown_name_raises`, `test_extra_optimizers_has_no_effect_when_optimization_disabled`, `test_defuse_matmul_integer_to_float_undoes_dynamic_quantize_matmul`, `test_defuse_matmul_integer_to_float_with_bias`, `test_defuse_matmul_integer_to_float_is_off_by_default`, `test_defuse_matmul_integer_to_float_leaves_plain_matmul_alone`.
- Numerically verified the defusion round-trip against `onnxruntime` (defused output close to, but not bitwise equal to, the original float model — only the weight went through lossy INT8 quantization).
- Manually verified the CLI too: `onnxsim --list-other-optimizers` and `onnxsim a.onnx b.onnx --enable-optimization replace_einsum_with_matmul`.
- Full `tests/test_simple.py` suite: no new failures (2 pre-existing failures from a missing, unrelated `onnxscript` dependency).
- `ruff format`, `ruff check`, `mypy`, and `clang-format --dry-run --Werror` all clean.

https://claude.ai/code/session_01TwY4Kx5PFkJwgpbgdr3CQf
