### PR TITLE
Recurse pruning passes into If/Loop/Scan/BeamSearch-family subgraphs

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -873,6 +873,87 @@ depthwise extreme (``group == Cin == Cout``, ``Cin/group == 1``), where
 each group's own Hessian correctly degenerates to a ``[kh*kw, kh*kw]``
 per-channel Hessian rather than anything degenerate or wrong at that
 boundary.
+
+Subgraph recursion (nested ``If``/``Loop``/``Scan``/``BeamSearch``-family
+graphs): every function above this paragraph was, until this note was
+added, blind to any node's ``GRAPH``-/``GRAPHS``-typed attribute -- a
+plain ``If``'s ``then_branch``/``else_branch``, ``Loop``/``Scan``'s
+``body``, or (confirmed live against onnxruntime's own contrib-op schema
+registry) ``com.microsoft::BeamSearch``/``GreedySearch``/``Sampling``/
+``WhisperBeamSearch``'s own ``decoder``/``encoder``/``init_decoder``
+attribute. Each of those is itself a full ``GraphProto`` that can carry
+arbitrary weight-bearing nodes -- for a whole-model-generation export
+(``onnxruntime.transformers.models.{t5,gpt2,whisper}.convert_generation``),
+essentially 100% of the actual prunable weight lives inside exactly one of
+these, invisible to every pass in this module, with no error and no report
+entry, until now. See :func:`_iter_subgraphs` and this module's own
+"Subgraph recursion" section comment (just above :func:`_iter_subgraphs`'s
+own definition) for the shared traversal primitive and the two
+correctness properties (implicit-capture scoping, no cross-scope
+initializer slicing) every subgraph-aware function below gets for free by
+construction.
+
+Subgraph-aware as of this note: :func:`weight_sparsity` (its pooled
+zero-fraction now sums across every nested subgraph too, not just the
+top-level graph -- otherwise it would be actively misleading, not merely
+incomplete, on a model whose real weight lives almost entirely inside one),
+:func:`apply_magnitude_pruning` (including its own `global_sparsity` mode,
+which pools every matched layer across every graph -- top-level and every
+nested subgraph alike -- into the one shared global ranking, consistent
+with "global" meaning the whole model), :func:`apply_structured_pruning`
+(every chain family it matches, with its own `global_sparsity` mode pooled
+*independently per graph* rather than across the whole model -- see that
+function's own docstring for exactly why), and
+:func:`apply_attention_head_pruning` (every block family it matches; a
+nested subgraph's own dynamic per-head bias/mask/head_sink classification
+is conservatively less capable than the top-level graph's own -- see that
+function's own docstring for exactly why and what that means in practice).
+
+Deliberately NOT subgraph-aware yet, a scope decision rather than an
+oversight -- each remains exactly as top-level-graph-only as it already
+was:
+
+- Every calibration-data-driven function
+  (:func:`apply_wanda_pruning`, :func:`apply_structured_wanda_pruning`,
+  :func:`apply_attention_head_wanda_pruning`, :func:`apply_sparsegpt_pruning`,
+  and any `_analyze_*` mirror of one of these reached through
+  :func:`analyze_pruning_sensitivity`): each works by adding extra graph
+  OUTPUTS to a probe copy of the model (:func:`_add_probe_outputs`) and
+  reading their values back from a real ``InferenceSession`` run. A tensor
+  that is only ever produced *inside* a nested subgraph has no such direct
+  route to becoming a top-level graph output -- doing this correctly would
+  need a new mechanism to hoist a probe value out through every enclosing
+  ``If``/``Loop`` node's own `output` list (extending each such node's own
+  output arity, and, for `If`, keeping `then_branch`/`else_branch` outputs
+  in lock-step, and for `Loop`, reconciling with its scan-output stacking
+  semantics), all the way up to the top level, and recursively so for a
+  subgraph nested inside another subgraph -- a materially different,
+  higher-risk engineering problem from applying an already-self-contained
+  per-graph matcher/slicer to more graphs, and out of scope for this
+  change.
+- Every other structural `apply_structured_pruning_*` family variant
+  (QDQ, MatMulNBits, MatMulBnb4, the FP8/FP4 block-quantized weight
+  families, QOperator, DynamicQuantizeMatMul, both MoE families
+  (expert-channel and whole-expert) and their QMoE counterparts, the
+  embedding/vocabulary family, and :func:`apply_transformer_block_pruning`)
+  follows the same generic `graph = out.graph` -> chain-find -> slice
+  shape :func:`apply_structured_pruning` does, and the same
+  :func:`_iter_subgraphs`-loop treatment applies to each mechanically --
+  but each is its own several-hundred-line, independently-tested function
+  body, and wiring roughly fifteen more of them through in the same change
+  was judged too large a single PR's worth of surface to review safely
+  alongside the four entry points above, which already cover this
+  module's two most emblematic scope gaps (SparseGPT-shaped no-calibration
+  structural pruning and the "sparsity report is actively misleading"
+  case). Left for a follow-up change; the pattern established by
+  :func:`apply_structured_pruning`'s own edit is the template to repeat.
+- :func:`analyze_pruning_sensitivity` itself dispatches to nineteen
+  separate `_analyze_*` implementations (one per supported `apply_fn`),
+  each with its own bespoke top-level-graph-only body mirroring its real
+  `apply_*` counterpart -- extending it would mean the same per-function
+  treatment as the point above, all nineteen of them, not a change to
+  :func:`analyze_pruning_sensitivity` itself; deferred for the same
+  review-size reason.
 """
 
 from __future__ import annotations
@@ -1186,6 +1267,103 @@ def _match_attention_weight_only(
     if info is None:
         return None
     return node.input[0], node.input[1]
+
+
+# --- Subgraph recursion -------------------------------------------------
+#
+# Every function above this section operates on a single ``GraphProto`` --
+# historically always ``model.graph``/``out.graph``, the top-level graph.
+# That leaves an entire class of real models invisible to every pass in
+# this module: a plain ``If``/``Loop``/``Scan`` node's ``then_branch``/
+# ``else_branch``/``body`` attribute, or (confirmed live against
+# onnxruntime's own contrib-op schema registry, ``AttrType.GRAPH``-typed)
+# ``com.microsoft::BeamSearch``/``GreedySearch``/``Sampling``/
+# ``WhisperBeamSearch``'s own ``decoder``/``encoder``/``init_decoder``
+# attributes, is itself a full ``GraphProto`` that can carry arbitrary
+# weight-bearing nodes -- for a whole-model-generation export produced by
+# ``onnxruntime.transformers.models.{t5,gpt2,whisper}.convert_generation``,
+# essentially 100% of the actual prunable weight lives inside exactly one
+# of these, not in the top-level graph at all.
+#
+# :func:`_iter_subgraphs` is the one shared primitive every subgraph-aware
+# entry point below builds on: it walks `graph`'s own `node` list, and
+# recursively every nested `GraphProto` reachable from any node's
+# `GRAPH`-/`GRAPHS`-typed attribute (genuinely recursive -- a subgraph's
+# own nodes can themselves carry further-nested subgraphs, e.g. an `If`
+# inside a `Loop` body), keyed purely on `onnx.AttributeProto.type` rather
+# than a per-op-name allowlist, so it needs no update when some future op
+# adds another graph-typed attribute.
+#
+# Every graph :func:`_iter_subgraphs` returns is then handed, completely
+# independently, to this module's existing per-graph chain-finders/
+# candidate-matchers/slicers UNCHANGED -- never merged with any sibling or
+# ancestor graph's own state. This is deliberate, not an oversight, and is
+# what makes the two correctness properties below hold for free, with no
+# extra bookkeeping:
+#
+# - Implicit-capture scoping: ONNX lets a subgraph's own node reference a
+#   name defined in an ENCLOSING graph's scope rather than its own
+#   `node`/`initializer` list (e.g. an `If` branch reading a weight that
+#   actually lives in the top-level graph's `initializer`). Every matcher
+#   in this module resolves a weight/value strictly via
+#   ``{t.name: t for t in graph.initializer}``/consumer maps built from
+#   the one `graph` it was given -- never the caller's own enclosing
+#   scope -- so a node whose input only resolves in an outer scope simply
+#   fails to match (`initializer_map.get(name) is None`, or the input
+#   isn't found as an internal producer at all) and that chain is
+#   declined, the same "decline rather than mis-slice" behavior this
+#   module already applies to every other unresolvable topology. No
+#   subgraph is ever treated as if it could see outward.
+# - Shared initializers across scopes: since every one of this module's
+#   slicers only ever mutates a tensor found in the CURRENT graph's own
+#   `initializer` list (never a parent's), and a parent-scope initializer
+#   an inner graph merely *reads* by implicit capture is -- by the point
+#   above -- never even matched as prunable from inside that inner graph,
+#   there is no path by which processing a subgraph could reach into, and
+#   corrupt, a tensor that actually belongs to (and is separately, safely
+#   processed as part of) an ancestor or sibling graph's own pass.
+#
+# What subgraph recursion does NOT change: shape/type validity. A
+# subgraph's own declared output `value_info` must still describe
+# whatever the actual (possibly now-differently-shaped, post-pruning)
+# tensor is once pruning is done -- exactly the same "keep the graph
+# valid, not just runnable" bar this module already holds for the
+# top-level graph everywhere else; a fixed (non-symbolic) subgraph output
+# dim that this module's ordinary `graph.value_info` staleness-eviction
+# doesn't reach (only interior `value_info` is evicted, never `input`/
+# `output`) is exactly the same kind of pre-existing "caller-declared,
+# not this module's to override" limitation this module already accepts
+# for the top-level graph's own inputs/outputs.
+#
+# Coverage is intentionally NOT comprehensive across every `apply_*`/
+# `analyze_*` function in this module -- see each subgraph-aware
+# function's own docstring for exactly what it covers, and this module's
+# own top-of-file docstring for the full list of what remains top-level-
+# graph-only and why.
+def _iter_subgraphs(graph: onnx.GraphProto) -> List[onnx.GraphProto]:
+    """Returns `graph` itself, first, followed by every ``GraphProto``
+    nested (recursively, to any depth) inside any of `graph`'s own nodes'
+    ``GRAPH``-/``GRAPHS``-typed attributes -- depth-first, in `graph.node`
+    then `node.attribute` declaration order, recursing into a found
+    subgraph's own nested subgraphs before moving on to the next node.
+    Matches purely by `onnx.AttributeProto.type`, so it needs no
+    op-specific allowlist: plain ``If``'s ``then_branch``/``else_branch``,
+    ``Loop``/``Scan``'s ``body``, and any other current or future op with
+    a graph-typed attribute (e.g. ``com.microsoft::BeamSearch``'s own
+    ``decoder``/``encoder``/``init_decoder``) are all picked up the same
+    way. See this section's own top comment for why every caller below is
+    safe to run its existing single-graph logic on each returned graph
+    completely independently.
+    """
+    graphs = [graph]
+    for node in graph.node:
+        for attr in node.attribute:
+            if attr.type == onnx.AttributeProto.GRAPH:
+                graphs.extend(_iter_subgraphs(attr.g))
+            elif attr.type == onnx.AttributeProto.GRAPHS:
+                for g in attr.graphs:
+                    graphs.extend(_iter_subgraphs(g))
+    return graphs
 
 
 def _candidates(
@@ -1755,6 +1933,20 @@ def apply_magnitude_pruning(
             to the target pattern; layers with a non-constant weight, a
             non-2-D MatMul/Gemm weight, or a non-4-D Conv weight are left
             untouched
+
+    Subgraph-aware (:func:`_iter_subgraphs`, see this module's own
+    "Subgraph recursion" section comment): every matched layer inside a
+    nested ``If``/``Loop``/``Scan``/``BeamSearch``-family subgraph, at any
+    nesting depth, is matched and masked exactly as if it were its own
+    top-level graph -- :func:`_candidates` is given one subgraph's own
+    `node`/`initializer` list at a time, so a chain that would need to
+    reach an implicitly-captured name from an enclosing scope is declined
+    (never matched at all) rather than mis-resolved. In `global_sparsity`
+    mode, every matched layer across every graph (top-level and every
+    nested subgraph alike) is pooled into the *same* single global ranking
+    -- consistent with "global" meaning the whole model, not just its
+    top-level graph -- so `sparsity`'s fraction is chosen from, and applied
+    to, that combined pool.
     """
     _validate_pattern(sparsity, n, m)
     if global_sparsity and n is not None:
@@ -1767,34 +1959,35 @@ def apply_magnitude_pruning(
 
     out = onnx.ModelProto()
     out.CopyFrom(model)
-    initializer_map = {t.name: t for t in out.graph.initializer}
-
-    candidates = _candidates(out.graph)
 
     if global_sparsity:
         entries = []
-        for _, _, w_name, weight_transposed, is_conv in candidates:
-            w_init = initializer_map[w_name]
-            w = _to_f64(w_init)
-            w_nk = _weight_to_nk(w, weight_transposed, is_conv)
-            entries.append(
-                (w_init, weight_transposed, is_conv, w.shape, w_nk, np.abs(w_nk))
-            )
+        for graph in _iter_subgraphs(out.graph):
+            initializer_map = {t.name: t for t in graph.initializer}
+            for _, _, w_name, weight_transposed, is_conv in _candidates(graph):
+                w_init = initializer_map[w_name]
+                w = _to_f64(w_init)
+                w_nk = _weight_to_nk(w, weight_transposed, is_conv)
+                entries.append(
+                    (w_init, weight_transposed, is_conv, w.shape, w_nk, np.abs(w_nk))
+                )
         _apply_global_unstructured_pruning(entries, sparsity)
         return out
 
-    for _, _, w_name, weight_transposed, is_conv in candidates:
-        w_init = initializer_map[w_name]
+    for graph in _iter_subgraphs(out.graph):
+        initializer_map = {t.name: t for t in graph.initializer}
+        for _, _, w_name, weight_transposed, is_conv in _candidates(graph):
+            w_init = initializer_map[w_name]
 
-        def importance_of_nk(w_nk, n=n, m=m, sparsity=sparsity):
-            importance = np.abs(w_nk)
-            return (
-                _nm_mask(importance, n, m)
-                if n is not None
-                else _sparsity_mask(importance, sparsity)
-            )
+            def importance_of_nk(w_nk, n=n, m=m, sparsity=sparsity):
+                importance = np.abs(w_nk)
+                return (
+                    _nm_mask(importance, n, m)
+                    if n is not None
+                    else _sparsity_mask(importance, sparsity)
+                )
 
-        _prune_weight(w_init, weight_transposed, importance_of_nk, is_conv=is_conv)
+            _prune_weight(w_init, weight_transposed, importance_of_nk, is_conv=is_conv)
 
     return out
 
@@ -2182,18 +2375,37 @@ def weight_sparsity(model: Union[str, onnx.ModelProto]) -> float:
     handling here: an exact-zero comparison and ``.size`` mean the same
     thing regardless of float precision), with no separate list to keep in
     sync.
-    Returns ``0.0`` if no matching layer is present.
+
+    Subgraph-aware (:func:`_iter_subgraphs`, see this module's own
+    "Subgraph recursion" section comment): every matched layer inside a
+    nested ``If``/``Loop``/``Scan``/``BeamSearch``-family subgraph, at any
+    nesting depth, is counted into the same pooled ``zeros``/``total``
+    tally as the top-level graph's own matches -- otherwise this number
+    would be actively misleading (not merely incomplete) on a model whose
+    real weight lives almost entirely inside such a subgraph, e.g. a
+    whole-model-generation export from
+    ``onnxruntime.transformers.models.{t5,gpt2,whisper}.convert_generation``
+    -- silently reporting a top-level-only sparsity that has nothing to do
+    with the model's actual overall zero-fraction. Each subgraph's own
+    matches are drawn strictly from that subgraph's own `initializer` list
+    (:func:`_candidates`, given that one subgraph at a time) -- a name only
+    resolvable via implicit capture from an enclosing scope is never
+    counted here, the same conservative "local initializers only" rule
+    every subgraph-aware `apply_*` function in this module already follows
+    (see this module's own "Subgraph recursion" section comment).
+    Returns ``0.0`` if no matching layer is present anywhere in the model.
     """
     if isinstance(model, str):
         model = onnx.load(model, load_external_data=False)
 
     zeros = 0
     total = 0
-    initializer_map = {t.name: t for t in model.graph.initializer}
-    for _, _, w_name, _, _ in _candidates(model.graph):
-        w = onnx.numpy_helper.to_array(initializer_map[w_name])
-        zeros += int(np.count_nonzero(w == 0))
-        total += w.size
+    for graph in _iter_subgraphs(model.graph):
+        initializer_map = {t.name: t for t in graph.initializer}
+        for _, _, w_name, _, _ in _candidates(graph):
+            w = onnx.numpy_helper.to_array(initializer_map[w_name])
+            zeros += int(np.count_nonzero(w == 0))
+            total += w.size
 
     return zeros / total if total else 0.0
 
@@ -9108,6 +9320,33 @@ def apply_structured_pruning(
     the "FP16/BFloat16 weight support" section comment above
     :func:`_match_conv_weight_only` for why that needs no separate
     downcast step.
+
+    Subgraph-aware (:func:`_iter_subgraphs`, see this module's own
+    "Subgraph recursion" section comment): every chain family above is
+    matched and pruned inside a nested ``If``/``Loop``/``Scan``/
+    ``BeamSearch``-family subgraph, at any nesting depth, exactly as if
+    that subgraph were its own top-level graph -- every chain-finder above
+    is given one graph (top-level or nested) at a time, so a chain that
+    would need to reach a producer/consumer/constant only resolvable via
+    an implicitly-captured name from an enclosing scope is declined
+    (never matched) rather than mis-resolved, and a weight is only ever
+    sliced out of the one graph's own `initializer` list it was actually
+    found in -- never an ancestor's or a sibling subgraph's. `touched`
+    (the shared touched-role/stale-`value_info` state) is reset per graph:
+    a name is only ever a "shared/tied initializer" conflict against
+    another chain matched *within that same graph*, never across graphs,
+    since ONNX names are scoped per-graph-tree-position and this module
+    never merges two graphs' own initializer/consumer maps together (see
+    this section's own top comment on implicit-capture scoping). In
+    `global_sparsity` mode, the pooled ranking/cutoff is likewise computed
+    *independently per graph* (not pooled across the whole model the way
+    :func:`apply_magnitude_pruning`'s own `global_sparsity` mode is) --
+    :func:`_apply_chains_global` builds its own `initializer_map` from a
+    single `graph` argument, so chains from two different graphs can never
+    share one of its calls; recomputing model-wide pooling into that
+    function was judged out of scope for this change (see this module's
+    own "Subgraph recursion" section comment), and per-graph pooling is
+    still a strict improvement over the prior top-level-only blind spot.
     """
     if not (0.0 <= sparsity < 1.0):
         raise ValueError(f"sparsity must be in [0, 1), got {sparsity}")
@@ -9117,57 +9356,59 @@ def apply_structured_pruning(
 
     out = onnx.ModelProto()
     out.CopyFrom(model)
-    graph = out.graph
 
-    chains = (
-        _find_chains(graph)
-        + _find_gated_chains(graph)
-        + _find_conv_chains(graph)
-        + _find_conv_residual_chains(graph)
-        + _find_matmul_residual_chains(graph)
-    )
-    concat_chains = _find_matmul_concat_chains(graph) + _find_conv_concat_chains(graph)
+    for graph in _iter_subgraphs(out.graph):
+        chains = (
+            _find_chains(graph)
+            + _find_gated_chains(graph)
+            + _find_conv_chains(graph)
+            + _find_conv_residual_chains(graph)
+            + _find_matmul_residual_chains(graph)
+        )
+        concat_chains = _find_matmul_concat_chains(graph) + _find_conv_concat_chains(
+            graph
+        )
 
-    touched = _TouchedState()
-    if global_sparsity:
-        global_chains = [c for c in chains if _chain_is_global_sparsity_eligible(c)]
-        if global_chains:
-            _apply_chains_global(
-                graph,
-                global_chains,
-                sparsity,
-                lambda chain, w_arrays_nk: _plain_structured_importance(
-                    chain, w_arrays_nk, importance_norm
-                ),
-                touched,
-            )
-    else:
-        if chains:
-            _apply_chains(
-                graph,
-                chains,
-                sparsity,
-                lambda chain, w_arrays_nk: _plain_structured_importance(
-                    chain, w_arrays_nk, importance_norm
-                ),
-                touched,
-            )
-        if concat_chains:
-            _apply_concat_chains(
-                graph,
-                concat_chains,
-                sparsity,
-                lambda _operand_name, w_arrays_nk: _plain_branch_importance(
-                    w_arrays_nk, importance_norm
-                ),
-                touched,
-            )
-    if touched.stale_value_info:
-        kept = [
-            vi for vi in graph.value_info if vi.name not in touched.stale_value_info
-        ]
-        del graph.value_info[:]
-        graph.value_info.extend(kept)
+        touched = _TouchedState()
+        if global_sparsity:
+            global_chains = [c for c in chains if _chain_is_global_sparsity_eligible(c)]
+            if global_chains:
+                _apply_chains_global(
+                    graph,
+                    global_chains,
+                    sparsity,
+                    lambda chain, w_arrays_nk: _plain_structured_importance(
+                        chain, w_arrays_nk, importance_norm
+                    ),
+                    touched,
+                )
+        else:
+            if chains:
+                _apply_chains(
+                    graph,
+                    chains,
+                    sparsity,
+                    lambda chain, w_arrays_nk: _plain_structured_importance(
+                        chain, w_arrays_nk, importance_norm
+                    ),
+                    touched,
+                )
+            if concat_chains:
+                _apply_concat_chains(
+                    graph,
+                    concat_chains,
+                    sparsity,
+                    lambda _operand_name, w_arrays_nk: _plain_branch_importance(
+                        w_arrays_nk, importance_norm
+                    ),
+                    touched,
+                )
+        if touched.stale_value_info:
+            kept = [
+                vi for vi in graph.value_info if vi.name not in touched.stale_value_info
+            ]
+            del graph.value_info[:]
+            graph.value_info.extend(kept)
 
     return out
 
@@ -18647,6 +18888,33 @@ def apply_attention_head_pruning(
     removal is pure index slicing that preserves each tensor's own original
     dtype untouched -- see the "FP16/BFloat16 weight support" section
     comment above :func:`_match_conv_weight_only`.
+
+    Subgraph-aware (:func:`_iter_subgraphs`, see this module's own
+    "Subgraph recursion" section comment): every block family above is
+    matched and pruned inside a nested ``If``/``Loop``/``Scan``/
+    ``BeamSearch``-family subgraph, at any nesting depth, exactly as if
+    that subgraph were its own top-level graph, with the same
+    implicit-capture decline behavior and local-initializer-only slicing
+    documented there. One deliberate difference from the top-level graph:
+    the top-level graph's own `value_info_by_name` is seeded by a real
+    ``onnx.shape_inference.infer_shapes()`` pass (unchanged from before
+    this function became subgraph-aware, so its own matching behavior is
+    byte-identical to before); a nested subgraph instead uses only its own
+    already-declared `input`/`output`/`value_info` with no inference step
+    (:func:`_value_info_by_name`, not :func:`_shape_inferred_value_info_by_name`)
+    -- re-running shape inference once per nested subgraph and mapping its
+    result back onto the *original* (not shape-inference's own internal
+    copy of the) subgraph was judged unnecessary complexity for this
+    change. This can only make a subgraph's own matching *more*
+    conservative than the top-level graph's, never less: every place this
+    value/info map is read (:func:`_dynamic_head_bias_axis` and friends)
+    already treats an unresolvable shape as "decline this one dynamic
+    input," not as an error, so a subgraph's own dynamic
+    `attention_bias`/`attn_mask`/`head_sink` input that is only
+    shape-resolvable via inference (rather than already declared outright)
+    is left unsliced there even though the equivalent top-level-graph case
+    would be handled -- a documented, conservative gap, not a correctness
+    risk.
     """
     if not (0.0 <= sparsity < 1.0):
         raise ValueError(f"sparsity must be in [0, 1), got {sparsity}")
@@ -18656,33 +18924,37 @@ def apply_attention_head_pruning(
 
     out = onnx.ModelProto()
     out.CopyFrom(model)
-    graph = out.graph
-    value_info_by_name = _shape_inferred_value_info_by_name(out)
+    top_value_info_by_name = _shape_inferred_value_info_by_name(out)
 
-    chains: List[_AttnLikeChain] = [
-        *_find_attention_chains(graph, value_info_by_name),
-        *_find_gqa_chains(graph, value_info_by_name),
-        *_find_onnx_attention_chains(graph, value_info_by_name),
-        *_find_mha_chains(graph, value_info_by_name),
-        *_find_packed_mha_chains(graph, value_info_by_name),
-        *_find_decoder_masked_mha_chains(graph, value_info_by_name),
-        *_find_paged_attention_chains(graph, value_info_by_name),
-        *_find_linear_attention_chains(graph, value_info_by_name),
-        *_find_sparse_attention_chains(graph, value_info_by_name),
-    ]
-    if chains:
-        _apply_attention_chains(
-            graph,
-            chains,
-            sparsity,
-            lambda chain, wq, wk, wv, dq, dk, dv: _plain_attention_head_importance(
-                chain, wq, wk, wv, dq, dk, dv, importance_norm
-            ),
-            lambda chain, wq, wk, wv: _gqa_group_importance(
-                chain, wq, wk, wv, importance_norm
-            ),
-            value_info_by_name,
+    for graph in _iter_subgraphs(out.graph):
+        value_info_by_name = (
+            top_value_info_by_name if graph is out.graph else _value_info_by_name(graph)
         )
+
+        chains: List[_AttnLikeChain] = [
+            *_find_attention_chains(graph, value_info_by_name),
+            *_find_gqa_chains(graph, value_info_by_name),
+            *_find_onnx_attention_chains(graph, value_info_by_name),
+            *_find_mha_chains(graph, value_info_by_name),
+            *_find_packed_mha_chains(graph, value_info_by_name),
+            *_find_decoder_masked_mha_chains(graph, value_info_by_name),
+            *_find_paged_attention_chains(graph, value_info_by_name),
+            *_find_linear_attention_chains(graph, value_info_by_name),
+            *_find_sparse_attention_chains(graph, value_info_by_name),
+        ]
+        if chains:
+            _apply_attention_chains(
+                graph,
+                chains,
+                sparsity,
+                lambda chain, wq, wk, wv, dq, dk, dv: _plain_attention_head_importance(
+                    chain, wq, wk, wv, dq, dk, dv, importance_norm
+                ),
+                lambda chain, wq, wk, wv: _gqa_group_importance(
+                    chain, wq, wk, wv, importance_norm
+                ),
+                value_info_by_name,
+            )
 
     return out
 

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -34301,3 +34301,546 @@ def test_apply_structured_pruning_dynamic_quantize_matmul_registered_in_sensitiv
         onnxsim.apply_structured_pruning_dynamic_quantize_matmul
         in onnxsim.pruning._SENSITIVITY_ANALYZERS
     )
+
+
+# --- Subgraph recursion --------------------------------------------------
+#
+# Covers :func:`onnxsim.pruning._iter_subgraphs` and the four entry points
+# built on it (:func:`apply_structured_pruning`, :func:`apply_magnitude_pruning`,
+# :func:`apply_attention_head_pruning`, :func:`weight_sparsity`) -- see
+# ``onnxsim/pruning.py``'s own top-of-file docstring, the "Subgraph
+# recursion" section comment directly above :func:`_iter_subgraphs`'s own
+# definition, and each of those four functions' own docstrings for the
+# full design.
+#
+# ``onnx.parser.parse_model``'s text format has no way to spell a
+# graph-typed node attribute (an ``If``'s ``then_branch``/``else_branch``),
+# so every model built below uses ``onnx.helper.make_node``/``make_graph``
+# directly instead, per this repo's own CLAUDE.md guidance for exactly
+# this case.
+
+
+def _mlp_branch_nodes(K, H, Out, prefix, seed):
+    # A minimal MatMul(Gemm)->Relu->MatMul chain, exactly
+    # :func:`_mlp_model`'s own shape, but returning bare
+    # nodes/initializers (not a whole model) so it can be dropped into a
+    # subgraph's own `node`/`initializer` lists.
+    rng = np.random.default_rng(seed)
+    w1 = rng.standard_normal((K, H)).astype(np.float32)
+    b1 = rng.standard_normal((H,)).astype(np.float32)
+    w2 = rng.standard_normal((H, Out)).astype(np.float32)
+    nodes = [
+        onnx.helper.make_node(
+            "Gemm", ["Xb", f"{prefix}W1", f"{prefix}B1"], [f"{prefix}h"]
+        ),
+        onnx.helper.make_node("Relu", [f"{prefix}h"], [f"{prefix}a"]),
+        onnx.helper.make_node("MatMul", [f"{prefix}a", f"{prefix}W2"], ["Yb"]),
+    ]
+    inits = [
+        _f32(w1, f"{prefix}W1"),
+        _f32(b1, f"{prefix}B1"),
+        _f32(w2, f"{prefix}W2"),
+    ]
+    return nodes, inits, dict(w1=w1, b1=b1, w2=w2)
+
+
+def _if_wrapped_mlp_model(K0=8, H0=16, Out0=4, K1=6, H1=12, OutB=3):
+    """A top-level MatMul(Gemm)->Relu->MatMul chain (`W1t`/`W2t`) PLUS an
+    ``If`` node whose `then_branch`/`else_branch` each carry their OWN
+    independent, identically-shaped MLP chain (`then_*`/`else_*`), with
+    their own weights living only in that branch's own `initializer` list
+    -- the core repro from this module's own subgraph-recursion
+    investigation: real prunable compute inside a plain ``If``'s branches,
+    invisible to every pass in this module before :func:`_iter_subgraphs`.
+    `Xb` (the branch chains' shared activation input) is an ordinary
+    top-level graph input, read by both branches purely via implicit
+    capture (an ``If`` branch subgraph takes no formal inputs of its own).
+    `cond` selects which branch actually executes at run time -- the
+    caller drives both `True` and `False` through `InferenceSession` to
+    exercise (and verify) both branches' own pruning independently, not
+    just whichever one happens to be tested first.
+    """
+    rng = np.random.default_rng(0)
+    w1t = rng.standard_normal((K0, H0)).astype(np.float32)
+    b1t = rng.standard_normal((H0,)).astype(np.float32)
+    w2t = rng.standard_normal((H0, Out0)).astype(np.float32)
+    top_nodes = [
+        onnx.helper.make_node("Gemm", ["X0", "W1t", "B1t"], ["ht"]),
+        onnx.helper.make_node("Relu", ["ht"], ["at"]),
+        onnx.helper.make_node("MatMul", ["at", "W2t"], ["Y0"]),
+    ]
+    top_inits = [_f32(w1t, "W1t"), _f32(b1t, "B1t"), _f32(w2t, "W2t")]
+
+    then_nodes, then_inits, then_cfg = _mlp_branch_nodes(K1, H1, OutB, "then_", seed=1)
+    else_nodes, else_inits, else_cfg = _mlp_branch_nodes(K1, H1, OutB, "else_", seed=2)
+
+    out_vi = onnx.helper.make_tensor_value_info(
+        "Yb", onnx.TensorProto.FLOAT, ["batch", OutB]
+    )
+    then_graph = onnx.helper.make_graph(
+        then_nodes, "then_graph", [], [out_vi], initializer=then_inits
+    )
+    else_graph = onnx.helper.make_graph(
+        else_nodes, "else_graph", [], [out_vi], initializer=else_inits
+    )
+    if_node = onnx.helper.make_node(
+        "If", ["cond"], ["Y1"], then_branch=then_graph, else_branch=else_graph
+    )
+
+    x0 = onnx.helper.make_tensor_value_info("X0", onnx.TensorProto.FLOAT, ["batch", K0])
+    xb = onnx.helper.make_tensor_value_info("Xb", onnx.TensorProto.FLOAT, ["batch", K1])
+    cond = onnx.helper.make_tensor_value_info("cond", onnx.TensorProto.BOOL, [])
+    y0 = onnx.helper.make_tensor_value_info(
+        "Y0", onnx.TensorProto.FLOAT, ["batch", Out0]
+    )
+    y1 = onnx.helper.make_tensor_value_info(
+        "Y1", onnx.TensorProto.FLOAT, ["batch", OutB]
+    )
+
+    graph = onnx.helper.make_graph(
+        [*top_nodes, if_node],
+        "g",
+        [x0, xb, cond],
+        [y0, y1],
+        initializer=top_inits,
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 17)]
+    )
+    model.ir_version = 10
+    onnx.checker.check_model(model)
+    return model, dict(w1t=w1t, b1t=b1t, w2t=w2t, then=then_cfg, else_=else_cfg)
+
+
+def _then_else_graphs(pruned_model):
+    if_node = next(n for n in pruned_model.graph.node if n.op_type == "If")
+    then_g = else_g = None
+    for attr in if_node.attribute:
+        if attr.name == "then_branch":
+            then_g = attr.g
+        elif attr.name == "else_branch":
+            else_g = attr.g
+    return then_g, else_g
+
+
+def test_iter_subgraphs_returns_only_top_graph_when_no_subgraphs_present():
+    # The regression-safety invariant every subgraph-aware function relies
+    # on: a model with no If/Loop/Scan node at all makes the new
+    # subgraph-aware loop run its existing per-graph body exactly once, on
+    # exactly the graph it always ran on -- byte-identical to before this
+    # change, not merely "close."
+    model = _mlp_model(K=8, H=32, Out=4)
+    graphs = onnxsim.pruning._iter_subgraphs(model.graph)
+    assert graphs == [model.graph]
+
+
+def test_iter_subgraphs_finds_nested_if_branches_recursively():
+    model, _cfg = _if_wrapped_mlp_model()
+    graphs = onnxsim.pruning._iter_subgraphs(model.graph)
+    names = [g.name for g in graphs]
+    # `graph` itself always comes first; `then_branch`/`else_branch` are
+    # each found (order between the two sibling branches isn't itself
+    # semantically meaningful -- only that both are reached).
+    assert names[0] == "g"
+    assert sorted(names[1:]) == ["else_graph", "then_graph"]
+
+
+def test_structured_pruning_no_subgraphs_matches_pre_existing_oracle_exactly():
+    # Same scenario (and same oracle) as
+    # test_structured_pruning_matches_manual_channel_deletion_exactly --
+    # restated here explicitly as this change's own regression-safety
+    # test: a subgraph-free model's pruning output is unaffected by
+    # apply_structured_pruning becoming subgraph-aware.
+    K, H, Out = 8, 32, 4
+    model = _mlp_model(K=K, H=H, Out=Out, bias=True)
+    orig = {t.name: onnx.numpy_helper.to_array(t) for t in model.graph.initializer}
+    w1, b1, w2 = orig["W1"], orig["B1"], orig["W2"]
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    keep = _oracle_keep_indices(w1, H // 2)
+
+    rng = np.random.default_rng(1)
+    x = rng.standard_normal((6, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+
+    h = x @ w1[:, keep] + b1[keep]
+    a = np.maximum(h, 0)
+    y_oracle = a @ w2[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_prunes_top_level_and_both_if_branches():
+    # The core repro: apply_structured_pruning must now match and prune
+    # the chain inside BOTH `then_branch` and `else_branch` (each with its
+    # own independent weights), not just the top-level chain -- verified
+    # both by initializer shape and by driving real execution (through
+    # InferenceSession) into EACH branch via `cond`, comparing against an
+    # independently reconstructed "already pruned" numpy oracle for that
+    # branch's own weights, plus a full-model onnx.checker.check_model
+    # pass on the pruned model (including its subgraphs).
+    K0, H0, Out0 = 8, 16, 4
+    K1, H1, OutB = 6, 12, 3
+    model, cfg = _if_wrapped_mlp_model(K0=K0, H0=H0, Out0=Out0, K1=K1, H1=H1, OutB=OutB)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    top_inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(top_inits["W1t"].dims) == [K0, H0 // 2]
+    assert list(top_inits["W2t"].dims) == [H0 // 2, Out0]
+
+    then_g, else_g = _then_else_graphs(pruned)
+    then_inits = {t.name: t for t in then_g.initializer}
+    else_inits = {t.name: t for t in else_g.initializer}
+    assert list(then_inits["then_W1"].dims) == [K1, H1 // 2]
+    assert list(then_inits["then_W2"].dims) == [H1 // 2, OutB]
+    assert list(else_inits["else_W1"].dims) == [K1, H1 // 2]
+    assert list(else_inits["else_W2"].dims) == [H1 // 2, OutB]
+
+    rng = np.random.default_rng(5)
+    x0 = rng.standard_normal((3, K0)).astype(np.float32)
+    xb = rng.standard_normal((3, K1)).astype(np.float32)
+
+    y0_true, y1_then = _run(pruned, {"X0": x0, "Xb": xb, "cond": np.array(True)})
+    y0_false, y1_else = _run(pruned, {"X0": x0, "Xb": xb, "cond": np.array(False)})
+
+    def _oracle(branch_cfg, keep_count):
+        w1, b1, w2 = branch_cfg["w1"], branch_cfg["b1"], branch_cfg["w2"]
+        keep = _oracle_keep_indices(w1, keep_count)
+        h = xb @ w1[:, keep] + b1[keep]
+        a = np.maximum(h, 0)
+        return a @ w2[keep, :]
+
+    np.testing.assert_allclose(
+        y1_then, _oracle(cfg["then"], H1 // 2), rtol=1e-5, atol=1e-5
+    )
+    np.testing.assert_allclose(
+        y1_else, _oracle(cfg["else_"], H1 // 2), rtol=1e-5, atol=1e-5
+    )
+
+    keep_top = _oracle_keep_indices(cfg["w1t"], H0 // 2)
+    h0 = x0 @ cfg["w1t"][:, keep_top] + cfg["b1t"][keep_top]
+    a0 = np.maximum(h0, 0)
+    y0_oracle = a0 @ cfg["w2t"][keep_top, :]
+    np.testing.assert_allclose(y0_true, y0_oracle, rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(y0_false, y0_oracle, rtol=1e-5, atol=1e-5)
+
+
+def _implicit_capture_model(K=6, H=12, Out=5, seed=3):
+    """A ``then_branch`` whose own producer (`W1`) and Relu look exactly
+    like the first half of an ordinary matchable chain, but whose
+    "consumer" MatMul reads `W_shared` -- a weight that exists ONLY in the
+    TOP-LEVEL graph's own `initializer` list, reached from inside the
+    subgraph purely by implicit capture. `W_shared` is also given a
+    genuine top-level use (`Identity`) so it's an ordinary, real top-level
+    initializer, not merely dead weight the subgraph happens to name.
+    """
+    rng = np.random.default_rng(seed)
+    w1 = rng.standard_normal((K, H)).astype(np.float32)
+    b1 = rng.standard_normal((H,)).astype(np.float32)
+    w_shared = rng.standard_normal((H, Out)).astype(np.float32)
+
+    then_nodes = [
+        onnx.helper.make_node("Gemm", ["Xb", "W1", "B1"], ["h"]),
+        onnx.helper.make_node("Relu", ["h"], ["a"]),
+        onnx.helper.make_node("MatMul", ["a", "W_shared"], ["Yb"]),
+    ]
+    then_inits = [_f32(w1, "W1"), _f32(b1, "B1")]
+    out_vi = onnx.helper.make_tensor_value_info(
+        "Yb", onnx.TensorProto.FLOAT, ["batch", Out]
+    )
+    then_graph = onnx.helper.make_graph(
+        then_nodes, "then_graph", [], [out_vi], initializer=then_inits
+    )
+
+    w_else = rng.standard_normal((K, Out)).astype(np.float32)
+    else_nodes = [onnx.helper.make_node("MatMul", ["Xb", "WElse"], ["Yb"])]
+    else_inits = [_f32(w_else, "WElse")]
+    else_graph = onnx.helper.make_graph(
+        else_nodes, "else_graph", [], [out_vi], initializer=else_inits
+    )
+
+    if_node = onnx.helper.make_node(
+        "If", ["cond"], ["Y1"], then_branch=then_graph, else_branch=else_graph
+    )
+    top_nodes = [
+        if_node,
+        onnx.helper.make_node("Identity", ["W_shared"], ["WSharedOut"]),
+    ]
+
+    xb = onnx.helper.make_tensor_value_info("Xb", onnx.TensorProto.FLOAT, ["batch", K])
+    cond = onnx.helper.make_tensor_value_info("cond", onnx.TensorProto.BOOL, [])
+    y1 = onnx.helper.make_tensor_value_info(
+        "Y1", onnx.TensorProto.FLOAT, ["batch", Out]
+    )
+    wshared_out = onnx.helper.make_tensor_value_info(
+        "WSharedOut", onnx.TensorProto.FLOAT, [H, Out]
+    )
+
+    graph = onnx.helper.make_graph(
+        top_nodes,
+        "g",
+        [xb, cond],
+        [y1, wshared_out],
+        initializer=[_f32(w_shared, "W_shared")],
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 17)]
+    )
+    model.ir_version = 10
+    onnx.checker.check_model(model)
+    return model, dict(w1=w1, b1=b1, w_shared=w_shared)
+
+
+def test_structured_pruning_declines_chain_needing_implicitly_captured_parent_weight():
+    # The correctness subtlety this module's own "Subgraph recursion"
+    # section comment calls out by name: a subgraph chain that would
+    # otherwise match, except its consumer weight only resolves via
+    # implicit capture from the PARENT graph's own initializer list, must
+    # be declined outright -- never matched by mistakenly reaching into
+    # the parent's own initializer_map, and never corrupting that parent
+    # initializer (which a sibling/parent pass legitimately also uses).
+    model, cfg = _implicit_capture_model()
+
+    then_g, _else_g = onnxsim.pruning._iter_subgraphs(model.graph)[1:3][0], None
+    chains = onnxsim.pruning._find_chains(then_g)
+    assert chains == []  # declined: W_shared isn't in then_graph's own initializer
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    top_inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(top_inits["W_shared"].dims) == list(cfg["w_shared"].shape)
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(top_inits["W_shared"]), cfg["w_shared"]
+    )
+
+    then_g_pruned, _else_g_pruned = _then_else_graphs(pruned)
+    then_inits = {t.name: t for t in then_g_pruned.initializer}
+    assert list(then_inits["W1"].dims) == list(cfg["w1"].shape)
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(then_inits["W1"]), cfg["w1"]
+    )
+
+    rng = np.random.default_rng(9)
+    xb = rng.standard_normal((3, 6)).astype(np.float32)
+    (y1, _wshared_out) = _run(pruned, {"Xb": xb, "cond": np.array(True)})
+    assert y1.shape == (3, 5)
+
+
+def test_weight_sparsity_counts_subgraph_initializers_too():
+    # Deliberately leave every TOP-LEVEL initializer untouched (so a
+    # top-level-only computation would report exactly 0.0) and zero out
+    # only a nested subgraph's own weight -- the sharpest possible
+    # demonstration that weight_sparsity's own pooled number really does
+    # include subgraph weights, not merely "a slightly different number
+    # that happens not to contradict it."
+    model, _cfg = _if_wrapped_mlp_model()
+
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+
+    then_g, _else_g = _then_else_graphs(out)
+    then_inits = {t.name: t for t in then_g.initializer}
+    then_w1 = onnx.numpy_helper.to_array(then_inits["then_W1"]).copy()
+    then_w1[:] = 0.0
+    then_inits["then_W1"].CopyFrom(
+        onnx.numpy_helper.from_array(then_w1, name="then_W1")
+    )
+
+    reported = onnxsim.weight_sparsity(out)
+
+    top_level_only_zeros = 0
+    top_level_only_total = 0
+    top_level_imap = {t.name: t for t in out.graph.initializer}
+    for _, _, w_name, _, _ in onnxsim.pruning._candidates(out.graph):
+        w = onnx.numpy_helper.to_array(top_level_imap[w_name])
+        top_level_only_zeros += int(np.count_nonzero(w == 0))
+        top_level_only_total += w.size
+    assert top_level_only_zeros == 0  # nothing at the top level was touched
+
+    zeros = 0
+    total = 0
+    for g in onnxsim.pruning._iter_subgraphs(out.graph):
+        imap = {t.name: t for t in g.initializer}
+        for _, _, w_name, _, _ in onnxsim.pruning._candidates(g):
+            w = onnx.numpy_helper.to_array(imap[w_name])
+            zeros += int(np.count_nonzero(w == 0))
+            total += w.size
+    expected = zeros / total
+
+    assert expected > 0.0  # the subgraph's own zeroed weight does count
+    assert reported == pytest.approx(expected)
+    # Strictly more than the (zero) top-level-only number -- the
+    # pre-existing top-level-only computation this module's own "Subgraph
+    # recursion" section comment says would otherwise be actively
+    # misleading, not merely incomplete.
+    assert reported > top_level_only_zeros / max(top_level_only_total, 1)
+
+
+def test_magnitude_pruning_masks_subgraph_weights():
+    model, _cfg = _if_wrapped_mlp_model()
+    pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    top_inits = {t.name: t for t in pruned.graph.initializer}
+    w1t = onnx.numpy_helper.to_array(top_inits["W1t"])
+    assert np.mean(w1t == 0) == pytest.approx(0.5, abs=0.05)
+
+    then_g, else_g = _then_else_graphs(pruned)
+    then_inits = {t.name: t for t in then_g.initializer}
+    else_inits = {t.name: t for t in else_g.initializer}
+    then_w1 = onnx.numpy_helper.to_array(then_inits["then_W1"])
+    else_w1 = onnx.numpy_helper.to_array(else_inits["else_W1"])
+    assert np.mean(then_w1 == 0) == pytest.approx(0.5, abs=0.05)
+    assert np.mean(else_w1 == 0) == pytest.approx(0.5, abs=0.05)
+
+
+def test_magnitude_pruning_global_sparsity_pools_across_top_level_and_subgraphs():
+    model, _cfg = _if_wrapped_mlp_model()
+    pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.3, global_sparsity=True)
+    onnx.checker.check_model(pruned)
+
+    top_inits = {t.name: t for t in pruned.graph.initializer}
+    then_g, else_g = _then_else_graphs(pruned)
+    then_inits = {t.name: t for t in then_g.initializer}
+    else_inits = {t.name: t for t in else_g.initializer}
+
+    total = 0
+    zeros = 0
+    for name_map, names in [
+        (top_inits, ["W1t", "W2t"]),
+        (then_inits, ["then_W1", "then_W2"]),
+        (else_inits, ["else_W1", "else_W2"]),
+    ]:
+        for name in names:
+            arr = onnx.numpy_helper.to_array(name_map[name])
+            total += arr.size
+            zeros += int(np.count_nonzero(arr == 0))
+
+    # One single global cutoff pooled across every matched layer in every
+    # graph -- not each graph/layer independently hitting 0.3 on its own.
+    assert zeros / total == pytest.approx(0.3, abs=0.02)
+
+
+def _attention_branch_nodes(K, H, D, Out, prefix, seed):
+    rng = np.random.default_rng(seed)
+    Nq = Nk = Nv = H * D
+    wqkv = rng.standard_normal((K, Nq + Nk + Nv)).astype(np.float32)
+    bqkv = rng.standard_normal((Nq + Nk + Nv,)).astype(np.float32)
+    wout = rng.standard_normal((Nv, Out)).astype(np.float32)
+    nodes = [
+        onnx.helper.make_node(
+            "Attention",
+            ["Xb", f"{prefix}Wqkv", f"{prefix}Bqkv"],
+            [f"{prefix}ctx"],
+            domain="com.microsoft",
+            num_heads=H,
+            qkv_hidden_sizes=[Nq, Nk, Nv],
+        ),
+        onnx.helper.make_node("MatMul", [f"{prefix}ctx", f"{prefix}Wout"], ["Yb"]),
+    ]
+    inits = [
+        _f32(wqkv, f"{prefix}Wqkv"),
+        _f32(bqkv, f"{prefix}Bqkv"),
+        _f32(wout, f"{prefix}Wout"),
+    ]
+    return nodes, inits
+
+
+def _if_attention_model(K=8, H=4, D=4, Out=6):
+    then_nodes, then_inits = _attention_branch_nodes(K, H, D, Out, "then_", seed=1)
+    else_nodes, else_inits = _attention_branch_nodes(K, H, D, Out, "else_", seed=2)
+    out_vi = onnx.helper.make_tensor_value_info(
+        "Yb", onnx.TensorProto.FLOAT, ["batch", "seq", Out]
+    )
+    then_graph = onnx.helper.make_graph(
+        then_nodes, "then_graph", [], [out_vi], initializer=then_inits
+    )
+    else_graph = onnx.helper.make_graph(
+        else_nodes, "else_graph", [], [out_vi], initializer=else_inits
+    )
+    if_node = onnx.helper.make_node(
+        "If", ["cond"], ["Y1"], then_branch=then_graph, else_branch=else_graph
+    )
+    xb = onnx.helper.make_tensor_value_info(
+        "Xb", onnx.TensorProto.FLOAT, ["batch", "seq", K]
+    )
+    cond = onnx.helper.make_tensor_value_info("cond", onnx.TensorProto.BOOL, [])
+    y1 = onnx.helper.make_tensor_value_info(
+        "Y1", onnx.TensorProto.FLOAT, ["batch", "seq", Out]
+    )
+    graph = onnx.helper.make_graph([if_node], "g", [xb, cond], [y1])
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 17),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    model.ir_version = 10
+    onnx.checker.check_model(model)
+    return model
+
+
+def test_attention_head_pruning_prunes_blocks_inside_if_branches():
+    K, H, D, Out = 8, 4, 4, 6
+    model = _if_attention_model(K=K, H=H, D=D, Out=Out)
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    then_g, else_g = _then_else_graphs(pruned)
+    for g, prefix in [(then_g, "then_"), (else_g, "else_")]:
+        inits = {t.name: t for t in g.initializer}
+        assert list(inits[f"{prefix}Wqkv"].dims) == [K, 3 * (H // 2) * D]
+        assert list(inits[f"{prefix}Wout"].dims) == [(H // 2) * D, Out]
+        node = next(n for n in g.node if n.op_type == "Attention")
+        num_heads = next(a.i for a in node.attribute if a.name == "num_heads")
+        assert num_heads == H // 2
+
+    rng = np.random.default_rng(4)
+    xb = rng.standard_normal((2, 3, K)).astype(np.float32)
+    (y_then,) = _run(pruned, {"Xb": xb, "cond": np.array(True)})
+    (y_else,) = _run(pruned, {"Xb": xb, "cond": np.array(False)})
+    assert y_then.shape == (2, 3, Out)
+    assert y_else.shape == (2, 3, Out)
+    assert np.all(np.isfinite(y_then))
+    assert np.all(np.isfinite(y_else))
+
+
+def test_wanda_pruning_still_leaves_subgraph_weights_untouched_documented_gap():
+    # apply_wanda_pruning is a calibration-data-driven function --
+    # deliberately NOT made subgraph-aware by this change (see this
+    # module's own top-of-file docstring, "Deliberately NOT subgraph-aware
+    # yet"). This test documents that gap explicitly: the top-level chain
+    # is pruned as always, but the subgraph's own identical chain is left
+    # completely, byte-for-byte untouched -- not approximated, not
+    # partially handled, exactly the same blind spot every function in
+    # this module had for every subgraph before this change, still true
+    # here on purpose.
+    model, cfg = _if_wrapped_mlp_model()
+
+    rng = np.random.default_rng(11)
+    calibration_data = [
+        {
+            "X0": rng.standard_normal((4, 8)).astype(np.float32),
+            "Xb": rng.standard_normal((4, 6)).astype(np.float32),
+            "cond": np.array(True),
+        }
+        for _ in range(3)
+    ]
+
+    pruned = onnxsim.apply_wanda_pruning(
+        model, sparsity=0.5, calibration_data=calibration_data
+    )
+    onnx.checker.check_model(pruned)
+
+    top_inits = {t.name: t for t in pruned.graph.initializer}
+    w1t = onnx.numpy_helper.to_array(top_inits["W1t"])
+    assert np.mean(w1t == 0) == pytest.approx(0.5, abs=0.05)  # top-level: pruned
+
+    then_g, _else_g = _then_else_graphs(pruned)
+    then_inits = {t.name: t for t in then_g.initializer}
+    then_w1 = onnx.numpy_helper.to_array(then_inits["then_W1"])
+    np.testing.assert_array_equal(then_w1, cfg["then"]["w1"])  # subgraph: untouched


### PR DESCRIPTION
## Summary

**Architectural gap, not a single-op addition.** Every function in this module operated only on `model.graph` (the top-level `GraphProto`) — none recursed into a nested `GraphProto` held inside a node's `GRAPH`/`GRAPHS`-typed attribute. This matters most for ONNX Runtime's own whole-model-generation deployment ops (`com.microsoft::BeamSearch`/`GreedySearch`/`Sampling`/`WhisperBeamSearch`, produced by `onnxruntime.transformers.models.{t5,gpt2,whisper}.convert_generation`), whose `decoder`/`encoder`/`init_decoder` attributes hold the *entire* transformer's weights — for such a model, essentially 100% of the actual prunable weight was invisible to every pass, with no error and no report entry. Plain `If`/`Loop`/`Scan` subgraphs have the identical blind spot. `weight_sparsity()` was actively misleading (not merely incomplete) on such a model.

## Empirically confirmed facts

- Confirmed live via `get_all_operator_schema()` that `BeamSearch`/`GreedySearch`/`Sampling`/`WhisperBeamSearch` all carry `decoder`/`encoder`/`init_decoder` as `AttrType.GRAPH` — confirmed independently in this review too.
- Built a repro (`If` node with a duplicated `MatMul→Relu→MatMul` chain in both `then_branch`/`else_branch`, matching an identical top-level chain): `apply_structured_pruning`/`apply_magnitude_pruning` correctly pruned the top-level copy but left both subgraph copies completely untouched; `weight_sparsity()` was fooled accordingly.

## What's added

One shared, genuinely recursive traversal primitive, `_iter_subgraphs(graph) -> [graph, *nested GraphProtos]`, keyed purely on `AttributeProto.type` (no op-name allowlist, so it needs no update when a future op adds another graph-typed attribute). Every existing per-graph chain-finder/matcher/slicer is reused **completely unchanged** — each returned graph is handed to the existing single-graph logic independently, never merged with any sibling/ancestor graph's state. This is what makes two correctness properties hold for free:

- **Implicit-capture scoping**: every matcher resolves weights/values strictly from `{t.name: t for t in graph.initializer}` built from the one graph it's given — never an enclosing scope — so a chain needing a parent-scope name simply fails to match and is declined, the same "decline rather than mis-slice" behavior this module already applies everywhere else.
- **No cross-scope initializer corruption**: since slicers only ever mutate a tensor found in the *current* graph's own initializer list, and a parent-scope tensor an inner graph merely reads via implicit capture is (by the point above) never even matched from inside that inner graph, there's no path by which subgraph processing could reach into and corrupt an ancestor/sibling graph's own tensor.

**Now subgraph-aware**: `weight_sparsity` (pooled across all graphs — otherwise actively misleading), `apply_magnitude_pruning` (including `global_sparsity`, pooled across all graphs), `apply_structured_pruning` (all chain families; `global_sparsity` pooled *per-graph*, not across the whole model — see that function's own docstring for why), `apply_attention_head_pruning` (all block families).

**Deliberately NOT subgraph-aware yet (documented explicitly, not a silent gap)**: every calibration-data-driven function (`apply_wanda_pruning`/`apply_structured_wanda_pruning`/`apply_attention_head_wanda_pruning`/`apply_sparsegpt_pruning`, and their `_analyze_*` mirrors) — these read probe values back via a real `InferenceSession` run of extra graph *outputs*, and hoisting a subgraph-internal tensor out through every enclosing `If`/`Loop`'s own output list is a materially different, higher-risk problem, out of scope here; and ~15 more `apply_structured_pruning_*` family variants (QDQ/MatMulNBits/MatMulBnb4/FP8/FP4/QOperator/DynamicQuantizeMatMul/MoE×4/embedding/transformer-block) — same mechanical `_iter_subgraphs`-loop treatment would apply, but wiring all of them through was judged too large a single PR's surface to review safely alongside the four entry points here.

## Test plan

- [x] `pytest tests/test_pruning.py -q` — 716 → 726 passed, zero regressions (10 new tests)
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — 0 errors (the established scoped command — the branch's own self-report of "25 errors in 7 files" was from a broader, non-standard mypy invocation and not a real issue, confirmed by re-running the correct command myself)
- [x] Core `If`-branch repro: both branches pruned/left correctly, whole model (including subgraphs) passes `onnx.checker.check_model`, real `InferenceSession` execution driven into both branches via `cond`, matched against independently reconstructed numpy oracles
- [x] Implicit-capture decline: a subgraph chain needing a parent-scope weight is declined outright, parent initializer left byte-unchanged
- [x] Subgraph-free regression safety (existing top-level-only fixtures behave identically)
- [x] `weight_sparsity`/`apply_magnitude_pruning`(+global)/`apply_attention_head_pruning` subgraph coverage

I independently re-confirmed the `BeamSearch`-family schema live, reviewed `_iter_subgraphs` and its four integration sites in detail (confirming the implicit-capture/no-cross-scope-corruption reasoning actually holds in the code, not just the comment), specifically re-ran `mypy onnxsim/pruning.py` myself to resolve the reported error-count discrepancy (0, matching baseline), spot-checked the implicit-capture and `weight_sparsity`-pooling tests for correctness, and ran the entire test/ruff/mypy suite myself in a clean environment before pushing.

---
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_