### PR TITLE
Recognize SkipLayerNormalization/SkipSimplifiedLayerNormalization as MatMul/Gemm residual merge points

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -2545,15 +2545,24 @@ def _find_conv_residual_chains(graph: onnx.GraphProto) -> List[_Chain]:
 # for whether pruning keeps those values meaningful for whatever reads them,
 # so it declines outright rather than guessing, same as everywhere else in
 # this pass. The optional fourth output, `input_skip_bias_sum` (the raw,
-# pre-normalization sum), needs no special handling at all: this pass never
-# reads it, and in the common post-LN transformer shape a later residual
-# connection's own `skip` operand is simply the *previous*
-# `SkipLayerNormalization`'s ordinary (normalized) `output` -- not that raw
-# sum -- so the very same "resolves to another eligible merge node's raw
-# output" backward-walk case :func:`_walk_matmul_producer_backward` already
-# handles for a chain of bare `Add`s (the "many residual blocks share one
-# spine" case) covers a chain of `SkipLayerNormalization` nodes for free,
-# with no dedicated code of its own.
+# pre-normalization sum), gets the same "declines if consumed" treatment,
+# for a different reason: this pass never reads it itself, and in the
+# common post-LN transformer shape a later residual connection's own `skip`
+# operand is simply the *previous* `SkipLayerNormalization`'s ordinary
+# (normalized) `output` -- not that raw sum -- so the "resolves to another
+# eligible merge node's raw output" backward-walk case
+# :func:`_walk_matmul_producer_backward` already handles for a chain of
+# bare `Add`s covers a chain of `SkipLayerNormalization` nodes for free.
+# But if *something else* in the graph reads `input_skip_bias_sum`
+# directly, pruning still changes its width -- it's a plain runtime sum of
+# `input`/`skip`, so it naturally comes out however wide those two end up
+# post-pruning, no static array to reslice -- and this pass has no way to
+# confirm that other consumer expects the new width rather than the
+# original one (confirmed concretely: a second graph output reading it
+# directly ends up with a shape mismatch against its own originally
+# declared shape). So it's declined whenever consumed by anything, the
+# same conservative bar `mean`/`inv_std_var` get, just for a shape reason
+# rather than a values-still-meaningful one.
 
 
 _SKIP_LAYER_NORM_OPS = ("SkipLayerNormalization", "SkipSimplifiedLayerNormalization")
@@ -2649,12 +2658,25 @@ def _match_matmul_residual_merge(
 
     Declines (``None``) the same way :func:`_skip_layer_norm_const_names`
     does for a non-constant/tied `gamma`/`beta`/`bias`, and additionally
-    whenever the op's optional `mean`/`inv_std_var` outputs (training-only;
-    onnxruntime's own CPU kernel never actually writes them, see this
-    section's own comment) are actually consumed by anything else in the
-    graph: this pass has no basis for whether pruning keeps those still
-    meaningful for whatever reads them, so it declines outright rather than
-    guessing, the same conservative bar this module draws everywhere else.
+    whenever any of the op's optional secondary outputs -- `mean`/
+    `inv_std_var` (training-only; onnxruntime's own CPU kernel never
+    actually writes them) *or* `input_skip_bias_sum` (the raw pre-norm sum)
+    -- are actually consumed by anything else in the graph. `mean`/
+    `inv_std_var`: this pass has no basis for whether pruning keeps those
+    still meaningful for whatever reads them. `input_skip_bias_sum` is
+    different in kind -- this pass never reads it itself, and its *shape*
+    (not its meaningfulness) is what's at risk: it naturally comes out
+    however wide `input`/`skip` end up post-pruning (a plain runtime sum of
+    two already-consistently-pruned tensors, nothing to reslice), but any
+    *other* consumer of it outside this chain has no idea that width just
+    changed and may expect the original one -- confirmed concretely: a
+    second graph output reading it directly ends up with a shape mismatch
+    against its own originally-declared shape once pruned. So this output
+    is held to the same "not consumed elsewhere" bar as `mean`/
+    `inv_std_var`, not because its value would be wrong, but because
+    nothing here can confirm whatever reads it still expects the resulting
+    shape -- the same "no basis to guess a shape survives" reasoning this
+    module already applies to fan-out generally.
     """
     if _is_eligible_add_merge(node, initializer_map):
         return (node.input[0], node.input[1]), ()
@@ -2681,7 +2703,7 @@ def _match_matmul_residual_merge(
         return None
     gamma_name, beta_name, bias_name = const_names
 
-    for out_idx in (1, 2):  # mean, inv_std_var: training-only, see docstring
+    for out_idx in (1, 2, 3):  # mean, inv_std_var, input_skip_bias_sum
         if len(node.output) > out_idx and node.output[out_idx]:
             out_name = node.output[out_idx]
             if consumers_of.get(out_name) or out_name in graph_outputs:

--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -82,6 +82,24 @@ special handling at all, since the backward walk stops at that projection's
 own MatMul/Gemm node without ever looking further upstream at what feeds
 it.
 
+A bare `Add` merge point is, however, the exception rather than the rule
+once a transformer has actually been run through onnxruntime's own
+transformer-optimizer tool: that pass fuses each residual `Add` (plus an
+optional per-channel bias `Add`) together with the *following*
+`LayerNorm`/RMSNorm into one ``com.microsoft::SkipLayerNormalization``/
+``SkipSimplifiedLayerNormalization`` node, so
+:func:`_match_matmul_residual_merge` recognizes that fused node as an
+eligible merge point too -- its `input`/`skip` inputs playing `Add`'s own
+two-operand role -- while also treating it as a per-channel affine hop
+whose `gamma` (required) and, if present, `beta` (``SkipLayerNormalization``
+only, dropped by the RMSNorm variant) and `bias` get sliced by the group's
+own `keep` set alongside everything else. See
+:func:`_find_matmul_residual_chains`'s own section comment for the exact
+fused arithmetic (confirmed against onnxruntime's own kernel source and by
+direct execution) and how a non-constant/tied `gamma`/`beta`/`bias`, or a
+consumed optional `mean`/`inv_std_var` output, is declined the same
+conservative way as everything above.
+
 General multi-branch dependency-graph pruning -- arbitrary fan-out, non-Add
 merges (`Concat`, ...) -- remains out of scope. The
 other part of the paper's pipeline -- an architecture *search* over what to prune,
@@ -2483,6 +2501,196 @@ def _find_conv_residual_chains(graph: onnx.GraphProto) -> List[_Chain]:
 #   MatMul/Gemm producer), never looking any further upstream at what feeds
 #   `Wo`. See
 #   `test_structured_pruning_matmul_residual_add_declines_on_bare_gqa_shortcut`.
+#
+# A bare `Add` is not, in practice, what the realistic target for this whole
+# residual mechanism -- a transformer already run through onnxruntime's own
+# transformer-optimizer tool, the same optimization pass that produces the
+# `com.microsoft::Attention`/`GroupQueryAttention` fused ops this module
+# already targets elsewhere -- actually has at each residual connection: that
+# optimizer fuses `Add(input, skip)` (plus an optional per-channel bias
+# `Add`) and the *following* `LayerNorm`/`SimplifiedLayerNormalization` into
+# one `com.microsoft::SkipLayerNormalization`/`SkipSimplifiedLayerNormalization`
+# node (`skip_layer_norm.cc`'s own `ComputeJob`, confirmed against
+# onnxruntime's schema (`bert_defs.cc`) and by direct execution --
+# `sum = input + skip (+ bias)`; `SkipLayerNormalization` computes ordinary
+# LayerNorm on `sum` (population mean/variance, `* gamma + beta` if `beta`
+# is given); `SkipSimplifiedLayerNormalization` -- the RMSNorm variant
+# LLaMA-style models use -- drops `beta`/mean-centering entirely:
+# `sum / sqrt(mean(sum**2) + epsilon) * gamma`). So a fully-optimized
+# transformer typically has *no* bare `Add` at its residual connections at
+# all, and without also recognizing this fused node the feature above would
+# rarely fire on the models it exists for. `_match_matmul_residual_merge`
+# closes that gap: such a node is simultaneously (1) the residual merge
+# point itself -- its first two inputs, `input`/`skip`, are exactly `Add`'s
+# two operands, walked backward the same way -- *and* (2) a per-channel
+# affine hop on top of that sum, since `gamma` (and `beta`/`bias`, if
+# given) scale/shift each surviving channel independently and so must be
+# sliced by the group's own `keep` set precisely like a bias/scale `Add`/
+# `Mul` hop's own constant already is. Rather than inventing a new shape for
+# that, `_match_matmul_residual_merge` returns those constants as two or
+# three synthetic `(node, const_name)` `chain_ops` entries against the same
+# node -- `_Chain.chain_ops` already tolerates more than one entry per node
+# (nothing about it assumes one entry per distinct node), so
+# `_apply_chains`'s existing per-hop constant-slicing loop, its touched-role
+# conflict tracking, and its stale-`value_info` cleanup all pick every one
+# of them up with no changes of their own. `beta` (`SkipLayerNormalization`
+# only) and `bias` are the op's own optional inputs -- simply absent
+# becomes no slice needed for that term; *present but non-constant* (like
+# `gamma`, required and always checked) declines the node outright, the
+# same as a non-constant bias on a MatMul/Gemm producer. The op's optional
+# `mean`/`inv_std_var` outputs are training-only bookkeeping onnxruntime's
+# own CPU kernel never actually populates (`skip_layer_norm.cc`'s `Compute`
+# only ever writes outputs 0 and 3); a real inference-exported graph should
+# never wire them anywhere, but if one somehow does, this pass has no basis
+# for whether pruning keeps those values meaningful for whatever reads them,
+# so it declines outright rather than guessing, same as everywhere else in
+# this pass. The optional fourth output, `input_skip_bias_sum` (the raw,
+# pre-normalization sum), needs no special handling at all: this pass never
+# reads it, and in the common post-LN transformer shape a later residual
+# connection's own `skip` operand is simply the *previous*
+# `SkipLayerNormalization`'s ordinary (normalized) `output` -- not that raw
+# sum -- so the very same "resolves to another eligible merge node's raw
+# output" backward-walk case :func:`_walk_matmul_producer_backward` already
+# handles for a chain of bare `Add`s (the "many residual blocks share one
+# spine" case) covers a chain of `SkipLayerNormalization` nodes for free,
+# with no dedicated code of its own.
+
+
+_SKIP_LAYER_NORM_OPS = ("SkipLayerNormalization", "SkipSimplifiedLayerNormalization")
+_SKIP_LAYER_NORM_DOMAIN = "com.microsoft"
+
+
+def _skip_layer_norm_const_names(
+    node: onnx.NodeProto, initializer_map: Dict[str, onnx.TensorProto]
+) -> Optional[Tuple[str, Optional[str], Optional[str]]]:
+    """If every constant input a ``com.microsoft::SkipLayerNormalization``/
+    ``SkipSimplifiedLayerNormalization`` `node` needs sliced -- `gamma`
+    (input 2, required), plus `beta` (input 3, ``SkipLayerNormalization``
+    only) and `bias` (input 4, or input 3 for the simplified/RMSNorm
+    variant, which has no `beta`), both optional -- is present exactly as
+    the node's own input list says, and, whenever present, a constant float
+    initializer shaped like a flat per-channel vector (``prod(dims) ==
+    dims[-1]``, the same self-consistency bar
+    :func:`_walk_matmul_producer_backward`'s own bias/scale hop check
+    already uses -- the real ``dims[-1] == n_channels`` check is deferred to
+    :func:`_find_matmul_residual_chains` once the group's real channel
+    count is known, exactly like that hop's own), returns
+    ``(gamma_name, beta_name_or_None, bias_name_or_None)``. `beta`/`bias`
+    simply absent from the node's own input list (as opposed to present but
+    non-constant) becomes ``None`` -- the corresponding term the kernel
+    itself omits, confirmed against onnxruntime's own ``skip_layer_norm.cc``
+    kernel and by direct execution (see this section's own comment).
+    Declines (``None``) on a non-constant `gamma`, a *present* but
+    non-constant `beta`/`bias`, or the same underlying tensor named for two
+    of `gamma`/`beta`/`bias` at once (double-slicing it in
+    :func:`_apply_chains`'s own per-hop loop would corrupt it) -- none of
+    these is guessed at.
+    """
+    simplified = node.op_type == "SkipSimplifiedLayerNormalization"
+
+    def _const_vec(name: str) -> bool:
+        init = initializer_map.get(name)
+        return (
+            init is not None
+            and init.data_type == onnx.TensorProto.FLOAT
+            and bool(list(init.dims))
+            and int(np.prod(init.dims)) == init.dims[-1]
+        )
+
+    if len(node.input) < 3 or not node.input[2] or not _const_vec(node.input[2]):
+        return None  # gamma is required
+    gamma_name = node.input[2]
+
+    beta_name: Optional[str] = None
+    bias_idx = 3
+    if not simplified:
+        bias_idx = 4
+        if len(node.input) > 3 and node.input[3]:
+            if not _const_vec(node.input[3]):
+                return None
+            beta_name = node.input[3]
+
+    bias_name: Optional[str] = None
+    if len(node.input) > bias_idx and node.input[bias_idx]:
+        if not _const_vec(node.input[bias_idx]):
+            return None
+        bias_name = node.input[bias_idx]
+
+    names = [n for n in (gamma_name, beta_name, bias_name) if n is not None]
+    if len(set(names)) != len(names):
+        return None  # tied gamma/beta/bias -- double-slicing would corrupt it
+
+    return gamma_name, beta_name, bias_name
+
+
+def _match_matmul_residual_merge(
+    node: onnx.NodeProto,
+    initializer_map: Dict[str, onnx.TensorProto],
+    consumers_of: Dict[str, List[onnx.NodeProto]],
+    graph_outputs: Set[str],
+) -> Optional[Tuple[Tuple[str, str], Tuple[Tuple[onnx.NodeProto, Optional[str]], ...]]]:
+    """The MatMul/Gemm residual finder's own eligible-merge-point check:
+    `node` is either a bare ``Add`` (:func:`_is_eligible_add_merge`, reused
+    unchanged, with no extra `chain_ops` of its own -- exactly today's
+    behavior) *or* a ``com.microsoft::SkipLayerNormalization``/
+    ``SkipSimplifiedLayerNormalization`` node (see this section's own
+    comment above for the exact fused arithmetic and how it was confirmed).
+    Its first two inputs (`input`, `skip`) play exactly the role `Add`'s two
+    operands do -- same "two independent branches must agree on one
+    channel-index set" merge point, same eligibility bar (distinct, both
+    non-constant) -- while its constant `gamma`/`beta`/`bias` inputs (see
+    :func:`_skip_layer_norm_const_names`) are a per-channel affine hop
+    riding the very same node, so this returns them as extra
+    ``(node, const_name)`` entries for the caller to fold into the resolved
+    chain's own `chain_ops`, reusing :func:`_apply_chains`'s existing
+    per-hop constant slicing verbatim -- the same way a bias/scale
+    ``Add``/``Mul`` hop's own single constant already does, just two or
+    three entries against the same node instead of one.
+
+    Declines (``None``) the same way :func:`_skip_layer_norm_const_names`
+    does for a non-constant/tied `gamma`/`beta`/`bias`, and additionally
+    whenever the op's optional `mean`/`inv_std_var` outputs (training-only;
+    onnxruntime's own CPU kernel never actually writes them, see this
+    section's own comment) are actually consumed by anything else in the
+    graph: this pass has no basis for whether pruning keeps those still
+    meaningful for whatever reads them, so it declines outright rather than
+    guessing, the same conservative bar this module draws everywhere else.
+    """
+    if _is_eligible_add_merge(node, initializer_map):
+        return (node.input[0], node.input[1]), ()
+
+    if (
+        node.domain != _SKIP_LAYER_NORM_DOMAIN
+        or node.op_type not in _SKIP_LAYER_NORM_OPS
+    ):
+        return None
+    if len(node.input) < 3:
+        return None
+    input_name, skip_name = node.input[0], node.input[1]
+    if (
+        not input_name
+        or not skip_name
+        or input_name == skip_name
+        or input_name in initializer_map
+        or skip_name in initializer_map
+    ):
+        return None
+
+    const_names = _skip_layer_norm_const_names(node, initializer_map)
+    if const_names is None:
+        return None
+    gamma_name, beta_name, bias_name = const_names
+
+    for out_idx in (1, 2):  # mean, inv_std_var: training-only, see docstring
+        if len(node.output) > out_idx and node.output[out_idx]:
+            out_name = node.output[out_idx]
+            if consumers_of.get(out_name) or out_name in graph_outputs:
+                return None
+
+    extra_ops = tuple(
+        (node, name) for name in (gamma_name, beta_name, bias_name) if name is not None
+    )
+    return (input_name, skip_name), extra_ops
 
 
 def _walk_matmul_producer_backward(
@@ -2498,8 +2706,9 @@ def _walk_matmul_producer_backward(
     Tuple[Tuple[onnx.NodeProto, Optional[str]], ...],
 ]:
     """The backward counterpart of :func:`_walk_to_consumer`, used only by
-    :func:`_find_matmul_residual_chains` to resolve one operand of an ``Add``
-    merge point back to whatever produces it -- the MatMul/Gemm analogue of
+    :func:`_find_matmul_residual_chains` to resolve one operand of an
+    eligible merge node (see :func:`_match_matmul_residual_merge`) back to
+    whatever produces it -- the MatMul/Gemm analogue of
     :func:`_walk_conv_producer_backward` (see this function's own section
     comment above for how the two differ: a wider hop set mirroring
     `_walk_to_consumer`'s own per-channel bias/scale ``Add``/``Mul`` hop,
@@ -2507,16 +2716,25 @@ def _walk_matmul_producer_backward(
     crossed -- `start` itself included -- to have exactly one consumer, the
     same safety bar every other hop in this module already holds every
     intermediate tensor to; this is what makes a shared "post-block" tensor
-    (read by both the next stage and directly by an `Add`) resolve to
-    ``"fail"`` rather than being silently pruned wrong.
+    (read by both the next stage and directly by a merge node) resolve to
+    ``"fail"`` rather than being silently pruned wrong. The usual
+    exactly-one-output check on every node crossed is relaxed to "its own
+    *first* output is `cur`" rather than "it has exactly one output" purely
+    to let a multi-output ``SkipLayerNormalization``-family node (`mean`/
+    `inv_std_var`/`input_skip_bias_sum`, all beyond its primary `output`)
+    through to :func:`_match_matmul_residual_merge`'s own check below --
+    every other node type this walk ever matches (`MatMul`/`Gemm`, a unary
+    activation, `Add`/`Mul`) already has exactly one output per its own
+    ONNX schema, so this is a no-op relaxation for them.
 
     Returns one of:
 
     - ``("producer", (producer, n_channels), chain_ops)`` -- resolved all
       the way back to a real MatMul/vanilla-Gemm producer;
-    - ``("add", add_node, chain_ops)`` -- resolved to another eligible
-      ``Add`` merge node's raw output instead (the caller unions this
-      group with that ``Add``'s own rather than treating it as a separate
+    - ``("add", merge_node, chain_ops)`` -- resolved to another eligible
+      merge node's raw output instead -- a bare ``Add`` or a
+      ``SkipLayerNormalization``-family node alike (the caller unions this
+      group with that node's own rather than treating it as a separate
       producer);
     - ``("fail", None, ())`` -- a graph input, an unrecognized producer
       (attention-op boundary, gated-Mul combine, ...), a branch, or the hop
@@ -2534,7 +2752,7 @@ def _walk_matmul_producer_backward(
         if len(consumers_of.get(cur, [])) != 1 or cur in graph_outputs:
             return "fail", None, ()
         node = node_by_output.get(cur)
-        if node is None or len(node.output) != 1 or node.output[0] != cur:
+        if node is None or not node.output or node.output[0] != cur:
             return "fail", None, ()
 
         prod_info = _match_producer(node, initializer_map)
@@ -2569,10 +2787,14 @@ def _walk_matmul_producer_backward(
             # shape, handled below; for `Mul` it's a gated (SwiGLU/GeGLU)
             # combine point this walk doesn't try to pick a branch through
             # (see this section's own comment) -- either way, falling
-            # through to the `Add`-merge check (which requires `Add`
-            # specifically) or `"fail"` is correct.
+            # through to the merge check (which requires `Add` or a
+            # ``SkipLayerNormalization``-family node specifically) or
+            # `"fail"` is correct.
 
-        if _is_eligible_add_merge(node, initializer_map):
+        merge = _match_matmul_residual_merge(
+            node, initializer_map, consumers_of, graph_outputs
+        )
+        if merge is not None:
             return "add", node, tuple(reversed(chain_ops))
 
         return "fail", None, ()
@@ -2585,18 +2807,27 @@ def _find_matmul_residual_chains(graph: onnx.GraphProto) -> List[_Chain]:
     section's own comment above and :func:`_find_conv_residual_chains`'s
     (this function mirrors that one's union-find structure exactly, over
     :func:`_walk_matmul_producer_backward` instead of
-    :func:`_walk_conv_producer_backward`). For every maximal union-find
-    group of transitively-connected eligible ``Add`` merge points
-    (:func:`_is_eligible_add_merge`), resolves every member's two operands:
-    each must reach either a real MatMul/vanilla-Gemm producer (a "leaf" of
-    the group) or another `Add` already in the same group. If *any* operand,
-    anywhere in the group, fails to resolve that way, or the leaf producers'
-    channel counts don't all agree, the *entire* group is declined -- never
-    partially pruned. A correctly-resolved group must reduce to exactly one
-    "sink" `Add` (the one whose own output isn't itself consumed by another
-    `Add` in the group); the chain walk continues forward from there via the
-    ordinary :func:`_walk_to_consumer` to find the group's one real
-    downstream consumer, exactly as any other MatMul/Gemm chain does.
+    :func:`_walk_conv_producer_backward`). Every eligible merge point
+    (:func:`_match_matmul_residual_merge` -- a bare ``Add`` or a
+    ``SkipLayerNormalization``-family node) contributes its own extra
+    `chain_ops` (empty for `Add`; `gamma`/`beta`/`bias` for the
+    normalization-fused case) up front, before any union-find grouping, so
+    every member of a resolved group -- not just its "sink" -- has its own
+    per-channel constants, if any, folded into the final chain the same
+    way. For every maximal union-find group of transitively-connected
+    eligible merge points, resolves every member's two operands: each must
+    reach either a real MatMul/vanilla-Gemm producer (a "leaf" of the
+    group) or another eligible merge node already in the same group. If
+    *any* operand, anywhere in the group, fails to resolve that way, or the
+    leaf producers' channel counts don't all agree, the *entire* group is
+    declined -- never partially pruned. A correctly-resolved group must
+    reduce to exactly one "sink" merge node (the one whose own output isn't
+    itself consumed by another merge node in the group); the chain walk
+    continues forward from there via the ordinary :func:`_walk_to_consumer`
+    to find the group's one real downstream consumer, exactly as any other
+    MatMul/Gemm chain does -- unaffected by which kind of node the sink
+    happens to be, since it only ever reads the sink's own raw output
+    tensor name.
     """
     initializer_map = {t.name: t for t in graph.initializer}
     consumers_of = _consumers_of(graph)
@@ -2606,14 +2837,24 @@ def _find_matmul_residual_chains(graph: onnx.GraphProto) -> List[_Chain]:
     def _is_internal(name: str) -> bool:
         return len(consumers_of.get(name, [])) == 1 and name not in graph_outputs
 
-    eligible_adds = [
-        node for node in graph.node if _is_eligible_add_merge(node, initializer_map)
+    Merge = Tuple[
+        onnx.NodeProto,
+        Tuple[str, str],
+        Tuple[Tuple[onnx.NodeProto, Optional[str]], ...],
     ]
-    if not eligible_adds:
+    merges: List[Merge] = []
+    for node in graph.node:
+        match = _match_matmul_residual_merge(
+            node, initializer_map, consumers_of, graph_outputs
+        )
+        if match is not None:
+            operands, extra_ops = match
+            merges.append((node, operands, extra_ops))
+    if not merges:
         return []
-    add_index = {id(node): i for i, node in enumerate(eligible_adds)}
+    merge_index = {id(m[0]): i for i, m in enumerate(merges)}
 
-    parent = list(range(len(eligible_adds)))
+    parent = list(range(len(merges)))
 
     def find(i: int) -> int:
         while parent[i] != i:
@@ -2633,9 +2874,9 @@ def _find_matmul_residual_chains(graph: onnx.GraphProto) -> List[_Chain]:
     ]
     edge_results: Dict[int, List[Edge]] = {}
     poisoned: Set[int] = set()
-    for idx, add_node in enumerate(eligible_adds):
+    for idx, (merge_node, operands, _extra_ops) in enumerate(merges):
         results: List[Edge] = []
-        for operand in add_node.input:
+        for operand in operands:
             edge = _walk_matmul_producer_backward(
                 operand,
                 node_by_output,
@@ -2650,7 +2891,7 @@ def _find_matmul_residual_chains(graph: onnx.GraphProto) -> List[_Chain]:
                 poisoned.add(idx)
             elif kind == "add":
                 assert isinstance(payload, onnx.NodeProto)
-                j = add_index.get(id(payload))
+                j = merge_index.get(id(payload))
                 if j is None:
                     poisoned.add(idx)  # defensive -- shouldn't happen
                 else:
@@ -2658,7 +2899,7 @@ def _find_matmul_residual_chains(graph: onnx.GraphProto) -> List[_Chain]:
         edge_results[idx] = results
 
     groups: Dict[int, List[int]] = {}
-    for idx in range(len(eligible_adds)):
+    for idx in range(len(merges)):
         groups.setdefault(find(idx), []).append(idx)
 
     chains: List[_Chain] = []
@@ -2672,6 +2913,7 @@ def _find_matmul_residual_chains(graph: onnx.GraphProto) -> List[_Chain]:
         referenced: Set[int] = set()
 
         for idx in members:
+            pre_chain_ops.extend(merges[idx][2])  # this merge node's own extra_ops
             for kind, payload, ops in edge_results[idx]:
                 pre_chain_ops.extend(ops)
                 if kind == "producer":
@@ -2683,17 +2925,18 @@ def _find_matmul_residual_chains(graph: onnx.GraphProto) -> List[_Chain]:
                     n_channels_set.add(n_channels)
                 elif kind == "add":
                     assert isinstance(payload, onnx.NodeProto)
-                    referenced.add(add_index[id(payload)])
+                    referenced.add(merge_index[id(payload)])
 
         if len(n_channels_set) != 1:
             continue  # branches disagree on channel count -- decline
         n_channels = next(iter(n_channels_set))
 
-        # Every bias/scale hop's constant was only self-consistently checked
-        # when first crossed (see _walk_matmul_producer_backward); now that
-        # the group's real channel count is known, re-validate it actually
-        # matches -- mirroring the depthwise-Conv-hop re-validation in
-        # _find_conv_residual_chains.
+        # Every bias/scale hop's constant, and every SkipLayerNorm-family
+        # merge's own gamma/beta/bias, was only self-consistently checked
+        # when first crossed/matched (see _walk_matmul_producer_backward,
+        # _match_matmul_residual_merge); now that the group's real channel
+        # count is known, re-validate it actually matches -- mirroring the
+        # depthwise-Conv-hop re-validation in _find_conv_residual_chains.
         if any(
             const_name is not None
             and initializer_map[const_name].dims[-1] != n_channels
@@ -2704,12 +2947,12 @@ def _find_matmul_residual_chains(graph: onnx.GraphProto) -> List[_Chain]:
         sinks = [idx for idx in members if idx not in referenced]
         if len(sinks) != 1:
             continue  # not a single linear chain of merges -- decline
-        sink_add = eligible_adds[sinks[0]]
+        sink_node = merges[sinks[0]][0]
 
         if len({p.weight for p in leaf_producers}) != len(leaf_producers):
             continue  # degenerate -- the same producer named twice
 
-        sink_out = sink_add.output[0]
+        sink_out = sink_node.output[0]
         if not _is_internal(sink_out):
             continue
 
@@ -2726,7 +2969,7 @@ def _find_matmul_residual_chains(graph: onnx.GraphProto) -> List[_Chain]:
 
         chain_ops = (
             tuple(pre_chain_ops)
-            + tuple((eligible_adds[i], None) for i in members)
+            + tuple((merges[i][0], None) for i in members)
             + fwd_chain_ops
         )
 
@@ -3283,23 +3526,40 @@ def apply_structured_pruning(
     module's own docstring) -- the transformer-block residual stream shape
     (``x = x + SelfAttn(LN(x))``, ``x = x + MLP(LN(x))``) that was
     previously declined outright. Same union-find grouping over eligible
-    ``Add`` merges, same single-consumer bar on every hop of every branch,
+    merge points, same single-consumer bar on every hop of every branch,
     same combined (root-sum-square) importance ranking; the one real
     difference is the backward walk mirrors :func:`_walk_to_consumer`'s own
     *wider* MatMul/Gemm hop set (unary activations plus a per-channel
     bias/scale ``Add``/``Mul`` against a constant) rather than the Conv
     walk's narrower one, since there is no depthwise-Conv-style pass-through
-    analogue for MatMul/Gemm at all. A gated (SwiGLU/GeGLU) combine feeding
-    a residual branch with no downstream projection in between, and a
-    residual branch that would need to cross a fused self-attention op
-    boundary (``com.microsoft::Attention``/``GroupQueryAttention``/``ai.onnx``
+    analogue for MatMul/Gemm at all. A bare ``Add`` merge point is only one
+    recognized shape -- since onnxruntime's own transformer-optimizer tool
+    typically fuses each residual ``Add`` (plus an optional per-channel bias
+    ``Add``) together with the *following* LayerNorm/RMSNorm into one
+    ``com.microsoft::SkipLayerNormalization``/
+    ``SkipSimplifiedLayerNormalization`` node instead, that fused node is
+    recognized as an eligible merge point too (:func:`_match_matmul_residual_merge`):
+    its ``input``/``skip`` inputs play ``Add``'s own two-operand role, while
+    its ``gamma`` (required) and, if present, ``beta``
+    (``SkipLayerNormalization`` only) and ``bias`` are sliced by the group's
+    own surviving channel indices alongside everything else, confirmed
+    against onnxruntime's own kernel source and by direct execution -- see
+    :func:`_find_matmul_residual_chains`'s own section comment for the exact
+    fused arithmetic. A gated (SwiGLU/GeGLU) combine feeding a residual
+    branch with no downstream projection in between, and a residual branch
+    that would need to cross a fused self-attention op boundary
+    (``com.microsoft::Attention``/``GroupQueryAttention``/``ai.onnx``
     ``Attention``) to reach a real producer, are both declined rather than
     guessed at -- see the section comment above
     :func:`_walk_matmul_producer_backward` for why neither is actually
     reachable by any hop this walk recognizes, and why the far more common
     shapes (a gated FFN's own output projection, or an attention block's own
-    output-projection MatMul, feeding the residual `Add`) need no special
-    handling at all.
+    output-projection MatMul, feeding the residual `Add`/`SkipLayerNormalization`)
+    need no special handling at all. A non-constant (or, for ``beta``/``bias``,
+    present-but-non-constant) ``gamma``/``beta``/``bias``, or a
+    ``SkipLayerNormalization``-family node whose optional ``mean``/
+    ``inv_std_var`` outputs are actually consumed elsewhere, is declined the
+    same conservative way.
 
     :param model: the original onnx ModelProto or file path
     :param sparsity: target fraction of each matched producer's output
@@ -3344,8 +3604,10 @@ def apply_structured_wanda_pruning(
     as :func:`apply_wanda_pruning` is to :func:`apply_magnitude_pruning`:
     same real structural channel removal, same topology matching (a single
     producer, a gated pair, or a bounded Conv *or* MatMul/Gemm
-    residual/``Add``-merge group -> zero or more shape-preserving elementwise
-    ops and, for a Conv chain, depthwise Conv hops -> one consumer,
+    residual/merge group -- an ``Add`` or, for MatMul/Gemm, also a
+    ``SkipLayerNormalization``-family node, see :func:`apply_structured_pruning`'s
+    own docstring) -> zero or more shape-preserving elementwise ops and, for
+    a Conv chain, depthwise Conv hops -> one consumer,
     MatMul/Gemm or Conv, general grouped Conv included on either side, see
     :func:`apply_structured_pruning`'s own docstring) including the same
     depthwise-Conv pass-through sliced by the producer's channel indices

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -3132,6 +3132,333 @@ def test_structured_wanda_pruning_matmul_residual_add_matches_oracle():
     np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
 
 
+# --- apply_structured_pruning: MatMul/Gemm residual via SkipLayerNormalization ---
+#
+# The realistic shape the MatMul/Gemm residual tests above rarely see in
+# practice: a transformer already run through onnxruntime's own
+# transformer-optimizer tool, which fuses each residual `Add` (plus an
+# optional per-channel bias `Add`) together with the *following*
+# LayerNorm/RMSNorm into one `com.microsoft::SkipLayerNormalization`/
+# `SkipSimplifiedLayerNormalization` node -- see
+# `_match_matmul_residual_merge`'s own docstring and this module's "MatMul/
+# Gemm residual" section comment for the exact fused arithmetic (confirmed
+# against onnxruntime's own `skip_layer_norm.cc` kernel source and by
+# direct execution before any of this was written).
+
+
+def _skip_layer_norm_residual_diamond_model(
+    wf, ws, wout, gamma, beta=None, bias=None, simplified=False, epsilon=1e-5
+):
+    # y = SkipLayerNormalization(MatMul_f(X), MatMul_s(X), gamma, beta?,
+    # bias?) -- the SkipLayerNormalization/SkipSimplifiedLayerNormalization
+    # analogue of _matmul_residual_diamond_model: two entirely independent
+    # MatMul producers merge via the fused node instead of a bare `Add`, and
+    # must therefore still share one surviving channel-index set, feeding
+    # one real consumer. `beta`/`bias` are each included only if given --
+    # `beta` absent but `bias` present (SkipLayerNormalization only; the
+    # simplified/RMSNorm variant has no `beta` at all) uses the onnx text
+    # format's positional-placeholder syntax (an empty operand) to reach
+    # `bias`'s own input index with `beta` skipped, exactly the way this
+    # file's own GroupQueryAttention model builders already skip an unused
+    # optional input.
+    K, C = wf.shape
+    Out = wout.shape[1]
+    op = "SkipSimplifiedLayerNormalization" if simplified else "SkipLayerNormalization"
+    initializer = [
+        _f32(wf, "WF"),
+        _f32(ws, "WS"),
+        _f32(wout, "WOUT"),
+        _f32(gamma, "Gamma"),
+    ]
+    inputs = ["f", "s", "Gamma"]
+    if not simplified:
+        inputs.append("Beta" if beta is not None else "")
+        if beta is not None:
+            initializer.append(_f32(beta, "Beta"))
+    if bias is not None:
+        inputs.append("Bias")
+        initializer.append(_f32(bias, "Bias"))
+    while inputs and inputs[-1] == "":
+        inputs.pop()
+    ins = ", ".join(inputs)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          f = MatMul(X, WF)
+          s = MatMul(X, WS)
+          y = com.microsoft.{op} <epsilon={epsilon}> ({ins})
+          Y = MatMul(y, WOUT)
+        }}
+        """,
+        initializer=initializer,
+        opset=17,
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+    return model
+
+
+def _skip_layer_norm_keep(wf, ws, C):
+    importance = np.sqrt(
+        np.square(np.linalg.norm(wf.astype(np.float64), axis=0))
+        + np.square(np.linalg.norm(ws.astype(np.float64), axis=0))
+    )
+    keep = np.sort(np.argsort(-importance)[: C // 2])
+    # The conflicting-importance construction every test below uses is only
+    # doing its job if the combined keep set actually straddles both halves.
+    assert np.any(keep < C // 2) and np.any(keep >= C // 2)
+    return keep
+
+
+def _conflicting_wf_ws(seed, K, C):
+    rng = np.random.default_rng(seed)
+    scale_f = np.where(np.arange(C) < C // 2, 3.0, 0.3).astype(np.float32)
+    scale_s = np.where(np.arange(C) < C // 2, 0.3, 3.0).astype(np.float32)
+    wf = rng.standard_normal((K, C)).astype(np.float32) * scale_f
+    ws = rng.standard_normal((K, C)).astype(np.float32) * scale_s
+    return rng, wf, ws
+
+
+def test_structured_pruning_skip_layer_norm_residual_shrinks_matched_layers():
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(110)
+    wf = rng.standard_normal((K, C)).astype(np.float32)
+    ws = rng.standard_normal((K, C)).astype(np.float32)
+    wout = rng.standard_normal((C, Out)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    beta = rng.standard_normal((C,)).astype(np.float32)
+    model = _skip_layer_norm_residual_diamond_model(wf, ws, wout, gamma, beta=beta)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["WF"].dims) == [K, C // 2]
+    assert list(inits["WS"].dims) == [K, C // 2]
+    assert list(inits["WOUT"].dims) == [C // 2, Out]
+    assert list(inits["Gamma"].dims) == [C // 2]
+    assert list(inits["Beta"].dims) == [C // 2]
+
+
+def test_structured_pruning_skip_layer_norm_residual_matches_oracle():
+    # Correctness bar: exact equivalence to hand-slicing both independent
+    # MatMul producers *and* Gamma/Beta to the same combined-importance keep
+    # set -- with weights deliberately built so the two branches disagree
+    # about which channels matter most, so a bug that used only one
+    # branch's importance (or forgot to slice Gamma/Beta) would be caught,
+    # including by onnx.checker (a missed Gamma/Beta slice is a shape
+    # mismatch against the now-pruned MatMul outputs) and, more precisely,
+    # by the numeric oracle comparison below (a missed slice that
+    # onnxruntime's broadcasting rules happened to tolerate anyway would
+    # still compute the wrong per-channel scale/shift).
+    K, C, Out = 8, 16, 4
+    rng, wf, ws = _conflicting_wf_ws(110, K, C)
+    wout = rng.standard_normal((C, Out)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    beta = rng.standard_normal((C,)).astype(np.float32)
+    model = _skip_layer_norm_residual_diamond_model(wf, ws, wout, gamma, beta=beta)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep = _skip_layer_norm_keep(wf, ws, C)
+    oracle = _skip_layer_norm_residual_diamond_model(
+        wf[:, keep], ws[:, keep], wout[keep, :], gamma[keep], beta=beta[keep]
+    )
+
+    rng_x = np.random.default_rng(111)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_skip_simplified_layer_norm_residual_matches_oracle():
+    # SkipSimplifiedLayerNormalization -- the RMSNorm variant LLaMA-style
+    # models use -- drops `beta`/mean-centering entirely (see this module's
+    # own docstring and the "MatMul/Gemm residual" section comment for the
+    # exact RMSNorm arithmetic); this is the same oracle bar as the plain
+    # SkipLayerNormalization test above, minus `beta`.
+    K, C, Out = 8, 16, 4
+    rng, wf, ws = _conflicting_wf_ws(112, K, C)
+    wout = rng.standard_normal((C, Out)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    model = _skip_layer_norm_residual_diamond_model(
+        wf, ws, wout, gamma, simplified=True
+    )
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert "Beta" not in inits
+
+    keep = _skip_layer_norm_keep(wf, ws, C)
+    oracle = _skip_layer_norm_residual_diamond_model(
+        wf[:, keep], ws[:, keep], wout[keep, :], gamma[keep], simplified=True
+    )
+
+    rng_x = np.random.default_rng(113)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_skip_layer_norm_residual_with_bias_matches_oracle():
+    # `bias` present (and, deliberately, `beta` absent -- SkipLayerNorm's
+    # own optional inputs are independent of each other): exercises the
+    # bias-idx-shift in `_skip_layer_norm_const_names` (bias lives at input
+    # index 4 when beta is declared, but the model builder above still
+    # reaches it via the parser's positional-placeholder syntax when beta
+    # is skipped) and confirms `Bias` is sliced correctly alongside `Gamma`.
+    K, C, Out = 8, 16, 4
+    rng, wf, ws = _conflicting_wf_ws(114, K, C)
+    wout = rng.standard_normal((C, Out)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    bias = rng.standard_normal((C,)).astype(np.float32)
+    model = _skip_layer_norm_residual_diamond_model(wf, ws, wout, gamma, bias=bias)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Bias"].dims) == [C // 2]
+
+    keep = _skip_layer_norm_keep(wf, ws, C)
+    oracle = _skip_layer_norm_residual_diamond_model(
+        wf[:, keep], ws[:, keep], wout[keep, :], gamma[keep], bias=bias[keep]
+    )
+
+    rng_x = np.random.default_rng(115)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_skip_layer_norm_residual_declines_on_nonconstant_beta():
+    # `Beta` is a graph input, not a constant initializer -- `gamma` (also
+    # required) is fine, but a *present* non-constant `beta` still means
+    # this pass can't slice it, so the whole chain is declined and the
+    # model is left byte-identical, the same conservative bar a
+    # non-constant Gemm bias already gets elsewhere in this module.
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(116)
+    wf = rng.standard_normal((K, C)).astype(np.float32)
+    ws = rng.standard_normal((K, C)).astype(np.float32)
+    wout = rng.standard_normal((C, Out)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X, float[{C}] Beta) => (float[batch,{Out}] Y)
+        {{
+          f = MatMul(X, WF)
+          s = MatMul(X, WS)
+          y = com.microsoft.SkipLayerNormalization <epsilon=1e-5> (f, s, Gamma, Beta)
+          Y = MatMul(y, WOUT)
+        }}
+        """,
+        initializer=[
+            _f32(wf, "WF"),
+            _f32(ws, "WS"),
+            _f32(wout, "WOUT"),
+            _f32(gamma, "Gamma"),
+        ],
+        opset=17,
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
+def test_structured_pruning_skip_layer_norm_residual_declines_on_consumed_mean_output():
+    # The training-only `mean` output (index 1) is actually consumed here
+    # (wired straight to a second graph output) -- onnxruntime's own CPU
+    # kernel never actually populates it (see this module's own docstring),
+    # and this pass has no basis for whether pruning keeps it meaningful for
+    # whatever reads it, so the whole chain is declined outright rather
+    # than guessed at, leaving the model byte-identical.
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(117)
+    wf = rng.standard_normal((K, C)).astype(np.float32)
+    ws = rng.standard_normal((K, C)).astype(np.float32)
+    wout = rng.standard_normal((C, Out)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    beta = rng.standard_normal((C,)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y, float[batch] MeanOut)
+        {{
+          f = MatMul(X, WF)
+          s = MatMul(X, WS)
+          y, MeanOut = com.microsoft.SkipLayerNormalization <epsilon=1e-5> (f, s, Gamma, Beta)
+          Y = MatMul(y, WOUT)
+        }}
+        """,
+        initializer=[
+            _f32(wf, "WF"),
+            _f32(ws, "WS"),
+            _f32(wout, "WOUT"),
+            _f32(gamma, "Gamma"),
+            _f32(beta, "Beta"),
+        ],
+        opset=17,
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
+def test_structured_wanda_pruning_skip_layer_norm_residual_matches_oracle():
+    # apply_structured_wanda_pruning picks up SkipLayerNormalization-fused
+    # residual grouping for free -- _find_matmul_residual_chains is shared
+    # with apply_structured_pruning, and the activation norm is captured at
+    # the same probe point (`chain.consumer_node.input[0]`) any other
+    # MatMul/Gemm chain uses.
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(118)
+    wf = rng.standard_normal((K, C)).astype(np.float32)
+    ws = rng.standard_normal((K, C)).astype(np.float32)
+    wout = rng.standard_normal((C, Out)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    beta = rng.standard_normal((C,)).astype(np.float32)
+    model = _skip_layer_norm_residual_diamond_model(wf, ws, wout, gamma, beta=beta)
+
+    probe_model = onnx.ModelProto()
+    probe_model.CopyFrom(model)
+    probe_model.graph.output.append(
+        onnx.helper.make_tensor_value_info("y", onnx.TensorProto.FLOAT, None)
+    )
+
+    rng_cal = np.random.default_rng(119)
+    x_cal = rng_cal.standard_normal((6, K)).astype(np.float32)
+    calibration_data = [{"X": x_cal}]
+
+    _, y_cal = _run(probe_model, {"X": x_cal})
+    act_norm = np.sqrt(np.mean(np.square(y_cal.astype(np.float64)), axis=0))
+    base_importance = np.sqrt(
+        np.square(np.linalg.norm(wf.astype(np.float64), axis=0))
+        + np.square(np.linalg.norm(ws.astype(np.float64), axis=0))
+    )
+    importance = base_importance * np.maximum(act_norm, 1e-8)
+    keep = np.sort(np.argsort(-importance)[: C // 2])
+
+    pruned = onnxsim.apply_structured_wanda_pruning(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned)
+
+    oracle = _skip_layer_norm_residual_diamond_model(
+        wf[:, keep], ws[:, keep], wout[keep, :], gamma[keep], beta=beta[keep]
+    )
+    rng_x = np.random.default_rng(120)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
 # --- apply_structured_wanda_pruning ------------------------------------------
 
 

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -3410,6 +3410,49 @@ def test_structured_pruning_skip_layer_norm_residual_declines_on_consumed_mean_o
     assert pruned.SerializeToString() == model.SerializeToString()
 
 
+def test_structured_pruning_skip_layer_norm_residual_declines_on_consumed_sum_output():
+    # The fourth output, `input_skip_bias_sum` (the raw, pre-normalization
+    # `f + s`), is consumed directly here by a second graph output. Unlike
+    # `mean`/`inv_std_var`, this pass never reads this output itself and its
+    # *value* would still be correct post-pruning (it's a plain runtime sum
+    # of two already-consistently-pruned tensors) -- but its *shape* shrinks
+    # along with `f`/`s`, and this pass has no way to confirm the outside
+    # consumer (here, the graph's own declared output shape) still expects
+    # the new, narrower width. Declined outright, model left byte-identical
+    # -- confirmed to actually matter: before this decline existed, pruning
+    # produced a model whose `SumOut` graph output disagreed with its own
+    # declared shape (a lenient-merge warning from onnxruntime, and a hard
+    # failure for any stricter consumer of that output elsewhere).
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(119)
+    wf = rng.standard_normal((K, C)).astype(np.float32)
+    ws = rng.standard_normal((K, C)).astype(np.float32)
+    wout = rng.standard_normal((C, Out)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y, float[batch,{C}] SumOut)
+        {{
+          f = MatMul(X, WF)
+          s = MatMul(X, WS)
+          y, mean, inv_std, SumOut = com.microsoft.SkipSimplifiedLayerNormalization <epsilon=1e-5> (f, s, Gamma)
+          Y = MatMul(y, WOUT)
+        }}
+        """,
+        initializer=[
+            _f32(wf, "WF"),
+            _f32(ws, "WS"),
+            _f32(wout, "WOUT"),
+            _f32(gamma, "Gamma"),
+        ],
+        opset=17,
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
 def test_structured_wanda_pruning_skip_layer_norm_residual_matches_oracle():
     # apply_structured_wanda_pruning picks up SkipLayerNormalization-fused
     # residual grouping for free -- _find_matmul_residual_chains is shared
@@ -3456,6 +3499,73 @@ def test_structured_wanda_pruning_skip_layer_norm_residual_matches_oracle():
     x = rng_x.standard_normal((5, K)).astype(np.float32)
     (y,) = _run(pruned, {"X": x})
     (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_mixed_add_and_skip_layer_norm_spine_matches_oracle():
+    # A transitive spine of *two different* merge-node kinds sharing one
+    # channel count: a bare `Add` (f1, s1) feeds forward as one operand of a
+    # downstream `SkipLayerNormalization` merge (with f2 as the other) --
+    # the "many residual blocks share one spine" case, but mixing an
+    # ordinary transformer-block Add-residual with a fused post-LN block
+    # right after it, exactly the shape a real model transitioning between
+    # an un-fused and a fused block would take. `_walk_matmul_producer_backward`'s
+    # own "resolves to another eligible merge node's raw output" case
+    # doesn't care which kind of node it resolves to -- confirmed here with
+    # a genuinely mixed pair rather than two of the same kind.
+    K, C, Kz, Out = 8, 16, 5, 4
+    rng = np.random.default_rng(121)
+    wf1 = rng.standard_normal((K, C)).astype(np.float32)
+    ws1 = rng.standard_normal((K, C)).astype(np.float32)
+    wf2 = rng.standard_normal((Kz, C)).astype(np.float32)
+    wout = rng.standard_normal((C, Out)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+
+    def _build(wf1, ws1, wf2, wout, gamma):
+        return _model(
+            f"""
+            g (float[batch,{wf1.shape[0]}] X, float[batch,{wf2.shape[0]}] Z) => (float[batch,{wout.shape[1]}] Y)
+            {{
+              f1 = MatMul(X, WF1)
+              s1 = MatMul(X, WS1)
+              add1 = Add(f1, s1)
+              f2 = MatMul(Z, WF2)
+              merged, mean, inv_std, sbs = com.microsoft.SkipSimplifiedLayerNormalization <epsilon=1e-5> (f2, add1, Gamma)
+              Y = MatMul(merged, WOUT)
+            }}
+            """,
+            initializer=[
+                _f32(wf1, "WF1"),
+                _f32(ws1, "WS1"),
+                _f32(wf2, "WF2"),
+                _f32(wout, "WOUT"),
+                _f32(gamma, "Gamma"),
+            ],
+            opset=17,
+        )
+
+    model = _build(wf1, ws1, wf2, wout, gamma)
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    importance = np.sqrt(
+        np.square(np.linalg.norm(wf1.astype(np.float64), axis=0))
+        + np.square(np.linalg.norm(ws1.astype(np.float64), axis=0))
+        + np.square(np.linalg.norm(wf2.astype(np.float64), axis=0))
+    )
+    keep = np.sort(np.argsort(-importance)[: C // 2])
+    oracle = _build(
+        wf1[:, keep], ws1[:, keep], wf2[:, keep], wout[keep, :], gamma[keep]
+    )
+    oracle.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+
+    rng_x = np.random.default_rng(122)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    z = rng_x.standard_normal((5, Kz)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x, "Z": z})
+    (y_oracle,) = _run(oracle, {"X": x, "Z": z})
     np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
 
 


### PR DESCRIPTION
## Summary
- The MatMul/Gemm residual-chain support just merged (`_find_matmul_residual_chains`) only recognizes a bare `Add(a, b)` as a residual merge point. But the realistic target model for this feature — one already run through onnxruntime's own transformer optimizer, the same tool that produces the `com.microsoft::Attention`/`GroupQueryAttention` ops this module already specifically targets — typically fuses each residual connection's `Add` (and the following LayerNorm/RMSNorm) into one `com.microsoft::SkipLayerNormalization`/`SkipSimplifiedLayerNormalization` node instead. So the feature that was just built may rarely fire on the exact models it exists for. This PR closes that gap.
- **Operator semantics were confirmed, not assumed**: fetched onnxruntime's own source directly (`bert_defs.cc` for the schema, `skip_layer_norm.cc` for the exact kernel arithmetic — confirmed `output = LayerNorm(input+skip[+bias], gamma[, beta])`, RMSNorm variant for the "Simplified" op, and that the CPU kernel never actually writes the optional `mean`/`inv_std_var` outputs), then empirically verified against this environment's real onnxruntime (1.29.0) across 6 small graphs (both ops × beta/bias present/absent) before writing any pruning logic against that understanding.
- New `_match_matmul_residual_merge` unifies eligible-merge-point detection: a bare `Add` (delegates to the unchanged `_is_eligible_add_merge`) or a `SkipLayerNormalization`-family node, whose first two inputs (`input`, `skip`) play exactly `Add`'s role. The op's constant `gamma`/`beta`/`bias` are a per-channel affine hop riding the same node — returned as extra `(node, const_name)` `chain_ops` entries, reusing `_apply_chains`'s existing per-hop constant-slicing verbatim (no changes needed there at all).
- `_walk_matmul_producer_backward`'s "exactly one output" safety check relaxes to "first output is `cur`" (a no-op for every previously-matched node type) so the multi-output `SkipLayerNorm` node can be recognized.
- **A real correctness gap found and fixed during review, beyond the PR's own original scope**: the optional 4th output, `input_skip_bias_sum` (the raw pre-normalization sum), wasn't checked for external consumers. Its *value* stays correct post-pruning (a plain runtime sum of two already-consistently-pruned tensors), but its *shape* shrinks along with `input`/`skip`, and nothing here can confirm an outside consumer still expects the new width. Confirmed concretely by reproduction: a second graph output reading it directly ended up with a shape mismatch against its own originally-declared shape (onnxruntime degrades this to a lenient-merge warning; a stricter consumer would hard-fail). Now declined the same conservative way `mean`/`inv_std_var` already are, with a regression test that fails without the fix (verified by temporarily reverting it).
- Also added a mixed `Add`-then-`SkipLayerNorm` transitive-spine test: the "resolves to another eligible merge node" backward-walk case (the "many residual blocks share one spine" chaining) was previously only exercised by a scratch check during development (two `SkipSimplifiedLayerNormalization` nodes), not committed as a regression test, and never with a genuinely mixed pair of merge-node kinds.
- **Declined, honestly, not guessed at**: non-constant `gamma`/`beta`/`bias`; the same underlying tensor named for two of `gamma`/`beta`/`bias` at once (would double-slice and corrupt it); `mean`/`inv_std_var` actually consumed by anything; `input_skip_bias_sum` actually consumed by anything (see above).
- **Independently verified beyond the PR's own tests**: built a fresh model with conflicting per-branch importance and both `gamma`/`beta` present (not reusing the PR's own test code), confirmed every sliced tensor (`WA`/`WB`/`WOUT`/`GAMMA`/`BETA`) matches the hand-computed combined-importance indices exactly, and confirmed the real onnxruntime output matches a hand-built oracle exactly.

## Test plan
- [x] `pytest tests/test_pruning.py -q` — 146 passed (up from 137)
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — clean
- [x] Independent verification: conflicting-importance model with gamma+beta re-derived by hand and confirmed via onnxruntime with a fresh test case; the `input_skip_bias_sum` fix confirmed by reproducing the shape-mismatch failure, then confirming the fix declines it (byte-identical model)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_