### PR TITLE
Resolve a gated Mul feeding a Concat branch directly

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -4238,11 +4238,15 @@ def _find_gated_chains(graph: onnx.GraphProto) -> List[_Chain]:
 # does -- no dedicated check was needed to draw that boundary, it falls out
 # for free from what the walkers already do and don't recognize. A gated
 # (SwiGLU/GeGLU) pair feeding a `Concat` operand directly, with no real
-# producer's raw output in
-# between, is declined the same way: neither backward walker resolves
-# through a `Mul` of two non-constant operands (see the MatMul residual
-# section's own comment for why), so that shape falls through to `"fail"`
-# too.
+# producer's raw output in between and no `Add`/`SkipLayerNormalization`
+# merge involved either, *is* resolved for MatMul/Gemm branches -- see
+# :func:`_find_matmul_concat_chains`'s own docstring for exactly how (a
+# third, `"gated"`, outcome from :func:`_walk_matmul_producer_backward`,
+# distinct from both the plain-producer and composed-residual-group shapes
+# above). Conv has no such combine point in scope at all -- `_BINARY_CHANNEL_OPS`
+# is a MatMul/Gemm-only concept, :func:`_walk_conv_producer_backward` never
+# recognizes a `Mul` hop -- so a Conv `Concat` branch bottoming out at one
+# still falls through to `"fail"` exactly as before.
 #
 # `Concat`'s own `axis` attribute must actually be the channel axis this
 # pass's importance ranking operates on, and the two node families need
@@ -4729,22 +4733,62 @@ def _find_matmul_concat_chains(graph: onnx.GraphProto) -> List[_ConcatChain]:
     `axis` only when the operands' rank is confirmed via `value_info` to
     actually be `rank - 1`) is resolved backward, via
     :func:`_walk_matmul_producer_backward` (reused unchanged from the
-    MatMul/Gemm residual section above), to either a real MatMul/vanilla-Gemm
-    producer (`"producer"`) or an eligible residual/`SkipLayerNormalization`
-    merge's whole group (`"add"`, composed via
+    MatMul/Gemm residual section above, `producer_infos` passed through the
+    same way :func:`_find_matmul_residual_chains` does so a gated ``Mul`` hop
+    can resolve too -- see below), to a real MatMul/vanilla-Gemm producer
+    (`"producer"`), an eligible residual/`SkipLayerNormalization` merge's
+    whole group (`"add"`, composed via
     :func:`_resolve_matmul_residual_group_for_concat` -- see this section's
     own comment for exactly what composing that requires and what it
-    declines). If *any* operand fails to resolve either way, or two operands
-    (or two leaf producers of the same composed group, or a leaf producer of
-    one branch against another branch's own) name the very same producer
-    weight (degenerate), the whole `Concat` node is declined -- never
-    partially pruned.
+    declines), or a gated (SwiGLU/GeGLU-style) ``Mul`` of two non-constant
+    operands feeding this `Concat` operand directly (`"gated"`, resolved by
+    :func:`_walk_matmul_producer_backward` itself via
+    :func:`_trace_gate_producer_backward` -- unlike the `"add"` composition
+    above, there is no whole transitively-connected group to walk out from
+    here: just this one `Mul` node's own two operands, each already resolved
+    to its own real producer by the walker, both becoming this one branch's
+    own `producers` tuple, ranked together by the same root-sum-square
+    importance :func:`_plain_branch_importance` already applies to a
+    multi-producer branch. Safe for exactly the reason the residual section's
+    own "gated" outcome already is: `_trace_gate_producer_backward` holds
+    every tensor on the gate/up branches to an exact single-consumer bar, and
+    :func:`_branch_walk_has_fanout` -- reused unchanged, since the walk's own
+    `edges` deliberately excludes the gated ``Mul``'s own two operands, see
+    :func:`_walk_matmul_producer_backward`'s own docstring -- still confirms
+    the ``Mul``'s own raw output has no consumer but this `Concat`, so no
+    fan-out anywhere on either shape this composition could miss. Strictly
+    disjoint from the `"add"` outcome by construction, not just today's
+    matching: :func:`_match_matmul_residual_merge` only ever matches a bare
+    ``Add`` or a ``SkipLayerNormalization``-family node, never a ``Mul``, so
+    no node can ever resolve as both). If *any* operand fails to resolve at
+    all, or two operands (or two leaf/gate/up producers of the same composed
+    group or gated pair, or a leaf producer of one branch against another
+    branch's own) name the very same producer weight (degenerate), the whole
+    `Concat` node is declined -- never partially pruned.
     """
     initializer_map = {t.name: t for t in graph.initializer}
     consumers_of = _consumers_of(graph)
     node_by_output = {out: node for node in graph.node for out in node.output}
     graph_outputs = {o.name for o in graph.output}
     value_info_by_name = _value_info_by_name(graph)
+
+    # _find_gated_chains's own producer-lookup map, built once here and
+    # threaded through _walk_matmul_producer_backward below -- needed only to
+    # resolve a gated Mul hop via _trace_gate_producer_backward, exactly the
+    # way _find_matmul_residual_chains already builds and passes this same
+    # map (see this function's own docstring above).
+    producer_infos: Dict[str, Tuple[onnx.NodeProto, str, bool, Optional[str], int]] = {}
+    for node in graph.node:
+        info = _match_producer(node, initializer_map)
+        if info is not None:
+            w_name, weight_transposed, bias_name, n_channels = info
+            producer_infos[node.output[0]] = (
+                node,
+                w_name,
+                weight_transposed,
+                bias_name,
+                n_channels,
+            )
 
     def _is_internal(name: str) -> bool:
         return len(consumers_of.get(name, [])) == 1 and name not in graph_outputs
@@ -4770,6 +4814,7 @@ def _find_matmul_concat_chains(graph: onnx.GraphProto) -> List[_ConcatChain]:
                 consumers_of,
                 graph_outputs,
                 _MAX_CHAIN_HOPS,
+                producer_infos,
             )
             if kind == "fail":
                 declined = True
@@ -4777,6 +4822,31 @@ def _find_matmul_concat_chains(graph: onnx.GraphProto) -> List[_ConcatChain]:
             if _branch_walk_has_fanout(operand, edges, consumers_of, node):
                 declined = True
                 break
+            if kind == "gated":
+                producer_a, producer_b, n_channels = cast(
+                    Tuple[_Producer, _Producer, int], payload
+                )
+                if (
+                    producer_a.weight == producer_b.weight
+                    or producer_a.weight in seen_weights
+                    or producer_b.weight in seen_weights
+                ):
+                    declined = True
+                    break
+                seen_weights.add(producer_a.weight)
+                seen_weights.add(producer_b.weight)
+                branches.append(
+                    _ConcatBranch(
+                        (producer_a, producer_b),
+                        pre_ops,
+                        (),
+                        n_channels,
+                        offset,
+                        operand,
+                    )
+                )
+                offset += n_channels
+                continue
             if kind == "add":
                 assert isinstance(payload, onnx.NodeProto)
                 resolved = _resolve_matmul_residual_group_for_concat(

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -5543,6 +5543,117 @@ def test_structured_pruning_matmul_concat_declines_on_residual_merge_group_inter
     np.testing.assert_array_equal(inits["WOUT"], wout)
 
 
+def test_structured_pruning_matmul_concat_composes_with_gated_branch_matches_oracle():
+    # A gated (SwiGLU-style) Mul of two non-constant operands feeds one
+    # Concat operand directly -- no real producer's raw output in between,
+    # and no Add/SkipLayerNormalization merge involved at all, distinct from
+    # both the plain-producer and composed-residual-group Concat branch
+    # shapes already covered above. Composed, not declined (see
+    # _find_matmul_concat_chains's own docstring on the "gated" outcome):
+    # WG and WU's two raw outputs each become this one branch's own
+    # `producers`, ranked together by the same root-sum-square importance a
+    # standalone gated pair already uses. Deliberately adversarial on both
+    # axes at once, mirroring the residual-composition sibling test above:
+    # WG/WU individually disagree about which half of the columns matter
+    # most (so only their *combined* norm, not either producer's own, can be
+    # driving the gated branch's keep set), and WB (the plain second Concat
+    # branch) is scaled 10x larger so a bug that (wrongly) mixed the two
+    # Concat branches' importances into one ranking would starve WB's own
+    # columns entirely.
+    K, C, Cb, Out = 8, 16, 6, 3
+    rng, wg, wu = _conflicting_wf_ws(233, K, C)
+    wb = rng.standard_normal((K, Cb)).astype(np.float32) * 10.0
+    wout = rng.standard_normal((C + Cb, Out)).astype(np.float32)
+
+    def _build(wg_, wu_, wb_, wout_):
+        return _model(
+            f"""
+            g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+            {{
+              gate = MatMul(X, WG)
+              gate_act = Sigmoid(gate)
+              up = MatMul(X, WU)
+              h = Mul(gate_act, up)
+              hb = MatMul(X, WB)
+              merged = Concat<axis=-1>(h, hb)
+              Y = MatMul(merged, WOUT)
+            }}
+            """,
+            initializer=[
+                _f32(wg_, "WG"),
+                _f32(wu_, "WU"),
+                _f32(wb_, "WB"),
+                _f32(wout_, "WOUT"),
+            ],
+        )
+
+    model = _build(wg, wu, wb, wout)
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep_g = _skip_layer_norm_keep(wg, wu, C)
+    importance_b = np.linalg.norm(wb.astype(np.float64), axis=0)
+    keep_b = np.sort(np.argsort(-importance_b)[: Cb // 2])
+    assert len(keep_b) == Cb // 2  # branch b kept its own top half, not starved to 0
+    global_keep = np.concatenate([keep_g, keep_b + C])
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["WG"], wg[:, keep_g])
+    np.testing.assert_array_equal(inits["WU"], wu[:, keep_g])
+    np.testing.assert_array_equal(inits["WB"], wb[:, keep_b])
+    np.testing.assert_array_equal(inits["WOUT"], wout[global_keep, :])
+
+    oracle = _build(wg[:, keep_g], wu[:, keep_g], wb[:, keep_b], wout[global_keep, :])
+    rng_x = np.random.default_rng(234)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_matmul_concat_declines_on_gated_branch_with_extra_fanout():
+    # Same gated-Mul-feeds-Concat-directly shape as the composed test above,
+    # except `gate_act` (the gate's own activation output) additionally
+    # feeds a second graph output `Z` -- must still decline the *whole*
+    # Concat group, not just this one branch: _trace_gate_producer_backward
+    # (reused unchanged from _find_gated_chains) holds every tensor on a
+    # gate/up path to an exact single-consumer bar, and embedding it inside
+    # _walk_matmul_producer_backward doesn't relax that bar here either --
+    # mirrors test_structured_pruning_matmul_residual_add_declines_on_gated_branch_with_extra_fanout,
+    # the same regression proven for the residual composition.
+    K, C, Cb, Out = 8, 16, 6, 3
+    rng, wg, wu = _conflicting_wf_ws(235, K, C)
+    wb = rng.standard_normal((K, Cb)).astype(np.float32)
+    wout = rng.standard_normal((C + Cb, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y, float[batch,{C}] Z)
+        {{
+          gate = MatMul(X, WG)
+          gate_act = Sigmoid(gate)
+          up = MatMul(X, WU)
+          h = Mul(gate_act, up)
+          hb = MatMul(X, WB)
+          merged = Concat<axis=-1>(h, hb)
+          Y = MatMul(merged, WOUT)
+          Z = Identity(gate_act)
+        }}
+        """,
+        initializer=[
+            _f32(wg, "WG"),
+            _f32(wu, "WU"),
+            _f32(wb, "WB"),
+            _f32(wout, "WOUT"),
+        ],
+    )
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["WG"], wg)
+    np.testing.assert_array_equal(inits["WU"], wu)
+    np.testing.assert_array_equal(inits["WB"], wb)
+    np.testing.assert_array_equal(inits["WOUT"], wout)
+
+
 def test_structured_pruning_matmul_concat_declines_on_duplicate_operand():
     # Concat(h, h) -- the same tensor named twice as an operand of the same
     # Concat node -- is degenerate (not two independent branches at all) and


### PR DESCRIPTION
## Summary
- `Concat`-merged skip-connection pruning previously declined whenever a branch was fed directly by a gated (SwiGLU/GeGLU-style) `Mul` combine, with no real producer's raw output and no `Add`/`SkipLayerNormalization` merge involved either — a third composition distinct from the two already landed (a residual/merge group composed with a `Concat` branch, and a gated `Mul` composed with a residual branch).
- Investigated and found this composition is actually simpler than the residual-group-into-Concat case: no whole transitively-connected group to resolve, just one `Mul` node's own two operands, each walked back via the existing `_trace_gate_producer_backward` (exactly as the residual "gated" case already does), both producers becoming this one `Concat` branch's own `producers` tuple. `_ConcatBranch.producers` already supports a multi-producer tuple from the prior residual-composition work, and `_plain_branch_importance` already combines multiple producers by root-sum-square — both reused directly with no further generalization. `_trace_gate_producer_backward`'s own exact single-consumer bar on every tensor it crosses is the same fan-out guarantee this composition needs; `_branch_walk_has_fanout` (unchanged) separately confirms the `Mul`'s own raw output has no consumer but the `Concat` node.
- Verified explicitly (not assumed) that this can't interact with the existing residual-group composition: `_match_matmul_residual_merge` only ever matches `Add`/`SkipLayerNormalization`, never `Mul` — the two outcomes are disjoint by node-type construction, so threading `producer_infos` into the `Concat` finder has zero effect on the existing `"add"`-outcome path.
- Implemented: `_find_matmul_concat_chains` now builds `producer_infos` (the same way `_find_matmul_residual_chains` already does) and passes it into its `_walk_matmul_producer_backward` calls, handling the new `"gated"` outcome by building a `_ConcatBranch` from both resolved producers — mirroring how the existing `"add"`-outcome composition already builds a multi-producer branch.
- Verified with a fresh adversarial model: a gated `Mul` combine feeding one `Concat` operand directly, alongside an ordinary second `Concat` branch, with deliberately conflicting importance profiles across all three producers (gate, up, plain), confirming the real onnxruntime output matches a hand-built oracle exactly. Added a fan-out-decline regression test mirroring the equivalent existing residual-composition test.

## Test plan
- [x] `pytest tests/test_pruning.py -q` — 199 passed
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — same pre-existing, unrelated errors as `master`; no new ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_