### PR TITLE
tests: migrate test_function_rewriter_compile_rule.py to onnx.parser

### DIFF
--- a/tests/test_function_rewriter_compile_rule.py
+++ b/tests/test_function_rewriter_compile_rule.py
@@ -34,7 +34,7 @@ import textwrap
 import numpy as np
 import onnx
 import pytest
-from onnx import helper
+from onnx import parser
 
 import onnxsim
 
@@ -113,12 +113,22 @@ def _apply_onnxscript_rule(model, rule):
     return _rewriter.rewrite(model, pattern_rewrite_rules=rules)
 
 
+def _model(body, initializer=(), opset=18, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
 def _f32(array, name):
     return onnx.numpy_helper.from_array(array.astype(np.float32), name)
-
-
-def _vi(name, shape):
-    return helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
 
 
 # --------------------------------------------------------------------------
@@ -137,16 +147,18 @@ def test_compiled_matmul_add_pattern_from_real_rule():
     assert [n.op_type for n in pattern_fp.node] == ["MatMul", "Add"]
 
     def build():
-        nodes = [
-            helper.make_node("MatMul", ["x", "W"], ["mm"]),
-            helper.make_node("Add", ["mm", "B"], ["y"]),
-        ]
-        inits = [_f32(np.random.randn(4, 5), "W"), _f32(np.random.randn(5), "B")]
-        graph = helper.make_graph(
-            nodes, "g", [_vi("x", [3, 4])], [_vi("y", [3, 5])], inits
-        )
-        return helper.make_model(
-            graph, opset_imports=[helper.make_opsetid("", 18)], ir_version=10
+        return _model(
+            """
+            g (float[3,4] x) => (float[3,5] y)
+            {
+              mm = MatMul(x, W)
+              y = Add(mm, B)
+            }
+            """,
+            initializer=[
+                _f32(np.random.randn(4, 5), "W"),
+                _f32(np.random.randn(5), "B"),
+            ],
         )
 
     ours, check_ok = onnxsim.simplify(
@@ -176,19 +188,15 @@ def test_compiled_reshape_reshape_pattern_from_real_rule():
     assert [n.op_type for n in pattern_fp.node] == ["Reshape", "Reshape"]
 
     def build():
-        nodes = [
-            helper.make_node("Reshape", ["x", "s1"], ["t"]),
-            helper.make_node("Reshape", ["t", "s2"], ["y"]),
-        ]
-        inits = [
-            onnx.numpy_helper.from_array(np.array([2, 12], dtype=np.int64), "s1"),
-            onnx.numpy_helper.from_array(np.array([4, 6], dtype=np.int64), "s2"),
-        ]
-        graph = helper.make_graph(
-            nodes, "g", [_vi("x", [3, 8])], [_vi("y", [4, 6])], inits
-        )
-        return helper.make_model(
-            graph, opset_imports=[helper.make_opsetid("", 18)], ir_version=10
+        return _model(
+            """
+            g (float[3,8] x) => (float[4,6] y)
+            <int64[2] s1 = {2, 12}, int64[2] s2 = {4, 6}>
+            {
+              t = Reshape(x, s1)
+              y = Reshape(t, s2)
+            }
+            """
         )
 
     ours, check_ok = onnxsim.simplify(
@@ -216,15 +224,14 @@ def test_compiled_successive_relu_both_from_real_rule():
     assert [n.op_type for n in replacement_fp.node] == ["Relu"]
 
     def build():
-        nodes = [
-            helper.make_node("Relu", ["x"], ["t"]),
-            helper.make_node("Relu", ["t"], ["y"]),
-        ]
-        graph = helper.make_graph(
-            nodes, "g", [_vi("x", [2, 2])], [_vi("y", [2, 2])], []
-        )
-        return helper.make_model(
-            graph, opset_imports=[helper.make_opsetid("", 18)], ir_version=10
+        return _model(
+            """
+            g (float[2,2] x) => (float[2,2] y)
+            {
+              t = Relu(x)
+              y = Relu(t)
+            }
+            """
         )
 
     ours, check_ok = onnxsim.simplify(


### PR DESCRIPTION
## Summary
- Rebuild the three inline test models (matmul+add, reshape+reshape, successive relu) with `onnx.parser.parse_model` via the repo-wide `_model(body, initializer=(), opset=..., ir_version=...)` helper, instead of chains of `onnx.helper.make_node`/`make_graph`/`make_model`.
- The reshape test's two shape initializers (small, fixed int64 constants) move inline as text-literal initializers rather than `numpy_helper.from_array` calls, per CLAUDE.md's guidance for small/deterministic constants.
- Weight tensors (random-valued) stay as numpy-built `onnx.numpy_helper.from_array` initializers attached after parsing, per CLAUDE.md.
- No `onnx.helper` exceptions were needed elsewhere in this file. The dynamically-compiled onnxscript FunctionProtos (`pattern_fp`/`replacement_fp`, produced by `_compile_fn_to_function_proto` from real onnxscript rewrite-rule methods) are unrelated to this migration and untouched.

## Test plan
- [x] `ruff check tests/test_function_rewriter_compile_rule.py` -- clean
- [x] `ruff format --check tests/test_function_rewriter_compile_rule.py` -- clean
- [x] `pytest tests/test_function_rewriter_compile_rule.py -q` -- same result before/after (1 skipped, in this env onnxscript's internal `@script` machinery is unavailable so the module self-test skip fires)
- [x] `mypy tests/test_function_rewriter_compile_rule.py` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7

---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_