### PR TITLE
tests: migrate test_double_quantization.py to onnx.parser

### DIFF
--- a/tests/test_double_quantization.py
+++ b/tests/test_double_quantization.py
@@ -6,24 +6,27 @@ per-block/per-channel scale tensors).
 
 import numpy as np
 import onnx
-import onnx.helper
 import onnx.numpy_helper
 import pytest
+from onnx import parser
 
 import onnxsim
 
 ort = pytest.importorskip("onnxruntime")
 
 
-def _vi(name, shape, elem_type=onnx.TensorProto.FLOAT):
-    return onnx.helper.make_tensor_value_info(name, elem_type, shape)
-
-
-def _model(nodes, inputs, outputs, initializer, opset=21):
-    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
-    return onnx.helper.make_model(
-        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
     )
+    model.graph.initializer.extend(initializer)
+    return model
 
 
 def _run(model, feeds):
@@ -33,6 +36,22 @@ def _run(model, feeds):
     return sess.run(None, feeds)
 
 
+def _int4_codes_tensor(codes, name="codes"):
+    # onnx.helper (not the text parser) because these need to be byte-equal
+    # to onnxsim.adaround._pack_int4's own packed-nibble encoding: the
+    # parser has no INT4 tensor literal syntax that lets us hand it
+    # pre-packed raw_data directly.
+    tensor = onnx.TensorProto()
+    tensor.name = name
+    tensor.data_type = onnx.TensorProto.INT4
+    tensor.dims.extend(codes.shape)
+
+    from onnxsim.adaround import _pack_int4
+
+    tensor.raw_data = _pack_int4(codes.astype(np.int64))
+    return tensor
+
+
 def _blockwise_int4_model(k=32, n=8, block_size=8, seed=0):
     # Mirrors quantize_weight_only_int4's own output shape: INT4 codes
     # [K, N], scale [K/block_size, N], DequantizeLinear(axis=0, block_size).
@@ -40,32 +59,18 @@ def _blockwise_int4_model(k=32, n=8, block_size=8, seed=0):
     codes = rng.integers(-7, 8, size=(k, n)).astype(np.int8)
     scale = (rng.random((k // block_size, n)).astype(np.float32) + 0.1) * 0.05
 
-    codes_tensor = onnx.TensorProto()
-    codes_tensor.name = "codes"
-    codes_tensor.data_type = onnx.TensorProto.INT4
-    codes_tensor.dims.extend([k, n])
-    # Pack the same way onnxsim.adaround._pack_int4 does: two nibbles per
-    # byte, little-endian within the byte, row-major over a flattened
-    # [k, n] array -- reuse the real helper for exactness.
-    from onnxsim.adaround import _pack_int4
-
-    codes_tensor.raw_data = _pack_int4(codes.astype(np.int64))
-
-    nodes = [
-        onnx.helper.make_node(
-            "DequantizeLinear",
-            ["codes", "scale"],
-            ["w_hat"],
-            axis=0,
-            block_size=block_size,
-        ),
-        onnx.helper.make_node("MatMul", ["X", "w_hat"], ["Y"]),
-    ]
     return _model(
-        nodes,
-        [_vi("X", ["batch", k])],
-        [_vi("Y", ["batch", n])],
-        [codes_tensor, onnx.numpy_helper.from_array(scale, name="scale")],
+        f"""
+        g (float[batch,{k}] X) => (float[batch,{n}] Y)
+        {{
+          w_hat = DequantizeLinear<axis=0, block_size={block_size}>(codes, scale)
+          Y = MatMul(X, w_hat)
+        }}
+        """,
+        initializer=[
+            _int4_codes_tensor(codes),
+            onnx.numpy_helper.from_array(scale, name="scale"),
+        ],
     )
 
 
@@ -106,30 +111,29 @@ def test_double_quantization_declines_dynamic_scale_input():
     # A scale fed by a graph input (not a constant initializer) -- e.g.
     # quantize_kv_cache's Value-style per-token scale stream -- is left
     # untouched: there is nothing to fold into a constant meta-scale.
-    nodes = [
-        onnx.helper.make_node("DequantizeLinear", ["codes", "scale"], ["w_hat"]),
-    ]
     codes = np.zeros((8, 8), dtype=np.int8)
-    codes_tensor = onnx.TensorProto()
-    codes_tensor.name = "codes"
-    codes_tensor.data_type = onnx.TensorProto.INT4
-    codes_tensor.dims.extend([8, 8])
-    from onnxsim.adaround import _pack_int4
-
-    codes_tensor.raw_data = _pack_int4(codes.astype(np.int64))
     model = _model(
-        nodes,
-        [_vi("scale", [8, 8])],
-        [_vi("w_hat", [8, 8])],
-        [codes_tensor],
+        """
+        g (float[8,8] scale) => (float[8,8] w_hat)
+        {
+          w_hat = DequantizeLinear(codes, scale)
+        }
+        """,
+        initializer=[_int4_codes_tensor(codes)],
     )
     q = onnxsim.apply_double_quantization(model, min_elements=4)
     assert q.SerializeToString() == model.SerializeToString()
 
 
 def test_double_quantization_noop_without_dequantize_linear():
-    nodes = [onnx.helper.make_node("Relu", ["X"], ["Y"])]
-    model = _model(nodes, [_vi("X", [4, 4])], [_vi("Y", [4, 4])], [])
+    model = _model(
+        """
+        g (float[4,4] X) => (float[4,4] Y)
+        {
+          Y = Relu(X)
+        }
+        """
+    )
     result = onnxsim.apply_double_quantization(model)
     assert result.SerializeToString() == model.SerializeToString()
 
@@ -138,12 +142,14 @@ def test_double_quantization_composes_with_spinquant():
     rng = np.random.default_rng(4)
     K, N = 32, 8
     weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
-    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
     model = _model(
-        nodes,
-        [_vi("X", ["batch", K])],
-        [_vi("Y", ["batch", N])],
-        [onnx.numpy_helper.from_array(weight, name="W")],
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[onnx.numpy_helper.from_array(weight, name="W")],
     )
     spun = onnxsim.apply_spinquant(model, block_size=8, num_samples=16, seed=5)
     both = onnxsim.apply_double_quantization(spun, min_elements=4)


### PR DESCRIPTION
Replaces the `onnx.helper.make_node`/`make_graph`/`make_model` chains in
`tests/test_double_quantization.py` with `onnx.parser.parse_model` text-format
construction, per the repo-wide migration documented in `CLAUDE.md`.

- Adds the standard `_model(body, initializer=(), opset=21, ir_version=10)`
  helper wrapping `parser.parse_model`, matching the pattern already used
  in `test_spinquant.py`, `test_spqr.py`, and the other migrated test_*.py
  files.
- `_blockwise_int4_model`'s random scale array stays as a numpy-built
  `onnx.numpy_helper.from_array` initializer attached after parsing.
- The packed-INT4 codes tensors are the one `onnx.helper` exception here:
  they must be byte-equal to `onnxsim.adaround._pack_int4`'s own
  nibble-packed `raw_data`, and the parser has no INT4 tensor literal
  syntax for pre-packed raw data. Factored the shared construction into a
  small `_int4_codes_tensor` helper with a comment explaining why.
- The two tests that previously hand-built ad hoc graphs via `_vi`/
  `make_node` (`test_double_quantization_declines_dynamic_scale_input`,
  `test_double_quantization_noop_without_dequantize_linear`,
  `test_double_quantization_composes_with_spinquant`) now use inline
  parser text bodies.

No test semantics or coverage changed -- same 6 tests, same assertions.
Verified with `ruff check`/`ruff format --check` and
`pytest tests/test_double_quantization.py -q` (6 passed, matching the
pre-migration run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBV456YjzEc2GTaoGXrf7)_