### PR TITLE
Add Clip (ReLU6) pass-through hop to structured pruning

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -576,7 +576,7 @@ now-deprecated per-*group* schema is excluded by the same per-channel shape
 check every other hop in this module already applies, not by inspecting the
 model's own declared opset).
 
-A Conv chain also crosses four more op kinds transparently, each needing no
+A Conv chain also crosses five more op kinds transparently, each needing no
 weight of its own sliced (folded into `chain_ops` exactly like a unary
 activation, not a dedicated pass-through tuple) -- these close the two most
 common CNN backbone shapes this pass previously left completely unpruned end
@@ -613,14 +613,35 @@ outright). See :func:`_match_resize_channel_pass_through`/
 static-provability bar (including the `axes` attribute/input each op gained
 at a later opset, and why a negative `axes` entry declines rather than
 assumes a tensor rank this pass doesn't have on hand at that point in the
-walk). Unlike the depthwise-Conv/GroupNorm hops above, all four are
-recognized in *both* directions the Conv-chain machinery needs them --
+walk). ``Clip`` (the op ``torch.nn.ReLU6`` lowers to, opset 11+'s
+``input, min?, max?`` input-based signature -- confirmed live via
+``onnx.defs.get_schema("Clip")`` -- ubiquitous throughout MobileNetV2/V3,
+EfficientNet-Lite, and quantization-aware-training exports; confirmed
+empirically, before this support existed, via
+``grep -n "\"Clip\""`` over this Conv-chain-walking section returning zero
+hits) is narrower still in one sense and wider in another: unlike ``Resize``/
+``Pad``, its own `min`/`max` operands are never axis-indexed tensors at all
+(each "must be a scalar (tensor of empty shape)" per the op's own schema
+text), so once each present operand is confirmed to actually be a constant,
+single-element tensor -- declined, never guessed at, whenever it isn't --
+no axis reasoning, and no dependence on `n_channels`, is needed at all; see
+:func:`_match_clip_channel_pass_through`'s own docstring for the exact bar
+and why (unlike `scales[1] == 1.0`/`pads[axis] == 0`) neither operand's
+*value* needs inspecting either. Unlike the depthwise-Conv/GroupNorm hops
+above, all five are recognized in *both* directions the Conv-chain machinery
+needs them --
 :func:`_walk_to_conv_consumer`'s forward walk (reached by
 :func:`_find_conv_chains`'s own plain chains, a residual/merge group's
 fan-out branches, and a Concat-branch-merge's shared consumer alike) and
 :func:`_walk_conv_producer_backward`'s backward walk (reached by
 :func:`_find_conv_residual_chains`'s own ``Add``-operand resolution and
-:func:`_find_conv_concat_chains`'s own branch resolution). Deliberately left
+:func:`_find_conv_concat_chains`'s own branch resolution). ``Clip`` is, in
+addition, recognized the identical way by the MatMul/Gemm-chain walkers
+(:func:`_walk_to_consumer`/:func:`_walk_matmul_producer_backward`) -- unlike
+``Resize``/``Pad``, which stay Conv-chain-only (axis 1 is meaningless on a
+MatMul/Gemm chain's own last-channel-axis convention), ``Clip``'s complete
+axis-agnosticism means the identical matcher and reasoning already apply
+unchanged to a QAT-style activation-clipping-after-Linear shape too. Deliberately left
 out of scope, and not attempted: a
 ``GlobalAveragePool -> Flatten -> Gemm`` classifier head, where a Conv's
 surviving channel set would need to be re-derived through `Flatten`'s exact
@@ -3766,13 +3787,17 @@ def _walk_to_consumer(
     elementwise ops (an activation, an Add/Mul against a constant
     per-channel bias/scale, a fused ``com.microsoft::BiasGelu``/
     ``FastGelu`` node -- see `_FUSED_BIAS_GELU_OPS`'s own comment and
-    :func:`_match_fused_bias_gelu` -- or a plain `_NORM_PASS_THROUGH_OPS`
+    :func:`_match_fused_bias_gelu` -- a plain `_NORM_PASS_THROUGH_OPS`
     node whose own ``axis`` normalizes exactly `cur`'s last axis -- see that
     constant's own comment, :func:`_norm_axis_is_last`, and
-    :func:`_norm_pass_through_const_names`) with no other consumer anywhere
-    along the way, until a MatMul/vanilla-Gemm consumer is found whose
-    reduction dimension matches `n_channels`. Returns ``(None, ())`` if the
-    walk runs out of hops, hits a branch, or never reaches such a consumer.
+    :func:`_norm_pass_through_const_names` -- or a channel-agnostic ``Clip``
+    -- see :func:`_match_clip_channel_pass_through`, the QAT-style
+    activation-clipping-after-Linear shape, needing no axis reasoning at all
+    since neither `min` nor `max` is axis-indexed to begin with) with no
+    other consumer anywhere along the way, until a MatMul/vanilla-Gemm
+    consumer is found whose reduction dimension matches `n_channels`.
+    Returns ``(None, ())`` if the walk runs out of hops, hits a branch, or
+    never reaches such a consumer.
 
     `forced_first_hop`, when given, is used as the walk's very first hop
     instead of deriving it from `consumers_of[start]` -- see
@@ -3886,6 +3911,15 @@ def _walk_to_consumer(
                 break
             const_name = scale_name
             extra_const_name = bias_name
+        elif (
+            nxt.op_type == "Clip"
+            and nxt.domain == ""
+            and nxt.input
+            and nxt.input[0] == cur
+            and len(nxt.output) == 1
+            and _match_clip_channel_pass_through(nxt, initializer_map)
+        ):
+            pass  # channel-agnostic -- no const of its own to slice
         else:
             break
 
@@ -4599,6 +4633,91 @@ def _match_pad_channel_pass_through(
     return begin == 0 and end == 0
 
 
+def _match_clip_channel_pass_through(
+    node: onnx.NodeProto, initializer_map: Dict[str, onnx.TensorProto]
+) -> bool:
+    """True iff `node` (already confirmed by the caller to be a plain
+    (default-domain) ``Clip``, `node.input[0]` the tensor being walked
+    through) is a pure elementwise clamp with zero channel dependence, so it
+    is safe to cross transparently -- the op ``torch.nn.ReLU6`` (ubiquitous
+    in MobileNetV2/V3, EfficientNet-Lite, and quantization-aware-training
+    exports) lowers to (confirmed live: ``torch.onnx.export`` of a
+    ``Conv -> ReLU6 -> Conv`` module emits exactly a ``Clip`` node whose
+    `min`/`max` are fed by ``Constant``-producing nodes -- which this pass's
+    own docstring already assumes have been folded into initializers by the
+    time onnxsim's optimizer pipeline runs, the same assumption every other
+    "constant initializer only" hop in this module already relies on).
+
+    Unlike :func:`_match_resize_channel_pass_through`/
+    :func:`_match_pad_channel_pass_through`, which each need to statically
+    prove that some *specific* input axis is left untouched, ``Clip``'s own
+    `min`/`max` operands are never axis-indexed at all: per ``Clip``'s own
+    schema (confirmed live via ``onnx.defs.get_schema("Clip")``, the opset
+    11+ input-based signature -- `input, min?, max?` -- `since_version=13`
+    in this environment's own onnx==1.22.0), each "must be a scalar (tensor
+    of empty shape)", broadcast uniformly over *every* element regardless of
+    which axis -- let alone which channel -- it sits on. So once each is
+    confirmed to actually *be* such a scalar constant, no axis reasoning is
+    needed at all, unlike every other hop in this section, and the same
+    check works unchanged for a Conv chain's own axis-1 channel convention
+    and a MatMul/Gemm chain's own last-axis convention alike (this matcher
+    is shared by both -- see :func:`_walk_to_conv_consumer`/
+    :func:`_walk_conv_producer_backward` and :func:`_walk_to_consumer`/
+    :func:`_walk_matmul_producer_backward`).
+
+    Declines (``False``) rather than guesses whenever it cannot statically
+    confirm that:
+
+    - `min`/`max` (each optional per the schema -- ``ReLU6``'s own two-sided
+      clamp sets both, but a one-sided ``Relu``-with-only-an-upper-bound or
+      ``-only-a-lower-bound`` shape some exporters emit is just as safe and
+      still matched here), when actually present (a present-but-empty-string
+      placeholder, e.g. ``Clip(X, , Max)`` with `min` omitted, counts as
+      *not* present, mirroring `_resize_conv_pair_model`'s own `roi` slot),
+      is a constant initializer -- a runtime-computed bound (e.g. fed by a
+      `Shape`/`Cast`/reduction op elsewhere in the graph) means this pass
+      cannot confirm it has no channel dependence at all, so it's declined,
+      never guessed at, mirroring every other "statically-known-constant-
+      only" bar in this module (`_match_resize_channel_pass_through`'s own
+      `scales`, `_match_group_norm_pass_through`'s own `scale`/`bias`, ...).
+    - that constant is single-element -- `dims` exactly ``[]`` or ``[1]``,
+      the two ways a genuine per-tensor scalar is conventionally exported
+      (mirroring `_qop_scalar_dims_ok`'s own identical check elsewhere in
+      this module). ``Clip``'s own schema already requires `min`/`max` to be
+      scalar, but nothing stops a non-conforming graph from naming a
+      differently (e.g. per-channel-)shaped tensor there instead -- declined
+      the same conservative way a non-constant one is, never guessed at,
+      rather than trusted on the schema's word alone.
+
+    Neither `min` nor `max`'s own *value* is ever inspected -- unlike
+    `_match_resize_channel_pass_through`'s `scales[1] == 1.0`/
+    `_match_pad_channel_pass_through`'s `pads[axis] == 0` value checks, a
+    scalar clamp bound commutes with a channel-axis slice for *any* value:
+    clamping is a pure elementwise op, so slicing which channels survive
+    first and clamping after computes exactly the same surviving values as
+    clamping first and slicing after, whatever `min`/`max` actually are --
+    confirmed empirically via a real `onnxruntime.InferenceSession` (max abs
+    diff `0.0`), not just from the schema text -- see this feature's own
+    verification and `tests/test_pruning.py`'s Clip pass-through tests.
+    """
+    if node.op_type != "Clip" or node.domain != "":
+        return False
+    if not node.input or not node.input[0]:
+        return False
+    for idx in (1, 2):  # min, max -- both optional, opset 11+ input-based
+        if len(node.input) <= idx:
+            continue
+        name = node.input[idx]
+        if not name:
+            continue  # omitted optional input (empty-string placeholder)
+        init = initializer_map.get(name)
+        if init is None:
+            return False  # non-constant -- declined, never guessed at
+        if list(init.dims) not in ([], [1]):
+            return False  # not a scalar -- declined, never guessed at
+    return True
+
+
 def _walk_to_conv_consumer(
     start: str,
     initializer_map: Dict[str, onnx.TensorProto],
@@ -4622,7 +4741,12 @@ def _walk_to_conv_consumer(
     see `_CONV_POOL_PASS_THROUGH`'s own comment), a channel-axis-unaffected
     ``Resize``/``Pad`` (see :func:`_match_resize_channel_pass_through`/
     :func:`_match_pad_channel_pass_through` -- declined, not guessed at,
-    whenever the channel axis can't be statically proven untouched), depthwise
+    whenever the channel axis can't be statically proven untouched), a
+    channel-agnostic ``Clip`` (see :func:`_match_clip_channel_pass_through`
+    -- the ``ReLU6`` op MobileNet/EfficientNet-Lite-style backbones use
+    throughout; declined whenever a present `min`/`max` operand isn't a
+    scalar constant, needing no axis reasoning at all since neither operand
+    is axis-indexed to begin with), depthwise
     Conv hops (see :func:`_match_depthwise_conv_pass_through` -- transparent
     to the channel-index mapping, but each still needs its own weight/bias
     sliced and its ``group`` attribute updated, so they're returned separately
@@ -4651,8 +4775,8 @@ def _walk_to_conv_consumer(
     the walk with no consumer found, same as any other unmatched topology.
     Unlike the MatMul/Gemm walk, no per-channel ``Add``/``Mul`` op is
     recognized -- see this module's own docstring for why that's out of
-    scope for Conv chains. A pooling/``Resize``/``Pad`` hop, like a unary
-    activation, needs no weight/bias of its own sliced at all -- it is folded
+    scope for Conv chains. A pooling/``Resize``/``Pad``/``Clip`` hop, like a
+    unary activation, needs no weight/bias of its own sliced at all -- it is folded
     into `chain_ops` (a plain ``(node, None)`` entry, the const-name always
     ``None``) rather than needing a dedicated tuple type the way
     `conv_pass_through`/`group_norm` do, since :func:`_apply_chains` already
@@ -4813,6 +4937,21 @@ def _walk_to_conv_consumer(
             and nxt.input[0] == cur
             and len(nxt.output) == 1
             and _match_pad_channel_pass_through(nxt, initializer_map)
+        ):
+            out2 = nxt.output[0]
+            if len(consumers_of.get(out2, [])) != 1 or out2 in graph_outputs:
+                break
+            chain_ops.append((nxt, None))
+            cur = out2
+            continue
+
+        if (
+            nxt.op_type == "Clip"
+            and nxt.domain == ""
+            and nxt.input
+            and nxt.input[0] == cur
+            and len(nxt.output) == 1
+            and _match_clip_channel_pass_through(nxt, initializer_map)
         ):
             out2 = nxt.output[0]
             if len(consumers_of.get(out2, [])) != 1 or out2 in graph_outputs:
@@ -5113,7 +5252,10 @@ def _walk_conv_producer_backward(
     not-yet-known group channel count, since `_match_resize_channel_pass_
     through` only ever recognizes a `scales`-driven `Resize`, a ratio that
     needs no channel count to validate, never a `sizes`-driven one -- see
-    that function's own docstring for why), declining (only) whenever a
+    that function's own docstring for why), and a channel-agnostic ``Clip``
+    (see :func:`_match_clip_channel_pass_through` -- likewise needs no
+    channel count at all, since neither `min` nor `max` is axis-indexed to
+    begin with), declining (only) whenever a
     tensor crossed -- `start` itself included -- is a graph output (a
     caller-observed shape this pass never resizes); *how many* other things
     also read that same tensor is deliberately **not** checked here -- see
@@ -5222,6 +5364,14 @@ def _walk_conv_producer_backward(
             continue
 
         if node.op_type == "Pad" and _match_pad_channel_pass_through(
+            node, initializer_map
+        ):
+            unary_ops.append(node)
+            edges.append((node.input[0], node))
+            cur = node.input[0]
+            continue
+
+        if node.op_type == "Clip" and _match_clip_channel_pass_through(
             node, initializer_map
         ):
             unary_ops.append(node)
@@ -5999,8 +6149,10 @@ def _walk_matmul_producer_backward(
     whatever produces it -- the MatMul/Gemm analogue of
     :func:`_walk_conv_producer_backward` (see this function's own section
     comment above for how the two differ: a wider hop set mirroring
-    `_walk_to_consumer`'s own per-channel bias/scale ``Add``/``Mul`` hop,
-    and no depthwise-pass-through analogue at all). Declines (only) whenever
+    `_walk_to_consumer`'s own per-channel bias/scale ``Add``/``Mul`` hop
+    (plus a channel-agnostic ``Clip``, see
+    :func:`_match_clip_channel_pass_through`), and no depthwise-pass-through
+    analogue at all). Declines (only) whenever
     a tensor crossed -- `start` itself included -- is a graph output (a
     caller-observed shape this pass never resizes); *how many* other things
     also read that same tensor is deliberately **not** checked here -- see
@@ -6091,6 +6243,14 @@ def _walk_matmul_producer_backward(
             )
 
         if node.op_type in _UNARY_PASS_THROUGH and len(node.input) == 1:
+            chain_ops.append((node, None))
+            edges.append((node.input[0], node))
+            cur = node.input[0]
+            continue
+
+        if node.op_type == "Clip" and _match_clip_channel_pass_through(
+            node, initializer_map
+        ):
             chain_ops.append((node, None))
             edges.append((node.input[0], node))
             cur = node.input[0]

--- a/scripts/cross/run_s390x_tests.sh
+++ b/scripts/cross/run_s390x_tests.sh
@@ -95,10 +95,11 @@ print(sys.byteorder, \"endian | python\", sys.version.split()[0],
 # above, only tests/ and pyproject.toml are copied into the chroot, so none of
 # those imports resolve there regardless of what's pip-installed. Same story
 # for test_check_decode_parity.py, which imports scripts/apple/check_decode_parity
-# at module scope, and test_compute_retention.py, which imports
-# scripts/apple/compute_retention the same way. test_rtdetrv4.py imports
-# onnxruntime directly at module scope for the same "no s390x build" reason
-# as test_qnn_compat.py and friends above.
+# at module scope, and test_compute_retention.py, test_run_quality_eval.py and
+# test_aggregate_quality_trend.py, which import scripts/apple/compute_retention,
+# scripts/apple/run_quality_eval and scripts/apple/aggregate_quality_trend the
+# same way. test_rtdetrv4.py imports onnxruntime directly at module scope for
+# the same "no s390x build" reason as test_qnn_compat.py and friends above.
 #
 # The three deselected BN-fusion tests fail onnxsim's own check_n equivalence
 # check whenever onnxruntime is absent and the reference evaluator is used
@@ -129,6 +130,7 @@ chroot "${SYSROOT}" /bin/sh -c "cd /work && GITHUB_STEP_SUMMARY=${CHROOT_SUMMARY
   --ignore=tests/test_coreml_compat.py --ignore=tests/test_migraphx_compat.py \
   --ignore=tests/test_openvino_compat.py --ignore=tests/test_check_decode_parity.py \
   --ignore=tests/test_compute_retention.py --ignore=tests/test_rtdetrv4.py \
+  --ignore=tests/test_run_quality_eval.py --ignore=tests/test_aggregate_quality_trend.py \
   --deselect tests/test_fusion_patterns.py::test_fuse_conv_bn_into_conv \
   --deselect tests/test_fusion_patterns.py::test_fuse_convtranspose_bn \
   --deselect tests/test_fusion_patterns.py::test_fuse_conv_with_bias_bn_into_conv ${PYTEST_ARGS:-}"

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -5730,6 +5730,293 @@ def test_structured_pruning_resize_upsample_concat_unet_decoder_matches_oracle_e
     np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
 
 
+# --- Conv chain: Clip (ReLU6) pass-through hop -------------------------------
+#
+# `Clip` -- the op `torch.nn.ReLU6` lowers to (opset 11+'s `input, min?, max?`
+# input-based signature) -- is a pure elementwise clamp with zero channel
+# dependence whenever a present `min`/`max` operand is a scalar constant (see
+# `_match_clip_channel_pass_through`'s own docstring): unlike `Resize`/`Pad`,
+# neither operand is axis-indexed at all, so no axis reasoning -- and no
+# dependence on the actual `min`/`max` *value* -- is needed to prove it's
+# safe to cross transparently. This closes the ReLU6 activation shape
+# MobileNetV2/V3 and EfficientNet-Lite backbones use throughout (confirmed
+# empirically, before this hop existed, via `grep -n "\"Clip\""` over this
+# Conv-chain-walking section returning zero hits).
+
+
+def _clip_conv_pair_model(w1, w2, min_val=None, max_val=None, b1=None, spatial=10):
+    """`Conv -> Clip -> Conv`, `min_val`/`max_val` (each `None` or a Python
+    float) become `Min`/`Max` 0-D float32 scalar initializers -- omitted
+    entirely from `Clip`'s own inputs when `None`, exactly like `ReLU6`'s own
+    two-sided clamp when both are given, or the one-sided shape some
+    exporters emit when only one is (`Clip`'s own schema makes both
+    optional)."""
+    Cin, C2 = w1.shape[1], w2.shape[0]
+    initializer = [_f32(w1, "W1"), _f32(w2, "W2")]
+    if b1 is not None:
+        conv1 = "h = Conv<kernel_shape=[3,3]>(X, W1, B1)"
+        initializer.append(_f32(b1, "B1"))
+    else:
+        conv1 = "h = Conv<kernel_shape=[3,3]>(X, W1)"
+    if min_val is not None:
+        initializer.append(
+            onnx.numpy_helper.from_array(np.array(min_val, dtype=np.float32), "Min")
+        )
+    if max_val is not None:
+        initializer.append(
+            onnx.numpy_helper.from_array(np.array(max_val, dtype=np.float32), "Max")
+        )
+    if min_val is not None and max_val is not None:
+        clip_node = "p = Clip(h, Min, Max)"
+    elif min_val is not None:
+        clip_node = "p = Clip(h, Min)"
+    elif max_val is not None:
+        clip_node = "p = Clip(h, , Max)"
+    else:
+        clip_node = "p = Clip(h)"
+    out_spatial = spatial - 4  # two valid (no-pad) 3x3 convs
+    return _model(
+        f"""
+        g (float[N,{Cin},{spatial},{spatial}] X) => (float[N,{C2},{out_spatial},{out_spatial}] Y)
+        {{
+          {conv1}
+          {clip_node}
+          Y = Conv<kernel_shape=[3,3]>(p, W2)
+        }}
+        """,
+        initializer=initializer,
+    )
+
+
+def test_structured_pruning_clip_relu6_pass_through_matches_oracle_exactly():
+    # Conv -> Clip(min=0, max=6) -> Conv, both bounds plain scalar constant
+    # initializers -- exactly `ReLU6`'s own two-sided clamp, and the shape
+    # `torch.onnx.export(nn.ReLU6(), ...)` emits live (`Clip` fed by
+    # `Constant`-folded scalar `min`/`max`, confirmed by direct export in
+    # this feature's own verification). Must be left entirely untouched
+    # (only its own `h`/`p` shapes change), weights sliced normally on both
+    # sides, output matching an independently, already-pruned reference
+    # model -- never a post-hoc slice of the full unpruned model's own
+    # output.
+    Cin, C1, C2 = 3, 16, 8
+    rng = np.random.default_rng(79)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    b1 = rng.standard_normal((C1,)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    model = _clip_conv_pair_model(w1, w2, min_val=0.0, max_val=6.0, b1=b1)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    dims_after = _initializer_dims(pruned)
+    assert dims_after["W1"][0] == C1 // 2
+    assert dims_after["W2"][1] == C1 // 2
+    # The Clip node itself is untouched -- still a plain scalar Min/Max.
+    pruned_clip = next(n for n in pruned.graph.node if n.op_type == "Clip")
+    pruned_inits = {
+        t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer
+    }
+    np.testing.assert_array_equal(pruned_inits[pruned_clip.input[1]], np.float32(0.0))
+    np.testing.assert_array_equal(pruned_inits[pruned_clip.input[2]], np.float32(6.0))
+
+    keep = _oracle_keep_indices_conv(w1, C1 // 2)
+    oracle = _clip_conv_pair_model(
+        w1[keep], w2[:, keep], min_val=0.0, max_val=6.0, b1=b1[keep]
+    )
+
+    rng_x = np.random.default_rng(80)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_clip_min_only_pass_through_matches_oracle_exactly():
+    # `max` omitted entirely (a one-sided lower-bound clamp -- plain `Relu`
+    # with an explicit `Clip` encoding some exporters use) -- both operands
+    # are optional per Clip's own schema, so this must still be recognized.
+    Cin, C1, C2 = 3, 16, 8
+    rng = np.random.default_rng(81)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    model = _clip_conv_pair_model(w1, w2, min_val=0.0, max_val=None)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    dims_after = _initializer_dims(pruned)
+    assert dims_after["W1"][0] == C1 // 2
+    assert dims_after["W2"][1] == C1 // 2
+
+    keep = _oracle_keep_indices_conv(w1, C1 // 2)
+    oracle = _clip_conv_pair_model(w1[keep], w2[:, keep], min_val=0.0, max_val=None)
+
+    rng_x = np.random.default_rng(82)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_clip_max_only_pass_through_matches_oracle_exactly():
+    # `min` omitted entirely (empty-string placeholder, `Clip(h, , Max)`) --
+    # a one-sided upper-bound clamp, the mirror image of the min-only case
+    # above.
+    Cin, C1, C2 = 3, 16, 8
+    rng = np.random.default_rng(83)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    model = _clip_conv_pair_model(w1, w2, min_val=None, max_val=6.0)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    dims_after = _initializer_dims(pruned)
+    assert dims_after["W1"][0] == C1 // 2
+    assert dims_after["W2"][1] == C1 // 2
+
+    keep = _oracle_keep_indices_conv(w1, C1 // 2)
+    oracle = _clip_conv_pair_model(w1[keep], w2[:, keep], min_val=None, max_val=6.0)
+
+    rng_x = np.random.default_rng(84)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_clip_nonconstant_min_declines():
+    # `min` fed by a non-constant node (an `Identity` of a graph input, the
+    # same "runtime-computed" shape `test_structured_pruning_pad_dynamic_
+    # pads_declines` already covers for `Pad`) -- this pass cannot confirm
+    # it has no channel dependence at all without evaluating the graph, so
+    # it must decline outright, never guessed at, leaving the whole chain
+    # untouched.
+    Cin, C1, C2 = 3, 8, 4
+    rng = np.random.default_rng(85)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X, float MinIn) => (float[N,{C2},6,6] Y)
+        {{
+          h = Conv<kernel_shape=[3,3]>(X, W1)
+          min_dyn = Identity(MinIn)
+          p = Clip(h, min_dyn)
+          Y = Conv<kernel_shape=[3,3]>(p, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2")],
+    )
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+
+
+def test_structured_pruning_clip_nonscalar_min_declines():
+    # `min` a per-channel-shaped constant (`[C1]`, matching the producer's
+    # own channel count) rather than a genuine scalar -- `Clip`'s own schema
+    # requires `min`/`max` to be scalar, but nothing stops a non-conforming
+    # graph from naming a differently-shaped tensor there instead, so this
+    # must still be declined, never guessed at (mirroring
+    # `_match_clip_channel_pass_through`'s own docstring: trusted by
+    # confirmed shape, never by the schema's word alone).
+    Cin, C1, C2 = 3, 8, 4
+    rng = np.random.default_rng(86)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    min_per_channel = onnx.numpy_helper.from_array(
+        np.zeros((C1,), dtype=np.float32), "MinPerChannel"
+    )
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{C2},6,6] Y)
+        {{
+          h = Conv<kernel_shape=[3,3]>(X, W1)
+          p = Clip(h, MinPerChannel)
+          Y = Conv<kernel_shape=[3,3]>(p, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2"), min_per_channel],
+    )
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+
+
+def _mlp_clip_model(K=8, H=32, Out=4, min_val=0.0, max_val=6.0, bias=True, seed=0):
+    """The MatMul/Gemm-chain analogue of `_clip_conv_pair_model`: `MatMul/
+    Gemm -> Clip -> MatMul`, exercising `_walk_to_consumer`'s own `Clip`
+    hop (the QAT-style activation-clipping-after-Linear shape) rather than
+    the Conv-chain walkers the tests above exercise."""
+    rng = np.random.default_rng(seed)
+    w1 = rng.standard_normal((K, H)).astype(np.float32)
+    w2 = rng.standard_normal((H, Out)).astype(np.float32)
+    initializer = [_f32(w1, "W1"), _f32(w2, "W2")]
+    if min_val is not None:
+        initializer.append(
+            onnx.numpy_helper.from_array(np.array(min_val, dtype=np.float32), "Min")
+        )
+    if max_val is not None:
+        initializer.append(
+            onnx.numpy_helper.from_array(np.array(max_val, dtype=np.float32), "Max")
+        )
+    if min_val is not None and max_val is not None:
+        clip_node = "a = Clip(h, Min, Max)"
+    elif min_val is not None:
+        clip_node = "a = Clip(h, Min)"
+    elif max_val is not None:
+        clip_node = "a = Clip(h, , Max)"
+    else:
+        clip_node = "a = Clip(h)"
+    if bias:
+        b1 = rng.standard_normal((H,)).astype(np.float32)
+        gemm1 = "h = Gemm(X, W1, B1)"
+        initializer.append(_f32(b1, "B1"))
+    else:
+        gemm1 = "h = MatMul(X, W1)"
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          {gemm1}
+          {clip_node}
+          Y = MatMul(a, W2)
+        }}
+        """,
+        initializer=initializer,
+    )
+
+
+def test_structured_pruning_matmul_clip_pass_through_matches_oracle_exactly():
+    # The MatMul/Gemm-chain analogue of
+    # `test_structured_pruning_clip_relu6_pass_through_matches_oracle_exactly`
+    # -- QAT-style activation clipping after a Linear layer is also common
+    # (`torch.nn.ReLU6`/`torch.ao.quantization`'s own fake-quant clamp
+    # shapes alike), and `Clip`'s complete axis-agnosticism means the exact
+    # same matcher already applies unchanged here, no MatMul/Gemm-specific
+    # machinery needed.
+    K, H, Out = 8, 32, 4
+    model = _mlp_clip_model(K=K, H=H, Out=Out, min_val=0.0, max_val=6.0)
+    orig = {t.name: onnx.numpy_helper.to_array(t) for t in model.graph.initializer}
+    w1, b1, w2 = orig["W1"], orig["B1"], orig["W2"]
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    dims_after = _initializer_dims(pruned)
+    assert dims_after["W1"][1] == H // 2
+    assert dims_after["W2"][0] == H // 2
+
+    keep = _oracle_keep_indices(w1, H // 2)
+    rng = np.random.default_rng(2)
+    x = rng.standard_normal((6, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+
+    h = x @ w1[:, keep] + b1[keep]
+    a = np.clip(h, 0.0, 6.0)
+    y_oracle = a @ w2[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
 def test_structured_wanda_pruning_conv_chain_matches_oracle_exactly():
     Cin, C1, C2 = 3, 16, 8
     rng = np.random.default_rng(40)


### PR DESCRIPTION
## Summary

`Clip` (opset 11+'s `input, min?, max?` signature — the op `torch.nn.ReLU6` lowers to) was completely unrecognized as a Conv-chain or MatMul/Gemm-chain pass-through hop. A `Conv → Clip(min, max) → Conv` chain — the ReLU6 activation shape MobileNetV2/V3, EfficientNet-Lite, and quantization-aware-training exports use throughout — failed the walkers' single-input pass-through check and went completely unpruned end to end, even though `Clip`'s `min`/`max` are, per the op's own schema, always scalar and therefore have zero channel dependence.

## Empirically confirmed facts

- `onnx.defs.get_schema("Clip")`: `since_version=13`, `min`/`max` are optional inputs (I re-confirmed this myself live in the verified worktree).
- `grep -n '"Clip"'` over the Conv-chain-walking section returned zero hits before this change (re-confirmed).
- Live `torch.onnx.export(nn.ReLU6(), ...)` on a `Conv → ReLU6 → Conv` module emits exactly a `Clip` node whose `min`/`max` are fed by `Constant`-producing nodes (matching this module's existing "runs post-onnxsim-simplification, Constants already folded into initializers" assumption used by the Resize/Pad hops).
- Commutation (slicing channels before vs. after a scalar-bounded `Clip`) verified as exact via real `onnxruntime.InferenceSession` execution — a pure elementwise clamp commutes with a channel-axis slice for any bound value, since neither `min` nor `max` is axis-indexed at all.
- I independently re-ran the full verification suite myself in the worktree after the agent's work: `pytest tests/test_pruning.py -q` → **794 passed** (788 → 794, +6 new tests), `ruff format --check` clean, `ruff check` clean, `mypy onnxsim/pruning.py` (the exact scoped command) → **0 errors**, matching baseline.

## What's added / scope

- New `_match_clip_channel_pass_through()`, matching the existing `_match_resize_channel_pass_through`/`_match_pad_channel_pass_through` style: recognizes a `Clip` hop only when a present `min`/`max` operand is a constant, single-element (`[]` or `[1]`) initializer — declined, never guessed at, whenever it's non-constant or not scalar. Unlike Resize/Pad, neither operand is axis-indexed, so no axis reasoning or channel count is needed at all, and the same matcher applies unchanged to a Conv chain's axis-1 convention and a MatMul/Gemm chain's last-axis convention.
- Wired into all four walkers: `_walk_to_conv_consumer`, `_walk_conv_producer_backward` (Conv chains) and `_walk_to_consumer`, `_walk_matmul_producer_backward` (MatMul/Gemm chains — extended since it turned out structurally trivial given the axis-agnosticism).
- Folds into `chain_ops` as a plain `(node, None)` entry, identical to the Resize/Pad hops — no weight to slice.
- Module docstring and all four walker docstrings updated to document the new hop.

## Test plan

- [x] `Conv → Clip(min, max both scalar constants) → Conv` prunes correctly, output matches an independently-reconstructed already-pruned reference model (never the full unpruned model's own output).
- [x] One-sided `Clip` (`min`-only, `max`-only) — both optional per schema — handled correctly, for both Conv and MatMul/Gemm chains.
- [x] Decline tests: non-constant `min`, non-scalar (per-channel-shaped) `min` — verified the chain is declined outright rather than mis-sliced.
- [x] `pytest tests/test_pruning.py -q`: 788 → 794 passed.
- [x] `ruff format --check .` / `ruff check .`: clean.
- [x] `mypy onnxsim/pruning.py` (exact scoped command): 0 errors, matching baseline.

I independently re-verified this PR after implementation: reviewed the full diff line by line, re-confirmed the `Clip` schema claim live myself, re-ran the entire verification suite (tests/ruff/mypy) fresh in the worktree rather than trusting the implementing agent's self-report, and confirmed the working tree was clean with everything properly committed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_