### PR TITLE
Drop Python 3.10 support, require Python 3.11+

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -54,18 +54,18 @@ jobs:
         # not natively here.
         os: [ubuntu-24.04, ubuntu-24.04-arm, macos-15]
         # Full Python coverage on push/release; a reduced set on pull_request to
-        # cut CI jobs. cp310 exercises a version-specific (below-abi3-floor)
-        # wheel and cp312 the abi3 wheel that also serves 3.13/3.14, so cp311 and
-        # cp313 add no distinct build coverage on PRs. The free-threaded cp314t
+        # cut CI jobs. cp311 exercises a version-specific (below-abi3-floor)
+        # wheel and cp312 the abi3 wheel that also serves 3.13/3.14, so cp313
+        # adds no distinct build coverage on PRs. The free-threaded cp314t
         # job (via include below) still runs on every event.
-        py_ver: ${{ github.event_name == 'pull_request' && fromJSON('["cp310", "cp312"]') || fromJSON('["cp310", "cp311", "cp312", "cp313"]') }}
+        py_ver: ${{ github.event_name == 'pull_request' && fromJSON('["cp311", "cp312"]') || fromJSON('["cp311", "cp312", "cp313"]') }}
         include:
           - os: ubuntu-24.04
             py_ver: cp314t
             # test_ext allocates a ~2 GiB fp16 tensor and OOM-kills the
             # free-threaded runner (SIGKILL / exit 137), just as it does on the
             # Windows runner (see test_wheels_windows_cross). Skip it here; the
-            # same test still runs on the cp310-cp313 jobs (cp310/cp312 on PRs).
+            # same test still runs on the cp311-cp313 jobs (cp311/cp312 on PRs).
             pytest_args: '-k "not test_ext"'
     steps:
     - uses: actions/checkout@v7
@@ -95,8 +95,8 @@ jobs:
   # (clang + lld + a self-contained UCRT sysroot) instead of built natively on a
   # Windows runner. 3.12 and 3.13 share a single cp312-abi3 wheel (nanobind
   # limited-API module + the stable-ABI python3.lib from the CPython NuGet
-  # package); 3.10 and 3.11 are below the abi3 floor and get version-specific
-  # wheels. See scripts/cross/README.md.
+  # package); 3.11 is below the abi3 floor and gets a version-specific
+  # wheel. See scripts/cross/README.md.
   build_wheels_windows_cross:
     name: Cross-build Windows wheel on Ubuntu (${{ matrix.artifact }}, llvm-mingw)
     env:
@@ -109,7 +109,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { py_ver: '3.10', abi3: '0', artifact: cp310 }   # version-specific (below abi3 floor)
           - { py_ver: '3.11', abi3: '0', artifact: cp311 }   # version-specific (below abi3 floor)
           - { py_ver: '3.12', abi3: '1', artifact: abi3 }    # abi3: also serves 3.13+
     steps:
@@ -159,7 +158,7 @@ jobs:
         # The 3.13 job re-tests the exact cp312-abi3 wheel the 3.12 job already
         # covers, so drop it on pull_request to cut a CI job; push/release still
         # test both.
-        include: ${{ github.event_name == 'pull_request' && fromJSON('[{"py_ver":"3.10","artifact":"cp310"},{"py_ver":"3.11","artifact":"cp311"},{"py_ver":"3.12","artifact":"abi3"}]') || fromJSON('[{"py_ver":"3.10","artifact":"cp310"},{"py_ver":"3.11","artifact":"cp311"},{"py_ver":"3.12","artifact":"abi3"},{"py_ver":"3.13","artifact":"abi3"}]') }}
+        include: ${{ github.event_name == 'pull_request' && fromJSON('[{"py_ver":"3.11","artifact":"cp311"},{"py_ver":"3.12","artifact":"abi3"}]') || fromJSON('[{"py_ver":"3.11","artifact":"cp311"},{"py_ver":"3.12","artifact":"abi3"},{"py_ver":"3.13","artifact":"abi3"}]') }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install tools
         run: |
           python -m pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Simplify your ONNX model"
 readme = "README.md"
 license = "MIT AND (Apache-2.0 OR BSD-2-Clause)"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "onnx",
     "rich",
@@ -21,7 +21,6 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -69,7 +68,7 @@ select = ["E4", "E7", "E9", "F", "I"]
 [tool.mypy]
 # Type-check the Python package (not the tests, which lean on dynamic fixtures).
 files = ["onnxsim"]
-python_version = "3.10"
+python_version = "3.11"
 # onnx/numpy/onnxruntime/torch expose partial or no type information, the
 # compiled `onnxsim_cpp2py_export` extension has no stubs, and upstream stubs
 # are incomplete (e.g. onnx OpSchema methods). Treat every third-party import as

--- a/scripts/cross/README.md
+++ b/scripts/cross/README.md
@@ -73,13 +73,13 @@ run is a cold cache, later runs reuse it.
 ## Scope / status
 
 * Covers the Windows CPython versions shipped by `build-and-test.yml`:
-  **3.10, 3.11, 3.12, 3.13**. This cross-build **is** the Windows release path —
+  **3.11, 3.12, 3.13**. This cross-build **is** the Windows release path —
   it replaces the native Windows build, and its wheels are published to PyPI by
   the `upload_pypi` job alongside the natively-built Linux/macOS wheels.
 * **3.12 and 3.13 share one `cp312-abi3` wheel**: a genuine limited-API module
   (nanobind sets `Py_LIMITED_API` and links nuget's `python3.lib`, so the `.pyd`
-  imports `python3.dll`). **3.10 and 3.11** are below nanobind's abi3 floor
-  (3.12), so they get **version-specific** wheels (`ABI3=0`, tag `cp3XX-cp3XX`,
+  imports `python3.dll`). **3.11** is below nanobind's abi3 floor
+  (3.12), so it gets a **version-specific** wheel (`ABI3=0`, tag `cp3XX-cp3XX`,
   linking `pythonXY.dll`).
 * onnxruntime is **not** compiled in (`-DONNXSIM_BUILTIN_ORT=OFF`, matching the
   pip build), keeping the cross-compile surface to onnx + protobuf + nanobind.

--- a/scripts/cross/assemble_wheel.py
+++ b/scripts/cross/assemble_wheel.py
@@ -69,7 +69,7 @@ Classifier: Intended Audience :: Developers
 Classifier: Programming Language :: Python :: 3 :: Only
 Classifier: Topic :: Scientific/Engineering
 Classifier: Topic :: Software Development
-Requires-Python: >=3.10
+Requires-Python: >=3.11
 Requires-Dist: onnx
 Requires-Dist: rich
 Provides-Extra: onnxruntime


### PR DESCRIPTION
This PR updates the project to require Python 3.11 as the minimum supported version, dropping support for Python 3.10.

## Summary
Removes Python 3.10 from all build configurations, CI workflows, and project metadata. This simplifies the build matrix and reduces CI job count while aligning with the project's support strategy.

## Key changes

- **pyproject.toml**: Updated `requires-python` from `>=3.10` to `>=3.11` and removed the `Programming Language :: Python :: 3.10` classifier
- **CI workflows**: 
  - Removed cp310 from the build matrix in `build-and-test.yml`
  - Removed the Python 3.10 cross-build job from Windows cross-compilation in `build-and-test.yml`
  - Updated test coverage comments to reflect cp311 as the version-specific wheel baseline
  - Updated `lint.yml` to use Python 3.11 instead of 3.10
- **Documentation**: Updated `scripts/cross/README.md` to reflect that only Python 3.11, 3.12, and 3.13 are supported
- **Build scripts**: Updated `scripts/cross/assemble_wheel.py` metadata to reflect the new minimum version

## Implementation details

The changes maintain the same build strategy for remaining versions:
- Python 3.11 remains as the version-specific wheel (below nanobind's abi3 floor at 3.12)
- Python 3.12+ continue to use the abi3 wheel
- CI job count is reduced on pull requests by removing the redundant cp310 job

https://claude.ai/code/session_01Y3HGZsnW8p6cG9UvnSMaDi