### PR TITLE
tests: migrate test_static_quantize_conv.py to onnx.parser

### DIFF
--- a/tests/test_static_quantize_conv.py
+++ b/tests/test_static_quantize_conv.py
@@ -2,19 +2,19 @@
 ``static_quantize_conv`` C++ pass).
 
 Mirrors ``test_static_quantize_matmul.py``: each model is built directly with
-``onnx.helper``, calibrated with random data, quantized, and then actually
-run through ONNX Runtime -- both before and after quantization -- so the
-quantized graph must load and execute under a real inference engine, and its
-outputs must stay close to the float baseline.
+the ONNX text format, calibrated with random data, quantized, and then
+actually run through ONNX Runtime -- both before and after quantization -- so
+the quantized graph must load and execute under a real inference engine, and
+its outputs must stay close to the float baseline.
 """
 
 import collections
 
 import numpy as np
 import onnx
-import onnx.helper
 import onnx.numpy_helper
 import pytest
+from onnx import parser
 
 import onnxsim
 
@@ -23,17 +23,20 @@ import onnxsim
 ort = pytest.importorskip("onnxruntime")
 
 
-def _model(nodes, inputs, outputs, initializer, opset=13):
-    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
+def _model(body, initializer=(), opset=13, ir_version=10):
     # Pin a low IR version so the model loads under older onnxruntime builds
     # (which cap at IR version 11), matching test_fusion_patterns.py.
-    return onnx.helper.make_model(
-        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
     )
-
-
-def _vi(name, shape):
-    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+    model.graph.initializer.extend(initializer)
+    return model
 
 
 def _f32(array, name):
@@ -67,13 +70,14 @@ def test_quantize_conv():
     rng = np.random.default_rng(0)
     cout, cin = 8, 3
     weight = _f32(rng.standard_normal((cout, cin, 3, 3)) * 0.5, "W")
-    nodes = [
-        onnx.helper.make_node(
-            "Conv", ["X", "W"], ["Y"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
-        )
-    ]
     model = _model(
-        nodes, [_vi("X", [1, cin, 16, 16])], [_vi("Y", [1, cout, 16, 16])], [weight]
+        """
+        g (float[1,3,16,16] X) => (float[1,8,16,16] Y)
+        {
+          Y = Conv<kernel_shape = [3, 3], pads = [1, 1, 1, 1]>(X, W)
+        }
+        """,
+        [weight],
     )
 
     quant = onnxsim.quantize_static(model, num_calibration_samples=16, seed=0)
@@ -92,15 +96,13 @@ def test_quantize_conv_with_bias():
     cout, cin = 4, 2
     weight = _f32(rng.standard_normal((cout, cin, 3, 3)) * 0.5, "W")
     bias = _f32(rng.standard_normal(cout), "B")
-    nodes = [
-        onnx.helper.make_node(
-            "Conv", ["X", "W", "B"], ["Y"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
-        )
-    ]
     model = _model(
-        nodes,
-        [_vi("X", [2, cin, 8, 8])],
-        [_vi("Y", [2, cout, 8, 8])],
+        """
+        g (float[2,2,8,8] X) => (float[2,4,8,8] Y)
+        {
+          Y = Conv<kernel_shape = [3, 3], pads = [1, 1, 1, 1]>(X, W, B)
+        }
+        """,
         [weight, bias],
     )
 
@@ -120,12 +122,13 @@ def test_quantize_conv_with_bias():
 def test_quantize_skips_non_constant_conv_weight():
     # Both Conv operands are graph inputs (neither is a constant), so there
     # is nothing to quantize ahead of time.
-    nodes = [onnx.helper.make_node("Conv", ["X", "W"], ["Y"], kernel_shape=[3, 3])]
     model = _model(
-        nodes,
-        [_vi("X", [1, 3, 8, 8]), _vi("W", [4, 3, 3, 3])],
-        [_vi("Y", [1, 4, 6, 6])],
-        [],
+        """
+        g (float[1,3,8,8] X, float[4,3,3,3] W) => (float[1,4,6,6] Y)
+        {
+          Y = Conv<kernel_shape = [3, 3]>(X, W)
+        }
+        """
     )
     quant = onnxsim.quantize_static(model)
     assert _op_counts(quant)["Conv"] == 1
@@ -135,9 +138,15 @@ def test_quantize_skips_non_constant_conv_weight():
 def test_quantize_skips_old_opset_conv():
     # DequantizeLinear's per-channel `axis` attribute needs opset >= 13.
     weight = _f32(np.random.randn(4, 3, 3, 3).astype(np.float32), "W")
-    nodes = [onnx.helper.make_node("Conv", ["X", "W"], ["Y"], kernel_shape=[3, 3])]
     model = _model(
-        nodes, [_vi("X", [1, 3, 8, 8])], [_vi("Y", [1, 4, 6, 6])], [weight], opset=12
+        """
+        g (float[1,3,8,8] X) => (float[1,4,6,6] Y)
+        {
+          Y = Conv<kernel_shape = [3, 3]>(X, W)
+        }
+        """,
+        [weight],
+        opset=12,
     )
     quant = onnxsim.quantize_static(model)
     assert _op_counts(quant)["Conv"] == 1
@@ -146,8 +155,15 @@ def test_quantize_skips_old_opset_conv():
 
 def test_calibrate_includes_conv_activation():
     weight = _f32(np.random.randn(4, 3, 3, 3).astype(np.float32), "W")
-    nodes = [onnx.helper.make_node("Conv", ["X", "W"], ["Y"], kernel_shape=[3, 3])]
-    model = _model(nodes, [_vi("X", [1, 3, 8, 8])], [_vi("Y", [1, 4, 6, 6])], [weight])
+    model = _model(
+        """
+        g (float[1,3,8,8] X) => (float[1,4,6,6] Y)
+        {
+          Y = Conv<kernel_shape = [3, 3]>(X, W)
+        }
+        """,
+        [weight],
+    )
     data = onnxsim.generate_random_calibration_data(model, num_samples=4, seed=0)
     ranges = onnxsim.calibrate(model, data)
     assert set(ranges.keys()) == {"X"}


### PR DESCRIPTION
Continuation of the onnx.parser-based test readability migration.

Replaces `onnx.helper.make_node`/`make_graph`/`make_model` graph construction
in `tests/test_static_quantize_conv.py` with the ONNX text format via the
established `_model(body, initializer=(), opset=..., ir_version=...)` helper
(matching `tests/test_static_quantize_matmul.py` and other already-migrated
files). This is a pure construction-style refactor -- test names, assertions,
and coverage are unchanged.

No exceptions were needed: all tensors are either random/computed weight
initializers (kept as `onnx.numpy_helper.from_array(...)` attached via the
`initializer=[...]` param, per the established convention) or plain graph
inputs, so nothing required keeping `onnx.helper` node/graph construction.

## Test plan

- [x] `python3 -m py_compile tests/test_static_quantize_conv.py`
- [x] `ruff check tests/test_static_quantize_conv.py` -- clean
- [x] `python3 -m pytest tests/test_static_quantize_conv.py -q --no-header` -- run 3x, all 5 tests pass each time
- [x] Test count cross-check: `git show origin/master:tests/test_static_quantize_conv.py | grep -c "^def test_"` == 5, matches migrated file

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_