### PR TITLE
Add target_opset_version="latest", profile ConvertOpsetVersion, fix its "back to protobuf" copy cost

### DIFF
--- a/bench/RESULTS_opset_version_converter.md
+++ b/bench/RESULTS_opset_version_converter.md
@@ -1,0 +1,129 @@
+# Opset version converter: profiling `target_opset_version` and fixing the "back to protobuf" cost
+
+**Goal:** the opset version converter (`target_opset_version`, `onnx::version_conversion::ConvertVersion`)
+is opt-in and effectively unused in onnxsim's own test suite (two tiny dedicated
+tests). Before considering it for wider use, profile it and fix what's actually
+slow.
+
+**Tool:** [`bench/opset_conversion_profile.py`](./opset_conversion_profile.py)
+(new) -- synthetic, self-contained (no downloads): a low-opset (9) Conv/BatchNorm/Relu
+stack with real numpy-backed initializer weights, at a few sizes, run through
+`simplify(model, target_opset_version="latest", profile=...)` in a subprocess,
+parsing the same `ONNXSIM_PROFILE` summary table `profile_sample.py` uses.
+**Build:** this session's `HEAD`, `onnxsim` built via the normal wheel path
+(`ONNXSIM_BUILTIN_ORT=OFF`), vendored `third_party/onnx` at `bea23e9` plus the
+fix below (max supported default-domain opset: 28).
+
+## Two changes needed before this was even measurable
+
+1. **`target_opset_version="latest"`** (`onnx_simplifier.py`, CLI `--target-opset
+   latest`): resolves to the highest default-domain opset this build's
+   compiled-in onnx schema registry supports (a new `C.max_default_domain_opset_version()`
+   binding), *not* the pip `onnx` package's `onnx.defs.onnx_opset_version()` --
+   onnxsim vendors its own fork, which can differ. The `None` default (no
+   conversion) is unchanged; this is purely an added way to opt in.
+2. **`ConvertOpsetVersion` was invisible to `ONNXSIM_PROFILE`.** In
+   `onnxsim.cpp`, the call ran *before* the `Simplify` root `ProfiledScope`, so
+   its cost never appeared in the flame graph or the pass-phase summary table --
+   it would have shown up only as unaccounted time before the first pass. Fixed
+   by giving it its own `ProfiledScope("ConvertOpsetVersion")`, sibling to
+   `Simplify`.
+
+## Finding #1: the "back to protobuf" cost -- confirmed, and fixed
+
+`onnx::version_conversion::ConvertVersion` always went through the *copying*
+`ImportModelProto(const ModelProto&)` / default `ExportModelProto(...,
+consume_tensor_data=false)`, duplicating every initializer's raw bytes twice
+(once into the internal Graph IR, once back out) on every call -- even though
+`third_party/onnx/onnx/common/ir_pb_converter.h` already ships moving/consuming
+overloads (`ImportModelProto(ModelProto&)`, `ExportModelProto(...,
+consume_tensor_data=true)`) built for onnx-optimizer's own
+`Optimizer::optimize()`. The version converter simply never adopted them.
+
+**Fix:** added `convert_version(ModelProto&, ...)` / `ConvertVersion(ModelProto&,
+int)` consuming overloads (in `third_party/onnx`, purely additive -- the
+original const-ref copying overloads are untouched, so `onnx`'s own Python
+bindings and any other caller are unaffected) and wired onnxsim's
+`ConvertOpsetVersion` to reach them by taking its model by value and having the
+call site `std::move` it in.
+
+**Measured (median of 5 trials, `ConvertOpsetVersion` span only, same binary,
+`ONNXSIM_BENCH_FORCE_COPYING_CONVERT` env toggle used locally for the A/B and
+removed before committing):**
+
+| model | initializer bytes | before (copying) | after (moving) | speedup |
+|---|---:|---:|---:|---:|
+| tiny (1 block) | 0.0 MB | 4.44 ms | 4.31 ms | ~1.0x (no data to copy) |
+| medium (20 blocks) | 3.0 MB | 10.13 ms | 6.29 ms | 1.6x |
+| large (40 blocks) | 13.3 MB | 28.89 ms | 7.99 ms | 3.6x |
+| xlarge (100 blocks) | 92.5 MB | 143.94 ms | 25.55 ms | **5.6x** |
+
+The gap grows with initializer bytes and nothing else -- consistent with a
+data-copy cost eliminated, not an algorithmic one. For any model with
+non-trivial weights (i.e. most real models), this alone is a multi-x win on
+the opset-conversion step specifically.
+
+## Finding #2: a flat ~4ms per-call floor, unrelated to model size or step count
+
+Isolating the fixed part (tiny model, 3 nodes, varying only the starting
+opset so `ConvertOpsetVersion` takes 0, 1, or ~19 steps to reach opset 28):
+
+| start opset | steps to target | `ConvertOpsetVersion` |
+|---|---:|---:|
+| 28 (== target) | 0 (early-out, `ConvertVersion` never called) | 0.03 ms |
+| 27 | 1 | 4.53 ms |
+| 9 | ~19 | 4.13 ms |
+
+Going from 0 steps to 1 step costs ~4.5ms; going from 1 step to 19 steps costs
+*nothing* measurable. So this floor is not the per-step graph walk -- it's the
+fixed cost of constructing a `DefaultVersionConverter` at all: its constructor
+rebuilds `all_schemas` from `OpSchemaRegistry::get_all_schemas_with_history()`
+(copies every registered `OpSchema`, across all ops and versions) and
+re-registers on the order of a thousand hardcoded adapters via
+`std::make_unique<...>`, from scratch, on every single `ConvertVersion()` call
+-- see `third_party/onnx/onnx/version_converter/convert.h`'s constructor and
+`convert.cc`'s `DefaultVersionConverter v;` local.
+
+For anything under a few MB of initializers (i.e. a lot of real models), this
+~4ms floor is comparable to or larger than Finding #1's data-copy cost, and
+today it's paid on *every* `simplify(..., target_opset_version=...)` call
+regardless of model size.
+
+**Not fixed in this pass.** A naive "build the `DefaultVersionConverter` once,
+cache it as a process-wide static" is unsound: onnxsim registers additional
+op schemas into the *same* live `OpSchemaRegistry` at runtime, per model
+(`RegisterCustomDefaultDomainOpSchemas`, `RegisterContribOpSchemas`, and
+Python's `import_onnx_schemas()` bridging `onnx.defs.register_schema`), so a
+cache built on the first call could go stale and either miss a later model's
+custom op (throwing "no registered schema") or silently ignore it. A correct
+fix needs a cheap way to know the schema registry hasn't changed since the
+cache was built; `OpSchemaRegistry` exposes no such generation counter today
+(and its backing map is private), so this needs either:
+
+- adding a mutation counter to `OpSchemaRegistry` itself (touches onnx core,
+  bumped in `RegisterSchema`/`DeregisterSchema`), or
+- a narrower, onnxsim-side counter bumped at onnxsim's own schema-registration
+  call sites, threaded through into the fork's `ConvertVersion()` as an
+  optional cache-invalidation hint.
+
+Either is a real architecture change to code this session hasn't stress-tested
+sufficiently to ship with confidence, given the correctness stakes (silently
+converting a model with a stale/missing custom-op adapter is worse than the
+~4ms it would save). Recommended as a follow-up, not attempted here.
+
+## What's shipped
+
+- `onnxsim/onnx_simplifier.py`, `onnxsim/cpp2py_export.cc`: `target_opset_version="latest"`.
+- `onnxsim/onnxsim.cpp`: `ConvertOpsetVersion` now profiled.
+- `onnxsim/model_prep.{h,cpp}`: `ConvertOpsetVersion` takes its model by value
+  and forwards it as a mutable lvalue so the call reaches the new consuming
+  overload; call site `std::move`s the model in.
+- `third_party/onnx` (branch `claude/onnx-version-converter-perf`, pushed to
+  `onnxsim/onnx`, not yet merged/re-pinned): the consuming `convert_version`
+  / `ConvertVersion` overloads.
+- `bench/opset_conversion_profile.py`: the profiling script used above, kept
+  for re-measuring after a Finding #2 fix or against real models.
+
+**Verified:** `tests/test_python_api.py`'s two `target_opset_version` tests and
+the full `test_python_api.py` module pass; CLI (`--target-opset latest`) and
+Python API (`target_opset_version="latest"`) both smoke-tested end to end.

--- a/bench/opset_conversion_profile.py
+++ b/bench/opset_conversion_profile.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Profile onnxsim's opset version converter path (``target_opset_version``).
+
+Follow-up to ``RESULTS_profiling_survey.md``, which found the Python<->C++
+marshalling boundary dominating simplify()'s *unprofiled* time. That report's
+fix (passing paths through, avoiding a double SerializeToString) closed one
+"invisible to ONNXSIM_PROFILE" gap. This script targets a second one:
+``ConvertOpsetVersion`` (the C++ wrapper around onnx's version converter,
+``onnx::version_conversion::ConvertVersion``) used to run *before* the
+profiled "Simplify" root span in onnxsim.cpp, so its cost never showed up in
+``ONNXSIM_PROFILE`` output at all -- see onnxsim.cpp's ConvertOpsetVersion
+call site. It is now wrapped in its own "ConvertOpsetVersion" span, sibling to
+"Simplify", so this script can measure it directly.
+
+Synthetic models (not a downloaded regression model) so this is
+self-contained and reproducible: a low-opset (9) CNN-shaped graph, built at a
+few sizes, with real numpy-backed initializer weights -- large enough for the
+Import/Export "back to protobuf" (ModelProto <-> onnx IR Graph) tensor-copy
+cost highlighted in issue discussion to be visible, small enough to run
+quickly and stay within sandbox disk/memory limits.
+
+Usage:
+    python bench/opset_conversion_profile.py [--trials N] [--target latest]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import resource
+import subprocess
+import sys
+import tempfile
+import time
+
+import numpy as np
+import onnx
+from onnx import numpy_helper, parser
+
+WORK_DIR = os.environ.get("OPSET_PROFILE_DIR", tempfile.mkdtemp(prefix="onnxsim_opset_profile_"))
+
+
+def _conv_bn_relu_block(idx: int, channels: int) -> tuple[str, list[onnx.TensorProto]]:
+    """One Conv+BatchNormalization+Relu block as an onnx-text fragment, plus its
+    initializers (weights sized to give the model real tensor bytes to copy)."""
+    w_name, b_name = f"w{idx}", f"b{idx}"
+    scale, bias, mean, var = f"s{idx}", f"bs{idx}", f"m{idx}", f"v{idx}"
+    w = numpy_helper.from_array(
+        np.random.randn(channels, channels, 3, 3).astype(np.float32) * 0.01, name=w_name
+    )
+    b = numpy_helper.from_array(np.zeros(channels, dtype=np.float32), name=b_name)
+    s = numpy_helper.from_array(np.ones(channels, dtype=np.float32), name=scale)
+    bs = numpy_helper.from_array(np.zeros(channels, dtype=np.float32), name=bias)
+    m = numpy_helper.from_array(np.zeros(channels, dtype=np.float32), name=mean)
+    v = numpy_helper.from_array(np.ones(channels, dtype=np.float32), name=var)
+    prev = "x" if idx == 0 else f"y{idx - 1}"
+    body = f"""
+        c{idx} = Conv<pads=[1,1,1,1]>({prev}, {w_name}, {b_name})
+        n{idx} = BatchNormalization(c{idx}, {scale}, {bias}, {mean}, {var})
+        y{idx} = Relu(n{idx})
+    """
+    return body, [w, b, s, bs, m, v]
+
+
+def build_model(num_blocks: int, channels: int = 64, opset: int = 9) -> onnx.ModelProto:
+    """A num_blocks-deep Conv/BN/Relu stack at a low opset, so
+    target_opset_version="latest" has real adapter work to do (BatchNormalization
+    alone changed shape at opsets 9, 14; Conv/Relu are stable but still walked)."""
+    bodies, inits = [], []
+    for i in range(num_blocks):
+        body, block_inits = _conv_bn_relu_block(i, channels)
+        bodies.append(body)
+        inits.extend(block_inits)
+
+    last = f"y{num_blocks - 1}"
+    text = f"""
+        <ir_version: 8, opset_import: ["": {opset}]>
+        graph (float[1,{channels},32,32] x) => (float[1,{channels},32,32] {last})
+        {{
+            {"".join(bodies)}
+        }}
+    """
+    model = parser.parse_model(text)
+    model.graph.initializer.extend(inits)
+    return model
+
+
+CHILD_SRC = r'''
+import json, resource, sys, time
+import onnx
+from onnxsim import simplify
+
+model_path = sys.argv[1]
+profile_path = sys.argv[2]
+target = sys.argv[3]
+target = "latest" if target == "latest" else int(target)
+
+model = onnx.load(model_path)
+t0 = time.time()
+sim, ok = simplify(model, target_opset_version=target, profile=profile_path)
+dt = time.time() - t0
+peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0
+opset = next(o.version for o in sim.opset_import if o.domain in ("", "ai.onnx"))
+print("__CHILDRESULT__" + json.dumps({
+    "seconds": round(dt, 4),
+    "peak_rss_mb": round(peak, 1),
+    "valid": bool(ok),
+    "result_opset": opset,
+}))
+'''
+
+
+def run_child(model_path: str, profile_path: str, target: str):
+    args = [sys.executable, "-c", CHILD_SRC, model_path, profile_path, target]
+    proc = subprocess.run(args, capture_output=True, text=True)
+    result = None
+    for line in proc.stdout.splitlines():
+        if line.startswith("__CHILDRESULT__"):
+            result = json.loads(line[len("__CHILDRESULT__"):])
+    return result, proc.stdout, proc.stderr
+
+
+def parse_summary_table(stdout: str) -> dict:
+    lines = stdout.splitlines()
+    rows = {}
+    in_table = False
+    for line in lines:
+        if "onnxsim profiling summary" in line:
+            in_table = True
+            continue
+        if not in_table:
+            continue
+        if line.startswith("function") or line.startswith("---"):
+            continue
+        if not line.strip():
+            break
+        m = re.match(r"^(\s*)(\S+)\s+(\d+)\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)\s*$", line)
+        if not m:
+            continue
+        indent, name, calls, wall, cpu, max_wall, peak = m.groups()
+        rows[name.strip()] = {
+            "calls": int(calls),
+            "wall_ms": float(wall),
+            "peak_mib": float(peak),
+        }
+    return rows
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--trials", type=int, default=3)
+    ap.add_argument("--target", default="latest")
+    ap.add_argument(
+        "--configs",
+        default="tiny:1:16,large:40:96",
+        help="comma-separated name:num_blocks:channels configs",
+    )
+    args = ap.parse_args()
+
+    os.makedirs(WORK_DIR, exist_ok=True)
+    print(f"work dir: {WORK_DIR}\n")
+
+    for cfg in args.configs.split(","):
+        name, num_blocks, channels = cfg.split(":")
+        num_blocks, channels = int(num_blocks), int(channels)
+        model = build_model(num_blocks, channels)
+        model_path = os.path.join(WORK_DIR, f"{name}.onnx")
+        onnx.save(model, model_path)
+        total_init_bytes = sum(len(t.raw_data) for t in model.graph.initializer)
+        print(f"=== {name}: {num_blocks} blocks, {channels} ch, "
+              f"{len(model.graph.node)} nodes, "
+              f"{total_init_bytes / 1e6:.1f} MB initializers, opset 9 -> {args.target} ===")
+
+        trial_results = []
+        for t in range(args.trials):
+            profile_path = os.path.join(WORK_DIR, f"{name}_trial{t}.json")
+            result, out, err = run_child(model_path, profile_path, args.target)
+            if result is None:
+                print(f"  trial {t}: CRASHED\n--- stdout ---\n{out[-2000:]}\n--- stderr ---\n{err[-2000:]}")
+                continue
+            table = parse_summary_table(out)
+            convert = table.get("ConvertOpsetVersion")
+            simplify_span = table.get("Simplify")
+            trial_results.append({
+                "seconds": result["seconds"],
+                "peak_rss_mb": result["peak_rss_mb"],
+                "convert_ms": convert["wall_ms"] if convert else None,
+                "simplify_ms": simplify_span["wall_ms"] if simplify_span else None,
+            })
+            conv_str = f"{convert['wall_ms']:.2f}ms" if convert else "n/a (not profiled?)"
+            simp_str = f"{simplify_span['wall_ms']:.2f}ms" if simplify_span else "n/a"
+            print(f"  trial {t}: total={result['seconds']:.3f}s peak={result['peak_rss_mb']:.1f}MiB "
+                  f"ConvertOpsetVersion={conv_str} Simplify={simp_str} "
+                  f"result_opset={result['result_opset']} valid={result['valid']}")
+
+        if trial_results:
+            conv_vals = [r["convert_ms"] for r in trial_results if r["convert_ms"] is not None]
+            if conv_vals:
+                print(f"  -> ConvertOpsetVersion median: {sorted(conv_vals)[len(conv_vals)//2]:.2f}ms "
+                      f"(min={min(conv_vals):.2f}ms, max={max(conv_vals):.2f}ms)")
+        print()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -323,6 +323,19 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
 
   using namespace py::literals;
 
+  // The maximum default-domain ("" / "ai.onnx") opset version this build's
+  // compiled-in onnx schema registry knows about -- i.e. what
+  // target_opset_version="latest" resolves to. Exposed so the Python side can
+  // resolve "latest" against the same registry ConvertOpsetVersion itself
+  // uses, rather than guessing from the (possibly differently-versioned)
+  // pip-installed `onnx` package.
+  m.def("max_default_domain_opset_version", []() {
+    return onnx::OpSchemaRegistry::DomainToVersionRange::Instance()
+        .Map()
+        .at("")
+        .second;
+  });
+
   // Compute the model metrics (op counts, size, MACs, memory access, peak
   // footprint) in C++ so the Python ``model_info`` can delegate the counting to
   // a single implementation. The symbolic metrics are returned as

--- a/onnxsim/model_prep.cpp
+++ b/onnxsim/model_prep.cpp
@@ -7,6 +7,7 @@
 #include <cstring>
 #include <set>
 #include <stdexcept>
+#include <utility>
 
 #include "constant_folding.h"
 #include "contrib_schemas.h"
@@ -497,7 +498,14 @@ void RemoveUnusedOutputs(onnx::ModelProto& model,
 // custom/other-domain opset imports are left untouched. Returns the model
 // unchanged when it is already at the requested version or does not import the
 // default domain.
-onnx::ModelProto ConvertOpsetVersion(const onnx::ModelProto& model,
+//
+// Takes ``model`` by value, and passes it as a mutable lvalue to
+// ConvertVersion below, so the call chain resolves to ConvertVersion's
+// consuming overload -- which moves initializer bytes through the Graph IR
+// round trip instead of copying them -- rather than the copying, const-ref
+// overload. Callers should ``std::move`` in a model they no longer need, so
+// this by-value parameter is itself move-constructed rather than copied.
+onnx::ModelProto ConvertOpsetVersion(onnx::ModelProto model,
                                      int target_version) {
   const auto current = DefaultOpsetVersion(model);
   if (!current || *current == target_version) {

--- a/onnxsim/model_prep.h
+++ b/onnxsim/model_prep.h
@@ -206,8 +206,10 @@ void RemoveUnusedOutputs(onnx::ModelProto& model,
                          const std::vector<std::string>& unused_output);
 
 // Convert the default ONNX domain of the model to target_version using onnx's
-// own version converter.
-onnx::ModelProto ConvertOpsetVersion(const onnx::ModelProto& model,
+// own version converter. Takes ``model`` by value so a caller who no longer
+// needs their copy can ``std::move`` it in and get a move-only, non-copying
+// conversion; see the .cpp for why.
+onnx::ModelProto ConvertOpsetVersion(onnx::ModelProto model,
                                      int target_version);
 
 // Shared schema setup for the single-pass debug helpers and the quantization

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -1176,7 +1176,7 @@ def simplify(
     inline_functions: bool = False,
     import_custom_schemas: bool = True,
     input_shapes=None,
-    target_opset_version: Optional[int] = None,
+    target_opset_version: Optional[Union[int, Literal["latest"]]] = None,
     extra_optimizers: Optional[List[str]] = None,
     custom_rewriter: Optional[ModelRewriter] = None,
     function_rewrite_rules: Optional[Sequence[FunctionRewriteRule]] = None,
@@ -1229,7 +1229,11 @@ def simplify(
     :param target_opset_version: Convert the model to this opset version (of the default ONNX domain)
             before simplifying, using onnx's version converter (run inside the C++ core so every
             binding shares the behavior). This can be used to upgrade (or downgrade) the model's
-            opset during simplification. When None (the default), the opset version is left unchanged.
+            opset during simplification. Pass the literal string ``"latest"`` to resolve to the
+            highest default-domain opset version this onnxsim build's compiled-in onnx schema
+            registry supports (note this can differ from the pip-installed ``onnx`` package's own
+            ``onnx.defs.onnx_opset_version()``, since onnxsim vendors its own onnx fork). When None
+            (the default), the opset version is left unchanged.
     :param extra_optimizers: The counterpart to ``skipped_optimizers``: run these named onnx-optimizer
             passes in addition to the default fuse/elimination set, rather than excluding some of it.
             This is how a pass registered as ``PassType::Other`` -- excluded from the default set
@@ -1369,6 +1373,18 @@ def simplify(
     # degrade to no folding. Checking here turns a misconfigured provider (e.g.
     # CUDA requested without the onnxruntime-gpu build) into an immediate error.
     backend.validate_providers(providers)
+
+    # ``target_opset_version="latest"`` resolves against the C++ core's own
+    # compiled-in onnx schema registry (the same one ConvertOpsetVersion uses),
+    # not the pip-installed `onnx` package's `onnx.defs.onnx_opset_version()` --
+    # the two can differ since onnxsim vendors its own onnx fork.
+    if target_opset_version == "latest":
+        target_opset_version = C.max_default_domain_opset_version()
+    elif target_opset_version is not None and not isinstance(target_opset_version, int):
+        raise ValueError(
+            "target_opset_version must be an int, the string 'latest', or None, "
+            f"got {target_opset_version!r}"
+        )
 
     if dynamic_input_shape:
         print(
@@ -2127,8 +2143,8 @@ def main():
     )
     parser.add_argument(
         "--target-opset",
-        help="Convert the model to this opset version (of the default ONNX domain) before simplifying, for example '--target-opset 18'. Can be used to upgrade (or downgrade) the model's opset during simplification.",
-        type=int,
+        help="Convert the model to this opset version (of the default ONNX domain) before simplifying, for example '--target-opset 18'. Can be used to upgrade (or downgrade) the model's opset during simplification. Pass 'latest' to resolve to the highest opset version this onnxsim build supports.",
+        type=lambda s: s if s == "latest" else int(s),
         default=None,
     )
     parser.add_argument(

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -735,9 +735,17 @@ static onnx::ModelProto SimplifyImpl(
   }
   // Optionally convert the model to a different opset version (of the default
   // ONNX domain) first, so the simplification below can clean up any redundant
-  // nodes the version converter introduces.
+  // nodes the version converter introduces. Wrapped in its own profiled span --
+  // sibling to, not nested inside, the "Simplify" root below -- so its cost is
+  // visible in the flame graph / profile_pass_phases output instead of showing
+  // up as unaccounted time before the first pass.
   if (target_opset_version) {
-    sim_model = ConvertOpsetVersion(sim_model, *target_opset_version);
+    onnxsim::ProfiledScope opset_scope("ConvertOpsetVersion");
+    // std::move: sim_model is about to be overwritten by the result anyway,
+    // so let ConvertOpsetVersion's by-value parameter move-construct instead
+    // of copying -- required for it to reach ConvertVersion's non-copying
+    // overload (see model_prep.cpp).
+    sim_model = ConvertOpsetVersion(std::move(sim_model), *target_opset_version);
   }
   {
     // A single root span so the profiled fixed points nest under one box in the

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -745,7 +745,8 @@ static onnx::ModelProto SimplifyImpl(
     // so let ConvertOpsetVersion's by-value parameter move-construct instead
     // of copying -- required for it to reach ConvertVersion's non-copying
     // overload (see model_prep.cpp).
-    sim_model = ConvertOpsetVersion(std::move(sim_model), *target_opset_version);
+    sim_model =
+        ConvertOpsetVersion(std::move(sim_model), *target_opset_version);
   }
   {
     // A single root span so the profiled fixed points nest under one box in the


### PR DESCRIPTION
## Summary

- `target_opset_version` now accepts the literal string `"latest"` (Python API and CLI `--target-opset latest`), resolving against the C++ core's own compiled-in onnx schema registry via a new `C.max_default_domain_opset_version()` binding, rather than the pip `onnx` package's `onnx.defs.onnx_opset_version()` (onnxsim vendors its own onnx fork, so the two can differ). The `None` default (no conversion) is unchanged.
- `ConvertOpsetVersion`'s call in `onnxsim.cpp` previously ran *before* the `Simplify` root `ProfiledScope`, so its cost was invisible to `ONNXSIM_PROFILE`/`profile_pass_phases`. It now has its own profiled span.
- Found and fixed a real "back to protobuf" cost: `onnx::version_conversion::ConvertVersion` always went through the copying `ImportModelProto(const ModelProto&)` / `ExportModelProto(..., consume_tensor_data=false)`, duplicating every initializer's raw bytes twice per call, even though `third_party/onnx`'s `ir_pb_converter.h` already ships moving/consuming overloads built for onnx-optimizer's `Optimizer::optimize()` -- the version converter itself just never adopted them. Added consuming `convert_version`/`ConvertVersion` overloads (purely additive; existing const-ref callers, including onnx's own Python bindings, are unaffected) and wired `ConvertOpsetVersion`/its call site to reach them via `std::move`.
- Added `bench/opset_conversion_profile.py`, a self-contained synthetic-model profiling script used to measure the fix, and `bench/RESULTS_opset_version_converter.md` writing up the methodology and numbers.

**Measured** (median of 5 trials, same binary, A/B'd via a local-only env toggle never committed): `ConvertOpsetVersion` time drops 1.6x-5.6x depending on initializer size, e.g. 143.94ms -> 25.55ms on a ~92.5MB model, scaling with initializer bytes as expected for an eliminated double copy.

**Also found, not fixed here:** a flat ~4ms per-call floor in `DefaultVersionConverter`'s constructor (it rebuilds its full schema/adapter registry from scratch on every `ConvertVersion()` call), independent of model size or opset-step count. A safe fix needs a cache-invalidation signal that doesn't exist yet, since onnxsim registers additional op schemas into the same live registry at runtime (custom ops) -- see the results doc for why a naive static cache would be unsound, and two possible correct approaches.

## Dependency

The actual "back to protobuf" fix lives in the vendored onnx fork (a separate repo, pulled in as the `third_party/onnx` submodule) and is **not yet merged/re-pinned here** -- see `onnxsim/onnx#claude/onnx-version-converter-perf` (pushed, awaiting review). This PR's C++ changes (`model_prep.cpp`/`.h`, `onnxsim.cpp`) call the new consuming overload and are inert no-ops against the *current* pinned submodule commit until that fork PR merges and the submodule pin is bumped -- they don't change behavior on their own.

## Test plan

- [x] `tests/test_python_api.py::test_target_opset_version_upgrades_model` and `::test_target_opset_version_none_keeps_opset` pass
- [x] Full `tests/test_python_api.py` suite passes (60/60, excluding 3 pre-existing >2GB-class tests this sandbox can't run without OOMing, unrelated to this change)
- [x] `target_opset_version="latest"` and `--target-opset latest` smoke-tested end to end (Python API and CLI)
- [x] Invalid `target_opset_version` value raises `ValueError` as documented
- [x] Profiling comparison in `bench/RESULTS_opset_version_converter.md`, run against a locally-patched `third_party/onnx` checkout (the pending fork PR's exact diff)


---
_Generated by [Claude Code](https://claude.ai/code/session_016usAkmLpCM45QcgXdAZ2oS)_