### PR TITLE
Add legacy GGML quant (Q4_0/Q4_1/Q5_0/Q5_1) decode support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -590,6 +590,14 @@ if (ONNXSIM_TESTS)
   target_include_directories(ggml_mxfp4_test PRIVATE onnxsim)
   add_test(NAME ggml_mxfp4_test COMMAND ggml_mxfp4_test)
 
+  # GGML legacy quant (Q4_0/Q4_1/Q5_0/Q5_1) dequantization
+  # (ggml_legacy_quant.h) -- same standalone-buildable dependency footprint
+  # as ggml_kquant_test above (it reuses that header's fp16 conversion, but
+  # still needs only gguf_dtype.h/ggml_kquant.h, no protobuf/onnx).
+  add_executable(ggml_legacy_quant_test onnxsim/ggml_legacy_quant_test.cpp)
+  target_include_directories(ggml_legacy_quant_test PRIVATE onnxsim)
+  add_test(NAME ggml_legacy_quant_test COMMAND ggml_legacy_quant_test)
+
   # TensorPool's GGUF read/write (tensor_pool_gguf.cpp) depends only on
   # tensor_pool.{h,cpp} and gguf_dtype.h, so it too builds and runs
   # standalone without ONNX / ONNX Runtime configured.

--- a/docs/import-gguf-weights.md
+++ b/docs/import-gguf-weights.md
@@ -37,16 +37,20 @@ being overwritten with bytes that don't fit its declared shape. This does
 **not** include tensors simply absent from `model`'s initializers, which
 are silently left alone.
 
-## GGML "K-quant" and MXFP4 support
+## GGML "K-quant", legacy quant, and MXFP4 support
 
 Real quantized checkpoints store most of their weights as one of GGML's
 block-quantized formats, not plain float. This function decodes the
 **K-quant** family -- `Q4_K`, `Q5_K`, `Q6_K` (256-element super-blocks, each
 with its own packed 6-bit per-sub-block scale/min pair) and `Q8_0`
 (32-element blocks, one fp16 scale each) -- which is what Unsloth's `*_K_M`/
-`*_K_S`/`Q8_0` GGUF exports actually use for the bulk of their tensors, plus
-**MXFP4** (32-element blocks, one shared power-of-two E8M0 exponent byte and
-16 bytes of packed 4-bit e2m1-style codes) -- the OCP Microscaling FP4 format
+`*_K_S`/`Q8_0` GGUF exports actually use for the bulk of their tensors; the
+**legacy** family -- `Q4_0`, `Q4_1`, `Q5_0`, `Q5_1` (plain 32-element blocks,
+no super-block scale/min table) -- which llama.cpp's own mixed-precision
+quantizers still pick for particular tensor roles (embeddings, attention
+projections) even in an otherwise K-quant checkpoint; and **MXFP4**
+(32-element blocks, one shared power-of-two E8M0 exponent byte and 16 bytes
+of packed 4-bit e2m1-style codes) -- the OCP Microscaling FP4 format
 official gpt-oss GGUF releases use natively for their MoE expert weights.
 Every block layout and dequantization formula is transcribed directly from
 GGML's own reference implementation
@@ -54,24 +58,39 @@ GGML's own reference implementation
 `ggml-quants.c`'s `dequantize_row_q*`/`dequantize_row_mxfp4` functions,
 `ggml-impl.h`'s `ggml_e8m0_to_fp32_half`) and cross-checked against an
 independent from-scratch re-implementation over full random blocks before
-being committed (see `onnxsim/ggml_kquant.h`'s and `onnxsim/ggml_mxfp4.h`'s
-file comments).
+being committed (see `onnxsim/ggml_kquant.h`'s, `onnxsim/
+ggml_legacy_quant.h`'s, and `onnxsim/ggml_mxfp4.h`'s file comments).
 
-A matched K-quant or MXFP4 tensor's initializer has its `data_type` forced
-to `FLOAT` regardless of what `model` previously declared for it -- the
-decoded values are only meaningful as float32.
+The legacy family's real-world importance was confirmed empirically, not
+assumed: fetching the real header of several official
+[`unsloth/gpt-oss-20b-GGUF`](https://huggingface.co/unsloth/gpt-oss-20b-GGUF)
+quantizations (via an HTTP range request for just the header bytes, no need
+to download the multi-gigabyte weight data) showed that most of the
+popular, size-optimized ones -- `Q4_K_M`, `Q4_K_S`, `Q5_K_M`, `Q4_0`,
+`UD-Q4_K_XL` -- mix in one or more legacy-family tensors for `token_embd`/
+`attn_q`/`attn_k`/`attn_v`, and would fail to import at all without this.
+Only the largest variants (`F16`, `Q8_0`, `Q6_K`, `UD-Q8_K_XL`) used
+exclusively K-quant/MXFP4/raw types before this family was added. The
+smallest variants (`Q2_K`, `Q3_K_M`) still fail: they additionally need
+`Q3_K` and an `IQ*`/`Q2_K`-family type, which remain out of scope (see
+"Scope" below).
+
+A matched K-quant, legacy-quant, or MXFP4 tensor's initializer has its
+`data_type` forced to `FLOAT` regardless of what `model` previously
+declared for it -- the decoded values are only meaningful as float32.
 
 ## Scope
 
 Handled:
-- `Q4_K`, `Q5_K`, `Q6_K`, `Q8_0`, `MXFP4` -- decoded to float32.
+- `Q4_K`, `Q5_K`, `Q6_K`, `Q8_0` (K-quant), `Q4_0`, `Q4_1`, `Q5_0`, `Q5_1`
+  (legacy), `MXFP4` -- decoded to float32.
 - Any raw (already-unquantized) GGML type (`F32`, `F16`, `BF16`, `F64`,
   `I8`/`I16`/`I32`/`I64`) -- copied through unchanged, same as `import_gguf`.
 
 Not handled (reported in `skipped`, left untouched):
-- The legacy `Q4_0`/`Q4_1`/`Q5_0`/`Q5_1`/`Q8_1` family, `Q2_K`/`Q3_K`/`Q8_K`,
-  `NVFP4`, and every `IQ*` importance-matrix variant -- these have real,
-  different block layouts this decoder does not implement.
+- `Q8_1`, `Q2_K`/`Q3_K`/`Q8_K`, `NVFP4`, and every `IQ*` importance-matrix
+  variant -- these have real, different block layouts this decoder does not
+  implement.
 
 Only an initializer whose *name* matches a GGUF tensor is ever touched;
 `import_gguf_weights` never adds new initializers or otherwise changes the
@@ -163,12 +182,13 @@ alone, for a MoE graph you already built or exported some other way.
 ## Tests
 
 `tests/test_import_gguf_weights.py` writes real, byte-accurate GGUF v3
-files containing hand-encoded `Q8_0`/`Q4_K` blocks with known values
-(computing each expected float independently, not by reusing the C++
-decoder under test) and checks `import_gguf_weights`' decoded result against
-them, plus coverage for multi-dimensional shapes (GGML's
-innermost-dimension-first `ne[]` vs ONNX's outermost-first shape), the
-unsupported/unmatched skip list, raw-dtype passthrough, a real 3D
+files containing hand-encoded `Q8_0`/`Q4_K` (K-quant), `Q4_0`/`Q4_1`/`Q5_0`/
+`Q5_1` (legacy, see `test_import_q4_0_weights` and friends), and MXFP4
+blocks with known values (computing each expected float independently, not
+by reusing the C++ decoder under test) and checks `import_gguf_weights`'
+decoded result against them, plus coverage for multi-dimensional shapes
+(GGML's innermost-dimension-first `ne[]` vs ONNX's outermost-first shape),
+the unsupported/unmatched skip list, raw-dtype passthrough, a real 3D
 expert-tensor round trip under llama.cpp's own MoE naming convention (see
 the "Mixture-of-experts" section above), and a shape-mismatched tensor
 ending up in `skipped` with its initializer's original value intact.

--- a/onnxsim/ggml_legacy_quant.h
+++ b/onnxsim/ggml_legacy_quant.h
@@ -1,0 +1,186 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Dequantization for GGML's legacy Q4_0/Q4_1/Q5_0/Q5_1 block formats
+ * (gguf_dtype.h's IsLegacyQuant): decodes a tensor's native, still-packed
+ * GGML block bytes (see gguf_dtype.h's LegacyQuantBlockBytes) into plain
+ * host-order float32 values.
+ *
+ * Pure, dependency-free (no protobuf, no onnx headers) like gguf_dtype.h and
+ * ggml_kquant.h -- operates on raw bytes and the same integer ggml_type
+ * codes, so this builds and unit-tests standalone.
+ *
+ * Every block layout and dequantization formula here is transcribed
+ * verbatim from GGML's own reference implementation
+ * (https://github.com/ggml-org/ggml -- ggml-common.h's
+ * block_q4_0/block_q4_1/block_q5_0/block_q5_1 struct layouts, ggml-quants.c's
+ * dequantize_row_q4_0/q4_1/q5_0/q5_1). Byte order: like onnx::TensorProto::
+ * raw_data and every GGUF file (see tensor_pool.h's file comment), a
+ * block's multi-byte fields are little-endian on disk regardless of host
+ * byte order -- this file's Float16BitsToFloat32 argument is always
+ * reconstructed via explicit byte-at-a-time reads (ReadLE16/ReadLE32), never
+ * a reinterpret_cast of the block struct, so decoding is correct on a
+ * big-endian host too (this repo tests on s390x). A block's single-byte
+ * fields (the packed quant codes) need no such care -- one byte has no
+ * endianness.
+ *
+ * Unlike the K-quant family (ggml_kquant.h), each of these four types packs
+ * a single, plain 32-element block with no super-block scale/min table:
+ * Q4_0/Q5_0 reconstruct as `code*d` (with a fixed per-format zero-point bias
+ * subtracted from the 4/5-bit code before scaling), Q4_1/Q5_1 as
+ * `code*d + m` (an explicit per-block min, no bias needed since the code is
+ * used unsigned). Q5_0/Q5_1's 5th bit lives in a separate 4-byte `qh`
+ * bitfield, one bit per element, rather than packed alongside the other 4
+ * bits.
+ *
+ * Reuses ggml_kquant.h's ReadLE16/Float16BitsToFloat32 (every one of these
+ * four formats' scale/min fields is the same fp16 GGML `ggml_half` K-quant
+ * already needs to decode) rather than duplicating that conversion --
+ * unlike gguf_dtype.h's own choice to duplicate small wire-format constants
+ * across codecs, an fp16-to-fp32 conversion is intricate enough (denormal/
+ * inf/nan handling) that a second, independently-maintained copy would risk
+ * silently drifting out of sync with the original.
+ */
+#ifndef ONNXSIM_GGML_LEGACY_QUANT_H_
+#define ONNXSIM_GGML_LEGACY_QUANT_H_
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include "ggml_kquant.h"
+#include "gguf_dtype.h"
+
+namespace onnxsim {
+namespace tensor_pool {
+namespace gguf {
+
+// Reconstructs a little-endian uint32_t from four bytes, regardless of host
+// byte order -- Q5_0/Q5_1's `qh` field, mirroring ggml_kquant.h's ReadLE16
+// for the 2-byte case.
+inline uint32_t ReadLE32(const uint8_t* p) {
+  return static_cast<uint32_t>(p[0]) | (static_cast<uint32_t>(p[1]) << 8) |
+         (static_cast<uint32_t>(p[2]) << 16) |
+         (static_cast<uint32_t>(p[3]) << 24);
+}
+
+// Decodes one 18-byte Q4_0 block (32 elements) into `out`. Each 4-bit code
+// is biased by -8 (Q4_0's codes are unsigned 0..15, representing signed
+// -8..7) before scaling -- no separate min value stored.
+inline void DequantizeQ4_0Block(const uint8_t* block, float* out) {
+  const float d = Float16BitsToFloat32(ReadLE16(block));
+  const uint8_t* qs = block + 2;
+  for (int j = 0; j < 16; ++j) {
+    const int x0 = (qs[j] & 0x0F) - 8;
+    const int x1 = (qs[j] >> 4) - 8;
+    out[j] = static_cast<float>(x0) * d;
+    out[j + 16] = static_cast<float>(x1) * d;
+  }
+}
+
+// Decodes one 20-byte Q4_1 block (32 elements) into `out`. Codes are used
+// unsigned (0..15) with an explicit per-block min `m` added after scaling.
+inline void DequantizeQ4_1Block(const uint8_t* block, float* out) {
+  const float d = Float16BitsToFloat32(ReadLE16(block));
+  const float m = Float16BitsToFloat32(ReadLE16(block + 2));
+  const uint8_t* qs = block + 4;
+  for (int j = 0; j < 16; ++j) {
+    const int x0 = qs[j] & 0x0F;
+    const int x1 = qs[j] >> 4;
+    out[j] = static_cast<float>(x0) * d + m;
+    out[j + 16] = static_cast<float>(x1) * d + m;
+  }
+}
+
+// Decodes one 22-byte Q5_0 block (32 elements) into `out`. Each element's
+// 5th (high) bit lives in the block's 4-byte `qh` bitfield rather than
+// alongside the other 4 bits in `qs`; the resulting 5-bit unsigned code
+// (0..31) is biased by -16 before scaling -- no separate min value stored.
+inline void DequantizeQ5_0Block(const uint8_t* block, float* out) {
+  const float d = Float16BitsToFloat32(ReadLE16(block));
+  const uint32_t qh = ReadLE32(block + 2);
+  const uint8_t* qs = block + 6;
+  for (int j = 0; j < 16; ++j) {
+    const uint8_t xh_0 = static_cast<uint8_t>(((qh >> (j + 0)) << 4) & 0x10);
+    const uint8_t xh_1 = static_cast<uint8_t>((qh >> (j + 12)) & 0x10);
+    const int x0 = ((qs[j] & 0x0F) | xh_0) - 16;
+    const int x1 = ((qs[j] >> 4) | xh_1) - 16;
+    out[j] = static_cast<float>(x0) * d;
+    out[j + 16] = static_cast<float>(x1) * d;
+  }
+}
+
+// Decodes one 24-byte Q5_1 block (32 elements) into `out`. Same 5th-bit
+// scheme as Q5_0, but the resulting 5-bit code is used unsigned (0..31)
+// with an explicit per-block min `m` added after scaling, like Q4_1.
+inline void DequantizeQ5_1Block(const uint8_t* block, float* out) {
+  const float d = Float16BitsToFloat32(ReadLE16(block));
+  const float m = Float16BitsToFloat32(ReadLE16(block + 2));
+  const uint32_t qh = ReadLE32(block + 4);
+  const uint8_t* qs = block + 8;
+  for (int j = 0; j < 16; ++j) {
+    const uint8_t xh_0 = static_cast<uint8_t>(((qh >> (j + 0)) << 4) & 0x10);
+    const uint8_t xh_1 = static_cast<uint8_t>((qh >> (j + 12)) & 0x10);
+    const int x0 = (qs[j] & 0x0F) | xh_0;
+    const int x1 = (qs[j] >> 4) | xh_1;
+    out[j] = static_cast<float>(x0) * d + m;
+    out[j + 16] = static_cast<float>(x1) * d + m;
+  }
+}
+
+// Decodes `raw` (an IsLegacyQuant(ggml_type) tensor's native block bytes,
+// exactly `numel / 32 * LegacyQuantBlockBytes(ggml_type)` bytes long) into
+// `numel` host-order float32 values, appended to `out` (not cleared first).
+// Returns false, leaving `out` untouched, if `ggml_type` is not one of the
+// four IsLegacyQuant types, `numel` is not a multiple of 32, or `raw_size`
+// does not match the expected byte length for `numel` elements (a corrupt/
+// truncated buffer).
+inline bool DequantizeGgmlLegacyQuant(const uint8_t* raw, size_t raw_size,
+                                      uint32_t ggml_type, int64_t numel,
+                                      std::vector<float>* out) {
+  if (!IsLegacyQuant(ggml_type) || numel < 0) {
+    return false;
+  }
+  const size_t block_elems = LegacyQuantBlockElements(ggml_type);
+  const size_t block_bytes = LegacyQuantBlockBytes(ggml_type);
+  const uint64_t unumel = static_cast<uint64_t>(numel);
+  if (unumel % block_elems != 0) {
+    return false;
+  }
+  const uint64_t num_blocks = unumel / block_elems;
+  if (num_blocks * block_bytes != raw_size) {
+    return false;
+  }
+
+  const size_t out_start = out->size();
+  out->resize(out_start + unumel);
+  float* dst = out->data() + out_start;
+  const uint8_t* src = raw;
+  for (uint64_t b = 0; b < num_blocks; ++b) {
+    switch (ggml_type) {
+      case GGML_TYPE_Q4_0:
+        DequantizeQ4_0Block(src, dst);
+        break;
+      case GGML_TYPE_Q4_1:
+        DequantizeQ4_1Block(src, dst);
+        break;
+      case GGML_TYPE_Q5_0:
+        DequantizeQ5_0Block(src, dst);
+        break;
+      case GGML_TYPE_Q5_1:
+        DequantizeQ5_1Block(src, dst);
+        break;
+      default:
+        return false;  // Unreachable: IsLegacyQuant already filtered this.
+    }
+    src += block_bytes;
+    dst += block_elems;
+  }
+  return true;
+}
+
+}  // namespace gguf
+}  // namespace tensor_pool
+}  // namespace onnxsim
+
+#endif  // ONNXSIM_GGML_LEGACY_QUANT_H_

--- a/onnxsim/ggml_legacy_quant_test.cpp
+++ b/onnxsim/ggml_legacy_quant_test.cpp
@@ -1,0 +1,212 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Standalone: g++ -std=c++20 ggml_legacy_quant_test.cpp -o t && ./t
+ *
+ * Dependency-free unit test for ggml_legacy_quant.h's GGML legacy quant
+ * dequantization (Q4_0, Q4_1, Q5_0, Q5_1), mirroring ggml_kquant_test.cpp's
+ * style.
+ *
+ * Every block layout/formula this decodes was cross-checked against GGML's
+ * own reference (ggml-common.h's block_q4_0/q4_1/q5_0/q5_1, ggml-quants.c's
+ * dequantize_row_q4_0/q4_1/q5_0/q5_1). The cases here are small,
+ * hand-verifiable vectors (chosen so most of a block's bytes are zero and
+ * its non-zero bytes' contribution can be checked by hand), meant to catch
+ * a regression in this file specifically, not to re-derive GGML's spec from
+ * scratch.
+ */
+#include "ggml_legacy_quant.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+using namespace onnxsim::tensor_pool::gguf;
+
+namespace {
+
+int g_failures = 0;
+
+void Check(bool cond, const std::string& what) {
+  if (!cond) {
+    std::fprintf(stderr, "FAIL: %s\n", what.c_str());
+    ++g_failures;
+  }
+}
+
+void CheckNear(float got, float want, const std::string& what,
+               float tol = 1e-4f) {
+  Check(std::fabs(got - want) <= tol, what + " (got " + std::to_string(got) +
+                                          ", want " + std::to_string(want) +
+                                          ")");
+}
+
+// Encodes `f` as an IEEE754 half-precision bit pattern -- same reference
+// encoder as ggml_kquant_test.cpp's EncodeF16 (round-to-nearest not
+// implemented; every value used below is exactly representable in fp16),
+// used only to BUILD test input.
+uint16_t EncodeF16(float f) {
+  uint32_t x;
+  std::memcpy(&x, &f, 4);
+  uint32_t sign = (x >> 16) & 0x8000u;
+  int32_t exp = static_cast<int32_t>((x >> 23) & 0xFFu) - 127 + 15;
+  uint32_t mant = x & 0x7FFFFFu;
+  if (exp <= 0) return static_cast<uint16_t>(sign);
+  if (exp >= 0x1F) return static_cast<uint16_t>(sign | 0x7C00u);
+  return static_cast<uint16_t>(sign | (static_cast<uint32_t>(exp) << 10) |
+                               (mant >> 13));
+}
+
+void WriteLE16(std::vector<uint8_t>& buf, uint16_t v) {
+  buf.push_back(static_cast<uint8_t>(v & 0xFF));
+  buf.push_back(static_cast<uint8_t>((v >> 8) & 0xFF));
+}
+
+// d = 2.0, qs[i] = i (so the low/high nibbles span the full 0-15 range this
+// test cares about). expected[j] = (qs[j]&0xF - 8) * 2.0, expected[j+16] =
+// (qs[j]>>4 - 8) * 2.0.
+void TestQ4_0() {
+  std::vector<uint8_t> block;
+  WriteLE16(block, EncodeF16(2.0f));
+  for (int i = 0; i < 16; ++i) block.push_back(static_cast<uint8_t>(i));
+  Check(block.size() == LegacyQuantBlockBytes(GGML_TYPE_Q4_0), "Q4_0 size");
+
+  float out[32];
+  DequantizeQ4_0Block(block.data(), out);
+  // qs[0] = 0x00: low nibble 0 -> (0-8)*2 = -16; high nibble 0 -> -16.
+  CheckNear(out[0], -16.0f, "Q4_0 element 0");
+  CheckNear(out[16], -16.0f, "Q4_0 element 16");
+  // qs[15] = 0x0F: low nibble 15 -> (15-8)*2 = 14; high nibble 0 -> -16.
+  CheckNear(out[15], 14.0f, "Q4_0 element 15");
+  CheckNear(out[31], -16.0f, "Q4_0 element 31");
+
+  std::vector<uint8_t> two_blocks = block;
+  two_blocks.insert(two_blocks.end(), block.begin(), block.end());
+  std::vector<float> dispatched;
+  Check(DequantizeGgmlLegacyQuant(two_blocks.data(), two_blocks.size(),
+                                  GGML_TYPE_Q4_0, 64, &dispatched),
+        "DequantizeGgmlLegacyQuant(Q4_0, 2 blocks) succeeds");
+  Check(dispatched.size() == 64, "DequantizeGgmlLegacyQuant(Q4_0) size");
+  if (dispatched.size() == 64) {
+    CheckNear(dispatched[0], -16.0f, "Q4_0 dispatcher block 0 elem 0");
+    CheckNear(dispatched[32], -16.0f, "Q4_0 dispatcher block 1 elem 0");
+  }
+}
+
+// d = 1.0, m = 0.5, qs[0] = 0x0A (low nibble 10, high nibble 0), rest zero.
+// expected[0] = 10*1.0 + 0.5 = 10.5; expected[16] = 0*1.0 + 0.5 = 0.5.
+void TestQ4_1() {
+  std::vector<uint8_t> block(LegacyQuantBlockBytes(GGML_TYPE_Q4_1), 0);
+  const uint16_t d_bits = EncodeF16(1.0f);
+  const uint16_t m_bits = EncodeF16(0.5f);
+  block[0] = static_cast<uint8_t>(d_bits & 0xFF);
+  block[1] = static_cast<uint8_t>((d_bits >> 8) & 0xFF);
+  block[2] = static_cast<uint8_t>(m_bits & 0xFF);
+  block[3] = static_cast<uint8_t>((m_bits >> 8) & 0xFF);
+  block[4] = 0x0A;  // qs[0]
+
+  float out[32];
+  DequantizeQ4_1Block(block.data(), out);
+  CheckNear(out[0], 10.5f, "Q4_1 element 0");
+  CheckNear(out[16], 0.5f, "Q4_1 element 16 (zeroed nibble)");
+  CheckNear(out[1], 0.5f, "Q4_1 element 1 (zeroed nibble)");
+}
+
+// d = 2.0, qh selects the 5th bit for element 0 only (bit 0 -> xh_0 set for
+// j=0), qs[0] low nibble = 3. expected[0] = ((3 | 16) - 16) * 2.0 = 3*2=6.0
+// Wait: xh_0 for j=0 is bit (j+0)=0 of qh, shifted <<4 and masked 0x10, so a
+// set bit 0 contributes 0x10 to the low nibble -> code = 3 | 0x10 = 19,
+// 19-16=3, *d=2 -> 6.0. High nibble (element 16) uses xh_1 = bit (j+12)=12
+// of qh; left at 0, so code = (qs[0]>>4) - 16 = 0-16 = -16, *2 = -32.0.
+void TestQ5_0() {
+  std::vector<uint8_t> block(LegacyQuantBlockBytes(GGML_TYPE_Q5_0), 0);
+  const uint16_t d_bits = EncodeF16(2.0f);
+  block[0] = static_cast<uint8_t>(d_bits & 0xFF);
+  block[1] = static_cast<uint8_t>((d_bits >> 8) & 0xFF);
+  // qh is block[2..5]; set bit 0.
+  block[2] = 0x01;
+  // qs starts at block[6]; qs[0] low nibble = 3.
+  block[6] = 0x03;
+
+  float out[32];
+  DequantizeQ5_0Block(block.data(), out);
+  CheckNear(out[0], 6.0f, "Q5_0 element 0 (5th bit set)");
+  CheckNear(out[16], -32.0f, "Q5_0 element 16 (5th bit unset)");
+  CheckNear(out[1], -32.0f, "Q5_0 element 1 (zeroed nibble, no 5th bit)");
+
+  std::vector<uint8_t> two_blocks = block;
+  two_blocks.insert(two_blocks.end(), block.begin(), block.end());
+  std::vector<float> dispatched;
+  Check(DequantizeGgmlLegacyQuant(two_blocks.data(), two_blocks.size(),
+                                  GGML_TYPE_Q5_0, 64, &dispatched),
+        "DequantizeGgmlLegacyQuant(Q5_0, 2 blocks) succeeds");
+  Check(dispatched.size() == 64, "DequantizeGgmlLegacyQuant(Q5_0) size");
+  if (dispatched.size() == 64) {
+    CheckNear(dispatched[0], 6.0f, "Q5_0 dispatcher block 0 elem 0");
+    CheckNear(dispatched[32], 6.0f, "Q5_0 dispatcher block 1 elem 0");
+  }
+}
+
+// Same 5th-bit trick as Q5_0, but with an explicit min like Q4_1: d=1.0,
+// m=0.5, qh bit 0 set (adds 16 to element 0's code), qs[0] low nibble = 3.
+// expected[0] = (3|16)*1.0 + 0.5 = 19.5. expected[16] (xh_1 unset,
+// qs[0]>>4=0): 0*1.0+0.5 = 0.5.
+void TestQ5_1() {
+  std::vector<uint8_t> block(LegacyQuantBlockBytes(GGML_TYPE_Q5_1), 0);
+  const uint16_t d_bits = EncodeF16(1.0f);
+  const uint16_t m_bits = EncodeF16(0.5f);
+  block[0] = static_cast<uint8_t>(d_bits & 0xFF);
+  block[1] = static_cast<uint8_t>((d_bits >> 8) & 0xFF);
+  block[2] = static_cast<uint8_t>(m_bits & 0xFF);
+  block[3] = static_cast<uint8_t>((m_bits >> 8) & 0xFF);
+  // qh is block[4..7]; set bit 0.
+  block[4] = 0x01;
+  // qs starts at block[8]; qs[0] low nibble = 3.
+  block[8] = 0x03;
+
+  float out[32];
+  DequantizeQ5_1Block(block.data(), out);
+  CheckNear(out[0], 19.5f, "Q5_1 element 0 (5th bit set)");
+  CheckNear(out[16], 0.5f, "Q5_1 element 16 (5th bit unset, zeroed nibble)");
+}
+
+void TestDequantizeGgmlLegacyQuantRejectsBadInput() {
+  std::vector<uint8_t> q4_0_block(LegacyQuantBlockBytes(GGML_TYPE_Q4_0), 0);
+  std::vector<float> out;
+
+  Check(!DequantizeGgmlLegacyQuant(q4_0_block.data(), q4_0_block.size(),
+                                   GGML_TYPE_Q4_0, 33, &out),
+        "rejects non-block-aligned numel");
+  Check(!DequantizeGgmlLegacyQuant(q4_0_block.data(), q4_0_block.size() - 1,
+                                   GGML_TYPE_Q4_0, 32, &out),
+        "rejects mismatched raw_size");
+  Check(!DequantizeGgmlLegacyQuant(q4_0_block.data(), q4_0_block.size(),
+                                   GGML_TYPE_F32, 32, &out),
+        "rejects non-legacy-quant ggml_type");
+  Check(!DequantizeGgmlLegacyQuant(q4_0_block.data(), q4_0_block.size(),
+                                   GGML_TYPE_Q8_0, 32, &out),
+        "rejects K-quant ggml_type");
+  Check(!DequantizeGgmlLegacyQuant(q4_0_block.data(), q4_0_block.size(),
+                                   GGML_TYPE_Q4_0, -1, &out),
+        "rejects negative numel");
+  Check(out.empty(), "no partial output written on any rejected call");
+}
+
+}  // namespace
+
+int main() {
+  TestQ4_0();
+  TestQ4_1();
+  TestQ5_0();
+  TestQ5_1();
+  TestDequantizeGgmlLegacyQuantRejectsBadInput();
+
+  if (g_failures == 0) {
+    std::printf("ggml_legacy_quant_test: all checks passed\n");
+    return 0;
+  }
+  std::fprintf(stderr, "ggml_legacy_quant_test: %d failure(s)\n", g_failures);
+  return 1;
+}

--- a/onnxsim/gguf_dtype.h
+++ b/onnxsim/gguf_dtype.h
@@ -49,6 +49,20 @@
  * rather than folding into IsKQuant, but is otherwise handled the same way:
  * its own ONNXSIM_GGML_MXFP4 private dtype code, native block bytes carried
  * verbatim until ggml_mxfp4.h's DequantizeGgmlMxfp4 decodes it to float32.
+ *
+ * THIRD EXCEPTION -- the legacy Q4_0/Q4_1/Q5_0/Q5_1 family (see
+ * IsLegacyQuant/ggml_legacy_quant.h): real quantized checkpoints don't only
+ * use K-quant for every tensor -- llama.cpp's own mixed-precision "Q4_K_M"-
+ * style quantizers pick one of these legacy per-32-element formats for
+ * particular tensor roles (embeddings, attention projections) even in an
+ * otherwise K-quant checkpoint (confirmed empirically: several of a real,
+ * official gpt-oss-20b GGUF release's popular size-optimized quantizations
+ * -- e.g. Q4_K_S, Q4_0, Q5_K_M -- fail to import for exactly this reason
+ * without this family). Same affine (scale * code [- min]) reconstruction
+ * as K-quant's Q4_K/Q5_K, just over a plain 32-element block with no
+ * super-block scale/min table -- structurally simpler, not unrelated, but
+ * still a different block layout than any IsKQuant type, so it gets its own
+ * predicate and block-size helpers rather than folding into IsKQuant.
  */
 #ifndef ONNXSIM_GGUF_DTYPE_H_
 #define ONNXSIM_GGUF_DTYPE_H_
@@ -100,6 +114,10 @@ enum MetadataValueType : uint32_t {
 enum GgmlType : uint32_t {
   GGML_TYPE_F32 = 0,
   GGML_TYPE_F16 = 1,
+  GGML_TYPE_Q4_0 = 2,
+  GGML_TYPE_Q4_1 = 3,
+  GGML_TYPE_Q5_0 = 6,
+  GGML_TYPE_Q5_1 = 7,
   GGML_TYPE_Q8_0 = 8,
   GGML_TYPE_Q4_K = 12,
   GGML_TYPE_Q5_K = 13,
@@ -133,16 +151,21 @@ enum OnnxDtype : int32_t {
 
 // Private, onnxsim-fork-only dtype codes an Entry::dtype (or a TensorProto
 // this loader briefly produces before HydrateTensorProto decodes it away --
-// see the file comment) may hold for a still-packed GGML K-quant or MXFP4
-// tensor. Chosen from a range (10000+) with no plausible collision against
-// ONNX's own DataType enum (defined up to 26 as of this writing -- see
-// onnx.in.proto); never reassign or reuse one of these five values.
+// see the file comment) may hold for a still-packed GGML K-quant, MXFP4, or
+// legacy-quant tensor. Chosen from a range (10000+) with no plausible
+// collision against ONNX's own DataType enum (defined up to 26 as of this
+// writing -- see onnx.in.proto); never reassign or reuse one of these nine
+// values.
 enum OnnxsimPrivateDtype : int32_t {
   ONNXSIM_GGML_Q4_K = 10001,
   ONNXSIM_GGML_Q5_K = 10002,
   ONNXSIM_GGML_Q6_K = 10003,
   ONNXSIM_GGML_Q8_0 = 10004,
   ONNXSIM_GGML_MXFP4 = 10005,
+  ONNXSIM_GGML_Q4_0 = 10006,
+  ONNXSIM_GGML_Q4_1 = 10007,
+  ONNXSIM_GGML_Q5_0 = 10008,
+  ONNXSIM_GGML_Q5_1 = 10009,
 };
 
 // Bytes of one element. 0 for a ggml_type this mapping doesn't cover
@@ -249,6 +272,50 @@ inline size_t Mxfp4BlockBytes(uint32_t ggml_type) {
   return IsMxfp4(ggml_type) ? 17 : 0;
 }
 
+// True for one of the four legacy block-quantized types this mapping covers
+// (see the file comment's THIRD EXCEPTION paragraph) -- Q4_0, Q4_1, Q5_0,
+// Q5_1, all 32-element blocks. False for every other ggml_type, including
+// every quantized family this mapping does NOT decode (Q2_K, Q3_K, every
+// IQ*_ variant, ...).
+inline bool IsLegacyQuant(uint32_t ggml_type) {
+  switch (ggml_type) {
+    case GGML_TYPE_Q4_0:
+    case GGML_TYPE_Q4_1:
+    case GGML_TYPE_Q5_0:
+    case GGML_TYPE_Q5_1:
+      return true;
+    default:
+      return false;
+  }
+}
+
+// Elements per block for an IsLegacyQuant ggml_type. 0 for anything else.
+inline size_t LegacyQuantBlockElements(uint32_t ggml_type) {
+  return IsLegacyQuant(ggml_type) ? 32 : 0;
+}
+
+// Bytes per block for an IsLegacyQuant ggml_type -- the packed on-disk size
+// of one 32-element block (a 2-byte fp16 scale, an optional second 2-byte
+// fp16 min for the "_1" variants, an optional 4-byte high-bit table for the
+// "5_" variants, plus 16 bytes of packed 4-bit codes -- see
+// block_q4_0/block_q4_1/block_q5_0/block_q5_1 in ggml's ggml-common.h, and
+// ggml_legacy_quant.h's DequantizeGgmlLegacyQuant for the exact byte layout
+// each decodes). 0 for anything else.
+inline size_t LegacyQuantBlockBytes(uint32_t ggml_type) {
+  switch (ggml_type) {
+    case GGML_TYPE_Q4_0:
+      return 18;  // 2 (d) + 16 (qs)
+    case GGML_TYPE_Q4_1:
+      return 20;  // 2 (d) + 2 (m) + 16 (qs)
+    case GGML_TYPE_Q5_0:
+      return 22;  // 2 (d) + 4 (qh) + 16 (qs)
+    case GGML_TYPE_Q5_1:
+      return 24;  // 2 (d) + 2 (m) + 4 (qh) + 16 (qs)
+    default:
+      return 0;
+  }
+}
+
 // Map a ggml_type to its ONNX dtype code -- ONNXSIM_GGML_* (see that enum's
 // doc comment) for one of the four IsKQuant types, an ordinary ONNX_* code
 // for a raw type. Returns false (leaving `*out` untouched) for a quantized
@@ -295,6 +362,18 @@ inline bool ToOnnx(uint32_t ggml_type, int32_t* out) {
     case GGML_TYPE_MXFP4:
       *out = ONNXSIM_GGML_MXFP4;
       return true;
+    case GGML_TYPE_Q4_0:
+      *out = ONNXSIM_GGML_Q4_0;
+      return true;
+    case GGML_TYPE_Q4_1:
+      *out = ONNXSIM_GGML_Q4_1;
+      return true;
+    case GGML_TYPE_Q5_0:
+      *out = ONNXSIM_GGML_Q5_0;
+      return true;
+    case GGML_TYPE_Q5_1:
+      *out = ONNXSIM_GGML_Q5_1;
+      return true;
     default:
       return false;
   }
@@ -335,18 +414,29 @@ inline bool TryTotalBytes(uint32_t ggml_type, uint64_t nelems,
                   static_cast<uint64_t>(Mxfp4BlockBytes(ggml_type));
     return true;
   }
+  if (IsLegacyQuant(ggml_type)) {
+    const uint64_t block_elems =
+        static_cast<uint64_t>(LegacyQuantBlockElements(ggml_type));
+    if (nelems % block_elems != 0) {
+      return false;
+    }
+    *out_nbytes = (nelems / block_elems) *
+                  static_cast<uint64_t>(LegacyQuantBlockBytes(ggml_type));
+    return true;
+  }
   return false;
 }
 
 // Inverse of ToOnnx. Returns false for an ONNX dtype with no raw ggml_type
 // counterpart (STRING, COMPLEX64/128, UNDEFINED, the unsigned int family --
 // ggml has no unsigned integer types at all, quantized or otherwise -- or
-// one of onnxsim's own custom dtypes this mapping doesn't cover). The five
+// one of onnxsim's own custom dtypes this mapping doesn't cover). The nine
 // ONNXSIM_GGML_* codes DO round-trip here (unlike every other private dtype
-// a caller might construct): a pooled K-quant or MXFP4 entry that still
-// holds its native, un-decoded block bytes (see the file comment) can always
-// be written back out to a real GGUF file bit-for-bit, the same as any other
-// pooled dtype -- TensorPool::SaveGGUF relies on that.
+// a caller might construct): a pooled K-quant, MXFP4, or legacy-quant entry
+// that still holds its native, un-decoded block bytes (see the file
+// comment) can always be written back out to a real GGUF file bit-for-bit,
+// the same as any other pooled dtype -- TensorPool::SaveGGUF relies on
+// that.
 inline bool FromOnnx(int32_t onnx_dtype, uint32_t* out) {
   switch (onnx_dtype) {
     case ONNX_FLOAT:
@@ -387,6 +477,18 @@ inline bool FromOnnx(int32_t onnx_dtype, uint32_t* out) {
       return true;
     case ONNXSIM_GGML_MXFP4:
       *out = GGML_TYPE_MXFP4;
+      return true;
+    case ONNXSIM_GGML_Q4_0:
+      *out = GGML_TYPE_Q4_0;
+      return true;
+    case ONNXSIM_GGML_Q4_1:
+      *out = GGML_TYPE_Q4_1;
+      return true;
+    case ONNXSIM_GGML_Q5_0:
+      *out = GGML_TYPE_Q5_0;
+      return true;
+    case ONNXSIM_GGML_Q5_1:
+      *out = GGML_TYPE_Q5_1;
       return true;
     default:
       return false;

--- a/onnxsim/gguf_dtype_test.cpp
+++ b/onnxsim/gguf_dtype_test.cpp
@@ -54,12 +54,13 @@ int main() {
           "ToOnnx(FromOnnx(" + std::to_string(row.onnx) + "))) round-trips");
   }
 
-  // Quantized types this mapping does NOT decode (legacy Q4_0/Q4_1/Q5_0/
-  // Q5_1/Q8_1, Q2_K/Q3_K, Q8_K, IQ*_XXS/BF16-adjacent codes, NVFP4, ...) or
-  // unrecognized types are rejected, not guessed at. Deliberately excludes
-  // 8/12/13/14 (Q8_0/Q4_K/Q5_K/Q6_K) and 39 (MXFP4), which ARE supported --
-  // see the k_quant_rows loop and the MXFP4 checks below.
-  const uint32_t quantized[] = {2, 3, 6, 7, 9, 10, 11, 15, 16, 20, 29, 9999};
+  // Quantized types this mapping does NOT decode (Q8_1, Q2_K/Q3_K, Q8_K,
+  // IQ*_XXS/BF16-adjacent codes, NVFP4, ...) or unrecognized types are
+  // rejected, not guessed at. Deliberately excludes 2/3/6/7 (Q4_0/Q4_1/
+  // Q5_0/Q5_1), 8/12/13/14 (Q8_0/Q4_K/Q5_K/Q6_K), and 39 (MXFP4), which ARE
+  // supported -- see the legacy_quant_rows/k_quant_rows loops and the
+  // MXFP4 checks below.
+  const uint32_t quantized[] = {9, 10, 11, 15, 16, 20, 29, 9999};
   for (uint32_t q : quantized) {
     int32_t onnx = -1;
     Check(!ToOnnx(q, &onnx),
@@ -70,6 +71,8 @@ int main() {
           "IsKQuant is false for unsupported type " + std::to_string(q));
     Check(!IsMxfp4(q),
           "IsMxfp4 is false for unsupported type " + std::to_string(q));
+    Check(!IsLegacyQuant(q),
+          "IsLegacyQuant is false for unsupported type " + std::to_string(q));
     Check(ElementSize(q) == 0,
           "ElementSize is 0 for quantized/unknown type " + std::to_string(q));
     uint64_t nbytes = 0xFFFFFFFFFFFFFFFFull;
@@ -99,6 +102,8 @@ int main() {
   for (const auto& row : k_quant_rows) {
     Check(IsKQuant(row.ggml), "IsKQuant(" + std::to_string(row.ggml) + ")");
     Check(!IsMxfp4(row.ggml), "!IsMxfp4(" + std::to_string(row.ggml) + ")");
+    Check(!IsLegacyQuant(row.ggml),
+          "!IsLegacyQuant(" + std::to_string(row.ggml) + ")");
     Check(!IsRaw(row.ggml), "!IsRaw(" + std::to_string(row.ggml) + ")");
     Check(ElementSize(row.ggml) == 0,
           "ElementSize is 0 for K-quant type " + std::to_string(row.ggml));
@@ -135,6 +140,7 @@ int main() {
   // math.
   Check(IsMxfp4(GGML_TYPE_MXFP4), "IsMxfp4(GGML_TYPE_MXFP4)");
   Check(!IsKQuant(GGML_TYPE_MXFP4), "!IsKQuant(GGML_TYPE_MXFP4)");
+  Check(!IsLegacyQuant(GGML_TYPE_MXFP4), "!IsLegacyQuant(GGML_TYPE_MXFP4)");
   Check(!IsRaw(GGML_TYPE_MXFP4), "!IsRaw(GGML_TYPE_MXFP4)");
   Check(ElementSize(GGML_TYPE_MXFP4) == 0, "ElementSize(MXFP4) == 0");
   Check(Mxfp4BlockElements(GGML_TYPE_MXFP4) == 32, "Mxfp4BlockElements == 32");
@@ -152,6 +158,52 @@ int main() {
           "TryTotalBytes(MXFP4, 3 blocks)");
     Check(!TryTotalBytes(GGML_TYPE_MXFP4, 33, &nbytes),
           "TryTotalBytes rejects non-block-aligned nelems for MXFP4");
+  }
+
+  // The four legacy types this mapping DOES decode -- Q4_0/Q4_1/Q5_0/Q5_1,
+  // all plain 32-element blocks (no super-block scale/min table, unlike
+  // K-quant). Each round-trips through ToOnnx/FromOnnx to its own private
+  // ONNXSIM_GGML_* code, is not IsRaw/IsKQuant/IsMxfp4, and TryTotalBytes
+  // agrees with LegacyQuantBlockElements/LegacyQuantBlockBytes's block math.
+  struct LegacyQuantRow {
+    uint32_t ggml;
+    int32_t onnx;
+    size_t block_bytes;
+  };
+  const LegacyQuantRow legacy_quant_rows[] = {
+      {GGML_TYPE_Q4_0, ONNXSIM_GGML_Q4_0, 18},
+      {GGML_TYPE_Q4_1, ONNXSIM_GGML_Q4_1, 20},
+      {GGML_TYPE_Q5_0, ONNXSIM_GGML_Q5_0, 22},
+      {GGML_TYPE_Q5_1, ONNXSIM_GGML_Q5_1, 24},
+  };
+  for (const auto& row : legacy_quant_rows) {
+    Check(IsLegacyQuant(row.ggml),
+          "IsLegacyQuant(" + std::to_string(row.ggml) + ")");
+    Check(!IsKQuant(row.ggml), "!IsKQuant(" + std::to_string(row.ggml) + ")");
+    Check(!IsMxfp4(row.ggml), "!IsMxfp4(" + std::to_string(row.ggml) + ")");
+    Check(!IsRaw(row.ggml), "!IsRaw(" + std::to_string(row.ggml) + ")");
+    Check(ElementSize(row.ggml) == 0,
+          "ElementSize is 0 for legacy-quant type " + std::to_string(row.ggml));
+    Check(LegacyQuantBlockElements(row.ggml) == 32,
+          "LegacyQuantBlockElements(" + std::to_string(row.ggml) + ") == 32");
+    Check(LegacyQuantBlockBytes(row.ggml) == row.block_bytes,
+          "LegacyQuantBlockBytes(" + std::to_string(row.ggml) + ")");
+
+    int32_t onnx = -1;
+    Check(ToOnnx(row.ggml, &onnx) && onnx == row.onnx,
+          "ToOnnx(" + std::to_string(row.ggml) +
+              ") == " + std::to_string(row.onnx));
+    uint32_t ggml_back = 0;
+    Check(FromOnnx(row.onnx, &ggml_back) && ggml_back == row.ggml,
+          "FromOnnx(ToOnnx(" + std::to_string(row.ggml) + "))) round-trips");
+
+    uint64_t nbytes = 0;
+    Check(TryTotalBytes(row.ggml, 32 * 3, &nbytes) &&
+              nbytes == row.block_bytes * 3,
+          "TryTotalBytes(" + std::to_string(row.ggml) + ", 3 blocks)");
+    Check(!TryTotalBytes(row.ggml, 33, &nbytes),
+          "TryTotalBytes rejects non-block-aligned nelems for " +
+              std::to_string(row.ggml));
   }
 
   // ONNX dtypes with no raw ggml counterpart (unsigned ints, BOOL, STRING,

--- a/onnxsim/gguf_reconstruct.py
+++ b/onnxsim/gguf_reconstruct.py
@@ -54,7 +54,7 @@ worse tradeoff than a curated, explicit template per architecture family.
 architecture, its hyperparameters, and its tensors' names/shapes -- without
 reading any tensor byte data; :func:`import_gguf_weights` (reused here
 unmodified) supplies the actual values, including its existing K-quant
-(Q4_K/Q5_K/Q6_K/Q8_0) decode.
+(Q4_K/Q5_K/Q6_K/Q8_0), legacy (Q4_0/Q4_1/Q5_0/Q5_1), and MXFP4 decode.
 
 Scope note on shapes: the returned graph's ``batch_size``/``seq_len`` are
 concrete, caller-chosen static dimensions, not dynamic axes. Real llama.cpp
@@ -107,11 +107,11 @@ _GGML_RAW_TO_ONNX = {
     28: onnx.TensorProto.DOUBLE,  # F64
     30: onnx.TensorProto.BFLOAT16,  # BF16
 }
-# Q8_0, Q4_K, Q5_K, Q6_K, MXFP4 -- import_gguf_weights forces these to FLOAT
-# regardless of what the initializer previously declared (see
-# tensor_pool_gguf_bridge.h's HydrateTensorProtoFromGGUF), so that is what
-# must be declared here too.
-_GGML_KQUANT_TYPES = {8, 12, 13, 14, 39}
+# Q8_0, Q4_K, Q5_K, Q6_K (K-quant), Q4_0, Q4_1, Q5_0, Q5_1 (legacy), MXFP4 --
+# import_gguf_weights forces these to FLOAT regardless of what the
+# initializer previously declared (see tensor_pool_gguf_bridge.h's
+# HydrateTensorProtoFromGGUF), so that is what must be declared here too.
+_GGML_KQUANT_TYPES = {2, 3, 6, 7, 8, 12, 13, 14, 39}
 
 _ONNX_DTYPE_ITEMSIZE = {
     onnx.TensorProto.FLOAT: 4,
@@ -1048,8 +1048,8 @@ def _reconstruct_llama_family(
             raise UnsupportedArchitectureError(
                 f"tensor '{name}' uses ggml_type {ggml_type}, which "
                 "import_gguf_weights cannot decode (only F32/F16/BF16/F64/"
-                "I8/I16/I32/I64, the Q4_K/Q5_K/Q6_K/Q8_0 K-quant family, and "
-                "MXFP4 are supported)"
+                "I8/I16/I32/I64, the Q4_K/Q5_K/Q6_K/Q8_0 K-quant family, the "
+                "Q4_0/Q4_1/Q5_0/Q5_1 legacy family, and MXFP4 are supported)"
             )
         b.placeholder_weight(name, expected_shape, onnx_dtype)
         return name
@@ -1400,8 +1400,8 @@ def _reconstruct_gpt_oss(meta: dict, batch_size: int, seq_len: int) -> onnx.Grap
             raise UnsupportedArchitectureError(
                 f"tensor '{name}' uses ggml_type {ggml_type}, which "
                 "import_gguf_weights cannot decode (only F32/F16/BF16/F64/"
-                "I8/I16/I32/I64, the Q4_K/Q5_K/Q6_K/Q8_0 K-quant family, and "
-                "MXFP4 are supported)"
+                "I8/I16/I32/I64, the Q4_K/Q5_K/Q6_K/Q8_0 K-quant family, the "
+                "Q4_0/Q4_1/Q5_0/Q5_1 legacy family, and MXFP4 are supported)"
             )
         b.placeholder_weight(name, expected_shape, onnx_dtype)
         return name
@@ -1520,7 +1520,8 @@ def reconstruct_gguf_graph(
     itself from the checkpoint's own declared hyperparameters
     (:func:`read_gguf_metadata`), then calls ``import_gguf_weights``
     internally to hydrate it -- so it reuses that function's existing
-    K-quant (Q4_K/Q5_K/Q6_K/Q8_0) decode unchanged.
+    K-quant (Q4_K/Q5_K/Q6_K/Q8_0), legacy (Q4_0/Q4_1/Q5_0/Q5_1), and MXFP4
+    decode unchanged.
 
     :param gguf_path: path to the GGUF checkpoint
     :param batch_size: static batch dimension baked into the returned

--- a/onnxsim/tensor_pool.h
+++ b/onnxsim/tensor_pool.h
@@ -207,15 +207,18 @@ class TensorPool {
   // translation unit from the safetensors codec above, since the two file
   // formats share nothing but the TensorPool storage they read into/from.
   // See gguf_dtype.h's file comment for an important scope note: most of
-  // GGML's block-quantized types (Q4_0, every IQ*_ variant, ...) have no
-  // ONNX raw-data equivalent and are never pooled -- LoadGGUF skips and
+  // GGML's block-quantized types (Q2_K, Q3_K, every IQ*_ variant, ...) have
+  // no ONNX raw-data equivalent and are never pooled -- LoadGGUF skips and
   // reports them rather than writing garbage. The K-quant family
   // (Q4_K/Q5_K/Q6_K/Q8_0) -- what a real quantized checkpoint (e.g.
-  // Unsloth's GGUF exports) actually uses for the bulk of its weights -- and
-  // MXFP4 (gpt-oss-20b's own native MoE-expert quantization) ARE pooled,
-  // holding their native, still-packed block bytes (see gguf_dtype.h's
-  // IsKQuant/IsMxfp4); DequantizeToFloat below decodes an entry like that to
-  // plain float32 values.
+  // Unsloth's GGUF exports) actually uses for the bulk of its weights --
+  // the legacy family (Q4_0/Q4_1/Q5_0/Q5_1, which llama.cpp's own mixed-
+  // precision quantizers still pick for particular tensor roles even in an
+  // otherwise K-quant checkpoint) -- and MXFP4 (gpt-oss-20b's own native
+  // MoE-expert quantization) ARE pooled, holding their native, still-packed
+  // block bytes (see gguf_dtype.h's IsKQuant/IsLegacyQuant/IsMxfp4);
+  // DequantizeToFloat below decodes an entry like that to plain float32
+  // values.
 
   // Write every entry to a GGUF file at `path`. Every dtype TensorPool can
   // hold has a raw ggml_type counterpart (see gguf_dtype.h), so -- unlike
@@ -241,12 +244,12 @@ class TensorPool {
 
   // Replace this pool's contents with every tensor in the GGUF file at
   // `path` whose ggml_type this pool can represent -- either a *raw*,
-  // unquantized type (stored as-is) or one of the four K-quant types or the
-  // MXFP4 type gguf_dtype.h's IsKQuant/IsMxfp4 cover (stored as its native,
-  // still-packed block bytes -- see DequantizeToFloat to decode one). Every
-  // other quantized type (Q4_0, every IQ*_ variant, ...) has no
-  // representation this pool can hold at all. Unlike LoadSafetensors, this
-  // does NOT read the whole file into memory: only the (small) header/
+  // unquantized type (stored as-is) or one of the block-quantized types
+  // gguf_dtype.h's IsKQuant/IsLegacyQuant/IsMxfp4 cover (stored as its
+  // native, still-packed block bytes -- see DequantizeToFloat to decode
+  // one). Every other quantized type (Q2_K, Q3_K, every IQ*_ variant, ...)
+  // has no representation this pool can hold at all. Unlike LoadSafetensors,
+  // this does NOT read the whole file into memory: only the (small) header/
   // metadata/tensor-info section is read up front, and each *included*
   // tensor's bytes are read with their own targeted seek + read -- loading a
   // large quantized checkpoint this way costs only the bytes of the tensors
@@ -287,14 +290,14 @@ class TensorPool {
 
   // Decodes `name`'s entry to plain float32 values, appended to `out` (not
   // cleared first) -- the only way to get usable numeric values out of an
-  // entry LoadGGUF/LoadGGUFMmap pooled from a K-quant (Q4_K/Q5_K/Q6_K/Q8_0)
-  // or MXFP4 source, since its `data` otherwise holds native, still-packed
-  // GGML block bytes, not per-element values (see gguf_dtype.h's
-  // IsKQuant/IsMxfp4). Returns false, leaving `out` untouched, if `name`
-  // isn't in the pool or its dtype is not one of those five codes (including
-  // an ordinary raw dtype, e.g. FLOAT/FLOAT16 -- those need no decoding at
-  // all; read Entry::data directly, the same way every other TensorPool
-  // consumer already does).
+  // entry LoadGGUF/LoadGGUFMmap pooled from a K-quant (Q4_K/Q5_K/Q6_K/Q8_0),
+  // legacy (Q4_0/Q4_1/Q5_0/Q5_1), or MXFP4 source, since its `data`
+  // otherwise holds native, still-packed GGML block bytes, not per-element
+  // values (see gguf_dtype.h's IsKQuant/IsLegacyQuant/IsMxfp4). Returns
+  // false, leaving `out` untouched, if `name` isn't in the pool or its
+  // dtype is not one of those nine codes (including an ordinary raw dtype,
+  // e.g. FLOAT/FLOAT16 -- those need no decoding at all; read Entry::data
+  // directly, the same way every other TensorPool consumer already does).
   bool DequantizeToFloat(const std::string& name,
                          std::vector<float>* out) const;
 

--- a/onnxsim/tensor_pool_gguf.cpp
+++ b/onnxsim/tensor_pool_gguf.cpp
@@ -12,6 +12,7 @@
 #include <streambuf>
 
 #include "ggml_kquant.h"
+#include "ggml_legacy_quant.h"
 #include "ggml_mxfp4.h"
 #include "gguf_dtype.h"
 #include "mmap_file.h"
@@ -689,6 +690,10 @@ bool TensorPool::DequantizeToFloat(const std::string& name,
   }
   if (IsMxfp4(ggml_type)) {
     return DequantizeGgmlMxfp4(data, entry->data.size(), ggml_type, numel, out);
+  }
+  if (IsLegacyQuant(ggml_type)) {
+    return DequantizeGgmlLegacyQuant(data, entry->data.size(), ggml_type, numel,
+                                     out);
   }
   return false;
 }

--- a/onnxsim/tensor_pool_gguf_bridge.h
+++ b/onnxsim/tensor_pool_gguf_bridge.h
@@ -11,13 +11,17 @@
  * representation during Simplify().
  *
  * The GGUF-specific thing worth calling out here is gguf_dtype.h's scope:
- * most of GGML's block-quantized types (Q4_0, every IQ*_ variant, ...) have
- * no ONNX raw-data equivalent at all, so ImportModelWithGGUF's
+ * most of GGML's block-quantized types (Q2_K, Q3_K, every IQ*_ variant, ...)
+ * have no ONNX raw-data equivalent at all, so ImportModelWithGGUF's
  * `skipped_out` matters more here than ImportModelWithSafetensors's
- * equivalent ever would in practice. The K-quant family this mapping DOES
- * cover (Q4_K/Q5_K/Q6_K/Q8_0 -- what a real quantized checkpoint, e.g.
- * Unsloth's GGUF exports, actually uses for the bulk of its weights) is
- * hydrated as ordinary float32, via HydrateTensorProtoFromGGUF's decode --
+ * equivalent ever would in practice. The families this mapping DOES cover
+ * -- K-quant (Q4_K/Q5_K/Q6_K/Q8_0, what a real quantized checkpoint, e.g.
+ * Unsloth's GGUF exports, actually uses for the bulk of its weights),
+ * legacy (Q4_0/Q4_1/Q5_0/Q5_1, which llama.cpp's own mixed-precision
+ * quantizers still pick for particular tensor roles even in an otherwise
+ * K-quant checkpoint), and MXFP4 (gpt-oss's native MoE-expert
+ * quantization) -- are hydrated as ordinary float32, via
+ * HydrateTensorProtoFromGGUF's decode --
  * ImportModelWithGGUF is the intended way to pull a third-party GGUF
  * checkpoint's weight *values* into an ONNX graph you already have, by
  * initializer name (it needs no embedded onnxsim model, unlike
@@ -51,10 +55,11 @@ namespace tensor_pool {
 
 // GGUF counterpart of tensor_pool_bridge.h's HydrateTensorProto: same
 // contract (returns false, leaving `tensor` untouched, if `name` isn't
-// pooled) EXCEPT a K-quant-native or MXFP4-native entry (Q4_K/Q5_K/Q6_K/
-// Q8_0/MXFP4 -- see gguf_dtype.h's IsKQuant/IsMxfp4) is decoded to plain
-// float32 raw_data instead of copied verbatim, and `tensor`'s data_type is
-// forced to FLOAT to match --
+// pooled) EXCEPT a K-quant-native, MXFP4-native, or legacy-quant-native
+// entry (Q4_K/Q5_K/Q6_K/Q8_0/MXFP4/Q4_0/Q4_1/Q5_0/Q5_1 -- see gguf_dtype.h's
+// IsKQuant/IsMxfp4/IsLegacyQuant) is decoded to plain float32 raw_data
+// instead of copied verbatim, and `tensor`'s data_type is forced to FLOAT
+// to match --
 // overriding whatever data_type the caller's initializer previously
 // declared, since the decoded values are only meaningful as float32 (the
 // caller's own declared dtype reflects whatever *their* graph expects,
@@ -70,10 +75,12 @@ inline bool HydrateTensorProtoFromGGUF(const std::string& name,
 
   uint32_t ggml_type;
   if (gguf::FromOnnx(entry->dtype, &ggml_type) &&
-      (gguf::IsKQuant(ggml_type) || gguf::IsMxfp4(ggml_type))) {
+      (gguf::IsKQuant(ggml_type) || gguf::IsMxfp4(ggml_type) ||
+       gguf::IsLegacyQuant(ggml_type))) {
     std::vector<float> floats;
     if (!pool.DequantizeToFloat(name, &floats)) {
-      // Unreachable: FromOnnx+IsKQuant/IsMxfp4 already validated dtype.
+      // Unreachable: FromOnnx+IsKQuant/IsMxfp4/IsLegacyQuant already
+      // validated dtype.
       return false;
     }
     tensor.set_data_location(onnx::TensorProto::DEFAULT);
@@ -136,12 +143,12 @@ inline size_t ExportModelWithGGUF(
 }
 
 // Load `gguf_path` into `pool` and, for every graph initializer whose name
-// matches a pooled tensor -- a raw-dtype tensor, or a K-quant/MXFP4 one (see
-// gguf_dtype.h's IsKQuant/IsMxfp4), either hydrate it in place (hydrate_all,
-// the default -- a K-quant/MXFP4 match is decoded to float32, see
-// HydrateTensorProtoFromGGUF) or leave it as a lazy EXTERNAL reference
-// (hydrate_all=false; see tensor_pool_bridge.h's caveat on this mode --
-// note a K-quant/MXFP4 match left lazy this way still needs
+// matches a pooled tensor -- a raw-dtype tensor, or a K-quant/MXFP4/legacy-
+// quant one (see gguf_dtype.h's IsKQuant/IsMxfp4/IsLegacyQuant), either
+// hydrate it in place (hydrate_all, the default -- such a match is decoded
+// to float32, see HydrateTensorProtoFromGGUF) or leave it as a lazy
+// EXTERNAL reference (hydrate_all=false; see tensor_pool_bridge.h's caveat
+// on this mode -- note a match left lazy this way still needs
 // HydrateTensorProtoFromGGUF, not the plain HydrateTensorProto that caveat
 // points to, when it's eventually hydrated on demand).
 // Returns the number of initializers matched (hydrated or marked lazy).

--- a/onnxsim/tensor_pool_gguf_bridge_test.cpp
+++ b/onnxsim/tensor_pool_gguf_bridge_test.cpp
@@ -253,10 +253,11 @@ void TestImportModelWithGGUFLazy() {
   std::remove(path.c_str());
 }
 
-// Hand-builds a GGUF file with one raw F32 tensor ("w1") and one Q4_0
-// (quantized) tensor ("w2"), then imports it against a model declaring both
-// as initializers -- the scenario a real quantized-LLM checkpoint puts a
-// caller in for nearly every weight.
+// Hand-builds a GGUF file with one raw F32 tensor ("w1") and one Q3_K
+// (quantized, unsupported -- deliberately NOT one of IsKQuant/IsLegacyQuant/
+// IsMxfp4's covered types) tensor ("w2"), then imports it against a model
+// declaring both as initializers -- the scenario a real quantized-LLM
+// checkpoint puts a caller in for nearly every weight.
 void TestImportModelWithGGUFSkipsQuantized() {
   std::string path = TempPath("_quantized.gguf");
   {
@@ -279,7 +280,7 @@ void TestImportModelWithGGUFSkipsQuantized() {
     write_string("w2");
     WriteLE<uint32_t>(out, 1);
     WriteLE<uint64_t>(out, 32);  // ne[0]
-    WriteLE<uint32_t>(out, 2);   // GGML_TYPE_Q4_0
+    WriteLE<uint32_t>(out, 11);  // GGML_TYPE_Q3_K
     WriteLE<uint64_t>(out, kDefaultAlignment);
 
     uint64_t header_end = static_cast<uint64_t>(out.tellp());
@@ -474,6 +475,81 @@ void TestImportModelWithGGUFDecodesMxfp4() {
   std::remove(path.c_str());
 }
 
+// Same shape as TestImportModelWithGGUFDecodesMxfp4, but for the legacy
+// Q4_0 format -- confirms HydrateTensorProtoFromGGUF's IsKQuant-or-IsMxfp4-
+// or-IsLegacyQuant branch actually reaches the decode path when called
+// through the full ImportModelWithGGUF bridge, not just
+// TensorPool::DequantizeToFloat directly (see tensor_pool_gguf_test.cpp's
+// TestLegacyQuantRoundTripAndDecode for that narrower check). d = 2.0
+// (fp16 0x4000), qs[i] = i -- the same hand-verified vector
+// ggml_legacy_quant_test.cpp hand-verifies.
+void TestImportModelWithGGUFDecodesLegacyQuant() {
+  std::string path = TempPath("_legacy_quant_import.gguf");
+  {
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    auto write_string = [&](const std::string& s) {
+      WriteLE<uint64_t>(out, s.size());
+      out.write(s.data(), static_cast<std::streamsize>(s.size()));
+    };
+    WriteLE<uint32_t>(out, kMagic);
+    WriteLE<uint32_t>(out, kSupportedVersion);
+    WriteLE<uint64_t>(out, 1);  // tensor_count
+    WriteLE<uint64_t>(out, 0);  // metadata_kv_count
+
+    write_string("w");
+    WriteLE<uint32_t>(out, 1);
+    WriteLE<uint64_t>(out, 32);  // ne[0]
+    WriteLE<uint32_t>(out, GGML_TYPE_Q4_0);
+    WriteLE<uint64_t>(out, 0);  // offset
+
+    uint64_t header_end = static_cast<uint64_t>(out.tellp());
+    uint64_t data_start = (header_end + kDefaultAlignment - 1) /
+                          kDefaultAlignment * kDefaultAlignment;
+    for (uint64_t i = header_end; i < data_start; ++i) out.put('\0');
+    WriteLE<uint16_t>(out, 0x4000);  // d = 2.0 (fp16)
+    for (int i = 0; i < 16; ++i) {
+      out.put(static_cast<char>(static_cast<uint8_t>(i)));  // qs[i]
+    }
+  }
+
+  onnx::ModelProto model;
+  auto* w = model.mutable_graph()->add_initializer();
+  w->set_name("w");
+  w->set_data_type(onnx::TensorProto::INT32);  // deliberately wrong
+  w->add_dims(32);
+
+  TensorPool pool;
+  std::vector<std::string> skipped;
+  size_t matched = ImportModelWithGGUF(model, path, pool, true, &skipped);
+  Check(matched == 1, "the Q4_0 tensor is matched");
+  Check(skipped.empty(), "nothing skipped -- Q4_0 is now supported");
+
+  const auto& hydrated = model.graph().initializer(0);
+  Check(hydrated.data_type() == onnx::TensorProto::FLOAT,
+        "Q4_0 hydration forces data_type to FLOAT, overriding the caller's "
+        "(wrong) declared INT32");
+  Check(hydrated.has_raw_data() &&
+            hydrated.raw_data().size() == 32 * sizeof(float),
+        "hydrated raw_data is 32 float32 values");
+  bool values_ok = hydrated.raw_data().size() == 32 * sizeof(float);
+  if (values_ok) {
+    std::string bytes = hydrated.raw_data();
+    if constexpr (!onnxsim::dlpack::kRawDataIsHostOrder) {
+      onnxsim::dlpack::SwapElementBytes(
+          reinterpret_cast<uint8_t*>(bytes.data()), bytes.size(),
+          sizeof(float));
+    }
+    float floats[32];
+    std::memcpy(floats, bytes.data(), sizeof(floats));
+    values_ok = std::fabs(floats[0] - (-16.0f)) < 1e-4f &&
+                std::fabs(floats[15] - 14.0f) < 1e-4f &&
+                std::fabs(floats[31] - (-16.0f)) < 1e-4f;
+  }
+  Check(values_ok, "hydrated values decode as expected");
+
+  std::remove(path.c_str());
+}
+
 // ImportModelWithGGUFToPool is import_gguf_weights's FFI-friendly sibling of
 // ImportModelWithGGUF(hydrate_all=true): same K-quant decode
 // (HydrateTensorProtoFromGGUF, reused unchanged), but the matched tensor's
@@ -576,6 +652,7 @@ int main() {
   TestImportModelWithGGUFSkipsQuantized();
   TestImportModelWithGGUFDecodesKQuant();
   TestImportModelWithGGUFDecodesMxfp4();
+  TestImportModelWithGGUFDecodesLegacyQuant();
   TestImportModelWithGGUFToPool();
 
   if (g_failures == 0) {

--- a/onnxsim/tensor_pool_gguf_test.cpp
+++ b/onnxsim/tensor_pool_gguf_test.cpp
@@ -140,10 +140,11 @@ void TestAlignmentPadding() {
 }
 
 // Writes a minimal, hand-built GGUF v3 file with one raw F32 tensor and one
-// tensor of a made-up "quantized" ggml_type (id 2 == GGML_TYPE_Q4_0) this
-// pool cannot represent, to exercise LoadGGUF's skip-and-report path -- the
-// case that matters most in practice, since a real quantized LLM's .gguf is
-// mostly tensors like this.
+// tensor of a quantized ggml_type this pool cannot represent (id 11 ==
+// GGML_TYPE_Q3_K -- a real GGML type, deliberately NOT one of IsKQuant/
+// IsLegacyQuant/IsMxfp4's covered types), to exercise LoadGGUF's
+// skip-and-report path -- the case that matters most in practice, since a
+// real quantized LLM's .gguf is mostly tensors like this.
 void TestSkipsUnsupportedDtype() {
   std::string path = TempPath("_quantized.gguf");
   {
@@ -165,13 +166,13 @@ void TestSkipsUnsupportedDtype() {
     WriteLE<uint32_t>(out, GGML_TYPE_F32);  // type
     WriteLE<uint64_t>(out, 0);              // offset
 
-    // Tensor 1: "quant", ggml_type 2 (Q4_0), ne=[32] -- offset chosen past
+    // Tensor 1: "quant", ggml_type 11 (Q3_K), ne=[32] -- offset chosen past
     // 'raw's aligned 32-byte slot. This test never decodes its bytes (can't
     // -- that's the whole point), so the payload content doesn't matter.
     write_string("quant");
     WriteLE<uint32_t>(out, 1);                  // n_dimensions
     WriteLE<uint64_t>(out, 32);                 // ne[0]
-    WriteLE<uint32_t>(out, 2);                  // GGML_TYPE_Q4_0
+    WriteLE<uint32_t>(out, 11);                 // GGML_TYPE_Q3_K
     WriteLE<uint64_t>(out, kDefaultAlignment);  // offset (aligned)
 
     // Pad to the data section (header ends right here; align up to 32).
@@ -187,8 +188,9 @@ void TestSkipsUnsupportedDtype() {
     // data_start).
     uint64_t cur = static_cast<uint64_t>(out.tellp()) - data_start;
     for (uint64_t i = cur; i < kDefaultAlignment; ++i) out.put('\0');
-    // 'quant' tensor's Q4_0 block data: 18 bytes/block * 1 block for 32
-    // elements (block size 32) -- exact bytes don't matter, just presence.
+    // 'quant' tensor's (unsupported, never decoded) block data -- exact
+    // byte count doesn't matter, just presence, since this is the last
+    // tensor in the file and nothing after it needs to be located.
     for (int i = 0; i < 18; ++i) out.put('\xAB');
   }
 
@@ -268,7 +270,7 @@ void TestLoadGGUFMmapRoundTrip() {
 
 void TestLoadGGUFMmapSkipsUnsupportedDtype() {
   // Same hand-built file as TestSkipsUnsupportedDtype (one raw F32 tensor,
-  // one made-up quantized type this pool can't represent), loaded through
+  // one quantized type this pool can't represent), loaded through
   // LoadGGUFMmap -- confirms the mapped path skips-and-reports exactly like
   // the seek+read path rather than e.g. faulting trying to decode it.
   std::string path = TempPath("_mmap_quantized.gguf");
@@ -293,7 +295,7 @@ void TestLoadGGUFMmapSkipsUnsupportedDtype() {
     write_string("quant");
     WriteLE<uint32_t>(out, 1);
     WriteLE<uint64_t>(out, 32);
-    WriteLE<uint32_t>(out, 2);  // GGML_TYPE_Q4_0
+    WriteLE<uint32_t>(out, 11);  // GGML_TYPE_Q3_K
     WriteLE<uint64_t>(out, kDefaultAlignment);
 
     uint64_t header_end = static_cast<uint64_t>(out.tellp());
@@ -538,6 +540,49 @@ void TestMxfp4RoundTripAndDecode() {
   std::remove(path.c_str());
 }
 
+void TestLegacyQuantRoundTripAndDecode() {
+  // A Q4_0 block: d = 2.0 (fp16 0x4000), qs[i] = i -- the same hand-verified
+  // vector ggml_legacy_quant_test.cpp hand-verifies, reused here to check
+  // TensorPool's own plumbing (pooling, SaveGGUF/LoadGGUF byte-exact round
+  // trip, DequantizeToFloat), not the decode math itself.
+  const uint16_t d_bits = 0x4000;
+  std::string block(18, '\0');
+  block[0] = static_cast<char>(d_bits & 0xFF);
+  block[1] = static_cast<char>((d_bits >> 8) & 0xFF);
+  for (int i = 0; i < 16; ++i) {
+    block[2 + i] = static_cast<char>(static_cast<uint8_t>(i));
+  }
+
+  TensorPool pool;
+  pool.Add("w", ONNXSIM_GGML_Q4_0, {32}, std::string(block));
+
+  std::string path = TempPath("_legacy_quant.gguf");
+  pool.SaveGGUF(path);
+
+  TensorPool loaded;
+  auto skipped = loaded.LoadGGUF(path);
+  Check(skipped.empty(), "Q4_0 tensor is not skipped");
+  const Entry* w = loaded.Find("w");
+  Check(w != nullptr, "Q4_0 tensor is present");
+  if (w != nullptr) {
+    Check(w->dtype == ONNXSIM_GGML_Q4_0, "Q4_0 dtype round-trips");
+    Check(w->shape == std::vector<int64_t>({32}), "Q4_0 shape round-trips");
+    Check(w->data == block, "Q4_0 native block bytes round-trip bit-exact");
+
+    std::vector<float> decoded;
+    Check(loaded.DequantizeToFloat("w", &decoded),
+          "DequantizeToFloat succeeds for a Q4_0 entry");
+    Check(decoded.size() == 32, "DequantizeToFloat output size");
+    if (decoded.size() == 32) {
+      Check(std::fabs(decoded[0] - (-16.0f)) < 1e-4f, "Q4_0 element 0");
+      Check(std::fabs(decoded[15] - 14.0f) < 1e-4f, "Q4_0 element 15");
+      Check(std::fabs(decoded[31] - (-16.0f)) < 1e-4f, "Q4_0 element 31");
+    }
+  }
+
+  std::remove(path.c_str());
+}
+
 }  // namespace
 
 int main() {
@@ -554,6 +599,7 @@ int main() {
   TestKQuantRoundTripAndDecode();
   TestLoadGGUFRejectsMisalignedKQuantTensor();
   TestMxfp4RoundTripAndDecode();
+  TestLegacyQuantRoundTripAndDecode();
 
   if (g_failures == 0) {
     std::printf("tensor_pool_gguf_test: all checks passed\n");

--- a/scripts/cross/build_s390x_extension.sh
+++ b/scripts/cross/build_s390x_extension.sh
@@ -219,12 +219,14 @@ cmake --build "${BUILD_DIR}" --target onnx_cpp2py_export -j "${JOBS}"
 # ggml_mxfp4_test (the GGML MXFP4 dequantization ggml_mxfp4.h implements --
 # same rationale as ggml_kquant_test above: decoded values are real numeric
 # output, not just copied bytes) is dependency-free too and belongs here for
-# the same reason.
+# the same reason. ggml_legacy_quant_test (the GGML Q4_0/Q4_1/Q5_0/Q5_1
+# dequantization ggml_legacy_quant.h implements) is dependency-free for the
+# same reason too.
 cmake --build "${BUILD_DIR}" --target sym_expr_test model_metrics_test \
   sym_value_eval_test sym_shape_infer_test dlpack_dtype_test \
   tensor_pool_dtype_test tensor_pool_test tensor_pool_hash_test \
-  gguf_dtype_test ggml_kquant_test ggml_mxfp4_test tensor_pool_gguf_test \
-  read_gguf_metadata_test -j "${JOBS}"
+  gguf_dtype_test ggml_kquant_test ggml_mxfp4_test ggml_legacy_quant_test \
+  tensor_pool_gguf_test read_gguf_metadata_test -j "${JOBS}"
 # tensor_pool_bridge_test, tensor_pool_gguf_bridge_test,
 # tensor_pool_archive_test, precision_estimator_test, and
 # contrib_schemas_moe_test are NOT dependency-free (they exercise

--- a/scripts/cross/run_s390x_tests.sh
+++ b/scripts/cross/run_s390x_tests.sh
@@ -68,6 +68,17 @@ rm -rf "${SYSROOT}/work/tests"
 cp -r "${REPO_ROOT}/tests" "${SYSROOT}/work/tests"
 cp "${REPO_ROOT}/pyproject.toml" "${SYSROOT}/work/"
 
+# tests/test_check_decode_parity.py imports check_decode_parity from
+# scripts/apple/ at module scope (see that test file's sys.path.insert).
+# Copy just that one module in, not the rest of scripts/apple/ -- its
+# siblings (export_llm_to_coreml.py, coreml_backend.py, ...) pull in
+# coremltools/torch/transformers, which have no s390x build.
+# check_decode_parity.py itself only imports argparse/sys/pathlib, so it's
+# safe to run standalone here.
+rm -rf "${SYSROOT}/work/scripts"
+mkdir -p "${SYSROOT}/work/scripts/apple"
+cp "${REPO_ROOT}/scripts/apple/check_decode_parity.py" "${SYSROOT}/work/scripts/apple/"
+
 echo "== environment =="
 chroot "${SYSROOT}" /bin/sh -c 'cd /work && PYTHONPATH=/work/pylibs python3 -c "
 import sys, numpy, onnx, onnxsim

--- a/tests/test_import_gguf_weights.py
+++ b/tests/test_import_gguf_weights.py
@@ -6,14 +6,19 @@ already have.
 
 Covers the GGML "K-quant" block formats (Q8_0, Q4_K, Q5_K, Q6_K) real
 quantized checkpoints (e.g. Unsloth's GGUF exports) actually use for the
-bulk of their weights, plus MXFP4 (the OCP Microscaling FP4 format official
-gpt-oss GGUF releases use natively for their MoE expert weights): this
-module writes real, byte-accurate GGUF v3 files containing hand-encoded
-blocks with known values, computing each expected dequantized float
-independently (a from-scratch transcription of GGML's published block
-layout/dequant formula, not a reuse of the C++ decoder under test -- see
-ggml_kquant.h/ggml_mxfp4.h) and checking onnxsim's decoded result against
-it.
+bulk of their weights; the legacy family (Q4_0, Q4_1, Q5_0, Q5_1) llama.cpp's
+own mixed-precision quantizers still pick for particular tensor roles even
+in an otherwise K-quant checkpoint (confirmed empirically against several
+real, official gpt-oss-20b GGUF releases -- several of the most popular
+size-optimized quantizations, e.g. Q4_K_S/Q4_0/UD-Q4_K_XL, use these for
+their embedding/attention tensors); and MXFP4 (the OCP Microscaling FP4
+format official gpt-oss GGUF releases use natively for their MoE expert
+weights): this module writes real, byte-accurate GGUF v3 files containing
+hand-encoded blocks with known values, computing each expected dequantized
+float independently (a from-scratch transcription of GGML's published
+block layout/dequant formula, not a reuse of the C++ decoder under test --
+see ggml_kquant.h/ggml_legacy_quant.h/ggml_mxfp4.h) and checking onnxsim's
+decoded result against it.
 """
 
 import struct
@@ -35,7 +40,11 @@ GGML_TYPE_Q4_K = 12
 GGML_TYPE_Q5_K = 13
 GGML_TYPE_Q6_K = 14
 GGML_TYPE_MXFP4 = 39
-GGML_TYPE_Q4_0 = 2  # legacy family onnxsim does NOT decode -- must be skipped
+GGML_TYPE_Q4_0 = 2
+GGML_TYPE_Q4_1 = 3
+GGML_TYPE_Q5_0 = 6
+GGML_TYPE_Q5_1 = 7
+GGML_TYPE_Q3_K = 11  # NOT decoded by onnxsim -- must be skipped
 
 
 def _align_up(n, align=32):
@@ -160,6 +169,89 @@ def _make_mxfp4_block(rng):
     return raw, expected
 
 
+def _make_q4_0_block(rng):
+    # One 32-element Q4_0 block: a single fp16 scale plus 16 bytes of packed
+    # 4-bit codes (unsigned 0..15, representing signed -8..7 via a fixed -8
+    # bias, no separate min value).
+    d = round(float(rng.uniform(0.01, 5.0)), 4)
+    d_bits = _f16_bits(d)
+    codes = [int(rng.integers(0, 16)) for _ in range(32)]
+    qs = bytes((codes[i] & 0xF) | ((codes[i + 16] & 0xF) << 4) for i in range(16))
+    raw = struct.pack("<H", d_bits) + qs
+    d_f = _f16_to_f32(d_bits)
+    expected = [(c - 8) * d_f for c in codes]
+    return raw, expected
+
+
+def _make_q4_1_block(rng):
+    # Like Q4_0, but with an explicit fp16 min added after scaling instead
+    # of a fixed bias (codes are used unsigned, 0..15).
+    d = round(float(rng.uniform(0.01, 2.0)), 4)
+    m = round(float(rng.uniform(-1.0, 1.0)), 4)
+    d_bits, m_bits = _f16_bits(d), _f16_bits(m)
+    codes = [int(rng.integers(0, 16)) for _ in range(32)]
+    qs = bytes((codes[i] & 0xF) | ((codes[i + 16] & 0xF) << 4) for i in range(16))
+    raw = struct.pack("<HH", d_bits, m_bits) + qs
+    d_f, m_f = _f16_to_f32(d_bits), _f16_to_f32(m_bits)
+    expected = [c * d_f + m_f for c in codes]
+    return raw, expected
+
+
+def _make_q5_0_block(rng):
+    # Like Q4_0, but each element's 5th (high) bit lives in a separate
+    # 4-byte `qh` bitfield (one bit per element) rather than packed
+    # alongside the other 4 bits -- the resulting 5-bit unsigned code
+    # (0..31) is biased by -16 before scaling.
+    d = round(float(rng.uniform(0.01, 5.0)), 4)
+    d_bits = _f16_bits(d)
+    codes = [int(rng.integers(0, 32)) for _ in range(32)]
+    low_nibbles = [c & 0xF for c in codes]
+    high_bits = [(c >> 4) & 0x1 for c in codes]
+    qs = bytes(
+        (low_nibbles[i] & 0xF) | ((low_nibbles[i + 16] & 0xF) << 4) for i in range(16)
+    )
+    # GGML's qh packing: element j's high bit lives at bit j (j < 16) or bit
+    # (j - 16) + 16 (j >= 16) of the 32-bit qh word -- i.e. bit j directly
+    # for the low half, bit j+16 for the high half (see
+    # dequantize_row_q5_0's xh_0/xh_1 extraction, which this mirrors in the
+    # opposite direction).
+    qh = 0
+    for j in range(16):
+        if high_bits[j]:
+            qh |= 1 << j
+        if high_bits[j + 16]:
+            qh |= 1 << (j + 16)
+    raw = struct.pack("<H", d_bits) + struct.pack("<I", qh) + qs
+    d_f = _f16_to_f32(d_bits)
+    expected = [(c - 16) * d_f for c in codes]
+    return raw, expected
+
+
+def _make_q5_1_block(rng):
+    # Like Q5_0, but with an explicit fp16 min added after scaling instead
+    # of a fixed bias (the 5-bit code is used unsigned, 0..31), matching
+    # Q4_1's own relationship to Q4_0.
+    d = round(float(rng.uniform(0.01, 2.0)), 4)
+    m = round(float(rng.uniform(-1.0, 1.0)), 4)
+    d_bits, m_bits = _f16_bits(d), _f16_bits(m)
+    codes = [int(rng.integers(0, 32)) for _ in range(32)]
+    low_nibbles = [c & 0xF for c in codes]
+    high_bits = [(c >> 4) & 0x1 for c in codes]
+    qs = bytes(
+        (low_nibbles[i] & 0xF) | ((low_nibbles[i + 16] & 0xF) << 4) for i in range(16)
+    )
+    qh = 0
+    for j in range(16):
+        if high_bits[j]:
+            qh |= 1 << j
+        if high_bits[j + 16]:
+            qh |= 1 << (j + 16)
+    raw = struct.pack("<HH", d_bits, m_bits) + struct.pack("<I", qh) + qs
+    d_f, m_f = _f16_to_f32(d_bits), _f16_to_f32(m_bits)
+    expected = [c * d_f + m_f for c in codes]
+    return raw, expected
+
+
 def _model(body, initializer=(), opset=13, ir_version=10):
     model = parser.parse_model(
         f"""
@@ -243,6 +335,70 @@ def test_import_mxfp4_weights(tmp_path):
     np.testing.assert_allclose(got, np.array(expected, dtype=np.float32), rtol=1e-5)
 
 
+def test_import_q4_0_weights(tmp_path):
+    rng = np.random.default_rng(11)
+    raw, expected = _make_q4_0_block(rng)
+    gguf_path = str(tmp_path / "model.gguf")
+    _write_gguf(gguf_path, [("W", GGML_TYPE_Q4_0, [32], raw)])
+
+    model = _identity_model("W", [32])
+    result, skipped = onnxsim.import_gguf_weights(model, gguf_path)
+
+    assert skipped == []
+    w = next(i for i in result.graph.initializer if i.name == "W")
+    assert w.data_type == onnx.TensorProto.FLOAT
+    got = onnx.numpy_helper.to_array(w)
+    np.testing.assert_allclose(got, np.array(expected, dtype=np.float32), rtol=1e-5)
+
+
+def test_import_q4_1_weights(tmp_path):
+    rng = np.random.default_rng(12)
+    raw, expected = _make_q4_1_block(rng)
+    gguf_path = str(tmp_path / "model.gguf")
+    _write_gguf(gguf_path, [("W", GGML_TYPE_Q4_1, [32], raw)])
+
+    model = _identity_model("W", [32])
+    result, skipped = onnxsim.import_gguf_weights(model, gguf_path)
+
+    assert skipped == []
+    w = next(i for i in result.graph.initializer if i.name == "W")
+    assert w.data_type == onnx.TensorProto.FLOAT
+    got = onnx.numpy_helper.to_array(w)
+    np.testing.assert_allclose(got, np.array(expected, dtype=np.float32), rtol=1e-5)
+
+
+def test_import_q5_0_weights(tmp_path):
+    rng = np.random.default_rng(13)
+    raw, expected = _make_q5_0_block(rng)
+    gguf_path = str(tmp_path / "model.gguf")
+    _write_gguf(gguf_path, [("W", GGML_TYPE_Q5_0, [32], raw)])
+
+    model = _identity_model("W", [32])
+    result, skipped = onnxsim.import_gguf_weights(model, gguf_path)
+
+    assert skipped == []
+    w = next(i for i in result.graph.initializer if i.name == "W")
+    assert w.data_type == onnx.TensorProto.FLOAT
+    got = onnx.numpy_helper.to_array(w)
+    np.testing.assert_allclose(got, np.array(expected, dtype=np.float32), rtol=1e-5)
+
+
+def test_import_q5_1_weights(tmp_path):
+    rng = np.random.default_rng(14)
+    raw, expected = _make_q5_1_block(rng)
+    gguf_path = str(tmp_path / "model.gguf")
+    _write_gguf(gguf_path, [("W", GGML_TYPE_Q5_1, [32], raw)])
+
+    model = _identity_model("W", [32])
+    result, skipped = onnxsim.import_gguf_weights(model, gguf_path)
+
+    assert skipped == []
+    w = next(i for i in result.graph.initializer if i.name == "W")
+    assert w.data_type == onnx.TensorProto.FLOAT
+    got = onnx.numpy_helper.to_array(w)
+    np.testing.assert_allclose(got, np.array(expected, dtype=np.float32), rtol=1e-5)
+
+
 def test_import_multiple_tensors_two_dims(tmp_path):
     # Exercises the ne[]-order reversal (GGML innermost-first vs ONNX
     # outermost-first) with a non-square shape, and multiple Q8_0 blocks
@@ -271,13 +427,16 @@ def test_import_skips_unmatched_and_unsupported(tmp_path):
     rng = np.random.default_rng(3)
     raw, _ = _make_q8_0_block(rng)
     gguf_path = str(tmp_path / "model.gguf")
-    legacy_raw = b"\x00" * 18  # Q4_0 block: 2 (d) + 16 (packed nibbles).
+    # Q3_K is not decoded by onnxsim at all, so its exact byte count doesn't
+    # matter here (this tensor's bytes are never read) -- picked because
+    # it's the last tensor in this file, so nothing after it needs locating.
+    unsupported_raw = b"\x00" * 110
     _write_gguf(
         gguf_path,
         [
             ("W", GGML_TYPE_Q8_0, [32], raw),
             ("not_in_graph", GGML_TYPE_Q8_0, [32], raw),
-            ("legacy", GGML_TYPE_Q4_0, [32], legacy_raw),
+            ("unsupported", GGML_TYPE_Q3_K, [256], unsupported_raw),
         ],
     )
 
@@ -289,7 +448,7 @@ def test_import_skips_unmatched_and_unsupported(tmp_path):
     # level skip list (unsupported ggml_type), not a name-matching report.
     # It also never becomes a `model` initializer (this call only hydrates
     # initializers the graph already has, never adds new ones).
-    assert set(skipped) == {"legacy"}
+    assert set(skipped) == {"unsupported"}
     names = {i.name for i in result.graph.initializer}
     assert names == {"W"}
     w = next(i for i in result.graph.initializer if i.name == "W")


### PR DESCRIPTION
## Summary

- Real-world validation of the merged gpt-oss support (fetching header metadata from `unsloth/gpt-oss-20b-GGUF` on Hugging Face via HTTP range requests, no full download needed) showed that most popular size-optimized quantizations — `Q4_K_M`, `Q4_K_S`, `Q5_K_M`, `Q4_0`, `UD-Q4_K_XL` — mix legacy-family GGML types (`Q4_0`/`Q5_0`/`Q5_1`) into `token_embd`/`attn_q`/`attn_k`/`attn_v` tensors even though they're otherwise K-quant checkpoints. Only the largest variants (`F16`, `Q8_0`, `Q6_K`, `UD-Q8_K_XL`) used exclusively K-quant/MXFP4/raw types before this change, so `import_gguf_weights`/`reconstruct_gguf_graph` failed to fully hydrate the smaller, more commonly used quantizations.
- Adds a new `onnxsim/ggml_legacy_quant.h` decoder for `Q4_0`/`Q4_1` (fixed-bias/explicit-min 32-element blocks) and `Q5_0`/`Q5_1` (same, plus a packed 5th-bit `qh` word), mirroring the existing `ggml_kquant.h`/`ggml_mxfp4.h` pattern exactly. Wired into `gguf_dtype.h`'s dtype tables, `TensorPool::DequantizeToFloat`, and `HydrateTensorProtoFromGGUF`.
- Every block layout and dequantization formula is transcribed directly from GGML's own reference implementation (`ggml-quants.c`'s `dequantize_row_q4_0`/`q4_1`/`q5_0`/`q5_1`) and cross-checked against an independent from-scratch re-implementation over random blocks before being committed.
- Re-validated against the real checkpoint headers after implementing: `Q4_K_M`/`Q4_K_S`/`Q4_0`/`UD-Q4_K_XL`/`Q5_K_M` now show zero unsupported tensors. `Q2_K`/`Q3_K_M` correctly remain unsupported — they additionally need `Q3_K`/`IQ*`-family types, which stay out of scope.
- Fixes three pre-existing tests (`tensor_pool_gguf_test.cpp`, `tensor_pool_gguf_bridge_test.cpp`, `tests/test_import_gguf_weights.py`) that had hardcoded `GGML_TYPE_Q4_0` as their "definitely unsupported" example tensor, which broke now that `Q4_0` is supported — switched all three to `Q3_K` instead, a real GGML type still genuinely outside this decoder's scope.
- Updates `docs/import-gguf-weights.md` to describe the legacy family, cite the real-world validation methodology/results, and reflect the new test coverage.

## Test plan

- [x] New standalone C++ unit test `onnxsim/ggml_legacy_quant_test.cpp` (hand-verified Q4_0/Q4_1/Q5_0/Q5_1 test vectors, independently computed) — passes.
- [x] Extended `onnxsim/gguf_dtype_test.cpp` with a `legacy_quant_rows` table mirroring the existing K-quant/MXFP4 coverage — passes.
- [x] Extended `onnxsim/tensor_pool_gguf_test.cpp` and `onnxsim/tensor_pool_gguf_bridge_test.cpp` with legacy-quant round-trip/decode tests — passes.
- [x] Extended `tests/test_import_gguf_weights.py` with `test_import_q4_0_weights`/`test_import_q4_1_weights`/`test_import_q5_0_weights`/`test_import_q5_1_weights`, each building byte-accurate GGUF blocks with an independent Python-side dequant formula (including correct `qh` bit-packing for Q5_0/Q5_1).
- [x] Full `ctest` — 19/19 passed.
- [x] Full `CI=true python3 -m pytest tests/ -q --ignore=tests/test_timm.py` — 1379 passed, 76 skipped.
- [x] `ruff check` / `ruff format --diff` / `mypy` clean on touched Python files.
- [x] `clang-format --dry-run --Werror` clean on all touched C++ files.
- [x] Added `ggml_legacy_quant_test` to `scripts/cross/build_s390x_extension.sh`'s explicit build-target list up front (a real gap that caused a silent CI failure for the MXFP4 decoder in a prior PR).


---
_Generated by [Claude Code](https://claude.ai/code/session_0153LP27pjLXDEFX5vrhHvNk)_