### PR TITLE
tests: migrate test_spqr.py to onnx.parser

### DIFF
--- a/tests/test_spqr.py
+++ b/tests/test_spqr.py
@@ -6,9 +6,9 @@ sparse ``ScatterND`` correction).
 
 import numpy as np
 import onnx
-import onnx.helper
 import onnx.numpy_helper
 import pytest
+from onnx import parser
 
 import onnxsim
 from onnxsim.omniquant import _quantize_blockwise_int4_with_clip
@@ -16,30 +16,35 @@ from onnxsim.omniquant import _quantize_blockwise_int4_with_clip
 ort = pytest.importorskip("onnxruntime")
 
 
-def _vi(name, shape):
-    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
 
 
 def _f32(array, name):
     return onnx.numpy_helper.from_array(array.astype(np.float32), name)
 
 
-def _model(nodes, inputs, outputs, initializer, opset=21):
-    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
-    return onnx.helper.make_model(
-        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
-    )
-
-
 def _matmul_model(K=32, N=8, weight=None, seed=0, opset=21):
     if weight is None:
         rng = np.random.default_rng(seed)
         weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
     return _model(
-        nodes,
-        [_vi("X", ["batch", K])],
-        [_vi("Y", ["batch", N])],
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
         [_f32(weight, "W")],
         opset=opset,
     )
@@ -126,17 +131,27 @@ def test_spqr_declines_when_k_not_divisible_by_block_size():
 
 
 def test_spqr_declines_non_constant_weight():
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
     model = _model(
-        nodes, [_vi("X", [4, 32]), _vi("W", [32, 4])], [_vi("Y", [4, 4])], []
+        """
+        g (float[4,32] X, float[32,4] W) => (float[4,4] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """
     )
     q = onnxsim.quantize_weight_only_spqr(model)
     assert q.SerializeToString() == model.SerializeToString()
 
 
 def test_spqr_noop_when_no_matmul_present():
-    nodes = [onnx.helper.make_node("Relu", ["X"], ["Y"])]
-    model = _model(nodes, [_vi("X", [4, 4])], [_vi("Y", [4, 4])], [])
+    model = _model(
+        """
+        g (float[4,4] X) => (float[4,4] Y)
+        {
+          Y = Relu(X)
+        }
+        """
+    )
     result = onnxsim.quantize_weight_only_spqr(model)
     assert result.SerializeToString() == model.SerializeToString()
 


### PR DESCRIPTION
Replaces the `onnx.helper.make_node`/`make_graph`/`make_model` chains in
`tests/test_spqr.py` with `onnx.parser.parse_model` text-format
construction, per the repo-wide migration documented in `CLAUDE.md`.

- Adds the standard `_model(body, initializer=(), opset=21, ir_version=10)`
  helper wrapping `parser.parse_model`, matching the pattern already used
  in `test_gptq.py`, `test_awq.py`, `test_pruning.py`, etc.
- `_matmul_model`'s random/explicit weight arrays stay as numpy-built
  `onnx.numpy_helper.from_array` initializers attached after parsing.
- The two tests that previously hand-built ad hoc graphs via `_vi`/
  `make_node` (`test_spqr_declines_non_constant_weight`,
  `test_spqr_noop_when_no_matmul_present`) now use inline parser text
  bodies.
- No `onnx.helper` exceptions were needed for this file (no byte-equal
  tensors, unranked value info, or external-data weights).

No test semantics or coverage changed -- same 8 tests, same assertions.
Verified with `ruff check`/`ruff format --check` and
`pytest tests/test_spqr.py -q` (8 passed, matching the pre-migration run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_