### PR TITLE
Attention-head pruning: support com.microsoft::MultiHeadAttention

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -10367,10 +10367,18 @@ def apply_structured_pruning_matmul_nbits(
 
 # --- Attention-head pruning -----------------------------------------------
 
-# Three fused self-attention ops are matched here -- two from the
-# ``com.microsoft`` domain, produced by onnxsim's own fusion passes from a
-# decomposed self-attention block, plus the standard ``ai.onnx`` op -- each
-# pruned at the granularity its own kernel contract allows:
+# Four fused self-/cross-attention ops are matched here -- three from the
+# ``com.microsoft`` domain (two produced by onnxsim's own fusion passes from a
+# decomposed self-attention block, plus `MultiHeadAttention`, which onnxsim's
+# own fusion passes deliberately never emit -- see `fuse_gqa.h`'s own comment
+# on why -- but which ONNX Runtime's *own* transformer graph optimizer
+# (`onnxruntime.transformers.fusion_attention.AttentionFusion
+# .create_multihead_attention_node`/`.create_attention_node`, installed in
+# this environment at `onnxruntime/transformers/fusion_attention.py`) emits
+# routinely for BERT/ViT/CLIP/T5/Whisper-style encoder and cross-attention
+# exports -- a real, common op this module was previously unable to prune at
+# all), plus the standard ``ai.onnx`` op -- each pruned at the granularity
+# its own kernel contract allows:
 #
 # - `Attention` (onnxsim/passes/fuse_attention.h): a single merged QKV
 #   weight/bias ([hidden_size, Nq+Nk+Nv] / [Nq+Nk+Nv]) plus
@@ -10522,10 +10530,87 @@ def apply_structured_pruning_matmul_nbits(
 #   ai.onnx Attention" section), the same oracle-vs-onnxruntime bar every
 #   other function in this module is held to; no structural-only fallback
 #   was needed.
+# - `com.microsoft::MultiHeadAttention` (schema confirmed live via
+#   ``onnxruntime.capi.onnxruntime_pybind11_state.get_all_operator_schema()``
+#   against this environment's installed onnxruntime 1.29.0): unlike
+#   `com.microsoft::Attention` above, this op does **not** own any
+#   projection weight at all -- its `query`/`key`/`value` inputs (indices
+#   0/1/2) are already-projected, rank-3 ``[batch, seq, hidden]`` activation
+#   tensors, exactly `GroupQueryAttention`'s own calling convention (the
+#   schema's alternate "packed QKV" input shape for `query` alone, rank 5,
+#   is excluded the same way `_match_gqa_producer` excludes
+#   `GroupQueryAttention`'s own packed convention -- by requiring `key`/
+#   `value` both non-empty). So this op reuses
+#   :func:`_find_separate_qkv_chains` outright, via a fourth matcher,
+#   :func:`_match_multi_head_attention_producer` -- Q's/K's/V's own MatMul/
+#   vanilla-Gemm producer weights (matched by the same
+#   :func:`_match_producer` every other separate-Q/K/V op here uses) are
+#   what gets pruned, never a weight owned by the `MultiHeadAttention` node
+#   itself. Confirmed against ONNX Runtime's *own* transformer fusion code
+#   (`onnxruntime.transformers.fusion_attention.AttentionFusion
+#   .create_multihead_attention_node`, the real code path Hugging Face
+#   Optimum's ORT model optimizer runs for BERT/ViT/CLIP/T5/Whisper-style
+#   models), the realistic export shape feeds Q/K/V into this op straight
+#   from their own MatMul's raw output -- **no** `Add` bias hop in between
+#   (unlike every other op matched in this section) -- and instead folds
+#   Q's/K's/V's three separate biases into *one* combined tensor
+#   (``concatenate([q_bias, k_bias, v_bias])``, exactly
+#   `create_combined_qkv_bias`'s own construction) passed as this op's own
+#   `bias` input (index 3); a model built by hand with per-producer
+#   `Gemm`-with-bias projections feeding this op directly instead is *also*
+#   matched (`_match_producer` already handles a Gemm's own bias
+#   independently of this combined one) -- the two are not mutually
+#   exclusive and both are sliced when both are present. This combined bias
+#   is genuinely new shape this module had no infrastructure for -- neither
+#   one merged *weight+bias* (`_AttentionChain`'s own shape) nor three
+#   independent per-producer biases (every other `_GQAChain`-shaped op's own
+#   shape) -- so :class:`_GQAChain` gained one new field, `mha_bias`, and
+#   :func:`_find_separate_qkv_chains` gained a `combined_bias_input_index`
+#   parameter: when the node input at that index is a non-empty constant, it
+#   is validated to be exactly `[nq + nk + nv]`-shaped (declined, the whole
+#   chain, otherwise -- a non-constant or wrong-shaped combined bias can't be
+#   safely left half-updated) and recorded; :func:`_apply_one_gqa_chain`
+#   slices it in three head-aligned ranges (Q's own kept-head columns, then
+#   K's shifted by the pre-pruning `nq`, then V's shifted by the pre-pruning
+#   `nq + nk`) in the same single combined-index-set style
+#   `chain.packed_split_sizes`'s own packed-bias branch already uses for a
+#   different (packed-*weight*) shape. This op's own `num_heads` attribute
+#   (no separate `kv_num_heads` -- confirmed by the schema dump above having
+#   only one head-count attribute at all, and independently by
+#   `fuse_gqa.h`'s own comment that `MultiHeadAttention` "rejects mismatched
+#   hidden sizes" -- i.e. no GQA/MQA support) means every "KV group" this
+#   pass's shared `_GQAChain`/:func:`_apply_one_gqa_chain` machinery forms is
+#   exactly one query head wide (`group_size == num_heads // kv_num_heads ==
+#   1` always) -- individual per-head pruning, the same granularity plain
+#   `com.microsoft::Attention` gets, arrived at for free by feeding
+#   `num_heads` as both `num_heads` and `kv_num_heads` to the shared
+#   machinery, with no group-vs-head distinction to add. This op's own
+#   `attention_bias` (index 5, same broadcastable-or-per-head shape/
+#   treatment as `GroupQueryAttention`'s own, via the same
+#   :func:`_head_bias_axis`) and `past_key`/`past_value` (indices 6/7, the
+#   same BNSH float layout as every other op here, via the same
+#   :func:`_past_kv_constants_are_sliceable`, called with no `scale_indices`
+#   since this op's own schema has no `k_scale`/`v_scale` inputs at all) get
+#   the identical treatment as `GroupQueryAttention`'s own analogous inputs.
+#   `key_padding_mask` (index 4) is, per its own schema doc, one of five
+#   shapes -- none with a `num_heads`-sized axis -- so it is always left
+#   alone, the same reasoning `com.microsoft::Attention`'s own `mask_index`
+#   already gets. All of this was verified empirically, not assumed from the
+#   schema doc alone: a minimal `MultiHeadAttention` graph (separate Q/K/V
+#   `MatMul` producers, a combined bias, an output-projection `MatMul`) run
+#   through a real `onnxruntime.InferenceSession` matched a numpy reference
+#   oracle to ~1.3e-8 max-abs-diff (float32 noise) both before and after a
+#   manually-pre-reduced 4-head-to-3-head slice built exactly the way
+#   described above; perturbing one head's own slice of a constant
+#   `attention_bias` changed only that head's own output slice (~4e-7,
+#   zero everywhere else); a `past_key`/`past_value`-bearing node ran
+#   successfully with the documented BNSH shape -- see
+#   ``tests/test_pruning.py``'s own "MultiHeadAttention" section for the
+#   in-repo version of these checks.
 #
 # Cross-attention (Q projected from one source tensor, K/V from a genuinely
 # *different* one -- the encoder-decoder shape) was investigated explicitly
-# for all three matched op types, not left an untested assumption:
+# for all four matched op types, not left an untested assumption:
 #
 # - `com.microsoft::Attention`'s own contrib-op schema (`bert_defs.cc`, the
 #   same source consulted elsewhere in this module for `SkipLayerNormalization`)
@@ -10534,9 +10619,11 @@ def apply_structured_pruning_matmul_nbits(
 #   to come from at all. Cross-attention isn't a shape this op's schema can
 #   express, so it's simply not applicable here -- not a gap in
 #   :func:`_match_attention_producer` to close.
-# - `GroupQueryAttention` and the plain ``ai.onnx`` `Attention` op both
-#   already support it, confirmed by construction and by execution: neither
-#   :func:`_match_gqa_producer`/:func:`_match_onnx_attention_producer` nor
+# - `GroupQueryAttention`, the plain ``ai.onnx`` `Attention` op, and
+#   `MultiHeadAttention` all already support it, confirmed by construction
+#   and by execution: none of :func:`_match_gqa_producer`/
+#   :func:`_match_onnx_attention_producer`/
+#   :func:`_match_multi_head_attention_producer` nor
 #   :func:`_find_separate_qkv_chains` (their shared caller) ever compares
 #   Q's own producer against K's or V's own -- each of the three is matched,
 #   via :func:`_match_producer`, purely from its own MatMul/vanilla-Gemm
@@ -10544,17 +10631,25 @@ def apply_structured_pruning_matmul_nbits(
 #   ultimately trace back to. A model where Q's producer reads from one
 #   graph input and K/V's producers read from an entirely different one (a
 #   real decoder/encoder pair, potentially different feature dimensions
-#   too) matches exactly the same way a self-attention model does. Both
-#   ops' own schema docs name this explicitly -- `GroupQueryAttention`'s
-#   own doc string opens with "Group Query **Self/Cross** Attention", and
-#   the plain op's doc (`onnx.defs.get_schema("Attention", domain="")` on
+#   too) matches exactly the same way a self-attention model does. All
+#   three ops' own schema docs name this explicitly -- `GroupQueryAttention`'s
+#   own doc string opens with "Group Query **Self/Cross** Attention", the
+#   plain op's doc (`onnx.defs.get_schema("Attention", domain="")` on
 #   this environment's installed ``onnx==1.22.0``) states outright "this
 #   operator covers self and cross variants ... For cross attention, query
-#   and key might have different lengths" -- and this is verified here the
-#   same oracle-vs-onnxruntime way as everything else (see
+#   and key might have different lengths", and `MultiHeadAttention`'s own
+#   doc opens with "Multi-Head **Self/Cross** Attention" -- and this is
+#   verified here the same oracle-vs-onnxruntime way as everything else (see
 #   ``tests/test_pruning.py``'s own "cross-attention" subsections under the
-#   GroupQueryAttention/plain-Attention sections), with distinct source
-#   tensors of distinct feature dimensions feeding Q vs K/V.
+#   GroupQueryAttention/plain-Attention/MultiHeadAttention sections), with
+#   distinct source tensors, and (for `MultiHeadAttention` and the plain
+#   ``ai.onnx`` op) distinct sequence lengths too, feeding Q vs K/V --
+#   `MultiHeadAttention`'s own cross-attention run matched a numpy oracle to
+#   ~1.3e-8 max-abs-diff both before and after the same 4-head-to-3-head
+#   pruning slice described above, with no restriction of this pass's own
+#   and, unlike `GroupQueryAttention` below, no onnxruntime-kernel-level
+#   same-sequence-length restriction found either (verified directly, not
+#   merely assumed from the absence of a doc-string caveat).
 # - One real bug turned up along the way and is fixed here:
 #   :func:`_gqa_group_importance`'s combined-importance score used to
 #   ``np.concatenate`` each group's Q, K, and V weight *blocks* into one
@@ -10706,6 +10801,20 @@ class _GQAChain:
     # pass-through existed, gets ``None`` on both exactly as before.
     q_norm_rope: Optional["_QKNormRopePassThrough"] = None
     k_norm_rope: Optional["_QKNormRopePassThrough"] = None
+    # Set only for a matched ``com.microsoft::MultiHeadAttention`` node whose
+    # own `bias` input (index 3) is a non-empty constant: the name of that
+    # tensor, which -- unlike `.q_bias`/`.k_bias`/`.v_bias` above (each an
+    # independent per-*producer* bias, from that producer's own Gemm) -- is
+    # one single ``[nq + nk + nv]``-shaped tensor holding Q's, K's, and V's
+    # three biases concatenated end to end (`.q_weight`'s producer bias, if
+    # matched via `_match_producer`, is a distinct, independent tensor from
+    # this one; both are sliced when both are present -- see this module's
+    # own "Attention-head pruning" section comment for how this shape was
+    # confirmed against ONNX Runtime's own transformer fusion code).
+    # ``None`` (the default) for every other matched op, and for a matched
+    # `MultiHeadAttention` node whose own `bias` input is absent/empty --
+    # both exactly as before this field existed.
+    mha_bias: Optional[str] = None
 
 
 # Either kind of matched attention block, sharing enough of a common shape
@@ -11235,6 +11344,96 @@ def _match_onnx_attention_producer(
     return q_num_heads, kv_num_heads
 
 
+def _match_multi_head_attention_producer(
+    node: onnx.NodeProto, initializer_map: Dict[str, onnx.TensorProto]
+) -> Optional[Tuple[int, int]]:
+    """If `node` is a ``com.microsoft::MultiHeadAttention`` node this module
+    can safely act on, returns ``(num_heads, num_heads)`` -- the same
+    ``(num_heads, kv_num_heads)`` shape :func:`_match_gqa_producer`/
+    :func:`_match_onnx_attention_producer` return, but with `kv_num_heads`
+    always equal to `num_heads`: this op's own schema (confirmed live via
+    ``onnxruntime.capi.onnxruntime_pybind11_state.get_all_operator_schema()``
+    against this environment's installed onnxruntime 1.29.0) has exactly one
+    head-count attribute, `num_heads` -- no GQA/MQA support at all (also
+    confirmed independently by `fuse_gqa.h`'s own comment: "verified
+    `MultiHeadAttention` rejects mismatched hidden sizes at runtime"), so
+    every "KV group" the shared :class:`_GQAChain`/:func:`_apply_one_gqa_chain`
+    machinery this function feeds into forms is exactly one query head wide
+    -- ordinary per-head pruning, arrived at for free by feeding this same
+    `num_heads` value as both fields with no separate GQA-vs-MHA branch
+    needed anywhere downstream.
+
+    Unlike `com.microsoft::Attention`, this op owns no projection weight at
+    all: its `query`/`key`/`value` inputs (indices 0/1/2) are
+    already-projected, rank-3 ``[batch, seq, hidden]`` activation tensors --
+    the same calling convention `GroupQueryAttention` uses -- so Q's/K's/V's
+    own separate MatMul/vanilla-Gemm producers (not a weight owned by this
+    node) are what :func:`_find_separate_qkv_chains` matches and
+    :func:`_apply_one_gqa_chain` prunes, exactly as for `GroupQueryAttention`.
+    Requiring `key`/`value` both non-empty (same as
+    :func:`_match_gqa_producer`'s own check) excludes this op's alternate
+    "packed QKV" calling convention, where `query` alone carries a packed,
+    rank-5 ``(batch, kv_sequence_length, num_heads, 3, head_size)`` tensor
+    and `key`/`value` are left empty -- a different tensor layout this
+    function doesn't attempt to slice, the same reasoning
+    :func:`_match_gqa_producer`'s own docstring gives for its own analogous
+    exclusion.
+
+    The optional `attention_bias` input (index 5), documented shape
+    ``(batch_size or 1, num_heads or 1, sequence_length,
+    total_sequence_length)`` -- confirmed, via actual onnxruntime execution,
+    to have a real per-head effect (perturbing one head's own slice changes
+    only that head's own output slice and no other) -- gets the identical
+    constant-resolves-cleanly-or-is-declined treatment via
+    :func:`_head_bias_axis` that `GroupQueryAttention`'s own `attention_bias`
+    and the plain ai.onnx op's own `attn_mask` already get.
+    `key_padding_mask` (index 4) is, per its own schema doc, one of five
+    shapes -- none with a `num_heads`-sized axis -- so it is unconditionally
+    head-count-independent and never inspected here, the same reasoning
+    plain `com.microsoft::Attention`'s own `mask_index` already gets. The
+    optional `past_key`/`past_value` inputs (indices 6/7 -- a different pair
+    of indices from `GroupQueryAttention`'s own 3/4 and the plain ai.onnx
+    op's own 4/5) get the same safety gate via the same shared
+    :func:`_past_kv_constants_are_sliceable`, called with no `scale_indices`:
+    this op's own schema has no `k_scale`/`v_scale` inputs at all (confirmed
+    off the same live schema dump), so a quantized cache here is declined
+    outright exactly as it is for the plain ai.onnx op.
+    :func:`_apply_one_gqa_chain` performs the actual slice(s) of both once a
+    match succeeds. This op's own `bias` input (index 3 -- a combined,
+    ``[nq + nk + nv]``-shaped concatenation of Q's/K's/V's three biases, the
+    shape ONNX Runtime's own transformer fusion code
+    (`fusion_attention.py`'s own `create_combined_qkv_bias`) actually
+    produces for the realistic BERT/ViT/CLIP/T5/Whisper export pattern) is
+    *not* validated here -- `nq`/`nk`/`nv` aren't known until
+    :func:`_find_separate_qkv_chains` has resolved all three producers, so
+    that validation (and recording the bias's own name onto
+    :class:`_GQAChain`'s `mha_bias` field) happens there instead, via its own
+    `combined_bias_input_index` parameter.
+    """
+    if node.domain != _ATTENTION_DOMAIN or node.op_type != "MultiHeadAttention":
+        return None
+    if len(node.input) < 3 or not (node.input[0] and node.input[1] and node.input[2]):
+        return None
+
+    num_heads = None
+    for attr in node.attribute:
+        if attr.name == "num_heads":
+            num_heads = attr.i
+    if not num_heads or num_heads <= 0:
+        return None
+
+    if len(node.input) > 5 and node.input[5]:  # attention_bias
+        bias_init = initializer_map.get(node.input[5])
+        if bias_init is not None and int(np.prod(bias_init.dims)) > 0:
+            if _head_bias_axis(list(bias_init.dims), num_heads) is None:
+                return None  # doesn't statically resolve -- decline rather than guess
+
+    if not _past_kv_constants_are_sliceable(node, initializer_map, (6, 7), num_heads):
+        return None
+
+    return num_heads, num_heads
+
+
 def _match_packed_qkv_split(
     split_node: onnx.NodeProto,
     initializer_map: Dict[str, onnx.TensorProto],
@@ -11672,22 +11871,33 @@ def _find_separate_qkv_chains(
     match_producer,
     num_heads_attr: str,
     allow_differing_v_head_size: bool = False,
+    combined_bias_input_index: Optional[int] = None,
 ) -> List[_GQAChain]:
-    """Shared body for :func:`_find_gqa_chains` and
-    :func:`_find_onnx_attention_chains`: both match a fused attention node
-    fed by three separate, un-merged Q/K/V MatMul/vanilla-Gemm projections
-    (as opposed to :func:`_find_attention_chains`'s single merged-QKV-weight
+    """Shared body for :func:`_find_gqa_chains`,
+    :func:`_find_onnx_attention_chains`, and :func:`_find_mha_chains`: all
+    three match a fused attention node fed by three separate, un-merged
+    Q/K/V MatMul/vanilla-Gemm projections (as opposed to
+    :func:`_find_attention_chains`'s single merged-QKV-weight
     ``com.microsoft::Attention``) and prune it at whole-KV-group granularity
     (see :func:`_apply_one_gqa_chain`/:func:`_gqa_group_importance`),
     differing only in which node/attributes `match_producer` recognizes
-    (:func:`_match_gqa_producer` or :func:`_match_onnx_attention_producer`),
-    which attribute on the matched node holds the query head count
-    (`num_heads_attr` -- see :class:`_GQAChain`'s own field of that name),
-    and whether V's own head_size is allowed to differ from Q/K's shared one
-    (`allow_differing_v_head_size` -- ``False`` for `GroupQueryAttention`,
-    which `fuse_gqa.h` never emits with anything but equal Q/K/V head_size,
-    ``True`` for the plain ai.onnx op, whose schema genuinely allows it; see
-    :class:`_GQAChain`'s own `v_head_size` field).
+    (:func:`_match_gqa_producer`, :func:`_match_onnx_attention_producer`, or
+    :func:`_match_multi_head_attention_producer`), which attribute on the
+    matched node holds the query head count (`num_heads_attr` -- see
+    :class:`_GQAChain`'s own field of that name), whether V's own head_size
+    is allowed to differ from Q/K's shared one (`allow_differing_v_head_size`
+    -- ``False`` for `GroupQueryAttention`, which `fuse_gqa.h` never emits
+    with anything but equal Q/K/V head_size, ``True`` for the plain ai.onnx
+    op and `MultiHeadAttention`, whose schemas genuinely allow it; see
+    :class:`_GQAChain`'s own `v_head_size` field), and whether the matched
+    node itself owns one combined ``[nq + nk + nv]``-shaped Q+K+V bias on one
+    of its own inputs (`combined_bias_input_index` -- ``None``, the default,
+    for `GroupQueryAttention`/the plain ai.onnx op, neither of which has such
+    an input; the `MultiHeadAttention`-specific `bias` input's own index, 3,
+    for :func:`_find_mha_chains` -- see :class:`_GQAChain`'s own `mha_bias`
+    field and this module's "Attention-head pruning" section comment for why
+    this is a genuinely different shape from every other bias this function
+    already threads through `producer_infos` below).
     """
     initializer_map = {t.name: t for t in graph.initializer}
     consumers_of = _consumers_of(graph)
@@ -11830,6 +12040,31 @@ def _find_separate_qkv_chains(
         ):
             continue
 
+        # `MultiHeadAttention`-only: its own `bias` input (index 3) is a
+        # single combined tensor, not a per-producer one -- validated here
+        # (rather than in :func:`_match_multi_head_attention_producer`,
+        # which runs before `nq`/`nk`/`nv` are known) against the exact
+        # ``[nq + nk + nv]`` shape ONNX Runtime's own transformer fusion
+        # code (`create_combined_qkv_bias`) actually produces. Present but
+        # non-constant or wrong-shaped declines the whole chain outright --
+        # a bias this pass can't prove safe to leave untouched, unlike an
+        # absent one, which needs no touching at all.
+        mha_bias: Optional[str] = None
+        if (
+            combined_bias_input_index is not None
+            and len(node.input) > combined_bias_input_index
+        ):
+            bias_name = node.input[combined_bias_input_index]
+            if bias_name:
+                bias_init = initializer_map.get(bias_name)
+                if (
+                    bias_init is None
+                    or not _is_supported_float_dtype(bias_init.data_type)
+                    or list(bias_init.dims) != [nq + nk + nv]
+                ):
+                    continue
+                mha_bias = bias_name
+
         out_name = node.output[0]
         if not _is_internal(out_name):
             continue
@@ -11876,6 +12111,7 @@ def _find_separate_qkv_chains(
                 packed_split_sizes=packed_split_sizes,
                 q_norm_rope=q_norm_rope,
                 k_norm_rope=k_norm_rope,
+                mha_bias=mha_bias,
             )
         )
     return chains
@@ -11899,6 +12135,30 @@ def _find_onnx_attention_chains(graph: onnx.GraphProto) -> List[_GQAChain]:
         _match_onnx_attention_producer,
         "q_num_heads",
         allow_differing_v_head_size=True,
+    )
+
+
+def _find_mha_chains(graph: onnx.GraphProto) -> List[_GQAChain]:
+    """The ``com.microsoft::MultiHeadAttention`` analogue of
+    :func:`_find_gqa_chains`/:func:`_find_onnx_attention_chains` -- see
+    :func:`_find_separate_qkv_chains` (the shared body) and
+    :func:`_match_multi_head_attention_producer` (what's matched and why
+    it's declined otherwise). Passes ``allow_differing_v_head_size=True``
+    (confirmed empirically: a minimal `MultiHeadAttention` node whose V
+    projection is a genuinely different width than Q's/K's shared one -- 2
+    heads of width 4 for Q/K, width 3 for V -- runs successfully under this
+    environment's onnxruntime, the same real-execution bar every other
+    matcher in this section is held to) and
+    ``combined_bias_input_index=3`` -- this op's own `bias` input, the one
+    combined-Q/K/V-bias shape :class:`_GQAChain`'s own `mha_bias` field (and
+    this module's "Attention-head pruning" section comment) documents.
+    """
+    return _find_separate_qkv_chains(
+        graph,
+        _match_multi_head_attention_producer,
+        "num_heads",
+        allow_differing_v_head_size=True,
+        combined_bias_input_index=3,
     )
 
 
@@ -12120,10 +12380,15 @@ def _apply_one_gqa_chain(
     sparsity: float,
     compute_group_importance,
 ) -> Optional[Tuple[Set[str], str, Set[str]]]:
-    """Applies whole-KV-group pruning to one matched ``GroupQueryAttention``
-    or plain ``ai.onnx::Attention`` block (see :class:`_GQAChain`'s own
-    `num_heads_attr` field for how the two are told apart when writing the
-    new query head count back) in place: every dropped group removes one
+    """Applies whole-KV-group pruning to one matched ``GroupQueryAttention``,
+    plain ``ai.onnx::Attention``, or ``MultiHeadAttention`` block (see
+    :class:`_GQAChain`'s own `num_heads_attr` field for how the three are
+    told apart when writing the new query head count back -- and, since
+    `MultiHeadAttention` has no separate `kv_num_heads` at all,
+    `chain.kv_num_heads == chain.num_heads` always for it, so every "group"
+    this function forms for it is exactly one query head wide, ordinary
+    per-head pruning arrived at with no dedicated branch) in place: every
+    dropped group removes one
     *contiguous* ``head_size``-wide column block from K's own separate
     weight and one *contiguous* ``v_head_size``-wide column block (equal to
     ``head_size`` for `GroupQueryAttention`, not necessarily for the plain
@@ -12179,6 +12444,17 @@ def _apply_one_gqa_chain(
     `sin_cache` ever needs touching (both confirmed head-independent -- see
     this module's own "Attention-head pruning" section comment).
 
+    When `chain.mha_bias` is set (`MultiHeadAttention` only -- see
+    :class:`_GQAChain`'s own field of that name), it names one combined
+    ``[nq + nk + nv]``-shaped tensor holding Q's/K's/V's three biases
+    concatenated end to end on the `MultiHeadAttention` node's own `bias`
+    input, sliced in the identical three head-aligned ranges the packed-QKV
+    branch above uses for a packed *weight* -- an independent, unrelated
+    sharing (this bias can be combined even when Q's/K's/V's own weights
+    are three genuinely separate tensors, the realistic
+    `MultiHeadAttention` export shape) so it is applied regardless of
+    whether `chain.packed_split_sizes` is set.
+
     Returns ``(producer_weight_names, consumer_weight_name,
     stale_output_names)`` on success, or ``None`` if `sparsity` rounds to no
     groups dropped for this block (a no-op, left for the caller to skip).
@@ -12191,6 +12467,14 @@ def _apply_one_gqa_chain(
     d = chain.head_size
     dv = chain.v_head_size
     group_size = chain.num_heads // chain.kv_num_heads
+    # Pre-pruning flat widths of Q's/K's own producer weight -- needed both
+    # by the packed-QKV branch below (a column-range view into one shared
+    # tensor) and, independently, by `chain.mha_bias`'s own combined-bias
+    # slice further down (a `MultiHeadAttention`-only, bias-only sharing
+    # that has nothing to do with whether the *weights* are packed -- see
+    # this module's own "Attention-head pruning" section comment).
+    nq_orig = chain.num_heads * d
+    nk_orig = chain.kv_num_heads * d
 
     # `_gqa_group_importance` (and any caller-supplied Wanda variant of it)
     # indexes columns as the head axis, mirroring
@@ -12213,8 +12497,6 @@ def _apply_one_gqa_chain(
         # ``[K, N]`` array, computed from the chain's own original (before
         # this call's own pruning) head counts, rather than three
         # independently-stored arrays.
-        nq_orig = chain.num_heads * d
-        nk_orig = chain.kv_num_heads * d
         w_kn = _to_f64(wq_init)
         if chain.q_weight_transposed:
             w_kn = w_kn.T  # [K, Nq+Nk+Nv]
@@ -12282,18 +12564,39 @@ def _apply_one_gqa_chain(
         if chain.v_bias is not None:
             _slice_last_axis(initializer_map[chain.v_bias], v_idx)
 
+    # `MultiHeadAttention`-only: its own combined `bias` input (see
+    # :class:`_GQAChain`'s own `mha_bias` field) is one single
+    # ``[nq + nk + nv]``-shaped tensor holding Q's, K's, and V's three
+    # biases concatenated end to end -- sliced in the same three
+    # head-aligned ranges (Q's own kept columns, then K's shifted by the
+    # *original* `nq_orig`, then V's shifted by `nq_orig + nk_orig`) the
+    # packed-QKV branch above already uses for a packed *weight*, but
+    # independent of whether `chain.packed_split_sizes` is set -- this bias
+    # sharing and that weight sharing are two unrelated shapes that happen
+    # to reuse the same column-index-set trick.
+    if chain.mha_bias is not None:
+        full_bias_idx = np.concatenate(
+            [q_idx, k_idx + nq_orig, v_idx + nq_orig + nk_orig]
+        )
+        _slice_last_axis(initializer_map[chain.mha_bias], full_bias_idx)
+
     # `GroupQueryAttention`'s past_key/past_value live at input indices 3/4,
-    # the plain ai.onnx op's own at 4/5 (see `_match_gqa_producer`'s and
-    # `_match_onnx_attention_producer`'s own docstrings) -- both already
-    # confirmed, at match time, to be either absent/dynamic (nothing to do
-    # here) or a BNSH-format constant (plain FLOAT, or quantized with a
-    # schema-conforming scale) safe to slice along axis 1 by `keep_groups`
-    # (see :func:`_past_kv_constants_are_sliceable`).
+    # the plain ai.onnx op's own at 4/5, `MultiHeadAttention`'s own at 6/7
+    # (see `_match_gqa_producer`'s, `_match_onnx_attention_producer`'s, and
+    # `_match_multi_head_attention_producer`'s own docstrings) -- all three
+    # already confirmed, at match time, to be either absent/dynamic (nothing
+    # to do here) or a BNSH-format constant (plain FLOAT, or -- GQA only --
+    # quantized with a schema-conforming scale) safe to slice along axis 1
+    # by `keep_groups` (see :func:`_past_kv_constants_are_sliceable`).
     is_gqa = (
         chain.node.domain == _ATTENTION_DOMAIN
         and chain.node.op_type == "GroupQueryAttention"
     )
-    past_kv_indices = (3, 4) if is_gqa else (4, 5)
+    is_mha = (
+        chain.node.domain == _ATTENTION_DOMAIN
+        and chain.node.op_type == "MultiHeadAttention"
+    )
+    past_kv_indices = (3, 4) if is_gqa else (6, 7) if is_mha else (4, 5)
     for idx in past_kv_indices:
         if len(chain.node.input) <= idx or not chain.node.input[idx]:
             continue
@@ -12322,14 +12625,16 @@ def _apply_one_gqa_chain(
             # else: PER_TENSOR broadcast scalar -- no per-head axis to slice
 
     # `attention_bias`/`attn_mask` (index 10 for `GroupQueryAttention`, 3
-    # for the plain ai.onnx op -- see `_match_gqa_producer`'s and
-    # `_match_onnx_attention_producer`'s own docstrings) is sliced along its
-    # own head axis by `keep_q_heads` -- *query*-head granularity, not
-    # `keep_groups`'s kv-group one -- whenever `_head_bias_axis` resolves it
-    # to a genuine per-head tensor against the pre-pruning `chain.num_heads`;
-    # left untouched when it resolves to a broadcast (or is absent/dynamic,
-    # matched the same "nothing to slice" way here as at match time).
-    mask_idx = 10 if is_gqa else 3
+    # for the plain ai.onnx op, 5 for `MultiHeadAttention` -- see
+    # `_match_gqa_producer`'s, `_match_onnx_attention_producer`'s, and
+    # `_match_multi_head_attention_producer`'s own docstrings) is sliced
+    # along its own head axis by `keep_q_heads` -- *query*-head granularity,
+    # not `keep_groups`'s kv-group one -- whenever `_head_bias_axis` resolves
+    # it to a genuine per-head tensor against the pre-pruning
+    # `chain.num_heads`; left untouched when it resolves to a broadcast (or
+    # is absent/dynamic, matched the same "nothing to slice" way here as at
+    # match time).
+    mask_idx = 10 if is_gqa else 5 if is_mha else 3
     if len(chain.node.input) > mask_idx and chain.node.input[mask_idx]:
         mask_init = initializer_map.get(chain.node.input[mask_idx])
         if mask_init is not None:
@@ -12419,12 +12724,16 @@ def _apply_attention_chains(
     :func:`apply_attention_head_wanda_pruning`, mirroring
     :func:`_apply_chains`'s own shape (cross-chain touched-role
     bookkeeping, stale ``value_info`` cleanup) but dispatching each chain to
-    :func:`_apply_one_plain_attention_chain` (a matched ``Attention``
-    block) or :func:`_apply_one_gqa_chain` (a matched
-    ``GroupQueryAttention`` block) for the actual per-chain slicing, since
-    the two ops' weight layouts (one merged QKV tensor vs. three separate
-    Q/K/V producers) and pruning unit (individual head vs. whole KV group)
-    are different enough that sharing that part wouldn't simplify either.
+    :func:`_apply_one_plain_attention_chain` (a matched merged-QKV
+    ``Attention`` block) or :func:`_apply_one_gqa_chain` (a matched
+    ``GroupQueryAttention``, plain ``ai.onnx::Attention``, or
+    `MultiHeadAttention` block -- all three share the one :class:`_GQAChain`
+    shape, so all three dispatch here identically) for the actual per-chain
+    slicing, since the merged-QKV op's weight layout (one merged QKV tensor)
+    versus the other three's (separate Q/K/V producers) and pruning unit
+    (individual head vs. whole KV group -- one query head wide, for
+    `MultiHeadAttention`) are different enough that sharing that part
+    wouldn't simplify either.
     """
     initializer_map = {t.name: t for t in graph.initializer}
     producer_touched: Set[str] = set()
@@ -12472,16 +12781,19 @@ def apply_attention_head_pruning(
 ) -> onnx.ModelProto:
     """Removes whole attention heads -- or, for grouped-query attention,
     whole KV groups -- from every matched ``com.microsoft::Attention``,
-    ``com.microsoft::GroupQueryAttention``, or plain ``ai.onnx::Attention``
-    node (the fused self-attention blocks onnxsim's own
-    ``fuse_attention``/``fuse_gqa`` optimizer passes produce, plus the
-    standard ONNX op those two contrib ops are converging towards -- see
-    this module's own "Attention-head pruning" section comment for the real
-    schema each was confirmed against and how) whose output feeds,
-    optionally through a single shape-preserving ``Reshape``, exactly one
-    downstream MatMul/vanilla-Gemm's reduction dimension (the output
-    projection) -- the attention analogue of :func:`apply_structured_pruning`,
-    at head (or KV-group) instead of single-channel granularity.
+    ``com.microsoft::GroupQueryAttention``, ``com.microsoft::MultiHeadAttention``,
+    or plain ``ai.onnx::Attention`` node (the fused self-attention blocks
+    onnxsim's own ``fuse_attention``/``fuse_gqa`` optimizer passes produce,
+    `MultiHeadAttention`, which those passes deliberately never emit but ONNX
+    Runtime's own transformer graph optimizer routinely does for BERT/ViT/
+    CLIP/T5/Whisper-style exports, and the standard ONNX op the contrib ops
+    are converging towards -- see this module's own "Attention-head pruning"
+    section comment for the real schema each was confirmed against and how)
+    whose output feeds, optionally through a single shape-preserving
+    ``Reshape``, exactly one downstream MatMul/vanilla-Gemm's reduction
+    dimension (the output projection) -- the attention analogue of
+    :func:`apply_structured_pruning`, at head (or KV-group) instead of
+    single-channel granularity.
 
     For each matched plain ``com.microsoft::Attention`` block: ranks every
     head by the combined Frobenius norm of its own
@@ -12494,29 +12806,37 @@ def apply_attention_head_pruning(
     for every surviving head, the same guarantee
     :func:`apply_structured_pruning` gives per channel.
 
-    For each matched ``GroupQueryAttention`` or plain ``ai.onnx::Attention``
-    block: ranks every *KV group* (a KV head and the
-    ``num_heads / kv_num_heads`` query heads the kernel maps to it) by the
-    combined Frobenius norm of that group's own Q+K+V weight block across
-    Q's, K's, and V's own separate producer weights, drops the
+    For each matched ``GroupQueryAttention``, plain ``ai.onnx::Attention``,
+    or ``MultiHeadAttention`` block: ranks every *KV group* (a KV head and
+    the ``num_heads / kv_num_heads`` query heads the kernel maps to it -- for
+    `MultiHeadAttention`, which has no separate `kv_num_heads` at all, this
+    is always exactly one query head, so this reduces to ordinary per-head
+    pruning) by the combined Frobenius norm of that group's own Q+K+V weight
+    block across Q's, K's, and V's own separate producer weights, drops the
     lowest-``sparsity``-fraction of groups (at least one group is always
     kept), and removes the corresponding column blocks from all three
-    producers (and their biases, if present) together with the matching row
-    block from the output projection's weight, decrementing the query head
-    count (``num_heads`` for `GroupQueryAttention`, ``q_num_heads`` for the
-    plain ``ai.onnx`` op) and ``kv_num_heads`` by the number of groups
-    dropped -- so their ratio (query heads per KV head) is unchanged,
-    keeping every surviving KV head mapped to exactly the same number of
-    query heads the kernel requires. An individual query head is never
-    dropped on its own: only a whole group, since neither kernel has a way
-    to keep a KV head alive for some, but not all, of the query heads that
+    producers (and their biases, if present -- for `MultiHeadAttention`,
+    which typically has no per-producer bias at all, folding Q's/K's/V's
+    three biases instead into one combined tensor on its own `bias` input,
+    that combined tensor's own three head-aligned ranges are sliced the same
+    way -- see :class:`_GQAChain`'s own `mha_bias` field) together with the
+    matching row block from the output projection's weight, decrementing the
+    query head count (``num_heads`` for `GroupQueryAttention`/
+    `MultiHeadAttention`, ``q_num_heads`` for the plain ``ai.onnx`` op) and
+    ``kv_num_heads`` by the number of groups dropped -- so their ratio
+    (query heads per KV head) is unchanged, keeping every surviving KV head
+    mapped to exactly the same number of query heads the kernel requires. An
+    individual query head is never dropped on its own from a genuine
+    GQA/MQA block: only a whole group, since neither kernel has a way to
+    keep a KV head alive for some, but not all, of the query heads that
     shared it. A connected `past_key`/`past_value` that is a constant of the
     expected float BNSH shape is sliced along its own `kv_num_heads` axis by
     the same index set (see :func:`_past_kv_constants_are_sliceable`,
-    :func:`_apply_one_gqa_chain`); a plain ``ai.onnx::Attention`` node's V
-    head size may genuinely differ from Q/K's own (a shape that op's schema
-    allows but `GroupQueryAttention` never produces) and is sliced correctly
-    at its own width -- see :class:`_GQAChain`'s own `v_head_size` field.
+    :func:`_apply_one_gqa_chain`); a plain ``ai.onnx::Attention`` or
+    `MultiHeadAttention` node's V head size may genuinely differ from Q/K's
+    own (a shape both ops' schemas allow but `GroupQueryAttention` never
+    produces) and is sliced correctly at its own width -- see
+    :class:`_GQAChain`'s own `v_head_size` field.
 
     :param model: the original onnx ModelProto or file path
     :param sparsity: target fraction of each matched block's heads (or, for
@@ -12573,6 +12893,7 @@ def apply_attention_head_pruning(
         *_find_attention_chains(graph),
         *_find_gqa_chains(graph),
         *_find_onnx_attention_chains(graph),
+        *_find_mha_chains(graph),
     ]
     if chains:
         _apply_attention_chains(
@@ -12647,22 +12968,23 @@ def apply_attention_head_wanda_pruning(
     """The calibrated upgrade of :func:`apply_attention_head_pruning`,
     exactly as :func:`apply_structured_wanda_pruning` is to
     :func:`apply_structured_pruning`: same real head (or, for
-    GroupQueryAttention/plain ai.onnx Attention, whole-KV-group) removal,
-    same topology matching, including the identical `attention_bias`/
-    `attn_mask`/`head_sink` per-head-axis slicing treatment (see
-    :func:`apply_attention_head_pruning`'s own docstring for the three
-    matched op types and exactly what each does with those inputs), but
-    each unit's importance
+    GroupQueryAttention/plain ai.onnx Attention/MultiHeadAttention,
+    whole-KV-group) removal, same topology matching, including the
+    identical `attention_bias`/`attn_mask`/`head_sink` per-head-axis slicing
+    treatment (see :func:`apply_attention_head_pruning`'s own docstring for
+    the four matched op types and exactly what each does with those
+    inputs), but each unit's importance
     is ``||W||_F * ||X||_2`` -- the plain Frobenius-norm weight score times
     the combined (root-sum-square) activation norm of that unit's own slice
     of the *output projection's* input, captured over calibration data --
     instead of weight magnitude alone. For a plain ``com.microsoft::Attention``
-    block this is per head, exactly as before; for a ``GroupQueryAttention``
-    or plain ``ai.onnx::Attention`` block the activation norm is combined
-    (root-sum-square) over every query head a KV group owns, mirroring how
-    :func:`_gqa_group_importance` combines that same group's weight norm
-    across Q+K+V -- both matched separate-Q/K/V-producer ops share that one
-    importance function (and this one calibrated wrapper around it)
+    block this is per head, exactly as before; for a ``GroupQueryAttention``,
+    plain ``ai.onnx::Attention``, or ``MultiHeadAttention`` block the
+    activation norm is combined (root-sum-square) over every query head a KV
+    group owns (exactly one query head, for `MultiHeadAttention`), mirroring
+    how :func:`_gqa_group_importance` combines that same group's weight norm
+    across Q+K+V -- all three matched separate-Q/K/V-producer ops share that
+    one importance function (and this one calibrated wrapper around it)
     unmodified.
 
     :param model: the original onnx ModelProto or file path
@@ -12721,6 +13043,7 @@ def apply_attention_head_wanda_pruning(
         *_find_attention_chains(graph),
         *_find_gqa_chains(graph),
         *_find_onnx_attention_chains(graph),
+        *_find_mha_chains(graph),
     ]
     if not chains:
         return out
@@ -16726,8 +17049,13 @@ class PruningLayerSensitivity:
             `_find_qdq_chains` matches both through one unified walk,
             unlike the plain float structured family's five separate
             finders, so this is the one family-string split available for
-            it); ``"attention_head"``/
-            ``"attention_gqa_group"`` for attention pruning (shared by
+            it); ``"attention_head"`` (plain merged-QKV
+            ``com.microsoft::Attention``)/``"attention_gqa_group"``
+            (``GroupQueryAttention``/plain ``ai.onnx::Attention``, whole-KV-
+            group granularity)/``"attention_mha_head"``
+            (``MultiHeadAttention``, individual-head granularity -- it has
+            no separate `kv_num_heads` at all, so every "group" is one
+            head) for attention pruning (shared by
             :func:`apply_attention_head_pruning` and its Wanda-calibrated
             counterpart :func:`apply_attention_head_wanda_pruning` alike --
             `family` names the topology a unit was matched by, not the
@@ -17793,7 +18121,8 @@ def _attention_not_eligible(
         is_attn_like = (
             node.op_type == "Attention" and node.domain in (_ATTENTION_DOMAIN, "")
         ) or (
-            node.op_type == "GroupQueryAttention" and node.domain == _ATTENTION_DOMAIN
+            node.op_type in ("GroupQueryAttention", "MultiHeadAttention")
+            and node.domain == _ATTENTION_DOMAIN
         )
         if not is_attn_like or id(node) in matched_ids:
             continue
@@ -17833,7 +18162,18 @@ def _analyze_attention_chains(
         if isinstance(chain, _GQAChain):
             producer_names = {chain.q_weight, chain.k_weight, chain.v_weight}
             h = chain.kv_num_heads
-            family = "attention_gqa_group"
+            # `MultiHeadAttention` has no separate `kv_num_heads` at all
+            # (`chain.kv_num_heads == chain.num_heads` always for it -- see
+            # :func:`_match_multi_head_attention_producer`'s own docstring),
+            # so every "group" this shared `_GQAChain` machinery forms for
+            # it is exactly one query head wide -- a distinct family string
+            # names that, rather than reporting genuine multi-head KV groups
+            # and individual-head MHA pruning identically.
+            family = (
+                "attention_mha_head"
+                if chain.node.op_type == "MultiHeadAttention"
+                else "attention_gqa_group"
+            )
         else:
             producer_names = {chain.weight}
             h = chain.num_heads
@@ -17936,7 +18276,7 @@ def _analyze_attention_head_pruning(
 ) -> PruningSensitivityReport:
     """Dry-run mirror of :func:`apply_attention_head_pruning`: same
     matching (:func:`_find_attention_chains`/:func:`_find_gqa_chains`/
-    :func:`_find_onnx_attention_chains`) and per-chain loop
+    :func:`_find_onnx_attention_chains`/:func:`_find_mha_chains`) and per-chain loop
     (:func:`_analyze_attention_chains`, the same shared body
     :func:`_analyze_attention_head_wanda_pruning` uses), with plain
     (:func:`_plain_attention_head_importance`/:func:`_gqa_group_importance`)
@@ -17953,6 +18293,7 @@ def _analyze_attention_head_pruning(
         *_find_attention_chains(graph),
         *_find_gqa_chains(graph),
         *_find_onnx_attention_chains(graph),
+        *_find_mha_chains(graph),
     ]
     layers = _analyze_attention_chains(
         graph,
@@ -17982,7 +18323,7 @@ def _analyze_attention_head_wanda_pruning(
 ) -> PruningSensitivityReport:
     """Dry-run mirror of :func:`apply_attention_head_wanda_pruning` -- same
     matching (:func:`_find_attention_chains`/:func:`_find_gqa_chains`/
-    :func:`_find_onnx_attention_chains`), calibration
+    :func:`_find_onnx_attention_chains`/:func:`_find_mha_chains`), calibration
     (:func:`_wanda_attention_calibration_stats`, the exact same helper
     :func:`apply_attention_head_wanda_pruning` itself calls), per-chain loop
     (:func:`_analyze_attention_chains`), and importance
@@ -18007,6 +18348,7 @@ def _analyze_attention_head_wanda_pruning(
         *_find_attention_chains(graph),
         *_find_gqa_chains(graph),
         *_find_onnx_attention_chains(graph),
+        *_find_mha_chains(graph),
     ]
     if not chains:
         return PruningSensitivityReport(

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -11924,6 +11924,694 @@ def test_onnx_attention_wanda_pruning_cross_attention_matches_oracle_exactly():
     np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
 
 
+# --- apply_attention_head_pruning / _wanda_pruning -- MultiHeadAttention --
+#
+# ``onnxruntime.capi.onnxruntime_pybind11_state.get_all_operator_schema()``
+# against this environment's installed onnxruntime 1.29.0 confirms:
+# `com.microsoft::MultiHeadAttention`, one head-count attribute (`num_heads`
+# -- no `kv_num_heads`, no GQA/MQA support at all), and inputs `query, key,
+# value, bias?, key_padding_mask?, attention_bias?, past_key?, past_value?,
+# past_sequence_length?, cache_indirection?` -- `query`/`key`/`value` are
+# already-projected activation tensors (this op owns no projection weight of
+# its own), and `bias` (index 3), when connected, is one single
+# ``[nq + nk + nv]``-shaped tensor -- confirmed against ONNX Runtime's own
+# transformer fusion code (`onnxruntime.transformers.fusion_attention
+# .AttentionFusion.create_multihead_attention_node`/`create_combined_qkv_bias`,
+# installed in this environment) to be exactly the shape that code produces
+# for the realistic BERT/ViT/CLIP/T5/Whisper export pattern: Q/K/V fed
+# straight from their own MatMul's raw output (no per-producer bias `Add`),
+# with Q's/K's/V's three biases folded into this one combined tensor
+# instead. See onnxsim/pruning.py's own "Attention-head pruning" section
+# comment for the full empirical investigation (measured oracle-agreement
+# numbers included) this proves, and this module's own
+# ``test_gqa_pruning_matches_oracle_exactly``/
+# ``test_onnx_attention_pruning_matches_oracle_exactly`` for the oracle
+# style these tests continue.
+
+
+def _mha_model(
+    K=8,
+    H=4,
+    D=4,
+    Out=6,
+    seed=0,
+    batch=2,
+    seq=5,
+    combined_bias=False,  # attach a combined [Nq+Nk+Nv] tensor to MHA's own `bias` input
+    producer_bias=False,  # Q/K/V come from Gemm-with-bias producers instead of raw MatMul
+    wq=None,
+    wk=None,
+    wv=None,
+    bq=None,
+    bk=None,
+    bv=None,
+    wout=None,
+    attention_bias=None,  # constant attention_bias array, or None (unconnected)
+    past_kv=None,  # None (omitted) | "nonempty" (constant) | "dynamic" (graph input)
+    past_key=None,  # explicit override for past_kv="nonempty" (else random)
+    past_value=None,  # explicit override for past_kv="nonempty" (else random)
+    Dv=None,  # V's own head_size, if it should genuinely differ from D
+):
+    # `Dv` (V's own head_size, defaulting to `D`) is independent of Q/K's
+    # `D`: this op's own schema genuinely allows the two to differ (verified
+    # empirically -- see onnxsim/pruning.py's own "Attention-head pruning"
+    # section comment), the same shape the plain ai.onnx op's own schema
+    # allows and `GroupQueryAttention` never does.
+    if Dv is None:
+        Dv = D
+    rng = np.random.default_rng(seed)
+    Nq, Nk, Nv = H * D, H * D, H * Dv
+    if wq is None:
+        wq = rng.standard_normal((K, Nq)).astype(np.float32)
+    if wk is None:
+        wk = rng.standard_normal((K, Nk)).astype(np.float32)
+    if wv is None:
+        wv = rng.standard_normal((K, Nv)).astype(np.float32)
+    if wout is None:
+        wout = rng.standard_normal((Nv, Out)).astype(np.float32)
+
+    initializer = [_f32(wq, "Wq"), _f32(wk, "Wk"), _f32(wv, "Wv"), _f32(wout, "Wout")]
+    q_op, k_op, v_op = "MatMul(X, Wq)", "MatMul(X, Wk)", "MatMul(X, Wv)"
+    if producer_bias:
+        # Gemm's own ONNX spec requires a rank-2 input, so a bias-carrying
+        # Gemm producer can't sit directly ahead of this op's rank-3
+        # query/key/value inputs in a graph meant to actually run through
+        # onnxruntime (see `test_onnx_attention_pruning_slices_bias_when_
+        # producer_has_one`'s own comment for the same point made there) --
+        # exercised against the initializers directly instead, never run.
+        if bq is None:
+            bq = rng.standard_normal((Nq,)).astype(np.float32)
+        if bk is None:
+            bk = rng.standard_normal((Nk,)).astype(np.float32)
+        if bv is None:
+            bv = rng.standard_normal((Nv,)).astype(np.float32)
+        initializer += [_f32(bq, "Bq"), _f32(bk, "Bk"), _f32(bv, "Bv")]
+        q_op, k_op, v_op = "Gemm(X, Wq, Bq)", "Gemm(X, Wk, Bk)", "Gemm(X, Wv, Bv)"
+
+    operands = ["q", "k", "v"]
+    if combined_bias:
+        if bq is None:
+            bq = rng.standard_normal((Nq,)).astype(np.float32)
+        if bk is None:
+            bk = rng.standard_normal((Nk,)).astype(np.float32)
+        if bv is None:
+            bv = rng.standard_normal((Nv,)).astype(np.float32)
+        combined = np.concatenate([bq, bk, bv]).astype(np.float32)
+        initializer.append(_f32(combined, "Bias"))
+        operands.append("Bias")
+    else:
+        operands.append("")
+
+    extra_graph_inputs = ""
+    if attention_bias is not None or past_kv is not None:
+        operands.append("")  # key_padding_mask -- never touched by this pass
+        if attention_bias is not None:
+            initializer.append(_f32(np.asarray(attention_bias), "AttentionBias"))
+            operands.append("AttentionBias")
+        else:
+            operands.append("")
+        if past_kv == "nonempty":
+            if past_key is None:
+                past_key = rng.standard_normal((batch, H, 1, D)).astype(np.float32)
+            if past_value is None:
+                past_value = rng.standard_normal((batch, H, 1, Dv)).astype(np.float32)
+            initializer += [_f32(past_key, "PastKey"), _f32(past_value, "PastValue")]
+            operands += ["PastKey", "PastValue"]
+        elif past_kv == "dynamic":
+            operands += ["PastKeyIn", "PastValueIn"]
+            extra_graph_inputs += (
+                f", float[{batch},{H},1,{D}] PastKeyIn"
+                f", float[{batch},{H},1,{Dv}] PastValueIn"
+            )
+
+    while operands and operands[-1] == "":
+        operands.pop()
+
+    # onnxruntime's own kernel for this op requires `present_key`/
+    # `present_value` declared as node outputs whenever `past_key`/
+    # `past_value` are connected at all -- same requirement confirmed for
+    # `GroupQueryAttention`/the plain ai.onnx op elsewhere in this file.
+    ctx_outputs = "ctx, present_key, present_value" if past_kv else "ctx"
+
+    body = f"""
+        g (float[{batch},{seq},{K}] X{extra_graph_inputs}) => (float[{batch},{seq},{Out}] Y)
+        {{
+          q = {q_op}
+          k = {k_op}
+          v = {v_op}
+          {ctx_outputs} = com.microsoft.MultiHeadAttention <num_heads={H}> ({", ".join(operands)})
+          Y = MatMul(ctx, Wout)
+        }}
+        """
+
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17, "com.microsoft": 1]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model, dict(
+        K=K,
+        H=H,
+        D=D,
+        Dv=Dv,
+        Out=Out,
+        Nq=Nq,
+        Nk=Nk,
+        Nv=Nv,
+        wq=wq,
+        wk=wk,
+        wv=wv,
+        bq=bq,
+        bk=bk,
+        bv=bv,
+        wout=wout,
+        batch=batch,
+        seq=seq,
+        past_key=past_key,
+        past_value=past_value,
+    )
+
+
+def _mha_node(model):
+    return next(
+        n
+        for n in model.graph.node
+        if n.op_type == "MultiHeadAttention" and n.domain == "com.microsoft"
+    )
+
+
+def _mha_num_heads(node):
+    return next(a.i for a in node.attribute if a.name == "num_heads")
+
+
+def test_mha_pruning_shrinks_matched_block():
+    model, cfg = _mha_model(K=8, H=4, D=4, Out=6)
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    node = _mha_node(pruned)
+    assert _mha_num_heads(node) == 2  # max(1, 4 - round(4*0.5))
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Wq"].dims) == [8, 8]
+    assert list(inits["Wk"].dims) == [8, 8]
+    assert list(inits["Wv"].dims) == [8, 8]
+    assert list(inits["Wout"].dims) == [8, 6]
+
+    rng = np.random.default_rng(1)
+    x = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    assert y.shape == (cfg["batch"], cfg["seq"], cfg["Out"])
+
+
+def test_mha_pruning_zero_sparsity_is_a_no_op():
+    model, cfg = _mha_model(K=8, H=8, D=4, Out=6, seed=7)
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.0)
+    node = _mha_node(pruned)
+    assert _mha_num_heads(node) == cfg["H"]
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["Wq"], cfg["wq"])
+    np.testing.assert_array_equal(inits["Wk"], cfg["wk"])
+    np.testing.assert_array_equal(inits["Wv"], cfg["wv"])
+    np.testing.assert_array_equal(inits["Wout"], cfg["wout"])
+
+
+def test_mha_pruning_matches_oracle_exactly():
+    # Self-attention, with the realistic combined-`bias`-input shape
+    # (`combined_bias=True`) ONNX Runtime's own transformer fusion code
+    # actually produces -- see this section's own comment above.
+    model, cfg = _mha_model(K=8, H=8, D=4, Out=6, seed=1, combined_bias=True)
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    node = _mha_node(pruned)
+    num_heads = _mha_num_heads(node)
+    assert num_heads == 4  # max(1, 8 - round(8*0.5))
+
+    d = cfg["D"]
+    keep_heads = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], cfg["H"], cfg["H"], d, num_heads
+    )
+    idx = _head_idx(keep_heads, d)
+
+    oracle, _ = _mha_model(
+        K=cfg["K"],
+        H=len(keep_heads),
+        D=d,
+        Out=cfg["Out"],
+        seed=1,
+        combined_bias=True,
+        wq=cfg["wq"][:, idx],
+        wk=cfg["wk"][:, idx],
+        wv=cfg["wv"][:, idx],
+        bq=cfg["bq"][idx],
+        bk=cfg["bk"][idx],
+        bv=cfg["bv"][idx],
+        wout=cfg["wout"][idx, :],
+        batch=cfg["batch"],
+        seq=cfg["seq"],
+    )
+
+    rng = np.random.default_rng(2)
+    x = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_mha_pruning_slices_combined_bias_exactly():
+    model, cfg = _mha_model(K=8, H=4, D=4, Out=6, seed=3, combined_bias=True)
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+
+    node = _mha_node(pruned)
+    num_heads = _mha_num_heads(node)
+    d = cfg["D"]
+    keep_heads = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], cfg["H"], cfg["H"], d, num_heads
+    )
+    idx = _head_idx(keep_heads, d)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    expected = np.concatenate([cfg["bq"][idx], cfg["bk"][idx], cfg["bv"][idx]])
+    np.testing.assert_array_equal(inits["Bias"], expected)
+
+
+def test_mha_pruning_slices_producer_bias_when_producer_has_one():
+    # `chain.q_bias`/`k_bias`/`v_bias` (an independent per-producer bias,
+    # from that producer's own Gemm) is a genuinely different tensor from
+    # `chain.mha_bias` (this op's own combined `bias` input) -- both are
+    # sliced when both are present, but this test exercises the
+    # per-producer path alone.
+    model, cfg = _mha_model(K=8, H=4, D=4, Out=6, seed=14, producer_bias=True)
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+
+    node = _mha_node(pruned)
+    num_heads = _mha_num_heads(node)
+    d = cfg["D"]
+    keep_heads = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], cfg["H"], cfg["H"], d, num_heads
+    )
+    idx = _head_idx(keep_heads, d)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["Wq"], cfg["wq"][:, idx])
+    np.testing.assert_array_equal(inits["Wk"], cfg["wk"][:, idx])
+    np.testing.assert_array_equal(inits["Wv"], cfg["wv"][:, idx])
+    np.testing.assert_array_equal(inits["Bq"], cfg["bq"][idx])
+    np.testing.assert_array_equal(inits["Bk"], cfg["bk"][idx])
+    np.testing.assert_array_equal(inits["Bv"], cfg["bv"][idx])
+
+
+def test_mha_pruning_malformed_combined_bias_is_declined():
+    # A `bias` input present but not the schema's own `[nq+nk+nv]` shape
+    # (here, a single scalar) can't be safely left half-updated -- the whole
+    # match is declined rather than mis-sliced.
+    model, cfg = _mha_model(K=8, H=4, D=4, Out=6, seed=15)
+    bias_init = onnx.numpy_helper.from_array(
+        np.zeros((1,), dtype=np.float32), "BadBias"
+    )
+    model.graph.initializer.append(bias_init)
+    node = _mha_node(model)
+    node.input.extend(["BadBias"])
+
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    node = _mha_node(pruned)
+    assert _mha_num_heads(node) == cfg["H"]  # left completely untouched
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["Wq"], cfg["wq"])
+
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_attention_head_pruning, sparsity=0.5
+    )
+    # `_node_label` falls back to the node's own first output name when it
+    # has no explicit `.name` (the parser text format never sets one) --
+    # "ctx" here, `_mha_model`'s own output name for its `MultiHeadAttention`
+    # node.
+    assert report.not_eligible == ["MultiHeadAttention 'ctx'"]
+
+
+def test_mha_pruning_attention_bias_is_sliced_and_matches_oracle():
+    H, D = 4, 4
+    seq = 5
+    rng = np.random.default_rng(16)
+    attention_bias = rng.standard_normal((1, H, seq, seq)).astype(np.float32)
+    model, cfg = _mha_model(
+        K=8, H=H, D=D, Out=6, seed=16, seq=seq, attention_bias=attention_bias
+    )
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    node = _mha_node(pruned)
+    num_heads = _mha_num_heads(node)
+    keep_heads = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], H, H, D, num_heads
+    )
+    idx = _head_idx(keep_heads, D)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["AttentionBias"], attention_bias[:, keep_heads])
+
+    oracle, _ = _mha_model(
+        K=cfg["K"],
+        H=len(keep_heads),
+        D=D,
+        Out=cfg["Out"],
+        seed=16,
+        seq=seq,
+        attention_bias=attention_bias[:, keep_heads],
+        wq=cfg["wq"][:, idx],
+        wk=cfg["wk"][:, idx],
+        wv=cfg["wv"][:, idx],
+        wout=cfg["wout"][idx, :],
+        batch=cfg["batch"],
+    )
+    rng2 = np.random.default_rng(17)
+    x = rng2.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_mha_pruning_nonempty_past_kv_constant_matches_oracle_exactly():
+    model, cfg = _mha_model(K=8, H=4, D=4, Out=6, seed=18, past_kv="nonempty")
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    node = _mha_node(pruned)
+    num_heads = _mha_num_heads(node)
+    d = cfg["D"]
+    keep_heads = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], cfg["H"], cfg["H"], d, num_heads
+    )
+    idx = _head_idx(keep_heads, d)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["PastKey"], cfg["past_key"][:, keep_heads])
+    np.testing.assert_array_equal(inits["PastValue"], cfg["past_value"][:, keep_heads])
+
+    oracle, _ = _mha_model(
+        K=cfg["K"],
+        H=len(keep_heads),
+        D=d,
+        Out=cfg["Out"],
+        seed=18,
+        past_kv="nonempty",
+        past_key=cfg["past_key"][:, keep_heads],
+        past_value=cfg["past_value"][:, keep_heads],
+        wq=cfg["wq"][:, idx],
+        wk=cfg["wk"][:, idx],
+        wv=cfg["wv"][:, idx],
+        wout=cfg["wout"][idx, :],
+        batch=cfg["batch"],
+        seq=cfg["seq"],
+    )
+    rng = np.random.default_rng(19)
+    x = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_mha_pruning_diff_v_head_size_matches_oracle_exactly():
+    # V's own head_size (Dv) genuinely differs from Q/K's shared one (D) --
+    # a shape this op's schema allows (confirmed empirically, see
+    # onnxsim/pruning.py's own "Attention-head pruning" section comment) but
+    # `GroupQueryAttention` never produces.
+    model, cfg = _mha_model(K=8, H=4, D=4, Dv=6, Out=6, seed=20)
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    node = _mha_node(pruned)
+    num_heads = _mha_num_heads(node)
+    d, dv = cfg["D"], cfg["Dv"]
+    keep_heads = _oracle_keep_groups(
+        cfg["wq"],
+        cfg["wk"],
+        cfg["wv"],
+        cfg["H"],
+        cfg["H"],
+        d,
+        num_heads,
+        v_head_size=dv,
+    )
+    q_idx = _head_idx(keep_heads, d)
+    v_idx = _head_idx(keep_heads, dv)
+
+    oracle, _ = _mha_model(
+        K=cfg["K"],
+        H=len(keep_heads),
+        D=d,
+        Dv=dv,
+        Out=cfg["Out"],
+        seed=20,
+        wq=cfg["wq"][:, q_idx],
+        wk=cfg["wk"][:, q_idx],
+        wv=cfg["wv"][:, v_idx],
+        wout=cfg["wout"][v_idx, :],
+        batch=cfg["batch"],
+        seq=cfg["seq"],
+    )
+    rng = np.random.default_rng(21)
+    x = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_mha_pruning_packed_qkv_query_input_is_declined():
+    # This op's own alternate "packed QKV" calling convention -- `query`
+    # alone carrying a packed, rank-5 tensor, `key`/`value` left empty -- is
+    # a different tensor layout this pass doesn't attempt to slice (the same
+    # schema-level convention `GroupQueryAttention` itself declines -- see
+    # `_match_gqa_producer`'s own docstring). Structural-only: `key`/`value`
+    # genuinely absent is enough to decline the match, regardless of
+    # whether `query` is actually packed-shaped.
+    H, D = 4, 4
+    K = H * D
+    batch, seq = 2, 5
+    rng = np.random.default_rng(22)
+    wq = rng.standard_normal((K, K)).astype(np.float32)
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17, "com.microsoft": 1]
+        >
+        g (float[{batch},{seq},{K}] X) => (float[{batch},{seq},{K}] Y)
+        {{
+          q = MatMul(X, Wq)
+          ctx = com.microsoft.MultiHeadAttention <num_heads={H}> (q)
+          Y = Identity(ctx)
+        }}
+        """
+    )
+    model.graph.initializer.append(_f32(wq, "Wq"))
+
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_attention_head_pruning, sparsity=0.5
+    )
+    assert report.not_eligible == ["MultiHeadAttention 'ctx'"]
+
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    node = _mha_node(pruned)
+    assert _mha_num_heads(node) == H  # left completely untouched
+
+
+# --- apply_attention_head_pruning / _wanda_pruning -- MultiHeadAttention,
+# cross-attention (Q and K/V from genuinely different source tensors, at
+# genuinely different sequence lengths) --------------------------------
+#
+# Confirmed empirically (see onnxsim/pruning.py's own "Attention-head
+# pruning" section comment): unlike `GroupQueryAttention`'s own onnxruntime
+# CPU-kernel restriction (equal Q/K-V sequence length unless a non-empty
+# past_key/past_value is also supplied), `MultiHeadAttention` has no such
+# restriction -- `seq_q`/`seq_kv` genuinely differ below, exactly like the
+# plain ai.onnx Attention op's own cross-attention section.
+
+
+def _mha_cross_model(
+    K_dec=8,
+    K_enc=6,
+    H=4,
+    D=4,
+    Out=6,
+    seed=0,
+    batch=2,
+    seq_q=5,
+    seq_kv=7,
+    wq=None,
+    wk=None,
+    wv=None,
+    wout=None,
+):
+    rng = np.random.default_rng(seed)
+    Nq = H * D
+    if wq is None:
+        wq = rng.standard_normal((K_dec, Nq)).astype(np.float32)
+    if wk is None:
+        wk = rng.standard_normal((K_enc, Nq)).astype(np.float32)
+    if wv is None:
+        wv = rng.standard_normal((K_enc, Nq)).astype(np.float32)
+    if wout is None:
+        wout = rng.standard_normal((Nq, Out)).astype(np.float32)
+
+    initializer = [_f32(wq, "Wq"), _f32(wk, "Wk"), _f32(wv, "Wv"), _f32(wout, "Wout")]
+
+    body = f"""
+        g (float[{batch},{seq_q},{K_dec}] Xdec, float[{batch},{seq_kv},{K_enc}] Xenc) => (float[{batch},{seq_q},{Out}] Y)
+        {{
+          q = MatMul(Xdec, Wq)
+          k = MatMul(Xenc, Wk)
+          v = MatMul(Xenc, Wv)
+          ctx = com.microsoft.MultiHeadAttention <num_heads={H}> (q, k, v)
+          Y = MatMul(ctx, Wout)
+        }}
+        """
+
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17, "com.microsoft": 1]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model, dict(
+        K_dec=K_dec,
+        K_enc=K_enc,
+        H=H,
+        D=D,
+        Out=Out,
+        Nq=Nq,
+        wq=wq,
+        wk=wk,
+        wv=wv,
+        wout=wout,
+        batch=batch,
+        seq_q=seq_q,
+        seq_kv=seq_kv,
+    )
+
+
+def test_mha_pruning_cross_attention_matches_oracle_exactly():
+    # Q's own producer weight (`K_dec` rows) and K/V's own (`K_enc` rows)
+    # have genuinely different row counts here -- `_oracle_keep_groups_cross`
+    # (sqrt(sum of squared per-block norms), not concatenate-then-norm) is
+    # required for exactly the reason `_gqa_group_importance`'s own updated
+    # comment in onnxsim/pruning.py explains.
+    model, cfg = _mha_cross_model(K_dec=8, K_enc=6, H=8, D=4, Out=6, seed=26)
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    node = _mha_node(pruned)
+    num_heads = _mha_num_heads(node)
+    d = cfg["D"]
+    keep_heads = _oracle_keep_groups_cross(
+        cfg["wq"], cfg["wk"], cfg["wv"], cfg["H"], cfg["H"], d, num_heads
+    )
+    idx = _head_idx(keep_heads, d)
+
+    oracle, _ = _mha_cross_model(
+        K_dec=cfg["K_dec"],
+        K_enc=cfg["K_enc"],
+        H=len(keep_heads),
+        D=d,
+        Out=cfg["Out"],
+        seed=26,
+        wq=cfg["wq"][:, idx],
+        wk=cfg["wk"][:, idx],
+        wv=cfg["wv"][:, idx],
+        wout=cfg["wout"][idx, :],
+        batch=cfg["batch"],
+        seq_q=cfg["seq_q"],
+        seq_kv=cfg["seq_kv"],
+    )
+
+    rng = np.random.default_rng(27)
+    xdec = rng.standard_normal((cfg["batch"], cfg["seq_q"], cfg["K_dec"])).astype(
+        np.float32
+    )
+    xenc = rng.standard_normal((cfg["batch"], cfg["seq_kv"], cfg["K_enc"])).astype(
+        np.float32
+    )
+    (y_pruned,) = _run(pruned, {"Xdec": xdec, "Xenc": xenc})
+    (y_oracle,) = _run(oracle, {"Xdec": xdec, "Xenc": xenc})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+    # Sanity: Q and K/V really are independently sourced, at genuinely
+    # different sequence lengths -- perturbing Xenc alone (Xdec held fixed)
+    # must still change the output.
+    (y_pruned2,) = _run(pruned, {"Xdec": xdec, "Xenc": xenc + 1.0})
+    assert not np.allclose(y_pruned, y_pruned2)
+
+
+def test_mha_wanda_pruning_matches_oracle_exactly():
+    model, cfg = _mha_model(K=8, H=8, D=4, Out=6, seed=28, combined_bias=True)
+
+    rng = np.random.default_rng(29)
+    x_cal = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    calibration_data = [{"X": x_cal}]
+
+    pruned = onnxsim.apply_attention_head_wanda_pruning(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned)
+
+    probe_model = onnx.ModelProto()
+    probe_model.CopyFrom(model)
+    probe_model.graph.output.append(onnx.ValueInfoProto(name="ctx"))
+    (_, ctx_cal) = _run(probe_model, {"X": x_cal})
+    act_norm = np.sqrt(np.mean(np.square(ctx_cal.astype(np.float64)), axis=(0, 1)))
+
+    d = cfg["D"]
+    importance = np.zeros(cfg["H"])
+    for h in range(cfg["H"]):
+        block = np.concatenate(
+            [
+                cfg["wq"][:, h * d : (h + 1) * d],
+                cfg["wk"][:, h * d : (h + 1) * d],
+                cfg["wv"][:, h * d : (h + 1) * d],
+            ],
+            axis=1,
+        )
+        base = np.linalg.norm(block)
+        act_head = np.linalg.norm(act_norm[h * d : (h + 1) * d])
+        importance[h] = base * max(act_head, 1e-8)
+    keep_heads = np.sort(np.argsort(-importance)[:4])  # max(1, 8 - round(8*0.5))
+    idx = _head_idx(keep_heads, d)
+
+    oracle, _ = _mha_model(
+        K=cfg["K"],
+        H=len(keep_heads),
+        D=d,
+        Out=cfg["Out"],
+        seed=28,
+        combined_bias=True,
+        wq=cfg["wq"][:, idx],
+        wk=cfg["wk"][:, idx],
+        wv=cfg["wv"][:, idx],
+        bq=cfg["bq"][idx],
+        bk=cfg["bk"][idx],
+        bv=cfg["bv"][idx],
+        wout=cfg["wout"][idx, :],
+        batch=cfg["batch"],
+        seq=cfg["seq"],
+    )
+
+    rng2 = np.random.default_rng(30)
+    x = rng2.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
 def test_attention_head_pruning_handles_all_three_attention_op_types_in_one_model():
     # Regression check for `_apply_attention_chains`'s per-chain-type
     # dispatch once a third node type shares it: a plain
@@ -17132,6 +17820,60 @@ def test_analyze_attention_head_wanda_pruning_gqa_matches_real_call():
     assert dims_after["Wq"][1] == kept_groups * group_size * D
     assert dims_after["Wk"][1] == kept_groups * D
     assert dims_after["Wv"][1] == kept_groups * D
+
+
+def test_analyze_attention_head_pruning_mha_matches_real_call():
+    H, D = 4, 8
+    model, info = _mha_model(H=H, D=D, seed=62)
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_attention_head_pruning, sparsity=0.5
+    )
+    assert len(report.layers) == 1
+    layer = report.layers[0]
+    # `MultiHeadAttention` has no separate `kv_num_heads` at all, so this
+    # dry-run mirror uses a distinct family string from genuine
+    # `GroupQueryAttention` KV-group pruning -- see
+    # :func:`onnxsim.pruning._analyze_attention_chains`'s own comment.
+    assert layer.family == "attention_mha_head"
+    assert layer.total == H
+    assert report.not_eligible == []
+
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    dims_after = _initializer_dims(pruned)
+    kept = H - layer.would_drop
+    assert dims_after["Wq"][1] == kept * D
+    assert dims_after["Wk"][1] == kept * D
+    assert dims_after["Wv"][1] == kept * D
+
+
+def test_analyze_attention_head_wanda_pruning_mha_matches_real_call():
+    H, D = 4, 8
+    model, info = _mha_model(H=H, D=D, seed=63)
+    rng = np.random.default_rng(64)
+    x_cal = rng.standard_normal((info["batch"], info["seq"], info["K"])).astype(
+        np.float32
+    )
+    calibration_data = [{"X": x_cal}]
+
+    report = onnxsim.analyze_pruning_sensitivity(
+        model,
+        onnxsim.apply_attention_head_wanda_pruning,
+        calibration_data=calibration_data,
+        sparsity=0.5,
+    )
+    assert len(report.layers) == 1
+    layer = report.layers[0]
+    assert layer.family == "attention_mha_head"
+    assert layer.total == H
+
+    pruned = onnxsim.apply_attention_head_wanda_pruning(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    dims_after = _initializer_dims(pruned)
+    kept = H - layer.would_drop
+    assert dims_after["Wq"][1] == kept * D
+    assert dims_after["Wk"][1] == kept * D
+    assert dims_after["Wv"][1] == kept * D
 
 
 def test_analyze_moe_expert_channel_pruning_matches_real_call():


### PR DESCRIPTION
## Summary

`apply_attention_head_pruning`/`apply_attention_head_wanda_pruning` previously recognized only `com.microsoft::Attention` (merged-QKV-weight) and `GroupQueryAttention`, plus the plain `ai.onnx::Attention` op. `com.microsoft::MultiHeadAttention` — a real, separate contrib op that takes already-separately-projected Q/K/V activation tensors (it owns no projection weight itself) — was unrecognized entirely. This is the op ONNX Runtime's own transformer graph-optimizer (`fusion_attention.py`) emits for BERT/ViT/CLIP/T5/Whisper-style encoder and cross-attention exports — common Hugging Face Optimum ORT-optimized model downloads — so head-pruning was completely unavailable for any model exported/optimized this way.

## Empirically confirmed facts (live `onnxruntime` 1.29.0 schema + real `InferenceSession` runs)

- Schema (via `get_all_operator_schema()`): inputs `query, key, value, bias?, key_padding_mask?, attention_bias?, past_key?, past_value?, past_sequence_length?, cache_indirection?`; one attribute, `num_heads` — no `kv_num_heads` (no GQA/MQA support on this op, corroborated by this repo's own `fuse_gqa.h` comment).
- The realistic export (matching ONNX Runtime's own `fusion_attention.AttentionFusion.create_multihead_attention_node`, what HF Optimum's ORT optimizer runs) feeds Q/K/V straight from their own `MatMul`'s raw output and folds all three per-producer biases into one combined `[nq+nk+nv]`-shaped tensor on this op's own `bias` input.
- A minimal self-attention graph matched a numpy oracle to `1.3e-8`; the same graph pruned 4→3 heads (weights/bias/output-projection sliced per-head, combined bias sliced in three head-aligned ranges) matched a pruned-from-scratch numpy oracle to `1.1e-8`/`8.7e-9`. Independently re-verified during review with a fresh from-scratch numpy attention oracle: `9.2e-8` max-abs-diff.
- `attention_bias` has a real, isolated per-head effect (confirmed: perturbing one head's slice changed only that head's output). `past_key`/`past_value` follow the same BNSH layout as `GroupQueryAttention`.
- **Cross-attention is in scope** — unlike `GroupQueryAttention`'s onnxruntime-kernel same-sequence-length restriction, `MultiHeadAttention` places no such restriction (confirmed: different Q/K-V sources, different sequence lengths, `1.3e-8` agreement) — and is tested.

## What's added

Since `MultiHeadAttention` has one shared `num_heads` (no `kv_num_heads`), it reuses `GroupQueryAttention`'s/plain `Attention`'s existing `_GQAChain`/`_find_separate_qkv_chains`/`_apply_one_gqa_chain` machinery outright — feeding `num_heads` as both fields collapses "KV group" pruning to ordinary per-head pruning for free. The one new matcher is `_match_multi_head_attention_producer`; the one new concept is the combined bias (`_GQAChain.mha_bias`, a `combined_bias_input_index` parameter validating the `[nq+nk+nv]` shape and slicing it via the same three-range column-index trick the packed-QKV weight branch already used). Wired into both `apply_attention_head_pruning`/`apply_attention_head_wanda_pruning` and both `_analyze_*` dry-run mirrors; new `"attention_mha_head"` sensitivity family.

## Test plan
- [x] `pytest tests/test_pruning.py -q` — 495 passed (was 481 before this change)
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — 0 new errors vs. master's baseline
- [x] Self-attention and cross-attention oracle-exact correctness (shrink + no-op)
- [x] Combined-bias and per-producer-bias slicing, malformed-combined-bias decline
- [x] `attention_bias`/`past_key`/`past_value` slicing, differing V head_size
- [x] Schema-level packed-QKV-input decline, Wanda-calibrated variant, dry-run-vs-real-call cross-checks

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_