### PR TITLE
Fix intermittent Pyodide/wasm32 CMake Python find_package flake

### DIFF
--- a/build_wasm_pyodide.sh
+++ b/build_wasm_pyodide.sh
@@ -84,6 +84,21 @@ if [ -z "${PYODIDE_PYTHON_INCLUDE:-}" ]; then
     exit 1
 fi
 PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE:-python3}
+# Resolve to an absolute path before handing it to CMake. A bare name here
+# left CMake's own find_program() to re-resolve "python3", which -- only
+# intermittently, same toolchain/versions, fresh checkout each time -- picked
+# a DIFFERENT, wrong-architecture interpreter (e.g. the runner's native
+# /bin/python) for onnx-optimizer's generic find_package(Python ...) call
+# (see docs/wasm_pyodide.md's "Plumbing target Python headers" section),
+# failing the whole configure with "Wrong architecture for the interpreter".
+# An already-absolute, already-verified-to-exist path removes that
+# re-resolution step entirely: CMake takes it as-is.
+if command -v "$PYTHON_EXECUTABLE" >/dev/null 2>&1; then
+    PYTHON_EXECUTABLE=$(command -v "$PYTHON_EXECUTABLE")
+else
+    echo "error: PYTHON_EXECUTABLE '$PYTHON_EXECUTABLE' not found" >&2
+    exit 1
+fi
 
 # --- Host protoc: identical approach to build_wasm.sh -- reused verbatim so
 # the two scripts don't drift on how a matching host protoc is found/built.

--- a/docs/wasm_pyodide.md
+++ b/docs/wasm_pyodide.md
@@ -101,6 +101,17 @@ to the same target headers, together with:
 - `Python3_FIND_ABI`/`Python_FIND_ABI` set to `ANY;ANY;ANY;ANY`, to avoid a
   strict-ABI mismatch rejection between the host interpreter and the
   target's ABI tag.
+- `Python3_EXECUTABLE`/`Python_EXECUTABLE` must be an **absolute path**, not
+  a bare command name. A bare `python3` left CMake's own `find_program()`
+  free to re-resolve it -- which, only intermittently (same toolchain
+  versions, a fresh checkout/configure each time, no stale `CMakeCache.txt`
+  to blame), picked a different, wrong-architecture interpreter (the CI
+  runner's native `/bin/python`) for onnx-optimizer's generic
+  `find_package(Python ...)` call instead, failing the configure with
+  `Could NOT find Python ... Wrong architecture for the interpreter
+  "/bin/python"`. `build_wasm_pyodide.sh` resolves `PYTHON_EXECUTABLE` via
+  `command -v` before passing it to CMake so there is nothing left for
+  CMake to re-resolve.
 
 ### 3. nanobind 3.0.0's missing `<cstdio>` include
 


### PR DESCRIPTION
## Summary

- `build_wasm_pyodide.sh` now resolves `PYTHON_EXECUTABLE` to an absolute path (via `command -v`) before passing it to CMake as `Python3_EXECUTABLE`/`Python_EXECUTABLE`, instead of the bare `python3` name.

## Problem

The `Pyodide / wasm32-emscripten build` CI job (`.github/workflows/pyodide-wasm.yml`) has been failing intermittently with:

```
CMake Error ... Could NOT find Python (missing: Python_EXECUTABLE Interpreter) (found suitable version "3.13.2", minimum required is "3")
    Reason given by package:
        Interpreter: Wrong architecture for the interpreter "/bin/python"
...
third_party/onnx-optimizer/CMakeLists.txt:96 (find_package)
```

This is not tied to any particular commit — I confirmed it by re-running the workflow twice, back-to-back, against `master`'s unchanged head (`e416c62`) and got a green run followed moments later by the byte-identical failure above, with no code, toolchain-version, or cache changes in between.

The script only ever passed a bare `python3` as the `Python3_EXECUTABLE`/`Python_EXECUTABLE` CMake hints. That leaves CMake's own `find_program()` free to re-resolve the name itself — which, apparently non-deterministically, sometimes picks the CI runner's native `/bin/python` instead for onnx-optimizer's generic (unversioned) `find_package(Python ...)` call. `/bin/python` is a native x86_64 interpreter, which correctly fails CMake's cross-compile architecture validation for the wasm32 target — the underlying config problem is that the wrong interpreter path got resolved in the first place, this run.

## Fix

Resolve `PYTHON_EXECUTABLE` to an absolute path with `command -v` up front in `build_wasm_pyodide.sh`, so CMake takes it as-is with no re-resolution step left to be nondeterministic. Also documented in `docs/wasm_pyodide.md`'s "Plumbing target Python headers through three separate CMake hint namespaces" section, alongside the other `Python3_EXECUTABLE`/`Python_EXECUTABLE`-related pitfalls already written up there.

## Test plan

- [x] `bash -n build_wasm_pyodide.sh` (syntax check)
- [x] Verified the resolution logic standalone (`command -v python3` → absolute path)
- [ ] CI: `Pyodide / wasm32-emscripten build` should pass consistently on this branch

https://claude.ai/code/session_01VWRirLwfqaX9Hwd63vSuSH

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWRirLwfqaX9Hwd63vSuSH)_