### PR TITLE
tests: migrate test_dynamic_quantize_matmul.py to onnx.parser

### DIFF
--- a/tests/test_dynamic_quantize_matmul.py
+++ b/tests/test_dynamic_quantize_matmul.py
@@ -1,7 +1,7 @@
 """Tests for ``onnxsim.quantize_dynamic`` (the ``dynamic_quantize_matmul`` C++
 pass).
 
-Each model is built directly with ``onnx.helper`` (no torch dependency),
+Each model is built directly with the ONNX text format (no torch dependency),
 quantized, and then actually run through ONNX Runtime -- both before and after
 quantization -- so these tests double as a minimal end-to-end
 simplify/quantize/deploy check: the quantized graph must load and execute
@@ -13,9 +13,9 @@ import collections
 
 import numpy as np
 import onnx
-import onnx.helper
 import onnx.numpy_helper
 import pytest
+from onnx import parser
 
 import onnxsim
 
@@ -24,17 +24,20 @@ import onnxsim
 ort = pytest.importorskip("onnxruntime")
 
 
-def _model(nodes, inputs, outputs, initializer, opset=13):
-    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
+def _model(body, initializer=(), opset=13, ir_version=10):
     # Pin a low IR version so the model loads under older onnxruntime builds
     # (which cap at IR version 11), matching test_fusion_patterns.py.
-    return onnx.helper.make_model(
-        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
     )
-
-
-def _vi(name, shape):
-    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+    model.graph.initializer.extend(initializer)
+    return model
 
 
 def _f32(array, name):
@@ -78,8 +81,15 @@ def test_quantize_matmul():
     rng = np.random.default_rng(0)
     K, N = 32, 16
     weight = _f32(rng.standard_normal((K, N)) * 0.5, "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [4, K])], [_vi("Y", [4, N])], [weight])
+    model = _model(
+        f"""
+        g (float[4,{K}] X) => (float[4,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [weight],
+    )
 
     quant = onnxsim.quantize_dynamic(model)
     onnx.checker.check_model(quant)
@@ -101,8 +111,15 @@ def test_quantize_gemm_transb_with_bias():
     K, N = 24, 12
     weight = _f32(rng.standard_normal((N, K)) * 0.5, "W")
     bias = _f32(rng.standard_normal(N), "B")
-    nodes = [onnx.helper.make_node("Gemm", ["X", "W", "B"], ["Y"], transB=1)]
-    model = _model(nodes, [_vi("X", [3, K])], [_vi("Y", [3, N])], [weight, bias])
+    model = _model(
+        f"""
+        g (float[3,{K}] X) => (float[3,{N}] Y)
+        {{
+          Y = Gemm<transB = 1>(X, W, B)
+        }}
+        """,
+        [weight, bias],
+    )
 
     quant = onnxsim.quantize_dynamic(model)
     onnx.checker.check_model(quant)
@@ -120,8 +137,14 @@ def test_quantize_gemm_transb_with_bias():
 def test_quantize_skips_non_constant_weight():
     # Both MatMul operands are graph inputs (neither is a constant), so there
     # is nothing to quantize ahead of time.
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [4, 8]), _vi("W", [8, 4])], [_vi("Y", [4, 4])], [])
+    model = _model(
+        """
+        g (float[4,8] X, float[8,4] W) => (float[4,4] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """
+    )
     quant = onnxsim.quantize_dynamic(model)
     assert _op_counts(quant)["MatMul"] == 1
 
@@ -129,8 +152,15 @@ def test_quantize_skips_non_constant_weight():
 def test_quantize_skips_non_default_gemm_attrs():
     # alpha != 1 falls outside the "vanilla" Gemm shape this pass handles.
     weight = _f32(np.random.randn(8, 4).astype(np.float32), "W")
-    nodes = [onnx.helper.make_node("Gemm", ["X", "W"], ["Y"], alpha=2.0)]
-    model = _model(nodes, [_vi("X", [4, 8])], [_vi("Y", [4, 4])], [weight])
+    model = _model(
+        """
+        g (float[4,8] X) => (float[4,4] Y)
+        {
+          Y = Gemm<alpha = 2.0>(X, W)
+        }
+        """,
+        [weight],
+    )
     quant = onnxsim.quantize_dynamic(model)
     assert _op_counts(quant)["Gemm"] == 1
 
@@ -146,8 +176,15 @@ def test_quantize_skips_reduction_depth_that_would_overflow_int32():
 
     k = MAX_SAFE_INT32_REDUCTION_DEPTH + 1
     weight = _f32(np.random.randn(k, 1) * 0.01, "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [1, k])], [_vi("Y", [1, 1])], [weight])
+    model = _model(
+        f"""
+        g (float[1,{k}] X) => (float[1,1] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [weight],
+    )
 
     quant = onnxsim.quantize_dynamic(model)
     onnx.checker.check_model(quant)
@@ -163,8 +200,15 @@ def test_quantize_still_applies_at_the_safe_reduction_depth_boundary():
 
     k = MAX_SAFE_INT32_REDUCTION_DEPTH
     weight = _f32(np.random.randn(k, 1) * 0.01, "W")
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    model = _model(nodes, [_vi("X", [1, k])], [_vi("Y", [1, 1])], [weight])
+    model = _model(
+        f"""
+        g (float[1,{k}] X) => (float[1,1] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [weight],
+    )
 
     quant = onnxsim.quantize_dynamic(model)
     onnx.checker.check_model(quant)


### PR DESCRIPTION
Continuation of the onnx.parser-based test readability migration.

Replaces `onnx.helper.make_node`/`make_graph`/`make_model` graph construction in `tests/test_dynamic_quantize_matmul.py` with the ONNX text format, via the established `_model(body, initializer=(), opset=13, ir_version=10)` helper (matching the file's original opset/ir_version defaults). `_vi` is dropped (no longer used); `onnx.helper` import is removed since nothing calls it any more. Test names, assertions, and behavior/coverage are unchanged -- this is a pure construction-style refactor.

No exceptions needed: all 6 tests build plain float32 tensors with regular (non-scalar, statically-known) shapes, so none of the documented `onnx.helper`-keeping exceptions applied. Weight/bias tensors are still built with `numpy_helper.from_array` (random/deterministic-seeded numpy arrays) and attached via the `initializer=[...]` param, per the migration guidance.

## Test plan

- [x] `python3 -m py_compile tests/test_dynamic_quantize_matmul.py`
- [x] `ruff check tests/test_dynamic_quantize_matmul.py` -- clean
- [x] `python3 -m pytest tests/test_dynamic_quantize_matmul.py -q --no-header` run 3x -- 6 passed each time
- [x] Test count cross-check: `git show origin/master:tests/test_dynamic_quantize_matmul.py | grep -c "^def test_"` == 6, matches migrated file's 6

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_