### PR TITLE
Admit block-aligned grouped Conv consumers for Concat-merged structured pruning

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -260,6 +260,36 @@ is declined outright rather than guessed at -- see
 :func:`_find_matmul_concat_chains`/:func:`_find_conv_concat_chains`'s own
 section comment for exactly why that line is where it's drawn.
 
+The shared downstream consumer of a Conv `Concat` merge may itself be a
+general grouped (`group != 1`) Conv -- but only when every branch's own
+fixed offset lands exactly on one of the consumer's own `group` block
+boundaries (`block = n_channels / group`), so every block the consumer's
+own per-block top-k needs a uniform survivor count from is owned by exactly
+one branch, never split across two. This is *not* simply inherited from the
+ordinary grouped-producer/grouped-consumer composition above: there, every
+producer's own output already sits in one *shared* index space the
+consumer's blocks partition, all pruned to one shared `keep` set, so one
+global block size settles every block at once. A `Concat` branch, by
+contrast, is pruned *independently*, by its own top-k over its own slice,
+with no visibility into any sibling branch's ranking -- the entire reason
+`Concat` support exists in the first place (see above). When branch
+boundaries are block-aligned, that independence is harmless: each block
+falls wholly inside one branch, which alone can satisfy that block's own
+uniform-count requirement (an internal per-block top-k of its own, mirroring
+:func:`_apply_chains`'s mechanism, just scoped to the blocks it contains).
+When a block instead straddles two branches, satisfying it needs the counts
+each branch independently contributes to that one shared block to sum to
+exactly the required `per_group_keep` -- which two rankings computed with no
+knowledge of each other have no general way to guarantee, and reconciling it
+would need exactly the cross-branch agreement `Concat` support exists to
+avoid. So that case is declined outright, the whole chain, the same
+conservative way as everywhere else in this module -- see
+:func:`_concat_branches_align_to_consumer_group`'s own docstring for the
+exact admission condition, the full argument, and a concrete counter-example
+of the straddling case. (MatMul/Gemm has no grouping concept at all, so this
+paragraph is Conv-only; a MatMul/Gemm `Concat` chain's consumer is always
+ordinary.)
+
 General multi-branch dependency-graph pruning remains out of scope --
 a non-`Add`/`SkipLayerNormalization`/`Concat` merge op, and fan-out
 anywhere *except* forward from an already-established residual/merge
@@ -4767,11 +4797,21 @@ def _find_gated_chains(graph: onnx.GraphProto) -> List[_Chain]:
 # `Concat` node itself never needs its own attributes changed (its output
 # shape is simply whatever its inputs' shapes are, so pruning each branch's
 # own producer already gives it the right, smaller input on its own). A
-# grouped (`group != 1`) Conv consumer is declined the same way
-# :func:`_find_conv_residual_chains` declines one: its per-group top-k
-# assumes every producer feeds the consumer's full channel range, which a
-# multi-branch group of independently-sized, independently-pruned branches
-# doesn't establish.
+# grouped (`group != 1`) Conv consumer (Conv chains only -- MatMul/Gemm has
+# no grouping concept) is admitted, but only when every branch's own fixed
+# offset lands exactly on one of the consumer's own `group` block
+# boundaries (:func:`_concat_branches_align_to_consumer_group`) -- unlike
+# the ordinary grouped-producer/grouped-consumer composition
+# (:func:`_find_conv_chains`), where every producer already shares one
+# combined `keep` set with the consumer's own block partition, a `Concat`
+# branch is pruned *independently* with no visibility into any sibling
+# branch's ranking, so a block owned by more than one branch has no general
+# way to land on that block's own required uniform survivor count without
+# reintroducing exactly the cross-branch agreement `Concat` support exists
+# to avoid -- that case (and only that case) is still declined outright, the
+# same way :func:`_find_conv_residual_chains` declines every grouped
+# consumer. See :func:`_concat_branches_align_to_consumer_group`'s own
+# docstring for the full safety argument and a concrete counter-example.
 
 
 def _concat_axis(node: onnx.NodeProto) -> Optional[int]:
@@ -4931,6 +4971,18 @@ class _ConcatChain:
     # Depthwise Conv hops crossed between the `Concat` node and the real
     # consumer (Conv chains only; see :class:`_ConvPassThrough`).
     conv_pass_through: Tuple[_ConvPassThrough, ...] = ()
+    # 1 for an ordinary consumer (always, for a MatMul/Gemm chain -- MatMul/
+    # Gemm has no grouping concept at all) or a Conv consumer this module
+    # declines to admit as grouped; > 1 for a general grouped Conv consumer
+    # admitted per :func:`_concat_branches_align_to_consumer_group` -- see
+    # that function's own docstring and this section's own comment for
+    # exactly which grouped consumers are safe to admit and why. Mirrors
+    # :class:`_Chain`'s own `consumer_group` field/:func:`_chain_group`, but
+    # unlike that field this one is *not* found by inspecting `producers`
+    # first: a `Concat` branch's own producer is never itself grouped (see
+    # this section's own comment), so the consumer's `group` is always the
+    # one that governs here.
+    consumer_group: int = 1
 
 
 def _branch_walk_has_fanout(
@@ -5409,6 +5461,79 @@ def _find_matmul_concat_chains(graph: onnx.GraphProto) -> List[_ConcatChain]:
     return chains
 
 
+def _concat_branches_align_to_consumer_group(
+    branches: Sequence[_ConcatBranch], n_channels: int, group: int
+) -> bool:
+    """True if a grouped (``group > 1``) Conv consumer's own `group`
+    equal-sized input-channel blocks (``block = n_channels // group``, the
+    same partition :func:`_slice_grouped_consumer_conv_weight` slices
+    against) line up exactly with this `Concat` merge's own branch
+    boundaries -- every branch's fixed `offset` a multiple of `block` -- so
+    that every one of the consumer's `group` blocks is owned by exactly one
+    branch, never split across two. Always ``True`` for ``group <= 1`` (an
+    ordinary consumer has no block partition to line up with at all).
+
+    This is precisely the boundary this composition is safe at, and no
+    wider -- the same block-partition argument :func:`_chain_group`'s own
+    docstring works through for a single grouped producer/consumer, but
+    *not* simply inherited from it, because a `Concat` branch's own pruning
+    is structurally different from that chain's: an ordinary chain's
+    producer(s) are all pruned to one *shared* `keep` set (the entire
+    reason :func:`_chain_group`'s single global `block` size works there --
+    every producer's own output is literally the same index space the
+    consumer's blocks partition), whereas a `Concat` branch is pruned
+    *independently*, by its own top-k over its own disjoint slice, with no
+    visibility into any other branch's ranking or how many channels it
+    plans to keep -- the entire reason `Concat` support exists in the first
+    place (see this module's own docstring and this section's own comment).
+    When every branch boundary is block-aligned, each of the consumer's
+    `group` blocks falls entirely within one branch's own slice, so that
+    branch alone can satisfy the block's own uniform-survivor-count
+    requirement: it simply treats each of its own ``own_width // block``
+    contained blocks exactly the way a single grouped producer already
+    treats its own `group` blocks in :func:`_apply_chains` (an independent
+    per-block top-k, keeping `per_group_keep` channels from each -- the
+    *same* count every other block anywhere in this merge keeps, since
+    `per_group_keep` is computed once from `block` and `sparsity`, and
+    `block` itself depends only on the consumer's own `group` and the
+    merge's total `n_channels`, never on which branch a channel happens to
+    fall in). No cross-branch agreement is ever needed, because no block
+    ever has more than one branch to agree between.
+
+    When a block instead straddles two (or more) branches -- some branch's
+    own boundary falls in the interior of a block rather than at its edge --
+    satisfying that block's own uniform-count requirement needs the counts
+    each of those branches independently contributes *from that one shared
+    block* to sum to exactly `per_group_keep`. A branch's own top-k, ranked
+    with no knowledge of any sibling branch's importance or how many
+    channels that sibling plans to keep, has no general way to land on a
+    matching split; reconciling it would need exactly the cross-branch
+    importance comparison `Concat` support was built to avoid -- silently
+    reintroducing the "must all agree" coupling an `Add`/
+    `SkipLayerNormalization` merge has, and a `Concat` merge deliberately
+    doesn't. Concrete counter-example: ``block=4``, ``per_group_keep=2``,
+    branch `a` owns local columns ``[0, 3)`` of that block (3 channels) and
+    branch `b` owns column ``[3, 4)`` (1 channel) -- if `a`'s own top-3
+    ranking keeps all 3 of its channels (a legitimate outcome of *its own*
+    sparsity target) and `b` keeps its 1, the block ends up with 4
+    survivors, not 2; if `a` keeps only 1 and `b` keeps its 1, the block
+    ends up with 2 survivors but there was no shared signal that told `a`
+    to cut down to 1 rather than the 2 or 3 its own ranking alone would
+    justify. Either way, `a` and `b`'s independent decisions can't be made
+    to reliably land on the one *any* correct grouped-Conv consumer needs
+    without deciding, from *outside* either branch's own ranking, how the
+    budget for that one shared block is split between them -- so this case
+    is declined outright, the same conservative way as everywhere else in
+    this module, whenever any block spans more than one branch (checked by
+    :func:`_find_conv_concat_chains` before a chain with `group > 1` is ever
+    produced).
+    """
+    if group <= 1:
+        return True
+    block = n_channels // group
+    return all(b.offset % block == 0 for b in branches)
+
+
 def _find_conv_concat_chains(graph: onnx.GraphProto) -> List[_ConcatChain]:
     """The Conv analogue of :func:`_find_matmul_concat_chains`: every operand
     of a channel-axis `Concat` (`axis in (1, -3)` -- the channel axis of a
@@ -5423,8 +5548,14 @@ def _find_conv_concat_chains(graph: onnx.GraphProto) -> List[_ConcatChain]:
     :func:`_find_matmul_concat_chains`'s own section comment for exactly
     what composing that requires and what it declines, identical reasoning
     on the Conv side) -- `"fail"` is declined outright either way. The
-    consumer must itself be an ordinary (`group=1`) Conv -- see this
-    section's own comment for why a grouped consumer is declined here.
+    consumer may be an ordinary (`group=1`) Conv, or a general grouped
+    (`group > 1`) Conv whose own block boundaries line up exactly with
+    every branch's own fixed offset -- see
+    :func:`_concat_branches_align_to_consumer_group`'s own docstring for
+    the exact admission condition and the safety argument (and the
+    concrete counter-example) for why a *misaligned* grouped consumer is
+    still declined, the same conservative way a residual/merge group
+    declines one outright regardless of alignment.
     """
     initializer_map = {t.name: t for t in graph.initializer}
     consumers_of = _consumers_of(graph)
@@ -5545,8 +5676,10 @@ def _find_conv_concat_chains(graph: onnx.GraphProto) -> List[_ConcatChain]:
         if consumer is None:
             continue
         consumer_node, consumer_weight, consumer_group = consumer
-        if consumer_group != 1:
-            continue  # see this section's own comment -- grouped consumer declined
+        if not _concat_branches_align_to_consumer_group(
+            branches, total_n, consumer_group
+        ):
+            continue  # see _concat_branches_align_to_consumer_group's own docstring
 
         chains.append(
             _ConcatChain(
@@ -5559,6 +5692,7 @@ def _find_conv_concat_chains(graph: onnx.GraphProto) -> List[_ConcatChain]:
                 consumer_is_conv=True,
                 n_channels=total_n,
                 conv_pass_through=fwd_pass_through,
+                consumer_group=consumer_group,
             )
         )
     return chains
@@ -5623,6 +5757,27 @@ def _apply_concat_chains(
     the two can never doubly resize the same weight; the caller flushes
     ``value_info`` once, from `touched.stale_value_info`, after every such
     call.
+
+    When `chain.consumer_group` (Conv chains only -- always 1 for a MatMul/
+    Gemm chain) is greater than 1, each branch's own independent `keep` is
+    still chosen with no cross-branch coordination -- only *how* it's chosen
+    within one branch changes: rather than one plain top-k of that branch's
+    own `n_channels`, it's chosen as one independent top-k *per
+    `block`-sized block the branch contains* (``block = chain.n_channels //
+    chain.consumer_group``, the exact same global block size and
+    `per_group_keep` target used everywhere else in this merge), exactly
+    mirroring :func:`_apply_chains`'s own per-block mechanism for a single
+    grouped producer/consumer -- safe here specifically because
+    :func:`_concat_branches_align_to_consumer_group` already confirmed every
+    such block falls entirely inside one branch before this chain was ever
+    produced, so a branch's own `n_channels // block` is always a whole
+    number and no block's own uniform-count requirement ever needs
+    contributions from more than one branch. See that function's own
+    docstring for the full safety argument (and the concrete counter-example
+    for why a straddling block is declined instead). The final consumer
+    slice is, correspondingly,
+    :func:`_slice_grouped_consumer_conv_weight` rather than
+    :func:`_slice_consumer_weight` whenever `consumer_group > 1`.
     """
     initializer_map = {t.name: t for t in graph.initializer}
 
@@ -5663,11 +5818,23 @@ def _apply_concat_chains(
         ):
             continue  # a shared/tied initializer another chain already resized
 
+        group = chain.consumer_group
+        if group > 1:
+            block = chain.n_channels // group
+            per_group_keep = max(1, round(block * (1.0 - sparsity)))
+
         branch_keeps: List[np.ndarray] = []
         any_pruned = False
         for b in chain.branches:
             n = b.n_channels
-            keep_count = max(1, n - round(n * sparsity))
+            if group > 1:
+                # Whole number by construction -- see
+                # _concat_branches_align_to_consumer_group's own docstring
+                # and this function's own docstring above.
+                local_blocks = n // block
+                keep_count = per_group_keep * local_blocks
+            else:
+                keep_count = max(1, n - round(n * sparsity))
             if keep_count >= n:
                 branch_keeps.append(np.arange(n))
                 continue
@@ -5683,7 +5850,24 @@ def _apply_concat_chains(
                     else (w if p.weight_transposed else w.T)  # [N, K]
                 )
             importance = compute_branch_importance(b.operand_name, w_arrays_nk)
-            branch_keeps.append(np.sort(np.argsort(-importance)[:keep_count]))
+            if group > 1:
+                # One independent top-k per block contained in this branch --
+                # see this function's own docstring.
+                branch_keeps.append(
+                    np.concatenate(
+                        [
+                            np.sort(
+                                np.argsort(-importance[gi * block : (gi + 1) * block])[
+                                    :per_group_keep
+                                ]
+                            )
+                            + gi * block
+                            for gi in range(local_blocks)
+                        ]
+                    )
+                )
+            else:
+                branch_keeps.append(np.sort(np.argsort(-importance)[:keep_count]))
 
         if not any_pruned:
             continue  # every branch rounds down to a no-op -- nothing to do
@@ -5729,12 +5913,20 @@ def _apply_concat_chains(
                 _slice_last_axis(initializer_map[hop.bias], global_keep)
             _set_conv_group_attr(hop.node, len(global_keep))
 
-        _slice_consumer_weight(
-            initializer_map[chain.consumer_weight],
-            chain.consumer_weight_transposed,
-            global_keep,
-            is_conv=chain.consumer_is_conv,
-        )
+        if chain.consumer_is_conv and group > 1:
+            _slice_grouped_consumer_conv_weight(
+                initializer_map[chain.consumer_weight],
+                global_keep,
+                group,
+                chain.n_channels,
+            )
+        else:
+            _slice_consumer_weight(
+                initializer_map[chain.consumer_weight],
+                chain.consumer_weight_transposed,
+                global_keep,
+                is_conv=chain.consumer_is_conv,
+            )
 
         touched.producer.update(producer_weights)
         touched.consumer.add(chain.consumer_weight)
@@ -5817,6 +6009,17 @@ def _slice_grouped_consumer_conv_weight(
     consumer's own blocks are always the exact same partition of
     `n_channels` -- never a case where one side's block boundaries split a
     count unevenly relative to the other's.
+
+    The other caller, :func:`_apply_concat_chains` (a ``Concat``-merged
+    branch group feeding a grouped consumer), establishes the same
+    uniform-per-block-count guarantee by a different route: there is no
+    single producer whose blocks the consumer's must match, but
+    :func:`_concat_branches_align_to_consumer_group` already confirmed every
+    one of the consumer's own blocks falls entirely inside one branch, and
+    that branch's own per-block top-k (mirroring :func:`_apply_chains`'s
+    mechanism exactly, just scoped to the blocks it contains) keeps the same
+    `per_group_keep` count from each -- see that function's own docstring
+    for the full argument.
     """
     w = onnx.numpy_helper.to_array(w_init)
     out_channels = w.shape[0]
@@ -6503,8 +6706,15 @@ def apply_structured_pruning(
     out elsewhere, bottoms out at a graph input, or would need to cross a
     residual (``Add``/``SkipLayerNormalization``) merge or another
     ``Concat`` to reach one, declines the *entire* group, never partially
-    pruned. A grouped (``group != 1``) Conv consumer is likewise declined,
-    the same reason a residual group declines one.
+    pruned. A grouped (``group != 1``) Conv consumer is admitted, but only
+    when every branch's own fixed offset lands on one of the consumer's own
+    `group` block boundaries, so every block is owned by exactly one branch
+    -- see :func:`_concat_branches_align_to_consumer_group`'s own docstring
+    for the exact condition and why a block straddling two branches is still
+    declined (the same reason a residual group declines any grouped
+    consumer): a `Concat` branch's independent, no-cross-branch-visibility
+    ranking has no general way to land two branches on a matching split of
+    one shared block's required survivor count.
 
     :param model: the original onnx ModelProto or file path
     :param sparsity: target fraction of each matched producer's output

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -6834,13 +6834,18 @@ def test_structured_pruning_conv_concat_declines_on_wrong_axis():
     np.testing.assert_array_equal(inits["WOUT"], wout)
 
 
-def test_structured_pruning_conv_concat_declines_on_grouped_conv_consumer():
-    # The downstream consumer is a general grouped Conv -- declined the same
-    # way _find_conv_residual_chains declines one (see this section's own
-    # comment): the per-group top-k assumes every producer feeds the
-    # consumer's full channel range, which independently-pruned Concat
-    # branches don't establish.
-    Cin, Ca, Cb, Cout, group = 3, 4, 4, 8, 2
+def test_structured_pruning_conv_concat_declines_on_straddling_grouped_conv_consumer():
+    # The downstream consumer is a general grouped Conv (group=2, so
+    # block=(Ca+Cb)//group=4), but branch B's own fixed offset (Ca=3) is
+    # *not* a multiple of that block size: block 0 is channels [0, 4), and
+    # branch A only owns [0, 3) of it -- column 3 belongs to branch B. That
+    # one block therefore straddles both branches (see
+    # _concat_branches_align_to_consumer_group's own docstring for exactly
+    # this counter-example), so it's still declined outright, the whole
+    # chain untouched -- unlike a block-aligned grouped consumer (see
+    # test_structured_pruning_conv_concat_admits_block_aligned_grouped_conv_consumer
+    # below), which *is* now admitted.
+    Cin, Ca, Cb, Cout, group = 3, 3, 5, 8, 2
     rng = np.random.default_rng(224)
     wa = rng.standard_normal((Ca, Cin, 3, 3)).astype(np.float32)
     wb = rng.standard_normal((Cb, Cin, 3, 3)).astype(np.float32)
@@ -6862,6 +6867,308 @@ def test_structured_pruning_conv_concat_declines_on_grouped_conv_consumer():
     np.testing.assert_array_equal(inits["WA"], wa)
     np.testing.assert_array_equal(inits["WB"], wb)
     np.testing.assert_array_equal(inits["WOUT"], wout)
+
+
+def test_structured_pruning_conv_concat_admits_block_aligned_grouped_conv_consumer():
+    # Ca == Cb == 4 and group=2 give block=(Ca+Cb)//group=4 -- each branch
+    # owns exactly one of the consumer's two blocks (offsets 0 and 4, both
+    # multiples of 4), the simplest block-aligned shape
+    # _concat_branches_align_to_consumer_group admits: every block has
+    # exactly one owning branch, so no cross-branch agreement is ever
+    # needed and each branch's own ordinary top-k (one block == its own
+    # whole n_channels here) already is that block's own per-block top-k.
+    Cin, Ca, Cb, Cout, group = 3, 4, 4, 8, 2
+    rng = np.random.default_rng(224)
+    wa = rng.standard_normal((Ca, Cin, 3, 3)).astype(np.float32)
+    wb = rng.standard_normal((Cb, Cin, 3, 3)).astype(np.float32)
+    wout = rng.standard_normal((Cout, (Ca + Cb) // group, 1, 1)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{Cout},8,8] Y)
+        {{
+          ha = Conv<kernel_shape=[3,3]>(X, WA)
+          hb = Conv<kernel_shape=[3,3]>(X, WB)
+          merged = Concat<axis=1>(ha, hb)
+          Y = Conv<kernel_shape=[1,1], group={group}>(merged, WOUT)
+        }}
+        """,
+        initializer=[_f32(wa, "WA"), _f32(wb, "WB"), _f32(wout, "WOUT")],
+    )
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    # Each branch is exactly one block wide here, so its own per-block
+    # top-k reduces to an ordinary whole-branch top-k -- group=1 passed to
+    # the existing per-group oracle helper below gives exactly that.
+    keep_a = _oracle_keep_indices_conv_grouped(wa, 1, 0.5)
+    keep_b = _oracle_keep_indices_conv_grouped(wb, 1, 0.5)
+    assert len(keep_a) == 2 and len(keep_b) == 2
+    global_keep = np.concatenate([keep_a, keep_b + Ca])
+    wout_sliced = _oracle_slice_grouped_consumer_conv(wout, global_keep, group, Ca + Cb)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["WA"], wa[keep_a])
+    np.testing.assert_array_equal(inits["WB"], wb[keep_b])
+    np.testing.assert_array_equal(inits["WOUT"], wout_sliced)
+
+    oracle = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{Cout},8,8] Y)
+        {{
+          ha = Conv<kernel_shape=[3,3]>(X, WA)
+          hb = Conv<kernel_shape=[3,3]>(X, WB)
+          merged = Concat<axis=1>(ha, hb)
+          Y = Conv<kernel_shape=[1,1], group={group}>(merged, WOUT)
+        }}
+        """,
+        initializer=[
+            _f32(wa[keep_a], "WA"),
+            _f32(wb[keep_b], "WB"),
+            _f32(wout_sliced, "WOUT"),
+        ],
+    )
+    rng_x = np.random.default_rng(225)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_conv_concat_grouped_consumer_prunes_branches_independently_despite_conflicting_importance():
+    # Deliberately adversarial: branch A's weights are scaled 100x larger
+    # than branch B's, so by *any* cross-branch-comparable ranking branch B
+    # would look catastrophically unimportant next to branch A -- if this
+    # composition secretly needed the branches to agree (the way a
+    # gated pair or residual merge's shared producers must), a buggy
+    # implementation could plausibly starve branch B's own block down to
+    # fewer survivors than its own 50% sparsity target, or even try to
+    # "borrow" extra keep budget for branch A's block from branch B's.
+    # Concat branches need no such agreement (this module's own docstring):
+    # each branch is ranked and pruned purely against *itself*, so branch
+    # B's own block keeps exactly its own per_group_keep=2 channels
+    # regardless of branch A's own weight scale.
+    Cin, Ca, Cb, Cout, group = 3, 4, 4, 8, 2
+    rng = np.random.default_rng(226)
+    wa = rng.standard_normal((Ca, Cin, 3, 3)).astype(np.float32) * 100.0
+    wb = rng.standard_normal((Cb, Cin, 3, 3)).astype(np.float32) * 0.01
+    wout = rng.standard_normal((Cout, (Ca + Cb) // group, 1, 1)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{Cout},8,8] Y)
+        {{
+          ha = Conv<kernel_shape=[3,3]>(X, WA)
+          hb = Conv<kernel_shape=[3,3]>(X, WB)
+          merged = Concat<axis=1>(ha, hb)
+          Y = Conv<kernel_shape=[1,1], group={group}>(merged, WOUT)
+        }}
+        """,
+        initializer=[_f32(wa, "WA"), _f32(wb, "WB"), _f32(wout, "WOUT")],
+    )
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep_a = _oracle_keep_indices_conv_grouped(wa, 1, 0.5)
+    keep_b = _oracle_keep_indices_conv_grouped(wb, 1, 0.5)
+    # The crux of this test: branch B keeps exactly `per_group_keep` of its
+    # own channels -- not zero, and not fewer than branch A's own count --
+    # despite being 10,000x smaller in weight magnitude.
+    assert len(keep_a) == 2 and len(keep_b) == 2
+    global_keep = np.concatenate([keep_a, keep_b + Ca])
+    wout_sliced = _oracle_slice_grouped_consumer_conv(wout, global_keep, group, Ca + Cb)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["WA"], wa[keep_a])
+    np.testing.assert_array_equal(inits["WB"], wb[keep_b])
+    np.testing.assert_array_equal(inits["WOUT"], wout_sliced)
+
+    oracle = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{Cout},8,8] Y)
+        {{
+          ha = Conv<kernel_shape=[3,3]>(X, WA)
+          hb = Conv<kernel_shape=[3,3]>(X, WB)
+          merged = Concat<axis=1>(ha, hb)
+          Y = Conv<kernel_shape=[1,1], group={group}>(merged, WOUT)
+        }}
+        """,
+        initializer=[
+            _f32(wa[keep_a], "WA"),
+            _f32(wb[keep_b], "WB"),
+            _f32(wout_sliced, "WOUT"),
+        ],
+    )
+    rng_x = np.random.default_rng(227)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_conv_concat_grouped_consumer_branch_spanning_multiple_blocks_matches_oracle():
+    # group=3 gives block=(Ca+Cb)//group=4. Branch A (Ca=8) spans *two* of
+    # the consumer's three blocks on its own (offsets 0 and 4, both
+    # multiples of 4); branch B (Cb=4) owns the third block alone (offset
+    # 8). This is the case _concat_branches_align_to_consumer_group's own
+    # docstring singles out: a branch containing more than one block must
+    # keep a *uniform* per_group_keep count from *each* of its own
+    # contained blocks, not just an ordinary flat top-k over its whole
+    # n_channels. Engineered so the two constructions disagree and are
+    # separately checkable: branch A's first four filters (local block 0)
+    # are scaled 100x larger than its last four (local block 1), so a
+    # (wrong) flat top-4-of-8 over the whole branch would keep all of
+    # block 0 and none of block 1 -- violating the grouped consumer's own
+    # per-block-uniform-count requirement outright (and producing an empty
+    # `local_keep` for the WOUT filter group belonging to block 1). The
+    # correct per-block-aware selection keeps exactly 2 from each of
+    # branch A's own two blocks regardless of the magnitude gap.
+    Cin, Ca, Cb, Cout, group = 3, 8, 4, 9, 3
+    n_channels = Ca + Cb
+    block = n_channels // group
+    rng = np.random.default_rng(228)
+    wa = rng.standard_normal((Ca, Cin, 3, 3)).astype(np.float32)
+    wa[:4] *= 100.0  # local block 0 -- overwhelmingly "more important"
+    wa[4:] *= 0.01  # local block 1 -- overwhelmingly "less important"
+    wb = rng.standard_normal((Cb, Cin, 3, 3)).astype(np.float32)
+    wout = rng.standard_normal((Cout, n_channels // group, 1, 1)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{Cout},8,8] Y)
+        {{
+          ha = Conv<kernel_shape=[3,3]>(X, WA)
+          hb = Conv<kernel_shape=[3,3]>(X, WB)
+          merged = Concat<axis=1>(ha, hb)
+          Y = Conv<kernel_shape=[1,1], group={group}>(merged, WOUT)
+        }}
+        """,
+        initializer=[_f32(wa, "WA"), _f32(wb, "WB"), _f32(wout, "WOUT")],
+    )
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    # Branch A spans Ca // block == 2 of the consumer's own blocks.
+    keep_a = _oracle_keep_indices_conv_grouped(wa, Ca // block, 0.5)
+    keep_b = _oracle_keep_indices_conv_grouped(wb, Cb // block, 0.5)
+    # The crux of this test: exactly 2 survivors from *each* of branch A's
+    # own two local blocks, not 4-and-0 (what a flat whole-branch top-k
+    # would produce given the 100x/0.01x magnitude gap above).
+    local_block0 = keep_a[keep_a < 4]
+    local_block1 = keep_a[keep_a >= 4]
+    assert len(local_block0) == 2
+    assert len(local_block1) == 2
+    assert len(keep_b) == 2
+
+    global_keep = np.concatenate([keep_a, keep_b + Ca])
+    wout_sliced = _oracle_slice_grouped_consumer_conv(
+        wout, global_keep, group, n_channels
+    )
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["WA"], wa[keep_a])
+    np.testing.assert_array_equal(inits["WB"], wb[keep_b])
+    np.testing.assert_array_equal(inits["WOUT"], wout_sliced)
+
+    oracle = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{Cout},8,8] Y)
+        {{
+          ha = Conv<kernel_shape=[3,3]>(X, WA)
+          hb = Conv<kernel_shape=[3,3]>(X, WB)
+          merged = Concat<axis=1>(ha, hb)
+          Y = Conv<kernel_shape=[1,1], group={group}>(merged, WOUT)
+        }}
+        """,
+        initializer=[
+            _f32(wa[keep_a], "WA"),
+            _f32(wb[keep_b], "WB"),
+            _f32(wout_sliced, "WOUT"),
+        ],
+    )
+    rng_x = np.random.default_rng(229)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_wanda_pruning_conv_concat_admits_block_aligned_grouped_conv_consumer():
+    # The Wanda analogue of
+    # test_structured_pruning_conv_concat_admits_block_aligned_grouped_conv_consumer:
+    # confirms the group-aware per-block branch selection composes
+    # correctly with _wanda_branch_importance's own activation-weighted
+    # metric (captured at each branch's own Concat operand, exactly as an
+    # ungrouped Concat consumer already is), not just the plain L2 path.
+    Cin, Ca, Cb, Cout, group = 3, 4, 4, 8, 2
+    rng = np.random.default_rng(230)
+    wa = rng.standard_normal((Ca, Cin, 3, 3)).astype(np.float32)
+    wb = rng.standard_normal((Cb, Cin, 3, 3)).astype(np.float32)
+    wout = rng.standard_normal((Cout, (Ca + Cb) // group, 1, 1)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{Cout},8,8] Y)
+        {{
+          ha = Conv<kernel_shape=[3,3]>(X, WA)
+          hb = Conv<kernel_shape=[3,3]>(X, WB)
+          merged = Concat<axis=1>(ha, hb)
+          Y = Conv<kernel_shape=[1,1], group={group}>(merged, WOUT)
+        }}
+        """,
+        initializer=[_f32(wa, "WA"), _f32(wb, "WB"), _f32(wout, "WOUT")],
+    )
+
+    probe_model = onnx.ModelProto()
+    probe_model.CopyFrom(model)
+    probe_model.graph.output.append(
+        onnx.helper.make_tensor_value_info("ha", onnx.TensorProto.FLOAT, None)
+    )
+    probe_model.graph.output.append(
+        onnx.helper.make_tensor_value_info("hb", onnx.TensorProto.FLOAT, None)
+    )
+    rng_cal = np.random.default_rng(231)
+    x_cal = rng_cal.standard_normal((4, Cin, 10, 10)).astype(np.float32)
+    calibration_data = [{"X": x_cal}]
+    _, ha_cal, hb_cal = _run(probe_model, {"X": x_cal})
+    norm_a = np.sqrt(np.mean(np.square(ha_cal.astype(np.float64)), axis=(0, 2, 3)))
+    norm_b = np.sqrt(np.mean(np.square(hb_cal.astype(np.float64)), axis=(0, 2, 3)))
+
+    pruned = onnxsim.apply_structured_wanda_pruning(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned)
+
+    imp_a = np.linalg.norm(wa.reshape(Ca, -1).astype(np.float64), axis=1) * np.maximum(
+        norm_a, 1e-8
+    )
+    imp_b = np.linalg.norm(wb.reshape(Cb, -1).astype(np.float64), axis=1) * np.maximum(
+        norm_b, 1e-8
+    )
+    # Each branch is exactly one block wide, so its own per-block top-k is
+    # an ordinary whole-branch top-k over this Wanda-weighted importance.
+    keep_a = np.sort(np.argsort(-imp_a)[:2])
+    keep_b = np.sort(np.argsort(-imp_b)[:2])
+    global_keep = np.concatenate([keep_a, keep_b + Ca])
+    wout_sliced = _oracle_slice_grouped_consumer_conv(wout, global_keep, group, Ca + Cb)
+
+    oracle = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{Cout},8,8] Y)
+        {{
+          ha = Conv<kernel_shape=[3,3]>(X, WA)
+          hb = Conv<kernel_shape=[3,3]>(X, WB)
+          merged = Concat<axis=1>(ha, hb)
+          Y = Conv<kernel_shape=[1,1], group={group}>(merged, WOUT)
+        }}
+        """,
+        initializer=[
+            _f32(wa[keep_a], "WA"),
+            _f32(wb[keep_b], "WB"),
+            _f32(wout_sliced, "WOUT"),
+        ],
+    )
+    rng_x = np.random.default_rng(232)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
 
 
 # --- apply_structured_wanda_pruning ------------------------------------------


### PR DESCRIPTION
## Summary
- `apply_structured_pruning`/`apply_structured_wanda_pruning`'s `Concat`-merged skip-connection support (the U-Net-style encoder/decoder merge) previously declined outright whenever the shared downstream consumer was a general grouped (`group != 1`) Conv, the same conservative treatment a residual/merge group gives one. Investigated whether that's actually necessary in every case, or only in some.
- **Admitted, in a precisely bounded sub-case**: a grouped consumer is now accepted when every `Concat` branch's own fixed offset lands exactly on one of the consumer's own `group` block boundaries (`block = n_channels // group`) — so every block is owned by exactly one branch, never split across two. When that holds, each branch can satisfy its own contained blocks' uniform-survivor-count requirement entirely on its own (an internal per-block top-k, mirroring `_apply_chains`'s existing per-group mechanism for a single grouped producer/consumer), with zero cross-branch coordination needed.
- **Still declined, with a concrete counter-example**: when a block instead straddles two branches, satisfying that block's required count needs the two branches' independently-computed keep-counts to sum correctly — impossible in general without reintroducing exactly the cross-branch importance agreement `Concat` support exists to avoid (worked counter-example in `_concat_branches_align_to_consumer_group`'s own docstring: `block=4`, branch `a` owns 3 columns, branch `b` owns 1 — no combination of independent per-branch decisions reliably lands on the required count of 2).

## Implementation
- `_ConcatChain.consumer_group` field (mirrors `_Chain.consumer_group`)
- New `_concat_branches_align_to_consumer_group()` admission check in `_find_conv_concat_chains`, replacing the previous outright `group != 1` decline
- `_apply_concat_chains` does an independent per-block top-k within each branch's own contained blocks when `consumer_group > 1`, then slices the consumer via the existing `_slice_grouped_consumer_conv_weight`
- Docstrings updated (module header, Concat section comment, `_find_conv_concat_chains`, `_apply_concat_chains`, `_slice_grouped_consumer_conv_weight`, `apply_structured_pruning`) with the full safety argument and the counter-example

## Test plan
- [x] `pytest tests/test_pruning.py -q` — 251 passed (was 247 before this change)
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — 0 errors, matches master's baseline
- [x] Real onnxruntime execution against independently-constructed oracles for: the basic block-aligned admission case; a conflicting-per-branch-importance adversarial case (100x weight-scale gap, proving branch independence is preserved); a branch-spanning-multiple-blocks adversarial case (100x/0.01x magnitude split across a branch's own two blocks, engineered so a naive flat top-k would produce a checkably wrong answer — keep exactly 2 from *each* of the branch's own two blocks, not 4-and-0); a Wanda-pruning variant; and a straddling-block decline test (topology left completely untouched)

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_