### PR TITLE
Add Q2_K/Q3_K K-quant decode support to import_gguf_weights

### DIFF
--- a/docs/import-gguf-weights.md
+++ b/docs/import-gguf-weights.md
@@ -41,39 +41,49 @@ are silently left alone.
 
 Real quantized checkpoints store most of their weights as one of GGML's
 block-quantized formats, not plain float. This function decodes the
-**K-quant** family -- `Q4_K`, `Q5_K`, `Q6_K` (256-element super-blocks, each
-with its own packed 6-bit per-sub-block scale/min pair) and `Q8_0`
-(32-element blocks, one fp16 scale each) -- which is what Unsloth's `*_K_M`/
-`*_K_S`/`Q8_0` GGUF exports actually use for the bulk of their tensors; the
-**legacy** family -- `Q4_0`, `Q4_1`, `Q5_0`, `Q5_1` (plain 32-element blocks,
-no super-block scale/min table) -- which llama.cpp's own mixed-precision
-quantizers still pick for particular tensor roles (embeddings, attention
-projections) even in an otherwise K-quant checkpoint; and **MXFP4**
-(32-element blocks, one shared power-of-two E8M0 exponent byte and 16 bytes
-of packed 4-bit e2m1-style codes) -- the OCP Microscaling FP4 format
-official gpt-oss GGUF releases use natively for their MoE expert weights.
-Every block layout and dequantization formula is transcribed directly from
-GGML's own reference implementation
+**K-quant** family -- `Q2_K`, `Q3_K`, `Q4_K`, `Q5_K`, `Q6_K` (256-element
+super-blocks, each with its own packed sub-block scale/min or scale table)
+and `Q8_0` (32-element blocks, one fp16 scale each) -- which is what
+Unsloth's `*_K_M`/`*_K_S`/`Q8_0` GGUF exports actually use for the bulk of
+their tensors; the **legacy** family -- `Q4_0`, `Q4_1`, `Q5_0`, `Q5_1`
+(plain 32-element blocks, no super-block scale/min table) -- which
+llama.cpp's own mixed-precision quantizers still pick for particular tensor
+roles (embeddings, attention projections) even in an otherwise K-quant
+checkpoint; and **MXFP4** (32-element blocks, one shared power-of-two E8M0
+exponent byte and 16 bytes of packed 4-bit e2m1-style codes) -- the OCP
+Microscaling FP4 format official gpt-oss GGUF releases use natively for
+their MoE expert weights. Every block layout and dequantization formula is
+transcribed directly from GGML's own reference implementation
 (https://github.com/ggml-org/ggml -- `ggml-common.h`'s block structs,
 `ggml-quants.c`'s `dequantize_row_q*`/`dequantize_row_mxfp4` functions,
 `ggml-impl.h`'s `ggml_e8m0_to_fp32_half`) and cross-checked against an
 independent from-scratch re-implementation over full random blocks before
 being committed (see `onnxsim/ggml_kquant.h`'s, `onnxsim/
-ggml_legacy_quant.h`'s, and `onnxsim/ggml_mxfp4.h`'s file comments).
+ggml_legacy_quant.h`'s, and `onnxsim/ggml_mxfp4.h`'s file comments). `Q3_K`
+needed one extra layer of care: GGML's own reference unpacks its 12-byte
+packed-6-bit scale table by `memcpy`-ing it onto a native `uint32_t[3]` and
+bit-twiddling those words directly, which only reproduces little-endian byte
+order -- `ggml_kquant.h`'s `UnpackQ3KScales` does the identical bit-twiddling
+arithmetic but starting from explicit little-endian word reads, so it
+decodes correctly on a big-endian host too (this repo tests on s390x).
 
-The legacy family's real-world importance was confirmed empirically, not
-assumed: fetching the real header of several official
+The legacy and K-quant-completion (`Q2_K`/`Q3_K`) families' real-world
+importance were both confirmed empirically, not assumed: fetching the real
+header of several official
 [`unsloth/gpt-oss-20b-GGUF`](https://huggingface.co/unsloth/gpt-oss-20b-GGUF)
 quantizations (via an HTTP range request for just the header bytes, no need
 to download the multi-gigabyte weight data) showed that most of the
 popular, size-optimized ones -- `Q4_K_M`, `Q4_K_S`, `Q5_K_M`, `Q4_0`,
 `UD-Q4_K_XL` -- mix in one or more legacy-family tensors for `token_embd`/
-`attn_q`/`attn_k`/`attn_v`, and would fail to import at all without this.
+`attn_q`/`attn_k`/`attn_v`, and would fail to import at all without that
+family; and that the two smallest variants, `Q2_K` and `Q3_K_M`, mix in
+`Q2_K`/`Q3_K` tensors themselves (unsurprising, given their names) for the
+same tensor roles. With both families added, every one of these
+quantizations' non-`IQ4_NL` tensors now decodes; only their `IQ4_NL`
+tensors (an importance-matrix format, see "Scope" below) remain unsupported
+-- confirmed by re-fetching and re-checking each header after implementing.
 Only the largest variants (`F16`, `Q8_0`, `Q6_K`, `UD-Q8_K_XL`) used
-exclusively K-quant/MXFP4/raw types before this family was added. The
-smallest variants (`Q2_K`, `Q3_K_M`) still fail: they additionally need
-`Q3_K` and an `IQ*`/`Q2_K`-family type, which remain out of scope (see
-"Scope" below).
+exclusively K-quant/MXFP4/raw types from the start.
 
 A matched K-quant, legacy-quant, or MXFP4 tensor's initializer has its
 `data_type` forced to `FLOAT` regardless of what `model` previously
@@ -82,15 +92,16 @@ declared for it -- the decoded values are only meaningful as float32.
 ## Scope
 
 Handled:
-- `Q4_K`, `Q5_K`, `Q6_K`, `Q8_0` (K-quant), `Q4_0`, `Q4_1`, `Q5_0`, `Q5_1`
-  (legacy), `MXFP4` -- decoded to float32.
+- `Q2_K`, `Q3_K`, `Q4_K`, `Q5_K`, `Q6_K`, `Q8_0` (K-quant), `Q4_0`, `Q4_1`,
+  `Q5_0`, `Q5_1` (legacy), `MXFP4` -- decoded to float32.
 - Any raw (already-unquantized) GGML type (`F32`, `F16`, `BF16`, `F64`,
   `I8`/`I16`/`I32`/`I64`) -- copied through unchanged, same as `import_gguf`.
 
 Not handled (reported in `skipped`, left untouched):
-- `Q8_1`, `Q2_K`/`Q3_K`/`Q8_K`, `NVFP4`, and every `IQ*` importance-matrix
-  variant -- these have real, different block layouts this decoder does not
-  implement.
+- `Q8_1`, `Q8_K`, `NVFP4`, and every `IQ*` importance-matrix variant (e.g.
+  `IQ4_NL`, used by several real gpt-oss-20b quantizations for a handful of
+  tensors even alongside K-quant/legacy/MXFP4 for the rest) -- these have
+  real, different block layouts this decoder does not implement.
 
 Only an initializer whose *name* matches a GGUF tensor is ever touched;
 `import_gguf_weights` never adds new initializers or otherwise changes the
@@ -182,9 +193,10 @@ alone, for a MoE graph you already built or exported some other way.
 ## Tests
 
 `tests/test_import_gguf_weights.py` writes real, byte-accurate GGUF v3
-files containing hand-encoded `Q8_0`/`Q4_K` (K-quant), `Q4_0`/`Q4_1`/`Q5_0`/
-`Q5_1` (legacy, see `test_import_q4_0_weights` and friends), and MXFP4
-blocks with known values (computing each expected float independently, not
+files containing hand-encoded `Q2_K`/`Q3_K`/`Q4_K`/`Q8_0` (K-quant, see
+`test_import_q2_k_weights` and friends), `Q4_0`/`Q4_1`/`Q5_0`/`Q5_1`
+(legacy, see `test_import_q4_0_weights` and friends), and MXFP4 blocks with
+known values (computing each expected float independently, not
 by reusing the C++ decoder under test) and checks `import_gguf_weights`'
 decoded result against them, plus coverage for multi-dimensional shapes
 (GGML's innermost-dimension-first `ne[]` vs ONNX's outermost-first shape),

--- a/onnxsim/ggml_kquant.h
+++ b/onnxsim/ggml_kquant.h
@@ -1,10 +1,10 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Dequantization for the four GGML "K-quant" block formats gguf_dtype.h's
- * IsKQuant covers (Q4_K, Q5_K, Q6_K, Q8_0): decodes a tensor's native, still-
- * packed GGML block bytes (see gguf_dtype.h's KQuantBlockBytes) into plain
- * host-order float32 values.
+ * Dequantization for the six GGML "K-quant" block formats gguf_dtype.h's
+ * IsKQuant covers (Q2_K, Q3_K, Q4_K, Q5_K, Q6_K, Q8_0): decodes a tensor's
+ * native, still-packed GGML block bytes (see gguf_dtype.h's KQuantBlockBytes)
+ * into plain host-order float32 values.
  *
  * Pure, dependency-free (no protobuf, no onnx headers) like gguf_dtype.h
  * itself -- operates on raw bytes and the same integer ggml_type codes, so
@@ -23,6 +23,18 @@
  * big-endian host too (this repo tests on s390x). A block's single-byte
  * fields (the packed quant codes, the int8 Q6_K scales) need no such care --
  * one byte has no endianness.
+ *
+ * Q3_K is the one exception needing extra care: GGML's own reference
+ * unpacks its 12-byte packed 6-bit scale table by `memcpy`-ing it onto a
+ * `uint32_t[3]` and bit-twiddling those words directly (see
+ * dequantize_row_q3_K) -- correct only when `memcpy` onto a native
+ * `uint32_t` happens to reproduce little-endian byte order, i.e. only on a
+ * little-endian host; GGML itself has no big-endian handling for this at
+ * all. UnpackQ3KScales below reproduces the exact same bit-twiddling
+ * arithmetic (verified bit-for-bit equivalent to the reference over 2000
+ * random scale tables via an independent Python re-implementation) but
+ * starting from explicit little-endian word reads/writes (ReadLE32Word/
+ * ByteOfLE32), so the result is identical on any host byte order.
  */
 #ifndef ONNXSIM_GGML_KQUANT_H_
 #define ONNXSIM_GGML_KQUANT_H_
@@ -92,6 +104,114 @@ inline void GetScaleMinK4(int j, const uint8_t* q, uint8_t* d, uint8_t* m) {
   } else {
     *d = static_cast<uint8_t>((q[j + 4] & 0xF) | ((q[j - 4] >> 6) << 4));
     *m = static_cast<uint8_t>((q[j + 4] >> 4) | ((q[j - 0] >> 6) << 4));
+  }
+}
+
+// Reconstructs a little-endian uint32_t from four bytes, regardless of host
+// byte order -- ReadLE16's 32-bit counterpart, needed by UnpackQ3KScales.
+inline uint32_t ReadLE32Word(const uint8_t* p) {
+  return static_cast<uint32_t>(p[0]) | (static_cast<uint32_t>(p[1]) << 8) |
+         (static_cast<uint32_t>(p[2]) << 16) |
+         (static_cast<uint32_t>(p[3]) << 24);
+}
+
+// Extracts byte `byte_index` (0 = least significant) of `word` as if `word`
+// were stored little-endian -- the write-side counterpart to ReadLE32Word,
+// used to pull individual bytes back out of the words UnpackQ3KScales
+// computes, independent of host byte order.
+inline uint8_t ByteOfLE32(uint32_t word, int byte_index) {
+  return static_cast<uint8_t>((word >> (8 * byte_index)) & 0xFFu);
+}
+
+// Unpacks Q3_K's 12-byte packed-6-bit scale table into 16 signed values in
+// `out` (still offset by +32, matching GGML's own `scales[is++] - 32` step,
+// left to the caller). Mirrors ggml-quants.c's dequantize_row_q3_K bit-
+// twiddling exactly, but built from explicit little-endian word reads
+// (ReadLE32Word) and byte extraction (ByteOfLE32) instead of the
+// reference's `memcpy` onto a native `uint32_t[3]` -- see this file's
+// comment for why the reference's version only works on a little-endian
+// host, and why this one doesn't need to care.
+inline void UnpackQ3KScales(const uint8_t* scales12, int8_t out[16]) {
+  const uint32_t kmask1 = 0x03030303u;
+  const uint32_t kmask2 = 0x0f0f0f0fu;
+  uint32_t aux[4];
+  aux[0] = ReadLE32Word(scales12 + 0);
+  aux[1] = ReadLE32Word(scales12 + 4);
+  aux[2] = ReadLE32Word(scales12 + 8);
+  const uint32_t tmp = aux[2];
+  const uint32_t new0 = (aux[0] & kmask2) | (((tmp >> 0) & kmask1) << 4);
+  const uint32_t new1 = (aux[1] & kmask2) | (((tmp >> 2) & kmask1) << 4);
+  const uint32_t new2 = ((aux[0] >> 4) & kmask2) | (((tmp >> 4) & kmask1) << 4);
+  const uint32_t new3 = ((aux[1] >> 4) & kmask2) | (((tmp >> 6) & kmask1) << 4);
+  aux[0] = new0;
+  aux[1] = new1;
+  aux[2] = new2;
+  aux[3] = new3;
+  for (int k = 0; k < 16; ++k) {
+    out[k] = static_cast<int8_t>(ByteOfLE32(aux[k / 4], k % 4));
+  }
+}
+
+// Decodes one 84-byte Q2_K block (256 elements) into `out`.
+inline void DequantizeQ2_KBlock(const uint8_t* block, float* out) {
+  const uint8_t* scales = block;  // 16 bytes
+  const uint8_t* q = block + 16;  // 64 bytes
+  const float d = Float16BitsToFloat32(ReadLE16(block + 16 + 64));
+  const float dmin = Float16BitsToFloat32(ReadLE16(block + 16 + 64 + 2));
+
+  float* y = out;
+  int is = 0;
+  for (int n = 0; n < 256; n += 128) {
+    int shift = 0;
+    for (int j = 0; j < 4; ++j) {
+      uint8_t sc = scales[is++];
+      float dl = d * (sc & 0xF);
+      float ml = dmin * (sc >> 4);
+      for (int l = 0; l < 16; ++l) {
+        *y++ = dl * static_cast<float>((q[l] >> shift) & 3) - ml;
+      }
+      sc = scales[is++];
+      dl = d * (sc & 0xF);
+      ml = dmin * (sc >> 4);
+      for (int l = 0; l < 16; ++l) {
+        *y++ = dl * static_cast<float>((q[l + 16] >> shift) & 3) - ml;
+      }
+      shift += 2;
+    }
+    q += 32;
+  }
+}
+
+// Decodes one 110-byte Q3_K block (256 elements) into `out`.
+inline void DequantizeQ3_KBlock(const uint8_t* block, float* out) {
+  const uint8_t* hmask = block;                 // 32 bytes
+  const uint8_t* q = block + 32;                // 64 bytes
+  const uint8_t* scales_raw = block + 32 + 64;  // 12 bytes
+  const float d_all = Float16BitsToFloat32(ReadLE16(block + 32 + 64 + 12));
+
+  int8_t scales[16];
+  UnpackQ3KScales(scales_raw, scales);
+
+  float* y = out;
+  int is = 0;
+  uint8_t m = 1;
+  for (int n = 0; n < 256; n += 128) {
+    int shift = 0;
+    for (int j = 0; j < 4; ++j) {
+      float dl = d_all * static_cast<float>(scales[is++] - 32);
+      for (int l = 0; l < 16; ++l) {
+        const int low = (q[l] >> shift) & 3;
+        *y++ = dl * static_cast<float>(low - ((hmask[l] & m) ? 0 : 4));
+      }
+      dl = d_all * static_cast<float>(scales[is++] - 32);
+      for (int l = 0; l < 16; ++l) {
+        const int low = (q[l + 16] >> shift) & 3;
+        *y++ = dl * static_cast<float>(low - ((hmask[l + 16] & m) ? 0 : 4));
+      }
+      shift += 2;
+      m = static_cast<uint8_t>(m << 1);
+    }
+    q += 32;
   }
 }
 
@@ -200,7 +320,7 @@ inline void DequantizeQ6_KBlock(const uint8_t* block, float* out) {
 // `numel / KQuantBlockElements(ggml_type) * KQuantBlockBytes(ggml_type)`
 // bytes long) into `numel` host-order float32 values, appended to `out`
 // (not cleared first). Returns false, leaving `out` untouched, if
-// `ggml_type` is not one of the four IsKQuant types, `numel` is not a
+// `ggml_type` is not one of the six IsKQuant types, `numel` is not a
 // multiple of its block size, or `raw_size` does not match the expected
 // byte length for `numel` elements (a corrupt/truncated buffer).
 inline bool DequantizeGgmlKQuant(const uint8_t* raw, size_t raw_size,
@@ -228,6 +348,12 @@ inline bool DequantizeGgmlKQuant(const uint8_t* raw, size_t raw_size,
     switch (ggml_type) {
       case GGML_TYPE_Q8_0:
         DequantizeQ8_0Block(src, dst);
+        break;
+      case GGML_TYPE_Q2_K:
+        DequantizeQ2_KBlock(src, dst);
+        break;
+      case GGML_TYPE_Q3_K:
+        DequantizeQ3_KBlock(src, dst);
         break;
       case GGML_TYPE_Q4_K:
         DequantizeQ4_KBlock(src, dst);

--- a/onnxsim/ggml_kquant_test.cpp
+++ b/onnxsim/ggml_kquant_test.cpp
@@ -4,15 +4,20 @@
  * Standalone: g++ -std=c++20 ggml_kquant_test.cpp -o t && ./t
  *
  * Dependency-free unit test for ggml_kquant.h's GGML K-quant dequantization
- * (Q8_0, Q4_K, Q5_K, Q6_K), mirroring gguf_dtype_test.cpp's style.
+ * (Q2_K, Q3_K, Q4_K, Q5_K, Q6_K, Q8_0), mirroring gguf_dtype_test.cpp's
+ * style.
  *
  * Every block layout/formula this decodes was cross-checked against an
  * independent from-scratch Python transcription of GGML's own reference
- * (ggml-quants.c's dequantize_row_q8_0/q4_K/q5_K/q6_K) over full random
- * blocks -- 0 error. The cases here are smaller, hand-verifiable vectors
- * (chosen so most of a block's bytes are zero and its non-zero bytes'
- * contribution can be checked by hand), meant to catch a regression in this
- * file specifically, not to re-derive GGML's spec from scratch.
+ * (ggml-quants.c's dequantize_row_q2_K/q3_K/q4_K/q5_K/q6_K/q8_0) over full
+ * random blocks -- 0 error; Q3_K's UnpackQ3KScales specifically was fuzzed
+ * against the reference's own memcpy-onto-uint32_t bit-twiddling over 2000
+ * random 12-byte scale tables (see ggml_kquant.h's file comment for why that
+ * needed its own verification pass). The cases here are smaller, hand-
+ * verifiable vectors (chosen so most of a block's bytes are zero and its
+ * non-zero bytes' contribution can be checked by hand), meant to catch a
+ * regression in this file specifically, not to re-derive GGML's spec from
+ * scratch.
  */
 #include "ggml_kquant.h"
 
@@ -208,6 +213,84 @@ void TestQ6_K() {
   CheckNear(out[0], -290.0f, "Q6_K element 0");
 }
 
+// Same zeroed-sub-block trick as TestQ4_K/TestQ5_K: only the first (scale,
+// min) pair (scales[0]) is non-trivial, everything else stays 0.
+void TestQ2_K() {
+  std::vector<uint8_t> block(KQuantBlockBytes(GGML_TYPE_Q2_K), 0);
+  uint8_t* scales = block.data();   // 16 bytes
+  uint8_t* qs = block.data() + 16;  // 64 bytes
+  const uint16_t d_bits = EncodeF16(1.0f);
+  const uint16_t dmin_bits = EncodeF16(0.5f);
+  block[16 + 64] = static_cast<uint8_t>(d_bits & 0xFF);
+  block[16 + 64 + 1] = static_cast<uint8_t>((d_bits >> 8) & 0xFF);
+  block[16 + 64 + 2] = static_cast<uint8_t>(dmin_bits & 0xFF);
+  block[16 + 64 + 3] = static_cast<uint8_t>((dmin_bits >> 8) & 0xFF);
+  scales[0] = 0x31;  // low nibble (scale) = 1, high nibble (min) = 3
+  qs[0] = 0x01;      // element 0: 2-bit code (qs[0] >> 0) & 3 = 1
+  // qs[1] left 0 -> element 1's 2-bit code is 0.
+
+  // dl = d * 1 = 1.0; ml = dmin * 3 = 1.5.
+  // expected[0] = dl * 1 - ml = 1.0 - 1.5 = -0.5.
+  // expected[1] = dl * 0 - ml = -1.5.
+  float out[256];
+  DequantizeQ2_KBlock(block.data(), out);
+  CheckNear(out[0], -0.5f, "Q2_K sub-block 0 element 0");
+  CheckNear(out[1], -1.5f, "Q2_K sub-block 0 element 1 (qs[1]=0)");
+  CheckNear(out[16], 0.0f, "Q2_K sub-block 1 (zeroed scale/min) is 0");
+}
+
+// Q3_K's -32 scale bias means (unlike Q4_K/Q5_K/Q6_K) a zeroed scale byte
+// does NOT give a trivially-zero output -- no zeroed-sub-block shortcut, so
+// this checks a single fully-determined element instead (same approach as
+// TestQ6_K). scales12 has only its first byte set, chosen so
+// UnpackQ3KScales's bit-spreading from the other two words contributes
+// nothing and scales[0] reduces to exactly that byte's low nibble (verified
+// separately in TestUnpackQ3KScales below and against the Python reference
+// -- see this file's header comment).
+void TestQ3_K() {
+  std::vector<uint8_t> block(KQuantBlockBytes(GGML_TYPE_Q3_K), 0);
+  // hmask (block.data(), 32 bytes) is left all 0.
+  uint8_t* qs = block.data() + 32;             // 64 bytes
+  uint8_t* scales12 = block.data() + 32 + 64;  // 12 bytes
+  const uint16_t d_bits = EncodeF16(1.0f);
+  block[32 + 64 + 12] = static_cast<uint8_t>(d_bits & 0xFF);
+  block[32 + 64 + 12 + 1] = static_cast<uint8_t>((d_bits >> 8) & 0xFF);
+  scales12[0] = 0x1F;  // -> unpacked scales[0] == 15 (see TestUnpackQ3KScales)
+  qs[0] = 0x01;        // element 0's 2-bit low code: (qs[0] >> 0) & 3 = 1
+
+  // dl = d_all * (15 - 32) = -17. hmask[0] == 0 -> bit m=1 clear -> subtract
+  // 4: value = 1 - 4 = -3. expected[0] = dl * -3 = 51.0.
+  float out[256];
+  DequantizeQ3_KBlock(block.data(), out);
+  CheckNear(out[0], 51.0f, "Q3_K element 0");
+}
+
+void TestUnpackQ3KScales() {
+  // scales12 with only byte 0 set: the two other 32-bit words (and the
+  // `tmp`-derived high-bit spreading) contribute nothing, so scales[0]
+  // reduces to exactly (scales12[0] & 0x0F) -- 0x1F & 0x0F == 15.
+  uint8_t scales12[12] = {0x1F, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  int8_t out[16];
+  UnpackQ3KScales(scales12, out);
+  Check(out[0] == 15, "UnpackQ3KScales single-byte input");
+  Check(out[1] == 0, "UnpackQ3KScales untouched slot stays 0");
+
+  // A fully mixed input, independently cross-checked against a from-scratch
+  // Python re-implementation of the reference's memcpy-onto-uint32_t
+  // bit-twiddling (see ggml_kquant.h's file comment) -- not hand-derivable,
+  // but pinned here as a regression check once verified externally.
+  uint8_t mixed[12] = {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB,
+                       0xCD, 0xEF, 0x10, 0x32, 0x54, 0x76};
+  const int8_t want[16] = {1,  35, 5,  39, 9, 11, 29, 31,
+                           16, 50, 20, 54, 8, 10, 28, 30};
+  UnpackQ3KScales(mixed, out);
+  bool ok = true;
+  for (int i = 0; i < 16; ++i) {
+    if (out[i] != want[i]) ok = false;
+  }
+  Check(ok, "UnpackQ3KScales mixed input matches Python reference");
+}
+
 void TestDequantizeGgmlKQuantRejectsBadInput() {
   std::vector<uint8_t> q8_block(KQuantBlockBytes(GGML_TYPE_Q8_0), 0);
   std::vector<float> out;
@@ -240,6 +323,9 @@ void TestDequantizeGgmlKQuantRejectsBadInput() {
 int main() {
   TestFloat16BitsToFloat32();
   TestQ8_0();
+  TestQ2_K();
+  TestQ3_K();
+  TestUnpackQ3KScales();
   TestQ4_K();
   TestQ5_K();
   TestQ6_K();

--- a/onnxsim/gguf_dtype.h
+++ b/onnxsim/gguf_dtype.h
@@ -23,11 +23,12 @@
  * (tensor_pool_gguf.cpp) skips such tensors and reports them, rather than
  * materializing garbage bytes as if they were raw floats.
  *
- * EXCEPTION -- the "K-quant" family this mapping DOES cover (Q4_K, Q5_K,
- * Q6_K, plus the simpler per-32-element Q8_0): these are the block formats
- * real-world quantized checkpoints (e.g. Unsloth's GGUF exports) actually
- * use for the bulk of their weights, unlike the rarer legacy Q4_0-family and
- * IQ*-family types this mapping still does not cover. Each maps to one of
+ * EXCEPTION -- the "K-quant" family this mapping DOES cover (Q2_K, Q3_K,
+ * Q4_K, Q5_K, Q6_K, plus the simpler per-32-element Q8_0): these are the
+ * block formats real-world quantized checkpoints (e.g. Unsloth's GGUF
+ * exports) actually use for the bulk of their weights, unlike the rarer
+ * legacy Q4_0-family and IQ*-family types this mapping still does not
+ * cover. Each maps to one of
  * the ONNXSIM_GGML_* codes below -- private, onnxsim-fork-only integer
  * values, NOT part of the ONNX spec (TensorProto's `data_type` field is
  * plain `int32`, not the enum type, precisely so a private code like this
@@ -119,6 +120,8 @@ enum GgmlType : uint32_t {
   GGML_TYPE_Q5_0 = 6,
   GGML_TYPE_Q5_1 = 7,
   GGML_TYPE_Q8_0 = 8,
+  GGML_TYPE_Q2_K = 10,
+  GGML_TYPE_Q3_K = 11,
   GGML_TYPE_Q4_K = 12,
   GGML_TYPE_Q5_K = 13,
   GGML_TYPE_Q6_K = 14,
@@ -154,7 +157,7 @@ enum OnnxDtype : int32_t {
 // see the file comment) may hold for a still-packed GGML K-quant, MXFP4, or
 // legacy-quant tensor. Chosen from a range (10000+) with no plausible
 // collision against ONNX's own DataType enum (defined up to 26 as of this
-// writing -- see onnx.in.proto); never reassign or reuse one of these nine
+// writing -- see onnx.in.proto); never reassign or reuse one of these eleven
 // values.
 enum OnnxsimPrivateDtype : int32_t {
   ONNXSIM_GGML_Q4_K = 10001,
@@ -166,6 +169,8 @@ enum OnnxsimPrivateDtype : int32_t {
   ONNXSIM_GGML_Q4_1 = 10007,
   ONNXSIM_GGML_Q5_0 = 10008,
   ONNXSIM_GGML_Q5_1 = 10009,
+  ONNXSIM_GGML_Q2_K = 10010,
+  ONNXSIM_GGML_Q3_K = 10011,
 };
 
 // Bytes of one element. 0 for a ggml_type this mapping doesn't cover
@@ -193,17 +198,19 @@ inline size_t ElementSize(uint32_t ggml_type) {
 // True for a ggml_type with a fixed-width, unquantized, one-value-per-
 // element layout -- the only kind ElementSize/nelems*ElementSize sizing
 // applies to. False for every quantized/K-quant/IQ* type (including the
-// four IsKQuant covers below, which need TryTotalBytes instead -- see that
+// six IsKQuant covers below, which need TryTotalBytes instead -- see that
 // function) and anything this mapping doesn't recognize.
 inline bool IsRaw(uint32_t ggml_type) { return ElementSize(ggml_type) != 0; }
 
-// True for one of the four block-quantized types this mapping covers (see
-// the file comment's EXCEPTION paragraph) -- Q4_K/Q5_K/Q6_K (super-blocks of
-// 256 elements) or Q8_0 (blocks of 32). False for every other ggml_type,
-// including every quantized family this mapping does NOT decode (Q4_0,
-// every IQ*_ variant, ...).
+// True for one of the six block-quantized types this mapping covers (see
+// the file comment's EXCEPTION paragraph) -- Q2_K/Q3_K/Q4_K/Q5_K/Q6_K
+// (super-blocks of 256 elements) or Q8_0 (blocks of 32). False for every
+// other ggml_type, including every quantized family this mapping does NOT
+// decode (Q4_0, every IQ*_ variant, ...).
 inline bool IsKQuant(uint32_t ggml_type) {
   switch (ggml_type) {
+    case GGML_TYPE_Q2_K:
+    case GGML_TYPE_Q3_K:
     case GGML_TYPE_Q4_K:
     case GGML_TYPE_Q5_K:
     case GGML_TYPE_Q6_K:
@@ -219,6 +226,8 @@ inline size_t KQuantBlockElements(uint32_t ggml_type) {
   switch (ggml_type) {
     case GGML_TYPE_Q8_0:
       return 32;
+    case GGML_TYPE_Q2_K:
+    case GGML_TYPE_Q3_K:
     case GGML_TYPE_Q4_K:
     case GGML_TYPE_Q5_K:
     case GGML_TYPE_Q6_K:
@@ -232,13 +241,20 @@ inline size_t KQuantBlockElements(uint32_t ggml_type) {
 // one KQuantBlockElements(ggml_type)-element block (a 2-byte fp16 scale plus
 // the packed sub-byte quant codes for Q8_0; two 2-byte fp16 super-block
 // scales, a 12-byte packed 6-bit scale/min table, and the packed quant codes
-// for Q4_K/Q5_K/Q6_K -- see block_q4_K/block_q5_K/block_q6_K/block_q8_0 in
+// for Q4_K/Q5_K/Q6_K; a 16-byte packed 4-bit scale/min table and the packed
+// 2-bit quant codes for Q2_K; a 12-byte packed 6-bit scale table, a 32-byte
+// high-bit mask, and the packed 2-bit low quant codes for Q3_K -- see
+// block_q2_K/block_q3_K/block_q4_K/block_q5_K/block_q6_K/block_q8_0 in
 // ggml's ggml-common.h, and ggml_kquant.h's DequantizeGgmlKQuant for the
 // exact byte layout each decodes). 0 for anything else.
 inline size_t KQuantBlockBytes(uint32_t ggml_type) {
   switch (ggml_type) {
     case GGML_TYPE_Q8_0:
       return 34;  // 2 (d) + 32 (qs)
+    case GGML_TYPE_Q2_K:
+      return 84;  // 16 (scales) + 64 (qs) + 2 (d) + 2 (dmin)
+    case GGML_TYPE_Q3_K:
+      return 110;  // 32 (hmask) + 64 (qs) + 12 (scales) + 2 (d)
     case GGML_TYPE_Q4_K:
       return 144;  // 2 (d) + 2 (dmin) + 12 (scales) + 128 (qs)
     case GGML_TYPE_Q5_K:
@@ -275,8 +291,8 @@ inline size_t Mxfp4BlockBytes(uint32_t ggml_type) {
 // True for one of the four legacy block-quantized types this mapping covers
 // (see the file comment's THIRD EXCEPTION paragraph) -- Q4_0, Q4_1, Q5_0,
 // Q5_1, all 32-element blocks. False for every other ggml_type, including
-// every quantized family this mapping does NOT decode (Q2_K, Q3_K, every
-// IQ*_ variant, ...).
+// every quantized family this mapping does NOT decode (every IQ*_ variant,
+// Q8_1, Q8_K, ...).
 inline bool IsLegacyQuant(uint32_t ggml_type) {
   switch (ggml_type) {
     case GGML_TYPE_Q4_0:
@@ -317,7 +333,7 @@ inline size_t LegacyQuantBlockBytes(uint32_t ggml_type) {
 }
 
 // Map a ggml_type to its ONNX dtype code -- ONNXSIM_GGML_* (see that enum's
-// doc comment) for one of the four IsKQuant types, an ordinary ONNX_* code
+// doc comment) for one of the six IsKQuant types, an ordinary ONNX_* code
 // for a raw type. Returns false (leaving `*out` untouched) for a quantized
 // type this mapping doesn't cover (Q4_0, IQ*, ...) or one it doesn't
 // recognize at all.
@@ -358,6 +374,12 @@ inline bool ToOnnx(uint32_t ggml_type, int32_t* out) {
       return true;
     case GGML_TYPE_Q8_0:
       *out = ONNXSIM_GGML_Q8_0;
+      return true;
+    case GGML_TYPE_Q2_K:
+      *out = ONNXSIM_GGML_Q2_K;
+      return true;
+    case GGML_TYPE_Q3_K:
+      *out = ONNXSIM_GGML_Q3_K;
       return true;
     case GGML_TYPE_MXFP4:
       *out = ONNXSIM_GGML_MXFP4;
@@ -430,7 +452,7 @@ inline bool TryTotalBytes(uint32_t ggml_type, uint64_t nelems,
 // Inverse of ToOnnx. Returns false for an ONNX dtype with no raw ggml_type
 // counterpart (STRING, COMPLEX64/128, UNDEFINED, the unsigned int family --
 // ggml has no unsigned integer types at all, quantized or otherwise -- or
-// one of onnxsim's own custom dtypes this mapping doesn't cover). The nine
+// one of onnxsim's own custom dtypes this mapping doesn't cover). The eleven
 // ONNXSIM_GGML_* codes DO round-trip here (unlike every other private dtype
 // a caller might construct): a pooled K-quant, MXFP4, or legacy-quant entry
 // that still holds its native, un-decoded block bytes (see the file
@@ -474,6 +496,12 @@ inline bool FromOnnx(int32_t onnx_dtype, uint32_t* out) {
       return true;
     case ONNXSIM_GGML_Q8_0:
       *out = GGML_TYPE_Q8_0;
+      return true;
+    case ONNXSIM_GGML_Q2_K:
+      *out = GGML_TYPE_Q2_K;
+      return true;
+    case ONNXSIM_GGML_Q3_K:
+      *out = GGML_TYPE_Q3_K;
       return true;
     case ONNXSIM_GGML_MXFP4:
       *out = GGML_TYPE_MXFP4;

--- a/onnxsim/gguf_dtype_test.cpp
+++ b/onnxsim/gguf_dtype_test.cpp
@@ -54,13 +54,13 @@ int main() {
           "ToOnnx(FromOnnx(" + std::to_string(row.onnx) + "))) round-trips");
   }
 
-  // Quantized types this mapping does NOT decode (Q8_1, Q2_K/Q3_K, Q8_K,
-  // IQ*_XXS/BF16-adjacent codes, NVFP4, ...) or unrecognized types are
-  // rejected, not guessed at. Deliberately excludes 2/3/6/7 (Q4_0/Q4_1/
-  // Q5_0/Q5_1), 8/12/13/14 (Q8_0/Q4_K/Q5_K/Q6_K), and 39 (MXFP4), which ARE
-  // supported -- see the legacy_quant_rows/k_quant_rows loops and the
+  // Quantized types this mapping does NOT decode (Q8_1, Q8_K, IQ*_XXS/
+  // BF16-adjacent codes, NVFP4, ...) or unrecognized types are rejected,
+  // not guessed at. Deliberately excludes 2/3/6/7 (Q4_0/Q4_1/Q5_0/Q5_1),
+  // 8/10/11/12/13/14 (Q8_0/Q2_K/Q3_K/Q4_K/Q5_K/Q6_K), and 39 (MXFP4), which
+  // ARE supported -- see the legacy_quant_rows/k_quant_rows loops and the
   // MXFP4 checks below.
-  const uint32_t quantized[] = {9, 10, 11, 15, 16, 20, 29, 9999};
+  const uint32_t quantized[] = {9, 15, 16, 20, 29, 9999};
   for (uint32_t q : quantized) {
     int32_t onnx = -1;
     Check(!ToOnnx(q, &onnx),
@@ -80,13 +80,14 @@ int main() {
           "TryTotalBytes rejects unsupported type " + std::to_string(q));
   }
 
-  // The four K-quant types this mapping DOES decode -- Q4_K/Q5_K/Q6_K
-  // (super-blocks of 256 elements) and Q8_0 (blocks of 32). Each round-trips
-  // through ToOnnx/FromOnnx to its private ONNXSIM_GGML_* code (unlike every
-  // OTHER private dtype a caller might construct, which FromOnnx correctly
-  // rejects -- see the unsupported_onnx loop below), is NOT IsRaw (its
-  // sizing is block-based, not per-element), and TryTotalBytes agrees with
-  // KQuantBlockElements/KQuantBlockBytes's block math.
+  // The six K-quant types this mapping DOES decode -- Q2_K/Q3_K/Q4_K/Q5_K/
+  // Q6_K (super-blocks of 256 elements) and Q8_0 (blocks of 32). Each
+  // round-trips through ToOnnx/FromOnnx to its private ONNXSIM_GGML_* code
+  // (unlike every OTHER private dtype a caller might construct, which
+  // FromOnnx correctly rejects -- see the unsupported_onnx loop below), is
+  // NOT IsRaw (its sizing is block-based, not per-element), and
+  // TryTotalBytes agrees with KQuantBlockElements/KQuantBlockBytes's block
+  // math.
   struct KQuantRow {
     uint32_t ggml;
     int32_t onnx;
@@ -95,6 +96,8 @@ int main() {
   };
   const KQuantRow k_quant_rows[] = {
       {GGML_TYPE_Q8_0, ONNXSIM_GGML_Q8_0, 32, 34},
+      {GGML_TYPE_Q2_K, ONNXSIM_GGML_Q2_K, 256, 84},
+      {GGML_TYPE_Q3_K, ONNXSIM_GGML_Q3_K, 256, 110},
       {GGML_TYPE_Q4_K, ONNXSIM_GGML_Q4_K, 256, 144},
       {GGML_TYPE_Q5_K, ONNXSIM_GGML_Q5_K, 256, 176},
       {GGML_TYPE_Q6_K, ONNXSIM_GGML_Q6_K, 256, 210},

--- a/onnxsim/gguf_reconstruct.py
+++ b/onnxsim/gguf_reconstruct.py
@@ -54,7 +54,8 @@ worse tradeoff than a curated, explicit template per architecture family.
 architecture, its hyperparameters, and its tensors' names/shapes -- without
 reading any tensor byte data; :func:`import_gguf_weights` (reused here
 unmodified) supplies the actual values, including its existing K-quant
-(Q4_K/Q5_K/Q6_K/Q8_0), legacy (Q4_0/Q4_1/Q5_0/Q5_1), and MXFP4 decode.
+(Q2_K/Q3_K/Q4_K/Q5_K/Q6_K/Q8_0), legacy (Q4_0/Q4_1/Q5_0/Q5_1), and MXFP4
+decode.
 
 Scope note on shapes: the returned graph's ``batch_size``/``seq_len`` are
 concrete, caller-chosen static dimensions, not dynamic axes. Real llama.cpp
@@ -107,11 +108,11 @@ _GGML_RAW_TO_ONNX = {
     28: onnx.TensorProto.DOUBLE,  # F64
     30: onnx.TensorProto.BFLOAT16,  # BF16
 }
-# Q8_0, Q4_K, Q5_K, Q6_K (K-quant), Q4_0, Q4_1, Q5_0, Q5_1 (legacy), MXFP4 --
-# import_gguf_weights forces these to FLOAT regardless of what the
-# initializer previously declared (see tensor_pool_gguf_bridge.h's
+# Q2_K, Q3_K, Q4_K, Q5_K, Q6_K, Q8_0 (K-quant), Q4_0, Q4_1, Q5_0, Q5_1
+# (legacy), MXFP4 -- import_gguf_weights forces these to FLOAT regardless of
+# what the initializer previously declared (see tensor_pool_gguf_bridge.h's
 # HydrateTensorProtoFromGGUF), so that is what must be declared here too.
-_GGML_KQUANT_TYPES = {2, 3, 6, 7, 8, 12, 13, 14, 39}
+_GGML_KQUANT_TYPES = {2, 3, 6, 7, 8, 10, 11, 12, 13, 14, 39}
 
 _ONNX_DTYPE_ITEMSIZE = {
     onnx.TensorProto.FLOAT: 4,
@@ -1048,8 +1049,9 @@ def _reconstruct_llama_family(
             raise UnsupportedArchitectureError(
                 f"tensor '{name}' uses ggml_type {ggml_type}, which "
                 "import_gguf_weights cannot decode (only F32/F16/BF16/F64/"
-                "I8/I16/I32/I64, the Q4_K/Q5_K/Q6_K/Q8_0 K-quant family, the "
-                "Q4_0/Q4_1/Q5_0/Q5_1 legacy family, and MXFP4 are supported)"
+                "I8/I16/I32/I64, the Q2_K/Q3_K/Q4_K/Q5_K/Q6_K/Q8_0 K-quant "
+                "family, the Q4_0/Q4_1/Q5_0/Q5_1 legacy family, and MXFP4 are "
+                "supported)"
             )
         b.placeholder_weight(name, expected_shape, onnx_dtype)
         return name
@@ -1400,8 +1402,9 @@ def _reconstruct_gpt_oss(meta: dict, batch_size: int, seq_len: int) -> onnx.Grap
             raise UnsupportedArchitectureError(
                 f"tensor '{name}' uses ggml_type {ggml_type}, which "
                 "import_gguf_weights cannot decode (only F32/F16/BF16/F64/"
-                "I8/I16/I32/I64, the Q4_K/Q5_K/Q6_K/Q8_0 K-quant family, the "
-                "Q4_0/Q4_1/Q5_0/Q5_1 legacy family, and MXFP4 are supported)"
+                "I8/I16/I32/I64, the Q2_K/Q3_K/Q4_K/Q5_K/Q6_K/Q8_0 K-quant "
+                "family, the Q4_0/Q4_1/Q5_0/Q5_1 legacy family, and MXFP4 are "
+                "supported)"
             )
         b.placeholder_weight(name, expected_shape, onnx_dtype)
         return name
@@ -1520,8 +1523,8 @@ def reconstruct_gguf_graph(
     itself from the checkpoint's own declared hyperparameters
     (:func:`read_gguf_metadata`), then calls ``import_gguf_weights``
     internally to hydrate it -- so it reuses that function's existing
-    K-quant (Q4_K/Q5_K/Q6_K/Q8_0), legacy (Q4_0/Q4_1/Q5_0/Q5_1), and MXFP4
-    decode unchanged.
+    K-quant (Q2_K/Q3_K/Q4_K/Q5_K/Q6_K/Q8_0), legacy (Q4_0/Q4_1/Q5_0/Q5_1), and
+    MXFP4 decode unchanged.
 
     :param gguf_path: path to the GGUF checkpoint
     :param batch_size: static batch dimension baked into the returned

--- a/onnxsim/tensor_pool.h
+++ b/onnxsim/tensor_pool.h
@@ -207,10 +207,10 @@ class TensorPool {
   // translation unit from the safetensors codec above, since the two file
   // formats share nothing but the TensorPool storage they read into/from.
   // See gguf_dtype.h's file comment for an important scope note: most of
-  // GGML's block-quantized types (Q2_K, Q3_K, every IQ*_ variant, ...) have
+  // GGML's block-quantized types (every IQ*_ variant, Q8_1, Q8_K, ...) have
   // no ONNX raw-data equivalent and are never pooled -- LoadGGUF skips and
   // reports them rather than writing garbage. The K-quant family
-  // (Q4_K/Q5_K/Q6_K/Q8_0) -- what a real quantized checkpoint (e.g.
+  // (Q2_K/Q3_K/Q4_K/Q5_K/Q6_K/Q8_0) -- what a real quantized checkpoint (e.g.
   // Unsloth's GGUF exports) actually uses for the bulk of its weights --
   // the legacy family (Q4_0/Q4_1/Q5_0/Q5_1, which llama.cpp's own mixed-
   // precision quantizers still pick for particular tensor roles even in an
@@ -247,7 +247,7 @@ class TensorPool {
   // unquantized type (stored as-is) or one of the block-quantized types
   // gguf_dtype.h's IsKQuant/IsLegacyQuant/IsMxfp4 cover (stored as its
   // native, still-packed block bytes -- see DequantizeToFloat to decode
-  // one). Every other quantized type (Q2_K, Q3_K, every IQ*_ variant, ...)
+  // one). Every other quantized type (every IQ*_ variant, Q8_1, Q8_K, ...)
   // has no representation this pool can hold at all. Unlike LoadSafetensors,
   // this does NOT read the whole file into memory: only the (small) header/
   // metadata/tensor-info section is read up front, and each *included*

--- a/onnxsim/tensor_pool_gguf_bridge.h
+++ b/onnxsim/tensor_pool_gguf_bridge.h
@@ -11,15 +11,15 @@
  * representation during Simplify().
  *
  * The GGUF-specific thing worth calling out here is gguf_dtype.h's scope:
- * most of GGML's block-quantized types (Q2_K, Q3_K, every IQ*_ variant, ...)
+ * most of GGML's block-quantized types (every IQ*_ variant, Q8_1, Q8_K, ...)
  * have no ONNX raw-data equivalent at all, so ImportModelWithGGUF's
  * `skipped_out` matters more here than ImportModelWithSafetensors's
  * equivalent ever would in practice. The families this mapping DOES cover
- * -- K-quant (Q4_K/Q5_K/Q6_K/Q8_0, what a real quantized checkpoint, e.g.
- * Unsloth's GGUF exports, actually uses for the bulk of its weights),
- * legacy (Q4_0/Q4_1/Q5_0/Q5_1, which llama.cpp's own mixed-precision
- * quantizers still pick for particular tensor roles even in an otherwise
- * K-quant checkpoint), and MXFP4 (gpt-oss's native MoE-expert
+ * -- K-quant (Q2_K/Q3_K/Q4_K/Q5_K/Q6_K/Q8_0, what a real quantized
+ * checkpoint, e.g. Unsloth's GGUF exports, actually uses for the bulk of
+ * its weights), legacy (Q4_0/Q4_1/Q5_0/Q5_1, which llama.cpp's own mixed-
+ * precision quantizers still pick for particular tensor roles even in an
+ * otherwise K-quant checkpoint), and MXFP4 (gpt-oss's native MoE-expert
  * quantization) -- are hydrated as ordinary float32, via
  * HydrateTensorProtoFromGGUF's decode --
  * ImportModelWithGGUF is the intended way to pull a third-party GGUF

--- a/onnxsim/tensor_pool_gguf_bridge_test.cpp
+++ b/onnxsim/tensor_pool_gguf_bridge_test.cpp
@@ -253,7 +253,7 @@ void TestImportModelWithGGUFLazy() {
   std::remove(path.c_str());
 }
 
-// Hand-builds a GGUF file with one raw F32 tensor ("w1") and one Q3_K
+// Hand-builds a GGUF file with one raw F32 tensor ("w1") and one Q8_K
 // (quantized, unsupported -- deliberately NOT one of IsKQuant/IsLegacyQuant/
 // IsMxfp4's covered types) tensor ("w2"), then imports it against a model
 // declaring both as initializers -- the scenario a real quantized-LLM
@@ -280,7 +280,7 @@ void TestImportModelWithGGUFSkipsQuantized() {
     write_string("w2");
     WriteLE<uint32_t>(out, 1);
     WriteLE<uint64_t>(out, 32);  // ne[0]
-    WriteLE<uint32_t>(out, 11);  // GGML_TYPE_Q3_K
+    WriteLE<uint32_t>(out, 15);  // GGML_TYPE_Q8_K
     WriteLE<uint64_t>(out, kDefaultAlignment);
 
     uint64_t header_end = static_cast<uint64_t>(out.tellp());

--- a/onnxsim/tensor_pool_gguf_test.cpp
+++ b/onnxsim/tensor_pool_gguf_test.cpp
@@ -140,8 +140,8 @@ void TestAlignmentPadding() {
 }
 
 // Writes a minimal, hand-built GGUF v3 file with one raw F32 tensor and one
-// tensor of a quantized ggml_type this pool cannot represent (id 11 ==
-// GGML_TYPE_Q3_K -- a real GGML type, deliberately NOT one of IsKQuant/
+// tensor of a quantized ggml_type this pool cannot represent (id 15 ==
+// GGML_TYPE_Q8_K -- a real GGML type, deliberately NOT one of IsKQuant/
 // IsLegacyQuant/IsMxfp4's covered types), to exercise LoadGGUF's
 // skip-and-report path -- the case that matters most in practice, since a
 // real quantized LLM's .gguf is mostly tensors like this.
@@ -166,13 +166,13 @@ void TestSkipsUnsupportedDtype() {
     WriteLE<uint32_t>(out, GGML_TYPE_F32);  // type
     WriteLE<uint64_t>(out, 0);              // offset
 
-    // Tensor 1: "quant", ggml_type 11 (Q3_K), ne=[32] -- offset chosen past
+    // Tensor 1: "quant", ggml_type 15 (Q8_K), ne=[32] -- offset chosen past
     // 'raw's aligned 32-byte slot. This test never decodes its bytes (can't
     // -- that's the whole point), so the payload content doesn't matter.
     write_string("quant");
     WriteLE<uint32_t>(out, 1);                  // n_dimensions
     WriteLE<uint64_t>(out, 32);                 // ne[0]
-    WriteLE<uint32_t>(out, 11);                 // GGML_TYPE_Q3_K
+    WriteLE<uint32_t>(out, 15);                 // GGML_TYPE_Q8_K
     WriteLE<uint64_t>(out, kDefaultAlignment);  // offset (aligned)
 
     // Pad to the data section (header ends right here; align up to 32).
@@ -295,7 +295,7 @@ void TestLoadGGUFMmapSkipsUnsupportedDtype() {
     write_string("quant");
     WriteLE<uint32_t>(out, 1);
     WriteLE<uint64_t>(out, 32);
-    WriteLE<uint32_t>(out, 11);  // GGML_TYPE_Q3_K
+    WriteLE<uint32_t>(out, 15);  // GGML_TYPE_Q8_K
     WriteLE<uint64_t>(out, kDefaultAlignment);
 
     uint64_t header_end = static_cast<uint64_t>(out.tellp());

--- a/tests/test_import_gguf_weights.py
+++ b/tests/test_import_gguf_weights.py
@@ -4,8 +4,8 @@ Unlike ``import_gguf``, this needs no embedded onnxsim model, and is the
 intended way to bring a third-party GGUF's weight *values* into a graph you
 already have.
 
-Covers the GGML "K-quant" block formats (Q8_0, Q4_K, Q5_K, Q6_K) real
-quantized checkpoints (e.g. Unsloth's GGUF exports) actually use for the
+Covers the GGML "K-quant" block formats (Q2_K, Q3_K, Q4_K, Q5_K, Q6_K, Q8_0)
+real quantized checkpoints (e.g. Unsloth's GGUF exports) actually use for the
 bulk of their weights; the legacy family (Q4_0, Q4_1, Q5_0, Q5_1) llama.cpp's
 own mixed-precision quantizers still pick for particular tensor roles even
 in an otherwise K-quant checkpoint (confirmed empirically against several
@@ -36,6 +36,8 @@ GGUF_VERSION = 3
 # ggml_type codes this suite constructs (see onnxsim/gguf_dtype.h).
 GGML_TYPE_F32 = 0
 GGML_TYPE_Q8_0 = 8
+GGML_TYPE_Q2_K = 10
+GGML_TYPE_Q3_K = 11
 GGML_TYPE_Q4_K = 12
 GGML_TYPE_Q5_K = 13
 GGML_TYPE_Q6_K = 14
@@ -44,7 +46,7 @@ GGML_TYPE_Q4_0 = 2
 GGML_TYPE_Q4_1 = 3
 GGML_TYPE_Q5_0 = 6
 GGML_TYPE_Q5_1 = 7
-GGML_TYPE_Q3_K = 11  # NOT decoded by onnxsim -- must be skipped
+GGML_TYPE_Q8_K = 15  # NOT decoded by onnxsim -- must be skipped
 
 
 def _align_up(n, align=32):
@@ -101,6 +103,107 @@ def _make_q8_0_block(rng):
     d_bits = _f16_bits(d)
     raw = struct.pack("<H", d_bits) + bytes(q & 0xFF for q in qs)
     expected = [q * _f16_to_f32(d_bits) for q in qs]
+    return raw, expected
+
+
+def _make_q2_k_block(rng):
+    # One 256-element Q2_K super-block: 16 bytes of packed 4-bit (scale, min)
+    # pairs (one pair per 16-element sub-block), 64 bytes of packed 2-bit
+    # quant codes, then two fp16 super-block scales (d, dmin) -- transcribed
+    # directly from ggml-quants.c's dequantize_row_q2_K.
+    d = round(float(rng.uniform(0.01, 2.0)), 4)
+    dmin = round(float(rng.uniform(0.01, 1.0)), 4)
+    d_bits, dmin_bits = _f16_bits(d), _f16_bits(dmin)
+    scales = [int(rng.integers(0, 256)) for _ in range(16)]
+    qs = [int(rng.integers(0, 256)) for _ in range(64)]
+    raw = bytes(scales) + bytes(qs) + struct.pack("<HH", d_bits, dmin_bits)
+
+    d_f, dmin_f = _f16_to_f32(d_bits), _f16_to_f32(dmin_bits)
+    expected = [0.0] * 256
+    is_, y = 0, 0
+    q_off = 0
+    for _n in range(0, 256, 128):
+        shift = 0
+        for _j in range(4):
+            sc = scales[is_]
+            is_ += 1
+            dl, ml = d_f * (sc & 0xF), dmin_f * (sc >> 4)
+            for idx in range(16):
+                expected[y] = dl * ((qs[q_off + idx] >> shift) & 3) - ml
+                y += 1
+            sc = scales[is_]
+            is_ += 1
+            dl, ml = d_f * (sc & 0xF), dmin_f * (sc >> 4)
+            for idx in range(16):
+                expected[y] = dl * ((qs[q_off + 16 + idx] >> shift) & 3) - ml
+                y += 1
+            shift += 2
+        q_off += 32
+    return raw, expected
+
+
+def _unpack_q3k_scales(scales12):
+    # Unpacks Q3_K's 12-byte packed-6-bit scale table into 16 signed values
+    # (still offset by +32, matching GGML's own `scales[is++] - 32` step) --
+    # transcribed directly from ggml-quants.c's dequantize_row_q3_K, reading
+    # each 4-byte word explicitly little-endian rather than via GGML's own
+    # (little-endian-host-only) `memcpy` onto a native `uint32_t[3]` -- see
+    # onnxsim/ggml_kquant.h's file comment for why that distinction matters.
+    def le32(b):
+        return b[0] | (b[1] << 8) | (b[2] << 16) | (b[3] << 24)
+
+    aux = [le32(scales12[0:4]), le32(scales12[4:8]), le32(scales12[8:12]), 0]
+    kmask1, kmask2 = 0x03030303, 0x0F0F0F0F
+    tmp = aux[2]
+    new0 = (aux[0] & kmask2) | (((tmp >> 0) & kmask1) << 4)
+    new1 = (aux[1] & kmask2) | (((tmp >> 2) & kmask1) << 4)
+    new2 = ((aux[0] >> 4) & kmask2) | (((tmp >> 4) & kmask1) << 4)
+    new3 = ((aux[1] >> 4) & kmask2) | (((tmp >> 6) & kmask1) << 4)
+    aux = [new0 & 0xFFFFFFFF, new1 & 0xFFFFFFFF, new2 & 0xFFFFFFFF, new3 & 0xFFFFFFFF]
+    out = []
+    for k in range(16):
+        byte = (aux[k // 4] >> (8 * (k % 4))) & 0xFF
+        out.append(byte - 256 if byte >= 128 else byte)
+    return out
+
+
+def _make_q3_k_block(rng):
+    # One 256-element Q3_K super-block: a 32-byte high-bit mask, 64 bytes of
+    # packed 2-bit low quant codes, a 12-byte packed-6-bit scale table, then
+    # one fp16 super-block scale -- transcribed directly from
+    # ggml-quants.c's dequantize_row_q3_K.
+    d = round(float(rng.uniform(0.01, 2.0)), 4)
+    d_bits = _f16_bits(d)
+    hmask = [int(rng.integers(0, 256)) for _ in range(32)]
+    qs = [int(rng.integers(0, 256)) for _ in range(64)]
+    scales12 = bytes(int(rng.integers(0, 256)) for _ in range(12))
+    raw = bytes(hmask) + bytes(qs) + scales12 + struct.pack("<H", d_bits)
+
+    d_f = _f16_to_f32(d_bits)
+    scales = _unpack_q3k_scales(scales12)
+    expected = [0.0] * 256
+    is_, y, m = 0, 0, 1
+    q_off = 0
+    for _n in range(0, 256, 128):
+        shift = 0
+        for _j in range(4):
+            dl = d_f * (scales[is_] - 32)
+            is_ += 1
+            for idx in range(16):
+                low = (qs[q_off + idx] >> shift) & 3
+                bit = hmask[idx] & m
+                expected[y] = dl * (low - (0 if bit else 4))
+                y += 1
+            dl = d_f * (scales[is_] - 32)
+            is_ += 1
+            for idx in range(16):
+                low = (qs[q_off + 16 + idx] >> shift) & 3
+                bit = hmask[idx + 16] & m
+                expected[y] = dl * (low - (0 if bit else 4))
+                y += 1
+            shift += 2
+            m = (m << 1) & 0xFF
+        q_off += 32
     return raw, expected
 
 
@@ -303,6 +406,38 @@ def test_import_q8_0_weights(tmp_path):
     np.testing.assert_allclose(got, np.array(expected, dtype=np.float32), rtol=1e-5)
 
 
+def test_import_q2_k_weights(tmp_path):
+    rng = np.random.default_rng(11)
+    raw, expected = _make_q2_k_block(rng)
+    gguf_path = str(tmp_path / "model.gguf")
+    _write_gguf(gguf_path, [("W", GGML_TYPE_Q2_K, [256], raw)])
+
+    model = _identity_model("W", [256])
+    result, skipped = onnxsim.import_gguf_weights(model, gguf_path)
+
+    assert skipped == []
+    w = next(i for i in result.graph.initializer if i.name == "W")
+    assert w.data_type == onnx.TensorProto.FLOAT
+    got = onnx.numpy_helper.to_array(w)
+    np.testing.assert_allclose(got, np.array(expected, dtype=np.float32), rtol=1e-5)
+
+
+def test_import_q3_k_weights(tmp_path):
+    rng = np.random.default_rng(12)
+    raw, expected = _make_q3_k_block(rng)
+    gguf_path = str(tmp_path / "model.gguf")
+    _write_gguf(gguf_path, [("W", GGML_TYPE_Q3_K, [256], raw)])
+
+    model = _identity_model("W", [256])
+    result, skipped = onnxsim.import_gguf_weights(model, gguf_path)
+
+    assert skipped == []
+    w = next(i for i in result.graph.initializer if i.name == "W")
+    assert w.data_type == onnx.TensorProto.FLOAT
+    got = onnx.numpy_helper.to_array(w)
+    np.testing.assert_allclose(got, np.array(expected, dtype=np.float32), rtol=1e-5)
+
+
 def test_import_q4_k_weights(tmp_path):
     rng = np.random.default_rng(1)
     raw, expected = _make_q4_k_block(rng)
@@ -427,7 +562,7 @@ def test_import_skips_unmatched_and_unsupported(tmp_path):
     rng = np.random.default_rng(3)
     raw, _ = _make_q8_0_block(rng)
     gguf_path = str(tmp_path / "model.gguf")
-    # Q3_K is not decoded by onnxsim at all, so its exact byte count doesn't
+    # Q8_K is not decoded by onnxsim at all, so its exact byte count doesn't
     # matter here (this tensor's bytes are never read) -- picked because
     # it's the last tensor in this file, so nothing after it needs locating.
     unsupported_raw = b"\x00" * 110
@@ -436,7 +571,7 @@ def test_import_skips_unmatched_and_unsupported(tmp_path):
         [
             ("W", GGML_TYPE_Q8_0, [32], raw),
             ("not_in_graph", GGML_TYPE_Q8_0, [32], raw),
-            ("unsupported", GGML_TYPE_Q3_K, [256], unsupported_raw),
+            ("unsupported", GGML_TYPE_Q8_K, [256], unsupported_raw),
         ],
     )
 


### PR DESCRIPTION
## Summary

- Re-validating the merged legacy-quant work (#953) against real `unsloth/gpt-oss-20b-GGUF` headers (fetched via HTTP range request, no full download) showed the two smallest quantizations, `Q2_K` and `Q3_K_M`, still failed to fully import: they mix in `Q2_K`/`Q3_K` tensors themselves for `token_embd`/`attn_q`/`attn_k`/`attn_v` — unsurprising given their names, but until now those two K-quant types were the only remaining gap in this decoder.
- Adds `Q2_K` (16-byte packed 4-bit scale/min table + 64 bytes of packed 2-bit codes) and `Q3_K` (32-byte high-bit mask + 64 bytes of packed 2-bit low codes + 12-byte packed 6-bit scale table) decode to `onnxsim/ggml_kquant.h`, folded into `IsKQuant` alongside the existing `Q4_K`/`Q5_K`/`Q6_K`/`Q8_0` members since they share the same super-block design (K-quant is now feature-complete for its 6 member types).
- `Q3_K` needed one extra layer of care: GGML's own reference unpacks its 12-byte packed-6-bit scale table by `memcpy`-ing it onto a native `uint32_t[3]` and bit-twiddling those words directly — correct only on a little-endian host (GGML itself has no big-endian handling for this at all). `UnpackQ3KScales` reproduces the identical bit-twiddling arithmetic but starting from explicit little-endian word reads/byte extraction, so it decodes correctly on a big-endian host too (this repo tests on s390x). Verified bit-for-bit equivalent to the reference over 2000 random scale tables via an independent Python re-implementation before being committed.
- Every block layout/formula was transcribed directly from GGML's own `ggml-common.h`/`ggml-quants.c` (fetched fresh from `ggml-org/ggml` on GitHub) and cross-checked against an independent from-scratch Python re-implementation over 300 full random blocks per type (153,600 elements total) — 0 mismatches.
- Re-validated against the real checkpoint headers after implementing: `Q2_K` and `Q3_K_M` now decode every tensor except their `IQ4_NL` ones (an importance-matrix format, still out of scope) — confirmed by re-fetching and re-checking each header's per-tensor `ggml_type` histogram.
- Fixes three tests that used `Q3_K` as their "definitely unsupported" example tensor (from #953, before this PR made `Q3_K` supported) — switched all three to `Q8_K`, a real GGML type still genuinely outside this decoder's scope.
- Updates `docs/import-gguf-weights.md` to describe the completed K-quant family and the real-world validation results.

## Test plan

- [x] Extended `onnxsim/ggml_kquant_test.cpp` with hand-verified `TestQ2_K`/`TestQ3_K`/`TestUnpackQ3KScales` vectors, plus a standalone fuzz cross-check (300 random blocks per type against an independent Python reference; not checked in, run manually during development) — 0 mismatches across 153,600 elements.
- [x] Extended `onnxsim/gguf_dtype_test.cpp`'s `k_quant_rows` table with `Q2_K`/`Q3_K` rows; removed them from the "unsupported quantized type" rejection list.
- [x] Extended `tests/test_import_gguf_weights.py` with `test_import_q2_k_weights`/`test_import_q3_k_weights`, each building byte-accurate GGUF blocks with an independent Python-side dequant formula (including the `Q3_K` scale-table unpacking).
- [x] Full `ctest` — 19/19 passed.
- [x] Full `CI=true python3 -m pytest tests/ -q --ignore=tests/test_timm.py` — 1422 passed, 77 skipped.
- [x] `ruff check` / `ruff format --diff` / `mypy` clean on touched Python files.
- [x] `clang-format --dry-run --Werror` clean on all touched C++ files.
- [x] No `CMakeLists.txt`/s390x build-script changes needed — `Q2_K`/`Q3_K` extend the already-registered `ggml_kquant_test` binary rather than adding a new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153LP27pjLXDEFX5vrhHvNk


---
_Generated by [Claude Code](https://claude.ai/code/session_0153LP27pjLXDEFX5vrhHvNk)_