### PR TITLE
Recognize decomposed (opset&lt;=16, not-yet-fused) LayerNorm as a pruning hop

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -281,6 +281,73 @@ residual/gated/`Concat` machinery described below, since all three reuse
 this same :func:`_walk_to_consumer` for their own forward continuation, with
 no composition-specific code of its own.
 
+The fused `LayerNormalization` node the paragraph above recognizes is itself
+only opset 17+ (confirmed live: ``onnx.defs.get_schema("LayerNormalization")
+.since_version == 17`` in this environment's own onnx==1.22.0) -- a model
+exported at opset <= 16, still extremely common (broad runtime/NPU/TensorRT
+compatibility targets, and universal for older exports), has no fused op to
+lower `nn.LayerNorm` to at all, and its exporter emits LayerNorm's own
+canonical decomposition as plain ops instead: confirmed live
+(``torch.onnx.export(nn.LayerNorm(C), ..., opset_version=16)``) to be exactly
+``mean = ReduceMean(x, axes=[-1]); centered = Sub(x, mean); sq = Pow(centered,
+2.0); var = ReduceMean(sq, axes=[-1]); std = Sqrt(Add(var, eps)); normed =
+Div(centered, std); out = Add(Mul(normed, gamma), beta)`` -- `x` read twice
+(by the first `ReduceMean` and by `Sub`), `centered` read twice (by `Pow`
+and by `Div`), every other tensor read once. Without also recognizing this
+shape, a raw, not-yet-fused opset <= 16 export of the exact same "MatMul ->
+LayerNorm -> MatMul" chain the paragraph above handles would silently go
+completely unpruned -- confirmed empirically (see this feature's own
+`tests/test_pruning.py` cases) -- the identical kind of gap the fused-node
+hop above, `BiasGelu`/`FastGelu`, and `SkipLayerNormalization` were each
+added to close for their own not-yet-fused shapes. `_walk_to_consumer`
+recognizes this fixed 9-node sequence too (via
+:func:`_match_decomposed_layer_norm_pass_through`, tried before its own
+ordinary single-hop dispatch specifically because this shape's root tensor
+is read *twice* -- see that function's own docstring for the full node-by-
+node decline conditions and the section comment above `_ConsumerMatch` for
+the exact live-verified shape and the "already folded into initializers by
+the time this pass runs" assumption its `Pow` exponent/`eps` constants,
+like `_match_clip_channel_pass_through`'s own `Clip` bounds, are held to),
+folding all 9 nodes into `chain_ops` in one hop -- only the `Mul`'s `gamma`
+and the final `Add`'s `beta` have anything sliced, held to the exact same
+`_flat_channel_const`/`dims[-1] == n_channels` bar as the fused node's own
+`scale`/`bias`, under the identical correctness argument the paragraph
+above already establishes (matching an independently-, already-pruned
+reference, not "slice after the fact"). Composes with an ordinary
+producer's, a gated combine's, and a `Concat`'s own raw output alike, not
+only with an *already-established* chain (e.g. sitting right after a
+per-channel bias `Add`): since this shape's own root tensor is read twice
+by design, every :func:`_walk_to_consumer` call site that used to gate on a
+strict single-consumer check before ever calling it
+(:func:`_find_chains`/:func:`_find_gated_chains`/
+:func:`_find_split_gated_chains`/:func:`_find_matmul_concat_chains`) now
+uses :func:`_matmul_walk_root_ok` instead -- see its own docstring for why
+dropping that gate down to "not a graph output" is safe for every
+previously-supported shape, not just this one. (`_resolve_matmul_fanout_branches`'s
+own `forced_first_hop` extra-branch resolution is the one exception,
+deliberately not composed with this hop -- see
+:func:`_match_decomposed_layer_norm_pass_through`'s own docstring.) Declines
+outright, never partially matched, on any deviation from this exact 9-node
+shape: an extra reader of
+`x` or `centered` beyond the two each expects, any other intermediate
+tensor read more than once or itself a graph output, a `Pow` exponent that
+isn't confirmed a constant scalar `2.0`, either `ReduceMean`'s own `axes`
+not resolving to exactly the tensor's last axis (the same "axis == -1
+outright, or a positive axis confirmed against a known rank" bar as the
+fused node's own `axis`, see :func:`_axis_resolves_to_last`, factored out
+of :func:`_norm_axis_is_last` and shared with this hop's own
+:func:`_reduce_mean_axis_is_last`), or a non-constant/wrongly-shaped/tied
+`gamma`/`beta` -- the same conservative bar every other hop in this module
+already holds itself to. Like the fused-node hop above, this is a
+MatMul/Gemm-chain-only hop (`_walk_to_consumer` only, never
+:func:`_walk_matmul_producer_backward`, which -- unlike the wider hop set
+its own section comment already describes -- has never recognized even the
+*fused* `_NORM_PASS_THROUGH_OPS` shape either; the far more common shape a
+residual `Add`'s own operand resolves back through is an FFN's down-
+projection or an attention block's own output projection, with no LayerNorm
+in between at all -- see that function's own section comment) and never a
+Conv-chain concept, for the identical reason the fused case already isn't.
+
 A `Concat` merge -- the U-Net-style encoder/decoder skip connection
 (`merged = Concat(a, b, axis=1)`, each branch keeping its own disjoint slice
 of the merged channel range) -- looks at first glance like it needs the same
@@ -3455,36 +3522,56 @@ def _norm_axis(node: onnx.NodeProto) -> int:
     return -1  # schema default for every _NORM_PASS_THROUGH_OPS op
 
 
-def _norm_axis_is_last(
-    node: onnx.NodeProto,
+def _axis_resolves_to_last(
+    axis: int,
     x_name: str,
     value_info_by_name: Optional[Dict[str, onnx.ValueInfoProto]],
 ) -> bool:
-    """True if `node`'s own ``axis`` attribute is confirmed to normalize
-    *only* the last axis of `x_name` -- ``axis == -1`` outright (every one of
-    these ops' own schema already normalizes from `axis` through the last
-    dimension, so ``-1`` unambiguously means exactly one axis, the last,
-    regardless of rank), or a positive `axis` only when `x_name`'s own rank
-    is known (:func:`_tensor_rank`) and equals ``axis == rank - 1`` -- the
-    same reasoning, and the same "decline rather than guess" bar on an
-    unknown rank, as :func:`_concat_axis_is_last`'s own positive-axis case
+    """Shared core of :func:`_norm_axis_is_last` (a `_NORM_PASS_THROUGH_OPS`
+    node's single-int ``axis`` attribute) and
+    :func:`_reduce_mean_axis_is_last` (a plain ``ReduceMean`` node's own
+    single-entry ``axes`` list attribute, part of
+    :func:`_match_decomposed_layer_norm_pass_through`'s own decomposed-LayerNorm
+    shape) -- both resolve one already-extracted candidate `axis` int against
+    `x_name`'s own rank the identical way, so this factors that resolution
+    out rather than duplicating it. True iff `axis` is confirmed to select
+    *only* `x_name`'s own last axis: ``axis == -1`` outright (ONNX's
+    negative-axis convention already counts from the end, so ``-1``
+    unambiguously means exactly one axis, the last, regardless of rank), or
+    a positive `axis` only when `x_name`'s own rank is known
+    (:func:`_tensor_rank`) and equals ``axis == rank - 1`` -- the same
+    reasoning, and the same "decline rather than guess" bar on an unknown
+    rank, as :func:`_concat_axis_is_last`'s own positive-axis case
     (`value_info_by_name` left ``None`` simply narrows this to the `axis ==
     -1` case, never guesses -- every :func:`_walk_to_consumer` caller today
     threads its own graph's `value_info_by_name` through, so this only
     matters for a hypothetical future caller that doesn't). Any other axis
     (e.g. ``-2``, or a positive axis short of ``rank - 1``) spans more than
-    this one trailing channel axis --
-    multi-axis normalization this hop is deliberately out of scope for (see
-    this section's own comment above) -- and is declined here, never guessed
-    at.
+    this one trailing channel axis -- out of scope for either caller -- and
+    is declined here, never guessed at.
     """
-    axis = _norm_axis(node)
     if axis == -1:
         return True
     if axis < 0 or value_info_by_name is None:
         return False
     rank = _tensor_rank(x_name, value_info_by_name)
     return rank is not None and axis == rank - 1
+
+
+def _norm_axis_is_last(
+    node: onnx.NodeProto,
+    x_name: str,
+    value_info_by_name: Optional[Dict[str, onnx.ValueInfoProto]],
+) -> bool:
+    """True if `node`'s own ``axis`` attribute is confirmed to normalize
+    *only* the last axis of `x_name` -- see :func:`_axis_resolves_to_last`
+    (this is simply that shared resolution applied to
+    `_NORM_PASS_THROUGH_OPS`'s own single-int ``axis`` attribute, extracted
+    via :func:`_norm_axis`). Multi-axis normalization (`axis` short of the
+    last dimension) is out of scope for this hop and is declined here, never
+    guessed at.
+    """
+    return _axis_resolves_to_last(_norm_axis(node), x_name, value_info_by_name)
 
 
 def _norm_pass_through_const_names(
@@ -3532,6 +3619,70 @@ def _norm_pass_through_const_names(
     return scale_name, bias_name
 
 
+# Decomposed (not-yet-fused) LayerNorm, recognized by
+# :func:`_match_decomposed_layer_norm_pass_through` as a *second*,
+# multi-node `_walk_to_consumer` hop alongside `_NORM_PASS_THROUGH_OPS`'s own
+# single-node one -- covering a real, common gap the fused-node hop above
+# leaves open. `LayerNormalization`'s own schema is only opset 17+
+# (confirmed live via ``onnx.defs.get_schema("LayerNormalization").since_version
+# == 17`` in this environment's own onnx==1.22.0); a model exported at
+# opset <= 16 -- still extremely common, for broad runtime/NPU/TensorRT
+# compatibility targets, and universal for older exports -- has no fused
+# `LayerNormalization` op to lower `nn.LayerNorm` to at all, so exporters
+# emit its canonical decomposition as plain ops instead. Confirmed live
+# (``torch.onnx.export(nn.LayerNorm(C), ..., opset_version=16)``, both a
+# bare 2-D input and a 3-D ``[batch, seq, C]`` one sitting between two
+# ``Linear`` layers) as exactly this fixed 9-node sequence, `x` the
+# tensor being walked through:
+#
+#     mean     = ReduceMean(x, axes=[-1])
+#     centered = Sub(x, mean)
+#     sq       = Pow(centered, 2.0)
+#     var      = ReduceMean(sq, axes=[-1])
+#     var_eps  = Add(var, eps)
+#     std      = Sqrt(var_eps)
+#     normed   = Div(centered, std)
+#     scaled   = Mul(normed, gamma)
+#     out      = Add(scaled, beta)
+#
+# -- `x` consumed twice (by the first `ReduceMean` and by `Sub`), `centered`
+# consumed twice (by `Pow` and by `Div`), every other intermediate tensor
+# consumed exactly once, `2.0`/`eps` each a ``Constant``-node output in the
+# raw export (not yet an initializer) -- but see this comment's own note
+# below on why that's not what this matcher itself checks for. This is
+# `LayerNormalization`'s own textbook definition (``(x - mean(x)) /
+# sqrt(var(x) + eps) * gamma + beta``), not a coincidence: it's what every
+# ONNX exporter's own decomposition of `aten::layer_norm` reduces to once
+# there's no fused op to target, so this exact shape (short of the two
+# Constant-node/initializer nodes, folded away by the time this pass ever
+# runs -- see below) is expected to recur across exporters and opsets, not
+# a torch-only artifact.
+#
+# Live-checked at opset 18, for comparison: `torch.onnx.export` emits the
+# *fused* `LayerNormalization` node directly there (opset 17+ already makes
+# it available), never this decomposition -- so the decomposed shape below
+# is, in practice, only ever produced at opset <= 16, where `ReduceMean`'s
+# own `axes` is always the attribute form (`_reduce_mean_axis_is_last`'s own
+# comment). This is therefore additive, not overlapping, with the fused-node
+# hop `_NORM_PASS_THROUGH_OPS` already covers -- a real export only ever
+# takes one shape or the other for the same `nn.LayerNorm`, never both.
+#
+# The `2.0` `Pow` exponent and `eps` `Add` operand are fed by ``Constant``
+# nodes, not initializers, in a raw, freshly-exported graph -- but exactly
+# like `_match_clip_channel_pass_through`'s own `ReLU6`-lowered-to-`Clip`
+# case (see that function's own comment), this pass's own docstring already
+# assumes a `Constant` node feeding a *value* no hop here needs to slice has
+# been folded into a plain initializer by the time onnxsim's own optimizer
+# pipeline (which runs before this pruning pass, not as part of it) is done
+# -- the same "constant initializer only" bar every other hop in this module
+# already holds every operand it reads to, never a live graph-walk back
+# through a `Constant` node's own attribute. A model handed to
+# :func:`apply_structured_pruning` with those still live `Constant` nodes
+# (skipping onnxsim's own simplify step) simply declines this hop -- the
+# `Pow`/`Add` operands aren't initializers at all, so
+# :func:`_match_decomposed_layer_norm_pass_through`'s own constant checks
+# fail closed, the same "declined, not guessed at" outcome every other
+# not-yet-folded `Constant` producer already gets here.
 _ConsumerMatch = Tuple[onnx.NodeProto, str, bool]  # (node, weight, weight_transposed)
 
 
@@ -4002,6 +4153,423 @@ def _match_fused_bias_gelu(
     return data_name, bias_name
 
 
+def _reduce_mean_axis_is_last(
+    node: onnx.NodeProto,
+    input_name: str,
+    value_info_by_name: Optional[Dict[str, onnx.ValueInfoProto]],
+) -> bool:
+    """True iff a plain (default-domain) ``ReduceMean`` `node` -- one of
+    :func:`_match_decomposed_layer_norm_pass_through`'s own two ``ReduceMean``
+    nodes, `input_name` its own single input -- is confirmed to reduce
+    *only* `input_name`'s last axis, keeping that axis (size 1) rather than
+    dropping it: the shape LayerNorm's own mean/variance reduction needs.
+    Mirrors :func:`_norm_axis_is_last`'s reasoning (both share
+    :func:`_axis_resolves_to_last`'s own core), adapted for ``ReduceMean``'s
+    own opset <= 17 schema, where ``axes`` is a *list*-valued attribute
+    (confirmed live via ``onnx.defs.get_schema("ReduceMean", 18)``: opset 18
+    moves it to an optional *input* instead -- a form this function
+    deliberately never recognizes, see below), unlike
+    `_NORM_PASS_THROUGH_OPS`'s own single-int ``axis`` attribute.
+
+    Declines (``False``) whenever:
+
+    - `node` isn't a plain ``ReduceMean`` with exactly one input equal to
+      `input_name` (its own opset <= 17 schema takes no other input at all).
+    - ``axes`` is absent -- the schema default then reduces *every* axis,
+      not just the last one, a different computation from LayerNorm's own
+      single-trailing-axis reduction -- or names more than one axis.
+    - ``keepdims`` is anything but its schema default/an explicit ``1``:
+      ``keepdims=0`` would drop the reduced axis entirely rather than
+      leaving it as a broadcastable size-1 axis, breaking the following
+      ``Sub``'s/``Add``'s own broadcast against a higher-rank operand for
+      any rank above 1 -- confirmed live, not a shape torch's own opset <=
+      16 LayerNorm decomposition ever emits, so declined here rather than
+      reasoned through generally.
+    - The one remaining `axes` entry doesn't resolve to `input_name`'s own
+      last axis (:func:`_axis_resolves_to_last` -- same "axis == -1
+      outright, or a positive axis confirmed against a known rank, never
+      guessed at" bar as everywhere else in this module).
+
+    Deliberately doesn't recognize opset 18+'s own optional ``axes`` *input*
+    form at all: live-checked (``torch.onnx.export(nn.LayerNorm(...),
+    opset_version=18, ...)``), a `LayerNorm` module already lowers straight
+    to the *fused* ``LayerNormalization`` op once that op exists (opset 17+,
+    see `_NORM_PASS_THROUGH_OPS`'s own comment) -- the decomposed shape this
+    function exists for is therefore only ever actually produced at
+    opset <= 16 in practice, where ``axes`` is always the attribute form; an
+    opset 18+-style ``axes`` *input* on this exact node shape is not a
+    real-export case this matcher was verified against, so it's left
+    declined rather than guessed at, the same conservative bar as every
+    other unverified shape in this module.
+    """
+    if (
+        node.op_type != "ReduceMean"
+        or node.domain != ""
+        or list(node.input) != [input_name]
+    ):
+        return False
+    axes_attr: Optional[List[int]] = None
+    keepdims = 1
+    for attr in node.attribute:
+        if attr.name == "axes":
+            axes_attr = list(attr.ints)
+        elif attr.name == "keepdims":
+            keepdims = attr.i
+    if keepdims != 1 or axes_attr is None or len(axes_attr) != 1:
+        return False
+    return _axis_resolves_to_last(axes_attr[0], input_name, value_info_by_name)
+
+
+def _decomposed_layer_norm_pow_exponent_is_two(
+    name: str, initializer_map: Dict[str, onnx.TensorProto]
+) -> bool:
+    """True iff `name` names a constant float *scalar* initializer (`dims`
+    exactly ``[]``/``[1]``, mirroring :func:`_match_clip_channel_pass_through`'s
+    own `min`/`max` scalar bar) whose value is exactly ``2.0``. ``Pow``'s own
+    schema (``X, Y -> X ** Y``, a fixed operand order, never commutative)
+    makes `name` its second input; per
+    :func:`_match_decomposed_layer_norm_pass_through`'s own docstring, this
+    confirms the node genuinely computes ``(x - mean) ** 2`` -- LayerNorm's
+    own variance term -- rather than some other exponent this pass has no
+    basis for treating as channel-pruning-safe (it never inspects a
+    surviving weight's own numeric *values* to justify a hop shape the way
+    it does here). Declines (``False``) on a non-constant, non-float,
+    non-scalar, or not-exactly-``2.0`` value -- never guessed at.
+    """
+    init = initializer_map.get(name)
+    if (
+        init is None
+        or not _is_supported_float_dtype(init.data_type)
+        or list(init.dims) not in ([], [1])
+    ):
+        return False
+    values = onnx.numpy_helper.to_array(init).reshape(-1).tolist()
+    return len(values) == 1 and float(values[0]) == 2.0
+
+
+def _flat_scalar_float_const(
+    name: str, initializer_map: Dict[str, onnx.TensorProto]
+) -> bool:
+    """True iff `name` names a constant float *scalar* initializer (`dims`
+    exactly ``[]``/``[1]``, the same bar
+    :func:`_decomposed_layer_norm_pow_exponent_is_two` and
+    :func:`_match_clip_channel_pass_through`'s own `min`/`max` already use) --
+    used by :func:`_match_decomposed_layer_norm_pass_through` for the
+    variance-``Add``'s own ``eps`` operand, whose numeric *value* is never
+    itself inspected (any epsilon is equally safe -- it's never sliced,
+    unlike `gamma`/`beta`, so its own value plays no role in whether pruning
+    ahead of it is safe, only its *shape* does: a non-scalar operand there
+    would mean this isn't really LayerNorm's own scalar-epsilon variance
+    term at all, and is declined the same conservative way, never guessed
+    at).
+    """
+    init = initializer_map.get(name)
+    return (
+        init is not None
+        and _is_supported_float_dtype(init.data_type)
+        and list(init.dims) in ([], [1])
+    )
+
+
+def _match_decomposed_layer_norm_pass_through(
+    x_name: str,
+    consumers_of: Dict[str, List[onnx.NodeProto]],
+    initializer_map: Dict[str, onnx.TensorProto],
+    graph_outputs: Set[str],
+    n_channels: int,
+    value_info_by_name: Optional[Dict[str, onnx.ValueInfoProto]],
+) -> Optional[Tuple[str, Tuple[Tuple[onnx.NodeProto, Optional[str]], ...]]]:
+    """If `x_name` is the root of exactly the fixed 9-node decomposed-
+    LayerNorm sequence documented in this section's own comment above
+    `_ConsumerMatch` -- confirmed live via ``torch.onnx.export(nn.LayerNorm(C),
+    ..., opset_version=16)`` -- returns ``(out_name, chain_ops)``: `out_name`
+    the sequence's own true final output (the tensor :func:`_walk_to_consumer`
+    should continue walking from), `chain_ops` all 9 nodes in walk order as
+    ``(node, const_name_or_None)`` pairs ready to fold directly into a
+    :class:`_Chain`'s own `chain_ops` field -- only the `Mul`'s `gamma`
+    (input 1) and the final `Add`'s `beta` (input 1) have anything to slice;
+    every other node's own entry carries ``None`` (the `Pow` exponent and
+    variance-``Add``'s own `eps` are scalars, never sliced at all -- see
+    `_decomposed_layer_norm_pow_exponent_is_two`'s/`_flat_scalar_float_const`'s
+    own comments).
+
+    Unlike this module's other single-node hop matchers, `x_name` itself
+    (not just some node's `.input[0]`) is the very thing being matched here
+    -- this is a *multi*-node hop, called by :func:`_walk_to_consumer` at two
+    points: before its own ordinary "exactly one consumer" dispatch (`cur`
+    itself the sequence's own root, e.g. a producer's raw output feeding the
+    sequence directly), and again as a fallback wherever an *ordinary* hop's
+    own output would otherwise fail that dispatch's single-consumer bar
+    (e.g. a per-channel bias `Add` whose own output feeds the sequence
+    instead of continuing as an ordinary single-consumer hop) -- both exist
+    because this shape's own root tensor is read *twice* (by the sequence's
+    first ``ReduceMean`` and by its ``Sub``), a shape the ordinary
+    single-consumer walk can never reach on its own from either point. Every
+    other tensor inside the sequence
+    is held to the exact same "no stray fan-out" bar every other hop in this
+    module already applies -- exactly one consumer, and not itself a graph
+    output (`graph_outputs`) -- except `centered` (`Sub`'s own output),
+    which -- like `x_name` -- is read twice by design (`Pow` and `Div`).
+    Declines (``None``, never partially matched) on:
+
+    - `x_name` read by anything other than exactly one ``ReduceMean`` and
+      one ``Sub`` (in particular, a *third* reader of any kind).
+    - Either ``ReduceMean`` not confirmed to reduce exactly `x_name`'s (or
+      the first one's own output squared) last axis
+      (:func:`_reduce_mean_axis_is_last`) -- the axis this pass is actually
+      pruning.
+    - `Sub`'s own inputs not exactly ``(x_name, mean)`` in that fixed
+      (schema-mandated, non-commutative) order.
+    - `centered` (`Sub`'s output) read by anything other than exactly one
+      ``Pow`` and one ``Div``.
+    - `Pow`'s own inputs not exactly ``(centered, <scalar 2.0>)``
+      (:func:`_decomposed_layer_norm_pow_exponent_is_two`) in that fixed,
+      schema-mandated order.
+    - The second ``ReduceMean``'s own input not exactly `Pow`'s own output,
+      or (again) not confirmed to reduce that tensor's own last axis.
+    - The variance ``Add`` not exactly ``Add(var, eps)`` (either operand
+      order -- `Add` is commutative) with `eps` a genuine scalar constant
+      (:func:`_flat_scalar_float_const`) distinct from `var`.
+    - ``Sqrt``'s own input not exactly the variance ``Add``'s own output.
+    - `std` (``Sqrt``'s output) not read by *the exact same* ``Div`` node
+      already identified above as `centered`'s own second reader -- ruling
+      out a graph that merely happens to have *a* ``Div`` node consuming
+      `std`, a different one from the one consuming `centered`.
+    - ``Div``'s own inputs not exactly ``(centered, std)`` in that fixed,
+      schema-mandated order.
+    - `Mul`'s own inputs not exactly ``(normed, gamma)`` (either operand
+      order) with `gamma` a genuine constant float flat per-channel vector
+      (:func:`_flat_channel_const`, the same bar
+      :func:`_norm_pass_through_const_names`'s own `scale` already uses)
+      whose `dims[-1]` matches `n_channels` -- the real channel-count check
+      every hop in this module ultimately applies to its own per-channel
+      operand, distinct from `normed`.
+    - The final `Add`'s own inputs not exactly ``(scaled, beta)`` (either
+      operand order) with `beta` held to the identical bar as `gamma` above
+      -- distinct from `scaled` *and* from `gamma` itself (a tied
+      `gamma`/`beta` would be double-sliced by :func:`_apply_chains`'s own
+      per-hop loop, corrupting it, exactly the concern
+      `_norm_pass_through_const_names`'s own tied-`scale`/`bias` check
+      already guards against).
+    - Any intermediate tensor along the way (`mean`, `sq`, `var`, `var_eps`,
+      `std`, `normed`, `scaled`) itself a graph output, or read by anything
+      other than the one node this sequence's own fixed shape expects.
+
+    The sequence's own true final output (the last ``Add``'s own output) is
+    *not* itself checked against `graph_outputs`/single-consumer here --
+    exactly like an ordinary single-node hop's own `out2`, that check is the
+    caller's (:func:`_walk_to_consumer`'s own per-iteration "cur" check),
+    applied uniformly whether `cur` arrived via an ordinary hop or this one.
+    """
+    x_consumers = consumers_of.get(x_name, [])
+    if len(x_consumers) != 2:
+        return None
+    reduce_mean: Optional[onnx.NodeProto] = None
+    sub: Optional[onnx.NodeProto] = None
+    for cand in x_consumers:
+        if cand.op_type == "ReduceMean" and reduce_mean is None:
+            reduce_mean = cand
+        elif cand.op_type == "Sub" and sub is None:
+            sub = cand
+    if reduce_mean is None or sub is None or reduce_mean is sub:
+        return None
+    if len(reduce_mean.output) != 1 or not reduce_mean.output[0]:
+        return None
+    if not _reduce_mean_axis_is_last(reduce_mean, x_name, value_info_by_name):
+        return None
+    mean_name = reduce_mean.output[0]
+    if mean_name in graph_outputs:
+        return None
+    if len(consumers_of.get(mean_name, [])) != 1:
+        return None
+
+    if (
+        sub.domain != ""
+        or list(sub.input) != [x_name, mean_name]
+        or len(sub.output) != 1
+        or not sub.output[0]
+    ):
+        return None
+    centered_name = sub.output[0]
+    if centered_name in graph_outputs:
+        return None
+    centered_consumers = consumers_of.get(centered_name, [])
+    if len(centered_consumers) != 2:
+        return None
+    pow_node: Optional[onnx.NodeProto] = None
+    div_node: Optional[onnx.NodeProto] = None
+    for cand in centered_consumers:
+        if cand.op_type == "Pow" and pow_node is None:
+            pow_node = cand
+        elif cand.op_type == "Div" and div_node is None:
+            div_node = cand
+    if pow_node is None or div_node is None or pow_node is div_node:
+        return None
+
+    if (
+        pow_node.domain != ""
+        or len(pow_node.input) != 2
+        or pow_node.input[0] != centered_name
+        or len(pow_node.output) != 1
+        or not pow_node.output[0]
+        or not _decomposed_layer_norm_pow_exponent_is_two(
+            pow_node.input[1], initializer_map
+        )
+    ):
+        return None
+    sq_name = pow_node.output[0]
+    if sq_name in graph_outputs or len(consumers_of.get(sq_name, [])) != 1:
+        return None
+
+    var_reduce = consumers_of[sq_name][0]
+    if len(var_reduce.output) != 1 or not var_reduce.output[0]:
+        return None
+    if not _reduce_mean_axis_is_last(var_reduce, sq_name, value_info_by_name):
+        return None
+    var_name = var_reduce.output[0]
+    if var_name in graph_outputs:
+        return None
+    if len(consumers_of.get(var_name, [])) != 1:
+        return None
+
+    add_eps = consumers_of[var_name][0]
+    if (
+        add_eps.op_type != "Add"
+        or add_eps.domain != ""
+        or len(add_eps.input) != 2
+        or var_name not in add_eps.input
+        or len(add_eps.output) != 1
+        or not add_eps.output[0]
+    ):
+        return None
+    eps_name = add_eps.input[1] if add_eps.input[0] == var_name else add_eps.input[0]
+    if eps_name == var_name or not _flat_scalar_float_const(eps_name, initializer_map):
+        return None
+    var_eps_name = add_eps.output[0]
+    if var_eps_name in graph_outputs or len(consumers_of.get(var_eps_name, [])) != 1:
+        return None
+
+    sqrt_node = consumers_of[var_eps_name][0]
+    if (
+        sqrt_node.op_type != "Sqrt"
+        or sqrt_node.domain != ""
+        or list(sqrt_node.input) != [var_eps_name]
+        or len(sqrt_node.output) != 1
+        or not sqrt_node.output[0]
+    ):
+        return None
+    std_name = sqrt_node.output[0]
+    if std_name in graph_outputs or len(consumers_of.get(std_name, [])) != 1:
+        return None
+    if consumers_of[std_name][0] is not div_node:
+        return None  # std must feed the *same* Div node `centered` forked to
+
+    if (
+        div_node.domain != ""
+        or list(div_node.input) != [centered_name, std_name]
+        or len(div_node.output) != 1
+        or not div_node.output[0]
+    ):
+        return None
+    normed_name = div_node.output[0]
+    if normed_name in graph_outputs or len(consumers_of.get(normed_name, [])) != 1:
+        return None
+
+    mul_node = consumers_of[normed_name][0]
+    if (
+        mul_node.op_type != "Mul"
+        or mul_node.domain != ""
+        or len(mul_node.input) != 2
+        or normed_name not in mul_node.input
+        or len(mul_node.output) != 1
+        or not mul_node.output[0]
+    ):
+        return None
+    gamma_name = (
+        mul_node.input[1] if mul_node.input[0] == normed_name else mul_node.input[0]
+    )
+    if (
+        gamma_name == normed_name
+        or not _flat_channel_const(gamma_name, initializer_map)
+        or initializer_map[gamma_name].dims[-1] != n_channels
+    ):
+        return None
+    scaled_name = mul_node.output[0]
+    if scaled_name in graph_outputs or len(consumers_of.get(scaled_name, [])) != 1:
+        return None
+
+    add_beta = consumers_of[scaled_name][0]
+    if (
+        add_beta.op_type != "Add"
+        or add_beta.domain != ""
+        or len(add_beta.input) != 2
+        or scaled_name not in add_beta.input
+        or len(add_beta.output) != 1
+        or not add_beta.output[0]
+    ):
+        return None
+    beta_name = (
+        add_beta.input[1] if add_beta.input[0] == scaled_name else add_beta.input[0]
+    )
+    if (
+        beta_name == scaled_name
+        or beta_name == gamma_name  # tied gamma/beta -- double-slicing corrupts it
+        or not _flat_channel_const(beta_name, initializer_map)
+        or initializer_map[beta_name].dims[-1] != n_channels
+    ):
+        return None
+
+    out_name = add_beta.output[0]
+    chain_ops: Tuple[Tuple[onnx.NodeProto, Optional[str]], ...] = (
+        (reduce_mean, None),
+        (sub, None),
+        (pow_node, None),
+        (var_reduce, None),
+        (add_eps, None),
+        (sqrt_node, None),
+        (div_node, None),
+        (mul_node, gamma_name),
+        (add_beta, beta_name),
+    )
+    return out_name, chain_ops
+
+
+def _matmul_walk_root_ok(name: str, graph_outputs: Set[str]) -> bool:
+    """True unless `name` is itself a graph output -- the one condition
+    :func:`_walk_to_consumer` can never itself recover from once called (a
+    caller-observed tensor's own shape must never silently change out from
+    under it). Every *other* "is this safe to walk forward from" question --
+    an ordinary single consumer, or the decomposed-LayerNorm-root
+    *two*-consumer shape :func:`_match_decomposed_layer_norm_pass_through`
+    recognizes -- is left entirely to :func:`_walk_to_consumer`'s own hop-0
+    dispatch, which declines (returns no consumer, `(None, ())`) exactly the
+    same way skipping the call here already did for every case this module
+    supported before that hop existed: a tensor with zero consumers, or two
+    or more that don't happen to match the decomposed-LayerNorm shape,
+    still makes the very first hop's own dispatch fail immediately, with no
+    wasted walking.
+
+    Used, in place of a plain `_is_internal(out_name)` single-consumer gate,
+    by every :func:`_find_chains`/:func:`_find_gated_chains`/
+    :func:`_find_split_gated_chains`/:func:`_find_matmul_concat_chains` call
+    site that hands `_walk_to_consumer` a producer's, a gated combine's, or
+    a `Concat`'s own raw output as `start` -- the shape a decomposed
+    LayerNorm sitting *directly* on that root (no ordinary hop first) needs,
+    since its own root tensor is read twice by design and a strict
+    single-consumer gate would otherwise always reject it before the walk
+    ever got a chance to try (mirroring the identical fallback
+    :func:`_walk_to_consumer` itself already needs for an *ordinary* hop's
+    own output landing on such a root -- see its own top-of-loop and `out2`
+    comments). Never used ahead of a `forced_first_hop` call
+    (:func:`_resolve_matmul_fanout_branches`'s own extra-branch resolution):
+    `forced_first_hop` always takes hop 0's own dispatch directly, so this
+    hop can never be reached there regardless -- that composition is
+    deliberately out of this hop's scope, see
+    :func:`_match_decomposed_layer_norm_pass_through`'s own docstring.
+    """
+    return name not in graph_outputs
+
+
 def _walk_to_consumer(
     start: str,
     initializer_map: Dict[str, onnx.TensorProto],
@@ -4019,20 +4587,23 @@ def _walk_to_consumer(
     :func:`_match_fused_bias_gelu` -- a plain `_NORM_PASS_THROUGH_OPS`
     node whose own ``axis`` normalizes exactly `cur`'s last axis -- see that
     constant's own comment, :func:`_norm_axis_is_last`, and
-    :func:`_norm_pass_through_const_names` -- a ``PRelu`` node (see
-    :func:`_match_prelu_pass_through_matmul`): a *scalar* or
-    single-shared-parameter `slope` (every dimension size 1) needs no
-    operand of its own sliced, the same shape a plain unary activation hop
-    already gets; a *per-channel* `slope` (flat, last-axis-is-channel,
-    exactly :func:`_flat_channel_const`'s own bar) is co-sliced exactly like
-    an `Add`/`Mul` hop's own constant already is -- or a channel-agnostic
-    ``Clip`` (see :func:`_match_clip_channel_pass_through`, the QAT-style
-    activation-clipping-after-Linear shape, needing no axis reasoning at all
-    since neither `min` nor `max` is axis-indexed to begin with) with no
-    other consumer anywhere along the way, until a MatMul/vanilla-Gemm
-    consumer is found whose reduction dimension matches `n_channels`.
-    Returns ``(None, ())`` if the walk runs out of hops, hits a branch, or
-    never reaches such a consumer.
+    :func:`_norm_pass_through_const_names` -- or the *decomposed*, not-yet-
+    fused LayerNorm sequence a raw opset <= 16 export emits instead of a
+    fused `_NORM_PASS_THROUGH_OPS` node (see the section comment above
+    `_ConsumerMatch` and :func:`_match_decomposed_layer_norm_pass_through`)
+    -- a ``PRelu`` node (see :func:`_match_prelu_pass_through_matmul`): a
+    *scalar* or single-shared-parameter `slope` (every dimension size 1)
+    needs no operand of its own sliced, the same shape a plain unary
+    activation hop already gets; a *per-channel* `slope` (flat,
+    last-axis-is-channel, exactly :func:`_flat_channel_const`'s own bar) is
+    co-sliced exactly like an `Add`/`Mul` hop's own constant already is --
+    or a channel-agnostic ``Clip`` (see :func:`_match_clip_channel_pass_through`,
+    the QAT-style activation-clipping-after-Linear shape, needing no axis
+    reasoning at all since neither `min` nor `max` is axis-indexed to begin
+    with) with no other consumer anywhere along the way, until a
+    MatMul/vanilla-Gemm consumer is found whose reduction dimension matches
+    `n_channels`. Returns ``(None, ())`` if the walk runs out of hops, hits
+    a branch, or never reaches such a consumer.
 
     `forced_first_hop`, when given, is used as the walk's very first hop
     instead of deriving it from `consumers_of[start]` -- see
@@ -4058,6 +4629,30 @@ def _walk_to_consumer(
         if _hop == 0 and forced_first_hop is not None:
             nxt = forced_first_hop
         else:
+            # Tried before the ordinary "exactly one consumer" dispatch
+            # below, since a decomposed LayerNorm's own root tensor is read
+            # *twice* (by its first `ReduceMean` and its `Sub`) -- a shape
+            # that dispatch can never reach on its own. Declines instantly
+            # (returns `None`) whenever `cur` doesn't have exactly two
+            # consumers, so this costs an ordinary hop nothing. Not
+            # attempted alongside `forced_first_hop` (`_hop == 0` there
+            # always takes the branch above instead) -- see
+            # :func:`_match_decomposed_layer_norm_pass_through`'s own
+            # docstring; that composition is out of this hop's scope.
+            ln_match = _match_decomposed_layer_norm_pass_through(
+                cur,
+                consumers_of,
+                initializer_map,
+                graph_outputs,
+                n_channels,
+                value_info_by_name,
+            )
+            if ln_match is not None:
+                ln_out_name, ln_chain_ops = ln_match
+                chain_ops.extend(ln_chain_ops)
+                cur = ln_out_name
+                continue
+
             candidates = consumers_of.get(cur, [])
             if len(candidates) != 1:
                 break
@@ -4169,12 +4764,42 @@ def _walk_to_consumer(
             break
 
         out2 = nxt.output[0]
-        if len(consumers_of.get(out2, [])) != 1 or out2 in graph_outputs:
+        if out2 in graph_outputs:
             break
+        # Ordinarily `out2` must have exactly one consumer to safely become
+        # the walk's new `cur` -- but a decomposed LayerNorm's own root
+        # tensor is, by its own fixed shape, read *twice* (see
+        # :func:`_match_decomposed_layer_norm_pass_through`'s own
+        # docstring), so an `out2` this hop produces right where such a
+        # sequence begins (e.g. a bias `Add` feeding both the sequence's own
+        # `ReduceMean` and `Sub`) would otherwise always fail this check and
+        # break the walk before ever reaching the top-of-loop dispatch that
+        # tries this hop for `cur` -- that dispatch only ever sees `cur`
+        # *after* a hop already committed to advancing past it. Trying the
+        # same matcher here first, before the ordinary single-consumer bar,
+        # closes that gap: every other multi-consumer `out2` still declines
+        # exactly as before.
+        ln_match = None
+        if len(consumers_of.get(out2, [])) != 1:
+            ln_match = _match_decomposed_layer_norm_pass_through(
+                out2,
+                consumers_of,
+                initializer_map,
+                graph_outputs,
+                n_channels,
+                value_info_by_name,
+            )
+            if ln_match is None:
+                break
         chain_ops.append((nxt, const_name))
         if extra_const_name is not None:
             chain_ops.append((nxt, extra_const_name))
-        cur = out2
+        if ln_match is not None:
+            ln_out_name, ln_chain_ops = ln_match
+            chain_ops.extend(ln_chain_ops)
+            cur = ln_out_name
+        else:
+            cur = out2
 
     return consumer, tuple(chain_ops)
 
@@ -4185,11 +4810,6 @@ def _find_chains(graph: onnx.GraphProto) -> List[_Chain]:
     graph_outputs = {o.name for o in graph.output}
     value_info_by_name = _value_info_by_name(graph)
 
-    def _is_internal(name: str) -> bool:
-        # Safe to reshape only if exactly one node reads it and it isn't
-        # itself something the caller observes (a graph output).
-        return len(consumers_of.get(name, [])) == 1 and name not in graph_outputs
-
     chains = []
     for node in graph.node:
         info = _match_producer(node, initializer_map)
@@ -4198,7 +4818,7 @@ def _find_chains(graph: onnx.GraphProto) -> List[_Chain]:
         w_name, weight_transposed, bias_name, n_channels = info
 
         out_name = node.output[0]
-        if not _is_internal(out_name):
+        if not _matmul_walk_root_ok(out_name, graph_outputs):
             continue
 
         consumer, chain_ops = _walk_to_consumer(
@@ -7420,7 +8040,7 @@ def _find_gated_chains(graph: onnx.GraphProto) -> List[_Chain]:
             continue
 
         out_name = node.output[0]
-        if not _is_internal(out_name):
+        if not _matmul_walk_root_ok(out_name, graph_outputs):
             continue
 
         consumer, chain_ops = _walk_to_consumer(
@@ -7859,7 +8479,7 @@ def _find_split_gated_chains(graph: onnx.GraphProto) -> List[_SplitGatedChain]:
         ]
 
         out_name = node.output[0]
-        if not _is_internal(out_name):
+        if not _matmul_walk_root_ok(out_name, graph_outputs):
             continue
 
         consumer, chain_ops = _walk_to_consumer(
@@ -8737,9 +9357,6 @@ def _find_matmul_concat_chains(graph: onnx.GraphProto) -> List[_ConcatChain]:
                 n_channels,
             )
 
-    def _is_internal(name: str) -> bool:
-        return len(consumers_of.get(name, [])) == 1 and name not in graph_outputs
-
     chains: List[_ConcatChain] = []
     for node in graph.node:
         if node.op_type != "Concat" or len(node.input) < 2 or len(node.output) != 1:
@@ -8857,7 +9474,7 @@ def _find_matmul_concat_chains(graph: onnx.GraphProto) -> List[_ConcatChain]:
             continue
 
         out_name = node.output[0]
-        if not _is_internal(out_name):
+        if not _matmul_walk_root_ok(out_name, graph_outputs):
             continue
         total_n = offset
         consumer, fwd_chain_ops = _walk_to_consumer(

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -3038,6 +3038,336 @@ def test_structured_pruning_layer_norm_positive_axis_needs_known_rank():
     assert list(inits["Gamma"].dims) == [C // 2]
 
 
+# --- apply_structured_pruning: *decomposed* (not-yet-fused) LayerNorm -------
+#
+# `LayerNormalization`'s own schema is only opset 17+ (confirmed live:
+# `onnx.defs.get_schema("LayerNormalization").since_version == 17`), so an
+# export at opset <= 16 -- still extremely common -- has no fused op to lower
+# `nn.LayerNorm` to at all. Confirmed live (`torch.onnx.export(nn.LayerNorm(C),
+# ..., opset_version=16)`, both a bare 2-D input and a 3-D one sitting between
+# two Linear layers), the exporter emits the exact 9-node canonical
+# decomposition below instead -- `up` read twice (by the first `ReduceMean`
+# and by `Sub`), `centered` read twice (by `Pow` and by `Div`), every other
+# tensor read once. At opset 18 the very same `nn.LayerNorm` module lowers
+# straight to the fused op instead (also confirmed live) -- so this is a
+# second, additive shape, never overlapping with the fused-node hop tested
+# above for the same module. `_match_decomposed_layer_norm_pass_through`
+# recognizes it as one more `_walk_to_consumer` hop; before this pass gained
+# it, this exact "MatMul -> decomposed LayerNorm -> MatMul" chain went
+# completely unpruned (confirmed independently against this task's own base
+# commit before this feature existed).
+
+
+def _decomposed_layer_norm_model(w1, gamma, beta, w2, axis=-1, opset=16, pow_exp=2.0):
+    K, C = w1.shape
+    Out = w2.shape[1]
+    initializer = [
+        _f32(w1, "W1"),
+        onnx.numpy_helper.from_array(np.array(pow_exp, dtype=np.float32), "Two"),
+        onnx.numpy_helper.from_array(np.array(1e-5, dtype=np.float32), "Eps"),
+        _f32(gamma, "Gamma"),
+        _f32(beta, "Beta"),
+        _f32(w2, "W2"),
+    ]
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          up = MatMul(X, W1)
+          mean = ReduceMean<axes=[{axis}]>(up)
+          centered = Sub(up, mean)
+          sq = Pow(centered, Two)
+          var = ReduceMean<axes=[{axis}]>(sq)
+          var_eps = Add(var, Eps)
+          std = Sqrt(var_eps)
+          normed = Div(centered, std)
+          scaled = Mul(normed, Gamma)
+          h = Add(scaled, Beta)
+          Y = MatMul(h, W2)
+        }}
+        """,
+        initializer=initializer,
+        opset=opset,
+    )
+
+
+def test_structured_pruning_decomposed_layer_norm_pass_through_shrinks_matched_layers():
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(240)
+    w1 = rng.standard_normal((K, C)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    beta = rng.standard_normal((C,)).astype(np.float32)
+    w2 = rng.standard_normal((C, Out)).astype(np.float32)
+    model = _decomposed_layer_norm_model(w1, gamma, beta, w2)
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [K, C // 2]
+    assert list(inits["Gamma"].dims) == [C // 2]
+    assert list(inits["Beta"].dims) == [C // 2]
+    assert list(inits["W2"].dims) == [C // 2, Out]
+    # Every decomposition node itself is untouched (still the same 9 nodes,
+    # same op types/wiring) -- only the two per-channel constants shrink.
+    assert [n.op_type for n in pruned.graph.node] == [
+        "MatMul",
+        "ReduceMean",
+        "Sub",
+        "Pow",
+        "ReduceMean",
+        "Add",
+        "Sqrt",
+        "Div",
+        "Mul",
+        "Add",
+        "MatMul",
+    ]
+
+
+def test_structured_pruning_decomposed_layer_norm_pass_through_matches_oracle_adversarially():
+    # Mirrors test_structured_pruning_layer_norm_pass_through_matches_oracle_adversarially
+    # exactly, for the decomposed shape: W1 engineered so the surviving `keep`
+    # set is deliberately not the first C//2 channels, Gamma/Beta spanning
+    # three orders of magnitude, strictly increasing by channel index -- a
+    # positional (rather than index-set) slice of Gamma/Beta would misapply a
+    # wildly-wrong-magnitude affine term to a kept channel, detectably wrong
+    # by orders of magnitude. The reference is built from scratch (never a
+    # post-hoc slice of the full unpruned model's own output), run through
+    # real onnxruntime.
+    K, C, Out = 4, 8, 2
+    rng = np.random.default_rng(241)
+    col_scale = np.linspace(0.1, 2.0, C).astype(np.float32)
+    w1 = (rng.standard_normal((K, C)) * col_scale).astype(np.float32)
+    gamma = (np.arange(1, C + 1, dtype=np.float64) * 0.001).astype(np.float32)
+    beta = (np.arange(1, C + 1, dtype=np.float64) * 1000.0).astype(np.float32)
+    w2 = rng.standard_normal((C, Out)).astype(np.float32)
+    model = _decomposed_layer_norm_model(w1, gamma, beta, w2)
+    onnx.checker.check_model(model)
+
+    keep_count = C // 2
+    keep = _oracle_keep_indices(w1, keep_count)
+    assert not np.array_equal(keep, np.arange(keep_count))  # confirm adversarial
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+
+    def _layer_norm(v, g, b, eps=1e-5):
+        mean = v.mean(axis=-1, keepdims=True)
+        var = v.var(axis=-1, keepdims=True)
+        return (v - mean) / np.sqrt(var + eps) * g + b
+
+    h_correct = _layer_norm(x @ w1[:, keep], gamma[keep], beta[keep])
+    y_correct = h_correct @ w2[keep, :]
+    np.testing.assert_allclose(y, y_correct, rtol=1e-4, atol=1e-4)
+
+    wrong_gamma = gamma[:keep_count]
+    wrong_beta = beta[:keep_count]
+    h_wrong = _layer_norm(x @ w1[:, keep], wrong_gamma, wrong_beta)
+    y_wrong = h_wrong @ w2[keep, :]
+    assert np.max(np.abs(y - y_wrong)) > 1e-2 * max(1.0, np.max(np.abs(y_correct)))
+
+
+def test_structured_pruning_decomposed_layer_norm_pow_exponent_not_two_is_declined():
+    # Pow's own exponent must be confirmed a genuine constant scalar 2 (the
+    # variance term LayerNorm's own math actually computes) -- any other
+    # exponent is a different computation this pass has no basis for treating
+    # as channel-pruning-safe, and must be declined outright, never guessed
+    # at.
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(242)
+    w1 = rng.standard_normal((K, C)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    beta = rng.standard_normal((C,)).astype(np.float32)
+    w2 = rng.standard_normal((C, Out)).astype(np.float32)
+    model = _decomposed_layer_norm_model(w1, gamma, beta, w2, pow_exp=3.0)
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
+def test_structured_pruning_decomposed_layer_norm_axis_not_last_is_declined():
+    # axis=-2 on a rank-2 [batch, C] tensor normalizes over the batch axis,
+    # not the trailing channel axis being pruned -- out of this hop's own
+    # declared scope, mirroring the fused-node axis=-2 decline case above.
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(243)
+    w1 = rng.standard_normal((K, C)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    beta = rng.standard_normal((C,)).astype(np.float32)
+    w2 = rng.standard_normal((C, Out)).astype(np.float32)
+    model = _decomposed_layer_norm_model(w1, gamma, beta, w2, axis=-2)
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
+def test_structured_pruning_decomposed_layer_norm_extra_root_consumer_is_declined():
+    # `up` (the decomposition's own root tensor) must be read by *exactly*
+    # the ReduceMean/Sub pair this shape expects -- a third reader (here, an
+    # extra Identity tapping the same tensor for a second graph output) means
+    # this pass can no longer prove pruning `up`'s channels leaves that third
+    # reader's own expectations intact, so the whole chain is declined
+    # outright, never partially matched.
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(244)
+    w1 = rng.standard_normal((K, C)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    beta = rng.standard_normal((C,)).astype(np.float32)
+    w2 = rng.standard_normal((C, Out)).astype(np.float32)
+    initializer = [
+        _f32(w1, "W1"),
+        onnx.numpy_helper.from_array(np.array(2.0, dtype=np.float32), "Two"),
+        onnx.numpy_helper.from_array(np.array(1e-5, dtype=np.float32), "Eps"),
+        _f32(gamma, "Gamma"),
+        _f32(beta, "Beta"),
+        _f32(w2, "W2"),
+    ]
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y, float[batch,{C}] Extra)
+        {{
+          up = MatMul(X, W1)
+          Extra = Identity(up)
+          mean = ReduceMean<axes=[-1]>(up)
+          centered = Sub(up, mean)
+          sq = Pow(centered, Two)
+          var = ReduceMean<axes=[-1]>(sq)
+          var_eps = Add(var, Eps)
+          std = Sqrt(var_eps)
+          normed = Div(centered, std)
+          scaled = Mul(normed, Gamma)
+          h = Add(scaled, Beta)
+          Y = MatMul(h, W2)
+        }}
+        """,
+        initializer=initializer,
+        opset=16,
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
+def test_structured_pruning_decomposed_layer_norm_extra_centered_consumer_is_declined():
+    # `centered` (Sub's own output) must likewise be read by *exactly* the
+    # Pow/Div pair this shape expects -- an extra reader is declined the
+    # same conservative way as an extra reader of `up` above.
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(245)
+    w1 = rng.standard_normal((K, C)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    beta = rng.standard_normal((C,)).astype(np.float32)
+    w2 = rng.standard_normal((C, Out)).astype(np.float32)
+    initializer = [
+        _f32(w1, "W1"),
+        onnx.numpy_helper.from_array(np.array(2.0, dtype=np.float32), "Two"),
+        onnx.numpy_helper.from_array(np.array(1e-5, dtype=np.float32), "Eps"),
+        _f32(gamma, "Gamma"),
+        _f32(beta, "Beta"),
+        _f32(w2, "W2"),
+    ]
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y, float[batch,{C}] Extra)
+        {{
+          up = MatMul(X, W1)
+          mean = ReduceMean<axes=[-1]>(up)
+          centered = Sub(up, mean)
+          Extra = Identity(centered)
+          sq = Pow(centered, Two)
+          var = ReduceMean<axes=[-1]>(sq)
+          var_eps = Add(var, Eps)
+          std = Sqrt(var_eps)
+          normed = Div(centered, std)
+          scaled = Mul(normed, Gamma)
+          h = Add(scaled, Beta)
+          Y = MatMul(h, W2)
+        }}
+        """,
+        initializer=initializer,
+        opset=16,
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
+def test_structured_pruning_decomposed_layer_norm_after_bias_add_matches_oracle():
+    # The decomposition's own root tensor (`up`, read twice) sitting right
+    # after an ordinary preceding hop (a per-channel bias `Add`, itself
+    # producing a tensor read twice) -- confirms the fix composes with an
+    # already-established chain_ops hop, not just a bare producer output
+    # feeding the decomposition directly (every test above starts the
+    # decomposition right at the MatMul's own raw output).
+    K, C, Out = 6, 12, 3
+    rng = np.random.default_rng(246)
+    w1 = rng.standard_normal((K, C)).astype(np.float32)
+    b1 = rng.standard_normal((C,)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    beta = rng.standard_normal((C,)).astype(np.float32)
+    w2 = rng.standard_normal((C, Out)).astype(np.float32)
+    initializer = [
+        _f32(w1, "W1"),
+        _f32(b1, "B1"),
+        onnx.numpy_helper.from_array(np.array(2.0, dtype=np.float32), "Two"),
+        onnx.numpy_helper.from_array(np.array(1e-5, dtype=np.float32), "Eps"),
+        _f32(gamma, "Gamma"),
+        _f32(beta, "Beta"),
+        _f32(w2, "W2"),
+    ]
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          mm = MatMul(X, W1)
+          up = Add(mm, B1)
+          mean = ReduceMean<axes=[-1]>(up)
+          centered = Sub(up, mean)
+          sq = Pow(centered, Two)
+          var = ReduceMean<axes=[-1]>(sq)
+          var_eps = Add(var, Eps)
+          std = Sqrt(var_eps)
+          normed = Div(centered, std)
+          scaled = Mul(normed, Gamma)
+          h = Add(scaled, Beta)
+          Y = MatMul(h, W2)
+        }}
+        """,
+        initializer=initializer,
+        opset=16,
+    )
+    onnx.checker.check_model(model)
+
+    keep_count = C // 2
+    keep = _oracle_keep_indices(w1, keep_count)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Gamma"].dims) == [keep_count]
+
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+
+    def _layer_norm(v, g, b, eps=1e-5):
+        mean = v.mean(axis=-1, keepdims=True)
+        var = v.var(axis=-1, keepdims=True)
+        return (v - mean) / np.sqrt(var + eps) * g + b
+
+    up_ref = x @ w1[:, keep] + b1[keep]
+    h_correct = _layer_norm(up_ref, gamma[keep], beta[keep])
+    y_correct = h_correct @ w2[keep, :]
+    np.testing.assert_allclose(y, y_correct, rtol=1e-4, atol=1e-4)
+
+
 def test_structured_pruning_gated_ffn_layer_norm_pass_through_matches_oracle():
     # Composition check: a gated (SwiGLU-style) combine feeding a plain
     # LayerNormalization before the down-projection -- confirms the hop


### PR DESCRIPTION
## Summary

`_NORM_PASS_THROUGH_OPS` only recognizes the literal fused `LayerNormalization` node — but that op's own schema is opset 17+ (`onnx.defs.get_schema("LayerNormalization").since_version == 17`, re-confirmed live). Any export at opset ≤ 16 — still extremely common for broad runtime/NPU/TensorRT compatibility, and universal for older exports — has no fused op to lower `nn.LayerNorm` to at all, so exporters emit its canonical 9-node decomposition instead. A `MatMul/Gemm → {decomposed LayerNorm} → MatMul/Gemm` chain therefore came out **completely unpruned end to end**, even though the identical chain using the fused node already worked.

## Empirically confirmed facts

- `onnx.defs.get_schema("LayerNormalization").since_version == 17` — re-confirmed independently.
- I independently re-ran `torch.onnx.export(nn.LayerNorm(8), ..., opset_version=16)` myself and inspected the raw node list: exactly `ReduceMean → Sub(x, mean) → Pow(·, 2.0) → ReduceMean → Add(·, eps) → Sqrt → Div(centered, std) → Mul(·, gamma) → Add(·, beta)` — 9 nodes, `x` read twice (by the first `ReduceMean` and `Sub`), `Sub`'s output read twice (by `Pow` and `Div`) — matching exactly what the matcher expects and what's documented.
- I independently reproduced the actual before/after pruning behavior change myself (not just re-running the committed tests): hand-built this exact 9-node decomposition between two `Gemm`s and ran `apply_structured_pruning(model, sparsity=0.5)` against this branch — `W1`/`W2` correctly pruned (`[32,16]→[32,8]`, `[16,16]→[8,16]`), `Gamma`/`Beta` correctly co-sliced to `[8]` each.
- I independently re-ran the full verification suite in the worktree: `pytest tests/test_pruning.py -q` → **814 passed** (807 → 814, +7 new tests), `ruff format --check`/`ruff check` clean, `mypy onnxsim/pruning.py` (exact scoped command) → **0 errors**, matching baseline.

## What's added / scope

- `_match_decomposed_layer_norm_pass_through`: new matcher recognizing the exact 9-node shape rooted at the tensor being walked through. Declines outright, never partially matches, on any deviation: extra fan-out on any intermediate tensor, non-scalar/non-2.0 `Pow` exponent, non-last-axis `ReduceMean`, non-constant/wrongly-shaped/tied `gamma`/`beta`, wrong operand order on any non-commutative op (`Sub`/`Div`/`Pow`), etc.
- `_axis_resolves_to_last` factored out of `_norm_axis_is_last` and shared with the new `_reduce_mean_axis_is_last` (handles `ReduceMean`'s own list-valued `axes` attribute, opset ≤ 17 form only — the opset 18+ `axes`-as-input form is out of scope since a real `LayerNorm` export at opset 18+ already lowers to the fused op instead, live-confirmed).
- `_decomposed_layer_norm_pow_exponent_is_two`/`_flat_scalar_float_const` for the scalar-constant checks (`Pow`'s exponent, the variance `Add`'s `eps`).
- Wired into `_walk_to_consumer` at two points (the chain's root tensor, and as a fallback wherever an ordinary hop's own output would otherwise fail the single-consumer dispatch) — required relaxing the pre-walk gate at `_find_chains`/`_find_gated_chains`/`_find_split_gated_chains`/`_find_matmul_concat_chains` from a strict single-consumer check to the new `_matmul_walk_root_ok` (only "not a graph output"), since this shape's root tensor is read twice by design; the actual consumer-count validation is left entirely to `_walk_to_consumer`'s own hop-0 dispatch, so this cannot regress any previously-supported single-consumer chain.
- Deliberately **not** wired into `_walk_matmul_producer_backward` (confirmed live it never recognized even the *fused* `_NORM_PASS_THROUGH_OPS` shape either — a residual `Add`'s own operand almost always resolves back through an FFN down-projection or attention output-projection instead) or any Conv-chain walker (LayerNorm is not a Conv-chain concept, same as the fused case).
- Module docstring updated.

## Test plan

- [x] Decomposed-LayerNorm chain prunes correctly, output matches an independently-reconstructed already-pruned reference model via real onnxruntime execution (never the full unpruned model's own output).
- [x] 4 decline cases: wrong `Pow` exponent, wrong `ReduceMean` axis, extra consumer on the root tensor, extra consumer on the `Sub` output — chain declined outright rather than mis-pruned.
- [x] Composition test: the decomposition sitting right after an ordinary per-channel bias `Add` hop (exercising the fallback dispatch point, not just the root-tensor one).
- [x] Existing fused-`LayerNormalization`-node tests unaffected (no regression).
- [x] `pytest tests/test_pruning.py -q`: 807 → 814 passed.
- [x] `ruff format --check .` / `ruff check .`: clean.
- [x] `mypy onnxsim/pruning.py` (exact scoped command): 0 errors, matching baseline.

I independently re-verified this PR after implementation: reviewed the full diff line by line (the matcher's every decline condition, the `_matmul_walk_root_ok` relaxation and its four call sites, confirming it cannot regress any existing single-consumer chain since the real validation is entirely deferred to `_walk_to_consumer`'s own dispatch), independently re-ran the `torch.onnx.export` opset-16 decomposition check myself and confirmed it matches exactly, independently reproduced the actual before/after pruning behavior change against this branch's own public API (not just the test suite), and re-ran the entire verification suite (tests/ruff/mypy) fresh in the worktree.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_