### PR TITLE
tests: migrate test_weight_only_quantize_int4.py to onnx.parser

### DIFF
--- a/tests/test_weight_only_quantize_int4.py
+++ b/tests/test_weight_only_quantize_int4.py
@@ -2,22 +2,22 @@
 ``weight_only_quantize_int4_matmul``/``weight_only_quantize_int4_conv`` C++
 passes).
 
-Each model is built directly with ``onnx.helper`` (no torch dependency),
-quantized, and then actually run through ONNX Runtime -- both before and
-after quantization -- so these tests double as a minimal end-to-end
-simplify/quantize/deploy check: the quantized graph must load and execute
-under a real inference engine, and its outputs must stay close to the float
-baseline. Needs opset 21 for INT4 tensors and DequantizeLinear's block_size
-attribute.
+Each model is built directly with the ONNX text format (no torch
+dependency), quantized, and then actually run through ONNX Runtime -- both
+before and after quantization -- so these tests double as a minimal
+end-to-end simplify/quantize/deploy check: the quantized graph must load and
+execute under a real inference engine, and its outputs must stay close to the
+float baseline. Needs opset 21 for INT4 tensors and DequantizeLinear's
+block_size attribute.
 """
 
 import collections
 
 import numpy as np
 import onnx
-import onnx.helper
 import onnx.numpy_helper
 import pytest
+from onnx import parser
 
 import onnxsim
 
@@ -26,19 +26,22 @@ import onnxsim
 ort = pytest.importorskip("onnxruntime")
 
 
-def _model(nodes, inputs, outputs, initializer, opset=21):
-    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
+def _model(body, initializer=(), opset=21, ir_version=10):
     # Pin a low-ish IR version so the model loads under older onnxruntime
     # builds, matching test_fusion_patterns.py -- IR version 10 supports
     # opset 21 fine (IR version only gates the *envelope*, not individual op
     # opsets).
-    return onnx.helper.make_model(
-        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
     )
-
-
-def _vi(name, shape):
-    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+    model.graph.initializer.extend(initializer)
+    return model
 
 
 def _f32(array, name):
@@ -78,8 +81,15 @@ def test_quantize_matmul():
     rng = np.random.default_rng(0)
     K, N = 64, 16
     weight = _f32(rng.standard_normal((K, N)) * 0.5, "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [4, K])], [_vi("Y", [4, N])], [weight])
+    model = _model(
+        f"""
+        g (float[4,{K}] X) => (float[4,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[weight],
+    )
 
     quant = onnxsim.quantize_weight_only_int4(model)
     onnx.checker.check_model(quant)
@@ -101,8 +111,15 @@ def test_quantize_gemm_transb_with_bias():
     K, N = 96, 12
     weight = _f32(rng.standard_normal((N, K)) * 0.5, "W")
     bias = _f32(rng.standard_normal(N), "B")
-    nodes = [onnx.helper.make_node("Gemm", ["X", "W", "B"], ["Y"], transB=1)]
-    model = _model(nodes, [_vi("X", [3, K])], [_vi("Y", [3, N])], [weight, bias])
+    model = _model(
+        f"""
+        g (float[3,{K}] X) => (float[3,{N}] Y)
+        {{
+          Y = Gemm<transB = 1>(X, W, B)
+        }}
+        """,
+        initializer=[weight, bias],
+    )
 
     quant = onnxsim.quantize_weight_only_int4(model)
     onnx.checker.check_model(quant)
@@ -121,8 +138,15 @@ def test_quantize_scale_shape_matches_block_count():
     rng = np.random.default_rng(2)
     K, N = 64, 8
     weight = _f32(rng.standard_normal((K, N)) * 0.5, "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [1, K])], [_vi("Y", [1, N])], [weight])
+    model = _model(
+        f"""
+        g (float[1,{K}] X) => (float[1,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[weight],
+    )
 
     quant = onnxsim.quantize_weight_only_int4(model)
     scale_init = next(
@@ -138,8 +162,15 @@ def test_quantize_skips_k_not_divisible_by_block_size():
     rng = np.random.default_rng(3)
     K, N = 48, 8
     weight = _f32(rng.standard_normal((K, N)) * 0.5, "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [1, K])], [_vi("Y", [1, N])], [weight])
+    model = _model(
+        f"""
+        g (float[1,{K}] X) => (float[1,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[weight],
+    )
 
     quant = onnxsim.quantize_weight_only_int4(model)
     assert _op_counts(quant)["MatMul"] == 1
@@ -153,9 +184,14 @@ def test_quantize_conv_pointwise():
     rng = np.random.default_rng(5)
     cout, cin = 16, 32
     weight = _f32(rng.standard_normal((cout, cin, 1, 1)) * 0.5, "W")
-    nodes = [onnx.helper.make_node("Conv", ["X", "W"], ["Y"], kernel_shape=[1, 1])]
     model = _model(
-        nodes, [_vi("X", [1, cin, 8, 8])], [_vi("Y", [1, cout, 8, 8])], [weight]
+        f"""
+        g (float[1,{cin},8,8] X) => (float[1,{cout},8,8] Y)
+        {{
+          Y = Conv<kernel_shape = [1, 1]>(X, W)
+        }}
+        """,
+        initializer=[weight],
     )
 
     quant = onnxsim.quantize_weight_only_int4(model)
@@ -181,9 +217,14 @@ def test_quantize_conv_spatial_kernel_with_bias():
     cout, cin = 4, 8
     weight = _f32(rng.standard_normal((cout, cin, 2, 2)) * 0.5, "W")
     bias = _f32(rng.standard_normal(cout), "B")
-    nodes = [onnx.helper.make_node("Conv", ["X", "W", "B"], ["Y"], kernel_shape=[2, 2])]
     model = _model(
-        nodes, [_vi("X", [1, cin, 8, 8])], [_vi("Y", [1, cout, 7, 7])], [weight, bias]
+        f"""
+        g (float[1,{cin},8,8] X) => (float[1,{cout},7,7] Y)
+        {{
+          Y = Conv<kernel_shape = [2, 2]>(X, W, B)
+        }}
+        """,
+        initializer=[weight, bias],
     )
 
     quant = onnxsim.quantize_weight_only_int4(model)
@@ -202,12 +243,14 @@ def test_quantize_conv_skips_inner_not_divisible_by_block_size():
     rng = np.random.default_rng(7)
     cout, cin = 4, 4
     weight = _f32(rng.standard_normal((cout, cin, 3, 3)) * 0.5, "W")
-    nodes = [onnx.helper.make_node("Conv", ["X", "W"], ["Y"], kernel_shape=[3, 3])]
     model = _model(
-        nodes,
-        [_vi("X", [1, cin, 8, 8])],
-        [_vi("Y", [1, cout, 6, 6])],
-        [weight],
+        f"""
+        g (float[1,{cin},8,8] X) => (float[1,{cout},6,6] Y)
+        {{
+          Y = Conv<kernel_shape = [3, 3]>(X, W)
+        }}
+        """,
+        initializer=[weight],
     )
 
     quant = onnxsim.quantize_weight_only_int4(model)
@@ -216,9 +259,13 @@ def test_quantize_conv_skips_inner_not_divisible_by_block_size():
 
 
 def test_quantize_skips_non_constant_weight():
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
     model = _model(
-        nodes, [_vi("X", [4, 64]), _vi("W", [64, 4])], [_vi("Y", [4, 4])], []
+        """
+        g (float[4,64] X, float[64,4] W) => (float[4,4] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """
     )
     quant = onnxsim.quantize_weight_only_int4(model)
     assert _op_counts(quant)["MatMul"] == 1
@@ -227,8 +274,16 @@ def test_quantize_skips_non_constant_weight():
 def test_quantize_skips_old_opset():
     # INT4 tensors and DequantizeLinear's block_size both need opset >= 21.
     weight = _f32(np.random.default_rng(4).standard_normal((64, 4)), "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [4, 64])], [_vi("Y", [4, 4])], [weight], opset=20)
+    model = _model(
+        """
+        g (float[4,64] X) => (float[4,4] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """,
+        initializer=[weight],
+        opset=20,
+    )
     quant = onnxsim.quantize_weight_only_int4(model)
     assert _op_counts(quant)["MatMul"] == 1
     assert _op_counts(quant)["DequantizeLinear"] == 0


### PR DESCRIPTION
Continuation of the onnx.parser-based test readability migration.

Replaces `onnx.helper.make_node`/`make_graph`/`make_model` graph construction in `tests/test_weight_only_quantize_int4.py` with the ONNX text format via the established `_model(body, initializer=(), opset=21, ir_version=10)` helper. Random/large weight and bias tensors stay built with numpy + `onnx.numpy_helper.from_array` and are attached via the `initializer=[...]` param, per the established convention. Removed the now-unused `_vi` helper and the `import onnx.helper` line.

No onnx.helper exceptions were needed in this file — no byte-equal tensor matching and no unranked value info.

Test names, assertions, and behavior/coverage are unchanged — this is a pure construction-style refactor.

## Test plan

- [x] `python3 -m py_compile tests/test_weight_only_quantize_int4.py`
- [x] `ruff check tests/test_weight_only_quantize_int4.py`
- [x] `python3 -m pytest tests/test_weight_only_quantize_int4.py -q --no-header` — run 3x, all 9 tests pass each time
- [x] Test count cross-check: `git show origin/master:tests/test_weight_only_quantize_int4.py | grep -c "^def test_"` == 9 == count in migrated file

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_