### PR TITLE
Track top-level graph initializers separately in model info

### DIFF
--- a/onnxsim/model_info.cpp
+++ b/onnxsim/model_info.cpp
@@ -381,6 +381,7 @@ ModelInfo GetModelInfo(const onnx::ModelProto& model,
                        bool run_shape_inference) {
   ModelInfo info;
   CountGraphOps(model.graph(), info.op_nums);
+  info.initializer_count = model.graph().initializer_size();
   // ByteSizeLong() (not the 32-bit ByteSize()) so models above 2GB do not
   // overflow; external tensor data is then added from metadata. Op counts and
   // size come from the model as given -- not the shape-inferred copy below,
@@ -436,6 +437,11 @@ std::string FormatSimplifyingInfo(const onnx::ModelProto& model_ori,
   std::string size_cell = HumanReadableSize(opt.model_size);
   if (opt.model_size < ori.model_size) size_cell += " *";
   rows.push_back({"Model Size", HumanReadableSize(ori.model_size), size_cell});
+
+  std::string init_cell = std::to_string(opt.initializer_count);
+  if (opt.initializer_count < ori.initializer_count) init_cell += " *";
+  rows.push_back({"Initializers", std::to_string(ori.initializer_count),
+                  init_cell});
 
   // Symbolic metric rows: a smaller representative magnitude (every dynamic dim
   // -> 1) counts as the improvement, since "<" on a genuine formula is not

--- a/onnxsim/model_info.cpp
+++ b/onnxsim/model_info.cpp
@@ -440,8 +440,8 @@ std::string FormatSimplifyingInfo(const onnx::ModelProto& model_ori,
 
   std::string init_cell = std::to_string(opt.initializer_count);
   if (opt.initializer_count < ori.initializer_count) init_cell += " *";
-  rows.push_back({"Initializers", std::to_string(ori.initializer_count),
-                  init_cell});
+  rows.push_back(
+      {"Initializers", std::to_string(ori.initializer_count), init_cell});
 
   // Symbolic metric rows: a smaller representative magnitude (every dynamic dim
   // -> 1) counts as the improvement, since "<" on a genuine formula is not

--- a/onnxsim/model_info.h
+++ b/onnxsim/model_info.h
@@ -37,6 +37,13 @@
 struct ModelInfo {
   std::map<std::string, int64_t> op_nums;
   int64_t model_size = 0;
+  // Count of the top-level graph's own initializers -- not the recursive,
+  // subgraph-including tally that ``op_nums["Constant"]`` folds initializers
+  // into. Reported as its own "Initializers" row by ``FormatSimplifyingInfo``
+  // so a change here (e.g. weights folded into a fused node, or duplicate
+  // initializers deduplicated) is visible without it being muddied by actual
+  // ``Constant`` nodes in the same count.
+  int64_t initializer_count = 0;
   onnxsim::SymExpr macs;
   onnxsim::SymExpr mem_access;
   onnxsim::SymExpr memory_footprint;
@@ -71,8 +78,9 @@ void AnnotateModelInfo(onnx::ModelProto& model);
 
 // Render an ASCII table comparing an original and a simplified model, mirroring
 // the layout of the Python ``print_simplifying_info``: one row per op type (the
-// sorted union of both models' ops), then ``Model Size``, ``MACs``, ``FLOPs``,
-// ``Memory Access``, ``Memory Footprint`` and ``Compute Density``, with columns
+// sorted union of both models' ops), then ``Model Size``, ``Initializers``,
+// ``MACs``, ``FLOPs``, ``Memory Access``, ``Memory Footprint`` and
+// ``Compute Density``, with columns
 // for the original and simplified values. A metric that improved (a dropped op
 // count, or a smaller size / MACs / memory figure) is flagged with a trailing
 // ``*``, since these bindings print to plain terminals where the Python

--- a/onnxsim/model_info.py
+++ b/onnxsim/model_info.py
@@ -561,7 +561,8 @@ class ModelInfo:
     Model info contains:
     1. Num of every op
     2. Model size
-    3. MACs / FLOPs of the compute-dominant operators: Conv, ConvTranspose,
+    3. Count of the top-level graph's own initializers (``initializer_count``)
+    4. MACs / FLOPs of the compute-dominant operators: Conv, ConvTranspose,
        Gemm, MatMul, Attention, and the quantized twins (ConvInteger,
        QLinearConv, MatMulInteger, QLinearMatMul). Shapes come from ONNX shape
        inference -- or, when the optional ``onnx-shape-inference`` package
@@ -577,7 +578,7 @@ class ModelInfo:
        functions (and nested ones) are inlined, and schema-registered function
        ops without a bespoke counter fall back to their context-dependent body
        (best-effort).
-    4. Memory metrics, derived statically from the same inferred shapes (no
+    5. Memory metrics, derived statically from the same inferred shapes (no
        runtime execution needed):
        - ``mem_access``: total bytes read and written across a forward pass --
          every node's inputs (weights included) plus its outputs.
@@ -649,6 +650,13 @@ class ModelInfo:
         # whether or not the weights on disk have been loaded).
         op_nums, self.model_size, macs, mem_access, footprint = _cpp_metrics(model)
         self.op_nums = defaultdict(int, op_nums)
+        # The top-level graph's own initializer count -- unlike
+        # ``op_nums["Constant"]``, which folds initializers (recursively,
+        # subgraphs included) together with actual ``Constant`` nodes, this is
+        # reported as its own "Initializers" row so a change there (weights
+        # folded into a fused node, duplicate initializers deduplicated, ...)
+        # is visible on its own.
+        self.initializer_count = len(model.graph.initializer)
         # A function op's compute lives in its body, so recount MACs and the
         # memory metrics on the function-expanded (inlined) graph -- the counters
         # then see the MatMuls, Convs, etc. inside every function instance. The
@@ -862,6 +870,13 @@ def print_simplifying_info(
         opt_info.model_size,
         lambda opt, ori: opt < ori,
         postprocess=human_readable_size,
+    )
+    add_row(
+        table,
+        "Initializers",
+        ori_info.initializer_count,
+        opt_info.initializer_count,
+        lambda opt, ori: opt < ori,
     )
 
     # MACs/FLOPs may be symbolic, for which "<" yields an undecidable sympy


### PR DESCRIPTION
## Summary
Add explicit tracking of the top-level graph's own initializers as a separate metric in model info, distinct from the recursive `Constant` op count that includes subgraph constants.

## Changes
- **Python (`model_info.py`)**: 
  - Add `initializer_count` field to track the count of initializers in the top-level graph
  - Populate this field from `len(model.graph.initializer)` during `ModelInfo` initialization
  - Add "Initializers" row to the simplification info table, displayed between "Model Size" and "MACs/FLOPs"
  - Update docstring numbering to reflect the new metric

- **C++ (`model_info.h` and `model_info.cpp`)**:
  - Add `initializer_count` field to the `ModelInfo` struct
  - Populate it from `model.graph().initializer_size()` in `GetModelInfo()`
  - Add "Initializers" row to the formatted simplification info output
  - Update documentation to reflect the new metric in the output table

## Rationale
Unlike `op_nums["Constant"]`, which recursively counts both actual `Constant` nodes and initializers across the entire model (including subgraphs), this new metric shows only the top-level graph's own initializers. This makes it visible when weights are folded into fused nodes, initializers are deduplicated, or other structural changes occur at the graph level, without being obscured by the broader `Constant` count.

https://claude.ai/code/session_01EM1Ugib8sGg6YLQQWCLndt