### PR TITLE
tests: migrate test_weight_only_quantize_int8_block.py to onnx.parser

### DIFF
--- a/tests/test_weight_only_quantize_int8_block.py
+++ b/tests/test_weight_only_quantize_int8_block.py
@@ -15,9 +15,9 @@ import collections
 
 import numpy as np
 import onnx
-import onnx.helper
 import onnx.numpy_helper
 import pytest
+from onnx import parser
 
 import onnxsim
 
@@ -26,15 +26,18 @@ import onnxsim
 ort = pytest.importorskip("onnxruntime")
 
 
-def _model(nodes, inputs, outputs, initializer, opset=21):
-    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
-    return onnx.helper.make_model(
-        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
     )
-
-
-def _vi(name, shape):
-    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+    model.graph.initializer.extend(initializer)
+    return model
 
 
 def _f32(array, name):
@@ -65,8 +68,15 @@ def test_quantize_matmul():
     rng = np.random.default_rng(0)
     K, N = 64, 16
     weight = _f32(rng.standard_normal((K, N)) * 0.5, "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [4, K])], [_vi("Y", [4, N])], [weight])
+    model = _model(
+        f"""
+        g (float[4,{K}] X) => (float[4,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [weight],
+    )
 
     quant = onnxsim.quantize_weight_only_int8_block(model)
     onnx.checker.check_model(quant)
@@ -91,8 +101,15 @@ def test_quantize_more_precise_than_per_channel_int8():
     w = rng.standard_normal((K, N)).astype(np.float32) * 0.1
     w[0, :] = 50.0  # one outlier row blows a per-channel scale
     weight = _f32(w, "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [4, K])], [_vi("Y", [4, N])], [weight])
+    model = _model(
+        f"""
+        g (float[4,{K}] X) => (float[4,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [weight],
+    )
 
     quant_per_channel = onnxsim.quantize_weight_only(model)
     quant_block = onnxsim.quantize_weight_only_int8_block(model)
@@ -114,8 +131,15 @@ def test_quantize_gemm_transb_with_bias():
     K, N = 96, 12
     weight = _f32(rng.standard_normal((N, K)) * 0.5, "W")
     bias = _f32(rng.standard_normal(N), "B")
-    nodes = [onnx.helper.make_node("Gemm", ["X", "W", "B"], ["Y"], transB=1)]
-    model = _model(nodes, [_vi("X", [3, K])], [_vi("Y", [3, N])], [weight, bias])
+    model = _model(
+        f"""
+        g (float[3,{K}] X) => (float[3,{N}] Y)
+        {{
+          Y = Gemm<transB = 1>(X, W, B)
+        }}
+        """,
+        [weight, bias],
+    )
 
     quant = onnxsim.quantize_weight_only_int8_block(model)
     onnx.checker.check_model(quant)
@@ -134,8 +158,15 @@ def test_quantize_scale_shape_matches_block_count():
     rng = np.random.default_rng(2)
     K, N = 64, 8
     weight = _f32(rng.standard_normal((K, N)) * 0.5, "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [1, K])], [_vi("Y", [1, N])], [weight])
+    model = _model(
+        f"""
+        g (float[1,{K}] X) => (float[1,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [weight],
+    )
 
     quant = onnxsim.quantize_weight_only_int8_block(model)
     scale_init = next(
@@ -151,8 +182,15 @@ def test_quantize_skips_k_not_divisible_by_block_size():
     rng = np.random.default_rng(3)
     K, N = 48, 8
     weight = _f32(rng.standard_normal((K, N)) * 0.5, "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [1, K])], [_vi("Y", [1, N])], [weight])
+    model = _model(
+        f"""
+        g (float[1,{K}] X) => (float[1,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [weight],
+    )
 
     quant = onnxsim.quantize_weight_only_int8_block(model)
     assert _op_counts(quant)["MatMul"] == 1
@@ -166,9 +204,14 @@ def test_quantize_conv_pointwise():
     rng = np.random.default_rng(5)
     cout, cin = 16, 32
     weight = _f32(rng.standard_normal((cout, cin, 1, 1)) * 0.5, "W")
-    nodes = [onnx.helper.make_node("Conv", ["X", "W"], ["Y"], kernel_shape=[1, 1])]
     model = _model(
-        nodes, [_vi("X", [1, cin, 8, 8])], [_vi("Y", [1, cout, 8, 8])], [weight]
+        f"""
+        g (float[1,{cin},8,8] X) => (float[1,{cout},8,8] Y)
+        {{
+          Y = Conv<kernel_shape = [1, 1]>(X, W)
+        }}
+        """,
+        [weight],
     )
 
     quant = onnxsim.quantize_weight_only_int8_block(model)
@@ -194,9 +237,14 @@ def test_quantize_conv_spatial_kernel_with_bias():
     cout, cin = 4, 8
     weight = _f32(rng.standard_normal((cout, cin, 2, 2)) * 0.5, "W")
     bias = _f32(rng.standard_normal(cout), "B")
-    nodes = [onnx.helper.make_node("Conv", ["X", "W", "B"], ["Y"], kernel_shape=[2, 2])]
     model = _model(
-        nodes, [_vi("X", [1, cin, 8, 8])], [_vi("Y", [1, cout, 7, 7])], [weight, bias]
+        f"""
+        g (float[1,{cin},8,8] X) => (float[1,{cout},7,7] Y)
+        {{
+          Y = Conv<kernel_shape = [2, 2]>(X, W, B)
+        }}
+        """,
+        [weight, bias],
     )
 
     quant = onnxsim.quantize_weight_only_int8_block(model)
@@ -215,11 +263,13 @@ def test_quantize_conv_skips_inner_not_divisible_by_block_size():
     rng = np.random.default_rng(7)
     cout, cin = 4, 4
     weight = _f32(rng.standard_normal((cout, cin, 3, 3)) * 0.5, "W")
-    nodes = [onnx.helper.make_node("Conv", ["X", "W"], ["Y"], kernel_shape=[3, 3])]
     model = _model(
-        nodes,
-        [_vi("X", [1, cin, 8, 8])],
-        [_vi("Y", [1, cout, 6, 6])],
+        f"""
+        g (float[1,{cin},8,8] X) => (float[1,{cout},6,6] Y)
+        {{
+          Y = Conv<kernel_shape = [3, 3]>(X, W)
+        }}
+        """,
         [weight],
     )
 
@@ -229,9 +279,13 @@ def test_quantize_conv_skips_inner_not_divisible_by_block_size():
 
 
 def test_quantize_skips_non_constant_weight():
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
     model = _model(
-        nodes, [_vi("X", [4, 64]), _vi("W", [64, 4])], [_vi("Y", [4, 4])], []
+        """
+        g (float[4,64] X, float[64,4] W) => (float[4,4] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """
     )
     quant = onnxsim.quantize_weight_only_int8_block(model)
     assert _op_counts(quant)["MatMul"] == 1
@@ -240,8 +294,16 @@ def test_quantize_skips_non_constant_weight():
 def test_quantize_skips_old_opset():
     # DequantizeLinear's block_size attribute needs opset >= 21.
     weight = _f32(np.random.default_rng(4).standard_normal((64, 4)), "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [4, 64])], [_vi("Y", [4, 4])], [weight], opset=20)
+    model = _model(
+        """
+        g (float[4,64] X) => (float[4,4] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """,
+        [weight],
+        opset=20,
+    )
     quant = onnxsim.quantize_weight_only_int8_block(model)
     assert _op_counts(quant)["MatMul"] == 1
     assert _op_counts(quant)["DequantizeLinear"] == 0


### PR DESCRIPTION
Continuation of the onnx.parser-based test readability migration.

Replaces `onnx.helper.make_node`/`make_graph`/`make_model` graph construction in `tests/test_weight_only_quantize_int8_block.py` with the ONNX text format, via the established per-file `_model(body, initializer=(), opset=21, ir_version=10)` helper wrapping `onnx.parser.parse_model`. Random/precision-sensitive weight and bias tensors are still built with numpy + `onnx.numpy_helper.from_array` and attached via `initializer=[...]`, per the established convention.

No `onnx.helper` exceptions were needed for this file — all inputs/outputs are simple ranked float32 tensors with no byte-equality or unranked-shape requirements, so `onnx.helper` and its `_vi(...)` helper are removed entirely.

Test names, assertions, and coverage are unchanged — this is a pure construction-style refactor.

## Test plan
- [x] `python3 -m py_compile tests/test_weight_only_quantize_int8_block.py`
- [x] `ruff check tests/test_weight_only_quantize_int8_block.py` — clean
- [x] `python3 -m pytest tests/test_weight_only_quantize_int8_block.py -q --no-header` — run 3x, all 10 tests pass each time
- [x] Test count cross-check: `git show origin/master:tests/test_weight_only_quantize_int8_block.py | grep -c "^def test_"` == 10 == count in migrated file

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_