### PR TITLE
Add InstanceNormalization pass-through hop to structured pruning

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -542,8 +542,9 @@ producers; L1's is a plain sum, with no square/sqrt involved at all) and
 support is deliberately
 narrower than the MatMul/Gemm path in one respect that stays true
 regardless of grouping: producers/consumers are joined by unary activations,
-channel-preserving spatial ops (see below), and depthwise/GroupNorm
-pass-through hops -- no per-channel ``Add``/``Mul`` scale-or-bias op, since a
+channel-preserving spatial ops (see below), and depthwise/InstanceNorm/
+GroupNorm pass-through hops -- no per-channel ``Add``/``Mul`` scale-or-bias
+op, since a
 real Conv already carries any bias in its own optional third input, and
 ``BatchNormalization`` is expected to already be fused into the preceding
 Conv's weight by the time this pass runs (onnxsim's own default
@@ -575,6 +576,31 @@ are shaped per-channel (opset 21+'s schema; opset 18-20's differently-shaped,
 now-deprecated per-*group* schema is excluded by the same per-channel shape
 check every other hop in this module already applies, not by inspecting the
 model's own declared opset).
+
+A mid-chain ``InstanceNormalization`` (plain ONNX, standard domain) node is
+*also* special-cased, but reaches a substantially wider scope than GroupNorm
+above for a specific structural reason: its own ``y = scale * (x - mean) /
+sqrt(variance + epsilon) + B`` mean/variance are computed *per instance per
+channel* -- never pooled across a group of channels the way GroupNorm's own
+are -- so there is no group-boundary-drift risk to guard against at all.
+Confirmed both from the op's own math and directly by
+``onnxruntime.InferenceSession`` execution: dropping an *arbitrary* channel
+subset ahead of an InstanceNormalization commutes exactly (``0.0`` max abs
+diff) with slicing the channel axis before or after the op, for any subset
+-- unlike GroupNorm's own uniform-per-``num_groups``-block requirement, no
+constraint on *which* channels survive is needed here. This hop is
+therefore recognized unconditionally (no ``recognize_*`` gate the way
+GroupNorm's own is, and reached by every Conv-chain finder in this module,
+not just the plain single-producer/single-consumer one), any number of
+times per chain, in *both* directions -- treated exactly like a depthwise
+Conv's own "one weight row per channel" pass-through hop (its `scale`/`B`
+sliced by the same `keep` index set, no attribute of its own to rewrite)
+rather than needing GroupNorm's dedicated `num_groups`-aware machinery --
+see `_INSTANCE_NORM_PASS_THROUGH_OP`'s own comment for the full empirical
+finding and reasoning, and :func:`_match_instance_norm_pass_through`'s own
+docstring for why its own `scale`/`B` are held to a *narrower* shape bar
+(strictly rank-1) than GroupNorm's/LayerNorm's shared
+:func:`_flat_channel_const` check.
 
 A Conv chain also crosses four more op kinds transparently, each needing no
 weight of its own sliced (folded into `chain_ops` exactly like a unary
@@ -3279,6 +3305,54 @@ _NORM_PASS_THROUGH_OPS = (
 # rather than guessed" bar that mismatch already gets.
 _GROUP_NORM_PASS_THROUGH_OP = "GroupNormalization"
 
+# InstanceNormalization (plain ONNX, since_version=22 in this environment's
+# own onnx==1.22.0, but the 3-input/per-channel-scale shape below is
+# unchanged all the way back to opset 6 -- confirmed live via
+# ``onnx.defs.get_schema("InstanceNormalization")``) as a *second* Conv-chain
+# pass-through hop, alongside GroupNorm above. Its schema is much narrower
+# than GroupNorm's own multi-opset history: exactly three required inputs
+# (``input``, `scale`, `B` -- unlike GroupNorm's `scale`/`bias`, neither is
+# ever optional or shaped any way other than flat ``[C]``, so no opset-
+# dependent shape ambiguity like GroupNorm's opset-18-vs-21 `scale`/`bias`
+# layout change exists here at all), one required ``epsilon`` attribute this
+# hop never touches, and ``y = scale * (x - mean) / sqrt(variance + epsilon)
+# + B``, where -- this is the key structural difference from GroupNorm --
+# `mean`/`variance` are computed *per instance per channel*, never pooled
+# across a `num_groups`-wide block of channels the way GroupNorm's own
+# statistics are. Confirmed both from the op's own math and empirically
+# (a real `onnxruntime.InferenceSession` run, not assumed): dropping an
+# arbitrary channel *subset* ahead of an InstanceNormalization commutes
+# *exactly* (`0.0` max abs diff) with slicing the channel axis before or
+# after the op -- unlike GroupNorm's own ~0.42 divergence for a same-shape
+# example (see `_GROUP_NORM_PASS_THROUGH_OP`'s own comment), because every
+# channel's own mean/variance is computed from that channel alone, so
+# removing *other* channels can never perturb it. There is therefore no
+# group-boundary-drift risk to guard against at all here, and consequently
+# no `_chain_group`/uniform-per-block machinery to reuse or reimplement the
+# way the GroupNorm hop's own `num_groups` needs: this hop's `scale`/`B`
+# simply need to be sliced by whatever `keep` index set the chain's real
+# producer/consumer already agreed on, exactly like a depthwise Conv's own
+# per-channel weight/bias -- see :class:`_ConvPassThrough`'s own docstring,
+# which this hop reuses directly (its `weight`/`bias` fields hold this op's
+# own `scale`/`B` names) rather than a dedicated tuple type the way
+# :class:`_GroupNormPassThrough` needed one for its extra `num_groups` field.
+# `_apply_conv_pass_through_hop`'s own trailing ``group`` attribute rewrite
+# (keyed on ``node.op_type in ("Conv", "FusedConv")``) is simply never
+# reached for an ``InstanceNormalization`` node -- it has no such attribute
+# at all -- the same "no attribute to rewrite" shape `CausalConvWithState`'s
+# own hop already has. Because there is no per-hop constraint to enforce
+# (unlike GroupNorm, gated behind :func:`_walk_to_conv_consumer`'s own
+# `recognize_group_norm` parameter and gated to *at most one* hop per chain),
+# this hop needs neither restriction: it is recognized unconditionally, any
+# number of times per chain, by both :func:`_walk_to_conv_consumer` and
+# :func:`_walk_conv_producer_backward` alike -- the same "recognized in both
+# directions, everywhere the Conv-chain machinery already threads
+# `conv_pass_through`" scope a depthwise Conv hop already has (residual/merge
+# fan-out branches and Concat-branch resolution included, for free, since
+# they already thread `conv_pass_through` through unchanged). See
+# :func:`_match_instance_norm_pass_through`.
+_INSTANCE_NORM_PASS_THROUGH_OP = "InstanceNormalization"
+
 
 def _flat_channel_const(
     name: str, initializer_map: Dict[str, onnx.TensorProto]
@@ -3432,23 +3506,31 @@ class _Producer:
 
 @dataclass(frozen=True)
 class _ConvPassThrough:
-    """A depthwise Conv (``group == in_channels == out_channels``) -- or a
-    plain ``ai.onnx::CausalConvWithState`` node, the same "one weight row
-    per channel, no cross-channel mixing" shape (see
-    :func:`_match_causal_conv_with_state_pass_through` and this module's own
+    """A depthwise Conv (``group == in_channels == out_channels``), a
+    plain ``ai.onnx::CausalConvWithState`` node, or a plain
+    ``InstanceNormalization`` node -- the same "one weight row per channel,
+    no cross-channel mixing" shape (see
+    :func:`_match_causal_conv_with_state_pass_through`,
+    :func:`_match_instance_norm_pass_through`, and this module's own
     "Conv/pooling/Resize/Pad pass-through" section comment) -- the chain walk
     crossed transparently between a Conv chain's real producer and real
-    consumer. Neither mixes channels at all -- output channel ``i`` depends
-    only on input channel ``i`` -- so neither needs any independent
+    consumer. None of the three mixes channels at all -- output channel ``i``
+    depends only on input channel ``i`` -- so none needs any independent
     importance of its own the way a producer/consumer boundary does; each is
     carried on the matched :class:`_Chain` purely so
     :func:`_apply_conv_pass_through_hop` can slice its own ``[C, 1, k1, ...,
     kn]`` weight (and bias, if present) by the *same* `keep` index set as the
-    chain's real producer. A depthwise Conv additionally gets its own
+    chain's real producer -- or, for an ``InstanceNormalization`` hop, its
+    flat ``[C]`` `scale`/`B` (`weight`/`bias` playing that op's `scale`/`B`
+    role respectively; see `_INSTANCE_NORM_PASS_THROUGH_OP`'s own comment for
+    why no dedicated tuple type, and no `group`-style per-hop count
+    restriction, is needed here the way :class:`_GroupNormPassThrough`
+    needed one). A depthwise Conv additionally gets its own
     ``group`` attribute updated to the new channel count;
-    ``CausalConvWithState`` has no such attribute at all (its channel count
-    is implied purely by its weight's own axis-0 size), so nothing is
-    rewritten there for it. See :func:`_walk_to_conv_consumer`.
+    ``CausalConvWithState``/``InstanceNormalization`` have no such attribute
+    at all (each one's own channel count is implied purely by its `weight`/
+    `scale`'s own axis-0 size), so nothing is rewritten there for either. See
+    :func:`_walk_to_conv_consumer`.
     """
 
     node: onnx.NodeProto
@@ -3640,16 +3722,25 @@ def _apply_conv_pass_through_hop(
 
     A depthwise ``Conv`` hop's own `group` attribute (`== in_channels ==
     out_channels`) drops to the new channel count right alongside its
-    weight/bias, via :func:`_set_conv_group_attr` -- `CausalConvWithState`
-    has no such attribute at all (confirmed via live schema introspection,
-    ``onnx.defs.get_schema("CausalConvWithState", domain="")``: its own
-    channel count is implied purely by its weight's own axis-0 size, no
-    `group`/channel-count attribute exists on it to rewrite), so nothing is
-    rewritten there for it -- dispatched purely on `hop.node.op_type`, since
-    only these two op types ever reach this function (see
-    :func:`_match_depthwise_conv_pass_through`/
-    :func:`_match_causal_conv_with_state_pass_through`, the only two
-    matchers that ever construct a :class:`_ConvPassThrough`).
+    weight/bias, via :func:`_set_conv_group_attr` -- `CausalConvWithState`/
+    `InstanceNormalization` have no such attribute at all (confirmed via live
+    schema introspection, ``onnx.defs.get_schema("CausalConvWithState",
+    domain="")``/``onnx.defs.get_schema("InstanceNormalization")``: each
+    one's own channel count is implied purely by its `weight`/`scale`'s own
+    axis-0 size, no `group`/channel-count attribute exists on either to
+    rewrite), so nothing is rewritten there for either -- dispatched purely
+    on `hop.node.op_type`, since only these three op types ever reach this
+    function (see :func:`_match_depthwise_conv_pass_through`/
+    :func:`_match_causal_conv_with_state_pass_through`/
+    :func:`_match_instance_norm_pass_through`/
+    :func:`_match_instance_norm_pass_through_self`, the only matchers that
+    ever construct a :class:`_ConvPassThrough`). `hop.weight` -- an
+    ``InstanceNormalization`` hop's own `scale`, strictly rank-1 by
+    :func:`_match_instance_norm_pass_through`'s own bar -- is sliced by the
+    same axis-0 :func:`_slice_producer_weight` call below as a depthwise
+    Conv's weight; for a rank-1 tensor that is exactly the same slice
+    :func:`_slice_last_axis`'s own axis ``-1`` would produce, so no dedicated
+    branch is needed for it here.
     """
     _slice_producer_weight(initializer_map[hop.weight], False, keep, is_conv=True)
     if hop.bias is not None:
@@ -4419,6 +4510,98 @@ def _match_group_norm_pass_through(
     return scale_name, bias_name, num_groups
 
 
+def _match_instance_norm_pass_through(
+    node: onnx.NodeProto,
+    initializer_map: Dict[str, onnx.TensorProto],
+    n_channels: int,
+) -> Optional[Tuple[str, str]]:
+    """If `node` is a plain (default-domain) ``InstanceNormalization`` node
+    (opset 6+ -- see `_INSTANCE_NORM_PASS_THROUGH_OP`'s own comment) with
+    constant, exactly-1-D (``dims == [n_channels]``) `scale` (input 1) and
+    `B` (input 2) -- both required by the op's own schema -- returns
+    ``(scale_name, bias_name)``. Declines (``None``) on a missing/non-
+    constant/wrongly-shaped `scale` or `B`, or `scale`/`B` naming the same
+    tensor (double-slicing it in :func:`_apply_conv_pass_through_hop` would
+    corrupt it, the same tied-name bar :func:`_match_group_norm_pass_through`
+    already applies) -- none of these is guessed at.
+
+    Unlike :func:`_match_group_norm_pass_through`'s own
+    :func:`_flat_channel_const` bar (`prod(dims) == dims[-1]`, deliberately
+    loose enough to admit a broadcastable-but-not-strictly-1-D shape like
+    ``[1, 1, C]``), this requires `scale`/`B` to be *strictly* rank-1: the
+    returned names are carried on a plain :class:`_ConvPassThrough` (this
+    hop's own `scale`/`B` playing that class's `weight`/`bias` role -- see
+    `_INSTANCE_NORM_PASS_THROUGH_OP`'s own comment for why no dedicated
+    tuple type is needed here the way :class:`_GroupNormPassThrough` needed
+    one), whose own slicing (:func:`_apply_conv_pass_through_hop`) always
+    slices axis 0 (``is_conv=True``) rather than axis -1 -- correct only when
+    axis 0 already *is* the one-and-only axis, i.e. strictly rank-1. A
+    looser broadcastable shape would silently slice the wrong axis instead of
+    being declined, so this bar is deliberately narrower than
+    `_flat_channel_const`'s -- not a missed generalization: the ONNX schema
+    itself only ever documents `scale`/`B` as rank-1 ``[C]`` for this op (no
+    opset ever gave it GroupNorm's own per-*group* alternate shape), so
+    nothing real is excluded by holding to that.
+    """
+    if (
+        node.op_type != _INSTANCE_NORM_PASS_THROUGH_OP
+        or node.domain != ""
+        or len(node.input) != 3
+        or not node.input[1]
+        or not node.input[2]
+        or len(node.output) != 1
+    ):
+        return None
+    scale_name, bias_name = node.input[1], node.input[2]
+    if scale_name == bias_name:
+        return None  # tied scale/bias -- double-slicing would corrupt it
+    s_init = initializer_map.get(scale_name)
+    b_init = initializer_map.get(bias_name)
+    if (
+        s_init is None
+        or b_init is None
+        or not _is_supported_float_dtype(s_init.data_type)
+        or not _is_supported_float_dtype(b_init.data_type)
+        or len(s_init.dims) != 1
+        or len(b_init.dims) != 1
+        or s_init.dims[0] != n_channels
+        or b_init.dims[0] != n_channels
+    ):
+        return None
+    return scale_name, bias_name
+
+
+def _match_instance_norm_pass_through_self(
+    node: onnx.NodeProto, initializer_map: Dict[str, onnx.TensorProto]
+) -> Optional[Tuple[str, str]]:
+    """The InstanceNorm analogue of :func:`_match_conv_pass_through_self`,
+    for exactly the same reason: :func:`_walk_conv_producer_backward`'s
+    backward walk doesn't know its group's shared channel count yet at the
+    point it first crosses a hop, so this checks `node`'s own `scale` is
+    self-consistently rank-1 (by calling :func:`_match_instance_norm_pass_through`
+    with `scale`'s own `dims[0]` as the "expected" `n_channels`, trivially
+    satisfying that one check and leaving every other one -- constant `B`,
+    matching length, non-tied names -- intact). :func:`_find_conv_residual_chains`/
+    :func:`_resolve_conv_residual_group_for_concat` re-validate every such
+    hop against the group's real, established channel count once the whole
+    group is resolved, the same re-validation a depthwise pass-through hop
+    already gets there (``initializer_map[hop.weight].dims[0] != n_channels``
+    -- `hop.weight` here holds this op's own `scale` name, so that same
+    generic check already re-validates this hop correctly, with no dedicated
+    InstanceNorm-specific re-check needed).
+    """
+    if node.op_type != _INSTANCE_NORM_PASS_THROUGH_OP or len(node.input) < 2:
+        return None
+    s_init = initializer_map.get(node.input[1])
+    if (
+        s_init is None
+        or not _is_supported_float_dtype(s_init.data_type)
+        or len(s_init.dims) != 1
+    ):
+        return None
+    return _match_instance_norm_pass_through(node, initializer_map, s_init.dims[0])
+
+
 def _match_resize_channel_pass_through(
     node: onnx.NodeProto, initializer_map: Dict[str, onnx.TensorProto]
 ) -> bool:
@@ -4635,6 +4818,13 @@ def _walk_to_conv_consumer(
     forward walk is the *only* one of the two Conv-chain walkers that
     recognizes it -- see that section comment's own scope-boundary note for
     why the backward walk, :func:`_walk_conv_producer_backward`, cannot),
+    plain ``InstanceNormalization`` hops (see
+    :func:`_match_instance_norm_pass_through` and
+    `_INSTANCE_NORM_PASS_THROUGH_OP`'s own comment -- the same "one weight
+    row per channel" shape as a depthwise Conv, also returned via
+    `conv_pass_through`, with no `group` attribute to update and, unlike
+    every other hop in this list, no restriction on how many may appear per
+    chain -- both this forward walk *and* the backward one recognize it),
     and -- when
     `recognize_group_norm` -- at most one mid-chain ``GroupNormalization``
     hop (see :func:`_match_group_norm_pass_through` and
@@ -4756,6 +4946,35 @@ def _walk_to_conv_consumer(
                 conv_pass_through.append(
                     _ConvPassThrough(nxt, cc_weight, cc_bias, cc_past_state)
                 )
+                cur = out2
+                continue
+            break
+
+        if (
+            nxt.op_type == _INSTANCE_NORM_PASS_THROUGH_OP
+            and nxt.domain == ""
+            and nxt.input
+            and nxt.input[0] == cur
+        ):
+            # See `_INSTANCE_NORM_PASS_THROUGH_OP`'s own comment: recognized
+            # unconditionally (no `recognize_*` gate, and any number of times
+            # per chain, unlike the GroupNorm hop below) -- InstanceNorm's
+            # per-channel-only statistics carry no group-boundary-drift risk
+            # to guard against, so this hop is exactly as unrestricted as a
+            # depthwise Conv hop above, reusing the same `_ConvPassThrough`
+            # tuple type (its own `scale`/`B` playing that class's
+            # `weight`/`bias` role) rather than needing a dedicated one. Like
+            # `CausalConvWithState` above, this op is never a consumer in its
+            # own right, so a failed match here simply ends the walk.
+            instance_norm = _match_instance_norm_pass_through(
+                nxt, initializer_map, n_channels
+            )
+            if instance_norm is not None:
+                out2 = nxt.output[0]
+                if len(consumers_of.get(out2, [])) != 1 or out2 in graph_outputs:
+                    break
+                in_scale, in_bias = instance_norm
+                conv_pass_through.append(_ConvPassThrough(nxt, in_scale, in_bias))
                 cur = out2
                 continue
             break
@@ -5104,7 +5323,12 @@ def _walk_conv_producer_backward(
     producer, then merged via ``Concat`` with the encoder's skip branch).
     Walks backward from tensor `start` through unary pass-through
     activations, self-consistently-depthwise Conv hops (see
-    :func:`_match_conv_pass_through_self`), spatial pooling ops that never
+    :func:`_match_conv_pass_through_self`), self-consistent
+    ``InstanceNormalization`` hops (see
+    :func:`_match_instance_norm_pass_through_self` and
+    `_INSTANCE_NORM_PASS_THROUGH_OP`'s own comment -- recognized
+    unconditionally here too, unlike the GroupNorm hop, which this backward
+    walk never recognizes at all), spatial pooling ops that never
     mix channels (``MaxPool``/``AveragePool``/``GlobalAveragePool``,
     unconditionally -- see `_CONV_POOL_PASS_THROUGH`'s own comment), and a
     channel-axis-unaffected ``Resize``/``Pad`` (see
@@ -5193,6 +5417,14 @@ def _walk_conv_producer_backward(
         if dw is not None:
             dw_weight, dw_bias = dw
             pass_through.append(_ConvPassThrough(node, dw_weight, dw_bias))
+            edges.append((node.input[0], node))
+            cur = node.input[0]
+            continue
+
+        instance_norm = _match_instance_norm_pass_through_self(node, initializer_map)
+        if instance_norm is not None:
+            in_scale, in_bias = instance_norm
+            pass_through.append(_ConvPassThrough(node, in_scale, in_bias))
             edges.append((node.input[0], node))
             cur = node.input[0]
             continue

--- a/scripts/cross/run_s390x_tests.sh
+++ b/scripts/cross/run_s390x_tests.sh
@@ -95,10 +95,11 @@ print(sys.byteorder, \"endian | python\", sys.version.split()[0],
 # above, only tests/ and pyproject.toml are copied into the chroot, so none of
 # those imports resolve there regardless of what's pip-installed. Same story
 # for test_check_decode_parity.py, which imports scripts/apple/check_decode_parity
-# at module scope, and test_compute_retention.py, which imports
-# scripts/apple/compute_retention the same way. test_rtdetrv4.py imports
-# onnxruntime directly at module scope for the same "no s390x build" reason
-# as test_qnn_compat.py and friends above.
+# at module scope, and test_compute_retention.py, test_run_quality_eval.py and
+# test_aggregate_quality_trend.py, which import scripts/apple/compute_retention,
+# scripts/apple/run_quality_eval and scripts/apple/aggregate_quality_trend the
+# same way. test_rtdetrv4.py imports onnxruntime directly at module scope for
+# the same "no s390x build" reason as test_qnn_compat.py and friends above.
 #
 # The three deselected BN-fusion tests fail onnxsim's own check_n equivalence
 # check whenever onnxruntime is absent and the reference evaluator is used
@@ -129,6 +130,7 @@ chroot "${SYSROOT}" /bin/sh -c "cd /work && GITHUB_STEP_SUMMARY=${CHROOT_SUMMARY
   --ignore=tests/test_coreml_compat.py --ignore=tests/test_migraphx_compat.py \
   --ignore=tests/test_openvino_compat.py --ignore=tests/test_check_decode_parity.py \
   --ignore=tests/test_compute_retention.py --ignore=tests/test_rtdetrv4.py \
+  --ignore=tests/test_run_quality_eval.py --ignore=tests/test_aggregate_quality_trend.py \
   --deselect tests/test_fusion_patterns.py::test_fuse_conv_bn_into_conv \
   --deselect tests/test_fusion_patterns.py::test_fuse_convtranspose_bn \
   --deselect tests/test_fusion_patterns.py::test_fuse_conv_with_bias_bn_into_conv ${PYTEST_ARGS:-}"

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -5231,6 +5231,292 @@ def test_analyze_structured_pruning_group_norm_pass_through_matches_real_call():
     assert dims_after["GNBias"][0] == kept
 
 
+# --- Conv chain: InstanceNormalization pass-through hop ---------------------
+#
+# `InstanceNormalization` (plain ONNX, standard domain) is a *second*
+# mid-chain norm hop, alongside `GroupNormalization` above -- but, unlike
+# GroupNorm, carries no `num_groups`/uniform-per-block constraint at all:
+# its own mean/variance are computed per instance *per channel*, never
+# pooled across a group, so an arbitrary channel subset may be kept/dropped
+# with no group-boundary-drift risk to guard against. See
+# `_INSTANCE_NORM_PASS_THROUGH_OP`'s own comment for the full reasoning and
+# empirical confirmation (`0.0` max abs diff commuting with channel slicing,
+# vs. GroupNorm's own ~0.42 divergence for a same-shape example).
+
+
+def _instance_norm_conv_pair_model(w1, w2, in_scale, in_bias, b1=None, spatial=10):
+    """The mid-chain-``InstanceNormalization`` analogue of `_conv_pair_model`/
+    `_group_norm_conv_pair_model`: an `InstanceNormalization` node (3
+    required inputs; `scale`/`B` both strictly rank-1 ``[C1]``, per
+    :func:`onnxsim.pruning._match_instance_norm_pass_through`'s own bar)
+    sits between the two Convs. Unlike `_group_norm_conv_pair_model`, there
+    is no `num_groups`/producer-`group` parameter to thread through here at
+    all -- this hop places no constraint on which channels survive.
+    """
+    Cin, C2 = w1.shape[1], w2.shape[0]
+    initializer = [
+        _f32(w1, "W1"),
+        _f32(w2, "W2"),
+        _f32(in_scale, "INScale"),
+        _f32(in_bias, "INBias"),
+    ]
+    if b1 is not None:
+        conv1 = "h = Conv<kernel_shape=[3,3]>(X, W1, B1)"
+        initializer.append(_f32(b1, "B1"))
+    else:
+        conv1 = "h = Conv<kernel_shape=[3,3]>(X, W1)"
+    out_spatial = spatial - 4  # two valid (no-pad) 3x3 convs
+    return _model(
+        f"""
+        g (float[N,{Cin},{spatial},{spatial}] X) => (float[N,{C2},{out_spatial},{out_spatial}] Y)
+        {{
+          {conv1}
+          n = InstanceNormalization<epsilon=1e-05>(h, INScale, INBias)
+          Y = Conv<kernel_shape=[3,3]>(n, W2)
+        }}
+        """,
+        initializer=initializer,
+        opset=22,
+    )
+
+
+def test_structured_pruning_instance_norm_pass_through_matches_oracle_exactly():
+    # THE key correctness bar, same as every other Conv-chain hop's own
+    # oracle test: exact equivalence (float32 noise only) to an
+    # independently, already-pruned reference model -- never "matches the
+    # un-pruned model's own output sliced after the fact" (see
+    # `_INSTANCE_NORM_PASS_THROUGH_OP`'s own comment for why the latter isn't
+    # even the same computation). `_oracle_keep_indices_conv` -- the plain,
+    # unconstrained top-k `_apply_chains` itself uses for an ordinary
+    # (`group=1`) chain -- is the right oracle here precisely because this
+    # hop adds no grouping constraint of its own, unlike the GroupNorm hop's
+    # own `_oracle_keep_indices_conv_grouped`.
+    Cin, C1, C2 = 3, 16, 8
+    rng = np.random.default_rng(60)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    b1 = rng.standard_normal((C1,)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    in_scale = rng.standard_normal((C1,)).astype(np.float32)
+    in_bias = rng.standard_normal((C1,)).astype(np.float32)
+    model = _instance_norm_conv_pair_model(w1, w2, in_scale, in_bias, b1=b1)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    dims_after = _initializer_dims(pruned)
+    assert dims_after["W1"][0] == C1 // 2
+    assert dims_after["INScale"][0] == C1 // 2
+    assert dims_after["INBias"][0] == C1 // 2
+
+    keep = _oracle_keep_indices_conv(w1, C1 // 2)
+    oracle = _instance_norm_conv_pair_model(
+        w1[keep], w2[:, keep], in_scale[keep], in_bias[keep], b1=b1[keep]
+    )
+
+    rng_x = np.random.default_rng(61)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_instance_norm_tied_scale_bias_declines():
+    # `scale`/`B` naming the same initializer -- double-slicing it in
+    # `_apply_conv_pass_through_hop` would corrupt it, so the whole chain is
+    # declined outright, same as `_match_group_norm_pass_through`'s own
+    # tied-name bar.
+    Cin, C1, C2 = 3, 8, 4
+    rng = np.random.default_rng(62)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    tied = rng.standard_normal((C1,)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{C2},6,6] Y)
+        {{
+          h = Conv<kernel_shape=[3,3]>(X, W1)
+          n = InstanceNormalization<epsilon=1e-05>(h, Tied, Tied)
+          Y = Conv<kernel_shape=[3,3]>(n, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2"), _f32(tied, "Tied")],
+        opset=22,
+    )
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+    np.testing.assert_array_equal(inits["Tied"], tied)
+
+
+def test_structured_pruning_instance_norm_non_constant_scale_declines():
+    # `scale` fed by a runtime value (here, a second graph input) rather than
+    # a constant initializer -- this pass cannot know its per-channel values
+    # ahead of time, so the whole chain is declined outright, never guessed
+    # at, the same "statically-known-constant-only" bar every other
+    # per-channel hop in this module already applies.
+    Cin, C1, C2 = 3, 8, 4
+    rng = np.random.default_rng(63)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    in_bias = rng.standard_normal((C1,)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X, float[{C1}] Scale) => (float[N,{C2},6,6] Y)
+        {{
+          h = Conv<kernel_shape=[3,3]>(X, W1)
+          n = InstanceNormalization<epsilon=1e-05>(h, Scale, INBias)
+          Y = Conv<kernel_shape=[3,3]>(n, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2"), _f32(in_bias, "INBias")],
+        opset=22,
+    )
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+    np.testing.assert_array_equal(inits["INBias"], in_bias)
+
+
+def test_structured_pruning_instance_norm_non_1d_scale_declines():
+    # A `scale` shaped `[1, C1]` -- `_flat_channel_const`'s own looser
+    # "prod(dims) == dims[-1]" bar would admit this (a real GroupNorm/
+    # LayerNorm hop reuses that check), but `_match_instance_norm_pass_through`
+    # deliberately holds InstanceNorm's own `scale`/`B` to a *strictly*
+    # rank-1 bar instead (see its own docstring for why: this hop's `scale`/
+    # `B` are carried on a plain `_ConvPassThrough`, whose own slicing always
+    # slices axis 0, which is only ever the right axis when rank == 1).
+    # Declined outright rather than mis-sliced.
+    Cin, C1, C2 = 3, 8, 4
+    rng = np.random.default_rng(64)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    in_scale_2d = rng.standard_normal((1, C1)).astype(np.float32)
+    in_bias = rng.standard_normal((C1,)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{C2},6,6] Y)
+        {{
+          h = Conv<kernel_shape=[3,3]>(X, W1)
+          n = InstanceNormalization<epsilon=1e-05>(h, INScale, INBias)
+          Y = Conv<kernel_shape=[3,3]>(n, W2)
+        }}
+        """,
+        initializer=[
+            _f32(w1, "W1"),
+            _f32(w2, "W2"),
+            _f32(in_scale_2d, "INScale"),
+            _f32(in_bias, "INBias"),
+        ],
+        opset=22,
+    )
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+    np.testing.assert_array_equal(inits["INScale"], in_scale_2d)
+    np.testing.assert_array_equal(inits["INBias"], in_bias)
+
+
+def _residual_diamond_instance_norm_model(
+    w_f, in_scale, in_bias, w_s, w_out, spatial=10
+):
+    # The `_residual_diamond_model` shape, extended with an
+    # `InstanceNormalization` hop on the `f` branch between its own Conv
+    # producer and the `Add` merge -- exercises
+    # `_walk_conv_producer_backward`'s own new InstanceNorm branch (not just
+    # the forward `_walk_to_conv_consumer` one every other test above already
+    # covers), confirming the hop is crossed correctly walking *backward*
+    # from the `Add` operand to `f`'s own real Conv producer.
+    Cin = w_f.shape[1]
+    Cout = w_out.shape[0]
+    out_spatial = spatial - 4  # two chained 3x3 valid convs
+    return _model(
+        f"""
+        g (float[N,{Cin},{spatial},{spatial}] X) => (float[N,{Cout},{out_spatial},{out_spatial}] Y)
+        {{
+          f = Conv<kernel_shape=[3,3]>(X, WF)
+          n = InstanceNormalization<epsilon=1e-05>(f, INScale, INBias)
+          s = Conv<kernel_shape=[3,3]>(X, WS)
+          addr = Add(n, s)
+          r = Relu(addr)
+          Y = Conv<kernel_shape=[3,3]>(r, WOUT)
+        }}
+        """,
+        initializer=[
+            _f32(w_f, "WF"),
+            _f32(in_scale, "INScale"),
+            _f32(in_bias, "INBias"),
+            _f32(w_s, "WS"),
+            _f32(w_out, "WOUT"),
+        ],
+        opset=22,
+    )
+
+
+def test_structured_pruning_conv_residual_add_instance_norm_pass_through_matches_oracle():
+    Cin, C, Cout = 3, 16, 8
+    rng = np.random.default_rng(65)
+    w_f = rng.standard_normal((C, Cin, 3, 3)).astype(np.float32)
+    in_scale = rng.standard_normal((C,)).astype(np.float32)
+    in_bias = rng.standard_normal((C,)).astype(np.float32)
+    w_s = rng.standard_normal((C, Cin, 3, 3)).astype(np.float32)
+    w_out = rng.standard_normal((Cout, C, 3, 3)).astype(np.float32)
+    model = _residual_diamond_instance_norm_model(w_f, in_scale, in_bias, w_s, w_out)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    dims_after = _initializer_dims(pruned)
+    assert dims_after["WF"][0] == C // 2
+    assert dims_after["INScale"][0] == C // 2
+    assert dims_after["INBias"][0] == C // 2
+    assert dims_after["WS"][0] == C // 2
+
+    importance = np.sqrt(
+        np.square(np.linalg.norm(w_f.reshape(C, -1).astype(np.float64), axis=1))
+        + np.square(np.linalg.norm(w_s.reshape(C, -1).astype(np.float64), axis=1))
+    )
+    keep = np.sort(np.argsort(-importance)[: C // 2])
+    oracle = _residual_diamond_instance_norm_model(
+        w_f[keep], in_scale[keep], in_bias[keep], w_s[keep], w_out[:, keep]
+    )
+
+    rng_x = np.random.default_rng(66)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_analyze_structured_pruning_instance_norm_pass_through_matches_real_call():
+    # Dry-run/real-call cross-check for the InstanceNorm hop specifically,
+    # mirroring `test_analyze_structured_pruning_group_norm_pass_through_matches_real_call`
+    # above.
+    Cin, C1, C2 = 3, 16, 8
+    rng = np.random.default_rng(67)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    in_scale = rng.standard_normal((C1,)).astype(np.float32)
+    in_bias = rng.standard_normal((C1,)).astype(np.float32)
+    model = _instance_norm_conv_pair_model(w1, w2, in_scale, in_bias)
+
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_structured_pruning, sparsity=0.5
+    )
+    assert len(report.layers) == 1
+    layer = report.layers[0]
+    assert layer.family == "conv_plain"
+    assert layer.total == C1
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    dims_after = _initializer_dims(pruned)
+    kept = C1 - layer.would_drop
+    assert dims_after["W1"][0] == kept
+    assert dims_after["W2"][1] == kept
+    assert dims_after["INScale"][0] == kept
+    assert dims_after["INBias"][0] == kept
+
+
 # --- Conv chain: pooling/Resize/Pad pass-through hops -----------------------
 #
 # `MaxPool`/`AveragePool`/`GlobalAveragePool` (unconditional -- no weight of


### PR DESCRIPTION
## Summary

`InstanceNormalization` (plain ONNX, standard domain) was never recognized as a mid-chain Conv hop, so a `Conv → InstanceNormalization → Conv` chain — the CycleGAN/pix2pix/AdaIN-style CNN shape — went unpruned end to end, even though its `scale`/`B` are per-channel and safe to slice.

## Empirically confirmed facts

- `onnx.defs.get_schema("InstanceNormalization")`: 3 required inputs (`input`, `scale`, `B`), both `scale`/`B` per-channel, standard domain (re-confirmed independently in the verified worktree).
- Unlike `GroupNorm`, InstanceNorm's own mean/variance are computed *per instance per channel*, never pooled across a `num_groups`-wide block — so there is no group-boundary-drift risk to guard against at all.
- I independently re-ran the commutation check myself with a fresh script (not just re-running the committed test suite): built a real `Conv → InstanceNormalization → Conv`-equivalent pair of models via `onnxruntime.InferenceSession` — full model sliced post-hoc vs. an independently pre-sliced model, for a non-contiguous channel subset `[0,2,4,5]` of 6 — and confirmed **exactly 0.0 max abs diff**, matching the claimed commutation property.
- I independently re-ran the full verification suite in the worktree: `pytest tests/test_pruning.py -q` → **794 passed** (788 → 794, +6 new tests), `ruff format --check`/`ruff check` clean, `mypy onnxsim/pruning.py` (exact scoped command) → **0 errors**, matching baseline.

## What's added / scope

- `_match_instance_norm_pass_through()`/`_match_instance_norm_pass_through_self()` — recognized **unconditionally** (no `recognize_*` gate, any number of times per chain, in **both** directions) by both `_walk_to_conv_consumer` and `_walk_conv_producer_backward`, unlike GroupNorm's own single-hop-per-chain restriction — since InstanceNorm's per-channel-only statistics carry no group-boundary-drift risk at all.
- Reuses `_ConvPassThrough`/`_apply_conv_pass_through_hop` directly (`scale`/`B` playing that class's `weight`/`bias` role) rather than needing a dedicated tuple type the way GroupNorm's own `num_groups`-aware machinery does.
- `scale`/`B` are held to a strictly rank-1 `[C]` shape — deliberately narrower than `_flat_channel_const`'s own looser bar (which admits e.g. `[1,1,C]`) — since `_ConvPassThrough`'s own slicing always slices axis 0, correct only when axis 0 is the sole axis, and the op's schema never gives `scale`/`B` GroupNorm's alternate per-group shape anyway.
- Declines (never guesses) on non-constant, tied-name (`scale`/`B` naming the same initializer), or non-1D `scale`/`B`.
- Module docstring, `_ConvPassThrough`'s docstring, `_apply_conv_pass_through_hop`'s docstring, and both Conv-chain walker docstrings updated.

## Test plan

- [x] `Conv → InstanceNormalization → Conv` prunes correctly, output matches an independently-reconstructed already-pruned reference model via real onnxruntime execution (never the full unpruned model's own output).
- [x] Tied `scale`/`B` (same initializer) declines outright rather than double-slicing/corrupting it.
- [x] Non-constant `scale` (fed by a graph input) declines outright.
- [x] Non-1D `scale` (e.g. `[1, C]`) declines outright — the specific case `_flat_channel_const`'s looser bar would have wrongly admitted.
- [x] Residual-diamond composition test exercising the hop through `_walk_conv_producer_backward`.
- [x] `pytest tests/test_pruning.py -q`: 788 → 794 passed.
- [x] `ruff format --check .` / `ruff check .`: clean.
- [x] `mypy onnxsim/pruning.py` (exact scoped command): 0 errors, matching baseline.

I independently re-verified this PR after implementation: reviewed the full diff line by line, independently re-confirmed the exact-commutation claim myself with a fresh script against a real `InferenceSession` (0.0 max abs diff, matching what's documented), re-ran the entire verification suite (tests/ruff/mypy) fresh in the worktree, and committed + pushed this branch myself since the implementing agent had left the change staged but uncommitted.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_