### PR TITLE
tests: migrate test_tvm_integration.py to onnx.parser

### DIFF
--- a/tests/test_tvm_integration.py
+++ b/tests/test_tvm_integration.py
@@ -28,7 +28,7 @@ tests; the regular build-and-test matrix skips them.
 import numpy as np
 import onnx
 import pytest
-from onnx import TensorProto, helper, numpy_helper
+from onnx import numpy_helper, parser
 
 tvm = pytest.importorskip("tvm", reason="apache-tvm is not installed")
 onnx_frontend = pytest.importorskip(
@@ -42,10 +42,19 @@ _OPSET = 17
 _IR_VERSION = 8
 
 
-def _model(nodes, inputs, outputs, initializers, name) -> onnx.ModelProto:
-    graph = helper.make_graph(nodes, name, inputs, outputs, initializers)
-    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", _OPSET)])
-    model.ir_version = _IR_VERSION
+def _model(
+    body, initializer=(), opset=_OPSET, ir_version=_IR_VERSION
+) -> onnx.ModelProto:
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
     onnx.checker.check_model(model)
     return model
 
@@ -59,35 +68,33 @@ def _conv_bn_relu() -> onnx.ModelProto:
     w = numpy_helper.from_array(_rand(8, 3, 3, 3, seed=1), "w")
     scale = numpy_helper.from_array(_rand(1, 8, 1, 1, seed=2), "scale")
     shift = numpy_helper.from_array(_rand(1, 8, 1, 1, seed=3), "shift")
-    nodes = [
-        helper.make_node("Conv", ["x", "w"], ["c"], pads=[1, 1, 1, 1]),
-        helper.make_node("Mul", ["c", "scale"], ["m"]),
-        helper.make_node("Add", ["m", "shift"], ["a"]),
-        helper.make_node("Relu", ["a"], ["y"]),
-    ]
     return _model(
-        nodes,
-        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3, 8, 8])],
-        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 8, 8, 8])],
+        """
+        conv_bn_relu (float[1,3,8,8] x) => (float[1,8,8,8] y)
+        {
+          c = Conv<pads = [1, 1, 1, 1]>(x, w)
+          m = Mul(c, scale)
+          a = Add(m, shift)
+          y = Relu(a)
+        }
+        """,
         [w, scale, shift],
-        "conv_bn_relu",
     )
 
 
 def _redundant_transpose() -> onnx.ModelProto:
     """An identity Transpose (perm=[0,1,2,3]) that onnxsim removes outright."""
     w = numpy_helper.from_array(_rand(8, 3, 3, 3, seed=1), "w")
-    nodes = [
-        helper.make_node("Transpose", ["x"], ["t"], perm=[0, 1, 2, 3]),
-        helper.make_node("Conv", ["t", "w"], ["c"], pads=[1, 1, 1, 1]),
-        helper.make_node("Relu", ["c"], ["y"]),
-    ]
     return _model(
-        nodes,
-        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3, 8, 8])],
-        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 8, 8, 8])],
+        """
+        redundant_transpose (float[1,3,8,8] x) => (float[1,8,8,8] y)
+        {
+          t = Transpose<perm = [0, 1, 2, 3]>(x)
+          c = Conv<pads = [1, 1, 1, 1]>(t, w)
+          y = Relu(c)
+        }
+        """,
         [w],
-        "redundant_transpose",
     )
 
 
@@ -103,20 +110,19 @@ def _foldable_shape_reshape() -> onnx.ModelProto:
     idx = numpy_helper.from_array(np.array([0], np.int64), "idx")
     minus1 = numpy_helper.from_array(np.array([-1], np.int64), "m1")
     ch = numpy_helper.from_array(np.array([8], np.int64), "ch")
-    nodes = [
-        helper.make_node("Conv", ["x", "w"], ["c"], pads=[1, 1, 1, 1]),
-        helper.make_node("Relu", ["c"], ["r"]),
-        helper.make_node("Shape", ["r"], ["shp"]),
-        helper.make_node("Gather", ["shp", "idx"], ["n"], axis=0),
-        helper.make_node("Concat", ["n", "ch", "m1"], ["newshape"], axis=0),
-        helper.make_node("Reshape", ["r", "newshape"], ["y"]),
-    ]
     return _model(
-        nodes,
-        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3, 8, 8])],
-        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 8, 64])],
+        """
+        foldable_shape_reshape (float[1,3,8,8] x) => (float[1,8,64] y)
+        {
+          c = Conv<pads = [1, 1, 1, 1]>(x, w)
+          r = Relu(c)
+          shp = Shape(r)
+          n = Gather<axis = 0>(shp, idx)
+          newshape = Concat<axis = 0>(n, ch, m1)
+          y = Reshape(r, newshape)
+        }
+        """,
         [w, idx, minus1, ch],
-        "foldable_shape_reshape",
     )
 
 


### PR DESCRIPTION
Continuation of the onnx.parser-based test readability migration.
Replaces the onnx.helper.make_node/make_graph/make_model-based
`_model()` helper with the established
`_model(body, initializer=(), opset=..., ir_version=...)` helper that
wraps `onnx.parser.parse_model()` with the ONNX text format.

No onnx.helper exceptions were needed -- all three models
(`conv_bn_relu`, `redundant_transpose`, `foldable_shape_reshape`) use only
standard ONNX ops with simple identifier names, and their weight/index
tensors are kept as numpy-built `onnx.numpy_helper.from_array`
initializers, attached to the parsed graph programmatically, per the
established convention for random/large arrays.

Verified the migrated models parse, checker-validate, and simplify to
the same node counts as before (4->2, 3->2, 6->3), and that
pytest/ruff/mypy are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7

---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_