### PR TITLE
Add AdaQuant: joint weight-rounding + activation-clip calibration

### DIFF
--- a/docs/adaquant.md
+++ b/docs/adaquant.md
@@ -1,0 +1,131 @@
+# AdaQuant: joint weight-rounding + activation-clip calibration (`apply_adaquant`)
+
+## What this is
+
+`onnxsim.apply_adaquant` extends `onnxsim.apply_adaround`'s per-layer,
+gradient-descent weight-rounding optimization to also optimize the
+activation's own quantization range (its scale, and its zero-point, for
+asymmetric quantization) at the same time, against the same reconstruction
+loss. AdaRound only ever touches the weight side, leaving whatever
+calibration (`onnxsim.calibrate`) picked for the activation fixed; AdaQuant
+jointly gradient-descends both, on real calibration data, one layer at a
+time.
+
+```
+Before (produced by onnxsim.quantize_static):
+  Xq  = QuantizeLinear(X, Xs, Xzp)        -- Xs/Xzp: CALIBRATED, fixed
+  Xdq = DequantizeLinear(Xq, Xs, Xzp)
+  Wdq = DequantizeLinear(Wq, Ws, axis=<W's output-channel axis>)
+  Y   = MatMul(Xdq, Wdq)                  -- or Gemm
+
+After:
+  Xq  = QuantizeLinear(X, Xs', Xzp')      -- Xs'/Xzp': AdaQuant-OPTIMIZED
+  Xdq = DequantizeLinear(Xq, Xs', Xzp')
+  Wdq = DequantizeLinear(Wq', Ws, axis=<W's output-channel axis>)
+  Y   = MatMul(Xdq, Wdq)                  -- or Gemm
+```
+
+Only `Xs`, `Xzp`, and `Wq`'s integer codes change -- the graph structure,
+`Ws` (the weight's own per-channel scale), and every other tensor are left
+exactly as `quantize_static` produced them.
+
+## Where this comes from
+
+[AdaQuant](https://arxiv.org/abs/2006.10518) (Hubara, Nahshan, Hanani,
+Banner, Soudry, 2020/2021, "Improving Post Training Neural Quantization:
+Layer-wise Calibration and Integer Programming") is the paper that
+introduces `onnxsim.apply_adaround`'s closest relative. Nagel et al.'s
+AdaRound (ported first, and cited by this paper as related work) optimizes
+only the weight's own rounding, via a continuous "rectified sigmoid"
+relaxation of each element's floor/ceil choice, against a layer's
+reconstruction error (`||W_float @ X - W_quant @ X||^2`) -- leaving the
+activation's quantization range exactly what calibration picked. AdaQuant's
+own contribution is recognizing that this leaves error on the table for any
+scheme that *also* quantizes the activation (W8A8, unlike AdaRound's own
+weight-only INT4 target): the loss is a *joint* function of the weight's
+rounding and the activation's clip range
+(`Xdq = dequantize(quantize(X, scale, zero_point))`), and a rounding choice
+optimal against one activation range is not, in general, optimal against a
+different one -- a cross-term neither side's isolated optimization can see.
+AdaQuant optimizes both by gradient descent on the same loss, still
+layer-wise (each layer independently and sequentially, no cross-layer
+interaction -- the same scope AdaRound itself uses, and the "layer-wise
+calibration" half of the paper's own title).
+
+The paper's title bundles a second, unrelated contribution: an integer-
+programming solver that allocates a mixed per-layer bit-width budget across
+a whole network. **That half is not ported here** -- it is a distinct,
+much larger-scope global optimization problem (a budget-constrained search
+over per-layer precision choices for a whole model) with no relationship to
+the rounding/clip-range gradient descent this module implements. See
+`docs/exl3-quantization-survey.md` for this repository's own precedent of
+documenting an explicit "not ported" scope decision rather than silently
+under-delivering on a paper's title.
+
+The activation branch's gradients are the standard "straight-through"
+quantized-affine gradients (Bengio et al.'s STE, applied to a *learnable*
+clip range the way Esser et al. 2019's LSQ does): `round()`'s local
+gradient is 1 everywhere it isn't saturated by the surrounding clip, and
+the clip itself passes gradient through unchanged inside its range and
+blocks it outside -- composed step by step through the actual
+quantize-then-dequantize computation, not algebraically simplified first
+(naively collapsing `dequantize(quantize(x, s)) ≈ x` under a literal
+round-is-identity substitution would erase the very rounding-error signal
+the scale's gradient needs). Everything here is plain numpy with
+hand-derived gradients, matching `onnxsim.apply_adaround`'s own
+"post-hoc adjustment from real activations" style -- no autodiff framework.
+
+## Scope
+
+Handled:
+
+- `MatMul(X, W)` with `W` a constant 2-D float32 tensor, or `Gemm(X, W[, B])`
+  with `transA=0`, `alpha=1`, `beta=1` (when `B` is present) under the same
+  weight constraint -- `transB` may be 0 or 1 -- quantized by
+  `onnxsim.quantize_static` specifically: the QDQ shape shown above, with
+  the weight quantized per output channel, symmetric INT8, and the
+  activation quantized asymmetric uint8.
+- Both the weight's rounding (every element, via the same rectified-sigmoid
+  relaxation `apply_adaround` uses) and the activation's `(scale,
+  zero_point)` (kept continuous during optimization; the zero-point is
+  projected to the nearest integer in `[0, 255]` only once, at the end) are
+  optimized jointly.
+
+Left untouched (safe no-op, layer passes through as-is):
+
+- Any layer quantized by a scheme other than `quantize_static`'s QDQ format
+  -- including `onnxsim.quantize_qoperator_gemm`'s QGemm (`com.microsoft`
+  contrib op) format, which fuses activation quantization into a single
+  op instead of leaving it as an addressable `QuantizeLinear`/
+  `DequantizeLinear` pair, or any of the weight-only INT4 schemes
+  `apply_adaround`/`apply_awq`/`apply_gptq` already target.
+  Conv is not handled (`quantize_static` itself only quantizes MatMul and
+  "vanilla" Gemm into this QDQ shape; there is no Conv variant of it to
+  target).
+- A layer whose calibration activation was never captured (no data to
+  optimize against), or whose activation isn't a plain 2-D tensor.
+- The paper's own integer-programming bit-width allocation -- out of scope
+  for this module entirely, see above.
+- A model with no matching layer -- returned unchanged.
+
+## Usage
+
+```python
+import onnx
+import onnxsim
+
+model = onnx.load("model.onnx")
+calibration_data = [{"input_name": my_representative_batch}]
+
+quantized = onnxsim.quantize_static(model, calibration_data=calibration_data)
+adaquant_model = onnxsim.apply_adaquant(
+    model, quantized, calibration_data=calibration_data
+)
+onnx.save(adaquant_model, "model.adaquant.onnx")
+```
+
+`calibration_data` defaults to `onnxsim.generate_random_calibration_data`
+for both calls; pass the same real, representative batches to both (e.g.
+via `onnxsim.load_huggingface_calibration_data`) so the activation range
+`quantize_static` calibrates and the range `apply_adaquant` then refines
+are optimized against the same real distribution.

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -9,6 +9,7 @@ from onnxsim.accuracy import (
     quantize_auto,
     recommend_quantization,
 )
+from onnxsim.adaquant import apply_adaquant
 from onnxsim.adaround import apply_adaround
 from onnxsim.aqlm import quantize_weight_only_aqlm
 from onnxsim.attention_quantization import apply_attention_quantization
@@ -145,6 +146,7 @@ __all__ = [
     "cross_layer_equalize",
     "correct_bias",
     "apply_adaround",
+    "apply_adaquant",
     "apply_pruning_finetune",
     "apply_autoround",
     "auto_quantize_int4",

--- a/onnxsim/adaquant.py
+++ b/onnxsim/adaquant.py
@@ -1,0 +1,498 @@
+"""AdaQuant -- the layer-wise calibration half of "Improving Post Training
+Neural Quantization: Layer-wise Calibration and Integer Programming" (Hubara,
+Nahshan, Hanani, Banner, Soudry, 2020/2021,
+https://arxiv.org/abs/2006.10518). The paper has two independent
+contributions bundled under one name: (1) AdaQuant itself, a per-layer
+gradient-descent reconstruction-error minimization jointly over weight
+rounding *and* the activation's own clipping range, and (2) a separate
+integer-programming solver that allocates a mixed per-layer bit-width budget
+across a whole network. **Only (1) is ported here.** Bit-width allocation is
+a distinct, much larger-scope optimization problem (a global budget-
+constrained search over per-layer precision choices, not a per-layer
+reconstruction step) with no relationship to the rounding/clipping math this
+module implements, and is not attempted -- see
+``docs/exl3-quantization-survey.md`` for this repository's own precedent of
+documenting an explicit "not ported" scope decision rather than silently
+under-delivering on a paper's title.
+
+:func:`onnxsim.apply_adaround` already ports this paper's own closest
+relative -- Nagel et al.'s AdaRound -- which optimizes only *weight
+rounding* (a learned additive per-element perturbation, via the same
+"rectified sigmoid" relaxation this module reuses) against a layer's
+reconstruction error, leaving the activation's own quantization range fixed
+at whatever calibration (:func:`onnxsim.calibrate`'s min-max or entropy
+search) picked. AdaQuant's own insight is that this leaves error on the
+table: the reconstruction loss ``||W_float @ X - W_quant @ Xdq||^2`` is a
+*joint* function of both the weight's rounding and the activation's own
+clip range (``Xdq = dequantize(quantize(X, scale, zero_point))``), and the
+cross term between them (a weight rounding choice that would be optimal
+against one activation clip range is not, in general, optimal against a
+different one) is invisible to an optimizer that only ever touches one side.
+AdaQuant instead optimizes both by gradient descent on the *same* loss,
+per layer, starting from AdaRound-style weight-rounding relaxation and the
+calibrated activation range as its warm start -- still layer-wise (each
+layer optimized independently and sequentially, no cross-layer
+interaction, exactly :func:`onnxsim.apply_adaround`'s own scope), still
+plain numpy with hand-derived gradients, no autodiff framework.
+
+Consequently this module's *target scheme* also differs from
+:mod:`onnxsim.adaround`/:mod:`onnxsim.awq`/:mod:`onnxsim.gptq` (which all
+share :func:`onnxsim.quantize_weight_only_int4`'s weight-only INT4 scheme):
+AdaQuant only makes sense where the *activation* is itself quantized with a
+learnable clip range, i.e. :func:`onnxsim.quantize_static`'s W8A8 QDQ
+scheme, not a weight-only one. Of the two static-quantization graph shapes
+this repository produces, this module targets :func:`quantize_static`'s QDQ
+format (``QuantizeLinear``/``DequantizeLinear`` pairs wrapping an untouched
+MatMul/Gemm) rather than :func:`onnxsim.quantize_qoperator_gemm`'s QGemm
+format (a fused ``com.microsoft`` contrib op): the QDQ shape keeps the
+activation's scale/zero-point and the weight's codes/scale as ordinary,
+independently addressable initializers feeding standard ONNX
+Quantize/DequantizeLinear nodes, exactly the "locate an initializer by the
+node that consumes it, rewrite it in place" contract every onnxsim
+``apply_*`` correction pass already relies on -- QGemm's fused contrib-op
+inputs are no harder to *locate*, but there is no equivalent standard-ONNX
+node to rewrite them through, and this module has no need to touch QGemm's
+own compute node at all.
+
+For every MatMul, or "vanilla" Gemm (``transA=0``, ``alpha=1``, ``beta=1``),
+present (by node output name) in both ``float_model`` and ``quantized_model``
+whose ``quantized_model`` shape matches
+:func:`onnxsim.quantize_static`'s output exactly --
+
+.. code-block:: text
+
+    Xq  = QuantizeLinear(X, Xs, Xzp)        -- Xs/Xzp: asymmetric uint8
+    Xdq = DequantizeLinear(Xq, Xs, Xzp)
+    Wdq = DequantizeLinear(Wq, Ws, axis=<W's output-channel axis>)
+    Y   = MatMul(Xdq, Wdq)                  -- or Gemm
+
+-- this recovers each weight element's quantization bin the same way
+:mod:`onnxsim.adaround` does and optimizes a continuous rectified-sigmoid
+relaxation of its floor/ceil choice, *jointly* with ``Xs``/``Xzp`` (kept
+continuous during optimization, projected back to an integer zero-point in
+``[0, 255]`` only at the very end), against real activations captured from
+``float_model`` -- minimizing
+``||X @ W_float - dequantize(quantize(X, Xs, Xzp)) @ W_hat||^2`` by a small
+hand-rolled Adam loop over all three parameter groups at once. The
+activation branch's gradients are the standard "straight-through" quantized-
+affine gradients (as in Bengio et al.'s STE and, applied to a *learnable*
+clip range specifically, Esser et al. 2019's LSQ): ``round()``'s local
+gradient is taken as 1 everywhere it isn't saturated by the surrounding
+clip, and the clip's own gradient is 1 (pass-through) inside the clamped
+range and 0 outside it -- composed step by step through the actual
+quantize-then-dequantize computation graph, not algebraically simplified
+first (naively simplifying ``dequantize(quantize(x, s)) ≈ x`` under a
+literal round-is-identity substitution would erase the very rounding-error
+signal the scale gradient needs). The weight's own quantization *scale*
+stays exactly what :func:`quantize_static` calibrated -- only which integer
+each element rounds to is optimized, the same restriction
+:mod:`onnxsim.adaround` already imposes and this module inherits unchanged.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Tuple, Union
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+
+from onnxsim import backend
+from onnxsim.adaround import _GAMMA, _ZETA, _h_and_dhdv, _node_outputs
+from onnxsim.bias_correction import _add_probe_outputs
+from onnxsim.calibration import Tensors, generate_random_calibration_data
+
+_WEIGHT_N_MIN = -127.0
+_WEIGHT_N_MAX = 127.0
+_ACT_N_MAX = 255.0
+
+
+@dataclass
+class _Candidate:
+    output_name: str
+    float_node: onnx.NodeProto
+    w_float_init: onnx.TensorProto
+    wq_name: str
+    ws_name: str
+    channel_axis: int
+    weight_transposed: bool
+    x_scale_name: str
+    x_zp_name: str
+
+
+def _find_static_qdq_candidates(
+    float_model: onnx.ModelProto, quantized_model: onnx.ModelProto
+) -> List[_Candidate]:
+    q_by_output = _node_outputs(quantized_model.graph)
+    f_by_output = _node_outputs(float_model.graph)
+    q_init = {t.name: t for t in quantized_model.graph.initializer}
+    f_init = {t.name: t for t in float_model.graph.initializer}
+
+    candidates: List[_Candidate] = []
+    for out_name, qn in q_by_output.items():
+        if qn.op_type not in ("MatMul", "Gemm") or len(qn.input) < 2:
+            continue
+        fn = f_by_output.get(out_name)
+        if fn is None or fn.op_type != qn.op_type or len(fn.input) < 2:
+            continue
+
+        w_float_init = f_init.get(fn.input[1])
+        if (
+            w_float_init is None
+            or w_float_init.data_type != onnx.TensorProto.FLOAT
+            or len(w_float_init.dims) != 2
+        ):
+            continue
+
+        # Weight branch: Wdq = DequantizeLinear(Wq, Ws, axis=...), symmetric
+        # (no zero_point input) -- exactly static_quantize_matmul.h's shape.
+        wdq = q_by_output.get(qn.input[1])
+        if wdq is None or wdq.op_type != "DequantizeLinear" or len(wdq.input) != 2:
+            continue
+        wq_init = q_init.get(wdq.input[0])
+        ws_init = q_init.get(wdq.input[1])
+        if (
+            wq_init is None
+            or ws_init is None
+            or wq_init.data_type != onnx.TensorProto.INT8
+            or list(wq_init.dims) != list(w_float_init.dims)
+        ):
+            continue
+        axis = 1
+        for attr in wdq.attribute:
+            if attr.name == "axis":
+                axis = attr.i
+
+        # Activation branch: Xdq = DequantizeLinear(Xq, Xs, Xzp), Xq =
+        # QuantizeLinear(X, Xs, Xzp) -- both sharing the same scale/zero
+        # point initializers, exactly static_quantize_matmul.h's shape.
+        xdq = q_by_output.get(qn.input[0])
+        if xdq is None or xdq.op_type != "DequantizeLinear" or len(xdq.input) != 3:
+            continue
+        xq_node = q_by_output.get(xdq.input[0])
+        if (
+            xq_node is None
+            or xq_node.op_type != "QuantizeLinear"
+            or len(xq_node.input) != 3
+        ):
+            continue
+        x_scale_name, x_zp_name = xdq.input[1], xdq.input[2]
+        if xq_node.input[1] != x_scale_name or xq_node.input[2] != x_zp_name:
+            continue
+        x_scale_init = q_init.get(x_scale_name)
+        x_zp_init = q_init.get(x_zp_name)
+        if (
+            x_scale_init is None
+            or x_zp_init is None
+            or x_zp_init.data_type != onnx.TensorProto.UINT8
+        ):
+            continue
+
+        weight_transposed = False
+        if qn.op_type == "Gemm":
+            for attr in qn.attribute:
+                if attr.name == "transB":
+                    weight_transposed = bool(attr.i)
+
+        candidates.append(
+            _Candidate(
+                output_name=out_name,
+                float_node=fn,
+                w_float_init=w_float_init,
+                wq_name=wq_init.name,
+                ws_name=ws_init.name,
+                channel_axis=axis,
+                weight_transposed=weight_transposed,
+                x_scale_name=x_scale_name,
+                x_zp_name=x_zp_name,
+            )
+        )
+    return candidates
+
+
+def _optimize_adaquant(
+    w_nk: np.ndarray,
+    scale_n: np.ndarray,
+    x: np.ndarray,
+    x_scale0: float,
+    x_zp0: float,
+    num_iterations: int,
+    weight_learning_rate: float,
+    activation_learning_rate: float,
+    reg_param: float,
+    warm_start: float,
+    beta_range: Tuple[float, float],
+) -> Tuple[np.ndarray, float, int]:
+    """Jointly optimizes one layer's weight-rounding relaxation and its
+    activation's (scale, zero_point) against ``||x @ w_nk.T -
+    dequantize(quantize(x, s, zp)) @ w_hat.T||^2``, both by gradient descent
+    on the same loss. ``w_nk``/``scale_n`` are ``w_nk``'s float weight and
+    its (fixed, per-output-channel, symmetric) quantization scale, both
+    laid out ``[N, K]``/``[N]`` (output channel first) regardless of the
+    op's own storage layout; ``x`` is real calibration activations captured
+    from the float model, shape ``[num_samples, K]``.
+
+    Returns ``(codes_nk, x_scale, x_zero_point)``: the optimized integer
+    weight codes (shape like ``w_nk``, values in
+    ``[-127, 127]``), the optimized activation scale, and its optimized
+    zero-point (rounded to the nearest integer in ``[0, 255]``, uint8's
+    range).
+    """
+    n, k = w_nk.shape
+    scale_nk = np.repeat(scale_n[:, None], k, axis=1)
+
+    ratio = w_nk / scale_nk
+    floor_base = np.floor(ratio)
+    frac = np.clip(ratio - floor_base, 1e-4, 1.0 - 1e-4)
+    sig0 = np.clip((frac - _GAMMA) / (_ZETA - _GAMMA), 1e-4, 1.0 - 1e-4)
+    v = np.log(sig0 / (1.0 - sig0))
+
+    log_s = float(np.log(max(x_scale0, 1e-8)))
+    zp = float(np.clip(x_zp0, 0.0, _ACT_N_MAX))
+
+    m_v, v2_v = np.zeros_like(v), np.zeros_like(v)
+    m_s = v2_s = m_zp = v2_zp = 0.0
+    beta1, beta2, adam_eps = 0.9, 0.999, 1e-8
+
+    warm_start_iters = int(num_iterations * warm_start)
+    beta_start, beta_end = beta_range
+    n_elems = x.shape[0] * n
+
+    for t in range(num_iterations):
+        s_x = np.exp(log_s)
+
+        h, dh_dv = _h_and_dhdv(v)
+        raw_w = floor_base + h
+        w_hat = np.clip(raw_w, _WEIGHT_N_MIN, _WEIGHT_N_MAX) * scale_nk
+        active_w = (raw_w > _WEIGHT_N_MIN) & (raw_w < _WEIGHT_N_MAX)
+
+        # Straight-through quantize-dequantize of the activation: computed
+        # step by step (round, then add zero_point, then clip) so each
+        # step's own local gradient (1 for round via STE, 1 for the
+        # zero_point addition, 1 inside/0 outside the clip) composes
+        # correctly instead of being algebraically cancelled out.
+        rounded = np.round(x / s_x)
+        xq_raw = rounded + zp
+        active_x = (xq_raw > 0.0) & (xq_raw < _ACT_N_MAX)
+        xq = np.clip(xq_raw, 0.0, _ACT_N_MAX)
+        xdq = (xq - zp) * s_x
+
+        y_hat = xdq @ w_hat.T  # [S, N]
+        y_float = x @ w_nk.T  # [S, N]
+        dl_dy = 2.0 * (y_hat - y_float) / n_elems
+
+        dl_dw_hat = dl_dy.T @ xdq  # [N, K]
+        dl_dh = dl_dw_hat * np.where(active_w, scale_nk, 0.0)
+        grad_v = dl_dh * dh_dv
+
+        if t >= warm_start_iters:
+            progress = (t - warm_start_iters) / max(
+                1, num_iterations - warm_start_iters - 1
+            )
+            beta = beta_start + (beta_end - beta_start) * progress
+            u = 2.0 * h - 1.0
+            abs_u = np.abs(u)
+            dreg_dh = -2.0 * reg_param * beta * np.sign(u) * np.power(abs_u, beta - 1.0)
+            grad_v = grad_v + dreg_dh * dh_dv
+
+        dl_dxdq = dl_dy @ w_hat  # [S, K]
+        dxdq_ds = (xq - zp) - np.where(active_x, x / s_x, 0.0)
+        dxdq_dzp = s_x * (active_x.astype(np.float64) - 1.0)
+        grad_log_s = float(np.sum(dl_dxdq * dxdq_ds)) * s_x
+        grad_zp = float(np.sum(dl_dxdq * dxdq_dzp))
+
+        m_v = beta1 * m_v + (1.0 - beta1) * grad_v
+        v2_v = beta2 * v2_v + (1.0 - beta2) * (grad_v * grad_v)
+        bias_c1 = 1.0 - beta1 ** (t + 1)
+        bias_c2 = 1.0 - beta2 ** (t + 1)
+        v = v - weight_learning_rate * (m_v / bias_c1) / (
+            np.sqrt(v2_v / bias_c2) + adam_eps
+        )
+
+        m_s = beta1 * m_s + (1.0 - beta1) * grad_log_s
+        v2_s = beta2 * v2_s + (1.0 - beta2) * (grad_log_s * grad_log_s)
+        log_s = log_s - activation_learning_rate * (m_s / bias_c1) / (
+            (v2_s / bias_c2) ** 0.5 + adam_eps
+        )
+
+        m_zp = beta1 * m_zp + (1.0 - beta1) * grad_zp
+        v2_zp = beta2 * v2_zp + (1.0 - beta2) * (grad_zp * grad_zp)
+        zp = zp - activation_learning_rate * (m_zp / bias_c1) / (
+            (v2_zp / bias_c2) ** 0.5 + adam_eps
+        )
+        zp = float(np.clip(zp, 0.0, _ACT_N_MAX))
+
+    h_final, _ = _h_and_dhdv(v)
+    codes_nk = np.clip(floor_base + np.round(h_final), _WEIGHT_N_MIN, _WEIGHT_N_MAX)
+    x_scale = float(np.exp(log_s))
+    x_zero_point = int(np.clip(round(zp), 0, 255))
+    return codes_nk, x_scale, x_zero_point
+
+
+def apply_adaquant(
+    float_model: Union[str, onnx.ModelProto],
+    quantized_model: Union[str, onnx.ModelProto],
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_samples: int = 8,
+    seed: int = 0,
+    num_iterations: int = 300,
+    weight_learning_rate: float = 0.1,
+    activation_learning_rate: float = 0.01,
+    reg_param: float = 0.01,
+    warm_start: float = 0.2,
+    beta_range: Tuple[float, float] = (20.0, 2.0),
+    providers: Optional[Sequence[str]] = None,
+) -> onnx.ModelProto:
+    """Optimizes AdaQuant-style joint weight-rounding + activation-clip-range
+    calibration for every :func:`onnxsim.quantize_static`-quantized
+    MatMul/"vanilla" Gemm layer present (by node output name) in both
+    ``float_model`` and ``quantized_model``, using real activations captured
+    from ``float_model``. See this module's own docstring for the technique
+    and its relationship to :func:`onnxsim.apply_adaround`.
+
+    :param float_model: the original (unquantized) onnx ModelProto or file
+            path
+    :param quantized_model: a quantized version of ``float_model`` (onnx
+            ModelProto or file path), produced by
+            :func:`onnxsim.quantize_static`. Layers quantized by any other
+            scheme (including :func:`onnxsim.quantize_qoperator_gemm`'s
+            QGemm format -- see this module's own docstring for why), or
+            left unquantized, are left untouched. Assumes ``quantized_model``
+            was produced from ``float_model`` without renaming any
+            MatMul/Gemm node's own output tensor -- true of every onnxsim
+            ``quantize_*`` function.
+    :param calibration_data: representative input batches to optimize
+            against. Each batch is a ``{input_name: np.ndarray}`` dict
+            matching ``float_model``'s graph inputs -- see
+            :func:`onnxsim.generate_random_calibration_data` (the default
+            when omitted) and
+            :func:`onnxsim.load_huggingface_calibration_data` (real data, a
+            much more representative optimization target than random
+            input).
+    :param num_samples: random batches to generate when
+            ``calibration_data`` is omitted
+    :param seed: seed for the random calibration data (ignored if
+            ``calibration_data`` is supplied)
+    :param num_iterations: Adam steps to run per layer
+    :param weight_learning_rate: Adam learning rate for the per-element
+            weight-rounding relaxation (same role as
+            :func:`onnxsim.apply_adaround`'s ``learning_rate``)
+    :param activation_learning_rate: Adam learning rate for the
+            activation's scale (optimized in log-space) and zero-point
+    :param reg_param: weight of the regularization term that pulls each
+            weight element's rounding relaxation toward a hard 0/1
+            (floor/ceil) decision
+    :param warm_start: fraction of ``num_iterations`` (from the start) run
+            with the weight-rounding regularization term disabled
+    :param beta_range: ``(beta_start, beta_end)`` for the weight-rounding
+            regularization term's exponent, linearly annealed across the
+            iterations after ``warm_start``
+    :param providers: onnxruntime execution providers to run ``float_model``
+            on when capturing calibration activations
+    :returns: ``quantized_model`` with every matched layer's weight INT8
+            codes and activation (scale, zero_point) initializers rewritten
+            to their jointly-optimized values (same shapes/dtypes -- the
+            weight's own per-channel scale and the graph structure are
+            untouched)
+    """
+    if isinstance(float_model, str):
+        float_model = onnx.load(float_model, load_external_data=False)
+    if isinstance(quantized_model, str):
+        quantized_model = onnx.load(quantized_model, load_external_data=False)
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            float_model, num_samples=num_samples, seed=seed
+        )
+
+    candidates = _find_static_qdq_candidates(float_model, quantized_model)
+    if not candidates:
+        return quantized_model
+
+    probe_names = [c.float_node.input[0] for c in candidates]
+    float_probe = _add_probe_outputs(float_model, probe_names)
+
+    activations: Dict[str, List[np.ndarray]] = {name: [] for name in probe_names}
+    for batch in calibration_data:
+        out = backend.run_model(float_probe, batch, providers=providers)
+        for name in probe_names:
+            activations[name].append(np.asarray(out[name], dtype=np.float64))
+
+    q_init = {t.name: t for t in quantized_model.graph.initializer}
+    optimized_codes: Dict[str, np.ndarray] = {}
+    optimized_scale: Dict[str, float] = {}
+    optimized_zp: Dict[str, int] = {}
+
+    for c in candidates:
+        acts = [a for a in activations[c.float_node.input[0]] if a.ndim == 2]
+        if not acts:
+            continue  # not a plain 2-D activation (batched/broadcast MatMul); skip
+        x = np.concatenate(acts, axis=0)
+
+        w = onnx.numpy_helper.to_array(c.w_float_init).astype(np.float64)
+        dim0, dim1 = w.shape
+        if c.weight_transposed:
+            w_nk = w  # already [N, K]
+        else:
+            w_nk = w.T  # [K, N] -> [N, K]
+        if x.shape[1] != w_nk.shape[1]:
+            continue  # activation's feature dim doesn't match K; skip
+
+        ws_init = q_init.get(c.ws_name)
+        if ws_init is None:
+            continue
+        scale_n = onnx.numpy_helper.to_array(ws_init).astype(np.float64).reshape(-1)
+        if scale_n.shape[0] != w_nk.shape[0]:
+            continue
+
+        x_scale_init = q_init.get(c.x_scale_name)
+        x_zp_init = q_init.get(c.x_zp_name)
+        if x_scale_init is None or x_zp_init is None:
+            continue
+        x_scale0 = float(onnx.numpy_helper.to_array(x_scale_init).reshape(-1)[0])
+        x_zp0 = float(onnx.numpy_helper.to_array(x_zp_init).reshape(-1)[0])
+
+        codes_nk, x_scale, x_zp = _optimize_adaquant(
+            w_nk,
+            scale_n,
+            x,
+            x_scale0,
+            x_zp0,
+            num_iterations=num_iterations,
+            weight_learning_rate=weight_learning_rate,
+            activation_learning_rate=activation_learning_rate,
+            reg_param=reg_param,
+            warm_start=warm_start,
+            beta_range=beta_range,
+        )
+        codes_orig = codes_nk if c.weight_transposed else codes_nk.T
+        assert codes_orig.shape == (dim0, dim1)
+        optimized_codes[c.wq_name] = codes_orig.astype(np.int8)
+        optimized_scale[c.x_scale_name] = x_scale
+        optimized_zp[c.x_zp_name] = x_zp
+
+    if not optimized_codes:
+        return quantized_model
+
+    corrected = onnx.ModelProto()
+    corrected.CopyFrom(quantized_model)
+    for t in corrected.graph.initializer:
+        codes = optimized_codes.get(t.name)
+        if codes is not None:
+            t.CopyFrom(onnx.numpy_helper.from_array(codes, name=t.name))
+            continue
+        scale = optimized_scale.get(t.name)
+        if scale is not None:
+            t.CopyFrom(
+                onnx.numpy_helper.from_array(
+                    np.array(scale, dtype=np.float32), name=t.name
+                )
+            )
+            continue
+        zp = optimized_zp.get(t.name)
+        if zp is not None:
+            t.CopyFrom(
+                onnx.numpy_helper.from_array(np.array(zp, dtype=np.uint8), name=t.name)
+            )
+
+    return corrected

--- a/tests/test_adaquant.py
+++ b/tests/test_adaquant.py
@@ -1,0 +1,190 @@
+"""Tests for ``onnxsim.apply_adaquant`` (AdaQuant -- the layer-wise
+calibration half of Hubara et al. 2020/2021's "Improving Post Training
+Neural Quantization: Layer-wise Calibration and Integer Programming", see
+``onnxsim/adaquant.py``) -- jointly optimizes a W8A8-quantized MatMul/Gemm
+layer's weight rounding *and* its activation's (scale, zero_point) against
+real calibration data, targeting :func:`onnxsim.quantize_static`'s QDQ
+output.
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
+
+
+def _matmul_model(K=64, N=16, seed=0):
+    rng = np.random.default_rng(seed)
+    weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [_f32(weight, "W")],
+    )
+
+
+def _structured_calibration(K=64, num_samples=64, salient_channels=(3, 7), seed=1):
+    # A handful of large-magnitude, positively-shifted channels: like AWQ's
+    # own salient-channel scenario, but also asymmetric (nonzero mean) so
+    # the activation's calibrated zero-point isn't trivially 0 or 128 --
+    # AdaQuant's own joint optimization over the clip range actually has
+    # something to do here, not just the weight rounding.
+    rng = np.random.default_rng(seed)
+    x = rng.standard_normal((num_samples, K)).astype(np.float32)
+    for c in salient_channels:
+        x[:, c] = x[:, c] * 15.0 + 8.0
+    return x
+
+
+def _quantize_linear_node(model):
+    return next(n for n in model.graph.node if n.op_type == "QuantizeLinear")
+
+
+def test_adaquant_reduces_reconstruction_error_with_structured_calibration():
+    model = _matmul_model(K=64, N=16, seed=0)
+    x = _structured_calibration(K=64, num_samples=64, seed=1)
+    calibration_data = [{"X": x}]
+
+    quant = onnxsim.quantize_static(model, calibration_data=calibration_data)
+    onnx.checker.check_model(quant)
+    # quantize_static must have actually produced the QDQ MatMul shape this
+    # module targets -- otherwise this is vacuously comparing a model to
+    # itself.
+    assert any(n.op_type == "QuantizeLinear" for n in quant.graph.node)
+
+    adaquant_model = onnxsim.apply_adaquant(
+        model, quant, calibration_data=calibration_data
+    )
+    onnx.checker.check_model(adaquant_model)
+
+    (float_y,) = _run(model, {"X": x})
+    (quant_y,) = _run(quant, {"X": x})
+    (adaquant_y,) = _run(adaquant_model, {"X": x})
+
+    float_y = float_y.astype(np.float64)
+    quant_err = np.linalg.norm(float_y - quant_y.astype(np.float64))
+    adaquant_err = np.linalg.norm(float_y - adaquant_y.astype(np.float64))
+    assert adaquant_err < quant_err
+
+
+def test_adaquant_output_stays_close_to_float_via_onnxruntime():
+    model = _matmul_model(K=64, N=16, seed=2)
+    x = _structured_calibration(K=64, num_samples=32, seed=3)
+    calibration_data = [{"X": x}]
+
+    quant = onnxsim.quantize_static(model, calibration_data=calibration_data)
+    adaquant_model = onnxsim.apply_adaquant(
+        model, quant, calibration_data=calibration_data
+    )
+    onnx.checker.check_model(adaquant_model)
+
+    (float_y,) = _run(model, {"X": x})
+    (adaquant_y,) = _run(adaquant_model, {"X": x})
+    assert np.all(np.isfinite(adaquant_y))
+    assert _rel_l2(float_y, adaquant_y) < 0.25
+
+
+def test_adaquant_activation_scale_and_zero_point_stay_sane():
+    model = _matmul_model(K=32, N=8, seed=4)
+    x = _structured_calibration(K=32, num_samples=32, salient_channels=(1,), seed=5)
+    calibration_data = [{"X": x}]
+
+    quant = onnxsim.quantize_static(model, calibration_data=calibration_data)
+    adaquant_model = onnxsim.apply_adaquant(
+        model, quant, calibration_data=calibration_data
+    )
+
+    ql = _quantize_linear_node(adaquant_model)
+    init_by_name = {t.name: t for t in adaquant_model.graph.initializer}
+    x_scale = init_by_name[ql.input[1]]
+    x_zp = init_by_name[ql.input[2]]
+
+    assert x_scale.data_type == onnx.TensorProto.FLOAT
+    assert float(onnx.numpy_helper.to_array(x_scale)) > 0.0
+    assert x_zp.data_type == onnx.TensorProto.UINT8
+    zp_val = int(onnx.numpy_helper.to_array(x_zp))
+    assert 0 <= zp_val <= 255
+
+
+def test_adaquant_gemm_transb():
+    rng = np.random.default_rng(6)
+    K, N = 48, 12
+    weight = rng.standard_normal((N, K)).astype(np.float32) * 0.5
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = Gemm<transB = 1>(X, W)
+        }}
+        """,
+        [_f32(weight, "W")],
+    )
+    x = _structured_calibration(K=K, num_samples=32, salient_channels=(5, 20), seed=7)
+    calibration_data = [{"X": x}]
+
+    quant = onnxsim.quantize_static(model, calibration_data=calibration_data)
+    onnx.checker.check_model(quant)
+
+    adaquant_model = onnxsim.apply_adaquant(
+        model, quant, calibration_data=calibration_data
+    )
+    onnx.checker.check_model(adaquant_model)
+
+    (float_y,) = _run(model, {"X": x})
+    (adaquant_y,) = _run(adaquant_model, {"X": x})
+    assert _rel_l2(float_y, adaquant_y) < 0.25
+
+
+def test_adaquant_noop_when_no_matching_layer_present():
+    model = _model(
+        """
+        g (float[4,4] X) => (float[4,4] Y)
+        {
+          Y = Relu(X)
+        }
+        """
+    )
+    result = onnxsim.apply_adaquant(
+        model, model, calibration_data=[{"X": np.zeros((4, 4), dtype=np.float32)}]
+    )
+    assert result.SerializeToString() == model.SerializeToString()


### PR DESCRIPTION
## Summary

- Ports the layer-wise calibration half of Hubara, Nahshan, Hanani, Banner,
  Soudry, 2020/2021, "Improving Post Training Neural Quantization:
  Layer-wise Calibration and Integer Programming"
  (https://arxiv.org/abs/2006.10518) as `onnxsim.apply_adaquant`.
- Unlike `onnxsim.apply_adaround` (weight rounding only, targeting
  `quantize_weight_only_int4`'s weight-only INT4 scheme), AdaQuant jointly
  optimizes weight rounding *and* the activation's own `(scale,
  zero_point)` against the same per-layer reconstruction loss, targeting
  `onnxsim.quantize_static`'s W8A8 QDQ output
  (`QuantizeLinear`/`DequantizeLinear` around both the activation and the
  weight, wrapping an untouched MatMul/Gemm).
- The paper's other contribution — an integer-programming solver for
  mixed per-layer bit-width allocation — is a distinct, much larger-scope
  optimization problem and is explicitly **out of scope** here (documented
  in both the module docstring and `docs/adaquant.md`, following this
  repo's `docs/exl3-quantization-survey.md` precedent for documenting an
  explicit "not ported" decision).

## Empirically confirmed facts

- Built via a fresh worktree build (`git submodule update --init
  --recursive`, then `pip install -e . --no-build-isolation`) and verified
  with real `onnxruntime`, not just eyeballed math.
- On a `MatMul(X, W)` model (`K=64, N=16`) with structured (salient-channel,
  asymmetric) calibration data, measured end-to-end via real onnxruntime
  execution: `quantize_static`'s plain calibrated-affine reconstruction L2
  error was `11.95`; after `apply_adaquant`, `10.40` — a **13% reduction**
  in reconstruction error, from jointly re-optimizing the weight rounding
  and the activation's clip range against the same loss the plain
  calibrated quantization doesn't optimize at all.
- `pytest tests/test_adaquant.py -v`: **5 passed** (reconstruction-error
  reduction, end-to-end float-closeness via onnxruntime, activation
  scale/zero-point sanity, `Gemm transB=1`, no-op on no matching layer).
- `pytest tests/test_adaround.py tests/test_awq.py
  tests/test_bias_correction.py tests/test_static_quantize_matmul.py
  tests/test_entropy_calibration.py tests/test_adaquant.py -q`: **42
  passed** — no regressions in the modules this one imports helpers from
  or shares a target scheme's sibling with.
- `ruff format --check onnxsim tests` / `ruff check onnxsim tests`: clean
  (the one reformat-needed file, `onnxsim/version.py`, is untouched by
  this PR's diff — pre-existing, unrelated to this change).
- `python -m mypy` (whole-package, matching `pyproject.toml`): **22 errors
  in 7 files**, none in `onnxsim/adaquant.py` — zero new errors added (this
  is at or below the repo's own documented pre-existing baseline).

## What's added / scope

- `onnxsim/adaquant.py`: `apply_adaquant(float_model, quantized_model,
  calibration_data=None, ...)`. Matches MatMul/"vanilla" Gemm layers by
  node output name between `float_model` and `quantized_model` (the same
  contract every onnxsim `apply_*`/`correct_bias` function documents),
  restricted to `quantize_static`'s exact QDQ shape (symmetric per-channel
  INT8 weight, asymmetric uint8 activation) — `quantize_qoperator_gemm`'s
  fused `QGemm` (`com.microsoft`) shape is explicitly left untouched, since
  its scale/zero-point/weight-code initializers aren't addressable through
  a standard ONNX node the way QDQ's are.
- Weight rounding reuses `onnxsim.adaround`'s own rectified-sigmoid
  relaxation and regularization schedule (`_GAMMA`, `_ZETA`, `_h_and_dhdv`,
  `_node_outputs` imported directly, not reimplemented) at INT8's `[-127,
  127]` range instead of AdaRound's INT4 `[-7, 7]`.
- The activation branch adds hand-derived straight-through (STE)
  quantize-dequantize gradients for a *learnable* clip range (in the style
  of Esser et al. 2019's LSQ), composed step by step through the actual
  round-then-clip computation rather than algebraically simplified first —
  documented in the module docstring, since naively collapsing
  `dequantize(quantize(x, s)) ≈ x` would erase the very rounding-error
  signal the scale's gradient needs.
- Both parameter groups (weight-rounding relaxation, activation
  log-scale, activation zero-point) are optimized jointly in one Adam
  loop per layer; the weight's own per-channel scale (`Ws`) is left
  exactly as `quantize_static` calibrated it — only which integer each
  element rounds to, and the activation's clip range, are optimized.
- `docs/adaquant.md` (What this is / Where this comes from / Scope /
  Usage, mirroring `docs/duquant.md`'s section shape) and
  `tests/test_adaquant.py` (mirroring `tests/test_awq.py`'s
  `onnx.parser`-based helper pattern).
- Wired into `onnxsim/__init__.py` (`apply_adaquant` import + `__all__`
  entry, grouped near `apply_adaround`).

## Test plan

- [x] AdaQuant measurably reduces reconstruction error vs. plain
      `quantize_static` output on structured calibration data (real
      onnxruntime execution).
- [x] Output stays close to float end-to-end via real onnxruntime.
- [x] Optimized activation scale is positive and zero-point lands in
      uint8's valid `[0, 255]` range.
- [x] `Gemm transB=1` variant.
- [x] No-op when no `quantize_static`-shaped layer is present.
- [x] `ruff format --check` / `ruff check`: clean.
- [x] `python -m mypy`: 0 new errors vs. baseline.
- [x] Full C++ wheel build from a clean submodule checkout, tests run
      against the real compiled extension + real onnxruntime.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUhkd3jW8bhuF4n314xsXe

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUhkd3jW8bhuF4n314xsXe)_