### PR TITLE
CI: Add path filters to skip unnecessary workflow runs

### DIFF
--- a/.github/workflows/pyodide-wasm.yml
+++ b/.github/workflows/pyodide-wasm.yml
@@ -27,9 +27,12 @@
 #     package version, not "whatever's current", so this stays matched.
 name: Pyodide / wasm32-emscripten build
 
+# `onnxsim/**` below still needs `!onnxsim/**/*.py` next to it: this build
+# only compiles onnxsim's C++ core into the nanobind extension, so a
+# Python-only change under onnxsim/ (or elsewhere) doesn't affect it.
 on:
   pull_request:
-    paths:
+    paths: &pyodide-wasm-paths
       - ".github/workflows/pyodide-wasm.yml"
       - "build_wasm_pyodide.sh"
       - "docs/wasm_pyodide.md"
@@ -38,19 +41,11 @@ on:
       - "CMakeLists.txt"
       - "cmake/**"
       - "onnxsim/**"
+      - "!onnxsim/**/*.py"
       - ".gitmodules"
   push:
     branches: ["master"]
-    paths:
-      - ".github/workflows/pyodide-wasm.yml"
-      - "build_wasm_pyodide.sh"
-      - "docs/wasm_pyodide.md"
-      - "scripts/pyodide_smoke_test.mjs"
-      - "scripts/pyodide_demo/**"
-      - "CMakeLists.txt"
-      - "cmake/**"
-      - "onnxsim/**"
-      - ".gitmodules"
+    paths: *pyodide-wasm-paths
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,11 +1,31 @@
 name: Rust wrapper
 
+# `release`/`workflow_dispatch` are intentionally left without a `paths` filter
+# below (GitHub Actions only applies `paths` to `push`/`pull_request` anyway):
+# a release must always build+publish, and a manual dispatch should always run
+# regardless of what last changed.
 on:
   push:
     branches:
       - main
       - master
+    # Skip this (slow, native-build-heavy) workflow when a push/PR only
+    # touches onnxsim's Python side (onnxsim/**/*.py, tests/, docs/, etc.) --
+    # none of that affects the Rust crates or the C++ core they link against.
+    paths: &rust-paths
+      - "rust/**"
+      - "CMakeLists.txt"
+      - "cmake/**"
+      - "onnxsim/**"
+      - "!onnxsim/**/*.py"
+      - "third_party/**"
+      - ".gitmodules"
+      - "scripts/bump_binding_versions.sh"
+      - "scripts/test_rust_package_standalone.sh"
+      - "scripts/convertmodel/test/model.onnx"
+      - ".github/workflows/rust.yml"
   pull_request:
+    paths: *rust-paths
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -1,11 +1,27 @@
 name: Build and Test with sanitizers
 
+# This job's whole point is catching memory-safety/alignment bugs in onnxsim's
+# C++ core (and the onnx/onnx-optimizer/protobuf tree it links), so restrict
+# it to changes that can actually affect that: no point re-running an
+# instrumented ~native build for a Python-only change.
 on:
   push:
     branches:
       - main
       - master
+    paths: &sanitizer-paths
+      - "onnxsim/**"
+      - "!onnxsim/**/*.py"
+      - "CMakeLists.txt"
+      - "cmake/**"
+      - "third_party/**"
+      - "setup.py"
+      - "pyproject.toml"
+      - ".gitmodules"
+      - "scripts/leak.txt"
+      - ".github/workflows/sanitizer.yml"
   pull_request:
+    paths: *sanitizer-paths
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -33,13 +33,16 @@ on:
     branches: ["master", "pages"]
     # Only rebuild/deploy the WASM convertmodel demo when files that actually
     # affect it change (the C++ sources, the build scripts, the demo assets,
-    # or this workflow itself).
-    paths:
+    # or this workflow itself). `!onnxsim/**/*.py` excludes onnxsim's
+    # Python-only files -- this build compiles onnxsim's C++ core into the
+    # wasm module and never touches them.
+    paths: &static-paths
       - ".github/workflows/static.yml"
       - "build_wasm.sh"
       - "CMakeLists.txt"
       - "cmake/**"
       - "onnxsim/**"
+      - "!onnxsim/**/*.py"
       - "scripts/convertmodel/**"
       - "scripts/regression/models.json"
       - "npm/onnxsim/**"
@@ -52,18 +55,7 @@ on:
   # for what this skips (Netron, Pages/Cloudflare deploy) to keep it cheaper
   # than a full demo build.
   pull_request:
-    paths:
-      - ".github/workflows/static.yml"
-      - "build_wasm.sh"
-      - "CMakeLists.txt"
-      - "cmake/**"
-      - "onnxsim/**"
-      - "scripts/convertmodel/**"
-      - "scripts/regression/models.json"
-      - "npm/onnxsim/**"
-      - "scripts/build_npm_package.sh"
-      - "scripts/stage_npm_package.sh"
-      - ".gitmodules"
+    paths: *static-paths
 
   # Per-PR Cloudflare previews are opt-in: comment `/preview` on the pull
   # request. `issue_comment` has no path filter, which is fine — the whole point


### PR DESCRIPTION
## Summary
Add `paths` filters to GitHub Actions workflows to skip expensive builds when only Python files or unrelated code changes. This reduces CI overhead and speeds up feedback for Python-only changes.

## Key Changes
- **rust.yml**: Added `paths` filter to skip the Rust wrapper build when only Python files (`onnxsim/**/*.py`), tests, or docs change. The filter includes Rust sources, CMake config, C++ core, and related build scripts.
- **static.yml**: Added `!onnxsim/**/*.py` exclusion to the existing `paths` filter and deduplicated the `pull_request` paths by using a YAML anchor reference.
- **pyodide-wasm.yml**: Added `!onnxsim/**/*.py` exclusion and deduplicated `push`/`pull_request` paths using a YAML anchor reference, since both triggers use identical path filters.
- **sanitizer.yml**: Added `paths` filter to skip the sanitizer build for Python-only changes, since it only instruments the C++ core. Includes C++ sources, CMake config, build system files, and the workflow itself.

## Implementation Details
- All workflows now explicitly exclude `onnxsim/**/*.py` from their path filters, since these builds compile only the C++ core and never touch Python source files.
- Used YAML anchor references (`&name` / `*name`) to avoid duplicating identical path lists across `push` and `pull_request` triggers.
- Added clarifying comments explaining why Python files are excluded and why certain paths are included.
- `release` and `workflow_dispatch` triggers intentionally left without path filters, as releases must always build/publish and manual dispatches should always run.

https://claude.ai/code/session_0169ZJSVXJwG6wPMPvgruqBp