### PR TITLE
tests: migrate test_squeezellm.py to onnx.parser

### DIFF
--- a/tests/test_squeezellm.py
+++ b/tests/test_squeezellm.py
@@ -8,40 +8,45 @@ sparse-position correction.
 
 import numpy as np
 import onnx
-import onnx.helper
 import onnx.numpy_helper
 import pytest
+from onnx import parser
 
 import onnxsim
 
 ort = pytest.importorskip("onnxruntime")
 
 
-def _vi(name, shape):
-    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+def _model(body, initializer=(), opset=13, ir_version=8):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
 
 
 def _f32(array, name):
     return onnx.numpy_helper.from_array(array.astype(np.float32), name)
 
 
-def _model(nodes, inputs, outputs, initializer, opset=13):
-    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
-    return onnx.helper.make_model(
-        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=8
-    )
-
-
 def _matmul_model(K=64, N=16, weight=None, seed=0, opset=13):
     if weight is None:
         rng = np.random.default_rng(seed)
         weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
     return _model(
-        nodes,
-        [_vi("X", ["batch", K])],
-        [_vi("Y", ["batch", N])],
-        [_f32(weight, "W")],
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[_f32(weight, "W")],
         opset=opset,
     )
 
@@ -231,9 +236,14 @@ def test_squeezellm_gemm_transb():
     rng = np.random.default_rng(10)
     K, N = 64, 12
     weight = rng.standard_normal((N, K)).astype(np.float32) * 0.5
-    nodes = [onnx.helper.make_node("Gemm", ["X", "W"], ["Y"], transB=1)]
     model = _model(
-        nodes, [_vi("X", ["batch", K])], [_vi("Y", ["batch", N])], [_f32(weight, "W")]
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = Gemm<transB = 1>(X, W)
+        }}
+        """,
+        initializer=[_f32(weight, "W")],
     )
     x = _varied_calibration(K=K, num_samples=32, seed=11)
     calibration_data = [{"X": x}]
@@ -258,9 +268,13 @@ def test_squeezellm_skips_non_block_divisible_k():
 
 
 def test_squeezellm_skips_non_constant_weight():
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
     model = _model(
-        nodes, [_vi("X", [4, 64]), _vi("W", [64, 4])], [_vi("Y", [4, 4])], []
+        """
+        g (float[4,64] X, float[64,4] W) => (float[4,4] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """
     )
     q_model = onnxsim.quantize_weight_only_squeezellm(
         model, calibration_data=[{"X": np.zeros((4, 64), dtype=np.float32)}]
@@ -269,8 +283,14 @@ def test_squeezellm_skips_non_constant_weight():
 
 
 def test_squeezellm_noop_when_no_matmul_present():
-    nodes = [onnx.helper.make_node("Relu", ["X"], ["Y"])]
-    model = _model(nodes, [_vi("X", [4, 4])], [_vi("Y", [4, 4])], [])
+    model = _model(
+        """
+        g (float[4,4] X) => (float[4,4] Y)
+        {
+          Y = Relu(X)
+        }
+        """
+    )
     result = onnxsim.quantize_weight_only_squeezellm(
         model, calibration_data=[{"X": np.zeros((4, 4), dtype=np.float32)}]
     )


### PR DESCRIPTION
Continuation of the onnx.parser-based test readability migration.

Replaces `onnx.helper.make_node`/`make_graph`/`make_model` graph construction in `tests/test_squeezellm.py` with the ONNX text format via the established per-file `_model(body, initializer=(), opset=13, ir_version=8)` helper wrapping `onnx.parser.parse_model`.

- `_matmul_model` and the Gemm-transB test now build their graphs via text-format bodies with `initializer=[...]` for the (random or fixed) float32 weight tensors, using `onnx.numpy_helper.from_array` as before.
- The now-unused `_vi` value-info builder was removed, and `import onnx.helper` was dropped since nothing calls `onnx.helper.*` anymore.
- No exceptions to the standard pattern were needed for this file — no byte-equal tensor checks, no unranked value info, no large/random `Constant` node literals.
- Test names, assertions, and behavior/coverage are unchanged — this is a pure construction-style refactor.

## Test plan
- [x] `python3 -m py_compile tests/test_squeezellm.py`
- [x] `ruff check tests/test_squeezellm.py`
- [x] `python3 -m pytest tests/test_squeezellm.py -q --no-header` — run 3x, all 10 tests pass each time
- [x] Test count cross-check: `git show origin/master:tests/test_squeezellm.py | grep -c "^def test_"` == count in migrated file (10 == 10)

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_