### PR TITLE
Add Reshape-family fusion passes (Reshape/Squeeze/Unsqueeze/Flatten)

### DIFF
--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -16,6 +16,7 @@
 #include "passes/dynamic_quantize_matmul.h"
 #include "passes/dynamic_quantize_matmul_integer_to_float.h"
 #include "passes/dynamic_quantize_ternary_matmul.h"
+#include "passes/eliminate_consecutive_idempotent_ops.h"
 #include "passes/eliminate_loop_with_const_trip_count.h"
 #include "passes/eliminate_nop_dropout.h"
 #include "passes/eliminate_optional_get_element.h"
@@ -165,6 +166,7 @@ void RegisterCustomOptimizerPasses() {
     // names, so onnxsim's fixes/extensions (ConvTranspose fusions, no-op
     // opset-12 Dropout, zero-padding MaxPool, ...) apply while the fork itself
     // tracks upstream onnxoptimizer.
+    RegisterOrReplace<p::EliminateConsecutiveIdempotentOps>(registry);
     RegisterOrReplace<p::EliminateNopDropout>(registry);
     RegisterOrReplace<p::FuseAddBiasIntoConv>(registry);
     RegisterOrReplace<p::FuseBNIntoConv>(registry);

--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -40,6 +40,7 @@
 #include "passes/fuse_pad_into_pool.h"
 #include "passes/fuse_preceding_mul_into_conv.h"
 #include "passes/fuse_qkv.h"
+#include "passes/fuse_reshape_family.h"
 #include "passes/fuse_rms_norm.h"
 #include "passes/fuse_rope.h"
 #include "passes/magnitude_pruning.h"
@@ -128,6 +129,7 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::FuseMatMulIntoConv>(registry);
     RegisterOrReplace<p::FuseMulIntoConv>(registry);
     RegisterOrReplace<p::FusePrecedingMulIntoConv>(registry);
+    RegisterOrReplace<p::FuseReshapeFamily>(registry);
     RegisterOrReplace<p::FuseRMSNorm>(registry);
     RegisterOrReplace<p::FuseRope>(registry);
     RegisterOrReplace<p::MagnitudePruningConv>(registry);

--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -27,6 +27,7 @@
 #include "passes/fuse_attention.h"
 #include "passes/fuse_bn_into_conv.h"
 #include "passes/fuse_consecutive_mul.h"
+#include "passes/fuse_consecutive_reshapes.h"
 #include "passes/fuse_consecutive_unsqueezes.h"
 #include "passes/fuse_gelu.h"
 #include "passes/fuse_gqa.h"
@@ -118,6 +119,7 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::EliminateSequenceLengthConstruct>(registry);
     RegisterOrReplace<p::FuseAttention>(registry);
     RegisterOrReplace<p::FuseConsecutiveMul>(registry);
+    RegisterOrReplace<p::FuseConsecutiveReshapes>(registry);
     RegisterOrReplace<p::FuseGelu>(registry);
     RegisterOrReplace<p::FuseGQA>(registry);
     RegisterOrReplace<p::FuseLayerNorm>(registry);

--- a/onnxsim/custom_optimizer_passes.h
+++ b/onnxsim/custom_optimizer_passes.h
@@ -21,6 +21,7 @@ namespace onnxsim {
 //   - fuse_preceding_mul_into_conv
 //   - fuse_consecutive_mul
 //   - fuse_consecutive_reshapes
+//   - fuse_reshape_family
 //   - fuse_matmul_add_bias_into_gemm_batched
 //   - fuse_matmul_into_conv
 //   - eliminate_reshape_around_elementwise

--- a/onnxsim/custom_optimizer_passes.h
+++ b/onnxsim/custom_optimizer_passes.h
@@ -20,6 +20,7 @@ namespace onnxsim {
 //   - fuse_mul_into_conv
 //   - fuse_preceding_mul_into_conv
 //   - fuse_consecutive_mul
+//   - fuse_consecutive_reshapes
 //   - fuse_matmul_add_bias_into_gemm_batched
 //   - fuse_matmul_into_conv
 //   - eliminate_reshape_around_elementwise

--- a/onnxsim/passes/eliminate_consecutive_idempotent_ops.h
+++ b/onnxsim/passes/eliminate_consecutive_idempotent_ops.h
@@ -1,0 +1,89 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+#pragma once
+
+#include <unordered_set>
+
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+// onnxsim's own passes live in this nested namespace so their class
+// names never collide (ODR) with the same-named passes compiled into
+// onnxoptimizer; RegisterOrReplace still keys them by getPassName().
+namespace onnxsim_passes {
+
+struct EliminateConsecutiveIdempotentOps final : public PredicateBasedPass {
+  explicit EliminateConsecutiveIdempotentOps()
+      : PredicateBasedPass(PassType::Fuse, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+
+  std::string getPassName() const override {
+    return "eliminate_consecutive_idempotent_ops";
+  }
+
+  bool patternMatchPredicate(Node* node) override {
+    static const std::unordered_set<std::string> idempotent_ops = {
+        "Ceil", "Floor", "Round", "Relu", "Reshape", "Sign"};
+    for (const auto& op : idempotent_ops) {
+      // TODO: support uses().size() > 1 for ops except Reshape
+      if (CheckKind(node, Symbol(op), 0, Symbol(op)) &&
+          node->input(0)->uses().size() == 1) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // Unlike Ceil/Floor/Round/Relu/Sign (genuinely idempotent: f(f(x)) ==
+  // f(x)), Reshape(Reshape(X, s1), s2) is only equivalent to Reshape(X, s2)
+  // when s2's `0` entries (under the default allowzero=0, meaning "copy this
+  // dim from the node's input") can't be disturbed by dropping the
+  // intermediate reshape -- see fuse_consecutive_reshapes.h's file comment
+  // for the full rationale. Upstream onnx-optimizer's version of this pass
+  // fuses unconditionally, which silently changes which shape a `0` entry
+  // copies from.
+  static bool ReshapeFusionSafe(Node* node) {
+    if (node->hasAttribute(Symbol("allowzero")) &&
+        node->i(Symbol("allowzero")) == 1) {
+      return true;
+    }
+    const Tensor* new_shape_tensor = FetchConstantTensor(node->inputs()[1]);
+    if (!new_shape_tensor || new_shape_tensor->elem_type() !=
+                                 ONNX_NAMESPACE::TensorProto_DataType_INT64) {
+      return false;
+    }
+    const auto new_shape = ParseTensorData<int64_t>(new_shape_tensor);
+    return std::none_of(new_shape.begin(), new_shape.end(),
+                        [](int64_t d) { return d == 0; });
+  }
+
+  bool runTransform(Node* node, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    if (node->kind() == kReshape && !ReshapeFusionSafe(node)) {
+      return false;
+    }
+    Node* previous_node = node->input(0)->node();
+    std::vector<Dimension> sizes = previous_node->input(0)->sizes();
+    bool replacing_success =
+        tryReplacingAllUsesWith(node->input(0), previous_node->input(0));
+    if (replacing_success) {
+      if (node->kind() == kReshape) {
+        // restore the correct sizes
+        previous_node->input(0)->setSizes(sizes);
+      }
+      return true;
+    }
+    return false;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/fuse_consecutive_reshapes.h
+++ b/onnxsim/passes/fuse_consecutive_reshapes.h
@@ -1,0 +1,85 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+#pragma once
+
+// Before:
+//   Y = Reshape(X, shape1)
+//   Z = Reshape(Y, shape2)
+// After:
+//   Z = Reshape(X, shape2)
+//
+// Only the final target shape determines Z -- X and Y always have the same
+// total element count (that's what makes `Y = Reshape(X, shape1)` valid in
+// the first place), so a `-1` (infer-from-size) entry in shape2 resolves
+// identically whether it is X or Y that feeds the node.
+//
+// The one part of Reshape's semantics that *does* depend on which tensor
+// feeds the node is a literal `0` entry in shape2 under the default
+// allowzero=0: it means "copy this dimension from the node's input", i.e.
+// from Y's shape today, which would silently become X's shape after fusion
+// -- and X and Y can disagree at that position (that's the whole reason
+// shape1 exists). So this pass only fires when shape2 either has no such
+// copy-from-input `0` entries (nothing for the fusion to disturb) or the
+// node opts out of that semantic entirely via allowzero=1.
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+// onnxsim's own passes live in this nested namespace so their class
+// names never collide (ODR) with the same-named passes compiled into
+// onnxoptimizer; RegisterOrReplace still keys them by getPassName().
+namespace onnxsim_passes {
+
+struct FuseConsecutiveReshapes final : public PredicateBasedPass {
+  explicit FuseConsecutiveReshapes()
+      : PredicateBasedPass(PassType::Fuse, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+
+  std::string getPassName() const override {
+    return "fuse_consecutive_reshapes";
+  }
+
+  bool patternMatchPredicate(Node* node) override {
+    return CheckKind(node, kReshape, 0, kReshape);
+  }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+
+    const bool allowzero = n->hasAttribute(Symbol("allowzero")) &&
+                           n->i(Symbol("allowzero")) == 1;
+    if (!allowzero) {
+      const Tensor* new_shape_tensor = FetchConstantTensor(n->inputs()[1]);
+      if (!new_shape_tensor ||
+          new_shape_tensor->elem_type() !=
+              ONNX_NAMESPACE::TensorProto_DataType_INT64) {
+        // Can't rule out a copy-from-input `0` entry -- leave the chain
+        // alone.
+        return false;
+      }
+      const auto new_shape = ParseTensorData<int64_t>(new_shape_tensor);
+      if (std::any_of(new_shape.begin(), new_shape.end(),
+                      [](int64_t d) { return d == 0; })) {
+        return false;
+      }
+    }
+
+    Node* prev = PrevNode(n, 0);
+    n->replaceInput(0, prev->input(0));
+    if (prev->output()->uses().empty()) {
+      prev->destroy();
+    }
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/fuse_consecutive_reshapes.h
+++ b/onnxsim/passes/fuse_consecutive_reshapes.h
@@ -53,13 +53,12 @@ struct FuseConsecutiveReshapes final : public PredicateBasedPass {
                     NodeDestroyType& destroy_current) override {
     destroy_current = NodeDestroyType::DestroyZero;
 
-    const bool allowzero = n->hasAttribute(Symbol("allowzero")) &&
-                           n->i(Symbol("allowzero")) == 1;
+    const bool allowzero =
+        n->hasAttribute(Symbol("allowzero")) && n->i(Symbol("allowzero")) == 1;
     if (!allowzero) {
       const Tensor* new_shape_tensor = FetchConstantTensor(n->inputs()[1]);
-      if (!new_shape_tensor ||
-          new_shape_tensor->elem_type() !=
-              ONNX_NAMESPACE::TensorProto_DataType_INT64) {
+      if (!new_shape_tensor || new_shape_tensor->elem_type() !=
+                                   ONNX_NAMESPACE::TensorProto_DataType_INT64) {
         // Can't rule out a copy-from-input `0` entry -- leave the chain
         // alone.
         return false;

--- a/onnxsim/passes/fuse_reshape_family.h
+++ b/onnxsim/passes/fuse_reshape_family.h
@@ -1,0 +1,152 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+#pragma once
+
+// Reshape, Squeeze, Unsqueeze and Flatten all only rearrange a tensor's
+// shape -- none of them ever change its total element count. So for any two
+// adjacent ops drawn from that family:
+//   Y = <family op 1>(X, ...)
+//   Z = <family op 2>(Y, ...)
+// Z is exactly Reshape(X, shape(Z)), and shape(Z) needs at most one free
+// (not statically known) dimension to be expressible as a constant Reshape
+// target -- the free slot can always be written as Reshape's `-1` sentinel,
+// since the total element count flowing through the whole family chain is
+// invariant regardless of which intermediate tensor it's computed from.
+//
+// Squeeze<->Squeeze, Unsqueeze<->Unsqueeze, Squeeze<->Unsqueeze and
+// Reshape<->Reshape pairs already have their own dedicated fusions
+// (fuse_consecutive_squeezes, fuse_consecutive_unsqueezes,
+// fuse_consecutive_squeeze_unsqueeze, fuse_consecutive_reshapes /
+// eliminate_consecutive_idempotent_ops) that work by composing each pair's
+// own axis/shape rule and so still fuse when no shape is statically known.
+// This pass instead leans on already-computed shape inference, so it only
+// covers the mixed pairs those don't -- anything involving Flatten, plus
+// Reshape next to Squeeze/Unsqueeze -- and only fires once the *output*
+// shape of the pair has at most one unresolved dimension.
+#include <algorithm>
+
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+// onnxsim's own passes live in this nested namespace so their class
+// names never collide (ODR) with the same-named passes compiled into
+// onnxoptimizer; RegisterOrReplace still keys them by getPassName().
+namespace onnxsim_passes {
+
+struct FuseReshapeFamily final : public PredicateBasedPass {
+  explicit FuseReshapeFamily()
+      : PredicateBasedPass(PassType::Fuse, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+
+  std::string getPassName() const override { return "fuse_reshape_family"; }
+
+  static bool IsFamily(uint32_t kind) {
+    return kind == kReshape || kind == kSqueeze || kind == kUnsqueeze ||
+           kind == kFlatten;
+  }
+
+  // Pairs already covered by a dedicated, shape-agnostic fusion elsewhere
+  // (see the file comment above) -- left alone here so this pass only picks
+  // up the mixed pairs those don't.
+  static bool HandledElsewhere(uint32_t outer, uint32_t inner) {
+    if (outer == kReshape && inner == kReshape) return true;
+    if (outer == kSqueeze && inner == kSqueeze) return true;
+    if (outer == kUnsqueeze && inner == kUnsqueeze) return true;
+    if (outer == kSqueeze && inner == kUnsqueeze) return true;
+    if (outer == kUnsqueeze && inner == kSqueeze) return true;
+    return false;
+  }
+
+  bool patternMatchPredicate(Node* node) override {
+    if (!IsFamily(node->kind()) || node->inputs().empty()) {
+      return false;
+    }
+    Node* prev = node->input(0)->node();
+    return IsFamily(prev->kind()) &&
+           !HandledElsewhere(node->kind(), prev->kind());
+  }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+    if (!n->output()->has_sizes()) {
+      // Nothing to collapse to without a target shape.
+      return false;
+    }
+    const auto& dims = n->output()->sizes();
+    if (dims.empty()) {
+      // has_sizes() with zero dims is how a rank genuinely known to be 0
+      // (a scalar) and "shape inference couldn't determine a rank at all"
+      // both surface here -- e.g. Unsqueeze's shape inference can report
+      // this for a symbolic-shaped input even though its output can never
+      // actually be a scalar. Treat it as untrustworthy rather than risk
+      // emitting a Reshape to the wrong (empty) target shape.
+      return false;
+    }
+    std::vector<int64_t> shape;
+    shape.reserve(dims.size());
+    bool seen_unknown = false;
+    for (const auto& d : dims) {
+      if (d.is_int) {
+        shape.push_back(d.dim);
+        continue;
+      }
+      if (seen_unknown) {
+        // A second free dimension can't be encoded by Reshape's single -1.
+        return false;
+      }
+      seen_unknown = true;
+      shape.push_back(-1);
+    }
+
+    // A resolved `0` can only be baked as a literal Reshape entry once
+    // allowzero=1 (opset >= 14) makes it mean "this dim is 0" instead of
+    // the default "copy this dim from the input" -- see
+    // fuse_consecutive_reshapes.h's file comment for the full rationale.
+    const bool has_zero = std::any_of(shape.begin(), shape.end(),
+                                      [](int64_t d) { return d == 0; });
+    if (has_zero && getOpsetVersion(graph) < 14) {
+      return false;
+    }
+
+    Node* prev = PrevNode(n, 0);
+    Value* new_input = prev->input(0);
+
+    Tensor shape_t;
+    shape_t.sizes().push_back(static_cast<int64_t>(shape.size()));
+    shape_t.elem_type() = TensorProto_DataType_INT64;
+    shape_t.int64s() = shape;
+    Value* shape_v = graph.addInitializerAndCreateValue(shape_t);
+
+    Node* new_reshape = graph.create(kReshape, 1);
+    new_reshape->addInput(new_input);
+    new_reshape->addInput(shape_v);
+    if (has_zero) {
+      new_reshape->i_(Symbol("allowzero"), 1);
+    }
+    new_reshape->insertBefore(n);
+
+    // tryReplacingAllUsesWith redirects n's output uses to new_reshape's
+    // output and copies n's output's sizes/elem type onto it.
+    if (!tryReplacingAllUsesWith(n, new_reshape)) {
+      new_reshape->destroy();
+      return false;
+    }
+    destroy_current = NodeDestroyType::DestroyOne;
+    if (prev->output()->uses().empty()) {
+      prev->destroy();
+    }
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/tests/test_fusion_patterns.py
+++ b/tests/test_fusion_patterns.py
@@ -635,6 +635,60 @@ def test_fuse_concat_into_reshape():
     assert ops["Reshape"] == 1
 
 
+def test_fuse_consecutive_reshapes():
+    # Only the final target shape matters -- Reshape(Reshape(X, s1), s2)
+    # collapses to Reshape(X, s2) (fuse_consecutive_reshapes).
+    model = _model(
+        """
+        g (float[2,3,4] X) => (float[3,8] Y)
+        <int64[2] s1 = {6,4}, int64[2] s2 = {3,8}>
+        {
+          y = Reshape(X, s1)
+          Y = Reshape(y, s2)
+        }
+        """
+    )
+    _, ops = _simplify(model)
+    assert ops["Reshape"] == 1
+
+
+def test_fuse_consecutive_reshapes_chain():
+    # A longer chain collapses all the way down to the final reshape.
+    model = _model(
+        """
+        g (float[2,3,4] X) => (float[3,8] Y)
+        <int64[2] s1 = {4,6}, int64[2] s2 = {2,12}, int64[2] s3 = {3,8}>
+        {
+          y1 = Reshape(X, s1)
+          y2 = Reshape(y1, s2)
+          Y = Reshape(y2, s3)
+        }
+        """
+    )
+    _, ops = _simplify(model)
+    assert ops["Reshape"] == 1
+
+
+def test_fuse_consecutive_reshapes_declines_ambiguous_zero_copy():
+    # The outer reshape's `0` (under the default allowzero=0) means "copy
+    # this dim from the node's own input", i.e. from the inner reshape's
+    # output shape [2,3,4] (dim0=2) -- not from X's shape [6,4] (dim0=6).
+    # Fusing the two would silently change which shape the `0` copies from,
+    # so the pass must leave this chain alone.
+    model = _model(
+        """
+        g (float[6,4] X) => (float[2,12] Y)
+        <int64[3] s1 = {2,3,4}, int64[2] s2 = {0,-1}>
+        {
+          y = Reshape(X, s1)
+          Y = Reshape(y, s2)
+        }
+        """
+    )
+    _, ops = _simplify(model)
+    assert ops["Reshape"] == 2
+
+
 # --------------------------------------------------------------------------- #
 # Dead-node / no-op elimination
 # --------------------------------------------------------------------------- #

--- a/tests/test_fusion_patterns.py
+++ b/tests/test_fusion_patterns.py
@@ -689,6 +689,86 @@ def test_fuse_consecutive_reshapes_declines_ambiguous_zero_copy():
     assert ops["Reshape"] == 2
 
 
+def test_fuse_reshape_family_flatten_then_reshape():
+    # Flatten and Reshape both just rearrange a tensor's shape, so a Flatten
+    # immediately followed by a Reshape collapses into one Reshape
+    # (fuse_reshape_family), same as two consecutive Reshapes would.
+    model = _model(
+        """
+        g (float[2,3,4] X) => (float[3,8] Y)
+        <int64[2] s = {3,8}>
+        {
+          y = Flatten<axis = 1>(X)
+          Y = Reshape(y, s)
+        }
+        """
+    )
+    _, ops = _simplify(model)
+    assert ops["Flatten"] == 0
+    assert ops["Reshape"] == 1
+
+
+def test_fuse_reshape_family_squeeze_then_reshape():
+    # Squeeze followed by Reshape collapses the same way.
+    model = _model(
+        """
+        g (float[1,2,3,4] X) => (float[6,4] Y)
+        <int64[1] axes = {0}, int64[2] s = {6,4}>
+        {
+          y = Squeeze(X, axes)
+          Y = Reshape(y, s)
+        }
+        """
+    )
+    _, ops = _simplify(model)
+    assert ops["Squeeze"] == 0
+    assert ops["Reshape"] == 1
+
+
+def test_fuse_reshape_family_reshape_then_squeeze():
+    # The *outer* op need not be Reshape either -- Reshape followed by
+    # Squeeze collapses to a single Reshape (the outer Squeeze is replaced,
+    # not just bypassed).
+    model = _model(
+        """
+        g (float[2,3,4] X) => (float[2,12] Y)
+        <int64[3] s = {2,1,12}, int64[1] axes = {1}>
+        {
+          y = Reshape(X, s)
+          Y = Squeeze(y, axes)
+        }
+        """
+    )
+    _, ops = _simplify(model)
+    assert ops["Squeeze"] == 0
+    assert ops["Reshape"] == 1
+
+
+def test_fuse_reshape_family_declines_unresolved_output_shape():
+    # y's shape ([N, unk__0]) has two independent unresolved dims -- N and M
+    # are both symbolic -- and Unsqueeze's shape inference can't propagate a
+    # rank for Y from that, so the pass has no target shape to fuse to and
+    # must leave both nodes (rather than, say, guess a scalar target from an
+    # empty shape). N and M are dynamic, so this calls onnxsim.simplify
+    # directly with check_n=0 -- onnxsim's random-input equivalence check
+    # needs concrete dims -- and only asserts on graph structure.
+    model = _model(
+        """
+        g (float[N,M,4,5] X) => (float Y)
+        <int64[1] axes = {0}>
+        {
+          y = Flatten<axis = 1>(X)
+          Y = Unsqueeze(y, axes)
+        }
+        """
+    )
+    sim_model, _ = onnxsim.simplify(model, check_n=0)
+    ops = collections.Counter(n.op_type for n in sim_model.graph.node)
+    assert ops["Flatten"] == 1
+    assert ops["Unsqueeze"] == 1
+    assert ops["Reshape"] == 0
+
+
 # --------------------------------------------------------------------------- #
 # Dead-node / no-op elimination
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Adds simplification for the `Reshape` operator family, matching the existing `Squeeze`/`Unsqueeze` fusions, and fixes a related pre-existing bug found while testing it.

- **`fuse_consecutive_reshapes`** (`onnxsim/passes/fuse_consecutive_reshapes.h`): collapses `Reshape(Reshape(X, s1), s2)` into `Reshape(X, s2)`, since only the final target shape matters. Declines to fuse when the outer shape has a literal `0` entry (default `allowzero=0` "copy this dim from the input" semantics) that fusion would silently make copy from the wrong tensor, unless `allowzero=1` opts out of that semantic.

- **`fuse_reshape_family`** (`onnxsim/passes/fuse_reshape_family.h`): generalizes the same idea to *mixed* pairs from the wider reshape family -- `Reshape`, `Squeeze`, `Unsqueeze`, `Flatten` all only rearrange a tensor's shape and never change its element count, so any two adjacent ops from that family collapse to a single `Reshape` to the pair's known output shape. `Squeeze<->Squeeze`, `Unsqueeze<->Unsqueeze`, `Squeeze<->Unsqueeze` and `Reshape<->Reshape` pairs already have their own dedicated, shape-agnostic fusions, so this pass only picks up the remaining mixed pairs (anything involving `Flatten`, plus `Reshape` next to `Squeeze`/`Unsqueeze`). It leans on already-computed shape inference and only fires when the pair's output shape has at most one unresolved dimension -- that one dimension can always be written as Reshape's `-1` sentinel, since total element count is invariant through the whole family chain regardless of which intermediate tensor it's computed from.

- **Fix: `eliminate_consecutive_idempotent_ops`** (`onnxsim/passes/eliminate_consecutive_idempotent_ops.h`): while testing `fuse_consecutive_reshapes`, found that upstream onnx-optimizer's `eliminate_consecutive_idempotent_ops` treats `Reshape` as idempotent and unconditionally collapses consecutive reshapes -- unsound for the same `0`-copy-semantics reason above. Patched with onnxsim's usual override mechanism to add the same safety check.

- Tests in `tests/test_fusion_patterns.py` cover: basic and chained `Reshape` fusion, the ambiguous-`0` decline case, `Flatten`→`Reshape`, `Squeeze`→`Reshape`, `Reshape`→`Squeeze` (outer op replaced, not just bypassed), and declining to fuse when a pair's output has two independently unresolved dimensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GbyxPEEJSXbBmpYP2kBDG