### PR TITLE
Wire function-body inference into onnxsim's shape-inference call sites

### DIFF
--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -195,15 +195,46 @@ size_t CountGraphNodes(const onnx::Graph& graph) {
       std::distance(graph.nodes().begin(), graph.nodes().end()));
 }
 
+// Builds the map InferShapesOnGraph (via OptAndShapeOnGraph/
+// _EvalPartialShapeOnGraph below) needs to infer through a model-local
+// function call: onnx::Graph carries no notion of model.functions() itself
+// (see graph_shape_inference.h's own doc comment), so any caller with a
+// ModelProto in hand builds this once, the same way
+// shape_inference::InferShapes(ModelProto&, ...) does internally for the
+// protobuf-based path. Key format (domain:name, or domain:name:overload for
+// an IR>=10 function overload) matches what every ONNX helper expects --
+// see graph_shape_inference.h's own doc comment.
+onnx::shape_inference::ModelLocalFunctionsMap BuildModelLocalFunctionsMap(
+    const onnx::ModelProto& model) {
+  onnx::shape_inference::ModelLocalFunctionsMap functions;
+  functions.reserve(static_cast<size_t>(model.functions_size()));
+  for (const auto& fn : model.functions()) {
+    std::string id = fn.domain() + ":" + fn.name();
+    if (!fn.overload().empty()) {
+      id += ":" + fn.overload();
+    }
+    functions.emplace(std::move(id), &fn);
+  }
+  return functions;
+}
+
 // Runs InferShapesOnGraph + OptimizeGraphFixed to their own inner fixed
 // point directly on `g`, with no ModelProto conversion at either end -- the
 // Graph-resident core shared by OptAndShape's ModelFn (which wraps this in
 // one Import before and one Export after, see below) and the fully
 // Graph-native outer Pipeline (which shares one Import/Export across the
 // *whole* outer fixed point instead, see Simplify's !rewriter branch).
+// `model_local_functions` is forwarded unchanged to InferShapesOnGraph (see
+// that function's own doc comment) -- Graph carries no notion of
+// model-local functions itself, so a caller whose model has any must build
+// this map from its own ModelProto.functions() and pass it in; omitted
+// (the default, empty), a model-local function call's output is left
+// untouched, exactly as if the op had no registered schema.
 // Returns whether anything changed.
-bool OptAndShapeOnGraph(onnx::Graph& g, bool optimize, bool shape_inference,
-                        size_t fixed_point_iters) {
+bool OptAndShapeOnGraph(
+    onnx::Graph& g, bool optimize, bool shape_inference,
+    size_t fixed_point_iters,
+    const onnx::shape_inference::ModelLocalFunctionsMap& model_local_functions = {}) {
   // See OptAndShape's own doc comment for why these caches are scoped to
   // one call of this function rather than cleared every round underneath.
   onnx::optimization::ClearTensorContentDigestCache();
@@ -211,9 +242,10 @@ bool OptAndShapeOnGraph(onnx::Graph& g, bool optimize, bool shape_inference,
   using GraphFnChanged = std::function<bool(onnx::Graph&)>;
   bool any_changed = false;
   GraphFnChanged InferShapesOnGraphChanged =
-      shape_inference ? GraphFnChanged([&any_changed](onnx::Graph& graph) {
+      shape_inference ? GraphFnChanged([&any_changed, &model_local_functions](onnx::Graph& graph) {
         onnxsim::ProfiledScope scope("InferShapes");
-        const bool c = onnx::InferShapesOnGraph(graph);
+        const bool c = onnx::InferShapesOnGraph(
+            graph, onnx::ShapeInferenceOptions(), nullptr, model_local_functions);
         any_changed |= c;
         return c;
       })
@@ -554,7 +586,8 @@ static onnx::ModelProto SimplifyImpl(
         // are raw_data-heavy, and measured 98%+ of those hash calls were
         // otherwise recomputing a value already seen earlier in the same
         // run (see onnxsim issue #633).
-        OptAndShapeOnGraph(*g, optimize, shape_inference, fixed_point_iters);
+        OptAndShapeOnGraph(*g, optimize, shape_inference, fixed_point_iters,
+                          BuildModelLocalFunctionsMap(model));
         onnx::ModelProto out = onnx::PrepareOutput(model);
         onnx::ExportModelProto(&out, g, /*consume_tensor_data=*/true);
         // OptimizeGraphFixed never sees model-local functions (they live
@@ -618,11 +651,24 @@ static onnx::ModelProto SimplifyImpl(
     // ModelProto-based OptAndShape/FoldConstant path.
     using GraphFn = std::function<void(onnx::Graph&)>;
     using GraphFnChanged = std::function<bool(onnx::Graph&)>;
+    // Built once from the outer, pre-simplification `model` (SimplifyImpl's
+    // own parameter, not `sim_model` or any later ModelFn's own `model`
+    // parameter) and captured by value into both closures below: neither
+    // OptAndShapeOnGraph nor _EvalPartialShapeOnGraph's own InferShapesOnGraph
+    // call otherwise has any way to reach model.functions(), and this map
+    // needs to outlive every round of the fixed point these two closures
+    // drive. Still correct when include_inline_functions has already
+    // inlined `sim_model`'s own function calls away by the time this runs
+    // (see that option's own doc comment) -- the map is simply unreferenced
+    // by any node in that case, not wrong.
+    const onnx::shape_inference::ModelLocalFunctionsMap model_local_functions =
+        BuildModelLocalFunctionsMap(model);
     GraphFnChanged OptAndShapeOnGraphChanged =
-        [optimize, shape_inference, fixed_point_iters](onnx::Graph& graph) {
+        [optimize, shape_inference, fixed_point_iters,
+         model_local_functions](onnx::Graph& graph) {
           onnxsim::ProfiledScope scope("OptAndShape");
           return OptAndShapeOnGraph(graph, optimize, shape_inference,
-                                    fixed_point_iters);
+                                    fixed_point_iters, model_local_functions);
         };
     // `fold_ir_version` is declared above, alongside `converged`: see its own
     // comment for why it cannot live in this block despite only being read
@@ -630,9 +676,10 @@ static onnx::ModelProto SimplifyImpl(
     // below.
     GraphFnChanged FoldConstantOnGraphChanged =
         constant_folding
-            ? GraphFnChanged([&executor, &fold_ir_version](onnx::Graph& graph) {
+            ? GraphFnChanged([&executor, &fold_ir_version,
+                              model_local_functions](onnx::Graph& graph) {
                 onnxsim::ProfiledScope scope("FoldConstant");
-                const bool a = _EvalPartialShapeOnGraph(graph);
+                const bool a = _EvalPartialShapeOnGraph(graph, model_local_functions);
                 const bool b =
                     _FoldConstantOnGraph(executor, graph, fold_ir_version);
                 if (onnxsim::Profiler::Instance().enabled()) {

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -231,10 +231,10 @@ onnx::shape_inference::ModelLocalFunctionsMap BuildModelLocalFunctionsMap(
 // (the default, empty), a model-local function call's output is left
 // untouched, exactly as if the op had no registered schema.
 // Returns whether anything changed.
-bool OptAndShapeOnGraph(
-    onnx::Graph& g, bool optimize, bool shape_inference,
-    size_t fixed_point_iters,
-    const onnx::shape_inference::ModelLocalFunctionsMap& model_local_functions = {}) {
+bool OptAndShapeOnGraph(onnx::Graph& g, bool optimize, bool shape_inference,
+                        size_t fixed_point_iters,
+                        const onnx::shape_inference::ModelLocalFunctionsMap&
+                            model_local_functions = {}) {
   // See OptAndShape's own doc comment for why these caches are scoped to
   // one call of this function rather than cleared every round underneath.
   onnx::optimization::ClearTensorContentDigestCache();
@@ -242,10 +242,12 @@ bool OptAndShapeOnGraph(
   using GraphFnChanged = std::function<bool(onnx::Graph&)>;
   bool any_changed = false;
   GraphFnChanged InferShapesOnGraphChanged =
-      shape_inference ? GraphFnChanged([&any_changed, &model_local_functions](onnx::Graph& graph) {
+      shape_inference ? GraphFnChanged([&any_changed, &model_local_functions](
+                                           onnx::Graph& graph) {
         onnxsim::ProfiledScope scope("InferShapes");
-        const bool c = onnx::InferShapesOnGraph(
-            graph, onnx::ShapeInferenceOptions(), nullptr, model_local_functions);
+        const bool c =
+            onnx::InferShapesOnGraph(graph, onnx::ShapeInferenceOptions(),
+                                     nullptr, model_local_functions);
         any_changed |= c;
         return c;
       })
@@ -587,7 +589,7 @@ static onnx::ModelProto SimplifyImpl(
         // otherwise recomputing a value already seen earlier in the same
         // run (see onnxsim issue #633).
         OptAndShapeOnGraph(*g, optimize, shape_inference, fixed_point_iters,
-                          BuildModelLocalFunctionsMap(model));
+                           BuildModelLocalFunctionsMap(model));
         onnx::ModelProto out = onnx::PrepareOutput(model);
         onnx::ExportModelProto(&out, g, /*consume_tensor_data=*/true);
         // OptimizeGraphFixed never sees model-local functions (they live
@@ -675,20 +677,19 @@ static onnx::ModelProto SimplifyImpl(
     // here and set (from `model.ir_version()`) in the `Pipeline` lambda
     // below.
     GraphFnChanged FoldConstantOnGraphChanged =
-        constant_folding
-            ? GraphFnChanged([&executor, &fold_ir_version,
-                              model_local_functions](onnx::Graph& graph) {
-                onnxsim::ProfiledScope scope("FoldConstant");
-                const bool a = _EvalPartialShapeOnGraph(graph, model_local_functions);
-                const bool b =
-                    _FoldConstantOnGraph(executor, graph, fold_ir_version);
-                if (onnxsim::Profiler::Instance().enabled()) {
-                  onnxsim::Profiler::Instance().RecordNodeCount(
-                      "FoldConstant", CountGraphNodes(graph));
-                }
-                return a || b;
-              })
-            : GraphFnChanged([](onnx::Graph&) { return false; });
+        constant_folding ? GraphFnChanged([&executor, &fold_ir_version,
+                                           model_local_functions](
+                                              onnx::Graph& graph) {
+          onnxsim::ProfiledScope scope("FoldConstant");
+          const bool a = _EvalPartialShapeOnGraph(graph, model_local_functions);
+          const bool b = _FoldConstantOnGraph(executor, graph, fold_ir_version);
+          if (onnxsim::Profiler::Instance().enabled()) {
+            onnxsim::Profiler::Instance().RecordNodeCount(
+                "FoldConstant", CountGraphNodes(graph));
+          }
+          return a || b;
+        })
+                         : GraphFnChanged([](onnx::Graph&) { return false; });
     GraphFn PipelineOnGraph =
         FixedPointFn(OptAndShapeOnGraphChanged, FoldConstantOnGraphChanged,
                      fixed_point_iters, &converged);

--- a/onnxsim/partial_shape_eval.cpp
+++ b/onnxsim/partial_shape_eval.cpp
@@ -852,7 +852,9 @@ void _EvalPartialShape(onnx::ModelProto& model) {
 // onnx/common/graph_shape_inference.h) instead of onnx's protobuf-based
 // InferShapes. Returns whether anything changed, so the fully Graph-native
 // outer pipeline can use it as a GraphFnChanged step.
-bool _EvalPartialShapeOnGraph(onnx::Graph& g) {
+bool _EvalPartialShapeOnGraph(
+    onnx::Graph& g,
+    const onnx::shape_inference::ModelLocalFunctionsMap& model_local_functions) {
   // Mirrors _EvalPartialShape's own snapshot/restore of value_info/output:
   // this pass's own data-propagation inference call must not leave its
   // (lenient, check_type=false) shape/type conclusions on the graph --
@@ -891,7 +893,7 @@ bool _EvalPartialShapeOnGraph(onnx::Graph& g) {
                                               /*error_mode=*/0,
                                               /*enable_data_propagation=*/true);
     try {
-      onnx::InferShapesOnGraph(g, options, &data_map);
+      onnx::InferShapesOnGraph(g, options, &data_map, model_local_functions);
     } catch (const std::exception&) {
       restore();
       return false;

--- a/onnxsim/partial_shape_eval.cpp
+++ b/onnxsim/partial_shape_eval.cpp
@@ -853,8 +853,8 @@ void _EvalPartialShape(onnx::ModelProto& model) {
 // InferShapes. Returns whether anything changed, so the fully Graph-native
 // outer pipeline can use it as a GraphFnChanged step.
 bool _EvalPartialShapeOnGraph(
-    onnx::Graph& g,
-    const onnx::shape_inference::ModelLocalFunctionsMap& model_local_functions) {
+    onnx::Graph& g, const onnx::shape_inference::ModelLocalFunctionsMap&
+                        model_local_functions) {
   // Mirrors _EvalPartialShape's own snapshot/restore of value_info/output:
   // this pass's own data-propagation inference call must not leave its
   // (lenient, check_type=false) shape/type conclusions on the graph --

--- a/onnxsim/partial_shape_eval.h
+++ b/onnxsim/partial_shape_eval.h
@@ -31,8 +31,8 @@ void _EvalPartialShape(onnx::ModelProto& model);
 // model-local functions, or the caller doesn't have them on hand. Returns
 // whether anything changed.
 bool _EvalPartialShapeOnGraph(
-    onnx::Graph& g,
-    const onnx::shape_inference::ModelLocalFunctionsMap& model_local_functions = {});
+    onnx::Graph& g, const onnx::shape_inference::ModelLocalFunctionsMap&
+                        model_local_functions = {});
 
 // Unset the recurrent initial states of RNN/GRU/LSTM nodes in `graph` (and
 // its nested subgraphs) that are provably all zeros (issue #314), so the

--- a/onnxsim/partial_shape_eval.h
+++ b/onnxsim/partial_shape_eval.h
@@ -7,6 +7,7 @@
 // .cpp for the two entry points' shared design note.
 
 #include <onnx/onnx_pb.h>
+#include <onnx/shape_inference/implementation.h>  // for shape_inference::ModelLocalFunctionsMap
 
 namespace onnx {
 class Graph;
@@ -23,8 +24,15 @@ void _InferShapes(onnx::ModelProto& model);
 void _EvalPartialShape(onnx::ModelProto& model);
 
 // Graph-native counterpart of _EvalPartialShape, reached without a
-// ModelProto <-> Graph round trip. Returns whether anything changed.
-bool _EvalPartialShapeOnGraph(onnx::Graph& g);
+// ModelProto <-> Graph round trip. `model_local_functions` is forwarded
+// unchanged to the InferShapesOnGraph call this makes internally (see that
+// function's own doc comment, onnx/common/graph_shape_inference.h) --
+// omitted (the default, empty) if the graph's owning model has no
+// model-local functions, or the caller doesn't have them on hand. Returns
+// whether anything changed.
+bool _EvalPartialShapeOnGraph(
+    onnx::Graph& g,
+    const onnx::shape_inference::ModelLocalFunctionsMap& model_local_functions = {});
 
 // Unset the recurrent initial states of RNN/GRU/LSTM nodes in `graph` (and
 // its nested subgraphs) that are provably all zeros (issue #314), so the

--- a/scripts/cross/run_s390x_tests.sh
+++ b/scripts/cross/run_s390x_tests.sh
@@ -82,7 +82,9 @@ print(sys.byteorder, \"endian | python\", sys.version.split()[0],
 # import their vendor backend module (e.g. ``coreml_backend``) and a ``models``
 # fixture module from a sibling scripts/<vendor>/ directory at module scope --
 # above, only tests/ and pyproject.toml are copied into the chroot, so none of
-# those imports resolve there regardless of what's pip-installed.
+# those imports resolve there regardless of what's pip-installed. Same story
+# for test_check_decode_parity.py, which imports scripts/apple/check_decode_parity
+# at module scope.
 #
 # The three deselected BN-fusion tests fail onnxsim's own check_n equivalence
 # check whenever onnxruntime is absent and the reference evaluator is used
@@ -110,7 +112,7 @@ chroot "${SYSROOT}" /bin/sh -c "cd /work && GITHUB_STEP_SUMMARY=${CHROOT_SUMMARY
   --ignore=tests/test_gan.py \
   --ignore=tests/test_qnn_compat.py --ignore=tests/test_modelopt_integration.py \
   --ignore=tests/test_coreml_compat.py --ignore=tests/test_migraphx_compat.py \
-  --ignore=tests/test_openvino_compat.py \
+  --ignore=tests/test_openvino_compat.py --ignore=tests/test_check_decode_parity.py \
   --deselect tests/test_fusion_patterns.py::test_fuse_conv_bn_into_conv \
   --deselect tests/test_fusion_patterns.py::test_fuse_convtranspose_bn \
   --deselect tests/test_fusion_patterns.py::test_fuse_conv_with_bias_bn_into_conv ${PYTEST_ARGS:-}"

--- a/tests/test_function_body_inference.py
+++ b/tests/test_function_body_inference.py
@@ -1,0 +1,99 @@
+"""Coverage for onnx's Graph-native function-body inference (added upstream in
+onnxsim/onnx's ``function-body-inference-on-graph`` branch): a node calling an
+onnx function -- model-local (``ModelProto.functions()``) or schema-attached
+(``OpSchema::HasFunction()``) -- previously had its output left completely
+untyped by onnxsim's shape-inference pass, exactly as if the op had no
+registered schema at all. onnxsim now builds and passes the model-local
+function map its C++ core needs (see ``BuildModelLocalFunctionsMap`` in
+onnxsim.cpp) so this works even without inlining the function away first
+(``inline_functions`` defaults to ``False``).
+"""
+
+import onnx
+from onnx import parser
+
+import onnxsim
+
+
+def _clear_output_type(model, name, rank):
+    # onnx.parser's own untyped output syntax (`=> (y)`, with no type
+    # annotation at all) parses to a ValueInfoProto with no `type` field at
+    # all, and onnxsim's own model checker requires every graph output to
+    # declare both a `type` and a `shape` (a definite rank -- ONNX doesn't
+    # allow a graph-boundary value to have a wholly unknown rank, only
+    # individual unknown dim values within a known rank). So this builds the
+    # least informative value_info the checker will accept: elem_type
+    # UNDEFINED, `rank` dims each with neither dim_value nor dim_param set.
+    # Any concrete type/dim values found on this output afterward must have
+    # come from onnxsim actually running inference through the function
+    # body, not from the original model.
+    for vi in model.graph.output:
+        if vi.name == name:
+            vi.CopyFrom(onnx.helper.make_tensor_value_info(name, onnx.TensorProto.UNDEFINED, [None] * rank))
+            return
+    raise AssertionError(f"no such graph output: {name}")
+
+
+def test_model_local_function_call_gets_shape_inferred_without_inlining():
+    model = parser.parse_model(
+        """
+        <ir_version: 10, opset_import: ["": 18, "custom.domain": 1]>
+        agg (float[2,3,4] x) => (y)
+        {
+            y = custom.domain.MyNormalize (x)
+        }
+        """
+    )
+    func = parser.parse_function(
+        """
+        <domain: "custom.domain", opset_import: ["": 18]>
+        MyNormalize (X) => (Y)
+        {
+            Y = Relu(X)
+        }
+        """
+    )
+    model.functions.append(func)
+    _clear_output_type(model, "y", rank=3)
+
+    sim_model, check_ok = onnxsim.simplify(model, check_n=0)
+    assert check_ok
+
+    # The call must survive un-inlined (inline_functions=False is the
+    # default) -- this test is specifically about inferring *through* a
+    # function call left in place, not about inlining making it moot.
+    op_types = [n.op_type for n in sim_model.graph.node]
+    assert op_types == ["MyNormalize"], op_types
+    assert len(sim_model.functions) == 1
+
+    y = sim_model.graph.output[0]
+    assert y.type.tensor_type.elem_type == onnx.TensorProto.FLOAT
+    dims = [d.dim_value for d in y.type.tensor_type.shape.dim]
+    assert dims == [2, 3, 4], dims
+
+
+def test_schema_attached_function_call_gets_shape_inferred():
+    # MeanVarianceNormalization has a schema-attached function body
+    # (OpSchema::HasFunction()) and no ordinary type/shape inference
+    # function of its own -- confirmed via
+    # onnx.defs.get_all_schemas_with_history() -- so it needs the same new
+    # inference path as a model-local function, but with no map to plumb
+    # through at all: it's resolved directly off the op's own schema.
+    model = parser.parse_model(
+        """
+        <ir_version: 10, opset_import: ["": 13]>
+        agg (float[2,3,4] x) => (y)
+        {
+            y = MeanVarianceNormalization <axes = [0, 2]> (x)
+        }
+        """
+    )
+    _clear_output_type(model, "y", rank=3)
+
+    sim_model, check_ok = onnxsim.simplify(model, check_n=0)
+    assert check_ok
+
+    y = sim_model.graph.output[0]
+    assert y.type.tensor_type.elem_type == onnx.TensorProto.FLOAT
+    dims = [d.dim_value for d in y.type.tensor_type.shape.dim]
+    assert dims == [2, 3, 4], dims

--- a/tests/test_function_body_inference.py
+++ b/tests/test_function_body_inference.py
@@ -29,7 +29,11 @@ def _clear_output_type(model, name, rank):
     # body, not from the original model.
     for vi in model.graph.output:
         if vi.name == name:
-            vi.CopyFrom(onnx.helper.make_tensor_value_info(name, onnx.TensorProto.UNDEFINED, [None] * rank))
+            vi.CopyFrom(
+                onnx.helper.make_tensor_value_info(
+                    name, onnx.TensorProto.UNDEFINED, [None] * rank
+                )
+            )
             return
     raise AssertionError(f"no such graph output: {name}")
 


### PR DESCRIPTION
## Summary

Bumps `third_party/onnx` to `onnxsim/onnx`'s `function-body-inference-on-graph` branch (commit `ec5e5dfc`), which closes `InferShapesOnGraph`'s own previously-documented "v1 scope" gap: a node calling an onnx **function** (schema-attached, e.g. `MeanVarianceNormalization`, or model-local via `ModelProto.functions()`) had its output left completely untyped, exactly as if the op had no registered schema at all. The onnx-side fix dispatches through onnx's existing, unmodified `shape_inference::InferShapeForFunctionNode()`, mirroring the same pattern `InferShapesOnGraph` already uses to recurse into If/Loop/Scan bodies via `GraphInferencerImpl`.

This surfaced during an exploratory conversation earlier this session about the benefits/costs of onnx's C++ IR for shape inference — function-body inference was listed as a documented gap, closed first on the onnx side, now wired into onnxsim.

## What changed

- **Schema-attached functions** need no onnxsim-side changes — resolved automatically off the op's own schema.
- **Model-local functions** do: `Graph` carries no notion of them itself, so `InferShapesOnGraph` grew a new optional `ModelLocalFunctionsMap` parameter that a caller with the owning `ModelProto` must build and pass in.
- Adds `BuildModelLocalFunctionsMap()` (`onnxsim.cpp`), built once per `SimplifyImpl()` call from the outer model's own `functions()` and threaded through both `OptAndShapeOnGraph` and `_EvalPartialShapeOnGraph` (the latter's signature gained the same parameter — `partial_shape_eval.h`/`.cpp`) at every call site: the `ModelProto`-wrapping `OptAndShape` `ModelFn`, and the fully Graph-native outer pipeline (`Simplify`'s `!rewriter` branch).
- This closes the gap for the **default** case too (`inline_functions=false`, the default): a model-local function call left in the graph — not inlined away — now gets correctly shape-inferred through its body rather than staying opaque.

## Verification

- **onnx side** (already verified on the onnx PR): `onnx_gtests` 146/146 (144 previous + 2 new gtests covering the same two cases directly against `Graph`).
- **Two new end-to-end tests** (`tests/test_function_body_inference.py`):
  - `test_model_local_function_call_gets_shape_inferred_without_inlining`: a hand-built model-local `FunctionProto` (`Relu` body) referenced by a node with no ordinary schema at all — the call survives un-inlined and its output gets the correct inferred type/shape.
  - `test_schema_attached_function_call_gets_shape_inferred`: `MeanVarianceNormalization`, needing no map at all.
- **onnxsim's own pytest suite**: 1302 passed, 68 skipped, 0 failures. Four tests deselected as pre-existing local-sandbox memory constraints unrelated to this change (`test_torchvision_maskrcnn_fpn_opset11`, `test_torchvision_keypointrcnn_fpn`, `test_torchvision_fasterrcnn_fpn`, `test_model_larger_than_2gb` — all confirmed via A/B baseline comparison against the pre-change build to fail identically with or without this PR's diff; real CI likely has more headroom and may not hit any of them).

## Notes

- No onnx-side (`third_party/onnx`'s own) source review needed here beyond what's already in the linked onnx PR — this PR is the submodule bump plus the onnxsim-side wiring.
- `onnxsim/onnx`'s `function-body-inference-on-graph` branch is pushed but not yet merged into its own `main` — the submodule pointer here references the branch-tip commit directly, which is sufficient for pinning (same pattern as this repo's prior submodule-bump PRs).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVvc9sNaXh1Ebk6dzN9wP6)_