### PR TITLE
tests: migrate test_ort_matmul_nbits_workaround.py to onnx.parser

### DIFF
--- a/tests/test_ort_matmul_nbits_workaround.py
+++ b/tests/test_ort_matmul_nbits_workaround.py
@@ -12,36 +12,44 @@ which doesn't care about optimization level since it doesn't hit this bug.
 
 import numpy as np
 import onnx
-import onnx.helper
 import onnx.numpy_helper
 import pytest
+from onnx import parser
 
 import onnxsim
 
 ort = pytest.importorskip("onnxruntime")
 
 
-def _vi(name, shape):
-    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
 
 
 def _f32(array, name):
     return onnx.numpy_helper.from_array(array.astype(np.float32), name)
 
 
-def _model(nodes, inputs, outputs, initializer, opset=21):
-    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
-    return onnx.helper.make_model(
-        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
-    )
-
-
 def _matmul_model(K=32, N=16, seed=0):
     rng = np.random.default_rng(seed)
     weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
     return _model(
-        nodes, [_vi("X", ["batch", K])], [_vi("Y", ["batch", N])], [_f32(weight, "W")]
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [_f32(weight, "W")],
     )
 
 
@@ -110,9 +118,14 @@ def test_workaround_noop_on_gemm_transb1():
     rng = np.random.default_rng(3)
     K, N = 32, 12
     weight = rng.standard_normal((N, K)).astype(np.float32) * 0.5
-    nodes = [onnx.helper.make_node("Gemm", ["X", "W"], ["Y"], transB=1)]
     model = _model(
-        nodes, [_vi("X", ["batch", K])], [_vi("Y", ["batch", N])], [_f32(weight, "W")]
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = Gemm<transB = 1>(X, W)
+        }}
+        """,
+        [_f32(weight, "W")],
     )
     quant = onnxsim.quantize_weight_only_int4(model)
     dq_node = next(n for n in quant.graph.node if n.op_type == "DequantizeLinear")
@@ -124,8 +137,14 @@ def test_workaround_noop_on_gemm_transb1():
 
 
 def test_workaround_noop_when_no_matmul_present():
-    nodes = [onnx.helper.make_node("Relu", ["X"], ["Y"])]
-    model = _model(nodes, [_vi("X", [4, 4])], [_vi("Y", [4, 4])], [])
+    model = _model(
+        """
+        g (float[4,4] X) => (float[4,4] Y)
+        {
+          Y = Relu(X)
+        }
+        """
+    )
     result = onnxsim.workaround_ort_matmul_nbits_axis0_bug(model)
     assert result.SerializeToString() == model.SerializeToString()
 


### PR DESCRIPTION
## Summary

Continuation of the onnx.parser-based test readability migration (see CLAUDE.md's "Prefer `onnx.parser`-based model construction in tests" section).

- Replaces `onnx.helper.make_node`/`make_graph`/`make_model` graph construction in `tests/test_ort_matmul_nbits_workaround.py` with the ONNX text format, via the established `_model(body, initializer=(), opset=21, ir_version=10)` helper (matching this file's original opset 21 / ir_version 10 defaults).
- `_matmul_model(K, N, seed)` now builds its body as an f-string interpolating `K`/`N` into the text-format signature, keeping the random weight tensor as a numpy-built `onnx.numpy_helper.from_array` initializer (per the established convention for random/large arrays).
- The `Gemm<transB = 1>` and plain `Relu`/`MatMul` models were similarly converted to inline text-format bodies.
- Removed the now-unused `_vi` helper and the `import onnx.helper` line (nothing in the file calls `onnx.helper.*` anymore).
- No `onnx.helper` exceptions were needed — every model in this file is built from standard ONNX ops only (no `com.microsoft` contrib ops appear directly; `DequantizeLinear`/`MatMulNBits`-related nodes are produced internally by the `onnxsim` passes under test, not hand-built here).
- Test names, assertions, and behavior/coverage are unchanged — this is a pure construction-style refactor.

## Test plan

- [x] `python3 -m py_compile tests/test_ort_matmul_nbits_workaround.py` — clean
- [x] `ruff check tests/test_ort_matmul_nbits_workaround.py` — clean (`All checks passed!`)
- [x] `python3 -m pytest tests/test_ort_matmul_nbits_workaround.py -q --no-header` — 7 passed, run 3x to rule out flakiness (random test data)
- [x] Test count cross-check: `git show origin/master:tests/test_ort_matmul_nbits_workaround.py | grep -c "^def test_"` = 7, matches migrated file's `grep -c "^def test_"` = 7

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_