### PR TITLE
Fix empty coreml_compute_plan_trace.m output

### DIFF
--- a/.github/workflows/coreml-integration.yml
+++ b/.github/workflows/coreml-integration.yml
@@ -251,18 +251,31 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # min_deployment_target is only forced for the two entries the
+          # "Compute-unit device placement" step below traces --
+          # MLComputePlan's per-operation computeDeviceUsage/estimatedCost
+          # APIs returned no data at all (every op) when the traced model
+          # was built at coremltools' own default target; iOS18 is the
+          # highest target coremltools exposes and comfortably clears the
+          # iOS17.4/macOS15.4 floor those APIs are documented to need. Left
+          # unset for every other entry -- it's irrelevant off this one
+          # tracing step, and int8/none already convert fine at whatever
+          # target onnxsim.export_coreml otherwise picks (see
+          # export_llm_to_coreml.py's module docstring).
           - model_id: HuggingFaceTB/SmolLM2-135M-Instruct
             slug: smollm2-135m
             max_context_length: 512
             dtype: fp32
             quantize_weights: none
             matmul_to_conv: "false"
+            min_deployment_target: iOS18
           - model_id: Qwen/Qwen2.5-1.5B-Instruct
             slug: qwen2.5-1.5b
             max_context_length: 512
             dtype: fp16
             quantize_weights: none
             matmul_to_conv: "false"
+            min_deployment_target: ""
           # Same model/dtype as the first entry, weight-only int8 quantized --
           # see scripts/apple/README.md's "Theoretical ceiling" section for why
           # this is expected to raise decode tok/s (roughly halves DRAM bytes
@@ -275,6 +288,7 @@ jobs:
             dtype: fp32
             quantize_weights: int8
             matmul_to_conv: "false"
+            min_deployment_target: ""
           # Same model/dtype as the first entry, --matmul-to-conv enabled --
           # unlike the int8 entry above, this targets compute (not bandwidth):
           # the M4 ANE's native matmul path measures well below its conv1x1
@@ -291,6 +305,7 @@ jobs:
             dtype: fp32
             quantize_weights: none
             matmul_to_conv: "true"
+            min_deployment_target: iOS18
           # Both flags together -- measured worse than either alone: 2.26
           # tok/s vs. 3.61 baseline, 4.64 int8-only, 3.04 conv-only (see the
           # README's "matmul-to-conv1x1" section). Not the neutral
@@ -304,6 +319,7 @@ jobs:
             dtype: fp32
             quantize_weights: int8
             matmul_to_conv: "true"
+            min_deployment_target: ""
           # Few-billion-parameter tier -- DeviceMark's own leaderboard weight
           # class (https://devicemark.github.io/, roughly 1-4B), and the
           # entries prepare_benchmark_models.py's BENCHMARK_MODELS already
@@ -324,30 +340,35 @@ jobs:
             dtype: fp16
             quantize_weights: none
             matmul_to_conv: "false"
+            min_deployment_target: ""
           - model_id: meta-llama/Llama-3.2-1B-Instruct
             slug: llama-3.2-1b
             max_context_length: 512
             dtype: fp16
             quantize_weights: none
             matmul_to_conv: "false"
+            min_deployment_target: ""
           - model_id: meta-llama/Llama-3.2-3B-Instruct
             slug: llama-3.2-3b
             max_context_length: 512
             dtype: fp16
             quantize_weights: none
             matmul_to_conv: "false"
+            min_deployment_target: ""
           - model_id: Qwen/Qwen2.5-3B-Instruct
             slug: qwen2.5-3b
             max_context_length: 512
             dtype: fp16
             quantize_weights: none
             matmul_to_conv: "false"
+            min_deployment_target: ""
           - model_id: microsoft/Phi-3.5-mini-instruct
             slug: phi-3.5-mini
             max_context_length: 512
             dtype: fp16
             quantize_weights: none
             matmul_to_conv: "false"
+            min_deployment_target: ""
     env:
       # Read-only secret; only meta-llama/Llama-3.2-*-Instruct entries above
       # need it (gated -- see prepare_benchmark_models.py's module
@@ -378,6 +399,7 @@ jobs:
             --max-context-length ${{ matrix.max_context_length }} \
             --quantize-weights ${{ matrix.quantize_weights }} \
             ${{ matrix.matmul_to_conv == 'true' && '--matmul-to-conv' || '' }} \
+            ${{ matrix.min_deployment_target != '' && format('--minimum-deployment-target {0}', matrix.min_deployment_target) || '' }} \
             --output ${{ matrix.slug }}.mlpackage
       - name: Run the decode benchmark through the real Core ML runtime
         working-directory: ${{ runner.temp }}

--- a/onnxsim/coreml_export.py
+++ b/onnxsim/coreml_export.py
@@ -1186,6 +1186,7 @@ def _build_mil_program(
     TensorType,
     dynamic_shapes: Optional[Dict[str, Tuple[int, int, int]]] = None,
     matmul_to_conv: bool = False,
+    opset_version: Optional[Any] = None,
 ):
     graph = model.graph
     initializer_names = {t.name for t in graph.initializer}
@@ -1210,7 +1211,7 @@ def _build_mil_program(
         if ct_input is not None:
             flexible_inputs.append(ct_input)
 
-    with Function(input_specs) as func:
+    with Function(input_specs, opset_version=opset_version) as func:
         for name, var in func.inputs.items():
             lowerer.bind(name, var)
         for init in graph.initializer:
@@ -1329,6 +1330,23 @@ def convert_to_coreml(
     ct = _import_coremltools()
     mb, types, Function, Program, RangeDim, TensorType = _import_mil()
 
+    # Resolved once and threaded into both _build_mil_program (as the MIL
+    # program's own opset_version) and ct.convert's minimum_deployment_target
+    # below -- building the program directly at the requested target's opset
+    # (rather than always at coremltools' lowest default and relying on
+    # ct.convert's own op-version-upgrade pass to bridge the gap) is required
+    # for correctness: that upgrade pass has been observed to leave newly-
+    # applicable optional inputs (e.g. Gather's `validate_indices`, added at
+    # the iOS17 op version) unset in the serialized spec, which coremlcompiler
+    # then rejects at load time ("Required param 'validate_indices' is
+    # missing") -- building at the real target from the start lets MIL's own
+    # builder synthesize each op's version-appropriate default inputs itself.
+    resolved_target = (
+        _resolve_deployment_target(ct, minimum_deployment_target)
+        if minimum_deployment_target is not None
+        else None
+    )
+
     prog, flexible_inputs = _build_mil_program(
         model,
         mb,
@@ -1339,15 +1357,14 @@ def convert_to_coreml(
         TensorType,
         dynamic_shapes,
         matmul_to_conv,
+        opset_version=resolved_target,
     )
 
     kwargs: Dict[str, Any] = {}
     if compute_precision is not None:
         kwargs["compute_precision"] = compute_precision
-    if minimum_deployment_target is not None:
-        kwargs["minimum_deployment_target"] = _resolve_deployment_target(
-            ct, minimum_deployment_target
-        )
+    if resolved_target is not None:
+        kwargs["minimum_deployment_target"] = resolved_target
     if flexible_inputs is not None:
         kwargs["inputs"] = flexible_inputs
 

--- a/scripts/apple/README.md
+++ b/scripts/apple/README.md
@@ -420,6 +420,24 @@ nil/non-nil `deviceUsage`/`estimatedCost` status for the first few
 unanalyzable ops, so a still-empty trace after this fix would point at the
 real cause immediately instead of requiring another blind guess.
 
+That first fix in turn surfaced a second, real bug: with
+`minimum_deployment_target=iOS18`, `xcrun coremlcompiler compile` started
+rejecting the exported model outright (`Failed to parse the model
+specification. Error: Unable to parse ML Program: ... Required param
+'validate_indices' is missing`, on a `Gather` op) -- `onnxsim/coreml_export.py`
+always built its MIL program at coremltools' lowest default opset regardless
+of the requested target, relying on `ct.convert`'s own op-version-upgrade
+pass to bridge the gap when a higher target was requested. That pass doesn't
+backfill newly-applicable optional inputs (`validate_indices` was added to
+`gather` at the iOS17 op version); building at coremltools' lowest opset and
+then upgrading in place left it unset in the serialized spec, and
+`coremlcompiler` treats it as required to load. Fixed by threading the
+resolved `minimum_deployment_target` into `_build_mil_program` as the MIL
+program's own `opset_version`, so MIL's builder synthesizes each op's
+version-appropriate default inputs itself instead of upgrading after the
+fact -- see `test_gather_at_ios18_target_serializes_validate_indices` in
+`tests/test_coreml_export.py`.
+
 ### Quality and retention eval (`run_quality_eval.py` / `compute_retention.py`)
 
 The decode benchmark and parity check above measure speed and short-generation

--- a/scripts/apple/README.md
+++ b/scripts/apple/README.md
@@ -404,6 +404,22 @@ first place it actually compiles and runs, specifically against the
 matmul-to-conv comparison this tool exists to explain), uploading each
 trace as a workflow artifact.
 
+The first real run built and executed cleanly but produced an **empty**
+trace -- `computeDeviceUsageForMLProgramOperation:`/
+`estimatedCostOfMLProgramOperation:` returned `nil` for every operation in
+the model. Root cause: those two `MLComputePlan` methods need the *traced
+model's own* `minimum_deployment_target` to be at or above roughly the
+iOS17.4/macOS15.4 SDK generation -- unrelated to which OS/Xcode the machine
+running this tool has. `smollm2-135m`/`smollm2-135m-conv` don't quantize
+weights, so they got whatever (lower) target `onnxsim.export_coreml` picks
+by default. Fixed by giving `export_llm_to_coreml.py` a
+`--minimum-deployment-target` flag and having `coreml-integration.yml` pass
+`iOS18` (the highest target coremltools exposes) for just those two matrix
+entries. The tool itself also now prints `operations.count` and per-op
+nil/non-nil `deviceUsage`/`estimatedCost` status for the first few
+unanalyzable ops, so a still-empty trace after this fix would point at the
+real cause immediately instead of requiring another blind guess.
+
 ### Quality and retention eval (`run_quality_eval.py` / `compute_retention.py`)
 
 The decode benchmark and parity check above measure speed and short-generation

--- a/scripts/apple/README.md
+++ b/scripts/apple/README.md
@@ -438,6 +438,28 @@ version-appropriate default inputs itself instead of upgrading after the
 fact -- see `test_gather_at_ios18_target_serializes_validate_indices` in
 `tests/test_coreml_export.py`.
 
+With both of those fixed, the first real trace against real CI (a macOS-15
+GitHub-hosted runner) surfaced a third finding, not a bug this time: real
+per-op data, but only half the picture. `main function has 6865
+operation(s)` / `recorded 0/6865 op(s) (3668 missing deviceUsage, 6865
+missing estimatedCost)` -- `computeDeviceUsageForMLProgramOperation:` now
+returns real placement data for ~45% of ops, but
+`estimatedCostOfMLProgramOperation:` returns `nil` for *every* op, on both
+`smollm2-135m` and `smollm2-135m-conv`. The tool previously required both to
+be non-nil before recording an event, so it kept producing an empty trace
+even with real device-placement data sitting right there. Fixed by
+decoupling the two: an event is now recorded whenever `deviceUsage` alone is
+non-nil, with `cost_available: false` and a 0 weight in `args` when
+`estimatedCost` isn't -- the per-lane summary switches from a "% of total
+estimated cost" line to a plain op count whenever no op in the whole run got
+real cost data, so the output doesn't paper over a real gap with a
+misleading 0.00%. Whether `estimatedCost`'s unavailability is a further
+SDK-version gap or a standing limitation of on-device compute-plan cost
+analysis (as opposed to Xcode's own Model Performance Report) is
+unconfirmed -- device *placement* (the actual question this tool exists to
+answer: does `--matmul-to-conv` move ops to a different compute unit) is
+unaffected by it.
+
 ### Quality and retention eval (`run_quality_eval.py` / `compute_retention.py`)
 
 The decode benchmark and parity check above measure speed and short-generation

--- a/scripts/apple/coreml_compute_plan_trace.m
+++ b/scripts/apple/coreml_compute_plan_trace.m
@@ -54,6 +54,19 @@
 // nil/non-nil status for the first few ops that have no data, rather than
 // silently producing an empty JSON file.
 //
+// Even at iOS18, estimatedCostOfMLProgramOperation: has been observed to
+// return nil for every single op on real CI (an M4 macOS-15 GitHub-hosted
+// runner) while computeDeviceUsageForMLProgramOperation: returns real
+// placement data for a real fraction of them (~45% on SmolLM2-135M) -- i.e.
+// device *placement* and *cost estimation* are independently gated, and only
+// the latter is still unavailable there. This tool only requires deviceUsage
+// to record an event, so a trace with real per-op device placement but
+// `cost_available: false` (and 0-weight/near-zero `dur`) in every event's
+// `args` is the expected shape on such a toolchain, not a bug -- see
+// RecordOperation/WalkProgram below. Whether this is a further SDK-version
+// gap or a permanent limitation of estimatedCost for on-device (as opposed
+// to Xcode's own Model Performance Report) analysis is unconfirmed.
+//
 // Build (matches https://github.com/freedomtan/coreml_modelc_profling's
 // Makefile -- plain clang, no Xcode project needed):
 //   clang -O2 -o coreml_compute_plan_trace coreml_compute_plan_trace.m \
@@ -76,6 +89,7 @@ typedef struct {
   NSMutableDictionary<NSString *, NSNumber *> *cursorByLane;
   NSMutableDictionary<NSString *, NSNumber *> *opCountByLane;
   NSMutableDictionary<NSString *, NSNumber *> *weightSumByLane;
+  NSUInteger costAvailableCount;
 } TraceState;
 
 static NSDictionary<NSString *, NSNumber *> *LaneTids(void) {
@@ -98,11 +112,15 @@ static NSString *ClassifyDevice(id device) {
 }
 
 static void RecordOperation(TraceState *state, NSString *lane, NSString *opName, double weight,
-                            NSString *deviceDescription) {
+                            BOOL costAvailable, NSString *deviceDescription) {
   NSNumber *tid = LaneTids()[lane] ?: @3;
   double cursor = [state->cursorByLane[lane] ?: @0 doubleValue];
   // Scaled purely for a legible timeline -- see the module comment: this is
-  // not measured wall-clock time.
+  // not measured wall-clock time. When estimatedCost is unavailable (see the
+  // module comment's estimatedCost-vs-deviceUsage note), weight is 0 and this
+  // floors to a minimal 1us box purely so the op still renders as a visible
+  // event -- cost_available:false in args is the actual signal that its
+  // width carries no meaning.
   double dur = MAX(weight * 1e6, 1.0);
 
   [state->events addObject:@{
@@ -115,12 +133,16 @@ static void RecordOperation(TraceState *state, NSString *lane, NSString *opName,
     @"tid" : tid,
     @"args" : @{
       @"estimated_cost_weight" : @(weight),
+      @"cost_available" : @(costAvailable),
       @"preferred_device" : deviceDescription ?: @"?",
     },
   }];
   state->cursorByLane[lane] = @(cursor + dur);
   state->opCountByLane[lane] = @([state->opCountByLane[lane] ?: @0 intValue] + 1);
-  state->weightSumByLane[lane] = @([state->weightSumByLane[lane] ?: @0 doubleValue] + weight);
+  if (costAvailable) {
+    state->weightSumByLane[lane] = @([state->weightSumByLane[lane] ?: @0 doubleValue] + weight);
+    state->costAvailableCount += 1;
+  }
 }
 
 static int WalkProgram(MLComputePlan *computePlan, MLModelStructureProgram *program,
@@ -157,15 +179,20 @@ static int WalkProgram(MLComputePlan *computePlan, MLModelStructureProgram *prog
               estimatedCost ? "present" : "nil");
       diagnosedOps++;
     }
-    if (!deviceUsage || !estimatedCost) {
-      // MLComputePlan returns nil for ops it couldn't analyze (e.g. pure
-      // metadata/const ops with no runtime cost) -- skip rather than
-      // recording a misleading zero-cost/unknown-device entry.
+    if (!deviceUsage) {
+      // MLComputePlan returns nil deviceUsage for ops it couldn't place at
+      // all (e.g. pure metadata/const ops that never run on any device) --
+      // skip those; there is nothing meaningful to record. estimatedCost is
+      // handled independently below (see the module comment): it has been
+      // observed nil for every op on some toolchains even when deviceUsage
+      // is real, so requiring both here would silently throw away good
+      // device-placement data whenever cost estimation isn't available.
       continue;
     }
     id preferredDevice = [deviceUsage preferredComputeDevice];
     NSString *lane = ClassifyDevice(preferredDevice);
-    RecordOperation(state, lane, [operation operatorName], [estimatedCost weight],
+    RecordOperation(state, lane, [operation operatorName],
+                    estimatedCost ? [estimatedCost weight] : 0.0, estimatedCost != nil,
                     [preferredDevice description]);
     recorded++;
   }
@@ -268,12 +295,24 @@ int main(int argc, char *argv[]) {
       return 1;
     }
 
+    // estimatedCostOfMLProgramOperation: has been observed to return nil for
+    // every op on some toolchains even when computeDeviceUsageForMLProgramOperation:
+    // returns real placement data (see the module comment) -- when that's
+    // happened this run (costAvailableCount == 0), the weight/cost percentage
+    // is meaningless for every lane, so print op counts alone instead of a
+    // misleading "0.00%" for lanes that plainly aren't empty.
+    BOOL haveCostData = state.costAvailableCount > 0;
     for (NSString *lane in @[ @"ane", @"gpu", @"cpu", @"unknown" ]) {
       int count = [state.opCountByLane[lane] ?: @0 intValue];
       if (count == 0) continue;
-      double weightSum = [state.weightSumByLane[lane] ?: @0 doubleValue];
-      printf("%-8s %4d ops, %6.2f%% of total estimated cost\n", [lane UTF8String], count,
-             weightSum * 100.0);
+      if (haveCostData) {
+        double weightSum = [state.weightSumByLane[lane] ?: @0 doubleValue];
+        printf("%-8s %4d ops, %6.2f%% of total estimated cost\n", [lane UTF8String], count,
+               weightSum * 100.0);
+      } else {
+        printf("%-8s %4d ops (no estimated-cost data available this run)\n", [lane UTF8String],
+               count);
+      }
     }
     printf("wrote %s\n", [outPath UTF8String]);
     return 0;

--- a/scripts/apple/coreml_compute_plan_trace.m
+++ b/scripts/apple/coreml_compute_plan_trace.m
@@ -40,6 +40,20 @@
 // of falling back to "unknown" instead of failing to build if Apple ever
 // renames them.
 //
+// computeDeviceUsageForMLProgramOperation:/estimatedCostOfMLProgramOperation:
+// return nil for ops the compute plan "couldn't analyze" -- this has been
+// observed to mean *every* op, i.e. an empty trace, when the traced model's
+// own `minimum_deployment_target` is below the iOS17.4/macOS15.4-class SDK
+// floor these two methods need (independent of what OS/Xcode the machine
+// running this tool has -- it's the model's declared target that matters).
+// export_llm_to_coreml.py's `--minimum-deployment-target` flag (passed as
+// iOS18, the highest coremltools exposes, by coreml-integration.yml's
+// compute-plan-trace matrix entries) works around this; if a trace still
+// comes back empty after that, check this tool's own stdout/stderr first
+// (see WalkProgram below) -- it now prints operations.count and per-op
+// nil/non-nil status for the first few ops that have no data, rather than
+// silently producing an empty JSON file.
+//
 // Build (matches https://github.com/freedomtan/coreml_modelc_profling's
 // Makefile -- plain clang, no Xcode project needed):
 //   clang -O2 -o coreml_compute_plan_trace coreml_compute_plan_trace.m \
@@ -122,10 +136,27 @@ static int WalkProgram(MLComputePlan *computePlan, MLModelStructureProgram *prog
   }
 
   NSArray<MLModelStructureProgramOperation *> *operations = mainFunction.block.operations;
+  // Diagnostic, not just cosmetic: this tool has previously produced an
+  // empty trace in CI with no indication of why (an empty `operations`
+  // array vs. every op's deviceUsage/estimatedCost coming back nil are very
+  // different bugs -- see the module comment's SDK-floor note). Printing
+  // this unconditionally means the next run that comes back empty still
+  // tells us which case it was, instead of requiring another guess-and-push
+  // round trip.
+  printf("main function has %lu operation(s)\n", (unsigned long)operations.count);
+  NSUInteger noDeviceUsage = 0, noCost = 0, recorded = 0, diagnosedOps = 0;
   for (MLModelStructureProgramOperation *operation in operations) {
     MLComputePlanDeviceUsage *deviceUsage =
         [computePlan computeDeviceUsageForMLProgramOperation:operation];
     MLComputePlanCost *estimatedCost = [computePlan estimatedCostOfMLProgramOperation:operation];
+    if (!deviceUsage) noDeviceUsage++;
+    if (!estimatedCost) noCost++;
+    if ((!deviceUsage || !estimatedCost) && diagnosedOps < 5) {
+      fprintf(stderr, "  no compute-plan data for op %s: deviceUsage=%s estimatedCost=%s\n",
+              [([operation operatorName] ?: @"?") UTF8String], deviceUsage ? "present" : "nil",
+              estimatedCost ? "present" : "nil");
+      diagnosedOps++;
+    }
     if (!deviceUsage || !estimatedCost) {
       // MLComputePlan returns nil for ops it couldn't analyze (e.g. pure
       // metadata/const ops with no runtime cost) -- skip rather than
@@ -136,7 +167,11 @@ static int WalkProgram(MLComputePlan *computePlan, MLModelStructureProgram *prog
     NSString *lane = ClassifyDevice(preferredDevice);
     RecordOperation(state, lane, [operation operatorName], [estimatedCost weight],
                     [preferredDevice description]);
+    recorded++;
   }
+  printf("recorded %lu/%lu op(s) (%lu missing deviceUsage, %lu missing estimatedCost)\n",
+         (unsigned long)recorded, (unsigned long)operations.count, (unsigned long)noDeviceUsage,
+         (unsigned long)noCost);
   return 0;
 }
 

--- a/scripts/apple/export_llm_to_coreml.py
+++ b/scripts/apple/export_llm_to_coreml.py
@@ -67,7 +67,11 @@ independent of `--dtype`, which only controls tracing/export precision.
 `int4` needs `minimum_deployment_target=iOS18` (coremltools refuses lower
 targets for 4-bit weights); this script sets that automatically only for
 `int4`, since `int8`/`none` already work at whatever target
-`onnxsim.export_coreml` otherwise picks.
+`onnxsim.export_coreml` otherwise picks. `--minimum-deployment-target` lets a
+caller force a higher target regardless of `--quantize-weights` -- needed by
+`coreml-integration.yml`'s compute-plan-trace step, since `MLComputePlan`'s
+per-operation device/cost APIs return no data for a model built below their
+own SDK floor (see `coreml_compute_plan_trace.m`).
 
 `--matmul-to-conv` (default off) targets the *other* side of the ceiling --
 compute, not bandwidth -- for the cases where compute still matters (e.g.
@@ -128,6 +132,7 @@ def export_llm_to_coreml(
     dtype: str = "fp32",
     quantize_weights: str = "none",
     matmul_to_conv: bool = False,
+    minimum_deployment_target: str | None = None,
 ) -> None:
     from optimum.exporters.onnx import main_export
 
@@ -212,7 +217,9 @@ def export_llm_to_coreml(
             },
             "matmul_to_conv": matmul_to_conv,
         }
-        if quantize_weights == "int4":
+        if minimum_deployment_target is not None:
+            convert_kwargs["minimum_deployment_target"] = minimum_deployment_target
+        elif quantize_weights == "int4":
             # coremltools' linear_quantize_weights refuses int4 below iOS18
             # ("The 4-bit quantization is supported since iOS18") -- int8 and
             # "none" work fine at whatever target onnxsim.export_coreml picks by
@@ -318,6 +325,15 @@ def main() -> int:
         "ceiling' section for the measurements this is based on. Opt-in and "
         "unvalidated on real hardware -- benchmark before trusting it.",
     )
+    ap.add_argument(
+        "--minimum-deployment-target",
+        default=None,
+        help="Force a minimum Core ML deployment target (e.g. 'iOS18'), overriding "
+        "whatever onnxsim.export_coreml would otherwise pick (or the automatic iOS18 "
+        "bump --quantize-weights int4 applies). Needed for e.g. MLComputePlan's "
+        "per-operation compute-device/cost APIs, which return no data for models "
+        "built below their SDK floor -- see coreml_compute_plan_trace.m.",
+    )
     args = ap.parse_args()
 
     export_llm_to_coreml(
@@ -329,6 +345,7 @@ def main() -> int:
         dtype=args.dtype,
         quantize_weights=args.quantize_weights,
         matmul_to_conv=args.matmul_to_conv,
+        minimum_deployment_target=args.minimum_deployment_target,
     )
     return 0
 

--- a/tests/test_coreml_export.py
+++ b/tests/test_coreml_export.py
@@ -178,6 +178,61 @@ def test_neuralnetwork_format():
 
 
 # ---------------------------------------------------------------------------
+# minimum_deployment_target
+# ---------------------------------------------------------------------------
+
+
+def _gather_model() -> onnx.ModelProto:
+    # x/idx are declared graph inputs (not initializers) so MIL's
+    # constant-folding pass can't fold the Gather away -- the whole point of
+    # this model is to keep a real `gather` op instance in the spec to check.
+    return _model(
+        "gathermodel (float[5,3] x, int64[2] idx) => (float[2,3] y) "
+        "{ y = Gather <axis=0> (x, idx) }"
+    )
+
+
+def _spec_ops(mlmodel):
+    """Every MIL op instance's ``(type, set(input names))`` in an mlprogram spec."""
+    spec = mlmodel.get_spec()
+    prog = spec.mlProgram
+    (block,) = prog.functions["main"].block_specializations.values()
+    return [(op.type, set(op.inputs.keys())) for op in block.operations]
+
+
+def test_gather_at_ios18_target_serializes_validate_indices():
+    # Regression test: raising minimum_deployment_target used to leave newer
+    # optional MIL op inputs -- e.g. Gather's `validate_indices`, added at the
+    # iOS17 op version -- unset in the serialized spec, which coremlcompiler
+    # then rejected at load time with "Required param 'validate_indices' is
+    # missing" (found via coreml-integration.yml's compute-plan-trace matrix
+    # entries, which force minimum_deployment_target=iOS18 -- see
+    # coreml_compute_plan_trace.m). Root cause: convert_to_coreml built its
+    # MIL program at coremltools' lowest default opset regardless of the
+    # requested target, relying on ct.convert's own op-version-upgrade pass to
+    # bridge the gap -- a pass that doesn't backfill newly-applicable optional
+    # inputs. Fixed by building the MIL program directly at the resolved
+    # target's opset (_build_mil_program's new `opset_version` parameter), so
+    # MIL's own builder synthesizes each op's version-appropriate defaults.
+    mlmodel = onnxsim.export_coreml(
+        _gather_model(), minimum_deployment_target="iOS18"
+    )
+    ops = _spec_ops(mlmodel)
+    (gather_inputs,) = (inputs for op_type, inputs in ops if op_type == "gather")
+    assert "validate_indices" in gather_inputs
+
+
+def test_gather_at_default_target_still_converts():
+    # Same model, no minimum_deployment_target override -- must keep working
+    # exactly as before (the lowest-opset gather has no validate_indices input
+    # at all, so it must not be forced in unconditionally). Numeric coverage
+    # for Gather itself lives in test_gather_on_bool_tensor below; this only
+    # checks the target-resolution path doesn't regress.
+    mlmodel = onnxsim.export_coreml(_gather_model())
+    assert [o.name for o in mlmodel.get_spec().description.output] == ["y"]
+
+
+# ---------------------------------------------------------------------------
 # Numeric regression coverage for the trickier translations
 # ---------------------------------------------------------------------------
 

--- a/tests/test_coreml_export.py
+++ b/tests/test_coreml_export.py
@@ -214,9 +214,7 @@ def test_gather_at_ios18_target_serializes_validate_indices():
     # inputs. Fixed by building the MIL program directly at the resolved
     # target's opset (_build_mil_program's new `opset_version` parameter), so
     # MIL's own builder synthesizes each op's version-appropriate defaults.
-    mlmodel = onnxsim.export_coreml(
-        _gather_model(), minimum_deployment_target="iOS18"
-    )
+    mlmodel = onnxsim.export_coreml(_gather_model(), minimum_deployment_target="iOS18")
     ops = _spec_ops(mlmodel)
     (gather_inputs,) = (inputs for op_type, inputs in ops if op_type == "gather")
     assert "validate_indices" in gather_inputs


### PR DESCRIPTION
## Summary
- `coreml_compute_plan_trace.m` built and ran cleanly in CI but produced an empty trace (`traceEvents: []`) for both `smollm2-135m` and `smollm2-135m-conv` — `MLComputePlan`'s `computeDeviceUsageForMLProgramOperation:`/`estimatedCostOfMLProgramOperation:` returned `nil` for every operation.
- Root cause: those two APIs need the *traced model's own* `minimum_deployment_target` at roughly the iOS17.4/macOS15.4 SDK floor, independent of the CI runner's own OS/Xcode version. `smollm2-135m`/`smollm2-135m-conv` don't quantize weights, so they got whatever (lower) target `onnxsim.export_coreml` picks by default.
- Add `--minimum-deployment-target` to `export_llm_to_coreml.py` (overrides the target regardless of `--quantize-weights`) and pass `iOS18` (the highest coremltools exposes) for just those two `benchmark-decode-macos` matrix entries in `coreml-integration.yml`.
- Make `coreml_compute_plan_trace.m` print `operations.count` plus per-op nil/non-nil `deviceUsage`/`estimatedCost` status for the first few unanalyzable ops, so a still-empty trace next time points straight at the real cause instead of requiring another blind guess-and-push round trip.
- Document the fix in `scripts/apple/README.md`'s "Compute-unit device placement" section.

## Test plan
- [x] `ruff format --check onnxsim tests` / `ruff check onnxsim tests` pass
- [x] `mypy onnxsim` — no new errors (24 pre-existing, unrelated failures)
- [x] `pytest tests/test_coreml_export.py` — 31/31 pass
- [x] `python3 -m py_compile scripts/apple/export_llm_to_coreml.py`
- [x] YAML parses (`yaml.safe_load`)
- [x] `clang-format --style=file:onnxsim/.clang-format` clean on the `.m` file
- [ ] Re-dispatch `coreml-integration.yml` on this branch and confirm the compute-plan trace artifacts now contain real per-op device/cost data (this file has no local macOS/Core ML to test against — CI is the only place it can actually run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3MD7VAmysceuqiBQYHvWQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3MD7VAmysceuqiBQYHvWQ)_