### PR TITLE
Add quality/retention eval: IFEval benchmark scoring via lm-eval

### DIFF
--- a/.github/workflows/coreml-integration.yml
+++ b/.github/workflows/coreml-integration.yml
@@ -50,6 +50,19 @@ name: Core ML Integration
 # (Llama-style via SmolLM2, Qwen2) so a translator regression specific to one
 # doesn't hide behind the other passing. Also workflow_dispatch/schedule-only,
 # matching the other real-model jobs.
+#
+# A fifth job -- `quality-eval-macos` -- is the first slice of
+# bench/TODO_quality_retention_eval.md's quality/retention plan: it runs a small
+# IFEval subset (scripts/apple/run_quality_eval.py, an lm-evaluation-harness wrapper)
+# against both the float Hugging Face model (CPU, no macOS needed for that half) and
+# the exported Core ML model (scripts/apple/lm_eval_coreml_adapter.py, real Core ML
+# runtime), then scripts/apple/compute_retention.py reports the quantized/float score
+# ratio -- the third DeviceMark axis (https://devicemark.github.io/) alongside decode
+# speed and parity. Deliberately small (--limit, --max-gen-toks) and IFEval-only for
+# now: a prototype run of even a single MMLU-Pro example against this suite's
+# unbatched single-sequence decode took minutes on a small model on CPU (see that
+# plan doc's "Proposed scope" section) -- MMLU-Pro and MATH-500 stay future work until
+# that cost is addressed. Also workflow_dispatch/schedule-only.
 
 on:
   schedule:
@@ -281,5 +294,60 @@ jobs:
             python3 "$GITHUB_WORKSPACE/scripts/apple/check_decode_parity.py" \
               ${{ matrix.model_id }} ${{ matrix.slug }}.mlpackage \
               --prompt "The capital of France is" --max-new-tokens 20
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
+  quality-eval-macos:
+    name: Run quality/retention eval (macOS, real Core ML)
+    needs: build-macos
+    if: github.event_name != 'pull_request'
+    runs-on: macos-15
+    timeout-minutes: 30
+    env:
+      MODEL_ID: HuggingFaceTB/SmolLM2-135M-Instruct
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+      - uses: actions/download-artifact@v8
+        with:
+          name: onnxsim-wheel-macos
+          path: wheelhouse
+      - name: Install onnxsim wheel + LLM export/eval deps
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install "optimum-onnx" transformers coremltools onnxruntime "lm-eval[ifeval]"
+          python3 -m pip install wheelhouse/*.whl
+      - name: Verify the installed wheel is used (not the source tree)
+        working-directory: ${{ runner.temp }}
+        run: python3 -c "import onnxsim, onnxsim.onnxsim_cpp2py_export as m; print(onnxsim.__version__, m.__file__)"
+      - name: Export ${{ env.MODEL_ID }}
+        working-directory: ${{ runner.temp }}
+        run: |
+          python3 "$GITHUB_WORKSPACE/scripts/apple/export_llm_to_coreml.py" \
+            "$MODEL_ID" --max-context-length 512 --output model.mlpackage
+      - name: Evaluate the float (Hugging Face) model on a small IFEval subset
+        working-directory: ${{ runner.temp }}
+        run: |
+          python3 "$GITHUB_WORKSPACE/scripts/apple/run_quality_eval.py" \
+            --model hf --model-args "pretrained=$MODEL_ID,dtype=float32" \
+            --tasks ifeval --limit 10 --max-gen-toks 128 --apply-chat-template \
+            --output float_ifeval.json
+      - name: Evaluate the quantized (Core ML) model on the same subset
+        working-directory: ${{ runner.temp }}
+        run: |
+          python3 "$GITHUB_WORKSPACE/scripts/apple/run_quality_eval.py" \
+            --model coreml --model-args "pretrained=model.mlpackage" \
+            --tasks ifeval --limit 10 --max-gen-toks 128 --apply-chat-template \
+            --output coreml_ifeval.json
+      - name: Compute quantized/float retention
+        working-directory: ${{ runner.temp }}
+        run: |
+          {
+            echo "### Quality/retention: $MODEL_ID (IFEval, --limit 10 -- not benchmark-grade)"
+            echo '```'
+            python3 "$GITHUB_WORKSPACE/scripts/apple/compute_retention.py" \
+              float_ifeval.json coreml_ifeval.json
             echo '```'
           } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/bench/TODO_quality_retention_eval.md
+++ b/bench/TODO_quality_retention_eval.md
@@ -1,14 +1,25 @@
 # Open: quality + retention measurement for the Core ML LLM benchmark suite
 
-**Status:** planning only -- nothing in this doc is implemented yet. `scripts/apple`
-currently measures decode speed (`run_llm_decode_benchmark.py`) and prefill/decode
-correctness against the HF reference at the token level (`check_decode_parity.py`,
-agreement rate + first divergence). It has no way to answer "is the model still
-*good*" -- accuracy on a real benchmark -- or "how much accuracy did quantization/
-fp16 conversion cost" -- the two other axes
+**Status:** first slice implemented -- IFEval only, both directions (float + quantized
+eval, retention computation), wired into a `workflow_dispatch`/schedule-only CI job.
+`scripts/apple` now has `run_quality_eval.py` (an `lm-evaluation-harness` wrapper
+supporting `--model hf` and `--model coreml`), `lm_eval_coreml_adapter.py` (the
+`CoreMLDecoder`-wrapping `generate_until` adapter), and `compute_retention.py`
+(quantized/float ratio, unit-tested in `tests/test_compute_retention.py`) -- see
+`scripts/apple/README.md`'s "Quality and retention eval" section for usage. MMLU-Pro
+and MATH-500 are validated as *working* through the same scripts (see "What's been
+prototyped" below) but not yet in CI: a real compute-cost finding during prototyping
+(below) means they need more thought before they're CI-feasible at all, not just a
+config change. This doc's "Next steps" now reflects what's left, not a from-scratch
+plan.
+
+`scripts/apple` previously only measured decode speed (`run_llm_decode_benchmark.py`)
+and prefill/decode correctness against the HF reference at the token level
+(`check_decode_parity.py`, agreement rate + first divergence) -- it had no way to
+answer "is the model still *good*" -- accuracy on a real benchmark -- or "how much
+accuracy did quantization/fp16 conversion cost" -- the two other axes
 [DeviceMark](https://devicemark.github.io/)'s leaderboard reports alongside speed and
-memory. This doc lays out an approach for both, sized to what this repo's CI can
-actually run, without committing to an implementation yet.
+memory.
 
 ## What DeviceMark measures (recalled, not re-fetched -- see the caveat below)
 
@@ -31,20 +42,27 @@ Full IFEval/MMLU-Pro/MATH-500 runs are thousands of prompts each -- at this suit
 current unbatched, single-sequence-at-a-time Core ML decode design (see
 `run_llm_decode_benchmark.py`'s module docstring), that's hours per model on a
 GitHub-hosted macOS runner, not viable for even a `workflow_dispatch`/schedule-only
-job. Two knobs to make it CI-feasible without abandoning the same benchmarks:
+job. Two knobs make it CI-feasible without abandoning the same benchmarks -- both now
+implemented as `run_quality_eval.py` flags:
 
-1. **Subset, not full set.** A fixed random N-sample subset (e.g. 50-100 prompts) per
-   benchmark, seeded for reproducibility. Reports a noisier but directionally useful
-   score, not a leaderboard-grade number -- call this out explicitly in any output
-   ("N=100 subset, not the full benchmark") so it's never mistaken for a comparable
-   DeviceMark score.
+1. **Subset, not full set (`--limit`).** A fixed N-sample subset per benchmark
+   (`quality-eval-macos`'s CI job uses 10). Reports a noisier but directionally useful
+   score, not a leaderboard-grade number -- `lm_eval` itself warns about this at the
+   CLI level, and `run_quality_eval.py`'s module docstring repeats the warning; never
+   mistake it for a comparable DeviceMark score.
 2. **Float side never needs macOS.** Retention's denominator (`float_accuracy`) only
    needs the original Hugging Face model running through `transformers` on CPU --
-   exactly what `check_decode_parity.py`'s reference half already does. That run can
-   happen anywhere (including this dev sandbox, no Core ML/macOS needed), leaving only
-   the numerator (`quantized_accuracy`, the Core ML `.mlpackage`) as the part that must
-   run on a macOS runner. Splitting the two lets the float-side eval iterate fast in a
-   normal Linux CI job or locally, independent of macOS runner minutes.
+   exactly what `check_decode_parity.py`'s reference half already does, and what
+   `run_quality_eval.py --model hf` does (forces `device=cpu` explicitly -- see that
+   script for why). That run can happen anywhere (including a token-less dev sandbox,
+   no Core ML/macOS needed), leaving only the numerator (`quantized_accuracy`, the
+   Core ML `.mlpackage`, `--model coreml`) as the part that must run on a macOS runner.
+   `quality-eval-macos` still runs both sides in the same job for simplicity (it needs
+   the macOS runner for the Core ML half anyway), but nothing stops splitting the float
+   side into a cheaper Linux job later if macOS runner minutes become the bottleneck.
+3. **Generation length cap (`--max-gen-toks`), added after prototyping.** Not
+   anticipated in the original version of this plan -- see "What's been prototyped"
+   below for why it turned out to matter as much as `--limit`.
 
 ## Harness choice
 
@@ -58,19 +76,21 @@ integration point is a small custom adapter class, not a fork of the harness its
 
 - **Float side:** `lm_eval`'s existing `hf` model type already wraps
   `transformers.AutoModelForCausalLM` directly -- no adapter needed, just
-  `lm_eval.simple_evaluate(model="hf", model_args=f"pretrained={model_id}", tasks=[...])`.
-- **Quantized side:** a new adapter, something like `scripts/apple/lm_eval_coreml_adapter.py`,
-  wrapping `CoreMLDecoder` (from `run_llm_decode_benchmark.py`, already handles
-  prefill + growing-KV-cache decode) to implement `generate_until` (IFEval and
-  MATH-500 are generation tasks: free-form / chain-of-thought responses scored by a
-  verifier or answer-extraction, not by comparing log-likelihoods of fixed
-  continuations). MMLU-Pro is multiple-choice and could use either `generate_until`
-  (generate, then extract the letter) or `loglikelihood` (score each candidate
-  continuation) depending on which the harness's stock MMLU-Pro task expects. Whether
-  `loglikelihood` is reachable through `CoreMLDecoder`'s current single-token-at-a-time
-  interface (it would need per-candidate teacher-forced logprobs, not just greedy
-  argmax) is an open question the "Next steps" below need to resolve before committing
-  to `lm-evaluation-harness` over a lighter custom scorer for MMLU-Pro specifically.
+  `run_quality_eval.py --model hf --model-args pretrained=<model_id>`.
+- **Quantized side:** `scripts/apple/lm_eval_coreml_adapter.py`, wrapping
+  `CoreMLDecoder` (from `run_llm_decode_benchmark.py`, already handles prefill +
+  growing-KV-cache decode) to implement `generate_until`.
+- **Resolved (was an open question in the original version of this plan):** does
+  MMLU-Pro need `loglikelihood` (per-candidate teacher-forced logprobs), which
+  `CoreMLDecoder`'s greedy `generate()` can't produce? No -- checked directly against
+  the installed `lm-eval==0.4.12`: `mmlu_pro`'s task YAML (`_default_template_yaml`)
+  declares `output_type: generate_until`, same as `ifeval` and `hendrycks_math500`
+  (MATH-500). All three of this plan's target benchmarks are `generate_until` in this
+  harness version, so `lm_eval_coreml_adapter.py` only implements that method;
+  `loglikelihood`/`loglikelihood_rolling` raise if a future task actually needs them.
+  (This is a property of the installed harness version's task definitions, not a law of
+  nature -- worth a quick re-check of the relevant task YAML if `lm_eval` is ever
+  upgraded across a version that might change it.)
 
 Alternative considered: a from-scratch minimal harness (just load each benchmark's
 public dataset, format prompts, generate, score). Rejected as the default plan --
@@ -100,6 +120,42 @@ harness's model-interface assumptions turn out to be a bad fit for
   string-equality check would undercount correct answers in different but equivalent
   forms.
 
+## What's been prototyped
+
+All three target benchmarks were run end-to-end through `run_quality_eval.py --model
+hf` against `HuggingFaceTB/SmolLM2-135M-Instruct` (CPU, this dev sandbox -- the
+smallest, fastest-iterating already-validated model) to confirm the harness's task
+definitions and this repo's dependency set actually work together, not just as a
+design on paper:
+
+- **IFEval:** works end-to-end; `quality-eval-macos`'s CI job runs this one.
+- **`hendrycks_math500` (MATH-500):** works end-to-end, and was noticeably faster per
+  example than MMLU-Pro at the same `--limit` (no explicit `max_gen_toks` in its task
+  YAML, so it relies on the model naturally stopping rather than a large fixed budget).
+- **`mmlu_pro_biology` (one MMLU-Pro subject, not the full 14-subject group):** works
+  end-to-end, but is dramatically more expensive than the other two --
+  **~2 minutes for a single example** at `--limit 1` (5-shot context, 2048-token
+  `max_gen_toks`) against a 135M-parameter model on CPU. This is the finding that added
+  `--max-gen-toks` to `run_quality_eval.py`: a benchmark's default generation budget
+  directly sets wall-clock cost at this suite's unbatched-decode scale, and MMLU-Pro's
+  default is an order of magnitude larger than the other two. Whether capping
+  `--max-gen-toks` low enough to make MMLU-Pro CI-feasible also lets the model actually
+  finish its "think step by step, then answer (X)" reasoning before being cut off (and
+  so still score meaningfully) is untested -- see "Next steps".
+- **Not yet run at all against the quantized (Core ML) side** -- everything above only
+  exercised `--model hf`; `--model coreml` (`lm_eval_coreml_adapter.py`) has only been
+  import/registration-checked (confirms `@register_model("coreml")` resolves and the
+  class instantiates the right base class), not run against a real `.mlpackage` on real
+  Core ML, since prototyping happened in a Linux dev sandbox with no macOS runtime.
+  `quality-eval-macos`'s first real CI run is this adapter's first real-Core-ML test.
+- A `run_quality_eval.py --model hf` call needs `device="cpu"` forced explicitly
+  (`run_quality_eval.py` does this automatically for `--model hf`) -- without it,
+  `transformers`' newer device-map auto-detection path
+  (`caching_allocator_warmup` -> `torch.cuda.current_device()`) raised
+  `AssertionError: Torch not compiled with CUDA enabled` in this CPU-only sandbox, even
+  though `torch.cuda.is_available()` correctly reports `False` elsewhere. Not filed
+  upstream; worked around locally since it's one explicit kwarg.
+
 ## Retention computation
 
 ```
@@ -127,22 +183,38 @@ actually compare.
 
 ## Next steps, if picking this up
 
-1. Re-read DeviceMark's actual methodology page (subset sizes if any, exact benchmark
+1. ~~Prototype the float-side eval first~~ -- done, see "What's been prototyped": all
+   three target benchmarks confirmed working end-to-end via `run_quality_eval.py
+   --model hf`.
+2. ~~Resolve the `loglikelihood`-vs-`generate_until` question for MMLU-Pro~~ -- done,
+   see "Harness choice": resolved to `generate_until` for all three benchmarks against
+   the installed harness version, no teacher-forced-logprob path needed.
+3. ~~Build the `CoreMLDecoder`-wrapping `lm_eval` adapter~~ -- done
+   (`lm_eval_coreml_adapter.py`), but **not yet validated against real Core ML** --
+   only import/registration-checked in a non-macOS sandbox so far. Confirming it
+   end-to-end (does `quality-eval-macos` actually pass, does the Core ML side's IFEval
+   score land in a sane range relative to the float side's on the same subset) is the
+   most valuable next check once this doc's changes reach a macOS CI run.
+4. ~~Wire a small-subset run into a new CI job~~ -- done (`quality-eval-macos`), but
+   **IFEval only**. MMLU-Pro and MATH-500 remain future work:
+   - MMLU-Pro's ~2-minutes-per-example cost (see "What's been prototyped") needs
+     either a much lower `--max-gen-toks` (with a check that a still-useful score comes
+     out -- an aggressively truncated "think step by step" response might just always
+     score 0, which would be worse than not running it at all) or accepting a very
+     small `--limit` (1-3 examples) purely as a smoke test rather than a real quality
+     signal.
+   - MATH-500 looked cheaper in the prototype and is probably the more promising second
+     benchmark to add to `quality-eval-macos` -- worth trying before MMLU-Pro.
+   - The full `mmlu_pro` group (14 subjects) was never attempted even structurally;
+     only one subject (`mmlu_pro_biology`) has been run. Even after solving the
+     per-example cost, decide whether CI should sample across all 14 subjects or just a
+     couple of representative ones.
+5. Re-read DeviceMark's actual methodology page (subset sizes if any, exact benchmark
    versions/splits, how they define retention) from an environment that isn't blocked
    from reaching `devicemark.github.io`, and reconcile any difference from this doc's
-   recalled description before implementing.
-2. Prototype the float-side eval first (no macOS needed): `lm_eval.simple_evaluate`
-   against one already-validated model (e.g. `HuggingFaceTB/SmolLM2-135M-Instruct`) on
-   a small IFEval subset, to confirm the harness's task definitions and scoring run
-   cleanly in this repo's dependency set before touching the Core ML side at all.
-3. Resolve the `loglikelihood`-vs-`generate_until` question for MMLU-Pro against
-   `CoreMLDecoder`'s interface (see "Harness choice" above) -- this decides whether
-   `CoreMLDecoder` needs a new teacher-forced-logprob code path or whether
-   `generate_until`-based answer extraction is good enough.
-4. Build the `CoreMLDecoder`-wrapping `lm_eval` adapter and validate it end-to-end
-   against one small model + one benchmark subset on a macOS runner, comparing its
-   score to the float side's score on the same subset (sanity: they should be close
-   for an unquantized-in-spirit fp16 Core ML model, not wildly different).
-5. Wire a small-subset run into a new `workflow_dispatch`/schedule-only CI job (own
-   job, not folded into `benchmark-decode-macos`, given the likely runtime), reporting
-   per DeviceMark's three benchmarks plus retention, once 2-4 are validated.
+   recalled description -- still not done; everything implemented so far is sized by
+   this repo's own CI constraints, not verified against DeviceMark's actual
+   methodology.
+6. Once more than one model has been run through `quality-eval-macos` (or a MATH-500/
+   MMLU-Pro variant of it), consider the machine-readable JSON artifact idea in
+   "Reporting" below -- not worth building for a single data point.

--- a/scripts/apple/README.md
+++ b/scripts/apple/README.md
@@ -151,6 +151,69 @@ The pure comparison logic (`compare_token_sequences`) has no coremltools/
 torch/transformers dependency and is unit-tested directly in
 `tests/test_check_decode_parity.py`.
 
+### Quality and retention eval (`run_quality_eval.py` / `compute_retention.py`)
+
+The decode benchmark and parity check above measure speed and short-generation
+correctness; they say nothing about actual model *quality* -- DeviceMark's
+third axis (alongside decode speed and memory), scored via IFEval, MMLU-Pro,
+and MATH-500, plus **retention**: how much of the float model's benchmark
+score survives quantization (`quantized_score / float_score`). See
+`bench/TODO_quality_retention_eval.md` for the full plan; this is the first
+implemented slice of it.
+
+Rather than reimplementing any benchmark's prompt formatting or answer
+scoring, these two scripts lean on
+[`lm-evaluation-harness`](https://github.com/EleutherAI/lm-evaluation-harness)
+(`pip install "lm-eval[ifeval]"`), which already has all three as task
+definitions:
+
+- `lm_eval_coreml_adapter.py` registers a `coreml` model backend wrapping
+  `CoreMLDecoder` so the harness can score an exported `.mlpackage` the same
+  way it scores any other model. It only implements `generate_until` --
+  IFEval, MMLU-Pro, and `hendrycks_math500` (MATH-500) are all
+  `generate_until` tasks in this harness version (free-form generation,
+  scored by a verifier or answer extraction), never `loglikelihood`-based
+  multiple choice, so `CoreMLDecoder`'s existing greedy `generate()` is
+  already the right primitive -- no teacher-forced-logprob code path needed.
+- `run_quality_eval.py` is a thin CLI over `lm_eval.simple_evaluate`,
+  supporting both `--model hf` (the float side -- CPU-only, no macOS needed)
+  and `--model coreml` (the quantized side -- macOS/real Core ML only) against
+  the same task/subset, writing a small JSON summary.
+- `compute_retention.py` takes one JSON from each side and reports the
+  per-task, per-metric retention ratio.
+
+```bash
+pip install "optimum-onnx" transformers coremltools onnxruntime "lm-eval[ifeval]"
+python export_llm_to_coreml.py HuggingFaceTB/SmolLM2-135M-Instruct \
+    --max-context-length 512 --output model.mlpackage
+python run_quality_eval.py --model hf \
+    --model-args pretrained=HuggingFaceTB/SmolLM2-135M-Instruct,dtype=float32 \
+    --tasks ifeval --limit 10 --max-gen-toks 128 --apply-chat-template \
+    --output float_ifeval.json
+python run_quality_eval.py --model coreml --model-args pretrained=model.mlpackage \
+    --tasks ifeval --limit 10 --max-gen-toks 128 --apply-chat-template \
+    --output coreml_ifeval.json
+python compute_retention.py float_ifeval.json coreml_ifeval.json
+```
+
+A `--limit`-restricted run like the one above is explicitly **not**
+benchmark-grade (`lm_eval` itself warns about this) -- treat it as "did this
+get meaningfully worse", not as a score comparable to a published
+leaderboard entry. `--max-gen-toks` matters more here than on a typical
+batched GPU eval: each generated token is its own single-token forward pass
+on an unbatched decoder (HF on CPU, or a real Core ML `.mlpackage`), so a
+benchmark's default generation budget (MMLU-Pro's is 2048 tokens) directly
+sets wall-clock cost. A prototype run of even a single MMLU-Pro example
+against `HuggingFaceTB/SmolLM2-135M-Instruct` on CPU took well over a
+minute at that default -- `coreml-integration.yml`'s `quality-eval-macos`
+job (workflow_dispatch/schedule-only) therefore only runs IFEval for now,
+with both `--limit` and `--max-gen-toks` capped; MMLU-Pro and MATH-500 stay
+future work until that cost is addressed (see the plan doc's "Next steps").
+
+The retention-ratio logic (`compute_retention`) has no lm-evaluation-harness/
+torch/coremltools dependency and is unit-tested directly in
+`tests/test_compute_retention.py`.
+
 ### Scaling to few-billion-parameter models
 
 DeviceMark's own leaderboard mostly tests models in the 1-4B range, well

--- a/scripts/apple/compute_retention.py
+++ b/scripts/apple/compute_retention.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Compute quantized-vs-float retention from two `run_quality_eval.py` result files.
+
+`retention = quantized_score / float_score`, per (task, metric) -- how much of
+the float model's benchmark score the quantized (Core ML) model keeps, the
+same shape of number DeviceMark's (https://devicemark.github.io/) leaderboard
+reports alongside decode speed and memory. See
+`bench/TODO_quality_retention_eval.md` for the full plan this is one piece of.
+
+Usage:
+    python run_quality_eval.py --model hf --model-args pretrained=... \\
+        --tasks ifeval --limit 20 --output float_ifeval.json
+    python run_quality_eval.py --model coreml --model-args pretrained=... \\
+        --tasks ifeval --limit 20 --output coreml_ifeval.json
+    python compute_retention.py float_ifeval.json coreml_ifeval.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def compute_retention(float_tasks: dict, quantized_tasks: dict) -> dict:
+    """Per-(task, metric) retention for every metric present on both sides.
+
+    `float_tasks`/`quantized_tasks` are `run_quality_eval.py` output's "tasks"
+    field: `{task: {metric: value}}`. A metric present on only one side (a
+    task run with different `--tasks` on each side, or a non-numeric field
+    like an internal alias) is silently skipped rather than raising -- the
+    two result files come from independent runs and aren't guaranteed to
+    line up exactly. A float score of exactly 0 makes the ratio undefined
+    (nothing to retain, or the metric legitimately can't score 0 by
+    construction and something else broke) -- reported as `None`, not `inf`
+    or `nan`.
+    """
+    retention = {}
+    for task, float_metrics in float_tasks.items():
+        quantized_metrics = quantized_tasks.get(task)
+        if not quantized_metrics:
+            continue
+
+        task_retention = {}
+        for metric, float_value in float_metrics.items():
+            if metric not in quantized_metrics:
+                continue
+            quantized_value = quantized_metrics[metric]
+            if not isinstance(float_value, (int, float)) or not isinstance(
+                quantized_value, (int, float)
+            ):
+                continue
+            task_retention[metric] = {
+                "float": float_value,
+                "quantized": quantized_value,
+                "retention": (quantized_value / float_value) if float_value else None,
+            }
+        if task_retention:
+            retention[task] = task_retention
+    return retention
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument(
+        "float_result", help="JSON file from run_quality_eval.py --model hf"
+    )
+    ap.add_argument(
+        "quantized_result", help="JSON file from run_quality_eval.py --model coreml"
+    )
+    ap.add_argument(
+        "--output", help="Write the JSON summary here (default: stdout only)"
+    )
+    args = ap.parse_args()
+
+    with open(args.float_result) as f:
+        float_result = json.load(f)
+    with open(args.quantized_result) as f:
+        quantized_result = json.load(f)
+
+    retention = compute_retention(float_result["tasks"], quantized_result["tasks"])
+    if not retention:
+        print(
+            "No task/metric overlap between the two result files -- nothing to "
+            "compute retention for.",
+            file=sys.stderr,
+        )
+        return 1
+
+    for task, metrics in retention.items():
+        print(f"\n{task}:")
+        for metric, values in metrics.items():
+            ret = values["retention"]
+            ret_str = f"{ret:.1%}" if ret is not None else "N/A (float score was 0)"
+            print(
+                f"  {metric}: float={values['float']:.4f} "
+                f"quantized={values['quantized']:.4f} retention={ret_str}"
+            )
+
+    if args.output:
+        with open(args.output, "w") as f:
+            json.dump(retention, f, indent=2)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/apple/lm_eval_coreml_adapter.py
+++ b/scripts/apple/lm_eval_coreml_adapter.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""`lm-evaluation-harness` model adapter around `CoreMLDecoder`.
+
+Lets `lm_eval` (https://github.com/EleutherAI/lm-evaluation-harness) run its
+existing IFEval, MMLU-Pro, and MATH-500 (`hendrycks_math500`) task
+definitions -- prompt formatting, few-shot sampling, and (critically) each
+benchmark's answer scoring/parsing -- against a `.mlpackage` exported by
+`export_llm_to_coreml.py`, instead of reimplementing any of that.
+
+This only needs to implement `generate_until`: all three target benchmarks
+(IFEval, MMLU-Pro, `hendrycks_math500`) are `generate_until` tasks in
+`lm-evaluation-harness` (free-form generation, scored by a verifier or
+answer extraction) -- none of them are `loglikelihood`-based multiple choice,
+so `CoreMLDecoder`'s existing single-token-at-a-time greedy `generate()` is
+already the right shape of primitive; no teacher-forced-logprob code path is
+needed. `loglikelihood`/`loglikelihood_rolling` are left unimplemented and
+raise if a task actually needs them.
+
+`CoreMLDecoder.generate()` only knows how to stop on `eos_token_id` or the
+model's max context length -- it has no notion of the arbitrary stop
+*strings* (`until`) `generate_until` requests carry (e.g. MMLU-Pro's
+`"Question:"`, marking the start of the next few-shot example). This adapter
+decodes the accumulated token ids to text after every new token and checks
+for `until` there, stopping generation as soon as one appears -- an O(n^2)
+sequence of `tokenizer.decode` calls, fine at the token budgets a Core ML
+decode-benchmark suite runs at (tens to low hundreds of tokens), not
+something to reuse for a truly long-generation workload.
+
+Only exists so `--model coreml` resolves for `lm_eval`; import it (or pass
+`--include_path` pointing at this directory) before invoking the harness --
+see `run_quality_eval.py`, which does this for you.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from lm_eval.api.model import LM
+from lm_eval.api.registry import register_model
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from run_llm_decode_benchmark import CoreMLDecoder  # noqa: E402
+
+
+@register_model("coreml")
+class CoreMLLM(LM):
+    """`lm_eval` model backend for a Core ML `.mlpackage` from `export_llm_to_coreml.py`.
+
+    Usage: `lm_eval run --model coreml --model_args pretrained=model.mlpackage ...`
+    (with this module imported first so the `coreml` name is registered).
+    """
+
+    def __init__(
+        self,
+        pretrained: str,
+        compute_units: str = "ALL",
+        max_gen_toks: int = 256,
+        **kwargs,
+    ) -> None:
+        super().__init__()
+        from transformers import AutoTokenizer
+
+        model_dir = Path(pretrained).parent
+        self.tokenizer = AutoTokenizer.from_pretrained(str(model_dir))
+        self.decoder = CoreMLDecoder(pretrained, compute_units=compute_units)
+        self.default_max_gen_toks = max_gen_toks
+
+    def _generate_one(self, context: str, gen_kwargs: dict) -> str:
+        until = gen_kwargs.get("until") or []
+        if isinstance(until, str):
+            until = [until]
+        max_gen_toks = gen_kwargs.get("max_gen_toks") or self.default_max_gen_toks
+
+        prompt_ids = self.tokenizer(context, return_tensors="np")["input_ids"][
+            0
+        ].tolist()
+        # Leave room for at least one generated token even for a prompt near
+        # this model's max context length, rather than raising.
+        max_gen_toks = min(
+            max_gen_toks,
+            max(1, self.decoder.max_context_length - len(prompt_ids)),
+        )
+
+        generated_ids: list[int] = []
+        for token_id, _dt in self.decoder.generate(
+            prompt_ids, max_gen_toks, self.tokenizer.eos_token_id
+        ):
+            generated_ids.append(token_id)
+            text = self.tokenizer.decode(generated_ids, skip_special_tokens=True)
+            cut = min((text.find(u) for u in until if u in text), default=None)
+            if cut is not None:
+                return text[:cut]
+        return self.tokenizer.decode(generated_ids, skip_special_tokens=True)
+
+    def generate_until(self, requests: list) -> list[str]:
+        results = []
+        for request in requests:
+            context, gen_kwargs = request.args
+            results.append(self._generate_one(context, gen_kwargs))
+        return results
+
+    def loglikelihood(self, requests: list) -> list[tuple[float, bool]]:
+        raise NotImplementedError(
+            "CoreMLLM only implements generate_until -- IFEval, MMLU-Pro, and "
+            "hendrycks_math500 (this adapter's target benchmarks) are all "
+            "generate_until tasks and never call loglikelihood. If a task that "
+            "needs multiple-choice loglikelihood scoring is added, this adapter "
+            "needs teacher-forced logprobs from CoreMLDecoder, which it doesn't "
+            "currently expose (see the module docstring)."
+        )
+
+    def loglikelihood_rolling(self, requests: list) -> list[float]:
+        raise NotImplementedError(
+            "CoreMLLM only implements generate_until -- see loglikelihood()."
+        )

--- a/scripts/apple/run_quality_eval.py
+++ b/scripts/apple/run_quality_eval.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Run a quality-benchmark subset against a float (HF) or quantized (Core ML) model.
+
+A thin CLI over `lm_eval.simple_evaluate` (from `lm-evaluation-harness`,
+https://github.com/EleutherAI/lm-evaluation-harness) -- see
+`bench/TODO_quality_retention_eval.md` for why that harness rather than a
+custom scorer: it already implements IFEval, MMLU-Pro, and MATH-500's prompt
+formatting, few-shot sampling, and (the part worth not reimplementing) each
+benchmark's answer scoring. This script only adds two things on top: a
+`--model coreml` backend (`lm_eval_coreml_adapter.py`, wrapping
+`CoreMLDecoder`) so the same harness can score the *exported* model too, and
+`--limit` defaulting to a small subset -- a full run of any of these
+benchmarks is thousands of prompts, hours at this suite's current unbatched,
+single-sequence-at-a-time Core ML decode design (see
+`run_llm_decode_benchmark.py`'s module docstring). A `--limit`-restricted run
+is explicitly *not* a benchmark-grade score (`lm_eval` itself warns about
+this) -- treat its output as "did this get meaningfully worse", not as a
+number comparable to a published IFEval/MMLU-Pro/MATH-500 leaderboard entry.
+
+Run the float side (no macOS/Core ML needed) against the original Hugging
+Face model:
+    python run_quality_eval.py --model hf \\
+        --model-args pretrained=HuggingFaceTB/SmolLM2-135M-Instruct \\
+        --tasks ifeval --limit 20 --output float_ifeval.json
+
+Run the quantized side (macOS only, real Core ML) against the exported model:
+    python run_quality_eval.py --model coreml \\
+        --model-args pretrained=smollm2.mlpackage \\
+        --tasks ifeval --limit 20 --output coreml_ifeval.json
+
+Then compare the two with `compute_retention.py`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def run_quality_eval(
+    model: str,
+    model_args: str,
+    tasks: list[str],
+    limit: int | None,
+    num_fewshot: int | None,
+    apply_chat_template: bool,
+    max_gen_toks: int | None = None,
+) -> dict:
+    if model == "coreml":
+        import lm_eval_coreml_adapter  # noqa: F401  registers the "coreml" model
+
+    from lm_eval.evaluator import simple_evaluate
+
+    results = simple_evaluate(
+        model=model,
+        model_args=model_args,
+        tasks=tasks,
+        limit=limit,
+        num_fewshot=num_fewshot,
+        # Overrides every task's own generation_kwargs -- caps a benchmark's
+        # potentially long default (MMLU-Pro's is 2048) uniformly, which
+        # matters a lot more here than on a batched GPU eval: each token is
+        # its own single-token forward pass on an unbatched decoder (HF on
+        # CPU, or a real Core ML .mlpackage), so generation length dominates
+        # wall-clock cost. See the module docstring.
+        gen_kwargs={"max_gen_toks": max_gen_toks} if max_gen_toks else None,
+        # The float side always runs on CPU (that's the point -- no macOS needed
+        # for it, see the module docstring); left unset for "coreml", where
+        # device isn't a concept CoreMLLM has (Core ML picks its own compute
+        # unit -- see CoreMLDecoder's compute_units instead). Without this,
+        # transformers' own device-map auto-detection can misbehave in a
+        # CPU-only environment (observed: an AssertionError from
+        # torch.cuda.current_device() during weight loading, even though
+        # torch.cuda.is_available() is False) -- forcing "cpu" here sidesteps it.
+        device="cpu" if model == "hf" else None,
+        apply_chat_template=apply_chat_template,
+        fewshot_as_multiturn=apply_chat_template,
+        batch_size=1,
+        log_samples=False,
+    )
+    if results is None:
+        raise RuntimeError("lm_eval.simple_evaluate() returned no results")
+
+    return {
+        "model": model,
+        "model_args": model_args,
+        "limit": limit,
+        "num_fewshot": num_fewshot,
+        "tasks": {
+            task: {
+                metric: value
+                for metric, value in metrics.items()
+                # lm_eval's own "metric_name,filter_name" convention for an actual
+                # scored metric -- distinguishes it from bookkeeping fields on the
+                # same dict ("alias", "sample_len", "name", none of which contain
+                # a comma) and from each metric's paired stderr entry
+                # ("metric_stderr,<filter_name>" -- the filter name varies per
+                # task, e.g. MMLU-Pro's "custom-extract", not always "none", and
+                # is itself sometimes the non-numeric string "N/A").
+                if "," in metric and "_stderr," not in metric
+            }
+            for task, metrics in results["results"].items()
+        },
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument(
+        "--model", required=True, choices=["hf", "coreml"], help="lm_eval model backend"
+    )
+    ap.add_argument(
+        "--model-args",
+        required=True,
+        help="lm_eval model_args, e.g. 'pretrained=HuggingFaceTB/SmolLM2-135M-Instruct' "
+        "(--model hf) or 'pretrained=model.mlpackage' (--model coreml)",
+    )
+    ap.add_argument(
+        "--tasks",
+        default="ifeval",
+        help="Comma-separated lm_eval task names (default: ifeval). Other targets: "
+        "hendrycks_math500 (MATH-500), mmlu_pro_<subject> (one MMLU-Pro subject; the "
+        "full 'mmlu_pro' group is 14 subjects x 5-shot, likely too slow for a --limit "
+        "run against an unbatched Core ML decoder)",
+    )
+    ap.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Number of examples per task (default: 20). Not a benchmark-grade score "
+        "at this size -- see the module docstring.",
+    )
+    ap.add_argument(
+        "--num-fewshot",
+        type=int,
+        default=None,
+        help="Override each task's default few-shot count (default: use the task's own).",
+    )
+    ap.add_argument(
+        "--apply-chat-template",
+        action="store_true",
+        help="Format prompts through the model's chat template (recommended for "
+        "instruct models; lm_eval warns if this is left off for one).",
+    )
+    ap.add_argument(
+        "--max-gen-toks",
+        type=int,
+        default=None,
+        help="Cap every task's generation length (default: each task's own, e.g. "
+        "MMLU-Pro's 2048) -- see the module docstring on why this matters more here "
+        "than on a batched GPU eval.",
+    )
+    ap.add_argument(
+        "--output", help="Write the JSON summary here (default: stdout only)"
+    )
+    args = ap.parse_args()
+
+    result = run_quality_eval(
+        args.model,
+        args.model_args,
+        args.tasks.split(","),
+        args.limit,
+        args.num_fewshot,
+        args.apply_chat_template,
+        args.max_gen_toks,
+    )
+
+    text = json.dumps(result, indent=2)
+    print(text)
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(text)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_compute_retention.py
+++ b/tests/test_compute_retention.py
@@ -1,0 +1,83 @@
+"""Unit tests for scripts/apple/compute_retention.py's retention computation.
+
+`compute_retention` is plain dict logic with no lm-evaluation-harness/torch/
+coremltools dependency, so it's tested directly here -- see that module's
+docstring for what retention means and why a zero float score reports `None`
+rather than `inf`/`nan`.
+"""
+
+import os
+import sys
+
+import pytest
+
+_APPLE_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "apple"
+)
+if _APPLE_DIR not in sys.path:
+    sys.path.insert(0, _APPLE_DIR)
+
+from compute_retention import compute_retention  # noqa: E402
+
+
+def test_full_retention_when_scores_match():
+    result = compute_retention(
+        {"ifeval": {"prompt_level_strict_acc,none": 0.8}},
+        {"ifeval": {"prompt_level_strict_acc,none": 0.8}},
+    )
+    assert result == {
+        "ifeval": {
+            "prompt_level_strict_acc,none": {
+                "float": 0.8,
+                "quantized": 0.8,
+                "retention": 1.0,
+            }
+        }
+    }
+
+
+def test_partial_retention():
+    result = compute_retention(
+        {"ifeval": {"acc": 0.8}},
+        {"ifeval": {"acc": 0.6}},
+    )
+    assert result["ifeval"]["acc"]["retention"] == pytest.approx(0.75)
+
+
+def test_zero_float_score_reports_none_not_inf():
+    result = compute_retention(
+        {"hendrycks_math500": {"exact_match": 0.0}},
+        {"hendrycks_math500": {"exact_match": 0.0}},
+    )
+    assert result["hendrycks_math500"]["exact_match"]["retention"] is None
+
+
+def test_skips_tasks_missing_on_one_side():
+    result = compute_retention(
+        {"ifeval": {"acc": 0.8}, "mmlu_pro_biology": {"acc": 0.5}},
+        {"ifeval": {"acc": 0.7}},
+    )
+    assert list(result.keys()) == ["ifeval"]
+
+
+def test_skips_metrics_missing_on_one_side():
+    result = compute_retention(
+        {"ifeval": {"acc": 0.8, "extra_metric": 1.0}},
+        {"ifeval": {"acc": 0.7}},
+    )
+    assert list(result["ifeval"].keys()) == ["acc"]
+
+
+def test_skips_non_numeric_metrics():
+    result = compute_retention(
+        {"ifeval": {"acc": 0.8, "alias": "ifeval"}},
+        {"ifeval": {"acc": 0.7, "alias": "ifeval"}},
+    )
+    assert list(result["ifeval"].keys()) == ["acc"]
+
+
+def test_no_overlap_returns_empty():
+    result = compute_retention(
+        {"ifeval": {"acc": 0.8}}, {"mmlu_pro_biology": {"acc": 0.5}}
+    )
+    assert result == {}


### PR DESCRIPTION
Implements the first slice of the quality/retention evaluation plan from `bench/TODO_quality_retention_eval.md`: benchmark-based accuracy scoring and quantization retention measurement (quantized/float score ratio) for Core ML exported models.

## Summary

Adds three new scripts and a CI job to measure how well quantized Core ML models retain the accuracy of their float Hugging Face originals on real benchmarks (IFEval, with MMLU-Pro and MATH-500 validated but not yet in CI). Leverages `lm-evaluation-harness` for prompt formatting, few-shot sampling, and answer scoring rather than reimplementing these per-benchmark.

## Key changes

- **`scripts/apple/run_quality_eval.py`**: Thin CLI wrapper over `lm_eval.simple_evaluate` supporting both `--model hf` (float, CPU-only) and `--model coreml` (quantized, macOS/Core ML) backends. Includes `--limit` (subset size) and `--max-gen-toks` (generation budget cap) flags to keep CI-feasible runtimes on unbatched single-sequence decode. Outputs JSON summary of per-task metrics.

- **`scripts/apple/lm_eval_coreml_adapter.py`**: Registers a `coreml` model backend for `lm-evaluation-harness` by wrapping `CoreMLDecoder`. Implements `generate_until` (the only method needed for IFEval, MMLU-Pro, and MATH-500 in the installed harness version) with stop-string detection via post-token-decode text search.

- **`scripts/apple/compute_retention.py`**: Computes per-task, per-metric retention ratios from two `run_quality_eval.py` result files (float and quantized). Handles missing metrics/tasks gracefully and reports `None` for undefined ratios (zero float score).

- **`tests/test_compute_retention.py`**: Unit tests for retention computation logic (no external dependencies).

- **`.github/workflows/coreml-integration.yml`**: New `quality-eval-macos` CI job (workflow_dispatch/schedule-only) that exports SmolLM2-135M-Instruct to Core ML, evaluates both float and quantized sides on a 10-example IFEval subset with capped generation length, and reports retention.

- **`bench/TODO_quality_retention_eval.md`** and **`scripts/apple/README.md`**: Updated to reflect implemented status, prototyping findings (MMLU-Pro's 2048-token default makes single examples take minutes on CPU), and usage examples.

## Notable implementation details

- **Generation length matters more here than batched GPU eval**: Each token is a separate forward pass on unbatched decode (HF on CPU or real Core ML), so a benchmark's default generation budget directly sets wall-clock cost. MMLU-Pro's 2048-token default made even single examples prohibitively slow during prototyping, motivating the `--max-gen-toks` flag.

- **Float side never needs macOS**: `run_quality_eval.py --model hf` forces `device="cpu"` explicitly to avoid `transformers`' device-map auto-detection issues in CPU-only environments, allowing the float baseline to run anywhere (Linux CI, dev sandbox) independent of macOS runner minutes.

- **All three target benchmarks are `generate_until` tasks**: IFEval, MMLU-Pro, and `hendrycks_math500` (MATH-500) all use free-form generation with verifier/answer-extraction scoring in the installed `lm-eval==0.4.12`, so `CoreMLDecoder`'s greedy `generate()` is sufficient; no teacher-forced logprobs needed.

- **Subset-based, not benchmark-grade**: `--limit` restricts to a small sample (CI uses 10 examples) for speed. `lm_eval` itself warns about this; the output is directional ("did this get worse") not leaderboard-comparable.

https://claude.ai/code/session_01T3MD7VAmysceuqiBQYHvWQ