### PR TITLE
Recognize fused SkipLayerNormalization as a transformer block entry norm

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -12259,22 +12259,14 @@ def apply_embedding_vocab_magnitude_pruning(
 # residual machinery and this environment's real onnxruntime schemas rather
 # than assumed, and each worth stating plainly:
 #
-# 1. Both the merge point *and* the entry norm matched here are the
-#    unfused shapes only: the merge is *only* a bare `Add`
-#    (:func:`_is_eligible_add_merge`, reused unchanged from the residual
-#    *channel*-pruning machinery above -- exactly the same "two distinct,
-#    non-constant operands" eligibility bar), and `LN` is only a plain,
-#    single-input `LayerNormalization`/`RMSNormalization`/
-#    `SimplifiedLayerNormalization` node (:func:`_is_entry_ln_node`) --
-#    never a fused `SkipLayerNormalization`/`SkipSimplifiedLayerNormalization`
-#    node in *either* role, the way :func:`_match_matmul_residual_merge`
-#    accepts it as the merge for channel pruning. That is a deliberate,
-#    real narrowing versus this module's own existing residual machinery,
-#    not an oversight, and it costs real coverage on a model that has
-#    actually been run through onnxruntime's transformer optimizer (which
-#    fuses nearly every residual `Add` immediately followed by a
-#    `LayerNorm` into exactly this fused node) -- worth being honest about
-#    rather than glossing over:
+# 1. The merge point matched here is the unfused shape only: it is *only*
+#    a bare `Add` (:func:`_is_eligible_add_merge`, reused unchanged from
+#    the residual *channel*-pruning machinery above -- exactly the same
+#    "two distinct, non-constant operands" eligibility bar), never a fused
+#    `SkipLayerNormalization`/`SkipSimplifiedLayerNormalization` node the
+#    way :func:`_match_matmul_residual_merge` accepts it as the merge for
+#    channel pruning. That is a deliberate, real narrowing, not an
+#    oversight:
 #
 #    - As the merge, a `SkipLayerNormalization`-family node's own
 #      *primary* output is always the *normalized* sum (`LN(x_in +
@@ -12283,31 +12275,51 @@ def apply_embedding_vocab_magnitude_pruning(
 #      could safely repoint every consumer to that is both already
 #      present in the graph *and* means "`x_in`, unnormalized" the way a
 #      bare `Add`'s own `x_in` operand already, directly, does).
-#    - As the entry norm, `LN(x_in)` is only recognized when `x_in` is
-#      *literally* some node's own single data input
-#      (:func:`_is_entry_ln_node`'s own `node.input[0] == x_in` check) --
-#      exactly what a plain `LayerNormalization`/`RMSNormalization`/
-#      `SimplifiedLayerNormalization` node's own first input already is,
-#      but *not* what a `SkipLayerNormalization`-family node's own first
-#      input is: that node normalizes `input + skip`, a *sum* of two
-#      separate tensors, and the block's own true `x_in` (the previous
-#      block's own raw, unnormalized residual value) only exists as a
-#      *named* tensor at all when that sum is separately materialized as
-#      the node's own optional fourth output, `input_skip_bias_sum` --
-#      which onnxruntime's optimizer only ever emits when something
-#      downstream actually still needs it, not unconditionally. Matching
-#      this shape too is a real, tractable extension (recognize
-#      `node.output[3]`, when present, as an *alternative* `x_in` source
-#      for a `SkipLayerNormalization`-family node feeding `F`), but it is
-#      a genuinely different check from the single-input-only one
-#      :func:`_is_entry_ln_node` performs today, not a free extension of
-#      it -- left out of this initial version's scope rather than rushed
-#      in, so it is not implemented here.
+#
+#    The *entry* norm, `LN(x_in)`, is recognized in both shapes: a plain,
+#    single-input `LayerNormalization`/`RMSNormalization`/
+#    `SimplifiedLayerNormalization` node (:func:`_is_entry_ln_node`,
+#    `node.input[0] == x_in`), *or* a fused `SkipLayerNormalization`/
+#    `SkipSimplifiedLayerNormalization` node (:func:`_is_fused_entry_ln_node`)
+#    reached via its own *primary* (normalized) output, whose optional
+#    fourth output -- `input_skip_bias_sum`, confirmed (against
+#    onnxruntime's real `com.microsoft` schema via
+#    `get_all_operator_schema()`, and by direct execution -- see this
+#    section's own comment near :func:`_is_fused_entry_ln_node`) to be the
+#    raw, pre-normalization `input + skip (+ bias)` sum, bit-exact -- when
+#    *present* stands in for `x_in`: it names, as an ordinary graph
+#    tensor, exactly the same "previous block's own raw, unnormalized
+#    residual value" a bare `Add`'s own `x_in` operand already, directly,
+#    is. onnxruntime's transformer optimizer only ever emits this fourth
+#    output when something downstream still needs it (confirmed
+#    empirically: omitted from the node's own `output` list, it simply
+#    isn't computed or exposed at all -- no error, no silent
+#    materialization), so the match declines cleanly whenever it's absent,
+#    exactly the "decline outright, never guess" bar every other check in
+#    this section holds to. Unlike the merge case, this fused node is
+#    never added to the block's own `block_nodes` (never deleted) when
+#    matched this way: unlike a plain `LN` node (whose own *input* is
+#    `x_in`, produced entirely outside the block), this node's own
+#    *output* (`input_skip_bias_sum`) *is* `x_in` -- deleting the node that
+#    produces the very tensor every rewired `x_out` consumer needs to keep
+#    reading would corrupt the graph. It is left in place, computing
+#    exactly what it always did; its own primary (normalized) output
+#    simply loses its only consumer (`F`, deleted along with the rest of
+#    the block) and goes unread, which is harmless -- a later
+#    simplification pass is free to notice and remove it, this pass has no
+#    need to. The merge itself is untouched by any of this -- still
+#    matched, `x_out`-side, only as a bare `Add`; see point above.
 #
 #    A raw, not-yet-optimizer-fused export (the common case for a model
 #    straight out of a training framework's own ONNX exporter) still
 #    matches fully -- it has no `SkipLayerNormalization` nodes to begin
 #    with, only plain `Add`/`LayerNormalization`-family nodes throughout.
+#    A fully optimizer-fused export -- where the residual `Add` immediately
+#    preceding block `N`'s own entry `LN` got fused into block `N-1`'s own
+#    merge, producing exactly this `SkipLayerNormalization`-family node --
+#    is now matched too, provided block `N`'s own *merge* (its `x_out`)
+#    remains a bare `Add` (e.g. the last block before a final, non-fused
+#    `LayerNormalization`) -- the realistic shape this extension targets.
 # 2. Attention and MLP/FFN blocks are matched -- and dropped -- fully
 #    independently of each other, never only as a paired "whole
 #    transformer layer". Nothing in the graph structure requires pairing:
@@ -12375,6 +12387,48 @@ def _is_entry_ln_node(node: onnx.NodeProto, x_in: str) -> bool:
     )
 
 
+def _is_fused_entry_ln_node(node: onnx.NodeProto, x_in: str, t: str) -> bool:
+    """True if `node` is a ``com.microsoft::SkipLayerNormalization``/
+    ``SkipSimplifiedLayerNormalization`` node (:data:`_SKIP_LAYER_NORM_OPS`/
+    :data:`_SKIP_LAYER_NORM_DOMAIN`, the same constants
+    :func:`_skip_layer_norm_const_names` uses for the unrelated channel-
+    pruning residual merge above) reached, during the backward walk, via
+    its own *primary* output `t` -- i.e. `t == node.output[0]`, the
+    normalized `LN(input + skip (+ bias))` value `F` actually reads -- and
+    whose own optional fourth output, `input_skip_bias_sum`, is both
+    present (``len(node.output) > 3`` and non-empty -- onnxruntime only
+    ever materializes it when something downstream still needs it;
+    confirmed empirically, see this section's own comment above) and
+    textually equal to `x_in`.
+
+    This is the fused analogue of :func:`_is_entry_ln_node`'s own
+    `node.input[0] == x_in` check -- confirmed, via
+    `onnxruntime.capi.onnxruntime_pybind11_state.get_all_operator_schema()`
+    against both ops' real ``com.microsoft`` schemas, and independently by
+    running a real node through a real `onnxruntime.InferenceSession` and
+    comparing bit-exact (not merely close) against an independently
+    hand-computed `input + skip (+ bias)`, that `input_skip_bias_sum` is
+    exactly the raw, pre-normalization sum -- i.e. exactly what a bare
+    `Add`'s own `x_in` operand would already, directly, be, standing in
+    for it here since the fused node's own first *input* (unlike a plain
+    `LN` node's) is not `x_in` itself but a sum of two separate tensors.
+    Requiring `t == node.output[0]` specifically (rather than accepting a
+    match reached via `mean`/`inv_std_var`, the op's other two optional
+    outputs) mirrors :func:`_is_entry_ln_node`'s own single-input
+    specificity, and keeps this from ever misfiring on a node reached only
+    through those training-only, in-practice-never-wired outputs.
+    """
+    return (
+        node.domain == _SKIP_LAYER_NORM_DOMAIN
+        and node.op_type in _SKIP_LAYER_NORM_OPS
+        and len(node.output) >= 1
+        and node.output[0] == t
+        and len(node.output) > 3
+        and node.output[3] != ""
+        and node.output[3] == x_in
+    )
+
+
 @dataclass(frozen=True)
 class _DroppableBlock:
     merge_node: onnx.NodeProto
@@ -12409,13 +12463,18 @@ def _try_resolve_droppable_block(
       unlike every chain walk elsewhere in this module, since nothing here
       needs to recognize any *particular* shape of `F`, only that
       everything inside it stays inside it) must reach `x_in` *only* via
-      one or more :func:`_is_entry_ln_node` boundaries (`LN(x_in)`,
-      not recursed past) -- reaching `x_in` directly, bypassing every such
-      boundary, means `F` reads `x_in` raw rather than only its own norm,
-      not the pattern this pass targets, and declines the whole candidate;
-      finding *no* such boundary at all (`F`'s own backward walk never
-      touches `x_in`) declines it the same way -- some other tensor
-      entirely feeds the merge's `other` operand, not `F(LN(x_in))`.
+      one or more entry-norm boundaries, not recursed past: either a plain
+      `LN(x_in)` node (:func:`_is_entry_ln_node`), or a fused
+      `SkipLayerNormalization`/`SkipSimplifiedLayerNormalization` node
+      reached via its own primary output whose optional fourth output
+      equals `x_in` (:func:`_is_fused_entry_ln_node` -- see this section's
+      own comment above for why the fourth output is the correct `x_in`
+      stand-in). Reaching `x_in` directly, bypassing every such boundary,
+      means `F` reads `x_in` raw rather than only its own norm, not the
+      pattern this pass targets, and declines the whole candidate; finding
+      *no* such boundary at all (`F`'s own backward walk never touches
+      `x_in`) declines it the same way -- some other tensor entirely feeds
+      the merge's `other` operand, not `F(LN(x_in))`.
     - Every node the walk collects (the block's own interior, plus
       `merge_node` itself) must have every one of its own output tensors
       read by nothing outside that same set, and never be a graph output
@@ -12427,6 +12486,10 @@ def _try_resolve_droppable_block(
       and declines the block -- see this section's own comment above for
       why this one general check is also exactly what makes a
       KV-cache-bearing block decline itself, with no dedicated detection.
+      A fused entry-norm node matched via :func:`_is_fused_entry_ln_node`
+      is deliberately *not* added to this set -- see that function's own
+      docstring and this section's own comment for why it is preserved
+      (never deleted) rather than collected as ordinary block interior.
 
     A graph input reached mid-walk (an attention mask, position ids, a
     KV-cache input, or any other tensor `F` reads that isn't produced by
@@ -12437,6 +12500,15 @@ def _try_resolve_droppable_block(
     """
     block_node_ids: Set[int] = {id(merge_node)}
     block_nodes: List[onnx.NodeProto] = [merge_node]
+    # Fused entry-norm nodes matched via `_is_fused_entry_ln_node`: kept
+    # out of `block_node_ids`/`block_nodes` (never deleted -- their own
+    # fourth output *is* `x_in`; see this function's own docstring and
+    # this section's own comment). Tracked separately so a *second* visit
+    # to the same node, via one of its other outputs (`mean`/
+    # `inv_std_var`, in practice never wired to anything -- see this
+    # section's own comment), can neither re-add it to `block_nodes` nor
+    # be silently accepted as some other, contradictory role.
+    fused_boundary_ids: Set[int] = set()
     found_entry_ln = False
     visited: Set[str] = set()
     frontier: List[str] = [other]
@@ -12450,12 +12522,26 @@ def _try_resolve_droppable_block(
         node = node_by_output.get(t)
         if node is None:
             continue  # graph input or initializer -- a leaf, not a problem
+        if id(node) in fused_boundary_ids:
+            continue  # already resolved as this block's own fused boundary
         if _is_entry_ln_node(node, x_in):
             found_entry_ln = True
             if id(node) not in block_node_ids:
                 block_node_ids.add(id(node))
                 block_nodes.append(node)
             continue  # boundary -- LN's own input (x_in) is not recursed into
+        if _is_fused_entry_ln_node(node, x_in, t):
+            if id(node) in block_node_ids:
+                # Already collected as ordinary block interior via one of
+                # this same node's *other* outputs, before this visit
+                # discovered it's actually this block's own fused
+                # boundary -- irreconcilable (its own `x_in`-bearing
+                # output can't be both deleted and preserved), so decline
+                # rather than guess which role is right.
+                return None
+            found_entry_ln = True
+            fused_boundary_ids.add(id(node))
+            continue  # boundary -- preserved, not deleted, not recursed into
         if id(node) not in block_node_ids:
             block_node_ids.add(id(node))
             block_nodes.append(node)
@@ -12743,11 +12829,14 @@ def apply_transformer_block_pruning(
     ``x = x + MLP(LN(x))``) wholesale, rather than shrinking every block a
     little the way every other `apply_*` function in this module does --
     see this section's own comment above for the exact pattern matched,
-    the two scope decisions this narrows to (bare-`Add` merges and a
-    plain, unfused entry norm only -- a `SkipLayerNormalization`-family
-    node is not recognized in either role, so a model already run through
-    onnxruntime's own transformer optimizer needs its own follow-up
-    coverage this initial version doesn't take on; attention and MLP/FFN
+    the two scope decisions this narrows to (the merge is a bare `Add`
+    only -- a `SkipLayerNormalization`-family node is never recognized in
+    that role; the entry norm accepts either a plain, unfused `LN(x_in)`
+    node *or* a fused `SkipLayerNormalization`/
+    `SkipSimplifiedLayerNormalization` node, via its own optional fourth
+    output, standing in for `x_in` -- so a model already run through
+    onnxruntime's own transformer optimizer is matched too, provided each
+    block's own merge itself is still a bare `Add`; attention and MLP/FFN
     blocks matched and dropped fully independently, never only as a
     "whole layer" pair) and why a KV-cache-bearing attention block needs
     no dedicated handling to always decline safely on its own.

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -14884,6 +14884,360 @@ def test_transformer_block_pruning_matches_simplified_layer_normalization_entry(
     np.testing.assert_array_equal(pruned_y, x)
 
 
+def test_transformer_block_pruning_matches_fused_skip_layer_normalization_entry():
+    # A fused ``com.microsoft::SkipLayerNormalization`` node as the block's
+    # own *entry* norm -- exactly what onnxruntime's transformer optimizer
+    # produces by fusing the *previous* residual `Add` with the following
+    # `LayerNormalization`. Built directly with `onnx.helper.make_node`,
+    # not `onnx.parser` (CLAUDE.md's documented exception): the text
+    # format can't express a custom-domain op with this multi-output
+    # fusion shape (a `com.microsoft` node with skipped middle outputs).
+    #
+    # `input`/`skip` stand in for whatever fed the *previous* block's own
+    # (now-fused-away) residual Add; this block's own merge itself stays
+    # an ordinary, unfused `Add` (this pass's own merge-side scope, see
+    # this module's own section comment) -- realistic for e.g. the last
+    # block before a final, non-fused `LayerNormalization`.
+    H = 8
+    rng = np.random.default_rng(41)
+    gamma = rng.standard_normal(H).astype(np.float32)
+    beta = rng.standard_normal(H).astype(np.float32)
+    w = (rng.standard_normal((H, H)) * 1e-6).astype(np.float32)
+
+    def _skip_ln_node(sum_output_name):
+        return onnx.helper.make_node(
+            "SkipLayerNormalization",
+            ["input", "skip", "Gamma", "Beta"],
+            ["ln_out", "", "", sum_output_name],
+            domain="com.microsoft",
+            epsilon=1e-5,
+        )
+
+    initializer = [_f32(gamma, "Gamma"), _f32(beta, "Beta")]
+    inputs = [
+        onnx.helper.make_tensor_value_info("input", onnx.TensorProto.FLOAT, [1, 4, H]),
+        onnx.helper.make_tensor_value_info("skip", onnx.TensorProto.FLOAT, [1, 4, H]),
+    ]
+
+    skip_ln = _skip_ln_node("sum_out")
+    h = onnx.helper.make_node("MatMul", ["ln_out", "W"], ["h"])
+    y = onnx.helper.make_node("Add", ["sum_out", "h"], ["y"])
+    graph = onnx.helper.make_graph(
+        [skip_ln, h, y],
+        "g",
+        inputs,
+        [onnx.helper.make_tensor_value_info("y", onnx.TensorProto.FLOAT, [1, 4, H])],
+        initializer=initializer + [_f32(w, "W")],
+        # A real onnxruntime-optimized export carries a declared shape for
+        # every named intermediate tensor (the whole graph was shape-
+        # inferred and saved that way by the optimizer tool). Declaring it
+        # here too matters concretely: plain `onnx.shape_inference` has no
+        # inference function for a `com.microsoft` op, so without this,
+        # `sum_out`'s shape would come out unknown and
+        # :func:`onnxsim.pruning._shapes_match` would (correctly, safely)
+        # decline the match rather than assume the shapes line up --
+        # confirmed empirically while building this test.
+        value_info=[
+            onnx.helper.make_tensor_value_info(
+                "sum_out", onnx.TensorProto.FLOAT, [1, 4, H]
+            )
+        ],
+    )
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 17),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+        ir_version=10,
+    )
+    onnx.checker.check_model(model)
+
+    # The independently hand-built reference: the block already manually
+    # excised, `y` wired straight to the fused node's own raw
+    # `input + skip (+ bias)` sum -- computed by the *same* op/kernel (not
+    # a hand-derived float formula), so the comparison below is bit-exact
+    # by construction, not merely numerically close.
+    ref_skip_ln = _skip_ln_node("y")
+    ref_graph = onnx.helper.make_graph(
+        [ref_skip_ln],
+        "g",
+        inputs,
+        [onnx.helper.make_tensor_value_info("y", onnx.TensorProto.FLOAT, [1, 4, H])],
+        initializer=initializer,
+    )
+    ref = onnx.helper.make_model(
+        ref_graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 17),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+        ir_version=10,
+    )
+    onnx.checker.check_model(ref)
+
+    pruned = onnxsim.apply_transformer_block_pruning(
+        model, num_blocks_to_drop=1, seed=0, num_samples=4
+    )
+    onnx.checker.check_model(pruned)
+
+    # The fused SkipLayerNormalization node itself survives, unchanged --
+    # deleting it would delete the very tensor (`sum_out`) every rewired
+    # `x_out` consumer now reads (see this module's own section comment)
+    # -- its own primary (`ln_out`) output now unread. `MatMul`/`Add` (the
+    # rest of the block, plus the merge) are gone, replaced by the
+    # rewiring `Identity` that preserves the graph's own declared output
+    # name.
+    assert [n.op_type for n in pruned.graph.node] == [
+        "SkipLayerNormalization",
+        "Identity",
+    ]
+
+    x_in = np.random.default_rng(42).standard_normal((1, 4, H)).astype(np.float32)
+    x_skip = np.random.default_rng(43).standard_normal((1, 4, H)).astype(np.float32)
+    (pruned_y,) = _run(pruned, {"input": x_in, "skip": x_skip})
+    (ref_y,) = _run(ref, {"input": x_in, "skip": x_skip})
+    np.testing.assert_array_equal(pruned_y, ref_y)
+
+
+def test_transformer_block_pruning_matches_fused_skip_simplified_layer_normalization_entry():
+    # ``SkipSimplifiedLayerNormalization`` (the RMSNorm-equivalent fused
+    # variant, no `beta`) as the entry norm -- confirms the fused-entry
+    # match isn't specific to the (non-simplified) `SkipLayerNormalization`
+    # schema. Built with `onnx.helper` for the same reason as the sibling
+    # test above.
+    H = 8
+    rng = np.random.default_rng(45)
+    gamma = rng.standard_normal(H).astype(np.float32)
+    w = (rng.standard_normal((H, H)) * 1e-6).astype(np.float32)
+
+    def _skip_ln_node(sum_output_name):
+        return onnx.helper.make_node(
+            "SkipSimplifiedLayerNormalization",
+            ["input", "skip", "Gamma"],
+            ["ln_out", "", "", sum_output_name],
+            domain="com.microsoft",
+            epsilon=1e-5,
+        )
+
+    initializer = [_f32(gamma, "Gamma")]
+    inputs = [
+        onnx.helper.make_tensor_value_info("input", onnx.TensorProto.FLOAT, [1, 4, H]),
+        onnx.helper.make_tensor_value_info("skip", onnx.TensorProto.FLOAT, [1, 4, H]),
+    ]
+
+    skip_ln = _skip_ln_node("sum_out")
+    h = onnx.helper.make_node("MatMul", ["ln_out", "W"], ["h"])
+    y = onnx.helper.make_node("Add", ["sum_out", "h"], ["y"])
+    graph = onnx.helper.make_graph(
+        [skip_ln, h, y],
+        "g",
+        inputs,
+        [onnx.helper.make_tensor_value_info("y", onnx.TensorProto.FLOAT, [1, 4, H])],
+        initializer=initializer + [_f32(w, "W")],
+        # See the sibling `SkipLayerNormalization` test above for why this
+        # declared shape (mirroring a real ORT-optimized export) matters.
+        value_info=[
+            onnx.helper.make_tensor_value_info(
+                "sum_out", onnx.TensorProto.FLOAT, [1, 4, H]
+            )
+        ],
+    )
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 17),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+        ir_version=10,
+    )
+    onnx.checker.check_model(model)
+
+    ref_skip_ln = _skip_ln_node("y")
+    ref_graph = onnx.helper.make_graph(
+        [ref_skip_ln],
+        "g",
+        inputs,
+        [onnx.helper.make_tensor_value_info("y", onnx.TensorProto.FLOAT, [1, 4, H])],
+        initializer=initializer,
+    )
+    ref = onnx.helper.make_model(
+        ref_graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 17),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+        ir_version=10,
+    )
+    onnx.checker.check_model(ref)
+
+    pruned = onnxsim.apply_transformer_block_pruning(
+        model, num_blocks_to_drop=1, seed=0, num_samples=4
+    )
+    onnx.checker.check_model(pruned)
+    assert [n.op_type for n in pruned.graph.node] == [
+        "SkipSimplifiedLayerNormalization",
+        "Identity",
+    ]
+
+    x_in = np.random.default_rng(46).standard_normal((1, 4, H)).astype(np.float32)
+    x_skip = np.random.default_rng(47).standard_normal((1, 4, H)).astype(np.float32)
+    (pruned_y,) = _run(pruned, {"input": x_in, "skip": x_skip})
+    (ref_y,) = _run(ref, {"input": x_in, "skip": x_skip})
+    np.testing.assert_array_equal(pruned_y, ref_y)
+
+
+def test_transformer_block_pruning_declines_fused_entry_when_sum_output_absent():
+    # The fused node's own optional fourth output (`input_skip_bias_sum`)
+    # is never declared at all -- confirmed empirically (see this
+    # module's own section comment) to mean onnxruntime never computes or
+    # exposes it, so there is no tensor this pass could safely treat as
+    # `x_in`. The merge's own identity operand is `input` (the fused
+    # node's own *first* input) directly instead -- structurally close to
+    # a real fused-entry block, but not the pattern this pass targets: it
+    # must decline outright rather than mismatch onto some other tensor
+    # (e.g. `input`, which is not `x_in` -- the true `x_in` doesn't exist
+    # as a named tensor in this graph at all). Left completely untouched.
+    H = 8
+    rng = np.random.default_rng(49)
+    gamma = rng.standard_normal(H).astype(np.float32)
+    beta = rng.standard_normal(H).astype(np.float32)
+    w = rng.standard_normal((H, H)).astype(np.float32)
+
+    skip_ln = onnx.helper.make_node(
+        "SkipLayerNormalization",
+        ["input", "skip", "Gamma", "Beta"],
+        ["ln_out"],  # no fourth output declared at all
+        domain="com.microsoft",
+        epsilon=1e-5,
+    )
+    h = onnx.helper.make_node("MatMul", ["ln_out", "W"], ["h"])
+    y = onnx.helper.make_node("Add", ["input", "h"], ["y"])
+    graph = onnx.helper.make_graph(
+        [skip_ln, h, y],
+        "g",
+        [
+            onnx.helper.make_tensor_value_info(
+                "input", onnx.TensorProto.FLOAT, [1, 4, H]
+            ),
+            onnx.helper.make_tensor_value_info(
+                "skip", onnx.TensorProto.FLOAT, [1, 4, H]
+            ),
+        ],
+        [onnx.helper.make_tensor_value_info("y", onnx.TensorProto.FLOAT, [1, 4, H])],
+        initializer=[_f32(gamma, "Gamma"), _f32(beta, "Beta"), _f32(w, "W")],
+    )
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 17),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+        ir_version=10,
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_transformer_block_pruning(
+        model, num_blocks_to_drop=1, seed=0, num_samples=4
+    )
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
+def test_transformer_block_pruning_declines_kv_cache_bearing_attention_block_with_fused_entry():
+    # The same KV-cache decline as
+    # `test_transformer_block_pruning_declines_kv_cache_bearing_attention_block`
+    # above, but reached through the new fused-`SkipLayerNormalization`
+    # entry path instead of a plain `LayerNormalization` -- confirms the
+    # existing generic "no block-internal output may leak outside the
+    # block" safety check applies identically regardless of which entry
+    # shape found the candidate. Left completely untouched.
+    K, NH, D = 8, 2, 4
+    Nqkv = NH * D
+    rng = np.random.default_rng(51)
+    gamma = rng.standard_normal(K).astype(np.float32)
+    beta = rng.standard_normal(K).astype(np.float32)
+    wq = rng.standard_normal((K, Nqkv)).astype(np.float32)
+    wk = rng.standard_normal((K, Nqkv)).astype(np.float32)
+    wv = rng.standard_normal((K, Nqkv)).astype(np.float32)
+    wout = rng.standard_normal((Nqkv, K)).astype(np.float32)
+
+    skip_ln = onnx.helper.make_node(
+        "SkipLayerNormalization",
+        ["input", "skip", "Gamma", "Beta"],
+        ["ln_out", "", "", "sum_out"],
+        domain="com.microsoft",
+        epsilon=1e-5,
+    )
+    q = onnx.helper.make_node("MatMul", ["ln_out", "Wq"], ["q"])
+    k = onnx.helper.make_node("MatMul", ["ln_out", "Wk"], ["k"])
+    v = onnx.helper.make_node("MatMul", ["ln_out", "Wv"], ["v"])
+    attn = onnx.helper.make_node(
+        "GroupQueryAttention",
+        ["q", "k", "v"],
+        ["ctx", "present_k", "present_v"],
+        domain="com.microsoft",
+        num_heads=NH,
+        kv_num_heads=NH,
+    )
+    fout = onnx.helper.make_node("MatMul", ["ctx", "Wout"], ["fout"])
+    y = onnx.helper.make_node("Add", ["sum_out", "fout"], ["y"])
+
+    graph = onnx.helper.make_graph(
+        [skip_ln, q, k, v, attn, fout, y],
+        "g",
+        [
+            onnx.helper.make_tensor_value_info(
+                "input", onnx.TensorProto.FLOAT, [2, 5, K]
+            ),
+            onnx.helper.make_tensor_value_info(
+                "skip", onnx.TensorProto.FLOAT, [2, 5, K]
+            ),
+        ],
+        [
+            onnx.helper.make_tensor_value_info("y", onnx.TensorProto.FLOAT, [2, 5, K]),
+            onnx.helper.make_tensor_value_info(
+                "present_k", onnx.TensorProto.FLOAT, [2, 5, Nqkv]
+            ),
+            onnx.helper.make_tensor_value_info(
+                "present_v", onnx.TensorProto.FLOAT, [2, 5, Nqkv]
+            ),
+        ],
+        initializer=[
+            _f32(gamma, "Gamma"),
+            _f32(beta, "Beta"),
+            _f32(wq, "Wq"),
+            _f32(wk, "Wk"),
+            _f32(wv, "Wv"),
+            _f32(wout, "Wout"),
+        ],
+        # Declared, matching a real ORT-optimized export, so the fused
+        # entry is actually resolved into a full candidate (and only then
+        # correctly declined on the KV-cache leak below) rather than
+        # separately declining on an unrelated unknown-shape gap in plain
+        # `onnx.shape_inference` -- see the positive fused-entry tests
+        # above for why this is needed.
+        value_info=[
+            onnx.helper.make_tensor_value_info(
+                "sum_out", onnx.TensorProto.FLOAT, [2, 5, K]
+            )
+        ],
+    )
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 17),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+        ir_version=10,
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_transformer_block_pruning(
+        model, num_blocks_to_drop=1, seed=0, num_samples=4
+    )
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
 def test_transformer_block_pruning_declines_when_intermediate_tensor_has_external_consumer():
     # LN's own output also feeds a second graph output directly -- an
     # intermediate tensor read outside the block, exactly the topology


### PR DESCRIPTION
## Summary

`apply_transformer_block_pruning`'s own scope comment previously stated plainly that a model already run through onnxruntime's transformer optimizer — which fuses nearly every residual `Add` immediately followed by a `LayerNorm` into a single `com.microsoft::SkipLayerNormalization`/`SkipSimplifiedLayerNormalization` node — was out of scope for the *entry-norm* side of block matching (`LN(x_in)`), costing real coverage on exactly the kind of already-optimized export this pass is most likely to see in practice. This PR closes that gap.

## Schema facts (confirmed live, not assumed)

- Queried `onnxruntime.capi.onnxruntime_pybind11_state.get_all_operator_schema()` directly: both `SkipLayerNormalization` and `SkipSimplifiedLayerNormalization` (`com.microsoft`) have inputs `[input, skip, gamma(required), beta(optional, non-simplified only), bias(optional)]` and outputs `[output(required), mean(optional), inv_std_var(optional), input_skip_bias_sum(optional)]`.
- Built minimal real nodes and ran them through a real `onnxruntime.InferenceSession`: when the 4th output's name is omitted from the node's own `output` list, onnxruntime simply doesn't compute or expose it — no error, no silent materialization. When declared, it materializes and is **bit-exact equal** to `input + skip (+ bias)` — confirmed via `np.array_equal`, not `allclose` — distinct from the normalized primary `output`.

## What changed

- New `_is_fused_entry_ln_node(node, x_in, t)`: matches a `SkipLayerNormalization`/`SkipSimplifiedLayerNormalization` node reached via its own *primary* output, whose 4th output equals `x_in`.
- `_try_resolve_droppable_block`'s backward walk now recognizes this boundary alongside the existing plain-`LN` check. Critically, the fused node is **never added to `block_nodes`** (never deleted) when matched this way — unlike a plain `LN` node, its own *output* (`input_skip_bias_sum`) *is* `x_in`, so deleting it would corrupt the graph feeding every rewired `x_out` consumer. Its own primary (normalized) output simply loses its only consumer and goes unread, which is harmless.
- A `fused_boundary_ids` set guards against a contradictory second classification of the same node reached via one of its other (training-only, in-practice-never-wired) outputs.
- The merge side (`x_out`) stays bare-`Add`-only, untouched — this PR only extends the *entry-norm* recognition, per the module's own existing, deliberate merge-side scope decision.
- A raw, not-yet-optimizer-fused export still matches fully, unaffected.

## Test plan
- [x] `pytest tests/test_pruning.py -q` — 375 passed (was 371 before this change)
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — 0 errors, matches master's baseline
- [x] Real fused-entry block-drop tests (`SkipLayerNormalization` and `SkipSimplifiedLayerNormalization`) checked **bit-exact** (`assert_array_equal`) via real onnxruntime execution against an independently-built reference wired to the *same* op's own raw sum output — not a hand-derived float formula, so the comparison is bit-exact by construction
- [x] Decline-path test: 4th output not declared → declines cleanly, model byte-identical to input
- [x] Decline-path test: existing KV-cache-bearing-block safety check still applies identically through the new fused-entry path

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_