### PR TITLE
Slice k_scale/v_scale for quantized GroupQueryAttention KV-cache pruning

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -5957,14 +5957,20 @@ def apply_structured_wanda_pruning(
 #   it) is ever removed at once, ranked by the combined importance of the
 #   group's whole Q+K+V block -- see :func:`_apply_one_gqa_chain` and
 #   :func:`_gqa_group_importance`. A connected `past_key`/`past_value` that
-#   is a constant of the expected float BNSH shape (see
+#   is a constant of the expected BNSH shape (see
 #   :func:`_past_kv_constants_are_sliceable`) is sliced along its own
 #   `kv_num_heads` axis by the same `keep_groups` index set used for K's/V's
-#   own producer weights; one of any other shape/dtype (a quantized cache,
-#   most notably -- its own `k_scale`/`v_scale` tensors would need identical
-#   slicing to stay consistent, which this module makes no attempt at), or a
-#   packed-QKV/missing-required-input node this module cannot prove safe to
-#   leave alone, is declined outright -- see :func:`_match_gqa_producer`.
+#   own producer weights -- for a plain FLOAT cache unconditionally, and for
+#   a *quantized* one (`float8e4m3fn`/`uint8`/`int8`, which this op's own
+#   schema allows specifically to shrink KV-cache memory) together with its
+#   own `k_scale`/`v_scale` tensor, sliced the identical way when that scale
+#   is itself a constant of the schema's `"PER_CHANNEL"` shape (left alone,
+#   needing no slicing at all, when `"PER_TENSOR"` -- a single broadcast
+#   scalar with no per-head axis); a cache of any other shape/dtype, a
+#   quantized cache with no scale connected or one of an unrecognized shape,
+#   or a packed-QKV/missing-required-input node this module cannot prove
+#   safe to leave alone, is declined outright -- see
+#   :func:`_match_gqa_producer`.
 # - the plain ``ai.onnx`` `Attention` (opset 24+, domain ``""``, schema
 #   confirmed against this environment's installed ``onnx==1.22.0`` via
 #   ``onnx.defs.get_schema("Attention", domain="")`` -- it is fully defined
@@ -6093,6 +6099,20 @@ def apply_structured_wanda_pruning(
 #   dimensions) throughout, oracle-verified via onnxruntime with no
 #   restriction of this pass's own.
 _ATTENTION_DOMAIN = "com.microsoft"
+
+# The three quantized-cache dtypes `GroupQueryAttention`'s own `T_CACHE` type
+# constraint allows for `past_key`/`past_value` beyond plain FLOAT -- see
+# :func:`_past_kv_constants_are_sliceable`'s own docstring for how this was
+# confirmed directly off the installed `onnxruntime` package's schema
+# registry (`float16`/`bfloat16`, `T_CACHE`'s other two members, are *not*
+# quantized dtypes and stay declined by the plain FLOAT-only branch below,
+# same as before this constant existed -- out of scope for this quantized-
+# cache-specific extension).
+_QUANTIZED_KV_CACHE_DTYPES = {
+    onnx.TensorProto.UINT8,
+    onnx.TensorProto.INT8,
+    onnx.TensorProto.FLOAT8E4M3FN,
+}
 
 
 @dataclass(frozen=True)
@@ -6357,6 +6377,7 @@ def _past_kv_constants_are_sliceable(
     initializer_map: Dict[str, onnx.TensorProto],
     indices: Tuple[int, int],
     kv_num_heads: int,
+    scale_indices: Optional[Tuple[int, int]] = None,
 ) -> bool:
     """Shared safety gate for a matched node's optional `past_key`/
     `past_value` inputs (at `indices`, a `(past_key_idx, past_value_idx)`
@@ -6382,30 +6403,72 @@ def _past_kv_constants_are_sliceable(
     could corrupt by leaving untouched, the same reasoning that already
     applied before this function existed. A *constant* one is declined
     (this function returns ``False``, and the caller's whole match fails)
-    only when its shape/dtype isn't confidently this exact layout -- not
-    FLOAT, not rank 4, or its axis-1 length doesn't already match
-    `kv_num_heads` -- rather than guessed at; this also declines a
-    quantized KV cache (`float8e4m3fn`/`uint8`/`int8`, both ops' schemas
-    allow for `past_key`/`past_value` specifically to shrink KV-cache
-    memory) outright, since a quantized cache's own `k_scale`/`v_scale`
-    tensors would need identical per-KV-head-axis slicing to stay
-    consistent and this function makes no attempt to locate or slice them.
-    Otherwise (a constant of the expected float BNSH shape, or none
-    connected at all) returns ``True`` -- :func:`_apply_one_gqa_chain`
-    itself performs the actual axis-1 slice once a match succeeds.
+    when its shape isn't confidently this exact layout -- not rank 4, or its
+    axis-1 length doesn't already match `kv_num_heads` -- rather than
+    guessed at.
+
+    A plain-FLOAT constant of that shape is always accepted (the original,
+    unquantized case). A constant whose dtype is instead one of
+    :data:`_QUANTIZED_KV_CACHE_DTYPES` (`float8e4m3fn`/`uint8`/`int8` --
+    confirmed via `GroupQueryAttention`'s own `T_CACHE` type constraint,
+    `get_all_operator_schema()` again, whose "Quantization" doc section
+    states outright: "When quantization is enabled, `past_key` and
+    `past_value` inputs can be of type `float8e4m3fn`, `uint8` or `int8`.
+    The corresponding `k_scale` and `v_scale` tensors must be provided.")
+    is a *quantized* KV cache, only ever accepted when the caller passes
+    `scale_indices` (a `(k_scale_idx, v_scale_idx)` pair the caller's own op
+    schema defines) -- `GroupQueryAttention` passes ``(12, 13)``
+    (`k_scale`/`v_scale`'s own input positions per that same schema dump);
+    the plain ``ai.onnx::Attention`` op has no `k_scale`/`v_scale` inputs at
+    all (confirmed directly off `onnx.defs.get_schema("Attention",
+    domain="")` on this environment's installed `onnx==1.22.0`: its full
+    input list is `Q, K, V, attn_mask?, past_key?, past_value?,
+    nonpad_kv_seqlen?` -- no scale inputs -- and its `past_key`/`past_value`
+    type constraints `T1`/`T2` are `{float, float16, bfloat16, double}` only,
+    with no quantized dtype in either), so :func:`_match_onnx_attention_producer`
+    never passes `scale_indices` and a quantized cache there is declined
+    outright by the branch below, exactly as it always was. When
+    `scale_indices` *is* given and the cache is quantized, the corresponding
+    scale input is required to be connected (per the schema quote above) and,
+    if it is itself a constant, must be one of the two shapes the schema's
+    own "Quantization Modes" doc section names: `"PER_TENSOR"` (a single
+    scalar, e.g. shape `[1]` -- broadcasts identically regardless of
+    `kv_num_heads`, so it needs no slicing and is left completely alone) or
+    `"PER_CHANNEL"` (`[1, kv_num_heads, 1, head_size]` -- the *same* axis-1
+    `kv_num_heads` layout as the cache tensor itself, so it is safe to slice
+    along axis 1 by the identical `keep_groups` index set, exactly the
+    reasoning that already applied to the cache tensor); any other constant
+    scale shape (not rank 4 with axis-1 length `kv_num_heads`, and not a
+    single-element broadcast) is declined the same conservative way an
+    unrecognized cache shape already is, rather than guessed at, and a
+    *dynamic* (non-constant) scale is left alone exactly like a dynamic
+    cache tensor -- the caller's own runtime data, not a weight this rewrite
+    could silently corrupt by leaving untouched. :func:`_apply_one_gqa_chain`
+    itself performs the actual axis-1 slice(s) once a match succeeds.
     """
-    for idx in indices:
+    for idx, scale_idx in zip(indices, scale_indices or (None, None)):
         if len(node.input) <= idx or not node.input[idx]:
             continue
         past_init = initializer_map.get(node.input[idx])
         if past_init is None:
             continue  # dynamic -- the caller's own runtime data, left alone
-        if (
-            past_init.data_type != onnx.TensorProto.FLOAT
-            or len(past_init.dims) != 4
-            or past_init.dims[1] != kv_num_heads
-        ):
-            return False  # not a shape/dtype this function can safely slice
+        if len(past_init.dims) != 4 or past_init.dims[1] != kv_num_heads:
+            return False  # not a shape this function can safely slice
+        if past_init.data_type == onnx.TensorProto.FLOAT:
+            continue  # unquantized cache -- nothing else to check
+        if scale_idx is None or past_init.data_type not in _QUANTIZED_KV_CACHE_DTYPES:
+            return False  # quantized dtype with nowhere to locate its scale
+        if len(node.input) <= scale_idx or not node.input[scale_idx]:
+            return False  # quantized cache with no k_scale/v_scale connected
+        scale_init = initializer_map.get(node.input[scale_idx])
+        if scale_init is None:
+            continue  # dynamic scale -- the caller's own runtime data
+        if scale_init.data_type != onnx.TensorProto.FLOAT:
+            return False  # not T_KV_SCALE's own float-only constraint
+        if int(np.prod(scale_init.dims)) == 1:
+            continue  # PER_TENSOR: a single broadcast scalar, nothing to slice
+        if len(scale_init.dims) != 4 or scale_init.dims[1] != kv_num_heads:
+            return False  # not the PER_CHANNEL [1, kv_num_heads, 1, head_size] layout
     return True
 
 
@@ -6426,13 +6489,20 @@ def _match_gqa_producer(
     one); `num_heads`/`kv_num_heads` attributes with `num_heads` a positive
     multiple of `kv_num_heads`; and a `past_key`/`past_value` (indices 3/4)
     this module can safely act on, per
-    :func:`_past_kv_constants_are_sliceable` -- a constant one is sliced
-    along its own `kv_num_heads` axis by :func:`_apply_one_gqa_chain`, using
-    exactly the same `keep_groups` index set K's/V's own producer weights
-    are sliced by. cos_cache/sin_cache (indices 7/8, for rotary position
-    embedding), if present, are always left alone regardless: both are
-    `[max_sequence_length, rotary_dim/2]`, broadcast identically across
-    every head, so a head/group count change can never invalidate them.
+    :func:`_past_kv_constants_are_sliceable` (passed `scale_indices=(12,
+    13)`, `k_scale`/`v_scale`'s own input positions on this op's schema) --
+    a constant float BNSH cache is sliced along its own `kv_num_heads` axis
+    by :func:`_apply_one_gqa_chain`, using exactly the same `keep_groups`
+    index set K's/V's own producer weights are sliced by; a constant
+    quantized (`float8e4m3fn`/`uint8`/`int8`) cache is sliced the same way,
+    together with its own `k_scale`/`v_scale` when that scale is itself a
+    constant of the schema's `"PER_CHANNEL"` shape (left alone, needing no
+    slicing, when `"PER_TENSOR"` -- see :func:`_past_kv_constants_are_sliceable`'s
+    own docstring for the full quantized-cache reasoning). cos_cache/sin_cache
+    (indices 7/8, for rotary position embedding), if present, are always left
+    alone regardless: both are `[max_sequence_length, rotary_dim/2]`,
+    broadcast identically across every head, so a head/group count change
+    can never invalidate them.
     """
     if node.domain != _ATTENTION_DOMAIN or node.op_type != "GroupQueryAttention":
         return None
@@ -6451,7 +6521,7 @@ def _match_gqa_producer(
         return None
 
     if not _past_kv_constants_are_sliceable(
-        node, initializer_map, (3, 4), kv_num_heads
+        node, initializer_map, (3, 4), kv_num_heads, scale_indices=(12, 13)
     ):
         return None
 
@@ -6496,14 +6566,21 @@ def _match_onnx_attention_producer(
     and this op has no `seqlens_k`/`total_sequence_length` equivalent to
     require) get the same safety gate :func:`_match_gqa_producer` gives its
     own `past_key`/`past_value`, via the same shared
-    :func:`_past_kv_constants_are_sliceable` -- a constant one of the
-    expected float BNSH shape is sliced along its own `kv_num_heads` axis by
-    :func:`_apply_one_gqa_chain`, using the same `keep_groups` index set
-    K's/V's own producer weights are sliced by; one of any other shape/dtype
-    declines the whole match, and a dynamic one is left alone as always.
-    `nonpad_kv_seqlen` (index 6), like `GroupQueryAttention`'s own
-    `seqlens_k`, is `[batch_size]`-shaped and independent of head count, so
-    its presence never blocks a match either.
+    :func:`_past_kv_constants_are_sliceable` -- but called here with no
+    `scale_indices` (left at that parameter's default, `None`), unlike
+    `GroupQueryAttention`'s own call: this op's schema (confirmed via
+    `onnx.defs.get_schema("Attention", domain="")`) has no `k_scale`/
+    `v_scale` inputs at all, and its `past_key`/`past_value` type
+    constraints (`T1`/`T2`) list only `float`/`float16`/`bfloat16`/`double`
+    -- no quantized dtype -- so a constant `past_key`/`past_value` here is
+    only ever sliced when it is that expected float BNSH shape, along its
+    own `kv_num_heads` axis, by :func:`_apply_one_gqa_chain`, using the same
+    `keep_groups` index set K's/V's own producer weights are sliced by; a
+    quantized cache (off-schema for this particular op) still declines the
+    whole match outright, exactly as before, and a dynamic one is left alone
+    as always. `nonpad_kv_seqlen` (index 6), like `GroupQueryAttention`'s
+    own `seqlens_k`, is `[batch_size]`-shaped and independent of head count,
+    so its presence never blocks a match either.
     """
     if node.domain != "" or node.op_type != "Attention":
         return None
@@ -6882,12 +6959,19 @@ def _apply_one_gqa_chain(
     hidden dim -- laid out per *query* head at *V's* own per-head width) --
     never an individual query head in isolation. A connected constant
     `past_key`/`past_value` (see :func:`_past_kv_constants_are_sliceable`,
-    already confirmed at match time to be a float BNSH-format tensor) is
-    sliced along its own `kv_num_heads` axis (axis 1) by the same
-    `keep_groups` index set. Returns ``(producer_weight_names,
-    consumer_weight_name, stale_output_names)`` on success, or ``None`` if
-    `sparsity` rounds to no groups dropped for this block (a no-op, left for
-    the caller to skip).
+    already confirmed at match time to be a BNSH-format tensor, plain FLOAT
+    or a quantized `float8e4m3fn`/`uint8`/`int8` cache with a
+    schema-conforming `k_scale`/`v_scale`) is sliced along its own
+    `kv_num_heads` axis (axis 1) by the same `keep_groups` index set; for a
+    `GroupQueryAttention` block whose cache is quantized, its own
+    `k_scale`/`v_scale` (only ever present on this op -- see
+    :func:`_match_gqa_producer`'s own docstring) is sliced the identical way
+    when it is itself a constant of the schema's `"PER_CHANNEL"` shape
+    (`[1, kv_num_heads, 1, head_size]`), left alone when `"PER_TENSOR"` (a
+    single broadcast scalar, already confirmed to need no slicing) or
+    dynamic. Returns ``(producer_weight_names, consumer_weight_name,
+    stale_output_names)`` on success, or ``None`` if `sparsity` rounds to no
+    groups dropped for this block (a no-op, left for the caller to skip).
     """
     h = chain.kv_num_heads
     keep_count = max(1, h - round(h * sparsity))
@@ -6953,8 +7037,9 @@ def _apply_one_gqa_chain(
     # the plain ai.onnx op's own at 4/5 (see `_match_gqa_producer`'s and
     # `_match_onnx_attention_producer`'s own docstrings) -- both already
     # confirmed, at match time, to be either absent/dynamic (nothing to do
-    # here) or a float BNSH-format constant safe to slice along axis 1 by
-    # `keep_groups` (see :func:`_past_kv_constants_are_sliceable`).
+    # here) or a BNSH-format constant (plain FLOAT, or quantized with a
+    # schema-conforming scale) safe to slice along axis 1 by `keep_groups`
+    # (see :func:`_past_kv_constants_are_sliceable`).
     is_gqa = (
         chain.node.domain == _ATTENTION_DOMAIN
         and chain.node.op_type == "GroupQueryAttention"
@@ -6966,6 +7051,26 @@ def _apply_one_gqa_chain(
         past_init = initializer_map.get(chain.node.input[idx])
         if past_init is not None:
             _slice_axis1(past_init, keep_groups)
+
+    # `k_scale`/`v_scale` (indices 12/13, `GroupQueryAttention`-only -- the
+    # plain ai.onnx op's schema has no such inputs, see
+    # `_match_onnx_attention_producer`'s own docstring) were already
+    # confirmed at match time to be either absent/dynamic (nothing to do
+    # here), a `"PER_TENSOR"` scalar broadcast (no per-head axis, left as-is
+    # below), or a `"PER_CHANNEL"` `[1, kv_num_heads, 1, head_size]` float
+    # constant -- the same axis-1 `kv_num_heads` layout as the cache tensor
+    # itself -- safe to slice along axis 1 by the identical `keep_groups`
+    # (see :func:`_past_kv_constants_are_sliceable`).
+    if is_gqa:
+        for idx in (12, 13):
+            if len(chain.node.input) <= idx or not chain.node.input[idx]:
+                continue
+            scale_init = initializer_map.get(chain.node.input[idx])
+            if scale_init is None:
+                continue  # dynamic -- caller's own runtime data, left alone
+            if len(scale_init.dims) == 4 and scale_init.dims[1] == h:
+                _slice_axis1(scale_init, keep_groups)
+            # else: PER_TENSOR broadcast scalar -- no per-head axis to slice
 
     new_kv_num_heads = keep_count
     new_num_heads = keep_count * group_size

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -3,6 +3,7 @@ Wanda pruning (calibrated on activation norms), and structured (channel)
 pruning, see ``onnxsim/pruning.py``.
 """
 
+import ml_dtypes
 import numpy as np
 import onnx
 import onnx.helper
@@ -6437,6 +6438,12 @@ def _gqa_model(
     past_kv=None,  # None (empty) | "nonempty" (constant) | "dynamic" (graph input)
     past_key=None,  # explicit override for past_kv="nonempty" (else random)
     past_value=None,  # explicit override for past_kv="nonempty" (else random)
+    past_kv_dtype=np.float32,  # dtype of PastKey/PastValue -- quantized when non-float
+    k_scale=None,  # constant k_scale (PER_TENSOR/PER_CHANNEL array) or None (unconnected)
+    v_scale=None,  # constant v_scale, same convention as k_scale
+    k_quant_type=None,  # GQA node's own k_quant_type attribute, e.g. "PER_TENSOR"
+    v_quant_type=None,  # GQA node's own v_quant_type attribute
+    kv_cache_bit_width=None,  # GQA node's own kv_cache_bit_width attribute (8 or 4)
 ):
     # Real ONNX Runtime CPU kernels for GroupQueryAttention require
     # head_size to be a multiple of 8 (verified empirically -- a smaller
@@ -6485,14 +6492,41 @@ def _gqa_model(
         onnx.numpy_helper.from_array(np.array(total_seq, dtype=np.int32), "TotalSeq")
     )
 
+    def _random_past_kv_default():
+        # `np.iinfo` covers `int8`/`uint8`; `float8e4m3fn` is neither
+        # `np.floating` nor an integer dtype `np.iinfo` recognizes (its
+        # numpy `kind` is opaque, `'V'`), so it gets its own small-range
+        # float draw instead -- well inside e4m3's own representable range
+        # (~448 magnitude) with plenty of margin for its coarser mantissa.
+        if np.issubdtype(past_kv_dtype, np.floating):
+            return rng.standard_normal((batch, KVH, 1, D))
+        try:
+            info = np.iinfo(past_kv_dtype)
+        except (ValueError, TypeError):
+            return rng.uniform(-2.0, 2.0, size=(batch, KVH, 1, D))
+        return rng.integers(
+            max(info.min, -64), min(info.max, 64) + 1, size=(batch, KVH, 1, D)
+        )
+
     operands = ["q", "k", "v"]
     extra_graph_inputs = ""
     if past_kv == "nonempty":
         if past_key is None:
-            past_key = rng.standard_normal((batch, KVH, 1, D)).astype(np.float32)
+            past_key = _random_past_kv_default()
         if past_value is None:
-            past_value = rng.standard_normal((batch, KVH, 1, D)).astype(np.float32)
-        initializer += [_f32(past_key, "PastKey"), _f32(past_value, "PastValue")]
+            past_value = _random_past_kv_default()
+        # Cast once and reuse the *quantized* (post-cast) array both for the
+        # initializer and the returned `cfg` -- `past_kv_dtype`'s own cast
+        # can be lossy (`float8e4m3fn`'s coarse mantissa, most notably), so
+        # a caller comparing `cfg["past_key"]` against the model's own
+        # initializer (e.g. after slicing) needs the already-quantized
+        # values, not the pre-cast ones.
+        past_key = np.asarray(past_key).astype(past_kv_dtype)
+        past_value = np.asarray(past_value).astype(past_kv_dtype)
+        initializer += [
+            onnx.numpy_helper.from_array(past_key, "PastKey"),
+            onnx.numpy_helper.from_array(past_value, "PastValue"),
+        ]
         operands += ["PastKey", "PastValue"]
     elif past_kv == "dynamic":
         operands += ["PastKeyIn", "PastValueIn"]
@@ -6504,6 +6538,25 @@ def _gqa_model(
         operands += ["", ""]
     operands += ["SeqLensK", "TotalSeq"]
 
+    # `k_scale`/`v_scale` (GQA input indices 12/13) sit behind five other
+    # optional inputs (cos_cache/sin_cache/position_ids/attention_bias/
+    # head_sink, indices 7-11, all left unconnected here -- none of this
+    # module's own matching/slicing touches them) that must be threaded
+    # through as empty positional placeholders for the text format's
+    # positional-input convention to reach index 12/13 at all.
+    if k_scale is not None or v_scale is not None:
+        operands += [""] * 5
+        if k_scale is not None:
+            initializer.append(_f32(np.asarray(k_scale), "KScale"))
+            operands.append("KScale")
+        else:
+            operands.append("")
+        if v_scale is not None:
+            initializer.append(_f32(np.asarray(v_scale), "VScale"))
+            operands.append("VScale")
+        else:
+            operands.append("")
+
     if with_reshape:
         shape = np.array([batch, seq, Nq], dtype=np.int64)
         initializer.append(onnx.numpy_helper.from_array(shape, "Shape"))
@@ -6511,13 +6564,21 @@ def _gqa_model(
     else:
         tail = "Y = MatMul(ctx, Wout)"
 
+    attrs = f"num_heads={H}, kv_num_heads={KVH}"
+    if k_quant_type is not None:
+        attrs += f', k_quant_type = "{k_quant_type}"'
+    if v_quant_type is not None:
+        attrs += f', v_quant_type = "{v_quant_type}"'
+    if kv_cache_bit_width is not None:
+        attrs += f", kv_cache_bit_width={kv_cache_bit_width}"
+
     body = f"""
         g (float[{batch},{seq},{K}] X{extra_graph_inputs}) => (float[{batch},{seq},{Out}] Y)
         {{
           q = {q_op}
           k = {k_op}
           v = {v_op}
-          ctx, pk, pv = com.microsoft.GroupQueryAttention <num_heads={H}, kv_num_heads={KVH}> ({", ".join(operands)})
+          ctx, pk, pv = com.microsoft.GroupQueryAttention <{attrs}> ({", ".join(operands)})
           {tail}
         }}
         """
@@ -6551,6 +6612,8 @@ def _gqa_model(
         seq=seq,
         past_key=past_key,
         past_value=past_value,
+        k_scale=k_scale,
+        v_scale=v_scale,
     )
 
 
@@ -6842,17 +6905,21 @@ def test_gqa_pruning_dynamic_past_kv_input_is_still_pruned():
     assert list(inits["Wv"].dims) == [8, 1 * cfg["D"]]
 
 
-def test_gqa_pruning_quantized_past_kv_constant_is_left_untouched():
+def test_gqa_pruning_quantized_past_kv_constant_with_no_scale_is_left_untouched():
     # A non-FLOAT constant past_key/past_value (standing in for a quantized
     # KV cache -- GroupQueryAttention's own schema allows `past_key`/
     # `past_value` to be `float8e4m3fn`/`uint8`/`int8` when quantized, per
     # `onnxruntime.capi.onnxruntime_pybind11_state.get_all_operator_schema()`'s
-    # own "Quantization" section) is declined outright by
-    # `_past_kv_constants_are_sliceable` rather than sliced as if it were an
-    # ordinary float BNSH tensor: a quantized cache's own `k_scale`/
-    # `v_scale` tensors would need identical per-KV-head-axis slicing to
-    # stay consistent, which this module makes no attempt to locate or
-    # slice, so guessing here would silently corrupt the cache.
+    # own "Quantization" section) with *no* `k_scale`/`v_scale` wired up at
+    # all is declined outright by `_past_kv_constants_are_sliceable` rather
+    # than sliced as if it were an ordinary float BNSH tensor: that schema
+    # section states the corresponding scale "must be provided" whenever
+    # quantization is enabled, so a quantized cache with no scale connected
+    # is off-schema and not a shape this module can prove safe to touch --
+    # unlike the case with a real, schema-conforming scale connected (see
+    # `test_gqa_pruning_quantized_int8_per_tensor_scale_matches_oracle_exactly`
+    # and `test_gqa_pruning_quantized_int8_per_channel_scale_matches_oracle_exactly`
+    # below), which this module *does* now slice consistently.
     model, cfg = _gqa_model(K=8, H=8, KVH=2, D=8, Out=6, seed=25, past_kv="nonempty")
     inits_map = {t.name: t for t in model.graph.initializer}
     quantized_past_key = onnx.numpy_helper.from_array(
@@ -6871,6 +6938,357 @@ def test_gqa_pruning_quantized_past_kv_constant_is_left_untouched():
     }
     for name in inits_before:
         np.testing.assert_array_equal(inits_before[name], inits_after[name])
+
+
+def test_gqa_pruning_quantized_int8_per_tensor_scale_matches_oracle_exactly():
+    # A quantized (`int8`) constant past_key/past_value with a real,
+    # schema-conforming `"PER_TENSOR"` `k_scale`/`v_scale` (a single
+    # broadcast scalar, shape `[1]` -- GroupQueryAttention's own
+    # "Quantization Modes" doc section) is now matched and pruned: the cache
+    # is sliced along its `kv_num_heads` axis by the same `keep_groups` used
+    # for K's/V's own producer weights, exactly like an unquantized cache,
+    # while the scale -- having no per-head axis at all -- is left
+    # completely untouched. Verified by *actual execution*: real
+    # onnxruntime (confirmed in this environment to run a quantized
+    # `GroupQueryAttention` node on CPU, `int8` cache, unlike `uint8` which
+    # this environment's onnxruntime CPU kernel errors on for any input --
+    # a pre-existing runtime limitation unrelated to this module, not
+    # exercised via execution here) on the pruned model matches a
+    # from-scratch oracle model built with every tensor (weights, cache,
+    # scale) pre-sliced by hand to the identical indices.
+    K, H, KVH, D, Out = 8, 8, 2, 8, 6
+    rng = np.random.default_rng(50)
+    k_scale = np.array([0.05], dtype=np.float32)
+    v_scale = np.array([0.03], dtype=np.float32)
+    model, cfg = _gqa_model(
+        K=K,
+        H=H,
+        KVH=KVH,
+        D=D,
+        Out=Out,
+        seed=50,
+        batch=1,
+        past_kv="nonempty",
+        past_kv_dtype=np.int8,
+        k_scale=k_scale,
+        v_scale=v_scale,
+        k_quant_type="PER_TENSOR",
+        v_quant_type="PER_TENSOR",
+        kv_cache_bit_width=8,
+    )
+    onnx.checker.check_model(model)
+    assert len(onnxsim.pruning._find_gqa_chains(model.graph)) == 1
+
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    node = _gqa_node(pruned)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    assert kv_num_heads == 1  # max(1, 2 - round(2*0.5))
+    group_size = H // KVH
+
+    keep_groups = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], H, KVH, D, kv_num_heads
+    )
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    q_idx, kv_idx = _head_idx(keep_q_heads, D), _head_idx(keep_groups, D)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(
+        inits["PastKey"], cfg["past_key"][:, keep_groups, :, :]
+    )
+    np.testing.assert_array_equal(
+        inits["PastValue"], cfg["past_value"][:, keep_groups, :, :]
+    )
+    # PER_TENSOR: no per-head axis -- the scale is untouched, byte-for-byte.
+    np.testing.assert_array_equal(inits["KScale"], k_scale)
+    np.testing.assert_array_equal(inits["VScale"], v_scale)
+
+    oracle, _ = _gqa_model(
+        K=K,
+        H=num_heads,
+        KVH=kv_num_heads,
+        D=D,
+        Out=Out,
+        seed=50,
+        batch=cfg["batch"],
+        seq=cfg["seq"],
+        wq=cfg["wq"][:, q_idx],
+        wk=cfg["wk"][:, kv_idx],
+        wv=cfg["wv"][:, kv_idx],
+        wout=cfg["wout"][q_idx, :],
+        past_kv="nonempty",
+        past_key=cfg["past_key"][:, keep_groups, :, :],
+        past_value=cfg["past_value"][:, keep_groups, :, :],
+        past_kv_dtype=np.int8,
+        k_scale=k_scale,
+        v_scale=v_scale,
+        k_quant_type="PER_TENSOR",
+        v_quant_type="PER_TENSOR",
+        kv_cache_bit_width=8,
+    )
+    onnx.checker.check_model(oracle)
+
+    x = rng.standard_normal((cfg["batch"], cfg["seq"], K)).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_gqa_pruning_quantized_int8_per_channel_scale_matches_oracle_exactly():
+    # Same as the `"PER_TENSOR"` case above, but with a real
+    # `"PER_CHANNEL"` `k_scale`/`v_scale` (`[1, kv_num_heads, 1, head_size]`
+    # -- the *same* axis-1 `kv_num_heads` layout as the cache tensor itself,
+    # per the schema's own doc section) holding per-KV-head scale data: the
+    # scale is now sliced along axis 1 by the identical `keep_groups` index
+    # set the cache tensor and K's/V's own producer weights are sliced by,
+    # not merely left alone. Verified the same way, via real onnxruntime
+    # execution against a from-scratch, hand-sliced oracle model.
+    K, H, KVH, D, Out = 8, 8, 2, 8, 6
+    rng = np.random.default_rng(51)
+    k_scale = rng.uniform(0.01, 0.1, size=(1, KVH, 1, D)).astype(np.float32)
+    v_scale = rng.uniform(0.01, 0.1, size=(1, KVH, 1, D)).astype(np.float32)
+    model, cfg = _gqa_model(
+        K=K,
+        H=H,
+        KVH=KVH,
+        D=D,
+        Out=Out,
+        seed=51,
+        batch=1,
+        past_kv="nonempty",
+        past_kv_dtype=np.int8,
+        k_scale=k_scale,
+        v_scale=v_scale,
+        k_quant_type="PER_CHANNEL",
+        v_quant_type="PER_CHANNEL",
+        kv_cache_bit_width=8,
+    )
+    onnx.checker.check_model(model)
+    assert len(onnxsim.pruning._find_gqa_chains(model.graph)) == 1
+
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    node = _gqa_node(pruned)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    assert kv_num_heads == 1
+    group_size = H // KVH
+
+    keep_groups = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], H, KVH, D, kv_num_heads
+    )
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    q_idx, kv_idx = _head_idx(keep_q_heads, D), _head_idx(keep_groups, D)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(
+        inits["PastKey"], cfg["past_key"][:, keep_groups, :, :]
+    )
+    np.testing.assert_array_equal(
+        inits["PastValue"], cfg["past_value"][:, keep_groups, :, :]
+    )
+    # PER_CHANNEL: sliced along axis 1 by the identical `keep_groups`.
+    np.testing.assert_array_equal(inits["KScale"], k_scale[:, keep_groups, :, :])
+    np.testing.assert_array_equal(inits["VScale"], v_scale[:, keep_groups, :, :])
+
+    oracle, _ = _gqa_model(
+        K=K,
+        H=num_heads,
+        KVH=kv_num_heads,
+        D=D,
+        Out=Out,
+        seed=51,
+        batch=cfg["batch"],
+        seq=cfg["seq"],
+        wq=cfg["wq"][:, q_idx],
+        wk=cfg["wk"][:, kv_idx],
+        wv=cfg["wv"][:, kv_idx],
+        wout=cfg["wout"][q_idx, :],
+        past_kv="nonempty",
+        past_key=cfg["past_key"][:, keep_groups, :, :],
+        past_value=cfg["past_value"][:, keep_groups, :, :],
+        past_kv_dtype=np.int8,
+        k_scale=k_scale[:, keep_groups, :, :],
+        v_scale=v_scale[:, keep_groups, :, :],
+        k_quant_type="PER_CHANNEL",
+        v_quant_type="PER_CHANNEL",
+        kv_cache_bit_width=8,
+    )
+    onnx.checker.check_model(oracle)
+
+    x = rng.standard_normal((cfg["batch"], cfg["seq"], K)).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_gqa_pruning_quantized_cache_malformed_scale_shape_is_declined():
+    # A `k_scale`/`v_scale` constant that is neither the `"PER_TENSOR"`
+    # single-broadcast-scalar shape nor the `"PER_CHANNEL"`
+    # `[1, kv_num_heads, 1, head_size]` layout (here: a plain rank-2
+    # `[kv_num_heads, head_size]` tensor, a shape neither this module nor
+    # the schema's own two named quantization modes account for) declines
+    # the whole match outright -- guessing at a slicing axis for a shape the
+    # schema itself doesn't document would risk silently producing a
+    # mismatched scale.
+    K, H, KVH, D, Out = 8, 8, 2, 8, 6
+    bad_scale = (
+        np.random.default_rng(52).uniform(0.01, 0.1, size=(KVH, D)).astype(np.float32)
+    )
+    model, cfg = _gqa_model(
+        K=K,
+        H=H,
+        KVH=KVH,
+        D=D,
+        Out=Out,
+        seed=52,
+        batch=1,
+        past_kv="nonempty",
+        past_kv_dtype=np.int8,
+        k_scale=bad_scale,
+        v_scale=bad_scale,
+        k_quant_type="PER_CHANNEL",
+        v_quant_type="PER_CHANNEL",
+        kv_cache_bit_width=8,
+    )
+    assert onnxsim.pruning._find_gqa_chains(model.graph) == []
+
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    inits_before = {
+        t.name: onnx.numpy_helper.to_array(t) for t in model.graph.initializer
+    }
+    inits_after = {
+        t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer
+    }
+    for name in inits_before:
+        np.testing.assert_array_equal(inits_before[name], inits_after[name])
+
+
+def test_gqa_pruning_quantized_cache_dynamic_scale_does_not_block_match():
+    # A *dynamic* (non-constant, an ordinary graph input) `k_scale`/`v_scale`
+    # -- even one shaped like a real `"PER_CHANNEL"` scale -- is left alone
+    # exactly like a dynamic past_key/past_value: it is the caller's own
+    # runtime data, not a weight this rewrite could corrupt by leaving
+    # untouched, so it must not block the match. The quantized cache itself
+    # is still sliced along its own `kv_num_heads` axis as usual.
+    K, H, KVH, D, Out = 8, 8, 2, 8, 6
+    rng = np.random.default_rng(53)
+    wq = rng.standard_normal((K, H * D)).astype(np.float32)
+    wk = rng.standard_normal((K, KVH * D)).astype(np.float32)
+    wv = rng.standard_normal((K, KVH * D)).astype(np.float32)
+    wout = rng.standard_normal((H * D, Out)).astype(np.float32)
+    past_key = rng.integers(-64, 64, size=(1, KVH, 1, D)).astype(np.int8)
+    past_value = rng.integers(-64, 64, size=(1, KVH, 1, D)).astype(np.int8)
+
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17, "com.microsoft": 1]
+        >
+        g (float[1,1,{K}] X, float[1,{KVH},1,{D}] KScaleIn, float[1,{KVH},1,{D}] VScaleIn)
+        => (float[1,1,{Out}] Y)
+        {{
+          q = MatMul(X, Wq)
+          k = MatMul(X, Wk)
+          v = MatMul(X, Wv)
+          ctx, pk, pv = com.microsoft.GroupQueryAttention
+              <num_heads={H}, kv_num_heads={KVH}, k_quant_type = "PER_CHANNEL",
+               v_quant_type = "PER_CHANNEL", kv_cache_bit_width=8>
+              (q, k, v, PastKey, PastValue, SeqLensK, TotalSeq,
+               "", "", "", "", "", KScaleIn, VScaleIn)
+          Y = MatMul(ctx, Wout)
+        }}
+        """
+    )
+    model.graph.initializer.extend(
+        [
+            _f32(wq, "Wq"),
+            _f32(wk, "Wk"),
+            _f32(wv, "Wv"),
+            _f32(wout, "Wout"),
+            onnx.numpy_helper.from_array(past_key, "PastKey"),
+            onnx.numpy_helper.from_array(past_value, "PastValue"),
+            onnx.numpy_helper.from_array(np.array([0], dtype=np.int32), "SeqLensK"),
+            onnx.numpy_helper.from_array(np.array(1, dtype=np.int32), "TotalSeq"),
+        ]
+    )
+    onnx.checker.check_model(model)
+    assert len(onnxsim.pruning._find_gqa_chains(model.graph)) == 1
+
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    node = _gqa_node(pruned)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    assert kv_num_heads == 1
+    # The scale inputs stay wired to the same (untouched) graph inputs.
+    assert list(node.input[12:14]) == ["KScaleIn", "VScaleIn"]
+
+    keep_groups = _oracle_keep_groups(wq, wk, wv, H, KVH, D, kv_num_heads)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["PastKey"], past_key[:, keep_groups, :, :])
+    np.testing.assert_array_equal(inits["PastValue"], past_value[:, keep_groups, :, :])
+
+
+def test_gqa_pruning_quantized_cache_accepts_every_schema_quantized_dtype():
+    # `GroupQueryAttention`'s own `T_CACHE` type constraint allows exactly
+    # three quantized dtypes for `past_key`/`past_value`:
+    # `float8e4m3fn`/`uint8`/`int8` (confirmed via
+    # `onnxruntime.capi.onnxruntime_pybind11_state.get_all_operator_schema()`).
+    # `int8` is exercised end-to-end via real onnxruntime execution in
+    # `test_gqa_pruning_quantized_int8_per_tensor_scale_matches_oracle_exactly`/
+    # `..._per_channel_scale_matches_oracle_exactly` above; `uint8` cannot be
+    # (this environment's onnxruntime CPU `GroupQueryAttention` kernel
+    # errors -- "Tensor type mismatch" -- on *any* `uint8` cache, even an
+    # unpruned, un-modified one, a pre-existing runtime limitation unrelated
+    # to this module) and `float8e4m3fn` is not attempted via execution
+    # either, so both are instead verified structurally here: the match
+    # succeeds and the cache/scale tensors are sliced to the exact expected
+    # values (direct tensor inspection), the fallback this task's own
+    # instructions call for when execution isn't available.
+    K, H, KVH, D, Out = 8, 8, 2, 8, 6
+    for dtype in (np.uint8, ml_dtypes.float8_e4m3fn):
+        k_scale = np.array([0.05], dtype=np.float32)
+        v_scale = np.array([0.03], dtype=np.float32)
+        model, cfg = _gqa_model(
+            K=K,
+            H=H,
+            KVH=KVH,
+            D=D,
+            Out=Out,
+            seed=54,
+            batch=1,
+            past_kv="nonempty",
+            past_kv_dtype=dtype,
+            k_scale=k_scale,
+            v_scale=v_scale,
+            k_quant_type="PER_TENSOR",
+            v_quant_type="PER_TENSOR",
+            kv_cache_bit_width=8,
+        )
+        onnx.checker.check_model(model)
+        assert len(onnxsim.pruning._find_gqa_chains(model.graph)) == 1, dtype
+
+        pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+        onnx.checker.check_model(pruned)
+        node = _gqa_node(pruned)
+        _, kv_num_heads = _gqa_attrs(node)
+        keep_groups = _oracle_keep_groups(
+            cfg["wq"], cfg["wk"], cfg["wv"], H, KVH, D, kv_num_heads
+        )
+        inits = {
+            t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer
+        }
+        np.testing.assert_array_equal(
+            inits["PastKey"], cfg["past_key"][:, keep_groups, :, :]
+        )
+        np.testing.assert_array_equal(
+            inits["PastValue"], cfg["past_value"][:, keep_groups, :, :]
+        )
+        np.testing.assert_array_equal(inits["KScale"], k_scale)
+        np.testing.assert_array_equal(inits["VScale"], v_scale)
 
 
 def test_gqa_wanda_pruning_matches_oracle_exactly():


### PR DESCRIPTION
## Summary
- Attention-head pruning's recently-landed constant KV-cache slicing previously declined outright whenever `past_key`/`past_value` was quantized (`float8e4m3fn`/`uint8`/`int8`), since the corresponding `k_scale`/`v_scale` tensors weren't sliced to match.
- Confirmed the real schema directly from source rather than guessing: `GroupQueryAttention`'s own schema (`onnxruntime.capi.onnxruntime_pybind11_state.get_all_operator_schema()`) puts `k_scale`/`v_scale` at input indices 12/13, type `T_KV_SCALE` (float only), and its own "Quantization Modes" doc names two scale shapes — `"PER_TENSOR"` (`[1]`, a pure broadcast scalar with no per-head axis) and `"PER_CHANNEL"` (`[1, kv_num_heads, 1, head_size]` — the *same* axis-1 `kv_num_heads` layout the cache tensor itself already uses).
- Found, contrary to the initial assumption, that the plain `ai.onnx::Attention` op has **no `k_scale`/`v_scale` inputs at all** and its `past_key`/`past_value` type constraints allow only `float`/`float16`/`bfloat16`/`double` — no quantized dtype whatsoever (confirmed via `onnx.defs.get_schema("Attention", domain="")`). So this fix is `GroupQueryAttention`-only; a quantized cache on the plain op correctly continues to decline outright, since it's off-schema there, not merely unattempted.
- Implemented: `_past_kv_constants_are_sliceable` gained an optional `scale_indices` parameter (`(12, 13)` for `GroupQueryAttention`, omitted for plain `Attention`). A quantized cache is now accepted when its scale is a schema-conforming `PER_TENSOR` (left untouched — nothing to slice) or `PER_CHANNEL` (sliced along axis 1 by the same `keep_groups` index set already used for the cache and K/V weights) constant, or is dynamic (left alone, same as a dynamic cache); any other scale shape, or a quantized cache with no scale connected, still declines the whole match. `_apply_one_gqa_chain` performs the actual `k_scale`/`v_scale` slicing right after the existing cache slicing.

## Test plan
- [x] `pytest tests/test_pruning.py -q` — 202 passed
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — same pre-existing, unrelated errors as `master`; no new ones
- [x] Real onnxruntime execution (int8 cache, both `PER_TENSOR` and `PER_CHANNEL` scale) matches a from-scratch hand-sliced oracle exactly; `uint8`/`float8e4m3fn` verified structurally via direct tensor inspection (this environment's onnxruntime CPU kernel doesn't execute `uint8` GQA inputs at all, a pre-existing runtime limitation unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_