### PR TITLE
Scale the Core ML LLM export pipeline to few-billion-parameter models

### DIFF
--- a/onnxsim/coreml_export.py
+++ b/onnxsim/coreml_export.py
@@ -392,10 +392,13 @@ def _op_expand(lowerer, node, ins, attrs):
         x = lowerer.mb.cast(
             x=x, dtype="int32", name=lowerer.fresh_name(node, "boolcast")
         )
-    # `fill`'s output dtype follows its `value`'s Python type (int -> an integer
-    # MIL type, float -> a float one); match `x`'s (post-bool-cast) dtype so the
-    # `add` below doesn't reject the two operands as mismatched types.
-    fill_value = 0 if x.dtype == lowerer.types.int32 else 0.0
+    # `fill`'s output dtype follows its `value`'s Python type (`int` always
+    # becomes MIL's int32, a bare `float` always becomes fp32 regardless of
+    # context); match `x`'s (post-bool-cast) dtype explicitly via a numpy
+    # scalar so the `add` below doesn't reject the two operands as mismatched
+    # types -- e.g. an fp16 model's `x` next to fp32 `zeros`.
+    np_dtype = lowerer.types.nptype_from_builtin(x.dtype)
+    fill_value = np_dtype(0)
     zeros = lowerer.mb.fill(
         shape=shape_var, value=fill_value, name=lowerer.fresh_name(node, "zeros")
     )
@@ -409,7 +412,8 @@ def _op_expand(lowerer, node, ins, attrs):
 
 @_register("Neg")
 def _op_neg(lowerer, node, ins, attrs):
-    return [lowerer.mb.mul(x=ins[0], y=np.float32(-1.0), name=lowerer.fresh_name(node))]
+    np_dtype = lowerer.types.nptype_from_builtin(ins[0].dtype)
+    return [lowerer.mb.mul(x=ins[0], y=np_dtype(-1.0), name=lowerer.fresh_name(node))]
 
 
 @_register("LeakyRelu")
@@ -486,17 +490,18 @@ def _op_gemm(lowerer, node, ins, attrs):
         name=lowerer.fresh_name(node, "matmul"),
     )
     if alpha != 1.0:
+        np_dtype = lowerer.types.nptype_from_builtin(y.dtype)
         y = lowerer.mb.mul(
-            x=y, y=np.float32(alpha), name=lowerer.fresh_name(node, "alpha")
+            x=y, y=np_dtype(alpha), name=lowerer.fresh_name(node, "alpha")
         )
     if c is not None:
-        term = (
-            c
-            if beta == 1.0
-            else lowerer.mb.mul(
-                x=c, y=np.float32(beta), name=lowerer.fresh_name(node, "beta")
+        if beta == 1.0:
+            term = c
+        else:
+            np_dtype = lowerer.types.nptype_from_builtin(c.dtype)
+            term = lowerer.mb.mul(
+                x=c, y=np_dtype(beta), name=lowerer.fresh_name(node, "beta")
             )
-        )
         y = lowerer.mb.add(x=y, y=term, name=lowerer.fresh_name(node))
     return [y]
 
@@ -1042,8 +1047,12 @@ def _op_constant_of_shape(lowerer, node, ins, attrs):
     if shape_var.val is None:
         # The target shape is only known at runtime (e.g. derived from a KV
         # cache's dynamic length) -- MIL's `fill` op takes a non-constant shape,
-        # unlike materializing a numpy array here.
-        fill_val = _as_mil_array(np.array(fill_val, dtype=dtype)).item()
+        # unlike materializing a numpy array here. Keep `fill_val` as a numpy
+        # scalar (not a bare Python `int`/`float` via `.item()`): MIL infers a
+        # bare Python float as fp32 regardless of `dtype` here, which would
+        # produce e.g. an fp32 fill for an fp16 model.
+        mil_arr = _as_mil_array(np.array(fill_val, dtype=dtype))
+        fill_val = mil_arr.dtype.type(mil_arr.reshape(-1)[0])
         return [
             lowerer.mb.fill(
                 shape=shape_var, value=fill_val, name=lowerer.fresh_name(node)

--- a/scripts/apple/README.md
+++ b/scripts/apple/README.md
@@ -109,6 +109,37 @@ methodology.
   the rest of this directory, it only *runs* a model on macOS (that's where
   Core ML's runtime lives); the export step itself needs no Apple hardware.
 
+### Scaling to few-billion-parameter models
+
+DeviceMark's own leaderboard mostly tests models in the 1-4B range, well
+past `HuggingFaceTB/SmolLM2-135M-Instruct`'s 135M. The export pipeline above
+has also been validated end-to-end against `HuggingFaceTB/SmolLM2-1.7B-Instruct`
+(24 layers, ~3.4GB of fp16 weights) -- converting a model at that scale
+needs a couple of extra considerations `export_llm_to_coreml.py` handles for
+you, and one flag worth knowing about:
+
+- `--dtype fp16` traces and exports the ONNX graph in half precision
+  instead of the default float32. Tracing a multi-billion-parameter model in
+  float32 can transiently hold more than one full-size copy of its weights
+  in memory (PyTorch's own model plus the in-progress ONNX graph); `fp16`
+  roughly halves that peak. This is independent of Core ML's own output
+  precision, which defaults to float16 regardless of the ONNX input's dtype.
+- The batch-size fix-up and `onnxsim.simplify` step both operate on the
+  model **by file path**, not as an in-memory `ModelProto` -- passing a
+  `ModelProto` to either serializes the whole model to one protobuf message
+  first, which protobuf itself caps at 2GiB (comfortably cleared by a
+  multi-billion-parameter model's weights). Passing a path instead uses
+  onnx's/onnxsim's own file-based C++ entry points, which need only about
+  1x the model's size in peak memory rather than 2x+ (see
+  `bench/RESULTS_synthetic_decoder_oom.md` in the repo root for the
+  investigation that fixed the `onnxsim.simplify` side of this).
+- `main_export(..., do_validation=False)` skips `optimum`'s own
+  PyTorch-vs-ONNX-Runtime comparison pass, which otherwise keeps a second
+  full copy of the model resident purely to check optimum's own export --
+  a check this pipeline doesn't rely on (onnxsim's `onnx.checker.check_model`
+  and the Core ML conversion actually succeeding are the checks that matter
+  here).
+
 ```bash
 pip install "optimum-onnx" transformers coremltools
 python export_llm_to_coreml.py HuggingFaceTB/SmolLM2-135M-Instruct \

--- a/scripts/apple/export_llm_to_coreml.py
+++ b/scripts/apple/export_llm_to_coreml.py
@@ -54,7 +54,6 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import gc
 import shutil
 import sys
 import tempfile
@@ -116,30 +115,45 @@ def export_llm_to_coreml(
         )
 
         onnx_path = Path(tmpdir) / "model.onnx"
-        model = onnx.load(str(onnx_path))
 
         print(
             "Pinning batch_size=1 (sequence_length/past_sequence_length stay dynamic)...",
             flush=True,
         )
-        _fix_batch_size(model, batch_size=1)
-        onnx.checker.check_model(model)
+        # `_fix_batch_size` only touches declared shape dim fields, never tensor
+        # data, so this whole step never needs the model's weights loaded into
+        # memory -- `load_external_data=False` leaves each initializer as just its
+        # on-disk location, and re-saving keeps those references intact (same
+        # directory, untouched external-data files).
+        fixed_model = onnx.load(str(onnx_path), load_external_data=False)
+        _fix_batch_size(fixed_model, batch_size=1)
+        onnx.save(fixed_model, str(onnx_path))
+        num_nodes_before = len(fixed_model.graph.node)
+        del fixed_model
+
+        # A path-based check (unlike passing a ModelProto) uses onnx's C++
+        # file checker directly, with no in-memory protobuf-serialization size
+        # limit to trip over on a multi-billion-parameter model.
+        onnx.checker.check_model(str(onnx_path))
 
         print("Simplifying with onnxsim...", flush=True)
         import onnxsim
 
-        simplified, ok = onnxsim.simplify(model)
+        simplified_path = Path(tmpdir) / "model_simplified.onnx"
+        # Passing a *path* (not a ModelProto) with check_n=0 engages onnxsim's
+        # C++ path-to-path fast route, which needs only ~1x the model's size in
+        # peak memory (see bench/RESULTS_synthetic_decoder_oom.md) instead of the
+        # 2+x an in-memory ModelProto round trip costs.
+        _, ok = onnxsim.simplify(
+            str(onnx_path), output_path=str(simplified_path), check_n=0
+        )
         if not ok:
             raise RuntimeError("onnxsim.simplify() reported failure")
-        print(
-            f"  {len(model.graph.node)} -> {len(simplified.graph.node)} nodes",
-            flush=True,
-        )
-        # `model` is a full second copy of every weight and is no longer needed --
-        # drop it before Core ML conversion builds a third (a multi-billion-parameter
-        # model can't afford three copies resident at once).
-        del model
-        gc.collect()
+
+        # Only now load real tensor values: Core ML conversion needs them (MIL
+        # constants), everything before this point only needed shapes.
+        simplified = onnx.load(str(simplified_path))
+        print(f"  {num_nodes_before} -> {len(simplified.graph.node)} nodes", flush=True)
 
         print(f"Converting to Core ML ({convert_to}), dynamic KV cache...", flush=True)
         onnxsim.export_coreml(

--- a/scripts/apple/export_llm_to_coreml.py
+++ b/scripts/apple/export_llm_to_coreml.py
@@ -38,6 +38,14 @@ Pipeline: `optimum.exporters.onnx` (decoder-with-past, dynamic axes) -> pin
 `batch_size` to 1 -> `onnxsim.simplify` -> `onnxsim.export_coreml` with
 `dynamic_shapes` for `sequence_length` / `past_sequence_length` / their sum.
 
+`--dtype` (default `fp32`) controls the precision the ONNX graph itself is
+traced and computed in -- separate from Core ML's own output precision,
+which defaults to float16 regardless (coremltools' `compute_precision`).
+For a multi-billion-parameter model, tracing in float32 means PyTorch and
+the in-progress ONNX graph can hold more than one full-size copy of the
+model's weights at once (well over the model's own on-disk size); `--dtype
+fp16` roughly halves that peak.
+
 Usage:
     python export_llm_to_coreml.py HuggingFaceTB/SmolLM2-135M-Instruct \\
         --max-context-length 512 --output smollm2.mlpackage
@@ -77,13 +85,14 @@ def export_llm_to_coreml(
     max_context_length: int = 512,
     opset: int = 17,
     convert_to: str = "mlprogram",
+    dtype: str = "fp32",
 ) -> None:
     from optimum.exporters.onnx import main_export
 
     with tempfile.TemporaryDirectory(prefix="onnxsim_llm_export_") as tmpdir:
         print(
             f"Exporting {model_id!r} to ONNX (decoder-with-past, dynamic shapes, "
-            f"opset {opset})...",
+            f"opset {opset}, dtype {dtype})...",
             flush=True,
         )
         main_export(
@@ -103,6 +112,7 @@ def export_llm_to_coreml(
             # call below and the Core ML conversion that follows are the
             # correctness checks this pipeline actually relies on.
             do_validation=False,
+            dtype=dtype,
         )
 
         onnx_path = Path(tmpdir) / "model.onnx"
@@ -186,6 +196,14 @@ def main() -> int:
         default="mlprogram",
         dest="convert_to",
     )
+    ap.add_argument(
+        "--dtype",
+        choices=["fp32", "fp16", "bf16"],
+        default="fp32",
+        help="Precision to trace and export the ONNX graph in (default: fp32). Use "
+        "fp16 for multi-billion-parameter models where tracing in float32 risks "
+        "running out of memory (see the module docstring).",
+    )
     args = ap.parse_args()
 
     export_llm_to_coreml(
@@ -194,6 +212,7 @@ def main() -> int:
         max_context_length=args.max_context_length,
         opset=args.opset,
         convert_to=args.convert_to,
+        dtype=args.dtype,
     )
     return 0
 

--- a/scripts/apple/export_llm_to_coreml.py
+++ b/scripts/apple/export_llm_to_coreml.py
@@ -46,6 +46,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import gc
 import shutil
 import sys
 import tempfile
@@ -95,6 +96,13 @@ def export_llm_to_coreml(
             # sequence_length/past_sequence_length dynamic regardless (see the
             # module docstring for why 2, not 1).
             sequence_length=2,
+            # optimum's own PyTorch-vs-ONNX-Runtime validation pass keeps both a
+            # full copy of the model and an onnxruntime session resident at once,
+            # roughly doubling peak memory during export -- prohibitive for a
+            # multi-billion-parameter model. onnxsim's own onnx.checker.check_model
+            # call below and the Core ML conversion that follows are the
+            # correctness checks this pipeline actually relies on.
+            do_validation=False,
         )
 
         onnx_path = Path(tmpdir) / "model.onnx"
@@ -117,6 +125,11 @@ def export_llm_to_coreml(
             f"  {len(model.graph.node)} -> {len(simplified.graph.node)} nodes",
             flush=True,
         )
+        # `model` is a full second copy of every weight and is no longer needed --
+        # drop it before Core ML conversion builds a third (a multi-billion-parameter
+        # model can't afford three copies resident at once).
+        del model
+        gc.collect()
 
         print(f"Converting to Core ML ({convert_to}), dynamic KV cache...", flush=True)
         onnxsim.export_coreml(

--- a/tests/test_coreml_export.py
+++ b/tests/test_coreml_export.py
@@ -219,6 +219,42 @@ def test_gemm_alpha_beta_transb_matches_onnxruntime():
     np.testing.assert_allclose(_mil_const_value(model), expected, rtol=1e-5, atol=1e-5)
 
 
+def test_gemm_alpha_beta_fp16_matches_expected():
+    # Regression test: the alpha/beta scale factors used to be created as a bare
+    # Python float, which MIL infers as fp32 regardless of context -- multiplying
+    # it against an fp16 operand raised a dtype-mismatch error (found while
+    # converting an fp16-exported multi-billion-parameter LLM).
+    rng = np.random.RandomState(0)
+    a = rng.randn(3, 4).astype(np.float16)
+    b = rng.randn(5, 4).astype(np.float16)
+    c = rng.randn(5).astype(np.float16)
+    inits = [
+        numpy_helper.from_array(a, name="a"),
+        numpy_helper.from_array(b, name="b"),
+        numpy_helper.from_array(c, name="c"),
+    ]
+    model = _model(
+        "gemm () => (float16[3,5] out) "
+        "{ out = Gemm <alpha=0.5, beta=2.0, transB=1> (a, b, c) }",
+        initializer=inits,
+    )
+    expected = 0.5 * (a.astype(np.float32) @ b.astype(np.float32).T) + 2.0 * c.astype(
+        np.float32
+    )
+    np.testing.assert_allclose(_mil_const_value(model), expected, rtol=1e-2, atol=1e-2)
+
+
+def test_neg_fp16_matches_expected():
+    # Same class of bug as the Gemm fp16 case above, in Neg's `mul(x, -1)`
+    # lowering.
+    x = np.array([1.5, -2.0, 0.0], dtype=np.float16)
+    model = _model(
+        "neg () => (float16[3] y) { y = Neg (x) }",
+        initializer=[numpy_helper.from_array(x, name="x")],
+    )
+    np.testing.assert_array_equal(_mil_const_value(model), -x.astype(np.float32))
+
+
 def test_pad_reflect_matches_onnxruntime():
     x = np.arange(12, dtype=np.float32).reshape(1, 1, 3, 4)
     pads = np.array([0, 0, 1, 1, 0, 0, 1, 1], np.int64)
@@ -444,6 +480,49 @@ def test_dynamic_shapes_expand_to_runtime_shape():
         }
         """,
     )
+    onnx.checker.check_model(model)
+    mlmodel = onnxsim.export_coreml(model, dynamic_shapes={"N": (1, 2, 8)})
+    (out_desc,) = mlmodel.get_spec().description.output
+    assert out_desc.name == "y"
+
+
+def test_dynamic_shapes_expand_fp16_to_runtime_shape():
+    # Same scenario as test_dynamic_shapes_expand_to_runtime_shape, but fp16:
+    # the fallback's `fill`+`add` used to hardcode an fp32 zero regardless of
+    # `x`'s actual dtype, so this raised a dtype-mismatch error against fp16.
+    model = _model(
+        """
+        expand_dyn (float16[N,4] x) => (float16[N,4] y)
+        {
+            shp = Shape (x)
+            one = Constant <value_float = 1.0> ()
+            one16 = Cast <to = 10> (one)
+            y = Expand (one16, shp)
+        }
+        """,
+    )
+    onnx.checker.check_model(model)
+    mlmodel = onnxsim.export_coreml(model, dynamic_shapes={"N": (1, 2, 8)})
+    (out_desc,) = mlmodel.get_spec().description.output
+    assert out_desc.name == "y"
+
+
+def test_constant_of_shape_dynamic_fp16():
+    # Same class of bug as the Expand case above, in ConstantOfShape's dynamic
+    # `fill` fallback: extracting the fill value via numpy's `.item()` silently
+    # discarded its fp16 dtype, so `fill` produced an fp32 tensor instead. The
+    # text-format parser has no syntax for a node's tensor-valued attribute, so
+    # this one is built with onnx.helper (see CLAUDE.md's note on that exception).
+    x = onnx.helper.make_tensor_value_info("x", onnx.TensorProto.FLOAT16, ["N", 4])
+    y = onnx.helper.make_tensor_value_info("y", onnx.TensorProto.FLOAT16, ["N", 4])
+    shape_node = onnx.helper.make_node("Shape", ["x"], ["shp"])
+    value = numpy_helper.from_array(np.array([2.0], dtype=np.float16))
+    cos_node = onnx.helper.make_node("ConstantOfShape", ["shp"], ["y"], value=value)
+    graph = onnx.helper.make_graph([shape_node, cos_node], "g", [x], [y])
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 17)]
+    )
+    model.ir_version = 8
     onnx.checker.check_model(model)
     mlmodel = onnxsim.export_coreml(model, dynamic_shapes={"N": (1, 2, 8)})
     (out_desc,) = mlmodel.get_spec().description.output


### PR DESCRIPTION
## Summary

Follow-up to #917: validates and fixes `scripts/apple/export_llm_to_coreml.py`'s pipeline against a model at the scale DeviceMark's leaderboard actually benchmarks (1-4B params), not just the 135M prototype. Found and fixed three independent problems while converting `HuggingFaceTB/SmolLM2-1.7B-Instruct` (24 layers, ~3.4GB fp16), all reproducible on the small 135M model with the right inputs (see the added regression tests).

## Key changes

**`scripts/apple/export_llm_to_coreml.py`**
- Added `--dtype {fp32,fp16,bf16}` (default `fp32`, unchanged for existing users): tracing/exporting a multi-billion-parameter model in float32 can transiently hold more than one full-size copy of its weights (PyTorch's model + the in-progress ONNX graph), which OOM-killed at ~14GB in this environment's 15GB budget. `fp16` roughly halves that peak.
- `main_export(..., do_validation=False)`: skips `optimum`'s own PyTorch-vs-ONNX-Runtime comparison pass, which otherwise keeps a second full model copy resident just to check optimum's own export -- not a check this pipeline relies on.
- Reworked the batch-size fix-up and `onnxsim.simplify` call to stay **path-based** instead of passing an in-memory `ModelProto`: both `onnx.checker.check_model(<ModelProto>)` and `onnxsim.simplify(<ModelProto>)` serialize the whole model to one protobuf message first, which protobuf itself caps at 2GiB -- comfortably cleared by a multi-billion-parameter model. Passing a file path instead engages onnx's/onnxsim's own file-based C++ entry points (`check_model_path`, `SimplifyPath`), which per `bench/RESULTS_synthetic_decoder_oom.md` need only ~1x model size in peak memory rather than 2x+.

**`onnxsim/coreml_export.py`**
- Fixed dtype-mismatch bugs in `Neg`, `Gemm`'s alpha/beta scaling, and the dynamic-shape fallbacks of `Expand`/`ConstantOfShape`: each created a scalar MIL constant as a bare Python float (or via `.item()`, which discards a numpy array's dtype), and MIL infers a bare Python float as fp32 regardless of context -- multiplying/adding that against an fp16 tensor operand raised a hard dtype-mismatch error. Fixed by deriving the constant's numpy dtype from the actual operand's MIL dtype (`types.nptype_from_builtin`).

**`tests/test_coreml_export.py`**
- Added regression tests for all four dtype fixes above (`test_gemm_alpha_beta_fp16_matches_expected`, `test_neg_fp16_matches_expected`, `test_dynamic_shapes_expand_fp16_to_runtime_shape`, `test_constant_of_shape_dynamic_fp16`).

**`scripts/apple/README.md`**
- Documents the few-billion-parameter validation and the considerations above.

## Test plan

- [x] `tests/test_coreml_export.py` / `tests/test_mlir_export.py`: 25 passed, 1 skipped
- [x] `ruff format` / `ruff check`: clean
- [x] End-to-end: `HuggingFaceTB/SmolLM2-135M-Instruct` (fp32, unchanged path) still converts and round-trips through the rewritten pipeline identically to before
- [x] End-to-end: `HuggingFaceTB/SmolLM2-1.7B-Instruct` (`--dtype fp16`, 24 layers, ~3.4GB output `.mlpackage`) converts successfully -- 51 inputs / 49 outputs, correct flexible KV-cache shape ranges
- [ ] Actual on-device decode tok/s for a model at this scale still needs Core ML's runtime (macOS only) -- not measured in this environment; the macOS `coreml-integration` CI job's small-model "Convert + predict" check covers what it always has

https://claude.ai/code/session_01T3MD7VAmysceuqiBQYHvWQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3MD7VAmysceuqiBQYHvWQ)_