### PR TITLE
tests: migrate test_qoperator_quantize_matmul.py to onnx.parser

### DIFF
--- a/tests/test_qoperator_quantize_matmul.py
+++ b/tests/test_qoperator_quantize_matmul.py
@@ -1,21 +1,21 @@
 """Tests for ``onnxsim.quantize_qoperator`` (the ``qoperator_quantize_matmul``
 C++ pass) and its output-range calibration helper.
 
-Each model is built directly with ``onnx.helper`` (no torch dependency),
-calibrated with random data, quantized, and then actually run through ONNX
-Runtime -- both before and after quantization -- so these tests double as a
-minimal end-to-end calibrate/quantize/deploy check: the quantized graph must
-load and execute under a real inference engine, and its outputs must stay
-close to the float baseline.
+Each model is built directly with the ``onnx.parser`` text format (no torch
+dependency), calibrated with random data, quantized, and then actually run
+through ONNX Runtime -- both before and after quantization -- so these tests
+double as a minimal end-to-end calibrate/quantize/deploy check: the quantized
+graph must load and execute under a real inference engine, and its outputs
+must stay close to the float baseline.
 """
 
 import collections
 
 import numpy as np
 import onnx
-import onnx.helper
 import onnx.numpy_helper
 import pytest
+from onnx import parser
 
 import onnxsim
 
@@ -24,17 +24,20 @@ import onnxsim
 ort = pytest.importorskip("onnxruntime")
 
 
-def _model(nodes, inputs, outputs, initializer, opset=13):
-    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
+def _model(body, initializer=(), opset=13, ir_version=10):
     # Pin a low IR version so the model loads under older onnxruntime builds
     # (which cap at IR version 11), matching test_fusion_patterns.py.
-    return onnx.helper.make_model(
-        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
     )
-
-
-def _vi(name, shape):
-    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+    model.graph.initializer.extend(initializer)
+    return model
 
 
 def _f32(array, name):
@@ -68,8 +71,15 @@ def test_quantize_matmul():
     rng = np.random.default_rng(0)
     K, N = 32, 16
     weight = _f32(rng.standard_normal((K, N)) * 0.5, "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [4, K])], [_vi("Y", [4, N])], [weight])
+    model = _model(
+        f"""
+        g (float[4,{K}] X) => (float[4,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [weight],
+    )
 
     quant = onnxsim.quantize_qoperator(model, num_calibration_samples=16, seed=0)
     onnx.checker.check_model(quant)
@@ -94,8 +104,15 @@ def test_quantize_gemm_transb_with_bias():
     K, N = 24, 12
     weight = _f32(rng.standard_normal((N, K)) * 0.5, "W")
     bias = _f32(rng.standard_normal(N), "B")
-    nodes = [onnx.helper.make_node("Gemm", ["X", "W", "B"], ["Y"], transB=1)]
-    model = _model(nodes, [_vi("X", [3, K])], [_vi("Y", [3, N])], [weight, bias])
+    model = _model(
+        f"""
+        g (float[3,{K}] X) => (float[3,{N}] Y)
+        {{
+          Y = Gemm<transB = 1>(X, W, B)
+        }}
+        """,
+        [weight, bias],
+    )
 
     quant = onnxsim.quantize_qoperator(model, num_calibration_samples=16, seed=1)
     onnx.checker.check_model(quant)
@@ -113,8 +130,14 @@ def test_quantize_gemm_transb_with_bias():
 def test_quantize_skips_non_constant_weight():
     # Both MatMul operands are graph inputs (neither is a constant), so there
     # is nothing to quantize ahead of time.
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [4, 8]), _vi("W", [8, 4])], [_vi("Y", [4, 4])], [])
+    model = _model(
+        """
+        g (float[4,8] X, float[8,4] W) => (float[4,4] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """
+    )
     quant = onnxsim.quantize_qoperator(model)
     assert _op_counts(quant)["MatMul"] == 1
     assert _op_counts(quant)["QLinearMatMul"] == 0
@@ -123,8 +146,15 @@ def test_quantize_skips_non_constant_weight():
 def test_quantize_skips_non_default_gemm_attrs():
     # alpha != 1 falls outside the "vanilla" Gemm shape this pass handles.
     weight = _f32(np.random.randn(8, 4).astype(np.float32), "W")
-    nodes = [onnx.helper.make_node("Gemm", ["X", "W"], ["Y"], alpha=2.0)]
-    model = _model(nodes, [_vi("X", [4, 8])], [_vi("Y", [4, 4])], [weight])
+    model = _model(
+        """
+        g (float[4,8] X) => (float[4,4] Y)
+        {
+          Y = Gemm<alpha = 2.0>(X, W)
+        }
+        """,
+        [weight],
+    )
     quant = onnxsim.quantize_qoperator(model)
     assert _op_counts(quant)["Gemm"] == 1
     assert _op_counts(quant)["QLinearMatMul"] == 0
@@ -133,8 +163,16 @@ def test_quantize_skips_non_default_gemm_attrs():
 def test_quantize_skips_old_opset():
     # QLinearMatMul needs opset >= 10.
     weight = _f32(np.random.randn(8, 4).astype(np.float32), "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [4, 8])], [_vi("Y", [4, 4])], [weight], opset=9)
+    model = _model(
+        """
+        g (float[4,8] X) => (float[4,4] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """,
+        [weight],
+        opset=9,
+    )
     quant = onnxsim.quantize_qoperator(model)
     assert _op_counts(quant)["MatMul"] == 1
     assert _op_counts(quant)["QLinearMatMul"] == 0
@@ -142,8 +180,15 @@ def test_quantize_skips_old_opset():
 
 def test_list_qoperator_quantizable_outputs_includes_matmul_output():
     weight = _f32(np.random.randn(8, 4).astype(np.float32), "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [2, 8])], [_vi("Y", [2, 4])], [weight])
+    model = _model(
+        """
+        g (float[2,8] X) => (float[2,4] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """,
+        [weight],
+    )
     import onnxsim.onnxsim_cpp2py_export as C
 
     names = C.list_qoperator_quantizable_outputs(model.SerializeToString())
@@ -152,8 +197,15 @@ def test_list_qoperator_quantizable_outputs_includes_matmul_output():
 
 def test_calibrate_with_extra_tensor_names_includes_output():
     weight = _f32(np.random.randn(8, 4).astype(np.float32), "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [2, 8])], [_vi("Y", [2, 4])], [weight])
+    model = _model(
+        """
+        g (float[2,8] X) => (float[2,4] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """,
+        [weight],
+    )
     data = onnxsim.generate_random_calibration_data(model, num_samples=4, seed=0)
     ranges = onnxsim.calibrate(model, data, extra_tensor_names=["Y"])
     assert set(ranges.keys()) == {"X", "Y"}


### PR DESCRIPTION
Continuation of the onnx.parser-based test readability migration.

Replaces `onnx.helper.make_node`/`make_graph`/`make_model` graph construction in `tests/test_qoperator_quantize_matmul.py` with the ONNX text format via the established `_model(body, initializer=(), opset=..., ir_version=...)` helper (opset 13, ir_version 10, matching the file's original defaults).

- No `onnx.helper` exceptions were needed for this file: all weight/bias tensors remain numpy-built initializers (via the retained `_f32()` helper) attached through `initializer=[...]`, since they're randomly generated and not meant to byte-match anything.
- Removed the now-unused `_vi()` value-info helper.
- Test names, assertions, and coverage are unchanged — pure construction-style refactor.

### Test plan
- [x] `python3 -m py_compile tests/test_qoperator_quantize_matmul.py`
- [x] `ruff check tests/test_qoperator_quantize_matmul.py` — clean
- [x] `python3 -m pytest tests/test_qoperator_quantize_matmul.py -q --no-header` — run 3x, all 7 tests pass each time
- [x] Test count cross-check: `git show origin/master:tests/test_qoperator_quantize_matmul.py | grep -c "^def test_"` == 7, matches migrated file's 7

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_