### PR TITLE
Wire attention-head pruning into apply_optimization_pipeline

### DIFF
--- a/onnxsim/optimize_pipeline.py
+++ b/onnxsim/optimize_pipeline.py
@@ -9,10 +9,16 @@ techniques on top of a single fixed INT4 baseline.
 
 1. **Simplify** (:func:`onnxsim.simplify`) -- always, as a fusion/cleanup
    baseline every later stage builds on.
-2. **Prune** (optional, ``sparsity``) -- :func:`onnxsim.apply_structured_pruning_cpp`
-   (data-free channel pruning): shrinking the model *before* quantizing means
-   later stages spend their whole error budget on channels that survive,
-   rather than on ones that will end up zeroed anyway.
+2. **Prune** -- shrinking the model *before* quantizing means later stages
+   spend their whole error budget on weights that survive, rather than on
+   ones that will end up zeroed/removed anyway. Two independent, data-free
+   sub-stages, each optional and order-independent (they target disjoint
+   node sets -- see this module's own "C++ vs. Python" note below):
+   - (optional, ``attention_sparsity``) :func:`onnxsim.apply_attention_head_pruning_cpp`
+     -- drops whole attention heads (or, for grouped-query attention, whole
+     KV groups) from every matched fused self-attention block.
+   - (optional, ``sparsity``) :func:`onnxsim.apply_structured_pruning_cpp`
+     -- channel/filter pruning of the remaining MatMul/Gemm/Conv layers.
 3. **Cross-Layer Equalize** (:func:`onnxsim.cross_layer_equalize`) -- always;
    data-free, changes nothing but weight parameterization (see its own
    docstring), and reduces the error every later quantization stage
@@ -57,17 +63,24 @@ onnxsim quantization/pruning algorithm -- :func:`onnxsim.apply_duquant`/
 Wanda/SparseGPT-calibrated pruning are all still directly callable on their
 own, just not wired into this particular escalation.
 
-**C++ vs. Python.** The rotation (stage 4b), pruning (stage 2), and
-compression (stage 6) stages all use their C++-backed ports
-(:func:`onnxsim.apply_quarot_cpp`, :func:`onnxsim.apply_structured_pruning_cpp`,
-:func:`onnxsim.apply_double_quantization_cpp`) -- all three are at full scope
+**C++ vs. Python.** The rotation (stage 4b), both pruning sub-stages
+(stage 2), and compression (stage 6) all use their C++-backed ports
+(:func:`onnxsim.apply_quarot_cpp`, :func:`onnxsim.apply_attention_head_pruning_cpp`,
+:func:`onnxsim.apply_structured_pruning_cpp`,
+:func:`onnxsim.apply_double_quantization_cpp`) -- all four are at full scope
 parity with their pure-Python counterparts for the way this pipeline calls
 them (default ``block_size``/``epsilon``/``min_elements``/``sparsity``,
-magnitude-based channel importance rather than the calibrated Wanda
+magnitude-based channel/head importance rather than the calibrated Wanda
 variant), so the native path is strictly faster with no behavior gap. As
-with the other two, this needs revisiting if ``pruning.py``'s own
-data-free ``apply_structured_pruning`` grows a new chain topology the C++
-port (``structured_pruning_entry.cpp``) hasn't caught up to yet.
+with the others, this needs revisiting if ``pruning.py``'s own data-free
+``apply_structured_pruning``/``apply_attention_head_pruning`` grows a new
+topology the C++ ports (``structured_pruning_entry.cpp``) haven't caught up
+to yet. The two pruning sub-stages target disjoint node sets by
+construction -- :func:`onnxsim.apply_structured_pruning_cpp`'s own chain
+finders require a MatMul/Gemm/Conv *consumer*, which a fused self-attention
+op is never matched as, so it never touches the Q/K/V/output-projection
+weights :func:`onnxsim.apply_attention_head_pruning_cpp` prunes -- so
+running both, in either order, is safe.
 """
 
 from __future__ import annotations
@@ -83,6 +96,7 @@ from onnxsim.bias_correction import correct_bias
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 from onnxsim.mixed_precision import apply_mixed_precision_quantization
 from onnxsim.onnx_simplifier import (
+    apply_attention_head_pruning_cpp,
     apply_double_quantization_cpp,
     apply_quarot_cpp,
     apply_structured_pruning_cpp,
@@ -96,11 +110,12 @@ from onnxsim.onnx_simplifier import (
 class OptimizationPipelineResult:
     """One :func:`apply_optimization_pipeline` result: the optimized model
     reached, which stages were applied to reach it (in application order,
-    a prefix of ``["structured_pruning", "cross_layer_equalization",
-    "quantize_weight_only_int4" | "apply_mixed_precision_quantization" |
-    "quarot", "adaround", "bias_correction", "double_quantization"]``), its
-    measured accuracy drop against the original float model, and whether it
-    met ``accuracy_budget``.
+    a prefix of ``["attention_head_pruning", "structured_pruning",
+    "cross_layer_equalization", "quantize_weight_only_int4" |
+    "apply_mixed_precision_quantization" | "quarot", "adaround",
+    "bias_correction", "double_quantization"]``), its measured accuracy
+    drop against the original float model, and whether it met
+    ``accuracy_budget``.
     """
 
     optimized_model: onnx.ModelProto
@@ -117,6 +132,7 @@ def apply_optimization_pipeline(
     seed: int = 0,
     providers: Optional[Sequence[str]] = None,
     sparsity: Optional[float] = None,
+    attention_sparsity: Optional[float] = None,
     bit_selection: str = "uniform",
     use_rotation: bool = False,
     num_adaround_iterations: int = 300,
@@ -146,6 +162,13 @@ def apply_optimization_pipeline(
             own target fraction of output channels to remove, applied to the
             float model before quantizing; ``None`` (the default) skips
             pruning entirely
+    :param attention_sparsity: if given, :func:`onnxsim.apply_attention_head_pruning_cpp`'s
+            own target fraction of attention heads (or, for grouped-query
+            attention, whole KV groups) to remove, applied to the float
+            model before quantizing (and before ``sparsity``'s own channel
+            pruning); ``None`` (the default) skips attention-head pruning
+            entirely. Independent of ``sparsity`` -- either, both, or
+            neither may be given
     :param bit_selection: ``"uniform"`` (the default) quantizes every layer
             to :func:`onnxsim.quantize_weight_only_int4`; ``"mixed_precision"``
             instead uses :func:`onnxsim.apply_mixed_precision_quantization`
@@ -199,6 +222,11 @@ def apply_optimization_pipeline(
 
     stages: List[str] = []
     float_model = model
+    if attention_sparsity is not None:
+        float_model = apply_attention_head_pruning_cpp(
+            float_model, sparsity=attention_sparsity
+        )
+        stages.append("attention_head_pruning")
     if sparsity is not None:
         float_model = apply_structured_pruning_cpp(float_model, sparsity=sparsity)
         stages.append("structured_pruning")

--- a/tests/test_optimize_pipeline.py
+++ b/tests/test_optimize_pipeline.py
@@ -150,6 +150,80 @@ def test_pipeline_without_pruning_skips_structured_pruning_stage():
     assert "structured_pruning" not in result.stages_applied
 
 
+def _attention_pipeline_model(K=8, H=4, D=4, Out=6, seed=0):
+    # A single fused com.microsoft::Attention block (merged QKV weight)
+    # feeding a plain MatMul output projection -- attention_sparsity's own
+    # target topology, distinct from _conv_and_gemm_model/_gemm_model's
+    # plain MatMul/Conv chains that ``sparsity`` targets.
+    rng = np.random.default_rng(seed)
+    nq = nk = nv = H * D
+    wqkv = rng.standard_normal((K, nq + nk + nv)).astype(np.float32) * 0.5
+    bqkv = rng.standard_normal((nq + nk + nv,)).astype(np.float32) * 0.1
+    wout = rng.standard_normal((nv, Out)).astype(np.float32) * 0.5
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17, "com.microsoft": 1]
+        >
+        g (float[batch,seq,{K}] X) => (float[batch,seq,{Out}] Y)
+        {{
+          ctx = com.microsoft.Attention <num_heads={H}, qkv_hidden_sizes=[{nq},{nk},{nv}]> (X, Wqkv, Bqkv)
+          Y = MatMul(ctx, Wout)
+        }}
+        """
+    )
+    model.graph.initializer.extend(
+        [_f32(wqkv, "Wqkv"), _f32(bqkv, "Bqkv"), _f32(wout, "Wout")]
+    )
+    return model
+
+
+def test_pipeline_with_attention_sparsity_applies_attention_head_pruning_stage():
+    model = _attention_pipeline_model(seed=24)
+    rng = np.random.default_rng(25)
+    calibration_data = [{"X": rng.standard_normal((2, 5, 8)).astype(np.float32)}]
+
+    result = onnxsim.apply_optimization_pipeline(
+        model,
+        accuracy_budget=1.0,
+        calibration_data=calibration_data,
+        attention_sparsity=0.5,
+    )
+    assert result.stages_applied[0] == "attention_head_pruning"
+    onnx.checker.check_model(result.optimized_model)
+
+
+def test_pipeline_without_attention_sparsity_skips_attention_head_pruning_stage():
+    model = _attention_pipeline_model(seed=26)
+    rng = np.random.default_rng(27)
+    calibration_data = [{"X": rng.standard_normal((2, 5, 8)).astype(np.float32)}]
+
+    result = onnxsim.apply_optimization_pipeline(
+        model, accuracy_budget=1.0, calibration_data=calibration_data
+    )
+    assert "attention_head_pruning" not in result.stages_applied
+
+
+def test_pipeline_applies_both_pruning_sub_stages_independently():
+    model = _attention_pipeline_model(seed=28)
+    rng = np.random.default_rng(29)
+    calibration_data = [{"X": rng.standard_normal((2, 5, 8)).astype(np.float32)}]
+
+    result = onnxsim.apply_optimization_pipeline(
+        model,
+        accuracy_budget=1.0,
+        calibration_data=calibration_data,
+        attention_sparsity=0.5,
+        sparsity=0.25,
+    )
+    assert result.stages_applied[:2] == [
+        "attention_head_pruning",
+        "structured_pruning",
+    ]
+    onnx.checker.check_model(result.optimized_model)
+
+
 def test_pipeline_mixed_precision_bit_selection():
     model = _gemm_model(seed=15)
     rng = np.random.default_rng(16)


### PR DESCRIPTION
## Summary

Follow-up to #919 (the C++ structured-pruning port reaching full parity):
`apply_optimization_pipeline` (`onnxsim/optimize_pipeline.py`) had a
`sparsity` parameter for channel/filter pruning
(`apply_structured_pruning_cpp`) but nothing wired up for
`apply_attention_head_pruning_cpp`, even though both are data-free,
C++-backed, and already at scope parity with their Python references.

- Adds a new optional `attention_sparsity` parameter, applied as its own
  stage (`"attention_head_pruning"`) before the existing `sparsity`-gated
  `"structured_pruning"` stage.
- The two pruning sub-stages are safe to run in either order: `apply_structured_pruning_cpp`'s
  own chain finders require a MatMul/Gemm/Conv *consumer*, which a fused
  self-attention op (`com.microsoft::Attention`/`GroupQueryAttention`/plain
  `ai.onnx::Attention`) is never matched as, so it never touches the
  Q/K/V/output-projection weights `apply_attention_head_pruning_cpp` prunes
  — documented explicitly in the module's own docstring.
- `attention_sparsity` and `sparsity` are independent: either, both, or
  neither may be given.

## Test plan

- [x] New tests in `tests/test_optimize_pipeline.py`: attention pruning
      stage applied when `attention_sparsity` is given, skipped when
      omitted, and both pruning sub-stages applied (in order) when both
      parameters are given.
- [x] `pytest tests/test_optimize_pipeline.py` — 12 passed
- [x] Full `pytest tests/` (minus pre-existing torch/timm-gated files
      unrelated to this change) — 1019 passed, 87 skipped
- [x] `ruff check` / `ruff format --check` clean

---

https://claude.ai/code/session_01FAiv55epkSMz7NPXD4r97u


---
_Generated by [Claude Code](https://claude.ai/code/session_01FAiv55epkSMz7NPXD4r97u)_