### PR TITLE
Support gated (SwiGLU/GeGLU) pairs in QDQ and MatMulNBits structured pruning

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -8246,19 +8246,25 @@ def apply_structured_wanda_pruning(
 #     and empirically confirmed here, per the module's own convention of
 #     explicitly discussing every topology boundary.
 #   * A *general grouped* or depthwise Conv (``group != 1``) on either side
-#     of a QDQ chain, and a gated (SwiGLU/GeGLU) pair, a residual/skip-
-#     connection merge, or a Concat-merged branch group anywhere in a QDQ
-#     chain. Every one of these is already a materially bigger project for
-#     the *plain float* case above (see this module's own top-of-file
-#     docstring) even before QDQ enters the picture; composing either with a
-#     QDQ weight's extra scale/zero-point bookkeeping is well beyond this
-#     section's scope. Only the plain single producer -> [zero or more
-#     shape-preserving unary activations, see `_UNARY_PASS_THROUGH`] ->
-#     single consumer topology (an ordinary, ``group=1`` Conv or MatMul/
-#     vanilla-Gemm on both ends) is matched -- no per-channel Add/Mul
-#     bias/scale hop either, unlike the plain float MatMul/Gemm chain walk
-#     above (:func:`_walk_to_consumer`), unnecessary complexity for this
-#     section's own deliberately narrow first cut.
+#     of a QDQ chain, a residual/skip-connection merge, or a Concat-merged
+#     branch group anywhere in a QDQ chain. Every one of these is already a
+#     materially bigger project for the *plain float* case above (see this
+#     module's own top-of-file docstring) even before QDQ enters the
+#     picture; composing either with a QDQ weight's extra scale/zero-point
+#     bookkeeping is well beyond this section's scope. Only the plain single
+#     producer -> [zero or more shape-preserving unary activations, see
+#     `_UNARY_PASS_THROUGH`] -> single consumer topology (an ordinary,
+#     ``group=1`` Conv or MatMul/vanilla-Gemm on both ends) is matched -- no
+#     per-channel Add/Mul bias/scale hop either, unlike the plain float
+#     MatMul/Gemm chain walk above (:func:`_walk_to_consumer`), unnecessary
+#     complexity for this section's own deliberately narrow first cut. A
+#     gated (SwiGLU/GeGLU) MatMul/Gemm pair, by contrast, IS matched
+#     (:func:`_find_qdq_gated_chains`) -- see
+#     :func:`apply_structured_pruning_qdq`'s own docstring: the topology
+#     itself needed no new machinery beyond mirroring
+#     :func:`_find_gated_chains`'s own backward walk against QDQ-resolved
+#     producers, so it no longer belonged on this "materially bigger
+#     project" list.
 #   * Blocked quantization (opset 21+'s ``block_size`` attribute) with
 #     INT8/UINT8 codes, or blocking along the output-channel axis rather
 #     than the reduction axis, is declined by
@@ -8946,6 +8952,11 @@ class _QDQProducer:
     bias: Optional[str]
     weight_transposed: bool
     is_conv: bool
+    # Activation nodes between this producer's raw output and the point it
+    # combines with another producer (a gated pair only -- see
+    # :func:`_find_qdq_gated_chains`; empty for a plain single-producer
+    # chain). Mirrors :attr:`_Producer.pre_ops` exactly.
+    pre_ops: Tuple[onnx.NodeProto, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -8959,6 +8970,21 @@ class _QDQConsumer:
 @dataclass(frozen=True)
 class _QDQChain:
     producer: _QDQProducer
+    chain_ops: Tuple[onnx.NodeProto, ...]
+    consumer: _QDQConsumer
+    n_channels: int
+
+
+@dataclass(frozen=True)
+class _QDQGatedChain:
+    """The QDQ analogue of a gated (SwiGLU/GeGLU) :class:`_Chain` -- two
+    producers (`producer_a`/`producer_b`, gate_proj/up_proj) combined by an
+    elementwise product, feeding one `consumer` (down_proj), any one or
+    more of the three QDQ-quantized. See :func:`_find_qdq_gated_chains`.
+    """
+
+    producer_a: _QDQProducer
+    producer_b: _QDQProducer
     chain_ops: Tuple[onnx.NodeProto, ...]
     consumer: _QDQConsumer
     n_channels: int
@@ -9151,6 +9177,216 @@ def _find_qdq_chains(graph: onnx.GraphProto) -> List[_QDQChain]:
     return chains
 
 
+def _trace_gate_producer_backward_qdq(
+    tensor_name: str,
+    node_by_output: Dict[str, onnx.NodeProto],
+    producer_infos: Dict[
+        str, Tuple[onnx.NodeProto, _WeightRef, bool, Optional[str], int]
+    ],
+    consumers_of: Dict[str, List[onnx.NodeProto]],
+    graph_outputs: Set[str],
+    max_hops: int,
+) -> Optional[
+    Tuple[
+        Tuple[onnx.NodeProto, _WeightRef, bool, Optional[str], int],
+        Tuple[onnx.NodeProto, ...],
+    ]
+]:
+    """The QDQ analogue of :func:`_trace_gate_producer_backward`: walks
+    backward from `tensor_name` through unary activation ops until it
+    resolves to a QDQ-or-plain-float MatMul/vanilla-Gemm producer's raw
+    output (`producer_infos`, keyed the same way but built from
+    :func:`_match_matmul_qdq` instead of :func:`_match_producer` -- see
+    :func:`_find_qdq_gated_chains`). Duplicated rather than shared with the
+    plain-float walker, the same "self-contained per section" choice this
+    module's own QDQ section comment already gives for its other helpers
+    (e.g. :func:`_qdq_block_aligned_keep_blocks`): the two `producer_infos`
+    dicts hold structurally different tuples (a weight *name* there, a
+    resolved :class:`_WeightRef` here), so sharing one function would need
+    either an unsound cast or a wider, less precise type on both call
+    sites.
+    """
+    pre_ops: List[onnx.NodeProto] = []
+    cur = tensor_name
+    for _ in range(max_hops):
+        if len(consumers_of.get(cur, [])) != 1 or cur in graph_outputs:
+            return None
+        if cur in producer_infos:
+            return producer_infos[cur], tuple(reversed(pre_ops))
+        producer_node = node_by_output.get(cur)
+        if producer_node is None:
+            return None
+        if not (
+            producer_node.op_type in _UNARY_PASS_THROUGH
+            and len(producer_node.input) == 1
+            and len(producer_node.output) == 1
+        ):
+            return None
+        pre_ops.append(producer_node)
+        cur = producer_node.input[0]
+    return None
+
+
+def _qdq_gated_channel_importance(
+    w_a_nk: np.ndarray, w_b_nk: np.ndarray, importance_norm: str
+) -> np.ndarray:
+    """Combined importance across a QDQ gated pair's two producers -- root-
+    sum-square (L2) or plain sum (L1) of each producer's own per-channel
+    dequantized-row norm, mirroring :func:`_plain_structured_importance`'s
+    own gated-pair combination exactly (see that function's own docstring
+    for the identity this implements), restricted to the always-exactly-
+    two-producer case a QDQ gated chain matches (no general N-producer
+    residual/Concat composition here).
+    """
+    if importance_norm == "l1":
+        return _qdq_channel_importance(w_a_nk, "l1") + _qdq_channel_importance(
+            w_b_nk, "l1"
+        )
+    return np.sqrt(
+        np.square(_qdq_channel_importance(w_a_nk, "l2"))
+        + np.square(_qdq_channel_importance(w_b_nk, "l2"))
+    )
+
+
+def _find_qdq_gated_chains(graph: onnx.GraphProto) -> List[_QDQGatedChain]:
+    """The QDQ analogue of :func:`_find_gated_chains`: recognizes the same
+    gated (SwiGLU/GeGLU) MatMul/vanilla-Gemm pair -- gate_proj/up_proj
+    sharing one input, combined via a plain elementwise ``Mul`` of two
+    non-constant operands (each optionally through its own
+    `_UNARY_PASS_THROUGH` activation -- an unactivated GLU, or any
+    activation expressed as ordinary unary ops, e.g. GeGLU's ``Gelu``) or
+    ONNX's native fused ``SwiGLU`` node (opset 28+, with nothing between
+    either producer's raw output and the op), feeding into exactly one
+    downstream MatMul/vanilla-Gemm consumer (:func:`_walk_to_consumer_qdq`)
+    -- except gate_proj/up_proj/down_proj may now each independently
+    resolve (:func:`_resolve_weight_ref`, the exact same resolution
+    :func:`_find_qdq_chains`'s own single-producer case uses) to either a
+    direct float initializer or a QDQ-quantized one, requiring at least one
+    of the three to actually be QDQ (a plain float/float/float triple is
+    :func:`_find_gated_chains`'s own job, not duplicated here). A gate
+    activation decomposed into more than one node isn't recognized here
+    either, for the identical reason :func:`_find_gated_chains`'s own
+    docstring gives -- that block is safely left untouched.
+    """
+    initializer_map = {t.name: t for t in graph.initializer}
+    consumers_of = _consumers_of(graph)
+    dq_of = {
+        n.output[0]: n
+        for n in graph.node
+        if n.op_type == "DequantizeLinear" and len(n.output) == 1
+    }
+    graph_outputs = {o.name for o in graph.output}
+    node_by_output = {out: node for node in graph.node for out in node.output}
+
+    def _is_internal(name: str) -> bool:
+        return len(consumers_of.get(name, [])) == 1 and name not in graph_outputs
+
+    producer_infos: Dict[
+        str, Tuple[onnx.NodeProto, _WeightRef, bool, Optional[str], int]
+    ] = {}
+    for node in graph.node:
+        mm = _match_matmul_qdq(node, initializer_map, dq_of, consumers_of)
+        if mm is not None:
+            _x_name, ref, weight_transposed, bias_name, out_channels, _in_channels = mm
+            producer_infos[node.output[0]] = (
+                node,
+                ref,
+                weight_transposed,
+                bias_name,
+                out_channels,
+            )
+
+    def _producer(info, pre_ops) -> _QDQProducer:
+        node, ref, weight_transposed, bias_name, _n = info
+        return _QDQProducer(node, ref, bias_name, weight_transposed, False, pre_ops)
+
+    chains: List[_QDQGatedChain] = []
+    for node in graph.node:
+        if node.op_type == "Mul" and len(node.input) == 2 and len(node.output) == 1:
+            a_name, b_name = node.input
+            if (
+                a_name == b_name
+                or a_name in initializer_map
+                or b_name in initializer_map
+            ):
+                continue
+            trace_a = _trace_gate_producer_backward_qdq(
+                a_name,
+                node_by_output,
+                producer_infos,
+                consumers_of,
+                graph_outputs,
+                _MAX_CHAIN_HOPS,
+            )
+            trace_b = _trace_gate_producer_backward_qdq(
+                b_name,
+                node_by_output,
+                producer_infos,
+                consumers_of,
+                graph_outputs,
+                _MAX_CHAIN_HOPS,
+            )
+            if trace_a is None or trace_b is None:
+                continue
+            info_a, pre_a = trace_a
+            info_b, pre_b = trace_b
+        elif (
+            node.op_type == "SwiGLU" and len(node.input) == 2 and len(node.output) == 1
+        ):
+            a_name, b_name = node.input
+            if a_name in initializer_map or b_name in initializer_map:
+                continue
+            if not (_is_internal(a_name) and _is_internal(b_name)):
+                continue
+            info_a_lookup = producer_infos.get(a_name)
+            info_b_lookup = producer_infos.get(b_name)
+            if info_a_lookup is None or info_b_lookup is None:
+                continue
+            info_a, pre_a = info_a_lookup, ()
+            info_b, pre_b = info_b_lookup, ()
+        else:
+            continue
+
+        node_a, n_a = info_a[0], info_a[4]
+        node_b, n_b = info_b[0], info_b[4]
+        if node_a is node_b or n_a != n_b:
+            continue
+
+        out_name = node.output[0]
+        if not _is_internal(out_name):
+            continue
+
+        found = _walk_to_consumer_qdq(
+            out_name,
+            False,
+            initializer_map,
+            dq_of,
+            consumers_of,
+            graph_outputs,
+            n_a,
+            _MAX_CHAIN_HOPS,
+        )
+        if found is None:
+            continue
+        consumer, chain_ops = found
+
+        producer_a = _producer(info_a, pre_a)
+        producer_b = _producer(info_b, pre_b)
+        if not (producer_a.ref.is_qdq or producer_b.ref.is_qdq or consumer.ref.is_qdq):
+            continue  # all plain float -- _find_gated_chains's own job
+
+        chains.append(
+            _QDQGatedChain(
+                producer_a=producer_a,
+                producer_b=producer_b,
+                chain_ops=chain_ops,
+                consumer=consumer,
+                n_channels=n_a,
+            )
+        )
+    return chains
+
+
 def apply_structured_pruning_qdq(
     model: Union[str, onnx.ModelProto],
     sparsity: float = 0.5,
@@ -9218,19 +9454,42 @@ def apply_structured_pruning_qdq(
     :func:`apply_structured_pruning_matmul_nbits`'s own identical
     precedent.
 
-    No general grouped/depthwise Conv, gated (SwiGLU/GeGLU) pair, residual/
-    skip-connection merge, or Concat-merged branch group is matched for a
-    QDQ chain -- every one of those is already a materially bigger project
-    for the plain float case (:func:`apply_structured_pruning`'s own
-    docstring); composing any of them with QDQ's extra scale/zero-point
-    bookkeeping is out of scope here (see this module's "QDQ" section
-    comment for the full reasoning). Call :func:`apply_structured_pruning`/
-    :func:`apply_structured_wanda_pruning` for those topologies on an
-    all-float graph, and this function for the narrower QDQ-aware slice
-    above; the two never touch the same tensor (a QDQ chain requires at
-    least one QDQ-quantized side, which the float-only passes above can
-    never match in the first place, their own weight matchers requiring a
-    *direct* float initializer).
+    Also handles the gated (SwiGLU/GeGLU) FFN pair
+    (:func:`_find_qdq_gated_chains`, the QDQ analogue of
+    :func:`_find_gated_chains`) -- gate_proj/up_proj (two MatMul/vanilla-
+    Gemm producers sharing one input, combined by an elementwise ``Mul``
+    with gate_proj's output optionally passed through one of the same
+    unary activations first, or ONNX's native fused ``SwiGLU`` op) feeding
+    one down_proj consumer, with any one or more of the three
+    QDQ-quantized (a plain float/float/float triple stays
+    :func:`apply_structured_pruning`'s own job). Both producers are ranked
+    by combined (root-sum-square, or plain sum for L1) importance of their
+    own dequantized rows (:func:`_qdq_gated_channel_importance`) and cut to
+    the *same* surviving channel-index set, since they're about to be
+    multiplied elementwise -- each producer's own int8/int4 codes/scale/
+    zero-point co-sliced in lockstep exactly like an ordinary QDQ
+    producer's above, using the very same per-role slicing helpers
+    (:func:`_slice_producer_weight_qdq`); down_proj is sliced on its input
+    axis exactly like an ordinary QDQ consumer above
+    (:func:`_slice_consumer_weight_qdq`/:func:`_slice_consumer_weight_qdq_block`),
+    including the identical blockwise block-alignment check and whole-chain
+    decline when the keep-set doesn't land on whole `block_size` blocks.
+    Gated pairs are MatMul/Gemm-only, mirroring :func:`_find_gated_chains`'s
+    own restriction -- Conv chains never take part in this composition.
+
+    No general grouped/depthwise Conv, residual/skip-connection merge, or
+    Concat-merged branch group is matched for a QDQ chain -- every one of
+    those is already a materially bigger project for the plain float case
+    (:func:`apply_structured_pruning`'s own docstring); composing any of
+    them with QDQ's extra scale/zero-point bookkeeping is out of scope here
+    (see this module's "QDQ" section comment for the full reasoning). Call
+    :func:`apply_structured_pruning`/:func:`apply_structured_wanda_pruning`
+    for those topologies on an all-float graph, and this function for the
+    narrower QDQ-aware slice above (gated pair included); the two never
+    touch the same tensor (a QDQ chain requires at least one QDQ-quantized
+    side, which the float-only passes above can never match in the first
+    place, their own weight matchers requiring a *direct* float
+    initializer).
 
     :param model: onnx ModelProto object or file path
     :param sparsity: fraction of each eligible producer's output channels to
@@ -9249,7 +9508,8 @@ def apply_structured_pruning_qdq(
     graph = out.graph
 
     chains = _find_qdq_chains(graph)
-    if not chains:
+    gated_chains = _find_qdq_gated_chains(graph)
+    if not chains and not gated_chains:
         return out
 
     initializer_map = {t.name: t for t in graph.initializer}
@@ -9317,6 +9577,76 @@ def apply_structured_pruning_qdq(
             stale_value_info.add(p.ref.qdq.dq_node.output[0])
         elif p.ref.qdq_block is not None:
             stale_value_info.add(p.ref.qdq_block.dq_node.output[0])
+        if c.ref.qdq is not None:
+            stale_value_info.add(c.ref.qdq.dq_node.output[0])
+        elif c.ref.qdq_block is not None:
+            stale_value_info.add(c.ref.qdq_block.dq_node.output[0])
+
+    for gchain in gated_chains:
+        pa, pb, c = gchain.producer_a, gchain.producer_b, gchain.consumer
+        pa_key = _weight_ref_key(pa.ref)
+        pb_key = _weight_ref_key(pb.ref)
+        c_key = _weight_ref_key(c.ref)
+        if pa_key == pb_key or pa_key == c_key or pb_key == c_key:
+            continue  # degenerate (a weight tied across two roles)
+        if (
+            pa_key in producer_touched
+            or pb_key in producer_touched
+            or c_key in consumer_touched
+        ):
+            continue  # a shared/tied weight another chain already resized
+
+        n = gchain.n_channels
+        keep_count = max(1, n - round(n * sparsity))
+        if keep_count >= n:
+            continue  # rounds down to nothing for this layer -- no-op
+
+        w_a_nk = _weight_to_nk(
+            _weight_ref_dequantized(pa.ref), pa.weight_transposed, False
+        )
+        w_b_nk = _weight_to_nk(
+            _weight_ref_dequantized(pb.ref), pb.weight_transposed, False
+        )
+        importance = _qdq_gated_channel_importance(w_a_nk, w_b_nk, importance_norm)
+        # `kind="stable"` for the identical block-alignment-determinism
+        # reason the single-producer loop above documents on this same line.
+        keep = np.sort(np.argsort(-importance, kind="stable")[:keep_count])
+
+        keep_blocks = None
+        if c.ref.qdq_block is not None:
+            keep_blocks = _qdq_block_aligned_keep_blocks(
+                keep, n, c.ref.qdq_block.block_size
+            )
+            if keep_blocks is None:
+                continue  # non-block-aligned keep set for this blockwise
+                # consumer -- decline the whole gated group, see this
+                # function's own top comment
+
+        _slice_producer_weight_qdq(pa.ref, pa.weight_transposed, keep, False)
+        if pa.bias is not None:
+            _slice_last_axis(initializer_map[pa.bias], keep)
+        _slice_producer_weight_qdq(pb.ref, pb.weight_transposed, keep, False)
+        if pb.bias is not None:
+            _slice_last_axis(initializer_map[pb.bias], keep)
+        if keep_blocks is not None:
+            assert c.ref.qdq_block is not None
+            _slice_consumer_weight_qdq_block(c.ref.qdq_block, keep, keep_blocks)
+        else:
+            _slice_consumer_weight_qdq(c.ref, c.weight_transposed, keep, False)
+
+        producer_touched.add(pa_key)
+        producer_touched.add(pb_key)
+        consumer_touched.add(c_key)
+        stale_value_info.add(pa.node.output[0])
+        stale_value_info.update(op.output[0] for op in pa.pre_ops)
+        stale_value_info.add(pb.node.output[0])
+        stale_value_info.update(op.output[0] for op in pb.pre_ops)
+        stale_value_info.update(op.output[0] for op in gchain.chain_ops)
+        for p in (pa, pb):
+            if p.ref.qdq is not None:
+                stale_value_info.add(p.ref.qdq.dq_node.output[0])
+            elif p.ref.qdq_block is not None:
+                stale_value_info.add(p.ref.qdq_block.dq_node.output[0])
         if c.ref.qdq is not None:
             stale_value_info.add(c.ref.qdq.dq_node.output[0])
         elif c.ref.qdq_block is not None:
@@ -9521,12 +9851,17 @@ def apply_structured_pruning_qdq(
 #     dequantize/requantize paths in one chain is a real but separate
 #     extension left to a follow-up, not attempted here.
 #   * No grouped/depthwise structure (there is none to speak of --
-#     ``MatMulNBits`` has no ``group`` attribute), gated (SwiGLU/GeGLU)
-#     pair, residual/skip-connection merge, or Concat-merged branch group
-#     is matched -- only the plain single producer -> [zero or more
-#     shape-preserving unary activations, `_UNARY_PASS_THROUGH`] -> single
-#     consumer topology, identical in spirit to the QDQ section's own
-#     ``_walk_to_consumer_qdq``.
+#     ``MatMulNBits`` has no ``group`` attribute), residual/skip-connection
+#     merge, or Concat-merged branch group is matched -- only the plain
+#     single producer -> [zero or more shape-preserving unary activations,
+#     `_UNARY_PASS_THROUGH`] -> single consumer topology, identical in
+#     spirit to the QDQ section's own ``_walk_to_consumer_qdq``. A gated
+#     (SwiGLU/GeGLU) pair IS matched, though
+#     (:func:`_find_matmul_nbits_gated_chains`) -- see
+#     :func:`apply_structured_pruning_matmul_nbits`'s own docstring: same
+#     backward-walk topology as :func:`_find_gated_chains`, just against
+#     producers that may each independently be ``MatMulNBits`` or
+#     plain-float.
 #   * A shared/tied ``B``/``scales``/``zero_points``/``bias`` tensor (read
 #     by more than one node) is declined by the matcher itself, the same
 #     bar every other matcher in this module is held to -- a plain-float
@@ -10120,6 +10455,32 @@ class _MatMulNBitsChain:
     n_channels: int
 
 
+@dataclass(frozen=True)
+class _MatMulNBitsGatedChain:
+    """The ``MatMulNBits`` analogue of a gated (SwiGLU/GeGLU) :class:`_Chain`
+    -- two producers (`producer_a`/`producer_b`, gate_proj/up_proj, each
+    EITHER a ``MatMulNBits`` node OR a plain-float peer -- see
+    :data:`_MatMulNBitsChainSide`) combined by an elementwise product,
+    feeding one `consumer` (down_proj, same either/or), with at least one
+    of the three a ``MatMulNBits`` node. `producer_a_pre_ops`/
+    `producer_b_pre_ops` carry each branch's own activation nodes between
+    its raw output and the combine point (mirrors :attr:`_Producer.pre_ops`
+    -- kept on the chain itself, rather than added as a field on
+    :data:`_MatMulNBitsChainSide`, since that type is a bare ``Union`` of
+    two independently-defined weight-fact dataclasses shared with the
+    single-producer chain above, not a per-role wrapper). See
+    :func:`_find_matmul_nbits_gated_chains`.
+    """
+
+    producer_a: _MatMulNBitsChainSide
+    producer_a_pre_ops: Tuple[onnx.NodeProto, ...]
+    producer_b: _MatMulNBitsChainSide
+    producer_b_pre_ops: Tuple[onnx.NodeProto, ...]
+    chain_ops: Tuple[onnx.NodeProto, ...]
+    consumer: _MatMulNBitsChainSide
+    n_channels: int
+
+
 def _walk_to_matmul_nbits_consumer(
     start: str,
     initializer_map: Dict[str, onnx.TensorProto],
@@ -10230,6 +10591,189 @@ def _find_matmul_nbits_chains(graph: onnx.GraphProto) -> List[_MatMulNBitsChain]
     return chains
 
 
+def _trace_gate_producer_backward_matmul_nbits(
+    tensor_name: str,
+    node_by_output: Dict[str, onnx.NodeProto],
+    producer_infos: Dict[str, Tuple[onnx.NodeProto, _MatMulNBitsChainSide, int]],
+    consumers_of: Dict[str, List[onnx.NodeProto]],
+    graph_outputs: Set[str],
+    max_hops: int,
+) -> Optional[
+    Tuple[Tuple[onnx.NodeProto, _MatMulNBitsChainSide, int], Tuple[onnx.NodeProto, ...]]
+]:
+    """The ``MatMulNBits`` analogue of :func:`_trace_gate_producer_backward`
+    (and :func:`_trace_gate_producer_backward_qdq`): walks backward from
+    `tensor_name` through unary activation ops until it resolves to a
+    ``MatMulNBits``-or-plain-float MatMul/vanilla-Gemm producer's raw
+    output (`producer_infos`, built from :func:`_match_matmul_nbits`/
+    :func:`_match_plain_matmul_nbits_peer` -- see
+    :func:`_find_matmul_nbits_gated_chains`). Duplicated rather than shared
+    with the QDQ section's own walker, for the identical reason that
+    section gives (structurally different `producer_infos` value types).
+    """
+    pre_ops: List[onnx.NodeProto] = []
+    cur = tensor_name
+    for _ in range(max_hops):
+        if len(consumers_of.get(cur, [])) != 1 or cur in graph_outputs:
+            return None
+        if cur in producer_infos:
+            return producer_infos[cur], tuple(reversed(pre_ops))
+        producer_node = node_by_output.get(cur)
+        if producer_node is None:
+            return None
+        if not (
+            producer_node.op_type in _UNARY_PASS_THROUGH
+            and len(producer_node.input) == 1
+            and len(producer_node.output) == 1
+        ):
+            return None
+        pre_ops.append(producer_node)
+        cur = producer_node.input[0]
+    return None
+
+
+def _matmul_nbits_gated_channel_importance(
+    w_a_nk: np.ndarray, w_b_nk: np.ndarray, importance_norm: str
+) -> np.ndarray:
+    """Combined importance across a ``MatMulNBits`` gated pair's two
+    producers -- root-sum-square (L2) or plain sum (L1) of each producer's
+    own per-channel dequantized-or-plain row norm, mirroring
+    :func:`_qdq_gated_channel_importance`'s own identical combination
+    (duplicated rather than shared for this section's own established
+    "self-contained" reason -- see its own top comment).
+    """
+    if importance_norm == "l1":
+        return _qdq_channel_importance(w_a_nk, "l1") + _qdq_channel_importance(
+            w_b_nk, "l1"
+        )
+    return np.sqrt(
+        np.square(_qdq_channel_importance(w_a_nk, "l2"))
+        + np.square(_qdq_channel_importance(w_b_nk, "l2"))
+    )
+
+
+def _find_matmul_nbits_gated_chains(
+    graph: onnx.GraphProto,
+) -> List[_MatMulNBitsGatedChain]:
+    """The ``MatMulNBits`` analogue of :func:`_find_qdq_gated_chains` (and,
+    ultimately, of :func:`_find_gated_chains` itself): recognizes the same
+    gated (SwiGLU/GeGLU) MatMul/vanilla-Gemm pair -- gate_proj/up_proj
+    sharing one input, combined via a plain elementwise ``Mul`` of two
+    non-constant operands (each optionally through its own
+    `_UNARY_PASS_THROUGH` activation) or ONNX's native fused ``SwiGLU``
+    node, feeding into exactly one downstream consumer whose input-channel
+    count matches (:func:`_walk_to_matmul_nbits_consumer`) -- except
+    gate_proj/up_proj/down_proj may now each independently be EITHER a
+    ``MatMulNBits`` node OR a plain-float MatMul/vanilla-Gemm peer
+    (:func:`_match_matmul_nbits`/:func:`_match_plain_matmul_nbits_peer`,
+    the exact same resolution :func:`_find_matmul_nbits_chains`'s own
+    single-producer case uses), requiring at least one of the three to
+    actually be ``MatMulNBits`` (an all-plain-float triple is
+    :func:`_find_gated_chains`'s own job, not duplicated here).
+    """
+    initializer_map = {t.name: t for t in graph.initializer}
+    consumers_of = _consumers_of(graph)
+    graph_outputs = {o.name for o in graph.output}
+    node_by_output = {out: node for node in graph.node for out in node.output}
+
+    def _is_internal(name: str) -> bool:
+        return len(consumers_of.get(name, [])) == 1 and name not in graph_outputs
+
+    producer_infos: Dict[str, Tuple[onnx.NodeProto, _MatMulNBitsChainSide, int]] = {}
+    for node in graph.node:
+        if node.op_type == "MatMulNBits":
+            w = _match_matmul_nbits(node, initializer_map, consumers_of)
+            if w is not None:
+                producer_infos[node.output[0]] = (node, w, w.N)
+        else:
+            peer = _match_plain_matmul_nbits_peer(node, initializer_map, consumers_of)
+            if peer is not None:
+                producer_infos[node.output[0]] = (node, peer, peer.out_channels)
+
+    chains: List[_MatMulNBitsGatedChain] = []
+    for node in graph.node:
+        if node.op_type == "Mul" and len(node.input) == 2 and len(node.output) == 1:
+            a_name, b_name = node.input
+            if (
+                a_name == b_name
+                or a_name in initializer_map
+                or b_name in initializer_map
+            ):
+                continue
+            trace_a = _trace_gate_producer_backward_matmul_nbits(
+                a_name,
+                node_by_output,
+                producer_infos,
+                consumers_of,
+                graph_outputs,
+                _MAX_CHAIN_HOPS,
+            )
+            trace_b = _trace_gate_producer_backward_matmul_nbits(
+                b_name,
+                node_by_output,
+                producer_infos,
+                consumers_of,
+                graph_outputs,
+                _MAX_CHAIN_HOPS,
+            )
+            if trace_a is None or trace_b is None:
+                continue
+            info_a, pre_a = trace_a
+            info_b, pre_b = trace_b
+        elif (
+            node.op_type == "SwiGLU" and len(node.input) == 2 and len(node.output) == 1
+        ):
+            a_name, b_name = node.input
+            if a_name in initializer_map or b_name in initializer_map:
+                continue
+            if not (_is_internal(a_name) and _is_internal(b_name)):
+                continue
+            info_a_lookup = producer_infos.get(a_name)
+            info_b_lookup = producer_infos.get(b_name)
+            if info_a_lookup is None or info_b_lookup is None:
+                continue
+            info_a, pre_a = info_a_lookup, ()
+            info_b, pre_b = info_b_lookup, ()
+        else:
+            continue
+
+        node_a, side_a, n_a = info_a
+        node_b, side_b, n_b = info_b
+        if node_a is node_b or n_a != n_b:
+            continue
+
+        out_name = node.output[0]
+        if not _is_internal(out_name):
+            continue
+
+        found = _walk_to_matmul_nbits_consumer(
+            out_name, initializer_map, consumers_of, graph_outputs, n_a, _MAX_CHAIN_HOPS
+        )
+        if found is None:
+            continue
+        consumer, chain_ops = found
+
+        if (
+            isinstance(side_a, _PlainMatMulNBitsPeer)
+            and isinstance(side_b, _PlainMatMulNBitsPeer)
+            and isinstance(consumer, _PlainMatMulNBitsPeer)
+        ):
+            continue  # all plain float -- _find_gated_chains's own job
+
+        chains.append(
+            _MatMulNBitsGatedChain(
+                producer_a=side_a,
+                producer_a_pre_ops=pre_a,
+                producer_b=side_b,
+                producer_b_pre_ops=pre_b,
+                chain_ops=chain_ops,
+                consumer=consumer,
+                n_channels=n_a,
+            )
+        )
+    return chains
+
+
 def apply_structured_pruning_matmul_nbits(
     model: Union[str, onnx.ModelProto],
     sparsity: float = 0.5,
@@ -10273,15 +10817,42 @@ def apply_structured_pruning_matmul_nbits(
     untouched rather than forcing a partial-block re-quantization or a
     disagreeing keep-set between the two.
 
+    Also handles the gated (SwiGLU/GeGLU) FFN pair
+    (:func:`_find_matmul_nbits_gated_chains`, the ``MatMulNBits`` analogue
+    of :func:`_find_gated_chains`) -- gate_proj/up_proj (two producers
+    sharing one input, EACH independently either a ``MatMulNBits`` node or
+    a plain-float MatMul/vanilla-Gemm peer, combined by an elementwise
+    ``Mul`` with gate_proj's output optionally passed through one of the
+    same unary activations first, or ONNX's native fused ``SwiGLU`` op)
+    feeding one down_proj consumer (same either/or), with at least one of
+    the three a ``MatMulNBits`` node. Both producers are ranked by combined
+    (root-sum-square, or plain sum for L1) importance of their own
+    dequantized-or-plain rows (:func:`_matmul_nbits_gated_channel_importance`)
+    and cut to the *same* surviving channel-index set, since they're about
+    to be multiplied elementwise -- each producer sliced by the same
+    per-role helper an ordinary chain's producer already uses
+    (:func:`_slice_matmul_nbits_chain_producer`). down_proj is sliced on
+    its input axis exactly like an ordinary consumer above
+    (:func:`_slice_matmul_nbits_chain_consumer`), including the identical
+    block-alignment check -- and whole-group decline when the keep-set
+    doesn't land on whole `block_size` blocks -- whenever down_proj is
+    itself ``MatMulNBits``-quantized; a plain-float down_proj has no block
+    structure, so any keep-set applies directly, same as an ordinary
+    single-producer chain's plain-float consumer. Gated pairs are
+    MatMul/Gemm-only, mirroring :func:`_find_gated_chains`'s own
+    restriction.
+
     See this module's section comment for the full list of scope
     boundaries: ``bits`` restricted to ``{4, 8}`` (empirically verified;
     ``bits=2`` remains out of scope), ``weight_prepacked`` and ``g_idx``
     always declined, a QDQ-quantized weight on the other side of a mixed
     chain remains out of scope (unlike
     :func:`apply_structured_pruning_qdq`'s own float/QDQ mixing -- this
-    section mixes ``MatMulNBits`` with plain float ONLY), no grouped/
-    gated/residual/Concat-merge topology, a padded partial final block
-    declined, a shared/tied operand declined.
+    section mixes ``MatMulNBits`` with plain float ONLY), no general
+    grouped/depthwise structure, residual/skip-connection merge, or
+    Concat-merge topology (gated pairs are the one composition now
+    supported, above), a padded partial final block declined, a
+    shared/tied operand declined.
 
     :param model: onnx ModelProto object or file path
     :param sparsity: fraction of each eligible producer's output channels to
@@ -10300,7 +10871,8 @@ def apply_structured_pruning_matmul_nbits(
     graph = out.graph
 
     chains = _find_matmul_nbits_chains(graph)
-    if not chains:
+    gated_chains = _find_matmul_nbits_gated_chains(graph)
+    if not chains and not gated_chains:
         return out
 
     producer_touched: Set[str] = set()
@@ -10357,6 +10929,59 @@ def apply_structured_pruning_matmul_nbits(
         consumer_touched.add(c_key)
         stale_value_info.add(p.node.output[0])
         stale_value_info.update(op.output[0] for op in chain.chain_ops)
+
+    for gchain in gated_chains:
+        pa, pb, c = gchain.producer_a, gchain.producer_b, gchain.consumer
+        pa_key = _matmul_nbits_chain_side_key(pa)
+        pb_key = _matmul_nbits_chain_side_key(pb)
+        c_key = _matmul_nbits_chain_side_key(c)
+        if pa_key == pb_key or pa_key == c_key or pb_key == c_key:
+            continue  # degenerate (a weight tied across two roles)
+        if (
+            pa_key in producer_touched
+            or pb_key in producer_touched
+            or c_key in consumer_touched
+        ):
+            continue  # a shared/tied weight another chain already resized
+
+        n = gchain.n_channels
+        keep_count = max(1, n - round(n * sparsity))
+        if keep_count >= n:
+            continue  # rounds down to nothing for this layer -- no-op
+
+        w_a_nk = _matmul_nbits_chain_producer_weight_nk(pa)
+        w_b_nk = _matmul_nbits_chain_producer_weight_nk(pb)
+        importance = _matmul_nbits_gated_channel_importance(
+            w_a_nk, w_b_nk, importance_norm
+        )
+        # `kind="stable"` for the identical block-alignment-determinism
+        # reason the single-producer loop above documents on this same line.
+        keep = np.sort(np.argsort(-importance, kind="stable")[:keep_count])
+
+        if isinstance(c, _MatMulNBitsWeight):
+            keep_blocks = _matmul_nbits_block_aligned_keep_blocks(
+                keep, c.k_blocks, c.block_size
+            )
+            if keep_blocks is None:
+                continue  # non-block-aligned request for this consumer --
+                # decline the whole gated group, see this section's own top
+                # comment
+            consumer_keep = keep_blocks
+        else:
+            consumer_keep = keep  # plain-float consumer -- no block structure
+
+        _slice_matmul_nbits_chain_producer(pa, keep)
+        _slice_matmul_nbits_chain_producer(pb, keep)
+        _slice_matmul_nbits_chain_consumer(c, consumer_keep)
+
+        producer_touched.add(pa_key)
+        producer_touched.add(pb_key)
+        consumer_touched.add(c_key)
+        stale_value_info.add(pa.node.output[0])
+        stale_value_info.update(op.output[0] for op in gchain.producer_a_pre_ops)
+        stale_value_info.add(pb.node.output[0])
+        stale_value_info.update(op.output[0] for op in gchain.producer_b_pre_ops)
+        stale_value_info.update(op.output[0] for op in gchain.chain_ops)
 
     if stale_value_info:
         kept = [vi for vi in graph.value_info if vi.name not in stale_value_info]
@@ -16634,25 +17259,32 @@ def apply_transformer_block_pruning(
 #   `_find_qdq_chains` matches (requiring at least one side to actually be
 #   QDQ-quantized), ranked by `_qdq_channel_importance` on the producer's
 #   own *dequantized* weight row -- the exact same helper the real
-#   function uses to rank, never for the actual (still-quantized) rewrite.
-#   No grouped/depthwise Conv, gated pair, residual merge, or Concat
-#   branch group is matched for a QDQ chain by the real function either,
-#   so none is reported as a matched unit here (they fall out via
-#   `not_eligible` exactly like any other unmatched Conv/MatMul/Gemm node,
-#   same as the plain float structured family above).
+#   function uses to rank, never for the actual (still-quantized) rewrite
+#   -- plus the gated (SwiGLU/GeGLU) pair `_find_qdq_gated_chains` matches
+#   (`family="qdq_matmul_gated"`), ranked by the combined
+#   `_qdq_gated_channel_importance` of both producers, the same way the
+#   plain float structured family's own gated pair is. No grouped/
+#   depthwise Conv, residual merge, or Concat branch group is matched for a
+#   QDQ chain by the real function either, so none is reported as a matched
+#   unit here (they fall out via `not_eligible` exactly like any other
+#   unmatched Conv/MatMul/Gemm node, same as the plain float structured
+#   family above).
 # - `apply_structured_pruning_matmul_nbits` (``MatMulNBits``-quantized
 #   channel pruning): the ``MatMulNBits``-to-``MatMulNBits``-only topology
 #   `_find_matmul_nbits_chains` matches, ranked by `_qdq_channel_importance`
 #   on the producer's own *dequantized* weight row
 #   (`_matmul_nbits_dequantized`, the same helper the real function uses to
-#   rank, never for the actual int4-code rewrite). A chain whose keep-set
-#   doesn't happen to land on the consumer's own `block_size` boundaries
-#   (`_matmul_nbits_block_aligned_keep_blocks` returning `None`) is reported
-#   `would_drop=0`/`margin=None` -- a genuinely matched unit the real call
-#   still declines to touch, mirroring that outcome exactly rather than
-#   folding it into `not_eligible`. No grouped, gated, residual, or
-#   Concat-merged topology is matched here either, for the same reason the
-#   QDQ family above has none.
+#   rank, never for the actual int4-code rewrite) -- plus the gated
+#   (SwiGLU/GeGLU) pair `_find_matmul_nbits_gated_chains` matches
+#   (`family="matmul_nbits_gated"`), ranked by the combined
+#   `_matmul_nbits_gated_channel_importance` of both producers. A chain (or
+#   gated group) whose keep-set doesn't happen to land on the consumer's
+#   own `block_size` boundaries (`_matmul_nbits_block_aligned_keep_blocks`
+#   returning `None`) is reported `would_drop=0`/`margin=None` -- a
+#   genuinely matched unit the real call still declines to touch, mirroring
+#   that outcome exactly rather than folding it into `not_eligible`. No
+#   grouped, residual, or Concat-merged topology is matched here either,
+#   for the same reason the QDQ family above has none.
 # - `apply_embedding_vocab_magnitude_pruning` (embedding/lm_head vocabulary,
 #   magnitude-ranked): `_match_embedding_chain`'s own single matched-or-not
 #   embedding table, ranked by combined embedding-row/untied-lm_head-row L2
@@ -17428,11 +18060,19 @@ def _analyze_structured_wanda_pruning(
 # --- QDQ (quantized-weight) structured family -------------------------------
 
 
-def _qdq_not_eligible(graph: onnx.GraphProto, chains: List[_QDQChain]) -> List[str]:
+def _qdq_not_eligible(
+    graph: onnx.GraphProto,
+    chains: List[_QDQChain],
+    gated_chains: List[_QDQGatedChain],
+) -> List[str]:
     matched_ids: Set[int] = set()
     for chain in chains:
         matched_ids.add(id(chain.producer.node))
         matched_ids.add(id(chain.consumer.node))
+    for gchain in gated_chains:
+        matched_ids.add(id(gchain.producer_a.node))
+        matched_ids.add(id(gchain.producer_b.node))
+        matched_ids.add(id(gchain.consumer.node))
     not_eligible = []
     for node in graph.node:
         if node.op_type not in ("Conv", "MatMul", "Gemm"):
@@ -17484,15 +18124,24 @@ def _analyze_structured_pruning_qdq(
     rather than a `not_eligible` entry (the chain WAS matched; it just
     can't be safely cut at this exact `sparsity`).
 
-    No general grouped/depthwise Conv, gated pair, residual/skip-
-    connection merge, or Concat-merged branch group is ever matched here
-    at all (see :func:`apply_structured_pruning_qdq`'s own docstring) --
-    such a node simply never enters `_find_qdq_chains`'s own return value
-    in the first place, so it is reported via `not_eligible` exactly like
-    any other unmatched Conv/MatMul/Gemm node, with no QDQ-specific label
-    of its own distinguishing *why* it was declined (the real function
-    itself gives none either -- these topologies are out of scope, not
-    individually diagnosed).
+    Also mirrors the real call's own gated (SwiGLU/GeGLU) pair support
+    (:func:`_find_qdq_gated_chains`, `family="qdq_matmul_gated"`) -- same
+    touched-role/keep-count/block-alignment treatment as an ordinary QDQ
+    chain above, just against the combined (root-sum-square, or plain sum
+    for L1) importance of both producers
+    (:func:`_qdq_gated_channel_importance`), and reported as one row per
+    gated pair (`label` joining both producers' own labels, mirroring
+    :func:`_chain_label`'s own plain-float convention).
+
+    No general grouped/depthwise Conv, residual/skip-connection merge, or
+    Concat-merged branch group is ever matched here at all (see
+    :func:`apply_structured_pruning_qdq`'s own docstring) -- such a node
+    simply never enters `_find_qdq_chains`'s/`_find_qdq_gated_chains`'s own
+    return value in the first place, so it is reported via `not_eligible`
+    exactly like any other unmatched Conv/MatMul/Gemm node, with no
+    QDQ-specific label of its own distinguishing *why* it was declined (the
+    real function itself gives none either -- these topologies are out of
+    scope, not individually diagnosed).
     """
     if not (0.0 <= sparsity < 1.0):
         raise ValueError(f"sparsity must be in [0, 1), got {sparsity}")
@@ -17502,8 +18151,9 @@ def _analyze_structured_pruning_qdq(
     graph = model.graph
 
     chains = _find_qdq_chains(graph)
-    not_eligible = _qdq_not_eligible(graph, chains)
-    if not chains:
+    gated_chains = _find_qdq_gated_chains(graph)
+    not_eligible = _qdq_not_eligible(graph, chains, gated_chains)
+    if not chains and not gated_chains:
         return PruningSensitivityReport(layers=[], not_eligible=not_eligible)
 
     producer_touched: Set[str] = set()
@@ -17597,6 +18247,98 @@ def _analyze_structured_pruning_qdq(
         producer_touched.add(p_key)
         consumer_touched.add(c_key)
 
+    for gchain in gated_chains:
+        pa, pb, c = gchain.producer_a, gchain.producer_b, gchain.consumer
+        pa_key = _weight_ref_key(pa.ref)
+        pb_key = _weight_ref_key(pb.ref)
+        c_key = _weight_ref_key(c.ref)
+        if pa_key == pb_key or pa_key == c_key or pb_key == c_key:
+            continue  # degenerate (a weight tied across two roles) -- no report row
+
+        label = f"{_node_label(pa.node)} + {_node_label(pb.node)}"
+        family = "qdq_matmul_gated"
+        n = gchain.n_channels
+
+        if (
+            pa_key in producer_touched
+            or pb_key in producer_touched
+            or c_key in consumer_touched
+        ):
+            layers.append(
+                PruningLayerSensitivity(
+                    label=label,
+                    family=family,
+                    total=n,
+                    would_drop=0,
+                    margin=None,
+                    importance_min=0.0,
+                    importance_max=0.0,
+                )
+            )
+            continue  # a shared/tied weight another chain already claimed
+
+        keep_count = max(1, n - round(n * sparsity))
+        if keep_count >= n:
+            layers.append(
+                PruningLayerSensitivity(
+                    label=label,
+                    family=family,
+                    total=n,
+                    would_drop=0,
+                    margin=None,
+                    importance_min=0.0,
+                    importance_max=0.0,
+                )
+            )
+            continue  # rounds down to nothing for this chain -- no-op
+
+        w_a_nk = _weight_to_nk(
+            _weight_ref_dequantized(pa.ref), pa.weight_transposed, False
+        )
+        w_b_nk = _weight_to_nk(
+            _weight_ref_dequantized(pb.ref), pb.weight_transposed, False
+        )
+        importance = _qdq_gated_channel_importance(w_a_nk, w_b_nk, importance_norm)
+        keep = np.sort(np.argsort(-importance, kind="stable")[:keep_count])
+
+        if c.ref.qdq_block is not None:
+            keep_blocks = _qdq_block_aligned_keep_blocks(
+                keep, n, c.ref.qdq_block.block_size
+            )
+            if keep_blocks is None:
+                layers.append(
+                    PruningLayerSensitivity(
+                        label=label,
+                        family=family,
+                        total=n,
+                        would_drop=0,
+                        margin=None,
+                        importance_min=0.0,
+                        importance_max=0.0,
+                    )
+                )
+                continue  # non-block-aligned keep set -- real call declines
+                # this whole gated group too, see this function's own docstring
+
+        keep_mask = np.zeros(n, dtype=bool)
+        keep_mask[keep] = True
+
+        layers.append(
+            PruningLayerSensitivity(
+                label=label,
+                family=family,
+                total=n,
+                would_drop=int(n - keep_count),
+                margin=_normalized_margin(importance, keep_mask),
+                importance_min=float(importance.min()),
+                importance_max=float(importance.max()),
+            )
+        )
+
+        producer_touched.add(pa_key)
+        producer_touched.add(pb_key)
+        consumer_touched.add(c_key)
+
     return PruningSensitivityReport(layers=layers, not_eligible=not_eligible)
 
 
@@ -17604,12 +18346,18 @@ def _analyze_structured_pruning_qdq(
 
 
 def _matmul_nbits_not_eligible(
-    graph: onnx.GraphProto, chains: List[_MatMulNBitsChain]
+    graph: onnx.GraphProto,
+    chains: List[_MatMulNBitsChain],
+    gated_chains: List[_MatMulNBitsGatedChain],
 ) -> List[str]:
     matched_ids: Set[int] = set()
     for chain in chains:
         matched_ids.add(id(chain.producer.node))
         matched_ids.add(id(chain.consumer.node))
+    for gchain in gated_chains:
+        matched_ids.add(id(gchain.producer_a.node))
+        matched_ids.add(id(gchain.producer_b.node))
+        matched_ids.add(id(gchain.consumer.node))
     not_eligible = []
     for node in graph.node:
         if node.op_type != "MatMulNBits" or node.domain != "com.microsoft":
@@ -17665,12 +18413,22 @@ def _analyze_structured_pruning_matmul_nbits(
     and consumer role gets no report row at all (mirroring
     :func:`_analyze_structured_pruning_qdq`'s own identical treatment).
 
-    No grouped/depthwise structure, gated pair, residual/skip-connection
-    merge, or Concat-merged branch group is ever matched here at all (see
+    Also mirrors the real call's own gated (SwiGLU/GeGLU) pair support
+    (:func:`_find_matmul_nbits_gated_chains`, `family="matmul_nbits_gated"`)
+    -- same touched-role/keep-count/block-alignment treatment as an
+    ordinary chain above, just against the combined (root-sum-square, or
+    plain sum for L1) importance of both producers
+    (:func:`_matmul_nbits_gated_channel_importance`), and reported as one
+    row per gated pair (`label` joining both producers' own labels,
+    mirroring :func:`_chain_label`'s own plain-float convention).
+
+    No general grouped/depthwise structure, residual/skip-connection merge,
+    or Concat-merged branch group is ever matched here at all (see
     :func:`apply_structured_pruning_matmul_nbits`'s own docstring) -- such a
-    node simply never enters :func:`_find_matmul_nbits_chains`'s own return
-    value in the first place, so it is reported via `not_eligible` exactly
-    like any other unmatched ``MatMulNBits`` node.
+    node simply never enters :func:`_find_matmul_nbits_chains`'s/
+    :func:`_find_matmul_nbits_gated_chains`'s own return value in the first
+    place, so it is reported via `not_eligible` exactly like any other
+    unmatched ``MatMulNBits`` node.
     """
     if not (0.0 <= sparsity < 1.0):
         raise ValueError(f"sparsity must be in [0, 1), got {sparsity}")
@@ -17680,8 +18438,9 @@ def _analyze_structured_pruning_matmul_nbits(
     graph = model.graph
 
     chains = _find_matmul_nbits_chains(graph)
-    not_eligible = _matmul_nbits_not_eligible(graph, chains)
-    if not chains:
+    gated_chains = _find_matmul_nbits_gated_chains(graph)
+    not_eligible = _matmul_nbits_not_eligible(graph, chains, gated_chains)
+    if not chains and not gated_chains:
         return PruningSensitivityReport(layers=[], not_eligible=not_eligible)
 
     producer_touched: Set[str] = set()
@@ -17776,6 +18535,99 @@ def _analyze_structured_pruning_matmul_nbits(
         )
 
         producer_touched.add(p_key)
+        consumer_touched.add(c_key)
+
+    for gchain in gated_chains:
+        pa, pb, c = gchain.producer_a, gchain.producer_b, gchain.consumer
+        pa_key = _matmul_nbits_chain_side_key(pa)
+        pb_key = _matmul_nbits_chain_side_key(pb)
+        c_key = _matmul_nbits_chain_side_key(c)
+        if pa_key == pb_key or pa_key == c_key or pb_key == c_key:
+            continue  # degenerate (a weight tied across two roles) -- no report row
+
+        label = f"{_node_label(pa.node)} + {_node_label(pb.node)}"
+        family = "matmul_nbits_gated"
+        n = gchain.n_channels
+
+        if (
+            pa_key in producer_touched
+            or pb_key in producer_touched
+            or c_key in consumer_touched
+        ):
+            layers.append(
+                PruningLayerSensitivity(
+                    label=label,
+                    family=family,
+                    total=n,
+                    would_drop=0,
+                    margin=None,
+                    importance_min=0.0,
+                    importance_max=0.0,
+                )
+            )
+            continue  # a shared/tied weight another chain already claimed
+
+        keep_count = max(1, n - round(n * sparsity))
+        if keep_count >= n:
+            layers.append(
+                PruningLayerSensitivity(
+                    label=label,
+                    family=family,
+                    total=n,
+                    would_drop=0,
+                    margin=None,
+                    importance_min=0.0,
+                    importance_max=0.0,
+                )
+            )
+            continue  # rounds down to nothing for this chain -- no-op
+
+        w_a_nk = _matmul_nbits_chain_producer_weight_nk(pa)
+        w_b_nk = _matmul_nbits_chain_producer_weight_nk(pb)
+        importance = _matmul_nbits_gated_channel_importance(
+            w_a_nk, w_b_nk, importance_norm
+        )
+        keep = np.sort(np.argsort(-importance, kind="stable")[:keep_count])
+
+        if isinstance(c, _MatMulNBitsWeight):
+            keep_blocks = _matmul_nbits_block_aligned_keep_blocks(
+                keep, c.k_blocks, c.block_size
+            )
+            if keep_blocks is None:
+                layers.append(
+                    PruningLayerSensitivity(
+                        label=label,
+                        family=family,
+                        total=n,
+                        would_drop=0,
+                        margin=None,
+                        importance_min=0.0,
+                        importance_max=0.0,
+                    )
+                )
+                continue  # non-block-aligned keep-set for this consumer --
+                # the real call declines this whole gated group too, see
+                # this function's own docstring
+        # else: a plain-float consumer has no block structure -- the real
+        # call applies any keep-set directly.
+
+        keep_mask = np.zeros(n, dtype=bool)
+        keep_mask[keep] = True
+
+        layers.append(
+            PruningLayerSensitivity(
+                label=label,
+                family=family,
+                total=n,
+                would_drop=int(n - keep_count),
+                margin=_normalized_margin(importance, keep_mask),
+                importance_min=float(importance.min()),
+                importance_max=float(importance.max()),
+            )
+        )
+
+        producer_touched.add(pa_key)
+        producer_touched.add(pb_key)
         consumer_touched.add(c_key)
 
     return PruningSensitivityReport(layers=layers, not_eligible=not_eligible)

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -21038,6 +21038,286 @@ def test_analyze_structured_pruning_qdq_blockwise_matches_real_call():
     assert layer2.margin is None
 
 
+# --- apply_structured_pruning_qdq: gated (SwiGLU/GeGLU) pair -----------------
+#
+# The QDQ analogue of the plain-float gated-FFN tests above
+# (``_swiglu_mlp_model``/``_combined_keep_indices``) -- see
+# ``onnxsim/pruning.py``'s own ``_find_qdq_gated_chains``/
+# ``_qdq_gated_channel_importance`` docstrings. ``_combined_keep_indices`` is
+# reused unchanged for the importance oracle (its own ``w.T`` convention
+# matches a QDQ weight's *dequantized* array exactly, since dequantization
+# doesn't change orientation).
+
+
+def _qdq_gated_mlp_model(K=8, H=16, Out=4, gate_activation="Sigmoid", seed=0):
+    # gate_proj/up_proj: per-channel INT8 QDQ MatMul producers sharing input
+    # X; down_proj: plain float MatMul consumer -- at least one QDQ side, as
+    # apply_structured_pruning_qdq's own docstring requires.
+    rng = np.random.default_rng(seed)
+    Wgq = rng.integers(-100, 100, size=(K, H)).astype(np.int8)
+    Wgscale = np.abs(rng.standard_normal(H)).astype(np.float32) * 0.02 + 0.001
+    Wuq = rng.integers(-100, 100, size=(K, H)).astype(np.int8)
+    Wuscale = np.abs(rng.standard_normal(H)).astype(np.float32) * 0.02 + 0.001
+    Wd = rng.standard_normal((H, Out)).astype(np.float32)
+    initializer = [
+        _i8(Wgq, "Wgq"),
+        _f32(Wgscale, "Wgscale"),
+        _i8(Wuq, "Wuq"),
+        _f32(Wuscale, "Wuscale"),
+        _f32(Wd, "Wd"),
+    ]
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          Wgdq = DequantizeLinear<axis=1>(Wgq, Wgscale)
+          gate = MatMul(X, Wgdq)
+          gate_act = {gate_activation}(gate)
+          Wudq = DequantizeLinear<axis=1>(Wuq, Wuscale)
+          up = MatMul(X, Wudq)
+          h = Mul(gate_act, up)
+          Y = MatMul(h, Wd)
+        }}
+        """,
+        initializer=initializer,
+    )
+    return model, Wgq, Wgscale, Wuq, Wuscale, Wd
+
+
+def test_qdq_structured_pruning_gated_ffn_matches_oracle():
+    K, H, Out = 8, 16, 4
+    model, Wgq, Wgscale, Wuq, Wuscale, Wd = _qdq_gated_mlp_model(K, H, Out, seed=21)
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_qdq(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Wgq"].dims) == [K, H // 2]
+    assert list(inits["Wgscale"].dims) == [H // 2]
+    assert list(inits["Wuq"].dims) == [K, H // 2]
+    assert list(inits["Wuscale"].dims) == [H // 2]
+    assert list(inits["Wd"].dims) == [H // 2, Out]
+
+    wg_dequant = _qdq_dequant(Wgq, Wgscale, None, axis=1)
+    wu_dequant = _qdq_dequant(Wuq, Wuscale, None, axis=1)
+    keep = _combined_keep_indices(wg_dequant, wu_dequant, H // 2)
+
+    # Exact co-slice: both producers' own int8 codes AND scales sliced by
+    # the identical `keep` set, never independently re-derived.
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Wgq"]), Wgq[:, keep]
+    )
+    np.testing.assert_allclose(
+        onnx.numpy_helper.to_array(inits["Wgscale"]), Wgscale[keep]
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Wuq"]), Wuq[:, keep]
+    )
+    np.testing.assert_allclose(
+        onnx.numpy_helper.to_array(inits["Wuscale"]), Wuscale[keep]
+    )
+
+    rng = np.random.default_rng(22)
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run_unfused(pruned, {"X": x})
+
+    gate = 1.0 / (1.0 + np.exp(-(x @ wg_dequant[:, keep])))
+    up = x @ wu_dequant[:, keep]
+    y_oracle = (gate * up) @ Wd[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_qdq_structured_pruning_gated_ffn_prunes_both_branches_to_same_channels():
+    # Mirrors test_structured_pruning_gated_ffn_prunes_both_branches_to_same_channels
+    # for the QDQ case -- the real risk is gate/up disagreeing on which
+    # channels survive, silently breaking the elementwise product's
+    # alignment.
+    K, H, Out = 8, 20, 4
+    model, Wgq, Wgscale, Wuq, Wuscale, _Wd = _qdq_gated_mlp_model(K, H, Out, seed=23)
+    pruned = onnxsim.apply_structured_pruning_qdq(model, sparsity=0.3)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+
+    wg_dequant = _qdq_dequant(Wgq, Wgscale, None, axis=1)
+    wu_dequant = _qdq_dequant(Wuq, Wuscale, None, axis=1)
+    keep = _combined_keep_indices(wg_dequant, wu_dequant, H - round(H * 0.3))
+
+    np.testing.assert_array_equal(inits["Wgq"], Wgq[:, keep])
+    np.testing.assert_array_equal(inits["Wuq"], Wuq[:, keep])
+
+
+def test_qdq_structured_pruning_gelu_gated_ffn_matches_oracle():
+    # GeGLU: the gate activation is Gelu (tanh approximation) rather than
+    # Sigmoid -- exercises _find_qdq_gated_chains's own reuse of the plain-
+    # float gated matcher's unary-activation set (_UNARY_PASS_THROUGH),
+    # mirroring test_structured_pruning_gelu_gated_ffn_matches_oracle.
+    K, H, Out = 8, 16, 4
+    rng = np.random.default_rng(24)
+    Wgq = rng.integers(-100, 100, size=(K, H)).astype(np.int8)
+    Wgscale = np.abs(rng.standard_normal(H)).astype(np.float32) * 0.02 + 0.001
+    Wuq = rng.integers(-100, 100, size=(K, H)).astype(np.int8)
+    Wuscale = np.abs(rng.standard_normal(H)).astype(np.float32) * 0.02 + 0.001
+    Wd = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          Wgdq = DequantizeLinear<axis=1>(Wgq, Wgscale)
+          gate = MatMul(X, Wgdq)
+          gate_act = Gelu<approximate = "tanh">(gate)
+          Wudq = DequantizeLinear<axis=1>(Wuq, Wuscale)
+          up = MatMul(X, Wudq)
+          h = Mul(gate_act, up)
+          Y = MatMul(h, Wd)
+        }}
+        """,
+        initializer=[
+            _i8(Wgq, "Wgq"),
+            _f32(Wgscale, "Wgscale"),
+            _i8(Wuq, "Wuq"),
+            _f32(Wuscale, "Wuscale"),
+            _f32(Wd, "Wd"),
+        ],
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_qdq(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    wg_dequant = _qdq_dequant(Wgq, Wgscale, None, axis=1)
+    wu_dequant = _qdq_dequant(Wuq, Wuscale, None, axis=1)
+    keep = _combined_keep_indices(wg_dequant, wu_dequant, H // 2)
+
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run_unfused(pruned, {"X": x})
+
+    g = x @ wg_dequant[:, keep]
+    gate = 0.5 * g * (1.0 + np.tanh(np.sqrt(2.0 / np.pi) * (g + 0.044715 * g**3)))
+    up = x @ wu_dequant[:, keep]
+    y_oracle = (gate * up) @ Wd[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def _qdq_gated_blockwise_down_model(K, H, Out, block_size, wg, wu, seed=0):
+    # gate_proj/up_proj: plain float MatMul producers; down_proj: blockwise
+    # INT4 QDQ MatMul consumer (axis=0 block-quantized on H, down_proj's own
+    # reduction axis) -- exercises this gated path's own block-alignment
+    # check on the CONSUMER side (mirrors
+    # _matmul_qdq_blockwise_consumer_model, extended to a gated pair).
+    rng = np.random.default_rng(seed)
+    h_blocks = H // block_size
+    Wdq = rng.integers(-8, 8, size=(H, Out)).astype(np.int8)
+    Wdscale = (
+        np.abs(rng.standard_normal((h_blocks, Out))).astype(np.float32) * 0.02 + 0.001
+    )
+    initializer = [
+        _f32(wg, "Wg"),
+        _f32(wu, "Wu"),
+        _int4(Wdq, "Wdq"),
+        _f32(Wdscale, "Wdscale"),
+    ]
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          gate = MatMul(X, Wg)
+          gate_act = Sigmoid(gate)
+          up = MatMul(X, Wu)
+          h = Mul(gate_act, up)
+          Wddq = DequantizeLinear<axis=0, block_size={block_size}>(Wdq, Wdscale)
+          Y = MatMul(h, Wddq)
+        }}
+        """,
+        initializer=initializer,
+    )
+    return model, Wdq, Wdscale
+
+
+def test_qdq_structured_pruning_gated_ffn_blockwise_consumer_block_aligned_matches_oracle():
+    K, H, Out, block_size = 4, 16, 4, 4
+    n_blocks = H // block_size
+    rng = np.random.default_rng(107)
+    # Both gate and up engineered so blocks 0/2 are large-magnitude (kept)
+    # and blocks 1/3 are small (dropped) -- a deterministic, block-aligned
+    # 50% combined keep set.
+    wg = _block_grouped_column_weight(
+        rng, K, n_blocks, block_size, high_block_idx={0, 2}
+    )
+    wu = _block_grouped_column_weight(
+        rng, K, n_blocks, block_size, high_block_idx={0, 2}
+    )
+    model, Wdq, Wdscale = _qdq_gated_blockwise_down_model(
+        K, H, Out, block_size, wg, wu, seed=108
+    )
+    onnx.checker.check_model(model)
+
+    keep = _combined_keep_indices(wg, wu, H // 2)
+    keep_blocks = sorted({int(k) // block_size for k in keep})
+    assert keep_blocks == [0, 2]  # confirms the engineered data is genuinely
+    # block-aligned, not merely lucky
+
+    pruned = onnxsim.apply_structured_pruning_qdq(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Wg"].dims) == [K, H // 2]
+    assert list(inits["Wu"].dims) == [K, H // 2]
+    assert list(inits["Wdq"].dims) == [H // 2, Out]
+    assert list(inits["Wdscale"].dims) == [n_blocks // 2, Out]
+
+    wd_dequant = _qdq_block_dequant(Wdq, Wdscale, None, axis=0, block_size=block_size)
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run_unfused(pruned, {"X": x})
+
+    gate = 1.0 / (1.0 + np.exp(-(x @ wg[:, keep])))
+    up = x @ wu[:, keep]
+    y_oracle = (gate * up) @ wd_dequant[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_qdq_structured_pruning_gated_ffn_blockwise_consumer_non_block_aligned_declines():
+    # `keep_count` for a 0.625 sparsity on H=16 is 6, not a multiple of
+    # block_size=4 -- the whole gated group (both producers AND the
+    # consumer) must be left completely untouched, mirroring
+    # test_qdq_blockwise_consumer_non_block_aligned_declines's own
+    # single-producer precedent.
+    K, H, Out, block_size = 4, 16, 4, 4
+    rng = np.random.default_rng(109)
+    wg = rng.standard_normal((K, H)).astype(np.float32)
+    wu = rng.standard_normal((K, H)).astype(np.float32)
+    model, Wdq, Wdscale = _qdq_gated_blockwise_down_model(
+        K, H, Out, block_size, wg, wu, seed=110
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_qdq(model, sparsity=0.625)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Wg"].dims) == [K, H]  # untouched
+    assert list(inits["Wu"].dims) == [K, H]  # untouched
+    assert list(inits["Wdq"].dims) == [H, Out]  # untouched
+
+
+def test_analyze_structured_pruning_qdq_gated_matches_real_call():
+    K, H, Out = 8, 16, 4
+    model, *_ = _qdq_gated_mlp_model(K, H, Out, seed=25)
+
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_structured_pruning_qdq, sparsity=0.5
+    )
+    assert len(report.layers) == 1
+    layer = report.layers[0]
+    assert layer.family == "qdq_matmul_gated"
+    assert layer.total == H
+    assert report.not_eligible == []
+
+    pruned = onnxsim.apply_structured_pruning_qdq(model, sparsity=0.5)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    kept = H - layer.would_drop
+    assert inits["Wgq"].dims[1] == kept
+    assert inits["Wuq"].dims[1] == kept
+    assert inits["Wd"].dims[0] == kept
+
+
 # --- apply_structured_pruning_matmul_nbits -----------------------------------
 #
 # See ``onnxsim/pruning.py``'s own "MatMulNBits (block-quantized weight)
@@ -22520,3 +22800,249 @@ def test_matmul_nbits_pruning_invalid_sparsity_raises():
         onnxsim.apply_structured_pruning_matmul_nbits(model, sparsity=1.0)
     with pytest.raises(ValueError):
         onnxsim.apply_structured_pruning_matmul_nbits(model, sparsity=-0.1)
+
+
+# --- apply_structured_pruning_matmul_nbits: gated (SwiGLU/GeGLU) pair -------
+#
+# The MatMulNBits analogue of the plain-float gated-FFN tests
+# (``_swiglu_mlp_model``/``_combined_keep_indices``) and the QDQ gated tests
+# above -- see ``onnxsim/pruning.py``'s own ``_find_matmul_nbits_gated_chains``/
+# ``_matmul_nbits_gated_channel_importance`` docstrings. Every quantization
+# artifact is built via this file's own independent reference implementation
+# (``_nbits_quantize_block``/``_nbits_pack_B``/``_nbits_dequant``), never a
+# call into ``onnxsim.pruning``'s own private packing helpers.
+
+
+def _nbits_gated_model(K, H, Out, block_size, W_gate, W_up, W_down, bits=4):
+    # X -> gate=MatMulNBits(Bg) -[Sigmoid]-> gate_act, up=MatMulNBits(Bu) ->
+    # Mul(gate_act, up) -> down=MatMulNBits(Bd) -> Y. All three block-
+    # quantized: gate_proj/up_proj along their own K=`K` axis (unrelated to
+    # the shared gated channel count H), down_proj along its own K=`H` axis
+    # -- the axis this section's own block-alignment check cares about.
+    assert K % block_size == 0
+    assert H % block_size == 0
+    qcodes_g, scales_g, zp_g, kbg = _nbits_quantize_block(W_gate, block_size, bits)
+    qcodes_u, scales_u, zp_u, kbu = _nbits_quantize_block(W_up, block_size, bits)
+    qcodes_d, scales_d, zp_d, kbd = _nbits_quantize_block(W_down, block_size, bits)
+    Bg = _nbits_pack_B(qcodes_g, H, kbg, block_size, bits)
+    Bu = _nbits_pack_B(qcodes_u, H, kbu, block_size, bits)
+    Bd = _nbits_pack_B(qcodes_d, Out, kbd, block_size, bits)
+
+    initializer = [
+        onnx.numpy_helper.from_array(Bg, name="Bg"),
+        onnx.numpy_helper.from_array(scales_g, name="scales_g"),
+        onnx.numpy_helper.from_array(_nbits_pack_codes(zp_g, bits), name="zp_g"),
+        onnx.numpy_helper.from_array(Bu, name="Bu"),
+        onnx.numpy_helper.from_array(scales_u, name="scales_u"),
+        onnx.numpy_helper.from_array(_nbits_pack_codes(zp_u, bits), name="zp_u"),
+        onnx.numpy_helper.from_array(Bd, name="Bd"),
+        onnx.numpy_helper.from_array(scales_d, name="scales_d"),
+        onnx.numpy_helper.from_array(_nbits_pack_codes(zp_d, bits), name="zp_d"),
+    ]
+
+    node_g = _nbits_node(
+        "mm_g", "X", "gate", "Bg", "scales_g", "zp_g", None, H, K, block_size, bits
+    )
+    act = onnx.helper.make_node("Sigmoid", ["gate"], ["gate_act"])
+    node_u = _nbits_node(
+        "mm_u", "X", "up", "Bu", "scales_u", "zp_u", None, H, K, block_size, bits
+    )
+    mul = onnx.helper.make_node("Mul", ["gate_act", "up"], ["h"])
+    node_d = _nbits_node(
+        "mm_d", "h", "Y", "Bd", "scales_d", "zp_d", None, Out, H, block_size, bits
+    )
+
+    M = 3
+    graph = onnx.helper.make_graph(
+        [node_g, act, node_u, mul, node_d],
+        "g",
+        inputs=[
+            onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, [M, K])
+        ],
+        outputs=[
+            onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [M, Out])
+        ],
+        initializer=initializer,
+    )
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 21),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    model.ir_version = 10
+    return model, dict(
+        qcodes_g=qcodes_g,
+        scales_g=scales_g,
+        zp_g=zp_g,
+        kbg=kbg,
+        qcodes_u=qcodes_u,
+        scales_u=scales_u,
+        zp_u=zp_u,
+        kbu=kbu,
+        qcodes_d=qcodes_d,
+        scales_d=scales_d,
+        zp_d=zp_d,
+        kbd=kbd,
+    )
+
+
+def test_matmul_nbits_pruning_gated_ffn_matches_oracle():
+    # H=32 output channels (gate/up), block_size=16 -> down_proj's own
+    # K2=H=32 axis is exactly 2 blocks. Both W_gate/W_up engineered so the
+    # combined L2-norm importance keeps EXACTLY rows 0-15 (block 0) and
+    # drops 16-31 (block 1) -- a real keep-set the pass has to derive on its
+    # own, that also happens to land on a whole-block boundary.
+    K, H, Out, block_size, bits = 16, 32, 4, 16, 4
+    rng = np.random.default_rng(200)
+    W_gate = (rng.standard_normal((H, K)) * 0.2).astype(np.float32)
+    W_gate[:16] *= 6.0
+    W_up = (rng.standard_normal((H, K)) * 0.2).astype(np.float32)
+    W_up[:16] *= 6.0
+    W_down = (rng.standard_normal((Out, H)) * 0.2).astype(np.float32)
+
+    model, info = _nbits_gated_model(K, H, Out, block_size, W_gate, W_up, W_down, bits)
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_matmul_nbits(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep = np.arange(16)  # expected keep-set: rows 0-15 (block 0)
+    keep_blocks = np.array([0])
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Bg"].dims) == [16, info["kbg"], block_size * bits // 8]
+    assert list(inits["scales_g"].dims) == [16, info["kbg"]]
+    assert list(inits["Bu"].dims) == [16, info["kbu"], block_size * bits // 8]
+    assert list(inits["Bd"].dims) == [Out, 1, block_size * bits // 8]
+    assert list(inits["scales_d"].dims) == [Out, 1]
+    mm_g = next(n for n in pruned.graph.node if n.name == "mm_g")
+    mm_u = next(n for n in pruned.graph.node if n.name == "mm_u")
+    mm_d = next(n for n in pruned.graph.node if n.name == "mm_d")
+    assert next(a.i for a in mm_g.attribute if a.name == "N") == 16
+    assert next(a.i for a in mm_u.attribute if a.name == "N") == 16
+    assert next(a.i for a in mm_d.attribute if a.name == "K") == 16
+
+    # Exact (byte-level) "slice, don't recompute" checks -- the pruned
+    # graph's own tensors must equal a HAND-SLICE of the ORIGINAL quantized
+    # codes, never a re-quantization of the sliced float weight.
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Bg"]),
+        _nbits_pack_B(info["qcodes_g"][keep], 16, info["kbg"], block_size, bits),
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Bu"]),
+        _nbits_pack_B(info["qcodes_u"][keep], 16, info["kbu"], block_size, bits),
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Bd"]),
+        _nbits_pack_B(info["qcodes_d"][:, keep], Out, 1, block_size, bits),
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["zp_d"]),
+        _nbits_pack_codes(info["zp_d"][:, keep_blocks], bits),
+    )
+
+    # A pure-float64 dequantize-then-matmul oracle built directly from the
+    # pass's own (unmodified) quantized codes, sliced by hand -- the
+    # tightest oracle, at float rounding error only.
+    wg_dequant = _nbits_dequant(
+        info["qcodes_g"], info["scales_g"], info["zp_g"], block_size, bits
+    )
+    wu_dequant = _nbits_dequant(
+        info["qcodes_u"], info["scales_u"], info["zp_u"], block_size, bits
+    )
+    wd_dequant = _nbits_dequant(
+        info["qcodes_d"], info["scales_d"], info["zp_d"], block_size, bits
+    )
+
+    x = rng.standard_normal((3, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+
+    gate_lin = x.astype(np.float64) @ wg_dequant[keep].T
+    gate = 1.0 / (1.0 + np.exp(-gate_lin))
+    up_lin = x.astype(np.float64) @ wu_dequant[keep].T
+    h = gate * up_lin
+    y_oracle = h @ wd_dequant[:, keep].T
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-3, atol=1e-3)
+
+
+def test_matmul_nbits_pruning_gated_ffn_non_block_aligned_declines():
+    # keep_count for a 0.4 sparsity on H=32 is 20 (round(32*0.6)), not a
+    # multiple of block_size=16 -- the whole gated group (both producers
+    # AND the consumer) must be left completely untouched, mirroring
+    # test_matmul_nbits_pruning_consumer_declines_non_block_aligned's own
+    # single-producer precedent.
+    K, H, Out, block_size, bits = 16, 32, 4, 16, 4
+    rng = np.random.default_rng(201)
+    W_gate = (rng.standard_normal((H, K)) * 0.2).astype(np.float32)
+    W_up = (rng.standard_normal((H, K)) * 0.2).astype(np.float32)
+    W_down = (rng.standard_normal((Out, H)) * 0.2).astype(np.float32)
+
+    model, info = _nbits_gated_model(K, H, Out, block_size, W_gate, W_up, W_down, bits)
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_matmul_nbits(model, sparsity=0.4)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    # Untouched: N/K unchanged on every one of the three nodes.
+    assert list(inits["Bg"].dims) == [H, info["kbg"], block_size * bits // 8]
+    assert list(inits["Bu"].dims) == [H, info["kbu"], block_size * bits // 8]
+    assert list(inits["Bd"].dims) == [Out, info["kbd"], block_size * bits // 8]
+    mm_g = next(n for n in pruned.graph.node if n.name == "mm_g")
+    mm_d = next(n for n in pruned.graph.node if n.name == "mm_d")
+    assert next(a.i for a in mm_g.attribute if a.name == "N") == H
+    assert next(a.i for a in mm_d.attribute if a.name == "K") == H
+
+
+def test_analyze_structured_pruning_matmul_nbits_gated_matches_real_call():
+    K, H, Out, block_size, bits = 16, 32, 4, 16, 4
+    rng = np.random.default_rng(202)
+    W_gate = (rng.standard_normal((H, K)) * 0.2).astype(np.float32)
+    W_gate[:16] *= 6.0
+    W_up = (rng.standard_normal((H, K)) * 0.2).astype(np.float32)
+    W_up[:16] *= 6.0
+    W_down = (rng.standard_normal((Out, H)) * 0.2).astype(np.float32)
+    model, _info = _nbits_gated_model(K, H, Out, block_size, W_gate, W_up, W_down, bits)
+
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_structured_pruning_matmul_nbits, sparsity=0.5
+    )
+    assert len(report.layers) == 1
+    layer = report.layers[0]
+    assert layer.family == "matmul_nbits_gated"
+    assert layer.total == H
+    assert report.not_eligible == []
+
+    pruned = onnxsim.apply_structured_pruning_matmul_nbits(model, sparsity=0.5)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    kept = H - layer.would_drop
+    mm_g = next(n for n in pruned.graph.node if n.name == "mm_g")
+    assert next(a.i for a in mm_g.attribute if a.name == "N") == kept
+    assert inits["Bd"].dims[1] == kept // block_size
+
+
+def test_analyze_structured_pruning_matmul_nbits_gated_non_block_aligned_matches_real_decline():
+    # Dry-run/real-call cross-check for the non-block-aligned decline case
+    # -- mirrors test_analyze_structured_pruning_qdq_blockwise_matches_real_call's
+    # own aligned/non-aligned pairing, for the gated MatMulNBits family.
+    K, H, Out, block_size, bits = 16, 32, 4, 16, 4
+    rng = np.random.default_rng(203)
+    W_gate = (rng.standard_normal((H, K)) * 0.2).astype(np.float32)
+    W_up = (rng.standard_normal((H, K)) * 0.2).astype(np.float32)
+    W_down = (rng.standard_normal((Out, H)) * 0.2).astype(np.float32)
+    model, _info = _nbits_gated_model(K, H, Out, block_size, W_gate, W_up, W_down, bits)
+
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_structured_pruning_matmul_nbits, sparsity=0.4
+    )
+    pruned = onnxsim.apply_structured_pruning_matmul_nbits(model, sparsity=0.4)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert len(report.layers) == 1
+    layer = report.layers[0]
+    assert layer.family == "matmul_nbits_gated"
+    real_would_drop = H - onnx.numpy_helper.to_array(inits["Bg"]).shape[0]
+    assert layer.would_drop == real_would_drop == 0
+    assert layer.margin is None


### PR DESCRIPTION
## Summary

`apply_structured_pruning`/`apply_structured_wanda_pruning` already prune gated (SwiGLU/GeGLU) `gate_proj`/`up_proj`/`down_proj` triples — the FFN shape of essentially every current open LLM (Llama, Mistral, Qwen, Gemma, Phi) — but only for plain-float weights. Both quantized structured-pruning passes (`apply_structured_pruning_qdq`, `apply_structured_pruning_matmul_nbits`) explicitly declined this topology. Quantized (QDQ int8/blockwise-int4, or MatMulNBits int4/int8) exports of this exact triple — the standard way modern LLMs ship as ONNX for CPU/edge inference (ONNX Runtime GenAI Model Builder, Olive, Hugging Face Optimum) — were therefore entirely unprunable via the gated-pair path.

## What's added

Both `apply_structured_pruning_qdq` and `apply_structured_pruning_matmul_nbits` now recognize and prune a gated pair — `gate_proj`/`up_proj` sharing one input, combined via elementwise `Mul` (gate_proj optionally through an activation first) or the native fused `SwiGLU` op, feeding one `down_proj` consumer — where any one or more of the three is quantized (a plain float/float/float triple stays `apply_structured_pruning`'s own job).

- New matchers `_find_qdq_gated_chains`/`_find_matmul_nbits_gated_chains`, each mirroring the existing plain-float `_find_gated_chains` topology exactly, with backward-walk helpers (`_trace_gate_producer_backward_qdq`/`_matmul_nbits`) resolving each producer through `_resolve_weight_ref`/plain-vs-quantized `MatMulNBits` matching instead of a plain-float-only match.
- Both producers are co-sliced to the *same* keep-set (combined L1/L2 importance across both, mirroring `_plain_structured_importance`'s own gated-pair identity), reusing each section's existing single-producer slicing helpers — no new slicing code.
- `down_proj` is sliced via the existing single-consumer helpers, including the MatMulNBits/QDQ-blockwise block-alignment check: the whole gated group is declined untouched (not partially pruned) when the keep-set doesn't land on whole blocks — the same safety guarantee the single-producer path already has.
- `_analyze_structured_pruning_qdq`/`_analyze_structured_pruning_matmul_nbits` (the dry-run sensitivity mirrors) updated in lockstep with new `"qdq_matmul_gated"`/`"matmul_nbits_gated"` report families.

Docstrings/section comments on both functions updated to state gated pairs are now supported, while grouped/depthwise Conv, residual/skip-connection merge, and Concat-merged branch groups remain explicitly out of scope, unchanged.

## Test plan
- [x] `pytest tests/test_pruning.py -q` — 491 passed (was 481 before this change)
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — 0 new errors vs. master's baseline
- [x] QDQ gated-FFN correctness (real `InferenceSession`, unfused to avoid ORT's own QDQ-fusion accumulation-order change, vs. an independently hand-sliced dequantized-weight numpy oracle) — `rtol=atol=1e-4`
- [x] MatMulNBits gated-FFN correctness (same rigor) — `rtol=atol=1e-3` (int4 rounding only, since existing codes are sliced, never re-quantized)
- [x] Mixed-activation (GeGLU) variant, blockwise-consumer block-aligned and non-block-aligned decline for both families
- [x] Dry-run-vs-real-call cross-check tests for both families, including the non-block-aligned decline case

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_