### PR TITLE
Fix GQA/onnx-Attention cross-attention importance crash, confirm support

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -3980,6 +3980,86 @@ def apply_structured_wanda_pruning(
 #   ai.onnx Attention" section), the same oracle-vs-onnxruntime bar every
 #   other function in this module is held to; no structural-only fallback
 #   was needed.
+#
+# Cross-attention (Q projected from one source tensor, K/V from a genuinely
+# *different* one -- the encoder-decoder shape) was investigated explicitly
+# for all three matched op types, not left an untested assumption:
+#
+# - `com.microsoft::Attention`'s own contrib-op schema (`bert_defs.cc`, the
+#   same source consulted elsewhere in this module for `SkipLayerNormalization`)
+#   takes a single `input` tensor that its one merged weight projects to
+#   Q, K, *and* V alike -- there is no second, encoder-side input for K/V
+#   to come from at all. Cross-attention isn't a shape this op's schema can
+#   express, so it's simply not applicable here -- not a gap in
+#   :func:`_match_attention_producer` to close.
+# - `GroupQueryAttention` and the plain ``ai.onnx`` `Attention` op both
+#   already support it, confirmed by construction and by execution: neither
+#   :func:`_match_gqa_producer`/:func:`_match_onnx_attention_producer` nor
+#   :func:`_find_separate_qkv_chains` (their shared caller) ever compares
+#   Q's own producer against K's or V's own -- each of the three is matched,
+#   via :func:`_match_producer`, purely from its own MatMul/vanilla-Gemm
+#   node and its own weight, with no check tying it to where the *other two*
+#   ultimately trace back to. A model where Q's producer reads from one
+#   graph input and K/V's producers read from an entirely different one (a
+#   real decoder/encoder pair, potentially different feature dimensions
+#   too) matches exactly the same way a self-attention model does. Both
+#   ops' own schema docs name this explicitly -- `GroupQueryAttention`'s
+#   own doc string opens with "Group Query **Self/Cross** Attention", and
+#   the plain op's doc (`onnx.defs.get_schema("Attention", domain="")` on
+#   this environment's installed ``onnx==1.22.0``) states outright "this
+#   operator covers self and cross variants ... For cross attention, query
+#   and key might have different lengths" -- and this is verified here the
+#   same oracle-vs-onnxruntime way as everything else (see
+#   ``tests/test_pruning.py``'s own "cross-attention" subsections under the
+#   GroupQueryAttention/plain-Attention sections), with distinct source
+#   tensors of distinct feature dimensions feeding Q vs K/V.
+# - One real bug turned up along the way and is fixed here:
+#   :func:`_gqa_group_importance`'s combined-importance score used to
+#   ``np.concatenate`` each group's Q, K, and V weight *blocks* into one
+#   matrix before taking a single Frobenius norm -- silently assuming Q's
+#   own producer weight has the same row count (its source tensor's own
+#   feature dimension) as K/V's own, true for every self-attention shape
+#   but not guaranteed once Q and K/V read from different source tensors of
+#   different widths. On such a model it didn't mis-rank -- it raised a
+#   bare ``ValueError`` from numpy and crashed the whole pruning call. Fixed
+#   to combine each block's own Frobenius norm via
+#   ``sqrt(sum of squares)`` instead of concatenating first -- numerically
+#   identical to the old formula whenever the concatenation was even legal
+#   (``||[A B]||_F^2 == ||A||_F^2 + ||B||_F^2``), well-defined when it isn't
+#   -- see that function's own updated comment, and
+#   ``test_gqa_pruning_cross_attention_matches_oracle_exactly``/
+#   ``test_onnx_attention_pruning_cross_attention_matches_oracle_exactly``
+#   in ``tests/test_pruning.py`` (both fail with that bare ``ValueError``
+#   without this fix).
+# - The Wanda-calibrated variant's own activation probe
+#   (:func:`apply_attention_head_wanda_pruning`) sits at
+#   `chain.consumer_node.input[0]` -- the *single* tensor downstream of the
+#   matched op's own output projection, after Q/K/V have already been
+#   reduced to one attention output -- never at Q's or K/V's own activation
+#   directly, so it needs no per-source calibration-data key of its own and
+#   is unaffected by whether Q and K/V trace back to the same graph input or
+#   two different ones; a calibration batch dict simply needs an entry for
+#   every graph input the model actually has (both the decoder- and
+#   encoder-side ones for cross-attention), exactly as
+#   :func:`onnxsim.generate_random_calibration_data` already produces.
+# - `GroupQueryAttention`'s own real-world calling convention does impose
+#   one genuine restriction beyond this module's control: this environment's
+#   onnxruntime (1.29.0) CPU kernel requires Q's and K/V's sequence length
+#   to match unless a non-empty `past_key`/`past_value` is also supplied --
+#   confirmed empirically, not merely read off the schema doc, which
+#   promises cross-attention support without mentioning this -- and a
+#   non-empty constant `past_key`/`past_value` is already a shape
+#   :func:`_match_gqa_producer` declines outright (see its own docstring).
+#   A single-call `GroupQueryAttention` cross-attention model with a
+#   genuinely different K/V sequence length therefore isn't a topology this
+#   module ever has the chance to match in the first place -- an
+#   onnxruntime-kernel-level restriction on the op itself, not a limitation
+#   this module's own matching or pruning logic adds. The plain ``ai.onnx``
+#   `Attention` op has no such restriction (also confirmed empirically): its
+#   cross-attention test below uses genuinely different Q/K-V sequence
+#   lengths (as well as different source tensors and different feature
+#   dimensions) throughout, oracle-verified via onnxruntime with no
+#   restriction of this pass's own.
 _ATTENTION_DOMAIN = "com.microsoft"
 
 
@@ -4527,6 +4607,28 @@ def _gqa_group_importance(
     # at group instead of individual-head granularity, since a lone query
     # head can't be pruned out from under a shared KV head in isolation
     # (see this module's own "Attention-head pruning" section comment).
+    #
+    # Combined via sqrt(sum of squared per-block Frobenius norms) rather
+    # than norm(concatenate(q_block, k_block, v_block, axis=1)) -- the two
+    # are numerically identical whenever the concatenation is even legal
+    # (||[A B]||_F^2 == ||A||_F^2 + ||B||_F^2 for any A, B sharing a row
+    # count, since Frobenius norm squared is just the sum of every entry
+    # squared, and concatenating along columns doesn't change that sum) --
+    # but this form stays well-defined when it isn't: Q's own producer
+    # weight has as many rows as Q's own source tensor's feature dimension,
+    # while K/V's own producer weight has as many rows as K/V's own source
+    # tensor's feature dimension, and for cross-attention (Q and K/V drawn
+    # from genuinely different source tensors, e.g. a decoder/encoder pair)
+    # those two feature dimensions need not match at all -- an ordinary,
+    # correctly-matched shape this function must still rank, not one
+    # :func:`_match_gqa_producer`/:func:`_match_onnx_attention_producer`
+    # decline (nothing about either matcher, or :func:`_find_separate_qkv_chains`
+    # that calls them, ties Q's producer weight's row count to K/V's own --
+    # see this module's "Attention-head pruning" section comment for the
+    # confirmed-supported cross-attention shape this guards). The old
+    # concatenate-based form would raise a bare ``ValueError`` from numpy
+    # the moment it ran on such a model, crashing the whole pruning call
+    # instead of ranking it.
     d = chain.head_size
     group_size = chain.num_heads // chain.kv_num_heads
     importance = np.zeros(chain.kv_num_heads, dtype=np.float64)
@@ -4540,8 +4642,10 @@ def _gqa_group_importance(
         )
         k_block = wk[:, kv * d : (kv + 1) * d]
         v_block = wv[:, kv * d : (kv + 1) * d]
-        importance[kv] = np.linalg.norm(
-            np.concatenate([q_block, k_block, v_block], axis=1)
+        importance[kv] = np.sqrt(
+            np.linalg.norm(q_block) ** 2
+            + np.linalg.norm(k_block) ** 2
+            + np.linalg.norm(v_block) ** 2
         )
     return importance
 

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -4919,6 +4919,264 @@ def test_gqa_wanda_pruning_falls_back_to_plain_with_no_calibration_batches():
         np.testing.assert_array_equal(inits_plain[name], inits_wanda[name])
 
 
+# --- apply_attention_head_pruning / _wanda_pruning -- GroupQueryAttention,
+# cross-attention (Q and K/V from genuinely different source tensors) ------
+#
+# See onnxsim/pruning.py's own "Attention-head pruning" section comment for
+# the full investigation this proves: GroupQueryAttention's matchers never
+# tie Q's own producer to K/V's own, so a real encoder/decoder pair (Q from
+# one graph input, K/V from a different one, with its own different feature
+# dimension) matches and prunes correctly -- oracle-verified here exactly
+# like every self-attention GroupQueryAttention test above. Sequence length
+# is kept equal between the two source tensors (a real onnxruntime
+# GroupQueryAttention CPU-kernel restriction confirmed empirically, not a
+# limitation this module's own matching/pruning logic adds -- see that same
+# section comment); the plain ai.onnx Attention cross-attention section
+# further below uses genuinely different sequence lengths too, since that
+# op's own kernel has no such restriction.
+
+
+def _gqa_cross_model(
+    K_dec=8,
+    K_enc=6,
+    H=4,
+    KVH=2,
+    D=8,
+    Out=6,
+    seed=0,
+    batch=2,
+    seq=5,
+    wq=None,
+    wk=None,
+    wv=None,
+    wout=None,
+):
+    rng = np.random.default_rng(seed)
+    Nq, Nkv = H * D, KVH * D
+    if wq is None:
+        wq = rng.standard_normal((K_dec, Nq)).astype(np.float32)
+    if wk is None:
+        wk = rng.standard_normal((K_enc, Nkv)).astype(np.float32)
+    if wv is None:
+        wv = rng.standard_normal((K_enc, Nkv)).astype(np.float32)
+    if wout is None:
+        wout = rng.standard_normal((Nq, Out)).astype(np.float32)
+
+    initializer = [
+        _f32(wq, "Wq"),
+        _f32(wk, "Wk"),
+        _f32(wv, "Wv"),
+        _f32(wout, "Wout"),
+        onnx.numpy_helper.from_array(
+            np.full((batch,), seq - 1, dtype=np.int32), "SeqLensK"
+        ),
+        onnx.numpy_helper.from_array(np.array(seq, dtype=np.int32), "TotalSeq"),
+    ]
+
+    body = f"""
+        g (float[{batch},{seq},{K_dec}] Xdec, float[{batch},{seq},{K_enc}] Xenc) => (float[{batch},{seq},{Out}] Y)
+        {{
+          q = MatMul(Xdec, Wq)
+          k = MatMul(Xenc, Wk)
+          v = MatMul(Xenc, Wv)
+          ctx, pk, pv = com.microsoft.GroupQueryAttention <num_heads={H}, kv_num_heads={KVH}> (q, k, v, , , SeqLensK, TotalSeq)
+          Y = MatMul(ctx, Wout)
+        }}
+        """
+
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17, "com.microsoft": 1]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model, dict(
+        K_dec=K_dec,
+        K_enc=K_enc,
+        H=H,
+        KVH=KVH,
+        D=D,
+        Out=Out,
+        Nq=Nq,
+        Nkv=Nkv,
+        wq=wq,
+        wk=wk,
+        wv=wv,
+        wout=wout,
+        batch=batch,
+        seq=seq,
+    )
+
+
+def _oracle_keep_groups_cross(
+    wq, wk, wv, num_heads, kv_num_heads, head_size, keep_count
+):
+    # Like `_oracle_keep_groups` above, but combines each KV group's Q/K/V
+    # block importance via sqrt(sum of squared per-block Frobenius norms)
+    # rather than norm(concatenate(...)) -- required once wq's own row count
+    # (Q's source tensor's own feature dimension) differs from wk's/wv's own
+    # (K/V's source tensor's own feature dimension), exactly the shape this
+    # helper is for. See `_gqa_group_importance`'s own updated comment in
+    # onnxsim/pruning.py for why the two formulas agree whenever
+    # concatenation is legal, and why only this one stays well-defined when
+    # it isn't.
+    group_size = num_heads // kv_num_heads
+    importance = np.zeros(kv_num_heads)
+    for kv in range(kv_num_heads):
+        q_block = np.concatenate(
+            [
+                wq[:, h * head_size : (h + 1) * head_size]
+                for h in range(kv * group_size, (kv + 1) * group_size)
+            ],
+            axis=1,
+        )
+        k_block = wk[:, kv * head_size : (kv + 1) * head_size]
+        v_block = wv[:, kv * head_size : (kv + 1) * head_size]
+        importance[kv] = np.sqrt(
+            np.linalg.norm(q_block) ** 2
+            + np.linalg.norm(k_block) ** 2
+            + np.linalg.norm(v_block) ** 2
+        )
+    return np.sort(np.argsort(-importance)[:keep_count])
+
+
+def test_gqa_pruning_cross_attention_matches_oracle_exactly():
+    # Without the `_gqa_group_importance` fix (concatenate-then-norm, which
+    # requires wq's row count to equal wk's/wv's own), this raises a bare
+    # numpy ValueError instead of reaching the assertions below -- K_dec=8 !=
+    # K_enc=6 here is deliberate.
+    model, cfg = _gqa_cross_model(K_dec=8, K_enc=6, H=8, KVH=2, D=8, Out=6, seed=20)
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    node = _gqa_node(pruned)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    group_size = cfg["H"] // cfg["KVH"]
+    assert kv_num_heads == 1  # max(1, 2 - round(2*0.5))
+    assert num_heads == kv_num_heads * group_size
+
+    keep_groups = _oracle_keep_groups_cross(
+        cfg["wq"], cfg["wk"], cfg["wv"], cfg["H"], cfg["KVH"], cfg["D"], kv_num_heads
+    )
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    d = cfg["D"]
+    q_idx, kv_idx = _head_idx(keep_q_heads, d), _head_idx(keep_groups, d)
+
+    oracle, _ = _gqa_cross_model(
+        K_dec=cfg["K_dec"],
+        K_enc=cfg["K_enc"],
+        H=num_heads,
+        KVH=kv_num_heads,
+        D=d,
+        Out=cfg["Out"],
+        seed=20,
+        wq=cfg["wq"][:, q_idx],
+        wk=cfg["wk"][:, kv_idx],
+        wv=cfg["wv"][:, kv_idx],
+        wout=cfg["wout"][q_idx, :],
+        batch=cfg["batch"],
+        seq=cfg["seq"],
+    )
+
+    rng = np.random.default_rng(21)
+    xdec = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K_dec"])).astype(
+        np.float32
+    )
+    xenc = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K_enc"])).astype(
+        np.float32
+    )
+    (y_pruned,) = _run(pruned, {"Xdec": xdec, "Xenc": xenc})
+    (y_oracle,) = _run(oracle, {"Xdec": xdec, "Xenc": xenc})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+    # Sanity: Q and K/V really are independently sourced, not accidentally
+    # both reading the same tensor -- perturbing Xenc alone (Xdec held
+    # fixed) must still change the output.
+    (y_pruned2,) = _run(pruned, {"Xdec": xdec, "Xenc": xenc + 1.0})
+    assert not np.allclose(y_pruned, y_pruned2)
+
+
+def test_gqa_wanda_pruning_cross_attention_matches_oracle_exactly():
+    model, cfg = _gqa_cross_model(K_dec=8, K_enc=6, H=8, KVH=2, D=8, Out=6, seed=22)
+
+    rng = np.random.default_rng(23)
+    xdec_cal = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K_dec"])).astype(
+        np.float32
+    )
+    xenc_cal = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K_enc"])).astype(
+        np.float32
+    )
+    calibration_data = [{"Xdec": xdec_cal, "Xenc": xenc_cal}]
+
+    pruned = onnxsim.apply_attention_head_wanda_pruning(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned)
+
+    probe_model = onnx.ModelProto()
+    probe_model.CopyFrom(model)
+    probe_model.graph.output.append(onnx.ValueInfoProto(name="ctx"))
+    (_, ctx_cal) = _run(probe_model, {"Xdec": xdec_cal, "Xenc": xenc_cal})
+    act_norm = np.sqrt(np.mean(np.square(ctx_cal.astype(np.float64)), axis=(0, 1)))
+
+    d = cfg["D"]
+    group_size = cfg["H"] // cfg["KVH"]
+    importance = np.zeros(cfg["KVH"])
+    for kv in range(cfg["KVH"]):
+        q_block = np.concatenate(
+            [
+                cfg["wq"][:, h * d : (h + 1) * d]
+                for h in range(kv * group_size, (kv + 1) * group_size)
+            ],
+            axis=1,
+        )
+        k_block = cfg["wk"][:, kv * d : (kv + 1) * d]
+        v_block = cfg["wv"][:, kv * d : (kv + 1) * d]
+        base = np.sqrt(
+            np.linalg.norm(q_block) ** 2
+            + np.linalg.norm(k_block) ** 2
+            + np.linalg.norm(v_block) ** 2
+        )
+        act_group = np.linalg.norm(
+            act_norm[kv * group_size * d : (kv + 1) * group_size * d]
+        )
+        importance[kv] = base * max(act_group, 1e-8)
+    keep_groups = np.sort(np.argsort(-importance)[:1])  # max(1, 2 - round(2*0.5)) == 1
+
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    q_idx, kv_idx = _head_idx(keep_q_heads, d), _head_idx(keep_groups, d)
+
+    oracle, _ = _gqa_cross_model(
+        K_dec=cfg["K_dec"],
+        K_enc=cfg["K_enc"],
+        H=len(keep_q_heads),
+        KVH=len(keep_groups),
+        D=d,
+        Out=cfg["Out"],
+        seed=22,
+        wq=cfg["wq"][:, q_idx],
+        wk=cfg["wk"][:, kv_idx],
+        wv=cfg["wv"][:, kv_idx],
+        wout=cfg["wout"][q_idx, :],
+        batch=cfg["batch"],
+        seq=cfg["seq"],
+    )
+
+    xdec = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K_dec"])).astype(
+        np.float32
+    )
+    xenc = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K_enc"])).astype(
+        np.float32
+    )
+    (y_pruned,) = _run(pruned, {"Xdec": xdec, "Xenc": xenc})
+    (y_oracle,) = _run(oracle, {"Xdec": xdec, "Xenc": xenc})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
 def test_attention_head_pruning_handles_attention_and_gqa_in_one_model():
     # Regression check for _apply_attention_chains's per-chain-type
     # dispatch: a plain `Attention` block and a `GroupQueryAttention` block
@@ -5761,6 +6019,229 @@ def test_onnx_attention_wanda_pruning_falls_back_to_plain_with_no_calibration_ba
     }
     for name in inits_plain:
         np.testing.assert_array_equal(inits_plain[name], inits_wanda[name])
+
+
+# --- apply_attention_head_pruning / _wanda_pruning -- plain ai.onnx
+# Attention, cross-attention (Q and K/V from genuinely different source
+# tensors, at genuinely different sequence lengths) ------------------------
+#
+# Unlike GroupQueryAttention's own cross-attention section above (equal
+# sequence length only, an onnxruntime CPU-kernel restriction on that op --
+# see onnxsim/pruning.py's own "Attention-head pruning" section comment),
+# this op's own onnxruntime kernel has no such restriction (confirmed
+# empirically): `seq_q` and `seq_kv` genuinely differ below, exercising this
+# op's own schema doc ("For cross attention, query and key might have
+# different lengths") at full strength, oracle-verified via onnxruntime like
+# every other function in this module.
+
+
+def _onnx_attention_cross_model(
+    K_dec=8,
+    K_enc=6,
+    H=4,
+    KVH=2,
+    D=4,
+    Out=6,
+    seed=0,
+    batch=2,
+    seq_q=5,
+    seq_kv=7,
+    wq=None,
+    wk=None,
+    wv=None,
+    wout=None,
+):
+    rng = np.random.default_rng(seed)
+    Nq, Nkv = H * D, KVH * D
+    if wq is None:
+        wq = rng.standard_normal((K_dec, Nq)).astype(np.float32)
+    if wk is None:
+        wk = rng.standard_normal((K_enc, Nkv)).astype(np.float32)
+    if wv is None:
+        wv = rng.standard_normal((K_enc, Nkv)).astype(np.float32)
+    if wout is None:
+        wout = rng.standard_normal((Nq, Out)).astype(np.float32)
+
+    initializer = [_f32(wq, "Wq"), _f32(wk, "Wk"), _f32(wv, "Wv"), _f32(wout, "Wout")]
+
+    body = f"""
+        g (float[{batch},{seq_q},{K_dec}] Xdec, float[{batch},{seq_kv},{K_enc}] Xenc) => (float[{batch},{seq_q},{Out}] Y)
+        {{
+          q = MatMul(Xdec, Wq)
+          k = MatMul(Xenc, Wk)
+          v = MatMul(Xenc, Wv)
+          ctx = Attention <q_num_heads={H}, kv_num_heads={KVH}> (q, k, v)
+          Y = MatMul(ctx, Wout)
+        }}
+        """
+
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 24]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model, dict(
+        K_dec=K_dec,
+        K_enc=K_enc,
+        H=H,
+        KVH=KVH,
+        D=D,
+        Out=Out,
+        Nq=Nq,
+        Nkv=Nkv,
+        wq=wq,
+        wk=wk,
+        wv=wv,
+        wout=wout,
+        batch=batch,
+        seq_q=seq_q,
+        seq_kv=seq_kv,
+    )
+
+
+def test_onnx_attention_pruning_cross_attention_matches_oracle_exactly():
+    # Without the `_gqa_group_importance` fix this shares with the
+    # GroupQueryAttention cross-attention test above, this raises a bare
+    # numpy ValueError instead of reaching the assertions below --
+    # K_dec=8 != K_enc=6 here is deliberate, and (unlike that test)
+    # seq_q=5 != seq_kv=7 too, since this op's own kernel allows it.
+    model, cfg = _onnx_attention_cross_model(
+        K_dec=8, K_enc=6, H=8, KVH=2, D=4, Out=6, seed=24
+    )
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    node = _onnx_attention_node(pruned)
+    q_num_heads, kv_num_heads = _onnx_attention_attrs(node)
+    group_size = cfg["H"] // cfg["KVH"]
+    assert kv_num_heads == 1  # max(1, 2 - round(2*0.5))
+    assert q_num_heads == kv_num_heads * group_size
+
+    keep_groups = _oracle_keep_groups_cross(
+        cfg["wq"], cfg["wk"], cfg["wv"], cfg["H"], cfg["KVH"], cfg["D"], kv_num_heads
+    )
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    d = cfg["D"]
+    q_idx, kv_idx = _head_idx(keep_q_heads, d), _head_idx(keep_groups, d)
+
+    oracle, _ = _onnx_attention_cross_model(
+        K_dec=cfg["K_dec"],
+        K_enc=cfg["K_enc"],
+        H=q_num_heads,
+        KVH=kv_num_heads,
+        D=d,
+        Out=cfg["Out"],
+        seed=24,
+        wq=cfg["wq"][:, q_idx],
+        wk=cfg["wk"][:, kv_idx],
+        wv=cfg["wv"][:, kv_idx],
+        wout=cfg["wout"][q_idx, :],
+        batch=cfg["batch"],
+        seq_q=cfg["seq_q"],
+        seq_kv=cfg["seq_kv"],
+    )
+
+    rng = np.random.default_rng(25)
+    xdec = rng.standard_normal((cfg["batch"], cfg["seq_q"], cfg["K_dec"])).astype(
+        np.float32
+    )
+    xenc = rng.standard_normal((cfg["batch"], cfg["seq_kv"], cfg["K_enc"])).astype(
+        np.float32
+    )
+    (y_pruned,) = _run(pruned, {"Xdec": xdec, "Xenc": xenc})
+    (y_oracle,) = _run(oracle, {"Xdec": xdec, "Xenc": xenc})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+    # Sanity: Q and K/V really are independently sourced, at genuinely
+    # different sequence lengths -- perturbing Xenc alone (Xdec held fixed)
+    # must still change the output.
+    (y_pruned2,) = _run(pruned, {"Xdec": xdec, "Xenc": xenc + 1.0})
+    assert not np.allclose(y_pruned, y_pruned2)
+
+
+def test_onnx_attention_wanda_pruning_cross_attention_matches_oracle_exactly():
+    model, cfg = _onnx_attention_cross_model(
+        K_dec=8, K_enc=6, H=8, KVH=2, D=4, Out=6, seed=26
+    )
+
+    rng = np.random.default_rng(27)
+    xdec_cal = rng.standard_normal((cfg["batch"], cfg["seq_q"], cfg["K_dec"])).astype(
+        np.float32
+    )
+    xenc_cal = rng.standard_normal((cfg["batch"], cfg["seq_kv"], cfg["K_enc"])).astype(
+        np.float32
+    )
+    calibration_data = [{"Xdec": xdec_cal, "Xenc": xenc_cal}]
+
+    pruned = onnxsim.apply_attention_head_wanda_pruning(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned)
+
+    probe_model = onnx.ModelProto()
+    probe_model.CopyFrom(model)
+    probe_model.graph.output.append(onnx.ValueInfoProto(name="ctx"))
+    (_, ctx_cal) = _run(probe_model, {"Xdec": xdec_cal, "Xenc": xenc_cal})
+    act_norm = np.sqrt(np.mean(np.square(ctx_cal.astype(np.float64)), axis=(0, 1)))
+
+    d = cfg["D"]
+    group_size = cfg["H"] // cfg["KVH"]
+    importance = np.zeros(cfg["KVH"])
+    for kv in range(cfg["KVH"]):
+        q_block = np.concatenate(
+            [
+                cfg["wq"][:, h * d : (h + 1) * d]
+                for h in range(kv * group_size, (kv + 1) * group_size)
+            ],
+            axis=1,
+        )
+        k_block = cfg["wk"][:, kv * d : (kv + 1) * d]
+        v_block = cfg["wv"][:, kv * d : (kv + 1) * d]
+        base = np.sqrt(
+            np.linalg.norm(q_block) ** 2
+            + np.linalg.norm(k_block) ** 2
+            + np.linalg.norm(v_block) ** 2
+        )
+        act_group = np.linalg.norm(
+            act_norm[kv * group_size * d : (kv + 1) * group_size * d]
+        )
+        importance[kv] = base * max(act_group, 1e-8)
+    keep_groups = np.sort(np.argsort(-importance)[:1])  # max(1, 2 - round(2*0.5)) == 1
+
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    q_idx, kv_idx = _head_idx(keep_q_heads, d), _head_idx(keep_groups, d)
+
+    oracle, _ = _onnx_attention_cross_model(
+        K_dec=cfg["K_dec"],
+        K_enc=cfg["K_enc"],
+        H=len(keep_q_heads),
+        KVH=len(keep_groups),
+        D=d,
+        Out=cfg["Out"],
+        seed=26,
+        wq=cfg["wq"][:, q_idx],
+        wk=cfg["wk"][:, kv_idx],
+        wv=cfg["wv"][:, kv_idx],
+        wout=cfg["wout"][q_idx, :],
+        batch=cfg["batch"],
+        seq_q=cfg["seq_q"],
+        seq_kv=cfg["seq_kv"],
+    )
+
+    xdec = rng.standard_normal((cfg["batch"], cfg["seq_q"], cfg["K_dec"])).astype(
+        np.float32
+    )
+    xenc = rng.standard_normal((cfg["batch"], cfg["seq_kv"], cfg["K_enc"])).astype(
+        np.float32
+    )
+    (y_pruned,) = _run(pruned, {"Xdec": xdec, "Xenc": xenc})
+    (y_oracle,) = _run(oracle, {"Xdec": xdec, "Xenc": xenc})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
 
 
 def test_attention_head_pruning_handles_all_three_attention_op_types_in_one_model():


### PR DESCRIPTION
## Summary
- Investigated whether cross-attention (Q projected from one source tensor, K/V from a genuinely different one — the encoder-decoder attention shape) is correctly supported by this module's attention-head-pruning matchers, previously only flagged as "a narrow edge case, likely low-impact" without being actually investigated.
- **`com.microsoft::Attention`: confirmed structurally inapplicable, not a gap.** Fetched onnxruntime's own `bert_defs.cc` schema directly: the op takes a single `input` tensor that its one merged weight projects to Q, K, *and* V — there's no second, encoder-side input for K/V to come from. Documented as such rather than left ambiguous.
- **`GroupQueryAttention`/plain `ai.onnx::Attention`: already correctly matched (no matcher assumes Q's and K/V's producers share a source), but a real crash bug was hiding in the shared importance computation.** `_gqa_group_importance` (used by both ops' plain and Wanda-calibrated pruning) combined each KV-group's importance via `np.concatenate([q_block, k_block, v_block], axis=1)` before taking one Frobenius norm — silently assuming Q's own producer weight has the same row count as K/V's own. True for every self-attention shape (same source tensor), false for a genuine cross-attention shape where Q and K/V are projected from source tensors with different feature widths — `numpy.concatenate` raises a bare `ValueError` the instant such a model is pruned, crashing the whole call instead of ranking it.
- **Fix**: replaced the concatenate-then-norm with `sqrt(||Q_block||² + ||K_block||² + ||V_block||²)` — proven numerically identical to the old formula whenever concatenation was even legal (`||[A B]||_F² = ||A||_F² + ||B||_F²`), well-defined when it isn't. **Independently confirmed load-bearing**: reverted the fix and reran the cross-attention tests — all 4 failed with exactly the predicted `ValueError` (`array at index 0 has size 8 and the array at index 1 has size 6`); restored the fix and confirmed they pass.
- **GQA's own sequence-length restriction is a real onnxruntime kernel limit, not a matcher limitation**: empirically (onnxruntime 1.29.0), `GroupQueryAttention`'s CPU kernel requires Q's and K/V's sequence length to match unless a non-empty `past_key`/`past_value` is supplied — and a non-empty constant `past_key`/`past_value` is already declined outright by the existing matcher, so a differing-seq-length GQA cross-attention call is a topology this module never gets the chance to see in the first place. Plain `ai.onnx::Attention` has no such kernel restriction (also confirmed empirically) and fully exercises its own schema's documented "query and key might have different lengths" cross-attention shape.
- Wanda's own activation probe sits downstream of the attention op's output, after Q/K/V have already merged into one tensor — confirmed no per-source calibration-key handling is needed.

## Test plan
- [x] `pytest tests/test_pruning.py -q` — 159 passed (up from 155)
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — clean
- [x] Independent verification: reverted the fix and confirmed all 4 new cross-attention tests fail with the exact predicted `ValueError`, then confirmed they pass with the fix restored; also independently confirmed the fixed code runs cross-attention pruning without crashing on a fresh model outside the PR's own test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_