### PR TITLE
tests: migrate test_quip_sharp.py to onnx.parser

### DIFF
--- a/tests/test_quip_sharp.py
+++ b/tests/test_quip_sharp.py
@@ -9,9 +9,9 @@ import itertools
 
 import numpy as np
 import onnx
-import onnx.helper
 import onnx.numpy_helper
 import pytest
+from onnx import parser
 
 import onnxsim
 from onnxsim.quip_sharp import (
@@ -23,28 +23,36 @@ from onnxsim.quip_sharp import (
 ort = pytest.importorskip("onnxruntime")
 
 
-def _vi(name, shape):
-    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
-
-
 def _f32(array, name):
     return onnx.numpy_helper.from_array(array.astype(np.float32), name)
 
 
-def _model(nodes, inputs, outputs, initializer, opset=21):
-    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
-    return onnx.helper.make_model(
-        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
     )
+    model.graph.initializer.extend(initializer)
+    return model
 
 
 def _matmul_model(K=32, N=16, weight=None, seed=0):
     if weight is None:
         rng = np.random.default_rng(seed)
         weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
     return _model(
-        nodes, [_vi("X", ["batch", K])], [_vi("Y", ["batch", N])], [_f32(weight, "W")]
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[_f32(weight, "W")],
     )
 
 
@@ -214,12 +222,14 @@ def test_quip_sharp_gemm_transb_with_bias():
     K, N = 40, 10
     weight = rng.standard_normal((N, K)).astype(np.float32) * 0.5
     bias = rng.standard_normal(N).astype(np.float32)
-    nodes = [onnx.helper.make_node("Gemm", ["X", "W", "B"], ["Y"], transB=1)]
     model = _model(
-        nodes,
-        [_vi("X", ["batch", K])],
-        [_vi("Y", ["batch", N])],
-        [_f32(weight, "W"), _f32(bias, "B")],
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = Gemm<transB = 1>(X, W, B)
+        }}
+        """,
+        initializer=[_f32(weight, "W"), _f32(bias, "B")],
     )
     q = onnxsim.apply_quip_sharp(model, seed=1)
     onnx.checker.check_model(q)
@@ -238,16 +248,26 @@ def test_quip_sharp_skips_non_group_divisible_k():
 
 
 def test_quip_sharp_skips_non_constant_weight():
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
     model = _model(
-        nodes, [_vi("X", [4, 32]), _vi("W", [32, 4])], [_vi("Y", [4, 4])], []
+        """
+        g (float[4,32] X, float[32,4] W) => (float[4,4] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """
     )
     q = onnxsim.apply_quip_sharp(model)
     assert q.SerializeToString() == model.SerializeToString()
 
 
 def test_quip_sharp_noop_when_no_matmul_present():
-    nodes = [onnx.helper.make_node("Relu", ["X"], ["Y"])]
-    model = _model(nodes, [_vi("X", [4, 4])], [_vi("Y", [4, 4])], [])
+    model = _model(
+        """
+        g (float[4,4] X) => (float[4,4] Y)
+        {
+          Y = Relu(X)
+        }
+        """
+    )
     result = onnxsim.apply_quip_sharp(model)
     assert result.SerializeToString() == model.SerializeToString()


### PR DESCRIPTION
Continuation of the onnx.parser-based test readability migration.

Replaces `onnx.helper.make_node`/`make_graph`/`make_model` graph construction in `tests/test_quip_sharp.py` with the ONNX text format via the established `_model(body, initializer=(), opset=21, ir_version=10)` helper (matching this file's original opset/ir_version defaults). This is a pure construction-style refactor -- test names, assertions, and coverage are unchanged.

No exceptions to the standard pattern were needed: all graphs in this file use only float32 tensors with static/symbolic shapes and either no weight (a plain `Relu`/`MatMul`-with-graph-input-weight case) or a numpy-generated weight initializer attached via `initializer=[...]`, which is directly supported by the established helper.

## Test plan
- [x] `python3 -m py_compile tests/test_quip_sharp.py`
- [x] `ruff check tests/test_quip_sharp.py` -- clean
- [x] `python3 -m pytest tests/test_quip_sharp.py -q --no-header` -- 13 passed, run 3x to rule out flakiness from random test data
- [x] Test count cross-check: `git show origin/master:tests/test_quip_sharp.py | grep -c "^def test_"` == 13 == count in migrated file

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_