### PR TITLE
Add pruning-recovery fine-tune stage (onnxsim.apply_pruning_finetune)

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -38,6 +38,7 @@ from onnxsim.embedding_quantization import (
     quantize_embedding_binary,
     quantize_embedding_int8,
 )
+from onnxsim.finetune import apply_pruning_finetune
 from onnxsim.gguf_reconstruct import (
     UnsupportedArchitectureError,
     reconstruct_gguf_graph,
@@ -128,6 +129,7 @@ __all__ = [
     "cross_layer_equalize",
     "correct_bias",
     "apply_adaround",
+    "apply_pruning_finetune",
     "apply_autoround",
     "auto_quantize_int4",
     "AutoQuantResult",

--- a/onnxsim/finetune.py
+++ b/onnxsim/finetune.py
@@ -1,0 +1,409 @@
+"""Layer-wise MatMul/Gemm weight fine-tuning that recovers accuracy lost to
+*structured* (channel) or *attention-head* pruning -- the pruning analogue
+of :mod:`onnxsim.adaround`'s own "recover accuracy lost to quantization"
+role, reusing the same established idiom this codebase already uses there
+(and in :mod:`onnxsim.bias_correction`): real activations captured from a
+reference model, a closed-form fit against them, no generic autodiff or
+backprop-through-the-graph framework of any kind.
+
+:func:`apply_pruning_finetune` takes the *pre-pruning* float model
+(``original_model``) and its pruned counterpart (``pruned_model``, e.g. the
+output of :func:`onnxsim.apply_structured_pruning_cpp`/
+:func:`onnxsim.apply_attention_head_pruning_cpp` or their Wanda-calibrated
+counterparts) and, for every MatMul/Gemm node present (by node output name
+and op type) in both, re-derives that layer's own surviving output/input
+channel indices and re-solves its weight (and bias, if it has one) as a
+ridge-regression fit against ``original_model``'s own real activations --
+not just re-slicing the original weight (what pruning itself already did),
+but choosing the *best* surviving weight values to reconstruct what the
+*original*, unpruned layer would have produced, over the channels that
+survive.
+
+**Why this is exact, not approximate, for a single pass.** Pruning is a
+pure "delete some rows/columns of a weight tensor" operation -- it changes
+*which* channels flow through the graph, but never the *value* of a
+channel that survives, and every hop in between (a unary activation, a
+per-channel bias/scale) is itself channel-order-preserving. So, before any
+fine-tuning happens, a pruned layer's own real input activation is
+*exactly* equal to ``original_model``'s own activation at that same tensor,
+restricted to whichever input channels this layer's own pruning kept --
+no need to actually run ``pruned_model`` at all to know what it would
+produce there. This is the same one-shot-capture design
+:func:`onnxsim.apply_adaround` already uses (it never re-runs
+``quantized_model`` between layers either): every layer's own optimization
+target is computed once, up front, from ``original_model`` alone.
+
+**Channel correspondence.** Pruning's own ``keep`` index set (see
+``onnxsim/pruning.py``'s own ``_apply_chains``) is never exposed by the
+pruning functions themselves, so this module reconstructs it by exact
+(bit-identical) matching: a pruned weight's own surviving rows (or columns)
+are, by construction, an order-preserving subsequence of the original
+weight's own rows (or columns) -- a plain ``np.sort``-then-gather, no
+reordering, no value change -- so a forward two-pointer scan finds exactly
+which original index each surviving one came from
+(:func:`_find_keep_indices`). Comparing a *whole* row (or column) this way
+needs the *other* axis's own width to already agree between the two
+weights, though, so this only recovers the correspondence for a layer
+pruned on at most one axis at a time -- its own output channels (this
+layer is itself some producer chain's own consumer, or the primary
+producer of one), its own input channels (this layer is itself some
+chain's own consumer), or neither (still worth fine-tuning against shifted
+upstream activations, but only once weight equality confirms nothing else
+changed it) -- see :func:`_find_channel_correspondence`. A layer pruned on
+*both* axes at once (an interior layer that is itself both some chain's
+own consumer and a different chain's own producer), or one whose weight
+isn't a clean subsequence of its own original counterpart at all (this
+module was pointed at two unrelated models, or something other than
+pruning touched the weight in between), is left completely untouched,
+never guessed at -- the same conservative boundary every ``pruning.py``
+chain finder already holds.
+
+**The fit itself.** For one layer, let ``X`` be ``original_model``'s own
+captured input activation restricted to this layer's own surviving input
+channels, and ``Y`` be ``original_model``'s own analytically-computed
+output (``X_full @ W_orig.T [+ bias_orig]``) restricted to this layer's own
+surviving output channels -- both computed directly from one probed
+activation and the original weight/bias, mirroring
+:func:`onnxsim.apply_adaround`'s own single-probe-point-per-layer design.
+The new weight (and bias, if present) minimizes
+``||X @ W.T [+ b] - Y||^2 + reg_param * ||[W, b] - [W_pruned, b_pruned]||^2``
+-- ordinary ridge regression, ``reg_param`` (relative to the calibration
+data's own scale) pulling the fit back toward pruning's own already-sliced
+weight when calibration data is too scarce, relative to the layer's own
+parameter count, to trust unregularized least squares. Solved in closed
+form (a single linear solve per layer) rather than any iterative
+optimizer -- unlike AdaRound's own non-convex rounding relaxation, this is
+an ordinary (convex) least-squares problem with no relaxation needed.
+
+**Scope.** MatMul/vanilla-Gemm only, matching
+:func:`onnxsim.apply_adaround`'s own scope exactly -- no Conv support (a
+Conv layer's own im2col expansion, and the padding/stride/dilation
+bookkeeping ``pruning.py``'s own Wanda-calibrated Conv path already needs,
+is real extra work this module doesn't yet do). A captured activation that
+isn't a plain 2-D array (e.g. an un-flattened ``[batch, seq, K]`` tensor)
+is skipped, the same boundary :func:`onnxsim.apply_adaround` already has.
+This also does not, itself, touch attention-head-pruned Q/K/V/output-
+projection weights that live inside a fused ``com.microsoft::Attention``/
+``GroupQueryAttention``/``ai.onnx::Attention`` node (no MatMul/Gemm node
+exists for a packed-QKV weight at all) or that feed such a fused op as a
+consumer (this module only matches a MatMul/Gemm *consumer*) -- covered
+only when attention-head pruning happens to leave ordinary MatMul/Gemm
+layers around it (e.g. an unrelated MLP block) unchanged in shape, which
+this module still usefully re-fits against the shifted upstream
+activations flowing into it. And, per this module's own "Channel
+correspondence" note above, a layer pruned on *both* its own input and
+output channels at once is left untouched too -- still a real gap for a
+model with several matched layers chained back to back, narrower than
+what ``apply_structured_pruning``'s own chain finders themselves recognize.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Union
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+
+from onnxsim import backend
+from onnxsim.bias_correction import _add_probe_outputs
+from onnxsim.calibration import Tensors, generate_random_calibration_data
+from onnxsim.smoothquant import _match_matmul_like
+
+
+@dataclass
+class _Candidate:
+    x_name: str
+    pruned_node: onnx.NodeProto
+    w_orig: onnx.TensorProto
+    w_pruned: onnx.TensorProto
+    b_orig: Optional[onnx.TensorProto]
+    b_pruned: Optional[onnx.TensorProto]
+    weight_transposed: bool
+
+
+def _node_by_output(graph: onnx.GraphProto) -> Dict[str, onnx.NodeProto]:
+    m: Dict[str, onnx.NodeProto] = {}
+    for n in graph.node:
+        if n.output:
+            m[n.output[0]] = n
+    return m
+
+
+def _find_matmul_finetune_candidates(
+    original_model: onnx.ModelProto, pruned_model: onnx.ModelProto
+) -> List[_Candidate]:
+    orig_by_output = _node_by_output(original_model.graph)
+    pruned_by_output = _node_by_output(pruned_model.graph)
+    orig_init = {t.name: t for t in original_model.graph.initializer}
+    pruned_init = {t.name: t for t in pruned_model.graph.initializer}
+
+    candidates: List[_Candidate] = []
+    for out_name, pn in pruned_by_output.items():
+        on = orig_by_output.get(out_name)
+        if on is None or on.op_type != pn.op_type:
+            continue
+        p_match = _match_matmul_like(pn)
+        o_match = _match_matmul_like(on)
+        if p_match is None or o_match is None:
+            continue
+        p_x_name, p_w_name, p_transposed = p_match
+        o_x_name, o_w_name, o_transposed = o_match
+        if p_transposed != o_transposed:
+            continue
+
+        w_pruned = pruned_init.get(p_w_name)
+        w_orig = orig_init.get(o_w_name)
+        if (
+            w_pruned is None
+            or w_orig is None
+            or w_pruned.data_type != onnx.TensorProto.FLOAT
+            or w_orig.data_type != onnx.TensorProto.FLOAT
+            or len(w_pruned.dims) != 2
+            or len(w_orig.dims) != 2
+        ):
+            continue
+
+        b_pruned = pruned_init.get(pn.input[2]) if len(pn.input) == 3 else None
+        b_orig = orig_init.get(on.input[2]) if len(on.input) == 3 else None
+        if (b_pruned is None) != (b_orig is None):
+            continue  # bias presence disagrees -- something other than pruning touched this
+
+        candidates.append(
+            _Candidate(
+                x_name=o_x_name,
+                pruned_node=pn,
+                w_orig=w_orig,
+                w_pruned=w_pruned,
+                b_orig=b_orig,
+                b_pruned=b_pruned,
+                weight_transposed=p_transposed,
+            )
+        )
+    return candidates
+
+
+def _find_keep_indices(
+    orig_rows: np.ndarray, pruned_rows: np.ndarray
+) -> Optional[np.ndarray]:
+    """Returns the ``len(pruned_rows)``-length array of ``orig_rows``'s own
+    indices ``pruned_rows`` was sliced from, reconstructed by exact
+    (bit-identical) forward two-pointer subsequence matching -- see this
+    module's own docstring for why pruning's own slice always makes
+    ``pruned_rows`` an order-preserving subsequence of ``orig_rows``.
+    Returns ``None`` if it isn't one (declined conservatively).
+    """
+    if (
+        pruned_rows.shape[0] > orig_rows.shape[0]
+        or orig_rows.shape[1:] != pruned_rows.shape[1:]
+    ):
+        return None
+    keep = np.empty(pruned_rows.shape[0], dtype=np.int64)
+    oi = 0
+    n_orig = orig_rows.shape[0]
+    for pi in range(pruned_rows.shape[0]):
+        while oi < n_orig and not np.array_equal(orig_rows[oi], pruned_rows[pi]):
+            oi += 1
+        if oi >= n_orig:
+            return None
+        keep[pi] = oi
+        oi += 1
+    return keep
+
+
+def _find_channel_correspondence(
+    w_orig_nk: np.ndarray, w_pruned_nk: np.ndarray
+) -> "tuple[Optional[np.ndarray], Optional[np.ndarray]]":
+    """Finds ``(keep_out, keep_in)`` for one layer's ``[N, K]``-normalized
+    weight pair. Row/column matching alone can only recover one axis's own
+    ``keep`` set at a time -- comparing a *full* row (or column) requires
+    the *other* axis's own width to already agree between the two matrices
+    -- so this only handles a layer pruned on at most one axis: its own
+    output channels (a producer chain's own pruning), its own input
+    channels (a consumer chain's own pruning), or neither (still worth
+    fine-tuning against shifted upstream activations, but only if the two
+    weights are otherwise identical -- see :func:`_find_keep_indices`'s own
+    same-length-subsequence-forces-equality argument). A layer pruned on
+    *both* axes at once (an interior layer that is itself both some
+    producer chain's own consumer and some other chain's own producer) is
+    declined outright -- recovering two simultaneous, independent ``keep``
+    sets from the pruned matrix's own content alone is a real ambiguous
+    inverse problem this module doesn't attempt to solve, rather than
+    risk a wrong (silently corrupting) channel correspondence.
+    """
+    n_orig, k_orig = w_orig_nk.shape
+    n_pruned, k_pruned = w_pruned_nk.shape
+    if k_orig == k_pruned:
+        keep_out = _find_keep_indices(w_orig_nk, w_pruned_nk)
+        keep_in = np.arange(k_orig) if keep_out is not None else None
+        return keep_out, keep_in
+    if n_orig == n_pruned:
+        keep_in = _find_keep_indices(w_orig_nk.T, w_pruned_nk.T)
+        keep_out = np.arange(n_orig) if keep_in is not None else None
+        return keep_out, keep_in
+    return (
+        None,
+        None,
+    )  # both axes changed -- declined, see this function's own docstring
+
+
+def _ridge_fit(
+    x: np.ndarray,
+    y: np.ndarray,
+    w0: np.ndarray,
+    b0: Optional[np.ndarray],
+    reg_param: float,
+) -> "tuple[np.ndarray, Optional[np.ndarray]]":
+    """Ridge-regression fit of ``y ~= x @ w.T [+ b]`` (``x``: ``[num_samples,
+    K]``, ``y``: ``[num_samples, N]``, ``w0``/``b0``: the current ``[N, K]``/
+    ``[N]`` weight/bias this fit is regularized toward), ``reg_param``
+    scaled relative to ``x``'s own Gram matrix so it needs no per-model
+    tuning. Returns the new ``(w, b)`` (``b`` is ``None`` iff ``b0`` is).
+    """
+    has_bias = b0 is not None
+    if has_bias:
+        x_aug = np.concatenate([x, np.ones((x.shape[0], 1))], axis=1)
+        w0_aug = np.concatenate([w0, b0[:, None]], axis=1)
+    else:
+        x_aug = x
+        w0_aug = w0
+
+    gram = x_aug.T @ x_aug
+    lam = reg_param * (np.trace(gram) / gram.shape[0])
+    a = gram + lam * np.eye(gram.shape[0])
+    rhs = x_aug.T @ y + lam * w0_aug.T
+    w_aug_t = np.linalg.solve(a, rhs)  # [K(+1), N]
+
+    if has_bias:
+        return w_aug_t[:-1, :].T, w_aug_t[-1, :]
+    return w_aug_t.T, None
+
+
+def apply_pruning_finetune(
+    original_model: Union[str, onnx.ModelProto],
+    pruned_model: Union[str, onnx.ModelProto],
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_samples: int = 8,
+    seed: int = 0,
+    reg_param: float = 1e-2,
+    providers: Optional[Sequence[str]] = None,
+) -> onnx.ModelProto:
+    """Fine-tunes every surviving MatMul/vanilla-Gemm layer present (by node
+    output name) in both ``original_model`` and ``pruned_model`` to better
+    reconstruct ``original_model``'s own real activations over calibration
+    data -- see this module's own docstring for the full technique, its
+    exactness argument, and its scope boundaries.
+
+    :param original_model: the pre-pruning onnx ModelProto or file path
+    :param pruned_model: ``original_model`` after
+            :func:`onnxsim.apply_structured_pruning_cpp`/
+            :func:`onnxsim.apply_attention_head_pruning_cpp` (or their
+            Wanda-calibrated counterparts) -- onnx ModelProto or file path.
+            Assumes no MatMul/Gemm node's own output tensor was renamed
+            between the two, true of every onnxsim pruning function
+    :param calibration_data: representative input batches to fit each
+            layer's own reconstruction on. Each batch is a
+            ``{input_name: np.ndarray}`` dict matching ``original_model``'s
+            graph inputs -- see :func:`onnxsim.generate_random_calibration_data`
+            (the default when omitted)
+    :param num_samples: random batches to generate when
+            ``calibration_data`` is omitted
+    :param seed: seed for the random calibration data (ignored if
+            ``calibration_data`` is supplied)
+    :param reg_param: ridge-regression regularization strength, relative to
+            the calibration data's own scale (see this module's own
+            docstring), pulling each layer's fit back toward its current
+            (already-pruned) weight when calibration data is too scarce,
+            relative to the layer's own parameter count, to trust
+            unregularized least squares
+    :param providers: onnxruntime execution providers to run
+            ``original_model`` on when capturing calibration activations
+    :returns: ``pruned_model`` with every matched layer's weight (and bias,
+            if it has one) replaced by its fine-tuned fit; a layer whose
+            weight isn't a clean row/column subsequence of its own
+            ``original_model`` counterpart, or whose captured activation
+            isn't a plain 2-D array, is left completely untouched
+    """
+    if isinstance(original_model, str):
+        original_model = onnx.load(original_model, load_external_data=False)
+    if isinstance(pruned_model, str):
+        pruned_model = onnx.load(pruned_model, load_external_data=False)
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            original_model, num_samples=num_samples, seed=seed
+        )
+
+    candidates = _find_matmul_finetune_candidates(original_model, pruned_model)
+    if not candidates:
+        return pruned_model
+
+    probe_names = sorted({c.x_name for c in candidates})
+    orig_probe = _add_probe_outputs(original_model, probe_names)
+
+    activations: Dict[str, List[np.ndarray]] = {name: [] for name in probe_names}
+    for batch in calibration_data:
+        out = backend.run_model(orig_probe, batch, providers=providers)
+        for name in probe_names:
+            activations[name].append(np.asarray(out[name], dtype=np.float64))
+
+    optimized_w: Dict[str, np.ndarray] = {}
+    optimized_b: Dict[str, np.ndarray] = {}
+    for c in candidates:
+        acts = [a for a in activations[c.x_name] if a.ndim == 2]
+        if not acts:
+            continue  # not a plain 2-D activation -- skip, see this module's own docstring
+        x_full = np.concatenate(acts, axis=0)
+
+        w_orig = onnx.numpy_helper.to_array(c.w_orig).astype(np.float64)
+        w_pruned = onnx.numpy_helper.to_array(c.w_pruned).astype(np.float64)
+        b_orig = (
+            onnx.numpy_helper.to_array(c.b_orig).astype(np.float64)
+            if c.b_orig is not None
+            else None
+        )
+        b_pruned = (
+            onnx.numpy_helper.to_array(c.b_pruned).astype(np.float64)
+            if c.b_pruned is not None
+            else None
+        )
+
+        # Normalize to [N, K] (output channel first) regardless of storage
+        # layout, mirroring apply_adaround's own convention.
+        w_orig_nk = w_orig if c.weight_transposed else w_orig.T
+        w_pruned_nk = w_pruned if c.weight_transposed else w_pruned.T
+        if x_full.shape[1] != w_orig_nk.shape[1]:
+            continue  # activation's feature dim doesn't match K -- skip
+
+        keep_out, keep_in = _find_channel_correspondence(w_orig_nk, w_pruned_nk)
+        if keep_in is None or keep_out is None:
+            continue  # not a clean subsequence of the original -- decline
+
+        x = x_full[:, keep_in]
+        y_full = x_full @ w_orig_nk.T
+        if b_orig is not None:
+            y_full = y_full + b_orig
+        y = y_full[:, keep_out]
+
+        w_new_nk, b_new = _ridge_fit(x, y, w_pruned_nk, b_pruned, reg_param)
+
+        w_write = w_new_nk if c.weight_transposed else w_new_nk.T
+        optimized_w[c.w_pruned.name] = w_write.astype(np.float32)
+        if b_new is not None:
+            optimized_b[c.b_pruned.name] = b_new.astype(np.float32)
+
+    if not optimized_w:
+        return pruned_model
+
+    finetuned = onnx.ModelProto()
+    finetuned.CopyFrom(pruned_model)
+    for t in finetuned.graph.initializer:
+        w = optimized_w.get(t.name)
+        if w is not None:
+            t.CopyFrom(onnx.numpy_helper.from_array(w, name=t.name))
+            continue
+        b = optimized_b.get(t.name)
+        if b is not None:
+            t.CopyFrom(onnx.numpy_helper.from_array(b, name=t.name))
+
+    return finetuned

--- a/onnxsim/finetune.py
+++ b/onnxsim/finetune.py
@@ -261,8 +261,7 @@ def _ridge_fit(
     scaled relative to ``x``'s own Gram matrix so it needs no per-model
     tuning. Returns the new ``(w, b)`` (``b`` is ``None`` iff ``b0`` is).
     """
-    has_bias = b0 is not None
-    if has_bias:
+    if b0 is not None:
         x_aug = np.concatenate([x, np.ones((x.shape[0], 1))], axis=1)
         w0_aug = np.concatenate([w0, b0[:, None]], axis=1)
     else:
@@ -275,7 +274,7 @@ def _ridge_fit(
     rhs = x_aug.T @ y + lam * w0_aug.T
     w_aug_t = np.linalg.solve(a, rhs)  # [K(+1), N]
 
-    if has_bias:
+    if b0 is not None:
         return w_aug_t[:-1, :].T, w_aug_t[-1, :]
     return w_aug_t.T, None
 
@@ -389,7 +388,7 @@ def apply_pruning_finetune(
 
         w_write = w_new_nk if c.weight_transposed else w_new_nk.T
         optimized_w[c.w_pruned.name] = w_write.astype(np.float32)
-        if b_new is not None:
+        if b_new is not None and c.b_pruned is not None:
             optimized_b[c.b_pruned.name] = b_new.astype(np.float32)
 
     if not optimized_w:

--- a/onnxsim/optimize_pipeline.py
+++ b/onnxsim/optimize_pipeline.py
@@ -26,6 +26,16 @@ techniques on top of a single fixed INT4 baseline.
      MatMul/Gemm/Conv layers -- :func:`onnxsim.apply_structured_pruning_cpp`
      (data-free, the default) or, with ``pruning_method="wanda"``,
      :func:`onnxsim.apply_structured_wanda_pruning` (calibrated).
+   If either sub-stage actually ran, :func:`onnxsim.apply_pruning_finetune`
+   is then tried against them: a closed-form, layer-wise ridge-regression
+   refit of every surviving MatMul/Gemm weight against the *original*
+   (pre-pruning) model's own real activations, recovering some of the
+   accuracy pruning's own plain channel deletion gives up -- see that
+   module's own docstring for the full technique. Measured and kept only
+   if it doesn't measurably worsen the post-pruning float model's own
+   accuracy (the same "try it, keep only if not worse" gate stage 6's own
+   compression uses), since ridge-regression fine-tuning on scarce
+   calibration data carries real overfitting risk of its own.
 3. **Cross-Layer Equalize** (:func:`onnxsim.cross_layer_equalize`) -- always;
    data-free, changes nothing but weight parameterization (see its own
    docstring), and reduces the error every later quantization stage
@@ -81,6 +91,10 @@ function matches -- ``pruning.py``'s own newer options on top of that
 directly callable on their own too, not exposed as pipeline parameters
 here.
 
+:func:`onnxsim.apply_pruning_finetune` is pure-Python only, same as
+``pruning_method="wanda"`` and ``rotation_method="duquant"``/``"spinquant"``
+-- see this module's own "C++ vs. Python" note below.
+
 **C++ vs. Python.** The magnitude-based pruning sub-stages (stage 2's own
 default), rotation (stage 4b's own ``rotation_method="quarot"`` default),
 and compression (stage 6) use C++-backed ports
@@ -124,6 +138,7 @@ from onnxsim.adaround import apply_adaround
 from onnxsim.bias_correction import correct_bias
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 from onnxsim.duquant import apply_duquant
+from onnxsim.finetune import apply_pruning_finetune
 from onnxsim.mixed_precision import apply_mixed_precision_quantization
 from onnxsim.onnx_simplifier import (
     apply_attention_head_pruning_cpp,
@@ -146,7 +161,7 @@ class OptimizationPipelineResult:
     """One :func:`apply_optimization_pipeline` result: the optimized model
     reached, which stages were applied to reach it (in application order,
     a prefix of ``["attention_head_pruning" | "attention_head_wanda_pruning",
-    "structured_pruning" | "structured_wanda_pruning",
+    "structured_pruning" | "structured_wanda_pruning", "pruning_finetune",
     "cross_layer_equalization", "quantize_weight_only_int4" |
     "apply_mixed_precision_quantization" | "quarot" | "duquant" |
     "spinquant", "adaround", "bias_correction", "double_quantization"]``),
@@ -205,7 +220,10 @@ def apply_optimization_pipeline(
             remove, applied to the float model before quantizing (and
             before ``sparsity``'s own channel pruning); ``None`` (the
             default) skips attention-head pruning entirely. Independent of
-            ``sparsity`` -- either, both, or neither may be given
+            ``sparsity`` -- either, both, or neither may be given. If either
+            is given, :func:`onnxsim.apply_pruning_finetune` is also tried
+            against the resulting pruned float model (see this module's own
+            docstring), using the same ``calibration_data``
     :param pruning_method: ``"magnitude"`` (the default) uses the data-free,
             C++-backed :func:`onnxsim.apply_structured_pruning_cpp`/
             :func:`onnxsim.apply_attention_head_pruning_cpp`; ``"wanda"``
@@ -316,6 +334,30 @@ def apply_optimization_pipeline(
         else:
             float_model = apply_structured_pruning_cpp(float_model, sparsity=sparsity)
             stages.append("structured_pruning")
+
+    if len(stages) > 0:
+        # Something was actually pruned -- try recovering some of the
+        # accuracy plain channel deletion gave up, kept only if it doesn't
+        # measurably worsen the post-pruning float model's own accuracy
+        # (mirrors stage 6's own "try it, keep only if not worse" gate for
+        # compression, since ridge-regression fine-tuning on scarce
+        # calibration data carries real overfitting risk of its own).
+        finetuned = apply_pruning_finetune(
+            model,
+            float_model,
+            calibration_data=calibration_data,
+            num_samples=num_samples,
+            seed=seed,
+            providers=providers,
+        )
+        pruned_report = _measure(float_model)
+        finetuned_report = _measure(finetuned)
+        if finetuned_report.all_finite and (
+            not pruned_report.all_finite
+            or finetuned_report.worst_relative_l2 <= pruned_report.worst_relative_l2
+        ):
+            float_model = finetuned
+            stages.append("pruning_finetune")
 
     float_model = cross_layer_equalize(float_model)
     stages.append("cross_layer_equalization")

--- a/tests/test_finetune.py
+++ b/tests/test_finetune.py
@@ -1,0 +1,363 @@
+"""Tests for ``onnxsim.finetune`` -- layer-wise ridge-regression fine-tuning
+that recovers accuracy lost to structured/attention-head pruning, see
+``onnxsim/finetune.py``.
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+from onnxsim.finetune import (
+    _find_channel_correspondence,
+    _find_keep_indices,
+    _ridge_fit,
+)
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(body, initializer=(), opset=21):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _weights(model):
+    return {t.name: onnx.numpy_helper.to_array(t) for t in model.graph.initializer}
+
+
+def _mlp_model(K=8, H=32, Out=4, bias=True, seed=0):
+    rng = np.random.default_rng(seed)
+    w1 = rng.standard_normal((K, H)).astype(np.float32)
+    w2 = rng.standard_normal((H, Out)).astype(np.float32)
+    initializer = [_f32(w1, "W1"), _f32(w2, "W2")]
+    if bias:
+        b1 = rng.standard_normal((H,)).astype(np.float32)
+        gemm1 = "h = Gemm(X, W1, B1)"
+        initializer.append(_f32(b1, "B1"))
+    else:
+        gemm1 = "h = MatMul(X, W1)"
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          {gemm1}
+          a = Relu(h)
+          Y = MatMul(a, W2)
+        }}
+        """,
+        initializer=initializer,
+    )
+
+
+def _3layer_model(K=8, H1=16, H2=16, Out=4, seed=0):
+    rng = np.random.default_rng(seed)
+    w1 = rng.standard_normal((K, H1)).astype(np.float32)
+    w2 = rng.standard_normal((H1, H2)).astype(np.float32)
+    w3 = rng.standard_normal((H2, Out)).astype(np.float32)
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          h1 = MatMul(X, W1)
+          a1 = Relu(h1)
+          h2 = MatMul(a1, W2)
+          a2 = Relu(h2)
+          Y = MatMul(a2, W3)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2"), _f32(w3, "W3")],
+    )
+
+
+def _rel_err(y, y_ref):
+    return np.linalg.norm(y - y_ref) / np.linalg.norm(y_ref)
+
+
+def test_finetune_reduces_reconstruction_error_after_structured_pruning():
+    K, H, Out = 8, 32, 4
+    model = _mlp_model(K=K, H=H, Out=Out, seed=0)
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    rng = np.random.default_rng(1)
+    x_calib = rng.standard_normal((256, K)).astype(np.float32)
+    calibration_data = [{"X": x_calib}]
+
+    finetuned = onnxsim.apply_pruning_finetune(
+        model, pruned, calibration_data=calibration_data, reg_param=1e-4
+    )
+    onnx.checker.check_model(finetuned)
+
+    x_test = rng.standard_normal((64, K)).astype(np.float32)
+    (y_orig,) = _run(model, {"X": x_test})
+    (y_pruned,) = _run(pruned, {"X": x_test})
+    (y_finetuned,) = _run(finetuned, {"X": x_test})
+
+    err_pruned = _rel_err(y_pruned, y_orig)
+    err_finetuned = _rel_err(y_finetuned, y_orig)
+    assert err_finetuned < err_pruned
+
+
+def test_finetune_shapes_are_unchanged():
+    K, H, Out = 8, 32, 4
+    model = _mlp_model(K=K, H=H, Out=Out, seed=2)
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+
+    rng = np.random.default_rng(3)
+    calibration_data = [{"X": rng.standard_normal((64, K)).astype(np.float32)}]
+    finetuned = onnxsim.apply_pruning_finetune(
+        model, pruned, calibration_data=calibration_data
+    )
+
+    pruned_w = _weights(pruned)
+    finetuned_w = _weights(finetuned)
+    assert finetuned_w.keys() == pruned_w.keys()
+    for name in pruned_w:
+        assert finetuned_w[name].shape == pruned_w[name].shape
+
+
+def test_finetune_leaves_output_producer_weight_unchanged():
+    # The very first layer's own output channels are pruned (a producer
+    # chain), but its own input channels are not -- pruning's own row
+    # slice is already the exact least-squares reconstruction of the
+    # target (see this module's own docstring), so fine-tuning should
+    # leave it untouched.
+    K, H, Out = 8, 32, 4
+    model = _mlp_model(K=K, H=H, Out=Out, seed=4)
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+
+    rng = np.random.default_rng(5)
+    calibration_data = [{"X": rng.standard_normal((128, K)).astype(np.float32)}]
+    finetuned = onnxsim.apply_pruning_finetune(
+        model, pruned, calibration_data=calibration_data, reg_param=1e-6
+    )
+
+    pruned_w = _weights(pruned)
+    finetuned_w = _weights(finetuned)
+    np.testing.assert_allclose(finetuned_w["W1"], pruned_w["W1"], rtol=1e-3, atol=1e-4)
+    np.testing.assert_allclose(finetuned_w["B1"], pruned_w["B1"], rtol=1e-3, atol=1e-4)
+    # W2 (input-pruned consumer) should actually change.
+    assert not np.allclose(finetuned_w["W2"], pruned_w["W2"])
+
+
+def test_finetune_declines_dual_axis_pruned_interior_layer():
+    K, H1, H2, Out = 8, 16, 16, 4
+    model = _3layer_model(K=K, H1=H1, H2=H2, Out=Out, seed=6)
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    # W2 is the interior layer -- pruned on both its own input (H1) and
+    # output (H2) axes.
+    assert list(inits["W2"].dims) != [H1, H2]
+
+    rng = np.random.default_rng(7)
+    calibration_data = [{"X": rng.standard_normal((128, K)).astype(np.float32)}]
+    finetuned = onnxsim.apply_pruning_finetune(
+        model, pruned, calibration_data=calibration_data
+    )
+    onnx.checker.check_model(finetuned)
+
+    pruned_w = _weights(pruned)
+    finetuned_w = _weights(finetuned)
+    # Declined outright -- left byte-identical to the pruned model's own
+    # weight, never guessed at.
+    np.testing.assert_array_equal(finetuned_w["W2"], pruned_w["W2"])
+    # W3 (input-pruned consumer of the last chain) should still be
+    # re-fit against the shifted upstream activation.
+    assert not np.allclose(finetuned_w["W3"], pruned_w["W3"])
+
+    x_test = rng.standard_normal((16, K)).astype(np.float32)
+    (y,) = _run(finetuned, {"X": x_test})
+    assert np.all(np.isfinite(y))
+
+
+def test_finetune_is_a_noop_when_no_matmul_or_gemm_nodes_present():
+    model = _model(
+        """
+        g (float[batch,4] X) => (float[batch,4] Y)
+        {
+          Y = Relu(X)
+        }
+        """
+    )
+    pruned = onnx.ModelProto()
+    pruned.CopyFrom(model)
+
+    result = onnxsim.apply_pruning_finetune(model, pruned)
+    assert result is pruned
+
+
+def test_finetune_is_a_noop_when_pruned_model_equals_original():
+    # No candidate is declined here, but every layer's own fit is already
+    # (up to floating point) the current weight -- nothing meaningfully
+    # changes.
+    K, H, Out = 8, 32, 4
+    model = _mlp_model(K=K, H=H, Out=Out, seed=8)
+    pruned = onnx.ModelProto()
+    pruned.CopyFrom(model)
+
+    rng = np.random.default_rng(9)
+    calibration_data = [{"X": rng.standard_normal((256, K)).astype(np.float32)}]
+    finetuned = onnxsim.apply_pruning_finetune(
+        model, pruned, calibration_data=calibration_data, reg_param=1e-8
+    )
+
+    orig_w = _weights(model)
+    finetuned_w = _weights(finetuned)
+    for name in orig_w:
+        np.testing.assert_allclose(
+            finetuned_w[name], orig_w[name], rtol=1e-2, atol=1e-3
+        )
+
+
+def test_finetune_accepts_file_paths(tmp_path):
+    K, H, Out = 8, 32, 4
+    model = _mlp_model(K=K, H=H, Out=Out, seed=10)
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+
+    orig_path = tmp_path / "orig.onnx"
+    pruned_path = tmp_path / "pruned.onnx"
+    onnx.save(model, str(orig_path))
+    onnx.save(pruned, str(pruned_path))
+
+    rng = np.random.default_rng(11)
+    calibration_data = [{"X": rng.standard_normal((64, K)).astype(np.float32)}]
+    finetuned = onnxsim.apply_pruning_finetune(
+        str(orig_path), str(pruned_path), calibration_data=calibration_data
+    )
+    assert isinstance(finetuned, onnx.ModelProto)
+    onnx.checker.check_model(finetuned)
+
+
+def test_finetune_generates_calibration_data_when_omitted():
+    K, H, Out = 8, 16, 4
+    model = _mlp_model(K=K, H=H, Out=Out, seed=12)
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    finetuned = onnxsim.apply_pruning_finetune(model, pruned, num_samples=16, seed=0)
+    onnx.checker.check_model(finetuned)
+
+
+# --- unit tests for the module's own private helpers ------------------------
+
+
+def test_find_keep_indices_recovers_exact_subsequence():
+    orig = np.arange(30).reshape(10, 3).astype(np.float64)
+    keep = np.array([1, 3, 4, 8])
+    pruned = orig[keep]
+    found = _find_keep_indices(orig, pruned)
+    np.testing.assert_array_equal(found, keep)
+
+
+def test_find_keep_indices_declines_on_mismatched_content():
+    rng = np.random.default_rng(0)
+    orig = rng.standard_normal((10, 3))
+    pruned = rng.standard_normal((4, 3))  # unrelated rows
+    assert _find_keep_indices(orig, pruned) is None
+
+
+def test_find_keep_indices_declines_when_pruned_is_larger():
+    orig = np.arange(12).reshape(4, 3).astype(np.float64)
+    pruned = np.arange(18).reshape(6, 3).astype(np.float64)
+    assert _find_keep_indices(orig, pruned) is None
+
+
+def test_find_channel_correspondence_output_axis_only():
+    rng = np.random.default_rng(1)
+    w_orig = rng.standard_normal((10, 4))
+    keep_out = np.array([0, 2, 5, 9])
+    w_pruned = w_orig[keep_out]
+    found_out, found_in = _find_channel_correspondence(w_orig, w_pruned)
+    np.testing.assert_array_equal(found_out, keep_out)
+    np.testing.assert_array_equal(found_in, np.arange(4))
+
+
+def test_find_channel_correspondence_input_axis_only():
+    rng = np.random.default_rng(2)
+    w_orig = rng.standard_normal((5, 10))
+    keep_in = np.array([1, 2, 6, 7, 8])
+    w_pruned = w_orig[:, keep_in]
+    found_out, found_in = _find_channel_correspondence(w_orig, w_pruned)
+    np.testing.assert_array_equal(found_out, np.arange(5))
+    np.testing.assert_array_equal(found_in, keep_in)
+
+
+def test_find_channel_correspondence_declines_both_axes_pruned():
+    rng = np.random.default_rng(3)
+    w_orig = rng.standard_normal((10, 10))
+    w_pruned = w_orig[np.ix_([0, 2, 4, 6], [1, 3, 5, 7])]
+    found_out, found_in = _find_channel_correspondence(w_orig, w_pruned)
+    assert found_out is None
+    assert found_in is None
+
+
+def test_ridge_fit_matches_unregularized_least_squares_oracle():
+    rng = np.random.default_rng(4)
+    num_samples, K, N = 200, 6, 3
+    x = rng.standard_normal((num_samples, K))
+    w_true = rng.standard_normal((N, K))
+    b_true = rng.standard_normal(N)
+    y = x @ w_true.T + b_true
+
+    w0 = rng.standard_normal((N, K))  # far from optimal -- reg_param -> 0
+    b0 = rng.standard_normal(N)
+    w_fit, b_fit = _ridge_fit(x, y, w0, b0, reg_param=1e-10)
+
+    np.testing.assert_allclose(w_fit, w_true, rtol=1e-3, atol=1e-3)
+    np.testing.assert_allclose(b_fit, b_true, rtol=1e-3, atol=1e-3)
+
+
+def test_ridge_fit_pulls_toward_w0_with_no_calibration_signal():
+    rng = np.random.default_rng(5)
+    K, N = 6, 3
+    x = np.zeros((4, K))  # no signal at all
+    y = np.zeros((4, N))
+    w0 = rng.standard_normal((N, K))
+    b0 = rng.standard_normal(N)
+    # x contributes nothing to the Gram matrix's own K x K weight block --
+    # only the bias-augmented ones-column does -- so the regularized normal
+    # equations reduce to lam * w = lam * w0 for the weight part exactly,
+    # regardless of reg_param's magnitude, while the bias part still
+    # competes against the (nonzero, all-ones) bias column and only
+    # converges to b0 as reg_param grows large.
+    w_fit, b_fit = _ridge_fit(x, y, w0, b0, reg_param=1.0)
+    np.testing.assert_allclose(w_fit, w0)
+
+    w_fit_huge, b_fit_huge = _ridge_fit(x, y, w0, b0, reg_param=1e12)
+    np.testing.assert_allclose(w_fit_huge, w0)
+    np.testing.assert_allclose(b_fit_huge, b0, rtol=1e-6)
+
+
+def test_ridge_fit_without_bias():
+    rng = np.random.default_rng(6)
+    num_samples, K, N = 100, 5, 2
+    x = rng.standard_normal((num_samples, K))
+    w_true = rng.standard_normal((N, K))
+    y = x @ w_true.T
+    w0 = rng.standard_normal((N, K))
+    w_fit, b_fit = _ridge_fit(x, y, w0, None, reg_param=1e-10)
+    assert b_fit is None
+    np.testing.assert_allclose(w_fit, w_true, rtol=1e-3, atol=1e-3)

--- a/tests/test_optimize_pipeline.py
+++ b/tests/test_optimize_pipeline.py
@@ -224,6 +224,54 @@ def test_pipeline_applies_both_pruning_sub_stages_independently():
     onnx.checker.check_model(result.optimized_model)
 
 
+def _mlp_pipeline_model(K=8, H=32, Out=4, seed=0):
+    # A plain Gemm -> Relu -> MatMul chain -- apply_structured_pruning's own
+    # simplest target topology (no Conv im2col bookkeeping), and one of
+    # apply_pruning_finetune's own matched MatMul/Gemm consumer layers
+    # (see tests/test_finetune.py's own identically-shaped model).
+    rng = np.random.default_rng(seed)
+    w1 = rng.standard_normal((K, H)).astype(np.float32)
+    b1 = rng.standard_normal((H,)).astype(np.float32)
+    w2 = rng.standard_normal((H, Out)).astype(np.float32)
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          h = Gemm(X, W1, B1)
+          a = Relu(h)
+          Y = MatMul(a, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(b1, "B1"), _f32(w2, "W2")],
+    )
+
+
+def test_pipeline_applies_pruning_finetune_stage_after_structured_pruning():
+    model = _mlp_pipeline_model(K=8, H=32, Out=4, seed=40)
+    rng = np.random.default_rng(41)
+    calibration_data = [{"X": rng.standard_normal((256, 8)).astype(np.float32)}]
+
+    result = onnxsim.apply_optimization_pipeline(
+        model,
+        accuracy_budget=1.0,
+        calibration_data=calibration_data,
+        sparsity=0.5,
+    )
+    assert result.stages_applied[:2] == ["structured_pruning", "pruning_finetune"]
+    onnx.checker.check_model(result.optimized_model)
+
+
+def test_pipeline_without_pruning_skips_pruning_finetune_stage():
+    model = _gemm_model(seed=42)
+    rng = np.random.default_rng(43)
+    calibration_data = [{"X": rng.standard_normal((8, 64)).astype(np.float32)}]
+
+    result = onnxsim.apply_optimization_pipeline(
+        model, accuracy_budget=1.0, calibration_data=calibration_data
+    )
+    assert "pruning_finetune" not in result.stages_applied
+
+
 def test_pipeline_with_wanda_pruning_method_applies_structured_wanda_pruning_stage():
     model = _conv_and_gemm_model(seed=30)
     rng = np.random.default_rng(31)


### PR DESCRIPTION
## Summary

- Adds `onnxsim/finetune.py` (`apply_pruning_finetune`): closed-form, layer-wise ridge-regression fine-tuning that recovers accuracy lost to structured/attention-head pruning. Follows this codebase's established "capture real activations, solve locally" idiom (`adaround.py`, `bias_correction.py`) rather than any generic autodiff/backprop framework.
  - For every MatMul/Gemm layer present (by node output name) in both the pre-pruning and pruned models, reconstructs that layer's own surviving channel indices via exact (bit-identical) subsequence matching, then refits the weight (and bias) as a ridge-regression solve against the *original* model's own real calibration activations.
  - Exact, not approximate, for a single pass: since pruning only deletes channels and never changes a surviving channel's value, the pruned model's own pre-finetune activations are exactly derivable from the original model alone — the pruned model itself never needs to be executed.
  - A layer pruned on *both* its input and output axes at once (an ambiguous inverse problem) is conservatively declined and left untouched, documented in the module's own docstring.
- Wires `apply_pruning_finetune` into `apply_optimization_pipeline` as a new stage, run right after either pruning sub-stage (`attention_sparsity`/`sparsity`) when one actually ran. Kept only if it doesn't measurably worsen the post-pruning float model's own accuracy — the same "try it, keep only if not worse" gate stage 6's own double-quantization compression already uses.
- Exports `apply_pruning_finetune` from `onnxsim/__init__.py`.

## Test plan

- [x] New `tests/test_finetune.py` (17 tests): oracle-verified ridge-regression fit, exact channel-correspondence recovery (output-axis-only, input-axis-only, declined dual-axis), end-to-end reconstruction error reduction after structured pruning, no-op cases, file-path inputs, default random calibration data.
- [x] New tests in `tests/test_optimize_pipeline.py`: `pruning_finetune` stage applied after `structured_pruning` when `sparsity` is given; skipped when no pruning stage ran.
- [x] `ruff check` / `ruff format --check` pass on all changed/new files.
- [x] Full test suite (`pytest tests/`, excluding the torch/timm-gated files): 1129 passed, 87 skipped, 0 failed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FAiv55epkSMz7NPXD4r97u)_