### PR TITLE
Fix double protobuf round-trip in safetensors/gguf export and import

### DIFF
--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -1330,55 +1330,83 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
   // functions for the real-offset design). Exchanged as bytes for the model
   // (like ``simplify``) and a real path for the archive itself, since the
   // archive is inherently file-based.
+  //
+  // `tensor_bytes` carries each eligible tensor's raw_data separately from
+  // `model_bytes` (whose Python caller has already stripped those same
+  // fields before serializing) -- avoids paying a full protobuf encode
+  // (Python) + decode (here) of the tensor data on top of the copies
+  // AdoptAllWithPlaceholderOffsets/the archive write already make; see that
+  // function's doc comment. Converting each py::bytes to a std::string is
+  // the one necessary copy of that tensor's bytes crossing into C++.
   m.def(
       "export_safetensors",
-      [](const py::bytes& model_bytes, const std::string& out_path) {
+      [](const py::bytes& model_bytes,
+         std::map<std::string, py::bytes>& tensor_bytes,
+         const std::string& out_path) {
         onnx::ModelProto model;
         ParseProtoFromBytes(&model, model_bytes.c_str(), model_bytes.size());
+        std::map<std::string, std::string> external_bytes;
+        for (auto& [name, b] : tensor_bytes) {
+          external_bytes.emplace(name, std::string(b.c_str(), b.size()));
+        }
         onnxsim::tensor_pool::TensorPool pool;
-        onnxsim::tensor_pool::SaveModelAsSafetensorsStandalone(model, out_path,
-                                                               pool);
+        onnxsim::tensor_pool::SaveModelAsSafetensorsStandalone(
+            model, out_path, pool, &external_bytes);
       },
-      "model_bytes"_a, "out_path"_a);
+      "model_bytes"_a, "tensor_bytes"_a, "out_path"_a);
 
+  // Always loads lazily (hydrate_all=false) for the same reason
+  // load_model's binding does -- see that binding's comment. Returns the
+  // TensorPool too so the Python wrapper can hydrate tensor-by-tensor
+  // itself instead of paying a second full-model serialize/parse here.
   m.def(
       "import_safetensors",
-      [](const std::string& in_path) -> py::bytes {
+      [](const std::string& in_path)
+          -> std::tuple<py::bytes, onnxsim::tensor_pool::TensorPool> {
         onnx::ModelProto model;
         onnxsim::tensor_pool::TensorPool pool;
-        if (!onnxsim::tensor_pool::LoadModelFromSafetensors(in_path, &model,
-                                                            pool)) {
+        if (!onnxsim::tensor_pool::LoadModelFromSafetensors(
+                in_path, &model, pool, /*hydrate_all=*/false)) {
           throw std::runtime_error(
               "safetensors file has no embedded onnxsim model (a plain "
               "weights-only archive is not importable as a graph)");
         }
         const std::string out = model.SerializeAsString();
-        return py::bytes(out.data(), out.size());
+        return {py::bytes(out.data(), out.size()), std::move(pool)};
       },
       "in_path"_a);
 
   m.def(
       "export_gguf",
-      [](const py::bytes& model_bytes, const std::string& out_path) {
+      [](const py::bytes& model_bytes,
+         std::map<std::string, py::bytes>& tensor_bytes,
+         const std::string& out_path) {
         onnx::ModelProto model;
         ParseProtoFromBytes(&model, model_bytes.c_str(), model_bytes.size());
+        std::map<std::string, std::string> external_bytes;
+        for (auto& [name, b] : tensor_bytes) {
+          external_bytes.emplace(name, std::string(b.c_str(), b.size()));
+        }
         onnxsim::tensor_pool::TensorPool pool;
-        onnxsim::tensor_pool::SaveModelAsGGUFStandalone(model, out_path, pool);
+        onnxsim::tensor_pool::SaveModelAsGGUFStandalone(
+            model, out_path, pool, /*string_metadata=*/{}, &external_bytes);
       },
-      "model_bytes"_a, "out_path"_a);
+      "model_bytes"_a, "tensor_bytes"_a, "out_path"_a);
 
   m.def(
       "import_gguf",
-      [](const std::string& in_path) -> py::bytes {
+      [](const std::string& in_path)
+          -> std::tuple<py::bytes, onnxsim::tensor_pool::TensorPool> {
         onnx::ModelProto model;
         onnxsim::tensor_pool::TensorPool pool;
-        if (!onnxsim::tensor_pool::LoadModelFromGGUF(in_path, &model, pool)) {
+        if (!onnxsim::tensor_pool::LoadModelFromGGUF(in_path, &model, pool,
+                                                     /*hydrate_all=*/false)) {
           throw std::runtime_error(
               "gguf file has no embedded onnxsim model (a plain weights-only "
               "archive is not importable as a graph)");
         }
         const std::string out = model.SerializeAsString();
-        return py::bytes(out.data(), out.size());
+        return {py::bytes(out.data(), out.size()), std::move(pool)};
       },
       "in_path"_a);
 

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -343,6 +343,91 @@ def import_onnx_schemas() -> int:
     return imported
 
 
+def _extract_tensor_to_dict(
+    tensor: onnx.TensorProto, key: str, tensor_bytes: Dict[str, bytes]
+) -> None:
+    if (
+        tensor.data_location == onnx.TensorProto.EXTERNAL
+        or tensor.data_type == onnx.TensorProto.STRING
+        or not tensor.HasField("raw_data")
+    ):
+        return
+    tensor_bytes[key] = tensor.raw_data
+    tensor.ClearField("raw_data")
+
+
+def _extract_attr_tensors_to_dict(
+    attr: onnx.AttributeProto, path: str, tensor_bytes: Dict[str, bytes]
+) -> None:
+    if attr.HasField("t"):
+        _extract_tensor_to_dict(attr.t, attr.t.name or f"{path}/t", tensor_bytes)
+    for i, t in enumerate(attr.tensors):
+        _extract_tensor_to_dict(t, t.name or f"{path}/tensors{i}", tensor_bytes)
+    if attr.HasField("g"):
+        _extract_graph_tensors_to_dict(attr.g, tensor_bytes)
+    for g in attr.graphs:
+        _extract_graph_tensors_to_dict(g, tensor_bytes)
+
+
+def _extract_graph_tensors_to_dict(
+    graph: onnx.GraphProto, tensor_bytes: Dict[str, bytes]
+) -> None:
+    """Reverse of :func:`_hydrate_graph_tensors_from_pool`: pulls every
+    eligible tensor's ``raw_data`` out of ``graph`` (initializers and node
+    attribute tensors, recursing into subgraphs) into ``tensor_bytes`` --
+    keyed the same way tensor_pool_bridge.h's ForEachTensor derives pool
+    keys -- and clears it from the tensor in place, so the ``ModelProto``
+    this graph belongs to can be serialized across the FFI boundary without
+    paying to encode/decode the (potentially huge) tensor bytes a second
+    time; ``AdoptAllWithPlaceholderOffsets``'s C++ side expects exactly this
+    stripped state when given an ``external_tensor_bytes`` map.
+    """
+    for i, init in enumerate(graph.initializer):
+        _extract_tensor_to_dict(init, init.name or f"initializer{i}", tensor_bytes)
+    for ni, node in enumerate(graph.node):
+        node_path = node.name or f"node{ni}"
+        for ai, attr in enumerate(node.attribute):
+            _extract_attr_tensors_to_dict(attr, f"{node_path}/attr{ai}", tensor_bytes)
+
+
+def _restore_tensor_raw_data(
+    tensor: onnx.TensorProto, key: str, tensor_bytes: Dict[str, bytes]
+) -> None:
+    if key in tensor_bytes:
+        tensor.raw_data = tensor_bytes[key]
+
+
+def _restore_attr_tensors_raw_data(
+    attr: onnx.AttributeProto, path: str, tensor_bytes: Dict[str, bytes]
+) -> None:
+    if attr.HasField("t"):
+        _restore_tensor_raw_data(attr.t, attr.t.name or f"{path}/t", tensor_bytes)
+    for i, t in enumerate(attr.tensors):
+        _restore_tensor_raw_data(t, t.name or f"{path}/tensors{i}", tensor_bytes)
+    if attr.HasField("g"):
+        _restore_graph_tensors_raw_data(attr.g, tensor_bytes)
+    for g in attr.graphs:
+        _restore_graph_tensors_raw_data(g, tensor_bytes)
+
+
+def _restore_graph_tensors_raw_data(
+    graph: onnx.GraphProto, tensor_bytes: Dict[str, bytes]
+) -> None:
+    """Undoes :func:`_extract_graph_tensors_to_dict`: puts each extracted
+    tensor's ``raw_data`` back so the caller's ``model`` is left exactly as
+    it was, once the export call that needed it stripped out has returned
+    (or raised). This restore is a plain in-memory field assignment --
+    no serialization, no FFI crossing -- so it doesn't reintroduce the
+    protobuf round-trip cost the extraction was written to avoid.
+    """
+    for i, init in enumerate(graph.initializer):
+        _restore_tensor_raw_data(init, init.name or f"initializer{i}", tensor_bytes)
+    for ni, node in enumerate(graph.node):
+        node_path = node.name or f"node{ni}"
+        for ai, attr in enumerate(node.attribute):
+            _restore_attr_tensors_raw_data(attr, f"{node_path}/attr{ai}", tensor_bytes)
+
+
 def export_safetensors(model: onnx.ModelProto, out_path: str) -> None:
     """Export ``model`` to a standalone safetensors archive at ``out_path``.
 
@@ -351,8 +436,20 @@ def export_safetensors(model: onnx.ModelProto, out_path: str) -> None:
     no onnxsim involved -- and the graph itself is embedded alongside them, so
     ``out_path`` alone is both the model's weights and its graph. Reload it
     with :func:`import_safetensors`.
+
+    ``model`` is left unchanged once this returns (including on error): each
+    tensor's ``raw_data`` is transiently cleared before crossing into C++ (so
+    the accompanying model-structure serialize doesn't also re-encode the
+    -- potentially huge -- tensor bytes a second time) and restored
+    afterwards, a plain in-memory assignment with no serialization or FFI
+    cost of its own.
     """
-    C.export_safetensors(model.SerializeToString(), out_path)
+    tensor_bytes: Dict[str, bytes] = {}
+    _extract_graph_tensors_to_dict(model.graph, tensor_bytes)
+    try:
+        C.export_safetensors(model.SerializeToString(), tensor_bytes, out_path)
+    finally:
+        _restore_graph_tensors_raw_data(model.graph, tensor_bytes)
 
 
 def import_safetensors(in_path: str) -> onnx.ModelProto:
@@ -364,8 +461,10 @@ def import_safetensors(in_path: str) -> onnx.ModelProto:
     ``RuntimeError`` if the archive has no embedded onnxsim model, e.g. a
     plain weights-only safetensors file with no graph to import.
     """
+    model_bytes, pool = C.import_safetensors(in_path)
     model = onnx.ModelProto()
-    model.ParseFromString(C.import_safetensors(in_path))
+    model.ParseFromString(model_bytes)
+    _hydrate_graph_tensors_from_pool(model.graph, pool)
     return model
 
 
@@ -485,14 +584,23 @@ def load_model(
 
 
 def export_gguf(model: onnx.ModelProto, out_path: str) -> None:
-    """GGUF counterpart of :func:`export_safetensors`."""
-    C.export_gguf(model.SerializeToString(), out_path)
+    """GGUF counterpart of :func:`export_safetensors`, including its
+    leaves-``model``-unchanged contract.
+    """
+    tensor_bytes: Dict[str, bytes] = {}
+    _extract_graph_tensors_to_dict(model.graph, tensor_bytes)
+    try:
+        C.export_gguf(model.SerializeToString(), tensor_bytes, out_path)
+    finally:
+        _restore_graph_tensors_raw_data(model.graph, tensor_bytes)
 
 
 def import_gguf(in_path: str) -> onnx.ModelProto:
     """GGUF counterpart of :func:`import_safetensors`."""
+    model_bytes, pool = C.import_gguf(in_path)
     model = onnx.ModelProto()
-    model.ParseFromString(C.import_gguf(in_path))
+    model.ParseFromString(model_bytes)
+    _hydrate_graph_tensors_from_pool(model.graph, pool)
     return model
 
 

--- a/onnxsim/tensor_pool_bridge.h
+++ b/onnxsim/tensor_pool_bridge.h
@@ -585,14 +585,43 @@ inline std::string FixedWidthDecimal(uint64_t v) {
 // each adopted tensor's pool key alongside its TensorProto*, exactly like
 // ExportModelWithSafetensors's internal bookkeeping, so the second half can
 // find and re-patch them without a second graph traversal.
+//
+// `external_tensor_bytes`, when non-null, supplies the adopted bytes
+// directly (keyed the same way ForEachTensor derives pool keys) instead of
+// pulling them out of each TensorProto's own raw_data via
+// AdoptFromTensorProto -- entries are moved out of the map as they're
+// consumed. This is for a caller (see cpp2py_export.cc's
+// export_safetensors/export_gguf) that already has the tensor bytes
+// separately and stripped `model`'s own raw_data fields before crossing it
+// into C++, to avoid paying a full protobuf encode/decode of the
+// (potentially huge) tensor data on top of the copies pool.Add and the
+// eventual archive write already make. A tensor with no raw_data left (or
+// none to begin with, e.g. it already used a typed field) and no matching
+// entry in the map is simply not adopted, same as AdoptFromTensorProto's
+// own "nothing eligible" case.
 inline std::vector<std::pair<std::string, onnx::TensorProto*>>
-AdoptAllWithPlaceholderOffsets(onnx::ModelProto& model,
-                               const std::string& archive_path,
-                               TensorPool& pool) {
+AdoptAllWithPlaceholderOffsets(
+    onnx::ModelProto& model, const std::string& archive_path, TensorPool& pool,
+    std::map<std::string, std::string>* external_tensor_bytes = nullptr) {
   std::vector<std::pair<std::string, onnx::TensorProto*>> adopted;
   detail::ForEachTensor(*model.mutable_graph(), [&](const std::string& name,
                                                     onnx::TensorProto& t) {
-    if (!AdoptFromTensorProto(name, t, pool)) return;
+    bool ok;
+    if (external_tensor_bytes != nullptr) {
+      auto it = external_tensor_bytes->find(name);
+      if (it == external_tensor_bytes->end()) {
+        ok = false;
+      } else {
+        std::vector<int64_t> shape(t.dims().begin(), t.dims().end());
+        pool.Add(name, t.data_type(), std::move(shape), std::move(it->second));
+        external_tensor_bytes->erase(it);
+        t.clear_raw_data();
+        ok = true;
+      }
+    } else {
+      ok = AdoptFromTensorProto(name, t, pool);
+    }
+    if (!ok) return;
     t.set_data_location(onnx::TensorProto::EXTERNAL);
     t.clear_external_data();
     auto set_kv = [&](const std::string& k, const std::string& v) {
@@ -658,10 +687,11 @@ inline void PatchFileBytes(const std::string& path, uint64_t offset,
 // involved. Every weight tensor is written to disk exactly once; the model
 // blob itself is written, then patched in place (same algorithm as
 // SaveModelAsGGUFStandalone) -- see this section's top comment.
-inline void SaveModelAsSafetensorsStandalone(onnx::ModelProto& model,
-                                             const std::string& path,
-                                             TensorPool& pool) {
-  auto adopted = AdoptAllWithPlaceholderOffsets(model, path, pool);
+inline void SaveModelAsSafetensorsStandalone(
+    onnx::ModelProto& model, const std::string& path, TensorPool& pool,
+    std::map<std::string, std::string>* external_tensor_bytes = nullptr) {
+  auto adopted =
+      AdoptAllWithPlaceholderOffsets(model, path, pool, external_tensor_bytes);
   CheckNoEmbeddedModelKeyCollision(pool);
 
   std::string placeholder_bytes;

--- a/onnxsim/tensor_pool_gguf_bridge.h
+++ b/onnxsim/tensor_pool_gguf_bridge.h
@@ -217,8 +217,10 @@ inline bool LoadModelFromGGUF(const std::string& path, onnx::ModelProto* model,
 // written to disk exactly once despite the model blob needing two passes.
 inline void SaveModelAsGGUFStandalone(
     onnx::ModelProto& model, const std::string& path, TensorPool& pool,
-    const std::map<std::string, std::string>& string_metadata = {}) {
-  auto adopted = AdoptAllWithPlaceholderOffsets(model, path, pool);
+    const std::map<std::string, std::string>& string_metadata = {},
+    std::map<std::string, std::string>* external_tensor_bytes = nullptr) {
+  auto adopted =
+      AdoptAllWithPlaceholderOffsets(model, path, pool, external_tensor_bytes);
   CheckNoEmbeddedModelKeyCollision(pool);
 
   std::string placeholder_bytes;

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -1288,6 +1288,88 @@ def test_load_model_dispatches_to_gguf_archive():
     assert set(pool.names()) >= {"a", "b"}
 
 
+@pytest.mark.parametrize(
+    "export_fn,import_fn,ext",
+    [
+        (onnxsim.export_safetensors, onnxsim.import_safetensors, "safetensors"),
+        (onnxsim.export_gguf, onnxsim.import_gguf, "gguf"),
+    ],
+)
+def test_export_archive_leaves_model_unchanged(export_fn, import_fn, ext):
+    # export_safetensors/export_gguf used to cross the whole model (tensor
+    # bytes included) into C++ via a single SerializeToString()/ParseFromString()
+    # round trip -- the same double-encode pattern load_model's hydrate_all=True
+    # path had (see that function's docstring). The fix pulls each tensor's
+    # raw_data out into a separate dict up front (so the accompanying
+    # model-structure serialize is cheap) and puts it back once the C++ call
+    # returns -- this must be transparent to the caller: `model` compares
+    # byte-equal to a snapshot taken before the call, even though it was
+    # mutated and restored in between.
+    model, a, b = _make_add_model()
+    before = onnx.ModelProto()
+    before.CopyFrom(model)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        archive_path = os.path.join(tmpdir, f"model.{ext}")
+        export_fn(model, archive_path)
+        assert model == before
+
+        loaded = import_fn(archive_path)
+
+    onnx.checker.check_model(loaded)
+    np.testing.assert_allclose(
+        onnx.numpy_helper.to_array(loaded.graph.initializer[0]), a
+    )
+    np.testing.assert_allclose(
+        onnx.numpy_helper.to_array(loaded.graph.initializer[1]), b
+    )
+
+
+@pytest.mark.parametrize(
+    "export_fn,import_fn",
+    [
+        (onnxsim.export_safetensors, onnxsim.import_safetensors),
+        (onnxsim.export_gguf, onnxsim.import_gguf),
+    ],
+)
+def test_export_archive_roundtrips_unnamed_attribute_tensor(export_fn, import_fn):
+    # The extraction side of the same fix (_extract_graph_tensors_to_dict)
+    # must key an unnamed node-attribute tensor the same positional way
+    # (`node<i>/attr<j>/t`) its hydration counterpart does, or the C++ side's
+    # external_tensor_bytes lookup misses and the tensor is silently dropped
+    # from the archive instead of exported.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 17]
+        >
+        g (float[2,2] x) => (float[2,2] y)
+        {
+          c = Constant<value = float[2,2] {0.0, 1.0, 2.0, 3.0}>()
+          y = Add(x, c)
+        }
+        """
+    )
+    (const_node,) = [n for n in model.graph.node if n.op_type == "Constant"]
+    (value_attr,) = [a for a in const_node.attribute if a.name == "value"]
+    value_attr.t.ClearField("name")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        archive_path = os.path.join(tmpdir, "model.archive")
+        export_fn(model, archive_path)
+        loaded = import_fn(archive_path)
+
+    onnx.checker.check_model(loaded)
+    (loaded_const,) = [n for n in loaded.graph.node if n.op_type == "Constant"]
+    (loaded_value,) = [a for a in loaded_const.attribute if a.name == "value"]
+    assert loaded_value.t.data_location == onnx.TensorProto.DEFAULT
+    np.testing.assert_allclose(
+        onnx.numpy_helper.to_array(loaded_value.t),
+        np.array([[0.0, 1.0], [2.0, 3.0]], dtype=np.float32),
+    )
+
+
 @skip_in_ci()
 @pytest.mark.skipif(sys.platform == "win32", reason="resource.getrusage is POSIX-only")
 def test_simplify_path_peak_memory_stays_near_model_size():


### PR DESCRIPTION
## Summary
- `export_safetensors`/`export_gguf` used to serialize the whole model -- tensor bytes included -- to cross into C++, and `import_safetensors`/`import_gguf` did the same on the way back: the same double protobuf encode/decode pattern `load_model` had before it was fixed in #874. Each tensor's `raw_data` is now extracted into a separate dict up front (so the accompanying model-structure serialize is cheap), and the C++ import bindings now return the model alongside a `TensorPool` so hydration happens tensor-by-tensor in Python instead of via a second full-model parse.
- `export_safetensors`/`export_gguf` now leave the caller's model byte-identical once they return (including on error): `raw_data` is transiently cleared, then restored -- a plain in-memory assignment, no serialization or FFI cost -- so callers don't need to treat the model as mutated.
- `AdoptAllWithPlaceholderOffsets` (`tensor_pool_bridge.h`), and `SaveModelAsSafetensorsStandalone`/`SaveModelAsGGUFStandalone`, gain an optional `external_tensor_bytes` map so the bulk tensor data can be supplied directly instead of pulled from each `TensorProto`'s own `raw_data`.

Measured on a 2000-tensor/40MB model (min of 7 runs, comparing against the pre-fix build via `git stash`): `export_safetensors` 1.8x faster, `import_safetensors` 4.4x faster, `export_gguf` 1.6x faster, `import_gguf` 2.6x faster.

## Test plan
- [x] New pytest cases in `tests/test_python_api.py`: `export_safetensors`/`export_gguf` leave the model unchanged (parametrized over both formats), and both formats round-trip an unnamed node-attribute tensor correctly (the same positional pool-key derivation `load_model`'s hydration already relies on).
- [x] Full `tests/test_python_api.py` and `tests/test_import_gguf_weights.py` suites pass (pre-existing torch-stub-only failures excluded, unrelated to this change).
- [x] Existing `tensor_pool_bridge_test` C++ unit test suite passes unchanged.
- [x] `clang-format`, `ruff format`/`ruff check`, and `mypy` all clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqY6mNXsYwstPjnuHGUR3M

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqY6mNXsYwstPjnuHGUR3M)_