### PR TITLE
Add QuantizeLinear/DequantizeLinear/QLinearMatMul to the XNNPACK backend

### DIFF
--- a/docs/dlpack-executor.md
+++ b/docs/dlpack-executor.md
@@ -125,18 +125,44 @@ it the call's `inputs`, invokes it, and wraps the outputs as
 `DLManagedTensor`s.
 
 Unlike `CppModelExecutor`, which delegates to ORT and so handles essentially
-any ONNX op, this lowering supports only a small, explicit fp32 op set —
-`Add`/`Sub`/`Mul`/`Div`, `Relu`, `Sigmoid`, `Gemm`/`MatMul` (2D operands only),
-and `Reshape` (static target shape only) — see
+any ONNX op, this lowering supports only a small, explicit op set — see
 `onnx_to_xnnpack_subgraph.h`'s `kSupportedOps`. `Lower()` throws
 `std::runtime_error` naming the reason for anything outside that: an
-unsupported op, a non-fp32 tensor, `Gemm` with `alpha != 1` or `transA != 0`,
-a `Reshape` target shape that is itself produced by another node in the fold
-group rather than being a constant or a feed, and so on. Notably absent is
-`Conv`: XNNPACK's convolution Node is NHWC-native while ONNX's is NCHW, and
-getting that layout conversion (activations *and* the OIHW→OHWI weight
-transpose) right needs more verification than this first cut has had — left
-as follow-up work rather than shipped un-verified.
+unsupported op, an unsupported tensor dtype, `Gemm` with `alpha != 1` or
+`transA != 0`, a `Reshape` target shape that is itself produced by another
+node in the fold group rather than being a constant or a feed, and so on.
+Notably absent is `Conv`: XNNPACK's convolution Node is NHWC-native while
+ONNX's is NCHW, and getting that layout conversion (activations *and* the
+OIHW→OHWI weight transpose) right needs more verification than this first
+cut has had — left as follow-up work rather than shipped un-verified.
+
+Most of the op set is fp32 only: `Add`/`Sub`/`Mul`/`Div`, `Relu`, `Sigmoid`,
+`Gemm`/`MatMul` (2D operands only), `Reshape` (static target shape only).
+`QuantizeLinear`, `DequantizeLinear`, and `QLinearMatMul` additionally
+support standard ONNX int8/uint8 quantization, mapped onto XNNPACK's own
+quantized datatypes (`qint8`/`quint8`/`qcint8`) — `QuantizeLinear`/
+`DequantizeLinear` lower to an `xnn_unary_convert` Node bridging an fp32
+Value and a quantized one; `QLinearMatMul` (no float in between; a's/b's/
+y's own quantized Values feed `xnn_define_fully_connected` directly, the
+same Node Gemm/MatMul use) supports `b` quantized per-tensor or per-column.
+Scope is deliberately narrower here too: per-tensor only for
+`QuantizeLinear`/`DequantizeLinear` and `QLinearMatMul`'s output, symmetric
+(`zero_point == 0`) only for per-channel quantization (XNNPACK's per-channel
+datatypes don't have a per-channel zero-point parameter at the API surface
+this lowering uses), and no `com.microsoft` contrib ops (`QGemm`,
+`QLinearConv`, `QLinearAdd`, ...) — only standard ONNX.
+
+One correctness trap worth flagging for anyone extending this further:
+`xnn_define_channelwise_quantized_tensor_value` stores its `scale` array as
+a bare pointer (read again whenever a runtime is created from the
+subgraph), not a copy — unlike `dims`, which it does copy. A per-channel
+scale array therefore needs the same "outlive the subgraph and any runtime
+built from it" lifetime as tensor data does (see
+`LoweredSubgraph::owned_scale_arrays`, parallel to `owned_tensors`); get
+this wrong and the failure mode is not a crash, it's silent all-zero
+output, caught only by an actual numeric test
+(`xnnpack_executor_test.cpp`'s per-channel `QLinearMatMul` case), not a
+build or a null-pointer check.
 
 This makes `GetXnnpackModelExecutor()` an explicitly opt-in *alternative*
 executor (pass it to `Simplify` instead of `GetBuiltinModelExecutor()` when
@@ -145,8 +171,9 @@ way `tests/test_tinygrad_integration.py` / `test_nncase_integration.py` test
 those backends), not a general-purpose replacement: swapping it in for a
 model using an unsupported op fails constant folding outright rather than
 falling back. `onnxsim/xnnpack_executor_test.cpp` exercises it end to end
-(each supported op, a two-node chain, and the unsupported-op error path)
-against independently-computed expected values.
+(each supported op, a two-node chain, quantize/dequantize round trips,
+per-tensor and per-channel `QLinearMatMul`, and the unsupported-op error
+path) against independently-computed expected values.
 
 Build it with `-DONNXSIM_BUILTIN_XNNPACK=ON` (see `cmake/build_xnnpack.cmake`,
 which `FetchContent`s XNNPACK — pinned by commit, since XNNPACK has no tagged

--- a/onnxsim/onnx_to_xnnpack_subgraph.cpp
+++ b/onnxsim/onnx_to_xnnpack_subgraph.cpp
@@ -11,6 +11,7 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 #include "dlpack_bridge.h"
 #include "dlpack_dtype.h"
@@ -144,6 +145,24 @@ int64_t AttrInt(const onnx::NodeProto& node, const std::string& name,
   return attr != nullptr ? attr->i() : default_value;
 }
 
+// Maps an ONNX quantized element dtype to the matching XNNPACK datatype.
+// Only int8/uint8 -- the two ONNX quantization uses (QuantizeLinear/
+// DequantizeLinear/QLinearMatMul's int8 or uint8 tensors), never int32
+// (QLinearMatMul-style bias accumulation is not part of this lowering's
+// quantized op set) or the sub-8-bit/float8 types XNNPACK also has
+// datatypes for.
+xnn_datatype MapQuantDtype(int32_t onnx_dtype) {
+  switch (onnx_dtype) {
+    case onnx::TensorProto::INT8:
+      return xnn_datatype_qint8;
+    case onnx::TensorProto::UINT8:
+      return xnn_datatype_quint8;
+    default:
+      throw std::runtime_error(
+          "xnnpack backend: a quantized tensor must be int8 or uint8");
+  }
+}
+
 // Threaded through every per-node lowering function below. Owns nothing
 // itself -- `subgraph` and `owned_tensors` are borrowed from the
 // LoweredSubgraph the caller (Lower(), at the bottom of this file) is
@@ -162,6 +181,15 @@ struct LoweringContext {
   // means the graph declared an output no node in it actually produces.
   std::unordered_map<std::string, uint32_t> pending_outputs;
   std::vector<DLManagedTensorPtr>* owned_tensors = nullptr;
+  // See LoweredSubgraph::owned_scale_arrays -- backs a per-channel
+  // quantized Value's scale array, which XNNPACK stores as a bare pointer.
+  std::vector<std::vector<float>>* owned_scale_arrays = nullptr;
+  // Set once in Lower() before any node is lowered. Needed to turn an
+  // external output id back into an index into `*output_dtypes` (output ids
+  // are reserved as [num_inputs, num_inputs + num_outputs), one per
+  // model.graph().output() position -- see Lower()).
+  uint32_t num_inputs = 0;
+  std::vector<DLDataType>* output_dtypes = nullptr;
 
   const std::vector<int64_t>& ShapeOf(const std::string& name) const {
     auto it = shapes.find(name);
@@ -210,43 +238,200 @@ struct LoweringContext {
     return id;
   }
 
-  // Reads out the actual int64 values of `name`, which must be a graph input
-  // or an initializer (not the output of another node in this fold group --
-  // XNNPACK's Reshape/Transpose take their target shape/permutation as
-  // compile-time-static arguments, not a runtime tensor input).
-  std::vector<int64_t> ReadInt64Values(const std::string& name) {
+  // Like GetOrDefineValueId, but for a Value that is either already defined
+  // (in which case `scale_name`/`zero_point_name`/`axis` are ignored -- the
+  // Value keeps whatever quantization it was first defined with) or a
+  // constant int8/uint8 initializer, quantized either per-tensor
+  // (`scale_name` resolves to exactly one value) or per-channel
+  // (`scale_name` resolves to one value per channel along `axis`, and
+  // `zero_point_name` must then be all zero --
+  // xnn_define_channelwise_quantized_tensor_value has no per-channel
+  // zero-point parameter, i.e. only symmetric per-channel quantization is
+  // supported).
+  uint32_t GetOrDefineQuantizedValueId(const std::string& name,
+                                       const std::string& scale_name,
+                                       const std::string& zero_point_name,
+                                       int64_t axis) {
+    auto it = value_ids.find(name);
+    if (it != value_ids.end()) return it->second;
+
+    auto init_it = initializers.find(name);
+    if (init_it == initializers.end()) {
+      throw std::runtime_error(
+          "xnnpack backend: value '" + name +
+          "' is neither a graph input, an initializer, nor a prior node "
+          "output");
+    }
+    const onnx::TensorProto& tp = *init_it->second;
+    const xnn_datatype dtype = MapQuantDtype(tp.data_type());
+    DLManagedTensor* dlt = dlpack::FromTensorProtoBorrowing(tp);
+    owned_tensors->emplace_back(dlt);
+    std::vector<int64_t> shape(dlt->dl_tensor.shape,
+                               dlt->dl_tensor.shape + dlt->dl_tensor.ndim);
+    auto dims = ToSizeVec(shape);
+
+    auto scales = ReadFloatValues(scale_name);
+    uint32_t id;
+    if (scales.size() == 1) {
+      int32_t zp_dtype;
+      const auto zps = ReadZeroPointValues(zero_point_name, &zp_dtype);
+      if (zps.size() != 1) {
+        throw std::runtime_error("xnnpack backend: '" + zero_point_name +
+                                 "' must have exactly one element for "
+                                 "per-tensor quantization of '" +
+                                 name + "'");
+      }
+      if (zp_dtype != tp.data_type()) {
+        throw std::runtime_error("xnnpack backend: '" + name +
+                                 "' and its zero point '" + zero_point_name +
+                                 "' must have the same int8/uint8 dtype");
+      }
+      CheckStatus(
+          xnn_define_quantized_tensor_value(
+              subgraph, dtype, zps[0], scales[0], dims.size(), dims.data(),
+              dlt->dl_tensor.data, XNN_INVALID_VALUE_ID, 0, &id),
+          "define quantized initializer '" + name + "'");
+    } else {
+      if (axis < 0 || static_cast<size_t>(axis) >= shape.size() ||
+          shape[static_cast<size_t>(axis)] !=
+              static_cast<int64_t>(scales.size())) {
+        throw std::runtime_error("xnnpack backend: '" + scale_name +
+                                 "' does not match '" + name +
+                                 "'s shape at axis " + std::to_string(axis));
+      }
+      // XNNPACK's per-channel datatypes are a distinct enum from their
+      // per-tensor counterparts (xnn_datatype_qcint8, not
+      // xnn_datatype_qint8) and only exist for signed data -- there is no
+      // per-channel unsigned-int8 datatype.
+      if (tp.data_type() != onnx::TensorProto::INT8) {
+        throw std::runtime_error(
+            "xnnpack backend: per-channel quantization of '" + name +
+            "' is only supported for int8 (not uint8)");
+      }
+      int32_t zp_dtype;
+      const auto zps = ReadZeroPointValues(zero_point_name, &zp_dtype);
+      if (!std::all_of(zps.begin(), zps.end(),
+                       [](int32_t z) { return z == 0; })) {
+        throw std::runtime_error(
+            "xnnpack backend: per-channel zero point for '" + name +
+            "' must be all zero (only symmetric per-channel quantization "
+            "is supported)");
+      }
+      // xnn_define_channelwise_quantized_tensor_value stores `scale` as a
+      // bare pointer (xnn_value.quantization.channelwise_scale), read again
+      // whenever a runtime is later created from this subgraph -- so the
+      // array must outlive this function call. Move it into
+      // owned_scale_arrays (parallel to owned_tensors' handling of tensor
+      // data) rather than passing the local `scales`' pointer directly,
+      // which would dangle the moment this function returns.
+      owned_scale_arrays->push_back(std::move(scales));
+      const float* scale_ptr = owned_scale_arrays->back().data();
+      CheckStatus(xnn_define_channelwise_quantized_tensor_value(
+                      subgraph, xnn_datatype_qcint8, scale_ptr, dims.size(),
+                      static_cast<size_t>(axis), dims.data(),
+                      dlt->dl_tensor.data, XNN_INVALID_VALUE_ID, 0, &id),
+                  "define channelwise-quantized initializer '" + name + "'");
+    }
+    value_ids[name] = id;
+    shapes[name] = std::move(shape);
+    return id;
+  }
+
+  // Resolves `name` to its concrete DLTensor -- either a graph input's
+  // tensor directly, or (for an initializer) a freshly materialized
+  // DLManagedTensor owned via `owned_tensors`. `name` must be a graph input
+  // or an initializer, not the output of another node in this fold group:
+  // every Read*Values helper below reads a compile-time-static argument
+  // (a shape, a permutation, a quantization scale/zero-point), never a
+  // runtime tensor. Shared by every Read*Values helper; each does its own
+  // dtype check since the expected dtype differs per caller.
+  const DLTensor& ResolveStaticTensor(const std::string& name) {
     auto gi = graph_input_index.find(name);
     if (gi != graph_input_index.end()) {
-      const DLTensor& t = inputs[gi->second]->dl_tensor;
-      if (!(t.dtype.code == kDLInt && t.dtype.bits == 64)) {
-        throw std::runtime_error("xnnpack backend: '" + name +
-                                 "' must be int64 to be used as a static "
-                                 "shape");
-      }
-      const auto* data = reinterpret_cast<const int64_t*>(
-          static_cast<const uint8_t*>(t.data) + t.byte_offset);
-      return std::vector<int64_t>(data,
-                                  data + dlpack::NumElements(t.shape, t.ndim));
+      return inputs[gi->second]->dl_tensor;
     }
     auto init_it = initializers.find(name);
     if (init_it != initializers.end()) {
-      const onnx::TensorProto& tp = *init_it->second;
-      if (tp.data_type() != onnx::TensorProto::INT64) {
-        throw std::runtime_error("xnnpack backend: '" + name +
-                                 "' must be int64 to be used as a static "
-                                 "shape");
-      }
-      DLManagedTensor* dlt = dlpack::FromTensorProtoBorrowing(tp);
+      DLManagedTensor* dlt = dlpack::FromTensorProtoBorrowing(*init_it->second);
       owned_tensors->emplace_back(dlt);
-      const auto* data = static_cast<const int64_t*>(dlt->dl_tensor.data);
-      return std::vector<int64_t>(
-          data, data + dlpack::NumElements(dlt->dl_tensor.shape,
-                                           dlt->dl_tensor.ndim));
+      return owned_tensors->back()->dl_tensor;
     }
     throw std::runtime_error(
         "xnnpack backend: '" + name +
-        "' must be a constant or a graph input to be used as a static shape "
+        "' must be a constant or a graph input to be used as a static value "
         "(this lowering does not support one produced by another node)");
+  }
+
+  // Reads out the actual int64 values of `name` -- used for Reshape's target
+  // shape.
+  std::vector<int64_t> ReadInt64Values(const std::string& name) {
+    const DLTensor& t = ResolveStaticTensor(name);
+    if (!(t.dtype.code == kDLInt && t.dtype.bits == 64)) {
+      throw std::runtime_error("xnnpack backend: '" + name +
+                               "' must be int64 to be used as a static shape");
+    }
+    const auto* data = reinterpret_cast<const int64_t*>(
+        static_cast<const uint8_t*>(t.data) + t.byte_offset);
+    return std::vector<int64_t>(data,
+                                data + dlpack::NumElements(t.shape, t.ndim));
+  }
+
+  // Reads out the actual fp32 values of `name` -- used for QuantizeLinear /
+  // DequantizeLinear / QLinearMatMul's scale tensors (per-tensor: one
+  // element; per-channel: one per output channel).
+  std::vector<float> ReadFloatValues(const std::string& name) {
+    const DLTensor& t = ResolveStaticTensor(name);
+    if (!(t.dtype.code == kDLFloat && t.dtype.bits == 32)) {
+      throw std::runtime_error("xnnpack backend: '" + name +
+                               "' must be fp32 to be used as a static scale");
+    }
+    const auto* data = reinterpret_cast<const float*>(
+        static_cast<const uint8_t*>(t.data) + t.byte_offset);
+    return std::vector<float>(data,
+                              data + dlpack::NumElements(t.shape, t.ndim));
+  }
+
+  // Reads out the values of `name` (int8 or uint8) widened to int32 -- used
+  // for QuantizeLinear/DequantizeLinear/QLinearMatMul's zero-point tensors.
+  // `*onnx_dtype_out` is set to the tensor's own ONNX dtype (TensorProto::
+  // INT8 or ::UINT8), which callers use (via MapQuantDtype) to determine a
+  // quantized Value's own datatype.
+  std::vector<int32_t> ReadZeroPointValues(const std::string& name,
+                                           int32_t* onnx_dtype_out) {
+    const DLTensor& t = ResolveStaticTensor(name);
+    const int64_t n = dlpack::NumElements(t.shape, t.ndim);
+    const auto* data = static_cast<const uint8_t*>(t.data) + t.byte_offset;
+    std::vector<int32_t> out(n);
+    if (t.dtype.code == kDLInt && t.dtype.bits == 8) {
+      *onnx_dtype_out = onnx::TensorProto::INT8;
+      for (int64_t i = 0; i < n; ++i) {
+        out[i] = reinterpret_cast<const int8_t*>(data)[i];
+      }
+    } else if (t.dtype.code == kDLUInt && t.dtype.bits == 8) {
+      *onnx_dtype_out = onnx::TensorProto::UINT8;
+      for (int64_t i = 0; i < n; ++i) out[i] = data[i];
+    } else {
+      throw std::runtime_error("xnnpack backend: '" + name +
+                               "' must be int8 or uint8 to be used as a "
+                               "zero point");
+    }
+    return out;
+  }
+
+  // Resolves the external id (and its flag) `name` should use when it is
+  // first defined as an output Value: the reserved external-output id if
+  // `name` is one of the graph's declared outputs, or XNN_INVALID_VALUE_ID
+  // (auto-assigned internal id) otherwise. Shared by DefineOutputValue and
+  // DefineQuantizedOutputValue below.
+  std::pair<uint32_t, uint32_t> ResolveOutputExternalId(
+      const std::string& name) {
+    auto it = pending_outputs.find(name);
+    if (it == pending_outputs.end()) {
+      return {XNN_INVALID_VALUE_ID, 0u};
+    }
+    const uint32_t external_id = it->second;
+    pending_outputs.erase(it);
+    return {external_id, static_cast<uint32_t>(XNN_VALUE_FLAG_EXTERNAL_OUTPUT)};
   }
 
   // Defines the output Value for a just-lowered node: as the reserved
@@ -256,19 +441,48 @@ struct LoweringContext {
   uint32_t DefineOutputValue(const std::string& name,
                              const std::vector<int64_t>& shape) {
     auto dims = ToSizeVec(shape);
-    uint32_t external_id = XNN_INVALID_VALUE_ID;
-    uint32_t flags = 0;
-    auto it = pending_outputs.find(name);
-    if (it != pending_outputs.end()) {
-      external_id = it->second;
-      flags = XNN_VALUE_FLAG_EXTERNAL_OUTPUT;
-      pending_outputs.erase(it);
+    const auto [external_id, flags] = ResolveOutputExternalId(name);
+    if (flags != 0) {
+      (*output_dtypes)[external_id - num_inputs] = DLDataType{kDLFloat, 32, 1};
     }
     uint32_t id;
     CheckStatus(
         xnn_define_tensor_value(subgraph, xnn_datatype_fp32, dims.size(),
                                 dims.data(), nullptr, external_id, flags, &id),
         "define value '" + name + "'");
+    value_ids[name] = id;
+    shapes[name] = shape;
+    return id;
+  }
+
+  // Like DefineOutputValue, but for a per-tensor quantized (qint8/quint8)
+  // Value -- QuantizeLinear's output, or QLinearMatMul's (this lowering only
+  // supports a per-tensor y_scale/y_zero_point for both; per-axis output
+  // quantization is unusual in practice and unsupported here).
+  uint32_t DefineQuantizedOutputValue(const std::string& name,
+                                      const std::vector<int64_t>& shape,
+                                      xnn_datatype dtype, float scale,
+                                      int32_t zero_point) {
+    auto dims = ToSizeVec(shape);
+    const auto [external_id, flags] = ResolveOutputExternalId(name);
+    if (flags != 0) {
+      DLDataType dl_dtype;
+      if (dtype == xnn_datatype_qint8) {
+        dl_dtype = DLDataType{kDLInt, 8, 1};
+      } else if (dtype == xnn_datatype_quint8) {
+        dl_dtype = DLDataType{kDLUInt, 8, 1};
+      } else {
+        throw std::runtime_error(
+            "xnnpack backend: internal error, unexpected quantized output "
+            "dtype");
+      }
+      (*output_dtypes)[external_id - num_inputs] = dl_dtype;
+    }
+    uint32_t id;
+    CheckStatus(xnn_define_quantized_tensor_value(
+                    subgraph, dtype, zero_point, scale, dims.size(),
+                    dims.data(), nullptr, external_id, flags, &id),
+                "define value '" + name + "'");
     value_ids[name] = id;
     shapes[name] = shape;
     return id;
@@ -416,6 +630,140 @@ void LowerReshape(LoweringContext& ctx, const onnx::NodeProto& node) {
               "Reshape '" + node.name() + "'");
 }
 
+// QuantizeLinear(x, y_scale, y_zero_point) -> y (int8/uint8). Lowers to an
+// XNNPACK "convert" Node between an fp32 Value and a quantized Value --
+// XNNPACK's unified subgraph ops (unlike DLPack) determine int8-vs-fp32
+// behavior from each Value's own declared datatype, not a separate op
+// variant. Per-tensor only (y_scale/y_zero_point are always required here,
+// so the output dtype is unambiguous; per-axis activation quantization is
+// unusual in practice and unsupported).
+void LowerQuantizeLinear(LoweringContext& ctx, const onnx::NodeProto& node) {
+  if (node.input_size() != 3 || node.output_size() != 1) {
+    throw std::runtime_error(
+        "xnnpack backend: QuantizeLinear must have 3 inputs (x, y_scale, "
+        "y_zero_point) and 1 output -- y_zero_point is required here so "
+        "the output dtype (int8 vs uint8) is unambiguous");
+  }
+  const uint32_t in_id = ctx.GetOrDefineValueId(node.input(0));
+  const auto& in_shape = ctx.ShapeOf(node.input(0));
+  const auto scales = ctx.ReadFloatValues(node.input(1));
+  if (scales.size() != 1) {
+    throw std::runtime_error(
+        "xnnpack backend: QuantizeLinear: per-axis quantization is not "
+        "supported (y_scale must have exactly one element)");
+  }
+  int32_t onnx_dtype;
+  const auto zps = ctx.ReadZeroPointValues(node.input(2), &onnx_dtype);
+  if (zps.size() != 1) {
+    throw std::runtime_error(
+        "xnnpack backend: QuantizeLinear: y_zero_point must have exactly "
+        "one element");
+  }
+  const uint32_t out = ctx.DefineQuantizedOutputValue(
+      node.output(0), in_shape, MapQuantDtype(onnx_dtype), scales[0], zps[0]);
+  xnn_unary_params params{};
+  CheckStatus(
+      xnn_define_unary(ctx.subgraph, xnn_unary_convert, &params, in_id, out, 0),
+      "QuantizeLinear '" + node.name() + "'");
+}
+
+// DequantizeLinear(x, x_scale, x_zero_point) -> y (fp32). The inverse
+// convert Node of LowerQuantizeLinear above. `x` is usually the output of a
+// preceding QuantizeLinear in this fold group, but may also be a constant
+// int8/uint8 initializer dequantized directly (handled the same way
+// QLinearMatMul's operands are, via GetOrDefineQuantizedValueId) -- per-
+// tensor only, like QuantizeLinear.
+void LowerDequantizeLinear(LoweringContext& ctx, const onnx::NodeProto& node) {
+  if (node.input_size() != 3 || node.output_size() != 1) {
+    throw std::runtime_error(
+        "xnnpack backend: DequantizeLinear must have 3 inputs (x, x_scale, "
+        "x_zero_point) and 1 output");
+  }
+  const auto scales = ctx.ReadFloatValues(node.input(1));
+  if (scales.size() != 1) {
+    throw std::runtime_error(
+        "xnnpack backend: DequantizeLinear: per-axis quantization is not "
+        "supported (x_scale must have exactly one element)");
+  }
+  const uint32_t in_id = ctx.GetOrDefineQuantizedValueId(
+      node.input(0), node.input(1), node.input(2), /*axis=*/1);
+  const auto& in_shape = ctx.ShapeOf(node.input(0));
+  const uint32_t out = ctx.DefineOutputValue(node.output(0), in_shape);
+  xnn_unary_params params{};
+  CheckStatus(
+      xnn_define_unary(ctx.subgraph, xnn_unary_convert, &params, in_id, out, 0),
+      "DequantizeLinear '" + node.name() + "'");
+}
+
+// QLinearMatMul(a, a_scale, a_zero_point, b, b_scale, b_zero_point, y_scale,
+// y_zero_point) -> y. Unlike QuantizeLinear/DequantizeLinear (a bridging
+// convert Node), this is a genuine int8 compute op -- ONNX's fused
+// quantized-matmul, operating directly on already-quantized a/b/y with no
+// float in between. Maps to the same xnn_define_fully_connected used for
+// Gemm/MatMul above (XNNPACK dispatches on the Values' quantized datatype
+// internally); QLinearMatMul has no bias input.
+void LowerQLinearMatMul(LoweringContext& ctx, const onnx::NodeProto& node) {
+  if (node.input_size() != 8 || node.output_size() != 1) {
+    throw std::runtime_error(
+        "xnnpack backend: QLinearMatMul must have 8 inputs (a, a_scale, "
+        "a_zero_point, b, b_scale, b_zero_point, y_scale, y_zero_point) "
+        "and 1 output");
+  }
+  const std::string& a = node.input(0);
+  const std::string& a_scale = node.input(1);
+  const std::string& a_zp = node.input(2);
+  const std::string& b = node.input(3);
+  const std::string& b_scale = node.input(4);
+  const std::string& b_zp = node.input(5);
+  const std::string& y_scale = node.input(6);
+  const std::string& y_zp = node.input(7);
+
+  // a is always per-tensor quantized per the ONNX spec (a_scale is a single
+  // value). b may be per-tensor or per-column (b_scale one value per output
+  // channel). b's layout here is [K, N] -- QLinearMatMul has no transpose
+  // attribute, unlike Gemm -- so its output-channel axis is 1, matching the
+  // XNN_FLAG_TRANSPOSE_WEIGHTS passed to xnn_define_fully_connected below
+  // (the same flag/layout LowerMatMul above uses for plain fp32 MatMul).
+  const uint32_t a_id =
+      ctx.GetOrDefineQuantizedValueId(a, a_scale, a_zp, /*axis=*/1);
+  const uint32_t b_id =
+      ctx.GetOrDefineQuantizedValueId(b, b_scale, b_zp, /*axis=*/1);
+  const auto& a_shape = ctx.ShapeOf(a);
+  const auto& b_shape = ctx.ShapeOf(b);
+  if (a_shape.size() != 2 || b_shape.size() != 2) {
+    throw std::runtime_error(
+        "xnnpack backend: QLinearMatMul only supports 2D operands");
+  }
+  const int64_t m = a_shape[0], k = a_shape[1];
+  if (b_shape[0] != k) {
+    throw std::runtime_error(
+        "xnnpack backend: QLinearMatMul: incompatible operand shapes");
+  }
+  const int64_t n = b_shape[1];
+
+  const auto y_scales = ctx.ReadFloatValues(y_scale);
+  if (y_scales.size() != 1) {
+    throw std::runtime_error(
+        "xnnpack backend: QLinearMatMul: per-axis output quantization is "
+        "not supported (y_scale must have exactly one element)");
+  }
+  int32_t y_onnx_dtype;
+  const auto y_zps = ctx.ReadZeroPointValues(y_zp, &y_onnx_dtype);
+  if (y_zps.size() != 1) {
+    throw std::runtime_error(
+        "xnnpack backend: QLinearMatMul: y_zero_point must have exactly "
+        "one element");
+  }
+  const uint32_t out = ctx.DefineQuantizedOutputValue(
+      node.output(0), {m, n}, MapQuantDtype(y_onnx_dtype), y_scales[0],
+      y_zps[0]);
+  CheckStatus(xnn_define_fully_connected(
+                  ctx.subgraph, -std::numeric_limits<float>::infinity(),
+                  std::numeric_limits<float>::infinity(), a_id, b_id,
+                  XNN_INVALID_VALUE_ID, out, XNN_FLAG_TRANSPOSE_WEIGHTS),
+              "QLinearMatMul '" + node.name() + "'");
+}
+
 void LowerNode(LoweringContext& ctx, const onnx::NodeProto& node) {
   const std::string& op = node.op_type();
   if (op == "Add") return LowerBinary(ctx, node, xnn_binary_add);
@@ -435,6 +783,9 @@ void LowerNode(LoweringContext& ctx, const onnx::NodeProto& node) {
   if (op == "Gemm") return LowerGemm(ctx, node);
   if (op == "MatMul") return LowerMatMul(ctx, node);
   if (op == "Reshape") return LowerReshape(ctx, node);
+  if (op == "QuantizeLinear") return LowerQuantizeLinear(ctx, node);
+  if (op == "DequantizeLinear") return LowerDequantizeLinear(ctx, node);
+  if (op == "QLinearMatMul") return LowerQLinearMatMul(ctx, node);
   throw std::runtime_error("xnnpack backend: unsupported op '" + op +
                            "' (node '" + node.name() + "')");
 }
@@ -463,12 +814,16 @@ LoweredSubgraph Lower(const onnx::ModelProto& model,
   LoweredSubgraph result;
   LoweringContext ctx{model, inputs};
   ctx.owned_tensors = &result.owned_tensors;
+  ctx.owned_scale_arrays = &result.owned_scale_arrays;
   for (const auto& tp : graph.initializer()) {
     ctx.initializers[tp.name()] = &tp;
   }
 
   const uint32_t num_inputs = static_cast<uint32_t>(graph.input_size());
   const uint32_t num_outputs = static_cast<uint32_t>(graph.output_size());
+  ctx.num_inputs = num_inputs;
+  result.output_dtypes.assign(num_outputs, DLDataType{});
+  ctx.output_dtypes = &result.output_dtypes;
   CheckStatus(xnn_create_subgraph(num_inputs + num_outputs, 0, &ctx.subgraph),
               "create subgraph");
   // Own the subgraph from this point on, so a throw below still cleans it up

--- a/onnxsim/onnx_to_xnnpack_subgraph.h
+++ b/onnxsim/onnx_to_xnnpack_subgraph.h
@@ -6,12 +6,22 @@
  * `xnn_subgraph_t` -- the "ONNX to XNNPACK's Subgraph API" translation.
  *
  * This is deliberately NOT a general ONNX importer: it supports a small,
- * explicit set of fp32 ops (see kSupportedOps below) and throws
+ * explicit set of ops (see kSupportedOps below) and throws
  * std::runtime_error with a specific reason for anything else -- an
- * unsupported op, a non-fp32 tensor, a shape it cannot resolve statically, an
- * attribute combination it does not implement. onnxsim/xnnpack_executor.h is
- * the ModelExecutor adapter that calls this, creates a runtime from the
- * result, and is the piece that actually invokes XNNPACK.
+ * unsupported op, an unsupported tensor dtype, a shape it cannot resolve
+ * statically, an attribute combination it does not implement.
+ * onnxsim/xnnpack_executor.h is the ModelExecutor adapter that calls this,
+ * creates a runtime from the result, and is the piece that actually invokes
+ * XNNPACK.
+ *
+ * Dtypes: graph inputs/outputs and most ops are fp32 only. QuantizeLinear,
+ * DequantizeLinear, and QLinearMatMul additionally support standard ONNX
+ * int8/uint8 quantization (XNNPACK's qint8/quint8/qcint8 datatypes) --
+ * QuantizeLinear/DequantizeLinear per-tensor only, QLinearMatMul's "b"
+ * operand per-tensor or per-column (matching how int8 weights are commonly
+ * quantized). There is no support for ONNX Runtime's `com.microsoft`
+ * contrib quantized ops (QGemm, QLinearConv, QLinearAdd, ...) -- only
+ * standard ONNX ops, matching this lowering's fp32 op set.
  *
  * Shapes: unlike ONNX Runtime (which re-derives shapes from the model itself),
  * XNNPACK's `xnn_define_tensor_value` requires every Value's shape up front,
@@ -42,7 +52,18 @@ namespace xnnpack_backend {
 // Op types this lowering understands. Anything else in the fold-group graph
 // makes Lower() throw std::runtime_error naming the unsupported op.
 inline constexpr const char* kSupportedOps[] = {
-    "Add", "Sub", "Mul", "Div", "Relu", "Sigmoid", "Gemm", "MatMul", "Reshape",
+    "Add",
+    "Sub",
+    "Mul",
+    "Div",
+    "Relu",
+    "Sigmoid",
+    "Gemm",
+    "MatMul",
+    "Reshape",
+    "QuantizeLinear",
+    "DequantizeLinear",
+    "QLinearMatMul",
 };
 
 // Owns an xnn_subgraph_t plus everything it borrows: `subgraph` holds
@@ -60,12 +81,28 @@ struct LoweredSubgraph {
   // implementation.
   std::vector<uint32_t> input_value_ids;
   std::vector<uint32_t> output_value_ids;
+  // DLPack dtype of each output_value_ids[i] -- always fp32 before this
+  // lowering supported QuantizeLinear/QLinearMatMul, but a quantized op can
+  // now make a graph output int8/uint8, so the ModelExecutor adapter
+  // (xnnpack_executor.cpp) needs this to allocate the right kind of output
+  // buffer and set the right dtype on the DLManagedTensor it returns; it
+  // cannot recover this from xnn_get_external_value_shape (shape only).
+  std::vector<DLDataType> output_dtypes;
 
   // Backing storage for any tensor materialized during lowering (currently:
   // only a big-endian host's byte-swapped copy of an initializer -- see
   // dlpack_bridge.h's kRawDataIsHostOrder). Must outlive `subgraph` and any
   // xnn_runtime_t created from it.
   std::vector<DLManagedTensorPtr> owned_tensors;
+
+  // Backing storage for per-channel quantization scale arrays.
+  // xnn_define_channelwise_quantized_tensor_value stores the `scale`
+  // pointer it is given as-is (xnn_value.quantization.channelwise_scale) --
+  // it does not copy the array -- and that pointer is read again whenever a
+  // runtime is created from this subgraph, so it needs the same "outlive
+  // `subgraph` and any runtime built from it" lifetime `owned_tensors`
+  // above documents, just for float scale arrays instead of tensor data.
+  std::vector<std::vector<float>> owned_scale_arrays;
 
   LoweredSubgraph() = default;
   // Not = default: a defaulted move would shallow-copy `subgraph` without
@@ -75,7 +112,9 @@ struct LoweredSubgraph {
       : subgraph(other.subgraph),
         input_value_ids(std::move(other.input_value_ids)),
         output_value_ids(std::move(other.output_value_ids)),
-        owned_tensors(std::move(other.owned_tensors)) {
+        output_dtypes(std::move(other.output_dtypes)),
+        owned_tensors(std::move(other.owned_tensors)),
+        owned_scale_arrays(std::move(other.owned_scale_arrays)) {
     other.subgraph = nullptr;
   }
   LoweredSubgraph& operator=(LoweredSubgraph&& other) noexcept {
@@ -84,7 +123,9 @@ struct LoweredSubgraph {
       subgraph = other.subgraph;
       input_value_ids = std::move(other.input_value_ids);
       output_value_ids = std::move(other.output_value_ids);
+      output_dtypes = std::move(other.output_dtypes);
       owned_tensors = std::move(other.owned_tensors);
+      owned_scale_arrays = std::move(other.owned_scale_arrays);
       other.subgraph = nullptr;
     }
     return *this;

--- a/onnxsim/xnnpack_executor.cpp
+++ b/onnxsim/xnnpack_executor.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "dlpack/dlpack.h"
+#include "dlpack_dtype.h"
 #include "onnx_to_xnnpack_subgraph.h"
 #include "onnxsim.h"
 
@@ -48,9 +49,15 @@ void EnsureXnnpackInitialized() {
 // outputs into caller-supplied memory rather than handing back its own
 // buffer, so Run() below allocates `data` itself and this struct is what the
 // returned DLManagedTensor's deleter frees.
+//
+// `data` is raw bytes rather than a typed vector: most outputs are fp32, but
+// a quantized op (QuantizeLinear, QLinearMatMul) can make a graph output
+// int8/uint8 -- see LoweredSubgraph::output_dtypes, which is where `dtype`
+// below comes from.
 struct XnnpackOutputBuffer {
-  std::vector<float> data;
+  std::vector<uint8_t> data;
   std::vector<int64_t> shape;
+  DLDataType dtype;
 };
 
 DLManagedTensor* WrapOutputBuffer(std::unique_ptr<XnnpackOutputBuffer> ctx) {
@@ -58,7 +65,7 @@ DLManagedTensor* WrapOutputBuffer(std::unique_ptr<XnnpackOutputBuffer> ctx) {
   managed->dl_tensor.data = ctx->data.data();
   managed->dl_tensor.device = DLDevice{kDLCPU, 0};
   managed->dl_tensor.ndim = static_cast<int32_t>(ctx->shape.size());
-  managed->dl_tensor.dtype = DLDataType{kDLFloat, 32, 1};
+  managed->dl_tensor.dtype = ctx->dtype;
   managed->dl_tensor.shape = ctx->shape.data();
   managed->dl_tensor.strides = nullptr;
   managed->dl_tensor.byte_offset = 0;
@@ -117,7 +124,8 @@ struct XnnpackModelExecutor : public ModelExecutor {
     // shapes are returned by xnn_get_external_value_shape").
     std::vector<std::unique_ptr<XnnpackOutputBuffer>> out_bufs;
     out_bufs.reserve(lowered.output_value_ids.size());
-    for (uint32_t out_id : lowered.output_value_ids) {
+    for (size_t i = 0; i < lowered.output_value_ids.size(); ++i) {
+      const uint32_t out_id = lowered.output_value_ids[i];
       size_t ndim = 0;
       size_t dims[XNN_MAX_TENSOR_DIMS];
       CheckXnnStatus(
@@ -125,9 +133,10 @@ struct XnnpackModelExecutor : public ModelExecutor {
           "xnn_get_external_value_shape");
       auto buf = std::make_unique<XnnpackOutputBuffer>();
       buf->shape.assign(dims, dims + ndim);
+      buf->dtype = lowered.output_dtypes[i];
       size_t nelem = 1;
       for (size_t d : buf->shape) nelem *= d;
-      buf->data.assign(nelem, 0.0f);
+      buf->data.assign(nelem * onnxsim::dlpack::SizeOf(buf->dtype), 0);
       external_values.push_back(xnn_external_value{out_id, buf->data.data()});
       out_bufs.push_back(std::move(buf));
     }

--- a/onnxsim/xnnpack_executor_test.cpp
+++ b/onnxsim/xnnpack_executor_test.cpp
@@ -74,6 +74,23 @@ onnx::ValueInfoProto MakeValueInfo(const std::string& name,
   return vi;
 }
 
+// Int8/uint8 initializer, used for QuantizeLinear/QLinearMatMul's zero-point
+// tensors (0-d for per-tensor, 1-d for per-channel) and for an
+// already-quantized weight fed directly into QLinearMatMul.
+template <typename T>
+onnx::TensorProto MakeIntInitializer(const std::string& name,
+                                     const std::vector<int64_t>& dims,
+                                     const std::vector<T>& data,
+                                     onnx::TensorProto::DataType dtype) {
+  onnx::TensorProto t;
+  t.set_name(name);
+  t.set_data_type(dtype);
+  for (int64_t d : dims) t.add_dims(d);
+  t.set_raw_data(std::string(reinterpret_cast<const char*>(data.data()),
+                             data.size() * sizeof(T)));
+  return t;
+}
+
 onnx::NodeProto MakeNode(const std::string& op_type,
                          const std::vector<std::string>& inputs,
                          const std::vector<std::string>& outputs) {
@@ -141,6 +158,10 @@ DLManagedTensor MakeInputTensorI64(std::vector<int64_t>& shape,
 
 const float* OutData(const DLManagedTensorPtr& t) {
   return static_cast<const float*>(t->dl_tensor.data);
+}
+
+const uint8_t* OutDataU8(const DLManagedTensorPtr& t) {
+  return static_cast<const uint8_t*>(t->dl_tensor.data);
 }
 
 void TestAddThenReluBroadcast() {
@@ -292,6 +313,160 @@ void TestUnsupportedOpThrows() {
         "silently mis-executing");
 }
 
+void TestQuantizeDequantizeRoundTrip() {
+  // X --QuantizeLinear(scale=0.5, zero_point=10, uint8)--> Q
+  //   --DequantizeLinear(same scale/zero_point)-------> Y
+  // Values are exact multiples of the 0.5 scale, so quantization is
+  // lossless and Y must equal X exactly; Q is also a graph output so its
+  // actual uint8 bytes can be checked independently of the round trip
+  // (masking one op's bug with the other's inverse bug is otherwise
+  // possible).
+  auto scale = MakeFloatInitializer("scale", {}, {0.5f});
+  auto zero_point = MakeIntInitializer<uint8_t>("zero_point", {}, {10},
+                                                onnx::TensorProto::UINT8);
+  auto model = MakeModel(
+      {MakeNode("QuantizeLinear", {"X", "scale", "zero_point"}, {"Q"}),
+       MakeNode("DequantizeLinear", {"Q", "scale", "zero_point"}, {"Y"})},
+      {MakeValueInfo("X", {4})},
+      {MakeValueInfo("Q", {4}), MakeValueInfo("Y", {4})}, {scale, zero_point});
+
+  std::vector<int64_t> x_shape{4};
+  std::vector<float> x_data{0.0f, 1.0f, -1.0f, 2.5f};
+  DLManagedTensor x = MakeInputTensor(x_shape, x_data);
+
+  auto outputs = GetXnnpackModelExecutor()->Run(model, {&x});
+  Check(outputs.size() == 2, "Quantize/Dequantize: two outputs");
+  if (outputs.size() != 2) return;
+  Check(outputs[0]->dl_tensor.dtype.code == kDLUInt &&
+            outputs[0]->dl_tensor.dtype.bits == 8,
+        "Quantize/Dequantize: Q is uint8");
+  const uint8_t* q = OutDataU8(outputs[0]);
+  const uint8_t expected_q[4] = {10, 12, 8, 15};
+  for (int i = 0; i < 4; ++i) {
+    Check(q[i] == expected_q[i], "Quantize/Dequantize: Q element " +
+                                     std::to_string(i) + " (got " +
+                                     std::to_string(q[i]) + ", want " +
+                                     std::to_string(expected_q[i]) + ")");
+  }
+  Check(outputs[1]->dl_tensor.dtype.code == kDLFloat,
+        "Quantize/Dequantize: Y is fp32");
+  const float* y = OutData(outputs[1]);
+  for (int i = 0; i < 4; ++i) {
+    CheckClose(y[i], x_data[i],
+               "Quantize/Dequantize: Y element " + std::to_string(i));
+  }
+}
+
+void TestQLinearMatMulPerTensor() {
+  // A: [2,3] fp32 input --QuantizeLinear(scale=1,zp=0,int8)--> Aq
+  // B: [3,2] int8 constant, per-tensor (scale=1,zp=0)
+  // QLinearMatMul(Aq, B) --DequantizeLinear--> Y
+  // All scales are 1.0 and zero points 0, so quantization is lossless and Y
+  // must equal the plain matrix product of A and B exactly.
+  auto a_scale = MakeFloatInitializer("a_scale", {}, {1.0f});
+  auto a_zp =
+      MakeIntInitializer<int8_t>("a_zp", {}, {0}, onnx::TensorProto::INT8);
+  auto b = MakeIntInitializer<int8_t>("b", {3, 2}, {1, 4, 2, 5, 3, 6},
+                                      onnx::TensorProto::INT8);
+  auto b_scale = MakeFloatInitializer("b_scale", {}, {1.0f});
+  auto b_zp =
+      MakeIntInitializer<int8_t>("b_zp", {}, {0}, onnx::TensorProto::INT8);
+  auto y_scale = MakeFloatInitializer("y_scale", {}, {1.0f});
+  auto y_zp =
+      MakeIntInitializer<int8_t>("y_zp", {}, {0}, onnx::TensorProto::INT8);
+
+  auto model = MakeModel(
+      {MakeNode("QuantizeLinear", {"A", "a_scale", "a_zp"}, {"Aq"}),
+       MakeNode(
+           "QLinearMatMul",
+           {"Aq", "a_scale", "a_zp", "b", "b_scale", "b_zp", "y_scale", "y_zp"},
+           {"Yq"}),
+       MakeNode("DequantizeLinear", {"Yq", "y_scale", "y_zp"}, {"Y"})},
+      {MakeValueInfo("A", {2, 3})}, {MakeValueInfo("Y", {2, 2})},
+      {a_scale, a_zp, b, b_scale, b_zp, y_scale, y_zp});
+
+  std::vector<int64_t> a_shape{2, 3};
+  std::vector<float> a_data{1, 0, 0, 0, 1, 0};
+  DLManagedTensor a = MakeInputTensor(a_shape, a_data);
+
+  auto outputs = GetXnnpackModelExecutor()->Run(model, {&a});
+  Check(outputs.size() == 1, "QLinearMatMul (per-tensor): one output");
+  if (outputs.empty()) return;
+  const float* out = OutData(outputs[0]);
+  const float expected[4] = {1, 4, 2, 5};
+  for (int i = 0; i < 4; ++i) {
+    CheckClose(out[i], expected[i],
+               "QLinearMatMul (per-tensor): element " + std::to_string(i));
+  }
+}
+
+void TestQLinearMatMulPerChannel() {
+  // Same A/Aq as TestQLinearMatMulPerTensor, but B's quantization is
+  // per-column (b_scale has one value per output channel N=2: 2.0 and 0.5),
+  // exercising xnn_define_channelwise_quantized_tensor_value's channel_dim
+  // -- which must be 1 (B's own [K, N] layout, matching
+  // XNN_FLAG_TRANSPOSE_WEIGHTS), not 0, or the scales would apply along the
+  // wrong axis and this test's expected values would be wrong.
+  auto a_scale = MakeFloatInitializer("a_scale", {}, {1.0f});
+  auto a_zp =
+      MakeIntInitializer<int8_t>("a_zp", {}, {0}, onnx::TensorProto::INT8);
+  auto b = MakeIntInitializer<int8_t>("b", {3, 2}, {1, 4, 2, 5, 3, 6},
+                                      onnx::TensorProto::INT8);
+  auto b_scale = MakeFloatInitializer("b_scale", {2}, {2.0f, 0.5f});
+  auto b_zp =
+      MakeIntInitializer<int8_t>("b_zp", {2}, {0, 0}, onnx::TensorProto::INT8);
+  auto y_scale = MakeFloatInitializer("y_scale", {}, {0.5f});
+  auto y_zp =
+      MakeIntInitializer<int8_t>("y_zp", {}, {0}, onnx::TensorProto::INT8);
+
+  auto model = MakeModel(
+      {MakeNode("QuantizeLinear", {"A", "a_scale", "a_zp"}, {"Aq"}),
+       MakeNode(
+           "QLinearMatMul",
+           {"Aq", "a_scale", "a_zp", "b", "b_scale", "b_zp", "y_scale", "y_zp"},
+           {"Yq"}),
+       MakeNode("DequantizeLinear", {"Yq", "y_scale", "y_zp"}, {"Y"})},
+      {MakeValueInfo("A", {2, 3})}, {MakeValueInfo("Y", {2, 2})},
+      {a_scale, a_zp, b, b_scale, b_zp, y_scale, y_zp});
+
+  std::vector<int64_t> a_shape{2, 3};
+  std::vector<float> a_data{1, 0, 0, 0, 1, 0};
+  DLManagedTensor a = MakeInputTensor(a_shape, a_data);
+
+  auto outputs = GetXnnpackModelExecutor()->Run(model, {&a});
+  Check(outputs.size() == 1, "QLinearMatMul (per-channel): one output");
+  if (outputs.empty()) return;
+  const float* out = OutData(outputs[0]);
+  // Real B = [[1*2,4*0.5],[2*2,5*0.5],[3*2,6*0.5]] = [[2,2],[4,2.5],[6,3]].
+  // Row 0 of A selects B's row 0 -> [2,2]; row 1 selects B's row 1 ->
+  // [4,2.5].
+  const float expected[4] = {2, 2, 4, 2.5f};
+  for (int i = 0; i < 4; ++i) {
+    CheckClose(out[i], expected[i],
+               "QLinearMatMul (per-channel): element " + std::to_string(i));
+  }
+}
+
+void TestQuantizeLinearWithoutZeroPointThrows() {
+  auto scale = MakeFloatInitializer("scale", {}, {1.0f});
+  auto model =
+      MakeModel({MakeNode("QuantizeLinear", {"X", "scale"}, {"Q"})},
+                {MakeValueInfo("X", {2})}, {MakeValueInfo("Q", {2})}, {scale});
+  std::vector<int64_t> x_shape{2};
+  std::vector<float> x_data{1.0f, 2.0f};
+  DLManagedTensor x = MakeInputTensor(x_shape, x_data);
+
+  bool threw = false;
+  try {
+    GetXnnpackModelExecutor()->Run(model, {&x});
+  } catch (const std::exception&) {
+    threw = true;
+  }
+  Check(threw,
+        "QuantizeLinear without y_zero_point: Run() throws rather than "
+        "guessing the output dtype");
+}
+
 }  // namespace
 
 int main() {
@@ -301,6 +476,10 @@ int main() {
   TestMatMul2D();
   TestReshapeWithInferredDim();
   TestUnsupportedOpThrows();
+  TestQuantizeDequantizeRoundTrip();
+  TestQLinearMatMulPerTensor();
+  TestQLinearMatMulPerChannel();
+  TestQuantizeLinearWithoutZeroPointThrows();
 
   if (g_failures == 0) {
     std::printf("xnnpack_executor_test: all checks passed\n");


### PR DESCRIPTION
## Summary

Follow-up to #995 (merged): extends the XNNPACK `ModelExecutor`'s ONNX lowering (`onnxsim/onnx_to_xnnpack_subgraph.cpp`) with standard int8/uint8 quantization support. XNNPACK is best known for accelerating exactly this kind of quantized inference, so this fills in the most obviously-missing capability from the initial fp32-only cut.

- `QuantizeLinear`/`DequantizeLinear` lower to an `xnn_unary_convert` Node bridging an fp32 Value and a quantized one (`qint8`/`quint8`); per-tensor only.
- `QLinearMatMul` (2D operands, matching the existing `MatMul` restriction) maps to the same `xnn_define_fully_connected` Node `Gemm`/`MatMul` already use, with quantized `a`/`b`/`y` Values — no float in between. `b` may be quantized per-tensor or per-column (`xnn_datatype_qcint8`), matching how int8 weights are commonly quantized.
- `LoweredSubgraph` gains `output_dtypes` (a quantized op can now make a graph output int8/uint8, which `xnnpack_executor.cpp` previously assumed was always fp32) and `owned_scale_arrays`.
- `docs/dlpack-executor.md` documents the new scope, including a correctness note for anyone extending this further (see below).

## A real bug, caught by actually running the tests

`xnn_define_channelwise_quantized_tensor_value` stores its `scale` array as a bare pointer (read again whenever a runtime is created from the subgraph), not a copy — unlike `dims`, which it does copy. The per-channel `QLinearMatMul` test initially came back all zeros (a dangling-pointer read into freed memory, not a crash) until the scale array was moved into subgraph-lifetime storage (`owned_scale_arrays`) instead of a function-local `std::vector`. I confirmed this by reading XNNPACK's own source (`src/tensor.c`), not just guessing from the header.

Also caught only by running the tests: XNNPACK's fully-connected op requires matching int8-throughout or uint8-throughout quantization (a `qint8` input/filter paired with a `quint8` output is rejected with `xnn_status_invalid_parameter`) — the per-tensor/per-channel `QLinearMatMul` tests initially got this wrong.

## Test plan

- [x] `xnnpack_executor_test.cpp` adds: a quantize/dequantize round-trip test that checks the intermediate quantized bytes directly (not just the round trip, so one op's bug can't mask the other's), per-tensor and per-channel `QLinearMatMul` tests, and an unsupported-input error case — all against independently hand-computed expected values.
- [x] Built and ran locally against a real XNNPACK build (`-DONNXSIM_BUILTIN_XNNPACK=ON -DONNXSIM_TESTS=ON`) — all checks pass, including after the two fixes above.
- [x] `clang-format` (pinned 18.1.8) applied to all changed files.
- CI: the `XNNPACK ModelExecutor backend (native)` job in `backend-integration.yml` (added in #995) will build and run this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TgcTy2fige3usNq9iZoHE

---
_Generated by [Claude Code](https://claude.ai/code/session_014TgcTy2fige3usNq9iZoHE)_