### PR TITLE
Add Outlier Suppression+ channel-wise shift+scale quantization pre-conditioning

### DIFF
--- a/docs/outlier-suppression-plus.md
+++ b/docs/outlier-suppression-plus.md
@@ -1,0 +1,112 @@
+# Outlier Suppression+: channel-wise shifting and scaling (`apply_outlier_suppression_plus`)
+
+## What this is
+
+`onnxsim.apply_outlier_suppression_plus` extends `onnxsim.apply_smoothquant`
+with a **channel-wise shift**: before migrating quantization difficulty via
+SmoothQuant's own scale, it re-centers each activation channel around zero,
+using the channel's own calibration min/max midpoint, and folds the shift's
+constant contribution back into the layer's output. Like `apply_smoothquant`,
+this performs only the migration -- the result is still a float model,
+provably equivalent to the input, meant to be fed to a separate W8A8
+quantizer (e.g. `quantize_static`/`quantize_qoperator_gemm`) afterwards.
+
+```
+Before:
+  Y = MatMul(X, W) [+ bias]        -- W constant, [K, N], float32
+
+After:
+  Xshift = Sub(X, Z)                -- Z: initializer, float32 [K]
+  Xscaled = Mul(Xshift, 1/S)        -- S: initializer, float32 [K]
+  Ypre = MatMul(Xscaled, W * S) [+ bias]
+  Y = Add(Ypre, Z @ W)              -- Z @ W: initializer, float32 [N]
+```
+
+## Where this comes from
+
+[Outlier Suppression+](https://arxiv.org/abs/2304.09145) (Wei et al., 2023,
+EMNLP 2023) starts from `apply_smoothquant`'s own migration idea (scaling an
+activation channel down and the matching weight row up by the same factor,
+an exact no-op on the unquantized function) and observes a gap it leaves
+open: SmoothQuant's scale is a single positive multiplier per channel, so it
+can shrink a channel's *magnitude* but can never fix a channel that sits
+mostly on one side of zero -- an **asymmetric** outlier, common in
+post-LayerNorm transformer activations. Scaling a lopsided range by any
+positive constant leaves it exactly as lopsided; only a *shift* can recenter
+it.
+
+Outlier Suppression+ therefore adds a channel-wise shift ahead of the scale:
+for each input channel `j`, `z_j = (max(X_j) + min(X_j)) / 2` -- the
+midpoint of that channel's own observed calibration range -- is subtracted
+before scaling. This module then reuses `apply_smoothquant`'s own
+closed-form scale formula (`s_j = max(|X_j - z_j|) ** alpha / max(|W_j|) **
+(1 - alpha)`) on the now-shifted channel. The paper additionally proposes an
+iterative grid refinement on top of that closed form to search for a better
+scale than the formula alone gives; that refinement is not ported here --
+what this module ports is the paper's headline structural contribution over
+SmoothQuant (the shift), not its secondary scale-search refinement, matching
+`apply_smoothquant`'s own documented practice of using the closed-form scale
+rather than searching it.
+
+Shifting an affine layer's input is not a free transformation the way
+scaling is: `(X - z) @ W` differs from `X @ W` by exactly `z @ W`, a
+*constant* vector (the same `z` every calibration batch converges to,
+independent of the specific input at inference time). This module folds that
+constant back in via a new `Add` node inserted right after the layer,
+reusing the same "rename the producer's output, insert an op that reproduces
+the original name" mechanics `onnxsim.correct_bias`'s own `_apply_correction`
+helper already uses -- so every existing downstream consumer keeps working
+unmodified. Unlike `correct_bias`, what's being folded back in here is an
+*exact* algebraic identity from the shift, not an empirically-measured
+quantization error: composing the shift, the scale, and this correction
+reproduces the original float function exactly (up to floating-point
+rounding), for any choice of `z`/`s` at all.
+
+## Scope
+
+Handled:
+
+- `MatMul(X, W)` (2 inputs), or `Gemm(X, W[, B])` with `transA=0`, `alpha=1`,
+  and (when `B` is present) `beta=1`. `transB` may be 0 or 1.
+- `W` must be a constant 2-D float32 tensor.
+- `X` must, when probed on the supplied calibration data, be a plain 2-D
+  tensor (`[rows, K]`) whose `K` matches `W`'s reduction dimension.
+
+Left untouched (safe no-op, node passes through as-is):
+
+- Non-constant or non-2-D weights.
+- A layer whose activation input never appeared as a plain 2-D tensor across
+  the calibration batches (e.g. a 3-D `[batch, seq, hidden]` activation, or
+  one that never ran at all).
+- A model with no matching layer.
+
+## Usage
+
+```python
+import onnx
+import onnxsim
+
+model = onnx.load("model.onnx")
+migrated = onnxsim.apply_outlier_suppression_plus(model, alpha=0.5)
+quantized, check_ok = onnxsim.quantize_static(migrated), True
+onnx.save(quantized, "model.osplus.quant.onnx")
+```
+
+`calibration_data` defaults to `onnxsim.generate_random_calibration_data`;
+pass real representative batches (e.g. via
+`onnxsim.load_huggingface_calibration_data`) for a shift and scale that
+actually target the model's own real activation distribution, the same
+caveat `apply_smoothquant` documents.
+
+## Relationship to `apply_smoothquant`
+
+`apply_outlier_suppression_plus` is a strict superset of what
+`apply_smoothquant` does: setting every channel's shift to `z = 0` (e.g. a
+symmetric calibration distribution, where `max(X_j) == -min(X_j)`) makes the
+two migrations numerically identical except for the extra (all-zero, hence
+no-op) `Add` node this module always inserts. The two are not meant to be
+composed -- each is a complete, self-contained migration to run ahead of a
+W8A8 quantizer; pick whichever best matches the target model's own
+activation distribution (a model with mostly symmetric outliers gains
+nothing from the extra shift and its `Sub`/`Add` node overhead; one with
+pronounced asymmetric outliers benefits from it).

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -90,6 +90,7 @@ from onnxsim.optimize_pipeline import (
     apply_optimization_pipeline,
 )
 from onnxsim.ort_matmul_nbits_workaround import workaround_ort_matmul_nbits_axis0_bug
+from onnxsim.outlier_suppression_plus import apply_outlier_suppression_plus
 from onnxsim.precision_estimator import (
     ModelQuantizationEstimate,
     estimate_model_quantization_drop,
@@ -155,6 +156,7 @@ __all__ = [
     "apply_attention_quantization",
     "apply_gptq",
     "apply_smoothquant",
+    "apply_outlier_suppression_plus",
     "apply_llm_int8",
     "apply_low_rank_compensation",
     "apply_mixed_precision_quantization",

--- a/onnxsim/outlier_suppression_plus.py
+++ b/onnxsim/outlier_suppression_plus.py
@@ -1,0 +1,253 @@
+"""Outlier Suppression+ (Wei et al., 2023, "Outlier Suppression+: Accurate
+quantization of large language models by equivalent and optimal shifting and
+scaling", EMNLP 2023, https://arxiv.org/abs/2304.09145). Its predecessor,
+Outlier Suppression (the same authors' earlier NeurIPS 2022 paper), is
+distinct and not what this module ports. onnxsim ports the *algorithm*, not
+any framework's code, per the same rationale as :mod:`onnxsim.smoothquant`.
+
+:mod:`onnxsim.smoothquant` migrates per-channel activation quantization
+difficulty into the weight via a single elementwise *scale* -- ``s_j``
+shrinks activation channel ``j``'s range at the cost of expanding weight row
+``j``'s range. That works well for channels whose outliers are large in
+*magnitude* but roughly *symmetric* around zero. Outlier Suppression+'s
+observation: many transformer activation channels (especially post-LayerNorm)
+carry a large, consistent *asymmetric* component too -- a channel sitting
+mostly on one side of zero -- which a symmetric scale cannot address at all
+(scaling a lopsided range by any positive constant leaves it just as
+lopsided), forcing a symmetric quantizer's range to cover the channel's full
+excursion from its own worst-case value down to (or up from) zero.
+
+Outlier Suppression+ therefore adds a **channel-wise shift** ahead of
+SmoothQuant's own scale: for each input channel ``j``,
+
+    z_j = (max(X_j) + min(X_j)) / 2
+
+(the midpoint of that channel's observed calibration range) is subtracted
+from ``X_j`` before scaling, re-centering it around zero and roughly halving
+the range a symmetric quantizer must cover for a channel that was originally
+one-sided. Shifting an affine layer's input is not, on its own, a free
+transformation the way scaling is -- ``(X - z) @ W`` differs from ``X @ W``
+by exactly ``z @ W``, a *constant* (calibration-independent, per-output-
+-channel) vector -- so this module folds that constant back in as an
+additive correction on the layer's own output, via a new ``Add`` node
+inserted right after it (the same "measure a per-channel constant, fold it
+back in with an ``Add``" mechanics :func:`onnxsim.correct_bias` already
+uses, though what's being corrected for here is an exact algebraic identity
+from the shift, not an empirically-measured quantization error). The result:
+``Y = ((X - z) / s) @ (W * s)^T + z @ W^T`` is *exactly* ``X @ W^T`` for any
+choice of ``z``/``s`` (up to floating-point rounding) -- provably so, not
+just approximately, since every step is a linear re-parameterization of the
+same affine map, never an approximation.
+
+For the scaling step itself, this module reuses
+:mod:`onnxsim.smoothquant`'s own closed-form, alpha-parameterized formula
+(``s_j = max(|X_j - z_j|) ** alpha / max(|W_j|) ** (1 - alpha)``), applied to
+the now-*shifted* activation rather than the raw one, matching
+:mod:`onnxsim.smoothquant`'s own documented practice of using a single fixed
+``alpha`` rather than a per-layer search. The Outlier Suppression+ paper
+additionally proposes its own iterative grid refinement on top of that
+formula to squeeze out a further, typically small, improvement over the
+plain closed form -- that refinement is not reproduced here; what onnxsim
+ports is the paper's headline structural contribution over SmoothQuant (the
+shift), not its secondary scale-search refinement.
+
+Like :func:`onnxsim.apply_smoothquant`, this only performs the *migration*:
+:func:`apply_outlier_suppression_plus` returns a float model, provably
+equivalent to the input up to floating-point rounding -- no quantization
+happens here. The result is meant to be fed to a W8A8 quantizer afterwards
+(e.g. :func:`onnxsim.quantize_static`/:func:`onnxsim.quantize_qoperator_gemm`),
+exactly how :func:`onnxsim.apply_smoothquant` is used.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Sequence, Union
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+
+from onnxsim import backend
+from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.calibration import Tensors, generate_random_calibration_data
+from onnxsim.smoothquant import _match_matmul_like
+
+
+def apply_outlier_suppression_plus(
+    model: Union[str, onnx.ModelProto],
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_samples: int = 8,
+    seed: int = 0,
+    alpha: float = 0.5,
+    epsilon: float = 1e-5,
+    providers: Optional[Sequence[str]] = None,
+) -> onnx.ModelProto:
+    """Applies Outlier Suppression+'s channel-wise shifting and scaling to
+    every MatMul/vanilla-Gemm layer with a constant 2-D float32 weight and a
+    plain 2-D activation input, using real calibration activations. See this
+    module's own docstring for the technique. Returns a float model -- pass
+    the result to a W8A8 quantizer (e.g. :func:`onnxsim.quantize_static`) to
+    actually quantize it.
+
+    :param model: the original (unquantized) onnx ModelProto or file path
+    :param calibration_data: representative input batches to measure each
+            input channel's activation range on. Each batch is a
+            ``{input_name: np.ndarray}`` dict matching ``model``'s graph
+            inputs -- see :func:`onnxsim.generate_random_calibration_data`
+            (the default when omitted) and
+            :func:`onnxsim.load_huggingface_calibration_data` (real data, a
+            much more representative migration than random input).
+    :param num_samples: random batches to generate when
+            ``calibration_data`` is omitted
+    :param seed: seed for the random calibration data (ignored if
+            ``calibration_data`` is supplied)
+    :param alpha: the scaling step's migration strength, identical in
+            meaning to :func:`onnxsim.apply_smoothquant`'s own ``alpha``
+            (applied to the *shifted* activation's range rather than the
+            raw activation's)
+    :param epsilon: floor applied to every per-channel activation/weight
+            max-abs value before computing the scale, avoiding a divide-by-
+            zero on an all-zero (or exactly-centered) channel
+    :param providers: onnxruntime execution providers to run ``model`` on
+            when capturing calibration activations
+    :returns: ``model`` with every matched layer's weight columns rescaled
+            in place, a new ``Mul``+``Sub`` pair inserted before it applying
+            the shift and scale to its activation input, and a new ``Add``
+            inserted after it restoring the shift's constant contribution to
+            the output; layers with a non-constant, non-2-D weight, or whose
+            activation input isn't a plain 2-D tensor matching the weight's
+            reduction dimension, are left untouched
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            model, num_samples=num_samples, seed=seed
+        )
+
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    graph = out.graph
+    initializer_map = {t.name: t for t in graph.initializer}
+    taken_names = _all_names(graph)
+
+    nodes = list(graph.node)
+    candidates = []
+    for node in nodes:
+        match = _match_matmul_like(node)
+        if match is None:
+            continue
+        x_name, w_name, weight_transposed = match
+        w_init = initializer_map.get(w_name)
+        if (
+            w_init is None
+            or w_init.data_type != onnx.TensorProto.FLOAT
+            or len(w_init.dims) != 2
+        ):
+            continue
+        candidates.append((node, x_name, w_name, weight_transposed))
+
+    if not candidates:
+        return out
+
+    probe_names = sorted({x_name for _, x_name, _, _ in candidates})
+    probe_model = _add_probe_outputs(out, probe_names)
+
+    act_max: Dict[str, np.ndarray] = {}
+    act_min: Dict[str, np.ndarray] = {}
+    for batch in calibration_data:
+        result = backend.run_model(probe_model, batch, providers=providers)
+        for name in probe_names:
+            x = np.asarray(result[name], dtype=np.float64)
+            if x.ndim != 2:
+                continue
+            mx, mn = x.max(axis=0), x.min(axis=0)
+            act_max[name] = mx if name not in act_max else np.maximum(act_max[name], mx)
+            act_min[name] = mn if name not in act_min else np.minimum(act_min[name], mn)
+
+    for node, x_name, w_name, weight_transposed in candidates:
+        mx = act_max.get(x_name)
+        mn = act_min.get(x_name)
+        if mx is None:
+            continue  # never observed as a plain 2-D tensor; skip
+
+        w_init = initializer_map[w_name]
+        w_nk_orig = onnx.numpy_helper.to_array(w_init).astype(np.float64)
+        dim0, dim1 = w_nk_orig.shape
+        w_nk = w_nk_orig if weight_transposed else w_nk_orig.T  # [N, K]
+        k = w_nk.shape[1]
+        if mx.shape[0] != k:
+            continue  # activation's feature dim doesn't match K; skip
+
+        # Channel-wise shift: recenters each channel around zero. The
+        # shifted channel's own max-abs is exactly half its observed
+        # range -- no second pass over calibration data needed.
+        z = (mx + mn) / 2.0  # [K]
+        shifted_absmax = np.maximum((mx - mn) / 2.0, epsilon)  # [K]
+
+        weight_channel = np.maximum(np.abs(w_nk).max(axis=0), epsilon)  # [K]
+        s = (shifted_absmax**alpha) / (weight_channel ** (1.0 - alpha))
+        s = np.maximum(s, epsilon)
+
+        # Exact algebraic fold: Y = ((X - z) / s) @ (W * s)^T + z @ W^T,
+        # using the *original* (unscaled) weight for the correction term --
+        # see this module's own docstring.
+        correction = (w_nk @ z).astype(np.float32)  # [N]
+
+        w_smooth_nk = w_nk * s[np.newaxis, :]
+        w_new = w_smooth_nk if weight_transposed else w_smooth_nk.T
+        w_new = w_new.reshape(dim0, dim1).astype(np.float32)
+        w_init.CopyFrom(onnx.numpy_helper.from_array(w_new, name=w_name))
+
+        z_name = _unique_name(f"{x_name}_os_plus_shift", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(z.astype(np.float32), name=z_name)
+        )
+        shifted_name = _unique_name(f"{x_name}_os_plus_shifted", taken_names)
+        sub_node = onnx.helper.make_node(
+            "Sub",
+            [x_name, z_name],
+            [shifted_name],
+            name=_unique_name(f"{x_name}_os_plus_sub", taken_names),
+        )
+
+        inv_s = (1.0 / s).astype(np.float32)
+        scale_name = _unique_name(f"{x_name}_os_plus_inv_scale", taken_names)
+        graph.initializer.append(onnx.numpy_helper.from_array(inv_s, name=scale_name))
+        scaled_name = _unique_name(f"{x_name}_os_plus_scaled", taken_names)
+        mul_node = onnx.helper.make_node(
+            "Mul",
+            [shifted_name, scale_name],
+            [scaled_name],
+            name=_unique_name(f"{x_name}_os_plus_mul", taken_names),
+        )
+
+        node_idx = next(i for i, n in enumerate(graph.node) if n is node)
+        graph.node.insert(node_idx, mul_node)
+        graph.node.insert(node_idx, sub_node)
+        node.input[0] = scaled_name
+
+        # Restore the shift's constant contribution via a new Add right
+        # after the layer's own output, renaming its output to a fresh
+        # internal name (mirroring onnxsim.bias_correction._apply_correction)
+        # so every existing downstream consumer keeps working unmodified.
+        node_idx = next(i for i, n in enumerate(graph.node) if n is node)
+        pre_name = _unique_name(f"{node.output[0]}_os_plus_pre_shift", taken_names)
+        original_output = node.output[0]
+        node.output[0] = pre_name
+        correction_name = _unique_name(
+            f"{original_output}_os_plus_correction", taken_names
+        )
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(correction, name=correction_name)
+        )
+        add_node = onnx.helper.make_node(
+            "Add",
+            [pre_name, correction_name],
+            [original_output],
+            name=_unique_name(f"{original_output}_os_plus_add", taken_names),
+        )
+        graph.node.insert(node_idx + 1, add_node)
+
+    return out

--- a/tests/test_outlier_suppression_plus.py
+++ b/tests/test_outlier_suppression_plus.py
@@ -1,0 +1,240 @@
+"""Tests for ``onnxsim.apply_outlier_suppression_plus`` (Outlier
+Suppression+, see ``onnxsim/outlier_suppression_plus.py``) -- shifts each
+MatMul/Gemm activation channel to re-center it around zero
+(``z_j = (max(X_j) + min(X_j)) / 2``) before applying
+:mod:`onnxsim.smoothquant`'s own scale migration, folding the shift's
+constant contribution back into the layer's output via a new ``Add`` so the
+whole transformation stays exact pre-quantization.
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _model(body, initializer=(), opset=13, ir_version=8):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _matmul_model(K=64, N=16, weight=None, seed=0):
+    if weight is None:
+        rng = np.random.default_rng(seed)
+        weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[_f32(weight, "W")],
+    )
+
+
+def _run(model, feeds, output_names=None):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    names = output_names or [o.name for o in sess.get_outputs()]
+    return dict(zip(names, sess.run(names, feeds)))
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
+
+
+def _with_extra_output(model, name):
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    existing = {o.name for o in out.graph.output}
+    if name not in existing:
+        out.graph.output.append(onnx.ValueInfoProto(name=name))
+    return out
+
+
+def _lopsided_calibration(K=64, num_samples=64, lopsided_channels=(3, 7), seed=1):
+    # Outlier Suppression+'s own motivating scenario: a few channels sitting
+    # mostly on one side of zero (a large mean offset), which a symmetric
+    # per-channel scale (SmoothQuant's own migration) cannot shrink at all.
+    rng = np.random.default_rng(seed)
+    x = rng.standard_normal((num_samples, K)).astype(np.float32)
+    for i, c in enumerate(lopsided_channels):
+        x[:, c] = x[:, c] * 2.0 + (20.0 + 10.0 * i)  # shifted well off zero
+    return x
+
+
+def test_outlier_suppression_plus_output_matches_float_almost_exactly():
+    # Like SmoothQuant, this is exact real-number math (a shift folded back
+    # in via Add, a scale folded via reciprocal Mul/Mul) -- no quantization
+    # happens here, so the output should match the float model far more
+    # tightly than any lossy INT4/INT8 scheme's tolerance.
+    model = _matmul_model(K=64, N=16, seed=0)
+    x = _lopsided_calibration(K=64, num_samples=64, seed=1)
+    calibration_data = [{"X": x}]
+
+    osp_model = onnxsim.apply_outlier_suppression_plus(
+        model, calibration_data=calibration_data
+    )
+    onnx.checker.check_model(osp_model)
+    assert any(n.op_type == "Sub" for n in osp_model.graph.node)
+    assert any(n.op_type == "Mul" for n in osp_model.graph.node)
+    assert any(n.op_type == "Add" for n in osp_model.graph.node)
+
+    float_out = _run(model, {"X": x})
+    osp_out = _run(osp_model, {"X": x}, output_names=["Y"])
+    assert np.all(np.isfinite(osp_out["Y"]))
+    assert _rel_l2(float_out["Y"], osp_out["Y"]) < 1e-4
+
+
+def test_outlier_suppression_plus_shift_recenters_lopsided_channels():
+    K = 64
+    model = _matmul_model(K=K, N=16, seed=2)
+    lopsided = (3, 7)
+    x = _lopsided_calibration(K=K, num_samples=64, lopsided_channels=lopsided, seed=3)
+    calibration_data = [{"X": x}]
+
+    osp_model = onnxsim.apply_outlier_suppression_plus(
+        model, calibration_data=calibration_data
+    )
+    sub_node = next(n for n in osp_model.graph.node if n.op_type == "Sub")
+    probe_model = _with_extra_output(osp_model, sub_node.output[0])
+    result = _run(probe_model, {"X": x}, output_names=[sub_node.output[0]])
+    shifted = result[sub_node.output[0]]
+
+    # After shifting, every channel's own (max + min) / 2 should collapse to
+    # ~0 -- including the originally lopsided ones, which the shift alone
+    # (with no scaling at all) is exactly designed to fix.
+    midpoints = (shifted.max(axis=0) + shifted.min(axis=0)) / 2.0
+    assert np.allclose(midpoints, 0.0, atol=1e-3)
+
+    original_midpoints = (x.max(axis=0) + x.min(axis=0)) / 2.0
+    for c in lopsided:
+        assert abs(original_midpoints[c]) > 5.0  # confirms the scenario itself
+
+
+def test_outlier_suppression_plus_reduces_range_more_than_smoothquant_alone():
+    # The shift should make a lopsided channel's post-migration range no
+    # larger than plain SmoothQuant would leave it (SmoothQuant, having no
+    # shift, cannot narrow a lopsided channel's max(|X|) at all -- it can
+    # only move that difficulty into the weight, never shrink it).
+    K = 64
+    model = _matmul_model(K=K, N=16, seed=4)
+    x = _lopsided_calibration(K=K, num_samples=64, lopsided_channels=(3, 7), seed=5)
+    calibration_data = [{"X": x}]
+
+    osp_model = onnxsim.apply_outlier_suppression_plus(
+        model, calibration_data=calibration_data
+    )
+    mul_node = next(n for n in osp_model.graph.node if n.op_type == "Mul")
+    probe_model = _with_extra_output(osp_model, mul_node.output[0])
+    result = _run(probe_model, {"X": x}, output_names=[mul_node.output[0]])
+    osp_scaled = result[mul_node.output[0]]
+
+    sq_model = onnxsim.apply_smoothquant(model, calibration_data=calibration_data)
+    sq_mul = next(n for n in sq_model.graph.node if n.op_type == "Mul")
+    sq_probe = _with_extra_output(sq_model, sq_mul.output[0])
+    sq_result = _run(sq_probe, {"X": x}, output_names=[sq_mul.output[0]])
+    sq_scaled = sq_result[sq_mul.output[0]]
+
+    osp_spread = np.abs(osp_scaled).max(axis=0)
+    sq_spread = np.abs(sq_scaled).max(axis=0)
+    assert osp_spread.max() / osp_spread.min() < sq_spread.max() / sq_spread.min()
+
+
+def test_outlier_suppression_plus_gemm_transb():
+    rng = np.random.default_rng(6)
+    K, N = 96, 12
+    weight = rng.standard_normal((N, K)).astype(np.float32) * 0.5
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = Gemm<transB = 1>(X, W)
+        }}
+        """,
+        initializer=[_f32(weight, "W")],
+    )
+    x = _lopsided_calibration(K=K, num_samples=32, lopsided_channels=(10, 50), seed=7)
+    calibration_data = [{"X": x}]
+
+    osp_model = onnxsim.apply_outlier_suppression_plus(
+        model, calibration_data=calibration_data
+    )
+    onnx.checker.check_model(osp_model)
+
+    float_out = _run(model, {"X": x})
+    osp_out = _run(osp_model, {"X": x}, output_names=["Y"])
+    assert _rel_l2(float_out["Y"], osp_out["Y"]) < 1e-4
+
+
+def test_outlier_suppression_plus_noop_when_no_matmul_present():
+    model = _model(
+        """
+        g (float[4,4] X) => (float[4,4] Y)
+        {
+          Y = Relu(X)
+        }
+        """
+    )
+    result = onnxsim.apply_outlier_suppression_plus(
+        model, calibration_data=[{"X": np.zeros((4, 4), dtype=np.float32)}]
+    )
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_outlier_suppression_plus_skips_non_constant_weight():
+    model = _model(
+        """
+        g (float[4,64] X, float[64,4] W) => (float[4,4] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """
+    )
+    result = onnxsim.apply_outlier_suppression_plus(
+        model, calibration_data=[{"X": np.zeros((4, 64), dtype=np.float32)}]
+    )
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_outlier_suppression_plus_skips_non_2d_activation():
+    # A 3-D activation (e.g. [batch, seq, hidden], typical of an
+    # ONNX-exported transformer) isn't a plain 2-D tensor -- matches this
+    # module's own documented scope, same as onnxsim.apply_smoothquant.
+    K, N = 16, 8
+    rng = np.random.default_rng(8)
+    weight = rng.standard_normal((K, N)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,seq,{K}] X) => (float[batch,seq,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[_f32(weight, "W")],
+    )
+    x = rng.standard_normal((2, 3, K)).astype(np.float32)
+    result = onnxsim.apply_outlier_suppression_plus(model, calibration_data=[{"X": x}])
+    assert result.SerializeToString() == model.SerializeToString()


### PR DESCRIPTION
## Summary

`onnxsim.apply_smoothquant` migrates per-channel activation quantization difficulty into the weight via a single symmetric *scale*, but that structurally cannot help a channel that sits mostly on one side of zero (an **asymmetric** outlier, common in post-LayerNorm transformer activations) — scaling a lopsided range by any positive constant leaves it exactly as lopsided.

This adds `onnxsim.apply_outlier_suppression_plus` ([Wei et al., 2023, EMNLP 2023](https://arxiv.org/abs/2304.09145)), which extends SmoothQuant's own migration with a **channel-wise shift** (`z_j = (max(X_j) + min(X_j)) / 2`) applied before the scale, folding the shift's constant contribution back into the layer's output via a new `Add` node so the whole transformation stays an exact algebraic identity pre-quantization — same "lossless pre-conditioning ahead of a separate W8A8 quantizer" role `apply_smoothquant` already fills.

## Empirically confirmed facts

- Repo-wide grep for "outlier suppression", "rptq", "billm"/"pb-llm", "zeroquant", "atom quant", "flexround", "lqer" (and the existing `docs/nncf-comparison-future-work.md`/`docs/exl3-quantization-survey.md` research notes) confirmed this technique wasn't already ported before starting.
- Real onnxruntime run (`K=64, N=16` MatMul, calibration data with 2 channels shifted well off zero, e.g. mean offset ~20-30): float vs. `apply_outlier_suppression_plus`-migrated output — **max abs diff `1.72e-05`, relative L2 `2.0e-07`** — confirms the shift+scale+correction composition is an exact identity (up to float rounding), not an approximation.
- `pytest tests/test_outlier_suppression_plus.py -v`: **7 passed** (exactness via real onnxruntime, shift recenters lopsided channels to `(max+min)/2 ≈ 0`, migration beats plain SmoothQuant's post-scale channel-range spread on lopsided channels, `Gemm transB=1`, and three no-op/skip cases).
- `pytest tests/test_smoothquant.py tests/test_bias_correction.py tests/test_awq.py -q`: **28 passed** — confirms no regression in the modules this one imports from (`onnxsim.smoothquant._match_matmul_like`, `onnxsim.bias_correction`'s probe/naming helpers).
- `ruff check`/`ruff format --check` on the new/changed files: clean (repo-wide `ruff check .` shows 18 pre-existing errors, all in unrelated files, e.g. a `scripts/` helper — none in files this PR touches).
- `python -m mypy` (whole-package, matching `pyproject.toml`'s `[tool.mypy] files = ["onnxsim"]`): **25 errors in 7 files**, identical count/files whether or not `onnxsim/outlier_suppression_plus.py` is included — this PR adds zero new mypy errors.
- Full extension rebuild (`git submodule update --init --recursive` + `pip install -e . --no-build-isolation -v`) succeeded from a clean checkout; all the above was run against that real build, not mocked.

## What's added / scope

- `onnxsim/outlier_suppression_plus.py` — `apply_outlier_suppression_plus(model, calibration_data=None, num_samples=8, seed=0, alpha=0.5, epsilon=1e-5, providers=None)`. Matches `MatMul`/vanilla-`Gemm` nodes with a constant 2-D float32 weight and a plain 2-D activation input (reuses `onnxsim.smoothquant._match_matmul_like`, no reimplementation). For each matched layer: computes per-channel `z = (max+min)/2` and reuses SmoothQuant's own closed-form scale formula on the *shifted* channel; rescales the weight in place; inserts `Sub`→`Mul` before the layer (shift, then scale) and a new `Add` after it (`z @ W`, using the *original* unscaled weight) restoring the shift's exact constant contribution — reusing the same "rename producer output, insert an op that reproduces the original name" mechanics `onnxsim.bias_correction`'s `_apply_correction` already uses, so downstream consumers keep working unmodified.
- Deliberately **not** ported: the paper's own iterative grid-search refinement on top of the closed-form scale (a secondary, typically small improvement) — this PR ports the paper's headline structural contribution over SmoothQuant (the shift), matching `apply_smoothquant`'s own documented practice of using the closed-form scale rather than searching it. Documented explicitly in the module's own docstring.
- `tests/test_outlier_suppression_plus.py` — 7 tests, built via `onnx.parser.parse_model` per this repo's `CLAUDE.md` convention.
- `docs/outlier-suppression-plus.md` — before/after graph shape, paper provenance, scope (handled/left-untouched), usage, relationship to `apply_smoothquant`.
- `onnxsim/__init__.py` — registers `apply_outlier_suppression_plus` (import + `__all__`).

## Test plan

- [x] Real onnxruntime execution: float vs. migrated output matches to `< 1e-4` relative L2 (measured `2.0e-07`).
- [x] Shift actually recenters lopsided channels: post-`Sub` `(max+min)/2 ≈ 0` for every channel, including ones that started with a >5.0 mean offset.
- [x] Migration reduces post-scale channel-range spread more than plain `apply_smoothquant` on the same lopsided calibration set (SmoothQuant's own scale alone cannot narrow a lopsided channel's `max(|X|)`).
- [x] `Gemm transB=1` end-to-end.
- [x] No-op when no matching layer / non-constant weight / non-2-D activation.
- [x] `pytest tests/test_outlier_suppression_plus.py -v`: 7 passed.
- [x] `pytest tests/test_smoothquant.py tests/test_bias_correction.py tests/test_awq.py -q`: 28 passed (no regression).
- [x] `ruff check` / `ruff format --check`: clean.
- [x] `mypy`: 25 errors, unchanged from baseline, none in this PR's files.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxBPwkiTv7m32wAZtAubyc

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxBPwkiTv7m32wAZtAubyc)_