### PR TITLE
Add PRelu pass-through hop to structured pruning's Conv/MatMul chains

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -542,9 +542,13 @@ producers; L1's is a plain sum, with no square/sqrt involved at all) and
 support is deliberately
 narrower than the MatMul/Gemm path in one respect that stays true
 regardless of grouping: producers/consumers are joined by unary activations,
-channel-preserving spatial ops (see below), and depthwise/GroupNorm
+channel-preserving spatial ops (see below), and depthwise/GroupNorm/PRelu
 pass-through hops -- no per-channel ``Add``/``Mul`` scale-or-bias op, since a
-real Conv already carries any bias in its own optional third input, and
+real Conv already carries any bias in its own optional third input (a
+per-channel ``PRelu`` `slope` -- see below -- is not such a bias/scale op at
+all, just another "one value per channel" operand riding a shape-preserving
+activation, the same reason a depthwise Conv's own weight already crosses
+transparently here), and
 ``BatchNormalization`` is expected to already be fused into the preceding
 Conv's weight by the time this pass runs (onnxsim's own default
 optimization does exactly that, see ``fuse_bn_into_conv``), so a raw
@@ -628,6 +632,52 @@ memory layout into the Gemm weight's own input columns -- a fundamentally
 different, harder problem than the plain axis slice every hop in this
 section performs, not a bigger version of the same one (see
 `_CONV_POOL_PASS_THROUGH`'s own comment for the precise boundary).
+
+A Conv chain also crosses a mid-chain ``PRelu`` -- the
+``Conv -> PRelu -> Conv`` shape a real MobileFaceNet/ResNet-style
+face-recognition backbone's own per-channel activation takes, previously
+unpruned end to end the same way the un-recognized `MaxPool`/`Resize`/`Pad`
+shapes above once were (confirmed empirically with zero live hits before
+this support existed, via ``grep -n "PRelu"`` over this Conv-chain-walking
+section) -- transparently, but only when `slope` (its second input) cleanly
+falls into one of the two shapes real exporters produce (see
+:func:`_match_prelu_pass_through`'s own docstring for the exact bar,
+confirmed live via a real ``torch.onnx.export`` of both
+``nn.PReLU(num_parameters=C)`` and ``nn.PReLU(1)``, and by direct
+``onnxruntime.InferenceSession`` execution against an independently,
+already-pruned reference model for both): a **per-channel** `slope`
+(``[C, 1, ..., 1]``, one value per channel, no cross-channel mixing at all --
+the same "one weight row per channel" shape a depthwise Conv's own weight
+already is) is co-sliced by the chain's own `keep` index set, reusing
+:class:`_ConvPassThrough`/:func:`_apply_conv_pass_through_hop` directly
+rather than a dedicated hop type -- PRelu has no ``group`` attribute for
+that shared apply path's own op-type dispatch to (correctly) leave alone,
+the same way it already leaves `CausalConvWithState` alone; a **scalar**
+(single-shared-parameter) `slope` multiplies every channel identically, so
+pruning some away changes nothing about it -- it is left completely
+untouched, folded into `chain_ops` exactly like a pooling/`Resize`/`Pad`
+hop's own "nothing to slice" entry. Unlike `CausalConvWithState` (forward
+walk only) but like every other hop in this paragraph's family, a PRelu hop
+is recognized in *both* directions (:func:`_walk_to_conv_consumer`'s forward
+walk and :func:`_walk_conv_producer_backward`'s backward walk, the latter
+via :func:`_match_prelu_pass_through_self`'s self-consistent variant,
+mirroring the depthwise-Conv self-check's own trick), so it composes for
+free with the residual/merge and Concat-branch machinery described below,
+the same way a depthwise Conv hop already does. A MatMul/Gemm chain crosses
+a mid-chain ``PRelu`` too (:func:`_walk_to_consumer`/
+:func:`_walk_matmul_producer_backward`, via
+:func:`_match_prelu_pass_through_matmul`/
+:func:`_match_prelu_pass_through_matmul_self`) -- the same scalar-vs-
+per-channel split, just against that chain family's own last-axis-is-channel
+convention (:func:`_flat_channel_const`'s own bar) rather than axis 1, so a
+per-channel `slope` there is a bare ``[C]``, not `[C, 1, 1]`, and needs no
+dedicated hop type at all -- an ordinary ``(node, slope_name)`` `chain_ops`
+entry, exactly like a bias/scale ``Add``/``Mul`` hop's own constant, already
+suffices. A bare rank-1 `[C]` slope is deliberately *not* treated as
+per-channel on the Conv side -- see :func:`_match_prelu_pass_through`'s own
+docstring for why the two chain families' opposite channel-axis conventions
+make the same literal shape safe on one side and unsafe, unproven, on the
+other.
 
 Within that, three ``group`` shapes are distinguished. Ordinary
 (``group=1``) Conv is the base case already described above. The
@@ -3432,23 +3482,29 @@ class _Producer:
 
 @dataclass(frozen=True)
 class _ConvPassThrough:
-    """A depthwise Conv (``group == in_channels == out_channels``) -- or a
-    plain ``ai.onnx::CausalConvWithState`` node, the same "one weight row
-    per channel, no cross-channel mixing" shape (see
-    :func:`_match_causal_conv_with_state_pass_through` and this module's own
-    "Conv/pooling/Resize/Pad pass-through" section comment) -- the chain walk
-    crossed transparently between a Conv chain's real producer and real
-    consumer. Neither mixes channels at all -- output channel ``i`` depends
-    only on input channel ``i`` -- so neither needs any independent
-    importance of its own the way a producer/consumer boundary does; each is
-    carried on the matched :class:`_Chain` purely so
-    :func:`_apply_conv_pass_through_hop` can slice its own ``[C, 1, k1, ...,
-    kn]`` weight (and bias, if present) by the *same* `keep` index set as the
-    chain's real producer. A depthwise Conv additionally gets its own
-    ``group`` attribute updated to the new channel count;
-    ``CausalConvWithState`` has no such attribute at all (its channel count
-    is implied purely by its weight's own axis-0 size), so nothing is
-    rewritten there for it. See :func:`_walk_to_conv_consumer`.
+    """A depthwise Conv (``group == in_channels == out_channels``), a plain
+    ``ai.onnx::CausalConvWithState`` node, or a per-channel ``PRelu`` --
+    three genuinely different ops sharing the same "one weight row per
+    channel, no cross-channel mixing" shape (see
+    :func:`_match_causal_conv_with_state_pass_through`/
+    :func:`_match_prelu_pass_through` and this module's own "Conv/pooling/
+    Resize/Pad pass-through" section comment) -- the chain walk crossed
+    transparently between a Conv chain's real producer and real consumer.
+    None mixes channels at all -- output channel ``i`` depends only on input
+    channel ``i`` -- so none needs any independent importance of its own the
+    way a producer/consumer boundary does; each is carried on the matched
+    :class:`_Chain` purely so :func:`_apply_conv_pass_through_hop` can slice
+    its own ``[C, 1, k1, ..., kn]``-shaped weight (and bias, if present) by
+    the *same* `keep` index set as the chain's real producer -- PRelu's own
+    ``[C, 1, ..., 1]`` `slope` fits this identical axis-0, any-trailing-rank
+    slice with no kernel dims of its own to worry about, needing no
+    dedicated hop type. A depthwise Conv additionally gets its own ``group``
+    attribute updated to the new channel count; neither
+    ``CausalConvWithState`` nor ``PRelu`` has any such attribute at all
+    (`CausalConvWithState`'s channel count is implied purely by its weight's
+    own axis-0 size; `PRelu` has no channel-count attribute at all, ever),
+    so nothing is rewritten there for either. See
+    :func:`_walk_to_conv_consumer`.
     """
 
     node: onnx.NodeProto
@@ -3640,16 +3696,20 @@ def _apply_conv_pass_through_hop(
 
     A depthwise ``Conv`` hop's own `group` attribute (`== in_channels ==
     out_channels`) drops to the new channel count right alongside its
-    weight/bias, via :func:`_set_conv_group_attr` -- `CausalConvWithState`
-    has no such attribute at all (confirmed via live schema introspection,
-    ``onnx.defs.get_schema("CausalConvWithState", domain="")``: its own
-    channel count is implied purely by its weight's own axis-0 size, no
-    `group`/channel-count attribute exists on it to rewrite), so nothing is
-    rewritten there for it -- dispatched purely on `hop.node.op_type`, since
-    only these two op types ever reach this function (see
+    weight/bias, via :func:`_set_conv_group_attr` -- neither
+    `CausalConvWithState` nor `PRelu` has any such attribute at all
+    (confirmed via live schema introspection,
+    ``onnx.defs.get_schema("CausalConvWithState", domain="")``/
+    ``onnx.defs.get_schema("PRelu")``: `CausalConvWithState`'s own channel
+    count is implied purely by its weight's own axis-0 size, and `PRelu` has
+    no channel-count-describing attribute of any kind, no
+    `group`/channel-count attribute exists on either to rewrite), so nothing
+    is rewritten there for either -- dispatched purely on `hop.node.op_type`,
+    since only these three op types ever reach this function (see
     :func:`_match_depthwise_conv_pass_through`/
-    :func:`_match_causal_conv_with_state_pass_through`, the only two
-    matchers that ever construct a :class:`_ConvPassThrough`).
+    :func:`_match_causal_conv_with_state_pass_through`/
+    :func:`_match_prelu_pass_through`/:func:`_match_prelu_pass_through_self`,
+    the only matchers that ever construct a :class:`_ConvPassThrough`).
     """
     _slice_producer_weight(initializer_map[hop.weight], False, keep, is_conv=True)
     if hop.bias is not None:
@@ -3695,6 +3755,82 @@ def _match_producer(
             return None  # non-constant bias -- can't safely prune it
     n_channels = w_init.dims[0] if weight_transposed else w_init.dims[1]
     return w_name, weight_transposed, bias_name, n_channels
+
+
+def _match_prelu_pass_through_matmul(
+    node: onnx.NodeProto,
+    initializer_map: Dict[str, onnx.TensorProto],
+    n_channels: int,
+) -> Optional[Tuple[bool, Optional[str]]]:
+    """The MatMul/Gemm-chain analogue of :func:`_match_prelu_pass_through`
+    (that function's own docstring covers the shared reasoning in full --
+    only what differs is restated here): since a MatMul/Gemm chain's own
+    channel axis is the tensor's *last* axis, not axis 1 (see this module's
+    own docstring), `slope`'s per-channel shape here is the same flat,
+    last-axis-is-channel vector every other MatMul/Gemm hop's own constant
+    operand is already held to (:func:`_flat_channel_const`'s own
+    ``prod(dims) == dims[-1]`` bar -- e.g. a bare `[C]`, safe here in a way
+    it is *not* for a Conv chain's own `[C, 1, 1]` convention, since there is
+    no trailing spatial axis for a rank-1 `[C]` to spuriously align against
+    instead). Returns ``(is_per_channel, slope_name_or_None)`` with the
+    identical scalar (``prod(dims) == 1`` -- left untouched) vs. per-channel
+    (``dims[-1] == n_channels`` -- co-sliced, folded into the caller's own
+    `chain_ops` as an ordinary ``(node, slope_name)`` entry, no dedicated hop
+    type needed here the way the Conv walk's axis-0 slice needs
+    :class:`_ConvPassThrough`) split :func:`_match_prelu_pass_through` makes,
+    just against the opposite axis convention. Declines (``None``) the same
+    conservative way for a missing/non-constant/otherwise-malformed `slope`.
+    """
+    if node.op_type != "PRelu" or node.domain != "":
+        return None
+    if len(node.input) != 2 or not node.input[0] or not node.input[1]:
+        return None
+    if len(node.output) != 1:
+        return None
+    slope_name = node.input[1]
+    s_init = initializer_map.get(slope_name)
+    if s_init is None or not _is_supported_float_dtype(s_init.data_type):
+        return None
+    dims = list(s_init.dims)
+    if not dims:
+        return None
+    if int(np.prod(dims)) == 1:
+        return False, None  # scalar / single shared parameter -- untouched
+    if int(np.prod(dims)) == dims[-1] and dims[-1] == n_channels:
+        return True, slope_name
+    return None
+
+
+def _match_prelu_pass_through_matmul_self(
+    node: onnx.NodeProto, initializer_map: Dict[str, onnx.TensorProto]
+) -> Optional[Tuple[bool, Optional[str]]]:
+    """The backward-walk (:func:`_walk_matmul_producer_backward`) counterpart
+    of :func:`_match_prelu_pass_through_matmul`, mirroring
+    :func:`_match_prelu_pass_through_self`'s identical trick for the Conv
+    walk: the backward residual/``Concat``-branch walk doesn't know its
+    group's real shared channel count yet at the point it first crosses a
+    PRelu hop, so this checks `slope`'s own shape is self-consistent by
+    calling that same matcher with `slope`'s own `dims[-1]` as the "expected"
+    channel count -- trivially satisfying the per-channel case's own
+    ``dims[-1] == n_channels`` check (and never even consulted by the scalar
+    case, which only ever compares `slope`'s own total size to ``1``).
+    :func:`_find_matmul_residual_chains` already re-validates every
+    `chain_ops` constant this walk returns against the group's real channel
+    count once resolved (the same generic, hop-kind-agnostic check its own
+    bias/scale ``Add``/``Mul`` and ``BiasGelu``/``FastGelu`` hops already
+    get -- see that function's own comment), so no PRelu-specific
+    re-validation is needed here.
+    """
+    if node.op_type != "PRelu" or node.domain != "" or len(node.input) != 2:
+        return None
+    slope_name = node.input[1]
+    if not slope_name:
+        return None
+    s_init = initializer_map.get(slope_name)
+    if s_init is None:
+        return None
+    expected = s_init.dims[-1] if list(s_init.dims) else 1
+    return _match_prelu_pass_through_matmul(node, initializer_map, expected)
 
 
 def _match_fused_bias_gelu(
@@ -3766,13 +3902,20 @@ def _walk_to_consumer(
     elementwise ops (an activation, an Add/Mul against a constant
     per-channel bias/scale, a fused ``com.microsoft::BiasGelu``/
     ``FastGelu`` node -- see `_FUSED_BIAS_GELU_OPS`'s own comment and
-    :func:`_match_fused_bias_gelu` -- or a plain `_NORM_PASS_THROUGH_OPS`
+    :func:`_match_fused_bias_gelu` -- a plain `_NORM_PASS_THROUGH_OPS`
     node whose own ``axis`` normalizes exactly `cur`'s last axis -- see that
     constant's own comment, :func:`_norm_axis_is_last`, and
-    :func:`_norm_pass_through_const_names`) with no other consumer anywhere
-    along the way, until a MatMul/vanilla-Gemm consumer is found whose
-    reduction dimension matches `n_channels`. Returns ``(None, ())`` if the
-    walk runs out of hops, hits a branch, or never reaches such a consumer.
+    :func:`_norm_pass_through_const_names` -- or a ``PRelu`` node (see
+    :func:`_match_prelu_pass_through_matmul`): a *scalar* or
+    single-shared-parameter `slope` (every dimension size 1) needs no
+    operand of its own sliced, the same shape a plain unary activation hop
+    already gets; a *per-channel* `slope` (flat, last-axis-is-channel,
+    exactly :func:`_flat_channel_const`'s own bar) is co-sliced exactly like
+    an `Add`/`Mul` hop's own constant already is) with no other consumer
+    anywhere along the way, until a MatMul/vanilla-Gemm consumer is found
+    whose reduction dimension matches `n_channels`. Returns ``(None, ())`` if
+    the walk runs out of hops, hits a branch, or never reaches such a
+    consumer.
 
     `forced_first_hop`, when given, is used as the walk's very first hop
     instead of deriving it from `consumers_of[start]` -- see
@@ -3853,6 +3996,16 @@ def _walk_to_consumer(
             ):
                 break
             const_name = bias_name
+        elif nxt.op_type == "PRelu" and nxt.domain == "":
+            if not nxt.input or nxt.input[0] != cur:
+                break
+            prelu_match = _match_prelu_pass_through_matmul(
+                nxt, initializer_map, n_channels
+            )
+            if prelu_match is None:
+                break
+            is_per_channel, slope_name = prelu_match
+            const_name = slope_name if is_per_channel else None
         elif nxt.op_type in _NORM_PASS_THROUGH_OPS and nxt.domain == "":
             if not nxt.input or nxt.input[0] != cur:
                 break
@@ -4599,6 +4752,107 @@ def _match_pad_channel_pass_through(
     return begin == 0 and end == 0
 
 
+def _match_prelu_pass_through(
+    node: onnx.NodeProto,
+    initializer_map: Dict[str, onnx.TensorProto],
+    n_channels: int,
+) -> Optional[Tuple[bool, Optional[str]]]:
+    """If `node` is a plain (default-domain) ``PRelu`` node (`node.input[0]`
+    the tensor being walked through) whose own ``slope`` (input 1) is a
+    constant float initializer cleanly falling into one of the two shapes
+    real exporters produce, returns ``(is_per_channel, slope_name_or_None)``:
+
+    - **scalar / single shared parameter** (every dimension size 1 --
+      ``prod(dims) == 1``, e.g. a bare scalar, `[1]`, or the `[1, 1, 1]` a
+      real ``torch.onnx.export`` of ``nn.PReLU(1)`` emits, confirmed live)
+      -- ``(False, None)``: the same value multiplies every channel, so
+      pruning some away changes nothing about it -- it is left completely
+      untouched, the same "no operand of its own to slice" shape a unary
+      activation hop already gets.
+    - **per-channel** (``dims[0] == n_channels``, every other dimension size
+      1 -- e.g. the `[C, 1, 1]` a real ``torch.onnx.export`` of
+      ``nn.PReLU(C)`` emits for a 2-D Conv, confirmed live) --
+      ``(True, slope_name)``: one independent value per channel, co-sliced
+      by the chain's own `keep` index set exactly like a depthwise Conv
+      hop's own weight already is (see :class:`_ConvPassThrough`, which this
+      module reuses for this hop rather than a dedicated type -- `slope`'s
+      ``[C, 1, ..., 1]`` layout needs exactly the same axis-0,
+      any-trailing-rank slice :func:`_slice_producer_weight` already
+      performs for a depthwise Conv's own weight, and PRelu has no `group`
+      attribute for :func:`_apply_conv_pass_through_hop`'s own dispatch to
+      (correctly) leave untouched).
+
+    A bare rank-1 `[C]` slope is deliberately **not** treated as per-channel
+    here, unlike a MatMul/Gemm chain's own last-axis-is-channel convention
+    (:func:`_flat_channel_const`) -- this module's Conv-chain machinery
+    assumes NCHW's axis-1-is-channel convention throughout (see this
+    module's own docstring), and ONNX's unidirectional broadcasting aligns
+    a slope's own dimensions against `X`'s *trailing* ones: a `[C]` slope
+    padded against a rank-4 `NCHW` tensor lands on axis 3 (`W`), not axis 1,
+    unless `C` happens to equal `W` by coincidence -- confirmed live via a
+    real ``torch.onnx.export`` of ``nn.PReLU(C)``, which always emits the
+    trailing-``1``s-padded `[C, 1, 1]` shape above, never a bare `[C]`, for
+    exactly this reason. Requiring at least one trailing size-1 dimension
+    (``len(dims) >= 2``) is what rules a bare `[C]` out here.
+
+    Declines (``None``) whenever `node` isn't a plain ``PRelu``, `slope`
+    is missing or non-constant, or its shape doesn't cleanly fall into
+    either shape above (e.g. a per-*group*, non-per-channel, or otherwise
+    malformed shape) -- never guessed at, the same conservative bar every
+    other hop in this module already holds its own constant operand to.
+    """
+    if node.op_type != "PRelu" or node.domain != "":
+        return None
+    if len(node.input) != 2 or not node.input[0] or not node.input[1]:
+        return None
+    if len(node.output) != 1:
+        return None
+    slope_name = node.input[1]
+    s_init = initializer_map.get(slope_name)
+    if s_init is None or not _is_supported_float_dtype(s_init.data_type):
+        return None
+    dims = list(s_init.dims)
+    if not dims:
+        return None
+    if int(np.prod(dims)) == 1:
+        return False, None  # scalar / single shared parameter -- untouched
+    if len(dims) >= 2 and dims[0] == n_channels and all(d == 1 for d in dims[1:]):
+        return True, slope_name
+    return None
+
+
+def _match_prelu_pass_through_self(
+    node: onnx.NodeProto, initializer_map: Dict[str, onnx.TensorProto]
+) -> Optional[Tuple[bool, Optional[str]]]:
+    """The PRelu pass-through check :func:`_walk_conv_producer_backward` uses:
+    unlike :func:`_match_prelu_pass_through`, which validates a hop against an
+    externally supplied `n_channels`, the backward residual walk doesn't know
+    its group's shared channel count yet at the point it first crosses a
+    PRelu hop, so this checks the node's own `slope` is self-consistently
+    shaped by calling that same matcher with `slope`'s own `dims[0]` as the
+    "expected" channel count -- trivially satisfying the per-channel case's
+    own `dims[0] == n_channels` check and leaving every other one (including
+    the scalar case, which never even looks at `n_channels`) intact. Mirrors
+    :func:`_match_conv_pass_through_self`'s identical trick for a depthwise
+    Conv hop. :func:`_find_conv_residual_chains`/:func:`_find_conv_concat_chains`'s
+    own branch resolution re-validates every per-channel hop this returns
+    against the group's real, established channel count once the whole group
+    is resolved (the same generic `pass_through` re-validation a depthwise
+    hop already gets, keyed only on `hop.weight`'s own `dims[0]`, needing no
+    PRelu-specific case of its own).
+    """
+    if node.op_type != "PRelu" or node.domain != "" or len(node.input) != 2:
+        return None
+    slope_name = node.input[1]
+    if not slope_name:
+        return None
+    s_init = initializer_map.get(slope_name)
+    if s_init is None:
+        return None
+    expected = s_init.dims[0] if list(s_init.dims) else 1
+    return _match_prelu_pass_through(node, initializer_map, expected)
+
+
 def _walk_to_conv_consumer(
     start: str,
     initializer_map: Dict[str, onnx.TensorProto],
@@ -4634,8 +4888,16 @@ def _walk_to_conv_consumer(
     `conv_pass_through`, but with no `group` attribute to update; this
     forward walk is the *only* one of the two Conv-chain walkers that
     recognizes it -- see that section comment's own scope-boundary note for
-    why the backward walk, :func:`_walk_conv_producer_backward`, cannot),
-    and -- when
+    why the backward walk, :func:`_walk_conv_producer_backward`, cannot), a
+    ``PRelu`` hop (see :func:`_match_prelu_pass_through`) -- a *scalar* or
+    single-shared-parameter `slope` (every dimension size 1) is folded into
+    `chain_ops` like a pooling/`Resize`/`Pad` hop (nothing to slice, the same
+    value multiplies every surviving channel unchanged), while a
+    *per-channel* `slope` (`[C, 1, ..., 1]`) is returned via
+    `conv_pass_through` instead, exactly like a depthwise Conv's own weight
+    -- recognized by *both* Conv-chain walkers, unlike `CausalConvWithState`,
+    since :func:`_match_prelu_pass_through_self` needs no externally supplied
+    channel count the way `CausalConvWithState`'s own hop would, and -- when
     `recognize_group_norm` -- at most one mid-chain ``GroupNormalization``
     hop (see :func:`_match_group_norm_pass_through` and
     `_GROUP_NORM_PASS_THROUGH_OP`'s own comment for why only one, and why
@@ -4820,6 +5082,28 @@ def _walk_to_conv_consumer(
             chain_ops.append((nxt, None))
             cur = out2
             continue
+
+        if (
+            nxt.op_type == "PRelu"
+            and nxt.domain == ""
+            and nxt.input
+            and nxt.input[0] == cur
+            and len(nxt.output) == 1
+        ):
+            prelu_match = _match_prelu_pass_through(nxt, initializer_map, n_channels)
+            if prelu_match is not None:
+                out2 = nxt.output[0]
+                if len(consumers_of.get(out2, [])) != 1 or out2 in graph_outputs:
+                    break
+                is_per_channel, slope_name = prelu_match
+                if is_per_channel:
+                    assert slope_name is not None
+                    conv_pass_through.append(_ConvPassThrough(nxt, slope_name, None))
+                else:
+                    chain_ops.append((nxt, None))
+                cur = out2
+                continue
+            break
 
         if not (
             (
@@ -5106,14 +5390,21 @@ def _walk_conv_producer_backward(
     activations, self-consistently-depthwise Conv hops (see
     :func:`_match_conv_pass_through_self`), spatial pooling ops that never
     mix channels (``MaxPool``/``AveragePool``/``GlobalAveragePool``,
-    unconditionally -- see `_CONV_POOL_PASS_THROUGH`'s own comment), and a
+    unconditionally -- see `_CONV_POOL_PASS_THROUGH`'s own comment), a
     channel-axis-unaffected ``Resize``/``Pad`` (see
     :func:`_match_resize_channel_pass_through`/
     :func:`_match_pad_channel_pass_through` -- neither needs this walk's own
     not-yet-known group channel count, since `_match_resize_channel_pass_
     through` only ever recognizes a `scales`-driven `Resize`, a ratio that
     needs no channel count to validate, never a `sizes`-driven one -- see
-    that function's own docstring for why), declining (only) whenever a
+    that function's own docstring for why), and a self-consistently-shaped
+    ``PRelu`` hop (see :func:`_match_prelu_pass_through_self`, which -- like
+    the depthwise-Conv self-check above -- needs no externally supplied
+    channel count either, since a scalar `slope`'s own shape needs none at
+    all and a per-channel `slope`'s own `dims[0]` trivially satisfies its
+    own "expected count" check; re-validated for real once the group's
+    channel count is known, exactly like a depthwise Conv hop already is),
+    declining (only) whenever a
     tensor crossed -- `start` itself included -- is a graph output (a
     caller-observed shape this pass never resizes); *how many* other things
     also read that same tensor is deliberately **not** checked here -- see
@@ -5225,6 +5516,18 @@ def _walk_conv_producer_backward(
             node, initializer_map
         ):
             unary_ops.append(node)
+            edges.append((node.input[0], node))
+            cur = node.input[0]
+            continue
+
+        prelu_self_match = _match_prelu_pass_through_self(node, initializer_map)
+        if prelu_self_match is not None:
+            is_per_channel, slope_name = prelu_self_match
+            if is_per_channel:
+                assert slope_name is not None
+                pass_through.append(_ConvPassThrough(node, slope_name, None))
+            else:
+                unary_ops.append(node)
             edges.append((node.input[0], node))
             cur = node.input[0]
             continue
@@ -5993,14 +6296,19 @@ def _walk_matmul_producer_backward(
     Tuple[Tuple[onnx.NodeProto, Optional[str]], ...],
     Tuple[Tuple[str, onnx.NodeProto], ...],
 ]:
-    """The backward counterpart of :func:`_walk_to_consumer`, used only by
+    """The backward counterpart of :func:`_walk_to_consumer`, used by
     :func:`_find_matmul_residual_chains` to resolve one operand of an
     eligible merge node (see :func:`_match_matmul_residual_merge`) back to
-    whatever produces it -- the MatMul/Gemm analogue of
-    :func:`_walk_conv_producer_backward` (see this function's own section
-    comment above for how the two differ: a wider hop set mirroring
-    `_walk_to_consumer`'s own per-channel bias/scale ``Add``/``Mul`` hop,
-    and no depthwise-pass-through analogue at all). Declines (only) whenever
+    whatever produces it, and by :func:`_find_matmul_concat_chains` to
+    resolve one branch of a channel-axis ``Concat`` the same way -- the
+    MatMul/Gemm analogue of :func:`_walk_conv_producer_backward` (see this
+    function's own section comment above for how the two differ: a wider hop
+    set mirroring `_walk_to_consumer`'s own per-channel bias/scale
+    ``Add``/``Mul`` and ``PRelu`` hops -- the latter via
+    :func:`_match_prelu_pass_through_matmul_self`, the self-consistent
+    backward-walk counterpart of :func:`_match_prelu_pass_through_matmul`,
+    mirroring the depthwise-Conv self-check's identical trick -- and no
+    depthwise-pass-through analogue at all). Declines (only) whenever
     a tensor crossed -- `start` itself included -- is a graph output (a
     caller-observed shape this pass never resizes); *how many* other things
     also read that same tensor is deliberately **not** checked here -- see
@@ -6235,6 +6543,16 @@ def _walk_matmul_producer_backward(
                 chain_ops.append((node, bias_name))
                 edges.append((data_name, node))
                 cur = data_name
+                continue
+            return "fail", None, (), ()
+
+        if node.op_type == "PRelu" and node.domain == "" and len(node.input) == 2:
+            prelu_match = _match_prelu_pass_through_matmul_self(node, initializer_map)
+            if prelu_match is not None:
+                is_per_channel, slope_name = prelu_match
+                chain_ops.append((node, slope_name if is_per_channel else None))
+                edges.append((node.input[0], node))
+                cur = node.input[0]
                 continue
             return "fail", None, (), ()
 
@@ -8616,14 +8934,15 @@ def _apply_concat_chains(
                 # handling: channel i is exactly upstream channel i, so the
                 # hop's own weight/bias slice by this branch's own `keep`
                 # -- see :func:`_apply_conv_pass_through_hop`. (In practice
-                # this is always a depthwise `Conv` hop here, never a
-                # `CausalConvWithState` one -- see that op's own "Conv/
-                # pooling/Resize/Pad pass-through" section-comment scope
-                # note: it's only ever recognized by the forward walk, and
-                # this `b.conv_pass_through` is populated by the *backward*
-                # one -- but routing through the shared helper regardless
-                # keeps this branch correct even if that ever changes,
-                # rather than duplicating its op-type dispatch here too.)
+                # this is always a depthwise `Conv` or per-channel `PRelu`
+                # hop here, never a `CausalConvWithState` one -- see that
+                # op's own "Conv/pooling/Resize/Pad pass-through"
+                # section-comment scope note: it's only ever recognized by
+                # the forward walk, and this `b.conv_pass_through` is
+                # populated by the *backward* one -- but routing through the
+                # shared helper regardless keeps this branch correct even if
+                # that ever changes, rather than duplicating its op-type
+                # dispatch here too.)
                 _apply_conv_pass_through_hop(hop, initializer_map, keep, len(keep))
 
         global_keep = np.concatenate(

--- a/scripts/cross/run_s390x_tests.sh
+++ b/scripts/cross/run_s390x_tests.sh
@@ -95,10 +95,11 @@ print(sys.byteorder, \"endian | python\", sys.version.split()[0],
 # above, only tests/ and pyproject.toml are copied into the chroot, so none of
 # those imports resolve there regardless of what's pip-installed. Same story
 # for test_check_decode_parity.py, which imports scripts/apple/check_decode_parity
-# at module scope, and test_compute_retention.py, which imports
-# scripts/apple/compute_retention the same way. test_rtdetrv4.py imports
-# onnxruntime directly at module scope for the same "no s390x build" reason
-# as test_qnn_compat.py and friends above.
+# at module scope, and test_compute_retention.py, test_run_quality_eval.py and
+# test_aggregate_quality_trend.py, which import scripts/apple/compute_retention,
+# scripts/apple/run_quality_eval and scripts/apple/aggregate_quality_trend the
+# same way. test_rtdetrv4.py imports onnxruntime directly at module scope for
+# the same "no s390x build" reason as test_qnn_compat.py and friends above.
 #
 # The three deselected BN-fusion tests fail onnxsim's own check_n equivalence
 # check whenever onnxruntime is absent and the reference evaluator is used
@@ -129,6 +130,7 @@ chroot "${SYSROOT}" /bin/sh -c "cd /work && GITHUB_STEP_SUMMARY=${CHROOT_SUMMARY
   --ignore=tests/test_coreml_compat.py --ignore=tests/test_migraphx_compat.py \
   --ignore=tests/test_openvino_compat.py --ignore=tests/test_check_decode_parity.py \
   --ignore=tests/test_compute_retention.py --ignore=tests/test_rtdetrv4.py \
+  --ignore=tests/test_run_quality_eval.py --ignore=tests/test_aggregate_quality_trend.py \
   --deselect tests/test_fusion_patterns.py::test_fuse_conv_bn_into_conv \
   --deselect tests/test_fusion_patterns.py::test_fuse_convtranspose_bn \
   --deselect tests/test_fusion_patterns.py::test_fuse_conv_with_bias_bn_into_conv ${PYTEST_ARGS:-}"

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -5669,6 +5669,348 @@ def test_structured_pruning_pad_dynamic_pads_declines():
     np.testing.assert_array_equal(inits["W2"], w2)
 
 
+# --- Conv chain: PRelu pass-through hop --------------------------------
+#
+# `Conv -> PRelu -> Conv`: the MobileFaceNet/ResNet-style face-recognition
+# backbone shape this hop exists for (previously left completely unpruned
+# end to end -- confirmed empirically, before this hop existed, via
+# `grep -n "PRelu" onnxsim/pruning.py` inside the Conv-chain-walking section
+# returning zero hits). `slope`'s own shape decides which of
+# `_match_prelu_pass_through`'s two cases applies: per-channel
+# (`[C1, 1, 1]`, co-sliced) or scalar/single-shared-parameter (`[1, 1, 1]` --
+# the real shape a `torch.onnx.export` of `nn.PReLU(1)` emits, confirmed
+# live -- left untouched).
+
+
+def _prelu_conv_pair_model(w1, w2, slope, b1=None, spatial=10):
+    Cin, C2 = w1.shape[1], w2.shape[0]
+    initializer = [_f32(w1, "W1"), _f32(w2, "W2"), _f32(slope, "Slope")]
+    if b1 is not None:
+        conv1 = "h = Conv<kernel_shape=[3,3]>(X, W1, B1)"
+        initializer.append(_f32(b1, "B1"))
+    else:
+        conv1 = "h = Conv<kernel_shape=[3,3]>(X, W1)"
+    out_spatial = spatial - 4  # two valid (no-pad) 3x3 convs
+    return _model(
+        f"""
+        g (float[N,{Cin},{spatial},{spatial}] X) => (float[N,{C2},{out_spatial},{out_spatial}] Y)
+        {{
+          {conv1}
+          a = PRelu(h, Slope)
+          Y = Conv<kernel_shape=[3,3]>(a, W2)
+        }}
+        """,
+        initializer=initializer,
+    )
+
+
+def test_structured_pruning_prelu_per_channel_pass_through_matches_oracle_exactly():
+    # THE key correctness bar, same as every other Conv-chain hop's own
+    # oracle test: exact equivalence (float32 noise only) to an
+    # independently, already-pruned reference model whose own `slope` is
+    # sliced to the same kept indices from the start -- not "close", and not
+    # "run the original PRelu, then slice its output" after the fact.
+    Cin, C1, C2 = 3, 16, 8
+    rng = np.random.default_rng(90)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    b1 = rng.standard_normal((C1,)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    slope = rng.standard_normal((C1, 1, 1)).astype(np.float32)
+    model = _prelu_conv_pair_model(w1, w2, slope, b1=b1)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    dims_after = _initializer_dims(pruned)
+    assert dims_after["W1"][0] == C1 // 2
+    assert dims_after["W2"][1] == C1 // 2
+    assert dims_after["Slope"] == (C1 // 2, 1, 1)
+
+    keep = _oracle_keep_indices_conv(w1, C1 // 2)
+    oracle = _prelu_conv_pair_model(w1[keep], w2[:, keep], slope[keep], b1=b1[keep])
+
+    rng_x = np.random.default_rng(91)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_prelu_scalar_shared_slope_pass_through_matches_oracle_exactly():
+    # A scalar/single-shared-parameter `slope` (`nn.PReLU(1)` in torch
+    # terms) multiplies every channel identically, so it must be left
+    # completely untouched -- unlike the per-channel case, `Slope`'s own
+    # shape stays exactly `(1, 1, 1)` after pruning, byte-identical to the
+    # original.
+    Cin, C1, C2 = 3, 16, 8
+    rng = np.random.default_rng(92)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    slope = rng.standard_normal((1, 1, 1)).astype(np.float32)
+    model = _prelu_conv_pair_model(w1, w2, slope)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    dims_after = _initializer_dims(pruned)
+    assert dims_after["W1"][0] == C1 // 2
+    assert dims_after["W2"][1] == C1 // 2
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["Slope"], slope)  # left completely untouched
+
+    keep = _oracle_keep_indices_conv(w1, C1 // 2)
+    oracle = _prelu_conv_pair_model(w1[keep], w2[:, keep], slope)
+
+    rng_x = np.random.default_rng(93)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_prelu_mismatched_slope_shape_declines():
+    # A `slope` shape that cleanly falls into neither the per-channel
+    # (`dims[0] == n_channels`, every other dim size 1) nor the scalar
+    # (`prod(dims) == 1`) case -- here, one value per *pair* of channels, a
+    # per-group-style shape this hop is not held to guess the semantics of
+    # -- must decline the whole chain outright, never mis-sliced.
+    Cin, C1, C2 = 3, 8, 4
+    rng = np.random.default_rng(94)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    slope = rng.standard_normal((C1 // 2, 1, 1)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{C2},6,6] Y)
+        {{
+          h = Conv<kernel_shape=[3,3]>(X, W1)
+          a = PRelu(h, Slope)
+          Y = Conv<kernel_shape=[3,3]>(a, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2"), _f32(slope, "Slope")],
+    )
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+    np.testing.assert_array_equal(inits["Slope"], slope)
+
+
+def test_structured_pruning_prelu_bare_rank1_channel_shape_declines():
+    # A bare rank-1 `[C1]` slope -- deliberately *not* treated as
+    # per-channel for a Conv chain (unlike a MatMul/Gemm chain's own
+    # last-axis-is-channel convention): ONNX's unidirectional broadcasting
+    # would align it against the *trailing* (spatial) axis of a rank-4 NCHW
+    # tensor, not axis 1, so accepting it here would risk silently mis-
+    # slicing a tensor that isn't really per-channel at all. Must decline,
+    # leaving the whole chain untouched.
+    Cin, C1, C2 = 3, 8, 4
+    rng = np.random.default_rng(95)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    slope = rng.standard_normal((C1,)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{C2},6,6] Y)
+        {{
+          h = Conv<kernel_shape=[3,3]>(X, W1)
+          a = PRelu(h, Slope)
+          Y = Conv<kernel_shape=[3,3]>(a, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2"), _f32(slope, "Slope")],
+    )
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+    np.testing.assert_array_equal(inits["Slope"], slope)
+
+
+def _residual_diamond_prelu_model(w_f, w_s, w_out, slope, spatial=10):
+    # The same "projection shortcut" residual shape as
+    # `_residual_diamond_model`, with a per-channel PRelu hop sitting
+    # between the `f` branch's own real Conv producer and the `Add` merge --
+    # crossed transparently by the *backward* walk
+    # (`_walk_conv_producer_backward`, via
+    # `_match_prelu_pass_through_self`) on its way from the Add's own `f`
+    # operand back to its real Conv producer.
+    Cin = w_f.shape[1]
+    Cout = w_out.shape[0]
+    out_spatial = spatial - 4  # two chained 3x3 valid convs
+    return _model(
+        f"""
+        g (float[N,{Cin},{spatial},{spatial}] X) => (float[N,{Cout},{out_spatial},{out_spatial}] Y)
+        {{
+          f = Conv<kernel_shape=[3,3]>(X, WF)
+          fp = PRelu(f, Slope)
+          s = Conv<kernel_shape=[3,3]>(X, WS)
+          addr = Add(fp, s)
+          r = Relu(addr)
+          Y = Conv<kernel_shape=[3,3]>(r, WOUT)
+        }}
+        """,
+        initializer=[
+            _f32(w_f, "WF"),
+            _f32(w_s, "WS"),
+            _f32(w_out, "WOUT"),
+            _f32(slope, "Slope"),
+        ],
+    )
+
+
+def test_structured_pruning_conv_residual_add_prelu_pass_through_matches_oracle():
+    # Exercises the *backward* walk's own PRelu hop
+    # (`_match_prelu_pass_through_self`), not just the forward one the tests
+    # above cover: a per-channel PRelu sitting between a residual branch's
+    # own real Conv producer and the `Add` merge must be crossed
+    # transparently and its `Slope` co-sliced by the same combined-
+    # importance `keep` set both producers share.
+    Cin, C, Cout = 3, 16, 8
+    rng = np.random.default_rng(96)
+    w_f = rng.standard_normal((C, Cin, 3, 3)).astype(np.float32)
+    w_s = rng.standard_normal((C, Cin, 3, 3)).astype(np.float32)
+    w_out = rng.standard_normal((Cout, C, 3, 3)).astype(np.float32)
+    slope = rng.standard_normal((C, 1, 1)).astype(np.float32)
+    model = _residual_diamond_prelu_model(w_f, w_s, w_out, slope)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    dims_after = _initializer_dims(pruned)
+    assert dims_after["Slope"] == (C // 2, 1, 1)
+
+    importance = np.sqrt(
+        np.square(np.linalg.norm(w_f.reshape(C, -1).astype(np.float64), axis=1))
+        + np.square(np.linalg.norm(w_s.reshape(C, -1).astype(np.float64), axis=1))
+    )
+    keep = np.sort(np.argsort(-importance)[: C // 2])
+    oracle = _residual_diamond_prelu_model(
+        w_f[keep], w_s[keep], w_out[:, keep], slope[keep]
+    )
+
+    rng_x = np.random.default_rng(97)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+# --- MatMul/Gemm chain: PRelu pass-through hop -------------------------
+
+
+def _mlp_prelu_model(K, H, Out, slope, bias=True, seed=0):
+    rng = np.random.default_rng(seed)
+    w1 = rng.standard_normal((K, H)).astype(np.float32)
+    w2 = rng.standard_normal((H, Out)).astype(np.float32)
+    initializer = [_f32(w1, "W1"), _f32(w2, "W2"), _f32(slope, "Slope")]
+    if bias:
+        b1 = rng.standard_normal((H,)).astype(np.float32)
+        gemm1 = "h = Gemm(X, W1, B1)"
+        initializer.append(_f32(b1, "B1"))
+    else:
+        gemm1 = "h = MatMul(X, W1)"
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          {gemm1}
+          a = PRelu(h, Slope)
+          Y = MatMul(a, W2)
+        }}
+        """,
+        initializer=initializer,
+    )
+    return model, w1, w2, (b1 if bias else None)
+
+
+def test_structured_pruning_matmul_prelu_per_channel_pass_through_matches_oracle_exactly():
+    # The MatMul/Gemm-chain analogue of the Conv per-channel test above --
+    # here `slope`'s per-channel shape is the flat, last-axis-is-channel
+    # `[H]` this chain family's own convention uses (`_flat_channel_const`'s
+    # own bar), not the Conv walk's `[C, 1, 1]`.
+    K, H, Out = 8, 32, 4
+    model, w1, w2, b1 = _mlp_prelu_model(
+        K, H, Out, slope=np.random.default_rng(98).standard_normal(H).astype(np.float32)
+    )
+    slope = onnx.numpy_helper.to_array(
+        next(t for t in model.graph.initializer if t.name == "Slope")
+    )
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    dims_after = _initializer_dims(pruned)
+    keep_count = H // 2
+    assert dims_after["W1"][1] == keep_count
+    assert dims_after["Slope"] == (keep_count,)
+
+    keep = _oracle_keep_indices(w1, keep_count)
+    # Built directly (rather than re-invoking `_mlp_prelu_model`, which
+    # always draws its own fresh random weights) so the oracle is sliced
+    # from these exact same arrays.
+    oracle = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          h = Gemm(X, W1, B1)
+          a = PRelu(h, Slope)
+          Y = MatMul(a, W2)
+        }}
+        """,
+        initializer=[
+            _f32(w1[:, keep], "W1"),
+            _f32(w2[keep], "W2"),
+            _f32(b1[keep], "B1"),
+            _f32(slope[keep], "Slope"),
+        ],
+    )
+
+    rng_x = np.random.default_rng(99)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_matmul_prelu_scalar_shared_slope_pass_through_matches_oracle_exactly():
+    # A scalar/single-shared-parameter `slope` -- left completely untouched,
+    # the MatMul/Gemm-chain analogue of the Conv scalar test above.
+    K, H, Out = 8, 32, 4
+    slope = np.random.default_rng(100).standard_normal(1).astype(np.float32)
+    model, w1, w2, b1 = _mlp_prelu_model(K, H, Out, slope=slope)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    dims_after = _initializer_dims(pruned)
+    keep_count = H // 2
+    assert dims_after["W1"][1] == keep_count
+    assert dims_after["Slope"] == (1,)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["Slope"], slope)
+
+    keep = _oracle_keep_indices(w1, keep_count)
+    oracle = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          h = Gemm(X, W1, B1)
+          a = PRelu(h, Slope)
+          Y = MatMul(a, W2)
+        }}
+        """,
+        initializer=[
+            _f32(w1[:, keep], "W1"),
+            _f32(w2[keep], "W2"),
+            _f32(b1[keep], "B1"),
+            _f32(slope, "Slope"),
+        ],
+    )
+
+    rng_x = np.random.default_rng(101)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
 def test_structured_pruning_resize_upsample_concat_unet_decoder_matches_oracle_exactly():
     # The real-world shape this backward-walk extension exists for: a U-Net/
     # diffusion-model-style decoder branch (`Conv -> Resize` upsampling the


### PR DESCRIPTION
## Summary

`Conv → PRelu → Conv` (a common shape in MobileFaceNet/ResNet-style face-recognition backbones) previously went unpruned end to end: `PRelu`'s 2-input shape (`X`, `slope`) correctly declined the existing single-input unary-hop check, but no dedicated hop ever recognized it.

## Empirically confirmed facts

- `onnx.defs.get_schema("PRelu")`: `slope` is a required second input, unidirectionally broadcastable (re-confirmed independently).
- Live `torch.onnx.export` of both `nn.PReLU(num_parameters=C)` and `nn.PReLU(1)` shows the real exported shapes — I independently reproduced this myself in the verified worktree (`nn.PReLU(4)` on a `Conv2d` output → slope initializer shaped exactly `[4, 1, 1]`), confirming the per-channel case pads with trailing `1`s to align against `NCHW`'s axis-1 channel convention under ONNX's unidirectional (right-aligned) broadcasting rules — a bare `[C]` would instead align against the tensor's *trailing* (spatial) axis, which is why the Conv-side matcher deliberately requires `len(dims) >= 2` with trailing-1s rather than accepting a bare `[C]` the way the MatMul/Gemm-side matcher does (that side's last-axis-is-channel convention makes a bare `[C]` the correct/only per-channel shape there instead).
- I independently re-ran the full verification suite in the worktree: `pytest tests/test_pruning.py -q` → **795 passed** (788 → 795, +7 new tests), `ruff format --check`/`ruff check` clean, `mypy onnxsim/pruning.py` (exact scoped command) → **0 errors**, matching baseline.

## What's added / scope

- `_match_prelu_pass_through`/`_match_prelu_pass_through_self` (Conv chains, axis-1-is-channel) and `_match_prelu_pass_through_matmul`/`_match_prelu_pass_through_matmul_self` (MatMul/Gemm chains, last-axis-is-channel). Each splits `slope` into: **per-channel** (co-sliced by the chain's `keep` set) vs. **scalar/single-shared-parameter** (every dim size 1 — left completely untouched) vs. **decline** (any other shape, never guessed at).
- On the Conv side, the per-channel case reuses `_ConvPassThrough`/`_apply_conv_pass_through_hop` directly (no new dataclass) — `slope`'s `[C,1,...,1]` layout needs exactly the same axis-0 slice a depthwise Conv's own weight already gets, and PRelu has no `group` attribute for that path's op-type dispatch to (correctly) skip.
- Wired into all four walker functions (`_walk_to_conv_consumer`, `_walk_conv_producer_backward`, `_walk_to_consumer`, `_walk_matmul_producer_backward`), so it composes for free with the existing residual/merge and Concat-branch machinery — exercised by a dedicated Conv-residual-Add test hitting the backward walk specifically, not just the plain forward-chain case.
- Module docstring, `_ConvPassThrough`'s docstring, `_apply_conv_pass_through_hop`'s docstring, and both walker docstrings updated.

## Test plan

- [x] Conv per-channel pass-through matches an independently-pruned oracle via real onnxruntime execution.
- [x] Conv scalar/shared-slope pass-through leaves the slope untouched.
- [x] MatMul/Gemm per-channel and scalar pass-through, same oracle-matching bar.
- [x] Mismatched-shape decline and bare-rank-1-`[C]`-on-Conv-side decline (the specific broadcast-misalignment case above) — chain declined outright rather than mis-sliced.
- [x] Conv residual-Add composition exercising the backward walk.
- [x] `pytest tests/test_pruning.py -q`: 788 → 795 passed.
- [x] `ruff format --check .` / `ruff check .`: clean.
- [x] `mypy onnxsim/pruning.py` (exact scoped command): 0 errors, matching baseline.

I independently re-verified this PR after implementation: reviewed the full diff of both matcher functions line by line, independently reproduced the `nn.PReLU(4)` → `[4,1,1]` torch export shape claim myself in a fresh script (confirmed exactly as reported), re-ran the entire verification suite (tests/ruff/mypy) fresh in the worktree, and confirmed the working tree was clean with everything properly committed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_