### PR TITLE
Extend structured pruning across depthwise Convs transparently

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -96,9 +96,31 @@ already carries any bias in its own optional third input, and
 Conv's weight by the time this pass runs (onnxsim's own default
 optimization does exactly that, see ``fuse_bn_into_conv``), so a raw
 per-channel affine between two Convs isn't a shape this pass special-cases.
-A grouped or depthwise Conv (``group != 1``) is left untouched entirely:
-its output and input channels aren't independent per-index the way this
-pass's single producer/consumer cut assumes.
+A *general* grouped Conv (``group`` neither 1 nor equal to its channel
+count) is left untouched entirely: its output and input channels aren't
+independent per-index the way this pass's single producer/consumer cut
+assumes, and safely cutting a shared group's channels needs real
+group-aware bookkeeping this pass does not attempt (the same boundary
+attention-head pruning below draws around GroupQueryAttention). The
+*depthwise* special case (``group == in_channels == out_channels``,
+weight ``[C, 1, kH, kW]``) is different: with one filter per channel and
+no cross-channel mixing at all, output channel ``i`` depends only on
+input channel ``i``, so a depthwise Conv sitting between a chain's real
+producer and real consumer needs no independent importance of its own --
+the chain walk (:func:`_walk_to_conv_consumer`) crosses it transparently,
+like one more shape-preserving activation hop, carrying whatever
+channel-index set survives upstream straight through unchanged, while
+still slicing that depthwise layer's own weight/bias by the same indices
+and shrinking its ``group`` attribute to match. This is exactly the
+``Conv(1x1, group=1) -> DepthwiseConv(3x3, group=C) -> Conv(1x1,
+group=1)`` "inverted residual" block MobileNet/EfficientNet-style
+efficient CNN backbones use throughout, so it's worth the special case; a
+depthwise Conv is never itself matched as a producer or consumer (see
+:func:`_match_conv_producer`/:func:`_match_conv_consumer`), only ever a
+transparent hop between two real ``group=1`` Conv boundaries -- one
+sitting last before a graph output or an unhandled branch simply ends the
+chain unmatched, same as any other topology this pass declines to guess
+at.
 :func:`apply_structured_wanda_pruning` is the calibrated upgrade of that
 same technique -- ``||W_row||_2 * ||X||_2`` per channel instead of weight
 magnitude alone -- exactly the same relationship Wanda has to plain
@@ -655,6 +677,25 @@ class _Producer:
 
 
 @dataclass(frozen=True)
+class _ConvPassThrough:
+    """A depthwise Conv (``group == in_channels == out_channels``) the chain
+    walk crossed transparently between a Conv chain's real producer and real
+    consumer. A depthwise Conv mixes no channels at all -- output channel
+    ``i`` depends only on input channel ``i`` -- so it needs no independent
+    importance of its own the way a producer/consumer boundary does; it is
+    carried on the matched :class:`_Chain` purely so :func:`_apply_chains`
+    can slice its own ``[C, 1, kH, kW]`` weight (and bias, if present) by
+    the *same* `keep` index set as the chain's real producer, and update its
+    ``group`` attribute to the new channel count. See
+    :func:`_walk_to_conv_consumer`.
+    """
+
+    node: onnx.NodeProto
+    weight: str
+    bias: Optional[str]
+
+
+@dataclass(frozen=True)
 class _Chain:
     # One producer for a plain chain; two for a gated (elementwise-product)
     # pair, where both branches must agree on which channels survive.
@@ -668,6 +709,10 @@ class _Chain:
     # ``[out_channels, in_channels, kH, kW]`` weight, regardless of
     # `consumer_weight_transposed` (unused then).
     consumer_is_conv: bool = False
+    # Depthwise Conv hops the chain walk crossed transparently between the
+    # real producer and the real consumer (Conv chains only -- see
+    # :class:`_ConvPassThrough`; always empty for a MatMul/Gemm chain).
+    conv_pass_through: Tuple[_ConvPassThrough, ...] = ()
 
 
 def _consumers_of(graph: onnx.GraphProto) -> Dict[str, List[onnx.NodeProto]]:
@@ -842,7 +887,13 @@ def _match_conv_producer(
     ``(weight_name, bias_name_or_None, out_channels)``. A grouped or
     depthwise Conv (``group != 1``) never matches: its output and input
     channels aren't independent per-index the way this pass's single
-    producer/consumer cut assumes.
+    producer/consumer cut assumes -- true here too for the depthwise case,
+    even though a depthwise Conv *is* given a narrower exception elsewhere
+    in this pass, as a transparent pass-through hop the chain walk may
+    cross between two real producer/consumer boundaries (see
+    :func:`_match_depthwise_conv_pass_through`,
+    :func:`_walk_to_conv_consumer`) -- it is never itself matched as a
+    producer.
     """
     if node.op_type != "Conv" or len(node.input) < 2:
         return None
@@ -867,7 +918,11 @@ def _match_conv_consumer(
     node: onnx.NodeProto, initializer_map: Dict[str, onnx.TensorProto]
 ) -> Optional[Tuple[str, int]]:
     """If `node` is an ordinary (``group=1``) 2-D ``Conv`` with a constant
-    4-D float32 weight, returns ``(weight_name, in_channels)``.
+    4-D float32 weight, returns ``(weight_name, in_channels)``. Like
+    :func:`_match_conv_producer`, a depthwise Conv never matches here
+    either -- it's only ever a transparent pass-through hop the chain walk
+    crosses en route to a *real* ``group=1`` consumer, never a consumer
+    itself (see :func:`_match_depthwise_conv_pass_through`).
     """
     if node.op_type != "Conv" or len(node.input) < 2:
         return None
@@ -883,6 +938,47 @@ def _match_conv_consumer(
     return w_name, w_init.dims[1]
 
 
+def _match_depthwise_conv_pass_through(
+    node: onnx.NodeProto,
+    initializer_map: Dict[str, onnx.TensorProto],
+    n_channels: int,
+) -> Optional[Tuple[str, Optional[str]]]:
+    """If `node` is a depthwise 2-D ``Conv`` (``group == in_channels ==
+    out_channels == n_channels``) with a constant ``[n_channels, 1, kH,
+    kW]`` float32 weight (and, if present, a constant bias), returns
+    ``(weight_name, bias_name_or_None)``. A depthwise Conv mixes no channels
+    at all -- output channel ``i`` depends only on input channel ``i`` --
+    unlike a general grouped Conv (``group`` neither 1 nor `n_channels`),
+    which is not matched here and stays out of scope for this pass entirely
+    (see :func:`_match_conv_producer`/:func:`_match_conv_consumer`'s own
+    docstrings): only in the depthwise case is every output channel tied
+    1:1 to the same-index input channel, which is what lets the chain walk
+    (:func:`_walk_to_conv_consumer`) treat it as a transparent pass-through
+    hop -- carrying whatever channel-index set survives upstream straight
+    through, unchanged -- rather than a producer or consumer of its own.
+    """
+    if node.op_type != "Conv" or len(node.input) < 2:
+        return None
+    w_name = node.input[1]
+    w_init = initializer_map.get(w_name)
+    if (
+        w_init is None
+        or w_init.data_type != onnx.TensorProto.FLOAT
+        or len(w_init.dims) != 4
+        or w_init.dims[0] != n_channels
+        or w_init.dims[1] != 1
+        or _conv_group(node) != n_channels
+    ):
+        return None
+    bias_name = None
+    if len(node.input) == 3 and node.input[2]:
+        bias_name = node.input[2]
+        b_init = initializer_map.get(bias_name)
+        if b_init is None or b_init.data_type != onnx.TensorProto.FLOAT:
+            return None  # non-constant bias -- can't safely prune it
+    return w_name, bias_name
+
+
 def _walk_to_conv_consumer(
     start: str,
     initializer_map: Dict[str, onnx.TensorProto],
@@ -891,17 +987,28 @@ def _walk_to_conv_consumer(
     n_channels: int,
     max_hops: int,
 ) -> Tuple[
-    Optional[Tuple[onnx.NodeProto, str]], Tuple[Tuple[onnx.NodeProto, None], ...]
+    Optional[Tuple[onnx.NodeProto, str]],
+    Tuple[Tuple[onnx.NodeProto, None], ...],
+    Tuple[_ConvPassThrough, ...],
 ]:
     """The Conv analogue of :func:`_walk_to_consumer`: from tensor `start`,
     walks forward through unary shape-preserving activations (see
-    `_UNARY_PASS_THROUGH`) with no other consumer anywhere along the way,
-    until an ordinary Conv consumer is found whose input channel count
-    matches `n_channels`. Unlike the MatMul/Gemm walk, no per-channel
+    `_UNARY_PASS_THROUGH`) and depthwise Conv hops (see
+    :func:`_match_depthwise_conv_pass_through` -- transparent to the
+    channel-index mapping, but each still needs its own weight/bias sliced
+    and its ``group`` attribute updated, so they're returned separately as
+    `conv_pass_through` rather than folded into `chain_ops`) with no other
+    consumer anywhere along the way, until an ordinary (``group=1``) Conv
+    consumer is found whose input channel count matches `n_channels`. A
+    depthwise Conv is only ever a transparent hop, never a match for the
+    consumer role itself -- one sitting last before a graph output or a
+    branch simply ends the walk with no consumer found, same as any other
+    unmatched topology. Unlike the MatMul/Gemm walk, no per-channel
     ``Add``/``Mul`` op is recognized -- see this module's own docstring for
     why that's out of scope for Conv chains.
     """
     chain_ops: List[Tuple[onnx.NodeProto, None]] = []
+    conv_pass_through: List[_ConvPassThrough] = []
     consumer = None
     cur = start
     for _hop in range(max_hops):
@@ -911,6 +1018,18 @@ def _walk_to_conv_consumer(
         nxt = candidates[0]
 
         if nxt.op_type == "Conv" and nxt.input[0] == cur:
+            depthwise = _match_depthwise_conv_pass_through(
+                nxt, initializer_map, n_channels
+            )
+            if depthwise is not None:
+                out2 = nxt.output[0]
+                if len(consumers_of.get(out2, [])) != 1 or out2 in graph_outputs:
+                    break
+                dw_weight, dw_bias = depthwise
+                conv_pass_through.append(_ConvPassThrough(nxt, dw_weight, dw_bias))
+                cur = out2
+                continue
+
             match = _match_conv_consumer(nxt, initializer_map)
             if match is not None and match[1] == n_channels:
                 consumer = (nxt, match[0])
@@ -929,7 +1048,7 @@ def _walk_to_conv_consumer(
         chain_ops.append((nxt, None))
         cur = out2
 
-    return consumer, tuple(chain_ops)
+    return consumer, tuple(chain_ops), tuple(conv_pass_through)
 
 
 def _find_conv_chains(graph: onnx.GraphProto) -> List[_Chain]:
@@ -951,7 +1070,7 @@ def _find_conv_chains(graph: onnx.GraphProto) -> List[_Chain]:
         if not _is_internal(out_name):
             continue
 
-        consumer, chain_ops = _walk_to_conv_consumer(
+        consumer, chain_ops, conv_pass_through = _walk_to_conv_consumer(
             out_name,
             initializer_map,
             consumers_of,
@@ -971,6 +1090,7 @@ def _find_conv_chains(graph: onnx.GraphProto) -> List[_Chain]:
                 consumer_weight_transposed=False,
                 n_channels=n_channels,
                 consumer_is_conv=True,
+                conv_pass_through=conv_pass_through,
             )
         )
     return chains
@@ -1220,12 +1340,17 @@ def _apply_chains(
     producer_touched: Set[str] = set()
     consumer_touched: Set[str] = set()
     const_touched: Set[str] = set()
+    conv_hop_touched: Set[str] = set()
     stale_value_info: Set[str] = set()
 
     for chain in chains:
         producer_weights = {p.weight for p in chain.producers}
         if len(producer_weights) != len(chain.producers):
             continue  # degenerate (a gated pair naming the same weight twice)
+
+        conv_hop_weights = {h.weight for h in chain.conv_pass_through}
+        if len(conv_hop_weights) != len(chain.conv_pass_through):
+            continue  # degenerate (the same depthwise weight named twice)
 
         consts = {p.bias for p in chain.producers if p.bias is not None}
         consts.update(
@@ -1235,6 +1360,7 @@ def _apply_chains(
             (producer_weights & producer_touched)
             or chain.consumer_weight in consumer_touched
             or (consts & const_touched)
+            or (conv_hop_weights & conv_hop_touched)
         ):
             continue  # a shared/tied initializer another chain already resized
 
@@ -1263,6 +1389,28 @@ def _apply_chains(
         for _, const_name in chain.chain_ops:
             if const_name is not None:
                 _slice_last_axis(initializer_map[const_name], keep)
+        for hop in chain.conv_pass_through:
+            # Same `keep` index set as the real producer -- a depthwise
+            # Conv's own channel i is exactly upstream channel i, so its
+            # weight (output-channel axis 0, like any Conv producer) and
+            # bias slice identically, and `group` (== in_channels ==
+            # out_channels for a depthwise Conv) drops to the new count
+            # right alongside them.
+            _slice_producer_weight(
+                initializer_map[hop.weight], False, keep, is_conv=True
+            )
+            if hop.bias is not None:
+                _slice_last_axis(initializer_map[hop.bias], keep)
+            found_group = False
+            for attr in hop.node.attribute:
+                if attr.name == "group":
+                    attr.i = keep_count
+                    found_group = True
+                    break
+            if not found_group:
+                hop.node.attribute.append(
+                    onnx.helper.make_attribute("group", keep_count)
+                )
         _slice_consumer_weight(
             initializer_map[chain.consumer_weight],
             chain.consumer_weight_transposed,
@@ -1273,12 +1421,14 @@ def _apply_chains(
         producer_touched.update(producer_weights)
         consumer_touched.add(chain.consumer_weight)
         const_touched.update(consts)
+        conv_hop_touched.update(conv_hop_weights)
         for p in chain.producers:
             stale_value_info.add(p.node.output[0])
             stale_value_info.update(pre_op.output[0] for pre_op in p.pre_ops)
         stale_value_info.update(
             chain_node.output[0] for chain_node, _ in chain.chain_ops
         )
+        stale_value_info.update(hop.node.output[0] for hop in chain.conv_pass_through)
 
     if stale_value_info:
         kept = [vi for vi in graph.value_info if vi.name not in stale_value_info]
@@ -1317,10 +1467,17 @@ def apply_structured_pruning(
     The same cut applies to ordinary (``group=1``) 2-D ``Conv`` producer ->
     consumer pairs -- each output filter's whole ``[in_channels, kH, kW]``
     kernel ranked by its own L2 norm, exactly Li et al.'s original filter-
-    pruning criterion -- joined only by unary activations (no per-channel
-    Add/Mul: a Conv already carries its own bias, and ``BatchNormalization``
-    is expected to already be fused into the preceding Conv by the time this
-    pass runs). A grouped or depthwise Conv is left untouched.
+    pruning criterion -- joined by unary activations and/or depthwise Conv
+    hops (``group == in_channels == out_channels``: one filter per channel,
+    no cross-channel mixing, so it's crossed transparently -- its own
+    weight/bias sliced by the producer's channel indices and its ``group``
+    attribute shrunk to match, but it contributes no importance of its own
+    and can't itself be the producer or consumer -- see this module's own
+    docstring). No per-channel Add/Mul between two Convs (a Conv already
+    carries its own bias, and ``BatchNormalization`` is expected to already
+    be fused into the preceding Conv by the time this pass runs). A
+    *general* grouped Conv (``group`` neither 1 nor its channel count) is
+    left untouched.
 
     Also handles the gated FFN pattern most current LLMs use in place of a
     plain two-layer MLP (SwiGLU/GeGLU: ``down(act(gate(x)) * up(x))``, see
@@ -1367,8 +1524,13 @@ def apply_structured_wanda_pruning(
     as :func:`apply_wanda_pruning` is to :func:`apply_magnitude_pruning`:
     same real structural channel removal, same topology matching (a single
     producer or a gated pair -> zero or more shape-preserving elementwise
-    ops -> one consumer, MatMul/Gemm or Conv, see
-    :func:`apply_structured_pruning`'s own docstring), but each chain's
+    ops and, for a Conv chain, depthwise Conv hops -> one consumer,
+    MatMul/Gemm or Conv, see :func:`apply_structured_pruning`'s own
+    docstring) including the same depthwise-Conv pass-through sliced by the
+    producer's channel indices alone -- it contributes no activation norm
+    of its own to the ranking either, being transparent to the chain's
+    channel-index mapping just as it is to plain L2-norm importance -- but
+    each chain's
     output channels are ranked by ``||W_row||_2 * ||X||_2`` -- L2 norm of
     that channel's own weight row (or, for Conv, whole filter), times the
     L2 norm of the *activation* actually flowing through that channel over

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -867,6 +867,184 @@ def _oracle_keep_indices_conv(w, keep_count):
     return np.sort(np.argsort(-importance)[:keep_count])
 
 
+def _depthwise_pair_model(w1, dw_hops, w2, b1=None, spatial=10, activation="Relu"):
+    """The Conv-chain oracle builder, extended with zero or more depthwise
+    pass-through hops between producer and consumer: `dw_hops` is a list of
+    ``(weight[C1, 1, kH, kW], bias_or_None)`` depthwise Convs (``group`` is
+    always `weight.shape[0]`, so slicing `w1`/`dw_hops`/`w2` down together
+    -- as every test below does for its own "oracle" call -- keeps every
+    depthwise hop's `group` attribute consistent with its sliced weight for
+    free). Each hop, like the producer, is followed by `activation`.
+    """
+    Cin, C2 = w1.shape[1], w2.shape[0]
+    initializer = [_f32(w1, "W1"), _f32(w2, "W2")]
+    if b1 is not None:
+        lines = ["h0 = Conv<kernel_shape=[3,3]>(X, W1, B1)"]
+        initializer.append(_f32(b1, "B1"))
+    else:
+        lines = ["h0 = Conv<kernel_shape=[3,3]>(X, W1)"]
+    lines.append(f"a0 = {activation}(h0)")
+    cur = "a0"
+    n_convs = 1
+    for i, (wd, bd) in enumerate(dw_hops):
+        group = wd.shape[0]
+        w_name, b_name = f"WD{i}", f"BD{i}"
+        initializer.append(_f32(wd, w_name))
+        if bd is not None:
+            initializer.append(_f32(bd, b_name))
+            lines.append(
+                f"hd{i} = Conv<kernel_shape=[3,3], group={group}>"
+                f"({cur}, {w_name}, {b_name})"
+            )
+        else:
+            lines.append(
+                f"hd{i} = Conv<kernel_shape=[3,3], group={group}>({cur}, {w_name})"
+            )
+        lines.append(f"ad{i} = {activation}(hd{i})")
+        cur = f"ad{i}"
+        n_convs += 1
+    lines.append(f"Y = Conv<kernel_shape=[3,3]>({cur}, W2)")
+    n_convs += 1
+    out_spatial = spatial - 2 * n_convs  # each 3x3 valid conv shrinks by 2
+    body = "\n          ".join(lines)
+    return _model(
+        f"""
+        g (float[N,{Cin},{spatial},{spatial}] X) => (float[N,{C2},{out_spatial},{out_spatial}] Y)
+        {{
+          {body}
+        }}
+        """,
+        initializer=initializer,
+    )
+
+
+def test_structured_pruning_depthwise_pass_through_matches_manual_channel_deletion_exactly():
+    # A MobileNet/EfficientNet-style inverted-residual block:
+    # Conv(group=1) -> Relu -> DepthwiseConv(group=C1) -> Relu ->
+    # Conv(group=1). The depthwise layer mixes no channels at all -- output
+    # channel i depends only on input channel i -- so the chain walk must
+    # cross it transparently: the same channel-index set the real
+    # producer/consumer pair is pruned to also slices the depthwise layer's
+    # own weight and bias, and shrinks its `group` attribute to match.
+    Cin, C1, C2 = 3, 16, 8
+    rng = np.random.default_rng(50)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    b1 = rng.standard_normal((C1,)).astype(np.float32)
+    wd = rng.standard_normal((C1, 1, 3, 3)).astype(np.float32)
+    bd = rng.standard_normal((C1,)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    model = _depthwise_pair_model(w1, [(wd, bd)], w2, b1=b1)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    assert inits["WD0"].shape == (C1 // 2, 1, 3, 3)
+    assert inits["BD0"].shape == (C1 // 2,)
+    dw_node = next(n for n in pruned.graph.node if "WD0" in n.input)
+    group_attr = next(a for a in dw_node.attribute if a.name == "group")
+    assert group_attr.i == C1 // 2
+
+    keep = _oracle_keep_indices_conv(w1, C1 // 2)
+    oracle = _depthwise_pair_model(
+        w1[keep], [(wd[keep], bd[keep])], w2[:, keep], b1=b1[keep]
+    )
+
+    rng_x = np.random.default_rng(51)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_multiple_consecutive_depthwise_pass_through_hops_matches_oracle():
+    # Two depthwise Convs back to back (e.g. a wider spatial receptive
+    # field built from stacked depthwise layers) -- both must be crossed
+    # transparently by the same channel-index set, each sliced and
+    # re-grouped independently. The second hop also has no bias, folding in
+    # that case too.
+    Cin, C1, C2 = 3, 12, 6
+    rng = np.random.default_rng(52)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    wd1 = rng.standard_normal((C1, 1, 3, 3)).astype(np.float32)
+    bd1 = rng.standard_normal((C1,)).astype(np.float32)
+    wd2 = rng.standard_normal((C1, 1, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    model = _depthwise_pair_model(w1, [(wd1, bd1), (wd2, None)], w2, spatial=14)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.25)
+    onnx.checker.check_model(pruned)
+
+    keep = _oracle_keep_indices_conv(w1, C1 - round(C1 * 0.25))
+    oracle = _depthwise_pair_model(
+        w1[keep], [(wd1[keep], bd1[keep]), (wd2[keep], None)], w2[:, keep], spatial=14
+    )
+
+    rng_x = np.random.default_rng(53)
+    x = rng_x.standard_normal((2, Cin, 14, 14)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_depthwise_pass_through_no_bias_matches_oracle():
+    # A depthwise hop with no bias at all -- its own [C1, 1, kH, kW] weight
+    # is the only thing that needs slicing for it.
+    Cin, C1, C2 = 4, 10, 5
+    rng = np.random.default_rng(54)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    wd = rng.standard_normal((C1, 1, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    model = _depthwise_pair_model(w1, [(wd, None)], w2, activation="Sigmoid")
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.3)
+    onnx.checker.check_model(pruned)
+
+    keep = _oracle_keep_indices_conv(w1, C1 - round(C1 * 0.3))
+    oracle = _depthwise_pair_model(
+        w1[keep], [(wd[keep], None)], w2[:, keep], activation="Sigmoid"
+    )
+
+    rng_x = np.random.default_rng(55)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_depthwise_pass_through_branch_is_left_untouched():
+    # A depthwise Conv whose output feeds more than one consumer (a
+    # branch) can't be crossed transparently either -- doing so would mean
+    # picking one branch to carry the chain forward while silently leaving
+    # the other reading a now-stale channel count. Left untouched, same as
+    # any other branching point this pass declines to guess at (the same
+    # single-consumer requirement every other hop in this pass already
+    # holds every intermediate tensor to).
+    Cin, C1 = 3, 8
+    rng = np.random.default_rng(56)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    wd = rng.standard_normal((C1, 1, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C1, C1, 3, 3)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{C1},4,4] Y1, float[N,{C1},6,6] Y2)
+        {{
+          h = Conv<kernel_shape=[3,3]>(X, W1)
+          a = Relu(h)
+          d = Conv<kernel_shape=[3,3], group={C1}>(a, WD)
+          Y1 = Conv<kernel_shape=[3,3]>(d, W2)
+          Y2 = Relu(d)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(wd, "WD"), _f32(w2, "W2")],
+    )
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["WD"], wd)
+    np.testing.assert_array_equal(inits["W2"], w2)
+
+
 def test_structured_pruning_conv_chain_shrinks_matched_layers():
     Cin, C1, C2 = 3, 16, 8
     model = _conv_model(Cin=Cin, C1=C1, C2=C2, bias=True)
@@ -929,11 +1107,13 @@ def test_structured_pruning_conv_only_chain_matches_oracle_no_bias():
 
 
 def test_structured_pruning_skips_grouped_producer_conv():
-    # A depthwise Conv (group == in_channels == out_channels) has its
-    # output and input channels tied 1:1 through its own weight -- not the
-    # independent per-index relationship this pass's cut assumes -- so it
-    # must be left completely untouched as a producer, even though the
-    # topology otherwise looks identical to a matched pair.
+    # A depthwise Conv (group == in_channels == out_channels) is never
+    # itself matched as a producer -- it's only ever a transparent
+    # pass-through hop the chain walk may cross between two real
+    # producer/consumer boundaries (see the "depthwise_pass_through" tests
+    # above). With nothing upstream of it here, there's no real producer to
+    # anchor a chain at all, so both layers stay completely untouched, even
+    # though the topology otherwise looks identical to a matched pair.
     C = 8
     rng = np.random.default_rng(34)
     w1 = rng.standard_normal((C, 1, 3, 3)).astype(np.float32)
@@ -956,6 +1136,12 @@ def test_structured_pruning_skips_grouped_producer_conv():
 
 
 def test_structured_pruning_skips_grouped_consumer_conv():
+    # A depthwise Conv is likewise never matched as a *consumer* -- when
+    # its own output feeds a graph output (as here) rather than a further
+    # real Conv, crossing it as a pass-through hop simply runs out of chain
+    # to walk (see "depthwise Conv ... last node before a graph output" in
+    # this module's own docstring), so the walk finds no real consumer and
+    # the whole chain -- producer included -- is left untouched.
     Cin, C1 = 3, 8
     rng = np.random.default_rng(35)
     w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
@@ -975,6 +1161,63 @@ def test_structured_pruning_skips_grouped_consumer_conv():
     inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
     np.testing.assert_array_equal(inits["W1"], w1)
     np.testing.assert_array_equal(inits["W2"], w2)
+
+
+def test_structured_pruning_skips_general_grouped_producer_conv():
+    # A *general* grouped Conv (group=2, neither 1 nor equal to its own
+    # channel count) is not the depthwise special case above -- it stays
+    # completely out of scope, exactly as before this pass learned to cross
+    # depthwise Convs transparently.
+    C = 8
+    rng = np.random.default_rng(57)
+    w1 = rng.standard_normal((C, C // 2, 3, 3)).astype(np.float32)  # group=2
+    w2 = rng.standard_normal((C, C, 3, 3)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{C},10,10] X) => (float[N,{C},6,6] Y)
+        {{
+          h = Conv<kernel_shape=[3,3], group=2>(X, W1)
+          a = Relu(h)
+          Y = Conv<kernel_shape=[3,3]>(a, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2")],
+    )
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+
+
+def test_structured_pruning_skips_general_grouped_consumer_conv():
+    # A general group=2 Conv sitting *between* a real producer and a real
+    # further consumer must also stay a hard stop, not a transparent hop --
+    # only the depthwise case (group == channel count, weight [C, 1, kH,
+    # kW]) is safe to cross, since only there is every output channel tied
+    # 1:1 to a single input channel with no cross-channel mixing at all.
+    Cin, C1, C2 = 3, 8, 4
+    rng = np.random.default_rng(58)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C1, C1 // 2, 3, 3)).astype(np.float32)  # group=2
+    w3 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},14,14] X) => (float[N,{C2},8,8] Y)
+        {{
+          h = Conv<kernel_shape=[3,3]>(X, W1)
+          a = Relu(h)
+          m = Conv<kernel_shape=[3,3], group=2>(a, W2)
+          b = Relu(m)
+          Y = Conv<kernel_shape=[3,3]>(b, W3)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2"), _f32(w3, "W3")],
+    )
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+    np.testing.assert_array_equal(inits["W3"], w3)
 
 
 def test_structured_pruning_conv_into_non_pass_through_op_is_left_untouched():
@@ -1070,6 +1313,50 @@ def test_structured_wanda_pruning_conv_chain_matches_oracle_exactly():
 
     oracle = _conv_pair_model(w1[keep], w2[:, keep])
     rng_x = np.random.default_rng(42)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_wanda_pruning_depthwise_pass_through_matches_oracle_exactly():
+    # Same oracle bar with a depthwise hop in the middle: the calibrated
+    # activation norm is captured right where the chain feeds its *real*
+    # consumer -- i.e. downstream of the (transparent) depthwise hop, not
+    # at the real producer's own raw output -- since a depthwise Conv
+    # contributes no importance of its own to the ranking.
+    Cin, C1, C2 = 3, 16, 8
+    rng = np.random.default_rng(70)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    wd = rng.standard_normal((C1, 1, 3, 3)).astype(np.float32)
+    bd = rng.standard_normal((C1,)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    model = _depthwise_pair_model(w1, [(wd, bd)], w2)
+
+    probe_model = onnx.ModelProto()
+    probe_model.CopyFrom(model)
+    probe_model.graph.output.append(
+        onnx.helper.make_tensor_value_info("ad0", onnx.TensorProto.FLOAT, None)
+    )
+
+    rng_cal = np.random.default_rng(71)
+    x_cal = rng_cal.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    calibration_data = [{"X": x_cal}]
+
+    _, ad0_cal = _run(probe_model, {"X": x_cal})
+    act_norm = np.sqrt(np.mean(np.square(ad0_cal.astype(np.float64)), axis=(0, 2, 3)))
+    importance = np.linalg.norm(
+        w1.reshape(C1, -1).astype(np.float64), axis=1
+    ) * np.maximum(act_norm, 1e-8)
+    keep = np.sort(np.argsort(-importance)[: C1 // 2])
+
+    pruned = onnxsim.apply_structured_wanda_pruning(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned)
+
+    oracle = _depthwise_pair_model(w1[keep], [(wd[keep], bd[keep])], w2[:, keep])
+    rng_x = np.random.default_rng(72)
     x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
     (y,) = _run(pruned, {"X": x})
     (y_oracle,) = _run(oracle, {"X": x})


### PR DESCRIPTION
## Summary
- `apply_structured_pruning`/`apply_structured_wanda_pruning` previously left any grouped Conv (`group != 1`) — depthwise included — completely untouched, since a general grouped Conv's output/input channels aren't independent per-index.
- **Depthwise Conv** (`group == in_channels == out_channels`, weight `[C, 1, kH, kW]`, one filter per channel, no cross-channel mixing) is different: output channel `i` depends only on input channel `i`, so it needs no independent importance of its own — it's now recognized as a **transparent pass-through hop** in the Conv chain walk (the Conv analogue of the existing unary-activation pass-through), rather than as a producer or consumer. A depthwise Conv is never itself matched as a producer/consumer; only ever a hop between two real `group=1` Conv boundaries.
- Crossing a depthwise hop still slices that layer's own weight/bias by the same indices as the real producer, and shrinks its `group` attribute to match — this is exactly the `Conv(1x1, group=1) -> DepthwiseConv(3x3, group=C) -> Conv(1x1, group=1)` "inverted residual" block MobileNet/EfficientNet-style backbones use throughout, so structured pruning can now do something useful on them.
- General (non-depthwise) grouped Conv remains explicitly out of scope.
- 7 new tests: single/multiple consecutive depthwise hops (with and without bias), a depthwise-Conv-into-a-branch safety case, the Wanda-calibrated oracle counterpart, and two explicit `group=2` (non-depthwise) regression tests confirming that case still declines.

## Test plan
- [x] `pytest tests/test_pruning.py -q` — 61 passed
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_