### PR TITLE
Optimize CI matrix: reduce macOS and wheel test jobs on PRs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -67,13 +67,12 @@ jobs:
             # Windows runner (see test_wheels_windows_cross). Skip it here; the
             # same test still runs on the cp311-cp313 jobs (cp311/cp312 on PRs).
             pytest_args: '-k "not test_ext"'
-        # macOS runners are the slowest/most contended in this matrix; a plain
-        # push to main/master (merged commits, not a tagged release) only
-        # needs one macOS build to confirm the platform still works, so drop
-        # it down to the oldest supported version there. PRs already build a
-        # reduced set (above) and releases still need full coverage, so this
-        # only fires for the 'push' trigger.
-        exclude: ${{ github.event_name == 'push' && fromJSON('[{"os":"macos-15","py_ver":"cp312"},{"os":"macos-15","py_ver":"cp313"}]') || fromJSON('[]') }}
+        # macOS runners are the slowest/most contended in this matrix; a pull
+        # request only needs one macOS build to confirm the platform still
+        # works, so drop it down to the oldest supported version there. push
+        # and release still need full coverage, so this only fires for the
+        # 'pull_request' trigger.
+        exclude: ${{ github.event_name == 'pull_request' && fromJSON('[{"os":"macos-15","py_ver":"cp312"}]') || fromJSON('[]') }}
     steps:
     - uses: actions/checkout@v7
       with:
@@ -162,13 +161,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # The 3.13 job re-tests the exact cp312-abi3 wheel the 3.12 job already
-        # covers, so drop it on pull_request to cut a CI job; release still
-        # tests all three. A plain push to main/master (merged commits, not a
-        # tagged release) only needs a smoke test that the cross-built wheels
-        # still install and run, so it's cut further to just the oldest
-        # (cp311) artifact.
-        include: ${{ github.event_name == 'pull_request' && fromJSON('[{"py_ver":"3.11","artifact":"cp311"},{"py_ver":"3.12","artifact":"abi3"}]') || github.event_name == 'push' && fromJSON('[{"py_ver":"3.11","artifact":"cp311"}]') || fromJSON('[{"py_ver":"3.11","artifact":"cp311"},{"py_ver":"3.12","artifact":"abi3"},{"py_ver":"3.13","artifact":"abi3"}]') }}
+        # A pull request only needs a smoke test that the cross-built wheels
+        # still install and run, so it's cut down to just the oldest (cp311)
+        # artifact there; push/release still test all three (the 3.13 entry
+        # re-tests the exact cp312-abi3 wheel the 3.12 job already covers, but
+        # that's fine outside PRs where CI job count matters less).
+        include: ${{ github.event_name == 'pull_request' && fromJSON('[{"py_ver":"3.11","artifact":"cp311"}]') || fromJSON('[{"py_ver":"3.11","artifact":"cp311"},{"py_ver":"3.12","artifact":"abi3"},{"py_ver":"3.13","artifact":"abi3"}]') }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -67,6 +67,13 @@ jobs:
             # Windows runner (see test_wheels_windows_cross). Skip it here; the
             # same test still runs on the cp311-cp313 jobs (cp311/cp312 on PRs).
             pytest_args: '-k "not test_ext"'
+        # macOS runners are the slowest/most contended in this matrix; a plain
+        # push to main/master (merged commits, not a tagged release) only
+        # needs one macOS build to confirm the platform still works, so drop
+        # it down to the oldest supported version there. PRs already build a
+        # reduced set (above) and releases still need full coverage, so this
+        # only fires for the 'push' trigger.
+        exclude: ${{ github.event_name == 'push' && fromJSON('[{"os":"macos-15","py_ver":"cp312"},{"os":"macos-15","py_ver":"cp313"}]') || fromJSON('[]') }}
     steps:
     - uses: actions/checkout@v7
       with:
@@ -156,9 +163,12 @@ jobs:
       fail-fast: false
       matrix:
         # The 3.13 job re-tests the exact cp312-abi3 wheel the 3.12 job already
-        # covers, so drop it on pull_request to cut a CI job; push/release still
-        # test both.
-        include: ${{ github.event_name == 'pull_request' && fromJSON('[{"py_ver":"3.11","artifact":"cp311"},{"py_ver":"3.12","artifact":"abi3"}]') || fromJSON('[{"py_ver":"3.11","artifact":"cp311"},{"py_ver":"3.12","artifact":"abi3"},{"py_ver":"3.13","artifact":"abi3"}]') }}
+        # covers, so drop it on pull_request to cut a CI job; release still
+        # tests all three. A plain push to main/master (merged commits, not a
+        # tagged release) only needs a smoke test that the cross-built wheels
+        # still install and run, so it's cut further to just the oldest
+        # (cp311) artifact.
+        include: ${{ github.event_name == 'pull_request' && fromJSON('[{"py_ver":"3.11","artifact":"cp311"},{"py_ver":"3.12","artifact":"abi3"}]') || github.event_name == 'push' && fromJSON('[{"py_ver":"3.11","artifact":"cp311"}]') || fromJSON('[{"py_ver":"3.11","artifact":"cp311"},{"py_ver":"3.12","artifact":"abi3"},{"py_ver":"3.13","artifact":"abi3"}]') }}
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
## Summary
Reduce CI job count for pull requests by skipping redundant test configurations while maintaining full coverage for push and release events.

## Changes
- **macOS matrix exclusion**: Skip `macos-15` with `cp312` on pull requests, keeping only the oldest supported macOS version to confirm platform compatibility. Full matrix still runs on push/release.
- **Wheel test matrix reduction**: For pull requests, test only the `cp311` artifact as a smoke test that cross-built wheels install and run correctly. Push/release events continue testing all three artifacts (`cp311`, `cp312-abi3`, `cp313-abi3`).

## Rationale
macOS runners are the slowest and most contended resources in the CI matrix. A single macOS build per PR is sufficient to verify platform compatibility, while push and release workflows need comprehensive coverage. Similarly, the wheel test matrix includes a redundant `cp312-abi3` test (already covered by the `cp312` build), which can be skipped on PRs without losing confidence in the build.

https://claude.ai/code/session_01P5jmQB5qjWa43ZQeyc6Ffs