### PR TITLE
Fix MatMulNBits sensitivity analyzer for the now-Union chain-side type

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -17684,7 +17684,8 @@ def _analyze_structured_pruning_matmul_nbits(
 
     for chain in chains:
         p, c = chain.producer, chain.consumer
-        p_key, c_key = p.b_init.name, c.b_init.name
+        p_key = _matmul_nbits_chain_side_key(p)
+        c_key = _matmul_nbits_chain_side_key(c)
         if p_key == c_key:
             continue  # degenerate (the same weight in both roles) -- no report row
 
@@ -17721,7 +17722,7 @@ def _analyze_structured_pruning_matmul_nbits(
             )
             continue  # rounds down to nothing for this chain -- no-op
 
-        w_nk = _matmul_nbits_dequantized(p)
+        w_nk = _matmul_nbits_chain_producer_weight_nk(p)
         importance = _qdq_channel_importance(w_nk, importance_norm)
         # `kind="stable"` to match `apply_structured_pruning_matmul_nbits`'s
         # own tie-break exactly (see that function's own comment on this
@@ -17730,24 +17731,31 @@ def _analyze_structured_pruning_matmul_nbits(
         # the real call's, platform-dependently.
         keep = np.sort(np.argsort(-importance, kind="stable")[:keep_count])
 
-        keep_blocks = _matmul_nbits_block_aligned_keep_blocks(
-            keep, c.k_blocks, c.block_size
-        )
-        if keep_blocks is None:
-            layers.append(
-                PruningLayerSensitivity(
-                    label=label,
-                    family=family,
-                    total=n,
-                    would_drop=0,
-                    margin=None,
-                    importance_min=0.0,
-                    importance_max=0.0,
-                )
+        # Block-alignment only applies when the CONSUMER is itself a
+        # `MatMulNBits` node (see `apply_structured_pruning_matmul_nbits`'s
+        # own identical branch): a plain-float consumer (mixed-chain support,
+        # onnxsim/onnxsim#969) has no block structure at all, so any keep-set
+        # applies directly there -- mirrored here so this dry-run's
+        # would_drop/margin never diverges from what the real call decides.
+        if isinstance(c, _MatMulNBitsWeight):
+            keep_blocks = _matmul_nbits_block_aligned_keep_blocks(
+                keep, c.k_blocks, c.block_size
             )
-            continue  # non-block-aligned keep-set for this consumer -- the
-            # real call declines this chain entirely too, see this
-            # function's own docstring
+            if keep_blocks is None:
+                layers.append(
+                    PruningLayerSensitivity(
+                        label=label,
+                        family=family,
+                        total=n,
+                        would_drop=0,
+                        margin=None,
+                        importance_min=0.0,
+                        importance_max=0.0,
+                    )
+                )
+                continue  # non-block-aligned keep-set for this consumer --
+                # the real call declines this chain entirely too, see this
+                # function's own docstring
 
         keep_mask = np.zeros(n, dtype=bool)
         keep_mask[keep] = True

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -17540,6 +17540,77 @@ def test_analyze_structured_pruning_matmul_nbits_matches_real_call():
     assert inits["B2"].dims[1] == kept // block_size  # consumer's block axis
 
 
+def test_analyze_structured_pruning_matmul_nbits_mixed_plain_float_consumer_matches_real_call():
+    # onnxsim/onnxsim#969 generalized `_MatMulNBitsChain.producer`/`.consumer`
+    # to a `_MatMulNBitsWeight | _PlainMatMulNBitsPeer` union (mixed
+    # MatMulNBits/plain-float chains) -- this dry-run mirror must handle a
+    # plain-float CONSUMER exactly like the real call does: no block
+    # structure at all, so the producer's own top-keep_count-by-norm
+    # keep-set applies directly, would_drop/margin computed the same way
+    # a MatMulNBits-to-MatMulNBits chain's would be, never declined for
+    # "non-block-aligned" (that check doesn't even apply here). Same shape
+    # as test_matmul_nbits_pruning_mixed_matmulnbits_producer_then_plain_float_consumer_matches_oracle.
+    N1, K1, Out, block_size = 32, 64, 8, 16
+    rng = np.random.default_rng(120)
+    W1 = rng.standard_normal((N1, K1)).astype(np.float32) * 0.2
+    W1[:16] *= 6.0  # rows 0-15: large magnitude (kept); 16-31: small (dropped)
+    bias1 = (rng.standard_normal(N1) * 0.05).astype(np.float32)
+    qcodes1, scales1, zp1, kb1 = _nbits_quantize_block(W1, block_size)
+    B1 = _nbits_pack_B(qcodes1, N1, kb1, block_size)
+    ZP1 = _nbits_pack_codes(zp1, 4)
+
+    W2 = rng.standard_normal((N1, Out)).astype(np.float32) * 0.3  # [K, N] storage
+
+    node1 = _nbits_node(
+        "mm1", "A", "h1", "B1", "scales1", "zp1", "bias1", N1, K1, block_size
+    )
+    act = onnx.helper.make_node("Relu", ["h1"], ["h1_act"])
+    node2 = onnx.helper.make_node("MatMul", ["h1_act", "W2"], ["Y"], name="mm2")
+    graph = onnx.helper.make_graph(
+        [node1, act, node2],
+        "g",
+        inputs=[
+            onnx.helper.make_tensor_value_info("A", onnx.TensorProto.FLOAT, [3, K1])
+        ],
+        outputs=[
+            onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [3, Out])
+        ],
+        initializer=[
+            onnx.numpy_helper.from_array(B1, name="B1"),
+            onnx.numpy_helper.from_array(scales1, name="scales1"),
+            onnx.numpy_helper.from_array(ZP1, name="zp1"),
+            onnx.numpy_helper.from_array(bias1, name="bias1"),
+            onnx.numpy_helper.from_array(W2, name="W2"),
+        ],
+    )
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 21),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    model.ir_version = 10
+    onnx.checker.check_model(model)
+
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_structured_pruning_matmul_nbits, sparsity=0.5
+    )
+    assert len(report.layers) == 1
+    layer = report.layers[0]
+    assert layer.family == "matmul_nbits"
+    assert layer.total == N1
+    assert layer.would_drop == 16
+    assert layer.margin is not None and layer.margin > 0.5
+    assert report.not_eligible == []
+
+    pruned = onnxsim.apply_structured_pruning_matmul_nbits(model, sparsity=0.5)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    kept = N1 - layer.would_drop
+    assert inits["B1"].dims[0] == kept
+    assert inits["W2"].dims[0] == kept  # plain-float consumer -- no block axis
+
+
 def test_analyze_structured_pruning_matmul_nbits_not_eligible_lists_unmatched_nodes():
     # Mirrors test_analyze_structured_pruning_qdq_not_eligible_lists_unmatched_nodes
     # for the MatMulNBits family: a third, orphan MatMulNBits node reading


### PR DESCRIPTION
## Summary

#969 generalized `_MatMulNBitsChain.producer`/`.consumer` from always `_MatMulNBitsWeight` to a `_MatMulNBitsWeight | _PlainMatMulNBitsPeer` union, to support mixed MatMulNBits/plain-float chains. This broke `_analyze_structured_pruning_matmul_nbits` (added by #968), which still assumed the producer/consumer were always `_MatMulNBitsWeight` — both PRs merged into master within the same minute, so the interaction wasn't caught by either PR's own CI (each ran against its own, unmodified base). `mypy` currently fails on master with 4 `union-attr`/`arg-type` errors, and the function would raise a real `AttributeError` at runtime for any mixed chain.

## What's fixed

Mirrors the real `apply_structured_pruning_matmul_nbits` function's own handling exactly:
- Uses `_matmul_nbits_chain_side_key`/`_matmul_nbits_chain_producer_weight_nk` instead of the `_MatMulNBitsWeight`-only `b_init`/`_matmul_nbits_dequantized`.
- Gates the block-alignment check on `isinstance(c, _MatMulNBitsWeight)` — a plain-float consumer has no block structure, so its keep-set applies directly rather than being checked for block alignment.

Without this, the dry-run analyzer could predict a different outcome than the real mutating call for a mixed chain, on top of the outright `AttributeError`.

## Test plan
- [x] `pytest tests/test_pruning.py -q` — 480 passed
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — 0 errors (was 4 on current master)
- [x] New cross-check test exercising the analyzer against a mixed MatMulNBits-producer/plain-float-consumer chain, verifying `would_drop`/`margin` match the real mutating call

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_