### PR TITLE
tests: migrate test_low_rank_compensation.py to onnx.parser

### DIFF
--- a/tests/test_low_rank_compensation.py
+++ b/tests/test_low_rank_compensation.py
@@ -7,36 +7,44 @@ directly from the two weights with no calibration data.
 
 import numpy as np
 import onnx
-import onnx.helper
 import onnx.numpy_helper
 import pytest
+from onnx import parser
 
 import onnxsim
 
 ort = pytest.importorskip("onnxruntime")
 
 
-def _vi(name, shape):
-    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
 
 
 def _f32(array, name):
     return onnx.numpy_helper.from_array(array.astype(np.float32), name)
 
 
-def _model(nodes, inputs, outputs, initializer, opset=21):
-    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
-    return onnx.helper.make_model(
-        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
-    )
-
-
 def _matmul_model(K=64, N=16, seed=0):
     rng = np.random.default_rng(seed)
     weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
     return _model(
-        nodes, [_vi("X", ["batch", K])], [_vi("Y", ["batch", N])], [_f32(weight, "W")]
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [_f32(weight, "W")],
     )
 
 
@@ -137,9 +145,14 @@ def test_lorc_gemm_transb():
     rng = np.random.default_rng(8)
     K, N = 48, 12
     weight = rng.standard_normal((N, K)).astype(np.float32) * 0.5
-    nodes = [onnx.helper.make_node("Gemm", ["X", "W"], ["Y"], transB=1)]
     model = _model(
-        nodes, [_vi("X", ["batch", K])], [_vi("Y", ["batch", N])], [_f32(weight, "W")]
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = Gemm<transB = 1>(X, W)
+        }}
+        """,
+        [_f32(weight, "W")],
     )
     quant = onnxsim.quantize_weight_only_int4(model)
     onnx.checker.check_model(quant)
@@ -154,7 +167,13 @@ def test_lorc_gemm_transb():
 
 
 def test_lorc_noop_when_no_int4_matmul_present():
-    nodes = [onnx.helper.make_node("Relu", ["X"], ["Y"])]
-    model = _model(nodes, [_vi("X", [4, 4])], [_vi("Y", [4, 4])], [])
+    model = _model(
+        """
+        g (float[4,4] X) => (float[4,4] Y)
+        {
+          Y = Relu(X)
+        }
+        """
+    )
     result = onnxsim.apply_low_rank_compensation(model, model, rank=4)
     assert result.SerializeToString() == model.SerializeToString()


### PR DESCRIPTION
Continuation of the onnx.parser-based test readability migration.

Replaces `onnx.helper.make_node`/`make_graph`/`make_model` graph construction in `tests/test_low_rank_compensation.py` with the ONNX text format via the established `_model(body, initializer=(), opset=..., ir_version=...)` helper (opset 21, ir_version 10, matching the file's original defaults).

- `_matmul_model` (MatMul with a dynamic `batch` dim) and the `Gemm<transB = 1>` test now build their graphs as text; random weight initializers stay built via `numpy_helper.from_array` and are attached through the `initializer=[...]` param, per the established convention.
- The `Relu`-only no-op test converts directly to a fixed-shape text graph.
- Removed the now-unused `_vi` value-info helper and the `import onnx.helper` line (nothing calls `onnx.helper.*` anymore).
- No exceptions were needed -- every model in this file expresses cleanly in the text format.

Test names, assertions, and behavior/coverage are unchanged -- this is a pure construction-style refactor.

## Test plan
- [x] `python3 -m py_compile tests/test_low_rank_compensation.py`
- [x] `ruff check tests/test_low_rank_compensation.py`
- [x] `python3 -m pytest tests/test_low_rank_compensation.py -q --no-header` -- run 3x, all 6 tests pass each time
- [x] Test count cross-check: `git show origin/master:tests/test_low_rank_compensation.py | grep -c "^def test_"` == 6 == count in migrated file

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_