### PR TITLE
Document M4 ANE decode ceiling and add weight-only quantization export

### DIFF
--- a/.github/workflows/coreml-integration.yml
+++ b/.github/workflows/coreml-integration.yml
@@ -46,16 +46,18 @@ name: Core ML Integration
 # job in this workflow only checks that a graph *converts*; this is the one place
 # the decode benchmark and parity harnesses themselves actually execute anywhere,
 # since no environment developing this repo has a macOS/Core ML runtime to run
-# them in locally. The matrix spans two already-validated architecture families
-# (Llama-style via SmolLM2, Qwen2) so a translator regression specific to one
-# doesn't hide behind the other passing, plus a third entry re-running SmolLM2
-# with --quantize-weights int8 (scripts/apple/export_llm_to_coreml.py) so the
-# weight-only-quantization decode speedup and decode parity are both measured
-# on real hardware, not just asserted -- plus a fourth entry with
-# --matmul-to-conv instead, targeting the compute (not bandwidth) side of the
-# same theoretical-ceiling analysis (see scripts/apple/README.md). This is the
-# only place either flag's actual effect on decode tok/s gets measured, since
-# no environment developing this repo has real Core ML to run it on. Also
+# them in locally. The matrix spans multiple architecture families (Llama-style
+# via SmolLM2/Llama-3.2, Qwen2, Phi-3's fused qkv_proj/gate_up_proj) so a
+# translator regression specific to one doesn't hide behind another passing,
+# across both the smoke-test tier (SmolLM2-135M, plus --quantize-weights int8
+# and --matmul-to-conv variants of it -- see scripts/apple/README.md's
+# "Theoretical ceiling" and "matmul-to-conv1x1" sections for what those
+# measured; --matmul-to-conv stays off by default, measured slower not
+# faster here) and the few-billion-parameter tier DeviceMark's own
+# leaderboard actually tests (https://devicemark.github.io/, roughly 1-4B --
+# SmolLM2-1.7B, Qwen2.5-3B, Llama-3.2-1B/3B, Phi-3.5-mini). This is the one
+# place any of this actually executes anywhere, since no environment
+# developing this repo has real Core ML to run it on. Also
 # workflow_dispatch/schedule-only, matching the other real-model jobs.
 #
 # A fifth job -- `quality-eval-macos` -- is the first slice of
@@ -302,6 +304,55 @@ jobs:
             dtype: fp32
             quantize_weights: int8
             matmul_to_conv: "true"
+          # Few-billion-parameter tier -- DeviceMark's own leaderboard weight
+          # class (https://devicemark.github.io/, roughly 1-4B), and the
+          # entries prepare_benchmark_models.py's BENCHMARK_MODELS already
+          # lists but this job didn't yet run real decode benchmark/parity
+          # against. SmolLM2-1.7B and Llama-3.2-1B are already validated for
+          # export+convert; Qwen2.5-3B and Llama-3.2-3B previously OOM'd
+          # during ONNX export/trace in a 15GB-RAM dev sandbox (not a
+          # translator issue -- see BENCHMARK_MODELS' notes), so this is
+          # also the first real test of whether this runner's memory clears
+          # that bar. Phi-3.5-mini is a structurally different graph shape
+          # (fused qkv_proj/gate_up_proj projections) than the Llama/Qwen2
+          # entries above, so it's new translator coverage regardless of the
+          # speed number. The Llama-3.2 entries are gated -- HF_TOKEN below,
+          # same read-only secret export-benchmark-models already uses.
+          - model_id: HuggingFaceTB/SmolLM2-1.7B-Instruct
+            slug: smollm2-1.7b
+            max_context_length: 512
+            dtype: fp16
+            quantize_weights: none
+            matmul_to_conv: "false"
+          - model_id: meta-llama/Llama-3.2-1B-Instruct
+            slug: llama-3.2-1b
+            max_context_length: 512
+            dtype: fp16
+            quantize_weights: none
+            matmul_to_conv: "false"
+          - model_id: meta-llama/Llama-3.2-3B-Instruct
+            slug: llama-3.2-3b
+            max_context_length: 512
+            dtype: fp16
+            quantize_weights: none
+            matmul_to_conv: "false"
+          - model_id: Qwen/Qwen2.5-3B-Instruct
+            slug: qwen2.5-3b
+            max_context_length: 512
+            dtype: fp16
+            quantize_weights: none
+            matmul_to_conv: "false"
+          - model_id: microsoft/Phi-3.5-mini-instruct
+            slug: phi-3.5-mini
+            max_context_length: 512
+            dtype: fp16
+            quantize_weights: none
+            matmul_to_conv: "false"
+    env:
+      # Read-only secret; only meta-llama/Llama-3.2-*-Instruct entries above
+      # need it (gated -- see prepare_benchmark_models.py's module
+      # docstring). Harmless to set for every matrix entry.
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7

--- a/.github/workflows/coreml-integration.yml
+++ b/.github/workflows/coreml-integration.yml
@@ -51,8 +51,12 @@ name: Core ML Integration
 # doesn't hide behind the other passing, plus a third entry re-running SmolLM2
 # with --quantize-weights int8 (scripts/apple/export_llm_to_coreml.py) so the
 # weight-only-quantization decode speedup and decode parity are both measured
-# on real hardware, not just asserted. Also workflow_dispatch/schedule-only,
-# matching the other real-model jobs.
+# on real hardware, not just asserted -- plus a fourth entry with
+# --matmul-to-conv instead, targeting the compute (not bandwidth) side of the
+# same theoretical-ceiling analysis (see scripts/apple/README.md). This is the
+# only place either flag's actual effect on decode tok/s gets measured, since
+# no environment developing this repo has real Core ML to run it on. Also
+# workflow_dispatch/schedule-only, matching the other real-model jobs.
 
 on:
   schedule:
@@ -237,11 +241,13 @@ jobs:
             max_context_length: 512
             dtype: fp32
             quantize_weights: none
+            matmul_to_conv: "false"
           - model_id: Qwen/Qwen2.5-1.5B-Instruct
             slug: qwen2.5-1.5b
             max_context_length: 512
             dtype: fp16
             quantize_weights: none
+            matmul_to_conv: "false"
           # Same model/dtype as the first entry, weight-only int8 quantized --
           # see scripts/apple/README.md's "Theoretical ceiling" section for why
           # this is expected to raise decode tok/s (roughly halves DRAM bytes
@@ -253,6 +259,20 @@ jobs:
             max_context_length: 512
             dtype: fp32
             quantize_weights: int8
+            matmul_to_conv: "false"
+          # Same model/dtype as the first entry, --matmul-to-conv enabled --
+          # unlike the int8 entry above, this targets compute (not bandwidth):
+          # the M4 ANE's native matmul path measures well below its conv1x1
+          # path on the same hardware (see the README's "Theoretical ceiling"
+          # section). Untested against this pipeline's actual shapes (mostly
+          # single-token decode) until this job runs it -- this entry is that
+          # measurement, not a claim it helps.
+          - model_id: HuggingFaceTB/SmolLM2-135M-Instruct
+            slug: smollm2-135m-conv
+            max_context_length: 512
+            dtype: fp32
+            quantize_weights: none
+            matmul_to_conv: "true"
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
@@ -277,6 +297,7 @@ jobs:
             ${{ matrix.model_id }} --dtype ${{ matrix.dtype }} \
             --max-context-length ${{ matrix.max_context_length }} \
             --quantize-weights ${{ matrix.quantize_weights }} \
+            ${{ matrix.matmul_to_conv == 'true' && '--matmul-to-conv' || '' }} \
             --output ${{ matrix.slug }}.mlpackage
       - name: Run the decode benchmark through the real Core ML runtime
         working-directory: ${{ runner.temp }}

--- a/.github/workflows/coreml-integration.yml
+++ b/.github/workflows/coreml-integration.yml
@@ -277,9 +277,12 @@ jobs:
           # unlike the int8 entry above, this targets compute (not bandwidth):
           # the M4 ANE's native matmul path measures well below its conv1x1
           # path on the same hardware (see the README's "Theoretical ceiling"
-          # section). Untested against this pipeline's actual shapes (mostly
-          # single-token decode) until this job runs it -- this entry is that
-          # measurement, not a claim it helps.
+          # section). Measured on this pipeline's actual shapes (mostly
+          # single-token decode) as slower, not faster, than the matmul
+          # baseline (see the README's "matmul-to-conv1x1" section) -- kept
+          # here, and the flag stays opt-in/off by default, so a future
+          # change to the rewrite or a different model size can be checked
+          # against the same baseline without re-deriving this result.
           - model_id: HuggingFaceTB/SmolLM2-135M-Instruct
             slug: smollm2-135m-conv
             max_context_length: 512

--- a/.github/workflows/coreml-integration.yml
+++ b/.github/workflows/coreml-integration.yml
@@ -289,13 +289,13 @@ jobs:
             dtype: fp32
             quantize_weights: none
             matmul_to_conv: "true"
-          # Both flags together -- int8 targets bandwidth, matmul-to-conv
-          # targets compute, and nothing about them should interact (int8
-          # only changes how the weight constants are stored/dequantized
-          # before the op runs; matmul-to-conv only changes which op the
-          # dequantized weight feeds into), but that's an assumption, not a
-          # measurement. This entry checks it directly rather than inferring
-          # it from the two isolated entries above.
+          # Both flags together -- measured worse than either alone: 2.26
+          # tok/s vs. 3.61 baseline, 4.64 int8-only, 3.04 conv-only (see the
+          # README's "matmul-to-conv1x1" section). Not the neutral
+          # composition the two flags' independent scopes (weight storage
+          # vs. which op consumes it) would suggest. Kept here as a
+          # regression check now that this is known, not because either
+          # flag is expected to be enabled together in practice.
           - model_id: HuggingFaceTB/SmolLM2-135M-Instruct
             slug: smollm2-135m-int8-conv
             max_context_length: 512

--- a/.github/workflows/coreml-integration.yml
+++ b/.github/workflows/coreml-integration.yml
@@ -371,7 +371,7 @@ jobs:
       - name: Install onnxsim wheel + LLM export/eval deps
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install "optimum-onnx" transformers coremltools onnxruntime "lm-eval[ifeval]"
+          python3 -m pip install "optimum-onnx" transformers accelerate coremltools onnxruntime "lm-eval[ifeval]"
           python3 -m pip install wheelhouse/*.whl
       - name: Verify the installed wheel is used (not the source tree)
         working-directory: ${{ runner.temp }}

--- a/.github/workflows/coreml-integration.yml
+++ b/.github/workflows/coreml-integration.yml
@@ -48,7 +48,10 @@ name: Core ML Integration
 # since no environment developing this repo has a macOS/Core ML runtime to run
 # them in locally. The matrix spans two already-validated architecture families
 # (Llama-style via SmolLM2, Qwen2) so a translator regression specific to one
-# doesn't hide behind the other passing. Also workflow_dispatch/schedule-only,
+# doesn't hide behind the other passing, plus a third entry re-running SmolLM2
+# with --quantize-weights int8 (scripts/apple/export_llm_to_coreml.py) so the
+# weight-only-quantization decode speedup and decode parity are both measured
+# on real hardware, not just asserted. Also workflow_dispatch/schedule-only,
 # matching the other real-model jobs.
 
 on:
@@ -233,10 +236,23 @@ jobs:
             slug: smollm2-135m
             max_context_length: 512
             dtype: fp32
+            quantize_weights: none
           - model_id: Qwen/Qwen2.5-1.5B-Instruct
             slug: qwen2.5-1.5b
             max_context_length: 512
             dtype: fp16
+            quantize_weights: none
+          # Same model/dtype as the first entry, weight-only int8 quantized --
+          # see scripts/apple/README.md's "Theoretical ceiling" section for why
+          # this is expected to raise decode tok/s (roughly halves DRAM bytes
+          # read per token, the bandwidth-bound bottleneck for decode) without
+          # touching compute precision. Runs decode parity too, so a quality
+          # regression from quantization shows up here, not just a speed number.
+          - model_id: HuggingFaceTB/SmolLM2-135M-Instruct
+            slug: smollm2-135m-int8
+            max_context_length: 512
+            dtype: fp32
+            quantize_weights: int8
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
@@ -260,6 +276,7 @@ jobs:
           python3 "$GITHUB_WORKSPACE/scripts/apple/export_llm_to_coreml.py" \
             ${{ matrix.model_id }} --dtype ${{ matrix.dtype }} \
             --max-context-length ${{ matrix.max_context_length }} \
+            --quantize-weights ${{ matrix.quantize_weights }} \
             --output ${{ matrix.slug }}.mlpackage
       - name: Run the decode benchmark through the real Core ML runtime
         working-directory: ${{ runner.temp }}

--- a/.github/workflows/coreml-integration.yml
+++ b/.github/workflows/coreml-integration.yml
@@ -289,6 +289,19 @@ jobs:
             dtype: fp32
             quantize_weights: none
             matmul_to_conv: "true"
+          # Both flags together -- int8 targets bandwidth, matmul-to-conv
+          # targets compute, and nothing about them should interact (int8
+          # only changes how the weight constants are stored/dequantized
+          # before the op runs; matmul-to-conv only changes which op the
+          # dequantized weight feeds into), but that's an assumption, not a
+          # measurement. This entry checks it directly rather than inferring
+          # it from the two isolated entries above.
+          - model_id: HuggingFaceTB/SmolLM2-135M-Instruct
+            slug: smollm2-135m-int8-conv
+            max_context_length: 512
+            dtype: fp32
+            quantize_weights: int8
+            matmul_to_conv: "true"
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7

--- a/onnxsim/coreml_export.py
+++ b/onnxsim/coreml_export.py
@@ -233,10 +233,11 @@ def _const_scalar(var) -> float:
 class _Lowerer:
     """Walks an ONNX graph once, building the equivalent MIL ops as it goes."""
 
-    def __init__(self, mb, types, opset: int):
+    def __init__(self, mb, types, opset: int, matmul_to_conv: bool = False):
         self.mb = mb
         self.types = types
         self.opset = opset
+        self.matmul_to_conv = matmul_to_conv
         self._values: Dict[str, Any] = {}
         self._counter = 0
 
@@ -469,8 +470,65 @@ def _op_softmax(lowerer, node, ins, attrs):
     return [lowerer.mb.reshape(x=sm, shape=list(shape), name=lowerer.fresh_name(node))]
 
 
+def _matmul_as_conv1x1(lowerer, node, x, w):
+    """If ``lowerer.matmul_to_conv`` is set and this MatMul is a linear
+    projection (``x [B, S, C_in] @ w [C_in, C_out]`` with a compile-time-constant
+    2-D ``w`` -- the shape every attention/MLP projection in a transformer
+    decoder takes), lower it to a 1x1/pointwise ``conv`` instead of MIL's native
+    ``matmul``. Returns the output ``Var``, or ``None`` if the shapes don't
+    qualify (the caller falls back to ``matmul`` in that case).
+
+    Why: per the M4 Neural Engine's own reverse-engineered behavior (see
+    scripts/apple/README.md's "Theoretical ceiling" section), the ANE's compute
+    array parallelizes over *convolution* output channels -- its native ``matmul``
+    path only reaches ~30% of peak throughput on a single op, where a
+    channel-parallel conv1x1 chain reaches ~99%. Only ``x``'s rank-3
+    ``[batch, sequence, features]`` shape (this pipeline's actual shape, since
+    ``export_llm_to_coreml.py`` always pins ``batch_size=1``) is handled; any
+    other rank falls back to ``matmul`` rather than risk a shape bug on an
+    untested case.
+
+    The rewrite is a pure transpose/conv/transpose (MIL's ``conv`` accepts
+    ``[n, C_in, *d_in]`` for ``1 <= len(d_in) <= 3``, so 1-D conv's ``[n, C_in,
+    L]`` is exactly ``x`` transposed) -- no shape needs to be known or computed
+    ahead of time, so this is as dynamic-shape-safe as the matmul it replaces.
+    The weight transpose/reshape happens once, in Python, on the constant
+    array itself (never as graph ops), so it costs nothing at runtime.
+    """
+    if not lowerer.matmul_to_conv:
+        return None
+    if w.val is None or w.rank != 2:
+        return None
+    if x.rank != 3:
+        return None
+
+    # ONNX MatMul convention: w is [C_in, C_out]. MIL conv wants weight
+    # [C_out, C_in, K]; K=1 here (pointwise/1x1-equivalent).
+    conv_w = lowerer.make_const(
+        node.input[1], np.ascontiguousarray(w.val.T)[:, :, None]
+    )
+    xt = lowerer.mb.transpose(
+        x=x, perm=[0, 2, 1], name=lowerer.fresh_name(node, "conv_in")
+    )
+    conv_out = lowerer.mb.conv(
+        x=xt,
+        weight=conv_w,
+        strides=[1],
+        pad_type="valid",
+        dilations=[1],
+        groups=1,
+        name=lowerer.fresh_name(node, "conv"),
+    )
+    return lowerer.mb.transpose(
+        x=conv_out, perm=[0, 2, 1], name=lowerer.fresh_name(node)
+    )
+
+
 @_register("MatMul")
 def _op_matmul(lowerer, node, ins, attrs):
+    conv_out = _matmul_as_conv1x1(lowerer, node, ins[0], ins[1])
+    if conv_out is not None:
+        return [conv_out]
     return [lowerer.mb.matmul(x=ins[0], y=ins[1], name=lowerer.fresh_name(node))]
 
 
@@ -1126,6 +1184,7 @@ def _build_mil_program(
     RangeDim,
     TensorType,
     dynamic_shapes: Optional[Dict[str, Tuple[int, int, int]]] = None,
+    matmul_to_conv: bool = False,
 ):
     graph = model.graph
     initializer_names = {t.name for t in graph.initializer}
@@ -1134,7 +1193,7 @@ def _build_mil_program(
         if imp.domain in ("", "ai.onnx"):
             opset = imp.version
 
-    lowerer = _Lowerer(mb=mb, types=types, opset=opset)
+    lowerer = _Lowerer(mb=mb, types=types, opset=opset, matmul_to_conv=matmul_to_conv)
 
     dynamic_shapes = dynamic_shapes or {}
     range_dims: Dict[str, Any] = {}
@@ -1199,6 +1258,7 @@ def convert_to_coreml(
     minimum_deployment_target: Optional[Union[str, Any]] = None,
     skip_model_load: bool = True,
     dynamic_shapes: Optional[Dict[str, Tuple[int, int, int]]] = None,
+    matmul_to_conv: bool = False,
 ):
     """Convert an ONNX model to an in-memory Core ML model.
 
@@ -1238,6 +1298,21 @@ def convert_to_coreml(
         needs its own entry with that exact string as the key -- it is not
         automatically inferred from the terms it names. ``None`` (the default)
         requires every dimension to be static, as before.
+    matmul_to_conv:
+        Lower a linear-projection ``MatMul`` (``x [batch, sequence, C_in] @ w
+        [C_in, C_out]`` with compile-time-constant ``w``, rank-3 ``x`` -- the
+        shape every attention/MLP projection in a transformer decoder takes)
+        to a 1x1/pointwise ``conv`` instead of MIL's native ``matmul``
+        (default ``False``). The Apple Neural Engine's compute array
+        parallelizes over convolution output channels; its native matmul path
+        measures well below conv1x1's throughput on the same hardware -- see
+        `scripts/apple/README.md <../scripts/apple/README.md>`_'s "Theoretical
+        ceiling" section for the measurements this is based on and whether it
+        actually helps *this* pipeline's shapes (mostly single-token decode
+        steps, unlike the deep, wide chains that finding was measured on).
+        Any ``MatMul`` that doesn't match that exact shape (a non-constant or
+        non-2-D weight, or ``x`` of any rank other than 3) is left on the
+        ``matmul`` path unchanged.
 
     Returns
     -------
@@ -1254,7 +1329,15 @@ def convert_to_coreml(
     mb, types, Function, Program, RangeDim, TensorType = _import_mil()
 
     prog, flexible_inputs = _build_mil_program(
-        model, mb, types, Function, Program, RangeDim, TensorType, dynamic_shapes
+        model,
+        mb,
+        types,
+        Function,
+        Program,
+        RangeDim,
+        TensorType,
+        dynamic_shapes,
+        matmul_to_conv,
     )
 
     kwargs: Dict[str, Any] = {}

--- a/scripts/apple/README.md
+++ b/scripts/apple/README.md
@@ -110,12 +110,23 @@ methodology.
   Core ML's runtime lives); the export step itself needs no Apple hardware.
 
 `coreml-integration.yml`'s `benchmark-decode-macos` job runs this exact pair
-end-to-end on a macOS GitHub-hosted runner, over a small matrix
-(`HuggingFaceTB/SmolLM2-135M-Instruct` and `Qwen/Qwen2.5-1.5B-Instruct` --
-the two architecture families already validated by
-`prepare_benchmark_models.py`, so a translator regression specific to one
-doesn't hide behind the other passing), posting each model's numbers to that
-run's job summary -- `workflow_dispatch`/schedule-only, like the other
+end-to-end on a macOS GitHub-hosted runner, over a matrix spanning the
+smoke-test tier (`HuggingFaceTB/SmolLM2-135M-Instruct`, plus its
+`--quantize-weights`/`--matmul-to-conv` variants -- see below) and the
+few-billion-parameter tier DeviceMark's own leaderboard actually tests
+(`HuggingFaceTB/SmolLM2-1.7B-Instruct`, `Qwen/Qwen2.5-1.5B-Instruct`,
+`Qwen/Qwen2.5-3B-Instruct`, `meta-llama/Llama-3.2-1B-Instruct`,
+`meta-llama/Llama-3.2-3B-Instruct`, `microsoft/Phi-3.5-mini-instruct`) --
+multiple architecture families (Llama-style, Qwen2, Phi-3's fused
+`qkv_proj`/`gate_up_proj` projections) so a translator regression specific
+to one doesn't hide behind another passing. The `Llama-3.2-*` entries are
+gated (need `HF_TOKEN`, same read-only CI secret
+`prepare_benchmark_models.py` already uses); `Qwen2.5-3B-Instruct` and
+`Llama-3.2-3B-Instruct` previously OOM'd during ONNX export/trace in a
+15GB-RAM dev sandbox (see `prepare_benchmark_models.py`'s `BENCHMARK_MODELS`
+notes) -- not a translator issue, but untested on the CI runner's own
+memory until this matrix actually runs them. Posts each model's numbers to
+that run's job summary -- `workflow_dispatch`/schedule-only, like the other
 real-model jobs in that workflow, not on every PR.
 
 ### Theoretical ceiling

--- a/scripts/apple/README.md
+++ b/scripts/apple/README.md
@@ -318,6 +318,15 @@ the same baseline.) Stays opt-in and off by default; not revisiting unless a
 different model size/shape or a cheaper way to express the rewrite changes
 this result.
 
+`coreml-integration.yml`'s `benchmark-decode-macos` job also includes a
+`quantize_weights: int8` + `matmul_to_conv: "true"` matrix entry
+(`smollm2-135m-int8-conv`), checking the two flags together directly rather
+than assuming they compose from the two isolated results above -- int8 only
+changes how the weight constants are stored/dequantized before an op runs,
+matmul-to-conv only changes which op the dequantized weight feeds into, so
+they shouldn't interact, but that's an assumption worth checking rather than
+trusting.
+
 ### Quality and retention eval (`run_quality_eval.py` / `compute_retention.py`)
 
 The decode benchmark and parity check above measure speed and short-generation

--- a/scripts/apple/README.md
+++ b/scripts/apple/README.md
@@ -257,6 +257,52 @@ only the weight constants' on-disk/in-graph representation does.
 baseline) so both the decode-tok/s effect and decode parity are measured on
 real hardware, not just argued for from the theoretical ceiling.
 
+### matmul-to-conv1x1 (`--matmul-to-conv`)
+
+Where `--quantize-weights` targets the bandwidth side of the ceiling,
+`--matmul-to-conv` targets the *compute* side -- the M4 ANE's compute array
+parallelizes over convolution output channels, and its native `matmul` path
+measures well below conv1x1's throughput on the same hardware (see
+"Theoretical ceiling" above: a single matmul reaches ~30% of the fp16
+ceiling; a conv1x1 chain reaches ~99%). `onnxsim/coreml_export.py`'s
+translator normally lowers every ONNX `MatMul` straight to MIL's `matmul`;
+this flag makes it lower a **linear-projection** `MatMul` -- `x [batch,
+sequence, C_in] @ w [C_in, C_out]` with a compile-time-constant 2-D `w`,
+exactly the shape every attention/MLP projection in a transformer decoder
+takes -- to a 1x1/pointwise `conv` instead (transpose to conv1d's `[n, C_in,
+L]` layout, `conv` with a reshaped/transposed weight, transpose back; see
+`convert_to_coreml`'s docstring for exactly which shapes qualify). Any
+`MatMul` that doesn't match that shape (a non-constant or non-2-D weight, or
+`x` of any rank other than 3 -- the real, non-linear-projection attention
+score/context matmuls in every decoder layer, which multiply two activations
+together) is left on the native `matmul` path.
+
+```bash
+python export_llm_to_coreml.py HuggingFaceTB/SmolLM2-135M-Instruct \
+    --max-context-length 512 --matmul-to-conv --output smollm2-conv.mlpackage
+```
+
+Validated so far only at the level this dev sandbox can reach: the rewrite
+is unit-tested for numeric correctness via MIL constant-folding
+(`tests/test_coreml_export.py`, since `conv` itself has no
+`value_inference` to fold through directly, the tests instead pull its
+already-foldable `transpose`/`const` inputs and apply conv1x1's documented
+semantics in plain numpy against the same `MatMul` reference), and a full
+real-model export (`HuggingFaceTB/SmolLM2-135M-Instruct`) converts cleanly
+with an unchanged I/O signature and file size, replacing all 168
+linear-projection matmuls with `conv` while correctly leaving the ~60
+genuine attention-score/context matmuls alone. What that validation
+*cannot* show, lacking macOS/real Core ML in this environment, is whether
+it actually helps decode tok/s at this pipeline's shapes -- the measurements
+this flag is based on come from deep, wide conv1x1 chains (32-64 layers,
+512-1024 channels), not the single-token decode steps this suite mostly
+runs, and per-token sequence length here is far smaller than what those
+measurements used. `coreml-integration.yml`'s `benchmark-decode-macos` job
+includes a `matmul_to_conv: "true"` matrix entry (same model as the
+unquantized baseline, decode parity included) specifically to get that
+answer on real hardware; default it on only once that comparison actually
+shows an improvement.
+
 ### Scaling to few-billion-parameter models
 
 DeviceMark's own leaderboard mostly tests models in the 1-4B range, well

--- a/scripts/apple/README.md
+++ b/scripts/apple/README.md
@@ -303,6 +303,21 @@ unquantized baseline, decode parity included) specifically to get that
 answer on real hardware; default it on only once that comparison actually
 shows an improvement.
 
+**Measured on real hardware** (`HuggingFaceTB/SmolLM2-135M-Instruct`,
+`benchmark-decode-macos`, same runner/run as the unquantized baseline): this
+flag made decode *slower*, not faster -- 2.82 tok/s vs. the matmul
+baseline's 3.62 tok/s (-22%), with prefill roughly 50% slower too (1538ms
+vs. 1025ms for 5 tokens). The opposite of what the raw ANE conv1x1-vs-matmul
+throughput numbers suggested: those come from long, wide conv1x1 chains, not
+this pipeline's short, mostly-single-token sequences, where the extra
+transpose/conv/transpose bookkeeping this rewrite adds around every
+projection apparently costs more than the ANE's per-op throughput gains
+recover. (For reference, `--quantize-weights int8` on the same model/run
+*did* help, as the bandwidth-bound theory predicted: 4.29 tok/s, +18.5% over
+the same baseline.) Stays opt-in and off by default; not revisiting unless a
+different model size/shape or a cheaper way to express the rewrite changes
+this result.
+
 ### Quality and retention eval (`run_quality_eval.py` / `compute_retention.py`)
 
 The decode benchmark and parity check above measure speed and short-generation

--- a/scripts/apple/README.md
+++ b/scripts/apple/README.md
@@ -327,6 +327,19 @@ matmul-to-conv only changes which op the dequantized weight feeds into, so
 they shouldn't interact, but that's an assumption worth checking rather than
 trusting.
 
+**Measured, and they don't compose neutrally.** Same run, same runner, same
+model as the table above: baseline 3.61 tok/s, `--quantize-weights int8`
+alone 4.64 (+28.5%), `--matmul-to-conv` alone 3.04 (-16%), **both together
+2.26 (-37% vs. baseline, worse than either flag alone and worse than
+picking just int8)**. Mean decode step latency follows the same pattern
+(441.6ms combined vs. 215.5ms int8-only). Whatever's behind
+`--matmul-to-conv`'s standalone slowdown -- the added transpose/conv/
+transpose bookkeeping around every projection, most likely -- evidently
+gets worse, not better, once the weights it operates on are also
+quantized, rather than the two costs just adding. Reinforces the same
+conclusion from the solo measurement above: `--matmul-to-conv` isn't worth
+enabling for this pipeline's shapes, combined with int8 or otherwise.
+
 ### Quality and retention eval (`run_quality_eval.py` / `compute_retention.py`)
 
 The decode benchmark and parity check above measure speed and short-generation

--- a/scripts/apple/README.md
+++ b/scripts/apple/README.md
@@ -118,6 +118,77 @@ doesn't hide behind the other passing), posting each model's numbers to that
 run's job summary -- `workflow_dispatch`/schedule-only, like the other
 real-model jobs in that workflow, not on every PR.
 
+### Theoretical ceiling
+
+`run_llm_decode_benchmark.py` reports a decode tok/s number, but not what to
+expect from it. This section gives a back-of-envelope ceiling to compare a
+measured number against, sourced from Manjeet Singh's reverse-engineering of
+the M4 Neural Engine ("Inside the M4 ANE, Part 4: The Complete Machine",
+[maderix.github.io](https://maderix.github.io/articles/inside-the-m4-ane-part-4/),
+Aug 2026) -- the only public source we're aware of with hardware-level,
+measured (not marketing) numbers for this chip.
+
+**M4 ANE (H16G, 16 cores), measured:**
+
+| | |
+| --- | --- |
+| fp16 peak | 19 TFLOPS (18.77 TFLOPS / 98.8% of ceiling measured on a 64-layer conv1x1 chain -- a single isolated matmul only reaches ~30%) |
+| W8A8 (packed int8) peak | 38 TOPS (36.01 TOPS measured) |
+| Power at fp16 peak | 4.57 W (4.1 TFLOPS/W); 0 mW idle |
+| Unified DRAM bandwidth | 120 GB/s, shared with the CPU and GPU |
+| Dispatch floor | ~90 µs of host-side (XPC) overhead per ANE program submission, independent of the work submitted |
+
+**Why decode is bandwidth-bound, not compute-bound.** A single greedy decode
+step (this benchmark's shape: batch 1, one new token, reusing the KV cache)
+does roughly `2 x parameter_count` FLOPs of *compute* -- for
+`Qwen/Qwen2.5-1.5B-Instruct`, about 3 GFLOP, ~160 µs at the ANE's 19 TFLOPS
+ceiling. But producing that token requires reading essentially the entire
+weight set once (nothing amortizes a weight read across tokens at batch
+size 1, unlike prefill's one-pass-over-the-whole-prompt or a
+multi-sequence-batched server), and moving those bytes is the actual
+constraint:
+
+```
+decode tok/s ceiling ≈ DRAM bandwidth / weight bytes read per token
+                      ≈ 120 GB/s / (model parameter count x bytes per weight)
+```
+
+| Model | Params | fp16 weights | fp16 ceiling | int8-weight ceiling |
+| --- | --- | --- | --- | --- |
+| `HuggingFaceTB/SmolLM2-135M-Instruct` | 135M | 270 MB | ~444 tok/s | ~889 tok/s |
+| `Qwen/Qwen2.5-1.5B-Instruct` | 1.5B | 3.0 GB | ~40 tok/s | ~80 tok/s |
+| `HuggingFaceTB/SmolLM2-1.7B-Instruct` | 1.7B | 3.4 GB | ~35 tok/s | ~71 tok/s |
+
+For every model in this table, the bandwidth-bound time per token (µs to
+low-ms) is well past both the ~90 µs ANE dispatch floor and the sub-200 µs
+compute time -- so at these sizes, dispatch overhead and raw FLOPs are noise
+next to weight-streaming time, and the lever that actually moves decode tok/s
+is **bytes per weight**, not compute throughput. (The article's own explicit
+finding backs the general shape of this: *"For LLM inference, prefill
+provides the large matrix operations that suit the ANE. Token-by-token
+decode contains smaller operations for which the 90 µs submission cost can
+dominate, making CPU/SME execution more suitable"* -- true for a
+small-enough model or a system where the ANE isn't reading gigabytes of
+weights per step, but bandwidth dominates first at the model sizes in this
+suite.)
+
+This is also why W8A8 (packed int8 *compute*, up to 1.95x the fp16 rate per
+the article's own measurements) isn't the right lever here: it speeds up the
+compute time we've just shown is already negligible, and per the same
+article, weight-only int8 with fp16 activations "stays on the fp16 compute
+path" -- no compute speedup at all. What halving weight bytes *does* help,
+regardless of compute path, is the number in the denominator above:
+`--quantize-weights` (below) is aimed squarely at that, not at compute
+throughput.
+
+**Caveats:** this ceiling assumes the full 120 GB/s is available to weight
+streaming alone (no contention from the KV-cache read/write, other
+processes, or `MLComputeUnits=ALL` routing some ops to the GPU/CPU instead,
+each with their own bandwidth share); it is an optimistic upper bound, not a
+number `run_llm_decode_benchmark.py` should be expected to hit. It is also
+specific to the M4 -- later chips (see "The M6: Dual ANE" in the source
+article) change these constants.
+
 ### Decode parity (`check_decode_parity.py`)
 
 The decode benchmark above measures speed, not correctness -- a model that
@@ -150,6 +221,41 @@ decode benchmark, once per matrix entry, also posting to the job summary.
 The pure comparison logic (`compare_token_sequences`) has no coremltools/
 torch/transformers dependency and is unit-tested directly in
 `tests/test_check_decode_parity.py`.
+
+### Weight-only quantization (`--quantize-weights`)
+
+The "Theoretical ceiling" section above works out that a decode step is
+bandwidth-bound, not compute-bound, at every model size this suite has
+tested -- the whole weight set has to be read from DRAM once per token
+regardless of how little arithmetic that token needs, since nothing
+amortizes a weight read across tokens at batch size 1. `--quantize-weights
+{int8,int4}` pulls the lever that actually follows from that: it applies
+`coremltools.optimize.coreml.linear_quantize_weights` to the *converted*
+Core ML model (`constexpr_affine_dequantize`, per-channel, symmetric),
+replacing full-precision weight constants with int8/int4 ones that get
+dequantized back to float on the fly at compute time.
+
+```bash
+python export_llm_to_coreml.py HuggingFaceTB/SmolLM2-135M-Instruct \
+    --max-context-length 512 --quantize-weights int8 --output smollm2-int8.mlpackage
+```
+
+Deliberately **not** the same thing as Core ML's packed W8A8 mode (int8
+weights *and* activations, which the M4 ANE can run at up to ~2x the fp16
+*compute* rate): this flag only quantizes weights, leaving activations and
+the actual compute in float, so it doesn't touch the ANE's compute
+throughput at all -- appropriately, since compute isn't the bottleneck here
+per the ceiling analysis. What it does do is roughly halve (int8) or
+quarter (int4) the bytes moved from DRAM per decode step, which is the side
+of the ceiling that's actually binding. `run_llm_decode_benchmark.py` and
+`check_decode_parity.py` both work unchanged against a quantized
+`.mlpackage` -- shapes and dtypes at the model's I/O boundary don't change,
+only the weight constants' on-disk/in-graph representation does.
+
+`coreml-integration.yml`'s `benchmark-decode-macos` job includes a
+`quantize_weights: int8` matrix entry (same model as the unquantized
+baseline) so both the decode-tok/s effect and decode parity are measured on
+real hardware, not just argued for from the theoretical ceiling.
 
 ### Scaling to few-billion-parameter models
 

--- a/scripts/apple/export_llm_to_coreml.py
+++ b/scripts/apple/export_llm_to_coreml.py
@@ -69,6 +69,24 @@ targets for 4-bit weights); this script sets that automatically only for
 `int4`, since `int8`/`none` already work at whatever target
 `onnxsim.export_coreml` otherwise picks.
 
+`--matmul-to-conv` (default off) targets the *other* side of the ceiling --
+compute, not bandwidth -- for the cases where compute still matters (e.g.
+prefill's whole-prompt forward pass, or a bigger batch than this pipeline
+currently does). It lowers each attention/MLP projection's `MatMul` to a
+1x1/pointwise `conv` (`onnxsim.coreml_export`'s `matmul_to_conv`, see
+`onnxsim.export_coreml`'s docstring for exactly which shapes qualify): the
+Apple Neural Engine's compute array parallelizes over convolution output
+channels and its native matmul path measures well below conv1x1's throughput
+on the same hardware -- see README.md's "Theoretical ceiling" section for the
+measurements. This flag is a translator-level structural change (unlike
+`--quantize-weights`, it can in principle affect numeric behavior through a
+different-but-equivalent op sequence, though the underlying math is
+identical), and it has not been measured on real Core ML yet -- it exists so
+`coreml-integration.yml`'s `benchmark-decode-macos` job can actually measure
+whether it helps *this* pipeline's shapes (mostly single-token decode, unlike
+the deep/wide conv1x1 chains the cited measurements used) before anyone
+enables it by default.
+
 Usage:
     python export_llm_to_coreml.py HuggingFaceTB/SmolLM2-135M-Instruct \\
         --max-context-length 512 --output smollm2.mlpackage
@@ -109,6 +127,7 @@ def export_llm_to_coreml(
     convert_to: str = "mlprogram",
     dtype: str = "fp32",
     quantize_weights: str = "none",
+    matmul_to_conv: bool = False,
 ) -> None:
     from optimum.exporters.onnx import main_export
 
@@ -191,6 +210,7 @@ def export_llm_to_coreml(
                 "past_sequence_length": (0, 0, max_context_length - 1),
                 "past_sequence_length + sequence_length": (1, 1, max_context_length),
             },
+            "matmul_to_conv": matmul_to_conv,
         }
         if quantize_weights == "int4":
             # coremltools' linear_quantize_weights refuses int4 below iOS18
@@ -278,6 +298,15 @@ def main() -> int:
         "decode throughput at these model sizes, not compute precision. See the "
         "module docstring and README.md's 'Theoretical ceiling' section.",
     )
+    ap.add_argument(
+        "--matmul-to-conv",
+        action="store_true",
+        help="Lower each attention/MLP projection's MatMul to a 1x1/pointwise conv "
+        "instead of MIL's native matmul (default: off). The M4 ANE's compute array "
+        "parallelizes over convolution output channels; see README.md's 'Theoretical "
+        "ceiling' section for the measurements this is based on. Opt-in and "
+        "unvalidated on real hardware -- benchmark before trusting it.",
+    )
     args = ap.parse_args()
 
     export_llm_to_coreml(
@@ -288,6 +317,7 @@ def main() -> int:
         convert_to=args.convert_to,
         dtype=args.dtype,
         quantize_weights=args.quantize_weights,
+        matmul_to_conv=args.matmul_to_conv,
     )
     return 0
 

--- a/scripts/apple/export_llm_to_coreml.py
+++ b/scripts/apple/export_llm_to_coreml.py
@@ -46,6 +46,29 @@ the in-progress ONNX graph can hold more than one full-size copy of the
 model's weights at once (well over the model's own on-disk size); `--dtype
 fp16` roughly halves that peak.
 
+`--quantize-weights` (default `none`) applies
+`coremltools.optimize.coreml.linear_quantize_weights` to the *converted*
+Core ML model, replacing each weight `const` with
+`constexpr_affine_dequantize`/`constexpr_blockwise_shift_scale` (int8 or
+int4, per-channel, dequantized to float on the fly at compute time). See
+README.md's "Theoretical ceiling" section for why this is the lever worth
+pulling for *decode* specifically: a single-token decode step is
+memory-bandwidth-bound (the compute per token is tiny; the entire weight
+set has to be read from DRAM once per token regardless, since nothing
+amortizes that read across tokens at batch size 1), so halving weight
+bytes is a direct, roughly-proportional lever on decode tok/s -- unlike
+Core ML's packed W8A8 *compute* path (int8 weights **and** activations, up
+to ~2x compute throughput on the M4 ANE), which this flag does not use:
+weight-only quantization keeps activations and compute in float, so it
+doesn't touch the compute-bound side of the ceiling at all, only the
+bandwidth-bound side that actually matters for decode at these model
+sizes. Applied after conversion (not baked into the ONNX graph), so it's
+independent of `--dtype`, which only controls tracing/export precision.
+`int4` needs `minimum_deployment_target=iOS18` (coremltools refuses lower
+targets for 4-bit weights); this script sets that automatically only for
+`int4`, since `int8`/`none` already work at whatever target
+`onnxsim.export_coreml` otherwise picks.
+
 Usage:
     python export_llm_to_coreml.py HuggingFaceTB/SmolLM2-135M-Instruct \\
         --max-context-length 512 --output smollm2.mlpackage
@@ -85,6 +108,7 @@ def export_llm_to_coreml(
     opset: int = 17,
     convert_to: str = "mlprogram",
     dtype: str = "fp32",
+    quantize_weights: str = "none",
 ) -> None:
     from optimum.exporters.onnx import main_export
 
@@ -156,16 +180,43 @@ def export_llm_to_coreml(
         print(f"  {num_nodes_before} -> {len(simplified.graph.node)} nodes", flush=True)
 
         print(f"Converting to Core ML ({convert_to}), dynamic KV cache...", flush=True)
-        onnxsim.export_coreml(
-            simplified,
-            output_path,
-            convert_to=convert_to,
-            dynamic_shapes={
+        # Captured (not saved directly to output_path) so --quantize-weights can
+        # compress it in place first; export_coreml() returns the MLModel either
+        # way (see its docstring), so this doesn't change behavior when
+        # quantize_weights="none".
+        convert_kwargs = {
+            "convert_to": convert_to,
+            "dynamic_shapes": {
                 "sequence_length": (1, 1, max_context_length),
                 "past_sequence_length": (0, 0, max_context_length - 1),
                 "past_sequence_length + sequence_length": (1, 1, max_context_length),
             },
-        )
+        }
+        if quantize_weights == "int4":
+            # coremltools' linear_quantize_weights refuses int4 below iOS18
+            # ("The 4-bit quantization is supported since iOS18") -- int8 and
+            # "none" work fine at whatever target onnxsim.export_coreml picks by
+            # default (already high enough for the dynamic-shape RangeDim inputs
+            # this export needs), so this bump is scoped to int4 only.
+            convert_kwargs["minimum_deployment_target"] = "iOS18"
+        mlmodel = onnxsim.export_coreml(simplified, **convert_kwargs)
+
+        if quantize_weights != "none":
+            print(
+                f"Quantizing weights ({quantize_weights}, per-channel)...", flush=True
+            )
+            import coremltools.optimize.coreml as cto
+
+            config = cto.OptimizationConfig(
+                global_config=cto.OpLinearQuantizerConfig(
+                    mode="linear_symmetric",
+                    dtype=quantize_weights,
+                    granularity="per_channel",
+                )
+            )
+            mlmodel = cto.linear_quantize_weights(mlmodel, config)
+
+        mlmodel.save(output_path)
 
         # Carry the tokenizer along so run_llm_decode_benchmark.py can load
         # everything it needs from `output_path`'s sibling files.
@@ -218,6 +269,15 @@ def main() -> int:
         "fp16 for multi-billion-parameter models where tracing in float32 risks "
         "running out of memory (see the module docstring).",
     )
+    ap.add_argument(
+        "--quantize-weights",
+        choices=["none", "int8", "int4"],
+        default="none",
+        help="Weight-only post-conversion quantization (default: none). Reduces "
+        "weight bytes read from DRAM per decode step -- the lever that matters for "
+        "decode throughput at these model sizes, not compute precision. See the "
+        "module docstring and README.md's 'Theoretical ceiling' section.",
+    )
     args = ap.parse_args()
 
     export_llm_to_coreml(
@@ -227,6 +287,7 @@ def main() -> int:
         opset=args.opset,
         convert_to=args.convert_to,
         dtype=args.dtype,
+        quantize_weights=args.quantize_weights,
     )
     return 0
 

--- a/scripts/apple/lm_eval_coreml_adapter.py
+++ b/scripts/apple/lm_eval_coreml_adapter.py
@@ -66,6 +66,24 @@ class CoreMLLM(LM):
         self.decoder = CoreMLDecoder(pretrained, compute_units=compute_units)
         self.default_max_gen_toks = max_gen_toks
 
+    @property
+    def tokenizer_name(self) -> str:
+        """Fingerprint for lm_eval's request cache, used only with --apply-chat-template."""
+        return self.tokenizer.name_or_path.replace("/", "__")
+
+    def apply_chat_template(
+        self, chat_history: list[dict[str, str]], add_generation_prompt: bool = True
+    ) -> str:
+        """Format few-shot chat history via the HF tokenizer's own chat template.
+
+        Same job export_llm_to_coreml.py's tokenizer performs at export time --
+        reused here since --apply-chat-template needs it before generation, not
+        baked into the exported graph.
+        """
+        return self.tokenizer.apply_chat_template(
+            chat_history, tokenize=False, add_generation_prompt=add_generation_prompt
+        )
+
     def _generate_one(self, context: str, gen_kwargs: dict) -> str:
         until = gen_kwargs.get("until") or []
         if isinstance(until, str):

--- a/tests/test_coreml_export.py
+++ b/tests/test_coreml_export.py
@@ -368,6 +368,148 @@ def test_zero_length_input_dimension_is_static():
 
 
 # ---------------------------------------------------------------------------
+# matmul_to_conv (opt-in: lower a linear-projection MatMul to conv1x1 -- see
+# convert_to_coreml's docstring and scripts/apple/README.md's "Theoretical
+# ceiling" section for why). MIL's `conv` has no `value_inference`, unlike
+# `matmul`/`transpose`/`const`, so `_mil_const_value` (which needs the whole
+# graph to constant-fold to a single value) can't check a conv1x1 output
+# directly. Instead these tests pull the `conv` op's own (constant-folded)
+# *inputs* -- which do fold, since they're `transpose`/`const` outputs -- and
+# apply conv1x1's documented semantics (K=1, stride=1, pad=valid: a per-position
+# linear map) in plain numpy, checked against the same MatMul reference the
+# rewrite is replacing.
+# ---------------------------------------------------------------------------
+
+
+def _build_ops(model: onnx.ModelProto, dynamic_shapes=None, matmul_to_conv=False):
+    """Like ``_mil_const_value``, but returns the built MIL function itself
+    (not just a folded output value) -- for inspecting *which* ops got
+    emitted, or reading an intermediate (not just the final output) value.
+    """
+    prog, flexible_inputs = coreml_export._build_mil_program(
+        model,
+        *coreml_export._import_mil(),
+        dynamic_shapes,
+        matmul_to_conv,
+    )
+    return prog.functions["main"], flexible_inputs
+
+
+def _matmul_projection_model(a: np.ndarray, w: np.ndarray) -> onnx.ModelProto:
+    """``out = a @ w`` with both as initializers -- the shape every
+    attention/MLP projection in a transformer decoder takes: ``a`` is
+    ``[batch, sequence, C_in]`` (rank 3), ``w`` is a constant ``[C_in, C_out]``.
+    """
+    n, s, c_in = a.shape
+    c_out = w.shape[1]
+    inits = [numpy_helper.from_array(a, name="a"), numpy_helper.from_array(w, name="w")]
+    model = _model(
+        f"mm () => (float[{n},{s},{c_out}] out) {{ out = MatMul (a, w) }}",
+        initializer=inits,
+    )
+    onnx.checker.check_model(model)
+    return model
+
+
+def test_matmul_to_conv_disabled_by_default():
+    a = np.random.RandomState(0).randn(1, 3, 4).astype(np.float32)
+    w = np.random.RandomState(1).randn(4, 5).astype(np.float32)
+    model = _matmul_projection_model(a, w)
+
+    func, _ = _build_ops(model)  # matmul_to_conv defaults to False
+    op_types = [op.op_type for op in func.operations]
+    assert "matmul" in op_types
+    assert "conv" not in op_types
+    np.testing.assert_allclose(np.asarray(func.outputs[0].val), a @ w, atol=1e-5)
+
+
+def test_matmul_to_conv_rewrites_rank3_constant_projection():
+    a = np.random.RandomState(0).randn(1, 3, 4).astype(np.float32)
+    w = np.random.RandomState(1).randn(4, 5).astype(np.float32)
+    model = _matmul_projection_model(a, w)
+
+    func, _ = _build_ops(model, matmul_to_conv=True)
+    op_types = [op.op_type for op in func.operations]
+    assert "conv" in op_types
+    assert "matmul" not in op_types
+
+    (conv_op,) = [op for op in func.operations if op.op_type == "conv"]
+    x_in, w_in = conv_op.inputs["x"], conv_op.inputs["weight"]
+    # x transposed to conv1d's [n, C_in, L] layout; weight reshaped from
+    # MatMul's [C_in, C_out] to conv's [C_out, C_in, K=1].
+    np.testing.assert_allclose(x_in.val, a.transpose(0, 2, 1))
+    np.testing.assert_allclose(w_in.val, w.T[:, :, None])
+
+    # conv1x1 (K=1, stride=1, pad=valid) is, by definition, a per-position
+    # linear map -- apply that directly and check it lines up with the plain
+    # MatMul it's replacing.
+    manual_conv_out = np.einsum("ncl,oc->nol", x_in.val, w_in.val[:, :, 0])
+    np.testing.assert_allclose(manual_conv_out.transpose(0, 2, 1), a @ w, atol=1e-5)
+
+
+def test_matmul_to_conv_falls_back_for_non_constant_weight():
+    # Same shapes as the rewritten case above, but `w` is a declared graph
+    # input (not an initializer) -- not compile-time-constant, so the
+    # translator must leave this on the matmul path even with
+    # matmul_to_conv=True.
+    a = numpy_helper.from_array(
+        np.random.RandomState(0).randn(1, 3, 4).astype(np.float32), name="a"
+    )
+    model = _model(
+        "mm (float[4,5] w) => (float[1,3,5] out) { out = MatMul (a, w) }",
+        initializer=[a],
+    )
+    onnx.checker.check_model(model)
+
+    func, _ = _build_ops(model, matmul_to_conv=True)
+    op_types = [op.op_type for op in func.operations]
+    assert "matmul" in op_types
+    assert "conv" not in op_types
+
+
+def test_matmul_to_conv_falls_back_for_rank2_input():
+    # Same constant-weight shape as the rewritten case, but `a` is rank 2 (no
+    # separate batch/sequence axes) -- only rank-3 x is handled (see
+    # _matmul_as_conv1x1's docstring), so this must still use matmul.
+    a = np.random.RandomState(0).randn(3, 4).astype(np.float32)
+    w = np.random.RandomState(1).randn(4, 5).astype(np.float32)
+    inits = [numpy_helper.from_array(a, name="a"), numpy_helper.from_array(w, name="w")]
+    model = _model(
+        "mm () => (float[3,5] out) { out = MatMul (a, w) }", initializer=inits
+    )
+    onnx.checker.check_model(model)
+
+    func, _ = _build_ops(model, matmul_to_conv=True)
+    op_types = [op.op_type for op in func.operations]
+    assert "matmul" in op_types
+    assert "conv" not in op_types
+    np.testing.assert_allclose(np.asarray(func.outputs[0].val), a @ w, atol=1e-5)
+
+
+def test_matmul_to_conv_composes_with_dynamic_sequence_length():
+    # The actual target shape this rewrite exists for: a rank-3 input whose
+    # middle (sequence) axis is dynamic, exactly like export_llm_to_coreml.py's
+    # KV-cache decoder graphs. `a` can't be an initializer here (dynamic_shapes
+    # only applies to declared graph inputs), so this only checks the program
+    # builds and emits `conv` -- not a folded numeric value.
+    w = numpy_helper.from_array(
+        np.random.RandomState(1).randn(4, 5).astype(np.float32), name="w"
+    )
+    model = _model(
+        "mm (float[1,seq,4] a) => (float[1,seq,5] out) { out = MatMul (a, w) }",
+        initializer=[w],
+    )
+    onnx.checker.check_model(model)
+
+    func, flexible_inputs = _build_ops(
+        model, dynamic_shapes={"seq": (1, 4, 16)}, matmul_to_conv=True
+    )
+    op_types = [op.op_type for op in func.operations]
+    assert "conv" in op_types
+    assert flexible_inputs is not None and len(flexible_inputs) == 1
+
+
+# ---------------------------------------------------------------------------
 # Dynamic shapes (opt-in flexible input dimensions, e.g. a growing KV cache)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
scripts/apple/README.md's new "Theoretical ceiling" section works out,
from measured M4 Neural Engine numbers (19 TFLOPS fp16, 120 GB/s DRAM,
~90us dispatch floor -- Manjeet Singh, "Inside the M4 ANE, Part 4"), that
a single-token decode step is memory-bandwidth-bound rather than
compute-bound at every model size this suite has tested: the whole weight
set has to be read from DRAM once per token regardless, since nothing
amortizes that read across tokens at batch size 1.

export_llm_to_coreml.py's new --quantize-weights {int8,int4} flag follows
directly from that: it applies coremltools.optimize.coreml
.linear_quantize_weights to the converted model (constexpr_affine_dequantize,
per-channel, weights only -- activations and compute stay in float), which
targets the bandwidth side of the ceiling rather than Core ML's packed
W8A8 compute path. int4 needs minimum_deployment_target=iOS18
(coremltools refuses lower targets), applied only when requested so the
existing int8/none behavior is unaffected.

Validated locally (MIL construction/quantization needs no macOS -- only
running the model does): int8 and int4 both produce a .mlpackage with an
I/O signature identical to the unquantized baseline, and on-disk weight
bytes shrink to ~50% (int8) and ~25% (int4) of the fp16 baseline, matching
the bandwidth-bound theory exactly. coreml-integration.yml's
benchmark-decode-macos job gains a quantize_weights: int8 matrix entry so
the actual decode-tok/s effect and decode parity are measured on real
Core ML, not just argued for.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01T3MD7VAmysceuqiBQYHvWQ