### PR TITLE
Add bounded Concat-merged (skip-connection) structured pruning

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -147,8 +147,29 @@ own fusion pass to collapse into `BiasGelu`/`FastGelu` in the first place --
 a plain unfused `Gelu`/`Sigmoid` gate (already handled) is the shape that
 survives when there's no bias to fuse to begin with.
 
-General multi-branch dependency-graph pruning -- arbitrary fan-out, non-Add
-merges (`Concat`, ...) -- remains out of scope. The
+A `Concat` merge -- the U-Net-style encoder/decoder skip connection
+(`merged = Concat(a, b, axis=1)`, each branch keeping its own disjoint slice
+of the merged channel range) -- looks at first glance like it needs the same
+general dependency-graph machinery an `Add`/`SkipLayerNormalization` merge
+does, and was long declined outright on that assumption. It turns out not
+to: unlike `Add`, whose operands are summed position-for-position and so
+*must* agree on one shared surviving channel-index set, `Concat`'s branches
+are independent -- branch `a` (`Ca` channels) always owns columns `[0, Ca)`
+of the merged, pre-pruning tensor and branch `b` always owns `[Ca, Ca+Cb)`,
+fixed offsets neither branch's own pruning choice can move -- so each branch
+is ranked and pruned entirely on its own, no cross-branch agreement needed
+at all, and only the shared downstream consumer's weight needs new slicing
+logic (concatenating each branch's own surviving-channel set, shifted by its
+own fixed offset) to stay correct. See :func:`_find_matmul_concat_chains`/
+:func:`_find_conv_concat_chains`'s own section comment for the bounded,
+single-consumer-per-branch shape this reaches (a `Concat` chained
+transitively into another `Concat`, or composed with a gated/residual
+branch, is declined the same conservative way as everything above) and
+:func:`_apply_concat_chains`'s own docstring for why that per-branch,
+independent-`keep` shape needed a genuinely new sibling to
+`_Chain`/`_apply_chains` rather than fitting into the existing one. General
+multi-branch dependency-graph pruning -- arbitrary fan-out, a non-`Add`/
+`Concat` merge op, ... -- remains out of scope. The
 other part of the paper's pipeline -- an architecture *search* over what to prune,
 alternated with knowledge-distillation/RL recovery afterwards -- needs a
 training loop onnxsim does not have and is not in scope here at all; this
@@ -511,7 +532,7 @@ undertaking rather than a mechanical extension of the matching alone.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import numpy as np
@@ -1695,6 +1716,32 @@ class _Chain:
     # :func:`_chain_group`) and the dedicated slicing
     # :func:`_slice_grouped_consumer_conv_weight` performs.
     consumer_group: int = 1
+
+
+@dataclass
+class _TouchedState:
+    """Cross-chain touched-role bookkeeping, shared (by reference) between
+    :func:`_apply_chains` and :func:`_apply_concat_chains` so a weight one
+    of them resizes can never also be resized a second, conflicting time by
+    the other -- e.g. a Concat branch's own producer weight happening to
+    also be, via a tied/shared initializer, some ordinary chain's producer
+    elsewhere in the graph. See :func:`_apply_chains`'s own docstring for
+    what each per-role set tracks and why roles are kept separate.
+    """
+
+    producer: Set[str] = field(default_factory=set)
+    consumer: Set[str] = field(default_factory=set)
+    const: Set[str] = field(default_factory=set)
+    conv_hop: Set[str] = field(default_factory=set)
+    stale_value_info: Set[str] = field(default_factory=set)
+
+
+def _set_conv_group_attr(node: onnx.NodeProto, group: int) -> None:
+    for attr in node.attribute:
+        if attr.name == "group":
+            attr.i = group
+            return
+    node.attribute.append(onnx.helper.make_attribute("group", group))
 
 
 def _consumers_of(graph: onnx.GraphProto) -> Dict[str, List[onnx.NodeProto]]:
@@ -3348,6 +3395,536 @@ def _find_gated_chains(graph: onnx.GraphProto) -> List[_Chain]:
     return chains
 
 
+# --- Concat-merged (skip-connection) chains ---------------------------------
+#
+# A `Concat` merge -- the U-Net-style encoder/decoder skip connection,
+# `merged = Concat(a, b, ..., axis=C)` -- looks, at first glance, like it
+# needs the same general dependency-graph machinery an `Add`/
+# `SkipLayerNormalization` merge does (see the two residual sections above),
+# and this module long declined it outright on that assumption (see its own
+# docstring's prior "non-Add merges (`Concat`, ...)" phrase). It turns out
+# not to need that: unlike `Add`, whose operands are summed
+# position-for-position and therefore *must* agree on one shared surviving
+# channel-index set (the entire reason the two residual sections above exist
+# at all), `Concat`'s branches are structurally independent. Branch `a`
+# (`Ca` channels) always owns columns `[0, Ca)` of the merged, pre-pruning
+# tensor; branch `b` always owns `[Ca, Ca+Cb)`; and so on for every further
+# operand -- fixed, disjoint offsets into the *original* channel range that
+# neither branch's own pruning choice can move, since ONNX's `Concat`
+# simply lays its inputs out end to end in operand order. So each branch can
+# be ranked and pruned *entirely on its own* -- no cross-branch agreement
+# needed at all, unlike a gated pair or a residual group -- and the only new
+# work is on the *consumer* side: its weight needs slicing at those same
+# fixed block offsets, one independently-chosen `keep` set per block,
+# concatenated back together in branch order (:func:`_apply_concat_chains`).
+#
+# Both node families this module already splits its producer/consumer
+# matching by get their own finder here, exactly mirroring the
+# `_find_chains`/`_find_conv_chains` split: :func:`_find_matmul_concat_chains`
+# (MatMul/vanilla-Gemm) and :func:`_find_conv_concat_chains` (2-D, `group=1`
+# Conv). Both resolve every one of a `Concat` node's operands *backward* to a
+# real producer, reusing the exact same backward walkers the two residual
+# sections above already built and verified --
+# :func:`_walk_matmul_producer_backward`/:func:`_walk_conv_producer_backward`
+# -- rather than writing new ones: those walkers already hold every
+# intermediate tensor to the single-consumer safety bar this pass needs
+# (`start` itself included, so a branch that also fans out anywhere else
+# fails on its very first hop), and already resolve through the same unary
+# activations (plus, for MatMul/Gemm, a per-channel `Add`/`Mul`/
+# `BiasGelu`/`FastGelu` hop; for Conv, a self-consistently-depthwise
+# pass-through hop) a plain single-producer chain's own forward walk
+# recognizes. Only a `"producer"` outcome is accepted here, though: a
+# `"add"` outcome -- the branch resolves to an eligible `Add`/
+# `SkipLayerNormalization` residual merge instead of a real producer -- is
+# treated exactly like `"fail"` and declines the *entire* `Concat` group,
+# the same conservative "never partially pruned" bar the residual sections'
+# own union-find grouping holds every member to. Composing a residual merge
+# with a `Concat` merge on the same branch (e.g. a decoder block whose own
+# skip input is itself a residual sum) is a real, plausible topology this
+# module simply hasn't verified yet -- see this module's own docstring for
+# why that's an honest scope boundary rather than an oversight, not a case
+# this finder tries to guess at. Likewise, a `Concat` chained transitively
+# into *another* `Concat` (a "spine" of concatenations) is not walked
+# through either: neither backward walker recognizes `Concat` as a hop at
+# all, so an operand that bottoms out at one simply falls through to
+# `"fail"` the same way an unrecognized producer always does -- no dedicated
+# check was needed to draw that boundary, it falls out for free from what
+# the walkers already do and don't recognize. A gated (SwiGLU/GeGLU) pair
+# feeding a `Concat` operand directly, with no real producer's raw output in
+# between, is declined the same way: neither backward walker resolves
+# through a `Mul` of two non-constant operands (see the MatMul residual
+# section's own comment for why), so that shape falls through to `"fail"`
+# too.
+#
+# `Concat`'s own `axis` attribute must actually be the channel axis this
+# pass's importance ranking operates on, and the two node families need
+# different, deliberately conservative answers for what that means, since
+# neither this pass nor this module in general ever looks up a tensor's
+# rank from `value_info`/shape inference (every other topology decision in
+# this module is answerable from node attributes and initializer shapes
+# alone, and this keeps that property rather than adding a new,
+# shape-inference-dependent dependency just for `Concat`):
+#
+# - **Conv** branches are always rank-4 (`[N, C, H, W]`) -- every Conv this
+#   whole module ever matches is 2-D, no exception anywhere in this file --
+#   so the channel axis is unambiguously `axis == 1` (or the equivalent
+#   negative form, `axis == -3`); no rank lookup is ever needed.
+# - **MatMul/Gemm** branches have no fixed rank at all (`[batch, C]`,
+#   `[batch, seq, C]`, ...), but the reduction dimension every consumer
+#   match in this module already cares about is always the tensor's *last*
+#   axis regardless of rank (2-D weight, matrix-multiplied against
+#   whatever leading batch dimensions the input happens to carry) -- so only
+#   `axis == -1` is recognized. A model that spells the same last-axis
+#   concat with an explicit *positive* `axis` (e.g. `axis=1` on a 2-D
+#   `[batch, C]` tensor, numerically identical to `axis=-1` there) is
+#   declined rather than guessed at: confirming a positive `axis` actually
+#   equals "rank minus one" would need exactly the shape-inference-dependent
+#   rank lookup this module otherwise never needs, and this pass would
+#   rather decline a genuinely-safe-but-unconfirmed case than add that new
+#   dependency for it. See
+#   `test_structured_pruning_matmul_concat_declines_on_positive_axis`.
+#
+# Once every operand resolves and the branches' fixed offsets are known, the
+# ordinary forward walk (:func:`_walk_to_consumer`/
+# :func:`_walk_to_conv_consumer`) continues from the `Concat` node's own
+# output exactly as it would from any single producer's raw output, with
+# `n_channels` set to the *sum* of every branch's own channel count -- the
+# `Concat` node itself never needs its own attributes changed (its output
+# shape is simply whatever its inputs' shapes are, so pruning each branch's
+# own producer already gives it the right, smaller input on its own). A
+# grouped (`group != 1`) Conv consumer is declined the same way
+# :func:`_find_conv_residual_chains` declines one: its per-group top-k
+# assumes every producer feeds the consumer's full channel range, which a
+# multi-branch group of independently-sized, independently-pruned branches
+# doesn't establish.
+
+
+def _concat_axis(node: onnx.NodeProto) -> Optional[int]:
+    for attr in node.attribute:
+        if attr.name == "axis":
+            return attr.i
+    return None  # required attribute on Concat's own schema -- malformed if absent
+
+
+@dataclass(frozen=True)
+class _ConcatBranch:
+    """One resolved operand of a matched ``Concat`` merge group -- see this
+    section's own comment. Unlike an ``Add``/``SkipLayerNormalization``
+    residual merge's operands (:class:`_Chain`'s `producers`, all pruned to
+    one *shared* `keep` index set, since they're summed elementwise), every
+    `_ConcatBranch` in a :class:`_ConcatChain` is pruned to its *own
+    independent* `keep` set -- see :func:`_apply_concat_chains`'s own
+    docstring for why that needed a new sibling to :class:`_Producer`/
+    :class:`_Chain` rather than folding into them.
+    """
+
+    producer: _Producer  # `pre_ops` always left empty -- see `pre_ops` below
+    # Ops between the producer's own raw output and this branch's own
+    # `Concat` operand: ``(node, const_name_or_None)`` pairs, forward order
+    # -- exactly :class:`_Chain`'s own `chain_ops` shape (needed here rather
+    # than :class:`_Producer`'s own bare-node `pre_ops` tuple, because a
+    # MatMul/Gemm branch can carry a per-channel `Add`/`Mul`/`BiasGelu`/
+    # `FastGelu` constant on this hop, not just a unary activation).
+    pre_ops: Tuple[Tuple[onnx.NodeProto, Optional[str]], ...]
+    # Depthwise Conv pass-through hops crossed on this branch (Conv branches
+    # only; always empty for a MatMul/Gemm branch -- see
+    # :class:`_ConvPassThrough`).
+    conv_pass_through: Tuple[_ConvPassThrough, ...]
+    n_channels: int
+    # This branch's fixed offset into the merged (pre-pruning) channel
+    # range, in `Concat` operand order -- see this section's own comment for
+    # why this is safe to compute once, up front, from operand order alone.
+    offset: int
+    # The tensor name actually feeding the `Concat` node at this operand
+    # position (`== producer.node.output[0]` when `pre_ops` is empty) -- the
+    # Wanda activation-probe point for this branch, see
+    # :func:`apply_structured_wanda_pruning`.
+    operand_name: str
+
+
+@dataclass(frozen=True)
+class _ConcatChain:
+    """A matched ``Concat``-merged skip-connection group -- see this
+    section's own comment. `branches` are pruned independently of one
+    another (see :class:`_ConcatBranch`); the one shared downstream consumer
+    is sliced once, by the concatenation of every branch's own `keep` set,
+    each shifted by its own `offset`.
+    """
+
+    branches: Tuple[_ConcatBranch, ...]
+    concat_node: onnx.NodeProto
+    # Ops between the `Concat` node's own output and the real consumer --
+    # exactly :class:`_Chain`'s own `chain_ops` shape, built by the same
+    # forward walk (:func:`_walk_to_consumer`/:func:`_walk_to_conv_consumer`)
+    # an ordinary single-producer chain uses.
+    chain_ops: Tuple[Tuple[onnx.NodeProto, Optional[str]], ...]
+    consumer_node: onnx.NodeProto
+    consumer_weight: str
+    consumer_weight_transposed: bool
+    consumer_is_conv: bool
+    n_channels: int  # sum of every branch's own n_channels
+    # Depthwise Conv hops crossed between the `Concat` node and the real
+    # consumer (Conv chains only; see :class:`_ConvPassThrough`).
+    conv_pass_through: Tuple[_ConvPassThrough, ...] = ()
+
+
+def _find_matmul_concat_chains(graph: onnx.GraphProto) -> List[_ConcatChain]:
+    """Finds MatMul/Gemm ``Concat``-merged skip connections -- see this
+    section's own comment. Every operand of a last-axis `Concat` (`axis ==
+    -1`; see this section's own comment for why a positive `axis` is
+    declined even when it might numerically equal the tensor's last axis)
+    is resolved backward, via :func:`_walk_matmul_producer_backward` (reused
+    unchanged from the MatMul/Gemm residual section above), to a real
+    MatMul/vanilla-Gemm producer -- only a `"producer"` outcome is accepted;
+    `"add"` (the operand resolves to an eligible residual/
+    `SkipLayerNormalization` merge instead) is declined exactly like
+    `"fail"`, since composing a residual merge with a `Concat` merge on the
+    same branch isn't verified here (see this section's own comment). If
+    *any* operand fails to resolve to a real producer, or two operands
+    resolve to the very same producer weight (degenerate), the whole
+    `Concat` node is declined -- never partially pruned.
+    """
+    initializer_map = {t.name: t for t in graph.initializer}
+    consumers_of = _consumers_of(graph)
+    node_by_output = {out: node for node in graph.node for out in node.output}
+    graph_outputs = {o.name for o in graph.output}
+
+    def _is_internal(name: str) -> bool:
+        return len(consumers_of.get(name, [])) == 1 and name not in graph_outputs
+
+    chains: List[_ConcatChain] = []
+    for node in graph.node:
+        if node.op_type != "Concat" or len(node.input) < 2 or len(node.output) != 1:
+            continue
+        if _concat_axis(node) != -1:
+            continue
+        if len(set(node.input)) != len(node.input):
+            continue  # degenerate -- the same tensor concatenated with itself
+
+        branches: List[_ConcatBranch] = []
+        seen_weights: Set[str] = set()
+        offset = 0
+        declined = False
+        for operand in node.input:
+            kind, payload, pre_ops = _walk_matmul_producer_backward(
+                operand,
+                node_by_output,
+                initializer_map,
+                consumers_of,
+                graph_outputs,
+                _MAX_CHAIN_HOPS,
+            )
+            if kind != "producer":
+                declined = True
+                break
+            assert payload is not None and not isinstance(payload, onnx.NodeProto)
+            producer, n_channels = payload
+            if producer.weight in seen_weights:
+                declined = True
+                break
+            seen_weights.add(producer.weight)
+            branches.append(
+                _ConcatBranch(producer, pre_ops, (), n_channels, offset, operand)
+            )
+            offset += n_channels
+        if declined:
+            continue
+
+        out_name = node.output[0]
+        if not _is_internal(out_name):
+            continue
+        total_n = offset
+        consumer, fwd_chain_ops = _walk_to_consumer(
+            out_name,
+            initializer_map,
+            consumers_of,
+            graph_outputs,
+            total_n,
+            _MAX_CHAIN_HOPS,
+        )
+        if consumer is None:
+            continue
+
+        chains.append(
+            _ConcatChain(
+                branches=tuple(branches),
+                concat_node=node,
+                chain_ops=fwd_chain_ops,
+                consumer_node=consumer[0],
+                consumer_weight=consumer[1],
+                consumer_weight_transposed=consumer[2],
+                consumer_is_conv=False,
+                n_channels=total_n,
+            )
+        )
+    return chains
+
+
+def _find_conv_concat_chains(graph: onnx.GraphProto) -> List[_ConcatChain]:
+    """The Conv analogue of :func:`_find_matmul_concat_chains`: every operand
+    of a channel-axis `Concat` (`axis in (1, -3)` -- the channel axis of a
+    `[N, C, H, W]` tensor; see this section's own comment for why Conv needs
+    no rank ambiguity check the MatMul/Gemm side does) is resolved backward
+    via :func:`_walk_conv_producer_backward`, reused unchanged from the Conv
+    residual section above: only a `"producer"` outcome (a real `group=1`
+    Conv, reached through unary activations and/or self-consistently-
+    depthwise pass-through hops) is accepted -- `"add"` and `"fail"` are
+    both declined the same way :func:`_find_matmul_concat_chains` declines
+    `"add"`. The consumer must itself be an ordinary (`group=1`) Conv -- see
+    this section's own comment for why a grouped consumer is declined here.
+    """
+    initializer_map = {t.name: t for t in graph.initializer}
+    consumers_of = _consumers_of(graph)
+    node_by_output = {out: node for node in graph.node for out in node.output}
+    graph_outputs = {o.name for o in graph.output}
+
+    def _is_internal(name: str) -> bool:
+        return len(consumers_of.get(name, [])) == 1 and name not in graph_outputs
+
+    chains: List[_ConcatChain] = []
+    for node in graph.node:
+        if node.op_type != "Concat" or len(node.input) < 2 or len(node.output) != 1:
+            continue
+        if _concat_axis(node) not in (1, -3):
+            continue
+        if len(set(node.input)) != len(node.input):
+            continue
+
+        branches: List[_ConcatBranch] = []
+        seen_weights: Set[str] = set()
+        offset = 0
+        declined = False
+        for operand in node.input:
+            kind, payload, pass_through, unary_ops = _walk_conv_producer_backward(
+                operand,
+                node_by_output,
+                initializer_map,
+                consumers_of,
+                graph_outputs,
+                _MAX_CHAIN_HOPS,
+            )
+            if kind != "producer":
+                declined = True
+                break
+            assert payload is not None and not isinstance(payload, onnx.NodeProto)
+            producer, n_channels = payload
+            if producer.weight in seen_weights:
+                declined = True
+                break
+            seen_weights.add(producer.weight)
+            branches.append(
+                _ConcatBranch(
+                    producer,
+                    tuple((op, None) for op in unary_ops),
+                    pass_through,
+                    n_channels,
+                    offset,
+                    operand,
+                )
+            )
+            offset += n_channels
+        if declined:
+            continue
+
+        out_name = node.output[0]
+        if not _is_internal(out_name):
+            continue
+        total_n = offset
+        consumer, fwd_chain_ops, fwd_pass_through = _walk_to_conv_consumer(
+            out_name,
+            initializer_map,
+            consumers_of,
+            graph_outputs,
+            total_n,
+            _MAX_CHAIN_HOPS,
+        )
+        if consumer is None:
+            continue
+        consumer_node, consumer_weight, consumer_group = consumer
+        if consumer_group != 1:
+            continue  # see this section's own comment -- grouped consumer declined
+
+        chains.append(
+            _ConcatChain(
+                branches=tuple(branches),
+                concat_node=node,
+                chain_ops=fwd_chain_ops,
+                consumer_node=consumer_node,
+                consumer_weight=consumer_weight,
+                consumer_weight_transposed=False,
+                consumer_is_conv=True,
+                n_channels=total_n,
+                conv_pass_through=fwd_pass_through,
+            )
+        )
+    return chains
+
+
+def _plain_branch_importance(w_nk: np.ndarray) -> np.ndarray:
+    # A Concat branch is always exactly one producer, with no cross-branch
+    # combination the way a gated pair or residual group needs (see this
+    # section's own comment) -- so this is just plain per-row L2 norm,
+    # _plain_structured_importance's own single-producer case, standalone
+    # rather than routed through a _Chain.
+    return np.linalg.norm(w_nk, axis=1)
+
+
+def _apply_concat_chains(
+    graph: onnx.GraphProto,
+    chains: List[_ConcatChain],
+    sparsity: float,
+    compute_branch_importance,
+    touched: _TouchedState,
+) -> None:
+    """The Concat-merged analogue of :func:`_apply_chains` -- deliberately a
+    separate function, not a `_Chain`/`_apply_chains` extension, because the
+    two need genuinely different shapes. `_apply_chains` computes *one*
+    `keep` index set from *one* combined importance ranking and applies it,
+    unchanged, to every producer and the consumer alike -- exactly right for
+    a gated pair or a residual merge, where every branch *must* agree on the
+    same surviving channels since they're summed/multiplied elementwise
+    before the consumer ever sees them. A `Concat` branch never needs that
+    agreement (see this section's own comment): each branch owns its own
+    disjoint, fixed-offset slice of the merged channel range, so each is
+    ranked and pruned to its *own independent* `keep` set by
+    ``compute_branch_importance(operand_name, w_nk) ->
+    np.ndarray[branch.n_channels]``, and only the shared downstream consumer
+    is sliced once, by one combined index set -- the concatenation of every
+    branch's own `keep`, each shifted by its own fixed `offset`. Since
+    branch offsets strictly increase in `Concat` operand order and each
+    branch's own `keep` is itself ascending, that concatenation is
+    automatically ascending overall too, the same `keep` invariant
+    :func:`_apply_chains` maintains. `touched` is the same
+    :class:`_TouchedState` a sibling :func:`_apply_chains` call shares, so
+    the two can never doubly resize the same weight; the caller flushes
+    ``value_info`` once, from `touched.stale_value_info`, after every such
+    call.
+    """
+    initializer_map = {t.name: t for t in graph.initializer}
+
+    for chain in chains:
+        producer_weights = {b.producer.weight for b in chain.branches}
+        if len(producer_weights) != len(chain.branches):
+            continue  # degenerate -- two branches naming the same weight
+
+        conv_hop_weights = {
+            h.weight for b in chain.branches for h in b.conv_pass_through
+        }
+        conv_hop_weights |= {h.weight for h in chain.conv_pass_through}
+        n_conv_hops = sum(len(b.conv_pass_through) for b in chain.branches) + len(
+            chain.conv_pass_through
+        )
+        if len(conv_hop_weights) != n_conv_hops:
+            continue  # degenerate -- the same depthwise weight named twice
+
+        consts = {
+            b.producer.bias for b in chain.branches if b.producer.bias is not None
+        }
+        consts.update(
+            const_name
+            for b in chain.branches
+            for _, const_name in b.pre_ops
+            if const_name is not None
+        )
+        consts.update(
+            const_name for _, const_name in chain.chain_ops if const_name is not None
+        )
+
+        if (
+            (producer_weights & touched.producer)
+            or chain.consumer_weight in touched.consumer
+            or (consts & touched.const)
+            or (conv_hop_weights & touched.conv_hop)
+        ):
+            continue  # a shared/tied initializer another chain already resized
+
+        branch_keeps: List[np.ndarray] = []
+        any_pruned = False
+        for b in chain.branches:
+            n = b.n_channels
+            keep_count = max(1, n - round(n * sparsity))
+            if keep_count >= n:
+                branch_keeps.append(np.arange(n))
+                continue
+            any_pruned = True
+            w = onnx.numpy_helper.to_array(initializer_map[b.producer.weight]).astype(
+                np.float64
+            )
+            w_nk = (
+                w.reshape(w.shape[0], -1)  # [out_channels, in_channels*kH*kW]
+                if b.producer.is_conv
+                else (w if b.producer.weight_transposed else w.T)  # [N, K]
+            )
+            importance = compute_branch_importance(b.operand_name, w_nk)
+            branch_keeps.append(np.sort(np.argsort(-importance)[:keep_count]))
+
+        if not any_pruned:
+            continue  # every branch rounds down to a no-op -- nothing to do
+
+        for b, keep in zip(chain.branches, branch_keeps):
+            if len(keep) == b.n_channels:
+                continue  # this branch's own sparsity rounded to a no-op
+            _slice_producer_weight(
+                initializer_map[b.producer.weight],
+                b.producer.weight_transposed,
+                keep,
+                is_conv=b.producer.is_conv,
+            )
+            if b.producer.bias is not None:
+                _slice_last_axis(initializer_map[b.producer.bias], keep)
+            for _, const_name in b.pre_ops:
+                if const_name is not None:
+                    _slice_last_axis(initializer_map[const_name], keep)
+            for hop in b.conv_pass_through:
+                # Same reasoning as _apply_chains's own depthwise hop
+                # handling: channel i is exactly upstream channel i, so the
+                # hop's own weight/bias slice by this branch's own `keep`.
+                _slice_producer_weight(
+                    initializer_map[hop.weight], False, keep, is_conv=True
+                )
+                if hop.bias is not None:
+                    _slice_last_axis(initializer_map[hop.bias], keep)
+                _set_conv_group_attr(hop.node, len(keep))
+
+        global_keep = np.concatenate(
+            [keep + b.offset for b, keep in zip(chain.branches, branch_keeps)]
+        )
+
+        for _, const_name in chain.chain_ops:
+            if const_name is not None:
+                _slice_last_axis(initializer_map[const_name], global_keep)
+        for hop in chain.conv_pass_through:
+            _slice_producer_weight(
+                initializer_map[hop.weight], False, global_keep, is_conv=True
+            )
+            if hop.bias is not None:
+                _slice_last_axis(initializer_map[hop.bias], global_keep)
+            _set_conv_group_attr(hop.node, len(global_keep))
+
+        _slice_consumer_weight(
+            initializer_map[chain.consumer_weight],
+            chain.consumer_weight_transposed,
+            global_keep,
+            is_conv=chain.consumer_is_conv,
+        )
+
+        touched.producer.update(producer_weights)
+        touched.consumer.add(chain.consumer_weight)
+        touched.const.update(consts)
+        touched.conv_hop.update(conv_hop_weights)
+        touched.stale_value_info.add(chain.concat_node.output[0])
+        for b in chain.branches:
+            touched.stale_value_info.add(b.producer.node.output[0])
+            touched.stale_value_info.update(op.output[0] for op, _ in b.pre_ops)
+            touched.stale_value_info.update(
+                h.node.output[0] for h in b.conv_pass_through
+            )
+        touched.stale_value_info.update(op.output[0] for op, _ in chain.chain_ops)
+        touched.stale_value_info.update(
+            h.node.output[0] for h in chain.conv_pass_through
+        )
+
+
 def _slice_producer_weight(
     w_init: onnx.TensorProto,
     weight_transposed: bool,
@@ -3481,13 +4058,17 @@ def _apply_chains(
     chains: List[_Chain],
     sparsity: float,
     compute_importance,
+    touched: _TouchedState,
 ) -> None:
     """Shared body for :func:`apply_structured_pruning` and
     :func:`apply_structured_wanda_pruning`: resolves cross-chain touched-role
     conflicts, computes each surviving chain's target channel count, calls
     ``compute_importance(chain, w_arrays_nk) -> np.ndarray[n_channels]`` for
-    the ranking, and performs the actual slicing plus stale ``value_info``
-    cleanup. Mutates ``graph`` in place.
+    the ranking, and performs the actual slicing. Mutates ``graph`` in
+    place. `touched` accumulates every touched role and stale ``value_info``
+    name across this call *and* any sibling :func:`_apply_concat_chains`
+    call sharing the same `touched` -- the caller flushes ``value_info``
+    once, after every such call, from `touched.stale_value_info`.
 
     For a chain with :func:`_chain_group` (`group`) > 1 -- a general grouped
     Conv producer or consumer, see this module's own docstring -- `keep` is
@@ -3510,11 +4091,11 @@ def _apply_chains(
     # same tensor. Only collapse when the *same role* is claimed twice (a
     # tied/shared weight), tracked separately per role; bias/scale constants
     # only ever play one role, so a single shared set is enough for those.
-    producer_touched: Set[str] = set()
-    consumer_touched: Set[str] = set()
-    const_touched: Set[str] = set()
-    conv_hop_touched: Set[str] = set()
-    stale_value_info: Set[str] = set()
+    producer_touched = touched.producer
+    consumer_touched = touched.consumer
+    const_touched = touched.const
+    conv_hop_touched = touched.conv_hop
+    stale_value_info = touched.stale_value_info
 
     for chain in chains:
         producer_weights = {p.weight for p in chain.producers}
@@ -3599,16 +4180,7 @@ def _apply_chains(
             )
             if hop.bias is not None:
                 _slice_last_axis(initializer_map[hop.bias], keep)
-            found_group = False
-            for attr in hop.node.attribute:
-                if attr.name == "group":
-                    attr.i = keep_count
-                    found_group = True
-                    break
-            if not found_group:
-                hop.node.attribute.append(
-                    onnx.helper.make_attribute("group", keep_count)
-                )
+            _set_conv_group_attr(hop.node, keep_count)
         if chain.consumer_is_conv and chain.consumer_group > 1:
             _slice_grouped_consumer_conv_weight(
                 initializer_map[chain.consumer_weight], keep, chain.consumer_group, n
@@ -3632,11 +4204,6 @@ def _apply_chains(
             chain_node.output[0] for chain_node, _ in chain.chain_ops
         )
         stale_value_info.update(hop.node.output[0] for hop in chain.conv_pass_through)
-
-    if stale_value_info:
-        kept = [vi for vi in graph.value_info if vi.name not in stale_value_info]
-        del graph.value_info[:]
-        graph.value_info.extend(kept)
 
 
 def apply_structured_pruning(
@@ -3756,6 +4323,27 @@ def apply_structured_pruning(
     ``inv_std_var`` outputs are actually consumed elsewhere, is declined the
     same conservative way.
 
+    Also handles a bounded slice of the ``Concat``-merged skip-connection
+    case -- the U-Net-style encoder/decoder merge (see
+    :func:`_find_matmul_concat_chains`/:func:`_find_conv_concat_chains` and
+    this module's own docstring) -- for both MatMul/Gemm (last-axis
+    ``Concat`` only, ``axis == -1``) and Conv (channel-axis ``Concat``,
+    ``axis in (1, -3)``) branches. Unlike a gated pair or a residual merge,
+    a ``Concat``'s branches need no shared `keep` set at all: each branch
+    owns a fixed, disjoint slice of the merged channel range and is ranked
+    and pruned entirely on its own, by the same L2-norm criterion as a plain
+    single-producer chain; only the shared downstream consumer's weight
+    needs new slicing, at each branch's own fixed offset. Every branch is
+    held to the same single-consumer safety bar as everywhere else in this
+    pass, and must resolve to a real producer of the appropriate family
+    (MatMul/vanilla-Gemm, or a ``group=1`` Conv reached through unary
+    activations and/or depthwise pass-through hops) -- a branch that fans
+    out elsewhere, bottoms out at a graph input, or would need to cross a
+    residual (``Add``/``SkipLayerNormalization``) merge or another
+    ``Concat`` to reach one, declines the *entire* group, never partially
+    pruned. A grouped (``group != 1``) Conv consumer is likewise declined,
+    the same reason a residual group declines one.
+
     :param model: the original onnx ModelProto or file path
     :param sparsity: target fraction of each matched producer's output
             channels to remove (at least one channel is always kept)
@@ -3780,8 +4368,25 @@ def apply_structured_pruning(
         + _find_conv_residual_chains(graph)
         + _find_matmul_residual_chains(graph)
     )
+    concat_chains = _find_matmul_concat_chains(graph) + _find_conv_concat_chains(graph)
+
+    touched = _TouchedState()
     if chains:
-        _apply_chains(graph, chains, sparsity, _plain_structured_importance)
+        _apply_chains(graph, chains, sparsity, _plain_structured_importance, touched)
+    if concat_chains:
+        _apply_concat_chains(
+            graph,
+            concat_chains,
+            sparsity,
+            lambda _operand_name, w_nk: _plain_branch_importance(w_nk),
+            touched,
+        )
+    if touched.stale_value_info:
+        kept = [
+            vi for vi in graph.value_info if vi.name not in touched.stale_value_info
+        ]
+        del graph.value_info[:]
+        graph.value_info.extend(kept)
 
     return out
 
@@ -3820,6 +4425,13 @@ def apply_structured_wanda_pruning(
     transplanted to whole channels: a channel whose weight is individually
     unremarkable but which gates a consistently high-magnitude activation
     is kept over one with a larger weight norm but a near-dead activation.
+    A ``Concat``-merged group (see :func:`apply_structured_pruning`'s own
+    docstring) picks this up too: each branch is ranked by that same
+    ``||W_row||_2 * ||X||_2`` metric independently, with its own activation
+    captured right where it feeds into the ``Concat`` node (reduced the same
+    way, over every axis but the channel one), not at the shared downstream
+    consumer -- consistent with each branch needing no other branch's
+    agreement on anything, unlike a gated pair or residual merge.
 
     :param model: the original onnx ModelProto or file path
     :param calibration_data: representative input batches to measure each
@@ -3863,18 +4475,25 @@ def apply_structured_wanda_pruning(
         + _find_conv_residual_chains(graph)
         + _find_matmul_residual_chains(graph)
     )
-    if not chains:
+    concat_chains = _find_matmul_concat_chains(graph) + _find_conv_concat_chains(graph)
+    if not chains and not concat_chains:
         return out
 
     # The channel axis of the activation feeding each chain's consumer: a
     # MatMul/Gemm's reduction dimension is its input's last axis, while a
     # Conv's input channel dimension is always axis 1 of [N, C, H, W]. Two
     # chains can't disagree on a shared probe name -- a tensor has exactly
-    # one producer node, so it feeds one consumer type.
+    # one producer node, so it feeds one consumer type. A Concat branch's own
+    # probe point is instead wherever it feeds into the Concat node itself
+    # (see this function's own docstring) -- not the shared downstream
+    # consumer every other chain here probes at.
     channel_axis: Dict[str, int] = {
         chain.consumer_node.input[0]: (1 if chain.consumer_is_conv else -1)
         for chain in chains
     }
+    for cchain in concat_chains:
+        for b in cchain.branches:
+            channel_axis[b.operand_name] = 1 if b.producer.is_conv else -1
     probe_names = sorted(channel_axis)
     probe_model = _add_probe_outputs(out, probe_names)
 
@@ -3909,7 +4528,26 @@ def apply_structured_wanda_pruning(
             return base  # no matching activation observed -- fall back to |W|
         return base * np.maximum(norm, epsilon)
 
-    _apply_chains(graph, chains, sparsity, _wanda_structured_importance)
+    def _wanda_branch_importance(operand_name: str, w_nk: np.ndarray) -> np.ndarray:
+        base = _plain_branch_importance(w_nk)
+        norm = act_norm.get(operand_name)
+        if norm is None or norm.shape[0] != w_nk.shape[0]:
+            return base  # no matching activation observed -- fall back to |W|
+        return base * np.maximum(norm, epsilon)
+
+    touched = _TouchedState()
+    if chains:
+        _apply_chains(graph, chains, sparsity, _wanda_structured_importance, touched)
+    if concat_chains:
+        _apply_concat_chains(
+            graph, concat_chains, sparsity, _wanda_branch_importance, touched
+        )
+    if touched.stale_value_info:
+        kept = [
+            vi for vi in graph.value_info if vi.name not in touched.stale_value_info
+        ]
+        del graph.value_info[:]
+        graph.value_info.extend(kept)
     return out
 
 

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -3955,6 +3955,730 @@ def test_structured_pruning_mixed_add_and_skip_layer_norm_spine_matches_oracle()
     np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
 
 
+# --- apply_structured_pruning: Concat-merged (skip-connection) chains -------
+#
+# See onnxsim.pruning's own module docstring and the "Concat-merged
+# (skip-connection) chains" section comment above
+# _find_matmul_concat_chains/_find_conv_concat_chains for the full
+# reasoning. Unlike every merge kind tested above (a gated pair, an Add
+# residual, a SkipLayerNormalization-fused residual -- all of which force
+# every branch onto one *shared* keep set), a Concat's branches are
+# independent: each owns a fixed, disjoint slice of the merged channel
+# range and is ranked/pruned entirely on its own. The tests below are
+# deliberately built to catch a "treated it like a residual merge" bug --
+# one branch's weights scaled far larger than another's, or branches with
+# different channel counts -- since a shared-keep-set bug would silently
+# starve or ignore one branch, while independent per-branch selection
+# always keeps each branch's own top fraction regardless of the other
+# branch's scale.
+
+
+def _matmul_concat_model(weights, w_out, axis=-1):
+    # merged = Concat(MatMul(X, W0), MatMul(X, W1), ..., axis=axis);
+    # Y = MatMul(merged, WOUT) -- an arbitrary (2 or more) number of
+    # independent MatMul producers merge via Concat, each keeping its own
+    # disjoint slice of the merged channel range, feeding one real
+    # consumer. `weights[i]` is `[K, Ci]`; `w_out` is `[sum(Ci), Out]`.
+    K = weights[0].shape[0]
+    Out = w_out.shape[1]
+    initializer = []
+    names = []
+    lines = []
+    for i, w in enumerate(weights):
+        wname = f"W{i}"
+        initializer.append(_f32(w, wname))
+        lines.append(f"h{i} = MatMul(X, {wname})")
+        names.append(f"h{i}")
+    lines.append(f"merged = Concat<axis={axis}>({', '.join(names)})")
+    lines.append("Y = MatMul(merged, WOUT)")
+    initializer.append(_f32(w_out, "WOUT"))
+    body = "\n          ".join(lines)
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          {body}
+        }}
+        """,
+        initializer=initializer,
+    )
+
+
+def _conv_concat_model(weights, w_out, axis=1, spatial=10):
+    # The Conv analogue of _matmul_concat_model -- the U-Net-style
+    # encoder/decoder merge this whole section exists for. `weights[i]` is
+    # `[Ci, Cin, kH, kW]`; `w_out` is `[Cout, sum(Ci), kH, kW]`.
+    Cin = weights[0].shape[1]
+    Cout = w_out.shape[0]
+    initializer = []
+    names = []
+    lines = []
+    for i, w in enumerate(weights):
+        wname = f"W{i}"
+        initializer.append(_f32(w, wname))
+        lines.append(f"h{i} = Conv<kernel_shape=[3,3]>(X, {wname})")
+        names.append(f"h{i}")
+    lines.append(f"merged = Concat<axis={axis}>({', '.join(names)})")
+    lines.append("Y = Conv<kernel_shape=[3,3]>(merged, WOUT)")
+    initializer.append(_f32(w_out, "WOUT"))
+    out_spatial = spatial - 4
+    body = "\n          ".join(lines)
+    return _model(
+        f"""
+        g (float[N,{Cin},{spatial},{spatial}] X) => (float[N,{Cout},{out_spatial},{out_spatial}] Y)
+        {{
+          {body}
+        }}
+        """,
+        initializer=initializer,
+    )
+
+
+def test_structured_pruning_matmul_concat_prunes_each_branch_to_its_own_count():
+    # Ca != Cb, same sparsity fraction -- proves each branch is sized from
+    # its *own* channel count (round(Ca*(1-s)) vs round(Cb*(1-s))), not one
+    # shared count the way a gated/residual merge's shared keep set would
+    # force. keep_a = 10 - round(10*0.5) = 5; keep_b = 6 - round(6*0.5) = 3.
+    K, Ca, Cb, Out = 8, 10, 6, 4
+    rng = np.random.default_rng(200)
+    wa = rng.standard_normal((K, Ca)).astype(np.float32)
+    wb = rng.standard_normal((K, Cb)).astype(np.float32)
+    wout = rng.standard_normal((Ca + Cb, Out)).astype(np.float32)
+    model = _matmul_concat_model([wa, wb], wout)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W0"].dims) == [K, 5]
+    assert list(inits["W1"].dims) == [K, 3]
+    assert list(inits["WOUT"].dims) == [8, Out]
+
+
+def test_structured_pruning_matmul_concat_matches_oracle_no_cross_branch_coupling():
+    # Branch a's weights are scaled 10x branch b's -- a bug that (wrongly)
+    # combined both branches into one shared importance ranking, the way
+    # _find_matmul_residual_chains/_find_gated_chains do, would keep every
+    # one of branch a's columns and none of branch b's (a's smallest column
+    # still dwarfs b's largest). Correct independent per-branch ranking
+    # keeps each branch's own top half regardless of the other branch's
+    # scale -- confirmed both by an explicit non-empty/expected-set check on
+    # branch b's own survivors and by the full onnxruntime oracle match.
+    K, C, Out = 8, 8, 4
+    rng = np.random.default_rng(201)
+    wa = rng.standard_normal((K, C)).astype(np.float32) * 10.0
+    wb = rng.standard_normal((K, C)).astype(np.float32)
+    wout = rng.standard_normal((2 * C, Out)).astype(np.float32)
+    model = _matmul_concat_model([wa, wb], wout)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep_a = np.sort(
+        np.argsort(-np.linalg.norm(wa.astype(np.float64), axis=0))[: C // 2]
+    )
+    keep_b = np.sort(
+        np.argsort(-np.linalg.norm(wb.astype(np.float64), axis=0))[: C // 2]
+    )
+    assert len(keep_b) == C // 2  # branch b kept its own top half, not starved to 0
+    global_keep = np.concatenate([keep_a, keep_b + C])
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W0"], wa[:, keep_a])
+    np.testing.assert_array_equal(inits["W1"], wb[:, keep_b])
+    np.testing.assert_array_equal(inits["WOUT"], wout[global_keep, :])
+
+    oracle = _matmul_concat_model([wa[:, keep_a], wb[:, keep_b]], wout[global_keep, :])
+    rng_x = np.random.default_rng(202)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_matmul_concat_three_branches_matches_oracle():
+    # N-ary Concat (three branches, three different channel counts) -- not
+    # fixed at two operands the way an Add merge is.
+    K, Ca, Cb, Cc, Out = 6, 8, 4, 6, 3
+    rng = np.random.default_rng(203)
+    wa = rng.standard_normal((K, Ca)).astype(np.float32)
+    wb = rng.standard_normal((K, Cb)).astype(np.float32)
+    wc = rng.standard_normal((K, Cc)).astype(np.float32)
+    wout = rng.standard_normal((Ca + Cb + Cc, Out)).astype(np.float32)
+    model = _matmul_concat_model([wa, wb, wc], wout)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep_a = np.sort(np.argsort(-np.linalg.norm(wa.astype(np.float64), axis=0))[:4])
+    keep_b = np.sort(np.argsort(-np.linalg.norm(wb.astype(np.float64), axis=0))[:2])
+    keep_c = np.sort(np.argsort(-np.linalg.norm(wc.astype(np.float64), axis=0))[:3])
+    global_keep = np.concatenate([keep_a, keep_b + Ca, keep_c + Ca + Cb])
+    oracle = _matmul_concat_model(
+        [wa[:, keep_a], wb[:, keep_b], wc[:, keep_c]], wout[global_keep, :]
+    )
+
+    rng_x = np.random.default_rng(204)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_matmul_concat_branch_activation_matches_oracle():
+    # Each branch's own Relu (between its producer's raw output and the
+    # Concat operand) is carried on that branch's own `pre_ops` -- exercised
+    # here alongside a post-Concat Sigmoid (an ordinary _walk_to_consumer
+    # hop, unrelated to the Concat machinery itself) to confirm both compose.
+    K, Ca, Cb, Out = 8, 8, 6, 4
+    rng = np.random.default_rng(205)
+    wa = rng.standard_normal((K, Ca)).astype(np.float32)
+    wb = rng.standard_normal((K, Cb)).astype(np.float32)
+    wout = rng.standard_normal((Ca + Cb, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          ha = MatMul(X, WA)
+          aa = Relu(ha)
+          hb = MatMul(X, WB)
+          ab = Relu(hb)
+          merged = Concat<axis=-1>(aa, ab)
+          s = Sigmoid(merged)
+          Y = MatMul(s, WOUT)
+        }}
+        """,
+        initializer=[_f32(wa, "WA"), _f32(wb, "WB"), _f32(wout, "WOUT")],
+    )
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep_a = np.sort(
+        np.argsort(-np.linalg.norm(wa.astype(np.float64), axis=0))[: Ca // 2]
+    )
+    keep_b = np.sort(
+        np.argsort(-np.linalg.norm(wb.astype(np.float64), axis=0))[: Cb // 2]
+    )
+    global_keep = np.concatenate([keep_a, keep_b + Ca])
+    oracle = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          ha = MatMul(X, WA)
+          aa = Relu(ha)
+          hb = MatMul(X, WB)
+          ab = Relu(hb)
+          merged = Concat<axis=-1>(aa, ab)
+          s = Sigmoid(merged)
+          Y = MatMul(s, WOUT)
+        }}
+        """,
+        initializer=[
+            _f32(wa[:, keep_a], "WA"),
+            _f32(wb[:, keep_b], "WB"),
+            _f32(wout[global_keep, :], "WOUT"),
+        ],
+    )
+
+    rng_x = np.random.default_rng(206)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_wanda_pruning_matmul_concat_matches_oracle():
+    # Confirms the exact ||W_row||_2 * ||X||_2 formula and probe point
+    # (each branch's own operand feeding the Concat node, captured
+    # independently -- not the shared downstream consumer, and not mixed
+    # with the other branch's activation): weight columns are deliberately
+    # scaled so the two branches' importances differ, and the pruned
+    # result is checked bit-for-bit against a hand-computed oracle using
+    # the real captured activations, the same correctness bar every other
+    # "matches_oracle" test in this module holds to.
+    K, Ca, Cb, Out = 6, 6, 6, 4
+    rng = np.random.default_rng(207)
+    wa = rng.standard_normal((K, Ca)).astype(np.float32)
+    wb = rng.standard_normal((K, Cb)).astype(np.float32)
+    wa[:, : Ca // 2] *= 3.0  # weight-only ranking favors the first half ...
+    wb[:, : Cb // 2] *= 3.0
+    wout = rng.standard_normal((Ca + Cb, Out)).astype(np.float32)
+    model = _matmul_concat_model([wa, wb], wout)
+
+    probe_model = onnx.ModelProto()
+    probe_model.CopyFrom(model)
+    probe_model.graph.output.append(
+        onnx.helper.make_tensor_value_info("h0", onnx.TensorProto.FLOAT, None)
+    )
+    probe_model.graph.output.append(
+        onnx.helper.make_tensor_value_info("h1", onnx.TensorProto.FLOAT, None)
+    )
+
+    rng_cal = np.random.default_rng(208)
+    x_cal = rng_cal.standard_normal((16, K)).astype(np.float32)
+    calibration_data = [{"X": x_cal}]
+    _, h0_cal, h1_cal = _run(probe_model, {"X": x_cal})
+    norm_a = np.sqrt(np.mean(np.square(h0_cal.astype(np.float64)), axis=0))
+    norm_b = np.sqrt(np.mean(np.square(h1_cal.astype(np.float64)), axis=0))
+
+    pruned = onnxsim.apply_structured_wanda_pruning(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned)
+
+    importance_a = np.linalg.norm(wa.astype(np.float64), axis=0) * np.maximum(
+        norm_a, 1e-8
+    )
+    importance_b = np.linalg.norm(wb.astype(np.float64), axis=0) * np.maximum(
+        norm_b, 1e-8
+    )
+    keep_a = np.sort(np.argsort(-importance_a)[: Ca // 2])
+    keep_b = np.sort(np.argsort(-importance_b)[: Cb // 2])
+    global_keep = np.concatenate([keep_a, keep_b + Ca])
+    oracle = _matmul_concat_model([wa[:, keep_a], wb[:, keep_b]], wout[global_keep, :])
+
+    rng_x = np.random.default_rng(209)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_wanda_pruning_matmul_concat_protects_low_weight_high_activation_channel_per_branch():
+    # The structured analogue of Wanda's own motivating scenario
+    # (test_structured_wanda_pruning_protects_channels_with_small_weight_but_large_activation
+    # above), replayed independently on *each* branch of a Concat: branch
+    # a's own column 0 has a deliberately tiny weight (so plain L2-norm
+    # pruning drops it) but responds only to input feature k0, which
+    # calibration data makes huge -- and branch b's own column 0 is the
+    # same construction against a *different* feature k1. Both must be
+    # protected independently for this to pass: a bug that captured only
+    # one branch's activation (or swapped the two, or fell back to probing
+    # the shared downstream consumer) would protect at most one of them.
+    K, Ca, Cb = 8, 6, 6
+    k0, k1 = 0, 1
+    small_scale = 0.4  # matches the single-branch test's own scale
+    rng = np.random.default_rng(207)
+    wa = rng.standard_normal((K, Ca)).astype(np.float32) * 0.5
+    wb = rng.standard_normal((K, Cb)).astype(np.float32) * 0.5
+    # Every *non*-salient column, on both branches, is barred from
+    # responding to either amplified feature at all -- otherwise, since
+    # both branches share the same input X, an ordinary column with a
+    # random (uncontrolled) coefficient on k0/k1 would pick up the same
+    # amplification and swamp the deliberately small salient column's own
+    # importance, defeating the decoupling this test depends on. Branch a's
+    # own salient column (0) is then zeroed and given a single small tap on
+    # k0 alone; branch b's mirrors that against k1.
+    wa[k1, :] = 0.0  # branch a never responds to b's own amplified feature
+    wa[k0, 1:] = 0.0  # only branch a's own salient column responds to k0
+    wa[:, 0] = 0.0
+    wa[k0, 0] = small_scale
+    wb[k0, :] = 0.0  # branch b never responds to a's own amplified feature
+    wb[k1, 1:] = 0.0  # only branch b's own salient column responds to k1
+    wb[:, 0] = 0.0
+    wb[k1, 0] = small_scale
+    wout = rng.standard_normal((Ca + Cb, 4)).astype(np.float32)
+    model = _matmul_concat_model([wa, wb], wout)
+
+    x = rng.standard_normal((64, K)).astype(np.float32)
+    x[:, k0] *= 80.0
+    x[:, k1] *= 80.0
+    calibration_data = [{"X": x}]
+
+    plain = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    wanda = onnxsim.apply_structured_wanda_pruning(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    onnx.checker.check_model(plain)
+    onnx.checker.check_model(wanda)
+
+    assert 0 not in _kept_columns(plain, "W0", wa)
+    assert 0 in _kept_columns(wanda, "W0", wa)
+    assert 0 not in _kept_columns(plain, "W1", wb)
+    assert 0 in _kept_columns(wanda, "W1", wb)
+
+
+def test_structured_pruning_matmul_concat_declines_on_positive_axis():
+    # `axis=1` on a 2-D [batch, C] tensor is numerically the same as
+    # `axis=-1`, but this pass never looks up a tensor's rank (see this
+    # section's own comment), so a positive axis is declined rather than
+    # guessed at -- left completely untouched, even though this particular
+    # instance would in fact have been safe.
+    K, Ca, Cb, Out = 8, 6, 4, 3
+    rng = np.random.default_rng(210)
+    wa = rng.standard_normal((K, Ca)).astype(np.float32)
+    wb = rng.standard_normal((K, Cb)).astype(np.float32)
+    wout = rng.standard_normal((Ca + Cb, Out)).astype(np.float32)
+    model = _matmul_concat_model([wa, wb], wout, axis=1)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W0"], wa)
+    np.testing.assert_array_equal(inits["W1"], wb)
+    np.testing.assert_array_equal(inits["WOUT"], wout)
+
+
+def test_structured_pruning_matmul_concat_declines_on_branch_fan_out():
+    # Branch a's own raw output feeds both the Concat node *and* a second
+    # graph output directly -- the same single-consumer safety bar every
+    # other hop in this pass holds every intermediate tensor to. The whole
+    # group is declined, branch b included, never partially pruned.
+    K, Ca, Cb, Out = 8, 6, 4, 3
+    rng = np.random.default_rng(211)
+    wa = rng.standard_normal((K, Ca)).astype(np.float32)
+    wb = rng.standard_normal((K, Cb)).astype(np.float32)
+    wout = rng.standard_normal((Ca + Cb, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y, float[batch,{Ca}] Extra)
+        {{
+          ha = MatMul(X, WA)
+          hb = MatMul(X, WB)
+          merged = Concat<axis=-1>(ha, hb)
+          Y = MatMul(merged, WOUT)
+          Extra = Identity(ha)
+        }}
+        """,
+        initializer=[_f32(wa, "WA"), _f32(wb, "WB"), _f32(wout, "WOUT")],
+    )
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["WA"], wa)
+    np.testing.assert_array_equal(inits["WB"], wb)
+    np.testing.assert_array_equal(inits["WOUT"], wout)
+
+
+def test_structured_pruning_matmul_concat_declines_on_graph_input_branch():
+    # One Concat operand is a graph input *directly* -- its only consumer is
+    # the Concat node itself (so it passes the single-consumer check), but
+    # it has no producing node at all, so the backward walk fails on that
+    # operand and the whole group (including the *other*, otherwise-
+    # prunable branch) is declined. X2 is a second, unrelated input so this
+    # doesn't also (accidentally) exercise the fan-out decline path above.
+    K, Cb, Out = 6, 4, 3
+    rng = np.random.default_rng(212)
+    wb = rng.standard_normal((K, Cb)).astype(np.float32)
+    wout = rng.standard_normal((K + Cb, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X, float[batch,{K}] X2) => (float[batch,{Out}] Y)
+        {{
+          hb = MatMul(X2, WB)
+          merged = Concat<axis=-1>(X, hb)
+          Y = MatMul(merged, WOUT)
+        }}
+        """,
+        initializer=[_f32(wb, "WB"), _f32(wout, "WOUT")],
+    )
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["WB"], wb)
+    np.testing.assert_array_equal(inits["WOUT"], wout)
+
+
+def test_structured_pruning_matmul_concat_declines_on_residual_merge_branch():
+    # One Concat operand is itself an eligible Add-residual merge point's
+    # raw output -- composing a residual merge with a Concat merge on the
+    # same branch isn't verified (see this section's own comment): the
+    # backward walk's "add" outcome is declined exactly like "fail", so the
+    # whole group -- both the residual pair and the plain second branch --
+    # is left untouched.
+    K, C, Cb, Out = 8, 6, 4, 3
+    rng = np.random.default_rng(213)
+    wf = rng.standard_normal((K, C)).astype(np.float32)
+    ws = rng.standard_normal((K, C)).astype(np.float32)
+    wb = rng.standard_normal((K, Cb)).astype(np.float32)
+    wout = rng.standard_normal((C + Cb, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          f = MatMul(X, WF)
+          s = MatMul(X, WS)
+          addr = Add(f, s)
+          hb = MatMul(X, WB)
+          merged = Concat<axis=-1>(addr, hb)
+          Y = MatMul(merged, WOUT)
+        }}
+        """,
+        initializer=[
+            _f32(wf, "WF"),
+            _f32(ws, "WS"),
+            _f32(wb, "WB"),
+            _f32(wout, "WOUT"),
+        ],
+    )
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["WF"], wf)
+    np.testing.assert_array_equal(inits["WS"], ws)
+    np.testing.assert_array_equal(inits["WB"], wb)
+    np.testing.assert_array_equal(inits["WOUT"], wout)
+
+
+def test_structured_pruning_matmul_concat_declines_on_duplicate_operand():
+    # Concat(h, h) -- the same tensor named twice as an operand of the same
+    # Concat node -- is degenerate (not two independent branches at all) and
+    # is declined outright.
+    K, C, Out = 8, 6, 3
+    rng = np.random.default_rng(214)
+    w1 = rng.standard_normal((K, C)).astype(np.float32)
+    wout = rng.standard_normal((2 * C, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          h = MatMul(X, W1)
+          merged = Concat<axis=-1>(h, h)
+          Y = MatMul(merged, WOUT)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(wout, "WOUT")],
+    )
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["WOUT"], wout)
+
+
+def test_structured_pruning_conv_concat_prunes_each_branch_to_its_own_count():
+    Cin, Ca, Cb, Cout = 3, 10, 6, 4
+    rng = np.random.default_rng(215)
+    wa = rng.standard_normal((Ca, Cin, 3, 3)).astype(np.float32)
+    wb = rng.standard_normal((Cb, Cin, 3, 3)).astype(np.float32)
+    wout = rng.standard_normal((Cout, Ca + Cb, 3, 3)).astype(np.float32)
+    model = _conv_concat_model([wa, wb], wout)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W0"].dims) == [5, Cin, 3, 3]
+    assert list(inits["W1"].dims) == [3, Cin, 3, 3]
+    assert list(inits["WOUT"].dims) == [Cout, 8, 3, 3]
+
+
+def test_structured_pruning_conv_concat_matches_oracle_no_cross_branch_coupling():
+    # The Conv analogue of the MatMul "no cross-branch coupling" test above
+    # -- branch a's filters scaled 10x branch b's; correct independent
+    # per-branch ranking keeps each branch's own top half regardless.
+    Cin, C, Cout = 3, 8, 4
+    rng = np.random.default_rng(216)
+    wa = rng.standard_normal((C, Cin, 3, 3)).astype(np.float32) * 10.0
+    wb = rng.standard_normal((C, Cin, 3, 3)).astype(np.float32)
+    wout = rng.standard_normal((Cout, 2 * C, 3, 3)).astype(np.float32)
+    model = _conv_concat_model([wa, wb], wout)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep_a = _oracle_keep_indices_conv(wa, C // 2)
+    keep_b = _oracle_keep_indices_conv(wb, C // 2)
+    assert len(keep_b) == C // 2  # branch b kept its own top half, not starved to 0
+    global_keep = np.concatenate([keep_a, keep_b + C])
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W0"], wa[keep_a])
+    np.testing.assert_array_equal(inits["W1"], wb[keep_b])
+    np.testing.assert_array_equal(inits["WOUT"], wout[:, global_keep])
+
+    oracle = _conv_concat_model([wa[keep_a], wb[keep_b]], wout[:, global_keep])
+    rng_x = np.random.default_rng(217)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_conv_concat_with_depthwise_pass_through_matches_oracle():
+    # Branch a crosses a depthwise Conv hop (self-consistently matched by
+    # _walk_conv_producer_backward, the exact same mechanism the Conv
+    # residual section already verifies) before reaching the Concat node --
+    # confirming the pass-through hop's own weight/bias/`group` slice by
+    # branch a's own local `keep`, not the global one. The depthwise hop
+    # uses a 1x1 kernel (spatial-preserving) so branch a's own spatial size
+    # after its own two Convs (10 -> 8, unchanged by the 1x1 hop) still
+    # lines up with branch b's single-Conv spatial size (10 -> 8) at the
+    # point they Concat -- a 3x3 depthwise hop would shrink branch a's own
+    # spatial size a second time and the two branches could no longer
+    # Concat at all.
+    Cin, Ca, Cb, Cout = 3, 8, 4, 5
+    rng = np.random.default_rng(218)
+    wa = rng.standard_normal((Ca, Cin, 3, 3)).astype(np.float32)
+    wd = rng.standard_normal((Ca, 1, 1, 1)).astype(np.float32)
+    bd = rng.standard_normal((Ca,)).astype(np.float32)
+    wb = rng.standard_normal((Cb, Cin, 3, 3)).astype(np.float32)
+    wout = rng.standard_normal((Cout, Ca + Cb, 3, 3)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{Cout},6,6] Y)
+        {{
+          ha = Conv<kernel_shape=[3,3]>(X, WA)
+          ra = Relu(ha)
+          da = Conv<kernel_shape=[1,1], group={Ca}>(ra, WD, BD)
+          hb = Conv<kernel_shape=[3,3]>(X, WB)
+          merged = Concat<axis=1>(da, hb)
+          Y = Conv<kernel_shape=[3,3]>(merged, WOUT)
+        }}
+        """,
+        initializer=[
+            _f32(wa, "WA"),
+            _f32(wd, "WD"),
+            _f32(bd, "BD"),
+            _f32(wb, "WB"),
+            _f32(wout, "WOUT"),
+        ],
+    )
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep_a = _oracle_keep_indices_conv(wa, Ca // 2)
+    keep_b = _oracle_keep_indices_conv(wb, Cb // 2)
+    global_keep = np.concatenate([keep_a, keep_b + Ca])
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["WD"], wd[keep_a])
+    np.testing.assert_array_equal(inits["BD"], bd[keep_a])
+    dw_node = next(n for n in pruned.graph.node if "WD" in n.input)
+    group_attr = next(a.i for a in dw_node.attribute if a.name == "group")
+    assert group_attr == Ca // 2
+
+    oracle = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{Cout},6,6] Y)
+        {{
+          ha = Conv<kernel_shape=[3,3]>(X, WA)
+          ra = Relu(ha)
+          da = Conv<kernel_shape=[1,1], group={Ca // 2}>(ra, WD, BD)
+          hb = Conv<kernel_shape=[3,3]>(X, WB)
+          merged = Concat<axis=1>(da, hb)
+          Y = Conv<kernel_shape=[3,3]>(merged, WOUT)
+        }}
+        """,
+        initializer=[
+            _f32(wa[keep_a], "WA"),
+            _f32(wd[keep_a], "WD"),
+            _f32(bd[keep_a], "BD"),
+            _f32(wb[keep_b], "WB"),
+            _f32(wout[:, global_keep], "WOUT"),
+        ],
+    )
+    rng_x = np.random.default_rng(219)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_wanda_pruning_conv_concat_matches_oracle():
+    Cin, Ca, Cb, Cout = 3, 6, 6, 4
+    rng = np.random.default_rng(220)
+    wa = rng.standard_normal((Ca, Cin, 3, 3)).astype(np.float32)
+    wb = rng.standard_normal((Cb, Cin, 3, 3)).astype(np.float32)
+    wa[: Ca // 2] *= 3.0
+    wb[: Cb // 2] *= 3.0
+    wout = rng.standard_normal((Cout, Ca + Cb, 3, 3)).astype(np.float32)
+    model = _conv_concat_model([wa, wb], wout)
+
+    probe_model = onnx.ModelProto()
+    probe_model.CopyFrom(model)
+    probe_model.graph.output.append(
+        onnx.helper.make_tensor_value_info("h0", onnx.TensorProto.FLOAT, None)
+    )
+    probe_model.graph.output.append(
+        onnx.helper.make_tensor_value_info("h1", onnx.TensorProto.FLOAT, None)
+    )
+
+    rng_cal = np.random.default_rng(221)
+    x_cal = rng_cal.standard_normal((4, Cin, 10, 10)).astype(np.float32)
+    calibration_data = [{"X": x_cal}]
+    _, h0_cal, h1_cal = _run(probe_model, {"X": x_cal})
+    norm_a = np.sqrt(np.mean(np.square(h0_cal.astype(np.float64)), axis=(0, 2, 3)))
+    norm_b = np.sqrt(np.mean(np.square(h1_cal.astype(np.float64)), axis=(0, 2, 3)))
+
+    pruned = onnxsim.apply_structured_wanda_pruning(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned)
+
+    imp_a = np.linalg.norm(wa.reshape(Ca, -1).astype(np.float64), axis=1) * np.maximum(
+        norm_a, 1e-8
+    )
+    imp_b = np.linalg.norm(wb.reshape(Cb, -1).astype(np.float64), axis=1) * np.maximum(
+        norm_b, 1e-8
+    )
+    keep_a = np.sort(np.argsort(-imp_a)[: Ca // 2])
+    keep_b = np.sort(np.argsort(-imp_b)[: Cb // 2])
+    global_keep = np.concatenate([keep_a, keep_b + Ca])
+    oracle = _conv_concat_model([wa[keep_a], wb[keep_b]], wout[:, global_keep])
+
+    rng_x = np.random.default_rng(222)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_conv_concat_declines_on_wrong_axis():
+    # axis=2 is a spatial axis, not the channel axis of [N, C, H, W] -- left
+    # completely untouched, same conservative decline as a positive-axis
+    # MatMul/Gemm Concat.
+    Cin, Ca, Cb, Cout = 3, 4, 4, 4
+    rng = np.random.default_rng(223)
+    wa = rng.standard_normal((Ca, Cin, 3, 3)).astype(np.float32)
+    wb = rng.standard_normal((Cb, Cin, 3, 3)).astype(np.float32)
+    wout = rng.standard_normal((Cout, Ca, 3, 3)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{Cout},14,6] Y)
+        {{
+          ha = Conv<kernel_shape=[3,3]>(X, WA)
+          hb = Conv<kernel_shape=[3,3]>(X, WB)
+          merged = Concat<axis=2>(ha, hb)
+          Y = Conv<kernel_shape=[3,3]>(merged, WOUT)
+        }}
+        """,
+        initializer=[_f32(wa, "WA"), _f32(wb, "WB"), _f32(wout, "WOUT")],
+    )
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["WA"], wa)
+    np.testing.assert_array_equal(inits["WB"], wb)
+    np.testing.assert_array_equal(inits["WOUT"], wout)
+
+
+def test_structured_pruning_conv_concat_declines_on_grouped_conv_consumer():
+    # The downstream consumer is a general grouped Conv -- declined the same
+    # way _find_conv_residual_chains declines one (see this section's own
+    # comment): the per-group top-k assumes every producer feeds the
+    # consumer's full channel range, which independently-pruned Concat
+    # branches don't establish.
+    Cin, Ca, Cb, Cout, group = 3, 4, 4, 8, 2
+    rng = np.random.default_rng(224)
+    wa = rng.standard_normal((Ca, Cin, 3, 3)).astype(np.float32)
+    wb = rng.standard_normal((Cb, Cin, 3, 3)).astype(np.float32)
+    wout = rng.standard_normal((Cout, (Ca + Cb) // group, 1, 1)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{Cout},8,8] Y)
+        {{
+          ha = Conv<kernel_shape=[3,3]>(X, WA)
+          hb = Conv<kernel_shape=[3,3]>(X, WB)
+          merged = Concat<axis=1>(ha, hb)
+          Y = Conv<kernel_shape=[1,1], group={group}>(merged, WOUT)
+        }}
+        """,
+        initializer=[_f32(wa, "WA"), _f32(wb, "WB"), _f32(wout, "WOUT")],
+    )
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["WA"], wa)
+    np.testing.assert_array_equal(inits["WB"], wb)
+    np.testing.assert_array_equal(inits["WOUT"], wout)
+
+
 # --- apply_structured_wanda_pruning ------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- Investigated whether `Concat`-based skip connections (the U-Net-style encoder/decoder merge) have a bounded, provably-safe special case, the same way `Add`/`SkipLayerNormalization` residual connections turned out to — previously lumped in with the genuinely hard general-fan-out DepGraph problem and declined outright.
- **The structural insight checked out and is the opposite shape of the `Add` case**: `Add`'s operands are summed elementwise and *must* share one channel-index set (the entire reason the residual-chain machinery exists); `Concat`'s branches are structurally independent — branch `a` always owns columns `[0, Ca)` of the merged tensor, branch `b` always owns `[Ca, Ca+Cb)`, fixed by operand order alone, unaffected by how much of each branch survives pruning. So every branch can be ranked and pruned **entirely on its own**, and the only new mechanism needed is on the consumer side: slicing its weight at each branch's own fixed offset, using the concatenation of every branch's own `keep` set (each shifted by its own offset).
- Since `_Chain`/`_apply_chains`'s "one shared `keep` set, one importance ranking" shape genuinely doesn't fit N independent per-branch keep sets, this is a real sibling, not a forced extension: new `_ConcatBranch`/`_ConcatChain` dataclasses and `_apply_concat_chains`, alongside `_find_matmul_concat_chains`/`_find_conv_concat_chains`. Branch resolution reuses the *existing, unchanged* backward walkers the residual sections already built and verified.
- **A real cross-function safety gap was closed as part of this**: `_apply_chains` previously tracked its own touched-role bookkeeping locally, with no way to know if a `Concat` branch's producer weight was, via a tied/shared initializer, also some ordinary chain's producer elsewhere in the graph. New `_TouchedState`, shared by reference between `_apply_chains` and `_apply_concat_chains`, so a weight either one resizes can never be resized a second, conflicting time by the other.
- **Scope reached**: both MatMul/Gemm (last-axis `Concat`, `axis == -1` only — deliberately declines a positive axis even where it might numerically equal the last axis, to avoid a rank lookup) and Conv (`axis in (1, -3)`, `group=1` producers/consumer only); N-ary `Concat` (verified with 3 branches, different channel counts, different importance profiles); per-branch unary/bias-scale/`BiasGelu`/`FastGelu` hops before the `Concat` operand and depthwise-Conv pass-through hops; both `apply_structured_pruning` and `apply_structured_wanda_pruning` (each branch's own Wanda activation probed at its own pre-`Concat` point, not the shared consumer).
- **Declined, honestly, not guessed at** (each confirmed byte-identical): a positive `axis` on MatMul/Gemm branches; a non-channel `axis` on Conv; a branch that fans out to another consumer; a branch bottoming out at a graph input; a branch resolving through an `Add`/`SkipLayerNorm` residual merge (composing `Concat` with a residual merge on the same branch isn't verified here); duplicate `Concat` operands; a grouped (`group != 1`) Conv consumer; a `Concat` chained transitively into another `Concat` (falls out for free — neither backward walker recognizes `Concat` as a hop, so it's already an ordinary decline, no special-case code needed).
- **Three real bugs caught and fixed during the work's own development, before the first actual test run**: a Wanda test whose weight and activation magnitude were accidentally correlated through the shared input (not actually testing per-branch independence, as claimed); a Conv depthwise-pass-through test with a spatial-dimension mismatch between branches; a "declines on graph-input branch" test that was accidentally exercising the fan-out decline path instead.
- **Independently verified beyond the PR's own tests**: built a fresh 3-branch model (deliberately different channel counts, deliberately conflicting per-branch importance profiles) not reusing the PR's own test code, confirmed every branch prunes to its own independently-correct indices, the consumer is sliced at exactly the right offsets, and the real onnxruntime output matches a hand-built oracle exactly.

## Test plan
- [x] `pytest tests/test_pruning.py -q` — 172 passed (up from 159)
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — clean
- [x] Independent verification: fresh 3-branch, conflicting-importance, different-channel-count model re-derived by hand and confirmed via onnxruntime

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_