### PR TITLE
tests: migrate test_quantize_fp16.py to onnx.parser

### DIFF
--- a/tests/test_quantize_fp16.py
+++ b/tests/test_quantize_fp16.py
@@ -3,7 +3,7 @@
 Unlike onnxsim's other quantization tests, these models are built with
 multiple chained ops (not one MatMul/Conv in isolation), since quantize_fp16
 is a whole-graph transform rather than a per-node pattern match. Each model
-is built directly with ``onnx.helper``, quantized, and then actually run
+is built via the ONNX text format, quantized, and then actually run
 through ONNX Runtime -- both before and after quantization -- so the
 quantized graph must load and execute under a real inference engine.
 """
@@ -16,6 +16,7 @@ import onnx.helper
 import onnx.numpy_helper
 import onnx.shape_inference
 import pytest
+from onnx import parser
 
 import onnxsim
 
@@ -24,15 +25,18 @@ import onnxsim
 ort = pytest.importorskip("onnxruntime")
 
 
-def _model(nodes, inputs, outputs, initializer, opset=13):
-    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
-    return onnx.helper.make_model(
-        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+def _model(body, initializer=(), opset=13, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
     )
-
-
-def _vi(name, shape, elem_type=onnx.TensorProto.FLOAT):
-    return onnx.helper.make_tensor_value_info(name, elem_type, shape)
+    model.graph.initializer.extend(initializer)
+    return model
 
 
 def _f32(array, name):
@@ -86,12 +90,17 @@ def _two_matmul_model():
     k, n1, n2 = 16, 12, 8
     w1 = _f32(rng.standard_normal((k, n1)) * 0.5, "W1")
     w2 = _f32(rng.standard_normal((n1, n2)) * 0.5, "W2")
-    nodes = [
-        onnx.helper.make_node("MatMul", ["X", "W1"], ["H"]),
-        onnx.helper.make_node("Relu", ["H"], ["Hr"]),
-        onnx.helper.make_node("MatMul", ["Hr", "W2"], ["Y"]),
-    ]
-    model = _model(nodes, [_vi("X", [4, k])], [_vi("Y", [4, n2])], [w1, w2])
+    model = _model(
+        f"""
+        g (float[4,{k}] X) => (float[4,{n2}] Y)
+        {{
+          H = MatMul(X, W1)
+          Hr = Relu(H)
+          Y = MatMul(Hr, W2)
+        }}
+        """,
+        initializer=[w1, w2],
+    )
     return model, rng, k, n2
 
 
@@ -144,6 +153,12 @@ def test_quantize_fp16_converts_constant_node():
     # A Constant node's embedded value is a float32 "inline initializer" --
     # FetchConstantTensor covers it the same way as a true graph
     # initializer, so it should be converted too.
+    #
+    # The Constant's value is a randomly-generated array, which can't be
+    # cleanly spelled out as a text literal, and replacing it with a graph
+    # initializer would defeat the point of this test (it specifically
+    # exercises the Constant-node code path) -- so this one node is still
+    # built via onnx.helper/numpy_helper and spliced into the parsed graph.
     rng = np.random.default_rng(1)
     k, n = 8, 4
     w = rng.standard_normal((k, n)).astype(np.float32)
@@ -153,10 +168,15 @@ def test_quantize_fp16_converts_constant_node():
         ["W"],
         value=onnx.numpy_helper.from_array(w, "W"),
     )
-    matmul_node = onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])
     model = _model(
-        [const_node, matmul_node], [_vi("X", [3, k])], [_vi("Y", [3, n])], []
+        f"""
+        g (float[3,{k}] X) => (float[3,{n}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """
     )
+    model.graph.node.insert(0, const_node)
 
     quant = onnxsim.quantize_fp16(model)
     onnx.checker.check_model(quant)
@@ -169,10 +189,19 @@ def test_quantize_fp16_clamps_out_of_range_weight():
     # float16's largest finite magnitude is 65504; a weight far beyond that
     # must be clamped to it, not rounded to a float16 infinity that would
     # propagate NaN/Inf through downstream compute.
-    w = np.array([[1.0e10, -1.0e10, 3.0]], dtype=np.float32)  # [1, 3]
-    weight = _f32(w, "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [2, 1])], [_vi("Y", [2, 3])], [weight])
+    model = _model(
+        """
+        g (float[2,1] X) => (float[2,3] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """,
+        initializer=[
+            onnx.numpy_helper.from_array(
+                np.array([[1.0e10, -1.0e10, 3.0]], dtype=np.float32), "W"
+            )
+        ],
+    )
 
     quant = onnxsim.quantize_fp16(model)
     onnx.checker.check_model(quant)
@@ -192,12 +221,14 @@ def test_quantize_fp16_skips_optional_input_default_initializer():
     # input with a default value" convention) is left alone entirely -- see
     # quantize_fp16.h's doc comment.
     w = _f32(np.random.randn(4, 2).astype(np.float32), "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
     model = _model(
-        nodes,
-        [_vi("X", [3, 4]), _vi("W", [4, 2])],
-        [_vi("Y", [3, 2])],
-        [w],
+        """
+        g (float[3,4] X, float[4,2] W) => (float[3,2] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """,
+        initializer=[w],
     )
 
     quant = onnxsim.quantize_fp16(model)


### PR DESCRIPTION
Continuation of the onnx.parser-based test readability migration.

Replaces `onnx.helper.make_node`/`make_graph`/`make_model` graph construction in `tests/test_quantize_fp16.py` with the ONNX text format, via the established `_model(body, initializer=(), opset=13, ir_version=10)` helper. Test names, assertions, and behavior/coverage are unchanged -- this is a pure construction-style refactor.

**Exception kept on `onnx.helper`:** the `Constant` node in `test_quantize_fp16_converts_constant_node` embeds a randomly-generated array as its inline value, and the test specifically exercises the `FetchConstantTensor` code path for `Constant`-node values (as opposed to graph initializers). Replacing it with a graph initializer would defeat the point of the test, so that one node is still built via `onnx.helper.make_node`/`onnx.numpy_helper.from_array` and spliced into the parsed graph (`model.graph.node.insert(0, const_node)`), with a comment explaining why.

## Test plan
- [x] `python3 -m py_compile tests/test_quantize_fp16.py`
- [x] `ruff check tests/test_quantize_fp16.py`
- [x] `python3 -m pytest tests/test_quantize_fp16.py -q --no-header` -- run 3x, all 6 tests pass each time
- [x] Test count cross-check: `git show origin/master:tests/test_quantize_fp16.py | grep -c "^def test_"` (6) matches migrated file's count (6)

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_