### PR TITLE
Disable coverage workflow on pull requests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - master
-  pull_request:
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Remove the `pull_request` trigger from the coverage workflow to prevent it from running on every pull request.

## Summary
The coverage workflow is now only triggered on pushes to `main`/`master` branches and manual workflow dispatch, rather than on every pull request. This reduces unnecessary CI runs and focuses coverage reporting on the main branches.

## Changes
- Removed `pull_request:` trigger from `.github/workflows/coverage.yml`

The workflow will continue to run on:
- Pushes to `main` and `master` branches
- Manual workflow dispatch via `workflow_dispatch`

https://claude.ai/code/session_018puk4ddArLKnXBzPtN8mhh