### PR TITLE
tests: migrate test_autoround.py to onnx.parser

### DIFF
--- a/tests/test_autoround.py
+++ b/tests/test_autoround.py
@@ -6,24 +6,27 @@ INT4-quantized MatMul/Gemm layer, on top of what
 
 import numpy as np
 import onnx
-import onnx.helper
 import onnx.numpy_helper
 import pytest
+from onnx import parser
 
 import onnxsim
 
 ort = pytest.importorskip("onnxruntime")
 
 
-def _model(nodes, inputs, outputs, initializer, opset=21):
-    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
-    return onnx.helper.make_model(
-        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
     )
-
-
-def _vi(name, shape):
-    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+    model.graph.initializer.extend(initializer)
+    return model
 
 
 def _f32(array, name):
@@ -38,11 +41,13 @@ def _run(model, feeds):
 
 
 def _matmul_model(weight, K, N, batch, opset=21):
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
     return _model(
-        nodes,
-        [_vi("X", [batch, K])],
-        [_vi("Y", [batch, N])],
+        f"""
+        g (float[{batch},{K}] X) => (float[{batch},{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
         [_f32(weight, "W")],
         opset=opset,
     )
@@ -260,8 +265,14 @@ def test_autoround_codes_stay_in_range_and_output_finite():
 
 
 def test_autoround_noop_when_no_int4_matmul_present():
-    nodes = [onnx.helper.make_node("Relu", ["X"], ["Y"])]
-    model = _model(nodes, [_vi("X", [4, 4])], [_vi("Y", [4, 4])], [])
+    model = _model(
+        """
+        g (float[4,4] X) => (float[4,4] Y)
+        {
+          Y = Relu(X)
+        }
+        """
+    )
     result = onnxsim.apply_autoround(
         model, model, calibration_data=[{"X": np.zeros((4, 4), dtype=np.float32)}]
     )


### PR DESCRIPTION
Continuation of the onnx.parser-based test readability migration.

Replaces `onnx.helper.make_node`/`make_graph`/`make_model` graph construction in `tests/test_autoround.py` with the ONNX text format, via the established `_model(body, initializer=(), opset=..., ir_version=...)` helper (opset 21 / ir_version 10, matching the file's original defaults).

- `_matmul_model` now builds its single-node `MatMul` graph as a text-format body, with the weight still attached as an `onnx.numpy_helper.from_array`-built initializer (per the guidance for random/large weight tensors).
- `test_autoround_noop_when_no_int4_matmul_present`'s `Relu` model is now a text-format body too.
- Removed the now-unused `_vi` helper and the `import onnx.helper` line.
- No `onnx.helper` exceptions were needed — this file's model construction was small and had no byte-equal-tensor, unranked-shape, or external-data cases.

Test names, assertions, and behavior/coverage are unchanged — this is a pure construction-style refactor.

## Test plan
- [x] `python3 -m py_compile tests/test_autoround.py`
- [x] `ruff check tests/test_autoround.py`
- [x] `python3 -m pytest tests/test_autoround.py -q --no-header` — run 3x, all 5 tests pass each time
- [x] Test count cross-check: `git show origin/master:tests/test_autoround.py | grep -c "^def test_"` (5) matches the migrated file's count (5)

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_