### PR TITLE
Recognize fused BiasGelu/FastGelu/QuickGelu as MatMul/Gemm chain hops

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -100,6 +100,53 @@ direct execution) and how a non-constant/tied `gamma`/`beta`/`bias`, or a
 consumed optional `mean`/`inv_std_var` output, is declined the same
 conservative way as everything above.
 
+The same optimizer tool typically fuses an FFN block's own bias-add and
+activation together too, the same way it fuses a residual `Add` into
+`SkipLayerNormalization` above: ``com.microsoft::BiasGelu(A, B) = Gelu(A +
+B)`` (erf-based, the common case) and ``com.microsoft::FastGelu(X[, bias])``
+(the tanh-approximated Gelu, with `bias` optional) both collapse an ordinary
+``MatMul -> Add(bias) -> Gelu`` FFN hop into one node -- confirmed against
+onnxruntime's own schema (`contrib_defs.cc`) and CPU kernel (`bias_gelu.cc`)
+and by direct execution. Without also recognizing these, an FFN chain this
+whole feature exists for (``up = MatMul(x, W1); h = BiasGelu(up, Bias1);
+down = MatMul(h, W2)``) would fail at that one hop and the whole chain would
+go unpruned, the same gap the `SkipLayerNormalization` fix above closed for
+residual connections. :func:`_walk_to_consumer`/
+:func:`_walk_matmul_producer_backward` (the forward and backward MatMul/Gemm
+hop walkers) both recognize a `BiasGelu`/`FastGelu` node the same way they
+already recognize a bias/scale `Add`/`Mul` hop -- see
+:func:`_match_fused_bias_gelu` and `_FUSED_BIAS_GELU_OPS`'s own comment --
+sliced by the same `keep` set alongside everything else; a non-constant bias
+(`BiasGelu`'s own schema requires one; `FastGelu`'s is optional) declines
+the node outright, never guessed at. This is a MatMul/Gemm-chain-only hop,
+deliberately not extended to Conv chains: a real Conv already carries any
+bias in its own third input (see the Conv paragraph below), and neither
+fusion targets Conv graphs in practice. `com.microsoft::QuickGelu(X) = X *
+Sigmoid(alpha * X)` -- the third Gelu-family fusion the same optimizer tool
+emits, used by some model families in place of `BiasGelu`/`FastGelu` -- is a
+simpler case still: it takes no bias operand at all (`alpha` is a node
+*attribute*, not an input), so it is exactly as unary/shape-preserving as
+`Gelu`/`Sigmoid` already in `_UNARY_PASS_THROUGH`, and is matched by simply
+being added to that set -- extending every walker that already consults it
+(both MatMul/Gemm and Conv, forward and backward alike, plus
+:func:`_trace_gate_producer_backward`'s own gated-pair gate-activation
+matcher below) for free, with no dedicated hop machinery needed. A gated
+(SwiGLU/GeGLU) pair's own gate branch fused into `BiasGelu`/`FastGelu`
+specifically (as opposed to plain `Gelu`/`Sigmoid`, or the now-unary
+`QuickGelu`) is *not* recognized by :func:`_trace_gate_producer_backward`,
+and is left out of scope deliberately rather than extended: that tracer only
+ever walks back through single-input unary ops, with nowhere on
+:class:`_Producer` to carry a gate-branch-local bias constant the way
+`_Chain.chain_ops` already does for the shared post-combine chain, so
+supporting it would need new machinery (a `_Producer`-local `chain_ops`
+counterpart), not a one-line addition like `QuickGelu`'s. It is also the
+narrower case in practice: a gated FFN's gate projection commonly carries no
+bias at all (e.g. Llama-family linear layers), and when it does, only a
+*separate* `Add`+`Gelu` on that branch is even eligible for onnxruntime's
+own fusion pass to collapse into `BiasGelu`/`FastGelu` in the first place --
+a plain unfused `Gelu`/`Sigmoid` gate (already handled) is the shape that
+survives when there's no bias to fuse to begin with.
+
 General multi-branch dependency-graph pruning -- arbitrary fan-out, non-Add
 merges (`Concat`, ...) -- remains out of scope. The
 other part of the paper's pipeline -- an architecture *search* over what to prune,
@@ -1525,9 +1572,57 @@ _UNARY_PASS_THROUGH = {
     "Mish",
     "Identity",
     "Cast",
+    # com.microsoft::QuickGelu(X) = X * Sigmoid(alpha * X) (alpha an
+    # attribute, default 1.702, not a second *input* -- confirmed against
+    # onnxruntime's own schema, contrib_defs.cc, and by direct execution,
+    # see this module's own docstring): a single-input, single-output,
+    # purely elementwise activation exactly like every other entry in this
+    # set, just from a different domain -- membership here is by op_type
+    # alone for every entry, never by domain (a same-named op in an
+    # unrelated custom domain has always been a theoretical risk this set
+    # accepts, not one unique to this entry). Being unary, it needs no
+    # dedicated hop machinery at all: adding it here alone already extends
+    # every walker that already consults `_UNARY_PASS_THROUGH` --
+    # `_walk_to_consumer`/`_walk_to_conv_consumer` (forward), their two
+    # backward counterparts, *and* `_trace_gate_producer_backward`'s own
+    # gated-pair gate-activation matcher -- for free.
+    "QuickGelu",
 }
 _BINARY_CHANNEL_OPS = {"Add", "Mul"}
 _MAX_CHAIN_HOPS = 8
+
+# com.microsoft's fused bias-add + Gelu-family activation nodes -- the FFN
+# analogue of the SkipLayerNormalization residual fusion above, done by the
+# same onnxruntime transformer-optimizer tool: `BiasGelu(A, B) = Gelu(A + B)`
+# (erf-based, exactly plain ONNX Gelu's own default `approximate="none"`)
+# and `FastGelu(X[, bias]) = Gelu_tanh(X [+ bias])` (the tanh approximation,
+# `bias` optional) both fuse an FFN's bias-add into its following activation
+# the same way `BiasGelu`'s own name suggests -- confirmed against
+# onnxruntime's own schema (`contrib_defs.cc`) and CPU kernel
+# (`bias_gelu.cc`'s shared `BiasGelu<T, use_approximation>::AddBiasGelu`,
+# which literally computes `value = input[i] + bias[i]` then erf- or
+# tanh-based Gelu on `value`) and by direct execution. Neither fusion
+# changes *which* Gelu variant is being computed -- FastGelu's tanh
+# approximation is a different formula from plain `Gelu`'s erf-based one
+# regardless of fusion, already true before this pass ever mattered to
+# either -- so, exactly like a bias/scale `Add`/`Mul` hop's own constant,
+# what matters here is only that each is a per-channel-independent,
+# shape-preserving elementwise op with one extra constant operand to slice,
+# not its particular activation math. `BiasGelu`'s own schema makes `B`
+# (bias) a *required* second input; `FastGelu`'s marks its own `bias`
+# *optional* -- both handled by :func:`_match_fused_bias_gelu` below. Like
+# the `_BINARY_CHANNEL_OPS` bias/scale hop these sit alongside, this is a
+# MatMul/Gemm-chain-only hop (:func:`_walk_to_consumer`/
+# :func:`_walk_matmul_producer_backward`): Conv chains already decline any
+# per-channel `Add`/`Mul` hop at all (a real Conv's bias already lives in
+# its own third input, see this module's own docstring), and neither
+# optimizer fusion targets Conv graphs in practice, so no Conv-side
+# analogue is added.
+_FUSED_BIAS_GELU_OPS: Dict[str, bool] = {
+    "BiasGelu": True,  # bias (input 1) required by BiasGelu's own schema
+    "FastGelu": False,  # bias (input 1) optional for FastGelu
+}
+_FUSED_BIAS_GELU_DOMAIN = "com.microsoft"
 
 _ConsumerMatch = Tuple[onnx.NodeProto, str, bool]  # (node, weight, weight_transposed)
 
@@ -1638,6 +1733,61 @@ def _match_producer(
     return w_name, weight_transposed, bias_name, n_channels
 
 
+def _match_fused_bias_gelu(
+    node: onnx.NodeProto, initializer_map: Dict[str, onnx.TensorProto]
+) -> Optional[Tuple[str, Optional[str]]]:
+    """If `node` is a ``com.microsoft::BiasGelu``/``FastGelu`` node (see
+    `_FUSED_BIAS_GELU_OPS`'s own comment above for the exact fused
+    arithmetic and how it was confirmed), returns ``(data_name,
+    bias_name_or_None)``: `data_name` is the node's own primary input (`A`/
+    `X`, input 0), and `bias_name` is its per-channel bias operand (input 1)
+    when present and a constant float initializer shaped like a flat
+    per-last-axis vector -- the same self-consistency bar
+    :func:`_walk_matmul_producer_backward`'s own `_BINARY_CHANNEL_OPS` hop
+    check already uses (the real ``dims[-1] == n_channels`` check is
+    deferred to the caller: :func:`_walk_to_consumer` already knows
+    `n_channels` and checks immediately; :func:`_walk_matmul_producer_backward`
+    doesn't yet, and defers to :func:`_find_matmul_residual_chains` once the
+    group's real channel count is known, exactly like that hop's own and
+    `_skip_layer_norm_const_names`'s own deferred check).
+
+    Declines (``None``) when `node` isn't one of these ops/domain at all, or
+    when its bias is required but missing (`BiasGelu`'s own schema makes its
+    `B` input required, unlike `FastGelu`'s optional `bias`) or present but
+    non-constant -- never guessed at, the same conservative bar a
+    non-constant bias/scale on an ordinary `Add`/`Mul` hop already gets.
+    `FastGelu` with its bias genuinely absent (omitted entirely, or present
+    as an empty placeholder) returns ``(data_name, None)`` -- no term to
+    slice, the same shape a `SkipLayerNormalization` node's own absent
+    `beta`/`bias` already gets.
+    """
+    bias_required = _FUSED_BIAS_GELU_OPS.get(node.op_type)
+    if (
+        bias_required is None
+        or node.domain != _FUSED_BIAS_GELU_DOMAIN
+        or not node.input
+        or not node.input[0]
+        or len(node.output) != 1
+    ):
+        return None
+    data_name = node.input[0]
+    has_bias_input = len(node.input) > 1 and bool(node.input[1])
+    if not has_bias_input:
+        if bias_required:
+            return None  # BiasGelu's own schema requires a bias operand
+        return data_name, None  # FastGelu with no bias -- plain tanh-Gelu(x)
+    bias_name = node.input[1]
+    bias_init = initializer_map.get(bias_name)
+    if (
+        bias_init is None
+        or bias_init.data_type != onnx.TensorProto.FLOAT
+        or not list(bias_init.dims)
+        or int(np.prod(bias_init.dims)) != bias_init.dims[-1]
+    ):
+        return None  # non-constant bias -- can't safely slice/prune it
+    return data_name, bias_name
+
+
 def _walk_to_consumer(
     start: str,
     initializer_map: Dict[str, onnx.TensorProto],
@@ -1647,9 +1797,11 @@ def _walk_to_consumer(
     max_hops: int,
 ) -> Tuple[Optional[_ConsumerMatch], Tuple[Tuple[onnx.NodeProto, Optional[str]], ...]]:
     """From tensor `start`, walks forward through shape-preserving
-    elementwise ops (an activation, or an Add/Mul against a constant
-    per-channel bias/scale) with no other consumer anywhere along the way,
-    until a MatMul/vanilla-Gemm consumer is found whose reduction
+    elementwise ops (an activation, an Add/Mul against a constant
+    per-channel bias/scale, or a fused ``com.microsoft::BiasGelu``/
+    ``FastGelu`` node -- see `_FUSED_BIAS_GELU_OPS`'s own comment and
+    :func:`_match_fused_bias_gelu`) with no other consumer anywhere along
+    the way, until a MatMul/vanilla-Gemm consumer is found whose reduction
     dimension matches `n_channels`. Returns ``(None, ())`` if the walk
     runs out of hops, hits a branch, or never reaches such a consumer.
     """
@@ -1701,6 +1853,16 @@ def _walk_to_consumer(
                 const_name = other
             else:
                 break
+        elif nxt.op_type in _FUSED_BIAS_GELU_OPS:
+            fused = _match_fused_bias_gelu(nxt, initializer_map)
+            if fused is None or fused[0] != cur:
+                break
+            _, bias_name = fused
+            if bias_name is not None and (
+                initializer_map[bias_name].dims[-1] != n_channels
+            ):
+                break
+            const_name = bias_name
         else:
             break
 
@@ -2813,6 +2975,15 @@ def _walk_matmul_producer_backward(
             # ``SkipLayerNormalization``-family node specifically) or
             # `"fail"` is correct.
 
+        if node.op_type in _FUSED_BIAS_GELU_OPS:
+            fused = _match_fused_bias_gelu(node, initializer_map)
+            if fused is not None:
+                data_name, bias_name = fused
+                chain_ops.append((node, bias_name))
+                cur = data_name
+                continue
+            return "fail", None, ()
+
         merge = _match_matmul_residual_merge(
             node, initializer_map, consumers_of, graph_outputs
         )
@@ -2953,12 +3124,14 @@ def _find_matmul_residual_chains(graph: onnx.GraphProto) -> List[_Chain]:
             continue  # branches disagree on channel count -- decline
         n_channels = next(iter(n_channels_set))
 
-        # Every bias/scale hop's constant, and every SkipLayerNorm-family
-        # merge's own gamma/beta/bias, was only self-consistently checked
-        # when first crossed/matched (see _walk_matmul_producer_backward,
-        # _match_matmul_residual_merge); now that the group's real channel
-        # count is known, re-validate it actually matches -- mirroring the
-        # depthwise-Conv-hop re-validation in _find_conv_residual_chains.
+        # Every bias/scale hop's constant (an Add/Mul hop's own, or a fused
+        # BiasGelu/FastGelu hop's own bias -- see _match_fused_bias_gelu),
+        # and every SkipLayerNorm-family merge's own gamma/beta/bias, was
+        # only self-consistently checked when first crossed/matched (see
+        # _walk_matmul_producer_backward, _match_matmul_residual_merge); now
+        # that the group's real channel count is known, re-validate it
+        # actually matches -- mirroring the depthwise-Conv-hop re-validation
+        # in _find_conv_residual_chains.
         if any(
             const_name is not None
             and initializer_map[const_name].dims[-1] != n_channels

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -1428,6 +1428,346 @@ def test_structured_pruning_chains_through_a_third_layer():
     np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
 
 
+# --- apply_structured_pruning: fused BiasGelu/FastGelu/QuickGelu hop --------
+#
+# onnxruntime's own transformer-optimizer tool typically fuses an FFN
+# block's bias-add and Gelu-family activation into one node --
+# `com.microsoft::BiasGelu(A, B) = Gelu(A + B)` (erf-based) and
+# `com.microsoft::FastGelu(X[, bias])` (the tanh approximation, bias
+# optional) both collapse `MatMul -> Add(bias) -> Gelu` into a single hop;
+# `com.microsoft::QuickGelu(X) = X * Sigmoid(alpha * X)` is a third,
+# bias-free fusion some model families use instead. Semantics confirmed
+# against onnxruntime's own schema (`contrib_defs.cc`) and CPU kernel
+# (`bias_gelu.cc`'s shared `AddBiasGelu`, `quick_gelu.cc`) and by direct
+# execution before any of this was written -- see this module's own
+# docstring for the exact arithmetic and matching functions.
+
+
+def _erf_gelu(x):
+    # math.erf rather than scipy.special.erf, matching this file's own
+    # "needs no scipy/erf" convention for the tanh-approximated Gelu oracle
+    # above -- math.erf is stdlib, no extra dependency either.
+    import math
+
+    return 0.5 * x * (1.0 + np.vectorize(math.erf)(x / np.sqrt(2.0)))
+
+
+def _tanh_gelu(x):
+    return 0.5 * x * (1.0 + np.tanh(np.sqrt(2.0 / np.pi) * (x + 0.044715 * x**3)))
+
+
+def _quick_gelu(x, alpha=1.702):
+    return x * (1.0 / (1.0 + np.exp(-alpha * x)))
+
+
+def test_structured_pruning_bias_gelu_chain_matches_oracle():
+    # up = MatMul(x, W1); h = BiasGelu(up, Bias1); down = MatMul(h, W2) --
+    # the realistic fused-FFN shape this feature exists for. W1, Bias1, and
+    # W2 must all be sliced to the same combined-importance keep set.
+    K, H, Out = 8, 16, 4
+    rng = np.random.default_rng(120)
+    w1 = rng.standard_normal((K, H)).astype(np.float32)
+    bias1 = rng.standard_normal((H,)).astype(np.float32)
+    w2 = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          up = MatMul(X, W1)
+          h = com.microsoft.BiasGelu(up, Bias1)
+          Y = MatMul(h, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(bias1, "Bias1"), _f32(w2, "W2")],
+        opset=17,
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [K, H // 2]
+    assert list(inits["Bias1"].dims) == [H // 2]
+    assert list(inits["W2"].dims) == [H // 2, Out]
+
+    keep = _oracle_keep_indices(w1, H // 2)
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    h = _erf_gelu(x @ w1[:, keep] + bias1[keep])
+    y_oracle = h @ w2[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_structured_pruning_bias_gelu_declines_on_nonconstant_bias():
+    # BiasGelu's own schema makes its bias operand required, but here it's a
+    # graph input rather than a constant initializer -- can't safely slice
+    # it, so the whole chain is declined and the model is left
+    # byte-identical, the same conservative bar a non-constant Gemm bias
+    # already gets elsewhere in this module.
+    K, H, Out = 8, 16, 4
+    rng = np.random.default_rng(121)
+    w1 = rng.standard_normal((K, H)).astype(np.float32)
+    w2 = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X, float[{H}] Bias1) => (float[batch,{Out}] Y)
+        {{
+          up = MatMul(X, W1)
+          h = com.microsoft.BiasGelu(up, Bias1)
+          Y = MatMul(h, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2")],
+        opset=17,
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
+def test_structured_pruning_fast_gelu_with_bias_chain_matches_oracle():
+    # FastGelu's own bias is optional but present here -- same per-channel
+    # slicing bar as BiasGelu's required one, just via a different schema
+    # path (_match_fused_bias_gelu's own bias_required=False branch),
+    # and the tanh-approximated Gelu formula rather than the erf-based one.
+    K, H, Out = 8, 16, 4
+    rng = np.random.default_rng(122)
+    w1 = rng.standard_normal((K, H)).astype(np.float32)
+    bias1 = rng.standard_normal((H,)).astype(np.float32)
+    w2 = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          up = MatMul(X, W1)
+          h = com.microsoft.FastGelu(up, Bias1)
+          Y = MatMul(h, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(bias1, "Bias1"), _f32(w2, "W2")],
+        opset=17,
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Bias1"].dims) == [H // 2]
+
+    keep = _oracle_keep_indices(w1, H // 2)
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    h = _tanh_gelu(x @ w1[:, keep] + bias1[keep])
+    y_oracle = h @ w2[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_structured_pruning_fast_gelu_no_bias_chain_matches_oracle():
+    # FastGelu with its own optional bias genuinely absent -- exercises
+    # _match_fused_bias_gelu's own "bias omitted entirely" branch (a plain
+    # tanh-Gelu(x), no per-channel constant to slice at all).
+    K, H, Out = 8, 16, 4
+    rng = np.random.default_rng(123)
+    w1 = rng.standard_normal((K, H)).astype(np.float32)
+    w2 = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          up = MatMul(X, W1)
+          h = com.microsoft.FastGelu(up)
+          Y = MatMul(h, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2")],
+        opset=17,
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [K, H // 2]
+    assert list(inits["W2"].dims) == [H // 2, Out]
+
+    keep = _oracle_keep_indices(w1, H // 2)
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    h = _tanh_gelu(x @ w1[:, keep])
+    y_oracle = h @ w2[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_structured_pruning_quick_gelu_chain_matches_oracle():
+    # QuickGelu(X) = X * Sigmoid(alpha * X) takes no bias operand at all
+    # (alpha is a node attribute, not a second input), so -- unlike
+    # BiasGelu/FastGelu -- it needed no dedicated hop machinery, only
+    # joining `_UNARY_PASS_THROUGH`. Still gets its own oracle-verified
+    # test rather than assuming that "just works" from set membership alone.
+    K, H, Out = 8, 16, 4
+    rng = np.random.default_rng(124)
+    w1 = rng.standard_normal((K, H)).astype(np.float32)
+    w2 = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          up = MatMul(X, W1)
+          h = com.microsoft.QuickGelu(up)
+          Y = MatMul(h, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2")],
+        opset=17,
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [K, H // 2]
+    assert list(inits["W2"].dims) == [H // 2, Out]
+
+    keep = _oracle_keep_indices(w1, H // 2)
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    h = _quick_gelu(x @ w1[:, keep])
+    y_oracle = h @ w2[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_structured_pruning_conv_bias_gelu_hop_is_not_recognized():
+    # This fused-bias-activation hop is deliberately MatMul/Gemm-only (see
+    # this module's own docstring): a real Conv already carries any bias in
+    # its own third input, and neither optimizer fusion targets Conv graphs
+    # in practice. A Conv -> BiasGelu -> Conv chain must therefore be left
+    # completely untouched, the same as any other unrecognized hop.
+    Cin, Cmid, Cout, spatial = 4, 8, 6, 10
+    rng = np.random.default_rng(125)
+    w1 = rng.standard_normal((Cmid, Cin, 3, 3)).astype(np.float32)
+    bias1 = rng.standard_normal((Cmid,)).astype(np.float32)
+    w2 = rng.standard_normal((Cout, Cmid, 3, 3)).astype(np.float32)
+    mid_spatial = spatial - 2
+    out_spatial = mid_spatial - 2
+    model = _model(
+        f"""
+        g (float[N,{Cin},{spatial},{spatial}] X) => (float[N,{Cout},{out_spatial},{out_spatial}] Y)
+        {{
+          up = Conv<kernel_shape=[3,3]>(X, W1)
+          h = com.microsoft.BiasGelu(up, Bias1)
+          Y = Conv<kernel_shape=[3,3]>(h, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(bias1, "Bias1"), _f32(w2, "W2")],
+        opset=17,
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
+def test_structured_wanda_pruning_bias_gelu_chain_matches_oracle():
+    # apply_structured_wanda_pruning picks up the fused BiasGelu hop for
+    # free (the same _find_chains/_walk_to_consumer chain-finder as plain
+    # apply_structured_pruning) -- oracle-verified with real calibration
+    # data driving the activation-norm-weighted importance ranking.
+    K, H, Out = 8, 16, 4
+    rng = np.random.default_rng(126)
+    w1 = rng.standard_normal((K, H)).astype(np.float32)
+    bias1 = rng.standard_normal((H,)).astype(np.float32)
+    w2 = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          up = MatMul(X, W1)
+          h = com.microsoft.BiasGelu(up, Bias1)
+          Y = MatMul(h, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(bias1, "Bias1"), _f32(w2, "W2")],
+        opset=17,
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+
+    rng_cal = np.random.default_rng(127)
+    x_cal = rng_cal.standard_normal((32, K)).astype(np.float32)
+    calibration_data = [{"X": x_cal}]
+
+    pruned = onnxsim.apply_structured_wanda_pruning(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned)
+
+    # The activation norm is captured where the chain feeds its consumer --
+    # i.e. after BiasGelu, not the producer's raw pre-activation output.
+    h_cal = _erf_gelu(x_cal @ w1 + bias1)
+    act_norm = np.sqrt(np.mean(np.square(h_cal), axis=0))
+    importance = np.linalg.norm(w1.T, axis=1) * np.maximum(act_norm, 1e-8)
+    keep = np.sort(np.argsort(-importance)[: H // 2])
+
+    x = rng_cal.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    h = _erf_gelu(x @ w1[:, keep] + bias1[keep])
+    y_oracle = h @ w2[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_structured_pruning_matmul_residual_add_bias_gelu_hop_matches_oracle():
+    # One residual branch has a fused BiasGelu between its producer and the
+    # merge point -- exercises _walk_matmul_producer_backward's own new
+    # BiasGelu/FastGelu hop (the backward mirror of the forward walk's own
+    # hop tested above), telling it apart from the bare Add residual merge
+    # it sits next to.
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(128)
+    w1 = rng.standard_normal((K, C)).astype(np.float32)
+    bias1 = rng.standard_normal((C,)).astype(np.float32)
+    ws = rng.standard_normal((K, C)).astype(np.float32)
+    wout = rng.standard_normal((C, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          h = MatMul(X, W1)
+          f = com.microsoft.BiasGelu(h, Bias1)
+          s = MatMul(X, WS)
+          addr = Add(f, s)
+          r = Relu(addr)
+          Y = MatMul(r, WOUT)
+        }}
+        """,
+        initializer=[
+            _f32(w1, "W1"),
+            _f32(bias1, "Bias1"),
+            _f32(ws, "WS"),
+            _f32(wout, "WOUT"),
+        ],
+        opset=17,
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Bias1"].dims) == [C // 2]
+
+    importance = np.sqrt(
+        np.square(np.linalg.norm(w1.astype(np.float64), axis=0))
+        + np.square(np.linalg.norm(ws.astype(np.float64), axis=0))
+    )
+    keep = np.sort(np.argsort(-importance)[: C // 2])
+
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    f = _erf_gelu(x @ w1[:, keep] + bias1[keep])
+    s = x @ ws[:, keep]
+    y_oracle = np.maximum(f + s, 0) @ wout[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+
 # --- apply_structured_pruning: gated FFN (SwiGLU/GeGLU) ----------------------
 
 
@@ -1529,6 +1869,52 @@ def test_structured_pruning_gelu_gated_ffn_matches_oracle():
 
     g = x @ wg[:, keep]
     gate = 0.5 * g * (1.0 + np.tanh(np.sqrt(2.0 / np.pi) * (g + 0.044715 * g**3)))
+    up = x @ wu[:, keep]
+    y_oracle = (gate * up) @ wd[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_structured_pruning_quick_gelu_gated_ffn_matches_oracle():
+    # A gate branch fused into com.microsoft::QuickGelu -- some real
+    # gated-FFN model families use this in place of a plain Sigmoid/Gelu
+    # gate. QuickGelu is unary (no bias operand at all), so it needed no
+    # dedicated gated-chain machinery -- adding it to _UNARY_PASS_THROUGH
+    # alone already lets _trace_gate_producer_backward's own unary-only
+    # backward trace recognize it, the same way it already recognizes a
+    # plain Sigmoid/Gelu gate above. Confirmed here rather than assumed:
+    # this module's own docstring explicitly declines the *bias-carrying*
+    # BiasGelu/FastGelu fusion on a gate branch (out of scope, see there),
+    # but QuickGelu -- bias-free -- is not that case.
+    K, H, Out = 8, 16, 4
+    rng = np.random.default_rng(129)
+    wg = rng.standard_normal((K, H)).astype(np.float32)
+    wu = rng.standard_normal((K, H)).astype(np.float32)
+    wd = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          gate = MatMul(X, Wg)
+          gate_act = com.microsoft.QuickGelu(gate)
+          up = MatMul(X, Wu)
+          h = Mul(gate_act, up)
+          Y = MatMul(h, Wd)
+        }}
+        """,
+        initializer=[_f32(wg, "Wg"), _f32(wu, "Wu"), _f32(wd, "Wd")],
+        opset=17,
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    keep = _combined_keep_indices(wg, wu, H // 2)
+
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+
+    g = x @ wg[:, keep]
+    gate = _quick_gelu(g)
     up = x @ wu[:, keep]
     y_oracle = (gate * up) @ wd[keep, :]
     np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)


### PR DESCRIPTION
## Summary
- The MatMul/Gemm chain walkers (`_walk_to_consumer`/`_walk_matmul_producer_backward`) allow passing through a bounded set of shape-preserving hops between a producer and consumer — unary activations (`_UNARY_PASS_THROUGH`) and a per-channel bias/scale `Add`/`Mul`. But the same ONNX Runtime transformer-optimizer tool that produces `com.microsoft::SkipLayerNormalization` (just recognized in a prior PR) also fuses an FFN block's own bias-add and activation into one node — `com.microsoft::BiasGelu(A, B) = Gelu(A + B)` and `FastGelu(X[, bias])` (tanh-approximated, bias optional) — which the chain walk couldn't recognize at all: `BiasGelu` isn't unary (two inputs) and isn't `Add`/`Mul`. So `up = MatMul(x, W1); h = BiasGelu(up, Bias1); down = MatMul(h, W2)` — the exact "prune an FFN's intermediate dim" case this module's own docstring already cites as a basic working scenario — would fail at that one hop and go entirely unpruned on a realistically-optimized model. Same class of gap the `SkipLayerNormalization` fix closed for residual connections, this time for an ordinary interior hop.
- **Operator semantics confirmed, not assumed**: fetched onnxruntime's own source directly (`contrib_defs.cc`/`bert_defs.cc` for the schemas, `bias_gelu.cc`/`bias_gelu_helper.h` for the exact kernel arithmetic) — confirmed `BiasGelu`'s bias is schema-*required*, `FastGelu`'s is schema-*optional*, both computing `Gelu(A+B)` (erf-based for `BiasGelu`, tanh-approximated for `FastGelu`) on the summed value, and that `bias` must be a flat, last-axis-matching vector. Then empirically verified against this environment's real onnxruntime (1.29.0) across several small graphs before writing any pruning logic against that understanding.
- New `_match_fused_bias_gelu`/`_FUSED_BIAS_GELU_OPS` recognize `BiasGelu`/`FastGelu` on both the forward (`_walk_to_consumer`) and backward (`_walk_matmul_producer_backward`, used by MatMul/Gemm residual-chain resolution) walkers symmetrically, emitting the same `(node, bias_name)` `chain_ops` shape an ordinary bias/scale hop already does — so `_apply_chains`'s existing slicing, touched-role tracking, and `_find_matmul_residual_chains`'s existing deferred-channel-count revalidation all pick it up with zero further changes.
- `com.microsoft::QuickGelu(X) = X * Sigmoid(alpha*X)` (`alpha` a node attribute, not an input) takes no bias operand at all — genuinely unary, so it's just a one-line addition to `_UNARY_PASS_THROUGH`, extending every walker that already consults that set (Conv and MatMul/Gemm, forward and backward, plus the gated-FFN gate-branch tracer) for free.
- **Deliberately not extended to Conv chains**: a real Conv's bias already lives in its own third input, and neither optimizer fusion targets Conv graphs in practice — confirmed with a dedicated decline test (model left byte-identical).
- **A gated (SwiGLU/GeGLU) pair's own gate branch fused into `BiasGelu`/`FastGelu` specifically is left out of scope, honestly, with a real reason**: `_trace_gate_producer_backward` only ever walks back through single-input unary ops, and `_Producer` has no `chain_ops`-equivalent slot to carry a gate-branch-local bias constant — supporting it needs new per-producer bias-hop plumbing, not a one-line addition. It's also the narrower case in practice (bias-free gate projections are common, and only a *separate*, unfused `Add`+`Gelu` on a gate branch is even eligible for this specific ORT fusion to begin with). `QuickGelu` on a gate branch *is* in scope (bias-free, free via the unary-set addition) and has its own oracle test.
- Non-constant bias (on `BiasGelu` or a present `FastGelu` bias) declines the whole chain, never guessed at.
- **Independently verified beyond the PR's own tests**: built a fresh model with conflicting per-branch importance (not reusing the PR's own test code) spanning both the weight *and* the bias, confirmed every sliced tensor matches the hand-computed importance-ranked indices exactly at the index level, and confirmed the real onnxruntime output matches a hand-built oracle exactly.

## Test plan
- [x] `pytest tests/test_pruning.py -q` — 155 passed (up from 146)
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — clean
- [x] Independent verification: conflicting-importance model (weight + bias) re-derived by hand and confirmed via onnxruntime with a fresh test case

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_