### PR TITLE
Migrate tests/test_precision_estimator.py to onnx.parser

### DIFF
--- a/tests/test_precision_estimator.py
+++ b/tests/test_precision_estimator.py
@@ -1,16 +1,16 @@
 """Tests for ``onnxsim.estimate_quantization_precision`` (onnxsim/precision_estimator.py).
 
 Pure Python, read-only analysis -- no C++ extension involved -- so these
-models are built directly with ``onnx.helper`` and never run through an
-inference engine.
+models are built directly with the ONNX text format parser (``onnx.parser``)
+and never run through an inference engine.
 """
 
 import math
 
 import numpy as np
 import onnx
-import onnx.helper
 import onnx.numpy_helper
+from onnx import parser
 
 import onnxsim
 from onnxsim.precision_estimator import (
@@ -23,27 +23,39 @@ from onnxsim.precision_estimator import (
 )
 
 
-def _vi(name, shape):
-    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
-
-
 def _f32(array, name):
     return onnx.numpy_helper.from_array(np.asarray(array, dtype=np.float32), name)
 
 
-def _model(nodes, inputs, outputs, initializer, opset=17):
-    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
-    return onnx.helper.make_model(
-        graph, opset_imports=[onnx.helper.make_opsetid("", opset)]
+def _model(body, initializer=(), opset=17):
+    model = parser.parse_model(
+        f"""
+        <
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
     )
+    model.graph.initializer.extend(initializer)
+    # Left at the default (not pinned), matching the original onnx.helper.make_model
+    # calls here, which never passed ir_version either.
+    model.ir_version = onnx.IR_VERSION
+    return model
 
 
 def test_matmul_small_reduction_depth_is_safe_and_exact():
     rng = np.random.default_rng(0)
     K, N = 16, 4
     weight = _f32(rng.standard_normal((K, N)) * 0.1, "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [1, K])], [_vi("Y", [1, N])], [weight])
+    model = _model(
+        f"""
+        g (float[1,{K}] X) => (float[1,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[weight],
+    )
 
     estimates = onnxsim.estimate_quantization_precision(model)
     assert len(estimates) == 1
@@ -60,8 +72,15 @@ def test_matmul_small_reduction_depth_is_safe_and_exact():
 def test_matmul_reduction_depth_past_int32_bound_is_unsafe():
     k = MAX_SAFE_INT32_REDUCTION_DEPTH + 1
     weight = _f32(np.random.default_rng(1).standard_normal((k, 1)) * 0.01, "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [1, k])], [_vi("Y", [1, 1])], [weight])
+    model = _model(
+        f"""
+        g (float[1,{k}] X) => (float[1,1] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[weight],
+    )
 
     (est,) = onnxsim.estimate_quantization_precision(model)
     assert not est.int32_accumulator_safe
@@ -72,8 +91,15 @@ def test_matmul_reduction_depth_past_float32_exact_bound_but_int32_safe():
     k = MAX_EXACT_FLOAT32_REDUCTION_DEPTH + 1
     assert k <= MAX_SAFE_INT32_REDUCTION_DEPTH  # sanity: still int32-safe
     weight = _f32(np.random.default_rng(2).standard_normal((k, 1)) * 0.01, "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [1, k])], [_vi("Y", [1, 1])], [weight])
+    model = _model(
+        f"""
+        g (float[1,{k}] X) => (float[1,1] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[weight],
+    )
 
     (est,) = onnxsim.estimate_quantization_precision(model)
     assert est.int32_accumulator_safe
@@ -87,8 +113,15 @@ def test_matmul_outlier_channel_is_flagged():
     weight = rng.standard_normal((K, N)).astype(np.float32) * 0.05
     weight[:, 1] = 0.01  # channel 1: uniform small weights ...
     weight[0, 1] = 10.0  # ... plus one extreme outlier
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [1, K])], [_vi("Y", [1, N])], [_f32(weight, "W")])
+    model = _model(
+        f"""
+        g (float[1,{K}] X) => (float[1,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[_f32(weight, "W")],
+    )
 
     (est,) = onnxsim.estimate_quantization_precision(model)
     assert est.outlier_risk
@@ -99,8 +132,15 @@ def test_gemm_transb_reduction_depth_uses_transposed_layout():
     # PyTorch nn.Linear layout: weight [out_features, in_features] = [N, K].
     N, K = 4, 20
     weight = _f32(np.random.default_rng(4).standard_normal((N, K)) * 0.1, "W")
-    nodes = [onnx.helper.make_node("Gemm", ["X", "W"], ["Y"], transB=1)]
-    model = _model(nodes, [_vi("X", [1, K])], [_vi("Y", [1, N])], [weight])
+    model = _model(
+        f"""
+        g (float[1,{K}] X) => (float[1,{N}] Y)
+        {{
+          Y = Gemm<transB = 1>(X, W)
+        }}
+        """,
+        initializer=[weight],
+    )
 
     (est,) = onnxsim.estimate_quantization_precision(model)
     assert est.op_type == "Gemm"
@@ -113,10 +153,15 @@ def test_conv_reduction_depth_is_cin_times_kernel_volume():
     weight = _f32(
         np.random.default_rng(5).standard_normal((cout, cin, kh, kw)) * 0.1, "W"
     )
-    x = _vi("X", [1, cin, 16, 16])
-    y = _vi("Y", [1, cout, 12, 12])
-    nodes = [onnx.helper.make_node("Conv", ["X", "W"], ["Y"])]
-    model = _model(nodes, [x], [y], [weight])
+    model = _model(
+        f"""
+        g (float[1,{cin},16,16] X) => (float[1,{cout},12,12] Y)
+        {{
+          Y = Conv(X, W)
+        }}
+        """,
+        initializer=[weight],
+    )
 
     (est,) = onnxsim.estimate_quantization_precision(model)
     assert isinstance(est, ConvPrecisionEstimate)
@@ -126,19 +171,17 @@ def test_conv_reduction_depth_is_cin_times_kernel_volume():
 
 def test_attention_reports_head_dim_and_flags_scale_mismatch():
     q_heads, kv_heads, head_dim, sq, skv = 4, 4, 8, 6, 6
-    q = _vi("Q", [1, sq, q_heads * head_dim])
-    k = _vi("K", [1, skv, kv_heads * head_dim])
-    v = _vi("V", [1, skv, kv_heads * head_dim])
-    out = _vi("O", [1, sq, q_heads * head_dim])
-    node = onnx.helper.make_node(
-        "Attention",
-        ["Q", "K", "V"],
-        ["O"],
-        q_num_heads=q_heads,
-        kv_num_heads=kv_heads,
-        scale=1.0,  # deliberately not 1/sqrt(head_dim)
+    qh, kvh = q_heads * head_dim, kv_heads * head_dim
+    # scale=1.0 is deliberately not 1/sqrt(head_dim).
+    model = _model(
+        f"""
+        g (float[1,{sq},{qh}] Q, float[1,{skv},{kvh}] K, float[1,{skv},{kvh}] V) => (float[1,{sq},{qh}] O)
+        {{
+          O = Attention<q_num_heads = {q_heads}, kv_num_heads = {kv_heads}, scale = 1.0>(Q, K, V)
+        }}
+        """,
+        opset=23,
     )
-    model = _model([node], [q, k, v], [out], [], opset=23)
 
     (est,) = onnxsim.estimate_quantization_precision(model)
     assert isinstance(est, AttentionPrecisionEstimate)
@@ -152,18 +195,16 @@ def test_attention_reports_head_dim_and_flags_scale_mismatch():
 
 def test_attention_scale_matching_default_is_not_flagged():
     q_heads, kv_heads, head_dim, sq, skv = 2, 2, 16, 4, 4
-    q = _vi("Q", [1, sq, q_heads * head_dim])
-    k = _vi("K", [1, skv, kv_heads * head_dim])
-    v = _vi("V", [1, skv, kv_heads * head_dim])
-    out = _vi("O", [1, sq, q_heads * head_dim])
-    node = onnx.helper.make_node(
-        "Attention",
-        ["Q", "K", "V"],
-        ["O"],
-        q_num_heads=q_heads,
-        kv_num_heads=kv_heads,
+    qh, kvh = q_heads * head_dim, kv_heads * head_dim
+    model = _model(
+        f"""
+        g (float[1,{sq},{qh}] Q, float[1,{skv},{kvh}] K, float[1,{skv},{kvh}] V) => (float[1,{sq},{qh}] O)
+        {{
+          O = Attention<q_num_heads = {q_heads}, kv_num_heads = {kv_heads}>(Q, K, V)
+        }}
+        """,
+        opset=23,
     )
-    model = _model([node], [q, k, v], [out], [], opset=23)
 
     (est,) = onnxsim.estimate_quantization_precision(model)
     assert est.actual_scale is None
@@ -174,9 +215,16 @@ def test_attention_scale_matching_default_is_not_flagged():
 def test_matmul_fed_by_softmax_reports_known_activation_range():
     K, N = 32, 4
     weight = _f32(np.random.default_rng(7).standard_normal((K, N)) * 0.1, "W")
-    softmax = onnx.helper.make_node("Softmax", ["X"], ["S"], axis=-1)
-    matmul = onnx.helper.make_node("MatMul", ["S", "W"], ["Y"])
-    model = _model([softmax, matmul], [_vi("X", [1, K])], [_vi("Y", [1, N])], [weight])
+    model = _model(
+        f"""
+        g (float[1,{K}] X) => (float[1,{N}] Y)
+        {{
+          S = Softmax<axis = -1>(X)
+          Y = MatMul(S, W)
+        }}
+        """,
+        initializer=[weight],
+    )
 
     (est,) = onnxsim.estimate_quantization_precision(model)
     assert est.activation_producer_op == "Softmax"
@@ -193,13 +241,17 @@ def test_conv_fed_by_clip_with_constant_bounds_reports_range():
     weight = _f32(
         np.random.default_rng(8).standard_normal((cout, cin, kh, kw)) * 0.1, "W"
     )
-    lo = _f32(np.array(0.0), "lo")
-    hi = _f32(np.array(6.0), "hi")
-    clip = onnx.helper.make_node("Clip", ["X", "lo", "hi"], ["C"])
-    conv = onnx.helper.make_node("Conv", ["C", "W"], ["Y"])
-    x = _vi("X", [1, cin, 8, 8])
-    y = _vi("Y", [1, cout, 6, 6])
-    model = _model([clip, conv], [x], [y], [weight, lo, hi])
+    model = _model(
+        f"""
+        g (float[1,{cin},8,8] X) => (float[1,{cout},6,6] Y)
+        <float lo = {{0.0}}, float hi = {{6.0}}>
+        {{
+          C = Clip(X, lo, hi)
+          Y = Conv(C, W)
+        }}
+        """,
+        initializer=[weight],
+    )
 
     (est,) = onnxsim.estimate_quantization_precision(model)
     assert est.activation_producer_op == "Clip"
@@ -210,14 +262,16 @@ def test_clip_with_non_constant_bound_is_not_reported_as_known_range():
     # max ("hi") is a runtime activation, not a constant -- the range isn't
     # analytically fixed, so this must NOT be reported as known.
     weight = _f32(np.random.default_rng(9).standard_normal((16, 4)) * 0.1, "W")
-    clip = onnx.helper.make_node("Clip", ["X", "lo", "hi"], ["C"])
-    matmul = onnx.helper.make_node("MatMul", ["C", "W"], ["Y"])
-    lo = _f32(np.array(0.0), "lo")
     model = _model(
-        [clip, matmul],
-        [_vi("X", [1, 16]), _vi("hi", [])],
-        [_vi("Y", [1, 4])],
-        [weight, lo],
+        """
+        g (float[1,16] X, float hi) => (float[1,4] Y)
+        <float lo = {0.0}>
+        {
+          C = Clip(X, lo, hi)
+          Y = MatMul(C, W)
+        }
+        """,
+        initializer=[weight],
     )
 
     (est,) = onnxsim.estimate_quantization_precision(model)
@@ -229,9 +283,16 @@ def test_matmul_fed_by_relu_has_no_known_fixed_range():
     # Relu is only bounded on one side (non-negative, unbounded above), so it
     # doesn't qualify for a fixed (lo, hi) static-quantization range.
     weight = _f32(np.random.default_rng(10).standard_normal((16, 4)) * 0.1, "W")
-    relu = onnx.helper.make_node("Relu", ["X"], ["R"])
-    matmul = onnx.helper.make_node("MatMul", ["R", "W"], ["Y"])
-    model = _model([relu, matmul], [_vi("X", [1, 16])], [_vi("Y", [1, 4])], [weight])
+    model = _model(
+        """
+        g (float[1,16] X) => (float[1,4] Y)
+        {
+          R = Relu(X)
+          Y = MatMul(R, W)
+        }
+        """,
+        initializer=[weight],
+    )
 
     (est,) = onnxsim.estimate_quantization_precision(model)
     assert est.activation_producer_op is None
@@ -239,19 +300,30 @@ def test_matmul_fed_by_relu_has_no_known_fixed_range():
 
 
 def test_non_constant_weight_and_unrelated_ops_are_skipped():
-    nodes = [
-        onnx.helper.make_node("MatMul", ["X", "W"], ["Y"]),  # W not a constant
-        onnx.helper.make_node("Relu", ["Y"], ["Z"]),
-    ]
-    model = _model(nodes, [_vi("X", [1, 8]), _vi("W", [8, 4])], [_vi("Z", [1, 4])], [])
+    model = _model(
+        """
+        g (float[1,8] X, float[8,4] W) => (float[1,4] Z)
+        {
+          Y = MatMul(X, W)
+          Z = Relu(Y)
+        }
+        """
+    )
     assert onnxsim.estimate_quantization_precision(model) == []
 
 
 def test_never_modifies_the_model():
     rng = np.random.default_rng(6)
     weight = _f32(rng.standard_normal((8, 4)) * 0.1, "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [1, 8])], [_vi("Y", [1, 4])], [weight])
+    model = _model(
+        """
+        g (float[1,8] X) => (float[1,4] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """,
+        initializer=[weight],
+    )
     before = model.SerializeToString()
     onnxsim.estimate_quantization_precision(model)
     assert model.SerializeToString() == before
@@ -266,8 +338,15 @@ def test_model_drop_safe_with_no_outliers():
     # uniform-quantizer-noise baseline case, with no outlier-driven penalty.
     K, N = 16, 4
     weight = np.tile([0.1, -0.1], (K // 2, N)).astype(np.float32)
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [1, K])], [_vi("Y", [1, N])], [_f32(weight, "W")])
+    model = _model(
+        f"""
+        g (float[1,{K}] X) => (float[1,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[_f32(weight, "W")],
+    )
 
     est = onnxsim.estimate_model_quantization_drop(model)
     assert est.total_nodes_analyzed == 1
@@ -288,8 +367,15 @@ def test_model_drop_degraded_when_outlier_channel_present():
     weight = rng.standard_normal((K, N)).astype(np.float32) * 0.05
     weight[:, 1] = 0.01
     weight[0, 1] = 10.0  # channel 1: a single extreme outlier
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [1, K])], [_vi("Y", [1, N])], [_f32(weight, "W")])
+    model = _model(
+        f"""
+        g (float[1,{K}] X) => (float[1,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[_f32(weight, "W")],
+    )
 
     est = onnxsim.estimate_model_quantization_drop(model)
     assert est.risk_level == "degraded"
@@ -304,8 +390,15 @@ def test_model_drop_degraded_when_outlier_channel_present():
 def test_model_drop_unsafe_reports_nan_error_and_lists_the_node():
     k = MAX_SAFE_INT32_REDUCTION_DEPTH + 1
     weight = _f32(np.random.default_rng(22).standard_normal((k, 1)) * 0.01, "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [1, k])], [_vi("Y", [1, 1])], [weight])
+    model = _model(
+        f"""
+        g (float[1,{k}] X) => (float[1,1] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[weight],
+    )
 
     est = onnxsim.estimate_model_quantization_drop(model)
     assert est.risk_level == "unsafe"
@@ -320,14 +413,25 @@ def test_model_drop_more_unsafe_nodes_widen_the_aggregate_error():
     K, N = 16, 4
     w1 = _f32(rng.standard_normal((K, N)) * 0.1, "W1")
     w2 = _f32(rng.standard_normal((K, N)) * 0.1, "W2")
-    nodes = [
-        onnx.helper.make_node("MatMul", ["X", "W1"], ["Y1"]),
-        onnx.helper.make_node("MatMul", ["X", "W2"], ["Y2"]),
-    ]
     model = _model(
-        nodes, [_vi("X", [1, K])], [_vi("Y1", [1, N]), _vi("Y2", [1, N])], [w1, w2]
+        f"""
+        g (float[1,{K}] X) => (float[1,{N}] Y1, float[1,{N}] Y2)
+        {{
+          Y1 = MatMul(X, W1)
+          Y2 = MatMul(X, W2)
+        }}
+        """,
+        initializer=[w1, w2],
     )
-    one_node_model = _model([nodes[0]], [_vi("X", [1, K])], [_vi("Y1", [1, N])], [w1])
+    one_node_model = _model(
+        f"""
+        g (float[1,{K}] X) => (float[1,{N}] Y1)
+        {{
+          Y1 = MatMul(X, W1)
+        }}
+        """,
+        initializer=[w1],
+    )
 
     est_two = onnxsim.estimate_model_quantization_drop(model)
     est_one = onnxsim.estimate_model_quantization_drop(one_node_model)
@@ -337,10 +441,12 @@ def test_model_drop_more_unsafe_nodes_widen_the_aggregate_error():
 
 def test_model_drop_no_analyzable_nodes_is_safe_with_zero_error():
     model = _model(
-        [onnx.helper.make_node("Relu", ["X"], ["Y"])],
-        [_vi("X", [1, 4])],
-        [_vi("Y", [1, 4])],
-        [],
+        """
+        g (float[1,4] X) => (float[1,4] Y)
+        {
+          Y = Relu(X)
+        }
+        """
     )
     est = onnxsim.estimate_model_quantization_drop(model)
     assert est.total_nodes_analyzed == 0


### PR DESCRIPTION
Continuation of the `onnx.parser`-based test readability migration (#768, #771, #772, #773, #776), applied to `tests/test_precision_estimator.py`.

## Summary
- Replaces the file's `onnx.helper.make_node`/`make_graph`/`make_model` boilerplate with `onnx.parser.parse_model`'s ONNX text form, via a `_model(body, initializer=(), opset=17)` helper matching the previous migrations' pattern.
- This file's `_model` never pinned `ir_version` (unlike the other migrated files), so the helper leaves it at the installed `onnx` package's default (`onnx.IR_VERSION`) rather than hardcoding a value, preserving the original behavior exactly.
- Random weight initializers stay numpy-built and attached to the parsed graph programmatically; small fixed constants (`Clip`'s `lo`/`hi` bounds) are written as text literals since they're not random.
- One test (`test_clip_with_non_constant_bound_is_not_reported_as_known_range`) declares a genuine rank-0 scalar graph *input* (`hi`, not an initializer) directly in the text signature -- verified this parses to the same empty-shape tensor type `onnx.helper.make_tensor_value_info(..., shape=[])` produced.
- All 19 tests are unchanged in behavior/coverage -- same test names, same assertions.

## Testing
- `ruff check tests/test_precision_estimator.py` -- clean.
- `pytest tests/test_precision_estimator.py` against a locally built `onnxsim` -- 19 passed, run multiple times to rule out flakiness from the random weight data.

https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7

---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_