### PR TITLE
Add Split and Identity op support to symbolic value evaluator

### DIFF
--- a/onnxsim/sym_value_eval.cpp
+++ b/onnxsim/sym_value_eval.cpp
@@ -68,6 +68,17 @@ class Evaluator {
 
   std::map<std::string, SymTensor> Run() {
     for (const SymNode& node : graph_.node) {
+      // Split is the one op this pass folds that produces more than one
+      // output, so it is dispatched separately from the single-output Eval.
+      if (node.op_type == "Split") {
+        if (auto outs = EvalSplit(node)) {
+          for (std::size_t i = 0; i < node.output.size(); ++i) {
+            if (!node.output[i].empty())
+              values_[node.output[i]] = std::move((*outs)[i]);
+          }
+        }
+        continue;
+      }
       auto value = Eval(node);
       if (value && node.output.size() == 1 && !node.output[0].empty()) {
         values_[node.output[0]] = std::move(*value);
@@ -119,6 +130,7 @@ class Evaluator {
   std::optional<SymTensor> Eval(const SymNode& node) {
     const std::string& op = node.op_type;
     if (op == "Constant") return EvalConstant(node);
+    if (op == "Identity") return EvalIdentity(node);
     if (op == "Shape") return EvalShape(node);
     if (op == "Size") return EvalSize(node);
     if (op == "Gather") return EvalGather(node);
@@ -165,6 +177,13 @@ class Evaluator {
       if (a->i) return SymTensor::Scalar(SymExpr(*a->i));
     }
     return std::nullopt;
+  }
+
+  std::optional<SymTensor> EvalIdentity(const SymNode& node) {
+    if (node.input.empty()) return std::nullopt;
+    const SymTensor* data = Value(node.input[0]);
+    if (!data) return std::nullopt;
+    return *data;
   }
 
   std::optional<SymTensor> EvalShape(const SymNode& node) {
@@ -230,6 +249,49 @@ class Evaluator {
       out.insert(out.end(), t->data.begin(), t->data.end());
     }
     return SymTensor::Vector(std::move(out));
+  }
+
+  // Split is dispatched from Run() (see above), not from the single-output
+  // Eval() switch, since it has one output per node.output entry.
+  std::optional<std::vector<SymTensor>> EvalSplit(const SymNode& node) {
+    if (node.input.empty() || node.output.empty()) return std::nullopt;
+    const SymTensor* data = Value(node.input[0]);
+    if (!data || !data->is_vector()) return std::nullopt;
+    const int64_t axis = IntAttr(node, "axis", 0).value();
+    if (!(axis == 0 || axis == -1)) return std::nullopt;  // rank-1 data only
+    const int64_t len = data->size();
+    const std::size_t num_outputs = node.output.size();
+
+    // Split sizes: explicit via the deprecated "split" attribute or the
+    // opset-13+ second input; otherwise split evenly across num_outputs. The
+    // uneven-remainder rule for an implicit split (last chunk gets the
+    // remainder) varies across opsets, so an implicit split that does not
+    // divide evenly is left unresolved rather than guessed at.
+    std::vector<int64_t> sizes;
+    if (auto s = IntListOperand(node, "split", 1)) {
+      sizes = *s;
+    } else {
+      if (len % static_cast<int64_t>(num_outputs) != 0) return std::nullopt;
+      sizes.assign(num_outputs, len / static_cast<int64_t>(num_outputs));
+    }
+    if (sizes.size() != num_outputs) return std::nullopt;
+
+    int64_t total = 0;
+    for (int64_t s : sizes) {
+      if (s < 0) return std::nullopt;
+      total += s;
+    }
+    if (total != len) return std::nullopt;
+
+    std::vector<SymTensor> outs;
+    outs.reserve(num_outputs);
+    auto it = data->data.begin();
+    for (int64_t s : sizes) {
+      std::vector<SymExpr> chunk(it, it + s);
+      outs.push_back(SymTensor::Vector(std::move(chunk)));
+      it += s;
+    }
+    return outs;
   }
 
   std::optional<SymTensor> EvalUnsqueeze(const SymNode& node) {

--- a/onnxsim/sym_value_eval.h
+++ b/onnxsim/sym_value_eval.h
@@ -12,8 +12,8 @@ namespace onnxsim {
 
 // M1 of issue #532: a dependency-free *symbolic value evaluator* for the shape
 // scaffolding (`Shape -> Gather -> Unsqueeze -> Concat -> Reshape`, plus
-// `Where`/`Equal`/`Div`/`Expand`) that ONNX data propagation cannot fold on a
-// graph with a dynamic dimension.
+// `Where`/`Equal`/`Div`/`Expand`/`Split`/`Identity`) that ONNX data
+// propagation cannot fold on a graph with a dynamic dimension.
 //
 // ONNX data propagation carries a tensor's value as a TensorShapeProto whose
 // entries are either a concrete int or an *opaque* dim_param string; it cannot

--- a/onnxsim/sym_value_eval_test.cpp
+++ b/onnxsim/sym_value_eval_test.cpp
@@ -299,6 +299,48 @@ int main() {
     assert(Is(v, "sq", {"batch**2", "9"}, false));
   }
 
+  // === Split: even implicit split preserves the dynamic dim's identity =====
+  //   Shape([batch, 8]) -> Split(num_outputs=2) -> b == batch, eight == 8
+  {
+    SymGraph g;
+    g.shape["x"] = {batch, SymExpr(8)};
+    g.node = {N("Shape", {"x"}, {"s"}),
+              N("Split", {"s"}, {"b", "eight"}, {AInt("axis", 0)})};
+    const auto v = onnxsim::EvaluateSymbolicValues(g);
+    assert(Is(v, "b", {"batch"}, false));
+    assert(Is(v, "eight", {"8"}, false));
+  }
+
+  // Split with explicit sizes (the "split" attribute / opset-13+ 2nd input).
+  {
+    SymGraph g;
+    g.initializer["data"] = Vec({1, 2, 3, 4, 5});
+    g.node = {N("Split", {"data"}, {"head", "tail"}, {AInts("split", {2, 3})})};
+    const auto v = onnxsim::EvaluateSymbolicValues(g);
+    assert(Is(v, "head", {"1", "2"}, false));
+    assert(Is(v, "tail", {"3", "4", "5"}, false));
+  }
+
+  // An implicit split that does not divide evenly is left unresolved rather
+  // than guessing at the opset-specific remainder rule.
+  {
+    SymGraph g;
+    g.initializer["data"] = Vec({1, 2, 3});
+    g.node = {N("Split", {"data"}, {"a", "b"})};
+    const auto v = onnxsim::EvaluateSymbolicValues(g);
+    assert(v.find("a") == v.end());
+    assert(v.find("b") == v.end());
+  }
+
+  // === Identity passes the value through unchanged =========================
+  {
+    SymGraph g;
+    g.shape["x"] = {batch};
+    g.node = {N("Shape", {"x"}, {"s"}), N("Identity", {"s"}, {"id"})};
+    const auto v = onnxsim::EvaluateSymbolicValues(g);
+    assert(Is(v, "id", {"batch"}, false));
+  }
+
   // === Constant node seeds (value_ints) ====================================
   {
     SymGraph g;


### PR DESCRIPTION
## Summary
Extends the symbolic value evaluator to handle two additional ONNX operations: `Split` and `Identity`. This enables the shape inference pipeline to fold more complex shape-manipulation patterns that include these operators.

## Key Changes
- **Split operator support**: Implements `EvalSplit()` to handle both explicit splits (via the `split` attribute or opset-13+ second input) and implicit even splits. Conservatively returns `std::nullopt` for uneven implicit splits to avoid guessing at opset-specific remainder rules.
- **Identity operator support**: Implements `EvalIdentity()` to pass tensor values through unchanged.
- **Dispatch logic**: Adds special handling in `Run()` to dispatch `Split` separately since it produces multiple outputs (one per `node.output` entry), unlike other operators handled by the single-output `Eval()` switch.
- **Documentation**: Updates header comments to reflect the newly supported operators.

## Implementation Details
- `Split` is dispatched from `Run()` rather than the `Eval()` switch because it returns `std::vector<SymTensor>` instead of a single optional value, allowing it to populate multiple output names from a single node.
- The `Split` implementation validates that axis is 0 or -1 (rank-1 data only), checks split size consistency, and conservatively rejects uneven implicit splits to avoid opset-version-dependent behavior.
- Comprehensive test coverage added for both operators, including edge cases like uneven splits and dynamic dimension preservation.

https://claude.ai/code/session_011EXPkyK8fCGUJXHfHmCKgS