### PR TITLE
Accept a positive Concat axis for MatMul/Gemm pruning when rank is confirmed

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -3958,12 +3958,7 @@ def _find_gated_chains(graph: onnx.GraphProto) -> List[_Chain]:
 #
 # `Concat`'s own `axis` attribute must actually be the channel axis this
 # pass's importance ranking operates on, and the two node families need
-# different, deliberately conservative answers for what that means, since
-# neither this pass nor this module in general ever looks up a tensor's
-# rank from `value_info`/shape inference (every other topology decision in
-# this module is answerable from node attributes and initializer shapes
-# alone, and this keeps that property rather than adding a new,
-# shape-inference-dependent dependency just for `Concat`):
+# different answers for what that means:
 #
 # - **Conv** branches are always rank-4 (`[N, C, H, W]`) -- every Conv this
 #   whole module ever matches is 2-D, no exception anywhere in this file --
@@ -3973,16 +3968,33 @@ def _find_gated_chains(graph: onnx.GraphProto) -> List[_Chain]:
 #   `[batch, seq, C]`, ...), but the reduction dimension every consumer
 #   match in this module already cares about is always the tensor's *last*
 #   axis regardless of rank (2-D weight, matrix-multiplied against
-#   whatever leading batch dimensions the input happens to carry) -- so only
-#   `axis == -1` is recognized. A model that spells the same last-axis
-#   concat with an explicit *positive* `axis` (e.g. `axis=1` on a 2-D
-#   `[batch, C]` tensor, numerically identical to `axis=-1` there) is
-#   declined rather than guessed at: confirming a positive `axis` actually
-#   equals "rank minus one" would need exactly the shape-inference-dependent
-#   rank lookup this module otherwise never needs, and this pass would
-#   rather decline a genuinely-safe-but-unconfirmed case than add that new
-#   dependency for it. See
-#   `test_structured_pruning_matmul_concat_declines_on_positive_axis`.
+#   whatever leading batch dimensions the input happens to carry) -- so
+#   `axis == -1` is always recognized outright (ONNX's own negative-axis
+#   convention already counts from the end, no rank lookup needed). A model
+#   that spells the same last-axis concat with an explicit *positive*
+#   `axis` (e.g. `axis=1` on a 2-D `[batch, C]` tensor, numerically
+#   identical to `axis=-1` there) is only recognized when the operands'
+#   rank can actually be confirmed: unlike every other topology decision in
+#   this module (answerable from node attributes and initializer shapes
+#   alone), this one genuinely needs a rank, and the *only* place this
+#   module ever looks one up is here, from the graph's own
+#   `value_info`/`input`/`output` type annotations (:func:`_tensor_rank`) --
+#   never from running shape inference itself, which this module (like the
+#   rest of onnxsim's `apply_*`/`quantize_*` passes) never does. Those
+#   annotations are reliably present for a graph that already went through
+#   onnxsim's own (or any) shape-inference pass before reaching this one --
+#   the ordinary case, since structured pruning is meant to run as one step
+#   in a larger pipeline -- but are just as reliably *absent* for a bare
+#   hand-built graph (every model in this module's own test suite, for
+#   instance, unless a test opts in with
+#   `onnx.shape_inference.infer_shapes()`). So a positive `axis` is accepted
+#   only when at least one operand's rank is known and every operand with a
+#   known rank agrees this axis is `rank - 1`; if no operand's rank can be
+#   confirmed, or two operands disagree, it's declined exactly as before --
+#   never guessed at. See
+#   `test_structured_pruning_matmul_concat_accepts_positive_last_axis_when_rank_known`,
+#   `test_structured_pruning_matmul_concat_declines_on_positive_non_last_axis`,
+#   and `test_structured_pruning_matmul_concat_declines_on_positive_axis_unknown_rank`.
 #
 # Once every operand resolves and the branches' fixed offsets are known, the
 # ordinary forward walk (:func:`_walk_to_consumer`/
@@ -4004,6 +4016,77 @@ def _concat_axis(node: onnx.NodeProto) -> Optional[int]:
         if attr.name == "axis":
             return attr.i
     return None  # required attribute on Concat's own schema -- malformed if absent
+
+
+def _value_info_by_name(
+    graph: onnx.GraphProto,
+) -> Dict[str, onnx.ValueInfoProto]:
+    """Every ``ValueInfoProto`` the graph carries for its own tensors --
+    `input`, `output`, and interior `value_info` -- keyed by tensor name.
+    The sole use is :func:`_tensor_rank`'s positive-`Concat`-axis rank
+    lookup (see this section's own comment); nothing else in this module
+    ever consults a tensor's declared type/shape.
+    """
+    by_name: Dict[str, onnx.ValueInfoProto] = {}
+    for vi in graph.input:
+        by_name[vi.name] = vi
+    for vi in graph.output:
+        by_name[vi.name] = vi
+    for vi in graph.value_info:
+        by_name[vi.name] = vi
+    return by_name
+
+
+def _tensor_rank(
+    name: str, value_info_by_name: Dict[str, onnx.ValueInfoProto]
+) -> Optional[int]:
+    """The tensor's rank (number of dimensions), if the graph's own
+    `value_info`/`input`/`output` annotations state it -- `None` if the
+    tensor has no such annotation at all, the annotation isn't a tensor
+    type, or it's a tensor type with no `shape` field (ONNX's own "rank not
+    statically known" spelling, distinct from a `shape` field present but
+    with an unknown/symbolic *dimension value*, which this only needs the
+    dimension *count* of and so doesn't care about). Never runs shape
+    inference itself -- see this section's own comment for why that's the
+    deliberate boundary.
+    """
+    vi = value_info_by_name.get(name)
+    if vi is None or not vi.type.HasField("tensor_type"):
+        return None
+    tensor_type = vi.type.tensor_type
+    if not tensor_type.HasField("shape"):
+        return None
+    return len(tensor_type.shape.dim)
+
+
+def _concat_axis_is_last(
+    node: onnx.NodeProto, value_info_by_name: Dict[str, onnx.ValueInfoProto]
+) -> bool:
+    """True if `node`'s own `axis` attribute is confirmed to select the
+    last axis of its operands -- `axis == -1` outright (ONNX's negative-axis
+    convention already counts from the end), or a positive `axis` only when
+    at least one operand's rank is known (:func:`_tensor_rank`) and every
+    operand with a known rank agrees `axis == rank - 1`. See this section's
+    own comment for the full reasoning and why a positive axis is otherwise
+    declined rather than guessed at.
+    """
+    axis = _concat_axis(node)
+    if axis is None:
+        return False
+    if axis < 0:
+        return axis == -1
+    known_rank: Optional[int] = None
+    for operand in node.input:
+        rank = _tensor_rank(operand, value_info_by_name)
+        if rank is None:
+            continue
+        if known_rank is None:
+            known_rank = rank
+        elif rank != known_rank:
+            return False  # operands disagree -- decline rather than guess
+    if known_rank is None:
+        return False  # no operand's rank is known -- decline rather than guess
+    return axis == known_rank - 1
 
 
 @dataclass(frozen=True)
@@ -4103,24 +4186,26 @@ def _branch_walk_has_fanout(
 
 def _find_matmul_concat_chains(graph: onnx.GraphProto) -> List[_ConcatChain]:
     """Finds MatMul/Gemm ``Concat``-merged skip connections -- see this
-    section's own comment. Every operand of a last-axis `Concat` (`axis ==
-    -1`; see this section's own comment for why a positive `axis` is
-    declined even when it might numerically equal the tensor's last axis)
-    is resolved backward, via :func:`_walk_matmul_producer_backward` (reused
-    unchanged from the MatMul/Gemm residual section above), to a real
-    MatMul/vanilla-Gemm producer -- only a `"producer"` outcome is accepted;
-    `"add"` (the operand resolves to an eligible residual/
-    `SkipLayerNormalization` merge instead) is declined exactly like
-    `"fail"`, since composing a residual merge with a `Concat` merge on the
-    same branch isn't verified here (see this section's own comment). If
-    *any* operand fails to resolve to a real producer, or two operands
-    resolve to the very same producer weight (degenerate), the whole
-    `Concat` node is declined -- never partially pruned.
+    section's own comment. Every operand of a last-axis `Concat`
+    (:func:`_concat_axis_is_last` -- `axis == -1` outright, or a positive
+    `axis` only when the operands' rank is confirmed via `value_info` to
+    actually be `rank - 1`) is resolved backward, via
+    :func:`_walk_matmul_producer_backward` (reused unchanged from the
+    MatMul/Gemm residual section above), to a real MatMul/vanilla-Gemm
+    producer -- only a `"producer"` outcome is accepted; `"add"` (the
+    operand resolves to an eligible residual/`SkipLayerNormalization` merge
+    instead) is declined exactly like `"fail"`, since composing a residual
+    merge with a `Concat` merge on the same branch isn't verified here (see
+    this section's own comment). If *any* operand fails to resolve to a
+    real producer, or two operands resolve to the very same producer weight
+    (degenerate), the whole `Concat` node is declined -- never partially
+    pruned.
     """
     initializer_map = {t.name: t for t in graph.initializer}
     consumers_of = _consumers_of(graph)
     node_by_output = {out: node for node in graph.node for out in node.output}
     graph_outputs = {o.name for o in graph.output}
+    value_info_by_name = _value_info_by_name(graph)
 
     def _is_internal(name: str) -> bool:
         return len(consumers_of.get(name, [])) == 1 and name not in graph_outputs
@@ -4129,7 +4214,7 @@ def _find_matmul_concat_chains(graph: onnx.GraphProto) -> List[_ConcatChain]:
     for node in graph.node:
         if node.op_type != "Concat" or len(node.input) < 2 or len(node.output) != 1:
             continue
-        if _concat_axis(node) != -1:
+        if not _concat_axis_is_last(node, value_info_by_name):
             continue
         if len(set(node.input)) != len(node.input):
             continue  # degenerate -- the same tensor concatenated with itself
@@ -4939,7 +5024,9 @@ def apply_structured_pruning(
     case -- the U-Net-style encoder/decoder merge (see
     :func:`_find_matmul_concat_chains`/:func:`_find_conv_concat_chains` and
     this module's own docstring) -- for both MatMul/Gemm (last-axis
-    ``Concat`` only, ``axis == -1``) and Conv (channel-axis ``Concat``,
+    ``Concat`` only -- ``axis == -1`` outright, or a positive `axis`
+    confirmed via `value_info` to equal ``rank - 1``, see
+    :func:`_concat_axis_is_last`) and Conv (channel-axis ``Concat``,
     ``axis in (1, -3)``) branches. Unlike a gated pair or a residual merge,
     a ``Concat``'s branches need no shared `keep` set at all: each branch
     owns a fixed, disjoint slice of the merged channel range and is ranked

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -7,6 +7,7 @@ import numpy as np
 import onnx
 import onnx.helper
 import onnx.numpy_helper
+import onnx.shape_inference
 import pytest
 from onnx import parser
 
@@ -4790,18 +4791,126 @@ def test_structured_wanda_pruning_matmul_concat_protects_low_weight_high_activat
     assert 0 in _kept_columns(wanda, "W1", wb)
 
 
-def test_structured_pruning_matmul_concat_declines_on_positive_axis():
+def test_structured_pruning_matmul_concat_declines_on_positive_axis_unknown_rank():
     # `axis=1` on a 2-D [batch, C] tensor is numerically the same as
-    # `axis=-1`, but this pass never looks up a tensor's rank (see this
-    # section's own comment), so a positive axis is declined rather than
-    # guessed at -- left completely untouched, even though this particular
-    # instance would in fact have been safe.
+    # `axis=-1`, but this bare hand-built graph carries no value_info at
+    # all for the Concat operands (h0/h1 -- no shape-inference pass ever
+    # ran over it), so their rank can't be confirmed and the positive axis
+    # is declined rather than guessed at -- left completely untouched, even
+    # though this particular instance would in fact have been safe. See
+    # test_structured_pruning_matmul_concat_accepts_positive_last_axis_when_rank_known
+    # for the same topology once the rank *is* confirmable.
     K, Ca, Cb, Out = 8, 6, 4, 3
     rng = np.random.default_rng(210)
     wa = rng.standard_normal((K, Ca)).astype(np.float32)
     wb = rng.standard_normal((K, Cb)).astype(np.float32)
     wout = rng.standard_normal((Ca + Cb, Out)).astype(np.float32)
     model = _matmul_concat_model([wa, wb], wout, axis=1)
+    assert len(model.graph.value_info) == 0  # no rank annotation to piggyback on
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W0"], wa)
+    np.testing.assert_array_equal(inits["W1"], wb)
+    np.testing.assert_array_equal(inits["WOUT"], wout)
+
+
+def test_structured_pruning_matmul_concat_declines_on_positive_axis_shape_unknown_rank():
+    # Same as the unknown-rank test above, but this time the operands *do*
+    # carry a value_info entry each (as a partially shape-inferred graph
+    # might, e.g. a symbolic-rank input propagated through) -- just one
+    # with no `shape` field at all, ONNX's own "rank not statically known"
+    # spelling (see CLAUDE.md's own note on this pattern). _tensor_rank must
+    # treat that exactly like no annotation at all, not crash on it or
+    # (worse) treat a present-but-empty shape as rank 0.
+    K, Ca, Cb, Out = 8, 6, 4, 3
+    rng = np.random.default_rng(214)
+    wa = rng.standard_normal((K, Ca)).astype(np.float32)
+    wb = rng.standard_normal((K, Cb)).astype(np.float32)
+    wout = rng.standard_normal((Ca + Cb, Out)).astype(np.float32)
+    model = _matmul_concat_model([wa, wb], wout, axis=1)
+    for name in ("h0", "h1"):
+        vi = onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, [1, 1])
+        vi.type.tensor_type.ClearField("shape")
+        model.graph.value_info.append(vi)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W0"], wa)
+    np.testing.assert_array_equal(inits["W1"], wb)
+    np.testing.assert_array_equal(inits["WOUT"], wout)
+
+
+def test_structured_pruning_matmul_concat_accepts_positive_last_axis_when_rank_known():
+    # `axis=1` on 2-D [batch, C] tensors is numerically identical to
+    # `axis=-1`, and once the graph carries value_info confirming each
+    # operand's rank -- as it would after a real shape-inference pass (e.g.
+    # onnxsim's own) ran earlier in the pipeline, the ordinary case
+    # structured pruning is meant to run in -- this pass now recognizes and
+    # prunes it exactly the same as the equivalent `axis=-1` graph: same
+    # kept columns, same values, same runtime output. This is the
+    # "genuinely-safe-but-unconfirmed" case
+    # test_structured_pruning_matmul_concat_declines_on_positive_axis_unknown_rank
+    # documents becoming confirmed once the rank is actually knowable.
+    K, Ca, Cb, Out = 8, 6, 4, 3
+    rng = np.random.default_rng(212)
+    wa = rng.standard_normal((K, Ca)).astype(np.float32)
+    wb = rng.standard_normal((K, Cb)).astype(np.float32)
+    wout = rng.standard_normal((Ca + Cb, Out)).astype(np.float32)
+
+    model_neg = _matmul_concat_model([wa, wb], wout, axis=-1)
+    model_pos = _matmul_concat_model([wa, wb], wout, axis=1)
+    model_pos = onnx.shape_inference.infer_shapes(model_pos)
+    h0_vi = next(vi for vi in model_pos.graph.value_info if vi.name == "h0")
+    assert len(h0_vi.type.tensor_type.shape.dim) == 2  # rank actually confirmed
+
+    pruned_neg = onnxsim.apply_structured_pruning(model_neg, sparsity=0.5)
+    pruned_pos = onnxsim.apply_structured_pruning(model_pos, sparsity=0.5)
+    onnx.checker.check_model(pruned_neg)
+    onnx.checker.check_model(pruned_pos)
+
+    inits_neg = {
+        t.name: onnx.numpy_helper.to_array(t) for t in pruned_neg.graph.initializer
+    }
+    inits_pos = {
+        t.name: onnx.numpy_helper.to_array(t) for t in pruned_pos.graph.initializer
+    }
+    for name in ("W0", "W1", "WOUT"):
+        np.testing.assert_array_equal(inits_pos[name], inits_neg[name])
+    # Confirms it actually pruned (not merely "happened to match because
+    # both were left untouched"): the branch's output channel count shrank.
+    assert inits_pos["W0"].shape[1] < Ca
+
+    rng_x = np.random.default_rng(213)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y_neg,) = _run(pruned_neg, {"X": x})
+    (y_pos,) = _run(pruned_pos, {"X": x})
+    np.testing.assert_allclose(y_pos, y_neg, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_matmul_concat_declines_on_positive_non_last_axis():
+    # `axis=0` on rank-2 [batch, C] operands is confirmably *not* the last
+    # axis (`rank - 1 == 1`) -- proves _concat_axis_is_last actually checks
+    # the axis against the rank rather than accepting any positive axis
+    # once a rank is confirmable. Rank is attached directly (rather than
+    # via a real onnx.shape_inference.infer_shapes() pass, as the sibling
+    # accept/decline tests above do) since `axis=0` here doesn't actually
+    # describe a dimensionally-valid Concat (Ca != Cb along the
+    # non-concat axis) -- irrelevant to what this test isolates, since the
+    # axis check runs, and this whole group is declined, before any
+    # producer/consumer walk ever inspects that.
+    K, Ca, Cb, Out = 8, 6, 4, 3
+    rng = np.random.default_rng(215)
+    wa = rng.standard_normal((K, Ca)).astype(np.float32)
+    wb = rng.standard_normal((K, Cb)).astype(np.float32)
+    wout = rng.standard_normal((Ca + Cb, Out)).astype(np.float32)
+    model = _matmul_concat_model([wa, wb], wout, axis=0)
+    for name in ("h0", "h1"):
+        model.graph.value_info.append(
+            onnx.helper.make_tensor_value_info(
+                name, onnx.TensorProto.FLOAT, [None, None]
+            )
+        )
 
     pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
     inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}


### PR DESCRIPTION
## Summary
- The `Concat`-merged skip-connection pruning feature only recognized a MatMul/Gemm `Concat` node's `axis` attribute when it was exactly `-1`. A positive axis that's numerically identical (e.g. `axis=1` on a 2-D `[batch, C]` tensor) was declined outright, since confirming a positive axis actually equals "rank minus one" needs a rank lookup this module otherwise never performs anywhere else.
- Investigated before implementing: this module never runs shape inference itself, but it already carries `graph.value_info` machinery, and the graph a real pipeline hands to `apply_structured_pruning` has ordinarily already been through a shape-inference pass — so a rank lookup piggybacking on those existing annotations (`len(vi.type.tensor_type.shape.dim)`) is trivial and adds no new dependency, when the annotations are actually present.
- Implemented `_value_info_by_name`/`_tensor_rank`/`_concat_axis_is_last`: `axis == -1` is still recognized outright (no rank lookup needed, ONNX's own negative-axis convention already counts from the end); a positive axis is accepted only when at least one operand's rank is known via `value_info`/`input`/`output` annotations and every operand with a known rank agrees `axis == rank - 1` — never guessed at. No operand's rank known, or operands disagreeing, still declines exactly as before. The Conv path (`axis in (1, -3)`) is untouched — its channel axis is already rank-independent.
- New tests (`onnx.parser`-based, after a real `onnx.shape_inference.infer_shapes()` pass): a positive last axis with confirmed rank now prunes identically (byte-for-byte weights, matching onnxruntime output) to the equivalent `axis=-1` graph; a positive *non-last* axis with rank confirmed is still declined; unknown-rank cases (no `value_info` at all, and `value_info` present but with `ClearField("shape")` — ONNX's own "rank not statically known" spelling) are still declined.

## Test plan
- [x] `pytest tests/test_pruning.py -q` — 187 passed
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — same 3 pre-existing, unrelated errors as `master`; no new ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_