### PR TITLE
Add apply_mixed_precision_quantization: sensitivity-based per-layer bit width

### DIFF
--- a/docs/mixed-precision.md
+++ b/docs/mixed-precision.md
@@ -1,0 +1,92 @@
+# Mixed-precision quantization (`apply_mixed_precision_quantization`)
+
+## What this is
+
+`onnxsim.apply_mixed_precision_quantization` assigns **different bit
+widths to different layers** within one model, chosen from a
+calibration-driven sensitivity score, rather than applying one uniform
+scheme everywhere the way every other onnxsim quantizer does.
+
+```
+Before:
+  Y = MatMul(X, W) [+ bias]    -- one of many layers, W constant, float32
+
+After (per layer, chosen independently):
+  Whigh_hat = DequantizeLinear(Wq_int8, Ws, axis=0, block_size=32)  -- sensitive layers
+  Wlow_hat  = DequantizeLinear(Wq_int4, Ws, axis=0, block_size=32)  -- everything else
+  Y = MatMul(X, W*_hat) [+ bias]
+```
+
+## Where this comes from
+
+`onnxsim.quantize_weight_only_int4` (and everything built on it) applies
+block-wise INT4 to *every* matched layer; `onnxsim.recommend_quantization`
+searches across *global* schemes (try INT4-everywhere, then
+INT8-everywhere, ...) and returns whichever single one meets an accuracy
+budget. Neither assigns different bit widths to different layers within
+the *same* model -- which leaves real compression on the table: in any
+real network, some layers are far more sensitive to quantization error
+than others (the premise behind the mixed-precision/bit-width-search
+literature -- e.g. HAQ, and the per-layer outlier analysis behind
+`onnxsim.llm_int8`/`onnxsim.spqr`), so spending the same number of bits on
+every layer either wastes precision on layers that tolerate INT4 fine, or
+loses too much on the few layers that don't.
+
+This module is deliberately not a new *algorithm* the way
+`apply_spinquant`/`apply_duquant` are -- it is a dispatcher over two
+schemes onnxsim already has (block-wise INT4 and, for the most sensitive
+layers, block-wise INT8), choosing which one each layer gets from a
+data-driven sensitivity score:
+
+```
+mse = mean((W - INT4_dequant(W))^2)     -- INT4's own reconstruction error
+sensitivity = mse * mean(X^2)           -- scaled by typical input magnitude
+```
+
+`mean(X^2)` is the same per-layer activation-energy signal
+`apply_duquant`'s own sensitivity ranking is built on (there, per-channel;
+here, a single per-layer scalar, since the decision being made -- INT4 vs
+INT8 -- is per-layer, not per-channel). Layers are ranked by this score;
+the top `high_bits_fraction` (by count, most sensitive first) get
+block-wise INT8; every other layer gets ordinary block-wise INT4.
+
+## Scope
+
+Handled:
+
+- `MatMul(X, W)` with `W` a constant 2-D float32 tensor whose reduction
+  dimension `K` is divisible by `block_size`, or `Gemm(X, W[, B])` with
+  `transA=0`, `alpha=1`, `beta=1` (when `B` is present) under the same
+  weight constraint. `transB` may be 0 or 1.
+- Opsets >= 21 (INT4's tensor type and `DequantizeLinear`'s `block_size`
+  attribute both need opset 21).
+- `high_bits_fraction=0.0` quantizes every layer to INT4 (matching
+  `quantize_weight_only_int4`'s own behavior); `1.0` quantizes every layer
+  to INT8.
+
+Left untouched (safe no-op, node passes through as-is):
+
+- Non-constant weights, non-2-D weights, or a reduction dimension not
+  divisible by `block_size`.
+- A layer whose activation never appeared in any calibration batch (no
+  data to compute a sensitivity score from).
+- A model with no matching layer, or an opset older than 21.
+
+## Usage
+
+```python
+import onnx
+import onnxsim
+
+model = onnx.load("model.onnx")
+quantized = onnxsim.apply_mixed_precision_quantization(
+    model, high_bits_fraction=0.2, num_samples=32
+)
+onnx.save(quantized, "model.mixedprec.onnx")
+```
+
+`calibration_data` defaults to `onnxsim.generate_random_calibration_data`;
+pass real representative batches (e.g. via
+`onnxsim.load_huggingface_calibration_data`) for a sensitivity ranking
+that reflects the model's own real activation statistics, since the
+INT8/INT4 split depends on `mean(X^2)`, not just the weight itself.

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -45,6 +45,7 @@ from onnxsim.hqq import quantize_weight_only_int4_hqq
 from onnxsim.kv_cache_quantization import quantize_kv_cache
 from onnxsim.llm_int8 import apply_llm_int8
 from onnxsim.low_rank_compensation import apply_low_rank_compensation
+from onnxsim.mixed_precision import apply_mixed_precision_quantization
 from onnxsim.nf4 import NF4_CODEBOOK, quantize_weight_only_nf4
 from onnxsim.omniquant import apply_omniquant
 from onnxsim.onnx_simplifier import (
@@ -117,6 +118,7 @@ __all__ = [
     "apply_smoothquant",
     "apply_llm_int8",
     "apply_low_rank_compensation",
+    "apply_mixed_precision_quantization",
     "apply_quip_sharp",
     "apply_quarot",
     "apply_duquant",

--- a/onnxsim/mixed_precision.py
+++ b/onnxsim/mixed_precision.py
@@ -1,0 +1,301 @@
+"""Sensitivity-based mixed-precision weight quantization.
+
+Every quantizer already in onnxsim applies **one uniform scheme to the
+whole model**: :func:`onnxsim.quantize_weight_only_int4` block-INT4s every
+matched layer, :func:`onnxsim.accuracy.recommend_quantization` searches
+across *global* schemes (try INT4-everywhere, then INT8-everywhere, ...)
+and returns whichever single one meets the accuracy budget -- but nothing
+in onnxsim assigns *different* bit-widths to *different layers* within one
+model. That leaves real compression on the table: in any real network,
+some layers are far more sensitive to quantization error than others (the
+premise behind the mixed-precision/bit-width-search literature -- e.g.
+HAQ, Dettmers & Zettlemoyer's LLM.int8() outlier analysis, GPTQ's own
+per-layer error reporting), so spending the same number of bits on every
+layer either wastes precision on layers that tolerate INT4 fine, or loses
+too much on the few layers that don't.
+
+This module is deliberately not a new *algorithm* the way
+:mod:`onnxsim.spinquant`/:mod:`onnxsim.duquant` are -- it is a dispatcher
+over two schemes onnxsim already has (block-wise INT4 and, for the most
+sensitive layers, block-wise INT8), choosing which one each layer gets
+from a data-driven **sensitivity score**, then reusing existing
+graph-construction machinery for both.
+
+**The sensitivity score.** For a layer with weight ``W`` and calibration
+activation ``X``, this asks "how much would this layer's *output* change
+if ``W`` were quantized to INT4?" -- not just "how big is the raw
+quantization error", which ignores that a layer whose input is typically
+tiny barely matters even with a large per-weight error. Concretely:
+
+    mse = mean((W - INT4_dequant(W))^2)     -- INT4's own reconstruction error
+    sensitivity = mse * mean(X^2)           -- scaled by typical input magnitude
+
+``mean(X^2)`` is the same per-layer activation-energy signal
+:mod:`onnxsim.duquant`'s own sensitivity ranking is built on (there,
+per-channel; here, a single per-layer scalar, since the decision being
+made -- INT4 vs INT8 -- is per-layer, not per-channel). Layers are ranked
+by this score; the top ``high_bits_fraction`` (by count, most sensitive
+first) get block-wise INT8 (:func:`onnxsim.quantize_weight_only_int8_block`'s
+own granularity, reimplemented locally here since that function quantizes
+a whole model uniformly and can't be dispatched per-layer); every other
+layer gets ordinary block-wise INT4
+(:mod:`onnxsim.omniquant`'s own ``_quantize_blockwise_int4_with_clip``,
+the same backend :mod:`onnxsim.spinquant`/:mod:`onnxsim.spqr` already use).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Sequence, Union
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+
+from onnxsim import backend
+from onnxsim.adaround import _pack_int4
+from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.calibration import Tensors, generate_random_calibration_data
+from onnxsim.omniquant import _quantize_blockwise_int4_with_clip
+from onnxsim.quip_sharp import _match_matmul_like
+
+
+def _has_min_opset(model: onnx.ModelProto, min_version: int) -> bool:
+    return any(
+        o.domain in ("", "ai.onnx") and o.version >= min_version
+        for o in model.opset_import
+    )
+
+
+def _quantize_blockwise_int8(
+    w_nk: np.ndarray, block_size: int
+) -> "tuple[np.ndarray, np.ndarray]":
+    """Round-to-nearest block-wise INT8 (``[-127, 127]``) quantization of
+    ``w_nk`` ([N, K], output channel first) -- the same granularity
+    :func:`onnxsim.quantize_weight_only_int8_block` uses, reimplemented
+    here (rather than reused) since that function quantizes a whole model
+    uniformly and this module needs to apply it to only some layers.
+    """
+    n, k = w_nk.shape
+    num_blocks = k // block_size
+    blocks = w_nk.reshape(n, num_blocks, block_size)
+    scale_blocks = np.maximum(np.abs(blocks).max(axis=2), 1e-12) / 127.0
+    scale_full = np.repeat(scale_blocks, block_size, axis=1)
+    codes_nk = np.clip(np.round(w_nk / scale_full), -127.0, 127.0)
+    return codes_nk, scale_blocks
+
+
+def apply_mixed_precision_quantization(
+    model: Union[str, onnx.ModelProto],
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_samples: int = 8,
+    seed: int = 0,
+    high_bits_fraction: float = 0.2,
+    block_size: int = 32,
+    providers: Optional[Sequence[str]] = None,
+) -> onnx.ModelProto:
+    """Quantizes every MatMul/vanilla-Gemm layer with a constant 2-D
+    float32 weight whose reduction dimension ``K`` is divisible by
+    ``block_size`` to either block-wise INT8 or block-wise INT4, chosen
+    per layer from a calibration-driven sensitivity score -- see this
+    module's own docstring.
+
+    :param model: the original (unquantized) onnx ModelProto or file path
+    :param calibration_data: representative input batches (each a
+            ``{input_name: np.ndarray}`` dict matching ``model``'s graph
+            inputs) used to measure each layer's own typical activation
+            magnitude -- see :func:`onnxsim.generate_random_calibration_data`
+            (the default when omitted) and
+            :func:`onnxsim.load_huggingface_calibration_data` (real data,
+            a more representative ranking than random input)
+    :param num_samples: random batches to generate when ``calibration_data``
+            is omitted
+    :param seed: seed for the random calibration data (ignored if
+            ``calibration_data`` is supplied)
+    :param high_bits_fraction: fraction of matched layers (by count, most
+            sensitive first) that get block-wise INT8 instead of INT4;
+            ``0.0`` quantizes every layer to INT4 (matching
+            :func:`onnxsim.quantize_weight_only_int4`'s own behavior),
+            ``1.0`` quantizes every layer to INT8
+    :param block_size: elements per quantization block along ``K``, for
+            both the INT4 and INT8 tiers -- matching
+            :func:`onnxsim.quantize_weight_only_int4`'s own default
+    :param providers: onnxruntime execution providers to run calibration on
+    :returns: ``model`` with every matched layer's weight replaced by
+            block-wise INT4 or INT8 codes plus a per-block float32 scale
+            (``DequantizeLinear(..., axis=0, block_size=block_size)``);
+            output tensor name unchanged. Layers with a non-constant,
+            non-2-D weight, a reduction dimension not divisible by
+            ``block_size``, or no calibration activation available, are
+            left untouched; a model with no matching layer, or an opset
+            older than 21 (INT4's tensor type and ``DequantizeLinear``'s
+            ``block_size`` attribute both need opset 21), is returned
+            unchanged
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    if not _has_min_opset(model, 21):
+        return model
+
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    graph = out.graph
+    initializer_map = {t.name: t for t in graph.initializer}
+    taken_names = _all_names(graph)
+
+    nodes = list(graph.node)
+    candidates = []
+    for node in nodes:
+        match = _match_matmul_like(node)
+        if match is None:
+            continue
+        x_name, w_name, bias_name, weight_transposed = match
+        w_init = initializer_map.get(w_name)
+        if (
+            w_init is None
+            or w_init.data_type != onnx.TensorProto.FLOAT
+            or len(w_init.dims) != 2
+        ):
+            continue
+        dims = list(w_init.dims)
+        w_nk_shape = dims if weight_transposed else dims[::-1]
+        if w_nk_shape[1] % block_size != 0:
+            continue
+        candidates.append((node, x_name, w_name, bias_name, weight_transposed))
+
+    if not candidates:
+        return out
+
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            model, num_samples=num_samples, seed=seed
+        )
+
+    probe_names = sorted({x_name for _, x_name, _, _, _ in candidates})
+    probe_model = _add_probe_outputs(model, probe_names)
+    mean_x_sq: Dict[str, float] = {}
+    counts: Dict[str, int] = {}
+    for batch in calibration_data:
+        result = backend.run_model(probe_model, batch, providers=providers)
+        for name in probe_names:
+            x = np.asarray(result[name], dtype=np.float64)
+            total = float(np.sum(x**2))
+            mean_x_sq[name] = mean_x_sq.get(name, 0.0) + total
+            counts[name] = counts.get(name, 0) + x.size
+
+    for name in list(mean_x_sq):
+        if counts[name] > 0:
+            mean_x_sq[name] /= counts[name]
+
+    # Sensitivity per candidate: how much INT4 quantization error this
+    # layer's weight would have, scaled by that layer's own typical
+    # (calibration) input magnitude -- see module docstring.
+    sensitivities: List[Optional[float]] = []
+    for node, x_name, w_name, bias_name, weight_transposed in candidates:
+        if x_name not in mean_x_sq:
+            sensitivities.append(None)
+            continue
+        w_init = initializer_map[w_name]
+        w = onnx.numpy_helper.to_array(w_init).astype(np.float64)
+        w_nk = w if weight_transposed else w.T  # [N, K]
+        codes_nk, scale_blocks_nk = _quantize_blockwise_int4_with_clip(
+            w_nk, block_size, 1.0
+        )
+        scale_full = np.repeat(scale_blocks_nk, block_size, axis=1)
+        dequant_nk = codes_nk * scale_full
+        mse = float(np.mean((w_nk - dequant_nk) ** 2))
+        sensitivities.append(mse * mean_x_sq[x_name])
+
+    eligible_idx = [i for i, s in enumerate(sensitivities) if s is not None]
+    eligible_idx.sort(key=lambda i: sensitivities[i] or 0.0, reverse=True)
+    num_high_bits = int(round(high_bits_fraction * len(eligible_idx)))
+    high_bits_set = set(eligible_idx[:num_high_bits])
+
+    for idx, (node, x_name, w_name, bias_name, weight_transposed) in enumerate(
+        candidates
+    ):
+        if idx not in eligible_idx:
+            continue
+
+        w_init = initializer_map[w_name]
+        w = onnx.numpy_helper.to_array(w_init).astype(np.float64)
+        w_nk = w if weight_transposed else w.T  # [N, K]
+        n, k = w_nk.shape
+
+        use_int8 = idx in high_bits_set
+        if use_int8:
+            codes_nk, scale_blocks_nk = _quantize_blockwise_int8(w_nk, block_size)
+            codes_dtype = onnx.TensorProto.INT8
+            prefix = f"{w_name}_mixedprec_int8"
+        else:
+            codes_nk, scale_blocks_nk = _quantize_blockwise_int4_with_clip(
+                w_nk, block_size, 1.0
+            )
+            codes_dtype = onnx.TensorProto.INT4
+            prefix = f"{w_name}_mixedprec_int4"
+
+        codes_kn = codes_nk.T.astype(np.int64)  # [K, N], ready for a plain MatMul
+        scale_kn = scale_blocks_nk.T.astype(np.float32)  # [K/block_size, N]
+
+        codes_name = _unique_name(f"{prefix}_codes", taken_names)
+        codes_tensor = onnx.TensorProto()
+        codes_tensor.name = codes_name
+        codes_tensor.data_type = codes_dtype
+        codes_tensor.dims.extend([k, n])
+        if codes_dtype == onnx.TensorProto.INT4:
+            codes_tensor.raw_data = _pack_int4(codes_kn)
+        else:
+            codes_tensor.raw_data = codes_kn.astype(np.int8).tobytes()
+        graph.initializer.append(codes_tensor)
+
+        scale_name = _unique_name(f"{prefix}_scale", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(scale_kn, name=scale_name)
+        )
+
+        new_nodes: List[onnx.NodeProto] = []
+
+        def _new(op_type, inputs, out_suffix, **attrs):
+            out_name = _unique_name(f"{prefix}_{out_suffix}", taken_names)
+            n_ = onnx.helper.make_node(
+                op_type,
+                inputs,
+                [out_name],
+                name=_unique_name(f"{prefix}_{out_suffix}_node", taken_names),
+                **attrs,
+            )
+            new_nodes.append(n_)
+            return out_name
+
+        w_dequant = _new(
+            "DequantizeLinear",
+            [codes_name, scale_name],
+            "w_dequant",
+            axis=0,
+            block_size=block_size,
+        )
+        core = _new("MatMul", [x_name, w_dequant], "core")
+
+        old_output = node.output[0]
+        if bias_name is not None:
+            final = onnx.helper.make_node(
+                "Add",
+                [core, bias_name],
+                [old_output],
+                name=_unique_name(f"{prefix}_bias_add_node", taken_names),
+            )
+        else:
+            final = onnx.helper.make_node(
+                "Identity",
+                [core],
+                [old_output],
+                name=_unique_name(f"{prefix}_identity_node", taken_names),
+            )
+        new_nodes.append(final)
+
+        node_idx = next(i for i, n_ in enumerate(graph.node) if n_ is node)
+        for offset, new_node in enumerate(new_nodes):
+            graph.node.insert(node_idx + offset, new_node)
+        del graph.node[node_idx + len(new_nodes)]
+
+    return out

--- a/tests/test_mixed_precision.py
+++ b/tests/test_mixed_precision.py
@@ -1,0 +1,147 @@
+"""Tests for ``onnxsim.apply_mixed_precision_quantization`` -- see
+``onnxsim/mixed_precision.py`` for the technique (calibration-driven
+per-layer choice between block-wise INT8 and block-wise INT4).
+"""
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _model(nodes, inputs, outputs, initializer, opset=21):
+    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+    )
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
+
+
+def _two_layer_model(K=32, H=16, N=8, seed=0, opset=21):
+    rng = np.random.default_rng(seed)
+    w1 = rng.standard_normal((K, H)).astype(np.float32) * 0.5
+    # w2's rows get planted, large-magnitude outliers, making it far more
+    # sensitive to INT4 quantization than w1 -- so a good sensitivity
+    # ranking should pick THIS layer for the INT8 tier.
+    w2 = rng.standard_normal((H, N)).astype(np.float32) * 0.05
+    w2[0, :] = 20.0
+    nodes = [
+        onnx.helper.make_node("MatMul", ["X", "W1"], ["H1"]),
+        onnx.helper.make_node("MatMul", ["H1", "W2"], ["Y"]),
+    ]
+    return _model(
+        nodes,
+        [_vi("X", ["batch", K])],
+        [_vi("Y", ["batch", N])],
+        [_f32(w1, "W1"), _f32(w2, "W2")],
+        opset=opset,
+    )
+
+
+def test_mixed_precision_output_stays_close_to_float_via_onnxruntime():
+    model = _two_layer_model(K=32, H=16, N=8, seed=0)
+    q = onnxsim.apply_mixed_precision_quantization(
+        model, block_size=8, high_bits_fraction=0.5, num_samples=16, seed=1
+    )
+    onnx.checker.check_model(q)
+
+    rng = np.random.default_rng(2)
+    x = rng.standard_normal((8, 32)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x})
+    (q_y,) = _run(q, {"X": x})
+    assert np.all(np.isfinite(q_y))
+    assert _rel_l2(float_y, q_y) < 0.3
+
+
+def test_mixed_precision_picks_the_more_sensitive_layer_for_int8():
+    model = _two_layer_model(K=32, H=16, N=8, seed=3)
+    q = onnxsim.apply_mixed_precision_quantization(
+        model, block_size=8, high_bits_fraction=0.5, num_samples=32, seed=4
+    )
+    codes_by_prefix = {
+        t.name: t for t in q.graph.initializer if t.name.endswith("_codes")
+    }
+    w2_codes = next(t for name, t in codes_by_prefix.items() if name.startswith("W2_"))
+    w1_codes = next(t for name, t in codes_by_prefix.items() if name.startswith("W1_"))
+    # W2 has the planted outlier row -- it must be the INT8 (more precise)
+    # tier, while the ordinary W1 stays at INT4.
+    assert w2_codes.data_type == onnx.TensorProto.INT8
+    assert w1_codes.data_type == onnx.TensorProto.INT4
+
+
+def test_mixed_precision_zero_fraction_matches_all_int4():
+    model = _two_layer_model(K=32, H=16, N=8, seed=5)
+    q = onnxsim.apply_mixed_precision_quantization(
+        model, block_size=8, high_bits_fraction=0.0, num_samples=16, seed=6
+    )
+    codes = [t for t in q.graph.initializer if t.name.endswith("_codes")]
+    assert len(codes) == 2
+    assert all(t.data_type == onnx.TensorProto.INT4 for t in codes)
+
+
+def test_mixed_precision_one_fraction_matches_all_int8():
+    model = _two_layer_model(K=32, H=16, N=8, seed=7)
+    q = onnxsim.apply_mixed_precision_quantization(
+        model, block_size=8, high_bits_fraction=1.0, num_samples=16, seed=8
+    )
+    codes = [t for t in q.graph.initializer if t.name.endswith("_codes")]
+    assert len(codes) == 2
+    assert all(t.data_type == onnx.TensorProto.INT8 for t in codes)
+
+
+def test_mixed_precision_declines_when_k_not_divisible_by_block_size():
+    rng = np.random.default_rng(9)
+    weight = rng.standard_normal((20, 4)).astype(np.float32)  # 20 not a multiple of 8
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(
+        nodes, [_vi("X", ["batch", 20])], [_vi("Y", ["batch", 4])], [_f32(weight, "W")]
+    )
+    q = onnxsim.apply_mixed_precision_quantization(model, block_size=8)
+    assert q.SerializeToString() == model.SerializeToString()
+
+
+def test_mixed_precision_declines_non_constant_weight():
+    nodes = [onnx.helper.make_node("MatMul", ["X", "W"], ["Y"])]
+    model = _model(
+        nodes, [_vi("X", [4, 32]), _vi("W", [32, 4])], [_vi("Y", [4, 4])], []
+    )
+    q = onnxsim.apply_mixed_precision_quantization(model)
+    assert q.SerializeToString() == model.SerializeToString()
+
+
+def test_mixed_precision_noop_when_no_matmul_present():
+    nodes = [onnx.helper.make_node("Relu", ["X"], ["Y"])]
+    model = _model(nodes, [_vi("X", [4, 4])], [_vi("Y", [4, 4])], [])
+    result = onnxsim.apply_mixed_precision_quantization(model)
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_mixed_precision_declines_below_opset21():
+    model = _two_layer_model(K=32, H=16, N=8, opset=13)
+    result = onnxsim.apply_mixed_precision_quantization(model)
+    assert result.SerializeToString() == model.SerializeToString()


### PR DESCRIPTION
## Summary

- Adds `onnxsim.apply_mixed_precision_quantization` — assigns **different bit widths to different layers** within one model, chosen from a calibration-driven sensitivity score, rather than applying one uniform scheme model-wide the way every other onnxsim quantizer does.
- Every existing quantizer applies one scheme to every matched layer; `onnxsim.recommend_quantization` searches across *global* schemes (try INT4-everywhere, then INT8-everywhere, ...) but still picks one single winner for the whole model. Neither assigns different bit widths to different layers within the *same* model — leaving real compression on the table, since some layers are far more sensitive to quantization error than others.
- This module is deliberately not a new algorithm the way `apply_spinquant`/`apply_duquant` are — it's a **dispatcher** over two schemes onnxsim already has. For each layer: `sensitivity = mse(INT4_dequant(W), W) * mean(calibration_X^2)` — how much INT4 quantization would actually perturb that layer's *output*, not just the raw weight error. The top `high_bits_fraction` (most sensitive, by count) get block-wise INT8 (reimplemented locally here, since `quantize_weight_only_int8_block` quantizes a whole model uniformly and can't be dispatched per-layer); everything else gets ordinary block-wise INT4 (reusing `onnxsim.omniquant`'s own `_quantize_blockwise_int4_with_clip`, the same backend `apply_spinquant`/`quantize_weight_only_spqr` already use).

## Test plan

- [x] `tests/test_mixed_precision.py` (8 new tests): float-vs-quantized closeness via onnxruntime, a direct check that a layer with a planted outlier row gets routed to the INT8 tier while an ordinary layer stays INT4, `high_bits_fraction=0.0`/`1.0` boundary behavior, and decline paths (K not divisible by block_size, non-constant weight, no matching op, opset < 21).
- [x] Full regression sweep (`pytest tests/ --ignore=tests/test_torch_export.py --ignore=tests/test_timm.py`): 922 passed, 69 skipped, 0 failed.
- [x] `ruff format` / `ruff check --fix` / `mypy` clean on new/changed files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_