### PR TITLE
quantize_kv_cache: add KIVI's per-token Value-style quantization

### DIFF
--- a/docs/kv-cache-quantization.md
+++ b/docs/kv-cache-quantization.md
@@ -9,9 +9,16 @@ sequence axis, feeding a graph output (`present_key`/`present.{i}.key`,
 ...) that a caller feeds back in as next step's `past_*` input, exactly the
 shape `tools/onnx-deploy`'s own `KvCachePipeline` and
 `tests/test_symexpr_kv_cache_consistency.py`'s toy model both use -- and
-quantizes it to INT8, symmetric, one scale per channel (the head-dim axis),
-calibrated once from representative data and shared by every cached token
-for that stream's whole lifetime.
+quantizes it to INT8, symmetric, in one of two ways depending on the
+stream:
+
+- **Key-style** (the default): one scale per channel (the head-dim axis),
+  calibrated once from representative data and shared by every cached
+  token for that stream's whole lifetime.
+- **Value-style** (matched by name, or via `value_output_names`): a fresh,
+  data-free scale per *token*, computed from that token's own values the
+  instant it's produced, carried forward as a second growing KV-cache
+  stream alongside the codes.
 
 Every other quantizer in onnxsim compresses a **weight**: something
 computed once, offline, before the model ever runs. A KV cache is the
@@ -21,13 +28,13 @@ exactly why it is worth quantizing at all: it is the part of an LLM's
 memory footprint that scales with sequence length, unlike the weights.
 
 ```
-Before:
+Key-style, before:
   past_key: graph input, float32 [..., seq_past, head_dim]
   new_key:  float32 [..., seq_new, head_dim]         -- this step's own K/V
   present_key = Concat(past_key, new_key, axis=seq)  -- graph output,
                 and consumed by the attention math (QK^T / softmax@V)
 
-After:
+Key-style, after:
   past_key: graph input, INT8 [..., seq_past, head_dim]    -- dtype changed
   key_scale: initializer, float32 [head_dim]                 -- per-channel
   key_zero_point: initializer, INT8 [head_dim], all zero     -- symmetric
@@ -49,6 +56,34 @@ decode step stays constant as the sequence grows, and the graph's own
 float32) the whole way through a caller's decode loop -- not just an
 internal round-trip that still stores float32 everywhere.
 
+Value-style streams (matched by a `present` output name containing
+`".value"`, or listed explicitly via `value_output_names`) get a different
+rewrite -- no calibration, but a second parallel scale stream:
+
+```
+Value-style, after:
+  past_value: graph input, INT8 [..., seq_past, head_dim]
+  past_value_scale: graph input, float32 [..., seq_past, 1]   -- NEW input,
+    one scale per already-cached token
+  new_scale = max(reduce_max(abs(new_value), axis=head_dim), eps) / 127
+    -- one scale per new token, computed fresh from that token's own
+    values, no calibration data involved
+  new_value_q = cast(clip(round(new_value / new_scale), -128, 127), INT8)
+  present_value = Concat(past_value, new_value_q, axis=seq)          -- INT8
+  present_value_scale = Concat(past_value_scale, new_scale, axis=seq) -- NEW
+    output, float32, grows in lockstep with present_value
+  present_value_f = cast(present_value, float32) * present_value_scale
+  <every other consumer of the old float present_value now reads present_value_f>
+```
+
+Past tokens' scales are never revised once set (the same "no compounding
+requantization error" property as Key-style above) -- only this step's new
+token is ever quantized, at a scale tailored to it specifically. The new
+`past_value_scale`/`present_value_scale` pair is picked up by
+`KvCachePipeline`'s existing `present.`/`past_key_values.`
+string-substitution convention automatically, with no C++ changes needed
+(it's float32, a dtype `detail::BorrowView` already handled).
+
 ## Where this comes from
 
 Two published techniques quantize the KV cache well: **KIVI** (Liu et al.,
@@ -57,20 +92,17 @@ al., NeurIPS 2024, <https://arxiv.org/abs/2401.18079>). Both share the same
 core empirical finding: Key activations have a handful of channels with
 persistently large magnitude across the *whole* sequence, so quantizing Key
 **per channel** (one scale shared by every cached token) preserves far more
-accuracy than quantizing it per token. `quantize_kv_cache` reproduces that
-part of both papers.
+accuracy than quantizing it per token. `quantize_kv_cache`'s Key-style
+rewrite reproduces that part of both papers.
+
+KIVI's other empirical finding -- Value activations *don't* have that
+persistent-channel structure, so a **per-token** scale preserves more
+accuracy there instead -- is reproduced by `quantize_kv_cache`'s
+Value-style rewrite (matched automatically by name, or via
+`value_output_names`; needs opset 18, see Scope below).
 
 What it does **not** reproduce:
 
-- **KIVI's per-token Value quantization** (a fresh scale per cached token,
-  rather than one static per-channel scale). Per-token quantization would
-  need the scale itself to be a second, parallel growing KV-cache stream
-  (one scale per cached row, concatenated alongside the codes every step) --
-  a real increase in I/O surface this module's MVP scope skips, applying
-  the same static per-channel scheme to Value too. This matches what many
-  serving engines' plain "int8/fp8 KV cache" flag already does in
-  production, even though it is a documented simplification relative to
-  KIVI's own per-token scheme for Value specifically.
 - **KIVI's residual-window bookkeeping** (the most recent `R` tokens kept
   in full precision, only finalized into low-bit once they age out of that
   window). Deciding which tokens have "aged out" and need finalizing is
@@ -95,7 +127,10 @@ Handled:
   matches `past_key`/`present_key` as well as `optimum-onnx`'s own
   `past_key_values.{i}.key`/`present.{i}.key` convention.
 - Opsets >= 13 (`QuantizeLinear`/`DequantizeLinear`'s per-channel `axis`
-  needs opset 13).
+  needs opset 13) for Key-style streams; opsets >= 18
+  (`ReduceMax`'s `axes`-as-input form) for Value-style streams -- each
+  `Reduce*` op moved its `axes` attribute to an input on its own schedule,
+  not all at opset 13 the way `ReduceSum` did.
 
 Left untouched (safe no-op, node passes through as-is):
 
@@ -104,6 +139,8 @@ Left untouched (safe no-op, node passes through as-is):
 - A Concat whose axis *is* the last (channel) axis -- no distinct axis is
   left to quantize per-channel on.
 - A model with no matching Concat pattern, or an opset older than 13.
+- A stream matched as Value-style, when the model's opset is below 18 --
+  left completely untouched (not silently downgraded to Key-style).
 
 ## Usage
 
@@ -112,6 +149,10 @@ import onnx
 import onnxsim
 
 model = onnx.load("decoder_with_past_model.onnx")
+# Key-style (calibrated, per-channel) by default; any matched stream whose
+# present output name contains ".value" automatically gets Value-style
+# (data-free, per-token) treatment instead -- see value_output_names to
+# name streams explicitly.
 quantized = onnxsim.quantize_kv_cache(model, num_samples=32)
 onnx.save(quantized, "decoder_with_past_model.kv_int8.onnx")
 ```

--- a/onnxsim/kv_cache_quantization.py
+++ b/onnxsim/kv_cache_quantization.py
@@ -27,24 +27,38 @@ freshly computed activation, concatenated along the sequence axis, feeding a
 graph output (``present_key``/``present.{i}.key``, ...) that the caller
 feeds back in as next step's ``past_*`` input.
 
-What this module does **not** reproduce: KIVI's own per-token Value
-quantization (a fresh scale per cached token, rather than one static
-per-channel scale) and its residual-window bookkeeping (the most recent
-``R`` tokens kept in full precision, only finalized into low-bit once they
-age out of that window). Per-token Value quantization would need the scale
-itself to be a second, parallel growing KV-cache stream (one scale per
-cached row, concatenated alongside the codes every step) -- a real
-increase in I/O surface this module's MVP scope skips, applying the same
-static per-channel scheme (calibrated once, shared across every cached
-token) to Value too, matching what many serving engines' plain "int8/fp8 KV
-cache" flag already does in production. KIVI's residual window is inherently
-cross-step, host-side bookkeeping -- deciding which tokens have "aged out"
-and need finalizing is not something one exported ONNX graph can express on
-its own -- and belongs in ``tools/onnx-deploy/include/onnx_deploy/kv_cache_pipeline.h``
-(which already owns exactly this kind of cross-step cache state) as a
-follow-up, not here.
+KIVI's *other* empirical finding is that Value activations don't have that
+persistent-channel structure, so a static per-channel scale is the wrong
+shape for Value -- a **fresh, per-token scale** (computed from that token's
+own values, the instant it's produced) preserves much more accuracy there
+instead. This module reproduces that too, for every matched stream whose
+``present`` output name contains ``".value"`` (matching this repo's own
+``present.{i}.decoder.value``/``present.{i}.encoder.value`` convention --
+see ``tools/onnx-deploy/scripts/make_toy_seq2seq.py``) or is named
+explicitly via ``value_output_names`` -- every other matched stream keeps
+the per-channel treatment above. Per-token quantization needs no
+calibration data at all (each token's own scale is computed from that
+token's own values, at graph-run time), but it does need the scale itself
+carried forward as a **second, parallel growing KV-cache stream**
+alongside the codes -- see the graph rewrite below. It also needs opset 18
+(``ReduceMax``'s ``axes``-as-input form, unlike ``ReduceSum``'s -- already
+opset 13 -- only arrived there; each ``Reduce*`` op moved its ``axes``
+attribute to an input on its own schedule, not all at once); a stream
+matched as Value-style below opset 18 is left completely untouched rather
+than silently downgraded to Key-style.
 
-Graph rewrite, per matched ``Concat(past, new, axis=seq)`` cache stream:
+What this module does **not** reproduce: KIVI's residual-window
+bookkeeping (the most recent ``R`` tokens kept in full precision, only
+finalized into low-bit once they age out of that window). Deciding which
+tokens have "aged out" and need finalizing is cross-step, host-side
+bookkeeping -- not something one exported ONNX graph can express on its
+own -- and belongs in
+``tools/onnx-deploy/include/onnx_deploy/kv_cache_pipeline.h`` (which
+already owns exactly this kind of cross-step cache state) as a follow-up,
+not here.
+
+Graph rewrite, per matched ``Concat(past, new, axis=seq)`` cache stream --
+**Key-style** (default; static, calibrated, per-channel):
 
     Before:
       past_key: graph input, float32 [..., seq_past, head_dim]
@@ -72,6 +86,35 @@ cost per decode step stays constant as the sequence grows, and the graph's
 own ``present_*`` output is genuinely compressed (roughly 4x smaller than
 float32) the whole way through a caller's decode loop -- not just an
 internal round-trip that still stores float32 everywhere.
+
+**Value-style** (data-free, per-token, matched by name -- see above):
+
+    Before:
+      past_value: graph input, float32 [..., seq_past, head_dim]
+      new_value:  float32 [..., seq_new, head_dim]
+      present_value = Concat(past_value, new_value, axis=seq)
+
+    After:
+      past_value: graph input, INT8 [..., seq_past, head_dim]
+      past_value_scale: graph input, float32 [..., seq_past, 1]   -- NEW input,
+        one scale per already-cached token -- threaded by
+        KvCachePipeline's existing present./past_key_values. convention
+        with no C++ changes (it stays float32, and BorrowView already
+        handled float32 before this module existed)
+      new_scale = Max(ReduceMax(Abs(new_value), axes=[-1], keepdims=1), eps) / 127
+        -- one scale per *new* token, computed fresh from that token's own
+        values, no calibration data involved
+      new_value_q = Cast(Clip(Round(new_value / new_scale), -128, 127), INT8)
+      present_value = Concat(past_value, new_value_q, axis=seq)        -- INT8
+      present_value_scale = Concat(past_value_scale, new_scale, axis=seq)  -- NEW
+        output, float32, grows in lockstep with present_value
+      present_value_f = Cast(present_value, float32) * present_value_scale
+        -- broadcasts present_value_scale's trailing size-1 axis over head_dim
+      <every other consumer of the old float present_value now reads present_value_f>
+
+Past tokens' scales are never revised once set (matching the Key-style
+scheme's "no compounding requantization error" property above) -- only
+this step's new token(s) are ever quantized, at a fresh, tailored scale.
 """
 
 from __future__ import annotations
@@ -87,6 +130,13 @@ import onnx.numpy_helper
 from onnxsim import backend
 from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
 from onnxsim.calibration import Tensors, generate_random_calibration_data
+
+
+def _has_min_opset(model: onnx.ModelProto, min_version: int) -> bool:
+    return any(
+        o.domain in ("", "ai.onnx") and o.version >= min_version
+        for o in model.opset_import
+    )
 
 
 @dataclass
@@ -190,21 +240,28 @@ def quantize_kv_cache(
     num_samples: int = 8,
     seed: int = 0,
     providers: Optional[Sequence[str]] = None,
+    value_output_names: Optional[Sequence[str]] = None,
 ) -> onnx.ModelProto:
     """Quantizes every ``Concat(past, new, axis=seq)`` KV-cache stream this
     module can find (see this module's own docstring for the exact pattern
-    and graph rewrite) to INT8, symmetric, one scale per channel (the last
-    axis -- head-dim), calibrated once from representative data and shared
-    by every cached token for that stream's whole lifetime.
+    and both graph rewrites) to INT8, symmetric. Key-style streams (the
+    default) get one scale per channel (the last axis -- head-dim),
+    calibrated once from representative data and shared by every cached
+    token for that stream's whole lifetime. Value-style streams (matched by
+    name -- see ``value_output_names``) get a fresh, data-free scale per
+    token instead, computed from that token's own values the moment it's
+    produced.
 
     :param model: the original (unquantized) onnx ModelProto or file path
     :param calibration_data: representative input batches (each a
             ``{input_name: np.ndarray}`` dict matching ``model``'s graph
-            inputs) to calibrate the per-channel scale on -- see
-            :func:`onnxsim.generate_random_calibration_data` (the default
-            when omitted) and :func:`onnxsim.load_huggingface_calibration_data`
-            (real data, a more representative calibration than random
-            input). A ``past_key``/``past_key_values.*`` input with a
+            inputs) to calibrate Key-style streams' per-channel scale on --
+            see :func:`onnxsim.generate_random_calibration_data` (the
+            default when omitted) and
+            :func:`onnxsim.load_huggingface_calibration_data` (real data, a
+            more representative calibration than random input). Ignored
+            for Value-style streams, which need no calibration data at
+            all. A ``past_key``/``past_key_values.*`` input with a
             genuinely empty (statically zero) sequence-length dimension in
             ``model``'s own declared shape is filled in as an empty tensor
             by :func:`onnxsim.generate_random_calibration_data` automatically
@@ -216,20 +273,30 @@ def quantize_kv_cache(
     :param seed: seed for the random calibration data (ignored if
             ``calibration_data`` is supplied)
     :param providers: onnxruntime execution providers to calibrate on
+    :param value_output_names: which matched streams' ``present`` output
+            names get Value-style (per-token) treatment instead of the
+            default Key-style (per-channel) one -- if omitted, any matched
+            stream whose ``present`` output name contains ``".value"`` is
+            treated as Value-style automatically (matching this repo's own
+            ``present.{i}.decoder.value``/``present.{i}.encoder.value``
+            convention), every other stream gets Key-style. A stream
+            matched as Value-style is left completely untouched (not
+            downgraded to Key-style) when ``model``'s opset is below 18 --
+            see this module's own docstring
     :returns: ``model`` with every matched KV-cache stream's ``past_*``
-            graph input and ``present_*`` graph output changed to INT8, and
-            a ``QuantizeLinear``/``DequantizeLinear`` pair inserted around
-            it (see the module docstring's diagram); a model with no
+            graph input and ``present_*`` graph output changed to INT8
+            (Value-style streams additionally gain a new
+            ``past_*_scale``/``present_*_scale`` float32 input/output
+            pair -- see the module docstring's diagram); a model with no
             matching Concat pattern, or an opset older than 13
-            (``QuantizeLinear``/``DequantizeLinear``'s per-channel ``axis``
-            needs opset 13), is returned unchanged
+            (``QuantizeLinear``/``DequantizeLinear``'s per-channel ``axis``,
+            and ``ReduceMax``'s ``axes``-as-input, both need opset 13), is
+            returned unchanged
     """
     if isinstance(model, str):
         model = onnx.load(model, load_external_data=False)
 
-    if not any(
-        o.domain in ("", "ai.onnx") and o.version >= 13 for o in model.opset_import
-    ):
+    if not _has_min_opset(model, 13):
         return model
 
     out = onnx.ModelProto()
@@ -240,89 +307,279 @@ def quantize_kv_cache(
     if not candidates:
         return out
 
-    if calibration_data is None:
-        calibration_data = generate_random_calibration_data(
-            model, num_samples=num_samples, seed=seed
+    # Value-style needs ReduceMax's axes-as-input form, which (unlike
+    # ReduceSum's, already opset13) only arrived at opset 18 -- each
+    # Reduce* op moved its axes attribute to an input on its own schedule,
+    # not all together at opset13. A stream matched as Value-style below
+    # opset 18 is left completely untouched (not silently downgraded to
+    # Key-style) rather than guessing.
+    has_opset18 = _has_min_opset(model, 18)
+
+    value_candidates = []
+    channel_candidates = []
+    for c in candidates:
+        if _is_value_style(c.present_name, value_output_names):
+            if has_opset18:
+                value_candidates.append(c)
+            # else: leave this stream untouched -- see comment above.
+        else:
+            channel_candidates.append(c)
+
+    absmax: Dict[str, np.ndarray] = {}
+    if channel_candidates:
+        if calibration_data is None:
+            calibration_data = generate_random_calibration_data(
+                model, num_samples=num_samples, seed=seed
+            )
+        absmax = _per_channel_absmax(
+            channel_candidates, model, calibration_data, providers
         )
 
-    absmax = _per_channel_absmax(candidates, model, calibration_data, providers)
     taken_names: Set[str] = _all_names(graph)
     input_by_name = {i.name: i for i in graph.input}
     output_by_name = {o.name: o for o in graph.output}
 
-    for c in candidates:
+    for c in channel_candidates:
         if c.new_name not in absmax:
             continue  # this stream's activation never appeared in any batch
-        channel_absmax = np.maximum(absmax[c.new_name], 1e-12)
-        scale = (channel_absmax / 127.0).astype(np.float32)
-        num_channels = scale.shape[0]
-
-        scale_name = _unique_name(f"{c.present_name}_kv_scale", taken_names)
-        zp_name = _unique_name(f"{c.present_name}_kv_zero_point", taken_names)
-        graph.initializer.append(onnx.numpy_helper.from_array(scale, name=scale_name))
-        zp = np.zeros(num_channels, dtype=np.int8)
-        graph.initializer.append(onnx.numpy_helper.from_array(zp, name=zp_name))
-
-        # past_key/past_key_values.*: FLOAT -> INT8 (same shape).
-        past_input = input_by_name[c.past_name]
-        past_input.type.tensor_type.elem_type = onnx.TensorProto.INT8
-
-        # new_key_q = QuantizeLinear(new_key, scale, zero_point, axis=channel_axis)
-        new_q_name = _unique_name(f"{c.new_name}_kv_q", taken_names)
-        quantize_node = onnx.helper.make_node(
-            "QuantizeLinear",
-            [c.new_name, scale_name, zp_name],
-            [new_q_name],
-            name=_unique_name(f"{c.new_name}_kv_quantize_node", taken_names),
-            axis=c.channel_axis,
+        _apply_channel_style(
+            graph, c, absmax[c.new_name], taken_names, input_by_name, output_by_name
         )
 
-        # Rewire Concat's "new" input to the now-quantized tensor; the
-        # "past" input already reads the (now INT8) graph input as-is, so
-        # Concat's own output is INT8 -- exactly present_key's new dtype.
-        if c.new_is_first_input:
-            c.concat_node.input[0] = new_q_name
-        else:
-            c.concat_node.input[1] = new_q_name
-
-        present_output = output_by_name[c.present_name]
-        present_output.type.tensor_type.elem_type = onnx.TensorProto.INT8
-
-        # present_key_f = DequantizeLinear(present_key, scale, zero_point,
-        # axis=channel_axis) -- every *node* consumer of the old float
-        # present_key (the attention math) is rewired to this; the graph
-        # output binding itself is untouched, so it keeps resolving to
-        # Concat's own (now INT8) output tensor by name, unchanged.
-        dequant_name = _unique_name(f"{c.present_name}_kv_f", taken_names)
-        dequant_node = onnx.helper.make_node(
-            "DequantizeLinear",
-            [c.present_name, scale_name, zp_name],
-            [dequant_name],
-            name=_unique_name(f"{c.present_name}_kv_dequantize_node", taken_names),
-            axis=c.channel_axis,
-        )
-
-        # Rewire every *existing* consumer of present_name (everything
-        # except Concat itself) to the dequantized tensor now, before
-        # quantize_node/dequant_node are inserted below -- graph.node is a
-        # protobuf repeated field, and RepeatedCompositeFieldContainer.insert()
-        # copies the given message into a freshly allocated element rather
-        # than storing the object itself, so an `is quantize_node`/
-        # `is dequant_node` identity check taken *after* inserting them would
-        # never match anything actually in the container (silently leaving
-        # them out of the loop's exclusion and making dequant_node consume
-        # its own output). Doing the rewiring first sidesteps that: neither
-        # new node exists in graph.node yet, so there is nothing to
-        # incorrectly self-reference.
-        for node in graph.node:
-            if node is c.concat_node:
-                continue
-            for i, inp in enumerate(node.input):
-                if inp == c.present_name:
-                    node.input[i] = dequant_name
-
-        concat_idx = next(i for i, n in enumerate(graph.node) if n is c.concat_node)
-        graph.node.insert(concat_idx, quantize_node)
-        graph.node.insert(concat_idx + 2, dequant_node)
+    for c in value_candidates:
+        _apply_value_style(graph, c, taken_names, input_by_name, output_by_name)
 
     return out
+
+
+def _is_value_style(
+    present_name: str, value_output_names: Optional[Sequence[str]]
+) -> bool:
+    if value_output_names is not None:
+        return present_name in value_output_names
+    return ".value" in present_name
+
+
+def _rewire_consumers(
+    graph: onnx.GraphProto, c: _KvCacheCandidate, dequant_name: str
+) -> None:
+    # Must run *before* any new node referencing c.present_name is
+    # inserted into graph.node: RepeatedCompositeFieldContainer.insert()
+    # copies the given message into a freshly allocated element rather
+    # than storing the object itself, so an `is`-based identity check
+    # taken afterward would never match anything actually in the
+    # container (silently leaving a just-inserted node out of the
+    # exclusion below and making it consume its own output). Running this
+    # first sidesteps that: none of the new nodes exist in graph.node yet,
+    # so there is nothing to incorrectly self-reference.
+    for node in graph.node:
+        if node is c.concat_node:
+            continue
+        for i, inp in enumerate(node.input):
+            if inp == c.present_name:
+                node.input[i] = dequant_name
+
+
+def _apply_channel_style(
+    graph: onnx.GraphProto,
+    c: _KvCacheCandidate,
+    channel_absmax: np.ndarray,
+    taken_names: Set[str],
+    input_by_name: Dict[str, onnx.ValueInfoProto],
+    output_by_name: Dict[str, onnx.ValueInfoProto],
+) -> None:
+    """Static, calibrated, per-channel (Key-style) rewrite -- see the
+    module docstring's diagram.
+    """
+    scale = (np.maximum(channel_absmax, 1e-12) / 127.0).astype(np.float32)
+    num_channels = scale.shape[0]
+
+    scale_name = _unique_name(f"{c.present_name}_kv_scale", taken_names)
+    zp_name = _unique_name(f"{c.present_name}_kv_zero_point", taken_names)
+    graph.initializer.append(onnx.numpy_helper.from_array(scale, name=scale_name))
+    zp = np.zeros(num_channels, dtype=np.int8)
+    graph.initializer.append(onnx.numpy_helper.from_array(zp, name=zp_name))
+
+    # past_key/past_key_values.*: FLOAT -> INT8 (same shape).
+    past_input = input_by_name[c.past_name]
+    past_input.type.tensor_type.elem_type = onnx.TensorProto.INT8
+
+    # new_key_q = QuantizeLinear(new_key, scale, zero_point, axis=channel_axis)
+    new_q_name = _unique_name(f"{c.new_name}_kv_q", taken_names)
+    quantize_node = onnx.helper.make_node(
+        "QuantizeLinear",
+        [c.new_name, scale_name, zp_name],
+        [new_q_name],
+        name=_unique_name(f"{c.new_name}_kv_quantize_node", taken_names),
+        axis=c.channel_axis,
+    )
+
+    # Rewire Concat's "new" input to the now-quantized tensor; the "past"
+    # input already reads the (now INT8) graph input as-is, so Concat's
+    # own output is INT8 -- exactly present_key's new dtype.
+    if c.new_is_first_input:
+        c.concat_node.input[0] = new_q_name
+    else:
+        c.concat_node.input[1] = new_q_name
+
+    present_output = output_by_name[c.present_name]
+    present_output.type.tensor_type.elem_type = onnx.TensorProto.INT8
+
+    # present_key_f = DequantizeLinear(present_key, scale, zero_point,
+    # axis=channel_axis) -- every *node* consumer of the old float
+    # present_key (the attention math) is rewired to this; the graph
+    # output binding itself is untouched, so it keeps resolving to
+    # Concat's own (now INT8) output tensor by name, unchanged.
+    dequant_name = _unique_name(f"{c.present_name}_kv_f", taken_names)
+    dequant_node = onnx.helper.make_node(
+        "DequantizeLinear",
+        [c.present_name, scale_name, zp_name],
+        [dequant_name],
+        name=_unique_name(f"{c.present_name}_kv_dequantize_node", taken_names),
+        axis=c.channel_axis,
+    )
+
+    _rewire_consumers(graph, c, dequant_name)
+
+    concat_idx = next(i for i, n in enumerate(graph.node) if n is c.concat_node)
+    graph.node.insert(concat_idx, quantize_node)
+    graph.node.insert(concat_idx + 2, dequant_node)
+
+
+def _apply_value_style(
+    graph: onnx.GraphProto,
+    c: _KvCacheCandidate,
+    taken_names: Set[str],
+    input_by_name: Dict[str, onnx.ValueInfoProto],
+    output_by_name: Dict[str, onnx.ValueInfoProto],
+) -> None:
+    """Data-free, per-token (Value-style) rewrite -- see the module
+    docstring's diagram. Needs no calibration: each new token's own scale
+    is computed from that token's own values, at graph-run time.
+    """
+    prefix = f"{c.present_name}_kv"
+    past_input = input_by_name[c.past_name]
+    present_output = output_by_name[c.present_name]
+    past_rank = len(past_input.type.tensor_type.shape.dim)
+
+    # New past_*_scale graph input: same rank/leading dims as past_* (read
+    # before past_input's own dtype is mutated below), channel axis forced
+    # to size 1 -- one scale per already-cached token, broadcasting over
+    # head_dim. Picked up by KvCachePipeline's existing
+    # present./past_key_values. string-substitution convention with no
+    # C++ changes needed -- it stays float32, already handled.
+    past_scale_name = _unique_name(f"{c.past_name}_scale", taken_names)
+    past_scale_input = onnx.ValueInfoProto()
+    past_scale_input.name = past_scale_name
+    past_scale_input.type.tensor_type.elem_type = onnx.TensorProto.FLOAT
+    for i, d in enumerate(past_input.type.tensor_type.shape.dim):
+        new_dim = past_scale_input.type.tensor_type.shape.dim.add()
+        if i == c.channel_axis:
+            new_dim.dim_value = 1
+        elif d.HasField("dim_value"):
+            new_dim.dim_value = d.dim_value
+        elif d.HasField("dim_param"):
+            new_dim.dim_param = d.dim_param
+    graph.input.append(past_scale_input)
+
+    past_input.type.tensor_type.elem_type = onnx.TensorProto.INT8
+
+    eps_name = _unique_name(f"{prefix}_eps", taken_names)
+    graph.initializer.append(
+        onnx.numpy_helper.from_array(np.array(1e-12, dtype=np.float32), name=eps_name)
+    )
+    div127_name = _unique_name(f"{prefix}_127", taken_names)
+    graph.initializer.append(
+        onnx.numpy_helper.from_array(
+            np.array(127.0, dtype=np.float32), name=div127_name
+        )
+    )
+    clip_min_name = _unique_name(f"{prefix}_clip_min", taken_names)
+    graph.initializer.append(
+        onnx.numpy_helper.from_array(
+            np.array(-128.0, dtype=np.float32), name=clip_min_name
+        )
+    )
+    clip_max_name = _unique_name(f"{prefix}_clip_max", taken_names)
+    graph.initializer.append(
+        onnx.numpy_helper.from_array(
+            np.array(127.0, dtype=np.float32), name=clip_max_name
+        )
+    )
+    axes_name = _unique_name(f"{prefix}_reduce_axes", taken_names)
+    graph.initializer.append(
+        onnx.numpy_helper.from_array(
+            np.array([c.channel_axis], dtype=np.int64), name=axes_name
+        )
+    )
+
+    # new_scale = max(reduce_max(abs(new_value), axis=channel_axis), eps) / 127
+    abs_name = _unique_name(f"{prefix}_abs", taken_names)
+    max_name = _unique_name(f"{prefix}_max", taken_names)
+    safe_max_name = _unique_name(f"{prefix}_safe_max", taken_names)
+    new_scale_name = _unique_name(f"{prefix}_new_scale", taken_names)
+    # new_value_q = cast(clip(round(new_value / new_scale), -128, 127), INT8)
+    scaled_name = _unique_name(f"{prefix}_scaled", taken_names)
+    rounded_name = _unique_name(f"{prefix}_rounded", taken_names)
+    clipped_name = _unique_name(f"{prefix}_clipped", taken_names)
+    new_q_name = _unique_name(f"{c.new_name}_kv_q", taken_names)
+
+    pre_nodes = [
+        onnx.helper.make_node("Abs", [c.new_name], [abs_name]),
+        onnx.helper.make_node(
+            "ReduceMax", [abs_name, axes_name], [max_name], keepdims=1
+        ),
+        onnx.helper.make_node("Clip", [max_name, eps_name], [safe_max_name]),
+        onnx.helper.make_node("Div", [safe_max_name, div127_name], [new_scale_name]),
+        onnx.helper.make_node("Div", [c.new_name, new_scale_name], [scaled_name]),
+        onnx.helper.make_node("Round", [scaled_name], [rounded_name]),
+        onnx.helper.make_node(
+            "Clip", [rounded_name, clip_min_name, clip_max_name], [clipped_name]
+        ),
+        onnx.helper.make_node(
+            "Cast", [clipped_name], [new_q_name], to=onnx.TensorProto.INT8
+        ),
+    ]
+
+    if c.new_is_first_input:
+        c.concat_node.input[0] = new_q_name
+    else:
+        c.concat_node.input[1] = new_q_name
+    present_output.type.tensor_type.elem_type = onnx.TensorProto.INT8
+
+    # present_*_scale: NEW graph output, grows in lockstep with present_*
+    # itself (same seq_axis Concat, same two operands' relative order).
+    present_scale_name = _unique_name(f"{c.present_name}_scale", taken_names)
+    present_scale_output = onnx.ValueInfoProto()
+    present_scale_output.name = present_scale_name
+    present_scale_output.type.tensor_type.elem_type = onnx.TensorProto.FLOAT
+    for _ in range(past_rank):
+        present_scale_output.type.tensor_type.shape.dim.add()
+    present_scale_output.type.tensor_type.shape.dim[c.channel_axis].dim_value = 1
+    graph.output.append(present_scale_output)
+
+    present_f32_name = _unique_name(f"{prefix}_present_f32", taken_names)
+    dequant_name = _unique_name(f"{c.present_name}_kv_f", taken_names)
+    post_nodes = [
+        onnx.helper.make_node(
+            "Concat",
+            [past_scale_name, new_scale_name],
+            [present_scale_name],
+            name=_unique_name(f"{prefix}_concat_scale_node", taken_names),
+            axis=c.seq_axis,
+        ),
+        onnx.helper.make_node(
+            "Cast", [c.present_name], [present_f32_name], to=onnx.TensorProto.FLOAT
+        ),
+        onnx.helper.make_node(
+            "Mul", [present_f32_name, present_scale_name], [dequant_name]
+        ),
+    ]
+
+    _rewire_consumers(graph, c, dequant_name)
+
+    concat_idx = next(i for i, n in enumerate(graph.node) if n is c.concat_node)
+    for offset, node in enumerate(pre_nodes):
+        graph.node.insert(concat_idx + offset, node)
+    for offset, node in enumerate(post_nodes):
+        graph.node.insert(concat_idx + len(pre_nodes) + 1 + offset, node)

--- a/tests/test_kv_cache_quantization.py
+++ b/tests/test_kv_cache_quantization.py
@@ -67,6 +67,44 @@ def _rel_l2(a, b):
     return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
 
 
+def _kv_cache_value_model(batch=1, heads=2, head_dim=4, opset=18, symbolic_seq=True):
+    # Mirrors _kv_cache_model, but named to match this repo's own
+    # present.{i}.decoder.value-style convention (containing the literal
+    # substring ".value") so quantize_kv_cache's name-based auto-detection
+    # picks it up as a Value-style (per-token) stream instead of the
+    # default Key-style (per-channel) one.
+    seq_past = "seq_past" if symbolic_seq else 3
+    seq_present = "seq_present" if symbolic_seq else 4
+    nodes = [
+        onnx.helper.make_node("Identity", ["new_value_raw"], ["new_value"]),
+        onnx.helper.make_node(
+            "Concat",
+            ["past_key_values.0.value", "new_value"],
+            ["present.0.value"],
+            axis=2,
+        ),
+        onnx.helper.make_node(
+            "ReduceSum", ["present.0.value"], ["summary"], keepdims=0
+        ),
+    ]
+    graph = onnx.helper.make_graph(
+        nodes,
+        "g",
+        [
+            _vi("past_key_values.0.value", [batch, heads, seq_past, head_dim]),
+            _vi("new_value_raw", [batch, heads, 1, head_dim]),
+        ],
+        [
+            _vi("present.0.value", [batch, heads, seq_present, head_dim]),
+            _vi("summary", []),
+        ],
+        [],
+    )
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=8
+    )
+
+
 def test_kv_cache_quantization_changes_input_and_output_to_int8():
     model = _kv_cache_model()
     q = onnxsim.quantize_kv_cache(model, num_samples=4, seed=0)
@@ -188,3 +226,199 @@ def test_kv_cache_quantization_noop_below_opset13():
     model = _kv_cache_model(opset=12)
     result = onnxsim.quantize_kv_cache(model)
     assert result.SerializeToString() == model.SerializeToString()
+
+
+# ---------------------------------------------------- Value-style (KIVI) ---
+
+
+def test_value_style_matched_by_name_adds_second_scale_stream():
+    model = _kv_cache_value_model()
+    q = onnxsim.quantize_kv_cache(model)  # no calibration_data needed at all
+    onnx.checker.check_model(q)
+
+    past_vi = next(i for i in q.graph.input if i.name == "past_key_values.0.value")
+    present_vi = next(o for o in q.graph.output if o.name == "present.0.value")
+    assert past_vi.type.tensor_type.elem_type == onnx.TensorProto.INT8
+    assert present_vi.type.tensor_type.elem_type == onnx.TensorProto.INT8
+
+    # A brand-new paired scale input/output, threaded alongside the codes.
+    scale_in = next(
+        i for i in q.graph.input if i.name == "past_key_values.0.value_scale"
+    )
+    scale_out = next(o for o in q.graph.output if o.name == "present.0.value_scale")
+    assert scale_in.type.tensor_type.elem_type == onnx.TensorProto.FLOAT
+    assert scale_out.type.tensor_type.elem_type == onnx.TensorProto.FLOAT
+
+    op_types = [n.op_type for n in q.graph.node]
+    # Data-free per-token math, not the calibrated QuantizeLinear/
+    # DequantizeLinear pair the Key-style path uses.
+    for op in ("Abs", "ReduceMax", "Round", "Clip", "Cast", "Mul", "Div"):
+        assert op in op_types
+    assert "QuantizeLinear" not in op_types
+    assert "DequantizeLinear" not in op_types
+    assert op_types.count("Concat") == 2  # codes stream + scale stream
+
+
+def test_value_style_two_step_round_trip_close_to_float():
+    batch, heads, head_dim = 1, 2, 6
+    model = _kv_cache_value_model(batch=batch, heads=heads, head_dim=head_dim)
+    q = onnxsim.quantize_kv_cache(model)
+    dequant_node = next(n for n in q.graph.node if n.op_type == "Mul")
+    q_probe = onnx.ModelProto()
+    q_probe.CopyFrom(q)
+    q_probe.graph.output.append(onnx.ValueInfoProto(name=dequant_node.output[0]))
+
+    rng = np.random.default_rng(5)
+    empty_past = np.zeros((batch, heads, 0, head_dim), dtype=np.float32)
+    empty_past_scale = np.zeros((batch, heads, 0, 1), dtype=np.float32)
+    new0 = rng.standard_normal((batch, heads, 1, head_dim)).astype(np.float32)
+    new1 = rng.standard_normal((batch, heads, 1, head_dim)).astype(np.float32)
+
+    float_present0, _ = _run(
+        model, {"past_key_values.0.value": empty_past, "new_value_raw": new0}
+    )
+    float_present1, _ = _run(
+        model, {"past_key_values.0.value": float_present0, "new_value_raw": new1}
+    )
+
+    empty_past_int8 = np.zeros((batch, heads, 0, head_dim), dtype=np.int8)
+    q_present0, _, q_scale0 = _run(
+        q,
+        {
+            "past_key_values.0.value": empty_past_int8,
+            "past_key_values.0.value_scale": empty_past_scale,
+            "new_value_raw": new0,
+        },
+    )
+    assert q_present0.dtype == np.int8
+    q_present1, _, q_scale1, q_present1_f = _run(
+        q_probe,
+        {
+            "past_key_values.0.value": q_present0,
+            "past_key_values.0.value_scale": q_scale0,
+            "new_value_raw": new1,
+        },
+    )
+    assert q_present1.dtype == np.int8
+    # Same generous bound as the Key-style round-trip test -- a per-token
+    # scale still clips whatever this step's own token's max happens to be
+    # relative to its own value, but there is no calibration-coverage risk
+    # here at all (the scale is fit to that exact token, not estimated).
+    assert _rel_l2(float_present1, q_present1_f) < 0.1
+
+
+def test_explicit_value_output_names_overrides_name_heuristic():
+    # A present name that does *not* contain ".value" still gets Value-style
+    # treatment when named explicitly.
+    nodes = [
+        onnx.helper.make_node("Identity", ["new_raw"], ["new_x"]),
+        onnx.helper.make_node("Concat", ["past_x", "new_x"], ["present_x"], axis=2),
+    ]
+    graph = onnx.helper.make_graph(
+        nodes,
+        "g",
+        [_vi("past_x", [1, 2, "seq_past", 4]), _vi("new_raw", [1, 2, 1, 4])],
+        [_vi("present_x", [1, 2, "seq_present", 4])],
+        [],
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 18)], ir_version=8
+    )
+    q = onnxsim.quantize_kv_cache(model, value_output_names=["present_x"])
+    onnx.checker.check_model(q)
+    assert any(i.name == "past_x_scale" for i in q.graph.input)
+    assert any(o.name == "present_x_scale" for o in q.graph.output)
+
+
+def test_mixed_key_and_value_streams_get_asymmetric_treatment():
+    # The actual point of the feature: one model with both a Key-style and
+    # a Value-style stream gets the right treatment for each, in one call.
+    nodes = [
+        onnx.helper.make_node("Identity", ["new_key_raw"], ["new_key"]),
+        onnx.helper.make_node(
+            "Concat", ["past_key", "new_key"], ["present_key"], axis=2
+        ),
+        onnx.helper.make_node("Identity", ["new_value_raw"], ["new_value"]),
+        onnx.helper.make_node(
+            "Concat",
+            ["past_key_values.0.value", "new_value"],
+            ["present.0.value"],
+            axis=2,
+        ),
+    ]
+    graph = onnx.helper.make_graph(
+        nodes,
+        "g",
+        [
+            _vi("past_key", [1, 2, "seq_past", 4]),
+            _vi("new_key_raw", [1, 2, 1, 4]),
+            _vi("past_key_values.0.value", [1, 2, "seq_past", 4]),
+            _vi("new_value_raw", [1, 2, 1, 4]),
+        ],
+        [
+            _vi("present_key", [1, 2, "seq_present", 4]),
+            _vi("present.0.value", [1, 2, "seq_present", 4]),
+        ],
+        [],
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 18)], ir_version=8
+    )
+    q = onnxsim.quantize_kv_cache(model, num_samples=4, seed=0)
+    onnx.checker.check_model(q)
+
+    op_types = [n.op_type for n in q.graph.node]
+    assert "QuantizeLinear" in op_types  # the Key stream
+    assert "DequantizeLinear" in op_types
+    assert "ReduceMax" in op_types  # the Value stream
+    assert not any(i.name == "past_key_scale" for i in q.graph.input)
+    assert any(i.name == "past_key_values.0.value_scale" for i in q.graph.input)
+
+
+def test_value_style_left_untouched_below_opset18_while_key_style_still_works():
+    # ReduceMax's axes-as-input form (needed for the Value-style rewrite)
+    # only arrived at opset 18 -- ReduceSum got it at opset 13, but each
+    # Reduce* op moved on its own schedule. Below opset 18, a matched
+    # Value-style stream must be left completely untouched rather than
+    # silently downgraded to Key-style, while a co-existing Key-style
+    # stream in the same model is unaffected.
+    nodes = [
+        onnx.helper.make_node("Identity", ["new_key_raw"], ["new_key"]),
+        onnx.helper.make_node(
+            "Concat", ["past_key", "new_key"], ["present_key"], axis=2
+        ),
+        onnx.helper.make_node("Identity", ["new_value_raw"], ["new_value"]),
+        onnx.helper.make_node(
+            "Concat",
+            ["past_key_values.0.value", "new_value"],
+            ["present.0.value"],
+            axis=2,
+        ),
+    ]
+    graph = onnx.helper.make_graph(
+        nodes,
+        "g",
+        [
+            _vi("past_key", [1, 2, "seq_past", 4]),
+            _vi("new_key_raw", [1, 2, 1, 4]),
+            _vi("past_key_values.0.value", [1, 2, "seq_past", 4]),
+            _vi("new_value_raw", [1, 2, 1, 4]),
+        ],
+        [
+            _vi("present_key", [1, 2, "seq_present", 4]),
+            _vi("present.0.value", [1, 2, "seq_present", 4]),
+        ],
+        [],
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 13)], ir_version=8
+    )
+    q = onnxsim.quantize_kv_cache(model, num_samples=4, seed=0)
+    onnx.checker.check_model(q)
+
+    key_past = next(i for i in q.graph.input if i.name == "past_key")
+    value_past = next(i for i in q.graph.input if i.name == "past_key_values.0.value")
+    assert key_past.type.tensor_type.elem_type == onnx.TensorProto.INT8
+    assert value_past.type.tensor_type.elem_type == onnx.TensorProto.FLOAT  # untouched
+    assert not any(i.name == "past_key_values.0.value_scale" for i in q.graph.input)
+    assert "ReduceMax" not in [n.op_type for n in q.graph.node]


### PR DESCRIPTION
## Summary

Follows up on `quantize_kv_cache` (#759), completing the other half of
KIVI's asymmetric Key/Value split that the module's own docs previously
scoped out. Key-style (static, calibrated, per-channel) was already
implemented and matches KIVI's finding for Key activations. This adds
**Value-style**: a fresh, data-free scale per *token*, computed from that
token's own values the instant it's produced -- matching KIVI's other
finding, that Value activations don't have Key's persistent-channel
structure, so a per-token scale preserves more accuracy there.

## What changed

- New rewrite for streams matched as Value-style (a `present` output name
  containing `".value"` -- matching this repo's own
  `present.{i}.decoder.value` convention -- or listed explicitly via the
  new `value_output_names` parameter): `new_scale = max(reduce_max(abs(new_value),
  axis=head_dim), eps) / 127`, `new_value_q = cast(clip(round(new_value /
  new_scale), -128, 127), INT8)`, with the scale itself threaded forward
  as a **second, parallel growing KV-cache stream**
  (`past_*_scale`/`present_*_scale`) alongside the codes.
- The default (unnamed) behavior is unchanged: every existing test in
  `tests/test_kv_cache_quantization.py` passes unmodified, and the
  Key-style path's code is untouched other than being factored into its
  own helper function alongside the new one.
- The new scale stream needs zero changes to `onnx-deploy`'s
  `KvCachePipeline` -- it's float32, a dtype `detail::BorrowView` already
  handled before #759 even existed, and gets picked up by the existing
  `present.`/`past_key_values.` string-substitution convention for free.

## A real bug found and fixed before it shipped

`ReduceMax`'s `axes`-as-input form (needed to compute each new token's own
max) only arrived at **opset 18**, not opset 13 as I initially assumed --
`ReduceSum` got that at opset 13, but each `Reduce*` op moved its `axes`
attribute to an input on its own schedule, not all together. Caught this
via `onnx.checker.check_model` rejecting the constructed graph, not by
guessing: fixed by gating Value-style specifically on opset >= 18 and
leaving a matched stream *completely untouched* below that (never silently
downgraded to Key-style) -- verified with a dedicated test
(`test_value_style_left_untouched_below_opset18_while_key_style_still_works`)
covering a model with both stream types at opset 13, confirming the
Key-style stream is unaffected while the Value-style one is left alone.

## Verification

- `test_value_style_two_step_round_trip_close_to_float`: a genuine
  two-step round trip (empty cache -> step 0 -> step 1, threading *both*
  the codes and the new scale stream back in, exactly what a real pipeline
  does), compared against the float model's own output.
- `test_mixed_key_and_value_streams_get_asymmetric_treatment`: one model
  with both stream types, verifying each gets the right treatment in a
  single call -- the actual point of the feature.
- `test_explicit_value_output_names_overrides_name_heuristic`,
  `test_value_style_left_untouched_below_opset18_...`: the two edge cases
  above.
- All 6 pre-existing tests pass unmodified (11 total now).
- Full regression sweep (`tests/`, `CI=1`, extension rebuilt against
  current source first -- master has moved since this branch was last
  built): 732 passed, 78 skipped, 0 failures caused by this change (only
  pre-existing `onnxscript` `ModuleNotFoundError` in unrelated files).
- `ruff format` / `ruff check` / `mypy` clean (mypy's pre-existing 16
  errors in other files are unchanged; this module introduces none).

## Still out of scope (per the module's own docs, unchanged)

KIVI's residual-window bookkeeping (the most recent `R` tokens kept in
full precision) -- genuinely cross-step, host-side state belonging in
`onnx-deploy`'s `KvCachePipeline`, not a single ONNX graph rewrite.

## Test plan

- [x] `pytest tests/test_kv_cache_quantization.py -v`
- [x] Full `tests/` sweep with `CI=1`
- [x] `ruff format` / `ruff check` / `mypy`

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_