### PR TITLE
tests: migrate test_import_gguf_weights.py to onnx.parser

### DIFF
--- a/tests/test_import_gguf_weights.py
+++ b/tests/test_import_gguf_weights.py
@@ -18,8 +18,8 @@ import struct
 
 import numpy as np
 import onnx
-import onnx.helper
 import onnx.numpy_helper
+from onnx import parser
 
 import onnxsim
 
@@ -127,19 +127,34 @@ def _make_q4_k_block(rng):
     return raw, expected
 
 
-def _vi(name, shape, dtype=onnx.TensorProto.FLOAT):
-    return onnx.helper.make_tensor_value_info(name, dtype, shape)
+def _model(body, initializer=(), opset=13, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
 
 
 def _identity_model(name, shape):
     # A minimal single-initializer graph: Identity(W) -> Y, with W the
     # initializer import_gguf_weights should hydrate. Seeded with zeros so a
     # test failing to actually hydrate is caught (not accidentally correct).
+    dims = ",".join(str(d) for d in shape)
     weight = onnx.numpy_helper.from_array(np.zeros(shape, dtype=np.float32), name)
-    nodes = [onnx.helper.make_node("Identity", [name], ["Y"])]
-    graph = onnx.helper.make_graph(nodes, "g", [], [_vi("Y", shape)], [weight])
-    return onnx.helper.make_model(
-        graph, opset_imports=[onnx.helper.make_opsetid("", 13)], ir_version=10
+    return _model(
+        f"""
+        g () => (float[{dims}] Y)
+        {{
+          Y = Identity({name})
+        }}
+        """,
+        initializer=[weight],
     )
 
 


### PR DESCRIPTION
Continuation of the onnx.parser-based test readability migration.

Migrates `tests/test_import_gguf_weights.py` from `onnx.helper.make_node`/`make_graph`/`make_model` to `onnx.parser.parse_model` via the established `_model(body, initializer=(), opset=13, ir_version=10)` helper.

## Changes

- Added the standard `_model(...)` helper wrapping `parser.parse_model`.
- Rewrote `_identity_model(name, shape)` (the shared `Identity(W) -> Y` graph used by all 5 tests) to build its graph via the ONNX text format instead of `onnx.helper.make_graph`/`make_model`. The `W` weight initializer is still built with `onnx.numpy_helper.from_array(np.zeros(shape, ...), name)` and attached via the `initializer=[...]` param, since its shape varies per test.
- Removed the now-unused `_vi` helper and the `onnx.helper` import (nothing in the file calls `onnx.helper.*` anymore).
- GGUF binary file construction (`_write_gguf`, `_make_q8_0_block`, `_make_q4_k_block`, etc.) is unrelated to `onnx.helper` and was left untouched.

No exceptions to the standard pattern were needed for this file.

Test names, assertions, and coverage are unchanged — this is a pure construction-style refactor.

## Test plan

- [x] `python3 -m py_compile tests/test_import_gguf_weights.py` — clean
- [x] `ruff check tests/test_import_gguf_weights.py` — clean (`All checks passed!`)
- [x] `python3 -m pytest tests/test_import_gguf_weights.py -q --no-header` — 5 passed, run 3x to rule out flakiness from random test data
- [x] Test count cross-check: `git show origin/master:tests/test_import_gguf_weights.py | grep -c "^def test_"` == 5, matches migrated file's 5

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_