### PR TITLE
Add apply_double_quantization: QLoRA-style second-level scale quantization

### DIFF
--- a/docs/double-quantization.md
+++ b/docs/double-quantization.md
@@ -1,0 +1,97 @@
+# Double quantization (`apply_double_quantization`)
+
+## What this is
+
+`onnxsim.apply_double_quantization` is a second pass over an
+**already-quantized** onnx model: it finds every `DequantizeLinear` node
+whose scale is a sizable constant tensor (a per-block or per-channel
+scale, as every onnxsim block-wise INT4 scheme produces) and quantizes
+*that scale tensor itself* to UINT8, reconstructing it in-graph via a
+second, nested `DequantizeLinear`.
+
+```
+Before:
+  Whatever_hat = DequantizeLinear(Codes, Scale, ...)  -- Scale: float32, [blocks, N]
+
+After:
+  ScaleCodes: initializer, uint8, [blocks, N]
+  MetaScale: initializer, float32 scalar
+  ScaleHat = DequantizeLinear(ScaleCodes, MetaScale)
+  Whatever_hat = DequantizeLinear(Codes, ScaleHat, ...)  -- same attributes as before
+```
+
+A block of 32 INT4 codes needs 16 bytes of codes plus 4 bytes of its own
+float32 scale -- a 25% overhead on top of the codes themselves. Since
+those scale values are already absmax-normalized magnitudes (a much
+milder dynamic range than raw weights), quantizing them too trades a
+little more precision for real additional memory savings, without
+touching the original low-bit codes at all.
+
+## Where this comes from
+
+[QLoRA](https://arxiv.org/abs/2305.14314) (Dettmers et al., 2023, Section
+3.2) introduces double quantization as part of its own 4-bit NormalFloat
+scheme: after block-wise quantizing the weight, it quantizes the
+per-block scale factors themselves with an 8-bit quantizer (with its own
+observation that this saves roughly 0.37 bits/parameter on average across
+a whole model). This module reproduces that second-level idea directly,
+generically, as a standalone pass over any model's existing
+`DequantizeLinear` nodes -- it doesn't know or care which onnxsim module
+produced the outer node (or its `axis`/`block_size` attributes, left
+untouched), only that its scale input is a sufficiently large constant
+tensor. That makes it compose with every block-wise scheme already in
+onnxsim (`quantize_weight_only_int4`, `onnxsim.nf4`, `onnxsim.spqr`,
+`onnxsim.spinquant`, `onnxsim.quarot`, `onnxsim.quip_sharp`) unchanged,
+and with future ones with no new code -- unlike every other module in
+this package, `apply_double_quantization` has no live weights of its own
+to quantize; it only ever post-processes another quantizer's own output.
+
+Since scale values are always non-negative (absmax-derived magnitudes),
+the inner quantizer uses a plain unsigned `0..255` range with no
+zero-point offset (`codes = round(scale / meta_scale)`,
+`meta_scale = max(scale) / 255`) rather than the signed, symmetric ranges
+every other onnxsim INT4 scheme uses for weights -- the two quantization
+problems (weights, which are signed and roughly zero-centered; scales,
+which are strictly positive) call for different ranges.
+
+## Scope
+
+Handled:
+
+- Any `DequantizeLinear` node whose scale input (`node.input[1]`) is a
+  constant float32 initializer with at least `min_elements` values
+  (default 64) -- regardless of which module produced it, or what its
+  `axis`/`block_size` attributes are.
+
+Left untouched (safe no-op, node passes through as-is):
+
+- A scale smaller than `min_elements` (e.g. a single per-tensor scalar):
+  a second quantizer's own overhead (a meta-scale initializer plus a new
+  node) would cost more than it saves.
+- A scale that is not a constant initializer -- e.g. a dynamically
+  computed scale, like `quantize_kv_cache`'s Value-style per-token scale
+  stream, which is a graph input/output, not a constant.
+- A model with no `DequantizeLinear` node at all.
+
+The original float32 scale initializer is left in the graph, unreferenced
+(matching every other onnxsim rewrite, which leaves its own now-unused
+original tensor in place) -- pair this with `onnxsim.simplify()` (or any
+generic dead-initializer elimination) afterward to actually reclaim the
+storage the original float32 scale used.
+
+## Usage
+
+```python
+import onnx
+import onnxsim
+
+model = onnx.load("model.onnx")
+quantized = onnxsim.apply_quarot(model)          # or apply_spinquant,
+                                                   # quantize_weight_only_spqr,
+                                                   # quantize_weight_only_int4, ...
+doubly_quantized = onnxsim.apply_double_quantization(quantized)
+onnx.save(doubly_quantized, "model.doubleq.onnx")
+```
+
+Run this as the *last* step after any other quantizer -- it operates on
+`DequantizeLinear` nodes that must already exist in the graph.

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -30,6 +30,7 @@ from onnxsim.calibration import (
     quantize_static,
     quantize_static_int16,
 )
+from onnxsim.double_quantization import apply_double_quantization
 from onnxsim.embedding_quantization import (
     quantize_embedding_binary,
     quantize_embedding_int8,
@@ -141,6 +142,7 @@ __all__ = [
     "quantize_weight_only_squeezellm",
     "quantize_weight_only_aqlm",
     "quantize_weight_only_spqr",
+    "apply_double_quantization",
     "quantize_kv_cache",
     "quantize_embedding_binary",
     "quantize_embedding_int8",

--- a/onnxsim/double_quantization.py
+++ b/onnxsim/double_quantization.py
@@ -1,0 +1,143 @@
+"""Double quantization (Dettmers et al., 2023, "QLoRA: Efficient Finetuning
+of Quantized LLMs", https://arxiv.org/abs/2305.14314, Section 3.2). onnxsim
+ports the idea, not any framework's code, per the same rationale as the
+rest of this package's PTQ modules -- but unlike every other module here,
+this one has no "live weights" to quantize at all: it operates purely on
+an *already-quantized* onnx model, as a second pass.
+
+Every block-wise INT4/INT4-like scheme in onnxsim (`quantize_weight_only_int4`,
+:mod:`onnxsim.nf4`, :mod:`onnxsim.spqr`, :mod:`onnxsim.spinquant`,
+:mod:`onnxsim.quarot`, :mod:`onnxsim.quip_sharp`) stores one float32 scale
+per quantization block, alongside the packed low-bit codes -- e.g. a
+32-element block of INT4 codes needs 16 bytes of codes plus 4 bytes of
+scale, a 25% overhead on top of the codes themselves. QLoRA's own
+observation: those scale factors are themselves just numbers with their
+own, much milder, dynamic range (they're already absmax-normalized
+magnitudes, not raw weights) -- so quantizing *them* too, one more level
+down, trades a little more precision for real additional memory savings,
+without touching the original codes at all.
+
+This module implements that second level directly: for every
+``DequantizeLinear`` node already in the graph whose scale input is a
+constant float32 initializer with at least ``min_elements`` values (a
+per-block or per-channel scale tensor -- a single scalar per-tensor scale
+isn't worth the overhead of a second quantizer around it), the scale
+tensor itself is quantized to UINT8 with a single per-tensor meta-scale
+(``codes = round(scale / meta_scale)``, ``meta_scale = max(scale) / 255``
+-- scale values are always non-negative absmax-derived magnitudes, so a
+plain unsigned 0..255 range needs no zero-point offset) and reconstructed
+in-graph via a second, nested ``DequantizeLinear(codes_uint8, meta_scale)``
+feeding into the original node's own scale input:
+
+    Before:
+      Whatever_hat = DequantizeLinear(Codes, Scale, ...)  -- Scale: float32, [blocks, N]
+
+    After:
+      ScaleCodes: initializer, uint8, [blocks, N]
+      MetaScale: initializer, float32 scalar
+      ScaleHat = DequantizeLinear(ScaleCodes, MetaScale)
+      Whatever_hat = DequantizeLinear(Codes, ScaleHat, ...)  -- same attributes as before
+
+This is technique-agnostic: it doesn't know or care which module produced
+the outer ``DequantizeLinear`` (or its ``axis``/``block_size`` attributes,
+left untouched), only that its scale input is a sufficiently large constant
+tensor -- so it composes with every block-wise scheme above unchanged, and
+with future ones with no new code. The original float32 scale initializer
+is left in the graph, unreferenced, exactly like every other onnxsim
+rewrite leaves its own now-unused original weight initializer in place
+(e.g. :mod:`onnxsim.spinquant`'s original float32 ``W``) -- pair this with
+:func:`onnxsim.simplify` (or any generic dead-initializer elimination)
+afterward to actually reclaim the storage the original float32 scale used.
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+
+from onnxsim.bias_correction import _all_names, _unique_name
+
+
+def apply_double_quantization(
+    model: Union[str, onnx.ModelProto],
+    min_elements: int = 64,
+) -> onnx.ModelProto:
+    """Applies QLoRA-style double quantization (see this module's own
+    docstring) to every ``DequantizeLinear`` node already present in
+    ``model`` whose scale input is a constant float32 tensor with at
+    least ``min_elements`` values.
+
+    :param model: an already-quantized onnx ModelProto or file path (the
+            output of any onnxsim block-wise/per-channel quantizer, or
+            any other model containing ``DequantizeLinear`` nodes)
+    :param min_elements: minimum element count a ``DequantizeLinear``
+            node's scale tensor must have to be worth double-quantizing;
+            a smaller scale tensor (e.g. a single per-tensor scalar) is
+            left untouched, since a second quantizer's own overhead
+            (a meta-scale initializer plus a new node) would cost more
+            than it saves
+    :returns: ``model`` with every matched ``DequantizeLinear`` node's
+            scale input replaced by a UINT8-quantized-and-dequantized
+            reconstruction of the original scale values (see the module
+            docstring's diagram); all other node attributes (``axis``,
+            ``block_size``, etc.) unchanged. A scale that is not a
+            constant initializer (e.g. a dynamically-computed scale, like
+            :func:`onnxsim.quantize_kv_cache`'s Value-style per-token
+            scale), not float32, or too small, is left untouched; a model
+            with no matching node is returned unchanged
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    graph = out.graph
+    initializer_map = {t.name: t for t in graph.initializer}
+    taken_names = _all_names(graph)
+
+    candidates = []
+    for node in graph.node:
+        if node.op_type != "DequantizeLinear" or len(node.input) < 2:
+            continue
+        scale_init = initializer_map.get(node.input[1])
+        if scale_init is None or scale_init.data_type != onnx.TensorProto.FLOAT:
+            continue
+        scale = onnx.numpy_helper.to_array(scale_init)
+        if scale.size < min_elements:
+            continue
+        candidates.append((node, scale_init, scale))
+
+    if not candidates:
+        return out
+
+    for node, scale_init, scale in candidates:
+        scale64 = scale.astype(np.float64)
+        meta_scale = max(float(np.abs(scale64).max()), 1e-12) / 255.0
+        codes = np.clip(np.round(scale64 / meta_scale), 0, 255).astype(np.uint8)
+
+        prefix = f"{scale_init.name}_dblq"
+        codes_name = _unique_name(f"{prefix}_codes", taken_names)
+        graph.initializer.append(onnx.numpy_helper.from_array(codes, name=codes_name))
+        meta_scale_name = _unique_name(f"{prefix}_meta_scale", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(
+                np.array(meta_scale, dtype=np.float32), name=meta_scale_name
+            )
+        )
+
+        scale_hat_name = _unique_name(f"{prefix}_scale_hat", taken_names)
+        dequant_node = onnx.helper.make_node(
+            "DequantizeLinear",
+            [codes_name, meta_scale_name],
+            [scale_hat_name],
+            name=_unique_name(f"{prefix}_scale_hat_node", taken_names),
+        )
+        node_idx = next(i for i, n in enumerate(graph.node) if n is node)
+        graph.node.insert(node_idx, dequant_node)
+        node.input[1] = scale_hat_name
+
+    return out

--- a/tests/test_double_quantization.py
+++ b/tests/test_double_quantization.py
@@ -1,0 +1,156 @@
+"""Tests for ``onnxsim.apply_double_quantization`` -- see
+``onnxsim/double_quantization.py`` for the technique (QLoRA-style
+second-level UINT8 quantization of an already-quantized model's own
+per-block/per-channel scale tensors).
+"""
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _vi(name, shape, elem_type=onnx.TensorProto.FLOAT):
+    return onnx.helper.make_tensor_value_info(name, elem_type, shape)
+
+
+def _model(nodes, inputs, outputs, initializer, opset=21):
+    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+    )
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _blockwise_int4_model(k=32, n=8, block_size=8, seed=0):
+    # Mirrors quantize_weight_only_int4's own output shape: INT4 codes
+    # [K, N], scale [K/block_size, N], DequantizeLinear(axis=0, block_size).
+    rng = np.random.default_rng(seed)
+    codes = rng.integers(-7, 8, size=(k, n)).astype(np.int8)
+    scale = (rng.random((k // block_size, n)).astype(np.float32) + 0.1) * 0.05
+
+    codes_tensor = onnx.TensorProto()
+    codes_tensor.name = "codes"
+    codes_tensor.data_type = onnx.TensorProto.INT4
+    codes_tensor.dims.extend([k, n])
+    # Pack the same way onnxsim.adaround._pack_int4 does: two nibbles per
+    # byte, little-endian within the byte, row-major over a flattened
+    # [k, n] array -- reuse the real helper for exactness.
+    from onnxsim.adaround import _pack_int4
+
+    codes_tensor.raw_data = _pack_int4(codes.astype(np.int64))
+
+    nodes = [
+        onnx.helper.make_node(
+            "DequantizeLinear",
+            ["codes", "scale"],
+            ["w_hat"],
+            axis=0,
+            block_size=block_size,
+        ),
+        onnx.helper.make_node("MatMul", ["X", "w_hat"], ["Y"]),
+    ]
+    return _model(
+        nodes,
+        [_vi("X", ["batch", k])],
+        [_vi("Y", ["batch", n])],
+        [codes_tensor, onnx.numpy_helper.from_array(scale, name="scale")],
+    )
+
+
+def test_double_quantization_inserts_nested_dequantize_and_keeps_output_close():
+    model = _blockwise_int4_model(k=64, n=8, block_size=8, seed=0)
+    onnx.checker.check_model(model)
+    q = onnxsim.apply_double_quantization(model, min_elements=4)
+    onnx.checker.check_model(q)
+
+    op_types = [n.op_type for n in q.graph.node]
+    assert op_types.count("DequantizeLinear") == 2
+
+    rng = np.random.default_rng(1)
+    x = rng.standard_normal((4, 64)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x})
+    (q_y,) = _run(q, {"X": x})
+    rel = np.linalg.norm(float_y - q_y) / max(np.linalg.norm(float_y), 1e-6)
+    assert rel < 0.05
+
+
+def test_double_quantization_scale_codes_are_uint8():
+    model = _blockwise_int4_model(k=64, n=8, block_size=8, seed=2)
+    q = onnxsim.apply_double_quantization(model, min_elements=4)
+    codes_init = next(t for t in q.graph.initializer if t.name.endswith("_dblq_codes"))
+    assert codes_init.data_type == onnx.TensorProto.UINT8
+    codes = onnx.numpy_helper.to_array(codes_init)
+    assert codes.min() >= 0 and codes.max() <= 255
+
+
+def test_double_quantization_declines_small_scale_tensor():
+    # Default min_elements=64; an 8-element scale tensor isn't worth it.
+    model = _blockwise_int4_model(k=64, n=1, block_size=8, seed=3)
+    q = onnxsim.apply_double_quantization(model)  # default min_elements
+    assert q.SerializeToString() == model.SerializeToString()
+
+
+def test_double_quantization_declines_dynamic_scale_input():
+    # A scale fed by a graph input (not a constant initializer) -- e.g.
+    # quantize_kv_cache's Value-style per-token scale stream -- is left
+    # untouched: there is nothing to fold into a constant meta-scale.
+    nodes = [
+        onnx.helper.make_node("DequantizeLinear", ["codes", "scale"], ["w_hat"]),
+    ]
+    codes = np.zeros((8, 8), dtype=np.int8)
+    codes_tensor = onnx.TensorProto()
+    codes_tensor.name = "codes"
+    codes_tensor.data_type = onnx.TensorProto.INT4
+    codes_tensor.dims.extend([8, 8])
+    from onnxsim.adaround import _pack_int4
+
+    codes_tensor.raw_data = _pack_int4(codes.astype(np.int64))
+    model = _model(
+        nodes,
+        [_vi("scale", [8, 8])],
+        [_vi("w_hat", [8, 8])],
+        [codes_tensor],
+    )
+    q = onnxsim.apply_double_quantization(model, min_elements=4)
+    assert q.SerializeToString() == model.SerializeToString()
+
+
+def test_double_quantization_noop_without_dequantize_linear():
+    nodes = [onnx.helper.make_node("Relu", ["X"], ["Y"])]
+    model = _model(nodes, [_vi("X", [4, 4])], [_vi("Y", [4, 4])], [])
+    result = onnxsim.apply_double_quantization(model)
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_double_quantization_composes_with_spinquant():
+    rng = np.random.default_rng(4)
+    K, N = 32, 8
+    weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(
+        nodes,
+        [_vi("X", ["batch", K])],
+        [_vi("Y", ["batch", N])],
+        [onnx.numpy_helper.from_array(weight, name="W")],
+    )
+    spun = onnxsim.apply_spinquant(model, block_size=8, num_samples=16, seed=5)
+    both = onnxsim.apply_double_quantization(spun, min_elements=4)
+    onnx.checker.check_model(both)
+
+    x = rng.standard_normal((4, K)).astype(np.float32)
+    (spun_y,) = _run(spun, {"X": x})
+    (both_y,) = _run(both, {"X": x})
+    rel = np.linalg.norm(spun_y - both_y) / max(np.linalg.norm(spun_y), 1e-6)
+    assert rel < 0.05


### PR DESCRIPTION
## Summary

- Adds `onnxsim.apply_double_quantization`, porting [QLoRA](https://arxiv.org/abs/2305.14314)'s (Dettmers et al., 2023, Section 3.2) "double quantization" idea — quantizing a block-wise quantizer's own scale factors, one more level down, for real additional memory savings.
- Every block-wise INT4 scheme in onnxsim (`quantize_weight_only_int4`, `onnxsim.nf4`, `onnxsim.spqr`, `onnxsim.spinquant`, `onnxsim.quarot`, `onnxsim.quip_sharp`) stores one float32 scale per quantization block alongside the packed codes — a 25% overhead on top of a 32-element INT4 block. Since those scale values are already absmax-normalized magnitudes (a much milder dynamic range than raw weights), quantizing them too to UINT8 trades a little more precision for real extra savings.
- Unlike every other module in this package, this one has **no live weights to quantize at all** — it's a standalone second pass over an *already-quantized* model: it finds every `DequantizeLinear` node whose scale is a sizable constant tensor (`min_elements`, default 64) and quantizes that scale to UINT8 with a single per-tensor meta-scale, reconstructed via a nested `DequantizeLinear`.
- Technique-agnostic by construction — it only inspects a matched node's scale-tensor shape, not which module produced it or its `axis`/`block_size` attributes, so it composes with every block-wise scheme above unchanged, and with future ones with no new code.

## Test plan

- [x] `tests/test_double_quantization.py` (6 new tests): output stays close after the nested round-trip, scale codes are genuinely UINT8, composes with `apply_spinquant`'s own output end-to-end, and decline paths (a scale below `min_elements`, a dynamically-computed/non-constant scale like `quantize_kv_cache`'s Value-style stream, no `DequantizeLinear` present at all).
- [x] Full regression sweep (`pytest tests/ --ignore=tests/test_torch_export.py --ignore=tests/test_timm.py`): 889 passed, 69 skipped, 0 failed.
- [x] `ruff format` / `ruff check --fix` / `mypy` clean on new/changed files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_