### PR TITLE
Add extra_optimizers to the C API and Rust wrapper

### DIFF
--- a/onnxsim/capi/onnxsim_c_api.cpp
+++ b/onnxsim/capi/onnxsim_c_api.cpp
@@ -11,9 +11,11 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
+#include "custom_optimizer_passes.h"
 #include "function_rewriter.h"
 #include "model_info.h"
 #include "onnx/proto_utils.h"
@@ -78,6 +80,25 @@ std::optional<std::vector<std::string>> BuildSkipOptimizers(
   for (size_t i = 0; i < num_skip_optimizers; ++i) {
     const char* name =
         skip_optimizers != nullptr ? skip_optimizers[i] : nullptr;
+    passes.emplace_back(name != nullptr ? name : "");
+  }
+  return passes;
+}
+
+// Translate the (pointer array, count) FFI encoding into the optional vector
+// the C++ core expects. Unlike BuildSkipOptimizers there is no is_null flag:
+// num_extra_optimizers == 0 and std::nullopt behave identically (no extra
+// passes), so a plain count of 0 already means "none".
+std::optional<std::vector<std::string>> BuildExtraOptimizers(
+    const char* const* extra_optimizers, size_t num_extra_optimizers) {
+  if (num_extra_optimizers == 0) {
+    return std::nullopt;
+  }
+  std::vector<std::string> passes;
+  passes.reserve(num_extra_optimizers);
+  for (size_t i = 0; i < num_extra_optimizers; ++i) {
+    const char* name =
+        extra_optimizers != nullptr ? extra_optimizers[i] : nullptr;
     passes.emplace_back(name != nullptr ? name : "");
   }
   return passes;
@@ -204,6 +225,7 @@ OnnxsimStatus SimplifyToBuffer(
     const char* const* skip_optimizers, size_t num_skip_optimizers,
     int skip_optimizers_is_null, int constant_folding, int shape_inference,
     size_t tensor_size_threshold, int target_opset_version,
+    const char* const* extra_optimizers, size_t num_extra_optimizers,
     const GraphRewriter* rewriter, const ModelExecutor* executor,
     void** out_data, size_t* out_size, char** out_error) {
   if (out_data != nullptr) {
@@ -233,7 +255,13 @@ OnnxsimStatus SimplifyToBuffer(
         BuildSkipOptimizers(skip_optimizers, num_skip_optimizers,
                             skip_optimizers_is_null),
         constant_folding != 0, shape_inference != 0, tensor_size_threshold,
-        BuildTargetOpsetVersion(target_opset_version), rewriter);
+        BuildTargetOpsetVersion(target_opset_version), rewriter,
+        /*initializers_as_constants=*/true,
+        /*include_inline_functions=*/false,
+        /*mutable_initializer=*/true,
+        /*overwrite_input_shapes=*/std::nullopt,
+        /*unused_output=*/std::nullopt,
+        BuildExtraOptimizers(extra_optimizers, num_extra_optimizers));
 
     std::string out;
     if (!result.SerializeToString(&out)) {
@@ -296,6 +324,7 @@ OnnxsimStatus onnxsim_simplify(
     const char* const* skip_optimizers, size_t num_skip_optimizers,
     int skip_optimizers_is_null, int constant_folding, int shape_inference,
     size_t tensor_size_threshold, int target_opset_version,
+    const char* const* extra_optimizers, size_t num_extra_optimizers,
     OnnxsimRewriteFn rewrite_fn, OnnxsimRewriteFreeFn rewrite_free_fn,
     void* rewrite_user_data, void** out_data, size_t* out_size,
     char** out_error) {
@@ -303,12 +332,12 @@ OnnxsimStatus onnxsim_simplify(
   if (rewrite_fn != nullptr) {
     rewriter.emplace(rewrite_fn, rewrite_free_fn, rewrite_user_data);
   }
-  return SimplifyToBuffer(model_data, model_size, skip_optimizers,
-                          num_skip_optimizers, skip_optimizers_is_null,
-                          constant_folding, shape_inference,
-                          tensor_size_threshold, target_opset_version,
-                          rewriter.has_value() ? &rewriter.value() : nullptr,
-                          /*executor=*/nullptr, out_data, out_size, out_error);
+  return SimplifyToBuffer(
+      model_data, model_size, skip_optimizers, num_skip_optimizers,
+      skip_optimizers_is_null, constant_folding, shape_inference,
+      tensor_size_threshold, target_opset_version, extra_optimizers,
+      num_extra_optimizers, rewriter.has_value() ? &rewriter.value() : nullptr,
+      /*executor=*/nullptr, out_data, out_size, out_error);
 }
 
 OnnxsimStatus onnxsim_simplify_with_executor(
@@ -316,6 +345,7 @@ OnnxsimStatus onnxsim_simplify_with_executor(
     const char* const* skip_optimizers, size_t num_skip_optimizers,
     int skip_optimizers_is_null, int constant_folding, int shape_inference,
     size_t tensor_size_threshold, int target_opset_version,
+    const char* const* extra_optimizers, size_t num_extra_optimizers,
     OnnxsimRewriteFn rewrite_fn, OnnxsimRewriteFreeFn rewrite_free_fn,
     void* rewrite_user_data, OnnxsimExecuteFn execute_fn,
     OnnxsimExecuteFreeFn execute_free_fn, void* execute_user_data,
@@ -328,13 +358,13 @@ OnnxsimStatus onnxsim_simplify_with_executor(
   if (execute_fn != nullptr) {
     executor.emplace(execute_fn, execute_free_fn, execute_user_data);
   }
-  return SimplifyToBuffer(model_data, model_size, skip_optimizers,
-                          num_skip_optimizers, skip_optimizers_is_null,
-                          constant_folding, shape_inference,
-                          tensor_size_threshold, target_opset_version,
-                          rewriter.has_value() ? &rewriter.value() : nullptr,
-                          executor.has_value() ? &executor.value() : nullptr,
-                          out_data, out_size, out_error);
+  return SimplifyToBuffer(
+      model_data, model_size, skip_optimizers, num_skip_optimizers,
+      skip_optimizers_is_null, constant_folding, shape_inference,
+      tensor_size_threshold, target_opset_version, extra_optimizers,
+      num_extra_optimizers, rewriter.has_value() ? &rewriter.value() : nullptr,
+      executor.has_value() ? &executor.value() : nullptr, out_data, out_size,
+      out_error);
 }
 
 OnnxsimStatus onnxsim_simplify_with_rules(
@@ -344,13 +374,16 @@ OnnxsimStatus onnxsim_simplify_with_rules(
     size_t tensor_size_threshold, int target_opset_version,
     const void* const* pattern_data, const size_t* pattern_sizes,
     const void* const* replacement_data, const size_t* replacement_sizes,
-    size_t num_rules, void** out_data, size_t* out_size, char** out_error) {
+    size_t num_rules, const char* const* extra_optimizers,
+    size_t num_extra_optimizers, void** out_data, size_t* out_size,
+    char** out_error) {
   // With no rules this is just onnxsim_simplify (no callback rewriter).
   if (num_rules == 0) {
     return onnxsim_simplify(
         model_data, model_size, skip_optimizers, num_skip_optimizers,
         skip_optimizers_is_null, constant_folding, shape_inference,
-        tensor_size_threshold, target_opset_version, /*rewrite_fn=*/nullptr,
+        tensor_size_threshold, target_opset_version, extra_optimizers,
+        num_extra_optimizers, /*rewrite_fn=*/nullptr,
         /*rewrite_free_fn=*/nullptr, /*rewrite_user_data=*/nullptr, out_data,
         out_size, out_error);
   }
@@ -376,7 +409,8 @@ OnnxsimStatus onnxsim_simplify_with_rules(
     return SimplifyToBuffer(
         model_data, model_size, skip_optimizers, num_skip_optimizers,
         skip_optimizers_is_null, constant_folding, shape_inference,
-        tensor_size_threshold, target_opset_version, rewriter.get(),
+        tensor_size_threshold, target_opset_version, extra_optimizers,
+        num_extra_optimizers, rewriter.get(),
         /*executor=*/nullptr, out_data, out_size, out_error);
   } catch (const std::exception& e) {
     SetError(out_error, e.what());
@@ -392,6 +426,7 @@ OnnxsimStatus onnxsim_simplify_path(
     const char* const* skip_optimizers, size_t num_skip_optimizers,
     int skip_optimizers_is_null, int constant_folding, int shape_inference,
     size_t tensor_size_threshold, int target_opset_version,
+    const char* const* extra_optimizers, size_t num_extra_optimizers,
     OnnxsimRewriteFn rewrite_fn, OnnxsimRewriteFreeFn rewrite_free_fn,
     void* rewrite_user_data, char** out_error) {
   if (out_error != nullptr) {
@@ -415,7 +450,13 @@ OnnxsimStatus onnxsim_simplify_path(
                                      skip_optimizers_is_null),
                  constant_folding != 0, shape_inference != 0,
                  tensor_size_threshold,
-                 BuildTargetOpsetVersion(target_opset_version), rewriter_ptr);
+                 BuildTargetOpsetVersion(target_opset_version), rewriter_ptr,
+                 /*initializers_as_constants=*/true,
+                 /*include_inline_functions=*/false,
+                 /*mutable_initializer=*/true,
+                 /*overwrite_input_shapes=*/std::nullopt,
+                 /*unused_output=*/std::nullopt,
+                 BuildExtraOptimizers(extra_optimizers, num_extra_optimizers));
     return ONNXSIM_OK;
   } catch (const std::exception& e) {
     SetError(out_error, e.what());
@@ -430,6 +471,28 @@ char* onnxsim_list_optimizers(void) {
   try {
     std::string joined;
     for (const auto& pass : onnx::optimization::GetFuseAndEliminationPass()) {
+      if (!joined.empty()) {
+        joined.push_back('\n');
+      }
+      joined.append(pass);
+    }
+    return DupCString(joined);
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+char* onnxsim_list_other_optimizers(void) {
+  try {
+    onnxsim::RegisterCustomOptimizerPasses();
+    const auto default_passes = onnx::optimization::GetFuseAndEliminationPass();
+    const std::unordered_set<std::string> default_set(default_passes.begin(),
+                                                      default_passes.end());
+    std::string joined;
+    for (const auto& pass : onnx::optimization::GetAvailablePasses()) {
+      if (default_set.count(pass) != 0) {
+        continue;
+      }
       if (!joined.empty()) {
         joined.push_back('\n');
       }

--- a/onnxsim/capi/onnxsim_c_api.h
+++ b/onnxsim/capi/onnxsim_c_api.h
@@ -139,6 +139,19 @@ typedef void (*OnnxsimExecuteFreeFn)(void* user_data, DLManagedTensor** outputs,
  * the default ONNX domain (using onnx's version converter) before simplifying;
  * a value <= 0 leaves the opset version unchanged.
  *
+ * extra_optimizers/num_extra_optimizers name onnx-optimizer passes to run in
+ * ADDITION to the default fuse/elimination set (plus whatever
+ * skip_optimizers left in) -- the counterpart to skip_optimizers, and how a
+ * pass registered outside the default set (typically PassType::Other, e.g. a
+ * defusion that trades a backend-specific op for a more portable one) gets
+ * opted into. num_extra_optimizers == 0 behaves exactly like the C++ core's
+ * ``std::nullopt`` (no extra passes; also a no-op when skip_optimizers_is_null
+ * != 0, since that already disables optimization entirely). An unknown pass
+ * name is not validated here -- it throws from onnx-optimizer's own pass
+ * registry lookup, surfaced as ONNXSIM_ERROR with a message in *out_error,
+ * rather than being silently ignored. See onnxsim_list_other_optimizers for
+ * the set of names this can name.
+ *
  * rewrite_fn, when non-NULL, is a custom graph rewriter run inside the
  * simplification fixed point (see OnnxsimRewriteFn). rewrite_free_fn releases
  * the buffers it produces (may be NULL). rewrite_user_data is passed through to
@@ -155,7 +168,8 @@ onnxsim_simplify(const void* model_data, size_t model_size,
                  const char* const* skip_optimizers, size_t num_skip_optimizers,
                  int skip_optimizers_is_null, int constant_folding,
                  int shape_inference, size_t tensor_size_threshold,
-                 int target_opset_version, OnnxsimRewriteFn rewrite_fn,
+                 int target_opset_version, const char* const* extra_optimizers,
+                 size_t num_extra_optimizers, OnnxsimRewriteFn rewrite_fn,
                  OnnxsimRewriteFreeFn rewrite_free_fn, void* rewrite_user_data,
                  void** out_data, size_t* out_size, char** out_error);
 
@@ -167,13 +181,14 @@ onnxsim_simplify(const void* model_data, size_t model_size,
  * executor, making this a drop-in superset of onnxsim_simplify. execute_free_fn
  * (may be NULL) releases each output array; execute_user_data is passed through
  * to both callbacks. All other parameters and the out_* contract match
- * onnxsim_simplify.
+ * onnxsim_simplify, including extra_optimizers/num_extra_optimizers.
  */
 ONNXSIM_C_API OnnxsimStatus onnxsim_simplify_with_executor(
     const void* model_data, size_t model_size,
     const char* const* skip_optimizers, size_t num_skip_optimizers,
     int skip_optimizers_is_null, int constant_folding, int shape_inference,
     size_t tensor_size_threshold, int target_opset_version,
+    const char* const* extra_optimizers, size_t num_extra_optimizers,
     OnnxsimRewriteFn rewrite_fn, OnnxsimRewriteFreeFn rewrite_free_fn,
     void* rewrite_user_data, OnnxsimExecuteFn execute_fn,
     OnnxsimExecuteFreeFn execute_free_fn, void* execute_user_data,
@@ -192,7 +207,7 @@ ONNXSIM_C_API OnnxsimStatus onnxsim_simplify_with_executor(
  * `pattern_data[i]`/`pattern_sizes[i]` and `replacement_data[i]`/
  * `replacement_sizes[i]` describe rule `i`, for `i` in [0, num_rules). Passing
  * num_rules == 0 behaves exactly like onnxsim_simplify. All other parameters
- * match onnxsim_simplify.
+ * match onnxsim_simplify, including extra_optimizers/num_extra_optimizers.
  */
 ONNXSIM_C_API OnnxsimStatus onnxsim_simplify_with_rules(
     const void* model_data, size_t model_size,
@@ -201,7 +216,9 @@ ONNXSIM_C_API OnnxsimStatus onnxsim_simplify_with_rules(
     size_t tensor_size_threshold, int target_opset_version,
     const void* const* pattern_data, const size_t* pattern_sizes,
     const void* const* replacement_data, const size_t* replacement_sizes,
-    size_t num_rules, void** out_data, size_t* out_size, char** out_error);
+    size_t num_rules, const char* const* extra_optimizers,
+    size_t num_extra_optimizers, void** out_data, size_t* out_size,
+    char** out_error);
 
 /*
  * Same as onnxsim_simplify, but reads the input model from `in_path` and writes
@@ -213,6 +230,7 @@ ONNXSIM_C_API OnnxsimStatus onnxsim_simplify_path(
     const char* const* skip_optimizers, size_t num_skip_optimizers,
     int skip_optimizers_is_null, int constant_folding, int shape_inference,
     size_t tensor_size_threshold, int target_opset_version,
+    const char* const* extra_optimizers, size_t num_extra_optimizers,
     OnnxsimRewriteFn rewrite_fn, OnnxsimRewriteFreeFn rewrite_free_fn,
     void* rewrite_user_data, char** out_error);
 
@@ -222,6 +240,17 @@ ONNXSIM_C_API OnnxsimStatus onnxsim_simplify_path(
  * Returns NULL on allocation failure. Release with onnxsim_free_string.
  */
 ONNXSIM_C_API char* onnxsim_list_optimizers(void);
+
+/*
+ * Return the names of the optimizer passes registered but NOT in the default
+ * fuse/elimination set (typically PassType::Other, e.g.
+ * defuse_matmul_integer_to_float)
+ * -- the names valid for extra_optimizers/num_extra_optimizers on the
+ * onnxsim_simplify* functions above. Same format/ownership contract as
+ * onnxsim_list_optimizers: one name per line, NUL-terminated, NULL on
+ * allocation failure, release with onnxsim_free_string.
+ */
+ONNXSIM_C_API char* onnxsim_list_other_optimizers(void);
 
 /*
  * Render a human-readable diff between an original and a simplified model, both

--- a/rust/README.md
+++ b/rust/README.md
@@ -55,16 +55,22 @@ fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
     let opts = onnxsim::Options::new()
         .shape_inference(false)                       // skip if it crashes on your model
         .skip_optimizer("eliminate_nop_transpose")    // keep a specific pass off
+        .extra_optimizer("defuse_matmul_integer_to_float") // opt into a non-default pass
         .tensor_size_threshold(512 * 1024 * 1024);
     let simplified = onnxsim::simplify_with(&model, &opts)?;
     Ok(())
 }
 ```
 
-List the optimizer passes you can skip:
+List the optimizer passes you can skip, and the ones you can opt into with
+[`Options::extra_optimizer`] (off by default -- typically a graph-shape rewrite
+rather than a pure node reduction or fusion):
 
 ```rust
 for name in onnxsim::list_optimizers() {
+    println!("{name}");
+}
+for name in onnxsim::list_other_optimizers() {
     println!("{name}");
 }
 ```

--- a/rust/onnxsim-sys/src/lib.rs
+++ b/rust/onnxsim-sys/src/lib.rs
@@ -200,14 +200,18 @@ extern "C" {
     /// See `onnxsim_c_api.h` for the full contract. In brief:
     /// `skip_optimizers_is_null != 0` skips every optimizer pass; otherwise all
     /// passes run except the `num_skip_optimizers` names in `skip_optimizers`.
-    /// On success (`ONNXSIM_OK`) `out_data`/`out_size` own a buffer to free with
-    /// [`onnxsim_free_buffer`]; on failure (`ONNXSIM_ERROR`) `out_error` owns a
-    /// string to free with [`onnxsim_free_string`].
+    /// `extra_optimizers`/`num_extra_optimizers` name passes to run in ADDITION
+    /// to the default set (the counterpart to `skip_optimizers`); `0` behaves
+    /// like no extra passes. On success (`ONNXSIM_OK`) `out_data`/`out_size` own
+    /// a buffer to free with [`onnxsim_free_buffer`]; on failure
+    /// (`ONNXSIM_ERROR`) `out_error` owns a string to free with
+    /// [`onnxsim_free_string`].
     ///
     /// # Safety
     /// All non-null pointers must be valid; `model_data` must point to at least
-    /// `model_size` bytes and `skip_optimizers` to `num_skip_optimizers`
-    /// NUL-terminated strings when `skip_optimizers_is_null == 0`. When
+    /// `model_size` bytes, `skip_optimizers` to `num_skip_optimizers`
+    /// NUL-terminated strings when `skip_optimizers_is_null == 0`, and
+    /// `extra_optimizers` to `num_extra_optimizers` NUL-terminated strings. When
     /// `rewrite_fn` is `Some`, it (and the matching `rewrite_free_fn`) must obey
     /// the callback contract in `onnxsim_c_api.h`.
     pub fn onnxsim_simplify(
@@ -220,6 +224,8 @@ extern "C" {
         shape_inference: c_int,
         tensor_size_threshold: usize,
         target_opset_version: c_int,
+        extra_optimizers: *const *const c_char,
+        num_extra_optimizers: usize,
         rewrite_fn: Option<OnnxsimRewriteFn>,
         rewrite_free_fn: Option<OnnxsimRewriteFreeFn>,
         rewrite_user_data: *mut c_void,
@@ -234,7 +240,7 @@ extern "C" {
     /// This is the seam for embedding onnxsim in another ONNX-based stack. A
     /// `None` `execute_fn` falls back to the built-in executor, making this a
     /// drop-in superset of [`onnxsim_simplify`]. See `onnxsim_c_api.h` for the
-    /// full contract; the rewrite parameters match [`onnxsim_simplify`].
+    /// full contract; the other parameters match [`onnxsim_simplify`].
     ///
     /// # Safety
     /// All non-null pointers must be valid; `model_data` must point to at least
@@ -253,6 +259,8 @@ extern "C" {
         shape_inference: c_int,
         tensor_size_threshold: usize,
         target_opset_version: c_int,
+        extra_optimizers: *const *const c_char,
+        num_extra_optimizers: usize,
         rewrite_fn: Option<OnnxsimRewriteFn>,
         rewrite_free_fn: Option<OnnxsimRewriteFreeFn>,
         rewrite_user_data: *mut c_void,
@@ -292,6 +300,8 @@ extern "C" {
         replacement_data: *const *const c_void,
         replacement_sizes: *const usize,
         num_rules: usize,
+        extra_optimizers: *const *const c_char,
+        num_extra_optimizers: usize,
         out_data: *mut *mut c_void,
         out_size: *mut usize,
         out_error: *mut *mut c_char,
@@ -301,8 +311,8 @@ extern "C" {
     ///
     /// # Safety
     /// `in_path`/`out_path` must be valid NUL-terminated paths; the
-    /// `skip_optimizers` and `rewrite_fn`/`rewrite_free_fn` rules match
-    /// [`onnxsim_simplify`].
+    /// `skip_optimizers`, `extra_optimizers`, and `rewrite_fn`/`rewrite_free_fn`
+    /// rules match [`onnxsim_simplify`].
     pub fn onnxsim_simplify_path(
         in_path: *const c_char,
         out_path: *const c_char,
@@ -313,6 +323,8 @@ extern "C" {
         shape_inference: c_int,
         tensor_size_threshold: usize,
         target_opset_version: c_int,
+        extra_optimizers: *const *const c_char,
+        num_extra_optimizers: usize,
         rewrite_fn: Option<OnnxsimRewriteFn>,
         rewrite_free_fn: Option<OnnxsimRewriteFreeFn>,
         rewrite_user_data: *mut c_void,
@@ -326,6 +338,16 @@ extern "C" {
     /// # Safety
     /// Always safe to call; the returned pointer must be freed exactly once.
     pub fn onnxsim_list_optimizers() -> *mut c_char;
+
+    /// Return the names of the optimizer passes registered but NOT in the
+    /// default fuse/elimination set (typically `PassType::Other`, e.g.
+    /// `defuse_matmul_integer_to_float`) -- the names valid for
+    /// `extra_optimizers`/`num_extra_optimizers` above. Same format/ownership
+    /// contract as [`onnxsim_list_optimizers`].
+    ///
+    /// # Safety
+    /// Always safe to call; the returned pointer must be freed exactly once.
+    pub fn onnxsim_list_other_optimizers() -> *mut c_char;
 
     /// Render a human-readable diff (op counts + model size) between an original
     /// and a simplified model, both serialized `ModelProto` bytes. On

--- a/rust/onnxsim/src/lib.rs
+++ b/rust/onnxsim/src/lib.rs
@@ -147,6 +147,14 @@ pub struct Options {
     /// * `Some(list)` — run every fuse/elimination pass except the names in
     ///   `list` (an empty list runs them all).
     skip_optimizers: Option<Vec<String>>,
+    /// Optimizer passes to run in ADDITION to the default fuse/elimination set
+    /// (plus whatever `skip_optimizers` left in) -- the counterpart to
+    /// `skip_optimizers`, for a pass registered outside the default set
+    /// (typically `PassType::Other`, e.g. a defusion that trades a
+    /// backend-specific op for a more portable one). Empty (the default) means
+    /// no extra passes. See [`list_other_optimizers`] for valid names; an
+    /// unknown name is an error at simplify time, not silently ignored.
+    extra_optimizers: Vec<String>,
     constant_folding: bool,
     shape_inference: bool,
     tensor_size_threshold: usize,
@@ -163,6 +171,7 @@ impl Default for Options {
     fn default() -> Self {
         Options {
             skip_optimizers: Some(Vec::new()),
+            extra_optimizers: Vec::new(),
             constant_folding: true,
             shape_inference: true,
             tensor_size_threshold: DEFAULT_TENSOR_SIZE_THRESHOLD,
@@ -239,6 +248,30 @@ impl Options {
         self
     }
 
+    /// Run these optimizer passes in addition to the default fuse/elimination
+    /// set. Replaces any previously configured extra-optimizer list.
+    ///
+    /// This is how a pass registered outside the default set (typically
+    /// `PassType::Other`, since it's a graph-shape rewrite rather than a pure
+    /// node reduction or fusion) gets opted into. Has no effect if optimization
+    /// is entirely disabled ([`Options::without_optimizers`]). Use
+    /// [`list_other_optimizers`] to discover valid names; an unknown name is an
+    /// error at simplify time.
+    pub fn extra_optimizers<I, S>(mut self, names: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.extra_optimizers = names.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Add a single optimizer pass to the extra-optimizer list.
+    pub fn extra_optimizer<S: Into<String>>(mut self, name: S) -> Self {
+        self.extra_optimizers.push(name.into());
+        self
+    }
+
     /// Add a FunctionProto-based rewrite rule, matched and applied by onnxsim's
     /// C++ core inside the simplification fixed point.
     ///
@@ -272,6 +305,7 @@ pub fn simplify(model_bytes: &[u8]) -> Result<Vec<u8>, Error> {
 /// Returns the serialized simplified model.
 pub fn simplify_with(model_bytes: &[u8], options: &Options) -> Result<Vec<u8>, Error> {
     let ffi = FfiSkipOptimizers::new(options)?;
+    let extra = FfiExtraOptimizers::new(options)?;
 
     let mut out_data: *mut c_void = ptr::null_mut();
     let mut out_size: usize = 0;
@@ -289,6 +323,8 @@ pub fn simplify_with(model_bytes: &[u8], options: &Options) -> Result<Vec<u8>, E
                 bool_to_c(options.shape_inference),
                 options.tensor_size_threshold,
                 target_opset_to_c(options.target_opset_version),
+                extra.ptr(),
+                extra.len(),
                 None,
                 None,
                 ptr::null_mut(),
@@ -327,6 +363,8 @@ pub fn simplify_with(model_bytes: &[u8], options: &Options) -> Result<Vec<u8>, E
                 replacement_ptrs.as_ptr(),
                 replacement_sizes.as_ptr(),
                 rules.len(),
+                extra.ptr(),
+                extra.len(),
                 &mut out_data,
                 &mut out_size,
                 &mut out_error,
@@ -371,6 +409,7 @@ pub fn simplify_path_with<P: AsRef<Path>, Q: AsRef<Path>>(
     let in_c = path_to_cstring(input_path.as_ref())?;
     let out_c = path_to_cstring(output_path.as_ref())?;
     let ffi = FfiSkipOptimizers::new(options)?;
+    let extra = FfiExtraOptimizers::new(options)?;
 
     let mut out_error: *mut c_char = ptr::null_mut();
     let status = unsafe {
@@ -384,6 +423,8 @@ pub fn simplify_path_with<P: AsRef<Path>, Q: AsRef<Path>>(
             bool_to_c(options.shape_inference),
             options.tensor_size_threshold,
             target_opset_to_c(options.target_opset_version),
+            extra.ptr(),
+            extra.len(),
             None,
             None,
             ptr::null_mut(),
@@ -537,6 +578,7 @@ where
         panicked: false,
     };
     let ffi = FfiSkipOptimizers::new(options)?;
+    let extra = FfiExtraOptimizers::new(options)?;
 
     let mut out_data: *mut c_void = ptr::null_mut();
     let mut out_size: usize = 0;
@@ -553,6 +595,8 @@ where
             bool_to_c(options.shape_inference),
             options.tensor_size_threshold,
             target_opset_to_c(options.target_opset_version),
+            extra.ptr(),
+            extra.len(),
             Some(rewrite_trampoline),
             Some(rewrite_free_trampoline),
             &mut state as *mut RewriterState as *mut c_void,
@@ -598,6 +642,7 @@ where
         panicked: false,
     };
     let ffi = FfiSkipOptimizers::new(options)?;
+    let extra = FfiExtraOptimizers::new(options)?;
 
     let mut out_error: *mut c_char = ptr::null_mut();
     let status = unsafe {
@@ -611,6 +656,8 @@ where
             bool_to_c(options.shape_inference),
             options.tensor_size_threshold,
             target_opset_to_c(options.target_opset_version),
+            extra.ptr(),
+            extra.len(),
             Some(rewrite_trampoline),
             Some(rewrite_free_trampoline),
             &mut state as *mut RewriterState as *mut c_void,
@@ -631,6 +678,25 @@ where
 /// [`Options::skip_optimizers`].
 pub fn list_optimizers() -> Vec<String> {
     let raw = unsafe { onnxsim_sys::onnxsim_list_optimizers() };
+    if raw.is_null() {
+        return Vec::new();
+    }
+    let text = unsafe { CStr::from_ptr(raw) }
+        .to_string_lossy()
+        .into_owned();
+    unsafe { onnxsim_sys::onnxsim_free_string(raw) };
+    text.lines()
+        .filter(|line| !line.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+/// Return the names of the optimizer passes registered but NOT in the default
+/// fuse/elimination set (typically `PassType::Other`, e.g.
+/// `defuse_matmul_integer_to_float`) -- the names accepted by
+/// [`Options::extra_optimizer`] and [`Options::extra_optimizers`].
+pub fn list_other_optimizers() -> Vec<String> {
+    let raw = unsafe { onnxsim_sys::onnxsim_list_other_optimizers() };
     if raw.is_null() {
         return Vec::new();
     }
@@ -917,6 +983,47 @@ impl FfiSkipOptimizers {
 
     fn is_null_flag(&self) -> c_int {
         bool_to_c(self.is_null)
+    }
+}
+
+/// Owns the `CString`s and pointer array backing the `extra_optimizers` FFI
+/// arguments, keeping them alive for the duration of a call. Unlike
+/// [`FfiSkipOptimizers`] there is no null/empty distinction: an empty list
+/// already means "no extra passes".
+struct FfiExtraOptimizers {
+    // `_owned` keeps the C strings alive; `ptrs` points into them.
+    _owned: Vec<CString>,
+    ptrs: Vec<*const c_char>,
+}
+
+impl FfiExtraOptimizers {
+    fn new(options: &Options) -> Result<Self, Error> {
+        let mut owned = Vec::with_capacity(options.extra_optimizers.len());
+        for name in &options.extra_optimizers {
+            let c = CString::new(name.as_str()).map_err(|_| {
+                Error::InvalidArgument(format!(
+                    "optimizer name contains an interior NUL byte: {name:?}"
+                ))
+            })?;
+            owned.push(c);
+        }
+        let ptrs = owned.iter().map(|c| c.as_ptr()).collect();
+        Ok(FfiExtraOptimizers {
+            _owned: owned,
+            ptrs,
+        })
+    }
+
+    fn ptr(&self) -> *const *const c_char {
+        if self.ptrs.is_empty() {
+            ptr::null()
+        } else {
+            self.ptrs.as_ptr()
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.ptrs.len()
     }
 }
 
@@ -1360,6 +1467,7 @@ where
         panicked: false,
     };
     let ffi = FfiSkipOptimizers::new(options)?;
+    let extra = FfiExtraOptimizers::new(options)?;
 
     let mut out_data: *mut c_void = ptr::null_mut();
     let mut out_size: usize = 0;
@@ -1376,6 +1484,8 @@ where
             bool_to_c(options.shape_inference),
             options.tensor_size_threshold,
             target_opset_to_c(options.target_opset_version),
+            extra.ptr(),
+            extra.len(),
             None,
             None,
             ptr::null_mut(),
@@ -1456,8 +1566,56 @@ mod tests {
         assert!(opts.constant_folding);
         assert!(opts.shape_inference);
         assert_eq!(opts.skip_optimizers, Some(Vec::new()));
+        assert!(opts.extra_optimizers.is_empty());
         assert_eq!(opts.tensor_size_threshold, DEFAULT_TENSOR_SIZE_THRESHOLD);
         assert_eq!(opts.target_opset_version, None);
+    }
+
+    #[test]
+    fn extra_optimizer_appends() {
+        let opts = Options::new()
+            .extra_optimizer("replace_einsum_with_matmul")
+            .extra_optimizer("defuse_matmul_integer_to_float");
+        assert_eq!(
+            opts.extra_optimizers,
+            vec![
+                "replace_einsum_with_matmul".to_string(),
+                "defuse_matmul_integer_to_float".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn extra_optimizers_replaces_list() {
+        let opts = Options::new()
+            .extra_optimizer("a")
+            .extra_optimizers(["b", "c"]);
+        assert_eq!(
+            opts.extra_optimizers,
+            vec!["b".to_string(), "c".to_string()]
+        );
+    }
+
+    #[test]
+    fn ffi_extra_optimizers_layout() {
+        let opts = Options::new().extra_optimizers(["a", "bb"]);
+        let ffi = FfiExtraOptimizers::new(&opts).unwrap();
+        assert_eq!(ffi.len(), 2);
+        assert!(!ffi.ptr().is_null());
+
+        let empty = Options::new();
+        let ffi_empty = FfiExtraOptimizers::new(&empty).unwrap();
+        assert_eq!(ffi_empty.len(), 0);
+        assert!(ffi_empty.ptr().is_null());
+    }
+
+    #[test]
+    fn extra_optimizer_interior_nul_is_rejected() {
+        let opts = Options::new().extra_optimizer("bad\0name");
+        assert!(matches!(
+            FfiExtraOptimizers::new(&opts),
+            Err(Error::InvalidArgument(_))
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #769, which added the `extra_optimizers` opt-in API (the counterpart to `skip_optimizers`, letting a caller request a pass registered outside the default fuse/elimination set — e.g. `defuse_matmul_integer_to_float`) to the C++ core, Python binding, and CLI, but explicitly scoped out the C API and Rust wrapper as a "natural follow-up." This PR closes that gap.

- **C API** (`onnxsim/capi/onnxsim_c_api.h`/`.cpp`): added `extra_optimizers`/`num_extra_optimizers` parameters to `onnxsim_simplify`, `onnxsim_simplify_with_executor`, `onnxsim_simplify_with_rules`, and `onnxsim_simplify_path`. Unlike `skip_optimizers`, there's no separate "is_null" flag — a count of `0` already means "no extra passes," matching the C++ core's `std::nullopt` semantics exactly. Added `onnxsim_list_other_optimizers()`, mirroring `onnxsim_list_optimizers()` for the non-default set.
- **`onnxsim-sys`**: mirrors the new C signatures 1:1 and adds the `onnxsim_list_other_optimizers` binding.
- **`onnxsim` (Rust)**: `Options` gains `extra_optimizer()`/`extra_optimizers()` builder methods (mirroring `skip_optimizer()`/`skip_optimizers()`), and a new `list_other_optimizers()` function. A new `FfiExtraOptimizers` helper (mirroring the existing `FfiSkipOptimizers`) threads the new arguments through every FFI call site: `simplify_with`, `simplify_path_with`, `simplify_with_rewriter`, `simplify_path_with_rewriter`, and `simplify_with_executor`.
- `rust/README.md` updated with an example.

## Test plan

- Built `onnxsim_c` from source against a prebuilt ONNX Runtime release (`ONNXSIM_PREBUILT_ORT=1`, via `cargo build --workspace` — avoids compiling ORT from source) to get a real, working native library rather than just type-checking.
- Ran the full Rust workspace test suite, including the `#[ignore]`d integration tests, against that real library (`cargo test --workspace -- --include-ignored` with `ONNXSIM_LIB_DIR`/`ONNXSIM_TEST_MODEL` set): all pass.
- `cargo clippy --workspace --all-targets`: clean.
- Wrote a throwaway example exercising the new API end-to-end against a real `Einsum` model: confirmed `list_other_optimizers()` reports `replace_einsum_with_matmul`/`defuse_matmul_integer_to_float` (and `list_optimizers()` does not), that `Options::extra_optimizer("replace_einsum_with_matmul")` actually rewrites `Einsum` → `MatMul` (verified by parsing the returned `ModelProto` with `onnx.load`, not just a byte-substring check, which turned out to false-positive on unrelated bytes), and that an unknown pass name errors. Also cross-checked the raw C ABI directly via Python `ctypes` against the compiled `.so` to rule out a Rust-FFI-layer bug independently of the C++ core logic.
- `clang-format --dry-run --Werror` over the full C/C++ file set: clean. No Python files touched, so `ruff`/`mypy`/the Python test suite are unaffected.

https://claude.ai/code/session_01TwY4Kx5PFkJwgpbgdr3CQf


---
_Generated by [Claude Code](https://claude.ai/code/session_01TwY4Kx5PFkJwgpbgdr3CQf)_