### PR TITLE
Recognize com.microsoft::GemmFastGelu in pruning's producer/bias matchers

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -1055,10 +1055,34 @@ def _match_matmul_like(node: onnx.NodeProto):
     ``C`` and ``alpha``/``beta``/``transA``/``transB`` are ``Gemm``'s own,
     byte-identical, verbatim -- only two *extra* attributes,
     ``activation``/``activation_alpha``/``activation_beta``/
-    ``activation_gamma``, are added on top). Every caller in this module
-    that reaches a weight-bearing MatMul/Gemm through this matcher --
-    producer, K-axis consumer, QDQ, ``MatMulNBits``-peer, ``lm_head`` -- so
-    gains FusedGemm recognition for free, with no per-call-site change.
+    ``activation_gamma``, are added on top) -- and ``com.microsoft::
+    GemmFastGelu`` -- ORT's separate ``FusionGemmFastGelu`` result (a plain
+    ``MatMul`` whose consumer ``FastGelu``'s own ``bias`` input is folded
+    in, collapsed into one node: ``GemmFastGelu(X, W, bias?) =
+    FastGelu(X @ W [+ bias])``). Confirmed live the same way: schema
+    (``get_all_operator_schema()``) is ``GemmFastGelu(X, W, bias?) -> Y``,
+    domain ``com.microsoft``, *no* attributes at all -- no ``transA``/
+    ``transB``/``alpha``/``beta`` equivalent, unlike ``Gemm``/``FusedGemm``
+    -- and the real fusion source shipped in the installed ``onnxruntime``
+    package (``onnxruntime/transformers/fusion_gemmfastgelu.py``,
+    ``FusionGemmFastGelu.fuse``) matches a plain ``MatMul`` feeding a
+    ``FastGelu`` and re-emits ``matmul.input[1 - weight_index]`` (the non-
+    weight operand) and ``matmul.input[weight_index]`` (``W``) verbatim,
+    unrepacked, as ``GemmFastGelu``'s own first two inputs -- so, exactly
+    like plain ``MatMul``, ``W`` is stored **not** transposed (``weight_
+    transposed=False``): a ``[K, N]`` weight consumed as ``X @ W``, never
+    Gemm's own optional ``transB``-flagged ``[N, K]`` layout. There is
+    correspondingly no ``weight_transposed`` ambiguity to resolve via any
+    attribute the way ``FusedGemm``'s own ``transB`` needs above -- it is
+    unconditionally ``False``. Every caller in this module that reaches a
+    weight-bearing MatMul/Gemm through this matcher -- producer, K-axis
+    consumer, QDQ, ``MatMulNBits``-peer, ``lm_head`` -- so gains FusedGemm
+    *and* GemmFastGelu recognition for free, with no per-call-site change
+    (beyond the small number of sites that special-case bias handling by a
+    literal ``op_type in ("Gemm", "FusedGemm")`` membership check, which
+    need their own, separate widening to include ``"GemmFastGelu"`` -- this
+    matcher only ever returns the ``(X, W)`` pair, never the bias, exactly
+    like it already does for plain ``MatMul``).
 
     This override is deliberately local to :mod:`onnxsim.pruning` rather
     than made to the shared :mod:`onnxsim.smoothquant` copy itself: that
@@ -1074,22 +1098,31 @@ def _match_matmul_like(node: onnx.NodeProto):
     wrapper, not the original) keeps the widening scoped to exactly this
     module's own matchers, as directed.
 
-    The baked-in ``activation`` (and its params) never needs reading here:
-    pruning a Gemm's output/input channels only ever removes/reindexes rows
-    or columns of ``A``/``B``/``C`` before the (elementwise, per-output-
-    channel) activation is applied -- an activation function's own value
-    depends only on its own channel's pre-activation scalar, never on any
-    other channel, so slicing commutes with it regardless of which
-    activation (or none) is baked in. This is why FusedGemm needs no
-    separate "walk past a fused activation" handling at all, unlike a
-    *plain* Gemm followed by a *separate* activation node (`_UNARY_PASS_
-    THROUGH`) -- there is no separate node to walk past here; the
-    activation is already "inside" this one node, invisible to every hop of
-    chain-topology matching, confirmed end-to-end (a hand-built
-    FusedGemm->FusedGemm chain, and a real Gemm->Relu->Gemm model put
-    through ORT's own optimizer to get a genuine FusedGemm, both pruned and
-    re-run through a real ``InferenceSession`` -- see this module's own
-    tests).
+    The baked-in activation (``FusedGemm``'s own ``activation`` attribute,
+    or ``GemmFastGelu``'s always-tanh-approximation Gelu) never needs
+    reading here: pruning a Gemm/MatMul's output/input channels only ever
+    removes/reindexes rows or columns of ``A``/``B``/``C`` before the
+    (elementwise, per-output-channel) activation is applied -- an
+    activation function's own value depends only on its own channel's
+    pre-activation scalar, never on any other channel, so slicing commutes
+    with it regardless of which activation (or none) is baked in. This is
+    why neither FusedGemm nor GemmFastGelu needs any separate "walk past a
+    fused activation" handling at all, unlike a *plain* Gemm/MatMul
+    followed by a *separate* activation node (`_UNARY_PASS_THROUGH`) --
+    there is no separate node to walk past here; the activation is already
+    "inside" this one node, invisible to every hop of chain-topology
+    matching, confirmed end-to-end (a hand-built FusedGemm->FusedGemm
+    chain, a real Gemm->Relu->Gemm model put through ORT's own optimizer to
+    get a genuine FusedGemm, and a hand-built GemmFastGelu producer/chain,
+    each pruned and re-run through a real ``InferenceSession`` -- see this
+    module's own tests; GemmFastGelu itself has no CPU kernel in this
+    environment's onnxruntime build -- confirmed via
+    ``get_all_operator_schema()`` registering only its schema, not a CPU
+    kernel, and a direct ``InferenceSession`` load raising ``NOT_IMPLEMENTED``
+    -- so its own tests execute the byte-identical, ``FusionGemmFastGelu``-
+    confirmed-equivalent unfused ``MatMul``+``FastGelu`` decomposition of
+    the (already-pruned) node's own sliced weight/bias to get a real,
+    runnable oracle, rather than running the fused node type itself).
     """
     if node.op_type == "FusedGemm":
         attrs = {a.name: a for a in node.attribute}
@@ -1109,6 +1142,10 @@ def _match_matmul_like(node: onnx.NodeProto):
         trans_b = attrs.get("transB")
         weight_transposed = bool(trans_b is not None and trans_b.i)
         return node.input[0], node.input[1], weight_transposed
+    if node.op_type == "GemmFastGelu" and node.domain == _FUSED_BIAS_GELU_DOMAIN:
+        if len(node.input) not in (2, 3):
+            return None
+        return node.input[0], node.input[1], False
     return _match_matmul_like_base(node)
 
 
@@ -3622,8 +3659,9 @@ def _match_producer(
     node: onnx.NodeProto, initializer_map: Dict[str, onnx.TensorProto]
 ) -> Optional[Tuple[str, bool, Optional[str], int]]:
     """If `node` is a MatMul/vanilla-Gemm with a constant 2-D float32
-    weight (and, for Gemm, either no bias or a constant one), returns
-    ``(weight_name, weight_transposed, bias_name_or_None, n_channels)``.
+    weight (and, for Gemm/FusedGemm/GemmFastGelu, either no bias or a
+    constant one), returns ``(weight_name, weight_transposed,
+    bias_name_or_None, n_channels)``.
     """
     match = _match_matmul_like(node)
     if match is None:
@@ -3637,7 +3675,7 @@ def _match_producer(
     ):
         return None
     bias_name = None
-    if node.op_type in ("Gemm", "FusedGemm") and len(node.input) == 3:
+    if node.op_type in ("Gemm", "FusedGemm", "GemmFastGelu") and len(node.input) == 3:
         bias_name = node.input[2]
         if bias_name not in initializer_map:
             return None  # non-constant bias -- can't safely prune it
@@ -11005,7 +11043,11 @@ def _match_matmul_qdq(
     dims = _weight_ref_dims(ref)
     out_channels, in_channels = dims[axis], dims[1 - axis]
     bias_name = None
-    if node.op_type in ("Gemm", "FusedGemm") and len(node.input) == 3 and node.input[2]:
+    if (
+        node.op_type in ("Gemm", "FusedGemm", "GemmFastGelu")
+        and len(node.input) == 3
+        and node.input[2]
+    ):
         bias_name = node.input[2]
         b_init = initializer_map.get(bias_name)
         if b_init is None or not _is_supported_float_dtype(b_init.data_type):
@@ -12505,7 +12547,11 @@ def _match_plain_matmul_nbits_peer(
 
     bias_init = None
     bias_name = None
-    if node.op_type in ("Gemm", "FusedGemm") and len(node.input) == 3 and node.input[2]:
+    if (
+        node.op_type in ("Gemm", "FusedGemm", "GemmFastGelu")
+        and len(node.input) == 3
+        and node.input[2]
+    ):
         bias_name = node.input[2]
         bias_init = initializer_map.get(bias_name)
         if bias_init is None or not _is_supported_float_dtype(bias_init.data_type):
@@ -26727,7 +26773,11 @@ def _match_lm_head_tail(
             and list(b_init.dims) in ([vocab_size], [1, vocab_size])
         )
 
-    if node.op_type in ("Gemm", "FusedGemm") and len(node.input) == 3 and node.input[2]:
+    if (
+        node.op_type in ("Gemm", "FusedGemm", "GemmFastGelu")
+        and len(node.input) == 3
+        and node.input[2]
+    ):
         bias_name = node.input[2]
         if not _valid_bias(bias_name):
             return _LM_HEAD_BIAS_INVALID
@@ -28762,6 +28812,7 @@ def _unstructured_not_eligible(graph: onnx.GraphProto, candidates: List) -> List
                 "MatMul",
                 "Gemm",
                 "FusedGemm",
+                "GemmFastGelu",
             )
             and not is_attn
         ):
@@ -29043,7 +29094,14 @@ def _structured_not_eligible(
                 matched_ids.update(id(h.node) for h in b.conv_pass_through)
     not_eligible = []
     for node in graph.node:
-        if node.op_type not in ("Conv", "FusedConv", "MatMul", "Gemm", "FusedGemm"):
+        if node.op_type not in (
+            "Conv",
+            "FusedConv",
+            "MatMul",
+            "Gemm",
+            "FusedGemm",
+            "GemmFastGelu",
+        ):
             continue
         if id(node) in matched_ids:
             continue
@@ -29358,6 +29416,7 @@ def _qdq_not_eligible(
             "MatMul",
             "Gemm",
             "FusedGemm",
+            "GemmFastGelu",
         ):
             continue
         if id(node) in matched_ids:

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -35418,6 +35418,283 @@ def test_structured_not_eligible_reports_unmatched_fusedgemm():
     assert report.not_eligible == ["FusedGemm 'Y'"]
 
 
+# --- GemmFastGelu (com.microsoft, FusionGemmFastGelu) ---------------------
+#
+# `com.microsoft::GemmFastGelu` is ONNX Runtime's own fusion of a plain
+# `MatMul` feeding a `FastGelu` (`FastGelu`'s own optional `bias` input
+# folded in) into one node -- confirmed live against this environment's
+# installed onnxruntime (1.29.0):
+#
+#   * Schema (`onnxruntime.capi.onnxruntime_pybind11_state
+#     .get_all_operator_schema()`): `GemmFastGelu(X, W, bias?) -> Y`, domain
+#     `com.microsoft`, **no attributes at all** -- no `transA`/`transB`/
+#     `alpha`/`beta` equivalent, unlike `Gemm`/`FusedGemm`.
+#   * The real fusion source shipped in the installed `onnxruntime` package
+#     (`onnxruntime/transformers/fusion_gemmfastgelu.py`,
+#     `FusionGemmFastGelu.fuse`) matches a plain `MatMul` feeding a
+#     `FastGelu` and re-emits `matmul.input[1 - weight_index]` (the non-
+#     weight operand) and `matmul.input[weight_index]` (`W`) verbatim,
+#     unrepacked, as `GemmFastGelu`'s own first two inputs -- a pure
+#     op-fusion, nothing quantization-related, nothing repacked, and `W` is
+#     stored the same way plain `MatMul`'s own weight always is (**not**
+#     transposed), never `Gemm`'s own optional `transB`-flagged layout.
+#   * This environment's onnxruntime has **no CPU kernel** for
+#     `GemmFastGelu` itself: `get_all_operator_schema()` registers only its
+#     schema (`GetOpSchema<GemmFastGelu_Microsoft_ver1>`), and a direct
+#     `onnxruntime.InferenceSession` load of a hand-built `GemmFastGelu`
+#     node raises `NOT_IMPLEMENTED` ("Could not find an implementation for
+#     GemmFastGelu(1) node") on `CPUExecutionProvider` -- unlike
+#     `FusedGemm`, which really does have one (`FusedGemm<T>::FusedGemm`,
+#     confirmed present in the same binary via `strings`). So every test
+#     below that needs to actually *execute* a (possibly pruned)
+#     `GemmFastGelu` node runs `_decompose_gemmfastgelu` first: it rewrites
+#     each `GemmFastGelu(X, W, bias?)` node, in place, into the literal
+#     unfused `MatMul(X, W) -> FastGelu(h, bias?)` pair the fusion source
+#     above confirms it's byte-identical to, reusing the exact same
+#     (already-pruned, where relevant) `W`/`bias` initializers -- so the
+#     real numbers actually being checked are still the pruned model's own
+#     real, sliced weights, executed through a real `InferenceSession`
+#     (`FastGelu` itself does have a CPU kernel -- this file's own
+#     `_FUSED_BIAS_GELU_OPS`-based tests above already run it directly) --
+#     only the fused node *type* is unfused for execution purposes, since
+#     the fused type has nowhere to run in this environment.
+#
+# Since `W`/`bias` are byte-identical to plain `MatMul`+`FastGelu`'s own
+# (see above), every producer/consumer/weight-only matcher in this module
+# that recognizes `MatMul` by a literal `op_type` check now also recognizes
+# `GemmFastGelu` via the shared `_match_matmul_like` choke point (see
+# `onnxsim/pruning.py`'s own diff) -- plus the small, separate set of
+# bias-handling call sites that special-case `("Gemm", "FusedGemm")` by a
+# literal `op_type in (...)` membership check, each widened to include
+# `"GemmFastGelu"` too (`_match_producer`, `_match_matmul_qdq`,
+# `_match_plain_matmul_nbits_peer`, `_match_lm_head_tail`). No new "walk
+# past an activation" chain-hop machinery is needed -- exactly like
+# `FusedGemm`, the activation (`FastGelu`'s own tanh-approximation Gelu) is
+# already baked into the node itself, invisible to chain-topology matching,
+# so pruning's channel-slicing simply commutes through it unchanged.
+
+
+def _decompose_gemmfastgelu(model):
+    """Rewrites every `com.microsoft::GemmFastGelu` node in `model` (a copy
+    -- the input is never mutated) into the literal unfused
+    `MatMul(X, W) -> FastGelu(h, bias?)` two-node sequence it is confirmed
+    byte-identical to (see this section's own top comment) -- needed only
+    because this environment's onnxruntime has no CPU kernel for
+    `GemmFastGelu` itself, so `_run` can't execute the fused node type
+    directly. Reuses the node's own `W`/`bias` initializer names verbatim
+    (no new initializers, no copying), so a caller can decompose a *pruned*
+    model and still be running its own real, sliced weights.
+    """
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    new_nodes = []
+    for i, node in enumerate(out.graph.node):
+        if node.op_type != "GemmFastGelu" or node.domain != "com.microsoft":
+            new_nodes.append(node)
+            continue
+        x_name, w_name = node.input[0], node.input[1]
+        bias_name = node.input[2] if len(node.input) == 3 and node.input[2] else None
+        (y_name,) = node.output
+        h_name = f"{y_name}__gemmfastgelu_h"
+        matmul = onnx.helper.make_node(
+            "MatMul", [x_name, w_name], [h_name], name=f"{node.name}__matmul"
+        )
+        fastgelu_inputs = [h_name, bias_name] if bias_name else [h_name]
+        fastgelu = onnx.helper.make_node(
+            "FastGelu",
+            fastgelu_inputs,
+            [y_name],
+            name=f"{node.name}__fastgelu",
+            domain="com.microsoft",
+        )
+        new_nodes.extend([matmul, fastgelu])
+    del out.graph.node[:]
+    out.graph.node.extend(new_nodes)
+    return out
+
+
+def _gemmfastgelu_producer_chain_model(w1, w2, b1=None):
+    K, H = w1.shape
+    Out = w2.shape[1]
+    initializer = [_f32(w1, "W1"), _f32(w2, "W2")]
+    if b1 is not None:
+        gemm1 = "h = com.microsoft.GemmFastGelu(X, W1, B1)"
+        initializer.append(_f32(b1, "B1"))
+    else:
+        gemm1 = "h = com.microsoft.GemmFastGelu(X, W1)"
+    return _fused_model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          {gemm1}
+          Y = MatMul(h, W2)
+        }}
+        """,
+        initializer=initializer,
+    )
+
+
+def test_gemmfastgelu_hand_built_node_matches_matmul_then_fastgelu_via_decompose():
+    # Confirms _decompose_gemmfastgelu itself is a faithful, meaningful
+    # rewrite: a hand-built GemmFastGelu node, decomposed and run, must
+    # match an independently hand-built plain MatMul->FastGelu model run
+    # the ordinary way -- both executed by a real InferenceSession.
+    K, H = 8, 6
+    rng = np.random.default_rng(79)
+    w = rng.standard_normal((K, H)).astype(np.float32)
+    b = rng.standard_normal((H,)).astype(np.float32)
+    fused = _fused_model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{H}] Y)
+        {{
+          Y = com.microsoft.GemmFastGelu(X, W, B)
+        }}
+        """,
+        initializer=[_f32(w, "W"), _f32(b, "B")],
+    )
+    onnx.checker.check_model(fused)
+    plain = _fused_model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{H}] Y)
+        {{
+          h = MatMul(X, W)
+          Y = com.microsoft.FastGelu(h, B)
+        }}
+        """,
+        initializer=[_f32(w, "W"), _f32(b, "B")],
+    )
+    rng_x = np.random.default_rng(80)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y_decomposed,) = _run(_decompose_gemmfastgelu(fused), {"X": x})
+    (y_plain,) = _run(plain, {"X": x})
+    np.testing.assert_allclose(y_decomposed, y_plain, rtol=1e-6, atol=1e-6)
+
+
+def test_structured_pruning_gemmfastgelu_producer_matches_oracle():
+    # The real gap this section closes: pruning._candidates(graph) returned
+    # nothing at all for a hand-built, fused GemmFastGelu node before this
+    # change (confirmed live before writing this test), so
+    # apply_structured_pruning left its W completely untouched. Now the
+    # producer role is recognized via the shared _match_matmul_like choke
+    # point, exactly like FusedGemm's own producer test above.
+    K, H, Out = 8, 32, 4
+    rng = np.random.default_rng(81)
+    w1 = rng.standard_normal((K, H)).astype(np.float32)
+    b1 = rng.standard_normal((H,)).astype(np.float32)
+    w2 = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _gemmfastgelu_producer_chain_model(w1, w2, b1=b1)
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    assert "GemmFastGelu" in {n.op_type for n in pruned.graph.node}
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [K, H // 2]
+    assert list(inits["B1"].dims) == [H // 2]  # bias slicing correctness
+    assert list(inits["W2"].dims) == [H // 2, Out]
+
+    keep = _oracle_keep_indices(w1, H // 2)
+    oracle = _gemmfastgelu_producer_chain_model(w1[:, keep], w2[keep, :], b1=b1[keep])
+
+    rng_x = np.random.default_rng(82)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(_decompose_gemmfastgelu(pruned), {"X": x})
+    (y_oracle,) = _run(_decompose_gemmfastgelu(oracle), {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_gemmfastgelu_producer_no_bias_matches_oracle():
+    # GemmFastGelu's own bias is optional (unlike Gemm/FusedGemm's required-
+    # when-present-but-schema-optional C) -- confirms the no-bias (2-input)
+    # shape is matched too, not just the biased one above.
+    K, H, Out = 8, 24, 4
+    rng = np.random.default_rng(83)
+    w1 = rng.standard_normal((K, H)).astype(np.float32)
+    w2 = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _gemmfastgelu_producer_chain_model(w1, w2, b1=None)
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.25)
+    onnx.checker.check_model(pruned)
+    keep = _oracle_keep_indices(w1, H - round(H * 0.25))
+    oracle = _gemmfastgelu_producer_chain_model(w1[:, keep], w2[keep, :], b1=None)
+
+    rng_x = np.random.default_rng(84)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(_decompose_gemmfastgelu(pruned), {"X": x})
+    (y_oracle,) = _run(_decompose_gemmfastgelu(oracle), {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_two_node_matmul_fastgelu_regression():
+    # Regression-safety check: the pre-existing, separate two-node MatMul +
+    # FastGelu path (_FUSED_BIAS_GELU_OPS/_match_fused_bias_gelu, unrelated
+    # to this section's own _match_matmul_like widening) must still prune
+    # identically to before -- FastGelu itself has a real CPU kernel here,
+    # so this one runs directly, no decomposition needed.
+    K, H, Out = 8, 16, 4
+    rng = np.random.default_rng(85)
+    w1 = rng.standard_normal((K, H)).astype(np.float32)
+    b1 = rng.standard_normal((H,)).astype(np.float32)
+    w2 = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _fused_model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          up = MatMul(X, W1)
+          h = com.microsoft.FastGelu(up, Bias1)
+          Y = MatMul(h, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(b1, "Bias1"), _f32(w2, "W2")],
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Bias1"].dims) == [H // 2]
+
+    keep = _oracle_keep_indices(w1, H // 2)
+    rng_x = np.random.default_rng(86)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    h = x @ w1[:, keep] + b1[keep]
+    a = 0.5 * h * (1.0 + np.tanh(0.7978845608028654 * (h + 0.044715 * h**3)))
+    y_oracle = a @ w2[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_structured_not_eligible_reports_unmatched_gemmfastgelu():
+    # A GemmFastGelu that genuinely can't be matched (4 inputs -- GemmFastGelu
+    # has no attribute to misconfigure the way FusedGemm's transA=1 does
+    # above, so this uses the arity check _match_matmul_like's own
+    # GemmFastGelu branch applies instead) is a real, reportable decline
+    # this section can name, exactly like an unmatched FusedGemm already is
+    # -- confirms the diagnostic-eligibility sites were widened too, not
+    # just the pruning-correctness ones.
+    K, H = 8, 6
+    rng = np.random.default_rng(87)
+    w = rng.standard_normal((K, H)).astype(np.float32)
+    b = rng.standard_normal((H,)).astype(np.float32)
+    extra = rng.standard_normal((H,)).astype(np.float32)
+    model = _fused_model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{H}] Y)
+        {{
+          Y = com.microsoft.GemmFastGelu(X, W, B, Extra)
+        }}
+        """,
+        initializer=[_f32(w, "W"), _f32(b, "B"), _f32(extra, "Extra")],
+    )
+    onnx.checker.check_model(model)
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_structured_pruning, sparsity=0.5
+    )
+    assert report.not_eligible == ["GemmFastGelu 'Y'"]
+
+
 # --- Subgraph recursion --------------------------------------------------
 #
 # Covers :func:`onnxsim.pruning._iter_subgraphs` and the four entry points


### PR DESCRIPTION
## Summary

`com.microsoft::GemmFastGelu` — ORT's own fusion of a plain `MatMul` feeding a `FastGelu` (with `FastGelu`'s own `bias` input folded in) into one node — was unrecognized anywhere in this module, even though the equivalent two-separate-node shape is already fully supported via `_match_fused_bias_gelu`/`_FUSED_BIAS_GELU_OPS`. Same class of gap round 7 closed for `FusedConv`/`FusedGemm`.

## Empirically confirmed facts

- Live schema: `GemmFastGelu(X, W, bias?) -> Y`, domain `com.microsoft`, **no attributes at all** — no `transA`/`transB`/`alpha`/`beta` equivalent, unlike `Gemm`/`FusedGemm`. Confirmed independently in this review too.
- Real fusion source (`onnxruntime/transformers/fusion_gemmfastgelu.py`, `FusionGemmFastGelu.fuse`): matches a plain `MatMul` feeding a `FastGelu`, re-emits the weight input verbatim, unrepacked — so `W` is stored **not transposed** (`weight_transposed=False`), the same convention as plain `MatMul`, never `Gemm`'s optional `transB` layout. No ambiguity to resolve via any attribute (there are none).
- Confirmed the real gap live: a hand-built `GemmFastGelu` node made `_candidates(graph)` return `[]` and left `apply_structured_pruning`'s `W` completely untouched.
- **No CPU kernel exists for this op** in the installed onnxruntime — confirmed via schema-only registration (`GetOpSchema<GemmFastGelu_Microsoft_ver1>`) and, independently in this review, via `strings` on the ORT binary: a `FusedGemm<T>::FusedGemm` kernel constructor symbol exists, but no equivalent `GemmFastGelu<T>::GemmFastGelu` one. Tests therefore decompose the (already-pruned) node's sliced weight/bias into the byte-identical unfused `MatMul`+`FastGelu` pair to get a real, runnable `InferenceSession` oracle.
- Same "no separate walk-past-activation hop needed" reasoning as `FusedGemm`: pruning only slices whole rows/columns, which commutes with any per-channel elementwise activation baked into the node.

## What's added

Widened the single choke point `_match_matmul_like` to recognize `GemmFastGelu` (domain-gated via the existing `_FUSED_BIAS_GELU_DOMAIN` constant, `weight_transposed=False` unconditionally). Widened the 4 call sites that special-case bias handling via a literal `op_type in ("Gemm", "FusedGemm")` check (`_match_producer`, `_match_matmul_qdq`, `_match_plain_matmul_nbits_peer`, `_match_lm_head_tail`) and the 3 diagnostic `not_eligible` filters (`_unstructured_not_eligible`, `_structured_not_eligible`, `_qdq_not_eligible`) to include it too.

## Test plan

- [x] `pytest tests/test_pruning.py -q` — 761 → 766 passed, zero regressions (5 new tests)
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — 0 errors, unchanged from master's baseline
- [x] Producer-role structured pruning (both biased and bias-optional) against an independently-reconstructed already-pruned oracle, via decomposed real `InferenceSession` execution
- [x] Bias-slicing correctness
- [x] Regression check on the pre-existing two-node `MatMul`+`FastGelu` path
- [x] `not_eligible` diagnostic for a declined (4-input) `GemmFastGelu` node

I independently re-verified the live schema myself, confirmed the no-CPU-kernel claim via my own `strings` check on the ORT binary (finding `FusedGemm`'s kernel constructor but no `GemmFastGelu` equivalent), reviewed the full diff, and ran the entire test/ruff/mypy suite myself in a clean environment before pushing.

---
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_