### PR TITLE
Add apply_attention_quantization: INT8 quantization of the attention computation

### DIFF
--- a/docs/attention-quantization.md
+++ b/docs/attention-quantization.md
@@ -1,0 +1,99 @@
+# Attention computation quantization (`apply_attention_quantization`)
+
+## What this is
+
+`onnxsim.apply_attention_quantization` quantizes the attention
+computation itself -- not a weight, and not the KV-cache -- for the
+common decomposed attention subgraph:
+
+```
+Before:
+  scores  = MatMul(Q, Kt)                  -- Kt: K, transposed
+  scaled  = Mul(scores, scale)  [optional]  -- e.g. 1/sqrt(head_dim)
+  masked  = Add(scaled, mask)   [optional]  -- e.g. causal mask
+  probs   = Softmax(masked, axis=-1)
+  out     = MatMul(probs, V)
+
+After:
+  Qdq, Kdq = per-token INT8 round-trip of Q, Kt        -- data-free
+  scores   = MatMul(Qdq, Kdq)                          -- unchanged shape/attrs
+  ...scale/mask/softmax unchanged...
+  probsdq  = fixed-scale (1/255) UINT8 round-trip of probs
+  Vdq      = per-token INT8 round-trip of V             -- data-free
+  out      = MatMul(probsdq, Vdq)
+```
+
+## Where this comes from
+
+Every other quantizer in onnxsim targets either a weight-bearing
+MatMul/Gemm layer (`quantize_weight_only_int4` and everything built on
+it -- `apply_spinquant`, `apply_quarot`, `apply_duquant`, ...) or the
+KV-cache tensors specifically (`onnxsim.quantize_kv_cache`). Nothing
+quantizes the attention *computation* itself: the `QK^T` score matmul, or
+the `softmax(QK^T)@V` value-weighted sum. Both are pure
+activation-to-activation matmuls -- no constant weight at all -- so none
+of onnxsim's weight-quantization machinery applies to them.
+
+Three tensors get quantized to INT8, each via the technique already
+best-suited to what it actually is -- needing **no calibration data for
+any of them**:
+
+- **Q and K**: data-free, per-token dynamic INT8, the same pattern
+  `apply_quarot`/`apply_duquant` already use for their own activation
+  quantization (`scale = max(|x|, axis=-1) / 127`, computed fresh at
+  graph-run time).
+- **V**: the same per-token dynamic INT8 scheme.
+- **The Softmax output** (the attention probabilities): unlike every
+  other activation in onnxsim, a Softmax output's range isn't merely
+  typical -- it's *guaranteed* to lie in `[0, 1]` for any input at all
+  (the "activation-range provenance" fact `onnxsim.precision_estimator`'s
+  own docstring already names, point 4, but never previously used to
+  actually quantize anything). That makes it the one activation in this
+  whole package quantizable with a **fixed, non-data-dependent** scale --
+  UINT8 with `scale = 1/255`, `zero_point = 0` -- no calibration run, no
+  runtime scale computation at all, just an ordinary round-to-nearest
+  against a constant.
+
+The score matmul itself and the Softmax normalization are left running
+in float, exactly as `apply_smoothquant`/`apply_awq` leave their own
+internal reductions in float -- only the tensors *crossing* a matmul
+boundary are quantized. Like `apply_quarot`/`apply_duquant`'s own
+activation handling, the quantize-dequantize round trip is simulated in
+float32 (no true INT8 tensor type is used) since there is no real integer
+MatMul kernel available in an ordinary ONNX graph to benefit from an
+actual cast -- the point is to measure and preserve the precision loss a
+real INT8 attention kernel would introduce, not to save graph-level
+storage the way weight quantization does.
+
+## Scope
+
+Handled:
+
+- The subgraph `MatMul(Q, Kt) -> [Mul or Div] -> [Add] -> Softmax ->
+  MatMul(probs, V)`, where the optional scale (`Mul`/`Div`) and mask
+  (`Add`) nodes may each be present or absent, in either combination.
+- Opset >= 18 (the per-token Q/K/V scale's `ReduceMax` needs its
+  `axes`-as-input form, matching `quantize_kv_cache`'s own Value-style
+  gate).
+
+Left untouched (safe no-op, subgraph passes through as-is):
+
+- A Softmax node whose input doesn't trace back to a MatMul within two
+  hops, or whose output isn't consumed as a MatMul's first input.
+- A model with no matching subgraph, or an opset older than 18.
+
+## Usage
+
+```python
+import onnx
+import onnxsim
+
+model = onnx.load("model.onnx")
+quantized = onnxsim.apply_attention_quantization(model)
+onnx.save(quantized, "model.attnq.onnx")
+```
+
+Needs no calibration data at all: every scale in this module is either
+computed fresh from the actual data at graph-run time (Q, K, V) or fixed
+by the Softmax output's own guaranteed range (the attention
+probabilities).

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -11,6 +11,7 @@ from onnxsim.accuracy import (
 )
 from onnxsim.adaround import apply_adaround
 from onnxsim.aqlm import quantize_weight_only_aqlm
+from onnxsim.attention_quantization import apply_attention_quantization
 from onnxsim.autoquant import AutoQuantResult, auto_quantize_int4
 from onnxsim.autoround import apply_autoround
 from onnxsim.awq import apply_awq
@@ -116,6 +117,7 @@ __all__ = [
     "auto_quantize_int4",
     "AutoQuantResult",
     "apply_awq",
+    "apply_attention_quantization",
     "apply_gptq",
     "apply_smoothquant",
     "apply_llm_int8",

--- a/onnxsim/attention_quantization.py
+++ b/onnxsim/attention_quantization.py
@@ -1,0 +1,305 @@
+"""Attention computation quantization.
+
+Every other quantizer in onnxsim targets either a weight-bearing
+MatMul/Gemm layer (`quantize_weight_only_int4` and everything built on
+it -- `apply_spinquant`, `apply_quarot`, `apply_duquant`, ...) or the
+KV-cache tensors specifically (:mod:`onnxsim.kv_cache_quantization`).
+Nothing quantizes the attention *computation* itself: the
+``QK^T`` score matmul, or the ``softmax(QK^T)@V`` value-weighted sum.
+Both are pure activation-to-activation matmuls (no constant weight at
+all), so none of onnxsim's weight-quantization machinery applies to them.
+
+This module targets the common **decomposed** attention subgraph most
+ONNX exports still produce (rather than the newer, opset-23+ fused
+``Attention`` operator :mod:`onnxsim.precision_estimator` already has
+advisory-only awareness of -- see that module's own docstring, point 4,
+which flags Softmax's output range but doesn't act on it):
+
+    scores  = MatMul(Q, Kt)                  -- Kt: K, transposed
+    scaled  = Mul(scores, scale)  [optional]  -- e.g. 1/sqrt(head_dim)
+    masked  = Add(scaled, mask)   [optional]  -- e.g. causal mask
+    probs   = Softmax(masked, axis=-1)
+    out     = MatMul(probs, V)
+
+Three tensors get quantized to INT8, each via the technique already
+best-suited to what it actually is -- **no calibration data needed for
+any of them**:
+
+- **Q and K** (the score matmul's own operands): data-free, per-token
+  dynamic INT8 (the same pattern :mod:`onnxsim.quarot`/:mod:`onnxsim.duquant`
+  already use for their own activation quantization -- ``scale =
+  max(|x|, axis=-1) / 127``, computed fresh at graph-run time, no
+  calibration statistics stored).
+- **V** (the second matmul's other operand): the same per-token dynamic
+  INT8 scheme.
+- **The Softmax output itself** (the attention *probabilities*): unlike
+  every other activation in this codebase, a Softmax output's range is
+  not merely typical -- it is *guaranteed* to lie in ``[0, 1]`` for any
+  input at all (the same fact :mod:`onnxsim.precision_estimator`'s own
+  docstring already names as "activation-range provenance", point 4, but
+  never previously used to actually quantize anything). That makes it the
+  one activation in this whole package that can be quantized with a
+  **fixed, non-data-dependent** scale -- ``UINT8`` with ``scale = 1/255``,
+  ``zero_point = 0`` -- no calibration run, no runtime scale computation,
+  just an ordinary round-to-nearest against a constant.
+
+Score computation itself (``MatMul(Q, Kt)``) and the softmax normalization
+are left running in float, exactly as SmoothQuant/AWQ leave their own
+internal reductions in float -- only the three tensors *crossing* a
+matmul boundary are quantized, matching every other onnxsim quantizer's
+own convention of touching operands, not recomputing an op's own math in
+lower precision.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Union
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+
+from onnxsim.bias_correction import _all_names, _unique_name
+
+
+def _has_min_opset(model: onnx.ModelProto, min_version: int) -> bool:
+    return any(
+        o.domain in ("", "ai.onnx") and o.version >= min_version
+        for o in model.opset_import
+    )
+
+
+def _find_matmul_producer(
+    name: str, producer_by_output: Dict[str, onnx.NodeProto], hops_left: int
+) -> Optional[onnx.NodeProto]:
+    """Walks back from tensor ``name`` through at most ``hops_left``
+    Mul/Div/Add nodes (following each one's *first* input only -- the
+    scale/mask operand, never the divisor/mask itself) looking for the
+    MatMul that produced the raw attention scores. Returns ``None`` if no
+    such MatMul is found within the hop budget.
+    """
+    node = producer_by_output.get(name)
+    if node is None:
+        return None
+    if node.op_type == "MatMul":
+        return node
+    if hops_left <= 0 or node.op_type not in ("Mul", "Div", "Add"):
+        return None
+    return _find_matmul_producer(node.input[0], producer_by_output, hops_left - 1)
+
+
+class _AttentionCandidate:
+    def __init__(
+        self,
+        qk_matmul: onnx.NodeProto,
+        softmax: onnx.NodeProto,
+        out_matmul: onnx.NodeProto,
+    ):
+        self.qk_matmul = qk_matmul
+        self.softmax = softmax
+        self.out_matmul = out_matmul
+
+
+def _find_attention_candidates(graph: onnx.GraphProto) -> List[_AttentionCandidate]:
+    producer_by_output: Dict[str, onnx.NodeProto] = {}
+    for node in graph.node:
+        for out in node.output:
+            producer_by_output[out] = node
+
+    consumers_by_input: Dict[str, List[onnx.NodeProto]] = {}
+    for node in graph.node:
+        for inp in node.input:
+            consumers_by_input.setdefault(inp, []).append(node)
+
+    candidates = []
+    for node in graph.node:
+        if node.op_type != "Softmax":
+            continue
+        qk_matmul = _find_matmul_producer(node.input[0], producer_by_output, 2)
+        if qk_matmul is None:
+            continue
+        softmax_out = node.output[0]
+        consumers = consumers_by_input.get(softmax_out, [])
+        out_matmul = next(
+            (
+                c
+                for c in consumers
+                if c.op_type == "MatMul" and c.input[0] == softmax_out
+            ),
+            None,
+        )
+        if out_matmul is None:
+            continue
+        candidates.append(_AttentionCandidate(qk_matmul, node, out_matmul))
+    return candidates
+
+
+def apply_attention_quantization(
+    model: Union[str, onnx.ModelProto],
+    epsilon: float = 1e-12,
+) -> onnx.ModelProto:
+    """Quantizes every decomposed attention subgraph
+    (``MatMul(Q,Kt) -> [Mul/Div] -> [Add] -> Softmax -> MatMul(_,V)``) to
+    INT8 -- see this module's own docstring for the technique. Needs no
+    calibration data at all: Q/K/V use data-free per-token dynamic
+    scales, and the Softmax output uses a fixed scale (its range is
+    always ``[0, 1]``, by construction).
+
+    :param model: the original (unquantized) onnx ModelProto or file path
+    :param epsilon: floor applied to a token's own max-abs Q/K/V value
+            before using it as a scale, avoiding a divide-by-zero on an
+            all-zero token
+    :returns: ``model`` with every matched subgraph's ``Q``, ``Kt``, and
+            ``V`` operands, and the Softmax output, replaced by INT8
+            round-trip (quantize-then-immediately-dequantize, kept in
+            float32 to simulate the precision loss without a true integer
+            matmul) versions; the score MatMul and the Softmax
+            normalization itself are left running in float. A model with
+            no matching subgraph, or an opset older than 18 (``ReduceMax``'s
+            ``axes``-as-input form, used for the per-token Q/K/V scale,
+            needs opset 18 -- matching :func:`onnxsim.quantize_kv_cache`'s
+            own Value-style gate), is returned unchanged
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    if not _has_min_opset(model, 18):
+        return model
+
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    graph = out.graph
+    taken_names = _all_names(graph)
+
+    candidates = _find_attention_candidates(graph)
+    if not candidates:
+        return out
+
+    eps_name = _unique_name("attnq_eps", taken_names)
+    graph.initializer.append(
+        onnx.numpy_helper.from_array(np.array(epsilon, dtype=np.float32), name=eps_name)
+    )
+    i127_name = _unique_name("attnq_127", taken_names)
+    graph.initializer.append(
+        onnx.numpy_helper.from_array(np.array(127.0, dtype=np.float32), name=i127_name)
+    )
+    i127_min_name = _unique_name("attnq_neg127", taken_names)
+    graph.initializer.append(
+        onnx.numpy_helper.from_array(
+            np.array(-127.0, dtype=np.float32), name=i127_min_name
+        )
+    )
+    axes_name = _unique_name("attnq_axes", taken_names)
+    graph.initializer.append(
+        onnx.numpy_helper.from_array(np.array([-1], dtype=np.int64), name=axes_name)
+    )
+    probs_scale_name = _unique_name("attnq_probs_scale", taken_names)
+    graph.initializer.append(
+        onnx.numpy_helper.from_array(
+            np.array(1.0 / 255.0, dtype=np.float32), name=probs_scale_name
+        )
+    )
+    probs_max_name = _unique_name("attnq_probs_max", taken_names)
+    graph.initializer.append(
+        onnx.numpy_helper.from_array(
+            np.array(255.0, dtype=np.float32), name=probs_max_name
+        )
+    )
+    probs_zero_name = _unique_name("attnq_probs_zero", taken_names)
+    graph.initializer.append(
+        onnx.numpy_helper.from_array(
+            np.array(0.0, dtype=np.float32), name=probs_zero_name
+        )
+    )
+
+    # Per-target-node lists of nodes to insert immediately *before* that
+    # target, keyed by id() (NodeProto isn't hashable-by-value) -- built up
+    # per candidate below, then spliced into the graph in a single pass so
+    # every new node lands strictly before whichever original node first
+    # needs its output, preserving topological order even though a
+    # candidate's own new nodes split across two different insertion
+    # points (before qk_matmul, and separately before out_matmul, since
+    # the probs/V nodes depend on Softmax's own output, produced strictly
+    # between those two original nodes).
+    pre_insert: Dict[int, List[onnx.NodeProto]] = {}
+
+    def _quantize_per_token_int8(
+        x_name: str, tag: str, sink: List[onnx.NodeProto]
+    ) -> str:
+        def _new(op_type, inputs, out_suffix, **attrs):
+            out_name = _unique_name(f"attnq_{out_suffix}", taken_names)
+            n_ = onnx.helper.make_node(
+                op_type,
+                inputs,
+                [out_name],
+                name=_unique_name(f"attnq_{out_suffix}_node", taken_names),
+                **attrs,
+            )
+            sink.append(n_)
+            return out_name
+
+        # scale = max(reduce_max(abs(x), axis=-1), eps) / 127
+        # x_q = clip(round(x / scale), -127, 127); x_dq = x_q * scale
+        abs_name = _new("Abs", [x_name], f"{tag}_abs")
+        max_name = _new("ReduceMax", [abs_name, axes_name], f"{tag}_max", keepdims=1)
+        safe_max_name = _new("Clip", [max_name, eps_name], f"{tag}_safe_max")
+        scale_name = _new("Div", [safe_max_name, i127_name], f"{tag}_scale")
+        scaled_name = _new("Div", [x_name, scale_name], f"{tag}_scaled")
+        rounded_name = _new("Round", [scaled_name], f"{tag}_rounded")
+        clipped_name = _new(
+            "Clip", [rounded_name, i127_min_name, i127_name], f"{tag}_clipped"
+        )
+        return _new("Mul", [clipped_name, scale_name], f"{tag}_dequant")
+
+    for i, c in enumerate(candidates):
+        qk_sink: List[onnx.NodeProto] = []
+        q_dq = _quantize_per_token_int8(c.qk_matmul.input[0], f"q{i}", qk_sink)
+        k_dq = _quantize_per_token_int8(c.qk_matmul.input[1], f"k{i}", qk_sink)
+        c.qk_matmul.input[0] = q_dq
+        c.qk_matmul.input[1] = k_dq
+        pre_insert.setdefault(id(c.qk_matmul), []).extend(qk_sink)
+
+        out_sink: List[onnx.NodeProto] = []
+
+        def _new_out(op_type, inputs, out_suffix, **attrs):
+            out_name = _unique_name(f"attnq_{out_suffix}", taken_names)
+            n_ = onnx.helper.make_node(
+                op_type,
+                inputs,
+                [out_name],
+                name=_unique_name(f"attnq_{out_suffix}_node", taken_names),
+                **attrs,
+            )
+            out_sink.append(n_)
+            return out_name
+
+        # Fixed-scale UINT8 quantization of the softmax output: its range
+        # is [0, 1] for any input at all, so scale=1/255, zero_point=0
+        # needs no data-dependent computation.
+        probs_scaled = _new_out(
+            "Div", [c.softmax.output[0], probs_scale_name], f"probs{i}_scaled"
+        )
+        probs_rounded = _new_out("Round", [probs_scaled], f"probs{i}_rounded")
+        probs_clipped = _new_out(
+            "Clip",
+            [probs_rounded, probs_zero_name, probs_max_name],
+            f"probs{i}_clipped",
+        )
+        probs_dq = _new_out(
+            "Mul", [probs_clipped, probs_scale_name], f"probs{i}_dequant"
+        )
+
+        v_dq = _quantize_per_token_int8(c.out_matmul.input[1], f"v{i}", out_sink)
+
+        c.out_matmul.input[0] = probs_dq
+        c.out_matmul.input[1] = v_dq
+        pre_insert.setdefault(id(c.out_matmul), []).extend(out_sink)
+
+    rebuilt: List[onnx.NodeProto] = []
+    for node in list(graph.node):
+        rebuilt.extend(pre_insert.get(id(node), []))
+        rebuilt.append(node)
+    del graph.node[:]
+    graph.node.extend(rebuilt)
+
+    return out

--- a/tests/test_attention_quantization.py
+++ b/tests/test_attention_quantization.py
@@ -1,0 +1,153 @@
+"""Tests for ``onnxsim.apply_attention_quantization`` -- see
+``onnxsim/attention_quantization.py`` for the technique (INT8 quantization
+of the decomposed attention subgraph's own Q/K/V operands and, via a
+fixed non-data-dependent scale, its Softmax output).
+"""
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _model(nodes, inputs, outputs, initializer, opset=18):
+    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=9
+    )
+
+
+def _attention_model(seq=6, head_dim=8, use_mask=False, opset=18):
+    nodes = [
+        onnx.helper.make_node("Transpose", ["K"], ["Kt"], perm=[1, 0]),
+        onnx.helper.make_node("MatMul", ["Q", "Kt"], ["scores"]),
+        onnx.helper.make_node("Mul", ["scores", "scale"], ["scaled"]),
+    ]
+    softmax_input = "scaled"
+    initializer = [_f32(np.array(1.0 / np.sqrt(head_dim)), "scale")]
+    if use_mask:
+        mask = np.triu(np.full((seq, seq), -1e9, dtype=np.float32), k=1)
+        nodes.append(onnx.helper.make_node("Add", ["scaled", "mask"], ["masked"]))
+        initializer.append(_f32(mask, "mask"))
+        softmax_input = "masked"
+    nodes.append(onnx.helper.make_node("Softmax", [softmax_input], ["probs"], axis=-1))
+    nodes.append(onnx.helper.make_node("MatMul", ["probs", "V"], ["Y"]))
+    return _model(
+        nodes,
+        [
+            _vi("Q", [seq, head_dim]),
+            _vi("K", [seq, head_dim]),
+            _vi("V", [seq, head_dim]),
+        ],
+        [_vi("Y", [seq, head_dim])],
+        initializer,
+        opset=opset,
+    )
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
+
+
+def _feeds(seq=6, head_dim=8, seed=1):
+    rng = np.random.default_rng(seed)
+    return {
+        "Q": rng.standard_normal((seq, head_dim)).astype(np.float32),
+        "K": rng.standard_normal((seq, head_dim)).astype(np.float32),
+        "V": rng.standard_normal((seq, head_dim)).astype(np.float32),
+    }
+
+
+def test_attention_quantization_output_stays_close_to_float_via_onnxruntime():
+    model = _attention_model()
+    q = onnxsim.apply_attention_quantization(model)
+    onnx.checker.check_model(q)
+
+    feeds = _feeds()
+    (float_y,) = _run(model, feeds)
+    (q_y,) = _run(q, feeds)
+    assert np.all(np.isfinite(q_y))
+    assert _rel_l2(float_y, q_y) < 0.3
+
+
+def test_attention_quantization_handles_masked_variant():
+    model = _attention_model(use_mask=True)
+    q = onnxsim.apply_attention_quantization(model)
+    onnx.checker.check_model(q)
+
+    feeds = _feeds()
+    (float_y,) = _run(model, feeds)
+    (q_y,) = _run(q, feeds)
+    assert np.all(np.isfinite(q_y))
+    assert _rel_l2(float_y, q_y) < 0.3
+
+
+def test_attention_quantization_leaves_score_matmul_and_softmax_untouched():
+    model = _attention_model()
+    q = onnxsim.apply_attention_quantization(model)
+
+    op_types = [n.op_type for n in q.graph.node]
+    assert op_types.count("Softmax") == 1
+    assert op_types.count("MatMul") == 2  # QK^T and probs@V, both still present
+    assert "Round" in op_types  # the new quantize-dequantize machinery
+    assert "ReduceMax" in op_types
+
+
+def test_attention_quantization_probs_use_a_fixed_1_over_255_scale():
+    model = _attention_model()
+    q = onnxsim.apply_attention_quantization(model)
+
+    scale_init = next(t for t in q.graph.initializer if t.name == "attnq_probs_scale")
+    scale = onnx.numpy_helper.to_array(scale_init)
+    assert np.isclose(scale, 1.0 / 255.0)
+
+
+def test_attention_quantization_noop_without_attention_pattern():
+    nodes = [onnx.helper.make_node("Relu", ["X"], ["Y"])]
+    model = _model(nodes, [_vi("X", [4, 4])], [_vi("Y", [4, 4])], [])
+    result = onnxsim.apply_attention_quantization(model)
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_attention_quantization_noop_when_softmax_output_not_consumed_by_matmul():
+    nodes = [
+        onnx.helper.make_node("MatMul", ["Q", "K"], ["scores"]),
+        onnx.helper.make_node("Softmax", ["scores"], ["probs"], axis=-1),
+        onnx.helper.make_node("Identity", ["probs"], ["Y"]),
+    ]
+    model = _model(
+        nodes,
+        [_vi("Q", [4, 4]), _vi("K", [4, 4])],
+        [_vi("Y", [4, 4])],
+        [],
+    )
+    result = onnxsim.apply_attention_quantization(model)
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_attention_quantization_declines_below_opset18():
+    model = _attention_model(opset=13)
+    result = onnxsim.apply_attention_quantization(model)
+    assert result.SerializeToString() == model.SerializeToString()


### PR DESCRIPTION
## Summary

- Adds `onnxsim.apply_attention_quantization` — quantizes the attention **computation** itself, not a weight and not the KV-cache.
- Every other quantizer in onnxsim targets either a weight-bearing MatMul/Gemm layer (`quantize_weight_only_int4` and everything built on it) or the KV-cache tensors specifically (`onnxsim.quantize_kv_cache`). Nothing quantizes the `QK^T` score matmul or the `softmax(QK^T)@V` value-weighted sum — both are pure activation-to-activation matmuls, no constant weight at all.
- Matches the common decomposed attention subgraph `MatMul(Q,Kt) -> [Mul/Div] -> [Add] -> Softmax -> MatMul(_,V)` and quantizes three tensors to INT8, **no calibration data needed for any of them**:
  - **Q and K**: data-free per-token dynamic INT8, the same pattern `apply_quarot`/`apply_duquant` already use for their own activation quantization.
  - **V**: the same per-token dynamic INT8 scheme.
  - **The Softmax output** (attention probabilities): a **fixed** scale (`1/255`), since its range is guaranteed to be `[0, 1]` for any input at all — the exact fact `onnxsim.precision_estimator`'s own docstring already names ("activation-range provenance", point 4) but never previously used to actually quantize anything.
- The score matmul and Softmax normalization are left running in float; only the tensors crossing a matmul boundary are quantized (simulated in float32, same convention `apply_quarot`/`apply_duquant` use for their own activations, since there's no real integer matmul kernel to benefit from an actual cast).

## Test plan

- [x] `tests/test_attention_quantization.py` (7 new tests): float-vs-quantized closeness via onnxruntime (unmasked and causally-masked variants), the score MatMul/Softmax stay untouched, the probs scale is genuinely fixed at `1/255`, and decline paths (no attention pattern, Softmax output not consumed by a MatMul, opset < 18).
- [x] Full regression sweep (`pytest tests/ --ignore=tests/test_torch_export.py --ignore=tests/test_timm.py`): 966 passed, 69 skipped, 0 failed.
- [x] `ruff format` / `ruff check` / `mypy` clean.

Note: caught and fixed a real topological-ordering bug during development — my first draft inserted all new nodes for a matched subgraph at one position, which placed the Softmax-output-quantization nodes *before* the original Softmax node they depend on. Fixed by tracking per-target-node insertion points and splicing them into the graph in a single pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_