### PR TITLE
tests: migrate test_static_quantize_int16.py to onnx.parser

### DIFF
--- a/tests/test_static_quantize_int16.py
+++ b/tests/test_static_quantize_int16.py
@@ -12,9 +12,9 @@ import collections
 
 import numpy as np
 import onnx
-import onnx.helper
 import onnx.numpy_helper
 import pytest
+from onnx import parser
 
 import onnxsim
 
@@ -23,15 +23,18 @@ import onnxsim
 ort = pytest.importorskip("onnxruntime")
 
 
-def _model(nodes, inputs, outputs, initializer, opset=21):
-    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
-    return onnx.helper.make_model(
-        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
     )
-
-
-def _vi(name, shape):
-    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+    model.graph.initializer.extend(initializer)
+    return model
 
 
 def _f32(array, name):
@@ -62,8 +65,15 @@ def test_quantize_matmul():
     rng = np.random.default_rng(0)
     K, N = 32, 16
     weight = _f32(rng.standard_normal((K, N)) * 0.5, "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [4, K])], [_vi("Y", [4, N])], [weight])
+    model = _model(
+        f"""
+        g (float[4,{K}] X) => (float[4,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[weight],
+    )
 
     quant = onnxsim.quantize_static_int16(model, num_calibration_samples=16, seed=0)
     onnx.checker.check_model(quant)
@@ -83,11 +93,16 @@ def test_quantize_more_precise_than_uint8():
     rng = np.random.default_rng(4)
     K, N = 32, 16
     weight = _f32(rng.standard_normal((K, N)) * 0.5, "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [4, K])], [_vi("Y", [4, N])], [weight], opset=13)
+    body = f"""
+        g (float[4,{K}] X) => (float[4,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """
 
+    model = _model(body, initializer=[weight], opset=13)
     quant8 = onnxsim.quantize_static(model, num_calibration_samples=16, seed=0)
-    model21 = _model(nodes, [_vi("X", [4, K])], [_vi("Y", [4, N])], [weight])
+    model21 = _model(body, initializer=[weight])
     quant16 = onnxsim.quantize_static_int16(model21, num_calibration_samples=16, seed=0)
 
     x = rng.standard_normal((4, K)).astype(np.float32)
@@ -107,8 +122,15 @@ def test_quantize_gemm_transb_with_bias():
     K, N = 24, 12
     weight = _f32(rng.standard_normal((N, K)) * 0.5, "W")
     bias = _f32(rng.standard_normal(N), "B")
-    nodes = [onnx.helper.make_node("Gemm", ["X", "W", "B"], ["Y"], transB=1)]
-    model = _model(nodes, [_vi("X", [3, K])], [_vi("Y", [3, N])], [weight, bias])
+    model = _model(
+        f"""
+        g (float[3,{K}] X) => (float[3,{N}] Y)
+        {{
+          Y = Gemm<transB = 1>(X, W, B)
+        }}
+        """,
+        initializer=[weight, bias],
+    )
 
     quant = onnxsim.quantize_static_int16(model, num_calibration_samples=16, seed=1)
     onnx.checker.check_model(quant)
@@ -125,13 +147,14 @@ def test_quantize_conv():
     rng = np.random.default_rng(2)
     cout, cin = 8, 3
     weight = _f32(rng.standard_normal((cout, cin, 3, 3)) * 0.5, "W")
-    nodes = [
-        onnx.helper.make_node(
-            "Conv", ["X", "W"], ["Y"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
-        )
-    ]
     model = _model(
-        nodes, [_vi("X", [1, cin, 16, 16])], [_vi("Y", [1, cout, 16, 16])], [weight]
+        f"""
+        g (float[1,{cin},16,16] X) => (float[1,{cout},16,16] Y)
+        {{
+          Y = Conv<kernel_shape = [3, 3], pads = [1, 1, 1, 1]>(X, W)
+        }}
+        """,
+        initializer=[weight],
     )
 
     quant = onnxsim.quantize_static_int16(model, num_calibration_samples=16, seed=2)
@@ -146,8 +169,14 @@ def test_quantize_conv():
 
 
 def test_quantize_skips_non_constant_weight():
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [4, 8]), _vi("W", [8, 4])], [_vi("Y", [4, 4])], [])
+    model = _model(
+        """
+        g (float[4,8] X, float[8,4] W) => (float[4,4] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """
+    )
     quant = onnxsim.quantize_static_int16(model)
     assert _op_counts(quant)["MatMul"] == 1
 
@@ -155,8 +184,15 @@ def test_quantize_skips_non_constant_weight():
 def test_quantize_skips_non_default_gemm_attrs():
     # alpha != 1 falls outside the "vanilla" Gemm shape this pass handles.
     weight = _f32(np.random.randn(8, 4).astype(np.float32), "W")
-    nodes = [onnx.helper.make_node("Gemm", ["X", "W"], ["Y"], alpha=2.0)]
-    model = _model(nodes, [_vi("X", [4, 8])], [_vi("Y", [4, 4])], [weight])
+    model = _model(
+        """
+        g (float[4,8] X) => (float[4,4] Y)
+        {
+          Y = Gemm<alpha = 2.0>(X, W)
+        }
+        """,
+        initializer=[weight],
+    )
     quant = onnxsim.quantize_static_int16(model)
     assert _op_counts(quant)["Gemm"] == 1
 
@@ -166,8 +202,16 @@ def test_quantize_skips_old_opset():
     # quantize_static's opset >= 13, an opset in [13, 21) is old for this
     # pass even though it would be fine for the uint8 one.
     weight = _f32(np.random.randn(8, 4).astype(np.float32), "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [4, 8])], [_vi("Y", [4, 4])], [weight], opset=13)
+    model = _model(
+        """
+        g (float[4,8] X) => (float[4,4] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """,
+        initializer=[weight],
+        opset=13,
+    )
     quant = onnxsim.quantize_static_int16(model)
     assert _op_counts(quant)["MatMul"] == 1
     assert _op_counts(quant)["QuantizeLinear"] == 0


### PR DESCRIPTION
Continuation of the onnx.parser-based test readability migration.

Replaces `onnx.helper.make_node`/`make_graph`/`make_model` graph construction in `tests/test_static_quantize_int16.py` with the ONNX text format via the established `_model(body, initializer=(), opset=..., ir_version=...)` helper (default `opset=21, ir_version=10`, matching the file's original defaults).

No `onnx.helper` exceptions were needed. `onnx.numpy_helper.from_array` is still used to build the random/deterministic weight and bias initializers (`_f32` helper), attached to the parsed model via `initializer=[...]`. The now-unused `_vi` value-info helper and the `onnx.helper` import were removed.

Test names, assertions, and coverage are unchanged -- this is a pure construction-style refactor.

## Test plan

- [x] `python3 -m py_compile tests/test_static_quantize_int16.py`
- [x] `ruff check tests/test_static_quantize_int16.py` -- clean
- [x] `python3 -m pytest tests/test_static_quantize_int16.py -q --no-header` -- run 3x, all 7 tests pass each time
- [x] Test count cross-check: `git show origin/master:tests/test_static_quantize_int16.py | grep -c "^def test_"` == 7 == count in migrated file

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_