### PR TITLE
Compute retention on DeviceMark's completed-only accuracy

### DIFF
--- a/bench/TODO_quality_retention_eval.md
+++ b/bench/TODO_quality_retention_eval.md
@@ -8,11 +8,14 @@ and `--model coreml`), `lm_eval_coreml_adapter.py` (the `CoreMLDecoder`-wrapping
 `generate_until` adapter), and `compute_retention.py` (quantized/float ratio,
 unit-tested in `tests/test_compute_retention.py`) -- see
 `scripts/apple/README.md`'s "Quality and retention eval" section for usage.
-MMLU-Pro is validated as *working* through the same scripts (see "What's been
-prototyped" below) but not yet in CI: a real compute-cost finding during
-prototyping (below) means it needs more thought before it's CI-feasible at all,
-not just a config change. This doc's "Next steps" now reflects what's left, not a
-from-scratch plan.
+Retention is now computed on DeviceMark's own `acc_completed` definition
+(completed-only accuracy) when available, not plain `acc` -- see "What
+DeviceMark measures" -> "Retention" below. MMLU-Pro is validated as *working*
+through the same scripts (see "What's been prototyped" below) but not yet in
+CI: the compute-cost problem is solved (`--max-gen-toks 256`), but the current
+CI model scores 0/10 on `mmlu_pro_biology` regardless, making retention always
+`None` -- see "Next steps" item 4. This doc's "Next steps" now reflects what's
+left, not a from-scratch plan.
 
 `scripts/apple` previously only measured decode speed (`run_llm_decode_benchmark.py`)
 and prefill/decode correctness against the HF reference at the token level
@@ -57,10 +60,19 @@ int8 and float sides hit the token cap at different points (different
 weights, different no-answer rates), which would otherwise let the ratio be
 dominated by cap-timing rather than actual quantization damage -- documented
 on their side as "the retention confound," and it's why a retention number can
-land above 100% at small n. `compute_retention.py`'s
-`retention = quantized_score / float_score` on whatever `run_quality_eval.py`
-already scored (no completed-only split -- see "Proposed scope" below) is the
-same *shape* of ratio, on a coarser accuracy definition.
+land above 100% at small n. **Implemented (2026-09-03):** `run_quality_eval.py`
+now reports `acc_completed` alongside plain `acc` whenever `--max-gen-toks` is
+passed explicitly (already the case for both `quality-eval-macos` steps) --
+`is_completed()` classifies a sample as "completed" when its raw response's
+token count is strictly below `--max-gen-toks` (validated against real
+`mmlu_pro_biology` generations: every `[invalid]`-extracted sample had a
+token count *exactly* equal to the cap, every real-answer sample had a lower
+one -- see that function's docstring). `compute_retention.py`'s
+`_resolve_score()` prefers `acc_completed` when present and defined, falling
+back to plain `acc` when it isn't (no explicit `--max-gen-toks`, or every
+sampled item hit the cap) -- so `retention = quantized_score / float_score`
+is now on `acc_completed` in the case this doc originally called out, not "no
+completed-only split" as this paragraph used to say.
 
 **The bigger gap: DeviceMark's on-device runtime is not Core ML.** Its
 "shipped int8" column runs on the leaderboard author's own private on-device
@@ -319,11 +331,14 @@ trend-plotting script exists) -- that's the next piece if this is picked up furt
    this repo's own implementation needed to change as a result -- the CI-feasibility
    constraints (`--limit`, `--max-gen-toks`) that already exist are still the right call
    for a GitHub-hosted macOS runner's budget; this was a documentation-accuracy gap, not
-   a scope gap. One thing worth doing if this is picked up again: switch
-   `compute_retention.py`'s inputs to a completed-only accuracy (excluding no-answer
-   items from the denominator) to match how DeviceMark defines retention specifically,
-   rather than the plain `acc` `run_quality_eval.py` currently reports -- not done here
-   since it touches `run_quality_eval.py`'s output schema, not just docs.
+   a scope gap. ~~One thing worth doing if this is picked up again: switch
+   `compute_retention.py`'s inputs to a completed-only accuracy~~ -- done (2026-09-03),
+   see "What DeviceMark measures" -> "Retention" above: `run_quality_eval.py` now
+   reports `acc_completed` (whenever `--max-gen-toks` is explicit, which both CI steps
+   already pass) via a validated cap-based `is_completed()` check, and
+   `compute_retention.py` prefers it automatically. No CI YAML changes needed --
+   `retention_ifeval.json`/`retention_math500.json` pick this up on the next
+   `quality-eval-macos` run since both steps already pass `--max-gen-toks`.
 6. ~~Once more than one model has been run through `quality-eval-macos`... consider
    the machine-readable JSON artifact idea~~ -- done: MATH-500 landing alongside
    IFEval (see item 4) gave a second data point, so `compute_retention.py --output`

--- a/scripts/apple/README.md
+++ b/scripts/apple/README.md
@@ -477,8 +477,8 @@ and MATH-500, plus **retention**: how much of the float model's benchmark
 score survives quantization (`quantized_score / float_score`). See
 `bench/TODO_quality_retention_eval.md` for the full plan (including exactly
 how DeviceMark itself defines this -- subset sizes, 0-shot, and a
-completed-only accuracy this repo's own `compute_retention.py` doesn't yet
-replicate); this is the first implemented slice of it.
+completed-only accuracy `compute_retention.py` now replicates too, see below);
+this is the first implemented slice of it.
 
 Rather than reimplementing any benchmark's prompt formatting or answer
 scoring, these two scripts lean on
@@ -497,14 +497,21 @@ definitions:
 - `run_quality_eval.py` is a thin CLI over `lm_eval.simple_evaluate`,
   supporting both `--model hf` (the float side -- CPU-only, no macOS needed)
   and `--model coreml` (the quantized side -- macOS/real Core ML only) against
-  the same task/subset, writing a small JSON summary.
+  the same task/subset, writing a small JSON summary. Each scored metric
+  reports plain `acc` (no-answer-within-budget counts as wrong) and, whenever
+  `--max-gen-toks` is passed explicitly, `acc_completed` too -- accuracy over
+  only the samples whose response finished before exhausting that budget
+  (`is_completed()`; validated against real generations -- see that
+  function's docstring), DeviceMark's own retention definition.
 - `compute_retention.py` takes one JSON from each side and reports the
-  per-task, per-metric retention ratio. `--output` also writes a flat
-  `"records"` list (one object per task/metric: `model_id`, `benchmark`,
-  `metric`, `subset_n`, `float_acc`, `quantized_acc`, `retention`) alongside
-  the nested summary -- `coreml-integration.yml` uploads these as the
-  `quality-retention-results` CI artifact, so a run's numbers don't have to
-  be re-parsed out of `$GITHUB_STEP_SUMMARY` text.
+  per-task, per-metric retention ratio, preferring each side's `acc_completed`
+  when it's present and defined and falling back to plain `acc` otherwise
+  (`_resolve_score()`). `--output` also writes a flat `"records"` list (one
+  object per task/metric: `model_id`, `benchmark`, `metric`, `subset_n`,
+  `float_acc`, `quantized_acc`, `retention`, `float_basis`, `quantized_basis`)
+  alongside the nested summary -- `coreml-integration.yml` uploads these as
+  the `quality-retention-results` CI artifact, so a run's numbers don't have
+  to be re-parsed out of `$GITHUB_STEP_SUMMARY` text.
 
 ```bash
 pip install "optimum-onnx" transformers coremltools onnxruntime "lm-eval[ifeval]"

--- a/scripts/apple/compute_retention.py
+++ b/scripts/apple/compute_retention.py
@@ -22,18 +22,49 @@ import json
 import sys
 
 
+def _resolve_score(value) -> tuple[float, str] | tuple[None, None]:
+    """Extract a plain accuracy number and its basis from one `run_quality_eval.py`
+    `--output` metric entry.
+
+    `run_quality_eval.py` now reports each metric as `{"acc": ..., possibly
+    "acc_completed": ...}` (see that module's docstring) rather than a bare
+    number -- `acc_completed`, when present and defined, is DeviceMark's own
+    retention definition (accuracy over only the samples that produced an
+    answer before exhausting their generation budget, see
+    `bench/TODO_quality_retention_eval.md`'s "What DeviceMark measures"), so
+    it's preferred here. Falls back to plain `acc` when `acc_completed` is
+    absent (no explicit `--max-gen-toks` was passed to that run) or `None`
+    (every sampled item hit the cap -- nothing to average). A bare number is
+    also accepted directly (returned as-is, basis `"acc"`) for callers
+    (including tests) building this dict by hand rather than via
+    `run_quality_eval.py --output`. Anything else (a non-numeric field like an
+    internal alias) resolves to `(None, None)`.
+    """
+    if isinstance(value, (int, float)):
+        return value, "acc"
+    if isinstance(value, dict):
+        completed = value.get("acc_completed")
+        if isinstance(completed, (int, float)):
+            return completed, "acc_completed"
+        acc = value.get("acc")
+        if isinstance(acc, (int, float)):
+            return acc, "acc"
+    return None, None
+
+
 def compute_retention(float_tasks: dict, quantized_tasks: dict) -> dict:
     """Per-(task, metric) retention for every metric present on both sides.
 
     `float_tasks`/`quantized_tasks` are `run_quality_eval.py` output's "tasks"
-    field: `{task: {metric: value}}`. A metric present on only one side (a
-    task run with different `--tasks` on each side, or a non-numeric field
-    like an internal alias) is silently skipped rather than raising -- the
-    two result files come from independent runs and aren't guaranteed to
-    line up exactly. A float score of exactly 0 makes the ratio undefined
-    (nothing to retain, or the metric legitimately can't score 0 by
-    construction and something else broke) -- reported as `None`, not `inf`
-    or `nan`.
+    field: `{task: {metric: value}}`, `value` resolved via `_resolve_score`
+    (DeviceMark's completed-only accuracy when available, plain accuracy
+    otherwise). A metric present on only one side (a task run with different
+    `--tasks` on each side, or a non-numeric field like an internal alias) is
+    silently skipped rather than raising -- the two result files come from
+    independent runs and aren't guaranteed to line up exactly. A float score
+    of exactly 0 makes the ratio undefined (nothing to retain, or the metric
+    legitimately can't score 0 by construction and something else broke) --
+    reported as `None`, not `inf` or `nan`.
     """
     retention = {}
     for task, float_metrics in float_tasks.items():
@@ -46,14 +77,16 @@ def compute_retention(float_tasks: dict, quantized_tasks: dict) -> dict:
             if metric not in quantized_metrics:
                 continue
             quantized_value = quantized_metrics[metric]
-            if not isinstance(float_value, (int, float)) or not isinstance(
-                quantized_value, (int, float)
-            ):
+            float_score, float_basis = _resolve_score(float_value)
+            quantized_score, quantized_basis = _resolve_score(quantized_value)
+            if float_score is None or quantized_score is None:
                 continue
             task_retention[metric] = {
-                "float": float_value,
-                "quantized": quantized_value,
-                "retention": (quantized_value / float_value) if float_value else None,
+                "float": float_score,
+                "quantized": quantized_score,
+                "retention": (quantized_score / float_score) if float_score else None,
+                "float_basis": float_basis,
+                "quantized_basis": quantized_basis,
             }
         if task_retention:
             retention[task] = task_retention
@@ -65,7 +98,8 @@ def build_records(
 ) -> list[dict]:
     """Flatten `compute_retention`'s `{task: {metric: {...}}}` into one flat
     record per (task, metric): `{model_id, benchmark, metric, subset_n,
-    float_acc, quantized_acc, retention}`.
+    float_acc, quantized_acc, retention, float_basis, quantized_basis}`
+    (`*_basis` is `"acc_completed"` or `"acc"` -- see `_resolve_score`).
 
     The nested shape is convenient to print but awkward to accumulate across
     runs/models into a trend table without re-parsing it; this is the
@@ -86,6 +120,8 @@ def build_records(
                     "float_acc": values["float"],
                     "quantized_acc": values["quantized"],
                     "retention": values["retention"],
+                    "float_basis": values["float_basis"],
+                    "quantized_basis": values["quantized_basis"],
                 }
             )
     return records
@@ -133,9 +169,15 @@ def main() -> int:
         for metric, values in metrics.items():
             ret = values["retention"]
             ret_str = f"{ret:.1%}" if ret is not None else "N/A (float score was 0)"
+            basis_note = ""
+            if "acc_completed" in (values["float_basis"], values["quantized_basis"]):
+                basis_note = (
+                    f" [basis: float={values['float_basis']}, "
+                    f"quantized={values['quantized_basis']}]"
+                )
             print(
                 f"  {metric}: float={values['float']:.4f} "
-                f"quantized={values['quantized']:.4f} retention={ret_str}"
+                f"quantized={values['quantized']:.4f} retention={ret_str}{basis_note}"
             )
 
     if args.output:

--- a/scripts/apple/run_quality_eval.py
+++ b/scripts/apple/run_quality_eval.py
@@ -29,6 +29,16 @@ Run the quantized side (macOS only, real Core ML) against the exported model:
         --tasks ifeval --limit 20 --output coreml_ifeval.json
 
 Then compare the two with `compute_retention.py`.
+
+Each scored metric in `--output`'s "tasks" field is `{"acc": <plain accuracy,
+no-answer-within-budget counts as wrong>}`, plus (only when `--max-gen-toks`
+was passed explicitly, so there's a known budget to check a response against)
+`"total_n"`, `"completed_n"`, and `"acc_completed"` (accuracy over only the
+samples that produced an answer before exhausting that budget) -- DeviceMark's
+own retention definition, see `is_completed`'s docstring and
+`bench/TODO_quality_retention_eval.md`'s "What DeviceMark measures".
+`compute_retention.py` prefers `acc_completed` when present and defined,
+falling back to `acc` otherwise.
 """
 
 from __future__ import annotations
@@ -36,6 +46,70 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from pathlib import Path
+
+
+def is_completed(response_token_count: int, max_gen_toks: int | None) -> bool | None:
+    """Whether a `generate_until` response finished before exhausting its
+    generation budget -- DeviceMark's own definition of a benchmark item
+    "producing an answer" within its token cap, see
+    `bench/TODO_quality_retention_eval.md`'s "What DeviceMark measures".
+    Validated empirically (2026-09-03) against real `mmlu_pro_biology`
+    generations: every sample whose extracted answer was `lm_eval`'s
+    `[invalid]` (couldn't find a parseable answer) had a response token count
+    exactly equal to `max_gen_toks`, and every sample with a real extracted
+    answer had a strictly lower count -- a response that hit the cap without
+    naturally stopping (via `until` or EOS) is indistinguishable in length
+    from one that happened to need every last token, but that's the same
+    approximation DeviceMark's own cap-based definition makes.
+
+    `None` when `max_gen_toks` isn't known -- no explicit `--max-gen-toks`
+    was passed to this run, so there's no fixed budget to compare a
+    response's length against (guessing a task's own YAML default isn't
+    attempted here) -- callers should skip completed-only accounting
+    entirely in that case rather than report a number quietly computed
+    against the wrong cap.
+    """
+    if max_gen_toks is None:
+        return None
+    return response_token_count < max_gen_toks
+
+
+def aggregate_completed_only(values: list) -> float | None:
+    """Mean of per-sample metric values, restricted by the caller to
+    "completed" samples (see `is_completed`) before this is called.
+
+    Flattens any list-valued entries first: IFEval's `inst_level_*_acc`
+    metrics are a list of per-instruction booleans *per sample* (a single
+    response can satisfy some instructions and not others), not a scalar --
+    `lm_eval`'s own aggregation pools every instruction across every sample
+    before averaging, so this does the same, just over the completed subset,
+    to keep a completed-only IFEval score on the same footing as its
+    plain-`acc` counterpart. `None` on an empty list (no completed samples --
+    matches `compute_retention.py`'s handling of an undefined ratio for the
+    same reason: nothing to average).
+    """
+    flat = []
+    for value in values:
+        if isinstance(value, list):
+            flat.extend(value)
+        else:
+            flat.append(value)
+    if not flat:
+        return None
+    return sum(flat) / len(flat)
+
+
+def _load_tokenizer(model: str, model_args: str):
+    from transformers import AutoTokenizer
+
+    pretrained = dict(kv.split("=", 1) for kv in model_args.split(","))["pretrained"]
+    if model == "coreml":
+        # Tokenizer files sit alongside the .mlpackage, exported by
+        # export_llm_to_coreml.py -- same lookup lm_eval_coreml_adapter.py's
+        # own CoreMLLM.__init__ uses.
+        return AutoTokenizer.from_pretrained(str(Path(pretrained).parent))
+    return AutoTokenizer.from_pretrained(pretrained)
 
 
 def run_quality_eval(
@@ -77,31 +151,62 @@ def run_quality_eval(
         apply_chat_template=apply_chat_template,
         fewshot_as_multiturn=apply_chat_template,
         batch_size=1,
-        log_samples=False,
+        # Needed to recover each sample's raw response text below, for
+        # completed-only (DeviceMark's acc_completed) accounting -- see
+        # is_completed's docstring. Cheap: this is CPU tokenization of
+        # already-generated text, not another forward pass.
+        log_samples=True,
     )
     if results is None:
         raise RuntimeError("lm_eval.simple_evaluate() returned no results")
+
+    tokenizer = _load_tokenizer(model, model_args) if max_gen_toks is not None else None
+
+    tasks_out = {}
+    for task, metrics in results["results"].items():
+        samples = results["samples"].get(task, [])
+        scored_metrics = {
+            metric: value
+            for metric, value in metrics.items()
+            # lm_eval's own "metric_name,filter_name" convention for an actual
+            # scored metric -- distinguishes it from bookkeeping fields on the
+            # same dict ("alias", "sample_len", "name", none of which contain
+            # a comma) and from each metric's paired stderr entry
+            # ("metric_stderr,<filter_name>" -- the filter name varies per
+            # task, e.g. MMLU-Pro's "custom-extract", not always "none", and
+            # is itself sometimes the non-numeric string "N/A").
+            if "," in metric and "_stderr," not in metric
+        }
+
+        task_out = {}
+        for metric_full, agg_value in scored_metrics.items():
+            entry = {"acc": agg_value}
+            if tokenizer is not None:
+                metric_name = metric_full.split(",", 1)[0]
+                completed_values = []
+                completed_n = 0
+                for sample in samples:
+                    response = sample["resps"][0][0] if sample.get("resps") else ""
+                    n_toks = len(
+                        tokenizer(response, add_special_tokens=False)["input_ids"]
+                    )
+                    if is_completed(n_toks, max_gen_toks):
+                        completed_n += 1
+                        if metric_name in sample:
+                            completed_values.append(sample[metric_name])
+                entry["total_n"] = len(samples)
+                entry["completed_n"] = completed_n
+                entry["acc_completed"] = aggregate_completed_only(completed_values)
+            task_out[metric_full] = entry
+        tasks_out[task] = task_out
 
     return {
         "model": model,
         "model_args": model_args,
         "limit": limit,
         "num_fewshot": num_fewshot,
-        "tasks": {
-            task: {
-                metric: value
-                for metric, value in metrics.items()
-                # lm_eval's own "metric_name,filter_name" convention for an actual
-                # scored metric -- distinguishes it from bookkeeping fields on the
-                # same dict ("alias", "sample_len", "name", none of which contain
-                # a comma) and from each metric's paired stderr entry
-                # ("metric_stderr,<filter_name>" -- the filter name varies per
-                # task, e.g. MMLU-Pro's "custom-extract", not always "none", and
-                # is itself sometimes the non-numeric string "N/A").
-                if "," in metric and "_stderr," not in metric
-            }
-            for task, metrics in results["results"].items()
-        },
+        "max_gen_toks": max_gen_toks,
+        "tasks": tasks_out,
     }
 
 

--- a/tests/test_compute_retention.py
+++ b/tests/test_compute_retention.py
@@ -31,6 +31,8 @@ def test_full_retention_when_scores_match():
                 "float": 0.8,
                 "quantized": 0.8,
                 "retention": 1.0,
+                "float_basis": "acc",
+                "quantized_basis": "acc",
             }
         }
     }
@@ -100,8 +102,104 @@ def test_build_records_flattens_one_entry_per_task_metric():
         "float_acc": 0.8,
         "quantized_acc": 0.7,
         "retention": pytest.approx(0.875),
+        "float_basis": "acc",
+        "quantized_basis": "acc",
     }
 
 
 def test_build_records_on_empty_retention_returns_empty_list():
     assert build_records("model", 10, {}) == []
+
+
+def test_prefers_acc_completed_over_acc_when_both_present():
+    # run_quality_eval.py's --max-gen-toks-aware output shape: acc_completed is
+    # DeviceMark's own retention definition (see compute_retention.py's
+    # _resolve_score), so it should win over the plain no-answer-counts-as-wrong
+    # acc even though both are present.
+    result = compute_retention(
+        {
+            "ifeval": {
+                "acc": {
+                    "acc": 0.5,
+                    "completed_n": 4,
+                    "total_n": 10,
+                    "acc_completed": 0.8,
+                }
+            }
+        },
+        {
+            "ifeval": {
+                "acc": {
+                    "acc": 0.4,
+                    "completed_n": 6,
+                    "total_n": 10,
+                    "acc_completed": 0.6,
+                }
+            }
+        },
+    )
+    entry = result["ifeval"]["acc"]
+    assert entry["float"] == 0.8
+    assert entry["quantized"] == 0.6
+    assert entry["retention"] == pytest.approx(0.75)
+    assert entry["float_basis"] == "acc_completed"
+    assert entry["quantized_basis"] == "acc_completed"
+
+
+def test_falls_back_to_acc_when_acc_completed_is_none():
+    # Every sampled item hit the generation cap -- acc_completed has nothing
+    # to average, so it's None; falls back to plain acc rather than dropping
+    # the metric.
+    result = compute_retention(
+        {
+            "ifeval": {
+                "acc": {
+                    "acc": 0.5,
+                    "completed_n": 0,
+                    "total_n": 10,
+                    "acc_completed": None,
+                }
+            }
+        },
+        {
+            "ifeval": {
+                "acc": {
+                    "acc": 0.3,
+                    "completed_n": 0,
+                    "total_n": 10,
+                    "acc_completed": None,
+                }
+            }
+        },
+    )
+    entry = result["ifeval"]["acc"]
+    assert entry["float"] == 0.5
+    assert entry["quantized"] == 0.3
+    assert entry["float_basis"] == "acc"
+    assert entry["quantized_basis"] == "acc"
+
+
+def test_falls_back_to_acc_when_acc_completed_key_absent():
+    # No explicit --max-gen-toks was passed to run_quality_eval.py, so
+    # completed-only accounting was never attempted -- only "acc" is present.
+    result = compute_retention(
+        {"ifeval": {"acc": {"acc": 0.5}}},
+        {"ifeval": {"acc": {"acc": 0.4}}},
+    )
+    entry = result["ifeval"]["acc"]
+    assert entry["float"] == 0.5
+    assert entry["float_basis"] == "acc"
+
+
+def test_basis_tracked_independently_per_side():
+    # float side has a known --max-gen-toks (acc_completed available),
+    # quantized side doesn't -- each side should resolve independently.
+    result = compute_retention(
+        {"ifeval": {"acc": {"acc": 0.5, "acc_completed": 0.8}}},
+        {"ifeval": {"acc": {"acc": 0.4}}},
+    )
+    entry = result["ifeval"]["acc"]
+    assert entry["float"] == 0.8
+    assert entry["float_basis"] == "acc_completed"
+    assert entry["quantized"] == 0.4
+    assert entry["quantized_basis"] == "acc"

--- a/tests/test_run_quality_eval.py
+++ b/tests/test_run_quality_eval.py
@@ -1,0 +1,55 @@
+"""Unit tests for scripts/apple/run_quality_eval.py's pure completed-only
+accounting logic (`is_completed`, `aggregate_completed_only`) -- the
+lm_eval/transformers-dependent parts (tokenizer loading, `simple_evaluate`)
+aren't exercised here, see that module's docstring and
+bench/TODO_quality_retention_eval.md for how those are validated (an actual
+CI run, plus the manual token-count-vs-cap check that motivated this design).
+"""
+
+import os
+import sys
+
+import pytest
+
+_APPLE_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "apple"
+)
+if _APPLE_DIR not in sys.path:
+    sys.path.insert(0, _APPLE_DIR)
+
+from run_quality_eval import aggregate_completed_only, is_completed  # noqa: E402
+
+
+def test_is_completed_true_when_under_cap():
+    assert is_completed(50, 256) is True
+
+
+def test_is_completed_false_when_at_cap():
+    assert is_completed(256, 256) is False
+
+
+def test_is_completed_false_when_over_cap():
+    assert is_completed(300, 256) is False
+
+
+def test_is_completed_none_when_cap_unknown():
+    assert is_completed(50, None) is None
+
+
+def test_aggregate_completed_only_scalar_mean():
+    assert aggregate_completed_only([1, 0, 1, 1]) == 0.75
+
+
+def test_aggregate_completed_only_flattens_list_valued_metrics():
+    # ifeval's inst_level_*_acc is a list of per-instruction booleans per
+    # sample -- lm_eval pools every instruction across every sample before
+    # averaging, this should match that for the completed-only subset.
+    assert aggregate_completed_only([[True, False], [True]]) == pytest.approx(2 / 3)
+
+
+def test_aggregate_completed_only_mixed_scalar_and_list():
+    assert aggregate_completed_only([1, [1, 0]]) == pytest.approx(2 / 3)
+
+
+def test_aggregate_completed_only_empty_returns_none():
+    assert aggregate_completed_only([]) is None


### PR DESCRIPTION
## Summary
- `bench/TODO_quality_retention_eval.md`'s "What DeviceMark measures" section documented that DeviceMark computes retention on `acc_completed` (accuracy over only the samples that produced an answer before exhausting their generation budget), not the plain `acc` (no-answer-counts-as-wrong) this repo's `compute_retention.py` used -- flagged as a known gap, not implemented previously "since it touches `run_quality_eval.py`'s output schema, not just docs".
- `run_quality_eval.py` now reports `acc_completed` alongside plain `acc` for every scored metric, whenever `--max-gen-toks` is passed explicitly (already the case for both `quality-eval-macos` CI steps -- IFEval `128`, MATH-500 `256` -- so **no CI YAML changes are needed**, this activates on the next run). A sample counts as "completed" when its raw response's token count is strictly below the cap (`is_completed()`).
- That heuristic is empirically validated, not just plausible: re-ran `mmlu_pro_biology` locally with `log_samples=True` and tokenized each raw response -- every sample `lm_eval` extracted as `[invalid]` (no parseable answer) had a token count *exactly* equal to `--max-gen-toks`, and every sample with a real extracted answer had a strictly lower count. Clean separation, no ambiguous cases.
- `compute_retention.py`'s new `_resolve_score()` prefers each side's `acc_completed` when present and defined, falling back to plain `acc` when it isn't (no explicit `--max-gen-toks` was used, or every sampled item hit the cap -- nothing to average). The resolved basis (`acc_completed` vs `acc`) is tracked per side in the output and printed summary, and threaded through `build_records()`'s flat JSON records.
- IFEval's `inst_level_*_acc` metrics are a list of per-instruction booleans per sample (not a scalar) -- `aggregate_completed_only()` flattens these before averaging, matching how `lm_eval`'s own aggregation pools every instruction across every sample.
- Ran the full pipeline end-to-end locally (`run_quality_eval.py --model hf --tasks hendrycks_math500` -> `compute_retention.py`) to confirm the new JSON shape and printed summary work correctly, not just the unit tests.

## Test plan
- [x] `ruff format --check` / `ruff check` (pinned 0.14.0) on all touched Python files
- [x] `python3 -m mypy scripts/apple/run_quality_eval.py scripts/apple/compute_retention.py` -- no errors
- [x] `pytest tests/test_compute_retention.py tests/test_run_quality_eval.py` -- 21/21 pass (updated existing tests for the new per-metric shape, added new tests for the acc_completed preference/fallback logic and the new pure `is_completed`/`aggregate_completed_only` functions)
- [x] Ran `run_quality_eval.py --model hf --tasks hendrycks_math500 --limit 5 --max-gen-toks 128` locally, confirmed `total_n`/`completed_n`/`acc_completed` appear correctly in the output, then fed it through `compute_retention.py` and confirmed the printed summary and `--output` JSON (including the `[basis: ...]` note and `float_basis`/`quantized_basis` fields) are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3MD7VAmysceuqiBQYHvWQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3MD7VAmysceuqiBQYHvWQ)_