### PR TITLE
tests: migrate test_aqlm.py to onnx.parser

### DIFF
--- a/tests/test_aqlm.py
+++ b/tests/test_aqlm.py
@@ -6,37 +6,45 @@ of one lookup per codebook.
 
 import numpy as np
 import onnx
-import onnx.helper
 import onnx.numpy_helper
 import pytest
+from onnx import parser
 
 import onnxsim
 
 ort = pytest.importorskip("onnxruntime")
 
 
-def _vi(name, shape):
-    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+def _model(body, initializer=(), opset=13, ir_version=8):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
 
 
 def _f32(array, name):
     return onnx.numpy_helper.from_array(array.astype(np.float32), name)
 
 
-def _model(nodes, inputs, outputs, initializer, opset=13):
-    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
-    return onnx.helper.make_model(
-        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=8
-    )
-
-
 def _matmul_model(K=64, N=16, weight=None, seed=0):
     if weight is None:
         rng = np.random.default_rng(seed)
         weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
     return _model(
-        nodes, [_vi("X", ["batch", K])], [_vi("Y", ["batch", N])], [_f32(weight, "W")]
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[_f32(weight, "W")],
     )
 
 
@@ -153,9 +161,14 @@ def test_aqlm_gemm_transb():
     rng = np.random.default_rng(7)
     K, N = 64, 12
     weight = rng.standard_normal((N, K)).astype(np.float32) * 0.5
-    nodes = [onnx.helper.make_node("Gemm", ["X", "W"], ["Y"], transB=1)]
     model = _model(
-        nodes, [_vi("X", ["batch", K])], [_vi("Y", ["batch", N])], [_f32(weight, "W")]
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = Gemm<transB = 1>(X, W)
+        }}
+        """,
+        initializer=[_f32(weight, "W")],
     )
     q = onnxsim.quantize_weight_only_aqlm(model, group_dim=8, seed=2)
     onnx.checker.check_model(q)
@@ -185,16 +198,26 @@ def test_aqlm_skips_non_group_divisible_k():
 
 
 def test_aqlm_skips_non_constant_weight():
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
     model = _model(
-        nodes, [_vi("X", [4, 32]), _vi("W", [32, 4])], [_vi("Y", [4, 4])], []
+        """
+        g (float[4,32] X, float[32,4] W) => (float[4,4] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """
     )
     q = onnxsim.quantize_weight_only_aqlm(model)
     assert q.SerializeToString() == model.SerializeToString()
 
 
 def test_aqlm_noop_when_no_matmul_present():
-    nodes = [onnx.helper.make_node("Relu", ["X"], ["Y"])]
-    model = _model(nodes, [_vi("X", [4, 4])], [_vi("Y", [4, 4])], [])
+    model = _model(
+        """
+        g (float[4,4] X) => (float[4,4] Y)
+        {
+          Y = Relu(X)
+        }
+        """
+    )
     result = onnxsim.quantize_weight_only_aqlm(model)
     assert result.SerializeToString() == model.SerializeToString()


### PR DESCRIPTION
Continuation of the onnx.parser-based test readability migration.

Replaces `onnx.helper.make_node`/`make_graph`/`make_model` graph construction in `tests/test_aqlm.py` with the ONNX text format via the established `_model(body, initializer=(), opset=..., ir_version=...)` helper (built on `onnx.parser.parse_model`).

No exceptions needed this time: the random/large weight initializers (`_matmul_model`'s `W`, and the Gemm-transB test's `W`) are still built with `numpy` + `onnx.numpy_helper.from_array` and attached via the `initializer=[...]` parameter, per the established convention -- they aren't spelled out as text literals. `_vi` was dropped (no longer used), and `import onnx.helper` was removed since nothing in the file calls `onnx.helper.*` anymore.

Test names, assertions, and coverage are unchanged -- this is a pure construction-style refactor.

## Test plan

- [x] `python3 -m py_compile tests/test_aqlm.py`
- [x] `ruff check tests/test_aqlm.py`
- [x] `python3 -m pytest tests/test_aqlm.py -q --no-header` -- run 3x, all 8 tests pass each time
- [x] Test count cross-check: `git show origin/master:tests/test_aqlm.py | grep -c "^def test_"` (8) matches the migrated file (8)

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_