### PR TITLE
tests: migrate test_omniquant.py to onnx.parser

### DIFF
--- a/tests/test_omniquant.py
+++ b/tests/test_omniquant.py
@@ -7,28 +7,31 @@ of an existing ``quantize_weight_only_int4``-quantized model.
 
 import numpy as np
 import onnx
-import onnx.helper
 import onnx.numpy_helper
 import pytest
+from onnx import parser
 
 import onnxsim
 
 ort = pytest.importorskip("onnxruntime")
 
 
-def _vi(name, shape):
-    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
 
 
 def _f32(array, name):
     return onnx.numpy_helper.from_array(array.astype(np.float32), name)
-
-
-def _model(nodes, inputs, outputs, initializer, opset=21):
-    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
-    return onnx.helper.make_model(
-        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
-    )
 
 
 def _run(model, feeds):
@@ -48,9 +51,14 @@ def _matmul_model(K=64, N=16, weight=None, seed=0):
     if weight is None:
         rng = np.random.default_rng(seed)
         weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
     return _model(
-        nodes, [_vi("X", ["batch", K])], [_vi("Y", ["batch", N])], [_f32(weight, "W")]
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [_f32(weight, "W")],
     )
 
 
@@ -157,9 +165,14 @@ def test_omniquant_gemm_transb():
     rng = np.random.default_rng(6)
     K, N = 96, 12
     weight = rng.standard_normal((N, K)).astype(np.float32) * 0.5
-    nodes = [onnx.helper.make_node("Gemm", ["X", "W"], ["Y"], transB=1)]
     model = _model(
-        nodes, [_vi("X", ["batch", K])], [_vi("Y", ["batch", N])], [_f32(weight, "W")]
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = Gemm<transB = 1>(X, W)
+        }}
+        """,
+        [_f32(weight, "W")],
     )
     quant = onnxsim.quantize_weight_only_int4(model)
     onnx.checker.check_model(quant)
@@ -198,8 +211,14 @@ def test_omniquant_codes_stay_in_range():
 
 
 def test_omniquant_noop_when_no_int4_matmul_present():
-    nodes = [onnx.helper.make_node("Relu", ["X"], ["Y"])]
-    model = _model(nodes, [_vi("X", [4, 4])], [_vi("Y", [4, 4])], [])
+    model = _model(
+        """
+        g (float[4,4] X) => (float[4,4] Y)
+        {
+          Y = Relu(X)
+        }
+        """
+    )
     result = onnxsim.apply_omniquant(
         model, model, calibration_data=[{"X": np.zeros((4, 4), dtype=np.float32)}]
     )


### PR DESCRIPTION
Continuation of the onnx.parser-based test readability migration.

Replaces `onnx.helper.make_node`/`make_graph`/`make_model` graph construction in `tests/test_omniquant.py` with the ONNX text format via the established `_model(body, initializer=(), opset=..., ir_version=...)` helper (matching this file's original `opset=21`, `ir_version=10` defaults). The now-unused `_vi` helper and the `import onnx.helper` line were removed.

No exceptions were needed — every model in this file (a plain `MatMul`, a `Gemm` with `transB=1`, and a bare `Relu`) expresses cleanly in the ONNX text format; only the `W` weight initializer (numpy-generated) is still built via `onnx.numpy_helper.from_array` and attached through the `initializer=[...]` param, per the established pattern.

Test names, assertions, and behavior/coverage are unchanged — this is a pure construction-style refactor.

## Test plan
- [x] `python3 -m py_compile tests/test_omniquant.py`
- [x] `ruff check tests/test_omniquant.py`
- [x] `python3 -m pytest tests/test_omniquant.py -q --no-header` — run 3x, all 6 tests pass each time (no skips)
- [x] Test count cross-check: `git show origin/master:tests/test_omniquant.py | grep -c "^def test_"` == 6 == count in migrated file

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_