### PR TITLE
tests: migrate test_qoperator_quantize_conv.py to onnx.parser

### DIFF
--- a/tests/test_qoperator_quantize_conv.py
+++ b/tests/test_qoperator_quantize_conv.py
@@ -2,7 +2,7 @@
 ``qoperator_quantize_conv`` C++ pass).
 
 Mirrors ``test_qoperator_quantize_matmul.py``: each model is built directly
-with ``onnx.helper``, calibrated with random data, quantized, and then
+with the ONNX text format, calibrated with random data, quantized, and then
 actually run through ONNX Runtime -- both before and after quantization --
 so the quantized graph must load and execute under a real inference engine,
 and its outputs must stay close to the float baseline.
@@ -12,9 +12,9 @@ import collections
 
 import numpy as np
 import onnx
-import onnx.helper
 import onnx.numpy_helper
 import pytest
+from onnx import parser
 
 import onnxsim
 
@@ -23,17 +23,20 @@ import onnxsim
 ort = pytest.importorskip("onnxruntime")
 
 
-def _model(nodes, inputs, outputs, initializer, opset=13):
-    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
+def _model(body, initializer=(), opset=13, ir_version=10):
     # Pin a low IR version so the model loads under older onnxruntime builds
     # (which cap at IR version 11), matching test_fusion_patterns.py.
-    return onnx.helper.make_model(
-        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
     )
-
-
-def _vi(name, shape):
-    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+    model.graph.initializer.extend(initializer)
+    return model
 
 
 def _f32(array, name):
@@ -67,13 +70,14 @@ def test_quantize_conv():
     rng = np.random.default_rng(0)
     cout, cin = 8, 3
     weight = _f32(rng.standard_normal((cout, cin, 3, 3)) * 0.5, "W")
-    nodes = [
-        onnx.helper.make_node(
-            "Conv", ["X", "W"], ["Y"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
-        )
-    ]
     model = _model(
-        nodes, [_vi("X", [1, cin, 16, 16])], [_vi("Y", [1, cout, 16, 16])], [weight]
+        f"""
+        g (float[1,{cin},16,16] X) => (float[1,{cout},16,16] Y)
+        {{
+          Y = Conv<kernel_shape = [3, 3], pads = [1, 1, 1, 1]>(X, W)
+        }}
+        """,
+        [weight],
     )
 
     quant = onnxsim.quantize_qoperator(model, num_calibration_samples=16, seed=0)
@@ -98,15 +102,13 @@ def test_quantize_conv_with_constant_bias():
     cout, cin = 4, 2
     weight = _f32(rng.standard_normal((cout, cin, 3, 3)) * 0.5, "W")
     bias = _f32(rng.standard_normal(cout), "B")
-    nodes = [
-        onnx.helper.make_node(
-            "Conv", ["X", "W", "B"], ["Y"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
-        )
-    ]
     model = _model(
-        nodes,
-        [_vi("X", [2, cin, 8, 8])],
-        [_vi("Y", [2, cout, 8, 8])],
+        f"""
+        g (float[2,{cin},8,8] X) => (float[2,{cout},8,8] Y)
+        {{
+          Y = Conv<kernel_shape = [3, 3], pads = [1, 1, 1, 1]>(X, W, B)
+        }}
+        """,
         [weight, bias],
     )
 
@@ -133,11 +135,13 @@ def test_quantize_skips_non_constant_conv_bias():
     # fallback for it (unlike Gemm's bias in qoperator_quantize_matmul.h), so
     # this Conv is left alone entirely.
     weight = _f32(np.random.randn(4, 3, 3, 3).astype(np.float32), "W")
-    nodes = [onnx.helper.make_node("Conv", ["X", "W", "B"], ["Y"], kernel_shape=[3, 3])]
     model = _model(
-        nodes,
-        [_vi("X", [1, 3, 8, 8]), _vi("B", [4])],
-        [_vi("Y", [1, 4, 6, 6])],
+        """
+        g (float[1,3,8,8] X, float[4] B) => (float[1,4,6,6] Y)
+        {
+          Y = Conv<kernel_shape = [3, 3]>(X, W, B)
+        }
+        """,
         [weight],
     )
     quant = onnxsim.quantize_qoperator(model)
@@ -148,12 +152,13 @@ def test_quantize_skips_non_constant_conv_bias():
 def test_quantize_skips_non_constant_conv_weight():
     # Both Conv operands are graph inputs (neither is a constant), so there
     # is nothing to quantize ahead of time.
-    nodes = [onnx.helper.make_node("Conv", ["X", "W"], ["Y"], kernel_shape=[3, 3])]
     model = _model(
-        nodes,
-        [_vi("X", [1, 3, 8, 8]), _vi("W", [4, 3, 3, 3])],
-        [_vi("Y", [1, 4, 6, 6])],
-        [],
+        """
+        g (float[1,3,8,8] X, float[4,3,3,3] W) => (float[1,4,6,6] Y)
+        {
+          Y = Conv<kernel_shape = [3, 3]>(X, W)
+        }
+        """
     )
     quant = onnxsim.quantize_qoperator(model)
     assert _op_counts(quant)["Conv"] == 1
@@ -163,9 +168,15 @@ def test_quantize_skips_non_constant_conv_weight():
 def test_quantize_skips_old_opset_conv():
     # QLinearConv needs opset >= 10.
     weight = _f32(np.random.randn(4, 3, 3, 3).astype(np.float32), "W")
-    nodes = [onnx.helper.make_node("Conv", ["X", "W"], ["Y"], kernel_shape=[3, 3])]
     model = _model(
-        nodes, [_vi("X", [1, 3, 8, 8])], [_vi("Y", [1, 4, 6, 6])], [weight], opset=9
+        """
+        g (float[1,3,8,8] X) => (float[1,4,6,6] Y)
+        {
+          Y = Conv<kernel_shape = [3, 3]>(X, W)
+        }
+        """,
+        [weight],
+        opset=9,
     )
     quant = onnxsim.quantize_qoperator(model)
     assert _op_counts(quant)["Conv"] == 1
@@ -174,8 +185,15 @@ def test_quantize_skips_old_opset_conv():
 
 def test_list_qoperator_quantizable_outputs_includes_conv_output():
     weight = _f32(np.random.randn(4, 3, 3, 3).astype(np.float32), "W")
-    nodes = [onnx.helper.make_node("Conv", ["X", "W"], ["Y"], kernel_shape=[3, 3])]
-    model = _model(nodes, [_vi("X", [1, 3, 8, 8])], [_vi("Y", [1, 4, 6, 6])], [weight])
+    model = _model(
+        """
+        g (float[1,3,8,8] X) => (float[1,4,6,6] Y)
+        {
+          Y = Conv<kernel_shape = [3, 3]>(X, W)
+        }
+        """,
+        [weight],
+    )
     import onnxsim.onnxsim_cpp2py_export as C
 
     names = C.list_qoperator_quantizable_outputs(model.SerializeToString())
@@ -187,11 +205,13 @@ def test_list_qoperator_quantizable_outputs_excludes_non_constant_bias_conv():
     # test_quantize_skips_non_constant_conv_bias), so its output shouldn't be
     # listed as needing calibration either.
     weight = _f32(np.random.randn(4, 3, 3, 3).astype(np.float32), "W")
-    nodes = [onnx.helper.make_node("Conv", ["X", "W", "B"], ["Y"], kernel_shape=[3, 3])]
     model = _model(
-        nodes,
-        [_vi("X", [1, 3, 8, 8]), _vi("B", [4])],
-        [_vi("Y", [1, 4, 6, 6])],
+        """
+        g (float[1,3,8,8] X, float[4] B) => (float[1,4,6,6] Y)
+        {
+          Y = Conv<kernel_shape = [3, 3]>(X, W, B)
+        }
+        """,
         [weight],
     )
     import onnxsim.onnxsim_cpp2py_export as C


### PR DESCRIPTION
Continuation of the onnx.parser-based test readability migration.

Replaces `onnx.helper.make_node`/`make_graph`/`make_model` graph construction in `tests/test_qoperator_quantize_conv.py` with the ONNX text format via the established `_model(body, initializer=(), opset=..., ir_version=...)` helper (matching `test_fusion_patterns.py`'s IR-version-10 pin). Weight/bias initializers are still built with `numpy_helper.from_array` via a small `_f32` helper and attached through `initializer=[...]`, unreferenced in the graph signature — same convention as `test_pruning.py`/`test_fusion_patterns.py`. Removed the now-unused `_vi` value-info helper and the `onnx.helper` import (nothing in the file calls `onnx.helper.*` anymore).

No `onnx.helper` exceptions were needed for this file — no byte-equal tensor checks, no unranked value info, no large/random `Constant` node values.

Test names, assertions, and coverage are unchanged; this is a pure construction-style refactor.

## Test plan
- [x] `python3 -m py_compile tests/test_qoperator_quantize_conv.py`
- [x] `ruff check tests/test_qoperator_quantize_conv.py` — clean
- [x] `python3 -m pytest tests/test_qoperator_quantize_conv.py -q --no-header` — 7 passed, run 3x to rule out flakiness
- [x] Test count cross-check vs `origin/master`: 7 == 7

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_