### PR TITLE
Make _analyze_magnitude_pruning/_analyze_structured_pruning/_analyze_attention_head_pruning subgraph-aware

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -915,12 +915,9 @@ follow-up round, exactly the mechanical
 :func:`apply_structured_pruning` established, applied to each family's own
 `apply_*`/`_analyze_*` pair (every `_analyze_*` mirror got the identical
 treatment its own `apply_*` did, for the same "report what a real call
-would actually do" reason the dry-run family exists at all -- unlike this
-note's original four, whose own `_analyze_*` mirrors -- `_analyze_magnitude_pruning`,
-`_analyze_structured_pruning`, `_analyze_attention_head_pruning` --
-:func:`weight_sparsity` has none -- were left NOT subgraph-aware by the
-round that added this note, a pre-existing gap this follow-up round did
-not touch since none of those three were in its own assigned scope):
+would actually do" reason the dry-run family exists at all --
+:func:`weight_sparsity` has no `_analyze_*` mirror to extend, so it is
+untouched by this round):
 :func:`apply_structured_pruning_qdq`, :func:`apply_structured_pruning_matmul_nbits`
 (including its own fused `MatMulNBitsMlp`/`MatMulNBitsQkv` shapes; a nested
 subgraph's `value_info_by_name` is narrowed the same conservative way
@@ -973,6 +970,30 @@ case would be handled -- a documented, conservative gap, not a correctness
 risk; see that function's own docstring for the full reasoning behind
 every one of these choices).
 
+Extended in a later round still to the three `_analyze_*` mirrors the very
+first paragraph above's own round left out purely because they fell
+outside that round's own assigned scope, not any technical obstacle --
+their own `apply_*` counterparts were already subgraph-aware from that
+first paragraph onward: :func:`_analyze_magnitude_pruning` (including its
+own `global_sparsity` mode, pooled every matched layer across every
+graph -- top-level and every nested subgraph alike -- into the one shared
+global ranking, the identical whole-model pooling
+:func:`apply_magnitude_pruning`'s own `global_sparsity` mode already
+uses); :func:`_analyze_structured_pruning` (every chain family it
+matches, reported inside every graph the same way
+:func:`apply_structured_pruning` prunes it in -- `global_sparsity=True`
+remains a flat `NotImplementedError` for this dry-run function regardless
+of subgraphs, per :func:`analyze_pruning_sensitivity`'s own docstring, so
+there is no separate per-graph-vs-whole-model pooling decision to make
+here the way there was for the unstructured family above); and
+:func:`_analyze_attention_head_pruning` (every block family it matches,
+mirroring the same conservatively-narrower-in-subgraphs
+`value_info_by_name` behavior :func:`apply_attention_head_pruning`'s own
+docstring already establishes -- see that function's own docstring --
+so this report never over-predicts what a nested subgraph's own dynamic
+per-head bias/mask/head_sink classification would actually do; a real
+call would leave those cases untouched, and so does this report).
+
 Deliberately NOT subgraph-aware, a scope decision rather than an
 oversight -- each remains exactly as top-level-graph-only as it already
 was:
@@ -1004,13 +1025,6 @@ was:
   correctly fall back to without declining the whole function outright, so
   those three ARE subgraph-aware for matching/slicing/committing -- see the
   paragraph above.
-- :func:`analyze_pruning_sensitivity` itself dispatches to nineteen
-  separate `_analyze_*` implementations (one per supported `apply_fn`),
-  each with its own bespoke top-level-graph-only body mirroring its real
-  `apply_*` counterpart -- extending it would mean the same per-function
-  treatment as the point above, all nineteen of them, not a change to
-  :func:`analyze_pruning_sensitivity` itself; deferred for the same
-  review-size reason.
 """
 
 from __future__ import annotations
@@ -28781,8 +28795,7 @@ def _unstructured_family(node: onnx.NodeProto, is_conv: bool) -> str:
 
 
 def _analyze_unstructured(
-    graph: onnx.GraphProto,
-    candidates: List,
+    graph_candidates: List[Tuple[onnx.GraphProto, List]],
     compute_importance: Callable[
         [onnx.NodeProto, str, str, bool, bool, onnx.TensorProto, np.ndarray],
         np.ndarray,
@@ -28802,20 +28815,40 @@ def _analyze_unstructured(
     ``(node, x_name, w_name, weight_transposed, is_conv, w_init, w_nk)`` and
     returns an importance array shaped like `w_nk` -- plain ``|w_nk|`` for
     magnitude, :func:`_wanda_importance`'s metric for Wanda.
+
+    `graph_candidates` is a ``(graph, candidates)`` pair per graph to
+    analyze, `candidates` being that graph's own :func:`_candidates` result.
+    :func:`_analyze_magnitude_pruning` passes one entry per
+    :func:`_iter_subgraphs`-returned graph (top-level and every nested
+    ``If``/``Loop``/``Scan``/``BeamSearch``-family subgraph alike), mirroring
+    :func:`apply_magnitude_pruning`'s own subgraph awareness (see this
+    module's own "Subgraph recursion" section comment);
+    :func:`_analyze_wanda_pruning` always passes exactly one entry, its own
+    top-level graph only -- deliberately not subgraph-aware, see this
+    module's own top-of-file docstring for why. In `global_sparsity` mode
+    every candidate from every `graph_candidates` entry is pooled into one
+    shared ranking, so the pooling scope is whatever span of graphs the
+    caller itself passed in -- the whole model for
+    :func:`_analyze_magnitude_pruning` (consistent with
+    :func:`apply_magnitude_pruning`'s own `global_sparsity` mode, which
+    pools the same way), a single graph for :func:`_analyze_wanda_pruning`.
     """
-    initializer_map = {t.name: t for t in graph.initializer}
     layers: List[PruningLayerSensitivity] = []
+    not_eligible: List[str] = []
 
     if global_sparsity:
         entries = []
-        for node, x_name, w_name, weight_transposed, is_conv in candidates:
-            w_init = initializer_map[w_name]
-            w = onnx.numpy_helper.to_array(w_init).astype(np.float64)
-            w_nk = _weight_to_nk(w, weight_transposed, is_conv)
-            importance = compute_importance(
-                node, x_name, w_name, weight_transposed, is_conv, w_init, w_nk
-            )
-            entries.append((node, is_conv, w_nk, importance))
+        for graph, candidates in graph_candidates:
+            initializer_map = {t.name: t for t in graph.initializer}
+            for node, x_name, w_name, weight_transposed, is_conv in candidates:
+                w_init = initializer_map[w_name]
+                w = onnx.numpy_helper.to_array(w_init).astype(np.float64)
+                w_nk = _weight_to_nk(w, weight_transposed, is_conv)
+                importance = compute_importance(
+                    node, x_name, w_name, weight_transposed, is_conv, w_init, w_nk
+                )
+                entries.append((node, is_conv, w_nk, importance))
+            not_eligible.extend(_unstructured_not_eligible(graph, candidates))
 
         pooled = (
             np.concatenate([importance.reshape(-1) for *_, importance in entries])
@@ -28854,35 +28887,36 @@ def _analyze_unstructured(
                 )
             )
     else:
-        for node, x_name, w_name, weight_transposed, is_conv in candidates:
-            w_init = initializer_map[w_name]
-            w = onnx.numpy_helper.to_array(w_init).astype(np.float64)
-            w_nk = _weight_to_nk(w, weight_transposed, is_conv)
-            importance = compute_importance(
-                node, x_name, w_name, weight_transposed, is_conv, w_init, w_nk
-            )
-            mask = (
-                _nm_mask(importance, n, m)
-                if n is not None and m is not None
-                else _sparsity_mask(importance, sparsity)
-            )
-            would_drop = int((~mask).sum())
-            margin = _normalized_margin(importance, mask) if would_drop else None
-            layers.append(
-                PruningLayerSensitivity(
-                    label=_node_label(node),
-                    family=_unstructured_family(node, is_conv),
-                    total=int(mask.size),
-                    would_drop=would_drop,
-                    margin=margin,
-                    importance_min=float(importance.min()),
-                    importance_max=float(importance.max()),
+        for graph, candidates in graph_candidates:
+            initializer_map = {t.name: t for t in graph.initializer}
+            for node, x_name, w_name, weight_transposed, is_conv in candidates:
+                w_init = initializer_map[w_name]
+                w = onnx.numpy_helper.to_array(w_init).astype(np.float64)
+                w_nk = _weight_to_nk(w, weight_transposed, is_conv)
+                importance = compute_importance(
+                    node, x_name, w_name, weight_transposed, is_conv, w_init, w_nk
                 )
-            )
+                mask = (
+                    _nm_mask(importance, n, m)
+                    if n is not None and m is not None
+                    else _sparsity_mask(importance, sparsity)
+                )
+                would_drop = int((~mask).sum())
+                margin = _normalized_margin(importance, mask) if would_drop else None
+                layers.append(
+                    PruningLayerSensitivity(
+                        label=_node_label(node),
+                        family=_unstructured_family(node, is_conv),
+                        total=int(mask.size),
+                        would_drop=would_drop,
+                        margin=margin,
+                        importance_min=float(importance.min()),
+                        importance_max=float(importance.max()),
+                    )
+                )
+            not_eligible.extend(_unstructured_not_eligible(graph, candidates))
 
-    return PruningSensitivityReport(
-        layers=layers, not_eligible=_unstructured_not_eligible(graph, candidates)
-    )
+    return PruningSensitivityReport(layers=layers, not_eligible=not_eligible)
 
 
 def _analyze_magnitude_pruning(
@@ -28897,6 +28931,16 @@ def _analyze_magnitude_pruning(
     (:func:`_sparsity_mask`/:func:`_nm_mask`/
     :func:`_apply_global_unstructured_pruning`) logic, reused directly, but
     `model` is never mutated: see :func:`analyze_pruning_sensitivity`.
+
+    Subgraph-aware (:func:`_iter_subgraphs`, see this module's own
+    "Subgraph recursion" section comment): every matched layer inside a
+    nested ``If``/``Loop``/``Scan``/``BeamSearch``-family subgraph, at any
+    nesting depth, is matched and reported exactly as if it were its own
+    top-level graph, mirroring :func:`apply_magnitude_pruning`'s own
+    subgraph awareness -- including its `global_sparsity` mode, which pools
+    every matched layer across every graph (top-level and every nested
+    subgraph alike) into the one shared global ranking, exactly like the
+    real call.
     """
     _validate_pattern(sparsity, n, m)
     if global_sparsity and n is not None:
@@ -28906,8 +28950,6 @@ def _analyze_magnitude_pruning(
         )
     if isinstance(model, str):
         model = onnx.load(model, load_external_data=False)
-    graph = model.graph
-    candidates = _candidates(graph)
 
     def _importance(
         node: onnx.NodeProto,
@@ -28920,8 +28962,11 @@ def _analyze_magnitude_pruning(
     ) -> np.ndarray:
         return np.abs(w_nk)
 
+    graph_candidates = [
+        (graph, _candidates(graph)) for graph in _iter_subgraphs(model.graph)
+    ]
     return _analyze_unstructured(
-        graph, candidates, _importance, sparsity, n, m, global_sparsity
+        graph_candidates, _importance, sparsity, n, m, global_sparsity
     )
 
 
@@ -28993,7 +29038,7 @@ def _analyze_wanda_pruning(
         return _wanda_importance(w_nk, norm, epsilon)
 
     return _analyze_unstructured(
-        graph, candidates, _importance, sparsity, n, m, global_sparsity
+        [(graph, candidates)], _importance, sparsity, n, m, global_sparsity
     )
 
 
@@ -29222,6 +29267,16 @@ def _analyze_structured_pruning(
     :func:`analyze_pruning_sensitivity`'s own docstring for exactly which
     of that function's own topologies/modes are (and, for `Concat`-merged
     chains and `global_sparsity`, deliberately are not) covered.
+
+    Subgraph-aware (:func:`_iter_subgraphs`, see this module's own
+    "Subgraph recursion" section comment): every chain family is matched
+    and reported inside a nested ``If``/``Loop``/``Scan``/
+    ``BeamSearch``-family subgraph, at any nesting depth, exactly as if
+    that subgraph were its own top-level graph, mirroring
+    :func:`apply_structured_pruning`'s own subgraph awareness. A
+    `Concat`-merged skip-connection chain found in ANY graph -- top-level
+    or nested -- still declines the whole call (`NotImplementedError`), the
+    same as it always did for the top-level graph alone.
     """
     if not (0.0 <= sparsity < 1.0):
         raise ValueError(f"sparsity must be in [0, 1), got {sparsity}")
@@ -29234,28 +29289,33 @@ def _analyze_structured_pruning(
         )
     if isinstance(model, str):
         model = onnx.load(model, load_external_data=False)
-    graph = model.graph
 
-    concat_chains = _find_matmul_concat_chains(graph) + _find_conv_concat_chains(graph)
-    if concat_chains:
-        raise NotImplementedError(
-            "analyze_pruning_sensitivity does not support models containing "
-            "Concat-merged skip-connection chains for the structured family "
-            "yet -- see analyze_pruning_sensitivity's own docstring for why"
+    layers: List[PruningLayerSensitivity] = []
+    not_eligible: List[str] = []
+    for graph in _iter_subgraphs(model.graph):
+        concat_chains = _find_matmul_concat_chains(graph) + _find_conv_concat_chains(
+            graph
         )
+        if concat_chains:
+            raise NotImplementedError(
+                "analyze_pruning_sensitivity does not support models containing "
+                "Concat-merged skip-connection chains for the structured family "
+                "yet -- see analyze_pruning_sensitivity's own docstring for why"
+            )
 
-    chain_groups = _structured_chain_groups(graph)
-    layers = _analyze_chains(
-        graph,
-        chain_groups,
-        sparsity,
-        lambda chain, w_arrays_nk: _plain_structured_importance(
-            chain, w_arrays_nk, importance_norm
-        ),
-    )
-    return PruningSensitivityReport(
-        layers=layers, not_eligible=_structured_not_eligible(graph, chain_groups)
-    )
+        chain_groups = _structured_chain_groups(graph)
+        layers.extend(
+            _analyze_chains(
+                graph,
+                chain_groups,
+                sparsity,
+                lambda chain, w_arrays_nk: _plain_structured_importance(
+                    chain, w_arrays_nk, importance_norm
+                ),
+            )
+        )
+        not_eligible.extend(_structured_not_eligible(graph, chain_groups))
+    return PruningSensitivityReport(layers=layers, not_eligible=not_eligible)
 
 
 def _analyze_structured_wanda_pruning(
@@ -30368,40 +30428,65 @@ def _analyze_attention_head_pruning(
     :func:`_analyze_attention_head_wanda_pruning` uses), with plain
     (:func:`_plain_attention_head_importance`/:func:`_gqa_group_importance`)
     importance, reused directly, but `model` is never mutated.
+
+    Subgraph-aware (:func:`_iter_subgraphs`, see this module's own
+    "Subgraph recursion" section comment): every block family is matched
+    and reported inside a nested ``If``/``Loop``/``Scan``/
+    ``BeamSearch``-family subgraph, at any nesting depth, mirroring
+    :func:`apply_attention_head_pruning`'s own subgraph awareness --
+    including that same function's own conservative narrowing there: a
+    nested subgraph's `value_info_by_name` comes from its own
+    already-declared `input`/`output`/`value_info` only
+    (:func:`_value_info_by_name`, no shape-inference pass), never from
+    :func:`_shape_inferred_value_info_by_name` the way the top-level
+    graph's own is, so this report predicts the exact same conservative
+    outcome a real call would have for a nested subgraph's own dynamic
+    `attention_bias`/`attn_mask`/`head_sink` input that is only
+    shape-resolvable via inference rather than already declared outright
+    (left unmatched/undropped here too, not over-predicted) -- see
+    :func:`apply_attention_head_pruning`'s own docstring for exactly why.
     """
     if not (0.0 <= sparsity < 1.0):
         raise ValueError(f"sparsity must be in [0, 1), got {sparsity}")
     _validate_importance_norm(importance_norm)
     if isinstance(model, str):
         model = onnx.load(model, load_external_data=False)
-    graph = model.graph
-    value_info_by_name = _shape_inferred_value_info_by_name(model)
+    top_value_info_by_name = _shape_inferred_value_info_by_name(model)
 
-    chains: List[_AttnLikeChain] = [
-        *_find_attention_chains(graph, value_info_by_name),
-        *_find_gqa_chains(graph, value_info_by_name),
-        *_find_onnx_attention_chains(graph, value_info_by_name),
-        *_find_mha_chains(graph, value_info_by_name),
-        *_find_packed_mha_chains(graph, value_info_by_name),
-        *_find_decoder_masked_mha_chains(graph, value_info_by_name),
-        *_find_paged_attention_chains(graph, value_info_by_name),
-        *_find_linear_attention_chains(graph, value_info_by_name),
-        *_find_sparse_attention_chains(graph, value_info_by_name),
-    ]
-    layers = _analyze_attention_chains(
-        graph,
-        chains,
-        sparsity,
-        lambda chain, wq, wk, wv, dq, dk, dv: _plain_attention_head_importance(
-            chain, wq, wk, wv, dq, dk, dv, importance_norm
-        ),
-        lambda chain, wq, wk, wv: _gqa_group_importance(
-            chain, wq, wk, wv, importance_norm
-        ),
-    )
-    return PruningSensitivityReport(
-        layers=layers, not_eligible=_attention_not_eligible(graph, chains)
-    )
+    layers: List[PruningLayerSensitivity] = []
+    not_eligible: List[str] = []
+    for graph in _iter_subgraphs(model.graph):
+        value_info_by_name = (
+            top_value_info_by_name
+            if graph is model.graph
+            else _value_info_by_name(graph)
+        )
+        chains: List[_AttnLikeChain] = [
+            *_find_attention_chains(graph, value_info_by_name),
+            *_find_gqa_chains(graph, value_info_by_name),
+            *_find_onnx_attention_chains(graph, value_info_by_name),
+            *_find_mha_chains(graph, value_info_by_name),
+            *_find_packed_mha_chains(graph, value_info_by_name),
+            *_find_decoder_masked_mha_chains(graph, value_info_by_name),
+            *_find_paged_attention_chains(graph, value_info_by_name),
+            *_find_linear_attention_chains(graph, value_info_by_name),
+            *_find_sparse_attention_chains(graph, value_info_by_name),
+        ]
+        layers.extend(
+            _analyze_attention_chains(
+                graph,
+                chains,
+                sparsity,
+                lambda chain, wq, wk, wv, dq, dk, dv: _plain_attention_head_importance(
+                    chain, wq, wk, wv, dq, dk, dv, importance_norm
+                ),
+                lambda chain, wq, wk, wv: _gqa_group_importance(
+                    chain, wq, wk, wv, importance_norm
+                ),
+            )
+        )
+        not_eligible.extend(_attention_not_eligible(graph, chains))
+    return PruningSensitivityReport(layers=layers, not_eligible=not_eligible)
 
 
 def _analyze_attention_head_wanda_pruning(

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -35924,6 +35924,203 @@ def test_attention_head_pruning_prunes_blocks_inside_if_branches():
     assert np.all(np.isfinite(y_else))
 
 
+# --- Subgraph recursion, dry-run mirrors ----------------------------------
+#
+# _analyze_magnitude_pruning/_analyze_structured_pruning/
+# _analyze_attention_head_pruning were the three `_analyze_*` mirrors left
+# out of the "Subgraph recursion" round above purely as a scope decision
+# (see this module's own top-of-file docstring) even though their own
+# `apply_*` counterparts were already made subgraph-aware by it. These
+# tests cover that follow-up fix: one "reports a nested chain" test per
+# function (cross-checked against what the real `apply_*` call actually
+# does to that same model), plus one regression-safety test per function
+# on an existing top-level-only fixture.
+
+
+def test_analyze_magnitude_pruning_reports_subgraph_weights():
+    model, _cfg = _if_wrapped_mlp_model()
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_magnitude_pruning, sparsity=0.5
+    )
+    pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.5)
+
+    # _iter_subgraphs/_candidates order is topology-only (pruning only
+    # mutates weight VALUES in place, never node/initializer order), so
+    # walking the same graphs/candidates over the pruned model lines up
+    # 1:1 with report.layers -- pairing every nested-subgraph layer's own
+    # would_drop/total against what apply_magnitude_pruning actually did
+    # to that exact weight.
+    expected = []
+    for graph in onnxsim.pruning._iter_subgraphs(pruned.graph):
+        imap = {t.name: t for t in graph.initializer}
+        for _, _, w_name, _, _ in onnxsim.pruning._candidates(graph):
+            w = onnx.numpy_helper.to_array(imap[w_name])
+            expected.append((w_name, int(w.size), int((w == 0).sum())))
+
+    # Six independent MatMul/Gemm weights total: two at the top level, two
+    # in then_branch, two in else_branch -- not just the top-level pair.
+    assert len(report.layers) == len(expected) == 6
+    for layer, (_w_name, size, zeros) in zip(report.layers, expected):
+        assert layer.total == size
+        assert layer.would_drop == zeros
+    assert report.not_eligible == []
+
+
+def test_analyze_magnitude_pruning_global_sparsity_pools_across_top_level_and_subgraphs():
+    model, _cfg = _if_wrapped_mlp_model()
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_magnitude_pruning, sparsity=0.3, global_sparsity=True
+    )
+    pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.3, global_sparsity=True)
+
+    reported_total = sum(layer.total for layer in report.layers)
+    reported_drop = sum(layer.would_drop for layer in report.layers)
+
+    actual_total = 0
+    actual_drop = 0
+    for graph in onnxsim.pruning._iter_subgraphs(pruned.graph):
+        for _, _, w_name, _, _ in onnxsim.pruning._candidates(graph):
+            imap = {t.name: t for t in graph.initializer}
+            w = onnx.numpy_helper.to_array(imap[w_name])
+            actual_total += w.size
+            actual_drop += int((w == 0).sum())
+
+    # One single global cutoff pooled across every matched layer in every
+    # graph -- matching apply_magnitude_pruning's own whole-model pooling,
+    # not each graph/layer independently hitting 0.3 on its own.
+    assert reported_total == actual_total
+    assert reported_drop == actual_drop
+    assert reported_drop / reported_total == pytest.approx(0.3, abs=0.02)
+
+
+def test_analyze_magnitude_pruning_no_subgraphs_matches_pre_existing_behavior():
+    # Regression-safety: a subgraph-free model's report is unaffected by
+    # _analyze_magnitude_pruning becoming subgraph-aware -- same fixture
+    # and same expected numbers as
+    # test_analyze_magnitude_pruning_matches_real_call.
+    K, N = 64, 16
+    model = _matmul_model(K=K, N=N)
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_magnitude_pruning, sparsity=0.5
+    )
+    assert len(report.layers) == 1
+    layer = report.layers[0]
+    assert layer.family == "matmul"
+    assert layer.total == K * N
+    assert report.not_eligible == []
+
+    pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.5)
+    w = onnx.numpy_helper.to_array(pruned.graph.initializer[0])
+    assert layer.would_drop == int((w == 0).sum())
+
+
+def test_analyze_structured_pruning_reports_chain_inside_if_branch():
+    K0, H0, Out0 = 8, 16, 4
+    K1, H1, OutB = 6, 12, 3
+    model, _cfg = _if_wrapped_mlp_model(
+        K0=K0, H0=H0, Out0=Out0, K1=K1, H1=H1, OutB=OutB
+    )
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_structured_pruning, sparsity=0.5
+    )
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+
+    # Same alignment argument as the magnitude test above: chain-finder
+    # order only depends on topology, so re-deriving the chain groups from
+    # the PRUNED model's own graphs (post-slicing channel counts) lines up
+    # 1:1 with report.layers (computed from the ORIGINAL, unpruned model).
+    expected_totals = []
+    expected_drops = []
+    for orig_graph, pruned_graph in zip(
+        onnxsim.pruning._iter_subgraphs(model.graph),
+        onnxsim.pruning._iter_subgraphs(pruned.graph),
+    ):
+        orig_chains = onnxsim.pruning._structured_chain_groups(orig_graph)
+        pruned_chains = onnxsim.pruning._structured_chain_groups(pruned_graph)
+        for (_f1, chains), (_f2, pruned_chains_) in zip(orig_chains, pruned_chains):
+            for chain, pruned_chain in zip(chains, pruned_chains_):
+                expected_totals.append(chain.n_channels)
+                expected_drops.append(chain.n_channels - pruned_chain.n_channels)
+
+    # Three independent chains total: top level, then_branch, else_branch.
+    assert len(report.layers) == 3
+    assert [layer.total for layer in report.layers] == expected_totals == [H0, H1, H1]
+    assert [layer.would_drop for layer in report.layers] == expected_drops
+    assert report.not_eligible == []
+
+
+def test_analyze_structured_pruning_no_subgraphs_matches_pre_existing_behavior():
+    # Regression-safety: a subgraph-free model's report is unaffected by
+    # _analyze_structured_pruning becoming subgraph-aware -- same fixture
+    # and same expected numbers as
+    # test_analyze_structured_pruning_plain_chain_matches_real_call.
+    K, H, Out = 8, 32, 4
+    model = _mlp_model(K=K, H=H, Out=Out)
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_structured_pruning, sparsity=0.5
+    )
+    assert len(report.layers) == 1
+    layer = report.layers[0]
+    assert layer.family == "matmul_plain"
+    assert layer.total == H
+    assert report.not_eligible == []
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    dims_after = _initializer_dims(pruned)
+    assert dims_after["W1"][1] == H - layer.would_drop
+    assert dims_after["W2"][0] == H - layer.would_drop
+
+
+def test_analyze_attention_head_pruning_reports_blocks_inside_if_branches():
+    # The top-level graph here has NO Attention node at all (see
+    # _if_attention_model) -- before this fix, this exact model made
+    # analyze_pruning_sensitivity(model, apply_attention_head_pruning, ...)
+    # return an empty, misleading report (layers=[], not_eligible=[]) even
+    # though a real apply_attention_head_pruning call correctly prunes both
+    # branches' own attention blocks.
+    K, H, D, Out = 8, 4, 4, 6
+    model = _if_attention_model(K=K, H=H, D=D, Out=Out)
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_attention_head_pruning, sparsity=0.5
+    )
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+
+    assert len(report.layers) == 2  # then_branch's + else_branch's own block
+    for layer in report.layers:
+        assert layer.family == "attention_head"
+        assert layer.total == H
+        assert layer.would_drop == H // 2  # matches apply's own num_heads == H // 2
+    assert report.not_eligible == []
+
+    then_g, else_g = _then_else_graphs(pruned)
+    for g, prefix in [(then_g, "then_"), (else_g, "else_")]:
+        inits = {t.name: t for t in g.initializer}
+        assert list(inits[f"{prefix}Wqkv"].dims) == [K, 3 * (H // 2) * D]
+        assert list(inits[f"{prefix}Wout"].dims) == [(H // 2) * D, Out]
+
+
+def test_analyze_attention_head_pruning_no_subgraphs_matches_pre_existing_behavior():
+    # Regression-safety: a subgraph-free model's report is unaffected by
+    # _analyze_attention_head_pruning becoming subgraph-aware -- same
+    # fixture and same expected numbers as
+    # test_analyze_attention_head_pruning_plain_attention_matches_real_call.
+    K, H, D, Out = 8, 4, 4, 6
+    model, _info = _attention_model(K=K, H=H, D=D, Out=Out)
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_attention_head_pruning, sparsity=0.5
+    )
+    assert len(report.layers) == 1
+    layer = report.layers[0]
+    assert layer.family == "attention_head"
+    assert layer.total == H
+    assert report.not_eligible == []
+
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    dims_after = _initializer_dims(pruned)
+    kept = H - layer.would_drop
+    assert dims_after["Wqkv"][1] == kept * 3 * D
+
+
 def test_wanda_pruning_still_leaves_subgraph_weights_untouched_documented_gap():
     # apply_wanda_pruning is a calibration-data-driven function --
     # deliberately NOT made subgraph-aware by this change (see this


### PR DESCRIPTION
## Summary

`_analyze_magnitude_pruning`/`_analyze_structured_pruning`/`_analyze_attention_head_pruning` — the dry-run mirrors of `apply_magnitude_pruning`/`apply_structured_pruning`/`apply_attention_head_pruning` — were never made subgraph-aware, even though their own `apply_*` counterparts were two rounds ago, and every OTHER `_analyze_*` mirror in the file was made subgraph-aware last round. This was an explicitly-documented, known gap in the module's own top docstring (named these three by name, said why: purely out of a prior round's own assigned scope, not a technical obstacle).

## Empirically confirmed facts

- Confirmed live: all three still did `graph = model.graph` and passed that single top-level graph to `_candidates`/`_find_*_chains`, never looping over `_iter_subgraphs`.
- Live repro: a nested `If.then_branch` with a `MatMul` weight, nothing eligible at the top level. `apply_magnitude_pruning` correctly zeroes the nested weight, but `analyze_pruning_sensitivity(model, apply_magnitude_pruning, sparsity=0.5)` returned `layers=[]`, `not_eligible=[]` — the layer wasn't merely under-reported, it was completely invisible to the dry-run.

## What's added

`_analyze_unstructured` (the shared body for `_analyze_magnitude_pruning`/`_analyze_wanda_pruning`) now takes a list of `(graph, candidates)` pairs instead of a single graph. `_analyze_magnitude_pruning` builds one pair per `_iter_subgraphs(model.graph)` graph, with `global_sparsity` mode pooling every matched layer across every graph — the identical whole-model pooling `apply_magnitude_pruning`'s own `global_sparsity` mode already uses. `_analyze_wanda_pruning`'s call site is updated to pass `[(graph, candidates)]`, preserving its deliberate top-level-only behavior unchanged (confirmed in review: `not_eligible` is correctly accumulated per-graph in both the `global_sparsity` and non-`global_sparsity` branches).

`_analyze_structured_pruning` and `_analyze_attention_head_pruning` now loop `for graph in _iter_subgraphs(model.graph)`, aggregating `layers`/`not_eligible` across every graph, mirroring their `apply_*` counterparts' exact loop idioms — including `apply_attention_head_pruning`'s own conservatively-narrower-in-subgraphs `value_info_by_name` behavior, so the dry-run report never over-predicts what a real call would actually do.

Updated the module's top-of-file docstring: moved these three into the subgraph-aware list, removed the stale "left NOT subgraph-aware" claim, and removed a second stale bullet that (already inaccurately, by the time of this PR) claimed all nineteen `_analyze_*` mirrors remained top-level-only.

## Test plan

- [x] `pytest tests/test_pruning.py -q` — 761 → 768 passed, zero regressions (7 new tests)
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — 0 errors, unchanged from master's baseline
- [x] One nested-chain report test per function, each cross-checked numerically against a real `apply_*` call on the same model
- [x] Global-sparsity cross-graph-pooling test
- [x] Top-level-only regression-safety test per function

I independently reviewed the `_analyze_unstructured` restructuring in full (confirming `not_eligible` is correctly accumulated per-graph in both branches, and `_analyze_wanda_pruning`'s deliberate top-level-only scope is preserved via `[(graph, candidates)]`), and ran the entire test/ruff/mypy suite myself in a clean environment before pushing.

---
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_