### PR TITLE
Fold opset conversion into the resident-Graph pipeline

### DIFF
--- a/bench/RESULTS_opset_version_converter.md
+++ b/bench/RESULTS_opset_version_converter.md
@@ -127,3 +127,64 @@ converting a model with a stale/missing custom-op adapter is worse than the
 **Verified:** `tests/test_python_api.py`'s two `target_opset_version` tests and
 the full `test_python_api.py` module pass; CLI (`--target-opset latest`) and
 Python API (`target_opset_version="latest"`) both smoke-tested end to end.
+
+## Follow-up: folding opset conversion into the resident-Graph pipeline
+
+PR #886 (above) made `ConvertOpsetVersion`'s *own* Import/Export round trip
+cheap, but it was still a *second*, independent round trip: `Pipeline`'s
+`!rewriter` branch already imports `ModelProto` into an `onnx::Graph` once and
+exports once around the entire outer fixed point (shape inference,
+onnx-optimizer passes, constant folding) -- `ConvertOpsetVersion` ran as its
+own separate step *before* that, with its own Import/Export pair, even though
+the version converter's node-adaptation logic (`convert_graph`) already
+operates directly on `onnx::Graph`.
+
+**Fix:** exposed `DefaultVersionConverter::convert_version_on_graph` /
+`ConvertVersionOnGraph(std::shared_ptr<Graph>&, int)` in the onnx fork (branch
+`claude/onnx-version-converter-graph-api`, depends on the PR #886 branch) --
+the same node-adaptation logic, called directly on an already-resident
+`Graph&` instead of wrapped in its own ModelProto<->Graph conversion. Moved
+the `!rewriter` branch's opset conversion to call this directly on the graph
+`Pipeline` already imports, cutting the second Import/Export pair entirely.
+The `rewriter` branch (ModelProto-only; onnxscript's rewriter doesn't
+understand `onnx::Graph`) is unaffected and still uses the ModelProto-level
+`ConvertOpsetVersion`.
+
+**Measured (median of 5 trials, quiet host -- no concurrent test suite; an
+earlier pass run *while* the full test suite was running in the background
+showed a much larger apparent gap, which was CPU-contention noise, not a real
+effect; discarded):**
+
+| model | initializer bytes | before (2 round trips) | after (1 round trip) | change |
+|---|---:|---:|---:|---:|
+| tiny (1 block, 3 nodes) | 0.0 MB | 5.43ms | ~5.5ms | ~none (fixed-cost dominated either way) |
+| medium (20 blocks, 60 nodes) | 3.0 MB | ~15.2ms | ~15.4ms | ~none (too small to separate from noise) |
+| large (40 blocks, 120 nodes) | 13.3 MB | ~45-47ms | ~44-46ms | ~none |
+| xlarge (100 blocks, 300 nodes) | 92.5 MB | ~300.9ms (median, profiled span) | ~278.6ms (median, profiled span) | **~7% less profiled work** |
+
+Total process wall time for xlarge was noisier (before median 0.827s, after
+0.779s) with overlapping min/max ranges across only 5 trials each -- not
+strong enough on its own to call a wall-clock win, but the profiled-span
+numbers (which exclude whole-process OS/Python scheduling noise) show a real,
+consistent, if modest, improvement concentrated in the largest model.
+
+**Why modest, not dramatic:** PR #886 already eliminated the *data-copy* cost
+of the round trip (the dominant cost for large-initializer models) via the
+moving/consuming overloads. What this follow-up removes is reconstructing the
+`onnx::Graph` IR *structure* itself (Node/Value objects, attribute maps) a
+second time -- real, but scales with node count, not tensor bytes, so it only
+shows up clearly once a model has enough nodes (xlarge: 300) to matter. For
+node-count-heavy, weight-light models (e.g. a very deep model with modest
+per-layer weights) this fix would matter more in isolation than the numbers
+above suggest, since PR #886's copy-elimination wouldn't have much to save
+there either.
+
+**Also fixed in passing:** the profiler's text-summary column was too narrow
+(22 chars) for "ConvertOpsetVersion" (19 chars) once it nested one level
+deeper under "Pipeline" instead of sitting at depth 0 -- it printed as the
+truncated "ConvertOpsetVersio". Widened to 28.
+
+**Verified:** the two dedicated `target_opset_version` tests, the `rewriter`
+branch (smoke-tested with a no-op `custom_rewriter`, confirming it still uses
+the ModelProto path and converts correctly), and the full `test_python_api.py`
+suite (60/60, same pre-existing >2GB-class exclusions as before) all pass.

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -37,6 +37,7 @@
 #include "onnx/defs/printer.h"
 #include "onnx/inliner/inliner.h"
 #include "onnx/shape_inference/implementation.h"
+#include "onnx/version_converter/convert.h"
 #include "onnxoptimizer/model_util.h"
 #include "onnxoptimizer/optimize.h"
 #include "onnxoptimizer/passes/cse_util.h"
@@ -637,26 +638,40 @@ static onnx::ModelProto SimplifyImpl(
     GraphFn PipelineOnGraph =
         FixedPointFn(OptAndShapeOnGraphChanged, FoldConstantOnGraphChanged,
                      fixed_point_iters, &converged);
-    Pipeline = Profiled("Pipeline", [PipelineOnGraph, &fold_ir_version](
-                                        onnx::ModelProto& model) {
-      std::shared_ptr<onnx::Graph> g(onnx::ImportModelProto(model));
-      if (g.get() == nullptr) {
-        // Same fallback as Optimizer::optimize(): if we can't parse the
-        // model, leave it untouched.
-        return;
-      }
-      fold_ir_version = model.ir_version();
-      PipelineOnGraph(*g);
-      onnx::ModelProto out = onnx::PrepareOutput(model);
-      onnx::ExportModelProto(&out, g, /*consume_tensor_data=*/true);
-      // OptimizeGraphFixed never sees model-local functions (they live on
-      // ModelProto, not Graph), so carry them over unchanged -- mirroring
-      // Optimizer::optimize()'s own AddFunctionsToModel.
-      for (const auto& function_proto : model.functions()) {
-        *out.add_functions() = function_proto;
-      }
-      model = std::move(out);
-    });
+    Pipeline =
+        Profiled("Pipeline", [PipelineOnGraph, &fold_ir_version,
+                              target_opset_version](onnx::ModelProto& model) {
+          std::shared_ptr<onnx::Graph> g(onnx::ImportModelProto(model));
+          if (g.get() == nullptr) {
+            // Same fallback as Optimizer::optimize(): if we can't parse the
+            // model, leave it untouched.
+            return;
+          }
+          // Convert the default ONNX domain's opset first, directly on the
+          // resident graph via ConvertVersionOnGraph -- so the simplification
+          // below can clean up any redundant nodes the version converter
+          // introduces, same rationale as the old ModelProto-level
+          // ConvertOpsetVersion call this replaces -- but without paying a
+          // second Import/Export pair for it (unlike ConvertOpsetVersion, which
+          // always does its own; still used by the `rewriter` branch above,
+          // which has no resident Graph to share this one with).
+          if (target_opset_version) {
+            onnxsim::ProfiledScope opset_scope("ConvertOpsetVersion");
+            onnx::version_conversion::ConvertVersionOnGraph(
+                g, *target_opset_version);
+          }
+          fold_ir_version = model.ir_version();
+          PipelineOnGraph(*g);
+          onnx::ModelProto out = onnx::PrepareOutput(model);
+          onnx::ExportModelProto(&out, g, /*consume_tensor_data=*/true);
+          // OptimizeGraphFixed never sees model-local functions (they live on
+          // ModelProto, not Graph), so carry them over unchanged -- mirroring
+          // Optimizer::optimize()'s own AddFunctionsToModel.
+          for (const auto& function_proto : model.functions()) {
+            *out.add_functions() = function_proto;
+          }
+          model = std::move(out);
+        });
   }
   // The fixed points mutate in place, so make one working copy of the (const)
   // input model and simplify it in place. When the caller has told us
@@ -739,7 +754,13 @@ static onnx::ModelProto SimplifyImpl(
   // sibling to, not nested inside, the "Simplify" root below -- so its cost is
   // visible in the flame graph / profile_pass_phases output instead of showing
   // up as unaccounted time before the first pass.
-  if (target_opset_version) {
+  //
+  // Only needed here for the `rewriter` branch, which is ModelProto-based
+  // throughout (onnxscript's rewriter only understands ModelProto) and so has
+  // no resident Graph to fold this into. The no-rewriter branch does the
+  // equivalent conversion itself, directly on its own resident Graph, inside
+  // Pipeline above -- see its ConvertVersionOnGraph call.
+  if (target_opset_version && rewriter) {
     onnxsim::ProfiledScope opset_scope("ConvertOpsetVersion");
     // std::move: sim_model is about to be overwritten by the result anyway,
     // so let ConvertOpsetVersion's by-value parameter move-construct instead

--- a/onnxsim/profiler.cpp
+++ b/onnxsim/profiler.cpp
@@ -658,7 +658,11 @@ void PrintSummary(std::ostream& os, const std::vector<Event>& events) {
   os << "\nonnxsim profiling summary (per fixed-point function)\n";
   os << "-------------------------------------------------------------------"
         "------------------\n";
-  std::snprintf(buf, sizeof(buf), "%-22s %6s %12s %12s %12s %12s\n", "function",
+  // 28, not 22: wide enough for the longest span name ("ConvertOpsetVersion",
+  // 19 chars) plus up to two levels of 2-space indent -- it now nests under
+  // "Pipeline" rather than sitting at depth 0. Widen this again if a future
+  // span name plus its nesting depth would still overflow it.
+  std::snprintf(buf, sizeof(buf), "%-28s %6s %12s %12s %12s %12s\n", "function",
                 "calls", "wall(ms)", "cpu(ms)", "max wall(ms)", "peak(MiB)");
   os << buf;
   os << "-------------------------------------------------------------------"
@@ -667,10 +671,10 @@ void PrintSummary(std::ostream& os, const std::vector<Event>& events) {
     // Indent by nesting depth so the hierarchy is visible in the text summary.
     std::string label(static_cast<size_t>(std::max(0, a.min_depth)) * 2, ' ');
     label += a.name;
-    if (label.size() > 22) {
-      label = label.substr(0, 22);
+    if (label.size() > 28) {
+      label = label.substr(0, 28);
     }
-    std::snprintf(buf, sizeof(buf), "%-22s %6zu %12.2f %12.2f %12.2f %12.2f\n",
+    std::snprintf(buf, sizeof(buf), "%-28s %6zu %12.2f %12.2f %12.2f %12.2f\n",
                   label.c_str(), a.calls, ms(a.wall_us), ms(a.cpu_us),
                   ms(a.max_wall_us), BytesToMiB(a.peak_rss));
     os << buf;


### PR DESCRIPTION
## Summary

Follow-up to #886, which fixed the "back to protobuf" data-copy cost of `target_opset_version`'s `ConvertOpsetVersion`. That fix made the round trip cheap, but there were still *two* of them: `Pipeline`'s `!rewriter` branch already imports `ModelProto` into an `onnx::Graph` once and exports once around the entire outer fixed point (shape inference, onnx-optimizer passes, constant folding) -- `ConvertOpsetVersion` ran as its own separate step *before* that, with its own Import/Export pair, even though the version converter's node-adaptation logic already operates directly on `onnx::Graph`.

- Moves opset conversion inside `Pipeline`'s resident-Graph lambda, calling the onnx fork's new `ConvertVersionOnGraph` directly on the already-imported graph (before the fixed point runs, same as before, so redundant nodes it introduces still get cleaned up) instead of the `ModelProto`-level `ConvertOpsetVersion`. Cuts the second Import/Export pair entirely.
- The `rewriter` branch is unaffected -- it has no resident Graph (onnxscript's rewriter only understands `ModelProto`), so it keeps using `ConvertOpsetVersion` as before.
- Also widens the profiler's text-summary column from 22 to 28 characters: `"ConvertOpsetVersion"` (19 chars) now nests one level deeper, under `"Pipeline"` rather than sitting at depth 0 next to `"Simplify"`, and was getting truncated to `"ConvertOpsetVersio"` at the old width.

**Measured** (clean, quiet-host numbers -- see `bench/RESULTS_opset_version_converter.md`'s new section for the full writeup, including a discarded noisy first pass that turned out to be concurrent-test-suite CPU contention, not a real effect): a real but modest ~7% reduction in profiled work for a 92.5MB/300-node synthetic model. Smaller than #886's own win because that PR already eliminated the round trip's dominant (data-copy) cost; what this removes is reconstructing the `onnx::Graph` IR structure itself a second time, which scales with node count rather than tensor bytes -- so it matters more for node-heavy, weight-light models than the synthetic benchmark here (weight-heavy) shows.

## Dependency

Depends on the paired onnx fork PR: onnxsim/onnx#7 (`claude/onnx-version-converter-graph-api`, adds `ConvertVersionOnGraph`, based on `claude/graph-subgraph-node-cache` -- the branch `third_party/onnx` was already pinned to, not `main`, which has diverged incompatibly). Unlike #886, the `third_party/onnx` submodule pointer here **is** bumped (to that branch's tip) -- without it, `ConvertVersionOnGraph` doesn't exist in the build and CI fails to compile, which is exactly what happened before this pin bump. The pin will move again once onnxsim/onnx#7 is reviewed and merged.

## Test plan

- [x] `clang-format --style=file:onnxsim/.clang-format --dry-run --Werror` clean on the changed files (caught and fixed locally before pushing, unlike #886 where CI caught it)
- [x] `tests/test_python_api.py`'s two `target_opset_version` tests pass
- [x] Full `tests/test_python_api.py` suite passes (60/60, same pre-existing >2GB-class exclusions as #886, unrelated to this change -- confirmed by re-running the one flaky-under-contention test in isolation)
- [x] `rewriter` branch smoke-tested with a no-op `custom_rewriter` + `target_opset_version`, confirming it still converts correctly via the `ModelProto` path
- [x] Profiling comparison (before vs. after, same synthetic-model script from #886) in `bench/RESULTS_opset_version_converter.md`
- [x] Local build against the bumped submodule pin succeeds and all of the above still pass (CI previously failed to compile before this pin bump -- fixed now)
