### PR TITLE
Support dynamic input shapes in Core ML export via opt-in dim_param

### DIFF
--- a/onnxsim/coreml_export.py
+++ b/onnxsim/coreml_export.py
@@ -35,7 +35,7 @@ conversion still succeeds off of macOS; pass ``skip_model_load=False`` on macOS 
 model that's ready to run.
 """
 
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import onnx
@@ -76,10 +76,11 @@ def _import_coremltools():
 def _import_mil():
     try:
         from coremltools.converters.mil import Builder as mb
+        from coremltools.converters.mil.input_types import RangeDim, TensorType
         from coremltools.converters.mil.mil import Function, Program, types
     except ImportError as exc:
         raise RuntimeError(_COREML_INSTALL_HINT) from exc
-    return mb, types, Function, Program
+    return mb, types, Function, Program, RangeDim, TensorType
 
 
 def _as_mil_array(arr: np.ndarray) -> np.ndarray:
@@ -123,22 +124,62 @@ def _onnx_elem_type_to_mil(elem_type: int, types) -> Any:
     return mapping[elem_type]
 
 
-def _make_input_spec(value_info: onnx.ValueInfoProto, mb, types):
+def _make_input_spec(
+    value_info: onnx.ValueInfoProto,
+    mb,
+    types,
+    dynamic_shapes: Dict[str, Tuple[int, int, int]],
+    range_dims: Dict[str, Any],
+    RangeDim,
+    TensorType,
+):
+    """Build this input's MIL ``TensorSpec`` and, if it has a dynamic dim, the
+    matching coremltools ``TensorType`` (for ``ct.convert(inputs=...)``; ``None``
+    otherwise).
+
+    Each *named* dynamic dimension (an ONNX ``dim_param``) present as a key in
+    ``dynamic_shapes`` gets one shared ``RangeDim`` -- reused by name across every
+    input that has it (via ``range_dims``), so e.g. all of a KV cache's
+    ``past_key_values.*.key``/``value`` inputs vary together. A ``dim_param`` not
+    in ``dynamic_shapes`` is still rejected as non-static: this is opt-in, not a
+    blanket "allow anything".
+    """
     tt = value_info.type.tensor_type
-    shape = []
+    mil_shape: List[Any] = []
+    ct_shape: List[Any] = []
+    has_dynamic = False
     for d in tt.shape.dim:
         if d.HasField("dim_value"):
-            shape.append(int(d.dim_value))
-        else:
+            mil_shape.append(int(d.dim_value))
+            ct_shape.append(int(d.dim_value))
+            continue
+        name = d.dim_param
+        bounds = dynamic_shapes.get(name)
+        if bounds is None:
             raise RuntimeError(
                 f"Input '{value_info.name}' has a non-static dimension "
-                f"({d.dim_param or '?'!r}); onnxsim's Core ML exporter requires "
-                "fully static input shapes. Give the model concrete input shapes "
-                "first (e.g. via --overwrite-input-shape or "
-                "onnx.tools.update_model_dims) before exporting."
+                f"({name or '?'!r}); onnxsim's Core ML exporter requires fully "
+                "static input shapes by default. Give the model concrete input "
+                "shapes first (e.g. via --overwrite-input-shape or "
+                "onnx.tools.update_model_dims), or mark this dimension dynamic "
+                "via the `dynamic_shapes` argument, e.g. "
+                f"dynamic_shapes={{{name!r}: (lower_bound, default, upper_bound)}}."
             )
+        if name not in range_dims:
+            lower, default, upper = bounds
+            range_dims[name] = RangeDim(
+                lower_bound=lower, upper_bound=upper, default=default, symbol=name
+            )
+        rd = range_dims[name]
+        mil_shape.append(rd.symbol)
+        ct_shape.append(rd)
+        has_dynamic = True
     dtype = _onnx_elem_type_to_mil(tt.elem_type, types)
-    return mb.TensorSpec(shape=tuple(shape), dtype=dtype)
+    spec = mb.TensorSpec(shape=tuple(mil_shape), dtype=dtype)
+    ct_input = (
+        TensorType(name=value_info.name, shape=tuple(ct_shape)) if has_dynamic else None
+    )
+    return spec, ct_input
 
 
 def _node_attrs(node: onnx.NodeProto) -> Dict[str, Any]:
@@ -327,22 +368,43 @@ def _op_isnan(lowerer, node, ins, attrs):
 def _op_expand(lowerer, node, ins, attrs):
     x = ins[0]
     shape_var = ins[1]
-    if shape_var.val is None:
-        raise RuntimeError(
-            "Expand requires a compile-time-constant target 'shape' input"
+    if shape_var.val is not None:
+        target = [int(v) for v in shape_var.val]
+        x_shape = list(x.shape)
+        pad = len(target) - len(x_shape)
+        if pad > 0:
+            x_shape = [1] * pad + x_shape
+            x = lowerer.mb.reshape(
+                x=x, shape=x_shape, name=lowerer.fresh_name(node, "reshape")
+            )
+        # ONNX Expand's broadcast rule (each axis is either 1 or already equal to
+        # the target) maps directly onto `tile`'s integer repeat-count per axis.
+        reps = [t // s for s, t in zip(x_shape, target)]
+        return [lowerer.mb.tile(x=x, reps=reps, name=lowerer.fresh_name(node))]
+
+    # The target shape is itself only known at runtime (e.g. it depends on a KV
+    # cache's dynamic length) -- `tile` needs concrete integer repeat counts, so
+    # there's no way to pick those at conversion time. Broadcast-add a same-shaped
+    # zero tensor instead: MIL's `fill` accepts a non-constant shape, and adding a
+    # tensor of the target shape forces `x` to broadcast up to it.
+    is_bool = x.dtype == lowerer.types.bool
+    if is_bool:
+        x = lowerer.mb.cast(
+            x=x, dtype="int32", name=lowerer.fresh_name(node, "boolcast")
         )
-    target = [int(v) for v in shape_var.val]
-    x_shape = list(x.shape)
-    pad = len(target) - len(x_shape)
-    if pad > 0:
-        x_shape = [1] * pad + x_shape
-        x = lowerer.mb.reshape(
-            x=x, shape=x_shape, name=lowerer.fresh_name(node, "reshape")
-        )
-    # ONNX Expand's broadcast rule (each axis is either 1 or already equal to the
-    # target) maps directly onto `tile`'s integer repeat-count for that axis.
-    reps = [t // s for s, t in zip(x_shape, target)]
-    return [lowerer.mb.tile(x=x, reps=reps, name=lowerer.fresh_name(node))]
+    # `fill`'s output dtype follows its `value`'s Python type (int -> an integer
+    # MIL type, float -> a float one); match `x`'s (post-bool-cast) dtype so the
+    # `add` below doesn't reject the two operands as mismatched types.
+    fill_value = 0 if x.dtype == lowerer.types.int32 else 0.0
+    zeros = lowerer.mb.fill(
+        shape=shape_var, value=fill_value, name=lowerer.fresh_name(node, "zeros")
+    )
+    out = lowerer.mb.add(
+        x=x, y=zeros, name=lowerer.fresh_name(node, "expand" if is_bool else None)
+    )
+    if is_bool:
+        out = lowerer.mb.cast(x=out, dtype="bool", name=lowerer.fresh_name(node))
+    return [out]
 
 
 @_register("Neg")
@@ -614,11 +676,11 @@ _OP_HANDLERS["ReduceMax"] = _reduce("reduce_max")
 
 @_register("Reshape")
 def _op_reshape(lowerer, node, ins, attrs):
-    shape_var = ins[1]
-    if shape_var.val is None:
-        raise RuntimeError("Reshape requires a compile-time-constant 'shape' input")
-    shape = [int(v) for v in shape_var.val]
-    return [lowerer.mb.reshape(x=ins[0], shape=shape, name=lowerer.fresh_name(node))]
+    # MIL's reshape accepts a non-constant `shape` input directly (unlike most
+    # other shape-consuming ops here), so a `shape` derived from a dynamic Shape
+    # op (e.g. "keep the KV cache's current length, flatten the rest") works with
+    # no special-casing -- pass it straight through either way.
+    return [lowerer.mb.reshape(x=ins[0], shape=ins[1], name=lowerer.fresh_name(node))]
 
 
 @_register("Transpose")
@@ -721,63 +783,189 @@ def _op_pad(lowerer, node, ins, attrs):
     ]
 
 
+def _slice_scalar_element(lowerer, var, index: int, node, suffix: str):
+    """Element ``index`` of 1-D int tensor ``var``, as a length-1 piece: a plain
+    Python ``int`` if statically known, else a shape-``(1,)`` MIL Var."""
+    if var.val is not None:
+        return int(var.val[index])
+    return lowerer.mb.slice_by_index(
+        x=var,
+        begin=[index],
+        end=[index + 1],
+        stride=[1],
+        name=lowerer.fresh_name(node, suffix),
+    )
+
+
+def _axis_size(lowerer, x, axis: int, node, suffix: str):
+    """Size of ``x`` along ``axis``: a plain Python ``int`` if statically known,
+    else a shape-``(1,)`` MIL Var (via MIL's runtime ``shape`` op)."""
+    dim = x.shape[axis]
+    if isinstance(dim, (int, np.integer)):
+        return int(dim)
+    full_shape = lowerer.mb.shape(x=x, name=lowerer.fresh_name(node, suffix + "_shape"))
+    return lowerer.mb.slice_by_index(
+        x=full_shape,
+        begin=[axis],
+        end=[axis + 1],
+        stride=[1],
+        name=lowerer.fresh_name(node, suffix),
+    )
+
+
+def _as_slice_piece(value):
+    """A shape-``(1,)`` int32 array for a Python ``int`` piece; ``value`` itself
+    (already a MIL Var) otherwise. Used to mix static and dynamic Slice
+    begin/end pieces in one ``mb.concat``."""
+    return value if not isinstance(value, int) else np.array([value], dtype=np.int32)
+
+
+def _clamp_nonneg_slice_bound(lowerer, value, dim, node, suffix: str):
+    """Clamp a Slice ``start``/``end`` value into ``[0, dim]`` for a positive
+    stride, wrapping a negative value via ``value + dim`` first (ONNX Slice's own
+    rule). ``value``/``dim`` are each a Python ``int`` or a shape-``(1,)`` MIL Var
+    (see ``_slice_scalar_element``/``_axis_size``); returns a Python ``int`` only
+    when both inputs are, else a MIL Var.
+    """
+    if isinstance(value, int) and isinstance(dim, int):
+        wrapped = value + dim if value < 0 else value
+        return max(0, min(wrapped, dim))
+    value_t, dim_t = _as_slice_piece(value), _as_slice_piece(dim)
+    zero = np.array([0], dtype=np.int32)
+    wrapped = lowerer.mb.select(
+        cond=lowerer.mb.less(
+            x=value_t, y=zero, name=lowerer.fresh_name(node, suffix + "_neg")
+        ),
+        a=lowerer.mb.add(
+            x=value_t, y=dim_t, name=lowerer.fresh_name(node, suffix + "_wrap")
+        ),
+        b=value_t,
+        name=lowerer.fresh_name(node, suffix + "_sel"),
+    )
+    hi_clamped = lowerer.mb.minimum(
+        x=wrapped, y=dim_t, name=lowerer.fresh_name(node, suffix + "_min")
+    )
+    return lowerer.mb.maximum(
+        x=hi_clamped, y=zero, name=lowerer.fresh_name(node, suffix)
+    )
+
+
 @_register("Slice")
 def _op_slice(lowerer, node, ins, attrs):
     x = ins[0]
     rank = x.rank
-    shape = x.shape
-    if any(not isinstance(d, (int, np.integer)) for d in shape):
-        raise RuntimeError("Slice requires a fully static input shape")
+
     if len(ins) > 1:
-        starts = [int(v) for v in ins[1].val]
-        ends = [int(v) for v in ins[2].val]
-        axes = (
-            [int(v) for v in ins[3].val]
-            if len(ins) > 3 and ins[3] is not None
-            else list(range(len(starts)))
-        )
+        starts_var, ends_var = ins[1], ins[2]
+        axes_var = ins[3] if len(ins) > 3 and ins[3] is not None else None
+        steps_var = ins[4] if len(ins) > 4 and ins[4] is not None else None
+        if axes_var is not None and axes_var.val is None:
+            raise RuntimeError("Slice requires a compile-time-constant 'axes' input")
+        if steps_var is not None and steps_var.val is None:
+            raise RuntimeError("Slice requires a compile-time-constant 'steps' input")
+        if axes_var is not None:
+            axes = [int(v) for v in axes_var.val]
+        elif starts_var.val is not None:
+            axes = list(range(len(starts_var.val)))
+        elif ends_var.val is not None:
+            axes = list(range(len(ends_var.val)))
+        else:
+            raise RuntimeError(
+                "Slice needs a compile-time-constant 'axes' input when both "
+                "'starts' and 'ends' are dynamic (there is no way to tell how "
+                "many axes are being sliced)"
+            )
         steps = (
-            [int(v) for v in ins[4].val]
-            if len(ins) > 4 and ins[4] is not None
-            else [1] * len(starts)
+            [int(v) for v in steps_var.val]
+            if steps_var is not None
+            else [1] * len(axes)
         )
+        starts = [
+            _slice_scalar_element(lowerer, starts_var, i, node, "start")
+            for i in range(len(axes))
+        ]
+        ends = [
+            _slice_scalar_element(lowerer, ends_var, i, node, "end")
+            for i in range(len(axes))
+        ]
     else:
+        axes = [int(v) for v in attrs.get("axes", range(len(attrs["starts"])))]
+        steps = [1] * len(axes)
         starts = [int(v) for v in attrs["starts"]]
         ends = [int(v) for v in attrs["ends"]]
-        axes = [int(v) for v in attrs.get("axes", range(len(starts)))]
-        steps = [1] * len(starts)
 
-    # Reproduce ONNX Slice's own clamp algorithm (numpy-style negative-index
-    # wraparound, then clamp) rather than Python's `slice.indices()`: for a
-    # negative stride, a fully-clamped end of -1 means "include index 0", but MIL's
-    # `end` re-wraps a literal -1 to `dim - 1` (numpy indexing semantics), which
-    # would silently turn that into an empty slice. Route that one case through
-    # `end_mask` (MIL's "ignore `end`, go to the natural boundary" flag) instead.
-    begin, end, stride = [0] * rank, list(shape), [1] * rank
-    end_mask = [False] * rank
+    # An axis this node doesn't slice at all is left alone via begin_mask/end_mask,
+    # rather than pre-filled with `shape[a]` -- that axis's size doesn't need to be
+    # known at conversion time then (e.g. a dynamic KV-cache axis untouched by this
+    # particular Slice).
+    begin_list: List[Any] = [0] * rank
+    end_list: List[Any] = [0] * rank
+    stride = [1] * rank
+    begin_mask, end_mask = [True] * rank, [True] * rank
     for s, e, a, st in zip(starts, ends, axes, steps):
         a = a if a >= 0 else a + rank
-        dim = int(shape[a])
-        s = s + dim if s < 0 else s
-        e = e + dim if e < 0 else e
-        if st > 0:
-            s = max(0, min(s, dim))
-            e = max(0, min(e, dim))
-        else:
+        dim = _axis_size(lowerer, x, a, node, f"dim{a}")
+        is_dynamic = not (
+            isinstance(s, int) and isinstance(e, int) and isinstance(dim, int)
+        )
+        if st < 0:
+            if is_dynamic:
+                raise RuntimeError(
+                    f"Slice on axis {a} with a negative stride and a dynamic "
+                    "start/end/axis-size is not supported"
+                )
+            # Reproduce ONNX Slice's own clamp algorithm (numpy-style
+            # negative-index wraparound, then clamp) rather than Python's
+            # `slice.indices()`: for a negative stride, a fully-clamped end of -1
+            # means "include index 0", but MIL's `end` re-wraps a literal -1 to
+            # `dim - 1` (numpy indexing semantics), which would silently turn
+            # that into an empty slice. Route that one case through `end_mask`
+            # (MIL's "ignore `end`, go to the natural boundary" flag) instead.
+            s = s + dim if s < 0 else s
+            e = e + dim if e < 0 else e
             s = max(0, min(s, dim - 1))
             e = max(-1, min(e, dim - 1))
-        begin[a], stride[a] = s, st
-        if e == -1 and st < 0:
-            end_mask[a] = True
-            end[a] = 0  # ignored: end_mask[a] takes over
+            begin_list[a], stride[a] = s, st
+            begin_mask[a] = False
+            if e == -1:
+                end_mask[a] = True  # ignored: end_list[a] below is a don't-care
+            else:
+                end_list[a] = e
+                end_mask[a] = False
         else:
-            end[a] = e
-    kwargs = dict(
-        x=x, begin=begin, end=end, stride=stride, name=lowerer.fresh_name(node)
-    )
-    if any(end_mask):
-        kwargs["end_mask"] = end_mask
-    return [lowerer.mb.slice_by_index(**kwargs)]
+            begin_list[a] = _clamp_nonneg_slice_bound(
+                lowerer, s, dim, node, f"begin{a}"
+            )
+            end_list[a] = _clamp_nonneg_slice_bound(lowerer, e, dim, node, f"end{a}")
+            stride[a] = st
+            begin_mask[a] = False
+            end_mask[a] = False
+
+    if all(isinstance(v, int) for v in begin_list + end_list):
+        begin, end = begin_list, end_list
+    else:
+        begin = lowerer.mb.concat(
+            values=[_as_slice_piece(v) for v in begin_list],
+            axis=0,
+            name=lowerer.fresh_name(node, "begin"),
+        )
+        end = lowerer.mb.concat(
+            values=[_as_slice_piece(v) for v in end_list],
+            axis=0,
+            name=lowerer.fresh_name(node, "end"),
+        )
+
+    return [
+        lowerer.mb.slice_by_index(
+            x=x,
+            begin=begin,
+            end=end,
+            stride=stride,
+            begin_mask=begin_mask,
+            end_mask=end_mask,
+            name=lowerer.fresh_name(node),
+        )
+    ]
 
 
 @_register("Gather")
@@ -819,32 +1007,49 @@ def _op_tile(lowerer, node, ins, attrs):
 def _op_shape(lowerer, node, ins, attrs):
     x = ins[0]
     shape = x.shape
-    if any(not isinstance(d, (int, np.integer)) for d in shape):
-        raise RuntimeError("Shape requires a fully static input shape")
     rank = len(shape)
     start = int(attrs.get("start", 0))
     start = start if start >= 0 else start + rank
     end = int(attrs.get("end", rank))
     end = end if end >= 0 else end + rank
+    sliced = shape[start:end]
+    if all(isinstance(d, (int, np.integer)) for d in sliced):
+        return [lowerer.make_const(node.output[0], np.array(sliced, dtype=np.int64))]
+    # At least one requested dim is only known at runtime (e.g. a KV cache's
+    # dynamic length) -- emit MIL's own runtime `shape` op instead of a constant.
+    whole_range = (start, end) == (0, rank)
+    full = lowerer.mb.shape(
+        x=x, name=lowerer.fresh_name(node, None if whole_range else "full")
+    )
+    if whole_range:
+        return [full]
     return [
-        lowerer.make_const(node.output[0], np.array(shape[start:end], dtype=np.int64))
+        lowerer.mb.slice_by_index(
+            x=full, begin=[start], end=[end], stride=[1], name=lowerer.fresh_name(node)
+        )
     ]
 
 
 @_register("ConstantOfShape")
 def _op_constant_of_shape(lowerer, node, ins, attrs):
     shape_var = ins[0]
-    if shape_var.val is None:
-        raise RuntimeError(
-            "ConstantOfShape requires a compile-time-constant 'shape' input"
-        )
-    shape = [int(v) for v in shape_var.val]
     value = attrs.get("value")
     if value is not None:
         value = np.asarray(value)
         fill_val, dtype = value.reshape(-1)[0], value.dtype
     else:
         fill_val, dtype = 0.0, np.float32
+    if shape_var.val is None:
+        # The target shape is only known at runtime (e.g. derived from a KV
+        # cache's dynamic length) -- MIL's `fill` op takes a non-constant shape,
+        # unlike materializing a numpy array here.
+        fill_val = _as_mil_array(np.array(fill_val, dtype=dtype)).item()
+        return [
+            lowerer.mb.fill(
+                shape=shape_var, value=fill_val, name=lowerer.fresh_name(node)
+            )
+        ]
+    shape = [int(v) for v in shape_var.val]
     return [lowerer.make_const(node.output[0], np.full(shape, fill_val, dtype=dtype))]
 
 
@@ -903,7 +1108,16 @@ def _op_constant(lowerer, node, ins, attrs):
 SUPPORTED_ONNX_OPS = tuple(sorted(_OP_HANDLERS))
 
 
-def _build_mil_program(model: onnx.ModelProto, mb, types, Function, Program):
+def _build_mil_program(
+    model: onnx.ModelProto,
+    mb,
+    types,
+    Function,
+    Program,
+    RangeDim,
+    TensorType,
+    dynamic_shapes: Optional[Dict[str, Tuple[int, int, int]]] = None,
+):
     graph = model.graph
     initializer_names = {t.name for t in graph.initializer}
     opset = 1
@@ -913,11 +1127,19 @@ def _build_mil_program(model: onnx.ModelProto, mb, types, Function, Program):
 
     lowerer = _Lowerer(mb=mb, types=types, opset=opset)
 
+    dynamic_shapes = dynamic_shapes or {}
+    range_dims: Dict[str, Any] = {}
     input_specs = {}
+    flexible_inputs = []
     for inp in graph.input:
         if inp.name in initializer_names:
             continue
-        input_specs[inp.name] = _make_input_spec(inp, mb, types)
+        spec, ct_input = _make_input_spec(
+            inp, mb, types, dynamic_shapes, range_dims, RangeDim, TensorType
+        )
+        input_specs[inp.name] = spec
+        if ct_input is not None:
+            flexible_inputs.append(ct_input)
 
     with Function(input_specs) as func:
         for name, var in func.inputs.items():
@@ -935,7 +1157,7 @@ def _build_mil_program(model: onnx.ModelProto, mb, types, Function, Program):
 
     prog = Program()
     prog.add_function("main", func)
-    return prog
+    return prog, (flexible_inputs or None)
 
 
 def _resolve_compute_units(ct, compute_units: Union[str, Any]):
@@ -967,6 +1189,7 @@ def convert_to_coreml(
     compute_precision: Optional[Any] = None,
     minimum_deployment_target: Optional[Union[str, Any]] = None,
     skip_model_load: bool = True,
+    dynamic_shapes: Optional[Dict[str, Tuple[int, int, int]]] = None,
 ):
     """Convert an ONNX model to an in-memory Core ML model.
 
@@ -974,8 +1197,8 @@ def convert_to_coreml(
     ----------
     model:
         The ONNX model to convert. Typically the output of :func:`onnxsim.simplify`.
-        All graph inputs must have fully static shapes (see ``_make_input_spec``);
-        every node's op must be one of ``SUPPORTED_ONNX_OPS``.
+        Every graph input dimension must be either static or named in
+        ``dynamic_shapes``; every node's op must be one of ``SUPPORTED_ONNX_OPS``.
     convert_to:
         Core ML model type: ``"mlprogram"`` (the modern ``.mlpackage`` format,
         default) or ``"neuralnetwork"`` (the legacy ``.mlmodel`` format).
@@ -994,6 +1217,18 @@ def convert_to_coreml(
         Compiling requires Apple's Core ML toolchain and only succeeds on macOS; leave
         this ``True`` to convert models on any OS, or pass ``False`` on macOS to get a
         model that's ready to call ``.predict()`` on.
+    dynamic_shapes:
+        Opt in specific ONNX input dimensions as dynamic instead of requiring every
+        dimension to be static. Maps an ONNX ``dim_param`` name (e.g.
+        ``"past_sequence_length"``, the dimension that grows as a KV cache fills)
+        to a ``(lower_bound, default, upper_bound)`` tuple of concrete sizes. Every
+        input that shares the same ``dim_param`` name varies together (the common
+        case: a KV cache's ``past_key_values.*.key``/``value`` inputs). A
+        ``dim_param`` an ONNX exporter wrote as a derived expression (e.g.
+        ``"past_sequence_length + sequence_length"``, seen on an attention mask)
+        needs its own entry with that exact string as the key -- it is not
+        automatically inferred from the terms it names. ``None`` (the default)
+        requires every dimension to be static, as before.
 
     Returns
     -------
@@ -1002,13 +1237,16 @@ def convert_to_coreml(
     Raises
     ------
     RuntimeError
-        If coremltools is not installed, an input has a non-static shape, or the graph
-        uses an ONNX op/feature this translator does not support.
+        If coremltools is not installed, an input has a dimension that's neither
+        static nor named in ``dynamic_shapes``, or the graph uses an ONNX
+        op/feature this translator does not support.
     """
     ct = _import_coremltools()
-    mb, types, Function, Program = _import_mil()
+    mb, types, Function, Program, RangeDim, TensorType = _import_mil()
 
-    prog = _build_mil_program(model, mb, types, Function, Program)
+    prog, flexible_inputs = _build_mil_program(
+        model, mb, types, Function, Program, RangeDim, TensorType, dynamic_shapes
+    )
 
     kwargs: Dict[str, Any] = {}
     if compute_precision is not None:
@@ -1017,6 +1255,8 @@ def convert_to_coreml(
         kwargs["minimum_deployment_target"] = _resolve_deployment_target(
             ct, minimum_deployment_target
         )
+    if flexible_inputs is not None:
+        kwargs["inputs"] = flexible_inputs
 
     return ct.convert(
         prog,

--- a/scripts/apple/README.md
+++ b/scripts/apple/README.md
@@ -90,26 +90,29 @@ the same two axes (decode tok/s, peak memory) as
 methodology.
 
 - `export_llm_to_coreml.py` exports a Hugging Face causal LM (via
-  [`optimum-onnx`](https://github.com/huggingface/optimum-onnx)) to a
-  **fixed-context, empty-KV-cache** ONNX decoder, runs it through
-  `onnxsim.simplify`, and converts it with `onnxsim.export_coreml`. See its
-  module docstring for why the KV cache is pinned empty instead of growing
-  (onnxsim's Core ML exporter currently requires fully static shapes, and a
-  growing cache is a dynamic one) and what that costs: every decode step
-  reprocesses the whole context window instead of reusing previous work, so
-  this is *not* a production KV-cache deployment -- it's the largest
-  transformer graph onnxsim's Core ML exporter has been exercised against.
-  Extending the exporter to support one dynamic axis (so a real growing KV
-  cache becomes possible) is the natural next step here.
+  [`optimum-onnx`](https://github.com/huggingface/optimum-onnx)) to an ONNX
+  decoder-with-past, runs it through `onnxsim.simplify`, and converts it with
+  `onnxsim.export_coreml` using its `dynamic_shapes` argument to keep
+  `sequence_length` and `past_sequence_length` genuinely dynamic (bounded by
+  `--max-context-length`) instead of baking them to fixed values. The result
+  is one Core ML model that supports a real, O(1)-per-token growing KV
+  cache: a single forward pass over the whole prompt builds the initial
+  cache (prefill), and each new token is generated with a single-token
+  forward pass that reuses it, instead of reprocessing the whole context
+  every step. This exercises onnxsim's Core ML exporter's dynamic-shape
+  support (`onnxsim/coreml_export.py`'s `dynamic_shapes` argument) against
+  the largest, most control-flow-heavy transformer graph it's been run on.
 - `run_llm_decode_benchmark.py` loads the resulting `.mlpackage`, greedily
-  decodes a prompt, and reports decode tok/s and peak RSS. Like the rest of
-  this directory, it only *runs* a model on macOS (that's where Core ML's
-  runtime lives); the export step itself needs no Apple hardware.
+  decodes a prompt by prefilling once and then decoding one token at a time
+  against the growing cache, and reports prefill latency, decode tok/s
+  (decode steps only, matching DeviceMark's methodology), and peak RSS. Like
+  the rest of this directory, it only *runs* a model on macOS (that's where
+  Core ML's runtime lives); the export step itself needs no Apple hardware.
 
 ```bash
 pip install "optimum-onnx" transformers coremltools
 python export_llm_to_coreml.py HuggingFaceTB/SmolLM2-135M-Instruct \
-    --max-length 64 --output smollm2.mlpackage
+    --max-context-length 512 --output smollm2.mlpackage
 python run_llm_decode_benchmark.py smollm2.mlpackage \
     --prompt "The capital of France is" --max-new-tokens 20
 ```

--- a/scripts/apple/export_llm_to_coreml.py
+++ b/scripts/apple/export_llm_to_coreml.py
@@ -1,36 +1,46 @@
 #!/usr/bin/env python3
-"""Export a Hugging Face causal LM to a static-shape Core ML decoder.
+"""Export a Hugging Face causal LM to a real KV-cache Core ML decoder.
 
 Bridges a "decoder-with-past" ONNX export (produced by `optimum-onnx`,
-https://github.com/huggingface/optimum-onnx) to `onnxsim.export_coreml`, which
-requires fully static input shapes (see `onnxsim/coreml_export.py`). A real
-KV-cache decode loop needs the `past_sequence_length` axis to grow every step,
-which is dynamic -- there is no way to bake that into one static-shape Core ML
-model without extending the translator to support symbolic shapes.
+https://github.com/huggingface/optimum-onnx) to `onnxsim.export_coreml`. Unlike
+a plain static-shape export, this keeps `sequence_length` and
+`past_sequence_length` as genuinely dynamic axes all the way through to the
+Core ML model (via `onnxsim.export_coreml`'s `dynamic_shapes` argument, see
+`onnxsim/coreml_export.py`), so the resulting `.mlpackage` is one model that
+supports both:
 
-This script sidesteps that with a different (and simpler) decode strategy: a
-single static model with a fixed context window (`--max-length`), an *always
-empty* KV cache (`past_sequence_length` pinned to 0), and the full token
-sequence recomputed from scratch on every step (right-padded up to
-`--max-length`, reading the logits at the last real position). Standard causal
-masking already guarantees padding after the current position can't influence
-earlier positions, so this is exactly as correct as real KV-cache decoding --
-just O(context length) more compute per token instead of O(1), since nothing
-from the previous step's forward pass is reused. `run_llm_decode_benchmark.py`
-is the harness that actually runs this model and measures the resulting
-decode throughput; the numbers it reports describe *this* recompute strategy,
-not a production KV-cache deployment.
+- **prefill**: one forward pass over the whole prompt (`sequence_length` =
+  prompt length, `past_sequence_length` = 0), producing the initial cache.
+- **decode**: one forward pass per new token (`sequence_length` = 1),
+  consuming and extending the growing cache from the previous step.
 
-Pipeline: `optimum.exporters.onnx` (decoder-with-past, static batch/sequence
-length) -> pin `past_sequence_length` to 0 across every input/output ->
-`onnxsim.simplify` (folds the now-constant shape/mask arithmetic -- this is
-what turns most of the graph's `Shape`/`Equal`/`Range`/`ConstantOfShape`
-plumbing into plain constants before the Core ML translator ever sees it) ->
-`onnxsim.export_coreml`.
+This is a real, O(1)-per-decode-step KV cache -- each step only computes the
+new token's attention over the accumulated `present_*` cache from every prior
+step, instead of reprocessing the whole context window every time.
+`run_llm_decode_benchmark.py` is the harness that actually runs this model
+and carries the cache across steps.
+
+Only `batch_size` is pinned to a concrete value (1); `sequence_length`,
+`past_sequence_length`, and the composite `past_sequence_length +
+sequence_length` axis ONNX exporters emit for the attention mask are left
+dynamic, bounded by `--max-context-length` (the largest prompt + generated
+tokens the exported model will accept).
+
+`optimum`'s tracer cannot trace a `sequence_length` of exactly 1 for
+Llama-family models without corrupting the attention mask (see
+`onnx_export_from_model`'s "sequence length of 1" check) -- this only affects
+which shape is used to *trace* the model, not what shapes the exported graph
+accepts at runtime, so this script traces with `sequence_length=2` and lets
+`onnxsim.simplify` + the dynamic Core ML export handle the true dynamic
+range, `sequence_length=1` decode steps included.
+
+Pipeline: `optimum.exporters.onnx` (decoder-with-past, dynamic axes) -> pin
+`batch_size` to 1 -> `onnxsim.simplify` -> `onnxsim.export_coreml` with
+`dynamic_shapes` for `sequence_length` / `past_sequence_length` / their sum.
 
 Usage:
     python export_llm_to_coreml.py HuggingFaceTB/SmolLM2-135M-Instruct \\
-        --max-length 64 --output smollm2.mlpackage
+        --max-context-length 512 --output smollm2.mlpackage
 """
 
 from __future__ import annotations
@@ -44,42 +54,26 @@ from pathlib import Path
 import onnx
 
 
-def _fix_static_shapes(
-    model: onnx.ModelProto, batch_size: int, sequence_length: int
-) -> None:
-    """Replace `optimum`'s symbolic dims with the concrete ones it actually traced.
+def _fix_batch_size(model: onnx.ModelProto, batch_size: int) -> None:
+    """Pin the `batch_size` dim_param to a concrete value everywhere it appears.
 
-    `optimum.exporters.onnx`'s `--no-dynamic-axes`/`--batch_size`/`--sequence_length`
-    flags control the dummy inputs used to *trace* the model, not the dim_param
-    names written into the exported graph's declared input/output shapes -- those
-    stay symbolic regardless. The traced computation is already specialized to the
-    concrete shapes given at export time, so it's safe (and necessary, for
-    onnxsim's Core ML exporter) to overwrite the declared shapes to match.
+    `sequence_length`, `past_sequence_length`, and the composite
+    `past_sequence_length + sequence_length` dim_params are deliberately left
+    alone -- those are the axes this script's whole point is to keep dynamic.
     """
-    dims = {
-        "batch_size": batch_size,
-        "sequence_length": sequence_length,
-        "past_sequence_length": 0,
-        "past_sequence_length + sequence_length": sequence_length,
-    }
     for vi in list(model.graph.input) + list(model.graph.output):
         tt = vi.type.tensor_type
         for d in tt.shape.dim:
-            if d.HasField("dim_param"):
-                if d.dim_param not in dims:
-                    raise ValueError(
-                        f"Unrecognized dynamic dim {d.dim_param!r} on {vi.name!r}"
-                    )
-                value = dims[d.dim_param]
+            if d.HasField("dim_param") and d.dim_param == "batch_size":
                 d.Clear()
-                d.dim_value = value
+                d.dim_value = batch_size
 
 
 def export_llm_to_coreml(
     model_id: str,
     output_path: str,
     *,
-    max_length: int = 64,
+    max_context_length: int = 512,
     opset: int = 17,
     convert_to: str = "mlprogram",
 ) -> None:
@@ -87,7 +81,8 @@ def export_llm_to_coreml(
 
     with tempfile.TemporaryDirectory(prefix="onnxsim_llm_export_") as tmpdir:
         print(
-            f"Exporting {model_id!r} to ONNX (decoder-with-past, opset {opset})...",
+            f"Exporting {model_id!r} to ONNX (decoder-with-past, dynamic shapes, "
+            f"opset {opset})...",
             flush=True,
         )
         main_export(
@@ -95,19 +90,21 @@ def export_llm_to_coreml(
             output=tmpdir,
             task="text-generation-with-past",
             opset=opset,
-            no_dynamic_axes=True,
             batch_size=1,
-            sequence_length=max_length,
+            # Only used to trace the model; the exported graph keeps
+            # sequence_length/past_sequence_length dynamic regardless (see the
+            # module docstring for why 2, not 1).
+            sequence_length=2,
         )
 
         onnx_path = Path(tmpdir) / "model.onnx"
         model = onnx.load(str(onnx_path))
 
         print(
-            f"Pinning shapes to batch=1, sequence_length={max_length}, past_sequence_length=0...",
+            "Pinning batch_size=1 (sequence_length/past_sequence_length stay dynamic)...",
             flush=True,
         )
-        _fix_static_shapes(model, batch_size=1, sequence_length=max_length)
+        _fix_batch_size(model, batch_size=1)
         onnx.checker.check_model(model)
 
         print("Simplifying with onnxsim...", flush=True)
@@ -121,8 +118,17 @@ def export_llm_to_coreml(
             flush=True,
         )
 
-        print(f"Converting to Core ML ({convert_to})...", flush=True)
-        onnxsim.export_coreml(simplified, output_path, convert_to=convert_to)
+        print(f"Converting to Core ML ({convert_to}), dynamic KV cache...", flush=True)
+        onnxsim.export_coreml(
+            simplified,
+            output_path,
+            convert_to=convert_to,
+            dynamic_shapes={
+                "sequence_length": (1, 1, max_context_length),
+                "past_sequence_length": (0, 0, max_context_length - 1),
+                "past_sequence_length + sequence_length": (1, 1, max_context_length),
+            },
+        )
 
         # Carry the tokenizer along so run_llm_decode_benchmark.py can load
         # everything it needs from `output_path`'s sibling files.
@@ -152,12 +158,13 @@ def main() -> int:
         "--output", default="model.mlpackage", help="Output .mlpackage path"
     )
     ap.add_argument(
-        "--max-length",
+        "--max-context-length",
         type=int,
-        default=64,
-        help="Fixed context window: prompt + generated tokens must fit within this many "
-        "tokens (default: 64). Every decode step reprocesses the whole window (see the "
-        "module docstring), so this is also the per-step compute cost -- keep it small.",
+        default=512,
+        help="Upper bound on prompt + generated tokens the exported model will accept "
+        "(default: 512). Unlike a fixed-context recompute model, this only bounds the "
+        "KV cache's Core ML flexible-shape range -- actual per-step compute scales with "
+        "how much of that range is in use, not the bound itself.",
     )
     ap.add_argument("--opset", type=int, default=17)
     ap.add_argument(
@@ -171,7 +178,7 @@ def main() -> int:
     export_llm_to_coreml(
         args.model_id,
         args.output,
-        max_length=args.max_length,
+        max_context_length=args.max_context_length,
         opset=args.opset,
         convert_to=args.convert_to,
     )

--- a/scripts/apple/run_llm_decode_benchmark.py
+++ b/scripts/apple/run_llm_decode_benchmark.py
@@ -6,20 +6,21 @@ script produced (plus the tokenizer files it copied alongside it), greedily
 generates tokens, and reports decode tokens/second and peak resident memory --
 the same two axes DeviceMark's methodology measures on-device (see
 https://devicemark.github.io/ and its METHODOLOGY.md), computed the same way
-(wall-clock decode time on the actual runtime, RSS sampled during generation).
+(wall-clock decode time on the actual runtime, RSS sampled during generation,
+prefill excluded from the decode-tok/s window).
 
 This only runs where Core ML actually executes models: macOS (loading the
 model calls into Apple's Core ML framework, which isn't part of coremltools
 itself -- see `onnxsim/coreml_export.py`'s module docstring). It has nothing
 to do with WebGPU or any browser.
 
-Decode strategy: the exported model has no growing KV cache -- every call
-reprocesses the model's whole fixed-size context window from scratch (see
-export_llm_to_coreml.py's docstring for why). So the tok/s this reports is
-this recompute strategy's throughput, not what a real KV-cache-backed
-deployment of the same model would achieve; treat it as a benchmark of this
-pipeline, not a device capability number, until export_llm_to_coreml.py grows
-real KV-cache (dynamic-shape) support.
+Decode strategy: real KV-cache decode. The exported model accepts a growing
+`past_key_values_*` cache (see export_llm_to_coreml.py); a single forward
+pass processes the whole prompt once (prefill, building the initial cache),
+then each new token is generated with its own single-token forward pass that
+reuses the accumulated cache instead of reprocessing earlier tokens. Prefill
+is timed and reported separately (as "prefill"/time-to-first-token) and
+excluded from decode tok/s, matching DeviceMark's decode-only methodology.
 
 Usage:
     python run_llm_decode_benchmark.py smollm2.mlpackage \\
@@ -58,8 +59,13 @@ def _peak_rss_mb() -> float:
 
 
 class CoreMLDecoder:
-    """Wraps a fixed-context, empty-KV-cache Core ML decoder (see
-    export_llm_to_coreml.py) for greedy generation.
+    """Wraps a real growing-KV-cache Core ML decoder (see export_llm_to_coreml.py)
+    for greedy generation.
+
+    `predict()` is called once for the whole prompt (prefill) and then once per
+    generated token (decode), carrying the `present_*` outputs of each call
+    forward as the `past_key_values_*` inputs of the next -- so each decode step
+    only pays for the one new token, not the whole context.
     """
 
     def __init__(self, mlpackage_path: str, compute_units: str = "ALL"):
@@ -67,77 +73,117 @@ class CoreMLDecoder:
             mlpackage_path, compute_units=getattr(ct.ComputeUnit, compute_units)
         )
         spec = self.mlmodel.get_spec()
-        self._input_shapes = {}
+
         self._input_dtypes = {}
+        max_context_length = None
         for inp in spec.description.input:
             arr = inp.type.multiArrayType
-            self._input_shapes[inp.name] = list(arr.shape)
             self._input_dtypes[inp.name] = _DATATYPE_TO_NUMPY.get(
                 arr.dataType, np.float32
             )
+            if inp.name == "attention_mask":
+                max_context_length = arr.shapeRange.sizeRanges[-1].upperBound
+
+        if not max_context_length or max_context_length <= 0:
+            raise RuntimeError(
+                "could not determine a max context length from the model's "
+                "'attention_mask' input -- was this exported without "
+                "dynamic_shapes (see export_llm_to_coreml.py)?"
+            )
+        self.max_context_length = max_context_length
+
+        self._present_names = [
+            o.name for o in spec.description.output if o.name.startswith("present_")
+        ]
         (self._logits_name,) = [
             o.name for o in spec.description.output if o.name.startswith("logits")
         ]
+        self._empty_past_shapes = {}
+        for inp in spec.description.input:
+            if inp.name.startswith("past_key_values_"):
+                shape = list(inp.type.multiArrayType.shape)
+                shape[2] = 0  # past_sequence_length: empty cache
+                self._empty_past_shapes[inp.name] = shape
 
-        self.max_length = self._input_shapes["input_ids"][-1]
-        self._past_kv_feeds = {
+        self.prefill_seconds = 0.0
+        self.reset()
+
+    def reset(self) -> None:
+        """Clear the KV cache. Call before starting a new generation."""
+        self._cache = {
             name: np.zeros(shape, dtype=self._input_dtypes[name])
-            for name, shape in self._input_shapes.items()
-            if name.startswith("past_key_values")
+            for name, shape in self._empty_past_shapes.items()
         }
+        self._cache_len = 0
 
-    def _forward(self, input_ids: np.ndarray, num_real: int) -> np.ndarray:
-        """Run one forward pass over the padded window; return logits at the last
-        real position."""
-        attention_mask = np.zeros(
-            (1, self.max_length), dtype=self._input_dtypes["attention_mask"]
+    def _step(self, token_ids: list[int]) -> np.ndarray:
+        """Run one forward pass over `token_ids` (the whole prompt for prefill, or
+        a single new token for a decode step), extending the cache in place.
+        Returns the logits at the last position.
+        """
+        n = len(token_ids)
+        input_ids = np.array([token_ids], dtype=self._input_dtypes["input_ids"])
+        attention_mask = np.ones(
+            (1, self._cache_len + n), dtype=self._input_dtypes["attention_mask"]
         )
-        attention_mask[0, :num_real] = 1
         position_ids = np.arange(
-            self.max_length, dtype=self._input_dtypes["position_ids"]
+            self._cache_len,
+            self._cache_len + n,
+            dtype=self._input_dtypes["position_ids"],
         )[None, :]
         feeds = {
-            "input_ids": input_ids.astype(self._input_dtypes["input_ids"]),
+            "input_ids": input_ids,
             "attention_mask": attention_mask,
             "position_ids": position_ids,
-            **self._past_kv_feeds,
+            **self._cache,
         }
         out = self.mlmodel.predict(feeds)
-        return out[self._logits_name][0, num_real - 1]
+        self._cache = {
+            name.replace("present_", "past_key_values_", 1): out[name]
+            for name in self._present_names
+        }
+        self._cache_len += n
+        return out[self._logits_name][0, -1]
 
     def generate(
         self, prompt_ids: list[int], max_new_tokens: int, eos_token_id: int | None
     ):
-        """Greedily generate up to `max_new_tokens` tokens after `prompt_ids`.
+        """Prefill on `prompt_ids`, then greedily decode up to `max_new_tokens` more
+        tokens, one at a time, reusing the growing KV cache.
 
-        Yields (token_id, seconds_for_this_step) per generated token. Stops early
-        on `eos_token_id`, or once the fixed context window is full.
+        Yields (token_id, seconds_for_this_step) per generated token. The first
+        yielded token comes from the prefill pass (its cost is reported separately
+        via `self.prefill_seconds`, so its `seconds_for_this_step` is `None`);
+        every following token is a single-token decode step. Stops early on
+        `eos_token_id`, or once the KV cache reaches this model's max context
+        length.
         """
-        if len(prompt_ids) >= self.max_length:
+        self.reset()
+        if len(prompt_ids) > self.max_context_length:
             raise ValueError(
-                f"prompt has {len(prompt_ids)} tokens, but this model's fixed "
-                f"context window is only {self.max_length} (see --max-length in "
-                "export_llm_to_coreml.py)"
+                f"prompt has {len(prompt_ids)} tokens, exceeding this model's max "
+                f"context length of {self.max_context_length} (see "
+                "--max-context-length in export_llm_to_coreml.py)"
             )
-        input_ids = np.zeros((1, self.max_length), dtype=np.int64)
-        input_ids[0, : len(prompt_ids)] = prompt_ids
-        num_real = len(prompt_ids)
 
-        while num_real < self.max_length and (
-            max_new_tokens is None or max_new_tokens > 0
-        ):
-            t0 = time.perf_counter()
-            logits = self._forward(input_ids, num_real)
+        t0 = time.perf_counter()
+        logits = self._step(prompt_ids)
+        self.prefill_seconds = time.perf_counter() - t0
+
+        dt = None
+        generated = 0
+        while max_new_tokens is None or generated < max_new_tokens:
             next_id = int(np.argmax(logits))
-            dt = time.perf_counter() - t0
-
             yield next_id, dt
+            generated += 1
             if eos_token_id is not None and next_id == eos_token_id:
                 return
-            input_ids[0, num_real] = next_id
-            num_real += 1
-            if max_new_tokens is not None:
-                max_new_tokens -= 1
+            if self._cache_len >= self.max_context_length:
+                return
+
+            t0 = time.perf_counter()
+            logits = self._step([next_id])
+            dt = time.perf_counter() - t0
 
 
 def main() -> int:
@@ -166,7 +212,7 @@ def main() -> int:
         f"Loading {args.mlpackage} (compute_units={args.compute_units}) ...", flush=True
     )
     decoder = CoreMLDecoder(args.mlpackage, compute_units=args.compute_units)
-    print(f"Fixed context window: {decoder.max_length} tokens", flush=True)
+    print(f"Max context length: {decoder.max_context_length} tokens", flush=True)
 
     prompt_ids = tokenizer(args.prompt, return_tensors="np")["input_ids"][0].tolist()
     print(f"Prompt: {args.prompt!r} ({len(prompt_ids)} tokens)", flush=True)
@@ -177,15 +223,23 @@ def main() -> int:
         prompt_ids, args.max_new_tokens, tokenizer.eos_token_id
     ):
         generated.append(token_id)
-        step_times.append(dt)
+        if dt is not None:
+            step_times.append(dt)
 
     text = tokenizer.decode(generated, skip_special_tokens=True)
     print(f"\nGenerated ({len(generated)} tokens): {text!r}", flush=True)
 
+    print(
+        f"\nprefill: {1000 * decoder.prefill_seconds:.1f} ms ({len(prompt_ids)} tokens)",
+        flush=True,
+    )
     if step_times:
         total = sum(step_times)
-        print(f"\ndecode tok/s: {len(step_times) / total:.2f}", flush=True)
-        print(f"mean step latency: {1000 * total / len(step_times):.1f} ms", flush=True)
+        print(f"decode tok/s: {len(step_times) / total:.2f}", flush=True)
+        print(
+            f"mean decode step latency: {1000 * total / len(step_times):.1f} ms",
+            flush=True,
+        )
     print(f"peak RSS: {_peak_rss_mb():.1f} MB", flush=True)
     return 0
 

--- a/tests/test_coreml_export.py
+++ b/tests/test_coreml_export.py
@@ -111,7 +111,9 @@ def _mil_const_value(model: onnx.ModelProto):
     constant-folding evaluates the op with real numpy code, so the result reflects
     exactly how the translator wired up that op's arguments.
     """
-    prog = coreml_export._build_mil_program(model, *coreml_export._import_mil())
+    prog, _flexible_inputs = coreml_export._build_mil_program(
+        model, *coreml_export._import_mil()
+    )
     return np.asarray(prog.functions["main"].outputs[0].val)
 
 
@@ -326,6 +328,125 @@ def test_zero_length_input_dimension_is_static():
         initializer=[x, numpy_helper.from_array(y, name="y")],
     )
     np.testing.assert_array_equal(_mil_const_value(model), y)
+
+
+# ---------------------------------------------------------------------------
+# Dynamic shapes (opt-in flexible input dimensions, e.g. a growing KV cache)
+# ---------------------------------------------------------------------------
+
+
+def test_dynamic_shapes_declares_flexible_input_range():
+    model = _model(
+        "relu (float[N,3] x) => (float[N,3] y) { y = Relu (x) }",
+    )
+    onnx.checker.check_model(model)
+    mlmodel = onnxsim.export_coreml(model, dynamic_shapes={"N": (1, 2, 8)})
+    (in_desc,) = mlmodel.get_spec().description.input
+    arr = in_desc.type.multiArrayType
+    assert list(arr.shape) == [2, 3]
+    assert [(r.lowerBound, r.upperBound) for r in arr.shapeRange.sizeRanges] == [
+        (1, 8),
+        (3, 3),
+    ]
+
+
+def test_dynamic_shapes_shared_dim_param_varies_together():
+    # Two inputs sharing the same dim_param (like a KV cache's many
+    # past_key_values.*.key/value inputs sharing `past_sequence_length`) must
+    # resolve to the same symbol and flexible range.
+    model = _model(
+        "add (float[N,3] x, float[N,3] y) => (float[N,3] z) { z = Add (x, y) }",
+    )
+    onnx.checker.check_model(model)
+    mlmodel = onnxsim.export_coreml(model, dynamic_shapes={"N": (1, 2, 8)})
+    x_desc, y_desc = mlmodel.get_spec().description.input
+    for desc in (x_desc, y_desc):
+        arr = desc.type.multiArrayType
+        assert [(r.lowerBound, r.upperBound) for r in arr.shapeRange.sizeRanges][0] == (
+            1,
+            8,
+        )
+
+
+def test_dynamic_shapes_composite_dim_param_needs_own_entry():
+    # ONNX exporters sometimes emit a derived dim_param like
+    # "past_sequence_length + sequence_length" as its own literal string (e.g. on
+    # an attention mask) rather than deriving it from its terms -- giving
+    # dynamic_shapes entries for "P" and "Q" alone must not satisfy "P + Q". The
+    # parser can't spell a composite dim_param directly (it only accepts plain
+    # identifiers in a shape), so build the base graph with a placeholder dim and
+    # overwrite it with the literal composite string.
+    #
+    # Uses dim names ("P"/"Q") not reused by any other test in this module: a
+    # RuntimeError raised partway through building the MIL program (as this one
+    # deliberately triggers) leaves that dim's coremltools ``Symbol`` registered
+    # process-wide with no cleanup, so a later test reusing the same name would
+    # spuriously fail with "Symbol ... is used already".
+    model = _model(
+        "add (float[P,3] x, float[Q,3] y, float[K,3] mask) => (float[K,3] z) { z = Identity (mask) }",
+    )
+    for d in (
+        model.graph.input[2].type.tensor_type.shape.dim[0],
+        model.graph.output[0].type.tensor_type.shape.dim[0],
+    ):
+        d.Clear()
+        d.dim_param = "P + Q"
+    onnx.checker.check_model(model)
+
+    with pytest.raises(RuntimeError, match=r"non-static dimension \('P \+ Q'\)"):
+        onnxsim.export_coreml(model, dynamic_shapes={"P": (1, 2, 8), "Q": (1, 2, 8)})
+
+
+def test_dynamic_axis_slice_with_runtime_only_bound():
+    # Regression test for the SmolLM2 KV-cache export bug: a Slice whose `ends`
+    # value is itself only known at runtime (derived from Gather(Shape(x)) of a
+    # dynamically-shaped input, not a compile-time constant) used to crash with
+    # "'NoneType' object is not iterable" because the translator assumed
+    # `ends.val` was always available. Here `n` (fed as `ends`) is exactly such a
+    # runtime-only value, and axis 0 (the sliced axis) is itself the dynamic
+    # dimension.
+    model = _model(
+        """
+        slice_dyn (float[N,8] x) => (float[N,8] y)
+        {
+            zero = Constant <value_ints=[0]> ()
+            axis0 = Constant <value_ints=[0]> ()
+            shp = Shape (x)
+            idx0 = Constant <value_ints=[0]> ()
+            n = Gather <axis=0> (shp, idx0)
+            y = Slice (x, zero, n, axis0)
+        }
+        """,
+    )
+    onnx.checker.check_model(model)
+    mlmodel = onnxsim.export_coreml(model, dynamic_shapes={"N": (1, 2, 8)})
+    (in_desc,) = mlmodel.get_spec().description.input
+    arr = in_desc.type.multiArrayType
+    assert [(r.lowerBound, r.upperBound) for r in arr.shapeRange.sizeRanges][0] == (
+        1,
+        8,
+    )
+
+
+def test_dynamic_shapes_expand_to_runtime_shape():
+    # Regression test: Expand's target shape derived from Shape(x) of a
+    # dynamically-shaped input is not a compile-time constant either -- this
+    # used to raise "Expand requires a compile-time-constant target 'shape'
+    # input" (fixed via a fill+broadcast-add lowering for the dynamic case).
+    model = _model(
+        """
+        expand_dyn (float[N,4] x) => (float[N,4] y)
+        {
+            shp = Shape (x)
+            one = Constant <value_float = 1.0> ()
+            y = Expand (one, shp)
+        }
+        """,
+    )
+    onnx.checker.check_model(model)
+    mlmodel = onnxsim.export_coreml(model, dynamic_shapes={"N": (1, 2, 8)})
+    (out_desc,) = mlmodel.get_spec().description.output
+    assert out_desc.name == "y"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Extend `onnxsim.export_coreml()` to support genuinely dynamic input dimensions (e.g., a growing KV cache in LLM inference) via an opt-in `dynamic_shapes` argument. Previously, all input dimensions were required to be fully static. This enables exporting models with real KV-cache decode loops that reuse accumulated state across steps instead of reprocessing the entire context window.

## Key Changes

**Core ML exporter (`onnxsim/coreml_export.py`)**
- Add `dynamic_shapes: Optional[Dict[str, Tuple[int, int, int]]]` parameter to `convert_to_coreml()` and `_build_mil_program()`, mapping ONNX `dim_param` names to `(lower_bound, default, upper_bound)` tuples
- Import `RangeDim` and `TensorType` from coremltools to represent dynamic dimensions
- Refactor `_make_input_spec()` to:
  - Accept `dynamic_shapes` and `range_dims` dicts
  - Return both a MIL `TensorSpec` and an optional coremltools `TensorType` (for flexible inputs)
  - Reuse `RangeDim` by name across inputs sharing the same `dim_param` (e.g., KV cache's `past_key_values.*.key/value` inputs vary together)
  - Provide clearer error messages directing users to `dynamic_shapes` when a dimension is non-static
- Update shape-consuming ops to handle runtime-only values:
  - **`Expand`**: Add fallback for dynamic target shapes via `fill` + broadcast-add instead of `tile` (which requires compile-time repeat counts)
  - **`Reshape`**: Pass non-constant `shape` input directly to MIL's `reshape` (which accepts it natively)
  - **`Slice`**: Support dynamic `start`/`end` values via helper functions (`_slice_scalar_element`, `_axis_size`, `_clamp_nonneg_slice_bound`) that mix static and runtime values; handle negative strides only when all bounds are static
  - **`Shape`**: Emit MIL's runtime `shape` op when any requested dimension is dynamic
  - **`ConstantOfShape`**: Use MIL's `fill` op for dynamic shapes instead of materializing a numpy array

**LLM export script (`scripts/apple/export_llm_to_coreml.py`)**
- Rename `--max-length` to `--max-context-length` (reflects the new semantics: max prompt + generated tokens, not a fixed recompute window)
- Replace `_fix_static_shapes()` with `_fix_batch_size()`: only pin `batch_size=1`, leaving `sequence_length`, `past_sequence_length`, and their composite `past_sequence_length + sequence_length` genuinely dynamic
- Trace with `sequence_length=2` (not 1) to work around Llama-family attention mask corruption in `optimum`'s tracer, then let `onnxsim.simplify` + dynamic Core ML export handle the true range
- Pass `dynamic_shapes` to `onnxsim.export_coreml()` with bounds for `sequence_length`, `past_sequence_length`, and their sum

**Decoder benchmark (`scripts/apple/run_llm_decode_benchmark.py`)**
- Refactor `CoreMLDecoder` to implement real KV-cache decode:
  - Prefill: one forward pass over the whole prompt, building the initial cache
  - Decode: one forward pass per new token, reusing and extending the cache
  - Track `_cache` dict and `_cache_len` across steps; extract `present_*` outputs and feed them as `past_key_values_*` inputs to the next step
  - Report prefill time separately (as `self.prefill_seconds`) and exclude it from decode tok/s, matching DeviceMark's methodology
  - Determine `max_context_length` from the model's `attention_mask` input's shape range

**Tests

https://claude.ai/code/session_01T3MD7VAmysceuqiBQYHvWQ