### PR TITLE
Add RPTQ cluster-and-reorder pre-quantization pass

### DIFF
--- a/docs/rptq-quantization.md
+++ b/docs/rptq-quantization.md
@@ -1,0 +1,132 @@
+# RPTQ: cluster-and-reorder pre-quantization (`apply_rptq_reorder`)
+
+## What this is
+
+`onnxsim.apply_rptq_reorder` clusters a MatMul/vanilla-Gemm layer's input
+channels by their own calibration range, then **reorders** the activation
+(via a runtime `Gather`) and the weight's matching rows so same-cluster
+channels sit contiguously. Unlike `onnxsim.apply_smoothquant`/
+`onnxsim.apply_outlier_suppression_plus` (which *scale*/*shift* difficulty
+from the activation into the weight) or `onnxsim.apply_quarot`/
+`onnxsim.apply_duquant` (which *rotate*), this only *permutes* -- an exact
+algebraic identity for any permutation, not an approximation. Like those
+other migration passes, this returns a float model meant to be fed to a
+separate W8A8 quantizer afterwards; unlike them, the actual benefit RPTQ's
+paper reports needs a *per-cluster* quantization range, which is not (yet)
+wired through onnxsim's existing calibration/quantization API -- see
+"Scope" below.
+
+```
+Before:
+  Y = MatMul(X, W) [+ bias]           -- W constant, [K, N], float32
+
+After:
+  perm: initializer, int64 [K]        -- sorts channels by calibration cluster
+  Xr = Gather(X, perm, axis=-1)       -- reorders the activation's K axis
+  Y = MatMul(Xr, Wr) [+ bias]         -- Wr: W's K-axis rows permuted by perm
+```
+
+## Where this comes from
+
+[RPTQ](https://arxiv.org/abs/2304.01089) (Yuan et al., 2023) starts from the
+same observation `apply_smoothquant` does: a handful of transformer
+activation channels sit at a much larger scale than the rest, so a single
+per-tensor (or per-token) quantization range wastes most of its resolution
+on the ordinary channels. RPTQ's own fix is structurally different from
+scaling: a per-tensor range is only forced on the quantizer because *all*
+channels share one quantization group. If channels with similar ranges are
+grouped together and each group gets its own tight, independently-computed
+`[min, max]`-derived scale/zero-point (a **per-cluster** quantization
+scheme), no single channel's outlier-ness drags down the resolution
+available to unrelated channels. RPTQ finds those groups by **clustering**
+the `K` input channels by their own calibration range statistics, then
+**permuting** the channels so that same-cluster channels sit contiguously.
+
+Reordering the reduction axis of an activation and reordering the matching
+axis (the input-channel rows) of the weight the same way is an exact
+identity for any permutation `perm`:
+
+```
+Gather(X, perm, axis=-1) @ Gather(W, perm, axis=0) == X @ W
+```
+
+so, like `apply_smoothquant`, this module performs only the reorder: no
+quantization happens here. Per matched layer: compute each input channel's
+own calibration abs-max, cluster those per-channel statistics into
+`num_clusters` groups with a plain Lloyd's-algorithm k-means (no `scipy`
+dependency -- a from-scratch implementation, seeded at evenly spaced
+percentiles of the per-channel statistics rather than at random points, so a
+small `num_clusters` reliably separates distinct scales), derive the
+permutation that sorts channels by cluster, and apply it to both operands.
+
+RPTQ's own paper goes considerably further than this module does. Not
+ported: (1) a bespoke integer-programming search over the *number* of
+clusters trading off latency against accuracy -- `num_clusters` is instead a
+plain, fixed parameter, the same simplification `apply_smoothquant` makes
+for its own `alpha`; (2) reordering and per-cluster-quantizing the attention
+mechanism's own K/V cache and softmax input specifically -- RPTQ's paper
+targets those tensors above all (see `onnxsim.quantize_kv_cache` for
+onnxsim's own, separate KV-cache quantization support); and (3) a "reorder
+back" step fusing the inverse permutation into LayerNorm scale parameters so
+a reordered layer's output can feed the next, unreordered layer without a
+runtime `Gather` -- this module always materializes the reorder as an actual
+`Gather` node instead. This is the same "headline structural contribution,
+not every secondary refinement" scope line `apply_outlier_suppression_plus`
+draws relative to its own paper.
+
+## Scope
+
+Handled:
+
+- `MatMul(X, W)` (2 inputs), or `Gemm(X, W[, B])` with `transA=0`, `alpha=1`,
+  and (when `B` is present) `beta=1`. `transB` may be 0 or 1.
+- `W` must be a constant 2-D float32 tensor.
+- `X` must, when probed on the supplied calibration data, be a plain 2-D
+  tensor (`[rows, K]`) whose `K` matches `W`'s reduction dimension.
+
+Left untouched (safe no-op, node passes through as-is):
+
+- Non-constant or non-2-D weights.
+- A layer whose activation input never appeared as a plain 2-D tensor across
+  the calibration batches (e.g. a 3-D `[batch, seq, hidden]` activation, or
+  one that never ran at all).
+- A model with no matching layer.
+
+**Not wired up**: `apply_rptq_reorder` returns per-layer cluster boundary
+metadata (an `RptqLayerInfo` per matched layer, mapping the layer's
+original activation name to the permutation applied and the resulting
+`[start, end)` slices of the *permuted* channel axis each cluster occupies)
+alongside the reordered model -- exactly the information a per-cluster
+quantizer needs. Wiring that all the way through `onnxsim.calibrate`,
+`onnxsim.quantize_static`, or `onnxsim.quantize_qoperator_gemm` would need
+each of those to grow a new per-slice-of-a-tensor calibration mode (today
+they all calibrate exactly one range per whole tensor) -- real, independent
+scope beyond porting RPTQ's own permutation construction. Until that
+quantizer exists, running `apply_rptq_reorder` ahead of
+`quantize_static`/`quantize_qoperator_gemm` is still a free, exact
+transformation, but those quantizers will still calibrate one range across
+the whole (now-reordered) tensor rather than one per cluster, so the
+practical accuracy benefit RPTQ's own paper reports will not fully
+materialize until a per-cluster quantizer consumes `RptqLayerInfo` too.
+
+## Usage
+
+```python
+import onnx
+import onnxsim
+
+model = onnx.load("model.onnx")
+reordered, layer_info = onnxsim.apply_rptq_reorder(model, num_clusters=4)
+onnx.save(reordered, "model.rptq.onnx")
+
+# layer_info maps each matched layer's original activation name to an
+# RptqLayerInfo(x_name, w_name, gather_output, permutation, cluster_bounds)
+for x_name, info in layer_info.items():
+    print(x_name, "->", info.cluster_bounds)
+```
+
+`calibration_data` defaults to `onnxsim.generate_random_calibration_data`;
+pass real representative batches (e.g. via
+`onnxsim.load_huggingface_calibration_data`) for a clustering that actually
+reflects the model's own real per-channel ranges, the same caveat
+`apply_smoothquant`/`apply_duquant` document.

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -125,6 +125,7 @@ from onnxsim.pruning import (
 )
 from onnxsim.quarot import apply_quarot
 from onnxsim.quip_sharp import apply_quip_sharp
+from onnxsim.rptq import apply_rptq_reorder
 from onnxsim.smoothquant import apply_smoothquant
 from onnxsim.spinquant import apply_spinquant
 from onnxsim.spqr import quantize_weight_only_spqr
@@ -155,6 +156,7 @@ __all__ = [
     "apply_attention_quantization",
     "apply_gptq",
     "apply_smoothquant",
+    "apply_rptq_reorder",
     "apply_llm_int8",
     "apply_low_rank_compensation",
     "apply_mixed_precision_quantization",

--- a/onnxsim/rptq.py
+++ b/onnxsim/rptq.py
@@ -1,0 +1,331 @@
+"""RPTQ (Yuan et al., 2023, "RPTQ: Reorder-based Post-training Quantization
+for Large Language Models", https://arxiv.org/abs/2304.01089). onnxsim ports
+the *algorithm*, not any framework's code, per the same rationale as
+:mod:`onnxsim.smoothquant`/:mod:`onnxsim.duquant` (RPTQ's own reference
+implementation reorders and quantizes live PyTorch activations with no ONNX
+export path).
+
+:mod:`onnxsim.smoothquant`/:mod:`onnxsim.outlier_suppression_plus` address
+the same root problem RPTQ does -- a handful of transformer activation
+channels sit at a much larger scale than the rest, so a single per-tensor
+(or per-token) quantization range wastes most of its resolution on the
+ordinary channels -- but via *scaling* (and, for Outlier Suppression+, an
+added shift): move difficulty from the activation into the weight with an
+elementwise multiply. RPTQ's own fix is structurally different: it never
+rescales anything. Instead, it observes that a per-tensor range is only
+forced on the quantizer because *all* channels share one quantization
+group; if channels with similar ranges are grouped together and each group
+gets its own tight, independently-computed `[min, max]`-derived scale/zero
+-point (a **per-cluster** quantization scheme), a channel's outlier-ness no
+longer drags down the resolution available to unrelated channels. RPTQ finds
+those groups by **clustering** the `K` input channels -- by each channel's
+own calibration range statistics -- into a small number of clusters, then
+**permuting** the channels so that same-cluster channels sit contiguously.
+
+Reordering the reduction axis (`K`) of an activation and reordering the
+matching axis (the input-channel rows) of the weight the same way is an
+exact algebraic identity for any permutation `perm`, not an approximation:
+
+    Gather(X, perm, axis=-1) @ Gather(W, perm, axis=0) == X @ W
+
+(`Gather(W, perm, axis=0)` is `W[perm, :]` for a plain, un-transposed
+`MatMul`/Gemm weight, or `W[:, perm]` when `transB=1` stores the weight as
+`[N, K]` instead of `[K, N]`.) So, like :mod:`onnxsim.smoothquant`, this
+module only performs the *reorder*: :func:`apply_rptq_reorder` returns a
+float model, provably equivalent to the input up to floating-point
+rounding -- no quantization happens here. Concretely, per matched layer:
+compute each input channel's own calibration `[min, max]` (equivalently
+here, its abs-max -- see below), cluster those per-channel statistics into
+`num_clusters` groups with a plain Lloyd's-algorithm k-means (no `scipy`
+dependency), derive the permutation that sorts channels by cluster, insert
+a `Gather(X, perm_indices, axis=-1)` before the layer, and permute the
+weight's `K`-axis rows in place by that same permutation. This composition
+is exact regardless of how good the clustering turns out to be -- a bad
+cluster assignment only costs quantization quality downstream, never
+correctness of the permuted float graph produced here.
+
+RPTQ's own paper goes considerably further than this module does, most
+notably: (1) a bespoke integer-programming search over the *number* of
+clusters trading off latency against accuracy (this module instead takes
+`num_clusters` as a plain, fixed parameter, the same simplification
+:mod:`onnxsim.smoothquant` makes for its own `alpha`); (2) reordering and
+per-cluster-quantizing the attention mechanism's own K/V cache and
+softmax input specifically (RPTQ's main target, since those tensors are
+particularly outlier-heavy in the models the paper studies); and (3) a
+"reorder back" step fusing the inverse permutation into LayerNorm scale
+parameters so a reordered layer's *output* can feed directly into the next
+unreordered layer, avoiding a runtime `Gather` entirely. None of these are
+ported: this module targets the same general MatMul/Gemm layers
+:mod:`onnxsim.smoothquant` does (not attention-specific KV-cache/softmax
+tensors -- see :mod:`onnxsim.kv_cache_quantization` for onnxsim's existing,
+separate KV-cache quantization support), always materializes the reorder as
+a runtime `Gather` rather than fusing it away, and always quantizes the
+result of clustering with the number of clusters given, exactly the same
+"headline structural contribution, not every secondary refinement" scope
+line :mod:`onnxsim.outlier_suppression_plus` draws relative to its own
+paper.
+
+Because the whole point of the reorder is to let a *separate* quantizer
+apply a tight per-cluster range instead of one per-tensor range, this
+module also returns, alongside the permuted model, a small
+:class:`RptqLayerInfo` record per matched layer carrying the cluster
+boundaries in the *permuted* channel order. Wiring per-cluster ranges all
+the way through onnxsim's existing calibration/quantization API
+(:func:`onnxsim.calibrate`, :func:`onnxsim.quantize_static`,
+:func:`onnxsim.quantize_qoperator_gemm`) would need each of those to grow a
+new per-slice-of-a-tensor calibration mode -- none support anything finer
+than "one range per tensor" today -- which is real, independent scope
+beyond porting RPTQ's own permutation-construction contribution; this
+module stops at handing back the information a future per-cluster
+quantizer would need, the same honest boundary
+:mod:`onnxsim.outlier_suppression_plus`'s own docstring draws around OS+'s
+secondary scale-search refinement. Until that quantizer exists, the
+practical benefit of running this ahead of
+:func:`onnxsim.quantize_static`/:func:`onnxsim.quantize_qoperator_gemm` is
+smaller than RPTQ's own paper reports (those still calibrate one range per
+whole tensor) -- but the reorder is still free (an exact identity) and
+puts a model in the right shape for a per-cluster quantizer later.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Sequence, Tuple, Union
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+
+from onnxsim import backend
+from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.calibration import Tensors, generate_random_calibration_data
+from onnxsim.smoothquant import _match_matmul_like
+
+
+@dataclass
+class RptqLayerInfo:
+    """Per-cluster metadata for one RPTQ-reordered layer, as returned by
+    :func:`apply_rptq_reorder`. ``cluster_bounds`` names, for each cluster,
+    the half-open ``[start, end)`` slice of the *permuted* channel axis
+    (i.e. of the ``Gather`` node's output, and of the weight's permuted
+    ``K``-axis rows) that cluster occupies, in increasing order -- exactly
+    the slices a per-cluster quantizer would compute an independent
+    ``[min, max]``-derived scale/zero-point over.
+    """
+
+    x_name: str
+    w_name: str
+    gather_output: str
+    permutation: np.ndarray
+    cluster_bounds: List[Tuple[int, int]] = field(default_factory=list)
+
+
+def _kmeans_1d(
+    values: np.ndarray,
+    num_clusters: int,
+    rng: np.random.Generator,
+    num_iters: int = 50,
+) -> np.ndarray:
+    """Plain Lloyd's-algorithm k-means (no ``scipy`` dependency) clustering
+    1-D ``values`` into ``num_clusters`` groups. Returns a same-length
+    ``int64`` array of cluster assignments.
+
+    Centroids are seeded at evenly spaced percentiles of ``values`` (a
+    deterministic spread across the value range, not a random draw, so a
+    small ``num_clusters`` reliably separates distinct scales from the very
+    first iteration) rather than seeded fully randomly; ``rng`` only breaks
+    ties when two or more centroids end up numerically identical after
+    seeding (e.g. many duplicate values), nudging the duplicates apart so no
+    cluster is ever left permanently empty.
+    """
+    n = values.shape[0]
+    k = min(num_clusters, n)
+    percentiles = np.linspace(0.0, 100.0, k)
+    centroids = np.percentile(values, percentiles)
+    # Break ties from duplicate percentile values so every cluster starts
+    # with a distinct centroid.
+    for i in range(1, k):
+        if centroids[i] <= centroids[i - 1]:
+            centroids[i] = centroids[i - 1] + 1e-9 * (1.0 + abs(centroids[i - 1]))
+    jitter_scale = 1e-9 * (1.0 + np.abs(centroids).max())
+    centroids = centroids + rng.normal(scale=jitter_scale, size=k)
+
+    assignments = np.zeros(n, dtype=np.int64)
+    for _ in range(num_iters):
+        dist = np.abs(values[:, np.newaxis] - centroids[np.newaxis, :])
+        new_assignments = np.argmin(dist, axis=1)
+        if np.array_equal(new_assignments, assignments) and _ > 0:
+            break
+        assignments = new_assignments
+        for c in range(k):
+            members = values[assignments == c]
+            if members.size > 0:
+                centroids[c] = members.mean()
+    return assignments
+
+
+def _reorder_permutation(
+    assignments: np.ndarray,
+) -> Tuple[np.ndarray, List[Tuple[int, int]]]:
+    """Builds the permutation that sorts channel indices by cluster id (a
+    stable sort, so within a cluster channels keep their original relative
+    order), plus that permuted order's per-cluster ``[start, end)`` bounds.
+    ``perm[i]`` is the *original* channel index now sitting at permuted
+    position ``i``: ``Gather(X, perm, axis=-1)[..., i] == X[..., perm[i]]``.
+    """
+    order = np.argsort(assignments, kind="stable")
+    sorted_assignments = assignments[order]
+    bounds: List[Tuple[int, int]] = []
+    start = 0
+    for i in range(1, len(sorted_assignments) + 1):
+        if (
+            i == len(sorted_assignments)
+            or sorted_assignments[i] != sorted_assignments[start]
+        ):
+            bounds.append((start, i))
+            start = i
+    return order.astype(np.int64), bounds
+
+
+def apply_rptq_reorder(
+    model: Union[str, onnx.ModelProto],
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_samples: int = 8,
+    seed: int = 0,
+    num_clusters: int = 4,
+    providers: Optional[Sequence[str]] = None,
+) -> Tuple[onnx.ModelProto, Dict[str, RptqLayerInfo]]:
+    """Clusters and reorders every MatMul/vanilla-Gemm layer's input
+    channels (RPTQ's own contribution -- see this module's docstring),
+    using real calibration activations. Returns a float model -- an exact
+    reordering, not a quantization -- meant to be fed to a downstream
+    per-cluster-aware W8A8 quantizer; see this module's own docstring for
+    how far that composition is (and isn't) wired up today.
+
+    :param model: the original (unquantized) onnx ModelProto or file path
+    :param calibration_data: representative input batches to measure each
+            input channel's calibration range on. Each batch is a
+            ``{input_name: np.ndarray}`` dict matching ``model``'s graph
+            inputs -- see :func:`onnxsim.generate_random_calibration_data`
+            (the default when omitted) and
+            :func:`onnxsim.load_huggingface_calibration_data` (real data, a
+            much more representative clustering than random input).
+    :param num_samples: random batches to generate when
+            ``calibration_data`` is omitted
+    :param seed: seed for the random calibration data (ignored if
+            ``calibration_data`` is supplied) and for the k-means centroid
+            tie-breaking (a fresh ``numpy.random.Generator`` is derived per
+            matched layer, in graph node order)
+    :param num_clusters: number of channel clusters to reorder each
+            matched layer's input into (the paper's own default range is a
+            handful of clusters per layer; RPTQ's bespoke integer-
+            -programming search over this count is not ported -- see this
+            module's own docstring)
+    :param providers: onnxruntime execution providers to run ``model`` on
+            when capturing calibration activations
+    :returns: a ``(model, layer_info)`` pair. ``model`` has every matched
+            layer's weight rows permuted in place by ``K``-axis cluster and
+            a new ``Gather`` node inserted before it applying the same
+            permutation to its activation input. ``layer_info`` maps each
+            matched layer's original activation input name to an
+            :class:`RptqLayerInfo` record describing the permutation and
+            resulting cluster boundaries. Layers with a non-constant,
+            non-2-D weight, or whose activation input isn't a plain 2-D
+            tensor matching the weight's reduction dimension, are left
+            untouched and have no entry in ``layer_info``.
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            model, num_samples=num_samples, seed=seed
+        )
+
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    graph = out.graph
+    initializer_map = {t.name: t for t in graph.initializer}
+    taken_names = _all_names(graph)
+
+    nodes = list(graph.node)
+    candidates = []
+    for node in nodes:
+        match = _match_matmul_like(node)
+        if match is None:
+            continue
+        x_name, w_name, weight_transposed = match
+        w_init = initializer_map.get(w_name)
+        if (
+            w_init is None
+            or w_init.data_type != onnx.TensorProto.FLOAT
+            or len(w_init.dims) != 2
+        ):
+            continue
+        candidates.append((node, x_name, w_name, weight_transposed))
+
+    layer_info: Dict[str, RptqLayerInfo] = {}
+    if not candidates:
+        return out, layer_info
+
+    probe_names = sorted({x_name for _, x_name, _, _ in candidates})
+    probe_model = _add_probe_outputs(out, probe_names)
+
+    act_absmax: Dict[str, np.ndarray] = {}
+    for batch in calibration_data:
+        result = backend.run_model(probe_model, batch, providers=providers)
+        for name in probe_names:
+            x = np.asarray(result[name], dtype=np.float64)
+            if x.ndim != 2:
+                continue
+            m = np.abs(x).max(axis=0)
+            act_absmax[name] = (
+                m if name not in act_absmax else np.maximum(act_absmax[name], m)
+            )
+
+    rng = np.random.default_rng(seed)
+
+    for node, x_name, w_name, weight_transposed in candidates:
+        absmax = act_absmax.get(x_name)
+        if absmax is None:
+            continue  # never observed as a plain 2-D tensor; skip
+
+        w_init = initializer_map[w_name]
+        w = onnx.numpy_helper.to_array(w_init).astype(np.float64)
+        dim0, dim1 = w.shape
+        w_nk = w if weight_transposed else w.T  # [N, K], output channel first
+        k = w_nk.shape[1]
+        if absmax.shape[0] != k:
+            continue  # activation's feature dim doesn't match K; skip
+
+        assignments = _kmeans_1d(absmax, num_clusters, rng)
+        perm, bounds = _reorder_permutation(assignments)
+
+        w_permuted_nk = w_nk[:, perm]
+        w_new = w_permuted_nk if weight_transposed else w_permuted_nk.T
+        w_new = w_new.reshape(dim0, dim1).astype(np.float32)
+        w_init.CopyFrom(onnx.numpy_helper.from_array(w_new, name=w_name))
+
+        perm_name = _unique_name(f"{x_name}_rptq_perm", taken_names)
+        graph.initializer.append(onnx.numpy_helper.from_array(perm, name=perm_name))
+        gathered_name = _unique_name(f"{x_name}_rptq_reordered", taken_names)
+        gather_node = onnx.helper.make_node(
+            "Gather",
+            [x_name, perm_name],
+            [gathered_name],
+            name=_unique_name(f"{x_name}_rptq_gather", taken_names),
+            axis=-1,
+        )
+        node_idx = next(i for i, n in enumerate(graph.node) if n is node)
+        graph.node.insert(node_idx, gather_node)
+        node.input[0] = gathered_name
+
+        layer_info[x_name] = RptqLayerInfo(
+            x_name=x_name,
+            w_name=w_name,
+            gather_output=gathered_name,
+            permutation=perm,
+            cluster_bounds=bounds,
+        )
+
+    return out, layer_info

--- a/tests/test_rptq.py
+++ b/tests/test_rptq.py
@@ -1,0 +1,216 @@
+"""Tests for ``onnxsim.apply_rptq_reorder`` (RPTQ, see ``onnxsim/rptq.py``)
+-- clusters a MatMul/Gemm layer's input channels by their own calibration
+range and reorders them (plus the weight's matching rows) so same-cluster
+channels sit contiguously, an exact pre-quantization identity
+(``Gather(X, perm, axis=-1) @ Gather(W, perm, axis=0) == X @ W``) meant to
+run ahead of a separate per-cluster-aware W8A8 quantizer.
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+from onnxsim.rptq import RptqLayerInfo
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _model(body, initializer=(), opset=13, ir_version=8):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _matmul_model(K=64, N=16, weight=None, seed=0):
+    if weight is None:
+        rng = np.random.default_rng(seed)
+        weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[_f32(weight, "W")],
+    )
+
+
+def _run(model, feeds, output_names=None):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    names = output_names or [o.name for o in sess.get_outputs()]
+    return dict(zip(names, sess.run(names, feeds)))
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
+
+
+def _clustered_calibration(K=60, num_samples=64, num_clans=3, seed=1):
+    # RPTQ's own motivating scenario: distinct groups of channels sharing a
+    # similar magnitude within the group, but wildly different across
+    # groups -- exactly what a per-tensor quantization range wastes
+    # resolution on.
+    rng = np.random.default_rng(seed)
+    x = rng.standard_normal((num_samples, K)).astype(np.float32)
+    clan_of = np.arange(K) % num_clans
+    for clan in range(num_clans):
+        scale = 10.0**clan  # 1x, 10x, 100x, ...
+        x[:, clan_of == clan] *= scale
+    return x, clan_of
+
+
+def test_rptq_output_matches_float_almost_exactly():
+    # Like SmoothQuant, RPTQ's own reorder is exact algebraic identity, not
+    # an approximation -- so the tolerance is far tighter than any lossy
+    # INT4/INT8 quantization scheme's.
+    model = _matmul_model(K=60, N=16, seed=0)
+    x, _ = _clustered_calibration(K=60, num_samples=64, seed=1)
+    calibration_data = [{"X": x}]
+
+    rptq_model, layer_info = onnxsim.apply_rptq_reorder(
+        model, calibration_data=calibration_data, num_clusters=3
+    )
+    onnx.checker.check_model(rptq_model)
+    assert any(n.op_type == "Gather" for n in rptq_model.graph.node)
+    assert "X" in layer_info
+    assert isinstance(layer_info["X"], RptqLayerInfo)
+
+    float_out = _run(model, {"X": x})
+    rptq_out = _run(rptq_model, {"X": x}, output_names=["Y"])
+    assert np.all(np.isfinite(rptq_out["Y"]))
+    assert _rel_l2(float_out["Y"], rptq_out["Y"]) < 1e-4
+
+
+def test_rptq_clusters_similar_range_channels_together():
+    # Channels from the same "clan" (same magnitude scale) should be
+    # reordered to sit contiguously, and the resulting cluster boundaries
+    # should partition the permuted axis into exactly num_clusters groups
+    # that don't mix clans.
+    K, num_clans = 60, 3
+    model = _matmul_model(K=K, N=8, seed=2)
+    x, clan_of = _clustered_calibration(
+        K=K, num_samples=64, num_clans=num_clans, seed=3
+    )
+    calibration_data = [{"X": x}]
+
+    _, layer_info = onnxsim.apply_rptq_reorder(
+        model, calibration_data=calibration_data, num_clusters=num_clans
+    )
+    info = layer_info["X"]
+    assert len(info.cluster_bounds) == num_clans
+
+    perm = info.permutation
+    assert sorted(perm.tolist()) == list(range(K))
+    # Originally-interleaved channels (index % num_clans) must land in
+    # contiguous, non-interleaved runs after reordering.
+    permuted_clans = clan_of[perm]
+    for start, end in info.cluster_bounds:
+        segment = permuted_clans[start:end]
+        assert np.all(segment == segment[0]), (
+            "cluster segment mixes channels from different magnitude clans"
+        )
+    # Every original channel that was in the same clan should have ended up
+    # in the same cluster segment as every other channel from that clan.
+    seen_clan_per_segment = [permuted_clans[start] for start, _ in info.cluster_bounds]
+    assert len(set(seen_clan_per_segment)) == num_clans
+
+
+def test_rptq_gemm_transb():
+    rng = np.random.default_rng(8)
+    K, N = 96, 12
+    weight = rng.standard_normal((N, K)).astype(np.float32) * 0.5
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = Gemm<transB = 1>(X, W)
+        }}
+        """,
+        initializer=[_f32(weight, "W")],
+    )
+    x, _ = _clustered_calibration(K=K, num_samples=32, seed=9)
+    calibration_data = [{"X": x}]
+
+    rptq_model, layer_info = onnxsim.apply_rptq_reorder(
+        model, calibration_data=calibration_data, num_clusters=4
+    )
+    onnx.checker.check_model(rptq_model)
+    assert "X" in layer_info
+
+    float_out = _run(model, {"X": x})
+    rptq_out = _run(rptq_model, {"X": x}, output_names=["Y"])
+    assert _rel_l2(float_out["Y"], rptq_out["Y"]) < 1e-4
+
+
+def test_rptq_noop_when_no_matmul_present():
+    model = _model(
+        """
+        g (float[4,4] X) => (float[4,4] Y)
+        {
+          Y = Relu(X)
+        }
+        """
+    )
+    result, layer_info = onnxsim.apply_rptq_reorder(
+        model, calibration_data=[{"X": np.zeros((4, 4), dtype=np.float32)}]
+    )
+    assert result.SerializeToString() == model.SerializeToString()
+    assert layer_info == {}
+
+
+def test_rptq_skips_non_constant_weight():
+    model = _model(
+        """
+        g (float[4,64] X, float[64,4] W) => (float[4,4] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """
+    )
+    result, layer_info = onnxsim.apply_rptq_reorder(
+        model, calibration_data=[{"X": np.zeros((4, 64), dtype=np.float32)}]
+    )
+    assert result.SerializeToString() == model.SerializeToString()
+    assert layer_info == {}
+
+
+def test_rptq_skips_non_2d_activation():
+    # A 3-D activation (e.g. [batch, seq, hidden], typical of an
+    # ONNX-exported transformer) isn't a plain 2-D tensor -- matches this
+    # module's own documented scope, same as onnxsim.apply_smoothquant.
+    K, N = 16, 8
+    rng = np.random.default_rng(10)
+    weight = rng.standard_normal((K, N)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,seq,{K}] X) => (float[batch,seq,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[_f32(weight, "W")],
+    )
+    x = rng.standard_normal((2, 3, K)).astype(np.float32)
+    result, layer_info = onnxsim.apply_rptq_reorder(model, calibration_data=[{"X": x}])
+    assert result.SerializeToString() == model.SerializeToString()
+    assert layer_info == {}


### PR DESCRIPTION
## Summary

- Ports RPTQ (Yuan et al., 2023, "RPTQ: Reorder-based Post-training
  Quantization for Large Language Models",
  https://arxiv.org/abs/2304.01089) as a new onnxsim module,
  `onnxsim/rptq.py` (`onnxsim.apply_rptq_reorder`).
- Unlike `onnxsim.apply_smoothquant`/`onnxsim.apply_outlier_suppression_plus`
  (scale/shift) or `onnxsim.apply_quarot`/`onnxsim.apply_duquant` (rotate),
  RPTQ's own contribution is a **permutation**: cluster a MatMul/vanilla-Gemm
  layer's input channels by their own calibration range (a from-scratch,
  `scipy`-free Lloyd's-algorithm k-means), then reorder the activation (via
  `Gather`) and the weight's matching `K`-axis rows so same-cluster channels
  sit contiguously — an exact algebraic identity
  (`Gather(X, perm, axis=-1) @ Gather(W, perm, axis=0) == X @ W`), not an
  approximation.

## Empirically confirmed facts

- `ruff check onnxsim/rptq.py onnxsim/__init__.py tests/test_rptq.py` →
  `All checks passed!`; `ruff format --check` on the same files →
  `3 files already formatted`.
- `python -m mypy` (whole-package, matching `pyproject.toml`) →
  `Found 25 errors in 7 files (checked 49 source files)` — the exact same
  baseline count/file-set this repo's `CLAUDE.md` documents as pre-existing
  and unrelated to this change (`coreml_export.py`, `model_info.py`,
  `model_checking.py`, `calibration.py`, `pruning.py`, `onnx_simplifier.py`,
  `gguf_reconstruct.py`). Zero new errors.
- `pip install -e . --no-build-isolation` — real C++ build (vendored
  protobuf/abseil + onnx + onnx-optimizer), completed successfully
  (`Successfully installed ... onnxsim-0.7.3`).
- `pytest tests/test_rptq.py -v` with real `onnxruntime` (1.29.0): **6
  passed** (`test_rptq_output_matches_float_almost_exactly`,
  `test_rptq_clusters_similar_range_channels_together`,
  `test_rptq_gemm_transb`, `test_rptq_noop_when_no_matmul_present`,
  `test_rptq_skips_non_constant_weight`, `test_rptq_skips_non_2d_activation`).
  `tests/test_smoothquant.py` re-run alongside it: still 14/14 total passed
  (no regression from reusing its `_match_matmul_like` matcher).
- Measured a real onnxruntime max-abs-diff between the float model and the
  RPTQ-reordered model on a 3-clan synthetic calibration set (K=60, N=16,
  64 calibration rows, `num_clusters=3`): **max abs diff = 1.83e-4** against
  a max output magnitude of **1055.3** (relative ≈ 1.7e-7) — confirming the
  reorder is a real algebraic identity, not an approximation. The reported
  `cluster_bounds` for that run were `[(0, 20), (20, 40), (40, 60)]`,
  correctly separating the three interleaved magnitude clans (1x/10x/100x)
  into contiguous, non-mixed segments.

## What's added / scope

- `onnxsim/rptq.py`: `apply_rptq_reorder(model, calibration_data=None,
  num_samples=8, seed=0, num_clusters=4, providers=None)` →
  `(model, Dict[str, RptqLayerInfo])`. Reuses
  `onnxsim.smoothquant._match_matmul_like` for the MatMul/vanilla-Gemm
  matcher (per repo convention), and `onnxsim.bias_correction`'s
  `_add_probe_outputs`/`_all_names`/`_unique_name` helpers, the same way
  `onnxsim/duquant.py` and `onnxsim/smoothquant.py` do.
- Returns per-layer `RptqLayerInfo` (permutation + `[start, end)` cluster
  boundaries in the *permuted* channel order) as metadata for a future
  per-cluster-aware quantizer to consume — not wired all the way through
  `onnxsim.calibrate`/`quantize_static`/`quantize_qoperator_gemm` (none of
  those support anything finer than one range per whole tensor today; see
  the module's own docstring and `docs/rptq-quantization.md`'s "Scope"
  section for the explicit, honest boundary this draws, matching how
  `outlier_suppression_plus.py` declines to port OS+'s own secondary
  scale-search refinement).
- Deliberately **not** ported from the RPTQ paper: its integer-programming
  search over the number of clusters (a plain `num_clusters` parameter is
  used instead, like `apply_smoothquant`'s fixed `alpha`), its
  attention-specific K/V-cache/softmax reordering (out of scope — see
  `onnxsim.quantize_kv_cache` for onnxsim's existing, separate KV-cache
  quantization), and its "reorder back" LayerNorm-fusion step (the reorder
  is always materialized as a real `Gather` node here).
- `docs/rptq-quantization.md`: same section shape as `docs/duquant.md` (What
  this is / Where this comes from / Scope / Usage).
- `onnxsim/__init__.py`: added the `apply_rptq_reorder` import (alphabetical
  by module filename, between `quip_sharp` and `smoothquant`) and `__all__`
  entry (grouped near `apply_smoothquant`).

## Test plan

- [x] `ruff check` / `ruff format --check` clean on all new/changed files
- [x] `python -m mypy` — zero new errors vs. documented 25-error baseline
- [x] Real C++ build via `pip install -e . --no-build-isolation`
- [x] `pytest tests/test_rptq.py -v` — 6/6 passed with real onnxruntime
- [x] Real onnxruntime run confirming the reorder is an exact identity
      (measured max-abs-diff, see above)
- [x] `tests/test_smoothquant.py` re-run alongside — no regression

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFzjYQK41raM9rFCYahPg5

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFzjYQK41raM9rFCYahPg5)_