### PR TITLE
fix: restore missing _vi helper in test_kv_cache_quantization.py

### DIFF
--- a/tests/test_kv_cache_quantization.py
+++ b/tests/test_kv_cache_quantization.py
@@ -26,6 +26,14 @@ def _model(body, opset=13, ir_version=8):
     )
 
 
+def _vi(name, shape):
+    # Value-info builder for the handful of tests below that use dotted
+    # tensor names (e.g. "past_key_values.0.value") -- onnx.parser's text
+    # format has no syntax for identifiers containing ".", so those graphs
+    # stay on onnx.helper.make_graph/make_model construction.
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
 def _kv_cache_model(batch=1, heads=2, head_dim=4, opset=13, symbolic_seq=True):
     # new_key is deliberately routed through an Identity node rather than
     # being a bare graph input: a real exported decoder's "new" K/V is


### PR DESCRIPTION
## Summary

CI is currently red on every open PR that touches `tests/` (including the whole onnx.parser test-migration series), because `ruff check` lints the entire `tests/` tree and `tests/test_kv_cache_quantization.py` has 19 calls to an undefined name `_vi`.

Root cause: the manual merge-conflict resolution for #786 (bringing #774's Conv2D pruning changes into the parser-migration branch) accidentally dropped the `_vi()` value-info builder while keeping its call sites.

## Fix

Restores `_vi(name, shape)` — a thin `onnx.helper.make_tensor_value_info` wrapper — for the handful of tests in this file that build graphs with dotted tensor names (e.g. `"past_key_values.0.value"`), which `onnx.parser`'s text format has no syntax for.

## Test plan

- [x] `ruff check tests/test_kv_cache_quantization.py` — clean
- [x] `ruff format --check tests/test_kv_cache_quantization.py` — clean
- [x] `pytest tests/test_kv_cache_quantization.py -q` — 11 passed, run 3x, no flakiness

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_