### PR TITLE
Ignore test_check_decode_parity.py in s390x cross tests

### DIFF
--- a/scripts/cross/run_s390x_tests.sh
+++ b/scripts/cross/run_s390x_tests.sh
@@ -82,7 +82,9 @@ print(sys.byteorder, \"endian | python\", sys.version.split()[0],
 # import their vendor backend module (e.g. ``coreml_backend``) and a ``models``
 # fixture module from a sibling scripts/<vendor>/ directory at module scope --
 # above, only tests/ and pyproject.toml are copied into the chroot, so none of
-# those imports resolve there regardless of what's pip-installed.
+# those imports resolve there regardless of what's pip-installed. Same story
+# for test_check_decode_parity.py, which imports scripts/apple/check_decode_parity
+# at module scope.
 #
 # The three deselected BN-fusion tests fail onnxsim's own check_n equivalence
 # check whenever onnxruntime is absent and the reference evaluator is used
@@ -110,7 +112,7 @@ chroot "${SYSROOT}" /bin/sh -c "cd /work && GITHUB_STEP_SUMMARY=${CHROOT_SUMMARY
   --ignore=tests/test_gan.py \
   --ignore=tests/test_qnn_compat.py --ignore=tests/test_modelopt_integration.py \
   --ignore=tests/test_coreml_compat.py --ignore=tests/test_migraphx_compat.py \
-  --ignore=tests/test_openvino_compat.py \
+  --ignore=tests/test_openvino_compat.py --ignore=tests/test_check_decode_parity.py \
   --deselect tests/test_fusion_patterns.py::test_fuse_conv_bn_into_conv \
   --deselect tests/test_fusion_patterns.py::test_fuse_convtranspose_bn \
   --deselect tests/test_fusion_patterns.py::test_fuse_conv_with_bias_bn_into_conv ${PYTEST_ARGS:-}"


### PR DESCRIPTION
## Summary

- `tests/test_check_decode_parity.py` (added in 9aee86d) imports `scripts/apple/check_decode_parity` at module scope via a `sys.path.insert`, following the same pattern as the qnn/coreml/migraphx/openvino compat tests.
- `scripts/cross/run_s390x_tests.sh` only copies `tests/` and `pyproject.toml` into the s390x chroot (see the comment block above the pytest invocation), so `scripts/apple/` never makes it in there, and collection fails with `ModuleNotFoundError: No module named 'check_decode_parity'`.
- The script already `--ignore`s the four other vendor-backend test files for exactly this reason; `test_check_decode_parity.py` was missed when it was added.

This currently makes the `s390x (big endian)` CI check fail on `master` (and on every PR based on it) purely on collection, unrelated to any actual byte-order regression.

## Test plan

- [x] `bash -n scripts/cross/run_s390x_tests.sh` (shell syntax check)
- [x] Reviewed the diff: adds `--ignore=tests/test_check_decode_parity.py` next to the existing vendor-backend ignores, plus a comment explaining why, mirroring the existing pattern exactly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVvc9sNaXh1Ebk6dzN9wP6)_