### PR TITLE
Attention-head pruning: support DecoderMaskedSelfAttention/DecoderMaskedMultiHeadAttention

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -12590,6 +12590,254 @@ def apply_structured_pruning_matmul_nbits(
 #   lengths (as well as different source tensors and different feature
 #   dimensions) throughout, oracle-verified via onnxruntime with no
 #   restriction of this pass's own.
+#
+# `com.microsoft::DecoderMaskedSelfAttention`/`com.microsoft
+# ::DecoderMaskedMultiHeadAttention` -- ONNX Runtime's own step-of-1
+# decode-time IN-PLACE REWRITE TARGETS for `Attention`/`MultiHeadAttention`,
+# not merely two more independently-exported op types. This is real,
+# shipped code, not a schema definition nobody exercises -- confirmed by
+# reading `onnxruntime.transformers.convert_generation`, installed in this
+# environment (``python3 -c "import onnxruntime.transformers
+# .convert_generation as m; print(m.__file__)"`` -- note this module itself
+# imports `torch` at module scope and fails to import in a torch-less
+# environment like this one, so it was read directly off disk rather than
+# imported):
+# `update_decoder_subgraph_use_decoder_masked_attention` (its own
+# `switch_attention` branch) literally reassigns an existing `Attention`
+# node's `op_type` to `"DecoderMaskedSelfAttention"` in place, and
+# `replace_mha_with_dmmha` does the same for `MultiHeadAttention` ->
+# `"DecoderMaskedMultiHeadAttention"`, both called from
+# `convert_generation.py`'s own T5/GPT2/Whisper beam-search/greedy-search
+# export path (`main()`'s own `--use_decoder_masked_attention` CLI flag).
+# Concretely, for a real BERT/ViT/CLIP/T5/Whisper-style export already
+# matched by this section's own `Attention`/`MultiHeadAttention` bullets
+# above, running that export a second time through ORT's own beam-search
+# chaining tool can turn either into one of these two -- so a model this
+# section already prunes correctly today can arrive already rewritten, and
+# would previously have gone entirely unmatched (`grep -c
+# "DecoderMasked.*Attention" onnxsim/pruning.py` returned ``0`` before this
+# change).
+#
+# Both ops' full live schemas were pulled directly, not assumed from name
+# similarity to `Attention`/`MultiHeadAttention`, via
+# ``onnxruntime.capi.onnxruntime_pybind11_state.get_all_operator_schema()``
+# filtered for ``name in ("DecoderMaskedSelfAttention",
+# "DecoderMaskedMultiHeadAttention")`` against this environment's installed
+# onnxruntime 1.29.0 -- every input (name/type/required-optional/position),
+# output, attribute (required/default), and doc string, cross-checked
+# against `update_decoder_subgraph_use_decoder_masked_attention`'s/
+# `replace_mha_with_dmmha`'s own literal node-construction code above:
+#
+# - `DecoderMaskedSelfAttention`: merged QKV `weights`
+#   ``(input_hidden_size, hidden_size + hidden_size + v_hidden_size)`` --
+#   the *same* layout `com.microsoft::Attention` already has -- confirmed
+#   to share `Attention`'s own input *positions* too for everything this
+#   section touches (`weights`/`bias`/`mask_index`/`attention_bias` at
+#   1/2/3/5, unchanged), so :func:`_match_attention_producer`'s own op_type
+#   check was simply widened to accept it, degenerating cleanly into the
+#   same code path `Attention` already uses. Two schema differences from
+#   `Attention`, both confirmed directly off the live attribute dump
+#   (`do_rotary`, `mask_filter_value`, `scale`,
+#   `past_present_share_buffer`, `num_heads` -- five attributes total, no
+#   more), not assumed from the name:
+#   * **No `qkv_hidden_sizes` attribute at all** -- confirmed by its
+#     absence from that five-attribute list, despite the op's own doc
+#     *string* mentioning the phrase verbatim (evidently copy-pasted from
+#     `Attention`'s own doc and never edited to match the real schema).
+#     This traces through cleanly: `_match_attention_producer` already has
+#     a "schema default: Q/K/V evenly split the merged width" branch for
+#     whenever `Attention`'s own (there, schema-*optional*)
+#     `qkv_hidden_sizes` attribute is absent -- confirmed, by tracing that
+#     branch directly, to be exactly the code path this op needs
+#     unconditionally, so no new branch was needed, only extending the
+#     existing absent-attribute one to also cover "never has one at all."
+#     Since the matcher only ever accepts this op's own always-even split,
+#     `dq == dk == dv` is guaranteed, so `keep_count * dq == keep_count *
+#     dk == keep_count * dv` remains true after pruning too --
+#     :func:`_apply_one_plain_attention_chain` skips writing a
+#     `qkv_hidden_sizes` attribute back for this op type at all (it would
+#     be a dead, schema-unrecognized attribute the real kernel never
+#     reads), rather than writing one unconditionally the way it already
+#     does for plain `Attention`.
+#   * A required (not `Attention`'s own schema-optional) `past` input
+#     (index 4, unchanged position) -- real step-of-1 decode exports always
+#     leave this dynamic (the caller's own growing KV-cache state), so
+#     nothing needs slicing in the realistic case; a *constant* one (no
+#     established, tested slicing path here, unlike the `past_key`/
+#     `past_value` *pair* every separate-Q/K/V op in this section already
+#     handles) conservatively declines the whole match rather than being
+#     left silently stale -- see :func:`_match_attention_producer`'s own
+#     docstring.
+#   * `do_rotary` (fused rotary embedding computed *inside* the op, no
+#     external `cos_cache`/`sin_cache` input on this op's own schema at
+#     all -- confirmed by its full input list having none) is declined
+#     outright when set. This needed its own correctness check before
+#     being trusted, per this module's own established
+#     :func:`_walk_back_through_qk_norm_rope` precedent for *external*,
+#     graph-level `RotaryEmbedding` composing safely with head pruning
+#     (per-head rotation using only that head's own `head_size` slice and
+#     a position-dependent, never head-dependent, `cos`/`sin` lookup) --
+#     but that precedent's own safety argument rests on being able to
+#     *run* the rotation and confirm bit-identical results before/after
+#     pruning a subset of heads, and no CPU kernel exists for
+#     `DecoderMaskedSelfAttention` in this environment at all (confirmed
+#     empirically -- see below), so there is nothing here to run. Reaching
+#     for the next-best evidence -- the closely related, CPU-kernel-backed
+#     `com.microsoft::Attention` op's own `do_rotary=1` path (identical
+#     "fused, no external cache" shape) -- turned up a real, confirming
+#     signal rather than one: a minimal `onnx.checker`-valid `Attention`
+#     node with `do_rotary=1` fails at `InferenceSession.run` with
+#     ``"Rotary embedding is not supported in Attention CPU kernel...
+#     Please fuse the model with MHA + RotaryEmbedding"`` -- i.e. fused
+#     do_rotary is unimplemented in *this* op's CPU kernel too, in this
+#     environment. With neither op's own fused-rotary path executable here,
+#     no solid, execution-confirmed safety argument can be built for
+#     `DecoderMaskedSelfAttention`'s `do_rotary=1` specifically -- so, per
+#     this module's own conservative precedent elsewhere, it is declined
+#     outright (`do_rotary=1` in `node.attribute` makes
+#     :func:`_match_attention_producer` return ``None``) rather than
+#     guessed at. `do_rotary=0` (the schema default) matches unconditionally.
+# - `DecoderMaskedMultiHeadAttention`: same pre-projected-Q/K/V shape
+#   family as `MultiHeadAttention` (`query`/`key`/`value` already-projected
+#   activation tensors, no projection weight owned by the node itself), a
+#   real CPU kernel exists for it in this environment (confirmed by
+#   successfully constructing and running an `InferenceSession` -- unlike
+#   `DecoderMaskedSelfAttention` above, which fails
+#   `InferenceSession` construction outright with
+#   ``NOT_IMPLEMENTED : ... Could not find an implementation for
+#   DecoderMaskedSelfAttention``), so every claim below was verified via
+#   real execution against a from-scratch numpy oracle, not schema-doc-only.
+#   Given by :func:`_match_decoder_masked_multi_head_attention_producer`, a
+#   genuinely *separate* matcher function from
+#   :func:`_match_multi_head_attention_producer` (see that function's own
+#   docstring for exactly why a single shared function accepting both
+#   op-types was judged the *less* safe shape here, unlike the merged-QKV
+#   `Attention`/`DecoderMaskedSelfAttention` pair above) -- but reusing
+#   every bit of shared :class:`_GQAChain`/:func:`_apply_one_gqa_chain`/
+#   :func:`_find_separate_qkv_chains` machinery `MultiHeadAttention` itself
+#   already uses, via a new :func:`_find_decoder_masked_mha_chains` wrapper.
+#   Confirmed schema/behavior differences from `MultiHeadAttention`, none
+#   assumed from the name:
+#   * Every input beyond `query`/`key`/`value` sits at a **different
+#     index** from `MultiHeadAttention`'s own: `mask_index` at 3 (was
+#     `key_padding_mask` at 4), `attention_bias` at 4 (was 5), `past_key`/
+#     `past_value` at 5/6 (was 6/7), three new optional inputs
+#     (`past_sequence_length`/`beam_width`/`cache_indirection` at 7/8/9 --
+#     confirmed genuinely runtime-only: none has a `num_heads`-sized axis
+#     on its own schema doc, the identical "ignored, not sliced" treatment
+#     `mask_index` already gets, cross-checked against
+#     `update_decoder_subgraph_use_decoder_masked_attention`'s own literal
+#     construction, which threads `beam_width`/`cache_indirection` through
+#     as plain pass-through graph inputs with no per-head shape at all),
+#     and -- the one difference a single shared matcher could too easily
+#     get wrong -- a combined `bias` moved from index 3 all the way to
+#     index **10**, the *last* input, not merely appended after the new
+#     ones (confirmed both off the live schema dump and independently off
+#     `replace_mha_with_dmmha`'s own literal ``inputs=[...]`` list, which
+#     builds exactly this reordering by hand: `query, key, value,
+#     mask_index="", relative_position_bias="", past_key, past_value,
+#     past_sequence_length, beam_width, cache_indirection, bias`). The
+#     combined bias's own *shape* is unchanged -- still exactly `[nq + nk +
+#     nv]`, per this op's own doc ("Bias tensor with shape (hidden_size +
+#     hidden_size + v_hidden_size) from input projection") -- only its
+#     input *position* differs, so :class:`_GQAChain`'s existing
+#     `mha_bias` field/slicing needed no changes at all, only a different
+#     `combined_bias_input_index` passed to
+#     :func:`_find_separate_qkv_chains` (``10``, not ``3``).
+#   * `allow_differing_v_head_size` is **`False`** here -- *not* the same
+#     value `MultiHeadAttention` itself gets (`True`) -- confirmed by a
+#     real `InferenceSession` run: a node whose V projection is a
+#     genuinely different width than Q's/K's shared one fails outright with
+#     ``"QK head size should be same as V head size to use
+#     DecoderMaskedMultiHeadAttention"``. The same hard equal-head-size
+#     requirement `GroupQueryAttention`/`PagedAttention` already have, for
+#     the identical reason (neither's own fusion path ever produces a
+#     mismatched one) -- a real, confirmed behavioral difference from
+#     `MultiHeadAttention` this module's own naming convention could
+#     otherwise suggest doesn't exist.
+#   * This environment's CPU kernel additionally *requires*
+#     `past_present_share_buffer=1` whenever `past_key`/`past_value` are
+#     connected at all (a `false`/absent attribute fails outright,
+#     ``"past_present_share_buffer_ was false"``) -- an implementation
+#     requirement beyond what the schema's own optional-attribute framing
+#     alone suggests. Doesn't change anything this pass matches or slices
+#     (the attribute is passed through untouched regardless of its value,
+#     like every other op-level attribute this section doesn't rewrite),
+#     but shapes how `tests/test_pruning.py`'s own past-KV-cache tests for
+#     this op are actually constructed.
+#   * `past_key`/`past_value` share the identical BNSH layout (`(batch,
+#     num_heads, seq, head_size)`, `num_heads` at axis 1) as every other op
+#     in this section's own analogous inputs -- reuses
+#     :func:`_past_kv_constants_are_sliceable` unchanged, just at this op's
+#     own indices (5/6) and with no `scale_indices` (no `k_scale`/`v_scale`
+#     inputs on this op's own schema at all). `attention_bias` (index 4)
+#     confirmed to have the identical real, per-head numeric effect
+#     `MultiHeadAttention`'s own already has (perturbing one head's own
+#     slice of a connected constant, through a real end-to-end run, changed
+#     only that head's own output slice and nothing else) -- gets the
+#     identical :func:`_head_bias_axis`-mediated treatment.
+#   * Reporting reuses `MultiHeadAttention`'s own `family="attention_mha_head"`
+#     string rather than a new one: the granularity is genuinely identical
+#     (no separate `kv_num_heads` attribute on this op's own schema either,
+#     confirmed off the same live dump -- `chain.kv_num_heads ==
+#     chain.num_heads` always, exactly as for `MultiHeadAttention`), so a
+#     distinct family string would report a structurally identical thing
+#     under a different name for no reason -- unlike `PagedAttention`'s own
+#     genuinely different (real GQA-style) grouping, which does get its own.
+#   * **Cross-attention was investigated and found NOT to compose the way
+#     it does for `MultiHeadAttention`** -- confirmed, not assumed, and
+#     left deliberately unmatched. `MultiHeadAttention`'s own cross-
+#     attention shape (Q from one MatMul-fed rank-3 source, K/V from a
+#     genuinely different one, also rank-3) is already fully supported here
+#     (see the `MultiHeadAttention` bullet above) via the same generic
+#     :func:`_find_separate_qkv_chains` machinery -- but
+#     `DecoderMaskedMultiHeadAttention`'s own `key`/`value` inputs, per
+#     their own schema doc, take a genuinely *different shape* for cross
+#     attention than for self-attention: "Key with shape (batch_size, 1,
+#     hidden_size) for self attention **or past_key with shape
+#     (batch_size, num_heads, kv_sequence_length, head_size) for cross
+#     attention**" -- a pre-projected, already-BNSH-transposed rank-4
+#     tensor fed directly into `key`/`value`, not a rank-3
+#     `(batch_size, kv_sequence_length, hidden_size)` tensor from an
+#     ordinary MatMul producer the way `MultiHeadAttention`'s own
+#     cross-attention convention (and this whole section's `_match_producer`
+#     machinery) expects. Confirmed via two real `InferenceSession` runs,
+#     not doc-string-only: passing a rank-3 `key`/`value` pair with
+#     `kv_sequence_length != 1` (the shape a naive port of the
+#     `MultiHeadAttention` cross-attention test would use) runs to
+#     completion but produces silently **wrong** numbers (no error raised
+#     at all -- max-abs-diff ~1.1 against the numpy oracle, versus the
+#     rank-4 form's ~1.2e-7); the documented rank-4
+#     `(batch_size, num_heads, kv_sequence_length, head_size)` form matches
+#     the same oracle to ~1.2e-7. `_find_separate_qkv_chains`'s own
+#     `_match_producer`/`_match_matmul_like` machinery already declines
+#     that rank-4 shape by construction -- it isn't fed by a MatMul/
+#     vanilla-Gemm producer with a 2-D weight at all, so the per-branch
+#     "must be internal, must resolve via `_match_producer`" loop simply
+#     never matches it -- so no additional check was needed to keep this
+#     op's own cross-attention shape out of scope, but this is a genuine,
+#     confirmed scope boundary worth being explicit about, not an accident
+#     of some other unrelated check. (Separately: this op's own kernel also
+#     hard-requires `query`'s -- and, for the *self*-attention rank-3
+#     `key`/`value` form, their own -- sequence length to be exactly 1
+#     ("Input sequence length should be 1 to use
+#     DecoderMaskedMultiHeadAttention. Actual length is N" otherwise); this
+#     is a purely runtime-shape constraint on the graph's own actual batch/
+#     seq dimensions, invisible to this pass's static graph matching and
+#     unaffected by anything this pass slices, so it needed no code of its
+#     own -- noted here only because it explains why every
+#     `DecoderMaskedMultiHeadAttention` correctness test in
+#     `tests/test_pruning.py` below uses `seq_len=1` throughout.)
+#
+# Both ops' own dry-run mirrors (`_analyze_attention_head_pruning`/
+# `_analyze_attention_head_wanda_pruning`, via the shared
+# `_analyze_attention_chains`) and `_attention_not_eligible`'s own
+# "recognized but declined" reporting were updated identically -- a
+# `DecoderMaskedSelfAttention`/`DecoderMaskedMultiHeadAttention` node that
+# fails to match (the `do_rotary=1`/non-empty-constant-`past`/cross-
+# attention/mismatched-V-head-size cases above) is reported by name in
+# `not_eligible`, exactly like every other declined op-type in this
+# section, rather than silently vanishing from the report.
 _ATTENTION_DOMAIN = "com.microsoft"
 
 # The three quantized-cache dtypes `GroupQueryAttention`'s own `T_CACHE` type
@@ -12723,7 +12971,8 @@ _AttnLikeChain = Union[_AttentionChain, _GQAChain]
 def _match_attention_producer(
     node: onnx.NodeProto, initializer_map: Dict[str, onnx.TensorProto]
 ) -> Optional[Tuple[str, Optional[str], int, int, int, int]]:
-    """If `node` is a ``com.microsoft::Attention`` node with a constant 2-D
+    """If `node` is a ``com.microsoft::Attention`` *or*
+    ``com.microsoft::DecoderMaskedSelfAttention`` node with a constant 2-D
     float32 merged QKV weight ``[K, Nq+Nk+Nv]`` (and, if present, a
     constant 1-D float32 merged bias), returns
     ``(weight_name, bias_name_or_None, num_heads, Nq, Nk, Nv)``.
@@ -12754,9 +13003,75 @@ def _match_attention_producer(
     dynamic, absent, or a constant that resolves to the latter --
     :func:`_apply_one_plain_attention_chain` performs the actual slice once
     a match succeeds.
+
+    ``DecoderMaskedSelfAttention`` (schema confirmed live the same way,
+    ``since_version`` 1) is ONNX Runtime's own in-place rewrite target for a
+    step-of-1 decoder ``Attention`` node -- see this module's own
+    "Attention-head pruning" section comment for the full empirical
+    investigation (the real, shipped
+    `onnxruntime.transformers.convert_generation
+    .update_decoder_subgraph_use_decoder_masked_attention` rewrite this was
+    confirmed against). Its own schema shares `Attention`'s exact input
+    *positions* for everything this matcher/its caller touch --
+    `weights`/`bias`/`mask_index`/`attention_bias` sit at the identical
+    indices 1/2/3/5 -- so this function degenerates cleanly to the same
+    code path for it, with three differences this function accounts for:
+
+    - `past` (index 4) is *required* by this op's own schema (``Single``,
+      not `Attention`'s own ``Optional``) and, per its own doc, holds
+      combined key+value state shaped ``(2, batch_size, num_heads,
+      past_sequence_length, head_size)`` -- the same combined layout
+      `Attention`'s own (schema-optional, and never populated by any real
+      export this module has confirmed, so never validated here at all)
+      `past` input would have. A real step-of-1 decode export always
+      leaves this dynamic (an ordinary graph input threaded through every
+      decode call, updated in place) -- the caller's own runtime state, not
+      a weight this pass could safely reslice -- but a hand-built or
+      unusual graph could in principle bind a *constant* here; since this
+      function has no established, tested slicing path for it (unlike the
+      `past_key`/`past_value` pair every separate-Q/K/V op in this section
+      already handles via :func:`_past_kv_constants_are_sliceable`), a
+      constant `past` conservatively declines the whole match rather than
+      being left silently stale.
+    - `qkv_hidden_sizes` does not exist on this op's own schema at all
+      (confirmed by enumerating every attribute the live schema dump
+      reports for it: `do_rotary`, `mask_filter_value`, `scale`,
+      `past_present_share_buffer`, `num_heads` -- no `qkv_hidden_sizes`
+      member, despite this op's own doc *string* mentioning the phrase
+      verbatim, evidently copy-pasted from `Attention`'s own doc and never
+      edited) -- so this op always takes the "Schema default: Q/K/V evenly
+      split the merged width" branch below unconditionally, the exact
+      branch `Attention` itself already falls into whenever *its own*
+      (schema-optional, for `Attention`) `qkv_hidden_sizes` attribute is
+      absent. A node of this op type carrying an attribute of that name
+      anyway (a malformed or hand-edited graph -- this attribute has no
+      meaning to the real kernel, which never reads it) still declines the
+      match outright here, conservatively, rather than guessing whether
+      whatever produced it intended an uneven split this op's own kernel
+      could never actually honor.
+    - `do_rotary` (fused rotary position embedding computed inside the op
+      itself, no external `cos_cache`/`sin_cache` input on this op's own
+      schema at all) is declined outright when set (`!= 0`): see this
+      module's own "Attention-head pruning" section comment for the full
+      reasoning -- in short, this environment's CPU kernel for the closely
+      related `Attention` op explicitly does *not* implement `do_rotary` at
+      all ("Rotary embedding is not supported in Attention CPU kernel...",
+      confirmed via a real `onnxruntime.InferenceSession` run), and
+      `DecoderMaskedSelfAttention` itself has no CPU kernel in this
+      environment either (confirmed the same way -- `NOT_IMPLEMENTED`), so
+      there is no way to execute *either* op's own fused-rotary path here
+      to confirm per-head independence the way this module's own
+      :func:`_walk_back_through_qk_norm_rope` precedent (external,
+      graph-level `RotaryEmbedding`) was confirmed. `do_rotary=0` (the
+      schema default, and the only value ever actually exercised here)
+      matches unconditionally, same as `Attention` itself.
     """
-    if node.domain != _ATTENTION_DOMAIN or node.op_type != "Attention":
+    if node.domain != _ATTENTION_DOMAIN or node.op_type not in (
+        "Attention",
+        "DecoderMaskedSelfAttention",
+    ):
         return None
+    is_dmsa = node.op_type == "DecoderMaskedSelfAttention"
     if len(node.input) < 2:
         return None
     w_name = node.input[1]
@@ -12780,15 +13095,27 @@ def _match_attention_producer(
         ):
             return None
 
+    if is_dmsa and len(node.input) > 4 and node.input[4]:  # past
+        if node.input[4] in initializer_map:
+            return None  # no established/tested slicing path -- decline
+
     num_heads = None
     qkv_hidden_sizes: Optional[List[int]] = None
+    do_rotary = 0
     for attr in node.attribute:
         if attr.name == "num_heads":
             num_heads = attr.i
         elif attr.name == "qkv_hidden_sizes":
             qkv_hidden_sizes = list(attr.ints)
+        elif attr.name == "do_rotary":
+            do_rotary = attr.i
     if not num_heads or num_heads <= 0:
         return None
+    if is_dmsa:
+        if do_rotary:
+            return None  # fused RoPE -- no confirmed per-head-safe execution path here
+        if qkv_hidden_sizes is not None:
+            return None  # not a real attribute on this op's own schema -- decline
 
     if qkv_hidden_sizes is not None:
         if len(qkv_hidden_sizes) != 3:
@@ -13318,6 +13645,144 @@ def _match_multi_head_attention_producer(
                 return None  # doesn't statically resolve -- decline rather than guess
 
     if not _past_kv_constants_are_sliceable(node, initializer_map, (6, 7), num_heads):
+        return None
+
+    return num_heads, num_heads
+
+
+def _match_decoder_masked_multi_head_attention_producer(
+    node: onnx.NodeProto, initializer_map: Dict[str, onnx.TensorProto]
+) -> Optional[Tuple[int, int]]:
+    """If `node` is a ``com.microsoft::DecoderMaskedMultiHeadAttention`` node
+    this module can safely act on, returns ``(num_heads, num_heads)`` -- the
+    same shape :func:`_match_multi_head_attention_producer` returns for
+    `MultiHeadAttention`, `kv_num_heads` always equal to `num_heads` (this
+    op's own schema, confirmed live the same way, has exactly one head-count
+    attribute, `num_heads` -- no `kv_num_heads`).
+
+    This is ONNX Runtime's own in-place rewrite target for a step-of-1
+    decoder `MultiHeadAttention` node -- see this module's own
+    "Attention-head pruning" section comment for the full empirical
+    investigation (the real, shipped
+    `onnxruntime.transformers.convert_generation.replace_mha_with_dmmha`
+    rewrite this was confirmed against) and exactly why this gets its own
+    matcher function rather than widening
+    :func:`_match_multi_head_attention_producer`'s own op_type check the way
+    :func:`_match_attention_producer` does for `DecoderMaskedSelfAttention`:
+    unlike that merged-QKV pair, this op's own input *positions* genuinely
+    differ from `MultiHeadAttention`'s own at almost every index beyond
+    `query`/`key`/`value` (confirmed live, not assumed from the name
+    alone) -- `mask_index` at 3 (was `key_padding_mask` at 4),
+    `attention_bias` at 4 (was 5), `past_key`/`past_value` at 5/6 (was
+    6/7), three new optional inputs (`past_sequence_length`/`beam_width`/
+    `cache_indirection` at 7/8/9, all confirmed head-count-independent, see
+    below), and -- the one a single shared matcher accepting both op types
+    could too easily get wrong -- its own combined `bias` moves from index
+    3 to index **10**, the *last* input, not merely appended after new ones
+    (confirmed both off the live schema dump and independently off
+    `replace_mha_with_dmmha`'s own literal ``inputs=[...]`` list, which
+    builds exactly this reordering by hand). A single shared function
+    threading a per-op-type index table through every one of these would
+    have five different index tables to keep in sync instead of one; two
+    small, independently-readable matcher functions (mirroring this
+    section's own existing `GroupQueryAttention`-vs-`PagedAttention` /
+    plain-ai.onnx-`Attention` split, already four matcher functions deep
+    before this one) was judged the safer shape.
+
+    Confirmed, via actual onnxruntime execution (a real CPU kernel exists
+    for this op in this environment, unlike `DecoderMaskedSelfAttention`
+    below -- see this module's own "Attention-head pruning" section
+    comment), to differ from `MultiHeadAttention` in three ways this
+    function accounts for:
+
+    - `mask_index` (index 3), per its own doc, is one of the same several
+      shapes `MultiHeadAttention`'s own `key_padding_mask` documents --
+      none with a `num_heads`-sized axis -- so, like that input, it is
+      unconditionally head-count-independent and never inspected here.
+    - `attention_bias` (index 4, **not** 5) is confirmed to have the exact
+      same real, per-head numeric effect `MultiHeadAttention`'s own
+      analogous input already has (a hand-built model perturbing one
+      head's own slice of a connected constant changed only that head's
+      own output slice and no other, run end to end through a real
+      `onnxruntime.InferenceSession`) -- gets the identical
+      constant-resolves-cleanly-or-is-declined treatment via
+      :func:`_head_bias_axis`.
+    - `past_key`/`past_value` (indices 5/6, **not** 6/7) are laid out in
+      the identical BNSH format (`(batch_size, num_heads,
+      past_sequence_length, head_size)`, axis 1 the `num_heads` axis) as
+      every other op in this section's own `past_key`/`past_value`, so
+      reuse the same :func:`_past_kv_constants_are_sliceable` gate with no
+      `scale_indices` (this op's own schema has no `k_scale`/`v_scale`
+      inputs at all, confirmed off the same live schema dump). Empirically
+      confirmed further: this environment's CPU kernel additionally
+      *requires* `past_present_share_buffer=1` whenever `past_key`/
+      `past_value` are connected at all (a `false`-valued or absent
+      attribute fails outright, ``"past_present_share_buffer_ was
+      false"``) -- an implementation requirement beyond what the schema's
+      own optional-attribute framing alone would suggest, noted here since
+      it shapes how this op is actually exercised in
+      ``tests/test_pruning.py``, but not something this matcher itself
+      needs to check: `past_present_share_buffer` is passed through
+      untouched regardless of its value, the same as every other
+      op-level attribute this whole section doesn't rewrite.
+
+    `past_sequence_length` (index 7), `beam_width` (index 8), and
+    `cache_indirection` (index 9) are, per their own schema docs, a scalar
+    decode-position counter, a `[1]`-shaped beam-count scalar, and a
+    `[batch_size, beam_width, max_output_length]` buffer respectively --
+    none with a `num_heads`-sized axis anywhere -- so all three are
+    unconditionally left alone (never inspected here, never touched by
+    :func:`_apply_one_gqa_chain`), the same "ignored, not sliced" treatment
+    `mask_index` already gets. `output_qk` (an attribute, not an input --
+    "Need output the cross attention MatMul(Q, K)", producing an optional
+    4th node *output*) needs no handling either: an output's own shape is
+    whatever the runtime kernel produces for the node's own (already
+    correctly rewritten) `num_heads` attribute -- there is no static tensor
+    here to slice, the same reasoning every other matched op's own
+    `output`/`present`/`present_key`/`present_value` outputs already get
+    (never touched, never even named on :class:`_GQAChain`).
+
+    Cross-attention was investigated explicitly and found **not** to
+    compose the way it does for `MultiHeadAttention` -- deliberately left
+    unmatched here rather than assumed to work, see this module's own
+    "Attention-head pruning" section comment for the full empirical
+    finding (this op's own `key`/`value` inputs, per their own doc, take a
+    *different* shape for cross-attention than for self-attention -- a
+    pre-projected rank-4 `(batch_size, num_heads, kv_sequence_length,
+    head_size)` tensor fed directly, not `MultiHeadAttention`'s own rank-3
+    `(batch_size, kv_sequence_length, hidden_size)` MatMul-producer-fed
+    convention -- confirmed via real onnxruntime execution: a rank-3
+    `key`/`value` pair with `kv_sequence_length != 1` runs but produces
+    silently *wrong* numbers, no error at all, while the rank-4 form
+    matches a numpy oracle to ~1.2e-7). :func:`_find_separate_qkv_chains`'s
+    own `_match_producer`/`_match_matmul_like` machinery already declines
+    that rank-4 shape by construction (it isn't fed by a MatMul/vanilla-Gemm
+    producer with a 2-D weight at all), so no extra check is needed *here*
+    to keep it unmatched -- but this is a genuine, confirmed scope boundary
+    worth being explicit about, not an accident of some other check.
+    """
+    if (
+        node.domain != _ATTENTION_DOMAIN
+        or node.op_type != "DecoderMaskedMultiHeadAttention"
+    ):
+        return None
+    if len(node.input) < 3 or not (node.input[0] and node.input[1] and node.input[2]):
+        return None
+
+    num_heads = None
+    for attr in node.attribute:
+        if attr.name == "num_heads":
+            num_heads = attr.i
+    if not num_heads or num_heads <= 0:
+        return None
+
+    if len(node.input) > 4 and node.input[4]:  # attention_bias
+        bias_init = initializer_map.get(node.input[4])
+        if bias_init is not None and int(np.prod(bias_init.dims)) > 0:
+            if _head_bias_axis(list(bias_init.dims), num_heads) is None:
+                return None  # doesn't statically resolve -- decline rather than guess
+
+    if not _past_kv_constants_are_sliceable(node, initializer_map, (5, 6), num_heads):
         return None
 
     return num_heads, num_heads
@@ -14321,6 +14786,39 @@ def _find_mha_chains(graph: onnx.GraphProto) -> List[_GQAChain]:
     )
 
 
+def _find_decoder_masked_mha_chains(graph: onnx.GraphProto) -> List[_GQAChain]:
+    """The ``com.microsoft::DecoderMaskedMultiHeadAttention`` analogue of
+    :func:`_find_mha_chains` -- see :func:`_find_separate_qkv_chains` (the
+    shared body) and
+    :func:`_match_decoder_masked_multi_head_attention_producer` (what's
+    matched and why it's declined otherwise, including the full empirical
+    schema/execution investigation this whole function was built from).
+    Passes ``allow_differing_v_head_size=False`` -- **not** the same value
+    :func:`_find_mha_chains` passes for `MultiHeadAttention` -- confirmed
+    empirically via a real `onnxruntime.InferenceSession` run: a
+    `DecoderMaskedMultiHeadAttention` node whose V projection is a
+    genuinely different width than Q's/K's shared one fails outright
+    (``"QK head size should be same as V head size to use
+    DecoderMaskedMultiHeadAttention"``), the same hard equal-head-size
+    requirement `GroupQueryAttention`/`PagedAttention` already have (see
+    their own `_find_*_chains` docstrings) rather than `MultiHeadAttention`'s
+    own genuinely permissive one -- a real difference between two ops this
+    module's naming might otherwise suggest are identical in every way but
+    op_type. ``combined_bias_input_index=10`` -- this op's own `bias`
+    input, moved to the *last* position (not index 3, `MultiHeadAttention`'s
+    own) -- see :func:`_match_decoder_masked_multi_head_attention_producer`'s
+    own docstring for why that reordering is confirmed real rather than
+    assumed.
+    """
+    return _find_separate_qkv_chains(
+        graph,
+        _match_decoder_masked_multi_head_attention_producer,
+        "num_heads",
+        allow_differing_v_head_size=False,
+        combined_bias_input_index=10,
+    )
+
+
 def _find_paged_attention_chains(graph: onnx.GraphProto) -> List[_GQAChain]:
     """The ``com.microsoft::PagedAttention`` analogue of
     :func:`_find_gqa_chains` -- see :func:`_find_separate_qkv_chains` (the
@@ -14522,7 +15020,15 @@ def _apply_one_plain_attention_chain(
             found_qkv = True
             del attr.ints[:]
             attr.ints.extend([keep_count * dq, keep_count * dk, keep_count * dv])
-    if not found_qkv:
+    # `DecoderMaskedSelfAttention` has no `qkv_hidden_sizes` attribute on its
+    # own schema at all (see :func:`_match_attention_producer`'s own
+    # docstring) -- `dq == dk == dv` is guaranteed for it (the matcher only
+    # ever accepts its own always-even 3-way split), so `keep_count * dq ==
+    # keep_count * dk == keep_count * dv` remains true after pruning too,
+    # and the kernel's own even-split default reproduces the right shape
+    # with no attribute needed. Writing one anyway would just be a dead,
+    # schema-unrecognized attribute on the node -- harmless but pointless.
+    if not found_qkv and chain.node.op_type != "DecoderMaskedSelfAttention":
         chain.node.attribute.append(
             onnx.helper.make_attribute(
                 "qkv_hidden_sizes",
@@ -14764,13 +15270,15 @@ def _apply_one_gqa_chain(
         _slice_last_axis(initializer_map[chain.mha_bias], full_bias_idx)
 
     # `GroupQueryAttention`'s past_key/past_value live at input indices 3/4,
-    # the plain ai.onnx op's own at 4/5, `MultiHeadAttention`'s own at 6/7
-    # (see `_match_gqa_producer`'s, `_match_onnx_attention_producer`'s, and
-    # `_match_multi_head_attention_producer`'s own docstrings) -- all three
-    # already confirmed, at match time, to be either absent/dynamic (nothing
-    # to do here) or a BNSH-format constant (plain FLOAT, or -- GQA only --
-    # quantized with a schema-conforming scale) safe to slice along axis 1
-    # by `keep_groups` (see :func:`_past_kv_constants_are_sliceable`).
+    # the plain ai.onnx op's own at 4/5, `MultiHeadAttention`'s own at 6/7,
+    # `DecoderMaskedMultiHeadAttention`'s own at 5/6 (see `_match_gqa_producer`'s,
+    # `_match_onnx_attention_producer`'s, `_match_multi_head_attention_producer`'s,
+    # and :func:`_match_decoder_masked_multi_head_attention_producer`'s own
+    # docstrings) -- all four already confirmed, at match time, to be either
+    # absent/dynamic (nothing to do here) or a BNSH-format constant (plain
+    # FLOAT, or -- GQA only -- quantized with a schema-conforming scale)
+    # safe to slice along axis 1 by `keep_groups` (see
+    # :func:`_past_kv_constants_are_sliceable`).
     is_gqa = (
         chain.node.domain == _ATTENTION_DOMAIN
         and chain.node.op_type == "GroupQueryAttention"
@@ -14778,6 +15286,10 @@ def _apply_one_gqa_chain(
     is_mha = (
         chain.node.domain == _ATTENTION_DOMAIN
         and chain.node.op_type == "MultiHeadAttention"
+    )
+    is_dmmha = (
+        chain.node.domain == _ATTENTION_DOMAIN
+        and chain.node.op_type == "DecoderMaskedMultiHeadAttention"
     )
     # `PagedAttention`'s own `key_cache`/`value_cache` (indices 3/4) are
     # never sliced at all -- already confirmed, at match time, to always be
@@ -14792,7 +15304,15 @@ def _apply_one_gqa_chain(
         and chain.node.op_type == "PagedAttention"
     )
     past_kv_indices = (
-        (3, 4) if is_gqa else (6, 7) if is_mha else () if is_paged else (4, 5)
+        (3, 4)
+        if is_gqa
+        else (6, 7)
+        if is_mha
+        else (5, 6)
+        if is_dmmha
+        else ()
+        if is_paged
+        else (4, 5)
     )
     for idx in past_kv_indices:
         if len(chain.node.input) <= idx or not chain.node.input[idx]:
@@ -14842,20 +15362,23 @@ def _apply_one_gqa_chain(
             # else: PER_TENSOR broadcast scalar -- no per-head axis to slice
 
     # `attention_bias`/`attn_mask` (index 10 for `GroupQueryAttention`, 3
-    # for the plain ai.onnx op, 5 for `MultiHeadAttention` -- see
-    # `_match_gqa_producer`'s, `_match_onnx_attention_producer`'s, and
-    # `_match_multi_head_attention_producer`'s own docstrings) is sliced
-    # along its own head axis by `keep_q_heads` -- *query*-head granularity,
-    # not `keep_groups`'s kv-group one -- whenever `_head_bias_axis` resolves
-    # it to a genuine per-head tensor against the pre-pruning
-    # `chain.num_heads`; left untouched when it resolves to a broadcast (or
-    # is absent/dynamic, matched the same "nothing to slice" way here as at
-    # match time). `PagedAttention` has no `attention_bias`/`attn_mask`-
-    # equivalent input on its own schema at all (confirmed off the same live
-    # schema dump this whole family was built from), so this whole block is
-    # skipped for it outright -- `chain.node.input[3]` (`key_cache` for
-    # `PagedAttention`) must never be mistaken for one.
-    mask_idx = 10 if is_gqa else 5 if is_mha else None if is_paged else 3
+    # for the plain ai.onnx op, 5 for `MultiHeadAttention`, 4 for
+    # `DecoderMaskedMultiHeadAttention` -- see `_match_gqa_producer`'s,
+    # `_match_onnx_attention_producer`'s, `_match_multi_head_attention_producer`'s,
+    # and :func:`_match_decoder_masked_multi_head_attention_producer`'s own
+    # docstrings) is sliced along its own head axis by `keep_q_heads` --
+    # *query*-head granularity, not `keep_groups`'s kv-group one -- whenever
+    # `_head_bias_axis` resolves it to a genuine per-head tensor against the
+    # pre-pruning `chain.num_heads`; left untouched when it resolves to a
+    # broadcast (or is absent/dynamic, matched the same "nothing to slice"
+    # way here as at match time). `PagedAttention` has no `attention_bias`/
+    # `attn_mask`-equivalent input on its own schema at all (confirmed off
+    # the same live schema dump this whole family was built from), so this
+    # whole block is skipped for it outright -- `chain.node.input[3]`
+    # (`key_cache` for `PagedAttention`) must never be mistaken for one.
+    mask_idx = (
+        10 if is_gqa else 5 if is_mha else 4 if is_dmmha else None if is_paged else 3
+    )
     if (
         mask_idx is not None
         and len(chain.node.input) > mask_idx
@@ -15124,6 +15647,7 @@ def apply_attention_head_pruning(
         *_find_gqa_chains(graph),
         *_find_onnx_attention_chains(graph),
         *_find_mha_chains(graph),
+        *_find_decoder_masked_mha_chains(graph),
         *_find_paged_attention_chains(graph),
     ]
     if chains:
@@ -15275,6 +15799,7 @@ def apply_attention_head_wanda_pruning(
         *_find_gqa_chains(graph),
         *_find_onnx_attention_chains(graph),
         *_find_mha_chains(graph),
+        *_find_decoder_masked_mha_chains(graph),
         *_find_paged_attention_chains(graph),
     ]
     if not chains:
@@ -23504,7 +24029,13 @@ def _attention_not_eligible(
             node.op_type == "Attention" and node.domain in (_ATTENTION_DOMAIN, "")
         ) or (
             node.op_type
-            in ("GroupQueryAttention", "MultiHeadAttention", "PagedAttention")
+            in (
+                "GroupQueryAttention",
+                "MultiHeadAttention",
+                "PagedAttention",
+                "DecoderMaskedSelfAttention",
+                "DecoderMaskedMultiHeadAttention",
+            )
             and node.domain == _ATTENTION_DOMAIN
         )
         if not is_attn_like or id(node) in matched_ids:
@@ -23559,7 +24090,19 @@ def _analyze_attention_chains(
             # `GroupQueryAttention` itself supports, so it gets its own
             # `"_group"`-suffixed family string rather than sharing
             # `MultiHeadAttention`'s own `"_head"` one.
-            if chain.node.op_type == "MultiHeadAttention":
+            # `DecoderMaskedMultiHeadAttention` is ONNX Runtime's own
+            # in-place decode-time rewrite target for `MultiHeadAttention`
+            # (see this module's own "Attention-head pruning" section
+            # comment) -- same one-head-per-group granularity
+            # (`chain.kv_num_heads == chain.num_heads` always for it too,
+            # confirmed off its own schema the same way), so it shares
+            # `MultiHeadAttention`'s own family string rather than getting a
+            # distinct one: the reporting granularity is genuinely
+            # identical, not merely similarly named.
+            if chain.node.op_type in (
+                "MultiHeadAttention",
+                "DecoderMaskedMultiHeadAttention",
+            ):
                 family = "attention_mha_head"
             elif chain.node.op_type == "PagedAttention":
                 family = "attention_paged_group"
@@ -23686,6 +24229,7 @@ def _analyze_attention_head_pruning(
         *_find_gqa_chains(graph),
         *_find_onnx_attention_chains(graph),
         *_find_mha_chains(graph),
+        *_find_decoder_masked_mha_chains(graph),
         *_find_paged_attention_chains(graph),
     ]
     layers = _analyze_attention_chains(
@@ -23743,6 +24287,7 @@ def _analyze_attention_head_wanda_pruning(
         *_find_gqa_chains(graph),
         *_find_onnx_attention_chains(graph),
         *_find_mha_chains(graph),
+        *_find_decoder_masked_mha_chains(graph),
         *_find_paged_attention_chains(graph),
     ]
     if not chains:

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -13256,6 +13256,891 @@ def test_mha_wanda_pruning_matches_oracle_exactly():
     np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
 
 
+# --- apply_attention_head_pruning / _wanda_pruning -- DecoderMaskedSelfAttention --
+#
+# ONNX Runtime's own in-place decode-time rewrite target for
+# `com.microsoft::Attention` (`onnxruntime.transformers.convert_generation
+# .update_decoder_subgraph_use_decoder_masked_attention`'s own
+# `switch_attention` branch literally reassigns an `Attention` node's own
+# `op_type` to this) -- see onnxsim/pruning.py's own "Attention-head
+# pruning" section comment for the full empirical schema/execution
+# investigation this section's tests continue.
+#
+# **No CPU kernel exists for this op in this environment's onnxruntime at
+# all** (confirmed empirically: a minimal, `onnx.checker`-valid
+# `DecoderMaskedSelfAttention` node fails `onnxruntime.InferenceSession`
+# construction outright with ``NOT_IMPLEMENTED : ... Could not find an
+# implementation for DecoderMaskedSelfAttention``) -- so, following this
+# module's own `MatMulNBitsMlp`/`MatMulNBitsQkv`/`PagedAttention` precedent
+# for a matched op with no executable kernel (see onnxsim/pruning.py's own
+# section comments for those), every correctness test below decomposes a
+# pruned node's own sliced `weights`/`bias` into an equivalent, genuinely
+# executable plain `com.microsoft::Attention` node (same merged-QKV layout,
+# `do_rotary=0` -- the only value this pass ever matches for this op
+# anyway) and runs *that* through a real CPU-kernel `InferenceSession`,
+# compared against a numpy-oracle-equivalent independently-built smaller
+# `Attention` model using only the correctly-selected kept heads' own
+# original (pre-pruning) weight columns -- never the pruned
+# `DecoderMaskedSelfAttention` node itself, and never a comparison against
+# the *full, unpruned* model's own output.
+
+
+def _dmsa_model(
+    K=8,
+    H=4,
+    D=4,
+    Out=6,
+    seed=0,
+    batch=2,
+    bias=True,
+    wqkv=None,
+    bqkv=None,
+    wout=None,
+    do_rotary=0,
+    past="",  # "" (omitted) | "dynamic" | "constant"
+):
+    rng = np.random.default_rng(seed)
+    Nq = Nk = Nv = H * D
+    if wqkv is None:
+        wqkv = rng.standard_normal((K, Nq + Nk + Nv)).astype(np.float32)
+    if wout is None:
+        wout = rng.standard_normal((Nv, Out)).astype(np.float32)
+    if bias and bqkv is None:
+        bqkv = rng.standard_normal((Nq + Nk + Nv,)).astype(np.float32)
+
+    initializer = [_f32(wqkv, "Wqkv"), _f32(wout, "Wout")]
+    operands = ["X", "Wqkv"]
+    if bias:
+        initializer.append(_f32(bqkv, "Bqkv"))
+        operands.append("Bqkv")
+    else:
+        operands.append("")
+
+    extra_graph_inputs = ""
+    if past == "constant":
+        past_init = rng.standard_normal((2, batch, H, 1, D)).astype(np.float32)
+        initializer.append(_f32(past_init, "Past"))
+        operands += ["", "Past"]  # mask_index="", past="Past"
+    elif past == "dynamic":
+        operands += ["", "PastIn"]
+        extra_graph_inputs = f", float[2,{batch},{H},1,{D}] PastIn"
+
+    while operands and operands[-1] == "":
+        operands.pop()
+    qkv_inputs = ", ".join(operands)
+
+    attrs = f"num_heads={H}"
+    if do_rotary:
+        attrs += f", do_rotary={do_rotary}"
+
+    body = f"""
+        g (float[{batch},1,{K}] X{extra_graph_inputs}) => (float[{batch},1,{Out}] Y)
+        {{
+          ctx = com.microsoft.DecoderMaskedSelfAttention <{attrs}> ({qkv_inputs})
+          Y = MatMul(ctx, Wout)
+        }}
+        """
+
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17, "com.microsoft": 1]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model, dict(
+        K=K,
+        H=H,
+        D=D,
+        Out=Out,
+        Nq=Nq,
+        Nk=Nk,
+        Nv=Nv,
+        wqkv=wqkv,
+        bqkv=bqkv,
+        wout=wout,
+        batch=batch,
+    )
+
+
+def _dmsa_node(model):
+    return next(
+        n for n in model.graph.node if n.op_type == "DecoderMaskedSelfAttention"
+    )
+
+
+def _dmsa_num_heads(node):
+    return next(a.i for a in node.attribute if a.name == "num_heads")
+
+
+def _dmsa_has_qkv_hidden_sizes(node):
+    return any(a.name == "qkv_hidden_sizes" for a in node.attribute)
+
+
+def test_dmsa_pruning_shrinks_matched_block():
+    model, cfg = _dmsa_model(K=8, H=4, D=4, Out=6)
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+
+    node = _dmsa_node(pruned)
+    assert _dmsa_num_heads(node) == 2  # max(1, 4 - round(4*0.5))
+    # No `qkv_hidden_sizes` attribute is ever written back for this op --
+    # it doesn't exist on the op's own real schema at all (see
+    # onnxsim/pruning.py's own "Attention-head pruning" section comment).
+    assert not _dmsa_has_qkv_hidden_sizes(node)
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Wqkv"].dims) == [8, 24]  # 2 heads * (4+4+4)
+    assert list(inits["Bqkv"].dims) == [24]
+    assert list(inits["Wout"].dims) == [8, 6]
+
+
+def test_dmsa_pruning_zero_sparsity_is_a_no_op():
+    model, cfg = _dmsa_model(K=8, H=8, D=4, Out=6, seed=7)
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.0)
+    node = _dmsa_node(pruned)
+    assert _dmsa_num_heads(node) == cfg["H"]
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["Wqkv"], cfg["wqkv"])
+
+
+def test_dmsa_pruning_matches_oracle_via_attention_proxy():
+    # Even split -- `dq == dk == dv` -- is the *only* shape this matcher
+    # ever accepts for this op (no `qkv_hidden_sizes` attribute exists on
+    # its own real schema at all, see onnxsim/pruning.py's own
+    # "Attention-head pruning" section comment) -- confirmed here by
+    # slicing manually and checking the pruned weight's own head-block
+    # structure is exactly what a plain `Attention` proxy of the same
+    # (now-smaller) head count would expect.
+    model, cfg = _dmsa_model(K=8, H=8, D=4, Out=6, seed=1)
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+
+    node = _dmsa_node(pruned)
+    num_heads = _dmsa_num_heads(node)
+    assert num_heads == 4  # max(1, 8 - round(8*0.5))
+
+    d = cfg["D"]
+    keep_heads = _oracle_keep_heads(
+        cfg["wqkv"], cfg["Nq"], cfg["Nk"], cfg["Nv"], cfg["H"], num_heads
+    )
+    idx = _head_idx(keep_heads, d)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    q_idx = idx
+    k_idx = idx + cfg["Nq"]
+    v_idx = idx + cfg["Nq"] + cfg["Nk"]
+    all_idx = np.concatenate([q_idx, k_idx, v_idx])
+    np.testing.assert_array_equal(inits["Wqkv"], cfg["wqkv"][:, all_idx])
+
+    # Decompose the pruned node's own sliced tensors into a genuinely
+    # executable plain `Attention` proxy (see this section's own comment
+    # above for why) and compare against an independently-built smaller
+    # `Attention` oracle sliced straight from the *original* (pre-pruning)
+    # weights -- never against the full unpruned model's own output.
+    proxy, _ = _attention_model(
+        K=cfg["K"],
+        H=num_heads,
+        D=d,
+        Out=cfg["Out"],
+        wqkv=inits["Wqkv"],
+        bqkv=inits["Bqkv"],
+        wout=inits["Wout"],
+    )
+    oracle, _ = _attention_model(
+        K=cfg["K"],
+        H=num_heads,
+        D=d,
+        Out=cfg["Out"],
+        wqkv=cfg["wqkv"][:, all_idx],
+        bqkv=cfg["bqkv"][all_idx],
+        wout=cfg["wout"][idx, :],
+    )
+    rng = np.random.default_rng(2)
+    x = rng.standard_normal((cfg["batch"], 1, cfg["K"])).astype(np.float32)
+    (y_proxy,) = _run(proxy, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_proxy, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_dmsa_pruning_declines_do_rotary():
+    # Fused rotary (computed inside the op, no external cos_cache/sin_cache
+    # input on this op's own schema at all) is declined outright: no CPU
+    # kernel exists for this op at all in this environment, and the closely
+    # related, CPU-kernel-backed `Attention` op's own `do_rotary=1` path is
+    # itself confirmed unimplemented in this environment's CPU kernel
+    # ("Rotary embedding is not supported in Attention CPU kernel...") --
+    # see onnxsim/pruning.py's own "Attention-head pruning" section comment
+    # for the full reasoning. `do_rotary=0` (the default) matches fine, see
+    # every other test in this section.
+    model, cfg = _dmsa_model(K=8, H=4, D=4, Out=6, seed=3, do_rotary=1)
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    node = _dmsa_node(pruned)
+    assert _dmsa_num_heads(node) == cfg["H"]  # left completely untouched
+
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_attention_head_pruning, sparsity=0.5
+    )
+    assert report.not_eligible == ["DecoderMaskedSelfAttention 'ctx'"]
+    assert report.layers == []
+
+
+def test_dmsa_pruning_declines_constant_past():
+    # `past` is *required* by this op's own schema (unlike `Attention`'s
+    # own optional one) and real step-of-1 decode exports always leave it
+    # dynamic -- but a hand-built graph could in principle bind a constant
+    # there, which this pass has no established slicing path for (unlike
+    # the `past_key`/`past_value` *pair* every separate-Q/K/V op in this
+    # section already handles) -- so it conservatively declines the whole
+    # match rather than leaving a stale-shaped constant behind.
+    model, cfg = _dmsa_model(K=8, H=4, D=4, Out=6, seed=4, past="constant")
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    node = _dmsa_node(pruned)
+    assert _dmsa_num_heads(node) == cfg["H"]  # left completely untouched
+
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_attention_head_pruning, sparsity=0.5
+    )
+    assert report.not_eligible == ["DecoderMaskedSelfAttention 'ctx'"]
+
+
+def test_dmsa_pruning_dynamic_past_is_pruned_normally():
+    # A *dynamic* `past` (an ordinary graph input, the realistic step-of-1
+    # decode shape) is the caller's own runtime state, not a weight this
+    # pass could corrupt by leaving untouched -- matches and prunes
+    # normally, unlike the constant case above.
+    model, cfg = _dmsa_model(K=8, H=4, D=4, Out=6, seed=5, past="dynamic")
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    node = _dmsa_node(pruned)
+    assert _dmsa_num_heads(node) == 2  # max(1, 4 - round(4*0.5))
+
+
+def test_dmsa_pruning_dry_run_matches_real_call():
+    model, cfg = _dmsa_model(K=8, H=8, D=4, Out=6, seed=6)
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_attention_head_pruning, sparsity=0.5
+    )
+    assert len(report.layers) == 1
+    layer = report.layers[0]
+    assert layer.family == "attention_head"
+    assert layer.total == 8
+    assert layer.would_drop == 4  # round(8*0.5)
+
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    node = _dmsa_node(pruned)
+    assert cfg["H"] - _dmsa_num_heads(node) == layer.would_drop
+
+
+# --- apply_attention_head_pruning / _wanda_pruning -- DecoderMaskedMultiHeadAttention --
+#
+# ONNX Runtime's own in-place decode-time rewrite target for
+# `com.microsoft::MultiHeadAttention` (`onnxruntime.transformers
+# .convert_generation.replace_mha_with_dmmha`'s own literal node
+# construction) -- see onnxsim/pruning.py's own "Attention-head pruning"
+# section comment for the full empirical schema/execution investigation
+# this section's tests continue, including exactly why every input beyond
+# `query`/`key`/`value` sits at a different index than `MultiHeadAttention`'s
+# own (`mask_index`@3, `attention_bias`@4, `past_key`/`past_value`@5/6,
+# `past_sequence_length`/`beam_width`/`cache_indirection`@7/8/9, and a
+# combined `bias` moved all the way to index 10).
+#
+# Unlike `DecoderMaskedSelfAttention` above, a real CPU kernel *does* exist
+# for this op in this environment -- every correctness test below runs the
+# actual pruned `DecoderMaskedMultiHeadAttention` node through a real
+# `onnxruntime.InferenceSession`, matched against a numpy-oracle-equivalent
+# independently-built smaller `DecoderMaskedMultiHeadAttention` model using
+# only the correctly-selected kept heads' own original (pre-pruning)
+# weights -- never against the full unpruned model's own output. This
+# environment's own CPU kernel requires query/key/value sequence length to
+# be exactly 1 (``"Input sequence length should be 1 to use
+# DecoderMaskedMultiHeadAttention"`` otherwise) -- a purely runtime-shape
+# constraint invisible to this pass's own static graph matching, but every
+# model built below uses `seq_len=1` throughout so it can actually run.
+
+
+def _dmmha_model(
+    K=8,
+    H=4,
+    D=4,
+    Out=6,
+    seed=0,
+    batch=2,
+    combined_bias=False,
+    producer_bias=False,
+    wq=None,
+    wk=None,
+    wv=None,
+    bq=None,
+    bk=None,
+    bv=None,
+    wout=None,
+    attention_bias=None,
+    past_kv=None,  # None | "nonempty" | "dynamic"
+    past_key=None,
+    past_value=None,
+    past_seq=3,
+    max_seq=8,
+):
+    rng = np.random.default_rng(seed)
+    Nq = Nk = Nv = H * D
+    if wq is None:
+        wq = rng.standard_normal((K, Nq)).astype(np.float32)
+    if wk is None:
+        wk = rng.standard_normal((K, Nk)).astype(np.float32)
+    if wv is None:
+        wv = rng.standard_normal((K, Nv)).astype(np.float32)
+    if wout is None:
+        wout = rng.standard_normal((Nv, Out)).astype(np.float32)
+
+    initializer = [_f32(wq, "Wq"), _f32(wk, "Wk"), _f32(wv, "Wv"), _f32(wout, "Wout")]
+    q_op, k_op, v_op = "MatMul(X, Wq)", "MatMul(X, Wk)", "MatMul(X, Wv)"
+    if producer_bias:
+        if bq is None:
+            bq = rng.standard_normal((Nq,)).astype(np.float32)
+        if bk is None:
+            bk = rng.standard_normal((Nk,)).astype(np.float32)
+        if bv is None:
+            bv = rng.standard_normal((Nv,)).astype(np.float32)
+        initializer += [_f32(bq, "Bq"), _f32(bk, "Bk"), _f32(bv, "Bv")]
+        q_op, k_op, v_op = "Gemm(X, Wq, Bq)", "Gemm(X, Wk, Bk)", "Gemm(X, Wv, Bv)"
+
+    # Fixed-index layout: query, key, value, mask_index, attention_bias,
+    # past_key, past_value, past_sequence_length, beam_width,
+    # cache_indirection, bias -- see this section's own comment above for
+    # why this differs from `MultiHeadAttention`'s own layout.
+    operands = ["q", "k", "v", "", "", "", "", "", "", "", ""]
+    extra_graph_inputs = ""
+    present_outputs = ""
+    attrs = f"num_heads={H}"
+
+    if attention_bias is not None:
+        initializer.append(_f32(np.asarray(attention_bias), "AttentionBias"))
+        operands[4] = "AttentionBias"
+
+    if past_kv == "nonempty":
+        if past_key is None:
+            past_key = rng.standard_normal((batch, H, past_seq, D)).astype(np.float32)
+        if past_value is None:
+            past_value = rng.standard_normal((batch, H, past_seq, D)).astype(np.float32)
+        pk_buf = np.zeros((batch, H, max_seq, D), dtype=np.float32)
+        pv_buf = np.zeros((batch, H, max_seq, D), dtype=np.float32)
+        pk_buf[:, :, :past_seq, :] = past_key
+        pv_buf[:, :, :past_seq, :] = past_value
+        initializer += [_f32(pk_buf, "PastKey"), _f32(pv_buf, "PastValue")]
+        initializer.append(
+            onnx.numpy_helper.from_array(
+                np.array([past_seq], dtype=np.int32), "PastSeqLen"
+            )
+        )
+        operands[5] = "PastKey"
+        operands[6] = "PastValue"
+        operands[7] = "PastSeqLen"
+        present_outputs = ", present_key, present_value"
+        attrs += ", past_present_share_buffer=1"
+    elif past_kv == "dynamic":
+        operands[5] = "PastKeyIn"
+        operands[6] = "PastValueIn"
+        extra_graph_inputs += (
+            f", float[{batch},{H},{past_seq},{D}] PastKeyIn"
+            f", float[{batch},{H},{past_seq},{D}] PastValueIn"
+        )
+
+    if combined_bias:
+        if bq is None:
+            bq = rng.standard_normal((Nq,)).astype(np.float32)
+        if bk is None:
+            bk = rng.standard_normal((Nk,)).astype(np.float32)
+        if bv is None:
+            bv = rng.standard_normal((Nv,)).astype(np.float32)
+        combined = np.concatenate([bq, bk, bv]).astype(np.float32)
+        initializer.append(_f32(combined, "Bias"))
+        operands[10] = "Bias"
+
+    while operands and operands[-1] == "":
+        operands.pop()
+
+    ctx_outputs = "ctx" + present_outputs
+    body = f"""
+        g (float[{batch},1,{K}] X{extra_graph_inputs}) => (float[{batch},1,{Out}] Y)
+        {{
+          q = {q_op}
+          k = {k_op}
+          v = {v_op}
+          {ctx_outputs} = com.microsoft.DecoderMaskedMultiHeadAttention <{attrs}> ({", ".join(operands)})
+          Y = MatMul(ctx, Wout)
+        }}
+        """
+
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17, "com.microsoft": 1]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model, dict(
+        K=K,
+        H=H,
+        D=D,
+        Out=Out,
+        Nq=Nq,
+        Nk=Nk,
+        Nv=Nv,
+        wq=wq,
+        wk=wk,
+        wv=wv,
+        bq=bq,
+        bk=bk,
+        bv=bv,
+        wout=wout,
+        batch=batch,
+        past_key=past_key,
+        past_value=past_value,
+    )
+
+
+def _dmmha_node(model):
+    return next(
+        n for n in model.graph.node if n.op_type == "DecoderMaskedMultiHeadAttention"
+    )
+
+
+def _dmmha_num_heads(node):
+    return next(a.i for a in node.attribute if a.name == "num_heads")
+
+
+def test_dmmha_pruning_shrinks_matched_block():
+    model, cfg = _dmmha_model(K=8, H=4, D=4, Out=6)
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    node = _dmmha_node(pruned)
+    assert _dmmha_num_heads(node) == 2  # max(1, 4 - round(4*0.5))
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Wq"].dims) == [8, 8]
+    assert list(inits["Wk"].dims) == [8, 8]
+    assert list(inits["Wv"].dims) == [8, 8]
+    assert list(inits["Wout"].dims) == [8, 6]
+
+    rng = np.random.default_rng(1)
+    x = rng.standard_normal((cfg["batch"], 1, cfg["K"])).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    assert y.shape == (cfg["batch"], 1, cfg["Out"])
+
+
+def test_dmmha_pruning_zero_sparsity_is_a_no_op():
+    model, cfg = _dmmha_model(K=8, H=8, D=4, Out=6, seed=7)
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.0)
+    node = _dmmha_node(pruned)
+    assert _dmmha_num_heads(node) == cfg["H"]
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["Wq"], cfg["wq"])
+    np.testing.assert_array_equal(inits["Wk"], cfg["wk"])
+    np.testing.assert_array_equal(inits["Wv"], cfg["wv"])
+
+
+def test_dmmha_pruning_matches_oracle_exactly():
+    model, cfg = _dmmha_model(K=8, H=8, D=4, Out=6, seed=1, combined_bias=True)
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    node = _dmmha_node(pruned)
+    num_heads = _dmmha_num_heads(node)
+    assert num_heads == 4  # max(1, 8 - round(8*0.5))
+
+    d = cfg["D"]
+    keep_heads = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], cfg["H"], cfg["H"], d, num_heads
+    )
+    idx = _head_idx(keep_heads, d)
+
+    oracle, _ = _dmmha_model(
+        K=cfg["K"],
+        H=len(keep_heads),
+        D=d,
+        Out=cfg["Out"],
+        seed=1,
+        combined_bias=True,
+        wq=cfg["wq"][:, idx],
+        wk=cfg["wk"][:, idx],
+        wv=cfg["wv"][:, idx],
+        bq=cfg["bq"][idx],
+        bk=cfg["bk"][idx],
+        bv=cfg["bv"][idx],
+        wout=cfg["wout"][idx, :],
+        batch=cfg["batch"],
+    )
+
+    rng = np.random.default_rng(2)
+    x = rng.standard_normal((cfg["batch"], 1, cfg["K"])).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_dmmha_pruning_slices_combined_bias_exactly():
+    model, cfg = _dmmha_model(K=8, H=4, D=4, Out=6, seed=3, combined_bias=True)
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+
+    node = _dmmha_node(pruned)
+    num_heads = _dmmha_num_heads(node)
+    d = cfg["D"]
+    keep_heads = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], cfg["H"], cfg["H"], d, num_heads
+    )
+    idx = _head_idx(keep_heads, d)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    expected = np.concatenate([cfg["bq"][idx], cfg["bk"][idx], cfg["bv"][idx]])
+    np.testing.assert_array_equal(inits["Bias"], expected)
+    # Confirms the combined bias really is read off input index 10 (the
+    # node's own *last* input), not index 3 (`MultiHeadAttention`'s own).
+    assert node.input[10] == "Bias"
+
+
+def test_dmmha_pruning_attention_bias_is_sliced_and_matches_oracle():
+    # This environment's own CPU kernel additionally requires a connected
+    # `attention_bias` to run in the (cached) self-attention mode -- with no
+    # `past_key`/`past_value` connected at all it errors outright
+    # ("DecoderMaskedMultiHeadAttention does not support attention bias for
+    # cross-attention") -- so this test connects a past cache too, and
+    # sizes `attention_bias`'s own last axis to `total_sequence_length`
+    # (`past_seq + 1`), per this op's own kernel-level shape requirement.
+    H, D = 4, 4
+    past_seq = 3
+    total_seq = past_seq + 1
+    rng = np.random.default_rng(16)
+    attention_bias = rng.standard_normal((1, H, 1, total_seq)).astype(np.float32)
+    model, cfg = _dmmha_model(
+        K=8,
+        H=H,
+        D=D,
+        Out=6,
+        seed=16,
+        attention_bias=attention_bias,
+        past_kv="nonempty",
+        past_seq=past_seq,
+    )
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    node = _dmmha_node(pruned)
+    num_heads = _dmmha_num_heads(node)
+    keep_heads = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], H, H, D, num_heads
+    )
+    idx = _head_idx(keep_heads, D)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["AttentionBias"], attention_bias[:, keep_heads])
+    # Confirms the bias really is read off input index 4 (not 5, the
+    # position `MultiHeadAttention`'s own analogous input sits at).
+    assert node.input[4] == "AttentionBias"
+
+    oracle, _ = _dmmha_model(
+        K=cfg["K"],
+        H=len(keep_heads),
+        D=D,
+        Out=cfg["Out"],
+        seed=16,
+        attention_bias=attention_bias[:, keep_heads],
+        past_kv="nonempty",
+        past_seq=past_seq,
+        past_key=cfg["past_key"][:, keep_heads],
+        past_value=cfg["past_value"][:, keep_heads],
+        wq=cfg["wq"][:, idx],
+        wk=cfg["wk"][:, idx],
+        wv=cfg["wv"][:, idx],
+        wout=cfg["wout"][idx, :],
+        batch=cfg["batch"],
+    )
+    rng2 = np.random.default_rng(17)
+    x = rng2.standard_normal((cfg["batch"], 1, cfg["K"])).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_dmmha_pruning_nonempty_past_kv_constant_matches_oracle_exactly():
+    past_seq = 3
+    model, cfg = _dmmha_model(
+        K=8, H=4, D=4, Out=6, seed=18, past_kv="nonempty", past_seq=past_seq
+    )
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    node = _dmmha_node(pruned)
+    num_heads = _dmmha_num_heads(node)
+    d = cfg["D"]
+    keep_heads = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], cfg["H"], cfg["H"], d, num_heads
+    )
+    idx = _head_idx(keep_heads, d)
+
+    # `inits["PastKey"]`/`["PastValue"]` are already the post-pruning
+    # buffer (axis 1 already sliced down to `num_heads`) -- compare its own
+    # real (non-padding) `:past_seq` slice against the *original* cache
+    # sliced the same way, not re-index it a second time.
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(
+        inits["PastKey"][:, :, :past_seq, :], cfg["past_key"][:, keep_heads]
+    )
+    np.testing.assert_array_equal(
+        inits["PastValue"][:, :, :past_seq, :], cfg["past_value"][:, keep_heads]
+    )
+    # Confirms past_key/past_value really are read off indices 5/6 (not
+    # 6/7, `MultiHeadAttention`'s own).
+    assert node.input[5] == "PastKey"
+    assert node.input[6] == "PastValue"
+
+    oracle, _ = _dmmha_model(
+        K=cfg["K"],
+        H=len(keep_heads),
+        D=d,
+        Out=cfg["Out"],
+        seed=18,
+        past_kv="nonempty",
+        past_seq=past_seq,
+        past_key=cfg["past_key"][:, keep_heads],
+        past_value=cfg["past_value"][:, keep_heads],
+        wq=cfg["wq"][:, idx],
+        wk=cfg["wk"][:, idx],
+        wv=cfg["wv"][:, idx],
+        wout=cfg["wout"][idx, :],
+        batch=cfg["batch"],
+    )
+    rng = np.random.default_rng(19)
+    x = rng.standard_normal((cfg["batch"], 1, cfg["K"])).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_dmmha_pruning_dynamic_past_kv_is_left_untouched():
+    model, cfg = _dmmha_model(K=8, H=4, D=4, Out=6, seed=21, past_kv="dynamic")
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    node = _dmmha_node(pruned)
+    assert _dmmha_num_heads(node) == 2  # still prunes the producer weights
+    # The dynamic past_key/past_value graph inputs themselves are the
+    # caller's own runtime data -- left completely alone, same names/shapes.
+    input_names = {i.name for i in pruned.graph.input}
+    assert "PastKeyIn" in input_names
+    assert "PastValueIn" in input_names
+
+
+def test_dmmha_pruning_diff_v_head_size_is_declined():
+    # Unlike `MultiHeadAttention` (which genuinely allows V its own
+    # head_size), this op's own CPU kernel hard-requires equal Q/K/V
+    # head_size -- confirmed empirically ("QK head size should be same as V
+    # head size to use DecoderMaskedMultiHeadAttention") -- so
+    # `_find_decoder_masked_mha_chains` passes
+    # `allow_differing_v_head_size=False` and a node whose V width
+    # genuinely differs declines the whole match rather than being pruned
+    # into a shape that could never execute anyway.
+    K, H, D, Dv, Out = 8, 2, 4, 3, 5
+    model, cfg = _dmmha_model(K=K, H=H, D=D, Out=Out, seed=22)
+    # Hand-widen V's own weight/Wout to a genuinely different per-head width.
+    rng = np.random.default_rng(23)
+    wv2 = rng.standard_normal((K, H * Dv)).astype(np.float32)
+    wout2 = rng.standard_normal((H * Dv, Out)).astype(np.float32)
+    inits = {t.name: t for t in model.graph.initializer}
+    inits["Wv"].CopyFrom(_f32(wv2, "Wv"))
+    inits["Wout"].CopyFrom(_f32(wout2, "Wout"))
+
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    node = _dmmha_node(pruned)
+    assert _dmmha_num_heads(node) == H  # left completely untouched
+
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_attention_head_pruning, sparsity=0.5
+    )
+    assert report.not_eligible == ["DecoderMaskedMultiHeadAttention 'ctx'"]
+
+
+def test_dmmha_pruning_cross_attention_4d_kv_is_not_matched():
+    # The real cross-attention calling convention for this op feeds `key`/
+    # `value` as a pre-projected rank-4 `(batch, num_heads, kv_seq,
+    # head_size)` tensor directly (confirmed empirically -- see
+    # onnxsim/pruning.py's own "Attention-head pruning" section comment),
+    # not `MultiHeadAttention`'s own rank-3 MatMul-producer-fed convention.
+    # That rank-4 tensor is never fed by a MatMul/vanilla-Gemm producer
+    # with a 2-D weight at all, so `_find_separate_qkv_chains`'s own
+    # `_match_producer` naturally declines it -- confirmed here structurally
+    # (this test never claims the resulting model is numerically valid to
+    # actually run this way; only that this pass correctly leaves it alone
+    # rather than mis-slicing it).
+    H, D, K, Out = 4, 8, 8, 6
+    kv_seq = 7
+    rng = np.random.default_rng(24)
+    wq = rng.standard_normal((K, H * D)).astype(np.float32)
+    wout = rng.standard_normal((H * D, Out)).astype(np.float32)
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17, "com.microsoft": 1]
+        >
+        g (float[batch,1,{K}] X, float[batch,{H},{kv_seq},{D}] KeyIn, float[batch,{H},{kv_seq},{D}] ValueIn) => (float[batch,1,{Out}] Y)
+        {{
+          q = MatMul(X, Wq)
+          ctx = com.microsoft.DecoderMaskedMultiHeadAttention <num_heads={H}> (q, KeyIn, ValueIn)
+          Y = MatMul(ctx, Wout)
+        }}
+        """
+    )
+    model.graph.initializer.extend([_f32(wq, "Wq"), _f32(wout, "Wout")])
+
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    node = _dmmha_node(pruned)
+    assert _dmmha_num_heads(node) == H  # left completely untouched
+
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_attention_head_pruning, sparsity=0.5
+    )
+    assert report.not_eligible == ["DecoderMaskedMultiHeadAttention 'ctx'"]
+
+
+def test_dmmha_pruning_runtime_only_inputs_left_untouched():
+    # `mask_index`, `past_sequence_length`, `beam_width`, and
+    # `cache_indirection` never carry a `num_heads`-sized axis on their own
+    # schema docs (confirmed live -- see onnxsim/pruning.py's own
+    # "Attention-head pruning" section comment) -- connected as ordinary
+    # dynamic graph inputs, they are never inspected or touched by this
+    # pass at all.
+    K, H, D, Out, batch = 8, 4, 4, 6, 2
+    rng = np.random.default_rng(25)
+    wq = rng.standard_normal((K, H * D)).astype(np.float32)
+    wk = rng.standard_normal((K, H * D)).astype(np.float32)
+    wv = rng.standard_normal((K, H * D)).astype(np.float32)
+    wout = rng.standard_normal((H * D, Out)).astype(np.float32)
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17, "com.microsoft": 1]
+        >
+        g (float[{batch},1,{K}] X,
+           int32[{batch},1] MaskIndex,
+           int32[1] PastSeqLen,
+           int32[1] BeamWidth,
+           int32[{batch},1,1] CacheIndirection)
+          => (float[{batch},1,{Out}] Y)
+        {{
+          q = MatMul(X, Wq)
+          k = MatMul(X, Wk)
+          v = MatMul(X, Wv)
+          ctx = com.microsoft.DecoderMaskedMultiHeadAttention <num_heads={H}> (q, k, v, MaskIndex, "", "", "", PastSeqLen, BeamWidth, CacheIndirection)
+          Y = MatMul(ctx, Wout)
+        }}
+        """
+    )
+    model.graph.initializer.extend(
+        [_f32(wq, "Wq"), _f32(wk, "Wk"), _f32(wv, "Wv"), _f32(wout, "Wout")]
+    )
+
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    node = _dmmha_node(pruned)
+    assert _dmmha_num_heads(node) == 2  # matched/pruned normally
+    # The four runtime-only inputs are untouched -- same names, still
+    # present as graph inputs, unchanged.
+    assert list(node.input[3:4]) == ["MaskIndex"]
+    assert node.input[7:10] == ["PastSeqLen", "BeamWidth", "CacheIndirection"]
+    input_names = {i.name for i in pruned.graph.input}
+    assert {"MaskIndex", "PastSeqLen", "BeamWidth", "CacheIndirection"} <= input_names
+
+
+def test_dmmha_pruning_family_string_matches_mha():
+    # Reporting reuses `MultiHeadAttention`'s own family string rather than
+    # a distinct one -- the granularity is genuinely identical (no separate
+    # `kv_num_heads` on this op's own schema either), see
+    # onnxsim/pruning.py's own "Attention-head pruning" section comment.
+    model, cfg = _dmmha_model(K=8, H=8, D=4, Out=6, seed=26)
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_attention_head_pruning, sparsity=0.5
+    )
+    assert len(report.layers) == 1
+    assert report.layers[0].family == "attention_mha_head"
+
+
+def test_dmmha_pruning_dry_run_matches_real_call():
+    model, cfg = _dmmha_model(K=8, H=8, D=4, Out=6, seed=27, combined_bias=True)
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_attention_head_pruning, sparsity=0.5
+    )
+    assert len(report.layers) == 1
+    layer = report.layers[0]
+    assert layer.total == 8
+    assert layer.would_drop == 4  # round(8*0.5)
+
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    node = _dmmha_node(pruned)
+    assert cfg["H"] - _dmmha_num_heads(node) == layer.would_drop
+
+
+def test_dmmha_wanda_pruning_matches_oracle_exactly():
+    model, cfg = _dmmha_model(K=8, H=8, D=4, Out=6, seed=28, combined_bias=True)
+
+    rng = np.random.default_rng(29)
+    x_cal = rng.standard_normal((cfg["batch"], 1, cfg["K"])).astype(np.float32)
+    calibration_data = [{"X": x_cal}]
+
+    pruned = onnxsim.apply_attention_head_wanda_pruning(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned)
+
+    probe_model = onnx.ModelProto()
+    probe_model.CopyFrom(model)
+    probe_model.graph.output.append(onnx.ValueInfoProto(name="ctx"))
+    (_, ctx_cal) = _run(probe_model, {"X": x_cal})
+    act_norm = np.sqrt(np.mean(np.square(ctx_cal.astype(np.float64)), axis=(0, 1)))
+
+    d = cfg["D"]
+    importance = np.zeros(cfg["H"])
+    for h in range(cfg["H"]):
+        block = np.concatenate(
+            [
+                cfg["wq"][:, h * d : (h + 1) * d],
+                cfg["wk"][:, h * d : (h + 1) * d],
+                cfg["wv"][:, h * d : (h + 1) * d],
+            ],
+            axis=1,
+        )
+        base = np.linalg.norm(block)
+        act_head = np.linalg.norm(act_norm[h * d : (h + 1) * d])
+        importance[h] = base * max(act_head, 1e-8)
+    keep_heads = np.sort(np.argsort(-importance)[:4])  # max(1, 8 - round(8*0.5))
+    idx = _head_idx(keep_heads, d)
+
+    oracle, _ = _dmmha_model(
+        K=cfg["K"],
+        H=len(keep_heads),
+        D=d,
+        Out=cfg["Out"],
+        seed=28,
+        combined_bias=True,
+        wq=cfg["wq"][:, idx],
+        wk=cfg["wk"][:, idx],
+        wv=cfg["wv"][:, idx],
+        bq=cfg["bq"][idx],
+        bk=cfg["bk"][idx],
+        bv=cfg["bv"][idx],
+        wout=cfg["wout"][idx, :],
+        batch=cfg["batch"],
+    )
+
+    rng2 = np.random.default_rng(30)
+    x = rng2.standard_normal((cfg["batch"], 1, cfg["K"])).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
 def test_attention_head_pruning_handles_all_three_attention_op_types_in_one_model():
     # Regression check for `_apply_attention_chains`'s per-chain-type
     # dispatch once a third node type shares it: a plain


### PR DESCRIPTION
## Summary

ONNX Runtime's own `onnxruntime.transformers.convert_generation` module (used by ORT's own T5/GPT2/Whisper beam-search export path) rewrites already-exported `Attention`/`MultiHeadAttention` nodes into `com.microsoft::DecoderMaskedSelfAttention`/`DecoderMaskedMultiHeadAttention` for the step-of-1 decode path. Neither op was previously recognized by attention-head pruning.

## Empirically confirmed facts

- **The rewrite is real, shipped ORT code**: confirmed directly from the installed `onnxruntime` (1.29.0) package source — `convert_generation.py`'s `update_decoder_subgraph_use_decoder_masked_attention`/`replace_mha_with_dmmha` literally rebuild `Attention`/`MultiHeadAttention` nodes as the Decoder-masked variants via `onnx.helper.make_node`.
- **`DecoderMaskedSelfAttention`**: same merged-QKV `weights` layout as `Attention`, but **no `qkv_hidden_sizes` attribute at all** on the live schema (confirmed via `get_all_operator_schema()`) — the rewrite itself aborts if the source `Attention` node has one, so a real exported `DecoderMaskedSelfAttention` always assumes an even 3-way Q/K/V split. **No CPU kernel exists** in this environment (`InferenceSession` construction fails with `NOT_IMPLEMENTED`).
- **`DecoderMaskedMultiHeadAttention`**: same pre-projected Q/K/V shape family as `MultiHeadAttention`, but every input beyond `query`/`key`/`value` sits at a different index — most notably the combined `bias` moves from index 3 to index **10** (the last input), confirmed both off the live schema and off `replace_mha_with_dmmha`'s own literal input-list construction. **A real CPU kernel exists** here, so every claim below was verified via real execution against a from-scratch numpy oracle:
  - `allow_differing_v_head_size` must be **`False`** (unlike `MultiHeadAttention`'s `True`) — confirmed via a real `InferenceSession` run failing with `"QK head size should be same as V head size to use DecoderMaskedMultiHeadAttention"` when V's width differs.
  - `past_present_share_buffer=1` is required whenever `past_key`/`past_value` are connected — a `false`/absent attribute fails outright at the kernel level.
  - **Cross-attention was investigated and found NOT to compose the way it does for `MultiHeadAttention`** — confirmed, not assumed, and left deliberately unmatched (see PR diff's own section comment for the exact investigation).

## What's added

`_match_attention_producer` widened to accept `DecoderMaskedSelfAttention` (degenerates cleanly into the existing even-split path since the op never carries `qkv_hidden_sizes`); declines `do_rotary=1` outright (no execution-confirmed safety argument could be built — even the closely-related `Attention` op's own `do_rotary=1` CPU kernel path is unimplemented, "Please fuse the model with MHA + RotaryEmbedding"), a stray `qkv_hidden_sizes` attribute, or a constant `past`.

New, deliberately *separate* `_match_decoder_masked_multi_head_attention_producer`/`_find_decoder_masked_mha_chains` (kept apart from the `MultiHeadAttention` matcher rather than merged, since the index layouts diverge too much for one shared function to safely thread) reuse all existing `_GQAChain`/`_apply_one_gqa_chain`/`_find_separate_qkv_chains` machinery, just with `combined_bias_input_index=10` and `allow_differing_v_head_size=False`. Both wired into `apply_attention_head_pruning`/`apply_attention_head_wanda_pruning` and their `_analyze_*` mirrors. Reuses the existing `"attention_head"` (DMSA) and `"attention_mha_head"` (DMMHA — granularity is genuinely identical, no separate `kv_num_heads`) sensitivity families rather than inventing new ones.

## Test plan

- [x] `pytest tests/test_pruning.py -q` — 586 → 606 passed
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — 0 errors, unchanged from master's baseline
- [x] `DecoderMaskedSelfAttention` correctness via decomposition into an executable plain `Attention` proxy (no CPU kernel exists for the op itself) against a numpy oracle built from only the kept heads' weights
- [x] `DecoderMaskedMultiHeadAttention` correctness via real `InferenceSession` runs (self-attention, combined bias, `attention_bias` slicing, past_key/value cache slicing) against numpy oracles
- [x] Structural decline tests for cross-attention and mismatched V head size
- [x] Runtime-only-input (`mask_index`/`past_sequence_length`/`beam_width`/`cache_indirection`) untouched checks
- [x] Dry-run-vs-real-call parity

I independently re-confirmed the ORT source (the exact `onnx.helper.make_node` rewrite, the `qkv_hidden_sizes` abort condition, the `beam_width`/`cache_indirection` input construction), pulled both live schemas myself, and reproduced the "no CPU kernel for DMSA" failure before pushing this.

---
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_