### PR TITLE
tests: migrate test_halide_integration.py to onnx.parser

### DIFF
--- a/tests/test_halide_integration.py
+++ b/tests/test_halide_integration.py
@@ -42,7 +42,7 @@ regular build-and-test matrix skips them.
 import numpy as np
 import onnx
 import pytest
-from onnx import TensorProto, helper, numpy_helper
+from onnx import numpy_helper, parser
 
 hl = pytest.importorskip("halide", reason="halide is not installed")
 
@@ -83,10 +83,19 @@ def _safe_jit_target():
 _JIT_TARGET = _safe_jit_target()
 
 
-def _model(nodes, inputs, outputs, initializers, name) -> onnx.ModelProto:
-    graph = helper.make_graph(nodes, name, inputs, outputs, initializers)
-    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", _OPSET)])
-    model.ir_version = _IR_VERSION
+def _model(
+    body, initializer=(), opset=_OPSET, ir_version=_IR_VERSION
+) -> onnx.ModelProto:
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
     onnx.checker.check_model(model)
     return model
 
@@ -100,35 +109,33 @@ def _conv_bn_relu() -> onnx.ModelProto:
     w = numpy_helper.from_array(_rand(8, 3, 3, 3, seed=1), "w")
     scale = numpy_helper.from_array(_rand(1, 8, 1, 1, seed=2), "scale")
     shift = numpy_helper.from_array(_rand(1, 8, 1, 1, seed=3), "shift")
-    nodes = [
-        helper.make_node("Conv", ["x", "w"], ["c"], pads=[1, 1, 1, 1]),
-        helper.make_node("Mul", ["c", "scale"], ["m"]),
-        helper.make_node("Add", ["m", "shift"], ["a"]),
-        helper.make_node("Relu", ["a"], ["y"]),
-    ]
     return _model(
-        nodes,
-        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3, 8, 8])],
-        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 8, 8, 8])],
-        [w, scale, shift],
-        "conv_bn_relu",
+        """
+        conv_bn_relu (float[1,3,8,8] x) => (float[1,8,8,8] y)
+        {
+          c = Conv<pads = [1, 1, 1, 1]>(x, w)
+          m = Mul(c, scale)
+          a = Add(m, shift)
+          y = Relu(a)
+        }
+        """,
+        initializer=[w, scale, shift],
     )
 
 
 def _redundant_transpose() -> onnx.ModelProto:
     """An identity Transpose (perm=[0,1,2,3]) that onnxsim removes outright."""
     w = numpy_helper.from_array(_rand(8, 3, 3, 3, seed=1), "w")
-    nodes = [
-        helper.make_node("Transpose", ["x"], ["t"], perm=[0, 1, 2, 3]),
-        helper.make_node("Conv", ["t", "w"], ["c"], pads=[1, 1, 1, 1]),
-        helper.make_node("Relu", ["c"], ["y"]),
-    ]
     return _model(
-        nodes,
-        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3, 8, 8])],
-        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 8, 8, 8])],
-        [w],
-        "redundant_transpose",
+        """
+        redundant_transpose (float[1,3,8,8] x) => (float[1,8,8,8] y)
+        {
+          t = Transpose<perm = [0, 1, 2, 3]>(x)
+          c = Conv<pads = [1, 1, 1, 1]>(t, w)
+          y = Relu(c)
+        }
+        """,
+        initializer=[w],
     )
 
 
@@ -141,23 +148,20 @@ def _foldable_shape_reshape() -> onnx.ModelProto:
     whole chain into a literal target shape.
     """
     w = numpy_helper.from_array(_rand(8, 3, 3, 3, seed=1), "w")
-    idx = numpy_helper.from_array(np.array([0], np.int64), "idx")
-    minus1 = numpy_helper.from_array(np.array([-1], np.int64), "m1")
-    ch = numpy_helper.from_array(np.array([8], np.int64), "ch")
-    nodes = [
-        helper.make_node("Conv", ["x", "w"], ["c"], pads=[1, 1, 1, 1]),
-        helper.make_node("Relu", ["c"], ["r"]),
-        helper.make_node("Shape", ["r"], ["shp"]),
-        helper.make_node("Gather", ["shp", "idx"], ["n"], axis=0),
-        helper.make_node("Concat", ["n", "ch", "m1"], ["newshape"], axis=0),
-        helper.make_node("Reshape", ["r", "newshape"], ["y"]),
-    ]
     return _model(
-        nodes,
-        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3, 8, 8])],
-        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 8, 64])],
-        [w, idx, minus1, ch],
-        "foldable_shape_reshape",
+        """
+        foldable_shape_reshape (float[1,3,8,8] x) => (float[1,8,64] y)
+        <int64[1] idx = {0}, int64[1] m1 = {-1}, int64[1] ch = {8}>
+        {
+          c = Conv<pads = [1, 1, 1, 1]>(x, w)
+          r = Relu(c)
+          shp = Shape(r)
+          n = Gather<axis = 0>(shp, idx)
+          newshape = Concat<axis = 0>(n, ch, m1)
+          y = Reshape(r, newshape)
+        }
+        """,
+        initializer=[w],
     )
 
 


### PR DESCRIPTION
Replaces the `onnx.helper.make_node`/`make_graph`/`make_model` chains in this module's `_model()` helper and its three fixture builders (`_conv_bn_relu`, `_redundant_transpose`, `_foldable_shape_reshape`) with `onnx.parser`-based ONNX text format construction, following the repo-wide migration documented in `CLAUDE.md` and the `_model(body, initializer=(), opset=..., ir_version=...)` pattern already used by `tests/test_fusion_patterns.py`, `tests/test_pruning.py`, and others.

`_model()` now takes a text `body` (plus optional extra initializers) instead of positional nodes/inputs/outputs/initializers/name lists. Weight arrays (`w`, `scale`, `shift`) stay as numpy-built `numpy_helper.from_array` initializers attached after parsing, per CLAUDE.md's rule for random/large weight data.

One narrow exception: the small fixed int64 constants driving the `Shape -> Gather -> Concat -> Reshape` chain in `_foldable_shape_reshape` (`idx=[0]`, `m1=[-1]`, `ch=[8]`) are inlined as text-literal initializers (`<int64[1] idx = {0}, ...>`) rather than kept as separate `numpy_helper` tensors, since CLAUDE.md calls out small/fixed/deterministic constants as fine for text literals.

No behavioral change: model topology, tensor shapes, and initializer values are identical to before. Verified by constructing all three fixtures standalone and running them through `onnxsim.simplify()`, confirming the same node-count/op-type assertions the tests rely on (Mul/Add fold into Conv, the identity Transpose is removed, the Shape/Gather/Concat/Reshape chain collapses into a literal Reshape). `halide` is not installed in this environment, so the module's tests are skipped (`1 skipped`) both before and after this change — `ruff check`/`ruff format --check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7

---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_