### PR TITLE
Port Clip/PRelu pass-through hops and split gate_up_proj gated-FFN chains to C++ structured pruning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,7 @@ node_modules/
 /npm/onnxsim/onnxsim.cjs
 /npm/onnxsim/onnxsim.wasm
 /npm/onnxsim/ort_executor.mjs
+
+# Claude Code local session/tooling state (e.g. background-agent worktree
+# checkouts under .claude/worktrees/) -- never part of the repo itself.
+/.claude/

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -268,6 +268,31 @@ void SetInt64TensorLastDim(onnx::TensorProto* t, int64_t new_last) {
   t->set_raw_data(std::move(raw));
 }
 
+// The INT64 analogue of SetFloatTensorData -- overwrites `t` in place with a
+// fresh INT64 tensor of `dims`/`data`, keeping its existing name. Used only
+// by ApplySplitGatedChains's own `split` *input* rewrite (mirrors
+// pruning.py's own `size_init.CopyFrom(onnx.numpy_helper.from_array(...))`
+// for that same rewrite), which -- unlike SetInt64TensorLastDim's single-
+// element Reshape-target-shape rewrite -- replaces every element of a
+// 2-element `[keep_count, keep_count]` sizes tensor.
+void SetInt64TensorData(onnx::TensorProto* t, const std::vector<int64_t>& dims,
+                        const std::vector<int64_t>& data) {
+  const std::string name = t->name();
+  t->Clear();
+  t->set_name(name);
+  t->set_data_type(onnx::TensorProto::INT64);
+  for (int64_t d : dims) {
+    t->add_dims(d);
+  }
+  std::string raw(data.size() * sizeof(int64_t), '\0');
+  std::memcpy(raw.data(), data.data(), raw.size());
+  if constexpr (!onnxsim::dlpack::kRawDataIsHostOrder) {
+    onnxsim::dlpack::SwapElementBytes(reinterpret_cast<uint8_t*>(raw.data()),
+                                      raw.size(), sizeof(int64_t));
+  }
+  t->set_raw_data(std::move(raw));
+}
+
 int64_t ConvGroupAttr(const onnx::NodeProto& node) {
   for (const auto& attr : node.attribute()) {
     if (attr.name() == "group") {
@@ -4663,6 +4688,534 @@ void ApplyConcatChains(onnx::GraphProto* graph,
   }
 }
 
+// --- Split-merged (fused gate_up_proj) gated FFN chains, mirroring
+// pruning.py's own "Split-merged (fused gate_up_proj) gated FFN chains"
+// section -- _SplitGatedChain/_split_axis/_split_axis_is_last/
+// _split_explicit_sizes/_trace_split_half_backward/_find_split_gated_chains/
+// _apply_split_gated_chains -----------------------------------------------
+//
+// FindGatedChains above only recognizes the TWO-SEPARATE-PRODUCER shape:
+// Mul(gate_proj(x), up_proj(x)) with two distinct MatMul/Gemm weight
+// tensors. Real, currently-shipped Phi-3/Phi-3.5 (onnxruntime-genai) exports
+// use a different, equally common shape instead: ONE gate_up_proj MatMul/
+// Gemm producer (2*H output columns) -> Split(axis=-1, two equal H-wide
+// outputs) -> (gate, up) -> act(gate) * up (or native SwiGLU) -> down_proj.
+// Unlike the two-producer case, gate and up are two HALVES of the SAME
+// physical weight: columns [0, H) are gate, columns [H, 2H) are up (Split's
+// own output-order guarantee). "Neuron" i of the intermediate dimension is
+// therefore represented by BOTH column i and column H + i of the one
+// producer weight -- they must always be kept or dropped TOGETHER, so a
+// single `keep` set is chosen once over `h` (not `2h`) candidates and
+// applied at both fixed offsets of that one tensor -- see pruning.py's own
+// section comment for the full shape derivation, the exact supported/
+// declined boundary (MatMul/Gemm only, no quantized producer/consumer, the
+// producer's raw output must feed Split directly with no bias-Add hop in
+// between, `global_sparsity` mode excludes this family the same way an
+// ordinary gated pair already is), and the worked InferenceSession-verified
+// correctness argument -- this port covers the identical scope, kept
+// deliberately narrower only where the rest of this file already is (no
+// recursion into `If` subgraphs, matching every other finder here).
+//
+// Kept as its own struct (SplitGatedChain) rather than reusing Chain: the
+// shape genuinely differs from every other family this file matches --
+// exactly one physical producer tensor split by a dedicated Split node, one
+// `h`-wide keep set applied at two fixed offsets of that one tensor, plus
+// the Split node's own size bookkeeping -- none of which fits Chain's
+// "N independent producers, each pruned to the same, un-offset keep set"
+// shape. Applied by its own ApplySplitGatedChains, mirroring pruning.py's
+// own deliberate `_apply_chains`/`_apply_split_gated_chains` split (called
+// from ApplyStructuredPruning alongside, not instead of, ApplyChains) for
+// the identical reason: ApplyChains' shared per-chain body (one keep set,
+// applied unmodified to every producer/consumer weight it holds) has no
+// hook for "the same tensor, sliced at two different offsets" or for a
+// Split node's own attribute/input rewrite, and retrofitting one would
+// complicate every other chain family's own straight-line path for a
+// single caller.
+
+enum class SplitSizesKind { kAuto, kAttr, kInput };
+
+// node.attribute("axis"), Split's own schema default (0) -- unlike Concat's
+// *required* attribute, so an un-annotated Split still has a real axis to
+// check against (never itself grounds for decline). Mirrors pruning.py's
+// own _split_axis.
+int64_t SplitAxis(const onnx::NodeProto& node) {
+  for (const auto& attr : node.attribute()) {
+    if (attr.name() == "axis") {
+      return attr.i();
+    }
+  }
+  return 0;
+}
+
+// The Split-node analogue of ConcatAxisIsLast, with a single operand
+// (Split has exactly one data input) rather than Concat's several --
+// axis == -1 outright, or a positive axis only when node.input(0)'s own
+// rank is known via value_info and agrees; declined (never guessed at)
+// when that rank isn't known at all. Mirrors pruning.py's own
+// _split_axis_is_last.
+bool SplitAxisIsLast(
+    const onnx::NodeProto& node,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+        value_info_by_name) {
+  const int64_t axis = SplitAxis(node);
+  if (axis < 0) {
+    return axis == -1;
+  }
+  auto rank = TensorRank(node.input(0), value_info_by_name);
+  if (!rank) {
+    return false;  // Rank unknown -- decline rather than guess.
+  }
+  return axis == *rank - 1;
+}
+
+struct SplitSizesResult {
+  // Absent for "auto" (no explicit sizes anywhere -- a fully automatic even
+  // split, driven purely by the actual output count).
+  std::optional<std::vector<int64_t>> sizes;
+  SplitSizesKind kind;
+};
+
+// Describes how `node` (assumed already confirmed to be a Split) spells out
+// its own two output sizes: opsets before 13 spell explicit sizes as an
+// integer-list `split` *attribute*; opset 13+ moved that to an optional
+// `split` *input* instead (still accepting no sizes at all, for an even
+// split). Returns std::nullopt outright -- decline -- when a `split` input
+// IS present but is not a resolvable constant INT64 initializer. Mirrors
+// pruning.py's own _split_explicit_sizes exactly.
+std::optional<SplitSizesResult> SplitExplicitSizes(const onnx::NodeProto& node,
+                                                    const InitMap& init_map) {
+  if (node.input_size() >= 2 && !node.input(1).empty()) {
+    auto it = init_map.find(node.input(1));
+    if (it == init_map.end() ||
+        it->second->data_type() != onnx::TensorProto::INT64) {
+      return std::nullopt;
+    }
+    return SplitSizesResult{ReadInt64Tensor(*it->second), SplitSizesKind::kInput};
+  }
+  for (const auto& attr : node.attribute()) {
+    if (attr.name() == "split") {
+      return SplitSizesResult{
+          std::vector<int64_t>(attr.ints().begin(), attr.ints().end()),
+          SplitSizesKind::kAttr};
+    }
+  }
+  return SplitSizesResult{std::nullopt, SplitSizesKind::kAuto};
+}
+
+// One of a matched gate_up-style Split node's own two outputs.
+struct SplitHalfOf {
+  onnx::NodeProto* split_node;
+  int half_index;  // 0 or 1, node.output's own index.
+};
+
+// The split-half analogue of TraceGateProducerBackward: walks backward from
+// `tensor_name` through unary activation ops until it resolves to one
+// output of an already-matched gate_up Split node (a key of `split_half_of`)
+// instead of a real MatMul/Gemm producer's own raw output. Mirrors
+// pruning.py's own _trace_split_half_backward.
+std::optional<std::tuple<onnx::NodeProto*, int, std::vector<onnx::NodeProto*>>>
+TraceSplitHalfBackward(
+    const std::string& tensor_name,
+    const std::unordered_map<std::string, onnx::NodeProto*>& node_by_output,
+    const std::unordered_map<std::string, SplitHalfOf>& split_half_of,
+    const ConsumerMap& consumers_of,
+    const std::unordered_set<std::string>& graph_outputs, int max_hops) {
+  std::vector<onnx::NodeProto*> pre_ops;  // Backward order; reversed on return.
+  std::string cur = tensor_name;
+  for (int hop = 0; hop < max_hops; ++hop) {
+    if (ConsumerCount(consumers_of, cur) != 1 || graph_outputs.count(cur)) {
+      return std::nullopt;
+    }
+    auto sit = split_half_of.find(cur);
+    if (sit != split_half_of.end()) {
+      std::reverse(pre_ops.begin(), pre_ops.end());
+      return std::make_tuple(sit->second.split_node, sit->second.half_index,
+                             std::move(pre_ops));
+    }
+    auto nit = node_by_output.find(cur);
+    if (nit == node_by_output.end()) {
+      return std::nullopt;
+    }
+    onnx::NodeProto* producer_node = nit->second;
+    if (!(UnaryPassThroughOps().count(producer_node->op_type()) != 0 &&
+          producer_node->input_size() == 1 &&
+          producer_node->output_size() == 1)) {
+      return std::nullopt;
+    }
+    pre_ops.push_back(producer_node);
+    cur = producer_node->input(0);
+  }
+  return std::nullopt;
+}
+
+// One matched fused-gate_up_proj gated FFN block -- see this section's own
+// comment. `weight`/`bias` are the ONE physical producer tensor shared by
+// both the gate and up halves (columns [0, h) and [h, 2h) respectively).
+struct SplitGatedChain {
+  onnx::NodeProto* split_node;
+  onnx::NodeProto* producer_node;
+  std::string weight;
+  bool weight_transposed;
+  std::optional<std::string> bias;
+  int64_t h;  // Width of EACH half; the combined producer output is 2*h wide.
+  SplitSizesKind split_sizes_kind;
+  // Unary activation hops crossed between split_node.output(0)/(1) and the
+  // combine node -- purely for value_info staleness bookkeeping, mirroring
+  // Producer::pre_ops's own comment; nothing here ever needs its own
+  // slicing, being pure single-input/single-output activations.
+  std::vector<onnx::NodeProto*> half0_pre_ops;
+  std::vector<onnx::NodeProto*> half1_pre_ops;
+  onnx::NodeProto* combine_node;
+  std::vector<ChainOp> chain_ops;
+  onnx::NodeProto* consumer_node;
+  std::string consumer_weight;
+  bool consumer_weight_transposed;
+};
+
+// Finds fused-gate_up_proj gated FFN blocks -- see this section's own
+// comment for the full shape, the co-selection semantics, and exactly
+// what's supported/declined and why. Mirrors pruning.py's own
+// _find_split_gated_chains.
+std::vector<SplitGatedChain> FindSplitGatedChains(onnx::GraphProto* graph) {
+  InitMap init_map;
+  for (const auto& t : graph->initializer()) {
+    init_map[t.name()] = &t;
+  }
+  ConsumerMap consumers_of = ConsumersOf(graph);
+  std::unordered_set<std::string> graph_outputs;
+  for (const auto& o : graph->output()) {
+    graph_outputs.insert(o.name());
+  }
+  std::unordered_map<std::string, onnx::NodeProto*> node_by_output;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    for (const auto& out : node->output()) {
+      node_by_output[out] = node;
+    }
+  }
+  auto value_info_by_name = ValueInfoByName(*graph);
+  auto is_internal = [&](const std::string& name) {
+    return ConsumerCount(consumers_of, name) == 1 && !graph_outputs.count(name);
+  };
+
+  std::unordered_map<std::string, FullProducerMatch> producer_infos;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    auto info = MatchProducer(*node, init_map);
+    if (info) {
+      producer_infos[node->output(0)] =
+          FullProducerMatch{node, info->weight, info->weight_transposed,
+                            info->bias, info->n_channels};
+    }
+  }
+
+  // Every gate_up-style Split matched, up front -- keyed by the node's own
+  // pointer identity (mirroring pruning.py's own id(node) key) for the
+  // per-chain lookup below, and by each of its own two output tensor names
+  // for TraceSplitHalfBackward's own bottom-out check.
+  struct SplitMatch {
+    onnx::NodeProto* producer_node;
+    std::string weight;
+    bool weight_transposed;
+    std::optional<std::string> bias;
+    int64_t h;
+    SplitSizesKind kind;
+  };
+  std::unordered_map<onnx::NodeProto*, SplitMatch> split_matches;
+  std::unordered_map<std::string, SplitHalfOf> split_half_of;
+
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    if (node->op_type() != "Split" || node->output_size() != 2) {
+      continue;
+    }
+    if (node->input_size() == 0 || node->input(0).empty()) {
+      continue;
+    }
+    if (node->output(0) == node->output(1)) {
+      continue;  // Degenerate -- same tensor name twice.
+    }
+    const std::string& in_name = node->input(0);
+    if (!is_internal(in_name)) {
+      continue;
+    }
+    auto pit = producer_infos.find(in_name);
+    if (pit == producer_infos.end()) {
+      continue;
+    }
+    const FullProducerMatch& pinfo = pit->second;
+    if (pinfo.n_channels % 2 != 0) {
+      continue;
+    }
+    const int64_t h = pinfo.n_channels / 2;
+    if (!SplitAxisIsLast(*node, value_info_by_name)) {
+      continue;
+    }
+    auto sizes_result = SplitExplicitSizes(*node, init_map);
+    if (!sizes_result) {
+      continue;  // A dynamic (non-constant) split-sizes input -- decline.
+    }
+    if (sizes_result->kind != SplitSizesKind::kAuto) {
+      const auto& sizes = *sizes_result->sizes;
+      if (sizes.size() != 2 || sizes[0] != h || sizes[1] != h) {
+        continue;  // Not an equal two-way split of the producer's own output.
+      }
+    }
+    if (!(is_internal(node->output(0)) && is_internal(node->output(1)))) {
+      continue;
+    }
+    split_matches[node] = SplitMatch{pinfo.node, pinfo.weight,
+                                     pinfo.weight_transposed, pinfo.bias, h,
+                                     sizes_result->kind};
+    split_half_of[node->output(0)] = SplitHalfOf{node, 0};
+    split_half_of[node->output(1)] = SplitHalfOf{node, 1};
+  }
+
+  std::vector<SplitGatedChain> chains;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    onnx::NodeProto* split_a = nullptr;
+    onnx::NodeProto* split_b = nullptr;
+    int half_a = -1, half_b = -1;
+    std::vector<onnx::NodeProto*> pre_a, pre_b;
+
+    if (node->op_type() == "Mul" && node->input_size() == 2 &&
+        node->output_size() == 1) {
+      const std::string& a_name = node->input(0);
+      const std::string& b_name = node->input(1);
+      if (a_name == b_name || init_map.count(a_name) ||
+          init_map.count(b_name)) {
+        continue;
+      }
+      auto trace_a = TraceSplitHalfBackward(a_name, node_by_output,
+                                            split_half_of, consumers_of,
+                                            graph_outputs, kMaxChainHops);
+      auto trace_b = TraceSplitHalfBackward(b_name, node_by_output,
+                                            split_half_of, consumers_of,
+                                            graph_outputs, kMaxChainHops);
+      if (!trace_a || !trace_b) {
+        continue;
+      }
+      split_a = std::get<0>(*trace_a);
+      half_a = std::get<1>(*trace_a);
+      pre_a = std::move(std::get<2>(*trace_a));
+      split_b = std::get<0>(*trace_b);
+      half_b = std::get<1>(*trace_b);
+      pre_b = std::move(std::get<2>(*trace_b));
+    } else if (node->op_type() == "SwiGLU" && node->input_size() == 2 &&
+               node->output_size() == 1) {
+      const std::string& a_name = node->input(0);
+      const std::string& b_name = node->input(1);
+      if (init_map.count(a_name) || init_map.count(b_name)) {
+        continue;
+      }
+      if (!(is_internal(a_name) && is_internal(b_name))) {
+        continue;
+      }
+      auto ait = split_half_of.find(a_name);
+      auto bit = split_half_of.find(b_name);
+      if (ait == split_half_of.end() || bit == split_half_of.end()) {
+        continue;
+      }
+      split_a = ait->second.split_node;
+      half_a = ait->second.half_index;
+      split_b = bit->second.split_node;
+      half_b = bit->second.half_index;
+      // pre_a/pre_b stay empty -- SwiGLU's swish lives entirely inside the
+      // op, so there's nowhere to hang a pre-op.
+    } else {
+      continue;
+    }
+
+    if (split_a != split_b || half_a == half_b) {
+      continue;  // Not both halves of the very same Split.
+    }
+    const SplitMatch& sm = split_matches.at(split_a);
+
+    const std::string& out_name = node->output(0);
+    if (!is_internal(out_name)) {
+      continue;
+    }
+    auto [consumer, chain_ops] = WalkToConsumer(
+        out_name, init_map, consumers_of, graph_outputs, sm.h, kMaxChainHops);
+    if (!consumer) {
+      continue;
+    }
+    if (consumer->weight == sm.weight) {
+      continue;  // Degenerate -- consumer tied to the combined producer weight.
+    }
+
+    SplitGatedChain chain;
+    chain.split_node = split_a;
+    chain.producer_node = sm.producer_node;
+    chain.weight = sm.weight;
+    chain.weight_transposed = sm.weight_transposed;
+    chain.bias = sm.bias;
+    chain.h = sm.h;
+    chain.split_sizes_kind = sm.kind;
+    chain.half0_pre_ops = (half_a == 0) ? std::move(pre_a) : std::move(pre_b);
+    chain.half1_pre_ops = (half_a == 0) ? std::move(pre_b) : std::move(pre_a);
+    chain.combine_node = node;
+    chain.chain_ops = std::move(chain_ops);
+    chain.consumer_node = consumer->node;
+    chain.consumer_weight = consumer->weight;
+    chain.consumer_weight_transposed = consumer->weight_transposed;
+    chains.push_back(std::move(chain));
+  }
+  return chains;
+}
+
+// Applies every matched SplitGatedChain -- the fused gate_up_proj analogue
+// of ApplyChains' own gated-pair handling, deliberately a separate function
+// (like ApplyConcatChains) rather than folding into ApplyChains -- see this
+// section's own comment for why. `w_arrays_nk`-style combined
+// (root-sum-square) importance is computed directly over the two halves of
+// the one producer tensor: a channel whose gate-half weight is large but
+// whose up-half is negligible (or vice versa) ranks by their *combined*, not
+// independently-considered, importance -- mirroring
+// _plain_branch_importance's own combining formula, the same one an ordinary
+// two-producer gated pair's two producers already get combined by.
+//
+// A Split node's own explicit output-size spelling (if any), when present,
+// is rewritten to the new, still-EVEN [len(keep), len(keep)] once pruning
+// finishes -- "still even" is the entire point of co-selection: both halves
+// are always pruned by the exact same `keep` set, so they always stay the
+// same width as each other post-prune, same as pre-prune. A Split
+// `input`-spelled size that happens to be a *shared* constant initializer
+// (reused across more than one distinct Split node whose own `h` values
+// might disagree) is protected against a silent double-rewrite conflict by
+// `touched_split_size_inits` below, local to this one call -- a second
+// chain that would need to rewrite an already-rewritten shared initializer
+// to a *different* value is declined outright rather than corrupting the
+// first chain's own already-applied rewrite. Mirrors pruning.py's own
+// _apply_split_gated_chains.
+void ApplySplitGatedChains(onnx::GraphProto* graph,
+                           std::vector<SplitGatedChain>& chains,
+                           double sparsity, TouchedState& touched) {
+  std::unordered_map<std::string, onnx::TensorProto*> init_map;
+  for (int i = 0; i < graph->initializer_size(); ++i) {
+    onnx::TensorProto* t = graph->mutable_initializer(i);
+    init_map[t->name()] = t;
+  }
+  std::unordered_set<std::string> touched_split_size_inits;
+
+  for (auto& chain : chains) {
+    if (touched.producer.count(chain.weight) ||
+        touched.consumer.count(chain.consumer_weight) ||
+        (chain.bias && touched.const_names.count(*chain.bias))) {
+      continue;  // A shared/tied initializer another chain already resized.
+    }
+
+    std::optional<std::string> size_init_name;
+    if (chain.split_sizes_kind == SplitSizesKind::kInput) {
+      size_init_name = chain.split_node->input(1);
+      if (touched_split_size_inits.count(*size_init_name)) {
+        continue;  // A shared split-sizes constant another chain already rewrote.
+      }
+    }
+
+    const int64_t h = chain.h;
+    const int64_t keep_count = std::max<int64_t>(
+        1, h - std::llround(static_cast<double>(h) * sparsity));
+    if (keep_count >= h) {
+      continue;  // Rounds down to a no-op for this layer.
+    }
+
+    onnx::TensorProto* wt = init_map.at(chain.weight);
+    std::vector<int64_t> dims(wt->dims().begin(), wt->dims().end());
+    std::vector<float> data = ReadFloatTensor(*wt);
+    // w_nk: [2h, k] row-major, regardless of the tensor's own on-disk
+    // orientation -- mirrors ApplyChains' own w_arrays_nk construction.
+    std::vector<float> w_nk;
+    int64_t k;
+    if (chain.weight_transposed) {  // Already [2h, k].
+      w_nk = std::move(data);
+      k = dims[1];
+    } else {  // [k, 2h] -> [2h, k].
+      w_nk = TransposeFlat(data, dims[0], dims[1]);
+      k = dims[0];
+    }
+
+    std::vector<double> importance(static_cast<size_t>(h), 0.0);
+    for (int64_t c = 0; c < h; ++c) {
+      double sq_gate = 0.0, sq_up = 0.0;
+      for (int64_t j = 0; j < k; ++j) {
+        const double vg = w_nk[static_cast<size_t>(c * k + j)];
+        sq_gate += vg * vg;
+        const double vu = w_nk[static_cast<size_t>((h + c) * k + j)];
+        sq_up += vu * vu;
+      }
+      importance[static_cast<size_t>(c)] = std::sqrt(sq_gate + sq_up);
+    }
+    const std::vector<int64_t> keep = TopKIndicesAscending(importance, keep_count);
+    // `keep` (< h) and `keep + h` (>= h) are disjoint ranges, each already
+    // ascending -- their concatenation is therefore already ascending
+    // overall too, same `keep`-is-ascending invariant every other chain
+    // family in this file maintains, so no re-sort is needed here.
+    std::vector<int64_t> global_keep;
+    global_keep.reserve(keep.size() * 2);
+    global_keep.insert(global_keep.end(), keep.begin(), keep.end());
+    for (int64_t c : keep) {
+      global_keep.push_back(c + h);
+    }
+
+    SliceProducerWeight(wt, chain.weight_transposed, global_keep, false);
+    if (chain.bias) {
+      SliceLastAxis(init_map.at(*chain.bias), global_keep);
+    }
+    for (const auto& co : chain.chain_ops) {
+      if (co.const_name) {
+        SliceLastAxis(init_map.at(*co.const_name), keep);
+      }
+    }
+    SliceConsumerWeight(init_map.at(chain.consumer_weight),
+                        chain.consumer_weight_transposed, keep, false);
+
+    if (chain.split_sizes_kind == SplitSizesKind::kAttr) {
+      for (auto& attr : *chain.split_node->mutable_attribute()) {
+        if (attr.name() == "split") {
+          attr.clear_ints();
+          attr.add_ints(keep_count);
+          attr.add_ints(keep_count);
+          break;
+        }
+      }
+    } else if (chain.split_sizes_kind == SplitSizesKind::kInput) {
+      onnx::TensorProto* size_init = init_map.at(*size_init_name);
+      SetInt64TensorData(size_init, {2}, {keep_count, keep_count});
+      touched_split_size_inits.insert(*size_init_name);
+    }
+    // "auto": no explicit sizes anywhere -- the even split stays automatic
+    // at the new width, nothing to rewrite.
+
+    touched.producer.insert(chain.weight);
+    touched.consumer.insert(chain.consumer_weight);
+    if (chain.bias) {
+      touched.const_names.insert(*chain.bias);
+    }
+    for (const auto& co : chain.chain_ops) {
+      if (co.const_name) {
+        touched.const_names.insert(*co.const_name);
+      }
+    }
+
+    touched.stale_value_info.insert(chain.producer_node->output(0));
+    for (const auto& out : chain.split_node->output()) {
+      touched.stale_value_info.insert(out);
+    }
+    for (auto* op : chain.half0_pre_ops) {
+      touched.stale_value_info.insert(op->output(0));
+    }
+    for (auto* op : chain.half1_pre_ops) {
+      touched.stale_value_info.insert(op->output(0));
+    }
+    touched.stale_value_info.insert(chain.combine_node->output(0));
+    for (const auto& co : chain.chain_ops) {
+      touched.stale_value_info.insert(co.node->output(0));
+    }
+  }
+}
+
 }  // namespace
 
 onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
@@ -4695,6 +5248,7 @@ onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
   concat_chains.insert(concat_chains.end(),
                        std::make_move_iterator(conv_concat_chains.begin()),
                        std::make_move_iterator(conv_concat_chains.end()));
+  std::vector<SplitGatedChain> split_gated_chains = FindSplitGatedChains(graph);
 
   TouchedState touched;
   if (!chains.empty()) {
@@ -4702,6 +5256,14 @@ onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
   }
   if (!concat_chains.empty()) {
     ApplyConcatChains(graph, concat_chains, sparsity, touched);
+  }
+  if (!split_gated_chains.empty()) {
+    // A genuinely separate application pass, not folded into ApplyChains --
+    // see FindSplitGatedChains/ApplySplitGatedChains's own section comment
+    // for why. Shares `touched` with the calls above so a weight this pass
+    // resizes can never be double-resized by (or double-resize) an ordinary
+    // chain/Concat-chain that happens to touch the same initializer.
+    ApplySplitGatedChains(graph, split_gated_chains, sparsity, touched);
   }
   if (!touched.stale_value_info.empty()) {
     google::protobuf::RepeatedPtrField<onnx::ValueInfoProto> kept;

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -366,6 +366,156 @@ size_t ConsumerCount(const ConsumerMap& consumers_of, const std::string& name) {
   return it == consumers_of.end() ? 0 : it->second.size();
 }
 
+// True iff `node` (already confirmed by the caller to be a plain
+// (default-domain) `Clip`, `node.input(0)` the tensor being walked through)
+// is a pure elementwise clamp with zero channel dependence, so it is safe to
+// cross transparently -- mirrors pruning.py's own
+// _match_clip_channel_pass_through exactly (see that function's own
+// docstring for the full reasoning: this is the `torch.nn.ReLU6` shape
+// ubiquitous in MobileNetV2/V3, EfficientNet-Lite, and QAT exports). Unlike
+// a Resize/Pad hop, Clip's own `min`/`max` operands are never axis-indexed
+// at all -- per Clip's own schema each must already be a scalar (empty or
+// single-element shape), broadcasting uniformly over every element
+// regardless of axis, so no axis reasoning is needed and the identical check
+// works unchanged for a Conv chain's own axis-1 channel convention and a
+// MatMul/Gemm chain's own last-axis convention alike -- shared by
+// WalkToConvConsumer/WalkConvProducerBackward and
+// WalkToConsumer/WalkMatmulProducerBackward below. Declines (false), never
+// guesses, whenever a present `min`/`max` (each optional -- a present but
+// empty-string input counts as *not* present) is missing from the
+// initializer map (a runtime-computed bound) or not single-element shaped.
+// Neither bound's own *value* is ever inspected -- clamping is a pure
+// elementwise op, so slicing which channels survive first and clamping
+// after computes exactly the same result as clamping first and slicing
+// after, for any min/max value.
+bool MatchClipChannelPassThrough(const onnx::NodeProto& node,
+                                 const InitMap& init_map) {
+  if (node.op_type() != "Clip" || node.domain() != "") {
+    return false;
+  }
+  if (node.input_size() == 0 || node.input(0).empty()) {
+    return false;
+  }
+  for (int idx : {1, 2}) {  // min, max -- both optional, opset 11+ input-based.
+    if (node.input_size() <= idx) {
+      continue;
+    }
+    const std::string& name = node.input(idx);
+    if (name.empty()) {
+      continue;  // Omitted optional input (empty-string placeholder).
+    }
+    auto it = init_map.find(name);
+    if (it == init_map.end()) {
+      return false;  // Non-constant -- declined, never guessed at.
+    }
+    const auto& dims = it->second->dims();
+    const bool is_scalar =
+        dims.size() == 0 || (dims.size() == 1 && dims.Get(0) == 1);
+    if (!is_scalar) {
+      return false;  // Not a scalar -- declined, never guessed at.
+    }
+  }
+  return true;
+}
+
+// One PRelu pass-through hop match: `is_per_channel` tells the caller
+// whether `slope_name` (present only when `is_per_channel`) needs its own
+// axis-0 (Conv chain)/last-axis (MatMul chain) slice, or -- for a scalar/
+// single shared parameter slope -- needs no slicing at all, the same
+// "nothing of its own to touch" shape a plain unary activation hop already
+// gets. Mirrors pruning.py's own `Optional[Tuple[bool, Optional[str]]]`
+// return convention for _match_prelu_pass_through and its three siblings
+// below.
+struct PreluMatch {
+  bool is_per_channel;
+  std::optional<std::string> slope_name;
+};
+
+// The MatMul/Gemm-chain PRelu pass-through matcher used by WalkToConsumer,
+// mirroring pruning.py's own _match_prelu_pass_through_matmul: since a
+// MatMul/Gemm chain's own channel axis is the tensor's *last* axis (not
+// axis 1, as for a Conv chain), `slope`'s per-channel shape here is the same
+// flat, last-axis-is-channel vector every other MatMul/Gemm hop's own
+// constant operand already is held to (prod(dims) == dims[-1]) -- e.g. a
+// bare `[C]`, safe here in a way it is *not* for a Conv chain's own
+// `[C, 1, 1]` convention (there is no trailing spatial axis for a rank-1
+// `[C]` to spuriously align against instead). Returns
+// `(is_per_channel, slope_name_or_none)`: scalar (`prod(dims) == 1`) is left
+// completely untouched; per-channel (`dims[-1] == n_channels`) is folded
+// into the caller's own chain_ops as an ordinary (node, slope_name) entry --
+// no dedicated hop type needed here the way the Conv walk's axis-0 slice
+// needs ConvPassThrough. Declines (nullopt) for a missing/non-constant/
+// otherwise-malformed slope, the same conservative bar every other hop here
+// holds its own constant operand to.
+std::optional<PreluMatch> MatchPreluPassThroughMatmul(
+    const onnx::NodeProto& node, const InitMap& init_map,
+    int64_t n_channels) {
+  if (node.op_type() != "PRelu" || node.domain() != "") {
+    return std::nullopt;
+  }
+  if (node.input_size() != 2 || node.input(0).empty() ||
+      node.input(1).empty()) {
+    return std::nullopt;
+  }
+  if (node.output_size() != 1) {
+    return std::nullopt;
+  }
+  const std::string& slope_name = node.input(1);
+  auto it = init_map.find(slope_name);
+  if (it == init_map.end() ||
+      it->second->data_type() != onnx::TensorProto::FLOAT) {
+    return std::nullopt;
+  }
+  const onnx::TensorProto* s = it->second;
+  if (s->dims_size() == 0) {
+    return std::nullopt;
+  }
+  int64_t prod = 1;
+  for (int64_t d : s->dims()) {
+    prod *= d;
+  }
+  if (prod == 1) {
+    return PreluMatch{false, std::nullopt};  // Scalar -- untouched.
+  }
+  if (prod == s->dims(s->dims_size() - 1) &&
+      s->dims(s->dims_size() - 1) == n_channels) {
+    return PreluMatch{true, slope_name};
+  }
+  return std::nullopt;
+}
+
+// The backward-walk (WalkMatmulProducerBackward) counterpart of
+// MatchPreluPassThroughMatmul, mirroring pruning.py's own
+// _match_prelu_pass_through_matmul_self: the backward residual walk doesn't
+// know its group's real shared channel count yet at the point it first
+// crosses a PRelu hop, so this checks `slope`'s own shape is
+// self-consistent by calling that same matcher with `slope`'s own
+// `dims[-1]` as the "expected" channel count -- trivially satisfying the
+// per-channel case's own `dims[-1] == n_channels` check (never even
+// consulted by the scalar case). FindMatmulResidualChains/
+// ResolveMatmulResidualGroupForConcat already re-validate every chain_ops
+// constant this walk returns against the group's real channel count once
+// resolved, so no PRelu-specific re-validation is needed here.
+std::optional<PreluMatch> MatchPreluPassThroughMatmulSelf(
+    const onnx::NodeProto& node, const InitMap& init_map) {
+  if (node.op_type() != "PRelu" || node.domain() != "" ||
+      node.input_size() != 2) {
+    return std::nullopt;
+  }
+  const std::string& slope_name = node.input(1);
+  if (slope_name.empty()) {
+    return std::nullopt;
+  }
+  auto it = init_map.find(slope_name);
+  if (it == init_map.end()) {
+    return std::nullopt;
+  }
+  const int64_t expected = it->second->dims_size() > 0
+                               ? it->second->dims(it->second->dims_size() - 1)
+                               : 1;
+  return MatchPreluPassThroughMatmul(node, init_map, expected);
+}
+
 // True for an `Add` node the residual-chain finders below may treat as a
 // merge point: exactly two distinct, non-constant operands. Mirrors
 // pruning.py's own _is_eligible_add_merge exactly -- not Conv- or
@@ -554,6 +704,19 @@ std::pair<std::optional<ConsumerMatch>, std::vector<ChainOp>> WalkToConsumer(
         }
       }
       const_name = fused->bias_name;
+    } else if (nxt->op_type() == "PRelu" && nxt->domain() == "" &&
+               nxt->input_size() > 0 && nxt->input(0) == cur) {
+      auto prelu_match = MatchPreluPassThroughMatmul(*nxt, init_map, n_channels);
+      if (!prelu_match) {
+        break;
+      }
+      const_name = prelu_match->is_per_channel ? prelu_match->slope_name
+                                               : std::nullopt;
+    } else if (nxt->op_type() == "Clip" && nxt->domain() == "" &&
+               nxt->input_size() > 0 && nxt->input(0) == cur &&
+               nxt->output_size() == 1 &&
+               MatchClipChannelPassThrough(*nxt, init_map)) {
+      // Channel-agnostic -- no const of its own to slice.
     } else {
       break;
     }
@@ -878,6 +1041,86 @@ std::optional<DepthwiseMatch> MatchDepthwiseConvPassThrough(
   return DepthwiseMatch{node.input(1), bias};
 }
 
+// The Conv-chain PRelu pass-through matcher used by WalkToConvConsumer,
+// mirroring pruning.py's own _match_prelu_pass_through: if `node` is a plain
+// (default-domain) PRelu whose own `slope` (input 1) is a constant float
+// initializer cleanly falling into one of two shapes real exporters
+// produce, returns `(is_per_channel, slope_name_or_none)`:
+//
+// - scalar/single shared parameter (every dimension size 1 -- e.g. a bare
+//   scalar, `[1]`, or the `[1, 1, 1]` a real `torch.onnx.export` of
+//   `nn.PReLU(1)` emits) -- `(false, nullopt)`: the same value multiplies
+//   every channel, so pruning some away changes nothing about it -- left
+//   completely untouched, the same "no operand of its own to slice" shape a
+//   unary activation hop already gets.
+// - per-channel (`dims[0] == n_channels`, every other dimension size 1 --
+//   e.g. the `[C, 1, 1]` a real `torch.onnx.export` of `nn.PReLU(C)` emits
+//   for a 2-D Conv) -- `(true, slope_name)`: one independent value per
+//   channel, co-sliced by the chain's own `keep` index set exactly like a
+//   depthwise Conv hop's own weight already is -- this reuses ConvPassThrough
+//   for exactly that reason (`slope`'s own `[C, 1, ..., 1]` layout needs the
+//   identical axis-0, any-trailing-rank slice a depthwise Conv's own weight
+//   already gets, and PRelu has no `group` attribute for the caller's own
+//   conv-groupedness dispatch to (correctly) leave untouched -- see
+//   ApplyChains/ApplyConcatChains's own `op_type() == "Conv"` guard around
+//   `SetOrAddIntAttr(..., "group", ...)`).
+//
+// A bare rank-1 `[C]` slope is deliberately *not* treated as per-channel
+// here, unlike a MatMul/Gemm chain's own last-axis-is-channel convention
+// (MatchPreluPassThroughMatmul above) -- this module's Conv-chain machinery
+// assumes NCHW's axis-1-is-channel convention throughout, and ONNX's
+// unidirectional broadcasting aligns a slope's own dimensions against `X`'s
+// *trailing* ones: a `[C]` slope padded against a rank-4 NCHW tensor lands
+// on axis 3 (W), not axis 1, unless C happens to equal W by coincidence.
+// Requiring at least one trailing size-1 dimension (`dims_size() >= 2`) is
+// what rules a bare `[C]` out here. Declines (nullopt) whenever `node` isn't
+// a plain PRelu, `slope` is missing/non-constant, or its shape doesn't
+// cleanly fall into either shape above -- never guessed at.
+std::optional<PreluMatch> MatchPreluPassThrough(const onnx::NodeProto& node,
+                                                const InitMap& init_map,
+                                                int64_t n_channels) {
+  if (node.op_type() != "PRelu" || node.domain() != "") {
+    return std::nullopt;
+  }
+  if (node.input_size() != 2 || node.input(0).empty() ||
+      node.input(1).empty()) {
+    return std::nullopt;
+  }
+  if (node.output_size() != 1) {
+    return std::nullopt;
+  }
+  const std::string& slope_name = node.input(1);
+  auto it = init_map.find(slope_name);
+  if (it == init_map.end() ||
+      it->second->data_type() != onnx::TensorProto::FLOAT) {
+    return std::nullopt;
+  }
+  const onnx::TensorProto* s = it->second;
+  if (s->dims_size() == 0) {
+    return std::nullopt;
+  }
+  int64_t prod = 1;
+  for (int64_t d : s->dims()) {
+    prod *= d;
+  }
+  if (prod == 1) {
+    return PreluMatch{false, std::nullopt};  // Scalar -- untouched.
+  }
+  if (s->dims_size() >= 2 && s->dims(0) == n_channels) {
+    bool trailing_ones = true;
+    for (int i = 1; i < s->dims_size(); ++i) {
+      if (s->dims(i) != 1) {
+        trailing_ones = false;
+        break;
+      }
+    }
+    if (trailing_ones) {
+      return PreluMatch{true, slope_name};
+    }
+  }
+  return std::nullopt;
+}
+
 struct ConvConsumerResult {
   onnx::NodeProto* node;
   std::string weight;
@@ -926,6 +1169,40 @@ WalkToConvConsumer(const std::string& start, const InitMap& init_map,
         consumer = ConvConsumerResult{nxt, match->weight, match->group};
       }
       break;
+    }
+
+    if (nxt->op_type() == "PRelu" && nxt->domain() == "" &&
+        nxt->input_size() > 0 && nxt->input(0) == cur &&
+        nxt->output_size() == 1) {
+      auto prelu_match = MatchPreluPassThrough(*nxt, init_map, n_channels);
+      if (!prelu_match) {
+        break;
+      }
+      const std::string& out2 = nxt->output(0);
+      if (ConsumerCount(consumers_of, out2) != 1 || graph_outputs.count(out2)) {
+        break;
+      }
+      if (prelu_match->is_per_channel) {
+        pass_through.push_back(
+            ConvPassThrough{nxt, *prelu_match->slope_name, std::nullopt});
+      } else {
+        chain_ops.push_back(ChainOp{nxt, std::nullopt});
+      }
+      cur = out2;
+      continue;
+    }
+
+    if (nxt->op_type() == "Clip" && nxt->domain() == "" &&
+        nxt->input_size() > 0 && nxt->input(0) == cur &&
+        nxt->output_size() == 1 &&
+        MatchClipChannelPassThrough(*nxt, init_map)) {
+      const std::string& out2 = nxt->output(0);
+      if (ConsumerCount(consumers_of, out2) != 1 || graph_outputs.count(out2)) {
+        break;
+      }
+      chain_ops.push_back(ChainOp{nxt, std::nullopt});
+      cur = out2;
+      continue;
     }
 
     if (!(UnaryPassThroughOps().count(nxt->op_type()) != 0 &&
@@ -1049,6 +1326,40 @@ std::optional<DepthwiseMatch> MatchConvPassThroughSelf(
   return MatchDepthwiseConvPassThrough(node, init_map, it->second->dims(0));
 }
 
+// The backward-walk (WalkConvProducerBackward) counterpart of
+// MatchPreluPassThrough, mirroring pruning.py's own
+// _match_prelu_pass_through_self and MatchConvPassThroughSelf's own
+// identical trick: the backward residual walk doesn't know its group's
+// shared channel count yet at the point it first crosses a PRelu hop, so
+// this checks the node's own `slope` is self-consistently shaped by calling
+// that same matcher with `slope`'s own `dims(0)` as the "expected" channel
+// count -- trivially satisfying the per-channel case's own
+// `dims(0) == n_channels` check and leaving every other one (including the
+// scalar case, which never even looks at n_channels) intact.
+// FindConvResidualChains/ResolveConvResidualGroupForConcat re-validate every
+// per-channel hop this returns against the group's real, established
+// channel count once resolved (the same generic `pass_through`
+// re-validation a depthwise hop already gets, keyed only on `hop.weight`'s
+// own `dims(0)`, needing no PRelu-specific case of its own).
+std::optional<PreluMatch> MatchPreluPassThroughSelf(const onnx::NodeProto& node,
+                                                     const InitMap& init_map) {
+  if (node.op_type() != "PRelu" || node.domain() != "" ||
+      node.input_size() != 2) {
+    return std::nullopt;
+  }
+  const std::string& slope_name = node.input(1);
+  if (slope_name.empty()) {
+    return std::nullopt;
+  }
+  auto it = init_map.find(slope_name);
+  if (it == init_map.end()) {
+    return std::nullopt;
+  }
+  const int64_t expected =
+      it->second->dims_size() > 0 ? it->second->dims(0) : 1;
+  return MatchPreluPassThrough(node, init_map, expected);
+}
+
 // Walks backward from tensor `start` through unary pass-through activations
 // and self-consistently-depthwise Conv hops, declining (only) whenever a
 // tensor crossed -- `start` itself included -- is a graph output. Unlike the
@@ -1097,6 +1408,27 @@ ConvBackwardEdge WalkConvProducerBackward(
     auto dw = MatchConvPassThroughSelf(*node, init_map);
     if (dw) {
       pass_through.push_back(ConvPassThrough{node, dw->weight, dw->bias});
+      edges.push_back({node->input(0), node});
+      cur = node->input(0);
+      continue;
+    }
+
+    auto prelu_self = MatchPreluPassThroughSelf(*node, init_map);
+    if (prelu_self) {
+      if (prelu_self->is_per_channel) {
+        pass_through.push_back(
+            ConvPassThrough{node, *prelu_self->slope_name, std::nullopt});
+      } else {
+        unary_ops.push_back(node);
+      }
+      edges.push_back({node->input(0), node});
+      cur = node->input(0);
+      continue;
+    }
+
+    if (node->op_type() == "Clip" &&
+        MatchClipChannelPassThrough(*node, init_map)) {
+      unary_ops.push_back(node);
       edges.push_back({node->input(0), node});
       cur = node->input(0);
       continue;
@@ -1773,6 +2105,28 @@ MatMulBackwardEdge WalkMatmulProducerBackward(
         continue;
       }
       return MatMulBackwardEdge{};
+    }
+
+    if (node->op_type() == "PRelu" && node->domain() == "" &&
+        node->input_size() == 2) {
+      auto prelu_self = MatchPreluPassThroughMatmulSelf(*node, init_map);
+      if (prelu_self) {
+        chain_ops.push_back(ChainOp{
+            node, prelu_self->is_per_channel ? prelu_self->slope_name
+                                              : std::nullopt});
+        edges.push_back({node->input(0), node});
+        cur = node->input(0);
+        continue;
+      }
+      return MatMulBackwardEdge{};
+    }
+
+    if (node->op_type() == "Clip" &&
+        MatchClipChannelPassThrough(*node, init_map)) {
+      chain_ops.push_back(ChainOp{node, std::nullopt});
+      edges.push_back({node->input(0), node});
+      cur = node->input(0);
+      continue;
     }
 
     if (MatchResidualMerge(node, init_map, consumers_of, graph_outputs)) {
@@ -2493,7 +2847,14 @@ void ApplyChains(onnx::GraphProto* graph, std::vector<Chain>& chains,
       if (hop.bias) {
         SliceLastAxis(init_map.at(*hop.bias), keep);
       }
-      SetOrAddIntAttr(hop.node, "group", static_cast<int64_t>(keep.size()));
+      // A PRelu per-channel-slope hop reuses ConvPassThrough for its own
+      // slicing (see MatchPreluPassThrough's own comment) but, unlike a
+      // depthwise Conv hop, has no `group` attribute of its own to update --
+      // mirrors pruning.py's own _apply_conv_pass_through_hop, which only
+      // ever touches `group` when the hop node is actually a Conv.
+      if (hop.node->op_type() == "Conv") {
+        SetOrAddIntAttr(hop.node, "group", static_cast<int64_t>(keep.size()));
+      }
     }
     if (chain.consumer_is_conv && chain.consumer_group > 1) {
       SliceGroupedConsumerConvWeight(init_map.at(chain.consumer_weight), keep,
@@ -2522,7 +2883,9 @@ void ApplyChains(onnx::GraphProto* graph, std::vector<Chain>& chains,
         if (hop.bias) {
           SliceLastAxis(init_map.at(*hop.bias), keep);
         }
-        SetOrAddIntAttr(hop.node, "group", static_cast<int64_t>(keep.size()));
+        if (hop.node->op_type() == "Conv") {
+          SetOrAddIntAttr(hop.node, "group", static_cast<int64_t>(keep.size()));
+        }
       }
       if (b->consumer_is_conv && b->consumer_group > 1) {
         SliceGroupedConsumerConvWeight(init_map.at(b->consumer_weight), keep,
@@ -4236,7 +4599,9 @@ void ApplyConcatChains(onnx::GraphProto* graph,
         if (hop.bias) {
           SliceLastAxis(init_map.at(*hop.bias), keep);
         }
-        SetOrAddIntAttr(hop.node, "group", static_cast<int64_t>(keep.size()));
+        if (hop.node->op_type() == "Conv") {
+          SetOrAddIntAttr(hop.node, "group", static_cast<int64_t>(keep.size()));
+        }
       }
     }
 
@@ -4257,8 +4622,10 @@ void ApplyConcatChains(onnx::GraphProto* graph,
       if (hop.bias) {
         SliceLastAxis(init_map.at(*hop.bias), global_keep);
       }
-      SetOrAddIntAttr(hop.node, "group",
-                      static_cast<int64_t>(global_keep.size()));
+      if (hop.node->op_type() == "Conv") {
+        SetOrAddIntAttr(hop.node, "group",
+                        static_cast<int64_t>(global_keep.size()));
+      }
     }
 
     SliceConsumerWeight(init_map.at(chain.consumer_weight),

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -473,8 +473,7 @@ struct PreluMatch {
 // otherwise-malformed slope, the same conservative bar every other hop here
 // holds its own constant operand to.
 std::optional<PreluMatch> MatchPreluPassThroughMatmul(
-    const onnx::NodeProto& node, const InitMap& init_map,
-    int64_t n_channels) {
+    const onnx::NodeProto& node, const InitMap& init_map, int64_t n_channels) {
   if (node.op_type() != "PRelu" || node.domain() != "") {
     return std::nullopt;
   }
@@ -731,12 +730,13 @@ std::pair<std::optional<ConsumerMatch>, std::vector<ChainOp>> WalkToConsumer(
       const_name = fused->bias_name;
     } else if (nxt->op_type() == "PRelu" && nxt->domain() == "" &&
                nxt->input_size() > 0 && nxt->input(0) == cur) {
-      auto prelu_match = MatchPreluPassThroughMatmul(*nxt, init_map, n_channels);
+      auto prelu_match =
+          MatchPreluPassThroughMatmul(*nxt, init_map, n_channels);
       if (!prelu_match) {
         break;
       }
-      const_name = prelu_match->is_per_channel ? prelu_match->slope_name
-                                               : std::nullopt;
+      const_name =
+          prelu_match->is_per_channel ? prelu_match->slope_name : std::nullopt;
     } else if (nxt->op_type() == "Clip" && nxt->domain() == "" &&
                nxt->input_size() > 0 && nxt->input(0) == cur &&
                nxt->output_size() == 1 &&
@@ -1367,7 +1367,7 @@ std::optional<DepthwiseMatch> MatchConvPassThroughSelf(
 // re-validation a depthwise hop already gets, keyed only on `hop.weight`'s
 // own `dims(0)`, needing no PRelu-specific case of its own).
 std::optional<PreluMatch> MatchPreluPassThroughSelf(const onnx::NodeProto& node,
-                                                     const InitMap& init_map) {
+                                                    const InitMap& init_map) {
   if (node.op_type() != "PRelu" || node.domain() != "" ||
       node.input_size() != 2) {
     return std::nullopt;
@@ -2136,8 +2136,8 @@ MatMulBackwardEdge WalkMatmulProducerBackward(
         node->input_size() == 2) {
       auto prelu_self = MatchPreluPassThroughMatmulSelf(*node, init_map);
       if (prelu_self) {
-        chain_ops.push_back(ChainOp{
-            node, prelu_self->is_per_channel ? prelu_self->slope_name
+        chain_ops.push_back(ChainOp{node, prelu_self->is_per_channel
+                                              ? prelu_self->slope_name
                                               : std::nullopt});
         edges.push_back({node->input(0), node});
         cur = node->input(0);
@@ -4783,14 +4783,15 @@ struct SplitSizesResult {
 // IS present but is not a resolvable constant INT64 initializer. Mirrors
 // pruning.py's own _split_explicit_sizes exactly.
 std::optional<SplitSizesResult> SplitExplicitSizes(const onnx::NodeProto& node,
-                                                    const InitMap& init_map) {
+                                                   const InitMap& init_map) {
   if (node.input_size() >= 2 && !node.input(1).empty()) {
     auto it = init_map.find(node.input(1));
     if (it == init_map.end() ||
         it->second->data_type() != onnx::TensorProto::INT64) {
       return std::nullopt;
     }
-    return SplitSizesResult{ReadInt64Tensor(*it->second), SplitSizesKind::kInput};
+    return SplitSizesResult{ReadInt64Tensor(*it->second),
+                            SplitSizesKind::kInput};
   }
   for (const auto& attr : node.attribute()) {
     if (attr.name() == "split") {
@@ -4964,9 +4965,9 @@ std::vector<SplitGatedChain> FindSplitGatedChains(onnx::GraphProto* graph) {
     if (!(is_internal(node->output(0)) && is_internal(node->output(1)))) {
       continue;
     }
-    split_matches[node] = SplitMatch{pinfo.node, pinfo.weight,
-                                     pinfo.weight_transposed, pinfo.bias, h,
-                                     sizes_result->kind};
+    split_matches[node] = SplitMatch{
+        pinfo.node, pinfo.weight,      pinfo.weight_transposed, pinfo.bias,
+        h,          sizes_result->kind};
     split_half_of[node->output(0)] = SplitHalfOf{node, 0};
     split_half_of[node->output(1)] = SplitHalfOf{node, 1};
   }
@@ -4987,12 +4988,12 @@ std::vector<SplitGatedChain> FindSplitGatedChains(onnx::GraphProto* graph) {
           init_map.count(b_name)) {
         continue;
       }
-      auto trace_a = TraceSplitHalfBackward(a_name, node_by_output,
-                                            split_half_of, consumers_of,
-                                            graph_outputs, kMaxChainHops);
-      auto trace_b = TraceSplitHalfBackward(b_name, node_by_output,
-                                            split_half_of, consumers_of,
-                                            graph_outputs, kMaxChainHops);
+      auto trace_a =
+          TraceSplitHalfBackward(a_name, node_by_output, split_half_of,
+                                 consumers_of, graph_outputs, kMaxChainHops);
+      auto trace_b =
+          TraceSplitHalfBackward(b_name, node_by_output, split_half_of,
+                                 consumers_of, graph_outputs, kMaxChainHops);
       if (!trace_a || !trace_b) {
         continue;
       }
@@ -5110,7 +5111,8 @@ void ApplySplitGatedChains(onnx::GraphProto* graph,
     if (chain.split_sizes_kind == SplitSizesKind::kInput) {
       size_init_name = chain.split_node->input(1);
       if (touched_split_size_inits.count(*size_init_name)) {
-        continue;  // A shared split-sizes constant another chain already rewrote.
+        continue;  // A shared split-sizes constant another chain already
+                   // rewrote.
       }
     }
 
@@ -5147,7 +5149,8 @@ void ApplySplitGatedChains(onnx::GraphProto* graph,
       }
       importance[static_cast<size_t>(c)] = std::sqrt(sq_gate + sq_up);
     }
-    const std::vector<int64_t> keep = TopKIndicesAscending(importance, keep_count);
+    const std::vector<int64_t> keep =
+        TopKIndicesAscending(importance, keep_count);
     // `keep` (< h) and `keep + h` (>= h) are disjoint ranges, each already
     // ascending -- their concatenation is therefore already ascending
     // overall too, same `keep`-is-ascending invariant every other chain

--- a/tests/test_structured_pruning_cpp.py
+++ b/tests/test_structured_pruning_cpp.py
@@ -614,6 +614,363 @@ def test_cpp_structured_pruning_native_swiglu_node_prunes_both_producers_togethe
     np.testing.assert_array_equal(inits["Wd"], wd[keep, :])
 
 
+# --- Split-merged (fused gate_up_proj) gated FFN chains ----------------------
+#
+# Real Phi-3/Phi-3.5 (onnxruntime-genai) exports use ONE gate_up_proj MatMul/
+# Gemm whose 2*H-wide output is halved by a Split into a gate half and an up
+# half, rather than two separate gate_proj/up_proj producers -- see
+# onnxsim/structured_pruning_entry.cpp's own "Split-merged (fused
+# gate_up_proj) gated FFN chains" section comment (and onnxsim/pruning.py's
+# identically-named section, which this is ported from) for the full shape
+# and co-selection semantics these tests exercise: "neuron" i of the
+# intermediate dimension is represented by BOTH column i (gate) and column
+# H + i (up) of the ONE combined weight tensor, and must always be kept or
+# dropped together.
+
+
+def _split_gate_up_keep_indices(w, H, keep_count):
+    # The correct paired-importance ranking: combined (root-sum-square) norm
+    # of the gate half (columns [0, H)) and the up half (columns [H, 2H)) of
+    # the ONE combined weight `w` -- mirrors _combined_keep_indices's own
+    # formula for the two-separate-producer case above.
+    gate_half, up_half = w[:, :H], w[:, H:]
+    importance = np.sqrt(
+        np.square(np.linalg.norm(gate_half.T, axis=1))
+        + np.square(np.linalg.norm(up_half.T, axis=1))
+    )
+    return np.sort(np.argsort(-importance)[:keep_count])
+
+
+def _split_gate_up_mlp_model(
+    K=8,
+    H=16,
+    Out=4,
+    gate_activation="Sigmoid",
+    seed=0,
+    opset=21,
+    split_attrs="axis=-1, num_outputs=2",
+):
+    rng = np.random.default_rng(seed)
+    w = rng.standard_normal((K, 2 * H)).astype(np.float32)
+    wd = rng.standard_normal((H, Out)).astype(np.float32)
+    split_attr_text = f"<{split_attrs}>" if split_attrs else ""
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          combined = MatMul(X, W)
+          gate, up = Split {split_attr_text} (combined)
+          gate_act = {gate_activation}(gate)
+          h = Mul(gate_act, up)
+          Y = MatMul(h, Wd)
+        }}
+        """,
+        initializer=[_f32(w, "W"), _f32(wd, "Wd")],
+        opset=opset,
+    )
+    return model, w, wd
+
+
+def test_cpp_structured_pruning_split_gated_ffn_matches_oracle():
+    K, H, Out = 8, 16, 4
+    model, w, wd = _split_gate_up_mlp_model(K=K, H=H, Out=Out)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W"].dims) == [K, H]  # 2 * (H // 2)
+    assert list(inits["Wd"].dims) == [H // 2, Out]
+
+    keep = _split_gate_up_keep_indices(w, H, H // 2)
+    rng = np.random.default_rng(20)
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+
+    gate = 1.0 / (1.0 + np.exp(-(x @ w[:, keep])))
+    up = x @ w[:, H + keep]
+    y_oracle = (gate * up) @ wd[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_split_gated_ffn_prunes_both_halves_of_one_tensor():
+    # The real bug this pattern risks: only one of the two halves getting
+    # sliced (or the two halves disagreeing on which columns survive) --
+    # assert the SAME index set is dropped from both, out of the single
+    # physical weight tensor.
+    K, H, Out = 8, 20, 4
+    model, w, wd = _split_gate_up_mlp_model(K=K, H=H, Out=Out, seed=1)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.3)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    keep = _split_gate_up_keep_indices(w, H, H - round(H * 0.3))
+
+    np.testing.assert_array_equal(inits["W"][:, : len(keep)], w[:, keep])
+    np.testing.assert_array_equal(inits["W"][:, len(keep) :], w[:, H + keep])
+    np.testing.assert_array_equal(inits["Wd"], wd[keep, :])
+
+
+def test_cpp_structured_pruning_split_gated_ffn_uses_combined_paired_importance():
+    # Adversarial case: gate-half and up-half columns for the SAME neuron
+    # index deliberately have very different magnitudes, constructed so that
+    # ranking by EITHER half alone (a "sliced/ranked only one half" bug)
+    # picks a DIFFERENT keep-set than the correct combined (root-sum-square)
+    # ranking of the pair. K=2 with only row 0 non-zero makes each column's
+    # own L2 norm exactly its row-0 value, so the desired per-half
+    # magnitudes can be set directly and exactly.
+    K, H, Out = 2, 5, 3
+    gate_vals = np.array([9.0, 1.0, 6.0, 7.0, 0.5], dtype=np.float32)
+    up_vals = np.array([1.0, 8.9, 6.0, 0.5, 6.9], dtype=np.float32)
+    # combined (root-sum-square) importance per column:
+    #   col0: sqrt(9.0^2+1.0^2) = 9.0554  (rank 1)
+    #   col1: sqrt(1.0^2+8.9^2) = 8.9556  (rank 2)
+    #   col2: sqrt(6.0^2+6.0^2) = 8.4853  (rank 3)
+    #   col3: sqrt(7.0^2+0.5^2) = 7.0178  (rank 4)
+    #   col4: sqrt(0.5^2+6.9^2) = 6.9181  (rank 5)
+    # correct keep (top 3, combined) = [0, 1, 2]; gate-only top 3 would be
+    # [0, 2, 3] and up-only top 3 would be [1, 2, 4] -- both wrong.
+    w = np.zeros((K, 2 * H), dtype=np.float32)
+    w[0, :H] = gate_vals
+    w[0, H:] = up_vals
+    rng = np.random.default_rng(2)
+    wd = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          combined = MatMul(X, W)
+          gate, up = Split <axis=-1, num_outputs=2> (combined)
+          gate_act = Sigmoid(gate)
+          h = Mul(gate_act, up)
+          Y = MatMul(h, Wd)
+        }}
+        """,
+        initializer=[_f32(w, "W"), _f32(wd, "Wd")],
+    )
+
+    # H=5, sparsity=0.4 -> keep_count = 5 - round(5*0.4) = 3.
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.4)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    correct_keep = np.array([0, 1, 2])
+    gate_only_keep = np.array([0, 2, 3])  # what a gate-only-ranked bug would pick
+    up_only_keep = np.array([1, 2, 4])  # what an up-only-ranked bug would pick
+
+    np.testing.assert_array_equal(inits["W"][:, :3], w[:, correct_keep])
+    np.testing.assert_array_equal(inits["W"][:, 3:], w[:, H + correct_keep])
+    assert not np.array_equal(inits["W"][0, :3], w[0, gate_only_keep])
+    assert not np.array_equal(inits["W"][0, :3], w[0, up_only_keep])
+
+
+def test_cpp_structured_pruning_split_gated_ffn_gelu_activation_matches_oracle():
+    # GeGLU: same fused-gate_up_proj topology, a different (still-unary)
+    # gate activation -- mirrors this file's own
+    # test_cpp_structured_pruning_gelu_gated_ffn_matches_oracle above, but
+    # for the single fused-producer shape. Uses Gelu's tanh approximation so
+    # the oracle needs no scipy/erf. (Native ai.onnx Swish/HardSwish are not
+    # exercised here: UnaryPassThroughOps() -- shared by every gated-chain
+    # family in this port, not just this one -- does not yet recognize them,
+    # a pre-existing gap outside this feature's own scope.)
+    K, H, Out = 8, 16, 4
+    model, w, wd = _split_gate_up_mlp_model(
+        K=K, H=H, Out=Out, gate_activation='Gelu<approximate = "tanh">', seed=3
+    )
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep = _split_gate_up_keep_indices(w, H, H // 2)
+    rng = np.random.default_rng(30)
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+
+    g = x @ w[:, keep]
+    gate = 0.5 * g * (1.0 + np.tanh(np.sqrt(2.0 / np.pi) * (g + 0.044715 * g**3)))
+    up = x @ w[:, H + keep]
+    y_oracle = (gate * up) @ wd[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_cpp_structured_pruning_split_gated_ffn_explicit_equal_split_input_matches_oracle():
+    # opset 13+'s explicit `split` *input* (rather than the fully-automatic
+    # even split) spelled out as literally [H, H] -- the same semantic
+    # split, a different spelling; the pruned model's own Split input must
+    # be rewritten to the new, still-even [h', h'].
+    K, H, Out = 8, 16, 4
+    rng = np.random.default_rng(4)
+    w = rng.standard_normal((K, 2 * H)).astype(np.float32)
+    wd = rng.standard_normal((H, Out)).astype(np.float32)
+    sizes = onnx.numpy_helper.from_array(np.array([H, H], dtype=np.int64), name="Sizes")
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          combined = MatMul(X, W)
+          gate, up = Split <axis=-1> (combined, Sizes)
+          gate_act = Sigmoid(gate)
+          h = Mul(gate_act, up)
+          Y = MatMul(h, Wd)
+        }}
+        """,
+        initializer=[_f32(w, "W"), _f32(wd, "Wd"), sizes],
+    )
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    split_node = next(n for n in pruned.graph.node if n.op_type == "Split")
+    sizes_init = next(
+        t for t in pruned.graph.initializer if t.name == split_node.input[1]
+    )
+    assert list(onnx.numpy_helper.to_array(sizes_init)) == [H // 2, H // 2]
+
+    keep = _split_gate_up_keep_indices(w, H, H // 2)
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    gate = 1.0 / (1.0 + np.exp(-(x @ w[:, keep])))
+    up = x @ w[:, H + keep]
+    y_oracle = (gate * up) @ wd[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_split_gated_ffn_native_swiglu_matches_oracle():
+    # ONNX's native fused SwiGLU(a, b) = swish(a) * b (opset 28+), fed
+    # directly by the Split's own two raw outputs -- mirrors
+    # test_cpp_structured_pruning_native_swiglu_node_prunes_both_producers_together
+    # above, but for the single fused-producer gate_up_proj shape. Not yet
+    # supported by the installed onnx checker/onnxruntime in this
+    # environment (opset 28 is still under development upstream), so this
+    # verifies the graph surgery directly via tensor values rather than
+    # onnx.checker/onnxruntime execution.
+    K, H, Out = 8, 16, 4
+    rng = np.random.default_rng(12)
+    w = rng.standard_normal((K, 2 * H)).astype(np.float32)
+    wd = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          combined = MatMul(X, W)
+          gate, up = Split <axis=-1, num_outputs=2> (combined)
+          h = SwiGLU(gate, up)
+          Y = MatMul(h, Wd)
+        }}
+        """,
+        initializer=[_f32(w, "W"), _f32(wd, "Wd")],
+        opset=28,
+    )
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    keep = _split_gate_up_keep_indices(w, H, H // 2)
+
+    np.testing.assert_array_equal(inits["W"][:, : H // 2], w[:, keep])
+    np.testing.assert_array_equal(inits["W"][:, H // 2 :], w[:, H + keep])
+    np.testing.assert_array_equal(inits["Wd"], wd[keep, :])
+
+
+def test_cpp_structured_pruning_split_gated_ffn_gemm_producer_with_bias_matches_oracle():
+    # The producer may also be a vanilla Gemm with a fused constant bias
+    # (_match_producer/MatchProducer's own bias support) -- unlike a
+    # *separate* MatMul -> Add(bias) hop before Split (declined, see
+    # test_cpp_structured_pruning_split_gated_ffn_declines_bias_add_before_split
+    # below), Gemm's own bias operand is a per-channel constant riding along
+    # with the rest of the combined [K, 2H] weight, so it must be sliced at
+    # the same two fixed offsets.
+    K, H, Out = 8, 16, 4
+    rng = np.random.default_rng(13)
+    w = rng.standard_normal((K, 2 * H)).astype(np.float32)
+    b = rng.standard_normal((2 * H,)).astype(np.float32)
+    wd = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          combined = Gemm(X, W, B)
+          gate, up = Split <axis=-1, num_outputs=2> (combined)
+          gate_act = Sigmoid(gate)
+          h = Mul(gate_act, up)
+          Y = MatMul(h, Wd)
+        }}
+        """,
+        initializer=[_f32(w, "W"), _f32(b, "B"), _f32(wd, "Wd")],
+    )
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W"].dims) == [K, H]
+    assert list(inits["B"].dims) == [H]
+
+    keep = _split_gate_up_keep_indices(w, H, H // 2)
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    combined = x @ w[:, np.concatenate([keep, H + keep])] + b[np.concatenate([keep, H + keep])]
+    gate = 1.0 / (1.0 + np.exp(-combined[:, : H // 2]))
+    up = combined[:, H // 2 :]
+    y_oracle = (gate * up) @ wd[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_split_gated_ffn_declines_unequal_explicit_split():
+    K, H = 8, 16
+    rng = np.random.default_rng(5)
+    w = rng.standard_normal((K, 2 * H)).astype(np.float32)
+    sizes = onnx.numpy_helper.from_array(
+        np.array([H + 2, H - 2], dtype=np.int64), name="Sizes"
+    )
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{H + 2}] Gate, float[batch,{H - 2}] Up)
+        {{
+          combined = MatMul(X, W)
+          Gate, Up = Split <axis=-1> (combined, Sizes)
+        }}
+        """,
+        initializer=[_f32(w, "W"), sizes],
+    )
+    before = model.SerializeToString()
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    assert pruned.SerializeToString() == before
+
+
+def test_cpp_structured_pruning_split_gated_ffn_declines_when_axis_defaults_to_zero():
+    # Split's own schema default axis is 0, unlike Concat's *required*
+    # attribute -- an un-annotated Split here would target the batch axis,
+    # not the channel axis, and must be declined, not assumed.
+    K, H, Out = 8, 16, 4
+    model, w, wd = _split_gate_up_mlp_model(
+        K=K, H=H, Out=Out, seed=10, split_attrs="num_outputs=2"
+    )
+    before = model.SerializeToString()
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    assert pruned.SerializeToString() == before
+
+
+def test_cpp_structured_pruning_split_gated_ffn_declines_bias_add_before_split():
+    # A separate MatMul -> Add(bias) -> Split, rather than the producer's
+    # raw output feeding Split directly -- out of scope for this first pass
+    # (see this section's own comment in structured_pruning_entry.cpp).
+    K, H, Out = 8, 16, 4
+    rng = np.random.default_rng(8)
+    w = rng.standard_normal((K, 2 * H)).astype(np.float32)
+    bias = rng.standard_normal((2 * H,)).astype(np.float32)
+    wd = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          combined = MatMul(X, W)
+          combined_b = Add(combined, Bias)
+          gate, up = Split <axis=-1, num_outputs=2> (combined_b)
+          gate_act = Sigmoid(gate)
+          h = Mul(gate_act, up)
+          Y = MatMul(h, Wd)
+        }}
+        """,
+        initializer=[_f32(w, "W"), _f32(bias, "Bias"), _f32(wd, "Wd")],
+    )
+    before = model.SerializeToString()
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    assert pruned.SerializeToString() == before
+
+
 # --- Conv plain chains -------------------------------------------------------
 
 

--- a/tests/test_structured_pruning_cpp.py
+++ b/tests/test_structured_pruning_cpp.py
@@ -901,7 +901,9 @@ def test_cpp_structured_pruning_split_gated_ffn_gemm_producer_with_bias_matches_
     keep = _split_gate_up_keep_indices(w, H, H // 2)
     x = rng.standard_normal((5, K)).astype(np.float32)
     (y,) = _run(pruned, {"X": x})
-    combined = x @ w[:, np.concatenate([keep, H + keep])] + b[np.concatenate([keep, H + keep])]
+    combined = (
+        x @ w[:, np.concatenate([keep, H + keep])] + b[np.concatenate([keep, H + keep])]
+    )
     gate = 1.0 / (1.0 + np.exp(-combined[:, : H // 2]))
     up = combined[:, H // 2 :]
     y_oracle = (gate * up) @ wd[keep, :]

--- a/tests/test_structured_pruning_cpp.py
+++ b/tests/test_structured_pruning_cpp.py
@@ -1956,6 +1956,460 @@ def test_cpp_structured_pruning_skip_layer_norm_residual_declines_on_consumed_su
     assert pruned.SerializeToString() == model.SerializeToString()
 
 
+# --- PRelu/Clip channel pass-through hops ------------------------------------
+#
+# Two "channel pass-through hop" features ported from pruning.py's own
+# reference: a PRelu whose `slope` is either a scalar/single shared
+# parameter (left untouched) or a genuine per-channel constant (sliced by
+# the chain's own `keep` set, like a depthwise Conv hop's own weight), and a
+# Clip (the `torch.nn.ReLU6` shape MobileNet/EfficientNet-Lite exports)
+# crossed transparently whenever its `min`/`max` are each either omitted or
+# a constant scalar. See _match_prelu_pass_through(_self,_matmul,
+# _matmul_self) and _match_clip_channel_pass_through in pruning.py.
+
+
+def test_cpp_structured_pruning_prelu_per_channel_pass_through_conv_matches_oracle():
+    Cin, C1, C2 = 3, 16, 8
+    rng = np.random.default_rng(200)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    b1 = rng.standard_normal((C1,)).astype(np.float32)
+    slope = rng.uniform(0.05, 0.3, size=(C1, 1, 1)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+
+    def _mk(w1, b1, slope, w2):
+        return _model(
+            f"""
+            g (float[N,{Cin},10,10] X) => (float[N,{C2},6,6] Y)
+            {{
+              h = Conv<kernel_shape=[3,3]>(X, W1, B1)
+              a = PRelu(h, Slope)
+              Y = Conv<kernel_shape=[3,3]>(a, W2)
+            }}
+            """,
+            initializer=[
+                _f32(w1, "W1"),
+                _f32(b1, "B1"),
+                _f32(slope, "Slope"),
+                _f32(w2, "W2"),
+            ],
+        )
+
+    model = _mk(w1, b1, slope, w2)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    assert inits["Slope"].shape == (C1 // 2, 1, 1)
+    # The per-channel-slope hop reuses ConvPassThrough (same as a depthwise
+    # Conv hop), but PRelu has no `group` attribute of its own -- confirm the
+    # port doesn't erroneously bolt one on.
+    prelu_node = next(n for n in pruned.graph.node if n.op_type == "PRelu")
+    assert len(prelu_node.attribute) == 0
+
+    keep = _oracle_keep_indices_conv(w1, C1 // 2)
+    oracle = _mk(w1[keep], b1[keep], slope[keep], w2[:, keep])
+
+    rng_x = np.random.default_rng(201)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_prelu_scalar_slope_left_untouched_on_conv_chain():
+    Cin, C1, C2 = 3, 16, 8
+    rng = np.random.default_rng(202)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    slope = np.array([0.2], dtype=np.float32)  # single shared parameter.
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+
+    def _mk(w1, slope, w2):
+        return _model(
+            f"""
+            g (float[N,{Cin},10,10] X) => (float[N,{C2},6,6] Y)
+            {{
+              h = Conv<kernel_shape=[3,3]>(X, W1)
+              a = PRelu(h, Slope)
+              Y = Conv<kernel_shape=[3,3]>(a, W2)
+            }}
+            """,
+            initializer=[_f32(w1, "W1"), _f32(slope, "Slope"), _f32(w2, "W2")],
+        )
+
+    model = _mk(w1, slope, w2)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    # Scalar slope: same value multiplies every channel, so it's left
+    # completely untouched -- no "nothing of its own to slice" hop needed.
+    np.testing.assert_array_equal(inits["Slope"], slope)
+
+    keep = _oracle_keep_indices_conv(w1, C1 // 2)
+    oracle = _mk(w1[keep], slope, w2[:, keep])
+
+    rng_x = np.random.default_rng(203)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_clip_relu6_pass_through_conv_matches_oracle():
+    Cin, C1, C2 = 3, 16, 8
+    rng = np.random.default_rng(204)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    min_c = np.array(0.0, dtype=np.float32)
+    max_c = np.array(6.0, dtype=np.float32)
+
+    def _mk(w1, w2):
+        return _model(
+            f"""
+            g (float[N,{Cin},10,10] X) => (float[N,{C2},6,6] Y)
+            {{
+              h = Conv<kernel_shape=[3,3]>(X, W1)
+              a = Clip(h, Min, Max)
+              Y = Conv<kernel_shape=[3,3]>(a, W2)
+            }}
+            """,
+            initializer=[
+                _f32(w1, "W1"),
+                _f32(min_c, "Min"),
+                _f32(max_c, "Max"),
+                _f32(w2, "W2"),
+            ],
+        )
+
+    model = _mk(w1, w2)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [C1 // 2, Cin, 3, 3]
+    assert list(inits["W2"].dims) == [C2, C1 // 2, 3, 3]
+
+    keep = _oracle_keep_indices_conv(w1, C1 // 2)
+    oracle = _mk(w1[keep], w2[:, keep])
+
+    rng_x = np.random.default_rng(205)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_prelu_bare_rank1_slope_declines_on_conv_chain():
+    # A bare [C] slope is deliberately *not* treated as per-channel on a Conv
+    # chain (unlike a MatMul/Gemm chain's own last-axis convention): ONNX's
+    # unidirectional broadcasting would align it against the *trailing* (W)
+    # axis, not axis 1 -- declined, never guessed at.
+    Cin, C1, C2 = 3, 8, 4
+    rng = np.random.default_rng(206)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    slope = rng.uniform(0.05, 0.3, size=(C1,)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{C2},6,6] Y)
+        {{
+          h = Conv<kernel_shape=[3,3]>(X, W1)
+          a = PRelu(h, Slope)
+          Y = Conv<kernel_shape=[3,3]>(a, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(slope, "Slope"), _f32(w2, "W2")],
+    )
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["Slope"], slope)
+    np.testing.assert_array_equal(inits["W2"], w2)
+
+
+def test_cpp_structured_pruning_prelu_nonconstant_slope_declines():
+    Cin, C1, C2 = 3, 8, 4
+    rng = np.random.default_rng(207)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X, float[{C1},1,1] Slope) => (float[N,{C2},6,6] Y)
+        {{
+          h = Conv<kernel_shape=[3,3]>(X, W1)
+          a = PRelu(h, Slope)
+          Y = Conv<kernel_shape=[3,3]>(a, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2")],
+    )
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+
+
+def test_cpp_structured_pruning_clip_nonconstant_bound_declines():
+    Cin, C1, C2 = 3, 8, 4
+    rng = np.random.default_rng(208)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    min_c = np.array(0.0, dtype=np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X, float Max) => (float[N,{C2},6,6] Y)
+        {{
+          h = Conv<kernel_shape=[3,3]>(X, W1)
+          a = Clip(h, Min, Max)
+          Y = Conv<kernel_shape=[3,3]>(a, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(min_c, "Min"), _f32(w2, "W2")],
+    )
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+
+
+def test_cpp_structured_pruning_prelu_per_channel_pass_through_matmul_matches_oracle():
+    K, H, Out = 8, 32, 4
+    rng = np.random.default_rng(209)
+    w1 = rng.standard_normal((K, H)).astype(np.float32)
+    b1 = rng.standard_normal((H,)).astype(np.float32)
+    slope = rng.uniform(0.05, 0.3, size=(H,)).astype(np.float32)
+    w2 = rng.standard_normal((H, Out)).astype(np.float32)
+
+    def _mk(w1, b1, slope, w2):
+        return _model(
+            f"""
+            g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+            {{
+              h = Gemm(X, W1, B1)
+              a = PRelu(h, Slope)
+              Y = MatMul(a, W2)
+            }}
+            """,
+            initializer=[
+                _f32(w1, "W1"),
+                _f32(b1, "B1"),
+                _f32(slope, "Slope"),
+                _f32(w2, "W2"),
+            ],
+        )
+
+    model = _mk(w1, b1, slope, w2)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    assert inits["Slope"].shape == (H // 2,)
+
+    keep = _oracle_keep_indices(w1, H // 2)
+    oracle = _mk(w1[:, keep], b1[keep], slope[keep], w2[keep, :])
+
+    rng_x = np.random.default_rng(210)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_prelu_scalar_slope_left_untouched_on_matmul_chain():
+    K, H, Out = 8, 32, 4
+    rng = np.random.default_rng(211)
+    w1 = rng.standard_normal((K, H)).astype(np.float32)
+    # Single shared parameter, shape [1] -- mirrors _match_prelu_pass_through*'s
+    # own `if not dims: return None` bar, which (like the Conv-chain matcher)
+    # declines a true rank-0 slope; [1]/[1,1,1] is the shape real exporters
+    # (and this matcher) actually treat as "scalar".
+    slope = np.array([0.25], dtype=np.float32)
+    w2 = rng.standard_normal((H, Out)).astype(np.float32)
+
+    def _mk(w1, slope, w2):
+        return _model(
+            f"""
+            g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+            {{
+              h = MatMul(X, W1)
+              a = PRelu(h, Slope)
+              Y = MatMul(a, W2)
+            }}
+            """,
+            initializer=[_f32(w1, "W1"), _f32(slope, "Slope"), _f32(w2, "W2")],
+        )
+
+    model = _mk(w1, slope, w2)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["Slope"], slope)
+
+    keep = _oracle_keep_indices(w1, H // 2)
+    oracle = _mk(w1[:, keep], slope, w2[keep, :])
+
+    rng_x = np.random.default_rng(212)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_clip_relu6_pass_through_matmul_matches_oracle():
+    K, H, Out = 8, 32, 4
+    rng = np.random.default_rng(213)
+    w1 = rng.standard_normal((K, H)).astype(np.float32)
+    w2 = rng.standard_normal((H, Out)).astype(np.float32)
+    min_c = np.array(0.0, dtype=np.float32)
+    max_c = np.array([6.0], dtype=np.float32)  # single-element shape [1].
+
+    def _mk(w1, w2):
+        return _model(
+            f"""
+            g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+            {{
+              h = MatMul(X, W1)
+              a = Clip(h, Min, Max)
+              Y = MatMul(a, W2)
+            }}
+            """,
+            initializer=[
+                _f32(w1, "W1"),
+                _f32(min_c, "Min"),
+                _f32(max_c, "Max"),
+                _f32(w2, "W2"),
+            ],
+        )
+
+    model = _mk(w1, w2)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [K, H // 2]
+    assert list(inits["W2"].dims) == [H // 2, Out]
+
+    keep = _oracle_keep_indices(w1, H // 2)
+    oracle = _mk(w1[:, keep], w2[keep, :])
+
+    rng_x = np.random.default_rng(214)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_conv_residual_prelu_pass_through_hop_matches_oracle():
+    # A PRelu per-channel hop crossed by the *backward* walk
+    # (WalkConvProducerBackward/MatchPreluPassThroughSelf), not just the
+    # forward one -- exercises the residual-chain insertion point and the
+    # ApplyChains "group" attribute guard (PRelu must not get one).
+    Cin, C, Cout = 3, 16, 8
+    rng = np.random.default_rng(215)
+    w_f = rng.standard_normal((C, Cin, 3, 3)).astype(np.float32)
+    slope = rng.uniform(0.05, 0.3, size=(C, 1, 1)).astype(np.float32)
+    w_s = rng.standard_normal((C, Cin, 3, 3)).astype(np.float32)
+    w_out = rng.standard_normal((Cout, C, 3, 3)).astype(np.float32)
+
+    def _mk(w_f, slope, w_s, w_out):
+        return _model(
+            f"""
+            g (float[N,{Cin},10,10] X) => (float[N,{Cout},6,6] Y)
+            {{
+              f0 = Conv<kernel_shape=[3,3]>(X, WF)
+              f = PRelu(f0, Slope)
+              s = Conv<kernel_shape=[3,3]>(X, WS)
+              addr = Add(f, s)
+              r = Relu(addr)
+              Y = Conv<kernel_shape=[3,3]>(r, WOUT)
+            }}
+            """,
+            initializer=[
+                _f32(w_f, "WF"),
+                _f32(slope, "Slope"),
+                _f32(w_s, "WS"),
+                _f32(w_out, "WOUT"),
+            ],
+        )
+
+    model = _mk(w_f, slope, w_s, w_out)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    assert inits["Slope"].shape == (C // 2, 1, 1)
+    prelu_node = next(n for n in pruned.graph.node if n.op_type == "PRelu")
+    assert len(prelu_node.attribute) == 0
+
+    importance = np.sqrt(
+        np.square(np.linalg.norm(w_f.reshape(C, -1).astype(np.float64), axis=1))
+        + np.square(np.linalg.norm(w_s.reshape(C, -1).astype(np.float64), axis=1))
+    )
+    keep = np.sort(np.argsort(-importance)[: C // 2])
+    oracle = _mk(w_f[keep], slope[keep], w_s[keep], w_out[:, keep])
+
+    rng_x = np.random.default_rng(216)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_matmul_residual_clip_pass_through_hop_matches_oracle():
+    # A Clip crossed by the *backward* MatMul/Gemm walk
+    # (WalkMatmulProducerBackward) -- exercises that insertion point too.
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(217)
+    w_f = rng.standard_normal((K, C)).astype(np.float32)
+    w_s = rng.standard_normal((K, C)).astype(np.float32)
+    w_out = rng.standard_normal((C, Out)).astype(np.float32)
+    min_c = np.array(0.0, dtype=np.float32)
+    max_c = np.array(6.0, dtype=np.float32)
+
+    def _mk(w_f, w_s, w_out):
+        return _model(
+            f"""
+            g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+            {{
+              f0 = MatMul(X, WF)
+              f = Clip(f0, Min, Max)
+              s = MatMul(X, WS)
+              addr = Add(f, s)
+              r = Relu(addr)
+              Y = MatMul(r, WOUT)
+            }}
+            """,
+            initializer=[
+                _f32(w_f, "WF"),
+                _f32(min_c, "Min"),
+                _f32(max_c, "Max"),
+                _f32(w_s, "WS"),
+                _f32(w_out, "WOUT"),
+            ],
+        )
+
+    model = _mk(w_f, w_s, w_out)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    importance = np.sqrt(
+        np.square(np.linalg.norm(w_f.T.astype(np.float64), axis=1))
+        + np.square(np.linalg.norm(w_s.T.astype(np.float64), axis=1))
+    )
+    keep = np.sort(np.argsort(-importance)[: C // 2])
+    oracle = _mk(w_f[:, keep], w_s[:, keep], w_out[keep, :])
+
+    rng_x = np.random.default_rng(218)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
 # --- Concat-merged (skip-connection) chains ----------------------------------
 
 


### PR DESCRIPTION
## Summary

`onnxsim/structured_pruning_entry.cpp` is a C++ port of `onnxsim/pruning.py`'s structured (channel) pruning, kept behavior-identical but covering a smaller subset of topologies than the fast-growing Python reference. This PR closes two concrete gaps:

- **Clip (ReLU6) and PRelu channel pass-through hops** — extends the existing depthwise-Conv-style hop mechanism (`MatchDepthwiseConvPassThrough`) to two more ops that previously blocked the chain walk outright, for both Conv and MatMul/Gemm chains, forward and backward directions. Mirrors `pruning.py`'s `_match_clip_channel_pass_through` / `_match_prelu_pass_through(_self|_matmul|_matmul_self)`.
- **Split gate_up_proj gated-FFN chains** — a new chain family (`FindSplitGatedChains`/`ApplySplitGatedChains`) recognizing the fused Phi-3/Phi-3.5-style shape (one `gate_up_proj` MatMul/Gemm halved by a `Split` into gate/up, combined via `Mul`/native `SwiGLU`), as opposed to the two-separate-producer SwiGLU/GeGLU shape `FindGatedChains` already covers. Mirrors `pruning.py`'s `_find_split_gated_chains`/`_apply_split_gated_chains`, including the "gate and up are two halves of the same physical weight tensor, always kept/dropped together" correctness invariant.

Also fixes a latent bug the PRelu hop would otherwise have hit: `ApplyChains`/`ApplyConcatChains` unconditionally set a `group` attribute on every `conv_pass_through` hop node; now guarded to only fire for actual `Conv` nodes.

## Testing

- `pip install --no-build-isolation -ve .` (wheel build, `ONNXSIM_BUILTIN_ORT=OFF` as usual — no ONNX Runtime C++ build involved)
- `python3 -m pytest -v tests/test_structured_pruning_cpp.py tests/test_pruning_cpp.py tests/test_attention_head_pruning_cpp.py` — 111 passed, 0 failed, including the full pre-existing suite (no regressions)
- `ruff format`/`ruff check` on the touched test file

## Scope / follow-up

This does not close the full Python/C++ parity gap — still missing from the C++ port: GroupNorm/Resize/Pad channel pass-through hops, subgraph (If/Loop/Scan body) recursion, and QDQ/MatMulNBits/int4-quantized structured pruning support. Left for follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4t6ntCm72RfFf64W9GYB1

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4t6ntCm72RfFf64W9GYB1)_