### PR TITLE
tests: migrate test_spinquant.py to onnx.parser

### DIFF
--- a/tests/test_spinquant.py
+++ b/tests/test_spinquant.py
@@ -6,40 +6,44 @@ optimizer -- followed by block-wise INT4 quantization).
 
 import numpy as np
 import onnx
-import onnx.helper
 import onnx.numpy_helper
 import pytest
+from onnx import parser
 
 import onnxsim
 
 ort = pytest.importorskip("onnxruntime")
 
 
-def _vi(name, shape):
-    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
 
 
 def _f32(array, name):
     return onnx.numpy_helper.from_array(array.astype(np.float32), name)
 
 
-def _model(nodes, inputs, outputs, initializer, opset=21):
-    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
-    return onnx.helper.make_model(
-        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
-    )
-
-
-def _matmul_model(K=32, N=8, weight=None, seed=0, opset=21):
-    if weight is None:
-        rng = np.random.default_rng(seed)
-        weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+def _matmul_model(K=32, N=8, seed=0, opset=21):
+    rng = np.random.default_rng(seed)
+    weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
     return _model(
-        nodes,
-        [_vi("X", ["batch", K])],
-        [_vi("Y", ["batch", N])],
-        [_f32(weight, "W")],
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[_f32(weight, "W")],
         opset=opset,
     )
 
@@ -87,12 +91,14 @@ def test_spinquant_gemm_transb_with_bias():
     K, N = 32, 8
     weight = rng.standard_normal((N, K)).astype(np.float32) * 0.5
     bias = rng.standard_normal((N,)).astype(np.float32) * 0.1
-    nodes = [onnx.helper.make_node("Gemm", ["X", "W", "B"], ["Y"], transB=1)]
     model = _model(
-        nodes,
-        [_vi("X", ["batch", K])],
-        [_vi("Y", ["batch", N])],
-        [_f32(weight, "W"), _f32(bias, "B")],
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = Gemm<transB=1>(X, W, B)
+        }}
+        """,
+        initializer=[_f32(weight, "W"), _f32(bias, "B")],
     )
     q = onnxsim.apply_spinquant(model, block_size=8, num_samples=16, seed=6)
     onnx.checker.check_model(q)
@@ -111,17 +117,27 @@ def test_spinquant_declines_when_k_not_divisible_by_block_size():
 
 
 def test_spinquant_declines_non_constant_weight():
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
     model = _model(
-        nodes, [_vi("X", [4, 32]), _vi("W", [32, 4])], [_vi("Y", [4, 4])], []
+        """
+        g (float[4,32] X, float[32,4] W) => (float[4,4] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """
     )
     q = onnxsim.apply_spinquant(model)
     assert q.SerializeToString() == model.SerializeToString()
 
 
 def test_spinquant_noop_when_no_matmul_present():
-    nodes = [onnx.helper.make_node("Relu", ["X"], ["Y"])]
-    model = _model(nodes, [_vi("X", [4, 4])], [_vi("Y", [4, 4])], [])
+    model = _model(
+        """
+        g (float[4,4] X) => (float[4,4] Y)
+        {
+          Y = Relu(X)
+        }
+        """
+    )
     result = onnxsim.apply_spinquant(model)
     assert result.SerializeToString() == model.SerializeToString()
 


### PR DESCRIPTION
## Summary
- Rebuild the MatMul/Gemm test models in `tests/test_spinquant.py` with `onnx.parser` text-format graphs instead of `onnx.helper.make_node`/`make_graph`/`make_model` chains, matching the established pattern in `tests/test_pruning.py`, `tests/test_fusion_patterns.py`, etc.
- Added a `_model(body, initializer=(), opset=21, ir_version=10)` helper wrapping `parser.parse_model()`, with random weight/bias arrays still built with `numpy_helper.from_array` and attached as initializers after parsing.
- No `onnx.helper` exceptions were needed for this file -- every model fit the text format directly.
- No test behavior or coverage changes -- only how the input models are constructed.

## Test plan
- [x] `ruff check tests/test_spinquant.py` and `ruff format --check tests/test_spinquant.py` clean
- [x] `pytest tests/test_spinquant.py -q` -- 7 passed (same as before the change)
- [x] mypy not applicable (`[tool.mypy] files = ["onnxsim"]` excludes tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_