### PR TITLE
Add macOS Core ML decode benchmark job to CI workflow

### DIFF
--- a/.github/workflows/coreml-integration.yml
+++ b/.github/workflows/coreml-integration.yml
@@ -32,6 +32,16 @@ name: Core ML Integration
 # secret, the one thing a token-less local sandbox can't do (see that script's module
 # docstring). Like model-regression.yml's real-model sweep, this is multi-GB-download
 # heavy, so it runs on workflow_dispatch/schedule only, never on pull_request.
+#
+# A fourth job -- `benchmark-decode-macos` -- closes the loop those two only prepare
+# for: it exports a small model and actually runs scripts/apple/run_llm_decode_benchmark.py
+# against it through the real Core ML runtime on the macOS runner, the same two axes
+# (decode tok/s, peak RSS) DeviceMark's (https://devicemark.github.io/) on-device LLM
+# leaderboard measures. Every other job in this workflow only checks that a graph
+# *converts*; this is the one place the decode benchmark harness itself actually
+# executes anywhere, since no environment developing this repo has a macOS/Core ML
+# runtime to run it in locally. Also workflow_dispatch/schedule-only, matching the
+# other real-model jobs.
 
 on:
   schedule:
@@ -200,3 +210,43 @@ jobs:
           python "$GITHUB_WORKSPACE/scripts/apple/prepare_benchmark_models.py" \
             --only meta-llama/Llama-3.2-1B-Instruct \
             --output-dir benchmark_models
+
+  benchmark-decode-macos:
+    name: Run LLM decode benchmark (macOS, real Core ML)
+    needs: build-macos
+    if: github.event_name != 'pull_request'
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+      - uses: actions/download-artifact@v8
+        with:
+          name: onnxsim-wheel-macos
+          path: wheelhouse
+      - name: Install onnxsim wheel + LLM export/benchmark deps
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install "optimum-onnx" transformers coremltools onnxruntime
+          python3 -m pip install wheelhouse/*.whl
+      - name: Verify the installed wheel is used (not the source tree)
+        working-directory: ${{ runner.temp }}
+        run: python3 -c "import onnxsim, onnxsim.onnxsim_cpp2py_export as m; print(onnxsim.__version__, m.__file__)"
+      - name: Export HuggingFaceTB/SmolLM2-135M-Instruct
+        working-directory: ${{ runner.temp }}
+        run: |
+          python3 "$GITHUB_WORKSPACE/scripts/apple/export_llm_to_coreml.py" \
+            HuggingFaceTB/SmolLM2-135M-Instruct \
+            --max-context-length 512 --output smollm2.mlpackage
+      - name: Run the decode benchmark through the real Core ML runtime
+        working-directory: ${{ runner.temp }}
+        run: |
+          {
+            echo "### Decode benchmark: HuggingFaceTB/SmolLM2-135M-Instruct"
+            echo '```'
+            python3 "$GITHUB_WORKSPACE/scripts/apple/run_llm_decode_benchmark.py" \
+              smollm2.mlpackage --prompt "The capital of France is" --max-new-tokens 20
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/scripts/apple/README.md
+++ b/scripts/apple/README.md
@@ -109,6 +109,12 @@ methodology.
   the rest of this directory, it only *runs* a model on macOS (that's where
   Core ML's runtime lives); the export step itself needs no Apple hardware.
 
+`coreml-integration.yml`'s `benchmark-decode-macos` job runs this exact pair
+end-to-end (export `HuggingFaceTB/SmolLM2-135M-Instruct`, then the decode
+benchmark) on a macOS GitHub-hosted runner, posting the numbers to that run's
+job summary -- `workflow_dispatch`/schedule-only, like the other real-model
+jobs in that workflow, not on every PR.
+
 ### Scaling to few-billion-parameter models
 
 DeviceMark's own leaderboard mostly tests models in the 1-4B range, well


### PR DESCRIPTION
## Summary

Adds a new `benchmark-decode-macos` job to the Core ML integration workflow that exports a small LLM model and runs the decode benchmark against it through the real Core ML runtime on macOS, closing the loop for the benchmark infrastructure that was previously only prepared for but never actually executed in CI.

## Changes

- **Workflow job**: Added `benchmark-decode-macos` job to `.github/workflows/coreml-integration.yml` that:
  - Depends on the `build-macos` job to get the onnxsim wheel
  - Runs on `macos-15` with a 30-minute timeout
  - Exports `HuggingFaceTB/SmolLM2-135M-Instruct` to Core ML format with 512 token context
  - Executes `scripts/apple/run_llm_decode_benchmark.py` against the exported model through the real Core ML runtime
  - Posts benchmark results (decode tok/s, peak RSS) to the job summary
  - Runs only on `workflow_dispatch` and schedule events, not on pull requests (matching other real-model jobs)

- **Documentation**: Updated `scripts/apple/README.md` to document that the `benchmark-decode-macos` job runs the export and benchmark end-to-end on macOS CI, clarifying that this is the only place in the development workflow where the decode benchmark harness actually executes against real Core ML.

## Implementation Details

- The job verifies the installed wheel is used (not the source tree) before proceeding
- Uses `tee` to capture benchmark output to both stdout and the GitHub job summary
- Follows the same workflow_dispatch/schedule-only pattern as other real-model jobs (`prepare-benchmark-models-macos`) to avoid excessive CI costs
- This is the first and only place in the workflow where the decode benchmark actually runs, since local development environments typically lack macOS/Core ML runtime

https://claude.ai/code/session_01T3MD7VAmysceuqiBQYHvWQ