### PR TITLE
Attention-head pruning: support com.microsoft::SparseAttention

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -15606,6 +15606,159 @@ def _match_linear_attention_producer(
     return q_num_heads, kv_num_heads
 
 
+# ``com.microsoft::SparseAttention`` (block-sparse-KV attention used by
+# Phi-3-small-class long-context models exported via onnxruntime-genai --
+# schema confirmed live via
+# ``onnxruntime.capi.onnxruntime_pybind11_state.get_all_operator_schema()``
+# against this environment's installed onnxruntime 1.29.0, ``since_version``
+# 1): structurally the closest cousin of `GroupQueryAttention` itself, not
+# merely another entry in this "separate-Q/K/V" family -- `query`/`key`/
+# `value` (indices 0/1/2) are already-projected activation tensors (Q's/K's/
+# V's own separate MatMul/vanilla-Gemm producers are what gets pruned),
+# `num_heads`/`kv_num_heads` are both required attributes with `num_heads` a
+# positive multiple of `kv_num_heads` (same GQA/MQA taxonomy), and
+# `past_key`/`past_value` (indices 3/4 -- the *same* positions
+# `GroupQueryAttention`'s own occupy) are BNSH-format `(batch_size,
+# kv_num_heads, max_cache_sequence_length, head_size)` caches sliced along
+# the identical `kv_num_heads` axis by the same `keep_groups` index set --
+# so this whole op reuses :class:`_GQAChain`/:func:`_apply_one_gqa_chain`/
+# :func:`_gqa_group_importance` outright, via a seventh matcher,
+# :func:`_match_sparse_attention_producer`, exactly as `PagedAttention`/
+# `LinearAttention` already do. Genuinely different from `GroupQueryAttention`
+# in three ways:
+#
+# - `past_key`/`past_value` are **required** (`FormalParameterOption.Single`)
+#   here, not optional the way `GroupQueryAttention`'s own are -- this op has
+#   no "no cache at all" calling convention, per its own doc: "Only supports
+#   unidirectional attention with cache of past key and value in linear
+#   buffers." :func:`_past_kv_constants_are_sliceable` already handles a
+#   required-and-always-connected pair the identical way it handles
+#   GroupQueryAttention's optional one (its own per-index loop only ever
+#   *skips* an absent input; it never requires one) -- no dedicated branch
+#   needed there. This op's own `T` type constraint (confirmed via the live
+#   schema dump) is `{float, float16, bfloat16}` only -- no quantized
+#   `float8e4m3fn`/`uint8`/`int8` cache dtype at all, unlike
+#   `GroupQueryAttention`'s own `T_CACHE` -- so `scale_indices` is never
+#   passed here; a quantized-dtype cache is simply declined by
+#   :func:`_past_kv_constants_are_sliceable`'s own existing "no scale index
+#   to check against" branch, the correct outcome for a shape this op's
+#   schema doesn't even allow.
+# - `block_row_indices`/`block_col_indices` (indices 5/6, both required,
+#   `M`/int32) are the CSR representation of the block-sparse mask, shaped
+#   ``(num_layout, max_blocks + 1)``/``(num_layout, max_nnz_blocks)`` --
+#   *layout*-indexed, not head-indexed at all (per this op's own doc,
+#   `num_heads` cycles cyclically through `num_layout` layouts when
+#   `num_layout` doesn't equal `num_heads`), so neither tensor ever carries a
+#   `num_heads`-or-`kv_num_heads`-sized axis this pass could slice even if it
+#   wanted to -- both are always left completely untouched by
+#   :func:`_apply_one_gqa_chain`. What *does* need checking is the schema's
+#   own "`num_heads` is divisible by `num_layout`" invariant, which pruning
+#   `num_heads` down could silently break even though it held before pruning
+#   -- re-verified once the post-pruning head count is known (see
+#   :func:`_apply_one_gqa_chain`'s own `is_sparse_attention` branch), and the
+#   whole chain's pruning is declined (a no-op for that block, the same
+#   "sparsity rounds to no groups dropped" outcome) rather than emitting an
+#   invalid node. This requires knowing `num_layout` at all, which requires
+#   `block_row_indices` to be a *constant* -- a real block-sparse layout is a
+#   fixed structure baked at export time (unlike `GroupQueryAttention`'s own
+#   `past_key`/`past_value`, which can legitimately be genuine runtime data),
+#   so a *dynamic* `block_row_indices`/`block_col_indices` declines the whole
+#   match outright here, out of scope rather than guessed at.
+#   `total_sequence_length` (index 7, scalar)/`key_total_sequence_lengths`
+#   (index 8, `(batch_size,)`) are pure sequence-length bookkeeping, entirely
+#   head-count-independent, and `cos_cache`/`sin_cache` (indices 9/10,
+#   optional, `(max_rotary_sequence_length, head_size / 2)`) are the exact
+#   same broadcast-across-every-head shape `GroupQueryAttention`'s own
+#   `cos_cache`/`sin_cache` already are -- none of these four are ever
+#   inspected or touched here.
+# - This op has no `attention_bias`/`attn_mask`-equivalent input, and no
+#   `head_sink`, at all on its own schema (confirmed off the same live
+#   schema dump) -- so none of `GroupQueryAttention`'s own dynamic-bias
+#   safety-fix machinery (:func:`_head_bias_input_is_safe`/
+#   :func:`_slice_or_gather_head_bias`) applies here; `mask_idx` is simply
+#   `None` for this op in :func:`_apply_one_gqa_chain`, the same as
+#   `PagedAttention`/`LinearAttention`, both of which also have no such
+#   input.
+def _match_sparse_attention_producer(
+    node: onnx.NodeProto,
+    initializer_map: Dict[str, onnx.TensorProto],
+    value_info_by_name: Optional[Dict[str, onnx.ValueInfoProto]] = None,
+) -> Optional[Tuple[int, int]]:
+    """If `node` is a ``com.microsoft::SparseAttention`` node this module can
+    safely act on, returns ``(num_heads, kv_num_heads)`` -- the same shape
+    every other matcher in this family returns, reusing the identical
+    :class:`_GQAChain`/:func:`_apply_one_gqa_chain`/:func:`_gqa_group_importance`
+    whole-KV-group machinery. See this section's own comment above for the
+    full empirical schema findings this matcher was built from.
+    `value_info_by_name` is accepted, unused, purely for
+    :func:`_find_separate_qkv_chains`'s own uniform ``match_producer(node,
+    initializer_map, value_info_by_name)`` call convention (this op has no
+    per-head bias/mask input at all -- see :func:`_match_paged_attention_producer`'s
+    own docstring for the identical reasoning).
+    """
+    if node.domain != _ATTENTION_DOMAIN or node.op_type != "SparseAttention":
+        return None
+    if len(node.input) < 9:
+        return None
+    if not (node.input[0] and node.input[1] and node.input[2]):
+        return None  # excludes this op's own packed-QKV calling convention
+        # (`query` alone carrying `(num_heads + 2 * kv_num_heads) * head_size`
+        # columns, `key`/`value` left empty), the same reasoning
+        # :func:`_match_gqa_producer` already gives for its own analogous
+        # exclusion.
+    if not (node.input[3] and node.input[4]):
+        return None  # past_key/past_value -- required (Single) by this op's
+        # own schema, checked here for presence the same defensive way every
+        # other required input below is; a genuinely incomplete node
+        # otherwise, not a real export.
+    if not (node.input[5] and node.input[6] and node.input[7] and node.input[8]):
+        return None  # block_row_indices/block_col_indices/
+        # total_sequence_length/key_total_sequence_lengths -- all
+        # schema-required
+
+    num_heads = kv_num_heads = None
+    for attr in node.attribute:
+        if attr.name == "num_heads":
+            num_heads = attr.i
+        elif attr.name == "kv_num_heads":
+            kv_num_heads = attr.i
+    if not num_heads or not kv_num_heads or num_heads <= 0 or kv_num_heads <= 0:
+        return None
+    if num_heads % kv_num_heads != 0:
+        return None
+
+    if not _past_kv_constants_are_sliceable(
+        node, initializer_map, (3, 4), kv_num_heads
+    ):
+        return None  # no `scale_indices` -- this op's own `T` type
+        # constraint (`{float, float16, bfloat16}`) has no quantized cache
+        # dtype at all, unlike `GroupQueryAttention`'s own `T_CACHE`
+
+    # `block_row_indices`/`block_col_indices` must both be constant (see
+    # this section's own comment above for why a dynamic one is out of
+    # scope) and agree on their own shared `num_layout` leading dimension --
+    # needed to re-verify the schema's own "num_heads divisible by
+    # num_layout" invariant once pruning's post-pruning head count is known
+    # (:func:`_apply_one_gqa_chain`).
+    row_init = initializer_map.get(node.input[5])
+    col_init = initializer_map.get(node.input[6])
+    if row_init is None or col_init is None:
+        return None  # dynamic block mask -- not a real export, see docstring
+    if (
+        not row_init.dims
+        or not col_init.dims
+        or row_init.dims[0] != col_init.dims[0]
+        or row_init.dims[0] <= 0
+    ):
+        return None
+    num_layout = row_init.dims[0]
+    if num_heads % num_layout != 0:
+        return None  # violates this op's own documented invariant already,
+        # before this pass even touches anything -- not a real export
+
+    return num_heads, kv_num_heads
+
+
 def _match_packed_qkv_split(
     split_node: onnx.NodeProto,
     initializer_map: Dict[str, onnx.TensorProto],
@@ -17308,6 +17461,32 @@ def _find_linear_attention_chains(
     return out
 
 
+def _find_sparse_attention_chains(
+    graph: onnx.GraphProto,
+    value_info_by_name: Optional[Dict[str, onnx.ValueInfoProto]] = None,
+) -> List[_GQAChain]:
+    """The ``com.microsoft::SparseAttention`` analogue of
+    :func:`_find_gqa_chains`/:func:`_find_paged_attention_chains` -- see
+    :func:`_find_separate_qkv_chains` (the shared body) and
+    :func:`_match_sparse_attention_producer` (what's matched and why it's
+    declined otherwise, including the full empirical schema dump this whole
+    function was built from). Passes ``allow_differing_v_head_size=False``:
+    this op's own schema gives `past_key`/`present_key` and `past_value`/
+    `present_value` the identical `(batch_size, kv_num_heads,
+    max_cache_sequence_length, head_size)` shape -- one shared `head_size`
+    symbol for both K and V, exactly `GroupQueryAttention`'s own convention,
+    not the plain ai.onnx op's/`MultiHeadAttention`'s genuinely independent
+    `v_head_size`.
+    """
+    return _find_separate_qkv_chains(
+        graph,
+        _match_sparse_attention_producer,
+        "num_heads",
+        value_info_by_name,
+        allow_differing_v_head_size=False,
+    )
+
+
 def _plain_attention_head_importance(
     chain: _AttentionChain,
     wq: np.ndarray,
@@ -17624,6 +17803,30 @@ def _apply_one_gqa_chain(
     d = chain.head_size
     dv = chain.v_head_size
     group_size = chain.num_heads // chain.kv_num_heads
+
+    # `SparseAttention`-only (see this module's own "Attention-head pruning"
+    # section comment, the `SparseAttention` bullet, and
+    # :func:`_match_sparse_attention_producer`'s own docstring): its own
+    # `block_row_indices` (index 5), already confirmed at match time to be a
+    # constant whose leading dimension is `num_layout`, must still divide
+    # the *post*-pruning query head count -- pruning `num_heads` down can
+    # break this op's own "num_heads is divisible by num_layout" invariant
+    # even though it held before pruning. Checked here, before anything is
+    # mutated, so a violation declines this block's pruning outright (the
+    # same "sparsity rounds to no groups dropped" no-op outcome
+    # `keep_count >= h` above already gives the caller) rather than emitting
+    # an invalid node.
+    is_sparse_attention = (
+        chain.node.domain == _ATTENTION_DOMAIN
+        and chain.node.op_type == "SparseAttention"
+    )
+    if is_sparse_attention:
+        row_init = initializer_map.get(chain.node.input[5])
+        if row_init is not None and row_init.dims:
+            num_layout = row_init.dims[0]
+            if num_layout and (keep_count * group_size) % num_layout != 0:
+                return None
+
     # Pre-pruning flat widths of Q's/K's own producer weight -- needed both
     # by the packed-QKV branch below (a column-range view into one shared
     # tensor) and, independently, by `chain.mha_bias`'s own combined-bias
@@ -17739,14 +17942,17 @@ def _apply_one_gqa_chain(
 
     # `GroupQueryAttention`'s past_key/past_value live at input indices 3/4,
     # the plain ai.onnx op's own at 4/5, `MultiHeadAttention`'s own at 6/7,
-    # `DecoderMaskedMultiHeadAttention`'s own at 5/6 (see `_match_gqa_producer`'s,
+    # `DecoderMaskedMultiHeadAttention`'s own at 5/6, `SparseAttention`'s own
+    # at the *same* 3/4 `GroupQueryAttention` uses (see `_match_gqa_producer`'s,
     # `_match_onnx_attention_producer`'s, `_match_multi_head_attention_producer`'s,
-    # and :func:`_match_decoder_masked_multi_head_attention_producer`'s own
-    # docstrings) -- all four already confirmed, at match time, to be either
-    # absent/dynamic (nothing to do here) or a BNSH-format constant (plain
-    # FLOAT, or -- GQA only -- quantized with a schema-conforming scale)
-    # safe to slice along axis 1 by `keep_groups` (see
-    # :func:`_past_kv_constants_are_sliceable`).
+    # :func:`_match_decoder_masked_multi_head_attention_producer`'s, and
+    # :func:`_match_sparse_attention_producer`'s own docstrings) -- all five
+    # already confirmed, at match time, to be either absent/dynamic (nothing
+    # to do here) or a BNSH-format constant (plain FLOAT, or -- GQA only --
+    # quantized with a schema-conforming scale) safe to slice along axis 1
+    # by `keep_groups` (see :func:`_past_kv_constants_are_sliceable`).
+    # `is_sparse_attention` was already computed above (needed earlier, by
+    # this function's own `num_layout` divisibility check).
     is_gqa = (
         chain.node.domain == _ATTENTION_DOMAIN
         and chain.node.op_type == "GroupQueryAttention"
@@ -17783,7 +17989,7 @@ def _apply_one_gqa_chain(
     )
     past_kv_indices = (
         (3, 4)
-        if is_gqa
+        if is_gqa or is_sparse_attention
         else (6, 7)
         if is_mha
         else (5, 6)
@@ -17894,10 +18100,13 @@ def _apply_one_gqa_chain(
     # at all (confirmed off the same live schema dump this whole family was
     # built from), so this whole block is skipped for it outright --
     # `chain.node.input[3]` (`key_cache` for `PagedAttention`, `past_state`
-    # for `LinearAttention`) must never be mistaken for one. `LinearAttention`
-    # has no `attention_bias`/`attn_mask`-equivalent input on its own schema
-    # either (confirmed off the same live schema dump), so it is excluded
-    # here the same way `PagedAttention` is.
+    # for `LinearAttention`, `past_key` for `SparseAttention`) must never be
+    # mistaken for one. `LinearAttention` has no `attention_bias`/`attn_mask`-
+    # equivalent input on its own schema either (confirmed off the same live
+    # schema dump), so it is excluded here the same way `PagedAttention` is.
+    # Neither does `SparseAttention` (confirmed off the same live schema
+    # dump -- see :func:`_match_sparse_attention_producer`'s own docstring),
+    # excluded here the identical way.
     mask_idx = (
         10
         if is_gqa
@@ -17906,7 +18115,7 @@ def _apply_one_gqa_chain(
         else 4
         if is_dmmha
         else None
-        if is_paged or is_linear_attention
+        if is_paged or is_linear_attention or is_sparse_attention
         else 3
     )
     if mask_idx is not None:
@@ -18099,15 +18308,18 @@ def apply_attention_head_pruning(
     """Removes whole attention heads -- or, for grouped-query attention,
     whole KV groups -- from every matched ``com.microsoft::Attention``,
     ``com.microsoft::GroupQueryAttention``, ``com.microsoft::MultiHeadAttention``,
-    ``com.microsoft::PagedAttention``, or plain ``ai.onnx::Attention`` node
-    (the fused self-attention blocks onnxsim's own ``fuse_attention``/``fuse_gqa``
+    ``com.microsoft::PagedAttention``, ``com.microsoft::SparseAttention``, or
+    plain ``ai.onnx::Attention``/``LinearAttention`` node (the fused
+    self-attention blocks onnxsim's own ``fuse_attention``/``fuse_gqa``
     optimizer passes produce, `MultiHeadAttention`, which those passes
     deliberately never emit but ONNX Runtime's own transformer graph
     optimizer routinely does for BERT/ViT/CLIP/T5/Whisper-style exports,
     `PagedAttention`, a block-based-KV-cache continuous-batching op for LLM
-    serving, and the standard ONNX op the contrib ops are converging towards
-    -- see this module's own "Attention-head pruning" section comment for
-    the real schema each was confirmed against and how)
+    serving, `SparseAttention`, a block-sparse-KV attention op for
+    Phi-3-small-class long-context models, and the standard ONNX ops the
+    contrib ops are converging towards -- see this module's own
+    "Attention-head pruning" section comment for the real schema each was
+    confirmed against and how)
     whose output feeds, optionally through a single shape-preserving
     ``Reshape``, exactly one downstream MatMul/vanilla-Gemm's reduction
     dimension (the output projection) -- the attention analogue of
@@ -18217,6 +18429,7 @@ def apply_attention_head_pruning(
         *_find_decoder_masked_mha_chains(graph, value_info_by_name),
         *_find_paged_attention_chains(graph, value_info_by_name),
         *_find_linear_attention_chains(graph, value_info_by_name),
+        *_find_sparse_attention_chains(graph, value_info_by_name),
     ]
     if chains:
         _apply_attention_chains(
@@ -18372,6 +18585,7 @@ def apply_attention_head_wanda_pruning(
         *_find_decoder_masked_mha_chains(graph, value_info_by_name),
         *_find_paged_attention_chains(graph, value_info_by_name),
         *_find_linear_attention_chains(graph, value_info_by_name),
+        *_find_sparse_attention_chains(graph, value_info_by_name),
     ]
     if not chains:
         return out
@@ -28180,6 +28394,7 @@ def _attention_not_eligible(
                     "PagedAttention",
                     "DecoderMaskedSelfAttention",
                     "DecoderMaskedMultiHeadAttention",
+                    "SparseAttention",
                 )
                 and node.domain == _ATTENTION_DOMAIN
             )
@@ -28253,6 +28468,14 @@ def _analyze_attention_chains(
                 family = "attention_mha_head"
             elif chain.node.op_type == "PagedAttention":
                 family = "attention_paged_group"
+            elif chain.node.op_type == "SparseAttention":
+                # Its own dedicated family string, the same reasoning
+                # `attention_paged_group` gets for `PagedAttention` -- a
+                # genuine KV-group-granularity block-sparse op, distinguishable
+                # in a sensitivity report from plain `GroupQueryAttention`
+                # (see this module's own "Attention-head pruning" section
+                # comment, the `SparseAttention` bullet).
+                family = "attention_sparse_group"
             elif chain.node.op_type == "LinearAttention" and chain.node.domain == "":
                 # Plain ai.onnx domain, unlike every other op this shared
                 # machinery reports here -- its own dedicated family string
@@ -28388,6 +28611,7 @@ def _analyze_attention_head_pruning(
         *_find_decoder_masked_mha_chains(graph, value_info_by_name),
         *_find_paged_attention_chains(graph, value_info_by_name),
         *_find_linear_attention_chains(graph, value_info_by_name),
+        *_find_sparse_attention_chains(graph, value_info_by_name),
     ]
     layers = _analyze_attention_chains(
         graph,
@@ -28448,6 +28672,7 @@ def _analyze_attention_head_wanda_pruning(
         *_find_decoder_masked_mha_chains(graph, value_info_by_name),
         *_find_paged_attention_chains(graph, value_info_by_name),
         *_find_linear_attention_chains(graph, value_info_by_name),
+        *_find_sparse_attention_chains(graph, value_info_by_name),
     ]
     if not chains:
         return PruningSensitivityReport(

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -31754,6 +31754,385 @@ def test_analyze_attention_head_pruning_linear_attention_matches_real_call():
     assert dims_after["Wv"][1] == kept_groups * cfg["Dv"]
 
 
+# --- SparseAttention head pruning (com.microsoft, block-sparse-KV attention) ---
+#
+# Reuses the `GroupQueryAttention`-family's own whole-KV-group machinery
+# (`_GQAChain`/`_apply_one_gqa_chain`/`_gqa_group_importance`) -- see
+# onnxsim/pruning.py's own "Attention-head pruning" section comment, the
+# `SparseAttention` bullet (right above `_match_sparse_attention_producer`),
+# for the full empirical schema findings and scope boundary (a *dynamic*
+# `block_row_indices`/`block_col_indices` declines the whole match outright,
+# and a post-pruning head count that would violate this op's own "num_heads
+# divisible by num_layout" invariant declines that block's pruning as a
+# no-op). This op has a real CPU kernel in this environment's onnxruntime
+# (confirmed live), but its own schema requires `past_key`/`present_key`
+# (and `past_value`/`present_value`) to literally share the same memory
+# buffer at execution time ("For performance, past_key and present_key
+# share same memory buffer") -- verified empirically: an ordinary
+# `session.run()` call (which always allocates independent output buffers)
+# fails outright ("past_key->DataRaw() == present_key->DataRaw() ... was
+# false"). Every execution test here therefore uses onnxruntime's own
+# IOBinding API (`_run_sparse_attention`), binding the identical `OrtValue`
+# to both the past-cache input and the present-cache output, the same
+# buffer-reuse pattern a real onnxruntime-genai-style autoregressive decode
+# loop uses.
+
+
+def _sparse_attention_model(
+    K=8,
+    H=4,
+    KVH=2,
+    D=8,
+    Out=6,
+    seed=0,
+    batch=1,
+    seq=16,
+    sparse_block_size=16,
+    num_layout=1,
+    wq=None,
+    wk=None,
+    wv=None,
+    wout=None,
+    past_key=None,
+    past_value=None,
+    row_indices=None,
+    col_indices=None,
+    row_indices_dynamic=False,
+):
+    # Real ONNX Runtime CPU kernel for SparseAttention requires head_size to
+    # be a multiple of 8 (verified empirically, the same constraint
+    # GroupQueryAttention's own CPU kernel has -- see `_gqa_model`'s own
+    # comment), so D defaults to 8. `past_key`/`past_value` are declared as
+    # genuine graph inputs *and* given an initializer of the same name (the
+    # standard ONNX "optional input with a default constant" idiom, legal
+    # per `onnx.checker.check_model` -- confirmed below) so a caller can
+    # execute the model through onnxruntime's own IOBinding API (binding the
+    # same buffer to the input and the `present_key`/`present_value`
+    # output), while this module's own matcher/slicer still sees a genuine
+    # constant to prune (`initializer_map` reads `graph.initializer`, not
+    # `graph.input`).
+    rng = np.random.default_rng(seed)
+    Nq, Nkv = H * D, KVH * D
+    if wq is None:
+        wq = rng.standard_normal((K, Nq)).astype(np.float32) * 0.1
+    if wk is None:
+        wk = rng.standard_normal((K, Nkv)).astype(np.float32) * 0.1
+    if wv is None:
+        wv = rng.standard_normal((K, Nkv)).astype(np.float32) * 0.1
+    if wout is None:
+        wout = rng.standard_normal((Nq, Out)).astype(np.float32) * 0.1
+    if past_key is None:
+        past_key = rng.standard_normal((batch, KVH, seq, D)).astype(np.float32) * 0.1
+    if past_value is None:
+        past_value = rng.standard_normal((batch, KVH, seq, D)).astype(np.float32) * 0.1
+    past_key = np.ascontiguousarray(past_key, dtype=np.float32)
+    past_value = np.ascontiguousarray(past_value, dtype=np.float32)
+
+    initializer = [
+        _f32(wq, "Wq"),
+        _f32(wk, "Wk"),
+        _f32(wv, "Wv"),
+        _f32(wout, "Wout"),
+        onnx.numpy_helper.from_array(past_key, "PastKey"),
+        onnx.numpy_helper.from_array(past_value, "PastValue"),
+    ]
+
+    # A trivially "dense" single-row-block CSR mask (`seq == sparse_block_size`
+    # by default, exactly one query/key block, that one block attending
+    # fully to itself -- this op's own real unidirectional/causal masking is
+    # applied internally regardless), `num_layout` identical copies stacked
+    # along axis 0. This module never inspects `block_row_indices`'/
+    # `block_col_indices`' own *content* at all, only their shared leading
+    # `num_layout` dimension (see `_match_sparse_attention_producer`'s own
+    # docstring) -- confirmed via a real onnxruntime CPU-kernel run
+    # (`_run_sparse_attention`) that this minimal mask executes correctly.
+    if row_indices is None:
+        row_indices = np.tile(np.array([0, 1], dtype=np.int32), (num_layout, 1))
+    if col_indices is None:
+        col_indices = np.tile(np.array([0], dtype=np.int32), (num_layout, 1))
+    extra_inputs = ""
+    if row_indices_dynamic:
+        extra_inputs = f", int32[{row_indices.shape[0]},{row_indices.shape[1]}] RowIdx"
+    else:
+        initializer.append(onnx.numpy_helper.from_array(row_indices, "RowIdx"))
+    initializer.append(onnx.numpy_helper.from_array(col_indices, "ColIdx"))
+    initializer.append(
+        onnx.numpy_helper.from_array(np.array(seq, dtype=np.int32), "TotalSeq")
+    )
+    initializer.append(
+        onnx.numpy_helper.from_array(
+            np.full((batch,), seq, dtype=np.int32), "KeyTotalSeq"
+        )
+    )
+
+    # PastKey/PastValue/PresentKey/PresentValue declare a symbolic `kvh`
+    # dim, not a concrete `{KVH}`, for their own `kv_num_heads` axis: this
+    # module's own pruning only resizes the *initializer*'s real shape (the
+    # constant this pass actually slices), not this static graph-level
+    # ValueInfo declaration -- a concrete dim here would go stale the moment
+    # `KVH` is pruned down, and onnxruntime's own loader rejects an
+    # initializer whose shape no longer matches its declared graph input
+    # (confirmed empirically: "Shape of initializer PastValue does not
+    # match").
+    body = f"""
+        g (float[{batch},{seq},{K}] X, float[{batch},kvh,{seq},{D}] PastKey, float[{batch},kvh,{seq},{D}] PastValue{extra_inputs}) => (float[{batch},{seq},{Out}] Y, float[{batch},kvh,{seq},{D}] PresentKey, float[{batch},kvh,{seq},{D}] PresentValue)
+        {{
+          q = MatMul(X, Wq)
+          k = MatMul(X, Wk)
+          v = MatMul(X, Wv)
+          attn, PresentKey, PresentValue = com.microsoft.SparseAttention <num_heads={H}, kv_num_heads={KVH}, sparse_block_size={sparse_block_size}> (q, k, v, PastKey, PastValue, RowIdx, ColIdx, TotalSeq, KeyTotalSeq)
+          Y = MatMul(attn, Wout)
+        }}
+        """
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 18, "com.microsoft": 1]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model, dict(
+        K=K,
+        H=H,
+        KVH=KVH,
+        D=D,
+        Out=Out,
+        Nq=Nq,
+        Nkv=Nkv,
+        wq=wq,
+        wk=wk,
+        wv=wv,
+        wout=wout,
+        batch=batch,
+        seq=seq,
+        sparse_block_size=sparse_block_size,
+        num_layout=num_layout,
+        past_key=past_key,
+        past_value=past_value,
+    )
+
+
+def _sparse_attention_node(model):
+    return next(n for n in model.graph.node if n.op_type == "SparseAttention")
+
+
+def _sparse_attention_attrs(node):
+    num_heads = next(a.i for a in node.attribute if a.name == "num_heads")
+    kv_num_heads = next(a.i for a in node.attribute if a.name == "kv_num_heads")
+    return num_heads, kv_num_heads
+
+
+def _run_sparse_attention(model, x, past_key, past_value):
+    # See this section's own top comment for why plain `session.run()` (or
+    # this file's own `_run`) can't be used here: `present_key`/
+    # `present_value` must be bound to the exact same `OrtValue` as
+    # `past_key`/`past_value`.
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    past_key_ov = ort.OrtValue.ortvalue_from_numpy(np.ascontiguousarray(past_key))
+    past_value_ov = ort.OrtValue.ortvalue_from_numpy(np.ascontiguousarray(past_value))
+    io = sess.io_binding()
+    io.bind_cpu_input("X", np.ascontiguousarray(x))
+    io.bind_ortvalue_input("PastKey", past_key_ov)
+    io.bind_ortvalue_input("PastValue", past_value_ov)
+    io.bind_output("Y", "cpu")
+    io.bind_ortvalue_output("PresentKey", past_key_ov)
+    io.bind_ortvalue_output("PresentValue", past_value_ov)
+    sess.run_with_iobinding(io)
+    outs = io.copy_outputs_to_cpu()
+    return outs[0]
+
+
+def test_sparse_attention_pruning_shrinks_matched_block():
+    model, cfg = _sparse_attention_model(K=8, H=4, KVH=4, D=8, Out=6)
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    node = _sparse_attention_node(pruned)
+    num_heads, kv_num_heads = _sparse_attention_attrs(node)
+    assert num_heads == 2
+    assert kv_num_heads == 2
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Wq"].dims) == [8, 16]
+    assert list(inits["Wk"].dims) == [8, 16]
+    assert list(inits["Wv"].dims) == [8, 16]
+    assert list(inits["Wout"].dims) == [16, 6]
+    assert list(inits["PastKey"].dims) == [1, 2, 16, 8]
+    assert list(inits["PastValue"].dims) == [1, 2, 16, 8]
+
+
+def test_sparse_attention_pruning_zero_sparsity_is_a_no_op():
+    model, cfg = _sparse_attention_model(K=8, H=8, KVH=2, D=8, Out=6, seed=7)
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.0)
+    node = _sparse_attention_node(pruned)
+    num_heads, kv_num_heads = _sparse_attention_attrs(node)
+    assert num_heads == cfg["H"]
+    assert kv_num_heads == cfg["KVH"]
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["Wq"], cfg["wq"])
+    np.testing.assert_array_equal(inits["Wk"], cfg["wk"])
+    np.testing.assert_array_equal(inits["Wv"], cfg["wv"])
+
+
+def test_sparse_attention_pruning_matches_oracle_exactly():
+    # End-to-end correctness against an independently-reconstructed,
+    # already-pruned reference model -- this module's own established
+    # invariant (comparing against the *unpruned* model's own output has
+    # been a real, caught mistake in an earlier round of this project) --
+    # run through a real onnxruntime CPU kernel via `_run_sparse_attention`,
+    # not merely a shape check. Also directly exercises `past_key`/
+    # `past_value` (required, not optional, on this op's own schema) being
+    # sliced along their own `kv_num_heads` axis by the identical
+    # `keep_groups` index set K's/V's own producer weights are sliced by.
+    model, cfg = _sparse_attention_model(K=8, H=8, KVH=2, D=8, Out=6, seed=1)
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    node = _sparse_attention_node(pruned)
+    num_heads, kv_num_heads = _sparse_attention_attrs(node)
+    group_size = cfg["H"] // cfg["KVH"]
+    assert kv_num_heads == 1  # max(1, 2 - round(2*0.5))
+    assert num_heads == kv_num_heads * group_size
+
+    keep_groups = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], cfg["H"], cfg["KVH"], cfg["D"], kv_num_heads
+    )
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    d = cfg["D"]
+    q_idx, kv_idx = _head_idx(keep_q_heads, d), _head_idx(keep_groups, d)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["Wq"], cfg["wq"][:, q_idx])
+    np.testing.assert_array_equal(inits["Wk"], cfg["wk"][:, kv_idx])
+    np.testing.assert_array_equal(inits["Wv"], cfg["wv"][:, kv_idx])
+    np.testing.assert_array_equal(inits["Wout"], cfg["wout"][q_idx, :])
+    np.testing.assert_array_equal(
+        inits["PastKey"], cfg["past_key"][:, keep_groups, :, :]
+    )
+    np.testing.assert_array_equal(
+        inits["PastValue"], cfg["past_value"][:, keep_groups, :, :]
+    )
+
+    oracle, _ = _sparse_attention_model(
+        K=cfg["K"],
+        H=num_heads,
+        KVH=kv_num_heads,
+        D=d,
+        Out=cfg["Out"],
+        seed=1,
+        batch=cfg["batch"],
+        seq=cfg["seq"],
+        sparse_block_size=cfg["sparse_block_size"],
+        wq=cfg["wq"][:, q_idx],
+        wk=cfg["wk"][:, kv_idx],
+        wv=cfg["wv"][:, kv_idx],
+        wout=cfg["wout"][q_idx, :],
+        past_key=cfg["past_key"][:, keep_groups, :, :],
+        past_value=cfg["past_value"][:, keep_groups, :, :],
+    )
+    onnx.checker.check_model(oracle)
+
+    rng = np.random.default_rng(2)
+    x = (
+        rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+        * 0.1
+    )
+    pruned_past_key = cfg["past_key"][:, keep_groups, :, :]
+    pruned_past_value = cfg["past_value"][:, keep_groups, :, :]
+    y_pruned = _run_sparse_attention(pruned, x, pruned_past_key, pruned_past_value)
+    y_oracle = _run_sparse_attention(oracle, x, pruned_past_key, pruned_past_value)
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_sparse_attention_pruning_dynamic_block_row_indices_is_declined():
+    # `block_row_indices` (and, by the same reasoning, `block_col_indices`)
+    # must be a *constant* for this pass to know `num_layout` and re-verify
+    # this op's own "num_heads divisible by num_layout" invariant once
+    # pruning's post-pruning head count is known -- a real block-sparse
+    # layout is a fixed structure baked at export time, never genuine
+    # runtime data the way GroupQueryAttention's own past_key/past_value
+    # legitimately can be, so a *dynamic* one declines the whole match
+    # outright (see `_match_sparse_attention_producer`'s own docstring).
+    model, cfg = _sparse_attention_model(
+        K=8, H=4, KVH=2, D=8, Out=6, seed=3, row_indices_dynamic=True
+    )
+    before = {
+        t.name: onnx.numpy_helper.to_array(t).copy() for t in model.graph.initializer
+    }
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    after = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    for name in ("Wq", "Wk", "Wv", "Wout"):
+        np.testing.assert_array_equal(before[name], after[name])
+    node = _sparse_attention_node(pruned)
+    num_heads, kv_num_heads = _sparse_attention_attrs(node)
+    assert (num_heads, kv_num_heads) == (cfg["H"], cfg["KVH"])
+
+
+def test_sparse_attention_pruning_num_layout_divisibility_declined():
+    # H=4, KVH=4 (group_size=1, ordinary per-head groups), num_layout=2: at
+    # sparsity=0.75, keep_count == max(1, 4 - round(4*0.75)) == 1, so the
+    # post-pruning query head count would be 1 -- not divisible by
+    # num_layout == 2, which would silently break this op's own "num_heads
+    # is divisible by num_layout" invariant even though it held before
+    # pruning. Declined as a no-op for this block (the same "sparsity
+    # rounds to no groups dropped" outcome, from a different cause) rather
+    # than emitting an invalid node -- see `_apply_one_gqa_chain`'s own
+    # `is_sparse_attention` branch.
+    model, cfg = _sparse_attention_model(
+        K=8, H=4, KVH=4, D=8, Out=6, seed=5, num_layout=2
+    )
+    before = {
+        t.name: onnx.numpy_helper.to_array(t).copy() for t in model.graph.initializer
+    }
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.75)
+    onnx.checker.check_model(pruned)
+    after = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    for name in ("Wq", "Wk", "Wv", "Wout"):
+        np.testing.assert_array_equal(before[name], after[name])
+    node = _sparse_attention_node(pruned)
+    num_heads, kv_num_heads = _sparse_attention_attrs(node)
+    assert (num_heads, kv_num_heads) == (cfg["H"], cfg["KVH"])
+
+
+def test_sparse_attention_not_eligible_lists_unmatched_node():
+    model, cfg = _sparse_attention_model(
+        K=8, H=4, KVH=2, D=8, Out=6, seed=6, row_indices_dynamic=True
+    )
+    node = _sparse_attention_node(model)
+    node.name = "sa_orphan"
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_attention_head_pruning, sparsity=0.5
+    )
+    assert report.layers == []
+    assert report.not_eligible == ["SparseAttention 'sa_orphan'"]
+
+
+def test_analyze_attention_head_pruning_sparse_attention_matches_real_call():
+    model, cfg = _sparse_attention_model(K=8, H=8, KVH=2, D=8, Out=6, seed=7)
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_attention_head_pruning, sparsity=0.5
+    )
+    assert len(report.layers) == 1
+    layer = report.layers[0]
+    assert layer.family == "attention_sparse_group"
+    assert layer.total == cfg["KVH"]
+    assert report.not_eligible == []
+
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    dims_after = {t.name: list(t.dims) for t in pruned.graph.initializer}
+    kept_groups = cfg["KVH"] - layer.would_drop
+    group_size = cfg["H"] // cfg["KVH"]
+    assert dims_after["Wq"][1] == kept_groups * group_size * cfg["D"]
+    assert dims_after["Wk"][1] == kept_groups * cfg["D"]
+    assert dims_after["Wv"][1] == kept_groups * cfg["D"]
+
+
 # --- QOperator (QLinearConv/QLinearMatMul/QGemm) structured pruning tests --
 #
 # QLinearConv/QLinearMatMul/QGemm carry their own quantized weight/scale/


### PR DESCRIPTION
## Summary

`com.microsoft::SparseAttention` — a block-sparse-KV attention op used by Phi-3-small-class long-context models exported via onnxruntime-genai, with a `GroupQueryAttention`-shaped `num_heads`/`kv_num_heads` GQA/MQA taxonomy — had zero references in this module. This adds it to attention-head pruning, reusing the existing GQA whole-KV-group ranking/slicing machinery.

## Empirically confirmed facts

- Live schema (`get_all_operator_schema()`): `query`/`key`/`value` (indices 0/1/2, already-projected activations), `past_key`/`past_value` (indices 3/4 — the **same** positions `GroupQueryAttention` uses, but **required** here, not optional), `block_row_indices`/`block_col_indices`/`total_sequence_length`/`key_total_sequence_lengths` (indices 5-8, all `M`-typed/int32 layout- or sequence-indexed bookkeeping, never head-indexed), `cos_cache`/`sin_cache` (indices 9/10, optional, same broadcast-across-heads shape as GQA's own). No `attention_bias`/`attn_mask`/`head_sink` input at all.
- `past_key`/`past_value` are BNSH-format `(batch, kv_num_heads, max_cache_seq, head_size)` caches, sliced along the same `kv_num_heads` axis as GQA's own, by the identical `keep_groups` index set.
- `block_row_indices`/`block_col_indices` are the CSR representation of the block-sparse mask, shaped `(num_layout, ...)` — never head-indexed, so never sliced — but the op's own documented invariant ("`num_heads` divisible by `num_layout`") must be re-verified against the **post-pruning** head count, since pruning can silently break an invariant that held before. A dynamic (non-constant) `block_row_indices`/`block_col_indices` declines the whole match (a real block-sparse layout is a fixed export-time structure, not legitimate runtime data the way GQA's own past-KV can be); a post-pruning head count that would violate the invariant declines that block's pruning as a no-op instead of emitting an invalid node.
- A real CPU kernel exists, but the op's own schema requires `past_key`/`present_key` (and `past_value`/`present_value`) to literally share the same memory buffer at execution time — confirmed empirically (`session.run()` fails with `past_key->DataRaw() == present_key->DataRaw() ... was false`). Correctness tests use onnxruntime's own IOBinding API, binding the identical `OrtValue` to both the past-cache input and the present-cache output — the same buffer-reuse pattern a real onnxruntime-genai autoregressive decode loop uses.

## What's added

New `_match_sparse_attention_producer` (a seventh matcher in the family, alongside `GroupQueryAttention`/`PagedAttention`/`LinearAttention`/etc.) + `_find_sparse_attention_chains`, reusing `_GQAChain`/`_apply_one_gqa_chain`/`_gqa_group_importance` outright. A new `is_sparse_attention` branch in `_apply_one_gqa_chain` handles the required-past-KV indices and the num_layout-divisibility re-check. Wired into `apply_attention_head_pruning`, `apply_attention_head_wanda_pruning`, both `_analyze_*` dry-run mirrors, and `_attention_not_eligible` (new family string `"attention_sparse_group"`).

## Test plan

- [x] `pytest tests/test_pruning.py -q` — 680 → 687 passed, zero regressions (7 new tests)
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — 0 errors, unchanged from master's baseline
- [x] Weight-shape correctness (Q/K/V/O all sliced consistently)
- [x] End-to-end IOBinding-driven correctness against an independently-reconstructed "already pruned" reference model (this module's established invariant — never compared against the full unpruned model's own output)
- [x] `past_key`/`past_value` sliced correctly (required inputs, unlike GQA's optional ones)
- [x] Dynamic `block_row_indices` decline (whole chain left byte-unchanged)
- [x] `num_heads % num_layout` post-pruning-invariant decline
- [x] Zero-sparsity no-op, `not_eligible`/dry-run reporting parity

I independently re-verified the live schema myself (input indices, required/optional status, index-tensor types — all confirmed exactly as claimed), reviewed the full diff, ran the entire test/ruff/mypy suite myself in a clean environment, and specifically confirmed the end-to-end correctness test actually exercises the real CPU kernel via IOBinding against an independently-reconstructed reference model (not just a shape check) before pushing.

---
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_