### PR TITLE
tests: migrate test_model_info.py to onnx.parser

### DIFF
--- a/tests/test_model_info.py
+++ b/tests/test_model_info.py
@@ -1,15 +1,15 @@
 """Tests for MACs / FLOPs counting in ``onnxsim.model_info``.
 
-Every model is built directly with ``onnx.helper`` (no torch dependency). MAC
-counts are asserted against hand-computed values. The symbolic (sympy) path is
-exercised when sympy is installed and skipped otherwise, mirroring the optional
-``onnxsim[symbolic]`` extra.
+Every model is built via ``onnx.parser.parse_model`` (the ONNX text format; no
+torch dependency). MAC counts are asserted against hand-computed values. The
+symbolic (sympy) path is exercised when sympy is installed and skipped
+otherwise, mirroring the optional ``onnxsim[symbolic]`` extra.
 """
 
 import numpy as np
 import onnx
 import pytest
-from onnx import TensorProto, helper
+from onnx import helper, numpy_helper, parser
 
 from onnxsim import model_info
 from onnxsim.model_info import (
@@ -22,24 +22,30 @@ from onnxsim.model_info import (
 )
 
 
-def _model(nodes, inputs, outputs, initializers=None, opset=23):
-    graph = helper.make_graph(nodes, "g", inputs, outputs, initializers or [])
-    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", opset)])
+def _model(body, initializer=(), opset=23, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
     return model
 
 
-def _vi(name, shape, dtype=TensorProto.FLOAT):
-    return helper.make_tensor_value_info(name, dtype, shape)
+def _weight(shape, name):
+    # Zero-filled but potentially large (e.g. 4*3*3*3, 16*32 elements) --
+    # spelling these out as text-literal tensors would require one literal
+    # per element, so they're built as numpy arrays and attached as
+    # initializers after parsing, per the repo's established exception.
+    return numpy_helper.from_array(np.zeros(shape, np.float32), name)
 
 
-def _macs(nodes, inputs, outputs, initializers=None, opset=23):
-    return ModelInfo(_model(nodes, inputs, outputs, initializers, opset)).macs
-
-
-def _weight(name, shape):
-    return helper.make_tensor(
-        name, TensorProto.FLOAT, shape, np.zeros(shape, np.float32).flatten()
-    )
+def _macs(body, initializer=(), opset=23):
+    return ModelInfo(_model(body, initializer, opset)).macs
 
 
 # --------------------------------------------------------------------------- #
@@ -47,59 +53,72 @@ def _weight(name, shape):
 # --------------------------------------------------------------------------- #
 def test_conv_macs():
     # output 1*4*8*8, cin/group 3, kernel 3*3 -> 256 * 3 * 9
-    x = _vi("x", [1, 3, 8, 8])
-    w = _weight("w", [4, 3, 3, 3])
-    y = _vi("y", [1, 4, 8, 8])
-    node = helper.make_node(
-        "Conv", ["x", "w"], ["y"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
-    )
-    assert _macs([node], [x], [y], [w]) == 1 * 4 * 8 * 8 * 3 * (3 * 3)
+    body = """
+    g (float[1,3,8,8] x) => (float[1,4,8,8] y)
+    {
+      y = Conv<kernel_shape=[3,3], pads=[1,1,1,1]>(x, w)
+    }
+    """
+    macs = _macs(body, [_weight([4, 3, 3, 3], "w")])
+    assert macs == 1 * 4 * 8 * 8 * 3 * (3 * 3)
 
 
 def test_conv_grouped_macs():
     # depthwise: groups=4, weight [4, 1, 3, 3]; cin/group = 1
-    x = _vi("x", [1, 4, 8, 8])
-    w = _weight("w", [4, 1, 3, 3])
-    y = _vi("y", [1, 4, 8, 8])
-    node = helper.make_node(
-        "Conv", ["x", "w"], ["y"], kernel_shape=[3, 3], pads=[1, 1, 1, 1], group=4
-    )
-    assert _macs([node], [x], [y], [w]) == 1 * 4 * 8 * 8 * 1 * (3 * 3)
+    body = """
+    g (float[1,4,8,8] x) => (float[1,4,8,8] y)
+    {
+      y = Conv<kernel_shape=[3,3], pads=[1,1,1,1], group=4>(x, w)
+    }
+    """
+    macs = _macs(body, [_weight([4, 1, 3, 3], "w")])
+    assert macs == 1 * 4 * 8 * 8 * 1 * (3 * 3)
 
 
 def test_conv_transpose_macs():
     # input 1*3*8*8, out_channels/group 4, kernel 3*3
-    x = _vi("x", [1, 3, 8, 8])
-    w = _weight("w", [3, 4, 3, 3])  # [in, out/group, kH, kW]
-    y = _vi("y", [1, 4, 10, 10])
-    node = helper.make_node("ConvTranspose", ["x", "w"], ["y"], kernel_shape=[3, 3])
-    assert _macs([node], [x], [y], [w]) == 1 * 3 * 8 * 8 * 4 * (3 * 3)
+    body = """
+    g (float[1,3,8,8] x) => (float[1,4,10,10] y)
+    {
+      y = ConvTranspose<kernel_shape=[3,3]>(x, w)
+    }
+    """
+    # w is [in, out/group, kH, kW]
+    macs = _macs(body, [_weight([3, 4, 3, 3], "w")])
+    assert macs == 1 * 3 * 8 * 8 * 4 * (3 * 3)
 
 
 def test_gemm_macs():
-    a = _vi("a", [5, 7])
-    b = _vi("b", [7, 3])
-    y = _vi("y", [5, 3])
-    node = helper.make_node("Gemm", ["a", "b"], ["y"])
-    assert _macs([node], [a, b], [y]) == 5 * 3 * 7
+    body = """
+    g (float[5,7] a, float[7,3] b) => (float[5,3] y)
+    {
+      y = Gemm(a, b)
+    }
+    """
+    assert _macs(body) == 5 * 3 * 7
 
 
 def test_gemm_transposed_macs():
     # transB=1: b is [N, K] = [3, 7]; M=5, N=3, K=7
-    a = _vi("a", [5, 7])
-    b = _vi("b", [3, 7])
-    y = _vi("y", [5, 3])
-    node = helper.make_node("Gemm", ["a", "b"], ["y"], transB=1)
-    assert _macs([node], [a, b], [y]) == 5 * 3 * 7
+    body = """
+    g (float[5,7] a, float[3,7] b) => (float[5,3] y)
+    {
+      y = Gemm<transB=1>(a, b)
+    }
+    """
+    assert _macs(body) == 5 * 3 * 7
 
 
 def test_matmul_batched_macs():
     # A [2, 5, 7], B [7, 3] -> Y [2, 5, 3]; K=7
-    a = _vi("a", [2, 5, 7])
-    b = _weight("b", [7, 3])
-    y = _vi("y", [2, 5, 3])
-    node = helper.make_node("MatMul", ["a", "b"], ["y"])
-    assert _macs([node], [a], [y], [b]) == 2 * 5 * 3 * 7
+    body = """
+    g (float[2,5,7] a) => (float[2,5,3] y)
+    {
+      y = MatMul(a, b)
+    }
+    """
+    macs = _macs(body, [_weight([7, 3], "b")])
+    assert macs == 2 * 5 * 3 * 7
 
 
 # --------------------------------------------------------------------------- #
@@ -107,13 +126,15 @@ def test_matmul_batched_macs():
 # --------------------------------------------------------------------------- #
 def _attention_4d(hq, hkv):
     b, sq, skv, d, dv = 2, 16, 16, 64, 64
-    q = _vi("q", [b, hq, sq, d])
-    k = _vi("k", [b, hkv, skv, d])
-    v = _vi("v", [b, hkv, skv, dv])
-    y = _vi("y", [b, hq, sq, dv])
-    node = helper.make_node("Attention", ["q", "k", "v"], ["y"])
+    body = f"""
+    g (float[{b},{hq},{sq},{d}] q, float[{b},{hkv},{skv},{d}] k,
+       float[{b},{hkv},{skv},{dv}] v) => (float[{b},{hq},{sq},{dv}] y)
+    {{
+      y = Attention(q, k, v)
+    }}
+    """
     expected = b * hq * sq * skv * d + b * hq * sq * skv * dv
-    return _macs([node], [q, k, v], [y]), expected
+    return _macs(body), expected
 
 
 def test_attention_4d_mha():
@@ -129,107 +150,112 @@ def test_attention_4d_gqa_uses_query_heads():
 
 def test_attention_3d_uses_head_attrs():
     b, sq, skv, hidden, heads = 2, 16, 16, 512, 8
-    q = _vi("q", [b, sq, hidden])
-    k = _vi("k", [b, skv, hidden])
-    v = _vi("v", [b, skv, hidden])
-    y = _vi("y", [b, sq, hidden])
-    node = helper.make_node(
-        "Attention", ["q", "k", "v"], ["y"], q_num_heads=heads, kv_num_heads=heads
-    )
+    body = f"""
+    g (float[{b},{sq},{hidden}] q, float[{b},{skv},{hidden}] k,
+       float[{b},{skv},{hidden}] v) => (float[{b},{sq},{hidden}] y)
+    {{
+      y = Attention<q_num_heads={heads}, kv_num_heads={heads}>(q, k, v)
+    }}
+    """
     d = hidden // heads
     expected = b * heads * sq * skv * d + b * heads * sq * skv * d
-    assert _macs([node], [q, k, v], [y]) == expected
+    assert _macs(body) == expected
 
 
 def test_attention_3d_without_head_attrs_is_zero():
     # Head split is unknowable without q_num_heads / kv_num_heads.
     b, sq, hidden = 2, 16, 512
-    q = _vi("q", [b, sq, hidden])
-    k = _vi("k", [b, sq, hidden])
-    v = _vi("v", [b, sq, hidden])
-    y = _vi("y", [b, sq, hidden])
-    node = helper.make_node("Attention", ["q", "k", "v"], ["y"])
-    assert _macs([node], [q, k, v], [y]) == 0
+    body = f"""
+    g (float[{b},{sq},{hidden}] q, float[{b},{sq},{hidden}] k,
+       float[{b},{sq},{hidden}] v) => (float[{b},{sq},{hidden}] y)
+    {{
+      y = Attention(q, k, v)
+    }}
+    """
+    assert _macs(body) == 0
 
 
 # --------------------------------------------------------------------------- #
 # Quantized twins reuse the float formulas at the right operand indices
 # --------------------------------------------------------------------------- #
 def test_matmul_integer_macs():
-    a = _vi("a", [4, 8], TensorProto.UINT8)
-    b = _vi("b", [8, 16], TensorProto.UINT8)
-    y = _vi("y", [4, 16], TensorProto.INT32)
-    node = helper.make_node("MatMulInteger", ["a", "b"], ["y"])
-    assert _macs([node], [a, b], [y], opset=10) == 4 * 16 * 8
+    body = """
+    g (uint8[4,8] a, uint8[8,16] b) => (int32[4,16] y)
+    {
+      y = MatMulInteger(a, b)
+    }
+    """
+    assert _macs(body, opset=10) == 4 * 16 * 8
 
 
 def test_qlinearconv_weight_at_input3():
     # QLinearConv packs weight at input[3]: x, x_s, x_z, w, w_s, w_z, y_s, y_z
-    x = _vi("x", [1, 3, 8, 8], TensorProto.UINT8)
-    w = _vi("w", [4, 3, 3, 3], TensorProto.UINT8)
-    y = _vi("y", [1, 4, 8, 8], TensorProto.UINT8)
-    scalars = [
-        _vi("x_s", []),
-        _vi("x_z", [], TensorProto.UINT8),
-        _vi("w_s", [4]),
-        _vi("w_z", [4], TensorProto.UINT8),
-        _vi("y_s", []),
-        _vi("y_z", [], TensorProto.UINT8),
-    ]
-    node = helper.make_node(
-        "QLinearConv",
-        ["x", "x_s", "x_z", "w", "w_s", "w_z", "y_s", "y_z"],
-        ["y"],
-        kernel_shape=[3, 3],
-        pads=[1, 1, 1, 1],
-    )
-    assert _macs([node], [x] + scalars + [w], [y], opset=10) == 1 * 4 * 8 * 8 * 3 * 9
+    body = """
+    g (uint8[1,3,8,8] x, float x_s, uint8 x_z, uint8[4,3,3,3] w,
+       float[4] w_s, uint8[4] w_z, float y_s, uint8 y_z)
+      => (uint8[1,4,8,8] y)
+    {
+      y = QLinearConv<kernel_shape=[3,3], pads=[1,1,1,1]>(
+        x, x_s, x_z, w, w_s, w_z, y_s, y_z)
+    }
+    """
+    assert _macs(body, opset=10) == 1 * 4 * 8 * 8 * 3 * 9
 
 
 # --------------------------------------------------------------------------- #
 # Unknown / dynamic shapes
 # --------------------------------------------------------------------------- #
 def test_unnamed_dynamic_dim_counts_per_sample():
-    # A batch dim with neither a value nor a name: ONNX shape inference assigns
-    # it a generated symbol (e.g. "unk__0"), so the count is linear in that axis
-    # and collapses to the per-sample MACs when the axis is set to 1.
-    x = _vi("x", [None, 3, 8, 8])
-    w = _weight("w", [4, 3, 3, 3])
-    y = _vi("y", [None, 4, 8, 8])
-    node = helper.make_node(
-        "Conv", ["x", "w"], ["y"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
-    )
-    macs = _macs([node], [x], [y], [w])
+    # A batch dim with neither a value nor a name ("?" in the text format):
+    # ONNX shape inference assigns it a generated symbol (e.g. "unk__0"), so
+    # the count is linear in that axis and collapses to the per-sample MACs
+    # when the axis is set to 1.
+    body = """
+    g (float[?,3,8,8] x) => (float[?,4,8,8] y)
+    {
+      y = Conv<kernel_shape=[3,3], pads=[1,1,1,1]>(x, w)
+    }
+    """
+    macs = _macs(body, [_weight([4, 3, 3, 3], "w")])
     assert model_info._representative_number(macs) == 1 * 4 * 8 * 8 * 3 * 9
 
 
 def test_uninferrable_node_contributes_zero():
-    # When a required operand has no shape at all (empty shape map), the counter
-    # returns 0 rather than guessing.
+    # When a required operand has no shape at all (empty shape map), the
+    # counter returns 0 rather than guessing. This calls the counter
+    # directly with a bare NodeProto, not a full model, so it stays on
+    # onnx.helper rather than onnx.parser.
     node = helper.make_node("Gemm", ["a", "b"], ["y"])
     assert model_info._gemm_macs(node, {}) == 0
 
 
 def test_flops_is_twice_macs():
-    a = _vi("a", [5, 7])
-    b = _vi("b", [7, 3])
-    y = _vi("y", [5, 3])
-    info = ModelInfo(_model([helper.make_node("Gemm", ["a", "b"], ["y"])], [a, b], [y]))
+    body = """
+    g (float[5,7] a, float[7,3] b) => (float[5,3] y)
+    {
+      y = Gemm(a, b)
+    }
+    """
+    info = ModelInfo(_model(body))
     assert info.flops == 2 * info.macs
 
 
 # --------------------------------------------------------------------------- #
 # Symbolic (sympy) path
 # --------------------------------------------------------------------------- #
+def _symbolic_batch_conv_model():
+    body = """
+    g (float[batch,3,8,8] x) => (float[batch,4,8,8] y)
+    {
+      y = Conv<kernel_shape=[3,3], pads=[1,1,1,1]>(x, w)
+    }
+    """
+    return _model(body, [_weight([4, 3, 3, 3], "w")])
+
+
 def test_dynamic_dim_symbolic():
     sympy = pytest.importorskip("sympy")
-    x = _vi("x", ["batch", 3, 8, 8])
-    w = _weight("w", [4, 3, 3, 3])
-    y = _vi("y", ["batch", 4, 8, 8])
-    node = helper.make_node(
-        "Conv", ["x", "w"], ["y"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
-    )
-    macs = ModelInfo(_model([node], [x], [y], [w])).macs
+    macs = ModelInfo(_symbolic_batch_conv_model()).macs
     batch = sympy.Symbol("batch", positive=True, integer=True)
     assert sympy.simplify(macs - 1 * 4 * 8 * 8 * 3 * 9 * batch) == 0
 
@@ -239,12 +265,14 @@ def test_symbolic_dims_unify_across_tensors():
     # attention matmuls combine into a single seq**2 term.
     sympy = pytest.importorskip("sympy")
     b, hq, d = 2, 8, 64
-    q = _vi("q", [b, hq, "seq", d])
-    k = _vi("k", [b, hq, "seq", d])
-    v = _vi("v", [b, hq, "seq", d])
-    y = _vi("y", [b, hq, "seq", d])
-    node = helper.make_node("Attention", ["q", "k", "v"], ["y"])
-    macs = ModelInfo(_model([node], [q, k, v], [y])).macs
+    body = f"""
+    g (float[{b},{hq},seq,{d}] q, float[{b},{hq},seq,{d}] k,
+       float[{b},{hq},seq,{d}] v) => (float[{b},{hq},seq,{d}] y)
+    {{
+      y = Attention(q, k, v)
+    }}
+    """
+    macs = ModelInfo(_model(body)).macs
     seq = sympy.Symbol("seq", positive=True, integer=True)
     assert sympy.simplify(macs - 2 * b * hq * d * seq**2) == 0
 
@@ -257,13 +285,7 @@ def test_symbolic_human_readable_num():
 
 def test_print_simplifying_info_symbolic_does_not_raise():
     pytest.importorskip("sympy")
-    x = _vi("x", ["batch", 3, 8, 8])
-    w = _weight("w", [4, 3, 3, 3])
-    y = _vi("y", ["batch", 4, 8, 8])
-    node = helper.make_node(
-        "Conv", ["x", "w"], ["y"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
-    )
-    model = _model([node], [x], [y], [w])
+    model = _symbolic_batch_conv_model()
     model_info.print_simplifying_info(model, model)  # must not raise on symbolic "<"
 
 
@@ -281,13 +303,7 @@ def test_print_simplifying_info_factor_recursion_error_falls_back(monkeypatch):
 
     monkeypatch.setattr(sympy, "factor", _raise_recursion_error)
 
-    x = _vi("x", ["batch", 3, 8, 8])
-    w = _weight("w", [4, 3, 3, 3])
-    y = _vi("y", ["batch", 4, 8, 8])
-    node = helper.make_node(
-        "Conv", ["x", "w"], ["y"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
-    )
-    model = _model([node], [x], [y], [w])
+    model = _symbolic_batch_conv_model()
     model_info.print_simplifying_info(model, model)  # must not raise
 
     batch = sympy.Symbol("batch")
@@ -357,13 +373,7 @@ def test_representative_number_does_not_use_subs(monkeypatch):
 def test_dynamic_dim_without_sympy_assumes_one(monkeypatch):
     # With sympy unavailable, dynamic dims are assumed 1 (per-sample MACs).
     monkeypatch.setattr(model_info, "sympy", None)
-    x = _vi("x", ["batch", 3, 8, 8])
-    w = _weight("w", [4, 3, 3, 3])
-    y = _vi("y", ["batch", 4, 8, 8])
-    node = helper.make_node(
-        "Conv", ["x", "w"], ["y"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
-    )
-    assert ModelInfo(_model([node], [x], [y], [w])).macs == 1 * 4 * 8 * 8 * 3 * 9
+    assert ModelInfo(_symbolic_batch_conv_model()).macs == 1 * 4 * 8 * 8 * 3 * 9
 
 
 # --------------------------------------------------------------------------- #
@@ -376,23 +386,18 @@ def test_infer_shapes_uses_onnx_shape_inference_when_installed():
     # default), cannot see through -- it should recover "y"'s shape as
     # ["batch", 2, 3] instead of leaving it unknown.
     pytest.importorskip("onnx_shape_inference")
-    x = _vi("x", ["batch", 6])
-    y = _vi("y", None)
-    idx = helper.make_tensor("idx", TensorProto.INT64, [], [0])
-    axes = helper.make_tensor("axes", TensorProto.INT64, [1], [0])
-    two = helper.make_tensor("two", TensorProto.INT64, [1], [2])
-    three = helper.make_tensor("three", TensorProto.INT64, [1], [3])
-    nodes = [
-        helper.make_node("Shape", ["x"], ["x_shape"]),
-        helper.make_node("Gather", ["x_shape", "idx"], ["batch_dim"], axis=0),
-        helper.make_node("Unsqueeze", ["batch_dim", "axes"], ["batch_dim_1"]),
-        helper.make_node(
-            "Concat", ["batch_dim_1", "two", "three"], ["new_shape"], axis=0
-        ),
-        helper.make_node("Reshape", ["x", "new_shape"], ["y"]),
-    ]
-    model = _model(nodes, [x], [y], [idx, axes, two, three])
-    inferred = ModelInfo._infer_shapes(model)
+    body = """
+    g (float[batch,6] x) => (float[] y)
+    <int64 idx = {0}, int64[1] axes = {0}, int64[1] two = {2}, int64[1] three = {3}>
+    {
+      x_shape = Shape(x)
+      batch_dim = Gather<axis=0>(x_shape, idx)
+      batch_dim_1 = Unsqueeze(batch_dim, axes)
+      new_shape = Concat<axis=0>(batch_dim_1, two, three)
+      y = Reshape(x, new_shape)
+    }
+    """
+    inferred = ModelInfo._infer_shapes(_model(body))
     (out,) = [o for o in inferred.graph.output if o.name == "y"]
     dims = list(out.type.tensor_type.shape.dim)
     assert dims[0].dim_param == "batch"
@@ -404,13 +409,14 @@ def test_infer_shapes_falls_back_without_onnx_shape_inference(monkeypatch):
     # With the optional onnx-shape-inference backend unavailable, _infer_shapes
     # must still work via onnx's own shape_inference.
     monkeypatch.setattr(model_info, "infer_symbolic_shapes", None)
-    x = _vi("x", [1, 3, 8, 8])
-    w = _weight("w", [4, 3, 3, 3])
-    y = _vi("y", [1, 4, 8, 8])
-    node = helper.make_node(
-        "Conv", ["x", "w"], ["y"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
-    )
-    inferred = model_info.ModelInfo._infer_shapes(_model([node], [x], [y], [w]))
+    body = """
+    g (float[1,3,8,8] x) => (float[1,4,8,8] y)
+    {
+      y = Conv<kernel_shape=[3,3], pads=[1,1,1,1]>(x, w)
+    }
+    """
+    model = _model(body, [_weight([4, 3, 3, 3], "w")])
+    inferred = model_info.ModelInfo._infer_shapes(model)
     assert any(vi.name == "y" for vi in inferred.graph.output)
 
 
@@ -423,14 +429,15 @@ def test_infer_shapes_falls_back_when_onnx_shape_inference_raises(monkeypatch):
         raise RuntimeError("boom")
 
     monkeypatch.setattr(model_info, "infer_symbolic_shapes", _raise)
-    x = _vi("x", [1, 3, 8, 8])
-    w = _weight("w", [4, 3, 3, 3])
-    y = _vi("y", [1, 4, 8, 8])
-    node = helper.make_node(
-        "Conv", ["x", "w"], ["y"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
-    )
+    body = """
+    g (float[1,3,8,8] x) => (float[1,4,8,8] y)
+    {
+      y = Conv<kernel_shape=[3,3], pads=[1,1,1,1]>(x, w)
+    }
+    """
+    model = _model(body, [_weight([4, 3, 3, 3], "w")])
     with pytest.warns(UserWarning, match="onnx-shape-inference failed"):
-        inferred = ModelInfo._infer_shapes(_model([node], [x], [y], [w]))
+        inferred = ModelInfo._infer_shapes(model)
     assert any(vi.name == "y" for vi in inferred.graph.output)
 
 
@@ -462,61 +469,76 @@ def test_human_readable_size_symbolic():
 # --------------------------------------------------------------------------- #
 # Memory metrics: access traffic, peak footprint, compute density
 # --------------------------------------------------------------------------- #
-def _info(nodes, inputs, outputs, initializers=None, opset=23):
-    return ModelInfo(_model(nodes, inputs, outputs, initializers, opset))
+def _info(body, initializer=(), opset=23):
+    return ModelInfo(_model(body, initializer, opset))
 
 
 def test_memory_access_gemm():
     # float32 tensors: reads a (5*7) + b (7*3), writes y (5*3), 4 bytes each.
-    a = _vi("a", [5, 7])
-    b = _vi("b", [7, 3])
-    y = _vi("y", [5, 3])
-    node = helper.make_node("Gemm", ["a", "b"], ["y"])
+    body = """
+    g (float[5,7] a, float[7,3] b) => (float[5,3] y)
+    {
+      y = Gemm(a, b)
+    }
+    """
     expected = (5 * 7 + 7 * 3 + 5 * 3) * 4
-    assert _info([node], [a, b], [y]).mem_access == expected
+    assert _info(body).mem_access == expected
 
 
 def test_memory_access_counts_weights():
     # A weight fed as an initializer is read from memory, so its bytes count.
-    a = _vi("a", [4, 8])
-    b = _weight("b", [8, 16])
-    y = _vi("y", [4, 16])
-    node = helper.make_node("MatMul", ["a", "b"], ["y"])
+    body = """
+    g (float[4,8] a) => (float[4,16] y)
+    {
+      y = MatMul(a, b)
+    }
+    """
     expected = (4 * 8 + 8 * 16 + 4 * 16) * 4
-    assert _info([node], [a], [y], [b]).mem_access == expected
+    assert _info(body, [_weight([8, 16], "b")]).mem_access == expected
 
 
 def test_memory_access_respects_dtype_size():
     # float16 halves the bytes of the float32 case.
-    a = _vi("a", [5, 7], TensorProto.FLOAT16)
-    b = _vi("b", [7, 3], TensorProto.FLOAT16)
-    y = _vi("y", [5, 3], TensorProto.FLOAT16)
-    node = helper.make_node("Gemm", ["a", "b"], ["y"])
+    body = """
+    g (float16[5,7] a, float16[7,3] b) => (float16[5,3] y)
+    {
+      y = Gemm(a, b)
+    }
+    """
     expected = (5 * 7 + 7 * 3 + 5 * 3) * 2
-    assert _info([node], [a, b], [y]).mem_access == expected
+    assert _info(body).mem_access == expected
 
 
 def test_memory_access_unknown_shape_contributes_zero():
     # An intermediate with no inferred shape simply drops out of the total; the
     # known operands are still counted. No shapes are supplied (empty maps), so
-    # the node's traffic is entirely unknown and totals zero.
+    # the node's traffic is entirely unknown and totals zero. This calls the
+    # counter directly with a bare NodeProto, not a full model, so it stays on
+    # onnx.helper rather than onnx.parser.
     node = helper.make_node("Gemm", ["a", "b"], ["y"])
     assert model_info._node_memory_access(node, {}, {}) == 0
 
 
 def test_compute_density_is_flops_over_bytes():
-    a = _vi("a", [5, 7])
-    b = _vi("b", [7, 3])
-    y = _vi("y", [5, 3])
-    info = _info([helper.make_node("Gemm", ["a", "b"], ["y"])], [a, b], [y])
+    body = """
+    g (float[5,7] a, float[7,3] b) => (float[5,3] y)
+    {
+      y = Gemm(a, b)
+    }
+    """
+    info = _info(body)
     assert info.compute_density == info.flops / info.mem_access
 
 
 def test_compute_density_zero_when_no_traffic():
     # A shapeless model has no measurable traffic, so density is 0 (not a crash).
-    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, None)
-    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, None)
-    info = _info([helper.make_node("Relu", ["x"], ["y"])], [x], [y])
+    body = """
+    g (float[] x) => (float[] y)
+    {
+      y = Relu(x)
+    }
+    """
+    info = _info(body)
     assert info.mem_access == 0
     assert info.compute_density == 0
 
@@ -524,10 +546,13 @@ def test_compute_density_zero_when_no_traffic():
 def test_memory_footprint_single_node():
     # Gemm: inputs a, b live through the node and output y is produced -> peak is
     # every tensor resident at once.
-    a = _vi("a", [5, 7])
-    b = _vi("b", [7, 3])
-    y = _vi("y", [5, 3])
-    info = _info([helper.make_node("Gemm", ["a", "b"], ["y"])], [a, b], [y])
+    body = """
+    g (float[5,7] a, float[7,3] b) => (float[5,3] y)
+    {
+      y = Gemm(a, b)
+    }
+    """
+    info = _info(body)
     assert info.memory_footprint == (5 * 7 + 7 * 3 + 5 * 3) * 4
 
 
@@ -535,16 +560,14 @@ def test_memory_footprint_reuses_freed_activations():
     # x -> Conv -> h -> Relu -> y. x is dead after Conv, so it is not resident
     # during Relu; the peak is the larger of the two per-node working sets, not
     # the sum of every tensor.
-    x = _vi("x", [1, 3, 8, 8])
-    w = _weight("w", [4, 3, 3, 3])
-    y = _vi("y", [1, 4, 8, 8])
-    nodes = [
-        helper.make_node(
-            "Conv", ["x", "w"], ["h"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
-        ),
-        helper.make_node("Relu", ["h"], ["y"]),
-    ]
-    info = _info(nodes, [x], [y], [w])
+    body = """
+    g (float[1,3,8,8] x) => (float[1,4,8,8] y)
+    {
+      h = Conv<kernel_shape=[3,3], pads=[1,1,1,1]>(x, w)
+      y = Relu(h)
+    }
+    """
+    info = _info(body, [_weight([4, 3, 3, 3], "w")])
     b = 4  # float32
     weight_bytes = 4 * 3 * 3 * 3 * b
     x_bytes = 1 * 3 * 8 * 8 * b
@@ -559,10 +582,13 @@ def test_memory_footprint_reuses_freed_activations():
 
 def test_memory_metrics_symbolic_dynamic_batch():
     sympy = pytest.importorskip("sympy")
-    a = _vi("a", ["batch", 7])
-    b = _weight("b", [7, 3])
-    y = _vi("y", ["batch", 3])
-    info = _info([helper.make_node("MatMul", ["a", "b"], ["y"])], [a], [y], [b])
+    body = """
+    g (float[batch,7] a) => (float[batch,3] y)
+    {
+      y = MatMul(a, b)
+    }
+    """
+    info = _info(body, [_weight([7, 3], "b")])
     batch = sympy.Symbol("batch", positive=True, integer=True)
     expected = (7 * batch + 3 * batch) * 4 + (
         7 * 3
@@ -571,10 +597,13 @@ def test_memory_metrics_symbolic_dynamic_batch():
 
 
 def test_memory_metrics_reported_in_summary(capsys):
-    a = _vi("a", [5, 7])
-    b = _vi("b", [7, 3])
-    y = _vi("y", [5, 3])
-    model = _model([helper.make_node("Gemm", ["a", "b"], ["y"])], [a, b], [y])
+    body = """
+    g (float[5,7] a, float[7,3] b) => (float[5,3] y)
+    {
+      y = Gemm(a, b)
+    }
+    """
+    model = _model(body)
     model_info.print_simplifying_info(model, model)
     out = capsys.readouterr().out
     assert "Memory Access" in out
@@ -590,12 +619,13 @@ def _meta(proto):
 
 
 def _gemm_model():
-    a = _vi("a", [5, 7])
-    b = _vi("b", [7, 3])
-    y = _vi("y", [5, 3])
-    return _model(
-        [helper.make_node("Gemm", ["a", "b"], ["y"], name="gemm0")], [a, b], [y]
-    )
+    body = """
+    g (float[5,7] a, float[7,3] b) => (float[5,3] y)
+    {
+      [gemm0] y = Gemm(a, b)
+    }
+    """
+    return _model(body)
 
 
 def test_annotate_metadata_model_level():
@@ -634,10 +664,13 @@ def test_annotate_metadata_value_level():
 
 
 def test_annotate_metadata_annotates_initializers():
-    a = _vi("a", [4, 8])
-    b = _weight("b", [8, 16])
-    y = _vi("y", [4, 16])
-    model = _model([helper.make_node("MatMul", ["a", "b"], ["y"])], [a], [y], [b])
+    body = """
+    g (float[4,8] a) => (float[4,16] y)
+    {
+      y = MatMul(a, b)
+    }
+    """
+    model = _model(body, [_weight([8, 16], "b")])
     out = annotate_metadata(model)
     (init,) = out.graph.initializer
     assert _meta(init)[METADATA_PREFIX + "bytes"] == str(8 * 16 * 4)
@@ -663,12 +696,13 @@ def test_annotate_metadata_custom_prefix():
 
 def test_annotate_metadata_symbolic_stores_formula():
     pytest.importorskip("sympy")
-    a = _vi("a", ["batch", 7])
-    b = _weight("b", [7, 3])
-    y = _vi("y", ["batch", 3])
-    model = _model(
-        [helper.make_node("MatMul", ["a", "b"], ["y"], name="mm")], [a], [y], [b]
-    )
+    body = """
+    g (float[batch,7] a) => (float[batch,3] y)
+    {
+      [mm] y = MatMul(a, b)
+    }
+    """
+    model = _model(body, [_weight([7, 3], "b")])
     out = annotate_metadata(model)
     assert _meta(out.graph.node[0])[METADATA_PREFIX + "macs"] == "21*batch"
     a_vi = next(vi for vi in out.graph.input if vi.name == "a")
@@ -678,25 +712,36 @@ def test_annotate_metadata_symbolic_stores_formula():
 def test_annotate_metadata_recurses_subgraphs():
     # An If whose branches each hold a Gemm: the node inside a branch must be
     # annotated, and the model total must include that branch's MACs.
-    cond = helper.make_tensor_value_info("cond", TensorProto.BOOL, [])
-    y = _vi("y", [5, 3])
+    body = """
+    g (bool cond) => (float[5,3] y)
+    {
+      y = If (cond) <
+        then_branch = then_graph () => (float[5,3] y)
+        {
+          [gemm_t] y = Gemm(a_t, b_t)
+        },
+        else_branch = else_graph () => (float[5,3] y)
+        {
+          [gemm_e] y = Gemm(a_e, b_e)
+        }
+      >
+    }
+    """
+    model = _model(body)
+    if_node = model.graph.node[0]
+    then_g = next(a.g for a in if_node.attribute if a.name == "then_branch")
+    else_g = next(a.g for a in if_node.attribute if a.name == "else_branch")
+    # The branch subgraphs resolve a_t/b_t (a_e/b_e) purely from their own
+    # initializers -- an If's branches take no formal inputs.
+    then_g.initializer.extend([_weight([5, 7], "a_t"), _weight([7, 3], "b_t")])
+    else_g.initializer.extend([_weight([5, 7], "a_e"), _weight([7, 3], "b_e")])
 
-    def branch(name):
-        a = _weight("a_" + name, [5, 7])
-        b = _weight("b_" + name, [7, 3])
-        node = helper.make_node(
-            "Gemm", ["a_" + name, "b_" + name], ["y"], name="gemm_" + name
-        )
-        return helper.make_graph([node], name, [], [_vi("y", [5, 3])], [a, b])
-
-    if_node = helper.make_node(
-        "If", ["cond"], ["y"], then_branch=branch("t"), else_branch=branch("e")
-    )
-    model = _model([if_node], [cond], [y])
     out = annotate_metadata(model)
     # Locate the Gemm inside the then-branch and check it carries metrics.
-    then_g = next(a.g for a in out.graph.node[0].attribute if a.name == "then_branch")
-    gemm = next(n for n in then_g.node if n.op_type == "Gemm")
+    then_out_g = next(
+        a.g for a in out.graph.node[0].attribute if a.name == "then_branch"
+    )
+    gemm = next(n for n in then_out_g.node if n.op_type == "Gemm")
     assert _meta(gemm)[METADATA_PREFIX + "macs"] == str(5 * 3 * 7)
     # Model total counts both branches' Gemms.
     assert _meta(out)[METADATA_PREFIX + "macs"] == str(2 * 5 * 3 * 7)
@@ -714,11 +759,14 @@ def test_warns_when_shape_inference_fails(monkeypatch):
     # plain onnx.shape_inference path (and its failure) regardless of whether
     # onnx-shape-inference happens to be installed.
     monkeypatch.setattr(model_info, "infer_symbolic_shapes", None)
-    x = _vi("x", [1, 4])
-    y = _vi("y", [1, 4])
-    node = helper.make_node("Relu", ["x"], ["y"])
+    body = """
+    g (float[1,4] x) => (float[1,4] y)
+    {
+      y = Relu(x)
+    }
+    """
     with pytest.warns(UserWarning, match="Shape inference failed"):
-        ModelInfo(_model([node], [x], [y]))
+        ModelInfo(_model(body))
 
 
 # There is no "warn when a MAC counter raises" test: the counting is delegated
@@ -731,62 +779,75 @@ def test_warns_when_shape_inference_fails(monkeypatch):
 # --------------------------------------------------------------------------- #
 # Model-local function operators are counted via their bodies
 # --------------------------------------------------------------------------- #
-def _linear_function():
-    # A local function "MyLinear(x, w) -> MatMul(x, w)".
-    return helper.make_function(
-        "custom",
-        "MyLinear",
-        ["x", "w"],
-        ["y"],
-        [helper.make_node("MatMul", ["x", "w"], ["y"])],
-        [helper.make_opsetid("", 18)],
-    )
+_MY_LINEAR_FUNCTION = """
+<
+  domain: "custom",
+  opset_import: ["": 18]
+>
+MyLinear (x, w) => (y)
+{
+  y = MatMul(x, w)
+}
+"""
+
+_BLOCK_FUNCTION = """
+<
+  domain: "custom",
+  opset_import: ["": 18, "custom": 1]
+>
+Block (x, w) => (y)
+{
+  t = custom.MyLinear(x, w)
+  y = Relu(t)
+}
+"""
 
 
-def _function_model(nodes, inputs, outputs, initializers, functions):
-    model = helper.make_model(
-        helper.make_graph(nodes, "g", inputs, outputs, initializers),
-        opset_imports=[helper.make_opsetid("", 18), helper.make_opsetid("custom", 1)],
-        functions=functions,
+def _function_model(body, initializer, functions):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 18, "custom": 1]
+        >
+        {body}
+        {functions}
+        """
     )
+    model.graph.initializer.extend(initializer)
     onnx.checker.check_model(model)
     return model
 
 
 def test_function_body_counted_and_op_kept():
     # MyLinear used twice: op counts show the function op, MACs sum the bodies.
-    x = _vi("X", [4, 8])
-    y = _vi("Y", [4, 32])
-    inits = [_weight("W1", [8, 16]), _weight("W2", [16, 32])]
-    nodes = [
-        helper.make_node("MyLinear", ["X", "W1"], ["H"], domain="custom"),
-        helper.make_node("MyLinear", ["H", "W2"], ["Y"], domain="custom"),
-    ]
-    info = ModelInfo(_function_model(nodes, [x], [y], inits, [_linear_function()]))
+    body = """
+    g (float[4,8] X) => (float[4,32] Y)
+    {
+      H = custom.MyLinear(X, W1)
+      Y = custom.MyLinear(H, W2)
+    }
+    """
+    model = _function_model(
+        body, [_weight([8, 16], "W1"), _weight([16, 32], "W2")], _MY_LINEAR_FUNCTION
+    )
+    info = ModelInfo(model)
     assert info.op_nums["MyLinear"] == 2  # op count keeps the function op
     assert info.macs == 4 * 16 * 8 + 4 * 32 * 16  # MACs come from the bodies
 
 
 def test_nested_function_body_counted():
     # Block(x, w) -> MyLinear(x, w) -> Relu; nested functions are inlined too.
-    inner = _linear_function()
-    outer = helper.make_function(
-        "custom",
-        "Block",
-        ["x", "w"],
-        ["y"],
-        [
-            helper.make_node("MyLinear", ["x", "w"], ["t"], domain="custom"),
-            helper.make_node("Relu", ["t"], ["y"]),
-        ],
-        [helper.make_opsetid("", 18), helper.make_opsetid("custom", 1)],
+    body = """
+    g (float[4,8] X) => (float[4,16] Y)
+    {
+      Y = custom.Block(X, W1)
+    }
+    """
+    model = _function_model(
+        body, [_weight([8, 16], "W1")], _MY_LINEAR_FUNCTION + _BLOCK_FUNCTION
     )
-    x = _vi("X", [4, 8])
-    y = _vi("Y", [4, 16])
-    nodes = [helper.make_node("Block", ["X", "W1"], ["Y"], domain="custom")]
-    info = ModelInfo(
-        _function_model(nodes, [x], [y], [_weight("W1", [8, 16])], [inner, outer])
-    )
+    info = ModelInfo(model)
     assert info.op_nums["Block"] == 1
     assert info.macs == 4 * 16 * 8
 
@@ -798,12 +859,13 @@ def test_warns_when_inlining_fails(monkeypatch):
         raise RuntimeError("inliner boom")
 
     monkeypatch.setattr(onnx.inliner, "inline_local_functions", boom)
-    x = _vi("X", [4, 8])
-    y = _vi("Y", [4, 16])
-    nodes = [helper.make_node("MyLinear", ["X", "W1"], ["Y"], domain="custom")]
-    model = _function_model(
-        nodes, [x], [y], [_weight("W1", [8, 16])], [_linear_function()]
-    )
+    body = """
+    g (float[4,8] X) => (float[4,16] Y)
+    {
+      Y = custom.MyLinear(X, W1)
+    }
+    """
+    model = _function_model(body, [_weight([8, 16], "W1")], _MY_LINEAR_FUNCTION)
     with pytest.warns(UserWarning, match="Failed to expand function bodies"):
         info = ModelInfo(model)
     assert info.macs == 0  # body compute uncounted, but no crash
@@ -814,16 +876,14 @@ def test_schema_function_fallback_counts_attention(monkeypatch):
     # must expand its context-dependent body and count the two internal MatMuls.
     monkeypatch.delitem(model_info._MAC_COUNTERS, "Attention")
     b, h, sq, d = 2, 8, 16, 64
-    q = _vi("Q", [b, h, sq, d])
-    k = _vi("K", [b, h, sq, d])
-    v = _vi("V", [b, h, sq, d])
-    y = _vi("Y", [b, h, sq, d])
-    node = helper.make_node("Attention", ["Q", "K", "V"], ["Y"])
-    model = helper.make_model(
-        helper.make_graph([node], "g", [q, k, v], [y]),
-        opset_imports=[helper.make_opsetid("", 24)],
-    )
-    info = ModelInfo(model)
+    body = f"""
+    g (float[{b},{h},{sq},{d}] Q, float[{b},{h},{sq},{d}] K,
+       float[{b},{h},{sq},{d}] V) => (float[{b},{h},{sq},{d}] Y)
+    {{
+      Y = Attention(Q, K, V)
+    }}
+    """
+    info = ModelInfo(_model(body, opset=24))
     assert info.op_nums["Attention"] == 1  # op count still shows the op
     assert info.macs == b * h * sq * sq * d * 2  # exact, via the expanded body
 
@@ -832,9 +892,13 @@ def test_schema_function_fallback_counts_attention(monkeypatch):
 # Graph diff: node/value level diff between original and simplified graphs
 # --------------------------------------------------------------------------- #
 def test_diff_graphs_unchanged_model_is_empty():
-    x = _vi("x", [1, 4])
-    y = _vi("y", [1, 4])
-    model = _model([helper.make_node("Relu", ["x"], ["y"])], [x], [y])
+    body = """
+    g (float[1,4] x) => (float[1,4] y)
+    {
+      y = Relu(x)
+    }
+    """
+    model = _model(body)
     diff = model_info.diff_graphs(model, model)
     assert diff.removed_nodes == []
     assert diff.added_nodes == []
@@ -845,17 +909,23 @@ def test_diff_graphs_unchanged_model_is_empty():
 
 def test_diff_graphs_detects_removed_and_added_nodes():
     # x -> Identity -> Relu -> y  becomes  x -> Relu -> y (Identity eliminated).
-    x = _vi("x", [1, 4])
-    y = _vi("y", [1, 4])
     ori = _model(
-        [
-            helper.make_node("Identity", ["x"], ["mid"], name="id0"),
-            helper.make_node("Relu", ["mid"], ["y"], name="relu0"),
-        ],
-        [x],
-        [y],
+        """
+        g (float[1,4] x) => (float[1,4] y)
+        {
+          [id0] mid = Identity(x)
+          [relu0] y = Relu(mid)
+        }
+        """
     )
-    opt = _model([helper.make_node("Relu", ["x"], ["y"], name="relu0")], [x], [y])
+    opt = _model(
+        """
+        g (float[1,4] x) => (float[1,4] y)
+        {
+          [relu0] y = Relu(x)
+        }
+        """
+    )
 
     diff = model_info.diff_graphs(ori, opt)
     assert [n.name for n in diff.removed_nodes] == ["id0"]
@@ -871,21 +941,21 @@ def test_diff_graphs_detects_removed_and_added_nodes():
 
 def test_diff_graphs_added_node_from_constant_folding():
     # A Shape node folded away and replaced by a Constant under a new name.
-    x = _vi("x", [1, 4])
-    y = _vi("y", [1])
-    ori = _model([helper.make_node("Shape", ["x"], ["y"], name="shape0")], [x], [y])
+    ori = _model(
+        """
+        g (float[1,4] x) => (float[1] y)
+        {
+          [shape0] y = Shape(x)
+        }
+        """
+    )
     opt = _model(
-        [
-            helper.make_node(
-                "Constant",
-                [],
-                ["y_folded"],
-                name="const0",
-                value=helper.make_tensor("v", TensorProto.INT64, [1], [4]),
-            )
-        ],
-        [x],
-        [_vi("y_folded", [1])],
+        """
+        g (float[1,4] x) => (float[1] y_folded)
+        {
+          [const0] y_folded = Constant<value = int64[1]{4}>()
+        }
+        """
     )
     diff = model_info.diff_graphs(ori, opt)
     assert [n.name for n in diff.removed_nodes] == ["shape0"]
@@ -897,10 +967,22 @@ def test_diff_graphs_added_node_from_constant_folding():
 
 def test_diff_graphs_detects_op_type_change():
     # Same output name "y", but the producing op_type changed.
-    x = _vi("x", [1, 4])
-    y = _vi("y", [1, 4])
-    ori = _model([helper.make_node("Relu", ["x"], ["y"], name="n")], [x], [y])
-    opt = _model([helper.make_node("Sigmoid", ["x"], ["y"], name="n")], [x], [y])
+    ori = _model(
+        """
+        g (float[1,4] x) => (float[1,4] y)
+        {
+          [n] y = Relu(x)
+        }
+        """
+    )
+    opt = _model(
+        """
+        g (float[1,4] x) => (float[1,4] y)
+        {
+          [n] y = Sigmoid(x)
+        }
+        """
+    )
     diff = model_info.diff_graphs(ori, opt)
     assert diff.removed_nodes == []
     assert diff.added_nodes == []
@@ -910,13 +992,23 @@ def test_diff_graphs_detects_op_type_change():
 
 
 def test_diff_graphs_removed_and_added_initializers():
-    x = _vi("x", [4, 8])
-    y = _vi("y", [4, 16])
-    b_ori = _weight("b", [8, 16])
-    ori = _model([helper.make_node("MatMul", ["x", "b"], ["y"])], [x], [y], [b_ori])
-    b_opt = _weight("b_folded", [8, 16])
+    ori = _model(
+        """
+        g (float[4,8] x) => (float[4,16] y)
+        {
+          y = MatMul(x, b)
+        }
+        """,
+        [_weight([8, 16], "b")],
+    )
     opt = _model(
-        [helper.make_node("MatMul", ["x", "b_folded"], ["y"])], [x], [y], [b_opt]
+        """
+        g (float[4,8] x) => (float[4,16] y)
+        {
+          y = MatMul(x, b_folded)
+        }
+        """,
+        [_weight([8, 16], "b_folded")],
     )
     diff = model_info.diff_graphs(ori, opt)
     assert diff.removed_values == ["b"]
@@ -924,17 +1016,23 @@ def test_diff_graphs_removed_and_added_initializers():
 
 
 def test_print_graph_diff_does_not_raise(capsys):
-    x = _vi("x", [1, 4])
-    y = _vi("y", [1, 4])
     ori = _model(
-        [
-            helper.make_node("Identity", ["x"], ["mid"], name="id0"),
-            helper.make_node("Relu", ["mid"], ["y"], name="relu0"),
-        ],
-        [x],
-        [y],
+        """
+        g (float[1,4] x) => (float[1,4] y)
+        {
+          [id0] mid = Identity(x)
+          [relu0] y = Relu(mid)
+        }
+        """
     )
-    opt = _model([helper.make_node("Relu", ["x"], ["y"], name="relu0")], [x], [y])
+    opt = _model(
+        """
+        g (float[1,4] x) => (float[1,4] y)
+        {
+          [relu0] y = Relu(x)
+        }
+        """
+    )
     model_info.print_graph_diff(ori, opt)
     out = capsys.readouterr().out
     assert "Nodes removed" in out
@@ -944,13 +1042,25 @@ def test_print_graph_diff_does_not_raise(capsys):
 
 
 def test_print_graph_diff_caps_output(capsys):
-    x = _vi("x", [1, 4])
-    ori_nodes = [
-        helper.make_node("Identity", ["x"], [f"mid{i}"], name=f"id{i}")
-        for i in range(5)
-    ]
-    ori = _model(ori_nodes, [x], [_vi("mid0", [1, 4])])
-    opt = _model([], [x], [_vi("x", [1, 4])])
+    ori = _model(
+        """
+        g (float[1,4] x) => (float[1,4] mid0)
+        {
+          [id0] mid0 = Identity(x)
+          [id1] mid1 = Identity(x)
+          [id2] mid2 = Identity(x)
+          [id3] mid3 = Identity(x)
+          [id4] mid4 = Identity(x)
+        }
+        """
+    )
+    opt = _model(
+        """
+        g (float[1,4] x) => (float[1,4] x)
+        {
+        }
+        """
+    )
     model_info.print_graph_diff(ori, opt, limit=2)
     out = capsys.readouterr().out
     assert "... and" in out
@@ -958,16 +1068,11 @@ def test_print_graph_diff_caps_output(capsys):
 
 def test_schema_function_fallback_layernorm_is_zero():
     # A context-dependent function with no matmuls must expand cleanly to 0 MACs.
-    x = _vi("X", [4, 16])
-    node = helper.make_node("LayerNormalization", ["X", "scale", "bias"], ["Y"])
-    model = helper.make_model(
-        helper.make_graph(
-            [node],
-            "g",
-            [x],
-            [_vi("Y", [4, 16])],
-            [_weight("scale", [16]), _weight("bias", [16])],
-        ),
-        opset_imports=[helper.make_opsetid("", 17)],
-    )
+    body = """
+    g (float[4,16] X) => (float[4,16] Y)
+    {
+      Y = LayerNormalization(X, scale, bias)
+    }
+    """
+    model = _model(body, [_weight([16], "scale"), _weight([16], "bias")], opset=17)
     assert ModelInfo(model).macs == 0


### PR DESCRIPTION
## Summary

Rebuilds the ~25 model-info tests (MACs/FLOPs counting, memory metrics, metadata annotation, graph diff, function-body counting) on `onnx.parser.parse_model` instead of `onnx.helper.make_node`/`make_graph`/`make_model` chains, following the same `_model(body, initializer=(), opset=..., ir_version=...)` helper used in the other already-migrated test files (`tests/test_python_api.py`, `tests/test_fusion_patterns.py`, `tests/test_pruning.py`, `tests/test_qoperator_quantize_matmul.py`).

Notable spots:
- The file's own "no shape at all" cases (unranked value info, and the unnamed/valueless dynamic dim in the Conv MAC test) turn out to be directly expressible in the text format itself (`float[] x` and `float[?,...] x`), so no `onnx.helper` fallback was needed there after all.
- Zero-filled weight tensors stay built via `numpy_helper.from_array` and attached as initializers after parsing -- spelling out tensors with dozens to hundreds of elements as text literals isn't practical, and the parser's literal broadcasting doesn't fill a tensor from a single value.
- `If`/subgraph and model-local-function tests use the text format's inline branch-graph and trailing function-definition syntax; branch-local weight initializers are still attached post-parse for the same size reason as above.
- Two tests that build a bare `NodeProto` to call an internal counter directly (not a full model) keep `onnx.helper.make_node`, since there's no graph/model for the text format to describe.

No test semantics changed -- only how the input models are constructed.

## Test plan
- [x] `ruff check tests/test_model_info.py` and `ruff format --check tests/test_model_info.py` clean
- [x] `pytest tests/test_model_info.py -q` -- 61 passed, 2 skipped (identical to before the change)
- [x] `mypy tests/test_model_info.py` -- same 19 pre-existing errors in unrelated files, none in this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7


---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_