### PR TITLE
docs: note the onnx.parser test-construction convention in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,3 +28,33 @@ Don't get confused by `ONNXSIM_BUILTIN_ORT` when working on the wheel build.
 So: **building ONNX Runtime is not required to build, test, or ship the Python wheel.**
 If you see long ONNX Runtime C++ compilation, that's the `ONNXSIM_BUILTIN_ORT=ON` path
 (standalone C++/WASM), not the wheel path.
+
+## Prefer `onnx.parser`-based model construction in tests
+
+When writing new tests or touching an existing test file's model-building code, build
+`ModelProto`/`GraphProto`/`FunctionProto` via `onnx.parser.parse_model()` /
+`parse_function()` (the ONNX text format) instead of chains of
+`onnx.helper.make_node`/`make_graph`/`make_model`. The text form reads like the graph it
+describes, so a test's structure is visible at a glance instead of buried in positional
+`make_node(...)` argument lists.
+
+- A common pattern across the migrated test files: a small
+  `_model(body, initializer=(), opset=..., ir_version=...)` helper that wraps
+  `parser.parse_model(f"<ir_version: ..., opset_import: [...]> {body}")` and then does
+  `model.graph.initializer.extend(initializer)`.
+- Keep random/large weight arrays as numpy-built `onnx.numpy_helper.from_array`
+  initializers attached programmatically after parsing -- don't try to spell out large
+  tensors as text literals. Small, fixed/deterministic constants are fine as text
+  literals (`<float C = {2.0}>`).
+- Helpers that build a reusable node sequence should return a text fragment (a string)
+  rather than a list of node protos, so callers can concatenate/interpolate them the same
+  way as the rest of the body.
+- It's fine to fall back to `onnx.helper` for the rare case where the text format can't
+  express the exact semantics under test -- e.g. a value info with no shape field at all
+  ("rank not statically known", `ClearField("shape")` after a placeholder parse), or a
+  tensor that must be byte-equal to a `numpy_helper.from_array`-produced one (the parser
+  encodes tensor literals as `float_data`, not `raw_data`). When you do this, leave a
+  short comment saying why the text form doesn't fit.
+
+See `tests/test_python_api.py`, `tests/test_fusion_patterns.py`, `tests/test_pruning.py`,
+and the other already-migrated `tests/test_*.py` files for the established pattern.


### PR DESCRIPTION
## Summary

Adds a "Prefer `onnx.parser`-based model construction in tests" section to `CLAUDE.md`, documenting the convention established across the `onnx.parser` test migration series (#768, #771, #772, #773, #776, #777, #778, #779, #781, #782, #783, #784, #785, #787, #788): prefer `onnx.parser.parse_model`/`parse_function` (the ONNX text format) over `onnx.helper.make_node`/`make_graph`/`make_model` chains when writing or touching test model-construction code.

Covers:
- The common `_model(body, initializer=(), opset=..., ir_version=...)` helper shape used across the migrated files.
- Keeping random/large weight initializers numpy-built and attached post-parse, vs. small fixed constants as text literals.
- Returning composable text fragments (strings) from reusable node-sequence helpers.
- The documented exceptions where falling back to `onnx.helper` is still correct (unranked value info via `ClearField("shape")`, byte-equal tensor matching against `numpy_helper.from_array`'s `raw_data` encoding).

No code changes — documentation only.

## Test plan

N/A — documentation-only change.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_