### PR TITLE
tests: migrate test_profiling.py to onnx.parser

### DIFF
--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -13,10 +13,24 @@ import os
 import numpy as np
 import onnx
 import pytest
-from onnx import TensorProto, helper, numpy_helper
+from onnx import numpy_helper, parser
 
 import onnxsim
 from onnxsim import backend
+
+
+def _model(body, initializer=(), opset=17, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
 
 
 def _foldable_model() -> onnx.ModelProto:
@@ -24,12 +38,16 @@ def _foldable_model() -> onnx.ModelProto:
     real simplification round runs (shape inference + optimizer + folding)."""
     a = numpy_helper.from_array(np.ones((1, 4), dtype=np.float32), name="A")
     b = numpy_helper.from_array(np.full((1, 4), 2.0, dtype=np.float32), name="B")
-    add_const = helper.make_node("Add", ["A", "B"], ["c"], name="add_const")
-    add_x = helper.make_node("Add", ["c", "x"], ["y"], name="add_x")
-    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 4])
-    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 4])
-    graph = helper.make_graph([add_const, add_x], "g", [x], [y], [a, b])
-    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    model = _model(
+        """
+        g (float[1,4] x) => (float[1,4] y)
+        {
+          c = Add(A, B)
+          y = Add(c, x)
+        }
+        """,
+        initializer=[a, b],
+    )
     onnx.checker.check_model(model)
     return model
 


### PR DESCRIPTION
Rebuilds `tests/test_profiling.py`'s `_foldable_model()` with `onnx.parser` (ONNX text format) instead of `onnx.helper.make_node`/`make_graph`/`make_model` chains, following the repo-wide migration documented in `CLAUDE.md`.

- Adds the established `_model(body, initializer=(), opset=..., ir_version=...)` helper wrapping `parser.parse_model()`, matching `tests/test_python_api.py`, `tests/test_fusion_patterns.py`, `tests/test_pruning.py`, and `tests/test_qoperator_quantize_matmul.py`.
- Keeps the two constant-folding initializers (`A`, `B`) as `numpy_helper.from_array` tensors attached programmatically after parsing, matching the `_make_add_model` precedent in `test_python_api.py`.
- Exception kept: the two `Add` nodes drop their explicit `name="add_const"`/`name="add_x"`. The text-format parser has no syntax for setting `Node.name` (an inline `<name="...">` after the op type instead creates a spurious "name" *attribute* on the node, not the node's name field). These names were never asserted on in the tests, only used for readability in comments, so dropping them doesn't change test semantics or coverage.

No behavior change: `ruff check`/`ruff format --check` are clean, `pytest tests/test_profiling.py -q` passes the same 11 tests as before, and `mypy` is clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_