### PR TITLE
Compose Concat skip-connection pruning with a residual/merge branch

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -178,11 +178,23 @@ logic (concatenating each branch's own surviving-channel set, shifted by its
 own fixed offset) to stay correct. See :func:`_find_matmul_concat_chains`/
 :func:`_find_conv_concat_chains`'s own section comment for the bounded,
 single-consumer-per-branch shape this reaches (a `Concat` chained
-transitively into another `Concat`, or composed with a gated/residual
-branch, is declined the same conservative way as everything above) and
+transitively into another `Concat`, or composed with a gated branch, is
+declined the same conservative way as everything above) and
 :func:`_apply_concat_chains`'s own docstring for why that per-branch,
 independent-`keep` shape needed a genuinely new sibling to
-`_Chain`/`_apply_chains` rather than fitting into the existing one.
+`_Chain`/`_apply_chains` rather than fitting into the existing one. A branch
+that bottoms out at an `Add`/`SkipLayerNormalization` residual merge instead
+of a real producer *is* composed, in one bounded shape: the merge's own
+whole transitively-connected group (see the residual sections above) is
+resolved exactly as it would be standalone, and -- *only* when that group
+has no consumer anywhere else at all (this one `Concat` branch is its
+sole reason to exist) -- the group's own combined-importance `keep` set
+becomes this one branch's own contribution, its several leaf producers all
+sliced together by it. A group with any other fan-out (an interior tensor
+also read elsewhere, or its sink feeding some other ordinary consumer too)
+is declined outright rather than guessed at -- see
+:func:`_find_matmul_concat_chains`/:func:`_find_conv_concat_chains`'s own
+section comment for exactly why that line is where it's drawn.
 
 General multi-branch dependency-graph pruning remains out of scope --
 a non-`Add`/`SkipLayerNormalization`/`Concat` merge op, and fan-out
@@ -3933,24 +3945,52 @@ def _find_gated_chains(graph: onnx.GraphProto) -> List[_Chain]:
 # activations (plus, for MatMul/Gemm, a per-channel `Add`/`Mul`/
 # `BiasGelu`/`FastGelu` hop; for Conv, a self-consistently-depthwise
 # pass-through hop) a plain single-producer chain's own forward walk
-# recognizes. Only a `"producer"` outcome is accepted here, though: a
+# recognizes. A `"producer"` outcome is accepted directly, as before. A
 # `"add"` outcome -- the branch resolves to an eligible `Add`/
 # `SkipLayerNormalization` residual merge instead of a real producer -- is
-# treated exactly like `"fail"` and declines the *entire* `Concat` group,
-# the same conservative "never partially pruned" bar the residual sections'
-# own union-find grouping holds every member to. Composing a residual merge
-# with a `Concat` merge on the same branch (e.g. a decoder block whose own
-# skip input is itself a residual sum) is a real, plausible topology this
-# module simply hasn't verified yet -- see this module's own docstring for
-# why that's an honest scope boundary rather than an oversight, not a case
-# this finder tries to guess at. Likewise, a `Concat` chained transitively
-# into *another* `Concat` (a "spine" of concatenations) is not walked
-# through either: neither backward walker recognizes `Concat` as a hop at
-# all, so an operand that bottoms out at one simply falls through to
-# `"fail"` the same way an unrecognized producer always does -- no dedicated
-# check was needed to draw that boundary, it falls out for free from what
-# the walkers already do and don't recognize. A gated (SwiGLU/GeGLU) pair
-# feeding a `Concat` operand directly, with no real producer's raw output in
+# now *composed*, but only in one bounded shape (see
+# :func:`_resolve_matmul_residual_group_for_concat`/
+# :func:`_resolve_conv_residual_group_for_concat`): the merge's own whole
+# transitively-connected group is resolved exactly the way the residual
+# sections above resolve it standalone (same union-find-over-eligible-merges
+# walk, same per-member operand resolution, same "any operand fails, the
+# entire group declines" bar) -- except its *sink* is never handed to
+# :func:`_walk_to_consumer`/:func:`_walk_to_conv_consumer` the way the
+# standalone residual finder needs to (that forward walker doesn't
+# recognize `Concat` as a hop at all -- see below -- so a group whose sink
+# feeds a `Concat` is *always* declined by the standalone residual finder,
+# today, independent of anything this finder does; nothing double-resolves
+# it). Instead, the branch's own already-known path from the group's sink
+# to this `Concat` operand (`"add"`'s own `pre_ops`/`edges`, exactly what a
+# plain producer outcome already carries) is checked for fan-out the same
+# way a plain producer branch already is
+# (:func:`_branch_walk_has_fanout`), and :func:`_resolve_matmul_fanout_branches`/
+# :func:`_resolve_conv_fanout_branches` -- the *exact* existing fan-out
+# resolver the standalone residual finder already uses, entirely
+# unmodified -- is reused to confirm the group has no *other* consumer
+# anywhere: every backbone tensor's only accounted consumer is the group's
+# own internal wiring plus this one already-known Concat-ward path, so an
+# empty result (no un-accounted consumer found at all) is this composition's
+# *success* case, the mirror image of what that function's own existing
+# caller treats as "no consumer, decline". Any non-empty result -- real
+# fan-out exists, whether resolvable to an ordinary chain or not -- declines
+# the whole `Concat` group instead of trying to reconcile a `Concat`
+# branch's own fixed-offset slice with an ordinary chain's shared,
+# un-offset one; see this module's own docstring for the worked reasoning.
+# Once resolved, the group's several leaf producers ride together on this
+# one branch (:class:`_ConcatBranch`'s own `producers` is a tuple for
+# exactly this reason, not always length one) and are ranked by the same
+# combined (root-sum-square) importance :func:`_plain_structured_importance`
+# already uses for an ordinary multi-producer chain, not
+# :func:`_plain_branch_importance`'s single-producer norm. Likewise, a
+# `Concat` chained transitively into *another* `Concat` (a "spine" of
+# concatenations) is not walked through: neither backward walker recognizes
+# `Concat` as a hop at all, so an operand that bottoms out at one simply
+# falls through to `"fail"` the same way an unrecognized producer always
+# does -- no dedicated check was needed to draw that boundary, it falls out
+# for free from what the walkers already do and don't recognize. A gated
+# (SwiGLU/GeGLU) pair feeding a `Concat` operand directly, with no real
+# producer's raw output in
 # between, is declined the same way: neither backward walker resolves
 # through a `Mul` of two non-constant operands (see the MatMul residual
 # section's own comment for why), so that shape falls through to `"fail"`
@@ -4018,17 +4058,33 @@ class _ConcatBranch:
     :class:`_Chain` rather than folding into them.
     """
 
-    producer: _Producer  # `pre_ops` always left empty -- see `pre_ops` below
-    # Ops between the producer's own raw output and this branch's own
-    # `Concat` operand: ``(node, const_name_or_None)`` pairs, forward order
-    # -- exactly :class:`_Chain`'s own `chain_ops` shape (needed here rather
-    # than :class:`_Producer`'s own bare-node `pre_ops` tuple, because a
-    # MatMul/Gemm branch can carry a per-channel `Add`/`Mul`/`BiasGelu`/
-    # `FastGelu` constant on this hop, not just a unary activation).
+    # One producer for a plain branch (`_Producer.pre_ops` always left empty
+    # -- see `pre_ops` below); more than one when this branch instead
+    # resolves through a composed residual/merge group -- see this section's
+    # own comment on the `"add"` outcome -- in which case every producer
+    # here shares this one branch's own combined-importance `keep` set,
+    # exactly the way :class:`_Chain`'s own multi-producer `producers` does
+    # for an ordinary residual chain.
+    producers: Tuple[_Producer, ...]
+    # Ops between the producer's own raw output (or, for a composed group,
+    # between every leaf producer/inter-merge hop *and* the group's own
+    # sink merge node, plus the sink's own raw output and this branch's own
+    # `Concat` operand -- the whole group collapses onto this one flat list,
+    # exactly as :func:`_find_matmul_residual_chains`/
+    # :func:`_find_conv_residual_chains` already flatten a standalone
+    # group's own internal wiring into one `_Chain.chain_ops`) and this
+    # branch's own `Concat` operand: ``(node, const_name_or_None)`` pairs,
+    # order-independent -- every entry is sliced by this branch's own single
+    # `keep` set regardless of position, exactly :class:`_Chain`'s own
+    # `chain_ops` shape (needed here rather than :class:`_Producer`'s own
+    # bare-node `pre_ops` tuple, because a MatMul/Gemm branch can carry a
+    # per-channel `Add`/`Mul`/`BiasGelu`/`FastGelu` constant on this hop, not
+    # just a unary activation).
     pre_ops: Tuple[Tuple[onnx.NodeProto, Optional[str]], ...]
     # Depthwise Conv pass-through hops crossed on this branch (Conv branches
     # only; always empty for a MatMul/Gemm branch -- see
-    # :class:`_ConvPassThrough`).
+    # :class:`_ConvPassThrough`), same flattening as `pre_ops` above for a
+    # composed group's own internal depthwise hops.
     conv_pass_through: Tuple[_ConvPassThrough, ...]
     n_channels: int
     # This branch's fixed offset into the merged (pre-pruning) channel
@@ -4036,9 +4092,12 @@ class _ConcatBranch:
     # why this is safe to compute once, up front, from operand order alone.
     offset: int
     # The tensor name actually feeding the `Concat` node at this operand
-    # position (`== producer.node.output[0]` when `pre_ops` is empty) -- the
-    # Wanda activation-probe point for this branch, see
-    # :func:`apply_structured_wanda_pruning`.
+    # position (`== producers[0].node.output[0]` when `pre_ops` is empty and
+    # this is a plain, single-producer branch) -- the Wanda activation-probe
+    # point for this branch, see :func:`apply_structured_wanda_pruning`. For
+    # a composed group branch this is still exactly where the group's own
+    # (possibly-multi-producer) output actually feeds the `Concat` node --
+    # a perfectly well-defined probe point either way.
     operand_name: str
 
 
@@ -4101,21 +4160,249 @@ def _branch_walk_has_fanout(
     return len(consumers) != 1 or consumers[0] is not prev_consumer
 
 
+_ResolvedMatmulResidualGroup = Tuple[
+    Tuple[_Producer, ...],
+    Tuple[Tuple[onnx.NodeProto, Optional[str]], ...],
+    int,
+    List[str],
+    Dict[str, Set[int]],
+]
+
+
+def _resolve_matmul_residual_group_for_concat(
+    root: onnx.NodeProto,
+    node_by_output: Dict[str, onnx.NodeProto],
+    initializer_map: Dict[str, onnx.TensorProto],
+    consumers_of: Dict[str, List[onnx.NodeProto]],
+    graph_outputs: Set[str],
+) -> Optional[_ResolvedMatmulResidualGroup]:
+    """Resolves `root` (an ``Add``/``SkipLayerNormalization`` merge a
+    ``Concat`` branch's own backward walk bottomed out at -- an `"add"`
+    outcome from :func:`_walk_matmul_producer_backward`) and its whole
+    transitively-connected residual/merge group, mirroring
+    :func:`_find_matmul_residual_chains`'s own per-group union-find loop
+    exactly (same per-member operand resolution via
+    :func:`_walk_matmul_producer_backward`, same "any operand fails, the
+    whole group declines" bar, same post-hoc bias/scale-constant
+    re-validation once the group's real channel count is known) but scoped
+    to just `root`'s own component -- reached by a plain worklist walk
+    outward from `root` rather than a global union-find over every merge
+    node in the graph, since `root` is already known to be the group's own
+    sink (see this section's own comment on the `"add"` outcome: nothing
+    else in the group can consume `root`'s own output, since that output's
+    sole consumer was already independently confirmed, by the caller, to be
+    the `Concat`-ward hop chain this branch is being resolved for).
+
+    Returns ``None`` the same way :func:`_find_matmul_residual_chains`
+    declines a whole group: an operand fails to resolve at all, the leaf
+    producers' channel counts disagree, a bias/scale constant doesn't
+    actually match that channel count, `root` turns out not to be the
+    group's own unique sink after all (defensive -- see above for why this
+    shouldn't happen), or the same producer is named twice. On success,
+    returns ``(leaf_producers, pre_chain_ops, n_channels, backbone_tensors,
+    accounted)`` -- the first three exactly mirror what
+    :func:`_find_matmul_residual_chains` would fold into a resolved
+    :class:`_Chain`'s own `producers`/`chain_ops`/`n_channels`; the last two
+    are the group's own internal wiring (every tensor an operand walk
+    crossed, and which specific node already accounts for it), handed to
+    :func:`_resolve_matmul_fanout_branches` by the caller to confirm the
+    group has no consumer anywhere else -- `root`'s own output is
+    deliberately *not* included (unlike that finder's own explicit
+    `sink_out` handling), since the caller already knows, and separately
+    verifies, its own single accounted consumer.
+    """
+    visited: List[onnx.NodeProto] = [root]
+    visited_ids = {id(root)}
+    referenced: Set[int] = set()
+    leaf_producers: List[_Producer] = []
+    n_channels_set: Set[int] = set()
+    pre_chain_ops: List[Tuple[onnx.NodeProto, Optional[str]]] = []
+    backbone_tensors: List[str] = []
+    accounted: Dict[str, Set[int]] = {}
+
+    def _mark_backbone(tensor: str, node: onnx.NodeProto) -> None:
+        if tensor not in accounted:
+            backbone_tensors.append(tensor)
+        accounted.setdefault(tensor, set()).add(id(node))
+
+    i = 0
+    while i < len(visited):
+        merge_node = visited[i]
+        i += 1
+        match = _match_matmul_residual_merge(
+            merge_node, initializer_map, consumers_of, graph_outputs
+        )
+        if match is None:
+            return None  # defensive -- every member here was matched once already
+        operands, extra_ops = match
+        pre_chain_ops.extend(extra_ops)
+        for operand in operands:
+            _mark_backbone(operand, merge_node)
+            kind, payload, ops, edges = _walk_matmul_producer_backward(
+                operand,
+                node_by_output,
+                initializer_map,
+                consumers_of,
+                graph_outputs,
+                _MAX_CHAIN_HOPS,
+            )
+            for tensor, hop_node in edges:
+                _mark_backbone(tensor, hop_node)
+            pre_chain_ops.extend(ops)
+            if kind == "producer":
+                assert payload is not None and not isinstance(payload, onnx.NodeProto)
+                producer, n_channels = payload
+                leaf_producers.append(producer)
+                n_channels_set.add(n_channels)
+            elif kind == "add":
+                assert isinstance(payload, onnx.NodeProto)
+                referenced.add(id(payload))
+                if id(payload) not in visited_ids:
+                    visited_ids.add(id(payload))
+                    visited.append(payload)
+            else:
+                return None  # "fail" -- decline the whole group
+
+    if len(n_channels_set) != 1:
+        return None  # branches disagree on channel count -- decline
+    n_channels = next(iter(n_channels_set))
+
+    if any(
+        const_name is not None and initializer_map[const_name].dims[-1] != n_channels
+        for _, const_name in pre_chain_ops
+    ):
+        return None
+
+    sinks = [id(n) for n in visited if id(n) not in referenced]
+    if sinks != [id(root)]:
+        return None  # not a single linear chain rooted at `root` -- decline
+
+    if len({p.weight for p in leaf_producers}) != len(leaf_producers):
+        return None  # degenerate -- the same producer named twice
+
+    return (
+        tuple(leaf_producers),
+        tuple(pre_chain_ops),
+        n_channels,
+        backbone_tensors,
+        accounted,
+    )
+
+
+_ResolvedConvResidualGroup = Tuple[
+    Tuple[_Producer, ...],
+    Tuple[_ConvPassThrough, ...],
+    Tuple[onnx.NodeProto, ...],
+    int,
+    List[str],
+    Dict[str, Set[int]],
+]
+
+
+def _resolve_conv_residual_group_for_concat(
+    root: onnx.NodeProto,
+    node_by_output: Dict[str, onnx.NodeProto],
+    initializer_map: Dict[str, onnx.TensorProto],
+    graph_outputs: Set[str],
+) -> Optional[_ResolvedConvResidualGroup]:
+    """The Conv analogue of :func:`_resolve_matmul_residual_group_for_concat`
+    -- see its own docstring for the shared reasoning this mirrors exactly
+    (only the per-member walker differs: :func:`_walk_conv_producer_backward`
+    instead of :func:`_walk_matmul_producer_backward`, and there is no
+    ``SkipLayerNormalization`` analogue or per-channel bias/scale hop to
+    re-validate on the Conv side, only depthwise pass-through hops -- see
+    :func:`_find_conv_residual_chains`'s own matching re-validation). Returns
+    ``(leaf_producers, pass_through, unary_ops, n_channels, backbone_tensors,
+    accounted)`` on success.
+    """
+    visited: List[onnx.NodeProto] = [root]
+    visited_ids = {id(root)}
+    referenced: Set[int] = set()
+    leaf_producers: List[_Producer] = []
+    n_channels_set: Set[int] = set()
+    pass_through: List[_ConvPassThrough] = []
+    unary_ops: List[onnx.NodeProto] = []
+    backbone_tensors: List[str] = []
+    accounted: Dict[str, Set[int]] = {}
+
+    def _mark_backbone(tensor: str, node: onnx.NodeProto) -> None:
+        if tensor not in accounted:
+            backbone_tensors.append(tensor)
+        accounted.setdefault(tensor, set()).add(id(node))
+
+    i = 0
+    while i < len(visited):
+        add_node = visited[i]
+        i += 1
+        if not _is_eligible_add_merge(add_node, initializer_map):
+            return None  # defensive -- every member here was matched once already
+        for operand in add_node.input:
+            _mark_backbone(operand, add_node)
+            kind, payload, pt, uops, edges = _walk_conv_producer_backward(
+                operand,
+                node_by_output,
+                initializer_map,
+                graph_outputs,
+                _MAX_CHAIN_HOPS,
+            )
+            for tensor, hop_node in edges:
+                _mark_backbone(tensor, hop_node)
+            pass_through.extend(pt)
+            unary_ops.extend(uops)
+            if kind == "producer":
+                assert payload is not None and not isinstance(payload, onnx.NodeProto)
+                producer, n_channels = payload
+                leaf_producers.append(producer)
+                n_channels_set.add(n_channels)
+            elif kind == "add":
+                assert isinstance(payload, onnx.NodeProto)
+                referenced.add(id(payload))
+                if id(payload) not in visited_ids:
+                    visited_ids.add(id(payload))
+                    visited.append(payload)
+            else:
+                return None  # "fail" -- decline the whole group
+
+    if len(n_channels_set) != 1:
+        return None  # branches disagree on channel count -- decline
+    n_channels = next(iter(n_channels_set))
+
+    if any(initializer_map[hop.weight].dims[0] != n_channels for hop in pass_through):
+        return None
+
+    sinks = [id(n) for n in visited if id(n) not in referenced]
+    if sinks != [id(root)]:
+        return None  # not a single linear chain rooted at `root` -- decline
+
+    if len({p.weight for p in leaf_producers}) != len(leaf_producers):
+        return None  # degenerate -- the same producer named twice
+
+    return (
+        tuple(leaf_producers),
+        tuple(pass_through),
+        tuple(unary_ops),
+        n_channels,
+        backbone_tensors,
+        accounted,
+    )
+
+
 def _find_matmul_concat_chains(graph: onnx.GraphProto) -> List[_ConcatChain]:
     """Finds MatMul/Gemm ``Concat``-merged skip connections -- see this
     section's own comment. Every operand of a last-axis `Concat` (`axis ==
     -1`; see this section's own comment for why a positive `axis` is
     declined even when it might numerically equal the tensor's last axis)
     is resolved backward, via :func:`_walk_matmul_producer_backward` (reused
-    unchanged from the MatMul/Gemm residual section above), to a real
-    MatMul/vanilla-Gemm producer -- only a `"producer"` outcome is accepted;
-    `"add"` (the operand resolves to an eligible residual/
-    `SkipLayerNormalization` merge instead) is declined exactly like
-    `"fail"`, since composing a residual merge with a `Concat` merge on the
-    same branch isn't verified here (see this section's own comment). If
-    *any* operand fails to resolve to a real producer, or two operands
-    resolve to the very same producer weight (degenerate), the whole
-    `Concat` node is declined -- never partially pruned.
+    unchanged from the MatMul/Gemm residual section above), to either a real
+    MatMul/vanilla-Gemm producer (`"producer"`) or an eligible residual/
+    `SkipLayerNormalization` merge's whole group (`"add"`, composed via
+    :func:`_resolve_matmul_residual_group_for_concat` -- see this section's
+    own comment for exactly what composing that requires and what it
+    declines). If *any* operand fails to resolve either way, or two operands
+    (or two leaf producers of the same composed group, or a leaf producer of
+    one branch against another branch's own) name the very same producer
+    weight (degenerate), the whole `Concat` node is declined -- never
+    partially pruned.
     """
     initializer_map = {t.name: t for t in graph.initializer}
     consumers_of = _consumers_of(graph)
@@ -4147,12 +4434,60 @@ def _find_matmul_concat_chains(graph: onnx.GraphProto) -> List[_ConcatChain]:
                 graph_outputs,
                 _MAX_CHAIN_HOPS,
             )
-            if kind != "producer":
+            if kind == "fail":
                 declined = True
                 break
             if _branch_walk_has_fanout(operand, edges, consumers_of, node):
                 declined = True
                 break
+            if kind == "add":
+                assert isinstance(payload, onnx.NodeProto)
+                resolved = _resolve_matmul_residual_group_for_concat(
+                    payload,
+                    node_by_output,
+                    initializer_map,
+                    consumers_of,
+                    graph_outputs,
+                )
+                if resolved is None:
+                    declined = True
+                    break
+                producers, group_chain_ops, n_channels, backbone, accounted = resolved
+                extra = _resolve_matmul_fanout_branches(
+                    backbone,
+                    accounted,
+                    initializer_map,
+                    consumers_of,
+                    graph_outputs,
+                    n_channels,
+                )
+                # `None` (resolution itself failed) or a non-empty list (real
+                # fan-out found, resolvable or not) both decline here -- only
+                # an exactly-empty list confirms the group has no consumer
+                # anywhere else, safe to compose as this one branch's own
+                # contribution (see this section's own comment on the
+                # `"add"` outcome for why an empty result is *this*
+                # function's success case, the mirror of what its own other
+                # caller, `_find_matmul_residual_chains`, treats it as).
+                if extra is None or extra:
+                    declined = True
+                    break
+                if any(p.weight in seen_weights for p in producers):
+                    declined = True
+                    break
+                seen_weights.update(p.weight for p in producers)
+                branches.append(
+                    _ConcatBranch(
+                        producers,
+                        group_chain_ops + pre_ops,
+                        (),
+                        n_channels,
+                        offset,
+                        operand,
+                    )
+                )
+                offset += n_channels
+                continue
             assert payload is not None and not isinstance(payload, onnx.NodeProto)
             producer, n_channels = payload
             if producer.weight in seen_weights:
@@ -4160,7 +4495,7 @@ def _find_matmul_concat_chains(graph: onnx.GraphProto) -> List[_ConcatChain]:
                 break
             seen_weights.add(producer.weight)
             branches.append(
-                _ConcatBranch(producer, pre_ops, (), n_channels, offset, operand)
+                _ConcatBranch((producer,), pre_ops, (), n_channels, offset, operand)
             )
             offset += n_channels
         if declined:
@@ -4202,12 +4537,16 @@ def _find_conv_concat_chains(graph: onnx.GraphProto) -> List[_ConcatChain]:
     `[N, C, H, W]` tensor; see this section's own comment for why Conv needs
     no rank ambiguity check the MatMul/Gemm side does) is resolved backward
     via :func:`_walk_conv_producer_backward`, reused unchanged from the Conv
-    residual section above: only a `"producer"` outcome (a real `group=1`
-    Conv, reached through unary activations and/or self-consistently-
-    depthwise pass-through hops) is accepted -- `"add"` and `"fail"` are
-    both declined the same way :func:`_find_matmul_concat_chains` declines
-    `"add"`. The consumer must itself be an ordinary (`group=1`) Conv -- see
-    this section's own comment for why a grouped consumer is declined here.
+    residual section above, to either a real `group=1` Conv producer
+    (`"producer"`, reached through unary activations and/or self-
+    consistently-depthwise pass-through hops) or an eligible `Add` merge's
+    whole group (`"add"`, composed via
+    :func:`_resolve_conv_residual_group_for_concat` -- see
+    :func:`_find_matmul_concat_chains`'s own section comment for exactly
+    what composing that requires and what it declines, identical reasoning
+    on the Conv side) -- `"fail"` is declined outright either way. The
+    consumer must itself be an ordinary (`group=1`) Conv -- see this
+    section's own comment for why a grouped consumer is declined here.
     """
     initializer_map = {t.name: t for t in graph.initializer}
     consumers_of = _consumers_of(graph)
@@ -4240,12 +4579,59 @@ def _find_conv_concat_chains(graph: onnx.GraphProto) -> List[_ConcatChain]:
                     _MAX_CHAIN_HOPS,
                 )
             )
-            if kind != "producer":
+            if kind == "fail":
                 declined = True
                 break
             if _branch_walk_has_fanout(operand, edges, consumers_of, node):
                 declined = True
                 break
+            if kind == "add":
+                assert isinstance(payload, onnx.NodeProto)
+                resolved = _resolve_conv_residual_group_for_concat(
+                    payload, node_by_output, initializer_map, graph_outputs
+                )
+                if resolved is None:
+                    declined = True
+                    break
+                (
+                    producers,
+                    group_pass_through,
+                    group_unary_ops,
+                    n_channels,
+                    backbone,
+                    accounted,
+                ) = resolved
+                extra = _resolve_conv_fanout_branches(
+                    backbone,
+                    accounted,
+                    initializer_map,
+                    consumers_of,
+                    graph_outputs,
+                    n_channels,
+                )
+                # See _find_matmul_concat_chains's own matching comment --
+                # only an exactly-empty result confirms no fan-out anywhere
+                # else in the group.
+                if extra is None or extra:
+                    declined = True
+                    break
+                if any(p.weight in seen_weights for p in producers):
+                    declined = True
+                    break
+                seen_weights.update(p.weight for p in producers)
+                branches.append(
+                    _ConcatBranch(
+                        producers,
+                        tuple((op, None) for op in group_unary_ops)
+                        + tuple((op, None) for op in unary_ops),
+                        group_pass_through + pass_through,
+                        n_channels,
+                        offset,
+                        operand,
+                    )
+                )
+                offset += n_channels
+                continue
             assert payload is not None and not isinstance(payload, onnx.NodeProto)
             producer, n_channels = payload
             if producer.weight in seen_weights:
@@ -4254,7 +4640,7 @@ def _find_conv_concat_chains(graph: onnx.GraphProto) -> List[_ConcatChain]:
             seen_weights.add(producer.weight)
             branches.append(
                 _ConcatBranch(
-                    producer,
+                    (producer,),
                     tuple((op, None) for op in unary_ops),
                     pass_through,
                     n_channels,
@@ -4300,13 +4686,20 @@ def _find_conv_concat_chains(graph: onnx.GraphProto) -> List[_ConcatChain]:
     return chains
 
 
-def _plain_branch_importance(w_nk: np.ndarray) -> np.ndarray:
-    # A Concat branch is always exactly one producer, with no cross-branch
-    # combination the way a gated pair or residual group needs (see this
-    # section's own comment) -- so this is just plain per-row L2 norm,
-    # _plain_structured_importance's own single-producer case, standalone
-    # rather than routed through a _Chain.
-    return np.linalg.norm(w_nk, axis=1)
+def _plain_branch_importance(w_arrays_nk: List[np.ndarray]) -> np.ndarray:
+    # A plain Concat branch is exactly one producer -- with a single array
+    # this is just plain per-row L2 norm, _plain_structured_importance's own
+    # single-producer case, standalone rather than routed through a _Chain.
+    # A branch composed from a residual/merge group's own multiple leaf
+    # producers (see this section's own comment on the `"add"` outcome)
+    # combines every producer's own per-row norm the same root-sum-square
+    # way _plain_structured_importance already does for an ordinary
+    # multi-producer chain, since they're summed elementwise before the
+    # group's own merge point ever combines them.
+    squared_norm = np.zeros(w_arrays_nk[0].shape[0], dtype=np.float64)
+    for w_nk in w_arrays_nk:
+        squared_norm += np.square(np.linalg.norm(w_nk, axis=1))
+    return np.sqrt(squared_norm)
 
 
 def _apply_concat_chains(
@@ -4327,9 +4720,13 @@ def _apply_concat_chains(
     agreement (see this section's own comment): each branch owns its own
     disjoint, fixed-offset slice of the merged channel range, so each is
     ranked and pruned to its *own independent* `keep` set by
-    ``compute_branch_importance(operand_name, w_nk) ->
-    np.ndarray[branch.n_channels]``, and only the shared downstream consumer
-    is sliced once, by one combined index set -- the concatenation of every
+    ``compute_branch_importance(operand_name, w_arrays_nk) ->
+    np.ndarray[branch.n_channels]`` (`w_arrays_nk` one weight matrix per
+    producer in the branch -- length one for a plain branch, more than one
+    for a branch composed from a residual/merge group's own several leaf
+    producers, see this section's own comment on the `"add"` outcome), and
+    only the shared downstream consumer is sliced once, by one combined
+    index set -- the concatenation of every
     branch's own `keep`, each shifted by its own fixed `offset`. Since
     branch offsets strictly increase in `Concat` operand order and each
     branch's own `keep` is itself ascending, that concatenation is
@@ -4343,9 +4740,10 @@ def _apply_concat_chains(
     initializer_map = {t.name: t for t in graph.initializer}
 
     for chain in chains:
-        producer_weights = {b.producer.weight for b in chain.branches}
-        if len(producer_weights) != len(chain.branches):
-            continue  # degenerate -- two branches naming the same weight
+        producer_weights = {p.weight for b in chain.branches for p in b.producers}
+        n_producers = sum(len(b.producers) for b in chain.branches)
+        if len(producer_weights) != n_producers:
+            continue  # degenerate -- two producers (same or different branch) naming the same weight
 
         conv_hop_weights = {
             h.weight for b in chain.branches for h in b.conv_pass_through
@@ -4358,7 +4756,7 @@ def _apply_concat_chains(
             continue  # degenerate -- the same depthwise weight named twice
 
         consts = {
-            b.producer.bias for b in chain.branches if b.producer.bias is not None
+            p.bias for b in chain.branches for p in b.producers if p.bias is not None
         }
         consts.update(
             const_name
@@ -4387,15 +4785,17 @@ def _apply_concat_chains(
                 branch_keeps.append(np.arange(n))
                 continue
             any_pruned = True
-            w = onnx.numpy_helper.to_array(initializer_map[b.producer.weight]).astype(
-                np.float64
-            )
-            w_nk = (
-                w.reshape(w.shape[0], -1)  # [out_channels, in_channels*kH*kW]
-                if b.producer.is_conv
-                else (w if b.producer.weight_transposed else w.T)  # [N, K]
-            )
-            importance = compute_branch_importance(b.operand_name, w_nk)
+            w_arrays_nk = []
+            for p in b.producers:
+                w = onnx.numpy_helper.to_array(initializer_map[p.weight]).astype(
+                    np.float64
+                )
+                w_arrays_nk.append(
+                    w.reshape(w.shape[0], -1)  # [out_channels, in_channels*kH*kW]
+                    if p.is_conv
+                    else (w if p.weight_transposed else w.T)  # [N, K]
+                )
+            importance = compute_branch_importance(b.operand_name, w_arrays_nk)
             branch_keeps.append(np.sort(np.argsort(-importance)[:keep_count]))
 
         if not any_pruned:
@@ -4404,14 +4804,15 @@ def _apply_concat_chains(
         for b, keep in zip(chain.branches, branch_keeps):
             if len(keep) == b.n_channels:
                 continue  # this branch's own sparsity rounded to a no-op
-            _slice_producer_weight(
-                initializer_map[b.producer.weight],
-                b.producer.weight_transposed,
-                keep,
-                is_conv=b.producer.is_conv,
-            )
-            if b.producer.bias is not None:
-                _slice_last_axis(initializer_map[b.producer.bias], keep)
+            for p in b.producers:
+                _slice_producer_weight(
+                    initializer_map[p.weight],
+                    p.weight_transposed,
+                    keep,
+                    is_conv=p.is_conv,
+                )
+                if p.bias is not None:
+                    _slice_last_axis(initializer_map[p.bias], keep)
             for _, const_name in b.pre_ops:
                 if const_name is not None:
                     _slice_last_axis(initializer_map[const_name], keep)
@@ -4454,7 +4855,7 @@ def _apply_concat_chains(
         touched.conv_hop.update(conv_hop_weights)
         touched.stale_value_info.add(chain.concat_node.output[0])
         for b in chain.branches:
-            touched.stale_value_info.add(b.producer.node.output[0])
+            touched.stale_value_info.update(p.node.output[0] for p in b.producers)
             touched.stale_value_info.update(op.output[0] for op, _ in b.pre_ops)
             touched.stale_value_info.update(
                 h.node.output[0] for h in b.conv_pass_through
@@ -4990,7 +5391,7 @@ def apply_structured_pruning(
             graph,
             concat_chains,
             sparsity,
-            lambda _operand_name, w_nk: _plain_branch_importance(w_nk),
+            lambda _operand_name, w_arrays_nk: _plain_branch_importance(w_arrays_nk),
             touched,
         )
     if touched.stale_value_info:
@@ -5105,7 +5506,12 @@ def apply_structured_wanda_pruning(
     }
     for cchain in concat_chains:
         for b in cchain.branches:
-            channel_axis[b.operand_name] = 1 if b.producer.is_conv else -1
+            # Every producer of a given branch is always uniformly Conv or
+            # uniformly MatMul/Gemm (a residual/merge-group-composed branch
+            # is only ever discovered by the one walker family that finder
+            # itself uses -- see this section's own comment) -- so any one
+            # producer's own `is_conv` speaks for the whole branch.
+            channel_axis[b.operand_name] = 1 if b.producers[0].is_conv else -1
     probe_names = sorted(channel_axis)
     probe_model = _add_probe_outputs(out, probe_names)
 
@@ -5140,10 +5546,12 @@ def apply_structured_wanda_pruning(
             return base  # no matching activation observed -- fall back to |W|
         return base * np.maximum(norm, epsilon)
 
-    def _wanda_branch_importance(operand_name: str, w_nk: np.ndarray) -> np.ndarray:
-        base = _plain_branch_importance(w_nk)
+    def _wanda_branch_importance(
+        operand_name: str, w_arrays_nk: List[np.ndarray]
+    ) -> np.ndarray:
+        base = _plain_branch_importance(w_arrays_nk)
         norm = act_norm.get(operand_name)
-        if norm is None or norm.shape[0] != w_nk.shape[0]:
+        if norm is None or norm.shape[0] != base.shape[0]:
             return base  # no matching activation observed -- fall back to |W|
         return base * np.maximum(norm, epsilon)
 

--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -4454,7 +4454,11 @@ def _resolve_matmul_residual_group_for_concat(
             pre_chain_ops.extend(ops)
             if kind == "producer":
                 assert payload is not None and not isinstance(payload, onnx.NodeProto)
-                producer, n_channels = payload
+                # `producer_infos` is never passed to the walk above, so a
+                # "producer" outcome here is always the plain 2-tuple -- the
+                # 3-tuple "gated" shape (see _walk_matmul_producer_backward's
+                # own docstring) is unreachable from this call site.
+                producer, n_channels = cast(Tuple[_Producer, int], payload)
                 leaf_producers.append(producer)
                 n_channels_set.add(n_channels)
             elif kind == "add":

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -4790,6 +4790,108 @@ def test_structured_wanda_pruning_matmul_concat_protects_low_weight_high_activat
     assert 0 in _kept_columns(wanda, "W1", wb)
 
 
+def test_structured_wanda_pruning_matmul_concat_composed_residual_branch_matches_oracle():
+    # The Wanda-calibrated analogue of
+    # test_structured_pruning_matmul_concat_composes_with_residual_merge_branch_matches_oracle:
+    # confirms the composed branch's own Wanda probe point is exactly where
+    # the residual group's own combined output (`addr`) feeds the `Concat`
+    # node -- not the shared downstream consumer, and not either individual
+    # producer's own raw output -- and that the base (weight-only) term
+    # combines both leaf producers' own per-row norms via the same
+    # root-sum-square formula _plain_structured_importance already uses for
+    # an ordinary multi-producer chain, exactly as
+    # _plain_branch_importance now does for a composed branch.
+    K, C, Cb, Out = 8, 8, 6, 3
+    rng = np.random.default_rng(221)
+    wf = rng.standard_normal((K, C)).astype(np.float32)
+    ws = rng.standard_normal((K, C)).astype(np.float32)
+    wb = rng.standard_normal((K, Cb)).astype(np.float32)
+    wout = rng.standard_normal((C + Cb, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          f = MatMul(X, WF)
+          s = MatMul(X, WS)
+          addr = Add(f, s)
+          hb = MatMul(X, WB)
+          merged = Concat<axis=-1>(addr, hb)
+          Y = MatMul(merged, WOUT)
+        }}
+        """,
+        initializer=[
+            _f32(wf, "WF"),
+            _f32(ws, "WS"),
+            _f32(wb, "WB"),
+            _f32(wout, "WOUT"),
+        ],
+    )
+
+    probe_model = onnx.ModelProto()
+    probe_model.CopyFrom(model)
+    probe_model.graph.output.append(
+        onnx.helper.make_tensor_value_info("addr", onnx.TensorProto.FLOAT, None)
+    )
+    probe_model.graph.output.append(
+        onnx.helper.make_tensor_value_info("hb", onnx.TensorProto.FLOAT, None)
+    )
+
+    rng_cal = np.random.default_rng(222)
+    x_cal = rng_cal.standard_normal((16, K)).astype(np.float32)
+    calibration_data = [{"X": x_cal}]
+    _, addr_cal, hb_cal = _run(probe_model, {"X": x_cal})
+    norm_r = np.sqrt(np.mean(np.square(addr_cal.astype(np.float64)), axis=0))
+    norm_b = np.sqrt(np.mean(np.square(hb_cal.astype(np.float64)), axis=0))
+
+    pruned = onnxsim.apply_structured_wanda_pruning(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned)
+
+    base_r = np.sqrt(
+        np.square(np.linalg.norm(wf.astype(np.float64), axis=0))
+        + np.square(np.linalg.norm(ws.astype(np.float64), axis=0))
+    )
+    importance_r = base_r * np.maximum(norm_r, 1e-8)
+    importance_b = np.linalg.norm(wb.astype(np.float64), axis=0) * np.maximum(
+        norm_b, 1e-8
+    )
+    keep_r = np.sort(np.argsort(-importance_r)[: C // 2])
+    keep_b = np.sort(np.argsort(-importance_b)[: Cb // 2])
+    global_keep = np.concatenate([keep_r, keep_b + C])
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["WF"], wf[:, keep_r])
+    np.testing.assert_array_equal(inits["WS"], ws[:, keep_r])
+    np.testing.assert_array_equal(inits["WB"], wb[:, keep_b])
+    np.testing.assert_array_equal(inits["WOUT"], wout[global_keep, :])
+
+    oracle = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          f = MatMul(X, WF)
+          s = MatMul(X, WS)
+          addr = Add(f, s)
+          hb = MatMul(X, WB)
+          merged = Concat<axis=-1>(addr, hb)
+          Y = MatMul(merged, WOUT)
+        }}
+        """,
+        initializer=[
+            _f32(wf[:, keep_r], "WF"),
+            _f32(ws[:, keep_r], "WS"),
+            _f32(wb[:, keep_b], "WB"),
+            _f32(wout[global_keep, :], "WOUT"),
+        ],
+    )
+    rng_x = np.random.default_rng(223)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
 def test_structured_pruning_matmul_concat_declines_on_positive_axis():
     # `axis=1` on a 2-D [batch, C] tensor is numerically the same as
     # `axis=-1`, but this pass never looks up a tensor's rank (see this
@@ -4868,18 +4970,27 @@ def test_structured_pruning_matmul_concat_declines_on_graph_input_branch():
     np.testing.assert_array_equal(inits["WOUT"], wout)
 
 
-def test_structured_pruning_matmul_concat_declines_on_residual_merge_branch():
+def test_structured_pruning_matmul_concat_composes_with_residual_merge_branch_matches_oracle():
     # One Concat operand is itself an eligible Add-residual merge point's
-    # raw output -- composing a residual merge with a Concat merge on the
-    # same branch isn't verified (see this section's own comment): the
-    # backward walk's "add" outcome is declined exactly like "fail", so the
-    # whole group -- both the residual pair and the plain second branch --
-    # is left untouched.
-    K, C, Cb, Out = 8, 6, 4, 3
+    # raw output, with no consumer anywhere else -- composed, not declined
+    # (see this section's own comment on the `"add"` outcome): the merge's
+    # own whole group (WF, WS) is resolved exactly as
+    # _find_matmul_residual_chains would resolve it standalone, and the
+    # group's own combined-importance keep set becomes this one branch's
+    # own contribution, independent of the plain second branch (WB).
+    # Deliberately adversarial on both axes at once: WF/WS individually
+    # disagree about which half of the columns matter most (so only their
+    # *combined* norm, not either producer's own, can be driving the
+    # residual branch's keep set), and WB is scaled 10x larger so a bug that
+    # (wrongly) mixed the two Concat branches' importances into one ranking
+    # would starve WB's own columns entirely.
+    K, C, Cb, Out = 8, 16, 6, 3
     rng = np.random.default_rng(213)
-    wf = rng.standard_normal((K, C)).astype(np.float32)
-    ws = rng.standard_normal((K, C)).astype(np.float32)
-    wb = rng.standard_normal((K, Cb)).astype(np.float32)
+    scale_f = np.where(np.arange(C) < C // 2, 3.0, 0.3).astype(np.float32)
+    scale_s = np.where(np.arange(C) < C // 2, 0.3, 3.0).astype(np.float32)
+    wf = rng.standard_normal((K, C)).astype(np.float32) * scale_f
+    ws = rng.standard_normal((K, C)).astype(np.float32) * scale_s
+    wb = rng.standard_normal((K, Cb)).astype(np.float32) * 10.0
     wout = rng.standard_normal((C + Cb, Out)).astype(np.float32)
     model = _model(
         f"""
@@ -4901,10 +5012,231 @@ def test_structured_pruning_matmul_concat_declines_on_residual_merge_branch():
         ],
     )
     pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    importance_r = np.sqrt(
+        np.square(np.linalg.norm(wf.astype(np.float64), axis=0))
+        + np.square(np.linalg.norm(ws.astype(np.float64), axis=0))
+    )
+    keep_r = np.sort(np.argsort(-importance_r)[: C // 2])
+    # The conflicting-importance construction above is only doing its job
+    # if the combined keep set actually straddles both halves.
+    assert np.any(keep_r < C // 2) and np.any(keep_r >= C // 2)
+    importance_b = np.linalg.norm(wb.astype(np.float64), axis=0)
+    keep_b = np.sort(np.argsort(-importance_b)[: Cb // 2])
+    assert len(keep_b) == Cb // 2  # branch b kept its own top half, not starved to 0
+    global_keep = np.concatenate([keep_r, keep_b + C])
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["WF"], wf[:, keep_r])
+    np.testing.assert_array_equal(inits["WS"], ws[:, keep_r])
+    np.testing.assert_array_equal(inits["WB"], wb[:, keep_b])
+    np.testing.assert_array_equal(inits["WOUT"], wout[global_keep, :])
+
+    oracle = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          f = MatMul(X, WF)
+          s = MatMul(X, WS)
+          addr = Add(f, s)
+          hb = MatMul(X, WB)
+          merged = Concat<axis=-1>(addr, hb)
+          Y = MatMul(merged, WOUT)
+        }}
+        """,
+        initializer=[
+            _f32(wf[:, keep_r], "WF"),
+            _f32(ws[:, keep_r], "WS"),
+            _f32(wb[:, keep_b], "WB"),
+            _f32(wout[global_keep, :], "WOUT"),
+        ],
+    )
+    rng_x = np.random.default_rng(214)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_matmul_concat_composes_with_skip_layer_norm_branch_matches_oracle():
+    # The composed branch's own merge point can be a fused
+    # `SkipLayerNormalization` node, not just a bare `Add` -- its own
+    # `gamma`/`beta` constants are folded into the composed branch's own
+    # `pre_ops` (via `_match_matmul_residual_merge`'s own `extra_ops`,
+    # reused unchanged inside `_resolve_matmul_residual_group_for_concat`)
+    # and sliced by the branch's own local `keep`, exactly as they would be
+    # for a standalone SkipLayerNormalization residual chain.
+    K, C, Cb, Out = 8, 16, 6, 3
+    rng, wf, ws = _conflicting_wf_ws(224, K, C)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    beta = rng.standard_normal((C,)).astype(np.float32)
+    wb = rng.standard_normal((K, Cb)).astype(np.float32) * 10.0
+    wout = rng.standard_normal((C + Cb, Out)).astype(np.float32)
+
+    def _build(wf_, ws_, gamma_, beta_, wb_, wout_):
+        m = _model(
+            f"""
+            g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+            {{
+              f = MatMul(X, WF)
+              s = MatMul(X, WS)
+              addr = com.microsoft.SkipLayerNormalization <epsilon=1e-5> (f, s, Gamma, Beta)
+              hb = MatMul(X, WB)
+              merged = Concat<axis=-1>(addr, hb)
+              Y = MatMul(merged, WOUT)
+            }}
+            """,
+            initializer=[
+                _f32(wf_, "WF"),
+                _f32(ws_, "WS"),
+                _f32(gamma_, "Gamma"),
+                _f32(beta_, "Beta"),
+                _f32(wb_, "WB"),
+                _f32(wout_, "WOUT"),
+            ],
+            opset=17,
+        )
+        m.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+        return m
+
+    model = _build(wf, ws, gamma, beta, wb, wout)
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep_r = _skip_layer_norm_keep(wf, ws, C)
+    importance_b = np.linalg.norm(wb.astype(np.float64), axis=0)
+    keep_b = np.sort(np.argsort(-importance_b)[: Cb // 2])
+    assert len(keep_b) == Cb // 2
+    global_keep = np.concatenate([keep_r, keep_b + C])
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["WF"], wf[:, keep_r])
+    np.testing.assert_array_equal(inits["WS"], ws[:, keep_r])
+    np.testing.assert_array_equal(inits["Gamma"], gamma[keep_r])
+    np.testing.assert_array_equal(inits["Beta"], beta[keep_r])
+    np.testing.assert_array_equal(inits["WB"], wb[:, keep_b])
+    np.testing.assert_array_equal(inits["WOUT"], wout[global_keep, :])
+
+    oracle = _build(
+        wf[:, keep_r],
+        ws[:, keep_r],
+        gamma[keep_r],
+        beta[keep_r],
+        wb[:, keep_b],
+        wout[global_keep, :],
+    )
+    rng_x = np.random.default_rng(225)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_structured_pruning_matmul_concat_declines_on_residual_merge_branch_direct_fan_out():
+    # Same shape as the composed test above, except `addr` (the residual
+    # group's own sink, and the tensor directly feeding the `Concat`
+    # operand) also feeds a second, ordinary consumer (`Z`) -- caught by the
+    # same `_branch_walk_has_fanout` check an ordinary (non-composed) branch
+    # is already held to: `addr`'s own consumer count is 2, not 1, so the
+    # `"add"` outcome is declined before group resolution is even
+    # attempted. Real fan-out this composition deliberately doesn't try to
+    # reconcile with the `Concat` branch's own fixed-offset slice (see this
+    # section's own comment on the `"add"` outcome): the whole `Concat`
+    # group is declined, exactly as if the branch had failed to resolve at
+    # all, so nothing here is touched -- not the residual pair, the plain
+    # second branch, or `Z`'s own consumer.
+    K, C, Cb, Cz, Out = 8, 6, 4, 3, 3
+    rng = np.random.default_rng(215)
+    wf = rng.standard_normal((K, C)).astype(np.float32)
+    ws = rng.standard_normal((K, C)).astype(np.float32)
+    wb = rng.standard_normal((K, Cb)).astype(np.float32)
+    wz = rng.standard_normal((C, Cz)).astype(np.float32)
+    wout = rng.standard_normal((C + Cb, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y, float[batch,{Cz}] Z)
+        {{
+          f = MatMul(X, WF)
+          s = MatMul(X, WS)
+          addr = Add(f, s)
+          hb = MatMul(X, WB)
+          merged = Concat<axis=-1>(addr, hb)
+          Y = MatMul(merged, WOUT)
+          Z = MatMul(addr, WZ)
+        }}
+        """,
+        initializer=[
+            _f32(wf, "WF"),
+            _f32(ws, "WS"),
+            _f32(wb, "WB"),
+            _f32(wz, "WZ"),
+            _f32(wout, "WOUT"),
+        ],
+    )
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
     inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
     np.testing.assert_array_equal(inits["WF"], wf)
     np.testing.assert_array_equal(inits["WS"], ws)
     np.testing.assert_array_equal(inits["WB"], wb)
+    np.testing.assert_array_equal(inits["WZ"], wz)
+    np.testing.assert_array_equal(inits["WOUT"], wout)
+
+
+def test_structured_pruning_matmul_concat_declines_on_residual_merge_group_interior_fan_out():
+    # A three-producer transitive group -- addr1 = Add(f, s), addr2 =
+    # Add(addr1, t) -- whose *sink* (`addr2`) feeds the `Concat` cleanly
+    # (its own only consumer), but whose *interior* tensor `addr1` also
+    # feeds a second, ordinary consumer (`Z`) elsewhere. `addr2`'s own
+    # direct walk to the `Concat` operand sees no fan-out at all (only
+    # `addr1`, an entirely different tensor, is over-read) -- so this
+    # exercises the deeper check, once the whole group is resolved:
+    # `_resolve_matmul_fanout_branches` finds `Z` as a real, resolvable
+    # extra consumer of the group's own internal wiring, and this
+    # composition declines rather than trying to reconcile a `Concat`
+    # branch's own fixed-offset slice with an ordinary chain sharing the
+    # same weights. The whole `Concat` group is declined -- nothing here is
+    # touched, not the three-producer group, the plain second branch, or
+    # `Z`'s own consumer.
+    K, C, Cb, Cz, Out = 8, 6, 4, 3, 3
+    rng = np.random.default_rng(216)
+    wf = rng.standard_normal((K, C)).astype(np.float32)
+    ws = rng.standard_normal((K, C)).astype(np.float32)
+    wt = rng.standard_normal((K, C)).astype(np.float32)
+    wb = rng.standard_normal((K, Cb)).astype(np.float32)
+    wz = rng.standard_normal((C, Cz)).astype(np.float32)
+    wout = rng.standard_normal((C + Cb, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y, float[batch,{Cz}] Z)
+        {{
+          f = MatMul(X, WF)
+          s = MatMul(X, WS)
+          addr1 = Add(f, s)
+          t = MatMul(X, WT)
+          addr2 = Add(addr1, t)
+          hb = MatMul(X, WB)
+          merged = Concat<axis=-1>(addr2, hb)
+          Y = MatMul(merged, WOUT)
+          Z = MatMul(addr1, WZ)
+        }}
+        """,
+        initializer=[
+            _f32(wf, "WF"),
+            _f32(ws, "WS"),
+            _f32(wt, "WT"),
+            _f32(wb, "WB"),
+            _f32(wz, "WZ"),
+            _f32(wout, "WOUT"),
+        ],
+    )
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["WF"], wf)
+    np.testing.assert_array_equal(inits["WS"], ws)
+    np.testing.assert_array_equal(inits["WT"], wt)
+    np.testing.assert_array_equal(inits["WB"], wb)
+    np.testing.assert_array_equal(inits["WZ"], wz)
     np.testing.assert_array_equal(inits["WOUT"], wout)
 
 
@@ -5106,6 +5438,95 @@ def test_structured_wanda_pruning_conv_concat_matches_oracle():
     oracle = _conv_concat_model([wa[keep_a], wb[keep_b]], wout[:, global_keep])
 
     rng_x = np.random.default_rng(222)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_conv_concat_composes_with_residual_merge_branch_matches_oracle():
+    # The Conv analogue of
+    # test_structured_pruning_matmul_concat_composes_with_residual_merge_branch_matches_oracle:
+    # one Concat branch (`addr = Add(Conv_f(X), Conv_s(X))`) is itself a
+    # residual-merge group with no consumer anywhere else, composed via
+    # _resolve_conv_residual_group_for_concat exactly as
+    # _find_conv_residual_chains would resolve it standalone; the other
+    # branch (`hb`) is plain and ranked entirely independently. Same double
+    # adversarial construction: WF/WS individually disagree about which
+    # half of the *filters* matter most (so only the group's own combined
+    # importance can be driving its keep set), and WB is scaled 10x larger
+    # (so a bug mixing the two Concat branches' importances would starve
+    # WB's own filters).
+    Cin, C, Cb, Cout = 3, 16, 6, 5
+    rng = np.random.default_rng(219)
+    scale_f = (
+        np.where(np.arange(C) < C // 2, 3.0, 0.3).astype(np.float32).reshape(C, 1, 1, 1)
+    )
+    scale_s = (
+        np.where(np.arange(C) < C // 2, 0.3, 3.0).astype(np.float32).reshape(C, 1, 1, 1)
+    )
+    wf = rng.standard_normal((C, Cin, 3, 3)).astype(np.float32) * scale_f
+    ws = rng.standard_normal((C, Cin, 3, 3)).astype(np.float32) * scale_s
+    wb = rng.standard_normal((Cb, Cin, 3, 3)).astype(np.float32) * 10.0
+    wout = rng.standard_normal((Cout, C + Cb, 3, 3)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{Cout},6,6] Y)
+        {{
+          f = Conv<kernel_shape=[3,3]>(X, WF)
+          s = Conv<kernel_shape=[3,3]>(X, WS)
+          addr = Add(f, s)
+          hb = Conv<kernel_shape=[3,3]>(X, WB)
+          merged = Concat<axis=1>(addr, hb)
+          Y = Conv<kernel_shape=[3,3]>(merged, WOUT)
+        }}
+        """,
+        initializer=[
+            _f32(wf, "WF"),
+            _f32(ws, "WS"),
+            _f32(wb, "WB"),
+            _f32(wout, "WOUT"),
+        ],
+    )
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    importance_r = np.sqrt(
+        np.square(np.linalg.norm(wf.reshape(C, -1).astype(np.float64), axis=1))
+        + np.square(np.linalg.norm(ws.reshape(C, -1).astype(np.float64), axis=1))
+    )
+    keep_r = np.sort(np.argsort(-importance_r)[: C // 2])
+    assert np.any(keep_r < C // 2) and np.any(keep_r >= C // 2)
+    keep_b = _oracle_keep_indices_conv(wb, Cb // 2)
+    assert len(keep_b) == Cb // 2
+    global_keep = np.concatenate([keep_r, keep_b + C])
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["WF"], wf[keep_r])
+    np.testing.assert_array_equal(inits["WS"], ws[keep_r])
+    np.testing.assert_array_equal(inits["WB"], wb[keep_b])
+    np.testing.assert_array_equal(inits["WOUT"], wout[:, global_keep])
+
+    oracle = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{Cout},6,6] Y)
+        {{
+          f = Conv<kernel_shape=[3,3]>(X, WF)
+          s = Conv<kernel_shape=[3,3]>(X, WS)
+          addr = Add(f, s)
+          hb = Conv<kernel_shape=[3,3]>(X, WB)
+          merged = Concat<axis=1>(addr, hb)
+          Y = Conv<kernel_shape=[3,3]>(merged, WOUT)
+        }}
+        """,
+        initializer=[
+            _f32(wf[keep_r], "WF"),
+            _f32(ws[keep_r], "WS"),
+            _f32(wb[keep_b], "WB"),
+            _f32(wout[:, global_keep], "WOUT"),
+        ],
+    )
+    rng_x = np.random.default_rng(220)
     x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
     (y,) = _run(pruned, {"X": x})
     (y_oracle,) = _run(oracle, {"X": x})


### PR DESCRIPTION
## Summary
- `Concat`-merged skip-connection pruning previously declined outright whenever a branch resolved backward to an eligible `Add`/`SkipLayerNormalization` residual merge instead of a real producer — documented as "isn't verified here" rather than "is unsafe."
- Investigated what composing the two would actually require: the merge's own whole transitively-connected group needs full resolution (same union-find-style walk the standalone residual finder already does), and — critically — the group must have **no consumer anywhere else at all**, since a `Concat` branch's fixed-offset slice semantics can't be reconciled with an ordinary chain's shared, un-offset `keep` set if the group is feeding two different things at once.
- Found this composition is safe and mechanically resolvable in exactly that bounded case. Implemented `_resolve_matmul_residual_group_for_concat`/`_resolve_conv_residual_group_for_concat` — self-contained group-resolution helpers scoped to one merge node's own component (deliberately not touching the existing, tested global-union-find residual finders) — then reused the *existing, unmodified* `_resolve_matmul_fanout_branches`/`_resolve_conv_fanout_branches` fan-out resolver as the safety check: an *empty* result (no un-accounted consumer anywhere in the group) is this composition's success case, the exact mirror of what that function's other existing caller treats as "no consumer, decline." Any real fan-out — resolvable or not — still declines the whole `Concat` group.
- `_ConcatBranch.producer: _Producer` generalized to `producers: Tuple[_Producer, ...]` (length 1 for a plain branch, more for a branch composed from a residual group's several leaf producers), with `_apply_concat_chains` and `_plain_branch_importance` updated to combine multiple producers by root-sum-square importance — the same metric `_plain_structured_importance` already uses for an ordinary multi-producer chain. Cross-branch and cross-producer degenerate-weight checks were generalized accordingly. Both `apply_structured_pruning` and `apply_structured_wanda_pruning` pick this up automatically.
- Verified with a deliberately adversarial fresh model: the residual group's two producers individually disagree about which half of the channels matter most (so only their *combined* norm can be driving the branch's keep set), composed with an independent second `Concat` branch scaled 10x larger (to catch a bug that mixed the two branches' importances together and starved one). Confirmed exact tensor equality against a hand-derived keep set and exact onnxruntime output match. Added Conv, `SkipLayerNormalization`, and Wanda-calibrated analogues, plus two new decline tests proving the fan-out boundary (direct operand fan-out, and fan-out interior to a transitive multi-merge group) is still correctly declined.

## Test plan
- [x] `pytest tests/test_pruning.py -q` — 189 passed
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — same 3 pre-existing, unrelated errors as `master`; no new ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_