### PR TITLE
Materialize impure constant folds as Constant nodes

### DIFF
--- a/onnxsim/constant_folding.cpp
+++ b/onnxsim/constant_folding.cpp
@@ -544,8 +544,8 @@ void RunOpsAndAddInitializers(
     std::unordered_map<std::string, const onnx::NodeProto*>&
         constant_node_producers,
     std::deque<onnx::NodeProto>& new_constant_nodes) {
-  const auto output_tps = RunOps(executor, model, ops, deferred_producers,
-                                 constant_node_producers);
+  const auto output_tps =
+      RunOps(executor, model, ops, deferred_producers, constant_node_producers);
   for (const auto& output_tp : output_tps) {
     if (impure_outputs.count(output_tp.name()) == 0) {
       *model.mutable_graph()->add_initializer() = output_tp;
@@ -961,7 +961,8 @@ onnx::ModelProto _FoldConstant(const ModelExecutor& executor,
   // nodes for impure outputs (see RunOpsAndAddInitializers); new_constant_nodes
   // owns those (a std::deque, not a std::vector, so the pointers this map
   // holds into it stay valid as more are appended).
-  std::unordered_map<std::string, const onnx::NodeProto*> constant_node_producers;
+  std::unordered_map<std::string, const onnx::NodeProto*>
+      constant_node_producers;
   for (const auto& node : model.graph().node()) {
     const bool is_default_domain =
         node.domain().empty() || node.domain() == "ai.onnx";
@@ -1449,9 +1450,9 @@ void FoldGroupOnGraph(
   std::vector<onnx::Node*> ops(const_nodes.begin() + begin,
                                const_nodes.begin() + end);
   try {
-    RunOpsOnGraphResult result = RunOpsOnGraph(
-        executor, g, ops, deferred_producers, constant_node_producers,
-        ir_version);
+    RunOpsOnGraphResult result =
+        RunOpsOnGraph(executor, g, ops, deferred_producers,
+                      constant_node_producers, ir_version);
     // Every op in this batch folded successfully (RunOpsOnGraph throws,
     // rather than partially populating its result, on any failure) -- decode
     // each returned TensorProto (ToTensorProto always emits raw_data, see
@@ -1560,7 +1561,8 @@ bool _FoldConstantOnGraph(const ModelExecutor& executor, onnx::Graph& g,
   // Constant nodes for impure outputs (see FoldGroupOnGraph).
   std::unordered_map<std::string, onnx::Node*> constant_node_producers;
   for (onnx::Node* node : node_ptrs) {
-    const std::string domain = node->has_domain() ? node->domain() : std::string();
+    const std::string domain =
+        node->has_domain() ? node->domain() : std::string();
     const bool is_default_domain = domain.empty() || domain == "ai.onnx";
     if (is_default_domain && node->kind() == onnx::kConstant) {
       for (onnx::Value* out : node->outputs()) {

--- a/onnxsim/constant_folding.cpp
+++ b/onnxsim/constant_folding.cpp
@@ -647,6 +647,17 @@ struct ConstantNodePartition {
   std::set<std::string> impure_outputs;
 };
 
+// Whether `node` (assumed op_type "Constant") was marked transient by another
+// onnxsim pass -- see kTransientConstantAttr's own comment.
+bool IsTransientConstant(const onnx::NodeProto& node) {
+  for (const auto& attr : node.attribute()) {
+    if (attr.name() == kTransientConstantAttr) {
+      return true;
+    }
+  }
+  return false;
+}
+
 ConstantNodePartition GetConstantNodes(const onnx::ModelProto& model) {
   // tensor with empty name("") represents the empty value of an optional input
   // so "" should be treated as a name of a constant tensor.
@@ -703,10 +714,14 @@ ConstantNodePartition GetConstantNodes(const onnx::ModelProto& model) {
     // provenance distinction on the very next fixed-point iteration. Its
     // output still joins const_names so downstream nodes recognize it as a
     // constant input -- but never pure_names, so any consumer is correctly
-    // treated as not purely initializer-derived either.
+    // treated as not purely initializer-derived either. Exception: a node
+    // marked transient (kTransientConstantAttr) is another onnxsim pass's own
+    // intermediate representation, not a provenance-worthy Constant, so it
+    // falls through to the ordinary foldable path below instead.
     const bool is_default_domain =
         node.domain().empty() || node.domain() == "ai.onnx";
-    if (is_default_domain && node.op_type() == "Constant") {
+    if (is_default_domain && node.op_type() == "Constant" &&
+        !IsTransientConstant(node)) {
       const_names.insert(node.output().begin(), node.output().end());
       non_const_nodes.push_back(node);
       continue;
@@ -1145,6 +1160,12 @@ size_t EstimateOutputBytesOnGraph(onnx::Node* node) {
   return total;
 }
 
+// Graph-native counterpart of IsTransientConstant.
+bool IsTransientConstantOnGraph(onnx::Node* node) {
+  static const onnx::Symbol kTransientAttr(kTransientConstantAttr);
+  return node->hasAttribute(kTransientAttr);
+}
+
 // Graph-native counterpart of GetConstantNodes.
 ConstantNodePartitionGraph GetConstantNodesOnGraph(
     onnx::Graph& g, const std::vector<onnx::Node*>& node_ptrs) {
@@ -1178,12 +1199,14 @@ ConstantNodePartitionGraph GetConstantNodesOnGraph(
     const std::string domain =
         node->has_domain() ? node->domain() : std::string();
     const std::string op_type = node->kind().toString();
-    // Leave Constant nodes untouched -- see GetConstantNodes' own comment on
-    // its identical special case for the full rationale (idempotence: a
-    // Constant node created by a previous round for an impure fold must not
-    // be trivially re-folded straight back into an initializer).
+    // Leave Constant nodes untouched, transient ones excepted -- see
+    // GetConstantNodes' own comment on its identical special case for the
+    // full rationale (idempotence: a Constant node created by a previous
+    // round for an impure fold must not be trivially re-folded straight back
+    // into an initializer) and kTransientConstantAttr's own comment.
     const bool is_default_domain = domain.empty() || domain == "ai.onnx";
-    if (is_default_domain && node->kind() == onnx::kConstant) {
+    if (is_default_domain && node->kind() == onnx::kConstant &&
+        !IsTransientConstantOnGraph(node)) {
       for (onnx::Value* out : node->outputs()) {
         const_names.insert(out->uniqueName());
       }

--- a/onnxsim/constant_folding.cpp
+++ b/onnxsim/constant_folding.cpp
@@ -8,6 +8,7 @@
 #endif
 #include <algorithm>
 #include <cstring>
+#include <deque>
 #include <functional>
 #include <iostream>
 #include <map>
@@ -335,7 +336,9 @@ std::vector<onnx::TensorProto> RunOps(
     const ModelExecutor& executor, const onnx::ModelProto& model,
     const std::vector<const onnx::NodeProto*>& ops,
     const std::unordered_map<std::string, const onnx::NodeProto*>&
-        deferred_producers) {
+        deferred_producers,
+    const std::unordered_map<std::string, const onnx::NodeProto*>&
+        constant_node_producers) {
   std::vector<std::string> input_names;
   // Pointers borrow directly from `model`'s own initializers -- `model` is
   // const and not touched again until every pointer here has been consumed
@@ -413,6 +416,16 @@ std::vector<onnx::TensorProto> RunOps(
             // Produced by a deferred node: inline it rather than treating the
             // (unmaterialized) output as an external constant input.
             include_node(*deferred_iter->second);
+            continue;
+          }
+          auto constant_iter = constant_node_producers.find(input);
+          if (constant_iter != constant_node_producers.end()) {
+            // Produced by a Constant node (pre-existing, or created by an
+            // earlier fold batch/round because that fold was not purely
+            // initializer-derived): its value has no initializer to look up,
+            // so inline the (zero-input, so trivially includable) Constant
+            // node itself instead.
+            include_node(*constant_iter->second);
             continue;
           }
           if (!seen_inputs.insert(input).second) {
@@ -499,14 +512,47 @@ std::vector<onnx::TensorProto> RunOps(
   return output_tps;
 }
 
+// Builds a `Constant` NodeProto whose sole output holds `output_tp` as its
+// `value` attribute (verbatim, raw_data included).
+onnx::NodeProto MakeConstantNode(const onnx::TensorProto& output_tp) {
+  onnx::NodeProto node;
+  node.set_op_type("Constant");
+  node.add_output(output_tp.name());
+  onnx::AttributeProto* attr = node.add_attribute();
+  attr->set_name("value");
+  attr->set_type(onnx::AttributeProto::TENSOR);
+  *attr->mutable_t() = output_tp;
+  return node;
+}
+
+// Materializes a successfully-folded batch's outputs into `model`: an output
+// in `impure_outputs` (see ConstantNodePartition's own doc comment) becomes a
+// fresh `Constant` node instead of a plain initializer. `new_constant_nodes`
+// owns every such node for the rest of this fold pass (stable references,
+// unlike a std::vector, since later batches keep pointers into it via
+// `constant_node_producers`) and collects them for the caller to splice into
+// the model's node list once folding is done (see _FoldConstant's
+// RebuildNodeList step). `constant_node_producers` is grown with each new
+// Constant node's output name so a later batch that consumes it can inline it
+// via RunOps' own lookup, exactly like a pre-existing Constant node.
 void RunOpsAndAddInitializers(
     const ModelExecutor& executor, onnx::ModelProto& model,
     const std::vector<const onnx::NodeProto*>& ops,
     const std::unordered_map<std::string, const onnx::NodeProto*>&
-        deferred_producers) {
-  const auto output_tps = RunOps(executor, model, ops, deferred_producers);
+        deferred_producers,
+    const std::set<std::string>& impure_outputs,
+    std::unordered_map<std::string, const onnx::NodeProto*>&
+        constant_node_producers,
+    std::deque<onnx::NodeProto>& new_constant_nodes) {
+  const auto output_tps = RunOps(executor, model, ops, deferred_producers,
+                                 constant_node_producers);
   for (const auto& output_tp : output_tps) {
-    *model.mutable_graph()->add_initializer() = output_tp;
+    if (impure_outputs.count(output_tp.name()) == 0) {
+      *model.mutable_graph()->add_initializer() = output_tp;
+      continue;
+    }
+    new_constant_nodes.push_back(MakeConstantNode(output_tp));
+    constant_node_producers[output_tp.name()] = &new_constant_nodes.back();
   }
 }
 
@@ -579,7 +625,8 @@ bool ProduceLargeTensor(const onnx::ModelProto& model,
 
 // The result of partitioning a graph's nodes for constant folding.
 struct ConstantNodePartition {
-  // Nodes whose output is materialized into an initializer by folding.
+  // Nodes whose output is materialized (into an initializer or a fresh
+  // Constant node, see impure_outputs below) by folding.
   std::vector<onnx::NodeProto> const_nodes;
   // Nodes kept in the graph (folded consumers reference their outputs via
   // initializers, or they are genuinely non-constant runtime nodes).
@@ -591,6 +638,13 @@ struct ConstantNodePartition {
   // foldable; RunOps inlines the producing node into the sub-model it executes,
   // so the large intermediate tensor is computed transiently and never stored.
   std::set<std::string> deferred_outputs;
+  // Outputs of const_nodes whose value does not trace back purely to graph
+  // initializers -- transitively, through a chain of other purely-initializer
+  // folds -- because somewhere upstream it consumes a Constant node's embedded
+  // value or a deferred output. These are materialized as a fresh Constant node
+  // rather than an initializer, so a value the graph actually computed stays
+  // visually distinct from literal weight data; see RunOpsAndAddInitializers.
+  std::set<std::string> impure_outputs;
 };
 
 ConstantNodePartition GetConstantNodes(const onnx::ModelProto& model) {
@@ -604,6 +658,11 @@ ConstantNodePartition GetConstantNodes(const onnx::ModelProto& model) {
   // O(constants seen so far) per input, i.e. O(nodes * initializers) overall
   // on a model with many weights; a hash set makes each lookup O(1) average.
   std::unordered_set<std::string> const_names{""};
+  // Subset of const_names whose value traces back purely to graph
+  // initializers -- transitively, through other purely-initializer folds --
+  // as opposed to a Constant node's embedded value or a deferred (large-
+  // tensor) output. See ConstantNodePartition::impure_outputs.
+  std::unordered_set<std::string> pure_names{""};
   ConstantNodePartition partition;
   auto& const_nodes = partition.const_nodes;
   auto& non_const_nodes = partition.non_const_nodes;
@@ -615,6 +674,7 @@ ConstantNodePartition GetConstantNodes(const onnx::ModelProto& model) {
   if (config.initializers_as_constants) {
     for (const auto& x : model.graph().initializer()) {
       const_names.insert(x.name());
+      pure_names.insert(x.name());
     }
   }
   // Map each domain to its imported opset version so the correct operator
@@ -633,6 +693,24 @@ ConstantNodePartition GetConstantNodes(const onnx::ModelProto& model) {
   };
   // node is already topo sorted
   for (const auto& node : model.graph().node()) {
+    // A Constant node's output is already a fully-resolved value -- leave it
+    // exactly as-is (never re-materialize it into an initializer or a new
+    // Constant node) rather than folding it like any other node. This keeps
+    // the pass idempotent: a Constant node this same function created on a
+    // previous round (because a fold was not purely initializer-derived, see
+    // impure_outputs) would otherwise be trivially "foldable" (zero inputs)
+    // and get flattened straight back into an initializer, erasing the
+    // provenance distinction on the very next fixed-point iteration. Its
+    // output still joins const_names so downstream nodes recognize it as a
+    // constant input -- but never pure_names, so any consumer is correctly
+    // treated as not purely initializer-derived either.
+    const bool is_default_domain =
+        node.domain().empty() || node.domain() == "ai.onnx";
+    if (is_default_domain && node.op_type() == "Constant") {
+      const_names.insert(node.output().begin(), node.output().end());
+      non_const_nodes.push_back(node);
+      continue;
+    }
     const bool foldable =
         IsOfficialOp(node.domain(), node.op_type()) &&
         IsDeterministic(node.domain(), node.op_type(),
@@ -646,9 +724,19 @@ ConstantNodePartition GetConstantNodes(const onnx::ModelProto& model) {
       continue;
     }
     if (!ProduceLargeTensor(model, node, config.tensor_size_threshold)) {
-      // Ordinary constant folding: the output is materialized as an
-      // initializer and the node is dropped.
+      // Ordinary constant folding: the output is materialized (as an
+      // initializer, or a Constant node if not purely initializer-derived)
+      // and the node is dropped.
+      const bool pure = std::all_of(
+          node.input().begin(), node.input().end(),
+          [&pure_names](const auto& x) { return pure_names.count(x) > 0; });
       const_names.insert(node.output().begin(), node.output().end());
+      if (pure) {
+        pure_names.insert(node.output().begin(), node.output().end());
+      } else {
+        partition.impure_outputs.insert(node.output().begin(),
+                                        node.output().end());
+      }
       const_nodes.push_back(node);
       continue;
     }
@@ -785,6 +873,10 @@ void FoldGroup(const ModelExecutor& executor, onnx::ModelProto& model,
                size_t end,
                const std::unordered_map<std::string, const onnx::NodeProto*>&
                    deferred_producers,
+               const std::set<std::string>& impure_outputs,
+               std::unordered_map<std::string, const onnx::NodeProto*>&
+                   constant_node_producers,
+               std::deque<onnx::NodeProto>& new_constant_nodes,
                std::set<std::string>& folded_outputs) {
   if (begin >= end) {
     return;
@@ -795,7 +887,9 @@ void FoldGroup(const ModelExecutor& executor, onnx::ModelProto& model,
     ops.push_back(&const_nodes[k]);
   }
   try {
-    RunOpsAndAddInitializers(executor, model, ops, deferred_producers);
+    RunOpsAndAddInitializers(executor, model, ops, deferred_producers,
+                             impure_outputs, constant_node_producers,
+                             new_constant_nodes);
     for (size_t k = begin; k < end; k++) {
       for (const auto& output : const_nodes[k].output()) {
         folded_outputs.insert(output);
@@ -811,8 +905,10 @@ void FoldGroup(const ModelExecutor& executor, onnx::ModelProto& model,
     }
     const size_t mid = begin + (end - begin) / 2;
     FoldGroup(executor, model, const_nodes, begin, mid, deferred_producers,
+              impure_outputs, constant_node_producers, new_constant_nodes,
               folded_outputs);
     FoldGroup(executor, model, const_nodes, mid, end, deferred_producers,
+              impure_outputs, constant_node_producers, new_constant_nodes,
               folded_outputs);
   }
 }
@@ -844,6 +940,23 @@ onnx::ModelProto _FoldConstant(const ModelExecutor& executor,
       }
     }
   }
+  // Map each pre-existing Constant node's output to the node itself, seeding
+  // the lookup RunOps uses to inline a Constant node's embedded value instead
+  // of looking it up as an initializer. Grown as folding creates new Constant
+  // nodes for impure outputs (see RunOpsAndAddInitializers); new_constant_nodes
+  // owns those (a std::deque, not a std::vector, so the pointers this map
+  // holds into it stay valid as more are appended).
+  std::unordered_map<std::string, const onnx::NodeProto*> constant_node_producers;
+  for (const auto& node : model.graph().node()) {
+    const bool is_default_domain =
+        node.domain().empty() || node.domain() == "ai.onnx";
+    if (is_default_domain && node.op_type() == "Constant") {
+      for (const auto& output : node.output()) {
+        constant_node_producers.emplace(output, &node);
+      }
+    }
+  }
+  std::deque<onnx::NodeProto> new_constant_nodes;
   // Look up each tensor's inferred shape so batches can be capped by the
   // bytes they would materialize (see below). Pointers reference `model`,
   // which is not mutated (only appended to) while the map is in use.
@@ -878,7 +991,8 @@ onnx::ModelProto _FoldConstant(const ModelExecutor& executor,
   for (size_t i = 0; i < num_const_nodes;) {
     if (consumes_deferred(const_nodes[i])) {
       FoldGroup(executor, model, const_nodes, i, i + 1, deferred_producers,
-                folded_outputs);
+                partition.impure_outputs, constant_node_producers,
+                new_constant_nodes, folded_outputs);
       i++;
       continue;
     }
@@ -894,7 +1008,8 @@ onnx::ModelProto _FoldConstant(const ModelExecutor& executor,
       j++;
     }
     FoldGroup(executor, model, const_nodes, i, j, deferred_producers,
-              folded_outputs);
+              partition.impure_outputs, constant_node_producers,
+              new_constant_nodes, folded_outputs);
     i = j;
   }
   // Rebuild the node list in its original topological order, dropping only
@@ -902,11 +1017,18 @@ onnx::ModelProto _FoldConstant(const ModelExecutor& executor,
   // node that failed to fold must keep its original position: appending it to
   // the end can place it after a non-const consumer (e.g. a Loop reading a
   // SequenceEmpty output), which breaks topological sorting and makes the
-  // resulting model fail onnx's checker (issues #238, #335, #352).
+  // resulting model fail onnx's checker (issues #238, #335, #352). Newly
+  // created Constant nodes (impure folds) are prepended ahead of everything
+  // else: they have no inputs of their own, so any position before their
+  // first use is topologically valid, and the front trivially satisfies that
+  // for every consumer regardless of where it sits in `original_nodes`.
   {
     onnxsim::ProfiledScope rebuild_scope("RebuildNodeList");
     google::protobuf::RepeatedPtrField<onnx::NodeProto> original_nodes;
     original_nodes.Swap(model.mutable_graph()->mutable_node());
+    for (auto& node : new_constant_nodes) {
+      *model.mutable_graph()->add_node() = std::move(node);
+    }
     for (auto& node : original_nodes) {
       const bool folded =
           node.output_size() > 0 && folded_outputs.count(node.output(0)) > 0;
@@ -938,12 +1060,17 @@ onnx::ModelProto _FoldConstant(const ModelExecutor& executor,
 // an initializer folding leaves dangling in that mode.
 
 struct ConstantNodePartitionGraph {
-  // Nodes whose output is materialized into an initializer by folding, in
-  // topological order.
+  // Nodes whose output is materialized (into an initializer or a fresh
+  // Constant node, see impure_outputs below) by folding, in topological
+  // order.
   std::vector<onnx::Node*> const_nodes;
   // Unique names of "deferred" nodes' outputs -- see ConstantNodePartition's
   // own doc comment; same semantics, ported verbatim.
   std::unordered_set<std::string> deferred_outputs;
+  // Outputs of const_nodes that do not trace back purely to graph
+  // initializers -- see ConstantNodePartition::impure_outputs, same
+  // semantics, ported verbatim.
+  std::unordered_set<std::string> impure_outputs;
 };
 
 bool HasSubgraphAttr(onnx::Node* node) {
@@ -1022,10 +1149,15 @@ size_t EstimateOutputBytesOnGraph(onnx::Node* node) {
 ConstantNodePartitionGraph GetConstantNodesOnGraph(
     onnx::Graph& g, const std::vector<onnx::Node*>& node_ptrs) {
   std::unordered_set<std::string> const_names{""};
+  // Subset of const_names whose value traces back purely to graph
+  // initializers -- see GetConstantNodes' own pure_names for the full
+  // rationale, ported verbatim.
+  std::unordered_set<std::string> pure_names{""};
   ConstantNodePartitionGraph partition;
   if (config.initializers_as_constants) {
     for (const auto& name : g.initializer_names()) {
       const_names.insert(name);
+      pure_names.insert(name);
     }
   }
   std::unordered_map<std::string, int> domain_to_version;
@@ -1046,6 +1178,17 @@ ConstantNodePartitionGraph GetConstantNodesOnGraph(
     const std::string domain =
         node->has_domain() ? node->domain() : std::string();
     const std::string op_type = node->kind().toString();
+    // Leave Constant nodes untouched -- see GetConstantNodes' own comment on
+    // its identical special case for the full rationale (idempotence: a
+    // Constant node created by a previous round for an impure fold must not
+    // be trivially re-folded straight back into an initializer).
+    const bool is_default_domain = domain.empty() || domain == "ai.onnx";
+    if (is_default_domain && node->kind() == onnx::kConstant) {
+      for (onnx::Value* out : node->outputs()) {
+        const_names.insert(out->uniqueName());
+      }
+      continue;
+    }
     const bool foldable =
         IsOfficialOp(domain, op_type) &&
         IsDeterministic(domain, op_type, opset_version_of(domain)) &&
@@ -1061,8 +1204,20 @@ ConstantNodePartitionGraph GetConstantNodesOnGraph(
       continue;
     }
     if (!ProduceLargeTensorOnGraph(node, config.tensor_size_threshold)) {
+      const bool pure = std::all_of(
+          node->inputs().begin(), node->inputs().end(),
+          [&pure_names](onnx::Value* v) {
+            const std::string name =
+                v->node()->kind() == onnx::kUndefined ? "" : v->uniqueName();
+            return pure_names.count(name) > 0;
+          });
       for (onnx::Value* out : node->outputs()) {
         const_names.insert(out->uniqueName());
+        if (pure) {
+          pure_names.insert(out->uniqueName());
+        } else {
+          partition.impure_outputs.insert(out->uniqueName());
+        }
       }
       partition.const_nodes.push_back(node);
       continue;
@@ -1094,6 +1249,7 @@ RunOpsOnGraphResult RunOpsOnGraph(
     const ModelExecutor& executor, onnx::Graph& g,
     const std::vector<onnx::Node*>& ops,
     const std::unordered_map<std::string, onnx::Node*>& deferred_producers,
+    const std::unordered_map<std::string, onnx::Node*>& constant_node_producers,
     int64_t ir_version) {
   std::vector<std::string> input_names;
   std::vector<const onnx::Tensor*> input_tensors;
@@ -1139,6 +1295,16 @@ RunOpsOnGraphResult RunOpsOnGraph(
       auto deferred_iter = deferred_producers.find(name);
       if (deferred_iter != deferred_producers.end()) {
         include_node(deferred_iter->second);
+        continue;
+      }
+      auto constant_iter = constant_node_producers.find(name);
+      if (constant_iter != constant_node_producers.end()) {
+        // Produced by a Constant node (pre-existing, or created by an
+        // earlier fold batch/round because that fold was not purely
+        // initializer-derived): its value has no initializer to look up, so
+        // inline the (zero-input, so trivially includable) Constant node
+        // itself instead.
+        include_node(constant_iter->second);
         continue;
       }
       if (!seen_inputs.insert(name).second) {
@@ -1239,13 +1405,20 @@ RunOpsOnGraphResult RunOpsOnGraph(
 }
 
 // Graph-native counterpart of FoldGroup: splices each successfully-folded
-// output directly into `g` as a new initializer (Graph::
-// addInitializerAndCreateValue), rewires the folded node's uses onto it,
-// and removes the folded node -- no NodeProto rebuild needed.
+// output directly into `g` -- as a new initializer (Graph::
+// addInitializerAndCreateValue) when it is in `impure_outputs` (see
+// ConstantNodePartitionGraph's own doc comment), a fresh Constant node
+// otherwise -- rewires the folded node's uses onto it, and removes the
+// folded node -- no NodeProto rebuild needed. `constant_node_producers` is
+// grown with each new Constant node so a later batch/round that consumes it
+// can inline it via RunOpsOnGraph's own lookup, exactly like a pre-existing
+// Constant node.
 void FoldGroupOnGraph(
     const ModelExecutor& executor, onnx::Graph& g,
     const std::vector<onnx::Node*>& const_nodes, size_t begin, size_t end,
     const std::unordered_map<std::string, onnx::Node*>& deferred_producers,
+    const std::unordered_set<std::string>& impure_outputs,
+    std::unordered_map<std::string, onnx::Node*>& constant_node_producers,
     size_t& num_folded, int64_t ir_version) {
   if (begin >= end) {
     return;
@@ -1253,16 +1426,17 @@ void FoldGroupOnGraph(
   std::vector<onnx::Node*> ops(const_nodes.begin() + begin,
                                const_nodes.begin() + end);
   try {
-    RunOpsOnGraphResult result =
-        RunOpsOnGraph(executor, g, ops, deferred_producers, ir_version);
+    RunOpsOnGraphResult result = RunOpsOnGraph(
+        executor, g, ops, deferred_producers, constant_node_producers,
+        ir_version);
     // Every op in this batch folded successfully (RunOpsOnGraph throws,
     // rather than partially populating its result, on any failure) -- decode
     // each returned TensorProto (ToTensorProto always emits raw_data, see
-    // dlpack_bridge.h) into a Tensor, add it as a new initializer, and
-    // rewire the Value it replaces onto it. A multi-output node's outputs
-    // are independent Values here, each replaced on its own; the owning
-    // node is only destroyed (never touched again after) once every one of
-    // its outputs has been replaced.
+    // dlpack_bridge.h) into a Tensor, add it as a new initializer or Constant
+    // node, and rewire the Value it replaces onto it. A multi-output node's
+    // outputs are independent Values here, each replaced on its own; the
+    // owning node is only destroyed (never touched again after) once every
+    // one of its outputs has been replaced.
     std::unordered_map<onnx::Node*, size_t> remaining_outputs;
     for (onnx::Node* node : ops) {
       remaining_outputs[node] = node->outputs().size();
@@ -1278,7 +1452,28 @@ void FoldGroupOnGraph(
       if (tp.has_raw_data()) {
         t.set_raw_data(tp.raw_data());
       }
-      onnx::Value* new_value = g.addInitializerAndCreateValue(t);
+      onnx::Value* new_value;
+      if (impure_outputs.count(tp.name()) == 0) {
+        new_value = g.addInitializerAndCreateValue(t);
+      } else {
+        // Not purely initializer-derived: materialize as a Constant node
+        // (inserted right where the folded node used to be -- always
+        // topologically valid, since a Constant node has no inputs of its
+        // own to satisfy) instead of an initializer.
+        onnx::Node* constant = g.create(onnx::kConstant, 1);
+        constant->t_(onnx::kvalue, t);
+        std::vector<onnx::Dimension> sizes;
+        sizes.reserve(tp.dims_size());
+        for (int64_t d : tp.dims()) {
+          sizes.emplace_back(d);
+        }
+        constant->output()->setSizes(sizes);
+        constant->output()->setElemType(tp.data_type());
+        constant->output()->setUniqueName(tp.name());
+        constant->insertBefore(owner);
+        constant_node_producers[tp.name()] = constant;
+        new_value = constant->output();
+      }
       old_value->replaceAllUsesWith(new_value);
       if (--remaining_outputs[owner] == 0) {
         owner->destroy();
@@ -1295,9 +1490,11 @@ void FoldGroupOnGraph(
     }
     const size_t mid = begin + (end - begin) / 2;
     FoldGroupOnGraph(executor, g, const_nodes, begin, mid, deferred_producers,
-                     num_folded, ir_version);
+                     impure_outputs, constant_node_producers, num_folded,
+                     ir_version);
     FoldGroupOnGraph(executor, g, const_nodes, mid, end, deferred_producers,
-                     num_folded, ir_version);
+                     impure_outputs, constant_node_producers, num_folded,
+                     ir_version);
   }
 }
 
@@ -1334,6 +1531,20 @@ bool _FoldConstantOnGraph(const ModelExecutor& executor, onnx::Graph& g,
       }
     }
   }
+  // Map each pre-existing Constant node's output to the node itself, seeding
+  // the lookup RunOpsOnGraph uses to inline a Constant node's embedded value
+  // instead of looking it up as an initializer. Grown as folding creates new
+  // Constant nodes for impure outputs (see FoldGroupOnGraph).
+  std::unordered_map<std::string, onnx::Node*> constant_node_producers;
+  for (onnx::Node* node : node_ptrs) {
+    const std::string domain = node->has_domain() ? node->domain() : std::string();
+    const bool is_default_domain = domain.empty() || domain == "ai.onnx";
+    if (is_default_domain && node->kind() == onnx::kConstant) {
+      for (onnx::Value* out : node->outputs()) {
+        constant_node_producers.emplace(out->uniqueName(), node);
+      }
+    }
+  }
 
   constexpr size_t kBatchByteBudget = size_t(256) << 20;  // 256 MiB
   constexpr size_t kBatchMaxNodes = 1024;
@@ -1354,6 +1565,7 @@ bool _FoldConstantOnGraph(const ModelExecutor& executor, onnx::Graph& g,
   for (size_t i = 0; i < num_const_nodes;) {
     if (consumes_deferred(const_nodes[i])) {
       FoldGroupOnGraph(executor, g, const_nodes, i, i + 1, deferred_producers,
+                       partition.impure_outputs, constant_node_producers,
                        num_folded, ir_version);
       i++;
       continue;
@@ -1370,6 +1582,7 @@ bool _FoldConstantOnGraph(const ModelExecutor& executor, onnx::Graph& g,
       j++;
     }
     FoldGroupOnGraph(executor, g, const_nodes, i, j, deferred_producers,
+                     partition.impure_outputs, constant_node_producers,
                      num_folded, ir_version);
     i = j;
   }

--- a/onnxsim/constant_folding.cpp
+++ b/onnxsim/constant_folding.cpp
@@ -955,18 +955,29 @@ onnx::ModelProto _FoldConstant(const ModelExecutor& executor,
       }
     }
   }
-  // Map each pre-existing Constant node's output to the node itself, seeding
-  // the lookup RunOps uses to inline a Constant node's embedded value instead
-  // of looking it up as an initializer. Grown as folding creates new Constant
-  // nodes for impure outputs (see RunOpsAndAddInitializers); new_constant_nodes
-  // owns those (a std::deque, not a std::vector, so the pointers this map
-  // holds into it stay valid as more are appended).
+  // Map each pre-existing, non-transient Constant node's output to the node
+  // itself, seeding the lookup RunOps uses to inline a Constant node's
+  // embedded value instead of looking it up as an initializer. Grown as
+  // folding creates new Constant nodes for impure outputs (see
+  // RunOpsAndAddInitializers); new_constant_nodes owns those (a std::deque,
+  // not a std::vector, so the pointers this map holds into it stay valid as
+  // more are appended).
+  //
+  // Transient Constant nodes (kTransientConstantAttr) are deliberately
+  // excluded: unlike a genuine Constant node -- which GetConstantNodes leaves
+  // untouched for this whole call -- a transient one is *not* special-cased
+  // there and flows through the ordinary foldable path instead, so it may be
+  // folded (and its NodeProto dropped from the model) by RebuildNodeList
+  // before this map is next consulted. Seeding it here would eventually
+  // dangle. It doesn't need to be seeded anyway: once folded, its value is a
+  // plain initializer that FindInitializerByName already resolves.
   std::unordered_map<std::string, const onnx::NodeProto*>
       constant_node_producers;
   for (const auto& node : model.graph().node()) {
     const bool is_default_domain =
         node.domain().empty() || node.domain() == "ai.onnx";
-    if (is_default_domain && node.op_type() == "Constant") {
+    if (is_default_domain && node.op_type() == "Constant" &&
+        !IsTransientConstant(node)) {
       for (const auto& output : node.output()) {
         constant_node_producers.emplace(output, &node);
       }
@@ -1555,16 +1566,28 @@ bool _FoldConstantOnGraph(const ModelExecutor& executor, onnx::Graph& g,
       }
     }
   }
-  // Map each pre-existing Constant node's output to the node itself, seeding
-  // the lookup RunOpsOnGraph uses to inline a Constant node's embedded value
-  // instead of looking it up as an initializer. Grown as folding creates new
-  // Constant nodes for impure outputs (see FoldGroupOnGraph).
+  // Map each pre-existing, non-transient Constant node's output to the node
+  // itself, seeding the lookup RunOpsOnGraph uses to inline a Constant node's
+  // embedded value instead of looking it up as an initializer. Grown as
+  // folding creates new Constant nodes for impure outputs (see
+  // FoldGroupOnGraph).
+  //
+  // Transient Constant nodes (kTransientConstantAttr) are deliberately
+  // excluded -- see _FoldConstant's identical seeding loop for the full
+  // rationale. Here it's a use-after-free, not just staleness: a transient
+  // node flows through the ordinary foldable path and gets destroyed
+  // (FoldGroupOnGraph's `owner->destroy()`) once folded, but this map is
+  // seeded once up front and never told, so a later batch's lookup could
+  // dereference the freed Node*. It doesn't need seeding anyway: once
+  // folded, its value is a plain initializer that g.getInitializer already
+  // resolves.
   std::unordered_map<std::string, onnx::Node*> constant_node_producers;
   for (onnx::Node* node : node_ptrs) {
     const std::string domain =
         node->has_domain() ? node->domain() : std::string();
     const bool is_default_domain = domain.empty() || domain == "ai.onnx";
-    if (is_default_domain && node->kind() == onnx::kConstant) {
+    if (is_default_domain && node->kind() == onnx::kConstant &&
+        !IsTransientConstantOnGraph(node)) {
       for (onnx::Value* out : node->outputs()) {
         constant_node_producers.emplace(out->uniqueName(), node);
       }

--- a/onnxsim/constant_folding.h
+++ b/onnxsim/constant_folding.h
@@ -2,10 +2,14 @@
 
 // Constant folding: partitioning a graph's nodes into foldable/non-foldable,
 // running the foldable ones through a ModelExecutor, and materializing their
-// outputs as initializers. Two parallel implementations live here: one that
-// works on onnx::ModelProto (used by the legacy Simplify path), and a
-// Graph-native one that walks onnx::Graph directly (see this file's own
-// top-of-.cpp comment on the Graph-native section for why both exist).
+// outputs -- as a plain initializer when the fold traces back purely to graph
+// initializers, or as a fresh Constant node otherwise (e.g. a fold that
+// consumed a pre-existing Constant node's embedded value), so that
+// provenance stays visible in the output model. Two parallel implementations
+// live here: one that works on onnx::ModelProto (used by the legacy Simplify
+// path), and a Graph-native one that walks onnx::Graph directly (see this
+// file's own top-of-.cpp comment on the Graph-native section for why both
+// exist).
 
 #include <onnx/onnx_pb.h>
 
@@ -41,9 +45,9 @@ extern Config config;
 // once, before the first folding round.
 void FixupSchemaDeterminism();
 
-// Fold every foldable constant subexpression of `model` into initializers,
-// dropping the folded nodes and sweeping up initializers left unused by the
-// fold.
+// Fold every foldable constant subexpression of `model` (into initializers or
+// Constant nodes, see this file's own top-of-file comment), dropping the
+// folded nodes and sweeping up initializers left unused by the fold.
 onnx::ModelProto _FoldConstant(const ModelExecutor& executor,
                                onnx::ModelProto model);
 

--- a/onnxsim/constant_folding.h
+++ b/onnxsim/constant_folding.h
@@ -24,6 +24,18 @@ namespace onnx {
 class Graph;
 }  // namespace onnx
 
+// Attribute name marking a `Constant` node as "transient": created by another
+// onnxsim pass (partial_shape_eval.cpp) purely as an intermediate
+// representation for a value that pass already proved is fully known, with
+// the explicit expectation (see that file's own comments) that the ordinary
+// constant folder will normalize it -- into a plain initializer if its value
+// is otherwise purely initializer-derived, exactly as if the pass had never
+// represented it as a Constant node at all. Such a node must not be treated
+// as a source of "not from initializers" provenance the way a genuine (user-
+// authored, or another impure fold's own) Constant node is; see
+// GetConstantNodes/GetConstantNodesOnGraph's Constant-node special case.
+inline constexpr char kTransientConstantAttr[] = "onnxsim_transient_constant";
+
 // Shared simplification configuration. Read by constant folding (this file)
 // and by Optimize()/OptAndShapeOnGraph() (onnxsim.cpp) to keep both in sync
 // on how initializers are treated and which optimizer passes run.

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -307,17 +307,24 @@ static onnx::ModelProto SimplifyImpl(
   // redundant here, and it aborts the whole process on graphs where a Gather
   // index cannot be statically resolved to an axis (common in dynamic-shape
   // detection models such as FasterRCNN). Always drop it from the pass list.
-  std::vector<std::string> always_disabled_passes = {"eliminate_shape_gather"};
-  // When initializers are treated as non-constant, keep ``Constant`` nodes in
-  // producer form: ``extract_constant_to_initializer`` would rewrite every
-  // Constant into an initializer, which -- being non-constant now -- would then
-  // block onnxsim's own constant folding of genuinely-constant subgraphs. The
-  // value-baking passes themselves already leave initializer weights alone via
-  // ``IsConstantTensor`` (see the onnx-optimizer changes), so only this
-  // representation-changing pass needs dropping.
-  if (!initializers_as_constants) {
-    always_disabled_passes.push_back("extract_constant_to_initializer");
-  }
+  // Always keep ``Constant`` nodes in producer form: onnxsim's own constant
+  // folder (constant_folding.cpp's GetConstantNodes/GetConstantNodesOnGraph)
+  // now leaves a ``Constant`` node untouched rather than baking it into an
+  // initializer, on the theory that a Constant node's value is not "graph
+  // weight data" the way an initializer is -- and materializes any fold that
+  // is not purely initializer-derived (directly or transitively) as a fresh
+  // Constant node of its own, so that distinction stays visible in the
+  // output model. ``extract_constant_to_initializer`` would erase it right
+  // back by rewriting every Constant into an initializer -- including ones
+  // onnxsim itself just created -- so it is always dropped from the pass
+  // list, not just when initializers are treated as non-constant (where it
+  // additionally has the correctness problem that its output, being
+  // non-constant, would block further folding of genuinely-constant
+  // subgraphs). The value-baking passes themselves already leave initializer
+  // weights alone via ``IsConstantTensor`` (see the onnx-optimizer changes),
+  // so only this representation-changing pass needs dropping.
+  std::vector<std::string> always_disabled_passes = {
+      "eliminate_shape_gather", "extract_constant_to_initializer"};
   auto is_disabled = [](const std::vector<std::string>& list,
                         const std::string& pass) {
     return std::find(list.begin(), list.end(), pass) != list.end();

--- a/onnxsim/partial_shape_eval.cpp
+++ b/onnxsim/partial_shape_eval.cpp
@@ -12,6 +12,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "constant_folding.h"
 #include "onnx/common/graph_shape_inference.h"
 #include "onnx/common/ir_pb_converter.h"
 #include "onnx/defs/schema.h"
@@ -752,6 +753,16 @@ void _EvalPartialShape(onnx::ModelProto& model) {
       attr->set_name("value");
       attr->set_type(onnx::AttributeProto::TENSOR);
       *attr->mutable_t() = std::move(iter->second);
+      // Marked transient (see kTransientConstantAttr's own comment): this
+      // Constant node is this pass's own intermediate representation for a
+      // value it already proved fully known, not a source of "not from
+      // initializers" provenance -- the ordinary constant folder should
+      // normalize it away like any other node, not treat it as an opaque
+      // Constant to leave alone.
+      onnx::AttributeProto* transient_attr = constant->add_attribute();
+      transient_attr->set_name(kTransientConstantAttr);
+      transient_attr->set_type(onnx::AttributeProto::INT);
+      transient_attr->set_i(1);
       continue;
     }
     auto fix_iter = node.output_size() == 1 ? reshape_fixes.find(node.output(0))
@@ -768,6 +779,11 @@ void _EvalPartialShape(onnx::ModelProto& model) {
       attr->set_name("value");
       attr->set_type(onnx::AttributeProto::TENSOR);
       *attr->mutable_t() = std::move(fix_iter->second.shape_tensor);
+      // Transient -- see the other creation site's own comment above.
+      onnx::AttributeProto* transient_attr = shape_const->add_attribute();
+      transient_attr->set_name(kTransientConstantAttr);
+      transient_attr->set_type(onnx::AttributeProto::INT);
+      transient_attr->set_i(1);
 
       onnx::NodeProto* reshape = model.mutable_graph()->add_node();
       *reshape = std::move(node);
@@ -1029,6 +1045,12 @@ bool _EvalPartialShapeOnGraph(onnx::Graph& g) {
   // shape-producing subgraph dead for the optimizer's own dead-node
   // elimination to remove.
   static const onnx::Symbol kValueAttr("value");
+  // Marked transient (see kTransientConstantAttr's own comment): this pass's
+  // Constant nodes are its own intermediate representation for a value
+  // already proved fully known, not a source of "not from initializers"
+  // provenance -- the ordinary constant folder should normalize them away
+  // like any other node.
+  static const onnx::Symbol kTransientAttr(kTransientConstantAttr);
   for (onnx::Node* node : node_ptrs) {
     if (node->outputs().size() != 1) continue;
     onnx::Value* out = node->outputs()[0];
@@ -1036,6 +1058,7 @@ bool _EvalPartialShapeOnGraph(onnx::Graph& g) {
     if (iter != folded_values.end()) {
       onnx::Node* constant = g.create(onnx::kConstant, 1);
       constant->t_(kValueAttr, iter->second);
+      constant->i_(kTransientAttr, 1);
       constant->outputs()[0]->setElemType(iter->second.elem_type());
       constant->outputs()[0]->setSizes(std::vector<onnx::Dimension>(
           iter->second.sizes().begin(), iter->second.sizes().end()));
@@ -1048,6 +1071,7 @@ bool _EvalPartialShapeOnGraph(onnx::Graph& g) {
     if (fix_iter != reshape_fixes.end() && node->kind() == onnx::kReshape) {
       onnx::Node* shape_const = g.create(onnx::kConstant, 1);
       shape_const->t_(kValueAttr, fix_iter->second.shape_tensor);
+      shape_const->i_(kTransientAttr, 1);
       shape_const->outputs()[0]->setElemType(
           fix_iter->second.shape_tensor.elem_type());
       shape_const->outputs()[0]->setSizes(std::vector<onnx::Dimension>(

--- a/tests/test_fusion_patterns.py
+++ b/tests/test_fusion_patterns.py
@@ -638,8 +638,11 @@ def test_defer_constant_expand_folds_small_consumer():
     # --no-large-tensor the Expand is not materialized, but ReduceSum over it is
     # a small (scalar) foldable output whose value depends on the data (so it is
     # not handled by shape propagation). The executor still folds it by running
-    # Expand+ReduceSum together, and the scalar feeds a runtime Add, so the whole
-    # constant chain collapses without ever storing the expanded tensor.
+    # Expand+ReduceSum together, and the scalar feeds a runtime Add, so the
+    # constant chain collapses without ever storing the expanded tensor. The
+    # folded scalar is materialized as a Constant node rather than an
+    # initializer -- a deferred (large-tensor) output is never treated as
+    # purely initializer-derived, so its consumer isn't either.
     model = _model(
         """
         g (float[4,8] X) => (float[4,8] Y)
@@ -656,11 +659,15 @@ def test_defer_constant_expand_folds_small_consumer():
     sim_model, ops = _simplify_no_large_tensor(model)
     assert ops["Expand"] == 0
     assert ops["ReduceSum"] == 0
-    assert ops["Constant"] == 0
+    assert ops["Constant"] == 1
     assert ops["Add"] == 1
     assert all(
         onnx.numpy_helper.to_array(init).size < 512 * 512
         for init in sim_model.graph.initializer
+    )
+    (s_node,) = [n for n in sim_model.graph.node if n.op_type == "Constant"]
+    np.testing.assert_allclose(
+        onnx.numpy_helper.to_array(s_node.attribute[0].t), 3.0 * 512 * 512
     )
 
 

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -2112,16 +2112,59 @@ def test_initializers_as_constants_default_folds_initializer():
 
 def test_initializers_as_non_constants_keeps_initializer_node():
     # Treating initializers as non-constant leaves the Mul on the initializer in
-    # the graph; only the Constant node (K) is still folded.
+    # the graph; K is a Constant node already, so folding leaves it untouched.
     model = _mul_init_by_const_model()
     sim_model, ok = onnxsim.simplify(model, initializers_as_constants=False)
     assert ok
     op_types = [n.op_type for n in sim_model.graph.node]
     assert "Mul" in op_types
     assert "Add" in op_types
-    # W stays an initializer, and K has been folded into one too.
+    # W stays an initializer.
     init_names = {i.name for i in sim_model.graph.initializer}
     assert "W" in init_names
+
+
+def test_fold_not_purely_from_initializer_becomes_constant_node():
+    # W * K -- W an initializer, K a Constant node -- is still folded away (both
+    # are constant), but since the fold consumed a Constant node's value rather
+    # than tracing back purely to graph initializers, the result must itself be
+    # materialized as a Constant node rather than baked into a plain
+    # initializer, so a value the graph actually computed stays visually
+    # distinct from literal weight data.
+    model = _mul_init_by_const_model()
+    sim_model, ok = onnxsim.simplify(model)
+    assert ok
+    init_names = {i.name for i in sim_model.graph.initializer}
+    assert "M" not in init_names
+    (m_node,) = [n for n in sim_model.graph.node if "M" in n.output]
+    assert m_node.op_type == "Constant"
+    value = onnx.numpy_helper.to_array(m_node.attribute[0].t)
+    np.testing.assert_array_equal(value, np.array([2.0, 4.0, 6.0], dtype=np.float32))
+
+
+def test_fold_purely_from_initializer_stays_initializer():
+    # A * B, where A and B are both plain initializers, is a fold rooted purely
+    # in initializer data (no Constant node anywhere upstream), so it must still
+    # collapse into a plain initializer, exactly as before this behavior was
+    # made to depend on provenance.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 14]
+        >
+        test_fold_purely_from_initializer_stays_initializer () => (float[3] y)
+        <float[3] A = {1.0, 2.0, 3.0}, float[3] B = {4.0, 5.0, 6.0}>
+        {
+          y = Mul(A, B)
+        }
+        """
+    )
+    sim_model, ok = onnxsim.simplify(model)
+    assert ok
+    assert len(sim_model.graph.node) == 0
+    assert len(sim_model.graph.initializer) == 1
+    assert sim_model.graph.initializer[0].name == "y"
 
 
 def _model_with_local_function() -> onnx.ModelProto:

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -52,7 +52,11 @@ def test_a_model_not_need_simplification():
     net = ModelNotNeedSimplification()
     dummy_input = torch.randn(2, 3, 4, 5)
     sim_model = export_simplify_and_check_by_python_api(net, dummy_input)
-    assert len(sim_model.graph.node) == 1
+    # The exporter emits the literal `1` as a Constant node; onnxsim now leaves
+    # a genuine Constant node as-is rather than baking it into an initializer
+    # (only a fold's *result* gets that treatment), so it survives alongside
+    # the (unfoldable, `x` being a real input) Add.
+    assert len(sim_model.graph.node) == 2
 
 
 def test_exprimental_simplify_subgraph():
@@ -75,9 +79,14 @@ def test_exprimental_simplify_subgraph():
     sim_model = export_simplify_and_check_by_python_api(
         net, dummy_input, simplify_kwargs={"include_subgraph": True}
     )
-    assert len(sim_model.graph.node) == 3
-    assert len(sim_model.graph.node[2].attribute[0].g.node) == 2
-    assert len(sim_model.graph.node[2].attribute[1].g.node) == 1
+    # The exporter's literal constants (the `1.0` comparison threshold, and the
+    # `3`s / `4` added to `x`) are each a genuine Constant node; onnxsim leaves
+    # them as-is rather than baking them into initializers, so they now show up
+    # as their own nodes (one at the top level, two in then_branch, one in
+    # else_branch) alongside the previously-counted ops.
+    assert len(sim_model.graph.node) == 4
+    assert len(sim_model.graph.node[3].attribute[0].g.node) == 4
+    assert len(sim_model.graph.node[3].attribute[1].g.node) == 2
 
 
 def test_dynamic_batch_size():
@@ -99,7 +108,9 @@ def test_dynamic_batch_size():
         },
         simplify_kwargs={"test_input_shapes": {"input": [2, 3, 4, 5]}},
     )
-    assert len(sim_model.graph.node) == 1
+    # The exporter emits the literal `2` as a Constant node, which onnxsim now
+    # leaves as-is (see test_a_model_not_need_simplification).
+    assert len(sim_model.graph.node) == 2
 
 
 def test_dynamic_axes_preserve_dynamic_dimension():
@@ -241,7 +252,11 @@ def test_unused_output():
         },
         simplify_kwargs={"unused_output": ["output1", "output2"]},
     )
-    assert len(sim_model.graph.node) == 4
+    # The exporter emits one shared Constant node for the literal `2` reused by
+    # all four ops; onnxsim now leaves it as-is (see
+    # test_a_model_not_need_simplification) instead of baking it into an
+    # initializer, so it survives alongside them.
+    assert len(sim_model.graph.node) == 5
 
 
 def test_remove_unused_initializer():
@@ -2139,7 +2154,7 @@ def test_fold_not_purely_from_initializer_becomes_constant_node():
     (m_node,) = [n for n in sim_model.graph.node if "M" in n.output]
     assert m_node.op_type == "Constant"
     value = onnx.numpy_helper.to_array(m_node.attribute[0].t)
-    np.testing.assert_array_equal(value, np.array([2.0, 4.0, 6.0], dtype=np.float32))
+    np.testing.assert_array_equal(value, np.array([[2.0, 4.0, 6.0]], dtype=np.float32))
 
 
 def test_fold_purely_from_initializer_stays_initializer():


### PR DESCRIPTION
## Summary

This change improves the provenance tracking of constant folding by distinguishing between folds that trace back purely to graph initializers versus those that consume pre-existing Constant nodes or deferred (large) outputs. Folds that are not purely initializer-derived are now materialized as fresh Constant nodes rather than plain initializers, keeping the distinction between "graph weight data" (initializers) and "values the graph computed" (Constant nodes) visible in the output model.

## Key Changes

- **Provenance-aware folding**: Track whether each foldable node's inputs trace back purely to initializers (`pure_names`) or include Constant nodes/deferred outputs (`impure_outputs`). Folds rooted in impure inputs are materialized as Constant nodes instead of initializers.

- **Constant node preservation**: Pre-existing Constant nodes are now left untouched during folding (never re-materialized into initializers), making the pass idempotent. This prevents a Constant node created by one fold round from being trivially re-folded into an initializer on the next iteration.

- **Transient Constant marking**: Introduce `kTransientConstantAttr` to mark Constant nodes created by `partial_shape_eval.cpp` as intermediate representations that should be normalized away like any other node, not treated as opaque constants. This preserves the correctness of the partial shape evaluation pass.

- **Dual implementation**: Apply the same logic to both the ModelProto-based path (`_FoldConstant`) and the Graph-native path (`_FoldConstantOnGraph`), maintaining consistency across both code paths.

- **Disable `extract_constant_to_initializer`**: Always disable this optimizer pass to prevent it from erasing the provenance distinction by converting all Constant nodes back to initializers.

## Implementation Details

- New `MakeConstantNode()` helper creates a Constant NodeProto from a folded output tensor.
- `RunOps()` and `RunOpsOnGraph()` now accept `constant_node_producers` maps to inline Constant nodes' embedded values instead of looking them up as initializers.
- `FoldGroup()` and `FoldGroupOnGraph()` route outputs through `impure_outputs` to decide between initializer vs. Constant node materialization.
- Node list rebuilding prepends newly-created Constant nodes at the front (topologically valid since they have no inputs).
- Tests verify that folds from pure initializers stay as initializers, while folds consuming Constant nodes become Constant nodes themselves.

https://claude.ai/code/session_01Gi8bKDcbJMBV2LHmLyv4Si