### PR TITLE
Add C++ ports of QuaRot, magnitude pruning, MXFP4, and double quantization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,7 @@ set(ONNXSIM_BLAKE3_COMPILE_DEFS
     BLAKE3_NO_SSE2 BLAKE3_NO_SSE41 BLAKE3_NO_AVX2 BLAKE3_NO_AVX512
     BLAKE3_USE_NEON=0)
 
-add_library(onnxsim onnxsim/onnxsim.cpp onnxsim/constant_folding.cpp onnxsim/partial_shape_eval.cpp onnxsim/model_prep.cpp onnxsim/quantize_entry.cpp onnxsim/cross_layer_equalization_entry.cpp onnxsim/contrib_schemas.cpp onnxsim/custom_optimizer_passes.cpp onnxsim/function_rewriter.cpp onnxsim/profiler.cpp onnxsim/model_info.cpp onnxsim/sym_expr.cpp onnxsim/sym_value_eval.cpp onnxsim/sym_shape_infer.cpp onnxsim/model_metrics.cpp onnxsim/precision_estimator.cpp onnxsim/tensor_pool.cpp onnxsim/tensor_pool_gguf.cpp onnxsim/tensor_pool_hash.cpp onnxsim/gemm_fusion_backend.cpp ${ONNXSIM_BLAKE3_SOURCES})
+add_library(onnxsim onnxsim/onnxsim.cpp onnxsim/constant_folding.cpp onnxsim/partial_shape_eval.cpp onnxsim/model_prep.cpp onnxsim/quantize_entry.cpp onnxsim/cross_layer_equalization_entry.cpp onnxsim/pruning_entry.cpp onnxsim/contrib_schemas.cpp onnxsim/custom_optimizer_passes.cpp onnxsim/function_rewriter.cpp onnxsim/profiler.cpp onnxsim/model_info.cpp onnxsim/sym_expr.cpp onnxsim/sym_value_eval.cpp onnxsim/sym_shape_infer.cpp onnxsim/model_metrics.cpp onnxsim/precision_estimator.cpp onnxsim/tensor_pool.cpp onnxsim/tensor_pool_gguf.cpp onnxsim/tensor_pool_hash.cpp onnxsim/gemm_fusion_backend.cpp ${ONNXSIM_BLAKE3_SOURCES})
 target_compile_definitions(onnxsim PRIVATE ${ONNXSIM_BLAKE3_COMPILE_DEFS})
 if (ONNXSIM_BUILTIN_ORT)
   # Both ways of obtaining ONNX Runtime ship/install headers flat under this

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -49,7 +49,13 @@ from onnxsim.mixed_precision import apply_mixed_precision_quantization
 from onnxsim.mx_quantization import MXFP4_CODEBOOK, quantize_weight_only_mxfp4
 from onnxsim.nf4 import NF4_CODEBOOK, quantize_weight_only_nf4
 from onnxsim.omniquant import apply_omniquant
+from onnxsim.optimize_pipeline import (
+    OptimizationPipelineResult,
+    apply_optimization_pipeline,
+)
 from onnxsim.onnx_simplifier import (
+    apply_double_quantization_cpp,
+    apply_quarot_cpp,
     cross_layer_equalize,
     export_gguf,
     export_safetensors,
@@ -59,6 +65,7 @@ from onnxsim.onnx_simplifier import (
     import_safetensors,
     load_model,
     main,
+    prune_magnitude_cpp,
     quantize_attention_dynamic,
     quantize_bf16,
     quantize_dynamic,
@@ -71,6 +78,7 @@ from onnxsim.onnx_simplifier import (
     quantize_weight_only_int8_block,
     quantize_weight_only_int16,
     quantize_weight_only_matmul_nbits,
+    quantize_weight_only_mxfp4_cpp,
     read_gguf_metadata,
     simplify,
 )
@@ -115,6 +123,8 @@ __all__ = [
     "apply_autoround",
     "auto_quantize_int4",
     "AutoQuantResult",
+    "apply_optimization_pipeline",
+    "OptimizationPipelineResult",
     "apply_awq",
     "apply_gptq",
     "apply_smoothquant",
@@ -123,10 +133,12 @@ __all__ = [
     "apply_mixed_precision_quantization",
     "apply_quip_sharp",
     "apply_quarot",
+    "apply_quarot_cpp",
     "apply_duquant",
     "apply_spinquant",
     "apply_omniquant",
     "apply_magnitude_pruning",
+    "prune_magnitude_cpp",
     "apply_wanda_pruning",
     "apply_sparsegpt_pruning",
     "apply_structured_pruning",
@@ -151,12 +163,14 @@ __all__ = [
     "quantize_weight_only_aqlm",
     "quantize_weight_only_spqr",
     "apply_double_quantization",
+    "apply_double_quantization_cpp",
     "quantize_kv_cache",
     "quantize_embedding_binary",
     "quantize_embedding_int8",
     "quantize_weight_only_matmul_nbits",
     "quantize_weight_only_int8_block",
     "quantize_weight_only_int16",
+    "quantize_weight_only_mxfp4_cpp",
     "quantize_static",
     "quantize_static_int16",
     "quantize_qoperator",

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -49,10 +49,6 @@ from onnxsim.mixed_precision import apply_mixed_precision_quantization
 from onnxsim.mx_quantization import MXFP4_CODEBOOK, quantize_weight_only_mxfp4
 from onnxsim.nf4 import NF4_CODEBOOK, quantize_weight_only_nf4
 from onnxsim.omniquant import apply_omniquant
-from onnxsim.optimize_pipeline import (
-    OptimizationPipelineResult,
-    apply_optimization_pipeline,
-)
 from onnxsim.onnx_simplifier import (
     apply_double_quantization_cpp,
     apply_quarot_cpp,
@@ -81,6 +77,10 @@ from onnxsim.onnx_simplifier import (
     quantize_weight_only_mxfp4_cpp,
     read_gguf_metadata,
     simplify,
+)
+from onnxsim.optimize_pipeline import (
+    OptimizationPipelineResult,
+    apply_optimization_pipeline,
 )
 from onnxsim.ort_matmul_nbits_workaround import workaround_ort_matmul_nbits_axis0_bug
 from onnxsim.precision_estimator import (

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -535,6 +535,78 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
       },
       "model_bytes"_a);
 
+  // OCP Microscaling MXFP4 weight-only quantizes every MatMul/vanilla-Gemm
+  // whose weight is a constant float32 tensor whose reduction dimension is
+  // divisible by 32, via a Gather-a-codebook-then-scale dequant chain (no
+  // native ONNX MX tensor type). Activations are never touched, so no
+  // calibration data is needed. See QuantizeWeightOnlyMXFP4 in onnxsim.h.
+  m.def(
+      "quantize_weight_only_mxfp4",
+      [](const py::bytes& model_proto_bytes) -> py::bytes {
+        InitEnv();
+        ONNX_NAMESPACE::ModelProto model;
+        ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
+                            model_proto_bytes.size());
+        const auto result = QuantizeWeightOnlyMXFP4(model);
+        std::string out;
+        result.SerializeToString(&out);
+        return py::bytes(out.data(), out.size());
+      },
+      "model_bytes"_a);
+
+  // QLoRA-style double quantization: quantizes every already-present
+  // DequantizeLinear node's own (large enough) constant scale tensor to
+  // UINT8 with a per-tensor meta-scale. See ApplyDoubleQuantization in
+  // onnxsim.h.
+  m.def(
+      "apply_double_quantization",
+      [](const py::bytes& model_proto_bytes) -> py::bytes {
+        InitEnv();
+        ONNX_NAMESPACE::ModelProto model;
+        ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
+                            model_proto_bytes.size());
+        const auto result = ApplyDoubleQuantization(model);
+        std::string out;
+        result.SerializeToString(&out);
+        return py::bytes(out.data(), out.size());
+      },
+      "model_bytes"_a);
+
+  // Magnitude pruning (Han et al., 2015): zeros the least-magnitude entries
+  // of every MatMul/vanilla-Gemm/Conv layer's constant weight, independently
+  // per output row/filter. Data-free. See PruneMagnitude in onnxsim.h.
+  m.def(
+      "prune_magnitude",
+      [](const py::bytes& model_proto_bytes, double sparsity) -> py::bytes {
+        InitEnv();
+        ONNX_NAMESPACE::ModelProto model;
+        ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
+                            model_proto_bytes.size());
+        const auto result = PruneMagnitude(model, sparsity);
+        std::string out;
+        result.SerializeToString(&out);
+        return py::bytes(out.data(), out.size());
+      },
+      "model_bytes"_a, "sparsity"_a);
+
+  // QuaRot (Ashkboos et al., 2024): rotation preprocessing plus INT4
+  // round-to-nearest quantization of both the weight and the activation of
+  // every MatMul/vanilla-Gemm layer. Data-free. See ApplyQuarot in
+  // onnxsim.h.
+  m.def(
+      "apply_quarot",
+      [](const py::bytes& model_proto_bytes, uint64_t seed) -> py::bytes {
+        InitEnv();
+        ONNX_NAMESPACE::ModelProto model;
+        ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
+                            model_proto_bytes.size());
+        const auto result = ApplyQuarot(model, seed);
+        std::string out;
+        result.SerializeToString(&out);
+        return py::bytes(out.data(), out.size());
+      },
+      "model_bytes"_a, "seed"_a);
+
   // Lists the activation tensor names quantize_static could quantize --
   // see ListQuantizableActivations in onnxsim.h.
   m.def(

--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -11,6 +11,7 @@
 #include "onnxoptimizer/optimize.h"
 #include "passes/cross_layer_equalization.h"
 #include "passes/defuse_matmul_integer_to_float.h"
+#include "passes/double_quantization.h"
 #include "passes/dynamic_quantize_attention.h"
 #include "passes/dynamic_quantize_matmul.h"
 #include "passes/dynamic_quantize_matmul_integer_to_float.h"
@@ -38,6 +39,7 @@
 #include "passes/fuse_qkv.h"
 #include "passes/fuse_rms_norm.h"
 #include "passes/fuse_rope.h"
+#include "passes/magnitude_pruning.h"
 #include "passes/qoperator_quantize_activation.h"
 #include "passes/qoperator_quantize_concat.h"
 #include "passes/qoperator_quantize_conv.h"
@@ -50,6 +52,7 @@
 #include "passes/quantize_bf16.h"
 #include "passes/quantize_fp16.h"
 #include "passes/quantize_fp8.h"
+#include "passes/quarot.h"
 #include "passes/rewrite_arg_reduce_select_last_index.h"
 #include "passes/static_quantize_conv.h"
 #include "passes/static_quantize_int16_conv.h"
@@ -64,6 +67,7 @@
 #include "passes/weight_only_quantize_int8_block_matmul.h"
 #include "passes/weight_only_quantize_matmul.h"
 #include "passes/weight_only_quantize_matmul_nbits.h"
+#include "passes/weight_only_quantize_mxfp4_matmul.h"
 
 namespace onnxsim {
 
@@ -100,6 +104,7 @@ void RegisterCustomOptimizerPasses() {
     // onnxsim-only rewrites (no built-in of the same name today).
     RegisterOrReplace<p::CrossLayerEqualization>(registry);
     RegisterOrReplace<p::DefuseMatMulIntegerToFloat>(registry);
+    RegisterOrReplace<p::DoubleQuantization>(registry);
     RegisterOrReplace<p::DynamicQuantizeAttention>(registry);
     RegisterOrReplace<p::DynamicQuantizeMatMul>(registry);
     RegisterOrReplace<p::DynamicQuantizeMatMulIntegerToFloat>(registry);
@@ -120,6 +125,8 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::FusePrecedingMulIntoConv>(registry);
     RegisterOrReplace<p::FuseRMSNorm>(registry);
     RegisterOrReplace<p::FuseRope>(registry);
+    RegisterOrReplace<p::MagnitudePruningConv>(registry);
+    RegisterOrReplace<p::MagnitudePruningMatMul>(registry);
     RegisterOrReplace<p::QOperatorQuantizeActivation>(registry);
     RegisterOrReplace<p::QOperatorQuantizeConcat>(registry);
     RegisterOrReplace<p::QOperatorQuantizeConv>(registry);
@@ -132,6 +139,7 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::QuantizeBf16Pass>(registry);
     RegisterOrReplace<p::QuantizeFp16Pass>(registry);
     RegisterOrReplace<p::QuantizeFp8Pass>(registry);
+    RegisterOrReplace<p::Quarot>(registry);
     RegisterOrReplace<p::RewriteArgReduceSelectLastIndex>(registry);
     RegisterOrReplace<p::StaticQuantizeConv>(registry);
     RegisterOrReplace<p::StaticQuantizeInt16Conv>(registry);
@@ -146,6 +154,7 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::WeightOnlyQuantizeInt8BlockMatMul>(registry);
     RegisterOrReplace<p::WeightOnlyQuantizeMatMul>(registry);
     RegisterOrReplace<p::WeightOnlyQuantizeMatMulNBits>(registry);
+    RegisterOrReplace<p::WeightOnlyQuantizeMXFP4MatMul>(registry);
 
     // onnxsim's patched versions of built-in onnxoptimizer passes. These
     // overwrite the registry entries the submodule registers under the same

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -978,6 +978,148 @@ def quantize_weight_only_int8_block(
     )
 
 
+def quantize_weight_only_mxfp4_cpp(
+    model: Union[str, onnx.ModelProto],
+) -> onnx.ModelProto:
+    """
+    C++-backed port of :func:`onnxsim.quantize_weight_only_mxfp4`: OCP
+    Microscaling MXFP4 weight-only quantizes every MatMul and every
+    "vanilla" Gemm (transA=0, alpha=1, beta=1) whose weight is a constant
+    2-D float32 tensor whose reduction dimension ``K`` is evenly divisible
+    by 32 (the OCP MX spec's own canonical block size).
+
+    Unlike every other ``quantize_weight_only_*`` scheme, MXFP4's per-block
+    scale is constrained to a pure power of two, and its 4-bit codes follow
+    a fixed, non-uniform (E2M1 floating-point) codebook rather than an
+    ordinary affine range -- see :func:`onnxsim.quantize_weight_only_mxfp4`'s
+    own docstring for the format's full definition. Needs no calibration
+    data: both the codebook and the per-block power-of-two scale come from
+    the weight's own values. Unlike the pure-Python implementation, ``Conv``
+    layers are not (yet) handled -- only ``MatMul``/``Gemm``.
+
+    This is a single, self-contained graph rewrite: unlike :func:`simplify`,
+    it does not run shape inference, constant folding, or any other pass.
+    Layers with a non-constant, non-2-D, or non-block-divisible weight are
+    left untouched. Consider calling :func:`simplify` before and/or after to
+    clean up the graph.
+
+    :param model: onnx ModelProto object or file path
+    :returns: the quantized onnx ModelProto
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    return onnx.load_from_string(
+        C.quantize_weight_only_mxfp4(model.SerializeToString())
+    )
+
+
+def apply_double_quantization_cpp(
+    model: Union[str, onnx.ModelProto],
+) -> onnx.ModelProto:
+    """
+    C++-backed port of :func:`onnxsim.apply_double_quantization`: applies
+    QLoRA-style double quantization (Dettmers et al., 2023, "QLoRA:
+    Efficient Finetuning of Quantized LLMs", Section 3.2) to every
+    ``DequantizeLinear`` node already present in ``model`` whose scale input
+    is a constant float32 tensor with at least 64 values.
+
+    Every block-wise/per-channel scale (e.g. one float32 value per 32-element
+    INT4 block) is itself quantized to UINT8 with a single per-tensor
+    meta-scale, reconstructed in-graph via a second, nested
+    ``DequantizeLinear`` feeding the original node's own scale input -- see
+    :func:`onnxsim.apply_double_quantization`'s own docstring for the exact
+    rewrite. This is technique-agnostic: it composes with the output of any
+    onnxsim block-wise/per-channel quantizer (or any other model containing
+    ``DequantizeLinear`` nodes) unchanged.
+
+    :param model: an already-quantized onnx ModelProto or file path
+    :returns: ``model`` with every matching ``DequantizeLinear`` node's scale
+            input double-quantized; a scale that is not a constant
+            initializer, not float32, or too small (fewer than 64 values) is
+            left untouched
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    return onnx.load_from_string(
+        C.apply_double_quantization(model.SerializeToString())
+    )
+
+
+def prune_magnitude_cpp(
+    model: Union[str, onnx.ModelProto],
+    sparsity: float = 0.5,
+) -> onnx.ModelProto:
+    """
+    C++-backed port of :func:`onnxsim.apply_magnitude_pruning`: zeros the
+    least-magnitude entries of every MatMul/vanilla-Gemm layer's constant
+    2-D float32 weight, and every Conv layer's constant 4-D float32 weight
+    (ordinary, depthwise, and general grouped Conv alike) -- the data-free
+    unstructured pruning baseline (Han et al., 2015).
+
+    Within each output row (or, for Conv, each output filter), keeps the
+    ``max(1, round(cols * (1 - sparsity)))`` highest-magnitude entries and
+    zeros the rest, so a layer with row-dependent weight scale doesn't get
+    some rows pruned to nothing and others left untouched.
+
+    Unlike the pure-Python :func:`onnxsim.apply_magnitude_pruning`, this
+    does not match ``com.microsoft::Attention``'s merged QKV weight, and
+    offers only the sparsity-ratio mode (no N:M semi-structured pruning).
+
+    This is a single, self-contained graph rewrite: unlike :func:`simplify`,
+    it does not run shape inference, constant folding, or any other pass.
+    Layers with a non-constant, non-2-D (MatMul/Gemm), or non-4-D (Conv)
+    weight are left untouched.
+
+    :param model: onnx ModelProto object or file path
+    :param sparsity: target fraction of each row's entries to zero; must be
+            in ``[0, 1)``
+    :returns: ``model`` with every matched layer's weight pruned in place
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    return onnx.load_from_string(
+        C.prune_magnitude(model.SerializeToString(), sparsity)
+    )
+
+
+def apply_quarot_cpp(
+    model: Union[str, onnx.ModelProto],
+    seed: int = 0,
+) -> onnx.ModelProto:
+    """
+    C++-backed port of :func:`onnxsim.apply_quarot`: applies QuaRot-style
+    random-rotation preprocessing (Ashkboos et al., 2024, "QuaRot:
+    Outlier-Free 4-Bit Inference in Rotated LLMs") plus INT4
+    round-to-nearest quantization of *both* the weight and the activation to
+    every MatMul/vanilla-Gemm layer with a constant 2-D float32 weight whose
+    reduction dimension ``K`` is divisible by 32.
+
+    Rotating the whole residual stream by a random orthogonal matrix removes
+    activation outliers the same way block quantization already tolerates
+    weight outliers, letting both MatMul operands drop to INT4 with no
+    calibration data at all -- see :func:`onnxsim.apply_quarot`'s own
+    docstring for the full rationale. Unlike that pure-Python
+    implementation, this port derives a fresh rotation per matched layer
+    from ``seed`` independently of graph node order, so results are *not*
+    expected to match the Python port bit-for-bit -- only to be similarly
+    accurate.
+
+    This is a single, self-contained graph rewrite: unlike :func:`simplify`,
+    it does not run shape inference, constant folding, or any other pass.
+    Layers with a non-constant, non-2-D weight, or a reduction dimension not
+    divisible by 32, are left untouched. Consider calling :func:`simplify`
+    before and/or after to clean up the graph.
+
+    :param model: the original (unquantized) onnx ModelProto or file path
+    :param seed: seed for the per-layer random rotation matrices
+    :returns: the rotated-and-quantized onnx ModelProto; a model with no
+            matching layer, or an opset older than 21, is returned unchanged
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    return onnx.load_from_string(C.apply_quarot(model.SerializeToString(), seed))
+
+
 def quantize_fp16(
     model: Union[str, onnx.ModelProto], keep_io_types: bool = True
 ) -> onnx.ModelProto:

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -1040,9 +1040,7 @@ def apply_double_quantization_cpp(
     """
     if isinstance(model, str):
         model = onnx.load(model, load_external_data=False)
-    return onnx.load_from_string(
-        C.apply_double_quantization(model.SerializeToString())
-    )
+    return onnx.load_from_string(C.apply_double_quantization(model.SerializeToString()))
 
 
 def prune_magnitude_cpp(
@@ -1077,9 +1075,7 @@ def prune_magnitude_cpp(
     """
     if isinstance(model, str):
         model = onnx.load(model, load_external_data=False)
-    return onnx.load_from_string(
-        C.prune_magnitude(model.SerializeToString(), sparsity)
-    )
+    return onnx.load_from_string(C.prune_magnitude(model.SerializeToString(), sparsity))
 
 
 def apply_quarot_cpp(

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -2,6 +2,7 @@
 
 #include <onnx/onnx_pb.h>
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -429,6 +430,89 @@ onnx::ModelProto QuantizeWeightOnlyInt16(const onnx::ModelProto& model);
 // reduction size not divisible by 32, non-default Gemm attributes,
 // non-float32 operands, an opset older than 21) are left as-is.
 onnx::ModelProto QuantizeWeightOnlyInt8Block(const onnx::ModelProto& model);
+
+// OCP Microscaling MXFP4 weight-only quantizes every MatMul and every
+// "vanilla" Gemm (transA=0, alpha=1, beta=1) whose weight is a constant
+// float32 tensor whose reduction dimension K is evenly divisible by 32
+// (the OCP MX spec's own canonical block size). Unlike every other
+// ``QuantizeWeightOnly*`` scheme, MXFP4's per-block scale is constrained to
+// a pure power of two, and its 4-bit codes follow a fixed, non-uniform
+// (E2M1 floating-point) codebook rather than an ordinary affine range --
+// ONNX has no native MX tensor type, so the rewrite builds the
+// dequantization out of ordinary opset-11+ ops (``Gather`` a codebook,
+// ``Mul`` by the per-block scale) instead of a single ``DequantizeLinear``.
+// The weight is quantized from its own static values only -- no calibration
+// data, and (like every ``QuantizeWeightOnly*`` scheme) the activation is
+// never touched. See ``passes/weight_only_quantize_mxfp4_matmul.h`` and
+// ``passes/quantize_mxfp4_common.h`` for the rewrite itself and the
+// format's own definition.
+//
+// Unlike ``Simplify``, this does not run shape inference, constant folding or
+// any other simplification pass -- it applies exactly this rewrite, once, to
+// a copy of ``model`` (which is left untouched) and returns the result. A
+// layer with a non-constant, non-2-D weight, or a reduction dimension not
+// divisible by 32, is left untouched; a model with no matching layer is
+// returned unchanged.
+onnx::ModelProto QuantizeWeightOnlyMXFP4(const onnx::ModelProto& model);
+
+// Applies QLoRA-style double quantization (Dettmers et al., 2023, Section
+// 3.2) to every ``DequantizeLinear`` node already present in ``model`` whose
+// scale input is a constant float32 tensor with at least 64 values (a
+// per-block or per-channel scale -- a single scalar per-tensor scale isn't
+// worth the overhead of a second quantizer around it). Unlike every
+// ``Quantize*`` scheme above, this has no "live weight" of its own to
+// quantize: it is a second pass over an *already-quantized* model, and
+// composes with any of them (or any other model containing
+// ``DequantizeLinear`` nodes) unchanged. See ``passes/double_quantization.h``
+// for the exact rewrite.
+//
+// Unlike ``Simplify``, this does not run shape inference, constant folding or
+// any other simplification pass -- it applies exactly this rewrite, to every
+// matching node, to a copy of ``model`` (which is left untouched) and
+// returns the result. A scale that is not a constant initializer, not
+// float32, or too small, is left untouched; a model with no matching node is
+// returned unchanged.
+onnx::ModelProto ApplyDoubleQuantization(const onnx::ModelProto& model);
+
+// Magnitude pruning (Han et al., 2015) -- the data-free unstructured
+// pruning baseline. Zeros the least-magnitude entries of every
+// MatMul/vanilla-Gemm layer's constant 2-D float32 weight, and every Conv
+// layer's constant 4-D float32 weight (ordinary, depthwise, and general
+// grouped Conv alike), independently per output row/filter: within each
+// row, keeps the max(1, round(cols * (1 - sparsity))) highest-magnitude
+// entries and zeros the rest. Unlike the pure-Python
+// ``apply_magnitude_pruning``, this does not match
+// ``com.microsoft::Attention``'s merged QKV weight, and offers only the
+// sparsity-ratio mode (no N:M semi-structured pruning) -- see
+// ``passes/magnitude_pruning.h`` for the exact rewrite and this scope note.
+//
+// Unlike ``Simplify``, this does not run shape inference, constant folding or
+// any other simplification pass -- it applies exactly this rewrite, to every
+// matching layer, to a copy of ``model`` (which is left untouched) and
+// returns the result. ``sparsity`` must be in [0, 1); throws
+// ``std::invalid_argument`` otherwise. A layer with a non-constant,
+// non-2-D (MatMul/Gemm), or non-4-D (Conv) weight is left untouched.
+onnx::ModelProto PruneMagnitude(const onnx::ModelProto& model, double sparsity);
+
+// QuaRot (Ashkboos et al., 2024) rotation preprocessing plus INT4
+// round-to-nearest quantization of *both* the weight and the activation of
+// every MatMul/vanilla-Gemm layer with a constant 2-D float32 weight whose
+// reduction dimension K is divisible by 32. Rotating the whole residual
+// stream by a random orthogonal matrix removes activation outliers the same
+// way :func:`quantize_weight_only_int4`-style block quantization already
+// tolerates weight outliers, letting both MatMul operands drop to INT4 with
+// no calibration data at all -- see ``passes/quarot.h`` for the exact
+// rewrite and rationale, and its scope note on the per-layer (not fused
+// cross-layer) rotation this port applies.
+//
+// Unlike ``Simplify``, this does not run shape inference, constant folding or
+// any other simplification pass -- it applies exactly this rewrite, to every
+// matching layer, to a copy of ``model`` (which is left untouched) and
+// returns the result. A layer with a non-constant, non-2-D weight, or a
+// reduction dimension not divisible by 32, is left untouched; a model with
+// no matching layer, or an opset older than 21, is returned unchanged.
+// ``seed`` derives a fresh, deterministic random rotation per matched layer.
+onnx::ModelProto ApplyQuarot(const onnx::ModelProto& model, uint64_t seed);
 
 // Lists the activation tensor names that ``QuantizeStatic`` could quantize in
 // ``model`` -- the first input of every MatMul, every "vanilla" Gemm

--- a/onnxsim/optimize_pipeline.py
+++ b/onnxsim/optimize_pipeline.py
@@ -1,0 +1,264 @@
+"""An end-to-end optimization pipeline chaining onnxsim's own recently added
+techniques together, in the same escalating-and-cumulative spirit as
+:mod:`onnxsim.autoquant`'s ``auto_quantize_int4`` (Qualcomm AIMET's
+AutoQuant), but spanning pruning, weight-only-vs-rotated quantization
+schemes, and post-hoc scale compression rather than just AIMET's own four
+techniques on top of a single fixed INT4 baseline.
+
+:func:`apply_optimization_pipeline` runs, cheapest and least invasive first:
+
+1. **Simplify** (:func:`onnxsim.simplify`) -- always, as a fusion/cleanup
+   baseline every later stage builds on.
+2. **Prune** (optional, ``sparsity``) -- :func:`onnxsim.apply_structured_pruning`
+   (data-free channel pruning): shrinking the model *before* quantizing means
+   later stages spend their whole error budget on channels that survive,
+   rather than on ones that will end up zeroed anyway.
+3. **Cross-Layer Equalize** (:func:`onnxsim.cross_layer_equalize`) -- always;
+   data-free, changes nothing but weight parameterization (see its own
+   docstring), and reduces the error every later quantization stage
+   introduces.
+4. **Quantize** -- one of two mutually exclusive schemes:
+   - ``bit_selection="uniform"`` (default): :func:`onnxsim.quantize_weight_only_int4`,
+     or, if ``calibration_data`` is available, ``bit_selection="mixed_precision"``
+     upgrades this to :func:`onnxsim.apply_mixed_precision_quantization`
+     (per-layer INT4/INT8 chosen by measured sensitivity).
+   - ``use_rotation=True``: :func:`onnxsim.apply_quarot` instead -- rotates
+     the residual stream so *both* the weight and the activation can drop to
+     INT4 (data-free), a strictly more aggressive alternative to the
+     weight-only scheme above, at the cost of the refinement stage below
+     (AdaRound/Bias Correction only optimize the weight-only scheme's own
+     ``DequantizeLinear`` shape).
+5. **Refine** (only reached if step 4 didn't meet ``accuracy_budget``, and
+   only when ``use_rotation`` is ``False``) -- :func:`onnxsim.apply_adaround`
+   then :func:`onnxsim.correct_bias`, reusing :mod:`onnxsim.autoquant`'s own
+   escalation order and its reasoning for that order (AdaRound before Bias
+   Correction, not after -- see that module's own docstring).
+6. **Compress** (:func:`onnxsim.apply_double_quantization`) -- always
+   attempted last, on whatever stage 4/5 produced: a second-level
+   quantization of the scale tensors themselves, essentially free in
+   accuracy (QLoRA's own finding) but not free in *risk*, so this pipeline
+   still measures it and only keeps it when it doesn't measurably worsen the
+   chosen stage's own accuracy.
+
+Every stage is measured with :func:`onnxsim.measure_accuracy_drop` against
+the *original* (simplified, pre-quantization) float model -- never against
+the previous stage -- matching :mod:`onnxsim.autoquant`'s own convention, so
+every stage's reported accuracy is directly comparable. Escalation stops as
+soon as a stage meets ``accuracy_budget``; if none do, the least-lossy stage
+reached is returned (``meets_budget=False``), the same fallback
+:func:`onnxsim.auto_quantize_int4`/:func:`onnxsim.recommend_quantization`
+already use.
+
+**Scope note.** This targets the pipeline's own six stages above, not every
+onnxsim quantization/pruning algorithm -- :func:`onnxsim.apply_duquant`/
+:func:`onnxsim.apply_spinquant` (calibrated rotation alternatives to
+:func:`onnxsim.apply_quarot`), :func:`onnxsim.apply_awq`/
+:func:`onnxsim.apply_gptq`/:func:`onnxsim.apply_smoothquant`/etc., and
+Wanda/SparseGPT-calibrated pruning are all still directly callable on their
+own, just not wired into this particular escalation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Sequence, Union
+
+import onnx
+
+from onnxsim.accuracy import AccuracyDropReport, measure_accuracy_drop
+from onnxsim.adaround import apply_adaround
+from onnxsim.bias_correction import correct_bias
+from onnxsim.calibration import Tensors, generate_random_calibration_data
+from onnxsim.double_quantization import apply_double_quantization
+from onnxsim.mixed_precision import apply_mixed_precision_quantization
+from onnxsim.onnx_simplifier import (
+    cross_layer_equalize,
+    quantize_weight_only_int4,
+    simplify,
+)
+from onnxsim.pruning import apply_structured_pruning
+from onnxsim.quarot import apply_quarot
+
+
+@dataclass
+class OptimizationPipelineResult:
+    """One :func:`apply_optimization_pipeline` result: the optimized model
+    reached, which stages were applied to reach it (in application order,
+    a prefix of ``["structured_pruning", "cross_layer_equalization",
+    "quantize_weight_only_int4" | "apply_mixed_precision_quantization" |
+    "quarot", "adaround", "bias_correction", "double_quantization"]``), its
+    measured accuracy drop against the original float model, and whether it
+    met ``accuracy_budget``.
+    """
+
+    optimized_model: onnx.ModelProto
+    report: AccuracyDropReport
+    stages_applied: List[str] = field(default_factory=list)
+    meets_budget: bool = False
+
+
+def apply_optimization_pipeline(
+    model: Union[str, onnx.ModelProto],
+    accuracy_budget: float = 0.1,
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_samples: int = 8,
+    seed: int = 0,
+    providers: Optional[Sequence[str]] = None,
+    sparsity: Optional[float] = None,
+    bit_selection: str = "uniform",
+    use_rotation: bool = False,
+    num_adaround_iterations: int = 300,
+) -> OptimizationPipelineResult:
+    """Runs ``model`` through the escalating pipeline described in this
+    module's own docstring, stopping as soon as a stage's measured accuracy
+    (:func:`onnxsim.measure_accuracy_drop`) meets ``accuracy_budget`` or
+    every stage has been tried.
+
+    :param model: the original (unquantized) onnx ModelProto or file path
+    :param accuracy_budget: maximum acceptable worst-case relative L2 error
+            (see :attr:`onnxsim.AccuracyDropReport.worst_relative_l2`) for a
+            stage to be accepted
+    :param calibration_data: representative input batches, used by every
+            data-driven stage (mixed-precision bit selection, AdaRound, Bias
+            Correction) and to measure each stage's accuracy drop. Each
+            batch is a ``{input_name: np.ndarray}`` dict matching ``model``'s
+            graph inputs -- see :func:`onnxsim.generate_random_calibration_data`
+            (the default when omitted)
+    :param num_samples: random batches to generate when ``calibration_data``
+            is omitted
+    :param seed: seed for the random calibration data (ignored if
+            ``calibration_data`` is supplied) and for :func:`onnxsim.apply_quarot`'s
+            own per-layer rotations
+    :param providers: onnxruntime execution providers to calibrate/run on
+    :param sparsity: if given, :func:`onnxsim.apply_structured_pruning`'s own
+            target fraction of output channels to remove, applied to the
+            float model before quantizing; ``None`` (the default) skips
+            pruning entirely
+    :param bit_selection: ``"uniform"`` (the default) quantizes every layer
+            to :func:`onnxsim.quantize_weight_only_int4`; ``"mixed_precision"``
+            instead uses :func:`onnxsim.apply_mixed_precision_quantization`
+            to pick INT4 or INT8 per layer from calibration-driven
+            sensitivity. Ignored when ``use_rotation`` is ``True``.
+    :param use_rotation: if ``True``, replaces the weight-only quantization
+            stage with :func:`onnxsim.apply_quarot` (data-free rotation
+            preprocessing, both weight and activation quantized to INT4);
+            skips the AdaRound/Bias Correction refinement stage, since those
+            only optimize the weight-only scheme's own ``DequantizeLinear``
+            shape
+    :param num_adaround_iterations: ``num_iterations`` forwarded to
+            :func:`onnxsim.apply_adaround`, only reached if quantization
+            alone misses ``accuracy_budget`` and ``use_rotation`` is
+            ``False``
+    :returns: the best stage reached -- ``meets_budget=True`` as soon as one
+            does, otherwise the least-lossy stage after every applicable
+            stage has been tried
+    """
+    if bit_selection not in ("uniform", "mixed_precision"):
+        raise ValueError(
+            f'bit_selection must be "uniform" or "mixed_precision", got {bit_selection!r}'
+        )
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    model, _ = simplify(model)
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            model, num_samples=num_samples, seed=seed
+        )
+
+    def _measure(candidate: onnx.ModelProto) -> AccuracyDropReport:
+        return measure_accuracy_drop(
+            model,
+            candidate,
+            calibration_data=calibration_data,
+            num_samples=num_samples,
+            seed=seed,
+            providers=providers,
+        )
+
+    def _meets(report: AccuracyDropReport) -> bool:
+        return report.all_finite and report.worst_relative_l2 < accuracy_budget
+
+    def _better(a: AccuracyDropReport, b: AccuracyDropReport) -> bool:
+        if a.all_finite and not b.all_finite:
+            return True
+        if not a.all_finite:
+            return False
+        return a.worst_relative_l2 < b.worst_relative_l2
+
+    stages: List[str] = []
+    float_model = model
+    if sparsity is not None:
+        float_model = apply_structured_pruning(float_model, sparsity=sparsity)
+        stages.append("structured_pruning")
+
+    float_model = cross_layer_equalize(float_model)
+    stages.append("cross_layer_equalization")
+
+    if use_rotation:
+        quantized = apply_quarot(float_model, seed=seed)
+        stages.append("quarot")
+    elif bit_selection == "mixed_precision":
+        quantized = apply_mixed_precision_quantization(
+            float_model,
+            calibration_data=calibration_data,
+            num_samples=num_samples,
+            seed=seed,
+            providers=providers,
+        )
+        stages.append("apply_mixed_precision_quantization")
+    else:
+        quantized = quantize_weight_only_int4(float_model)
+        stages.append("quantize_weight_only_int4")
+
+    report = _measure(quantized)
+    best = OptimizationPipelineResult(quantized, report, list(stages), _meets(report))
+
+    if not best.meets_budget and not use_rotation:
+        ada_quantized = apply_adaround(
+            float_model,
+            quantized,
+            calibration_data=calibration_data,
+            providers=providers,
+            num_iterations=num_adaround_iterations,
+        )
+        ada_report = _measure(ada_quantized)
+        stages.append("adaround")
+        ada_result = OptimizationPipelineResult(
+            ada_quantized, ada_report, list(stages), _meets(ada_report)
+        )
+        if _better(ada_report, best.report):
+            best = ada_result
+
+        if not ada_result.meets_budget:
+            bc_quantized = correct_bias(
+                float_model,
+                ada_quantized,
+                calibration_data=calibration_data,
+                providers=providers,
+            )
+            bc_report = _measure(bc_quantized)
+            stages.append("bias_correction")
+            bc_result = OptimizationPipelineResult(
+                bc_quantized, bc_report, list(stages), _meets(bc_report)
+            )
+            if _better(bc_report, best.report):
+                best = bc_result
+
+    # Compression is attempted last, on whatever stage produced `best`, and
+    # kept only when it doesn't measurably worsen that stage's own accuracy
+    # -- see this module's own docstring for why this isn't budget-gated
+    # escalation like the stages above.
+    compressed = apply_double_quantization(best.optimized_model)
+    compressed_report = _measure(compressed)
+    if compressed_report.all_finite and (
+        not best.report.all_finite
+        or compressed_report.worst_relative_l2 <= best.report.worst_relative_l2 * 1.05
+    ):
+        best = OptimizationPipelineResult(
+            compressed,
+            compressed_report,
+            best.stages_applied + ["double_quantization"],
+            _meets(compressed_report),
+        )
+
+    return best

--- a/onnxsim/passes/double_quantization.h
+++ b/onnxsim/passes/double_quantization.h
@@ -1,0 +1,159 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+// Double quantization (Dettmers et al., 2023, "QLoRA: Efficient Finetuning
+// of Quantized LLMs", Section 3.2) -- see double_quantization.py's own
+// docstring for the full rationale. Unlike every other pass in this
+// directory, this one has no "live weight" to quantize: it operates purely
+// on an *already-quantized* graph, as a second pass over every
+// DequantizeLinear node's own scale tensor.
+//
+// Every block-wise/per-channel scheme in onnxsim (weight_only_quantize_*,
+// static_quantize_*, ...) stores one float32 scale per quantization block --
+// e.g. a 32-element INT4 block needs 16 bytes of codes plus 4 bytes of
+// scale, a 25% overhead. This pass quantizes the scale tensor itself, one
+// more level down: for every DequantizeLinear node whose scale input (input
+// 1) is a constant float32 tensor with at least kMinElements values (a
+// per-block or per-channel scale -- a single scalar per-tensor scale isn't
+// worth a second quantizer's own overhead), the scale is quantized to UINT8
+// with a single per-tensor meta-scale and reconstructed via a second, nested
+// DequantizeLinear feeding into the original node's own scale input:
+//
+//   Before:
+//     Whatever = DequantizeLinear(Codes, Scale, ...)  -- Scale: float32 constant
+//   After:
+//     ScaleCodes: initializer, uint8, same shape as Scale
+//     MetaScale: initializer, float32 scalar, max(|Scale|) / 255
+//     ScaleHat = DequantizeLinear(ScaleCodes, MetaScale)
+//     Whatever = DequantizeLinear(Codes, ScaleHat, ...)  -- same attributes as before
+//
+// This is technique-agnostic (it only looks at the DequantizeLinear node's
+// own scale input, not who produced it), so it composes with every
+// block-wise/per-channel onnxsim scheme unchanged. It runs to a fixed point
+// naturally: the rewritten outer node's scale input (ScaleHat) is no longer
+// a constant initializer, so it never matches a second time, and the inner
+// DequantizeLinear's own scale (MetaScale, a single scalar) is always well
+// under kMinElements. The original float32 scale initializer is left in the
+// graph, unreferenced, like every other onnxsim rewrite's now-dead
+// initializer.
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+#include "passes/endian_read.h"
+#include "passes/quantize_conv_common.h"  // ReadFloatTensorFlat
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+// ReadFloatTensorFlat (quantize_conv_common.h) reads every element of a
+// tensor of any rank into a flat host-order vector<float> -- used here since
+// a DequantizeLinear scale tensor may be scalar, 1-D (per-channel), or 2-D
+// (per-block), unlike ReadFloatMatrix (quantize_matmul_common.h), which
+// targets only the always-2-D weight tensors its own callers match.
+
+inline bool MatchDoubleQuantizationCandidate(Node* n, int64_t min_elements,
+                                             const Tensor** scale_t_out) {
+  if (n->kind() != Symbol("DequantizeLinear") || n->inputs().size() < 2) {
+    return false;
+  }
+  const Tensor* scale_t = FetchConstantTensor(n->inputs()[1]);
+  if (scale_t == nullptr ||
+      scale_t->elem_type() != TensorProto_DataType_FLOAT) {
+    return false;
+  }
+  int64_t numel = 1;
+  for (const int64_t d : scale_t->sizes()) {
+    numel *= d;
+  }
+  if (numel < min_elements) {
+    return false;
+  }
+  *scale_t_out = scale_t;
+  return true;
+}
+
+struct DoubleQuantization final : public PredicateBasedPass {
+  // A per-tensor scalar scale (numel == 1) is never worth a second
+  // quantizer's own overhead (a meta-scale initializer plus a new node); 64
+  // matches double_quantization.py's own default.
+  static constexpr int64_t kMinElements = 64;
+
+  explicit DoubleQuantization()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+  std::string getPassName() const override { return "double_quantization"; }
+
+  bool patternMatchPredicate(Node* n) override {
+    const Tensor* scale_t = nullptr;
+    return MatchDoubleQuantizationCandidate(n, kMinElements, &scale_t);
+  }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+    const Tensor* scale_t = nullptr;
+    if (!MatchDoubleQuantizationCandidate(n, kMinElements, &scale_t)) {
+      return false;
+    }
+    Value* scale_v = n->inputs()[1];
+
+    const std::vector<float> scale_data = ReadFloatTensorFlat(*scale_t);
+    double max_abs = 0.0;
+    for (const float v : scale_data) {
+      max_abs = std::max(max_abs, static_cast<double>(std::fabs(v)));
+    }
+    // scale_data holds ordinary absmax-derived quantization scales, always
+    // non-negative, so a plain unsigned 0..255 range needs no zero-point
+    // offset.
+    const float meta_scale =
+        static_cast<float>(std::max(max_abs, 1e-12) / 255.0);
+
+    std::vector<uint8_t> codes(scale_data.size());
+    for (size_t i = 0; i < scale_data.size(); ++i) {
+      const float q = std::round(scale_data[i] / meta_scale);
+      codes[i] = static_cast<uint8_t>(std::clamp(q, 0.0f, 255.0f));
+    }
+
+    Tensor codes_t;
+    codes_t.elem_type() = TensorProto_DataType_UINT8;
+    codes_t.sizes() = scale_t->sizes();
+    codes_t.set_raw_data(WriteRawDataLittleEndian(codes));
+    Value* codes_v = graph.addInitializerAndCreateValue(codes_t);
+
+    Tensor meta_scale_t;
+    meta_scale_t.elem_type() = TensorProto_DataType_FLOAT;
+    meta_scale_t.floats() = {meta_scale};
+    Value* meta_scale_v = graph.addInitializerAndCreateValue(meta_scale_t);
+
+    // ScaleHat = DequantizeLinear(ScaleCodes, MetaScale) -- zero_point
+    // omitted (symmetric-unsigned, i.e. always 0).
+    Node* inner_dq = graph.create(Symbol("DequantizeLinear"), 1);
+    inner_dq->addInput(codes_v);
+    inner_dq->addInput(meta_scale_v);
+    inner_dq->insertBefore(n);
+    inner_dq->output()->setElemType(TensorProto_DataType_FLOAT);
+    inner_dq->output()->setSizes(scale_v->sizes());
+
+    // `n` (the original DequantizeLinear) is left otherwise untouched; only
+    // its scale input changes, to its dequantized-from-UINT8 reconstruction.
+    n->replaceInput(1, inner_dq->output());
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/double_quantization.h
+++ b/onnxsim/passes/double_quantization.h
@@ -24,12 +24,12 @@
 // DequantizeLinear feeding into the original node's own scale input:
 //
 //   Before:
-//     Whatever = DequantizeLinear(Codes, Scale, ...)  -- Scale: float32 constant
+//     Whatever = DequantizeLinear(Codes, Scale, ...)  -- Scale: constant
 //   After:
 //     ScaleCodes: initializer, uint8, same shape as Scale
 //     MetaScale: initializer, float32 scalar, max(|Scale|) / 255
 //     ScaleHat = DequantizeLinear(ScaleCodes, MetaScale)
-//     Whatever = DequantizeLinear(Codes, ScaleHat, ...)  -- same attributes as before
+//     Whatever = DequantizeLinear(Codes, ScaleHat, ...)  -- attrs unchanged
 //
 // This is technique-agnostic (it only looks at the DequantizeLinear node's
 // own scale input, not who produced it), so it composes with every

--- a/onnxsim/passes/magnitude_pruning.h
+++ b/onnxsim/passes/magnitude_pruning.h
@@ -1,0 +1,291 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+// Magnitude pruning (Han et al., 2015) -- the data-free unstructured
+// pruning baseline, C++ port of pruning.py's own apply_magnitude_pruning.
+// Zeros the least-magnitude entries of every MatMul/vanilla-Gemm layer's
+// constant 2-D float32 weight and every Conv layer's constant 4-D float32
+// weight (ordinary, depthwise, and general grouped Conv alike -- see
+// pruning.py's own module docstring for why grouping needs no special-
+// casing for unstructured pruning), independently per output row/filter so
+// a layer with row-dependent weight scale doesn't get some rows pruned to
+// nothing and others left untouched.
+//
+// Scope note: unlike pruning.py's apply_magnitude_pruning, this port does
+// not match com.microsoft::Attention's merged QKV weight (a rare contrib-op
+// case) and does not offer N:M (semi-structured) pruning -- only the
+// sparsity-ratio mode. Both remain available via the pure-Python
+// implementation.
+//
+// Before (illustrated for MatMul; a "vanilla" Gemm -- transA=0, alpha=1,
+// beta=1 -- and Conv are handled the same way, reshaped to
+// [out_channels, flattened_rest] first):
+//   Y = MatMul(X, W)         W constant, [K, N], float32
+// After:
+//   Wp = <W with each output channel's own lowest-|w| fraction zeroed>
+//   Y  = MatMul(X, Wp)
+//
+// The weight's shape, dtype, and every other node attribute are unchanged;
+// only element values within the existing tensor are zeroed (via a new
+// initializer of the same shape, not an in-place edit -- matching every
+// other onnxsim rewrite's "replace, don't mutate" convention for constants).
+// Since the replacement is still a plain constant float32 tensor of the
+// same shape, both patternMatchPredicate methods below explicitly check
+// whether pruning would still change anything (any would-be-dropped entry
+// that isn't already exactly zero) -- otherwise, unlike every other pass in
+// this directory (whose replacement is no longer constant, or has changed
+// kind/shape), the predicate would keep matching its own already-pruned
+// output forever, looping OptimizeFixed's fixed point indefinitely.
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+#include "passes/quantize_conv_common.h"
+#include "passes/quantize_matmul_common.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+// Target fraction of each row's entries to zero. A function-local static,
+// the same pattern QuantizeFp16KeepIoTypes() (quantize_fp16.h) uses to pass
+// a parameter into a pass that OptimizeFixed's pass-name-list interface has
+// no other way to carry -- set by PruneMagnitude (pruning_entry.cpp)
+// immediately before calling OptimizeFixed.
+inline double& MagnitudePruningSparsity() {
+  static double sparsity = 0.5;
+  return sparsity;
+}
+
+// Row-wise magnitude mask over a flat, row-major [rows, cols] `importance`
+// matrix: within each row independently, keeps the
+// max(1, round(cols * (1 - sparsity))) highest-importance entries and drops
+// the rest -- mirrors pruning.py's own _sparsity_mask exactly (same keep
+// count, same "never drop every entry of a row" floor), but via
+// std::stable_sort per row instead of a vectorized argsort (tie-breaking on
+// exactly-equal importances -- common with exact-zero weights -- may
+// therefore differ from the Python port's own choice of which zero-tied
+// entry to drop; both are equally valid magnitude-pruning outcomes).
+inline std::vector<bool> SparsityMaskRowMajor(const std::vector<float>& importance,
+                                              int64_t rows, int64_t cols,
+                                              double sparsity) {
+  std::vector<bool> mask(importance.size(), true);
+  // std::nearbyint (current rounding mode is FE_TONEAREST, i.e.
+  // round-half-to-even, by default) rather than std::lround
+  // (round-half-away-from-zero) to match Python's own round() -- the two
+  // differ only on an exact .5 tie, but pruning.py's _sparsity_mask uses
+  // Python's round() for its own keep count.
+  const int64_t keep = std::max<int64_t>(
+      1, static_cast<int64_t>(std::nearbyint(cols * (1.0 - sparsity))));
+  if (keep >= cols) {
+    return mask;
+  }
+  const int64_t drop = cols - keep;
+  std::vector<int64_t> order(static_cast<size_t>(cols));
+  for (int64_t r = 0; r < rows; ++r) {
+    const float* row = importance.data() + r * cols;
+    for (int64_t c = 0; c < cols; ++c) {
+      order[static_cast<size_t>(c)] = c;
+    }
+    std::stable_sort(order.begin(), order.end(), [&](int64_t a, int64_t b) {
+      return row[a] < row[b];
+    });
+    for (int64_t i = 0; i < drop; ++i) {
+      mask[static_cast<size_t>(r * cols + order[static_cast<size_t>(i)])] =
+          false;
+    }
+  }
+  return mask;
+}
+
+// Whether applying SparsityMaskRowMajor's own mask to `data` (row-major
+// [rows, cols], matching layout) would zero out at least one currently
+// nonzero entry -- see this file's own doc comment for why every predicate
+// below must check this before matching.
+inline bool MagnitudePruningWouldChange(const std::vector<float>& data,
+                                        int64_t rows, int64_t cols,
+                                        double sparsity) {
+  std::vector<float> importance(data.size());
+  for (size_t i = 0; i < data.size(); ++i) {
+    importance[i] = std::fabs(data[i]);
+  }
+  const std::vector<bool> mask =
+      SparsityMaskRowMajor(importance, rows, cols, sparsity);
+  for (size_t i = 0; i < data.size(); ++i) {
+    if (!mask[i] && data[i] != 0.0f) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Applies `mask` (row-major [rows, cols], SparsityMaskRowMajor's own layout)
+// to `data` (the same flat row-major layout), zeroing every masked-out
+// entry in place.
+inline void ApplyMaskRowMajor(std::vector<float>& data,
+                              const std::vector<bool>& mask) {
+  for (size_t i = 0; i < data.size(); ++i) {
+    if (!mask[i]) {
+      data[i] = 0.0f;
+    }
+  }
+}
+
+// ReadWeightNK (quantize_matmul_common.h) reads a 2-D MatMul/Gemm weight
+// into a flat row-major [N, K] (output channel first) buffer, used here so
+// SparsityMaskRowMajor's per-row grouping lines up with output channels
+// regardless of the weight's own on-disk (transposed or not) layout.
+
+struct MagnitudePruningMatMul final : public PredicateBasedPass {
+  explicit MagnitudePruningMatMul()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+  std::string getPassName() const override { return "magnitude_pruning_matmul"; }
+
+  bool patternMatchPredicate(Node* n) override {
+    MatMulLikeInfo info;
+    if (!MatchMatMulLike(n, info)) {
+      return false;
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+        w_t->sizes().size() != 2) {
+      return false;
+    }
+    const int64_t dim0 = w_t->sizes()[0];
+    const int64_t dim1 = w_t->sizes()[1];
+    const int64_t rows = info.weight_transposed ? dim0 : dim1;
+    const int64_t cols = info.weight_transposed ? dim1 : dim0;
+    const std::vector<float> w_nk = ReadWeightNK(*w_t, info.weight_transposed);
+    return MagnitudePruningWouldChange(w_nk, rows, cols,
+                                       MagnitudePruningSparsity());
+  }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+    MatMulLikeInfo info;
+    if (!MatchMatMulLike(n, info)) {
+      return false;
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+        w_t->sizes().size() != 2) {
+      return false;
+    }
+
+    const int64_t dim0 = w_t->sizes()[0];
+    const int64_t dim1 = w_t->sizes()[1];
+    const int64_t rows = info.weight_transposed ? dim0 : dim1;
+    const int64_t cols = info.weight_transposed ? dim1 : dim0;
+
+    std::vector<float> w_nk = ReadWeightNK(*w_t, info.weight_transposed);
+    std::vector<float> importance(w_nk.size());
+    for (size_t i = 0; i < w_nk.size(); ++i) {
+      importance[i] = std::fabs(w_nk[i]);
+    }
+    const std::vector<bool> mask = SparsityMaskRowMajor(
+        importance, rows, cols, MagnitudePruningSparsity());
+    ApplyMaskRowMajor(w_nk, mask);
+
+    Tensor w_pruned;
+    w_pruned.elem_type() = TensorProto_DataType_FLOAT;
+    w_pruned.sizes() = {dim0, dim1};
+    std::vector<float> out_data(static_cast<size_t>(dim0 * dim1));
+    for (int64_t i = 0; i < dim0; ++i) {
+      for (int64_t j = 0; j < dim1; ++j) {
+        out_data[static_cast<size_t>(i * dim1 + j)] =
+            info.weight_transposed ? w_nk[static_cast<size_t>(i * cols + j)]
+                                   : w_nk[static_cast<size_t>(j * cols + i)];
+      }
+    }
+    w_pruned.floats() = std::move(out_data);
+
+    Value* w_pruned_v = graph.addInitializerAndCreateValue(w_pruned);
+    n->replaceInput(1, w_pruned_v);
+    return true;
+  }
+};
+
+struct MagnitudePruningConv final : public PredicateBasedPass {
+  explicit MagnitudePruningConv()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+  std::string getPassName() const override { return "magnitude_pruning_conv"; }
+
+  bool patternMatchPredicate(Node* n) override {
+    ConvInfo info;
+    if (!MatchConv(n, info)) {
+      return false;
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+        w_t->sizes().size() != 4) {
+      return false;
+    }
+    const int64_t rows = w_t->sizes()[0];
+    int64_t cols = 1;
+    for (size_t i = 1; i < w_t->sizes().size(); ++i) {
+      cols *= w_t->sizes()[i];
+    }
+    const std::vector<float> data = ReadFloatTensorFlat(*w_t);
+    return MagnitudePruningWouldChange(data, rows, cols,
+                                       MagnitudePruningSparsity());
+  }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+    ConvInfo info;
+    if (!MatchConv(n, info)) {
+      return false;
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+        w_t->sizes().size() != 4) {
+      return false;
+    }
+
+    // [out_channels, in_channels/groups, kH, kW] -> [rows=out_channels,
+    // cols=flattened rest], the same reshape pruning.py's own _prune_weight
+    // uses for Conv.
+    const int64_t rows = w_t->sizes()[0];
+    int64_t cols = 1;
+    for (size_t i = 1; i < w_t->sizes().size(); ++i) {
+      cols *= w_t->sizes()[i];
+    }
+
+    std::vector<float> data = ReadFloatTensorFlat(*w_t);
+    std::vector<float> importance(data.size());
+    for (size_t i = 0; i < data.size(); ++i) {
+      importance[i] = std::fabs(data[i]);
+    }
+    const std::vector<bool> mask = SparsityMaskRowMajor(
+        importance, rows, cols, MagnitudePruningSparsity());
+    ApplyMaskRowMajor(data, mask);
+
+    Tensor w_pruned;
+    w_pruned.elem_type() = TensorProto_DataType_FLOAT;
+    w_pruned.sizes() = w_t->sizes();
+    w_pruned.floats() = std::move(data);
+
+    Value* w_pruned_v = graph.addInitializerAndCreateValue(w_pruned);
+    n->replaceInput(1, w_pruned_v);
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/magnitude_pruning.h
+++ b/onnxsim/passes/magnitude_pruning.h
@@ -77,9 +77,9 @@ inline double& MagnitudePruningSparsity() {
 // exactly-equal importances -- common with exact-zero weights -- may
 // therefore differ from the Python port's own choice of which zero-tied
 // entry to drop; both are equally valid magnitude-pruning outcomes).
-inline std::vector<bool> SparsityMaskRowMajor(const std::vector<float>& importance,
-                                              int64_t rows, int64_t cols,
-                                              double sparsity) {
+inline std::vector<bool> SparsityMaskRowMajor(
+    const std::vector<float>& importance, int64_t rows, int64_t cols,
+    double sparsity) {
   std::vector<bool> mask(importance.size(), true);
   // std::nearbyint (current rounding mode is FE_TONEAREST, i.e.
   // round-half-to-even, by default) rather than std::lround
@@ -98,9 +98,8 @@ inline std::vector<bool> SparsityMaskRowMajor(const std::vector<float>& importan
     for (int64_t c = 0; c < cols; ++c) {
       order[static_cast<size_t>(c)] = c;
     }
-    std::stable_sort(order.begin(), order.end(), [&](int64_t a, int64_t b) {
-      return row[a] < row[b];
-    });
+    std::stable_sort(order.begin(), order.end(),
+                     [&](int64_t a, int64_t b) { return row[a] < row[b]; });
     for (int64_t i = 0; i < drop; ++i) {
       mask[static_cast<size_t>(r * cols + order[static_cast<size_t>(i)])] =
           false;
@@ -151,7 +150,9 @@ struct MagnitudePruningMatMul final : public PredicateBasedPass {
   explicit MagnitudePruningMatMul()
       : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
                            PassOptimizationType::Compute) {}
-  std::string getPassName() const override { return "magnitude_pruning_matmul"; }
+  std::string getPassName() const override {
+    return "magnitude_pruning_matmul";
+  }
 
   bool patternMatchPredicate(Node* n) override {
     MatMulLikeInfo info;

--- a/onnxsim/passes/quantize_matmul_common.h
+++ b/onnxsim/passes/quantize_matmul_common.h
@@ -465,6 +465,32 @@ inline bool TryQuantizeWeightBlockwiseInt4InPlace(const Tensor& w_t,
   return true;
 }
 
+// Reads `w_t` (a 2-D float32 constant, [K, N] or, when `transposed`,
+// [N, K]) into a flat row-major [N, K] (output channel first) buffer --
+// matches TryQuantizeWeightBlockwiseInt4InPlace's own channel_axis
+// convention, used by callers (magnitude_pruning.h, quarot.h) that need the
+// weight in a fixed output-channel-first layout regardless of its own
+// on-disk transposed-or-not storage.
+inline std::vector<float> ReadWeightNK(const Tensor& w_t, bool transposed) {
+  const int64_t dim0 = w_t.sizes()[0];
+  const int64_t dim1 = w_t.sizes()[1];
+  const int64_t rows = transposed ? dim0 : dim1;
+  const int64_t cols = transposed ? dim1 : dim0;
+  const std::vector<float> data = ReadFloatMatrix(w_t);
+  std::vector<float> w_nk(static_cast<size_t>(rows * cols));
+  for (int64_t i = 0; i < dim0; ++i) {
+    for (int64_t j = 0; j < dim1; ++j) {
+      const float v = data[static_cast<size_t>(i * dim1 + j)];
+      if (transposed) {
+        w_nk[static_cast<size_t>(i * cols + j)] = v;
+      } else {
+        w_nk[static_cast<size_t>(j * cols + i)] = v;
+      }
+    }
+  }
+  return w_nk;
+}
+
 // Same block-wise scheme as TryQuantizeWeightBlockwiseInt4InPlace, but INT8
 // (values in [-127, 127], scale = max(|w|) / 127 per block) instead of
 // INT4 -- a middle ground between QuantizeWeightPerChannelInPlace's single

--- a/onnxsim/passes/quantize_mxfp4_common.h
+++ b/onnxsim/passes/quantize_mxfp4_common.h
@@ -1,0 +1,142 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+// Shared OCP Microscaling MXFP4 (E2M1 elements + power-of-two E8M0 block
+// scale) codebook and block-wise weight quantization helper, used by
+// weight_only_quantize_mxfp4_matmul.h. Ports mx_quantization.py's own
+// MXFP4_CODEBOOK / _quantize_mxfp4_blockwise -- see that module's docstring
+// for the format's own definition (OCP Microscaling Formats (MX)
+// Specification v1.0) and why a Gather-a-codebook idiom (rather than a
+// native ONNX tensor type, which does not exist for MX formats) is used to
+// represent it.
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+#include "onnx/common/ir.h"
+#include "passes/endian_read.h"
+#include "passes/quantize_matmul_common.h"  // ReadFloatMatrix
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+// E2M1's own 16 bit patterns, evaluated per the format definition (bias 1,
+// subnormal exponent field 0): magnitudes {0, 0.5, 1, 1.5, 2, 3, 4, 6},
+// signed. Fixed by the OCP MX spec -- not fit to any data.
+inline const std::vector<float>& MXFP4Codebook() {
+  static const std::vector<float> kCodebook = {
+      -6.0f, -4.0f, -3.0f, -2.0f, -1.5f, -1.0f, -0.5f, -0.0f,
+      0.0f,  0.5f,  1.0f,  1.5f,  2.0f,  3.0f,  4.0f,  6.0f,
+  };
+  return kCodebook;
+}
+
+// The largest magnitude E2M1 can represent (6.0 == 1.5 * 2^2) -- used to pick
+// each block's own power-of-two shared scale so the block's own
+// largest-magnitude element lands within E2M1's representable range.
+constexpr float kMXFP4MaxMagnitude = 6.0f;
+
+// OCP MX spec's own canonical block size for every MX format.
+constexpr int64_t kMXBlockSize = 32;
+
+inline uint8_t NearestMXFP4Code(float normalized) {
+  const auto& codebook = MXFP4Codebook();
+  size_t best = 0;
+  float best_diff = std::fabs(normalized - codebook[0]);
+  for (size_t i = 1; i < codebook.size(); ++i) {
+    const float diff = std::fabs(normalized - codebook[i]);
+    if (diff < best_diff) {
+      best_diff = diff;
+      best = i;
+    }
+  }
+  return static_cast<uint8_t>(best);
+}
+
+// Block-wise MXFP4 quantization of `w_t` (a 2-D float32 constant) *in its own
+// layout* (no transpose), mirroring
+// TryQuantizeWeightBlockwiseInt4InPlace's channel_axis/block_size/shape
+// conventions (quantize_matmul_common.h) exactly, but for MXFP4: `q_out`
+// holds one UINT8 codebook index (0..15) per element (SAME shape as `w_t`)
+// instead of a packed INT4 nibble, and `scale_out` holds one power-of-two
+// float32 scale per (block, channel) group -- the OCP MX spec's E8M0 *value*
+// (not its raw exponent-byte encoding, since ONNX has no E8M0 tensor type to
+// store that encoding in).
+//
+// Returns false (nothing written) when `K` (the reduction axis' size) is not
+// evenly divisible by `block_size`.
+inline bool TryQuantizeWeightBlockwiseMXFP4InPlace(const Tensor& w_t,
+                                                    int64_t channel_axis,
+                                                    int64_t block_size,
+                                                    Tensor& q_out,
+                                                    Tensor& scale_out) {
+  const auto& sizes = w_t.sizes();
+  const int64_t dim0 = sizes[0];
+  const int64_t dim1 = sizes[1];
+  const int64_t reduction_axis = 1 - channel_axis;
+  const int64_t K = reduction_axis == 0 ? dim0 : dim1;
+  if (block_size <= 0 || K % block_size != 0) {
+    return false;
+  }
+  const int64_t num_blocks = K / block_size;
+
+  const std::vector<float> data = ReadFloatMatrix(w_t);
+  auto at = [&](int64_t i, int64_t j) { return data[i * dim1 + j]; };
+  const int64_t scale_dim0 = reduction_axis == 0 ? num_blocks : dim0;
+  const int64_t scale_dim1 = reduction_axis == 1 ? num_blocks : dim1;
+  auto scale_index = [&](int64_t i, int64_t j) {
+    const int64_t si = reduction_axis == 0 ? i / block_size : i;
+    const int64_t sj = reduction_axis == 1 ? j / block_size : j;
+    return si * scale_dim1 + sj;
+  };
+
+  std::vector<float> max_abs(static_cast<size_t>(scale_dim0 * scale_dim1),
+                             0.0f);
+  for (int64_t i = 0; i < dim0; ++i) {
+    for (int64_t j = 0; j < dim1; ++j) {
+      float& m = max_abs[static_cast<size_t>(scale_index(i, j))];
+      m = std::max(m, std::fabs(at(i, j)));
+    }
+  }
+  std::vector<float> scale(max_abs.size());
+  for (size_t idx = 0; idx < max_abs.size(); ++idx) {
+    const float m = std::max(max_abs[idx], 1e-30f);
+    // The smallest power-of-two scale that keeps the block's own largest
+    // magnitude within E2M1's representable range (max 6.0): ceil(), not
+    // floor(log2)-2, so max_abs / scale is always <= 6.0 -- see
+    // mx_quantization.py's own _quantize_mxfp4_blockwise for why the
+    // floor-based alternative would silently clip.
+    const float shared_exponent = std::ceil(std::log2(m / kMXFP4MaxMagnitude));
+    scale[idx] = std::exp2(shared_exponent);
+  }
+
+  q_out.elem_type() = TensorProto_DataType_UINT8;
+  q_out.sizes() = {dim0, dim1};
+  std::vector<uint8_t> codes(static_cast<size_t>(dim0 * dim1));
+  for (int64_t i = 0; i < dim0; ++i) {
+    for (int64_t j = 0; j < dim1; ++j) {
+      const float s = scale[static_cast<size_t>(scale_index(i, j))];
+      const float normalized = at(i, j) / s;
+      codes[static_cast<size_t>(i * dim1 + j)] = NearestMXFP4Code(normalized);
+    }
+  }
+  q_out.set_raw_data(WriteRawDataLittleEndian(codes));
+
+  scale_out.elem_type() = TensorProto_DataType_FLOAT;
+  scale_out.sizes() = {scale_dim0, scale_dim1};
+  scale_out.floats() = std::move(scale);
+  return true;
+}
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/quantize_mxfp4_common.h
+++ b/onnxsim/passes/quantize_mxfp4_common.h
@@ -75,10 +75,10 @@ inline uint8_t NearestMXFP4Code(float normalized) {
 // Returns false (nothing written) when `K` (the reduction axis' size) is not
 // evenly divisible by `block_size`.
 inline bool TryQuantizeWeightBlockwiseMXFP4InPlace(const Tensor& w_t,
-                                                    int64_t channel_axis,
-                                                    int64_t block_size,
-                                                    Tensor& q_out,
-                                                    Tensor& scale_out) {
+                                                   int64_t channel_axis,
+                                                   int64_t block_size,
+                                                   Tensor& q_out,
+                                                   Tensor& scale_out) {
   const auto& sizes = w_t.sizes();
   const int64_t dim0 = sizes[0];
   const int64_t dim1 = sizes[1];

--- a/onnxsim/passes/quarot.h
+++ b/onnxsim/passes/quarot.h
@@ -121,8 +121,10 @@ struct Quarot final : public PredicateBasedPass {
       return false;
     }
 
-    const int64_t N = info.weight_transposed ? w_t->sizes()[0] : w_t->sizes()[1];
-    const int64_t K = info.weight_transposed ? w_t->sizes()[1] : w_t->sizes()[0];
+    const int64_t N =
+        info.weight_transposed ? w_t->sizes()[0] : w_t->sizes()[1];
+    const int64_t K =
+        info.weight_transposed ? w_t->sizes()[1] : w_t->sizes()[0];
     if (K % kBlockSize != 0) {
       return false;
     }
@@ -132,7 +134,7 @@ struct Quarot final : public PredicateBasedPass {
     const std::vector<float> w_nk = ReadWeightNK(*w_t, info.weight_transposed);
 
     std::mt19937_64 rng(QuarotSeed() ^
-                       (0x9E3779B97F4A7C15ULL * (n->output()->unique() + 1)));
+                        (0x9E3779B97F4A7C15ULL * (n->output()->unique() + 1)));
     const std::vector<float> u = RandomOrthogonalMatrix(K, rng);  // [K, K]
 
     // w_tilde_nk = w_nk @ u  -- [N, K], exact before quantization.
@@ -161,11 +163,12 @@ struct Quarot final : public PredicateBasedPass {
         float max_abs = 0.0f;
         for (int64_t j = 0; j < kBlockSize; ++j) {
           const int64_t c = blk * kBlockSize + j;
-          max_abs = std::max(
-              max_abs,
-              static_cast<float>(std::fabs(w_tilde_nk[static_cast<size_t>(r * K + c)])));
+          max_abs = std::max(max_abs,
+                             static_cast<float>(std::fabs(
+                                 w_tilde_nk[static_cast<size_t>(r * K + c)])));
         }
-        scale_kn[static_cast<size_t>(blk * N + r)] = max_abs > 0.0f ? max_abs / 7.0f : 1.0f;
+        scale_kn[static_cast<size_t>(blk * N + r)] =
+            max_abs > 0.0f ? max_abs / 7.0f : 1.0f;
       }
     }
     std::vector<int8_t> codes_kn(static_cast<size_t>(K * N));
@@ -186,8 +189,10 @@ struct Quarot final : public PredicateBasedPass {
     const int64_t numel = K * N;
     std::string packed(static_cast<size_t>((numel + 1) / 2), '\0');
     for (int64_t i = 0; i < numel; ++i) {
-      const uint8_t nibble = static_cast<uint8_t>(codes_kn[static_cast<size_t>(i)]) & 0x0F;
-      uint8_t& byte = reinterpret_cast<uint8_t&>(packed[static_cast<size_t>(i / 2)]);
+      const uint8_t nibble =
+          static_cast<uint8_t>(codes_kn[static_cast<size_t>(i)]) & 0x0F;
+      uint8_t& byte =
+          reinterpret_cast<uint8_t&>(packed[static_cast<size_t>(i / 2)]);
       if (i % 2 == 0) {
         byte = nibble;
       } else {

--- a/onnxsim/passes/quarot.h
+++ b/onnxsim/passes/quarot.h
@@ -1,0 +1,323 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+// QuaRot (Ashkboos et al., 2024, "QuaRot: Outlier-Free 4-Bit Inference in
+// Rotated LLMs") -- C++ port of quarot.py's own apply_quarot. See that
+// module's docstring for the full rationale (rotating the residual stream
+// by a random orthogonal matrix removes activation outliers the same way
+// it already removes weight outliers, letting *both* MatMul operands drop
+// to INT4 with plain round-to-nearest and no calibration data at all).
+//
+// Before (illustrated for MatMul; a "vanilla" Gemm -- transA=0, alpha=1,
+// beta=1 -- is handled the same way, its bias C carried through unchanged):
+//   Y = MatMul(X, W) [+ bias]                 W constant, [K, N], float32
+// After:
+//   U: initializer, float32 [K, K]            -- the random rotation
+//   Xrot = MatMul(X, U)                       -- runtime activation rotation
+//   Xq   = round_to_nearest_int4_per_token(Xrot)   -- data-free, no calibration
+//   Wtilde_hat = DequantizeLinear(Wtilde_q, Wtilde_s, axis=0, block_size=32)
+//                                               -- INT4 codes, [K, N]
+//   Y = MatMul(Xq, Wtilde_hat) [+ bias]
+//
+// Unlike every weight-only scheme in this directory, this pass replaces the
+// *entire* matched node (not just its weight input): the activation path
+// changes too. Only the common, unambiguous shape is handled: a MatMul, or
+// a Gemm with transA=0, alpha=1 and beta=1, whose weight (input 1) is a
+// constant 2-D float32 tensor whose reduction dimension K is divisible by
+// kBlockSize, on an opset >= 21 model (INT4 tensors and DequantizeLinear's
+// block_size attribute both need it). Everything else is left alone.
+//
+// Scope note: this reuses a fresh Haar-random rotation per matched layer
+// (random_orthogonal.h), matching quarot.py's/spinquant.py's own scope --
+// not the real QuaRot's single rotation fused across an entire decoder
+// stack (see quarot.py's own docstring for why: fusing one global rotation
+// needs a model-level residual-stream graph walk this port does not
+// attempt).
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+#include "passes/quantize_matmul_common.h"
+#include "passes/random_orthogonal.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+// Seed for the per-layer random rotations. A function-local static, the
+// same pattern MagnitudePruningSparsity() (magnitude_pruning.h) uses to
+// pass a parameter into a pass OptimizeFixed's pass-name-list interface has
+// no other way to carry -- set by ApplyQuarot (quantize_entry.cpp)
+// immediately before calling OptimizeFixed. A fresh std::mt19937_64,
+// reseeded from this value plus the matched node's own unique id, is used
+// per match so results are deterministic and reproducible for a given
+// model and seed, without needing a single stateful RNG threaded across
+// every match in graph node order the way quarot.py's own
+// numpy.random.Generator sequencing does (cross-language RNG bit-parity
+// with the Python port isn't a goal -- only that this port's own rotation
+// is deterministic and genuinely random-orthogonal).
+inline uint64_t& QuarotSeed() {
+  static uint64_t seed = 0;
+  return seed;
+}
+
+struct Quarot final : public PredicateBasedPass {
+  static constexpr int64_t kBlockSize = 32;
+  static constexpr float kEpsilon = 1e-12f;
+
+  explicit Quarot()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+  std::string getPassName() const override { return "quarot"; }
+
+  bool patternMatchPredicate(Node* n) override {
+    MatMulLikeInfo info;
+    if (!MatchMatMulLike(n, info)) {
+      return false;
+    }
+    const int opset = getOpsetVersion(*n->owningGraph());
+    if (opset != 0 && opset < 21) {
+      return false;
+    }
+    if (info.x->elemType() != TensorProto_DataType_FLOAT) {
+      return false;
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+        w_t->sizes().size() != 2) {
+      return false;
+    }
+    const int64_t channel_axis = info.weight_transposed ? 0 : 1;
+    const int64_t K = w_t->sizes()[1 - channel_axis];
+    return K % kBlockSize == 0;
+  }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+    MatMulLikeInfo info;
+    if (!MatchMatMulLike(n, info)) {
+      return false;
+    }
+    if (info.x->elemType() != TensorProto_DataType_FLOAT) {
+      return false;
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+        w_t->sizes().size() != 2) {
+      return false;
+    }
+
+    const int64_t N = info.weight_transposed ? w_t->sizes()[0] : w_t->sizes()[1];
+    const int64_t K = info.weight_transposed ? w_t->sizes()[1] : w_t->sizes()[0];
+    if (K % kBlockSize != 0) {
+      return false;
+    }
+    const int64_t num_blocks = K / kBlockSize;
+
+    // w_nk: [N, K], output channel first.
+    const std::vector<float> w_nk = ReadWeightNK(*w_t, info.weight_transposed);
+
+    std::mt19937_64 rng(QuarotSeed() ^
+                       (0x9E3779B97F4A7C15ULL * (n->output()->unique() + 1)));
+    const std::vector<float> u = RandomOrthogonalMatrix(K, rng);  // [K, K]
+
+    // w_tilde_nk = w_nk @ u  -- [N, K], exact before quantization.
+    std::vector<double> w_tilde_nk(static_cast<size_t>(N * K), 0.0);
+    for (int64_t r = 0; r < N; ++r) {
+      for (int64_t c = 0; c < K; ++c) {
+        double acc = 0.0;
+        const float* w_row = w_nk.data() + r * K;
+        for (int64_t kk = 0; kk < K; ++kk) {
+          acc += static_cast<double>(w_row[kk]) *
+                 static_cast<double>(u[static_cast<size_t>(kk * K + c)]);
+        }
+        w_tilde_nk[static_cast<size_t>(r * K + c)] = acc;
+      }
+    }
+
+    // Block-wise INT4 quantization of w_tilde, directly into [K, N] layout
+    // (codes_kn/scale_kn) so the final MatMul(Xq, Wdq) needs no extra
+    // Transpose node -- mirrors TryQuantizeWeightBlockwiseInt4InPlace's
+    // scale rule (max(|.|) / 7 per (block-of-K, output-channel) group) but
+    // written directly transposed, since transposing already-nibble-packed
+    // INT4 data afterward would need unpacking/repacking anyway.
+    std::vector<float> scale_kn(static_cast<size_t>(num_blocks * N), 0.0f);
+    for (int64_t r = 0; r < N; ++r) {
+      for (int64_t blk = 0; blk < num_blocks; ++blk) {
+        float max_abs = 0.0f;
+        for (int64_t j = 0; j < kBlockSize; ++j) {
+          const int64_t c = blk * kBlockSize + j;
+          max_abs = std::max(
+              max_abs,
+              static_cast<float>(std::fabs(w_tilde_nk[static_cast<size_t>(r * K + c)])));
+        }
+        scale_kn[static_cast<size_t>(blk * N + r)] = max_abs > 0.0f ? max_abs / 7.0f : 1.0f;
+      }
+    }
+    std::vector<int8_t> codes_kn(static_cast<size_t>(K * N));
+    for (int64_t r = 0; r < N; ++r) {
+      for (int64_t c = 0; c < K; ++c) {
+        const int64_t blk = c / kBlockSize;
+        const float s = scale_kn[static_cast<size_t>(blk * N + r)];
+        const float q = std::round(
+            static_cast<float>(w_tilde_nk[static_cast<size_t>(r * K + c)]) / s);
+        codes_kn[static_cast<size_t>(c * N + r)] =
+            static_cast<int8_t>(std::clamp(q, -7.0f, 7.0f));
+      }
+    }
+    // Pack two int4 codes per byte, low nibble first (K * N is always even:
+    // K is a multiple of kBlockSize=32) -- see
+    // TryQuantizeWeightBlockwiseInt4InPlace's identical packing for why this
+    // bypasses the typed int32_data field.
+    const int64_t numel = K * N;
+    std::string packed(static_cast<size_t>((numel + 1) / 2), '\0');
+    for (int64_t i = 0; i < numel; ++i) {
+      const uint8_t nibble = static_cast<uint8_t>(codes_kn[static_cast<size_t>(i)]) & 0x0F;
+      uint8_t& byte = reinterpret_cast<uint8_t&>(packed[static_cast<size_t>(i / 2)]);
+      if (i % 2 == 0) {
+        byte = nibble;
+      } else {
+        byte = static_cast<uint8_t>(byte | (nibble << 4));
+      }
+    }
+
+    Tensor codes_t;
+    codes_t.elem_type() = TensorProto_DataType_INT4;
+    codes_t.sizes() = {K, N};
+    codes_t.set_raw_data(std::move(packed));
+    Value* codes_v = graph.addInitializerAndCreateValue(codes_t);
+
+    Tensor scale_t;
+    scale_t.elem_type() = TensorProto_DataType_FLOAT;
+    scale_t.sizes() = {num_blocks, N};
+    scale_t.floats() = scale_kn;
+    Value* scale_v = graph.addInitializerAndCreateValue(scale_t);
+
+    Tensor u_t;
+    u_t.elem_type() = TensorProto_DataType_FLOAT;
+    u_t.sizes() = {K, K};
+    u_t.floats() = u;
+    Value* u_v = graph.addInitializerAndCreateValue(u_t);
+
+    Tensor eps_t;
+    eps_t.elem_type() = TensorProto_DataType_FLOAT;
+    eps_t.floats() = {kEpsilon};
+    Value* eps_v = graph.addInitializerAndCreateValue(eps_t);
+
+    Tensor seven_t;
+    seven_t.elem_type() = TensorProto_DataType_FLOAT;
+    seven_t.floats() = {7.0f};
+    Value* seven_v = graph.addInitializerAndCreateValue(seven_t);
+
+    Tensor clip_min_t;
+    clip_min_t.elem_type() = TensorProto_DataType_FLOAT;
+    clip_min_t.floats() = {-7.0f};
+    Value* clip_min_v = graph.addInitializerAndCreateValue(clip_min_t);
+
+    Tensor clip_max_t;
+    clip_max_t.elem_type() = TensorProto_DataType_FLOAT;
+    clip_max_t.floats() = {7.0f};
+    Value* clip_max_v = graph.addInitializerAndCreateValue(clip_max_t);
+
+    Tensor axes_t;
+    axes_t.elem_type() = TensorProto_DataType_INT64;
+    axes_t.sizes() = {1};
+    axes_t.int64s() = {-1};
+    Value* axes_v = graph.addInitializerAndCreateValue(axes_t);
+
+    auto make_node = [&](Symbol kind, const std::vector<Value*>& inputs) {
+      Node* node = graph.create(kind, 1);
+      for (Value* v : inputs) {
+        node->addInput(v);
+      }
+      node->insertBefore(n);
+      node->output()->setElemType(TensorProto_DataType_FLOAT);
+      return node;
+    };
+
+    // Xrot = MatMul(X, U)
+    Node* x_rot = make_node(kMatMul, {info.x, u_v});
+
+    // Data-free, per-token round-to-nearest INT4 activation quantization --
+    // simulated via an immediate dequantize (kept in float32) rather than a
+    // true packed INT4 tensor, since X isn't constant.
+    Node* x_abs = make_node(Symbol("Abs"), {x_rot->output()});
+    Node* x_max = graph.create(kReduceMax, 1);
+    x_max->addInput(x_abs->output());
+    x_max->addInput(axes_v);
+    x_max->i_(kkeepdims, 1);
+    x_max->insertBefore(n);
+    x_max->output()->setElemType(TensorProto_DataType_FLOAT);
+
+    Node* x_safe_max = graph.create(Symbol("Clip"), 1);
+    x_safe_max->addInput(x_max->output());
+    x_safe_max->addInput(eps_v);
+    x_safe_max->insertBefore(n);
+    x_safe_max->output()->setElemType(TensorProto_DataType_FLOAT);
+
+    Node* x_scale = make_node(kDiv, {x_safe_max->output(), seven_v});
+    Node* x_scaled = make_node(kDiv, {x_rot->output(), x_scale->output()});
+    Node* x_rounded = make_node(Symbol("Round"), {x_scaled->output()});
+
+    Node* x_clipped = graph.create(Symbol("Clip"), 1);
+    x_clipped->addInput(x_rounded->output());
+    x_clipped->addInput(clip_min_v);
+    x_clipped->addInput(clip_max_v);
+    x_clipped->insertBefore(n);
+    x_clipped->output()->setElemType(TensorProto_DataType_FLOAT);
+
+    Node* x_dequant = make_node(kMul, {x_clipped->output(), x_scale->output()});
+
+    Node* w_dequant = graph.create(Symbol("DequantizeLinear"), 1);
+    w_dequant->addInput(codes_v);
+    w_dequant->addInput(scale_v);
+    w_dequant->i_(kaxis, 0);
+    w_dequant->i_(Symbol("block_size"), kBlockSize);
+    w_dequant->insertBefore(n);
+    w_dequant->output()->setElemType(TensorProto_DataType_FLOAT);
+    w_dequant->output()->setSizes({Dimension(K), Dimension(N)});
+
+    Node* core = make_node(kMatMul, {x_dequant->output(), w_dequant->output()});
+
+    Value* final_output;
+    if (info.bias != nullptr) {
+      Node* bias_add = graph.create(kAdd, 1);
+      bias_add->addInput(core->output());
+      bias_add->addInput(info.bias);
+      bias_add->insertBefore(n);
+      bias_add->output()->setElemType(TensorProto_DataType_FLOAT);
+      final_output = bias_add->output();
+    } else {
+      final_output = core->output();
+    }
+    if (n->output()->sizes().size() > 0) {
+      final_output->setSizes(n->output()->sizes());
+    }
+
+    const bool replacing_success =
+        tryReplacingAllUsesWith(n->output(), final_output);
+    if (!replacing_success) {
+      return false;
+    }
+    destroy_current = NodeDestroyType::DestroyOne;
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/random_orthogonal.h
+++ b/onnxsim/passes/random_orthogonal.h
@@ -28,7 +28,8 @@ namespace onnxsim_passes {
 // columns is equivalent (a random Gaussian matrix's transpose is Gaussian
 // too) and needs no transpose afterward: the result already satisfies
 // U @ U^T == I, the property this rotation needs to be lossless on its own.
-inline std::vector<float> RandomOrthogonalMatrix(int64_t k, std::mt19937_64& rng) {
+inline std::vector<float> RandomOrthogonalMatrix(int64_t k,
+                                                 std::mt19937_64& rng) {
   std::normal_distribution<double> normal(0.0, 1.0);
   std::vector<double> rows(static_cast<size_t>(k * k));
   for (double& v : rows) {

--- a/onnxsim/passes/random_orthogonal.h
+++ b/onnxsim/passes/random_orthogonal.h
@@ -1,0 +1,74 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// A Haar-random orthogonal matrix generator, shared by quarot.h. Ports
+// quip_sharp.py's own _random_orthogonal_matrix (QR-decomposing a random
+// Gaussian matrix) -- see that module's docstring for why a uniformly
+// random orthogonal matrix (rather than a Hadamard-structured one, the real
+// QuaRot/QuIP# papers' own construction) suffices for the concentration-of-
+// measure argument this rotation relies on, at the cost of an O(K^2) dense
+// MatMul instead of an O(K log K) Fast Walsh-Hadamard Transform at
+// deployment.
+
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+#include <random>
+#include <vector>
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+// A Haar-random K x K orthogonal matrix (row-major, float32), built by
+// (modified) Gram-Schmidt orthonormalizing the rows of a K x K
+// standard-Gaussian random matrix. Orthonormalizing rows rather than
+// columns is equivalent (a random Gaussian matrix's transpose is Gaussian
+// too) and needs no transpose afterward: the result already satisfies
+// U @ U^T == I, the property this rotation needs to be lossless on its own.
+inline std::vector<float> RandomOrthogonalMatrix(int64_t k, std::mt19937_64& rng) {
+  std::normal_distribution<double> normal(0.0, 1.0);
+  std::vector<double> rows(static_cast<size_t>(k * k));
+  for (double& v : rows) {
+    v = normal(rng);
+  }
+
+  for (int64_t i = 0; i < k; ++i) {
+    double* ri = rows.data() + i * k;
+    for (int64_t j = 0; j < i; ++j) {
+      const double* rj = rows.data() + j * k;
+      double dot = 0.0;
+      for (int64_t c = 0; c < k; ++c) {
+        dot += ri[c] * rj[c];
+      }
+      for (int64_t c = 0; c < k; ++c) {
+        ri[c] -= dot * rj[c];
+      }
+    }
+    double norm_sq = 0.0;
+    for (int64_t c = 0; c < k; ++c) {
+      norm_sq += ri[c] * ri[c];
+    }
+    double norm = std::sqrt(norm_sq);
+    if (norm < 1e-12) {
+      norm = 1e-12;  // A degenerate row is vanishingly unlikely with
+                     // continuous Gaussian input; floor rather than divide
+                     // by zero.
+    }
+    for (int64_t c = 0; c < k; ++c) {
+      ri[c] /= norm;
+    }
+  }
+
+  std::vector<float> out(rows.size());
+  for (size_t i = 0; i < rows.size(); ++i) {
+    out[i] = static_cast<float>(rows[i]);
+  }
+  return out;
+}
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/weight_only_quantize_mxfp4_matmul.h
+++ b/onnxsim/passes/weight_only_quantize_mxfp4_matmul.h
@@ -1,0 +1,203 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+// OCP Microscaling MXFP4 weight-only quantization: like
+// weight_only_quantize_int4_matmul.h, only the constant weight is quantized
+// and the activation is left exactly as it was -- no calibration data, no
+// runtime quantize/dequantize cost on the activation path. Unlike INT4 (an
+// ordinary affine DequantizeLinear), MXFP4's scale is constrained to a pure
+// power of two and its 4-bit codes follow a fixed, non-uniform (E2M1
+// floating-point) codebook -- ONNX has no native MX tensor type, so this
+// pass builds the dequantization out of ordinary opset-11+ ops instead of a
+// single DequantizeLinear. See quantize_mxfp4_common.h and
+// mx_quantization.py's own docstring for the format's full definition.
+//
+// Before (illustrated for MatMul; a "vanilla" Gemm -- transA=0, alpha=1,
+// beta=1 -- is handled the same way, its bias C left untouched):
+//   Y = MatMul(X, W)         W constant, 2-D, float32, [K, N]
+// After:
+//   Codes = Cast(Wq, INT64)                     -- Wq: UINT8 codebook indices
+//   Gathered = Gather(Codebook, Codes, axis=0)  -- Codebook: the 16-value E2M1 table
+//   Blocked  = Reshape(Gathered, <blocked shape>)
+//   ScaleB   = Reshape(Ws, <matching blocked shape, block dim singleton>)
+//   Scaled   = Mul(Blocked, ScaleB)
+//   Wdq      = Reshape(Scaled, W's original shape)
+//   Y = MatMul(X, Wdq)
+//
+// Only the common, unambiguous shape is handled: a MatMul, or a Gemm with
+// transA=0, alpha=1 and beta=1 (transB may be 0 or 1), whose weight (input 1)
+// is a constant 2-D float32 tensor whose reduction dimension K is evenly
+// divisible by kBlockSize, and whose activation (input 0) is float32.
+// Everything else is left alone.
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+#include "passes/quantize_matmul_common.h"
+#include "passes/quantize_mxfp4_common.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+struct WeightOnlyQuantizeMXFP4MatMul final : public PredicateBasedPass {
+  // The OCP MX spec's own canonical block size for every MX format.
+  static constexpr int64_t kBlockSize = kMXBlockSize;
+
+  explicit WeightOnlyQuantizeMXFP4MatMul()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+  std::string getPassName() const override {
+    return "weight_only_quantize_mxfp4_matmul";
+  }
+
+  bool patternMatchPredicate(Node* n) override {
+    MatMulLikeInfo info;
+    if (!MatchMatMulLike(n, info)) {
+      return false;
+    }
+    if (info.x->elemType() != TensorProto_DataType_FLOAT) {
+      return false;
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+        w_t->sizes().size() != 2) {
+      return false;
+    }
+    const int64_t channel_axis = info.weight_transposed ? 0 : 1;
+    const int64_t K = w_t->sizes()[1 - channel_axis];
+    return K % kBlockSize == 0;
+  }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+    MatMulLikeInfo info;
+    if (!MatchMatMulLike(n, info)) {
+      return false;
+    }
+    if (info.x->elemType() != TensorProto_DataType_FLOAT) {
+      return false;
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+        w_t->sizes().size() != 2) {
+      return false;
+    }
+
+    const int64_t channel_axis = info.weight_transposed ? 0 : 1;
+    const int64_t reduction_axis = 1 - channel_axis;
+    Tensor w_q;
+    Tensor w_scale;
+    if (!TryQuantizeWeightBlockwiseMXFP4InPlace(*w_t, channel_axis, kBlockSize,
+                                                w_q, w_scale)) {
+      return false;
+    }
+
+    const int64_t dim0 = w_t->sizes()[0];
+    const int64_t dim1 = w_t->sizes()[1];
+    const int64_t K = reduction_axis == 0 ? dim0 : dim1;
+    const int64_t num_blocks = K / kBlockSize;
+
+    // A fresh codebook initializer per matched layer, matching this
+    // codebase's existing convention of not sharing constant initializers
+    // across separate PredicateBasedPass matches (e.g. fuse_bn_into_conv.h's
+    // per-match epsilon constant) -- 16 float32 values is a negligible
+    // overhead, and a pass instance is reused (via RegisterOrReplace's
+    // std::call_once) across every future Quantize* call in the process, so
+    // it must not cache any Value*/Node* pointer into a specific graph
+    // across matches.
+    Tensor codebook_t;
+    codebook_t.elem_type() = TensorProto_DataType_FLOAT;
+    codebook_t.sizes() = {static_cast<int64_t>(MXFP4Codebook().size())};
+    codebook_t.floats() = MXFP4Codebook();
+    Value* codebook_v = graph.addInitializerAndCreateValue(codebook_t);
+
+    Value* codes_v = graph.addInitializerAndCreateValue(w_q);
+    Value* scale_v = graph.addInitializerAndCreateValue(w_scale);
+
+    Node* cast = graph.create(kCast, 1);
+    cast->addInput(codes_v);
+    cast->i_(kto, TensorProto_DataType_INT64);
+    cast->insertBefore(n);
+    cast->output()->setElemType(TensorProto_DataType_INT64);
+    cast->output()->setSizes(codes_v->sizes());
+
+    Node* gather = graph.create(Symbol("Gather"), 1);
+    gather->addInput(codebook_v);
+    gather->addInput(cast->output());
+    gather->i_(kaxis, 0);
+    gather->insertBefore(n);
+    gather->output()->setElemType(TensorProto_DataType_FLOAT);
+    gather->output()->setSizes(codes_v->sizes());
+
+    // Reshape the gathered (elementwise) values and the per-block scale into
+    // matching 3-D shapes that expose the block dimension explicitly, so a
+    // plain Mul can broadcast each block's single scale across its own
+    // block_size elements -- gathered's flat [dim0, dim1] shape has no such
+    // dimension of its own to broadcast against scale's smaller
+    // [scale_dim0, scale_dim1] shape directly.
+    std::vector<int64_t> blocked_shape;
+    std::vector<int64_t> scale_shape;
+    if (reduction_axis == 1) {
+      blocked_shape = {dim0, num_blocks, kBlockSize};
+      scale_shape = {dim0, num_blocks, 1};
+    } else {
+      blocked_shape = {num_blocks, kBlockSize, dim1};
+      scale_shape = {num_blocks, 1, dim1};
+    }
+
+    auto make_shape_initializer = [&](const std::vector<int64_t>& shape) {
+      Tensor t;
+      t.elem_type() = TensorProto_DataType_INT64;
+      t.sizes() = {static_cast<int64_t>(shape.size())};
+      t.int64s() = shape;
+      return graph.addInitializerAndCreateValue(t);
+    };
+
+    Node* reshape1 = graph.create(kReshape, 1);
+    reshape1->addInput(gather->output());
+    reshape1->addInput(make_shape_initializer(blocked_shape));
+    reshape1->insertBefore(n);
+    reshape1->output()->setElemType(TensorProto_DataType_FLOAT);
+
+    Node* reshape2 = graph.create(kReshape, 1);
+    reshape2->addInput(scale_v);
+    reshape2->addInput(make_shape_initializer(scale_shape));
+    reshape2->insertBefore(n);
+    reshape2->output()->setElemType(TensorProto_DataType_FLOAT);
+
+    Node* mul = graph.create(kMul, 1);
+    mul->addInput(reshape1->output());
+    mul->addInput(reshape2->output());
+    mul->insertBefore(n);
+    mul->output()->setElemType(TensorProto_DataType_FLOAT);
+
+    Node* reshape3 = graph.create(kReshape, 1);
+    reshape3->addInput(mul->output());
+    reshape3->addInput(make_shape_initializer({dim0, dim1}));
+    reshape3->insertBefore(n);
+    reshape3->output()->setElemType(TensorProto_DataType_FLOAT);
+    if (info.w->sizes().size() > 0) {
+      reshape3->output()->setSizes(info.w->sizes());
+    }
+
+    // The MatMul/Gemm node and its activation input are left untouched; only
+    // the weight input changes, to its dequantized counterpart.
+    n->replaceInput(1, reshape3->output());
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/weight_only_quantize_mxfp4_matmul.h
+++ b/onnxsim/passes/weight_only_quantize_mxfp4_matmul.h
@@ -21,12 +21,10 @@
 //   Y = MatMul(X, W)         W constant, 2-D, float32, [K, N]
 // After:
 //   Codes = Cast(Wq, INT64)                     -- Wq: UINT8 codebook indices
-//   Gathered = Gather(Codebook, Codes, axis=0)  -- Codebook: the 16-value E2M1 table
-//   Blocked  = Reshape(Gathered, <blocked shape>)
-//   ScaleB   = Reshape(Ws, <matching blocked shape, block dim singleton>)
-//   Scaled   = Mul(Blocked, ScaleB)
-//   Wdq      = Reshape(Scaled, W's original shape)
-//   Y = MatMul(X, Wdq)
+//   Gathered = Gather(Codebook, Codes, axis=0)  -- Codebook: the 16-value E2M1
+//   table Blocked  = Reshape(Gathered, <blocked shape>) ScaleB   = Reshape(Ws,
+//   <matching blocked shape, block dim singleton>) Scaled   = Mul(Blocked,
+//   ScaleB) Wdq      = Reshape(Scaled, W's original shape) Y = MatMul(X, Wdq)
 //
 // Only the common, unambiguous shape is handled: a MatMul, or a Gemm with
 // transA=0, alpha=1 and beta=1 (transB may be 0 or 1), whose weight (input 1)

--- a/onnxsim/pruning_entry.cpp
+++ b/onnxsim/pruning_entry.cpp
@@ -11,10 +11,12 @@
 #include "onnxoptimizer/optimize.h"
 #include "passes/magnitude_pruning.h"
 
-onnx::ModelProto PruneMagnitude(const onnx::ModelProto& model, double sparsity) {
+onnx::ModelProto PruneMagnitude(const onnx::ModelProto& model,
+                                double sparsity) {
   if (!(sparsity >= 0.0 && sparsity < 1.0)) {
-    throw std::invalid_argument("PruneMagnitude: sparsity must be in [0, 1), got " +
-                                std::to_string(sparsity));
+    throw std::invalid_argument(
+        "PruneMagnitude: sparsity must be in [0, 1), got " +
+        std::to_string(sparsity));
   }
   PrepareSchemasForDebug(model);
   // Registers magnitude_pruning_matmul/_conv (idempotent) into

--- a/onnxsim/pruning_entry.cpp
+++ b/onnxsim/pruning_entry.cpp
@@ -1,0 +1,31 @@
+#include "pruning_entry.h"
+
+#include <onnx/onnx_pb.h>
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "custom_optimizer_passes.h"
+#include "model_prep.h"
+#include "onnxoptimizer/optimize.h"
+#include "passes/magnitude_pruning.h"
+
+onnx::ModelProto PruneMagnitude(const onnx::ModelProto& model, double sparsity) {
+  if (!(sparsity >= 0.0 && sparsity < 1.0)) {
+    throw std::invalid_argument("PruneMagnitude: sparsity must be in [0, 1), got " +
+                                std::to_string(sparsity));
+  }
+  PrepareSchemasForDebug(model);
+  // Registers magnitude_pruning_matmul/_conv (idempotent) into
+  // onnxoptimizer's registry so OptimizeFixed can find them by name below.
+  onnxsim::RegisterCustomOptimizerPasses();
+  // magnitude_pruning_matmul/_conv read this the same way quantize_fp16
+  // reads QuantizeFp16KeepIoTypes() -- OptimizeFixed's pass-name list has no
+  // way to carry a parameter directly.
+  ONNX_NAMESPACE::optimization::onnxsim_passes::MagnitudePruningSparsity() =
+      sparsity;
+  return onnx::optimization::OptimizeFixed(
+      model, std::vector<std::string>{"magnitude_pruning_matmul",
+                                      "magnitude_pruning_conv"});
+}

--- a/onnxsim/pruning_entry.h
+++ b/onnxsim/pruning_entry.h
@@ -1,0 +1,13 @@
+#pragma once
+
+// Single-call pruning entry points exposed to Python, mirroring
+// quantize_entry.h's own "one named custom_optimizer_passes.cpp pass,
+// standalone via OptimizeFixed" shape -- but for pruning, which is not
+// itself a quantization scheme, so it does not belong in quantize_entry.h
+// alongside the actual Quantize* schemes (same rationale
+// cross_layer_equalization_entry.h gives for its own separate file). See
+// onnxsim.h for the per-function documentation these mirror.
+
+#include <onnx/onnx_pb.h>
+
+onnx::ModelProto PruneMagnitude(const onnx::ModelProto& model, double sparsity);

--- a/onnxsim/quantize_entry.cpp
+++ b/onnxsim/quantize_entry.cpp
@@ -20,6 +20,7 @@
 #include "passes/quantize_fp16.h"
 #include "passes/quantize_fp8.h"
 #include "passes/quantize_matmul_common.h"
+#include "passes/quarot.h"
 #include "passes/static_quantize_matmul.h"
 
 onnx::ModelProto QuantizeDynamic(const onnx::ModelProto& model) {
@@ -108,6 +109,37 @@ onnx::ModelProto QuantizeWeightOnlyInt8Block(const onnx::ModelProto& model) {
   return onnx::optimization::OptimizeFixed(
       model, std::vector<std::string>{"weight_only_quantize_int8_block_matmul",
                                       "weight_only_quantize_int8_block_conv"});
+}
+
+onnx::ModelProto QuantizeWeightOnlyMXFP4(const onnx::ModelProto& model) {
+  PrepareSchemasForDebug(model);
+  // Registers weight_only_quantize_mxfp4_matmul (idempotent) into
+  // onnxoptimizer's registry so OptimizeFixed can find it by name below.
+  onnxsim::RegisterCustomOptimizerPasses();
+  return onnx::optimization::OptimizeFixed(
+      model, std::vector<std::string>{"weight_only_quantize_mxfp4_matmul"});
+}
+
+onnx::ModelProto ApplyDoubleQuantization(const onnx::ModelProto& model) {
+  PrepareSchemasForDebug(model);
+  // Registers double_quantization (idempotent) into onnxoptimizer's registry
+  // so OptimizeFixed can find it by name below.
+  onnxsim::RegisterCustomOptimizerPasses();
+  return onnx::optimization::OptimizeFixed(
+      model, std::vector<std::string>{"double_quantization"});
+}
+
+onnx::ModelProto ApplyQuarot(const onnx::ModelProto& model, uint64_t seed) {
+  PrepareSchemasForDebug(model);
+  // Registers quarot (idempotent) into onnxoptimizer's registry so
+  // OptimizeFixed can find it by name below.
+  onnxsim::RegisterCustomOptimizerPasses();
+  // quarot reads this the same way quantize_fp16 reads
+  // QuantizeFp16KeepIoTypes() -- OptimizeFixed's pass-name list has no way
+  // to carry a parameter directly.
+  onnx::optimization::onnxsim_passes::QuarotSeed() = seed;
+  return onnx::optimization::OptimizeFixed(model,
+                                           std::vector<std::string>{"quarot"});
 }
 
 std::vector<std::string> ListQuantizableActivations(

--- a/onnxsim/quantize_entry.h
+++ b/onnxsim/quantize_entry.h
@@ -8,6 +8,7 @@
 
 #include <onnx/onnx_pb.h>
 
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -20,6 +21,7 @@ onnx::ModelProto QuantizeWeightOnlyInt4(const onnx::ModelProto& model);
 onnx::ModelProto QuantizeWeightOnlyMatMulNBits(const onnx::ModelProto& model);
 onnx::ModelProto QuantizeWeightOnlyInt16(const onnx::ModelProto& model);
 onnx::ModelProto QuantizeWeightOnlyInt8Block(const onnx::ModelProto& model);
+onnx::ModelProto QuantizeWeightOnlyMXFP4(const onnx::ModelProto& model);
 
 std::vector<std::string> ListQuantizableActivations(
     const onnx::ModelProto& model);
@@ -72,3 +74,6 @@ onnx::ModelProto QuantizeBf16(const onnx::ModelProto& model,
                               bool keep_io_types);
 onnx::ModelProto QuantizeFp8(const onnx::ModelProto& model,
                              const std::string& format, bool keep_io_types);
+
+onnx::ModelProto ApplyDoubleQuantization(const onnx::ModelProto& model);
+onnx::ModelProto ApplyQuarot(const onnx::ModelProto& model, uint64_t seed);

--- a/tests/test_double_quantization_cpp.py
+++ b/tests/test_double_quantization_cpp.py
@@ -1,0 +1,152 @@
+"""Tests for ``onnxsim.apply_double_quantization_cpp`` -- the C++-backed
+port of ``onnxsim.apply_double_quantization`` (see
+``onnxsim/passes/double_quantization.h``). The C++ pass hardcodes
+``min_elements=64`` (no per-call parameter, unlike the pure-Python version)
+and mints anonymous initializer names, so these tests locate tensors by
+shape/dtype rather than by the ``_dblq_*`` naming convention
+``test_double_quantization.py`` relies on.
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _int4_codes_tensor(codes, name="codes"):
+    tensor = onnx.TensorProto()
+    tensor.name = name
+    tensor.data_type = onnx.TensorProto.INT4
+    tensor.dims.extend(codes.shape)
+
+    from onnxsim.adaround import _pack_int4
+
+    tensor.raw_data = _pack_int4(codes.astype(np.int64))
+    return tensor
+
+
+def _blockwise_int4_model(k=64, n=8, block_size=8, seed=0):
+    # Mirrors quantize_weight_only_int4's own output shape: INT4 codes
+    # [K, N], scale [K/block_size, N], DequantizeLinear(axis=0, block_size).
+    # k // block_size * n must be >= 64 (the C++ pass's fixed min_elements)
+    # for these tests to actually exercise the rewrite.
+    rng = np.random.default_rng(seed)
+    codes = rng.integers(-7, 8, size=(k, n)).astype(np.int8)
+    scale = (rng.random((k // block_size, n)).astype(np.float32) + 0.1) * 0.05
+
+    return _model(
+        f"""
+        g (float[batch,{k}] X) => (float[batch,{n}] Y)
+        {{
+          w_hat = DequantizeLinear<axis=0, block_size={block_size}>(codes, scale)
+          Y = MatMul(X, w_hat)
+        }}
+        """,
+        initializer=[
+            _int4_codes_tensor(codes),
+            onnx.numpy_helper.from_array(scale, name="scale"),
+        ],
+    )
+
+
+def test_cpp_double_quantization_inserts_nested_dequantize_and_keeps_output_close():
+    model = _blockwise_int4_model(k=512, n=8, block_size=8, seed=0)  # 64x8=512 scales
+    onnx.checker.check_model(model)
+    q = onnxsim.apply_double_quantization_cpp(model)
+    onnx.checker.check_model(q)
+
+    op_types = [n.op_type for n in q.graph.node]
+    assert op_types.count("DequantizeLinear") == 2
+
+    rng = np.random.default_rng(1)
+    x = rng.standard_normal((4, 512)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x})
+    (q_y,) = _run(q, {"X": x})
+    rel = np.linalg.norm(float_y - q_y) / max(np.linalg.norm(float_y), 1e-6)
+    assert rel < 0.05
+
+
+def test_cpp_double_quantization_scale_codes_are_uint8():
+    model = _blockwise_int4_model(k=512, n=8, block_size=8, seed=2)
+    q = onnxsim.apply_double_quantization_cpp(model)
+    uint8_inits = [t for t in q.graph.initializer if t.data_type == onnx.TensorProto.UINT8]
+    assert len(uint8_inits) == 1
+    codes = onnx.numpy_helper.to_array(uint8_inits[0])
+    assert codes.min() >= 0 and codes.max() <= 255
+
+
+def test_cpp_double_quantization_declines_small_scale_tensor():
+    # The C++ pass's fixed min_elements=64; an 8-element scale tensor isn't
+    # worth it.
+    model = _blockwise_int4_model(k=64, n=1, block_size=8, seed=3)
+    q = onnxsim.apply_double_quantization_cpp(model)
+    assert q.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_double_quantization_declines_dynamic_scale_input():
+    codes = np.zeros((8, 8), dtype=np.int8)
+    model = _model(
+        """
+        g (float[8,8] scale) => (float[8,8] w_hat)
+        {
+          w_hat = DequantizeLinear(codes, scale)
+        }
+        """,
+        initializer=[_int4_codes_tensor(codes)],
+    )
+    q = onnxsim.apply_double_quantization_cpp(model)
+    assert q.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_double_quantization_noop_without_dequantize_linear():
+    model = _model(
+        """
+        g (float[4,4] X) => (float[4,4] Y)
+        {
+          Y = Relu(X)
+        }
+        """
+    )
+    result = onnxsim.apply_double_quantization_cpp(model)
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_double_quantization_matches_python_reference_output():
+    model = _blockwise_int4_model(k=512, n=8, block_size=8, seed=4)
+
+    q_py = onnxsim.apply_double_quantization(model, min_elements=64)
+    q_cpp = onnxsim.apply_double_quantization_cpp(model)
+    onnx.checker.check_model(q_py)
+    onnx.checker.check_model(q_cpp)
+
+    rng = np.random.default_rng(5)
+    x = rng.standard_normal((4, 512)).astype(np.float32)
+    (y_py,) = _run(q_py, {"X": x})
+    (y_cpp,) = _run(q_cpp, {"X": x})
+    assert np.allclose(y_py, y_cpp, rtol=1e-4, atol=1e-4)

--- a/tests/test_double_quantization_cpp.py
+++ b/tests/test_double_quantization_cpp.py
@@ -95,7 +95,9 @@ def test_cpp_double_quantization_inserts_nested_dequantize_and_keeps_output_clos
 def test_cpp_double_quantization_scale_codes_are_uint8():
     model = _blockwise_int4_model(k=512, n=8, block_size=8, seed=2)
     q = onnxsim.apply_double_quantization_cpp(model)
-    uint8_inits = [t for t in q.graph.initializer if t.data_type == onnx.TensorProto.UINT8]
+    uint8_inits = [
+        t for t in q.graph.initializer if t.data_type == onnx.TensorProto.UINT8
+    ]
     assert len(uint8_inits) == 1
     codes = onnx.numpy_helper.to_array(uint8_inits[0])
     assert codes.min() >= 0 and codes.max() <= 255

--- a/tests/test_mx_quantization_cpp.py
+++ b/tests/test_mx_quantization_cpp.py
@@ -1,0 +1,167 @@
+"""Tests for ``onnxsim.quantize_weight_only_mxfp4_cpp`` -- the C++-backed
+port of ``onnxsim.quantize_weight_only_mxfp4`` (see
+``onnxsim/passes/weight_only_quantize_mxfp4_matmul.h`` and
+``onnxsim/passes/quantize_mxfp4_common.h``). Cross-checks the C++ port
+against the pure-Python reference implementation on the same input, in
+addition to the same standalone checks ``test_mx_quantization.py`` runs.
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _model(body, initializer=(), opset=13, ir_version=8):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _matmul_model(K=64, N=16, weight=None, seed=0):
+    if weight is None:
+        rng = np.random.default_rng(seed)
+        weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[_f32(weight, "W")],
+    )
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
+
+
+def test_cpp_mxfp4_quantizes_matmul_with_standard_ops_only():
+    model = _matmul_model(K=64, N=16, seed=0)
+    q = onnxsim.quantize_weight_only_mxfp4_cpp(model)
+    onnx.checker.check_model(q)
+
+    op_types = {n.op_type for n in q.graph.node}
+    assert op_types <= {"MatMul", "Cast", "Gather", "Reshape", "Mul"}
+    assert all(n.domain in ("", "ai.onnx") for n in q.graph.node)
+
+
+def test_cpp_mxfp4_block_scale_is_a_power_of_two():
+    rng = np.random.default_rng(1)
+    weight = rng.standard_normal((64, 16)).astype(np.float32) * 3.7
+    model = _matmul_model(weight=weight)
+    q = onnxsim.quantize_weight_only_mxfp4_cpp(model)
+
+    # The scale initializer is whichever one is 2-D with the block-count
+    # shape [K // 32, N] -- unlike the pure-Python port, the C++ pass mints
+    # anonymous initializer names, so it's located by shape/dtype instead.
+    scale_init = next(
+        t
+        for t in q.graph.initializer
+        if t.data_type == onnx.TensorProto.FLOAT and list(t.dims) == [64 // 32, 16]
+    )
+    scale = onnx.numpy_helper.to_array(scale_init).astype(np.float64).ravel()
+    log2_scale = np.log2(scale)
+    assert np.all(np.abs(log2_scale - np.round(log2_scale)) < 1e-9)
+
+
+def test_cpp_mxfp4_output_stays_close_to_float_via_onnxruntime():
+    model = _matmul_model(K=64, N=16, seed=3)
+    q = onnxsim.quantize_weight_only_mxfp4_cpp(model)
+    onnx.checker.check_model(q)
+
+    rng = np.random.default_rng(4)
+    x = rng.standard_normal((8, 64)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x})
+    (q_y,) = _run(q, {"X": x})
+    assert np.all(np.isfinite(q_y))
+    assert _rel_l2(float_y, q_y) < 0.3
+
+
+def test_cpp_mxfp4_gemm_transb():
+    rng = np.random.default_rng(5)
+    K, N = 128, 12
+    weight = rng.standard_normal((N, K)).astype(np.float32) * 0.5
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = Gemm<transB = 1>(X, W)
+        }}
+        """,
+        initializer=[_f32(weight, "W")],
+    )
+    q = onnxsim.quantize_weight_only_mxfp4_cpp(model)
+    onnx.checker.check_model(q)
+
+    x = rng.standard_normal((4, K)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x})
+    (q_y,) = _run(q, {"X": x})
+    assert _rel_l2(float_y, q_y) < 0.3
+
+
+def test_cpp_mxfp4_skips_non_block_divisible_k():
+    model = _matmul_model(K=48, N=8, seed=7)  # 48 is not a multiple of 32
+    q = onnxsim.quantize_weight_only_mxfp4_cpp(model)
+    assert q.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_mxfp4_skips_non_constant_weight():
+    model = _model(
+        """
+        g (float[4,64] X, float[64,4] W) => (float[4,4] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """
+    )
+    q = onnxsim.quantize_weight_only_mxfp4_cpp(model)
+    assert q.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_mxfp4_matches_python_reference_output():
+    # The C++ port and the pure-Python reference implement the same
+    # block-wise MXFP4 algorithm (round-to-nearest onto the same fixed E2M1
+    # codebook, the same power-of-two scale rule) -- on the same weight they
+    # should produce numerically equivalent dequantized outputs, not just
+    # separately "close to float32".
+    rng = np.random.default_rng(9)
+    weight = rng.standard_normal((64, 16)).astype(np.float32) * 0.7
+    model = _matmul_model(weight=weight)
+
+    q_py = onnxsim.quantize_weight_only_mxfp4(model, block_size=32)
+    q_cpp = onnxsim.quantize_weight_only_mxfp4_cpp(model)
+    onnx.checker.check_model(q_py)
+    onnx.checker.check_model(q_cpp)
+
+    x = rng.standard_normal((4, 64)).astype(np.float32)
+    (y_py,) = _run(q_py, {"X": x})
+    (y_cpp,) = _run(q_cpp, {"X": x})
+    assert np.allclose(y_py, y_cpp, rtol=1e-4, atol=1e-4)

--- a/tests/test_optimize_pipeline.py
+++ b/tests/test_optimize_pipeline.py
@@ -204,7 +204,9 @@ def test_pipeline_report_matches_returned_model():
     recomputed = onnxsim.measure_accuracy_drop(
         simplified, result.optimized_model, calibration_data=calibration_data
     )
-    assert recomputed.worst_relative_l2 == pytest.approx(result.report.worst_relative_l2)
+    assert recomputed.worst_relative_l2 == pytest.approx(
+        result.report.worst_relative_l2
+    )
 
 
 def test_pipeline_is_deterministic_for_a_given_seed():

--- a/tests/test_optimize_pipeline.py
+++ b/tests/test_optimize_pipeline.py
@@ -1,0 +1,224 @@
+"""Tests for ``onnxsim.apply_optimization_pipeline`` (see
+``onnxsim/optimize_pipeline.py``) -- the escalating
+simplify -> prune -> CLE -> quantize -> refine -> compress pipeline chaining
+onnxsim's recently added features together.
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import onnx.shape_inference
+import pytest
+from onnx import parser
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(np.asarray(array, dtype=np.float32), name)
+
+
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    # weight-only/quarot passes decline a MatMul/Gemm whose activation
+    # input's elem_type isn't known -- true for an intermediate tensor with
+    # no declared value_info, which the parser never infers on its own.
+    return onnx.shape_inference.infer_shapes(model)
+
+
+def _gemm_model(K=64, N=16, batch=8, seed=0):
+    rng = np.random.default_rng(seed)
+    weight = rng.standard_normal((N, K)).astype(np.float32) * 0.5
+    bias = rng.standard_normal(N).astype(np.float32) * 0.1
+    return _model(
+        f"""
+        g (float[{batch},{K}] X) => (float[{batch},{N}] Y)
+        {{
+          Y = Gemm<transB = 1>(X, W, B)
+        }}
+        """,
+        initializer=[_f32(weight, "W"), _f32(bias, "B")],
+    )
+
+
+def _conv_and_gemm_model(seed=0):
+    # Conv1 -> Relu -> Conv2 (CLE has real work to do), then flattened into
+    # a Gemm (AdaRound/pruning have real work to do).
+    rng = np.random.default_rng(seed)
+    w1 = rng.standard_normal((8, 4, 3, 3)).astype(np.float32) * 0.1
+    w1[0] *= 30.0  # outlier channel, matching test_cross_layer_equalization.py
+    b1 = rng.standard_normal(8).astype(np.float32) * 0.01
+    w2 = rng.standard_normal((4, 8, 3, 3)).astype(np.float32) * 0.1
+    b2 = rng.standard_normal(4).astype(np.float32) * 0.01
+    wg = rng.standard_normal((4, 4 * 8 * 8)).astype(np.float32) * 0.05
+    bg = rng.standard_normal(4).astype(np.float32) * 0.01
+
+    return _model(
+        """
+        g (float[2,4,8,8] X) => (float[2,4] Y)
+        {
+          C1 = Conv<kernel_shape = [3, 3], pads = [1, 1, 1, 1]>(X, W1, B1)
+          R1 = Relu(C1)
+          C2 = Conv<kernel_shape = [3, 3], pads = [1, 1, 1, 1]>(R1, W2, B2)
+          F = Flatten(C2)
+          Y = Gemm<transB = 1>(F, WG, BG)
+        }
+        """,
+        initializer=[
+            _f32(w1, "W1"),
+            _f32(b1, "B1"),
+            _f32(w2, "W2"),
+            _f32(b2, "B2"),
+            _f32(wg, "WG"),
+            _f32(bg, "BG"),
+        ],
+    )
+
+
+def test_pipeline_returns_baseline_immediately_when_budget_is_loose():
+    model = _gemm_model(seed=1)
+    rng = np.random.default_rng(2)
+    calibration_data = [{"X": rng.standard_normal((8, 64)).astype(np.float32)}]
+
+    result = onnxsim.apply_optimization_pipeline(
+        model, accuracy_budget=1.0, calibration_data=calibration_data
+    )
+    assert result.meets_budget
+    assert "adaround" not in result.stages_applied
+    assert "bias_correction" not in result.stages_applied
+    assert "cross_layer_equalization" in result.stages_applied
+    assert "quantize_weight_only_int4" in result.stages_applied
+    onnx.checker.check_model(result.optimized_model)
+
+
+def test_pipeline_exhausts_refinement_stages_when_budget_is_unreachable():
+    model = _conv_and_gemm_model(seed=3)
+    rng = np.random.default_rng(4)
+    calibration_data = [{"X": rng.standard_normal((2, 4, 8, 8)).astype(np.float32)}]
+
+    result = onnxsim.apply_optimization_pipeline(
+        model,
+        accuracy_budget=0.0,  # unreachable -- every stage must be tried
+        calibration_data=calibration_data,
+        num_adaround_iterations=100,
+    )
+    assert not result.meets_budget
+    assert "adaround" in result.stages_applied
+    onnx.checker.check_model(result.optimized_model)
+
+    sess = ort.InferenceSession(
+        result.optimized_model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    (y,) = sess.run(None, calibration_data[0])
+    assert np.all(np.isfinite(y))
+
+
+def test_pipeline_with_pruning_applies_structured_pruning_stage():
+    model = _conv_and_gemm_model(seed=11)
+    rng = np.random.default_rng(12)
+    calibration_data = [{"X": rng.standard_normal((2, 4, 8, 8)).astype(np.float32)}]
+
+    result = onnxsim.apply_optimization_pipeline(
+        model,
+        accuracy_budget=1.0,
+        calibration_data=calibration_data,
+        sparsity=0.25,
+    )
+    assert result.stages_applied[0] == "structured_pruning"
+    onnx.checker.check_model(result.optimized_model)
+
+
+def test_pipeline_without_pruning_skips_structured_pruning_stage():
+    model = _gemm_model(seed=13)
+    rng = np.random.default_rng(14)
+    calibration_data = [{"X": rng.standard_normal((8, 64)).astype(np.float32)}]
+
+    result = onnxsim.apply_optimization_pipeline(
+        model, accuracy_budget=1.0, calibration_data=calibration_data
+    )
+    assert "structured_pruning" not in result.stages_applied
+
+
+def test_pipeline_mixed_precision_bit_selection():
+    model = _gemm_model(seed=15)
+    rng = np.random.default_rng(16)
+    calibration_data = [{"X": rng.standard_normal((8, 64)).astype(np.float32)}]
+
+    result = onnxsim.apply_optimization_pipeline(
+        model,
+        accuracy_budget=1.0,
+        calibration_data=calibration_data,
+        bit_selection="mixed_precision",
+    )
+    assert "apply_mixed_precision_quantization" in result.stages_applied
+    assert "quantize_weight_only_int4" not in result.stages_applied
+    onnx.checker.check_model(result.optimized_model)
+
+
+def test_pipeline_rotation_upgrade_skips_adaround_refinement():
+    model = _gemm_model(K=64, N=16, seed=17)
+    rng = np.random.default_rng(18)
+    calibration_data = [{"X": rng.standard_normal((8, 64)).astype(np.float32)}]
+
+    result = onnxsim.apply_optimization_pipeline(
+        model,
+        accuracy_budget=0.0,  # unreachable -- would otherwise trigger refinement
+        calibration_data=calibration_data,
+        use_rotation=True,
+    )
+    assert "quarot" in result.stages_applied
+    assert "adaround" not in result.stages_applied
+    assert "bias_correction" not in result.stages_applied
+    onnx.checker.check_model(result.optimized_model)
+
+
+def test_pipeline_rejects_invalid_bit_selection():
+    model = _gemm_model(seed=19)
+    with pytest.raises(ValueError):
+        onnxsim.apply_optimization_pipeline(model, bit_selection="bogus")
+
+
+def test_pipeline_report_matches_returned_model():
+    model = _gemm_model(seed=20)
+    rng = np.random.default_rng(21)
+    calibration_data = [{"X": rng.standard_normal((8, 64)).astype(np.float32)}]
+
+    result = onnxsim.apply_optimization_pipeline(
+        model,
+        accuracy_budget=0.0,
+        calibration_data=calibration_data,
+        num_adaround_iterations=50,
+    )
+    simplified, _ = onnxsim.simplify(model)
+    recomputed = onnxsim.measure_accuracy_drop(
+        simplified, result.optimized_model, calibration_data=calibration_data
+    )
+    assert recomputed.worst_relative_l2 == pytest.approx(result.report.worst_relative_l2)
+
+
+def test_pipeline_is_deterministic_for_a_given_seed():
+    model = _gemm_model(seed=22)
+    rng = np.random.default_rng(23)
+    calibration_data = [{"X": rng.standard_normal((8, 64)).astype(np.float32)}]
+
+    result1 = onnxsim.apply_optimization_pipeline(
+        model, accuracy_budget=1.0, calibration_data=calibration_data, seed=5
+    )
+    result2 = onnxsim.apply_optimization_pipeline(
+        model, accuracy_budget=1.0, calibration_data=calibration_data, seed=5
+    )
+    assert result1.stages_applied == result2.stages_applied
+    assert result1.optimized_model.SerializeToString() == (
+        result2.optimized_model.SerializeToString()
+    )

--- a/tests/test_pruning_cpp.py
+++ b/tests/test_pruning_cpp.py
@@ -1,0 +1,172 @@
+"""Tests for ``onnxsim.prune_magnitude_cpp`` -- the C++-backed port of
+``onnxsim.apply_magnitude_pruning`` (see
+``onnxsim/passes/magnitude_pruning.h``). Scope note: unlike the pure-Python
+version, this port does not match ``com.microsoft::Attention``'s merged QKV
+weight and offers no N:M pruning mode -- see that header's own doc comment.
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(body, initializer=(), opset=21):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _matmul_model(K=64, N=16, seed=0):
+    rng = np.random.default_rng(seed)
+    weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[_f32(weight, "W")],
+    )
+
+
+def _single_conv_model(w, spatial=10, group=1):
+    Cout, Cin_per_group, kh, kw = w.shape
+    Cin = Cin_per_group * group
+    out_spatial = spatial - kh + 1
+    attrs = f"kernel_shape=[{kh},{kw}]"
+    if group != 1:
+        attrs += f", group={group}"
+    return _model(
+        f"""
+        g (float[N,{Cin},{spatial},{spatial}] X) => (float[N,{Cout},{out_spatial},{out_spatial}] Y)
+        {{
+          Y = Conv<{attrs}>(X, W1)
+        }}
+        """,
+        initializer=[_f32(w, "W1")],
+    )
+
+
+def _weight(model):
+    # Unlike the pure-Python apply_magnitude_pruning (which mutates the
+    # existing initializer in place via w_init.CopyFrom), the C++ pass
+    # leaves the original initializer dangling and appends a *new*,
+    # anonymously-named one for the pruned weight, and rewires the node's
+    # own weight input to it (matching every other onnxsim rewrite's
+    # "replace, don't mutate" convention for constants) -- so the pruned
+    # weight must be found via the node's current weight input name, not
+    # assumed to still be named "W" or still be initializer[0].
+    node = model.graph.node[0]
+    w_name = node.input[1]
+    init = next(t for t in model.graph.initializer if t.name == w_name)
+    return onnx.numpy_helper.to_array(init)
+
+
+def test_cpp_magnitude_pruning_reaches_target_sparsity():
+    model = _matmul_model(K=64, N=16)
+    pruned = onnxsim.prune_magnitude_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    assert onnxsim.weight_sparsity(pruned) == pytest.approx(0.5, abs=1e-9)
+    assert _weight(pruned).shape == _weight(model).shape
+
+
+def test_cpp_magnitude_pruning_keeps_the_largest_entries_per_row():
+    model = _matmul_model(K=64, N=16)
+    pruned = onnxsim.prune_magnitude_cpp(model, sparsity=0.75)
+    w = _weight(model).astype(np.float64)  # [K, N]
+    w_pruned = _weight(pruned).astype(np.float64)
+    for col in range(w.shape[1]):
+        kept = np.flatnonzero(w_pruned[:, col] != 0)
+        assert len(kept) == 16  # round(64 * 0.25)
+        threshold = np.abs(w[:, col])[kept].min()
+        dropped_max = np.abs(w[:, col])[np.flatnonzero(w_pruned[:, col] == 0)].max()
+        assert dropped_max <= threshold
+
+
+def test_cpp_magnitude_pruning_zero_sparsity_is_a_no_op():
+    model = _matmul_model(K=32, N=8)
+    pruned = onnxsim.prune_magnitude_cpp(model, sparsity=0.0)
+    np.testing.assert_array_equal(_weight(pruned), _weight(model))
+
+
+def test_cpp_magnitude_pruning_rejects_invalid_sparsity():
+    model = _matmul_model(K=32, N=8)
+    with pytest.raises(Exception):
+        onnxsim.prune_magnitude_cpp(model, sparsity=1.0)
+
+
+def test_cpp_magnitude_pruning_conv_reaches_target_sparsity():
+    Cin, Cout = 4, 8  # K = Cin*3*3 = 36
+    rng = np.random.default_rng(60)
+    w = rng.standard_normal((Cout, Cin, 3, 3)).astype(np.float32)
+    model = _single_conv_model(w)
+
+    pruned = onnxsim.prune_magnitude_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    assert onnxsim.weight_sparsity(pruned) == pytest.approx(0.5, abs=1e-9)
+    assert _weight(pruned).shape == w.shape
+
+
+def test_cpp_magnitude_pruning_conv_depthwise_reaches_target_sparsity():
+    C = 8
+    rng = np.random.default_rng(61)
+    w = rng.standard_normal((C, 1, 4, 4)).astype(np.float32)  # K=16, halved exactly
+    model = _single_conv_model(w, spatial=10, group=C)
+
+    pruned = onnxsim.prune_magnitude_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    assert onnxsim.weight_sparsity(pruned) == pytest.approx(0.5, abs=1e-9)
+
+
+def test_cpp_magnitude_pruning_matches_python_reference():
+    # Both ports implement the exact same per-row keep-count rule -- on the
+    # same weight the *set* of surviving (nonzero) entries should match
+    # exactly, even if tie-breaking among equal-magnitude entries (rare with
+    # continuous random weights) could in principle differ.
+    model = _matmul_model(K=64, N=16, seed=7)
+    pruned_py = onnxsim.apply_magnitude_pruning(model, sparsity=0.5)
+    pruned_cpp = onnxsim.prune_magnitude_cpp(model, sparsity=0.5)
+
+    mask_py = _weight(pruned_py) != 0
+    mask_cpp = _weight(pruned_cpp) != 0
+    assert np.array_equal(mask_py, mask_cpp)
+    np.testing.assert_array_equal(_weight(pruned_py), _weight(pruned_cpp))
+
+
+def test_cpp_magnitude_pruning_output_stays_finite_and_close():
+    model = _matmul_model(K=64, N=16, seed=8)
+    pruned = onnxsim.prune_magnitude_cpp(model, sparsity=0.3)
+    onnx.checker.check_model(pruned)
+
+    rng = np.random.default_rng(9)
+    x = rng.standard_normal((4, 64)).astype(np.float32)
+    sess_f = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    sess_p = ort.InferenceSession(
+        pruned.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    (y_f,) = sess_f.run(None, {"X": x})
+    (y_p,) = sess_p.run(None, {"X": x})
+    assert np.all(np.isfinite(y_p))
+    rel = np.linalg.norm(y_f - y_p) / max(np.linalg.norm(y_f), 1e-6)
+    assert rel < 1.0  # 30% sparsity perturbs but shouldn't blow up the output

--- a/tests/test_quarot_cpp.py
+++ b/tests/test_quarot_cpp.py
@@ -1,0 +1,163 @@
+"""Tests for ``onnxsim.apply_quarot_cpp`` -- the C++-backed port of
+``onnxsim.apply_quarot`` (see ``onnxsim/passes/quarot.h`` and
+``onnxsim/passes/random_orthogonal.h``). Unlike the MXFP4/double-quantization
+C++ ports, this pass draws a fresh random rotation per layer using its own
+independent RNG derivation (not a numpy Generator sequenced across matches
+in graph node order), so its output is expected to be *accurate*, not
+bit-identical to the Python port -- these tests check structure and
+numerical accuracy rather than exact equality.
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _matmul_model(K=32, N=8, weight=None, seed=0, opset=21):
+    if weight is None:
+        rng = np.random.default_rng(seed)
+        weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[_f32(weight, "W")],
+        opset=opset,
+    )
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
+
+
+def test_cpp_quarot_quantizes_matmul_with_standard_ops_only():
+    model = _matmul_model(K=32, N=8, seed=0)
+    q = onnxsim.apply_quarot_cpp(model, seed=0)
+    onnx.checker.check_model(q)
+
+    op_types = {n.op_type for n in q.graph.node}
+    assert op_types <= {
+        "MatMul",
+        "Abs",
+        "ReduceMax",
+        "Clip",
+        "Div",
+        "Round",
+        "Mul",
+        "DequantizeLinear",
+        "Add",
+        "Identity",
+    }
+    assert all(n.domain in ("", "ai.onnx") for n in q.graph.node)
+
+
+def test_cpp_quarot_rotation_is_orthogonal():
+    model = _matmul_model(K=32, N=8, seed=1)
+    q = onnxsim.apply_quarot_cpp(model, seed=2)
+    u = next(
+        onnx.numpy_helper.to_array(t)
+        for t in q.graph.initializer
+        if list(t.dims) == [32, 32]
+    )
+    identity = u.astype(np.float64) @ u.astype(np.float64).T
+    assert np.allclose(identity, np.eye(32), atol=1e-4)
+
+
+def test_cpp_quarot_output_stays_close_to_float_via_onnxruntime():
+    model = _matmul_model(K=32, N=8, seed=3)
+    q = onnxsim.apply_quarot_cpp(model, seed=3)
+    onnx.checker.check_model(q)
+
+    rng = np.random.default_rng(4)
+    x = rng.standard_normal((8, 32)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x})
+    (q_y,) = _run(q, {"X": x})
+    assert np.all(np.isfinite(q_y))
+    assert _rel_l2(float_y, q_y) < 0.5
+
+
+def test_cpp_quarot_gemm_with_bias():
+    rng = np.random.default_rng(5)
+    K, N = 64, 12
+    weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    bias = rng.standard_normal((N,)).astype(np.float32) * 0.1
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = Gemm(X, W, B)
+        }}
+        """,
+        initializer=[_f32(weight, "W"), _f32(bias, "B")],
+    )
+    q = onnxsim.apply_quarot_cpp(model, seed=6)
+    onnx.checker.check_model(q)
+    assert any(n.op_type == "Add" for n in q.graph.node)
+
+    x = rng.standard_normal((4, K)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x})
+    (q_y,) = _run(q, {"X": x})
+    assert np.all(np.isfinite(q_y))
+    assert _rel_l2(float_y, q_y) < 0.5
+
+
+def test_cpp_quarot_skips_non_block_divisible_k():
+    model = _matmul_model(K=48, N=8, seed=7)  # 48 is not a multiple of 32
+    q = onnxsim.apply_quarot_cpp(model, seed=0)
+    assert q.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_quarot_declines_pre_opset21():
+    model = _matmul_model(K=32, N=8, seed=8, opset=13)
+    q = onnxsim.apply_quarot_cpp(model, seed=0)
+    assert q.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_quarot_is_deterministic_for_a_given_seed():
+    model = _matmul_model(K=32, N=8, seed=9)
+    q1 = onnxsim.apply_quarot_cpp(model, seed=42)
+    q2 = onnxsim.apply_quarot_cpp(model, seed=42)
+    assert q1.SerializeToString() == q2.SerializeToString()
+
+
+def test_cpp_quarot_different_seeds_give_different_rotations():
+    model = _matmul_model(K=32, N=8, seed=10)
+    q1 = onnxsim.apply_quarot_cpp(model, seed=1)
+    q2 = onnxsim.apply_quarot_cpp(model, seed=2)
+    assert q1.SerializeToString() != q2.SerializeToString()


### PR DESCRIPTION
This PR adds C++ implementations of four quantization and pruning techniques, along with an end-to-end optimization pipeline that chains them together:

## Key Changes

**New C++ Passes:**
- **QuaRot** (`passes/quarot.h`): Rotates the residual stream by a random orthogonal matrix to remove activation outliers, enabling both weight and activation to be quantized to INT4 without calibration data. Includes a Haar-random orthogonal matrix generator (`passes/random_orthogonal.h`).
- **Magnitude Pruning** (`passes/magnitude_pruning.h`): Data-free unstructured pruning that zeros the least-magnitude entries per output channel in MatMul/Gemm/Conv layers.
- **MXFP4 Weight-Only Quantization** (`passes/weight_only_quantize_mxfp4_matmul.h`): OCP Microscaling MXFP4 quantization with fixed E2M1 codebook and power-of-two block scales, built from standard ops (Gather + Mul) since ONNX has no native MX tensor type. Includes shared quantization helpers (`passes/quantize_mxfp4_common.h`).
- **Double Quantization** (`passes/double_quantization.h`): QLoRA-style second-level quantization of scale tensors themselves to UINT8, composable with any block-wise/per-channel scheme.

**Python Integration:**
- New `optimize_pipeline.py`: End-to-end pipeline that escalates through simplify → prune → cross-layer-equalize → quantize (weight-only or rotated) → refine (AdaRound/bias correction) → compress (double quantization), measuring accuracy against the original float model and stopping when budget is met.
- C++ entry points in `quantize_entry.cpp` and new `pruning_entry.cpp` for single-call access to these passes.
- Python bindings in `cpp2py_export.cc` exposing `quantize_weight_only_mxfp4`, `apply_double_quantization_cpp`, `apply_quarot_cpp`, and `prune_magnitude_cpp`.

**Tests:**
- `test_optimize_pipeline.py`: Tests the full pipeline's escalation logic and accuracy measurement.
- `test_quarot_cpp.py`: Validates QuaRot's orthogonal rotation structure and numerical accuracy.
- `test_pruning_cpp.py`: Verifies magnitude pruning reaches target sparsity and preserves largest entries per row.
- `test_mx_quantization_cpp.py`: Cross-checks C++ MXFP4 against the pure-Python reference.
- `test_double_quantization_cpp.py`: Validates nested DequantizeLinear structure and output accuracy.

## Implementation Details

- **Deterministic randomness**: QuaRot uses a per-layer seeded RNG (via `QuarotSeed()` function-local static) for reproducible but independent rotations, rather than sequencing a single global RNG across matches.
- **Anonymous initializer names**: C++ passes mint new initializers with anonymous names (located by shape/dtype in tests) rather than predictable names, matching onnxsim's "replace, don't mutate" convention for constants.
- **Fixed-point termination**: Magnitude pruning explicitly checks whether pruning would change anything to avoid infinite loops in OptimizeFixed's fixed-point iteration.
- **Opset requirements**: QuaRot requires opset ≥ 21 (INT4 tensors and DequantizeLinear's block_size attribute); MXFP4 and double quantization work with opset 11+.
- **Scope limitations**: Unlike the Python ports, C++ implementations focus on the common case (MatMul/vanilla-Gemm for quantization; no com.microsoft::Attention for pruning) to keep the initial port manageable.

The pipeline follows `autoquant`'s escalation pattern, measuring each stage against the original float model and returning the least-lossy stage reached if no stage meets the accuracy budget.

https://claude.ai/code/session_01FAiv55epkSMz7NPXD4r97u