### PR TITLE
Add decode parity check against Hugging Face reference model

### DIFF
--- a/.github/workflows/coreml-integration.yml
+++ b/.github/workflows/coreml-integration.yml
@@ -34,14 +34,22 @@ name: Core ML Integration
 # heavy, so it runs on workflow_dispatch/schedule only, never on pull_request.
 #
 # A fourth job -- `benchmark-decode-macos` -- closes the loop those two only prepare
-# for: it exports a small model and actually runs scripts/apple/run_llm_decode_benchmark.py
-# against it through the real Core ML runtime on the macOS runner, the same two axes
-# (decode tok/s, peak RSS) DeviceMark's (https://devicemark.github.io/) on-device LLM
-# leaderboard measures. Every other job in this workflow only checks that a graph
-# *converts*; this is the one place the decode benchmark harness itself actually
-# executes anywhere, since no environment developing this repo has a macOS/Core ML
-# runtime to run it in locally. Also workflow_dispatch/schedule-only, matching the
-# other real-model jobs.
+# for: it exports each model in a small matrix and actually runs
+# scripts/apple/run_llm_decode_benchmark.py against it through the real Core ML
+# runtime on the macOS runner, the same two axes (decode tok/s, peak RSS)
+# DeviceMark's (https://devicemark.github.io/) on-device LLM leaderboard measures --
+# plus scripts/apple/check_decode_parity.py, which greedily generates the same
+# prompt through the original Hugging Face model (CPU) and reports how well the
+# two token sequences agree, to catch a translator bug that produces a model
+# Core ML happily runs but computes something wrong (see that script's module
+# docstring for why this is an agreement-rate check, not bit-exact). Every other
+# job in this workflow only checks that a graph *converts*; this is the one place
+# the decode benchmark and parity harnesses themselves actually execute anywhere,
+# since no environment developing this repo has a macOS/Core ML runtime to run
+# them in locally. The matrix spans two already-validated architecture families
+# (Llama-style via SmolLM2, Qwen2) so a translator regression specific to one
+# doesn't hide behind the other passing. Also workflow_dispatch/schedule-only,
+# matching the other real-model jobs.
 
 on:
   schedule:
@@ -216,7 +224,19 @@ jobs:
     needs: build-macos
     if: github.event_name != 'pull_request'
     runs-on: macos-15
-    timeout-minutes: 30
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - model_id: HuggingFaceTB/SmolLM2-135M-Instruct
+            slug: smollm2-135m
+            max_context_length: 512
+            dtype: fp32
+          - model_id: Qwen/Qwen2.5-1.5B-Instruct
+            slug: qwen2.5-1.5b
+            max_context_length: 512
+            dtype: fp16
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
@@ -234,19 +254,32 @@ jobs:
       - name: Verify the installed wheel is used (not the source tree)
         working-directory: ${{ runner.temp }}
         run: python3 -c "import onnxsim, onnxsim.onnxsim_cpp2py_export as m; print(onnxsim.__version__, m.__file__)"
-      - name: Export HuggingFaceTB/SmolLM2-135M-Instruct
+      - name: Export ${{ matrix.model_id }}
         working-directory: ${{ runner.temp }}
         run: |
           python3 "$GITHUB_WORKSPACE/scripts/apple/export_llm_to_coreml.py" \
-            HuggingFaceTB/SmolLM2-135M-Instruct \
-            --max-context-length 512 --output smollm2.mlpackage
+            ${{ matrix.model_id }} --dtype ${{ matrix.dtype }} \
+            --max-context-length ${{ matrix.max_context_length }} \
+            --output ${{ matrix.slug }}.mlpackage
       - name: Run the decode benchmark through the real Core ML runtime
         working-directory: ${{ runner.temp }}
         run: |
           {
-            echo "### Decode benchmark: HuggingFaceTB/SmolLM2-135M-Instruct"
+            echo "### Decode benchmark: ${{ matrix.model_id }}"
             echo '```'
             python3 "$GITHUB_WORKSPACE/scripts/apple/run_llm_decode_benchmark.py" \
-              smollm2.mlpackage --prompt "The capital of France is" --max-new-tokens 20
+              ${{ matrix.slug }}.mlpackage --prompt "The capital of France is" \
+              --max-new-tokens 20
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+      - name: Check decode parity against the Hugging Face reference model
+        working-directory: ${{ runner.temp }}
+        run: |
+          {
+            echo "### Decode parity: ${{ matrix.model_id }}"
+            echo '```'
+            python3 "$GITHUB_WORKSPACE/scripts/apple/check_decode_parity.py" \
+              ${{ matrix.model_id }} ${{ matrix.slug }}.mlpackage \
+              --prompt "The capital of France is" --max-new-tokens 20
             echo '```'
           } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/bench/TODO_quality_retention_eval.md
+++ b/bench/TODO_quality_retention_eval.md
@@ -1,0 +1,148 @@
+# Open: quality + retention measurement for the Core ML LLM benchmark suite
+
+**Status:** planning only -- nothing in this doc is implemented yet. `scripts/apple`
+currently measures decode speed (`run_llm_decode_benchmark.py`) and prefill/decode
+correctness against the HF reference at the token level (`check_decode_parity.py`,
+agreement rate + first divergence). It has no way to answer "is the model still
+*good*" -- accuracy on a real benchmark -- or "how much accuracy did quantization/
+fp16 conversion cost" -- the two other axes
+[DeviceMark](https://devicemark.github.io/)'s leaderboard reports alongside speed and
+memory. This doc lays out an approach for both, sized to what this repo's CI can
+actually run, without committing to an implementation yet.
+
+## What DeviceMark measures (recalled, not re-fetched -- see the caveat below)
+
+Quality: IFEval (instruction-following), MMLU-Pro (broad knowledge, harder
+multiple-choice than plain MMLU), MATH-500 (grade-school-through-competition math).
+Retention: `quantized_accuracy / float_accuracy` on the same benchmark(s) --
+how much of the float model's capability survives quantization to the on-device
+format. Both are computed per-model, alongside decode tok/s and memory, feeding one
+leaderboard row per model.
+
+**Caveat:** `devicemark.github.io` is blocked by this environment's outbound network
+policy, so this section is from earlier context in this work, not a fresh read of
+their methodology page. Re-check the actual page (benchmark set, subset sizes,
+scoring exactly as they define it) before implementing, from an environment that can
+reach it.
+
+## Proposed scope for this repo
+
+Full IFEval/MMLU-Pro/MATH-500 runs are thousands of prompts each -- at this suite's
+current unbatched, single-sequence-at-a-time Core ML decode design (see
+`run_llm_decode_benchmark.py`'s module docstring), that's hours per model on a
+GitHub-hosted macOS runner, not viable for even a `workflow_dispatch`/schedule-only
+job. Two knobs to make it CI-feasible without abandoning the same benchmarks:
+
+1. **Subset, not full set.** A fixed random N-sample subset (e.g. 50-100 prompts) per
+   benchmark, seeded for reproducibility. Reports a noisier but directionally useful
+   score, not a leaderboard-grade number -- call this out explicitly in any output
+   ("N=100 subset, not the full benchmark") so it's never mistaken for a comparable
+   DeviceMark score.
+2. **Float side never needs macOS.** Retention's denominator (`float_accuracy`) only
+   needs the original Hugging Face model running through `transformers` on CPU --
+   exactly what `check_decode_parity.py`'s reference half already does. That run can
+   happen anywhere (including this dev sandbox, no Core ML/macOS needed), leaving only
+   the numerator (`quantized_accuracy`, the Core ML `.mlpackage`) as the part that must
+   run on a macOS runner. Splitting the two lets the float-side eval iterate fast in a
+   normal Linux CI job or locally, independent of macOS runner minutes.
+
+## Harness choice
+
+[`lm-evaluation-harness`](https://github.com/EleutherAI/lm-evaluation-harness)
+(EleutherAI) already implements IFEval, MMLU-Pro, and MATH-500 as tasks --
+prompt templates, few-shot formatting, and (critically) the scoring/parsing logic
+per benchmark (see "Per-benchmark scoring" below), which would otherwise be a
+substantial reimplementation. It works against any model exposing its
+`lm_eval.api.model.LM` interface (primarily `loglikelihood`/`generate_until`), so the
+integration point is a small custom adapter class, not a fork of the harness itself:
+
+- **Float side:** `lm_eval`'s existing `hf` model type already wraps
+  `transformers.AutoModelForCausalLM` directly -- no adapter needed, just
+  `lm_eval.simple_evaluate(model="hf", model_args=f"pretrained={model_id}", tasks=[...])`.
+- **Quantized side:** a new adapter, something like `scripts/apple/lm_eval_coreml_adapter.py`,
+  wrapping `CoreMLDecoder` (from `run_llm_decode_benchmark.py`, already handles
+  prefill + growing-KV-cache decode) to implement `generate_until` (IFEval and
+  MATH-500 are generation tasks: free-form / chain-of-thought responses scored by a
+  verifier or answer-extraction, not by comparing log-likelihoods of fixed
+  continuations). MMLU-Pro is multiple-choice and could use either `generate_until`
+  (generate, then extract the letter) or `loglikelihood` (score each candidate
+  continuation) depending on which the harness's stock MMLU-Pro task expects. Whether
+  `loglikelihood` is reachable through `CoreMLDecoder`'s current single-token-at-a-time
+  interface (it would need per-candidate teacher-forced logprobs, not just greedy
+  argmax) is an open question the "Next steps" below need to resolve before committing
+  to `lm-evaluation-harness` over a lighter custom scorer for MMLU-Pro specifically.
+
+Alternative considered: a from-scratch minimal harness (just load each benchmark's
+public dataset, format prompts, generate, score). Rejected as the default plan --
+scoring IFEval's programmatic instruction verifiers and MATH-500's answer-equivalence
+correctly is fiddly and already solved in `lm-evaluation-harness`; reimplementing it
+risks silently-wrong scores that look plausible. Worth falling back to only if the
+harness's model-interface assumptions turn out to be a bad fit for
+`CoreMLDecoder`'s unbatched, growing-KV-cache shape.
+
+## Per-benchmark scoring considerations
+
+- **IFEval:** programmatic verifiers (e.g. "response contains exactly 3 bullet
+  points", "response is under N words") applied to the raw generated text -- no
+  external judge model needed, deterministic once generation is done. Sensitive to
+  generation length/truncation; `--max-new-tokens` needs to be generous enough that
+  legitimate compliant responses aren't cut off and marked failed for the wrong
+  reason.
+- **MMLU-Pro:** multiple-choice with up to 10 options (vs. plain MMLU's 4) -- answer
+  extraction from generated text (if using `generate_until`) needs to reliably find
+  the model's chosen letter, which is more failure-prone with more options and with a
+  small/lightly-instruction-tuned model (this suite's models are mostly 1-4B). Worth
+  checking the harness's built-in MMLU-Pro answer-extraction regex against a few
+  sample generations from a small model before trusting the aggregate score.
+- **MATH-500:** free-form final-answer extraction + symbolic/numeric equivalence
+  checking (e.g. `1/2` == `0.5` == `\frac{1}{2}`) -- `lm-evaluation-harness`'s task
+  implementation (or the original MATH repo's `is_equiv`) handles this; a naive
+  string-equality check would undercount correct answers in different but equivalent
+  forms.
+
+## Retention computation
+
+```
+retention = quantized_accuracy / float_accuracy   # per benchmark, per model
+```
+
+Both accuracies from the *same* subset (identical sampled prompts, identical scoring
+code) so the ratio isolates the quantized-vs-float gap rather than sampling noise
+between two different subsets. `float_accuracy` computed once per model (independent
+of Core ML, reusable across dtype variants if this suite ever benchmarks int8/int4
+Core ML variants of the same model). A ratio > 1.0 is possible on a small subset (both
+sides have noise) and isn't a bug -- worth clamping/annotating rather than treating as
+an error.
+
+## Reporting
+
+Following `run_llm_decode_benchmark.py`/`check_decode_parity.py`'s existing pattern:
+print a human-readable summary and let the CI job `tee` it into
+`$GITHUB_STEP_SUMMARY` (decode tok/s, memory, parity agreement, and now per-benchmark
+quality + retention, all in one place per model). A machine-readable JSON artifact
+alongside it (one object per model: `{model_id, benchmark, subset_n, quantized_acc,
+float_acc, retention}`) would let a later step turn a run history into a trend
+without re-parsing log text -- worth adding once there's more than one data point to
+actually compare.
+
+## Next steps, if picking this up
+
+1. Re-read DeviceMark's actual methodology page (subset sizes if any, exact benchmark
+   versions/splits, how they define retention) from an environment that isn't blocked
+   from reaching `devicemark.github.io`, and reconcile any difference from this doc's
+   recalled description before implementing.
+2. Prototype the float-side eval first (no macOS needed): `lm_eval.simple_evaluate`
+   against one already-validated model (e.g. `HuggingFaceTB/SmolLM2-135M-Instruct`) on
+   a small IFEval subset, to confirm the harness's task definitions and scoring run
+   cleanly in this repo's dependency set before touching the Core ML side at all.
+3. Resolve the `loglikelihood`-vs-`generate_until` question for MMLU-Pro against
+   `CoreMLDecoder`'s interface (see "Harness choice" above) -- this decides whether
+   `CoreMLDecoder` needs a new teacher-forced-logprob code path or whether
+   `generate_until`-based answer extraction is good enough.
+4. Build the `CoreMLDecoder`-wrapping `lm_eval` adapter and validate it end-to-end
+   against one small model + one benchmark subset on a macOS runner, comparing its
+   score to the float side's score on the same subset (sanity: they should be close
+   for an unquantized-in-spirit fp16 Core ML model, not wildly different).
+5. Wire a small-subset run into a new `workflow_dispatch`/schedule-only CI job (own
+   job, not folded into `benchmark-decode-macos`, given the likely runtime), reporting
+   per DeviceMark's three benchmarks plus retention, once 2-4 are validated.

--- a/scripts/apple/README.md
+++ b/scripts/apple/README.md
@@ -110,10 +110,46 @@ methodology.
   Core ML's runtime lives); the export step itself needs no Apple hardware.
 
 `coreml-integration.yml`'s `benchmark-decode-macos` job runs this exact pair
-end-to-end (export `HuggingFaceTB/SmolLM2-135M-Instruct`, then the decode
-benchmark) on a macOS GitHub-hosted runner, posting the numbers to that run's
-job summary -- `workflow_dispatch`/schedule-only, like the other real-model
-jobs in that workflow, not on every PR.
+end-to-end on a macOS GitHub-hosted runner, over a small matrix
+(`HuggingFaceTB/SmolLM2-135M-Instruct` and `Qwen/Qwen2.5-1.5B-Instruct` --
+the two architecture families already validated by
+`prepare_benchmark_models.py`, so a translator regression specific to one
+doesn't hide behind the other passing), posting each model's numbers to that
+run's job summary -- `workflow_dispatch`/schedule-only, like the other
+real-model jobs in that workflow, not on every PR.
+
+### Decode parity (`check_decode_parity.py`)
+
+The decode benchmark above measures speed, not correctness -- a model that
+runs fast but computes the wrong thing would still produce a number.
+`check_decode_parity.py` closes that gap: it greedily generates the same
+prompt through **both** the exported `.mlpackage` (via `CoreMLDecoder`, real
+Core ML runtime) and the original Hugging Face model (`transformers`,
+CPU-only, no macOS needed for that half), then reports the token-level
+agreement rate and the index of the first divergence between the two
+sequences.
+
+This is deliberately not a bit-exact check: Core ML runs at fp16 internally
+regardless of the ONNX graph's own dtype, while the `transformers` reference
+here runs at fp32 on CPU, so a close-logit token can legitimately flip the
+greedy argmax on one side and not the other -- and once one token diverges,
+every later token's context differs too, so agreement is expected to trail
+off after that point rather than resume. What the check actually watches for
+is *how much* the two disagree (`--min-agreement`, default 80%) and *how
+early* the first mismatch happens -- either one being far off is the signal
+that something in the export/conversion pipeline is wrong, not just fp16
+rounding.
+
+```bash
+python check_decode_parity.py HuggingFaceTB/SmolLM2-135M-Instruct \
+    smollm2.mlpackage --prompt "The capital of France is" --max-new-tokens 20
+```
+
+`coreml-integration.yml`'s `benchmark-decode-macos` job runs this after the
+decode benchmark, once per matrix entry, also posting to the job summary.
+The pure comparison logic (`compare_token_sequences`) has no coremltools/
+torch/transformers dependency and is unit-tested directly in
+`tests/test_check_decode_parity.py`.
 
 ### Scaling to few-billion-parameter models
 

--- a/scripts/apple/check_decode_parity.py
+++ b/scripts/apple/check_decode_parity.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Check that a Core ML decoder's greedy output agrees with its HF reference.
+
+`run_llm_decode_benchmark.py` measures *speed*; this measures *correctness*
+against something other than itself -- the original Hugging Face model,
+running greedy `generate()` on CPU through `transformers` -- rather than only
+comparing the exported model to itself run twice. That is the "device"
+(here: real Core ML, exercised the same way the benchmark does -- prefill
+once, then one single-token forward pass per step reusing the growing KV
+cache) side of DeviceMark's device-vs-reference parity idea
+(https://devicemark.github.io/); the "HF" side is exactly what this script
+loads for the reference.
+
+This is deliberately **not** a bit-exact/token-exact check. Core ML's
+`.mlpackage` runs in fp16 internally regardless of the ONNX graph's own
+dtype (see `export_llm_to_coreml.py`'s module docstring), and `transformers`'
+reference here runs in fp32 on CPU -- two different numeric paths through the
+same weights. On a token whose top-2 logits are close, that's enough to flip
+the greedy argmax, and one flipped token shifts every later token's context,
+so occasional divergence after the first mismatch is expected and not itself
+a bug. What this script actually watches for is *how much* the two disagree:
+a low token-level agreement rate, or a divergence that happens almost
+immediately, is the signal that something in the export/conversion pipeline
+(not just fp16 rounding) is wrong.
+
+Usage:
+    python check_decode_parity.py HuggingFaceTB/SmolLM2-135M-Instruct \\
+        smollm2.mlpackage --prompt "The capital of France is" \\
+        --max-new-tokens 20
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def compare_token_sequences(reference_ids: list[int], candidate_ids: list[int]) -> dict:
+    """Token-level agreement between two greedily-generated id sequences.
+
+    Compares position-by-position over the overlapping length (generation
+    lengths can differ, e.g. one side hits EOS earlier) and reports the
+    fraction of positions that match plus the index of the first mismatch
+    (`None` if the sequences agree everywhere compared). Kept separate from
+    any model/tokenizer loading so it's plain, fast-testable logic.
+    """
+    n = min(len(reference_ids), len(candidate_ids))
+    if n == 0:
+        return {"compared": 0, "agreement_rate": 1.0, "first_divergence": None}
+
+    first_divergence = None
+    matches = 0
+    for i in range(n):
+        if reference_ids[i] == candidate_ids[i]:
+            matches += 1
+        elif first_divergence is None:
+            first_divergence = i
+
+    return {
+        "compared": n,
+        "agreement_rate": matches / n,
+        "first_divergence": first_divergence,
+    }
+
+
+def _generate_reference_ids(
+    model_id: str, prompt_ids: list[int], max_new_tokens: int, eos_token_id: int | None
+) -> list[int]:
+    """Greedily generate `max_new_tokens` continuation ids with the original HF
+    model on CPU -- the "ground truth" side of the comparison.
+    """
+    import torch
+    from transformers import AutoModelForCausalLM
+
+    print(f"Loading HF reference model {model_id!r} (CPU, fp32)...", flush=True)
+    model = AutoModelForCausalLM.from_pretrained(model_id)
+    model.eval()
+
+    input_ids = torch.tensor([prompt_ids], dtype=torch.long)
+    with torch.no_grad():
+        out = model.generate(
+            input_ids,
+            max_new_tokens=max_new_tokens,
+            do_sample=False,
+            num_beams=1,
+            eos_token_id=eos_token_id,
+            pad_token_id=eos_token_id,
+        )
+    return out[0, len(prompt_ids) :].tolist()
+
+
+def _generate_coreml_ids(
+    mlpackage: str,
+    compute_units: str,
+    prompt_ids: list[int],
+    max_new_tokens: int,
+    eos_token_id: int | None,
+) -> list[int]:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from run_llm_decode_benchmark import CoreMLDecoder
+
+    print(f"Loading {mlpackage} (compute_units={compute_units})...", flush=True)
+    decoder = CoreMLDecoder(mlpackage, compute_units=compute_units)
+    return [
+        token_id
+        for token_id, _dt in decoder.generate(prompt_ids, max_new_tokens, eos_token_id)
+    ]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument(
+        "model_id", help="Hugging Face model id the .mlpackage was exported from"
+    )
+    ap.add_argument(
+        "mlpackage", help="Path to the .mlpackage from export_llm_to_coreml.py"
+    )
+    ap.add_argument("--prompt", default="The capital of France is")
+    ap.add_argument("--max-new-tokens", type=int, default=20)
+    ap.add_argument(
+        "--compute-units",
+        default="ALL",
+        choices=["ALL", "CPU_ONLY", "CPU_AND_GPU", "CPU_AND_NE"],
+    )
+    ap.add_argument(
+        "--min-agreement",
+        type=float,
+        default=0.8,
+        help="Exit non-zero if the token-level agreement rate falls below this "
+        "fraction (default: 0.8). fp16-vs-fp32 numeric drift makes bit-exact "
+        "agreement the wrong bar -- see the module docstring.",
+    )
+    args = ap.parse_args()
+
+    model_dir = Path(args.mlpackage).parent
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(str(model_dir))
+    prompt_ids = tokenizer(args.prompt, return_tensors="np")["input_ids"][0].tolist()
+    print(f"Prompt: {args.prompt!r} ({len(prompt_ids)} tokens)", flush=True)
+
+    reference_ids = _generate_reference_ids(
+        args.model_id, prompt_ids, args.max_new_tokens, tokenizer.eos_token_id
+    )
+    candidate_ids = _generate_coreml_ids(
+        args.mlpackage,
+        args.compute_units,
+        prompt_ids,
+        args.max_new_tokens,
+        tokenizer.eos_token_id,
+    )
+
+    print(
+        f"HF reference : {tokenizer.decode(reference_ids, skip_special_tokens=True)!r}"
+    )
+    print(
+        f"Core ML      : {tokenizer.decode(candidate_ids, skip_special_tokens=True)!r}"
+    )
+
+    result = compare_token_sequences(reference_ids, candidate_ids)
+    print(
+        f"\nagreement: {result['agreement_rate']:.1%} over {result['compared']} "
+        f"compared tokens (reference: {len(reference_ids)}, Core ML: "
+        f"{len(candidate_ids)})",
+        flush=True,
+    )
+    if result["first_divergence"] is not None:
+        print(
+            f"first divergence at token index {result['first_divergence']}", flush=True
+        )
+
+    if result["agreement_rate"] < args.min_agreement:
+        print(
+            f"FAIL: agreement {result['agreement_rate']:.1%} is below "
+            f"--min-agreement {args.min_agreement:.1%}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("OK", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_decode_parity.py
+++ b/tests/test_check_decode_parity.py
@@ -1,0 +1,57 @@
+"""Unit tests for scripts/apple/check_decode_parity.py's comparison logic.
+
+`compare_token_sequences` is plain list-of-ints logic with no coremltools/
+torch/transformers dependency, so it's tested directly here rather than only
+via the coremltools-gated scripts under scripts/apple -- see that module's
+docstring for why the check is agreement-rate-based, not exact-match.
+"""
+
+import os
+import sys
+
+import pytest
+
+_APPLE_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "apple"
+)
+if _APPLE_DIR not in sys.path:
+    sys.path.insert(0, _APPLE_DIR)
+
+from check_decode_parity import compare_token_sequences  # noqa: E402
+
+
+def test_identical_sequences_agree_fully():
+    result = compare_token_sequences([1, 2, 3, 4], [1, 2, 3, 4])
+    assert result == {"compared": 4, "agreement_rate": 1.0, "first_divergence": None}
+
+
+def test_diverges_at_first_mismatch():
+    result = compare_token_sequences([1, 2, 3, 4], [1, 2, 9, 4])
+    assert result["compared"] == 4
+    assert result["agreement_rate"] == 0.75
+    assert result["first_divergence"] == 2
+
+
+def test_diverges_immediately():
+    result = compare_token_sequences([1, 2, 3], [9, 2, 3])
+    assert result["first_divergence"] == 0
+    assert result["agreement_rate"] == pytest.approx(2 / 3)
+
+
+def test_completely_disjoint():
+    result = compare_token_sequences([1, 2, 3], [4, 5, 6])
+    assert result == {"compared": 3, "agreement_rate": 0.0, "first_divergence": 0}
+
+
+def test_compares_only_the_overlapping_length():
+    # One side generated fewer tokens (e.g. hit EOS earlier) -- only the
+    # shared prefix is compared, not padded/truncated to match.
+    result = compare_token_sequences([1, 2, 3, 4, 5], [1, 2, 3])
+    assert result["compared"] == 3
+    assert result["agreement_rate"] == 1.0
+    assert result["first_divergence"] is None
+
+
+def test_empty_sequences():
+    result = compare_token_sequences([], [])
+    assert result == {"compared": 0, "agreement_rate": 1.0, "first_divergence": None}


### PR DESCRIPTION
## Summary

Adds `check_decode_parity.py`, a correctness validation script that compares greedy token generation between exported Core ML models and their original Hugging Face references. This complements the existing decode speed benchmark by catching translator bugs that produce models Core ML can run but compute incorrectly.

## Key Changes

- **New script: `scripts/apple/check_decode_parity.py`**
  - Greedily generates the same prompt through both the Core ML `.mlpackage` (via `CoreMLDecoder`) and the original HF model (`transformers` on CPU)
  - Reports token-level agreement rate and index of first divergence
  - Deliberately not bit-exact: Core ML runs at fp16 internally while `transformers` reference runs at fp32, so close-logit tokens can legitimately flip the greedy argmax on one side
  - Configurable `--min-agreement` threshold (default 80%) to catch real export bugs while tolerating expected fp16/fp32 numeric drift
  - Includes comprehensive module docstring explaining the methodology and why agreement-rate checking is the right bar

- **Unit tests: `tests/test_check_decode_parity.py`**
  - Tests the pure comparison logic (`compare_token_sequences`) which has no heavy dependencies
  - Covers identical sequences, divergence at various points, length mismatches, and edge cases

- **CI integration: Updated `coreml-integration.yml`**
  - Expanded `benchmark-decode-macos` job to run over a 2-model matrix (SmolLM2-135M and Qwen2.5-1.5B) covering two architecture families
  - Increased timeout from 30 to 60 minutes to accommodate parity checks
  - Runs parity check after decode benchmark for each matrix entry, posting results to job summary
  - Matrix includes dtype specification (fp32 for SmolLM2, fp16 for Qwen2.5) to validate both paths

- **Documentation: Updated `scripts/apple/README.md`**
  - Added "Decode parity" section explaining the new check, its methodology, and usage
  - Clarified that the matrix covers two architecture families to catch architecture-specific regressions
  - Noted that the pure comparison logic is unit-tested separately

- **Planning doc: `bench/TODO_quality_retention_eval.md`**
  - Outlines future work for quality + retention measurement (IFEval, MMLU-Pro, MATH-500)
  - Proposes using `lm-evaluation-harness` with a custom Core ML adapter
  - Sized for CI feasibility with subset sampling and split float/quantized evaluation
  - Marked as planning-only, not yet implemented

## Implementation Details

The parity check is designed to be pragmatic about numeric differences:
- Compares only the overlapping length of generated sequences (one side may hit EOS earlier)
- Tracks both overall agreement rate and the index of first divergence
- Allows configuration of the minimum acceptable agreement rate via `--min-agreement`
- Provides clear output showing both decoded sequences and detailed statistics

The CI matrix strategy ensures that a translator regression specific to one architecture family (e.g., Llama-style vs. Qwen) doesn't hide behind the other passing.

https://claude.ai/code/session_01T3MD7VAmysceuqiBQYHvWQ