### PR TITLE
Fix double protobuf round-trip in import_gguf_weights

### DIFF
--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -1490,25 +1490,32 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
   // tensor (Q4_K/Q5_K/Q6_K/Q8_0 -- what most real quantized checkpoints,
   // e.g. Unsloth's GGUF exports, actually use for the bulk of their
   // weights) is decoded to float32; see
-  // ImportModelWithGGUF/HydrateTensorProtoFromGGUF in
-  // tensor_pool_gguf_bridge.h. Returns (updated model bytes, names of GGUF
-  // tensors present in the file but skipped because their ggml_type has no
+  // ImportModelWithGGUFToPool/HydrateTensorProtoFromGGUF in
+  // tensor_pool_gguf_bridge.h. Returns (byte-free model bytes, the matched
+  // tensors' already-decoded bytes as a TensorPool, names of GGUF tensors
+  // present in the file but skipped because their ggml_type has no
   // representation TensorPool can hold at all, e.g. a legacy Q4_0 or IQ*-
   // family tensor -- NOT tensors simply absent from `model`'s
   // initializers, which this silently leaves alone rather than reporting).
+  // Splitting the matched tensors out into a TensorPool, rather than
+  // writing them into `model` and returning the whole thing serialized,
+  // avoids a full protobuf encode (here) + decode (Python) of the
+  // (potentially huge) newly-hydrated tensor data on top of the copies
+  // ImportModelWithGGUFToPool already makes.
   m.def(
       "import_gguf_weights",
       [](const py::bytes& model_bytes, const std::string& gguf_path)
-          -> std::tuple<py::bytes, std::vector<std::string>> {
+          -> std::tuple<py::bytes, onnxsim::tensor_pool::TensorPool,
+                        std::vector<std::string>> {
         onnx::ModelProto model;
         ParseProtoFromBytes(&model, model_bytes.c_str(), model_bytes.size());
-        onnxsim::tensor_pool::TensorPool pool;
+        onnxsim::tensor_pool::TensorPool matched;
         std::vector<std::string> skipped;
-        onnxsim::tensor_pool::ImportModelWithGGUF(model, gguf_path, pool,
-                                                  /*hydrate_all=*/true,
-                                                  &skipped);
+        onnxsim::tensor_pool::ImportModelWithGGUFToPool(model, gguf_path,
+                                                        matched, &skipped);
         const std::string out = model.SerializeAsString();
-        return {py::bytes(out.data(), out.size()), std::move(skipped)};
+        return {py::bytes(out.data(), out.size()), std::move(matched),
+                std::move(skipped)};
       },
       "model_bytes"_a, "gguf_path"_a);
 

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -628,20 +628,36 @@ def import_gguf_weights(
             alone except for a matched K-quant tensor, whose data_type is
             forced to FLOAT (the only meaningful type for a dequantized
             result) regardless of what the initializer previously declared.
+            Never mutated by this call, whether passed in directly or
+            loaded from a path.
     :param gguf_path: path to the GGUF file to pull weight values from
-    :returns: ``(model, skipped)`` -- the hydrated model, and the names of
-            GGUF tensors present in the file but skipped because their
-            quantized format has no decoder here (the legacy ``Q4_0``
-            family, every ``IQ*`` variant, ...). A GGUF tensor with no
-            matching initializer name in ``model`` is simply not brought
-            in -- it does NOT appear in ``skipped``, which reports only
-            unsupported *formats*, not name mismatches.
+    :returns: ``(model, skipped)`` -- the hydrated model (a distinct object
+            from ``model``, if a ``ModelProto`` was passed in), and the
+            names of GGUF tensors present in the file but skipped because
+            their quantized format has no decoder here (the legacy
+            ``Q4_0`` family, every ``IQ*`` variant, ...). A GGUF tensor
+            with no matching initializer name in ``model`` is simply not
+            brought in -- it does NOT appear in ``skipped``, which reports
+            only unsupported *formats*, not name mismatches.
     """
     if isinstance(model, str):
         model = onnx.load(model, load_external_data=False)
-    model_bytes, skipped = C.import_gguf_weights(model.SerializeToString(), gguf_path)
+    # C++ only ever clears/rewrites a *matched* initializer's raw_data --
+    # every unmatched one crosses back out untouched, still carrying
+    # whatever `model` already had -- so the matched ones are the only
+    # ones that need filling in here; a matched tensor's OLD value never
+    # needs to survive the round trip at all, so there's nothing to
+    # extract-and-restore on the way in either (unlike export_gguf, which
+    # strips every tensor's raw_data because ALL of it needs to cross).
+    model_bytes, matched, skipped = C.import_gguf_weights(
+        model.SerializeToString(), gguf_path
+    )
     result = onnx.ModelProto()
     result.ParseFromString(model_bytes)
+    for init in result.graph.initializer:
+        if init.name in matched:
+            init.data_type = matched.dtype(init.name)
+            init.raw_data = matched.bytes(init.name)
     return result, skipped
 
 

--- a/onnxsim/tensor_pool_gguf_bridge.h
+++ b/onnxsim/tensor_pool_gguf_bridge.h
@@ -182,6 +182,48 @@ inline size_t ImportModelWithGGUF(
   return matched;
 }
 
+// Like ImportModelWithGGUF(hydrate_all=true), but instead of writing each
+// matched tensor's decoded bytes directly into `model`'s initializer (which
+// a caller crossing an FFI boundary would then have to pay a full
+// protobuf encode/decode of, on top of the copies below already make --
+// see AdoptAllWithPlaceholderOffsets's analogous external_tensor_bytes
+// design for the export direction), stashes them into a fresh `matched`
+// pool instead, keyed by initializer name, and clears the (now-superseded,
+// since it's about to be overwritten) old raw_data from the initializer in
+// `model` -- so a caller only has to serialize/return a byte-free `model`
+// plus `matched`, and fill each matched initializer in on its own side
+// (`matched.dtype(name)`/`matched.bytes(name)`; a K-quant entry decodes to
+// FLOAT here exactly as HydrateTensorProtoFromGGUF would, so the caller
+// never needs to know which matches were K-quant). Reuses
+// HydrateTensorProtoFromGGUF unchanged (via a throwaway `scratch` per
+// matched tensor) rather than duplicating its K-quant-vs-raw-dtype
+// decode logic. Returns the number of tensors matched (== `matched`.size()
+// once this returns); `skipped_out` has the same meaning as
+// ImportModelWithGGUF's.
+inline size_t ImportModelWithGGUFToPool(
+    onnx::ModelProto& model, const std::string& gguf_path, TensorPool& matched,
+    std::vector<std::string>* skipped_out = nullptr) {
+  TensorPool file_pool;
+  std::vector<std::string> skipped = file_pool.LoadGGUF(gguf_path);
+  if (skipped_out != nullptr) *skipped_out = std::move(skipped);
+
+  size_t n = 0;
+  for (auto& init : *model.mutable_graph()->mutable_initializer()) {
+    onnx::TensorProto scratch;
+    scratch.set_data_type(init.data_type());
+    *scratch.mutable_dims() = init.dims();
+    if (!HydrateTensorProtoFromGGUF(init.name(), scratch, file_pool)) continue;
+
+    std::vector<int64_t> shape(scratch.dims().begin(), scratch.dims().end());
+    std::unique_ptr<std::string> bytes(scratch.release_raw_data());
+    matched.Add(init.name(), scratch.data_type(), std::move(shape),
+                std::move(*bytes));
+    init.clear_raw_data();
+    ++n;
+  }
+  return n;
+}
+
 // GGUF counterparts of tensor_pool_bridge.h's SaveModelAsSafetensors /
 // LoadModelFromSafetensors -- see that header's top comment for the
 // self-describing-archive design (EmbedModel/ExtractModel, which these

--- a/onnxsim/tensor_pool_gguf_bridge_test.cpp
+++ b/onnxsim/tensor_pool_gguf_bridge_test.cpp
@@ -398,6 +398,98 @@ void TestImportModelWithGGUFDecodesKQuant() {
   std::remove(path.c_str());
 }
 
+// ImportModelWithGGUFToPool is import_gguf_weights's FFI-friendly sibling of
+// ImportModelWithGGUF(hydrate_all=true): same K-quant decode
+// (HydrateTensorProtoFromGGUF, reused unchanged), but the matched tensor's
+// bytes land in a caller-supplied pool -- keyed by name, dtype-normalized
+// exactly like the direct-hydration path -- instead of being written into
+// `model`, which is left with that initializer's raw_data cleared (not
+// hydrated) and every unmatched initializer completely untouched.
+void TestImportModelWithGGUFToPool() {
+  std::string path = TempPath("_to_pool_import.gguf");
+  {
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    auto write_string = [&](const std::string& s) {
+      WriteLE<uint64_t>(out, s.size());
+      out.write(s.data(), static_cast<std::streamsize>(s.size()));
+    };
+    WriteLE<uint32_t>(out, kMagic);
+    WriteLE<uint32_t>(out, kSupportedVersion);
+    WriteLE<uint64_t>(out, 1);  // tensor_count
+    WriteLE<uint64_t>(out, 0);  // metadata_kv_count
+
+    write_string("w");
+    WriteLE<uint32_t>(out, 1);
+    WriteLE<uint64_t>(out, 32);  // ne[0]
+    WriteLE<uint32_t>(out, GGML_TYPE_Q8_0);
+    WriteLE<uint64_t>(out, 0);  // offset
+
+    uint64_t header_end = static_cast<uint64_t>(out.tellp());
+    uint64_t data_start = (header_end + kDefaultAlignment - 1) /
+                          kDefaultAlignment * kDefaultAlignment;
+    for (uint64_t i = header_end; i < data_start; ++i) out.put('\0');
+    WriteLE<uint16_t>(out, 0x4000);  // d = 2.0 (fp16)
+    for (int i = 0; i < 32; ++i) {
+      out.put(static_cast<char>(static_cast<int8_t>(i - 16)));  // qs[i]
+    }
+  }
+
+  onnx::ModelProto model;
+  auto* w = model.mutable_graph()->add_initializer();
+  w->set_name("w");
+  w->set_data_type(onnx::TensorProto::INT32);  // deliberately wrong
+  w->add_dims(32);
+  const std::string kept_bytes = "unmatched-bytes";
+  *model.mutable_graph()->add_initializer() =
+      MakeInitializer("untouched", onnx::TensorProto::FLOAT, {1}, kept_bytes);
+
+  TensorPool matched;
+  std::vector<std::string> skipped;
+  size_t n = ImportModelWithGGUFToPool(model, path, matched, &skipped);
+  Check(n == 1, "one tensor matched");
+  Check(matched.size() == 1, "the pool holds exactly the matched tensor");
+  Check(skipped.empty(), "nothing skipped -- Q8_0 is a supported K-quant type");
+
+  const auto& w_after = model.graph().initializer(0);
+  Check(!w_after.has_raw_data(),
+        "the matched initializer's OLD raw_data is cleared, not hydrated, "
+        "in `model` itself -- the caller fills it in from `matched`");
+  Check(w_after.data_type() == onnx::TensorProto::INT32,
+        "model itself is untouched beyond clearing raw_data -- data_type "
+        "override only applies to the pool entry, mirroring how a caller "
+        "would apply it");
+
+  const auto& untouched_after = model.graph().initializer(1);
+  Check(untouched_after.has_raw_data() &&
+            untouched_after.raw_data() == kept_bytes,
+        "the unmatched initializer is completely untouched");
+
+  const Entry* entry = matched.Find("w");
+  Check(entry != nullptr, "pool has an entry for the matched tensor");
+  bool values_ok = entry != nullptr &&
+                   entry->dtype == onnx::TensorProto::FLOAT &&
+                   entry->data.size() == 32 * sizeof(float);
+  Check(values_ok, "pool entry is FLOAT32 (K-quant decode target), 32 values");
+  if (values_ok) {
+    std::string bytes(entry->data);
+    if constexpr (!onnxsim::dlpack::kRawDataIsHostOrder) {
+      onnxsim::dlpack::SwapElementBytes(
+          reinterpret_cast<uint8_t*>(bytes.data()), bytes.size(),
+          sizeof(float));
+    }
+    float floats[32];
+    std::memcpy(floats, bytes.data(), sizeof(floats));
+    for (int i = 0; i < 32 && values_ok; ++i) {
+      float want = static_cast<float>(i - 16) * 2.0f;
+      values_ok = std::fabs(floats[i] - want) < 1e-4f;
+    }
+  }
+  Check(values_ok,
+        "pool entry decodes to (i - 16) * 2.0, same as direct hydration");
+
+  std::remove(path.c_str());
+}
+
 }  // namespace
 
 int main() {
@@ -407,6 +499,7 @@ int main() {
   TestImportModelWithGGUFLazy();
   TestImportModelWithGGUFSkipsQuantized();
   TestImportModelWithGGUFDecodesKQuant();
+  TestImportModelWithGGUFToPool();
 
   if (g_failures == 0) {
     std::printf("tensor_pool_gguf_bridge_test: all checks passed\n");

--- a/tests/test_import_gguf_weights.py
+++ b/tests/test_import_gguf_weights.py
@@ -260,3 +260,53 @@ def test_import_raw_dtype_passthrough(tmp_path):
     w = next(i for i in result.graph.initializer if i.name == "W")
     got = onnx.numpy_helper.to_array(w)
     np.testing.assert_array_equal(got, values)
+
+
+def test_import_leaves_input_model_unchanged_and_preserves_unmatched(tmp_path):
+    # Regression test for the C.import_gguf_weights binding change: matched
+    # tensors' bytes now come back as a separate TensorPool instead of being
+    # written into a fully re-serialized model (the same double protobuf
+    # round-trip load_model/import_safetensors/import_gguf were fixed for),
+    # so the caller's own `model` object must come back untouched, and an
+    # initializer with NO match in the GGUF file must keep its original
+    # value in `result` -- both are easy to get wrong when the matched and
+    # unmatched tensors take different code paths on the way back.
+    rng = np.random.default_rng(5)
+    raw, expected = _make_q8_0_block(rng)
+    gguf_path = str(tmp_path / "model.gguf")
+    _write_gguf(gguf_path, [("matched", GGML_TYPE_Q8_0, [32], raw)])
+
+    unmatched_value = np.array([9.0, 9.0, 9.0, 9.0], dtype=np.float32)
+    model = _model(
+        """
+        g () => (float[32] Y, float[4] Z)
+        {
+          Y = Identity(matched)
+          Z = Identity(unmatched)
+        }
+        """,
+        initializer=[
+            onnx.numpy_helper.from_array(np.zeros(32, dtype=np.float32), "matched"),
+            onnx.numpy_helper.from_array(unmatched_value, "unmatched"),
+        ],
+    )
+    before = onnx.ModelProto()
+    before.CopyFrom(model)
+
+    result, skipped = onnxsim.import_gguf_weights(model, gguf_path)
+
+    assert model == before, "import_gguf_weights must not mutate its input"
+    assert skipped == []
+
+    matched_init = next(i for i in result.graph.initializer if i.name == "matched")
+    assert matched_init.data_type == onnx.TensorProto.FLOAT
+    np.testing.assert_allclose(
+        onnx.numpy_helper.to_array(matched_init),
+        np.array(expected, dtype=np.float32),
+        rtol=1e-5,
+    )
+
+    unmatched_init = next(i for i in result.graph.initializer if i.name == "unmatched")
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(unmatched_init), unmatched_value
+    )


### PR DESCRIPTION
## Summary
- `import_gguf_weights` had the same double protobuf round-trip bug already fixed in `load_model`/`export_safetensors`/`export_gguf`/`import_safetensors`/`import_gguf` (#884): it hydrated matched initializers directly into the `ModelProto` in C++, then paid a full protobuf encode (C++) + decode (Python) of the *whole* model -- including every newly-hydrated tensor's bytes -- to cross the FFI boundary.
- Add `ImportModelWithGGUFToPool` (`tensor_pool_gguf_bridge.h`), which reuses `HydrateTensorProtoFromGGUF`'s existing K-quant-vs-raw-dtype decode logic unchanged (via a throwaway scratch tensor) but stashes each matched tensor's already-decoded bytes into a separate `TensorPool` instead of writing them into the model, clearing the (now-superseded) old `raw_data` from the matching initializer. This keeps the K-quant dequantization logic (which only exists in C++) fully in C++, while letting the FFI-crossing side follow the same "return a byte-free model + a TensorPool" shape already used by `load_model`/`import_safetensors`/`import_gguf`.
- The Python wrapper fills each matched initializer in directly from the returned pool (dtype included, since a K-quant match forces `FLOAT`); every unmatched initializer crosses back completely untouched -- no extraction/restoration needed on the Python side, since C++ only ever clears a *matched* initializer's `raw_data`.

Measured on a 2000-tensor/40MB synthetic GGUF checkpoint (min of 5 runs) for the documented intended usage (an empty-placeholder graph being filled in): **~2x faster (104ms -> 51ms)**.

I initially tried a version that pre-emptively stripped/restored the whole graph in Python (mirroring the export-side fix), but that actually made the "everything matches" case *slower* (134ms) -- it added a redundant extract-then-immediately-discard pass for tensors about to be overwritten anyway. Letting C++ handle the split (only clearing what's actually matched) avoided that regression.

## Test plan
- [x] New C++ unit test in `tensor_pool_gguf_bridge_test.cpp` (`TestImportModelWithGGUFToPool`): verifies the matched tensor's decoded bytes/dtype land in the returned pool, the matching initializer's `raw_data` is cleared (not hydrated) in `model` itself, and an unmatched initializer is left completely untouched.
- [x] New pytest case in `tests/test_import_gguf_weights.py`: `import_gguf_weights` leaves the input model unchanged and preserves an initializer with no GGUF match, alongside a K-quant-decoded match.
- [x] Full existing `tensor_pool_gguf_bridge_test`, `tests/test_import_gguf_weights.py`, and `tests/test_python_api.py` suites pass (no regressions).
- [x] `clang-format`, `ruff format`/`ruff check`, and `mypy` all clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqY6mNXsYwstPjnuHGUR3M

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqY6mNXsYwstPjnuHGUR3M)_