### PR TITLE
Fix mypy lint failure in _analyze_structured_pruning_matmul_nbits

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -17626,34 +17626,35 @@ def _analyze_structured_pruning_matmul_nbits(
     importance_norm: _ImportanceNorm = "l2",
 ) -> PruningSensitivityReport:
     """Dry-run mirror of :func:`apply_structured_pruning_matmul_nbits` --
-    same matching (:func:`_find_matmul_nbits_chains`, the
-    ``MatMulNBits``-to-``MatMulNBits``-only topology this family's own
-    section comment describes), touched-role bookkeeping (a chain sharing a
-    `B` weight -- on either side -- with an earlier one in
-    :func:`_find_matmul_nbits_chains`'s own return order is reported
-    `would_drop=0`/`margin=None`, exactly the "left completely untouched"
-    outcome the real call gives it too, not folded into `not_eligible`),
-    keep-count, and importance (:func:`_qdq_channel_importance`, ranking the
-    producer's own *dequantized* weight row -- :func:`_matmul_nbits_dequantized`,
-    the exact same helper :func:`apply_structured_pruning_matmul_nbits`
-    itself calls, never for the actual int4-code rewrite) logic, reused
-    directly, but `model` is never mutated. `family` is always
-    ``"matmul_nbits"`` -- unlike the QDQ family's own Conv/MatMul split,
-    :func:`_find_matmul_nbits_chains` only ever matches
-    ``MatMulNBits``-to-``MatMulNBits`` chains, so there is no second
-    topology to distinguish.
+    same matching (:func:`_find_matmul_nbits_chains`, which also accepts a
+    MIXED ``MatMulNBits``/plain-float chain as long as at least one side is
+    ``MatMulNBits``, per that function's own docstring), touched-role
+    bookkeeping (a chain sharing a weight -- on either side -- with an
+    earlier one in :func:`_find_matmul_nbits_chains`'s own return order is
+    reported `would_drop=0`/`margin=None`, exactly the "left completely
+    untouched" outcome the real call gives it too, not folded into
+    `not_eligible`), keep-count, and importance (:func:`_qdq_channel_importance`,
+    ranking the producer's own *dequantized* weight row --
+    :func:`_matmul_nbits_chain_producer_weight_nk`, the exact same helper
+    :func:`apply_structured_pruning_matmul_nbits` itself calls, never for the
+    actual int4-code rewrite) logic, reused directly, but `model` is never
+    mutated. `family` is always ``"matmul_nbits"`` -- unlike the QDQ
+    family's own Conv/MatMul split, :func:`_find_matmul_nbits_chains` has no
+    second topology to distinguish.
 
-    A chain whose keep-set doesn't happen to align to the consumer's own
-    `block_size` boundaries (:func:`_matmul_nbits_block_aligned_keep_blocks`
-    returning ``None`` -- an individual K-column can't be dropped without
-    re-quantizing its whole block, out of scope) is also reported
-    `would_drop=0`/`margin=None`, mirroring the real function's own decline
-    of that chain entirely (both producer and consumer left completely
-    untouched, rather than a partial-block re-quantization or a
-    disagreeing keep-set between the two) -- this is a genuinely matched
-    unit the real call still declines to touch, so it gets a report row
-    here too, unlike `not_eligible` (reserved for topology
-    :func:`_find_matmul_nbits_chains` never recognized at all).
+    A chain whose consumer is ``MatMulNBits`` and whose keep-set doesn't
+    happen to align to that consumer's own `block_size` boundaries
+    (:func:`_matmul_nbits_block_aligned_keep_blocks` returning ``None`` -- an
+    individual K-column can't be dropped without re-quantizing its whole
+    block, out of scope) is also reported `would_drop=0`/`margin=None`,
+    mirroring the real function's own decline of that chain entirely (both
+    producer and consumer left completely untouched, rather than a
+    partial-block re-quantization or a disagreeing keep-set between the
+    two) -- this is a genuinely matched unit the real call still declines to
+    touch, so it gets a report row here too, unlike `not_eligible` (reserved
+    for topology :func:`_find_matmul_nbits_chains` never recognized at all).
+    A plain-float consumer has no block structure, so this check never
+    applies to it -- mirrors the real call's own `isinstance` dispatch.
 
     A degenerate chain naming the exact same weight in both the producer
     and consumer role gets no report row at all (mirroring
@@ -17684,7 +17685,8 @@ def _analyze_structured_pruning_matmul_nbits(
 
     for chain in chains:
         p, c = chain.producer, chain.consumer
-        p_key, c_key = p.b_init.name, c.b_init.name
+        p_key = _matmul_nbits_chain_side_key(p)
+        c_key = _matmul_nbits_chain_side_key(c)
         if p_key == c_key:
             continue  # degenerate (the same weight in both roles) -- no report row
 
@@ -17721,7 +17723,7 @@ def _analyze_structured_pruning_matmul_nbits(
             )
             continue  # rounds down to nothing for this chain -- no-op
 
-        w_nk = _matmul_nbits_dequantized(p)
+        w_nk = _matmul_nbits_chain_producer_weight_nk(p)
         importance = _qdq_channel_importance(w_nk, importance_norm)
         # `kind="stable"` to match `apply_structured_pruning_matmul_nbits`'s
         # own tie-break exactly (see that function's own comment on this
@@ -17730,24 +17732,25 @@ def _analyze_structured_pruning_matmul_nbits(
         # the real call's, platform-dependently.
         keep = np.sort(np.argsort(-importance, kind="stable")[:keep_count])
 
-        keep_blocks = _matmul_nbits_block_aligned_keep_blocks(
-            keep, c.k_blocks, c.block_size
-        )
-        if keep_blocks is None:
-            layers.append(
-                PruningLayerSensitivity(
-                    label=label,
-                    family=family,
-                    total=n,
-                    would_drop=0,
-                    margin=None,
-                    importance_min=0.0,
-                    importance_max=0.0,
-                )
+        if isinstance(c, _MatMulNBitsWeight):
+            keep_blocks = _matmul_nbits_block_aligned_keep_blocks(
+                keep, c.k_blocks, c.block_size
             )
-            continue  # non-block-aligned keep-set for this consumer -- the
-            # real call declines this chain entirely too, see this
-            # function's own docstring
+            if keep_blocks is None:
+                layers.append(
+                    PruningLayerSensitivity(
+                        label=label,
+                        family=family,
+                        total=n,
+                        would_drop=0,
+                        margin=None,
+                        importance_min=0.0,
+                        importance_max=0.0,
+                    )
+                )
+                continue  # non-block-aligned keep-set for this consumer -- the
+                # real call declines this chain entirely too, see this
+                # function's own docstring
 
         keep_mask = np.zeros(n, dtype=bool)
         keep_mask[keep] = True

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -22315,6 +22315,117 @@ def test_matmul_nbits_pruning_declines_mixed_qdq_chain():
     assert inits_before == inits_after
 
 
+def test_analyze_structured_pruning_matmul_nbits_mixed_chain_does_not_crash():
+    # _analyze_structured_pruning_matmul_nbits (the dry-run sensitivity
+    # mirror) must handle a MIXED MatMulNBits/plain-float chain exactly like
+    # apply_structured_pruning_matmul_nbits itself does -- neither side of
+    # _MatMulNBitsChainSide is guaranteed to be a _MatMulNBitsWeight (see
+    # _find_matmul_nbits_chains's own docstring), so code that reaches for a
+    # _MatMulNBitsWeight-only attribute (``b_init``, ``k_blocks``,
+    # ``block_size``) unconditionally on either side would raise
+    # AttributeError the first time a chain's producer or consumer turns out
+    # to be the plain-float _PlainMatMulNBitsPeer instead. Reuses both mixed
+    # models the apply()-side oracle tests above already built (the plain
+    # producer here has no block structure of its own, so this only
+    # exercises the ``b_init``/producer-key half of that bug; the
+    # MatMulNBits-producer model exercises the ``k_blocks``/``block_size``
+    # consumer half), and cross-checks the sensitivity report's `would_drop`
+    # against what the real apply() call actually prunes.
+    N1, K1, Out, block_size = 32, 64, 8, 16
+    rng = np.random.default_rng(120)
+    W1 = rng.standard_normal((N1, K1)).astype(np.float32) * 0.2
+    W1[:16] *= 6.0
+    bias1 = (rng.standard_normal(N1) * 0.05).astype(np.float32)
+    qcodes1, scales1, zp1, kb1 = _nbits_quantize_block(W1, block_size)
+    B1 = _nbits_pack_B(qcodes1, N1, kb1, block_size)
+    ZP1 = _nbits_pack_codes(zp1, 4)
+    W2 = rng.standard_normal((N1, Out)).astype(np.float32) * 0.3
+
+    node1 = _nbits_node(
+        "mm1", "A", "h1", "B1", "scales1", "zp1", "bias1", N1, K1, block_size
+    )
+    act = onnx.helper.make_node("Relu", ["h1"], ["h1_act"])
+    node2 = onnx.helper.make_node("MatMul", ["h1_act", "W2"], ["Y"], name="mm2")
+    graph = onnx.helper.make_graph(
+        [node1, act, node2],
+        "g",
+        inputs=[
+            onnx.helper.make_tensor_value_info("A", onnx.TensorProto.FLOAT, [3, K1])
+        ],
+        outputs=[
+            onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [3, Out])
+        ],
+        initializer=[
+            onnx.numpy_helper.from_array(B1, name="B1"),
+            onnx.numpy_helper.from_array(scales1, name="scales1"),
+            onnx.numpy_helper.from_array(ZP1, name="zp1"),
+            onnx.numpy_helper.from_array(bias1, name="bias1"),
+            onnx.numpy_helper.from_array(W2, name="W2"),
+        ],
+    )
+    model_nbits_producer = onnx.helper.make_model(
+        graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 21),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    model_nbits_producer.ir_version = 10
+    onnx.checker.check_model(model_nbits_producer)
+
+    N1b, K1b, N2b, block_sizeb = 32, 64, 8, 16
+    rngb = np.random.default_rng(122)
+    W1b = rngb.standard_normal((K1b, N1b)).astype(np.float32) * 0.2
+    W1b[:, :16] *= 6.0
+    W2b = rngb.standard_normal((N2b, N1b)).astype(np.float32) * 0.2
+    qcodes2b, scales2b, zp2b, kb2b = _nbits_quantize_block(W2b, block_sizeb)
+    B2b = _nbits_pack_B(qcodes2b, N2b, kb2b, block_sizeb)
+    ZP2b = _nbits_pack_codes(zp2b, 4)
+
+    node1b = onnx.helper.make_node("MatMul", ["A", "W1"], ["h1"], name="mm1")
+    actb = onnx.helper.make_node("Relu", ["h1"], ["h1_act"])
+    node2b = _nbits_node(
+        "mm2", "h1_act", "Y", "B2", "scales2", "zp2", None, N2b, N1b, block_sizeb
+    )
+    graphb = onnx.helper.make_graph(
+        [node1b, actb, node2b],
+        "g",
+        inputs=[
+            onnx.helper.make_tensor_value_info("A", onnx.TensorProto.FLOAT, [3, K1b])
+        ],
+        outputs=[
+            onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [3, N2b])
+        ],
+        initializer=[
+            onnx.numpy_helper.from_array(W1b, name="W1"),
+            onnx.numpy_helper.from_array(B2b, name="B2"),
+            onnx.numpy_helper.from_array(scales2b, name="scales2"),
+            onnx.numpy_helper.from_array(ZP2b, name="zp2"),
+        ],
+    )
+    model_plain_producer = onnx.helper.make_model(
+        graphb,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 21),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    model_plain_producer.ir_version = 10
+    onnx.checker.check_model(model_plain_producer)
+
+    for model in (model_nbits_producer, model_plain_producer):
+        report = onnxsim.analyze_pruning_sensitivity(
+            model, onnxsim.apply_structured_pruning_matmul_nbits, sparsity=0.5
+        )
+        assert report.not_eligible == []
+        assert len(report.layers) == 1
+        layer = report.layers[0]
+        pruned = onnxsim.apply_structured_pruning_matmul_nbits(model, sparsity=0.5)
+        pruned_n1 = next(t for t in pruned.graph.initializer if t.name in ("B1", "W1"))
+        real_n1 = pruned_n1.dims[0] if pruned_n1.name == "B1" else pruned_n1.dims[1]
+        assert layer.would_drop == layer.total - real_n1
+
+
 def test_matmul_nbits_pruning_zero_sparsity_is_a_no_op():
     N1, K1, N2, block_size = 32, 64, 8, 16
     rng = np.random.default_rng(116)


### PR DESCRIPTION
CI's Lint workflow was failing mypy with 4 union-attr/arg-type errors: the
dry-run sensitivity mirror assumed both producer and consumer were always
_MatMulNBitsWeight and reached for .b_init/.k_blocks/.block_size
unconditionally, even though _find_matmul_nbits_chains can match a MIXED
MatMulNBits/plain-float chain (only requires at least one side to be
MatMulNBits). This wasn't just a typing gap -- it would raise AttributeError
at runtime on such a mixed chain. Mirror
apply_structured_pruning_matmul_nbits's own dispatch
(_matmul_nbits_chain_side_key / _matmul_nbits_chain_producer_weight_nk /
isinstance(c, _MatMulNBitsWeight)) and correct the docstring's now-inaccurate
"MatMulNBits-to-MatMulNBits-only" claim.

Adds a regression test exercising both mixed-chain directions through the
sensitivity report.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014umtnBMRWbTkmxnim4P1rH