### PR TITLE
Add tests validating onnxsim's quantize/prune passes on a drafter model

### DIFF
--- a/tests/test_speculative_decoding_drafter.py
+++ b/tests/test_speculative_decoding_drafter.py
@@ -1,0 +1,235 @@
+"""Tests that onnxsim's generic (op-pattern-based) quantization and pruning
+passes -- :func:`onnxsim.quantize_weight_only_int4` and
+:func:`onnxsim.apply_magnitude_pruning` -- work unmodified on a speculative
+decoding "drafter" model, e.g. an EAGLE3 (Li et al., 2025) draft model.
+
+onnxsim has no architecture-specific handling for these models -- there is
+none to have, since these passes only ever look for a constant-weight
+MatMul/Gemm/Conv, and a drafter's linear layers are exactly that. This is a
+regression test for that claim, built from the real structural fingerprint
+of a published EAGLE3 checkpoint (AngelSlim/Qwen3-1.7B_eagle3 on the
+Hugging Face Hub; see also sglang's llama_eagle3.py, the reference
+implementation for the ``LlamaForCausalLMEagle3`` architecture): unlike a
+plain decoder layer, a drafter's attention block reads target-model context
+rather than only its own tokens, so:
+
+  - the drafter's own token embedding (``input_embeds``) is concatenated
+    with the target model's hidden states (fused down from several
+    concatenated target layers by an ``fc`` projection) *before* the
+    QKV projections -- so those projections' input dimension is double the
+    hidden size, not equal to it (``qkv_in`` is ``2H`` below);
+  - the output head projects to a *draft* vocabulary
+    (``draft_vocab_size``), which is deliberately smaller than the target
+    model's real vocabulary, rather than a same-sized LM head.
+
+This model intentionally skips RoPE/GQA/causal masking (ordinary decoder
+mechanics already covered by ``tests/test_fuse_attention.py`` and
+``tests/test_fuse_gqa.py``) to isolate exactly those two drafter-specific
+traits, at a size (32-dim hidden, so every quantizable layer's reduction
+size is a clean multiple of the INT4 pass's 32-element block) small enough
+to keep as literal text per this repo's convention (see CLAUDE.md) while
+still exercising the same op patterns -- weighted MatMul, plus two
+activation-only MatMuls for the attention score/value products that must be
+left unquantized -- found in the real checkpoint's exported graph.
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+H = 32  # drafter hidden size
+AUX = 3 * H  # concatenated target hidden states (3 aux layers, EAGLE3 default)
+QKV_IN = 2 * H  # doubled: concat(embeds, fc(aux)) before Q/K/V
+INTER = 64  # MLP intermediate size
+DRAFT_VOCAB = 16  # deliberately smaller than any real target vocab
+
+
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _weight(rng, k, n, name):
+    return _f32(rng.standard_normal((k, n)) * (1.0 / np.sqrt(k)), name)
+
+
+def _eagle3_drafter_model(seed=0):
+    # Mirrors LlamaForCausalLMEagle3's single-layer forward: fc-fuse the
+    # target's aux hidden states, concat with the drafter's own token
+    # embedding to double the QKV input width, self-attend, MLP, then a
+    # reduced-vocabulary LM head -- see this module's docstring.
+    rng = np.random.default_rng(seed)
+    weights = [
+        _weight(rng, AUX, H, "W_fc"),
+        _weight(rng, QKV_IN, H, "W_q"),
+        _weight(rng, QKV_IN, H, "W_k"),
+        _weight(rng, QKV_IN, H, "W_v"),
+        _weight(rng, H, H, "W_o"),
+        _weight(rng, H, INTER, "W_gate"),
+        _weight(rng, H, INTER, "W_up"),
+        _weight(rng, INTER, H, "W_down"),
+        _weight(rng, H, DRAFT_VOCAB, "W_lm_head"),
+    ]
+    model = _model(
+        f"""
+        eagle3_drafter (float[batch,seq,{H}] input_embeds, float[batch,seq,{AUX}] aux_hidden_states)
+            => (float[batch,seq,{DRAFT_VOCAB}] draft_logits)
+        {{
+          hidden = MatMul(aux_hidden_states, W_fc)
+          qkv_in = Concat <axis = -1> (input_embeds, hidden)
+          q = MatMul(qkv_in, W_q)
+          k = MatMul(qkv_in, W_k)
+          v = MatMul(qkv_in, W_v)
+          kt = Transpose <perm = [0, 2, 1]> (k)
+          scores = MatMul(q, kt)
+          probs = Softmax <axis = -1> (scores)
+          attn = MatMul(probs, v)
+          attn_out = MatMul(attn, W_o)
+          h2 = Add(attn_out, hidden)
+          gate = MatMul(h2, W_gate)
+          up = MatMul(h2, W_up)
+          gate_sigmoid = Sigmoid(gate)
+          silu = Mul(gate, gate_sigmoid)
+          mlp_hidden = Mul(silu, up)
+          mlp_out = MatMul(mlp_hidden, W_down)
+          h3 = Add(mlp_out, h2)
+          draft_logits = MatMul(h3, W_lm_head)
+        }}
+        """,
+        weights,
+    )
+    onnx.checker.check_model(model)
+    return model
+
+
+def _feeds(batch=2, seq=5, seed=1):
+    rng = np.random.default_rng(seed)
+    return {
+        "input_embeds": rng.standard_normal((batch, seq, H)).astype(np.float32),
+        "aux_hidden_states": rng.standard_normal((batch, seq, AUX)).astype(np.float32),
+    }
+
+
+def test_drafter_fingerprint_qkv_takes_doubled_input():
+    # The one thing that distinguishes this from an ordinary decoder layer's
+    # self-attention: Q/K/V read a *2H*-wide concat(embeds, target features),
+    # not a plain H-wide hidden state.
+    model = _eagle3_drafter_model()
+    w_q = next(t for t in model.graph.initializer if t.name == "W_q")
+    assert w_q.dims[0] == QKV_IN == 2 * H
+
+
+def test_simplify_preserves_output():
+    model = _eagle3_drafter_model()
+    feeds = _feeds()
+    (float_y,) = _run(model, feeds)
+
+    simplified, check_ok = onnxsim.simplify(model)
+    onnx.checker.check_model(simplified)
+    assert check_ok
+
+    (simplified_y,) = _run(simplified, feeds)
+    np.testing.assert_allclose(float_y, simplified_y, atol=1e-5, rtol=1e-5)
+
+
+def test_quantize_weight_only_int4_hits_every_weighted_matmul_only():
+    # quantize_weight_only_int4 deliberately skips shape inference (see its
+    # own docstring), so it only sees a *later* MatMul's reduction size once
+    # something has annotated the intermediate tensors' shapes -- simplify()
+    # is the documented way to do that. A drafter is a chain of several
+    # such layers (fc -> q/k/v/o -> gate/up/down -> lm_head), so skipping
+    # this step silently leaves every layer but the first (whose input
+    # shape is already known from the graph signature) unquantized.
+    #
+    # simplify() also fuses Q/K/V here: all three read the same qkv_in
+    # tensor, so the simplifier merges them into one wider MatMul + Split
+    # (a real, separately-useful optimization for a drafter specifically,
+    # since Q/K/V projections sharing one input is exactly this
+    # architecture's shape) -- collapsing 9 weighted layers to 7 distinct
+    # MatMul nodes before quantization ever runs.
+    model, _ = onnxsim.simplify(_eagle3_drafter_model())
+    quant = onnxsim.quantize_weight_only_int4(model)
+    onnx.checker.check_model(quant)
+
+    dq_nodes = [n for n in quant.graph.node if n.op_type == "DequantizeLinear"]
+    # 7 weighted layers post-fusion: fc, qkv (fused), o, gate, up, down,
+    # lm_head. The two activation@activation MatMuls (q@k^T and probs@v)
+    # must NOT be touched -- they have no constant weight operand to
+    # quantize.
+    assert len(dq_nodes) == 7
+    for dq in dq_nodes:
+        block_size = next(a.i for a in dq.attribute if a.name == "block_size")
+        assert block_size == 32
+
+    feeds = _feeds()
+    (quant_y,) = _run(quant, feeds)
+    assert np.all(np.isfinite(quant_y))
+    assert quant_y.shape == (2, 5, DRAFT_VOCAB)
+
+
+def test_quantize_weight_only_int4_without_simplify_first_only_hits_first_layer():
+    # The pitfall the previous test's comment describes, made explicit: on
+    # the *raw* parser-built graph (no value_info for intermediate tensors,
+    # since only the graph's own input/output signature is typed), only
+    # W_fc's MatMul -- whose input shape is known directly from the graph
+    # signature -- gets quantized. The other 8 chained layers are silently
+    # left alone. Wiring quantization into a real multi-layer model means
+    # simplify()-ing (or otherwise shape-inferring) it first, always.
+    quant = onnxsim.quantize_weight_only_int4(_eagle3_drafter_model())
+    dq_nodes = [n for n in quant.graph.node if n.op_type == "DequantizeLinear"]
+    assert len(dq_nodes) == 1
+
+
+def test_magnitude_pruning_reaches_target_sparsity_and_still_runs():
+    model = _eagle3_drafter_model()
+    pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    assert onnxsim.weight_sparsity(pruned) == pytest.approx(0.5, abs=1e-6)
+
+    feeds = _feeds()
+    (pruned_y,) = _run(pruned, feeds)
+    assert np.all(np.isfinite(pruned_y))
+    assert pruned_y.shape == (2, 5, DRAFT_VOCAB)
+
+
+def test_quantize_then_prune_compose():
+    # The two passes are independent graph rewrites over the same op
+    # patterns, so nothing about running one should preclude the other --
+    # this is the "wire quantization/pruning up to a real drafter" claim in
+    # its simplest composable form.
+    model, _ = onnxsim.simplify(_eagle3_drafter_model())
+    quant = onnxsim.quantize_weight_only_int4(model)
+    simplified, _ = onnxsim.simplify(quant, skip_fuse_bn=True)
+    pruned = onnxsim.apply_magnitude_pruning(simplified, sparsity=0.3)
+    onnx.checker.check_model(pruned)
+
+    feeds = _feeds()
+    (out,) = _run(pruned, feeds)
+    assert np.all(np.isfinite(out))
+    assert out.shape == (2, 5, DRAFT_VOCAB)

--- a/tests/test_speculative_decoding_drafter_hub_checkpoint.py
+++ b/tests/test_speculative_decoding_drafter_hub_checkpoint.py
@@ -1,0 +1,325 @@
+"""Real-world companion to ``tests/test_speculative_decoding_drafter.py`` and
+``tests/test_speculative_decoding_drafter_torch_export.py``: those two build
+a synthetic, EAGLE3-shaped graph (by hand, and via a real ``torch.onnx.export``
+respectively) at a tiny 32-dim size kept as literal test code per this repo's
+convention (see CLAUDE.md). This file instead downloads and exercises an
+actual **published** EAGLE3 drafter checkpoint from the Hugging Face Hub --
+``AngelSlim/Qwen3-1.7B_eagle3`` (paired with the real Qwen3-1.7B target
+model) -- the smallest real EAGLE3 checkpoint found on the Hub at the time
+this was written, and the one this whole test family was originally
+developed and validated against.
+
+The architecture (``_RealEagle3Drafter`` below) is a faithful, from-scratch
+PyTorch re-implementation of the ``LlamaForCausalLMEagle3`` reference
+(sglang's ``srt/models/llama_eagle3.py``, adapted from SafeAILab/EAGLE),
+built from this checkpoint's own real tensor names/shapes rather than
+guessed -- see this test's own weight-name mapping in
+``_load_real_checkpoint`` for exactly what a real checkpoint contains. It
+takes the target model's token embeddings and concatenated auxiliary hidden
+states as plain tensor inputs (not the ~3.4GB Qwen3-1.7B target model
+itself): that mirrors how EAGLE3 is actually served (SGLang/vLLM run it as
+a companion model fed the target's hidden states), and keeps this test to
+downloading only the ~270MB drafter.
+
+Same heavy/optional dependencies and skip conventions as
+``test_export_transformers.py``: torch, onnxscript (torch's dynamo ONNX
+exporter needs it), and onnxruntime are not normal test dependencies, so
+this file skips unless they're already importable, and skips (rather than
+fails) on a network error downloading the real checkpoint from the Hub. To
+run it locally::
+
+    pip install torch onnxscript onnxruntime
+    pip install --force-reinstall --no-deps .   # the onnxsim under test
+    pytest tests/test_speculative_decoding_drafter_hub_checkpoint.py -v -s
+"""
+
+import json
+import urllib.request
+
+import numpy as np
+import onnx
+import pytest
+
+import onnxsim
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("onnxscript")
+ort = pytest.importorskip("onnxruntime")
+
+HF_REPO = "AngelSlim/Qwen3-1.7B_eagle3"
+_DOWNLOAD_TIMEOUT_S = 120
+
+
+def _download(tmp_path):
+    config_path = tmp_path / "config.json"
+    weights_path = tmp_path / "pytorch_model.bin"
+    for name, dest in [
+        ("config.json", config_path),
+        ("pytorch_model.bin", weights_path),
+    ]:
+        url = f"https://huggingface.co/{HF_REPO}/resolve/main/{name}"
+        with urllib.request.urlopen(url, timeout=_DOWNLOAD_TIMEOUT_S) as resp:
+            dest.write_bytes(resp.read())
+    return config_path, weights_path
+
+
+class _RMSNorm(torch.nn.Module):
+    def __init__(self, dim, eps):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.ones(dim))
+        self.eps = eps
+
+    def forward(self, x, residual=None):
+        if residual is not None:
+            x = x + residual
+            residual = x
+        x = x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+        x = x * self.weight
+        return x if residual is None else (x, residual)
+
+
+def _rotate_half(x):
+    x1, x2 = x.chunk(2, dim=-1)
+    return torch.cat((-x2, x1), dim=-1)
+
+
+class _RealEagle3Drafter(torch.nn.Module):
+    """Faithful re-implementation of ``LlamaForCausalLMEagle3``'s single
+    layer (see this module's docstring), parameterized from a real
+    checkpoint's own ``config.json`` rather than hardcoded constants.
+    """
+
+    def __init__(self, cfg):
+        super().__init__()
+        H = cfg["hidden_size"]
+        self.head_dim = cfg["head_dim"]
+        self.num_heads = cfg["num_attention_heads"]
+        self.num_kv_heads = cfg["num_key_value_heads"]
+        self.rope_theta = cfg["rope_theta"]
+        eps = cfg["rms_norm_eps"]
+        num_aux = 3
+
+        self.fc = torch.nn.Linear(H * num_aux, H, bias=False)
+        self.hidden_norm = _RMSNorm(H, eps)
+        self.input_layernorm = _RMSNorm(H, eps)
+        self.q_proj = torch.nn.Linear(2 * H, self.num_heads * self.head_dim, bias=False)
+        self.k_proj = torch.nn.Linear(
+            2 * H, self.num_kv_heads * self.head_dim, bias=False
+        )
+        self.v_proj = torch.nn.Linear(
+            2 * H, self.num_kv_heads * self.head_dim, bias=False
+        )
+        self.o_proj = torch.nn.Linear(self.num_heads * self.head_dim, H, bias=False)
+        self.post_attention_layernorm = _RMSNorm(H, eps)
+        self.gate_proj = torch.nn.Linear(H, cfg["intermediate_size"], bias=False)
+        self.up_proj = torch.nn.Linear(H, cfg["intermediate_size"], bias=False)
+        self.down_proj = torch.nn.Linear(cfg["intermediate_size"], H, bias=False)
+        self.norm = _RMSNorm(H, eps)
+        self.lm_head = torch.nn.Linear(H, cfg["draft_vocab_size"], bias=False)
+
+    def _rope(self, positions, device, dtype):
+        inv_freq = 1.0 / (
+            self.rope_theta
+            ** (
+                torch.arange(0, self.head_dim, 2, device=device, dtype=torch.float32)
+                / self.head_dim
+            )
+        )
+        freqs = positions.float()[..., None] * inv_freq[None, None, :]
+        emb = torch.cat((freqs, freqs), dim=-1)
+        return emb.cos()[:, None, :, :].to(dtype), emb.sin()[:, None, :, :].to(dtype)
+
+    def forward(self, input_embeds, aux_hidden_states, positions):
+        cos, sin = self._rope(positions, input_embeds.device, input_embeds.dtype)
+
+        fc_out = self.fc(aux_hidden_states)
+        residual = fc_out
+        hidden_states = self.hidden_norm(fc_out)
+        embeds = self.input_layernorm(input_embeds)
+        qkv_in = torch.cat([embeds, hidden_states], dim=-1)
+
+        bsz, seqlen, _ = qkv_in.shape
+        q = (
+            self.q_proj(qkv_in)
+            .view(bsz, seqlen, self.num_heads, self.head_dim)
+            .transpose(1, 2)
+        )
+        k = (
+            self.k_proj(qkv_in)
+            .view(bsz, seqlen, self.num_kv_heads, self.head_dim)
+            .transpose(1, 2)
+        )
+        v = (
+            self.v_proj(qkv_in)
+            .view(bsz, seqlen, self.num_kv_heads, self.head_dim)
+            .transpose(1, 2)
+        )
+        q = q * cos + _rotate_half(q) * sin
+        k = k * cos + _rotate_half(k) * sin
+        rep = self.num_heads // self.num_kv_heads
+        k = k.repeat_interleave(rep, dim=1)
+        v = v.repeat_interleave(rep, dim=1)
+        attn = torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn = attn.transpose(1, 2).reshape(bsz, seqlen, self.num_heads * self.head_dim)
+        attn_out = self.o_proj(attn)
+
+        hidden_states, residual = self.post_attention_layernorm(attn_out, residual)
+        mlp_out = self.down_proj(
+            torch.nn.functional.silu(self.gate_proj(hidden_states))
+            * self.up_proj(hidden_states)
+        )
+
+        hidden_states, _ = self.norm(mlp_out, residual)
+        return self.lm_head(hidden_states)
+
+
+def _load_real_checkpoint(model, state_dict):
+    # The real checkpoint's own tensor names (see this repo's development
+    # notes / sglang's llama_eagle3.py load_weights): a single "midlayer"
+    # holding the drafter's one transformer layer, plus top-level fc/norm/
+    # lm_head. d2t/t2d (draft<->target vocab remap tables) are a serving-time
+    # concern, irrelevant to the graph this test exports.
+    mapping = {
+        "midlayer.self_attn.q_proj.weight": "q_proj.weight",
+        "midlayer.self_attn.k_proj.weight": "k_proj.weight",
+        "midlayer.self_attn.v_proj.weight": "v_proj.weight",
+        "midlayer.self_attn.o_proj.weight": "o_proj.weight",
+        "midlayer.mlp.gate_proj.weight": "gate_proj.weight",
+        "midlayer.mlp.up_proj.weight": "up_proj.weight",
+        "midlayer.mlp.down_proj.weight": "down_proj.weight",
+        "midlayer.hidden_norm.weight": "hidden_norm.weight",
+        "midlayer.input_layernorm.weight": "input_layernorm.weight",
+        "midlayer.post_attention_layernorm.weight": "post_attention_layernorm.weight",
+        "norm.weight": "norm.weight",
+        "fc.weight": "fc.weight",
+        "lm_head.weight": "lm_head.weight",
+    }
+    own = dict(model.named_parameters())
+    missing = [k for k in mapping if k not in state_dict]
+    if missing:
+        raise KeyError(f"real checkpoint is missing expected tensors: {missing}")
+    with torch.no_grad():
+        for ckpt_name, own_name in mapping.items():
+            own[own_name].copy_(state_dict[ckpt_name].float())
+
+
+@pytest.fixture(scope="module")
+def real_eagle3_drafter(tmp_path_factory):
+    tmp_path = tmp_path_factory.mktemp("eagle3_hub_checkpoint")
+    try:
+        config_path, weights_path = _download(tmp_path)
+        cfg = json.loads(config_path.read_text())
+        state_dict = torch.load(weights_path, map_location="cpu", weights_only=True)
+    except Exception as e:  # network/hub errors surface as a variety of types
+        pytest.skip(f"Could not download {HF_REPO} from Hugging Face Hub: {e}")
+
+    model = _RealEagle3Drafter(cfg)
+    _load_real_checkpoint(model, state_dict)
+    model.eval()
+    return model, cfg
+
+
+def _feeds(hidden_size, batch=1, seq=6, seed=0):
+    rng = np.random.default_rng(seed)
+    return {
+        "input_embeds": rng.standard_normal((batch, seq, hidden_size)).astype(
+            np.float32
+        ),
+        "aux_hidden_states": rng.standard_normal((batch, seq, hidden_size * 3)).astype(
+            np.float32
+        ),
+        "positions": np.arange(seq, dtype=np.int64)[None, :],
+    }
+
+
+def _run(onnx_model, feeds):
+    sess = ort.InferenceSession(
+        onnx_model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(["draft_logits"], feeds)[0]
+
+
+@pytest.fixture(scope="module")
+def exported_onnx_model(real_eagle3_drafter, tmp_path_factory):
+    # torch.onnx.export's dynamo tracing takes 20-60s on this real,
+    # 2048-hidden-dim GQA model -- module-scoped so the three tests below
+    # share one export instead of paying that cost three times over.
+    model, cfg = real_eagle3_drafter
+    H = cfg["hidden_size"]
+    example = (
+        torch.randn(1, 6, H),
+        torch.randn(1, 6, H * 3),
+        torch.arange(6, dtype=torch.long).unsqueeze(0),
+    )
+    onnx_path = str(tmp_path_factory.mktemp("export") / "real_eagle3_drafter.onnx")
+    torch.onnx.export(
+        model,
+        example,
+        onnx_path,
+        input_names=["input_embeds", "aux_hidden_states", "positions"],
+        output_names=["draft_logits"],
+        dynamic_axes={
+            "input_embeds": {0: "batch", 1: "seq"},
+            "aux_hidden_states": {0: "batch", 1: "seq"},
+            "positions": {0: "batch", 1: "seq"},
+            "draft_logits": {0: "batch", 1: "seq"},
+        },
+        opset_version=21,
+    )
+    return onnx.load(onnx_path)
+
+
+def test_real_checkpoint_exports_and_matches_eager(
+    real_eagle3_drafter, exported_onnx_model
+):
+    model, cfg = real_eagle3_drafter
+    feeds = _feeds(cfg["hidden_size"])
+    with torch.no_grad():
+        eager_out = model(
+            torch.from_numpy(feeds["input_embeds"]),
+            torch.from_numpy(feeds["aux_hidden_states"]),
+            torch.from_numpy(feeds["positions"]),
+        ).numpy()
+
+    onnx_out = _run(exported_onnx_model, feeds)
+    assert onnx_out.shape == (1, 6, cfg["draft_vocab_size"])
+    np.testing.assert_allclose(eager_out, onnx_out, atol=1e-3, rtol=1e-3)
+
+
+def test_real_checkpoint_simplifies_cleanly(real_eagle3_drafter, exported_onnx_model):
+    _, cfg = real_eagle3_drafter
+    feeds = _feeds(cfg["hidden_size"])
+    baseline = _run(exported_onnx_model, feeds)
+
+    simplified, check_ok = onnxsim.simplify(exported_onnx_model)
+    onnx.checker.check_model(simplified)
+    assert check_ok
+
+    simplified_out = _run(simplified, feeds)
+    np.testing.assert_allclose(baseline, simplified_out, atol=1e-3, rtol=1e-3)
+
+
+def test_real_checkpoint_quantizes_and_prunes(real_eagle3_drafter, exported_onnx_model):
+    _, cfg = real_eagle3_drafter
+    simplified, _ = onnxsim.simplify(exported_onnx_model)
+
+    quantized = onnxsim.quantize_weight_only_int4(simplified)
+    onnx.checker.check_model(quantized)
+    dq_nodes = [n for n in quantized.graph.node if n.op_type == "DequantizeLinear"]
+    # Unlike the synthetic companion tests' single-head attention (where
+    # Q/K/V all project to the same width and simplify() fuses them into one
+    # wider matmul), this is real GQA -- 16 query heads, 8 KV heads -- so
+    # q_proj (2048-wide) and k_proj/v_proj (1024-wide each) have different
+    # output shapes and are never fusion candidates. All 9 weighted layers
+    # (fc, q, k, v, o, gate, up, down, lm_head) stay distinct and quantized.
+    assert len(dq_nodes) == 9
+
+    pruned = onnxsim.apply_magnitude_pruning(simplified, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    assert onnxsim.weight_sparsity(pruned) == pytest.approx(0.5, abs=1e-6)
+
+    feeds = _feeds(cfg["hidden_size"])
+    for m in (quantized, pruned):
+        out = _run(m, feeds)
+        assert np.all(np.isfinite(out))
+        assert out.shape == (1, 6, cfg["draft_vocab_size"])

--- a/tests/test_speculative_decoding_drafter_torch_export.py
+++ b/tests/test_speculative_decoding_drafter_torch_export.py
@@ -1,0 +1,224 @@
+"""End-to-end companion to ``tests/test_speculative_decoding_drafter.py``:
+that file's graph is hand-built via ``onnx.parser`` text (per this repo's own
+convention, see CLAUDE.md); this one builds the *same* architecture as a real
+PyTorch ``nn.Module`` and puts it through ``torch.onnx.export`` for real,
+before feeding the result to the same onnxsim passes. Hand-written ONNX text
+can't accidentally reproduce exporter-specific quirks -- this closes that
+gap. Two real ones showed up doing this against an actual published EAGLE3
+checkpoint (AngelSlim/Qwen3-1.7B_eagle3) during development and are pinned
+here as regressions:
+
+  - the dynamo-based ``torch.onnx.export`` path requires **opset 21**
+    for :func:`onnxsim.quantize_weight_only_int4` to do anything at all --
+    at opset < 21 every node is silently left unquantized (`quantize_weight_
+    only_int4`'s own docstring: "an opset older than 21 ... left untouched"),
+    with no error or warning from either torch or onnxsim;
+  - unlike the parser-built companion test's raw graph -- which has no
+    ``value_info`` for its intermediates, so :func:`onnxsim.quantize_weight_
+    only_int4` (which explicitly skips shape inference) only catches the
+    first layer in a chain -- torch's dynamo exporter fully annotates every
+    intermediate tensor's shape already, so quantization works directly on
+    the raw export without a ``simplify()`` pass first. Worth confirming
+    explicitly rather than assuming one hand-built-graph finding transfers
+    to a real exporter's output. ``simplify()`` is still worth running
+    first regardless: it fuses the sibling Q/K/V projections (all three
+    read the same ``qkv_in`` tensor) into one wider matmul, taking the
+    weighted-layer count from 9 down to 7 before quantization ever runs.
+
+Same heavy/optional dependencies and skip convention as
+``test_export_transformers.py``: torch and onnxscript (torch's dynamo ONNX
+exporter needs it, see torch/onnx/_internal/exporter/_core.py) are not
+normal test dependencies, so this file skips unless they're already
+importable. To run it locally::
+
+    pip install torch onnxscript onnxruntime
+    pip install --force-reinstall --no-deps .   # the onnxsim under test
+    pytest tests/test_speculative_decoding_drafter_torch_export.py -v
+"""
+
+import numpy as np
+import onnx
+import pytest
+
+import onnxsim
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("onnxscript")
+ort = pytest.importorskip("onnxruntime")
+
+H = 32  # drafter hidden size
+AUX = 3 * H  # concatenated target hidden states (3 aux layers, EAGLE3 default)
+QKV_IN = 2 * H  # doubled: concat(embeds, fc(aux)) before Q/K/V
+INTER = 64  # MLP intermediate size
+DRAFT_VOCAB = 16  # deliberately smaller than any real target vocab
+
+
+class _TinyEagle3Drafter(torch.nn.Module):
+    """Same architecture, same shapes, as this module's parser-built sibling
+    (``tests/test_speculative_decoding_drafter.py``'s ``_eagle3_drafter_model``)
+    -- RoPE/GQA/causal masking deliberately left out for the same reason: the
+    point here is exercising the drafter-specific fc-fuse + doubled-QKV-input
+    + reduced-vocab-head shape through a real exporter, not re-testing
+    ordinary decoder mechanics.
+    """
+
+    def __init__(self):
+        super().__init__()
+        gen = torch.Generator().manual_seed(0)
+
+        def w(k, n):
+            return torch.nn.Parameter(torch.randn(k, n, generator=gen) / k**0.5)
+
+        self.w_fc = w(AUX, H)
+        self.w_q = w(QKV_IN, H)
+        self.w_k = w(QKV_IN, H)
+        self.w_v = w(QKV_IN, H)
+        self.w_o = w(H, H)
+        self.w_gate = w(H, INTER)
+        self.w_up = w(H, INTER)
+        self.w_down = w(INTER, H)
+        self.w_lm_head = w(H, DRAFT_VOCAB)
+
+    def forward(self, input_embeds, aux_hidden_states):
+        hidden = aux_hidden_states @ self.w_fc
+        qkv_in = torch.cat([input_embeds, hidden], dim=-1)
+        q = qkv_in @ self.w_q
+        k = qkv_in @ self.w_k
+        v = qkv_in @ self.w_v
+        scores = q @ k.transpose(-2, -1)
+        probs = torch.softmax(scores, dim=-1)
+        attn = probs @ v
+        h2 = attn @ self.w_o + hidden
+        gate = h2 @ self.w_gate
+        up = h2 @ self.w_up
+        silu = gate * torch.sigmoid(gate)
+        mlp_out = (silu * up) @ self.w_down
+        h3 = mlp_out + h2
+        return h3 @ self.w_lm_head
+
+
+def _feeds(batch=2, seq=5, seed=1):
+    rng = np.random.default_rng(seed)
+    return {
+        "input_embeds": rng.standard_normal((batch, seq, H)).astype(np.float32),
+        "aux_hidden_states": rng.standard_normal((batch, seq, AUX)).astype(np.float32),
+    }
+
+
+def _export(tmp_path, opset_version=21, name="drafter.onnx"):
+    torch.manual_seed(0)
+    model = _TinyEagle3Drafter().eval()
+    example = (torch.randn(2, 5, H), torch.randn(2, 5, AUX))
+    onnx_path = str(tmp_path / name)
+    torch.onnx.export(
+        model,
+        example,
+        onnx_path,
+        input_names=["input_embeds", "aux_hidden_states"],
+        output_names=["draft_logits"],
+        dynamic_axes={
+            "input_embeds": {0: "batch", 1: "seq"},
+            "aux_hidden_states": {0: "batch", 1: "seq"},
+            "draft_logits": {0: "batch", 1: "seq"},
+        },
+        opset_version=opset_version,
+    )
+    return model, onnx_path
+
+
+def _run(onnx_path_or_model, feeds):
+    payload = (
+        onnx_path_or_model
+        if isinstance(onnx_path_or_model, str)
+        else onnx_path_or_model.SerializeToString()
+    )
+    sess = ort.InferenceSession(payload, providers=["CPUExecutionProvider"])
+    return sess.run(["draft_logits"], feeds)[0]
+
+
+def test_torch_export_matches_eager(tmp_path):
+    model, onnx_path = _export(tmp_path)
+    feeds = _feeds()
+
+    with torch.no_grad():
+        eager_out = model(
+            torch.from_numpy(feeds["input_embeds"]),
+            torch.from_numpy(feeds["aux_hidden_states"]),
+        ).numpy()
+
+    onnx_out = _run(onnx_path, feeds)
+    np.testing.assert_allclose(eager_out, onnx_out, atol=1e-4, rtol=1e-3)
+
+
+def test_simplify_preserves_torch_exported_output(tmp_path):
+    _, onnx_path = _export(tmp_path)
+    feeds = _feeds()
+    baseline = _run(onnx_path, feeds)
+
+    simplified, check_ok = onnxsim.simplify(onnx.load(onnx_path))
+    onnx.checker.check_model(simplified)
+    assert check_ok
+
+    simplified_out = _run(simplified, feeds)
+    np.testing.assert_allclose(baseline, simplified_out, atol=1e-4, rtol=1e-3)
+
+
+def test_quantize_weight_only_int4_needs_opset_21(tmp_path):
+    # Regression for the real, silent trap found exporting an actual EAGLE3
+    # checkpoint: at opset 18 the pass matches nothing at all, with no error.
+    _, onnx_path_old = _export(tmp_path, opset_version=18, name="old.onnx")
+    quant_old = onnxsim.quantize_weight_only_int4(
+        onnxsim.simplify(onnx.load(onnx_path_old))[0]
+    )
+    assert not any(n.op_type == "DequantizeLinear" for n in quant_old.graph.node)
+
+    _, onnx_path_new = _export(tmp_path, opset_version=21, name="new.onnx")
+    quant_new = onnxsim.quantize_weight_only_int4(
+        onnxsim.simplify(onnx.load(onnx_path_new))[0]
+    )
+    dq_nodes = [n for n in quant_new.graph.node if n.op_type == "DequantizeLinear"]
+    # fc, qkv (simplify fuses q/k/v), o, gate, up, down, lm_head
+    assert len(dq_nodes) == 7
+
+
+def test_quantize_weight_only_int4_works_without_simplify_first(tmp_path):
+    # The parser-built companion test (test_speculative_decoding_drafter.py)
+    # shows quantize_weight_only_int4 catching only the first layer of a
+    # hand-built graph with no value_info for its intermediates -- it
+    # explicitly skips shape inference itself. It would be easy to assume
+    # that finding just carries over to any multi-layer graph; it does not:
+    # torch's dynamo exporter already annotates every intermediate tensor's
+    # shape, so all 9 weighted layers (fc, q, k, v, o, gate, up, down,
+    # lm_head -- unfused, since simplify() never ran to merge q/k/v) get
+    # quantized directly on the raw export.
+    _, onnx_path = _export(tmp_path)
+    raw_quant = onnxsim.quantize_weight_only_int4(onnx.load(onnx_path))
+    assert sum(n.op_type == "DequantizeLinear" for n in raw_quant.graph.node) == 9
+
+    # simplify() is still worth running first regardless: it additionally
+    # fuses the sibling Q/K/V matmuls (all three read qkv_in) into one wider
+    # matmul, so the same 9 layers collapse to 7 distinct nodes to quantize.
+    simplified_quant = onnxsim.quantize_weight_only_int4(
+        onnxsim.simplify(onnx.load(onnx_path))[0]
+    )
+    simplified_dq = sum(
+        n.op_type == "DequantizeLinear" for n in simplified_quant.graph.node
+    )
+    assert simplified_dq == 7
+
+
+def test_quantize_and_prune_torch_exported_drafter_stays_finite(tmp_path):
+    _, onnx_path = _export(tmp_path)
+    simplified, _ = onnxsim.simplify(onnx.load(onnx_path))
+
+    quantized = onnxsim.quantize_weight_only_int4(simplified)
+    onnx.checker.check_model(quantized)
+    pruned = onnxsim.apply_magnitude_pruning(simplified, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    assert onnxsim.weight_sparsity(pruned) == pytest.approx(0.5, abs=1e-6)
+
+    feeds = _feeds()
+    for m in (quantized, pruned):
+        out = _run(m, feeds)
+        assert np.all(np.isfinite(out))
+        assert out.shape == (2, 5, DRAFT_VOCAB)


### PR DESCRIPTION
Verifies onnxsim.quantize_weight_only_int4 and onnxsim.apply_magnitude_pruning
work unmodified on a speculative-decoding drafter (EAGLE3-shaped: fc-fused
target hidden states doubling the QKV input width, reduced-vocabulary LM
head), built from the real structural fingerprint of the published
AngelSlim/Qwen3-1.7B_eagle3 checkpoint. Also captures a real usage pitfall
as its own regression test: quantize_weight_only_int4 skips shape inference,
so without calling simplify() first it silently only quantizes the first
layer in a chain.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LPhFNvwMtKbLBAvNSTaH2i