### PR TITLE
tests: migrate test_weight_only_quantize_int16.py to onnx.parser

### DIFF
--- a/tests/test_weight_only_quantize_int16.py
+++ b/tests/test_weight_only_quantize_int16.py
@@ -12,9 +12,9 @@ import collections
 
 import numpy as np
 import onnx
-import onnx.helper
 import onnx.numpy_helper
 import pytest
+from onnx import parser
 
 import onnxsim
 
@@ -23,15 +23,18 @@ import onnxsim
 ort = pytest.importorskip("onnxruntime")
 
 
-def _model(nodes, inputs, outputs, initializer, opset=21):
-    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
-    return onnx.helper.make_model(
-        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
     )
-
-
-def _vi(name, shape):
-    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+    model.graph.initializer.extend(initializer)
+    return model
 
 
 def _f32(array, name):
@@ -79,8 +82,15 @@ def test_quantize_matmul():
     rng = np.random.default_rng(0)
     K, N = 32, 16
     weight = _f32(rng.standard_normal((K, N)) * 0.5, "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [4, K])], [_vi("Y", [4, N])], [weight])
+    model = _model(
+        f"""
+        g (float[4,{K}] X) => (float[4,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [weight],
+    )
 
     quant = onnxsim.quantize_weight_only_int16(model)
     onnx.checker.check_model(quant)
@@ -102,8 +112,16 @@ def test_quantize_matmul_more_precise_than_int8():
     rng = np.random.default_rng(4)
     K, N = 32, 16
     weight = _f32(rng.standard_normal((K, N)) * 0.5, "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [4, K])], [_vi("Y", [4, N])], [weight], opset=13)
+    model = _model(
+        f"""
+        g (float[4,{K}] X) => (float[4,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [weight],
+        opset=13,
+    )
 
     quant8 = onnxsim.quantize_weight_only(model)
     quant16 = onnxsim.quantize_weight_only_int16(model)
@@ -123,8 +141,15 @@ def test_quantize_gemm_transb_with_bias():
     K, N = 24, 12
     weight = _f32(rng.standard_normal((N, K)) * 0.5, "W")
     bias = _f32(rng.standard_normal(N), "B")
-    nodes = [onnx.helper.make_node("Gemm", ["X", "W", "B"], ["Y"], transB=1)]
-    model = _model(nodes, [_vi("X", [3, K])], [_vi("Y", [3, N])], [weight, bias])
+    model = _model(
+        f"""
+        g (float[3,{K}] X) => (float[3,{N}] Y)
+        {{
+          Y = Gemm<transB = 1>(X, W, B)
+        }}
+        """,
+        [weight, bias],
+    )
 
     quant = onnxsim.quantize_weight_only_int16(model)
     onnx.checker.check_model(quant)
@@ -140,13 +165,14 @@ def test_quantize_conv():
     rng = np.random.default_rng(2)
     cout, cin = 8, 3
     weight = _f32(rng.standard_normal((cout, cin, 3, 3)) * 0.5, "W")
-    nodes = [
-        onnx.helper.make_node(
-            "Conv", ["X", "W"], ["Y"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
-        )
-    ]
     model = _model(
-        nodes, [_vi("X", [1, cin, 16, 16])], [_vi("Y", [1, cout, 16, 16])], [weight]
+        f"""
+        g (float[1,{cin},16,16] X) => (float[1,{cout},16,16] Y)
+        {{
+          Y = Conv<kernel_shape = [3, 3], pads = [1, 1, 1, 1]>(X, W)
+        }}
+        """,
+        [weight],
     )
 
     quant = onnxsim.quantize_weight_only_int16(model)
@@ -168,15 +194,13 @@ def test_quantize_conv_with_bias():
     cout, cin = 4, 2
     weight = _f32(rng.standard_normal((cout, cin, 3, 3)) * 0.5, "W")
     bias = _f32(rng.standard_normal(cout), "B")
-    nodes = [
-        onnx.helper.make_node(
-            "Conv", ["X", "W", "B"], ["Y"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
-        )
-    ]
     model = _model(
-        nodes,
-        [_vi("X", [2, cin, 8, 8])],
-        [_vi("Y", [2, cout, 8, 8])],
+        f"""
+        g (float[2,{cin},8,8] X) => (float[2,{cout},8,8] Y)
+        {{
+          Y = Conv<kernel_shape = [3, 3], pads = [1, 1, 1, 1]>(X, W, B)
+        }}
+        """,
         [weight, bias],
     )
 
@@ -192,8 +216,14 @@ def test_quantize_conv_with_bias():
 
 
 def test_quantize_skips_non_constant_weight():
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [4, 8]), _vi("W", [8, 4])], [_vi("Y", [4, 4])], [])
+    model = _model(
+        """
+        g (float[4,8] X, float[8,4] W) => (float[4,4] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """
+    )
     quant = onnxsim.quantize_weight_only_int16(model)
     assert _op_counts(quant)["MatMul"] == 1
     assert _op_counts(quant)["DequantizeLinear"] == 0
@@ -201,8 +231,15 @@ def test_quantize_skips_non_constant_weight():
 
 def test_quantize_skips_non_default_gemm_attrs():
     weight = _f32(np.random.randn(8, 4).astype(np.float32), "W")
-    nodes = [onnx.helper.make_node("Gemm", ["X", "W"], ["Y"], alpha=2.0)]
-    model = _model(nodes, [_vi("X", [4, 8])], [_vi("Y", [4, 4])], [weight])
+    model = _model(
+        """
+        g (float[4,8] X) => (float[4,4] Y)
+        {
+          Y = Gemm<alpha = 2.0>(X, W)
+        }
+        """,
+        [weight],
+    )
     quant = onnxsim.quantize_weight_only_int16(model)
     assert _op_counts(quant)["Gemm"] == 1
     assert _op_counts(quant)["DequantizeLinear"] == 0
@@ -213,8 +250,16 @@ def test_quantize_skips_old_opset():
     # opset >= 13, an opset in [13, 21) is old for this pass even though it
     # would be fine for quantize_weight_only.
     weight = _f32(np.random.randn(8, 4).astype(np.float32), "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [4, 8])], [_vi("Y", [4, 4])], [weight], opset=13)
+    model = _model(
+        """
+        g (float[4,8] X) => (float[4,4] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """,
+        [weight],
+        opset=13,
+    )
     quant = onnxsim.quantize_weight_only_int16(model)
     assert _op_counts(quant)["MatMul"] == 1
     assert _op_counts(quant)["DequantizeLinear"] == 0


### PR DESCRIPTION
Continuation of the onnx.parser-based test readability migration.

Replaces `onnx.helper.make_node`/`make_graph`/`make_model` graph construction in `tests/test_weight_only_quantize_int16.py` with the ONNX text format via the established `_model(body, initializer=(), opset=..., ir_version=...)` helper (built on `onnx.parser.parse_model`).

No exceptions to the standard pattern were needed: every model in this file is a plain float32 graph with small/random weight initializers, so all of them convert cleanly to text-format bodies with `numpy`-built initializers attached via the `initializer=[...]` param. The now-unused `_vi` helper and `import onnx.helper` were removed.

Test names, assertions, and behavior/coverage are unchanged -- this is a pure construction-style refactor.

## Test plan
- [x] `python3 -m py_compile tests/test_weight_only_quantize_int16.py`
- [x] `ruff check tests/test_weight_only_quantize_int16.py` (clean)
- [x] `python3 -m pytest tests/test_weight_only_quantize_int16.py -q --no-header` -- run 3x, 8 passed each time
- [x] Test count cross-check: `git show origin/master:tests/test_weight_only_quantize_int16.py | grep -c "^def test_"` == 8 == count in migrated file

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_