### PR TITLE
Slice constant KV-cache and support independent V head_size in attention pruning

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -4550,6 +4550,18 @@ def _slice_last_axis(init: onnx.TensorProto, keep: np.ndarray) -> None:
     init.CopyFrom(onnx.numpy_helper.from_array(new, name=init.name))
 
 
+def _slice_axis1(init: onnx.TensorProto, keep: np.ndarray) -> None:
+    """Slices a rank-4 BNSH-format constant (a `past_key`/`past_value`
+    initializer -- see :func:`_past_kv_constants_are_sliceable`) along its
+    `kv_num_heads` axis (axis 1) by `keep`. Unlike :func:`_slice_last_axis`,
+    the axis being sliced here is never the last one -- BNSH's last axis is
+    `head_size`/`v_head_size`, untouched by a KV-group drop.
+    """
+    arr = onnx.numpy_helper.to_array(init)
+    new = np.take(arr, keep, axis=1)
+    init.CopyFrom(onnx.numpy_helper.from_array(new, name=init.name))
+
+
 def _plain_structured_importance(
     chain: _Chain, w_arrays_nk: List[np.ndarray]
 ) -> np.ndarray:
@@ -5192,10 +5204,15 @@ def apply_structured_wanda_pruning(
 #   head's own K/V column block, together with every query head mapped to
 #   it) is ever removed at once, ranked by the combined importance of the
 #   group's whole Q+K+V block -- see :func:`_apply_one_gqa_chain` and
-#   :func:`_gqa_group_importance`. A non-empty constant past-KV-cache input
-#   (which would itself need slicing along the `kv_num_heads` axis) or a
+#   :func:`_gqa_group_importance`. A connected `past_key`/`past_value` that
+#   is a constant of the expected float BNSH shape (see
+#   :func:`_past_kv_constants_are_sliceable`) is sliced along its own
+#   `kv_num_heads` axis by the same `keep_groups` index set used for K's/V's
+#   own producer weights; one of any other shape/dtype (a quantized cache,
+#   most notably -- its own `k_scale`/`v_scale` tensors would need identical
+#   slicing to stay consistent, which this module makes no attempt at), or a
 #   packed-QKV/missing-required-input node this module cannot prove safe to
-#   leave alone is declined outright -- see :func:`_match_gqa_producer`.
+#   leave alone, is declined outright -- see :func:`_match_gqa_producer`.
 # - the plain ``ai.onnx`` `Attention` (opset 24+, domain ``""``, schema
 #   confirmed against this environment's installed ``onnx==1.22.0`` via
 #   ``onnx.defs.get_schema("Attention", domain="")`` -- it is fully defined
@@ -5215,15 +5232,24 @@ def apply_structured_wanda_pruning(
 #   :class:`_GQAChain` carries which attribute name to write back
 #   (`num_heads_attr`); (2) it schema-allows V its own `head_size`
 #   independent of Q/K's (confirmed via the op's own backend test suite,
-#   e.g. ``test_attention_3d_diff_heads_sizes``) -- since
-#   :func:`_apply_one_gqa_chain`'s shared slicing assumes one uniform
-#   `head_size` the way `fuse_gqa.h` itself requires, a node whose V head
-#   size actually differs is declined rather than mis-sliced; (3) its
-#   optional `attn_mask`/`past_key`/`past_value` inputs (a different set
-#   from `GroupQueryAttention`'s own `past_key`/`past_value`/`seqlens_k`/
-#   `total_sequence_length`/`cos_cache`/`sin_cache`) get the same
-#   non-empty-constant-is-declined, dynamic-is-left-alone treatment
-#   :func:`_match_gqa_producer` already applies -- see
+#   e.g. ``test_attention_3d_diff_heads_sizes``), which `GroupQueryAttention`
+#   itself can never have (`fuse_gqa.h` requires equal Q/K/V head_size before
+#   it will even fuse a node) -- :class:`_GQAChain` carries Q's/K's shared
+#   `head_size` and V's own (possibly different) `v_head_size` as two
+#   separate fields, and :func:`_apply_one_gqa_chain`'s shared slicing uses
+#   whichever of the two actually applies to each tensor it touches (see
+#   that function's own docstring and :func:`_find_separate_qkv_chains`'s
+#   own `allow_differing_v_head_size` parameter, `False` for
+#   `GroupQueryAttention`, `True` here); (3) its optional `attn_mask` input
+#   (a mask this pass makes no attempt to slice, since doing so correctly
+#   would require resolving its own broadcast shape against the new
+#   `q_num_heads`) gets the same non-empty-constant-is-declined,
+#   dynamic-is-left-alone treatment as before, while its `past_key`/
+#   `past_value` (a different pair of input indices from
+#   `GroupQueryAttention`'s own `past_key`/`past_value`/`seqlens_k`/
+#   `total_sequence_length`/`cos_cache`/`sin_cache`) share
+#   :func:`_match_gqa_producer`'s own updated treatment via the same
+#   :func:`_past_kv_constants_are_sliceable` -- see
 #   :func:`_match_onnx_attention_producer`. Verified here via actual
 #   execution (``onnx.checker`` plus onnxruntime, both of which handle this
 #   op in this environment -- see ``tests/test_pruning.py``'s own "plain
@@ -5297,14 +5323,18 @@ def apply_structured_wanda_pruning(
 #   onnxruntime (1.29.0) CPU kernel requires Q's and K/V's sequence length
 #   to match unless a non-empty `past_key`/`past_value` is also supplied --
 #   confirmed empirically, not merely read off the schema doc, which
-#   promises cross-attention support without mentioning this -- and a
-#   non-empty constant `past_key`/`past_value` is already a shape
-#   :func:`_match_gqa_producer` declines outright (see its own docstring).
-#   A single-call `GroupQueryAttention` cross-attention model with a
-#   genuinely different K/V sequence length therefore isn't a topology this
-#   module ever has the chance to match in the first place -- an
-#   onnxruntime-kernel-level restriction on the op itself, not a limitation
-#   this module's own matching or pruning logic adds. The plain ``ai.onnx``
+#   promises cross-attention support without mentioning this. A non-empty
+#   constant `past_key`/`past_value` is, since the KV-cache-slicing fix
+#   above, no longer declined outright purely for being non-empty (see
+#   :func:`_past_kv_constants_are_sliceable`) -- but this module's own
+#   cross-attention support was verified only for the ordinary
+#   ``past_key``/``past_value``-omitted case (see the tests referenced
+#   above); a single-call cross-attention model additionally relying on a
+#   non-empty `past_key`/`past_value` specifically to satisfy this
+#   onnxruntime-kernel-level sequence-length restriction was not
+#   separately re-verified and remains untested here -- an
+#   onnxruntime-kernel-level restriction on the op itself either way, not a
+#   limitation this module's own matching or pruning logic adds. The plain ``ai.onnx``
 #   `Attention` op has no such restriction (also confirmed empirically): its
 #   cross-attention test below uses genuinely different Q/K-V sequence
 #   lengths (as well as different source tensors and different feature
@@ -5343,6 +5373,18 @@ class _GQAChain:
     num_heads: int
     kv_num_heads: int
     head_size: int
+    # V's own head_size -- equal to `head_size` for every `GroupQueryAttention`
+    # chain (`fuse_gqa.h` requires `q_head_size == k_head_size == v_head_size`
+    # before it will even fuse the op, confirmed by reading that requirement
+    # directly off `fuse_gqa.h` itself), but can genuinely differ for a plain
+    # ``ai.onnx::Attention`` chain -- that op's own schema gives V an
+    # independent `v_head_size` distinct from Q/K's shared `head_size` (see
+    # :func:`_match_onnx_attention_producer`'s own docstring and this
+    # module's "Attention-head pruning" section comment). Every place that
+    # slices/sizes something on Q's or K's own side (`.head_size`) versus
+    # V's or the output-projection's own side (`.v_head_size`) needs to pick
+    # the right one of these two fields -- see :func:`_apply_one_gqa_chain`.
+    v_head_size: int
     chain_ops: Tuple[Tuple[onnx.NodeProto, Optional[str]], ...]
     consumer_node: onnx.NodeProto
     consumer_weight: str
@@ -5558,6 +5600,63 @@ def _find_attention_chains(graph: onnx.GraphProto) -> List[_AttentionChain]:
     return chains
 
 
+def _past_kv_constants_are_sliceable(
+    node: onnx.NodeProto,
+    initializer_map: Dict[str, onnx.TensorProto],
+    indices: Tuple[int, int],
+    kv_num_heads: int,
+) -> bool:
+    """Shared safety gate for a matched node's optional `past_key`/
+    `past_value` inputs (at `indices`, a `(past_key_idx, past_value_idx)`
+    pair -- ``(3, 4)`` for `GroupQueryAttention`, ``(4, 5)`` for the plain
+    ``ai.onnx::Attention`` op), used by both :func:`_match_gqa_producer` and
+    :func:`_match_onnx_attention_producer`.
+
+    Both ops' own schemas lay a connected `past_key`/`past_value` out in
+    BNSH format -- ``(batch_size, kv_num_heads, past_sequence_length,
+    head_size_or_v_head_size)`` (`GroupQueryAttention`'s own contrib-op
+    schema doc, `onnxruntime.capi.onnxruntime_pybind11_state
+    .get_all_operator_schema()`'s "Cache Format" section: "The past and
+    present KV cache tensors are expected in a BNSH format: (batch_size,
+    num_heads, cache_sequence_length, head_size)"; the plain ai.onnx op's
+    own schema doc, `onnx.defs.get_schema("Attention", domain="")`, names
+    the same axis order for its own `past_key`/`past_value` inputs) -- so
+    the `kv_num_heads` axis sits at axis 1 of a rank-4 tensor, exactly the
+    axis :func:`_apply_one_gqa_chain`'s own `keep_groups` index set already
+    selects along K's/V's own producer weight. A *dynamic* (non-constant)
+    past_key/past_value -- an ordinary graph input or intermediate
+    activation, not a weight -- is always left alone and never blocks a
+    match: it is the caller's own runtime data, not something this rewrite
+    could corrupt by leaving untouched, the same reasoning that already
+    applied before this function existed. A *constant* one is declined
+    (this function returns ``False``, and the caller's whole match fails)
+    only when its shape/dtype isn't confidently this exact layout -- not
+    FLOAT, not rank 4, or its axis-1 length doesn't already match
+    `kv_num_heads` -- rather than guessed at; this also declines a
+    quantized KV cache (`float8e4m3fn`/`uint8`/`int8`, both ops' schemas
+    allow for `past_key`/`past_value` specifically to shrink KV-cache
+    memory) outright, since a quantized cache's own `k_scale`/`v_scale`
+    tensors would need identical per-KV-head-axis slicing to stay
+    consistent and this function makes no attempt to locate or slice them.
+    Otherwise (a constant of the expected float BNSH shape, or none
+    connected at all) returns ``True`` -- :func:`_apply_one_gqa_chain`
+    itself performs the actual axis-1 slice once a match succeeds.
+    """
+    for idx in indices:
+        if len(node.input) <= idx or not node.input[idx]:
+            continue
+        past_init = initializer_map.get(node.input[idx])
+        if past_init is None:
+            continue  # dynamic -- the caller's own runtime data, left alone
+        if (
+            past_init.data_type != onnx.TensorProto.FLOAT
+            or len(past_init.dims) != 4
+            or past_init.dims[1] != kv_num_heads
+        ):
+            return False  # not a shape/dtype this function can safely slice
+    return True
+
+
 def _match_gqa_producer(
     node: onnx.NodeProto, initializer_map: Dict[str, onnx.TensorProto]
 ) -> Optional[Tuple[int, int]]:
@@ -5573,20 +5672,15 @@ def _match_gqa_producer(
     need touching themselves -- their presence is checked only as a sign
     this is a real, complete GQA node rather than a partially-constructed
     one); `num_heads`/`kv_num_heads` attributes with `num_heads` a positive
-    multiple of `kv_num_heads`; and, for each of the optional `past_key`/
-    `past_value` inputs (indices 3/4) that is actually connected, that it
-    is *not* a non-empty constant -- such a tensor holds real per-KV-head
-    cache data laid out along the `kv_num_heads` axis this function would
-    need to slice but doesn't attempt to, so a node with one is declined
-    outright rather than pruned incorrectly. A *dynamic* (non-constant)
-    past_key/past_value -- an ordinary graph input or intermediate
-    activation, not a weight -- is left alone and does not block the match:
-    it is the caller's own runtime data, not something this rewrite could
-    corrupt by leaving untouched. cos_cache/sin_cache (indices 7/8, for
-    rotary position embedding), if present, are also always left alone:
-    both are `[max_sequence_length, rotary_dim/2]`, broadcast identically
-    across every head, so a head/group count change can never invalidate
-    them.
+    multiple of `kv_num_heads`; and a `past_key`/`past_value` (indices 3/4)
+    this module can safely act on, per
+    :func:`_past_kv_constants_are_sliceable` -- a constant one is sliced
+    along its own `kv_num_heads` axis by :func:`_apply_one_gqa_chain`, using
+    exactly the same `keep_groups` index set K's/V's own producer weights
+    are sliced by. cos_cache/sin_cache (indices 7/8, for rotary position
+    embedding), if present, are always left alone regardless: both are
+    `[max_sequence_length, rotary_dim/2]`, broadcast identically across
+    every head, so a head/group count change can never invalidate them.
     """
     if node.domain != _ATTENTION_DOMAIN or node.op_type != "GroupQueryAttention":
         return None
@@ -5604,12 +5698,10 @@ def _match_gqa_producer(
     if num_heads % kv_num_heads != 0:
         return None
 
-    for idx in (3, 4):  # past_key, past_value
-        if len(node.input) <= idx or not node.input[idx]:
-            continue
-        past_init = initializer_map.get(node.input[idx])
-        if past_init is not None and int(np.prod(past_init.dims)) > 0:
-            return None  # non-empty KV-cache constant -- would need slicing
+    if not _past_kv_constants_are_sliceable(
+        node, initializer_map, (3, 4), kv_num_heads
+    ):
+        return None
 
     return num_heads, kv_num_heads
 
@@ -5640,17 +5732,26 @@ def _match_onnx_attention_producer(
     attributes for, so a node relying on rank-4-inferred head counts isn't
     a shape this pass tracks and is declined rather than guessed at.
 
-    The optional `attn_mask`/`past_key`/`past_value` inputs (indices 3/4/5
-    -- a different set from `GroupQueryAttention`'s own, and this op has no
-    `seqlens_k`/`total_sequence_length` equivalent to require) get the same
-    treatment :func:`_match_gqa_producer` gives `past_key`/`past_value`:
-    each is declined outright if it is connected to a non-empty constant
-    (real per-head mask or KV-cache data this function doesn't attempt to
-    slice), but left alone -- and does not block the match -- if dynamic
-    (an ordinary graph input or intermediate activation, the caller's own
-    runtime data). `nonpad_kv_seqlen` (index 6), like `GroupQueryAttention`'s
-    own `seqlens_k`, is `[batch_size]`-shaped and independent of head count,
-    so its presence never blocks a match either.
+    The optional `attn_mask` input (index 3) is declined outright if it is
+    connected to a non-empty constant (real per-head mask data broadcastable
+    to a `q_num_heads`-sized axis -- unlike `past_key`/`past_value` below,
+    slicing this correctly would require resolving its own broadcast shape
+    against the new `q_num_heads`, which this function makes no attempt at),
+    but left alone -- and does not block the match -- if dynamic (an
+    ordinary graph input or intermediate activation, the caller's own
+    runtime data). The optional `past_key`/`past_value` inputs (indices
+    4/5 -- a different pair of indices from `GroupQueryAttention`'s own 3/4,
+    and this op has no `seqlens_k`/`total_sequence_length` equivalent to
+    require) get the same safety gate :func:`_match_gqa_producer` gives its
+    own `past_key`/`past_value`, via the same shared
+    :func:`_past_kv_constants_are_sliceable` -- a constant one of the
+    expected float BNSH shape is sliced along its own `kv_num_heads` axis by
+    :func:`_apply_one_gqa_chain`, using the same `keep_groups` index set
+    K's/V's own producer weights are sliced by; one of any other shape/dtype
+    declines the whole match, and a dynamic one is left alone as always.
+    `nonpad_kv_seqlen` (index 6), like `GroupQueryAttention`'s own
+    `seqlens_k`, is `[batch_size]`-shaped and independent of head count, so
+    its presence never blocks a match either.
     """
     if node.domain != "" or node.op_type != "Attention":
         return None
@@ -5668,12 +5769,15 @@ def _match_onnx_attention_producer(
     if q_num_heads % kv_num_heads != 0:
         return None
 
-    for idx in (3, 4, 5):  # attn_mask, past_key, past_value
-        if len(node.input) <= idx or not node.input[idx]:
-            continue
-        const_init = initializer_map.get(node.input[idx])
-        if const_init is not None and int(np.prod(const_init.dims)) > 0:
-            return None  # non-empty constant -- would need slicing
+    if len(node.input) > 3 and node.input[3]:  # attn_mask
+        mask_init = initializer_map.get(node.input[3])
+        if mask_init is not None and int(np.prod(mask_init.dims)) > 0:
+            return None  # non-empty constant mask -- would need slicing
+
+    if not _past_kv_constants_are_sliceable(
+        node, initializer_map, (4, 5), kv_num_heads
+    ):
+        return None
 
     return q_num_heads, kv_num_heads
 
@@ -5682,6 +5786,7 @@ def _find_separate_qkv_chains(
     graph: onnx.GraphProto,
     match_producer,
     num_heads_attr: str,
+    allow_differing_v_head_size: bool = False,
 ) -> List[_GQAChain]:
     """Shared body for :func:`_find_gqa_chains` and
     :func:`_find_onnx_attention_chains`: both match a fused attention node
@@ -5690,9 +5795,14 @@ def _find_separate_qkv_chains(
     ``com.microsoft::Attention``) and prune it at whole-KV-group granularity
     (see :func:`_apply_one_gqa_chain`/:func:`_gqa_group_importance`),
     differing only in which node/attributes `match_producer` recognizes
-    (:func:`_match_gqa_producer` or :func:`_match_onnx_attention_producer`)
-    and which attribute on the matched node holds the query head count
-    (`num_heads_attr` -- see :class:`_GQAChain`'s own field of that name).
+    (:func:`_match_gqa_producer` or :func:`_match_onnx_attention_producer`),
+    which attribute on the matched node holds the query head count
+    (`num_heads_attr` -- see :class:`_GQAChain`'s own field of that name),
+    and whether V's own head_size is allowed to differ from Q/K's shared one
+    (`allow_differing_v_head_size` -- ``False`` for `GroupQueryAttention`,
+    which `fuse_gqa.h` never emits with anything but equal Q/K/V head_size,
+    ``True`` for the plain ai.onnx op, whose schema genuinely allows it; see
+    :class:`_GQAChain`'s own `v_head_size` field).
     """
     initializer_map = {t.name: t for t in graph.initializer}
     consumers_of = _consumers_of(graph)
@@ -5742,35 +5852,42 @@ def _find_separate_qkv_chains(
         ):
             continue
         head_size = nq // num_heads
-        if (
-            head_size <= 0
-            or nk // kv_num_heads != head_size
-            or nv // kv_num_heads != head_size
-        ):
-            # `fuse_gqa.h` requires equal Q/K/V head_size, and this is the
-            # same restriction :func:`_match_onnx_attention_producer`'s own
-            # docstring narrows the plain ai.onnx op's own, more permissive
-            # schema down to (that op genuinely allows V its own head_size,
-            # see this module's "Attention-head pruning" section comment) --
-            # a node whose V head size actually differs is declined here
-            # rather than mis-sliced by this shared, uniform-head_size body.
+        v_head_size = nv // kv_num_heads
+        if head_size <= 0 or v_head_size <= 0 or nk // kv_num_heads != head_size:
+            # Q's and K's own head_size must always agree -- required by the
+            # QK^T dot product itself (both ops' schemas name a single
+            # shared `head_size` for Q/K, distinct from V's own), not a
+            # restriction this pass adds, so a mismatch here is declined
+            # regardless of `allow_differing_v_head_size`.
+            continue
+        if not allow_differing_v_head_size and v_head_size != head_size:
+            # `fuse_gqa.h` requires equal Q/K/V head_size before it will
+            # even fuse a `GroupQueryAttention` node (confirmed by reading
+            # that requirement directly off `fuse_gqa.h` itself: `q_head_size
+            # != k_head_size || q_head_size != v_head_size` is one of its own
+            # fusion-declining conditions) -- a `GroupQueryAttention` node
+            # whose V head size actually differs is declined here rather
+            # than mis-sliced, since no real GQA node could ever have one.
             continue
 
         out_name = node.output[0]
         if not _is_internal(out_name):
             continue
 
-        # Both matched ops' raw output is Nq (= num_heads * head_size) wide
-        # -- unlike plain `com.microsoft::Attention` (V-hidden-size-wide),
-        # each is head-count-and-size symmetric with the query side (per
-        # fuse_gqa.h's own "Y = GroupQueryAttention(...)" shape comment, and
-        # -- since this function only ever matches the equal-head_size case
-        # above -- the ai.onnx op's own "q_num_heads * head_size_v" output
-        # width, see its reference kernel) -- so
-        # `_walk_to_attention_consumer`'s generic "raw output width"
-        # parameter is passed `nq` here, not an analogue of `nv`.
+        # The raw output is always `num_heads * v_head_size` wide -- unlike
+        # plain `com.microsoft::Attention` (whose own raw-output-width
+        # parameter this same helper takes is named `nv` generically), both
+        # matched ops here size their output per *query* head but with
+        # *V's* own per-head width (`fuse_gqa.h`'s own "Y =
+        # GroupQueryAttention(...)" shape comment; the ai.onnx op's own
+        # "hidden_size = q_num_heads * v_head_size" 3D output shape, see its
+        # schema doc) -- equal to `nq` exactly when `v_head_size ==
+        # head_size` (always true for `GroupQueryAttention`; not required
+        # for the plain ai.onnx op once `allow_differing_v_head_size` lets
+        # it differ).
+        raw_out_width = num_heads * v_head_size
         consumer, chain_ops = _walk_to_attention_consumer(
-            out_name, initializer_map, consumers_of, graph_outputs, nq
+            out_name, initializer_map, consumers_of, graph_outputs, raw_out_width
         )
         if consumer is None:
             continue
@@ -5790,6 +5907,7 @@ def _find_separate_qkv_chains(
                 num_heads=num_heads,
                 kv_num_heads=kv_num_heads,
                 head_size=head_size,
+                v_head_size=v_head_size,
                 chain_ops=chain_ops,
                 consumer_node=consumer[0],
                 consumer_weight=consumer[1],
@@ -5808,10 +5926,16 @@ def _find_onnx_attention_chains(graph: onnx.GraphProto) -> List[_GQAChain]:
     """The plain ``ai.onnx::Attention`` analogue of :func:`_find_gqa_chains`
     -- see :func:`_find_separate_qkv_chains` (the shared body) and
     :func:`_match_onnx_attention_producer` (what's matched and why it's
-    declined otherwise).
+    declined otherwise). Passes ``allow_differing_v_head_size=True``: unlike
+    `GroupQueryAttention`, this op's own schema genuinely allows V its own
+    `v_head_size` independent of Q/K's shared `head_size` (see
+    :class:`_GQAChain`'s own `v_head_size` field).
     """
     return _find_separate_qkv_chains(
-        graph, _match_onnx_attention_producer, "q_num_heads"
+        graph,
+        _match_onnx_attention_producer,
+        "q_num_heads",
+        allow_differing_v_head_size=True,
     )
 
 
@@ -5879,7 +6003,16 @@ def _gqa_group_importance(
     # concatenate-based form would raise a bare ``ValueError`` from numpy
     # the moment it ran on such a model, crashing the whole pruning call
     # instead of ranking it.
+    #
+    # `d`/`dv` similarly needn't agree: `d` (`chain.head_size`) is Q's and
+    # K's own shared per-head column width in their own producer weights,
+    # `dv` (`chain.v_head_size`) is V's own -- equal for every
+    # `GroupQueryAttention` chain, but not necessarily for a plain
+    # ai.onnx `Attention` chain (see :class:`_GQAChain`'s own `v_head_size`
+    # field) -- so `v_block`'s own column stride into `wv` must use `dv`,
+    # not `d`.
     d = chain.head_size
+    dv = chain.v_head_size
     group_size = chain.num_heads // chain.kv_num_heads
     importance = np.zeros(chain.kv_num_heads, dtype=np.float64)
     for kv in range(chain.kv_num_heads):
@@ -5891,7 +6024,7 @@ def _gqa_group_importance(
             axis=1,
         )
         k_block = wk[:, kv * d : (kv + 1) * d]
-        v_block = wv[:, kv * d : (kv + 1) * d]
+        v_block = wv[:, kv * dv : (kv + 1) * dv]
         importance[kv] = np.sqrt(
             np.linalg.norm(q_block) ** 2
             + np.linalg.norm(k_block) ** 2
@@ -5986,14 +6119,23 @@ def _apply_one_gqa_chain(
     or plain ``ai.onnx::Attention`` block (see :class:`_GQAChain`'s own
     `num_heads_attr` field for how the two are told apart when writing the
     new query head count back) in place: every dropped group removes one
-    *contiguous* ``head_size``-wide column block from each of K's and V's
-    own separate weights, together with the ``num_heads / kv_num_heads``
-    query-head-sized blocks mapped to that group from Q's own separate
-    weight (and the matching row block from the consumer) -- never an
-    individual query head in isolation. Returns
-    ``(producer_weight_names, consumer_weight_name, stale_output_names)`` on
-    success, or ``None`` if `sparsity` rounds to no groups dropped for this
-    block (a no-op, left for the caller to skip).
+    *contiguous* ``head_size``-wide column block from K's own separate
+    weight and one *contiguous* ``v_head_size``-wide column block (equal to
+    ``head_size`` for `GroupQueryAttention`, not necessarily for the plain
+    ai.onnx op -- see :class:`_GQAChain`'s own `v_head_size` field) from V's
+    own, together with the ``num_heads / kv_num_heads`` query-head-sized
+    blocks mapped to that group from Q's own separate weight (and the
+    matching ``v_head_size``-wide-per-head row block from the consumer,
+    since the consumer's own reduction axis is the attention output's own
+    hidden dim -- laid out per *query* head at *V's* own per-head width) --
+    never an individual query head in isolation. A connected constant
+    `past_key`/`past_value` (see :func:`_past_kv_constants_are_sliceable`,
+    already confirmed at match time to be a float BNSH-format tensor) is
+    sliced along its own `kv_num_heads` axis (axis 1) by the same
+    `keep_groups` index set. Returns ``(producer_weight_names,
+    consumer_weight_name, stale_output_names)`` on success, or ``None`` if
+    `sparsity` rounds to no groups dropped for this block (a no-op, left for
+    the caller to skip).
     """
     h = chain.kv_num_heads
     keep_count = max(1, h - round(h * sparsity))
@@ -6001,6 +6143,7 @@ def _apply_one_gqa_chain(
         return None
 
     d = chain.head_size
+    dv = chain.v_head_size
     group_size = chain.num_heads // chain.kv_num_heads
 
     # `_gqa_group_importance` (and any caller-supplied Wanda variant of it)
@@ -6029,18 +6172,48 @@ def _apply_one_gqa_chain(
     keep_q_heads = np.concatenate(
         [np.arange(g * group_size, (g + 1) * group_size) for g in keep_groups]
     )
+    # `q_idx`/`k_idx` index Q's/K's own producer weight columns (their
+    # shared per-head width `d`); `v_idx` indexes V's own producer weight
+    # columns at *its* own per-head width `dv`, which can differ. `y_idx`
+    # indexes the *output* side instead -- the consumer's reduction
+    # dimension and the raw output's own trailing axis (the reshape hop's
+    # target shape, if any) -- both laid out per query head at V's own
+    # per-head width `dv`, not Q's/K's `d`: `q_idx` (built with `d`) is only
+    # coincidentally the right index set for those two when `dv == d`, which
+    # is why the two were never distinguished before V could have its own
+    # head_size.
     q_idx = _head_column_indices(keep_q_heads, d)
-    kv_idx = _head_column_indices(keep_groups, d)
+    k_idx = _head_column_indices(keep_groups, d)
+    v_idx = _head_column_indices(keep_groups, dv)
+    y_idx = _head_column_indices(keep_q_heads, dv)
 
     _slice_producer_weight(wq_init, chain.q_weight_transposed, q_idx)
-    _slice_producer_weight(wk_init, chain.k_weight_transposed, kv_idx)
-    _slice_producer_weight(wv_init, chain.v_weight_transposed, kv_idx)
+    _slice_producer_weight(wk_init, chain.k_weight_transposed, k_idx)
+    _slice_producer_weight(wv_init, chain.v_weight_transposed, v_idx)
     if chain.q_bias is not None:
         _slice_last_axis(initializer_map[chain.q_bias], q_idx)
     if chain.k_bias is not None:
-        _slice_last_axis(initializer_map[chain.k_bias], kv_idx)
+        _slice_last_axis(initializer_map[chain.k_bias], k_idx)
     if chain.v_bias is not None:
-        _slice_last_axis(initializer_map[chain.v_bias], kv_idx)
+        _slice_last_axis(initializer_map[chain.v_bias], v_idx)
+
+    # `GroupQueryAttention`'s past_key/past_value live at input indices 3/4,
+    # the plain ai.onnx op's own at 4/5 (see `_match_gqa_producer`'s and
+    # `_match_onnx_attention_producer`'s own docstrings) -- both already
+    # confirmed, at match time, to be either absent/dynamic (nothing to do
+    # here) or a float BNSH-format constant safe to slice along axis 1 by
+    # `keep_groups` (see :func:`_past_kv_constants_are_sliceable`).
+    is_gqa = (
+        chain.node.domain == _ATTENTION_DOMAIN
+        and chain.node.op_type == "GroupQueryAttention"
+    )
+    past_kv_indices = (3, 4) if is_gqa else (4, 5)
+    for idx in past_kv_indices:
+        if len(chain.node.input) <= idx or not chain.node.input[idx]:
+            continue
+        past_init = initializer_map.get(chain.node.input[idx])
+        if past_init is not None:
+            _slice_axis1(past_init, keep_groups)
 
     new_kv_num_heads = keep_count
     new_num_heads = keep_count * group_size
@@ -6053,14 +6226,14 @@ def _apply_one_gqa_chain(
     _slice_consumer_weight(
         initializer_map[chain.consumer_weight],
         chain.consumer_weight_transposed,
-        q_idx,
+        y_idx,
     )
 
     for _, shape_name in chain.chain_ops:
         if shape_name is not None:
             shape_init = initializer_map[shape_name]
             dims = onnx.numpy_helper.to_array(shape_init).copy()
-            dims[-1] = new_num_heads * d
+            dims[-1] = new_num_heads * dv
             shape_init.CopyFrom(
                 onnx.numpy_helper.from_array(dims, name=shape_init.name)
             )
@@ -6175,10 +6348,13 @@ def apply_attention_head_pruning(
     query heads the kernel requires. An individual query head is never
     dropped on its own: only a whole group, since neither kernel has a way
     to keep a KV head alive for some, but not all, of the query heads that
-    shared it. A plain ``ai.onnx::Attention`` node whose V head size
-    genuinely differs from Q/K's own (a shape that op's schema allows but
-    `GroupQueryAttention` never produces) is declined rather than mis-sliced
-    -- see :func:`_match_onnx_attention_producer`.
+    shared it. A connected `past_key`/`past_value` that is a constant of the
+    expected float BNSH shape is sliced along its own `kv_num_heads` axis by
+    the same index set (see :func:`_past_kv_constants_are_sliceable`,
+    :func:`_apply_one_gqa_chain`); a plain ``ai.onnx::Attention`` node's V
+    head size may genuinely differ from Q/K's own (a shape that op's schema
+    allows but `GroupQueryAttention` never produces) and is sliced correctly
+    at its own width -- see :class:`_GQAChain`'s own `v_head_size` field.
 
     :param model: the original onnx ModelProto or file path
     :param sparsity: target fraction of each matched block's heads (or, for
@@ -6188,11 +6364,12 @@ def apply_attention_head_pruning(
             place; anything not matching that exact topology (a
             non-constant weight, a packed-QKV GroupQueryAttention node, a
             GroupQueryAttention/plain ai.onnx Attention node with a
-            non-empty constant past-KV-cache or attention-mask input, an
-            ai.onnx Attention node with differing Q/K/V head sizes or
-            without explicit ``q_num_heads``/``kv_num_heads`` attributes, a
-            consumer whose reduction dimension doesn't line up, ...) is left
-            completely untouched
+            non-empty constant past-KV-cache of unexpected shape/dtype (e.g.
+            a quantized KV cache) or a non-empty constant attention-mask
+            input, an ai.onnx Attention node without explicit
+            ``q_num_heads``/``kv_num_heads`` attributes or with Q's/K's own
+            head sizes mismatched, a consumer whose reduction dimension
+            doesn't line up, ...) is left completely untouched
     """
     if not (0.0 <= sparsity < 1.0):
         raise ValueError(f"sparsity must be in [0, 1), got {sparsity}")
@@ -6330,14 +6507,21 @@ def apply_attention_head_wanda_pruning(
     def _wanda_gqa_group_importance(chain, wq, wk, wv):
         base = _gqa_group_importance(chain, wq, wk, wv)
         norm = act_norm.get(chain.consumer_node.input[0])
-        width = chain.num_heads * chain.head_size
+        # The probed activation is the consumer's own input -- the attention
+        # output, laid out per *query* head at *V's* own per-head width
+        # (`chain.v_head_size`), the same `dv` :func:`_apply_one_gqa_chain`
+        # itself uses for that tensor's own indexing (equal to
+        # `chain.head_size` for `GroupQueryAttention`, not necessarily for
+        # the plain ai.onnx op -- see :class:`_GQAChain`'s own `v_head_size`
+        # field).
+        dv = chain.v_head_size
+        width = chain.num_heads * dv
         if norm is None or norm.shape[0] != width:
             return base  # no matching activation observed -- fall back to plain
-        d = chain.head_size
         group_size = chain.num_heads // chain.kv_num_heads
         act_group = np.array(
             [
-                np.linalg.norm(norm[kv * group_size * d : (kv + 1) * group_size * d])
+                np.linalg.norm(norm[kv * group_size * dv : (kv + 1) * group_size * dv])
                 for kv in range(chain.kv_num_heads)
             ]
         )

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -5711,6 +5711,8 @@ def _gqa_model(
     bv=None,
     wout=None,
     past_kv=None,  # None (empty) | "nonempty" (constant) | "dynamic" (graph input)
+    past_key=None,  # explicit override for past_kv="nonempty" (else random)
+    past_value=None,  # explicit override for past_kv="nonempty" (else random)
 ):
     # Real ONNX Runtime CPU kernels for GroupQueryAttention require
     # head_size to be a multiple of 8 (verified empirically -- a smaller
@@ -5742,22 +5744,30 @@ def _gqa_model(
 
     # seqlens_k/total_sequence_length: mandatory KV-cache bookkeeping inputs
     # GroupQueryAttention's schema requires even for a plain, no-cache
-    # forward pass (see fuse_gqa.h's own top comment) -- `S-1` per batch row
-    # and `S`, exactly what fuse_gqa.h itself synthesizes.
+    # forward pass (see fuse_gqa.h's own top comment) -- `total_seq - 1` per
+    # batch row and `total_seq`, where `total_seq = seq + past_seq_len`
+    # (`past_seq_len` is the hardcoded past_key/past_value sequence length of
+    # 1 below when past_kv is connected at all, constant or dynamic, else 0)
+    # -- `S-1`/`S` exactly when there's no past context, what fuse_attn.h
+    # itself synthesizes for that no-cache case.
+    past_seq_len = 1 if past_kv in ("nonempty", "dynamic") else 0
+    total_seq = seq + past_seq_len
     initializer.append(
         onnx.numpy_helper.from_array(
-            np.full((batch,), seq - 1, dtype=np.int32), "SeqLensK"
+            np.full((batch,), total_seq - 1, dtype=np.int32), "SeqLensK"
         )
     )
     initializer.append(
-        onnx.numpy_helper.from_array(np.array(seq, dtype=np.int32), "TotalSeq")
+        onnx.numpy_helper.from_array(np.array(total_seq, dtype=np.int32), "TotalSeq")
     )
 
     operands = ["q", "k", "v"]
     extra_graph_inputs = ""
     if past_kv == "nonempty":
-        past_key = rng.standard_normal((batch, KVH, 1, D)).astype(np.float32)
-        past_value = rng.standard_normal((batch, KVH, 1, D)).astype(np.float32)
+        if past_key is None:
+            past_key = rng.standard_normal((batch, KVH, 1, D)).astype(np.float32)
+        if past_value is None:
+            past_value = rng.standard_normal((batch, KVH, 1, D)).astype(np.float32)
         initializer += [_f32(past_key, "PastKey"), _f32(past_value, "PastValue")]
         operands += ["PastKey", "PastValue"]
     elif past_kv == "dynamic":
@@ -5815,6 +5825,8 @@ def _gqa_model(
         wout=wout,
         batch=batch,
         seq=seq,
+        past_key=past_key,
+        past_value=past_value,
     )
 
 
@@ -5828,7 +5840,15 @@ def _gqa_attrs(node):
     return num_heads, kv_num_heads
 
 
-def _oracle_keep_groups(wq, wk, wv, num_heads, kv_num_heads, head_size, keep_count):
+def _oracle_keep_groups(
+    wq, wk, wv, num_heads, kv_num_heads, head_size, keep_count, v_head_size=None
+):
+    # `v_head_size` (V's own per-head column stride into `wv`) defaults to
+    # `head_size` (Q's/K's shared one) -- the uniform case every caller but
+    # the plain-ai.onnx-Attention "diff V head size" tests wants; those pass
+    # a genuinely different `v_head_size` explicitly.
+    if v_head_size is None:
+        v_head_size = head_size
     group_size = num_heads // kv_num_heads
     importance = np.zeros(kv_num_heads)
     for kv in range(kv_num_heads):
@@ -5840,7 +5860,7 @@ def _oracle_keep_groups(wq, wk, wv, num_heads, kv_num_heads, head_size, keep_cou
             axis=1,
         )
         k_block = wk[:, kv * head_size : (kv + 1) * head_size]
-        v_block = wv[:, kv * head_size : (kv + 1) * head_size]
+        v_block = wv[:, kv * v_head_size : (kv + 1) * v_head_size]
         importance[kv] = np.linalg.norm(
             np.concatenate([q_block, k_block, v_block], axis=1)
         )
@@ -6013,20 +6033,68 @@ def test_gqa_pruning_reshape_hop_is_recognized_and_shape_updated():
     assert y.shape == (cfg["batch"], cfg["seq"], cfg["Out"])
 
 
-def test_gqa_pruning_nonempty_past_kv_constant_is_left_untouched():
+def test_gqa_pruning_nonempty_past_kv_constant_matches_oracle_exactly():
     # A non-empty constant past_key/past_value holds real per-KV-head cache
-    # data along the kv_num_heads axis that this module would need to slice
-    # but doesn't attempt to -- declined outright rather than corrupted.
-    model, cfg = _gqa_model(K=8, H=8, KVH=2, D=8, Out=6, seed=12, past_kv="nonempty")
+    # data laid out along the kv_num_heads axis (BNSH format, confirmed via
+    # `onnxruntime.capi.onnxruntime_pybind11_state.get_all_operator_schema()`
+    # -- see `_past_kv_constants_are_sliceable`'s own docstring) -- sliced
+    # along that same axis by the identical `keep_groups` index set K's/V's
+    # own producer weights are sliced by, rather than declined. `batch=1`:
+    # onnxruntime's own GroupQueryAttention CPU kernel requires
+    # `batch_size == 1` whenever `sequence_length > 1` and a past context is
+    # supplied (verified empirically, see this module's own "Attention-head
+    # pruning" section comment).
+    model, cfg = _gqa_model(
+        K=8, H=8, KVH=2, D=8, Out=6, seed=12, batch=1, past_kv="nonempty"
+    )
     pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
-    inits_before = {
-        t.name: onnx.numpy_helper.to_array(t) for t in model.graph.initializer
-    }
-    inits_after = {
-        t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer
-    }
-    for name in inits_before:
-        np.testing.assert_array_equal(inits_before[name], inits_after[name])
+    onnx.checker.check_model(pruned)
+
+    node = _gqa_node(pruned)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    group_size = cfg["H"] // cfg["KVH"]
+    assert kv_num_heads == 1  # max(1, 2 - round(2*0.5))
+    assert num_heads == kv_num_heads * group_size
+
+    keep_groups = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], cfg["H"], cfg["KVH"], cfg["D"], kv_num_heads
+    )
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    d = cfg["D"]
+    q_idx, kv_idx = _head_idx(keep_q_heads, d), _head_idx(keep_groups, d)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(
+        inits["PastKey"], cfg["past_key"][:, keep_groups, :, :]
+    )
+    np.testing.assert_array_equal(
+        inits["PastValue"], cfg["past_value"][:, keep_groups, :, :]
+    )
+
+    oracle, _ = _gqa_model(
+        K=cfg["K"],
+        H=num_heads,
+        KVH=kv_num_heads,
+        D=d,
+        Out=cfg["Out"],
+        seed=12,
+        batch=cfg["batch"],
+        seq=cfg["seq"],
+        wq=cfg["wq"][:, q_idx],
+        wk=cfg["wk"][:, kv_idx],
+        wv=cfg["wv"][:, kv_idx],
+        wout=cfg["wout"][q_idx, :],
+        past_kv="nonempty",
+        past_key=cfg["past_key"][:, keep_groups, :, :],
+        past_value=cfg["past_value"][:, keep_groups, :, :],
+    )
+    onnx.checker.check_model(oracle)
+
+    rng = np.random.default_rng(20)
+    x = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
 
 
 def test_gqa_pruning_dynamic_past_kv_input_is_still_pruned():
@@ -6048,6 +6116,37 @@ def test_gqa_pruning_dynamic_past_kv_input_is_still_pruned():
     assert list(inits["Wq"].dims) == [8, 4 * cfg["D"]]
     assert list(inits["Wk"].dims) == [8, 1 * cfg["D"]]
     assert list(inits["Wv"].dims) == [8, 1 * cfg["D"]]
+
+
+def test_gqa_pruning_quantized_past_kv_constant_is_left_untouched():
+    # A non-FLOAT constant past_key/past_value (standing in for a quantized
+    # KV cache -- GroupQueryAttention's own schema allows `past_key`/
+    # `past_value` to be `float8e4m3fn`/`uint8`/`int8` when quantized, per
+    # `onnxruntime.capi.onnxruntime_pybind11_state.get_all_operator_schema()`'s
+    # own "Quantization" section) is declined outright by
+    # `_past_kv_constants_are_sliceable` rather than sliced as if it were an
+    # ordinary float BNSH tensor: a quantized cache's own `k_scale`/
+    # `v_scale` tensors would need identical per-KV-head-axis slicing to
+    # stay consistent, which this module makes no attempt to locate or
+    # slice, so guessing here would silently corrupt the cache.
+    model, cfg = _gqa_model(K=8, H=8, KVH=2, D=8, Out=6, seed=25, past_kv="nonempty")
+    inits_map = {t.name: t for t in model.graph.initializer}
+    quantized_past_key = onnx.numpy_helper.from_array(
+        onnx.numpy_helper.to_array(inits_map["PastKey"]).astype(np.uint8), "PastKey"
+    )
+    inits_map["PastKey"].CopyFrom(quantized_past_key)
+
+    assert onnxsim.pruning._find_gqa_chains(model.graph) == []
+
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    inits_before = {
+        t.name: onnx.numpy_helper.to_array(t) for t in model.graph.initializer
+    }
+    inits_after = {
+        t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer
+    }
+    for name in inits_before:
+        np.testing.assert_array_equal(inits_before[name], inits_after[name])
 
 
 def test_gqa_wanda_pruning_matches_oracle_exactly():
@@ -6660,21 +6759,33 @@ def _onnx_attention_model(
     wout=None,
     attn_mask=None,  # None (omitted) | "nonempty" (constant) | "dynamic" (graph input)
     past_kv=None,  # None (omitted) | "nonempty" (constant) | "dynamic" (graph input)
+    past_key=None,  # explicit override for past_kv="nonempty" (else random)
+    past_value=None,  # explicit override for past_kv="nonempty" (else random)
+    Dv=None,  # V's own head_size, if it should genuinely differ from D
 ):
     # Unlike `com.microsoft::GroupQueryAttention` (see `_gqa_model`'s own
     # comment), this op's real onnxruntime CPU kernel has no observed
     # head_size-multiple-of-8 requirement -- verified empirically above --
     # so D defaults to a small 4, mirroring `_attention_model`'s own default.
+    #
+    # `Dv` (V's own head_size, defaulting to `D` -- the uniform case every
+    # other caller of this helper wants) is independent of Q/K's `D`: unlike
+    # `_gqa_model`'s `GroupQueryAttention`, this op's own schema genuinely
+    # allows the two to differ (see this module's own "Attention-head
+    # pruning" section comment), and the raw output/output-projection's own
+    # reduction dim is sized off `Dv`, not `D` -- `H * Dv`, not `H * D`.
+    if Dv is None:
+        Dv = D
     rng = np.random.default_rng(seed)
-    Nq, Nkv = H * D, KVH * D
+    Nq, Nk, Nv = H * D, KVH * D, KVH * Dv
     if wq is None:
         wq = rng.standard_normal((K, Nq)).astype(np.float32)
     if wk is None:
-        wk = rng.standard_normal((K, Nkv)).astype(np.float32)
+        wk = rng.standard_normal((K, Nk)).astype(np.float32)
     if wv is None:
-        wv = rng.standard_normal((K, Nkv)).astype(np.float32)
+        wv = rng.standard_normal((K, Nv)).astype(np.float32)
     if wout is None:
-        wout = rng.standard_normal((Nq, Out)).astype(np.float32)
+        wout = rng.standard_normal((H * Dv, Out)).astype(np.float32)
 
     initializer = [_f32(wq, "Wq"), _f32(wk, "Wk"), _f32(wv, "Wv"), _f32(wout, "Wout")]
     q_op, k_op, v_op = "MatMul(X, Wq)", "MatMul(X, Wk)", "MatMul(X, Wv)"
@@ -6682,9 +6793,9 @@ def _onnx_attention_model(
         if bq is None:
             bq = rng.standard_normal((Nq,)).astype(np.float32)
         if bk is None:
-            bk = rng.standard_normal((Nkv,)).astype(np.float32)
+            bk = rng.standard_normal((Nk,)).astype(np.float32)
         if bv is None:
-            bv = rng.standard_normal((Nkv,)).astype(np.float32)
+            bv = rng.standard_normal((Nv,)).astype(np.float32)
         initializer += [_f32(bq, "Bq"), _f32(bk, "Bk"), _f32(bv, "Bv")]
         q_op, k_op, v_op = "Gemm(X, Wq, Bq)", "Gemm(X, Wk, Bk)", "Gemm(X, Wv, Bv)"
 
@@ -6702,15 +6813,17 @@ def _onnx_attention_model(
         operands.append("")
 
     if past_kv == "nonempty":
-        past_key = rng.standard_normal((batch, KVH, 1, D)).astype(np.float32)
-        past_value = rng.standard_normal((batch, KVH, 1, D)).astype(np.float32)
+        if past_key is None:
+            past_key = rng.standard_normal((batch, KVH, 1, D)).astype(np.float32)
+        if past_value is None:
+            past_value = rng.standard_normal((batch, KVH, 1, Dv)).astype(np.float32)
         initializer += [_f32(past_key, "PastKey"), _f32(past_value, "PastValue")]
         operands += ["PastKey", "PastValue"]
     elif past_kv == "dynamic":
         operands += ["PastKeyIn", "PastValueIn"]
         extra_graph_inputs += (
             f", float[{batch},{KVH},1,{D}] PastKeyIn"
-            f", float[{batch},{KVH},1,{D}] PastValueIn"
+            f", float[{batch},{KVH},1,{Dv}] PastValueIn"
         )
     else:
         operands += ["", ""]
@@ -6721,19 +6834,26 @@ def _onnx_attention_model(
         operands.pop()
 
     if with_reshape:
-        shape = np.array([batch, seq, Nq], dtype=np.int64)
+        shape = np.array([batch, seq, H * Dv], dtype=np.int64)
         initializer.append(onnx.numpy_helper.from_array(shape, "Shape"))
         tail = "ctx2 = Reshape(ctx, Shape)\n          Y = MatMul(ctx2, Wout)"
     else:
         tail = "Y = MatMul(ctx, Wout)"
 
+    # onnxruntime's own kernel for this op requires `present_key`/
+    # `present_value` (indices 1/2) declared as node outputs whenever
+    # `past_key`/`past_value` are connected at all (verified empirically:
+    # "The implementation does not support past_key provided and
+    # present_key being null") -- unused beyond the node itself, just like
+    # any other output no downstream node consumes.
+    ctx_outputs = "ctx, present_key, present_value" if past_kv else "ctx"
     body = f"""
         g (float[{batch},{seq},{K}] X{extra_graph_inputs}) => (float[{batch},{seq},{Out}] Y)
         {{
           q = {q_op}
           k = {k_op}
           v = {v_op}
-          ctx = Attention <q_num_heads={H}, kv_num_heads={KVH}> ({", ".join(operands)})
+          {ctx_outputs} = Attention <q_num_heads={H}, kv_num_heads={KVH}> ({", ".join(operands)})
           {tail}
         }}
         """
@@ -6753,9 +6873,12 @@ def _onnx_attention_model(
         H=H,
         KVH=KVH,
         D=D,
+        Dv=Dv,
         Out=Out,
         Nq=Nq,
-        Nkv=Nkv,
+        Nkv=Nk,
+        Nk=Nk,
+        Nv=Nv,
         wq=wq,
         wk=wk,
         wv=wv,
@@ -6765,6 +6888,8 @@ def _onnx_attention_model(
         wout=wout,
         batch=batch,
         seq=seq,
+        past_key=past_key,
+        past_value=past_value,
     )
 
 
@@ -6970,24 +7095,67 @@ def test_onnx_attention_pruning_reshape_hop_is_recognized_and_shape_updated():
     assert y.shape == (cfg["batch"], cfg["seq"], cfg["Out"])
 
 
-def test_onnx_attention_pruning_nonempty_past_kv_constant_is_left_untouched():
+def test_onnx_attention_pruning_nonempty_past_kv_constant_matches_oracle_exactly():
     # A non-empty constant past_key/past_value holds real per-KV-head cache
-    # data along the kv_num_heads axis this module would need to slice but
-    # doesn't attempt to -- declined outright, mirroring
-    # `test_gqa_pruning_nonempty_past_kv_constant_is_left_untouched` exactly
-    # (`_match_onnx_attention_producer` applies the identical safety check).
+    # data laid out along the kv_num_heads axis (BNSH format, confirmed via
+    # `onnx.defs.get_schema("Attention", domain="")` -- see
+    # `_past_kv_constants_are_sliceable`'s own docstring) -- sliced along
+    # that same axis by the identical `keep_groups` index set K's/V's own
+    # producer weights are sliced by, mirroring
+    # `test_gqa_pruning_nonempty_past_kv_constant_matches_oracle_exactly`
+    # (`_match_onnx_attention_producer` shares the identical safety gate and
+    # `_apply_one_gqa_chain` the identical slicing).
     model, cfg = _onnx_attention_model(
         K=8, H=8, KVH=2, D=4, Out=6, seed=12, past_kv="nonempty"
     )
     pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
-    inits_before = {
-        t.name: onnx.numpy_helper.to_array(t) for t in model.graph.initializer
-    }
-    inits_after = {
-        t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer
-    }
-    for name in inits_before:
-        np.testing.assert_array_equal(inits_before[name], inits_after[name])
+    onnx.checker.check_model(pruned)
+
+    node = _onnx_attention_node(pruned)
+    q_num_heads, kv_num_heads = _onnx_attention_attrs(node)
+    group_size = cfg["H"] // cfg["KVH"]
+    assert kv_num_heads == 1  # max(1, 2 - round(2*0.5))
+    assert q_num_heads == kv_num_heads * group_size
+
+    keep_groups = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], cfg["H"], cfg["KVH"], cfg["D"], kv_num_heads
+    )
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    d = cfg["D"]
+    q_idx, kv_idx = _head_idx(keep_q_heads, d), _head_idx(keep_groups, d)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(
+        inits["PastKey"], cfg["past_key"][:, keep_groups, :, :]
+    )
+    np.testing.assert_array_equal(
+        inits["PastValue"], cfg["past_value"][:, keep_groups, :, :]
+    )
+
+    oracle, _ = _onnx_attention_model(
+        K=cfg["K"],
+        H=q_num_heads,
+        KVH=kv_num_heads,
+        D=d,
+        Out=cfg["Out"],
+        seed=12,
+        batch=cfg["batch"],
+        seq=cfg["seq"],
+        wq=cfg["wq"][:, q_idx],
+        wk=cfg["wk"][:, kv_idx],
+        wv=cfg["wv"][:, kv_idx],
+        wout=cfg["wout"][q_idx, :],
+        past_kv="nonempty",
+        past_key=cfg["past_key"][:, keep_groups, :, :],
+        past_value=cfg["past_value"][:, keep_groups, :, :],
+    )
+    onnx.checker.check_model(oracle)
+
+    rng = np.random.default_rng(21)
+    x = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
 
 
 def test_onnx_attention_pruning_dynamic_past_kv_input_is_still_pruned():
@@ -7102,60 +7270,104 @@ def test_onnx_attention_pruning_missing_kv_num_heads_attribute_is_left_untouched
         np.testing.assert_array_equal(inits_before[name], inits_after[name])
 
 
-def test_onnx_attention_pruning_diff_v_head_size_is_left_untouched():
+def test_onnx_attention_pruning_diff_v_head_size_matches_oracle_exactly():
     # This op's real schema (unlike `com.microsoft::GroupQueryAttention`,
     # which `fuse_gqa.h` always emits with equal Q/K/V head_size) genuinely
     # allows V its own, independent head_size -- confirmed via the op's own
     # backend-test suite (`test_attention_3d_diff_heads_sizes` and friends
-    # in `onnx/backend/test/case/node/attention.py`). This pass reuses
-    # `_apply_one_gqa_chain`'s shared, uniform-head_size slicing body
-    # unmodified rather than a parallel implementation (see this module's
-    # own "Attention-head pruning" section comment), so a node whose V head
-    # size actually differs from Q/K's is declined here rather than
-    # mis-sliced -- checked directly against `_find_onnx_attention_chains`
-    # too, since nothing downstream needs exercising once the node fails to
-    # match at all.
-    K, H, KVH, D, Dv, Out = 8, 4, 4, 4, 6, 5
-    Nq, Nk, Nv = H * D, KVH * D, KVH * Dv
+    # in `onnx/backend/test/case/node/attention.py`) and via actual
+    # onnxruntime execution above. `_GQAChain` now carries Q's/K's shared
+    # `head_size` and V's own (possibly different) `v_head_size` as separate
+    # fields, and `_apply_one_gqa_chain` slices Q's/K's own producer weight
+    # at `head_size` while V's own producer weight -- and the output
+    # projection's own reduction dim, and the raw output's own width -- at
+    # `v_head_size` (see this module's own "Attention-head pruning" section
+    # comment). Each KV group's own Q+K+V block is scaled by a distinct,
+    # well-separated factor (not left to natural per-head random variance)
+    # so which 2 of 4 groups the importance ranking keeps is unambiguous,
+    # genuinely exercising the ranking logic rather than merely running
+    # without error.
+    K, H, KVH, D, Dv, Out = 8, 8, 4, 4, 6, 5
+    group_size = H // KVH
     rng = np.random.default_rng(19)
-    wq = rng.standard_normal((K, Nq)).astype(np.float32)
-    wk = rng.standard_normal((K, Nk)).astype(np.float32)
-    wv = rng.standard_normal((K, Nv)).astype(np.float32)
-    wout = rng.standard_normal((Nq, Out)).astype(np.float32)
-    # V's own head_size (`Dv`) differs from Q/K's (`D`) -- a shape this pass
-    # declines rather than mis-slices.
-    model = parser.parse_model(
-        f"""
-        <
-          ir_version: 10,
-          opset_import: ["": 24]
-        >
-        g (float[2,5,{K}] X) => (float[2,5,{Out}] Y)
-        {{
-          q = MatMul(X, Wq)
-          k = MatMul(X, Wk)
-          v = MatMul(X, Wv)
-          ctx = Attention <q_num_heads={H}, kv_num_heads={KVH}> (q, k, v)
-          Y = MatMul(ctx, Wout)
-        }}
-        """
-    )
-    model.graph.initializer.extend(
-        [_f32(wq, "Wq"), _f32(wk, "Wk"), _f32(wv, "Wv"), _f32(wout, "Wout")]
+    wq = rng.standard_normal((K, H * D)).astype(np.float32)
+    wk = rng.standard_normal((K, KVH * D)).astype(np.float32)
+    wv = rng.standard_normal((K, KVH * Dv)).astype(np.float32)
+    wout = rng.standard_normal((H * Dv, Out)).astype(np.float32)
+
+    # Group 0 and 2 are scaled far above group 1 and 3 -- the top-2 by
+    # importance (kv_num_heads == 2 at sparsity=0.5) are therefore exactly
+    # {0, 2}, regardless of the underlying random weights' own natural norm
+    # variance (a 20x-60x separation swamps it).
+    scales = [3.0, 0.1, 2.0, 0.05]
+    for kv, scale in enumerate(scales):
+        for h in range(kv * group_size, (kv + 1) * group_size):
+            wq[:, h * D : (h + 1) * D] *= scale
+        wk[:, kv * D : (kv + 1) * D] *= scale
+        wv[:, kv * Dv : (kv + 1) * Dv] *= scale
+
+    model, cfg = _onnx_attention_model(
+        K=K,
+        H=H,
+        KVH=KVH,
+        D=D,
+        Dv=Dv,
+        Out=Out,
+        seed=19,
+        wq=wq,
+        wk=wk,
+        wv=wv,
+        wout=wout,
     )
     onnx.checker.check_model(model)
 
-    assert onnxsim.pruning._find_onnx_attention_chains(model.graph) == []
-
     pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
-    inits_before = {
-        t.name: onnx.numpy_helper.to_array(t) for t in model.graph.initializer
-    }
-    inits_after = {
-        t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer
-    }
-    for name in inits_before:
-        np.testing.assert_array_equal(inits_before[name], inits_after[name])
+    onnx.checker.check_model(pruned)
+
+    node = _onnx_attention_node(pruned)
+    q_num_heads, kv_num_heads = _onnx_attention_attrs(node)
+    assert kv_num_heads == 2  # max(1, 4 - round(4*0.5))
+    assert q_num_heads == kv_num_heads * group_size
+
+    keep_groups = _oracle_keep_groups(
+        wq, wk, wv, H, KVH, D, kv_num_heads, v_head_size=Dv
+    )
+    assert list(keep_groups) == [0, 2]
+
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    q_idx = _head_idx(keep_q_heads, D)  # Q's own producer weight columns
+    kv_idx = _head_idx(keep_groups, D)  # K's own producer weight columns
+    v_idx = _head_idx(keep_groups, Dv)  # V's own producer weight columns
+    y_idx = _head_idx(keep_q_heads, Dv)  # output/consumer-side columns
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["Wq"], wq[:, q_idx])
+    np.testing.assert_array_equal(inits["Wk"], wk[:, kv_idx])
+    np.testing.assert_array_equal(inits["Wv"], wv[:, v_idx])
+    np.testing.assert_array_equal(inits["Wout"], wout[y_idx, :])
+
+    oracle, _ = _onnx_attention_model(
+        K=K,
+        H=q_num_heads,
+        KVH=kv_num_heads,
+        D=D,
+        Dv=Dv,
+        Out=Out,
+        seed=19,
+        wq=wq[:, q_idx],
+        wk=wk[:, kv_idx],
+        wv=wv[:, v_idx],
+        wout=wout[y_idx, :],
+        batch=cfg["batch"],
+        seq=cfg["seq"],
+    )
+    onnx.checker.check_model(oracle)
+
+    rng2 = np.random.default_rng(22)
+    x = rng2.standard_normal((cfg["batch"], cfg["seq"], K)).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
 
 
 def test_onnx_attention_wanda_pruning_matches_oracle_exactly():
@@ -7215,6 +7427,87 @@ def test_onnx_attention_wanda_pruning_matches_oracle_exactly():
     )
 
     x = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_onnx_attention_wanda_pruning_diff_v_head_size_matches_oracle_exactly():
+    # The Wanda-calibrated counterpart of
+    # `test_onnx_attention_pruning_diff_v_head_size_matches_oracle_exactly`:
+    # `_wanda_gqa_group_importance`'s own activation probe sits on the
+    # consumer's input (the attention output), laid out per query head at
+    # V's own `v_head_size` -- not Q's/K's `head_size` -- so both its own
+    # `width` check and its per-group activation window must stride by
+    # `v_head_size`, exactly like the weight-only path's `y_idx` does.
+    K, H, KVH, D, Dv, Out = 8, 8, 2, 4, 6, 5
+    group_size = H // KVH
+    model, cfg = _onnx_attention_model(K=K, H=H, KVH=KVH, D=D, Dv=Dv, Out=Out, seed=23)
+
+    rng = np.random.default_rng(24)
+    x_cal = rng.standard_normal((cfg["batch"], cfg["seq"], K)).astype(np.float32)
+    calibration_data = [{"X": x_cal}]
+
+    pruned = onnxsim.apply_attention_head_wanda_pruning(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned)
+
+    probe_model = onnx.ModelProto()
+    probe_model.CopyFrom(model)
+    probe_model.graph.output.append(onnx.ValueInfoProto(name="ctx"))
+    (_, ctx_cal) = _run(probe_model, {"X": x_cal})
+    act_norm = np.sqrt(np.mean(np.square(ctx_cal.astype(np.float64)), axis=(0, 1)))
+    assert act_norm.shape == (H * Dv,)  # sanity: laid out per Q head at Dv, not D
+
+    importance = np.zeros(KVH)
+    for kv in range(KVH):
+        q_block = np.concatenate(
+            [
+                cfg["wq"][:, h * D : (h + 1) * D]
+                for h in range(kv * group_size, (kv + 1) * group_size)
+            ],
+            axis=1,
+        )
+        k_block = cfg["wk"][:, kv * D : (kv + 1) * D]
+        v_block = cfg["wv"][:, kv * Dv : (kv + 1) * Dv]
+        base = np.linalg.norm(np.concatenate([q_block, k_block, v_block], axis=1))
+        act_group = np.linalg.norm(
+            act_norm[kv * group_size * Dv : (kv + 1) * group_size * Dv]
+        )
+        importance[kv] = base * max(act_group, 1e-8)
+    keep_groups = np.sort(np.argsort(-importance)[:1])  # max(1, 2 - round(2*0.5))
+
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    q_idx = _head_idx(keep_q_heads, D)
+    kv_idx = _head_idx(keep_groups, D)
+    v_idx = _head_idx(keep_groups, Dv)
+    y_idx = _head_idx(keep_q_heads, Dv)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["Wq"], cfg["wq"][:, q_idx])
+    np.testing.assert_array_equal(inits["Wk"], cfg["wk"][:, kv_idx])
+    np.testing.assert_array_equal(inits["Wv"], cfg["wv"][:, v_idx])
+    np.testing.assert_array_equal(inits["Wout"], cfg["wout"][y_idx, :])
+
+    oracle, _ = _onnx_attention_model(
+        K=K,
+        H=len(keep_q_heads),
+        KVH=len(keep_groups),
+        D=D,
+        Dv=Dv,
+        Out=Out,
+        seed=23,
+        wq=cfg["wq"][:, q_idx],
+        wk=cfg["wk"][:, kv_idx],
+        wv=cfg["wv"][:, v_idx],
+        wout=cfg["wout"][y_idx, :],
+        batch=cfg["batch"],
+        seq=cfg["seq"],
+    )
+    onnx.checker.check_model(oracle)
+
+    x = rng.standard_normal((cfg["batch"], cfg["seq"], K)).astype(np.float32)
     (y_pruned,) = _run(pruned, {"X": x})
     (y_oracle,) = _run(oracle, {"X": x})
     np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)


### PR DESCRIPTION
## Summary
- Closed two previously-documented gaps in attention-head structured pruning (`GroupQueryAttention` and plain `ai.onnx::Attention`):
  1. **Constant-baked `past_key`/`past_value` (KV cache).** Previously declined outright, since a non-empty constant cache tensor holds real per-KV-head data along the `kv_num_heads` axis this pass didn't attempt to slice. A *dynamic* (non-constant) cache was already fine.
  2. **Independent V `head_size`.** Plain `ai.onnx::Attention` schema-legally allows V its own `head_size` different from Q/K's (confirmed via the op's own backend conformance tests, e.g. `test_attention_3d_diff_heads_sizes`) — `GroupQueryAttention` itself can never produce this shape (`fuse_gqa.h` requires equal Q/K/V head_size before fusing), but the shared `_GQAChain`/`_apply_one_gqa_chain` body previously assumed one uniform head_size, so this case was declined for plain `Attention` too.
- Verified the exact BNSH cache layout (`(batch_size, kv_num_heads, seq_len, head_size)`) directly from the installed `onnxruntime==1.29.0`'s own schema registry and `onnx.defs.get_schema("Attention", domain="")`, rather than assuming it — axis 1 is `kv_num_heads` for both ops, at input indices (3, 4) for `GroupQueryAttention` and (4, 5) for plain `Attention`. (Independently re-confirmed the same axis/index claims directly against the live `onnxruntime`/`onnx` installations during review.)
- Implemented: new shared `_past_kv_constants_are_sliceable()` gates a constant `past_key`/`past_value` on being FLOAT, rank-4, with `dims[1] == kv_num_heads` (declining a quantized cache outright, since its `k_scale`/`v_scale` would also need slicing, not attempted here); `_apply_one_gqa_chain` slices a qualifying cache along axis 1 with the same `keep_groups` set already used for K/V weights. `_GQAChain` gained a separate `v_head_size` field (equal to `head_size` for every `GroupQueryAttention` chain, independently settable for plain `Attention` via a new `allow_differing_v_head_size` parameter on `_find_separate_qkv_chains`); slicing was split so V's own weight/output-side indices use `v_head_size` while Q/K's still use their shared `head_size`.
- Verified with fresh oracle tests (`onnx.parser`-based) against real onnxruntime execution: a model with a genuine constant `past_key`/`past_value` tensor prunes and slices the cache correctly; a plain `Attention` node with a genuinely different V head_size and deliberately conflicting per-head importance profiles matches an independently-constructed oracle exactly; a quantized KV cache is still correctly left untouched (adversarial safety-gate check).

## Test plan
- [x] `pytest tests/test_pruning.py -q` — 186 passed
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — same 3 pre-existing, unrelated errors as `master`; no new ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_