### PR TITLE
Copy chat_template.jinja alongside the exported tokenizer

### DIFF
--- a/scripts/apple/export_llm_to_coreml.py
+++ b/scripts/apple/export_llm_to_coreml.py
@@ -247,6 +247,17 @@ def export_llm_to_coreml(
             "special_tokens_map.json",
             "vocab.json",
             "merges.txt",
+            # Recent transformers releases store a chat model's chat template
+            # as this standalone file rather than (or in addition to)
+            # tokenizer_config.json's own inline "chat_template" key --
+            # dropping it here left AutoTokenizer.from_pretrained(out_dir)
+            # loading successfully but with no chat template at all, only
+            # surfacing later as "tokenizer.chat_template is not set" from
+            # lm_eval_coreml_adapter.py's apply_chat_template (used by
+            # run_quality_eval.py --apply-chat-template, not by
+            # run_llm_decode_benchmark.py/check_decode_parity.py, which
+            # build prompts without a chat template).
+            "chat_template.jinja",
         ):
             src = Path(tmpdir) / name
             if src.is_file():


### PR DESCRIPTION
Follow-up to #975 (merged before this fix landed).

`quality-eval-macos`'s `--model coreml` step failed with `ValueError: Cannot use chat template functions because tokenizer.chat_template is not set...`. `export_llm_to_coreml.py` copies a fixed whitelist of tokenizer files from `optimum`'s export tmpdir to the `.mlpackage`'s sibling directory, but that whitelist predates transformers' now-common convention of storing a chat model's chat template as a standalone `chat_template.jinja` file rather than (or alongside) `tokenizer_config.json`'s own inline key. `AutoTokenizer.from_pretrained(out_dir)` loaded fine but with no chat template at all -- only surfacing when `lm_eval_coreml_adapter.py`'s `apply_chat_template` (used by `run_quality_eval.py --apply-chat-template`) actually needed one. `run_llm_decode_benchmark.py`/`check_decode_parity.py` never hit this since they build prompts without a chat template.

Adds `chat_template.jinja` to the copied-file whitelist.

`ruff format`/`check` and `mypy` all pass; this file isn't covered by `tests/test_coreml_export.py` (no test needs a real HF download), and the fix's actual effect is CI-only for the same reason the original bug only showed up there -- this PR's `workflow_dispatch` run of `coreml-integration.yml` is what confirms it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3MD7VAmysceuqiBQYHvWQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3MD7VAmysceuqiBQYHvWQ)_