### PR TITLE
Extend unstructured/N:M pruning to fused-attention weights

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -89,6 +89,29 @@ other layer whose activation norm was never observed.
 see its own docstring for why a coarse approximation there would be worse
 than no compensation at all, not just less precise.
 
+All three unstructured/N:M functions also match the two fused self-
+attention ops the "Attention-head pruning" section below performs
+*structural* (whole-head) pruning on -- ``com.microsoft::Attention``'s
+merged QKV weight (``[K, Nq+Nk+Nv]``, matched by
+:func:`_match_attention_weight_only`, reusing :func:`_match_attention_producer`'s
+own criteria) and ``com.microsoft::GroupQueryAttention``'s separate Q/K/V
+projections, which need no special-casing at all: per
+:func:`_match_gqa_producer`'s own docstring they are ordinary MatMul/
+vanilla-Gemm nodes feeding into that op, not weights the op itself owns, so
+:func:`_candidates`' existing MatMul/Gemm matching already reaches them
+(ranked no differently from any other MatMul/Gemm layer). This is a
+completely different code path from head pruning below: it zeros
+individual weight entries within a head's columns rather than removing
+whole heads, exactly as useful on its own (e.g. reaching NVIDIA Ampere's
+2:4 sparse Tensor Cores, via :func:`onnxsim.convert_matmul_to_gemm`, on an
+already-``fuse_attention``'d model's QKV weight) as it is combined with
+head pruning first. Since unstructured/N:M pruning only ever zeros values
+and never changes shape, an ``Attention`` node's ``num_heads``/
+``qkv_hidden_sizes`` attributes -- which describe the merged weight's
+column layout, not any zeroed-vs-nonzero distinction within it -- can never
+drift out of sync with the (unchanged) weight shape, the same invariant
+this holds for every other matched layer type.
+
 Both magnitude and Wanda pruning support two sparsity patterns, chosen per
 invocation:
 
@@ -190,6 +213,42 @@ here rather than "corrected" to match, since the point of this function is
 to reproduce SparseGPT specifically. N:M pruning is unaffected (it is
 already per-row in the reference too, and matches this module's own
 ``n``/``m`` convention exactly).
+
+Unlike Conv, ``com.microsoft::Attention``'s merged QKV weight is **not**
+excluded from :func:`apply_sparsegpt_pruning`'s candidate list (nor, since
+they were never excluded to begin with, are ``GroupQueryAttention``'s
+separate Q/K/V projections -- see above). SparseGPT's correctness rests on
+``H`` accurately capturing which columns of *this weight's own input*
+correlate; unlike a Conv's im2col-unfolded receptive field, a merged QKV
+weight's input is the same plain ``[*, K]`` activation feeding an ordinary
+MatMul, with the same ``H = X^T X`` this function already computes for
+every other MatMul/Gemm layer, no new numerical machinery needed. What each
+output column of that weight is later used for downstream (split into
+Q/K/V, fed into a fused attention kernel) has no bearing on the linear-
+algebra correctness of pruning *this* layer's own weight against *this*
+layer's own input -- exactly why it would be inconsistent to include GQA's
+separate Q/K/V MatMuls (already unconditionally in scope, being ordinary
+MatMul/Gemm nodes) while excluding Attention's merged one on some notion of
+"this is an attention weight, treat it specially": neither needs it.
+
+Wanda's calibrated metric, by contrast, still falls back to plain magnitude
+for ``Attention``'s merged weight, the same as it already does for any
+MatMul/Gemm layer whose activation isn't a plain 2-D tensor at the probe
+point (see :func:`apply_wanda_pruning`'s own docstring): the op's own `X`
+input is rank-3 (``[batch, seq, hidden]``), and generalizing that one check
+to reduce over leading axes (mirroring :func:`apply_sparsegpt_pruning`'s
+own ``x.reshape(-1, x.shape[-1])``) would also change the documented,
+tested fallback behavior of every *existing* MatMul/Gemm layer whose own
+activation happens to be rank 3+ (a batched-sequence input is an entirely
+ordinary shape for a plain linear layer too, not something unique to
+Attention) -- a strictly larger behavior change than this task asked for,
+and not a free one: a per-row Wanda mask computed from a 2-D activation
+reduces over the batch axis alone, while the same computation over a
+reshaped 3-D activation reduces over batch *and* sequence position, a
+different (arguably more correct, but different) statistic. Left as a
+data-free-baseline fallback rather than changed silently underfoot; a
+future pass that wants Wanda calibration for a rank-3 activation is free to
+generalize this deliberately, as its own decision.
 """
 
 from __future__ import annotations
@@ -291,15 +350,68 @@ def _match_conv_weight_only(
     return node.input[0], w_name
 
 
+def _match_attention_weight_only(
+    node: onnx.NodeProto, initializer_map: Dict[str, onnx.TensorProto]
+) -> Optional[Tuple[str, str]]:
+    """If `node` is a ``com.microsoft::Attention`` node with a constant 2-D
+    float32 merged QKV weight (``[K, Nq+Nk+Nv]``), returns
+    ``(x_name, weight_name)``. Mirrors the "Attention-head pruning"
+    section's own :func:`_match_attention_producer` matching criteria
+    (including its ``num_heads``/``qkv_hidden_sizes`` consistency checks --
+    reused verbatim rather than re-implemented, even though nothing here
+    reads `num_heads` itself, so that a node this module's *structural*
+    head-pruning functions would decline as malformed is declined the same
+    way here), minus that function's bias handling -- magnitude/Wanda/
+    SparseGPT never touch bias, only the weight, so there's nothing to
+    validate there. Per :func:`_match_attention_producer`'s own docstring,
+    the merged weight has no transpose attribute of its own -- it is
+    already ``[K, N]``-shaped by construction -- so it is matched here
+    exactly like a non-transposed MatMul weight (``weight_transposed =
+    False`` in :func:`_candidates`' returned tuple); :func:`_prune_weight`'s
+    existing non-Conv path handles that shape with no Attention-specific
+    code at all. Unstructured/N:M pruning only ever zeros entries -- it
+    never changes `w_name`'s shape -- so the un-pruned merged weight's
+    ``num_heads``/``qkv_hidden_sizes`` attributes (read by every other
+    consumer of this weight, e.g. onnx.checker and any runtime) never drift
+    out of sync with its actual shape, the same invariant every other
+    matched layer type already gets from this module's value-only rewrite.
+    """
+    info = _match_attention_producer(node, initializer_map)
+    if info is None:
+        return None
+    return node.input[0], node.input[1]
+
+
 def _candidates(graph: onnx.GraphProto, include_conv: bool = True):
-    """Every MatMul/vanilla-Gemm node with a constant 2-D float32 weight,
-    plus -- when `include_conv` (the default; :func:`apply_sparsegpt_pruning`
-    passes ``False``, see its own docstring for why) -- every ordinary
-    (``group=1``) 2-D ``Conv`` node matched by :func:`_match_conv_weight_only`.
+    """Every MatMul/vanilla-Gemm node with a constant 2-D float32 weight
+    (this already includes a ``com.microsoft::GroupQueryAttention`` node's
+    separate Q/K/V projections: per :func:`_match_gqa_producer`'s own
+    docstring they are ordinary MatMul/vanilla-Gemm nodes feeding into that
+    op, not weights the op itself owns, so they need no special-casing here
+    at all -- they are ranked and pruned no differently from any other
+    MatMul/Gemm layer), plus:
+
+    - every ``com.microsoft::Attention`` node's constant 2-D float32 merged
+      QKV weight, matched by :func:`_match_attention_weight_only` -- unlike
+      GQA's separate projections, this *is* a weight the op itself owns
+      (``node.input[1]``), so it needs its own matcher; and
+    - when `include_conv` (the default; :func:`apply_sparsegpt_pruning`
+      passes ``False``, see its own docstring for why) -- every ordinary
+      (``group=1``) 2-D ``Conv`` node matched by
+      :func:`_match_conv_weight_only`.
+
     Returns ``(node, x_name, w_name, weight_transposed, is_conv)`` tuples;
     `weight_transposed` is always ``False`` (meaningless) for a Conv entry,
     whose output channel always lives on axis 0 of its fixed
-    ``[out_channels, in_channels, kH, kW]`` layout.
+    ``[out_channels, in_channels, kH, kW]`` layout, and likewise always
+    ``False`` (this time literally correct, not just meaningless -- see
+    :func:`_match_attention_weight_only`) for an Attention entry. Attention
+    matching is unconditional (not gated by `include_conv`, which -- per its
+    own name and :func:`apply_sparsegpt_pruning`'s own docstring -- concerns
+    only Conv's im2col-Hessian gap): see :func:`apply_sparsegpt_pruning`'s
+    own docstring for why a merged QKV weight has no analogous problem and
+    is deliberately included in its ``include_conv=False`` candidate list
+    too.
     """
     initializer_map = {t.name: t for t in graph.initializer}
     out = []
@@ -321,6 +433,11 @@ def _candidates(graph: onnx.GraphProto, include_conv: bool = True):
             if conv_match is not None:
                 x_name, w_name = conv_match
                 out.append((node, x_name, w_name, False, True))
+                continue
+        attn_match = _match_attention_weight_only(node, initializer_map)
+        if attn_match is not None:
+            x_name, w_name = attn_match
+            out.append((node, x_name, w_name, False, False))
     return out
 
 
@@ -490,11 +607,17 @@ def apply_magnitude_pruning(
     m: Optional[int] = None,
 ) -> onnx.ModelProto:
     """Zeros the least-magnitude entries of every MatMul/vanilla-Gemm
-    layer's constant 2-D float32 weight, and every ordinary (``group=1``)
-    2-D ``Conv`` layer's constant 4-D float32 weight -- the data-free
-    pruning baseline (Han et al., 2015). See this module's own docstring
-    for how importance is grouped (including the Conv reshape convention)
-    and why structured (shape-changing) pruning isn't offered here.
+    layer's constant 2-D float32 weight (this includes
+    ``com.microsoft::GroupQueryAttention``'s separate Q/K/V projections,
+    ordinary MatMul/Gemm nodes in their own right), every ordinary
+    (``group=1``) 2-D ``Conv`` layer's constant 4-D float32 weight, and
+    every ``com.microsoft::Attention`` node's constant 2-D float32 merged
+    QKV weight -- the data-free pruning baseline (Han et al., 2015). See
+    this module's own docstring for how importance is grouped (including
+    the Conv reshape convention), why the merged QKV weight needs no
+    special handling here beyond matching it (:func:`_candidates`, via
+    :func:`_match_attention_weight_only`), and why structured
+    (shape-changing) pruning isn't offered here.
 
     :param model: the original onnx ModelProto or file path
     :param sparsity: target fraction of each row's (or, for Conv, each
@@ -545,16 +668,22 @@ def apply_wanda_pruning(
     providers: Optional[Sequence[str]] = None,
 ) -> onnx.ModelProto:
     """Wanda pruning (Sun et al., 2023): zeros the least-important entries
-    of every MatMul/vanilla-Gemm layer's constant 2-D float32 weight, and
-    every ordinary (``group=1``) 2-D ``Conv`` layer's constant 4-D float32
-    weight, using ``|W_ij| * ||X_j||_2`` (weight magnitude times its
-    reduction-dimension entry's activation norm over calibration data) as
-    the importance metric instead of plain ``|W|``. See this module's own
+    of every MatMul/vanilla-Gemm layer's constant 2-D float32 weight (this
+    includes ``com.microsoft::GroupQueryAttention``'s separate Q/K/V
+    projections, ordinary MatMul/Gemm nodes in their own right), every
+    ordinary (``group=1``) 2-D ``Conv`` layer's constant 4-D float32 weight,
+    and every ``com.microsoft::Attention`` node's constant 2-D float32
+    merged QKV weight, using ``|W_ij| * ||X_j||_2`` (weight magnitude times
+    its reduction-dimension entry's activation norm over calibration data)
+    as the importance metric instead of plain ``|W|``. See this module's own
     docstring for the technique -- including what ``X_j`` means for a Conv
     column (one ``(in_channel, kh, kw)`` receptive-field offset, not a
-    whole input channel) and which Conv attribute combinations this
-    confidently handles -- and :func:`apply_magnitude_pruning` for the
-    calibration-free baseline this upgrades.
+    whole input channel), which Conv attribute combinations this confidently
+    handles, and why ``Attention``'s merged weight -- whose own activation
+    input is rank-3, not the plain 2-D tensor this metric requires -- always
+    falls back to plain magnitude here rather than being calibrated too --
+    and :func:`apply_magnitude_pruning` for the calibration-free baseline
+    this upgrades.
 
     :param model: the original onnx ModelProto or file path
     :param calibration_data: representative input batches to measure each
@@ -583,10 +712,12 @@ def apply_wanda_pruning(
             to the target pattern; a MatMul/Gemm layer with a non-constant
             or non-2-D weight, a Conv layer with a grouped or non-4-D
             weight, or any matched layer whose activation input isn't
-            usable (not a plain 2-D tensor for MatMul/Gemm; not a 4-D NCHW
-            tensor, or a Conv attribute combination :func:`_conv_spatial_attrs`
-            declines, for Conv) falls back to plain magnitude pruning (no
-            activation norm was ever observed)
+            usable (not a plain 2-D tensor for MatMul/Gemm or Attention --
+            Attention's own ``X`` input is always rank-3, so it always
+            falls into this case; not a 4-D NCHW tensor, or a Conv
+            attribute combination :func:`_conv_spatial_attrs` declines, for
+            Conv) falls back to plain magnitude pruning (no activation norm
+            was ever observed)
     """
     _validate_pattern(sparsity, n, m)
     if isinstance(model, str):
@@ -676,10 +807,14 @@ def apply_wanda_pruning(
 
 def weight_sparsity(model: Union[str, onnx.ModelProto]) -> float:
     """Fraction of exact-zero entries across every matched MatMul/vanilla-
-    Gemm or ordinary (``group=1``) 2-D Conv layer's constant weight -- a
-    quick way to confirm a pruning call reached its target, or to measure
-    an already-sparse model. Returns ``0.0`` if no matching layer is
-    present.
+    Gemm layer (including ``com.microsoft::GroupQueryAttention``'s separate
+    Q/K/V projections), ordinary (``group=1``) 2-D Conv layer, or
+    ``com.microsoft::Attention`` merged-QKV-weight layer's constant weight
+    -- a quick way to confirm a pruning call reached its target, or to
+    measure an already-sparse model. Shares :func:`_candidates` with every
+    ``apply_*_pruning`` function above, so it automatically reports across
+    whatever layer types they match, with no separate list to keep in sync.
+    Returns ``0.0`` if no matching layer is present.
     """
     if isinstance(model, str):
         model = onnx.load(model, load_external_data=False)
@@ -789,7 +924,10 @@ def apply_sparsegpt_pruning(
 ) -> onnx.ModelProto:
     """SparseGPT (Frantar & Alistarh, 2023): zeros the least-important
     entries of every MatMul/vanilla-Gemm layer's constant 2-D float32
-    weight, the same unstructured-or-N:M patterns
+    weight (this includes ``com.microsoft::GroupQueryAttention``'s separate
+    Q/K/V projections, ordinary MatMul/Gemm nodes in their own right) and
+    every ``com.microsoft::Attention`` node's constant 2-D float32 merged
+    QKV weight, the same unstructured-or-N:M patterns
     :func:`apply_magnitude_pruning`/:func:`apply_wanda_pruning` offer, but
     -- unlike either -- using a sequential, Hessian-error-compensating
     algorithm ported from GPTQ (:mod:`onnxsim.gptq`, same authors, same
@@ -819,6 +957,17 @@ def apply_sparsegpt_pruning(
     weight reshape; the codebase is only ever exercised on OPT/BLOOM,
     which have zero Conv layers). Rather than ship an unverified from-
     scratch Hessian, Conv is left unmatched here for now.
+
+    ``Attention``'s merged QKV weight has no analogous gap and is
+    deliberately matched here too (unconditionally -- see
+    :func:`_candidates`'s own docstring): its own input is a plain
+    ``[*, K]`` activation (the same ``X`` any ordinary MatMul reads), not an
+    im2col-unfolded receptive field, so ``H = X^T X`` is exactly as correct
+    for it as for every other MatMul/Gemm layer already matched here, with
+    no new machinery needed. See this module's own docstring for the fuller
+    reasoning, including why it would be inconsistent to exclude it while
+    ``GroupQueryAttention``'s separate Q/K/V MatMuls remain (and always
+    were) in scope.
 
     :param model: the original onnx ModelProto or file path
     :param calibration_data: representative input batches to compute each

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -2714,3 +2714,176 @@ def test_attention_head_pruning_handles_attention_and_gqa_in_one_model():
     y1, y2 = _run(pruned, {"X1": x1, "X2": x2})
     assert y1.shape == (batch, seq, Out1)
     assert y2.shape == (batch, seq, Out2)
+
+
+# --- magnitude/Wanda/SparseGPT pruning: Attention/GQA weights -----------
+#
+# The value-only (unstructured/N:M) pruning functions above -- as opposed
+# to this file's own attention *head* pruning section, which removes whole
+# heads -- reuse `_candidates()`/`_prune_weight()` unchanged for these
+# layer types; see onnxsim/pruning.py's own module docstring and
+# `_candidates`'s own docstring for the full reasoning. `_attention_model`/
+# `_gqa_model` (defined above, in the head-pruning section) are reused here
+# too -- same fused-attention topology, just pruned along a different axis.
+
+
+def test_magnitude_pruning_attention_merged_weight_reaches_target_sparsity():
+    model, cfg = _attention_model(K=8, H=4, D=4, Out=6, seed=20)
+    pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    wqkv_pruned = onnx.numpy_helper.to_array(inits["Wqkv"])
+    assert wqkv_pruned.shape == cfg["wqkv"].shape
+    zeros = np.count_nonzero(wqkv_pruned == 0)
+    assert zeros / wqkv_pruned.size == pytest.approx(0.5, abs=1e-9)
+
+    # Bias is never touched by this pass -- only the matched weight is.
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Bqkv"]), cfg["bqkv"]
+    )
+
+    # num_heads/qkv_hidden_sizes describe the merged weight's *column
+    # layout*, not any zeroed-vs-nonzero split within it -- since this pass
+    # only zeros values and never reshapes the weight, the whole node (not
+    # just these two attributes) must come out byte-identical.
+    node_before = _attention_node(model)
+    node_after = _attention_node(pruned)
+    assert node_after.SerializeToString() == node_before.SerializeToString()
+    num_heads, qkv = _attention_attrs(node_after)
+    assert num_heads == cfg["H"]
+    assert qkv == [cfg["Nq"], cfg["Nk"], cfg["Nv"]]
+
+
+def test_magnitude_pruning_attention_merged_weight_keeps_the_largest_entries_per_column():
+    model, cfg = _attention_model(K=8, H=4, D=4, Out=6, seed=21)
+    pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.75)
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    w = cfg["wqkv"].astype(np.float64)  # [K, N]
+    w_pruned = onnx.numpy_helper.to_array(inits["Wqkv"]).astype(np.float64)
+    keep_count = round(cfg["K"] * 0.25)
+    for col in range(w.shape[1]):
+        kept = np.flatnonzero(w_pruned[:, col] != 0)
+        assert len(kept) == keep_count
+        threshold = np.abs(w[:, col])[kept].min()
+        dropped_max = np.abs(w[:, col])[np.flatnonzero(w_pruned[:, col] == 0)].max()
+        assert dropped_max <= threshold
+
+
+def test_magnitude_pruning_attention_merged_weight_nm_pattern():
+    model, cfg = _attention_model(K=16, H=4, D=4, Out=6, seed=22)
+    pruned = onnxsim.apply_magnitude_pruning(model, n=2, m=4)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    w_pruned = onnx.numpy_helper.to_array(inits["Wqkv"]).T  # [N, K]
+    for row in w_pruned:
+        for start in range(0, len(row), 4):
+            group = row[start : start + 4]
+            assert np.count_nonzero(group) <= 2
+
+
+def test_wanda_pruning_attention_merged_weight_falls_back_to_magnitude():
+    # `Attention`'s own `X` input is rank-3 ([batch, seq, hidden]), not the
+    # plain 2-D tensor Wanda's calibrated metric requires at the probe
+    # point -- the documented fallback every other MatMul/Gemm layer with a
+    # non-2-D activation already gets (see apply_wanda_pruning's own
+    # docstring), not a crash and not an untouched layer.
+    model, cfg = _attention_model(K=8, H=4, D=4, Out=6, seed=23)
+    rng = np.random.default_rng(24)
+    x = rng.standard_normal((2, 5, cfg["K"])).astype(np.float32)
+
+    magnitude_pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.5)
+    wanda_pruned = onnxsim.apply_wanda_pruning(
+        model, calibration_data=[{"X": x}], sparsity=0.5
+    )
+    onnx.checker.check_model(wanda_pruned)
+
+    inits_m = {t.name: t for t in magnitude_pruned.graph.initializer}
+    inits_w = {t.name: t for t in wanda_pruned.graph.initializer}
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits_m["Wqkv"]),
+        onnx.numpy_helper.to_array(inits_w["Wqkv"]),
+    )
+
+
+def test_sparsegpt_pruning_attention_merged_weight_matches_reference_transliteration():
+    # Unlike Conv, `Attention`'s merged QKV weight has a plain `[*, K]`
+    # activation as its own input (no im2col unfolding), so it is
+    # deliberately included in SparseGPT's candidate list -- see
+    # apply_sparsegpt_pruning's own docstring. `H = X^T X` is computed the
+    # same way as any other MatMul/Gemm layer, reduced over every leading
+    # axis of the rank-3 `X`.
+    K = 8
+    model, cfg = _attention_model(K=K, H=4, D=4, Out=6, seed=25)
+    rng = np.random.default_rng(26)
+    x_cal = rng.standard_normal((3, 6, K)).astype(np.float32)  # [batch, seq, K]
+
+    pruned = onnxsim.apply_sparsegpt_pruning(
+        model, calibration_data=[{"X": x_cal}], sparsity=0.5, proc_block_size=6
+    )
+    onnx.checker.check_model(pruned)
+
+    x_flat = x_cal.reshape(-1, K).astype(np.float64)
+    w_nk = cfg["wqkv"].T.astype(np.float64)  # [N, K]
+    h = x_flat.T @ x_flat
+    expected_nk = _reference_sparsegpt(
+        w_nk, h, sparsity=0.5, n=None, m=None, percdamp=0.01, blocksize=6
+    )
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    w_pruned = onnx.numpy_helper.to_array(inits["Wqkv"]).T.astype(np.float64)
+    np.testing.assert_allclose(w_pruned, expected_nk, rtol=1e-6, atol=1e-6)
+
+    node_before = _attention_node(model)
+    node_after = _attention_node(pruned)
+    assert node_after.SerializeToString() == node_before.SerializeToString()
+
+
+def test_magnitude_pruning_gqa_qkv_weights_already_matched():
+    # Not new behavior: Wq/Wk/Wv are ordinary MatMul producers feeding
+    # GroupQueryAttention, not weights the op itself owns (see
+    # _match_gqa_producer's own docstring) -- `_candidates` already matched
+    # them as plain MatMul/Gemm layers before this task added any
+    # Attention-specific matching at all. This test exists to prove that
+    # explicitly rather than leaving it implicit.
+    model, cfg = _gqa_model(K=8, H=4, KVH=2, D=8, Out=6, seed=27)
+    pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    for name, original in (("Wq", cfg["wq"]), ("Wk", cfg["wk"]), ("Wv", cfg["wv"])):
+        w = onnx.numpy_helper.to_array(inits[name])
+        assert w.shape == original.shape
+        zeros = np.count_nonzero(w == 0)
+        assert zeros / w.size == pytest.approx(0.5, abs=1e-9)
+        assert not np.array_equal(w, original)
+
+    # num_heads/kv_num_heads are untouched -- this is a value-only rewrite
+    # of Wq/Wk/Wv/Wout, not the structural head-pruning this file's own
+    # `apply_attention_head_pruning` performs on the same node type.
+    node_before = _gqa_node(model)
+    node_after = _gqa_node(pruned)
+    assert node_after.SerializeToString() == node_before.SerializeToString()
+
+    rng = np.random.default_rng(28)
+    x = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    assert y.shape == (cfg["batch"], cfg["seq"], cfg["Out"])
+
+
+def test_weight_sparsity_includes_attention_and_gqa_weights():
+    model, cfg = _attention_model(K=8, H=4, D=4, Out=6, seed=29)
+    assert onnxsim.weight_sparsity(model) == 0.0
+    pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.5)
+    # Both Wqkv (newly matched here) and Wout (already matched before this
+    # task) are now exactly half-zero, so the whole model's aggregate
+    # sparsity is still 0.5 -- automatic, since weight_sparsity shares
+    # `_candidates` with every apply_*_pruning function.
+    assert onnxsim.weight_sparsity(pruned) == pytest.approx(0.5, abs=1e-9)
+
+    gqa_model, _ = _gqa_model(K=8, H=4, KVH=2, D=8, Out=6, seed=30)
+    assert onnxsim.weight_sparsity(gqa_model) == 0.0
+    gqa_pruned = onnxsim.apply_magnitude_pruning(gqa_model, sparsity=0.5)
+    assert onnxsim.weight_sparsity(gqa_pruned) == pytest.approx(0.5, abs=1e-9)


### PR DESCRIPTION
## Summary
- `apply_magnitude_pruning`/`apply_wanda_pruning`/`apply_sparsegpt_pruning`/`weight_sparsity` previously had no path to reach a fused `com.microsoft::Attention` node's merged QKV weight (`[K, Nq+Nk+Nv]`) at all — only the separate output-projection MatMul/Gemm, and, via the *structural* head-pruning functions, whole heads.
- `_candidates()` now also matches `Attention`'s merged weight via a new `_match_attention_weight_only` (mirrors `_match_conv_weight_only`'s pattern, reusing `_match_attention_producer`'s own criteria minus its bias handling). It's treated exactly like a non-transposed MatMul weight, so `_prune_weight`'s existing non-Conv path needed no changes.
- **`GroupQueryAttention`'s separate Q/K/V weights already worked with zero code changes** — they're ordinary MatMul/Gemm producer nodes feeding the op, already reachable by `_candidates`' existing generic matching. Confirmed by inspection and a new regression test rather than assumed.
- **Wanda**: left `x.ndim != 2` un-generalized — Attention's rank-3 `X` input falls back to plain magnitude, the same documented fallback every other non-2-D-activation MatMul/Gemm layer already gets (generalizing this would also silently change pre-existing, tested fallback behavior for unrelated layers, a bigger change than asked for here).
- **SparseGPT**: the Attention merged weight *is* included in scope (unlike Conv, its input is a plain `[*, K]` activation, so `H = X^T X` is exactly as correct as for any other MatMul/Gemm layer — no im2col complication).
- Confirmed unstructured/N:M pruning never changes shape, so `num_heads`/`qkv_hidden_sizes` can't drift out of sync — verified with a byte-identical-attribute test.

## Test plan
- [x] `pytest tests/test_pruning.py -q` — 89 passed
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_