### PR TITLE
Add aggregate_quality_trend.py to trend quality/retention across runs

### DIFF
--- a/bench/TODO_quality_retention_eval.md
+++ b/bench/TODO_quality_retention_eval.md
@@ -10,7 +10,10 @@ unit-tested in `tests/test_compute_retention.py`) -- see
 `scripts/apple/README.md`'s "Quality and retention eval" section for usage.
 Retention is now computed on DeviceMark's own `acc_completed` definition
 (completed-only accuracy) when available, not plain `acc` -- see "What
-DeviceMark measures" -> "Retention" below. MMLU-Pro is validated as *working*
+DeviceMark measures" -> "Retention" below. `scripts/apple/aggregate_quality_trend.py`
+groups `compute_retention.py --output` files by `(model_id, benchmark, metric)`
+into a trend across runs -- not wired into CI itself, see "Reporting" below.
+MMLU-Pro is validated as *working*
 through the same scripts (see "What's been prototyped" below) but not yet in
 CI: the compute-cost problem is solved (`--max-gen-toks 256`), but the current
 CI model scores 0/10 on `mmlu_pro_biology` regardless, making retention always
@@ -265,11 +268,20 @@ print a human-readable summary and let the CI job `tee` it into
 quality + retention, all in one place per model). A machine-readable JSON artifact
 alongside it -- `compute_retention.py --output`'s `"records"` list, one object per
 (task, metric): `{model_id, benchmark, metric, subset_n, float_acc, quantized_acc,
-retention}` (`build_records()`, unit-tested in `test_compute_retention.py`) --
-now exists and is uploaded from `quality-eval-macos` as the `quality-retention-results`
-artifact, one JSON per benchmark (IFEval, MATH-500). Lets a later step turn a run
-history into a trend without re-parsing log text; nothing reads these back yet (no
-trend-plotting script exists) -- that's the next piece if this is picked up further.
+retention, float_basis, quantized_basis}` (`build_records()`, unit-tested in
+`test_compute_retention.py`) -- now exists and is uploaded from `quality-eval-macos`
+as the `quality-retention-results` artifact, one JSON per benchmark (IFEval,
+MATH-500). `scripts/apple/aggregate_quality_trend.py` (2026-09-03) is the "next
+piece" that used to be missing: it reads several of these files (grouped by
+`(model_id, benchmark, metric)`, preserving input order as the chronological axis
+since records carry no timestamp) and prints/writes a trend instead of one isolated
+data point per run -- see `scripts/apple/README.md`'s "Quality and retention eval"
+section for usage. It is **not** wired into CI itself: `quality-eval-macos` runs a
+single fixed model with no run-history persistence today (each run's artifact is
+independent, nothing accumulates them), so this script is meant to be run by hand
+against artifacts downloaded from a handful of past runs. Automatically fetching and
+persisting that history from inside the workflow is a separate, bigger decision, not
+attempted here.
 
 ## Next steps, if picking this up
 
@@ -344,6 +356,13 @@ trend-plotting script exists) -- that's the next piece if this is picked up furt
    IFEval (see item 4) gave a second data point, so `compute_retention.py --output`
    now writes a flat `"records"` list (`build_records()`) and `quality-eval-macos`
    uploads both benchmarks' JSON as the `quality-retention-results` artifact -- see
-   "Reporting" above. Nothing consumes these across runs yet (no trend-plotting
-   script) -- that would be the next piece once there's an actual run history worth
-   trending.
+   "Reporting" above. ~~Nothing consumes these across runs yet (no trend-plotting
+   script)~~ -- done (2026-09-03): `scripts/apple/aggregate_quality_trend.py` reads
+   several of these files and groups them into a trend -- see "Reporting" above.
+   Genuinely still open: nothing in CI *produces* a multi-run history to feed it yet
+   (`quality-eval-macos` has no run-history persistence -- each run's artifact is
+   independent), so today this only has value run by hand against manually-downloaded
+   past artifacts. Wiring automatic history collection into CI (persisting
+   `quality-retention-results` across runs, or fetching past runs' artifacts via the
+   Actions API from inside the workflow) is a separate, bigger decision, not attempted
+   here.

--- a/scripts/apple/README.md
+++ b/scripts/apple/README.md
@@ -512,6 +512,19 @@ definitions:
   alongside the nested summary -- `coreml-integration.yml` uploads these as
   the `quality-retention-results` CI artifact, so a run's numbers don't have
   to be re-parsed out of `$GITHUB_STEP_SUMMARY` text.
+- `aggregate_quality_trend.py` reads several `compute_retention.py --output`
+  files (e.g. downloaded from a handful of past `quality-eval-macos` runs)
+  and groups their `"records"` by `(model_id, benchmark, metric)`, so a
+  model's retention/accuracy can be read as a trend across runs instead of
+  one isolated data point per run:
+  ```bash
+  python aggregate_quality_trend.py retention_ifeval_run1.json \
+      retention_ifeval_run2.json --output trend.json
+  ```
+  Not wired into CI -- `quality-eval-macos` runs a single fixed model with no
+  run-history persistence today, so this is meant to be run by hand against
+  artifacts fetched from past runs (`gh run download` or the Actions UI), not
+  something the workflow calls itself yet.
 
 ```bash
 pip install "optimum-onnx" transformers coremltools onnxruntime "lm-eval[ifeval]"

--- a/scripts/apple/aggregate_quality_trend.py
+++ b/scripts/apple/aggregate_quality_trend.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Aggregate `compute_retention.py --output` files from multiple runs into a trend.
+
+`compute_retention.py --output` writes a flat `"records"` list (one object per
+(task, metric): `{model_id, benchmark, metric, subset_n, float_acc,
+quantized_acc, retention, float_basis, quantized_basis}`, see that module's
+`build_records()`) alongside its nested summary -- `quality-eval-macos`
+uploads these as the `quality-retention-results` CI artifact on every run,
+see `bench/TODO_quality_retention_eval.md`'s "Reporting" section. This script
+is the "next piece" that doc flagged: read several of those files (e.g.
+downloaded from a handful of past `quality-eval-macos` runs via `gh run
+download` or the Actions UI -- fetching that history automatically isn't
+wired into CI itself, see the module docstring's last paragraph) and group
+them by `(model_id, benchmark, metric)` so a run's retention/accuracy numbers
+can be read as a trend instead of one isolated data point per run.
+
+Not wired into CI: `quality-eval-macos` runs a single fixed model
+(`HuggingFaceTB/SmolLM2-135M-Instruct`) with no run-history persistence
+today, so there's nothing to aggregate automatically yet -- this script is
+meant to be run by hand (or from a separate follow-up job) against
+artifacts downloaded from several past runs. Records carry no timestamp;
+the order files are passed in on the command line is treated as
+chronological (oldest first) -- pass them in that order.
+
+Usage:
+    python aggregate_quality_trend.py retention_ifeval_run1.json \\
+        retention_ifeval_run2.json retention_math500_run1.json \\
+        retention_math500_run2.json --output trend.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def build_trend(records: list[dict]) -> dict[tuple, list[dict]]:
+    """Group flat records (`compute_retention.py`'s `build_records()` shape,
+    each expected to carry a `"source"` field identifying which run/file it
+    came from -- see `_load_records`) by `(model_id, benchmark, metric)`,
+    preserving input order. Callers are responsible for passing `records` in
+    chronological order (oldest first) across however many input files they
+    concatenate -- there's no timestamp field to sort by independently.
+    """
+    trend: dict[tuple, list[dict]] = {}
+    for record in records:
+        key = (record.get("model_id"), record["benchmark"], record["metric"])
+        trend.setdefault(key, []).append(record)
+    return trend
+
+
+def _load_records(path: str) -> list[dict]:
+    with open(path) as f:
+        data = json.load(f)
+    records = data.get("records")
+    if records is None:
+        raise ValueError(
+            f"{path}: no 'records' field -- pass a compute_retention.py --output "
+            "file (needs the flat 'records' list build_records() writes, not just "
+            "the nested 'retention' summary)"
+        )
+    source = Path(path).name
+    return [{**record, "source": source} for record in records]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument(
+        "files",
+        nargs="+",
+        help="compute_retention.py --output JSON files, oldest run first",
+    )
+    ap.add_argument(
+        "--output",
+        help="Write the grouped trend as JSON here (default: printed summary only)",
+    )
+    args = ap.parse_args()
+
+    all_records = []
+    for path in args.files:
+        all_records.extend(_load_records(path))
+
+    trend = build_trend(all_records)
+    if not trend:
+        print("No records found across the given files.", file=sys.stderr)
+        return 1
+
+    for (model_id, benchmark, metric), entries in trend.items():
+        print(f"\n{model_id or '?'} / {benchmark} / {metric}:")
+        for entry in entries:
+            ret = entry["retention"]
+            ret_str = f"{ret:.1%}" if ret is not None else "N/A"
+            print(
+                f"  {entry['source']}: retention={ret_str} "
+                f"(float={entry['float_acc']:.4f} [{entry['float_basis']}], "
+                f"quantized={entry['quantized_acc']:.4f} [{entry['quantized_basis']}], "
+                f"n={entry['subset_n']})"
+            )
+        defined = [e["retention"] for e in entries if e["retention"] is not None]
+        if len(defined) >= 2:
+            print(
+                f"  change ({entries[0]['source']} -> {entries[-1]['source']}, "
+                f"first/last defined retention): {defined[-1] - defined[0]:+.1%}"
+            )
+
+    if args.output:
+        json_trend = [
+            {
+                "model_id": model_id,
+                "benchmark": benchmark,
+                "metric": metric,
+                "runs": entries,
+            }
+            for (model_id, benchmark, metric), entries in trend.items()
+        ]
+        with open(args.output, "w") as f:
+            json.dump(json_trend, f, indent=2)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_aggregate_quality_trend.py
+++ b/tests/test_aggregate_quality_trend.py
@@ -1,0 +1,105 @@
+"""Unit tests for scripts/apple/aggregate_quality_trend.py's pure grouping
+logic (`build_trend`) -- file loading/CLI plumbing (`_load_records`, `main`)
+isn't exercised here, see that module's docstring for how it's meant to be
+run (against compute_retention.py --output files from several past
+quality-eval-macos runs).
+"""
+
+import os
+import sys
+
+_APPLE_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "apple"
+)
+if _APPLE_DIR not in sys.path:
+    sys.path.insert(0, _APPLE_DIR)
+
+from aggregate_quality_trend import build_trend  # noqa: E402
+
+
+def test_groups_by_model_benchmark_metric():
+    records = [
+        {
+            "model_id": "m1",
+            "benchmark": "ifeval",
+            "metric": "acc",
+            "retention": 0.8,
+            "source": "run1.json",
+        },
+        {
+            "model_id": "m1",
+            "benchmark": "ifeval",
+            "metric": "acc",
+            "retention": 0.9,
+            "source": "run2.json",
+        },
+        {
+            "model_id": "m1",
+            "benchmark": "hendrycks_math500",
+            "metric": "exact_match",
+            "retention": 0.5,
+            "source": "run1.json",
+        },
+    ]
+    trend = build_trend(records)
+    assert set(trend.keys()) == {
+        ("m1", "ifeval", "acc"),
+        ("m1", "hendrycks_math500", "exact_match"),
+    }
+    assert [r["source"] for r in trend[("m1", "ifeval", "acc")]] == [
+        "run1.json",
+        "run2.json",
+    ]
+
+
+def test_preserves_input_order_within_group():
+    records = [
+        {
+            "model_id": "m",
+            "benchmark": "b",
+            "metric": "x",
+            "retention": 0.1,
+            "source": "a",
+        },
+        {
+            "model_id": "m",
+            "benchmark": "b",
+            "metric": "x",
+            "retention": 0.2,
+            "source": "b",
+        },
+        {
+            "model_id": "m",
+            "benchmark": "b",
+            "metric": "x",
+            "retention": 0.3,
+            "source": "c",
+        },
+    ]
+    trend = build_trend(records)
+    assert [r["retention"] for r in trend[("m", "b", "x")]] == [0.1, 0.2, 0.3]
+
+
+def test_empty_records_returns_empty_dict():
+    assert build_trend([]) == {}
+
+
+def test_different_model_ids_kept_separate():
+    records = [
+        {
+            "model_id": "m1",
+            "benchmark": "ifeval",
+            "metric": "acc",
+            "retention": 0.8,
+            "source": "a",
+        },
+        {
+            "model_id": "m2",
+            "benchmark": "ifeval",
+            "metric": "acc",
+            "retention": 0.7,
+            "source": "b",
+        },
+    ]
+    trend = build_trend(records)
+    assert set(trend.keys()) == {("m1", "ifeval", "acc"), ("m2", "ifeval", "acc")}


### PR DESCRIPTION
## Summary
- `bench/TODO_quality_retention_eval.md`'s "Reporting" section flagged this as the last missing piece: `compute_retention.py --output`'s flat `"records"` list existed (and `quality-eval-macos` uploads it as the `quality-retention-results` CI artifact on every run), but nothing read multiple runs' worth of them back into a trend.
- `scripts/apple/aggregate_quality_trend.py` reads several `compute_retention.py --output` JSON files and groups their `"records"` by `(model_id, benchmark, metric)`, preserving input order (records carry no timestamp, so the order files are passed in is treated as chronological). Prints a per-group history (retention/float/quantized/basis/n per run, plus a first-vs-last-defined delta) and can optionally write the grouped result as JSON.
- Pure grouping logic (`build_trend()`) is unit-tested directly, same pattern as `compute_retention.py`'s own tests -- no `lm_eval`/`transformers` dependency needed to test it.
- Deliberately **not** wired into CI: `quality-eval-macos` runs a single fixed model with no run-history persistence today, so there's nothing to aggregate automatically yet. This script is meant to be run by hand against artifacts downloaded from a handful of past runs (`gh run download` or the Actions UI). Automating history collection from inside the workflow (persisting artifacts across runs, or fetching past runs' artifacts via the Actions API) is a separate, bigger decision, not attempted here -- flagged as such in the doc.
- Updates `bench/TODO_quality_retention_eval.md` and `scripts/apple/README.md` to describe the new script and its scope.

## Test plan
- [x] `ruff format --check` / `ruff check` (pinned 0.14.0) on all touched Python files
- [x] `python3 -m mypy scripts/apple/aggregate_quality_trend.py` -- no errors
- [x] `pytest tests/test_aggregate_quality_trend.py` -- 4/4 pass; full `scripts/apple`-related suite (`test_compute_retention.py`, `test_run_quality_eval.py`, `test_aggregate_quality_trend.py`) -- 25/25 pass
- [x] Ran the CLI end-to-end against two synthetic `compute_retention.py`-shaped JSON files (same benchmark, different retention values) and confirmed the printed trend, the `[+20.0%]`-style delta line, and the `--output` JSON grouping are all correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3MD7VAmysceuqiBQYHvWQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3MD7VAmysceuqiBQYHvWQ)_