### PR TITLE
Structured pruning: add Swish/HardSwish to the shared unary pass-through set

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -2662,6 +2662,20 @@ _UNARY_PASS_THROUGH = {
     # backward counterparts, *and* `_trace_gate_producer_backward`'s own
     # gated-pair gate-activation matcher -- for free.
     "QuickGelu",
+    # ai.onnx (domain "") Swish(X) = X * Sigmoid(alpha * X), opset 24+ --
+    # `alpha` is a float *attribute* (default 1.0), not a second input,
+    # confirmed live via `onnx.defs.get_schema("Swish")`: single required
+    # input `X`, single output `Y`. Same shape as `QuickGelu` above (its own
+    # com.microsoft counterpart) -- unary, elementwise, no operand to slice
+    # -- so it belongs here for the identical reason.
+    "Swish",
+    # ai.onnx (domain "") HardSwish(X) = X * HardSigmoid<alpha=1/6,
+    # beta=0.5>(X), opset 22+ (the canonical MobileNetV3/EfficientNet-Lite
+    # activation) -- confirmed live via `onnx.defs.get_schema("HardSwish")`:
+    # single input `X`, single output `Y`, *no* attributes at all. Unary and
+    # elementwise like `HardSigmoid` already above, so the same reasoning
+    # applies.
+    "HardSwish",
 }
 _BINARY_CHANNEL_OPS = {"Add", "Mul"}
 _MAX_CHAIN_HOPS = 8

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -3167,7 +3167,7 @@ def _combined_keep_indices(w_gate, w_up, keep_count):
     return np.sort(np.argsort(-importance)[:keep_count])
 
 
-def _swiglu_mlp_model(K=8, H=16, Out=4, gate_activation="Sigmoid", seed=0):
+def _swiglu_mlp_model(K=8, H=16, Out=4, gate_activation="Sigmoid", seed=0, opset=21):
     rng = np.random.default_rng(seed)
     wg = rng.standard_normal((K, H)).astype(np.float32)
     wu = rng.standard_normal((K, H)).astype(np.float32)
@@ -3184,6 +3184,7 @@ def _swiglu_mlp_model(K=8, H=16, Out=4, gate_activation="Sigmoid", seed=0):
         }}
         """,
         initializer=[_f32(wg, "Wg"), _f32(wu, "Wu"), _f32(wd, "Wd")],
+        opset=opset,
     )
     return model, wg, wu, wd
 
@@ -3306,6 +3307,69 @@ def test_structured_pruning_quick_gelu_gated_ffn_matches_oracle():
     up = x @ wu[:, keep]
     y_oracle = (gate * up) @ wd[keep, :]
     np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_structured_pruning_swish_gated_ffn_matches_oracle():
+    # The SwiGLU-shaped gated MatMul chain with ai.onnx (domain "") Swish
+    # (opset 24+) as the gate activation -- the pattern its name literally
+    # comes from (Swish-Gated Linear Unit). Swish is unary (alpha is a
+    # float attribute, not a second input), so -- exactly like the
+    # QuickGelu gated-FFN case above -- it needed no dedicated gated-chain
+    # machinery, only joining `_UNARY_PASS_THROUGH`.
+    K, H, Out = 8, 16, 4
+    model, wg, wu, wd = _swiglu_mlp_model(
+        K=K, H=H, Out=Out, gate_activation="Swish", seed=130, opset=24
+    )
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Wg"].dims) == [K, H // 2]
+    assert list(inits["Wu"].dims) == [K, H // 2]
+    assert list(inits["Wd"].dims) == [H // 2, Out]
+
+    keep = _combined_keep_indices(wg, wu, H // 2)
+    rng = np.random.default_rng(131)
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+
+    g = x @ wg[:, keep]
+    gate = g / (1.0 + np.exp(-g))  # Swish(x) = x * sigmoid(alpha * x), alpha=1.0
+    up = x @ wu[:, keep]
+    y_oracle = (gate * up) @ wd[keep, :]
+    assert np.isfinite(y).all()
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_structured_pruning_swish_gated_ffn_prunes_same_shape_as_sigmoid_gate():
+    # The only difference between a Swish-gated and Sigmoid-gated chain
+    # should be the missing-vs-present set membership fixed here -- not
+    # some broader gated-chain limitation. Same K/H/Out/seed/sparsity as
+    # the Sigmoid-gated `_swiglu_mlp_model` default, so any divergence in
+    # which/how many channels survive would show up directly.
+    K, H, Out, seed, sparsity = 8, 16, 4, 30, 0.5
+    sigmoid_model, wg, wu, wd = _swiglu_mlp_model(
+        K=K, H=H, Out=Out, gate_activation="Sigmoid", seed=seed
+    )
+    swish_model, wg2, wu2, wd2 = _swiglu_mlp_model(
+        K=K, H=H, Out=Out, gate_activation="Swish", seed=seed, opset=24
+    )
+    np.testing.assert_array_equal(wg, wg2)
+    np.testing.assert_array_equal(wu, wu2)
+    np.testing.assert_array_equal(wd, wd2)
+
+    sigmoid_pruned = onnxsim.apply_structured_pruning(sigmoid_model, sparsity=sparsity)
+    swish_pruned = onnxsim.apply_structured_pruning(swish_model, sparsity=sparsity)
+
+    sigmoid_inits = {
+        t.name: onnx.numpy_helper.to_array(t) for t in sigmoid_pruned.graph.initializer
+    }
+    swish_inits = {
+        t.name: onnx.numpy_helper.to_array(t) for t in swish_pruned.graph.initializer
+    }
+    for name in ("Wg", "Wu", "Wd"):
+        assert sigmoid_inits[name].shape == swish_inits[name].shape
+        np.testing.assert_array_equal(sigmoid_inits[name], swish_inits[name])
 
 
 def test_structured_pruning_ungated_mul_of_two_producers_still_matches_oracle():
@@ -3444,7 +3508,7 @@ def test_structured_pruning_native_swiglu_node_prunes_both_producers_together():
 # --- Conv2D structured pruning ------------------------------------------
 
 
-def _conv_pair_model(w1, w2, b1=None, spatial=10, activation="Relu"):
+def _conv_pair_model(w1, w2, b1=None, spatial=10, activation="Relu", opset=21):
     Cin, C2 = w1.shape[1], w2.shape[0]
     initializer = [_f32(w1, "W1"), _f32(w2, "W2")]
     if b1 is not None:
@@ -3463,6 +3527,7 @@ def _conv_pair_model(w1, w2, b1=None, spatial=10, activation="Relu"):
         }}
         """,
         initializer=initializer,
+        opset=opset,
     )
 
 
@@ -3810,6 +3875,71 @@ def test_structured_pruning_conv_chain_with_dilation_matches_oracle_exactly():
     x = rng_x.standard_normal((2, Cin, 19, 19)).astype(np.float32)
     (y,) = _run(pruned, {"X": x})
     (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_conv_chain_swish_matches_oracle_exactly():
+    # ai.onnx (domain "") Swish(X) = X * Sigmoid(alpha * X), opset 24+ --
+    # joined _UNARY_PASS_THROUGH alongside QuickGelu (see that set's own
+    # comment). Same oracle bar as
+    # test_structured_pruning_conv_chain_matches_manual_channel_deletion_exactly:
+    # exact equivalence, via a real onnxruntime InferenceSession, to
+    # deleting the same output filters by hand -- confirms both that the
+    # chain is matched *and* pruned (not just left untouched-but-passing).
+    Cin, C1, C2 = 3, 16, 8
+    rng = np.random.default_rng(234)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    b1 = rng.standard_normal((C1,)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    model = _conv_pair_model(w1, w2, b1=b1, activation="Swish", opset=24)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [C1 // 2, Cin, 3, 3]
+    assert list(inits["W2"].dims) == [C2, C1 // 2, 3, 3]
+
+    keep = _oracle_keep_indices_conv(w1, C1 // 2)
+    oracle = _conv_pair_model(
+        w1[keep], w2[:, keep], b1=b1[keep], activation="Swish", opset=24
+    )
+
+    rng_x = np.random.default_rng(235)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    assert np.isfinite(y).all()
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_conv_chain_hardswish_matches_oracle_exactly():
+    # ai.onnx (domain "") HardSwish(X) = X * HardSigmoid<alpha=1/6,
+    # beta=0.5>(X), opset 22+ -- the canonical MobileNetV3/EfficientNet-Lite
+    # activation, no attributes at all. Same oracle bar as the Swish test
+    # above.
+    Cin, C1, C2 = 3, 16, 8
+    rng = np.random.default_rng(236)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    b1 = rng.standard_normal((C1,)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    model = _conv_pair_model(w1, w2, b1=b1, activation="HardSwish", opset=22)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [C1 // 2, Cin, 3, 3]
+    assert list(inits["W2"].dims) == [C2, C1 // 2, 3, 3]
+
+    keep = _oracle_keep_indices_conv(w1, C1 // 2)
+    oracle = _conv_pair_model(
+        w1[keep], w2[:, keep], b1=b1[keep], activation="HardSwish", opset=22
+    )
+
+    rng_x = np.random.default_rng(237)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    assert np.isfinite(y).all()
     np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
 
 


### PR DESCRIPTION
## Summary

`_UNARY_PASS_THROUGH` (`onnxsim/pruning.py`) is the single shared set every structured-pruning chain walker in this module consults to decide whether an activation node sitting between two weight-bearing layers (Conv/MatMul/gated-MLP producers, QDQ, MatMulNBits, block-quantized FP4/FP8, QOperator — 12 call sites) blocks channel/head pruning from propagating through it. It listed `Relu, LeakyRelu, Elu, Selu, Sigmoid, Tanh, Softplus, Softsign, Gelu, HardSigmoid, Mish, Identity, Cast, QuickGelu` but was missing standard ONNX `Swish` (opset 24+) and `HardSwish` (opset 22+, the canonical MobileNetV3/EfficientNet-Lite activation) — both single-input/single-output elementwise ops with no per-channel tensor operand, exactly the membership criterion every existing entry satisfies.

## Empirically confirmed facts

- `onnx.defs.get_schema("Swish")`: domain `""`, opset 24+, single input `X`, single output `Y`, `alpha` is a **float attribute** (default 1.0), not a second input — `Y = X * Sigmoid(alpha * X)`.
- `onnx.defs.get_schema("HardSwish")`: domain `""`, opset 22+ (not 14, as an earlier survey guessed — corrected against the installed `onnx==1.22.0`), single input `X`, single output `Y`, **no attributes at all**.
- Reproduced the bug on unpatched master via `onnx.parser`-built models + `apply_structured_pruning(sparsity=0.5)`: `Conv→Relu→Conv` prunes 16→8 channels correctly, but `Conv→Swish→Conv` and `Conv→HardSwish→Conv` were left completely unpruned. A SwiGLU-shaped gated MatMul chain (`gate=MatMul; up=MatMul; act=Swish(gate); combined=Mul(act,up); y=MatMul(combined,w_down)`) confirmed the *only* difference vs. the identical topology with `Sigmoid` was the missing set entry — both now prune to the same shape.
- Audited all 12 call sites of `_UNARY_PASS_THROUGH` — every one uses the identical unconditional `op_type in _UNARY_PASS_THROUGH` check, so this single addition point has broad, uniform leverage with no special-cased exclusions to mirror.

## What's added

Two lines added to `_UNARY_PASS_THROUGH`, with comments matching the existing `QuickGelu` entry's style/citation pattern. No new machinery — this is exactly why the fix is a single shared-set addition rather than per-family code.

## Test plan

- [x] `pytest tests/test_pruning.py -q` — 664 → 668 passed, zero regressions
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — 0 errors, unchanged from master's baseline
- [x] `Conv→Swish→Conv` and `Conv→HardSwish→Conv`: exact equivalence (via real `onnxruntime.InferenceSession`) to manually deleting the same filters, at the correct opsets (24/22 respectively)
- [x] SwiGLU-shaped `Swish`-gated FFN: matches an independent numpy oracle, and produces byte-identical pruned weights to the equivalent `Sigmoid`-gated chain
- [x] Real `InferenceSession` execution on all pruned models (finite output, correct shapes) — not just a shape check

I independently re-verified both schemas live, reviewed the diff (minimal — a two-entry set addition plus tests), re-ran the full test/ruff/mypy suite myself in a clean environment, and read every new test to confirm they compare pruned-model output against an independently reconstructed "already pruned" reference model (this module's established correctness invariant), not against the full unpruned model's own output, before pushing.

---
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_