### PR TITLE
tests: migrate test_hqq.py to onnx.parser

### DIFF
--- a/tests/test_hqq.py
+++ b/tests/test_hqq.py
@@ -7,27 +7,45 @@ fit a naive min/max range implicitly targets.
 
 import numpy as np
 import onnx
-import onnx.helper
 import onnx.numpy_helper
 import pytest
+from onnx import parser
 
 import onnxsim
 
 ort = pytest.importorskip("onnxruntime")
 
 
-def _vi(name, shape):
-    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
 
 
 def _f32(array, name):
     return onnx.numpy_helper.from_array(array.astype(np.float32), name)
 
 
-def _model(nodes, inputs, outputs, initializer, opset=21):
-    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
-    return onnx.helper.make_model(
-        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+def _matmul_model(K=64, N=16, weight=None, seed=0):
+    if weight is None:
+        rng = np.random.default_rng(seed)
+        weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [_f32(weight, "W")],
     )
 
 
@@ -42,16 +60,6 @@ def _rel_l2(a, b):
     a = np.asarray(a, dtype=np.float64).ravel()
     b = np.asarray(b, dtype=np.float64).ravel()
     return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
-
-
-def _matmul_model(K=64, N=16, weight=None, seed=0):
-    if weight is None:
-        rng = np.random.default_rng(seed)
-        weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
-    return _model(
-        nodes, [_vi("X", ["batch", K])], [_vi("Y", ["batch", N])], [_f32(weight, "W")]
-    )
 
 
 def _dequantize_hqq(model):
@@ -159,9 +167,14 @@ def test_hqq_gemm_transb():
     rng = np.random.default_rng(4)
     K, N = 96, 12
     weight = rng.standard_normal((N, K)).astype(np.float32) * 0.5
-    nodes = [onnx.helper.make_node("Gemm", ["X", "W"], ["Y"], transB=1)]
     model = _model(
-        nodes, [_vi("X", ["batch", K])], [_vi("Y", ["batch", N])], [_f32(weight, "W")]
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = Gemm<transB = 1>(X, W)
+        }}
+        """,
+        [_f32(weight, "W")],
     )
     hqq_model = onnxsim.quantize_weight_only_int4_hqq(model)
     onnx.checker.check_model(hqq_model)
@@ -199,9 +212,13 @@ def test_hqq_skips_non_block_divisible_k():
 
 
 def test_hqq_skips_non_constant_weight():
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
     model = _model(
-        nodes, [_vi("X", [4, 64]), _vi("W", [64, 4])], [_vi("Y", [4, 4])], []
+        """
+        g (float[4,64] X, float[64,4] W) => (float[4,4] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """
     )
     hqq_model = onnxsim.quantize_weight_only_int4_hqq(model)
     op_types = [n.op_type for n in hqq_model.graph.node]


### PR DESCRIPTION
Continuation of the onnx.parser-based test readability migration.

Replaces `onnx.helper.make_node`/`make_graph`/`make_model` graph construction in `tests/test_hqq.py` with the ONNX text format via the established `_model(body, initializer=(), opset=..., ir_version=...)` helper (matching the original file's `opset=21`, `ir_version=10` defaults).

- `_matmul_model` now builds its MatMul graph via an f-string text fragment, keeping the random/weight initializer attached programmatically via `numpy_helper.from_array`.
- `test_hqq_gemm_transb` and `test_hqq_skips_non_constant_weight` were converted to inline text-format bodies.
- Removed the now-unused `_vi` value-info helper and the `onnx.helper` import (nothing in the file calls `onnx.helper.*` anymore).
- No exceptions were needed — every construct in this file has a direct text-format equivalent.

Test names, assertions, and behavior/coverage are unchanged — this is a pure construction-style refactor.

## Test plan
- [x] `python3 -m py_compile tests/test_hqq.py`
- [x] `ruff check tests/test_hqq.py` (clean)
- [x] `python3 -m pytest tests/test_hqq.py -q --no-header` — 7 passed, run 3x to rule out flakiness
- [x] Test count cross-check: `git show origin/master:tests/test_hqq.py | grep -c "^def test_"` == 7, matches migrated file

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_