### PR TITLE
Prune fused MatMulNBitsMlp/MatMulNBitsQkv nodes (ORT WebGPU-EP fusions)

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -9595,6 +9595,70 @@ def apply_structured_pruning_qdq(
 #     apply when the consumer side of a mixed chain is the plain-float one
 #     -- the producer's own keep-set (whatever it is) applies directly, the
 #     same as any other plain-float consumer elsewhere in this module.
+#
+# ``MatMulNBitsMlp``/``MatMulNBitsQkv`` -- ORT's own graph-optimizer fusions of
+# a same-input gate/up ``MatMulNBits`` pair, or a shared-input/shared-norm
+# Q/K/V ``MatMulNBits`` triple, into one node each -- are matched as
+# ADDITIONAL producer shapes below (:func:`_match_matmul_nbits_mlp`/
+# :func:`_match_matmul_nbits_qkv` and the dedicated
+# :func:`_apply_matmul_nbits_mlp_chains`/:func:`_apply_matmul_nbits_qkv_chains`
+# passes :func:`apply_structured_pruning_matmul_nbits` also runs), not folded
+# into :func:`_match_matmul_nbits`/:func:`_find_matmul_nbits_chains` itself --
+# a fused node owns TWO or THREE independent weight pairs, not the one
+# producer/consumer pair that abstraction assumes, so it needed its own
+# matcher/apply pair, sharing this section's own low-level helpers
+# (:func:`_unpack_nbits_codes`/:func:`_pack_nbits_codes`,
+# :func:`_matmul_nbits_dequantized`, :func:`_matmul_nbits_block_aligned_keep_blocks`,
+# :func:`_slice_matmul_nbits_consumer_blocks`, :func:`_walk_to_matmul_nbits_consumer`)
+# rather than reusing :class:`_MatMulNBitsWeight`'s own single-producer shape
+# directly. Full empirical/schema details, and the exact scope this covers
+# and declines, live in the section comment directly above the two matchers
+# themselves (search this file for "MatMulNBitsMlp/MatMulNBitsQkv (fused
+# block-quantized weight) structured pruning" -- placed after this module's
+# own "Attention-head pruning" section since ``MatMulNBitsQkv``'s own
+# pruning unit, per-KV-group, directly reuses that section's
+# :func:`_match_gqa_producer`/:func:`_match_onnx_attention_producer`/
+# :func:`_gqa_group_importance`-style machinery). The one fact worth
+# surfacing here, at the top of this whole ``MatMulNBits`` family: **both
+# fused ops are WebGPU-execution-provider-specific.** Confirmed directly off
+# this environment's installed ``onnxruntime`` (1.29.0) shared library
+# (``strings`` on ``onnxruntime_pybind11_state...so``, not merely inferred
+# from the schema doc's own "...supported by the WebGPU kernel" wording):
+# the fusion pass's own log strings read ``"MatMulNBitsMlpFusion: skipping
+# candidate due to non-WebGPU EP assignment."`` -- i.e. ORT's graph optimizer
+# only ever performs this fusion when the *target* execution provider is
+# WebGPU, not unconditionally for every quantized export the way the plain
+# ``MatMulNBits`` quantization itself is. A model actually *containing*
+# either fused node on disk is still a completely real, valid artifact (an
+# ``InferenceSession.optimized_model_filepath`` save with the WebGPU EP
+# selected, or any other tool/version that performs the same fusion), and
+# this section's matching/slicing logic depends on nothing WebGPU-specific
+# -- it only reads the same constant tensors/attributes the live schema
+# documents. But it does mean this environment (no GPU, no WebGPU adapter --
+# confirmed by actually requesting one: ``Failed to get a WebGPU adapter: No
+# supported adapters``, both via the system `onnxruntime` install and a
+# separately-installed `onnxruntime-webgpu` 1.27.0 wheel, tried specifically
+# to check) cannot execute either fused node end to end via a real
+# ``InferenceSession`` the way this section's *plain* ``MatMulNBits`` tests
+# do -- so this section's own new tests instead decompose a (pruned) fused
+# node's own weight tensors back into equivalent standalone
+# ``MatMulNBits``/``SimplifiedLayerNormalization`` nodes and run THOSE
+# through a real CPU-kernel ``InferenceSession`` (both of which this
+# environment's CPU EP genuinely implements) against a numpy oracle -- the
+# same underlying tensors and packing this section's slicing code actually
+# touches, just exercised through an executable proxy topology rather than
+# the literal fused op. See ``tests/test_pruning.py``'s own
+# ``test_matmul_nbits_mlp_pruning_matches_decomposed_oracle`` and
+# ``test_matmul_nbits_qkv_pruning_matches_decomposed_oracle`` for exactly
+# this methodology, and this section's own top-of-file empirical notes on
+# ``B``/``scales``/``bias`` packing (reused verbatim here, unchanged) for
+# why that decomposition is a faithful proxy and not a guess: both fused
+# ops' own live schemas type every weight/scale/bias input identically to
+# plain ``MatMulNBits``'s own ``B``/``scales``/``bias`` (same ``T1``/``T2``
+# type constraints, same per-input doc wording -- "Packed uint8 tensor for
+# the <branch> projection weights", etc.), and both ops' own doc strings
+# write their fused arithmetic as literal, unmodified ``MatMulNBits(...)``
+# calls, not merely an informally similar computation.
 
 
 def _matmul_nbits_int_attr(
@@ -9966,6 +10030,46 @@ def _slice_matmul_nbits_consumer_blocks(
     _set_matmul_nbits_int_attr(w.node, "K", len(keep_blocks) * w.block_size)
 
 
+def _slice_matmul_nbits_rows_no_zp(
+    b_init: onnx.TensorProto,
+    scales_init: onnx.TensorProto,
+    bias_init: Optional[onnx.TensorProto],
+    keep: np.ndarray,
+) -> None:
+    """Row-slices (``N`` axis) `b_init`/`scales_init`/`bias_init` in place --
+    the ``zero_points``-free analogue of
+    :func:`_slice_matmul_nbits_producer_rows`, for one branch of a matched
+    ``MatMulNBitsMlp``/``MatMulNBitsQkv`` node: neither fused op's schema
+    has a ``zero_points`` input at all (confirmed via live schema
+    introspection -- see the "MatMulNBitsMlp/MatMulNBitsQkv (fused
+    block-quantized weight) structured pruning" section comment), so every
+    weight slot on both is implicitly the schema's own default zero point,
+    with nothing packed on this axis for :func:`_unpack_nbits_codes`/
+    :func:`_pack_nbits_codes` to touch at all (contrast
+    :func:`_slice_matmul_nbits_producer_rows`, which must handle a
+    *possibly* packed ``zero_points``). Unlike that function, this one
+    never updates any node attribute itself: a fused node's own N-sized
+    attribute is either shared by more than one branch (``MatMulNBitsMlp``'s
+    single ``N``, sized once per branch call -- harmlessly redundant, same
+    value both times) or not literally named ``"N"`` at all
+    (``MatMulNBitsQkv``'s own ``Nq``/``Nkv``), so naming the right one is
+    left to the caller.
+    """
+    b = onnx.numpy_helper.to_array(b_init)
+    b_init.CopyFrom(onnx.numpy_helper.from_array(b[keep], name=b_init.name))
+
+    scales = onnx.numpy_helper.to_array(scales_init)
+    scales_init.CopyFrom(
+        onnx.numpy_helper.from_array(scales[keep], name=scales_init.name)
+    )
+
+    if bias_init is not None:
+        bias = onnx.numpy_helper.to_array(bias_init)
+        bias_init.CopyFrom(
+            onnx.numpy_helper.from_array(bias[keep], name=bias_init.name)
+        )
+
+
 @dataclass(frozen=True)
 class _PlainMatMulNBitsPeer:
     """A plain-float ``MatMul``/vanilla-``Gemm`` node's own weight, matched
@@ -10283,6 +10387,46 @@ def apply_structured_pruning_matmul_nbits(
     gated/residual/Concat-merge topology, a padded partial final block
     declined, a shared/tied operand declined.
 
+    ALSO prunes two ``com.microsoft`` fusions of ``MatMulNBits`` itself --
+    ORT's own WebGPU-EP-targeted graph optimizer routinely emits both for a
+    quantized LLM export, silently defeating the plain ``MatMulNBits``
+    matching above entirely if left unhandled (see the "MatMulNBitsMlp/
+    MatMulNBitsQkv (fused block-quantized weight) structured pruning"
+    section comment for the full empirical schema investigation, scope, and
+    limitations):
+
+    * ``MatMulNBitsMlp`` (a fused ``gate``/``up`` SwiGLU/GeGLU-style MLP
+      pair sharing one input and one output-channel count): co-slices
+      ``gate``'s and ``up``'s own shared output-channel axis to one shared
+      keep-set (:func:`_match_matmul_nbits_mlp`/
+      :func:`_apply_matmul_nbits_mlp_chains`, ranked by
+      :func:`_matmul_nbits_mlp_gated_importance` -- the block-quantized
+      analogue of this module's own plain-float gated-pair criterion), then
+      slices whichever ``MatMulNBits``-or-plain-float node consumes its
+      output the same way the plain single-producer chain above does
+      (:func:`_walk_to_matmul_nbits_consumer`, reused verbatim).
+    * ``MatMulNBitsQkv`` (a fused, shared-input/shared-norm Q/K/V
+      projection triple): prunes whole KV groups
+      (:func:`_match_matmul_nbits_qkv`/:func:`_apply_matmul_nbits_qkv_chains`,
+      ranked by :func:`_matmul_nbits_qkv_group_importance`), reusing this
+      module's own GQA/packed-QKV attention-head-pruning matchers
+      (:func:`_match_gqa_producer`/:func:`_match_onnx_attention_producer`)
+      to find and validate the downstream ``GroupQueryAttention``/plain
+      ``ai.onnx::Attention`` consumer those Q/K/V outputs must feed
+      directly (no per-head Q/K-norm + RoPE pass-through hop -- see that
+      section comment for exactly why this is a deliberate, documented
+      scope boundary), and this module's own attention-chain bookkeeping
+      for that consumer's own optional per-head operands (`past_key`/
+      `past_value`, `k_scale`/`v_scale`, `attention_bias`/`attn_mask`,
+      `head_sink`).
+
+    Both fused ops' own ``skip``/``norm_scale`` inputs (an optionally-fused
+    ``(Skip)SimplifiedLayerNormalization`` preceding the projection(s)) are
+    read but never themselves re-sliced: this whole function only ever
+    prunes OUTPUT-channel axes, never the shared INPUT (``K``/hidden-size)
+    axis those two operands would need re-slicing for -- a real, documented
+    limitation (see that section comment), not an oversight.
+
     :param model: onnx ModelProto object or file path
     :param sparsity: fraction of each eligible producer's output channels to
             drop (rounded, at least one channel is always kept)
@@ -10300,7 +10444,9 @@ def apply_structured_pruning_matmul_nbits(
     graph = out.graph
 
     chains = _find_matmul_nbits_chains(graph)
-    if not chains:
+    mlp_chains = _find_matmul_nbits_mlp_chains(graph)
+    qkv_chains = _find_matmul_nbits_qkv_chains(graph)
+    if not chains and not mlp_chains and not qkv_chains:
         return out
 
     producer_touched: Set[str] = set()
@@ -10357,6 +10503,25 @@ def apply_structured_pruning_matmul_nbits(
         consumer_touched.add(c_key)
         stale_value_info.add(p.node.output[0])
         stale_value_info.update(op.output[0] for op in chain.chain_ops)
+
+    _apply_matmul_nbits_mlp_chains(
+        graph,
+        mlp_chains,
+        sparsity,
+        importance_norm,
+        producer_touched,
+        consumer_touched,
+        stale_value_info,
+    )
+    _apply_matmul_nbits_qkv_chains(
+        graph,
+        qkv_chains,
+        sparsity,
+        importance_norm,
+        producer_touched,
+        consumer_touched,
+        stale_value_info,
+    )
 
     if stale_value_info:
         kept = [vi for vi in graph.value_info if vi.name not in stale_value_info]
@@ -12775,6 +12940,984 @@ def apply_attention_head_wanda_pruning(
         _wanda_gqa_group_importance,
     )
     return out
+
+
+# --- MatMulNBitsMlp/MatMulNBitsQkv (fused block-quantized weight) structured
+#     pruning ----------------------------------------------------------------
+#
+# ``com.microsoft::MatMulNBitsMlp``/``com.microsoft::MatMulNBitsQkv`` are two
+# more fusions ONNX Runtime's own graph optimizer performs on top of plain
+# ``MatMulNBits`` (see this module's "MatMulNBits (block-quantized weight)
+# structured pruning" section comment for that op's own full empirical
+# investigation, reused verbatim below): ``MatMulNBitsMlp`` fuses a
+# same-input ``gate``/``up`` ``MatMulNBits`` pair (the SwiGLU/GeGLU-style
+# gated-MLP shape :func:`_find_gated_chains` already handles for plain-float
+# weights) into one node; ``MatMulNBitsQkv`` fuses a shared-input,
+# shared-norm Q/K/V ``MatMulNBits`` triple (the packed/separate-QKV shape
+# :func:`_find_separate_qkv_chains` already handles for plain-float/mixed
+# weights) into one node. Once ORT's optimizer performs either fusion, the
+# plain :func:`_match_matmul_nbits` matcher above simply never sees a
+# standalone ``MatMulNBits`` node for that block at all -- silently turning
+# :func:`apply_structured_pruning_matmul_nbits` into a no-op for it, not
+# merely a missed optimization. This section closes that gap.
+#
+# Every schema fact below was confirmed empirically against this
+# environment's live ``onnxruntime`` (1.29.0) install, the same way this
+# module's own "MatMulNBits" section comment already established for plain
+# ``MatMulNBits`` -- via
+# ``onnxruntime.capi.onnxruntime_pybind11_state.get_all_operator_schema()``
+# for both fused ops' full input/output/attribute lists, not guessed by
+# extrapolating from the plain op's own schema:
+#
+#   * ``MatMulNBitsMlp`` inputs, in order: ``A`` (T1, unquantized), ``skip``
+#     (optional, T1 -- an ``Add``-style residual input to an optionally
+#     fused ``(Skip)SimplifiedLayerNormalization`` preceding both
+#     projections), ``norm_scale`` (**optional** here -- confirmed via the
+#     live schema's own ``FormalParameterOption``, T1, shape ``[K]``),
+#     ``gate_B``/``gate_scales``/``gate_bias`` (T2/T1/T1 optional, exactly
+#     ``MatMulNBits``'s own ``B``/``scales``/``bias`` typing and per-input
+#     doc wording), then ``up_B``/``up_scales``/``up_bias`` the same shape.
+#     Outputs: ``Y`` (T1, the fused ``activation(gate) * up`` result), plus
+#     an optional ``input_skip_bias_sum`` (the ``SkipSimplifiedLayerNormalization``
+#     residual sum, when fused). Attributes: ``activation`` (required
+#     string -- this section never inspects its *value*, see below),
+#     ``block_size``/``K``/``N`` (required ints, ``N``/``K`` SHARED by both
+#     branches -- unlike plain ``MatMulNBits``, there is exactly one ``N``
+#     attribute for two weight pairs), ``bits`` (optional, default 4, same
+#     schema-serialized default as plain ``MatMulNBits``), ``accuracy_level``/
+#     ``epsilon`` (ignored -- the latter only matters for the optional fused
+#     norm, which this section never touches, see below). **No
+#     ``zero_points`` input at all**, on either branch -- a real finding,
+#     not an omission: the plain op's own 4th input slot simply has no
+#     analogue here, so every weight slot implicitly uses the schema's own
+#     documented default zero point (``2 ** (bits - 1)``) unconditionally.
+#   * ``MatMulNBitsQkv`` inputs, in order: ``A``, ``skip`` (optional),
+#     ``norm_scale`` (**required** here -- unlike ``MatMulNBitsMlp``'s own
+#     optional one, confirmed the same way: this op always applies
+#     ``(Skip)SimplifiedLayerNormalization`` to ``A`` before every
+#     projection, per its own doc string's fused-arithmetic formula), then
+#     ``q_B``/``q_scales``/``q_bias``, ``k_B``/``k_scales``/``k_bias``,
+#     ``v_B``/``v_scales``/``v_bias`` (each the same T2/T1/T1-optional
+#     typing as ``MatMulNBits``'s own operands). Outputs: ``Q``/``K``/``V``
+#     (T1 each), plus an optional ``input_skip_bias_sum``. Attributes:
+#     ``block_size``/``K`` (shared reduction dim for every branch),
+#     ``Nq``/``Nkv`` (``Nkv`` SHARED by K and V -- there is no independent
+#     ``Nv``, confirmed via the live schema, so K's and V's own per-head
+#     width are always identical by construction, never independently
+#     specifiable the way a plain ``ai.onnx::Attention`` chain's own
+#     `v_head_size` can be, see :func:`_find_matmul_nbits_qkv_chains`),
+#     ``bits`` (optional, default 4), ``epsilon`` (the fused norm's own
+#     epsilon), ``accuracy_level`` (ignored). Also **no ``zero_points``
+#     input** on any of the three branches -- confirmed the same way.
+#   * Neither fused op carries ``num_heads``/``kv_num_heads``/head-count
+#     metadata of its own AT ALL -- a real, load-bearing finding: this
+#     section cannot determine per-head/per-KV-group structure from either
+#     matched node in isolation. `MatMulNBitsQkv`'s own per-KV-group
+#     pruning unit is therefore only reachable by finding the REAL
+#     downstream consumer that DOES carry that metadata -- a
+#     ``GroupQueryAttention``/plain ``ai.onnx::Attention`` node whose own
+#     query/key/value inputs are fed directly by this node's own
+#     `Q`/`K`/`V` outputs -- and reusing that consumer's own already-proven
+#     matchers (:func:`_match_gqa_producer`/:func:`_match_onnx_attention_producer`)
+#     rather than re-deriving head counts from scratch. ``MatMulNBitsMlp``
+#     needs no such consumer lookup for its own pruning unit (whole output
+#     channels, ranked the same "gated pair" way this module's own
+#     plain-float SwiGLU/GeGLU precedent already uses), but still needs one
+#     to find and slice whichever downstream node consumes ITS OWN output
+#     (see below).
+#   * **Both fusions are WebGPU-execution-provider-specific** -- this is the
+#     single most important empirical finding for this section, and is
+#     documented at length, with the exact confirmation method and the
+#     resulting testing-methodology consequence, at the top of this
+#     module's own "MatMulNBits (block-quantized weight) structured
+#     pruning" section comment (search this file for
+#     "MatMulNBitsMlpFusion: skipping candidate"). In short: neither fused
+#     node can be executed end to end via a real ``InferenceSession`` in
+#     this (GPU-less) environment, so this section's own new tests instead
+#     decompose a (pruned) fused node's own tensors back into equivalent
+#     standalone ``MatMulNBits``/``SimplifiedLayerNormalization`` nodes and
+#     run THOSE through a real CPU-kernel ``InferenceSession`` against a
+#     numpy oracle -- the exact same underlying packed tensors this
+#     section's own slicing code touches, just exercised through an
+#     executable proxy topology. This does not weaken confidence in the
+#     SCHEMA facts above (read directly off the live schema registry,
+#     independent of which EP can execute the op) or the PACKING facts (this
+#     section reuses, unchanged, the plain ``MatMulNBits`` section's own
+#     packing investigation -- both fused ops' schemas type every weight/
+#     scale/bias operand identically, and both ops' own doc strings write
+#     their fused arithmetic as literal ``MatMulNBits(...)`` calls, not an
+#     informally similar computation) -- only the ability to exercise the
+#     literal fused node itself end to end in THIS sandbox.
+#
+# Scope boundaries this section lands on, deliberately, mirroring this
+# module's own conservative-decline posture everywhere else:
+#
+#   * ``activation`` (``MatMulNBitsMlp``'s own required string attribute) is
+#     never inspected or validated by this section at all -- and doesn't
+#     need to be: pruning ``gate``'s/``up``'s own shared OUTPUT-channel axis
+#     commutes with any per-element activation function applied afterward
+#     (dropping output channel `c` and then evaluating `activation` on the
+#     survivors is identical to evaluating `activation` on every channel and
+#     then dropping channel `c`, regardless of what `activation` computes),
+#     so this section carries the attribute through completely unchanged
+#     and never needs to know which function it names.
+#   * ``skip``/``norm_scale`` (on either fused op, when present) are read
+#     (to confirm they exist, where the schema requires it) but never
+#     themselves re-sliced: this section -- like the plain ``MatMulNBits``
+#     section above it -- only ever prunes OUTPUT-channel (``N``/``Nq``/
+#     ``Nkv``) axes, never the shared INPUT (``K``/hidden-size) axis
+#     ``norm_scale`` (and every branch's own reduction dimension) would need
+#     re-slicing for. A genuinely different pass would be needed to prune
+#     the transformer's own hidden/residual dimension through a fused
+#     ``(Skip)SimplifiedLayerNormalization`` this way -- out of scope here,
+#     same as it is for every other chain kind in this module (no existing
+#     pass in this file prunes the residual/hidden dimension of a
+#     ``MatMulNBits``-quantized transformer block at all, fused norm or
+#     not).
+#   * ``MatMulNBitsQkv``'s own Q/K-norm + RoPE pass-through hop -- the
+#     per-head ``SimplifiedLayerNorm``(+ optional ``RotaryEmbedding``)
+#     ``_find_separate_qkv_chains`` already recognizes between a plain-float
+#     packed-QKV-then-``Split`` producer and its own GQA consumer (see
+#     :func:`_walk_back_through_qk_norm_rope`) -- is NOT matched here: this
+#     node's own `Q`/`K` outputs must feed the attention consumer's own
+#     query/key inputs DIRECTLY (single consumer, no intervening node at
+#     all). A real export relying on that hop between a fused
+#     ``MatMulNBitsQkv`` node and its own attention consumer is declined
+#     here rather than mis-sliced -- a genuine, deliberate scope boundary
+#     this comment flags honestly rather than silently under-implementing.
+#   * The downstream output-projection consumer, for BOTH fused ops, is
+#     matched via the exact same ``MatMulNBits``-or-plain-float union the
+#     plain single-producer chain above already supports
+#     (:func:`_walk_to_matmul_nbits_consumer` for ``MatMulNBitsMlp``'s own
+#     `Y` output, reused verbatim; :func:`_walk_to_matmul_nbits_attention_consumer`
+#     for ``MatMulNBitsQkv``'s own attention-consumer output, the analogous
+#     new function this section adds since that consumer is never itself a
+#     ``MatMulNBits`` node) -- never a QDQ-quantized one, for the same
+#     out-of-scope reason the plain section above gives.
+#   * A shared/tied ``B``/``scales``/``bias`` tensor (read by more than one
+#     node), or two branches degenerately naming the exact same underlying
+#     weight tensor, are both declined by the matchers themselves, the same
+#     bar every matcher in this module is held to.
+#   * ``bits``/``block_size``/``K``-alignment restrictions are IDENTICAL to
+#     plain ``MatMulNBits`` (``bits in {4, 8}``, ``block_size`` a power of
+#     two ``>= 16``, ``K`` an exact multiple of `block_size`) -- reusing
+#     :func:`_matmul_nbits_int_attr`/:func:`_MATMUL_NBITS_VALID_BLOCK_SIZES`
+#     directly, not re-derived.
+
+
+@dataclass(frozen=True)
+class _MatMulNBitsMlpWeight:
+    """A matched ``com.microsoft::MatMulNBitsMlp`` node's two block-
+    quantized weight operands (``gate``/``up``), matched by
+    :func:`_match_matmul_nbits_mlp` -- see this section's own top comment
+    for the empirically-confirmed schema this depends on. Unlike
+    :class:`_MatMulNBitsWeight`, there is no ``zero_points`` field at all:
+    neither this op nor ``MatMulNBitsQkv`` has a ``zero_points`` input on
+    its live schema (confirmed via live schema introspection -- every
+    weight slot on both fused ops uses the schema's own implicit default
+    zero point, ``2 ** (bits - 1)``, unconditionally).
+    """
+
+    node: onnx.NodeProto
+    gate_b: onnx.TensorProto
+    gate_scales: onnx.TensorProto
+    gate_bias: Optional[onnx.TensorProto]
+    up_b: onnx.TensorProto
+    up_scales: onnx.TensorProto
+    up_bias: Optional[onnx.TensorProto]
+    N: int
+    K: int
+    bits: int
+    block_size: int
+    k_blocks: int
+
+
+def _match_matmul_nbits_mlp(
+    node: onnx.NodeProto,
+    initializer_map: Dict[str, onnx.TensorProto],
+    consumers_of: Dict[str, List[onnx.NodeProto]],
+) -> Optional[_MatMulNBitsMlpWeight]:
+    """If `node` is a ``com.microsoft::MatMulNBitsMlp`` node matching every
+    scope boundary this section's own top comment documents, returns the
+    match -- the fused-gated-MLP analogue of :func:`_match_matmul_nbits`.
+    `skip`/`norm_scale` (inputs 1/2), when present, are read but never
+    otherwise inspected: this matcher (and the pruning pass built on it)
+    only ever prunes `gate`'s/`up`'s own shared OUTPUT (`N`) axis, never
+    their shared INPUT (`K`) axis those two operands would need re-slicing
+    for -- see this section's own top comment for why that's a deliberate,
+    documented scope boundary rather than an oversight.
+    """
+    if node.op_type != "MatMulNBitsMlp" or node.domain != "com.microsoft":
+        return None
+    if len(node.input) < 8 or len(node.output) < 1:
+        return None
+    a_name = node.input[0]
+    gate_b_name, gate_scales_name = node.input[3], node.input[4]
+    gate_bias_name = node.input[5] if node.input[5] else None
+    up_b_name, up_scales_name = node.input[6], node.input[7]
+    up_bias_name = node.input[8] if len(node.input) > 8 and node.input[8] else None
+    if not (
+        a_name and gate_b_name and gate_scales_name and up_b_name and up_scales_name
+    ):
+        return None
+    if gate_b_name == up_b_name:
+        return None  # degenerate -- can't independently slice a shared weight
+
+    block_size = _matmul_nbits_int_attr(node, "block_size")
+    N = _matmul_nbits_int_attr(node, "N")
+    K = _matmul_nbits_int_attr(node, "K")
+    if block_size is None or N is None or K is None or N <= 0 or K <= 0:
+        return None
+    if block_size not in _MATMUL_NBITS_VALID_BLOCK_SIZES:
+        return None
+    if K % block_size != 0:
+        return None
+    bits = _matmul_nbits_int_attr(node, "bits", 4)
+    if bits not in (4, 8):
+        return None
+
+    k_blocks = K // block_size
+    blob_size = block_size * bits // 8
+
+    def _resolve_branch(
+        b_name: str, scales_name: str, bias_name: Optional[str]
+    ) -> Optional[
+        Tuple[onnx.TensorProto, onnx.TensorProto, Optional[onnx.TensorProto]]
+    ]:
+        b_init = initializer_map.get(b_name)
+        scales_init = initializer_map.get(scales_name)
+        if b_init is None or scales_init is None:
+            return None  # non-constant B/scales -- can't safely slice them
+        if b_init.data_type != onnx.TensorProto.UINT8:
+            return None
+        if list(b_init.dims) != [N, k_blocks, blob_size]:
+            return None
+        if scales_init.data_type not in (
+            onnx.TensorProto.FLOAT,
+            onnx.TensorProto.FLOAT16,
+            onnx.TensorProto.BFLOAT16,
+        ):
+            return None
+        if list(scales_init.dims) != [N, k_blocks]:
+            return None
+        bias_init = None
+        if bias_name is not None:
+            bias_init = initializer_map.get(bias_name)
+            if bias_init is None or bias_init.data_type != scales_init.data_type:
+                return None
+            if list(bias_init.dims) != [N]:
+                return None
+        for nm in (b_name, scales_name) + ((bias_name,) if bias_name else ()):
+            if len(consumers_of.get(nm, [])) != 1:
+                return None  # shared/tied tensor -- another node reads it too
+        return b_init, scales_init, bias_init
+
+    gate = _resolve_branch(gate_b_name, gate_scales_name, gate_bias_name)
+    if gate is None:
+        return None
+    up = _resolve_branch(up_b_name, up_scales_name, up_bias_name)
+    if up is None:
+        return None
+
+    return _MatMulNBitsMlpWeight(
+        node=node,
+        gate_b=gate[0],
+        gate_scales=gate[1],
+        gate_bias=gate[2],
+        up_b=up[0],
+        up_scales=up[1],
+        up_bias=up[2],
+        N=N,
+        K=K,
+        bits=bits,
+        block_size=block_size,
+        k_blocks=k_blocks,
+    )
+
+
+def _matmul_nbits_mlp_branch_weight(
+    p: _MatMulNBitsMlpWeight, branch: str
+) -> _MatMulNBitsWeight:
+    """Wraps one branch (`"gate"` or `"up"`) of a matched
+    :class:`_MatMulNBitsMlpWeight` as a synthetic :class:`_MatMulNBitsWeight`
+    -- purely so :func:`_matmul_nbits_dequantized` (IMPORTANCE RANKING ONLY,
+    never written back) can be reused verbatim rather than re-derived:
+    `zero_points_init` is always ``None`` here (neither branch has one, see
+    :class:`_MatMulNBitsMlpWeight`'s own docstring), which is exactly what
+    :func:`_matmul_nbits_dequantized` already needs to fall back to the
+    schema's own default zero point.
+    """
+    b, scales, bias = (
+        (p.gate_b, p.gate_scales, p.gate_bias)
+        if branch == "gate"
+        else (p.up_b, p.up_scales, p.up_bias)
+    )
+    return _MatMulNBitsWeight(
+        node=p.node,
+        b_init=b,
+        scales_init=scales,
+        zero_points_init=None,
+        zero_points_packed=False,
+        bias_init=bias,
+        N=p.N,
+        K=p.K,
+        bits=p.bits,
+        block_size=p.block_size,
+        k_blocks=p.k_blocks,
+    )
+
+
+def _matmul_nbits_mlp_gated_importance(
+    gate_nk: np.ndarray, up_nk: np.ndarray, importance_norm: str
+) -> np.ndarray:
+    """Combined per-output-channel importance of a matched
+    ``MatMulNBitsMlp`` node's `gate`/`up` branches -- the block-quantized
+    analogue of :func:`_plain_structured_importance`'s own gated-pair
+    combination (root-sum-square of the two branches' own L2 row norms for
+    ``"l2"``, plain sum of their L1 row norms for ``"l1"``), since `gate`
+    and `up` must always agree on one shared keep-set (``Y =
+    activation(gate) * up`` multiplies them elementwise, exactly the
+    plain-float SwiGLU/GeGLU precedent this fused op's own schema doc names
+    directly -- see :func:`_find_gated_chains`).
+    """
+    gate_imp = _qdq_channel_importance(gate_nk, importance_norm)
+    up_imp = _qdq_channel_importance(up_nk, importance_norm)
+    if importance_norm == "l1":
+        return gate_imp + up_imp
+    return np.sqrt(np.square(gate_imp) + np.square(up_imp))
+
+
+@dataclass(frozen=True)
+class _MatMulNBitsMlpChain:
+    producer: _MatMulNBitsMlpWeight
+    chain_ops: Tuple[onnx.NodeProto, ...]
+    consumer: _MatMulNBitsChainSide
+    n_channels: int
+
+
+def _find_matmul_nbits_mlp_chains(graph: onnx.GraphProto) -> List[_MatMulNBitsMlpChain]:
+    """The ``MatMulNBitsMlp`` analogue of :func:`_find_matmul_nbits_chains`:
+    every matched fused-gated-MLP node whose `Y` output feeds, through zero
+    or more shape-preserving unary activations with no other consumer along
+    the way, into a downstream ``MatMulNBits``-or-plain-float consumer --
+    reusing :func:`_walk_to_matmul_nbits_consumer` verbatim, the exact same
+    walk an ordinary single-``MatMulNBits``-producer chain uses (this fused
+    node's own `Y` is no different a producer, from the consumer's own
+    point of view, than a plain ``MatMulNBits`` node's output).
+    """
+    initializer_map = {t.name: t for t in graph.initializer}
+    consumers_of = _consumers_of(graph)
+    graph_outputs = {o.name for o in graph.output}
+
+    def _is_internal(name: str) -> bool:
+        return len(consumers_of.get(name, [])) == 1 and name not in graph_outputs
+
+    chains: List[_MatMulNBitsMlpChain] = []
+    for node in graph.node:
+        w = _match_matmul_nbits_mlp(node, initializer_map, consumers_of)
+        if w is None:
+            continue
+        out_name = node.output[0]
+        if not _is_internal(out_name):
+            continue
+        found = _walk_to_matmul_nbits_consumer(
+            out_name, initializer_map, consumers_of, graph_outputs, w.N, _MAX_CHAIN_HOPS
+        )
+        if found is None:
+            continue
+        consumer, chain_ops = found
+        chains.append(_MatMulNBitsMlpChain(w, chain_ops, consumer, w.N))
+    return chains
+
+
+def _apply_matmul_nbits_mlp_chains(
+    graph: onnx.GraphProto,
+    chains: List[_MatMulNBitsMlpChain],
+    sparsity: float,
+    importance_norm: str,
+    producer_touched: Set[str],
+    consumer_touched: Set[str],
+    stale_value_info: Set[str],
+) -> None:
+    """Applies whole-output-channel pruning to every matched
+    ``MatMulNBitsMlp`` chain in place -- co-slicing `gate`'s and `up`'s own
+    shared ``N`` axis to one shared `keep` set (ranked by
+    :func:`_matmul_nbits_mlp_gated_importance`), then the downstream
+    consumer's own reduction axis, mirroring
+    :func:`apply_structured_pruning_matmul_nbits`'s own per-chain loop
+    exactly (block-alignment decline for a ``MatMulNBits`` consumer, direct
+    application for a plain-float one). `producer_touched`/
+    `consumer_touched`/`stale_value_info` are the caller's own running sets,
+    shared across every ``MatMulNBits``-family chain kind so a tensor
+    played as one role by an earlier chain (of ANY of the three kinds) is
+    never resized twice.
+    """
+    for chain in chains:
+        p, c = chain.producer, chain.consumer
+        p_keys = {p.gate_b.name, p.up_b.name}
+        c_key = _matmul_nbits_chain_side_key(c)
+        if c_key in p_keys:
+            continue  # degenerate (the same weight in both roles)
+        if p_keys & producer_touched or c_key in consumer_touched:
+            continue  # a shared/tied weight another chain already resized
+
+        n = chain.n_channels
+        keep_count = max(1, n - round(n * sparsity))
+        if keep_count >= n:
+            continue  # rounds down to nothing for this layer -- no-op
+
+        gate_nk = _matmul_nbits_dequantized(_matmul_nbits_mlp_branch_weight(p, "gate"))
+        up_nk = _matmul_nbits_dequantized(_matmul_nbits_mlp_branch_weight(p, "up"))
+        importance = _matmul_nbits_mlp_gated_importance(gate_nk, up_nk, importance_norm)
+        # `kind="stable"` for the identical reason
+        # `apply_structured_pruning_matmul_nbits`'s own per-chain loop gives
+        # on this same line -- keeps this pass's own selection deterministic
+        # across platforms and matching its `_analyze_*` dry-run mirror.
+        keep = np.sort(np.argsort(-importance, kind="stable")[:keep_count])
+
+        if isinstance(c, _MatMulNBitsWeight):
+            keep_blocks = _matmul_nbits_block_aligned_keep_blocks(
+                keep, c.k_blocks, c.block_size
+            )
+            if keep_blocks is None:
+                continue  # non-block-aligned request for this consumer -- decline
+            consumer_keep = keep_blocks
+        else:
+            consumer_keep = keep  # plain-float consumer -- no block structure
+
+        _slice_matmul_nbits_rows_no_zp(p.gate_b, p.gate_scales, p.gate_bias, keep)
+        _slice_matmul_nbits_rows_no_zp(p.up_b, p.up_scales, p.up_bias, keep)
+        _set_matmul_nbits_int_attr(p.node, "N", len(keep))
+        _slice_matmul_nbits_chain_consumer(c, consumer_keep)
+
+        producer_touched.update(p_keys)
+        consumer_touched.add(c_key)
+        stale_value_info.add(p.node.output[0])
+        stale_value_info.update(op.output[0] for op in chain.chain_ops)
+
+
+def _walk_to_matmul_nbits_attention_consumer(
+    start: str,
+    initializer_map: Dict[str, onnx.TensorProto],
+    consumers_of: Dict[str, List[onnx.NodeProto]],
+    graph_outputs: Set[str],
+    nv: int,
+) -> Tuple[
+    Optional[_MatMulNBitsChainSide], Tuple[Tuple[onnx.NodeProto, Optional[str]], ...]
+]:
+    """The ``MatMulNBits``-aware analogue of :func:`_walk_to_attention_consumer`:
+    from a matched ``GroupQueryAttention``/plain ``ai.onnx::Attention``
+    node's own raw (`nv`-wide) output `start`, optionally through one
+    ``Reshape`` hop (identical shape/single-use safety check to that
+    function's own), to an output projection whose reduction dimension
+    matches `nv` -- either a ``MatMulNBits`` node
+    (:func:`_match_matmul_nbits`) or a plain-float MatMul/vanilla-Gemm
+    (:func:`_match_plain_matmul_nbits_peer`), the same ``MatMulNBits``/
+    plain-float union :func:`_walk_to_matmul_nbits_consumer` already
+    supports for an ordinary chain. A real quantized transformer block's
+    own output projection is exactly as likely to be ``MatMulNBits``-
+    quantized as its fused Q/K/V projection already is, so
+    :func:`_walk_to_attention_consumer`'s own plain-float-only consumer
+    would be a real, silent gap here -- this function closes it, at the one
+    extra `Reshape`-hop granularity that function already supports (no
+    further activation/hop chain beyond that, mirroring
+    :func:`_walk_to_attention_consumer`'s own identical restriction, not a
+    new one this function adds).
+    """
+    candidates = consumers_of.get(start, [])
+    if len(candidates) != 1:
+        return None, ()
+    node = candidates[0]
+    chain_ops: Tuple[Tuple[onnx.NodeProto, Optional[str]], ...] = ()
+    cur = start
+
+    if node.op_type == "Reshape" and node.input[:1] == [cur]:
+        last_dim = _reshape_last_dim(node, initializer_map)
+        if last_dim != nv:
+            return None, ()
+        shape_name = node.input[1]
+        if len(consumers_of.get(shape_name, [])) != 1:
+            return None, ()  # shared shape constant -- mutating it isn't safe
+        out_name = node.output[0]
+        if len(consumers_of.get(out_name, [])) != 1 or out_name in graph_outputs:
+            return None, ()
+        chain_ops = ((node, shape_name),)
+        cur = out_name
+        next_candidates = consumers_of.get(cur, [])
+        if len(next_candidates) != 1:
+            return None, chain_ops
+        node = next_candidates[0]
+
+    if (
+        node.op_type == "MatMulNBits"
+        and node.domain == "com.microsoft"
+        and node.input[0] == cur
+    ):
+        w = _match_matmul_nbits(node, initializer_map, consumers_of)
+        if w is None or w.K != nv:
+            return None, chain_ops
+        return w, chain_ops
+
+    mm = _match_matmul_like(node)
+    if mm is not None and mm[0] == cur:
+        peer = _match_plain_matmul_nbits_peer(node, initializer_map, consumers_of)
+        if peer is None or peer.in_channels != nv:
+            return None, chain_ops
+        return peer, chain_ops
+
+    return None, chain_ops
+
+
+@dataclass(frozen=True)
+class _MatMulNBitsQkvWeight:
+    """A matched ``com.microsoft::MatMulNBitsQkv`` node's three block-
+    quantized weight operands (`q`/`k`/`v`), matched by
+    :func:`_match_matmul_nbits_qkv`. Like :class:`_MatMulNBitsMlpWeight`, no
+    ``zero_points`` field at all -- confirmed absent from this op's live
+    schema too, see this section's own top comment.
+    """
+
+    node: onnx.NodeProto
+    q_b: onnx.TensorProto
+    q_scales: onnx.TensorProto
+    q_bias: Optional[onnx.TensorProto]
+    k_b: onnx.TensorProto
+    k_scales: onnx.TensorProto
+    k_bias: Optional[onnx.TensorProto]
+    v_b: onnx.TensorProto
+    v_scales: onnx.TensorProto
+    v_bias: Optional[onnx.TensorProto]
+    Nq: int
+    Nkv: int
+    K: int
+    bits: int
+    block_size: int
+    k_blocks: int
+
+
+def _match_matmul_nbits_qkv(
+    node: onnx.NodeProto,
+    initializer_map: Dict[str, onnx.TensorProto],
+    consumers_of: Dict[str, List[onnx.NodeProto]],
+) -> Optional[_MatMulNBitsQkvWeight]:
+    """If `node` is a ``com.microsoft::MatMulNBitsQkv`` node matching every
+    scope boundary this section's own top comment documents, returns the
+    match. `skip` (input 1, optional) and `norm_scale` (input 2, always
+    REQUIRED on this op's live schema -- unlike ``MatMulNBitsMlp``'s own
+    optional one, confirmed via live schema introspection) are read but
+    never otherwise inspected, for the identical reason
+    :func:`_match_matmul_nbits_mlp` gives its own `skip`/`norm_scale`: only
+    the shared ``Nq``/``Nkv`` OUTPUT axes are ever pruned here, never the
+    shared ``K`` INPUT axis those two operands (and every one of `q`/`k`/
+    `v`'s own weights) would need re-slicing for.
+    """
+    if node.op_type != "MatMulNBitsQkv" or node.domain != "com.microsoft":
+        return None
+    if len(node.input) < 11 or len(node.output) < 3:
+        return None
+    a_name = node.input[0]
+    norm_scale_name = node.input[2] if node.input[2] else None
+    if not a_name or norm_scale_name is None:
+        return None
+    q_b_name, q_scales_name = node.input[3], node.input[4]
+    q_bias_name = node.input[5] if node.input[5] else None
+    k_b_name, k_scales_name = node.input[6], node.input[7]
+    k_bias_name = node.input[8] if node.input[8] else None
+    v_b_name, v_scales_name = node.input[9], node.input[10]
+    v_bias_name = node.input[11] if len(node.input) > 11 and node.input[11] else None
+    if not (
+        q_b_name
+        and q_scales_name
+        and k_b_name
+        and k_scales_name
+        and v_b_name
+        and v_scales_name
+    ):
+        return None
+    if q_b_name == k_b_name or q_b_name == v_b_name or k_b_name == v_b_name:
+        return None  # degenerate -- can't independently slice a shared weight
+
+    block_size = _matmul_nbits_int_attr(node, "block_size")
+    Nq = _matmul_nbits_int_attr(node, "Nq")
+    Nkv = _matmul_nbits_int_attr(node, "Nkv")
+    K = _matmul_nbits_int_attr(node, "K")
+    if block_size is None or Nq is None or Nkv is None or K is None:
+        return None
+    if Nq <= 0 or Nkv <= 0 or K <= 0:
+        return None
+    if block_size not in _MATMUL_NBITS_VALID_BLOCK_SIZES:
+        return None
+    if K % block_size != 0:
+        return None
+    bits = _matmul_nbits_int_attr(node, "bits", 4)
+    if bits not in (4, 8):
+        return None
+
+    k_blocks = K // block_size
+    blob_size = block_size * bits // 8
+
+    def _resolve_branch(
+        n: int, b_name: str, scales_name: str, bias_name: Optional[str]
+    ) -> Optional[
+        Tuple[onnx.TensorProto, onnx.TensorProto, Optional[onnx.TensorProto]]
+    ]:
+        b_init = initializer_map.get(b_name)
+        scales_init = initializer_map.get(scales_name)
+        if b_init is None or scales_init is None:
+            return None
+        if b_init.data_type != onnx.TensorProto.UINT8:
+            return None
+        if list(b_init.dims) != [n, k_blocks, blob_size]:
+            return None
+        if scales_init.data_type not in (
+            onnx.TensorProto.FLOAT,
+            onnx.TensorProto.FLOAT16,
+            onnx.TensorProto.BFLOAT16,
+        ):
+            return None
+        if list(scales_init.dims) != [n, k_blocks]:
+            return None
+        bias_init = None
+        if bias_name is not None:
+            bias_init = initializer_map.get(bias_name)
+            if bias_init is None or bias_init.data_type != scales_init.data_type:
+                return None
+            if list(bias_init.dims) != [n]:
+                return None
+        for nm in (b_name, scales_name) + ((bias_name,) if bias_name else ()):
+            if len(consumers_of.get(nm, [])) != 1:
+                return None
+        return b_init, scales_init, bias_init
+
+    q = _resolve_branch(Nq, q_b_name, q_scales_name, q_bias_name)
+    if q is None:
+        return None
+    k = _resolve_branch(Nkv, k_b_name, k_scales_name, k_bias_name)
+    if k is None:
+        return None
+    v = _resolve_branch(Nkv, v_b_name, v_scales_name, v_bias_name)
+    if v is None:
+        return None
+
+    return _MatMulNBitsQkvWeight(
+        node=node,
+        q_b=q[0],
+        q_scales=q[1],
+        q_bias=q[2],
+        k_b=k[0],
+        k_scales=k[1],
+        k_bias=k[2],
+        v_b=v[0],
+        v_scales=v[1],
+        v_bias=v[2],
+        Nq=Nq,
+        Nkv=Nkv,
+        K=K,
+        bits=bits,
+        block_size=block_size,
+        k_blocks=k_blocks,
+    )
+
+
+def _matmul_nbits_qkv_branch_weight(
+    p: _MatMulNBitsQkvWeight, branch: str
+) -> _MatMulNBitsWeight:
+    """The ``MatMulNBitsQkv`` analogue of
+    :func:`_matmul_nbits_mlp_branch_weight`: wraps one branch (`"q"`, `"k"`,
+    or `"v"`) as a synthetic :class:`_MatMulNBitsWeight` so
+    :func:`_matmul_nbits_dequantized` can be reused verbatim.
+    """
+    if branch == "q":
+        b, scales, bias, n = p.q_b, p.q_scales, p.q_bias, p.Nq
+    elif branch == "k":
+        b, scales, bias, n = p.k_b, p.k_scales, p.k_bias, p.Nkv
+    else:
+        b, scales, bias, n = p.v_b, p.v_scales, p.v_bias, p.Nkv
+    return _MatMulNBitsWeight(
+        node=p.node,
+        b_init=b,
+        scales_init=scales,
+        zero_points_init=None,
+        zero_points_packed=False,
+        bias_init=bias,
+        N=n,
+        K=p.K,
+        bits=p.bits,
+        block_size=p.block_size,
+        k_blocks=p.k_blocks,
+    )
+
+
+def _matmul_nbits_qkv_group_importance(
+    q_nk: np.ndarray,
+    k_nk: np.ndarray,
+    v_nk: np.ndarray,
+    group_size: int,
+    kv_num_heads: int,
+    head_size: int,
+    importance_norm: str,
+) -> np.ndarray:
+    """The ``MatMulNBitsQkv`` analogue of :func:`_gqa_group_importance`:
+    combined per-KV-group importance of `q`'s/`k`'s/`v`'s own dequantized
+    producer-weight ROWS -- this section's own ``[N, K]`` convention
+    (contrast :func:`_gqa_group_importance`'s own ``[K, N]`` one, since a
+    ``MatMulNBits`` dequantized weight's leading axis is always its own
+    output-channel ``N`` axis, never transposed -- see
+    :func:`_matmul_nbits_dequantized`). Every KV group's own query-head
+    rows, K rows, and V rows are contiguous `head_size`-wide row ranges of
+    `q_nk`'s/`k_nk`'s/`v_nk`'s own ``N`` axis -- the same "heads are
+    contiguous output-channel ranges" convention this module already uses
+    everywhere else (:func:`_head_column_indices`, `_gqa_group_importance`
+    itself).
+    """
+    importance = np.zeros(kv_num_heads, dtype=np.float64)
+    for kv in range(kv_num_heads):
+        q_block = q_nk[
+            kv * group_size * head_size : (kv + 1) * group_size * head_size, :
+        ]
+        k_block = k_nk[kv * head_size : (kv + 1) * head_size, :]
+        v_block = v_nk[kv * head_size : (kv + 1) * head_size, :]
+        if importance_norm == "l1":
+            importance[kv] = (
+                np.abs(q_block).sum() + np.abs(k_block).sum() + np.abs(v_block).sum()
+            )
+        else:
+            importance[kv] = np.sqrt(
+                np.linalg.norm(q_block) ** 2
+                + np.linalg.norm(k_block) ** 2
+                + np.linalg.norm(v_block) ** 2
+            )
+    return importance
+
+
+@dataclass(frozen=True)
+class _MatMulNBitsQkvChain:
+    producer: _MatMulNBitsQkvWeight
+    attn_node: onnx.NodeProto
+    num_heads: int
+    kv_num_heads: int
+    head_size: int
+    num_heads_attr: str
+    chain_ops: Tuple[Tuple[onnx.NodeProto, Optional[str]], ...]
+    consumer: _MatMulNBitsChainSide
+
+
+def _find_matmul_nbits_qkv_chains(graph: onnx.GraphProto) -> List[_MatMulNBitsQkvChain]:
+    """Matches a ``MatMulNBitsQkv`` node whose `Q`/`K`/`V` outputs each feed
+    -- directly, single-consumer, no intermediate hop -- into the
+    respective query/key/value inputs of one shared downstream
+    ``GroupQueryAttention`` (:func:`_match_gqa_producer`) or plain
+    ``ai.onnx::Attention`` (:func:`_match_onnx_attention_producer`) node,
+    reused verbatim (both already validate `num_heads`/`kv_num_heads` and
+    every optional per-head `past_key`/`past_value`/`k_scale`/`v_scale`/
+    `attention_bias`/`head_sink` operand's own safety), and whose own
+    output in turn reaches a ``MatMulNBits``-or-plain-float output
+    projection (:func:`_walk_to_matmul_nbits_attention_consumer`).
+
+    Unlike :func:`_find_separate_qkv_chains` (this module's own plain-float
+    separate-Q/K/V-producer precedent), NO per-head Q/K-norm + RoPE
+    pass-through hop (:func:`_walk_back_through_qk_norm_rope`) is matched
+    between this fused node's own `Q`/`K` outputs and the attention
+    consumer -- a real, deliberate, documented scope boundary (see this
+    section's own top comment), not an oversight: a model relying on that
+    hop is declined here rather than mis-sliced.
+    """
+    initializer_map = {t.name: t for t in graph.initializer}
+    consumers_of = _consumers_of(graph)
+    graph_outputs = {o.name for o in graph.output}
+
+    def _is_internal(name: str) -> bool:
+        return len(consumers_of.get(name, [])) == 1 and name not in graph_outputs
+
+    chains: List[_MatMulNBitsQkvChain] = []
+    for node in graph.node:
+        w = _match_matmul_nbits_qkv(node, initializer_map, consumers_of)
+        if w is None:
+            continue
+
+        q_out, k_out, v_out = node.output[0], node.output[1], node.output[2]
+        if not (_is_internal(q_out) and _is_internal(k_out) and _is_internal(v_out)):
+            continue
+        attn = consumers_of[q_out][0]
+        if consumers_of[k_out][0] is not attn or consumers_of[v_out][0] is not attn:
+            continue  # Q/K/V must feed the exact same downstream node
+        if len(attn.input) < 3:
+            continue
+        if attn.input[0] != q_out or attn.input[1] != k_out or attn.input[2] != v_out:
+            continue  # must land on the consumer's own query/key/value inputs
+
+        num_heads_attr = "num_heads"
+        info: Optional[Tuple[int, int]]
+        if attn.domain == _ATTENTION_DOMAIN and attn.op_type == "GroupQueryAttention":
+            info = _match_gqa_producer(attn, initializer_map)
+        elif attn.domain == "" and attn.op_type == "Attention":
+            info = _match_onnx_attention_producer(attn, initializer_map)
+            num_heads_attr = "q_num_heads"
+        else:
+            info = None
+        if info is None:
+            continue
+        num_heads, kv_num_heads = info
+        if w.Nq % num_heads or w.Nkv % kv_num_heads:
+            continue
+        head_size = w.Nq // num_heads
+        if head_size <= 0 or w.Nkv // kv_num_heads != head_size:
+            continue
+
+        out_name = attn.output[0]
+        if not _is_internal(out_name):
+            continue
+        raw_out_width = num_heads * head_size
+        consumer, chain_ops = _walk_to_matmul_nbits_attention_consumer(
+            out_name, initializer_map, consumers_of, graph_outputs, raw_out_width
+        )
+        if consumer is None:
+            continue
+
+        chains.append(
+            _MatMulNBitsQkvChain(
+                producer=w,
+                attn_node=attn,
+                num_heads=num_heads,
+                kv_num_heads=kv_num_heads,
+                head_size=head_size,
+                num_heads_attr=num_heads_attr,
+                chain_ops=chain_ops,
+                consumer=consumer,
+            )
+        )
+    return chains
+
+
+def _apply_matmul_nbits_qkv_chains(
+    graph: onnx.GraphProto,
+    chains: List[_MatMulNBitsQkvChain],
+    sparsity: float,
+    importance_norm: str,
+    producer_touched: Set[str],
+    consumer_touched: Set[str],
+    stale_value_info: Set[str],
+) -> None:
+    """Applies whole-KV-group pruning to every matched ``MatMulNBitsQkv``
+    chain in place -- the fused-op analogue of :func:`_apply_one_gqa_chain`,
+    reusing that function's own consumer-side bookkeeping (`past_key`/
+    `past_value`, `k_scale`/`v_scale`, `attention_bias`/`attn_mask`,
+    `head_sink`, `num_heads`/`kv_num_heads` attribute rewrite) directly
+    against `chain.attn_node`, since that node itself owns no weight of its
+    own to slice here -- only `q`'s/`k`'s/`v`'s own producer weights (this
+    function's own job) and the downstream output-projection consumer
+    (:func:`_slice_matmul_nbits_chain_consumer`, reused verbatim).
+    """
+    initializer_map = {t.name: t for t in graph.initializer}
+
+    for chain in chains:
+        p, c = chain.producer, chain.consumer
+        p_keys = {p.q_b.name, p.k_b.name, p.v_b.name}
+        c_key = _matmul_nbits_chain_side_key(c)
+        if c_key in p_keys:
+            continue  # degenerate (the same weight in both roles)
+        if p_keys & producer_touched or c_key in consumer_touched:
+            continue  # a shared/tied weight another chain already resized
+
+        h = chain.kv_num_heads
+        keep_count = max(1, h - round(h * sparsity))
+        if keep_count >= h:
+            continue  # rounds down to nothing for this block -- no-op
+
+        d = chain.head_size
+        group_size = chain.num_heads // chain.kv_num_heads
+
+        q_nk = _matmul_nbits_dequantized(_matmul_nbits_qkv_branch_weight(p, "q"))
+        k_nk = _matmul_nbits_dequantized(_matmul_nbits_qkv_branch_weight(p, "k"))
+        v_nk = _matmul_nbits_dequantized(_matmul_nbits_qkv_branch_weight(p, "v"))
+        importance = _matmul_nbits_qkv_group_importance(
+            q_nk, k_nk, v_nk, group_size, h, d, importance_norm
+        )
+        # `kind="stable"` for the same reason `_apply_matmul_nbits_mlp_chains`'s
+        # own identical comment gives.
+        keep_groups = np.sort(np.argsort(-importance, kind="stable")[:keep_count])
+        keep_q_heads = np.concatenate(
+            [np.arange(g * group_size, (g + 1) * group_size) for g in keep_groups]
+        )
+        q_idx = _head_column_indices(keep_q_heads, d)
+        kv_idx = _head_column_indices(keep_groups, d)
+
+        if isinstance(c, _MatMulNBitsWeight):
+            keep_blocks = _matmul_nbits_block_aligned_keep_blocks(
+                q_idx, c.k_blocks, c.block_size
+            )
+            if keep_blocks is None:
+                continue  # non-block-aligned request for this consumer -- decline
+            consumer_keep = keep_blocks
+        else:
+            consumer_keep = q_idx  # plain-float consumer -- no block structure
+
+        _slice_matmul_nbits_rows_no_zp(p.q_b, p.q_scales, p.q_bias, q_idx)
+        _slice_matmul_nbits_rows_no_zp(p.k_b, p.k_scales, p.k_bias, kv_idx)
+        _slice_matmul_nbits_rows_no_zp(p.v_b, p.v_scales, p.v_bias, kv_idx)
+        _set_matmul_nbits_int_attr(p.node, "Nq", len(q_idx))
+        _set_matmul_nbits_int_attr(p.node, "Nkv", len(kv_idx))
+
+        new_num_heads = keep_count * group_size
+        for attr in chain.attn_node.attribute:
+            if attr.name == chain.num_heads_attr:
+                attr.i = new_num_heads
+            elif attr.name == "kv_num_heads":
+                attr.i = keep_count
+
+        is_gqa = (
+            chain.attn_node.domain == _ATTENTION_DOMAIN
+            and chain.attn_node.op_type == "GroupQueryAttention"
+        )
+        past_kv_indices = (3, 4) if is_gqa else (4, 5)
+        for idx in past_kv_indices:
+            if len(chain.attn_node.input) <= idx or not chain.attn_node.input[idx]:
+                continue
+            past_init = initializer_map.get(chain.attn_node.input[idx])
+            if past_init is not None:
+                _slice_axis1(past_init, keep_groups)
+
+        if is_gqa:
+            for idx in (12, 13):
+                if len(chain.attn_node.input) <= idx or not chain.attn_node.input[idx]:
+                    continue
+                scale_init = initializer_map.get(chain.attn_node.input[idx])
+                if scale_init is None:
+                    continue
+                if len(scale_init.dims) == 4 and scale_init.dims[1] == h:
+                    _slice_axis1(scale_init, keep_groups)
+
+        mask_idx = 10 if is_gqa else 3
+        if len(chain.attn_node.input) > mask_idx and chain.attn_node.input[mask_idx]:
+            mask_init = initializer_map.get(chain.attn_node.input[mask_idx])
+            if mask_init is not None:
+                axis = _head_bias_axis(list(mask_init.dims), chain.num_heads)
+                if axis is not None and axis >= 0:
+                    _slice_axis(mask_init, keep_q_heads, axis)
+
+        if is_gqa and len(chain.attn_node.input) > 11 and chain.attn_node.input[11]:
+            sink_init = initializer_map.get(chain.attn_node.input[11])
+            if sink_init is not None:
+                _slice_last_axis(sink_init, keep_q_heads)
+
+        _slice_matmul_nbits_chain_consumer(c, consumer_keep)
+
+        for op, shape_name in chain.chain_ops:
+            if shape_name is not None:
+                shape_init = initializer_map[shape_name]
+                dims = onnx.numpy_helper.to_array(shape_init).copy()
+                dims[-1] = new_num_heads * d
+                shape_init.CopyFrom(
+                    onnx.numpy_helper.from_array(dims, name=shape_init.name)
+                )
+
+        producer_touched.update(p_keys)
+        consumer_touched.add(c_key)
+        stale_value_info.add(p.node.output[0])
+        stale_value_info.add(p.node.output[1])
+        stale_value_info.add(p.node.output[2])
+        stale_value_info.add(chain.attn_node.output[0])
+        stale_value_info.update(op.output[0] for op, _ in chain.chain_ops)
 
 
 # --- MoE expert-intermediate-channel pruning --------------------------------
@@ -17604,15 +18747,35 @@ def _analyze_structured_pruning_qdq(
 
 
 def _matmul_nbits_not_eligible(
-    graph: onnx.GraphProto, chains: List[_MatMulNBitsChain]
+    graph: onnx.GraphProto,
+    chains: List[_MatMulNBitsChain],
+    mlp_chains: List[_MatMulNBitsMlpChain],
+    qkv_chains: List[_MatMulNBitsQkvChain],
 ) -> List[str]:
+    """Extended, alongside :func:`apply_structured_pruning_matmul_nbits`'s
+    own new ``MatMulNBitsMlp``/``MatMulNBitsQkv`` matching, to also mark a
+    matched fused node's own producer (and, for ``MatMulNBitsQkv``, its own
+    downstream attention consumer) ineligible -- otherwise a fused node this
+    module's new matchers *do* recognize would still show up in
+    `not_eligible` merely for not being a plain ``MatMulNBits`` node, an
+    obviously wrong report once this module actually prunes it.
+    """
     matched_ids: Set[int] = set()
     for chain in chains:
         matched_ids.add(id(chain.producer.node))
         matched_ids.add(id(chain.consumer.node))
+    for mlp_chain in mlp_chains:
+        matched_ids.add(id(mlp_chain.producer.node))
+        matched_ids.add(id(mlp_chain.consumer.node))
+    for qkv_chain in qkv_chains:
+        matched_ids.add(id(qkv_chain.producer.node))
+        matched_ids.add(id(qkv_chain.attn_node))
+        matched_ids.add(id(qkv_chain.consumer.node))
     not_eligible = []
     for node in graph.node:
-        if node.op_type != "MatMulNBits" or node.domain != "com.microsoft":
+        if node.domain != "com.microsoft":
+            continue
+        if node.op_type not in ("MatMulNBits", "MatMulNBitsMlp", "MatMulNBitsQkv"):
             continue
         if id(node) in matched_ids:
             continue
@@ -17671,6 +18834,22 @@ def _analyze_structured_pruning_matmul_nbits(
     node simply never enters :func:`_find_matmul_nbits_chains`'s own return
     value in the first place, so it is reported via `not_eligible` exactly
     like any other unmatched ``MatMulNBits`` node.
+
+    ALSO mirrors :func:`apply_structured_pruning_matmul_nbits`'s own new
+    ``MatMulNBitsMlp``/``MatMulNBitsQkv`` fused-node matching: appends one
+    report row per matched :func:`_find_matmul_nbits_mlp_chains`/
+    :func:`_find_matmul_nbits_qkv_chains` chain
+    (:func:`_analyze_matmul_nbits_mlp_chains`/
+    :func:`_analyze_matmul_nbits_qkv_chains`, in the "MatMulNBitsMlp/
+    MatMulNBitsQkv (fused block-quantized weight) structured family" section
+    below -- placed after "Attention-head family" for the identical reason
+    the real functions live after "Attention-head pruning": the QKV mirror
+    reuses that family's own matchers), each sharing this function's own
+    `producer_touched`/`consumer_touched` sets so a tensor touched by one
+    family's chain is correctly reported as already-claimed by another's.
+    `family` is ``"matmul_nbits_mlp"``/``"matmul_nbits_qkv"`` respectively;
+    the latter's `total`/`would_drop` are in KV-GROUP units, not raw
+    channel counts (this fused op's own pruning unit).
     """
     if not (0.0 <= sparsity < 1.0):
         raise ValueError(f"sparsity must be in [0, 1), got {sparsity}")
@@ -17680,8 +18859,10 @@ def _analyze_structured_pruning_matmul_nbits(
     graph = model.graph
 
     chains = _find_matmul_nbits_chains(graph)
-    not_eligible = _matmul_nbits_not_eligible(graph, chains)
-    if not chains:
+    mlp_chains = _find_matmul_nbits_mlp_chains(graph)
+    qkv_chains = _find_matmul_nbits_qkv_chains(graph)
+    not_eligible = _matmul_nbits_not_eligible(graph, chains, mlp_chains, qkv_chains)
+    if not chains and not mlp_chains and not qkv_chains:
         return PruningSensitivityReport(layers=[], not_eligible=not_eligible)
 
     producer_touched: Set[str] = set()
@@ -17777,6 +18958,17 @@ def _analyze_structured_pruning_matmul_nbits(
 
         producer_touched.add(p_key)
         consumer_touched.add(c_key)
+
+    layers.extend(
+        _analyze_matmul_nbits_mlp_chains(
+            mlp_chains, sparsity, importance_norm, producer_touched, consumer_touched
+        )
+    )
+    layers.extend(
+        _analyze_matmul_nbits_qkv_chains(
+            qkv_chains, sparsity, importance_norm, producer_touched, consumer_touched
+        )
+    )
 
     return PruningSensitivityReport(layers=layers, not_eligible=not_eligible)
 
@@ -18058,6 +19250,234 @@ def _analyze_attention_head_wanda_pruning(
     return PruningSensitivityReport(
         layers=layers, not_eligible=_attention_not_eligible(graph, chains)
     )
+
+
+# --- MatMulNBitsMlp/MatMulNBitsQkv (fused block-quantized weight) structured
+#     family ---------------------------------------------------------------
+#
+# Dry-run mirrors of :func:`_apply_matmul_nbits_mlp_chains`/
+# :func:`_apply_matmul_nbits_qkv_chains` -- both called directly from
+# :func:`_analyze_structured_pruning_matmul_nbits` above (the same single
+# `_analyze_*` :func:`apply_structured_pruning_matmul_nbits` itself maps to
+# in `_SENSITIVITY_ANALYZERS`; these two fused-node kinds get no separate
+# public entry point of their own, mirroring the real `apply_*` function's
+# own shape). Placed after "Attention-head family" -- rather than
+# immediately alongside `_analyze_structured_pruning_matmul_nbits` itself --
+# because the QKV mirror reuses that family's own already-defined
+# `_match_gqa_producer`/`_match_onnx_attention_producer`/`_head_bias_axis`-
+# style machinery, the same layout reason the real (mutating)
+# `_apply_matmul_nbits_qkv_chains` lives after "Attention-head pruning".
+
+
+def _analyze_matmul_nbits_mlp_chains(
+    chains: List[_MatMulNBitsMlpChain],
+    sparsity: float,
+    importance_norm: str,
+    producer_touched: Set[str],
+    consumer_touched: Set[str],
+) -> List[PruningLayerSensitivity]:
+    """Dry-run mirror of :func:`_apply_matmul_nbits_mlp_chains` -- same
+    matching, touched-role bookkeeping, keep-count, and importance
+    (:func:`_matmul_nbits_mlp_gated_importance`) logic, reused directly,
+    never mutating anything. `producer_touched`/`consumer_touched` are the
+    caller's own running sets (shared with the plain ``MatMulNBits`` and
+    ``MatMulNBitsQkv`` mirrors too, mutated in place here exactly as the
+    real function's own identically-named sets are). `family` is always
+    ``"matmul_nbits_mlp"``.
+    """
+    layers: List[PruningLayerSensitivity] = []
+    for chain in chains:
+        p, c = chain.producer, chain.consumer
+        p_keys = {p.gate_b.name, p.up_b.name}
+        c_key = _matmul_nbits_chain_side_key(c)
+        if c_key in p_keys:
+            continue  # degenerate (the same weight in both roles) -- no report row
+
+        label = _node_label(p.node)
+        family = "matmul_nbits_mlp"
+        n = chain.n_channels
+
+        if p_keys & producer_touched or c_key in consumer_touched:
+            layers.append(
+                PruningLayerSensitivity(
+                    label=label,
+                    family=family,
+                    total=n,
+                    would_drop=0,
+                    margin=None,
+                    importance_min=0.0,
+                    importance_max=0.0,
+                )
+            )
+            continue  # a shared/tied weight another chain already claimed
+
+        keep_count = max(1, n - round(n * sparsity))
+        if keep_count >= n:
+            layers.append(
+                PruningLayerSensitivity(
+                    label=label,
+                    family=family,
+                    total=n,
+                    would_drop=0,
+                    margin=None,
+                    importance_min=0.0,
+                    importance_max=0.0,
+                )
+            )
+            continue  # rounds down to nothing for this chain -- no-op
+
+        gate_nk = _matmul_nbits_dequantized(_matmul_nbits_mlp_branch_weight(p, "gate"))
+        up_nk = _matmul_nbits_dequantized(_matmul_nbits_mlp_branch_weight(p, "up"))
+        importance = _matmul_nbits_mlp_gated_importance(gate_nk, up_nk, importance_norm)
+        keep = np.sort(np.argsort(-importance, kind="stable")[:keep_count])
+
+        if isinstance(c, _MatMulNBitsWeight):
+            keep_blocks = _matmul_nbits_block_aligned_keep_blocks(
+                keep, c.k_blocks, c.block_size
+            )
+            if keep_blocks is None:
+                layers.append(
+                    PruningLayerSensitivity(
+                        label=label,
+                        family=family,
+                        total=n,
+                        would_drop=0,
+                        margin=None,
+                        importance_min=0.0,
+                        importance_max=0.0,
+                    )
+                )
+                continue  # non-block-aligned keep-set -- the real call
+                # declines this chain entirely too
+
+        keep_mask = np.zeros(n, dtype=bool)
+        keep_mask[keep] = True
+
+        layers.append(
+            PruningLayerSensitivity(
+                label=label,
+                family=family,
+                total=n,
+                would_drop=int(n - keep_count),
+                margin=_normalized_margin(importance, keep_mask),
+                importance_min=float(importance.min()),
+                importance_max=float(importance.max()),
+            )
+        )
+
+        producer_touched.update(p_keys)
+        consumer_touched.add(c_key)
+
+    return layers
+
+
+def _analyze_matmul_nbits_qkv_chains(
+    chains: List[_MatMulNBitsQkvChain],
+    sparsity: float,
+    importance_norm: str,
+    producer_touched: Set[str],
+    consumer_touched: Set[str],
+) -> List[PruningLayerSensitivity]:
+    """Dry-run mirror of :func:`_apply_matmul_nbits_qkv_chains` -- same
+    matching, touched-role bookkeeping, keep-group-count, and importance
+    (:func:`_matmul_nbits_qkv_group_importance`) logic, reused directly,
+    never mutating anything. `total`/`would_drop` are in KV-GROUP units
+    (this fused op's own pruning unit -- mirrors
+    :func:`_analyze_attention_head_pruning`'s own GQA family reporting), not
+    raw channel counts. `family` is always ``"matmul_nbits_qkv"``.
+    """
+    layers: List[PruningLayerSensitivity] = []
+    for chain in chains:
+        p, c = chain.producer, chain.consumer
+        p_keys = {p.q_b.name, p.k_b.name, p.v_b.name}
+        c_key = _matmul_nbits_chain_side_key(c)
+        if c_key in p_keys:
+            continue  # degenerate -- no report row
+
+        label = _node_label(p.node)
+        family = "matmul_nbits_qkv"
+        h = chain.kv_num_heads
+
+        if p_keys & producer_touched or c_key in consumer_touched:
+            layers.append(
+                PruningLayerSensitivity(
+                    label=label,
+                    family=family,
+                    total=h,
+                    would_drop=0,
+                    margin=None,
+                    importance_min=0.0,
+                    importance_max=0.0,
+                )
+            )
+            continue
+
+        keep_count = max(1, h - round(h * sparsity))
+        if keep_count >= h:
+            layers.append(
+                PruningLayerSensitivity(
+                    label=label,
+                    family=family,
+                    total=h,
+                    would_drop=0,
+                    margin=None,
+                    importance_min=0.0,
+                    importance_max=0.0,
+                )
+            )
+            continue
+
+        d = chain.head_size
+        group_size = chain.num_heads // chain.kv_num_heads
+        q_nk = _matmul_nbits_dequantized(_matmul_nbits_qkv_branch_weight(p, "q"))
+        k_nk = _matmul_nbits_dequantized(_matmul_nbits_qkv_branch_weight(p, "k"))
+        v_nk = _matmul_nbits_dequantized(_matmul_nbits_qkv_branch_weight(p, "v"))
+        importance = _matmul_nbits_qkv_group_importance(
+            q_nk, k_nk, v_nk, group_size, h, d, importance_norm
+        )
+        keep_groups = np.sort(np.argsort(-importance, kind="stable")[:keep_count])
+        keep_q_heads = np.concatenate(
+            [np.arange(g * group_size, (g + 1) * group_size) for g in keep_groups]
+        )
+        q_idx = _head_column_indices(keep_q_heads, d)
+
+        if isinstance(c, _MatMulNBitsWeight):
+            keep_blocks = _matmul_nbits_block_aligned_keep_blocks(
+                q_idx, c.k_blocks, c.block_size
+            )
+            if keep_blocks is None:
+                layers.append(
+                    PruningLayerSensitivity(
+                        label=label,
+                        family=family,
+                        total=h,
+                        would_drop=0,
+                        margin=None,
+                        importance_min=0.0,
+                        importance_max=0.0,
+                    )
+                )
+                continue
+
+        keep_mask = np.zeros(h, dtype=bool)
+        keep_mask[keep_groups] = True
+
+        layers.append(
+            PruningLayerSensitivity(
+                label=label,
+                family=family,
+                total=h,
+                would_drop=int(h - keep_count),
+                margin=_normalized_margin(importance, keep_mask),
+                importance_min=float(importance.min()),
+                importance_max=float(importance.max()),
+            )
+        )
+
+        producer_touched.update(p_keys)
+        consumer_touched.add(c_key)
+
+    return layers
 
 
 # --- MoE expert-intermediate-channel family --------------------------------

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -22520,3 +22520,765 @@ def test_matmul_nbits_pruning_invalid_sparsity_raises():
         onnxsim.apply_structured_pruning_matmul_nbits(model, sparsity=1.0)
     with pytest.raises(ValueError):
         onnxsim.apply_structured_pruning_matmul_nbits(model, sparsity=-0.1)
+
+
+# --- apply_structured_pruning_matmul_nbits: fused MatMulNBitsMlp/MatMulNBitsQkv ---
+#
+# See ``onnxsim/pruning.py``'s own "MatMulNBitsMlp/MatMulNBitsQkv (fused
+# block-quantized weight) structured pruning" section comment for the full
+# empirical schema investigation and, most importantly, WHY neither fused op
+# can be executed end to end via a real ``InferenceSession`` in this
+# environment (both fusions are WebGPU-execution-provider-specific;
+# confirmed no WebGPU adapter is reachable here, via both the system
+# ``onnxruntime`` install and a separately-installed `onnxruntime-webgpu`
+# wheel, tried specifically to check). Every correctness test below
+# therefore DECOMPOSES a (pruned) fused node's own weight tensors back into
+# equivalent standalone ``MatMulNBits``/``SimplifiedLayerNormalization``
+# nodes and runs THOSE through a real CPU-kernel ``InferenceSession`` --
+# both of which this environment's CPU EP genuinely implements -- against an
+# independent numpy oracle. This is a faithful proxy, not a guess: both
+# fused ops' own live schemas type every weight/scale/bias input identically
+# to plain ``MatMulNBits``'s own ``B``/``scales``/``bias`` (confirmed via
+# live schema introspection), and both ops' own doc strings write their
+# fused arithmetic as literal, unmodified ``MatMulNBits(...)``/
+# ``SimplifiedLayerNormalization(...)`` calls.
+#
+# Quantization here uses the schema's own DEFAULT zero point
+# (``2 ** (bits - 1)``) throughout -- unlike ``_nbits_quantize_block``
+# above, neither fused op has a ``zero_points`` input at all (confirmed via
+# live schema introspection), so there is no explicit zero-point tensor to
+# attach.
+
+
+def _nbits_quantize_default_zp(W, block_size, bits=4):
+    """Independent reference block quantizer using the schema's own DEFAULT
+    zero point (``2 ** (bits - 1)``) rather than an explicit
+    ``zero_points`` tensor -- the only encoding ``MatMulNBitsMlp``/
+    ``MatMulNBitsQkv`` support, since neither has a ``zero_points`` input at
+    all (see this section's own top comment). Returns ``(qcodes uint8 [N,
+    K], scales float32 [N, k_blocks], k_blocks)``.
+    """
+    N, K = W.shape
+    assert K % block_size == 0
+    k_blocks = K // block_size
+    qmax = (1 << bits) - 1
+    zp = float(1 << (bits - 1))
+    scales = np.zeros((N, k_blocks), dtype=np.float32)
+    qcodes = np.zeros((N, K), dtype=np.uint8)
+    for n in range(N):
+        for kb in range(k_blocks):
+            k0, k1 = kb * block_size, (kb + 1) * block_size
+            block = W[n, k0:k1]
+            maxabs = max(float(np.max(np.abs(block))), 1e-8)
+            scale = maxabs / max(zp, qmax - zp)
+            scales[n, kb] = scale
+            codes = np.round(block / scale + zp).clip(0, qmax)
+            qcodes[n, k0:k1] = codes.astype(np.uint8)
+    return qcodes, scales, k_blocks
+
+
+def _matmul_nbits_mlp_model(N, K, N2, block_size, W_gate, W_up, bias_gate, bias_up):
+    """Builds ``A -> MatMulNBitsMlp(mlp, activation=Relu) -> Y -> MatMul(down)
+    -> Z``, a real ``com.microsoft::MatMulNBitsMlp`` node (no ``skip``/
+    ``norm_scale`` -- both left empty, see this section's own top comment
+    for why this pass never needs to touch either) feeding a plain-float
+    output projection. Built via ``onnx.helper`` rather than
+    ``onnx.parser.parse_model`` -- the same CLAUDE.md-documented fallback
+    this file's own plain-``MatMulNBits`` section above already uses, for
+    the identical reason (optional inputs interleaved with present ones).
+    Returns ``(model, info)`` with every independently-computed
+    quantization artifact needed to hand-build an oracle.
+    """
+    qcodes_g, scales_g, kb = _nbits_quantize_default_zp(W_gate, block_size)
+    qcodes_u, scales_u, _kb2 = _nbits_quantize_default_zp(W_up, block_size)
+    gate_B = _nbits_pack_B(qcodes_g, N, kb, block_size)
+    up_B = _nbits_pack_B(qcodes_u, N, kb, block_size)
+    rng = np.random.default_rng(9001)
+    down_w = (rng.standard_normal((N, N2)) * 0.3).astype(np.float32)
+
+    node = onnx.helper.make_node(
+        "MatMulNBitsMlp",
+        inputs=[
+            "A",
+            "",
+            "",
+            "gate_B",
+            "gate_scales",
+            "gate_bias",
+            "up_B",
+            "up_scales",
+            "up_bias",
+        ],
+        outputs=["Y"],
+        domain="com.microsoft",
+        name="mlp",
+        activation="Relu",
+        block_size=block_size,
+        bits=4,
+        N=N,
+        K=K,
+    )
+    down_node = onnx.helper.make_node("MatMul", ["Y", "down_w"], ["Z"], name="down")
+    graph = onnx.helper.make_graph(
+        [node, down_node],
+        "g",
+        inputs=[
+            onnx.helper.make_tensor_value_info("A", onnx.TensorProto.FLOAT, [None, K])
+        ],
+        outputs=[
+            onnx.helper.make_tensor_value_info("Z", onnx.TensorProto.FLOAT, [None, N2])
+        ],
+        initializer=[
+            onnx.numpy_helper.from_array(gate_B, name="gate_B"),
+            onnx.numpy_helper.from_array(scales_g, name="gate_scales"),
+            onnx.numpy_helper.from_array(bias_gate, name="gate_bias"),
+            onnx.numpy_helper.from_array(up_B, name="up_B"),
+            onnx.numpy_helper.from_array(scales_u, name="up_scales"),
+            onnx.numpy_helper.from_array(bias_up, name="up_bias"),
+            onnx.numpy_helper.from_array(down_w, name="down_w"),
+        ],
+    )
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 21),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    model.ir_version = 10
+    return model, dict(
+        qcodes_g=qcodes_g,
+        scales_g=scales_g,
+        qcodes_u=qcodes_u,
+        scales_u=scales_u,
+        kb=kb,
+        down_w=down_w,
+    )
+
+
+def test_matmul_nbits_mlp_pruning_matches_decomposed_oracle():
+    # Channels 0-3 engineered LARGE (kept), 4-7 SMALL (dropped) on BOTH
+    # gate/up branches, so the combined (root-sum-square) importance ranking
+    # is unambiguous: sparsity=0.5 must keep exactly {0, 1, 2, 3}.
+    N, K, N2, block_size = 8, 32, 5, 32
+    rng = np.random.default_rng(200)
+    W_gate = (rng.standard_normal((N, K)) * 0.3).astype(np.float32)
+    W_up = (rng.standard_normal((N, K)) * 0.3).astype(np.float32)
+    W_gate[:4] *= 8.0
+    W_up[:4] *= 8.0
+    W_gate[4:] *= 0.05
+    W_up[4:] *= 0.05
+    bias_gate = (rng.standard_normal(N) * 0.05).astype(np.float32)
+    bias_up = (rng.standard_normal(N) * 0.05).astype(np.float32)
+
+    model, info = _matmul_nbits_mlp_model(
+        N, K, N2, block_size, W_gate, W_up, bias_gate, bias_up
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_matmul_nbits(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep = np.array([0, 1, 2, 3])
+    mlp_node = next(n for n in pruned.graph.node if n.name == "mlp")
+    assert next(a.i for a in mlp_node.attribute if a.name == "N") == 4
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["gate_B"].dims) == [4, info["kb"], block_size * 4 // 8]
+    assert list(inits["up_B"].dims) == [4, info["kb"], block_size * 4 // 8]
+
+    # "slice, don't recompute": the pruned packed tensors must be BYTE-
+    # IDENTICAL to the original ones restricted to `keep`, not merely
+    # numerically close.
+    gate_B_expected = _nbits_pack_B(info["qcodes_g"][keep], 4, info["kb"], block_size)
+    up_B_expected = _nbits_pack_B(info["qcodes_u"][keep], 4, info["kb"], block_size)
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["gate_B"]), gate_B_expected
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["up_B"]), up_B_expected
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["down_w"]), info["down_w"][keep]
+    )
+
+    # Decompose the PRUNED fused node's own tensors into two standalone
+    # MatMulNBits nodes and run them through a real CPU-kernel
+    # InferenceSession -- see this section's own top comment for why the
+    # literal fused node itself cannot be executed here.
+    decomposed = onnx.helper.make_model(
+        onnx.helper.make_graph(
+            [
+                _nbits_node(
+                    "mm_gate",
+                    "A",
+                    "gate_out",
+                    "gate_B",
+                    "gate_scales",
+                    None,
+                    "gate_bias",
+                    4,
+                    K,
+                    block_size,
+                ),
+                _nbits_node(
+                    "mm_up",
+                    "A",
+                    "up_out",
+                    "up_B",
+                    "up_scales",
+                    None,
+                    "up_bias",
+                    4,
+                    K,
+                    block_size,
+                ),
+            ],
+            "g",
+            inputs=[
+                onnx.helper.make_tensor_value_info(
+                    "A", onnx.TensorProto.FLOAT, [None, K]
+                )
+            ],
+            outputs=[
+                onnx.helper.make_tensor_value_info(
+                    "gate_out", onnx.TensorProto.FLOAT, [None, 4]
+                ),
+                onnx.helper.make_tensor_value_info(
+                    "up_out", onnx.TensorProto.FLOAT, [None, 4]
+                ),
+            ],
+            initializer=[
+                inits["gate_B"],
+                inits["gate_scales"],
+                inits["gate_bias"],
+                inits["up_B"],
+                inits["up_scales"],
+                inits["up_bias"],
+            ],
+        ),
+        opset_imports=[
+            onnx.helper.make_opsetid("", 21),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    decomposed.ir_version = 10
+
+    x = np.random.default_rng(201).standard_normal((3, K)).astype(np.float32)
+    gate_out, up_out = _run(decomposed, {"A": x})
+    y_actual = np.maximum(gate_out, 0) * up_out
+
+    w_gate_dequant = _nbits_dequant(
+        info["qcodes_g"], info["scales_g"], None, block_size
+    )
+    w_up_dequant = _nbits_dequant(info["qcodes_u"], info["scales_u"], None, block_size)
+    gate_ref = x.astype(np.float64) @ w_gate_dequant[keep].T + bias_gate[keep]
+    up_ref = x.astype(np.float64) @ w_up_dequant[keep].T + bias_up[keep]
+    y_ref = np.maximum(gate_ref, 0) * up_ref
+
+    np.testing.assert_allclose(y_actual, y_ref, rtol=1e-3, atol=1e-3)
+
+
+def _matmul_nbits_qkv_model(
+    num_heads,
+    kv_num_heads,
+    d,
+    K,
+    block_size,
+    N2,
+    W_q,
+    W_k,
+    W_v,
+    bias_q,
+    bias_k,
+    bias_v,
+    norm_scale,
+    consumer="plain",
+    consumer_block_size=None,
+):
+    """Builds ``A -> MatMulNBitsQkv(qkv) -> (Q, K, V) ->
+    GroupQueryAttention(attn) -> MatMul/MatMulNBits(down) -> Z``. `Q`/`K`/`V`
+    feed the attention node's own query/key/value inputs DIRECTLY (no
+    per-head norm/RoPE hop -- see this section's own top comment for why
+    that hop is out of scope). ``consumer="plain"`` builds a plain-float
+    output projection; ``consumer="nbits"`` builds a real ``MatMulNBits``
+    one (block size `consumer_block_size`), to exercise the block-alignment
+    decline path.
+    """
+    Nq = num_heads * d
+    Nkv = kv_num_heads * d
+    qcodes_q, scales_q, kb = _nbits_quantize_default_zp(W_q, block_size)
+    qcodes_k, scales_k, _ = _nbits_quantize_default_zp(W_k, block_size)
+    qcodes_v, scales_v, _ = _nbits_quantize_default_zp(W_v, block_size)
+    q_B = _nbits_pack_B(qcodes_q, Nq, kb, block_size)
+    k_B = _nbits_pack_B(qcodes_k, Nkv, kb, block_size)
+    v_B = _nbits_pack_B(qcodes_v, Nkv, kb, block_size)
+
+    qkv_node = onnx.helper.make_node(
+        "MatMulNBitsQkv",
+        inputs=[
+            "A",
+            "",
+            "norm_scale",
+            "q_B",
+            "q_scales",
+            "q_bias",
+            "k_B",
+            "k_scales",
+            "k_bias",
+            "v_B",
+            "v_scales",
+            "v_bias",
+        ],
+        outputs=["Q", "K", "V"],
+        domain="com.microsoft",
+        name="qkv",
+        block_size=block_size,
+        bits=4,
+        Nq=Nq,
+        Nkv=Nkv,
+        K=K,
+    )
+    attn_node = onnx.helper.make_node(
+        "GroupQueryAttention",
+        inputs=["Q", "K", "V", "", "", "", ""],
+        outputs=["attn_out"],
+        domain="com.microsoft",
+        name="attn",
+        num_heads=num_heads,
+        kv_num_heads=kv_num_heads,
+    )
+    raw_out_width = num_heads * d
+    rng = np.random.default_rng(9002)
+    initializer = [
+        onnx.numpy_helper.from_array(q_B, name="q_B"),
+        onnx.numpy_helper.from_array(scales_q, name="q_scales"),
+        onnx.numpy_helper.from_array(bias_q, name="q_bias"),
+        onnx.numpy_helper.from_array(k_B, name="k_B"),
+        onnx.numpy_helper.from_array(scales_k, name="k_scales"),
+        onnx.numpy_helper.from_array(bias_k, name="k_bias"),
+        onnx.numpy_helper.from_array(v_B, name="v_B"),
+        onnx.numpy_helper.from_array(scales_v, name="v_scales"),
+        onnx.numpy_helper.from_array(bias_v, name="v_bias"),
+        onnx.numpy_helper.from_array(norm_scale, name="norm_scale"),
+    ]
+    if consumer == "plain":
+        down_w = (rng.standard_normal((raw_out_width, N2)) * 0.3).astype(np.float32)
+        down_node = onnx.helper.make_node(
+            "MatMul", ["attn_out", "down_w"], ["Z"], name="down"
+        )
+        initializer.append(onnx.numpy_helper.from_array(down_w, name="down_w"))
+        consumer_info = dict(down_w=down_w)
+    else:
+        assert consumer_block_size is not None
+        Wc = (rng.standard_normal((N2, raw_out_width)) * 0.3).astype(np.float32)
+        qcodes_c, scales_c, _zp_c, kbc = _nbits_quantize_block(Wc, consumer_block_size)
+        Bc = _nbits_pack_B(qcodes_c, N2, kbc, consumer_block_size)
+        initializer.append(onnx.numpy_helper.from_array(Bc, name="down_B"))
+        initializer.append(onnx.numpy_helper.from_array(scales_c, name="down_scales"))
+        down_node = _nbits_node(
+            "down",
+            "attn_out",
+            "Z",
+            "down_B",
+            "down_scales",
+            None,
+            None,
+            N2,
+            raw_out_width,
+            consumer_block_size,
+        )
+        consumer_info = dict(qcodes_c=qcodes_c, scales_c=scales_c, kbc=kbc)
+
+    graph = onnx.helper.make_graph(
+        [qkv_node, attn_node, down_node],
+        "g",
+        inputs=[
+            onnx.helper.make_tensor_value_info("A", onnx.TensorProto.FLOAT, [None, K])
+        ],
+        outputs=[
+            onnx.helper.make_tensor_value_info("Z", onnx.TensorProto.FLOAT, [None, N2])
+        ],
+        initializer=initializer,
+    )
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 21),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    model.ir_version = 10
+    info = dict(
+        qcodes_q=qcodes_q,
+        scales_q=scales_q,
+        qcodes_k=qcodes_k,
+        scales_k=scales_k,
+        qcodes_v=qcodes_v,
+        scales_v=scales_v,
+        kb=kb,
+        Nq=Nq,
+        Nkv=Nkv,
+    )
+    info.update(consumer_info)
+    return model, info
+
+
+def test_matmul_nbits_qkv_pruning_matches_decomposed_oracle():
+    # 4 query heads, 2 KV heads (group_size=2), head_size=2. KV group 0
+    # (query heads 0,1 + kv head 0) engineered LARGE (kept); KV group 1
+    # (query heads 2,3 + kv head 1) engineered SMALL (dropped). sparsity=0.5
+    # -> keep exactly 1 of 2 groups: group 0.
+    num_heads, kv_num_heads, d, K, block_size, N2 = 4, 2, 2, 32, 32, 5
+    rng = np.random.default_rng(300)
+    W_q = (rng.standard_normal((num_heads * d, K)) * 0.3).astype(np.float32)
+    W_k = (rng.standard_normal((kv_num_heads * d, K)) * 0.3).astype(np.float32)
+    W_v = (rng.standard_normal((kv_num_heads * d, K)) * 0.3).astype(np.float32)
+    W_q[:4] *= 8.0
+    W_q[4:] *= 0.05
+    W_k[:2] *= 8.0
+    W_k[2:] *= 0.05
+    W_v[:2] *= 8.0
+    W_v[2:] *= 0.05
+    bias_q = (rng.standard_normal(num_heads * d) * 0.05).astype(np.float32)
+    bias_k = (rng.standard_normal(kv_num_heads * d) * 0.05).astype(np.float32)
+    bias_v = (rng.standard_normal(kv_num_heads * d) * 0.05).astype(np.float32)
+    norm_scale = (1.0 + rng.standard_normal(K) * 0.1).astype(np.float32)
+
+    model, info = _matmul_nbits_qkv_model(
+        num_heads,
+        kv_num_heads,
+        d,
+        K,
+        block_size,
+        N2,
+        W_q,
+        W_k,
+        W_v,
+        bias_q,
+        bias_k,
+        bias_v,
+        norm_scale,
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_matmul_nbits(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    q_keep = np.array([0, 1, 2, 3])  # heads 0,1 (group 0), d=2 -> rows 0-3
+    kv_keep = np.array([0, 1])  # kv head 0, d=2 -> rows 0-1
+
+    qkv_node = next(n for n in pruned.graph.node if n.name == "qkv")
+    assert next(a.i for a in qkv_node.attribute if a.name == "Nq") == 4
+    assert next(a.i for a in qkv_node.attribute if a.name == "Nkv") == 2
+    attn_node = next(n for n in pruned.graph.node if n.name == "attn")
+    assert next(a.i for a in attn_node.attribute if a.name == "num_heads") == 2
+    assert next(a.i for a in attn_node.attribute if a.name == "kv_num_heads") == 1
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    q_B_expected = _nbits_pack_B(info["qcodes_q"][q_keep], 4, info["kb"], block_size)
+    k_B_expected = _nbits_pack_B(info["qcodes_k"][kv_keep], 2, info["kb"], block_size)
+    v_B_expected = _nbits_pack_B(info["qcodes_v"][kv_keep], 2, info["kb"], block_size)
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["q_B"]), q_B_expected
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["k_B"]), k_B_expected
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["v_B"]), v_B_expected
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["down_w"]), info["down_w"][q_keep]
+    )
+
+    # Decompose: real SimplifiedLayerNormalization + 3x real MatMulNBits
+    # CPU kernels, run on the PRUNED tensors, against an independent numpy
+    # RMSNorm + dequantize-then-matmul oracle -- see this section's own top
+    # comment for why the fused node itself cannot be executed here.
+    decomposed = onnx.helper.make_model(
+        onnx.helper.make_graph(
+            [
+                onnx.helper.make_node(
+                    "SimplifiedLayerNormalization",
+                    ["A", "norm_scale"],
+                    ["A_norm"],
+                    domain="",
+                    axis=-1,
+                    epsilon=1e-5,
+                ),
+                _nbits_node(
+                    "mm_q",
+                    "A_norm",
+                    "q_out",
+                    "q_B",
+                    "q_scales",
+                    None,
+                    "q_bias",
+                    4,
+                    K,
+                    block_size,
+                ),
+                _nbits_node(
+                    "mm_k",
+                    "A_norm",
+                    "k_out",
+                    "k_B",
+                    "k_scales",
+                    None,
+                    "k_bias",
+                    2,
+                    K,
+                    block_size,
+                ),
+                _nbits_node(
+                    "mm_v",
+                    "A_norm",
+                    "v_out",
+                    "v_B",
+                    "v_scales",
+                    None,
+                    "v_bias",
+                    2,
+                    K,
+                    block_size,
+                ),
+            ],
+            "g",
+            inputs=[
+                onnx.helper.make_tensor_value_info(
+                    "A", onnx.TensorProto.FLOAT, [None, K]
+                )
+            ],
+            outputs=[
+                onnx.helper.make_tensor_value_info(
+                    "q_out", onnx.TensorProto.FLOAT, [None, 4]
+                ),
+                onnx.helper.make_tensor_value_info(
+                    "k_out", onnx.TensorProto.FLOAT, [None, 2]
+                ),
+                onnx.helper.make_tensor_value_info(
+                    "v_out", onnx.TensorProto.FLOAT, [None, 2]
+                ),
+            ],
+            initializer=[
+                inits["norm_scale"],
+                inits["q_B"],
+                inits["q_scales"],
+                inits["q_bias"],
+                inits["k_B"],
+                inits["k_scales"],
+                inits["k_bias"],
+                inits["v_B"],
+                inits["v_scales"],
+                inits["v_bias"],
+            ],
+        ),
+        opset_imports=[
+            onnx.helper.make_opsetid("", 21),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    decomposed.ir_version = 10
+
+    x = np.random.default_rng(301).standard_normal((3, K)).astype(np.float32)
+    q_actual, k_actual, v_actual = _run(decomposed, {"A": x})
+
+    def _rmsnorm(a, scale, eps):
+        rms = np.sqrt(np.mean(a.astype(np.float64) ** 2, axis=-1, keepdims=True) + eps)
+        return (a.astype(np.float64) / rms) * scale.astype(np.float64)
+
+    a_norm_ref = _rmsnorm(x, norm_scale, 1e-5)
+    w_q_dequant = _nbits_dequant(info["qcodes_q"], info["scales_q"], None, block_size)
+    w_k_dequant = _nbits_dequant(info["qcodes_k"], info["scales_k"], None, block_size)
+    w_v_dequant = _nbits_dequant(info["qcodes_v"], info["scales_v"], None, block_size)
+    q_ref = a_norm_ref @ w_q_dequant[q_keep].T + bias_q[q_keep]
+    k_ref = a_norm_ref @ w_k_dequant[kv_keep].T + bias_k[kv_keep]
+    v_ref = a_norm_ref @ w_v_dequant[kv_keep].T + bias_v[kv_keep]
+
+    np.testing.assert_allclose(q_actual, q_ref, rtol=1e-3, atol=1e-3)
+    np.testing.assert_allclose(k_actual, k_ref, rtol=1e-3, atol=1e-3)
+    np.testing.assert_allclose(v_actual, v_ref, rtol=1e-3, atol=1e-3)
+
+
+def test_matmul_nbits_qkv_pruning_declines_non_block_aligned_consumer():
+    # head_size=3 (unlike the block-aligned test above's head_size=2):
+    # keep_q_heads=[0, 1] (group 0) -> q_idx = rows [0..5] (6 elements),
+    # which straddles the MatMulNBits consumer's own block boundary at row
+    # 4 (block_size=4: blocks [0,4), [4,8), [8,12)) -- rows 4, 5 are only
+    # PART of block 1, so this keep-set is NOT block-aligned. The whole
+    # chain (qkv node, attention node, AND consumer) must be left
+    # completely untouched, mirroring the plain-``MatMulNBits`` consumer's
+    # own identical decline precedent.
+    num_heads, kv_num_heads, d, K, block_size, N2 = 4, 2, 3, 32, 32, 4
+    consumer_block_size = 4
+    rng = np.random.default_rng(400)
+    W_q = (rng.standard_normal((num_heads * d, K)) * 0.3).astype(np.float32)
+    W_k = (rng.standard_normal((kv_num_heads * d, K)) * 0.3).astype(np.float32)
+    W_v = (rng.standard_normal((kv_num_heads * d, K)) * 0.3).astype(np.float32)
+    W_q[:6] *= 8.0
+    W_q[6:] *= 0.05
+    W_k[:3] *= 8.0
+    W_k[3:] *= 0.05
+    W_v[:3] *= 8.0
+    W_v[3:] *= 0.05
+    bias_q = (rng.standard_normal(num_heads * d) * 0.05).astype(np.float32)
+    bias_k = (rng.standard_normal(kv_num_heads * d) * 0.05).astype(np.float32)
+    bias_v = (rng.standard_normal(kv_num_heads * d) * 0.05).astype(np.float32)
+    norm_scale = (1.0 + rng.standard_normal(K) * 0.1).astype(np.float32)
+
+    model, _info = _matmul_nbits_qkv_model(
+        num_heads,
+        kv_num_heads,
+        d,
+        K,
+        block_size,
+        N2,
+        W_q,
+        W_k,
+        W_v,
+        bias_q,
+        bias_k,
+        bias_v,
+        norm_scale,
+        consumer="nbits",
+        consumer_block_size=consumer_block_size,
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_matmul_nbits(model, sparsity=0.5)
+
+    inits_before = {t.name: t.SerializeToString() for t in model.graph.initializer}
+    inits_after = {t.name: t.SerializeToString() for t in pruned.graph.initializer}
+    assert inits_before == inits_after
+    attrs_before = [
+        (n.name, [(a.name, a.i) for a in n.attribute]) for n in model.graph.node
+    ]
+    attrs_after = [
+        (n.name, [(a.name, a.i) for a in n.attribute]) for n in pruned.graph.node
+    ]
+    assert attrs_before == attrs_after
+
+
+def test_matmul_nbits_mlp_qkv_pruning_dry_run_matches_real_call():
+    N, K, N2, block_size = 8, 32, 5, 32
+    rng = np.random.default_rng(500)
+    W_gate = (rng.standard_normal((N, K)) * 0.3).astype(np.float32)
+    W_up = (rng.standard_normal((N, K)) * 0.3).astype(np.float32)
+    W_gate[:4] *= 8.0
+    W_up[:4] *= 8.0
+    W_gate[4:] *= 0.05
+    W_up[4:] *= 0.05
+    bias_gate = (rng.standard_normal(N) * 0.05).astype(np.float32)
+    bias_up = (rng.standard_normal(N) * 0.05).astype(np.float32)
+    mlp_model, _info = _matmul_nbits_mlp_model(
+        N, K, N2, block_size, W_gate, W_up, bias_gate, bias_up
+    )
+
+    num_heads, kv_num_heads, d = 4, 2, 2
+    W_q = (rng.standard_normal((num_heads * d, K)) * 0.3).astype(np.float32)
+    W_k = (rng.standard_normal((kv_num_heads * d, K)) * 0.3).astype(np.float32)
+    W_v = (rng.standard_normal((kv_num_heads * d, K)) * 0.3).astype(np.float32)
+    W_q[:4] *= 8.0
+    W_q[4:] *= 0.05
+    W_k[:2] *= 8.0
+    W_k[2:] *= 0.05
+    W_v[:2] *= 8.0
+    W_v[2:] *= 0.05
+    bias_q = (rng.standard_normal(num_heads * d) * 0.05).astype(np.float32)
+    bias_k = (rng.standard_normal(kv_num_heads * d) * 0.05).astype(np.float32)
+    bias_v = (rng.standard_normal(kv_num_heads * d) * 0.05).astype(np.float32)
+    norm_scale = (1.0 + rng.standard_normal(K) * 0.1).astype(np.float32)
+    qkv_model, _info2 = _matmul_nbits_qkv_model(
+        num_heads,
+        kv_num_heads,
+        d,
+        K,
+        block_size,
+        N2,
+        W_q,
+        W_k,
+        W_v,
+        bias_q,
+        bias_k,
+        bias_v,
+        norm_scale,
+    )
+
+    for model, expect_family in (
+        (mlp_model, "matmul_nbits_mlp"),
+        (qkv_model, "matmul_nbits_qkv"),
+    ):
+        report = onnxsim.analyze_pruning_sensitivity(
+            model, onnxsim.apply_structured_pruning_matmul_nbits, sparsity=0.5
+        )
+        assert report.not_eligible == []
+        assert len(report.layers) == 1
+        layer = report.layers[0]
+        assert layer.family == expect_family
+
+        pruned = onnxsim.apply_structured_pruning_matmul_nbits(model, sparsity=0.5)
+        if expect_family == "matmul_nbits_mlp":
+            node = next(n for n in pruned.graph.node if n.name == "mlp")
+            real_new_n = next(a.i for a in node.attribute if a.name == "N")
+        else:
+            node = next(n for n in pruned.graph.node if n.name == "attn")
+            real_new_n = next(a.i for a in node.attribute if a.name == "kv_num_heads")
+        assert layer.would_drop == layer.total - real_new_n
+
+    # An orphan fused node (no eligible downstream consumer) is reported via
+    # `not_eligible`, not silently dropped -- extends this file's own
+    # existing plain-``MatMulNBits`` orphan-node precedent
+    # (``test_...not_eligible``-style coverage above) to both new op types.
+    orphan_mlp = onnx.helper.make_model(
+        onnx.helper.make_graph(
+            [
+                onnx.helper.make_node(
+                    "MatMulNBitsMlp",
+                    ["A", "", "", "gate_B", "gate_scales", "", "up_B", "up_scales", ""],
+                    ["Y"],
+                    domain="com.microsoft",
+                    name="mlp_orphan",
+                    activation="Relu",
+                    block_size=32,
+                    bits=4,
+                    N=4,
+                    K=32,
+                )
+            ],
+            "g",
+            inputs=[
+                onnx.helper.make_tensor_value_info(
+                    "A", onnx.TensorProto.FLOAT, [None, 32]
+                )
+            ],
+            outputs=[
+                onnx.helper.make_tensor_value_info(
+                    "Y", onnx.TensorProto.FLOAT, [None, 4]
+                )
+            ],
+            initializer=[
+                onnx.numpy_helper.from_array(
+                    np.zeros((4, 1, 16), dtype=np.uint8), name="gate_B"
+                ),
+                onnx.numpy_helper.from_array(
+                    np.ones((4, 1), dtype=np.float32), name="gate_scales"
+                ),
+                onnx.numpy_helper.from_array(
+                    np.zeros((4, 1, 16), dtype=np.uint8), name="up_B"
+                ),
+                onnx.numpy_helper.from_array(
+                    np.ones((4, 1), dtype=np.float32), name="up_scales"
+                ),
+            ],
+        ),
+        opset_imports=[
+            onnx.helper.make_opsetid("", 21),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    orphan_mlp.ir_version = 10
+    report = onnxsim.analyze_pruning_sensitivity(
+        orphan_mlp, onnxsim.apply_structured_pruning_matmul_nbits, sparsity=0.5
+    )
+    assert report.layers == []
+    assert report.not_eligible == ["MatMulNBitsMlp 'mlp_orphan'"]


### PR DESCRIPTION
## Summary

`apply_structured_pruning_matmul_nbits`/`_analyze_structured_pruning_matmul_nbits` gained support for two more `com.microsoft` fusions ORT's own graph optimizer performs on top of plain `MatMulNBits`:

- **`MatMulNBitsMlp`** — a fused, same-input `gate`/`up` `MatMulNBits` pair (the block-quantized analogue of the SwiGLU/GeGLU gated-MLP shape `_find_gated_chains` already handles for plain-float weights). Co-slices `gate`'s/`up`'s shared output-channel axis to one shared keep-set, ranked by a combined L1/L2 importance mirroring the existing gated-pair criterion, then slices the downstream consumer.
- **`MatMulNBitsQkv`** — a fused, shared-input/shared-norm Q/K/V `MatMulNBits` triple. Prunes whole KV groups by reusing this module's own `GroupQueryAttention`/plain `ai.onnx::Attention` matchers (`_match_gqa_producer`/`_match_onnx_attention_producer`) to find and validate the real downstream attention consumer that carries head-count metadata (neither fused op has `num_heads`/`kv_num_heads` of its own), then reuses that family's per-head bookkeeping (`past_key`/`past_value`, `k_scale`/`v_scale`, `attention_bias`/mask, `head_sink`).

Both `apply_*`'s `_analyze_*` dry-run mirrors got matching `"matmul_nbits_mlp"`/`"matmul_nbits_qkv"` sensitivity-report families.

## Empirically confirmed facts (live `onnxruntime` 1.29.0 install, this environment)

- Both ops' full schemas confirmed via `onnxruntime.capi.onnxruntime_pybind11_state.get_all_operator_schema()`:
  - `MatMulNBitsMlp`: inputs `A, skip?, norm_scale?, gate_B, gate_scales, gate_bias?, up_B, up_scales, up_bias?`; outputs `Y, input_skip_bias_sum?`; attrs `activation(req), block_size(req), K(req), N(req), bits(opt,4), accuracy_level, epsilon`. **`norm_scale` is optional.**
  - `MatMulNBitsQkv`: inputs `A, skip?, norm_scale(REQUIRED), q/k/v_B+scales+bias?`; outputs `Q, K, V, input_skip_bias_sum?`; attrs `block_size(req), K(req), Nq(req), Nkv(req, shared by K and V), bits(opt,4), epsilon, accuracy_level`. **No `num_heads`/`kv_num_heads` on the op itself.**
  - **Neither op has a `zero_points` input at all** — every weight slot implicitly uses the schema's own default zero point.
- **Both fusions are WebGPU-EP-specific**, confirmed via `strings` on the installed `onnxruntime_pybind11_state...so`: the optimizer's own log message reads `"MatMulNBitsMlpFusion: skipping candidate due to non-WebGPU EP assignment."` This sandbox has no GPU/Vulkan driver (confirmed with both the system `onnxruntime` and a separately-installed `onnxruntime-webgpu==1.27.0` wheel — adapter creation fails with "No supported adapters"), so neither fused node is end-to-end executable here via a real `InferenceSession`.
- Verification substitute: each new test decomposes a pruned fused node's own tensors back into equivalent standalone `MatMulNBits`/`SimplifiedLayerNormalization` nodes (which do have CPU kernels) and runs those through a real `InferenceSession` against an independent numpy oracle (e.g. RMSNorm vs. numpy oracle: 3.66e-7 max abs err).

## Deliberately out of scope (documented in the section comment)

- No K-axis (input/hidden-dimension) pruning through either fused node — only output-channel axes are pruned, matching every other chain kind in this module.
- `skip`/`norm_scale` are read (validated present when required) but never re-sliced.
- No per-head Q/K-norm + RoPE pass-through hop for `MatMulNBitsQkv` (unlike the plain-float `_find_separate_qkv_chains` precedent) — a model relying on that hop is declined rather than mis-sliced.
- `bits=2`, `weight_prepacked`, `g_idx` remain out of scope (inherited from the existing plain `MatMulNBits` pass).

## Test plan

- [x] `pytest tests/test_pruning.py -q` — 481 → 485 passed
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — 0 errors
- [x] Independently re-confirmed both live schemas via `get_all_operator_schema()`
- [x] Independently confirmed the WebGPU-EP-only fusion behavior and lack of a usable WebGPU adapter in this sandbox
- [x] Reviewed the diff for correctness and consistency with this module's existing `MatMulNBits`/GQA-attention conventions

---
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_