### PR TITLE
tests: migrate test_export_transformers_save.py to onnx.parser

### DIFF
--- a/tests/test_export_transformers_save.py
+++ b/tests/test_export_transformers_save.py
@@ -9,23 +9,39 @@ import os
 
 import numpy as np
 import onnx
-import onnx.helper
 import onnx.numpy_helper
 import pytest
+from onnx import parser
 
 from onnxsim.transformers_export import _save
+
+
+def _model(body, initializer=(), opset=17, ir_version=9):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
 
 
 def _tiny_model():
     w = onnx.numpy_helper.from_array(
         np.random.RandomState(0).rand(4, 4).astype(np.float32), "W"
     )
-    x = onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, [4, 4])
-    y = onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [4, 4])
-    node = onnx.helper.make_node("Add", ["X", "W"], ["Y"])
-    graph = onnx.helper.make_graph([node], "g", [x], [y], initializer=[w])
-    return onnx.helper.make_model(
-        graph, opset_imports=[onnx.helper.make_opsetid("", 17)], ir_version=9
+    return _model(
+        """
+        g (float[4,4] X) => (float[4,4] Y)
+        {
+          Y = Add(X, W)
+        }
+        """,
+        initializer=[w],
     )
 
 


### PR DESCRIPTION
Continuation of the onnx.parser-based test readability migration.

Replaces `onnx.helper.make_node`/`make_graph`/`make_model` graph construction
in `tests/test_export_transformers_save.py` with the ONNX text format via the
established `_model(body, initializer=(), opset=..., ir_version=...)` helper
(matching the file's original `opset=17, ir_version=9` defaults).

The single random weight initializer (`W`, a `(4, 4)` float32 array seeded
with `np.random.RandomState(0)`) is still built with `onnx.numpy_helper.from_array`
and attached via the `initializer=[...]` parameter, per the established
convention for randomly-generated tensors that shouldn't be spelled out as
text literals.

No `onnx.helper` exceptions were needed beyond that — dropped the now-unused
`import onnx.helper` line.

## Test plan
- [x] `python3 -m py_compile tests/test_export_transformers_save.py`
- [x] `ruff check tests/test_export_transformers_save.py` — clean
- [x] `python3 -m pytest tests/test_export_transformers_save.py -q --no-header` — 5 passed, run 3x to rule out flakiness
- [x] Test count cross-check: `grep -c "^def test_"` is 4 on both master and the migrated file (one test is parametrized, producing 5 collected items)

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_