### PR TITLE
Add quantize_weight_only_spqr: outlier-aware block INT4 quantization

### DIFF
--- a/docs/spqr.md
+++ b/docs/spqr.md
@@ -1,0 +1,106 @@
+# SpQR: outlier-aware block INT4 quantization (`quantize_weight_only_spqr`)
+
+## What this is
+
+`onnxsim.quantize_weight_only_spqr` quantizes a layer's weight to INT4
+block-wise like `onnxsim.quantize_weight_only_int4` does, but first pulls
+a small fraction of the weight's own most sensitive elements out of each
+block's scale computation, storing an exact correction for just those
+positions instead of letting them drag the whole block's precision down.
+
+```
+Before:
+  Y = MatMul(X, W) [+ bias]                  -- W constant, [K, N], float32
+
+After:
+  Wq  = <int4, per-(block, column) symmetric, outlier positions
+         excluded from each block's own scale>
+  Ws  = <float32, [K/block_size, N]>
+  Wdq = DequantizeLinear(Wq, Ws, axis=0, block_size=block_size)  -- float32
+  zeros = ConstantOfShape([K, N], value=0.0)
+  correction = ScatterND(zeros, outlier_indices, outlier_values)  -- float32
+  Wreconstructed = Wdq + correction
+  Y = MatMul(X, Wreconstructed) [+ bias]
+```
+
+A single unusually large weight inside an otherwise ordinary block forces
+that block's whole scale up, wasting resolution on every other element
+sharing it. Excluding the outlier from the scale computation lets the rest
+of the block quantize tighter; the excluded position itself is
+reconstructed exactly via a sparse correction, not quantized at all.
+
+## Where this comes from
+
+[SpQR](https://arxiv.org/abs/2306.03078) (Dettmers et al., 2023) observes
+that outliers in LLM weights are scattered individual elements throughout
+the matrix, not confined to a few channels the way activation outliers
+are (the problem `onnxsim.apply_llm_int8`/`onnxsim.apply_smoothquant`
+address) -- so excluding them channel-wise doesn't fit; they need to be
+found and excluded element-by-element.
+
+SpQR's own reference implementation ranks each weight's importance using
+its true contribution to the OBQ/GPTQ objective, computed from the full
+inverse-Hessian of the layer's calibration data -- expensive, and (like
+GPTQ's own column-by-column update order) not independently verifiable
+without re-deriving the same numerically delicate procedure. This module
+uses the classical **diagonal-Hessian approximation** to that same
+objective instead: for a squared-error objective with Hessian
+`H = 2 X^T X`, OBQ's per-weight error contribution
+`w_k^2 / [H^-1]_kk` reduces, when `H` is approximated as diagonal, to
+`w_k^2 * H_kk = w_k^2 * mean(X[:, k]^2)` -- an ordinary, closed-form
+sensitivity score computed directly from the weight and calibration
+activations, no matrix inversion involved. The elements with the largest
+score (by default the top 1%, tunable via `outlier_fraction`) become the
+sparse correction; every other element is quantized normally.
+
+The sparse correction itself is stored efficiently: only the
+`num_outliers` outlier `(row, col)` positions and their correction values
+are kept (an initializer of shape `[num_outliers, 2]` plus one of shape
+`[num_outliers]`), reconstructed at runtime via `ScatterND` into a
+`ConstantOfShape`-produced zero tensor -- ordinary ONNX ops, no custom
+sparse tensor type or contrib op needed. Every outlier position
+reconstructs exactly, since the correction is defined as
+`W - block_quantized(W)` at exactly that position, independent of how it
+happened to round.
+
+## Scope
+
+Handled:
+
+- `MatMul(X, W)` with `W` a constant 2-D float32 tensor whose reduction
+  dimension `K` is divisible by `block_size`, or `Gemm(X, W[, B])` with
+  `transA=0`, `alpha=1`, `beta=1` (when `B` is present) under the same
+  weight constraint. `transB` may be 0 or 1.
+- Opsets >= 21 (INT4's tensor type and `DequantizeLinear`'s `block_size`
+  attribute both need opset 21, matching `quantize_weight_only_int4`).
+- `outlier_fraction=0.0` (or rounding to zero outliers for a given layer)
+  skips the `ScatterND` machinery entirely for that layer, falling back
+  to plain block-wise RTN.
+
+Left untouched (safe no-op, node passes through as-is):
+
+- Non-constant weights, non-2-D weights, or a reduction dimension not
+  divisible by `block_size`.
+- A layer whose activation never appeared in any calibration batch (no
+  data to compute a sensitivity score from).
+- A model with no matching layer, or an opset older than 21.
+
+## Usage
+
+```python
+import onnx
+import onnxsim
+
+model = onnx.load("model.onnx")
+quantized = onnxsim.quantize_weight_only_spqr(
+    model, block_size=16, outlier_fraction=0.01, num_samples=32
+)
+onnx.save(quantized, "model.spqr.onnx")
+```
+
+`calibration_data` defaults to `onnxsim.generate_random_calibration_data`;
+pass real representative batches (e.g. via
+`onnxsim.load_huggingface_calibration_data`) for a sensitivity ranking
+that reflects the model's own real activation statistics, since which
+elements count as outliers depends on `mean(X[:, k]^2)`, not just the
+weight itself.

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -88,6 +88,7 @@ from onnxsim.pruning import (
 from onnxsim.quip_sharp import apply_quip_sharp
 from onnxsim.smoothquant import apply_smoothquant
 from onnxsim.spinquant import apply_spinquant
+from onnxsim.spqr import quantize_weight_only_spqr
 from onnxsim.squeezellm import quantize_weight_only_squeezellm
 from onnxsim.tensorrt_sparsity import convert_matmul_to_gemm
 from onnxsim.transformers_export import export_transformers_model
@@ -137,6 +138,7 @@ __all__ = [
     "NF4_CODEBOOK",
     "quantize_weight_only_squeezellm",
     "quantize_weight_only_aqlm",
+    "quantize_weight_only_spqr",
     "quantize_kv_cache",
     "quantize_embedding_binary",
     "quantize_embedding_int8",

--- a/onnxsim/spqr.py
+++ b/onnxsim/spqr.py
@@ -1,0 +1,333 @@
+"""SpQR (Dettmers et al., 2023, "SpQR: A Sparse-Quantized Representation
+for Near-Lossless LLM Weight Compression", https://arxiv.org/abs/2306.03078).
+onnxsim ports the algorithm, not any framework's code, per the same
+rationale as :mod:`onnxsim.awq`/:mod:`onnxsim.gptq`/:mod:`onnxsim.spinquant`
+(SpQR's own reference implementation quantizes live PyTorch weights via a
+custom outlier-detection-and-packing pipeline, with no ONNX export path).
+
+Ordinary block-wise RTN quantization (what
+:func:`onnxsim.quantize_weight_only_int4` does) picks one scale per block
+of the reduction dimension. A single unusually large weight *within* a
+block forces that block's whole scale up, wasting resolution on every
+other, ordinary-magnitude element sharing it -- the same "outlier" problem
+:mod:`onnxsim.llm_int8`/:mod:`onnxsim.smoothquant` address for
+*activations*, but here it is individual *weight* elements, scattered
+throughout the matrix rather than confined to a few channels, so excluding
+them channel-wise (like :mod:`onnxsim.llm_int8`) doesn't fit. SpQR's own
+idea: identify the small fraction of weight elements whose quantization
+error actually matters, exclude them from each block's own scale
+computation (so the *rest* of the block quantizes tighter), and store an
+exact correction for those specific elements as an explicit sparse
+overlay -- ``W_reconstructed = block_quantized(W) + sparse_correction``,
+with the correction defined as exactly ``W - block_quantized(W)`` at each
+outlier position, so it cancels that position's quantization error
+completely regardless of how the block-quantized value there was rounded.
+
+**Picking which elements are outliers.** SpQR's own reference
+implementation uses each weight's true contribution to the OBQ/GPTQ
+objective, computed from the full inverse-Hessian of the layer's
+calibration data -- expensive, and (like GPTQ's own column-by-column
+update order) not independently verifiable without re-deriving the same
+numerically delicate procedure. This module uses the classical
+**diagonal-Hessian approximation** to that same objective instead: for a
+squared-error objective with Hessian ``H = 2 X^T X``, OBQ's per-weight
+error contribution ``w_k^2 / [H^{-1}]_{kk}`` reduces, when ``H`` is
+approximated as diagonal, to ``w_k^2 * H_{kk} = w_k^2 * mean(X[:, k]^2)``
+-- an ordinary, closed-form sensitivity score computed directly from the
+weight and calibration activations, no matrix inversion involved. The
+elements with the largest score (by default the top 1%, tunable via
+``outlier_fraction``) are excluded from their block's scale computation
+and become the sparse correction; every other element is quantized
+normally.
+
+**Storing the sparse correction efficiently.** Naively adding a dense
+``[N, K]`` correction matrix back would cost as much storage as the
+original float32 weight, defeating the point. Instead, only the
+``num_outliers`` outlier ``(row, col)`` positions and their correction
+values are stored (an initializer of shape ``[num_outliers, 2]`` plus one
+of shape ``[num_outliers]`` -- at 1% density, a small fraction of the
+dense weight's own footprint), and the graph reconstructs the full dense
+correction at runtime via ``ScatterND`` into a ``ConstantOfShape``-produced
+zero tensor -- both ordinary ONNX ops, no custom sparse tensor type or
+contrib op needed:
+
+    Before:
+      Y = MatMul(X, W) [+ bias]                  -- W constant, [K, N], float32
+
+    After:
+      Wq  = <int4, per-(block, column) symmetric, outlier positions
+             excluded from each block's own scale>
+      Ws  = <float32, [K/block_size, N]>
+      Wdq = DequantizeLinear(Wq, Ws, axis=0, block_size=block_size)  -- float32
+      zeros = ConstantOfShape([K, N], value=0.0)
+      correction = ScatterND(zeros, outlier_indices, outlier_values)  -- float32
+      Wreconstructed = Wdq + correction
+      Y = MatMul(X, Wreconstructed) [+ bias]
+
+Every outlier position reconstructs *exactly* (the correction is defined
+as the exact residual there, independent of how that position happened to
+round), while the excluded-from-scale blocks quantize every ordinary
+element more tightly than plain :func:`onnxsim.quantize_weight_only_int4`
+would with the same outliers still dragging the scale up.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Sequence, Union
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+
+from onnxsim import backend
+from onnxsim.adaround import _pack_int4
+from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.calibration import Tensors, generate_random_calibration_data
+from onnxsim.quip_sharp import _match_matmul_like
+
+
+def _has_min_opset(model: onnx.ModelProto, min_version: int) -> bool:
+    return any(
+        o.domain in ("", "ai.onnx") and o.version >= min_version
+        for o in model.opset_import
+    )
+
+
+def quantize_weight_only_spqr(
+    model: Union[str, onnx.ModelProto],
+    block_size: int = 16,
+    outlier_fraction: float = 0.01,
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_samples: int = 8,
+    seed: int = 0,
+    providers: Optional[Sequence[str]] = None,
+) -> onnx.ModelProto:
+    """Applies SpQR-style outlier-aware block-wise INT4 quantization (see
+    this module's own docstring) to every MatMul/vanilla-Gemm layer with a
+    constant 2-D float32 weight whose reduction dimension ``K`` is
+    divisible by ``block_size``.
+
+    :param model: the original (unquantized) onnx ModelProto or file path
+    :param block_size: elements per quantization block along ``K``,
+            matching :func:`onnxsim.quantize_weight_only_int4`'s own
+            default granularity (SpQR's own typical choice is finer,
+            8-32)
+    :param outlier_fraction: fraction of each layer's weight elements
+            (by count) excluded from block-scale computation and stored
+            as an exact sparse correction instead -- SpQR's own paper
+            uses roughly 1%
+    :param calibration_data: representative input batches (each a
+            ``{input_name: np.ndarray}`` dict matching ``model``'s graph
+            inputs) used to compute each weight element's sensitivity
+            score -- see :func:`onnxsim.generate_random_calibration_data`
+            (the default when omitted) and
+            :func:`onnxsim.load_huggingface_calibration_data` (real data,
+            a more representative sensitivity ranking than random input)
+    :param num_samples: random batches to generate when ``calibration_data``
+            is omitted
+    :param seed: seed for the random calibration data (ignored if
+            ``calibration_data`` is supplied)
+    :param providers: onnxruntime execution providers to run calibration on
+    :returns: ``model`` with every matched layer's weight replaced by
+            block-wise INT4 codes plus a sparse outlier correction (see
+            the module docstring's diagram); output tensor name unchanged.
+            Layers with a non-constant, non-2-D weight, a reduction
+            dimension not divisible by ``block_size``, or no calibration
+            activation available, are left untouched; a model with no
+            matching layer, or an opset older than 21 (INT4's tensor type
+            and ``DequantizeLinear``'s ``block_size`` attribute both need
+            opset 21), is returned unchanged
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    if not _has_min_opset(model, 21):
+        return model
+
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    graph = out.graph
+    initializer_map = {t.name: t for t in graph.initializer}
+    taken_names = _all_names(graph)
+
+    nodes = list(graph.node)
+    candidates = []
+    for node in nodes:
+        match = _match_matmul_like(node)
+        if match is None:
+            continue
+        x_name, w_name, bias_name, weight_transposed = match
+        w_init = initializer_map.get(w_name)
+        if (
+            w_init is None
+            or w_init.data_type != onnx.TensorProto.FLOAT
+            or len(w_init.dims) != 2
+        ):
+            continue
+        candidates.append((node, x_name, w_name, bias_name, weight_transposed))
+
+    if not candidates:
+        return out
+
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            model, num_samples=num_samples, seed=seed
+        )
+
+    probe_names = sorted({x_name for _, x_name, _, _, _ in candidates})
+    probe_model = _add_probe_outputs(model, probe_names)
+    activations: Dict[str, List[np.ndarray]] = {name: [] for name in probe_names}
+    for batch in calibration_data:
+        result = backend.run_model(probe_model, batch, providers=providers)
+        for name in probe_names:
+            arr = np.asarray(result[name], dtype=np.float64)
+            if arr.ndim == 2:
+                activations[name].append(arr)
+
+    for node, x_name, w_name, bias_name, weight_transposed in candidates:
+        acts = activations.get(x_name, [])
+        if not acts:
+            continue
+        x = np.concatenate(acts, axis=0)
+
+        w_init = initializer_map[w_name]
+        w = onnx.numpy_helper.to_array(w_init).astype(np.float64)
+        w_nk = w if weight_transposed else w.T  # [N, K], output channel first
+        n, k = w_nk.shape
+        if k % block_size != 0 or x.shape[1] != k:
+            continue
+
+        # Diagonal-Hessian OBQ sensitivity score -- see module docstring.
+        h_k = np.mean(x**2, axis=0)  # [K]
+        sensitivity = (w_nk**2) * h_k[np.newaxis, :]  # [N, K]
+
+        num_outliers = int(round(outlier_fraction * n * k))
+        num_blocks = k // block_size
+        if num_outliers > 0:
+            flat_idx = np.argpartition(sensitivity.ravel(), -num_outliers)[
+                -num_outliers:
+            ]
+            outlier_rows, outlier_cols = np.unravel_index(flat_idx, (n, k))
+            mask = np.ones((n, k), dtype=bool)
+            mask[outlier_rows, outlier_cols] = False
+        else:
+            outlier_rows = np.empty(0, dtype=np.int64)
+            outlier_cols = np.empty(0, dtype=np.int64)
+            mask = np.ones((n, k), dtype=bool)
+
+        blocks = w_nk.reshape(n, num_blocks, block_size)
+        mask_blocks = mask.reshape(n, num_blocks, block_size)
+        abs_masked = np.where(mask_blocks, np.abs(blocks), 0.0)
+        scale_blocks = (
+            np.maximum(abs_masked.max(axis=2), 1e-12) / 7.0
+        )  # [N, num_blocks]
+        scale_full = np.repeat(scale_blocks, block_size, axis=1)  # [N, K]
+
+        codes_nk = np.clip(np.round(w_nk / scale_full), -7.0, 7.0)
+        dequant_nk = codes_nk * scale_full
+
+        prefix = f"{w_name}_spqr"
+        codes_kn = codes_nk.T.astype(np.int64)  # [K, N]
+        scale_kn = scale_blocks.T.astype(np.float32)  # [K/block_size, N]
+
+        codes_name = _unique_name(f"{prefix}_codes", taken_names)
+        codes_tensor = onnx.TensorProto()
+        codes_tensor.name = codes_name
+        codes_tensor.data_type = onnx.TensorProto.INT4
+        codes_tensor.dims.extend([k, n])
+        codes_tensor.raw_data = _pack_int4(codes_kn)
+        graph.initializer.append(codes_tensor)
+
+        scale_name = _unique_name(f"{prefix}_scale", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(scale_kn, name=scale_name)
+        )
+
+        new_nodes: List[onnx.NodeProto] = []
+
+        def _new(op_type, inputs, out_suffix, **attrs):
+            out_name = _unique_name(f"{prefix}_{out_suffix}", taken_names)
+            n_ = onnx.helper.make_node(
+                op_type,
+                inputs,
+                [out_name],
+                name=_unique_name(f"{prefix}_{out_suffix}_node", taken_names),
+                **attrs,
+            )
+            new_nodes.append(n_)
+            return out_name
+
+        w_dequant = _new(
+            "DequantizeLinear",
+            [codes_name, scale_name],
+            "w_dequant",
+            axis=0,
+            block_size=block_size,
+        )
+
+        if num_outliers > 0:
+            correction_values = (
+                w_nk[outlier_rows, outlier_cols]
+                - dequant_nk[outlier_rows, outlier_cols]
+            )
+            # [K, N]-layout indices, matching codes_kn/scale_kn's own
+            # transposed storage: index[i] = [k_pos, n_pos].
+            outlier_indices_kn = np.stack([outlier_cols, outlier_rows], axis=1)
+
+            indices_name = _unique_name(f"{prefix}_outlier_indices", taken_names)
+            graph.initializer.append(
+                onnx.numpy_helper.from_array(
+                    outlier_indices_kn.astype(np.int64), name=indices_name
+                )
+            )
+            values_name = _unique_name(f"{prefix}_outlier_values", taken_names)
+            graph.initializer.append(
+                onnx.numpy_helper.from_array(
+                    correction_values.astype(np.float32), name=values_name
+                )
+            )
+            shape_name = _unique_name(f"{prefix}_shape", taken_names)
+            graph.initializer.append(
+                onnx.numpy_helper.from_array(
+                    np.array([k, n], dtype=np.int64), name=shape_name
+                )
+            )
+
+            zeros = _new(
+                "ConstantOfShape",
+                [shape_name],
+                "zeros",
+                value=onnx.numpy_helper.from_array(np.array([0.0], dtype=np.float32)),
+            )
+            correction = _new(
+                "ScatterND", [zeros, indices_name, values_name], "correction"
+            )
+            w_reconstructed = _new("Add", [w_dequant, correction], "w_reconstructed")
+        else:
+            w_reconstructed = w_dequant
+
+        core = _new("MatMul", [x_name, w_reconstructed], "core")
+
+        old_output = node.output[0]
+        if bias_name is not None:
+            final = onnx.helper.make_node(
+                "Add",
+                [core, bias_name],
+                [old_output],
+                name=_unique_name(f"{prefix}_bias_add_node", taken_names),
+            )
+        else:
+            final = onnx.helper.make_node(
+                "Identity",
+                [core],
+                [old_output],
+                name=_unique_name(f"{prefix}_identity_node", taken_names),
+            )
+        new_nodes.append(final)
+
+        node_idx = next(i for i, n_ in enumerate(graph.node) if n_ is node)
+        for offset, new_node in enumerate(new_nodes):
+            graph.node.insert(node_idx + offset, new_node)
+        del graph.node[node_idx + len(new_nodes)]
+
+    return out

--- a/tests/test_spqr.py
+++ b/tests/test_spqr.py
@@ -1,0 +1,158 @@
+"""Tests for ``onnxsim.quantize_weight_only_spqr`` -- see ``onnxsim/spqr.py``
+for the technique (outlier-aware block-wise INT4 quantization using a
+diagonal-Hessian OBQ sensitivity score to pick outliers, reconstructed via a
+sparse ``ScatterND`` correction).
+"""
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+
+import onnxsim
+from onnxsim.omniquant import _quantize_blockwise_int4_with_clip
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _model(nodes, inputs, outputs, initializer, opset=21):
+    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+    )
+
+
+def _matmul_model(K=32, N=8, weight=None, seed=0, opset=21):
+    if weight is None:
+        rng = np.random.default_rng(seed)
+        weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    return _model(
+        nodes,
+        [_vi("X", ["batch", K])],
+        [_vi("Y", ["batch", N])],
+        [_f32(weight, "W")],
+        opset=opset,
+    )
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
+
+
+def test_spqr_output_stays_close_to_float_via_onnxruntime():
+    model = _matmul_model(K=32, N=8, seed=0)
+    q = onnxsim.quantize_weight_only_spqr(
+        model, block_size=8, outlier_fraction=0.02, num_samples=16, seed=1
+    )
+    onnx.checker.check_model(q)
+
+    op_types = [n.op_type for n in q.graph.node]
+    assert "DequantizeLinear" in op_types
+    assert "ScatterND" in op_types
+
+    rng = np.random.default_rng(2)
+    x = rng.standard_normal((8, 32)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x})
+    (q_y,) = _run(q, {"X": x})
+    assert np.all(np.isfinite(q_y))
+    assert _rel_l2(float_y, q_y) < 0.3
+
+
+def test_spqr_outlier_positions_reconstruct_exactly():
+    rng = np.random.default_rng(3)
+    weight = rng.standard_normal((32, 8)).astype(np.float32) * 0.1
+    weight[0, 0] = 50.0
+    model = _matmul_model(K=32, N=8, weight=weight)
+    q = onnxsim.quantize_weight_only_spqr(
+        model, block_size=8, outlier_fraction=0.05, num_samples=16, seed=4
+    )
+    onnx.checker.check_model(q)
+
+    onehot = np.zeros((1, 32), dtype=np.float32)
+    onehot[0, 0] = 1.0
+    (q_y,) = _run(q, {"X": onehot})
+    assert abs(float(q_y[0, 0]) - 50.0) < 1e-3
+
+
+def test_spqr_reduces_error_vs_plain_blockwise_quantization():
+    rng = np.random.default_rng(6)
+    weight = rng.standard_normal((32, 8)).astype(np.float32) * 0.1
+    weight[0, 0] = 40.0
+    weight[5, 3] = -35.0
+
+    codes_nk, scale_nk = _quantize_blockwise_int4_with_clip(
+        weight.T.astype(np.float64), 8, 1.0
+    )
+    plain_dequant = (codes_nk * np.repeat(scale_nk, 8, axis=1)).T
+    plain_err = np.abs(weight.astype(np.float64) - plain_dequant)
+
+    model = _matmul_model(K=32, N=8, weight=weight)
+    q = onnxsim.quantize_weight_only_spqr(
+        model, block_size=8, outlier_fraction=0.02, num_samples=16, seed=7
+    )
+
+    probe = np.eye(32, dtype=np.float32)
+    (q_y,) = _run(q, {"X": probe})
+    spqr_dequant = q_y  # [32, 8] -- row k = reconstructed W[k, :]
+    spqr_err = np.abs(weight.astype(np.float64) - spqr_dequant.astype(np.float64))
+
+    assert spqr_err.max() <= plain_err.max() + 1e-6
+    assert spqr_err.sum() < plain_err.sum()
+
+
+def test_spqr_declines_when_k_not_divisible_by_block_size():
+    model = _matmul_model(K=20, N=4, seed=9)  # 20 is not a multiple of 8
+    q = onnxsim.quantize_weight_only_spqr(model, block_size=8)
+    assert q.SerializeToString() == model.SerializeToString()
+
+
+def test_spqr_declines_non_constant_weight():
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(
+        nodes, [_vi("X", [4, 32]), _vi("W", [32, 4])], [_vi("Y", [4, 4])], []
+    )
+    q = onnxsim.quantize_weight_only_spqr(model)
+    assert q.SerializeToString() == model.SerializeToString()
+
+
+def test_spqr_noop_when_no_matmul_present():
+    nodes = [onnx.helper.make_node("Relu", ["X"], ["Y"])]
+    model = _model(nodes, [_vi("X", [4, 4])], [_vi("Y", [4, 4])], [])
+    result = onnxsim.quantize_weight_only_spqr(model)
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_spqr_declines_below_opset21():
+    model = _matmul_model(K=32, N=8, opset=13)
+    result = onnxsim.quantize_weight_only_spqr(model)
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_spqr_zero_outlier_fraction_skips_sparse_correction():
+    model = _matmul_model(K=32, N=8, seed=10)
+    q = onnxsim.quantize_weight_only_spqr(
+        model, block_size=8, outlier_fraction=0.0, num_samples=16, seed=11
+    )
+    onnx.checker.check_model(q)
+    op_types = [n.op_type for n in q.graph.node]
+    assert "ScatterND" not in op_types
+    assert "DequantizeLinear" in op_types


### PR DESCRIPTION
## Summary

- Adds `onnxsim.quantize_weight_only_spqr`, porting [SpQR](https://arxiv.org/abs/2306.03078) (Dettmers et al., 2023) — outlier-aware block-wise INT4 weight quantization.
- Ordinary block-wise RTN quantization (`onnxsim.quantize_weight_only_int4`) picks one scale per block of the reduction dimension; a single unusually large weight *within* a block forces that block's whole scale up, wasting resolution on every other, ordinary-magnitude element sharing it. SpQR excludes a small fraction of a layer's most sensitive weight elements from each block's own scale computation, and stores an exact correction for just those positions via a sparse `ScatterND` overlay (`ConstantOfShape` zeros + `ScatterND` at the outlier `(row, col)` positions) instead of a dense same-shape matrix.
- Outlier ranking uses a classical **diagonal-Hessian OBQ sensitivity score** — `w_k^2 * mean(X[:,k]^2)`, no matrix inversion — rather than SpQR's own full-inverse-Hessian ranking (expensive, and not independently verifiable without re-deriving the same numerically delicate GPTQ-style procedure).
- Handles `MatMul(X, W)` / `Gemm(X, W[, B])` with a constant 2-D float32 weight whose reduction dimension is divisible by `block_size`, opset >= 21. `outlier_fraction=0.0` skips the `ScatterND` machinery entirely, falling back to plain block-wise RTN.

## Test plan

- [x] `tests/test_spqr.py` (8 new tests): float-vs-quantized closeness via onnxruntime, exact reconstruction at a planted outlier position, error reduction vs. plain block-wise quantization, and decline paths (K not divisible by block_size, non-constant weight, no matching op, opset < 21, zero outlier fraction skips the sparse correction).
- [x] Full regression sweep (`pytest tests/ --ignore=tests/test_torch_export.py --ignore=tests/test_timm.py`): 819 passed, 68 skipped, 0 failed.
- [x] `ruff format` / `ruff check --fix` / `mypy` clean on new/changed files.

Note: this PR does not include the fix for the pre-existing `test_kv_cache_quantization.py` `_vi` bug that surfaced in CI — that's split out into #842 since it's unrelated to SpQR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_