### PR TITLE
tests: migrate test_modelopt_integration.py to onnx.parser

### DIFF
--- a/tests/test_modelopt_integration.py
+++ b/tests/test_modelopt_integration.py
@@ -21,8 +21,9 @@ runs these tests; the regular build-and-test matrix skips them.
 
 import numpy as np
 import onnx
+import onnx.numpy_helper
 import pytest
-from onnx import TensorProto, helper
+from onnx import TensorProto, parser
 
 # Skip the entire module unless NVIDIA ModelOpt's ONNX quantization is available.
 # Checked before importing onnxsim so a ModelOpt-less run skips cleanly.
@@ -32,6 +33,20 @@ moq = pytest.importorskip(
 )
 
 import onnxsim  # noqa: E402  (imported after the ModelOpt availability check)
+
+
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
 
 
 def _build_fp32_model(path: str) -> None:
@@ -46,36 +61,25 @@ def _build_fp32_model(path: str) -> None:
     32-channel Conv and 32x32 MatMul below are deliberately above those floors.
     """
     rng = np.random.RandomState(0)
-    conv_w = helper.make_tensor(
-        "conv_w",
-        TensorProto.FLOAT,
-        [32, 32, 3, 3],
-        rng.randn(32 * 32 * 3 * 3).astype(np.float32).tolist(),
+    # Random/large weight arrays: kept as numpy-built initializers per the
+    # established convention rather than spelled out as text literals.
+    conv_w = onnx.numpy_helper.from_array(
+        rng.randn(32, 32, 3, 3).astype(np.float32), "conv_w"
     )
-    mm_w = helper.make_tensor(
-        "mm_w",
-        TensorProto.FLOAT,
-        [32, 32],
-        rng.randn(32 * 32).astype(np.float32).tolist(),
-    )
-    nodes = [
-        helper.make_node(
-            "Conv", ["X", "conv_w"], ["c"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
-        ),
-        helper.make_node("Relu", ["c"], ["r"]),
-        helper.make_node("GlobalAveragePool", ["r"], ["p"]),
-        helper.make_node("Flatten", ["p"], ["f"], axis=1),
-        helper.make_node("MatMul", ["f", "mm_w"], ["Y"]),
-    ]
-    graph = helper.make_graph(
-        nodes,
-        "modelopt_src",
-        [helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 32, 8, 8])],
-        [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 32])],
+    mm_w = onnx.numpy_helper.from_array(rng.randn(32, 32).astype(np.float32), "mm_w")
+    model = _model(
+        """
+        modelopt_src (float[1,32,8,8] X) => (float[1,32] Y)
+        {
+          c = Conv<kernel_shape=[3,3], pads=[1,1,1,1]>(X, conv_w)
+          r = Relu(c)
+          p = GlobalAveragePool(r)
+          f = Flatten<axis=1>(p)
+          Y = MatMul(f, mm_w)
+        }
+        """,
         [conv_w, mm_w],
     )
-    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
-    model.ir_version = 10
     onnx.checker.check_model(model)
     onnx.save(model, path)
 


### PR DESCRIPTION
Continuation of the onnx.parser-based test readability migration.

Replaces the `onnx.helper.make_node`/`make_graph`/`make_model` chain in `_build_fp32_model` with the ONNX text format via the established `_model(body, initializer=(), opset=..., ir_version=...)` helper (same pattern as `tests/test_python_api.py`, `tests/test_fusion_patterns.py`, `tests/test_pruning.py`, `tests/test_qoperator_quantize_matmul.py`).

No `onnx.helper` exceptions were needed -- the Conv + Relu + GlobalAveragePool + Flatten + MatMul graph uses only standard ONNX ops expressible in the text format. The `conv_w`/`mm_w` weight tensors stay numpy-built `onnx.numpy_helper.from_array` initializers per the established convention for random/large arrays, attached to the parsed model afterward rather than spelled out as text literals.

No test semantics changed -- only how the fp32 source model is constructed.

## Test plan
- [x] `ruff check tests/test_modelopt_integration.py` -- clean
- [x] `ruff format --check tests/test_modelopt_integration.py` -- clean
- [x] `python -m pytest tests/test_modelopt_integration.py -q` -- 1 skipped (nvidia-modelopt not installed in this environment), same as before the change
- [x] mypy: not applicable -- `pyproject.toml`'s `[tool.mypy]` scopes `files = ["onnxsim"]`, tests are excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7

---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_