### PR TITLE
Fix undefined _vi helper in test_kv_cache_quantization.py

### DIFF
--- a/tests/test_kv_cache_quantization.py
+++ b/tests/test_kv_cache_quantization.py
@@ -14,6 +14,10 @@ import onnxsim
 ort = pytest.importorskip("onnxruntime")
 
 
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
 def _model(body, opset=13, ir_version=8):
     return parser.parse_model(
         f"""


### PR DESCRIPTION
## Summary

- Fixes `tests/test_kv_cache_quantization.py`, which was broken on master: `_vi` was referenced in several test bodies (added by the KIVI Value-style PR #790) but the onnx.parser migration in PR #786 removed the file's `_vi` helper definition along with most other call sites, leaving these few undefined. `ruff check`'s F821 pass caught it — but only on a later PR's CI, since Python doesn't fail on an undefined name until the function body actually runs.
- Adds back a minimal `_vi(name, shape) -> onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)` helper, matching the pattern already used by other test files in this repo (e.g. `tests/test_spinquant.py`).

## Test plan

- [x] `pytest tests/test_kv_cache_quantization.py -v`: all 11 tests pass.
- [x] `ruff check tests`: clean (no more F821).
- [x] Full regression sweep (`pytest tests/ --ignore=tests/test_torch_export.py --ignore=tests/test_timm.py`): 819 passed, 68 skipped, 0 failed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_