### PR TITLE
Add MXFP4 GGUF decode + gpt-oss-20b architecture support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -584,6 +584,12 @@ if (ONNXSIM_TESTS)
   target_include_directories(ggml_kquant_test PRIVATE onnxsim)
   add_test(NAME ggml_kquant_test COMMAND ggml_kquant_test)
 
+  # GGML MXFP4 dequantization (ggml_mxfp4.h) -- same standalone-buildable
+  # dependency footprint as ggml_kquant_test above.
+  add_executable(ggml_mxfp4_test onnxsim/ggml_mxfp4_test.cpp)
+  target_include_directories(ggml_mxfp4_test PRIVATE onnxsim)
+  add_test(NAME ggml_mxfp4_test COMMAND ggml_mxfp4_test)
+
   # TensorPool's GGUF read/write (tensor_pool_gguf.cpp) depends only on
   # tensor_pool.{h,cpp} and gguf_dtype.h, so it too builds and runs
   # standalone without ONNX / ONNX Runtime configured.

--- a/docs/import-gguf-weights.md
+++ b/docs/import-gguf-weights.md
@@ -79,39 +79,52 @@ graph's structure.
 
 ## Mixture-of-experts (MoE) checkpoints
 
-llama.cpp's own GGUF convention for a MoE model's per-expert feed-forward
-weights lines up with `com.microsoft.MoE`'s layout without any extra work,
-for the three families checked (Mixtral, Qwen3-MoE, gpt-oss): the tensors
-are named `blk.N.ffn_gate_exps.weight` / `blk.N.ffn_up_exps.weight` /
-`blk.N.ffn_down_exps.weight` (gate=`fc1_experts_weights`, up=
-`fc3_experts_weights`, down=`fc2_experts_weights` -- see
-`contrib_schemas.cpp`'s `BuildMoEFunctionBody` comment for that naming) and
-`blk.N.ffn_gate_inp.weight` for the router. Their GGML shapes, reversed by
-this function's existing (rank-agnostic) `ne[]`-order rule, land exactly on
-`com.microsoft.MoE`'s own `fc1_experts_weights`/`fc2_experts_weights`/
-`fc3_experts_weights` shapes -- no additional transpose needed, because
-GGML's per-expert matrix already uses the same `[in, out]` convention as an
-ordinary 2D linear weight (which this function already round-trips
-correctly), just with an extra leading expert axis. K-quant blocks apply to
-the flattened element stream regardless of tensor rank, so the existing
-decoder needs no MoE-specific change either -- see
-`tests/test_import_gguf_weights.py`'s
+llama.cpp's own GGUF convention for a Mixtral-style MoE model's per-expert
+feed-forward weights lines up with `com.microsoft.MoE`'s Mixtral-style
+(`activation_type="silu"` + separate `fc3`) layout without any extra work:
+the tensors are named `blk.N.ffn_gate_exps.weight` /
+`blk.N.ffn_up_exps.weight` / `blk.N.ffn_down_exps.weight` (gate=
+`fc1_experts_weights`, up=`fc3_experts_weights`, down=`fc2_experts_weights`
+-- see `contrib_schemas.cpp`'s `BuildMoEFunctionBody` comment for that
+naming) and `blk.N.ffn_gate_inp.weight` for the router. Their GGML shapes,
+reversed by this function's existing (rank-agnostic) `ne[]`-order rule,
+land exactly on `com.microsoft.MoE`'s own `fc1_experts_weights`/
+`fc2_experts_weights`/`fc3_experts_weights` shapes -- no additional
+transpose needed, because GGML's per-expert matrix already uses the same
+`[in, out]` convention as an ordinary 2D linear weight (which this function
+already round-trips correctly), just with an extra leading expert axis.
+K-quant/MXFP4 blocks apply to the flattened element stream regardless of
+tensor rank, so the existing decoder needs no MoE-specific change either --
+see `tests/test_import_gguf_weights.py`'s
 `test_import_gguf_weights_hydrates_a_moe_node_with_llama_cpp_names` for an
 end-to-end round trip through a real `com.microsoft.MoE` node.
 
-One real gap remains, reported by simple absence from the model (there is
-no matching initializer for `import_gguf_weights` to report as `skipped`
-in the first place) rather than silently mishandled: some newer llama.cpp
-architectures, including official gpt-oss releases, fuse the gate and up
-projections into one `ffn_gate_up_exps` tensor instead of two separate ones
--- there is no 1:1 initializer to hydrate that into (the same fused-layout
-gap `swiglu_fusion` has in the reference decomposition itself). Bridging a
-real gpt-oss checkpoint (which keeps gate/up as the two separate
-`ffn_gate_exps`/`ffn_up_exps` tensors, each MXFP4-quantized and individually
-decodable by this function) into `com.microsoft.MoE`'s single interleaved
-`swiglu_fusion=1` buffer needs an explicit cross-tensor fusion step beyond
-`import_gguf_weights`' simple 1:1 name-matching contract -- not implemented
-here.
+**gpt-oss is different**: it keeps gate/up as the same two separate
+`ffn_gate_exps`/`ffn_up_exps` tensors (verified directly against
+`llama.cpp/src/models/openai-moe.cpp`'s `load_arch_tensors` -- there is no
+single fused tensor anywhere in a real gpt-oss GGUF file), but each one is
+individually decodable by this function exactly like Mixtral's (MXFP4 or
+K-quant, doesn't matter). What's genuinely different is which
+`com.microsoft.MoE` reference decomposition applies: gpt-oss needs the
+`activation_type="swiglu"`/`swiglu_fusion=1` one (added alongside the MXFP4
+decoder above), which expects ONE interleaved fc1 tensor, not two separate
+ones. `import_gguf_weights` alone -- simple 1:1 name-matching -- cannot
+build that interleaved tensor; `onnxsim.reconstruct_gguf_graph`'s `gpt-oss`
+architecture template (see the next section) does this as ordinary ONNX
+graph ops (`Reshape`/`Concat`/`Reshape`) at graph-construction time, which
+`onnxsim.simplify()` later constant-folds away for free. A caller building
+their own gpt-oss graph from scratch (rather than going through
+`reconstruct_gguf_graph`) would need to do the same interleave themselves
+before calling `import_gguf_weights` -- this function still has no
+built-in way to fuse two named tensors into one on a caller's behalf.
+
+Some newer llama.cpp architectures fuse the gate and up projections into
+one `ffn_gate_up_exps` tensor *in the GGUF file itself* instead of two
+separate ones -- a genuinely different, still-unaddressed case (there is no
+1:1 initializer for `import_gguf_weights` to hydrate that into at all, and
+no matching GGUF tensor for it to report as `skipped` either, since the
+absence is simply invisible from a caller's own two-separate-initializer
+graph). gpt-oss is not an example of this -- see above.
 
 ## Why not reconstruct the whole model from the GGUF file?
 
@@ -125,14 +138,27 @@ problem of getting a checkpoint's *weight values* into a graph you already
 have, regardless of architecture.
 
 `onnxsim.reconstruct_gguf_graph` (see `onnxsim/gguf_reconstruct.py`) takes
-the other approach for a small, curated set of recognized architectures --
-currently the Llama family (`llama`, `qwen2`, `mistral`, which share the
-same RMSNorm/RoPE/GQA/SwiGLU block shape): it builds the graph itself from
-the checkpoint's declared hyperparameters, then calls
-`import_gguf_weights` internally to hydrate it. No MoE architecture has a
-template there yet -- the "MoE checkpoints" section above is about
-`import_gguf_weights` alone, for a MoE graph you already built or exported
-some other way.
+the other approach for a small, curated set of recognized architectures: it
+builds the graph itself from the checkpoint's declared hyperparameters,
+then calls `import_gguf_weights` internally to hydrate it.
+
+- The Llama family (`llama`, `qwen2`, `mistral`, which share the same
+  RMSNorm/RoPE/GQA block shape) -- either a plain SwiGLU FFN, or, when
+  `expert_count > 0` (a Mixtral-style checkpoint), the Mixtral-style
+  `com.microsoft.MoE` node described above.
+- `gpt-oss` -- a genuinely different architecture (YaRN-scaled RoPE,
+  alternating sliding-window/full attention with attention sinks, and an
+  always-MoE FFN using the `swiglu_fusion=1` decomposition, gate/up fused
+  from the checkpoint's two separate tensors as described above). See
+  `onnxsim/gguf_reconstruct.py`'s module docstring and
+  `_reconstruct_gpt_oss`'s own docstring for exactly which llama.cpp source
+  every detail (tensor names, hardcoded activation constants, the
+  gating-function equivalence, YaRN's exact formula) was verified against.
+
+For any OTHER architecture (including one whose GGUF file fuses gate/up
+into a single `ffn_gate_up_exps` tensor -- the still-unaddressed case noted
+above), the "MoE checkpoints" section above is about `import_gguf_weights`
+alone, for a MoE graph you already built or exported some other way.
 
 ## Tests
 

--- a/docs/import-gguf-weights.md
+++ b/docs/import-gguf-weights.md
@@ -37,36 +37,41 @@ being overwritten with bytes that don't fit its declared shape. This does
 **not** include tensors simply absent from `model`'s initializers, which
 are silently left alone.
 
-## GGML "K-quant" support
+## GGML "K-quant" and MXFP4 support
 
 Real quantized checkpoints store most of their weights as one of GGML's
 block-quantized formats, not plain float. This function decodes the
 **K-quant** family -- `Q4_K`, `Q5_K`, `Q6_K` (256-element super-blocks, each
 with its own packed 6-bit per-sub-block scale/min pair) and `Q8_0`
 (32-element blocks, one fp16 scale each) -- which is what Unsloth's `*_K_M`/
-`*_K_S`/`Q8_0` GGUF exports actually use for the bulk of their tensors. Every
-block layout and dequantization formula is transcribed directly from GGML's
-own reference implementation
+`*_K_S`/`Q8_0` GGUF exports actually use for the bulk of their tensors, plus
+**MXFP4** (32-element blocks, one shared power-of-two E8M0 exponent byte and
+16 bytes of packed 4-bit e2m1-style codes) -- the OCP Microscaling FP4 format
+official gpt-oss GGUF releases use natively for their MoE expert weights.
+Every block layout and dequantization formula is transcribed directly from
+GGML's own reference implementation
 (https://github.com/ggml-org/ggml -- `ggml-common.h`'s block structs,
-`ggml-quants.c`'s `dequantize_row_q*` functions) and cross-checked against an
+`ggml-quants.c`'s `dequantize_row_q*`/`dequantize_row_mxfp4` functions,
+`ggml-impl.h`'s `ggml_e8m0_to_fp32_half`) and cross-checked against an
 independent from-scratch re-implementation over full random blocks before
-being committed (see `onnxsim/ggml_kquant.h`'s file comment).
+being committed (see `onnxsim/ggml_kquant.h`'s and `onnxsim/ggml_mxfp4.h`'s
+file comments).
 
-A matched K-quant tensor's initializer has its `data_type` forced to
-`FLOAT` regardless of what `model` previously declared for it -- the
+A matched K-quant or MXFP4 tensor's initializer has its `data_type` forced
+to `FLOAT` regardless of what `model` previously declared for it -- the
 decoded values are only meaningful as float32.
 
 ## Scope
 
 Handled:
-- `Q4_K`, `Q5_K`, `Q6_K`, `Q8_0` -- decoded to float32.
+- `Q4_K`, `Q5_K`, `Q6_K`, `Q8_0`, `MXFP4` -- decoded to float32.
 - Any raw (already-unquantized) GGML type (`F32`, `F16`, `BF16`, `F64`,
   `I8`/`I16`/`I32`/`I64`) -- copied through unchanged, same as `import_gguf`.
 
 Not handled (reported in `skipped`, left untouched):
 - The legacy `Q4_0`/`Q4_1`/`Q5_0`/`Q5_1`/`Q8_1` family, `Q2_K`/`Q3_K`/`Q8_K`,
-  and every `IQ*` importance-matrix variant -- these have real, different
-  block layouts this decoder does not implement.
+  `NVFP4`, and every `IQ*` importance-matrix variant -- these have real,
+  different block layouts this decoder does not implement.
 
 Only an initializer whose *name* matches a GGUF tensor is ever touched;
 `import_gguf_weights` never adds new initializers or otherwise changes the
@@ -94,14 +99,19 @@ decoder needs no MoE-specific change either -- see
 `test_import_gguf_weights_hydrates_a_moe_node_with_llama_cpp_names` for an
 end-to-end round trip through a real `com.microsoft.MoE` node.
 
-Two real gaps remain, both reported via `skipped` (or simply absent from
-the model, in the second case) rather than silently mishandled:
-- Official gpt-oss GGUF releases quantize expert weights as **MXFP4**, not
-  one of the K-quant formats this decoder implements.
-- Some newer llama.cpp architectures fuse the gate and up projections into
-  one `ffn_gate_up_exps` tensor instead of two separate ones -- there is no
-  1:1 initializer to hydrate that into (the same fused-layout gap
-  `swiglu_fusion` has in the reference decomposition itself).
+One real gap remains, reported by simple absence from the model (there is
+no matching initializer for `import_gguf_weights` to report as `skipped`
+in the first place) rather than silently mishandled: some newer llama.cpp
+architectures, including official gpt-oss releases, fuse the gate and up
+projections into one `ffn_gate_up_exps` tensor instead of two separate ones
+-- there is no 1:1 initializer to hydrate that into (the same fused-layout
+gap `swiglu_fusion` has in the reference decomposition itself). Bridging a
+real gpt-oss checkpoint (which keeps gate/up as the two separate
+`ffn_gate_exps`/`ffn_up_exps` tensors, each MXFP4-quantized and individually
+decodable by this function) into `com.microsoft.MoE`'s single interleaved
+`swiglu_fusion=1` buffer needs an explicit cross-tensor fusion step beyond
+`import_gguf_weights`' simple 1:1 name-matching contract -- not implemented
+here.
 
 ## Why not reconstruct the whole model from the GGUF file?
 

--- a/onnxsim/ggml_mxfp4.h
+++ b/onnxsim/ggml_mxfp4.h
@@ -1,0 +1,122 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Dequantization for GGML's MXFP4 block format (gguf_dtype.h's IsMxfp4):
+ * decodes a tensor's native, still-packed GGML block bytes (see
+ * gguf_dtype.h's Mxfp4BlockBytes) into plain host-order float32 values.
+ *
+ * Pure, dependency-free (no protobuf, no onnx headers) like gguf_dtype.h and
+ * ggml_kquant.h -- operates on raw bytes and the same integer ggml_type
+ * codes, so this builds and unit-tests standalone.
+ *
+ * Block layout and dequantization formula transcribed verbatim from GGML's
+ * own reference implementation (https://github.com/ggml-org/ggml --
+ * ggml-common.h's block_mxfp4 struct and kvalues_fp4/kvalues_mxfp4 lookup
+ * table, ggml-quants.c's dequantize_row_mxfp4, and ggml-impl.h's
+ * ggml_e8m0_to_fp32_half). MXFP4 (the OCP Microscaling FP4 format --
+ * https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf)
+ * is structurally unrelated to the K-quant family ggml_kquant.h covers:
+ * instead of a linear affine (scale * code - min) reconstruction over
+ * consecutive-pair-packed nibbles, each 32-element block carries one shared
+ * power-of-two E8M0 exponent byte and 16 bytes of packed 4-bit codes
+ * indexing a small fixed lookup table of signed e2m1-style magnitudes, with
+ * elements j and j+16 of the block packed into the low and high nibble of
+ * byte j (not elements 2j/2j+1, as K-quant packs). This is gpt-oss-20b's
+ * real, shipping GGUF quantization for its MoE expert weights
+ * (`general.architecture=gpt-oss`).
+ */
+#ifndef ONNXSIM_GGML_MXFP4_H_
+#define ONNXSIM_GGML_MXFP4_H_
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include "gguf_dtype.h"
+
+namespace onnxsim {
+namespace tensor_pool {
+namespace gguf {
+
+// GGML's kvalues_fp4/kvalues_mxfp4 table (shared with NVFP4): the 16
+// possible decoded magnitudes a 4-bit MXFP4 code indexes, already doubled
+// (matching GGML's own table verbatim, and GgmlE8m0ToFloat32Half's halved
+// scale below) -- codes 0-7 are the non-negative e2m1 magnitudes {0, 0.5, 1,
+// 1.5, 2, 3, 4, 6} times 2, codes 8-15 their negated counterparts.
+inline constexpr int8_t kMxfp4Values[16] = {0, 1,  2,  3,  4,  6,  8,  12,
+                                            0, -1, -2, -3, -4, -6, -8, -12};
+
+// GGML's ggml_e8m0_to_fp32_half: decodes one E8M0 (8-bit unsigned power-of-
+// two) exponent byte to *half* the float32 value it nominally represents --
+// GGML halves here because kMxfp4Values above is already doubled, so the
+// product of the two reproduces the true e2m1 magnitude without needing a
+// fractional entry in either table. `x < 2` has no normal float32
+// representation of 2^(x-127), so those two smallest cases are written
+// directly as denormal float32 bit patterns; `x >= 2` computes the normal-
+// float32 exponent field directly. NaNs are not handled, mirroring GGML's
+// own implementation (an E8M0 byte of 0xFF, GGML's own only NaN encoding,
+// never appears in a real MXFP4 tensor's per-block scale).
+inline float GgmlE8m0ToFloat32Half(uint8_t x) {
+  uint32_t bits;
+  if (x == 0) {
+    bits = 0x00200000u;  // 2^(-128)
+  } else if (x == 1) {
+    bits = 0x00400000u;  // 2^(-127)
+  } else {
+    bits = static_cast<uint32_t>(x - 1) << 23;  // 0.5 * 2^(x-127) = 2^(x-128)
+  }
+  float f;
+  std::memcpy(&f, &bits, sizeof(f));
+  return f;
+}
+
+// Decodes one 17-byte MXFP4 block (32 elements) into `out`.
+inline void DequantizeMxfp4Block(const uint8_t* block, float* out) {
+  const float d = GgmlE8m0ToFloat32Half(block[0]);
+  const uint8_t* qs = block + 1;  // 16 bytes, 2 elements packed per byte.
+  for (int j = 0; j < 16; ++j) {
+    out[j] = static_cast<float>(kMxfp4Values[qs[j] & 0xF]) * d;
+    out[j + 16] = static_cast<float>(kMxfp4Values[qs[j] >> 4]) * d;
+  }
+}
+
+// Decodes `raw` (an IsMxfp4(ggml_type) tensor's native block bytes, exactly
+// `numel / 32 * 17` bytes long) into `numel` host-order float32 values,
+// appended to `out` (not cleared first). Returns false, leaving `out`
+// untouched, if `ggml_type` is not MXFP4, `numel` is not a multiple of 32,
+// or `raw_size` does not match the expected byte length for `numel`
+// elements (a corrupt/truncated buffer).
+inline bool DequantizeGgmlMxfp4(const uint8_t* raw, size_t raw_size,
+                                uint32_t ggml_type, int64_t numel,
+                                std::vector<float>* out) {
+  if (!IsMxfp4(ggml_type) || numel < 0) {
+    return false;
+  }
+  const size_t block_elems = Mxfp4BlockElements(ggml_type);
+  const size_t block_bytes = Mxfp4BlockBytes(ggml_type);
+  const uint64_t unumel = static_cast<uint64_t>(numel);
+  if (unumel % block_elems != 0) {
+    return false;
+  }
+  const uint64_t num_blocks = unumel / block_elems;
+  if (num_blocks * block_bytes != raw_size) {
+    return false;
+  }
+
+  const size_t out_start = out->size();
+  out->resize(out_start + unumel);
+  float* dst = out->data() + out_start;
+  const uint8_t* src = raw;
+  for (uint64_t b = 0; b < num_blocks; ++b) {
+    DequantizeMxfp4Block(src, dst);
+    src += block_bytes;
+    dst += block_elems;
+  }
+  return true;
+}
+
+}  // namespace gguf
+}  // namespace tensor_pool
+}  // namespace onnxsim
+
+#endif  // ONNXSIM_GGML_MXFP4_H_

--- a/onnxsim/ggml_mxfp4_test.cpp
+++ b/onnxsim/ggml_mxfp4_test.cpp
@@ -1,0 +1,147 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Standalone: g++ -std=c++20 ggml_mxfp4_test.cpp -o t && ./t
+ *
+ * Dependency-free unit test for ggml_mxfp4.h's GGML MXFP4 dequantization,
+ * mirroring ggml_kquant_test.cpp's style.
+ *
+ * The block layout/formula this decodes was cross-checked against GGML's
+ * own reference (ggml-common.h's block_mxfp4/kvalues_fp4, ggml-quants.c's
+ * dequantize_row_mxfp4, ggml-impl.h's ggml_e8m0_to_fp32_half) by hand for
+ * the exponent values used below. The cases here are small, hand-verifiable
+ * vectors (E8M0 bytes chosen so the decoded scale is an exact power of two
+ * with no float rounding to reason about), meant to catch a regression in
+ * this file specifically, not to re-derive GGML's spec from scratch.
+ */
+#include "ggml_mxfp4.h"
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace onnxsim::tensor_pool::gguf;
+
+namespace {
+
+int g_failures = 0;
+
+void Check(bool cond, const std::string& what) {
+  if (!cond) {
+    std::fprintf(stderr, "FAIL: %s\n", what.c_str());
+    ++g_failures;
+  }
+}
+
+void CheckNear(float got, float want, const std::string& what,
+               float tol = 1e-6f) {
+  Check(std::fabs(got - want) <= tol, what + " (got " + std::to_string(got) +
+                                          ", want " + std::to_string(want) +
+                                          ")");
+}
+
+// GgmlE8m0ToFloat32Half(x) is exactly a power of two for every x (see the
+// function's own derivation), so every case here is bit-exact -- no
+// tolerance needed beyond float rounding of the expected value itself.
+void TestGgmlE8m0ToFloat32Half() {
+  // GgmlE8m0ToFloat32Half(x) == 2^(x-128) for every x (see the function's
+  // own derivation) -- checked against std::ldexp(1.0f, x - 128), an
+  // independent standard-library computation of the same power of two.
+  for (int x = 0; x <= 254; x += 17) {
+    CheckNear(GgmlE8m0ToFloat32Half(static_cast<uint8_t>(x)),
+              std::ldexp(1.0f, x - 128),
+              "e8m0(" + std::to_string(x) + ") == 2^(" +
+                  std::to_string(x - 128) + ")",
+              0.0f);
+  }
+  // Named checkpoints for readability: x=127 -> 0.5, x=128 -> 1.0,
+  // x=129 -> 2.0.
+  CheckNear(GgmlE8m0ToFloat32Half(127), 0.5f, "e8m0(127) == 0.5", 0.0f);
+  CheckNear(GgmlE8m0ToFloat32Half(128), 1.0f, "e8m0(128) == 1.0", 0.0f);
+  CheckNear(GgmlE8m0ToFloat32Half(129), 2.0f, "e8m0(129) == 2.0", 0.0f);
+}
+
+// d = GgmlE8m0ToFloat32Half(128) = 1.0 exactly, so decoded values equal
+// kMxfp4Values[code] exactly -- no scale-multiplication rounding to reason
+// about. qs[0] = 0x21 packs code 1 (low nibble, element 0) and code 2 (high
+// nibble, element 16); qs[1] = 0x9A packs code 10 (low nibble, element 1)
+// and code 9 (high nibble, element 17). Every other qs byte is 0, so every
+// other element decodes to kMxfp4Values[0] * d = 0.
+void TestMxfp4Block() {
+  std::vector<uint8_t> block(Mxfp4BlockBytes(GGML_TYPE_MXFP4), 0);
+  Check(block.size() == 17, "MXFP4 block size is 17 bytes");
+  block[0] = 128;   // e8m0 scale byte -> d = 1.0
+  block[1] = 0x21;  // qs[0]: low nibble 1, high nibble 2
+  block[2] = 0x9A;  // qs[1]: low nibble 0xA=10, high nibble 9
+
+  float out[32];
+  DequantizeMxfp4Block(block.data(), out);
+  CheckNear(out[0], 1.0f, "MXFP4 element 0 (code 1)");
+  CheckNear(out[16], 2.0f, "MXFP4 element 16 (code 2)");
+  CheckNear(out[1], -2.0f, "MXFP4 element 1 (code 10 -> -2)");
+  CheckNear(out[17], -1.0f, "MXFP4 element 17 (code 9 -> -1)");
+  CheckNear(out[2], 0.0f, "MXFP4 element 2 (code 0)");
+  CheckNear(out[31], 0.0f, "MXFP4 element 31 (code 0)");
+
+  // Through the dispatcher too, for 2 concatenated blocks (64 elements).
+  std::vector<uint8_t> two_blocks = block;
+  two_blocks.insert(two_blocks.end(), block.begin(), block.end());
+  std::vector<float> dispatched;
+  Check(DequantizeGgmlMxfp4(two_blocks.data(), two_blocks.size(),
+                            GGML_TYPE_MXFP4, 64, &dispatched),
+        "DequantizeGgmlMxfp4(2 blocks) succeeds");
+  Check(dispatched.size() == 64, "DequantizeGgmlMxfp4 output size");
+  if (dispatched.size() == 64) {
+    CheckNear(dispatched[0], 1.0f, "MXFP4 dispatcher block 0 elem 0");
+    CheckNear(dispatched[32], 1.0f, "MXFP4 dispatcher block 1 elem 0");
+    CheckNear(dispatched[33], -2.0f, "MXFP4 dispatcher block 1 elem 1");
+  }
+}
+
+void TestDequantizeGgmlMxfp4RejectsBadInput() {
+  std::vector<uint8_t> block(Mxfp4BlockBytes(GGML_TYPE_MXFP4), 0);
+  std::vector<float> out;
+
+  // Not a multiple of the block size.
+  Check(!DequantizeGgmlMxfp4(block.data(), block.size(), GGML_TYPE_MXFP4, 33,
+                             &out),
+        "rejects non-block-aligned numel");
+
+  // raw_size doesn't match numel's expected byte length.
+  Check(!DequantizeGgmlMxfp4(block.data(), block.size() - 1, GGML_TYPE_MXFP4,
+                             32, &out),
+        "rejects mismatched raw_size");
+
+  // Not MXFP4 at all (F32 -- a raw type, not a block-quantized one).
+  Check(
+      !DequantizeGgmlMxfp4(block.data(), block.size(), GGML_TYPE_F32, 32, &out),
+      "rejects non-MXFP4 ggml_type");
+
+  // Also not MXFP4: a K-quant type.
+  Check(!DequantizeGgmlMxfp4(block.data(), block.size(), GGML_TYPE_Q8_0, 32,
+                             &out),
+        "rejects K-quant ggml_type");
+
+  // Negative numel.
+  Check(!DequantizeGgmlMxfp4(block.data(), block.size(), GGML_TYPE_MXFP4, -1,
+                             &out),
+        "rejects negative numel");
+
+  Check(out.empty(), "no partial output written on any rejected call");
+}
+
+}  // namespace
+
+int main() {
+  TestGgmlE8m0ToFloat32Half();
+  TestMxfp4Block();
+  TestDequantizeGgmlMxfp4RejectsBadInput();
+
+  if (g_failures == 0) {
+    std::printf("ggml_mxfp4_test: all checks passed\n");
+    return 0;
+  }
+  std::fprintf(stderr, "ggml_mxfp4_test: %d failure(s)\n", g_failures);
+  return 1;
+}

--- a/onnxsim/gguf_dtype.h
+++ b/onnxsim/gguf_dtype.h
@@ -40,6 +40,15 @@
  * DequantizeGgmlKQuant, wired into tensor_pool_bridge.h's
  * HydrateTensorProto, always decodes to ONNX_FLOAT before a pooled K-quant
  * entry reaches a TensorProto a caller can observe.
+ *
+ * SECOND EXCEPTION -- MXFP4 (see IsMxfp4/ggml_mxfp4.h): gpt-oss-20b's own
+ * native GGUF quantization for its MoE expert weights. Structurally
+ * unrelated to the K-quant family above (a different, OCP-Microscaling-
+ * derived block layout and code table, not a scale/min affine
+ * reconstruction), so it gets its own predicate and block-size helpers
+ * rather than folding into IsKQuant, but is otherwise handled the same way:
+ * its own ONNXSIM_GGML_MXFP4 private dtype code, native block bytes carried
+ * verbatim until ggml_mxfp4.h's DequantizeGgmlMxfp4 decodes it to float32.
  */
 #ifndef ONNXSIM_GGUF_DTYPE_H_
 #define ONNXSIM_GGUF_DTYPE_H_
@@ -101,6 +110,7 @@ enum GgmlType : uint32_t {
   GGML_TYPE_I64 = 27,
   GGML_TYPE_F64 = 28,
   GGML_TYPE_BF16 = 30,
+  GGML_TYPE_MXFP4 = 39,
 };
 
 // --- ONNX dtype <-> ggml_type (raw types only; see the file comment) ------
@@ -123,15 +133,16 @@ enum OnnxDtype : int32_t {
 
 // Private, onnxsim-fork-only dtype codes an Entry::dtype (or a TensorProto
 // this loader briefly produces before HydrateTensorProto decodes it away --
-// see the file comment) may hold for a still-packed GGML K-quant tensor.
-// Chosen from a range (10000+) with no plausible collision against ONNX's
-// own DataType enum (defined up to 26 as of this writing -- see
-// onnx.in.proto); never reassign or reuse one of these four values.
+// see the file comment) may hold for a still-packed GGML K-quant or MXFP4
+// tensor. Chosen from a range (10000+) with no plausible collision against
+// ONNX's own DataType enum (defined up to 26 as of this writing -- see
+// onnx.in.proto); never reassign or reuse one of these five values.
 enum OnnxsimPrivateDtype : int32_t {
   ONNXSIM_GGML_Q4_K = 10001,
   ONNXSIM_GGML_Q5_K = 10002,
   ONNXSIM_GGML_Q6_K = 10003,
   ONNXSIM_GGML_Q8_0 = 10004,
+  ONNXSIM_GGML_MXFP4 = 10005,
 };
 
 // Bytes of one element. 0 for a ggml_type this mapping doesn't cover
@@ -216,6 +227,28 @@ inline size_t KQuantBlockBytes(uint32_t ggml_type) {
   }
 }
 
+// True for GGML's MXFP4 block format (the OCP Microscaling FP4 spec) --
+// gpt-oss-20b's own native GGUF quantization for its MoE expert weights.
+// Structurally unrelated to the K-quant family IsKQuant covers: a 32-element
+// block sharing one power-of-two E8M0 exponent byte plus 16 bytes of packed
+// 4-bit codes indexing a small fixed e2m1-style magnitude table, with
+// element j and j+16 of the block packed into the low/high nibble of byte j
+// (not element 2j/2j+1, as K-quant's consecutive-pair packing does) -- see
+// ggml_mxfp4.h's DequantizeMxfp4Block for the exact formula.
+inline bool IsMxfp4(uint32_t ggml_type) { return ggml_type == GGML_TYPE_MXFP4; }
+
+// Elements per block for an IsMxfp4 ggml_type. 0 for anything else.
+inline size_t Mxfp4BlockElements(uint32_t ggml_type) {
+  return IsMxfp4(ggml_type) ? 32 : 0;
+}
+
+// Bytes per block for an IsMxfp4 ggml_type -- 1 (the shared E8M0 exponent
+// byte) + 16 (32 packed 4-bit codes) -- see block_mxfp4 in ggml's
+// ggml-common.h. 0 for anything else.
+inline size_t Mxfp4BlockBytes(uint32_t ggml_type) {
+  return IsMxfp4(ggml_type) ? 17 : 0;
+}
+
 // Map a ggml_type to its ONNX dtype code -- ONNXSIM_GGML_* (see that enum's
 // doc comment) for one of the four IsKQuant types, an ordinary ONNX_* code
 // for a raw type. Returns false (leaving `*out` untouched) for a quantized
@@ -259,20 +292,23 @@ inline bool ToOnnx(uint32_t ggml_type, int32_t* out) {
     case GGML_TYPE_Q8_0:
       *out = ONNXSIM_GGML_Q8_0;
       return true;
+    case GGML_TYPE_MXFP4:
+      *out = ONNXSIM_GGML_MXFP4;
+      return true;
     default:
       return false;
   }
 }
 
-// The exact byte length of an IsRaw or IsKQuant ggml_type tensor holding
-// `nelems` total elements -- generalizes the simple `nelems *
+// The exact byte length of an IsRaw, IsKQuant, or IsMxfp4 ggml_type tensor
+// holding `nelems` total elements -- generalizes the simple `nelems *
 // ElementSize(ggml_type)` a raw type alone would need, to also cover a
-// K-quant type's block-based sizing (`nelems / KQuantBlockElements *
-// KQuantBlockBytes`). Returns false (leaving `*out_nbytes` untouched) for a
-// ggml_type this mapping doesn't cover at all, or a K-quant type whose
-// `nelems` is not an exact multiple of its block size (a malformed or
-// truncated tensor -- every real K-quant tensor's element count is block-
-// aligned, since GGML itself requires each row to be).
+// block-quantized type's block-based sizing (`nelems / block_elems *
+// block_bytes`). Returns false (leaving `*out_nbytes` untouched) for a
+// ggml_type this mapping doesn't cover at all, or a block-quantized type
+// whose `nelems` is not an exact multiple of its block size (a malformed or
+// truncated tensor -- every real block-quantized tensor's element count is
+// block-aligned, since GGML itself requires each row to be).
 inline bool TryTotalBytes(uint32_t ggml_type, uint64_t nelems,
                           uint64_t* out_nbytes) {
   if (IsRaw(ggml_type)) {
@@ -289,17 +325,27 @@ inline bool TryTotalBytes(uint32_t ggml_type, uint64_t nelems,
                   static_cast<uint64_t>(KQuantBlockBytes(ggml_type));
     return true;
   }
+  if (IsMxfp4(ggml_type)) {
+    const uint64_t block_elems =
+        static_cast<uint64_t>(Mxfp4BlockElements(ggml_type));
+    if (nelems % block_elems != 0) {
+      return false;
+    }
+    *out_nbytes = (nelems / block_elems) *
+                  static_cast<uint64_t>(Mxfp4BlockBytes(ggml_type));
+    return true;
+  }
   return false;
 }
 
 // Inverse of ToOnnx. Returns false for an ONNX dtype with no raw ggml_type
 // counterpart (STRING, COMPLEX64/128, UNDEFINED, the unsigned int family --
 // ggml has no unsigned integer types at all, quantized or otherwise -- or
-// one of onnxsim's own custom dtypes this mapping doesn't cover). The four
+// one of onnxsim's own custom dtypes this mapping doesn't cover). The five
 // ONNXSIM_GGML_* codes DO round-trip here (unlike every other private dtype
-// a caller might construct): a pooled K-quant entry that still holds its
-// native, un-decoded block bytes (see the file comment) can always be
-// written back out to a real GGUF file bit-for-bit, the same as any other
+// a caller might construct): a pooled K-quant or MXFP4 entry that still
+// holds its native, un-decoded block bytes (see the file comment) can always
+// be written back out to a real GGUF file bit-for-bit, the same as any other
 // pooled dtype -- TensorPool::SaveGGUF relies on that.
 inline bool FromOnnx(int32_t onnx_dtype, uint32_t* out) {
   switch (onnx_dtype) {
@@ -338,6 +384,9 @@ inline bool FromOnnx(int32_t onnx_dtype, uint32_t* out) {
       return true;
     case ONNXSIM_GGML_Q8_0:
       *out = GGML_TYPE_Q8_0;
+      return true;
+    case ONNXSIM_GGML_MXFP4:
+      *out = GGML_TYPE_MXFP4;
       return true;
     default:
       return false;

--- a/onnxsim/gguf_dtype_test.cpp
+++ b/onnxsim/gguf_dtype_test.cpp
@@ -55,10 +55,10 @@ int main() {
   }
 
   // Quantized types this mapping does NOT decode (legacy Q4_0/Q4_1/Q5_0/
-  // Q5_1/Q8_1, Q2_K/Q3_K, Q8_K, IQ*_XXS/BF16-adjacent codes, ...) or
+  // Q5_1/Q8_1, Q2_K/Q3_K, Q8_K, IQ*_XXS/BF16-adjacent codes, NVFP4, ...) or
   // unrecognized types are rejected, not guessed at. Deliberately excludes
-  // 8/12/13/14 (Q8_0/Q4_K/Q5_K/Q6_K), which ARE supported -- see the
-  // k_quant_rows loop below.
+  // 8/12/13/14 (Q8_0/Q4_K/Q5_K/Q6_K) and 39 (MXFP4), which ARE supported --
+  // see the k_quant_rows loop and the MXFP4 checks below.
   const uint32_t quantized[] = {2, 3, 6, 7, 9, 10, 11, 15, 16, 20, 29, 9999};
   for (uint32_t q : quantized) {
     int32_t onnx = -1;
@@ -68,6 +68,8 @@ int main() {
           "IsRaw is false for quantized/unknown type " + std::to_string(q));
     Check(!IsKQuant(q),
           "IsKQuant is false for unsupported type " + std::to_string(q));
+    Check(!IsMxfp4(q),
+          "IsMxfp4 is false for unsupported type " + std::to_string(q));
     Check(ElementSize(q) == 0,
           "ElementSize is 0 for quantized/unknown type " + std::to_string(q));
     uint64_t nbytes = 0xFFFFFFFFFFFFFFFFull;
@@ -96,6 +98,7 @@ int main() {
   };
   for (const auto& row : k_quant_rows) {
     Check(IsKQuant(row.ggml), "IsKQuant(" + std::to_string(row.ggml) + ")");
+    Check(!IsMxfp4(row.ggml), "!IsMxfp4(" + std::to_string(row.ggml) + ")");
     Check(!IsRaw(row.ggml), "!IsRaw(" + std::to_string(row.ggml) + ")");
     Check(ElementSize(row.ggml) == 0,
           "ElementSize is 0 for K-quant type " + std::to_string(row.ggml));
@@ -121,6 +124,34 @@ int main() {
     Check(!TryTotalBytes(row.ggml, row.block_elems + 1, &nbytes),
           "TryTotalBytes rejects non-block-aligned nelems for " +
               std::to_string(row.ggml));
+  }
+
+  // MXFP4 -- structurally unrelated to the K-quant family above (its own
+  // predicate, its own block size: 32 elements per 17-byte block, not one of
+  // KQuantBlockElements/KQuantBlockBytes's four combinations), but otherwise
+  // exercised the same way: round-trips through ToOnnx/FromOnnx to its own
+  // private ONNXSIM_GGML_MXFP4 code, is not IsRaw or IsKQuant, and
+  // TryTotalBytes agrees with Mxfp4BlockElements/Mxfp4BlockBytes's block
+  // math.
+  Check(IsMxfp4(GGML_TYPE_MXFP4), "IsMxfp4(GGML_TYPE_MXFP4)");
+  Check(!IsKQuant(GGML_TYPE_MXFP4), "!IsKQuant(GGML_TYPE_MXFP4)");
+  Check(!IsRaw(GGML_TYPE_MXFP4), "!IsRaw(GGML_TYPE_MXFP4)");
+  Check(ElementSize(GGML_TYPE_MXFP4) == 0, "ElementSize(MXFP4) == 0");
+  Check(Mxfp4BlockElements(GGML_TYPE_MXFP4) == 32, "Mxfp4BlockElements == 32");
+  Check(Mxfp4BlockBytes(GGML_TYPE_MXFP4) == 17, "Mxfp4BlockBytes == 17");
+  {
+    int32_t onnx = -1;
+    Check(ToOnnx(GGML_TYPE_MXFP4, &onnx) && onnx == ONNXSIM_GGML_MXFP4,
+          "ToOnnx(MXFP4) == ONNXSIM_GGML_MXFP4");
+    uint32_t ggml_back = 0;
+    Check(FromOnnx(onnx, &ggml_back) && ggml_back == GGML_TYPE_MXFP4,
+          "FromOnnx(ToOnnx(MXFP4)) round-trips");
+
+    uint64_t nbytes = 0;
+    Check(TryTotalBytes(GGML_TYPE_MXFP4, 32 * 3, &nbytes) && nbytes == 17 * 3,
+          "TryTotalBytes(MXFP4, 3 blocks)");
+    Check(!TryTotalBytes(GGML_TYPE_MXFP4, 33, &nbytes),
+          "TryTotalBytes rejects non-block-aligned nelems for MXFP4");
   }
 
   // ONNX dtypes with no raw ggml counterpart (unsigned ints, BOOL, STRING,

--- a/onnxsim/gguf_reconstruct.py
+++ b/onnxsim/gguf_reconstruct.py
@@ -1,13 +1,28 @@
 """Reconstructs an ONNX graph *and* its weights directly from a GGUF LLM
 checkpoint, for a small set of recognized decoder-only transformer
-architectures (currently the Llama family: Llama/Llama2/Llama3, Mistral, and
-Qwen2, which all share the same block shape -- RMSNorm, rotary position
-embeddings, grouped-query attention, a per-layer feed-forward block that is
-either a plain SwiGLU FFN or, for a Mixtral-style checkpoint, a
-``com.microsoft.MoE`` node -- differing only in things
-:func:`read_gguf_metadata` already reports: head counts, RoPE base, whether
-q/k/v projections carry a bias, whether the LM head is tied to the token
-embedding, and whether ``expert_count`` marks the checkpoint as MoE).
+architectures:
+
+- The Llama family (Llama/Llama2/Llama3, Mistral, and Qwen2), which all
+  share the same block shape -- RMSNorm, rotary position embeddings,
+  grouped-query attention, a per-layer feed-forward block that is either a
+  plain SwiGLU FFN or, for a Mixtral-style checkpoint, a
+  ``com.microsoft.MoE`` node -- differing only in things
+  :func:`read_gguf_metadata` already reports: head counts, RoPE base,
+  whether q/k/v projections carry a bias, whether the LM head is tied to
+  the token embedding, and whether ``expert_count`` marks the checkpoint as
+  MoE. Built by :func:`_reconstruct_llama_family`.
+- ``gpt-oss`` (OpenAI's gpt-oss-20b/120b), a genuinely different
+  architecture with no shared block shape with the family above: YaRN-
+  scaled RoPE, alternating sliding-window/full attention layers with a
+  learned per-head "attention sink" folded into the softmax denominator,
+  and an always-MoE FFN using ``com.microsoft.MoE``'s
+  ``activation_type="swiglu"``/``swiglu_fusion=1`` reference decomposition
+  (gate/up fused from llama.cpp's own separate ``ffn_gate_exps``/
+  ``ffn_up_exps`` tensors at graph-build time). Built by
+  :func:`_reconstruct_gpt_oss`; see that function's and
+  :func:`_gpt_oss_attention_block`'s/:func:`_gpt_oss_moe_ffn`'s own
+  docstrings for exactly which llama.cpp source (a real, offline
+  ``src/models/openai-moe.cpp`` checkout) confirmed every detail.
 
 Mixtral-style MoE: llama.cpp gives a Mixtral checkpoint the same
 ``general.architecture`` ("llama") as any dense Llama checkpoint --
@@ -17,7 +32,13 @@ same, dispatching to :func:`_moe_ffn`'s ``com.microsoft.MoE`` node (the
 reference decomposition registered for that schema in
 ``onnxsim/contrib_schemas.cpp``) instead of the plain FFN. See
 :func:`_moe_ffn`'s own docstring for exactly which llama.cpp source
-confirmed this maps onto that decomposition unchanged.
+confirmed this maps onto that decomposition unchanged. ``gpt-oss`` is
+always MoE (``general.architecture`` alone identifies it, no
+``expert_count`` sniffing needed) and always uses the ``swiglu`` activation
+rather than Mixtral's ``silu``+separate-``fc3`` -- see
+:func:`_gpt_oss_moe_ffn`'s own docstring for why these are mathematically
+compatible with the same schema's gating convention despite gpt-oss's own
+gating function being nominally different on paper.
 
 This is deliberately the "known architecture template" approach, not a
 generic GGUF/ggml graph-structure reconstructor: vLLM and SGLang's own GGUF
@@ -103,9 +124,14 @@ _ONNX_DTYPE_ITEMSIZE = {
     onnx.TensorProto.INT64: 8,
 }
 
-# general.architecture values this builder recognizes -- all share the same
-# block shape (RMSNorm/RoPE/GQA/SwiGLU); see the module docstring.
-_SUPPORTED_ARCHITECTURES = ("llama", "qwen2", "mistral")
+# general.architecture values this builder recognizes. "llama"/"qwen2"/
+# "mistral" share the same Llama-family block shape (RMSNorm/RoPE/GQA/
+# SwiGLU) and are built by _reconstruct_llama_family; "gpt-oss" is a
+# distinct architecture (YaRN-scaled RoPE, alternating sliding-window/full
+# attention with attention sinks, and a swiglu_fusion=1 MoE FFN) built by
+# _reconstruct_gpt_oss -- see the module docstring and each function's own
+# docstring.
+_SUPPORTED_ARCHITECTURES = ("llama", "qwen2", "mistral", "gpt-oss")
 
 
 class UnsupportedArchitectureError(NotImplementedError):
@@ -287,6 +313,633 @@ def _moe_ffn(
         domain="com.microsoft",
         k=n_expert_used,
         activation_type="silu",
+        normalize_routing_weights=1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# gpt-oss attention block -- standalone, NOT wired into
+# _reconstruct_llama_family, _SUPPORTED_ARCHITECTURES, or
+# reconstruct_gguf_graph's dispatch. Produced independently of this module's
+# MoE/FFN half (see _moe_ffn/_reconstruct_llama_family's own FFN branch,
+# which a sibling change handles for gpt-oss's Mixture-of-Experts FFN) so
+# the two can be reviewed/wired in separately.
+#
+# Verified directly against a local llama.cpp clone (the commit checked out
+# under /home/user/llama.cpp at the time this was written) -- specifically:
+#   - src/models/openai-moe.cpp: llama_model_openai_moe's
+#     load_arch_hparams/load_arch_tensors/graph ctor -- the actual gpt-oss
+#     graph builder and tensor shapes/names.
+#   - src/llama-graph.cpp: build_attn_mha (the shared softmax+sinks kernel
+#     every build_attn_* variant calls into) and
+#     llm_graph_input_attn_no_cache::set_input (the causal/SWA mask fill,
+#     "fill_mask" lambda).
+#   - src/llama-hparams.cpp/.h: set_swa_pattern (the alternating-layer
+#     pattern), is_masked_swa's LLAMA_SWA_TYPE_STANDARD case (the banded
+#     window rule).
+#   - src/llama-arch.cpp: LLM_ARCH_OPENAI_MOE's tensor-name map
+#     (LLM_TENSOR_ATTN_SINKS -> "blk.%d.attn_sinks") and its LLM_KV_*
+#     metadata key strings (attention.sliding_window[_pattern],
+#     attention.key_length/value_length, rope.scaling.*); and
+#     src/llama-model.cpp's rope-type classification switch, which puts
+#     LLM_ARCH_OPENAI_MOE in the "pairs of head values are offset by
+#     n_rot/2" (LLAMA_ROPE_TYPE_NEOX) group -- the same rotate-half
+#     convention _rotate_half/_apply_rope above already implement, so gpt-oss
+#     needs no different rotation *shape*, only a different theta/scale
+#     schedule (YaRN) and mask/sink treatment.
+#   - src/llama-context.cpp (llama_context's cparams derivation -- how
+#     yarn_ext_factor/yarn_attn_factor fall out of rope_scaling_type==yarn)
+#     and ggml/src/ggml.c + ggml/src/ggml-cpu/ops.cpp
+#     (ggml_rope_yarn_corr_dims, rope_yarn/ggml_rope_cache_init, and
+#     ggml_compute_forward_soft_max_f32's sink handling) for the exact
+#     numeric formulas transcribed below.
+#   - conversion/gpt_oss.py + conversion/base.py: what a real gpt-oss
+#     checkpoint's HF-to-GGUF conversion actually *writes* -- confirms which
+#     of the generic mechanisms above this specific architecture actually
+#     exercises (e.g. that no real gpt-oss GGUF sets a SWA-specific RoPE
+#     freq_base override or a non-default sliding_window_pattern).
+# and openai/gpt-oss-20b's own config.json on the Hugging Face Hub (fetched
+# directly for this work, not recalled from memory) for the concrete
+# hyperparameter values cited in the comments below (head_dim=64 vs
+# embedding_length/head_count=2880/64=45 -- i.e. head_dim is NOT
+# embedding_length/head_count for this architecture, unlike every
+# _SUPPORTED_ARCHITECTURES entry today; layer_types alternating
+# sliding_attention/full_attention starting at layer 0; sliding_window=128;
+# rope_scaling type "yarn" with factor=32, beta_fast=32, beta_slow=1,
+# original_max_position_embeddings=4096; rope_theta=150000).
+#
+# Corrections to the brief this was scoped from:
+#   - The attention-sink formula is NOT "append a per-head sink logit as an
+#     extra column, then drop that column's weight before the value
+#     matmul". It is folded into the softmax denominator only, and a sink
+#     "column" is never materialized against V at all -- see
+#     _gpt_oss_attention_block's own docstring for the exact kernel-level
+#     formula this was read off of.
+#   - "Possibly a distinct RoPE scaling scheme" is confirmed, not merely
+#     possible: gpt-oss-20b's real config.json uses YaRN (rope_scaling.type
+#     == "yarn"), not a bare freq_base RoPE -- see _gpt_oss_yarn_cos_sin.
+#   - RoPE's own freq_base/freq_scale are NOT windowed per sliding-vs-full
+#     layer for gpt-oss specifically (only the attention mask is) -- see
+#     _gpt_oss_attention_block's docstring for why, so a single cos/sin pair
+#     is computed once and reused across every layer, exactly like
+#     _reconstruct_llama_family already does for the plain-RoPE case.
+# ---------------------------------------------------------------------------
+
+
+def _gpt_oss_is_sliding_layer(layer_idx: int, swa_period: int) -> bool:
+    """Mirrors llama-hparams.cpp's ``set_swa_pattern(n_pattern,
+    dense_first=false)`` -- the default gpt-oss always uses (see
+    src/models/openai-moe.cpp's ``load_arch_hparams``, which never passes
+    ``dense_first=true``)::
+
+        is_swa_impl[il] = n_pattern == 0 || (il % n_pattern < (n_pattern - 1))
+
+    For gpt-oss's period of 2 (the hardcoded default in
+    ``load_arch_hparams`` -- no real gpt-oss GGUF sets
+    ``{arch}.attention.sliding_window_pattern``, since
+    ``conversion/gpt_oss.py`` never calls ``add_sliding_window_pattern``),
+    this alternates sliding/local at even layer indices (0, 2, 4, ...) and
+    full/global at odd ones -- confirmed against openai/gpt-oss-20b's own
+    ``config.json`` on the HF Hub, whose ``layer_types`` list literally
+    starts ``["sliding_attention", "full_attention", ...]``.
+    """
+    return swa_period == 0 or (layer_idx % swa_period) < (swa_period - 1)
+
+
+def _gpt_oss_attn_mask(seq_len: int, sliding: bool, n_swa: int) -> np.ndarray:
+    """A causal (``sliding=False``) or banded causal-plus-sliding-window
+    (``sliding=True``) additive attention mask, ``[seq_len, seq_len]``
+    float32, ``-1e9`` where disallowed and ``0`` where allowed.
+
+    Mirrors ``llm_graph_input_attn_no_cache::set_input``'s ``fill_mask``
+    lambda in llama-graph.cpp (gpt-oss sets no ALiBi, so that lambda's
+    ``hparams.use_alibi ? -abs(p0-p1) : 0.0f`` collapses to plain ``0.0f``
+    for every allowed cell) combined with
+    ``llama_hparams::is_masked_swa``'s ``LLAMA_SWA_TYPE_STANDARD`` case --
+    the SWA type gpt-oss's own ``load_arch_hparams`` hardcodes
+    (``hparams.swa_type = LLAMA_SWA_TYPE_STANDARD``) -- which masks a
+    (key pos p0, query pos p1) pair when ``p1 - p0 >= n_swa``, i.e. allows
+    exactly the ``n_swa`` most recent key positions up to and including the
+    query position itself.
+    """
+    q_pos = np.arange(seq_len)[:, None]
+    k_pos = np.arange(seq_len)[None, :]
+    diff = q_pos - k_pos
+    allowed = diff >= 0
+    if sliding:
+        allowed = allowed & (diff < n_swa)
+    return np.where(allowed, 0.0, -1e9).astype(np.float32)
+
+
+def _gpt_oss_yarn_cos_sin(
+    b: _Builder,
+    position_ids: str,
+    head_dim: int,
+    freq_base: float,
+    yarn_factor: float,
+    yarn_orig_ctx: float,
+    yarn_beta_fast: float,
+    yarn_beta_slow: float,
+    prefix: str,
+) -> Tuple[str, str]:
+    """YaRN-scaled RoPE cos/sin, each ``[batch, 1, seq, head_dim]`` --
+    transcribed from ggml/src/ggml.c's ``ggml_rope_yarn_corr_dims`` (the
+    ``low``/``high`` correction-dimension bounds) and
+    ggml/src/ggml-cpu/ops.cpp's ``rope_yarn``/``ggml_rope_cache_init`` (the
+    per-frequency-bin ramp mix and magnitude scale), with the
+    context-parameter-level ``yarn_attn_factor`` derivation in
+    src/llama-context.cpp folded in algebraically: that code computes a
+    ``cparams``-level attention-scale factor specifically so it cancels
+    back out against ``rope_yarn``'s own
+    ``mscale *= 1 + 0.1*log(1/freq_scale)`` for every model except
+    DeepSeek-V2 (which sets a nonzero ``rope_yarn_log_mul`` -- gpt-oss does
+    not), so the *net* magnitude scale actually reaching gpt-oss's RoPE is
+    exactly the textbook YaRN ``mscale`` below, not the intermediate value
+    either source file computes standalone.
+
+    ``ext_factor`` (how much of the ramp mix applies) is only ever 1.0 or
+    0.0 in llama.cpp when not explicitly overridden by a caller
+    (``cparams.yarn_ext_factor = rope_scaling_type == YARN ? 1.0f : 0.0f``,
+    src/llama-context.cpp) -- nothing in gpt-oss's own graph/model code
+    overrides it -- so this only implements that fixed ext_factor=1 case
+    (the one a real gpt-oss GGUF's ``rope.scaling.type=yarn`` metadata
+    always selects). It degenerates correctly to plain RoPE when
+    ``yarn_factor<=1.0``: freq_scale becomes 1.0 so the interpolated and
+    extrapolated angles coincide regardless of the ramp, and mscale's
+    ``scale<=1`` branch is exactly 1.0 -- matching every
+    _SUPPORTED_ARCHITECTURES checkpoint's plain-RoPE behavior today.
+
+    Only full rotary (``n_rot == head_dim``) is implemented, matching
+    gpt-oss's own tensor shapes (no partial-rotary GGUF key is read for
+    it) and this module's existing partial-rotary rejection elsewhere.
+    """
+    half = head_dim // 2
+    freq_idx = np.arange(half, dtype=np.float64)
+    inv_freq = 1.0 / (freq_base ** (2.0 * freq_idx / head_dim))
+
+    def corr_dim(n_rot: float) -> float:
+        # ggml_rope_yarn_corr_dim: n_dims * log(n_ctx_orig / (n_rot * 2pi))
+        # / (2 * log(base)) -- n_dims is head_dim here (full rotary).
+        return (
+            head_dim
+            * math.log(yarn_orig_ctx / (n_rot * 2.0 * math.pi))
+            / (2.0 * math.log(freq_base))
+        )
+
+    low = max(0.0, math.floor(corr_dim(yarn_beta_fast)))
+    high = min(float(head_dim - 1), math.ceil(corr_dim(yarn_beta_slow)))
+    # rope_yarn_ramp(low, high, i0), evaluated at i0 = 2*freq_idx (ggml's
+    # cache-fill loop steps i0 by 2, and only ever calls it with i0/2 ==
+    # freq_idx): ramp==1 fully "extrapolated" (short-range, low-freq-index
+    # dims), ramp==0 fully "interpolated" (long-range, high-freq-index
+    # dims).
+    ramp = 1.0 - np.clip((freq_idx - low) / max(1e-3, high - low), 0.0, 1.0)
+
+    freq_scale = 1.0 / yarn_factor
+    # theta(j) = pos * inv_freq[j] * weight[j], where weight[j] blends the
+    # scaled ("interpolated") and unscaled ("extrapolated") angle per
+    # rope_yarn's `theta = theta_interp*(1-ramp_mix) + theta_extrap*ramp_mix`
+    # (ramp_mix == ramp here since ext_factor == 1) -- algebraically the
+    # same theta since theta_interp/theta_extrap both factor as
+    # pos*inv_freq[j]*{freq_scale,1}.
+    weight = freq_scale * (1.0 - ramp) + ramp
+    # rope_yarn's `mscale *= 1 + 0.1*log(1/freq_scale)`, applied only when
+    # ext_factor != 0 (true here) -- this IS the net mscale reaching
+    # gpt-oss's RoPE; see this function's own docstring for why the
+    # cparams-level factor llama-context.cpp separately computes is not
+    # double-counted here.
+    mscale = 1.0 if yarn_factor <= 1.0 else 0.1 * math.log(yarn_factor) + 1.0
+
+    inv_freq_scaled_c = b.const(
+        (inv_freq * weight).reshape(1, 1, -1).astype(np.float32),
+        prefix=f"{prefix}.inv_freq",
+    )
+    mscale_c = b.const(np.array(mscale, dtype=np.float32), prefix=f"{prefix}.mscale")
+
+    pos_f = b.op("Cast", [position_ids], f"{prefix}.pos_f", to=onnx.TensorProto.FLOAT)
+    pos_unsq = _unsqueeze(b, pos_f, [-1], f"{prefix}.pos_unsq")
+    freqs = b.op("Mul", [pos_unsq, inv_freq_scaled_c], f"{prefix}.freqs")
+    emb = b.op("Concat", [freqs, freqs], f"{prefix}.emb", axis=-1)
+    cos_raw = b.op("Cos", [emb], f"{prefix}.cos_raw")
+    sin_raw = b.op("Sin", [emb], f"{prefix}.sin_raw")
+    cos = b.op("Mul", [cos_raw, mscale_c], f"{prefix}.cos")
+    sin = b.op("Mul", [sin_raw, mscale_c], f"{prefix}.sin")
+    cos_b = _unsqueeze(b, cos, [1], f"{prefix}.cos_b")
+    sin_b = _unsqueeze(b, sin, [1], f"{prefix}.sin_b")
+    return cos_b, sin_b
+
+
+def _gpt_oss_attention_block(
+    b: _Builder,
+    x: str,
+    p: str,
+    layer_idx: int,
+    n_embd: int,
+    n_head: int,
+    n_head_kv: int,
+    head_dim: int,
+    cos_b: str,
+    sin_b: str,
+    sliding_window: int,
+    swa_period: int,
+    batch_size: int,
+    seq_len: int,
+    eps: float,
+    declare,
+    declare_optional,
+) -> str:
+    """One gpt-oss transformer layer's attention sub-block: RMSNorm through
+    the post-output-projection residual add. Structurally mirrors
+    ``_reconstruct_llama_family``'s plain-GQA attention block (lines
+    ~458-524 as of this writing), reusing the same helpers
+    (``_rmsnorm``/``_linear``/``_apply_rope``/``_unsqueeze``), but differs
+    in three ways gpt-oss's own tensors/graph require:
+
+    1. Q/K/V/O projection shapes are NOT derived from
+       ``n_embd``/``n_head`` the way every _SUPPORTED_ARCHITECTURES entry's
+       shapes are today. gpt-oss's own ``head_dim`` is an independent GGUF
+       metadata value (``{arch}.attention.key_length`` /
+       ``.value_length``, generically read the same as any other
+       architecture that sets it -- see conversion/base.py writing both
+       from HF's ``head_dim`` config key) that is NOT
+       ``embedding_length // head_count``: gpt-oss-20b's own config has
+       ``head_dim=64`` while ``embedding_length/head_count = 2880/64 =
+       45`` -- a different, smaller number. So ``attn_q.weight``'s GGUF
+       shape is ``[n_head*head_dim, n_embd]`` (reversed to the ONNX-shape
+       ``[n_head*head_dim, n_embd]`` -- see ``declare``'s own note; here
+       "reversed" changes nothing since it's still 2-D) rather than
+       ``[n_embd, n_embd]``, and ``attn_output.weight`` is
+       ``[n_embd, n_head*head_dim]`` rather than ``[n_embd, n_embd]`` --
+       see src/llama-model.cpp's ``create_tensor_qkv``/
+       src/models/openai-moe.cpp's ``layer.wo`` construction.
+
+    2. The additive attention mask alternates between a plain causal mask
+       (odd ``layer_idx``) and a banded causal-plus-sliding-window mask of
+       width ``sliding_window`` (even ``layer_idx``) -- see
+       ``_gpt_oss_is_sliding_layer``/``_gpt_oss_attn_mask`` for the exact
+       llama.cpp source this reproduces. ``cos_b``/``sin_b`` are NOT
+       recomputed per layer type: gpt-oss copies its SWA-layer RoPE
+       freq_base/freq_scale from the non-SWA values before ever reading an
+       optional per-layer override key (src/models/openai-moe.cpp's
+       ``load_arch_hparams``), and no real gpt-oss GGUF sets that override
+       (``conversion/gpt_oss.py`` never writes
+       ``{arch}.rope.freq_base_swa``) -- so the caller computes ONE
+       ``cos_b``/``sin_b`` pair (via ``_gpt_oss_yarn_cos_sin``) and passes
+       it in for every layer, exactly like
+       ``_reconstruct_llama_family`` already does for the plain case.
+
+    3. Softmax gets an extra per-Q-head "attention sink" term folded into
+       its denominator. Per-head sink values live in GGUF tensor
+       ``{p}.attn_sinks.weight`` (note the ``.weight`` suffix on what is
+       actually a plain learned vector, not a matrix -- see
+       ``conversion/gpt_oss.py``'s ``filter_tensors`` explicitly appending
+       it, and src/llama-arch.cpp's ``LLM_TENSOR_ATTN_SINKS`` ->
+       ``"blk.%d.attn_sinks"`` map), shape ``[n_head]`` (one scalar per
+       Q head, reshaped here to broadcast against the ``[n_head_kv,
+       n_rep]``-split GQA score tensor the same way this module's existing
+       broadcasting-GQA scheme already splits Q's head axis). The exact
+       formula, read off ggml/src/ggml-cpu/ops.cpp's
+       ``ggml_compute_forward_soft_max_f32``'s sink branch (reached via
+       src/llama-graph.cpp's ``build_attn_mha`` ->
+       ``ggml_soft_max_add_sinks``): for each row of *masked, scaled*
+       logits ``s`` and that row's head's sink scalar ``k``,
+       ``m = max(max(s), k)``; ``softmax_i = exp(s_i - m) / (sum_j
+       exp(s_j - m) + exp(k - m))``. The sink term participates in the
+       row max and the normalizing sum ONLY -- it is never concatenated as
+       an actual extra key/value position and never contributes to the
+       value-weighted sum (``dp``, the kernel's actual softmax-weight
+       output array, has exactly ``n_kv`` entries; the sink's
+       ``exp(k-m)`` term only ever appears added into the scalar
+       denominator each of those entries is divided by). This corrects
+       the "append a column, then drop its weight before the value
+       matmul" framing this was scoped from -- no column is ever
+       materialized against V at all.
+    """
+    resid = x
+    h = _rmsnorm(
+        b, x, declare(f"{p}.attn_norm.weight", [n_embd]), eps, f"{p}.attn_norm"
+    )
+
+    n_embd_q = n_head * head_dim
+    n_embd_kv = n_head_kv * head_dim
+    q = _linear(
+        b,
+        h,
+        declare(f"{p}.attn_q.weight", [n_embd_q, n_embd]),
+        declare_optional(f"{p}.attn_q.bias", [n_embd_q]),
+        f"{p}.q_proj",
+    )
+    k = _linear(
+        b,
+        h,
+        declare(f"{p}.attn_k.weight", [n_embd_kv, n_embd]),
+        declare_optional(f"{p}.attn_k.bias", [n_embd_kv]),
+        f"{p}.k_proj",
+    )
+    v = _linear(
+        b,
+        h,
+        declare(f"{p}.attn_v.weight", [n_embd_kv, n_embd]),
+        declare_optional(f"{p}.attn_v.bias", [n_embd_kv]),
+        f"{p}.v_proj",
+    )
+
+    def reshape(t: str, dims: List[int], prefix: str) -> str:
+        return b.op("Reshape", [t, b.shape_const(dims)], prefix)
+
+    q = reshape(q, [batch_size, seq_len, n_head, head_dim], f"{p}.q_r")
+    q = b.op("Transpose", [q], f"{p}.q_t", perm=[0, 2, 1, 3])
+    k = reshape(k, [batch_size, seq_len, n_head_kv, head_dim], f"{p}.k_r")
+    k = b.op("Transpose", [k], f"{p}.k_t", perm=[0, 2, 1, 3])
+    v = reshape(v, [batch_size, seq_len, n_head_kv, head_dim], f"{p}.v_r")
+    v = b.op("Transpose", [v], f"{p}.v_t", perm=[0, 2, 1, 3])
+
+    q = _apply_rope(b, q, cos_b, sin_b, head_dim, f"{p}.q_rope")
+    k = _apply_rope(b, k, cos_b, sin_b, head_dim, f"{p}.k_rope")
+
+    # Grouped-query attention via broadcasting -- identical scheme to
+    # _reconstruct_llama_family's (see that function's own comment).
+    n_rep = n_head // n_head_kv
+    q5 = reshape(q, [batch_size, n_head_kv, n_rep, seq_len, head_dim], f"{p}.q5")
+    k5 = _unsqueeze(b, k, [2], f"{p}.k5")
+    v5 = _unsqueeze(b, v, [2], f"{p}.v5")
+
+    k5t = b.op("Transpose", [k5], f"{p}.k5t", perm=[0, 1, 2, 4, 3])
+    scores = b.op("MatMul", [q5, k5t], f"{p}.scores")
+    inv_sqrt_d = b.const(
+        np.array(1.0 / math.sqrt(head_dim), dtype=np.float32),
+        prefix=f"{p}.inv_sqrt_d",
+    )
+    scores = b.op("Mul", [scores, inv_sqrt_d], f"{p}.scores_scaled")
+
+    sliding = _gpt_oss_is_sliding_layer(layer_idx, swa_period)
+    mask_c = b.const(
+        _gpt_oss_attn_mask(seq_len, sliding, sliding_window),
+        prefix=f"{p}.attn_mask",
+    )
+    scores = b.op("Add", [scores, mask_c], f"{p}.scores_masked")
+
+    # Attention sinks: fold a per-head learned scalar into the softmax
+    # denominator only (see this function's own docstring, point 3, for
+    # the exact formula/citation).
+    sinks = declare(f"{p}.attn_sinks.weight", [n_head])
+    sinks_b = reshape(sinks, [1, n_head_kv, n_rep, 1, 1], f"{p}.sinks_b")
+
+    row_max = b.op("ReduceMax", [scores], f"{p}.row_max", axes=[-1], keepdims=1)
+    row_max = b.op("Max", [row_max, sinks_b], f"{p}.row_max_sinks")
+    shifted = b.op("Sub", [scores, row_max], f"{p}.shifted")
+    exp_shifted = b.op("Exp", [shifted], f"{p}.exp_shifted")
+    # Unlike ReduceMax/ReduceMean, ReduceSum's `axes` has been a second
+    # *input* (not an attribute) since opset 13 -- see _unsqueeze's own
+    # comment on the analogous Unsqueeze migration.
+    reduce_axes_c = b.const(np.array([-1], dtype=np.int64), prefix=f"{p}.reduce_axes")
+    sum_exp = b.op(
+        "ReduceSum", [exp_shifted, reduce_axes_c], f"{p}.sum_exp", keepdims=1
+    )
+    sink_shifted = b.op("Sub", [sinks_b, row_max], f"{p}.sink_shifted")
+    sink_exp = b.op("Exp", [sink_shifted], f"{p}.sink_exp")
+    denom = b.op("Add", [sum_exp, sink_exp], f"{p}.denom")
+    attn = b.op("Div", [exp_shifted, denom], f"{p}.attn")
+
+    out5 = b.op("MatMul", [attn, v5], f"{p}.attn_out5")
+    out = reshape(out5, [batch_size, n_head, seq_len, head_dim], f"{p}.out_r")
+    out = b.op("Transpose", [out], f"{p}.out_t", perm=[0, 2, 1, 3])
+    out = reshape(out, [batch_size, seq_len, n_embd_q], f"{p}.out_flat")
+    out = _linear(
+        b,
+        out,
+        declare(f"{p}.attn_output.weight", [n_embd, n_embd_q]),
+        declare_optional(f"{p}.attn_output.bias", [n_embd]),
+        f"{p}.o_proj",
+    )
+    return b.op("Add", [resid, out], f"{p}.attn_resid")
+
+
+def _interleave_gate_up(
+    b: _Builder,
+    gate: str,
+    up: str,
+    n_expert: int,
+    n_ff: int,
+    trailing: List[int],
+    prefix: str,
+) -> str:
+    """Repacks two separately-stored per-expert tensors (GGUF's own
+    ``ffn_gate_exps``/``ffn_up_exps`` convention -- see
+    :func:`_gpt_oss_moe_ffn`'s docstring) into the single, column-
+    interleaved tensor ``com.microsoft.MoE``'s ``swiglu_fusion=1`` reference
+    decomposition expects for ``fc1_experts_weights``/``fc1_experts_bias``:
+    row (or, for the 2D bias case, column) ``2*i`` of the fused tensor is
+    expert-local row ``i`` of `gate`, ``2*i+1`` is row ``i`` of `up` --
+    exactly the ``h1[:, 0::2]``/``h1[:, 1::2]`` de-interleaving
+    ``BuildMoEFunctionBody``'s generated function body (see
+    ``scripts/codegen/generate_moe_function_templates.py``'s
+    ``_swiglu_activation_lines``) undoes at runtime.
+
+    Implemented as ``Reshape`` (insert a size-1 axis right after the
+    per-expert row axis) -> ``Concat`` (stack gate/up along that new axis)
+    -> ``Reshape`` (flatten the row axis back down, twice as long) rather
+    than a strided ``Scatter``/interleave op that ONNX has no direct op
+    for. This exact reshape/concat/reshape sequence -- and specifically
+    that row-major flattening of a trailing ``(n_ff, 2)`` pair of axes
+    really does put `gate`'s row ``i`` at flat row ``2*i`` and `up`'s at
+    ``2*i+1``, not the other way around or interleaved some other way --
+    was checked two ways before being relied on here: an independent numpy
+    ``fused[..., 0::2, ...] = gate; fused[..., 1::2, ...] = up`` reference,
+    and a real onnxruntime CPU session running exactly these ops (see
+    ``tests/test_gguf_reconstruct.py``'s
+    ``test_gate_up_interleave_matches_independent_numpy_reference``).
+
+    `gate`/`up` are both shaped ``[n_expert, n_ff] + trailing`` (`trailing`
+    is ``[n_embd]`` for the two weight tensors, ``[]`` for the two 1D-per-
+    expert bias tensors) -- `trailing` is a parameter rather than hardcoded
+    so this one helper serves both cases identically. Like ``_linear``'s
+    weight Transpose, this whole reshape/concat/reshape chain runs on
+    initializers only, so a later ``onnxsim.simplify()`` constant-folds it
+    away for free once `gate`/`up` are actually hydrated by
+    ``import_gguf_weights`` -- it costs nothing at runtime once simplified.
+    """
+    split_shape = [n_expert, n_ff, 1] + trailing
+    fused_shape = [n_expert, 2 * n_ff] + trailing
+    g = b.op("Reshape", [gate, b.shape_const(split_shape)], f"{prefix}.g")
+    u = b.op("Reshape", [up, b.shape_const(split_shape)], f"{prefix}.u")
+    cat = b.op("Concat", [g, u], f"{prefix}.cat", axis=2)
+    return b.op("Reshape", [cat, b.shape_const(fused_shape)], prefix)
+
+
+def _gpt_oss_moe_ffn(
+    b: _Builder,
+    h: str,
+    p: str,
+    n_embd: int,
+    n_ff: int,
+    n_expert: int,
+    n_expert_used: int,
+    declare,
+    declare_optional,
+) -> str:
+    """A gpt-oss-20b-style MoE feed-forward block, as one
+    ``com.microsoft.MoE`` node using the ``activation_type="swiglu"``,
+    ``swiglu_fusion=1`` reference decomposition (as opposed to
+    :func:`_moe_ffn`'s Mixtral-style ``activation_type="silu"`` + separate
+    ``fc3`` one) -- confirmed against a real (offline, sparse-checked-out)
+    llama.cpp clone, not inferred from the schema docs alone:
+
+    * Tensor names/shapes: ``llama.cpp/src/models/openai-moe.cpp``'s
+      ``load_arch_tensors`` -- gpt-oss stores gate/up as two SEPARATE
+      per-expert tensors, ``blk.N.ffn_gate_exps.weight``/
+      ``blk.N.ffn_up_exps.weight`` (GGML shape ``{n_embd, n_ff_exp,
+      n_expert}`` each, reversing -- via `declare`'s existing rule, same as
+      :func:`_moe_ffn` -- onto ``[n_expert, n_ff, n_embd]``), NOT a single
+      pre-fused tensor; there is no fused tensor anywhere in the GGUF file.
+      Unlike Mixtral, gpt-oss also stores a REQUIRED (not
+      ``TENSOR_NOT_REQUIRED`` -- see ``llama-model-loader.h``'s
+      ``create_tensor`` flag argument, passed as ``0`` for every one of
+      these in ``load_arch_tensors``) bias for every one of router/gate/
+      up/down: ``blk.N.ffn_gate_inp.bias`` (``[n_expert]``),
+      ``blk.N.ffn_gate_exps.bias``/``blk.N.ffn_up_exps.bias`` (GGML
+      ``{n_ff_exp, n_expert}``, reversing to ``[n_expert, n_ff]``), and
+      ``blk.N.ffn_down_exps.bias`` (GGML ``{n_embd, n_expert}``, reversing
+      to ``[n_expert, n_embd]``) -- declared here via `declare_optional`
+      rather than `declare` purely as defense-in-depth against a
+      non-standard checkpoint; a real one always has them. Note gpt-oss
+      reports its expert intermediate size under a DIFFERENT GGUF key than
+      the dense case, ``<arch>.expert_feed_forward_length``
+      (``LLM_KV_EXPERT_FEED_FORWARD_LENGTH`` in ``llama-arch.cpp``), not
+      ``<arch>.feed_forward_length`` -- this function takes the already-
+      resolved `n_ff` as a plain argument, so it is the caller's job (not
+      done here, since this function is not wired into any dispatch yet)
+      to read the right key. ``general.architecture`` for this family is
+      ``"gpt-oss"`` (``LLM_ARCH_OPENAI_MOE`` in ``llama-arch.cpp``).
+
+    * fc1 fusion: ``com.microsoft.MoE``'s ``swiglu_fusion=1`` decomposition
+      needs ONE ``fc1_experts_weights`` tensor,
+      ``[n_expert, 2*n_ff, n_embd]``, gate/up interleaved row by row (see
+      :func:`_interleave_gate_up`'s own docstring for exactly how and how
+      that was verified) -- built here as ordinary graph ops from the two
+      separate GGUF tensors, matching ``fc1_experts_bias``
+      (``[n_expert, 2*n_ff]``) the same way. This is a graph-construction
+      convenience, not something llama.cpp's own graph builder does --
+      llama.cpp's ``build_moe_ffn`` (``llama-graph.cpp``) keeps gate/up as
+      two separate ``mul_mat_id`` calls and calls ``ggml_swiglu_oai(gate,
+      up, alpha, limit)`` on the pair directly (see below); the interleave
+      exists purely so this maps onto ONNX Runtime's actual CPU MoE kernel,
+      whose constructor (``onnxruntime/contrib_ops/cpu/moe/moe_cpu.cc``)
+      throws unless ``swiglu_fusion == 1`` for a SwiGLU node. Interleaving
+      first and then de-interleaving via the generated function body's own
+      strided ``Slice`` is a repacking, not a reordering of any actual
+      values, so it changes nothing numerically.
+
+    * Activation constants: ``llama.cpp/src/models/openai-moe.cpp``'s
+      ``build_moe_ffn`` call passes ``type_op=LLM_FFN_SWIGLU_OAI_MOE``;
+      ``llama-graph.cpp``'s ``LLM_FFN_SWIGLU_OAI_MOE`` case (the per-expert
+      branch, ~line 2226) hardcodes ``alpha=1.702f``/``limit=7.0f`` as
+      local ``constexpr``s -- NOT read from GGUF metadata, confirming the
+      caller's assumption -- and calls ``ggml_swiglu_oai(cur, up, alpha,
+      limit)``, whose CPU kernel
+      (``ggml/src/ggml-cpu/ops.cpp``'s ``ggml_compute_forward_swiglu_oai_f32``)
+      computes ``x = min(gate, limit); y = clamp(up, -limit, limit);
+      out = x / (1 + exp(-alpha*x)) * (y + 1.0)`` -- i.e. beta=1.0,
+      hardcoded the same way (there is no separate beta parameter/variable
+      at all; it's the literal ``+ 1.f`` in that line). This is
+      byte-for-byte the same formula
+      ``scripts/codegen/generate_moe_function_templates.py``'s
+      ``_swiglu_activation_lines`` builds for ``swiglu_fusion=1`` (gate
+      clamped with `Min` only, linear/up clamped both ways, same swish*
+      (linear+beta) shape) -- so ``activation_alpha=1.702``,
+      ``activation_beta=1.0``, ``swiglu_limit=7.0`` are exactly right.
+
+    * Gating: gpt-oss uses ``gating_op=LLAMA_EXPERT_GATING_FUNC_TYPE_SOFTMAX_WEIGHT``
+      (hardcoded in the ``build_moe_ffn`` call, not a GGUF-configurable
+      hparam for this architecture), which ``llama-graph.cpp``'s
+      ``build_moe_ffn`` (~line 1997) implements as: skip any softmax over
+      *all* experts (``probs = logits`` unchanged), pick the top-k experts
+      by raw logit value, gather their raw logits as `weights`, then
+      ``ggml_soft_max`` over just those `k` selected values (~line 2077) --
+      i.e. softmax is applied AFTER top-k, over only the selected experts'
+      logits, not before over all of them. ``norm_w`` (the extra
+      sum-and-divide renormalization step, ~line 2082) is passed as
+      ``false`` for gpt-oss, but is mathematically a no-op here regardless
+      (a softmax's own output already sums to 1, so dividing by that sum
+      changes nothing outside of the meaningless case the sum underflows
+      the routine's own ``6.103515625e-5`` floor).
+
+      ``com.microsoft.MoE``'s own routing (see
+      ``generate_moe_function_templates.py``'s routing-section comment,
+      and :func:`_moe_ffn`'s own docstring) is instead: softmax over ALL
+      experts, top-k selection of the resulting probabilities, then --
+      only when ``normalize_routing_weights=1`` -- renormalize the
+      selected probabilities by their own sum. This is a DIFFERENT
+      computation on paper, but is mathematically IDENTICAL to gpt-oss's
+      real gating, re-derived from scratch here (not just trusted from an
+      earlier, unverified pass): softmax is a strictly monotonic
+      (order-preserving) function of its input, so the set of top-k
+      experts selected by raw logit is exactly the set selected by
+      softmax-over-all-experts probability -- the same experts either way.
+      For a selected expert ``i`` among the top-k set ``S``, softmax-over-
+      all gives probability ``p_i = exp(logit_i) / Z`` where
+      ``Z = sum over ALL experts``. Renormalizing over ``S`` gives
+      ``p_i / sum_{j in S} p_j = [exp(logit_i)/Z] / [sum_{j in S}
+      exp(logit_j)/Z] = exp(logit_i) / sum_{j in S} exp(logit_j)`` -- the
+      ``Z`` cancels completely -- which is EXACTLY
+      ``softmax(logit_S)_i``, i.e. gpt-oss's own "softmax after top-k,
+      over only the selected logits" weight. So gpt-oss's gating needs NO
+      special wiring beyond what :func:`_moe_ffn` already does for
+      Mixtral: raw router logits straight into ``router_probs``,
+      ``normalize_routing_weights=1``. (This is the one place this
+      docstring confirms, rather than merely repeats, an assumption
+      supplied up front -- the derivation above was redone independently
+      against the real ``build_moe_ffn`` source read above, not copied
+      from an unverified earlier claim.)
+
+    Not wired into :func:`_reconstruct_llama_family` or
+    ``_SUPPORTED_ARCHITECTURES`` -- this is a standalone building block
+    only, for a caller to integrate once gpt-oss's attention block (sliding
+    -window pattern, attention sinks, RoPE scaling) also has a home there.
+    """
+    router_w = declare(f"{p}.ffn_gate_inp.weight", [n_expert, n_embd])
+    router_b = declare_optional(f"{p}.ffn_gate_inp.bias", [n_expert])
+    logits = _linear(b, h, router_w, router_b, f"{p}.moe_router")
+    router_probs = b.op(
+        "Reshape",
+        [logits, b.shape_const([-1, n_expert])],
+        f"{p}.moe_router_flat",
+    )
+
+    gate_w = declare(f"{p}.ffn_gate_exps.weight", [n_expert, n_ff, n_embd])
+    up_w = declare(f"{p}.ffn_up_exps.weight", [n_expert, n_ff, n_embd])
+    down_w = declare(f"{p}.ffn_down_exps.weight", [n_expert, n_embd, n_ff])
+    gate_b = declare_optional(f"{p}.ffn_gate_exps.bias", [n_expert, n_ff])
+    up_b = declare_optional(f"{p}.ffn_up_exps.bias", [n_expert, n_ff])
+    down_b = declare_optional(f"{p}.ffn_down_exps.bias", [n_expert, n_embd])
+
+    if (gate_b is None) != (up_b is None):
+        raise UnsupportedArchitectureError(
+            f"checkpoint has exactly one of '{p}.ffn_gate_exps.bias'/"
+            f"'{p}.ffn_up_exps.bias' -- both or neither are required to "
+            "build the fused fc1 bias swiglu_fusion=1 needs"
+        )
+
+    fc1_w = _interleave_gate_up(
+        b, gate_w, up_w, n_expert, n_ff, [n_embd], f"{p}.moe_fc1_w"
+    )
+    fc1_b = (
+        _interleave_gate_up(b, gate_b, up_b, n_expert, n_ff, [], f"{p}.moe_fc1_b")
+        if gate_b is not None
+        else ""
+    )
+
+    return b.op(
+        "MoE",
+        [h, router_probs, fc1_w, fc1_b, down_w, down_b or ""],
+        f"{p}.moe",
+        domain="com.microsoft",
+        k=n_expert_used,
+        activation_type="swiglu",
+        swiglu_fusion=1,
+        activation_alpha=1.702,
+        activation_beta=1.0,
+        swiglu_limit=7.0,
         normalize_routing_weights=1,
     )
 
@@ -582,13 +1235,285 @@ def _reconstruct_llama_family(
     return graph
 
 
+def _reconstruct_gpt_oss(meta: dict, batch_size: int, seq_len: int) -> onnx.GraphProto:
+    """Builds gpt-oss-20b's real per-layer structure directly from a GGUF
+    checkpoint: RMSNorm -> ``_gpt_oss_attention_block`` (YaRN-scaled RoPE,
+    alternating sliding-window/full masking, attention sinks) -> RMSNorm ->
+    ``_gpt_oss_moe_ffn`` (a ``swiglu_fusion=1`` ``com.microsoft.MoE`` node
+    with fc1 fused at graph-build time from llama.cpp's own separate
+    ``ffn_gate_exps``/``ffn_up_exps`` tensors). A distinct architecture
+    family from :func:`_reconstruct_llama_family`'s (they share no block
+    shape beyond "decoder-only transformer"), verified directly against
+    ``llama.cpp/src/models/openai-moe.cpp``'s
+    ``llama_model_openai_moe::graph`` constructor -- see that file's
+    per-layer loop for the exact op sequence this reproduces.
+
+    One naming detail this integration step is specifically responsible
+    for getting right (neither ``_gpt_oss_attention_block`` nor
+    ``_gpt_oss_moe_ffn`` reads a norm tensor themselves): the tensor
+    normalizing FFN's input is GGUF-named ``blk.N.post_attention_norm.weight``
+    for this architecture (``LLM_TENSOR_ATTN_POST_NORM`` in
+    ``llama-arch.cpp``) -- NOT ``blk.N.ffn_norm.weight``, the name
+    ``_reconstruct_llama_family``'s architectures use for the
+    functionally-identical "norm right before the FFN" role. llama.cpp
+    itself has two different GGUF tensor names for that same role, and
+    gpt-oss uses the other one (openai-moe.cpp's graph ctor: the residual
+    add after attention happens BEFORE this norm, and the FFN's own
+    residual add happens after it -- i.e. this is a pre-FFN norm exactly
+    like ``ffn_norm`` elsewhere, just named differently in this file).
+
+    gpt-oss's expert-router details differ from
+    ``_reconstruct_llama_family``'s validated Mixtral case in ways specific
+    to this function: a required ``ffn_gate_inp.bias`` (Mixtral's router has
+    none), and expert intermediate size reported under a different GGUF key
+    (``expert_feed_forward_length``, not the dense ``feed_forward_length``
+    -- see ``LLM_KV_EXPERT_FEED_FORWARD_LENGTH`` in ``llama-arch.cpp``).
+    ``head_dim`` is likewise independent GGUF metadata
+    (``attention.key_length``/``.value_length``), not
+    ``embedding_length // head_count`` -- see
+    ``_gpt_oss_attention_block``'s own docstring, point 1.
+    """
+    kv = meta["kv"]
+    tensors = {t["name"]: t for t in meta["tensors"]}
+    arch = kv["general.architecture"]
+
+    def key(suffix: str):
+        return f"{arch}.{suffix}"
+
+    n_embd = int(kv[key("embedding_length")])
+    n_layer = int(kv[key("block_count")])
+    n_ff = int(kv[key("expert_feed_forward_length")])
+    n_head = int(kv[key("attention.head_count")])
+    n_head_kv = int(kv.get(key("attention.head_count_kv"), n_head))
+    eps = float(
+        kv.get(
+            key("attention.layer_norm_rms_epsilon"),
+            kv.get(key("attention.layer_norm_epsilon"), 1e-5),
+        )
+    )
+    freq_base = float(kv.get(key("rope.freq_base"), 10000.0))
+
+    if n_head % n_head_kv != 0:
+        raise UnsupportedArchitectureError(
+            f"{key('attention.head_count')}={n_head} is not a multiple of "
+            f"{key('attention.head_count_kv')}={n_head_kv} (grouped-query "
+            "attention requires an integer head-repeat factor)"
+        )
+
+    # gpt-oss's head_dim is independent GGUF metadata, NOT
+    # embedding_length // head_count (see _gpt_oss_attention_block's own
+    # docstring, point 1, for gpt-oss-20b's real numbers: head_dim=64 vs
+    # embedding_length/head_count=2880/64=45).
+    head_dim_kv = kv.get(key("attention.key_length"))
+    head_dim_v = kv.get(key("attention.value_length"))
+    if head_dim_kv is None and head_dim_v is None:
+        raise UnsupportedArchitectureError(
+            f"gpt-oss requires {key('attention.key_length')} or "
+            f"{key('attention.value_length')} in GGUF metadata"
+        )
+    if head_dim_kv is not None and head_dim_v is not None:
+        if int(head_dim_kv) != int(head_dim_v):
+            raise UnsupportedArchitectureError(
+                f"{key('attention.key_length')}={head_dim_kv} != "
+                f"{key('attention.value_length')}={head_dim_v} (distinct "
+                "key/value head dims are not implemented)"
+            )
+    head_dim = int(head_dim_kv if head_dim_kv is not None else head_dim_v)
+
+    n_expert = int(kv.get(key("expert_count"), 0))
+    n_expert_used = int(kv.get(key("expert_used_count"), 0))
+    if n_expert <= 0 or n_expert_used <= 0 or n_expert_used > n_expert:
+        raise UnsupportedArchitectureError(
+            f"gpt-oss requires {key('expert_count')} > 0 and a positive "
+            f"{key('expert_used_count')} <= expert_count (got "
+            f"expert_count={n_expert}, expert_used_count={n_expert_used})"
+        )
+    # _gpt_oss_moe_ffn has no expert_weights_scale parameter at all (it
+    # assumes the default of no extra scaling), so the same guard
+    # _reconstruct_llama_family applies for Mixtral applies here too --
+    # see that function's identical check for why.
+    expert_weights_scale = float(kv.get(key("expert_weights_scale"), 0.0))
+    if expert_weights_scale not in (0.0, 1.0):
+        raise UnsupportedArchitectureError(
+            f"{key('expert_weights_scale')}={expert_weights_scale} is not "
+            "implemented (only the default of no extra scaling is)"
+        )
+
+    # llama.cpp's own load_arch_hparams reads this key as REQUIRED (a plain
+    # 2-arg ml.get_key call, which throws if absent) -- mirrored here rather
+    # than defaulted.
+    if key("attention.sliding_window") not in kv:
+        raise UnsupportedArchitectureError(
+            f"gpt-oss requires {key('attention.sliding_window')} in GGUF metadata"
+        )
+    sliding_window = int(kv[key("attention.sliding_window")])
+    # Unlike sliding_window above, llama.cpp reads this one as optional
+    # with a hardcoded default of 2 (load_arch_hparams's local
+    # `uint32_t swa_period = 2`) -- no real gpt-oss GGUF sets this key at
+    # all (see _gpt_oss_is_sliding_layer's own docstring).
+    swa_period = int(kv.get(key("attention.sliding_window_pattern"), 2))
+
+    rope_scaling_type = kv.get(key("rope.scaling.type"))
+    if rope_scaling_type is not None and rope_scaling_type not in ("yarn", "none"):
+        raise UnsupportedArchitectureError(
+            f"{key('rope.scaling.type')}={rope_scaling_type!r} is not "
+            "implemented (only 'yarn' and 'none' are)"
+        )
+    # _gpt_oss_yarn_cos_sin's own docstring: this degenerates correctly to
+    # plain RoPE when yarn_factor<=1.0 (the "none"/absent-key case), so no
+    # separate code path is needed for a non-YaRN checkpoint.
+    yarn_factor = float(kv.get(key("rope.scaling.factor"), 1.0))
+    yarn_orig_ctx = float(kv.get(key("rope.scaling.original_context_length"), 4096.0))
+    yarn_beta_fast = float(kv.get(key("rope.scaling.yarn_beta_fast"), 32.0))
+    yarn_beta_slow = float(kv.get(key("rope.scaling.yarn_beta_slow"), 1.0))
+
+    def require(name: str) -> dict:
+        info = tensors.get(name)
+        if info is None:
+            raise UnsupportedArchitectureError(
+                f"checkpoint is missing required tensor '{name}' for "
+                f"architecture '{arch}'"
+            )
+        return info
+
+    def optional(name: str) -> Optional[dict]:
+        return tensors.get(name)
+
+    b = _Builder()
+
+    def declare(name: str, expected_shape: List[int]) -> str:
+        info = require(name)
+        if info["shape"] != expected_shape:
+            raise UnsupportedArchitectureError(
+                f"tensor '{name}' has shape {info['shape']}, expected "
+                f"{expected_shape} for architecture '{arch}' with "
+                f"embedding_length={n_embd}, "
+                f"expert_feed_forward_length={n_ff}, head_count={n_head}, "
+                f"head_count_kv={n_head_kv}"
+            )
+        ggml_type = info["ggml_type"]
+        if ggml_type in _GGML_KQUANT_TYPES:
+            onnx_dtype = onnx.TensorProto.FLOAT
+        elif ggml_type in _GGML_RAW_TO_ONNX:
+            onnx_dtype = _GGML_RAW_TO_ONNX[ggml_type]
+        else:
+            raise UnsupportedArchitectureError(
+                f"tensor '{name}' uses ggml_type {ggml_type}, which "
+                "import_gguf_weights cannot decode (only F32/F16/BF16/F64/"
+                "I8/I16/I32/I64, the Q4_K/Q5_K/Q6_K/Q8_0 K-quant family, and "
+                "MXFP4 are supported)"
+            )
+        b.placeholder_weight(name, expected_shape, onnx_dtype)
+        return name
+
+    def declare_optional(name: str, expected_shape: List[int]) -> Optional[str]:
+        return declare(name, expected_shape) if optional(name) is not None else None
+
+    token_embd_info = require("token_embd.weight")
+    if len(token_embd_info["shape"]) != 2 or token_embd_info["shape"][1] != n_embd:
+        raise UnsupportedArchitectureError(
+            f"token_embd.weight shape {token_embd_info['shape']} does not "
+            f"match {key('embedding_length')}={n_embd}"
+        )
+    vocab_size = token_embd_info["shape"][0]
+    token_embd = declare("token_embd.weight", [vocab_size, n_embd])
+
+    input_ids = "input_ids"
+    position_ids = "position_ids"
+    graph_inputs = [
+        onnx.helper.make_tensor_value_info(
+            input_ids, onnx.TensorProto.INT64, [batch_size, seq_len]
+        ),
+        onnx.helper.make_tensor_value_info(
+            position_ids, onnx.TensorProto.INT64, [batch_size, seq_len]
+        ),
+    ]
+
+    x = b.op("Gather", [token_embd, input_ids], "embed", axis=0)
+
+    # YaRN cos/sin: identical across every layer (same position_ids, same
+    # freq_base/head_dim/YaRN params; the sliding-vs-full distinction is
+    # purely a masking difference -- see _gpt_oss_attention_block's own
+    # docstring, point 2, for why), so computed once here.
+    cos_b, sin_b = _gpt_oss_yarn_cos_sin(
+        b,
+        position_ids,
+        head_dim,
+        freq_base,
+        yarn_factor,
+        yarn_orig_ctx,
+        yarn_beta_fast,
+        yarn_beta_slow,
+        "rope",
+    )
+
+    for i in range(n_layer):
+        p = f"blk.{i}"
+        x = _gpt_oss_attention_block(
+            b,
+            x,
+            p,
+            i,
+            n_embd,
+            n_head,
+            n_head_kv,
+            head_dim,
+            cos_b,
+            sin_b,
+            sliding_window,
+            swa_period,
+            batch_size,
+            seq_len,
+            eps,
+            declare,
+            declare_optional,
+        )
+
+        resid = x
+        # Named "post_attention_norm" for this architecture, not "ffn_norm"
+        # -- see this function's own docstring.
+        h = _rmsnorm(
+            b,
+            x,
+            declare(f"{p}.post_attention_norm.weight", [n_embd]),
+            eps,
+            f"{p}.ffn_norm",
+        )
+        ffn_out = _gpt_oss_moe_ffn(
+            b, h, p, n_embd, n_ff, n_expert, n_expert_used, declare, declare_optional
+        )
+        x = b.op("Add", [resid, ffn_out], f"{p}.ffn_resid")
+
+    x = _rmsnorm(b, x, declare("output_norm.weight", [n_embd]), eps, "output_norm")
+
+    # Unlike _reconstruct_llama_family's tied-embeddings fallback,
+    # load_arch_tensors always creates a separate "output.weight" tensor
+    # for gpt-oss unconditionally -- no tied-embeddings case to handle.
+    lm_head = declare("output.weight", [vocab_size, n_embd])
+    logits = _linear(b, x, lm_head, None, "lm_head")
+
+    graph = onnx.helper.make_graph(
+        b.nodes,
+        f"gguf_{arch}",
+        graph_inputs,
+        [
+            onnx.helper.make_tensor_value_info(
+                logits, onnx.TensorProto.FLOAT, [batch_size, seq_len, vocab_size]
+            )
+        ],
+        initializer=b.initializers,
+    )
+    return graph
+
+
 def reconstruct_gguf_graph(
     gguf_path: str, batch_size: int = 1, seq_len: int = 8
 ) -> Tuple[onnx.ModelProto, List[str]]:
     """
     Build a runnable ONNX graph -- structure *and* weights -- directly from
     a GGUF checkpoint, for a recognized architecture (currently the Llama
-    family: ``llama``, ``qwen2``, ``mistral`` -- see the module docstring).
+    family: ``llama``, ``qwen2``, ``mistral``; and ``gpt-oss`` -- see the
+    module docstring).
 
     Unlike :func:`import_gguf_weights`, which only ever fills in an
     existing graph's initializer *values*, this constructs the graph
@@ -624,7 +1549,10 @@ def reconstruct_gguf_graph(
             f"supported: {', '.join(_SUPPORTED_ARCHITECTURES)}"
         )
 
-    graph = _reconstruct_llama_family(meta, batch_size, seq_len)
+    if arch == "gpt-oss":
+        graph = _reconstruct_gpt_oss(meta, batch_size, seq_len)
+    else:
+        graph = _reconstruct_llama_family(meta, batch_size, seq_len)
     model = onnx.helper.make_model(
         graph,
         opset_imports=[

--- a/onnxsim/gguf_reconstruct.py
+++ b/onnxsim/gguf_reconstruct.py
@@ -71,11 +71,11 @@ _OPSET = 17
 # with e.g. a cross-compiled wheel's smoke test) then refuse to load at all.
 _IR_VERSION = 8
 
-# Mirrors onnxsim/gguf_dtype.h's GgmlType enum and ToOnnx/IsKQuant mapping --
-# duplicated here rather than exposed through a new C++ binding, the same
-# choice tests/test_import_gguf_weights.py already made for its own small,
-# stable GGML_TYPE_* constants. See gguf_dtype.h's file comment: GGML never
-# reassigns an existing type ID, so this mapping does not drift.
+# Mirrors onnxsim/gguf_dtype.h's GgmlType enum and ToOnnx/IsKQuant/IsMxfp4
+# mapping -- duplicated here rather than exposed through a new C++ binding,
+# the same choice tests/test_import_gguf_weights.py already made for its own
+# small, stable GGML_TYPE_* constants. See gguf_dtype.h's file comment: GGML
+# never reassigns an existing type ID, so this mapping does not drift.
 _GGML_RAW_TO_ONNX = {
     0: onnx.TensorProto.FLOAT,  # F32
     1: onnx.TensorProto.FLOAT16,  # F16
@@ -86,11 +86,11 @@ _GGML_RAW_TO_ONNX = {
     28: onnx.TensorProto.DOUBLE,  # F64
     30: onnx.TensorProto.BFLOAT16,  # BF16
 }
-# Q8_0, Q4_K, Q5_K, Q6_K -- import_gguf_weights forces these to FLOAT
+# Q8_0, Q4_K, Q5_K, Q6_K, MXFP4 -- import_gguf_weights forces these to FLOAT
 # regardless of what the initializer previously declared (see
 # tensor_pool_gguf_bridge.h's HydrateTensorProtoFromGGUF), so that is what
 # must be declared here too.
-_GGML_KQUANT_TYPES = {8, 12, 13, 14}
+_GGML_KQUANT_TYPES = {8, 12, 13, 14, 39}
 
 _ONNX_DTYPE_ITEMSIZE = {
     onnx.TensorProto.FLOAT: 4,
@@ -395,8 +395,8 @@ def _reconstruct_llama_family(
             raise UnsupportedArchitectureError(
                 f"tensor '{name}' uses ggml_type {ggml_type}, which "
                 "import_gguf_weights cannot decode (only F32/F16/BF16/F64/"
-                "I8/I16/I32/I64 and the Q4_K/Q5_K/Q6_K/Q8_0 K-quant family "
-                "are supported)"
+                "I8/I16/I32/I64, the Q4_K/Q5_K/Q6_K/Q8_0 K-quant family, and "
+                "MXFP4 are supported)"
             )
         b.placeholder_weight(name, expected_shape, onnx_dtype)
         return name

--- a/onnxsim/tensor_pool.h
+++ b/onnxsim/tensor_pool.h
@@ -211,10 +211,11 @@ class TensorPool {
   // ONNX raw-data equivalent and are never pooled -- LoadGGUF skips and
   // reports them rather than writing garbage. The K-quant family
   // (Q4_K/Q5_K/Q6_K/Q8_0) -- what a real quantized checkpoint (e.g.
-  // Unsloth's GGUF exports) actually uses for the bulk of its weights -- IS
-  // pooled, holding its native, still-packed block bytes (see
-  // gguf_dtype.h's IsKQuant); DequantizeToFloat below decodes an entry like
-  // that to plain float32 values.
+  // Unsloth's GGUF exports) actually uses for the bulk of its weights -- and
+  // MXFP4 (gpt-oss-20b's own native MoE-expert quantization) ARE pooled,
+  // holding their native, still-packed block bytes (see gguf_dtype.h's
+  // IsKQuant/IsMxfp4); DequantizeToFloat below decodes an entry like that to
+  // plain float32 values.
 
   // Write every entry to a GGUF file at `path`. Every dtype TensorPool can
   // hold has a raw ggml_type counterpart (see gguf_dtype.h), so -- unlike
@@ -240,21 +241,22 @@ class TensorPool {
 
   // Replace this pool's contents with every tensor in the GGUF file at
   // `path` whose ggml_type this pool can represent -- either a *raw*,
-  // unquantized type (stored as-is) or one of the four K-quant types
-  // gguf_dtype.h's IsKQuant covers (stored as its native, still-packed
-  // block bytes -- see DequantizeToFloat to decode one). Every other
-  // quantized type (Q4_0, every IQ*_ variant, ...) has no representation
-  // this pool can hold at all. Unlike LoadSafetensors, this does NOT read
-  // the whole file into memory: only the (small) header/metadata/tensor-
-  // info section is read up front, and each *included* tensor's bytes are
-  // read with their own targeted seek + read -- loading a large quantized
-  // checkpoint this way costs only the bytes of the tensors this pool can
-  // actually use, not the whole file. Returns the names of tensors that
-  // were present in the file but skipped because their ggml_type has no
-  // representation this pool can hold (empty if every tensor was loaded).
-  // Throws std::runtime_error on I/O failure, an unrecognized magic/
-  // version, a malformed header, or a K-quant tensor whose element count
-  // is not a multiple of its quantization block size.
+  // unquantized type (stored as-is) or one of the four K-quant types or the
+  // MXFP4 type gguf_dtype.h's IsKQuant/IsMxfp4 cover (stored as its native,
+  // still-packed block bytes -- see DequantizeToFloat to decode one). Every
+  // other quantized type (Q4_0, every IQ*_ variant, ...) has no
+  // representation this pool can hold at all. Unlike LoadSafetensors, this
+  // does NOT read the whole file into memory: only the (small) header/
+  // metadata/tensor-info section is read up front, and each *included*
+  // tensor's bytes are read with their own targeted seek + read -- loading a
+  // large quantized checkpoint this way costs only the bytes of the tensors
+  // this pool can actually use, not the whole file. Returns the names of
+  // tensors that were present in the file but skipped because their
+  // ggml_type has no representation this pool can hold (empty if every
+  // tensor was loaded). Throws std::runtime_error on I/O failure, an
+  // unrecognized magic/version, a malformed header, or a block-quantized
+  // tensor whose element count is not a multiple of its quantization block
+  // size.
   std::vector<std::string> LoadGGUF(const std::string& path);
 
   // Like LoadGGUF, but memory-maps `path` (mmap() on POSIX, MapViewOfFile()
@@ -286,11 +288,11 @@ class TensorPool {
   // Decodes `name`'s entry to plain float32 values, appended to `out` (not
   // cleared first) -- the only way to get usable numeric values out of an
   // entry LoadGGUF/LoadGGUFMmap pooled from a K-quant (Q4_K/Q5_K/Q6_K/Q8_0)
-  // source, since its `data` otherwise holds native, still-packed GGML
-  // block bytes, not per-element values (see gguf_dtype.h's IsKQuant).
-  // Returns false, leaving `out` untouched, if `name` isn't in the pool or
-  // its dtype is not one of those four K-quant codes (including an
-  // ordinary raw dtype, e.g. FLOAT/FLOAT16 -- those need no decoding at
+  // or MXFP4 source, since its `data` otherwise holds native, still-packed
+  // GGML block bytes, not per-element values (see gguf_dtype.h's
+  // IsKQuant/IsMxfp4). Returns false, leaving `out` untouched, if `name`
+  // isn't in the pool or its dtype is not one of those five codes (including
+  // an ordinary raw dtype, e.g. FLOAT/FLOAT16 -- those need no decoding at
   // all; read Entry::data directly, the same way every other TensorPool
   // consumer already does).
   bool DequantizeToFloat(const std::string& name,

--- a/onnxsim/tensor_pool_gguf.cpp
+++ b/onnxsim/tensor_pool_gguf.cpp
@@ -12,6 +12,7 @@
 #include <streambuf>
 
 #include "ggml_kquant.h"
+#include "ggml_mxfp4.h"
 #include "gguf_dtype.h"
 #include "mmap_file.h"
 #include "tensor_pool.h"
@@ -676,14 +677,20 @@ bool TensorPool::DequantizeToFloat(const std::string& name,
     return false;
   }
   uint32_t ggml_type;
-  if (!FromOnnx(entry->dtype, &ggml_type) || !IsKQuant(ggml_type)) {
+  if (!FromOnnx(entry->dtype, &ggml_type)) {
     return false;
   }
   int64_t numel = 1;
   for (int64_t d : entry->shape) numel *= d;
-  return DequantizeGgmlKQuant(
-      reinterpret_cast<const uint8_t*>(entry->data.data()), entry->data.size(),
-      ggml_type, numel, out);
+  const auto* data = reinterpret_cast<const uint8_t*>(entry->data.data());
+  if (IsKQuant(ggml_type)) {
+    return DequantizeGgmlKQuant(data, entry->data.size(), ggml_type, numel,
+                                out);
+  }
+  if (IsMxfp4(ggml_type)) {
+    return DequantizeGgmlMxfp4(data, entry->data.size(), ggml_type, numel, out);
+  }
+  return false;
 }
 
 // Mirrors LoadGGUF's header-parsing loop (magic/version check, then the

--- a/onnxsim/tensor_pool_gguf_bridge.h
+++ b/onnxsim/tensor_pool_gguf_bridge.h
@@ -51,9 +51,10 @@ namespace tensor_pool {
 
 // GGUF counterpart of tensor_pool_bridge.h's HydrateTensorProto: same
 // contract (returns false, leaving `tensor` untouched, if `name` isn't
-// pooled) EXCEPT a K-quant-native entry (Q4_K/Q5_K/Q6_K/Q8_0 -- see
-// gguf_dtype.h's IsKQuant) is decoded to plain float32 raw_data instead of
-// copied verbatim, and `tensor`'s data_type is forced to FLOAT to match --
+// pooled) EXCEPT a K-quant-native or MXFP4-native entry (Q4_K/Q5_K/Q6_K/
+// Q8_0/MXFP4 -- see gguf_dtype.h's IsKQuant/IsMxfp4) is decoded to plain
+// float32 raw_data instead of copied verbatim, and `tensor`'s data_type is
+// forced to FLOAT to match --
 // overriding whatever data_type the caller's initializer previously
 // declared, since the decoded values are only meaningful as float32 (the
 // caller's own declared dtype reflects whatever *their* graph expects,
@@ -68,10 +69,12 @@ inline bool HydrateTensorProtoFromGGUF(const std::string& name,
   if (entry == nullptr) return false;
 
   uint32_t ggml_type;
-  if (gguf::FromOnnx(entry->dtype, &ggml_type) && gguf::IsKQuant(ggml_type)) {
+  if (gguf::FromOnnx(entry->dtype, &ggml_type) &&
+      (gguf::IsKQuant(ggml_type) || gguf::IsMxfp4(ggml_type))) {
     std::vector<float> floats;
     if (!pool.DequantizeToFloat(name, &floats)) {
-      return false;  // Unreachable: FromOnnx+IsKQuant already validated dtype.
+      // Unreachable: FromOnnx+IsKQuant/IsMxfp4 already validated dtype.
+      return false;
     }
     tensor.set_data_location(onnx::TensorProto::DEFAULT);
     tensor.clear_external_data();
@@ -133,12 +136,12 @@ inline size_t ExportModelWithGGUF(
 }
 
 // Load `gguf_path` into `pool` and, for every graph initializer whose name
-// matches a pooled tensor -- a raw-dtype tensor, or a K-quant one (see
-// gguf_dtype.h's IsKQuant), either hydrate it in place (hydrate_all, the
-// default -- a K-quant match is decoded to float32, see
+// matches a pooled tensor -- a raw-dtype tensor, or a K-quant/MXFP4 one (see
+// gguf_dtype.h's IsKQuant/IsMxfp4), either hydrate it in place (hydrate_all,
+// the default -- a K-quant/MXFP4 match is decoded to float32, see
 // HydrateTensorProtoFromGGUF) or leave it as a lazy EXTERNAL reference
 // (hydrate_all=false; see tensor_pool_bridge.h's caveat on this mode --
-// note a K-quant match left lazy this way still needs
+// note a K-quant/MXFP4 match left lazy this way still needs
 // HydrateTensorProtoFromGGUF, not the plain HydrateTensorProto that caveat
 // points to, when it's eventually hydrated on demand).
 // Returns the number of initializers matched (hydrated or marked lazy).

--- a/onnxsim/tensor_pool_gguf_bridge_test.cpp
+++ b/onnxsim/tensor_pool_gguf_bridge_test.cpp
@@ -398,6 +398,82 @@ void TestImportModelWithGGUFDecodesKQuant() {
   std::remove(path.c_str());
 }
 
+// Same shape as TestImportModelWithGGUFDecodesKQuant, but for MXFP4 --
+// confirms HydrateTensorProtoFromGGUF's IsKQuant-or-IsMxfp4 branch (not just
+// IsKQuant) actually reaches the decode path when called through the full
+// ImportModelWithGGUF bridge, not just TensorPool::DequantizeToFloat
+// directly (see tensor_pool_gguf_test.cpp's TestMxfp4RoundTripAndDecode for
+// that narrower check). e = 128 (E8M0 -> scale 1.0 exactly), qs[0] = 0x21,
+// qs[1] = 0x9A -- the same hand-verified vector ggml_mxfp4_test.cpp
+// hand-verifies.
+void TestImportModelWithGGUFDecodesMxfp4() {
+  std::string path = TempPath("_mxfp4_import.gguf");
+  {
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    auto write_string = [&](const std::string& s) {
+      WriteLE<uint64_t>(out, s.size());
+      out.write(s.data(), static_cast<std::streamsize>(s.size()));
+    };
+    WriteLE<uint32_t>(out, kMagic);
+    WriteLE<uint32_t>(out, kSupportedVersion);
+    WriteLE<uint64_t>(out, 1);  // tensor_count
+    WriteLE<uint64_t>(out, 0);  // metadata_kv_count
+
+    write_string("w");
+    WriteLE<uint32_t>(out, 1);
+    WriteLE<uint64_t>(out, 32);  // ne[0]
+    WriteLE<uint32_t>(out, GGML_TYPE_MXFP4);
+    WriteLE<uint64_t>(out, 0);  // offset
+
+    uint64_t header_end = static_cast<uint64_t>(out.tellp());
+    uint64_t data_start = (header_end + kDefaultAlignment - 1) /
+                          kDefaultAlignment * kDefaultAlignment;
+    for (uint64_t i = header_end; i < data_start; ++i) out.put('\0');
+    out.put(static_cast<char>(128));   // e (E8M0 scale byte) -> d = 1.0
+    out.put(static_cast<char>(0x21));  // qs[0]
+    out.put(static_cast<char>(0x9A));  // qs[1]
+    for (int i = 0; i < 14; ++i) out.put('\0');  // qs[2..15]
+  }
+
+  onnx::ModelProto model;
+  auto* w = model.mutable_graph()->add_initializer();
+  w->set_name("w");
+  w->set_data_type(onnx::TensorProto::INT32);  // deliberately wrong
+  w->add_dims(32);
+
+  TensorPool pool;
+  std::vector<std::string> skipped;
+  size_t matched = ImportModelWithGGUF(model, path, pool, true, &skipped);
+  Check(matched == 1, "the MXFP4 tensor is matched");
+  Check(skipped.empty(), "nothing skipped -- MXFP4 is now supported");
+
+  const auto& hydrated = model.graph().initializer(0);
+  Check(hydrated.data_type() == onnx::TensorProto::FLOAT,
+        "MXFP4 hydration forces data_type to FLOAT, overriding the "
+        "caller's (wrong) declared INT32");
+  Check(hydrated.has_raw_data() &&
+            hydrated.raw_data().size() == 32 * sizeof(float),
+        "hydrated raw_data is 32 float32 values");
+  bool values_ok = hydrated.raw_data().size() == 32 * sizeof(float);
+  if (values_ok) {
+    std::string bytes = hydrated.raw_data();
+    if constexpr (!onnxsim::dlpack::kRawDataIsHostOrder) {
+      onnxsim::dlpack::SwapElementBytes(
+          reinterpret_cast<uint8_t*>(bytes.data()), bytes.size(),
+          sizeof(float));
+    }
+    float floats[32];
+    std::memcpy(floats, bytes.data(), sizeof(floats));
+    values_ok = std::fabs(floats[0] - 1.0f) < 1e-6f &&
+                std::fabs(floats[16] - 2.0f) < 1e-6f &&
+                std::fabs(floats[1] - (-2.0f)) < 1e-6f &&
+                std::fabs(floats[17] - (-1.0f)) < 1e-6f;
+  }
+  Check(values_ok, "hydrated values decode as expected");
+
+  std::remove(path.c_str());
+}
+
 // ImportModelWithGGUFToPool is import_gguf_weights's FFI-friendly sibling of
 // ImportModelWithGGUF(hydrate_all=true): same K-quant decode
 // (HydrateTensorProtoFromGGUF, reused unchanged), but the matched tensor's
@@ -499,6 +575,7 @@ int main() {
   TestImportModelWithGGUFLazy();
   TestImportModelWithGGUFSkipsQuantized();
   TestImportModelWithGGUFDecodesKQuant();
+  TestImportModelWithGGUFDecodesMxfp4();
   TestImportModelWithGGUFToPool();
 
   if (g_failures == 0) {

--- a/onnxsim/tensor_pool_gguf_test.cpp
+++ b/onnxsim/tensor_pool_gguf_test.cpp
@@ -495,6 +495,49 @@ void TestLoadGGUFRejectsMisalignedKQuantTensor() {
   std::remove(path.c_str());
 }
 
+void TestMxfp4RoundTripAndDecode() {
+  // An MXFP4 block: e = 128 (E8M0 exponent byte -> scale d = 1.0 exactly,
+  // see ggml_mxfp4_test.cpp's TestGgmlE8m0ToFloat32Half), qs[0] = 0x21 and
+  // qs[1] = 0x9A -- the same hand-verified vector ggml_mxfp4_test.cpp
+  // hand-verifies, reused here to check TensorPool's own plumbing (pooling,
+  // SaveGGUF/LoadGGUF byte-exact round trip, DequantizeToFloat), not the
+  // decode math itself.
+  std::string block(17, '\0');
+  block[0] = static_cast<char>(128);
+  block[1] = static_cast<char>(0x21);
+  block[2] = static_cast<char>(0x9A);
+
+  TensorPool pool;
+  pool.Add("w", ONNXSIM_GGML_MXFP4, {32}, std::string(block));
+
+  std::string path = TempPath("_mxfp4.gguf");
+  pool.SaveGGUF(path);
+
+  TensorPool loaded;
+  auto skipped = loaded.LoadGGUF(path);
+  Check(skipped.empty(), "MXFP4 tensor is not skipped");
+  const Entry* w = loaded.Find("w");
+  Check(w != nullptr, "MXFP4 tensor is present");
+  if (w != nullptr) {
+    Check(w->dtype == ONNXSIM_GGML_MXFP4, "MXFP4 dtype round-trips");
+    Check(w->shape == std::vector<int64_t>({32}), "MXFP4 shape round-trips");
+    Check(w->data == block, "MXFP4 native block bytes round-trip bit-exact");
+
+    std::vector<float> decoded;
+    Check(loaded.DequantizeToFloat("w", &decoded),
+          "DequantizeToFloat succeeds for an MXFP4 entry");
+    Check(decoded.size() == 32, "DequantizeToFloat output size");
+    if (decoded.size() == 32) {
+      Check(std::fabs(decoded[0] - 1.0f) < 1e-6f, "MXFP4 element 0");
+      Check(std::fabs(decoded[16] - 2.0f) < 1e-6f, "MXFP4 element 16");
+      Check(std::fabs(decoded[1] - (-2.0f)) < 1e-6f, "MXFP4 element 1");
+      Check(std::fabs(decoded[17] - (-1.0f)) < 1e-6f, "MXFP4 element 17");
+    }
+  }
+
+  std::remove(path.c_str());
+}
+
 }  // namespace
 
 int main() {
@@ -510,6 +553,7 @@ int main() {
   TestLoadGGUFMmapMissingFileFallsBackAndThrows();
   TestKQuantRoundTripAndDecode();
   TestLoadGGUFRejectsMisalignedKQuantTensor();
+  TestMxfp4RoundTripAndDecode();
 
   if (g_failures == 0) {
     std::printf("tensor_pool_gguf_test: all checks passed\n");

--- a/scripts/cross/build_s390x_extension.sh
+++ b/scripts/cross/build_s390x_extension.sh
@@ -216,10 +216,14 @@ cmake --build "${BUILD_DIR}" --target onnx_cpp2py_export -j "${JOBS}"
 # this list, so omitting one here doesn't skip its test, it makes ctest try
 # to exec a binary that was never built: an instant, silent "Failed 0.00
 # sec" with no output, indistinguishable at a glance from a real crash.
+# ggml_mxfp4_test (the GGML MXFP4 dequantization ggml_mxfp4.h implements --
+# same rationale as ggml_kquant_test above: decoded values are real numeric
+# output, not just copied bytes) is dependency-free too and belongs here for
+# the same reason.
 cmake --build "${BUILD_DIR}" --target sym_expr_test model_metrics_test \
   sym_value_eval_test sym_shape_infer_test dlpack_dtype_test \
   tensor_pool_dtype_test tensor_pool_test tensor_pool_hash_test \
-  gguf_dtype_test ggml_kquant_test tensor_pool_gguf_test \
+  gguf_dtype_test ggml_kquant_test ggml_mxfp4_test tensor_pool_gguf_test \
   read_gguf_metadata_test -j "${JOBS}"
 # tensor_pool_bridge_test, tensor_pool_gguf_bridge_test,
 # tensor_pool_archive_test, precision_estimator_test, and

--- a/tests/test_gpt_oss_attention.py
+++ b/tests/test_gpt_oss_attention.py
@@ -1,0 +1,464 @@
+"""Tests for onnxsim.gguf_reconstruct's standalone gpt-oss attention block
+(``_gpt_oss_attention_block``, ``_gpt_oss_yarn_cos_sin``,
+``_gpt_oss_is_sliding_layer``, ``_gpt_oss_attn_mask``) -- see that module's
+own "gpt-oss attention block" section header for exactly what these were
+verified against in a real llama.cpp checkout, and for the corrections to
+the original brief this implementation was scoped from.
+
+None of these functions are reachable from
+``onnxsim.reconstruct_gguf_graph`` yet (``gpt-oss`` is not in
+``_SUPPORTED_ARCHITECTURES`` -- this is deliberately a standalone,
+not-yet-wired-in deliverable), so this drives them directly: build a tiny
+one-layer graph with ``_Builder`` the same way ``_reconstruct_llama_family``
+would for a real layer, hydrate its placeholder weights from a small
+hand-written real GGUF v3 file (mirroring test_gguf_reconstruct.py's own
+byte-level rigor for ``_write_gguf``), run it through
+``onnx.reference.ReferenceEvaluator``, and compare against an INDEPENDENT
+from-scratch numpy implementation of gpt-oss's YaRN RoPE, sliding-window
+masking, and attention-sink softmax -- re-derived directly from the
+ggml/llama.cpp formulas (``ggml_rope_yarn_corr_dims``, ``rope_yarn``,
+``ggml_compute_forward_soft_max_f32``'s sink branch,
+``llama_hparams::is_masked_swa``), not by calling the onnxsim helpers under
+test.
+"""
+
+import math
+import struct
+
+import numpy as np
+import onnx
+import onnx.helper
+from onnx.reference import ReferenceEvaluator
+
+from onnxsim.gguf_reconstruct import (
+    _Builder,
+    _gpt_oss_attention_block,
+    _gpt_oss_attn_mask,
+    _gpt_oss_is_sliding_layer,
+    _gpt_oss_yarn_cos_sin,
+)
+from onnxsim.onnx_simplifier import import_gguf_weights
+
+GGUF_MAGIC = 0x46554747
+GGUF_VERSION = 3
+GGML_TYPE_F32 = 0
+
+_OPSET = 17
+_IR_VERSION = 8
+
+
+def _string_bytes(s):
+    b = s.encode("utf-8")
+    return struct.pack("<Q", len(b)) + b
+
+
+def _align_up(n, align=32):
+    rem = n % align
+    return n if rem == 0 else n + (align - rem)
+
+
+def _write_gguf(path, weights):
+    """A real GGUF v3 file containing exactly ``weights`` (name -> numpy
+    array, ONNX-shape order) and NO metadata kv pairs -- this test drives
+    ``_gpt_oss_attention_block`` directly rather than through
+    ``reconstruct_gguf_graph``, so only ``import_gguf_weights``'s
+    tensor-data section is exercised, not any general.architecture/hparam
+    reading. Otherwise byte-for-byte the same encoding as
+    test_gguf_reconstruct.py's own ``_write_gguf`` (see that file's
+    comments for why the ``ne`` reversal / little-endian raw bytes /
+    32-byte alignment are done this way)."""
+    infos = b""
+    data_chunks = []
+    offset = 0
+    for name, arr in weights.items():
+        ne = list(reversed(arr.shape))
+        raw = arr.astype("<f4").tobytes()
+        infos += _string_bytes(name)
+        infos += struct.pack("<I", len(ne))
+        for d in ne:
+            infos += struct.pack("<Q", d)
+        infos += struct.pack("<I", GGML_TYPE_F32)
+        infos += struct.pack("<Q", offset)
+        data_chunks.append((offset, raw))
+        offset = _align_up(offset + len(raw))
+
+    header = struct.pack("<IIQQ", GGUF_MAGIC, GGUF_VERSION, len(weights), 0)
+    header_end = len(header) + len(infos)
+    data_section_start = _align_up(header_end)
+
+    with open(path, "wb") as f:
+        f.write(header)
+        f.write(infos)
+        f.write(b"\x00" * (data_section_start - header_end))
+        pos = data_section_start
+        for rel_offset, raw in data_chunks:
+            abs_offset = data_section_start + rel_offset
+            f.write(b"\x00" * (abs_offset - pos))
+            f.write(raw)
+            pos = abs_offset + len(raw)
+
+
+# A tiny config deliberately chosen so head_dim is NOT n_embd // n_head
+# (n_embd/n_head = 8/4 = 2, but head_dim = 6) -- exercising the exact
+# structural difference _gpt_oss_attention_block's own docstring (point 1)
+# says every _SUPPORTED_ARCHITECTURES entry today gets wrong for gpt-oss.
+N_EMBD = 8
+N_HEAD = 4
+N_HEAD_KV = 2
+HEAD_DIM = 6
+FREQ_BASE = 100.0
+YARN_FACTOR = 4.0
+YARN_ORIG_CTX = 8.0
+YARN_BETA_FAST = 8.0
+YARN_BETA_SLOW = 1.0
+SLIDING_WINDOW = 3
+SWA_PERIOD = 2
+EPS = 1e-5
+BATCH = 1
+SEQ = 6
+
+
+def _make_weights(seed):
+    rng = np.random.default_rng(seed)
+
+    def rand(*shape):
+        return rng.standard_normal(shape).astype(np.float32) * 0.1
+
+    n_embd_q = N_HEAD * HEAD_DIM
+    n_embd_kv = N_HEAD_KV * HEAD_DIM
+    return {
+        "blk.0.attn_norm.weight": rand(N_EMBD) + 1.0,
+        "blk.0.attn_q.weight": rand(n_embd_q, N_EMBD),
+        "blk.0.attn_q.bias": rand(n_embd_q),
+        "blk.0.attn_k.weight": rand(n_embd_kv, N_EMBD),
+        "blk.0.attn_k.bias": rand(n_embd_kv),
+        "blk.0.attn_v.weight": rand(n_embd_kv, N_EMBD),
+        "blk.0.attn_v.bias": rand(n_embd_kv),
+        "blk.0.attn_output.weight": rand(N_EMBD, n_embd_q),
+        "blk.0.attn_output.bias": rand(N_EMBD),
+        "blk.0.attn_sinks.weight": rand(N_HEAD),
+    }
+
+
+def _build_one_layer_model(weights, layer_idx):
+    """Builds a runnable one-layer ONNX model around
+    ``_gpt_oss_attention_block``/``_gpt_oss_yarn_cos_sin`` -- the graph
+    STRUCTURE comes entirely from the onnxsim code under test (this
+    function only supplies inputs/outputs and a placeholder-declaring
+    closure pair, the same role ``_reconstruct_llama_family``'s own
+    ``declare``/``declare_optional`` closures play there)."""
+    b = _Builder()
+
+    def declare(name, expected_shape):
+        assert list(weights[name].shape) == expected_shape, (
+            name,
+            weights[name].shape,
+            expected_shape,
+        )
+        b.placeholder_weight(name, expected_shape, onnx.TensorProto.FLOAT)
+        return name
+
+    def declare_optional(name, expected_shape):
+        return declare(name, expected_shape) if name in weights else None
+
+    hidden = "hidden_states"
+    position_ids = "position_ids"
+
+    cos_b, sin_b = _gpt_oss_yarn_cos_sin(
+        b,
+        position_ids,
+        HEAD_DIM,
+        FREQ_BASE,
+        YARN_FACTOR,
+        YARN_ORIG_CTX,
+        YARN_BETA_FAST,
+        YARN_BETA_SLOW,
+        "rope",
+    )
+    out = _gpt_oss_attention_block(
+        b,
+        hidden,
+        "blk.0",
+        layer_idx,
+        N_EMBD,
+        N_HEAD,
+        N_HEAD_KV,
+        HEAD_DIM,
+        cos_b,
+        sin_b,
+        SLIDING_WINDOW,
+        SWA_PERIOD,
+        BATCH,
+        SEQ,
+        EPS,
+        declare,
+        declare_optional,
+    )
+
+    graph = onnx.helper.make_graph(
+        b.nodes,
+        "gpt_oss_attn_test",
+        [
+            onnx.helper.make_tensor_value_info(
+                hidden, onnx.TensorProto.FLOAT, [BATCH, SEQ, N_EMBD]
+            ),
+            onnx.helper.make_tensor_value_info(
+                position_ids, onnx.TensorProto.INT64, [BATCH, SEQ]
+            ),
+        ],
+        [
+            onnx.helper.make_tensor_value_info(
+                out, onnx.TensorProto.FLOAT, [BATCH, SEQ, N_EMBD]
+            )
+        ],
+        initializer=b.initializers,
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", _OPSET)]
+    )
+    model.ir_version = _IR_VERSION
+    return model
+
+
+def _ref_yarn_cos_sin(position_ids, head_dim):
+    """Independent from-scratch re-derivation of gpt-oss's YaRN RoPE,
+    directly from ggml/src/ggml.c's ``ggml_rope_yarn_corr_dims`` and
+    ggml/src/ggml-cpu/ops.cpp's ``rope_yarn`` -- written without looking at
+    ``_gpt_oss_yarn_cos_sin``'s own code, only at the same llama.cpp source
+    it cites."""
+    half = head_dim // 2
+    j = np.arange(half, dtype=np.float64)
+    inv_freq = 1.0 / (FREQ_BASE ** (2.0 * j / head_dim))
+
+    def corr_dim(n_rot):
+        return (
+            head_dim
+            * math.log(YARN_ORIG_CTX / (n_rot * 2.0 * math.pi))
+            / (2.0 * math.log(FREQ_BASE))
+        )
+
+    low = max(0.0, math.floor(corr_dim(YARN_BETA_FAST)))
+    high = min(float(head_dim - 1), math.ceil(corr_dim(YARN_BETA_SLOW)))
+    ramp = 1.0 - np.clip((j - low) / max(1e-3, high - low), 0.0, 1.0)
+
+    freq_scale = 1.0 / YARN_FACTOR
+    theta_extrap = position_ids[..., None].astype(np.float64) * inv_freq[None, None, :]
+    theta_interp = freq_scale * theta_extrap
+    theta = theta_interp * (1 - ramp) + theta_extrap * ramp
+    mscale = 1.0 if YARN_FACTOR <= 1.0 else 0.1 * math.log(YARN_FACTOR) + 1.0
+
+    emb = np.concatenate([theta, theta], axis=-1)
+    cos = (np.cos(emb) * mscale).astype(np.float32)[:, None, :, :]
+    sin = (np.sin(emb) * mscale).astype(np.float32)[:, None, :, :]
+    return cos, sin
+
+
+def _ref_rotate_half(x):
+    half = x.shape[-1] // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return np.concatenate([-x2, x1], axis=-1)
+
+
+def _ref_attn_mask(sliding):
+    """Independent re-derivation of llama_hparams::is_masked_swa's
+    LLAMA_SWA_TYPE_STANDARD rule, written directly from that source
+    (masked when key-to-query distance p1-p0 >= n_swa), not from
+    ``_gpt_oss_attn_mask``'s code."""
+    mask = np.zeros((SEQ, SEQ), dtype=np.float32)
+    for p1 in range(SEQ):  # query position
+        for p0 in range(SEQ):  # key position
+            masked = p0 > p1  # causal
+            if sliding and (p1 - p0) >= SLIDING_WINDOW:
+                masked = True
+            if masked:
+                mask[p1, p0] = -1e9
+    return mask
+
+
+def _ref_forward(weights, input_hidden, position_ids, layer_idx):
+    """Independent from-scratch numpy forward pass for one gpt-oss
+    attention block -- RMSNorm, QKV projection, YaRN RoPE, GQA scores,
+    sliding-window-or-causal mask, attention-sink softmax
+    (``softmax_i = exp(s_i-m)/(sum_j exp(s_j-m) + exp(sink-m))``,
+    ``m = max(max(s), sink)`` -- read directly off
+    ggml_compute_forward_soft_max_f32's sink branch, not off
+    ``_gpt_oss_attention_block``'s code), output projection, residual add.
+    """
+    resid = input_hidden
+    var = np.mean(input_hidden * input_hidden, axis=-1, keepdims=True)
+    h = input_hidden / np.sqrt(var + EPS) * weights["blk.0.attn_norm.weight"]
+
+    q = h @ weights["blk.0.attn_q.weight"].T + weights["blk.0.attn_q.bias"]
+    k = h @ weights["blk.0.attn_k.weight"].T + weights["blk.0.attn_k.bias"]
+    v = h @ weights["blk.0.attn_v.weight"].T + weights["blk.0.attn_v.bias"]
+
+    q = q.reshape(BATCH, SEQ, N_HEAD, HEAD_DIM).transpose(0, 2, 1, 3)
+    k = k.reshape(BATCH, SEQ, N_HEAD_KV, HEAD_DIM).transpose(0, 2, 1, 3)
+    v = v.reshape(BATCH, SEQ, N_HEAD_KV, HEAD_DIM).transpose(0, 2, 1, 3)
+
+    cos, sin = _ref_yarn_cos_sin(position_ids, HEAD_DIM)
+    q = q * cos + _ref_rotate_half(q) * sin
+    k = k * cos + _ref_rotate_half(k) * sin
+
+    n_rep = N_HEAD // N_HEAD_KV
+    q5 = q.reshape(BATCH, N_HEAD_KV, n_rep, SEQ, HEAD_DIM)
+    k5 = k[:, :, None, :, :]
+    v5 = v[:, :, None, :, :]
+
+    scores = q5 @ np.swapaxes(k5, -1, -2) / math.sqrt(HEAD_DIM)
+
+    sliding = _gpt_oss_is_sliding_layer(layer_idx, SWA_PERIOD)
+    mask = _ref_attn_mask(sliding)
+    scores = scores + mask
+
+    sinks = weights["blk.0.attn_sinks.weight"].reshape(N_HEAD_KV, n_rep)
+    sinks_b = sinks[None, :, :, None, None]
+
+    row_max = np.max(scores, axis=-1, keepdims=True)
+    m = np.maximum(row_max, sinks_b)
+    exp_s = np.exp(scores - m)
+    sum_exp = np.sum(exp_s, axis=-1, keepdims=True)
+    sink_exp = np.exp(sinks_b - m)
+    attn = exp_s / (sum_exp + sink_exp)
+
+    out = attn @ v5  # [B, n_head_kv, n_rep, S, head_dim]
+    # Merge (n_head_kv, n_rep) -> n_head (row-major -- the same convention
+    # _gpt_oss_attention_block's q5/k5/v5 broadcasting split relies on),
+    # then move the head axis after S and flatten heads*head_dim -- matches
+    # the onnx graph's reshape(->n_head,S,head_dim)/transpose/reshape
+    # sequence exactly (merging is associative for row-major reshapes, so
+    # doing it in one transpose+reshape here is equivalent).
+    out = out.transpose(0, 3, 1, 2, 4).reshape(BATCH, SEQ, N_HEAD * HEAD_DIM)
+    out = (
+        out @ weights["blk.0.attn_output.weight"].T + weights["blk.0.attn_output.bias"]
+    )
+
+    return resid + out
+
+
+def test_gpt_oss_sliding_layer_pattern_matches_config():
+    # openai/gpt-oss-20b's own config.json (fetched from the HF Hub) lists
+    # layer_types = ["sliding_attention", "full_attention", ...] x12 for its
+    # 24 layers -- i.e. even layer indices are local/SWA, odd are
+    # full/global, with the default period-2 pattern
+    # (src/models/openai-moe.cpp never writes a
+    # sliding_window_pattern override into a real gpt-oss GGUF).
+    expected = [i % 2 == 0 for i in range(24)]
+    actual = [_gpt_oss_is_sliding_layer(i, swa_period=2) for i in range(24)]
+    assert actual == expected
+
+
+def test_gpt_oss_attn_mask_is_banded_for_sliding_layers():
+    mask = _gpt_oss_attn_mask(seq_len=6, sliding=True, n_swa=3)
+    # query pos 5 (0-indexed) may attend to key positions 3,4,5 only
+    # (n_swa=3 most recent positions, causal) -- positions 0,1,2 masked.
+    allowed = mask[5] == 0.0
+    assert list(allowed) == [False, False, False, True, True, True]
+    # every row still respects causality (no attending to the future)
+    for q in range(6):
+        assert np.all(mask[q, q + 1 :] == -1e9)
+
+
+def test_gpt_oss_attn_mask_is_plain_causal_for_full_layers():
+    mask = _gpt_oss_attn_mask(seq_len=6, sliding=False, n_swa=3)
+    expected = np.triu(np.full((6, 6), -1e9, dtype=np.float32), k=1)
+    np.testing.assert_array_equal(mask, expected)
+
+
+def test_gpt_oss_yarn_degenerates_to_plain_rope_at_factor_one():
+    # yarn_factor<=1.0 should be indistinguishable from plain (non-YaRN)
+    # RoPE: freq_scale==1 makes the interpolated/extrapolated angle
+    # identical regardless of the ramp, and mscale's scale<=1 branch is
+    # exactly 1.0 -- see _gpt_oss_yarn_cos_sin's own docstring.
+    b = _Builder()
+    cos_name, sin_name = _gpt_oss_yarn_cos_sin(
+        b, "position_ids", HEAD_DIM, FREQ_BASE, 1.0, YARN_ORIG_CTX, 8.0, 1.0, "rope"
+    )
+    graph = onnx.helper.make_graph(
+        b.nodes,
+        "yarn_degenerate_test",
+        [
+            onnx.helper.make_tensor_value_info(
+                "position_ids", onnx.TensorProto.INT64, [1, SEQ]
+            )
+        ],
+        [
+            onnx.helper.make_tensor_value_info(cos_name, onnx.TensorProto.FLOAT, None),
+            onnx.helper.make_tensor_value_info(sin_name, onnx.TensorProto.FLOAT, None),
+        ],
+        initializer=b.initializers,
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", _OPSET)]
+    )
+    model.ir_version = _IR_VERSION
+
+    position_ids = np.arange(SEQ, dtype=np.int64)[None, :]
+    sess = ReferenceEvaluator(model)
+    cos, sin = sess.run(None, {"position_ids": position_ids})
+
+    half = HEAD_DIM // 2
+    inv_freq = 1.0 / (FREQ_BASE ** (np.arange(0, HEAD_DIM, 2) / HEAD_DIM))
+    freqs = position_ids[..., None].astype(np.float64) * inv_freq[None, None, :]
+    emb = np.concatenate([freqs, freqs], axis=-1)
+    expected_cos = np.cos(emb).astype(np.float32)[:, None, :, :]
+    expected_sin = np.sin(emb).astype(np.float32)[:, None, :, :]
+
+    np.testing.assert_allclose(cos, expected_cos, atol=1e-5, rtol=1e-5)
+    np.testing.assert_allclose(sin, expected_sin, atol=1e-5, rtol=1e-5)
+    assert half == 3  # sanity: HEAD_DIM is even, as RoPE requires
+
+
+def test_gpt_oss_attention_block_matches_independent_reference_sliding_layer(
+    tmp_path,
+):
+    _check_layer_against_reference(tmp_path, layer_idx=0)  # even -> sliding
+
+
+def test_gpt_oss_attention_block_matches_independent_reference_full_layer(tmp_path):
+    _check_layer_against_reference(tmp_path, layer_idx=1)  # odd -> full/global
+
+
+def _check_layer_against_reference(tmp_path, layer_idx):
+    weights = _make_weights(seed=layer_idx + 1)
+    model = _build_one_layer_model(weights, layer_idx)
+
+    gguf_path = str(tmp_path / f"tiny_gpt_oss_layer{layer_idx}.gguf")
+    _write_gguf(gguf_path, weights)
+    model, skipped = import_gguf_weights(model, gguf_path)
+    assert skipped == []
+    onnx.checker.check_model(model)
+
+    rng = np.random.default_rng(100 + layer_idx)
+    hidden = rng.standard_normal((BATCH, SEQ, N_EMBD)).astype(np.float32) * 0.5
+    position_ids = np.arange(SEQ, dtype=np.int64)[None, :].repeat(BATCH, axis=0)
+
+    sess = ReferenceEvaluator(model)
+    (onnx_out,) = sess.run(
+        None, {"hidden_states": hidden, "position_ids": position_ids}
+    )
+
+    ref_out = _ref_forward(weights, hidden, position_ids, layer_idx)
+
+    assert onnx_out.shape == (BATCH, SEQ, N_EMBD)
+    np.testing.assert_allclose(onnx_out, ref_out, atol=1e-4, rtol=1e-4)
+
+
+def test_gpt_oss_attention_block_uses_independent_head_dim_not_embd_over_head_count():
+    # n_embd // n_head == 2 here, but HEAD_DIM == 6 -- confirming
+    # _gpt_oss_attention_block declares Q/K/V/O shapes from head_dim
+    # directly rather than (incorrectly) deriving it as n_embd // n_head,
+    # which every _SUPPORTED_ARCHITECTURES entry does today but gpt-oss's
+    # own checkpoint shapes do not support (see the module docstring's
+    # point 1: gpt-oss-20b itself has n_embd/n_head=45 != head_dim=64).
+    assert N_EMBD // N_HEAD != HEAD_DIM
+
+    weights = _make_weights(seed=42)
+    model = _build_one_layer_model(weights, layer_idx=0)
+    by_name = {i.name: i for i in model.graph.initializer}
+    n_embd_q = N_HEAD * HEAD_DIM
+    n_embd_kv = N_HEAD_KV * HEAD_DIM
+    assert list(by_name["blk.0.attn_q.weight"].dims) == [n_embd_q, N_EMBD]
+    assert list(by_name["blk.0.attn_k.weight"].dims) == [n_embd_kv, N_EMBD]
+    assert list(by_name["blk.0.attn_output.weight"].dims) == [N_EMBD, n_embd_q]
+    assert list(by_name["blk.0.attn_sinks.weight"].dims) == [N_HEAD]

--- a/tests/test_gpt_oss_moe_reconstruct.py
+++ b/tests/test_gpt_oss_moe_reconstruct.py
@@ -1,0 +1,420 @@
+"""Tests for ``onnxsim.gguf_reconstruct``'s gpt-oss-20b MoE/FFN building
+blocks: :func:`onnxsim.gguf_reconstruct._interleave_gate_up` and
+:func:`onnxsim.gguf_reconstruct._gpt_oss_moe_ffn`.
+
+Neither function is wired into :func:`onnxsim.reconstruct_gguf_graph`'s own
+dispatch yet (see ``_gpt_oss_moe_ffn``'s own docstring) -- gpt-oss's
+attention block (sliding-window pattern, attention sinks) has no home in
+``_reconstruct_llama_family`` yet either -- so these tests call the two
+functions directly rather than through ``onnxsim.reconstruct_gguf_graph``,
+mirroring ``tests/test_gguf_reconstruct.py``'s own rigor (hand-encoded
+byte-accurate synthetic GGUF v3 files, an independent from-scratch numpy
+reference for everything checked, and a real onnxruntime run via
+``onnx.utils.Extractor`` for the parts a bare ``sess.run`` can't reach
+because of the MoE node -- see that file's own top comment) but adapted to
+a function that has no dispatcher to build the surrounding graph for it.
+
+Both test functions here build their own small ONNX graph directly with
+``onnx.helper``/the module's own ``_Builder``, rather than via
+``onnx.parser`` (this repo's usual preference for test-authored models --
+see the repo's CLAUDE.md): the whole point of these tests is to exercise
+the actual node-emission logic inside ``_interleave_gate_up``/
+``_gpt_oss_moe_ffn``, which only exists as calls against ``_Builder``, so
+there is no hand-written text graph to parse in the first place -- the
+same situation ``test_gguf_reconstruct.py`` is in when it calls
+``onnxsim.reconstruct_gguf_graph`` instead of authoring text.
+"""
+
+import struct
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import onnx.utils
+import pytest
+
+import onnxsim
+from onnxsim.gguf_reconstruct import (
+    _IR_VERSION,
+    _OPSET,
+    UnsupportedArchitectureError,
+    _Builder,
+    _gpt_oss_moe_ffn,
+    _interleave_gate_up,
+)
+from onnxsim.onnx_simplifier import import_gguf_weights, read_gguf_metadata
+
+GGUF_MAGIC = 0x46554747
+GGUF_VERSION = 3
+GGUF_METADATA_VALUE_TYPE_STRING = 8
+GGML_TYPE_F32 = 0
+
+
+def _string_bytes(s):
+    b = s.encode("utf-8")
+    return struct.pack("<Q", len(b)) + b
+
+
+def _kv_string(key, value):
+    return (
+        _string_bytes(key)
+        + struct.pack("<I", GGUF_METADATA_VALUE_TYPE_STRING)
+        + _string_bytes(value)
+    )
+
+
+def _align_up(n, align=32):
+    rem = n % align
+    return n if rem == 0 else n + (align - rem)
+
+
+def _write_gguf(path, kv_chunks, weights):
+    """Minimal, byte-accurate GGUF v3 writer -- same technique as
+    ``tests/test_gguf_reconstruct.py``'s own ``_write_gguf`` (every tensor
+    plain F32, GGML's reversed-``ne`` convention over the array's own
+    contiguous row-major bytes), duplicated here rather than imported since
+    no test file in this repo imports fixtures from another one."""
+    infos = b""
+    data_chunks = []
+    offset = 0
+    for name, arr in weights.items():
+        ne = list(reversed(arr.shape))
+        raw = arr.astype("<f4").tobytes()
+        infos += _string_bytes(name)
+        infos += struct.pack("<I", len(ne))
+        for d in ne:
+            infos += struct.pack("<Q", d)
+        infos += struct.pack("<I", GGML_TYPE_F32)
+        infos += struct.pack("<Q", offset)
+        data_chunks.append((offset, raw))
+        offset = _align_up(offset + len(raw))
+
+    header = struct.pack(
+        "<IIQQ", GGUF_MAGIC, GGUF_VERSION, len(weights), len(kv_chunks)
+    )
+    body = b"".join(kv_chunks)
+    header_end = len(header) + len(body) + len(infos)
+    data_section_start = _align_up(header_end)
+
+    with open(path, "wb") as f:
+        f.write(header)
+        f.write(body)
+        f.write(infos)
+        f.write(b"\x00" * (data_section_start - header_end))
+        pos = data_section_start
+        for rel_offset, raw in data_chunks:
+            abs_offset = data_section_start + rel_offset
+            f.write(b"\x00" * (abs_offset - pos))
+            f.write(raw)
+            pos = abs_offset + len(raw)
+
+
+def _make_model(b, graph_inputs, graph_outputs, name):
+    graph = onnx.helper.make_graph(
+        b.nodes, name, graph_inputs, graph_outputs, initializer=b.initializers
+    )
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", _OPSET),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    model.ir_version = _IR_VERSION
+    return model
+
+
+def test_gate_up_interleave_matches_independent_numpy_reference():
+    """Standalone check of just :func:`_interleave_gate_up` -- both the 3D
+    weight case (``[n_expert, n_ff, n_embd]`` pair -> ``[n_expert, 2*n_ff,
+    n_embd]``) and the 2D bias case (``trailing=[]``) -- run for real via
+    onnxruntime and compared to an independent numpy
+    ``fused[:, 0::2, ...] = gate; fused[:, 1::2, ...] = up`` reference, not
+    just re-derived by hand (see ``_interleave_gate_up``'s own docstring
+    for the reshape/concat/reshape construction this exercises)."""
+    ort = pytest.importorskip("onnxruntime")
+    n_expert, n_ff, n_embd = 3, 5, 4
+
+    b = _Builder()
+    fc1_w = _interleave_gate_up(b, "gate", "up", n_expert, n_ff, [n_embd], "fc1_w")
+    fc1_b = _interleave_gate_up(b, "gate_b", "up_b", n_expert, n_ff, [], "fc1_b")
+
+    graph_inputs = [
+        onnx.helper.make_tensor_value_info(
+            "gate", onnx.TensorProto.FLOAT, [n_expert, n_ff, n_embd]
+        ),
+        onnx.helper.make_tensor_value_info(
+            "up", onnx.TensorProto.FLOAT, [n_expert, n_ff, n_embd]
+        ),
+        onnx.helper.make_tensor_value_info(
+            "gate_b", onnx.TensorProto.FLOAT, [n_expert, n_ff]
+        ),
+        onnx.helper.make_tensor_value_info(
+            "up_b", onnx.TensorProto.FLOAT, [n_expert, n_ff]
+        ),
+    ]
+    graph_outputs = [
+        onnx.helper.make_tensor_value_info(
+            fc1_w, onnx.TensorProto.FLOAT, [n_expert, 2 * n_ff, n_embd]
+        ),
+        onnx.helper.make_tensor_value_info(
+            fc1_b, onnx.TensorProto.FLOAT, [n_expert, 2 * n_ff]
+        ),
+    ]
+    model = _make_model(b, graph_inputs, graph_outputs, "interleave_test")
+    onnx.checker.check_model(model)
+
+    rng = np.random.default_rng(0)
+    gate = rng.standard_normal((n_expert, n_ff, n_embd)).astype(np.float32)
+    up = rng.standard_normal((n_expert, n_ff, n_embd)).astype(np.float32)
+    gate_b = rng.standard_normal((n_expert, n_ff)).astype(np.float32)
+    up_b = rng.standard_normal((n_expert, n_ff)).astype(np.float32)
+
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    got_w, got_b = sess.run(
+        [fc1_w, fc1_b], {"gate": gate, "up": up, "gate_b": gate_b, "up_b": up_b}
+    )
+
+    ref_w = np.empty((n_expert, 2 * n_ff, n_embd), dtype=np.float32)
+    ref_w[:, 0::2, :] = gate
+    ref_w[:, 1::2, :] = up
+    ref_b = np.empty((n_expert, 2 * n_ff), dtype=np.float32)
+    ref_b[:, 0::2] = gate_b
+    ref_b[:, 1::2] = up_b
+
+    np.testing.assert_array_equal(got_w, ref_w)
+    np.testing.assert_array_equal(got_b, ref_b)
+
+
+def _build_tiny_gpt_oss_moe_checkpoint(tmp_path, n_expert, n_expert_used, seed=5):
+    """A hand-built, real GGUF v3 file holding just one gpt-oss-style MoE
+    block's tensors (router + gate/up/down experts, all WITH the biases
+    real gpt-oss checkpoints always carry -- see ``_gpt_oss_moe_ffn``'s
+    docstring on why those are required, not optional, tensors for this
+    architecture) -- deliberately not a full transformer checkpoint, since
+    ``_gpt_oss_moe_ffn`` is not wired into any layer-building dispatch."""
+    rng = np.random.default_rng(seed)
+    n_embd, n_ff = 6, 4
+
+    def rand(*shape):
+        return rng.standard_normal(shape).astype(np.float32) * 0.1
+
+    weights = {
+        "blk.0.ffn_gate_inp.weight": rand(n_expert, n_embd),
+        "blk.0.ffn_gate_inp.bias": rand(n_expert),
+        "blk.0.ffn_gate_exps.weight": rand(n_expert, n_ff, n_embd),
+        "blk.0.ffn_gate_exps.bias": rand(n_expert, n_ff),
+        "blk.0.ffn_up_exps.weight": rand(n_expert, n_ff, n_embd),
+        "blk.0.ffn_up_exps.bias": rand(n_expert, n_ff),
+        "blk.0.ffn_down_exps.weight": rand(n_expert, n_embd, n_ff),
+        "blk.0.ffn_down_exps.bias": rand(n_expert, n_embd),
+    }
+    kv_chunks = [_kv_string("general.architecture", "gpt-oss")]
+    path = str(tmp_path / "tiny_gpt_oss_moe.gguf")
+    _write_gguf(path, kv_chunks, weights)
+    config = dict(
+        n_embd=n_embd, n_ff=n_ff, n_expert=n_expert, n_expert_used=n_expert_used
+    )
+    return path, weights, config
+
+
+def _declare_closures(b, tensors):
+    """A minimal stand-in for ``_reconstruct_llama_family``'s own
+    ``declare``/``declare_optional`` closures -- deliberately simplified
+    (every tensor here is plain F32, so no K-quant/MXFP4 dtype-mapping
+    logic is needed, unlike the real closures) since these tests only need
+    enough of that contract for ``_gpt_oss_moe_ffn`` to declare its own
+    placeholder initializers correctly."""
+    tensors_by_name = {t["name"]: t for t in tensors}
+
+    def declare(name, expected_shape):
+        info = tensors_by_name[name]
+        assert info["shape"] == expected_shape, (name, info["shape"], expected_shape)
+        b.placeholder_weight(name, expected_shape, onnx.TensorProto.FLOAT)
+        return name
+
+    def declare_optional(name, expected_shape):
+        return declare(name, expected_shape) if name in tensors_by_name else None
+
+    return declare, declare_optional
+
+
+def test_gpt_oss_moe_ffn_wires_up_the_moe_node_correctly(tmp_path):
+    """End-to-end: build a tiny gpt-oss-shaped GGUF checkpoint, run it
+    through ``_gpt_oss_moe_ffn`` directly (bypassing
+    ``reconstruct_gguf_graph``, which doesn't dispatch to it yet), and
+    check (a) the ``com.microsoft.MoE`` node's own attributes/shapes/wiring
+    match what ``_gpt_oss_moe_ffn``'s docstring claims, and (b) -- mirroring
+    ``test_gguf_reconstruct.py``'s
+    ``test_reconstructed_moe_graph_wires_up_the_moe_node_correctly`` --
+    everything upstream of the MoE node itself (the router logits AND the
+    interleaved fc1 weight/bias fusion) matches an independent numpy
+    reference exactly, extracted via ``onnx.utils.Extractor`` and run
+    through a real onnxruntime session, since a bare ``sess.run`` on the
+    full model would build an execution plan that includes the (CPU-
+    unsupported) swiglu MoE node regardless of which output is requested."""
+    ort = pytest.importorskip("onnxruntime")
+    n_expert, n_expert_used = 4, 2
+    path, weights, config = _build_tiny_gpt_oss_moe_checkpoint(
+        tmp_path, n_expert, n_expert_used
+    )
+    meta = read_gguf_metadata(path)
+
+    n_embd, n_ff = config["n_embd"], config["n_ff"]
+    batch, seq = 1, 3
+
+    b = _Builder()
+    declare, declare_optional = _declare_closures(b, meta["tensors"])
+    h = "h"
+    ffn_out = _gpt_oss_moe_ffn(
+        b, h, "blk.0", n_embd, n_ff, n_expert, n_expert_used, declare, declare_optional
+    )
+
+    graph_inputs = [
+        onnx.helper.make_tensor_value_info(
+            h, onnx.TensorProto.FLOAT, [batch, seq, n_embd]
+        )
+    ]
+    graph_outputs = [
+        onnx.helper.make_tensor_value_info(
+            ffn_out, onnx.TensorProto.FLOAT, [batch, seq, n_embd]
+        )
+    ]
+    model = _make_model(b, graph_inputs, graph_outputs, "gpt_oss_moe_test")
+    onnx.checker.check_model(model)
+
+    model, skipped = import_gguf_weights(model, path)
+    assert skipped == []
+
+    moe_nodes = [n for n in model.graph.node if n.op_type == "MoE"]
+    assert len(moe_nodes) == 1
+    node = moe_nodes[0]
+    assert node.domain == "com.microsoft"
+    attrs = {a.name: a for a in node.attribute}
+    assert attrs["k"].i == n_expert_used
+    assert attrs["activation_type"].s == b"swiglu"
+    assert attrs["swiglu_fusion"].i == 1
+    assert attrs["activation_alpha"].f == pytest.approx(1.702)
+    assert attrs["activation_beta"].f == pytest.approx(1.0)
+    assert attrs["swiglu_limit"].f == pytest.approx(7.0)
+    assert attrs["normalize_routing_weights"].i == 1
+
+    assert node.input[0] == h
+    router_probs_name, fc1_w_name, fc1_b_name, down_w_name, down_b_name = node.input[1:]
+    assert down_w_name == "blk.0.ffn_down_exps.weight"
+    assert down_b_name == "blk.0.ffn_down_exps.bias"
+
+    by_name = {i.name: i for i in model.graph.initializer}
+    assert list(by_name["blk.0.ffn_gate_exps.weight"].dims) == [n_expert, n_ff, n_embd]
+    assert list(by_name["blk.0.ffn_up_exps.weight"].dims) == [n_expert, n_ff, n_embd]
+    assert list(by_name["blk.0.ffn_down_exps.weight"].dims) == [n_expert, n_embd, n_ff]
+    assert list(by_name["blk.0.ffn_down_exps.bias"].dims) == [n_expert, n_embd]
+
+    simplified, ok = onnxsim.simplify(
+        model, check_n=0, perform_optimization=False, skip_constant_folding=True
+    )
+    assert ok
+    out_shape = simplified.graph.output[0].type.tensor_type.shape
+    assert [d.dim_value for d in out_shape.dim] == [batch, seq, n_embd]
+
+    # Extract the subgraph reachable from just the router logits and the
+    # fused fc1 weight/bias -- all upstream of (never dependent on) the MoE
+    # node, so onnx.utils.Extractor's real subgraph excludes it entirely
+    # (unlike onnxruntime's own execution-plan builder, which would still
+    # trip over it -- see this test's own docstring).
+    extractable = onnx.ModelProto()
+    extractable.CopyFrom(model)
+    for name, shape in (
+        (router_probs_name, [None, n_expert]),
+        (fc1_w_name, [n_expert, 2 * n_ff, n_embd]),
+        (fc1_b_name, [n_expert, 2 * n_ff]),
+    ):
+        extractable.graph.value_info.append(
+            onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+        )
+    probe_model = onnx.utils.Extractor(extractable).extract_model(
+        [h], [router_probs_name, fc1_w_name, fc1_b_name]
+    )
+
+    rng = np.random.default_rng(9)
+    h_val = rng.standard_normal((batch, seq, n_embd)).astype(np.float32)
+
+    sess = ort.InferenceSession(
+        probe_model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    router_probs, fc1_w, fc1_b = sess.run(
+        [router_probs_name, fc1_w_name, fc1_b_name], {h: h_val}
+    )
+
+    # Independent numpy reference, built from the very weights written into
+    # the GGUF file above -- not by re-reading anything back out of `model`.
+    router_w = weights["blk.0.ffn_gate_inp.weight"]
+    router_b = weights["blk.0.ffn_gate_inp.bias"]
+    ref_logits = h_val @ router_w.T + router_b
+    ref_router_probs = ref_logits.reshape(-1, n_expert)
+
+    gate_w, up_w = (
+        weights["blk.0.ffn_gate_exps.weight"],
+        weights["blk.0.ffn_up_exps.weight"],
+    )
+    gate_b, up_b = (
+        weights["blk.0.ffn_gate_exps.bias"],
+        weights["blk.0.ffn_up_exps.bias"],
+    )
+    ref_fc1_w = np.empty((n_expert, 2 * n_ff, n_embd), dtype=np.float32)
+    ref_fc1_w[:, 0::2, :] = gate_w
+    ref_fc1_w[:, 1::2, :] = up_w
+    ref_fc1_b = np.empty((n_expert, 2 * n_ff), dtype=np.float32)
+    ref_fc1_b[:, 0::2] = gate_b
+    ref_fc1_b[:, 1::2] = up_b
+
+    np.testing.assert_allclose(router_probs, ref_router_probs, atol=1e-5, rtol=1e-5)
+    np.testing.assert_array_equal(fc1_w, ref_fc1_w)
+    np.testing.assert_array_equal(fc1_b, ref_fc1_b)
+
+
+def test_gpt_oss_moe_ffn_requires_both_or_neither_gate_up_bias(tmp_path):
+    """A checkpoint with exactly one of ``ffn_gate_exps.bias``/
+    ``ffn_up_exps.bias`` present can't build the fused fc1 bias
+    ``swiglu_fusion=1`` needs (there is no defined meaning for interleaving
+    a real bias with a missing one) -- must be rejected up front, the same
+    way ``_reconstruct_llama_family``'s own ``declare`` rejects a
+    shape-mismatched tensor rather than silently building a wrong graph."""
+    n_expert, n_ff, n_embd = 2, 3, 4
+    tensors = [
+        {
+            "name": "blk.0.ffn_gate_inp.weight",
+            "shape": [n_expert, n_embd],
+            "ggml_type": GGML_TYPE_F32,
+        },
+        {
+            "name": "blk.0.ffn_gate_exps.weight",
+            "shape": [n_expert, n_ff, n_embd],
+            "ggml_type": GGML_TYPE_F32,
+        },
+        {
+            "name": "blk.0.ffn_gate_exps.bias",
+            "shape": [n_expert, n_ff],
+            "ggml_type": GGML_TYPE_F32,
+        },
+        {
+            "name": "blk.0.ffn_up_exps.weight",
+            "shape": [n_expert, n_ff, n_embd],
+            "ggml_type": GGML_TYPE_F32,
+        },
+        # blk.0.ffn_up_exps.bias deliberately omitted.
+        {
+            "name": "blk.0.ffn_down_exps.weight",
+            "shape": [n_expert, n_embd, n_ff],
+            "ggml_type": GGML_TYPE_F32,
+        },
+    ]
+    b = _Builder()
+    declare, declare_optional = _declare_closures(b, tensors)
+    with pytest.raises(UnsupportedArchitectureError, match="ffn_gate_exps.bias"):
+        _gpt_oss_moe_ffn(
+            b, "h", "blk.0", n_embd, n_ff, n_expert, 1, declare, declare_optional
+        )

--- a/tests/test_gpt_oss_reconstruct.py
+++ b/tests/test_gpt_oss_reconstruct.py
@@ -1,0 +1,362 @@
+"""Integration test for ``onnxsim.reconstruct_gguf_graph``'s gpt-oss
+dispatch: wires ``_gpt_oss_attention_block`` and ``_gpt_oss_moe_ffn``
+together (via ``_reconstruct_gpt_oss``) into a full multi-layer graph and
+checks the *plumbing* -- tensor names, shapes, attribute values, and the
+per-layer sliding/full mask alternation -- rather than re-deriving either
+block's own math, which ``tests/test_gpt_oss_attention.py`` and
+``tests/test_gpt_oss_moe_reconstruct.py`` already validate independently
+against real onnxruntime/``onnx.reference.ReferenceEvaluator`` runs.
+
+Deliberately exercises head_dim independence from
+embedding_length/head_count (see ``_gpt_oss_attention_block``'s own
+docstring, point 1): this checkpoint's ``head_dim`` does not equal
+``embedding_length // head_count``, the one thing that would silently break
+if the integration reused ``_reconstruct_llama_family``'s shape derivation
+instead of reading ``attention.key_length`` directly.
+"""
+
+import struct
+
+import numpy as np
+import onnx
+import pytest
+
+import onnxsim
+from onnxsim.gguf_reconstruct import UnsupportedArchitectureError
+
+GGUF_MAGIC = 0x46554747
+GGUF_VERSION = 3
+
+GGUF_METADATA_VALUE_TYPE_UINT32 = 4
+GGUF_METADATA_VALUE_TYPE_FLOAT32 = 6
+GGUF_METADATA_VALUE_TYPE_STRING = 8
+
+GGML_TYPE_F32 = 0
+
+
+def _string_bytes(s):
+    b = s.encode("utf-8")
+    return struct.pack("<Q", len(b)) + b
+
+
+def _kv_string(key, value):
+    return (
+        _string_bytes(key)
+        + struct.pack("<I", GGUF_METADATA_VALUE_TYPE_STRING)
+        + _string_bytes(value)
+    )
+
+
+def _kv_uint32(key, value):
+    return (
+        _string_bytes(key)
+        + struct.pack("<I", GGUF_METADATA_VALUE_TYPE_UINT32)
+        + struct.pack("<I", value)
+    )
+
+
+def _kv_float32(key, value):
+    return (
+        _string_bytes(key)
+        + struct.pack("<I", GGUF_METADATA_VALUE_TYPE_FLOAT32)
+        + struct.pack("<f", value)
+    )
+
+
+def _align_up(n, align=32):
+    rem = n % align
+    return n if rem == 0 else n + (align - rem)
+
+
+def _write_gguf(path, kv_chunks, weights):
+    """Same minimal, byte-accurate GGUF v3 writer as
+    ``tests/test_gguf_reconstruct.py``'s own ``_write_gguf`` (duplicated
+    per this repo's convention of not importing fixtures across test
+    files)."""
+    infos = b""
+    data_chunks = []
+    offset = 0
+    for name, arr in weights.items():
+        ne = list(reversed(arr.shape))
+        raw = arr.astype("<f4").tobytes()
+        infos += _string_bytes(name)
+        infos += struct.pack("<I", len(ne))
+        for d in ne:
+            infos += struct.pack("<Q", d)
+        infos += struct.pack("<I", GGML_TYPE_F32)
+        infos += struct.pack("<Q", offset)
+        data_chunks.append((offset, raw))
+        offset = _align_up(offset + len(raw))
+
+    header = struct.pack(
+        "<IIQQ", GGUF_MAGIC, GGUF_VERSION, len(weights), len(kv_chunks)
+    )
+    body = b"".join(kv_chunks)
+    header_end = len(header) + len(body) + len(infos)
+    data_section_start = _align_up(header_end)
+
+    with open(path, "wb") as f:
+        f.write(header)
+        f.write(body)
+        f.write(infos)
+        f.write(b"\x00" * (data_section_start - header_end))
+        pos = data_section_start
+        for rel_offset, raw in data_chunks:
+            abs_offset = data_section_start + rel_offset
+            f.write(b"\x00" * (abs_offset - pos))
+            f.write(raw)
+            pos = abs_offset + len(raw)
+
+
+def _build_tiny_gpt_oss_checkpoint(tmp_path, seed=11):
+    """A hand-built, real GGUF v3 file for a tiny (2-layer) gpt-oss-style
+    checkpoint -- every tensor gpt-oss's own ``load_arch_tensors`` requires
+    (see ``_gpt_oss_attention_block``/``_gpt_oss_moe_ffn``'s own docstrings
+    for the exact llama.cpp source each tensor name/shape was verified
+    against), including the required per-tensor biases and the per-layer
+    ``attn_sinks``/``post_attention_norm`` tensors neither building block
+    reads itself (the norm is this module's own integration responsibility
+    -- see ``_reconstruct_gpt_oss``'s docstring).
+
+    ``head_dim`` (6) is deliberately NOT ``n_embd // n_head`` (8 // 2 = 4)
+    -- the one detail that would silently break if the integration reused
+    ``_reconstruct_llama_family``'s shape derivation instead of reading
+    ``attention.key_length`` directly.
+    """
+    rng = np.random.default_rng(seed)
+    n_embd, n_head, n_head_kv, head_dim = 8, 2, 1, 6
+    n_embd_q = n_head * head_dim
+    n_embd_kv = n_head_kv * head_dim
+    n_layer = 2
+    n_ff = 5
+    n_expert, n_expert_used = 4, 2
+    vocab = 10
+    eps = 1e-5
+    freq_base = 10000.0
+    sliding_window = 2
+    yarn_factor = 2.0
+
+    def rand(*shape):
+        return rng.standard_normal(shape).astype(np.float32) * 0.1
+
+    weights = {"token_embd.weight": rand(vocab, n_embd)}
+    for i in range(n_layer):
+        p = f"blk.{i}"
+        weights[f"{p}.attn_norm.weight"] = rand(n_embd) + 1.0
+        weights[f"{p}.attn_q.weight"] = rand(n_embd_q, n_embd)
+        weights[f"{p}.attn_q.bias"] = rand(n_embd_q)
+        weights[f"{p}.attn_k.weight"] = rand(n_embd_kv, n_embd)
+        weights[f"{p}.attn_k.bias"] = rand(n_embd_kv)
+        weights[f"{p}.attn_v.weight"] = rand(n_embd_kv, n_embd)
+        weights[f"{p}.attn_v.bias"] = rand(n_embd_kv)
+        weights[f"{p}.attn_output.weight"] = rand(n_embd, n_embd_q)
+        weights[f"{p}.attn_output.bias"] = rand(n_embd)
+        weights[f"{p}.attn_sinks.weight"] = rand(n_head)
+        weights[f"{p}.post_attention_norm.weight"] = rand(n_embd) + 1.0
+        weights[f"{p}.ffn_gate_inp.weight"] = rand(n_expert, n_embd)
+        weights[f"{p}.ffn_gate_inp.bias"] = rand(n_expert)
+        weights[f"{p}.ffn_gate_exps.weight"] = rand(n_expert, n_ff, n_embd)
+        weights[f"{p}.ffn_gate_exps.bias"] = rand(n_expert, n_ff)
+        weights[f"{p}.ffn_up_exps.weight"] = rand(n_expert, n_ff, n_embd)
+        weights[f"{p}.ffn_up_exps.bias"] = rand(n_expert, n_ff)
+        weights[f"{p}.ffn_down_exps.weight"] = rand(n_expert, n_embd, n_ff)
+        weights[f"{p}.ffn_down_exps.bias"] = rand(n_expert, n_embd)
+    weights["output_norm.weight"] = rand(n_embd) + 1.0
+    weights["output.weight"] = rand(vocab, n_embd)
+
+    kv_chunks = [
+        _kv_string("general.architecture", "gpt-oss"),
+        _kv_uint32("gpt-oss.block_count", n_layer),
+        _kv_uint32("gpt-oss.embedding_length", n_embd),
+        _kv_uint32("gpt-oss.expert_feed_forward_length", n_ff),
+        _kv_uint32("gpt-oss.attention.head_count", n_head),
+        _kv_uint32("gpt-oss.attention.head_count_kv", n_head_kv),
+        _kv_uint32("gpt-oss.attention.key_length", head_dim),
+        _kv_uint32("gpt-oss.attention.value_length", head_dim),
+        _kv_float32("gpt-oss.attention.layer_norm_rms_epsilon", eps),
+        _kv_float32("gpt-oss.rope.freq_base", freq_base),
+        _kv_uint32("gpt-oss.attention.sliding_window", sliding_window),
+        _kv_uint32("gpt-oss.expert_count", n_expert),
+        _kv_uint32("gpt-oss.expert_used_count", n_expert_used),
+        _kv_string("gpt-oss.rope.scaling.type", "yarn"),
+        _kv_float32("gpt-oss.rope.scaling.factor", yarn_factor),
+        _kv_float32("gpt-oss.rope.scaling.original_context_length", 4096.0),
+        _kv_float32("gpt-oss.rope.scaling.yarn_beta_fast", 32.0),
+        _kv_float32("gpt-oss.rope.scaling.yarn_beta_slow", 1.0),
+    ]
+    path = str(tmp_path / "tiny_gpt_oss.gguf")
+    _write_gguf(path, kv_chunks, weights)
+
+    config = dict(
+        n_embd=n_embd,
+        n_head=n_head,
+        n_head_kv=n_head_kv,
+        head_dim=head_dim,
+        n_layer=n_layer,
+        n_ff=n_ff,
+        n_expert=n_expert,
+        n_expert_used=n_expert_used,
+        vocab=vocab,
+        sliding_window=sliding_window,
+    )
+    return path, weights, config
+
+
+def test_reconstruct_gpt_oss_wires_up_the_full_graph_correctly(tmp_path):
+    path, weights, config = _build_tiny_gpt_oss_checkpoint(tmp_path)
+    n_embd = config["n_embd"]
+    n_head = config["n_head"]
+    head_dim = config["head_dim"]
+    n_embd_q = n_head * head_dim
+    n_layer = config["n_layer"]
+    n_expert_used = config["n_expert_used"]
+    vocab = config["vocab"]
+    batch, seq = 1, 4
+
+    model, skipped = onnxsim.reconstruct_gguf_graph(path, batch_size=batch, seq_len=seq)
+    assert skipped == []
+    onnx.checker.check_model(model)
+
+    out = model.graph.output[0]
+    out_dims = [d.dim_value for d in out.type.tensor_type.shape.dim]
+    assert out_dims == [batch, seq, vocab]
+
+    by_name = {i.name: i for i in model.graph.initializer}
+
+    # head_dim independence: attn_q/attn_output use n_head*head_dim (12),
+    # not n_embd (8) -- the detail that would silently break if this
+    # integration reused _reconstruct_llama_family's shape derivation.
+    assert n_embd_q != n_embd
+    assert list(by_name["blk.0.attn_q.weight"].dims) == [n_embd_q, n_embd]
+    assert list(by_name["blk.0.attn_output.weight"].dims) == [n_embd, n_embd_q]
+
+    # The pre-FFN norm is named "post_attention_norm" for this architecture,
+    # NOT "ffn_norm" (see _reconstruct_gpt_oss's own docstring) -- both
+    # tensors must actually be hydrated (real values, not the placeholder's
+    # zero-fill) since the checkpoint provides post_attention_norm and
+    # reconstruct_gguf_graph calls import_gguf_weights internally.
+    assert "blk.0.post_attention_norm.weight" in by_name
+    assert "blk.0.ffn_norm.weight" not in by_name
+    got_norm = onnx.numpy_helper.to_array(by_name["blk.0.post_attention_norm.weight"])
+    np.testing.assert_allclose(
+        got_norm, weights["blk.0.post_attention_norm.weight"], rtol=1e-6
+    )
+
+    # attn_sinks is present and hydrated with the real per-head values.
+    got_sinks = onnx.numpy_helper.to_array(by_name["blk.0.attn_sinks.weight"])
+    np.testing.assert_allclose(got_sinks, weights["blk.0.attn_sinks.weight"], rtol=1e-6)
+
+    # Exactly one MoE node per layer, each with gpt-oss's swiglu attributes.
+    moe_nodes = [n for n in model.graph.node if n.op_type == "MoE"]
+    assert len(moe_nodes) == n_layer
+    for node in moe_nodes:
+        assert node.domain == "com.microsoft"
+        attrs = {a.name: a for a in node.attribute}
+        assert attrs["k"].i == n_expert_used
+        assert attrs["activation_type"].s == b"swiglu"
+        assert attrs["swiglu_fusion"].i == 1
+        assert attrs["activation_alpha"].f == pytest.approx(1.702)
+        assert attrs["activation_beta"].f == pytest.approx(1.0)
+        assert attrs["swiglu_limit"].f == pytest.approx(7.0)
+        assert attrs["normalize_routing_weights"].i == 1
+
+    # fc1_w is a computed (Reshape) output, not itself an initializer, until
+    # a later onnxsim.simplify() constant-folds it -- check it's actually
+    # produced by the gate/up interleave fusion (named with the
+    # _interleave_gate_up prefix _gpt_oss_moe_ffn passes) via its name and
+    # producing node's op_type, not by looking it up as an initializer.
+    fc1_w_name = moe_nodes[0].input[2]
+    assert fc1_w_name.startswith("blk.0.moe_fc1_w")
+    producer = next(n for n in model.graph.node if fc1_w_name in n.output)
+    assert producer.op_type == "Reshape"
+
+    # Per-layer sliding/full mask alternation (swa_period defaults to 2,
+    # so layer 0 is sliding and layer 1 is full -- see
+    # _gpt_oss_is_sliding_layer's own docstring): each layer's additive
+    # attention-mask CONSTANT is a distinct initializer (not shared across
+    # layers, since only every-other layer is banded), so this checks the
+    # actual embedded mask values rather than trusting the naming alone.
+    # Every _Builder-emitted name gets a unique numeric suffix (see
+    # _Builder._name), so look these up by prefix rather than exact name.
+    def _initializer_by_prefix(prefix: str) -> onnx.TensorProto:
+        matches = [t for name, t in by_name.items() if name.startswith(prefix)]
+        assert len(matches) == 1, (prefix, list(by_name))
+        return matches[0]
+
+    sliding_window = config["sliding_window"]
+    mask0 = onnx.numpy_helper.to_array(_initializer_by_prefix("blk.0.attn_mask"))
+    mask1 = onnx.numpy_helper.to_array(_initializer_by_prefix("blk.1.attn_mask"))
+    assert mask0.shape == (seq, seq)
+    # Sliding layer: query position 3 can see key positions 2,3 only
+    # (window width 2) -- key position 0/1 must be masked even though a
+    # plain causal mask alone would allow them.
+    assert mask0[3, 1] < -1.0 and mask0[3, 2] == 0.0 and mask0[3, 3] == 0.0
+    # Full layer: query position 3 can see every earlier key position.
+    assert mask1[3, 0] == 0.0 and mask1[3, 1] == 0.0
+    assert not np.array_equal(mask0, mask1)
+    assert sliding_window == 2  # sanity: matches the checkpoint's own metadata
+
+    # onnxsim.simplify() itself accepts the reconstructed graph (shape
+    # inference succeeds end to end) -- MoE has no CPU kernel, so this
+    # can't run through onnxruntime, matching the Mixtral MoE test's own
+    # scope (see test_gguf_reconstruct.py).
+    simplified, ok = onnxsim.simplify(
+        model, check_n=0, perform_optimization=False, skip_constant_folding=True
+    )
+    assert ok
+    out_shape = simplified.graph.output[0].type.tensor_type.shape
+    assert [d.dim_value for d in out_shape.dim] == [batch, seq, vocab]
+
+
+def test_reconstruct_gpt_oss_requires_sliding_window_metadata(tmp_path):
+    path, _weights, _config = _build_tiny_gpt_oss_checkpoint(tmp_path)
+    # Rewrite without the (required, per llama.cpp's own 2-arg get_key)
+    # sliding_window key by dropping it from a fresh build -- simplest way
+    # to construct the negative case is to omit it directly.
+    rng = np.random.default_rng(0)
+    n_embd, n_head, n_head_kv, head_dim = 4, 1, 1, 4
+    weights = {
+        "token_embd.weight": rng.standard_normal((3, n_embd)).astype(np.float32),
+    }
+    kv_chunks = [
+        _kv_string("general.architecture", "gpt-oss"),
+        _kv_uint32("gpt-oss.block_count", 1),
+        _kv_uint32("gpt-oss.embedding_length", n_embd),
+        _kv_uint32("gpt-oss.expert_feed_forward_length", 4),
+        _kv_uint32("gpt-oss.attention.head_count", n_head),
+        _kv_uint32("gpt-oss.attention.head_count_kv", n_head_kv),
+        _kv_uint32("gpt-oss.attention.key_length", head_dim),
+        _kv_uint32("gpt-oss.expert_count", 2),
+        _kv_uint32("gpt-oss.expert_used_count", 1),
+        # attention.sliding_window deliberately omitted.
+    ]
+    path2 = str(tmp_path / "missing_swa.gguf")
+    _write_gguf(path2, kv_chunks, weights)
+
+    with pytest.raises(UnsupportedArchitectureError, match="sliding_window"):
+        onnxsim.reconstruct_gguf_graph(path2)
+
+
+def test_reconstruct_gpt_oss_requires_head_dim_metadata(tmp_path):
+    rng = np.random.default_rng(0)
+    n_embd = 4
+    weights = {
+        "token_embd.weight": rng.standard_normal((3, n_embd)).astype(np.float32),
+    }
+    kv_chunks = [
+        _kv_string("general.architecture", "gpt-oss"),
+        _kv_uint32("gpt-oss.block_count", 1),
+        _kv_uint32("gpt-oss.embedding_length", n_embd),
+        _kv_uint32("gpt-oss.expert_feed_forward_length", 4),
+        _kv_uint32("gpt-oss.attention.head_count", 1),
+        _kv_uint32("gpt-oss.attention.head_count_kv", 1),
+        # attention.key_length/value_length deliberately omitted.
+        _kv_uint32("gpt-oss.attention.sliding_window", 2),
+        _kv_uint32("gpt-oss.expert_count", 2),
+        _kv_uint32("gpt-oss.expert_used_count", 1),
+    ]
+    path = str(tmp_path / "missing_head_dim.gguf")
+    _write_gguf(path, kv_chunks, weights)
+
+    with pytest.raises(UnsupportedArchitectureError, match="key_length"):
+        onnxsim.reconstruct_gguf_graph(path)

--- a/tests/test_import_gguf_weights.py
+++ b/tests/test_import_gguf_weights.py
@@ -6,12 +6,14 @@ already have.
 
 Covers the GGML "K-quant" block formats (Q8_0, Q4_K, Q5_K, Q6_K) real
 quantized checkpoints (e.g. Unsloth's GGUF exports) actually use for the
-bulk of their weights: this module writes real, byte-accurate GGUF v3 files
-containing hand-encoded K-quant blocks with known values, computing each
-expected dequantized float independently (a from-scratch transcription of
-GGML's published block layout/dequant formula, not a reuse of the C++
-decoder under test -- see ggml_kquant.h) and checking onnxsim's decoded
-result against it.
+bulk of their weights, plus MXFP4 (the OCP Microscaling FP4 format official
+gpt-oss GGUF releases use natively for their MoE expert weights): this
+module writes real, byte-accurate GGUF v3 files containing hand-encoded
+blocks with known values, computing each expected dequantized float
+independently (a from-scratch transcription of GGML's published block
+layout/dequant formula, not a reuse of the C++ decoder under test -- see
+ggml_kquant.h/ggml_mxfp4.h) and checking onnxsim's decoded result against
+it.
 """
 
 import struct
@@ -32,6 +34,7 @@ GGML_TYPE_Q8_0 = 8
 GGML_TYPE_Q4_K = 12
 GGML_TYPE_Q5_K = 13
 GGML_TYPE_Q6_K = 14
+GGML_TYPE_MXFP4 = 39
 GGML_TYPE_Q4_0 = 2  # legacy family onnxsim does NOT decode -- must be skipped
 
 
@@ -127,6 +130,36 @@ def _make_q4_k_block(rng):
     return raw, expected
 
 
+# GGML's kvalues_fp4/kvalues_mxfp4 table (e2m1-style magnitudes, doubled):
+# code 0-7 are the non-negative magnitudes {0, 0.5, 1, 1.5, 2, 3, 4, 6} times
+# 2, codes 8-15 their negated counterparts -- transcribed directly from the
+# OCP Microscaling FP4 spec table GGML itself uses (ggml-common.h's
+# kvalues_fp4), same as onnxsim/ggml_mxfp4.h's kMxfp4Values.
+_MXFP4_VALUES = [0, 1, 2, 3, 4, 6, 8, 12, 0, -1, -2, -3, -4, -6, -8, -12]
+
+
+def _e8m0_to_f32_half(e):
+    # Independent (pure floating-point, not bit-pattern-construction like
+    # ggml_mxfp4.h's GgmlE8m0ToFloat32Half) computation of the same value:
+    # an E8M0 byte `e` nominally encodes 2**(e-127), and GGML's own
+    # ggml_e8m0_to_fp32_half halves that (since _MXFP4_VALUES above is
+    # already doubled) -- 2**(e-128).
+    return 2.0 ** (e - 128)
+
+
+def _make_mxfp4_block(rng):
+    # One 32-element MXFP4 block: 1 byte E8M0 exponent + 16 bytes of packed
+    # 4-bit codes, element i and i+16 sharing byte i's low/high nibble (NOT
+    # the consecutive-pair packing K-quant uses).
+    e = int(rng.integers(0, 255))  # 255 is GGML's only NaN encoding
+    codes = [int(rng.integers(0, 16)) for _ in range(32)]
+    qs = bytes((codes[i] & 0xF) | ((codes[i + 16] & 0xF) << 4) for i in range(16))
+    raw = struct.pack("<B", e) + qs
+    d = _e8m0_to_f32_half(e)
+    expected = [_MXFP4_VALUES[c] * d for c in codes]
+    return raw, expected
+
+
 def _model(body, initializer=(), opset=13, ir_version=10):
     model = parser.parse_model(
         f"""
@@ -185,6 +218,22 @@ def test_import_q4_k_weights(tmp_path):
     _write_gguf(gguf_path, [("W", GGML_TYPE_Q4_K, [256], raw)])
 
     model = _identity_model("W", [256])
+    result, skipped = onnxsim.import_gguf_weights(model, gguf_path)
+
+    assert skipped == []
+    w = next(i for i in result.graph.initializer if i.name == "W")
+    assert w.data_type == onnx.TensorProto.FLOAT
+    got = onnx.numpy_helper.to_array(w)
+    np.testing.assert_allclose(got, np.array(expected, dtype=np.float32), rtol=1e-5)
+
+
+def test_import_mxfp4_weights(tmp_path):
+    rng = np.random.default_rng(10)
+    raw, expected = _make_mxfp4_block(rng)
+    gguf_path = str(tmp_path / "model.gguf")
+    _write_gguf(gguf_path, [("W", GGML_TYPE_MXFP4, [32], raw)])
+
+    model = _identity_model("W", [32])
     result, skipped = onnxsim.import_gguf_weights(model, gguf_path)
 
     assert skipped == []


### PR DESCRIPTION
## Summary

Follow-up to #921/#934 (`import_gguf_weights`/`com.microsoft.MoE` MoE work), closing the remaining real gaps for gpt-oss-20b end-to-end support: a **decoder** for its native quantization format, and a **graph-reconstruction template** for its architecture.

### Part 1: MXFP4 GGUF block-decode support (`import_gguf_weights`)

gpt-oss-20b's own GGUF checkpoints quantize their MoE expert weights as **MXFP4** (the OCP Microscaling FP4 format), a block format `import_gguf_weights` previously had no decoder for (only the K-quant family — Q4_K/Q5_K/Q6_K/Q8_0 — was supported).

- **Adds `gguf_dtype.h`'s `IsMxfp4` predicate** and block-size helpers (`Mxfp4BlockElements`/`Mxfp4BlockBytes` — 32 elements per 17-byte block) alongside the existing `IsKQuant` family, plus a new private dtype code `ONNXSIM_GGML_MXFP4`, and extends `ToOnnx`/`FromOnnx`/`TryTotalBytes` to cover it.
- **New `onnxsim/ggml_mxfp4.h` decoder**, mirroring `ggml_kquant.h`'s pure, dependency-free style: `block_mxfp4`'s layout (1 E8M0 exponent byte + 16 bytes of packed 4-bit codes), the `kvalues_fp4` lookup table, and `ggml_e8m0_to_fp32_half`, all transcribed directly from GGML's own reference implementation.
- **Wires it into `TensorPool::DequantizeToFloat`** and **`HydrateTensorProtoFromGGUF`**, so `import_gguf_weights`, `ImportModelWithGGUF`/`ImportModelWithGGUFToPool`, and `LoadGGUF`/`LoadGGUFMmap` all pick it up with no further plumbing changes.

### Part 2: gpt-oss-20b architecture support (`reconstruct_gguf_graph`)

Adds `gpt-oss` as a fully-supported architecture in `onnxsim.reconstruct_gguf_graph` — a genuinely different transformer family from the existing Llama-family template, verified directly against a local, offline llama.cpp checkout (`src/models/openai-moe.cpp`, `src/llama-graph.cpp`, `src/llama-arch.cpp`, `src/llama-hparams.cpp`, `ggml/src/ggml-cpu/ops.cpp`) and gpt-oss-20b's real `config.json`, not recalled from memory:

- **YaRN-scaled RoPE** (not bare freq_base RoPE), exact formula transcribed from `ggml_rope_yarn_corr_dims`/`rope_yarn`.
- **Alternating sliding-window/full attention** (period 2, starting local) with a learned per-head "attention sink" folded into the softmax denominator only — corrected from an earlier "append then drop a column" assumption; it's never materialized as an extra key/value position.
- **`head_dim` read from independent GGUF metadata** (`attention.key_length`/`.value_length`), NOT `embedding_length // head_count` the way every other supported architecture derives it (gpt-oss-20b: 64 vs 2880/64=45) — the one detail that would silently corrupt every other architecture's shape derivation if reused as-is.
- **An always-MoE FFN** using `com.microsoft.MoE`'s `activation_type="swiglu"`/`swiglu_fusion=1` reference decomposition (added in #934), with fc1 fused at graph-build time — via ordinary `Reshape`/`Concat`/`Reshape` ops, later constant-folded by `onnxsim.simplify()` — from the checkpoint's own separate `ffn_gate_exps`/`ffn_up_exps` tensors (gpt-oss never stores a pre-fused tensor, correcting an earlier assumption in this repo's own docs). The hardcoded activation constants (`alpha=1.702`, `beta=1.0`, `limit=7.0`) and gpt-oss's own gating function (proven mathematically identical to the schema's softmax-over-all→top-k→renormalize convention) are independently re-derived and verified, not assumed.
- **The pre-FFN norm tensor is GGUF-named `blk.N.post_attention_norm.weight`** for this architecture specifically — llama.cpp has two different tensor names for the same "norm right before the FFN" role, and gpt-oss uses the other one (a detail the integration step, not either building block alone, is responsible for getting right).

Also corrects a stale doc claim (`docs/import-gguf-weights.md` previously said gpt-oss fuses gate/up into one GGUF tensor — verified it does not; that gap belongs to some other, still-unaddressed newer llama.cpp architecture) and a stale "no MoE architecture has a template" note that was already outdated before this change.

## Test plan

- [x] New standalone unit test `ggml_mxfp4_test` (C++) — hand-verified block decode, bad-input rejection
- [x] `gguf_dtype_test`/`tensor_pool_gguf_test`/`tensor_pool_gguf_bridge_test` extended with MXFP4 coverage
- [x] `tests/test_gpt_oss_attention.py` (7 tests) — independent numpy reference via `onnx.reference.ReferenceEvaluator`
- [x] `tests/test_gpt_oss_moe_reconstruct.py` (3 tests) — real onnxruntime runs for the gate/up interleave fusion and router logits
- [x] `tests/test_gpt_oss_reconstruct.py` (3 tests) — full wired-together graph: tensor naming/shapes including `head_dim` independence, per-layer swiglu MoE attributes, sliding/full mask alternation
- [x] `pytest tests/test_import_gguf_weights.py tests/test_gguf_reconstruct.py -q` — all passing
- [x] Full suite: `CI=true pytest tests/ -q --ignore=tests/test_timm.py` — 1266 passed, 76 skipped, 0 failed
- [x] `ctest` (full C++ suite) — 18/18 passed
- [x] `ruff check` / `ruff format --diff` / `mypy` / `clang-format --dry-run --Werror` — all clean

https://claude.ai/code/session_0153LP27pjLXDEFX5vrhHvNk

---
_Generated by [Claude Code](https://claude.ai/code/session_0153LP27pjLXDEFX5vrhHvNk)_