### PR TITLE
tests: migrate test_backend.py to onnx.parser

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -7,7 +7,7 @@ reference evaluator instead of requiring / auto-installing onnxruntime.
 import numpy as np
 import onnx
 import pytest
-from onnx import TensorProto, helper, numpy_helper
+from onnx import parser
 
 import onnxsim
 from onnxsim import backend
@@ -15,19 +15,16 @@ from onnxsim import backend
 
 def _make_foldable_model() -> onnx.ModelProto:
     """A model whose ``a + b`` can be constant-folded, then added to input."""
-    a = numpy_helper.from_array(np.ones((2, 2), np.float32), "a")
-    b = numpy_helper.from_array(np.ones((2, 2), np.float32) * 2, "b")
-    add_const = helper.make_node("Add", ["a", "b"], ["c"])
-    add_input = helper.make_node("Add", ["c", "x"], ["y"])
-    graph = helper.make_graph(
-        [add_const, add_input],
-        "foldable",
-        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [2, 2])],
-        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [2, 2])],
-        [a, b],
-    )
-    model = helper.make_model(
-        graph, opset_imports=[helper.make_opsetid("", 18)], ir_version=10
+    model = parser.parse_model(
+        """
+        <ir_version: 10, opset_import: ["": 18]>
+        foldable (float[2,2] x) => (float[2,2] y)
+        <float[2,2] a = {1.0, 1.0, 1.0, 1.0}, float[2,2] b = {2.0, 2.0, 2.0, 2.0}>
+        {
+          c = Add(a, b)
+          y = Add(c, x)
+        }
+        """
     )
     onnx.checker.check_model(model)
     return model


### PR DESCRIPTION
## Summary

Continuation of the onnx.parser-based test readability migration (see CLAUDE.md's "Prefer `onnx.parser`-based model construction in tests" section).

- Replaces the `onnx.helper.make_node`/`make_graph`/`make_model` chain in `_make_foldable_model()` (`tests/test_backend.py`) with the ONNX text format via `onnx.parser.parse_model`.
- This file has a single model builder used by every test, with a fixed 2x2 shape and opset/ir_version, so the parsed text is built inline in `_make_foldable_model()` rather than through a generic `_model(body, ...)` helper — there is nothing else to parameterize.
- The two weight initializers (`a` = all-ones, `b` = all-twos, both 2x2 float32) are small, fixed, deterministic constants, so they're written as inline text-literal initializers in the graph header, per the established convention.
- `onnx.checker.check_model(model)` is preserved.
- No `onnx.helper` exceptions were needed — the model is a plain two-node `Add`/`Add` graph.
- Test names, assertions, and behavior/coverage are unchanged — this is a pure construction-style refactor.

## Test plan

- [x] `ruff check tests/test_backend.py` — clean (`All checks passed!`)
- [x] `ruff format --check tests/test_backend.py` — clean (`1 file already formatted`)
- [x] `pytest tests/test_backend.py -q` — 10 passed (same as before the change; onnxruntime is installed in this environment so no provider-selection tests are skipped)
- [x] mypy is scoped to `onnxsim` only (`files = ["onnxsim"]` in `pyproject.toml`), not `tests/`, so no mypy check applies here

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_