### PR TITLE
Add quantize_weight_only_kmeans: per-layer k-means weight codebook

### DIFF
--- a/docs/kmeans-quantization.md
+++ b/docs/kmeans-quantization.md
@@ -1,0 +1,76 @@
+# K-means weight-codebook quantization (`quantize_weight_only_kmeans`)
+
+## What this is
+
+`onnxsim.quantize_weight_only_kmeans` fits a small codebook to each
+layer's own weight values via ordinary k-means clustering, then stores
+one codebook index per weight instead of the weight itself.
+
+```
+Before:
+  Y = MatMul(X, W) [+ bias]                 -- W constant, [K, N], float32
+
+After:
+  Codebook: initializer, float32, [2**bits]  -- this LAYER's own fitted centroids
+  Codes: initializer, uint8, [K, N]           -- codebook index per element
+  Whatever_hat = Gather(Codebook, Cast(Codes, INT64), axis=0)
+  Y = MatMul(X, Whatever_hat) [+ bias]
+```
+
+Unlike every other codebook-based scheme in onnxsim, no per-block scale
+or `Reshape`/`Mul` is needed at all: since k-means clusters the weight's
+own values directly (not a normalized `[-1, 1]` range), the codebook
+entry gathered *is* the reconstructed weight.
+
+## Where this comes from
+
+[Deep Compression](https://arxiv.org/abs/1510.00149) (Han et al., 2015,
+Section 3) introduces "trained quantization": cluster a layer's weight
+values, share one codebook entry across every weight assigned to a
+cluster, then fine-tune the codebook's own values against the network's
+training loss. This module ports the *clustering* half via an ordinary,
+from-scratch Lloyd's-algorithm k-means fit (alternate assigning each
+weight to its nearest centroid, then recomputing each centroid as the
+mean of its assigned weights, until convergence) -- not the paper's own
+gradient-based codebook fine-tuning afterward, a training loop with no
+ONNX export path (the same reason `apply_gptq`/`apply_awq` port their own
+papers' *algorithms*, not any framework's live-training code). The
+pruning half of the same paper is already covered separately by
+`onnxsim.apply_magnitude_pruning`.
+
+Every codebook-based scheme already in onnxsim (`onnxsim.nf4`,
+`onnxsim.mx_quantization`) uses a **fixed** codebook -- chosen once by
+the format's own definition, identical for every tensor. This module's
+codebook is the opposite: fit *per layer*, directly to that layer's own
+weight distribution -- the classical, verifiable procedure for fitting a
+codebook to actual data, as opposed to NF4/MXFP4's fixed choices or
+`apply_spinquant`'s eigenbasis (a *rotation*, not a scalar codebook).
+
+## Scope
+
+Handled:
+
+- `MatMul(X, W)` with `W` a constant 2-D float32 tensor, or `Gemm(X, W[, B])`
+  with `transA=0`, `alpha=1`, `beta=1` (when `B` is present). `transB`
+  may be 0 or 1. No block-size or reduction-dimension divisibility
+  constraint -- clustering works on the flattened weight regardless of
+  shape.
+- `skip_names` to leave specific matched weights unquantized.
+
+Left untouched (safe no-op, node passes through as-is):
+
+- Non-constant or non-2-D weights.
+
+## Usage
+
+```python
+import onnx
+import onnxsim
+
+model = onnx.load("model.onnx")
+quantized = onnxsim.quantize_weight_only_kmeans(model, bits=4, iters=20)
+onnx.save(quantized, "model.kmeans.onnx")
+```
+
+Needs no calibration data: the codebook is fit entirely from the weight
+tensor's own values.

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -43,6 +43,7 @@ from onnxsim.gguf_reconstruct import (
 )
 from onnxsim.gptq import apply_gptq
 from onnxsim.hqq import quantize_weight_only_int4_hqq
+from onnxsim.kmeans_quantization import quantize_weight_only_kmeans
 from onnxsim.kv_cache_quantization import quantize_kv_cache
 from onnxsim.llm_int8 import apply_llm_int8
 from onnxsim.low_rank_compensation import apply_low_rank_compensation
@@ -158,6 +159,7 @@ __all__ = [
     "quantize_weight_only",
     "quantize_weight_only_int4",
     "quantize_weight_only_int4_hqq",
+    "quantize_weight_only_kmeans",
     "quantize_weight_only_nf4",
     "NF4_CODEBOOK",
     "quantize_weight_only_mxfp4",

--- a/onnxsim/kmeans_quantization.py
+++ b/onnxsim/kmeans_quantization.py
@@ -1,0 +1,202 @@
+"""K-means weight-codebook quantization (Han et al., 2015, "Deep
+Compression: Compressing Deep Neural Networks with Pruning, Trained
+Quantization and Huffman Coding", https://arxiv.org/abs/1510.00149,
+Section 3's own "trained quantization" -- the weight-sharing half of that
+paper; the pruning half is already covered by
+:mod:`onnxsim.pruning`/:mod:`onnxsim.apply_magnitude_pruning`). onnxsim
+ports the *idea* (cluster a layer's own weight values, share one codebook
+entry across every weight assigned to a cluster) via an ordinary,
+from-scratch Lloyd's-algorithm k-means fit -- not the paper's own
+gradient-based fine-tuning of the codebook after clustering (a training
+loop with no ONNX export path, the same reason :mod:`onnxsim.gptq`/
+:mod:`onnxsim.awq` port their own papers' *algorithms* rather than any
+framework's live-training code).
+
+Every codebook-based scheme already in onnxsim (:mod:`onnxsim.nf4`,
+:mod:`onnxsim.mx_quantization`) uses a **fixed** codebook -- 16 values
+chosen once, by the format's own definition (a standard normal
+distribution's quantile points for NF4; a 4-bit float format's own bit
+patterns for MXFP4), identical for every tensor. This module's codebook
+is the opposite: it is fit *per layer*, directly to that layer's own
+weight distribution, via k-means (Lloyd's algorithm: alternate assigning
+each weight to its nearest centroid, then recomputing each centroid as
+the mean of the weights assigned to it, until convergence or a fixed
+iteration budget) -- the classical, closed-form-per-iteration, verifiable
+procedure for fitting a codebook to actual data, as opposed to NF4/MXFP4's
+"the codebook needs no fitting because it isn't data-derived at all" or
+:mod:`onnxsim.spinquant`'s eigenbasis (a *rotation*, not a scalar
+codebook).
+
+Because the codebook is fit directly to real weight values (not to a
+*normalized* [-1, 1] range the way NF4's is), no per-block scale is
+needed at all -- the graph is simply:
+
+    Before:
+      Y = MatMul(X, W) [+ bias]                 -- W constant, [K, N], float32
+
+    After:
+      Codebook: initializer, float32, [2**bits]  -- this LAYER's own fitted centroids
+      Codes: initializer, uint8, [K, N]           -- codebook index per element
+      Whatever_hat = Gather(Codebook, Cast(Codes, INT64), axis=0)
+      Y = MatMul(X, Whatever_hat) [+ bias]
+
+-- two ordinary ops, no ``Reshape``/``Mul`` needed (unlike
+:mod:`onnxsim.nf4`, which reshapes to broadcast a *separate* per-block
+scale against its codebook lookup): here the gathered codebook value
+already *is* the reconstructed weight, since clustering was already done
+directly in the weight's own units.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+
+from onnxsim.bias_correction import _all_names, _unique_name
+from onnxsim.quip_sharp import _match_matmul_like
+
+
+def _kmeans_1d(
+    values: np.ndarray, k: int, iters: int, seed: int
+) -> "tuple[np.ndarray, np.ndarray]":
+    """Ordinary Lloyd's-algorithm k-means over a flat array of scalar
+    values. Returns ``(centroids, assignments)``: ``k`` fitted cluster
+    centers and, for each element of ``values``, its nearest centroid's
+    index.
+
+    Centroids are initialized at ``k`` evenly-spaced percentiles of
+    ``values`` itself (not uniformly random) -- a deterministic choice
+    that already roughly matches the data's own distribution shape,
+    converging in far fewer iterations than random initialization would
+    for the skewed, near-zero-centered distributions real weight tensors
+    have.
+    """
+    rng = np.random.default_rng(seed)
+    percentiles = np.linspace(0, 100, k)
+    centroids = np.unique(np.percentile(values, percentiles))
+    if centroids.shape[0] < k:
+        extra = rng.choice(values, size=k - centroids.shape[0], replace=True)
+        centroids = np.concatenate([centroids, extra])
+    centroids = centroids.astype(np.float64)
+
+    assignments = np.zeros(values.shape[0], dtype=np.int64)
+    for _ in range(iters):
+        distances = np.abs(values[:, np.newaxis] - centroids[np.newaxis, :])
+        assignments = np.argmin(distances, axis=1)
+        new_centroids = centroids.copy()
+        for c in range(k):
+            mask = assignments == c
+            if mask.any():
+                new_centroids[c] = values[mask].mean()
+        if np.allclose(new_centroids, centroids):
+            centroids = new_centroids
+            break
+        centroids = new_centroids
+
+    distances = np.abs(values[:, np.newaxis] - centroids[np.newaxis, :])
+    assignments = np.argmin(distances, axis=1)
+    return centroids, assignments
+
+
+def quantize_weight_only_kmeans(
+    model: Union[str, onnx.ModelProto],
+    bits: int = 4,
+    iters: int = 20,
+    seed: int = 0,
+    skip_names: Optional["set[str]"] = None,
+) -> onnx.ModelProto:
+    """Quantizes every MatMul/vanilla-Gemm layer with a constant 2-D
+    float32 weight into a per-layer k-means-fitted codebook -- see this
+    module's own docstring for the technique. Needs no calibration data:
+    the codebook is fit directly to the weight tensor's own values.
+
+    :param model: the original (unquantized) onnx ModelProto or file path
+    :param bits: codebook size is ``2**bits`` (default 4, matching every
+            other onnxsim scheme's own INT4-equivalent storage: 1 byte
+            per weight for the code plus one small, shared codebook, same
+            as :func:`onnxsim.quantize_weight_only_nf4`)
+    :param iters: maximum Lloyd's-algorithm iterations per layer (stops
+            early once no weight changes cluster assignment)
+    :param seed: seed for the random fallback samples used only if a
+            layer's own percentile-based centroid initialization yields
+            fewer than ``2**bits`` distinct starting points (e.g. a
+            weight with many repeated/zero values)
+    :param skip_names: weight initializer names to leave unquantized even
+            if otherwise eligible
+    :returns: ``model`` with every matched layer's weight replaced by
+            ``Gather(Codebook, Cast(Codes, INT64), axis=0)`` feeding the
+            original MatMul/Gemm node -- ordinary ONNX ops only, no
+            contrib op and no minimum opset beyond what
+            ``Gather``/``Cast`` themselves need (opset 11+). Layers with
+            a non-constant or non-2-D weight are left untouched.
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    skip_set: "set[str]" = set(skip_names) if skip_names is not None else set()
+
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    graph = out.graph
+    initializer_map = {t.name: t for t in graph.initializer}
+    taken_names = _all_names(graph)
+    num_codes = 2**bits
+
+    nodes = list(graph.node)
+    for node in nodes:
+        match = _match_matmul_like(node)
+        if match is None:
+            continue
+        _x_name, w_name, _bias_name, _weight_transposed = match
+        if w_name in skip_set:
+            continue
+        w_init = initializer_map.get(w_name)
+        if (
+            w_init is None
+            or w_init.data_type != onnx.TensorProto.FLOAT
+            or len(w_init.dims) != 2
+        ):
+            continue
+
+        w = onnx.numpy_helper.to_array(w_init).astype(np.float64)
+        dim0, dim1 = w.shape
+        flat = w.reshape(-1)
+
+        centroids, assignments = _kmeans_1d(flat, num_codes, iters, seed)
+        codes = assignments.reshape(dim0, dim1).astype(np.uint8)
+
+        prefix = f"{w_name}_kmeans"
+        codebook_name = _unique_name(f"{prefix}_codebook", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(
+                centroids.astype(np.float32), name=codebook_name
+            )
+        )
+        codes_name = _unique_name(f"{prefix}_codes", taken_names)
+        graph.initializer.append(onnx.numpy_helper.from_array(codes, name=codes_name))
+
+        cast_out = _unique_name(f"{prefix}_codes_i64", taken_names)
+        cast_node = onnx.helper.make_node(
+            "Cast", [codes_name], [cast_out], to=onnx.TensorProto.INT64
+        )
+        dq_out = _unique_name(f"{prefix}_dq", taken_names)
+        gather_node = onnx.helper.make_node(
+            "Gather",
+            [codebook_name, cast_out],
+            [dq_out],
+            axis=0,
+            name=_unique_name(f"{prefix}_gather_node", taken_names),
+        )
+
+        node_idx = next(i for i, n in enumerate(graph.node) if n is node)
+        graph.node.insert(node_idx, cast_node)
+        graph.node.insert(node_idx + 1, gather_node)
+
+        for i, inp in enumerate(node.input):
+            if inp == w_name:
+                node.input[i] = dq_out
+
+    return out

--- a/tests/test_kmeans_quantization.py
+++ b/tests/test_kmeans_quantization.py
@@ -1,0 +1,245 @@
+"""Tests for ``onnxsim.quantize_weight_only_kmeans`` -- see
+``onnxsim/kmeans_quantization.py`` for the technique (a per-layer,
+k-means-fitted weight codebook -- unlike NF4/MXFP4's fixed, data-independent
+codebooks -- represented via ordinary Gather/Cast, no scale multiply needed).
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _model(body, initializer=(), opset=13, ir_version=8):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _matmul_model(K=32, N=8, weight=None, seed=0):
+    if weight is None:
+        rng = np.random.default_rng(seed)
+        weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[_f32(weight, "W")],
+    )
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
+
+
+def _dequantize_by_hand(model, w_name="W"):
+    codebook = onnx.numpy_helper.to_array(
+        next(
+            t for t in model.graph.initializer if t.name == f"{w_name}_kmeans_codebook"
+        )
+    ).astype(np.float64)
+    codes = onnx.numpy_helper.to_array(
+        next(t for t in model.graph.initializer if t.name == f"{w_name}_kmeans_codes")
+    ).astype(np.int64)
+    return codebook[codes]
+
+
+def test_kmeans_quantizes_matmul_with_standard_ops_only():
+    model = _matmul_model(K=32, N=8, seed=0)
+    q = onnxsim.quantize_weight_only_kmeans(model)
+    onnx.checker.check_model(q)
+
+    op_types = {n.op_type for n in q.graph.node}
+    assert op_types <= {"MatMul", "Cast", "Gather"}
+    assert all(n.domain in ("", "ai.onnx") for n in q.graph.node)
+
+
+def test_kmeans_codebook_has_2_pow_bits_entries():
+    model = _matmul_model(K=32, N=8, seed=1)
+    q = onnxsim.quantize_weight_only_kmeans(model, bits=4)
+    codebook = next(t for t in q.graph.initializer if t.name == "W_kmeans_codebook")
+    assert onnx.numpy_helper.to_array(codebook).shape == (16,)
+
+
+def test_kmeans_dequantized_values_are_close_to_original():
+    rng = np.random.default_rng(2)
+    weight = rng.standard_normal((32, 8)).astype(np.float32) * 0.5
+    model = _matmul_model(weight=weight)
+    q = onnxsim.quantize_weight_only_kmeans(model, bits=4, iters=30)
+
+    w_hand = _dequantize_by_hand(q)
+    # A well-converged 16-centroid k-means fit to ~256 Gaussian samples
+    # should get most weights within a small fraction of the tensor's own
+    # standard deviation -- a real fit-quality check, not just "it runs".
+    assert np.sqrt(np.mean((w_hand - weight.astype(np.float64)) ** 2)) < 0.05
+
+
+def test_kmeans_two_different_layers_get_different_codebooks():
+    # The whole point vs. NF4/MXFP4: each layer's codebook is fit to
+    # THAT layer's own data, not shared globally.
+    rng = np.random.default_rng(3)
+    w1 = rng.standard_normal((32, 8)).astype(np.float32) * 0.1
+    w2 = rng.standard_normal((32, 8)).astype(np.float32) * 5.0
+    nodes = [
+        onnx.helper.make_node("MatMul", ["X", "W1"], ["H"]),
+        onnx.helper.make_node("MatMul", ["H", "W2"], ["Y"]),
+    ]
+    graph = onnx.helper.make_graph(
+        nodes,
+        "g",
+        [onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, [4, 32])],
+        [onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [4, 8])],
+        [_f32(w1, "W1"), _f32(w2, "W2")],
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 13)], ir_version=8
+    )
+    q = onnxsim.quantize_weight_only_kmeans(model)
+    cb1 = onnx.numpy_helper.to_array(
+        next(t for t in q.graph.initializer if t.name == "W1_kmeans_codebook")
+    )
+    cb2 = onnx.numpy_helper.to_array(
+        next(t for t in q.graph.initializer if t.name == "W2_kmeans_codebook")
+    )
+    assert not np.allclose(np.sort(cb1), np.sort(cb2))
+    # w2's own scale (~5.0) should be reflected in its own codebook's range.
+    assert np.abs(cb2).max() > np.abs(cb1).max() * 5
+
+
+def test_kmeans_output_stays_close_to_float_via_onnxruntime():
+    model = _matmul_model(K=32, N=8, seed=4)
+    q = onnxsim.quantize_weight_only_kmeans(model)
+    onnx.checker.check_model(q)
+
+    rng = np.random.default_rng(5)
+    x = rng.standard_normal((8, 32)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x})
+    (q_y,) = _run(q, {"X": x})
+    assert np.all(np.isfinite(q_y))
+    assert _rel_l2(float_y, q_y) < 0.2
+
+
+def test_kmeans_gemm_transb():
+    rng = np.random.default_rng(6)
+    K, N = 32, 12
+    weight = rng.standard_normal((N, K)).astype(np.float32) * 0.5
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = Gemm<transB = 1>(X, W)
+        }}
+        """,
+        initializer=[_f32(weight, "W")],
+    )
+    q = onnxsim.quantize_weight_only_kmeans(model)
+    onnx.checker.check_model(q)
+
+    x = rng.standard_normal((4, K)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x})
+    (q_y,) = _run(q, {"X": x})
+    assert _rel_l2(float_y, q_y) < 0.2
+
+
+def test_kmeans_codes_stay_in_range():
+    rng = np.random.default_rng(7)
+    weight = rng.standard_normal((32, 8)).astype(np.float32) * 3
+    model = _matmul_model(weight=weight)
+    q = onnxsim.quantize_weight_only_kmeans(model, bits=4)
+    codes = onnx.numpy_helper.to_array(
+        next(t for t in q.graph.initializer if t.name == "W_kmeans_codes")
+    )
+    assert np.all(codes >= 0) and np.all(codes <= 15)
+
+
+def test_kmeans_skip_names_leaves_matched_weight_untouched():
+    rng = np.random.default_rng(8)
+    w_base = rng.standard_normal((32, 8)).astype(np.float32) * 0.5
+    w_other = rng.standard_normal((32, 4)).astype(np.float32) * 0.1
+    nodes = [
+        onnx.helper.make_node("MatMul", ["X", "W"], ["Y"]),
+        onnx.helper.make_node("MatMul", ["X", "W_other"], ["H"]),
+    ]
+    graph = onnx.helper.make_graph(
+        nodes,
+        "g",
+        [onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, [4, 32])],
+        [
+            onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [4, 8]),
+            onnx.helper.make_tensor_value_info("H", onnx.TensorProto.FLOAT, [4, 4]),
+        ],
+        [_f32(w_base, "W"), _f32(w_other, "W_other")],
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 13)], ir_version=8
+    )
+    q = onnxsim.quantize_weight_only_kmeans(model, skip_names={"W_other"})
+    onnx.checker.check_model(q)
+
+    names = {t.name for t in q.graph.initializer}
+    assert "W_kmeans_codebook" in names
+    assert "W_other_kmeans_codebook" not in names
+    other_out = next(
+        onnx.numpy_helper.to_array(t)
+        for t in q.graph.initializer
+        if t.name == "W_other"
+    )
+    assert np.array_equal(other_out, w_other)
+
+
+def test_kmeans_skips_non_constant_weight():
+    model = _model(
+        """
+        g (float[4,32] X, float[32,4] W) => (float[4,4] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """
+    )
+    q = onnxsim.quantize_weight_only_kmeans(model)
+    assert q.SerializeToString() == model.SerializeToString()
+
+
+def test_kmeans_noop_when_no_matmul_present():
+    nodes = [onnx.helper.make_node("Relu", ["X"], ["Y"])]
+    graph = onnx.helper.make_graph(
+        nodes,
+        "g",
+        [onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, [4, 4])],
+        [onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [4, 4])],
+        [],
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 13)], ir_version=8
+    )
+    result = onnxsim.quantize_weight_only_kmeans(model)
+    assert result.SerializeToString() == model.SerializeToString()


### PR DESCRIPTION
## Summary

- Adds `onnxsim.quantize_weight_only_kmeans`, porting [Deep Compression](https://arxiv.org/abs/1510.00149)'s (Han et al., 2015, Section 3) "trained quantization" — fitting a small codebook to each layer's own weight values via ordinary k-means clustering, then storing one codebook index per weight instead of the weight itself.
- Every codebook-based scheme already in onnxsim (`onnxsim.nf4`, `onnxsim.mx_quantization`) uses a **fixed** codebook — chosen once by the format's own definition, identical for every tensor. This module's codebook is the opposite: fit *per layer*, directly to that layer's own weight distribution, via an ordinary from-scratch Lloyd's-algorithm k-means implementation (not the paper's own gradient-based codebook fine-tuning afterward, a training loop with no ONNX export path).
- Because the codebook is fit directly to real weight values (not to a normalized `[-1, 1]` range the way NF4's is), no per-block scale or `Reshape`/`Mul` is needed at all — the graph is just `Gather(Codebook, Cast(Codes, INT64), axis=0)`, two ordinary ops, simpler than NF4's own graph.
- The pruning half of the same Deep Compression paper is already covered separately by `onnxsim.apply_magnitude_pruning`.

## Test plan

- [x] `tests/test_kmeans_quantization.py` (10 new tests): standard-ops-only graph check, codebook has `2**bits` entries, dequantized values are close to the original (a real fit-quality check), two different layers get genuinely different codebooks (the whole differentiator vs. NF4/MXFP4), float-vs-quantized closeness via onnxruntime, `Gemm(transB=1)`, codes stay in range, `skip_names`, and decline paths (non-constant weight, no matching op).
- [x] Full regression sweep (`pytest tests/ --ignore=tests/test_torch_export.py --ignore=tests/test_timm.py`): 1013 passed, 71 skipped, 0 failed.
- [x] `ruff format` / `ruff check` / `mypy` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW3JXCHQHB89MtA87MfJhU)_