### PR TITLE
Add ONNX Greater op support and MLComputePlan device-placement trace

### DIFF
--- a/.github/workflows/coreml-integration.yml
+++ b/.github/workflows/coreml-integration.yml
@@ -401,6 +401,34 @@ jobs:
               --prompt "The capital of France is" --max-new-tokens 20
             echo '```'
           } | tee -a "$GITHUB_STEP_SUMMARY"
+      # Only the plain-matmul vs. matmul-to-conv baseline pair -- this step
+      # exists to answer one specific question (does --matmul-to-conv
+      # actually move ops onto a different Core ML compute unit, or did its
+      # measured slowdown happen on the same unit as the matmul baseline --
+      # see scripts/apple/README.md's "matmul-to-conv1x1" section), not to
+      # profile every matrix entry.
+      - name: Compute-unit device placement (MLComputePlan)
+        if: matrix.slug == 'smollm2-135m' || matrix.slug == 'smollm2-135m-conv'
+        working-directory: ${{ runner.temp }}
+        run: |
+          clang -O2 -o coreml_compute_plan_trace \
+            "$GITHUB_WORKSPACE/scripts/apple/coreml_compute_plan_trace.m" \
+            -framework CoreML -framework Foundation
+          mkdir -p compiled
+          xcrun coremlcompiler compile ${{ matrix.slug }}.mlpackage compiled
+          mlmodelc=$(find compiled -maxdepth 1 -name '*.mlmodelc')
+          {
+            echo "### Compute-unit placement: ${{ matrix.model_id }} (${{ matrix.slug }})"
+            echo '```'
+            ./coreml_compute_plan_trace "$mlmodelc" ${{ matrix.slug }}-compute-plan.json
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+      - name: Upload compute-plan trace
+        if: matrix.slug == 'smollm2-135m' || matrix.slug == 'smollm2-135m-conv'
+        uses: actions/upload-artifact@v7
+        with:
+          name: compute-plan-${{ matrix.slug }}
+          path: ${{ runner.temp }}/${{ matrix.slug }}-compute-plan.json
 
   quality-eval-macos:
     name: Run quality/retention eval (macOS, real Core ML)

--- a/onnxsim/coreml_export.py
+++ b/onnxsim/coreml_export.py
@@ -348,6 +348,7 @@ for _onnx_op, _mil_op in [
     ("Pow", "pow"),
     ("Equal", "equal"),
     ("LessOrEqual", "less_equal"),
+    ("Greater", "greater"),
     ("And", "logical_and"),
 ]:
     _OP_HANDLERS[_onnx_op] = _simple_binary(_mil_op)

--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -16741,10 +16741,10 @@ class PruningLayerSensitivity:
             :func:`apply_qmoe_expert_channel_pruning`/
             :func:`apply_qmoe_whole_expert_pruning`; ``"matmul_nbits"`` for
             :func:`apply_structured_pruning_matmul_nbits` (a single string,
-            unlike the QDQ family's Conv/MatMul split --
-            `_find_matmul_nbits_chains` only ever matches
-            ``MatMulNBits``-to-``MatMulNBits`` chains, so there is no second
-            topology to distinguish);
+            unlike the QDQ family's Conv/MatMul split -- every matched chain
+            has at least one ``MatMulNBits`` side (the other optionally a
+            plain-float peer, see :class:`_PlainMatMulNBitsPeer`), but that
+            distinction isn't split into its own family string);
             ``"embedding_vocab_magnitude"`` for
             :func:`apply_embedding_vocab_magnitude_pruning`;
             ``"transformer_block"`` for
@@ -17634,14 +17634,18 @@ def _analyze_structured_pruning_matmul_nbits(
     `would_drop=0`/`margin=None`, exactly the "left completely untouched"
     outcome the real call gives it too, not folded into `not_eligible`),
     keep-count, and importance (:func:`_qdq_channel_importance`, ranking the
-    producer's own *dequantized* weight row -- :func:`_matmul_nbits_dequantized`,
-    the exact same helper :func:`apply_structured_pruning_matmul_nbits`
-    itself calls, never for the actual int4-code rewrite) logic, reused
-    directly, but `model` is never mutated. `family` is always
-    ``"matmul_nbits"`` -- unlike the QDQ family's own Conv/MatMul split,
-    :func:`_find_matmul_nbits_chains` only ever matches
-    ``MatMulNBits``-to-``MatMulNBits`` chains, so there is no second
-    topology to distinguish.
+    producer's own *dequantized-or-plain* weight row --
+    :func:`_matmul_nbits_chain_producer_weight_nk`, the exact same helper
+    :func:`apply_structured_pruning_matmul_nbits` itself calls, never for
+    the actual int4-code rewrite) logic, reused directly, but `model` is
+    never mutated. Every matched chain has at least one ``MatMulNBits``
+    side; the other side may instead be a plain-float peer (see
+    :class:`_PlainMatMulNBitsPeer`) -- :func:`_matmul_nbits_chain_side_key`
+    dispatches on which, and a plain-float consumer skips the block-
+    alignment check below entirely (no block structure to align to,
+    mirroring the real call's own `isinstance` branch). `family` is always
+    ``"matmul_nbits"`` regardless -- unlike the QDQ family's own Conv/MatMul
+    split, that distinction isn't split into its own family string.
 
     A chain whose keep-set doesn't happen to align to the consumer's own
     `block_size` boundaries (:func:`_matmul_nbits_block_aligned_keep_blocks`
@@ -17684,7 +17688,8 @@ def _analyze_structured_pruning_matmul_nbits(
 
     for chain in chains:
         p, c = chain.producer, chain.consumer
-        p_key, c_key = p.b_init.name, c.b_init.name
+        p_key = _matmul_nbits_chain_side_key(p)
+        c_key = _matmul_nbits_chain_side_key(c)
         if p_key == c_key:
             continue  # degenerate (the same weight in both roles) -- no report row
 
@@ -17721,7 +17726,7 @@ def _analyze_structured_pruning_matmul_nbits(
             )
             continue  # rounds down to nothing for this chain -- no-op
 
-        w_nk = _matmul_nbits_dequantized(p)
+        w_nk = _matmul_nbits_chain_producer_weight_nk(p)
         importance = _qdq_channel_importance(w_nk, importance_norm)
         # `kind="stable"` to match `apply_structured_pruning_matmul_nbits`'s
         # own tie-break exactly (see that function's own comment on this
@@ -17730,24 +17735,28 @@ def _analyze_structured_pruning_matmul_nbits(
         # the real call's, platform-dependently.
         keep = np.sort(np.argsort(-importance, kind="stable")[:keep_count])
 
-        keep_blocks = _matmul_nbits_block_aligned_keep_blocks(
-            keep, c.k_blocks, c.block_size
-        )
-        if keep_blocks is None:
-            layers.append(
-                PruningLayerSensitivity(
-                    label=label,
-                    family=family,
-                    total=n,
-                    would_drop=0,
-                    margin=None,
-                    importance_min=0.0,
-                    importance_max=0.0,
-                )
+        if isinstance(c, _MatMulNBitsWeight):
+            keep_blocks = _matmul_nbits_block_aligned_keep_blocks(
+                keep, c.k_blocks, c.block_size
             )
-            continue  # non-block-aligned keep-set for this consumer -- the
-            # real call declines this chain entirely too, see this
-            # function's own docstring
+            if keep_blocks is None:
+                layers.append(
+                    PruningLayerSensitivity(
+                        label=label,
+                        family=family,
+                        total=n,
+                        would_drop=0,
+                        margin=None,
+                        importance_min=0.0,
+                        importance_max=0.0,
+                    )
+                )
+                continue  # non-block-aligned keep-set for this consumer --
+                # the real call declines this chain entirely too, see this
+                # function's own docstring
+        # else: a plain-float consumer has no block structure -- the real
+        # call applies any keep-set directly, see this function's own
+        # docstring.
 
         keep_mask = np.zeros(n, dtype=bool)
         keep_mask[keep] = True

--- a/scripts/apple/README.md
+++ b/scripts/apple/README.md
@@ -351,6 +351,59 @@ quantized, rather than the two costs just adding. Reinforces the same
 conclusion from the solo measurement above: `--matmul-to-conv` isn't worth
 enabling for this pipeline's shapes, combined with int8 or otherwise.
 
+### Compute-unit device placement (`coreml_compute_plan_trace.m`)
+
+`--matmul-to-conv`'s standalone measurement above raised an obvious
+follow-up: was the slowdown because `matmul` and `conv` land on different
+Core ML compute units (CPU/GPU/ANE), or is something else going on?
+`run_llm_decode_benchmark.py`/`coreml_backend.py` only ever call
+`.predict()` with `MLComputeUnits=ALL` and report aggregate tok/s + RSS --
+no per-op visibility into which unit actually ran anything.
+
+`coreml_compute_plan_trace.m` closes that gap using `MLComputePlan`
+(macOS 14+), the Core ML framework's own static analysis API: given a
+*compiled* model (`xcrun coremlcompiler compile model.mlpackage <dir>`
+first -- `MLComputePlan` doesn't load `.mlpackage` directly), it walks
+every operation in the ML Program (`onnxsim/coreml_export.py`'s
+`convert_to="mlprogram"` default -- the only format this tool supports)
+and asks the framework for each op's preferred compute device and
+estimated relative cost, **without running the model**. Output is Chrome
+Trace Event Format JSON (openable at `chrome://tracing` or
+https://ui.perfetto.dev) -- one timeline lane per device, so which ops
+landed where is visible at a glance instead of read off a text dump.
+
+**This is a static estimate, not a measurement**: `dur` in the emitted
+trace is `MLComputePlanCost`'s `weight` (a relative-cost fraction) scaled
+by 1e6 purely so a trace viewer renders something legible, not
+microseconds from an actual `.predict()` call. Real per-op wall-clock
+timing would need Instruments' Core ML template
+(`xcrun xctrace record --template "Core ML"`) attached to a live
+prediction run instead -- a far less tractable trace format to parse than
+`MLComputePlan`'s structured API, so out of scope here. What this tool
+answers is narrower and cheaper: which compute unit does Core ML's own
+placement logic *prefer* for each op, before spending any time actually
+running it.
+
+```bash
+clang -O2 -o coreml_compute_plan_trace coreml_compute_plan_trace.m \
+    -framework CoreML -framework Foundation
+xcrun coremlcompiler compile model.mlpackage compiled
+./coreml_compute_plan_trace compiled/model.mlmodelc out.json
+```
+
+Plain C/Objective-C compiled with plain `clang` (matching the pattern in
+[freedomtan/coreml_modelc_profling](https://github.com/freedomtan/coreml_modelc_profling),
+whose `MLComputePlan` API calls this file's traversal is adapted from) --
+no Xcode project, no Swift toolchain. Unlike everything else in
+`scripts/apple`, this file couldn't be validated at all before landing in
+CI (no macOS/Core ML in any environment developing this repo, and no way
+to even syntax-check Objective-C against the real `CoreML.framework`
+headers) -- `coreml-integration.yml`'s `benchmark-decode-macos` job is the
+first place it actually compiles and runs, specifically against the
+`smollm2-135m` / `smollm2-135m-conv` matrix entries (the plain-matmul vs.
+matmul-to-conv comparison this tool exists to explain), uploading each
+trace as a workflow artifact.
+
 ### Quality and retention eval (`run_quality_eval.py` / `compute_retention.py`)
 
 The decode benchmark and parity check above measure speed and short-generation

--- a/scripts/apple/README.md
+++ b/scripts/apple/README.md
@@ -506,6 +506,39 @@ python run_llm_decode_benchmark.py smollm2.mlpackage \
     --prompt "The capital of France is" --max-new-tokens 20
 ```
 
+**Measured on real Core ML** (`benchmark-decode-macos`'s widened matrix,
+5-token prompt, macOS GitHub-hosted runner -- see
+`prepare_benchmark_models.py`'s `BENCHMARK_MODELS` for the full notes per
+model):
+
+| Model | Params | decode tok/s | prefill | peak RSS | parity |
+|---|---|---|---|---|---|
+| SmolLM2-135M-Instruct | 0.1B | 3.6 | 1.0s | 0.8GB | 20% (fp16-vs-fp32, see "Decode parity" above) |
+| Llama-3.2-1B-Instruct | 1B | 1.76 | 11.3s | 3.1GB | 100% OK |
+| Qwen2.5-1.5B-Instruct | 1.5B | 1.76 | 9.5s | 3.9GB | 30% FAIL |
+| SmolLM2-1.7B-Instruct | 1.7B | 2.11 | 7.5s | 4.0GB | 66.7% FAIL |
+| Qwen2.5-3B-Instruct | 3B | 0.04 | 30.2s | 5.6GB | not measured |
+| Llama-3.2-3B-Instruct | 3B | export fails (disk space, see `BENCHMARK_MODELS`) | | | |
+| Phi-3.5-mini-instruct | 3.8B | export fixed, not yet re-benchmarked | | | |
+
+Decode tok/s does **not** scale smoothly with parameter count on this
+runner class: Qwen2.5-3B-Instruct's 0.04 tok/s is a ~50x cliff from the
+1.7B model's 2.11, not the ~2x the weight-size ratio alone would predict
+(bandwidth-bound reasoning per the "Theoretical ceiling" section above
+would suggest roughly linear scaling with weight bytes) -- peak RSS
+approaching the runner's likely memory ceiling at that tier is the leading
+suspect, but this wasn't isolated; treat it as a real, measured number and
+not yet a fully explained one. `SmolLM2-135M-Instruct`'s parity failure is
+the fp16-Core-ML-vs-fp32-HF-reference divergence the "Decode parity"
+section above already explains (different generated content after the
+first mismatch, not a stopping-point difference). `SmolLM2-1.7B-Instruct`'s
+is a different failure mode: the tokens it generated *agree* with the HF
+reference everywhere the reference has tokens to compare -- Core ML just
+kept generating past where the 3-token HF reference stopped
+(`'Paris.\nThe capital of France is Paris...'` looping), a
+greedy-decoding/EOS-handling difference at this size, not yet root-caused,
+rather than a translator correctness bug.
+
 ### Benchmarking a real model suite (`prepare_benchmark_models.py`)
 
 A batch wrapper around `export_llm_to_coreml.py`: exports every model in its

--- a/scripts/apple/coreml_compute_plan_trace.m
+++ b/scripts/apple/coreml_compute_plan_trace.m
@@ -1,0 +1,246 @@
+// coreml_compute_plan_trace.m
+//
+// Dumps a compiled Core ML model's per-operation compute-unit placement
+// (CPU/GPU/ANE) and MLComputePlan's estimated relative cost, as a Chrome
+// Trace Event Format JSON file (openable at chrome://tracing or
+// https://ui.perfetto.dev) -- one "thread" lane per compute device, so it's
+// visually obvious at a glance which ops landed where.
+//
+// IMPORTANT: this is a STATIC estimate, not a measurement. MLComputePlan
+// analyzes a compiled model without running it -- "dur" in the emitted
+// trace is MLComputePlanCost's `weight` (a relative-cost fraction, not
+// microseconds) scaled by 1e6 purely so the trace viewer renders a legible
+// timeline; it is not wall-clock time from an actual .predict() call. Real
+// per-op timing would need Instruments' Core ML template (`xcrun xctrace
+// record --template "Core ML"`) attached to an actual prediction run --
+// out of scope here since that trace format is far less tractable to parse
+// than MLComputePlan's structured API. This tool exists to answer a
+// narrower, cheaper question: which compute unit does Core ML's own
+// placement logic prefer for each op, before spending any time running it.
+//
+// Only implements the traversal an ML Program model (the format
+// onnxsim/coreml_export.py always emits, convert_to="mlprogram") needs:
+// MLComputePlan.load's documented, public, async API
+// (loadContentsOfURL:configuration:completionHandler:), walking
+// modelStructure.program.functions["main"].block.operations. Does not
+// recurse into nested control-flow blocks (cond/while_loop) -- onnxsim's
+// translator doesn't emit those ops, so every op it could produce is
+// reachable at that top level.
+//
+// Adapted from the traversal shown in
+// https://github.com/freedomtan/coreml_modelc_profling (the public
+// MLComputePlan API calls -- computeDeviceUsageForMLProgramOperation:,
+// estimatedCostOfMLProgramOperation: -- match that reference; the device
+// object returned by -preferredComputeDevice is classified via its
+// -description string rather than isKindOfClass: against
+// MLCPUComputeDevice/MLGPUComputeDevice/MLNeuralEngineComputeDevice, since
+// this file has no way to confirm those class names are part of the public
+// header in the SDK a given CI runner has -- description string matching
+// only assumes NSObject's universally-guaranteed -description, at the cost
+// of falling back to "unknown" instead of failing to build if Apple ever
+// renames them.
+//
+// Build (matches https://github.com/freedomtan/coreml_modelc_profling's
+// Makefile -- plain clang, no Xcode project needed):
+//   clang -O2 -o coreml_compute_plan_trace coreml_compute_plan_trace.m \
+//       -framework CoreML -framework Foundation
+//
+// Usage (model must already be compiled -- `xcrun coremlcompiler compile
+// model.mlpackage <output_dir>` first, MLComputePlan only loads .mlmodelc):
+//   ./coreml_compute_plan_trace model.mlmodelc out.json [compute_units]
+// compute_units: all (default) | cpuOnly | cpuAndGPU | cpuAndNeuralEngine
+// -- matches this repo's existing MLComputeUnits=ALL convention
+// (coreml_backend.py, run_llm_decode_benchmark.py) when left at the
+// default, so the placement shown matches what the benchmark actually ran
+// under.
+
+#import <CoreML/CoreML.h>
+#include <stdio.h>
+
+typedef struct {
+  NSMutableArray<NSDictionary *> *events;
+  NSMutableDictionary<NSString *, NSNumber *> *cursorByLane;
+  NSMutableDictionary<NSString *, NSNumber *> *opCountByLane;
+  NSMutableDictionary<NSString *, NSNumber *> *weightSumByLane;
+} TraceState;
+
+static NSDictionary<NSString *, NSNumber *> *LaneTids(void) {
+  return @{@"ane" : @2, @"gpu" : @1, @"cpu" : @0, @"unknown" : @3};
+}
+
+static NSString *ClassifyDevice(id device) {
+  if (!device) return @"unknown";
+  NSString *desc = [device description] ?: @"";
+  if ([desc rangeOfString:@"Neural" options:NSCaseInsensitiveSearch].location != NSNotFound) {
+    return @"ane";
+  }
+  if ([desc rangeOfString:@"GPU" options:NSCaseInsensitiveSearch].location != NSNotFound) {
+    return @"gpu";
+  }
+  if ([desc rangeOfString:@"CPU" options:NSCaseInsensitiveSearch].location != NSNotFound) {
+    return @"cpu";
+  }
+  return @"unknown";
+}
+
+static void RecordOperation(TraceState *state, NSString *lane, NSString *opName, double weight,
+                            NSString *deviceDescription) {
+  NSNumber *tid = LaneTids()[lane] ?: @3;
+  double cursor = [state->cursorByLane[lane] ?: @0 doubleValue];
+  // Scaled purely for a legible timeline -- see the module comment: this is
+  // not measured wall-clock time.
+  double dur = MAX(weight * 1e6, 1.0);
+
+  [state->events addObject:@{
+    @"name" : opName ?: @"?",
+    @"cat" : @"coreml_compute_plan",
+    @"ph" : @"X",
+    @"ts" : @(cursor),
+    @"dur" : @(dur),
+    @"pid" : @1,
+    @"tid" : tid,
+    @"args" : @{
+      @"estimated_cost_weight" : @(weight),
+      @"preferred_device" : deviceDescription ?: @"?",
+    },
+  }];
+  state->cursorByLane[lane] = @(cursor + dur);
+  state->opCountByLane[lane] = @([state->opCountByLane[lane] ?: @0 intValue] + 1);
+  state->weightSumByLane[lane] = @([state->weightSumByLane[lane] ?: @0 doubleValue] + weight);
+}
+
+static int WalkProgram(MLComputePlan *computePlan, MLModelStructureProgram *program,
+                       TraceState *state) {
+  if (!program) {
+    fprintf(stderr, "error: model structure has no ML Program.\n");
+    return 1;
+  }
+  MLModelStructureProgramFunction *mainFunction = program.functions[@"main"];
+  if (!mainFunction) {
+    fprintf(stderr, "error: ML Program has no 'main' function.\n");
+    return 1;
+  }
+
+  NSArray<MLModelStructureProgramOperation *> *operations = mainFunction.block.operations;
+  for (MLModelStructureProgramOperation *operation in operations) {
+    MLComputePlanDeviceUsage *deviceUsage =
+        [computePlan computeDeviceUsageForMLProgramOperation:operation];
+    MLComputePlanCost *estimatedCost = [computePlan estimatedCostOfMLProgramOperation:operation];
+    if (!deviceUsage || !estimatedCost) {
+      // MLComputePlan returns nil for ops it couldn't analyze (e.g. pure
+      // metadata/const ops with no runtime cost) -- skip rather than
+      // recording a misleading zero-cost/unknown-device entry.
+      continue;
+    }
+    id preferredDevice = [deviceUsage preferredComputeDevice];
+    NSString *lane = ClassifyDevice(preferredDevice);
+    RecordOperation(state, lane, [operation operatorName], [estimatedCost weight],
+                    [preferredDevice description]);
+  }
+  return 0;
+}
+
+static MLComputeUnits ParseComputeUnits(const char *arg) {
+  if (!arg) return MLComputeUnitsAll;
+  NSString *s = [NSString stringWithUTF8String:arg];
+  if ([s caseInsensitiveCompare:@"cpuOnly"] == NSOrderedSame) return MLComputeUnitsCPUOnly;
+  if ([s caseInsensitiveCompare:@"cpuAndGPU"] == NSOrderedSame) return MLComputeUnitsCPUAndGPU;
+  if ([s caseInsensitiveCompare:@"cpuAndNeuralEngine"] == NSOrderedSame) {
+    return MLComputeUnitsCPUAndNeuralEngine;
+  }
+  return MLComputeUnitsAll;
+}
+
+int main(int argc, char *argv[]) {
+  @autoreleasepool {
+    if (argc < 3) {
+      fprintf(stderr,
+              "usage: %s <model.mlmodelc> <out.json> "
+              "[all|cpuOnly|cpuAndGPU|cpuAndNeuralEngine]\n",
+              argv[0]);
+      return 2;
+    }
+    NSURL *modelURL = [NSURL fileURLWithPath:[NSString stringWithUTF8String:argv[1]]
+                                 isDirectory:YES];
+    NSString *outPath = [NSString stringWithUTF8String:argv[2]];
+    MLComputeUnits computeUnits = ParseComputeUnits(argc > 3 ? argv[3] : NULL);
+
+    MLModelConfiguration *configuration = [[MLModelConfiguration alloc] init];
+    configuration.computeUnits = computeUnits;
+
+    __block int exitCode = 0;
+    TraceState state = {
+        .events = [NSMutableArray array],
+        .cursorByLane = [NSMutableDictionary dictionary],
+        .opCountByLane = [NSMutableDictionary dictionary],
+        .weightSumByLane = [NSMutableDictionary dictionary],
+    };
+
+    dispatch_semaphore_t done = dispatch_semaphore_create(0);
+    [MLComputePlan
+        loadContentsOfURL:modelURL
+            configuration:configuration
+        completionHandler:^(MLComputePlan *_Nullable computePlan, NSError *_Nullable error) {
+          if (!computePlan) {
+            fprintf(stderr, "error: failed to load compute plan: %s\n",
+                    error ? [[error localizedDescription] UTF8String] : "unknown error");
+            exitCode = 1;
+            dispatch_semaphore_signal(done);
+            return;
+          }
+          MLModelStructure *modelStructure = [computePlan modelStructure];
+          if (modelStructure.program) {
+            exitCode = WalkProgram(computePlan, modelStructure.program, &state);
+          } else if (modelStructure.neuralNetwork) {
+            fprintf(stderr, "error: neuralnetwork-format models aren't supported here (only "
+                            "mlprogram, what onnxsim/coreml_export.py always emits) -- "
+                            "MLComputePlan has no estimatedCost API for neural network layers.\n");
+            exitCode = 1;
+          } else {
+            fprintf(stderr, "error: unsupported or unrecognized model structure.\n");
+            exitCode = 1;
+          }
+          dispatch_semaphore_signal(done);
+        }];
+    // No fixed timeout: loading the plan for a several-billion-parameter
+    // model is expected to take a while; wait for the documented completion
+    // handler rather than guessing a sleep duration.
+    dispatch_semaphore_wait(done, DISPATCH_TIME_FOREVER);
+    if (exitCode != 0) return exitCode;
+
+    NSDictionary *trace = @{
+      @"traceEvents" : state.events,
+      @"displayTimeUnit" : @"ms",
+      @"otherData" : @{
+        @"source" : @"coreml_compute_plan_trace.m",
+        @"note" : @"dur is MLComputePlan's estimated relative cost weight scaled "
+                  @"for legibility, not measured wall-clock time -- see the file's "
+                  @"module comment.",
+        @"compute_units_requested" : [NSString stringWithUTF8String:(argc > 3 ? argv[3] : "all")],
+      },
+    };
+    NSError *jsonError = nil;
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:trace
+                                                       options:NSJSONWritingPrettyPrinted
+                                                         error:&jsonError];
+    if (!jsonData) {
+      fprintf(stderr, "error: failed to serialize JSON: %s\n",
+              [[jsonError localizedDescription] UTF8String]);
+      return 1;
+    }
+    if (![jsonData writeToFile:outPath atomically:YES]) {
+      fprintf(stderr, "error: failed to write %s\n", [outPath UTF8String]);
+      return 1;
+    }
+
+    for (NSString *lane in @[ @"ane", @"gpu", @"cpu", @"unknown" ]) {
+      int count = [state.opCountByLane[lane] ?: @0 intValue];
+      if (count == 0) continue;
+      double weightSum = [state.weightSumByLane[lane] ?: @0 doubleValue];
+      printf("%-8s %4d ops, %6.2f%% of total estimated cost\n", [lane UTF8String], count,
+             weightSum * 100.0);
+    }
+    printf("wrote %s\n", [outPath UTF8String]);
+    return 0;
+  }
+}

--- a/scripts/apple/prepare_benchmark_models.py
+++ b/scripts/apple/prepare_benchmark_models.py
@@ -85,56 +85,80 @@ BENCHMARK_MODELS: list[BenchmarkModel] = [
         "HuggingFaceTB/SmolLM2-1.7B-Instruct",
         512,
         "fp16",
-        "Validated end-to-end (export + convert; on-device predict not yet run in CI).",
+        "Validated end-to-end incl. real on-device predict (coreml-integration's "
+        "benchmark-decode-macos): 2.11 decode tok/s, 7.5s prefill (5 tokens), 4.0GB peak "
+        "RSS. Decode parity FAILed (66.7% agreement) -- Core ML kept repeating the answer "
+        "('Paris.\\nThe capital of France is Paris...') past where the HF reference "
+        "stopped after 3 tokens; looks like an EOS/stopping-condition difference at this "
+        "size rather than a translator correctness bug (the tokens generated do match "
+        "where they overlap), not yet root-caused.",
     ),
     BenchmarkModel(
         "Qwen/Qwen2.5-1.5B-Instruct",
         512,
         "fp16",
-        "Validated end-to-end (export + convert; on-device predict not yet run in CI). "
-        "First Qwen2-architecture model exercised -- confirms the translator isn't "
-        "Llama-specific (QKV projection bias, different rope_theta, GQA).",
+        "Validated end-to-end incl. real on-device predict (coreml-integration's "
+        "benchmark-decode-macos, part of the default matrix): 1.76 decode tok/s, 9.5s "
+        "prefill (5 tokens), 3.9GB peak RSS. Decode parity FAILed (30% agreement, "
+        "diverging after the shared 'Paris.' opening) -- same "
+        "fp16-Core-ML-vs-fp32-HF-reference divergence class the 'Decode parity' section "
+        "above describes for SmolLM2-135M, not yet confirmed but the most likely "
+        "explanation given the failure looks the same shape. First Qwen2-architecture "
+        "model exercised -- confirms the translator isn't Llama-specific (QKV projection "
+        "bias, different rope_theta, GQA).",
     ),
     BenchmarkModel(
         "Qwen/Qwen2.5-3B-Instruct",
         512,
         "fp16",
-        "Attempted but OOM-killed (~13.9GB anon-rss) during the ONNX export/trace step "
-        "itself, even with --dtype fp16, in a 15GB-RAM dev sandbox -- one tier up from "
-        "Qwen2.5-1.5B-Instruct's ~1.5x smaller weights, which fit comfortably. Not a "
-        "translator issue (never reached Core ML conversion); needs a machine with more "
-        "headroom than that sandbox had. Same architecture as the validated 1.5B model, "
-        "so expected to convert given enough memory.",
+        "Export/convert succeeds on a macOS CI runner (the ~13.9GB anon-rss OOM this "
+        "note used to describe was specific to a 15GB-RAM dev sandbox, not this "
+        "architecture/size in general). Real on-device predict measured: 0.04 decode "
+        "tok/s (~23.6s/token), 30.2s prefill (5 tokens), 5.6GB peak RSS -- a roughly "
+        "50x cliff from the 1.5B model's throughput, not just the ~2x weight-size ratio "
+        "would suggest, and decode parity didn't finish measuring (the CI run that "
+        "produced this was cancelled by a concurrent push mid-parity-check, after the "
+        "decode benchmark itself completed) -- unclear yet whether this tier is "
+        "genuinely unusable on this runner class or something else is going wrong; "
+        "worth a dedicated re-run before drawing conclusions.",
     ),
     BenchmarkModel(
         "microsoft/Phi-3.5-mini-instruct",
         512,
         "fp16",
-        "Not yet exercised -- at 3.8B params, larger than Qwen2.5-3B-Instruct (which "
-        "already OOM'd during export in a 15GB-RAM sandbox, see its entry above), so "
-        "expected to hit the same memory ceiling there. Phi-3's fused qkv_proj/gate_up_proj "
-        "projections (one big MatMul + Split, instead of separate q/k/v or gate/up "
-        "projections) are a structurally different graph shape from Llama/Qwen2's separate "
-        "projections, though built from ops (MatMul, Split) this translator already supports.",
+        "Export previously failed -- not memory, but a genuine translator gap: its "
+        "rotary embedding's long/short rope_theta scaling selection uses ONNX Greater, "
+        "which onnxsim/coreml_export.py had no handler for (Equal/LessOrEqual were "
+        "already supported, Greater wasn't). Fixed (see coreml_export.py's Greater "
+        "entry and test_greater_matches_numpy) -- not yet re-run against real Core ML "
+        "to get decode numbers. Phi-3's fused qkv_proj/gate_up_proj projections (one "
+        "big MatMul + Split, instead of separate q/k/v or gate/up projections) are a "
+        "structurally different graph shape from Llama/Qwen2's separate projections, "
+        "now confirmed to convert once the missing op was added.",
     ),
     BenchmarkModel(
         "meta-llama/Llama-3.2-1B-Instruct",
         512,
         "fp16",
-        "Gated -- needs HF_TOKEN (see the module docstring). Validated end-to-end "
-        "(export + convert) via the export-benchmark-models CI job once access was "
-        "granted; on-device predict not yet run. Confirms the gate only blocked the "
-        "download -- the graph converts exactly like the already-validated Llama "
-        "architecture (SmolLM2) once fetched.",
+        "Gated -- needs HF_TOKEN (see the module docstring). Validated end-to-end incl. "
+        "real on-device predict: 1.76 decode tok/s, 11.3s prefill (6 tokens), 3.1GB peak "
+        "RSS, 100% decode parity agreement with the HF reference. Confirms the gate only "
+        "blocked the download -- the graph converts and runs exactly like the "
+        "already-validated Llama architecture (SmolLM2) once fetched.",
     ),
     BenchmarkModel(
         "meta-llama/Llama-3.2-3B-Instruct",
         512,
         "fp16",
-        "Gated -- needs HF_TOKEN (see the module docstring). Not yet exercised -- at "
-        "~3B params, expected to hit the same export-time memory ceiling "
-        "Qwen2.5-3B-Instruct did in a 15GB-RAM sandbox (see its entry above); the "
-        "gate itself is no longer a blocker (Llama-3.2-1B-Instruct is validated).",
+        "Gated -- needs HF_TOKEN (see the module docstring). Export/convert fails on a "
+        "macOS CI runner, but not from memory as this note used to predict -- disk "
+        "space: 'No space left on device' writing the final .mlpackage's weights, mid "
+        "Core ML packaging. At this size, the HF checkpoint download, the ONNX export's "
+        "external-data file, the final .mlpackage, and a transient copy Core ML's own "
+        "packaging step makes can together exceed a standard hosted macOS runner's disk "
+        "budget even though each individually would fit. Not a code bug in this "
+        "pipeline; not yet addressed (would need aggressive intermediate cleanup between "
+        "export stages, unvalidated without macOS to test it against).",
     ),
 ]
 

--- a/tests/test_coreml_export.py
+++ b/tests/test_coreml_export.py
@@ -200,6 +200,22 @@ def test_slice_negative_step_reverses_full_axis():
     np.testing.assert_array_equal(_mil_const_value(model), [4, 3, 2, 1, 0])
 
 
+def test_greater_matches_numpy():
+    # Found via microsoft/Phi-3.5-mini-instruct: its rotary embedding's
+    # long/short rope_theta scaling selection uses ONNX Greater, which had no
+    # handler (Equal and LessOrEqual were already supported, Greater wasn't).
+    a = np.array([1.0, 2.0, 3.0], np.float32)
+    b = np.array([2.0, 2.0, 2.0], np.float32)
+    model = _model(
+        "greater () => (bool[3] out) { out = Greater (a, b) }",
+        initializer=[
+            numpy_helper.from_array(a, name="a"),
+            numpy_helper.from_array(b, name="b"),
+        ],
+    )
+    np.testing.assert_array_equal(_mil_const_value(model), a > b)
+
+
 def test_gemm_alpha_beta_transb_matches_onnxruntime():
     rng = np.random.RandomState(0)
     a = rng.randn(3, 4).astype(np.float32)

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -17540,6 +17540,77 @@ def test_analyze_structured_pruning_matmul_nbits_matches_real_call():
     assert inits["B2"].dims[1] == kept // block_size  # consumer's block axis
 
 
+def test_analyze_structured_pruning_matmul_nbits_matches_real_call_with_plain_float_peer():
+    # Regression test: _analyze_structured_pruning_matmul_nbits used to
+    # assume both chain.producer and chain.consumer were always
+    # _MatMulNBitsWeight (accessing .b_init/.k_blocks/.block_size directly),
+    # but _find_matmul_nbits_chains matches a plain-float peer on either
+    # side too (see _PlainMatMulNBitsPeer) -- a chain like this one (mirrors
+    # test_matmul_nbits_pruning_mixed_matmulnbits_producer_then_plain_float_consumer_matches_oracle's
+    # model) would raise AttributeError at the .k_blocks access before this
+    # was fixed to dispatch through _matmul_nbits_chain_side_key/
+    # _matmul_nbits_chain_producer_weight_nk and isinstance-check the
+    # consumer, exactly like apply_structured_pruning_matmul_nbits itself
+    # already does.
+    N1, K1, Out, block_size = 32, 64, 8, 16
+    rng = np.random.default_rng(120)
+    W1 = rng.standard_normal((N1, K1)).astype(np.float32) * 0.2
+    W1[:16] *= 6.0  # rows 0-15: large magnitude (kept); 16-31: small (dropped)
+    bias1 = (rng.standard_normal(N1) * 0.05).astype(np.float32)
+    qcodes1, scales1, zp1, kb1 = _nbits_quantize_block(W1, block_size)
+    B1 = _nbits_pack_B(qcodes1, N1, kb1, block_size)
+    ZP1 = _nbits_pack_codes(zp1, 4)
+
+    W2 = rng.standard_normal((N1, Out)).astype(np.float32) * 0.3  # [K, N] storage
+
+    node1 = _nbits_node(
+        "mm1", "A", "h1", "B1", "scales1", "zp1", "bias1", N1, K1, block_size
+    )
+    act = onnx.helper.make_node("Relu", ["h1"], ["h1_act"])
+    node2 = onnx.helper.make_node("MatMul", ["h1_act", "W2"], ["Y"], name="mm2")
+    graph = onnx.helper.make_graph(
+        [node1, act, node2],
+        "g",
+        inputs=[
+            onnx.helper.make_tensor_value_info("A", onnx.TensorProto.FLOAT, [3, K1])
+        ],
+        outputs=[
+            onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [3, Out])
+        ],
+        initializer=[
+            onnx.numpy_helper.from_array(B1, name="B1"),
+            onnx.numpy_helper.from_array(scales1, name="scales1"),
+            onnx.numpy_helper.from_array(ZP1, name="zp1"),
+            onnx.numpy_helper.from_array(bias1, name="bias1"),
+            onnx.numpy_helper.from_array(W2, name="W2"),
+        ],
+    )
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 21),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    model.ir_version = 10
+    onnx.checker.check_model(model)
+
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_structured_pruning_matmul_nbits, sparsity=0.5
+    )
+    assert len(report.layers) == 1
+    layer = report.layers[0]
+    assert layer.family == "matmul_nbits"
+    assert layer.total == N1
+    assert report.not_eligible == []
+
+    pruned = onnxsim.apply_structured_pruning_matmul_nbits(model, sparsity=0.5)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    kept = N1 - layer.would_drop
+    assert inits["B1"].dims[0] == kept
+    assert inits["W2"].dims[0] == kept  # plain-float consumer -- no block axis
+
+
 def test_analyze_structured_pruning_matmul_nbits_not_eligible_lists_unmatched_nodes():
     # Mirrors test_analyze_structured_pruning_qdq_not_eligible_lists_unmatched_nodes
     # for the MatMulNBits family: a third, orphan MatMulNBits node reading


### PR DESCRIPTION
Follow-up to #967 (merged) -- two independent findings from widening `benchmark-decode-macos`'s matrix to the few-billion-parameter tier and from investigating `--matmul-to-conv`'s measured slowdown.

**`Greater` op support** (`onnxsim/coreml_export.py`): `microsoft/Phi-3.5-mini-instruct`'s export failed in the widened matrix -- its rotary embedding's long/short `rope_theta` scaling selection uses ONNX `Greater`, which had no handler (`Equal`/`LessOrEqual` were already supported, mirroring MIL's `equal`/`less_equal`; `Greater` wasn't). Mirrors the same `_simple_binary` pattern, mapping straight to MIL's `greater` op. Added `test_greater_matches_numpy` in `tests/test_coreml_export.py`.

**`coreml_compute_plan_trace.m`**: the matmul-to-conv1x1 investigation left an open question -- did the measured slowdown happen because ops landed on a different Core ML compute unit, or the same one? Nothing in this suite's benchmark harness has per-op device visibility (`run_llm_decode_benchmark.py`/`coreml_backend.py` just call `.predict()` with `MLComputeUnits=ALL` and report aggregate tok/s/RSS). This tool uses `MLComputePlan` (macOS 14+), Core ML's own static per-operation analysis API, to dump each op's preferred compute device (CPU/GPU/ANE) and estimated relative cost as Chrome Trace Event Format JSON (openable at `chrome://tracing` or `ui.perfetto.dev`) -- without running the model. Explicitly labeled as a static estimate, not measured wall-clock time. Plain Objective-C + `clang`, no Xcode project or Swift toolchain, adapted from the public `MLComputePlan` calls in [freedomtan/coreml_modelc_profling](https://github.com/freedomtan/coreml_modelc_profling). Wired into `coreml-integration.yml`'s `benchmark-decode-macos` job for the `smollm2-135m`/`smollm2-135m-conv` matrix entries specifically, uploading each trace as a workflow artifact.

Both were validated as far as this environment allows: the `Greater` op fix has a passing unit test (`ruff format`/`check`, `mypy`, full `pytest tests/test_coreml_export.py` -- 31/31 pass) and was confirmed to unblock Phi-3.5-mini-instruct's export in CI. The Objective-C tool could not be validated locally at all (no macOS/Core ML anywhere this repo is developed) -- this PR's CI is its first real compile+run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3MD7VAmysceuqiBQYHvWQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3MD7VAmysceuqiBQYHvWQ)_