### PR TITLE
Broaden LoRA layer coverage and add QLoRA support to onnx-finetune

### DIFF
--- a/.github/workflows/onnx-finetune-lora.yml
+++ b/.github/workflows/onnx-finetune-lora.yml
@@ -1,0 +1,73 @@
+name: onnx-finetune LoRA/QLoRA
+
+# tools/onnx-finetune's LoRA/QLoRA scripts (inject_lora.py, extract_lora_
+# adapter.py, apply_lora_adapter.py, prepare_qlora.py, lora_surgery.py) are
+# pure graph-surgery: unlike generate_artifacts.py/onnx-finetune itself (see
+# ../README.md), they need no training-enabled onnxruntime build -- so they
+# get their own lightweight, fast job here rather than piggybacking on a
+# full native build.
+#
+# lora-scripts (ubuntu-slim) covers the LoRA graph surgery itself (MatMul,
+# Gemm with any transA/transB, 1x1/group=1 Conv) with only onnx + numpy +
+# pytest installed -- no compiled onnxsim extension needed.
+#
+# lora-scripts-with-qlora additionally builds this repo's own onnxsim wheel
+# (ONNXSIM_BUILTIN_ORT=OFF, the same wheel-build path setup.py always uses --
+# see the top-level CLAUDE.md note that this does NOT build ONNX Runtime) so
+# prepare_qlora.py's onnxsim.nf4 integration -- the part that actually needs
+# onnxsim importable -- gets exercised for real instead of always skipping.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "tools/onnx-finetune/**"
+      - "onnxsim/nf4.py"
+      - "onnxsim/bias_correction.py"
+      - ".github/workflows/onnx-finetune-lora.yml"
+  push:
+    branches: [master]
+    paths:
+      - "tools/onnx-finetune/**"
+      - "onnxsim/nf4.py"
+      - "onnxsim/bias_correction.py"
+
+concurrency:
+  group: onnx-finetune-lora-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lora-scripts:
+    name: LoRA graph surgery (onnx + numpy only)
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: false
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+      - name: Install deps
+        run: pip install onnx numpy pytest
+      - name: pytest tools/onnx-finetune/tests
+        run: pytest tools/onnx-finetune/tests -v
+
+  lora-scripts-with-qlora:
+    name: LoRA + QLoRA (builds this repo's own onnxsim wheel)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+      - name: Install build + test deps
+        run: pip install nanobind pytest
+      - name: Build and install onnxsim (ONNXSIM_BUILTIN_ORT=OFF -- no ONNX Runtime build, see CLAUDE.md)
+        run: pip install -e . --no-build-isolation
+      - name: pytest tools/onnx-finetune/tests (including the onnxsim.nf4 / prepare_qlora.py path)
+        run: pytest tools/onnx-finetune/tests -v

--- a/.gitignore
+++ b/.gitignore
@@ -142,8 +142,10 @@ dmypy.json
 compile_commands.json
 temp*.py
 test*.py
-# ...but the real test suite under tests/ is tracked.
+# ...but the real test suites under tests/ and tools/onnx-finetune/tests/ are
+# tracked.
 !tests/test*.py
+!tools/onnx-finetune/tests/test*.py
 
 .setuptools-cmake-build/
 onnxsim/version.py

--- a/onnxsim/nf4.py
+++ b/onnxsim/nf4.py
@@ -46,7 +46,7 @@ variant is a possible future addition, not attempted here.
 
 from __future__ import annotations
 
-from typing import List, Union
+from typing import Iterable, List, Optional, Union
 
 import numpy as np
 import onnx
@@ -137,7 +137,9 @@ def _quantize_nf4_blockwise(
 
 
 def quantize_weight_only_nf4(
-    model: Union[str, onnx.ModelProto], block_size: int = 64
+    model: Union[str, onnx.ModelProto],
+    block_size: int = 64,
+    skip_names: Optional[Iterable[str]] = None,
 ) -> onnx.ModelProto:
     """Quantizes every MatMul/vanilla-Gemm layer with a constant 2-D
     float32 weight (whose reduction dimension ``K`` is evenly divisible by
@@ -150,6 +152,12 @@ def quantize_weight_only_nf4(
     :param block_size: elements per (output-channel, block) scale group
             along the reduction dimension; bitsandbytes' own QLoRA default
             is 64 (versus 32 for onnxsim's uniform-grid INT4 schemes)
+    :param skip_names: weight initializer names to leave unquantized even
+            if otherwise eligible -- e.g. QLoRA's own low-rank adapter
+            weights, which the recipe keeps at full precision and would
+            otherwise get caught here too (a LoRA branch is itself a plain
+            MatMul against a small 2-D initializer, indistinguishable from
+            any other layer's weight by shape alone)
     :returns: ``model`` with every matched layer's weight replaced by
             ``Mul(Reshape(Gather(codebook, Cast(Wq, INT64)), ...), Ws) ->
             Reshape(..., original shape)`` feeding the original MatMul/Gemm
@@ -160,6 +168,7 @@ def quantize_weight_only_nf4(
     """
     if isinstance(model, str):
         model = onnx.load(model, load_external_data=False)
+    skip_names = set(skip_names) if skip_names is not None else frozenset()
 
     out = onnx.ModelProto()
     out.CopyFrom(model)
@@ -174,6 +183,8 @@ def quantize_weight_only_nf4(
         if match is None:
             continue
         w_name, weight_transposed = match
+        if w_name in skip_names:
+            continue
         w_init = initializer_map.get(w_name)
         if (
             w_init is None

--- a/tests/test_nf4.py
+++ b/tests/test_nf4.py
@@ -153,6 +153,39 @@ def test_nf4_skips_non_block_divisible_k():
     assert nf4_model.SerializeToString() == model.SerializeToString()
 
 
+def test_nf4_skip_names_leaves_matched_weight_untouched():
+    # QLoRA freezes the base weight (quantized here) but keeps its own
+    # low-rank adapter weights -- structurally indistinguishable plain
+    # MatMul-against-a-2-D-initializer layers -- at full precision.
+    rng = np.random.default_rng(7)
+    w_base = rng.standard_normal((64, 16)).astype(np.float32) * 0.5
+    w_lora_a = rng.standard_normal((64, 4)).astype(np.float32) * 0.1
+    nodes = [
+        onnx.helper.make_node("MatMul", ["X", "W"], ["Y"]),
+        onnx.helper.make_node("MatMul", ["X", "W_lora_A"], ["H"]),
+    ]
+    model = _model(
+        nodes,
+        [_vi("X", ["batch", 64])],
+        [_vi("Y", ["batch", 16]), _vi("H", ["batch", 4])],
+        [_f32(w_base, "W"), _f32(w_lora_a, "W_lora_A")],
+    )
+    nf4_model = onnxsim.quantize_weight_only_nf4(
+        model, block_size=64, skip_names=["W_lora_A"]
+    )
+    onnx.checker.check_model(nf4_model)
+
+    names = {t.name for t in nf4_model.graph.initializer}
+    assert "W_nf4_q" in names  # base weight was quantized
+    assert "W_lora_A_nf4_q" not in names  # adapter weight was not
+    lora_a_out = next(
+        onnx.numpy_helper.to_array(t)
+        for t in nf4_model.graph.initializer
+        if t.name == "W_lora_A"
+    )
+    assert np.array_equal(lora_a_out, w_lora_a)  # untouched, byte-for-byte
+
+
 def test_nf4_skips_non_constant_weight():
     nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
     model = _model(

--- a/tools/onnx-finetune/README.md
+++ b/tools/onnx-finetune/README.md
@@ -159,14 +159,48 @@ python3 scripts/apply_lora_adapter.py model.onnx --adapter adapter.onnx \
 `inject_lora.py` adds, per targeted weight `W`, a
 `(alpha/rank) * (X @ lora_A @ lora_B)` branch alongside that layer's existing
 output (`lora_A` Kaiming-normal, `lora_B` zero, so injecting is a no-op until
-trained). `adapter.onnx` from step 4 is not a runnable model by itself --
-it's a plain tensor container holding just the `lora_A`/`lora_B` initializers
--- meant to be re-merged with `apply_lora_adapter.py`, not loaded directly
-into a session. This is a portable, ONNX-native adapter format built on
-these scripts; it is not the same binary format as ONNX Runtime GenAI's
+trained). Eligible layers are MatMul, Gemm (any `transA`/`transB`), and
+1x1/`group=1` Conv (a pointwise conv is just a per-pixel linear layer over
+channels) -- see `scripts/lora_surgery.py`'s own docstring for the exact
+rule. `adapter.onnx` from step 4 is not a runnable model by itself -- it's a
+plain tensor container holding just the `lora_A`/`lora_B` initializers --
+meant to be re-merged with `apply_lora_adapter.py`, not loaded directly into
+a session. This is a portable, ONNX-native adapter format built on these
+scripts; it is not the same binary format as ONNX Runtime GenAI's
 `.onnx_adapter` files (those come out of Olive's `convert-adapters`, for
 loading multiple adapters into one inference session via
 `Ort::LoraAdapter`/`RunOptions`).
+
+### QLoRA (NF4-quantized base + LoRA)
+
+`scripts/prepare_qlora.py` wires the LoRA graph surgery above together with
+`onnxsim.nf4.quantize_weight_only_nf4` (bitsandbytes' NF4 4-bit format, see
+`onnxsim/nf4.py`) to reproduce Dettmers et al. 2023's actual QLoRA recipe:
+freeze a 4-bit-quantized base model and train small full-precision adapters
+on top of its on-the-fly dequantized weights, instead of plain LoRA on an
+unquantized base. It replaces step 1 above; steps 2-5 are unchanged:
+
+```sh
+python3 scripts/prepare_qlora.py model.onnx -o model_qlora.onnx \
+  --rank 4 --block-size 64 --params-out lora.json
+
+python3 scripts/generate_artifacts.py model_qlora.onnx -o artifacts \
+  --lora-params-file lora.json --loss cross-entropy --optimizer adamw
+# ...then train, extract, and re-apply exactly as in the plain-LoRA workflow.
+```
+
+This needs the `onnxsim` package itself importable (build/install this
+repo's own wheel) for the NF4 quantization step -- unlike every other
+onnx-finetune script, which needs only `onnx` + `numpy`. Injection must run
+before quantization (quantizing first leaves nothing recognizable for
+`inject_lora.py`'s graph surgery to graft onto), and `prepare_qlora.py`
+always excludes the newly-injected `lora_A`/`lora_B` weights from
+quantization itself -- structurally they're just another small MatMul
+against a 2-D initializer, indistinguishable from any other layer's weight
+by shape alone, so leaving them eligible would NF4-quantize the adapter too
+and defeat the point of keeping it full precision. NF4 quantization only
+covers 2-D MatMul/vanilla-Gemm weights (see `onnxsim/nf4.py`), so a 1x1-Conv
+LoRA target stays full precision under `prepare_qlora.py` too.
 
 ## CLI reference
 

--- a/tools/onnx-finetune/scripts/inject_lora.py
+++ b/tools/onnx-finetune/scripts/inject_lora.py
@@ -2,11 +2,12 @@
 """Inject trainable LoRA (low-rank adaptation) branches into a bare .onnx
 model, in place of full-parameter fine-tuning.
 
-Every targeted MatMul/Gemm weight stays frozen; a small
+Every targeted MatMul/Gemm/1x1-Conv weight stays frozen; a small
 `(alpha/rank) * (X @ lora_A @ lora_B)` branch is added alongside its output
 (lora_A Kaiming-normal, lora_B zero, so the model is numerically unchanged
 until trained). Feed the output to generate_artifacts.py --lora-params-file
-to train only the injected adapter weights.
+to train only the injected adapter weights. See lora_surgery.py's own
+docstring for exactly which layers are eligible.
 """
 
 import argparse
@@ -37,7 +38,7 @@ def main():
         "--target-contains",
         action="append",
         default=[],
-        help="only target MatMul/Gemm nodes whose 2-D weight initializer name contains this "
+        help="only target MatMul/Gemm/1x1-Conv nodes whose weight initializer name contains this "
         "substring (repeatable). Omit to target every eligible node.",
     )
     p.add_argument("--seed", type=int, default=0)
@@ -56,9 +57,7 @@ def main():
         model, args.target_contains, args.rank, alpha, seed=args.seed
     )
     if not added:
-        sys.exit(
-            "error: no eligible MatMul/Gemm targets matched (2-D weight initializer, non-transposed input)"
-        )
+        sys.exit("error: no eligible MatMul/Gemm/1x1-Conv targets matched")
 
     onnx.checker.check_model(model)
     onnx.save(model, args.output)

--- a/tools/onnx-finetune/scripts/lora_surgery.py
+++ b/tools/onnx-finetune/scripts/lora_surgery.py
@@ -1,47 +1,74 @@
-"""Shared LoRA graph-surgery helpers used by inject_lora.py and
-apply_lora_adapter.py.
+"""Shared LoRA graph-surgery helpers used by inject_lora.py,
+apply_lora_adapter.py and prepare_qlora.py.
 
-Grafts a low-rank adapter branch onto a frozen MatMul/Gemm weight without
-touching the original node or any downstream consumer:
+Grafts a low-rank adapter branch onto a frozen MatMul/Gemm/1x1-Conv weight
+without touching the original node or any downstream consumer:
 
     Y = base_linear(X, W)                      # unchanged, W stays frozen
     Y += (alpha / rank) * (X @ lora_A @ lora_B) # new, small, trainable
 
 lora_A is Kaiming-normal, lora_B is zero, so injecting is a no-op until the
-adapter is actually trained -- the standard LoRA initialization.
+adapter is actually trained -- the standard LoRA initialization. Eligible
+layers:
+
+  - MatMul: any 2-D initializer as input[1]
+  - Gemm: any 2-D initializer as input[1] (any transA/transB)
+  - Conv: a 4-D initializer as input[1] with a 1x1 kernel and group=1
+    (a pointwise conv is just a per-pixel linear layer over channels)
 """
 
 import numpy as np
 from onnx import helper, numpy_helper
 
 
+def _attr_value(node, name, default=None):
+    for attr in node.attribute:
+        if attr.name == name:
+            return attr.i
+    return default
+
+
+def _target_info(initializers, node):
+    """Return (initializer, kind, extra) for an eligible node, or None.
+    kind is "linear" (MatMul/Gemm, extra={"transA", "transB"}) or "conv1x1"
+    (extra={})."""
+    if node.op_type in ("MatMul", "Gemm") and len(node.input) >= 2:
+        init = initializers.get(node.input[1])
+        if init is None or len(init.dims) != 2:
+            return None
+        transA = bool(_attr_value(node, "transA", 0))
+        transB = bool(_attr_value(node, "transB", 0))
+        return init, "linear", {"transA": transA, "transB": transB}
+    if node.op_type == "Conv" and len(node.input) >= 2:
+        init = initializers.get(node.input[1])
+        if init is None or len(init.dims) != 4:
+            return None
+        if tuple(init.dims[2:4]) != (1, 1):
+            return None
+        if _attr_value(node, "group", 1) != 1:
+            return None
+        return init, "conv1x1", {}
+    return None
+
+
 def find_targets(model, name_contains=None, exact_names=None):
-    """Eligible MatMul/Gemm nodes: op has a 2-D initializer as input[1], and
-    (for Gemm) does not transpose input[0]. Returns [(node, initializer,
-    transB)]. `exact_names` (exact initializer name match) takes precedence
-    over `name_contains` (substring match, empty/None means "match all")."""
+    """Eligible MatMul/Gemm/1x1-Conv nodes (see module docstring). Returns
+    [(node, initializer, kind, extra)]. `exact_names` (exact initializer
+    name match) takes precedence over `name_contains` (substring match,
+    empty/None means "match all")."""
     initializers = {i.name: i for i in model.graph.initializer}
     targets = []
     for node in model.graph.node:
-        if node.op_type not in ("MatMul", "Gemm") or len(node.input) < 2:
+        info = _target_info(initializers, node)
+        if info is None:
             continue
-        init = initializers.get(node.input[1])
-        if init is None or len(init.dims) != 2:
-            continue
+        init, kind, extra = info
         if exact_names is not None:
             if init.name not in exact_names:
                 continue
         elif name_contains and not any(s in init.name for s in name_contains):
             continue
-        transA, transB = False, False
-        for attr in node.attribute:
-            if attr.name == "transA":
-                transA = bool(attr.i)
-            elif attr.name == "transB":
-                transB = bool(attr.i)
-        if transA:
-            continue  # unusual for a linear layer; skip rather than guess
-        targets.append((node, init, transB))
+        targets.append((node, init, kind, extra))
     return targets
 
 
@@ -65,20 +92,28 @@ def inject(
     targets = find_targets(model, name_contains, exact_names)
 
     added = []
-    for node, init, transB in targets:
+    for node, init, kind, extra in targets:
         w = numpy_helper.to_array(init)
         dtype = w.dtype
-        in_dim, out_dim = (
-            (w.shape[1], w.shape[0]) if transB else (w.shape[0], w.shape[1])
-        )
-        a_name, b_name = lora_param_names(init.name)
 
+        if kind == "linear":
+            transB = extra["transB"]
+            in_dim, out_dim = (
+                (w.shape[1], w.shape[0]) if transB else (w.shape[0], w.shape[1])
+            )
+            a_shape, b_shape = (in_dim, rank), (rank, out_dim)
+        else:  # conv1x1: weight is [out_channels, in_channels, 1, 1]
+            out_channels, in_channels = w.shape[0], w.shape[1]
+            in_dim = in_channels
+            a_shape, b_shape = (rank, in_channels, 1, 1), (out_channels, rank, 1, 1)
+
+        a_name, b_name = lora_param_names(init.name)
         if lora_values is not None:
             a = np.asarray(lora_values[init.name][0], dtype=dtype)
             b = np.asarray(lora_values[init.name][1], dtype=dtype)
         else:
-            a = (rng.standard_normal((in_dim, rank)) / np.sqrt(in_dim)).astype(dtype)
-            b = np.zeros((rank, out_dim), dtype=dtype)
+            a = (rng.standard_normal(a_shape) / np.sqrt(in_dim)).astype(dtype)
+            b = np.zeros(b_shape, dtype=dtype)
 
         model.graph.initializer.append(numpy_helper.from_array(a, a_name))
         model.graph.initializer.append(numpy_helper.from_array(b, b_name))
@@ -94,17 +129,65 @@ def inject(
         # every downstream consumer sees the same output name as before.
         node.output[0] = base_out_name
 
-        new_nodes = [
-            helper.make_node(
-                "MatMul", [x_name, a_name], [h_name], name=f"{init.name}/lora_A_matmul"
-            ),
-            helper.make_node(
-                "MatMul",
-                [h_name, b_name],
-                [delta_name],
-                name=f"{init.name}/lora_B_matmul",
-            ),
-        ]
+        new_nodes = []
+        if kind == "linear":
+            if extra["transA"]:
+                # Gemm's op(A) = A^T when transA is set; feed the branch
+                # the same effective input the original node multiplies.
+                x_eff = f"{init.name}.lora_x_transposed"
+                new_nodes.append(
+                    helper.make_node(
+                        "Transpose",
+                        [x_name],
+                        [x_eff],
+                        perm=[1, 0],
+                        name=f"{init.name}/lora_transpose_x",
+                    )
+                )
+                x_name = x_eff
+            new_nodes += [
+                helper.make_node(
+                    "MatMul",
+                    [x_name, a_name],
+                    [h_name],
+                    name=f"{init.name}/lora_A_matmul",
+                ),
+                helper.make_node(
+                    "MatMul",
+                    [h_name, b_name],
+                    [delta_name],
+                    name=f"{init.name}/lora_B_matmul",
+                ),
+            ]
+        else:  # conv1x1
+            # The first conv reproduces the original node's spatial striding
+            # (in_channels -> rank); the second is a plain 1x1/stride-1
+            # channel mix (rank -> out_channels) since the first conv
+            # already applied any subsampling.
+            carried = [
+                a
+                for a in node.attribute
+                if a.name in ("strides", "pads", "auto_pad", "dilations")
+            ]
+            conv_a = helper.make_node(
+                "Conv",
+                [x_name, a_name],
+                [h_name],
+                name=f"{init.name}/lora_A_conv",
+                kernel_shape=[1, 1],
+            )
+            conv_a.attribute.extend(carried)
+            new_nodes += [
+                conv_a,
+                helper.make_node(
+                    "Conv",
+                    [h_name, b_name],
+                    [delta_name],
+                    name=f"{init.name}/lora_B_conv",
+                    kernel_shape=[1, 1],
+                ),
+            ]
+
         scale = alpha / rank
         add_input = delta_name
         if scale != 1.0:

--- a/tools/onnx-finetune/scripts/prepare_qlora.py
+++ b/tools/onnx-finetune/scripts/prepare_qlora.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""One-shot QLoRA prep: inject trainable LoRA adapters, then NF4-quantize
+the (now frozen) base weights they sit on top of -- Dettmers et al. 2023's
+actual recipe (freeze a 4-bit-quantized base model, train small full-
+precision low-rank adapters on top of its on-the-fly dequantized weights),
+rather than plain LoRA on an unquantized base.
+
+Order matters, in both directions:
+
+  - LoRA must be injected *before* NF4 quantization: onnxsim.nf4's own
+    matcher looks for a plain MatMul/Gemm feeding straight off a 2-D
+    initializer. Quantize first and that same node's weight input becomes
+    a computed dequantize-subgraph output instead, and inject_lora.py's
+    matcher (the same kind of plain-initializer check) would find nothing
+    left to graft onto.
+
+  - The injected lora_A/lora_B weights must then be excluded from
+    quantization: onnxsim.nf4's matcher only looks at op_type and shape,
+    and a LoRA branch is itself just a MatMul against a small 2-D
+    initializer -- structurally indistinguishable from any other layer's
+    weight. Left unexcluded, quantizing after injection would NF4-quantize
+    the adapter too, defeating the point of keeping it full precision.
+    This script always passes the injected pair names as skip_names, so
+    that never happens.
+
+Needs onnxsim importable (this repo's own package, i.e. built/installed --
+see the top-level README) for the NF4 quantization step; plain
+inject_lora.py needs only onnx + numpy.
+
+The rest of the pipeline is unchanged: feed the output to
+generate_artifacts.py --lora-params-file, train as usual, then
+extract_lora_adapter.py / apply_lora_adapter.py work exactly as they do for
+plain (non-quantized) LoRA -- they only ever touch lora_A/lora_B by name.
+NF4 quantization is presently limited to 2-D MatMul/vanilla-Gemm weights
+(see onnxsim/nf4.py); a 1x1-Conv LoRA target stays full precision here.
+"""
+
+import argparse
+import json
+import sys
+
+import lora_surgery
+import onnx
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("model", help="input .onnx file")
+    p.add_argument(
+        "-o",
+        "--output",
+        required=True,
+        help="where to write the QLoRA-ready .onnx model",
+    )
+    p.add_argument("--rank", type=int, default=4, help="adapter rank (default 4)")
+    p.add_argument(
+        "--alpha",
+        type=float,
+        default=None,
+        help="LoRA scaling numerator, delta is scaled by alpha/rank (default: equal to --rank, i.e. scale 1.0)",
+    )
+    p.add_argument(
+        "--target-contains",
+        action="append",
+        default=[],
+        help="only target MatMul/Gemm/1x1-Conv nodes whose weight initializer name contains this "
+        "substring (repeatable). Omit to target every eligible node.",
+    )
+    p.add_argument(
+        "--block-size",
+        type=int,
+        default=64,
+        help="NF4 quantization block size (bitsandbytes' own QLoRA default is 64)",
+    )
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument(
+        "--params-out", required=True, help="where to write the JSON adapter manifest"
+    )
+    args = p.parse_args()
+
+    try:
+        from onnxsim.nf4 import quantize_weight_only_nf4
+    except ImportError as e:
+        sys.exit(
+            "error: NF4 quantization needs the onnxsim package importable (build/install this "
+            f"repo's own wheel, see the top-level README) -- import failed: {e}"
+        )
+
+    alpha = args.alpha if args.alpha is not None else float(args.rank)
+
+    model = onnx.load(args.model)
+    added = lora_surgery.inject(
+        model, args.target_contains, args.rank, alpha, seed=args.seed
+    )
+    if not added:
+        sys.exit("error: no eligible MatMul/Gemm/1x1-Conv targets matched")
+
+    lora_param_names = {n for pair in added for n in pair}
+    model = quantize_weight_only_nf4(
+        model, block_size=args.block_size, skip_names=lora_param_names
+    )
+
+    onnx.checker.check_model(model)
+    onnx.save(model, args.output)
+    with open(args.params_out, "w") as f:
+        json.dump({"rank": args.rank, "alpha": alpha, "pairs": added}, f, indent=2)
+
+    print(
+        f"injected {len(added)} LoRA adapter(s) (rank={args.rank} alpha={alpha}) and "
+        f"NF4-quantized the frozen base weights (block_size={args.block_size}) -> {args.output}"
+    )
+    print(f"wrote adapter manifest -> {args.params_out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/onnx-finetune/tests/test_lora.py
+++ b/tools/onnx-finetune/tests/test_lora.py
@@ -1,0 +1,317 @@
+"""End-to-end tests for the LoRA/QLoRA scripts under tools/onnx-finetune/
+scripts: pure graph-surgery correctness, run via subprocess exactly as a
+real user would invoke each CLI. Needs only onnx + numpy (+ pytest) --
+unlike generate_artifacts.py/onnx-finetune itself, which need a
+training-enabled onnxruntime build (see ../README.md), these scripts never
+touch onnxruntime.
+
+Correctness is checked with onnx.reference.ReferenceEvaluator (bundled with
+the onnx package, no onnxruntime needed): every injected adapter must be a
+numerical no-op at its zero/Kaiming-normal init, and a "trained" adapter
+(lora_B perturbed away from zero, standing in for a real training run)
+extracted and re-applied to a fresh copy of the base model must reproduce
+the fine-tuned model's output exactly.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import onnx
+import pytest
+from onnx import TensorProto, helper, numpy_helper
+from onnx.reference import ReferenceEvaluator
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+
+
+def _run(script, *args):
+    subprocess.run([sys.executable, str(SCRIPTS / script), *args], check=True)
+
+
+def _perturb_lora_b(model_path, out_path, seed=7, scale=0.05):
+    model = onnx.load(model_path)
+    rng = np.random.default_rng(seed)
+    for init in model.graph.initializer:
+        if init.name.endswith(".lora_B"):
+            arr = numpy_helper.to_array(init)
+            new = (rng.standard_normal(arr.shape) * scale).astype(arr.dtype)
+            init.CopyFrom(numpy_helper.from_array(new, init.name))
+    onnx.save(model, out_path)
+
+
+def _matmul_model(path, in_dim=4, hidden=16, out_dim=1, seed=0):
+    rng = np.random.default_rng(seed)
+    w1 = (rng.standard_normal((in_dim, hidden)) * 0.1).astype(np.float32)
+    w2 = (rng.standard_normal((hidden, out_dim)) * 0.1).astype(np.float32)
+    nodes = [
+        helper.make_node("MatMul", ["input", "fc1.weight"], ["h"]),
+        helper.make_node("Relu", ["h"], ["r"]),
+        helper.make_node("MatMul", ["r", "fc2.weight"], ["output"]),
+    ]
+    graph = helper.make_graph(
+        nodes,
+        "matmul_net",
+        [helper.make_tensor_value_info("input", TensorProto.FLOAT, [None, in_dim])],
+        [helper.make_tensor_value_info("output", TensorProto.FLOAT, [None, out_dim])],
+        initializer=[
+            numpy_helper.from_array(w1, "fc1.weight"),
+            numpy_helper.from_array(w2, "fc2.weight"),
+        ],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    onnx.save(model, path)
+
+
+def _gemm_model(path, trans_a, trans_b, in_dim=5, out_dim=3, seed=0):
+    rng = np.random.default_rng(seed)
+    w_shape = (out_dim, in_dim) if trans_b else (in_dim, out_dim)
+    w = (rng.standard_normal(w_shape) * 0.1).astype(np.float32)
+    b = np.zeros(out_dim, dtype=np.float32)
+    x_shape = [in_dim, None] if trans_a else [None, in_dim]
+    x_name = "inputT" if trans_a else "input"
+    node = helper.make_node(
+        "Gemm",
+        [x_name, "fc.weight", "fc.bias"],
+        ["output"],
+        transA=int(trans_a),
+        transB=int(trans_b),
+    )
+    graph = helper.make_graph(
+        [node],
+        "gemm_net",
+        [helper.make_tensor_value_info(x_name, TensorProto.FLOAT, x_shape)],
+        [helper.make_tensor_value_info("output", TensorProto.FLOAT, [None, out_dim])],
+        initializer=[
+            numpy_helper.from_array(w, "fc.weight"),
+            numpy_helper.from_array(b, "fc.bias"),
+        ],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    onnx.save(model, path)
+    return x_name
+
+
+def _conv1x1_model(path, in_ch=3, mid_ch=8, out_ch=4, stride=2, seed=0):
+    rng = np.random.default_rng(seed)
+    w1 = (rng.standard_normal((mid_ch, in_ch, 1, 1)) * 0.1).astype(np.float32)
+    w2 = (rng.standard_normal((out_ch, mid_ch, 1, 1)) * 0.1).astype(np.float32)
+    nodes = [
+        helper.make_node(
+            "Conv",
+            ["input", "conv1.weight"],
+            ["h"],
+            kernel_shape=[1, 1],
+            strides=[stride, stride],
+        ),
+        helper.make_node("Relu", ["h"], ["r"]),
+        helper.make_node(
+            "Conv", ["r", "conv2.weight"], ["output"], kernel_shape=[1, 1]
+        ),
+    ]
+    graph = helper.make_graph(
+        nodes,
+        "conv1x1_net",
+        [
+            helper.make_tensor_value_info(
+                "input", TensorProto.FLOAT, [None, in_ch, 8, 8]
+            )
+        ],
+        [
+            helper.make_tensor_value_info(
+                "output", TensorProto.FLOAT, [None, out_ch, None, None]
+            )
+        ],
+        initializer=[
+            numpy_helper.from_array(w1, "conv1.weight"),
+            numpy_helper.from_array(w2, "conv2.weight"),
+        ],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    onnx.save(model, path)
+
+
+def _assert_noop_at_init(base_path, lora_path, feeds):
+    y0 = ReferenceEvaluator(str(base_path)).run(None, feeds)[0]
+    y1 = ReferenceEvaluator(str(lora_path)).run(None, feeds)[0]
+    assert np.allclose(y0, y1, atol=1e-6), np.abs(y0 - y1).max()
+
+
+def _assert_round_trips(tmp_path, base_path, lora_path, manifest_path, feeds):
+    finetuned_path = tmp_path / "finetuned.onnx"
+    _perturb_lora_b(lora_path, finetuned_path)
+
+    adapter_path = tmp_path / "adapter.onnx"
+    _run(
+        "extract_lora_adapter.py",
+        str(finetuned_path),
+        "--params-file",
+        str(manifest_path),
+        "-o",
+        str(adapter_path),
+    )
+
+    applied_path = tmp_path / "applied.onnx"
+    _run(
+        "apply_lora_adapter.py",
+        str(base_path),
+        "--adapter",
+        str(adapter_path),
+        "--params-file",
+        str(manifest_path),
+        "-o",
+        str(applied_path),
+    )
+
+    y_ft = ReferenceEvaluator(str(finetuned_path)).run(None, feeds)[0]
+    y_applied = ReferenceEvaluator(str(applied_path)).run(None, feeds)[0]
+    y_base = ReferenceEvaluator(str(base_path)).run(None, feeds)[0]
+    assert np.allclose(y_ft, y_applied, atol=1e-6)
+    assert np.abs(y_base - y_applied).max() > 1e-3  # the adapter did something
+
+
+def test_matmul_injection_noop_at_init_and_round_trips(tmp_path):
+    base_path = tmp_path / "base.onnx"
+    _matmul_model(base_path)
+    lora_path = tmp_path / "lora.onnx"
+    manifest_path = tmp_path / "manifest.json"
+    _run(
+        "inject_lora.py",
+        str(base_path),
+        "-o",
+        str(lora_path),
+        "--rank",
+        "2",
+        "--params-out",
+        str(manifest_path),
+    )
+
+    manifest = json.loads(manifest_path.read_text())
+    assert len(manifest["pairs"]) == 2  # fc1.weight, fc2.weight
+
+    x = np.random.default_rng(1).standard_normal((3, 4)).astype(np.float32)
+    _assert_noop_at_init(base_path, lora_path, {"input": x})
+    _assert_round_trips(tmp_path, base_path, lora_path, manifest_path, {"input": x})
+
+
+def test_gemm_transb_injection_noop_at_init(tmp_path):
+    base_path = tmp_path / "base.onnx"
+    _gemm_model(base_path, trans_a=False, trans_b=True)
+    lora_path = tmp_path / "lora.onnx"
+    manifest_path = tmp_path / "manifest.json"
+    _run(
+        "inject_lora.py",
+        str(base_path),
+        "-o",
+        str(lora_path),
+        "--rank",
+        "2",
+        "--params-out",
+        str(manifest_path),
+    )
+    x = np.random.default_rng(2).standard_normal((6, 5)).astype(np.float32)
+    _assert_noop_at_init(base_path, lora_path, {"input": x})
+    _assert_round_trips(tmp_path, base_path, lora_path, manifest_path, {"input": x})
+
+
+def test_gemm_transa_injection_noop_at_init(tmp_path):
+    base_path = tmp_path / "base.onnx"
+    _gemm_model(base_path, trans_a=True, trans_b=True)
+    lora_path = tmp_path / "lora.onnx"
+    manifest_path = tmp_path / "manifest.json"
+    _run(
+        "inject_lora.py",
+        str(base_path),
+        "-o",
+        str(lora_path),
+        "--rank",
+        "2",
+        "--params-out",
+        str(manifest_path),
+    )
+    xt = np.random.default_rng(3).standard_normal((5, 6)).astype(np.float32)
+    _assert_noop_at_init(base_path, lora_path, {"inputT": xt})
+    _assert_round_trips(tmp_path, base_path, lora_path, manifest_path, {"inputT": xt})
+
+
+def test_conv1x1_injection_noop_at_init(tmp_path):
+    base_path = tmp_path / "base.onnx"
+    _conv1x1_model(base_path)
+    lora_path = tmp_path / "lora.onnx"
+    manifest_path = tmp_path / "manifest.json"
+    _run(
+        "inject_lora.py",
+        str(base_path),
+        "-o",
+        str(lora_path),
+        "--rank",
+        "2",
+        "--params-out",
+        str(manifest_path),
+    )
+    x = np.random.default_rng(4).standard_normal((2, 3, 8, 8)).astype(np.float32)
+    _assert_noop_at_init(base_path, lora_path, {"input": x})
+    _assert_round_trips(tmp_path, base_path, lora_path, manifest_path, {"input": x})
+
+
+def test_target_contains_filters_by_name(tmp_path):
+    base_path = tmp_path / "base.onnx"
+    _matmul_model(base_path)
+    lora_path = tmp_path / "lora.onnx"
+    manifest_path = tmp_path / "manifest.json"
+    _run(
+        "inject_lora.py",
+        str(base_path),
+        "-o",
+        str(lora_path),
+        "--rank",
+        "2",
+        "--target-contains",
+        "fc1.weight",
+        "--params-out",
+        str(manifest_path),
+    )
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest["pairs"] == [["fc1.weight.lora_A", "fc1.weight.lora_B"]]
+
+
+def test_prepare_qlora_excludes_adapter_from_quantization(tmp_path):
+    pytest.importorskip("onnxsim.nf4")
+    base_path = tmp_path / "base.onnx"
+    _matmul_model(base_path, in_dim=64, hidden=128, out_dim=8)
+    qlora_path = tmp_path / "qlora.onnx"
+    manifest_path = tmp_path / "manifest.json"
+    _run(
+        "prepare_qlora.py",
+        str(base_path),
+        "-o",
+        str(qlora_path),
+        "--rank",
+        "2",
+        "--block-size",
+        "64",
+        "--params-out",
+        str(manifest_path),
+    )
+
+    model = onnx.load(qlora_path)
+    names = {t.name for t in model.graph.initializer}
+    manifest = json.loads(manifest_path.read_text())
+    for a_name, b_name in manifest["pairs"]:
+        assert f"{a_name}_nf4_q" not in names
+        assert f"{b_name}_nf4_q" not in names
+    assert any(n.endswith("_nf4_q") for n in names)  # the base weights WERE quantized
+
+    x = np.random.default_rng(5).standard_normal((4, 64)).astype(np.float32)
+    y_base = ReferenceEvaluator(str(base_path)).run(None, {"input": x})[0]
+    y_qlora = ReferenceEvaluator(str(qlora_path)).run(None, {"input": x})[0]
+    rel_l2 = np.linalg.norm(y_base - y_qlora) / np.linalg.norm(y_base)
+    assert rel_l2 < 0.25  # NF4 quantization noise only, adapters are zero-init


### PR DESCRIPTION
## Summary

Follow-up to the LoRA support added to `tools/onnx-finetune` (previously merged in #765). Extends it in two directions:

- **Broader layer coverage** in `lora_surgery.py`: LoRA injection previously only targeted 2-D MatMul/Gemm weights with `transA=0`. Now also supports:
  - Gemm with **any** `transA`/`transB` (inserts a `Transpose` node to match Gemm's own `op(A) = A^T` semantics when `transA` is set)
  - **1x1/`group=1` Conv** weights (a pointwise conv is a per-pixel linear layer over channels) -- the LoRA branch uses two Conv nodes (in→rank carrying the original stride/pad, rank→out at stride 1) instead of MatMul
- **QLoRA integration**: new `scripts/prepare_qlora.py` wires the LoRA graph surgery together with `onnxsim.nf4.quantize_weight_only_nf4` to reproduce Dettmers et al. 2023's actual QLoRA recipe -- freeze a 4-bit NF4-quantized base model and train small full-precision low-rank adapters on top of its on-the-fly dequantized weights.

## Bug caught along the way

While wiring up QLoRA, found that `quantize_weight_only_nf4`'s matcher can't distinguish an injected `lora_A`/`lora_B` branch from a real layer weight -- both are just a MatMul against a small 2-D initializer. Quantizing a LoRA-injected model with the existing API would silently NF4-quantize the adapter too, defeating the point of keeping it full precision. Fixed by adding an additive, backward-compatible `skip_names` parameter to `quantize_weight_only_nf4`; `prepare_qlora.py` always passes the injected pair names through it.

## Testing

No `onnxruntime`/compiled `onnxsim` extension available in this sandbox, so verification was done two ways:

- New graph-surgery paths (Conv 1x1, Gemm `transA=1`) verified numerically with `onnx.reference.ReferenceEvaluator`: no-op at zero-init, and `extract_lora_adapter.py` → `apply_lora_adapter.py` round-trips exactly onto a fresh base-model copy.
- `nf4.py`'s new `skip_names` behavior verified by loading it standalone (bypassing `onnxsim/__init__.py`'s compiled-extension-requiring import chain, just for local testing) and confirming: base weights get NF4-quantized, `lora_A`/`lora_B` do not, and the full `prepare_qlora.py` pipeline produces a checker-valid model whose output stays close to the float baseline (relative L2 ~0.09, consistent with NF4 quantization noise) with zero-init adapters.
- Added `test_nf4_skip_names_leaves_matched_weight_untouched` to `tests/test_nf4.py` (follows the file's existing `onnxruntime`-gated conventions) for CI to exercise for real.
- `ruff`, `black`, and `py_compile` all pass on every changed file.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01AJeZY2AcG5x4vaQAnjVFjj

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJeZY2AcG5x4vaQAnjVFjj)_