### PR TITLE
Fix Constant node values visibility in shape inference

### DIFF
--- a/onnxsim/partial_shape_eval.cpp
+++ b/onnxsim/partial_shape_eval.cpp
@@ -191,6 +191,53 @@ onnxsim::SymNode ToSymNode(const onnx::NodeProto& node) {
   return n;
 }
 
+// A `Constant` node's own embedded value, read directly from its `value` /
+// `value_ints` / `value_int` attribute -- mirrors sym_value_eval.cpp's own
+// EvalConstant. Needed because a genuine (non-transient) Constant node is
+// never folded into a graph initializer any more (constant_folding.cpp
+// deliberately leaves it as a producer node -- see kTransientConstantAttr's
+// own comment), yet M2's shape rules (Squeeze axes, Reshape/Expand shape,
+// Slice starts/ends/axes/steps, Split sizes, ...) only ever consult
+// ShapeGraph::initializer for a data-input's concrete values. Without this, an
+// int-list operand sourced from an unfolded Constant node is invisible to M2:
+// the rule either fails outright, or -- worse, for Squeeze/Unsqueeze's
+// "no axes" fallback -- silently substitutes the wrong heuristic (dropping
+// every dim that happens to be 1, including ones the real, unseen axes list
+// would not have touched). M1 (EvaluateSymbolicValues) does not need this: it
+// evaluates every node in topological order, `Constant` included.
+std::optional<onnxsim::SymTensor> ConstantNodeValue(const onnxsim::SymNode& node) {
+  if (node.op_type != "Constant") return std::nullopt;
+  if (const onnxsim::SymAttr* a = node.attr("value")) {
+    if (a->t) return *a->t;
+  }
+  if (const onnxsim::SymAttr* a = node.attr("value_ints")) {
+    std::vector<onnxsim::SymExpr> v;
+    v.reserve(a->ints.size());
+    for (int64_t x : a->ints) v.emplace_back(x);
+    return onnxsim::SymTensor::Vector(std::move(v));
+  }
+  if (const onnxsim::SymAttr* a = node.attr("value_int")) {
+    if (a->i) return onnxsim::SymTensor::Scalar(onnxsim::SymExpr(*a->i));
+  }
+  return std::nullopt;
+}
+
+// Adds every `Constant` node's own value into `initializers`, so M2's
+// ShapeGraph::initializer-only lookups (see ConstantNodeValue's own comment)
+// see it exactly as if it were a real graph initializer. `nodes` is the
+// already-built SymNode list, so this needs no re-parsing of attributes.
+void AddConstantNodeValues(
+    const std::vector<onnxsim::SymNode>& nodes,
+    std::map<std::string, onnxsim::SymTensor>& initializers) {
+  for (const auto& node : nodes) {
+    if (node.output.size() != 1 || node.output[0].empty()) continue;
+    if (initializers.count(node.output[0])) continue;
+    if (auto t = ConstantNodeValue(node)) {
+      initializers[node.output[0]] = std::move(*t);
+    }
+  }
+}
+
 // Run M2 (symbolic activation-shape inference) then M1 (symbolic value
 // evaluation) over `model`, returning every shape-data tensor the evaluator
 // could resolve as a SymTensor (its entries possibly still symbolic).
@@ -210,6 +257,7 @@ std::map<std::string, onnxsim::SymTensor> EvaluateModelSymbolicValues(
     for (int64_t d : init.dims()) s.emplace_back(d);
     shapes_seed[init.name()] = std::move(s);
   }
+  AddConstantNodeValues(nodes, initializers);
   auto seed = [&](const onnx::ValueInfoProto& vi) {
     if (shapes_seed.count(vi.name()))
       return;  // keep the concrete initializer shape
@@ -355,6 +403,7 @@ std::map<std::string, onnxsim::SymTensor> EvaluateGraphSymbolicValues(
     for (int64_t d : inits[i]->sizes()) s.emplace_back(d);
     shapes_seed[init_names[i]] = std::move(s);
   }
+  AddConstantNodeValues(nodes, initializers);
   auto seed = [&](onnx::Value* v) {
     if (shapes_seed.count(v->uniqueName()))
       return;  // keep the concrete initializer shape

--- a/onnxsim/partial_shape_eval.cpp
+++ b/onnxsim/partial_shape_eval.cpp
@@ -205,7 +205,8 @@ onnxsim::SymNode ToSymNode(const onnx::NodeProto& node) {
 // every dim that happens to be 1, including ones the real, unseen axes list
 // would not have touched). M1 (EvaluateSymbolicValues) does not need this: it
 // evaluates every node in topological order, `Constant` included.
-std::optional<onnxsim::SymTensor> ConstantNodeValue(const onnxsim::SymNode& node) {
+std::optional<onnxsim::SymTensor> ConstantNodeValue(
+    const onnxsim::SymNode& node) {
   if (node.op_type != "Constant") return std::nullopt;
   if (const onnxsim::SymAttr* a = node.attr("value")) {
     if (a->t) return *a->t;


### PR DESCRIPTION
## Summary

Fix shape inference (M2) to see values from unfolded `Constant` nodes by adding them to the initializers map. This resolves issues where shape rules that depend on concrete values (Squeeze axes, Reshape/Expand shape, Slice parameters, Split sizes, etc.) would fail or apply incorrect heuristics when those values came from `Constant` nodes rather than graph initializers.

## Problem

The constant folding pass (`constant_folding.cpp`) deliberately leaves genuine `Constant` nodes as producer nodes in the graph rather than folding them into initializers (marked with `kTransientConstantAttr`). However, M2's shape inference rules only consult `ShapeGraph::initializer` for concrete data values. This causes:

1. Shape rules to fail outright when they need values from unfolded `Constant` nodes
2. Silent correctness issues where fallback heuristics are used instead (e.g., Squeeze/Unsqueeze dropping all dims that happen to be 1, not just the intended axes)

M1 (symbolic value evaluation) doesn't have this problem because it evaluates every node in topological order, including `Constant` nodes.

## Changes

- **`ConstantNodeValue()`**: New helper function that extracts a `Constant` node's embedded value from its `value`, `value_ints`, or `value_int` attribute, mirroring the logic in `sym_value_eval.cpp`'s `EvalConstant`

- **`AddConstantNodeValues()`**: New function that populates the initializers map with values from all `Constant` nodes in the graph, making them visible to M2's shape rules

- **Integration**: Call `AddConstantNodeValues()` in both `EvaluateModelSymbolicValues()` and `EvaluateGraphSymbolicValues()` after building the SymNode list and before running shape inference

This ensures that shape rules see `Constant` node values exactly as if they were real graph initializers.

https://claude.ai/code/session_01VWRirLwfqaX9Hwd63vSuSH