### PR TITLE
GQA pruning: support CPU/DirectML Q/K-norm + RoPE pass-through in packed-QKV chains

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -9610,9 +9610,21 @@ def apply_structured_pruning_matmul_nbits(
 #   pattern (Microsoft's own onnxruntime-genai model builder's fused
 #   Q/K-norm GQA path, e.g. Qwen3-style models on CUDA/WebGPU) rather than
 #   assumed -- see :func:`_match_packed_qkv_split`'s own docstring for the
-#   exact topology matched, the export code path that produces it, and the
-#   narrower shapes (Q/K-norm without the in-op-fused path, or no Q/K-norm
-#   at all) deliberately left unmatched. Pruning a KV group out of a packed
+#   exact topology matched and the export code path that produces it. The
+#   CPU/DirectML variant of that same export path -- Q/K-norm requested but
+#   the fused in-op norm path unsupported there, so a per-head
+#   `SimplifiedLayerNorm` (and, unless RoPE is fused into the op itself, a
+#   `RotaryEmbedding`) sits between the `Split` and the op's own Q/K
+#   inputs -- is *also* matched, via :func:`_walk_back_through_qk_norm_rope`
+#   (see that function's own docstring for the exact topology and its own
+#   confirmed head-independence: neither the norm's own `scale` nor
+#   `RotaryEmbedding`'s `cos_cache`/`sin_cache` ever needs slicing, only a
+#   crossed `RotaryEmbedding`'s own `num_heads` attribute and a crossed
+#   `Reshape`'s own target width, both handled by
+#   :func:`_apply_one_gqa_chain`). Only a shape genuinely outside both of
+#   these -- an unrecognized op in the way, RoPE applied *before* norm, or
+#   no `Split` at all upstream of Q/K -- is still deliberately left
+#   unmatched. Pruning a KV group out of a packed
 #   chain removes that group's own Q/K/V column ranges from the *one*
 #   shared packed weight (and its packed bias, if any) in a single combined
 #   slice, and shrinks the `Split` node's own split-sizes constant to
@@ -9850,6 +9862,18 @@ class _GQAChain:
     # per-producer slices that would each invalidate the others' column
     # offsets into the same underlying storage.
     packed_split_sizes: Optional[str] = None
+    # Set only alongside `packed_split_sizes`, and only when a per-head
+    # Q/K-norm + RoPE "pass-through" (see :class:`_QKNormRopePassThrough`
+    # and :func:`_walk_back_through_qk_norm_rope`) was crossed walking back
+    # from `.node`'s own Q (`.q_norm_rope`) or K (`.k_norm_rope`) input to
+    # the shared `Split` -- the CPU/DirectML Q/K-norm GQA export shape
+    # `_match_packed_qkv_split`'s own docstring names as *not* matched by
+    # that function alone. ``None`` (the default) whenever that particular
+    # branch feeds `.node` directly from the `Split` with no hop in
+    # between -- every ordinary packed-QKV chain, matched before this
+    # pass-through existed, gets ``None`` on both exactly as before.
+    q_norm_rope: Optional["_QKNormRopePassThrough"] = None
+    k_norm_rope: Optional["_QKNormRopePassThrough"] = None
 
 
 # Either kind of matched attention block, sharing enough of a common shape
@@ -10414,15 +10438,35 @@ def _match_packed_qkv_split(
     inputs -- exactly the shape matched here). The common case with no
     Q/K norm instead relies on `GroupQueryAttention`'s own native
     packed-`query`-input convention and emits no `Split` at all, and the
-    case with Q/K norm but *no* fused in-op norm support instead runs
-    per-head `SimplifiedLayerNorm` (and, unless RoPE is itself fused into
-    the op, `RotaryEmbedding`) nodes between the `Split` and the op's own
-    inputs -- a shape this function does not match (its `Split` must feed
-    the consuming op's inputs directly, with nothing declined/matched
-    read here) and :func:`_find_separate_qkv_chains`'s own per-branch
-    :func:`_match_producer` walk declines like any other unrecognized
-    producer, rather than silently mis-slicing a shape this pass hasn't
-    verified.
+    case with Q/K norm but *no* fused in-op norm support (CPU/DirectML --
+    `is_fused_qk_norm_gqa_supported` only allows the in-op path on
+    CUDA/WebGPU) instead runs per-head `SimplifiedLayerNorm` (via a
+    `Reshape` -> `SimplifiedLayerNormalization` -> `Reshape` sandwich --
+    `make_qk_norm`'s own subgraph, confirmed by reading it directly) and,
+    unless RoPE is itself fused into the op, a `com.microsoft::RotaryEmbedding`
+    node between the `Split` and the op's own Q/K inputs (`make_qk_norm`
+    then `make_rotary_embedding_op`, in that order, per
+    `make_attention_qk_rope_and_norm`'s own comment "Base order: norm
+    first, then RoPE"). This function itself still requires `split_node`'s
+    own three outputs to feed *something* directly -- it never looks past
+    `split_node` itself -- but its caller,
+    :func:`_find_separate_qkv_chains`, no longer requires that something to
+    be the attention op's own Q/K inputs verbatim: it first walks *back*
+    from those inputs, via :func:`_walk_back_through_qk_norm_rope`, through
+    exactly this Reshape/Norm/Reshape-then-RotaryEmbedding shape (each hop
+    optional, independently, on Q's and K's own branch) to find the real
+    `Split` outputs this function is given, so the two together now cover
+    this CPU/DirectML shape too -- see that function's own docstring for
+    the exact topology and how its own head-independence (no gamma
+    slicing, no `RotaryEmbedding` weight/cache slicing -- only its own
+    `num_heads` attribute, when nonzero, and a crossed `Reshape`'s own
+    target-width entry ever need updating) was confirmed. Only a `Split`
+    output feeding neither the attention op directly nor one of these
+    exact hops -- an unrecognized intermediate op, a branch, RoPE before
+    norm, or a shape this pass hasn't otherwise verified -- still falls
+    through to :func:`_find_separate_qkv_chains`'s own per-branch
+    :func:`_match_producer` walk, which declines it like any other
+    unrecognized producer rather than silently mis-slicing it.
 
     Declines (``None``) unless every one of the following holds, checked
     with the same conservative bar as every other producer match in this
@@ -10498,6 +10542,299 @@ def _match_packed_qkv_split(
     return w_name, w_transposed, bias_name, nq, nk, nv, sizes_name
 
 
+# Scope boundaries this section lands on, deliberately: the CPU/DirectML
+# Q/K-norm GQA export shape (see :func:`_match_packed_qkv_split`'s own
+# docstring) inserts, between a packed-QKV `Split`'s own Q/K outputs and
+# `GroupQueryAttention`'s (or the plain ai.onnx `Attention` op's) own Q/K
+# inputs, an optional per-head norm sandwich (a `Reshape` collapsing
+# `(batch, seq, hidden)` to `(batch, seq * num_heads, head_size)`, a
+# `SimplifiedLayerNormalization` with its default `axis=-1` and a
+# `[head_size]` `scale` -- `make_qk_norm`'s own subgraph, read directly off
+# `onnxruntime_genai/models/builders/base.py`) and, unless RoPE is fused
+# into the attention op itself, an optional `com.microsoft::RotaryEmbedding`
+# node applied directly to the flat `(batch, seq, hidden)` tensor
+# (`make_rotary_embedding_op`), norm before RoPE when both are present
+# (`make_attention_qk_rope_and_norm`'s own comment: "Base order: norm
+# first, then RoPE"). :func:`_walk_back_through_qk_norm_rope` below walks
+# *backward* from the attention op's own Q or K input through this exact
+# optional-hop sequence to find the `Split` output feeding it, the same
+# direction :func:`_walk_matmul_producer_backward` already walks in this
+# module for an unrelated reason (residual-chain producers), and for the
+# same reason: the *forward* direction (`_walk_to_consumer`'s own style)
+# would need to start from the `Split`'s own output, guessing which
+# consumer among possibly several to follow, before it's known whether the
+# far end is even this attention op's own Q/K input at all.
+#
+# Two head-independence facts make every hop here safe to prune through
+# with **no slicing of the hop's own constants at all** -- confirmed
+# empirically (real `onnxruntime.InferenceSession` runs, not the schema
+# doc alone; see ``tests/test_pruning.py``'s own
+# ``test_simplified_layer_norm_is_head_independent_for_pruning``/
+# ``test_rotary_embedding_is_head_independent_for_pruning`` for the exact
+# models and numbers), not assumed:
+#
+# - `SimplifiedLayerNormalization`'s own `scale` (`[head_size]`, confirmed
+#   live via `onnxruntime.capi.onnxruntime_pybind11_state
+#   .get_all_operator_schema()` -- this op isn't in onnx's own schema
+#   registry at all despite registering under the default ("") domain, see
+#   this module's own `_NORM_PASS_THROUGH_OPS` comment far above -- on this
+#   environment's installed `onnx==1.22.0`/`onnxruntime==1.29.0` -- no
+#   `bias`/`B` input at all, unlike plain `LayerNormalization`) broadcasts
+#   *identically* to every head's own row regardless of how many heads
+#   exist: reducing over exactly the trailing `head_size` axis per
+#   `(batch, seq, head)` triple, with the *same* `scale` array applied to
+#   every head, dropping whole heads before or after this norm gives
+#   bit-identical results for the surviving heads either way (confirmed
+#   with a hand-built `Reshape` -> `SimplifiedLayerNormalization` ->
+#   `Reshape` model, keeping an arbitrary, non-contiguous subset of heads,
+#   `max abs diff == 0.0` both before and after). So, unlike every other
+#   per-channel affine operand this module tracks (`_NORM_PASS_THROUGH_OPS`'s
+#   own `scale`/`bias`, `_skip_layer_norm_const_names`'s own `gamma`/`beta`),
+#   this norm's own `scale` is *never* sliced here -- there is nothing
+#   head-shaped about it to slice.
+# - `com.microsoft::RotaryEmbedding` (confirmed live via
+#   `onnxruntime.capi.onnxruntime_pybind11_state.get_all_operator_schema()`
+#   to be a real op under that domain, inputs `[input, position_ids,
+#   cos_cache, sin_cache]`, attributes `num_heads`/`rotary_embedding_dim`/
+#   `interleaved`/`is_packed_batching`/`scale`) rotates each head's own
+#   `head_size` (or `rotary_embedding_dim`-wide prefix of it) slice using
+#   only that head's own data and a position-dependent (never head-
+#   dependent) `cos_cache`/`sin_cache` lookup -- confirmed head-independent,
+#   again bit-identical, across every `interleaved` (0 and 1) and
+#   full-vs-partial `rotary_embedding_dim` combination tried. Its own
+#   `num_heads` attribute is the *one* constant here that does need
+#   updating post-pruning -- unless it's already the schema's `0`
+#   ("infer `num_heads` from the input's own trailing width divided by
+#   `cos_cache`'s/`rotary_embedding_dim`'s own implied `head_size`",
+#   confirmed to self-adjust correctly to a smaller post-pruning head count
+#   with *no* attribute change needed at all) -- to the new post-pruning
+#   head count for whichever branch (Q's `num_heads`, K's `kv_num_heads`)
+#   it sits on; neither `cos_cache` nor `sin_cache` themselves ever need
+#   touching, having no head axis at all.
+#
+# A `Reshape`'s own two target-shape entries are `head_size` (never
+# changes) and this branch's flat width (`num_heads * head_size` or
+# `kv_num_heads * head_size`, which *does* shrink) -- only the second
+# `Reshape` (the one reconstructing the flat `(batch, seq, hidden)` shape
+# right after the norm) ever encodes the latter as a literal, and only
+# when it does (a resolvable, single-consumer constant -- see
+# :func:`_reshape_last_dim`) is that hop even crossed; otherwise the walk
+# simply doesn't cross it, and the match declines further up the call
+# chain the same way any other unrecognized shape does.
+#
+# Neither the `Reshape` collapsing to `(batch, seq * num_heads, head_size)`
+# ahead of the norm nor the norm's own training-only `inv_std_var` second
+# output (already declined, the same way, by `_walk_to_consumer`'s own
+# `_NORM_PASS_THROUGH_OPS` hop, whenever it's actually consumed) needs any
+# constant update at all -- neither depends on how many heads survive.
+@dataclass(frozen=True)
+class _QKNormRopePassThrough:
+    """One resolved Q- or K-branch "per-head norm + RoPE" pass-through a
+    packed-QKV chain walk crossed between a `_GQAChain`'s own `Split` (see
+    `_GQAChain.packed_split_sizes`) and the attention op's own Q or K
+    input -- see :func:`_walk_back_through_qk_norm_rope` (which builds
+    this) for the exact topology and how its head-independence was
+    confirmed. Unlike :class:`_ConvPassThrough`'s own `weight`/`bias`
+    fields, nothing here names a tensor :func:`_apply_one_gqa_chain` needs
+    to *slice* -- this section's own comment above covers why neither a
+    crossed norm's `scale` nor a crossed `RotaryEmbedding`'s `cos_cache`/
+    `sin_cache` ever needs touching. Two things still do:
+
+    - `rotary_node`: the crossed `RotaryEmbedding` node, or ``None`` when
+      RoPE wasn't crossed (norm-only, or neither). When present, its own
+      `num_heads` attribute -- whenever it isn't already the schema's `0`
+      -- is rewritten to this branch's new post-pruning head count.
+    - `reshape_shape`: the crossed post-norm `Reshape`'s own target-shape
+      constant name, or ``None`` when that `Reshape`/norm sandwich wasn't
+      crossed (RoPE-only, or neither). When present, its own last entry
+      (this branch's flat width) is rewritten to the new post-pruning
+      value, mirroring how :func:`_apply_one_gqa_chain`'s existing
+      `chain.chain_ops` loop already rewrites a *post*-attention-output
+      Reshape's own target width.
+
+    `nodes` lists every node actually crossed (any of `RotaryEmbedding`,
+    the post-norm `Reshape`, the `SimplifiedLayerNormalization`, and the
+    pre-norm `Reshape`, in that order, whichever were present) purely for
+    :func:`_apply_attention_chains`'s own stale-`value_info` bookkeeping --
+    every one of their own output tensors is narrower after pruning even
+    though, per the two fields above, only two of them ever need editing.
+    Never empty when this class is actually constructed --
+    :func:`_walk_back_through_qk_norm_rope` returns ``None`` instead of an
+    empty-`nodes` instance when nothing was crossed.
+    """
+
+    nodes: Tuple[onnx.NodeProto, ...]
+    rotary_node: Optional[onnx.NodeProto] = None
+    reshape_shape: Optional[str] = None
+
+
+def _walk_back_through_qk_norm_rope(
+    name: str,
+    initializer_map: Dict[str, onnx.TensorProto],
+    consumers_of: Dict[str, List[onnx.NodeProto]],
+    graph_outputs: Set[str],
+    node_by_output: Dict[str, onnx.NodeProto],
+) -> Tuple[str, Optional[_QKNormRopePassThrough]]:
+    """Walks *backward* from `name` -- `GroupQueryAttention`'s (or the
+    plain ai.onnx `Attention` op's) own Q or K input, already confirmed by
+    the caller to have exactly one consumer -- through an optional
+    `com.microsoft::RotaryEmbedding` node and, further back, an optional
+    `Reshape` -> `SimplifiedLayerNormalization` -> `Reshape` "per-head norm"
+    sandwich, stopping at the first tensor not produced by one of these two
+    recognized hops (each independently optional; the whole point of this
+    walk is that `name` may sit directly on a packed-QKV `Split`'s own
+    output with *neither* hop present at all, exactly as before this
+    pass-through existed). See this section's own comment above for the
+    exact topology (confirmed against onnxruntime-genai's own model
+    builder source) and the head-independence facts that make every hop
+    here safe with no constant slicing beyond what :class:`_QKNormRopePassThrough`
+    already names.
+
+    Every hop crossed is additionally required to have exactly one
+    consumer at each internal edge (the next hop inward, or `name`'s own
+    eventual attention-op input) and not itself be a graph output -- the
+    same "no other consumer along the way" bar every forward chain walk in
+    this module already holds (:func:`_walk_to_consumer`) -- so a norm/RoPE
+    tensor secretly reused elsewhere (a residual branch, a second attention
+    op) safely stops the walk there rather than risking a corrupting slice.
+    A crossed norm's own `inv_std_var` second output, when itself consumed
+    by anything, likewise stops the walk at that node -- the same
+    training-only-secondary-output bar :func:`_walk_to_consumer`'s own
+    `_NORM_PASS_THROUGH_OPS` hop already holds. A crossed post-norm
+    `Reshape`'s own target-shape input must be a constant whose last entry
+    is statically resolvable (:func:`_reshape_last_dim`) and single-consumer
+    (safe to overwrite in place) -- the same bar
+    :func:`_walk_to_attention_consumer`'s own Reshape hop already holds its
+    shape constant to -- or that `Reshape` (and, transitively, the norm
+    sandwich behind it) simply isn't crossed.
+
+    The norm's own `scale` is only confirmed here to be a flat
+    per-channel-shaped float constant (:func:`_flat_channel_const`) -- the
+    real ``dims == [head_size]`` check, only possible once `head_size` is
+    itself known (only after the packed producer this walk is feeding into
+    is resolved, which needs this walk's own result first), is left to the
+    caller (:func:`_qk_norm_rope_hop_is_consistent`), the same
+    deferred-check idiom :func:`_norm_pass_through_const_names` already
+    uses for its own `_NORM_PASS_THROUGH_OPS` hop.
+
+    Returns ``(root_name, hop)``: `root_name` is `name` itself and `hop` is
+    ``None`` when neither hop was crossed (the pre-existing, still-most-common
+    "Split feeds the attention op directly" shape); otherwise `root_name` is
+    the tensor immediately upstream of every hop crossed (expected, by the
+    caller, to be one of the shared `Split`'s own raw outputs) and `hop`
+    describes what was crossed.
+    """
+
+    def _is_internal(n: str) -> bool:
+        return len(consumers_of.get(n, [])) == 1 and n not in graph_outputs
+
+    nodes: List[onnx.NodeProto] = []
+    rotary_node: Optional[onnx.NodeProto] = None
+    reshape_shape: Optional[str] = None
+    cur = name
+
+    rope = node_by_output.get(cur)
+    if (
+        rope is not None
+        and rope.domain == _ATTENTION_DOMAIN
+        and rope.op_type == "RotaryEmbedding"
+        and len(rope.input) >= 1
+        and rope.input[0]
+        and len(rope.output) == 1
+        and rope.output[0] == cur
+        and _is_internal(rope.input[0])
+    ):
+        rotary_node = rope
+        nodes.append(rope)
+        cur = rope.input[0]
+
+    reshape2 = node_by_output.get(cur)
+    if (
+        reshape2 is not None
+        and reshape2.domain == ""
+        and reshape2.op_type == "Reshape"
+        and len(reshape2.input) == 2
+        and reshape2.input[0]
+        and len(reshape2.output) == 1
+        and reshape2.output[0] == cur
+        and _is_internal(reshape2.input[0])
+        and _reshape_last_dim(reshape2, initializer_map) is not None
+        and len(consumers_of.get(reshape2.input[1], [])) == 1
+    ):
+        norm_out = reshape2.input[0]
+        norm_node = node_by_output.get(norm_out)
+        if (
+            norm_node is not None
+            and norm_node.domain == ""
+            and norm_node.op_type == "SimplifiedLayerNormalization"
+            and len(norm_node.output) >= 1
+            and norm_node.output[0] == norm_out
+            and len(norm_node.input) == 2
+            and norm_node.input[1]
+            and _flat_channel_const(norm_node.input[1], initializer_map)
+            and _norm_axis_is_last(norm_node, norm_node.input[0], None)
+            and not (
+                len(norm_node.output) > 1
+                and norm_node.output[1]
+                and (
+                    consumers_of.get(norm_node.output[1])
+                    or norm_node.output[1] in graph_outputs
+                )
+            )
+            and norm_node.input[0]
+            and _is_internal(norm_node.input[0])
+        ):
+            reshape1 = node_by_output.get(norm_node.input[0])
+            if (
+                reshape1 is not None
+                and reshape1.domain == ""
+                and reshape1.op_type == "Reshape"
+                and len(reshape1.input) == 2
+                and reshape1.input[0]
+                and len(reshape1.output) == 1
+                and reshape1.output[0] == norm_node.input[0]
+                and _is_internal(reshape1.input[0])
+            ):
+                nodes.extend([reshape2, norm_node, reshape1])
+                reshape_shape = reshape2.input[1]
+                cur = reshape1.input[0]
+
+    if not nodes:
+        return name, None
+    return cur, _QKNormRopePassThrough(tuple(nodes), rotary_node, reshape_shape)
+
+
+def _qk_norm_rope_hop_is_consistent(
+    hop: Optional[_QKNormRopePassThrough],
+    initializer_map: Dict[str, onnx.TensorProto],
+    branch_width: int,
+    head_size: int,
+) -> bool:
+    """Deferred correctness check for a :func:`_walk_back_through_qk_norm_rope`
+    result, run only once `branch_width` (this branch's own pre-pruning
+    `nq`/`nk`) and `head_size` are themselves known -- see that function's
+    own docstring for why this can't be checked any earlier. `True`
+    (nothing to check) when `hop` is ``None`` (no pass-through crossed for
+    this branch). Otherwise: any crossed `SimplifiedLayerNormalization`'s
+    own `scale` must be exactly `[head_size]`-shaped (not just flat -- the
+    real per-head-width fact the walk itself deferred), and, when a post-norm
+    `Reshape` was crossed, its own target-shape constant's last entry must
+    exactly equal `branch_width` -- both declined (``False``), never
+    guessed at, on any mismatch.
+    """
+    if hop is None:
+        return True
+    for node in hop.nodes:
+        if node.op_type == "SimplifiedLayerNormalization":
+            if list(initializer_map[node.input[1]].dims) != [head_size]:
+                return False
+    if hop.reshape_shape is not None:
+        dims = onnx.numpy_helper.to_array(initializer_map[hop.reshape_shape])
+        if dims.size == 0 or int(dims[-1]) != branch_width:
+            return False
+    return True
+
+
 def _find_separate_qkv_chains(
     graph: onnx.GraphProto,
     match_producer,
@@ -10548,16 +10885,45 @@ def _find_separate_qkv_chains(
         # other shape (three genuinely independent producers, or anything
         # this function doesn't recognize) falls to that per-branch loop
         # unchanged.
+        #
+        # `root_q`/`root_k` walk *backward* from Q's/K's own attention-op
+        # input through an optional per-head norm + RoPE pass-through (see
+        # :func:`_walk_back_through_qk_norm_rope` and this section's own
+        # comment above) before checking for the shared `Split` -- `q_name`/
+        # `k_name` unchanged (and `q_hop`/`k_hop` both `None`) whenever
+        # neither hop is present, so this is a strict superset of the
+        # pre-existing "`Split` feeds the attention op directly" check, not
+        # a behavior change for any graph that already matched. V never
+        # gets this treatment -- `make_qk_norm`/`make_rotary_embedding_op`
+        # never touch V's own branch (see this section's own comment above)
+        # -- so `v_name` is still compared against `prod_q.output[2]`
+        # verbatim, exactly as before.
         packed_split_sizes: Optional[str] = None
-        prod_q = node_by_output.get(q_name) if _is_internal(q_name) else None
-        prod_k = node_by_output.get(k_name) if _is_internal(k_name) else None
+        q_norm_rope: Optional[_QKNormRopePassThrough] = None
+        k_norm_rope: Optional[_QKNormRopePassThrough] = None
+        root_q, q_hop = (
+            _walk_back_through_qk_norm_rope(
+                q_name, initializer_map, consumers_of, graph_outputs, node_by_output
+            )
+            if _is_internal(q_name)
+            else (q_name, None)
+        )
+        root_k, k_hop = (
+            _walk_back_through_qk_norm_rope(
+                k_name, initializer_map, consumers_of, graph_outputs, node_by_output
+            )
+            if _is_internal(k_name)
+            else (k_name, None)
+        )
+        prod_q = node_by_output.get(root_q) if _is_internal(root_q) else None
+        prod_k = node_by_output.get(root_k) if _is_internal(root_k) else None
         prod_v = node_by_output.get(v_name) if _is_internal(v_name) else None
         if (
             prod_q is not None
             and prod_q is prod_k
             and prod_q is prod_v
             and prod_q.op_type == "Split"
-            and list(prod_q.output) == [q_name, k_name, v_name]
+            and list(prod_q.output) == [root_q, root_k, v_name]
         ):
             packed = _match_packed_qkv_split(
                 prod_q, initializer_map, consumers_of, node_by_output
@@ -10570,6 +10936,8 @@ def _find_separate_qkv_chains(
                 (w_name, w_transposed, bias_name, nk),
                 (w_name, w_transposed, bias_name, nv),
             ]
+            q_norm_rope = q_hop
+            k_norm_rope = k_hop
         else:
             producer_infos = []
             matched = True
@@ -10611,6 +10979,23 @@ def _find_separate_qkv_chains(
             # fusion-declining conditions) -- a `GroupQueryAttention` node
             # whose V head size actually differs is declined here rather
             # than mis-sliced, since no real GQA node could ever have one.
+            continue
+
+        # Deferred correctness check for any Q/K-norm + RoPE pass-through
+        # crossed above (see :func:`_qk_norm_rope_hop_is_consistent`'s own
+        # docstring for why this can't run any earlier): a crossed norm's
+        # own `scale` must genuinely be `[head_size]`-wide, and a crossed
+        # post-norm `Reshape`'s own target width must genuinely be this
+        # branch's own pre-pruning flat width -- anything else means this
+        # walk crossed a shape it only structurally resembles, not the real
+        # Q/K-norm GQA export shape, and the whole match is declined here
+        # rather than mis-slicing it.
+        if not (
+            _qk_norm_rope_hop_is_consistent(q_norm_rope, initializer_map, nq, head_size)
+            and _qk_norm_rope_hop_is_consistent(
+                k_norm_rope, initializer_map, nk, head_size
+            )
+        ):
             continue
 
         out_name = node.output[0]
@@ -10657,6 +11042,8 @@ def _find_separate_qkv_chains(
                 consumer_weight_transposed=consumer[2],
                 num_heads_attr=num_heads_attr,
                 packed_split_sizes=packed_split_sizes,
+                q_norm_rope=q_norm_rope,
+                k_norm_rope=k_norm_rope,
             )
         )
     return chains
@@ -10949,7 +11336,16 @@ def _apply_one_gqa_chain(
     once by a combined column-index set instead of three independent
     per-producer slices, and the upstream `Split` node's own split-sizes
     constant is rewritten to the three new (post-pruning) column widths in
-    the same Q-then-K-then-V order -- see the branch below.
+    the same Q-then-K-then-V order -- see the branch below. When
+    `chain.q_norm_rope`/`chain.k_norm_rope` are additionally set (the
+    CPU/DirectML Q/K-norm GQA export shape -- see
+    :func:`_walk_back_through_qk_norm_rope`, :class:`_QKNormRopePassThrough`),
+    each crossed hop's own `RotaryEmbedding` `num_heads` attribute (when
+    nonzero) and post-norm `Reshape` target-width constant are rewritten to
+    that branch's new post-pruning head count/flat width -- neither a
+    crossed norm's own `scale` nor a `RotaryEmbedding`'s `cos_cache`/
+    `sin_cache` ever needs touching (both confirmed head-independent -- see
+    this module's own "Attention-head pruning" section comment).
 
     Returns ``(producer_weight_names, consumer_weight_name,
     stale_output_names)`` on success, or ``None`` if `sparsity` rounds to no
@@ -11141,8 +11537,38 @@ def _apply_one_gqa_chain(
                 onnx.numpy_helper.from_array(dims, name=shape_init.name)
             )
 
+    # Q's/K's own per-head norm + RoPE pass-through, if either branch
+    # crossed one (see :class:`_QKNormRopePassThrough`'s own docstring for
+    # why neither a crossed norm's own `scale` nor a crossed
+    # `RotaryEmbedding`'s `cos_cache`/`sin_cache` ever needs touching --
+    # only these two constants do): `new_branch_width`/`new_branch_heads`
+    # are Q's own post-pruning `num_heads`/flat width for `.q_norm_rope`,
+    # K's own post-pruning `kv_num_heads`/flat width (K's own head_size
+    # equals Q's/K's shared `d`, already confirmed at match time) for
+    # `.k_norm_rope`.
+    for hop, new_branch_heads, new_branch_width in (
+        (chain.q_norm_rope, new_num_heads, new_num_heads * d),
+        (chain.k_norm_rope, new_kv_num_heads, new_kv_num_heads * d),
+    ):
+        if hop is None:
+            continue
+        if hop.rotary_node is not None:
+            for attr in hop.rotary_node.attribute:
+                if attr.name == "num_heads" and attr.i != 0:
+                    attr.i = new_branch_heads
+        if hop.reshape_shape is not None:
+            shape_init = initializer_map[hop.reshape_shape]
+            dims = onnx.numpy_helper.to_array(shape_init).copy()
+            dims[-1] = new_branch_width
+            shape_init.CopyFrom(
+                onnx.numpy_helper.from_array(dims, name=shape_init.name)
+            )
+
     stale = {chain.node.output[0]}
     stale.update(op.output[0] for op, _ in chain.chain_ops)
+    for hop in (chain.q_norm_rope, chain.k_norm_rope):
+        if hop is not None:
+            stale.update(n.output[0] for n in hop.nodes if n.output and n.output[0])
     return (
         {chain.q_weight, chain.k_weight, chain.v_weight},
         chain.consumer_weight,

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -12786,6 +12786,751 @@ def test_gqa_native_packed_query_convention_still_declined():
     assert pruned.SerializeToString() == model.SerializeToString()
 
 
+# --- apply_attention_head_pruning / _wanda_pruning -- GroupQueryAttention,
+# packed-QKV-then-Split, CPU/DirectML Q/K-norm + RoPE pass-through --
+#
+# The shape `_match_packed_qkv_split`'s own docstring names as deliberately
+# left unmatched by that function alone: onnxruntime-genai's model builder,
+# when Q/K-norm is requested but the fused in-op norm path isn't supported
+# (CPU/DirectML -- `is_fused_qk_norm_gqa_supported` only allows it on
+# CUDA/WebGPU), emits a per-head `Reshape` -> `SimplifiedLayerNormalization`
+# -> `Reshape` sandwich (`make_qk_norm`) and, unless RoPE is fused into the
+# op itself, a `com.microsoft::RotaryEmbedding` node (`make_rotary_embedding_op`)
+# between the packed-QKV `Split`'s own Q/K outputs and `GroupQueryAttention`'s
+# own Q/K inputs, norm before RoPE (`make_attention_qk_rope_and_norm`'s own
+# "Base order: norm first, then RoPE" comment) -- see
+# :func:`onnxsim.pruning._walk_back_through_qk_norm_rope`'s own docstring
+# for the exact topology and this module's own "Attention-head pruning"
+# section comment for the empirically-confirmed head-independence facts
+# (a `SimplifiedLayerNormalization`'s own `scale` and a `RotaryEmbedding`'s
+# own `cos_cache`/`sin_cache` never need slicing at all) that make this
+# pass-through safe -- the two direct tests immediately below are the
+# empirical confirmation that comment refers to; every other test in this
+# section builds on top of them via the full matcher/pruning path.
+
+
+def test_simplified_layer_norm_is_head_independent_for_pruning():
+    # Direct confirmation of this section's own head-independence claim for
+    # `SimplifiedLayerNormalization`, isolated from the rest of the pruning
+    # machinery: a `(batch, seq, num_heads * head_size)` tensor, reshaped to
+    # expose `head_size` as the last axis (`make_qk_norm`'s own subgraph
+    # shape), normalized with a `[head_size]` `scale` shared identically
+    # across every head, reshaped back. Dropping an arbitrary, non-contiguous
+    # subset of heads *before* running this norm must give bit-identical
+    # results, for the surviving heads, to running it on the full tensor
+    # first and dropping those same heads *after* -- exactly the property
+    # that makes slicing whole heads out of the packed weight upstream of
+    # this norm safe without touching the norm's own `scale` at all.
+    def _norm_model(batch, seq, num_heads, head_size, scale):
+        hidden = num_heads * head_size
+        body = f"""
+            g (float[{batch},{seq},{hidden}] X) => (float[{batch},{seq},{hidden}] Y)
+            {{
+              r1 = Reshape(X, Shape1)
+              ln = SimplifiedLayerNormalization <axis=-1, epsilon=1e-6> (r1, Scale)
+              Y = Reshape(ln, Shape2)
+            }}
+            """
+        return _model(
+            body,
+            initializer=[
+                onnx.numpy_helper.from_array(
+                    np.array([0, -1, head_size], dtype=np.int64), "Shape1"
+                ),
+                onnx.numpy_helper.from_array(
+                    np.array([0, -1, hidden], dtype=np.int64), "Shape2"
+                ),
+                _f32(scale, "Scale"),
+            ],
+            opset=17,
+        )
+
+    batch, seq, num_heads, head_size = 2, 5, 6, 8
+    rng = np.random.default_rng(101)
+    scale = rng.standard_normal((head_size,)).astype(np.float32)
+    x = rng.standard_normal((batch, seq, num_heads * head_size)).astype(np.float32)
+
+    full_model = _norm_model(batch, seq, num_heads, head_size, scale)
+    (y_full,) = _run(full_model, {"X": x})
+    y_full_heads = y_full.reshape(batch, seq, num_heads, head_size)
+
+    keep = [0, 2, 3, 5]  # arbitrary, non-contiguous
+    x_heads = x.reshape(batch, seq, num_heads, head_size)
+    x_sub = x_heads[:, :, keep, :].reshape(batch, seq, len(keep) * head_size)
+
+    sub_model = _norm_model(batch, seq, len(keep), head_size, scale)
+    (y_sub,) = _run(sub_model, {"X": x_sub})
+    y_sub_heads = y_sub.reshape(batch, seq, len(keep), head_size)
+
+    np.testing.assert_array_equal(y_sub_heads, y_full_heads[:, :, keep, :])
+
+
+def test_rotary_embedding_is_head_independent_for_pruning():
+    # Direct confirmation of this section's own head-independence claim for
+    # `com.microsoft::RotaryEmbedding`, isolated from the rest of the
+    # pruning machinery, across every `interleaved`/`rotary_embedding_dim`
+    # combination this pass supports: dropping an arbitrary,
+    # non-contiguous subset of heads before or after this op gives
+    # bit-identical results for the surviving heads either way, since
+    # `cos_cache`/`sin_cache` are looked up purely by position, never by
+    # head index.
+    def _rope_model(
+        batch, seq, num_heads, head_size, cos, sin, interleaved, rotary_embedding_dim
+    ):
+        hidden = num_heads * head_size
+        body = f"""
+            g (float[{batch},{seq},{hidden}] X, int64[{batch},{seq}] PosIds)
+              => (float[{batch},{seq},{hidden}] Y)
+            {{
+              Y = com.microsoft.RotaryEmbedding
+                <num_heads={num_heads}, interleaved={interleaved}, rotary_embedding_dim={rotary_embedding_dim}>
+                (X, PosIds, Cos, Sin)
+            }}
+            """
+        return _model(
+            body,
+            initializer=[_f32(cos, "Cos"), _f32(sin, "Sin")],
+            opset=17,
+        )
+
+    batch, seq, num_heads, head_size = 2, 5, 6, 8
+    rng = np.random.default_rng(102)
+    max_pos = 16
+    keep = [0, 2, 3, 5]  # arbitrary, non-contiguous
+
+    for interleaved, rotary_embedding_dim in ((0, 0), (1, 0), (0, head_size // 2)):
+        rot_dim = rotary_embedding_dim if rotary_embedding_dim > 0 else head_size
+        half = rot_dim // 2
+        cos = rng.standard_normal((max_pos, half)).astype(np.float32)
+        sin = rng.standard_normal((max_pos, half)).astype(np.float32)
+        x = rng.standard_normal((batch, seq, num_heads * head_size)).astype(np.float32)
+        position_ids = rng.integers(0, max_pos, size=(batch, seq)).astype(np.int64)
+
+        full_model = _rope_model(
+            batch,
+            seq,
+            num_heads,
+            head_size,
+            cos,
+            sin,
+            interleaved,
+            rotary_embedding_dim,
+        )
+        (y_full,) = _run(full_model, {"X": x, "PosIds": position_ids})
+        y_full_heads = y_full.reshape(batch, seq, num_heads, head_size)
+
+        x_heads = x.reshape(batch, seq, num_heads, head_size)
+        x_sub = x_heads[:, :, keep, :].reshape(batch, seq, len(keep) * head_size)
+        sub_model = _rope_model(
+            batch,
+            seq,
+            len(keep),
+            head_size,
+            cos,
+            sin,
+            interleaved,
+            rotary_embedding_dim,
+        )
+        (y_sub,) = _run(sub_model, {"X": x_sub, "PosIds": position_ids})
+        y_sub_heads = y_sub.reshape(batch, seq, len(keep), head_size)
+
+        np.testing.assert_array_equal(y_sub_heads, y_full_heads[:, :, keep, :])
+
+
+def _qk_norm_rope_body(
+    prefix,
+    raw_name,
+    gamma_name,
+    reshape1_shape_name,
+    reshape2_shape_name,
+    with_norm,
+    with_rope,
+    cos_name="CosCache",
+    sin_name="SinCache",
+    pos_name="PosIds",
+    interleaved=0,
+    rotary_embedding_dim=0,
+    rotary_num_heads=None,
+):
+    # Returns a text fragment (per CLAUDE.md's own guidance for a reusable
+    # node sequence) plus the name of the final tensor it leaves behind --
+    # `raw_name` itself, unchanged, when both `with_norm`/`with_rope` are
+    # False.
+    lines = []
+    cur = raw_name
+    if with_norm:
+        lines.append(f"{prefix}_r1 = Reshape({cur}, {reshape1_shape_name})")
+        lines.append(
+            f"{prefix}_ln = SimplifiedLayerNormalization <axis=-1, epsilon=1e-6> "
+            f"({prefix}_r1, {gamma_name})"
+        )
+        lines.append(f"{prefix}_normed = Reshape({prefix}_ln, {reshape2_shape_name})")
+        cur = f"{prefix}_normed"
+    if with_rope:
+        nh = rotary_num_heads if rotary_num_heads is not None else 0
+        lines.append(
+            f"{prefix}_rot = com.microsoft.RotaryEmbedding "
+            f"<num_heads={nh}, interleaved={interleaved}, "
+            f"rotary_embedding_dim={rotary_embedding_dim}> "
+            f"({cur}, {pos_name}, {cos_name}, {sin_name})"
+        )
+        cur = f"{prefix}_rot"
+    return "\n          ".join(lines), cur
+
+
+def _gqa_qk_norm_rope_model(
+    K=8,
+    H=8,
+    KVH=2,
+    D=8,
+    Out=6,
+    seed=0,
+    batch=2,
+    seq=5,
+    packed=True,
+    with_norm=True,
+    with_rope=True,
+    interleaved=0,
+    rotary_embedding_dim=0,
+    q_rotary_num_heads=None,
+    k_rotary_num_heads=None,
+    wqkv=None,
+    wq=None,
+    wk=None,
+    wv=None,
+    wout=None,
+    q_gamma=None,
+    k_gamma=None,
+    cos=None,
+    sin=None,
+    position_ids=None,
+    max_pos=32,
+    rope_before_norm=False,
+):
+    # Mirrors `_gqa_packed_model`'s (`packed=True`) and `_gqa_model`'s
+    # (`packed=False`) own scaffolding, with an optional per-head norm +
+    # RoPE pass-through -- see this section's own comment above -- spliced
+    # in between the raw Q/K branches and `GroupQueryAttention`'s own
+    # inputs. `packed=False` builds the ordinary three-independent-producer
+    # shape (used here as an *independently*-constructed oracle, the same
+    # role `_gqa_model` already plays for the packed tests above), still
+    # with the same optional norm/RoPE hop on each of its own Q/K branches.
+    rng = np.random.default_rng(seed)
+    Nq, Nkv = H * D, KVH * D
+    if wout is None:
+        wout = rng.standard_normal((Nq, Out)).astype(np.float32)
+    initializer = [_f32(wout, "Wout")]
+
+    if packed:
+        if wqkv is None:
+            wqkv = rng.standard_normal((K, Nq + 2 * Nkv)).astype(np.float32)
+        initializer.append(_f32(wqkv, "Wqkv"))
+        split_sizes = np.array([Nq, Nkv, Nkv], dtype=np.int64)
+        initializer.append(onnx.numpy_helper.from_array(split_sizes, "SplitSizes"))
+        producer_body = (
+            "qkv = MatMul(X, Wqkv)\n"
+            "          q_raw, k_raw, v = Split <axis = -1> (qkv, SplitSizes)"
+        )
+    else:
+        if wq is None:
+            wq = rng.standard_normal((K, Nq)).astype(np.float32)
+        if wk is None:
+            wk = rng.standard_normal((K, Nkv)).astype(np.float32)
+        if wv is None:
+            wv = rng.standard_normal((K, Nkv)).astype(np.float32)
+        initializer += [_f32(wq, "Wq"), _f32(wk, "Wk"), _f32(wv, "Wv")]
+        producer_body = (
+            "q_raw = MatMul(X, Wq)\n"
+            "          k_raw = MatMul(X, Wk)\n"
+            "          v = MatMul(X, Wv)"
+        )
+
+    initializer.append(
+        onnx.numpy_helper.from_array(
+            np.full((batch,), seq - 1, dtype=np.int32), "SeqLensK"
+        )
+    )
+    initializer.append(
+        onnx.numpy_helper.from_array(np.array(seq, dtype=np.int32), "TotalSeq")
+    )
+
+    q_body, k_body, hop_body = "q_raw", "k_raw", ""
+    if with_norm or with_rope:
+        half = D // 2
+        if cos is None:
+            cos = rng.standard_normal((max_pos, half)).astype(np.float32)
+        if sin is None:
+            sin = rng.standard_normal((max_pos, half)).astype(np.float32)
+        if position_ids is None:
+            position_ids = np.tile(np.arange(seq, dtype=np.int64), (batch, 1))
+        initializer += [_f32(cos, "CosCache"), _f32(sin, "SinCache")]
+        initializer.append(onnx.numpy_helper.from_array(position_ids, "PosIds"))
+
+        if q_gamma is None:
+            q_gamma = rng.standard_normal((D,)).astype(np.float32)
+        if k_gamma is None:
+            k_gamma = rng.standard_normal((D,)).astype(np.float32)
+        initializer += [_f32(q_gamma, "QGamma"), _f32(k_gamma, "KGamma")]
+        initializer.append(
+            onnx.numpy_helper.from_array(
+                np.array([0, -1, D], dtype=np.int64), "QReshape1Shape"
+            )
+        )
+        initializer.append(
+            onnx.numpy_helper.from_array(
+                np.array([0, -1, Nq], dtype=np.int64), "QReshape2Shape"
+            )
+        )
+        initializer.append(
+            onnx.numpy_helper.from_array(
+                np.array([0, -1, D], dtype=np.int64), "KReshape1Shape"
+            )
+        )
+        initializer.append(
+            onnx.numpy_helper.from_array(
+                np.array([0, -1, Nkv], dtype=np.int64), "KReshape2Shape"
+            )
+        )
+
+        rope_kwargs = dict(
+            interleaved=interleaved, rotary_embedding_dim=rotary_embedding_dim
+        )
+        if not rope_before_norm:
+            q_text, q_body = _qk_norm_rope_body(
+                "q",
+                "q_raw",
+                "QGamma",
+                "QReshape1Shape",
+                "QReshape2Shape",
+                with_norm,
+                with_rope,
+                rotary_num_heads=q_rotary_num_heads,
+                **rope_kwargs,
+            )
+            k_text, k_body = _qk_norm_rope_body(
+                "k",
+                "k_raw",
+                "KGamma",
+                "KReshape1Shape",
+                "KReshape2Shape",
+                with_norm,
+                with_rope,
+                rotary_num_heads=k_rotary_num_heads,
+                **rope_kwargs,
+            )
+            hop_body = q_text + "\n          " + k_text
+        else:
+            # Adversarial (see `test_gqa_packed_qkv_rope_before_norm_is_declined`):
+            # RoPE applied *before* the norm sandwich -- the reverse of the
+            # real exporter's own order -- a shape
+            # `_walk_back_through_qk_norm_rope` doesn't recognize (it only
+            # ever crosses `RotaryEmbedding` as the *outermost* hop).
+            q_rope_text, q_rot = _qk_norm_rope_body(
+                "q",
+                "q_raw",
+                "QGamma",
+                "QReshape1Shape",
+                "QReshape2Shape",
+                False,
+                True,
+                rotary_num_heads=q_rotary_num_heads,
+                **rope_kwargs,
+            )
+            q_norm_text, q_body = _qk_norm_rope_body(
+                "qn",
+                q_rot,
+                "QGamma",
+                "QReshape1Shape",
+                "QReshape2Shape",
+                True,
+                False,
+            )
+            k_rope_text, k_rot = _qk_norm_rope_body(
+                "k",
+                "k_raw",
+                "KGamma",
+                "KReshape1Shape",
+                "KReshape2Shape",
+                False,
+                True,
+                rotary_num_heads=k_rotary_num_heads,
+                **rope_kwargs,
+            )
+            k_norm_text, k_body = _qk_norm_rope_body(
+                "kn",
+                k_rot,
+                "KGamma",
+                "KReshape1Shape",
+                "KReshape2Shape",
+                True,
+                False,
+            )
+            hop_body = "\n          ".join(
+                [q_rope_text, q_norm_text, k_rope_text, k_norm_text]
+            )
+
+    body = f"""
+        g (float[{batch},{seq},{K}] X) => (float[{batch},{seq},{Out}] Y)
+        {{
+          {producer_body}
+          {hop_body}
+          ctx, pk, pv = com.microsoft.GroupQueryAttention <num_heads={H}, kv_num_heads={KVH}> ({q_body}, {k_body}, v, , , SeqLensK, TotalSeq)
+          Y = MatMul(ctx, Wout)
+        }}
+        """
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17, "com.microsoft": 1]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model, dict(
+        K=K,
+        H=H,
+        KVH=KVH,
+        D=D,
+        Out=Out,
+        Nq=Nq,
+        Nkv=Nkv,
+        wqkv=wqkv,
+        wq=wq,
+        wk=wk,
+        wv=wv,
+        wout=wout,
+        q_gamma=q_gamma,
+        k_gamma=k_gamma,
+        cos=cos,
+        sin=sin,
+        position_ids=position_ids,
+        batch=batch,
+        seq=seq,
+    )
+
+
+def _qk_norm_rope_oracle_and_pruned(
+    K, H, KVH, D, Out, seed, sparsity, with_norm, with_rope, **extra
+):
+    # Shared body for every oracle-comparison test below: builds the packed
+    # (to-be-pruned) model, prunes it, and builds an *independently*
+    # constructed (`packed=False`) already-correctly-reduced oracle model
+    # from the exact same pre-pruning weights/gamma/cos/sin/position_ids --
+    # `q_gamma`/`k_gamma`/`cos`/`sin`/`position_ids` reused *verbatim*,
+    # unsliced, since none of them has any per-head axis to begin with (the
+    # whole point of this section's own head-independence facts) -- mirrors
+    # `test_gqa_packed_qkv_split_pruning_matches_oracle_exactly`'s own
+    # pattern one section above.
+    model, cfg = _gqa_qk_norm_rope_model(
+        K=K,
+        H=H,
+        KVH=KVH,
+        D=D,
+        Out=Out,
+        seed=seed,
+        with_norm=with_norm,
+        with_rope=with_rope,
+        **extra,
+    )
+    assert len(onnxsim.pruning._find_gqa_chains(model.graph)) == 1
+
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=sparsity)
+
+    Nq, Nkv = cfg["Nq"], cfg["Nkv"]
+    wqkv = cfg["wqkv"]
+    wq, wk, wv = wqkv[:, :Nq], wqkv[:, Nq : Nq + Nkv], wqkv[:, Nq + Nkv :]
+
+    group_size = H // KVH
+    keep_count = max(1, KVH - round(KVH * sparsity))
+    keep_groups = _oracle_keep_groups(wq, wk, wv, H, KVH, D, keep_count)
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    q_idx, kv_idx = _head_idx(keep_q_heads, D), _head_idx(keep_groups, D)
+
+    oracle_extra = dict(extra)
+    oracle_extra.pop("q_rotary_num_heads", None)
+    oracle_extra.pop("k_rotary_num_heads", None)
+    q_rotary_num_heads = extra.get("q_rotary_num_heads")
+    k_rotary_num_heads = extra.get("k_rotary_num_heads")
+
+    oracle, _ = _gqa_qk_norm_rope_model(
+        K=K,
+        H=len(keep_q_heads),
+        KVH=len(keep_groups),
+        D=D,
+        Out=Out,
+        seed=seed,
+        packed=False,
+        with_norm=with_norm,
+        with_rope=with_rope,
+        wq=wq[:, q_idx],
+        wk=wk[:, kv_idx],
+        wv=wv[:, kv_idx],
+        wout=cfg["wout"][q_idx, :],
+        q_gamma=cfg["q_gamma"],
+        k_gamma=cfg["k_gamma"],
+        cos=cfg["cos"],
+        sin=cfg["sin"],
+        position_ids=cfg["position_ids"],
+        q_rotary_num_heads=(
+            None
+            if q_rotary_num_heads is None or q_rotary_num_heads == 0
+            else len(keep_q_heads)
+        ),
+        k_rotary_num_heads=(
+            None
+            if k_rotary_num_heads is None or k_rotary_num_heads == 0
+            else len(keep_groups)
+        ),
+        **oracle_extra,
+    )
+
+    rng = np.random.default_rng(seed + 1000)
+    x = rng.standard_normal((cfg["batch"], cfg["seq"], K)).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    return pruned, oracle, y_pruned, y_oracle, keep_groups, keep_q_heads
+
+
+def test_gqa_packed_qkv_qk_norm_rope_pruning_matches_oracle_exactly():
+    # The common export shape (see this section's own comment above): both
+    # Q's and K's own branch get a per-head `SimplifiedLayerNorm` sandwich
+    # *and* `RotaryEmbedding`, `RotaryEmbedding`'s own `num_heads` left at
+    # the schema's `0` ("infer from shape") -- confirmed, empirically, to
+    # self-adjust to the new post-pruning head count with no attribute
+    # rewrite needed at all -- and `interleaved=1` for a bit of extra
+    # coverage beyond the default rotate-half layout, both already
+    # confirmed head-independent for every combination tried.
+    K, H, KVH, D, Out = 8, 8, 2, 8, 6
+    pruned, oracle, y_pruned, y_oracle, keep_groups, keep_q_heads = (
+        _qk_norm_rope_oracle_and_pruned(
+            K,
+            H,
+            KVH,
+            D,
+            Out,
+            seed=1,
+            sparsity=0.5,
+            with_norm=True,
+            with_rope=True,
+            interleaved=1,
+        )
+    )
+    node = _gqa_node(pruned)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    assert kv_num_heads == len(keep_groups) == 1
+    assert num_heads == len(keep_q_heads) == 4
+
+    rotary_nodes = [n for n in pruned.graph.node if n.op_type == "RotaryEmbedding"]
+    assert len(rotary_nodes) == 2
+    for n in rotary_nodes:
+        nh = next(a.i for a in n.attribute if a.name == "num_heads")
+        assert nh == 0  # left at the self-adjusting schema default, unchanged
+
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_gqa_packed_qkv_qk_norm_rope_pruning_updates_explicit_rotary_num_heads():
+    # The partial-rotary case (`onnxruntime_genai`'s own
+    # `make_rotary_embedding`: "num_heads=0 if partial_rotary_factor == 1.0
+    # else num_heads") leaves `RotaryEmbedding`'s own `num_heads` attribute
+    # *non*-zero -- the one crossed-hop constant that genuinely does need
+    # rewriting post-pruning (see this section's own comment above) --
+    # exercised here together with a partial `rotary_embedding_dim` (half
+    # of `head_size`), both already confirmed head-independent.
+    K, H, KVH, D, Out = 8, 8, 2, 8, 6
+    pruned, oracle, y_pruned, y_oracle, keep_groups, keep_q_heads = (
+        _qk_norm_rope_oracle_and_pruned(
+            K,
+            H,
+            KVH,
+            D,
+            Out,
+            seed=2,
+            sparsity=0.5,
+            with_norm=True,
+            with_rope=True,
+            rotary_embedding_dim=D // 2,
+            q_rotary_num_heads=H,
+            k_rotary_num_heads=KVH,
+        )
+    )
+    q_rot = next(
+        n
+        for n in pruned.graph.node
+        if n.op_type == "RotaryEmbedding" and n.input[0].startswith("q_")
+    )
+    k_rot = next(
+        n
+        for n in pruned.graph.node
+        if n.op_type == "RotaryEmbedding" and n.input[0].startswith("k_")
+    )
+    assert next(a.i for a in q_rot.attribute if a.name == "num_heads") == len(
+        keep_q_heads
+    )
+    assert next(a.i for a in k_rot.attribute if a.name == "num_heads") == len(
+        keep_groups
+    )
+
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_gqa_packed_qkv_norm_only_pruning_matches_oracle_exactly():
+    # Q/K-norm without RoPE (RoPE fused into the attention op itself, or
+    # simply absent) -- only the `Reshape` -> `SimplifiedLayerNormalization`
+    # -> `Reshape` sandwich is crossed on each of Q's/K's own branch, no
+    # `RotaryEmbedding` hop at all.
+    K, H, KVH, D, Out = 8, 8, 2, 8, 6
+    pruned, oracle, y_pruned, y_oracle, keep_groups, keep_q_heads = (
+        _qk_norm_rope_oracle_and_pruned(
+            K,
+            H,
+            KVH,
+            D,
+            Out,
+            seed=3,
+            sparsity=0.5,
+            with_norm=True,
+            with_rope=False,
+        )
+    )
+    assert not any(n.op_type == "RotaryEmbedding" for n in pruned.graph.node)
+    assert (
+        sum(n.op_type == "SimplifiedLayerNormalization" for n in pruned.graph.node) == 2
+    )
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_gqa_packed_qkv_rope_only_pruning_matches_oracle_exactly():
+    # RoPE without Q/K-norm (no norm requested at all) -- only the
+    # `RotaryEmbedding` hop is crossed, applied directly to the `Split`'s
+    # own raw Q/K outputs.
+    K, H, KVH, D, Out = 8, 8, 2, 8, 6
+    pruned, oracle, y_pruned, y_oracle, keep_groups, keep_q_heads = (
+        _qk_norm_rope_oracle_and_pruned(
+            K,
+            H,
+            KVH,
+            D,
+            Out,
+            seed=4,
+            sparsity=0.5,
+            with_norm=False,
+            with_rope=True,
+        )
+    )
+    assert not any(
+        n.op_type == "SimplifiedLayerNormalization" for n in pruned.graph.node
+    )
+    assert sum(n.op_type == "RotaryEmbedding" for n in pruned.graph.node) == 2
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_gqa_wanda_packed_qkv_qk_norm_rope_pruning_matches_oracle_exactly():
+    # The Wanda-calibrated variant shares :func:`_apply_one_gqa_chain` with
+    # the data-free path above -- only `compute_group_importance` differs
+    # (see `_gqa_group_importance`) -- so this exercises that the new
+    # `q_norm_rope`/`k_norm_rope` handling works unchanged under that
+    # shared apply path too, not just the data-free default.
+    K, H, KVH, D, Out = 8, 8, 2, 8, 6
+    model, cfg = _gqa_qk_norm_rope_model(
+        K=K, H=H, KVH=KVH, D=D, Out=Out, seed=5, with_norm=True, with_rope=True
+    )
+    rng = np.random.default_rng(6)
+    x_cal = rng.standard_normal((cfg["batch"], cfg["seq"], K)).astype(np.float32)
+    calibration_data = [{"X": x_cal}]
+
+    pruned = onnxsim.apply_attention_head_wanda_pruning(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+
+    probe_model = onnx.ModelProto()
+    probe_model.CopyFrom(model)
+    probe_model.graph.output.append(onnx.ValueInfoProto(name="ctx"))
+    (_, ctx_cal) = _run(probe_model, {"X": x_cal})
+    act_norm = np.sqrt(np.mean(np.square(ctx_cal.astype(np.float64)), axis=(0, 1)))
+
+    Nq, Nkv = cfg["Nq"], cfg["Nkv"]
+    wqkv = cfg["wqkv"]
+    wq, wk, wv = wqkv[:, :Nq], wqkv[:, Nq : Nq + Nkv], wqkv[:, Nq + Nkv :]
+
+    group_size = H // KVH
+    importance = np.zeros(KVH)
+    for kv in range(KVH):
+        q_block = np.concatenate(
+            [
+                wq[:, h * D : (h + 1) * D]
+                for h in range(kv * group_size, (kv + 1) * group_size)
+            ],
+            axis=1,
+        )
+        k_block = wk[:, kv * D : (kv + 1) * D]
+        v_block = wv[:, kv * D : (kv + 1) * D]
+        base = np.linalg.norm(np.concatenate([q_block, k_block, v_block], axis=1))
+        act_group = np.linalg.norm(
+            act_norm[kv * group_size * D : (kv + 1) * group_size * D]
+        )
+        importance[kv] = base * max(act_group, 1e-8)
+    keep_groups = np.sort(np.argsort(-importance)[:1])  # max(1, 2 - round(2*0.5)) == 1
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    q_idx, kv_idx = _head_idx(keep_q_heads, D), _head_idx(keep_groups, D)
+
+    oracle, _ = _gqa_qk_norm_rope_model(
+        K=K,
+        H=len(keep_q_heads),
+        KVH=len(keep_groups),
+        D=D,
+        Out=Out,
+        seed=5,
+        packed=False,
+        with_norm=True,
+        with_rope=True,
+        wq=wq[:, q_idx],
+        wk=wk[:, kv_idx],
+        wv=wv[:, kv_idx],
+        wout=cfg["wout"][q_idx, :],
+        q_gamma=cfg["q_gamma"],
+        k_gamma=cfg["k_gamma"],
+        cos=cfg["cos"],
+        sin=cfg["sin"],
+        position_ids=cfg["position_ids"],
+    )
+
+    x = rng.standard_normal((cfg["batch"], cfg["seq"], K)).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_gqa_packed_qkv_rope_before_norm_is_declined():
+    # Adversarial: RoPE applied *before* the norm sandwich instead of after
+    # -- the reverse of onnxruntime-genai's own confirmed order
+    # (`make_attention_qk_rope_and_norm`'s own "Base order: norm first,
+    # then RoPE" comment) -- is a shape `_walk_back_through_qk_norm_rope`
+    # doesn't recognize (it only ever crosses a `RotaryEmbedding` as the
+    # *outermost* hop, nearest the attention op's own input): neither Q's
+    # nor K's own branch ends up tracing back to the shared `Split`, so the
+    # whole chain is declined -- left completely untouched -- rather than
+    # silently mis-slicing a shape this pass hasn't verified.
+    K, H, KVH, D, Out = 8, 4, 2, 8, 6
+    model, cfg = _gqa_qk_norm_rope_model(
+        K=K,
+        H=H,
+        KVH=KVH,
+        D=D,
+        Out=Out,
+        seed=21,
+        with_norm=True,
+        with_rope=True,
+        rope_before_norm=True,
+    )
+    assert onnxsim.pruning._find_gqa_chains(model.graph) == []
+
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
 def test_structured_pruning_importance_norm_l2_is_the_unchanged_default():
     model, wg, wu, wd = _swiglu_mlp_model(K=8, H=16, Out=4, seed=30)
     default = onnxsim.apply_structured_pruning(model, sparsity=0.5)


### PR DESCRIPTION
## Summary

`_match_packed_qkv_split` previously only matched packed-QKV chains where `Split`'s outputs feed the attention op's Q/K/V inputs *directly*. When Q/K-norm is present but not fused into the attention op itself (only supported on CUDA/WebGPU per ONNX Runtime GenAI's own model-builder code), the CPU/DirectML export path instead emits separate per-head `SimplifiedLayerNormalization` (and usually `RotaryEmbedding`) nodes between `Split` and the attention op's inputs — a shape that was previously completely unmatched, leaving KV-group/head pruning entirely unavailable for CPU/DirectML exports of Q/K-normalized GQA models (e.g. Qwen3-style, a widely used current open-weight family).

## What's added

Extends the packed-QKV chain matcher to walk through, between `Split` and the attention op's Q/K inputs:
1. An optional per-head `Reshape → SimplifiedLayerNormalization → Reshape` sandwich (`_QKNormRopePassThrough`, `_walk_back_through_qk_norm_rope`).
2. An optional `com.microsoft::RotaryEmbedding` node.

Both hops are validated for consistency (gamma shape, Reshape target width) once `head_size`/branch width are known (`_qk_norm_rope_hop_is_consistent`), matching the module's existing deferred-check idiom.

## Empirically confirmed facts (real `onnxruntime.InferenceSession`)

- `SimplifiedLayerNormalization`'s `scale` has no bias input and shape `[head_size]`, applied identically to every head regardless of head count — slicing heads before vs. after the norm gives **bit-identical** results. Independently re-verified during review: max diff `0.0`.
- `com.microsoft::RotaryEmbedding` is head-independent across `interleaved` (0/1) and full/partial `rotary_embedding_dim` — also bit-identical. Independently re-verified during review (`num_heads=0` auto-inferred case): max diff `0.0`.
- `RotaryEmbedding`'s `num_heads=0` ("infer from shape") self-adjusts correctly to a smaller post-pruning head count with no attribute change needed; a nonzero value must be rewritten (along with the post-norm `Reshape`'s target width).

## Deliberately declined
RoPE applied *before* the norm sandwich (reverse of the confirmed real exporter order) is not recognized — declined outright (whole chain left untouched) rather than mismatched.

## Test plan
- [x] `pytest tests/test_pruning.py -q` — 442 passed (was 434 before this change)
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — 0 new errors, matches master's baseline
- [x] Direct head-independence checks for both `SimplifiedLayerNormalization` and `RotaryEmbedding`
- [x] Full norm+RoPE / norm-only / RoPE-only oracle-matched pruning tests (real `InferenceSession` vs. an independently-built already-reduced reference model)
- [x] Explicit-vs-self-adjusting `RotaryEmbedding.num_heads` handling
- [x] Wanda-calibrated variant
- [x] Negative/decline test for the reversed RoPE-before-norm order

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_