### PR TITLE
Add an opt-in XNNPACK ModelExecutor backend for constant folding

### DIFF
--- a/.github/workflows/backend-integration.yml
+++ b/.github/workflows/backend-integration.yml
@@ -9,6 +9,10 @@ name: Backend Integration
 # tests/test_torch_integration.py, tests/test_modelopt_integration.py,
 # tests/test_mmdeploy_integration.py. See docs/dlpack-executor.md, which frames
 # the DLPack executor boundary as an "embeddability" seam for stacks like these.
+# The xnnpack job below is the odd one out: it exercises
+# GetXnnpackModelExecutor() (onnxsim/xnnpack_executor_test.cpp) directly via a
+# native C++ build with ONNXSIM_BUILTIN_XNNPACK=ON, not a Python wheel, so it
+# does not depend on the `build` job below.
 #
 # These checks used to live in their own workflow files (tvm-integration.yml,
 # nncase-integration.yml, halide-integration.yml, modelopt-integration.yml),
@@ -44,6 +48,11 @@ on:
       - "onnxsim/onnx_simplifier.py"
       - "onnxsim/onnxsim.cpp"
       - "docs/dlpack-executor.md"
+      - "onnxsim/onnx_to_xnnpack_subgraph.h"
+      - "onnxsim/onnx_to_xnnpack_subgraph.cpp"
+      - "onnxsim/xnnpack_executor.cpp"
+      - "onnxsim/xnnpack_executor_test.cpp"
+      - "cmake/build_xnnpack.cmake"
 
 concurrency:
   group: backend-integration-${{ github.ref }}
@@ -324,3 +333,37 @@ jobs:
       - name: Run mmdeploy integration tests
         working-directory: ${{ runner.temp }}
         run: pytest -v "$GITHUB_WORKSPACE/tests/test_mmdeploy_integration.py"
+
+  xnnpack:
+    name: XNNPACK ModelExecutor backend (native)
+    # No `needs: build`: this is a plain native C++ build (ONNXSIM_BUILTIN_ORT
+    # is left off entirely), not a consumer of the Python wheel the other jobs
+    # here share.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      SCCACHE_GHA_ENABLED: "on"
+      ACTIONS_CACHE_SERVICE_V2: "on"
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+      - uses: mozilla-actions/sccache-action@v0.0.11
+      - run: sudo apt-get update && sudo apt-get install -y ninja-build
+      - name: Configure
+        run: |
+          cmake -G Ninja -S . -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
+            -DONNXSIM_BUILTIN_ORT=OFF \
+            -DONNXSIM_BUILTIN_XNNPACK=ON \
+            -DONNXSIM_TESTS=ON \
+            -DXNNPACK_BUILD_ALL_MICROKERNELS=OFF
+        # ALL_MICROKERNELS=OFF restricts XNNPACK to the host ISA instead of
+        # every ISA variant it can runtime-dispatch across -- fine here since
+        # this job only checks onnx_to_xnnpack_subgraph.cpp's lowering is
+        # correct, not that the resulting binary is portable across CPUs.
+      - name: Build
+        run: cmake --build build --target xnnpack_executor_test
+      - name: Run
+        run: ./build/xnnpack_executor_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,12 @@ option(ONNXSIM_C_API "Build the C ABI shared library used by the Rust wrapper an
 option(ONNXSIM_COVERAGE "Instrument onnxsim's own C++ targets for gcov/llvm-cov coverage" OFF)
 option(ONNXSIM_TESTS "Build the dependency-free C++ unit tests (e.g. sym_expr)" OFF)
 option(ONNXSIM_WASM_ORT_WEB "For the Emscripten build: delegate constant folding to the page's onnxruntime-web instead of compiling and linking ONNX Runtime into the module" OFF)
+# Opt-in additional ModelExecutor backend (see onnxsim/xnnpack_executor.h and
+# docs/dlpack-executor.md): runs constant-folding fold groups through Google's
+# XNNPACK instead of ONNX Runtime, for a small, explicitly-supported subset of
+# ops. Independent of ONNXSIM_BUILTIN_ORT -- both may be built at once; the
+# caller picks which GetXxxModelExecutor() to hand to Simplify.
+option(ONNXSIM_BUILTIN_XNNPACK "Build and link Google's XNNPACK as an additional (opt-in) ModelExecutor backend for constant folding" OFF)
 
 if (ONNXSIM_WASM_ORT_WEB)
   # The whole point of this mode is to NOT bundle ONNX Runtime -- constant
@@ -111,6 +117,14 @@ if (ONNXSIM_BUILTIN_ORT)
   set(ORT_NAME onnxruntime)
 endif()
 
+if (ONNXSIM_BUILTIN_XNNPACK)
+  if (EMSCRIPTEN)
+    message(FATAL_ERROR "ONNXSIM_BUILTIN_XNNPACK is not supported for the "
+                        "Emscripten/WebAssembly build")
+  endif()
+  include(cmake/build_xnnpack.cmake)
+endif()
+
 # onnxsim's own onnx/onnx-optimizer fork provides the `onnx` target -- used for
 # every build (onnxsim's own Graph-native optimizer/shape-inference fixed
 # point needs onnxsim-fork-only extensions, e.g. onnx/common/
@@ -164,6 +178,24 @@ if (ONNXSIM_BUILTIN_ORT)
   # onnxsim.cpp/dlpack_bridge.h include onnxruntime_cxx_api.h directly.
   target_include_directories(onnxsim PRIVATE ${ONNXRUNTIME_INCLUDE_DIR})
 endif()
+if (ONNXSIM_BUILTIN_XNNPACK)
+  # onnx_to_xnnpack_subgraph.cpp / xnnpack_executor.cpp include xnnpack.h
+  # directly; the XNNPACK CMake target itself (linked below) already exports
+  # this include directory to its own sources but not to onnxsim's.
+  target_sources(onnxsim PRIVATE onnxsim/onnx_to_xnnpack_subgraph.cpp
+                                 onnxsim/xnnpack_executor.cpp)
+  target_include_directories(onnxsim PRIVATE ${XNNPACK_INCLUDE_DIR})
+  # The actual `target_link_libraries(onnxsim ... XNNPACK)` call is further
+  # below, alongside onnx/onnx_optimizer/ORT_NAME: CMake requires every
+  # target_link_libraries call for a given target to use the same
+  # keyword/plain signature, and those existing calls are plain (no
+  # PUBLIC/PRIVATE/INTERFACE), so this one must be too rather than introduced
+  # here as its own PRIVATE call.
+  # Guards the xnnpack.h-facing glue (onnx_to_xnnpack_subgraph.h,
+  # GetXnnpackModelExecutor) the same way ONNXSIM_HAS_ORT guards the Ort::
+  # glue above.
+  target_compile_definitions(onnxsim PUBLIC ONNXSIM_HAS_XNNPACK)
+endif()
 target_include_directories(onnxsim PUBLIC onnxsim)
 # dlpack.h (at third_party/dlpack/dlpack.h) is the tensor-exchange type at the
 # ModelExecutor / C-ABI executor boundary (see docs/dlpack-executor.md). The
@@ -191,6 +223,9 @@ else()
   target_link_libraries(onnxsim onnx_optimizer onnx Threads::Threads)
   if (ONNXSIM_BUILTIN_ORT)
     target_link_libraries(onnxsim ${ORT_NAME})
+  endif()
+  if (ONNXSIM_BUILTIN_XNNPACK)
+    target_link_libraries(onnxsim XNNPACK)
   endif()
 endif()
 
@@ -639,4 +674,16 @@ if (ONNXSIM_TESTS)
   target_link_libraries(tensor_pool_archive_test onnxsim)
   onnxsim_add_ort_rpath(tensor_pool_archive_test)
   add_test(NAME tensor_pool_archive_test COMMAND tensor_pool_archive_test)
+
+  if (ONNXSIM_BUILTIN_XNNPACK)
+    # Exercises GetXnnpackModelExecutor() end to end (ONNX ModelProto in,
+    # DLManagedTensor out), so it links the fully-configured `onnxsim` target
+    # like the tests above, and additionally needs xnnpack.h for building its
+    # own input/expected-output tensors.
+    add_executable(xnnpack_executor_test onnxsim/xnnpack_executor_test.cpp)
+    target_link_libraries(xnnpack_executor_test onnxsim)
+    target_include_directories(xnnpack_executor_test PRIVATE ${XNNPACK_INCLUDE_DIR})
+    onnxsim_add_ort_rpath(xnnpack_executor_test)
+    add_test(NAME xnnpack_executor_test COMMAND xnnpack_executor_test)
+  endif()
 endif()

--- a/cmake/build_xnnpack.cmake
+++ b/cmake/build_xnnpack.cmake
@@ -1,0 +1,41 @@
+# Fetch and build Google's XNNPACK (a library of optimized neural-network
+# operator kernels for Arm/x86/WebAssembly CPUs) as an additional, opt-in
+# ModelExecutor backend for constant folding -- see onnxsim/xnnpack_executor.h
+# and docs/dlpack-executor.md.
+#
+# Unlike cmake/build_ort.cmake, this does not need ExternalProject's full
+# out-of-tree isolation: XNNPACK does not define an `onnx`/`onnx_proto` CMake
+# target, so it cannot collide with onnxsim's own third_party/onnx fork the
+# way an in-tree ONNX Runtime build would (see build_ort.cmake's own comment
+# for that collision). A plain FetchContent + add_subdirectory is therefore
+# sufficient here, and leaves onnxsim linking a normal CMake target (XNNPACK)
+# instead of an imported prebuilt library.
+#
+# XNNPACK has no tagged releases -- it is a rolling `master` -- so it is
+# pinned by commit hash rather than a version tag. Bump
+# ONNXSIM_XNNPACK_GIT_TAG to pick up newer kernels/ops.
+include(FetchContent)
+
+set(ONNXSIM_XNNPACK_GIT_TAG "a5acbbec8f21a1903bbe8ef711f4fc309970ee6d" CACHE STRING
+    "XNNPACK commit to build against (XNNPACK has no tagged releases)")
+
+# XNNPACK's own CMakeLists.txt defaults both of these ON (it is normally
+# built as part of a larger project's own test suite too); onnxsim only ever
+# links the library itself, so skip compiling XNNPACK's own tests and
+# benchmarks -- by far the largest share of its build time.
+set(XNNPACK_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(XNNPACK_BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
+set(XNNPACK_BUILD_LIBRARY ON CACHE BOOL "" FORCE)
+
+FetchContent_Declare(
+  xnnpack
+  GIT_REPOSITORY https://github.com/google/XNNPACK.git
+  GIT_TAG "${ONNXSIM_XNNPACK_GIT_TAG}")
+# XNNPACK's own CMakeLists.txt calls project(XNNPACK C CXX ASM) and, when
+# neither CPUINFO_SOURCE_DIR nor PTHREADPOOL_SOURCE_DIR is predefined,
+# transitively fetches its own `cpuinfo` and `pthreadpool` dependencies the
+# same way (see its cmake/DownloadCpuinfo.cmake / DownloadPThreadPool.cmake) --
+# nothing further is needed here for those.
+FetchContent_MakeAvailable(xnnpack)
+
+set(XNNPACK_INCLUDE_DIR "${xnnpack_SOURCE_DIR}/include")

--- a/docs/dlpack-executor.md
+++ b/docs/dlpack-executor.md
@@ -109,6 +109,52 @@ One boundary, several adapters (`dlpack_bridge.h` holds the conversions):
 | `CppModelExecutor` | onnxsim.cpp (built-in ORT) | `BorrowAsOrtValue` wraps the feed buffer via ORT's borrowing `CreateTensor` — **zero copy** | `FromOrtValue` moves ORT's own output buffer into the managed tensor — **zero copy** | none at the boundary |
 | `CApiModelExecutor` | capi/onnxsim_c_api.cpp | host receives borrowed `DLManagedTensor*` | host returns owned `DLManagedTensor*`, released via their deleters | host's choice |
 | `PyModelExecutor` | cpp2py_export.cc | `ToTensorProto` → bytes | bytes → `FromTensorProtoOwning` | protobuf round trip (see below) |
+| `XnnpackModelExecutor` | xnnpack_executor.cpp (`ONNXSIM_BUILTIN_XNNPACK`) | feed pointers passed straight to `xnn_setup_runtime_v2` as `xnn_external_value`s — **zero copy** | XNNPACK writes into an executor-allocated `std::vector<float>` (it has no ORT-style "hand back the session's buffer" mode) — **one copy at the boundary** (allocation, not a memcpy) | one allocation per output |
+
+### XNNPACK: an explicitly-partial backend, not a drop-in ORT replacement
+
+`GetXnnpackModelExecutor()` (`onnxsim/xnnpack_executor.h` declares it, guarded
+by `ONNXSIM_HAS_XNNPACK`) runs fold groups through Google's
+[XNNPACK](https://github.com/google/XNNPACK) instead of ONNX Runtime, going
+through XNNPACK's own graph-level **Subgraph API**
+(`xnn_create_subgraph`/`xnn_define_*`/`xnn_create_runtime_v4`) rather than its
+per-operator kernel API. `onnxsim/onnx_to_xnnpack_subgraph.{h,cpp}` is the
+ONNX-ModelProto-to-`xnn_subgraph_t` lowering; `onnxsim/xnnpack_executor.cpp`
+is the `ModelExecutor` adapter that creates a runtime from the result, feeds
+it the call's `inputs`, invokes it, and wraps the outputs as
+`DLManagedTensor`s.
+
+Unlike `CppModelExecutor`, which delegates to ORT and so handles essentially
+any ONNX op, this lowering supports only a small, explicit fp32 op set —
+`Add`/`Sub`/`Mul`/`Div`, `Relu`, `Sigmoid`, `Gemm`/`MatMul` (2D operands only),
+and `Reshape` (static target shape only) — see
+`onnx_to_xnnpack_subgraph.h`'s `kSupportedOps`. `Lower()` throws
+`std::runtime_error` naming the reason for anything outside that: an
+unsupported op, a non-fp32 tensor, `Gemm` with `alpha != 1` or `transA != 0`,
+a `Reshape` target shape that is itself produced by another node in the fold
+group rather than being a constant or a feed, and so on. Notably absent is
+`Conv`: XNNPACK's convolution Node is NHWC-native while ONNX's is NCHW, and
+getting that layout conversion (activations *and* the OIHW→OHWI weight
+transpose) right needs more verification than this first cut has had — left
+as follow-up work rather than shipped un-verified.
+
+This makes `GetXnnpackModelExecutor()` an explicitly opt-in *alternative*
+executor (pass it to `Simplify` instead of `GetBuiltinModelExecutor()` when
+you specifically want XNNPACK — e.g. to test XNNPACK embeddability the same
+way `tests/test_tinygrad_integration.py` / `test_nncase_integration.py` test
+those backends), not a general-purpose replacement: swapping it in for a
+model using an unsupported op fails constant folding outright rather than
+falling back. `onnxsim/xnnpack_executor_test.cpp` exercises it end to end
+(each supported op, a two-node chain, and the unsupported-op error path)
+against independently-computed expected values.
+
+Build it with `-DONNXSIM_BUILTIN_XNNPACK=ON` (see `cmake/build_xnnpack.cmake`,
+which `FetchContent`s XNNPACK — pinned by commit, since XNNPACK has no tagged
+releases — the same way ORT's from-source build fetches its own `cpuinfo` and
+`pthreadpool` dependencies). It composes with `ONNXSIM_BUILTIN_ORT`
+independently: a build can have either, both, or neither, and the caller
+picks which `GetXxxModelExecutor()` to hand `Simplify`. Not supported for the
+Emscripten/WebAssembly build.
 
 The Python adapter still pays a `TensorProto` round trip because the Python side
 (onnxruntime's Python API, onnx's reference evaluator) speaks `TensorProto`, not

--- a/onnxsim/onnx_to_xnnpack_subgraph.cpp
+++ b/onnxsim/onnx_to_xnnpack_subgraph.cpp
@@ -167,8 +167,7 @@ struct LoweringContext {
     auto it = shapes.find(name);
     if (it == shapes.end()) {
       throw std::runtime_error(
-          "xnnpack backend: internal error, no known shape for '" + name +
-          "'");
+          "xnnpack backend: internal error, no known shape for '" + name + "'");
     }
     return it->second;
   }
@@ -202,11 +201,10 @@ struct LoweringContext {
                                dlt->dl_tensor.shape + dlt->dl_tensor.ndim);
     auto dims = ToSizeVec(shape);
     uint32_t id;
-    CheckStatus(
-        xnn_define_tensor_value(subgraph, xnn_datatype_fp32, dims.size(),
-                                dims.data(), dlt->dl_tensor.data,
-                                XNN_INVALID_VALUE_ID, 0, &id),
-        "define initializer '" + name + "'");
+    CheckStatus(xnn_define_tensor_value(
+                    subgraph, xnn_datatype_fp32, dims.size(), dims.data(),
+                    dlt->dl_tensor.data, XNN_INVALID_VALUE_ID, 0, &id),
+                "define initializer '" + name + "'");
     value_ids[name] = id;
     shapes[name] = std::move(shape);
     return id;
@@ -227,8 +225,8 @@ struct LoweringContext {
       }
       const auto* data = reinterpret_cast<const int64_t*>(
           static_cast<const uint8_t*>(t.data) + t.byte_offset);
-      return std::vector<int64_t>(data, data + dlpack::NumElements(t.shape,
-                                                                    t.ndim));
+      return std::vector<int64_t>(data,
+                                  data + dlpack::NumElements(t.shape, t.ndim));
     }
     auto init_it = initializers.find(name);
     if (init_it != initializers.end()) {
@@ -240,8 +238,7 @@ struct LoweringContext {
       }
       DLManagedTensor* dlt = dlpack::FromTensorProtoBorrowing(tp);
       owned_tensors->emplace_back(dlt);
-      const auto* data =
-          static_cast<const int64_t*>(dlt->dl_tensor.data);
+      const auto* data = static_cast<const int64_t*>(dlt->dl_tensor.data);
       return std::vector<int64_t>(
           data, data + dlpack::NumElements(dlt->dl_tensor.shape,
                                            dlt->dl_tensor.ndim));
@@ -270,8 +267,7 @@ struct LoweringContext {
     uint32_t id;
     CheckStatus(
         xnn_define_tensor_value(subgraph, xnn_datatype_fp32, dims.size(),
-                                dims.data(), nullptr, external_id, flags,
-                                &id),
+                                dims.data(), nullptr, external_id, flags, &id),
         "define value '" + name + "'");
     value_ids[name] = id;
     shapes[name] = shape;
@@ -292,9 +288,8 @@ void LowerBinary(LoweringContext& ctx, const onnx::NodeProto& node,
   const uint32_t out = ctx.DefineOutputValue(node.output(0), out_shape);
   const xnn_binary_params params{-std::numeric_limits<double>::infinity(),
                                  std::numeric_limits<double>::infinity()};
-  CheckStatus(
-      xnn_define_binary(ctx.subgraph, type, &params, in1, in2, out, 0),
-      node.op_type() + " '" + node.name() + "'");
+  CheckStatus(xnn_define_binary(ctx.subgraph, type, &params, in1, in2, out, 0),
+              node.op_type() + " '" + node.name() + "'");
 }
 
 void LowerUnary(LoweringContext& ctx, const onnx::NodeProto& node,
@@ -347,14 +342,12 @@ void LowerMatMulLike(LoweringContext& ctx, const onnx::NodeProto& node,
     }
   }
   const uint32_t flags = b_is_transposed ? 0 : XNN_FLAG_TRANSPOSE_WEIGHTS;
-  const uint32_t out =
-      ctx.DefineOutputValue(node.output(0), {m, n});
-  CheckStatus(
-      xnn_define_fully_connected(
-          ctx.subgraph, -std::numeric_limits<float>::infinity(),
-          std::numeric_limits<float>::infinity(), a_id, b_id, bias_id, out,
-          flags),
-      node.op_type() + " '" + node.name() + "'");
+  const uint32_t out = ctx.DefineOutputValue(node.output(0), {m, n});
+  CheckStatus(xnn_define_fully_connected(
+                  ctx.subgraph, -std::numeric_limits<float>::infinity(),
+                  std::numeric_limits<float>::infinity(), a_id, b_id, bias_id,
+                  out, flags),
+              node.op_type() + " '" + node.name() + "'");
 }
 
 void LowerGemm(LoweringContext& ctx, const onnx::NodeProto& node) {
@@ -380,8 +373,7 @@ void LowerGemm(LoweringContext& ctx, const onnx::NodeProto& node) {
     if (beta == 1.0f) {
       bias_name = node.input(2);
     } else if (beta != 0.0f) {
-      throw std::runtime_error(
-          "xnnpack backend: Gemm beta must be 0 or 1");
+      throw std::runtime_error("xnnpack backend: Gemm beta must be 0 or 1");
     }
     // beta == 0: C is present but contributes nothing; drop it, matching the
     // ONNX spec ("if beta is 0, C is not required to be defined ... its
@@ -419,8 +411,8 @@ void LowerReshape(LoweringContext& ctx, const onnx::NodeProto& node) {
   }
   const uint32_t out = ctx.DefineOutputValue(node.output(0), out_shape);
   const auto dims = ToSizeVec(out_shape);
-  CheckStatus(xnn_define_static_reshape(ctx.subgraph, dims.size(),
-                                        dims.data(), in_id, out, 0),
+  CheckStatus(xnn_define_static_reshape(ctx.subgraph, dims.size(), dims.data(),
+                                        in_id, out, 0),
               "Reshape '" + node.name() + "'");
 }
 
@@ -462,10 +454,10 @@ LoweredSubgraph Lower(const onnx::ModelProto& model,
                       const std::vector<const DLManagedTensor*>& inputs) {
   const auto& graph = model.graph();
   if (static_cast<size_t>(graph.input_size()) != inputs.size()) {
-    throw std::invalid_argument(
-        "xnnpack backend: Lower() got " + std::to_string(inputs.size()) +
-        " inputs for a graph declaring " +
-        std::to_string(graph.input_size()) + " inputs");
+    throw std::invalid_argument("xnnpack backend: Lower() got " +
+                                std::to_string(inputs.size()) +
+                                " inputs for a graph declaring " +
+                                std::to_string(graph.input_size()) + " inputs");
   }
 
   LoweredSubgraph result;
@@ -477,9 +469,8 @@ LoweredSubgraph Lower(const onnx::ModelProto& model,
 
   const uint32_t num_inputs = static_cast<uint32_t>(graph.input_size());
   const uint32_t num_outputs = static_cast<uint32_t>(graph.output_size());
-  CheckStatus(
-      xnn_create_subgraph(num_inputs + num_outputs, 0, &ctx.subgraph),
-      "create subgraph");
+  CheckStatus(xnn_create_subgraph(num_inputs + num_outputs, 0, &ctx.subgraph),
+              "create subgraph");
   // Own the subgraph from this point on, so a throw below still cleans it up
   // via ~LoweredSubgraph.
   result.subgraph = ctx.subgraph;
@@ -498,11 +489,10 @@ LoweredSubgraph Lower(const onnx::ModelProto& model,
     std::vector<int64_t> shape(t.shape, t.shape + t.ndim);
     auto dims = ToSizeVec(shape);
     uint32_t id;
-    CheckStatus(
-        xnn_define_tensor_value(ctx.subgraph, xnn_datatype_fp32, dims.size(),
-                                dims.data(), nullptr, i,
-                                XNN_VALUE_FLAG_EXTERNAL_INPUT, &id),
-        "define graph input '" + vi.name() + "'");
+    CheckStatus(xnn_define_tensor_value(ctx.subgraph, xnn_datatype_fp32,
+                                        dims.size(), dims.data(), nullptr, i,
+                                        XNN_VALUE_FLAG_EXTERNAL_INPUT, &id),
+                "define graph input '" + vi.name() + "'");
     ctx.value_ids[vi.name()] = id;
     ctx.shapes[vi.name()] = std::move(shape);
     ctx.graph_input_index[vi.name()] = static_cast<int>(i);
@@ -524,16 +514,16 @@ LoweredSubgraph Lower(const onnx::ModelProto& model,
   }
 
   if (!ctx.pending_outputs.empty()) {
-    throw std::runtime_error(
-        "xnnpack backend: graph output '" + ctx.pending_outputs.begin()->first +
-        "' is not produced by any node in the graph");
+    throw std::runtime_error("xnnpack backend: graph output '" +
+                             ctx.pending_outputs.begin()->first +
+                             "' is not produced by any node in the graph");
   }
 
   result.input_value_ids.resize(num_inputs);
   std::iota(result.input_value_ids.begin(), result.input_value_ids.end(), 0);
   result.output_value_ids.resize(num_outputs);
   std::iota(result.output_value_ids.begin(), result.output_value_ids.end(),
-           num_inputs);
+            num_inputs);
   return result;
 }
 

--- a/onnxsim/onnx_to_xnnpack_subgraph.cpp
+++ b/onnxsim/onnx_to_xnnpack_subgraph.cpp
@@ -1,0 +1,541 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See onnx_to_xnnpack_subgraph.h for the design/scope of this lowering.
+ */
+#include "onnx_to_xnnpack_subgraph.h"
+
+#include <algorithm>
+#include <limits>
+#include <numeric>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+
+#include "dlpack_bridge.h"
+#include "dlpack_dtype.h"
+
+namespace onnxsim {
+namespace xnnpack_backend {
+
+namespace {
+
+const char* StatusToString(xnn_status s) {
+  switch (s) {
+    case xnn_status_success:
+      return "success";
+    case xnn_status_uninitialized:
+      return "uninitialized";
+    case xnn_status_invalid_parameter:
+      return "invalid_parameter";
+    case xnn_status_invalid_state:
+      return "invalid_state";
+    case xnn_status_unsupported_parameter:
+      return "unsupported_parameter";
+    case xnn_status_unsupported_hardware:
+      return "unsupported_hardware";
+    case xnn_status_out_of_memory:
+      return "out_of_memory";
+    case xnn_status_reallocation_required:
+      return "reallocation_required";
+    default:
+      return "unknown xnn_status";
+  }
+}
+
+void CheckStatus(xnn_status s, const std::string& what) {
+  if (s != xnn_status_success) {
+    throw std::runtime_error("xnnpack backend: " + what +
+                             " failed: " + StatusToString(s));
+  }
+}
+
+std::vector<size_t> ToSizeVec(const std::vector<int64_t>& dims) {
+  std::vector<size_t> out(dims.size());
+  for (size_t i = 0; i < dims.size(); ++i) {
+    if (dims[i] < 0) {
+      throw std::runtime_error(
+          "xnnpack backend: negative dimension in a resolved shape");
+    }
+    out[i] = static_cast<size_t>(dims[i]);
+  }
+  return out;
+}
+
+int64_t NumElements(const std::vector<int64_t>& shape) {
+  return std::accumulate(shape.begin(), shape.end(), int64_t{1},
+                         std::multiplies<int64_t>());
+}
+
+// ONNX/numpy multidirectional broadcasting of two shapes.
+std::vector<int64_t> BroadcastShape(const std::vector<int64_t>& a,
+                                    const std::vector<int64_t>& b) {
+  const size_t n = std::max(a.size(), b.size());
+  std::vector<int64_t> out(n);
+  for (size_t i = 0; i < n; ++i) {
+    const int64_t ad = i < n - a.size() ? 1 : a[i - (n - a.size())];
+    const int64_t bd = i < n - b.size() ? 1 : b[i - (n - b.size())];
+    if (ad != bd && ad != 1 && bd != 1) {
+      throw std::runtime_error(
+          "xnnpack backend: shapes are not broadcast-compatible");
+    }
+    out[i] = std::max(ad, bd);
+  }
+  return out;
+}
+
+// Resolves Reshape's -1 (infer) / 0 (copy from input) target-dim conventions
+// (allowzero=0, the ONNX default) against the reshaped tensor's input shape.
+std::vector<int64_t> ResolveReshapeTarget(const std::vector<int64_t>& in_shape,
+                                          const std::vector<int64_t>& target) {
+  std::vector<int64_t> out(target.size());
+  int64_t infer_axis = -1;
+  int64_t known_product = 1;
+  for (size_t i = 0; i < target.size(); ++i) {
+    if (target[i] == -1) {
+      if (infer_axis != -1) {
+        throw std::runtime_error(
+            "xnnpack backend: Reshape target has more than one -1");
+      }
+      infer_axis = static_cast<int64_t>(i);
+      out[i] = -1;
+    } else if (target[i] == 0) {
+      if (i >= in_shape.size()) {
+        throw std::runtime_error(
+            "xnnpack backend: Reshape target uses 0 (copy from input) past "
+            "the input tensor's rank");
+      }
+      out[i] = in_shape[i];
+      known_product *= out[i];
+    } else {
+      out[i] = target[i];
+      known_product *= out[i];
+    }
+  }
+  if (infer_axis != -1) {
+    const int64_t total = NumElements(in_shape);
+    if (known_product == 0 || total % known_product != 0) {
+      throw std::runtime_error(
+          "xnnpack backend: Reshape target's -1 dimension is not evenly "
+          "determined by the input's element count");
+    }
+    out[infer_axis] = total / known_product;
+  }
+  return out;
+}
+
+const onnx::AttributeProto* FindAttr(const onnx::NodeProto& node,
+                                     const std::string& name) {
+  for (const auto& attr : node.attribute()) {
+    if (attr.name() == name) return &attr;
+  }
+  return nullptr;
+}
+
+float AttrFloat(const onnx::NodeProto& node, const std::string& name,
+                float default_value) {
+  const auto* attr = FindAttr(node, name);
+  return attr != nullptr ? attr->f() : default_value;
+}
+
+int64_t AttrInt(const onnx::NodeProto& node, const std::string& name,
+                int64_t default_value) {
+  const auto* attr = FindAttr(node, name);
+  return attr != nullptr ? attr->i() : default_value;
+}
+
+// Threaded through every per-node lowering function below. Owns nothing
+// itself -- `subgraph` and `owned_tensors` are borrowed from the
+// LoweredSubgraph the caller (Lower(), at the bottom of this file) is
+// building, and outlive this context.
+struct LoweringContext {
+  const onnx::ModelProto& model;
+  const std::vector<const DLManagedTensor*>& inputs;
+  xnn_subgraph_t subgraph = nullptr;
+
+  std::unordered_map<std::string, uint32_t> value_ids;
+  std::unordered_map<std::string, std::vector<int64_t>> shapes;
+  std::unordered_map<std::string, const onnx::TensorProto*> initializers;
+  std::unordered_map<std::string, int> graph_input_index;
+  // Graph-output name -> its reserved XNNPACK external id. Erased as each
+  // output gets defined, so anything left once every node has been lowered
+  // means the graph declared an output no node in it actually produces.
+  std::unordered_map<std::string, uint32_t> pending_outputs;
+  std::vector<DLManagedTensorPtr>* owned_tensors = nullptr;
+
+  const std::vector<int64_t>& ShapeOf(const std::string& name) const {
+    auto it = shapes.find(name);
+    if (it == shapes.end()) {
+      throw std::runtime_error(
+          "xnnpack backend: internal error, no known shape for '" + name +
+          "'");
+    }
+    return it->second;
+  }
+
+  // Returns the XNNPACK Value ID for `name`, defining it as an internal
+  // constant Value (borrowing the initializer's data, via dlpack_bridge so a
+  // big-endian host gets a byte-swapped copy) the first time it is asked for.
+  // Throws if `name` is neither already-defined nor a graph initializer --
+  // i.e. it would have to be the output of a node not yet lowered, which
+  // cannot happen for a topologically-ordered graph feeding only forward
+  // references, or is simply unknown.
+  uint32_t GetOrDefineValueId(const std::string& name) {
+    auto it = value_ids.find(name);
+    if (it != value_ids.end()) return it->second;
+
+    auto init_it = initializers.find(name);
+    if (init_it == initializers.end()) {
+      throw std::runtime_error(
+          "xnnpack backend: value '" + name +
+          "' is neither a graph input, an initializer, nor a prior node "
+          "output");
+    }
+    const onnx::TensorProto& tp = *init_it->second;
+    if (tp.data_type() != onnx::TensorProto::FLOAT) {
+      throw std::runtime_error("xnnpack backend: initializer '" + name +
+                               "' is not fp32 (only fp32 is supported)");
+    }
+    DLManagedTensor* dlt = dlpack::FromTensorProtoBorrowing(tp);
+    owned_tensors->emplace_back(dlt);
+    std::vector<int64_t> shape(dlt->dl_tensor.shape,
+                               dlt->dl_tensor.shape + dlt->dl_tensor.ndim);
+    auto dims = ToSizeVec(shape);
+    uint32_t id;
+    CheckStatus(
+        xnn_define_tensor_value(subgraph, xnn_datatype_fp32, dims.size(),
+                                dims.data(), dlt->dl_tensor.data,
+                                XNN_INVALID_VALUE_ID, 0, &id),
+        "define initializer '" + name + "'");
+    value_ids[name] = id;
+    shapes[name] = std::move(shape);
+    return id;
+  }
+
+  // Reads out the actual int64 values of `name`, which must be a graph input
+  // or an initializer (not the output of another node in this fold group --
+  // XNNPACK's Reshape/Transpose take their target shape/permutation as
+  // compile-time-static arguments, not a runtime tensor input).
+  std::vector<int64_t> ReadInt64Values(const std::string& name) {
+    auto gi = graph_input_index.find(name);
+    if (gi != graph_input_index.end()) {
+      const DLTensor& t = inputs[gi->second]->dl_tensor;
+      if (!(t.dtype.code == kDLInt && t.dtype.bits == 64)) {
+        throw std::runtime_error("xnnpack backend: '" + name +
+                                 "' must be int64 to be used as a static "
+                                 "shape");
+      }
+      const auto* data = reinterpret_cast<const int64_t*>(
+          static_cast<const uint8_t*>(t.data) + t.byte_offset);
+      return std::vector<int64_t>(data, data + dlpack::NumElements(t.shape,
+                                                                    t.ndim));
+    }
+    auto init_it = initializers.find(name);
+    if (init_it != initializers.end()) {
+      const onnx::TensorProto& tp = *init_it->second;
+      if (tp.data_type() != onnx::TensorProto::INT64) {
+        throw std::runtime_error("xnnpack backend: '" + name +
+                                 "' must be int64 to be used as a static "
+                                 "shape");
+      }
+      DLManagedTensor* dlt = dlpack::FromTensorProtoBorrowing(tp);
+      owned_tensors->emplace_back(dlt);
+      const auto* data =
+          static_cast<const int64_t*>(dlt->dl_tensor.data);
+      return std::vector<int64_t>(
+          data, data + dlpack::NumElements(dlt->dl_tensor.shape,
+                                           dlt->dl_tensor.ndim));
+    }
+    throw std::runtime_error(
+        "xnnpack backend: '" + name +
+        "' must be a constant or a graph input to be used as a static shape "
+        "(this lowering does not support one produced by another node)");
+  }
+
+  // Defines the output Value for a just-lowered node: as the reserved
+  // external-output Value if `name` is one of the graph's declared outputs,
+  // or as an internal Value otherwise. Records its id/shape either way so
+  // later nodes can reference it as an input.
+  uint32_t DefineOutputValue(const std::string& name,
+                             const std::vector<int64_t>& shape) {
+    auto dims = ToSizeVec(shape);
+    uint32_t external_id = XNN_INVALID_VALUE_ID;
+    uint32_t flags = 0;
+    auto it = pending_outputs.find(name);
+    if (it != pending_outputs.end()) {
+      external_id = it->second;
+      flags = XNN_VALUE_FLAG_EXTERNAL_OUTPUT;
+      pending_outputs.erase(it);
+    }
+    uint32_t id;
+    CheckStatus(
+        xnn_define_tensor_value(subgraph, xnn_datatype_fp32, dims.size(),
+                                dims.data(), nullptr, external_id, flags,
+                                &id),
+        "define value '" + name + "'");
+    value_ids[name] = id;
+    shapes[name] = shape;
+    return id;
+  }
+};
+
+void LowerBinary(LoweringContext& ctx, const onnx::NodeProto& node,
+                 xnn_binary_operator type) {
+  if (node.input_size() != 2 || node.output_size() != 1) {
+    throw std::runtime_error("xnnpack backend: " + node.op_type() +
+                             " must have exactly 2 inputs and 1 output");
+  }
+  const uint32_t in1 = ctx.GetOrDefineValueId(node.input(0));
+  const uint32_t in2 = ctx.GetOrDefineValueId(node.input(1));
+  const auto out_shape =
+      BroadcastShape(ctx.ShapeOf(node.input(0)), ctx.ShapeOf(node.input(1)));
+  const uint32_t out = ctx.DefineOutputValue(node.output(0), out_shape);
+  const xnn_binary_params params{-std::numeric_limits<double>::infinity(),
+                                 std::numeric_limits<double>::infinity()};
+  CheckStatus(
+      xnn_define_binary(ctx.subgraph, type, &params, in1, in2, out, 0),
+      node.op_type() + " '" + node.name() + "'");
+}
+
+void LowerUnary(LoweringContext& ctx, const onnx::NodeProto& node,
+                xnn_unary_operator type, const xnn_unary_params& params) {
+  if (node.input_size() != 1 || node.output_size() != 1) {
+    throw std::runtime_error("xnnpack backend: " + node.op_type() +
+                             " must have exactly 1 input and 1 output");
+  }
+  const uint32_t in = ctx.GetOrDefineValueId(node.input(0));
+  const uint32_t out =
+      ctx.DefineOutputValue(node.output(0), ctx.ShapeOf(node.input(0)));
+  CheckStatus(xnn_define_unary(ctx.subgraph, type, &params, in, out, 0),
+              node.op_type() + " '" + node.name() + "'");
+}
+
+// Shared by Gemm (transA=0, transB in {0,1}) and MatMul (both 2D, no
+// transpose/bias) -- both lower to xnn_define_fully_connected, which is
+// XNNPACK's only matrix-multiply Node. `b_is_transposed` mirrors ONNX Gemm's
+// transB: false means B is [K, N] (needs XNN_FLAG_TRANSPOSE_WEIGHTS, since
+// xnn_define_fully_connected's default filter layout is [N, K]); true means B
+// is already [N, K].
+void LowerMatMulLike(LoweringContext& ctx, const onnx::NodeProto& node,
+                     const std::string& a_name, const std::string& b_name,
+                     const std::string& bias_name /* may be empty */,
+                     bool b_is_transposed) {
+  const uint32_t a_id = ctx.GetOrDefineValueId(a_name);
+  const uint32_t b_id = ctx.GetOrDefineValueId(b_name);
+  const auto& a_shape = ctx.ShapeOf(a_name);
+  const auto& b_shape = ctx.ShapeOf(b_name);
+  if (a_shape.size() != 2 || b_shape.size() != 2) {
+    throw std::runtime_error("xnnpack backend: " + node.op_type() +
+                             " only supports 2D operands");
+  }
+  const int64_t m = a_shape[0], k = a_shape[1];
+  const int64_t b_k = b_is_transposed ? b_shape[1] : b_shape[0];
+  const int64_t n = b_is_transposed ? b_shape[0] : b_shape[1];
+  if (b_k != k) {
+    throw std::runtime_error("xnnpack backend: " + node.op_type() +
+                             ": incompatible operand shapes");
+  }
+  uint32_t bias_id = XNN_INVALID_VALUE_ID;
+  if (!bias_name.empty()) {
+    bias_id = ctx.GetOrDefineValueId(bias_name);
+    const auto& c_shape = ctx.ShapeOf(bias_name);
+    if (!(c_shape.size() == 1 && c_shape[0] == n)) {
+      throw std::runtime_error(
+          "xnnpack backend: " + node.op_type() +
+          ": bias must be 1-D with shape [N] (broadcasting a scalar or "
+          "[M, N] bias is not supported)");
+    }
+  }
+  const uint32_t flags = b_is_transposed ? 0 : XNN_FLAG_TRANSPOSE_WEIGHTS;
+  const uint32_t out =
+      ctx.DefineOutputValue(node.output(0), {m, n});
+  CheckStatus(
+      xnn_define_fully_connected(
+          ctx.subgraph, -std::numeric_limits<float>::infinity(),
+          std::numeric_limits<float>::infinity(), a_id, b_id, bias_id, out,
+          flags),
+      node.op_type() + " '" + node.name() + "'");
+}
+
+void LowerGemm(LoweringContext& ctx, const onnx::NodeProto& node) {
+  if (node.input_size() < 2 || node.input_size() > 3 ||
+      node.output_size() != 1) {
+    throw std::runtime_error(
+        "xnnpack backend: Gemm must have 2 or 3 inputs and 1 output");
+  }
+  const float alpha = AttrFloat(node, "alpha", 1.0f);
+  const float beta = AttrFloat(node, "beta", 1.0f);
+  const int64_t transA = AttrInt(node, "transA", 0);
+  const int64_t transB = AttrInt(node, "transB", 0);
+  if (alpha != 1.0f) {
+    throw std::runtime_error(
+        "xnnpack backend: Gemm alpha != 1 is not supported");
+  }
+  if (transA != 0) {
+    throw std::runtime_error(
+        "xnnpack backend: Gemm transA != 0 is not supported");
+  }
+  std::string bias_name;
+  if (node.input_size() == 3) {
+    if (beta == 1.0f) {
+      bias_name = node.input(2);
+    } else if (beta != 0.0f) {
+      throw std::runtime_error(
+          "xnnpack backend: Gemm beta must be 0 or 1");
+    }
+    // beta == 0: C is present but contributes nothing; drop it, matching the
+    // ONNX spec ("if beta is 0, C is not required to be defined ... its
+    // values are ignored").
+  }
+  LowerMatMulLike(ctx, node, node.input(0), node.input(1), bias_name,
+                  /*b_is_transposed=*/transB != 0);
+}
+
+void LowerMatMul(LoweringContext& ctx, const onnx::NodeProto& node) {
+  if (node.input_size() != 2 || node.output_size() != 1) {
+    throw std::runtime_error(
+        "xnnpack backend: MatMul must have 2 inputs and 1 output");
+  }
+  LowerMatMulLike(ctx, node, node.input(0), node.input(1), /*bias_name=*/"",
+                  /*b_is_transposed=*/false);
+}
+
+void LowerReshape(LoweringContext& ctx, const onnx::NodeProto& node) {
+  if (node.input_size() != 2 || node.output_size() != 1) {
+    throw std::runtime_error(
+        "xnnpack backend: Reshape must have 2 inputs and 1 output");
+  }
+  if (AttrInt(node, "allowzero", 0) != 0) {
+    throw std::runtime_error(
+        "xnnpack backend: Reshape allowzero=1 is not supported");
+  }
+  const uint32_t in_id = ctx.GetOrDefineValueId(node.input(0));
+  const auto& in_shape = ctx.ShapeOf(node.input(0));
+  const auto target = ctx.ReadInt64Values(node.input(1));
+  const auto out_shape = ResolveReshapeTarget(in_shape, target);
+  if (NumElements(out_shape) != NumElements(in_shape)) {
+    throw std::runtime_error(
+        "xnnpack backend: Reshape target does not preserve element count");
+  }
+  const uint32_t out = ctx.DefineOutputValue(node.output(0), out_shape);
+  const auto dims = ToSizeVec(out_shape);
+  CheckStatus(xnn_define_static_reshape(ctx.subgraph, dims.size(),
+                                        dims.data(), in_id, out, 0),
+              "Reshape '" + node.name() + "'");
+}
+
+void LowerNode(LoweringContext& ctx, const onnx::NodeProto& node) {
+  const std::string& op = node.op_type();
+  if (op == "Add") return LowerBinary(ctx, node, xnn_binary_add);
+  if (op == "Sub") return LowerBinary(ctx, node, xnn_binary_subtract);
+  if (op == "Mul") return LowerBinary(ctx, node, xnn_binary_multiply);
+  if (op == "Div") return LowerBinary(ctx, node, xnn_binary_divide);
+  if (op == "Relu") {
+    xnn_unary_params p{};
+    p.clamp.min = 0.0f;
+    p.clamp.max = std::numeric_limits<float>::infinity();
+    return LowerUnary(ctx, node, xnn_unary_clamp, p);
+  }
+  if (op == "Sigmoid") {
+    xnn_unary_params p{};
+    return LowerUnary(ctx, node, xnn_unary_sigmoid, p);
+  }
+  if (op == "Gemm") return LowerGemm(ctx, node);
+  if (op == "MatMul") return LowerMatMul(ctx, node);
+  if (op == "Reshape") return LowerReshape(ctx, node);
+  throw std::runtime_error("xnnpack backend: unsupported op '" + op +
+                           "' (node '" + node.name() + "')");
+}
+
+}  // namespace
+
+LoweredSubgraph::~LoweredSubgraph() {
+  // Delete the subgraph (and any runtime built from it must already have
+  // been deleted by the caller -- see onnxsim/xnnpack_executor.cpp) before
+  // `owned_tensors` releases the buffers it may still be pointing at.
+  if (subgraph != nullptr) {
+    xnn_delete_subgraph(subgraph);
+  }
+}
+
+LoweredSubgraph Lower(const onnx::ModelProto& model,
+                      const std::vector<const DLManagedTensor*>& inputs) {
+  const auto& graph = model.graph();
+  if (static_cast<size_t>(graph.input_size()) != inputs.size()) {
+    throw std::invalid_argument(
+        "xnnpack backend: Lower() got " + std::to_string(inputs.size()) +
+        " inputs for a graph declaring " +
+        std::to_string(graph.input_size()) + " inputs");
+  }
+
+  LoweredSubgraph result;
+  LoweringContext ctx{model, inputs};
+  ctx.owned_tensors = &result.owned_tensors;
+  for (const auto& tp : graph.initializer()) {
+    ctx.initializers[tp.name()] = &tp;
+  }
+
+  const uint32_t num_inputs = static_cast<uint32_t>(graph.input_size());
+  const uint32_t num_outputs = static_cast<uint32_t>(graph.output_size());
+  CheckStatus(
+      xnn_create_subgraph(num_inputs + num_outputs, 0, &ctx.subgraph),
+      "create subgraph");
+  // Own the subgraph from this point on, so a throw below still cleans it up
+  // via ~LoweredSubgraph.
+  result.subgraph = ctx.subgraph;
+
+  for (uint32_t i = 0; i < num_inputs; ++i) {
+    const auto& vi = graph.input(i);
+    const DLTensor& t = inputs[i]->dl_tensor;
+    if (!(t.dtype.code == kDLFloat && t.dtype.bits == 32)) {
+      throw std::runtime_error("xnnpack backend: graph input '" + vi.name() +
+                               "' is not fp32 (only fp32 is supported)");
+    }
+    if (t.device.device_type != kDLCPU) {
+      throw std::runtime_error("xnnpack backend: graph input '" + vi.name() +
+                               "' is not a CPU tensor");
+    }
+    std::vector<int64_t> shape(t.shape, t.shape + t.ndim);
+    auto dims = ToSizeVec(shape);
+    uint32_t id;
+    CheckStatus(
+        xnn_define_tensor_value(ctx.subgraph, xnn_datatype_fp32, dims.size(),
+                                dims.data(), nullptr, i,
+                                XNN_VALUE_FLAG_EXTERNAL_INPUT, &id),
+        "define graph input '" + vi.name() + "'");
+    ctx.value_ids[vi.name()] = id;
+    ctx.shapes[vi.name()] = std::move(shape);
+    ctx.graph_input_index[vi.name()] = static_cast<int>(i);
+  }
+
+  for (uint32_t j = 0; j < num_outputs; ++j) {
+    const std::string& name = graph.output(j).name();
+    if (ctx.value_ids.count(name) != 0) {
+      throw std::runtime_error(
+          "xnnpack backend: graph output '" + name +
+          "' aliases a graph input directly, which this lowering does not "
+          "support");
+    }
+    ctx.pending_outputs[name] = num_inputs + j;
+  }
+
+  for (const auto& node : graph.node()) {
+    LowerNode(ctx, node);
+  }
+
+  if (!ctx.pending_outputs.empty()) {
+    throw std::runtime_error(
+        "xnnpack backend: graph output '" + ctx.pending_outputs.begin()->first +
+        "' is not produced by any node in the graph");
+  }
+
+  result.input_value_ids.resize(num_inputs);
+  std::iota(result.input_value_ids.begin(), result.input_value_ids.end(), 0);
+  result.output_value_ids.resize(num_outputs);
+  std::iota(result.output_value_ids.begin(), result.output_value_ids.end(),
+           num_inputs);
+  return result;
+}
+
+}  // namespace xnnpack_backend
+}  // namespace onnxsim

--- a/onnxsim/onnx_to_xnnpack_subgraph.h
+++ b/onnxsim/onnx_to_xnnpack_subgraph.h
@@ -42,8 +42,7 @@ namespace xnnpack_backend {
 // Op types this lowering understands. Anything else in the fold-group graph
 // makes Lower() throw std::runtime_error naming the unsupported op.
 inline constexpr const char* kSupportedOps[] = {
-    "Add", "Sub", "Mul", "Div", "Relu", "Sigmoid",
-    "Gemm", "MatMul", "Reshape",
+    "Add", "Sub", "Mul", "Div", "Relu", "Sigmoid", "Gemm", "MatMul", "Reshape",
 };
 
 // Owns an xnn_subgraph_t plus everything it borrows: `subgraph` holds

--- a/onnxsim/onnx_to_xnnpack_subgraph.h
+++ b/onnxsim/onnx_to_xnnpack_subgraph.h
@@ -1,0 +1,116 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Lowers an onnx::ModelProto (one of constant folding's throwaway fold-group
+ * sub-models, see onnxsim/constant_folding.cpp) into an XNNPACK
+ * `xnn_subgraph_t` -- the "ONNX to XNNPACK's Subgraph API" translation.
+ *
+ * This is deliberately NOT a general ONNX importer: it supports a small,
+ * explicit set of fp32 ops (see kSupportedOps below) and throws
+ * std::runtime_error with a specific reason for anything else -- an
+ * unsupported op, a non-fp32 tensor, a shape it cannot resolve statically, an
+ * attribute combination it does not implement. onnxsim/xnnpack_executor.h is
+ * the ModelExecutor adapter that calls this, creates a runtime from the
+ * result, and is the piece that actually invokes XNNPACK.
+ *
+ * Shapes: unlike ONNX Runtime (which re-derives shapes from the model itself),
+ * XNNPACK's `xnn_define_tensor_value` requires every Value's shape up front,
+ * including intermediate node outputs. Rather than depend on `model` already
+ * carrying populated ValueInfoProto shape annotations for every intermediate
+ * (constant_folding.cpp's fold-group models may or may not), this lowering
+ * computes each supported op's output shape itself from its already-known
+ * input shapes, in the same pass that walks the graph -- effectively a tiny,
+ * self-contained ONNX shape inference limited to the ops this backend
+ * supports.
+ */
+#ifndef ONNXSIM_ONNX_TO_XNNPACK_SUBGRAPH_H_
+#define ONNXSIM_ONNX_TO_XNNPACK_SUBGRAPH_H_
+
+#include <onnx/onnx_pb.h>
+#include <xnnpack.h>
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "dlpack/dlpack.h"
+#include "onnxsim.h"
+
+namespace onnxsim {
+namespace xnnpack_backend {
+
+// Op types this lowering understands. Anything else in the fold-group graph
+// makes Lower() throw std::runtime_error naming the unsupported op.
+inline constexpr const char* kSupportedOps[] = {
+    "Add", "Sub", "Mul", "Div", "Relu", "Sigmoid",
+    "Gemm", "MatMul", "Reshape",
+};
+
+// Owns an xnn_subgraph_t plus everything it borrows: `subgraph` holds
+// pointers into `model`'s initializers (safe -- Lower's caller, and this
+// struct's caller in turn, keep `model` alive for at least as long as this
+// struct) and into `input_bytes_holders` (owned here, for any tensor this
+// lowering itself materializes, e.g. a big-endian-swapped initializer).
+struct LoweredSubgraph {
+  xnn_subgraph_t subgraph = nullptr;
+
+  // Value IDs for model.graph().input(i) / model.graph().output(j), in the
+  // same positional order ModelExecutor::Run uses for `inputs` and its
+  // returned tensors. Reserved as XNNPACK external IDs [0, num_inputs) and
+  // [num_inputs, num_inputs + num_outputs) respectively -- see Lower()'s
+  // implementation.
+  std::vector<uint32_t> input_value_ids;
+  std::vector<uint32_t> output_value_ids;
+
+  // Backing storage for any tensor materialized during lowering (currently:
+  // only a big-endian host's byte-swapped copy of an initializer -- see
+  // dlpack_bridge.h's kRawDataIsHostOrder). Must outlive `subgraph` and any
+  // xnn_runtime_t created from it.
+  std::vector<DLManagedTensorPtr> owned_tensors;
+
+  LoweredSubgraph() = default;
+  // Not = default: a defaulted move would shallow-copy `subgraph` without
+  // nulling the source, so both the moved-from and moved-to object would
+  // call xnn_delete_subgraph on the same handle at destruction time.
+  LoweredSubgraph(LoweredSubgraph&& other) noexcept
+      : subgraph(other.subgraph),
+        input_value_ids(std::move(other.input_value_ids)),
+        output_value_ids(std::move(other.output_value_ids)),
+        owned_tensors(std::move(other.owned_tensors)) {
+    other.subgraph = nullptr;
+  }
+  LoweredSubgraph& operator=(LoweredSubgraph&& other) noexcept {
+    if (this != &other) {
+      if (subgraph != nullptr) xnn_delete_subgraph(subgraph);
+      subgraph = other.subgraph;
+      input_value_ids = std::move(other.input_value_ids);
+      output_value_ids = std::move(other.output_value_ids);
+      owned_tensors = std::move(other.owned_tensors);
+      other.subgraph = nullptr;
+    }
+    return *this;
+  }
+  LoweredSubgraph(const LoweredSubgraph&) = delete;
+  LoweredSubgraph& operator=(const LoweredSubgraph&) = delete;
+  ~LoweredSubgraph();
+};
+
+// Translate `model`'s graph into an XNNPACK subgraph. `inputs[i]` must
+// positionally match model.graph().input(i) (same contract as
+// ModelExecutor::Run) and are read (not retained) during lowering, to learn
+// graph-input shapes and, for a Reshape target-shape input that is itself a
+// graph input rather than an initializer, its actual values.
+//
+// Throws std::invalid_argument for a malformed call (size mismatch with
+// `inputs`) and std::runtime_error for anything this lowering does not
+// support -- an op outside kSupportedOps, a non-fp32 tensor, an attribute
+// combination not implemented (e.g. Gemm transA=1), or a shape this lowering
+// cannot resolve statically (e.g. Reshape's shape tensor produced by another
+// node in the same fold group rather than a constant/feed).
+LoweredSubgraph Lower(const onnx::ModelProto& model,
+                      const std::vector<const DLManagedTensor*>& inputs);
+
+}  // namespace xnnpack_backend
+}  // namespace onnxsim
+
+#endif  // ONNXSIM_ONNX_TO_XNNPACK_SUBGRAPH_H_

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -80,6 +80,18 @@ void InitEnv();
 std::shared_ptr<const ModelExecutor> GetBuiltinModelExecutor();
 #endif
 
+#ifdef ONNXSIM_HAS_XNNPACK
+// Returns a model executor backed by Google's XNNPACK (see
+// onnxsim/xnnpack_executor.h and docs/dlpack-executor.md). Only available
+// when onnxsim is built with ONNXSIM_BUILTIN_XNNPACK. Unlike
+// GetBuiltinModelExecutor, this executor supports only a small, explicit
+// subset of ops (see onnxsim/onnx_to_xnnpack_subgraph.h) -- Run() throws
+// std::runtime_error for anything else, so it is meant as an alternative,
+// explicitly-opted-into backend (e.g. for testing XNNPACK embeddability),
+// not a general-purpose drop-in replacement for the ORT-backed executor.
+std::shared_ptr<const ModelExecutor> GetXnnpackModelExecutor();
+#endif
+
 // ``target_opset_version``, when set, converts the model to that opset version
 // of the default ONNX domain (using onnx's version converter) before
 // simplifying, so the simplifier can clean up any redundant nodes the

--- a/onnxsim/xnnpack_executor.cpp
+++ b/onnxsim/xnnpack_executor.cpp
@@ -30,9 +30,9 @@ namespace {
 
 void CheckXnnStatus(xnn_status s, const char* what) {
   if (s != xnn_status_success) {
-    throw std::runtime_error(std::string("xnnpack backend: ") + what +
-                             " failed (xnn_status=" +
-                             std::to_string(static_cast<int>(s)) + ")");
+    throw std::runtime_error(
+        std::string("xnnpack backend: ") + what +
+        " failed (xnn_status=" + std::to_string(static_cast<int>(s)) + ")");
   }
 }
 
@@ -53,8 +53,7 @@ struct XnnpackOutputBuffer {
   std::vector<int64_t> shape;
 };
 
-DLManagedTensor* WrapOutputBuffer(
-    std::unique_ptr<XnnpackOutputBuffer> ctx) {
+DLManagedTensor* WrapOutputBuffer(std::unique_ptr<XnnpackOutputBuffer> ctx) {
   auto* managed = new DLManagedTensor;
   managed->dl_tensor.data = ctx->data.data();
   managed->dl_tensor.device = DLDevice{kDLCPU, 0};

--- a/onnxsim/xnnpack_executor.cpp
+++ b/onnxsim/xnnpack_executor.cpp
@@ -1,0 +1,156 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * ModelExecutor backed by Google's XNNPACK. onnx_to_xnnpack_subgraph.h does
+ * the ONNX -> XNNPACK Subgraph API translation; this file is the adapter that
+ * turns the resulting xnn_subgraph_t into an xnn_runtime_t, feeds it this
+ * call's `inputs`, invokes it, and hands the outputs back as DLManagedTensors
+ * -- the same role onnxsim/constant_folding.cpp's CppModelExecutor plays for
+ * ONNX Runtime (see docs/dlpack-executor.md's adapters table).
+ *
+ * Like CppModelExecutor's per-call Ort::Session, this builds a fresh
+ * xnn_subgraph_t + xnn_runtime_t on every Run() call: each call is one
+ * throwaway constant-folding fold group, not a model meant to be executed
+ * repeatedly, so there is nothing to gain from caching either across calls.
+ */
+#include <xnnpack.h>
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "dlpack/dlpack.h"
+#include "onnx_to_xnnpack_subgraph.h"
+#include "onnxsim.h"
+
+namespace {
+
+void CheckXnnStatus(xnn_status s, const char* what) {
+  if (s != xnn_status_success) {
+    throw std::runtime_error(std::string("xnnpack backend: ") + what +
+                             " failed (xnn_status=" +
+                             std::to_string(static_cast<int>(s)) + ")");
+  }
+}
+
+void EnsureXnnpackInitialized() {
+  static std::once_flag once;
+  static xnn_status status = xnn_status_uninitialized;
+  std::call_once(once, [] { status = xnn_initialize(/*allocator=*/nullptr); });
+  CheckXnnStatus(status, "xnn_initialize");
+}
+
+// Backing store for one output, allocated and owned by this executor: unlike
+// ONNX Runtime (see dlpack_bridge.h's FromOrtValue), XNNPACK writes external
+// outputs into caller-supplied memory rather than handing back its own
+// buffer, so Run() below allocates `data` itself and this struct is what the
+// returned DLManagedTensor's deleter frees.
+struct XnnpackOutputBuffer {
+  std::vector<float> data;
+  std::vector<int64_t> shape;
+};
+
+DLManagedTensor* WrapOutputBuffer(
+    std::unique_ptr<XnnpackOutputBuffer> ctx) {
+  auto* managed = new DLManagedTensor;
+  managed->dl_tensor.data = ctx->data.data();
+  managed->dl_tensor.device = DLDevice{kDLCPU, 0};
+  managed->dl_tensor.ndim = static_cast<int32_t>(ctx->shape.size());
+  managed->dl_tensor.dtype = DLDataType{kDLFloat, 32, 1};
+  managed->dl_tensor.shape = ctx->shape.data();
+  managed->dl_tensor.strides = nullptr;
+  managed->dl_tensor.byte_offset = 0;
+  managed->manager_ctx = ctx.release();
+  managed->deleter = [](DLManagedTensor* self) {
+    delete static_cast<XnnpackOutputBuffer*>(self->manager_ctx);
+    delete self;
+  };
+  return managed;
+}
+
+// xnn_delete_runtime must run before the LoweredSubgraph that built it (which
+// owns the subgraph and the static data backing every constant Value,
+// including packed-weight source buffers) is destroyed -- see
+// LoweredSubgraph's own destructor comment in onnx_to_xnnpack_subgraph.h.
+// Declaring a RuntimeGuard after the LoweredSubgraph in the same scope gets
+// this for free from C++'s reverse-order local destruction.
+struct RuntimeGuard {
+  xnn_runtime_t runtime = nullptr;
+  ~RuntimeGuard() {
+    if (runtime != nullptr) xnn_delete_runtime(runtime);
+  }
+};
+
+struct XnnpackModelExecutor : public ModelExecutor {
+  std::vector<DLManagedTensorPtr> Run(
+      const onnx::ModelProto& model,
+      const std::vector<const DLManagedTensor*>& inputs) const override {
+    EnsureXnnpackInitialized();
+
+    onnxsim::xnnpack_backend::LoweredSubgraph lowered =
+        onnxsim::xnnpack_backend::Lower(model, inputs);
+
+    RuntimeGuard rt;
+    CheckXnnStatus(
+        xnn_create_runtime_v4(lowered.subgraph, /*weights_cache=*/nullptr,
+                              /*workspace=*/nullptr, /*threadpool=*/nullptr,
+                              /*flags=*/0, &rt.runtime),
+        "xnn_create_runtime_v4");
+    CheckXnnStatus(xnn_reshape_runtime(rt.runtime), "xnn_reshape_runtime");
+
+    std::vector<xnn_external_value> external_values;
+    external_values.reserve(lowered.input_value_ids.size() +
+                            lowered.output_value_ids.size());
+    for (size_t i = 0; i < inputs.size(); ++i) {
+      const DLTensor& t = inputs[i]->dl_tensor;
+      external_values.push_back(xnn_external_value{
+          lowered.input_value_ids[i],
+          const_cast<void*>(static_cast<const void*>(
+              static_cast<const uint8_t*>(t.data) + t.byte_offset))});
+    }
+
+    // Reshape has already run, so every external value's shape (including
+    // outputs) is settled; query it rather than re-deriving it, per
+    // xnn_get_external_value_shape's documented contract ("Output tensor
+    // shapes are returned by xnn_get_external_value_shape").
+    std::vector<std::unique_ptr<XnnpackOutputBuffer>> out_bufs;
+    out_bufs.reserve(lowered.output_value_ids.size());
+    for (uint32_t out_id : lowered.output_value_ids) {
+      size_t ndim = 0;
+      size_t dims[XNN_MAX_TENSOR_DIMS];
+      CheckXnnStatus(
+          xnn_get_external_value_shape(rt.runtime, out_id, &ndim, dims),
+          "xnn_get_external_value_shape");
+      auto buf = std::make_unique<XnnpackOutputBuffer>();
+      buf->shape.assign(dims, dims + ndim);
+      size_t nelem = 1;
+      for (size_t d : buf->shape) nelem *= d;
+      buf->data.assign(nelem, 0.0f);
+      external_values.push_back(xnn_external_value{out_id, buf->data.data()});
+      out_bufs.push_back(std::move(buf));
+    }
+
+    CheckXnnStatus(xnn_setup_runtime_v2(rt.runtime, external_values.size(),
+                                        external_values.data()),
+                   "xnn_setup_runtime_v2");
+    CheckXnnStatus(xnn_invoke_runtime(rt.runtime), "xnn_invoke_runtime");
+
+    std::vector<DLManagedTensorPtr> outputs;
+    outputs.reserve(out_bufs.size());
+    for (auto& buf : out_bufs) {
+      outputs.emplace_back(WrapOutputBuffer(std::move(buf)));
+    }
+    return outputs;
+  }
+};
+
+}  // namespace
+
+std::shared_ptr<const ModelExecutor> GetXnnpackModelExecutor() {
+  static std::shared_ptr<const ModelExecutor> executor =
+      std::make_shared<XnnpackModelExecutor>();
+  return executor;
+}

--- a/onnxsim/xnnpack_executor_test.cpp
+++ b/onnxsim/xnnpack_executor_test.cpp
@@ -34,7 +34,7 @@ void Check(bool cond, const std::string& what) {
 }
 
 void CheckClose(double a, double b, const std::string& what,
-               double atol = 1e-4) {
+                double atol = 1e-4) {
   Check(std::fabs(a - b) <= atol, what + " (got " + std::to_string(a) +
                                       ", want " + std::to_string(b) + ")");
 }
@@ -157,23 +157,21 @@ void TestAddThenReluBroadcast() {
   DLManagedTensor x = MakeInputTensor(x_shape, x_data);
   DLManagedTensor y = MakeInputTensor(y_shape, y_data);
 
-  auto outputs =
-      GetXnnpackModelExecutor()->Run(model, {&x, &y});
+  auto outputs = GetXnnpackModelExecutor()->Run(model, {&x, &y});
   Check(outputs.size() == 1, "Add+Relu: one output");
   if (outputs.empty()) return;
   Check(outputs[0]->dl_tensor.ndim == 2, "Add+Relu: output rank");
   const float* out = OutData(outputs[0]);
   const float expected[6] = {1, 0, 2, 0, 3, 0};
   for (int i = 0; i < 6; ++i) {
-    CheckClose(out[i], expected[i],
-              "Add+Relu: element " + std::to_string(i));
+    CheckClose(out[i], expected[i], "Add+Relu: element " + std::to_string(i));
   }
 }
 
 void TestSigmoid() {
-  auto model = MakeModel({MakeNode("Sigmoid", {"X"}, {"Y"})},
-                         {MakeValueInfo("X", {3})}, {MakeValueInfo("Y", {3})},
-                         {});
+  auto model =
+      MakeModel({MakeNode("Sigmoid", {"X"}, {"Y"})}, {MakeValueInfo("X", {3})},
+                {MakeValueInfo("Y", {3})}, {});
   std::vector<int64_t> x_shape{3};
   std::vector<float> x_data{0.0f, 2.0f, -2.0f};
   DLManagedTensor x = MakeInputTensor(x_shape, x_data);
@@ -194,16 +192,15 @@ void TestGemmWithBiasAndTransB() {
   // Y = A @ B^T + C, shape [2,4].
   onnx::NodeProto gemm = MakeNode("Gemm", {"A", "B", "C"}, {"Y"});
   AddIntAttr(gemm, "transB", 1);
-  const std::vector<float> b_data{
-      1, 0, 0,   //
-      0, 1, 0,   //
-      0, 0, 1,   //
-      1, 1, 1};  // [4,3]
+  const std::vector<float> b_data{1, 0, 0,   //
+                                  0, 1, 0,   //
+                                  0, 0, 1,   //
+                                  1, 1, 1};  // [4,3]
   const std::vector<float> c_data{10, 20, 30, 40};
-  auto model =
-      MakeModel({gemm}, {MakeValueInfo("A", {2, 3})}, {MakeValueInfo("Y", {2, 4})},
-               {MakeFloatInitializer("B", {4, 3}, b_data),
-                MakeFloatInitializer("C", {4}, c_data)});
+  auto model = MakeModel({gemm}, {MakeValueInfo("A", {2, 3})},
+                         {MakeValueInfo("Y", {2, 4})},
+                         {MakeFloatInitializer("B", {4, 3}, b_data),
+                          MakeFloatInitializer("C", {4}, c_data)});
 
   std::vector<int64_t> a_shape{2, 3};
   std::vector<float> a_data{1, 2, 3, 4, 5, 6};
@@ -213,8 +210,8 @@ void TestGemmWithBiasAndTransB() {
   Check(outputs.size() == 1, "Gemm: one output");
   if (outputs.empty()) return;
   Check(outputs[0]->dl_tensor.shape[0] == 2 &&
-           outputs[0]->dl_tensor.shape[1] == 4,
-       "Gemm: output shape");
+            outputs[0]->dl_tensor.shape[1] == 4,
+        "Gemm: output shape");
   const float* out = OutData(outputs[0]);
   // Row 0 of A is [1,2,3]: B^T columns are the standard basis e0,e1,e2 plus
   // an all-ones column, so A@B^T row 0 is [1, 2, 3, 6], plus bias.
@@ -228,10 +225,10 @@ void TestGemmWithBiasAndTransB() {
 void TestMatMul2D() {
   // A: [2,3] input, B: [3,2] initializer -> Y: [2,2].
   const std::vector<float> b_data{1, 4, 2, 5, 3, 6};  // [3,2]
-  auto model = MakeModel({MakeNode("MatMul", {"A", "B"}, {"Y"})},
-                         {MakeValueInfo("A", {2, 3})},
-                         {MakeValueInfo("Y", {2, 2})},
-                         {MakeFloatInitializer("B", {3, 2}, b_data)});
+  auto model =
+      MakeModel({MakeNode("MatMul", {"A", "B"}, {"Y"})},
+                {MakeValueInfo("A", {2, 3})}, {MakeValueInfo("Y", {2, 2})},
+                {MakeFloatInitializer("B", {3, 2}, b_data)});
 
   std::vector<int64_t> a_shape{2, 3};
   std::vector<float> a_data{1, 0, 0, 0, 1, 0};
@@ -252,10 +249,10 @@ void TestMatMul2D() {
 void TestReshapeWithInferredDim() {
   // X: [2,3,4] (24 elements) reshaped via a [-1, 4] initializer to [6,4].
   // Reshape never reorders memory, so the flattened data must be unchanged.
-  auto model = MakeModel(
-      {MakeNode("Reshape", {"X", "shape"}, {"Y"})},
-      {MakeValueInfo("X", {2, 3, 4})}, {MakeValueInfo("Y", {6, 4})},
-      {MakeInt64Initializer("shape", {2}, {-1, 4})});
+  auto model =
+      MakeModel({MakeNode("Reshape", {"X", "shape"}, {"Y"})},
+                {MakeValueInfo("X", {2, 3, 4})}, {MakeValueInfo("Y", {6, 4})},
+                {MakeInt64Initializer("shape", {2}, {-1, 4})});
 
   std::vector<int64_t> x_shape{2, 3, 4};
   std::vector<float> x_data(24);
@@ -266,9 +263,9 @@ void TestReshapeWithInferredDim() {
   Check(outputs.size() == 1, "Reshape: one output");
   if (outputs.empty()) return;
   Check(outputs[0]->dl_tensor.ndim == 2 &&
-           outputs[0]->dl_tensor.shape[0] == 6 &&
-           outputs[0]->dl_tensor.shape[1] == 4,
-       "Reshape: resolved output shape");
+            outputs[0]->dl_tensor.shape[0] == 6 &&
+            outputs[0]->dl_tensor.shape[1] == 4,
+        "Reshape: resolved output shape");
   const float* out = OutData(outputs[0]);
   for (int i = 0; i < 24; ++i) {
     CheckClose(out[i], x_data[i], "Reshape: element " + std::to_string(i));
@@ -276,11 +273,10 @@ void TestReshapeWithInferredDim() {
 }
 
 void TestUnsupportedOpThrows() {
-  auto model = MakeModel({MakeNode("Conv", {"X", "W"}, {"Y"})},
-                         {MakeValueInfo("X", {1, 1, 4, 4})},
-                         {MakeValueInfo("Y", {1, 1, 4, 4})},
-                         {MakeFloatInitializer("W", {1, 1, 3, 3},
-                                               std::vector<float>(9, 1.0f))});
+  auto model = MakeModel(
+      {MakeNode("Conv", {"X", "W"}, {"Y"})}, {MakeValueInfo("X", {1, 1, 4, 4})},
+      {MakeValueInfo("Y", {1, 1, 4, 4})},
+      {MakeFloatInitializer("W", {1, 1, 3, 3}, std::vector<float>(9, 1.0f))});
   std::vector<int64_t> x_shape{1, 1, 4, 4};
   std::vector<float> x_data(16, 1.0f);
   DLManagedTensor x = MakeInputTensor(x_shape, x_data);
@@ -291,8 +287,9 @@ void TestUnsupportedOpThrows() {
   } catch (const std::exception&) {
     threw = true;
   }
-  Check(threw, "unsupported op (Conv): Run() throws rather than "
-              "silently mis-executing");
+  Check(threw,
+        "unsupported op (Conv): Run() throws rather than "
+        "silently mis-executing");
 }
 
 }  // namespace

--- a/onnxsim/xnnpack_executor_test.cpp
+++ b/onnxsim/xnnpack_executor_test.cpp
@@ -1,0 +1,314 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Exercises GetXnnpackModelExecutor() (onnxsim/xnnpack_executor.cpp) end to
+ * end: builds a small ONNX ModelProto by hand (mirroring
+ * precision_estimator_test.cpp's MakeNode/MakeModel helpers), feeds it
+ * through the real ModelExecutor::Run interface with DLManagedTensor inputs,
+ * and checks the resulting DLManagedTensor outputs against values computed
+ * independently in plain C++ -- a from-scratch numeric cross-check of the
+ * ONNX -> XNNPACK Subgraph API lowering (onnx_to_xnnpack_subgraph.cpp), not
+ * just "did it not crash". Needs onnx + XNNPACK configured, so this links
+ * the fully-configured `onnxsim` CMake target like precision_estimator_test.
+ */
+#include <onnx/onnx_pb.h>
+
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "dlpack/dlpack.h"
+#include "onnxsim.h"
+
+namespace {
+
+int g_failures = 0;
+
+void Check(bool cond, const std::string& what) {
+  if (!cond) {
+    std::fprintf(stderr, "FAIL: %s\n", what.c_str());
+    ++g_failures;
+  }
+}
+
+void CheckClose(double a, double b, const std::string& what,
+               double atol = 1e-4) {
+  Check(std::fabs(a - b) <= atol, what + " (got " + std::to_string(a) +
+                                      ", want " + std::to_string(b) + ")");
+}
+
+onnx::TensorProto MakeFloatInitializer(const std::string& name,
+                                       const std::vector<int64_t>& dims,
+                                       const std::vector<float>& data) {
+  onnx::TensorProto t;
+  t.set_name(name);
+  t.set_data_type(onnx::TensorProto::FLOAT);
+  for (int64_t d : dims) t.add_dims(d);
+  t.set_raw_data(std::string(reinterpret_cast<const char*>(data.data()),
+                             data.size() * sizeof(float)));
+  return t;
+}
+
+onnx::TensorProto MakeInt64Initializer(const std::string& name,
+                                       const std::vector<int64_t>& dims,
+                                       const std::vector<int64_t>& data) {
+  onnx::TensorProto t;
+  t.set_name(name);
+  t.set_data_type(onnx::TensorProto::INT64);
+  for (int64_t d : dims) t.add_dims(d);
+  t.set_raw_data(std::string(reinterpret_cast<const char*>(data.data()),
+                             data.size() * sizeof(int64_t)));
+  return t;
+}
+
+onnx::ValueInfoProto MakeValueInfo(const std::string& name,
+                                   const std::vector<int64_t>& dims) {
+  onnx::ValueInfoProto vi;
+  vi.set_name(name);
+  auto* tt = vi.mutable_type()->mutable_tensor_type();
+  tt->set_elem_type(onnx::TensorProto::FLOAT);
+  auto* shape = tt->mutable_shape();
+  for (int64_t d : dims) shape->add_dim()->set_dim_value(d);
+  return vi;
+}
+
+onnx::NodeProto MakeNode(const std::string& op_type,
+                         const std::vector<std::string>& inputs,
+                         const std::vector<std::string>& outputs) {
+  onnx::NodeProto n;
+  n.set_op_type(op_type);
+  for (const auto& i : inputs) n.add_input(i);
+  for (const auto& o : outputs) n.add_output(o);
+  return n;
+}
+
+void AddIntAttr(onnx::NodeProto& n, const std::string& name, int64_t v) {
+  auto* a = n.add_attribute();
+  a->set_name(name);
+  a->set_type(onnx::AttributeProto::INT);
+  a->set_i(v);
+}
+
+onnx::ModelProto MakeModel(const std::vector<onnx::NodeProto>& nodes,
+                           const std::vector<onnx::ValueInfoProto>& inputs,
+                           const std::vector<onnx::ValueInfoProto>& outputs,
+                           const std::vector<onnx::TensorProto>& initializers) {
+  onnx::ModelProto m;
+  m.set_ir_version(10);
+  auto* opset_import = m.add_opset_import();
+  opset_import->set_domain("");
+  opset_import->set_version(17);
+  auto* graph = m.mutable_graph();
+  graph->set_name("g");
+  for (const auto& n : nodes) *graph->add_node() = n;
+  for (const auto& i : inputs) *graph->add_input() = i;
+  for (const auto& o : outputs) *graph->add_output() = o;
+  for (const auto& t : initializers) *graph->add_initializer() = t;
+  return m;
+}
+
+// Wraps a caller-owned buffer as a non-owning DLManagedTensor (deleter left
+// null): the test always keeps the backing std::vector alive for at least as
+// long as the Run() call, matching ModelExecutor::Run's "inputs are borrowed"
+// contract, so nothing needs to free it via DLPack.
+DLManagedTensor MakeInputTensor(std::vector<int64_t>& shape,
+                                std::vector<float>& data) {
+  DLManagedTensor t{};
+  t.dl_tensor.data = data.data();
+  t.dl_tensor.device = DLDevice{kDLCPU, 0};
+  t.dl_tensor.ndim = static_cast<int32_t>(shape.size());
+  t.dl_tensor.dtype = DLDataType{kDLFloat, 32, 1};
+  t.dl_tensor.shape = shape.data();
+  t.dl_tensor.strides = nullptr;
+  t.dl_tensor.byte_offset = 0;
+  return t;
+}
+
+DLManagedTensor MakeInputTensorI64(std::vector<int64_t>& shape,
+                                   std::vector<int64_t>& data) {
+  DLManagedTensor t{};
+  t.dl_tensor.data = data.data();
+  t.dl_tensor.device = DLDevice{kDLCPU, 0};
+  t.dl_tensor.ndim = static_cast<int32_t>(shape.size());
+  t.dl_tensor.dtype = DLDataType{kDLInt, 64, 1};
+  t.dl_tensor.shape = shape.data();
+  t.dl_tensor.strides = nullptr;
+  t.dl_tensor.byte_offset = 0;
+  return t;
+}
+
+const float* OutData(const DLManagedTensorPtr& t) {
+  return static_cast<const float*>(t->dl_tensor.data);
+}
+
+void TestAddThenReluBroadcast() {
+  // X: [2,3], Y: [3] (broadcasts over the leading dim) -> Add -> Relu.
+  auto model = MakeModel(
+      {MakeNode("Add", {"X", "Y"}, {"sum"}), MakeNode("Relu", {"sum"}, {"Z"})},
+      {MakeValueInfo("X", {2, 3}), MakeValueInfo("Y", {3})},
+      {MakeValueInfo("Z", {2, 3})}, {});
+
+  std::vector<int64_t> x_shape{2, 3};
+  std::vector<float> x_data{1, -5, 3, -1, 2, -3};
+  std::vector<int64_t> y_shape{3};
+  std::vector<float> y_data{0, 1, -1};
+  DLManagedTensor x = MakeInputTensor(x_shape, x_data);
+  DLManagedTensor y = MakeInputTensor(y_shape, y_data);
+
+  auto outputs =
+      GetXnnpackModelExecutor()->Run(model, {&x, &y});
+  Check(outputs.size() == 1, "Add+Relu: one output");
+  if (outputs.empty()) return;
+  Check(outputs[0]->dl_tensor.ndim == 2, "Add+Relu: output rank");
+  const float* out = OutData(outputs[0]);
+  const float expected[6] = {1, 0, 2, 0, 3, 0};
+  for (int i = 0; i < 6; ++i) {
+    CheckClose(out[i], expected[i],
+              "Add+Relu: element " + std::to_string(i));
+  }
+}
+
+void TestSigmoid() {
+  auto model = MakeModel({MakeNode("Sigmoid", {"X"}, {"Y"})},
+                         {MakeValueInfo("X", {3})}, {MakeValueInfo("Y", {3})},
+                         {});
+  std::vector<int64_t> x_shape{3};
+  std::vector<float> x_data{0.0f, 2.0f, -2.0f};
+  DLManagedTensor x = MakeInputTensor(x_shape, x_data);
+
+  auto outputs = GetXnnpackModelExecutor()->Run(model, {&x});
+  Check(outputs.size() == 1, "Sigmoid: one output");
+  if (outputs.empty()) return;
+  const float* out = OutData(outputs[0]);
+  for (int i = 0; i < 3; ++i) {
+    const double expected = 1.0 / (1.0 + std::exp(-x_data[i]));
+    CheckClose(out[i], expected, "Sigmoid: element " + std::to_string(i));
+  }
+}
+
+void TestGemmWithBiasAndTransB() {
+  // A: [2,3] input. B: [4,3] initializer (transB=1, so B is already
+  // [output_channels, input_channels]). C (bias): [4] initializer.
+  // Y = A @ B^T + C, shape [2,4].
+  onnx::NodeProto gemm = MakeNode("Gemm", {"A", "B", "C"}, {"Y"});
+  AddIntAttr(gemm, "transB", 1);
+  const std::vector<float> b_data{
+      1, 0, 0,   //
+      0, 1, 0,   //
+      0, 0, 1,   //
+      1, 1, 1};  // [4,3]
+  const std::vector<float> c_data{10, 20, 30, 40};
+  auto model =
+      MakeModel({gemm}, {MakeValueInfo("A", {2, 3})}, {MakeValueInfo("Y", {2, 4})},
+               {MakeFloatInitializer("B", {4, 3}, b_data),
+                MakeFloatInitializer("C", {4}, c_data)});
+
+  std::vector<int64_t> a_shape{2, 3};
+  std::vector<float> a_data{1, 2, 3, 4, 5, 6};
+  DLManagedTensor a = MakeInputTensor(a_shape, a_data);
+
+  auto outputs = GetXnnpackModelExecutor()->Run(model, {&a});
+  Check(outputs.size() == 1, "Gemm: one output");
+  if (outputs.empty()) return;
+  Check(outputs[0]->dl_tensor.shape[0] == 2 &&
+           outputs[0]->dl_tensor.shape[1] == 4,
+       "Gemm: output shape");
+  const float* out = OutData(outputs[0]);
+  // Row 0 of A is [1,2,3]: B^T columns are the standard basis e0,e1,e2 plus
+  // an all-ones column, so A@B^T row 0 is [1, 2, 3, 6], plus bias.
+  const float expected[8] = {1 + 10, 2 + 20, 3 + 30, 6 + 40,
+                             4 + 10, 5 + 20, 6 + 30, 15 + 40};
+  for (int i = 0; i < 8; ++i) {
+    CheckClose(out[i], expected[i], "Gemm: element " + std::to_string(i));
+  }
+}
+
+void TestMatMul2D() {
+  // A: [2,3] input, B: [3,2] initializer -> Y: [2,2].
+  const std::vector<float> b_data{1, 4, 2, 5, 3, 6};  // [3,2]
+  auto model = MakeModel({MakeNode("MatMul", {"A", "B"}, {"Y"})},
+                         {MakeValueInfo("A", {2, 3})},
+                         {MakeValueInfo("Y", {2, 2})},
+                         {MakeFloatInitializer("B", {3, 2}, b_data)});
+
+  std::vector<int64_t> a_shape{2, 3};
+  std::vector<float> a_data{1, 0, 0, 0, 1, 0};
+  DLManagedTensor a = MakeInputTensor(a_shape, a_data);
+
+  auto outputs = GetXnnpackModelExecutor()->Run(model, {&a});
+  Check(outputs.size() == 1, "MatMul: one output");
+  if (outputs.empty()) return;
+  const float* out = OutData(outputs[0]);
+  // Row 0 = [1,0,0] selects B's first row [1,4]; row 1 = [0,1,0] selects
+  // B's second row [2,5].
+  const float expected[4] = {1, 4, 2, 5};
+  for (int i = 0; i < 4; ++i) {
+    CheckClose(out[i], expected[i], "MatMul: element " + std::to_string(i));
+  }
+}
+
+void TestReshapeWithInferredDim() {
+  // X: [2,3,4] (24 elements) reshaped via a [-1, 4] initializer to [6,4].
+  // Reshape never reorders memory, so the flattened data must be unchanged.
+  auto model = MakeModel(
+      {MakeNode("Reshape", {"X", "shape"}, {"Y"})},
+      {MakeValueInfo("X", {2, 3, 4})}, {MakeValueInfo("Y", {6, 4})},
+      {MakeInt64Initializer("shape", {2}, {-1, 4})});
+
+  std::vector<int64_t> x_shape{2, 3, 4};
+  std::vector<float> x_data(24);
+  for (int i = 0; i < 24; ++i) x_data[i] = static_cast<float>(i);
+  DLManagedTensor x = MakeInputTensor(x_shape, x_data);
+
+  auto outputs = GetXnnpackModelExecutor()->Run(model, {&x});
+  Check(outputs.size() == 1, "Reshape: one output");
+  if (outputs.empty()) return;
+  Check(outputs[0]->dl_tensor.ndim == 2 &&
+           outputs[0]->dl_tensor.shape[0] == 6 &&
+           outputs[0]->dl_tensor.shape[1] == 4,
+       "Reshape: resolved output shape");
+  const float* out = OutData(outputs[0]);
+  for (int i = 0; i < 24; ++i) {
+    CheckClose(out[i], x_data[i], "Reshape: element " + std::to_string(i));
+  }
+}
+
+void TestUnsupportedOpThrows() {
+  auto model = MakeModel({MakeNode("Conv", {"X", "W"}, {"Y"})},
+                         {MakeValueInfo("X", {1, 1, 4, 4})},
+                         {MakeValueInfo("Y", {1, 1, 4, 4})},
+                         {MakeFloatInitializer("W", {1, 1, 3, 3},
+                                               std::vector<float>(9, 1.0f))});
+  std::vector<int64_t> x_shape{1, 1, 4, 4};
+  std::vector<float> x_data(16, 1.0f);
+  DLManagedTensor x = MakeInputTensor(x_shape, x_data);
+
+  bool threw = false;
+  try {
+    GetXnnpackModelExecutor()->Run(model, {&x});
+  } catch (const std::exception&) {
+    threw = true;
+  }
+  Check(threw, "unsupported op (Conv): Run() throws rather than "
+              "silently mis-executing");
+}
+
+}  // namespace
+
+int main() {
+  TestAddThenReluBroadcast();
+  TestSigmoid();
+  TestGemmWithBiasAndTransB();
+  TestMatMul2D();
+  TestReshapeWithInferredDim();
+  TestUnsupportedOpThrows();
+
+  if (g_failures == 0) {
+    std::printf("xnnpack_executor_test: all checks passed\n");
+    return 0;
+  }
+  std::fprintf(stderr, "xnnpack_executor_test: %d failure(s)\n", g_failures);
+  return 1;
+}


### PR DESCRIPTION
Introduces GetXnnpackModelExecutor() (ONNXSIM_BUILTIN_XNNPACK, off by
default) as an alternative to the ONNX-Runtime-backed executor:

- onnxsim/onnx_to_xnnpack_subgraph.{h,cpp}: lowers a constant-folding
  fold-group ModelProto into XNNPACK's graph-level Subgraph API
  (xnn_create_subgraph / xnn_define_*), computing each supported op's
  output shape itself since XNNPACK requires every Value's shape up
  front. Supports a small, explicit fp32 op set (Add/Sub/Mul/Div,
  Relu, Sigmoid, Gemm/MatMul with 2D operands, static-shape Reshape)
  and throws a specific error for anything else -- notably Conv is
  left out, since ONNX's NCHW vs. XNNPACK's NHWC layout conversion
  needs more verification than this first cut has had.
- onnxsim/xnnpack_executor.cpp: the ModelExecutor adapter that builds
  an xnn_runtime_t from the lowered subgraph, feeds it a call's
  inputs, invokes it, and hands the outputs back as DLManagedTensors.
- onnxsim/xnnpack_executor_test.cpp: end-to-end checks against
  independently hand-computed expected values (elementwise ops, a
  two-node chain, Gemm bias/transB, MatMul, Reshape's -1 resolution,
  and the unsupported-op error path).
- cmake/build_xnnpack.cmake: FetchContents XNNPACK pinned by commit
  (it has no tagged releases), mirroring how build_ort.cmake obtains
  ONNX Runtime; composes independently of ONNXSIM_BUILTIN_ORT.
- docs/dlpack-executor.md: documents the new adapter and its scope.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014TgcTy2fige3usNq9iZoHE