### PR TITLE
Complete C++ port of structured pruning and add attention-head pruning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,7 @@ set(ONNXSIM_BLAKE3_COMPILE_DEFS
     BLAKE3_NO_SSE2 BLAKE3_NO_SSE41 BLAKE3_NO_AVX2 BLAKE3_NO_AVX512
     BLAKE3_USE_NEON=0)
 
-add_library(onnxsim onnxsim/onnxsim.cpp onnxsim/constant_folding.cpp onnxsim/partial_shape_eval.cpp onnxsim/model_prep.cpp onnxsim/quantize_entry.cpp onnxsim/cross_layer_equalization_entry.cpp onnxsim/pruning_entry.cpp onnxsim/contrib_schemas.cpp onnxsim/custom_optimizer_passes.cpp onnxsim/function_rewriter.cpp onnxsim/profiler.cpp onnxsim/model_info.cpp onnxsim/sym_expr.cpp onnxsim/sym_value_eval.cpp onnxsim/sym_shape_infer.cpp onnxsim/model_metrics.cpp onnxsim/precision_estimator.cpp onnxsim/tensor_pool.cpp onnxsim/tensor_pool_gguf.cpp onnxsim/tensor_pool_hash.cpp onnxsim/gemm_fusion_backend.cpp ${ONNXSIM_BLAKE3_SOURCES})
+add_library(onnxsim onnxsim/onnxsim.cpp onnxsim/constant_folding.cpp onnxsim/partial_shape_eval.cpp onnxsim/model_prep.cpp onnxsim/quantize_entry.cpp onnxsim/cross_layer_equalization_entry.cpp onnxsim/pruning_entry.cpp onnxsim/structured_pruning_entry.cpp onnxsim/contrib_schemas.cpp onnxsim/custom_optimizer_passes.cpp onnxsim/function_rewriter.cpp onnxsim/profiler.cpp onnxsim/model_info.cpp onnxsim/sym_expr.cpp onnxsim/sym_value_eval.cpp onnxsim/sym_shape_infer.cpp onnxsim/model_metrics.cpp onnxsim/precision_estimator.cpp onnxsim/tensor_pool.cpp onnxsim/tensor_pool_gguf.cpp onnxsim/tensor_pool_hash.cpp onnxsim/gemm_fusion_backend.cpp ${ONNXSIM_BLAKE3_SOURCES})
 target_compile_definitions(onnxsim PRIVATE ${ONNXSIM_BLAKE3_COMPILE_DEFS})
 if (ONNXSIM_BUILTIN_ORT)
   # Both ways of obtaining ONNX Runtime ship/install headers flat under this

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -52,6 +52,7 @@ from onnxsim.omniquant import apply_omniquant
 from onnxsim.onnx_simplifier import (
     apply_double_quantization_cpp,
     apply_quarot_cpp,
+    apply_structured_pruning_cpp,
     cross_layer_equalize,
     export_gguf,
     export_safetensors,
@@ -142,6 +143,7 @@ __all__ = [
     "apply_wanda_pruning",
     "apply_sparsegpt_pruning",
     "apply_structured_pruning",
+    "apply_structured_pruning_cpp",
     "apply_structured_wanda_pruning",
     "apply_attention_head_pruning",
     "apply_attention_head_wanda_pruning",

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -50,6 +50,7 @@ from onnxsim.mx_quantization import MXFP4_CODEBOOK, quantize_weight_only_mxfp4
 from onnxsim.nf4 import NF4_CODEBOOK, quantize_weight_only_nf4
 from onnxsim.omniquant import apply_omniquant
 from onnxsim.onnx_simplifier import (
+    apply_attention_head_pruning_cpp,
     apply_double_quantization_cpp,
     apply_quarot_cpp,
     apply_structured_pruning_cpp,
@@ -146,6 +147,7 @@ __all__ = [
     "apply_structured_pruning_cpp",
     "apply_structured_wanda_pruning",
     "apply_attention_head_pruning",
+    "apply_attention_head_pruning_cpp",
     "apply_attention_head_wanda_pruning",
     "weight_sparsity",
     "convert_matmul_to_gemm",

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -606,6 +606,23 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
       },
       "model_bytes"_a, "sparsity"_a);
 
+  // Attention-head pruning: removes whole attention heads (or, for
+  // grouped-query attention, whole KV groups) from every matched fused
+  // self-attention block. See ApplyAttentionHeadPruning in onnxsim.h.
+  m.def(
+      "apply_attention_head_pruning",
+      [](const py::bytes& model_proto_bytes, double sparsity) -> py::bytes {
+        InitEnv();
+        ONNX_NAMESPACE::ModelProto model;
+        ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
+                            model_proto_bytes.size());
+        const auto result = ApplyAttentionHeadPruning(model, sparsity);
+        std::string out;
+        result.SerializeToString(&out);
+        return py::bytes(out.data(), out.size());
+      },
+      "model_bytes"_a, "sparsity"_a);
+
   // QuaRot (Ashkboos et al., 2024): rotation preprocessing plus INT4
   // round-to-nearest quantization of both the weight and the activation of
   // every MatMul/vanilla-Gemm layer. Data-free. See ApplyQuarot in

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -589,6 +589,23 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
       },
       "model_bytes"_a, "sparsity"_a);
 
+  // Structured (channel) pruning: removes whole output channels from
+  // MatMul/vanilla-Gemm and Conv layers -- real structural pruning, not
+  // just value-only zeroing. See ApplyStructuredPruning in onnxsim.h.
+  m.def(
+      "apply_structured_pruning",
+      [](const py::bytes& model_proto_bytes, double sparsity) -> py::bytes {
+        InitEnv();
+        ONNX_NAMESPACE::ModelProto model;
+        ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
+                            model_proto_bytes.size());
+        const auto result = ApplyStructuredPruning(model, sparsity);
+        std::string out;
+        result.SerializeToString(&out);
+        return py::bytes(out.data(), out.size());
+      },
+      "model_bytes"_a, "sparsity"_a);
+
   // QuaRot (Ashkboos et al., 2024): rotation preprocessing plus INT4
   // round-to-nearest quantization of both the weight and the activation of
   // every MatMul/vanilla-Gemm layer. Data-free. See ApplyQuarot in

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -1078,6 +1078,58 @@ def prune_magnitude_cpp(
     return onnx.load_from_string(C.prune_magnitude(model.SerializeToString(), sparsity))
 
 
+def apply_structured_pruning_cpp(
+    model: Union[str, onnx.ModelProto],
+    sparsity: float = 0.5,
+) -> onnx.ModelProto:
+    """
+    C++-backed port of :func:`onnxsim.apply_structured_pruning`: removes
+    whole output channels from MatMul/vanilla-Gemm and Conv layers -- real
+    structural pruning (smaller weight tensors, smaller matmuls on any
+    runtime), as opposed to :func:`onnxsim.prune_magnitude_cpp`'s value-only
+    zeroing.
+
+    For every MatMul/vanilla-Gemm or 2-D Conv "producer" node whose output
+    feeds, through zero or more shape-preserving elementwise ops (an
+    activation, or -- MatMul/Gemm only -- an Add/Mul against a constant
+    per-channel bias/scale, or -- Conv only -- a depthwise Conv hop) with no
+    other consumer anywhere along that path, into exactly one downstream
+    "consumer" of the same family: ranks the producer's output channels by
+    L2 norm of their own weight row/filter, drops the lowest-``sparsity``-
+    fraction of them, and removes the corresponding rows/columns from the
+    producer's weight (and bias, if constant) and every intermediate
+    per-channel constant, and the matching columns/rows from the consumer's
+    weight. A general grouped Conv (neither ``group=1`` nor fully depthwise)
+    is matched too, as a producer and/or consumer, ranking/pruning each of
+    its ``group`` channel blocks independently.
+
+    Unlike the pure-Python :func:`onnxsim.apply_structured_pruning`, this
+    port does not (yet) include the gated-FFN (SwiGLU/GeGLU) pattern or the
+    Conv/MatMul residual-connection (skip-connection) chain support -- a
+    model whose only prunable structure is one of those unported shapes is
+    left completely untouched by this port; :func:`onnxsim.apply_structured_pruning`
+    remains the full-featured reference.
+
+    This is a single, self-contained graph rewrite: unlike :func:`simplify`,
+    it does not run shape inference, constant folding, or any other pass.
+
+    :param model: the original onnx ModelProto or file path
+    :param sparsity: target fraction of each matched producer's output
+            channels to remove (at least one channel is always kept); must
+            be in ``[0, 1)``
+    :returns: ``model`` with every matched chain's tensors resized in place;
+            anything not matching the exact topology above (branching, a
+            non-constant bias, a consumer whose reduction dimension doesn't
+            line up, a gated or residual chain, ...) is left completely
+            untouched
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    return onnx.load_from_string(
+        C.apply_structured_pruning(model.SerializeToString(), sparsity)
+    )
+
+
 def apply_quarot_cpp(
     model: Union[str, onnx.ModelProto],
     seed: int = 0,

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -1101,14 +1101,17 @@ def apply_structured_pruning_cpp(
     per-channel constant, and the matching columns/rows from the consumer's
     weight. A general grouped Conv (neither ``group=1`` nor fully depthwise)
     is matched too, as a producer and/or consumer, ranking/pruning each of
-    its ``group`` channel blocks independently.
+    its ``group`` channel blocks independently. The gated-FFN SwiGLU/GeGLU
+    pattern is matched too -- two producers combined by a ``Mul`` (or ONNX
+    opset-28+'s native ``SwiGLU`` node) feeding one consumer, both pruned to
+    the same combined-importance-ranked channel indices.
 
     Unlike the pure-Python :func:`onnxsim.apply_structured_pruning`, this
-    port does not (yet) include the gated-FFN (SwiGLU/GeGLU) pattern or the
-    Conv/MatMul residual-connection (skip-connection) chain support -- a
-    model whose only prunable structure is one of those unported shapes is
-    left completely untouched by this port; :func:`onnxsim.apply_structured_pruning`
-    remains the full-featured reference.
+    port does not (yet) include the Conv/MatMul residual-connection
+    (skip-connection) chain support -- a model whose only prunable structure
+    is one of those unported shapes is left completely untouched by this
+    port; :func:`onnxsim.apply_structured_pruning` remains the full-featured
+    reference.
 
     This is a single, self-contained graph rewrite: unlike :func:`simplify`,
     it does not run shape inference, constant folding, or any other pass.

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -1104,14 +1104,27 @@ def apply_structured_pruning_cpp(
     its ``group`` channel blocks independently. The gated-FFN SwiGLU/GeGLU
     pattern is matched too -- two producers combined by a ``Mul`` (or ONNX
     opset-28+'s native ``SwiGLU`` node) feeding one consumer, both pruned to
-    the same combined-importance-ranked channel indices.
+    the same combined-importance-ranked channel indices. A Conv or
+    MatMul/Gemm residual (skip-connection) chain is matched too -- a
+    channel-preserving ``Add(a, b)`` where both operands are non-constant
+    forces whichever real producer(s) feed ``a``/``b`` to agree on one
+    shared channel-index set, resolved via a backward walk plus union-find
+    grouping across such merge points that also covers a whole chain of
+    such merges transitively sharing one spine channel count (a lone
+    residual connection, or a linear stack of ``Add``-only merges; an
+    *interior* block of a real deep ResNet/transformer stage is left
+    completely untouched, the same "no branch-following" boundary every
+    other chain kind here already holds).
 
     Unlike the pure-Python :func:`onnxsim.apply_structured_pruning`, this
-    port does not (yet) include the Conv/MatMul residual-connection
-    (skip-connection) chain support -- a model whose only prunable structure
-    is one of those unported shapes is left completely untouched by this
-    port; :func:`onnxsim.apply_structured_pruning` remains the full-featured
-    reference.
+    port does not (yet) recognize a fused
+    ``com.microsoft::SkipLayerNormalization``/``SkipSimplifiedLayerNormalization``
+    node -- what onnxruntime's transformer optimizer collapses a bare
+    residual ``Add`` plus the following LayerNorm into -- as an eligible
+    merge point; a model whose residual connections have already been fused
+    that way is left untouched by this port's MatMul residual finder --
+    :func:`onnxsim.apply_structured_pruning` remains the full-featured
+    reference for that case.
 
     This is a single, self-contained graph rewrite: unlike :func:`simplify`,
     it does not run shape inference, constant folding, or any other pass.
@@ -1123,8 +1136,8 @@ def apply_structured_pruning_cpp(
     :returns: ``model`` with every matched chain's tensors resized in place;
             anything not matching the exact topology above (branching, a
             non-constant bias, a consumer whose reduction dimension doesn't
-            line up, a gated or residual chain, ...) is left completely
-            untouched
+            line up, a fused-SkipLayerNormalization residual, ...) is left
+            completely untouched
     """
     if isinstance(model, str):
         model = onnx.load(model, load_external_data=False)

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -1114,17 +1114,16 @@ def apply_structured_pruning_cpp(
     residual connection, or a linear stack of ``Add``-only merges; an
     *interior* block of a real deep ResNet/transformer stage is left
     completely untouched, the same "no branch-following" boundary every
-    other chain kind here already holds).
-
-    Unlike the pure-Python :func:`onnxsim.apply_structured_pruning`, this
-    port does not (yet) recognize a fused
+    other chain kind here already holds). For MatMul/Gemm specifically, a
+    fused
     ``com.microsoft::SkipLayerNormalization``/``SkipSimplifiedLayerNormalization``
     node -- what onnxruntime's transformer optimizer collapses a bare
-    residual ``Add`` plus the following LayerNorm into -- as an eligible
-    merge point; a model whose residual connections have already been fused
-    that way is left untouched by this port's MatMul residual finder --
-    :func:`onnxsim.apply_structured_pruning` remains the full-featured
-    reference for that case.
+    residual ``Add`` plus the following LayerNorm into, and so what a
+    fully-optimized transformer's own residual connections typically look
+    like -- is recognized as an eligible merge point too, its own
+    ``gamma``/``beta``/``bias`` constants riding along as a per-channel
+    affine hop on the resolved chain; a Conv residual chain only ever sees a
+    bare ``Add`` (there is no Conv analogue of that fused op).
 
     This is a single, self-contained graph rewrite: unlike :func:`simplify`,
     it does not run shape inference, constant folding, or any other pass.
@@ -1136,8 +1135,7 @@ def apply_structured_pruning_cpp(
     :returns: ``model`` with every matched chain's tensors resized in place;
             anything not matching the exact topology above (branching, a
             non-constant bias, a consumer whose reduction dimension doesn't
-            line up, a fused-SkipLayerNormalization residual, ...) is left
-            completely untouched
+            line up, ...) is left completely untouched
     """
     if isinstance(model, str):
         model = onnx.load(model, load_external_data=False)

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -1144,6 +1144,73 @@ def apply_structured_pruning_cpp(
     )
 
 
+def apply_attention_head_pruning_cpp(
+    model: Union[str, onnx.ModelProto],
+    sparsity: float = 0.5,
+) -> onnx.ModelProto:
+    """
+    C++-backed port of :func:`onnxsim.apply_attention_head_pruning`: removes
+    whole attention heads -- or, for grouped-query attention, whole KV
+    groups -- from every matched ``com.microsoft::Attention``,
+    ``com.microsoft::GroupQueryAttention``, or plain ``ai.onnx::Attention``
+    node whose output feeds, optionally through a single shape-preserving
+    ``Reshape``, exactly one downstream MatMul/vanilla-Gemm's reduction
+    dimension (the output projection) -- the attention analogue of
+    :func:`onnxsim.apply_structured_pruning_cpp`, at head (or KV-group)
+    instead of single-channel granularity.
+
+    For each matched plain ``com.microsoft::Attention`` block (a single
+    merged QKV weight/bias): ranks every head by the combined Frobenius norm
+    of its own Q, K, and V weight columns, drops the lowest-``sparsity``-
+    fraction of heads (at least one head is always kept), and removes the
+    corresponding column blocks from the merged QKV weight (and bias, if
+    present), decrementing ``num_heads``/``qkv_hidden_sizes`` accordingly,
+    and the matching row block from the output projection's weight.
+
+    For each matched ``GroupQueryAttention`` or plain ``ai.onnx::Attention``
+    block (separate, un-merged Q/K/V producers): ranks every *KV group* (a
+    KV head and the ``num_heads / kv_num_heads`` query heads the kernel maps
+    to it) by the combined Frobenius norm of that group's own Q+K+V weight
+    block, drops the lowest-``sparsity``-fraction of groups (at least one
+    group is always kept), and removes the corresponding column blocks from
+    all three producers (and their biases, if present) together with the
+    matching row block from the output projection's weight, decrementing the
+    query head count and ``kv_num_heads`` by the number of groups dropped --
+    so their ratio (query heads per KV head) is unchanged. An individual
+    query head is never dropped on its own: only a whole group, since
+    neither kernel has a way to keep a KV head alive for some, but not all,
+    of the query heads that shared it.
+
+    Unlike the pure-Python :func:`onnxsim.apply_attention_head_pruning`,
+    this port does not include the calibration-driven Wanda variant
+    (:func:`onnxsim.apply_attention_head_wanda_pruning`) -- data-free/
+    magnitude importance only, matching this codebase's C++-port scope
+    decision.
+
+    This is a single, self-contained graph rewrite: unlike :func:`simplify`,
+    it does not run shape inference, constant folding, or any other pass.
+
+    :param model: the original onnx ModelProto or file path
+    :param sparsity: target fraction of each matched block's heads (or, for
+            GroupQueryAttention/plain ai.onnx Attention, KV groups) to
+            remove (at least one is always kept); must be in ``[0, 1)``
+    :returns: ``model`` with every matched block's tensors resized in
+            place; anything not matching that exact topology (a
+            non-constant weight, a packed-QKV GroupQueryAttention node, a
+            GroupQueryAttention/plain ai.onnx Attention node with a
+            non-empty constant past-KV-cache or attention-mask input, an
+            ai.onnx Attention node with differing Q/K/V head sizes or
+            without explicit ``q_num_heads``/``kv_num_heads`` attributes, a
+            consumer whose reduction dimension doesn't line up, ...) is
+            left completely untouched
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    return onnx.load_from_string(
+        C.apply_attention_head_pruning(model.SerializeToString(), sparsity)
+    )
+
+
 def apply_quarot_cpp(
     model: Union[str, onnx.ModelProto],
     seed: int = 0,

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -565,6 +565,53 @@ onnx::ModelProto ApplyQuarot(const onnx::ModelProto& model, uint64_t seed);
 onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
                                         double sparsity);
 
+// Attention-head pruning: removes whole attention heads -- or, for
+// grouped-query attention, whole KV groups -- from every matched
+// ``com.microsoft::Attention``, ``com.microsoft::GroupQueryAttention``, or
+// plain ``ai.onnx::Attention`` node whose output feeds, optionally through a
+// single shape-preserving ``Reshape``, exactly one downstream MatMul/
+// vanilla-Gemm's reduction dimension (the output projection) -- the
+// attention analogue of ``ApplyStructuredPruning``, at head (or KV-group)
+// instead of single-channel granularity.
+//
+// For each matched plain ``com.microsoft::Attention`` block (a single merged
+// QKV weight/bias): ranks every head by the combined Frobenius norm of its
+// own Q, K, and V weight columns, drops the lowest-``sparsity``-fraction of
+// heads (at least one head is always kept), and removes the corresponding
+// column blocks from the merged QKV weight (and bias, if present),
+// decrementing ``num_heads``/``qkv_hidden_sizes`` accordingly, and the
+// matching row block from the output projection's weight.
+//
+// For each matched ``GroupQueryAttention`` or plain ``ai.onnx::Attention``
+// block (separate, un-merged Q/K/V producers): ranks every *KV group* (a KV
+// head and the ``num_heads / kv_num_heads`` query heads the kernel maps to
+// it) by the combined Frobenius norm of that group's own Q+K+V weight
+// block, drops the lowest-``sparsity``-fraction of groups (at least one
+// group is always kept), and removes the corresponding column blocks from
+// all three producers (and their biases, if present) together with the
+// matching row block from the output projection's weight, decrementing the
+// query head count and ``kv_num_heads`` by the number of groups dropped --
+// so their ratio (query heads per KV head) is unchanged. An individual
+// query head is never dropped on its own: only a whole group, since neither
+// kernel has a way to keep a KV head alive for some, but not all, of the
+// query heads that shared it.
+//
+// Unlike ``Simplify``, this does not run shape inference, constant folding or
+// any other simplification pass. ``sparsity`` must be in [0, 1); throws
+// ``std::invalid_argument`` otherwise. Anything not matching that exact
+// topology (a non-constant weight, a packed-QKV GroupQueryAttention node, a
+// GroupQueryAttention/plain ai.onnx Attention node with a non-empty constant
+// past-KV-cache or attention-mask input, an ai.onnx Attention node with
+// differing Q/K/V head sizes or without explicit
+// ``q_num_heads``/``kv_num_heads`` attributes, a consumer whose reduction
+// dimension doesn't line up, ...) is left completely untouched. Unlike the
+// pure-Python ``onnxsim.apply_attention_head_pruning``, this port does not
+// include the calibration-driven Wanda variant
+// (``onnxsim.apply_attention_head_wanda_pruning``) -- data-free/magnitude
+// importance only, matching this codebase's C++-port scope decision.
+onnx::ModelProto ApplyAttentionHeadPruning(const onnx::ModelProto& model,
+                                           double sparsity);
+
 // Lists the activation tensor names that ``QuantizeStatic`` could quantize in
 // ``model`` -- the first input of every MatMul, every "vanilla" Gemm
 // (transA=0, alpha=1, beta=1), and every Conv, whose weight is a constant

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -530,11 +530,14 @@ onnx::ModelProto ApplyQuarot(const onnx::ModelProto& model, uint64_t seed);
 // columns/rows from the consumer's weight. A general grouped Conv (neither
 // ``group=1`` nor fully depthwise) is matched too, as a producer and/or
 // consumer, ranking/pruning each of its ``group`` channel blocks
-// independently -- see ``structured_pruning_entry.cpp`` for the exact
-// algorithm and its scope note (this port does not (yet) include the
-// pure-Python implementation's gated-FFN or residual/skip-connection chain
-// support -- ``onnxsim.apply_structured_pruning`` remains the
-// full-featured reference).
+// independently. The gated-FFN SwiGLU/GeGLU pattern is matched too -- two
+// producers combined by a ``Mul`` (or ONNX opset-28+'s native ``SwiGLU``
+// node) feeding one consumer, both pruned to the same combined-importance-
+// ranked channel indices -- see ``structured_pruning_entry.cpp`` for the
+// exact algorithm and its scope note (this port does not (yet) include the
+// pure-Python implementation's residual/skip-connection chain support --
+// ``onnxsim.apply_structured_pruning`` remains the full-featured
+// reference).
 //
 // Unlike ``Simplify``, this does not run shape inference, constant folding or
 // any other simplification pass -- it applies exactly this rewrite, to every

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -533,11 +533,24 @@ onnx::ModelProto ApplyQuarot(const onnx::ModelProto& model, uint64_t seed);
 // independently. The gated-FFN SwiGLU/GeGLU pattern is matched too -- two
 // producers combined by a ``Mul`` (or ONNX opset-28+'s native ``SwiGLU``
 // node) feeding one consumer, both pruned to the same combined-importance-
-// ranked channel indices -- see ``structured_pruning_entry.cpp`` for the
-// exact algorithm and its scope note (this port does not (yet) include the
-// pure-Python implementation's residual/skip-connection chain support --
-// ``onnxsim.apply_structured_pruning`` remains the full-featured
-// reference).
+// ranked channel indices. A Conv or MatMul/Gemm residual (skip-connection)
+// chain is matched too -- a channel-preserving ``Add(a, b)`` where both
+// operands are non-constant forces whichever real producer(s) feed ``a``/
+// ``b`` to agree on one shared channel-index set, resolved via a backward
+// walk plus union-find grouping across such merge points that also covers a
+// whole chain of such merges transitively sharing one spine channel count
+// (a lone residual connection, or a linear stack of ``Add``-only merges;
+// an *interior* block of a real deep ResNet/transformer stage, whose own
+// "post-block" tensor is read both by the next block and directly by that
+// block's own ``Add``, is left completely untouched, the same "no
+// branch-following" boundary every other chain kind here already holds) --
+// see ``structured_pruning_entry.cpp`` for the exact algorithm and its
+// scope note (this port does not (yet) recognize a fused
+// ``com.microsoft::SkipLayerNormalization``/``SkipSimplifiedLayerNormalization``
+// node -- what onnxruntime's transformer optimizer collapses a bare
+// residual ``Add`` plus the following LayerNorm into -- as an eligible
+// merge point; ``onnxsim.apply_structured_pruning`` remains the
+// full-featured reference for that case).
 //
 // Unlike ``Simplify``, this does not run shape inference, constant folding or
 // any other simplification pass -- it applies exactly this rewrite, to every
@@ -545,8 +558,8 @@ onnx::ModelProto ApplyQuarot(const onnx::ModelProto& model, uint64_t seed);
 // returns the result. ``sparsity`` must be in [0, 1); throws
 // ``std::invalid_argument`` otherwise. Anything not matching the exact
 // topology above (branching, a non-constant bias, a consumer whose
-// reduction dimension doesn't line up, a gated or residual chain, ...) is
-// left completely untouched.
+// reduction dimension doesn't line up, a fused-SkipLayerNormalization
+// residual, ...) is left completely untouched.
 onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
                                         double sparsity);
 

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -514,6 +514,39 @@ onnx::ModelProto PruneMagnitude(const onnx::ModelProto& model, double sparsity);
 // ``seed`` derives a fresh, deterministic random rotation per matched layer.
 onnx::ModelProto ApplyQuarot(const onnx::ModelProto& model, uint64_t seed);
 
+// Structured (channel) pruning: removes whole output channels from
+// MatMul/vanilla-Gemm and Conv layers -- real structural pruning (smaller
+// weight tensors, smaller matmuls on any runtime), as opposed to
+// ``PruneMagnitude``'s value-only zeroing. For every MatMul/vanilla-Gemm or
+// 2-D Conv "producer" node whose output feeds, through zero or more
+// shape-preserving elementwise ops (an activation, or -- MatMul/Gemm only --
+// an Add/Mul against a constant per-channel bias/scale, or -- Conv only -- a
+// depthwise Conv hop) with no other consumer anywhere along that path, into
+// exactly one downstream "consumer" of the same family: ranks the
+// producer's output channels by L2 norm of their own weight row/filter,
+// drops the lowest-``sparsity``-fraction of them, and removes the
+// corresponding rows/columns from the producer's weight (and bias, if
+// constant) and every intermediate per-channel constant, and the matching
+// columns/rows from the consumer's weight. A general grouped Conv (neither
+// ``group=1`` nor fully depthwise) is matched too, as a producer and/or
+// consumer, ranking/pruning each of its ``group`` channel blocks
+// independently -- see ``structured_pruning_entry.cpp`` for the exact
+// algorithm and its scope note (this port does not (yet) include the
+// pure-Python implementation's gated-FFN or residual/skip-connection chain
+// support -- ``onnxsim.apply_structured_pruning`` remains the
+// full-featured reference).
+//
+// Unlike ``Simplify``, this does not run shape inference, constant folding or
+// any other simplification pass -- it applies exactly this rewrite, to every
+// matching chain, to a copy of ``model`` (which is left untouched) and
+// returns the result. ``sparsity`` must be in [0, 1); throws
+// ``std::invalid_argument`` otherwise. Anything not matching the exact
+// topology above (branching, a non-constant bias, a consumer whose
+// reduction dimension doesn't line up, a gated or residual chain, ...) is
+// left completely untouched.
+onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
+                                        double sparsity);
+
 // Lists the activation tensor names that ``QuantizeStatic`` could quantize in
 // ``model`` -- the first input of every MatMul, every "vanilla" Gemm
 // (transA=0, alpha=1, beta=1), and every Conv, whose weight is a constant

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -543,14 +543,17 @@ onnx::ModelProto ApplyQuarot(const onnx::ModelProto& model, uint64_t seed);
 // an *interior* block of a real deep ResNet/transformer stage, whose own
 // "post-block" tensor is read both by the next block and directly by that
 // block's own ``Add``, is left completely untouched, the same "no
-// branch-following" boundary every other chain kind here already holds) --
-// see ``structured_pruning_entry.cpp`` for the exact algorithm and its
-// scope note (this port does not (yet) recognize a fused
+// branch-following" boundary every other chain kind here already holds). For
+// MatMul/Gemm specifically, a fused
 // ``com.microsoft::SkipLayerNormalization``/``SkipSimplifiedLayerNormalization``
 // node -- what onnxruntime's transformer optimizer collapses a bare
-// residual ``Add`` plus the following LayerNorm into -- as an eligible
-// merge point; ``onnxsim.apply_structured_pruning`` remains the
-// full-featured reference for that case).
+// residual ``Add`` plus the following LayerNorm into, and so what a
+// fully-optimized transformer's own residual connections typically look
+// like -- is recognized as an eligible merge point too, its own
+// ``gamma``/``beta``/``bias`` constants riding along as a per-channel
+// affine hop on the resolved chain; a Conv residual chain only ever sees a
+// bare ``Add`` (there is no Conv analogue of that fused op). See
+// ``structured_pruning_entry.cpp`` for the exact algorithm.
 //
 // Unlike ``Simplify``, this does not run shape inference, constant folding or
 // any other simplification pass -- it applies exactly this rewrite, to every
@@ -558,8 +561,7 @@ onnx::ModelProto ApplyQuarot(const onnx::ModelProto& model, uint64_t seed);
 // returns the result. ``sparsity`` must be in [0, 1); throws
 // ``std::invalid_argument`` otherwise. Anything not matching the exact
 // topology above (branching, a non-constant bias, a consumer whose
-// reduction dimension doesn't line up, a fused-SkipLayerNormalization
-// residual, ...) is left completely untouched.
+// reduction dimension doesn't line up, ...) is left completely untouched.
 onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
                                         double sparsity);
 

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -2,19 +2,23 @@
 //
 // C++ port of pruning.py's own apply_structured_pruning -- see that
 // function's docstring for the full technique description (this is quoted
-// here only where it constrains scope). This port covers the two "plain
-// chain" topologies -- a MatMul/vanilla-Gemm producer -> consumer pair
-// (pruning.py's own _find_chains) and a Conv producer -> consumer pair,
-// including depthwise pass-through hops and general grouped Conv on either
-// side (_find_conv_chains) -- but not (yet) pruning.py's gated-FFN
-// (_find_gated_chains) or residual/skip-connection (_find_conv_residual_chains,
-// _find_matmul_residual_chains) chain finders: those need the same backward-
-// walk/union-find machinery as the forward walk here, layered on top, and
-// are left to the pure-Python implementation for now. A model whose only
-// prunable structure is one of those unported shapes is therefore left
-// completely untouched by this port -- exactly the same "declined, not
-// guessed at" behavior pruning.py's own docstring promises for any topology
-// it doesn't recognize, just a larger set of them.
+// here only where it constrains scope). This port covers three of
+// pruning.py's own five chain finders: a MatMul/vanilla-Gemm producer ->
+// consumer pair (_find_chains), a Conv producer -> consumer pair, including
+// depthwise pass-through hops and general grouped Conv on either side
+// (_find_conv_chains), and the gated-FFN SwiGLU/GeGLU pattern -- two
+// producers combined by Mul (or ONNX opset-28+'s native SwiGLU node) feeding
+// one consumer, both pruned to the same channel indices
+// (_find_gated_chains) -- but not (yet) the residual/skip-connection chain
+// finders (_find_conv_residual_chains, _find_matmul_residual_chains): those
+// need a backward walk plus union-find grouping across merge points, a
+// different (and larger) piece of machinery than the forward-only walk
+// every chain finder here uses, and are left to the pure-Python
+// implementation for now. A model whose only prunable structure is one of
+// those unported residual shapes is therefore left completely untouched by
+// this port -- exactly the same "declined, not guessed at" behavior
+// pruning.py's own docstring promises for any topology it doesn't
+// recognize, just a larger set of them.
 //
 // Implemented directly on onnx::GraphProto (protobuf), not onnxoptimizer's
 // Node/Value IR: pruning.py's own algorithm already works this way (name-
@@ -39,6 +43,7 @@
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "dlpack_dtype.h"
@@ -212,6 +217,11 @@ struct Producer {
   std::optional<std::string> bias;
   bool is_conv;
   int64_t group;
+  // Activation nodes between this producer's raw output and the point it
+  // combines with another producer (a gated pair only -- see
+  // FindGatedChains; empty for a plain single-producer chain), in forward
+  // order (raw output -> ... -> the tensor that feeds the combine op).
+  std::vector<onnx::NodeProto*> pre_ops;
 };
 
 struct ConvPassThrough {
@@ -387,6 +397,167 @@ std::vector<Chain> FindChains(onnx::GraphProto* graph) {
     chain.consumer_weight = consumer->weight;
     chain.consumer_weight_transposed = consumer->weight_transposed;
     chain.n_channels = info->n_channels;
+    chains.push_back(std::move(chain));
+  }
+  return chains;
+}
+
+// --- Gated FFN (SwiGLU/GeGLU) chains, mirroring _trace_gate_producer_backward/
+// _find_gated_chains ---------------------------------------------------------
+
+struct FullProducerMatch {
+  onnx::NodeProto* node;
+  std::string weight;
+  bool weight_transposed;
+  std::optional<std::string> bias;
+  int64_t n_channels;
+};
+
+// Walks backward from `tensor_name` through unary activation ops until it
+// resolves to a matmul-like producer's raw output -- the mirror image of
+// WalkToConsumer's forward walk, recognizing a gate branch's own activation
+// (e.g. SwiGLU's silu(gate) exported as a separate Sigmoid/Mul-by-a-second-
+// operand). Returns the resolved producer plus its pre_ops, in forward
+// order (closest to the producer first).
+std::optional<std::pair<FullProducerMatch, std::vector<onnx::NodeProto*>>>
+TraceGateProducerBackward(
+    const std::string& tensor_name,
+    const std::unordered_map<std::string, onnx::NodeProto*>& node_by_output,
+    const std::unordered_map<std::string, FullProducerMatch>& producer_infos,
+    const ConsumerMap& consumers_of,
+    const std::unordered_set<std::string>& graph_outputs, int max_hops) {
+  std::vector<onnx::NodeProto*> pre_ops;  // Backward order; reversed on return.
+  std::string cur = tensor_name;
+  for (int hop = 0; hop < max_hops; ++hop) {
+    if (ConsumerCount(consumers_of, cur) != 1 || graph_outputs.count(cur)) {
+      return std::nullopt;
+    }
+    auto pit = producer_infos.find(cur);
+    if (pit != producer_infos.end()) {
+      std::reverse(pre_ops.begin(), pre_ops.end());
+      return std::make_pair(pit->second, std::move(pre_ops));
+    }
+    auto nit = node_by_output.find(cur);
+    if (nit == node_by_output.end()) {
+      return std::nullopt;
+    }
+    onnx::NodeProto* producer_node = nit->second;
+    if (!(UnaryPassThroughOps().count(producer_node->op_type()) != 0 &&
+          producer_node->input_size() == 1 &&
+          producer_node->output_size() == 1)) {
+      return std::nullopt;
+    }
+    pre_ops.push_back(producer_node);
+    cur = producer_node->input(0);
+  }
+  return std::nullopt;
+}
+
+std::vector<Chain> FindGatedChains(onnx::GraphProto* graph) {
+  InitMap init_map;
+  for (const auto& t : graph->initializer()) {
+    init_map[t.name()] = &t;
+  }
+  ConsumerMap consumers_of = ConsumersOf(graph);
+  std::unordered_set<std::string> graph_outputs;
+  for (const auto& o : graph->output()) {
+    graph_outputs.insert(o.name());
+  }
+  auto is_internal = [&](const std::string& name) {
+    return ConsumerCount(consumers_of, name) == 1 && !graph_outputs.count(name);
+  };
+
+  std::unordered_map<std::string, onnx::NodeProto*> node_by_output;
+  std::unordered_map<std::string, FullProducerMatch> producer_infos;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    for (const auto& out : node->output()) {
+      node_by_output[out] = node;
+    }
+    auto info = MatchProducer(*node, init_map);
+    if (info) {
+      producer_infos[node->output(0)] =
+          FullProducerMatch{node, info->weight, info->weight_transposed,
+                            info->bias, info->n_channels};
+    }
+  }
+
+  std::vector<Chain> chains;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    std::optional<FullProducerMatch> info_a, info_b;
+    std::vector<onnx::NodeProto*> pre_a, pre_b;
+
+    if (node->op_type() == "Mul" && node->input_size() == 2 &&
+        node->output_size() == 1) {
+      const std::string& a_name = node->input(0);
+      const std::string& b_name = node->input(1);
+      if (a_name == b_name || init_map.count(a_name) ||
+          init_map.count(b_name)) {
+        continue;
+      }
+      auto trace_a =
+          TraceGateProducerBackward(a_name, node_by_output, producer_infos,
+                                    consumers_of, graph_outputs, kMaxChainHops);
+      auto trace_b =
+          TraceGateProducerBackward(b_name, node_by_output, producer_infos,
+                                    consumers_of, graph_outputs, kMaxChainHops);
+      if (!trace_a || !trace_b) {
+        continue;
+      }
+      info_a = trace_a->first;
+      pre_a = std::move(trace_a->second);
+      info_b = trace_b->first;
+      pre_b = std::move(trace_b->second);
+    } else if (node->op_type() == "SwiGLU" && node->input_size() == 2 &&
+               node->output_size() == 1) {
+      const std::string& a_name = node->input(0);
+      const std::string& b_name = node->input(1);
+      if (init_map.count(a_name) || init_map.count(b_name)) {
+        continue;
+      }
+      if (!(is_internal(a_name) && is_internal(b_name))) {
+        continue;
+      }
+      auto ait = producer_infos.find(a_name);
+      auto bit = producer_infos.find(b_name);
+      if (ait == producer_infos.end() || bit == producer_infos.end()) {
+        continue;
+      }
+      info_a = ait->second;
+      info_b = bit->second;
+    } else {
+      continue;
+    }
+
+    if (info_a->node == info_b->node ||
+        info_a->n_channels != info_b->n_channels) {
+      continue;
+    }
+
+    const std::string& out_name = node->output(0);
+    if (!is_internal(out_name)) {
+      continue;
+    }
+    auto [consumer, chain_ops] =
+        WalkToConsumer(out_name, init_map, consumers_of, graph_outputs,
+                       info_a->n_channels, kMaxChainHops);
+    if (!consumer) {
+      continue;
+    }
+
+    Chain chain;
+    chain.producers.push_back(Producer{info_a->node, info_a->weight,
+                                       info_a->weight_transposed, info_a->bias,
+                                       false, 1, std::move(pre_a)});
+    chain.producers.push_back(Producer{info_b->node, info_b->weight,
+                                       info_b->weight_transposed, info_b->bias,
+                                       false, 1, std::move(pre_b)});
+    chain.chain_ops = std::move(chain_ops);
+    chain.consumer_node = consumer->node;
+    chain.consumer_weight = consumer->weight;
+    chain.consumer_weight_transposed = consumer->weight_transposed;
+    chain.n_channels = info_a->n_channels;
     chains.push_back(std::move(chain));
   }
   return chains;
@@ -956,6 +1127,9 @@ void ApplyChains(onnx::GraphProto* graph, std::vector<Chain>& chains,
     }
     for (const auto& p : chain.producers) {
       stale_value_info.insert(p.node->output(0));
+      for (const auto* pre_op : p.pre_ops) {
+        stale_value_info.insert(pre_op->output(0));
+      }
     }
     for (const auto& co : chain.chain_ops) {
       stale_value_info.insert(co.node->output(0));
@@ -989,7 +1163,10 @@ onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
   onnx::GraphProto* graph = out.mutable_graph();
 
   std::vector<Chain> chains = FindChains(graph);
+  std::vector<Chain> gated_chains = FindGatedChains(graph);
   std::vector<Chain> conv_chains = FindConvChains(graph);
+  chains.insert(chains.end(), std::make_move_iterator(gated_chains.begin()),
+                std::make_move_iterator(gated_chains.end()));
   chains.insert(chains.end(), std::make_move_iterator(conv_chains.begin()),
                 std::make_move_iterator(conv_chains.end()));
   if (!chains.empty()) {

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -122,6 +122,57 @@ void SetFloatTensorData(onnx::TensorProto* t, const std::vector<int64_t>& dims,
   t->set_raw_data(std::move(raw));
 }
 
+// The INT64 analogue of ReadFloatTensor, used only by
+// FindAttentionChains/FindSeparateQkvChains's own Reshape-target-shape
+// reading and rewriting (WalkToAttentionConsumer/SetInt64TensorLastDim).
+std::vector<int64_t> ReadInt64Tensor(const onnx::TensorProto& t) {
+  int64_t numel = 1;
+  for (int64_t d : t.dims()) {
+    numel *= d;
+  }
+  std::vector<int64_t> out(static_cast<size_t>(numel));
+  if (t.has_raw_data()) {
+    std::memcpy(out.data(), t.raw_data().data(), out.size() * sizeof(int64_t));
+    if constexpr (!onnxsim::dlpack::kRawDataIsHostOrder) {
+      onnxsim::dlpack::SwapElementBytes(reinterpret_cast<uint8_t*>(out.data()),
+                                        out.size() * sizeof(int64_t),
+                                        sizeof(int64_t));
+    }
+  } else {
+    for (int64_t i = 0; i < numel; ++i) {
+      out[static_cast<size_t>(i)] = t.int64_data(static_cast<int>(i));
+    }
+  }
+  return out;
+}
+
+// Overwrites the last element of an INT64 tensor `t` in place with
+// `new_last`, keeping every other dim -- mirrors pruning.py's own
+// `dims[-1] = ...; shape_init.CopyFrom(from_array(dims))` pattern for a
+// Reshape node's own target-shape constant.
+void SetInt64TensorLastDim(onnx::TensorProto* t, int64_t new_last) {
+  std::vector<int64_t> data = ReadInt64Tensor(*t);
+  if (data.empty()) {
+    return;
+  }
+  data.back() = new_last;
+  const std::string name = t->name();
+  std::vector<int64_t> dims(t->dims().begin(), t->dims().end());
+  t->Clear();
+  t->set_name(name);
+  t->set_data_type(onnx::TensorProto::INT64);
+  for (int64_t d : dims) {
+    t->add_dims(d);
+  }
+  std::string raw(data.size() * sizeof(int64_t), '\0');
+  std::memcpy(raw.data(), data.data(), raw.size());
+  if constexpr (!onnxsim::dlpack::kRawDataIsHostOrder) {
+    onnxsim::dlpack::SwapElementBytes(reinterpret_cast<uint8_t*>(raw.data()),
+                                      raw.size(), sizeof(int64_t));
+  }
+  t->set_raw_data(std::move(raw));
+}
+
 int64_t ConvGroupAttr(const onnx::NodeProto& node) {
   for (const auto& attr : node.attribute()) {
     if (attr.name() == "group") {
@@ -1129,10 +1180,10 @@ std::vector<Chain> FindConvResidualChains(onnx::GraphProto* graph) {
 // (node, const_name) entries -- ApplyChains's existing per-hop constant
 // slicing picks them up with no changes of its own.
 
-constexpr char kSkipLayerNormDomain[] = "com.microsoft";
+constexpr char kComMicrosoftDomain[] = "com.microsoft";
 
 bool IsSkipLayerNormOp(const onnx::NodeProto& node) {
-  return node.domain() == kSkipLayerNormDomain &&
+  return node.domain() == kComMicrosoftDomain &&
          (node.op_type() == "SkipLayerNormalization" ||
           node.op_type() == "SkipSimplifiedLayerNormalization");
 }
@@ -1942,6 +1993,802 @@ void ApplyChains(onnx::GraphProto* graph, std::vector<Chain>& chains,
   }
 }
 
+// --- Attention-head pruning, mirroring pruning.py's own
+// _match_attention_producer/_walk_to_attention_consumer/
+// _find_attention_chains, _match_gqa_producer/_match_onnx_attention_producer/
+// _find_separate_qkv_chains, and _apply_one_plain_attention_chain/
+// _apply_one_gqa_chain/_apply_attention_chains. Data-free (magnitude/
+// Frobenius-norm) only -- pruning.py's own calibration-driven
+// apply_attention_head_wanda_pruning is not ported, matching this codebase's
+// established C++-port scope decision (data-free/closed-form techniques
+// only). Three fused self-attention ops are matched, each at the
+// granularity its own kernel contract allows -- see pruning.py's own
+// "Attention-head pruning" section comment for the full rationale (packed-
+// QKV vs. separate-Q/K/V weight layout, individual-head vs. whole-KV-group
+// pruning unit, and why the plain ai.onnx::Attention op reuses the
+// GroupQueryAttention machinery outright rather than a parallel
+// implementation) -- this comment only covers what's specific to the port:
+//
+// - com.microsoft::Attention: a single merged QKV weight/bias, one
+//   `num_heads` shared by Q/K/V alike -- every head owns an equally-sized,
+//   independent column block, so individual heads drop one at a time
+//   (FindAttentionChains/ApplyOnePlainAttentionChain).
+// - com.microsoft::GroupQueryAttention and the plain ai.onnx::Attention
+//   (opset 24+): separate, un-merged Q/K/V MatMul/vanilla-Gemm producers,
+//   `num_heads`/`kv_num_heads` (or `q_num_heads`/`kv_num_heads` for the
+//   plain op) attributes -- only a whole KV group (that KV head's own K/V
+//   column block, plus every query head mapped to it) is ever removed at
+//   once, since every surviving KV head must keep exactly the same number
+//   of query heads mapped to it after pruning (FindSeparateQkvChains/
+//   ApplyOneGqaChain, shared between the two ops).
+
+// True for a com.microsoft::Attention node with a constant 2-D float32
+// merged QKV weight [K, Nq+Nk+Nv] (and, if present, a constant 1-D float32
+// merged bias). Mirrors pruning.py's own _match_attention_producer.
+struct AttentionProducerMatch {
+  std::string weight;
+  std::optional<std::string> bias;
+  int64_t num_heads;
+  int64_t nq, nk, nv;
+};
+
+std::optional<AttentionProducerMatch> MatchAttentionProducer(
+    const onnx::NodeProto& node, const InitMap& init_map) {
+  if (node.domain() != kComMicrosoftDomain || node.op_type() != "Attention") {
+    return std::nullopt;
+  }
+  if (node.input_size() < 2) {
+    return std::nullopt;
+  }
+  const std::string& w_name = node.input(1);
+  auto wit = init_map.find(w_name);
+  if (wit == init_map.end() ||
+      wit->second->data_type() != onnx::TensorProto::FLOAT ||
+      wit->second->dims_size() != 2) {
+    return std::nullopt;
+  }
+  const int64_t total_n = wit->second->dims(1);
+
+  std::optional<std::string> bias_name;
+  if (node.input_size() >= 3 && !node.input(2).empty()) {
+    bias_name = node.input(2);
+    auto bit = init_map.find(*bias_name);
+    if (bit == init_map.end() ||
+        bit->second->data_type() != onnx::TensorProto::FLOAT ||
+        bit->second->dims_size() != 1 || bit->second->dims(0) != total_n) {
+      return std::nullopt;
+    }
+  }
+
+  int64_t num_heads = 0;
+  bool has_num_heads = false;
+  std::optional<std::vector<int64_t>> qkv_hidden_sizes;
+  for (const auto& attr : node.attribute()) {
+    if (attr.name() == "num_heads") {
+      num_heads = attr.i();
+      has_num_heads = true;
+    } else if (attr.name() == "qkv_hidden_sizes") {
+      qkv_hidden_sizes =
+          std::vector<int64_t>(attr.ints().begin(), attr.ints().end());
+    }
+  }
+  if (!has_num_heads || num_heads <= 0) {
+    return std::nullopt;
+  }
+
+  int64_t nq, nk, nv;
+  if (qkv_hidden_sizes) {
+    if (qkv_hidden_sizes->size() != 3) {
+      return std::nullopt;
+    }
+    nq = (*qkv_hidden_sizes)[0];
+    nk = (*qkv_hidden_sizes)[1];
+    nv = (*qkv_hidden_sizes)[2];
+  } else {  // Schema default: Q/K/V evenly split the merged width.
+    if (total_n % 3 != 0) {
+      return std::nullopt;
+    }
+    nq = nk = nv = total_n / 3;
+  }
+  if (nq <= 0 || nk <= 0 || nv <= 0 || nq + nk + nv != total_n ||
+      nq % num_heads != 0 || nk % num_heads != 0 || nv % num_heads != 0) {
+    return std::nullopt;
+  }
+  return AttentionProducerMatch{w_name, bias_name, num_heads, nq, nk, nv};
+}
+
+// If `node` is a Reshape whose target-shape input is a constant int64
+// tensor, returns its last entry (or nullopt for a wildcard/inferred -1/0
+// entry, or an unreadable shape).
+std::optional<int64_t> ReshapeLastDim(const onnx::NodeProto& node,
+                                      const InitMap& init_map) {
+  if (node.op_type() != "Reshape" || node.input_size() != 2) {
+    return std::nullopt;
+  }
+  auto it = init_map.find(node.input(1));
+  if (it == init_map.end() ||
+      it->second->data_type() != onnx::TensorProto::INT64) {
+    return std::nullopt;
+  }
+  std::vector<int64_t> dims = ReadInt64Tensor(*it->second);
+  if (dims.empty()) {
+    return std::nullopt;
+  }
+  const int64_t last = dims.back();
+  return last > 0 ? std::optional<int64_t>(last) : std::nullopt;
+}
+
+struct AttnChainOp {
+  onnx::NodeProto* node;
+  std::optional<std::string> shape_name;
+};
+
+// From an attention op's raw (V-hidden-size- or Q-hidden-size-wide,
+// depending on caller) output tensor `start`, optionally through a single
+// Reshape hop whose target shape's last entry is provably still `width`,
+// to a MatMul/vanilla-Gemm consumer (the output projection) whose
+// reduction dimension matches `width`. Mirrors pruning.py's own
+// _walk_to_attention_consumer.
+std::pair<std::optional<ConsumerMatch>, std::vector<AttnChainOp>>
+WalkToAttentionConsumer(const std::string& start, const InitMap& init_map,
+                        const ConsumerMap& consumers_of,
+                        const std::unordered_set<std::string>& graph_outputs,
+                        int64_t width) {
+  auto cit = consumers_of.find(start);
+  if (cit == consumers_of.end() || cit->second.size() != 1) {
+    return {std::nullopt, {}};
+  }
+  onnx::NodeProto* node = cit->second[0];
+  std::vector<AttnChainOp> chain_ops;
+  std::string cur = start;
+
+  if (node->op_type() == "Reshape" && node->input_size() >= 1 &&
+      node->input(0) == cur) {
+    auto last_dim = ReshapeLastDim(*node, init_map);
+    if (!last_dim || *last_dim != width) {
+      return {std::nullopt, {}};
+    }
+    const std::string& shape_name = node->input(1);
+    if (ConsumerCount(consumers_of, shape_name) != 1) {
+      return {std::nullopt, {}};  // Shared shape constant -- mutating unsafe.
+    }
+    const std::string& out_name = node->output(0);
+    if (ConsumerCount(consumers_of, out_name) != 1 ||
+        graph_outputs.count(out_name)) {
+      return {std::nullopt, {}};
+    }
+    chain_ops.push_back(AttnChainOp{node, shape_name});
+    cur = out_name;
+    node = consumers_of.at(cur)[0];
+  }
+
+  auto cm = MatchMatMulLikeRaw(*node);
+  if (!cm || cm->x_name != cur) {
+    return {std::nullopt, chain_ops};
+  }
+  auto wit = init_map.find(cm->w_name);
+  if (wit == init_map.end() ||
+      wit->second->data_type() != onnx::TensorProto::FLOAT ||
+      wit->second->dims_size() != 2) {
+    return {std::nullopt, chain_ops};
+  }
+  const int64_t k =
+      cm->weight_transposed ? wit->second->dims(1) : wit->second->dims(0);
+  if (k != width) {
+    return {std::nullopt, chain_ops};
+  }
+  return {ConsumerMatch{node, cm->w_name, cm->weight_transposed}, chain_ops};
+}
+
+enum class AttnChainKind { kPlainAttention, kGqaLike };
+
+// Either kind of matched attention block -- a single tagged struct rather
+// than pruning.py's own _AttnLikeChain union of two dataclasses, since
+// C++ has no direct analogue of Python's runtime isinstance() dispatch;
+// `kind` says which of the two field groups below is populated.
+struct AttnChain {
+  AttnChainKind kind;
+  onnx::NodeProto* node;
+  // kPlainAttention fields (com.microsoft::Attention's merged QKV weight):
+  std::string weight;
+  std::optional<std::string> bias;
+  int64_t num_heads = 0;
+  int64_t nq = 0, nk = 0, nv = 0;
+  // kGqaLike fields (GroupQueryAttention or plain ai.onnx::Attention's
+  // separate Q/K/V producers):
+  std::string q_weight, k_weight, v_weight;
+  bool q_weight_transposed = false;
+  bool k_weight_transposed = false;
+  bool v_weight_transposed = false;
+  std::optional<std::string> q_bias, k_bias, v_bias;
+  int64_t kv_num_heads = 0;
+  int64_t head_size = 0;
+  std::string num_heads_attr = "num_heads";
+  // Shared:
+  std::vector<AttnChainOp> chain_ops;
+  onnx::NodeProto* consumer_node = nullptr;
+  std::string consumer_weight;
+  bool consumer_weight_transposed = false;
+};
+
+std::vector<AttnChain> FindAttentionChains(onnx::GraphProto* graph) {
+  InitMap init_map;
+  for (const auto& t : graph->initializer()) {
+    init_map[t.name()] = &t;
+  }
+  ConsumerMap consumers_of = ConsumersOf(graph);
+  std::unordered_set<std::string> graph_outputs;
+  for (const auto& o : graph->output()) {
+    graph_outputs.insert(o.name());
+  }
+  auto is_internal = [&](const std::string& name) {
+    return ConsumerCount(consumers_of, name) == 1 && !graph_outputs.count(name);
+  };
+
+  std::vector<AttnChain> chains;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    auto info = MatchAttentionProducer(*node, init_map);
+    if (!info) {
+      continue;
+    }
+    const std::string& out_name = node->output(0);
+    if (!is_internal(out_name)) {
+      continue;
+    }
+    auto [consumer, chain_ops] = WalkToAttentionConsumer(
+        out_name, init_map, consumers_of, graph_outputs, info->nv);
+    if (!consumer) {
+      continue;
+    }
+
+    AttnChain chain;
+    chain.kind = AttnChainKind::kPlainAttention;
+    chain.node = node;
+    chain.weight = info->weight;
+    chain.bias = info->bias;
+    chain.num_heads = info->num_heads;
+    chain.nq = info->nq;
+    chain.nk = info->nk;
+    chain.nv = info->nv;
+    chain.chain_ops = std::move(chain_ops);
+    chain.consumer_node = consumer->node;
+    chain.consumer_weight = consumer->weight;
+    chain.consumer_weight_transposed = consumer->weight_transposed;
+    chains.push_back(std::move(chain));
+  }
+  return chains;
+}
+
+struct HeadCountsMatch {
+  int64_t num_heads;
+  int64_t kv_num_heads;
+};
+
+// If `node` is a com.microsoft::GroupQueryAttention node this pass can
+// safely act on (separate Q/K/V inputs -- rules out the op's packed-QKV
+// calling convention; no non-empty constant past_key/past_value), returns
+// (num_heads, kv_num_heads). Mirrors pruning.py's own _match_gqa_producer.
+std::optional<HeadCountsMatch> MatchGqaProducer(const onnx::NodeProto& node,
+                                                const InitMap& init_map) {
+  if (node.domain() != kComMicrosoftDomain ||
+      node.op_type() != "GroupQueryAttention") {
+    return std::nullopt;
+  }
+  if (node.input_size() < 7 || node.input(0).empty() || node.input(1).empty() ||
+      node.input(2).empty()) {
+    return std::nullopt;
+  }
+  int64_t num_heads = 0, kv_num_heads = 0;
+  bool has_nh = false, has_kv = false;
+  for (const auto& attr : node.attribute()) {
+    if (attr.name() == "num_heads") {
+      num_heads = attr.i();
+      has_nh = true;
+    } else if (attr.name() == "kv_num_heads") {
+      kv_num_heads = attr.i();
+      has_kv = true;
+    }
+  }
+  if (!has_nh || !has_kv || num_heads <= 0 || kv_num_heads <= 0) {
+    return std::nullopt;
+  }
+  if (num_heads % kv_num_heads != 0) {
+    return std::nullopt;
+  }
+  for (int idx : {3, 4}) {  // past_key, past_value.
+    if (node.input_size() <= idx || node.input(idx).empty()) {
+      continue;
+    }
+    auto it = init_map.find(node.input(idx));
+    if (it != init_map.end()) {
+      int64_t prod = 1;
+      for (int64_t d : it->second->dims()) {
+        prod *= d;
+      }
+      if (prod > 0) {
+        return std::nullopt;  // Non-empty KV-cache constant -- needs slicing.
+      }
+    }
+  }
+  return HeadCountsMatch{num_heads, kv_num_heads};
+}
+
+// If `node` is a plain ai.onnx::Attention node (domain "", opset 24+) this
+// pass can safely act on, returns (q_num_heads, kv_num_heads). Mirrors
+// pruning.py's own _match_onnx_attention_producer.
+std::optional<HeadCountsMatch> MatchOnnxAttentionProducer(
+    const onnx::NodeProto& node, const InitMap& init_map) {
+  if (!node.domain().empty() || node.op_type() != "Attention") {
+    return std::nullopt;
+  }
+  if (node.input_size() < 3 || node.input(0).empty() || node.input(1).empty() ||
+      node.input(2).empty()) {
+    return std::nullopt;
+  }
+  int64_t q_num_heads = 0, kv_num_heads = 0;
+  bool has_q = false, has_kv = false;
+  for (const auto& attr : node.attribute()) {
+    if (attr.name() == "q_num_heads") {
+      q_num_heads = attr.i();
+      has_q = true;
+    } else if (attr.name() == "kv_num_heads") {
+      kv_num_heads = attr.i();
+      has_kv = true;
+    }
+  }
+  if (!has_q || !has_kv || q_num_heads <= 0 || kv_num_heads <= 0) {
+    return std::nullopt;
+  }
+  if (q_num_heads % kv_num_heads != 0) {
+    return std::nullopt;
+  }
+  for (int idx : {3, 4, 5}) {  // attn_mask, past_key, past_value.
+    if (node.input_size() <= idx || node.input(idx).empty()) {
+      continue;
+    }
+    auto it = init_map.find(node.input(idx));
+    if (it != init_map.end()) {
+      int64_t prod = 1;
+      for (int64_t d : it->second->dims()) {
+        prod *= d;
+      }
+      if (prod > 0) {
+        return std::nullopt;  // Non-empty constant -- would need slicing.
+      }
+    }
+  }
+  return HeadCountsMatch{q_num_heads, kv_num_heads};
+}
+
+// Shared body for FindGqaChains/FindOnnxAttentionChains: both match a fused
+// attention node fed by three separate, un-merged Q/K/V MatMul/vanilla-Gemm
+// projections and prune it at whole-KV-group granularity, differing only in
+// `match_producer` and which attribute holds the query head count
+// (`num_heads_attr`). Mirrors pruning.py's own _find_separate_qkv_chains.
+std::vector<AttnChain> FindSeparateQkvChains(
+    onnx::GraphProto* graph,
+    const std::function<std::optional<HeadCountsMatch>(
+        const onnx::NodeProto&, const InitMap&)>& match_producer,
+    const std::string& num_heads_attr) {
+  InitMap init_map;
+  for (const auto& t : graph->initializer()) {
+    init_map[t.name()] = &t;
+  }
+  ConsumerMap consumers_of = ConsumersOf(graph);
+  std::unordered_set<std::string> graph_outputs;
+  for (const auto& o : graph->output()) {
+    graph_outputs.insert(o.name());
+  }
+  std::unordered_map<std::string, onnx::NodeProto*> node_by_output;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    for (const auto& out : node->output()) {
+      node_by_output[out] = node;
+    }
+  }
+  auto is_internal = [&](const std::string& name) {
+    return ConsumerCount(consumers_of, name) == 1 && !graph_outputs.count(name);
+  };
+
+  std::vector<AttnChain> chains;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    auto info = match_producer(*node, init_map);
+    if (!info) {
+      continue;
+    }
+
+    const std::string& q_name = node->input(0);
+    const std::string& k_name = node->input(1);
+    const std::string& v_name = node->input(2);
+    if (q_name == k_name || q_name == v_name || k_name == v_name) {
+      continue;  // Degenerate -- can't independently slice a shared producer.
+    }
+    if (!is_internal(q_name) || !is_internal(k_name) || !is_internal(v_name)) {
+      continue;
+    }
+    auto qit = node_by_output.find(q_name);
+    auto kit = node_by_output.find(k_name);
+    auto vit = node_by_output.find(v_name);
+    if (qit == node_by_output.end() || kit == node_by_output.end() ||
+        vit == node_by_output.end()) {
+      continue;
+    }
+    auto pq = MatchProducer(*qit->second, init_map);
+    auto pk = MatchProducer(*kit->second, init_map);
+    auto pv = MatchProducer(*vit->second, init_map);
+    if (!pq || !pk || !pv) {
+      continue;
+    }
+    if (pq->weight == pk->weight || pq->weight == pv->weight ||
+        pk->weight == pv->weight || pq->n_channels % info->num_heads != 0 ||
+        pk->n_channels % info->kv_num_heads != 0 ||
+        pv->n_channels % info->kv_num_heads != 0) {
+      continue;
+    }
+    const int64_t head_size = pq->n_channels / info->num_heads;
+    if (head_size <= 0 || pk->n_channels / info->kv_num_heads != head_size ||
+        pv->n_channels / info->kv_num_heads != head_size) {
+      // fuse_gqa.h requires equal Q/K/V head_size; the plain ai.onnx op's
+      // own more permissive schema allows V its own head_size, but this
+      // shared, uniform-head_size body declines that composition rather
+      // than mis-slicing it.
+      continue;
+    }
+
+    const std::string& out_name = node->output(0);
+    if (!is_internal(out_name)) {
+      continue;
+    }
+    // Both matched ops' raw output is Nq-wide (num_heads * head_size),
+    // unlike plain com.microsoft::Attention's V-hidden-size-wide output.
+    auto [consumer, chain_ops] = WalkToAttentionConsumer(
+        out_name, init_map, consumers_of, graph_outputs, pq->n_channels);
+    if (!consumer) {
+      continue;
+    }
+
+    AttnChain chain;
+    chain.kind = AttnChainKind::kGqaLike;
+    chain.node = node;
+    chain.q_weight = pq->weight;
+    chain.q_bias = pq->bias;
+    chain.q_weight_transposed = pq->weight_transposed;
+    chain.k_weight = pk->weight;
+    chain.k_bias = pk->bias;
+    chain.k_weight_transposed = pk->weight_transposed;
+    chain.v_weight = pv->weight;
+    chain.v_bias = pv->bias;
+    chain.v_weight_transposed = pv->weight_transposed;
+    chain.num_heads = info->num_heads;
+    chain.kv_num_heads = info->kv_num_heads;
+    chain.head_size = head_size;
+    chain.chain_ops = std::move(chain_ops);
+    chain.consumer_node = consumer->node;
+    chain.consumer_weight = consumer->weight;
+    chain.consumer_weight_transposed = consumer->weight_transposed;
+    chain.num_heads_attr = num_heads_attr;
+    chains.push_back(std::move(chain));
+  }
+  return chains;
+}
+
+std::vector<AttnChain> FindGqaChains(onnx::GraphProto* graph) {
+  return FindSeparateQkvChains(graph, MatchGqaProducer, "num_heads");
+}
+
+std::vector<AttnChain> FindOnnxAttentionChains(onnx::GraphProto* graph) {
+  return FindSeparateQkvChains(graph, MatchOnnxAttentionProducer,
+                               "q_num_heads");
+}
+
+// Column indices of every kept head's own head_size-wide block, in
+// ascending head order -- mirrors pruning.py's own _head_column_indices.
+std::vector<int64_t> HeadColumnIndices(const std::vector<int64_t>& keep_heads,
+                                       int64_t head_size) {
+  std::vector<int64_t> out;
+  out.reserve(keep_heads.size() * static_cast<size_t>(head_size));
+  for (int64_t h : keep_heads) {
+    for (int64_t i = 0; i < head_size; ++i) {
+      out.push_back(h * head_size + i);
+    }
+  }
+  return out;
+}
+
+struct AppliedAttn {
+  std::unordered_set<std::string> producer_weights;
+  std::string consumer_weight;
+  std::unordered_set<std::string> stale;
+};
+
+// Applies whole-head pruning to one matched com.microsoft::Attention block
+// in place -- mirrors pruning.py's own _apply_one_plain_attention_chain
+// (data-free/magnitude importance only; the Wanda variant's importance
+// callback indirection is not ported, see this section's own scope note).
+std::optional<AppliedAttn> ApplyOnePlainAttentionChain(
+    std::unordered_map<std::string, onnx::TensorProto*>& init_map,
+    AttnChain& chain, double sparsity) {
+  const int64_t h = chain.num_heads;
+  const int64_t keep_count =
+      std::max<int64_t>(1, h - std::llround(static_cast<double>(h) * sparsity));
+  if (keep_count >= h) {
+    return std::nullopt;
+  }
+
+  const int64_t dq = chain.nq / h, dk = chain.nk / h, dv = chain.nv / h;
+  onnx::TensorProto* w_init = init_map.at(chain.weight);
+  const int64_t K = w_init->dims(0);
+  const int64_t total_n = w_init->dims(1);
+  std::vector<float> w = ReadFloatTensor(*w_init);  // [K, total_n] row-major.
+
+  std::vector<double> importance(static_cast<size_t>(h), 0.0);
+  for (int64_t hh = 0; hh < h; ++hh) {
+    double sq = 0.0;
+    for (int64_t r = 0; r < K; ++r) {
+      for (int64_t c = hh * dq; c < (hh + 1) * dq; ++c) {
+        const double v = w[static_cast<size_t>(r * total_n + c)];
+        sq += v * v;
+      }
+      for (int64_t c = chain.nq + hh * dk; c < chain.nq + (hh + 1) * dk; ++c) {
+        const double v = w[static_cast<size_t>(r * total_n + c)];
+        sq += v * v;
+      }
+      for (int64_t c = chain.nq + chain.nk + hh * dv;
+           c < chain.nq + chain.nk + (hh + 1) * dv; ++c) {
+        const double v = w[static_cast<size_t>(r * total_n + c)];
+        sq += v * v;
+      }
+    }
+    importance[static_cast<size_t>(hh)] = std::sqrt(sq);
+  }
+
+  std::vector<int64_t> keep_heads =
+      TopKIndicesAscending(importance, keep_count);
+  std::vector<int64_t> q_idx = HeadColumnIndices(keep_heads, dq);
+  std::vector<int64_t> k_idx = HeadColumnIndices(keep_heads, dk);
+  for (auto& x : k_idx) {
+    x += chain.nq;
+  }
+  std::vector<int64_t> v_idx_local = HeadColumnIndices(keep_heads, dv);
+  std::vector<int64_t> v_idx = v_idx_local;
+  for (auto& x : v_idx) {
+    x += chain.nq + chain.nk;
+  }
+  std::vector<int64_t> all_idx;
+  all_idx.reserve(q_idx.size() + k_idx.size() + v_idx.size());
+  all_idx.insert(all_idx.end(), q_idx.begin(), q_idx.end());
+  all_idx.insert(all_idx.end(), k_idx.begin(), k_idx.end());
+  all_idx.insert(all_idx.end(), v_idx.begin(), v_idx.end());
+
+  std::vector<float> sliced_w = SliceAxis1(w, K, total_n, 1, all_idx);
+  SetFloatTensorData(w_init, {K, static_cast<int64_t>(all_idx.size())},
+                     sliced_w);
+  if (chain.bias) {
+    SliceLastAxis(init_map.at(*chain.bias), all_idx);
+  }
+
+  bool found_qkv = false;
+  for (auto& attr : *chain.node->mutable_attribute()) {
+    if (attr.name() == "num_heads") {
+      attr.set_i(keep_count);
+    } else if (attr.name() == "qkv_hidden_sizes") {
+      found_qkv = true;
+      attr.clear_ints();
+      attr.add_ints(keep_count * dq);
+      attr.add_ints(keep_count * dk);
+      attr.add_ints(keep_count * dv);
+    }
+  }
+  if (!found_qkv) {
+    onnx::AttributeProto* attr = chain.node->add_attribute();
+    attr->set_name("qkv_hidden_sizes");
+    attr->set_type(onnx::AttributeProto::INTS);
+    attr->add_ints(keep_count * dq);
+    attr->add_ints(keep_count * dk);
+    attr->add_ints(keep_count * dv);
+  }
+
+  SliceConsumerWeight(init_map.at(chain.consumer_weight),
+                      chain.consumer_weight_transposed, v_idx_local, false);
+
+  for (const auto& co : chain.chain_ops) {
+    if (co.shape_name) {
+      SetInt64TensorLastDim(init_map.at(*co.shape_name), keep_count * dv);
+    }
+  }
+
+  AppliedAttn out;
+  out.producer_weights = {chain.weight};
+  out.consumer_weight = chain.consumer_weight;
+  out.stale.insert(chain.node->output(0));
+  for (const auto& co : chain.chain_ops) {
+    out.stale.insert(co.node->output(0));
+  }
+  return out;
+}
+
+// Applies whole-KV-group pruning to one matched GroupQueryAttention or
+// plain ai.onnx::Attention block in place -- mirrors pruning.py's own
+// _apply_one_gqa_chain (data-free/magnitude importance only).
+std::optional<AppliedAttn> ApplyOneGqaChain(
+    std::unordered_map<std::string, onnx::TensorProto*>& init_map,
+    AttnChain& chain, double sparsity) {
+  const int64_t h = chain.kv_num_heads;
+  const int64_t keep_count =
+      std::max<int64_t>(1, h - std::llround(static_cast<double>(h) * sparsity));
+  if (keep_count >= h) {
+    return std::nullopt;
+  }
+
+  const int64_t d = chain.head_size;
+  const int64_t group_size = chain.num_heads / chain.kv_num_heads;
+
+  onnx::TensorProto* wq_init = init_map.at(chain.q_weight);
+  onnx::TensorProto* wk_init = init_map.at(chain.k_weight);
+  onnx::TensorProto* wv_init = init_map.at(chain.v_weight);
+  const std::vector<int64_t> wq_dims(wq_init->dims().begin(),
+                                     wq_init->dims().end());
+  const std::vector<int64_t> wk_dims(wk_init->dims().begin(),
+                                     wk_init->dims().end());
+  const std::vector<int64_t> wv_dims(wv_init->dims().begin(),
+                                     wv_init->dims().end());
+  std::vector<float> wq = ReadFloatTensor(*wq_init);
+  std::vector<float> wk = ReadFloatTensor(*wk_init);
+  std::vector<float> wv = ReadFloatTensor(*wv_init);
+
+  // Bring each to [K, N] (reduction dim first, head columns last) -- the
+  // *opposite* of SliceProducerWeight's "output channel first" convention,
+  // matching pruning.py's own comment on this same transpose.
+  const int64_t K = wq_dims[chain.q_weight_transposed ? 1 : 0];
+  const int64_t Nq = wq_dims[chain.q_weight_transposed ? 0 : 1];
+  const int64_t Nk = wk_dims[chain.k_weight_transposed ? 0 : 1];
+  const int64_t Nv = wv_dims[chain.v_weight_transposed ? 0 : 1];
+  std::vector<float> wq_kn = chain.q_weight_transposed
+                                 ? TransposeFlat(wq, wq_dims[0], wq_dims[1])
+                                 : wq;
+  std::vector<float> wk_kn = chain.k_weight_transposed
+                                 ? TransposeFlat(wk, wk_dims[0], wk_dims[1])
+                                 : wk;
+  std::vector<float> wv_kn = chain.v_weight_transposed
+                                 ? TransposeFlat(wv, wv_dims[0], wv_dims[1])
+                                 : wv;
+
+  std::vector<double> importance(static_cast<size_t>(chain.kv_num_heads), 0.0);
+  for (int64_t kv = 0; kv < chain.kv_num_heads; ++kv) {
+    double sq = 0.0;
+    for (int64_t r = 0; r < K; ++r) {
+      for (int64_t g = kv * group_size; g < (kv + 1) * group_size; ++g) {
+        for (int64_t c = g * d; c < (g + 1) * d; ++c) {
+          const double v = wq_kn[static_cast<size_t>(r * Nq + c)];
+          sq += v * v;
+        }
+      }
+      for (int64_t c = kv * d; c < (kv + 1) * d; ++c) {
+        const double v = wk_kn[static_cast<size_t>(r * Nk + c)];
+        sq += v * v;
+      }
+      for (int64_t c = kv * d; c < (kv + 1) * d; ++c) {
+        const double v = wv_kn[static_cast<size_t>(r * Nv + c)];
+        sq += v * v;
+      }
+    }
+    importance[static_cast<size_t>(kv)] = std::sqrt(sq);
+  }
+
+  std::vector<int64_t> keep_groups =
+      TopKIndicesAscending(importance, keep_count);
+  std::vector<int64_t> keep_q_heads;
+  keep_q_heads.reserve(keep_groups.size() * static_cast<size_t>(group_size));
+  for (int64_t g : keep_groups) {
+    for (int64_t hh = g * group_size; hh < (g + 1) * group_size; ++hh) {
+      keep_q_heads.push_back(hh);
+    }
+  }
+  std::vector<int64_t> q_idx = HeadColumnIndices(keep_q_heads, d);
+  std::vector<int64_t> kv_idx = HeadColumnIndices(keep_groups, d);
+
+  SliceProducerWeight(wq_init, chain.q_weight_transposed, q_idx, false);
+  SliceProducerWeight(wk_init, chain.k_weight_transposed, kv_idx, false);
+  SliceProducerWeight(wv_init, chain.v_weight_transposed, kv_idx, false);
+  if (chain.q_bias) {
+    SliceLastAxis(init_map.at(*chain.q_bias), q_idx);
+  }
+  if (chain.k_bias) {
+    SliceLastAxis(init_map.at(*chain.k_bias), kv_idx);
+  }
+  if (chain.v_bias) {
+    SliceLastAxis(init_map.at(*chain.v_bias), kv_idx);
+  }
+
+  const int64_t new_kv_num_heads = keep_count;
+  const int64_t new_num_heads = keep_count * group_size;
+  for (auto& attr : *chain.node->mutable_attribute()) {
+    if (attr.name() == chain.num_heads_attr) {
+      attr.set_i(new_num_heads);
+    } else if (attr.name() == "kv_num_heads") {
+      attr.set_i(new_kv_num_heads);
+    }
+  }
+
+  SliceConsumerWeight(init_map.at(chain.consumer_weight),
+                      chain.consumer_weight_transposed, q_idx, false);
+
+  for (const auto& co : chain.chain_ops) {
+    if (co.shape_name) {
+      SetInt64TensorLastDim(init_map.at(*co.shape_name), new_num_heads * d);
+    }
+  }
+
+  AppliedAttn out;
+  out.producer_weights = {chain.q_weight, chain.k_weight, chain.v_weight};
+  out.consumer_weight = chain.consumer_weight;
+  out.stale.insert(chain.node->output(0));
+  for (const auto& co : chain.chain_ops) {
+    out.stale.insert(co.node->output(0));
+  }
+  return out;
+}
+
+// Shared body dispatching each chain to ApplyOnePlainAttentionChain or
+// ApplyOneGqaChain, mirroring pruning.py's own _apply_attention_chains
+// (cross-chain touched-role bookkeeping, stale value_info cleanup).
+void ApplyAttentionChains(onnx::GraphProto* graph,
+                          std::vector<AttnChain>& chains, double sparsity) {
+  std::unordered_map<std::string, onnx::TensorProto*> init_map;
+  for (int i = 0; i < graph->initializer_size(); ++i) {
+    onnx::TensorProto* t = graph->mutable_initializer(i);
+    init_map[t->name()] = t;
+  }
+  std::unordered_set<std::string> producer_touched, consumer_touched,
+      stale_value_info;
+
+  for (auto& chain : chains) {
+    std::unordered_set<std::string> producer_names =
+        chain.kind == AttnChainKind::kGqaLike
+            ? std::unordered_set<std::string>{chain.q_weight, chain.k_weight,
+                                              chain.v_weight}
+            : std::unordered_set<std::string>{chain.weight};
+
+    bool conflict = consumer_touched.count(chain.consumer_weight) != 0;
+    for (const auto& w : producer_names) {
+      if (producer_touched.count(w)) {
+        conflict = true;
+      }
+    }
+    if (conflict) {
+      continue;
+    }
+
+    std::optional<AppliedAttn> applied =
+        chain.kind == AttnChainKind::kGqaLike
+            ? ApplyOneGqaChain(init_map, chain, sparsity)
+            : ApplyOnePlainAttentionChain(init_map, chain, sparsity);
+    if (!applied) {
+      continue;
+    }
+
+    for (const auto& w : applied->producer_weights) {
+      producer_touched.insert(w);
+    }
+    consumer_touched.insert(applied->consumer_weight);
+    for (const auto& s : applied->stale) {
+      stale_value_info.insert(s);
+    }
+  }
+
+  if (!stale_value_info.empty()) {
+    google::protobuf::RepeatedPtrField<onnx::ValueInfoProto> kept;
+    for (const auto& vi : graph->value_info()) {
+      if (!stale_value_info.count(vi.name())) {
+        *kept.Add() = vi;
+      }
+    }
+    graph->mutable_value_info()->Swap(&kept);
+  }
+}
+
 }  // namespace
 
 onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
@@ -1971,6 +2818,29 @@ onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
                 std::make_move_iterator(matmul_residual_chains.end()));
   if (!chains.empty()) {
     ApplyChains(graph, chains, sparsity);
+  }
+  return out;
+}
+
+onnx::ModelProto ApplyAttentionHeadPruning(const onnx::ModelProto& model,
+                                           double sparsity) {
+  if (!(sparsity >= 0.0 && sparsity < 1.0)) {
+    throw std::invalid_argument(
+        "ApplyAttentionHeadPruning: sparsity must be in [0, 1), got " +
+        std::to_string(sparsity));
+  }
+  onnx::ModelProto out = model;
+  onnx::GraphProto* graph = out.mutable_graph();
+
+  std::vector<AttnChain> chains = FindAttentionChains(graph);
+  std::vector<AttnChain> gqa_chains = FindGqaChains(graph);
+  std::vector<AttnChain> onnx_attn_chains = FindOnnxAttentionChains(graph);
+  chains.insert(chains.end(), std::make_move_iterator(gqa_chains.begin()),
+                std::make_move_iterator(gqa_chains.end()));
+  chains.insert(chains.end(), std::make_move_iterator(onnx_attn_chains.begin()),
+                std::make_move_iterator(onnx_attn_chains.end()));
+  if (!chains.empty()) {
+    ApplyAttentionChains(graph, chains, sparsity);
   }
   return out;
 }

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -1,0 +1,999 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// C++ port of pruning.py's own apply_structured_pruning -- see that
+// function's docstring for the full technique description (this is quoted
+// here only where it constrains scope). This port covers the two "plain
+// chain" topologies -- a MatMul/vanilla-Gemm producer -> consumer pair
+// (pruning.py's own _find_chains) and a Conv producer -> consumer pair,
+// including depthwise pass-through hops and general grouped Conv on either
+// side (_find_conv_chains) -- but not (yet) pruning.py's gated-FFN
+// (_find_gated_chains) or residual/skip-connection (_find_conv_residual_chains,
+// _find_matmul_residual_chains) chain finders: those need the same backward-
+// walk/union-find machinery as the forward walk here, layered on top, and
+// are left to the pure-Python implementation for now. A model whose only
+// prunable structure is one of those unported shapes is therefore left
+// completely untouched by this port -- exactly the same "declined, not
+// guessed at" behavior pruning.py's own docstring promises for any topology
+// it doesn't recognize, just a larger set of them.
+//
+// Implemented directly on onnx::GraphProto (protobuf), not onnxoptimizer's
+// Node/Value IR: pruning.py's own algorithm already works this way (name-
+// keyed producer/consumer maps, forward hop-by-hop walks with an explicit
+// hop budget), and no new node is ever inserted or removed here -- only
+// existing initializers' *values* (and, for a depthwise Conv pass-through
+// hop, its own `group` attribute) are overwritten in place -- so there is no
+// need for onnxoptimizer's fixed-point pass-registration machinery
+// (function_rewriter.cpp already establishes this same "operate on
+// GraphProto directly" precedent in this codebase for an equally graph-
+// global algorithm).
+
+#include "structured_pruning_entry.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <numeric>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "dlpack_dtype.h"
+
+namespace {
+
+constexpr int kMaxChainHops = 8;
+
+// Shape-preserving, channel-order-preserving unary ops that may sit between
+// a producer and consumer without blocking the chain -- mirrors pruning.py's
+// own _UNARY_PASS_THROUGH exactly.
+const std::unordered_set<std::string>& UnaryPassThroughOps() {
+  static const std::unordered_set<std::string> kOps = {
+      "Relu", "LeakyRelu", "Elu",      "Selu", "Sigmoid",
+      "Tanh", "Softplus",  "Softsign", "Gelu", "HardSigmoid",
+      "Mish", "Identity",  "Cast",
+  };
+  return kOps;
+}
+
+// --- Tensor <-> flat float buffer, mirroring onnx.numpy_helper -------------
+
+std::vector<float> ReadFloatTensor(const onnx::TensorProto& t) {
+  int64_t numel = 1;
+  for (int64_t d : t.dims()) {
+    numel *= d;
+  }
+  std::vector<float> out(static_cast<size_t>(numel));
+  if (t.has_raw_data()) {
+    std::memcpy(out.data(), t.raw_data().data(), out.size() * sizeof(float));
+    if constexpr (!onnxsim::dlpack::kRawDataIsHostOrder) {
+      onnxsim::dlpack::SwapElementBytes(reinterpret_cast<uint8_t*>(out.data()),
+                                        out.size() * sizeof(float),
+                                        sizeof(float));
+    }
+  } else {
+    for (int64_t i = 0; i < numel; ++i) {
+      out[static_cast<size_t>(i)] = t.float_data(static_cast<int>(i));
+    }
+  }
+  return out;
+}
+
+// Overwrites `t` in place with a FLOAT tensor of `dims`/`data`, keeping its
+// existing name -- the same "replace, don't mutate a live view" convention
+// onnx.numpy_helper.from_array's own always-raw_data output gives
+// w_init.CopyFrom(...) in the Python reference.
+void SetFloatTensorData(onnx::TensorProto* t, const std::vector<int64_t>& dims,
+                        const std::vector<float>& data) {
+  const std::string name = t->name();
+  t->Clear();
+  t->set_name(name);
+  t->set_data_type(onnx::TensorProto::FLOAT);
+  for (int64_t d : dims) {
+    t->add_dims(d);
+  }
+  std::string raw(data.size() * sizeof(float), '\0');
+  std::memcpy(raw.data(), data.data(), raw.size());
+  if constexpr (!onnxsim::dlpack::kRawDataIsHostOrder) {
+    onnxsim::dlpack::SwapElementBytes(reinterpret_cast<uint8_t*>(raw.data()),
+                                      raw.size(), sizeof(float));
+  }
+  t->set_raw_data(std::move(raw));
+}
+
+int64_t ConvGroupAttr(const onnx::NodeProto& node) {
+  for (const auto& attr : node.attribute()) {
+    if (attr.name() == "group") {
+      return attr.i();
+    }
+  }
+  return 1;  // ONNX default.
+}
+
+void SetOrAddIntAttr(onnx::NodeProto* node, const std::string& name,
+                     int64_t value) {
+  for (auto& attr : *node->mutable_attribute()) {
+    if (attr.name() == name) {
+      attr.set_type(onnx::AttributeProto::INT);
+      attr.set_i(value);
+      return;
+    }
+  }
+  onnx::AttributeProto* attr = node->add_attribute();
+  attr->set_name(name);
+  attr->set_type(onnx::AttributeProto::INT);
+  attr->set_i(value);
+}
+
+// --- MatMul/vanilla-Gemm matching, mirroring pruning.py's own (imported
+// from smoothquant.py) _match_matmul_like -------------------------------
+
+struct MatMulLikeMatch {
+  std::string x_name;
+  std::string w_name;
+  bool weight_transposed;
+};
+
+std::optional<MatMulLikeMatch> MatchMatMulLikeRaw(const onnx::NodeProto& node) {
+  if (node.op_type() == "MatMul") {
+    if (node.input_size() != 2) {
+      return std::nullopt;
+    }
+    return MatMulLikeMatch{node.input(0), node.input(1), false};
+  }
+  if (node.op_type() == "Gemm") {
+    const int num_inputs = node.input_size();
+    if (num_inputs != 2 && num_inputs != 3) {
+      return std::nullopt;
+    }
+    bool has_trans_a = false, has_alpha = false, has_beta = false;
+    int64_t trans_a = 0, trans_b = 0;
+    double alpha = 1.0, beta = 1.0;
+    for (const auto& attr : node.attribute()) {
+      if (attr.name() == "transA") {
+        trans_a = attr.i();
+        has_trans_a = true;
+      } else if (attr.name() == "alpha") {
+        alpha = attr.f();
+        has_alpha = true;
+      } else if (attr.name() == "beta") {
+        beta = attr.f();
+        has_beta = true;
+      } else if (attr.name() == "transB") {
+        trans_b = attr.i();
+      }
+    }
+    if (has_trans_a && trans_a != 0) {
+      return std::nullopt;
+    }
+    if (has_alpha && alpha != 1.0) {
+      return std::nullopt;
+    }
+    if (num_inputs == 3 && has_beta && beta != 1.0) {
+      return std::nullopt;
+    }
+    return MatMulLikeMatch{node.input(0), node.input(1), trans_b != 0};
+  }
+  return std::nullopt;
+}
+
+using InitMap = std::unordered_map<std::string, const onnx::TensorProto*>;
+using ConsumerMap =
+    std::unordered_map<std::string, std::vector<onnx::NodeProto*>>;
+
+ConsumerMap ConsumersOf(onnx::GraphProto* graph) {
+  ConsumerMap out;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    for (const auto& inp : node->input()) {
+      if (!inp.empty()) {
+        out[inp].push_back(node);
+      }
+    }
+  }
+  return out;
+}
+
+size_t ConsumerCount(const ConsumerMap& consumers_of, const std::string& name) {
+  auto it = consumers_of.find(name);
+  return it == consumers_of.end() ? 0 : it->second.size();
+}
+
+// --- Chain data model, mirroring pruning.py's own _Producer/_ConvPassThrough/
+// _Chain dataclasses -------------------------------------------------------
+
+struct Producer {
+  onnx::NodeProto* node;
+  std::string weight;
+  bool weight_transposed;
+  std::optional<std::string> bias;
+  bool is_conv;
+  int64_t group;
+};
+
+struct ConvPassThrough {
+  onnx::NodeProto* node;
+  std::string weight;
+  std::optional<std::string> bias;
+};
+
+struct ChainOp {
+  onnx::NodeProto* node;
+  std::optional<std::string> const_name;
+};
+
+struct Chain {
+  std::vector<Producer> producers;
+  std::vector<ChainOp> chain_ops;
+  onnx::NodeProto* consumer_node;
+  std::string consumer_weight;
+  bool consumer_weight_transposed;
+  int64_t n_channels;
+  bool consumer_is_conv = false;
+  std::vector<ConvPassThrough> conv_pass_through;
+  int64_t consumer_group = 1;
+};
+
+// --- MatMul/Gemm plain chains, mirroring _match_producer/_walk_to_consumer/
+// _find_chains --------------------------------------------------------------
+
+struct ProducerMatch {
+  std::string weight;
+  bool weight_transposed;
+  std::optional<std::string> bias;
+  int64_t n_channels;
+};
+
+std::optional<ProducerMatch> MatchProducer(const onnx::NodeProto& node,
+                                           const InitMap& init_map) {
+  auto m = MatchMatMulLikeRaw(node);
+  if (!m) {
+    return std::nullopt;
+  }
+  auto it = init_map.find(m->w_name);
+  if (it == init_map.end() ||
+      it->second->data_type() != onnx::TensorProto::FLOAT ||
+      it->second->dims_size() != 2) {
+    return std::nullopt;
+  }
+  std::optional<std::string> bias;
+  if (node.op_type() == "Gemm" && node.input_size() == 3) {
+    bias = node.input(2);
+    if (!init_map.count(*bias)) {
+      return std::nullopt;  // non-constant bias -- can't safely prune it.
+    }
+  }
+  const onnx::TensorProto* w = it->second;
+  const int64_t n_channels = m->weight_transposed ? w->dims(0) : w->dims(1);
+  return ProducerMatch{m->w_name, m->weight_transposed, bias, n_channels};
+}
+
+struct ConsumerMatch {
+  onnx::NodeProto* node;
+  std::string weight;
+  bool weight_transposed;
+};
+
+std::pair<std::optional<ConsumerMatch>, std::vector<ChainOp>> WalkToConsumer(
+    const std::string& start, const InitMap& init_map,
+    const ConsumerMap& consumers_of,
+    const std::unordered_set<std::string>& graph_outputs, int64_t n_channels,
+    int max_hops) {
+  std::vector<ChainOp> chain_ops;
+  std::optional<ConsumerMatch> consumer;
+  std::string cur = start;
+  for (int hop = 0; hop < max_hops; ++hop) {
+    auto cit = consumers_of.find(cur);
+    if (cit == consumers_of.end() || cit->second.size() != 1) {
+      break;
+    }
+    onnx::NodeProto* nxt = cit->second[0];
+
+    auto cm = MatchMatMulLikeRaw(*nxt);
+    if (cm && cm->x_name == cur) {
+      auto wit = init_map.find(cm->w_name);
+      if (wit != init_map.end() &&
+          wit->second->data_type() == onnx::TensorProto::FLOAT &&
+          wit->second->dims_size() == 2) {
+        const int64_t k =
+            cm->weight_transposed ? wit->second->dims(1) : wit->second->dims(0);
+        if (k == n_channels) {
+          consumer = ConsumerMatch{nxt, cm->w_name, cm->weight_transposed};
+        }
+      }
+      break;
+    }
+
+    const bool is_unary = UnaryPassThroughOps().count(nxt->op_type()) != 0 &&
+                          nxt->input_size() == 1 && nxt->input(0) == cur &&
+                          nxt->output_size() == 1;
+    std::optional<std::string> const_name;
+    if (is_unary) {
+      // No constant operand.
+    } else if ((nxt->op_type() == "Add" || nxt->op_type() == "Mul") &&
+               nxt->input_size() == 2 && nxt->output_size() == 1 &&
+               (nxt->input(0) == cur || nxt->input(1) == cur)) {
+      const std::string& other =
+          (nxt->input(0) == cur) ? nxt->input(1) : nxt->input(0);
+      auto oit = init_map.find(other);
+      bool valid = false;
+      if (oit != init_map.end()) {
+        const onnx::TensorProto* c = oit->second;
+        int64_t prod = 1;
+        for (int64_t d : c->dims()) {
+          prod *= d;
+        }
+        valid = c->data_type() == onnx::TensorProto::FLOAT &&
+                c->dims_size() > 0 &&
+                c->dims(c->dims_size() - 1) == n_channels && prod == n_channels;
+      }
+      if (!valid) {
+        break;
+      }
+      const_name = other;
+    } else {
+      break;
+    }
+
+    const std::string& out2 = nxt->output(0);
+    if (ConsumerCount(consumers_of, out2) != 1 || graph_outputs.count(out2)) {
+      break;
+    }
+    chain_ops.push_back(ChainOp{nxt, const_name});
+    cur = out2;
+  }
+  return {consumer, chain_ops};
+}
+
+std::vector<Chain> FindChains(onnx::GraphProto* graph) {
+  InitMap init_map;
+  for (const auto& t : graph->initializer()) {
+    init_map[t.name()] = &t;
+  }
+  ConsumerMap consumers_of = ConsumersOf(graph);
+  std::unordered_set<std::string> graph_outputs;
+  for (const auto& o : graph->output()) {
+    graph_outputs.insert(o.name());
+  }
+  auto is_internal = [&](const std::string& name) {
+    return ConsumerCount(consumers_of, name) == 1 && !graph_outputs.count(name);
+  };
+
+  std::vector<Chain> chains;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    auto info = MatchProducer(*node, init_map);
+    if (!info) {
+      continue;
+    }
+    const std::string& out_name = node->output(0);
+    if (!is_internal(out_name)) {
+      continue;
+    }
+    auto [consumer, chain_ops] =
+        WalkToConsumer(out_name, init_map, consumers_of, graph_outputs,
+                       info->n_channels, kMaxChainHops);
+    if (!consumer) {
+      continue;
+    }
+    Chain chain;
+    chain.producers.push_back(Producer{
+        node, info->weight, info->weight_transposed, info->bias, false, 1});
+    chain.chain_ops = std::move(chain_ops);
+    chain.consumer_node = consumer->node;
+    chain.consumer_weight = consumer->weight;
+    chain.consumer_weight_transposed = consumer->weight_transposed;
+    chain.n_channels = info->n_channels;
+    chains.push_back(std::move(chain));
+  }
+  return chains;
+}
+
+// --- Conv plain chains, mirroring _match_conv_producer/_match_conv_consumer/
+// _match_depthwise_conv_pass_through/_walk_to_conv_consumer/_find_conv_chains
+
+struct ConvProducerMatch {
+  std::string weight;
+  std::optional<std::string> bias;
+  int64_t out_channels;
+  int64_t group;
+};
+
+std::optional<ConvProducerMatch> MatchConvProducer(const onnx::NodeProto& node,
+                                                   const InitMap& init_map) {
+  if (node.op_type() != "Conv" || node.input_size() < 2) {
+    return std::nullopt;
+  }
+  auto it = init_map.find(node.input(1));
+  if (it == init_map.end() ||
+      it->second->data_type() != onnx::TensorProto::FLOAT ||
+      it->second->dims_size() != 4) {
+    return std::nullopt;
+  }
+  const onnx::TensorProto* w = it->second;
+  const int64_t group = ConvGroupAttr(node);
+  if (group < 1) {
+    return std::nullopt;
+  }
+  const int64_t out_channels = w->dims(0);
+  const int64_t in_channels = w->dims(1) * group;
+  if (group > 1 && (group >= in_channels || group == out_channels ||
+                    out_channels % group != 0)) {
+    return std::nullopt;
+  }
+  std::optional<std::string> bias;
+  if (node.input_size() == 3 && !node.input(2).empty()) {
+    bias = node.input(2);
+    if (!init_map.count(*bias)) {
+      return std::nullopt;
+    }
+  }
+  return ConvProducerMatch{node.input(1), bias, out_channels, group};
+}
+
+struct ConvConsumerMatch {
+  std::string weight;
+  int64_t in_channels;
+  int64_t group;
+};
+
+std::optional<ConvConsumerMatch> MatchConvConsumer(const onnx::NodeProto& node,
+                                                   const InitMap& init_map) {
+  if (node.op_type() != "Conv" || node.input_size() < 2) {
+    return std::nullopt;
+  }
+  auto it = init_map.find(node.input(1));
+  if (it == init_map.end() ||
+      it->second->data_type() != onnx::TensorProto::FLOAT ||
+      it->second->dims_size() != 4) {
+    return std::nullopt;
+  }
+  const onnx::TensorProto* w = it->second;
+  const int64_t group = ConvGroupAttr(node);
+  if (group < 1) {
+    return std::nullopt;
+  }
+  const int64_t out_channels = w->dims(0);
+  const int64_t in_channels = w->dims(1) * group;
+  if (group > 1 && (group >= in_channels || group == out_channels ||
+                    out_channels % group != 0)) {
+    return std::nullopt;
+  }
+  return ConvConsumerMatch{node.input(1), in_channels, group};
+}
+
+struct DepthwiseMatch {
+  std::string weight;
+  std::optional<std::string> bias;
+};
+
+std::optional<DepthwiseMatch> MatchDepthwiseConvPassThrough(
+    const onnx::NodeProto& node, const InitMap& init_map, int64_t n_channels) {
+  if (node.op_type() != "Conv" || node.input_size() < 2) {
+    return std::nullopt;
+  }
+  auto it = init_map.find(node.input(1));
+  if (it == init_map.end()) {
+    return std::nullopt;
+  }
+  const onnx::TensorProto* w = it->second;
+  if (w->data_type() != onnx::TensorProto::FLOAT || w->dims_size() != 4 ||
+      w->dims(0) != n_channels || w->dims(1) != 1 ||
+      ConvGroupAttr(node) != n_channels) {
+    return std::nullopt;
+  }
+  std::optional<std::string> bias;
+  if (node.input_size() == 3 && !node.input(2).empty()) {
+    bias = node.input(2);
+    auto bit = init_map.find(*bias);
+    if (bit == init_map.end() ||
+        bit->second->data_type() != onnx::TensorProto::FLOAT) {
+      return std::nullopt;
+    }
+  }
+  return DepthwiseMatch{node.input(1), bias};
+}
+
+struct ConvConsumerResult {
+  onnx::NodeProto* node;
+  std::string weight;
+  int64_t group;
+};
+
+std::tuple<std::optional<ConvConsumerResult>, std::vector<ChainOp>,
+           std::vector<ConvPassThrough>>
+WalkToConvConsumer(const std::string& start, const InitMap& init_map,
+                   const ConsumerMap& consumers_of,
+                   const std::unordered_set<std::string>& graph_outputs,
+                   int64_t n_channels, int max_hops) {
+  std::vector<ChainOp> chain_ops;
+  std::vector<ConvPassThrough> pass_through;
+  std::optional<ConvConsumerResult> consumer;
+  std::string cur = start;
+  for (int hop = 0; hop < max_hops; ++hop) {
+    auto cit = consumers_of.find(cur);
+    if (cit == consumers_of.end() || cit->second.size() != 1) {
+      break;
+    }
+    onnx::NodeProto* nxt = cit->second[0];
+
+    if (nxt->op_type() == "Conv" && nxt->input(0) == cur) {
+      auto dw = MatchDepthwiseConvPassThrough(*nxt, init_map, n_channels);
+      if (dw) {
+        const std::string& out2 = nxt->output(0);
+        if (ConsumerCount(consumers_of, out2) != 1 ||
+            graph_outputs.count(out2)) {
+          break;
+        }
+        pass_through.push_back(ConvPassThrough{nxt, dw->weight, dw->bias});
+        cur = out2;
+        continue;
+      }
+      auto match = MatchConvConsumer(*nxt, init_map);
+      if (match && match->in_channels == n_channels) {
+        consumer = ConvConsumerResult{nxt, match->weight, match->group};
+      }
+      break;
+    }
+
+    if (!(UnaryPassThroughOps().count(nxt->op_type()) != 0 &&
+          nxt->input_size() == 1 && nxt->input(0) == cur &&
+          nxt->output_size() == 1)) {
+      break;
+    }
+    const std::string& out2 = nxt->output(0);
+    if (ConsumerCount(consumers_of, out2) != 1 || graph_outputs.count(out2)) {
+      break;
+    }
+    chain_ops.push_back(ChainOp{nxt, std::nullopt});
+    cur = out2;
+  }
+  return {consumer, chain_ops, pass_through};
+}
+
+std::vector<Chain> FindConvChains(onnx::GraphProto* graph) {
+  InitMap init_map;
+  for (const auto& t : graph->initializer()) {
+    init_map[t.name()] = &t;
+  }
+  ConsumerMap consumers_of = ConsumersOf(graph);
+  std::unordered_set<std::string> graph_outputs;
+  for (const auto& o : graph->output()) {
+    graph_outputs.insert(o.name());
+  }
+  auto is_internal = [&](const std::string& name) {
+    return ConsumerCount(consumers_of, name) == 1 && !graph_outputs.count(name);
+  };
+
+  std::vector<Chain> chains;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    auto info = MatchConvProducer(*node, init_map);
+    if (!info) {
+      continue;
+    }
+    const std::string& out_name = node->output(0);
+    if (!is_internal(out_name)) {
+      continue;
+    }
+    auto [consumer, chain_ops, pass_through] =
+        WalkToConvConsumer(out_name, init_map, consumers_of, graph_outputs,
+                           info->out_channels, kMaxChainHops);
+    if (!consumer) {
+      continue;
+    }
+    if (info->group > 1 && consumer->group > 1 &&
+        info->group != consumer->group) {
+      continue;  // Both sides grouped with mismatched group counts: declined.
+    }
+
+    Chain chain;
+    chain.producers.push_back(
+        Producer{node, info->weight, false, info->bias, true, info->group});
+    chain.chain_ops = std::move(chain_ops);
+    chain.consumer_node = consumer->node;
+    chain.consumer_weight = consumer->weight;
+    chain.consumer_weight_transposed = false;
+    chain.n_channels = info->out_channels;
+    chain.consumer_is_conv = true;
+    chain.conv_pass_through = std::move(pass_through);
+    chain.consumer_group = consumer->group;
+    chains.push_back(std::move(chain));
+  }
+  return chains;
+}
+
+int64_t ChainGroup(const Chain& chain) {
+  if (chain.producers.size() == 1 && chain.producers[0].group > 1) {
+    return chain.producers[0].group;
+  }
+  return chain.consumer_group;
+}
+
+// --- Slicing, mirroring _slice_producer_weight/_slice_consumer_weight/
+// _slice_grouped_consumer_conv_weight/_slice_last_axis ----------------------
+
+// Keeps only rows in `keep` of a [rows, inner] row-major matrix.
+std::vector<float> SliceAxis0(const std::vector<float>& data, int64_t /*rows*/,
+                              int64_t inner, const std::vector<int64_t>& keep) {
+  std::vector<float> out(keep.size() * static_cast<size_t>(inner));
+  for (size_t i = 0; i < keep.size(); ++i) {
+    std::memcpy(out.data() + i * inner, data.data() + keep[i] * inner,
+                static_cast<size_t>(inner) * sizeof(float));
+  }
+  return out;
+}
+
+// Keeps only columns in `keep` of a [dim0, dim1, inner] row-major tensor
+// (axis 1 sliced; `inner` is the flattened size of every trailing axis).
+std::vector<float> SliceAxis1(const std::vector<float>& data, int64_t dim0,
+                              int64_t dim1, int64_t inner,
+                              const std::vector<int64_t>& keep) {
+  std::vector<float> out(static_cast<size_t>(dim0) * keep.size() *
+                         static_cast<size_t>(inner));
+  for (int64_t i = 0; i < dim0; ++i) {
+    for (size_t j = 0; j < keep.size(); ++j) {
+      std::memcpy(
+          out.data() + (static_cast<size_t>(i) * keep.size() + j) * inner,
+          data.data() + (i * dim1 + keep[j]) * inner,
+          static_cast<size_t>(inner) * sizeof(float));
+    }
+  }
+  return out;
+}
+
+void SliceProducerWeight(onnx::TensorProto* wt, bool weight_transposed,
+                         const std::vector<int64_t>& keep, bool is_conv) {
+  std::vector<int64_t> dims(wt->dims().begin(), wt->dims().end());
+  std::vector<float> data = ReadFloatTensor(*wt);
+  std::vector<float> out;
+  std::vector<int64_t> new_dims;
+  const int64_t kc = static_cast<int64_t>(keep.size());
+  if (is_conv) {
+    int64_t inner = 1;
+    for (size_t i = 1; i < dims.size(); ++i) {
+      inner *= dims[i];
+    }
+    out = SliceAxis0(data, dims[0], inner, keep);
+    new_dims = dims;
+    new_dims[0] = kc;
+  } else {
+    const int64_t dim0 = dims[0], dim1 = dims[1];
+    if (weight_transposed) {  // [N, K] -- output channel is axis 0.
+      out = SliceAxis0(data, dim0, dim1, keep);
+      new_dims = {kc, dim1};
+    } else {  // [K, N] -- output channel is axis 1.
+      out = SliceAxis1(data, dim0, dim1, 1, keep);
+      new_dims = {dim0, kc};
+    }
+  }
+  SetFloatTensorData(wt, new_dims, out);
+}
+
+void SliceConsumerWeight(onnx::TensorProto* wt, bool weight_transposed,
+                         const std::vector<int64_t>& keep, bool is_conv) {
+  std::vector<int64_t> dims(wt->dims().begin(), wt->dims().end());
+  std::vector<float> data = ReadFloatTensor(*wt);
+  std::vector<float> out;
+  std::vector<int64_t> new_dims;
+  const int64_t kc = static_cast<int64_t>(keep.size());
+  if (is_conv) {
+    int64_t inner = 1;
+    for (size_t i = 2; i < dims.size(); ++i) {
+      inner *= dims[i];
+    }
+    out = SliceAxis1(data, dims[0], dims[1], inner, keep);
+    new_dims = dims;
+    new_dims[1] = kc;
+  } else {
+    const int64_t dim0 = dims[0], dim1 = dims[1];
+    if (weight_transposed) {  // [N, K] -- reduction dim is axis 1.
+      out = SliceAxis1(data, dim0, dim1, 1, keep);
+      new_dims = {dim0, kc};
+    } else {  // [K, N] -- reduction dim is axis 0.
+      out = SliceAxis0(data, dim0, dim1, keep);
+      new_dims = {kc, dim1};
+    }
+  }
+  SetFloatTensorData(wt, new_dims, out);
+}
+
+// See pruning.py's own _slice_grouped_consumer_conv_weight for why a global
+// `keep` needs per-group-relative local translation here.
+void SliceGroupedConsumerConvWeight(onnx::TensorProto* wt,
+                                    const std::vector<int64_t>& keep,
+                                    int64_t group, int64_t n_channels) {
+  std::vector<int64_t> dims(wt->dims().begin(), wt->dims().end());
+  std::vector<float> data = ReadFloatTensor(*wt);
+  const int64_t out_channels = dims[0];
+  const int64_t in_per_group = dims[1];
+  int64_t inner = 1;
+  for (size_t i = 2; i < dims.size(); ++i) {
+    inner *= dims[i];
+  }
+  const int64_t out_per_group = out_channels / group;
+  const int64_t block = n_channels / group;
+
+  std::vector<std::vector<int64_t>> local_keeps(static_cast<size_t>(group));
+  for (int64_t k : keep) {
+    const int64_t gi = k / block;
+    local_keeps[static_cast<size_t>(gi)].push_back(k - gi * block);
+  }
+
+  std::vector<float> out;
+  out.reserve(data.size());  // upper bound
+  for (int64_t gi = 0; gi < group; ++gi) {
+    const auto& lk = local_keeps[static_cast<size_t>(gi)];
+    const int64_t filt_lo = gi * out_per_group;
+    for (int64_t r = filt_lo; r < filt_lo + out_per_group; ++r) {
+      for (int64_t local : lk) {
+        const float* src = data.data() + (r * in_per_group + local) * inner;
+        out.insert(out.end(), src, src + inner);
+      }
+    }
+  }
+  std::vector<int64_t> new_dims = dims;
+  new_dims[1] = static_cast<int64_t>(keep.size()) / group;
+  SetFloatTensorData(wt, new_dims, out);
+}
+
+void SliceLastAxis(onnx::TensorProto* t, const std::vector<int64_t>& keep) {
+  std::vector<int64_t> dims(t->dims().begin(), t->dims().end());
+  std::vector<float> data = ReadFloatTensor(*t);
+  std::vector<float> out(keep.size());
+  for (size_t i = 0; i < keep.size(); ++i) {
+    out[i] = data[static_cast<size_t>(keep[i])];
+  }
+  std::vector<int64_t> new_dims = dims;
+  if (new_dims.empty()) {
+    new_dims.push_back(static_cast<int64_t>(keep.size()));
+  } else {
+    new_dims.back() = static_cast<int64_t>(keep.size());
+  }
+  SetFloatTensorData(t, new_dims, out);
+}
+
+// Selects the `keep_count` highest-`importance` indices, returned sorted
+// ascending -- mirrors np.sort(np.argsort(-importance)[:keep_count]) (tie-
+// breaking among exactly-equal importances may differ from numpy's own
+// argsort, same caveat as magnitude_pruning.h's SparsityMaskRowMajor).
+std::vector<int64_t> TopKIndicesAscending(const std::vector<double>& importance,
+                                          int64_t keep_count) {
+  const int64_t n = static_cast<int64_t>(importance.size());
+  std::vector<int64_t> idx(static_cast<size_t>(n));
+  std::iota(idx.begin(), idx.end(), int64_t{0});
+  std::partial_sort(
+      idx.begin(), idx.begin() + keep_count, idx.end(),
+      [&](int64_t a, int64_t b) { return importance[a] > importance[b]; });
+  idx.resize(static_cast<size_t>(keep_count));
+  std::sort(idx.begin(), idx.end());
+  return idx;
+}
+
+// Transposes a [dim0, dim1] row-major matrix into [dim1, dim0].
+std::vector<float> TransposeFlat(const std::vector<float>& data, int64_t dim0,
+                                 int64_t dim1) {
+  std::vector<float> out(data.size());
+  for (int64_t i = 0; i < dim0; ++i) {
+    for (int64_t j = 0; j < dim1; ++j) {
+      out[static_cast<size_t>(j * dim0 + i)] =
+          data[static_cast<size_t>(i * dim1 + j)];
+    }
+  }
+  return out;
+}
+
+// --- Shared apply body, mirroring _apply_chains -----------------------------
+
+void ApplyChains(onnx::GraphProto* graph, std::vector<Chain>& chains,
+                 double sparsity) {
+  std::unordered_map<std::string, onnx::TensorProto*> init_map;
+  for (int i = 0; i < graph->initializer_size(); ++i) {
+    onnx::TensorProto* t = graph->mutable_initializer(i);
+    init_map[t->name()] = t;
+  }
+
+  std::unordered_set<std::string> producer_touched, consumer_touched,
+      const_touched, conv_hop_touched, stale_value_info;
+
+  for (auto& chain : chains) {
+    std::unordered_set<std::string> producer_weights;
+    bool degenerate = false;
+    for (const auto& p : chain.producers) {
+      if (!producer_weights.insert(p.weight).second) {
+        degenerate = true;
+        break;
+      }
+    }
+    if (degenerate) {
+      continue;
+    }
+    std::unordered_set<std::string> conv_hop_weights;
+    for (const auto& h : chain.conv_pass_through) {
+      if (!conv_hop_weights.insert(h.weight).second) {
+        degenerate = true;
+        break;
+      }
+    }
+    if (degenerate) {
+      continue;
+    }
+
+    std::unordered_set<std::string> consts;
+    for (const auto& p : chain.producers) {
+      if (p.bias) {
+        consts.insert(*p.bias);
+      }
+    }
+    for (const auto& co : chain.chain_ops) {
+      if (co.const_name) {
+        consts.insert(*co.const_name);
+      }
+    }
+
+    bool conflict = consumer_touched.count(chain.consumer_weight) != 0;
+    for (const auto& w : producer_weights) {
+      if (producer_touched.count(w)) {
+        conflict = true;
+      }
+    }
+    for (const auto& c : consts) {
+      if (const_touched.count(c)) {
+        conflict = true;
+      }
+    }
+    for (const auto& w : conv_hop_weights) {
+      if (conv_hop_touched.count(w)) {
+        conflict = true;
+      }
+    }
+    if (conflict) {
+      continue;  // A shared/tied initializer another chain already resized.
+    }
+
+    const int64_t n = chain.n_channels;
+    const int64_t group = ChainGroup(chain);
+    int64_t keep_count, per_group_keep = 0, block = 0;
+    if (group > 1) {
+      block = n / group;
+      per_group_keep = std::max<int64_t>(
+          1, std::llround(static_cast<double>(block) * (1.0 - sparsity)));
+      keep_count = per_group_keep * group;
+    } else {
+      keep_count = std::max<int64_t>(
+          1, n - std::llround(static_cast<double>(n) * sparsity));
+    }
+    if (keep_count >= n) {
+      continue;  // Rounds down to nothing for this layer -- no-op.
+    }
+
+    std::vector<std::vector<float>> w_arrays_nk;
+    for (const auto& p : chain.producers) {
+      onnx::TensorProto* wt = init_map.at(p.weight);
+      std::vector<int64_t> dims(wt->dims().begin(), wt->dims().end());
+      std::vector<float> data = ReadFloatTensor(*wt);
+      if (p.is_conv) {
+        w_arrays_nk.push_back(
+            std::move(data));  // Already [Cout, rest] flattened.
+      } else if (p.weight_transposed) {
+        w_arrays_nk.push_back(std::move(data));  // Already [N, K].
+      } else {
+        w_arrays_nk.push_back(
+            TransposeFlat(data, dims[0], dims[1]));  // [K,N] -> [N,K].
+      }
+    }
+
+    std::vector<double> importance(static_cast<size_t>(n), 0.0);
+    for (const auto& w_nk : w_arrays_nk) {
+      const int64_t k = static_cast<int64_t>(w_nk.size()) / n;
+      for (int64_t c = 0; c < n; ++c) {
+        double sq = 0.0;
+        for (int64_t j = 0; j < k; ++j) {
+          const double v = w_nk[static_cast<size_t>(c * k + j)];
+          sq += v * v;
+        }
+        importance[static_cast<size_t>(c)] += sq;
+      }
+    }
+    for (double& v : importance) {
+      v = std::sqrt(v);
+    }
+
+    std::vector<int64_t> keep;
+    if (group > 1) {
+      keep.reserve(static_cast<size_t>(keep_count));
+      for (int64_t gi = 0; gi < group; ++gi) {
+        std::vector<double> block_imp(importance.begin() + gi * block,
+                                      importance.begin() + (gi + 1) * block);
+        for (int64_t li : TopKIndicesAscending(block_imp, per_group_keep)) {
+          keep.push_back(li + gi * block);
+        }
+      }
+    } else {
+      keep = TopKIndicesAscending(importance, keep_count);
+    }
+
+    for (const auto& p : chain.producers) {
+      SliceProducerWeight(init_map.at(p.weight), p.weight_transposed, keep,
+                          p.is_conv);
+      if (p.bias) {
+        SliceLastAxis(init_map.at(*p.bias), keep);
+      }
+    }
+    for (const auto& co : chain.chain_ops) {
+      if (co.const_name) {
+        SliceLastAxis(init_map.at(*co.const_name), keep);
+      }
+    }
+    for (const auto& hop : chain.conv_pass_through) {
+      SliceProducerWeight(init_map.at(hop.weight), false, keep, true);
+      if (hop.bias) {
+        SliceLastAxis(init_map.at(*hop.bias), keep);
+      }
+      SetOrAddIntAttr(hop.node, "group", static_cast<int64_t>(keep.size()));
+    }
+    if (chain.consumer_is_conv && chain.consumer_group > 1) {
+      SliceGroupedConsumerConvWeight(init_map.at(chain.consumer_weight), keep,
+                                     chain.consumer_group, n);
+    } else {
+      SliceConsumerWeight(init_map.at(chain.consumer_weight),
+                          chain.consumer_weight_transposed, keep,
+                          chain.consumer_is_conv);
+    }
+
+    for (const auto& w : producer_weights) {
+      producer_touched.insert(w);
+    }
+    consumer_touched.insert(chain.consumer_weight);
+    for (const auto& c : consts) {
+      const_touched.insert(c);
+    }
+    for (const auto& w : conv_hop_weights) {
+      conv_hop_touched.insert(w);
+    }
+    for (const auto& p : chain.producers) {
+      stale_value_info.insert(p.node->output(0));
+    }
+    for (const auto& co : chain.chain_ops) {
+      stale_value_info.insert(co.node->output(0));
+    }
+    for (const auto& hop : chain.conv_pass_through) {
+      stale_value_info.insert(hop.node->output(0));
+    }
+  }
+
+  if (!stale_value_info.empty()) {
+    google::protobuf::RepeatedPtrField<onnx::ValueInfoProto> kept;
+    for (const auto& vi : graph->value_info()) {
+      if (!stale_value_info.count(vi.name())) {
+        *kept.Add() = vi;
+      }
+    }
+    graph->mutable_value_info()->Swap(&kept);
+  }
+}
+
+}  // namespace
+
+onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
+                                        double sparsity) {
+  if (!(sparsity >= 0.0 && sparsity < 1.0)) {
+    throw std::invalid_argument(
+        "ApplyStructuredPruning: sparsity must be in [0, 1), got " +
+        std::to_string(sparsity));
+  }
+  onnx::ModelProto out = model;
+  onnx::GraphProto* graph = out.mutable_graph();
+
+  std::vector<Chain> chains = FindChains(graph);
+  std::vector<Chain> conv_chains = FindConvChains(graph);
+  chains.insert(chains.end(), std::make_move_iterator(conv_chains.begin()),
+                std::make_move_iterator(conv_chains.end()));
+  if (!chains.empty()) {
+    ApplyChains(graph, chains, sparsity);
+  }
+  return out;
+}

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -13,24 +13,24 @@
 // general dependency-graph-grouping problem: a channel-preserving
 // `Add(a, b)` where both operands are non-constant forces whichever real
 // producer(s) feed `a`/`b` to be pruned to the same channel-index set. A
-// backward walk plus union-find grouping across such eligible Add merge
-// points (mirroring pruning.py's own _walk_conv_producer_backward/
+// backward walk plus union-find grouping across such eligible merge points
+// (mirroring pruning.py's own _walk_conv_producer_backward/
 // _find_conv_residual_chains and _walk_matmul_producer_backward/
 // _find_matmul_residual_chains) covers not just a single `Add(x, f(x))` but
 // a whole chain of such merges transitively sharing one spine channel
 // count; a group with any branch that fails to resolve, or whose leaf
 // producers disagree on channel count, is declined in its entirety, never
 // partially pruned -- the same conservative "no branch-following" boundary
-// every other chain finder here already holds. One piece of pruning.py's
-// own residual support is *not* ported here: recognizing a fused
-// com.microsoft::SkipLayerNormalization/SkipSimplifiedLayerNormalization
-// node (what onnxruntime's transformer optimizer collapses a bare residual
-// Add plus the following LayerNorm into) as an eligible merge point in its
-// own right -- see _match_matmul_residual_merge's own comment in
-// pruning.py for why that matters for a fully-optimized transformer. A
-// model whose residual connections have already been fused that way is
-// left untouched by this port's MatMul residual finder; the pure-Python
-// implementation remains the full-featured reference for that case.
+// every other chain finder here already holds. For MatMul/Gemm specifically,
+// a fused com.microsoft::SkipLayerNormalization/
+// SkipSimplifiedLayerNormalization node -- what onnxruntime's transformer
+// optimizer collapses a bare residual `Add` plus the following LayerNorm
+// into, and so what a fully-optimized transformer's residual connections
+// typically look like -- is also recognized as an eligible merge point
+// (mirroring pruning.py's own _match_matmul_residual_merge), its own
+// gamma/beta/bias constants riding along as a per-channel affine hop on the
+// resolved chain. Conv residual chains only ever see a bare `Add` -- there
+// is no Conv analogue of that fused op.
 //
 // Implemented directly on onnx::GraphProto (protobuf), not onnxoptimizer's
 // Node/Value IR: pruning.py's own algorithm already works this way (name-
@@ -1118,6 +1118,150 @@ std::vector<Chain> FindConvResidualChains(onnx::GraphProto* graph) {
 
 // --- MatMul/Gemm residual (Add-merged) chains, mirroring
 // _walk_matmul_producer_backward/_find_matmul_residual_chains ---------------
+//
+// A com.microsoft::SkipLayerNormalization/SkipSimplifiedLayerNormalization
+// node -- what onnxruntime's transformer optimizer fuses a bare residual Add
+// plus the following LayerNorm into -- is an eligible merge point too,
+// mirroring pruning.py's own _match_matmul_residual_merge: its first two
+// inputs (input/skip) play exactly the role Add's two operands do, while its
+// constant gamma/beta/bias inputs are a per-channel affine hop riding the
+// same node, folded into the resolved chain's own chain_ops as extra
+// (node, const_name) entries -- ApplyChains's existing per-hop constant
+// slicing picks them up with no changes of its own.
+
+constexpr char kSkipLayerNormDomain[] = "com.microsoft";
+
+bool IsSkipLayerNormOp(const onnx::NodeProto& node) {
+  return node.domain() == kSkipLayerNormDomain &&
+         (node.op_type() == "SkipLayerNormalization" ||
+          node.op_type() == "SkipSimplifiedLayerNormalization");
+}
+
+bool IsConstVec(const InitMap& init_map, const std::string& name) {
+  auto it = init_map.find(name);
+  if (it == init_map.end()) {
+    return false;
+  }
+  const onnx::TensorProto* t = it->second;
+  if (t->data_type() != onnx::TensorProto::FLOAT || t->dims_size() == 0) {
+    return false;
+  }
+  int64_t prod = 1;
+  for (int64_t d : t->dims()) {
+    prod *= d;
+  }
+  return prod == t->dims(t->dims_size() - 1);
+}
+
+struct SkipLayerNormConsts {
+  std::string gamma;
+  std::optional<std::string> beta;
+  std::optional<std::string> bias;
+};
+
+// If every constant input a SkipLayerNormalization/
+// SkipSimplifiedLayerNormalization `node` needs sliced -- gamma (input 2,
+// required), plus beta (input 3, SkipLayerNormalization only) and bias
+// (input 4, or input 3 for the simplified/RMSNorm variant) -- is present
+// exactly as the node's own input list says and, whenever present, a
+// constant float per-channel vector, returns their names. Declines on a
+// non-constant gamma, a present-but-non-constant beta/bias, or the same
+// tensor named for two of gamma/beta/bias at once (double-slicing it in
+// ApplyChains's own per-hop loop would corrupt it).
+std::optional<SkipLayerNormConsts> SkipLayerNormConstNames(
+    const onnx::NodeProto& node, const InitMap& init_map) {
+  const bool simplified = node.op_type() == "SkipSimplifiedLayerNormalization";
+  if (node.input_size() < 3 || node.input(2).empty() ||
+      !IsConstVec(init_map, node.input(2))) {
+    return std::nullopt;  // gamma is required.
+  }
+  const std::string gamma_name = node.input(2);
+
+  std::optional<std::string> beta_name;
+  int bias_idx = 3;
+  if (!simplified) {
+    bias_idx = 4;
+    if (node.input_size() > 3 && !node.input(3).empty()) {
+      if (!IsConstVec(init_map, node.input(3))) {
+        return std::nullopt;
+      }
+      beta_name = node.input(3);
+    }
+  }
+
+  std::optional<std::string> bias_name;
+  if (node.input_size() > bias_idx && !node.input(bias_idx).empty()) {
+    if (!IsConstVec(init_map, node.input(bias_idx))) {
+      return std::nullopt;
+    }
+    bias_name = node.input(bias_idx);
+  }
+
+  std::unordered_set<std::string> seen{gamma_name};
+  if (beta_name && !seen.insert(*beta_name).second) {
+    return std::nullopt;  // Tied gamma/beta -- double-slicing would corrupt it.
+  }
+  if (bias_name && !seen.insert(*bias_name).second) {
+    return std::nullopt;  // Tied gamma/bias or beta/bias.
+  }
+
+  return SkipLayerNormConsts{gamma_name, beta_name, bias_name};
+}
+
+struct ResidualMergeMatch {
+  std::string input_name;
+  std::string skip_name;
+  std::vector<ChainOp> extra_ops;
+};
+
+// The MatMul/Gemm residual finder's own eligible-merge-point check: `node`
+// is either a bare Add (IsEligibleAddMerge, with no extra chain_ops of its
+// own) or a SkipLayerNormalization-family node (see this section's own
+// comment above). Declines whenever any of the SkipLayerNorm-family node's
+// optional secondary outputs (mean/inv_std_var, training-only bookkeeping
+// onnxruntime's own CPU kernel never actually writes, or
+// input_skip_bias_sum, the raw pre-norm sum whose *shape* -- not
+// meaningfulness -- is at risk once input/skip are pruned to a different
+// width) are actually consumed by anything else in the graph.
+std::optional<ResidualMergeMatch> MatchResidualMerge(
+    onnx::NodeProto* node, const InitMap& init_map,
+    const ConsumerMap& consumers_of,
+    const std::unordered_set<std::string>& graph_outputs) {
+  if (IsEligibleAddMerge(*node, init_map)) {
+    return ResidualMergeMatch{node->input(0), node->input(1), {}};
+  }
+  if (!IsSkipLayerNormOp(*node) || node->input_size() < 3) {
+    return std::nullopt;
+  }
+  const std::string& input_name = node->input(0);
+  const std::string& skip_name = node->input(1);
+  if (input_name.empty() || skip_name.empty() || input_name == skip_name ||
+      init_map.count(input_name) || init_map.count(skip_name)) {
+    return std::nullopt;
+  }
+  auto consts = SkipLayerNormConstNames(*node, init_map);
+  if (!consts) {
+    return std::nullopt;
+  }
+  for (int out_idx : {1, 2, 3}) {  // mean, inv_std_var, input_skip_bias_sum.
+    if (node->output_size() > out_idx && !node->output(out_idx).empty()) {
+      const std::string& out_name = node->output(out_idx);
+      if (ConsumerCount(consumers_of, out_name) != 0 ||
+          graph_outputs.count(out_name)) {
+        return std::nullopt;
+      }
+    }
+  }
+  std::vector<ChainOp> extra_ops;
+  extra_ops.push_back(ChainOp{node, consts->gamma});
+  if (consts->beta) {
+    extra_ops.push_back(ChainOp{node, *consts->beta});
+  }
+  if (consts->bias) {
+    extra_ops.push_back(ChainOp{node, *consts->bias});
+  }
+  return ResidualMergeMatch{input_name, skip_name, std::move(extra_ops)};
+}
 
 // The backward counterpart of WalkToConsumer, used only by
 // FindMatmulResidualChains.
@@ -1201,7 +1345,7 @@ MatMulBackwardEdge WalkMatmulProducerBackward(
       // through to the merge check or "fail" is correct.
     }
 
-    if (IsEligibleAddMerge(*node, init_map)) {
+    if (MatchResidualMerge(node, init_map, consumers_of, graph_outputs)) {
       MatMulBackwardEdge edge;
       edge.kind = BackwardEdgeKind::kAdd;
       edge.add_node = node;
@@ -1217,9 +1361,12 @@ MatMulBackwardEdge WalkMatmulProducerBackward(
 
 // Finds MatMul/Gemm residual/skip-connection groups -- the MatMul/Gemm
 // analogue of FindConvResidualChains, over WalkMatmulProducerBackward
-// instead of WalkConvProducerBackward. See this section's own comment
-// above for the scope note (bare Add merge points only, not the fused
-// SkipLayerNormalization case pruning.py also recognizes).
+// instead of WalkConvProducerBackward. Every eligible merge point
+// (MatchResidualMerge -- a bare Add or a SkipLayerNormalization-family
+// node) contributes its own extra_ops (empty for Add; gamma/beta/bias for
+// the normalization-fused case) up front, before any union-find grouping,
+// so every member of a resolved group has its own per-channel constants
+// folded into the final chain the same way.
 std::vector<Chain> FindMatmulResidualChains(onnx::GraphProto* graph) {
   InitMap init_map;
   for (const auto& t : graph->initializer()) {
@@ -1241,11 +1388,21 @@ std::vector<Chain> FindMatmulResidualChains(onnx::GraphProto* graph) {
     }
   }
 
-  std::vector<onnx::NodeProto*> merges;
+  struct MergeInfo {
+    onnx::NodeProto* node;
+    std::string input_name;
+    std::string skip_name;
+    std::vector<ChainOp> extra_ops;
+  };
+  std::vector<MergeInfo> merges;
   for (int i = 0; i < graph->node_size(); ++i) {
     onnx::NodeProto* node = graph->mutable_node(i);
-    if (IsEligibleAddMerge(*node, init_map)) {
-      merges.push_back(node);
+    auto match =
+        MatchResidualMerge(node, init_map, consumers_of, graph_outputs);
+    if (match) {
+      merges.push_back(MergeInfo{node, std::move(match->input_name),
+                                 std::move(match->skip_name),
+                                 std::move(match->extra_ops)});
     }
   }
   if (merges.empty()) {
@@ -1253,7 +1410,7 @@ std::vector<Chain> FindMatmulResidualChains(onnx::GraphProto* graph) {
   }
   std::unordered_map<onnx::NodeProto*, int> merge_index;
   for (size_t i = 0; i < merges.size(); ++i) {
-    merge_index[merges[i]] = static_cast<int>(i);
+    merge_index[merges[i].node] = static_cast<int>(i);
   }
 
   std::vector<int> parent(merges.size());
@@ -1276,7 +1433,8 @@ std::vector<Chain> FindMatmulResidualChains(onnx::GraphProto* graph) {
   std::unordered_set<int> poisoned;
   for (size_t idx = 0; idx < merges.size(); ++idx) {
     std::vector<MatMulBackwardEdge> results;
-    for (const auto& operand : merges[idx]->input()) {
+    for (const auto& operand :
+         {merges[idx].input_name, merges[idx].skip_name}) {
       MatMulBackwardEdge edge = WalkMatmulProducerBackward(
           operand, node_by_output, init_map, consumers_of, graph_outputs,
           kMaxChainHops);
@@ -1321,6 +1479,9 @@ std::vector<Chain> FindMatmulResidualChains(onnx::GraphProto* graph) {
     std::unordered_set<int> referenced;
 
     for (int idx : members) {
+      pre_chain_ops.insert(pre_chain_ops.end(),
+                           merges[static_cast<size_t>(idx)].extra_ops.begin(),
+                           merges[static_cast<size_t>(idx)].extra_ops.end());
       for (auto& edge : edge_results[static_cast<size_t>(idx)]) {
         pre_chain_ops.insert(pre_chain_ops.end(), edge.chain_ops.begin(),
                              edge.chain_ops.end());
@@ -1361,7 +1522,7 @@ std::vector<Chain> FindMatmulResidualChains(onnx::GraphProto* graph) {
     if (sinks.size() != 1) {
       continue;  // Not a single linear chain of merges -- decline.
     }
-    onnx::NodeProto* sink_node = merges[static_cast<size_t>(sinks[0])];
+    onnx::NodeProto* sink_node = merges[static_cast<size_t>(sinks[0])].node;
 
     std::unordered_set<std::string> seen_weights;
     bool degenerate = false;
@@ -1390,7 +1551,7 @@ std::vector<Chain> FindMatmulResidualChains(onnx::GraphProto* graph) {
     std::vector<ChainOp> chain_ops = std::move(pre_chain_ops);
     for (int idx : members) {
       chain_ops.push_back(
-          ChainOp{merges[static_cast<size_t>(idx)], std::nullopt});
+          ChainOp{merges[static_cast<size_t>(idx)].node, std::nullopt});
     }
     for (auto& co : fwd_chain_ops) {
       chain_ops.push_back(std::move(co));

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -2,23 +2,35 @@
 //
 // C++ port of pruning.py's own apply_structured_pruning -- see that
 // function's docstring for the full technique description (this is quoted
-// here only where it constrains scope). This port covers three of
-// pruning.py's own five chain finders: a MatMul/vanilla-Gemm producer ->
+// here only where it constrains scope). This port covers all five of
+// pruning.py's own chain finders: a MatMul/vanilla-Gemm producer ->
 // consumer pair (_find_chains), a Conv producer -> consumer pair, including
 // depthwise pass-through hops and general grouped Conv on either side
-// (_find_conv_chains), and the gated-FFN SwiGLU/GeGLU pattern -- two
-// producers combined by Mul (or ONNX opset-28+'s native SwiGLU node) feeding
-// one consumer, both pruned to the same channel indices
-// (_find_gated_chains) -- but not (yet) the residual/skip-connection chain
-// finders (_find_conv_residual_chains, _find_matmul_residual_chains): those
-// need a backward walk plus union-find grouping across merge points, a
-// different (and larger) piece of machinery than the forward-only walk
-// every chain finder here uses, and are left to the pure-Python
-// implementation for now. A model whose only prunable structure is one of
-// those unported residual shapes is therefore left completely untouched by
-// this port -- exactly the same "declined, not guessed at" behavior
-// pruning.py's own docstring promises for any topology it doesn't
-// recognize, just a larger set of them.
+// (_find_conv_chains), the gated-FFN SwiGLU/GeGLU pattern -- two producers
+// combined by Mul (or ONNX opset-28+'s native SwiGLU node) feeding one
+// consumer, both pruned to the same channel indices (_find_gated_chains) --
+// and Conv/MatMul residual (skip-connection) chains, a bounded slice of the
+// general dependency-graph-grouping problem: a channel-preserving
+// `Add(a, b)` where both operands are non-constant forces whichever real
+// producer(s) feed `a`/`b` to be pruned to the same channel-index set. A
+// backward walk plus union-find grouping across such eligible Add merge
+// points (mirroring pruning.py's own _walk_conv_producer_backward/
+// _find_conv_residual_chains and _walk_matmul_producer_backward/
+// _find_matmul_residual_chains) covers not just a single `Add(x, f(x))` but
+// a whole chain of such merges transitively sharing one spine channel
+// count; a group with any branch that fails to resolve, or whose leaf
+// producers disagree on channel count, is declined in its entirety, never
+// partially pruned -- the same conservative "no branch-following" boundary
+// every other chain finder here already holds. One piece of pruning.py's
+// own residual support is *not* ported here: recognizing a fused
+// com.microsoft::SkipLayerNormalization/SkipSimplifiedLayerNormalization
+// node (what onnxruntime's transformer optimizer collapses a bare residual
+// Add plus the following LayerNorm into) as an eligible merge point in its
+// own right -- see _match_matmul_residual_merge's own comment in
+// pruning.py for why that matters for a fully-optimized transformer. A
+// model whose residual connections have already been fused that way is
+// left untouched by this port's MatMul residual finder; the pure-Python
+// implementation remains the full-featured reference for that case.
 //
 // Implemented directly on onnx::GraphProto (protobuf), not onnxoptimizer's
 // Node/Value IR: pruning.py's own algorithm already works this way (name-
@@ -36,6 +48,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#include <functional>
 #include <numeric>
 #include <optional>
 #include <stdexcept>
@@ -205,6 +218,16 @@ ConsumerMap ConsumersOf(onnx::GraphProto* graph) {
 size_t ConsumerCount(const ConsumerMap& consumers_of, const std::string& name) {
   auto it = consumers_of.find(name);
   return it == consumers_of.end() ? 0 : it->second.size();
+}
+
+// True for an `Add` node the residual-chain finders below may treat as a
+// merge point: exactly two distinct, non-constant operands. Mirrors
+// pruning.py's own _is_eligible_add_merge exactly -- not Conv- or
+// MatMul-specific, since it only inspects the node's own operands.
+bool IsEligibleAddMerge(const onnx::NodeProto& node, const InitMap& init_map) {
+  return node.op_type() == "Add" && node.input_size() == 2 &&
+         node.output_size() == 1 && node.input(0) != node.input(1) &&
+         !init_map.count(node.input(0)) && !init_map.count(node.input(1));
 }
 
 // --- Chain data model, mirroring pruning.py's own _Producer/_ConvPassThrough/
@@ -777,6 +800,614 @@ std::vector<Chain> FindConvChains(onnx::GraphProto* graph) {
   return chains;
 }
 
+// --- Residual (Add-merged) chains, mirroring _is_eligible_add_merge/
+// _walk_conv_producer_backward/_find_conv_residual_chains and
+// _walk_matmul_producer_backward/_find_matmul_residual_chains. Scope note:
+// this only recognizes a bare Add merge point, not pruning.py's own
+// com.microsoft::SkipLayerNormalization/SkipSimplifiedLayerNormalization
+// fusion (see _match_matmul_residual_merge's own comment in pruning.py) --
+// a model whose residual connections have already been fused into that op
+// by onnxruntime's transformer optimizer is left untouched by this port's
+// MatMul residual finder; the pure-Python implementation remains the
+// full-featured reference for that case.
+
+enum class BackwardEdgeKind { kFail, kProducer, kAdd };
+
+// The backward counterpart of WalkToConvConsumer, used only by
+// FindConvResidualChains to resolve one operand of an eligible Add merge
+// point back to whatever produces it.
+struct ConvBackwardEdge {
+  BackwardEdgeKind kind = BackwardEdgeKind::kFail;
+  Producer producer;
+  int64_t n_channels = 0;
+  onnx::NodeProto* add_node = nullptr;
+  std::vector<ConvPassThrough> pass_through;  // Forward order.
+  std::vector<onnx::NodeProto*> unary_ops;    // Forward order.
+};
+
+// The backward-walk analogue of MatchDepthwiseConvPassThrough: unlike that
+// matcher, which validates a hop against an externally supplied
+// n_channels, this checks the node's own weight is self-consistently
+// depthwise-shaped by calling it with the node's own dims(0) as the
+// "expected" count. FindConvResidualChains re-validates every such hop
+// against the group's real, established channel count once resolved.
+std::optional<DepthwiseMatch> MatchConvPassThroughSelf(
+    const onnx::NodeProto& node, const InitMap& init_map) {
+  if (node.op_type() != "Conv" || node.input_size() < 2) {
+    return std::nullopt;
+  }
+  auto it = init_map.find(node.input(1));
+  if (it == init_map.end() ||
+      it->second->data_type() != onnx::TensorProto::FLOAT ||
+      it->second->dims_size() != 4) {
+    return std::nullopt;
+  }
+  return MatchDepthwiseConvPassThrough(node, init_map, it->second->dims(0));
+}
+
+ConvBackwardEdge WalkConvProducerBackward(
+    const std::string& start,
+    const std::unordered_map<std::string, onnx::NodeProto*>& node_by_output,
+    const InitMap& init_map, const ConsumerMap& consumers_of,
+    const std::unordered_set<std::string>& graph_outputs, int max_hops) {
+  std::vector<ConvPassThrough> pass_through;  // Backward order.
+  std::vector<onnx::NodeProto*> unary_ops;    // Backward order.
+  std::string cur = start;
+  for (int hop = 0; hop < max_hops; ++hop) {
+    if (ConsumerCount(consumers_of, cur) != 1 || graph_outputs.count(cur)) {
+      return ConvBackwardEdge{};
+    }
+    auto nit = node_by_output.find(cur);
+    if (nit == node_by_output.end() || nit->second->output_size() != 1 ||
+        nit->second->output(0) != cur) {
+      return ConvBackwardEdge{};
+    }
+    onnx::NodeProto* node = nit->second;
+
+    auto prod_info = MatchConvProducer(*node, init_map);
+    if (prod_info) {
+      if (prod_info->group != 1) {
+        // General grouped Conv is out of scope for the residual/Add-merge
+        // case -- see WalkConvProducerBackward's Python counterpart.
+        return ConvBackwardEdge{};
+      }
+      ConvBackwardEdge edge;
+      edge.kind = BackwardEdgeKind::kProducer;
+      edge.producer =
+          Producer{node, prod_info->weight, false, prod_info->bias, true, 1};
+      edge.n_channels = prod_info->out_channels;
+      std::reverse(pass_through.begin(), pass_through.end());
+      std::reverse(unary_ops.begin(), unary_ops.end());
+      edge.pass_through = std::move(pass_through);
+      edge.unary_ops = std::move(unary_ops);
+      return edge;
+    }
+
+    auto dw = MatchConvPassThroughSelf(*node, init_map);
+    if (dw) {
+      pass_through.push_back(ConvPassThrough{node, dw->weight, dw->bias});
+      cur = node->input(0);
+      continue;
+    }
+
+    if (UnaryPassThroughOps().count(node->op_type()) != 0 &&
+        node->input_size() == 1) {
+      unary_ops.push_back(node);
+      cur = node->input(0);
+      continue;
+    }
+
+    if (IsEligibleAddMerge(*node, init_map)) {
+      ConvBackwardEdge edge;
+      edge.kind = BackwardEdgeKind::kAdd;
+      edge.add_node = node;
+      std::reverse(pass_through.begin(), pass_through.end());
+      std::reverse(unary_ops.begin(), unary_ops.end());
+      edge.pass_through = std::move(pass_through);
+      edge.unary_ops = std::move(unary_ops);
+      return edge;
+    }
+
+    return ConvBackwardEdge{};
+  }
+  return ConvBackwardEdge{};
+}
+
+// Finds Conv residual/skip-connection groups: for every maximal union-find
+// group of transitively-connected eligible Add merge points, resolves
+// every member's two operands via WalkConvProducerBackward. See this
+// section's own comment above and pruning.py's own
+// _find_conv_residual_chains for the full algorithm description.
+std::vector<Chain> FindConvResidualChains(onnx::GraphProto* graph) {
+  InitMap init_map;
+  for (const auto& t : graph->initializer()) {
+    init_map[t.name()] = &t;
+  }
+  ConsumerMap consumers_of = ConsumersOf(graph);
+  std::unordered_set<std::string> graph_outputs;
+  for (const auto& o : graph->output()) {
+    graph_outputs.insert(o.name());
+  }
+  auto is_internal = [&](const std::string& name) {
+    return ConsumerCount(consumers_of, name) == 1 && !graph_outputs.count(name);
+  };
+  std::unordered_map<std::string, onnx::NodeProto*> node_by_output;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    for (const auto& out : node->output()) {
+      node_by_output[out] = node;
+    }
+  }
+
+  std::vector<onnx::NodeProto*> eligible_adds;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    if (IsEligibleAddMerge(*node, init_map)) {
+      eligible_adds.push_back(node);
+    }
+  }
+  if (eligible_adds.empty()) {
+    return {};
+  }
+  std::unordered_map<onnx::NodeProto*, int> add_index;
+  for (size_t i = 0; i < eligible_adds.size(); ++i) {
+    add_index[eligible_adds[i]] = static_cast<int>(i);
+  }
+
+  std::vector<int> parent(eligible_adds.size());
+  std::iota(parent.begin(), parent.end(), 0);
+  std::function<int(int)> find = [&](int i) {
+    while (parent[i] != i) {
+      parent[i] = parent[parent[i]];
+      i = parent[i];
+    }
+    return i;
+  };
+  auto unite = [&](int i, int j) {
+    const int ri = find(i), rj = find(j);
+    if (ri != rj) {
+      parent[ri] = rj;
+    }
+  };
+
+  std::vector<std::vector<ConvBackwardEdge>> edge_results(eligible_adds.size());
+  std::unordered_set<int> poisoned;
+  for (size_t idx = 0; idx < eligible_adds.size(); ++idx) {
+    std::vector<ConvBackwardEdge> results;
+    for (const auto& operand : eligible_adds[idx]->input()) {
+      ConvBackwardEdge edge =
+          WalkConvProducerBackward(operand, node_by_output, init_map,
+                                   consumers_of, graph_outputs, kMaxChainHops);
+      if (edge.kind == BackwardEdgeKind::kFail) {
+        poisoned.insert(static_cast<int>(idx));
+      } else if (edge.kind == BackwardEdgeKind::kAdd) {
+        auto jit = add_index.find(edge.add_node);
+        if (jit == add_index.end()) {
+          poisoned.insert(
+              static_cast<int>(idx));  // Defensive -- shouldn't happen.
+        } else {
+          unite(static_cast<int>(idx), jit->second);
+        }
+      }
+      results.push_back(std::move(edge));
+    }
+    edge_results[idx] = std::move(results);
+  }
+
+  std::unordered_map<int, std::vector<int>> groups;
+  for (size_t idx = 0; idx < eligible_adds.size(); ++idx) {
+    groups[find(static_cast<int>(idx))].push_back(static_cast<int>(idx));
+  }
+
+  std::vector<Chain> chains;
+  for (auto& kv : groups) {
+    const std::vector<int>& members = kv.second;
+    bool any_poisoned = false;
+    for (int i : members) {
+      if (poisoned.count(i)) {
+        any_poisoned = true;
+        break;
+      }
+    }
+    if (any_poisoned) {
+      continue;
+    }
+
+    std::vector<Producer> leaf_producers;
+    std::unordered_set<int64_t> n_channels_set;
+    std::vector<ConvPassThrough> pass_through;
+    std::vector<onnx::NodeProto*> unary_ops;
+    std::unordered_set<int> referenced;
+
+    for (int idx : members) {
+      for (auto& edge : edge_results[static_cast<size_t>(idx)]) {
+        pass_through.insert(pass_through.end(), edge.pass_through.begin(),
+                            edge.pass_through.end());
+        unary_ops.insert(unary_ops.end(), edge.unary_ops.begin(),
+                         edge.unary_ops.end());
+        if (edge.kind == BackwardEdgeKind::kProducer) {
+          leaf_producers.push_back(edge.producer);
+          n_channels_set.insert(edge.n_channels);
+        } else if (edge.kind == BackwardEdgeKind::kAdd) {
+          referenced.insert(add_index[edge.add_node]);
+        }
+      }
+    }
+
+    if (n_channels_set.size() != 1) {
+      continue;  // Branches disagree on channel count -- decline.
+    }
+    const int64_t n_channels = *n_channels_set.begin();
+
+    bool dw_mismatch = false;
+    for (const auto& hop : pass_through) {
+      if (init_map.at(hop.weight)->dims(0) != n_channels) {
+        dw_mismatch = true;
+        break;
+      }
+    }
+    if (dw_mismatch) {
+      continue;
+    }
+
+    std::vector<int> sinks;
+    for (int idx : members) {
+      if (!referenced.count(idx)) {
+        sinks.push_back(idx);
+      }
+    }
+    if (sinks.size() != 1) {
+      continue;  // Not a single linear chain of merges -- decline.
+    }
+    onnx::NodeProto* sink_add = eligible_adds[static_cast<size_t>(sinks[0])];
+
+    std::unordered_set<std::string> seen_weights;
+    bool degenerate = false;
+    for (const auto& p : leaf_producers) {
+      if (!seen_weights.insert(p.weight).second) {
+        degenerate = true;
+        break;
+      }
+    }
+    if (degenerate) {
+      continue;  // The same producer named twice.
+    }
+
+    const std::string& sink_out = sink_add->output(0);
+    if (!is_internal(sink_out)) {
+      continue;
+    }
+
+    auto [consumer, fwd_chain_ops, fwd_pass_through] =
+        WalkToConvConsumer(sink_out, init_map, consumers_of, graph_outputs,
+                           n_channels, kMaxChainHops);
+    if (!consumer) {
+      continue;
+    }
+    if (consumer->group != 1) {
+      continue;
+    }
+
+    std::vector<ChainOp> chain_ops;
+    for (auto* op : unary_ops) {
+      chain_ops.push_back(ChainOp{op, std::nullopt});
+    }
+    for (int idx : members) {
+      chain_ops.push_back(
+          ChainOp{eligible_adds[static_cast<size_t>(idx)], std::nullopt});
+    }
+    for (auto& co : fwd_chain_ops) {
+      chain_ops.push_back(std::move(co));
+    }
+
+    Chain chain;
+    chain.producers = std::move(leaf_producers);
+    chain.chain_ops = std::move(chain_ops);
+    chain.consumer_node = consumer->node;
+    chain.consumer_weight = consumer->weight;
+    chain.consumer_weight_transposed = false;
+    chain.n_channels = n_channels;
+    chain.consumer_is_conv = true;
+    pass_through.insert(pass_through.end(), fwd_pass_through.begin(),
+                        fwd_pass_through.end());
+    chain.conv_pass_through = std::move(pass_through);
+    chains.push_back(std::move(chain));
+  }
+  return chains;
+}
+
+// --- MatMul/Gemm residual (Add-merged) chains, mirroring
+// _walk_matmul_producer_backward/_find_matmul_residual_chains ---------------
+
+// The backward counterpart of WalkToConsumer, used only by
+// FindMatmulResidualChains.
+struct MatMulBackwardEdge {
+  BackwardEdgeKind kind = BackwardEdgeKind::kFail;
+  Producer producer;
+  int64_t n_channels = 0;
+  onnx::NodeProto* add_node = nullptr;
+  std::vector<ChainOp> chain_ops;  // Forward order.
+};
+
+MatMulBackwardEdge WalkMatmulProducerBackward(
+    const std::string& start,
+    const std::unordered_map<std::string, onnx::NodeProto*>& node_by_output,
+    const InitMap& init_map, const ConsumerMap& consumers_of,
+    const std::unordered_set<std::string>& graph_outputs, int max_hops) {
+  std::vector<ChainOp> chain_ops;  // Backward order.
+  std::string cur = start;
+  for (int hop = 0; hop < max_hops; ++hop) {
+    if (ConsumerCount(consumers_of, cur) != 1 || graph_outputs.count(cur)) {
+      return MatMulBackwardEdge{};
+    }
+    auto nit = node_by_output.find(cur);
+    if (nit == node_by_output.end() || nit->second->output_size() == 0 ||
+        nit->second->output(0) != cur) {
+      return MatMulBackwardEdge{};
+    }
+    onnx::NodeProto* node = nit->second;
+
+    auto prod_info = MatchProducer(*node, init_map);
+    if (prod_info) {
+      MatMulBackwardEdge edge;
+      edge.kind = BackwardEdgeKind::kProducer;
+      edge.producer = Producer{node,
+                               prod_info->weight,
+                               prod_info->weight_transposed,
+                               prod_info->bias,
+                               false,
+                               1};
+      edge.n_channels = prod_info->n_channels;
+      std::reverse(chain_ops.begin(), chain_ops.end());
+      edge.chain_ops = std::move(chain_ops);
+      return edge;
+    }
+
+    if (UnaryPassThroughOps().count(node->op_type()) != 0 &&
+        node->input_size() == 1) {
+      chain_ops.push_back(ChainOp{node, std::nullopt});
+      cur = node->input(0);
+      continue;
+    }
+
+    if ((node->op_type() == "Add" || node->op_type() == "Mul") &&
+        node->input_size() == 2) {
+      const std::string& a_name = node->input(0);
+      const std::string& b_name = node->input(1);
+      const bool a_const = init_map.count(a_name) != 0;
+      const bool b_const = init_map.count(b_name) != 0;
+      if (a_const != b_const) {
+        const std::string& const_name = a_const ? a_name : b_name;
+        const std::string& other = a_const ? b_name : a_name;
+        const onnx::TensorProto* c = init_map.at(const_name);
+        int64_t prod = 1;
+        for (int64_t d : c->dims()) {
+          prod *= d;
+        }
+        const bool valid = c->data_type() == onnx::TensorProto::FLOAT &&
+                           c->dims_size() > 0 &&
+                           prod == c->dims(c->dims_size() - 1);
+        if (valid) {
+          chain_ops.push_back(ChainOp{node, const_name});
+          cur = other;
+          continue;
+        }
+        return MatMulBackwardEdge{};
+      }
+      // Both operands constant (degenerate) or both non-constant: for `Add`
+      // the latter is exactly IsEligibleAddMerge's own shape, handled
+      // below; for `Mul` it's a gated (SwiGLU/GeGLU) combine point this
+      // walk doesn't try to pick a branch through -- either way, falling
+      // through to the merge check or "fail" is correct.
+    }
+
+    if (IsEligibleAddMerge(*node, init_map)) {
+      MatMulBackwardEdge edge;
+      edge.kind = BackwardEdgeKind::kAdd;
+      edge.add_node = node;
+      std::reverse(chain_ops.begin(), chain_ops.end());
+      edge.chain_ops = std::move(chain_ops);
+      return edge;
+    }
+
+    return MatMulBackwardEdge{};
+  }
+  return MatMulBackwardEdge{};
+}
+
+// Finds MatMul/Gemm residual/skip-connection groups -- the MatMul/Gemm
+// analogue of FindConvResidualChains, over WalkMatmulProducerBackward
+// instead of WalkConvProducerBackward. See this section's own comment
+// above for the scope note (bare Add merge points only, not the fused
+// SkipLayerNormalization case pruning.py also recognizes).
+std::vector<Chain> FindMatmulResidualChains(onnx::GraphProto* graph) {
+  InitMap init_map;
+  for (const auto& t : graph->initializer()) {
+    init_map[t.name()] = &t;
+  }
+  ConsumerMap consumers_of = ConsumersOf(graph);
+  std::unordered_set<std::string> graph_outputs;
+  for (const auto& o : graph->output()) {
+    graph_outputs.insert(o.name());
+  }
+  auto is_internal = [&](const std::string& name) {
+    return ConsumerCount(consumers_of, name) == 1 && !graph_outputs.count(name);
+  };
+  std::unordered_map<std::string, onnx::NodeProto*> node_by_output;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    for (const auto& out : node->output()) {
+      node_by_output[out] = node;
+    }
+  }
+
+  std::vector<onnx::NodeProto*> merges;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    if (IsEligibleAddMerge(*node, init_map)) {
+      merges.push_back(node);
+    }
+  }
+  if (merges.empty()) {
+    return {};
+  }
+  std::unordered_map<onnx::NodeProto*, int> merge_index;
+  for (size_t i = 0; i < merges.size(); ++i) {
+    merge_index[merges[i]] = static_cast<int>(i);
+  }
+
+  std::vector<int> parent(merges.size());
+  std::iota(parent.begin(), parent.end(), 0);
+  std::function<int(int)> find = [&](int i) {
+    while (parent[i] != i) {
+      parent[i] = parent[parent[i]];
+      i = parent[i];
+    }
+    return i;
+  };
+  auto unite = [&](int i, int j) {
+    const int ri = find(i), rj = find(j);
+    if (ri != rj) {
+      parent[ri] = rj;
+    }
+  };
+
+  std::vector<std::vector<MatMulBackwardEdge>> edge_results(merges.size());
+  std::unordered_set<int> poisoned;
+  for (size_t idx = 0; idx < merges.size(); ++idx) {
+    std::vector<MatMulBackwardEdge> results;
+    for (const auto& operand : merges[idx]->input()) {
+      MatMulBackwardEdge edge = WalkMatmulProducerBackward(
+          operand, node_by_output, init_map, consumers_of, graph_outputs,
+          kMaxChainHops);
+      if (edge.kind == BackwardEdgeKind::kFail) {
+        poisoned.insert(static_cast<int>(idx));
+      } else if (edge.kind == BackwardEdgeKind::kAdd) {
+        auto jit = merge_index.find(edge.add_node);
+        if (jit == merge_index.end()) {
+          poisoned.insert(
+              static_cast<int>(idx));  // Defensive -- shouldn't happen.
+        } else {
+          unite(static_cast<int>(idx), jit->second);
+        }
+      }
+      results.push_back(std::move(edge));
+    }
+    edge_results[idx] = std::move(results);
+  }
+
+  std::unordered_map<int, std::vector<int>> groups;
+  for (size_t idx = 0; idx < merges.size(); ++idx) {
+    groups[find(static_cast<int>(idx))].push_back(static_cast<int>(idx));
+  }
+
+  std::vector<Chain> chains;
+  for (auto& kv : groups) {
+    const std::vector<int>& members = kv.second;
+    bool any_poisoned = false;
+    for (int i : members) {
+      if (poisoned.count(i)) {
+        any_poisoned = true;
+        break;
+      }
+    }
+    if (any_poisoned) {
+      continue;
+    }
+
+    std::vector<Producer> leaf_producers;
+    std::unordered_set<int64_t> n_channels_set;
+    std::vector<ChainOp> pre_chain_ops;
+    std::unordered_set<int> referenced;
+
+    for (int idx : members) {
+      for (auto& edge : edge_results[static_cast<size_t>(idx)]) {
+        pre_chain_ops.insert(pre_chain_ops.end(), edge.chain_ops.begin(),
+                             edge.chain_ops.end());
+        if (edge.kind == BackwardEdgeKind::kProducer) {
+          leaf_producers.push_back(edge.producer);
+          n_channels_set.insert(edge.n_channels);
+        } else if (edge.kind == BackwardEdgeKind::kAdd) {
+          referenced.insert(merge_index[edge.add_node]);
+        }
+      }
+    }
+
+    if (n_channels_set.size() != 1) {
+      continue;  // Branches disagree on channel count -- decline.
+    }
+    const int64_t n_channels = *n_channels_set.begin();
+
+    bool const_mismatch = false;
+    for (const auto& co : pre_chain_ops) {
+      if (co.const_name &&
+          init_map.at(*co.const_name)
+                  ->dims(init_map.at(*co.const_name)->dims_size() - 1) !=
+              n_channels) {
+        const_mismatch = true;
+        break;
+      }
+    }
+    if (const_mismatch) {
+      continue;
+    }
+
+    std::vector<int> sinks;
+    for (int idx : members) {
+      if (!referenced.count(idx)) {
+        sinks.push_back(idx);
+      }
+    }
+    if (sinks.size() != 1) {
+      continue;  // Not a single linear chain of merges -- decline.
+    }
+    onnx::NodeProto* sink_node = merges[static_cast<size_t>(sinks[0])];
+
+    std::unordered_set<std::string> seen_weights;
+    bool degenerate = false;
+    for (const auto& p : leaf_producers) {
+      if (!seen_weights.insert(p.weight).second) {
+        degenerate = true;
+        break;
+      }
+    }
+    if (degenerate) {
+      continue;  // The same producer named twice.
+    }
+
+    const std::string& sink_out = sink_node->output(0);
+    if (!is_internal(sink_out)) {
+      continue;
+    }
+
+    auto [consumer, fwd_chain_ops] =
+        WalkToConsumer(sink_out, init_map, consumers_of, graph_outputs,
+                       n_channels, kMaxChainHops);
+    if (!consumer) {
+      continue;
+    }
+
+    std::vector<ChainOp> chain_ops = std::move(pre_chain_ops);
+    for (int idx : members) {
+      chain_ops.push_back(
+          ChainOp{merges[static_cast<size_t>(idx)], std::nullopt});
+    }
+    for (auto& co : fwd_chain_ops) {
+      chain_ops.push_back(std::move(co));
+    }
+
+    Chain chain;
+    chain.producers = std::move(leaf_producers);
+    chain.chain_ops = std::move(chain_ops);
+    chain.consumer_node = consumer->node;
+    chain.consumer_weight = consumer->weight;
+    chain.consumer_weight_transposed = consumer->weight_transposed;
+    chain.n_channels = n_channels;
+    chains.push_back(std::move(chain));
+  }
+  return chains;
+}
+
 int64_t ChainGroup(const Chain& chain) {
   if (chain.producers.size() == 1 && chain.producers[0].group > 1) {
     return chain.producers[0].group;
@@ -1165,10 +1796,18 @@ onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
   std::vector<Chain> chains = FindChains(graph);
   std::vector<Chain> gated_chains = FindGatedChains(graph);
   std::vector<Chain> conv_chains = FindConvChains(graph);
+  std::vector<Chain> conv_residual_chains = FindConvResidualChains(graph);
+  std::vector<Chain> matmul_residual_chains = FindMatmulResidualChains(graph);
   chains.insert(chains.end(), std::make_move_iterator(gated_chains.begin()),
                 std::make_move_iterator(gated_chains.end()));
   chains.insert(chains.end(), std::make_move_iterator(conv_chains.begin()),
                 std::make_move_iterator(conv_chains.end()));
+  chains.insert(chains.end(),
+                std::make_move_iterator(conv_residual_chains.begin()),
+                std::make_move_iterator(conv_residual_chains.end()));
+  chains.insert(chains.end(),
+                std::make_move_iterator(matmul_residual_chains.begin()),
+                std::make_move_iterator(matmul_residual_chains.end()));
   if (!chains.empty()) {
     ApplyChains(graph, chains, sparsity);
   }

--- a/onnxsim/structured_pruning_entry.h
+++ b/onnxsim/structured_pruning_entry.h
@@ -1,18 +1,24 @@
 #pragma once
 
-// Structured (channel) pruning entry point exposed to Python, mirroring
-// pruning_entry.h's own "not a Quantize* scheme" rationale for its separate
-// file. Unlike every pass in onnxsim/passes/ (which run through
-// onnxoptimizer's Node/Value IR via OptimizeFixed), this operates directly
-// on onnx::GraphProto: the algorithm needs whole-graph, multi-hop forward/
-// backward tensor-name-based analysis (producer/consumer maps, chain
-// walking) that maps far more directly onto the same protobuf-level
-// approach onnxsim/pruning.py's own reference implementation takes than
-// onto the optimizer's PredicateBasedPass single-node-match model -- see
-// structured_pruning_entry.cpp's own top-of-file comment for the details
-// and scope of this port. See onnxsim.h for the documentation this mirrors.
+// Structured (channel) and attention-head pruning entry points exposed to
+// Python, mirroring pruning_entry.h's own "not a Quantize* scheme"
+// rationale for its separate file. Unlike every pass in onnxsim/passes/
+// (which run through onnxoptimizer's Node/Value IR via OptimizeFixed),
+// both operate directly on onnx::GraphProto: the algorithm needs
+// whole-graph, multi-hop forward/backward tensor-name-based analysis
+// (producer/consumer maps, chain walking) that maps far more directly onto
+// the same protobuf-level approach onnxsim/pruning.py's own reference
+// implementation takes than onto the optimizer's PredicateBasedPass
+// single-node-match model -- see structured_pruning_entry.cpp's own
+// top-of-file comment for the details and scope of both ports (attention-
+// head pruning lives in the same translation unit specifically to reuse
+// its producer/consumer/slicing helpers directly, rather than duplicating
+// them). See onnxsim.h for the documentation this mirrors.
 
 #include <onnx/onnx_pb.h>
 
 onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
                                         double sparsity);
+
+onnx::ModelProto ApplyAttentionHeadPruning(const onnx::ModelProto& model,
+                                           double sparsity);

--- a/onnxsim/structured_pruning_entry.h
+++ b/onnxsim/structured_pruning_entry.h
@@ -1,0 +1,18 @@
+#pragma once
+
+// Structured (channel) pruning entry point exposed to Python, mirroring
+// pruning_entry.h's own "not a Quantize* scheme" rationale for its separate
+// file. Unlike every pass in onnxsim/passes/ (which run through
+// onnxoptimizer's Node/Value IR via OptimizeFixed), this operates directly
+// on onnx::GraphProto: the algorithm needs whole-graph, multi-hop forward/
+// backward tensor-name-based analysis (producer/consumer maps, chain
+// walking) that maps far more directly onto the same protobuf-level
+// approach onnxsim/pruning.py's own reference implementation takes than
+// onto the optimizer's PredicateBasedPass single-node-match model -- see
+// structured_pruning_entry.cpp's own top-of-file comment for the details
+// and scope of this port. See onnxsim.h for the documentation this mirrors.
+
+#include <onnx/onnx_pb.h>
+
+onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
+                                        double sparsity);

--- a/tests/test_attention_head_pruning_cpp.py
+++ b/tests/test_attention_head_pruning_cpp.py
@@ -1,0 +1,908 @@
+"""Tests for ``onnxsim.apply_attention_head_pruning_cpp`` -- the C++-backed
+port of ``onnxsim.apply_attention_head_pruning`` (see
+``onnxsim/structured_pruning_entry.cpp``'s "Attention-head pruning" section).
+Data-free (magnitude/Frobenius-norm) only -- the calibration-driven Wanda
+variant (``onnxsim.apply_attention_head_wanda_pruning``) is not ported,
+matching this codebase's established C++-port scope decision. Tests here are
+adapted from ``test_pruning.py``'s own ``apply_attention_head_pruning``
+coverage for all three matched op families: plain ``com.microsoft::Attention``
+(merged QKV weight), ``com.microsoft::GroupQueryAttention``, and the plain
+``ai.onnx::Attention`` op (opset 24+).
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _head_idx(keep_heads, d):
+    return np.concatenate([np.arange(h * d, (h + 1) * d) for h in keep_heads])
+
+
+def _oracle_keep_heads(wqkv, nq, nk, nv, num_heads, keep_count):
+    dq, dk, dv = nq // num_heads, nk // num_heads, nv // num_heads
+    wq, wk, wv = wqkv[:, :nq], wqkv[:, nq : nq + nk], wqkv[:, nq + nk :]
+    importance = np.zeros(num_heads)
+    for h in range(num_heads):
+        block = np.concatenate(
+            [
+                wq[:, h * dq : (h + 1) * dq],
+                wk[:, h * dk : (h + 1) * dk],
+                wv[:, h * dv : (h + 1) * dv],
+            ],
+            axis=1,
+        )
+        importance[h] = np.linalg.norm(block)
+    return np.sort(np.argsort(-importance)[:keep_count])
+
+
+def _oracle_keep_groups(wq, wk, wv, num_heads, kv_num_heads, head_size, keep_count):
+    group_size = num_heads // kv_num_heads
+    importance = np.zeros(kv_num_heads)
+    for kv in range(kv_num_heads):
+        q_block = np.concatenate(
+            [
+                wq[:, h * head_size : (h + 1) * head_size]
+                for h in range(kv * group_size, (kv + 1) * group_size)
+            ],
+            axis=1,
+        )
+        k_block = wk[:, kv * head_size : (kv + 1) * head_size]
+        v_block = wv[:, kv * head_size : (kv + 1) * head_size]
+        importance[kv] = np.linalg.norm(
+            np.concatenate([q_block, k_block, v_block], axis=1)
+        )
+    return np.sort(np.argsort(-importance)[:keep_count])
+
+
+def _group_q_heads(keep_groups, group_size):
+    return np.concatenate(
+        [np.arange(g * group_size, (g + 1) * group_size) for g in keep_groups]
+    )
+
+
+# --- Plain com.microsoft::Attention (merged QKV weight) ---------------------
+
+
+def _attention_model(
+    K=8,
+    H=4,
+    D=4,
+    Out=6,
+    seed=0,
+    batch=2,
+    seq=5,
+    bias=True,
+    with_reshape=False,
+    wqkv=None,
+    bqkv=None,
+    wout=None,
+    num_heads=None,
+):
+    rng = np.random.default_rng(seed)
+    Nq = Nk = Nv = H * D
+    if wqkv is None:
+        wqkv = rng.standard_normal((K, Nq + Nk + Nv)).astype(np.float32)
+    if wout is None:
+        wout = rng.standard_normal((Nv, Out)).astype(np.float32)
+    if bias and bqkv is None:
+        bqkv = rng.standard_normal((Nq + Nk + Nv,)).astype(np.float32)
+    heads = H if num_heads is None else num_heads
+
+    initializer = [_f32(wqkv, "Wqkv"), _f32(wout, "Wout")]
+    qkv_inputs = "X, Wqkv"
+    if bias:
+        initializer.append(_f32(bqkv, "Bqkv"))
+        qkv_inputs = "X, Wqkv, Bqkv"
+
+    if with_reshape:
+        shape = np.array([batch, seq, Nv], dtype=np.int64)
+        initializer.append(onnx.numpy_helper.from_array(shape, "Shape"))
+        tail = "ctx2 = Reshape(ctx, Shape)\n          Y = MatMul(ctx2, Wout)"
+    else:
+        tail = "Y = MatMul(ctx, Wout)"
+
+    body = f"""
+        g (float[batch,seq,{K}] X) => (float[batch,seq,{Out}] Y)
+        {{
+          ctx = com.microsoft.Attention <num_heads={heads}, qkv_hidden_sizes=[{Nq},{Nk},{Nv}]> ({qkv_inputs})
+          {tail}
+        }}
+        """
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17, "com.microsoft": 1]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model, dict(
+        K=K, H=H, D=D, Out=Out, Nq=Nq, Nk=Nk, Nv=Nv, wqkv=wqkv, bqkv=bqkv, wout=wout
+    )
+
+
+def _attention_node(model):
+    return next(n for n in model.graph.node if n.op_type == "Attention")
+
+
+def _attention_attrs(node):
+    num_heads = next(a.i for a in node.attribute if a.name == "num_heads")
+    qkv = next(list(a.ints) for a in node.attribute if a.name == "qkv_hidden_sizes")
+    return num_heads, qkv
+
+
+def test_cpp_attention_head_pruning_shrinks_matched_block():
+    model, cfg = _attention_model(K=8, H=4, D=4, Out=6)
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    node = _attention_node(pruned)
+    num_heads, qkv = _attention_attrs(node)
+    assert num_heads == 2
+    assert qkv == [8, 8, 8]
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Wqkv"].dims) == [8, 24]
+    assert list(inits["Bqkv"].dims) == [24]
+    assert list(inits["Wout"].dims) == [8, 6]
+
+
+def test_cpp_attention_head_pruning_matches_manual_head_deletion_exactly():
+    model, cfg = _attention_model(K=8, H=4, D=4, Out=6, seed=1)
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep = _oracle_keep_heads(cfg["wqkv"], cfg["Nq"], cfg["Nk"], cfg["Nv"], cfg["H"], 2)
+    d = cfg["D"]
+    qi, ki, vi = (
+        _head_idx(keep, d),
+        _head_idx(keep, d) + cfg["Nq"],
+        _head_idx(keep, d) + cfg["Nq"] + cfg["Nk"],
+    )
+    all_idx = np.concatenate([qi, ki, vi])
+    oracle_wqkv = cfg["wqkv"][:, all_idx]
+    oracle_bqkv = cfg["bqkv"][all_idx]
+    oracle_wout = cfg["wout"][_head_idx(keep, d), :]
+    oracle, _ = _attention_model(
+        K=cfg["K"],
+        H=2,
+        D=d,
+        Out=cfg["Out"],
+        seed=1,
+        wqkv=oracle_wqkv,
+        bqkv=oracle_bqkv,
+        wout=oracle_wout,
+        num_heads=2,
+    )
+
+    rng = np.random.default_rng(2)
+    x = rng.standard_normal((2, 5, cfg["K"])).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_cpp_attention_head_pruning_reshape_hop_is_recognized_and_shape_updated():
+    model, cfg = _attention_model(K=8, H=4, D=4, Out=6, seed=3, with_reshape=True)
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.25)
+    onnx.checker.check_model(pruned)
+    assert [n.op_type for n in pruned.graph.node] == ["Attention", "Reshape", "MatMul"]
+
+    node = _attention_node(pruned)
+    num_heads, _ = _attention_attrs(node)
+    assert num_heads == 3  # round(4 - 4*0.25) == 3
+
+    shape = onnx.numpy_helper.to_array(
+        next(t for t in pruned.graph.initializer if t.name == "Shape")
+    )
+    assert shape[-1] == 3 * cfg["D"]  # updated to the new (post-prune) Nv
+
+    rng = np.random.default_rng(4)
+    x = rng.standard_normal((2, 5, cfg["K"])).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    assert y.shape == (2, 5, cfg["Out"])
+
+
+def test_cpp_attention_head_pruning_mismatched_consumer_reduction_dim_is_left_untouched():
+    K, H, D, Out = 8, 4, 4, 6
+    Nqkv = H * D
+    rng = np.random.default_rng(6)
+    wqkv = rng.standard_normal((K, 3 * Nqkv)).astype(np.float32)
+    wout_wrong = rng.standard_normal((Nqkv + 1, Out)).astype(np.float32)  # off-by-one
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17, "com.microsoft": 1]
+        >
+        g (float[2,5,{K}] X) => (float[2,5,{Out}] Y)
+        {{
+          ctx = com.microsoft.Attention <num_heads={H}, qkv_hidden_sizes=[{Nqkv},{Nqkv},{Nqkv}]> (X, Wqkv)
+          padded = Pad <pads = [0,0,0,0,0,1]> (ctx)
+          Y = MatMul(padded, Wout)
+        }}
+        """
+    )
+    model.graph.initializer.extend([_f32(wqkv, "Wqkv"), _f32(wout_wrong, "Wout")])
+
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    inits_before = {
+        t.name: onnx.numpy_helper.to_array(t) for t in model.graph.initializer
+    }
+    inits_after = {
+        t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer
+    }
+    for name in inits_before:
+        np.testing.assert_array_equal(inits_before[name], inits_after[name])
+
+
+def test_cpp_attention_head_pruning_zero_sparsity_is_a_no_op():
+    model, cfg = _attention_model(K=8, H=4, D=4, Out=6, seed=7)
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.0)
+    node = _attention_node(pruned)
+    num_heads, qkv = _attention_attrs(node)
+    assert num_heads == cfg["H"]
+    assert qkv == [cfg["Nq"], cfg["Nk"], cfg["Nv"]]
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["Wqkv"], cfg["wqkv"])
+
+
+def test_cpp_attention_head_pruning_invalid_sparsity_raises():
+    model, _ = _attention_model(K=8, H=4, D=4, Out=6)
+    with pytest.raises(Exception):
+        onnxsim.apply_attention_head_pruning_cpp(model, sparsity=1.0)
+    with pytest.raises(Exception):
+        onnxsim.apply_attention_head_pruning_cpp(model, sparsity=-0.1)
+
+
+# --- com.microsoft::GroupQueryAttention (separate Q/K/V producers) ---------
+
+
+def _gqa_model(
+    K=8,
+    H=4,
+    KVH=2,
+    D=8,
+    Out=6,
+    seed=0,
+    batch=2,
+    seq=5,
+    bias=False,
+    with_reshape=False,
+    wq=None,
+    wk=None,
+    wv=None,
+    bq=None,
+    bk=None,
+    bv=None,
+    wout=None,
+    past_kv=None,  # None (empty) | "nonempty" (constant) | "dynamic" (graph input)
+):
+    rng = np.random.default_rng(seed)
+    Nq, Nkv = H * D, KVH * D
+    if wq is None:
+        wq = rng.standard_normal((K, Nq)).astype(np.float32)
+    if wk is None:
+        wk = rng.standard_normal((K, Nkv)).astype(np.float32)
+    if wv is None:
+        wv = rng.standard_normal((K, Nkv)).astype(np.float32)
+    if wout is None:
+        wout = rng.standard_normal((Nq, Out)).astype(np.float32)
+
+    initializer = [_f32(wq, "Wq"), _f32(wk, "Wk"), _f32(wv, "Wv"), _f32(wout, "Wout")]
+    q_op, k_op, v_op = "MatMul(X, Wq)", "MatMul(X, Wk)", "MatMul(X, Wv)"
+    if bias:
+        if bq is None:
+            bq = rng.standard_normal((Nq,)).astype(np.float32)
+        if bk is None:
+            bk = rng.standard_normal((Nkv,)).astype(np.float32)
+        if bv is None:
+            bv = rng.standard_normal((Nkv,)).astype(np.float32)
+        initializer += [_f32(bq, "Bq"), _f32(bk, "Bk"), _f32(bv, "Bv")]
+        q_op, k_op, v_op = "Gemm(X, Wq, Bq)", "Gemm(X, Wk, Bk)", "Gemm(X, Wv, Bv)"
+
+    initializer.append(
+        onnx.numpy_helper.from_array(
+            np.full((batch,), seq - 1, dtype=np.int32), "SeqLensK"
+        )
+    )
+    initializer.append(
+        onnx.numpy_helper.from_array(np.array(seq, dtype=np.int32), "TotalSeq")
+    )
+
+    operands = ["q", "k", "v"]
+    extra_graph_inputs = ""
+    if past_kv == "nonempty":
+        past_key = rng.standard_normal((batch, KVH, 1, D)).astype(np.float32)
+        past_value = rng.standard_normal((batch, KVH, 1, D)).astype(np.float32)
+        initializer += [_f32(past_key, "PastKey"), _f32(past_value, "PastValue")]
+        operands += ["PastKey", "PastValue"]
+    elif past_kv == "dynamic":
+        operands += ["PastKeyIn", "PastValueIn"]
+        extra_graph_inputs = (
+            f", float[{batch},{KVH},1,{D}] PastKeyIn"
+            f", float[{batch},{KVH},1,{D}] PastValueIn"
+        )
+    else:
+        operands += ["", ""]
+    operands += ["SeqLensK", "TotalSeq"]
+
+    if with_reshape:
+        shape = np.array([batch, seq, Nq], dtype=np.int64)
+        initializer.append(onnx.numpy_helper.from_array(shape, "Shape"))
+        tail = "ctx2 = Reshape(ctx, Shape)\n          Y = MatMul(ctx2, Wout)"
+    else:
+        tail = "Y = MatMul(ctx, Wout)"
+
+    body = f"""
+        g (float[{batch},{seq},{K}] X{extra_graph_inputs}) => (float[{batch},{seq},{Out}] Y)
+        {{
+          q = {q_op}
+          k = {k_op}
+          v = {v_op}
+          ctx, pk, pv = com.microsoft.GroupQueryAttention <num_heads={H}, kv_num_heads={KVH}> ({", ".join(operands)})
+          {tail}
+        }}
+        """
+
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17, "com.microsoft": 1]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model, dict(
+        K=K,
+        H=H,
+        KVH=KVH,
+        D=D,
+        Out=Out,
+        Nq=Nq,
+        Nkv=Nkv,
+        wq=wq,
+        wk=wk,
+        wv=wv,
+        bq=bq,
+        bk=bk,
+        bv=bv,
+        wout=wout,
+        batch=batch,
+        seq=seq,
+    )
+
+
+def _gqa_node(model):
+    return next(n for n in model.graph.node if n.op_type == "GroupQueryAttention")
+
+
+def _gqa_attrs(node):
+    num_heads = next(a.i for a in node.attribute if a.name == "num_heads")
+    kv_num_heads = next(a.i for a in node.attribute if a.name == "kv_num_heads")
+    return num_heads, kv_num_heads
+
+
+def test_cpp_gqa_pruning_shrinks_matched_block():
+    model, cfg = _gqa_model(K=8, H=4, KVH=4, D=8, Out=6)
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    node = _gqa_node(pruned)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    assert num_heads == 2
+    assert kv_num_heads == 2
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Wq"].dims) == [8, 16]
+    assert list(inits["Wk"].dims) == [8, 16]
+    assert list(inits["Wv"].dims) == [8, 16]
+    assert list(inits["Wout"].dims) == [16, 6]
+
+
+def test_cpp_gqa_pruning_zero_sparsity_is_a_no_op():
+    model, cfg = _gqa_model(K=8, H=8, KVH=2, D=8, Out=6, seed=7)
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.0)
+    node = _gqa_node(pruned)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    assert num_heads == cfg["H"]
+    assert kv_num_heads == cfg["KVH"]
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["Wq"], cfg["wq"])
+    np.testing.assert_array_equal(inits["Wk"], cfg["wk"])
+    np.testing.assert_array_equal(inits["Wv"], cfg["wv"])
+
+
+def test_cpp_gqa_pruning_unequal_heads_drops_whole_groups_and_preserves_ratio():
+    model, cfg = _gqa_model(K=8, H=8, KVH=4, D=8, Out=6, seed=11)
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    node = _gqa_node(pruned)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    assert kv_num_heads == 2
+    assert num_heads == 4
+    assert num_heads // kv_num_heads == cfg["H"] // cfg["KVH"]
+
+    group_size = cfg["H"] // cfg["KVH"]
+    keep_groups = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], cfg["H"], cfg["KVH"], cfg["D"], 2
+    )
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    d = cfg["D"]
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["Wq"], cfg["wq"][:, _head_idx(keep_q_heads, d)])
+    np.testing.assert_array_equal(inits["Wk"], cfg["wk"][:, _head_idx(keep_groups, d)])
+    np.testing.assert_array_equal(inits["Wv"], cfg["wv"][:, _head_idx(keep_groups, d)])
+
+
+def test_cpp_gqa_pruning_matches_oracle_exactly():
+    model, cfg = _gqa_model(K=8, H=8, KVH=2, D=8, Out=6, seed=1)
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    node = _gqa_node(pruned)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    group_size = cfg["H"] // cfg["KVH"]
+    assert kv_num_heads == 1
+    assert num_heads == kv_num_heads * group_size
+
+    keep_groups = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], cfg["H"], cfg["KVH"], cfg["D"], kv_num_heads
+    )
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    d = cfg["D"]
+    q_idx, kv_idx = _head_idx(keep_q_heads, d), _head_idx(keep_groups, d)
+
+    oracle, _ = _gqa_model(
+        K=cfg["K"],
+        H=num_heads,
+        KVH=kv_num_heads,
+        D=d,
+        Out=cfg["Out"],
+        seed=1,
+        wq=cfg["wq"][:, q_idx],
+        wk=cfg["wk"][:, kv_idx],
+        wv=cfg["wv"][:, kv_idx],
+        wout=cfg["wout"][q_idx, :],
+        batch=cfg["batch"],
+        seq=cfg["seq"],
+    )
+
+    rng = np.random.default_rng(2)
+    x = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_cpp_gqa_pruning_slices_bias_when_producer_has_one():
+    model, cfg = _gqa_model(K=8, H=4, KVH=2, D=8, Out=6, seed=14, bias=True)
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+
+    node = _gqa_node(pruned)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    group_size = cfg["H"] // cfg["KVH"]
+    assert kv_num_heads == 1
+    assert num_heads == group_size
+
+    keep_groups = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], cfg["H"], cfg["KVH"], cfg["D"], kv_num_heads
+    )
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    d = cfg["D"]
+    q_idx, kv_idx = _head_idx(keep_q_heads, d), _head_idx(keep_groups, d)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["Wq"], cfg["wq"][:, q_idx])
+    np.testing.assert_array_equal(inits["Wk"], cfg["wk"][:, kv_idx])
+    np.testing.assert_array_equal(inits["Wv"], cfg["wv"][:, kv_idx])
+    np.testing.assert_array_equal(inits["Bq"], cfg["bq"][q_idx])
+    np.testing.assert_array_equal(inits["Bk"], cfg["bk"][kv_idx])
+    np.testing.assert_array_equal(inits["Bv"], cfg["bv"][kv_idx])
+
+
+def test_cpp_gqa_pruning_reshape_hop_is_recognized_and_shape_updated():
+    model, cfg = _gqa_model(K=8, H=4, KVH=2, D=8, Out=6, seed=3, with_reshape=True)
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    assert [n.op_type for n in pruned.graph.node] == [
+        "MatMul",
+        "MatMul",
+        "MatMul",
+        "GroupQueryAttention",
+        "Reshape",
+        "MatMul",
+    ]
+
+    node = _gqa_node(pruned)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    assert kv_num_heads == 1
+    assert num_heads == 2
+
+    shape = onnx.numpy_helper.to_array(
+        next(t for t in pruned.graph.initializer if t.name == "Shape")
+    )
+    assert shape[-1] == num_heads * cfg["D"]
+
+    rng = np.random.default_rng(4)
+    x = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    assert y.shape == (cfg["batch"], cfg["seq"], cfg["Out"])
+
+
+def test_cpp_gqa_pruning_nonempty_past_kv_constant_is_left_untouched():
+    model, cfg = _gqa_model(K=8, H=8, KVH=2, D=8, Out=6, seed=12, past_kv="nonempty")
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    inits_before = {
+        t.name: onnx.numpy_helper.to_array(t) for t in model.graph.initializer
+    }
+    inits_after = {
+        t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer
+    }
+    for name in inits_before:
+        np.testing.assert_array_equal(inits_before[name], inits_after[name])
+
+
+def test_cpp_gqa_pruning_dynamic_past_kv_input_is_still_pruned():
+    model, cfg = _gqa_model(K=8, H=8, KVH=2, D=8, Out=6, seed=13, past_kv="dynamic")
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    node = _gqa_node(pruned)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    group_size = cfg["H"] // cfg["KVH"]
+    assert kv_num_heads == 1
+    assert num_heads == group_size
+
+
+def test_cpp_attention_head_pruning_group_query_attention_missing_required_inputs_is_left_untouched():
+    K, H, D, Out = 8, 4, 4, 6
+    Nqkv = H * D
+    rng = np.random.default_rng(5)
+    wq = rng.standard_normal((K, Nqkv)).astype(np.float32)
+    wk = rng.standard_normal((K, Nqkv)).astype(np.float32)
+    wv = rng.standard_normal((K, Nqkv)).astype(np.float32)
+    wout = rng.standard_normal((Nqkv, Out)).astype(np.float32)
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17, "com.microsoft": 1]
+        >
+        g (float[2,5,{K}] X) => (float[2,5,{Out}] Y)
+        {{
+          q = MatMul(X, Wq)
+          k = MatMul(X, Wk)
+          v = MatMul(X, Wv)
+          ctx, present_k, present_v = com.microsoft.GroupQueryAttention <num_heads={H}, kv_num_heads={H}> (q, k, v)
+          Y = MatMul(ctx, Wout)
+        }}
+        """
+    )
+    model.graph.initializer.extend(
+        [_f32(wq, "Wq"), _f32(wk, "Wk"), _f32(wv, "Wv"), _f32(wout, "Wout")]
+    )
+
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    inits_before = {
+        t.name: onnx.numpy_helper.to_array(t) for t in model.graph.initializer
+    }
+    inits_after = {
+        t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer
+    }
+    for name in inits_before:
+        np.testing.assert_array_equal(inits_before[name], inits_after[name])
+
+
+# --- Plain ai.onnx::Attention (opset 24+) -----------------------------------
+
+
+def _onnx_attention_model(
+    K=8,
+    H=4,
+    KVH=2,
+    D=4,
+    Out=6,
+    seed=0,
+    batch=2,
+    seq=5,
+    bias=False,
+    with_reshape=False,
+    wq=None,
+    wk=None,
+    wv=None,
+    bq=None,
+    bk=None,
+    bv=None,
+    wout=None,
+    attn_mask=None,  # None (omitted) | "nonempty" (constant) | "dynamic" (graph input)
+    past_kv=None,  # None (omitted) | "nonempty" (constant) | "dynamic" (graph input)
+):
+    rng = np.random.default_rng(seed)
+    Nq, Nkv = H * D, KVH * D
+    if wq is None:
+        wq = rng.standard_normal((K, Nq)).astype(np.float32)
+    if wk is None:
+        wk = rng.standard_normal((K, Nkv)).astype(np.float32)
+    if wv is None:
+        wv = rng.standard_normal((K, Nkv)).astype(np.float32)
+    if wout is None:
+        wout = rng.standard_normal((Nq, Out)).astype(np.float32)
+
+    initializer = [_f32(wq, "Wq"), _f32(wk, "Wk"), _f32(wv, "Wv"), _f32(wout, "Wout")]
+    q_op, k_op, v_op = "MatMul(X, Wq)", "MatMul(X, Wk)", "MatMul(X, Wv)"
+    if bias:
+        if bq is None:
+            bq = rng.standard_normal((Nq,)).astype(np.float32)
+        if bk is None:
+            bk = rng.standard_normal((Nkv,)).astype(np.float32)
+        if bv is None:
+            bv = rng.standard_normal((Nkv,)).astype(np.float32)
+        initializer += [_f32(bq, "Bq"), _f32(bk, "Bk"), _f32(bv, "Bv")]
+        q_op, k_op, v_op = "Gemm(X, Wq, Bq)", "Gemm(X, Wk, Bk)", "Gemm(X, Wv, Bv)"
+
+    operands = ["q", "k", "v"]
+    extra_graph_inputs = ""
+
+    if attn_mask == "nonempty":
+        mask = np.zeros((seq, seq), dtype=np.float32)
+        initializer.append(_f32(mask, "AttnMask"))
+        operands.append("AttnMask")
+    elif attn_mask == "dynamic":
+        operands.append("AttnMaskIn")
+        extra_graph_inputs += f", float[{seq},{seq}] AttnMaskIn"
+    else:
+        operands.append("")
+
+    if past_kv == "nonempty":
+        past_key = rng.standard_normal((batch, KVH, 1, D)).astype(np.float32)
+        past_value = rng.standard_normal((batch, KVH, 1, D)).astype(np.float32)
+        initializer += [_f32(past_key, "PastKey"), _f32(past_value, "PastValue")]
+        operands += ["PastKey", "PastValue"]
+    elif past_kv == "dynamic":
+        operands += ["PastKeyIn", "PastValueIn"]
+        extra_graph_inputs += (
+            f", float[{batch},{KVH},1,{D}] PastKeyIn"
+            f", float[{batch},{KVH},1,{D}] PastValueIn"
+        )
+    else:
+        operands += ["", ""]
+
+    while operands and operands[-1] == "":
+        operands.pop()
+
+    if with_reshape:
+        shape = np.array([batch, seq, Nq], dtype=np.int64)
+        initializer.append(onnx.numpy_helper.from_array(shape, "Shape"))
+        tail = "ctx2 = Reshape(ctx, Shape)\n          Y = MatMul(ctx2, Wout)"
+    else:
+        tail = "Y = MatMul(ctx, Wout)"
+
+    body = f"""
+        g (float[{batch},{seq},{K}] X{extra_graph_inputs}) => (float[{batch},{seq},{Out}] Y)
+        {{
+          q = {q_op}
+          k = {k_op}
+          v = {v_op}
+          ctx = Attention <q_num_heads={H}, kv_num_heads={KVH}> ({", ".join(operands)})
+          {tail}
+        }}
+        """
+
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 24]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model, dict(
+        K=K,
+        H=H,
+        KVH=KVH,
+        D=D,
+        Out=Out,
+        Nq=Nq,
+        Nkv=Nkv,
+        wq=wq,
+        wk=wk,
+        wv=wv,
+        bq=bq,
+        bk=bk,
+        bv=bv,
+        wout=wout,
+        batch=batch,
+        seq=seq,
+    )
+
+
+def _onnx_attention_node(model):
+    return next(
+        n for n in model.graph.node if n.op_type == "Attention" and n.domain == ""
+    )
+
+
+def _onnx_attention_attrs(node):
+    q_num_heads = next(a.i for a in node.attribute if a.name == "q_num_heads")
+    kv_num_heads = next(a.i for a in node.attribute if a.name == "kv_num_heads")
+    return q_num_heads, kv_num_heads
+
+
+def test_cpp_onnx_attention_pruning_shrinks_matched_block():
+    model, cfg = _onnx_attention_model(K=8, H=4, KVH=2, D=4, Out=6)
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    node = _onnx_attention_node(pruned)
+    q_num_heads, kv_num_heads = _onnx_attention_attrs(node)
+    assert kv_num_heads == 1
+    assert q_num_heads == kv_num_heads * (cfg["H"] // cfg["KVH"])
+
+
+def test_cpp_onnx_attention_pruning_matches_oracle_exactly():
+    model, cfg = _onnx_attention_model(K=8, H=8, KVH=2, D=4, Out=6, seed=1)
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    node = _onnx_attention_node(pruned)
+    q_num_heads, kv_num_heads = _onnx_attention_attrs(node)
+    group_size = cfg["H"] // cfg["KVH"]
+    assert kv_num_heads == 1
+    assert q_num_heads == kv_num_heads * group_size
+
+    keep_groups = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], cfg["H"], cfg["KVH"], cfg["D"], kv_num_heads
+    )
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    d = cfg["D"]
+    q_idx, kv_idx = _head_idx(keep_q_heads, d), _head_idx(keep_groups, d)
+
+    oracle, _ = _onnx_attention_model(
+        K=cfg["K"],
+        H=len(keep_q_heads),
+        KVH=len(keep_groups),
+        D=d,
+        Out=cfg["Out"],
+        seed=1,
+        wq=cfg["wq"][:, q_idx],
+        wk=cfg["wk"][:, kv_idx],
+        wv=cfg["wv"][:, kv_idx],
+        wout=cfg["wout"][q_idx, :],
+        batch=cfg["batch"],
+        seq=cfg["seq"],
+    )
+
+    rng = np.random.default_rng(2)
+    x = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_cpp_onnx_attention_pruning_slices_bias_when_producer_has_one():
+    model, cfg = _onnx_attention_model(K=8, H=4, KVH=2, D=4, Out=6, seed=14, bias=True)
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+
+    node = _onnx_attention_node(pruned)
+    q_num_heads, kv_num_heads = _onnx_attention_attrs(node)
+    group_size = cfg["H"] // cfg["KVH"]
+    assert kv_num_heads == 1
+    assert q_num_heads == group_size
+
+    keep_groups = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], cfg["H"], cfg["KVH"], cfg["D"], kv_num_heads
+    )
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    d = cfg["D"]
+    q_idx, kv_idx = _head_idx(keep_q_heads, d), _head_idx(keep_groups, d)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["Wq"], cfg["wq"][:, q_idx])
+    np.testing.assert_array_equal(inits["Wk"], cfg["wk"][:, kv_idx])
+    np.testing.assert_array_equal(inits["Wv"], cfg["wv"][:, kv_idx])
+    np.testing.assert_array_equal(inits["Bq"], cfg["bq"][q_idx])
+    np.testing.assert_array_equal(inits["Bk"], cfg["bk"][kv_idx])
+    np.testing.assert_array_equal(inits["Bv"], cfg["bv"][kv_idx])
+
+
+def test_cpp_onnx_attention_pruning_nonempty_attn_mask_constant_is_left_untouched():
+    model, cfg = _onnx_attention_model(
+        K=8, H=4, KVH=2, D=4, Out=6, seed=17, attn_mask="nonempty"
+    )
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    inits_before = {
+        t.name: onnx.numpy_helper.to_array(t) for t in model.graph.initializer
+    }
+    inits_after = {
+        t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer
+    }
+    for name in inits_before:
+        np.testing.assert_array_equal(inits_before[name], inits_after[name])
+
+
+def test_cpp_onnx_attention_pruning_diff_v_head_size_is_left_untouched():
+    # This op's real schema (unlike GroupQueryAttention, which fuse_gqa.h
+    # always emits with equal Q/K/V head_size) genuinely allows V its own,
+    # independent head_size. This pass reuses the shared, uniform-head_size
+    # slicing body unmodified rather than a parallel implementation, so a
+    # node whose V head size actually differs from Q/K's is declined here
+    # rather than mis-sliced.
+    K, H, KVH, D, Dv, Out = 8, 4, 4, 4, 6, 5
+    Nq, Nk, Nv = H * D, KVH * D, KVH * Dv
+    rng = np.random.default_rng(19)
+    wq = rng.standard_normal((K, Nq)).astype(np.float32)
+    wk = rng.standard_normal((K, Nk)).astype(np.float32)
+    wv = rng.standard_normal((K, Nv)).astype(np.float32)
+    wout = rng.standard_normal((Nq, Out)).astype(np.float32)
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 24]
+        >
+        g (float[2,5,{K}] X) => (float[2,5,{Out}] Y)
+        {{
+          q = MatMul(X, Wq)
+          k = MatMul(X, Wk)
+          v = MatMul(X, Wv)
+          ctx = Attention <q_num_heads={H}, kv_num_heads={KVH}> (q, k, v)
+          Y = MatMul(ctx, Wout)
+        }}
+        """
+    )
+    model.graph.initializer.extend(
+        [_f32(wq, "Wq"), _f32(wk, "Wk"), _f32(wv, "Wv"), _f32(wout, "Wout")]
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    inits_before = {
+        t.name: onnx.numpy_helper.to_array(t) for t in model.graph.initializer
+    }
+    inits_after = {
+        t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer
+    }
+    for name in inits_before:
+        np.testing.assert_array_equal(inits_before[name], inits_after[name])
+
+
+# --- Cross-check against the pure-Python reference --------------------------
+
+
+def test_cpp_attention_head_pruning_matches_python_reference_output():
+    model, _ = _attention_model(K=8, H=4, D=4, Out=6, seed=21)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_py)
+    onnx.checker.check_model(pruned_cpp)
+
+    rng = np.random.default_rng(22)
+    x = rng.standard_normal((2, 5, 8)).astype(np.float32)
+    (y_py,) = _run(pruned_py, {"X": x})
+    (y_cpp,) = _run(pruned_cpp, {"X": x})
+    np.testing.assert_allclose(y_py, y_cpp, rtol=1e-4, atol=1e-4)

--- a/tests/test_structured_pruning_cpp.py
+++ b/tests/test_structured_pruning_cpp.py
@@ -1,0 +1,771 @@
+"""Tests for ``onnxsim.apply_structured_pruning_cpp`` -- the C++-backed port
+of ``onnxsim.apply_structured_pruning`` (see
+``onnxsim/structured_pruning_entry.cpp``). Scope note: this port covers only
+the two "plain chain" topologies (a MatMul/vanilla-Gemm or Conv producer
+feeding, through shape-preserving elementwise ops, exactly one consumer of
+the same family) -- not the pure-Python implementation's gated-FFN or
+residual/skip-connection chain support. Tests here are adapted from
+``test_pruning.py``'s own ``apply_structured_pruning`` coverage, scoped to
+the topologies this port actually implements, plus a couple of tests
+confirming the unported topologies are left untouched (never guessed at).
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(body, initializer=(), opset=21):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _oracle_keep_indices(w1, keep_count):
+    importance = np.linalg.norm(w1.T, axis=1)
+    return np.sort(np.argsort(-importance)[:keep_count])
+
+
+def _oracle_keep_indices_conv(w, keep_count):
+    importance = np.linalg.norm(w.reshape(w.shape[0], -1).astype(np.float64), axis=1)
+    return np.sort(np.argsort(-importance)[:keep_count])
+
+
+def _oracle_keep_indices_conv_grouped(w, group, sparsity):
+    out_channels = w.shape[0]
+    block = out_channels // group
+    per_group_keep = max(1, round(block * (1.0 - sparsity)))
+    parts = []
+    for gi in range(group):
+        lo, hi = gi * block, (gi + 1) * block
+        parts.append(_oracle_keep_indices_conv(w[lo:hi], per_group_keep) + lo)
+    return np.concatenate(parts)
+
+
+def _oracle_slice_grouped_consumer_conv(w2, keep, group, n_channels):
+    out_channels = w2.shape[0]
+    out_per_group = out_channels // group
+    block = n_channels // group
+    parts = []
+    for gi in range(group):
+        lo, hi = gi * block, (gi + 1) * block
+        local_keep = keep[(keep >= lo) & (keep < hi)] - lo
+        parts.append(w2[gi * out_per_group : (gi + 1) * out_per_group][:, local_keep])
+    return np.concatenate(parts, axis=0)
+
+
+def _mlp_model(K=8, H=32, Out=4, bias=True, activation="Relu", seed=0):
+    rng = np.random.default_rng(seed)
+    w1 = rng.standard_normal((K, H)).astype(np.float32)
+    w2 = rng.standard_normal((H, Out)).astype(np.float32)
+    initializer = [_f32(w1, "W1"), _f32(w2, "W2")]
+    if bias:
+        b1 = rng.standard_normal((H,)).astype(np.float32)
+        gemm1 = "h = Gemm(X, W1, B1)"
+        initializer.append(_f32(b1, "B1"))
+    else:
+        gemm1 = "h = MatMul(X, W1)"
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          {gemm1}
+          a = {activation}(h)
+          Y = MatMul(a, W2)
+        }}
+        """,
+        initializer=initializer,
+    )
+
+
+def _conv_pair_model(w1, w2, b1=None, spatial=10, activation="Relu"):
+    Cin, C2 = w1.shape[1], w2.shape[0]
+    initializer = [_f32(w1, "W1"), _f32(w2, "W2")]
+    if b1 is not None:
+        conv1 = "h = Conv<kernel_shape=[3,3]>(X, W1, B1)"
+        initializer.append(_f32(b1, "B1"))
+    else:
+        conv1 = "h = Conv<kernel_shape=[3,3]>(X, W1)"
+    out_spatial = spatial - 4
+    return _model(
+        f"""
+        g (float[N,{Cin},{spatial},{spatial}] X) => (float[N,{C2},{out_spatial},{out_spatial}] Y)
+        {{
+          {conv1}
+          a = {activation}(h)
+          Y = Conv<kernel_shape=[3,3]>(a, W2)
+        }}
+        """,
+        initializer=initializer,
+    )
+
+
+def _grouped_conv_pair_model(
+    w1, w2, group1=1, group2=1, b1=None, spatial=10, activation="Relu"
+):
+    Cin, C2 = w1.shape[1] * group1, w2.shape[0]
+    initializer = [_f32(w1, "W1"), _f32(w2, "W2")]
+    g1 = f", group={group1}" if group1 != 1 else ""
+    g2 = f", group={group2}" if group2 != 1 else ""
+    if b1 is not None:
+        conv1 = f"h = Conv<kernel_shape=[3,3]{g1}>(X, W1, B1)"
+        initializer.append(_f32(b1, "B1"))
+    else:
+        conv1 = f"h = Conv<kernel_shape=[3,3]{g1}>(X, W1)"
+    out_spatial = spatial - 4
+    return _model(
+        f"""
+        g (float[N,{Cin},{spatial},{spatial}] X) => (float[N,{C2},{out_spatial},{out_spatial}] Y)
+        {{
+          {conv1}
+          a = {activation}(h)
+          Y = Conv<kernel_shape=[3,3]{g2}>(a, W2)
+        }}
+        """,
+        initializer=initializer,
+    )
+
+
+def _depthwise_pair_model(w1, dw_hops, w2, b1=None, spatial=10, activation="Relu"):
+    Cin, C2 = w1.shape[1], w2.shape[0]
+    initializer = [_f32(w1, "W1"), _f32(w2, "W2")]
+    if b1 is not None:
+        lines = ["h0 = Conv<kernel_shape=[3,3]>(X, W1, B1)"]
+        initializer.append(_f32(b1, "B1"))
+    else:
+        lines = ["h0 = Conv<kernel_shape=[3,3]>(X, W1)"]
+    lines.append(f"a0 = {activation}(h0)")
+    cur = "a0"
+    n_convs = 1
+    for i, (wd, bd) in enumerate(dw_hops):
+        group = wd.shape[0]
+        w_name, b_name = f"WD{i}", f"BD{i}"
+        initializer.append(_f32(wd, w_name))
+        if bd is not None:
+            initializer.append(_f32(bd, b_name))
+            lines.append(
+                f"hd{i} = Conv<kernel_shape=[3,3], group={group}>"
+                f"({cur}, {w_name}, {b_name})"
+            )
+        else:
+            lines.append(
+                f"hd{i} = Conv<kernel_shape=[3,3], group={group}>({cur}, {w_name})"
+            )
+        lines.append(f"ad{i} = {activation}(hd{i})")
+        cur = f"ad{i}"
+        n_convs += 1
+    lines.append(f"Y = Conv<kernel_shape=[3,3]>({cur}, W2)")
+    n_convs += 1
+    out_spatial = spatial - 2 * n_convs
+    body = "\n          ".join(lines)
+    return _model(
+        f"""
+        g (float[N,{Cin},{spatial},{spatial}] X) => (float[N,{C2},{out_spatial},{out_spatial}] Y)
+        {{
+          {body}
+        }}
+        """,
+        initializer=initializer,
+    )
+
+
+# --- MatMul/Gemm plain chains -----------------------------------------------
+
+
+def test_cpp_structured_pruning_shrinks_matched_layers():
+    model = _mlp_model(K=8, H=32, Out=4)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [8, 16]
+    assert list(inits["B1"].dims) == [16]
+    assert list(inits["W2"].dims) == [16, 4]
+
+
+def test_cpp_structured_pruning_matches_manual_channel_deletion_exactly():
+    K, H, Out = 8, 32, 4
+    model = _mlp_model(K=K, H=H, Out=Out, bias=True)
+    orig = {t.name: onnx.numpy_helper.to_array(t) for t in model.graph.initializer}
+    w1, b1, w2 = orig["W1"], orig["B1"], orig["W2"]
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    keep = _oracle_keep_indices(w1, H // 2)
+
+    rng = np.random.default_rng(1)
+    x = rng.standard_normal((6, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+
+    h = x @ w1[:, keep] + b1[keep]
+    a = np.maximum(h, 0)
+    y_oracle = a @ w2[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_matmul_only_chain_matches_oracle():
+    K, H, Out = 8, 24, 4
+    model = _mlp_model(K=K, H=H, Out=Out, bias=False, activation="Sigmoid")
+    w1 = onnx.numpy_helper.to_array(model.graph.initializer[0])
+    w2 = onnx.numpy_helper.to_array(model.graph.initializer[1])
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.25)
+    keep = _oracle_keep_indices(w1, H - round(H * 0.25))
+
+    rng = np.random.default_rng(2)
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+
+    h = x @ w1[:, keep]
+    a = 1.0 / (1.0 + np.exp(-h))
+    y_oracle = a @ w2[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_bias_add_between_matmuls_matches_oracle():
+    K, H, Out = 8, 16, 4
+    rng = np.random.default_rng(3)
+    w1 = rng.standard_normal((K, H)).astype(np.float32)
+    bias = rng.standard_normal((H,)).astype(np.float32)
+    w2 = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          h = MatMul(X, W1)
+          hb = Add(h, Bias)
+          a = Relu(hb)
+          Y = MatMul(a, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(bias, "Bias"), _f32(w2, "W2")],
+    )
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Bias"].dims) == [H // 2]
+
+    keep = _oracle_keep_indices(w1, H // 2)
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    h = x @ w1[:, keep] + bias[keep]
+    a = np.maximum(h, 0)
+    y_oracle = a @ w2[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_skips_branching_output():
+    K, H, Out = 8, 16, 4
+    model = _mlp_model(K=K, H=H, Out=Out, bias=False)
+    model.graph.output.append(
+        onnx.helper.make_tensor_value_info("h", onnx.TensorProto.FLOAT, ["batch", H])
+    )
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [K, H]
+    assert list(inits["W2"].dims) == [H, Out]
+
+
+def test_cpp_structured_pruning_skips_multi_consumer_branch():
+    K, H, Out = 8, 16, 4
+    rng = np.random.default_rng(4)
+    w1 = rng.standard_normal((K, H)).astype(np.float32)
+    w2 = rng.standard_normal((H, Out)).astype(np.float32)
+    w3 = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y1, float[batch,{Out}] Y2)
+        {{
+          h = MatMul(X, W1)
+          Y1 = MatMul(h, W2)
+          Y2 = MatMul(h, W3)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2"), _f32(w3, "W3")],
+    )
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [K, H]
+
+
+def test_cpp_structured_pruning_zero_sparsity_is_a_no_op():
+    model = _mlp_model(K=8, H=16, Out=4)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.0)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [8, 16]
+
+
+def test_cpp_structured_pruning_invalid_sparsity_raises():
+    model = _mlp_model(K=8, H=16, Out=4)
+    with pytest.raises(Exception):
+        onnxsim.apply_structured_pruning_cpp(model, sparsity=1.0)
+    with pytest.raises(Exception):
+        onnxsim.apply_structured_pruning_cpp(model, sparsity=-0.1)
+
+
+def test_cpp_structured_pruning_chains_through_a_third_layer():
+    K, H1, H2, Out = 8, 16, 20, 4
+    rng = np.random.default_rng(5)
+    w1 = rng.standard_normal((K, H1)).astype(np.float32)
+    w2 = rng.standard_normal((H1, H2)).astype(np.float32)
+    w3 = rng.standard_normal((H2, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          h1 = MatMul(X, W1)
+          a1 = Relu(h1)
+          h2 = MatMul(a1, W2)
+          a2 = Relu(h2)
+          Y = MatMul(a2, W3)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2"), _f32(w3, "W3")],
+    )
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [K, H1 // 2]
+    assert list(inits["W2"].dims) == [H1 // 2, H2 // 2]
+    assert list(inits["W3"].dims) == [H2 // 2, Out]
+
+    keep1 = _oracle_keep_indices(w1, H1 // 2)
+    keep2 = _oracle_keep_indices(w2[keep1, :], H2 // 2)
+
+    rng2 = np.random.default_rng(6)
+    x = rng2.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    a1 = np.maximum(x @ w1[:, keep1], 0)
+    a2 = np.maximum(a1 @ w2[np.ix_(keep1, keep2)], 0)
+    y_oracle = a2 @ w3[keep2, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+# --- Gated FFN: unsupported by this port, must stay untouched --------------
+
+
+def test_cpp_structured_pruning_gated_ffn_is_left_untouched():
+    K, H, Out = 8, 16, 4
+    rng = np.random.default_rng(7)
+    wg = rng.standard_normal((K, H)).astype(np.float32)
+    wu = rng.standard_normal((K, H)).astype(np.float32)
+    wd = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          gate = MatMul(X, Wg)
+          gate_act = Sigmoid(gate)
+          up = MatMul(X, Wu)
+          h = Mul(gate_act, up)
+          Y = MatMul(h, Wd)
+        }}
+        """,
+        initializer=[_f32(wg, "Wg"), _f32(wu, "Wu"), _f32(wd, "Wd")],
+    )
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["Wg"], wg)
+    np.testing.assert_array_equal(inits["Wu"], wu)
+    np.testing.assert_array_equal(inits["Wd"], wd)
+
+
+# --- Conv plain chains -------------------------------------------------------
+
+
+def test_cpp_structured_pruning_conv_chain_shrinks_matched_layers():
+    Cin, C1, C2 = 3, 16, 8
+    rng = np.random.default_rng(30)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    b1 = rng.standard_normal((C1,)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    model = _conv_pair_model(w1, w2, b1=b1)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [C1 // 2, Cin, 3, 3]
+    assert list(inits["B1"].dims) == [C1 // 2]
+    assert list(inits["W2"].dims) == [C2, C1 // 2, 3, 3]
+
+
+def test_cpp_structured_pruning_conv_chain_matches_manual_channel_deletion_exactly():
+    Cin, C1, C2 = 3, 16, 8
+    rng = np.random.default_rng(30)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    b1 = rng.standard_normal((C1,)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    model = _conv_pair_model(w1, w2, b1=b1)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep = _oracle_keep_indices_conv(w1, C1 // 2)
+    oracle = _conv_pair_model(w1[keep], w2[:, keep], b1=b1[keep])
+
+    rng_x = np.random.default_rng(31)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_conv_only_chain_matches_oracle_no_bias():
+    Cin, C1, C2 = 4, 12, 6
+    rng = np.random.default_rng(32)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    model = _conv_pair_model(w1, w2, activation="Sigmoid")
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.25)
+    onnx.checker.check_model(pruned)
+
+    keep = _oracle_keep_indices_conv(w1, C1 - round(C1 * 0.25))
+    oracle = _conv_pair_model(w1[keep], w2[:, keep], activation="Sigmoid")
+
+    rng_x = np.random.default_rng(33)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_skips_grouped_producer_conv():
+    C = 8
+    rng = np.random.default_rng(34)
+    w1 = rng.standard_normal((C, 1, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C, C, 3, 3)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{C},10,10] X) => (float[N,{C},6,6] Y)
+        {{
+          h = Conv<kernel_shape=[3,3], group={C}>(X, W1)
+          a = Relu(h)
+          Y = Conv<kernel_shape=[3,3]>(a, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2")],
+    )
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+
+
+def test_cpp_structured_pruning_skips_grouped_consumer_conv():
+    Cin, C1 = 3, 8
+    rng = np.random.default_rng(35)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C1, 1, 3, 3)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{C1},6,6] Y)
+        {{
+          h = Conv<kernel_shape=[3,3]>(X, W1)
+          a = Relu(h)
+          Y = Conv<kernel_shape=[3,3], group={C1}>(a, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2")],
+    )
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+
+
+def test_cpp_structured_pruning_conv_into_non_pass_through_op_is_left_untouched():
+    Cin, C1, Out = 3, 8, 4
+    rng = np.random.default_rng(36)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C1, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{Out}] Y)
+        {{
+          h = Conv<kernel_shape=[3,3]>(X, W1)
+          p = GlobalAveragePool(h)
+          f = Flatten<axis=1>(p)
+          Y = MatMul(f, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2")],
+    )
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+
+
+def test_cpp_structured_pruning_conv_chain_scale_between_convs_is_left_untouched():
+    Cin, C1, C2 = 3, 8, 4
+    rng = np.random.default_rng(37)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    scale = rng.standard_normal((1, C1, 1, 1)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{C2},6,6] Y)
+        {{
+          h = Conv<kernel_shape=[3,3]>(X, W1)
+          s = Mul(h, Scale)
+          a = Relu(s)
+          Y = Conv<kernel_shape=[3,3]>(a, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(scale, "Scale"), _f32(w2, "W2")],
+    )
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+
+
+# --- Depthwise Conv pass-through hops ----------------------------------------
+
+
+def test_cpp_structured_pruning_depthwise_pass_through_matches_manual_channel_deletion_exactly():
+    Cin, C1, C2 = 3, 16, 8
+    rng = np.random.default_rng(50)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    b1 = rng.standard_normal((C1,)).astype(np.float32)
+    wd = rng.standard_normal((C1, 1, 3, 3)).astype(np.float32)
+    bd = rng.standard_normal((C1,)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    model = _depthwise_pair_model(w1, [(wd, bd)], w2, b1=b1)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    assert inits["WD0"].shape == (C1 // 2, 1, 3, 3)
+    assert inits["BD0"].shape == (C1 // 2,)
+    dw_node = next(n for n in pruned.graph.node if "WD0" in n.input)
+    group_attr = next(a for a in dw_node.attribute if a.name == "group")
+    assert group_attr.i == C1 // 2
+
+    keep = _oracle_keep_indices_conv(w1, C1 // 2)
+    oracle = _depthwise_pair_model(
+        w1[keep], [(wd[keep], bd[keep])], w2[:, keep], b1=b1[keep]
+    )
+
+    rng_x = np.random.default_rng(51)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_multiple_consecutive_depthwise_pass_through_hops_matches_oracle():
+    Cin, C1, C2 = 3, 12, 6
+    rng = np.random.default_rng(52)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    wd1 = rng.standard_normal((C1, 1, 3, 3)).astype(np.float32)
+    bd1 = rng.standard_normal((C1,)).astype(np.float32)
+    wd2 = rng.standard_normal((C1, 1, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    model = _depthwise_pair_model(w1, [(wd1, bd1), (wd2, None)], w2, spatial=14)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.25)
+    onnx.checker.check_model(pruned)
+
+    keep = _oracle_keep_indices_conv(w1, C1 - round(C1 * 0.25))
+    oracle = _depthwise_pair_model(
+        w1[keep], [(wd1[keep], bd1[keep]), (wd2[keep], None)], w2[:, keep], spatial=14
+    )
+
+    rng_x = np.random.default_rng(53)
+    x = rng_x.standard_normal((2, Cin, 14, 14)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_depthwise_pass_through_no_bias_matches_oracle():
+    Cin, C1, C2 = 4, 10, 5
+    rng = np.random.default_rng(54)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    wd = rng.standard_normal((C1, 1, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    model = _depthwise_pair_model(w1, [(wd, None)], w2, activation="Sigmoid")
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.3)
+    onnx.checker.check_model(pruned)
+
+    keep = _oracle_keep_indices_conv(w1, C1 - round(C1 * 0.3))
+    oracle = _depthwise_pair_model(
+        w1[keep], [(wd[keep], None)], w2[:, keep], activation="Sigmoid"
+    )
+
+    rng_x = np.random.default_rng(55)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_depthwise_pass_through_branch_is_left_untouched():
+    Cin, C1 = 3, 8
+    rng = np.random.default_rng(56)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    wd = rng.standard_normal((C1, 1, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C1, C1, 3, 3)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{C1},4,4] Y1, float[N,{C1},6,6] Y2)
+        {{
+          h = Conv<kernel_shape=[3,3]>(X, W1)
+          a = Relu(h)
+          d = Conv<kernel_shape=[3,3], group={C1}>(a, WD)
+          Y1 = Conv<kernel_shape=[3,3]>(d, W2)
+          Y2 = Relu(d)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(wd, "WD"), _f32(w2, "W2")],
+    )
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["WD"], wd)
+    np.testing.assert_array_equal(inits["W2"], w2)
+
+
+# --- General grouped Conv -----------------------------------------------------
+
+
+def test_cpp_structured_pruning_general_grouped_producer_conv_prunes_per_group_independently():
+    Cin, C1, C2, group = 4, 8, 4, 2
+    rng = np.random.default_rng(80)
+    w1 = rng.standard_normal((C1, Cin // group, 3, 3)).astype(np.float32)
+    w1[:4] *= 10.0
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    model = _grouped_conv_pair_model(w1, w2, group1=group)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep_grouped = _oracle_keep_indices_conv_grouped(w1, group, 0.5)
+    assert sum(i < 4 for i in keep_grouped) == 2
+    assert sum(i >= 4 for i in keep_grouped) == 2
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1[keep_grouped])
+    dw_node = next(n for n in pruned.graph.node if "W1" in n.input)
+    group_attr = next(a.i for a in dw_node.attribute if a.name == "group")
+    assert group_attr == group
+
+    oracle = _grouped_conv_pair_model(
+        w1[keep_grouped], w2[:, keep_grouped], group1=group
+    )
+    rng_x = np.random.default_rng(81)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_general_grouped_consumer_conv_matches_manual_channel_deletion_exactly():
+    Cin, C1, C2, group = 3, 8, 6, 2
+    rng = np.random.default_rng(82)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w1[:4] *= 8.0
+    w2 = rng.standard_normal((C2, C1 // group, 3, 3)).astype(np.float32)
+    model = _grouped_conv_pair_model(w1, w2, group2=group)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep = _oracle_keep_indices_conv_grouped(w1, group, 0.5)
+    w2_sliced = _oracle_slice_grouped_consumer_conv(w2, keep, group, C1)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1[keep])
+    np.testing.assert_array_equal(inits["W2"], w2_sliced)
+
+    oracle = _grouped_conv_pair_model(w1[keep], w2_sliced, group2=group)
+    rng_x = np.random.default_rng(83)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_both_sides_grouped_matching_group_count_matches_oracle():
+    Cin, C1, C2, group = 4, 8, 6, 2
+    rng = np.random.default_rng(84)
+    w1 = rng.standard_normal((C1, Cin // group, 3, 3)).astype(np.float32)
+    w1[:4] *= 6.0
+    w2 = rng.standard_normal((C2, C1 // group, 3, 3)).astype(np.float32)
+    model = _grouped_conv_pair_model(w1, w2, group1=group, group2=group)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep = _oracle_keep_indices_conv_grouped(w1, group, 0.5)
+    w2_sliced = _oracle_slice_grouped_consumer_conv(w2, keep, group, C1)
+    oracle = _grouped_conv_pair_model(w1[keep], w2_sliced, group1=group, group2=group)
+
+    rng_x = np.random.default_rng(85)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_skips_mismatched_grouped_producer_and_consumer():
+    Cin, C1, C2, gp, gc = 4, 8, 8, 2, 4
+    rng = np.random.default_rng(86)
+    w1 = rng.standard_normal((C1, Cin // gp, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1 // gc, 3, 3)).astype(np.float32)
+    model = _grouped_conv_pair_model(w1, w2, group1=gp, group2=gc)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+
+
+# --- Cross-check against the pure-Python reference --------------------------
+
+
+def test_cpp_structured_pruning_matches_python_reference_output():
+    K, H, Out = 8, 32, 4
+    model = _mlp_model(K=K, H=H, Out=Out, bias=True, seed=9)
+    pruned_py = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    pruned_cpp = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_py)
+    onnx.checker.check_model(pruned_cpp)
+
+    rng = np.random.default_rng(10)
+    x = rng.standard_normal((6, K)).astype(np.float32)
+    (y_py,) = _run(pruned_py, {"X": x})
+    (y_cpp,) = _run(pruned_cpp, {"X": x})
+    np.testing.assert_allclose(y_py, y_cpp, rtol=1e-5, atol=1e-5)

--- a/tests/test_structured_pruning_cpp.py
+++ b/tests/test_structured_pruning_cpp.py
@@ -6,13 +6,13 @@ through shape-preserving elementwise ops, exactly one consumer of the same
 family), the gated-FFN (SwiGLU/GeGLU) topology (two producers combined by
 ``Mul`` or the native ``SwiGLU`` op, pruned to a shared combined-importance
 channel set), and Conv/MatMul residual (skip-connection) chains (a
-channel-preserving bare ``Add(a, b)`` merge point, resolved via backward walk
-plus union-find grouping) -- but not the pure-Python implementation's fused
+channel-preserving merge point -- a bare ``Add(a, b)`` for either family, or,
+MatMul/Gemm only, a fused
 ``com.microsoft::SkipLayerNormalization``/``SkipSimplifiedLayerNormalization``
-residual-merge recognition. Tests here are adapted from ``test_pruning.py``'s
-own ``apply_structured_pruning`` coverage, scoped to the topologies this port
-actually implements, plus a couple of tests confirming the unported
-topologies are left untouched (never guessed at).
+node -- resolved via backward walk plus union-find grouping). Tests here are
+adapted from ``test_pruning.py``'s own ``apply_structured_pruning`` coverage,
+plus a couple of tests confirming unmatched topologies are left untouched
+(never guessed at).
 """
 
 import numpy as np
@@ -1545,49 +1545,268 @@ def test_cpp_structured_pruning_matmul_residual_add_declines_on_bare_gqa_shortcu
     np.testing.assert_array_equal(inits["Wout"], wout)
 
 
-# --- Fused SkipLayerNormalization residual merge: unsupported by this port,
-# must stay untouched ---------------------------------------------------
+# --- Fused SkipLayerNormalization residual merge ----------------------------
 
 
-def test_cpp_structured_pruning_skip_layer_norm_residual_is_left_untouched():
-    # com.microsoft::SkipLayerNormalization fuses a bare residual Add plus
-    # the following LayerNorm -- what onnxruntime's transformer optimizer
-    # produces at every residual connection of a fully-optimized
-    # transformer. This port does not (yet) recognize it as an eligible
-    # merge point (see structured_pruning_entry.cpp's own scope note), so a
-    # model whose only prunable residual structure takes this fused shape is
-    # left completely untouched.
-    K, C, Out = 8, 16, 4
-    rng = np.random.default_rng(102)
-    wf = rng.standard_normal((K, C)).astype(np.float32)
-    ws = rng.standard_normal((K, C)).astype(np.float32)
-    gamma = rng.standard_normal((C,)).astype(np.float32)
-    wout = rng.standard_normal((C, Out)).astype(np.float32)
+def _skip_layer_norm_residual_diamond_model(
+    wf, ws, wout, gamma, beta=None, bias=None, simplified=False, epsilon=1e-5
+):
+    # y = SkipLayerNormalization(MatMul_f(X), MatMul_s(X), gamma, beta?,
+    # bias?) -- the SkipLayerNormalization/SkipSimplifiedLayerNormalization
+    # analogue of _matmul_residual_diamond_model: two entirely independent
+    # MatMul producers merge via the fused node instead of a bare Add, and
+    # must therefore still share one surviving channel-index set, feeding
+    # one real consumer.
+    K, C = wf.shape
+    Out = wout.shape[1]
+    op = "SkipSimplifiedLayerNormalization" if simplified else "SkipLayerNormalization"
+    initializer = [
+        _f32(wf, "WF"),
+        _f32(ws, "WS"),
+        _f32(wout, "WOUT"),
+        _f32(gamma, "Gamma"),
+    ]
+    inputs = ["f", "s", "Gamma"]
+    if not simplified:
+        inputs.append("Beta" if beta is not None else "")
+        if beta is not None:
+            initializer.append(_f32(beta, "Beta"))
+    if bias is not None:
+        inputs.append("Bias")
+        initializer.append(_f32(bias, "Bias"))
+    while inputs and inputs[-1] == "":
+        inputs.pop()
+    ins = ", ".join(inputs)
     model = _model(
         f"""
         g (float[batch,{K}] X) => (float[batch,{Out}] Y)
         {{
           f = MatMul(X, WF)
           s = MatMul(X, WS)
-          normed = com.microsoft.SkipLayerNormalization <epsilon=1e-5> (f, s, Gamma)
-          Y = MatMul(normed, WOUT)
+          y = com.microsoft.{op} <epsilon={epsilon}> ({ins})
+          Y = MatMul(y, WOUT)
+        }}
+        """,
+        initializer=initializer,
+        opset=17,
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+    return model
+
+
+def _skip_layer_norm_keep(wf, ws, C):
+    importance = np.sqrt(
+        np.square(np.linalg.norm(wf.astype(np.float64), axis=0))
+        + np.square(np.linalg.norm(ws.astype(np.float64), axis=0))
+    )
+    keep = np.sort(np.argsort(-importance)[: C // 2])
+    assert np.any(keep < C // 2) and np.any(keep >= C // 2)
+    return keep
+
+
+def _conflicting_wf_ws(seed, K, C):
+    rng = np.random.default_rng(seed)
+    scale_f = np.where(np.arange(C) < C // 2, 3.0, 0.3).astype(np.float32)
+    scale_s = np.where(np.arange(C) < C // 2, 0.3, 3.0).astype(np.float32)
+    wf = rng.standard_normal((K, C)).astype(np.float32) * scale_f
+    ws = rng.standard_normal((K, C)).astype(np.float32) * scale_s
+    return rng, wf, ws
+
+
+def test_cpp_structured_pruning_skip_layer_norm_residual_matches_oracle():
+    K, C, Out = 8, 16, 4
+    rng, wf, ws = _conflicting_wf_ws(110, K, C)
+    wout = rng.standard_normal((C, Out)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    beta = rng.standard_normal((C,)).astype(np.float32)
+    model = _skip_layer_norm_residual_diamond_model(wf, ws, wout, gamma, beta=beta)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["WF"].dims) == [K, C // 2]
+    assert list(inits["WS"].dims) == [K, C // 2]
+    assert list(inits["WOUT"].dims) == [C // 2, Out]
+    assert list(inits["Gamma"].dims) == [C // 2]
+    assert list(inits["Beta"].dims) == [C // 2]
+
+    keep = _skip_layer_norm_keep(wf, ws, C)
+    oracle = _skip_layer_norm_residual_diamond_model(
+        wf[:, keep], ws[:, keep], wout[keep, :], gamma[keep], beta=beta[keep]
+    )
+
+    rng_x = np.random.default_rng(111)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_skip_simplified_layer_norm_residual_matches_oracle():
+    # SkipSimplifiedLayerNormalization -- the RMSNorm variant LLaMA-style
+    # models use -- drops beta/mean-centering entirely.
+    K, C, Out = 8, 16, 4
+    rng, wf, ws = _conflicting_wf_ws(112, K, C)
+    wout = rng.standard_normal((C, Out)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    model = _skip_layer_norm_residual_diamond_model(
+        wf, ws, wout, gamma, simplified=True
+    )
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert "Beta" not in inits
+
+    keep = _skip_layer_norm_keep(wf, ws, C)
+    oracle = _skip_layer_norm_residual_diamond_model(
+        wf[:, keep], ws[:, keep], wout[keep, :], gamma[keep], simplified=True
+    )
+
+    rng_x = np.random.default_rng(113)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_skip_layer_norm_residual_with_bias_matches_oracle():
+    # bias present (and, deliberately, beta absent -- SkipLayerNorm's own
+    # optional inputs are independent of each other): exercises the
+    # bias-idx-shift in SkipLayerNormConstNames (bias lives at input index 4
+    # when beta is declared) and confirms Bias is sliced alongside Gamma.
+    K, C, Out = 8, 16, 4
+    rng, wf, ws = _conflicting_wf_ws(114, K, C)
+    wout = rng.standard_normal((C, Out)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    bias = rng.standard_normal((C,)).astype(np.float32)
+    model = _skip_layer_norm_residual_diamond_model(wf, ws, wout, gamma, bias=bias)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Bias"].dims) == [C // 2]
+
+    keep = _skip_layer_norm_keep(wf, ws, C)
+    oracle = _skip_layer_norm_residual_diamond_model(
+        wf[:, keep], ws[:, keep], wout[keep, :], gamma[keep], bias=bias[keep]
+    )
+
+    rng_x = np.random.default_rng(115)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_skip_layer_norm_residual_declines_on_nonconstant_beta():
+    # Beta is a graph input, not a constant initializer -- gamma (also
+    # required) is fine, but a present non-constant beta still means this
+    # pass can't slice it, so the whole chain is declined and the model is
+    # left byte-identical.
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(116)
+    wf = rng.standard_normal((K, C)).astype(np.float32)
+    ws = rng.standard_normal((K, C)).astype(np.float32)
+    wout = rng.standard_normal((C, Out)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X, float[{C}] Beta) => (float[batch,{Out}] Y)
+        {{
+          f = MatMul(X, WF)
+          s = MatMul(X, WS)
+          y = com.microsoft.SkipLayerNormalization <epsilon=1e-5> (f, s, Gamma, Beta)
+          Y = MatMul(y, WOUT)
         }}
         """,
         initializer=[
             _f32(wf, "WF"),
             _f32(ws, "WS"),
-            _f32(gamma, "Gamma"),
             _f32(wout, "WOUT"),
+            _f32(gamma, "Gamma"),
         ],
         opset=17,
     )
     model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
 
     pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
-    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
-    np.testing.assert_array_equal(inits["WF"], wf)
-    np.testing.assert_array_equal(inits["WS"], ws)
-    np.testing.assert_array_equal(inits["WOUT"], wout)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_structured_pruning_skip_layer_norm_residual_declines_on_consumed_mean_output():
+    # The training-only mean output (index 1) is actually consumed here
+    # (wired straight to a second graph output) -- onnxruntime's own CPU
+    # kernel never actually populates it, and this pass has no basis for
+    # whether pruning keeps it meaningful for whatever reads it, so the
+    # whole chain is declined outright, leaving the model byte-identical.
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(117)
+    wf = rng.standard_normal((K, C)).astype(np.float32)
+    ws = rng.standard_normal((K, C)).astype(np.float32)
+    wout = rng.standard_normal((C, Out)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    beta = rng.standard_normal((C,)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y, float[batch] MeanOut)
+        {{
+          f = MatMul(X, WF)
+          s = MatMul(X, WS)
+          y, MeanOut = com.microsoft.SkipLayerNormalization <epsilon=1e-5> (f, s, Gamma, Beta)
+          Y = MatMul(y, WOUT)
+        }}
+        """,
+        initializer=[
+            _f32(wf, "WF"),
+            _f32(ws, "WS"),
+            _f32(wout, "WOUT"),
+            _f32(gamma, "Gamma"),
+            _f32(beta, "Beta"),
+        ],
+        opset=17,
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_structured_pruning_skip_layer_norm_residual_declines_on_consumed_sum_output():
+    # The fourth output, input_skip_bias_sum (the raw, pre-normalization
+    # f + s), is consumed directly here by a second graph output. Its shape
+    # shrinks along with f/s, and this pass has no way to confirm the
+    # outside consumer still expects the new, narrower width. Declined
+    # outright, model left byte-identical.
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(119)
+    wf = rng.standard_normal((K, C)).astype(np.float32)
+    ws = rng.standard_normal((K, C)).astype(np.float32)
+    wout = rng.standard_normal((C, Out)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y, float[batch,{C}] SumOut)
+        {{
+          f = MatMul(X, WF)
+          s = MatMul(X, WS)
+          y, mean, inv_std, SumOut = com.microsoft.SkipSimplifiedLayerNormalization <epsilon=1e-5> (f, s, Gamma)
+          Y = MatMul(y, WOUT)
+        }}
+        """,
+        initializer=[
+            _f32(wf, "WF"),
+            _f32(ws, "WS"),
+            _f32(wout, "WOUT"),
+            _f32(gamma, "Gamma"),
+        ],
+        opset=17,
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    assert pruned.SerializeToString() == model.SerializeToString()
 
 
 # --- Cross-check against the pure-Python reference --------------------------

--- a/tests/test_structured_pruning_cpp.py
+++ b/tests/test_structured_pruning_cpp.py
@@ -3,11 +3,14 @@ of ``onnxsim.apply_structured_pruning`` (see
 ``onnxsim/structured_pruning_entry.cpp``). Scope note: this port covers the
 "plain chain" topologies (a MatMul/vanilla-Gemm or Conv producer feeding,
 through shape-preserving elementwise ops, exactly one consumer of the same
-family) and the gated-FFN (SwiGLU/GeGLU) topology (two producers combined by
+family), the gated-FFN (SwiGLU/GeGLU) topology (two producers combined by
 ``Mul`` or the native ``SwiGLU`` op, pruned to a shared combined-importance
-channel set) -- not the pure-Python implementation's residual/skip-connection
-chain support. Tests here are adapted from ``test_pruning.py``'s own
-``apply_structured_pruning`` coverage, scoped to the topologies this port
+channel set), and Conv/MatMul residual (skip-connection) chains (a
+channel-preserving bare ``Add(a, b)`` merge point, resolved via backward walk
+plus union-find grouping) -- but not the pure-Python implementation's fused
+``com.microsoft::SkipLayerNormalization``/``SkipSimplifiedLayerNormalization``
+residual-merge recognition. Tests here are adapted from ``test_pruning.py``'s
+own ``apply_structured_pruning`` coverage, scoped to the topologies this port
 actually implements, plus a couple of tests confirming the unported
 topologies are left untouched (never guessed at).
 """
@@ -963,6 +966,628 @@ def test_cpp_structured_pruning_skips_mismatched_grouped_producer_and_consumer()
     inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
     np.testing.assert_array_equal(inits["W1"], w1)
     np.testing.assert_array_equal(inits["W2"], w2)
+
+
+# --- Conv residual (Add-merged) chains --------------------------------------
+
+
+def _residual_diamond_model(w_f, w_s, w_out, spatial=10):
+    # y = Conv_out(Relu(Add(Conv_f(X), Conv_s(X)))) -- a "projection
+    # shortcut" residual block: two entirely independent Conv producers
+    # merge via Add and must therefore share one surviving channel-index
+    # set, feeding one real consumer.
+    Cin = w_f.shape[1]
+    Cout = w_out.shape[0]
+    out_spatial = spatial - 4  # two chained 3x3 valid convs
+    return _model(
+        f"""
+        g (float[N,{Cin},{spatial},{spatial}] X) => (float[N,{Cout},{out_spatial},{out_spatial}] Y)
+        {{
+          f = Conv<kernel_shape=[3,3]>(X, WF)
+          s = Conv<kernel_shape=[3,3]>(X, WS)
+          addr = Add(f, s)
+          r = Relu(addr)
+          Y = Conv<kernel_shape=[3,3]>(r, WOUT)
+        }}
+        """,
+        initializer=[_f32(w_f, "WF"), _f32(w_s, "WS"), _f32(w_out, "WOUT")],
+    )
+
+
+def _residual_transitive_model(w_f1, w_s1, w_f2, w_out, spatial=10):
+    # Two Add merges chained transitively, sharing one spine channel count,
+    # with no branch anywhere along the chain: add1's own output feeds only
+    # into add2, never reused elsewhere -- the union-find grouping extends
+    # across both Adds into one group of three producers.
+    Cin = w_f1.shape[1]
+    Cz = w_f2.shape[1]
+    Cout = w_out.shape[0]
+    add1_spatial = spatial - 2  # one 3x3 valid conv each, from X
+    out_spatial = add1_spatial - 2  # WOUT's own 3x3 valid conv
+    return _model(
+        f"""
+        g (float[N,{Cin},{spatial},{spatial}] X, float[N,{Cz},{add1_spatial},{add1_spatial}] Z)
+            => (float[N,{Cout},{out_spatial},{out_spatial}] Y)
+        {{
+          f1 = Conv<kernel_shape=[3,3]>(X, WF1)
+          s1 = Conv<kernel_shape=[3,3]>(X, WS1)
+          add1 = Add(f1, s1)
+          f2 = Conv<kernel_shape=[1,1]>(Z, WF2)
+          add2 = Add(f2, add1)
+          r = Relu(add2)
+          Y = Conv<kernel_shape=[3,3]>(r, WOUT)
+        }}
+        """,
+        initializer=[
+            _f32(w_f1, "WF1"),
+            _f32(w_s1, "WS1"),
+            _f32(w_f2, "WF2"),
+            _f32(w_out, "WOUT"),
+        ],
+    )
+
+
+def test_cpp_structured_pruning_conv_residual_add_matches_oracle():
+    Cin, C, Cout = 3, 16, 8
+    rng = np.random.default_rng(80)
+    w_f = rng.standard_normal((C, Cin, 3, 3)).astype(np.float32)
+    w_s = rng.standard_normal((C, Cin, 3, 3)).astype(np.float32)
+    w_out = rng.standard_normal((Cout, C, 3, 3)).astype(np.float32)
+    model = _residual_diamond_model(w_f, w_s, w_out)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["WF"].dims) == [C // 2, Cin, 3, 3]
+    assert list(inits["WS"].dims) == [C // 2, Cin, 3, 3]
+    assert list(inits["WOUT"].dims) == [Cout, C // 2, 3, 3]
+
+    importance = np.sqrt(
+        np.square(np.linalg.norm(w_f.reshape(C, -1).astype(np.float64), axis=1))
+        + np.square(np.linalg.norm(w_s.reshape(C, -1).astype(np.float64), axis=1))
+    )
+    keep = np.sort(np.argsort(-importance)[: C // 2])
+    oracle = _residual_diamond_model(w_f[keep], w_s[keep], w_out[:, keep])
+
+    rng_x = np.random.default_rng(81)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_conv_residual_add_transitive_chain_matches_oracle():
+    Cin, C, Cz, Cout = 3, 16, 5, 8
+    rng = np.random.default_rng(82)
+    w_f1 = rng.standard_normal((C, Cin, 3, 3)).astype(np.float32)
+    w_s1 = rng.standard_normal((C, Cin, 3, 3)).astype(np.float32)
+    w_f2 = rng.standard_normal((C, Cz, 1, 1)).astype(np.float32)
+    w_out = rng.standard_normal((Cout, C, 3, 3)).astype(np.float32)
+    model = _residual_transitive_model(w_f1, w_s1, w_f2, w_out)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    importance = np.sqrt(
+        np.square(np.linalg.norm(w_f1.reshape(C, -1).astype(np.float64), axis=1))
+        + np.square(np.linalg.norm(w_s1.reshape(C, -1).astype(np.float64), axis=1))
+        + np.square(np.linalg.norm(w_f2.reshape(C, -1).astype(np.float64), axis=1))
+    )
+    keep = np.sort(np.argsort(-importance)[: C // 2])
+    oracle = _residual_transitive_model(
+        w_f1[keep], w_s1[keep], w_f2[keep], w_out[:, keep]
+    )
+
+    rng_x = np.random.default_rng(83)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    z = rng_x.standard_normal((2, Cz, 8, 8)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x, "Z": z})
+    (y_oracle,) = _run(oracle, {"X": x, "Z": z})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_conv_residual_add_declines_on_fan_out_branch():
+    # A realistic multi-block residual stage's interior boundary: `r`
+    # (add1's own post-block tensor) is read twice -- once by the next
+    # block's own first Conv, once unchanged as that next block's own Add
+    # shortcut operand -- exactly the fan-out backward walk's
+    # single-consumer bar declines. Left completely untouched.
+    Cin, C, Cout = 3, 16, 8
+    rng = np.random.default_rng(84)
+    w_f = rng.standard_normal((C, Cin, 3, 3)).astype(np.float32)
+    w_s = rng.standard_normal((C, Cin, 3, 3)).astype(np.float32)
+    w_next = rng.standard_normal((C, C, 1, 1)).astype(np.float32)
+    w_out = rng.standard_normal((Cout, C, 1, 1)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{Cout},8,8] Y)
+        {{
+          f = Conv<kernel_shape=[3,3]>(X, WF)
+          s = Conv<kernel_shape=[3,3]>(X, WS)
+          add1 = Add(f, s)
+          r = Relu(add1)
+          nxt = Conv<kernel_shape=[1,1]>(r, WNEXT)
+          add2 = Add(nxt, r)
+          Y = Conv<kernel_shape=[1,1]>(add2, WOUT)
+        }}
+        """,
+        initializer=[
+            _f32(w_f, "WF"),
+            _f32(w_s, "WS"),
+            _f32(w_next, "WNEXT"),
+            _f32(w_out, "WOUT"),
+        ],
+    )
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["WF"], w_f)
+    np.testing.assert_array_equal(inits["WS"], w_s)
+    np.testing.assert_array_equal(inits["WNEXT"], w_next)
+    np.testing.assert_array_equal(inits["WOUT"], w_out)
+
+
+def test_cpp_structured_pruning_conv_residual_add_declines_on_identity_shortcut():
+    # y = Conv2(Relu(Add(Conv1(X), X))): a classic identity-shortcut
+    # residual block with no Conv on the shortcut path at all. X has no
+    # producer this pass owns (it's a graph input) and is itself read
+    # twice (by Conv1 and directly by Add) -- either alone is enough to
+    # decline.
+    C, Cout = 8, 4
+    rng = np.random.default_rng(85)
+    w1 = rng.standard_normal((C, C, 1, 1)).astype(np.float32)
+    w2 = rng.standard_normal((Cout, C, 1, 1)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{C},10,10] X) => (float[N,{Cout},10,10] Y)
+        {{
+          f = Conv<kernel_shape=[1,1]>(X, W1)
+          add1 = Add(f, X)
+          r = Relu(add1)
+          Y = Conv<kernel_shape=[1,1]>(r, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2")],
+    )
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+
+
+def test_cpp_structured_pruning_conv_residual_add_declines_on_grouped_conv_consumer():
+    # Two independent Conv branches merge via Add, but the downstream
+    # consumer is a general grouped Conv (group=2) -- a composition the
+    # residual finder explicitly declines (_chain_group's per-group top-k
+    # assumes each producer feeds the consumer's full channel range, which a
+    # residual group's combined-importance ranking doesn't establish).
+    Cin, C, Cout, group = 3, 16, 8, 2
+    rng = np.random.default_rng(89)
+    w_f = rng.standard_normal((C, Cin, 3, 3)).astype(np.float32)
+    w_s = rng.standard_normal((C, Cin, 3, 3)).astype(np.float32)
+    w_out = rng.standard_normal((Cout, C // group, 1, 1)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{Cout},8,8] Y)
+        {{
+          f = Conv<kernel_shape=[3,3]>(X, WF)
+          s = Conv<kernel_shape=[3,3]>(X, WS)
+          addr = Add(f, s)
+          r = Relu(addr)
+          Y = Conv<kernel_shape=[1,1],group={group}>(r, WOUT)
+        }}
+        """,
+        initializer=[_f32(w_f, "WF"), _f32(w_s, "WS"), _f32(w_out, "WOUT")],
+    )
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["WF"], w_f)
+    np.testing.assert_array_equal(inits["WS"], w_s)
+    np.testing.assert_array_equal(inits["WOUT"], w_out)
+
+
+# --- MatMul/Gemm residual (Add-merged) chains -------------------------------
+
+
+def _matmul_residual_diamond_model(wf, ws, wout):
+    # y = MatMul_out(Relu(Add(MatMul_f(X), MatMul_s(X)))) -- the MatMul/Gemm
+    # analogue of _residual_diamond_model.
+    K, C = wf.shape
+    Out = wout.shape[1]
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          f = MatMul(X, WF)
+          s = MatMul(X, WS)
+          addr = Add(f, s)
+          r = Relu(addr)
+          Y = MatMul(r, WOUT)
+        }}
+        """,
+        initializer=[_f32(wf, "WF"), _f32(ws, "WS"), _f32(wout, "WOUT")],
+    )
+
+
+def _matmul_residual_transitive_model(wf1, ws1, wf2, wout):
+    # Two Add merges chained transitively, sharing one spine channel count
+    # -- the MatMul/Gemm analogue of _residual_transitive_model.
+    K, C = wf1.shape
+    Kz = wf2.shape[0]
+    Out = wout.shape[1]
+    return _model(
+        f"""
+        g (float[batch,{K}] X, float[batch,{Kz}] Z) => (float[batch,{Out}] Y)
+        {{
+          f1 = MatMul(X, WF1)
+          s1 = MatMul(X, WS1)
+          add1 = Add(f1, s1)
+          f2 = MatMul(Z, WF2)
+          add2 = Add(f2, add1)
+          r = Relu(add2)
+          Y = MatMul(r, WOUT)
+        }}
+        """,
+        initializer=[
+            _f32(wf1, "WF1"),
+            _f32(ws1, "WS1"),
+            _f32(wf2, "WF2"),
+            _f32(wout, "WOUT"),
+        ],
+    )
+
+
+def test_cpp_structured_pruning_matmul_residual_add_matches_oracle():
+    # Weights deliberately built so the two branches disagree about which
+    # channels matter most, so the correct combined-importance keep set is
+    # neither branch's own individual top-k.
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(90)
+    scale_f = np.where(np.arange(C) < C // 2, 3.0, 0.3).astype(np.float32)
+    scale_s = np.where(np.arange(C) < C // 2, 0.3, 3.0).astype(np.float32)
+    wf = rng.standard_normal((K, C)).astype(np.float32) * scale_f
+    ws = rng.standard_normal((K, C)).astype(np.float32) * scale_s
+    wout = rng.standard_normal((C, Out)).astype(np.float32)
+    model = _matmul_residual_diamond_model(wf, ws, wout)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    importance = np.sqrt(
+        np.square(np.linalg.norm(wf.astype(np.float64), axis=0))
+        + np.square(np.linalg.norm(ws.astype(np.float64), axis=0))
+    )
+    keep = np.sort(np.argsort(-importance)[: C // 2])
+    assert np.any(keep < C // 2) and np.any(keep >= C // 2)
+    oracle = _matmul_residual_diamond_model(wf[:, keep], ws[:, keep], wout[keep, :])
+
+    rng_x = np.random.default_rng(91)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_matmul_residual_add_transitive_chain_matches_oracle():
+    K, C, Kz, Out = 8, 16, 5, 4
+    rng = np.random.default_rng(92)
+    wf1 = rng.standard_normal((K, C)).astype(np.float32)
+    ws1 = rng.standard_normal((K, C)).astype(np.float32)
+    wf2 = rng.standard_normal((Kz, C)).astype(np.float32)
+    wout = rng.standard_normal((C, Out)).astype(np.float32)
+    model = _matmul_residual_transitive_model(wf1, ws1, wf2, wout)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    importance = np.sqrt(
+        np.square(np.linalg.norm(wf1.astype(np.float64), axis=0))
+        + np.square(np.linalg.norm(ws1.astype(np.float64), axis=0))
+        + np.square(np.linalg.norm(wf2.astype(np.float64), axis=0))
+    )
+    keep = np.sort(np.argsort(-importance)[: C // 2])
+    oracle = _matmul_residual_transitive_model(
+        wf1[:, keep], ws1[:, keep], wf2[:, keep], wout[keep, :]
+    )
+
+    rng_x = np.random.default_rng(93)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    z = rng_x.standard_normal((5, Kz)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x, "Z": z})
+    (y_oracle,) = _run(oracle, {"X": x, "Z": z})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_matmul_residual_add_declines_on_fan_out_branch():
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(94)
+    wf = rng.standard_normal((K, C)).astype(np.float32)
+    ws = rng.standard_normal((K, C)).astype(np.float32)
+    wnext = rng.standard_normal((C, C)).astype(np.float32)
+    wout = rng.standard_normal((C, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          f = MatMul(X, WF)
+          s = MatMul(X, WS)
+          add1 = Add(f, s)
+          r = Relu(add1)
+          nxt = MatMul(r, WNEXT)
+          add2 = Add(nxt, r)
+          Y = MatMul(add2, WOUT)
+        }}
+        """,
+        initializer=[
+            _f32(wf, "WF"),
+            _f32(ws, "WS"),
+            _f32(wnext, "WNEXT"),
+            _f32(wout, "WOUT"),
+        ],
+    )
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["WF"], wf)
+    np.testing.assert_array_equal(inits["WS"], ws)
+    np.testing.assert_array_equal(inits["WNEXT"], wnext)
+    np.testing.assert_array_equal(inits["WOUT"], wout)
+
+
+def test_cpp_structured_pruning_matmul_residual_add_declines_on_identity_shortcut():
+    # y = MatMul2(Relu(Add(MatMul1(X), X))): the exact x = x + f(x)
+    # transformer-residual identity-shortcut shape, no MatMul on the
+    # shortcut path at all.
+    C, Out = 8, 4
+    rng = np.random.default_rng(95)
+    w1 = rng.standard_normal((C, C)).astype(np.float32)
+    w2 = rng.standard_normal((C, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{C}] X) => (float[batch,{Out}] Y)
+        {{
+          f = MatMul(X, W1)
+          add1 = Add(f, X)
+          r = Relu(add1)
+          Y = MatMul(r, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2")],
+    )
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+
+
+def test_cpp_structured_pruning_matmul_residual_add_with_bias_hop_matches_oracle():
+    # One branch has a per-channel bias Add (a separate node, not Gemm's own
+    # bias input) between its producer and the residual merge -- exercises
+    # the wider MatMul/Gemm-only hop set and the self-consistent-then-
+    # revalidate check that tells this bias Add apart from an eligible
+    # residual-merge Add.
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(96)
+    w1 = rng.standard_normal((K, C)).astype(np.float32)
+    bias = rng.standard_normal((C,)).astype(np.float32)
+    ws = rng.standard_normal((K, C)).astype(np.float32)
+    wout = rng.standard_normal((C, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          h = MatMul(X, W1)
+          hb = Add(h, Bias)
+          f = Relu(hb)
+          s = MatMul(X, WS)
+          addr = Add(f, s)
+          r = Relu(addr)
+          Y = MatMul(r, WOUT)
+        }}
+        """,
+        initializer=[
+            _f32(w1, "W1"),
+            _f32(bias, "Bias"),
+            _f32(ws, "WS"),
+            _f32(wout, "WOUT"),
+        ],
+    )
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Bias"].dims) == [C // 2]
+
+    importance = np.sqrt(
+        np.square(np.linalg.norm(w1.astype(np.float64), axis=0))
+        + np.square(np.linalg.norm(ws.astype(np.float64), axis=0))
+    )
+    keep = np.sort(np.argsort(-importance)[: C // 2])
+
+    rng_x = np.random.default_rng(97)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    f = np.maximum(x @ w1[:, keep] + bias[keep], 0)
+    s = x @ ws[:, keep]
+    y_oracle = np.maximum(f + s, 0) @ wout[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_matmul_residual_add_transposed_gemm_producer_matches_oracle():
+    # One branch is a Gemm with transB=1 (weight stored [N, K]) rather than
+    # a plain MatMul's [K, N] -- a regression test for weight_transposed
+    # being carried correctly through the backward walk.
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(98)
+    w1t = rng.standard_normal((C, K)).astype(np.float32)  # [N, K] -- transB=1 layout
+    ws = rng.standard_normal((K, C)).astype(np.float32)
+    wout = rng.standard_normal((C, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          f = Gemm<transB = 1>(X, W1T)
+          s = MatMul(X, WS)
+          addr = Add(f, s)
+          r = Relu(addr)
+          Y = MatMul(r, WOUT)
+        }}
+        """,
+        initializer=[_f32(w1t, "W1T"), _f32(ws, "WS"), _f32(wout, "WOUT")],
+    )
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1T"].dims) == [C // 2, K]
+
+    importance = np.sqrt(
+        np.square(np.linalg.norm(w1t.astype(np.float64), axis=1))
+        + np.square(np.linalg.norm(ws.astype(np.float64), axis=0))
+    )
+    keep = np.sort(np.argsort(-importance)[: C // 2])
+
+    rng_x = np.random.default_rng(99)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    f = x @ w1t[keep, :].T
+    s = x @ ws[:, keep]
+    y_oracle = np.maximum(f + s, 0) @ wout[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_matmul_residual_add_declines_on_gated_branch_with_no_projection():
+    # A gated (SwiGLU-style) combine feeding directly into a residual Add,
+    # with no output-projection MatMul between the Mul and the Add -- the
+    # backward walk has no principled way to pick "the" one branch through a
+    # Mul of two non-constant operands, so this falls straight through to
+    # "fail" and the whole group is declined.
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(100)
+    wg = rng.standard_normal((K, C)).astype(np.float32)
+    wu = rng.standard_normal((K, C)).astype(np.float32)
+    wp = rng.standard_normal((K, C)).astype(np.float32)
+    wout = rng.standard_normal((C, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          gate = MatMul(X, WG)
+          gate_act = Sigmoid(gate)
+          up = MatMul(X, WU)
+          h = Mul(gate_act, up)
+          p = MatMul(X, WP)
+          addr = Add(p, h)
+          r = Relu(addr)
+          Y = MatMul(r, WOUT)
+        }}
+        """,
+        initializer=[
+            _f32(wg, "WG"),
+            _f32(wu, "WU"),
+            _f32(wp, "WP"),
+            _f32(wout, "WOUT"),
+        ],
+    )
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["WG"], wg)
+    np.testing.assert_array_equal(inits["WU"], wu)
+    np.testing.assert_array_equal(inits["WP"], wp)
+    np.testing.assert_array_equal(inits["WOUT"], wout)
+
+
+def test_cpp_structured_pruning_matmul_residual_add_declines_on_bare_gqa_shortcut():
+    # A residual branch whose backward walk would need to cross a fused
+    # self-attention op boundary to reach a real producer -- ctx (a
+    # GroupQueryAttention node's own raw output) feeds directly into the
+    # residual Add, with no output-projection MatMul in between. Neither
+    # GroupQueryAttention nor its Q/K/V MatMul producers can be reached
+    # through it.
+    K, H, D, Out = 8, 4, 4, 6
+    Nqkv = H * D
+    rng = np.random.default_rng(101)
+    wq = rng.standard_normal((K, Nqkv)).astype(np.float32)
+    wk = rng.standard_normal((K, Nqkv)).astype(np.float32)
+    wv = rng.standard_normal((K, Nqkv)).astype(np.float32)
+    wp = rng.standard_normal((K, Nqkv)).astype(np.float32)
+    wout = rng.standard_normal((Nqkv, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[2,5,{K}] X) => (float[2,5,{Out}] Y)
+        {{
+          q = MatMul(X, Wq)
+          k = MatMul(X, Wk)
+          v = MatMul(X, Wv)
+          ctx, present_k, present_v = com.microsoft.GroupQueryAttention <num_heads={H}, kv_num_heads={H}> (q, k, v)
+          p = MatMul(X, Wp)
+          addr = Add(p, ctx)
+          r = Relu(addr)
+          Y = MatMul(r, Wout)
+        }}
+        """,
+        initializer=[
+            _f32(wq, "Wq"),
+            _f32(wk, "Wk"),
+            _f32(wv, "Wv"),
+            _f32(wp, "Wp"),
+            _f32(wout, "Wout"),
+        ],
+        opset=17,
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["Wq"], wq)
+    np.testing.assert_array_equal(inits["Wk"], wk)
+    np.testing.assert_array_equal(inits["Wv"], wv)
+    np.testing.assert_array_equal(inits["Wp"], wp)
+    np.testing.assert_array_equal(inits["Wout"], wout)
+
+
+# --- Fused SkipLayerNormalization residual merge: unsupported by this port,
+# must stay untouched ---------------------------------------------------
+
+
+def test_cpp_structured_pruning_skip_layer_norm_residual_is_left_untouched():
+    # com.microsoft::SkipLayerNormalization fuses a bare residual Add plus
+    # the following LayerNorm -- what onnxruntime's transformer optimizer
+    # produces at every residual connection of a fully-optimized
+    # transformer. This port does not (yet) recognize it as an eligible
+    # merge point (see structured_pruning_entry.cpp's own scope note), so a
+    # model whose only prunable residual structure takes this fused shape is
+    # left completely untouched.
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(102)
+    wf = rng.standard_normal((K, C)).astype(np.float32)
+    ws = rng.standard_normal((K, C)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    wout = rng.standard_normal((C, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          f = MatMul(X, WF)
+          s = MatMul(X, WS)
+          normed = com.microsoft.SkipLayerNormalization <epsilon=1e-5> (f, s, Gamma)
+          Y = MatMul(normed, WOUT)
+        }}
+        """,
+        initializer=[
+            _f32(wf, "WF"),
+            _f32(ws, "WS"),
+            _f32(gamma, "Gamma"),
+            _f32(wout, "WOUT"),
+        ],
+        opset=17,
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["WF"], wf)
+    np.testing.assert_array_equal(inits["WS"], ws)
+    np.testing.assert_array_equal(inits["WOUT"], wout)
 
 
 # --- Cross-check against the pure-Python reference --------------------------

--- a/tests/test_structured_pruning_cpp.py
+++ b/tests/test_structured_pruning_cpp.py
@@ -1,13 +1,15 @@
 """Tests for ``onnxsim.apply_structured_pruning_cpp`` -- the C++-backed port
 of ``onnxsim.apply_structured_pruning`` (see
-``onnxsim/structured_pruning_entry.cpp``). Scope note: this port covers only
-the two "plain chain" topologies (a MatMul/vanilla-Gemm or Conv producer
-feeding, through shape-preserving elementwise ops, exactly one consumer of
-the same family) -- not the pure-Python implementation's gated-FFN or
-residual/skip-connection chain support. Tests here are adapted from
-``test_pruning.py``'s own ``apply_structured_pruning`` coverage, scoped to
-the topologies this port actually implements, plus a couple of tests
-confirming the unported topologies are left untouched (never guessed at).
+``onnxsim/structured_pruning_entry.cpp``). Scope note: this port covers the
+"plain chain" topologies (a MatMul/vanilla-Gemm or Conv producer feeding,
+through shape-preserving elementwise ops, exactly one consumer of the same
+family) and the gated-FFN (SwiGLU/GeGLU) topology (two producers combined by
+``Mul`` or the native ``SwiGLU`` op, pruned to a shared combined-importance
+channel set) -- not the pure-Python implementation's residual/skip-connection
+chain support. Tests here are adapted from ``test_pruning.py``'s own
+``apply_structured_pruning`` coverage, scoped to the topologies this port
+actually implements, plus a couple of tests confirming the unported
+topologies are left untouched (never guessed at).
 """
 
 import numpy as np
@@ -369,12 +371,19 @@ def test_cpp_structured_pruning_chains_through_a_third_layer():
     np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
 
 
-# --- Gated FFN: unsupported by this port, must stay untouched --------------
+# --- Gated FFN (SwiGLU/GeGLU) -----------------------------------------------
 
 
-def test_cpp_structured_pruning_gated_ffn_is_left_untouched():
-    K, H, Out = 8, 16, 4
-    rng = np.random.default_rng(7)
+def _combined_keep_indices(w_gate, w_up, keep_count):
+    importance = np.sqrt(
+        np.square(np.linalg.norm(w_gate.T, axis=1))
+        + np.square(np.linalg.norm(w_up.T, axis=1))
+    )
+    return np.sort(np.argsort(-importance)[:keep_count])
+
+
+def _swiglu_mlp_model(K=8, H=16, Out=4, gate_activation="Sigmoid", seed=0):
+    rng = np.random.default_rng(seed)
     wg = rng.standard_normal((K, H)).astype(np.float32)
     wu = rng.standard_normal((K, H)).astype(np.float32)
     wd = rng.standard_normal((H, Out)).astype(np.float32)
@@ -383,7 +392,7 @@ def test_cpp_structured_pruning_gated_ffn_is_left_untouched():
         g (float[batch,{K}] X) => (float[batch,{Out}] Y)
         {{
           gate = MatMul(X, Wg)
-          gate_act = Sigmoid(gate)
+          gate_act = {gate_activation}(gate)
           up = MatMul(X, Wu)
           h = Mul(gate_act, up)
           Y = MatMul(h, Wd)
@@ -391,11 +400,214 @@ def test_cpp_structured_pruning_gated_ffn_is_left_untouched():
         """,
         initializer=[_f32(wg, "Wg"), _f32(wu, "Wu"), _f32(wd, "Wd")],
     )
+    return model, wg, wu, wd
+
+
+def test_cpp_structured_pruning_gated_ffn_matches_oracle():
+    K, H, Out = 8, 16, 4
+    model, wg, wu, wd = _swiglu_mlp_model(K=K, H=H, Out=Out)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Wg"].dims) == [K, H // 2]
+    assert list(inits["Wu"].dims) == [K, H // 2]
+    assert list(inits["Wd"].dims) == [H // 2, Out]
+
+    keep = _combined_keep_indices(wg, wu, H // 2)
+    rng = np.random.default_rng(10)
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+
+    gate = 1.0 / (1.0 + np.exp(-(x @ wg[:, keep])))
+    up = x @ wu[:, keep]
+    y_oracle = (gate * up) @ wd[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_gated_ffn_prunes_both_branches_to_same_channels():
+    # The real bug this pattern risks: gate and up disagreeing on which
+    # channels survive, which would silently break the elementwise
+    # product's alignment. Assert they select the identical index set,
+    # not just that both shrank to the same *count*.
+    K, H, Out = 8, 20, 4
+    model, wg, wu, _ = _swiglu_mlp_model(K=K, H=H, Out=Out, seed=1)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.3)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    keep = _combined_keep_indices(wg, wu, H - round(H * 0.3))
+
+    np.testing.assert_array_equal(inits["Wg"], wg[:, keep])
+    np.testing.assert_array_equal(inits["Wu"], wu[:, keep])
+
+
+def test_cpp_structured_pruning_gelu_gated_ffn_matches_oracle():
+    # GeGLU: same gated topology, a different (still-unary) gate activation.
+    # Uses Gelu's tanh approximation so the oracle needs no scipy/erf.
+    K, H, Out = 8, 16, 4
+    rng = np.random.default_rng(11)
+    wg = rng.standard_normal((K, H)).astype(np.float32)
+    wu = rng.standard_normal((K, H)).astype(np.float32)
+    wd = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          gate = MatMul(X, Wg)
+          gate_act = Gelu<approximate = "tanh">(gate)
+          up = MatMul(X, Wu)
+          h = Mul(gate_act, up)
+          Y = MatMul(h, Wd)
+        }}
+        """,
+        initializer=[_f32(wg, "Wg"), _f32(wu, "Wu"), _f32(wd, "Wd")],
+    )
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    keep = _combined_keep_indices(wg, wu, H // 2)
+
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+
+    g = x @ wg[:, keep]
+    gate = 0.5 * g * (1.0 + np.tanh(np.sqrt(2.0 / np.pi) * (g + 0.044715 * g**3)))
+    up = x @ wu[:, keep]
+    y_oracle = (gate * up) @ wd[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_cpp_structured_pruning_ungated_mul_of_two_producers_still_matches_oracle():
+    # No activation at all on either branch -- a plain (unactivated) GLU,
+    # both Mul operands are raw producer outputs directly.
+    K, H, Out = 8, 12, 4
+    rng = np.random.default_rng(2)
+    w1 = rng.standard_normal((K, H)).astype(np.float32)
+    w2 = rng.standard_normal((K, H)).astype(np.float32)
+    w3 = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          a = MatMul(X, W1)
+          b = MatMul(X, W2)
+          h = Mul(a, b)
+          Y = MatMul(h, W3)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2"), _f32(w3, "W3")],
+    )
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    keep = _combined_keep_indices(w1, w2, H // 2)
+
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    y_oracle = ((x @ w1[:, keep]) * (x @ w2[:, keep])) @ w3[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_gated_mul_against_constant_scale_is_not_a_gate():
+    # Mul(a, constant) is the existing per-channel-scale chain continuation
+    # (already covered elsewhere), not a two-producer gated pair -- the
+    # constant operand must never be mistaken for a second producer.
+    K, H, Out = 8, 12, 4
+    rng = np.random.default_rng(3)
+    w1 = rng.standard_normal((K, H)).astype(np.float32)
+    scale = rng.standard_normal((H,)).astype(np.float32)
+    w2 = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          a = MatMul(X, W1)
+          h = Mul(a, Scale)
+          Y = MatMul(h, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(scale, "Scale"), _f32(w2, "W2")],
+    )
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [K, H // 2]
+    assert list(inits["Scale"].dims) == [H // 2]
+    assert list(inits["W2"].dims) == [H // 2, Out]
+
+
+def test_cpp_structured_pruning_gated_ffn_skips_when_a_branch_also_feeds_elsewhere():
+    # "up" also feeding a second consumer directly means pruning its
+    # channels would silently change what that other consumer sees --
+    # must be left completely untouched, same bar as the plain-chain case.
+    K, H, Out = 8, 12, 4
+    rng = np.random.default_rng(4)
+    wg = rng.standard_normal((K, H)).astype(np.float32)
+    wu = rng.standard_normal((K, H)).astype(np.float32)
+    wd = rng.standard_normal((H, Out)).astype(np.float32)
+    wother = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y1, float[batch,{Out}] Y2)
+        {{
+          gate = MatMul(X, Wg)
+          gate_act = Sigmoid(gate)
+          up = MatMul(X, Wu)
+          h = Mul(gate_act, up)
+          Y1 = MatMul(h, Wd)
+          Y2 = MatMul(up, Wother)
+        }}
+        """,
+        initializer=[
+            _f32(wg, "Wg"),
+            _f32(wu, "Wu"),
+            _f32(wd, "Wd"),
+            _f32(wother, "Wother"),
+        ],
+    )
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Wg"].dims) == [K, H]
+    assert list(inits["Wu"].dims) == [K, H]
+    assert list(inits["Wd"].dims) == [H, Out]
+
+
+def test_cpp_structured_pruning_native_swiglu_node_prunes_both_producers_together():
+    # ONNX's native fused SwiGLU(a, b) = swish(a) * b (opset 28+): the
+    # activation lives entirely inside the op, so a/b must be raw producer
+    # outputs with no separate activation node in between. Not yet
+    # supported by the installed onnx checker/onnxruntime in this
+    # environment (opset 28 is still under development upstream), so this
+    # verifies the graph surgery directly via tensor values rather than
+    # onnx.checker/onnxruntime execution.
+    K, H, Out = 8, 16, 4
+    rng = np.random.default_rng(5)
+    wg = rng.standard_normal((K, H)).astype(np.float32)
+    wu = rng.standard_normal((K, H)).astype(np.float32)
+    wd = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          gate = MatMul(X, Wg)
+          up = MatMul(X, Wu)
+          h = SwiGLU(gate, up)
+          Y = MatMul(h, Wd)
+        }}
+        """,
+        initializer=[_f32(wg, "Wg"), _f32(wu, "Wu"), _f32(wd, "Wd")],
+        opset=28,
+    )
+
     pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
     inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
-    np.testing.assert_array_equal(inits["Wg"], wg)
-    np.testing.assert_array_equal(inits["Wu"], wu)
-    np.testing.assert_array_equal(inits["Wd"], wd)
+    keep = _combined_keep_indices(wg, wu, H // 2)
+
+    np.testing.assert_array_equal(inits["Wg"], wg[:, keep])
+    np.testing.assert_array_equal(inits["Wu"], wu[:, keep])
+    np.testing.assert_array_equal(inits["Wd"], wd[keep, :])
 
 
 # --- Conv plain chains -------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #888, completing the C++ port of `onnxsim.apply_structured_pruning` and adding a new C++ port of `onnxsim.apply_attention_head_pruning`. Five commits, each independently landable:

- **Port structured (channel) pruning's plain-chain cases to C++** — MatMul/vanilla-Gemm and Conv producer→consumer chains, including depthwise pass-through and general grouped Conv, as `onnxsim.apply_structured_pruning_cpp`.
- **Extend to gated-FFN (SwiGLU/GeGLU) chains** — two producers combined by `Mul` (or ONNX opset-28+'s native `SwiGLU` node) feeding one consumer, pruned to a shared combined-importance channel set.
- **Extend to Conv/MatMul residual (skip-connection) chains** — a backward walk plus union-find grouping across eligible `Add` merge points, covering a channel-preserving `Add(a, b)` residual/skip connection (including transitive multi-`Add` spines), while declining fan-out branches, identity shortcuts, and other topologies the Python reference also declines.
- **Recognize fused `SkipLayerNormalization` as a MatMul residual merge point** — what onnxruntime's transformer optimizer collapses a bare residual `Add` plus the following LayerNorm into, closing the gap for fully-optimized transformer models.
- **Port attention-head pruning to C++** — a new `onnxsim.apply_attention_head_pruning_cpp`, covering all three fused self-attention op families: `com.microsoft::Attention` (merged QKV weight, individual-head granularity), `com.microsoft::GroupQueryAttention`, and the plain `ai.onnx::Attention` op (opset 24+), both pruned at whole-KV-group granularity.

Together these bring the C++ port to full parity with the Python reference's data-free/closed-form pruning techniques (magnitude, structured, and attention-head pruning). The calibration-driven Wanda/SparseGPT variants remain Python-only, per the scope decision from #888.

## Test plan

- [x] New unit tests for each chain topology (plain, gated, residual, SkipLayerNorm-fused, attention-head across all three op families), each including an oracle-match test verifying numeric equivalence to hand-sliced reference weights via onnxruntime execution
- [x] Cross-check tests comparing the C++ port's output directly against the pure-Python reference implementation
- [x] Decline/left-untouched tests for every topology the reference conservatively declines (fan-out branches, identity shortcuts, mismatched consumer dims, non-constant biases, etc.)
- [x] Full existing test suite passes with no regressions (915 passed, 84 skipped)
- [x] `clang-format`/`ruff format`/`ruff check` all clean

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01FAiv55epkSMz7NPXD4r97u


---
_Generated by [Claude Code](https://claude.ai/code/session_01FAiv55epkSMz7NPXD4r97u)_