### PR TITLE
Port subgraph recursion and GroupNorm/Resize/Pad pass-through hops to C++ structured pruning

### DIFF
--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -1147,8 +1147,7 @@ struct GroupNormMatch {
 // producer's/consumer's own `group`" check is left to the caller
 // (FindConvChains), which has visibility into both.
 std::optional<GroupNormMatch> MatchGroupNormPassThrough(
-    const onnx::NodeProto& node, const InitMap& init_map,
-    int64_t n_channels) {
+    const onnx::NodeProto& node, const InitMap& init_map, int64_t n_channels) {
   if (node.op_type() != "GroupNormalization" || node.domain() != "") {
     return std::nullopt;
   }
@@ -1281,8 +1280,7 @@ bool MatchPadChannelPassThrough(const onnx::NodeProto& node,
   if (node.op_type() != "Pad" || node.domain() != "") {
     return false;
   }
-  if (node.input_size() < 2 || node.input(0).empty() ||
-      node.input(1).empty()) {
+  if (node.input_size() < 2 || node.input(0).empty() || node.input(1).empty()) {
     return false;
   }
   auto pit = init_map.find(node.input(1));
@@ -1498,8 +1496,7 @@ WalkToConvConsumer(const std::string& start, const InitMap& init_map,
 
     if (nxt->op_type() == "Pad" && nxt->domain() == "" &&
         nxt->input_size() > 0 && nxt->input(0) == cur &&
-        nxt->output_size() == 1 &&
-        MatchPadChannelPassThrough(*nxt, init_map)) {
+        nxt->output_size() == 1 && MatchPadChannelPassThrough(*nxt, init_map)) {
       const std::string& out2 = nxt->output(0);
       if (ConsumerCount(consumers_of, out2) != 1 || graph_outputs.count(out2)) {
         break;
@@ -5738,7 +5735,8 @@ onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
     concat_chains.insert(concat_chains.end(),
                          std::make_move_iterator(conv_concat_chains.begin()),
                          std::make_move_iterator(conv_concat_chains.end()));
-    std::vector<SplitGatedChain> split_gated_chains = FindSplitGatedChains(graph);
+    std::vector<SplitGatedChain> split_gated_chains =
+        FindSplitGatedChains(graph);
 
     TouchedState touched;
     if (!chains.empty()) {

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -578,6 +578,34 @@ struct ChainOp {
   std::optional<std::string> const_name;
 };
 
+// One mid-chain `GroupNormalization` node WalkToConvConsumer crossed
+// transparently -- the Conv/spatial-path analogue of ConvPassThrough's
+// depthwise-Conv hop, for group-normalization statistics rather than a
+// channel-mixing-free Conv. Unlike ConvPassThrough, this needs BOTH its own
+// `scale` and `bias` sliced (both required by the op's own schema) -- via
+// SliceLastAxis, not ConvPassThrough's own axis-0 SliceProducerWeight: a
+// GroupNormalization `scale`/`bias` is only ever admitted here when
+// FlatChannelConst's `prod(dims) == dims[-1]` bar holds (mirroring
+// pruning.py's own `_flat_channel_const`), a looser bar than strictly
+// rank-1 that a naive axis-0 slice would get wrong for (e.g. a `[1, 1, C]`
+// shape), so this deliberately does NOT reuse ConvPassThrough the way a
+// per-channel PRelu `slope` (always exactly `[C, 1, ..., 1]`) safely does --
+// see MatchGroupNormPassThrough. Also unlike ConvPassThrough, this hop is
+// its own dedicated (at-most-one-per-chain) `Chain::group_norm` field rather
+// than living in a vector: its `num_groups` constrains ChainGroup()'s own
+// per-block `keep` selection exactly like a general grouped Conv's own
+// `group` does (see ChainGroup, MatchGroupNormPassThrough), a whole-chain
+// property no other conv_pass_through hop carries. `num_groups` itself is
+// never rewritten -- staying valid (the post-prune channel count still
+// divides it evenly) without changing it is the entire point of the
+// uniform-per-`num_groups`-block scope this hop is held to.
+struct GroupNormPassThrough {
+  onnx::NodeProto* node;
+  std::string scale;
+  std::string bias;
+  int64_t num_groups;
+};
+
 // One extra, independent forward-consumer branch a residual/merge group's
 // own fan-out resolves to -- mirroring pruning.py's own _ConsumerBranch --
 // fed by the exact same shared `keep` set as a Chain's own primary
@@ -606,6 +634,12 @@ struct Chain {
   // fan-out resolved -- see pruning.py's own _Chain.extra_consumers. Always
   // empty for every chain kind except a Conv/MatMul residual/merge group.
   std::vector<ConsumerBranch> extra_consumers;
+  // A single mid-chain `GroupNormalization` hop the chain walk crossed
+  // transparently -- FindConvChains only, for now (see WalkToConvConsumer's
+  // own `recognize_group_norm` parameter; always nullopt for every other
+  // chain kind -- residual/merge chains, Concat-merged chains, and every
+  // MatMul/Gemm chain -- mirroring pruning.py's own `_Chain.group_norm`).
+  std::optional<GroupNormPassThrough> group_norm;
 };
 
 // --- MatMul/Gemm plain chains, mirroring _match_producer/_walk_to_consumer/
@@ -1066,6 +1100,236 @@ std::optional<DepthwiseMatch> MatchDepthwiseConvPassThrough(
   return DepthwiseMatch{node.input(1), bias};
 }
 
+// True if `name` names a constant FLOAT initializer shaped like a flat
+// per-channel vector (`prod(dims) == dims[-1]`) -- mirrors pruning.py's own
+// `_flat_channel_const` exactly: the self-consistency bar every per-channel
+// affine/bias/scale hop in this module checks before ever accepting a
+// tensor as a slice target. The real `dims[-1] == n_channels` check, once
+// the chain's real channel count is known, is left to the caller
+// (MatchGroupNormPassThrough).
+bool FlatChannelConst(const std::string& name, const InitMap& init_map) {
+  auto it = init_map.find(name);
+  if (it == init_map.end() ||
+      it->second->data_type() != onnx::TensorProto::FLOAT) {
+    return false;
+  }
+  const auto& dims = it->second->dims();
+  if (dims.size() == 0) {
+    return false;
+  }
+  int64_t prod = 1;
+  for (int64_t d : dims) {
+    prod *= d;
+  }
+  return prod == dims.Get(dims.size() - 1);
+}
+
+struct GroupNormMatch {
+  std::string scale;
+  std::string bias;
+  int64_t num_groups;
+};
+
+// The Conv-chain GroupNormalization pass-through matcher used by
+// WalkToConvConsumer, mirroring pruning.py's own
+// _match_group_norm_pass_through: if `node` is a plain (default-domain)
+// `GroupNormalization` node whose own `num_groups` attribute evenly divides
+// `n_channels`, with constant, per-channel-shaped (FlatChannelConst,
+// `dims[-1] == n_channels` -- this alone already excludes the deprecated
+// opset-18 per-*group*-shaped schema whenever `num_groups < n_channels`)
+// `scale` (input 1) and `bias` (input 2) -- both required by the op's own
+// schema -- returns `{scale_name, bias_name, num_groups}`. Declines
+// (nullopt) on a missing/non-constant/wrongly-shaped `scale`/`bias`,
+// `num_groups < 1`, `n_channels % num_groups != 0`, or `scale`/`bias`
+// naming the same tensor (double-slicing it in ApplyChains's own per-hop
+// loop would corrupt it) -- none of these is guessed at. The real "does
+// this hop's own `num_groups` agree with a same-chain grouped Conv
+// producer's/consumer's own `group`" check is left to the caller
+// (FindConvChains), which has visibility into both.
+std::optional<GroupNormMatch> MatchGroupNormPassThrough(
+    const onnx::NodeProto& node, const InitMap& init_map,
+    int64_t n_channels) {
+  if (node.op_type() != "GroupNormalization" || node.domain() != "") {
+    return std::nullopt;
+  }
+  if (node.input_size() != 3 || node.input(1).empty() ||
+      node.input(2).empty()) {
+    return std::nullopt;
+  }
+  int64_t num_groups = 0;
+  for (const auto& attr : node.attribute()) {
+    if (attr.name() == "num_groups") {
+      num_groups = attr.i();
+    }
+  }
+  if (num_groups < 1 || n_channels % num_groups != 0) {
+    return std::nullopt;
+  }
+  const std::string& scale_name = node.input(1);
+  const std::string& bias_name = node.input(2);
+  if (scale_name == bias_name) {
+    return std::nullopt;  // Tied scale/bias -- double-slicing would corrupt it.
+  }
+  if (!FlatChannelConst(scale_name, init_map) ||
+      !FlatChannelConst(bias_name, init_map)) {
+    return std::nullopt;
+  }
+  const auto& sdims = init_map.at(scale_name)->dims();
+  const auto& bdims = init_map.at(bias_name)->dims();
+  if (sdims.Get(sdims.size() - 1) != n_channels ||
+      bdims.Get(bdims.size() - 1) != n_channels) {
+    return std::nullopt;
+  }
+  return GroupNormMatch{scale_name, bias_name, num_groups};
+}
+
+// True iff `node` (already confirmed by the caller to be a plain
+// (default-domain) `Resize`, `node.input(0)` the tensor being walked
+// through) provably leaves axis 1 -- the NCHW channel axis this module's
+// Conv-chain machinery assumes throughout -- unresized, so it is safe to
+// cross transparently. Declines (false) rather than guesses whenever it
+// cannot statically prove that -- mirrors pruning.py's own
+// _match_resize_channel_pass_through exactly (see that function's own
+// docstring for the full reasoning, including the empirically-confirmed
+// commutativity argument and why a `sizes`-driven Resize is declined
+// outright rather than guessed at):
+//
+// - Needs a length-3-or-4 `node.input` (`X, roi, scales[, sizes]`, the
+//   opset 11+ signature) so `scales` lands at a known, fixed position.
+// - Only a `scales` (tensor(float))-driven Resize is ever recognized -- a
+//   `sizes`-driven one is declined outright, always, never guessed at.
+// - `scales` must be a constant FLOAT initializer -- a runtime-computed
+//   value means this pass cannot know which axis is affected.
+// - The (opset 18+) `axes` attribute, when present, restricts which input
+//   axes `scales` actually describes. A negative `axes` entry declines the
+//   whole hop (can't resolve without a known rank); axis 1 simply not being
+//   named in `axes` at all means it is by definition not resized.
+bool MatchResizeChannelPassThrough(const onnx::NodeProto& node,
+                                   const InitMap& init_map) {
+  if (node.op_type() != "Resize" || node.domain() != "") {
+    return false;
+  }
+  if ((node.input_size() != 3 && node.input_size() != 4) ||
+      node.input(0).empty()) {
+    return false;
+  }
+  const std::string& scales_name = node.input(2);
+  if (scales_name.empty()) {
+    return false;  // Only a `scales`-driven Resize is ever recognized.
+  }
+  auto it = init_map.find(scales_name);
+  if (it == init_map.end() ||
+      it->second->data_type() != onnx::TensorProto::FLOAT) {
+    return false;
+  }
+  std::vector<float> values = ReadFloatTensor(*it->second);
+
+  std::optional<std::vector<int64_t>> axes_attr;
+  for (const auto& attr : node.attribute()) {
+    if (attr.name() == "axes") {
+      axes_attr = std::vector<int64_t>(attr.ints().begin(), attr.ints().end());
+    }
+  }
+
+  float channel_value;
+  if (!axes_attr) {
+    if (values.size() < 2) {
+      return false;  // No axis-1 slot in a `scales` this short.
+    }
+    channel_value = values[1];
+  } else {
+    for (int64_t a : *axes_attr) {
+      if (a < 0) {
+        return false;  // Can't resolve a negative axis without a known rank.
+      }
+    }
+    if (values.size() != axes_attr->size()) {
+      return false;  // Malformed -- schema requires equal length.
+    }
+    auto pos = std::find(axes_attr->begin(), axes_attr->end(), int64_t{1});
+    if (pos == axes_attr->end()) {
+      return true;  // Axis 1 isn't named -- definitely not resized.
+    }
+    channel_value = values[static_cast<size_t>(pos - axes_attr->begin())];
+  }
+  return channel_value == 1.0f;
+}
+
+// True iff `node` (already confirmed by the caller to be a plain
+// (default-domain) `Pad`, `node.input(0)` the tensor being walked through)
+// provably pads *nothing* on axis 1 -- the NCHW channel axis -- so it is
+// safe to cross transparently, whatever its `mode`. Declines (false) rather
+// than guesses whenever it cannot statically prove that -- mirrors
+// pruning.py's own _match_pad_channel_pass_through exactly (see that
+// function's own docstring for the full reasoning):
+//
+// - Needs a `pads` *input* at `node.input(1)` (opset 11+'s signature) that
+//   is a constant INT64 initializer -- opset < 11's older attribute-based
+//   `pads` is declined outright, mirroring MatchResizeChannelPassThrough's
+//   own "statically-known-constant-only" bar.
+// - The (opset 18+) `axes` *input* (`node.input(3)`), when present, must
+//   likewise be a constant INT64 initializer, and restricts which axes
+//   `pads` describes (`len(pads) == 2 * len(axes)`). A negative `axes`
+//   entry declines the whole hop; axis 1 not named in `axes` at all means
+//   it is by definition not padded.
+// - When `axes` is omitted, `pads` spans every input axis in order
+//   (`len(pads) == 2 * rank`), so `rank = len(pads) / 2` is recovered
+//   directly from `pads`'s own length, and axis 1's begin/end pads sit at
+//   `pads[1]`/`pads[rank + 1]`.
+bool MatchPadChannelPassThrough(const onnx::NodeProto& node,
+                                const InitMap& init_map) {
+  if (node.op_type() != "Pad" || node.domain() != "") {
+    return false;
+  }
+  if (node.input_size() < 2 || node.input(0).empty() ||
+      node.input(1).empty()) {
+    return false;
+  }
+  auto pit = init_map.find(node.input(1));
+  if (pit == init_map.end() ||
+      pit->second->data_type() != onnx::TensorProto::INT64) {
+    return false;
+  }
+  std::vector<int64_t> pads = ReadInt64Tensor(*pit->second);
+  std::string axes_name = node.input_size() > 3 ? node.input(3) : "";
+
+  int64_t begin, end;
+  if (!axes_name.empty()) {
+    auto ait = init_map.find(axes_name);
+    if (ait == init_map.end() ||
+        ait->second->data_type() != onnx::TensorProto::INT64) {
+      return false;
+    }
+    std::vector<int64_t> axes = ReadInt64Tensor(*ait->second);
+    for (int64_t a : axes) {
+      if (a < 0) {
+        return false;  // Can't resolve a negative axis without a known rank.
+      }
+    }
+    if (pads.size() != 2 * axes.size()) {
+      return false;  // Malformed -- schema requires equal length.
+    }
+    auto pos = std::find(axes.begin(), axes.end(), int64_t{1});
+    if (pos == axes.end()) {
+      return true;  // Axis 1 isn't named -- definitely not padded.
+    }
+    const size_t idx = static_cast<size_t>(pos - axes.begin());
+    begin = pads[idx];
+    end = pads[axes.size() + idx];
+  } else {
+    if (pads.size() % 2 != 0) {
+      return false;  // Malformed -- schema requires an even length.
+    }
+    const int64_t rank = static_cast<int64_t>(pads.size()) / 2;
+    if (rank < 2) {
+      return false;  // No axis-1 slot in a `pads` this short.
+    }
+    begin = pads[1];
+    end = pads[static_cast<size_t>(rank) + 1];
+  }
+  return begin == 0 && end == 0;
+}
+
 // The Conv-chain PRelu pass-through matcher used by WalkToConvConsumer,
 // mirroring pruning.py's own _match_prelu_pass_through: if `node` is a plain
 // (default-domain) PRelu whose own `slope` (input 1) is a constant float
@@ -1153,15 +1417,21 @@ struct ConvConsumerResult {
 };
 
 std::tuple<std::optional<ConvConsumerResult>, std::vector<ChainOp>,
-           std::vector<ConvPassThrough>>
+           std::vector<ConvPassThrough>, std::optional<GroupNormPassThrough>>
 WalkToConvConsumer(const std::string& start, const InitMap& init_map,
                    const ConsumerMap& consumers_of,
                    const std::unordered_set<std::string>& graph_outputs,
                    int64_t n_channels, int max_hops,
-                   onnx::NodeProto* forced_first_hop = nullptr) {
+                   onnx::NodeProto* forced_first_hop = nullptr,
+                   bool recognize_group_norm = false) {
   std::vector<ChainOp> chain_ops;
   std::vector<ConvPassThrough> pass_through;
   std::optional<ConvConsumerResult> consumer;
+  // At most one mid-chain GroupNormalization hop per chain -- mirrors
+  // pruning.py's own `group_norm is None` gate on _walk_to_conv_consumer's
+  // own matching `if`. Only ever recognized when `recognize_group_norm`
+  // (FindConvChains only, today -- see Chain::group_norm's own comment).
+  std::optional<GroupNormPassThrough> group_norm;
   std::string cur = start;
   for (int hop = 0; hop < max_hops; ++hop) {
     onnx::NodeProto* nxt;
@@ -1194,6 +1464,49 @@ WalkToConvConsumer(const std::string& start, const InitMap& init_map,
         consumer = ConvConsumerResult{nxt, match->weight, match->group};
       }
       break;
+    }
+
+    if (recognize_group_norm && !group_norm &&
+        nxt->op_type() == "GroupNormalization" && nxt->domain() == "" &&
+        nxt->input_size() > 0 && nxt->input(0) == cur) {
+      auto gn_match = MatchGroupNormPassThrough(*nxt, init_map, n_channels);
+      if (!gn_match) {
+        break;
+      }
+      const std::string& out2 = nxt->output(0);
+      if (ConsumerCount(consumers_of, out2) != 1 || graph_outputs.count(out2)) {
+        break;
+      }
+      group_norm = GroupNormPassThrough{nxt, gn_match->scale, gn_match->bias,
+                                        gn_match->num_groups};
+      cur = out2;
+      continue;
+    }
+
+    if (nxt->op_type() == "Resize" && nxt->domain() == "" &&
+        nxt->input_size() > 0 && nxt->input(0) == cur &&
+        nxt->output_size() == 1 &&
+        MatchResizeChannelPassThrough(*nxt, init_map)) {
+      const std::string& out2 = nxt->output(0);
+      if (ConsumerCount(consumers_of, out2) != 1 || graph_outputs.count(out2)) {
+        break;
+      }
+      chain_ops.push_back(ChainOp{nxt, std::nullopt});
+      cur = out2;
+      continue;
+    }
+
+    if (nxt->op_type() == "Pad" && nxt->domain() == "" &&
+        nxt->input_size() > 0 && nxt->input(0) == cur &&
+        nxt->output_size() == 1 &&
+        MatchPadChannelPassThrough(*nxt, init_map)) {
+      const std::string& out2 = nxt->output(0);
+      if (ConsumerCount(consumers_of, out2) != 1 || graph_outputs.count(out2)) {
+        break;
+      }
+      chain_ops.push_back(ChainOp{nxt, std::nullopt});
+      cur = out2;
+      continue;
     }
 
     if (nxt->op_type() == "PRelu" && nxt->domain() == "" &&
@@ -1242,7 +1555,7 @@ WalkToConvConsumer(const std::string& start, const InitMap& init_map,
     chain_ops.push_back(ChainOp{nxt, std::nullopt});
     cur = out2;
   }
-  return {consumer, chain_ops, pass_through};
+  return {consumer, chain_ops, pass_through, group_norm};
 }
 
 std::vector<Chain> FindConvChains(onnx::GraphProto* graph) {
@@ -1270,15 +1583,27 @@ std::vector<Chain> FindConvChains(onnx::GraphProto* graph) {
     if (!is_internal(out_name)) {
       continue;
     }
-    auto [consumer, chain_ops, pass_through] =
-        WalkToConvConsumer(out_name, init_map, consumers_of, graph_outputs,
-                           info->out_channels, kMaxChainHops);
+    auto [consumer, chain_ops, pass_through, group_norm] = WalkToConvConsumer(
+        out_name, init_map, consumers_of, graph_outputs, info->out_channels,
+        kMaxChainHops, /*forced_first_hop=*/nullptr,
+        /*recognize_group_norm=*/true);
     if (!consumer) {
       continue;
     }
     if (info->group > 1 && consumer->group > 1 &&
         info->group != consumer->group) {
       continue;  // Both sides grouped with mismatched group counts: declined.
+    }
+    if (group_norm &&
+        ((info->group > 1 && info->group != group_norm->num_groups) ||
+         (consumer->group > 1 && consumer->group != group_norm->num_groups))) {
+      // The mid-chain GroupNorm hop's own `num_groups` disagrees with a
+      // general grouped Conv producer's or consumer's own `group` -- the
+      // two partitions' own block boundaries wouldn't generally align,
+      // exactly the same "declined outright" bar the producer/consumer
+      // group mismatch above already gets. Mirrors pruning.py's own
+      // identical reconciliation check in _find_conv_chains.
+      continue;
     }
 
     Chain chain;
@@ -1292,6 +1617,7 @@ std::vector<Chain> FindConvChains(onnx::GraphProto* graph) {
     chain.consumer_is_conv = true;
     chain.conv_pass_through = std::move(pass_through);
     chain.consumer_group = consumer->group;
+    chain.group_norm = std::move(group_norm);
     chains.push_back(std::move(chain));
   }
   return chains;
@@ -1438,6 +1764,22 @@ ConvBackwardEdge WalkConvProducerBackward(
       continue;
     }
 
+    if (node->op_type() == "Resize" &&
+        MatchResizeChannelPassThrough(*node, init_map)) {
+      unary_ops.push_back(node);
+      edges.push_back({node->input(0), node});
+      cur = node->input(0);
+      continue;
+    }
+
+    if (node->op_type() == "Pad" &&
+        MatchPadChannelPassThrough(*node, init_map)) {
+      unary_ops.push_back(node);
+      edges.push_back({node->input(0), node});
+      cur = node->input(0);
+      continue;
+    }
+
     auto prelu_self = MatchPreluPassThroughSelf(*node, init_map);
     if (prelu_self) {
       if (prelu_self->is_per_channel) {
@@ -1524,9 +1866,15 @@ std::optional<std::vector<ConsumerBranch>> ResolveConvFanoutBranches(
       if (acc_it != accounted.end() && acc_it->second.count(consumer_node)) {
         continue;  // Already part of the group's own established wiring.
       }
-      auto [resolved, br_chain_ops, br_pass_through] =
+      // `recognize_group_norm` stays at its default (false) here -- a
+      // fan-out branch's own forward re-walk never recognizes a mid-chain
+      // GroupNorm hop, mirroring pruning.py's own _resolve_conv_fanout_branches
+      // (which never passes `recognize_group_norm=True` to its own
+      // _walk_to_conv_consumer call either).
+      auto [resolved, br_chain_ops, br_pass_through, br_group_norm] =
           WalkToConvConsumer(tensor, init_map, consumers_of, graph_outputs,
                              n_channels, kMaxChainHops, consumer_node);
+      (void)br_group_norm;  // Always nullopt -- see comment above.
       if (!resolved) {
         return std::nullopt;
       }
@@ -2474,12 +2822,25 @@ std::vector<Chain> FindMatmulResidualChains(onnx::GraphProto* graph) {
 }
 
 int64_t ChainGroup(const Chain& chain) {
+  int64_t group = chain.consumer_group;
   for (const auto& p : chain.producers) {
     if (p.group > 1) {
-      return p.group;
+      group = p.group;
+      break;
     }
   }
-  return chain.consumer_group;
+  // A mid-chain GroupNormalization hop's own `num_groups` takes priority
+  // over the plain producer/consumer `group` fields above -- FindConvChains
+  // already declined the chain outright if `num_groups` disagreed with a
+  // non-1 producer/consumer `group` (see its own reconciliation check), so
+  // whenever both are present they already agree, and returning
+  // `num_groups` unconditionally is equivalent to returning either. This is
+  // what makes GroupNorm's own per-group statistics stay valid after
+  // pruning -- mirrors pruning.py's own _chain_group exactly.
+  if (chain.group_norm) {
+    group = chain.group_norm->num_groups;
+  }
+  return group;
 }
 
 // --- Slicing, mirroring _slice_producer_weight/_slice_consumer_weight/
@@ -2767,6 +3128,14 @@ void ApplyChains(onnx::GraphProto* graph, std::vector<Chain>& chains,
         }
       }
     }
+    // A mid-chain GroupNorm hop's own `scale`/`bias` get exactly the same
+    // shared/tied-initializer conflict protection every other chain-op
+    // constant already does -- mirrors pruning.py's own
+    // `consts.update(_chain_group_norm_consts(chain))`.
+    if (chain.group_norm) {
+      consts.insert(chain.group_norm->scale);
+      consts.insert(chain.group_norm->bias);
+    }
 
     bool conflict = false;
     for (const auto& w : consumer_weights) {
@@ -2881,6 +3250,15 @@ void ApplyChains(onnx::GraphProto* graph, std::vector<Chain>& chains,
         SetOrAddIntAttr(hop.node, "group", static_cast<int64_t>(keep.size()));
       }
     }
+    if (chain.group_norm) {
+      // Same `keep` index set as the real producer -- `num_groups` itself is
+      // left untouched (see GroupNormPassThrough's own comment for why it
+      // stays valid without changing it). Sliced via SliceLastAxis, not
+      // ConvPassThrough's own axis-0 SliceProducerWeight -- see
+      // GroupNormPassThrough's own comment for why.
+      SliceLastAxis(init_map.at(chain.group_norm->scale), keep);
+      SliceLastAxis(init_map.at(chain.group_norm->bias), keep);
+    }
     if (chain.consumer_is_conv && chain.consumer_group > 1) {
       SliceGroupedConsumerConvWeight(init_map.at(chain.consumer_weight), keep,
                                      chain.consumer_group, n);
@@ -2945,6 +3323,9 @@ void ApplyChains(onnx::GraphProto* graph, std::vector<Chain>& chains,
     }
     for (const auto& hop : chain.conv_pass_through) {
       stale_value_info.insert(hop.node->output(0));
+    }
+    if (chain.group_norm) {
+      stale_value_info.insert(chain.group_norm->node->output(0));
     }
     for (const auto* b : extra_ptrs) {
       for (const auto& co : b->chain_ops) {
@@ -4446,9 +4827,15 @@ std::vector<ConcatChain> FindConvConcatChains(onnx::GraphProto* graph) {
       continue;
     }
     const int64_t total_n = offset;
-    auto [consumer, fwd_chain_ops, fwd_pass_through] =
+    // `recognize_group_norm` stays at its default (false) here too -- a
+    // Concat-merged chain's own forward consumer walk never recognizes a
+    // mid-chain GroupNorm hop either, mirroring pruning.py's own
+    // FindConvConcatChains-equivalent walk (GroupNorm pass-through is
+    // FindConvChains-only, see Chain::group_norm's own comment).
+    auto [consumer, fwd_chain_ops, fwd_pass_through, fwd_group_norm] =
         WalkToConvConsumer(out_name, init_map, consumers_of, graph_outputs,
                            total_n, kMaxChainHops);
+    (void)fwd_group_norm;  // Always nullopt -- see comment above.
     if (!consumer) {
       continue;
     }

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -5219,6 +5219,95 @@ void ApplySplitGatedChains(onnx::GraphProto* graph,
   }
 }
 
+// --- Subgraph recursion ------------------------------------------------
+//
+// Mirrors pruning.py's own `_iter_subgraphs` and the "Subgraph recursion"
+// section comment just above its definition there -- read that comment
+// block first if you're touching this; it's the design rationale for
+// everything below, not just for the Python side.
+//
+// A plain `If` node's `then_branch`/`else_branch`, a `Loop`/`Scan` node's
+// `body`, or (per pruning.py's own confirmation against onnxruntime's
+// contrib-op schema registry) a `com.microsoft::BeamSearch`/`GreedySearch`/
+// `Sampling`/`WhisperBeamSearch` node's own `decoder`/`encoder`/
+// `init_decoder` attribute is itself a full GraphProto that can carry
+// arbitrary weight-bearing nodes -- for a whole-model-generation export
+// (e.g. produced by `onnxruntime.transformers.models.{t5,gpt2,whisper}
+// .convert_generation`), essentially 100% of the actual prunable weight
+// lives inside one of these, not in the top-level graph at all. Without
+// this, the C++ port would silently prune nothing on such a model while
+// pruning.py's own `apply_structured_pruning`/`apply_attention_head_
+// pruning` (which this file is a behavior-identical port of) would prune
+// everything inside the subgraph -- a correctness gap, not just a missed
+// optimization.
+//
+// IterSubgraphs is the one shared primitive both public entry points below
+// build on: it walks `graph`'s own `node()` list and recursively every
+// nested GraphProto reachable from any node's GRAPH-/GRAPHS-typed
+// AttributeProto (genuinely recursive -- a subgraph's own nodes can
+// themselves carry further-nested subgraphs, e.g. an `If` inside a `Loop`
+// body), matched purely by `AttributeProto::type()` rather than a
+// per-op-name allowlist, so -- exactly like the Python original -- it
+// needs no update when some future op adds another graph-typed attribute.
+//
+// Every GraphProto* this returns is handed, completely independently, to
+// the existing per-graph Find*/Apply* functions below UNCHANGED -- never
+// merged with any sibling or ancestor graph's own state. This is what
+// makes the same two correctness properties pruning.py's own comment block
+// documents hold here too, with no extra bookkeeping:
+//
+// - Implicit-capture scoping: ONNX lets a subgraph's own node reference a
+//   name defined in an ENCLOSING graph's scope rather than its own
+//   node()/initializer() list (e.g. an `If` branch reading a weight that
+//   actually lives in the top-level graph's initializer list). Every
+//   Find*Chains function below resolves a weight/value strictly via an
+//   `init_map`/consumer map built from the one `graph` argument it was
+//   given -- never a caller's own enclosing scope -- so a node whose input
+//   only resolves in an outer scope simply fails to match and that chain
+//   is declined, the same "decline rather than mis-slice" behavior this
+//   file already applies to every other unresolvable topology. No
+//   subgraph is ever treated as if it could see outward.
+// - No double-counting across scopes: since every Apply*Chains function
+//   below only ever mutates a tensor found in the CURRENT graph's own
+//   mutable_initializer() list (never a parent's), and a parent-scope
+//   initializer an inner graph merely *reads* by implicit capture is --
+//   by the point above -- never even matched as prunable from inside that
+//   inner graph, there is no path by which processing a subgraph could
+//   reach into, and corrupt, a tensor that actually belongs to (and is
+//   separately, safely processed as part of) an ancestor or sibling
+//   graph's own pass. Each subgraph also gets its own fresh TouchedState
+//   (see ApplyStructuredPruning below) for the same reason pruning.py
+//   resets its own `_TouchedState` per graph: a name is only ever a
+//   "shared/tied initializer" conflict against another chain matched
+//   *within that same graph*, never across graphs -- ONNX names are
+//   scoped per-graph-tree-position and this file never merges two graphs'
+//   own initializer/consumer maps together.
+//
+// Depth-first, `graph.node()` then `node.attribute()` declaration order,
+// recursing into a found subgraph's own nested subgraphs before moving on
+// to the next node -- byte-for-byte the same traversal order as the
+// Python original, so a global_sparsity-style pooled ranking computed
+// per-graph (were the C++ port ever extended to that mode) would visit
+// graphs in the same order pruning.py does.
+std::vector<onnx::GraphProto*> IterSubgraphs(onnx::GraphProto* graph) {
+  std::vector<onnx::GraphProto*> graphs;
+  graphs.push_back(graph);
+  for (onnx::NodeProto& node : *graph->mutable_node()) {
+    for (onnx::AttributeProto& attr : *node.mutable_attribute()) {
+      if (attr.type() == onnx::AttributeProto::GRAPH) {
+        std::vector<onnx::GraphProto*> nested = IterSubgraphs(attr.mutable_g());
+        graphs.insert(graphs.end(), nested.begin(), nested.end());
+      } else if (attr.type() == onnx::AttributeProto::GRAPHS) {
+        for (onnx::GraphProto& g : *attr.mutable_graphs()) {
+          std::vector<onnx::GraphProto*> nested = IterSubgraphs(&g);
+          graphs.insert(graphs.end(), nested.begin(), nested.end());
+        }
+      }
+    }
+  }
+  return graphs;
+}
+
 }  // namespace
 
 onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
@@ -5229,53 +5318,66 @@ onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
         std::to_string(sparsity));
   }
   onnx::ModelProto out = model;
-  onnx::GraphProto* graph = out.mutable_graph();
 
-  std::vector<Chain> chains = FindChains(graph);
-  std::vector<Chain> gated_chains = FindGatedChains(graph);
-  std::vector<Chain> conv_chains = FindConvChains(graph);
-  std::vector<Chain> conv_residual_chains = FindConvResidualChains(graph);
-  std::vector<Chain> matmul_residual_chains = FindMatmulResidualChains(graph);
-  chains.insert(chains.end(), std::make_move_iterator(gated_chains.begin()),
-                std::make_move_iterator(gated_chains.end()));
-  chains.insert(chains.end(), std::make_move_iterator(conv_chains.begin()),
-                std::make_move_iterator(conv_chains.end()));
-  chains.insert(chains.end(),
-                std::make_move_iterator(conv_residual_chains.begin()),
-                std::make_move_iterator(conv_residual_chains.end()));
-  chains.insert(chains.end(),
-                std::make_move_iterator(matmul_residual_chains.begin()),
-                std::make_move_iterator(matmul_residual_chains.end()));
-  std::vector<ConcatChain> concat_chains = FindMatmulConcatChains(graph);
-  std::vector<ConcatChain> conv_concat_chains = FindConvConcatChains(graph);
-  concat_chains.insert(concat_chains.end(),
-                       std::make_move_iterator(conv_concat_chains.begin()),
-                       std::make_move_iterator(conv_concat_chains.end()));
-  std::vector<SplitGatedChain> split_gated_chains = FindSplitGatedChains(graph);
+  // Subgraph-aware (IterSubgraphs, see this file's own "Subgraph
+  // recursion" section comment above): every chain family below is
+  // matched and pruned inside a nested If/Loop/Scan/BeamSearch-family
+  // subgraph, at any nesting depth, exactly as if that subgraph were its
+  // own top-level graph -- each returned GraphProto* gets its own fresh
+  // TouchedState, so a "shared/tied initializer" conflict is only ever
+  // detected against another chain matched *within that same graph*,
+  // mirroring pruning.py's own apply_structured_pruning loop over
+  // `_iter_subgraphs(out.graph)` exactly (including resetting `touched`,
+  // and flushing `stale_value_info` into that same graph's own
+  // `value_info`, once per graph rather than once for the whole model).
+  for (onnx::GraphProto* graph : IterSubgraphs(out.mutable_graph())) {
+    std::vector<Chain> chains = FindChains(graph);
+    std::vector<Chain> gated_chains = FindGatedChains(graph);
+    std::vector<Chain> conv_chains = FindConvChains(graph);
+    std::vector<Chain> conv_residual_chains = FindConvResidualChains(graph);
+    std::vector<Chain> matmul_residual_chains = FindMatmulResidualChains(graph);
+    chains.insert(chains.end(), std::make_move_iterator(gated_chains.begin()),
+                  std::make_move_iterator(gated_chains.end()));
+    chains.insert(chains.end(), std::make_move_iterator(conv_chains.begin()),
+                  std::make_move_iterator(conv_chains.end()));
+    chains.insert(chains.end(),
+                  std::make_move_iterator(conv_residual_chains.begin()),
+                  std::make_move_iterator(conv_residual_chains.end()));
+    chains.insert(chains.end(),
+                  std::make_move_iterator(matmul_residual_chains.begin()),
+                  std::make_move_iterator(matmul_residual_chains.end()));
+    std::vector<ConcatChain> concat_chains = FindMatmulConcatChains(graph);
+    std::vector<ConcatChain> conv_concat_chains = FindConvConcatChains(graph);
+    concat_chains.insert(concat_chains.end(),
+                         std::make_move_iterator(conv_concat_chains.begin()),
+                         std::make_move_iterator(conv_concat_chains.end()));
+    std::vector<SplitGatedChain> split_gated_chains = FindSplitGatedChains(graph);
 
-  TouchedState touched;
-  if (!chains.empty()) {
-    ApplyChains(graph, chains, sparsity, touched);
-  }
-  if (!concat_chains.empty()) {
-    ApplyConcatChains(graph, concat_chains, sparsity, touched);
-  }
-  if (!split_gated_chains.empty()) {
-    // A genuinely separate application pass, not folded into ApplyChains --
-    // see FindSplitGatedChains/ApplySplitGatedChains's own section comment
-    // for why. Shares `touched` with the calls above so a weight this pass
-    // resizes can never be double-resized by (or double-resize) an ordinary
-    // chain/Concat-chain that happens to touch the same initializer.
-    ApplySplitGatedChains(graph, split_gated_chains, sparsity, touched);
-  }
-  if (!touched.stale_value_info.empty()) {
-    google::protobuf::RepeatedPtrField<onnx::ValueInfoProto> kept;
-    for (const auto& vi : graph->value_info()) {
-      if (!touched.stale_value_info.count(vi.name())) {
-        *kept.Add() = vi;
-      }
+    TouchedState touched;
+    if (!chains.empty()) {
+      ApplyChains(graph, chains, sparsity, touched);
     }
-    graph->mutable_value_info()->Swap(&kept);
+    if (!concat_chains.empty()) {
+      ApplyConcatChains(graph, concat_chains, sparsity, touched);
+    }
+    if (!split_gated_chains.empty()) {
+      // A genuinely separate application pass, not folded into ApplyChains
+      // -- see FindSplitGatedChains/ApplySplitGatedChains's own section
+      // comment for why. Shares `touched` with the calls above so a weight
+      // this pass resizes can never be double-resized by (or
+      // double-resize) an ordinary chain/Concat-chain that happens to
+      // touch the same initializer -- still scoped to this one graph only.
+      ApplySplitGatedChains(graph, split_gated_chains, sparsity, touched);
+    }
+    if (!touched.stale_value_info.empty()) {
+      google::protobuf::RepeatedPtrField<onnx::ValueInfoProto> kept;
+      for (const auto& vi : graph->value_info()) {
+        if (!touched.stale_value_info.count(vi.name())) {
+          *kept.Add() = vi;
+        }
+      }
+      graph->mutable_value_info()->Swap(&kept);
+    }
   }
   return out;
 }
@@ -5288,17 +5390,31 @@ onnx::ModelProto ApplyAttentionHeadPruning(const onnx::ModelProto& model,
         std::to_string(sparsity));
   }
   onnx::ModelProto out = model;
-  onnx::GraphProto* graph = out.mutable_graph();
 
-  std::vector<AttnChain> chains = FindAttentionChains(graph);
-  std::vector<AttnChain> gqa_chains = FindGqaChains(graph);
-  std::vector<AttnChain> onnx_attn_chains = FindOnnxAttentionChains(graph);
-  chains.insert(chains.end(), std::make_move_iterator(gqa_chains.begin()),
-                std::make_move_iterator(gqa_chains.end()));
-  chains.insert(chains.end(), std::make_move_iterator(onnx_attn_chains.begin()),
-                std::make_move_iterator(onnx_attn_chains.end()));
-  if (!chains.empty()) {
-    ApplyAttentionChains(graph, chains, sparsity);
+  // Subgraph-aware (IterSubgraphs, see this file's own "Subgraph
+  // recursion" section comment above): every chain family below is
+  // matched and pruned inside a nested If/Loop/Scan/BeamSearch-family
+  // subgraph, at any nesting depth, exactly as if that subgraph were its
+  // own top-level graph -- each Find*Chains call below is given one
+  // GraphProto* (top-level or nested) at a time, so a chain that would
+  // need to reach a producer/consumer only resolvable via an
+  // implicitly-captured name from an enclosing scope is declined (never
+  // matched) rather than mis-resolved, and ApplyAttentionChains only ever
+  // slices an initializer out of the one graph it was actually found in.
+  // Mirrors pruning.py's own apply_attention_head_pruning loop over
+  // `_iter_subgraphs(out.graph)`.
+  for (onnx::GraphProto* graph : IterSubgraphs(out.mutable_graph())) {
+    std::vector<AttnChain> chains = FindAttentionChains(graph);
+    std::vector<AttnChain> gqa_chains = FindGqaChains(graph);
+    std::vector<AttnChain> onnx_attn_chains = FindOnnxAttentionChains(graph);
+    chains.insert(chains.end(), std::make_move_iterator(gqa_chains.begin()),
+                  std::make_move_iterator(gqa_chains.end()));
+    chains.insert(chains.end(),
+                  std::make_move_iterator(onnx_attn_chains.begin()),
+                  std::make_move_iterator(onnx_attn_chains.end()));
+    if (!chains.empty()) {
+      ApplyAttentionChains(graph, chains, sparsity);
+    }
   }
   return out;
 }

--- a/tests/test_attention_head_pruning_cpp.py
+++ b/tests/test_attention_head_pruning_cpp.py
@@ -12,6 +12,7 @@ coverage for all three matched op families: plain ``com.microsoft::Attention``
 
 import numpy as np
 import onnx
+import onnx.helper
 import onnx.numpy_helper
 import pytest
 from onnx import parser
@@ -906,3 +907,188 @@ def test_cpp_attention_head_pruning_matches_python_reference_output():
     (y_py,) = _run(pruned_py, {"X": x})
     (y_cpp,) = _run(pruned_cpp, {"X": x})
     np.testing.assert_allclose(y_py, y_cpp, rtol=1e-4, atol=1e-4)
+
+
+# --- Subgraph recursion (If) -------------------------------------------------
+#
+# Covers `structured_pruning_entry.cpp`'s own `IterSubgraphs` and the
+# `ApplyAttentionHeadPruning` loop built on it -- a straight C++ port of
+# `onnxsim/pruning.py`'s own `_iter_subgraphs`/`apply_attention_head_pruning`
+# subgraph-recursion round (see that module's "Subgraph recursion" section
+# comment, and `structured_pruning_entry.cpp`'s own copy of it above
+# `IterSubgraphs`'s definition, for the full design rationale). Model shape
+# mirrors `tests/test_pruning.py`'s own `_if_attention_model`/
+# `test_attention_head_pruning_prunes_blocks_inside_if_branches` fixture,
+# just driven through `apply_attention_head_pruning_cpp` instead of the
+# pure-Python reference.
+#
+# `onnx.parser.parse_model`'s text format has no way to spell a graph-typed
+# node attribute (an `If`'s `then_branch`/`else_branch`), so the model below
+# uses `onnx.helper.make_node`/`make_graph` directly, per this repo's own
+# CLAUDE.md guidance for exactly this case -- see `test_structured_pruning_
+# cpp.py`'s own matching "Subgraph recursion" section for the `Loop`-body
+# half of this coverage (the two C++ port test files split the `If`/`Loop`
+# cases between them rather than duplicating both in each).
+
+
+def _attention_branch_nodes(K, H, D, Out, prefix, seed):
+    rng = np.random.default_rng(seed)
+    Nq = Nk = Nv = H * D
+    wqkv = rng.standard_normal((K, Nq + Nk + Nv)).astype(np.float32)
+    bqkv = rng.standard_normal((Nq + Nk + Nv,)).astype(np.float32)
+    wout = rng.standard_normal((Nv, Out)).astype(np.float32)
+    nodes = [
+        onnx.helper.make_node(
+            "Attention",
+            ["Xb", f"{prefix}Wqkv", f"{prefix}Bqkv"],
+            [f"{prefix}ctx"],
+            domain="com.microsoft",
+            num_heads=H,
+            qkv_hidden_sizes=[Nq, Nk, Nv],
+        ),
+        onnx.helper.make_node("MatMul", [f"{prefix}ctx", f"{prefix}Wout"], ["Yb"]),
+    ]
+    inits = [
+        _f32(wqkv, f"{prefix}Wqkv"),
+        _f32(bqkv, f"{prefix}Bqkv"),
+        _f32(wout, f"{prefix}Wout"),
+    ]
+    return nodes, inits, dict(wqkv=wqkv, bqkv=bqkv, wout=wout)
+
+
+def _if_attention_model(K=8, H=4, D=4, Out=6):
+    then_nodes, then_inits, then_cfg = _attention_branch_nodes(
+        K, H, D, Out, "then_", seed=1
+    )
+    else_nodes, else_inits, else_cfg = _attention_branch_nodes(
+        K, H, D, Out, "else_", seed=2
+    )
+    out_vi = onnx.helper.make_tensor_value_info(
+        "Yb", onnx.TensorProto.FLOAT, ["batch", "seq", Out]
+    )
+    then_graph = onnx.helper.make_graph(
+        then_nodes, "then_graph", [], [out_vi], initializer=then_inits
+    )
+    else_graph = onnx.helper.make_graph(
+        else_nodes, "else_graph", [], [out_vi], initializer=else_inits
+    )
+    if_node = onnx.helper.make_node(
+        "If", ["cond"], ["Y1"], then_branch=then_graph, else_branch=else_graph
+    )
+    xb = onnx.helper.make_tensor_value_info(
+        "Xb", onnx.TensorProto.FLOAT, ["batch", "seq", K]
+    )
+    cond = onnx.helper.make_tensor_value_info("cond", onnx.TensorProto.BOOL, [])
+    y1 = onnx.helper.make_tensor_value_info(
+        "Y1", onnx.TensorProto.FLOAT, ["batch", "seq", Out]
+    )
+    graph = onnx.helper.make_graph([if_node], "g", [xb, cond], [y1])
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 17),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    model.ir_version = 10
+    onnx.checker.check_model(model)
+    return model, dict(then=then_cfg, else_=else_cfg)
+
+
+def _then_else_graphs(pruned_model):
+    if_node = next(n for n in pruned_model.graph.node if n.op_type == "If")
+    then_g = else_g = None
+    for attr in if_node.attribute:
+        if attr.name == "then_branch":
+            then_g = attr.g
+        elif attr.name == "else_branch":
+            else_g = attr.g
+    return then_g, else_g
+
+
+def test_cpp_attention_head_pruning_prunes_blocks_inside_if_branches():
+    # The core repro: apply_attention_head_pruning_cpp must match and prune
+    # the merged-QKV Attention block inside BOTH `then_branch` and
+    # `else_branch` -- each with its own independent weights and its own
+    # independently-computed importance ranking/kept-head set -- not just a
+    # top-level block. Verified by initializer shape, by the node's own
+    # updated `num_heads` attribute, and by an exact oracle cross-check per
+    # branch (mirroring `test_cpp_attention_head_pruning_matches_manual_
+    # head_deletion_exactly`'s own oracle, just built independently once per
+    # branch to prove neither branch's ranking leaked into the other's).
+    K, H, D, Out = 8, 4, 4, 6
+    model, cfg = _if_attention_model(K=K, H=H, D=D, Out=Out)
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    then_g, else_g = _then_else_graphs(pruned)
+    rng = np.random.default_rng(4)
+    xb = rng.standard_normal((2, 3, K)).astype(np.float32)
+
+    for g, prefix, branch_cfg, cond in [
+        (then_g, "then_", cfg["then"], True),
+        (else_g, "else_", cfg["else_"], False),
+    ]:
+        inits = {t.name: t for t in g.initializer}
+        assert list(inits[f"{prefix}Wqkv"].dims) == [K, 3 * (H // 2) * D]
+        assert list(inits[f"{prefix}Wout"].dims) == [(H // 2) * D, Out]
+        node = next(n for n in g.node if n.op_type == "Attention")
+        num_heads = next(a.i for a in node.attribute if a.name == "num_heads")
+        assert num_heads == H // 2
+
+        wqkv, bqkv, wout = branch_cfg["wqkv"], branch_cfg["bqkv"], branch_cfg["wout"]
+        Nq = Nk = Nv = H * D
+        keep = _oracle_keep_heads(wqkv, Nq, Nk, Nv, H, H // 2)
+        qi, ki, vi = (
+            _head_idx(keep, D),
+            _head_idx(keep, D) + Nq,
+            _head_idx(keep, D) + Nq + Nk,
+        )
+        all_idx = np.concatenate([qi, ki, vi])
+        np.testing.assert_allclose(
+            onnx.numpy_helper.to_array(inits[f"{prefix}Wqkv"]),
+            wqkv[:, all_idx],
+            rtol=1e-5,
+            atol=1e-5,
+        )
+        np.testing.assert_allclose(
+            onnx.numpy_helper.to_array(inits[f"{prefix}Wout"]),
+            wout[_head_idx(keep, D), :],
+            rtol=1e-5,
+            atol=1e-5,
+        )
+
+        oracle_bqkv = bqkv[all_idx]
+        np.testing.assert_allclose(
+            onnx.numpy_helper.to_array(inits[f"{prefix}Bqkv"]),
+            oracle_bqkv,
+            rtol=1e-5,
+            atol=1e-5,
+        )
+
+        (yb,) = _run(pruned, {"Xb": xb, "cond": np.array(cond)})
+        assert yb.shape == (2, 3, Out)
+        assert np.all(np.isfinite(yb))
+
+
+def test_cpp_attention_head_pruning_matches_python_reference_output_with_if_subgraph():
+    # Cross-check against onnxsim.apply_attention_head_pruning (the
+    # pure-Python reference this C++ port mirrors) on a model where the
+    # only prunable attention block lives inside the `If`'s own branches --
+    # both `cond` values are driven through InferenceSession so both
+    # branches' own subgraph-recursion behavior is exercised.
+    K, H, D, Out = 8, 4, 4, 6
+    model, _cfg = _if_attention_model(K=K, H=H, D=D, Out=Out)
+
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_py)
+    onnx.checker.check_model(pruned_cpp)
+
+    rng = np.random.default_rng(23)
+    xb = rng.standard_normal((2, 3, K)).astype(np.float32)
+    for cond in (True, False):
+        feeds = {"Xb": xb, "cond": np.array(cond)}
+        (y_py,) = _run(pruned_py, feeds)
+        (y_cpp,) = _run(pruned_cpp, feeds)
+        np.testing.assert_allclose(y_py, y_cpp, rtol=1e-4, atol=1e-4)

--- a/tests/test_structured_pruning_cpp.py
+++ b/tests/test_structured_pruning_cpp.py
@@ -2769,6 +2769,443 @@ def test_cpp_structured_pruning_matmul_residual_clip_pass_through_hop_matches_or
     np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
 
 
+# --- Conv chain: GroupNormalization pass-through hop -------------------------
+#
+# `Conv -> GroupNormalization -> Conv`: mirrors test_pruning.py's own
+# `_group_norm_conv_pair_model` and its group-norm-pass-through test coverage.
+# Unlike PRelu/Clip, a mid-chain GroupNorm hop constrains `ChainGroup()`'s own
+# per-block `keep` selection to its own `num_groups` (see GroupNormPassThrough
+# and ChainGroup in structured_pruning_entry.cpp), so the oracle here uses
+# `_oracle_keep_indices_conv_grouped`, not the plain `_oracle_keep_indices_conv`
+# every other Conv-chain hop test uses.
+
+
+def _group_norm_conv_pair_model(w1, w2, gn_scale, gn_bias, num_groups, group1=1, b1=None):
+    Cin, C2 = w1.shape[1] * group1, w2.shape[0]
+    initializer = [
+        _f32(w1, "W1"),
+        _f32(w2, "W2"),
+        _f32(gn_scale, "GNScale"),
+        _f32(gn_bias, "GNBias"),
+    ]
+    g1 = f", group={group1}" if group1 != 1 else ""
+    if b1 is not None:
+        conv1 = f"h = Conv<kernel_shape=[3,3]{g1}>(X, W1, B1)"
+        initializer.append(_f32(b1, "B1"))
+    else:
+        conv1 = f"h = Conv<kernel_shape=[3,3]{g1}>(X, W1)"
+    return _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{C2},6,6] Y)
+        {{
+          {conv1}
+          gn = GroupNormalization<num_groups={num_groups}, epsilon=1e-05>(h, GNScale, GNBias)
+          Y = Conv<kernel_shape=[3,3]>(gn, W2)
+        }}
+        """,
+        initializer=initializer,
+    )
+
+
+def test_cpp_structured_pruning_group_norm_pass_through_matches_oracle():
+    Cin, C1, C2, num_groups = 3, 16, 8, 4
+    rng = np.random.default_rng(220)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    b1 = rng.standard_normal((C1,)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    gn_scale = rng.standard_normal((C1,)).astype(np.float32)
+    gn_bias = rng.standard_normal((C1,)).astype(np.float32)
+    model = _group_norm_conv_pair_model(w1, w2, gn_scale, gn_bias, num_groups, b1=b1)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    # `num_groups` (a node attribute, not a tensor) is unchanged; the
+    # surviving channel count must still divide it evenly.
+    assert inits["W1"].shape[0] % num_groups == 0
+    assert inits["W1"].shape[0] < C1  # actually pruned, not a no-op
+    assert inits["GNScale"].shape == inits["GNBias"].shape == (C1 // 2,)
+    gn_node = next(n for n in pruned.graph.node if n.op_type == "GroupNormalization")
+    assert next(a.i for a in gn_node.attribute if a.name == "num_groups") == num_groups
+
+    keep = _oracle_keep_indices_conv_grouped(w1, num_groups, 0.5)
+    oracle = _group_norm_conv_pair_model(
+        w1[keep], w2[:, keep], gn_scale[keep], gn_bias[keep], num_groups, b1=b1[keep]
+    )
+
+    rng_x = np.random.default_rng(221)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_group_norm_num_groups_mismatch_with_grouped_conv_declines():
+    # A mid-chain GroupNorm hop's own `num_groups` disagreeing with a
+    # same-chain grouped Conv producer's own `group` -- the two partitions'
+    # block boundaries wouldn't generally align, so the whole chain is
+    # declined outright, never guessed at, the same bar a plain
+    # producer_group != consumer_group mismatch already gets.
+    Cin, C1, C2, group1, num_groups = 4, 8, 8, 2, 4
+    rng = np.random.default_rng(222)
+    w1 = rng.standard_normal((C1, Cin // group1, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    gn_scale = rng.standard_normal((C1,)).astype(np.float32)
+    gn_bias = rng.standard_normal((C1,)).astype(np.float32)
+    model = _group_norm_conv_pair_model(
+        w1, w2, gn_scale, gn_bias, num_groups, group1=group1
+    )
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+    np.testing.assert_array_equal(inits["GNScale"], gn_scale)
+    np.testing.assert_array_equal(inits["GNBias"], gn_bias)
+
+
+def test_cpp_structured_pruning_group_norm_tied_scale_bias_declines():
+    # `scale`/`bias` naming the *same* tensor -- double-slicing it in
+    # ApplyChains's own per-hop loop would corrupt it, so this is declined
+    # outright, mirroring pruning.py's own tied-name bar
+    # (_match_group_norm_pass_through).
+    Cin, C1, C2, num_groups = 3, 8, 4, 2
+    rng = np.random.default_rng(223)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    tied = rng.standard_normal((C1,)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{C2},6,6] Y)
+        {{
+          h = Conv<kernel_shape=[3,3]>(X, W1)
+          gn = GroupNormalization<num_groups={num_groups}, epsilon=1e-05>(h, Tied, Tied)
+          Y = Conv<kernel_shape=[3,3]>(gn, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2"), _f32(tied, "Tied")],
+    )
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+    np.testing.assert_array_equal(inits["Tied"], tied)
+
+
+# --- Conv chain: Resize channel-safe pass-through hop -------------------------
+#
+# `Conv -> Resize(scales, spatial-only) -> Conv`: the U-Net/diffusion-model-
+# decoder-style upsampling shape. Mirrors test_pruning.py's own
+# `_resize_conv_pair_model` and its Resize-pass-through test coverage.
+
+
+def _resize_conv_pair_model(w1, w2, scales, b1=None, spatial=8, out_spatial_hw=None):
+    Cin, C2 = w1.shape[1], w2.shape[0]
+    initializer = [
+        _f32(w1, "W1"),
+        _f32(w2, "W2"),
+        onnx.numpy_helper.from_array(np.asarray(scales, dtype=np.float32), "Scales"),
+    ]
+    if b1 is not None:
+        conv1 = "h = Conv<kernel_shape=[3,3]>(X, W1, B1)"
+        initializer.append(_f32(b1, "B1"))
+    else:
+        conv1 = "h = Conv<kernel_shape=[3,3]>(X, W1)"
+    after_conv1 = spatial - 2
+    if out_spatial_hw is None:
+        mid_h = round(after_conv1 * scales[2])
+        out_spatial_hw = mid_h - 2
+    return _model(
+        f"""
+        g (float[N,{Cin},{spatial},{spatial}] X) => (float[N,{C2},{out_spatial_hw},{out_spatial_hw}] Y)
+        {{
+          {conv1}
+          p = Resize<mode="nearest">(h, , Scales)
+          Y = Conv<kernel_shape=[3,3]>(p, W2)
+        }}
+        """,
+        initializer=initializer,
+    )
+
+
+def test_cpp_structured_pruning_resize_channel_safe_pass_through_matches_oracle():
+    Cin, C1, C2 = 3, 16, 8
+    rng = np.random.default_rng(224)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    b1 = rng.standard_normal((C1,)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    scales = [1.0, 1.0, 2.0, 2.0]
+    model = _resize_conv_pair_model(w1, w2, scales, b1=b1)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [C1 // 2, Cin, 3, 3]
+    assert list(inits["W2"].dims) == [C2, C1 // 2, 3, 3]
+
+    keep = _oracle_keep_indices_conv(w1, C1 // 2)
+    oracle = _resize_conv_pair_model(w1[keep], w2[:, keep], scales, b1=b1[keep])
+
+    rng_x = np.random.default_rng(225)
+    x = rng_x.standard_normal((2, Cin, 8, 8)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_resize_channel_affecting_declines():
+    # scales[1] (the channel axis) == 2.0 -- genuinely resizes the channel
+    # axis itself, so it must be declined outright, never guessed at.
+    Cin, C1, C2 = 3, 8, 4
+    rng = np.random.default_rng(226)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    scales = [1.0, 2.0, 1.0, 1.0]
+    w2 = rng.standard_normal((C2, C1 * 2, 3, 3)).astype(np.float32)
+    model = _resize_conv_pair_model(w1, w2, scales, out_spatial_hw=4)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+
+
+def test_cpp_structured_pruning_resize_dynamic_scales_declines():
+    # `scales` computed at runtime (Shape -> Cast) rather than a constant
+    # initializer -- this pass cannot know which axis is affected without
+    # evaluating the graph, so it must decline outright, never guessed at.
+    Cin, C1, C2 = 3, 8, 4
+    rng = np.random.default_rng(227)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},8,8] X) => (float[N,{C2},4,4] Y)
+        {{
+          h = Conv<kernel_shape=[3,3]>(X, W1)
+          shp = Shape(h)
+          scales_dyn = Cast<to=1>(shp)
+          p = Resize<mode="nearest">(h, , scales_dyn)
+          Y = Conv<kernel_shape=[3,3]>(p, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2")],
+    )
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+
+
+def test_cpp_structured_pruning_conv_residual_resize_pass_through_hop_matches_oracle():
+    # A channel-safe Resize crossed by the *backward* walk
+    # (WalkConvProducerBackward) -- exercises the residual-chain insertion
+    # point, not just the forward one.
+    Cin, C, Cout = 3, 16, 8
+    rng = np.random.default_rng(228)
+    w_f = rng.standard_normal((C, Cin, 3, 3)).astype(np.float32)
+    scales = np.array([1.0, 1.0, 1.0, 1.0], dtype=np.float32)
+    w_s = rng.standard_normal((C, Cin, 3, 3)).astype(np.float32)
+    w_out = rng.standard_normal((Cout, C, 3, 3)).astype(np.float32)
+
+    def _mk(w_f, w_s, w_out):
+        return _model(
+            f"""
+            g (float[N,{Cin},10,10] X) => (float[N,{Cout},6,6] Y)
+            {{
+              f0 = Conv<kernel_shape=[3,3]>(X, WF)
+              f = Resize<mode="nearest">(f0, , Scales)
+              s = Conv<kernel_shape=[3,3]>(X, WS)
+              addr = Add(f, s)
+              r = Relu(addr)
+              Y = Conv<kernel_shape=[3,3]>(r, WOUT)
+            }}
+            """,
+            initializer=[
+                _f32(w_f, "WF"),
+                onnx.numpy_helper.from_array(scales, "Scales"),
+                _f32(w_s, "WS"),
+                _f32(w_out, "WOUT"),
+            ],
+        )
+
+    model = _mk(w_f, w_s, w_out)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    importance = np.sqrt(
+        np.square(np.linalg.norm(w_f.reshape(C, -1).astype(np.float64), axis=1))
+        + np.square(np.linalg.norm(w_s.reshape(C, -1).astype(np.float64), axis=1))
+    )
+    keep = np.sort(np.argsort(-importance)[: C // 2])
+    oracle = _mk(w_f[keep], w_s[keep], w_out[:, keep])
+
+    rng_x = np.random.default_rng(229)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+# --- Conv chain: Pad channel-safe pass-through hop ----------------------------
+#
+# `Conv -> Pad -> Conv`: mirrors test_pruning.py's own `_pad_conv_pair_model`
+# and its Pad-pass-through test coverage.
+
+
+def _pad_conv_pair_model(w1, w2, pads, b1=None, spatial=8):
+    """`Conv -> Pad -> Conv`, `pads` the raw 8-element (`2 * rank` for a
+    rank-4 NCHW tensor) ONNX `pads` layout: `[x1_begin, ..., xk_begin,
+    x1_end, ..., xk_end]`."""
+    Cin, C2 = w1.shape[1], w2.shape[0]
+    pads = np.asarray(pads, dtype=np.int64)
+    rank = len(pads) // 2
+    initializer = [
+        _f32(w1, "W1"),
+        _f32(w2, "W2"),
+        onnx.numpy_helper.from_array(pads, "Pads"),
+    ]
+    if b1 is not None:
+        conv1 = "h = Conv<kernel_shape=[3,3]>(X, W1, B1)"
+        initializer.append(_f32(b1, "B1"))
+    else:
+        conv1 = "h = Conv<kernel_shape=[3,3]>(X, W1)"
+    after_conv1 = spatial - 2
+    mid_h = after_conv1 + pads[2] + pads[rank + 2]  # axis 2 (H) begin+end pad
+    out_spatial = mid_h - 2
+    return _model(
+        f"""
+        g (float[N,{Cin},{spatial},{spatial}] X) => (float[N,{C2},{out_spatial},{out_spatial}] Y)
+        {{
+          {conv1}
+          p = Pad<mode="constant">(h, Pads)
+          Y = Conv<kernel_shape=[3,3]>(p, W2)
+        }}
+        """,
+        initializer=initializer,
+    )
+
+
+def test_cpp_structured_pruning_pad_channel_safe_pass_through_matches_oracle():
+    Cin, C1, C2 = 3, 16, 8
+    rng = np.random.default_rng(230)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    b1 = rng.standard_normal((C1,)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    pads = [0, 0, 1, 1, 0, 0, 1, 1]
+    model = _pad_conv_pair_model(w1, w2, pads, b1=b1)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [C1 // 2, Cin, 3, 3]
+    assert list(inits["W2"].dims) == [C2, C1 // 2, 3, 3]
+
+    keep = _oracle_keep_indices_conv(w1, C1 // 2)
+    oracle = _pad_conv_pair_model(w1[keep], w2[:, keep], pads, b1=b1[keep])
+
+    rng_x = np.random.default_rng(231)
+    x = rng_x.standard_normal((2, Cin, 8, 8)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_pad_channel_affecting_declines():
+    # Nonzero padding on axis 1 (channel) -- changes the output channel
+    # count outright, so this must be declined, never guessed at.
+    Cin, C1, C2 = 3, 8, 4
+    rng = np.random.default_rng(232)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    pads = [0, 1, 0, 0, 0, 1, 0, 0]
+    w2 = rng.standard_normal((C2, C1 + 2, 3, 3)).astype(np.float32)
+    model = _pad_conv_pair_model(w1, w2, pads)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+
+
+def test_cpp_structured_pruning_pad_dynamic_pads_declines():
+    # `pads` computed at runtime (a non-constant node output) rather than a
+    # constant initializer -- declined outright for the same reason as a
+    # dynamic Resize `scales` above.
+    Cin, C1, C2 = 3, 8, 4
+    rng = np.random.default_rng(233)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},8,8] X, int64[8] PadsIn) => (float[N,{C2},4,4] Y)
+        {{
+          h = Conv<kernel_shape=[3,3]>(X, W1)
+          pads_dyn = Identity(PadsIn)
+          p = Pad<mode="constant">(h, pads_dyn)
+          Y = Conv<kernel_shape=[3,3]>(p, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2")],
+    )
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+
+
+def test_cpp_structured_pruning_conv_residual_pad_pass_through_hop_matches_oracle():
+    # A channel-safe Pad crossed by the *backward* walk
+    # (WalkConvProducerBackward) -- exercises the residual-chain insertion
+    # point, not just the forward one.
+    Cin, C, Cout = 3, 16, 8
+    rng = np.random.default_rng(234)
+    w_f = rng.standard_normal((C, Cin, 3, 3)).astype(np.float32)
+    # All-zero pads (a no-op Pad node) -- keeps both Add operands' shapes
+    # equal (the merge point's own requirement) while still exercising the
+    # channel-safety matcher (pads[1] == pads[rank+1] == 0 is trivially true).
+    pads = np.array([0, 0, 0, 0, 0, 0, 0, 0], dtype=np.int64)
+    w_s = rng.standard_normal((C, Cin, 3, 3)).astype(np.float32)
+    w_out = rng.standard_normal((Cout, C, 3, 3)).astype(np.float32)
+
+    def _mk(w_f, w_s, w_out):
+        return _model(
+            f"""
+            g (float[N,{Cin},10,10] X) => (float[N,{Cout},6,6] Y)
+            {{
+              f0 = Conv<kernel_shape=[3,3]>(X, WF)
+              f = Pad<mode="constant">(f0, Pads)
+              s = Conv<kernel_shape=[3,3]>(X, WS)
+              addr = Add(f, s)
+              r = Relu(addr)
+              Y = Conv<kernel_shape=[3,3]>(r, WOUT)
+            }}
+            """,
+            initializer=[
+                _f32(w_f, "WF"),
+                onnx.numpy_helper.from_array(pads, "Pads"),
+                _f32(w_s, "WS"),
+                _f32(w_out, "WOUT"),
+            ],
+        )
+
+    model = _mk(w_f, w_s, w_out)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    importance = np.sqrt(
+        np.square(np.linalg.norm(w_f.reshape(C, -1).astype(np.float64), axis=1))
+        + np.square(np.linalg.norm(w_s.reshape(C, -1).astype(np.float64), axis=1))
+    )
+    keep = np.sort(np.argsort(-importance)[: C // 2])
+    oracle = _mk(w_f[keep], w_s[keep], w_out[:, keep])
+
+    rng_x = np.random.default_rng(235)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
 # --- Concat-merged (skip-connection) chains ----------------------------------
 
 

--- a/tests/test_structured_pruning_cpp.py
+++ b/tests/test_structured_pruning_cpp.py
@@ -2780,7 +2780,9 @@ def test_cpp_structured_pruning_matmul_residual_clip_pass_through_hop_matches_or
 # every other Conv-chain hop test uses.
 
 
-def _group_norm_conv_pair_model(w1, w2, gn_scale, gn_bias, num_groups, group1=1, b1=None):
+def _group_norm_conv_pair_model(
+    w1, w2, gn_scale, gn_bias, num_groups, group1=1, b1=None
+):
     Cin, C2 = w1.shape[1] * group1, w2.shape[0]
     initializer = [
         _f32(w1, "W1"),
@@ -3795,7 +3797,9 @@ def _loop_wrapped_mlp_model(K0=8, H0=16, Out0=4, K1=6, H1=12, OutB=3, M=3):
     iter_num_vi = onnx.helper.make_tensor_value_info(
         "iter_num", onnx.TensorProto.INT64, []
     )
-    cond_in_vi = onnx.helper.make_tensor_value_info("cond_in", onnx.TensorProto.BOOL, [])
+    cond_in_vi = onnx.helper.make_tensor_value_info(
+        "cond_in", onnx.TensorProto.BOOL, []
+    )
     cond_out_vi = onnx.helper.make_tensor_value_info(
         "cond_out", onnx.TensorProto.BOOL, []
     )
@@ -3968,7 +3972,9 @@ def test_cpp_structured_pruning_matches_python_reference_output_with_if_subgraph
     # whichever one a single run happens to select.
     K0, H0, Out0 = 8, 16, 4
     K1, H1, OutB = 6, 12, 3
-    model, _cfg = _if_wrapped_mlp_model(K0=K0, H0=H0, Out0=Out0, K1=K1, H1=H1, OutB=OutB)
+    model, _cfg = _if_wrapped_mlp_model(
+        K0=K0, H0=H0, Out0=Out0, K1=K1, H1=H1, OutB=OutB
+    )
 
     pruned_py = onnxsim.apply_structured_pruning(model, sparsity=0.5)
     pruned_cpp = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)

--- a/tests/test_structured_pruning_cpp.py
+++ b/tests/test_structured_pruning_cpp.py
@@ -3209,3 +3209,341 @@ def test_cpp_structured_pruning_matches_python_reference_output():
     (y_py,) = _run(pruned_py, {"X": x})
     (y_cpp,) = _run(pruned_cpp, {"X": x})
     np.testing.assert_allclose(y_py, y_cpp, rtol=1e-5, atol=1e-5)
+
+
+# --- Subgraph recursion (If/Loop) --------------------------------------------
+#
+# Covers `structured_pruning_entry.cpp`'s own `IterSubgraphs` and the
+# `ApplyStructuredPruning` loop built on it -- a straight C++ port of
+# `onnxsim/pruning.py`'s own `_iter_subgraphs`/`apply_structured_pruning`
+# subgraph-recursion round (see that module's "Subgraph recursion" section
+# comment, and `structured_pruning_entry.cpp`'s own copy of it directly
+# above `IterSubgraphs`'s definition, for the full design rationale). Model
+# shapes below mirror `tests/test_pruning.py`'s own
+# `_if_wrapped_mlp_model`/`test_structured_pruning_prunes_top_level_and_
+# both_if_branches` fixture exactly, so a diff against those tests is the
+# fastest way to see this is deliberately the same scenario, just driven
+# through `apply_structured_pruning_cpp` instead of the pure-Python
+# reference.
+#
+# `onnx.parser.parse_model`'s text format has no way to spell a graph-typed
+# node attribute (an `If`'s `then_branch`/`else_branch`, a `Loop`'s
+# `body`), so every model below uses `onnx.helper.make_node`/`make_graph`
+# directly instead, per this repo's own CLAUDE.md guidance for exactly this
+# case.
+
+
+def _mlp_branch_nodes(K, H, Out, prefix, seed):
+    # A minimal MatMul(Gemm)->Relu->MatMul chain, exactly `_mlp_model`'s own
+    # shape, but returning bare nodes/initializers (not a whole model) so it
+    # can be dropped into a subgraph's own `node`/`initializer` lists.
+    rng = np.random.default_rng(seed)
+    w1 = rng.standard_normal((K, H)).astype(np.float32)
+    b1 = rng.standard_normal((H,)).astype(np.float32)
+    w2 = rng.standard_normal((H, Out)).astype(np.float32)
+    nodes = [
+        onnx.helper.make_node(
+            "Gemm", ["Xb", f"{prefix}W1", f"{prefix}B1"], [f"{prefix}h"]
+        ),
+        onnx.helper.make_node("Relu", [f"{prefix}h"], [f"{prefix}a"]),
+        onnx.helper.make_node("MatMul", [f"{prefix}a", f"{prefix}W2"], ["Yb"]),
+    ]
+    inits = [
+        _f32(w1, f"{prefix}W1"),
+        _f32(b1, f"{prefix}B1"),
+        _f32(w2, f"{prefix}W2"),
+    ]
+    return nodes, inits, dict(w1=w1, b1=b1, w2=w2)
+
+
+def _if_wrapped_mlp_model(K0=8, H0=16, Out0=4, K1=6, H1=12, OutB=3):
+    """A top-level MatMul(Gemm)->Relu->MatMul chain (`W1t`/`W2t`) PLUS an
+    `If` node whose `then_branch`/`else_branch` each carry their OWN
+    independent, identically-shaped MLP chain (`then_*`/`else_*`), with
+    their own weights living only in that branch's own `initializer` list.
+    `Xb` (the branch chains' shared activation input) is an ordinary
+    top-level graph input, read by both branches purely via implicit
+    capture (an `If` branch subgraph takes no formal inputs of its own).
+    `cond` selects which branch actually executes at run time.
+    """
+    rng = np.random.default_rng(0)
+    w1t = rng.standard_normal((K0, H0)).astype(np.float32)
+    b1t = rng.standard_normal((H0,)).astype(np.float32)
+    w2t = rng.standard_normal((H0, Out0)).astype(np.float32)
+    top_nodes = [
+        onnx.helper.make_node("Gemm", ["X0", "W1t", "B1t"], ["ht"]),
+        onnx.helper.make_node("Relu", ["ht"], ["at"]),
+        onnx.helper.make_node("MatMul", ["at", "W2t"], ["Y0"]),
+    ]
+    top_inits = [_f32(w1t, "W1t"), _f32(b1t, "B1t"), _f32(w2t, "W2t")]
+
+    then_nodes, then_inits, then_cfg = _mlp_branch_nodes(K1, H1, OutB, "then_", seed=1)
+    else_nodes, else_inits, else_cfg = _mlp_branch_nodes(K1, H1, OutB, "else_", seed=2)
+
+    out_vi = onnx.helper.make_tensor_value_info(
+        "Yb", onnx.TensorProto.FLOAT, ["batch", OutB]
+    )
+    then_graph = onnx.helper.make_graph(
+        then_nodes, "then_graph", [], [out_vi], initializer=then_inits
+    )
+    else_graph = onnx.helper.make_graph(
+        else_nodes, "else_graph", [], [out_vi], initializer=else_inits
+    )
+    if_node = onnx.helper.make_node(
+        "If", ["cond"], ["Y1"], then_branch=then_graph, else_branch=else_graph
+    )
+
+    x0 = onnx.helper.make_tensor_value_info("X0", onnx.TensorProto.FLOAT, ["batch", K0])
+    xb = onnx.helper.make_tensor_value_info("Xb", onnx.TensorProto.FLOAT, ["batch", K1])
+    cond = onnx.helper.make_tensor_value_info("cond", onnx.TensorProto.BOOL, [])
+    y0 = onnx.helper.make_tensor_value_info(
+        "Y0", onnx.TensorProto.FLOAT, ["batch", Out0]
+    )
+    y1 = onnx.helper.make_tensor_value_info(
+        "Y1", onnx.TensorProto.FLOAT, ["batch", OutB]
+    )
+
+    graph = onnx.helper.make_graph(
+        [*top_nodes, if_node],
+        "g",
+        [x0, xb, cond],
+        [y0, y1],
+        initializer=top_inits,
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 17)]
+    )
+    model.ir_version = 10
+    onnx.checker.check_model(model)
+    return model, dict(w1t=w1t, b1t=b1t, w2t=w2t, then=then_cfg, else_=else_cfg)
+
+
+def _then_else_graphs(pruned_model):
+    if_node = next(n for n in pruned_model.graph.node if n.op_type == "If")
+    then_g = else_g = None
+    for attr in if_node.attribute:
+        if attr.name == "then_branch":
+            then_g = attr.g
+        elif attr.name == "else_branch":
+            else_g = attr.g
+    return then_g, else_g
+
+
+def _loop_wrapped_mlp_model(K0=8, H0=16, Out0=4, K1=6, H1=12, OutB=3, M=3):
+    """The `Loop`-body counterpart of `_if_wrapped_mlp_model` above --
+    covers the other half of "If/Loop/Scan" this file's own "Subgraph
+    recursion" comment (and `structured_pruning_entry.cpp`'s own copy of
+    it) names. A top-level MatMul(Gemm)->Relu->MatMul chain (`W1t`/`W2t`)
+    PLUS a `Loop` node whose `body` carries its OWN independent MLP chain
+    (`loop_*`), with its own weights living only in the body's own
+    `initializer` list. `Xb` is read every iteration purely via implicit
+    capture from the top-level graph's own input (`Loop`'s body takes only
+    `iter_num`/`cond_in` as formal inputs -- no loop-carried dependency);
+    `Yb` is emitted as a `scan_output`, stacked across all `M` iterations
+    into `Ys`.
+    """
+    rng = np.random.default_rng(0)
+    w1t = rng.standard_normal((K0, H0)).astype(np.float32)
+    b1t = rng.standard_normal((H0,)).astype(np.float32)
+    w2t = rng.standard_normal((H0, Out0)).astype(np.float32)
+    top_nodes = [
+        onnx.helper.make_node("Gemm", ["X0", "W1t", "B1t"], ["ht"]),
+        onnx.helper.make_node("Relu", ["ht"], ["at"]),
+        onnx.helper.make_node("MatMul", ["at", "W2t"], ["Y0"]),
+    ]
+    top_inits = [_f32(w1t, "W1t"), _f32(b1t, "B1t"), _f32(w2t, "W2t")]
+
+    body_nodes, body_inits, body_cfg = _mlp_branch_nodes(K1, H1, OutB, "loop_", seed=1)
+    cond_pass_through = onnx.helper.make_node("Identity", ["cond_in"], ["cond_out"])
+    iter_num_vi = onnx.helper.make_tensor_value_info(
+        "iter_num", onnx.TensorProto.INT64, []
+    )
+    cond_in_vi = onnx.helper.make_tensor_value_info("cond_in", onnx.TensorProto.BOOL, [])
+    cond_out_vi = onnx.helper.make_tensor_value_info(
+        "cond_out", onnx.TensorProto.BOOL, []
+    )
+    yb_vi = onnx.helper.make_tensor_value_info(
+        "Yb", onnx.TensorProto.FLOAT, ["batch", OutB]
+    )
+    body_graph = onnx.helper.make_graph(
+        [*body_nodes, cond_pass_through],
+        "loop_body",
+        [iter_num_vi, cond_in_vi],
+        [cond_out_vi, yb_vi],
+        initializer=body_inits,
+    )
+    loop_node = onnx.helper.make_node("Loop", ["M", "cond"], ["Ys"], body=body_graph)
+
+    x0 = onnx.helper.make_tensor_value_info("X0", onnx.TensorProto.FLOAT, ["batch", K0])
+    xb = onnx.helper.make_tensor_value_info("Xb", onnx.TensorProto.FLOAT, ["batch", K1])
+    m = onnx.helper.make_tensor_value_info("M", onnx.TensorProto.INT64, [])
+    cond = onnx.helper.make_tensor_value_info("cond", onnx.TensorProto.BOOL, [])
+    y0 = onnx.helper.make_tensor_value_info(
+        "Y0", onnx.TensorProto.FLOAT, ["batch", Out0]
+    )
+    ys = onnx.helper.make_tensor_value_info(
+        "Ys", onnx.TensorProto.FLOAT, [M, "batch", OutB]
+    )
+
+    graph = onnx.helper.make_graph(
+        [*top_nodes, loop_node],
+        "g",
+        [x0, xb, m, cond],
+        [y0, ys],
+        initializer=top_inits,
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 17)]
+    )
+    model.ir_version = 10
+    onnx.checker.check_model(model)
+    return model, dict(w1t=w1t, b1t=b1t, w2t=w2t, loop=body_cfg)
+
+
+def test_cpp_structured_pruning_prunes_top_level_and_both_if_branches():
+    # The core repro: apply_structured_pruning_cpp must match and prune the
+    # chain inside BOTH `then_branch` and `else_branch` (each with its own
+    # independent weights) -- not just the top-level chain -- verified both
+    # by initializer shape and by driving real execution (through
+    # InferenceSession) into EACH branch via `cond`, comparing against an
+    # independently reconstructed "already pruned" numpy oracle for that
+    # branch's own weights. Also proves independence both ways: the
+    # top-level chain's own pruning is unaffected by what's inside the `If`
+    # (it lands on exactly the same oracle
+    # `test_cpp_structured_pruning_matches_python_reference_output` already
+    # checks for a subgraph-free model), and each branch's own pruning is
+    # unaffected by the top-level chain or its sibling branch.
+    K0, H0, Out0 = 8, 16, 4
+    K1, H1, OutB = 6, 12, 3
+    model, cfg = _if_wrapped_mlp_model(K0=K0, H0=H0, Out0=Out0, K1=K1, H1=H1, OutB=OutB)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    top_inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(top_inits["W1t"].dims) == [K0, H0 // 2]
+    assert list(top_inits["W2t"].dims) == [H0 // 2, Out0]
+
+    then_g, else_g = _then_else_graphs(pruned)
+    then_inits = {t.name: t for t in then_g.initializer}
+    else_inits = {t.name: t for t in else_g.initializer}
+    assert list(then_inits["then_W1"].dims) == [K1, H1 // 2]
+    assert list(then_inits["then_W2"].dims) == [H1 // 2, OutB]
+    assert list(else_inits["else_W1"].dims) == [K1, H1 // 2]
+    assert list(else_inits["else_W2"].dims) == [H1 // 2, OutB]
+
+    rng = np.random.default_rng(5)
+    x0 = rng.standard_normal((3, K0)).astype(np.float32)
+    xb = rng.standard_normal((3, K1)).astype(np.float32)
+
+    y0_true, y1_then = _run(pruned, {"X0": x0, "Xb": xb, "cond": np.array(True)})
+    y0_false, y1_else = _run(pruned, {"X0": x0, "Xb": xb, "cond": np.array(False)})
+
+    def _oracle(branch_cfg, keep_count):
+        w1, b1, w2 = branch_cfg["w1"], branch_cfg["b1"], branch_cfg["w2"]
+        keep = _oracle_keep_indices(w1, keep_count)
+        h = xb @ w1[:, keep] + b1[keep]
+        a = np.maximum(h, 0)
+        return a @ w2[keep, :]
+
+    np.testing.assert_allclose(
+        y1_then, _oracle(cfg["then"], H1 // 2), rtol=1e-5, atol=1e-5
+    )
+    np.testing.assert_allclose(
+        y1_else, _oracle(cfg["else_"], H1 // 2), rtol=1e-5, atol=1e-5
+    )
+
+    keep_top = _oracle_keep_indices(cfg["w1t"], H0 // 2)
+    h0 = x0 @ cfg["w1t"][:, keep_top] + cfg["b1t"][keep_top]
+    a0 = np.maximum(h0, 0)
+    y0_oracle = a0 @ cfg["w2t"][keep_top, :]
+    np.testing.assert_allclose(y0_true, y0_oracle, rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(y0_false, y0_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_prunes_top_level_and_loop_body():
+    # Same repro as the `If`-branch test above, but for a `Loop` body --
+    # both the top-level chain and the chain living entirely inside the
+    # `body` subgraph must be pruned to the same H1 // 2 width, each using
+    # its own independent (in this case, identical-modulo-independent-
+    # oracle) importance ranking, with neither affecting the other.
+    K0, H0, Out0 = 8, 16, 4
+    K1, H1, OutB = 6, 12, 3
+    M = 3
+    model, cfg = _loop_wrapped_mlp_model(
+        K0=K0, H0=H0, Out0=Out0, K1=K1, H1=H1, OutB=OutB, M=M
+    )
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    top_inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(top_inits["W1t"].dims) == [K0, H0 // 2]
+    assert list(top_inits["W2t"].dims) == [H0 // 2, Out0]
+
+    loop_node = next(n for n in pruned.graph.node if n.op_type == "Loop")
+    body = next(a.g for a in loop_node.attribute if a.name == "body")
+    body_inits = {t.name: t for t in body.initializer}
+    assert list(body_inits["loop_W1"].dims) == [K1, H1 // 2]
+    assert list(body_inits["loop_W2"].dims) == [H1 // 2, OutB]
+
+    rng = np.random.default_rng(6)
+    x0 = rng.standard_normal((3, K0)).astype(np.float32)
+    xb = rng.standard_normal((3, K1)).astype(np.float32)
+    y0, ys = _run(
+        pruned,
+        {
+            "X0": x0,
+            "Xb": xb,
+            "M": np.array(M, dtype=np.int64),
+            "cond": np.array(True),
+        },
+    )
+
+    def _oracle(branch_cfg, keep_count):
+        w1, b1, w2 = branch_cfg["w1"], branch_cfg["b1"], branch_cfg["w2"]
+        keep = _oracle_keep_indices(w1, keep_count)
+        h = xb @ w1[:, keep] + b1[keep]
+        a = np.maximum(h, 0)
+        return a @ w2[keep, :]
+
+    yb_oracle = _oracle(cfg["loop"], H1 // 2)
+    # Every iteration recomputes the exact same thing (no loop-carried
+    # state, `Xb` fixed across iterations), so every one of the M stacked
+    # scan-output slices must equal the same oracle.
+    np.testing.assert_allclose(
+        ys, np.broadcast_to(yb_oracle, ys.shape), rtol=1e-5, atol=1e-5
+    )
+
+    keep_top = _oracle_keep_indices(cfg["w1t"], H0 // 2)
+    h0 = x0 @ cfg["w1t"][:, keep_top] + cfg["b1t"][keep_top]
+    a0 = np.maximum(h0, 0)
+    y0_oracle = a0 @ cfg["w2t"][keep_top, :]
+    np.testing.assert_allclose(y0, y0_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_matches_python_reference_output_with_if_subgraph():
+    # Cross-check against onnxsim.apply_structured_pruning (the pure-Python
+    # reference this C++ port mirrors) on a model where the only prunable
+    # weight worth talking about lives inside the `If`'s own branches --
+    # both `cond` values are driven through InferenceSession so both
+    # branches' own subgraph-recursion behavior is exercised, not just
+    # whichever one a single run happens to select.
+    K0, H0, Out0 = 8, 16, 4
+    K1, H1, OutB = 6, 12, 3
+    model, _cfg = _if_wrapped_mlp_model(K0=K0, H0=H0, Out0=Out0, K1=K1, H1=H1, OutB=OutB)
+
+    pruned_py = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    pruned_cpp = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_py)
+    onnx.checker.check_model(pruned_cpp)
+
+    rng = np.random.default_rng(7)
+    x0 = rng.standard_normal((3, K0)).astype(np.float32)
+    xb = rng.standard_normal((3, K1)).astype(np.float32)
+    for cond in (True, False):
+        feeds = {"X0": x0, "Xb": xb, "cond": np.array(cond)}
+        y0_py, y1_py = _run(pruned_py, feeds)
+        y0_cpp, y1_cpp = _run(pruned_cpp, feeds)
+        np.testing.assert_allclose(y0_py, y0_cpp, rtol=1e-5, atol=1e-5)
+        np.testing.assert_allclose(y1_py, y1_cpp, rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
## Summary

Follow-up to #1027, continuing the Python → C++ parity effort for `onnxsim/structured_pruning_entry.cpp` (the C++ port of `onnxsim/pruning.py`'s structured/attention-head pruning). Closes two more gaps:

- **Subgraph recursion** — `apply_structured_pruning_cpp`/`apply_attention_head_pruning_cpp` previously only pruned the top-level graph. Adds `IterSubgraphs` (a DFS mirror of `pruning.py`'s `_iter_subgraphs`, matched purely by `AttributeProto::GRAPH`/`GRAPHS` type, not an op allowlist) and rewires both entry points to run their existing per-graph logic independently over every nested `If`/`Loop`/`Scan` (etc.) subgraph, at any depth — matching Python's implicit-capture-scoping and no-cross-graph-state-sharing correctness properties.
- **GroupNorm/Resize/Pad channel pass-through hops** — extends the pass-through-hop mechanism (already covering depthwise Conv, PRelu, Clip from #1027) to three more Conv-chain-only ops. GroupNorm's scale/bias are sliced via a dedicated `GroupNormPassThrough`/`Chain::group_norm` (its `num_groups` also takes over as the chain's channel-grouping count, mirroring `_chain_group`); Resize/Pad are pure "safe to cross" boolean conditions, mirroring Clip's.

## Testing

- `pip install --no-build-isolation -ve .`
- `python3 -m pytest -v tests/test_structured_pruning_cpp.py tests/test_attention_head_pruning_cpp.py tests/test_pruning_cpp.py` — 127 passed, 0 failed, including all pre-existing coverage (no regressions)
- `clang-format --dry-run --Werror` / `ruff format --check` / `ruff check` on touched files

## Scope / follow-up

Still missing from the C++ port after this: QDQ/MatMulNBits/int4-quantized structured pruning support, and whatever else `onnxsim/pruning.py` keeps growing (it's under active, fast-moving development). Left for further rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4t6ntCm72RfFf64W9GYB1

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4t6ntCm72RfFf64W9GYB1)_