### PR TITLE
Add fuse_matmul_into_conv: MatMul/Gemm -> Conv for conv-optimized accelerators

### DIFF
--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -33,6 +33,7 @@
 #include "passes/fuse_layer_norm.h"
 #include "passes/fuse_matmul_add_bias_into_gemm.h"
 #include "passes/fuse_matmul_add_bias_into_gemm_batched.h"
+#include "passes/fuse_matmul_into_conv.h"
 #include "passes/fuse_mul_into_conv.h"
 #include "passes/fuse_pad_into_pool.h"
 #include "passes/fuse_preceding_mul_into_conv.h"
@@ -121,6 +122,7 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::FuseGQA>(registry);
     RegisterOrReplace<p::FuseLayerNorm>(registry);
     RegisterOrReplace<p::FuseMatMulAddBiasIntoGemmBatched>(registry);
+    RegisterOrReplace<p::FuseMatMulIntoConv>(registry);
     RegisterOrReplace<p::FuseMulIntoConv>(registry);
     RegisterOrReplace<p::FusePrecedingMulIntoConv>(registry);
     RegisterOrReplace<p::FuseRMSNorm>(registry);

--- a/onnxsim/custom_optimizer_passes.h
+++ b/onnxsim/custom_optimizer_passes.h
@@ -21,6 +21,7 @@ namespace onnxsim {
 //   - fuse_preceding_mul_into_conv
 //   - fuse_consecutive_mul
 //   - fuse_matmul_add_bias_into_gemm_batched
+//   - fuse_matmul_into_conv
 //   - eliminate_reshape_around_elementwise
 //   - fuse_rms_norm
 //   - fuse_rope

--- a/onnxsim/passes/fuse_matmul_into_conv.h
+++ b/onnxsim/passes/fuse_matmul_into_conv.h
@@ -1,0 +1,413 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+// Before (one of):
+//   Y = MatMul(X, W)                        // W: constant 2-D [K, N]
+//   Z = MatMul(X, W) + B                    // B: constant, broadcastable
+//                                            //    over the N axis
+//   Z = Gemm(X, W[, B], transA=0, alpha=1[, beta=1])
+//                                            // W: constant 2-D, [K, N]
+//                                            //    (transB=0) or [N, K]
+//                                            //    (transB=1)
+// After:
+//   X2 = Reshape(X, [-1, K, 1])
+//   W2 = Transpose/Unsqueeze(W) -> [N, K, 1]
+//   C  = Conv(X2, W2[, B'])                 // a 1-D, 1x1-kernel convolution
+//   Z  = Reshape(C, [d0, ..., d_{r-2}, N])
+//
+// X may have any rank >= 2; only its last (contracted) axis needs a static
+// size K. Every leading dim collapses into Conv's batch axis and is restored
+// by the trailing Reshape -- the same leading-dims-to-a-single-axis
+// scaffolding ``fuse_matmul_add_bias_into_gemm_batched`` uses to turn a
+// batched MatMul into a 2-D Gemm, except the target here is a 1x1 Conv, not
+// a Gemm.
+//
+// Rationale: some accelerators (embedded/mobile NPUs and DSPs among them)
+// ship a heavily tuned, general-purpose Conv datapath but a much weaker (or
+// altogether unaccelerated) generic MatMul/Gemm one. Every "Linear" layer
+// (nn.Linear, a Transformer's QKV/output projections and FFN, a CNN's final
+// classifier head after global pooling, ...) is mathematically a 1x1
+// convolution once its activation is reshaped to put the contracted axis on
+// the channel dimension, so rewriting it that way lets such backends keep
+// the whole network on their fast Conv engine instead of falling back to a
+// slow (or CPU) path for every Linear layer.
+//
+// This is a graph-shape rewrite, not a node-count reduction, and is a
+// *regression* on a MatMul/Gemm-first backend -- so, like
+// ``fuse_matmul_add_bias_into_gemm_batched``, it is registered as
+// PassType::Other (opt-in only, via ``extra_optimizers``), not part of the
+// default fuse set.
+//
+// Only ``transA=0`` and ``alpha=1``/``beta=1`` Gemm is handled -- the shape a
+// plain ``nn.Linear`` export (or onnxsim's own
+// ``fuse_matmul_add_bias_into_gemm``/``_batched``) always produces. Any
+// other Gemm is left untouched rather than taught to rescale the folded
+// weight/bias for an alpha/beta that essentially never occurs in practice.
+// A MatMul whose sole use is an Add this same pass could otherwise fuse the
+// bias from defers to that Add match instead of racing it, so the bias ends
+// up folded into the Conv directly rather than left behind as a trailing
+// Add the rewritten (rank >= 3) Conv output can no longer broadcast against
+// in the usual per-channel way.
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+// onnxsim's own passes live in this nested namespace so their class
+// names never collide (ODR) with the same-named passes compiled into
+// onnxoptimizer; RegisterOrReplace still keys them by getPassName().
+namespace onnxsim_passes {
+
+struct FuseMatMulIntoConv final : public PredicateBasedPass {
+  explicit FuseMatMulIntoConv()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+  std::string getPassName() const override { return "fuse_matmul_into_conv"; }
+
+  // This pass instance is reused across every round of onnxsim's
+  // simplification fixed point, but a batch of reserved names is only valid
+  // for the graph state it was reserved against -- other passes/rounds can
+  // introduce new names in between. Drop any leftover reservation from a
+  // prior runPass() call so nextReservedName() always reserves fresh against
+  // the current graph (mirrors fuse_matmul_add_bias_into_gemm_batched's own
+  // initializePass, same rationale).
+  bool initializePass(Graph&) override {
+    reserved_names_.clear();
+    reserved_used_ = 0;
+    return false;
+  }
+
+  static Value* MakeInt64Constant(Graph& graph, std::vector<int64_t> data,
+                                  std::string name) {
+    Tensor t;
+    t.setName(std::move(name));
+    t.sizes().push_back(static_cast<int64_t>(data.size()));
+    t.elem_type() = TensorProto_DataType_INT64;
+    t.int64s() = std::move(data);
+    return graph.addInitializerAndCreateValue(std::move(t));
+  }
+
+  // The pieces of a MatMul/Gemm-shaped Linear layer this pass rewrites.
+  struct Match {
+    bool ok = false;
+    Value* x = nullptr;     // activation, rank >= 2, static last dim K
+    Value* w = nullptr;     // constant weight, 2-D
+    bool w_is_n_k = false;  // true: w is laid out [N, K] (Gemm transB=1);
+                            // false: w is laid out [K, N] (MatMul, or Gemm
+                            // transB=0)
+    Value* bias = nullptr;  // constant, rank <= 1, may be null
+    int64_t k = 0;
+    int64_t n = 0;
+  };
+
+  static Match MatchNode(Node* node) {
+    Match m;
+    Node* mm = nullptr;
+    Value* bias = nullptr;
+
+    if (node->kind() == kAdd && node->inputs().size() == 2) {
+      // Add is commutative, so the MatMul may be either operand. Exporters
+      // differ: HuggingFace linear layers emit ``Add(bias, MatMul(x, W))``
+      // (MatMul second).
+      int mm_idx = -1;
+      for (int i = 0; i < 2; ++i) {
+        if (CheckKind(node->input(i), kMatMul) &&
+            node->input(i)->uses().size() == 1) {
+          mm_idx = i;
+          break;
+        }
+      }
+      if (mm_idx < 0) {
+        return m;
+      }
+      mm = node->input(mm_idx)->node();
+      bias = node->input(1 - mm_idx);
+    } else if (node->kind() == kMatMul) {
+      // Defer to the Add case above when this MatMul's only use is an Add
+      // this pass would rather fuse the bias from directly -- converting the
+      // bare MatMul first would leave that Add stranded after a Conv whose
+      // rank (>= 3, batch/channel/spatial) it can no longer broadcast a
+      // plain [N] bias against the way it could against a 2-D Gemm.
+      Value* out = node->output();
+      if (out->uses().size() == 1) {
+        Node* use = out->uses()[0].user;
+        if (use->kind() == kAdd && MatchNode(use).ok) {
+          return m;
+        }
+      }
+      mm = node;
+    } else if (node->kind() == kGemm) {
+      const int64_t trans_a =
+          GetValueFromAttrWithDefault(node, ktransA, int64_t(0));
+      const double alpha = GetValueFromAttrWithDefault(node, kalpha, 1.0);
+      if (trans_a != 0 || alpha != 1.0) {
+        return m;
+      }
+      mm = node;
+    } else {
+      return m;
+    }
+
+    Value* x = mm->input(0);
+    Value* w = mm->input(1);
+    bool w_is_n_k = false;
+    if (mm->kind() == kGemm) {
+      const int64_t trans_b =
+          GetValueFromAttrWithDefault(mm, ktransB, int64_t(0));
+      w_is_n_k = trans_b != 0;
+      if (mm->inputs().size() == 3) {
+        const double beta = GetValueFromAttrWithDefault(mm, kbeta, 1.0);
+        if (beta != 1.0) {
+          return m;
+        }
+        bias = mm->input(2);
+      }
+    }
+
+    if (!x->has_sizes()) {
+      return m;
+    }
+    const auto& x_shape = x->sizes();
+    if (x_shape.size() < 2 || !x_shape.back().is_int) {
+      return m;
+    }
+    const int64_t k = x_shape.back().dim;
+
+    if (!IsConstantTensor(w) || !w->has_sizes()) {
+      return m;
+    }
+    const auto& w_shape = w->sizes();
+    if (w_shape.size() != 2 || !w_shape[0].is_int || !w_shape[1].is_int) {
+      return m;
+    }
+    int64_t n_out;
+    if (w_is_n_k) {
+      if (w_shape[1].dim != k) {
+        return m;
+      }
+      n_out = w_shape[0].dim;
+    } else {
+      if (w_shape[0].dim != k) {
+        return m;
+      }
+      n_out = w_shape[1].dim;
+    }
+
+    if (bias != nullptr) {
+      if (!IsConstantTensor(bias) || !bias->has_sizes()) {
+        return m;
+      }
+      const auto& b_shape = bias->sizes();
+      if (b_shape.size() > 1) {
+        return m;
+      }
+      if (b_shape.size() == 1) {
+        if (!b_shape[0].is_int) {
+          return m;
+        }
+        if (b_shape[0].dim != n_out && b_shape[0].dim != 1) {
+          return m;
+        }
+      }
+    }
+
+    // Dynamic leading dims need Shape/Slice, i.e. opset >= 10 (mirrors
+    // fuse_matmul_add_bias_into_gemm_batched's own guard).
+    bool leading_static = true;
+    for (size_t i = 0; i + 1 < x_shape.size(); ++i) {
+      leading_static &= x_shape[i].is_int;
+    }
+    if (!leading_static) {
+      const int opset = getOpsetVersion(*node->owningGraph());
+      if (opset != 0 && opset < 10) {
+        return m;
+      }
+    }
+
+    m.ok = true;
+    m.x = x;
+    m.w = w;
+    m.w_is_n_k = w_is_n_k;
+    m.bias = bias;
+    m.k = k;
+    m.n = n_out;
+    return m;
+  }
+
+  bool patternMatchPredicate(Node* n) override { return MatchNode(n).ok; }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+    const Match match = MatchNode(n);
+    if (!match.ok) {
+      return false;
+    }
+
+    const auto& x_shape = match.x->sizes();
+    const int64_t rank = static_cast<int64_t>(x_shape.size());
+
+    // X2 = Reshape(X, [-1, K, 1])
+    Node* pre = graph.create(kReshape, 1);
+    pre->addInput(match.x);
+    pre->addInput(MakeInt64Constant(graph, {-1, match.k, 1},
+                                    nextReservedName(graph)));
+    pre->insertBefore(n);
+
+    // W2 = [N, K, 1], built from W by Transpose (if laid out [K, N]) then
+    // Unsqueeze. Both operate on a constant, so the constant folder
+    // materializes W2 as a plain initializer (fuse_mul_into_conv's own
+    // weight-folding convention).
+    Value* w2 = match.w;
+    if (!match.w_is_n_k) {
+      Node* transpose = graph.create(kTranspose, 1);
+      transpose->addInput(w2);
+      transpose->is_(kperm, std::vector<int64_t>{1, 0});
+      transpose->insertBefore(n);
+      w2 = transpose->output();
+    }
+    {
+      Node* unsqueeze = graph.create(kUnsqueeze, 1);
+      unsqueeze->addInput(w2);
+      const int opset = getOpsetVersion(graph);
+      const std::vector<int64_t> axes{2};
+      if (opset < 13 && opset != 0) {
+        unsqueeze->is_(kaxes, axes);
+      } else {
+        unsqueeze->addInput(
+            MakeInt64Constant(graph, axes, nextReservedName(graph)));
+      }
+      unsqueeze->insertBefore(n);
+      w2 = unsqueeze->output();
+    }
+
+    // Bias, if present, must end up as an exact 1-D [N] Conv bias (Conv's own
+    // B input has no broadcasting rules of its own, unlike Add).
+    Value* bias = nullptr;
+    if (match.bias != nullptr) {
+      bias = match.bias;
+      const auto& b_shape = bias->sizes();
+      const int64_t bias_numel = b_shape.size() == 0 ? 1 : b_shape[0].dim;
+      if (b_shape.size() == 0) {
+        Node* reshape = graph.create(kReshape, 1);
+        reshape->addInput(bias);
+        reshape->addInput(
+            MakeInt64Constant(graph, {1}, nextReservedName(graph)));
+        reshape->insertBefore(n);
+        bias = reshape->output();
+      }
+      if (bias_numel != match.n) {
+        Node* expand = graph.create(kExpand, 1);
+        expand->addInput(bias);
+        expand->addInput(
+            MakeInt64Constant(graph, {match.n}, nextReservedName(graph)));
+        expand->insertBefore(n);
+        bias = expand->output();
+      }
+    }
+
+    // C = Conv(X2, W2[, bias]) -- kernel_shape/strides/pads/dilations/group
+    // are all left at their defaults ([1]/[1]/[0,0]/[1]/1), which Conv's own
+    // shape inference derives from W2's shape when unset.
+    Node* conv = graph.create(kConv, 1);
+    conv->addInput(pre->output());
+    conv->addInput(w2);
+    if (bias != nullptr) {
+      conv->addInput(bias);
+    }
+    conv->insertBefore(n);
+
+    // Reconstruct the output shape [d0, ..., d_{r-2}, N].
+    bool leading_static = true;
+    std::vector<int64_t> leading_dims;
+    for (int64_t i = 0; i + 1 < rank; ++i) {
+      leading_static &= x_shape[i].is_int;
+      if (x_shape[i].is_int) {
+        leading_dims.push_back(x_shape[i].dim);
+      }
+    }
+
+    Node* post = graph.create(kReshape, n->outputs().size());
+    post->addInput(conv->output());
+
+    if (leading_static) {
+      std::vector<int64_t> out_shape = leading_dims;
+      out_shape.push_back(match.n);
+      post->addInput(MakeInt64Constant(graph, std::move(out_shape),
+                                       nextReservedName(graph)));
+    } else {
+      // shape(X) -> slice off the last dim -> concat with [N]
+      Node* shape = graph.create(Symbol("Shape"), 1);
+      shape->addInput(match.x);
+      shape->insertBefore(n);
+
+      Node* slice = graph.create(kSlice, 1);
+      slice->addInput(shape->output());
+      slice->addInput(
+          MakeInt64Constant(graph, {0}, nextReservedName(graph)));  // starts
+      slice->addInput(MakeInt64Constant(graph, {rank - 1},
+                                        nextReservedName(graph)));  // ends
+      slice->addInput(
+          MakeInt64Constant(graph, {0}, nextReservedName(graph)));  // axes
+      slice->insertBefore(n);
+
+      Node* concat = graph.create(kConcat, 1);
+      concat->addInput(slice->output());
+      concat->addInput(
+          MakeInt64Constant(graph, {match.n}, nextReservedName(graph)));
+      concat->i_(kaxis, 0);
+      concat->insertBefore(n);
+
+      post->addInput(concat->output());
+    }
+
+    for (int i = 0; i < static_cast<int>(n->outputs().size()); ++i) {
+      post->outputs()[i]->copyMetadata(n->outputs()[i]);
+    }
+    post->insertBefore(n);
+
+    if (!tryReplacingAllUsesWith(n, post)) {
+      return false;
+    }
+    // Destroy n (the Add, the bare MatMul, or the Gemm); if n was an Add,
+    // the now-dead MatMul underneath it is cleaned up by DCE.
+    destroy_current = NodeDestroyType::DestroyOne;
+    return true;
+  }
+
+ private:
+  // Each match mints several fresh initializer names (the pre-reshape's
+  // shape, the weight-transform's axes/unsqueeze constant, optionally the
+  // bias-expand shape, plus either the post-reshape's shape or -- on the
+  // dynamic-leading-dims path -- Slice's starts/ends/axes and Concat's [N]).
+  // Same batching fix as fuse_matmul_add_bias_into_gemm_batched (see its own
+  // comment on this exact mechanism, and onnxsim issue #651): draw from a
+  // batch reserved via Graph::reserveUniqueNames() (one scan per batch)
+  // instead of paying a full graph scan per name via
+  // Graph::addInitializerAndCreateValue -> getNextUniqueName().
+  static constexpr size_t kNameBatchSize = 256;
+  std::vector<std::string> reserved_names_;
+  size_t reserved_used_ = 0;
+
+  std::string nextReservedName(Graph& graph) {
+    if (reserved_used_ >= reserved_names_.size()) {
+      reserved_names_ = graph.reserveUniqueNames(kNameBatchSize);
+      reserved_used_ = 0;
+    }
+    return std::move(reserved_names_[reserved_used_++]);
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/fuse_matmul_into_conv.h
+++ b/onnxsim/passes/fuse_matmul_into_conv.h
@@ -280,9 +280,9 @@ struct FuseMatMulIntoConv final : public PredicateBasedPass {
       Node* unsqueeze = graph.create(kUnsqueeze, 1);
       unsqueeze->addInput(w2);
       const int opset = getOpsetVersion(graph);
-      const std::vector<int64_t> axes{2};
+      std::vector<int64_t> axes{2};
       if (opset < 13 && opset != 0) {
-        unsqueeze->is_(kaxes, axes);
+        unsqueeze->is_(kaxes, std::move(axes));
       } else {
         unsqueeze->addInput(
             MakeInt64Constant(graph, axes, nextReservedName(graph)));

--- a/onnxsim/passes/fuse_matmul_into_conv.h
+++ b/onnxsim/passes/fuse_matmul_into_conv.h
@@ -260,8 +260,8 @@ struct FuseMatMulIntoConv final : public PredicateBasedPass {
     // X2 = Reshape(X, [-1, K, 1])
     Node* pre = graph.create(kReshape, 1);
     pre->addInput(match.x);
-    pre->addInput(MakeInt64Constant(graph, {-1, match.k, 1},
-                                    nextReservedName(graph)));
+    pre->addInput(
+        MakeInt64Constant(graph, {-1, match.k, 1}, nextReservedName(graph)));
     pre->insertBefore(n);
 
     // W2 = [N, K, 1], built from W by Transpose (if laid out [K, N]) then

--- a/onnxsim/passes/fuse_matmul_into_conv.h
+++ b/onnxsim/passes/fuse_matmul_into_conv.h
@@ -9,22 +9,20 @@
 //   Y = MatMul(X, W)                        // W: constant 2-D [K, N]
 //   Z = MatMul(X, W) + B                    // B: constant, broadcastable
 //                                            //    over the N axis
-//   Z = Gemm(X, W[, B], transA=0, alpha=1[, beta=1])
-//                                            // W: constant 2-D, [K, N]
-//                                            //    (transB=0) or [N, K]
-//                                            //    (transB=1)
+//   Z = Gemm(X, W[, B], transA, transB, alpha=1[, beta=1])
+//                                            // W: constant 2-D
 // After:
-//   X2 = Reshape(X, [-1, K, 1])
-//   W2 = Transpose/Unsqueeze(W) -> [N, K, 1]
+//   X2 = Reshape(Transpose(X) if transA, [-1, K, 1])
+//   W2 = Transpose(Transpose(W) if transB) -> [N, K, 1] (+ Unsqueeze)
 //   C  = Conv(X2, W2[, B'])                 // a 1-D, 1x1-kernel convolution
 //   Z  = Reshape(C, [d0, ..., d_{r-2}, N])
 //
-// X may have any rank >= 2; only its last (contracted) axis needs a static
-// size K. Every leading dim collapses into Conv's batch axis and is restored
-// by the trailing Reshape -- the same leading-dims-to-a-single-axis
-// scaffolding ``fuse_matmul_add_bias_into_gemm_batched`` uses to turn a
-// batched MatMul into a 2-D Gemm, except the target here is a 1x1 Conv, not
-// a Gemm.
+// X may have any rank >= 2 (Gemm's is always exactly 2); only its last
+// (contracted, or first if transA) axis needs a static size K. Every leading
+// dim collapses into Conv's batch axis and is restored by the trailing
+// Reshape -- the same leading-dims-to-a-single-axis scaffolding
+// ``fuse_matmul_add_bias_into_gemm_batched`` uses to turn a batched MatMul
+// into a 2-D Gemm, except the target here is a 1x1 Conv, not a Gemm.
 //
 // Rationale: some accelerators (embedded/mobile NPUs and DSPs among them)
 // ship a heavily tuned, general-purpose Conv datapath but a much weaker (or
@@ -42,8 +40,24 @@
 // PassType::Other (opt-in only, via ``extra_optimizers``), not part of the
 // default fuse set.
 //
-// Only ``transA=0`` and ``alpha=1``/``beta=1`` Gemm is handled -- the shape a
-// plain ``nn.Linear`` export (or onnxsim's own
+// A non-default transA/transB is handled by literally inserting a Transpose
+// node for it -- rather than pattern-matching the attribute to decide which
+// of two hand-written weight/activation layouts to build -- and leaning on
+// onnx-optimizer's own eliminate_nop_transpose/fuse_consecutive_transposes
+// (already part of the default fuse/elimination set this pass's own
+// extra_optimizers caller runs alongside) to cancel whatever that Transpose
+// turns out not to need in the final graph: transB's normalizing Transpose
+// composes with the Conv-layout Transpose this pass always inserts for W
+// into a no-op perm, which eliminate_nop_transpose then deletes outright,
+// so a transB=1 Gemm (nn.Linear's own native export shape, W kept as
+// [out, in]) ends up with zero leftover Transpose nodes despite this pass
+// never special-casing that layout. transA's Transpose(X), by contrast, is
+// real work with no inverse anywhere else in the pattern, so it survives --
+// there is no way to avoid physically reordering X's elements once its
+// contracted axis is not already the layout Conv needs.
+//
+// Only ``alpha=1``/``beta=1`` Gemm is handled -- the scaling a plain
+// ``nn.Linear`` export (or onnxsim's own
 // ``fuse_matmul_add_bias_into_gemm``/``_batched``) always produces. Any
 // other Gemm is left untouched rather than taught to rescale the folded
 // weight/bias for an alpha/beta that essentially never occurs in practice.
@@ -53,6 +67,7 @@
 // Add the rewritten (rank >= 3) Conv output can no longer broadcast against
 // in the usual per-channel way.
 
+#include <algorithm>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -97,15 +112,35 @@ struct FuseMatMulIntoConv final : public PredicateBasedPass {
     return graph.addInitializerAndCreateValue(std::move(t));
   }
 
-  // The pieces of a MatMul/Gemm-shaped Linear layer this pass rewrites.
+  // ``physical``'s shape as it will read once transposed (its two-or-more
+  // axes reversed) if ``transposed``, else unchanged. Reversing (rather than
+  // swapping just the last two axes) matches what a Transpose<perm=[1,0]>
+  // node -- the only shape this pass ever inserts one for, since Gemm's
+  // transA/transB apply to a strictly 2-D operand -- actually does.
+  static std::vector<Dimension> LogicalShape(Value* physical, bool transposed) {
+    std::vector<Dimension> shape(physical->sizes().begin(),
+                                 physical->sizes().end());
+    if (transposed) {
+      std::reverse(shape.begin(), shape.end());
+    }
+    return shape;
+  }
+
+  // The pieces of a MatMul/Gemm-shaped Linear layer this pass rewrites. `x`
+  // and `w` are always the *physical* (as-written-in-the-graph) values;
+  // `transpose_x`/`transpose_w` record whether runTransform still needs to
+  // insert a Transpose node to reach the logical [..., K] / [K, N] shape the
+  // rest of this pass's own math (`k`, `n`, and every use of LogicalShape)
+  // already assumes.
   struct Match {
     bool ok = false;
-    Value* x = nullptr;     // activation, rank >= 2, static last dim K
-    Value* w = nullptr;     // constant weight, 2-D
-    bool w_is_n_k = false;  // true: w is laid out [N, K] (Gemm transB=1);
-                            // false: w is laid out [K, N] (MatMul, or Gemm
-                            // transB=0)
-    Value* bias = nullptr;  // constant, rank <= 1, may be null
+    Value* x = nullptr;        // activation; LogicalShape(x, transpose_x)
+                               // has rank >= 2 and a static last dim K
+    bool transpose_x = false;  // Gemm transA != 0
+    Value* w = nullptr;        // constant weight; LogicalShape(w,
+                               // transpose_w) is 2-D [K, N]
+    bool transpose_w = false;  // Gemm transB != 0
+    Value* bias = nullptr;     // constant, rank <= 1, may be null
     int64_t k = 0;
     int64_t n = 0;
   };
@@ -114,6 +149,8 @@ struct FuseMatMulIntoConv final : public PredicateBasedPass {
     Match m;
     Node* mm = nullptr;
     Value* bias = nullptr;
+    bool transpose_x = false;
+    bool transpose_w = false;
 
     if (node->kind() == kAdd && node->inputs().size() == 2) {
       // Add is commutative, so the MatMul may be either operand. Exporters
@@ -147,12 +184,12 @@ struct FuseMatMulIntoConv final : public PredicateBasedPass {
       }
       mm = node;
     } else if (node->kind() == kGemm) {
-      const int64_t trans_a =
-          GetValueFromAttrWithDefault(node, ktransA, int64_t(0));
       const double alpha = GetValueFromAttrWithDefault(node, kalpha, 1.0);
-      if (trans_a != 0 || alpha != 1.0) {
+      if (alpha != 1.0) {
         return m;
       }
+      transpose_x = GetValueFromAttrWithDefault(node, ktransA, int64_t(0)) != 0;
+      transpose_w = GetValueFromAttrWithDefault(node, ktransB, int64_t(0)) != 0;
       mm = node;
     } else {
       return m;
@@ -160,11 +197,12 @@ struct FuseMatMulIntoConv final : public PredicateBasedPass {
 
     Value* x = mm->input(0);
     Value* w = mm->input(1);
-    bool w_is_n_k = false;
     if (mm->kind() == kGemm) {
-      const int64_t trans_b =
-          GetValueFromAttrWithDefault(mm, ktransB, int64_t(0));
-      w_is_n_k = trans_b != 0;
+      // Gemm's A/B are strictly 2-D; a Transpose<perm=[1,0]> only implements
+      // transA/transB for that rank.
+      if (!x->has_sizes() || x->sizes().size() != 2) {
+        return m;
+      }
       if (mm->inputs().size() == 3) {
         const double beta = GetValueFromAttrWithDefault(mm, kbeta, 1.0);
         if (beta != 1.0) {
@@ -177,7 +215,7 @@ struct FuseMatMulIntoConv final : public PredicateBasedPass {
     if (!x->has_sizes()) {
       return m;
     }
-    const auto& x_shape = x->sizes();
+    const std::vector<Dimension> x_shape = LogicalShape(x, transpose_x);
     if (x_shape.size() < 2 || !x_shape.back().is_int) {
       return m;
     }
@@ -186,22 +224,14 @@ struct FuseMatMulIntoConv final : public PredicateBasedPass {
     if (!IsConstantTensor(w) || !w->has_sizes()) {
       return m;
     }
-    const auto& w_shape = w->sizes();
+    const std::vector<Dimension> w_shape = LogicalShape(w, transpose_w);
     if (w_shape.size() != 2 || !w_shape[0].is_int || !w_shape[1].is_int) {
       return m;
     }
-    int64_t n_out;
-    if (w_is_n_k) {
-      if (w_shape[1].dim != k) {
-        return m;
-      }
-      n_out = w_shape[0].dim;
-    } else {
-      if (w_shape[0].dim != k) {
-        return m;
-      }
-      n_out = w_shape[1].dim;
+    if (w_shape[0].dim != k) {
+      return m;
     }
+    const int64_t n_out = w_shape[1].dim;
 
     if (bias != nullptr) {
       if (!IsConstantTensor(bias) || !bias->has_sizes()) {
@@ -236,8 +266,9 @@ struct FuseMatMulIntoConv final : public PredicateBasedPass {
 
     m.ok = true;
     m.x = x;
+    m.transpose_x = transpose_x;
     m.w = w;
-    m.w_is_n_k = w_is_n_k;
+    m.transpose_w = transpose_w;
     m.bias = bias;
     m.k = k;
     m.n = n_out;
@@ -245,6 +276,19 @@ struct FuseMatMulIntoConv final : public PredicateBasedPass {
   }
 
   bool patternMatchPredicate(Node* n) override { return MatchNode(n).ok; }
+
+  // Inserts a Transpose<perm=[1,0]> of ``v`` right before ``anchor`` and
+  // returns its output, unconditionally -- callers decide whether the
+  // transpose is needed (``Match::transpose_x``/``transpose_w``) and skip
+  // calling this when it is not; this never itself pattern-matches the
+  // shape to decide whether to skip emitting the node.
+  static Value* InsertTranspose(Graph& graph, Value* v, Node* anchor) {
+    Node* transpose = graph.create(kTranspose, 1);
+    transpose->addInput(v);
+    transpose->is_(kperm, std::vector<int64_t>{1, 0});
+    transpose->insertBefore(anchor);
+    return transpose->output();
+  }
 
   bool runTransform(Node* n, Graph& graph,
                     NodeDestroyType& destroy_current) override {
@@ -254,28 +298,36 @@ struct FuseMatMulIntoConv final : public PredicateBasedPass {
       return false;
     }
 
-    const auto& x_shape = match.x->sizes();
+    // X, transposed into logical [..., K] form if Gemm's transA asked for it.
+    // A real Gemm transA=1 has no inverse anywhere else in this rewrite, so
+    // this Transpose is genuine work and stays in the final graph -- unlike
+    // W's transpose_w handling below, there is nothing for
+    // eliminate_nop_transpose/fuse_consecutive_transposes to cancel it with.
+    Value* x_logical =
+        match.transpose_x ? InsertTranspose(graph, match.x, n) : match.x;
+    const std::vector<Dimension> x_shape =
+        LogicalShape(match.x, match.transpose_x);
     const int64_t rank = static_cast<int64_t>(x_shape.size());
 
     // X2 = Reshape(X, [-1, K, 1])
     Node* pre = graph.create(kReshape, 1);
-    pre->addInput(match.x);
+    pre->addInput(x_logical);
     pre->addInput(
         MakeInt64Constant(graph, {-1, match.k, 1}, nextReservedName(graph)));
     pre->insertBefore(n);
 
-    // W2 = [N, K, 1], built from W by Transpose (if laid out [K, N]) then
-    // Unsqueeze. Both operate on a constant, so the constant folder
-    // materializes W2 as a plain initializer (fuse_mul_into_conv's own
-    // weight-folding convention).
-    Value* w2 = match.w;
-    if (!match.w_is_n_k) {
-      Node* transpose = graph.create(kTranspose, 1);
-      transpose->addInput(w2);
-      transpose->is_(kperm, std::vector<int64_t>{1, 0});
-      transpose->insertBefore(n);
-      w2 = transpose->output();
-    }
+    // W2 = [N, K, 1]: normalize W to logical [K, N] (inserting a Transpose
+    // for Gemm's transB, same as X above) and then -- always, never
+    // conditionally skipped -- Transpose again into Conv's own [N, K]
+    // weight-axis order plus a trailing Unsqueeze for the 1-D spatial dim.
+    // When transB already put W in that same [N, K] layout, the two
+    // Transpose<perm=[1,0]> nodes compose to a no-op that
+    // fuse_consecutive_transposes/eliminate_nop_transpose (both already in
+    // the default fuse/elimination set this opt-in pass runs alongside)
+    // delete outright -- see this file's own top comment.
+    Value* w_logical =
+        match.transpose_w ? InsertTranspose(graph, match.w, n) : match.w;
+    Value* w2 = InsertTranspose(graph, w_logical, n);
     {
       Node* unsqueeze = graph.create(kUnsqueeze, 1);
       unsqueeze->addInput(w2);
@@ -346,9 +398,11 @@ struct FuseMatMulIntoConv final : public PredicateBasedPass {
       post->addInput(MakeInt64Constant(graph, std::move(out_shape),
                                        nextReservedName(graph)));
     } else {
-      // shape(X) -> slice off the last dim -> concat with [N]
+      // shape(X) -> slice off the last dim -> concat with [N]. X here is
+      // x_logical (already transposed if transpose_x), so "the last dim" is
+      // K in logical order, matching x_shape/leading_dims above.
       Node* shape = graph.create(Symbol("Shape"), 1);
-      shape->addInput(match.x);
+      shape->addInput(x_logical);
       shape->insertBefore(n);
 
       Node* slice = graph.create(kSlice, 1);

--- a/tests/test_fusion_patterns.py
+++ b/tests/test_fusion_patterns.py
@@ -321,7 +321,12 @@ def test_fuse_gemm_into_conv_transb():
     # A plain nn.Linear typically exports as Gemm(X, W, B, transB=1) (W kept
     # in its natural [out, in] layout). fuse_matmul_into_conv also rewrites
     # this shape, not just MatMul -- no default pass turns Gemm back into
-    # MatMul, so no skipped_optimizers is needed here.
+    # MatMul, so no skipped_optimizers is needed here. fuse_matmul_into_conv
+    # itself never special-cases transB=1 to skip inserting a Transpose for
+    # W (it always builds the Conv weight the same way regardless of
+    # layout); the default fuse set's own fuse_consecutive_transposes +
+    # eliminate_nop_transpose cancel the resulting Transpose<perm=[1,0]>
+    # pair, so no Transpose survives either.
     W = np.random.randn(8, 16)  # [N, K], transB=1
     B = np.random.randn(8)
     model = _model(
@@ -336,17 +341,38 @@ def test_fuse_gemm_into_conv_transb():
     _, ops = _simplify_extra(model, extra_optimizers=["fuse_matmul_into_conv"])
     assert ops["Conv"] == 1
     assert ops["Gemm"] == 0
+    assert ops["Transpose"] == 0
 
 
-def test_fuse_matmul_into_conv_declines_non_default_gemm():
-    # transA=1 rescales which axis of X is contracted; fuse_matmul_into_conv
-    # only handles the plain transA=0 shape and leaves this Gemm untouched.
+def test_fuse_gemm_into_conv_transa():
+    # transA=1 has no counterpart anywhere else in the rewrite to cancel
+    # against, so -- unlike transB above -- the Transpose(X) this pass
+    # inserts for it is genuine work and survives in the final graph.
     W = np.random.randn(16, 8)
     model = _model(
         """
         g (float[16,4] X) => (float[4,8] Y)
         {
           Y = Gemm<transA = 1>(X, W)
+        }
+        """,
+        initializer=[_f32(W, "W")],
+    )
+    _, ops = _simplify_extra(model, extra_optimizers=["fuse_matmul_into_conv"])
+    assert ops["Conv"] == 1
+    assert ops["Gemm"] == 0
+    assert ops["Transpose"] == 1
+
+
+def test_fuse_matmul_into_conv_declines_non_default_alpha():
+    # alpha != 1 would need the folded weight rescaled; fuse_matmul_into_conv
+    # doesn't do that and leaves this Gemm untouched.
+    W = np.random.randn(16, 8)
+    model = _model(
+        """
+        g (float[4,16] X) => (float[4,8] Y)
+        {
+          Y = Gemm<alpha = 2.0>(X, W)
         }
         """,
         initializer=[_f32(W, "W")],

--- a/tests/test_fusion_patterns.py
+++ b/tests/test_fusion_patterns.py
@@ -37,6 +37,23 @@ def _simplify(model):
     return sim_model, collections.Counter(n.op_type for n in sim_model.graph.node)
 
 
+def _simplify_extra(model, extra_optimizers, skipped_optimizers=None):
+    # Like _simplify, but for a PassType::Other pass that is not part of the
+    # default fuse/elimination set (see extra_optimizers' own doc comment in
+    # onnxsim.h) -- e.g. fuse_matmul_into_conv, which must be opted into by
+    # name. skipped_optimizers additionally excludes named default passes
+    # that would otherwise race the opted-in one for the same node (see
+    # fuse_matmul_into_conv.h's own file comment).
+    sim_model, check_ok = onnxsim.simplify(
+        model,
+        check_n=3,
+        extra_optimizers=extra_optimizers,
+        skipped_optimizers=skipped_optimizers,
+    )
+    assert check_ok, "simplified model failed onnxsim's equivalence check"
+    return sim_model, collections.Counter(n.op_type for n in sim_model.graph.node)
+
+
 def _model(body, initializer=(), opset=13, ir_version=10):
     # Pin a low IR version by default so the model loads under the older
     # onnxruntime bundled with some CI wheels (which cap at IR version 11);
@@ -225,6 +242,118 @@ def test_batched_matmul_add_into_gemm():
     _, ops = _simplify(model)
     assert ops["Gemm"] == 1
     assert ops["MatMul"] == 0
+
+
+def test_fuse_matmul_into_conv_2d():
+    # A bare 2-D MatMul against a constant weight (e.g. a CNN's classifier
+    # head after global pooling + Flatten) is a Linear layer in disguise, and
+    # rewrites to a 1x1 Conv -- fuse_matmul_into_conv, opted in via
+    # extra_optimizers for accelerators whose Conv datapath is far better
+    # optimized than their generic MatMul one.
+    W = np.random.randn(16, 8)
+    model = _model(
+        """
+        g (float[4,16] X) => (float[4,8] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """,
+        initializer=[_f32(W, "W")],
+    )
+    _, ops = _simplify_extra(model, extra_optimizers=["fuse_matmul_into_conv"])
+    assert ops["Conv"] == 1
+    assert ops["MatMul"] == 0
+
+
+def test_fuse_matmul_into_conv_2d_with_bias():
+    # The default fuse set would otherwise fuse this MatMul+Add into a Gemm
+    # first (fuse_matmul_add_bias_into_gemm), so it's skipped here to isolate
+    # fuse_matmul_into_conv's own MatMul+Add(bias) -> Conv(bias) fusion.
+    W = np.random.randn(16, 8)
+    B = np.random.randn(8)
+    model = _model(
+        """
+        g (float[4,16] X) => (float[4,8] Y)
+        {
+          mm = MatMul(X, W)
+          Y = Add(mm, B)
+        }
+        """,
+        initializer=[_f32(W, "W"), _f32(B, "B")],
+    )
+    _, ops = _simplify_extra(
+        model,
+        extra_optimizers=["fuse_matmul_into_conv"],
+        skipped_optimizers=["fuse_matmul_add_bias_into_gemm"],
+    )
+    assert ops["Conv"] == 1
+    assert ops["MatMul"] == 0 and ops["Add"] == 0 and ops["Gemm"] == 0
+
+
+def test_fuse_batched_matmul_into_conv_with_bias():
+    # Same rank-3, bias-first (HuggingFace-style) Linear layer as
+    # test_batched_matmul_add_into_gemm, but targeting fuse_matmul_into_conv
+    # instead -- fuse_matmul_add_bias_into_gemm_batched is skipped since it is
+    # otherwise unconditionally in the default set and would race this one
+    # for the same Add(MatMul) node.
+    W = np.random.randn(8, 16)
+    b = np.random.randn(16)
+    model = _model(
+        """
+        g (float[2,4,8] X) => (float[2,4,16] Y)
+        {
+          mm = MatMul(X, W)
+          Y = Add(b, mm)
+        }
+        """,
+        initializer=[_f32(W, "W"), _f32(b, "b")],
+    )
+    _, ops = _simplify_extra(
+        model,
+        extra_optimizers=["fuse_matmul_into_conv"],
+        skipped_optimizers=["fuse_matmul_add_bias_into_gemm_batched"],
+    )
+    assert ops["Conv"] == 1
+    assert ops["MatMul"] == 0 and ops["Add"] == 0 and ops["Gemm"] == 0
+
+
+def test_fuse_gemm_into_conv_transb():
+    # A plain nn.Linear typically exports as Gemm(X, W, B, transB=1) (W kept
+    # in its natural [out, in] layout). fuse_matmul_into_conv also rewrites
+    # this shape, not just MatMul -- no default pass turns Gemm back into
+    # MatMul, so no skipped_optimizers is needed here.
+    W = np.random.randn(8, 16)  # [N, K], transB=1
+    B = np.random.randn(8)
+    model = _model(
+        """
+        g (float[4,16] X) => (float[4,8] Y)
+        {
+          Y = Gemm<transB = 1>(X, W, B)
+        }
+        """,
+        initializer=[_f32(W, "W"), _f32(B, "B")],
+    )
+    _, ops = _simplify_extra(model, extra_optimizers=["fuse_matmul_into_conv"])
+    assert ops["Conv"] == 1
+    assert ops["Gemm"] == 0
+
+
+def test_fuse_matmul_into_conv_declines_non_default_gemm():
+    # transA=1 rescales which axis of X is contracted; fuse_matmul_into_conv
+    # only handles the plain transA=0 shape and leaves this Gemm untouched.
+    W = np.random.randn(16, 8)
+    model = _model(
+        """
+        g (float[16,4] X) => (float[4,8] Y)
+        {
+          Y = Gemm<transA = 1>(X, W)
+        }
+        """,
+        initializer=[_f32(W, "W")],
+    )
+    _, ops = _simplify_extra(model, extra_optimizers=["fuse_matmul_into_conv"])
+    assert ops["Gemm"] == 1
+    assert ops["Conv"] == 0
 
 
 def test_fuse_pad_into_conv():


### PR DESCRIPTION
Some accelerators (embedded/mobile NPUs and DSPs among them) have a heavily
tuned Conv datapath but a much weaker (or unaccelerated) generic MatMul/Gemm
one. Every Linear layer (nn.Linear, a Transformer's QKV/FFN projections, a
CNN's classifier head after global pooling, ...) is mathematically a 1x1
convolution once its activation is reshaped to put the contracted axis on
the channel dimension, so this new onnxsim_passes::FuseMatMulIntoConv pass
rewrites MatMul (optionally fused with a following bias Add) and plain
Gemm (transA=0, alpha=1, beta=1) into Reshape -> Conv -> Reshape.

Registered as PassType::Other (opt-in via extra_optimizers, like
fuse_matmul_add_bias_into_gemm_batched) since it's a graph-shape rewrite
that would regress a MatMul/Gemm-first backend, not a default-on fusion.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GQXeHqhrQs8fE8cArhTxxA