### PR TITLE
Port decomposed LayerNorm/SiLU-GELU, InstanceNorm and CausalConvWithState hops to C++ structured pruning

### DIFF
--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -571,6 +571,19 @@ struct ConvPassThrough {
   onnx::NodeProto* node;
   std::string weight;
   std::optional<std::string> bias;
+  // Set only for a `CausalConvWithState` hop whose own `past_state` input
+  // (index 3) is itself a *constant* initializer -- a degenerate,
+  // unlikely-in-practice shape no real export produces (every real export
+  // feeds it as an ordinary graph input/runtime KV-cache-style buffer,
+  // needing no slicing at all -- the caller's own runtime data), but not
+  // one MatchCausalConvWithStatePassThrough assumes away: when set,
+  // ApplyChains/ApplyConcatChains slice its own channel axis (axis 1) by
+  // the same `keep` index set, mirroring GroupQueryAttention's own
+  // "slice if constant, leave alone if dynamic" treatment for its
+  // analogous `past_key`/`past_value`. Always nullopt for a depthwise Conv,
+  // InstanceNormalization, or PRelu hop. Mirrors pruning.py's own
+  // `_ConvPassThrough.past_state`.
+  std::optional<std::string> past_state;
 };
 
 struct ChainOp {
@@ -1011,9 +1024,17 @@ std::optional<ConvProducerMatch> MatchConvProducer(const onnx::NodeProto& node,
     return std::nullopt;
   }
   auto it = init_map.find(node.input(1));
+  // Any spatial rank n >= 1 (weight rank >= 3: one output-channel axis, one
+  // input-channel axis, at least one spatial axis) -- mirrors pruning.py's
+  // own _match_conv_producer exactly (see that function's own docstring:
+  // "1-D, 2-D, or 3-D alike"). Widened from this port's original
+  // exactly-rank-4 (2-D-only) bound so a 1-D Conv -- the only shape a real
+  // `CausalConvWithState` pipeline's own bracketing producer/consumer Conv
+  // can ever be, since that op's own I/O is always rank-3 -- can match here
+  // too; every existing rank-4 caller is unaffected, this only admits more.
   if (it == init_map.end() ||
       it->second->data_type() != onnx::TensorProto::FLOAT ||
-      it->second->dims_size() != 4) {
+      it->second->dims_size() < 3) {
     return std::nullopt;
   }
   const onnx::TensorProto* w = it->second;
@@ -1049,9 +1070,11 @@ std::optional<ConvConsumerMatch> MatchConvConsumer(const onnx::NodeProto& node,
     return std::nullopt;
   }
   auto it = init_map.find(node.input(1));
+  // See MatchConvProducer's own comment: any spatial rank n >= 1, mirroring
+  // pruning.py's own _match_conv_consumer.
   if (it == init_map.end() ||
       it->second->data_type() != onnx::TensorProto::FLOAT ||
-      it->second->dims_size() != 4) {
+      it->second->dims_size() < 3) {
     return std::nullopt;
   }
   const onnx::TensorProto* w = it->second;
@@ -1071,6 +1094,13 @@ std::optional<ConvConsumerMatch> MatchConvConsumer(const onnx::NodeProto& node,
 struct DepthwiseMatch {
   std::string weight;
   std::optional<std::string> bias;
+  // Set only by MatchCausalConvWithStatePassThrough, for a hop whose own
+  // `past_state` input (index 3) is itself a constant initializer of the
+  // documented rank-3 `(*, n_channels, *)` shape -- see that matcher's own
+  // comment. Always nullopt for a real depthwise Conv match
+  // (MatchDepthwiseConvPassThrough/MatchConvPassThroughSelf never set it --
+  // a plain Conv has no such fourth input at all).
+  std::optional<std::string> past_state;
 };
 
 std::optional<DepthwiseMatch> MatchDepthwiseConvPassThrough(
@@ -1083,7 +1113,9 @@ std::optional<DepthwiseMatch> MatchDepthwiseConvPassThrough(
     return std::nullopt;
   }
   const onnx::TensorProto* w = it->second;
-  if (w->data_type() != onnx::TensorProto::FLOAT || w->dims_size() != 4 ||
+  // Any spatial rank n >= 1 -- see MatchConvProducer's own comment; mirrors
+  // pruning.py's own _match_depthwise_conv_pass_through.
+  if (w->data_type() != onnx::TensorProto::FLOAT || w->dims_size() < 3 ||
       w->dims(0) != n_channels || w->dims(1) != 1 ||
       ConvGroupAttr(node) != n_channels) {
     return std::nullopt;
@@ -1097,7 +1129,75 @@ std::optional<DepthwiseMatch> MatchDepthwiseConvPassThrough(
       return std::nullopt;
     }
   }
-  return DepthwiseMatch{node.input(1), bias};
+  return DepthwiseMatch{node.input(1), bias, std::nullopt};
+}
+
+// The Conv-chain `CausalConvWithState` pass-through matcher used by
+// WalkToConvConsumer, mirroring pruning.py's own
+// _match_causal_conv_with_state_pass_through: if `node` is a plain
+// `ai.onnx::CausalConvWithState` node (opset 27+, domain "") whose constant
+// `weight` (input 1) is exactly the depthwise-Conv shape
+// MatchDepthwiseConvPassThrough already recognizes (`[n_channels, 1, k]`),
+// returns a DepthwiseMatch identical in shape to that matcher's own result
+// -- this op mixes no channels at all, identically to a depthwise Conv,
+// except it carries two extra per-channel-shaped operands a depthwise Conv
+// doesn't: an optional `bias` (input 2, identical treatment to a depthwise
+// Conv's own) and an optional `past_state` carry tensor (input 3), set on
+// the returned DepthwiseMatch only when it is itself a constant of the
+// documented rank-3 `(*, n_channels, *)` shape (axis 1 == n_channels) --
+// left nullopt (needing no slicing at all) when dynamic/absent, and this
+// whole match declined (nullopt) when it's a constant of any *other* shape
+// (never guessed at). This op's own second output, `present_state`, is
+// never a tensor this function slices (a runtime *output*, not a weight);
+// the caller (WalkToConvConsumer) is responsible for treating it as stale
+// alongside `output` -- see this file's own `stale_value_info` handling in
+// ApplyChains/ApplyConcatChains, which iterates every one of a hop node's
+// outputs, not just output(0), for exactly this reason.
+std::optional<DepthwiseMatch> MatchCausalConvWithStatePassThrough(
+    const onnx::NodeProto& node, const InitMap& init_map, int64_t n_channels) {
+  if (node.op_type() != "CausalConvWithState" || node.domain() != "") {
+    return std::nullopt;
+  }
+  if (node.input_size() < 2) {
+    return std::nullopt;
+  }
+  const std::string& w_name = node.input(1);
+  auto wit = init_map.find(w_name);
+  if (wit == init_map.end() ||
+      wit->second->data_type() != onnx::TensorProto::FLOAT ||
+      wit->second->dims_size() != 3 || wit->second->dims(0) != n_channels ||
+      wit->second->dims(1) != 1) {
+    return std::nullopt;
+  }
+  std::optional<std::string> bias;
+  if (node.input_size() > 2 && !node.input(2).empty()) {
+    bias = node.input(2);
+    auto bit = init_map.find(*bias);
+    if (bit == init_map.end() ||
+        bit->second->data_type() != onnx::TensorProto::FLOAT) {
+      return std::nullopt;  // Non-constant bias -- can't safely prune it.
+    }
+  }
+  std::optional<std::string> past_state;
+  if (node.input_size() > 3 && !node.input(3).empty()) {
+    auto pit = init_map.find(node.input(3));
+    if (pit != init_map.end()) {
+      // A constant past_state -- degenerate, but if present it must be the
+      // documented rank-3 (batch, channels, k-1) shape with axis 1 ==
+      // n_channels to be safely sliceable; anything else declines the whole
+      // hop rather than guessing which axis (if any) is really the channel
+      // one.
+      const onnx::TensorProto* ps = pit->second;
+      if (ps->data_type() != onnx::TensorProto::FLOAT || ps->dims_size() != 3 ||
+          ps->dims(1) != n_channels) {
+        return std::nullopt;
+      }
+      past_state = node.input(3);
+      // else: dynamic (an ordinary graph input/runtime buffer) -- the
+      // caller's own runtime data, needs no slicing, not tracked here.
+    }
+  }
+  return DepthwiseMatch{w_name, bias, past_state};
 }
 
 // True if `name` names a constant FLOAT initializer shaped like a flat
@@ -1180,6 +1280,62 @@ std::optional<GroupNormMatch> MatchGroupNormPassThrough(
     return std::nullopt;
   }
   return GroupNormMatch{scale_name, bias_name, num_groups};
+}
+
+struct InstanceNormMatch {
+  std::string scale;
+  std::string bias;
+};
+
+// The Conv-chain InstanceNormalization pass-through matcher used by
+// WalkToConvConsumer, mirroring pruning.py's own
+// _match_instance_norm_pass_through: if `node` is a plain (default-domain)
+// `InstanceNormalization` node (opset 6+) with constant, exactly-1-D
+// (`dims == [n_channels]`) `scale` (input 1) and `B` (input 2) -- both
+// required by the op's own schema -- returns `{scale_name, bias_name}`.
+// Declines (nullopt) on a missing/non-constant/wrongly-shaped `scale`/`B`,
+// or `scale`/`B` naming the same tensor (double-slicing it would corrupt
+// it, the same tied-name bar MatchGroupNormPassThrough already applies) --
+// none of these is guessed at.
+//
+// Unlike MatchGroupNormPassThrough's own FlatChannelConst bar
+// (`prod(dims) == dims[-1]`, deliberately loose enough to admit a
+// broadcastable-but-not-strictly-1-D shape like `[1, 1, C]`), this requires
+// `scale`/`B` to be *strictly* rank-1: the returned names are carried on a
+// plain ConvPassThrough (this hop's own `scale`/`B` playing that struct's
+// `weight`/`bias` role -- no dedicated struct needed here the way
+// GroupNormPassThrough needed one), whose own slicing (ApplyChains's own
+// SliceProducerWeight(..., is_conv=true) call) always slices axis 0 --
+// correct only when axis 0 already *is* the one-and-only axis, i.e.
+// strictly rank-1. A looser broadcastable shape would silently slice the
+// wrong axis instead of being declined, so this bar is deliberately
+// narrower than FlatChannelConst's -- not a missed generalization: the ONNX
+// schema itself only ever documents `scale`/`B` as rank-1 `[C]` for this
+// op (no opset ever gave it GroupNorm's own per-*group* alternate shape),
+// so nothing real is excluded by holding to that.
+std::optional<InstanceNormMatch> MatchInstanceNormPassThrough(
+    const onnx::NodeProto& node, const InitMap& init_map, int64_t n_channels) {
+  if (node.op_type() != "InstanceNormalization" || node.domain() != "" ||
+      node.input_size() != 3 || node.input(1).empty() ||
+      node.input(2).empty() || node.output_size() != 1) {
+    return std::nullopt;
+  }
+  const std::string& scale_name = node.input(1);
+  const std::string& bias_name = node.input(2);
+  if (scale_name == bias_name) {
+    return std::nullopt;  // Tied scale/B -- double-slicing would corrupt it.
+  }
+  auto sit = init_map.find(scale_name);
+  auto bit = init_map.find(bias_name);
+  if (sit == init_map.end() || bit == init_map.end() ||
+      sit->second->data_type() != onnx::TensorProto::FLOAT ||
+      bit->second->data_type() != onnx::TensorProto::FLOAT ||
+      sit->second->dims_size() != 1 || bit->second->dims_size() != 1 ||
+      sit->second->dims(0) != n_channels ||
+      bit->second->dims(0) != n_channels) {
+    return std::nullopt;
+  }
+  return InstanceNormMatch{scale_name, bias_name};
 }
 
 // True iff `node` (already confirmed by the caller to be a plain
@@ -1464,6 +1620,58 @@ WalkToConvConsumer(const std::string& start, const InitMap& init_map,
       break;
     }
 
+    if (nxt->op_type() == "CausalConvWithState" && nxt->domain() == "" &&
+        nxt->input_size() > 0 && nxt->input(0) == cur) {
+      // This op is never a consumer in its own right (unlike `Conv` above,
+      // which falls through to MatchConvConsumer on a depthwise-match
+      // miss), so a failed match here simply ends the walk -- mirrors
+      // pruning.py's own identical short-circuit in _walk_to_conv_consumer.
+      // See MatchCausalConvWithStatePassThrough's own comment for the full
+      // empirical schema findings, including why this hop is recognized
+      // only by this forward walk (WalkConvProducerBackward's own per-hop
+      // loop unconditionally declines any node with output_size() != 1, and
+      // this op always has two outputs).
+      auto cc = MatchCausalConvWithStatePassThrough(*nxt, init_map, n_channels);
+      if (cc) {
+        const std::string& out2 = nxt->output(0);
+        if (ConsumerCount(consumers_of, out2) != 1 ||
+            graph_outputs.count(out2)) {
+          break;
+        }
+        pass_through.push_back(
+            ConvPassThrough{nxt, cc->weight, cc->bias, cc->past_state});
+        cur = out2;
+        continue;
+      }
+      break;
+    }
+
+    if (nxt->op_type() == "InstanceNormalization" && nxt->domain() == "" &&
+        nxt->input_size() > 0 && nxt->input(0) == cur) {
+      // Recognized unconditionally (no `recognize_*` gate, and any number
+      // of times per chain, unlike the GroupNorm hop below) --
+      // InstanceNorm's per-channel-only statistics carry no
+      // group-boundary-drift risk to guard against, so this hop is exactly
+      // as unrestricted as a depthwise Conv hop above, reusing the same
+      // ConvPassThrough struct (its own `scale`/`B` playing that struct's
+      // `weight`/`bias` role) rather than needing a dedicated one. Like
+      // CausalConvWithState above, this op is never a consumer in its own
+      // right, so a failed match here simply ends the walk.
+      auto in_match = MatchInstanceNormPassThrough(*nxt, init_map, n_channels);
+      if (in_match) {
+        const std::string& out2 = nxt->output(0);
+        if (ConsumerCount(consumers_of, out2) != 1 ||
+            graph_outputs.count(out2)) {
+          break;
+        }
+        pass_through.push_back(
+            ConvPassThrough{nxt, in_match->scale, in_match->bias});
+        cur = out2;
+        continue;
+      }
+      break;
+    }
+
     if (recognize_group_norm && !group_norm &&
         nxt->op_type() == "GroupNormalization" && nxt->domain() == "" &&
         nxt->input_size() > 0 && nxt->input(0) == cur) {
@@ -1666,9 +1874,10 @@ std::optional<DepthwiseMatch> MatchConvPassThroughSelf(
     return std::nullopt;
   }
   auto it = init_map.find(node.input(1));
+  // Any spatial rank n >= 1 -- see MatchConvProducer's own comment.
   if (it == init_map.end() ||
       it->second->data_type() != onnx::TensorProto::FLOAT ||
-      it->second->dims_size() != 4) {
+      it->second->dims_size() < 3) {
     return std::nullopt;
   }
   return MatchDepthwiseConvPassThrough(node, init_map, it->second->dims(0));
@@ -1706,6 +1915,36 @@ std::optional<PreluMatch> MatchPreluPassThroughSelf(const onnx::NodeProto& node,
   const int64_t expected =
       it->second->dims_size() > 0 ? it->second->dims(0) : 1;
   return MatchPreluPassThrough(node, init_map, expected);
+}
+
+// The backward-walk (WalkConvProducerBackward) counterpart of
+// MatchInstanceNormPassThrough, mirroring pruning.py's own
+// _match_instance_norm_pass_through_self and MatchConvPassThroughSelf's own
+// identical trick: the backward walk doesn't know its group's shared
+// channel count yet at the point it first crosses this hop, so this checks
+// the node's own `scale` is self-consistently rank-1 by calling
+// MatchInstanceNormPassThrough with `scale`'s own `dims(0)` as the
+// "expected" n_channels -- trivially satisfying that one check and leaving
+// every other one (constant B, matching length, non-tied names) intact.
+// FindConvResidualChains/ResolveConvResidualGroupForConcat re-validate
+// every such hop against the group's real, established channel count once
+// resolved (the same generic pass_through re-validation a depthwise hop
+// already gets, keyed only on `hop.weight`'s own `dims(0)` -- `hop.weight`
+// here holds this op's own `scale` name, so that same generic check already
+// re-validates this hop correctly, with no dedicated InstanceNorm-specific
+// re-check needed).
+std::optional<InstanceNormMatch> MatchInstanceNormPassThroughSelf(
+    const onnx::NodeProto& node, const InitMap& init_map) {
+  if (node.op_type() != "InstanceNormalization" || node.input_size() < 2) {
+    return std::nullopt;
+  }
+  auto sit = init_map.find(node.input(1));
+  if (sit == init_map.end() ||
+      sit->second->data_type() != onnx::TensorProto::FLOAT ||
+      sit->second->dims_size() != 1) {
+    return std::nullopt;
+  }
+  return MatchInstanceNormPassThrough(node, init_map, sit->second->dims(0));
 }
 
 // Walks backward from tensor `start` through unary pass-through activations
@@ -1756,6 +1995,20 @@ ConvBackwardEdge WalkConvProducerBackward(
     auto dw = MatchConvPassThroughSelf(*node, init_map);
     if (dw) {
       pass_through.push_back(ConvPassThrough{node, dw->weight, dw->bias});
+      edges.push_back({node->input(0), node});
+      cur = node->input(0);
+      continue;
+    }
+
+    // Recognized unconditionally here too (no gate), mirroring
+    // MatchInstanceNormPassThrough's own unconditional recognition in
+    // WalkToConvConsumer -- InstanceNorm's per-channel-only statistics
+    // carry no group-boundary-drift risk to guard against, unlike the
+    // GroupNorm hop, which this backward walk never recognizes at all.
+    auto in_self = MatchInstanceNormPassThroughSelf(*node, init_map);
+    if (in_self) {
+      pass_through.push_back(
+          ConvPassThrough{node, in_self->scale, in_self->bias});
       edges.push_back({node->input(0), node});
       cur = node->input(0);
       continue;
@@ -3238,6 +3491,15 @@ void ApplyChains(onnx::GraphProto* graph, std::vector<Chain>& chains,
       if (hop.bias) {
         SliceLastAxis(init_map.at(*hop.bias), keep);
       }
+      if (hop.past_state) {
+        // A CausalConvWithState hop's own constant `past_state` -- rank-3
+        // `(batch, channels, k-1)`, channel axis 1 -- reuses
+        // SliceConsumerWeight's own `is_conv` branch (SliceAxis1 over
+        // dims(0)/dims(1) with `inner = prod(dims[2:])`), which slices
+        // exactly that axis; mirrors pruning.py's own _slice_axis1 call in
+        // _apply_conv_pass_through_hop.
+        SliceConsumerWeight(init_map.at(*hop.past_state), false, keep, true);
+      }
       // A PRelu per-channel-slope hop reuses ConvPassThrough for its own
       // slicing (see MatchPreluPassThrough's own comment) but, unlike a
       // depthwise Conv hop, has no `group` attribute of its own to update --
@@ -3283,6 +3545,9 @@ void ApplyChains(onnx::GraphProto* graph, std::vector<Chain>& chains,
         if (hop.bias) {
           SliceLastAxis(init_map.at(*hop.bias), keep);
         }
+        if (hop.past_state) {
+          SliceConsumerWeight(init_map.at(*hop.past_state), false, keep, true);
+        }
         if (hop.node->op_type() == "Conv") {
           SetOrAddIntAttr(hop.node, "group", static_cast<int64_t>(keep.size()));
         }
@@ -3318,8 +3583,13 @@ void ApplyChains(onnx::GraphProto* graph, std::vector<Chain>& chains,
     for (const auto& co : chain.chain_ops) {
       stale_value_info.insert(co.node->output(0));
     }
+    // Every output, not just [0] -- a hop node can have more than one (e.g.
+    // `CausalConvWithState`'s own `present_state`); see ConvPassThrough's
+    // own docstring.
     for (const auto& hop : chain.conv_pass_through) {
-      stale_value_info.insert(hop.node->output(0));
+      for (const auto& out : hop.node->output()) {
+        stale_value_info.insert(out);
+      }
     }
     if (chain.group_norm) {
       stale_value_info.insert(chain.group_norm->node->output(0));
@@ -3329,7 +3599,9 @@ void ApplyChains(onnx::GraphProto* graph, std::vector<Chain>& chains,
         stale_value_info.insert(co.node->output(0));
       }
       for (const auto& hop : b->conv_pass_through) {
-        stale_value_info.insert(hop.node->output(0));
+        for (const auto& out : hop.node->output()) {
+          stale_value_info.insert(out);
+        }
       }
     }
   }
@@ -5008,6 +5280,9 @@ void ApplyConcatChains(onnx::GraphProto* graph,
         if (hop.bias) {
           SliceLastAxis(init_map.at(*hop.bias), keep);
         }
+        if (hop.past_state) {
+          SliceConsumerWeight(init_map.at(*hop.past_state), false, keep, true);
+        }
         if (hop.node->op_type() == "Conv") {
           SetOrAddIntAttr(hop.node, "group", static_cast<int64_t>(keep.size()));
         }
@@ -5030,6 +5305,10 @@ void ApplyConcatChains(onnx::GraphProto* graph,
       SliceProducerWeight(init_map.at(hop.weight), false, global_keep, true);
       if (hop.bias) {
         SliceLastAxis(init_map.at(*hop.bias), global_keep);
+      }
+      if (hop.past_state) {
+        SliceConsumerWeight(init_map.at(*hop.past_state), false, global_keep,
+                            true);
       }
       if (hop.node->op_type() == "Conv") {
         SetOrAddIntAttr(hop.node, "group",
@@ -5059,15 +5338,22 @@ void ApplyConcatChains(onnx::GraphProto* graph,
       for (const auto& co : b.pre_ops) {
         touched.stale_value_info.insert(co.node->output(0));
       }
+      // Every output, not just [0] -- a hop node can have more than one
+      // (e.g. `CausalConvWithState`'s own `present_state`); see
+      // ConvPassThrough's own docstring.
       for (const auto& hop : b.conv_pass_through) {
-        touched.stale_value_info.insert(hop.node->output(0));
+        for (const auto& out : hop.node->output()) {
+          touched.stale_value_info.insert(out);
+        }
       }
     }
     for (const auto& co : chain.chain_ops) {
       touched.stale_value_info.insert(co.node->output(0));
     }
     for (const auto& hop : chain.conv_pass_through) {
-      touched.stale_value_info.insert(hop.node->output(0));
+      for (const auto& out : hop.node->output()) {
+        touched.stale_value_info.insert(out);
+      }
     }
   }
 }

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -115,6 +115,17 @@ const std::unordered_set<std::string>& UnaryPassThroughOps() {
       // membership here alone extends every walker that already consults
       // this set, mirroring pruning.py's own _UNARY_PASS_THROUGH.
       "QuickGelu",
+      // ai.onnx (domain "") Erf(X) -> Y, the error function: a single
+      // required input, a single output, no attributes at all -- exactly as
+      // unary/elementwise/parameter-free as every other entry here.
+      // Membership alone extends every walker that already consults this
+      // set for free, mirroring pruning.py's own identical addition -- but
+      // note it's only *part* of what a decomposed erf-GELU export needs:
+      // the rest (the scalar Div/Add operands, and the self-gating Mul
+      // against the walk's own running tensor) is a different shape unary
+      // membership alone can't reach -- see the "Self-gated activation
+      // decomposition" section comment above WalkGateBranch below.
+      "Erf",
   };
   return kOps;
 }
@@ -389,6 +400,34 @@ ConsumerMap ConsumersOf(onnx::GraphProto* graph) {
 size_t ConsumerCount(const ConsumerMap& consumers_of, const std::string& name) {
   auto it = consumers_of.find(name);
   return it == consumers_of.end() ? 0 : it->second.size();
+}
+
+// True if `name` names a constant FLOAT initializer shaped like a flat
+// per-channel vector (`prod(dims) == dims[-1]`) -- mirrors pruning.py's own
+// `_flat_channel_const` exactly: the self-consistency bar every per-channel
+// affine/bias/scale hop in this module checks before ever accepting a
+// tensor as a slice target. The real `dims[-1] == n_channels` check, once
+// the chain's real channel count is known, is left to the caller
+// (MatchGroupNormPassThrough, MatchDecomposedLayerNormPassThrough). Moved
+// ahead of MatchClipChannelPassThrough (its original position, still
+// unchanged relative to every other caller) so
+// MatchDecomposedLayerNormPassThrough below -- itself needed by WalkToConsumer,
+// which sits well before this function's own original location -- can call it.
+bool FlatChannelConst(const std::string& name, const InitMap& init_map) {
+  auto it = init_map.find(name);
+  if (it == init_map.end() ||
+      it->second->data_type() != onnx::TensorProto::FLOAT) {
+    return false;
+  }
+  const auto& dims = it->second->dims();
+  if (dims.size() == 0) {
+    return false;
+  }
+  int64_t prod = 1;
+  for (int64_t d : dims) {
+    prod *= d;
+  }
+  return prod == dims.Get(dims.size() - 1);
 }
 
 // True iff `node` (already confirmed by the caller to be a plain
@@ -695,6 +734,719 @@ struct ConsumerMatch {
   bool weight_transposed;
 };
 
+// --- Decomposed (not-yet-fused) LayerNorm pass-through, mirroring
+// pruning.py's own _match_decomposed_layer_norm_pass_through -----------------
+//
+// LayerNormalization's own schema is only opset 17+, so a model exported at
+// opset <= 16 -- still extremely common for broad runtime/NPU/TensorRT
+// compatibility -- has no fused op to lower nn.LayerNorm to at all, and
+// torch.onnx.export emits LayerNorm's own canonical decomposition as plain
+// ops instead:
+//
+//     mean     = ReduceMean(x, axes=[-1])
+//     centered = Sub(x, mean)
+//     sq       = Pow(centered, 2.0)
+//     var      = ReduceMean(sq, axes=[-1])
+//     var_eps  = Add(var, eps)
+//     std      = Sqrt(var_eps)
+//     normed   = Div(centered, std)
+//     scaled   = Mul(normed, gamma)
+//     out      = Add(scaled, beta)
+//
+// -- `x` consumed twice (by the first ReduceMean and by Sub), `centered`
+// consumed twice (by Pow and by Div), every other intermediate tensor
+// consumed exactly once. Recognized by WalkToConsumer as one more
+// MatMul/Gemm-chain-only hop (never WalkMatmulProducerBackward -- mirroring
+// pruning.py's own scope decision: the far more common shape a residual
+// Add's own operand resolves back through is an FFN's down-projection or an
+// attention block's own output projection, with no LayerNorm in between at
+// all), folding all 9 nodes into chain_ops in one hop. Only the Mul's own
+// gamma (input 1) and the final Add's own beta (input 1) have anything
+// sliced; every other node's entry carries no const name.
+//
+// Since this shape's own root tensor (`x`) is read *twice* by design, every
+// WalkToConsumer call site that used to gate on a strict single-consumer
+// check before ever calling it now uses MatmulWalkRootOk instead -- see its
+// own comment below for why dropping that gate down to "not a graph output"
+// is safe for every previously-supported shape, not just this one.
+//
+// Positive-axis ReduceMean `axes` (needing the tensor's own known rank to
+// resolve) is deliberately out of scope for this port -- only the
+// unambiguous `axes=[-1]` case is recognized (see ReduceMeanAxisIsLast's own
+// comment); pruning.py's own value_info-threaded rank resolution is not
+// mirrored here, and WalkToConsumer gains no such parameter. This only
+// narrows coverage (declines a case pruning.py's own version might still
+// accept), never a correctness gap -- the same "declined, not guessed at"
+// bar this port always holds itself to.
+constexpr int kMaxGateBranchHops = 4;
+
+// True iff `name` names a constant float *scalar* initializer (`dims`
+// exactly [] or [1]) -- the same scalar bar MatchClipChannelPassThrough's
+// own inline `min`/`max` check already uses, reused here for two different
+// callers that each need a plain, channel-agnostic constant operand: the
+// decomposed LayerNorm's own `eps` operand
+// (DecomposedLayerNormPowExponentIsTwo additionally checks the Pow
+// exponent's own *value* is exactly 2.0; `eps`'s own value is never
+// inspected, only its shape -- any epsilon is equally safe, it's never
+// sliced), and a self-gated activation decomposition's own gate-branch
+// "other operand" (sqrt(2), 1.0, erf-GELU's own trailing 0.5 -- see
+// WalkGateBranch below). Mirrors pruning.py's own
+// _flat_scalar_float_const/_gate_branch_scalar_const, which have identical
+// bodies for the identical reason.
+bool ScalarFloatConst(const std::string& name, const InitMap& init_map) {
+  auto it = init_map.find(name);
+  if (it == init_map.end() ||
+      it->second->data_type() != onnx::TensorProto::FLOAT) {
+    return false;
+  }
+  const auto& dims = it->second->dims();
+  return dims.size() == 0 || (dims.size() == 1 && dims.Get(0) == 1);
+}
+
+// True iff `name` names a constant float scalar (ScalarFloatConst) whose
+// value is exactly 2.0 -- Pow's own schema (X, Y -> X ** Y, a fixed operand
+// order) makes `name` its second input; this confirms the node genuinely
+// computes `(x - mean) ** 2`, LayerNorm's own variance term, rather than
+// some other exponent this pass has no basis for treating as
+// channel-pruning-safe. Mirrors pruning.py's own
+// _decomposed_layer_norm_pow_exponent_is_two.
+bool DecomposedLayerNormPowExponentIsTwo(const std::string& name,
+                                         const InitMap& init_map) {
+  if (!ScalarFloatConst(name, init_map)) {
+    return false;
+  }
+  std::vector<float> values = ReadFloatTensor(*init_map.at(name));
+  return values.size() == 1 && values[0] == 2.0f;
+}
+
+// True iff a plain (default-domain) `ReduceMean` `node` -- one of
+// MatchDecomposedLayerNormPassThrough's own two ReduceMean nodes,
+// `input_name` its own single input -- is confirmed to reduce *only*
+// `input_name`'s last axis, keeping that axis (`keepdims=1`, the shape
+// LayerNorm's own mean/variance reduction needs). Only the unambiguous
+// `axes == [-1]` case is recognized here -- unlike pruning.py's own
+// _reduce_mean_axis_is_last, this deliberately never resolves a positive
+// axis against the tensor's own rank (see this section's own comment above
+// for why); narrower coverage, declined rather than guessed at, never a
+// correctness gap. Declines whenever `axes` is absent (the schema default
+// then reduces *every* axis, a different computation) or names more than
+// one axis, or `keepdims` is anything but its schema default/an explicit 1
+// (`keepdims=0` would drop the reduced axis entirely, breaking the
+// following Sub's/Add's own broadcast).
+bool ReduceMeanAxisIsLast(const onnx::NodeProto& node,
+                          const std::string& input_name) {
+  if (node.op_type() != "ReduceMean" || node.domain() != "" ||
+      node.input_size() != 1 || node.input(0) != input_name) {
+    return false;
+  }
+  std::optional<std::vector<int64_t>> axes_attr;
+  int64_t keepdims = 1;
+  for (const auto& attr : node.attribute()) {
+    if (attr.name() == "axes") {
+      axes_attr.emplace(attr.ints().begin(), attr.ints().end());
+    } else if (attr.name() == "keepdims") {
+      keepdims = attr.i();
+    }
+  }
+  if (keepdims != 1 || !axes_attr || axes_attr->size() != 1) {
+    return false;
+  }
+  return (*axes_attr)[0] == -1;
+}
+
+struct DecomposedLayerNormMatch {
+  std::string out_name;
+  std::vector<ChainOp> chain_ops;  // All 9 nodes, forward order.
+};
+
+// If `x_name` is the root of exactly the fixed 9-node decomposed-LayerNorm
+// sequence documented in this section's own comment above, returns
+// `(out_name, chain_ops)` -- see that comment for the full shape and the
+// exact "declined, never partially matched" bar this holds every node/
+// tensor along the way to (an extra reader of `x_name`/`centered` beyond the
+// two each expects, any other intermediate tensor read more than once or
+// itself a graph output, a non-constant-2.0 Pow exponent, a ReduceMean axis
+// not resolving to -1, or a non-constant/wrongly-shaped/tied gamma/beta).
+// Mirrors pruning.py's own _match_decomposed_layer_norm_pass_through,
+// called by WalkToConsumer at two points -- before its own ordinary
+// single-consumer dispatch (`cur` itself the sequence's own root), and
+// again wherever an ordinary hop's own output would otherwise fail that
+// dispatch's single-consumer bar -- both needed because this shape's own
+// root tensor is read *twice*, a shape the ordinary single-consumer walk
+// can never reach on its own from either point.
+std::optional<DecomposedLayerNormMatch> MatchDecomposedLayerNormPassThrough(
+    const std::string& x_name, const ConsumerMap& consumers_of,
+    const InitMap& init_map,
+    const std::unordered_set<std::string>& graph_outputs, int64_t n_channels) {
+  auto xit = consumers_of.find(x_name);
+  if (xit == consumers_of.end() || xit->second.size() != 2) {
+    return std::nullopt;
+  }
+  onnx::NodeProto* reduce_mean = nullptr;
+  onnx::NodeProto* sub = nullptr;
+  for (onnx::NodeProto* cand : xit->second) {
+    if (cand->op_type() == "ReduceMean" && reduce_mean == nullptr) {
+      reduce_mean = cand;
+    } else if (cand->op_type() == "Sub" && sub == nullptr) {
+      sub = cand;
+    }
+  }
+  if (reduce_mean == nullptr || sub == nullptr || reduce_mean == sub) {
+    return std::nullopt;
+  }
+  if (reduce_mean->output_size() != 1 || reduce_mean->output(0).empty()) {
+    return std::nullopt;
+  }
+  if (!ReduceMeanAxisIsLast(*reduce_mean, x_name)) {
+    return std::nullopt;
+  }
+  const std::string& mean_name = reduce_mean->output(0);
+  if (graph_outputs.count(mean_name) ||
+      ConsumerCount(consumers_of, mean_name) != 1) {
+    return std::nullopt;
+  }
+
+  if (sub->domain() != "" || sub->input_size() != 2 ||
+      sub->input(0) != x_name || sub->input(1) != mean_name ||
+      sub->output_size() != 1 || sub->output(0).empty()) {
+    return std::nullopt;
+  }
+  const std::string& centered_name = sub->output(0);
+  if (graph_outputs.count(centered_name)) {
+    return std::nullopt;
+  }
+  auto cit = consumers_of.find(centered_name);
+  if (cit == consumers_of.end() || cit->second.size() != 2) {
+    return std::nullopt;
+  }
+  onnx::NodeProto* pow_node = nullptr;
+  onnx::NodeProto* div_node = nullptr;
+  for (onnx::NodeProto* cand : cit->second) {
+    if (cand->op_type() == "Pow" && pow_node == nullptr) {
+      pow_node = cand;
+    } else if (cand->op_type() == "Div" && div_node == nullptr) {
+      div_node = cand;
+    }
+  }
+  if (pow_node == nullptr || div_node == nullptr || pow_node == div_node) {
+    return std::nullopt;
+  }
+
+  if (pow_node->domain() != "" || pow_node->input_size() != 2 ||
+      pow_node->input(0) != centered_name || pow_node->output_size() != 1 ||
+      pow_node->output(0).empty() ||
+      !DecomposedLayerNormPowExponentIsTwo(pow_node->input(1), init_map)) {
+    return std::nullopt;
+  }
+  const std::string& sq_name = pow_node->output(0);
+  if (graph_outputs.count(sq_name) ||
+      ConsumerCount(consumers_of, sq_name) != 1) {
+    return std::nullopt;
+  }
+
+  onnx::NodeProto* var_reduce = consumers_of.at(sq_name)[0];
+  if (var_reduce->output_size() != 1 || var_reduce->output(0).empty()) {
+    return std::nullopt;
+  }
+  if (!ReduceMeanAxisIsLast(*var_reduce, sq_name)) {
+    return std::nullopt;
+  }
+  const std::string& var_name = var_reduce->output(0);
+  if (graph_outputs.count(var_name) ||
+      ConsumerCount(consumers_of, var_name) != 1) {
+    return std::nullopt;
+  }
+
+  onnx::NodeProto* add_eps = consumers_of.at(var_name)[0];
+  if (add_eps->op_type() != "Add" || add_eps->domain() != "" ||
+      add_eps->input_size() != 2 ||
+      (add_eps->input(0) != var_name && add_eps->input(1) != var_name) ||
+      add_eps->output_size() != 1 || add_eps->output(0).empty()) {
+    return std::nullopt;
+  }
+  const std::string& eps_name =
+      (add_eps->input(0) == var_name) ? add_eps->input(1) : add_eps->input(0);
+  if (eps_name == var_name || !ScalarFloatConst(eps_name, init_map)) {
+    return std::nullopt;
+  }
+  const std::string& var_eps_name = add_eps->output(0);
+  if (graph_outputs.count(var_eps_name) ||
+      ConsumerCount(consumers_of, var_eps_name) != 1) {
+    return std::nullopt;
+  }
+
+  onnx::NodeProto* sqrt_node = consumers_of.at(var_eps_name)[0];
+  if (sqrt_node->op_type() != "Sqrt" || sqrt_node->domain() != "" ||
+      sqrt_node->input_size() != 1 || sqrt_node->input(0) != var_eps_name ||
+      sqrt_node->output_size() != 1 || sqrt_node->output(0).empty()) {
+    return std::nullopt;
+  }
+  const std::string& std_name = sqrt_node->output(0);
+  if (graph_outputs.count(std_name) ||
+      ConsumerCount(consumers_of, std_name) != 1) {
+    return std::nullopt;
+  }
+  if (consumers_of.at(std_name)[0] != div_node) {
+    return std::nullopt;  // std must feed the *same* Div node centered forked
+                          // to.
+  }
+
+  if (div_node->domain() != "" || div_node->input_size() != 2 ||
+      div_node->input(0) != centered_name || div_node->input(1) != std_name ||
+      div_node->output_size() != 1 || div_node->output(0).empty()) {
+    return std::nullopt;
+  }
+  const std::string& normed_name = div_node->output(0);
+  if (graph_outputs.count(normed_name) ||
+      ConsumerCount(consumers_of, normed_name) != 1) {
+    return std::nullopt;
+  }
+
+  onnx::NodeProto* mul_node = consumers_of.at(normed_name)[0];
+  if (mul_node->op_type() != "Mul" || mul_node->domain() != "" ||
+      mul_node->input_size() != 2 ||
+      (mul_node->input(0) != normed_name &&
+       mul_node->input(1) != normed_name) ||
+      mul_node->output_size() != 1 || mul_node->output(0).empty()) {
+    return std::nullopt;
+  }
+  const std::string& gamma_name = (mul_node->input(0) == normed_name)
+                                      ? mul_node->input(1)
+                                      : mul_node->input(0);
+  if (gamma_name == normed_name || !FlatChannelConst(gamma_name, init_map) ||
+      init_map.at(gamma_name)->dims(init_map.at(gamma_name)->dims_size() - 1) !=
+          n_channels) {
+    return std::nullopt;
+  }
+  const std::string& scaled_name = mul_node->output(0);
+  if (graph_outputs.count(scaled_name) ||
+      ConsumerCount(consumers_of, scaled_name) != 1) {
+    return std::nullopt;
+  }
+
+  onnx::NodeProto* add_beta = consumers_of.at(scaled_name)[0];
+  if (add_beta->op_type() != "Add" || add_beta->domain() != "" ||
+      add_beta->input_size() != 2 ||
+      (add_beta->input(0) != scaled_name &&
+       add_beta->input(1) != scaled_name) ||
+      add_beta->output_size() != 1 || add_beta->output(0).empty()) {
+    return std::nullopt;
+  }
+  const std::string& beta_name = (add_beta->input(0) == scaled_name)
+                                     ? add_beta->input(1)
+                                     : add_beta->input(0);
+  if (beta_name == scaled_name || beta_name == gamma_name ||
+      !FlatChannelConst(beta_name, init_map) ||
+      init_map.at(beta_name)->dims(init_map.at(beta_name)->dims_size() - 1) !=
+          n_channels) {
+    return std::nullopt;
+  }
+
+  DecomposedLayerNormMatch result;
+  result.out_name = add_beta->output(0);
+  result.chain_ops = {
+      ChainOp{reduce_mean, std::nullopt}, ChainOp{sub, std::nullopt},
+      ChainOp{pow_node, std::nullopt},    ChainOp{var_reduce, std::nullopt},
+      ChainOp{add_eps, std::nullopt},     ChainOp{sqrt_node, std::nullopt},
+      ChainOp{div_node, std::nullopt},    ChainOp{mul_node, gamma_name},
+      ChainOp{add_beta, beta_name},
+  };
+  return result;
+}
+
+// True unless `name` is itself a graph output -- the one condition
+// WalkToConsumer can never itself recover from once called (a
+// caller-observed tensor's own shape must never silently change out from
+// under it). Every *other* "is this safe to walk forward from" question --
+// an ordinary single consumer, the decomposed-LayerNorm-root two-consumer
+// shape (MatchDecomposedLayerNormPassThrough), or a self-gated activation
+// decomposition's own two-consumer origin (MatchSelfGatedActivation, below)
+// -- is left entirely to WalkToConsumer's own hop-0 dispatch, which
+// declines (returns no consumer) exactly the same way skipping the call
+// here already did for every case this module supported before either hop
+// existed: a tensor with zero consumers, or two or more that don't happen
+// to match either shape, still makes the very first hop's own dispatch fail
+// immediately, with no wasted walking. Mirrors pruning.py's own
+// _matmul_walk_root_ok. Used, in place of a plain single-consumer gate, by
+// every MatMul/Gemm-chain finder (FindChains/FindGatedChains/
+// FindSplitGatedChains/FindMatmulConcatChains) that hands WalkToConsumer a
+// producer's, a gated combine's, or a Concat's own raw output as `start` --
+// never used ahead of a forced_first_hop call (ResolveMatmulFanoutBranches's
+// own extra-branch resolution), which always takes hop 0's own dispatch
+// directly regardless, so this gate can never be reached there.
+bool MatmulWalkRootOk(const std::string& name,
+                      const std::unordered_set<std::string>& graph_outputs) {
+  return !graph_outputs.count(name);
+}
+
+// --- Self-gated activation decomposition (SiLU/erf-GELU, unfused),
+// mirroring pruning.py's own "Self-gated activation decomposition" section
+// comment, _match_self_gated_activation[_backward], and _walk_gate_branch --
+//
+// Gelu/com.microsoft::Gelu (already unary, UnaryPassThroughOps()) and the
+// fused BiasGelu/FastGelu/QuickGelu hops all require either a late opset
+// (native Gelu needs opset 20+, Swish needs opset 24+) or onnxruntime's own
+// transformer-optimizer fusion pass. A raw torch.onnx.export, at any
+// earlier/default opset and without that fusion pass having run, emits the
+// literal decomposition instead -- a "self-gated" shape where the
+// producer's own output tensor `cur` feeds *two* consumers at once: the
+// gate branch's own first op, and the Mul that combines `cur` with the gate
+// branch's own final output. Two concrete shapes, both confirmed live via
+// torch.onnx.export in pruning.py's own commit history:
+//
+// - SiLU/Swish (the default activation in Ultralytics YOLOv5/v8's own Conv
+//   blocks, and the gate activation in Llama-family SwiGLU): `s =
+//   Sigmoid(cur); out = Mul(cur, s)`.
+// - erf-GELU (opset < 20, the overwhelming majority of real exports): `d =
+//   Div(cur, sqrt(2)); e = Erf(d); a = Add(e, 1.0); m = Mul(cur, a); out =
+//   Mul(m, 0.5)` -- the SiLU shape's own gate Mul plus a longer (Div, Erf,
+//   Add) gate branch and one trailing scalar-scale Mul.
+//
+// On a match, the whole diamond folds into the chain the same "nothing to
+// slice" way a pooling/Resize/Pad/Clip hop's own chain_ops entries already
+// do -- none of Sigmoid/Erf/the scalar Div/Add/Mul operands need their own
+// weight sliced, so every diamond node becomes one more (node, no-const)
+// chain_ops entry, and the walk continues from the diamond's own true
+// output tensor.
+//
+// Forward (WalkToConsumer/WalkToConvConsumer), the diamond is recognized
+// only as a walk's very *first* hop (`cur == start`, on the ordinary,
+// non-forced_first_hop path): every hop *after* the first already only ever
+// promotes `out2` to `cur` once `out2`'s own single-consumer bar is
+// confirmed, so `cur` can never legitimately have two consumers past hop 0
+// in the first place. Reaching hop 0 with a two-consumer `cur` at all needs
+// FindChains/FindConvChains's own pre-walk gate to admit exactly two
+// consumers there too (see each function's own comment) -- a false
+// admission there costs one wasted, safely-declining call, never a wrong
+// slice. A forced_first_hop call (ResolveMatmulFanoutBranches/
+// ResolveConvFanoutBranches) and a Concat-merge finder's own downstream walk
+// from a Concat node's merged output are deliberately left out of that
+// admission -- neither is the shape a real export ever produces directly, so
+// a diamond immediately following one of those is still declined, the same
+// conservative scope boundary pruning.py's own version draws.
+//
+// Backward (WalkMatmulProducerBackward/WalkConvProducerBackward), no
+// equivalent admission problem exists: every hop the backward walk crosses
+// is already checked fresh via node_by_output, with no "already vetted as
+// single-consumer" precondition the way the forward walk's post-hop-0 `cur`
+// has -- so the diamond is recognized the same way as any other backward
+// hop, checked ahead of the ordinary Add/Mul bias/scale dispatch (otherwise
+// indistinguishable from it by op type alone), at whatever position in the
+// chain it's actually crossed. The diamond's own origin tensor legitimately
+// has *two* real in-group consumers (the branch's own first node, and the
+// gate Mul) -- both recorded as `edges` entries, tolerated natively by the
+// `accounted` bookkeeping every residual/merge-group finder already builds
+// from them (a plain multiset-like structure, built for exactly this
+// "more than one in-group consumer of the same tensor" case). The one
+// caller this does *not* compose with safely is the direct Concat-branch
+// walk (BranchWalkHasFanout) -- that check re-derives a strict *linear*
+// single-consumer chain directly from `edges`, an assumption a
+// two-entries-sharing-one-tensor diamond genuinely breaks, so a Concat
+// branch that crosses one is simply declined there, the same safe (if
+// suboptimal) fallback a residual/merge fan-out already gets for other
+// shapes -- no change needed to that check for this feature.
+const std::unordered_set<std::string>& GateBranchBinaryOps() {
+  static const std::unordered_set<std::string> kOps = {"Div", "Mul", "Add",
+                                                       "Sub"};
+  return kOps;
+}
+
+// Walks forward from `branch_start`, whose own (already known) sole
+// consumer is `first_node`, through a strict chain of single-consumer hops
+// -- each either a node already in UnaryPassThroughOps() or a binary op in
+// GateBranchBinaryOps() against a genuine scalar constant (ScalarFloatConst)
+// -- until the chain's own running tensor reaches `target` exactly. Returns
+// the matched node tuple, in forward (execution) order, or nullopt if the
+// chain runs past kMaxGateBranchHops, crosses a graph output, hits an
+// intermediate tensor with anything other than exactly one consumer, or
+// never reaches `target` at all -- declined, never guessed at, the same
+// conservative bar every other hop in this file already holds a mid-chain
+// tensor to. Shared by both MatchSelfGatedActivation (forward) and
+// MatchSelfGatedActivationBackward (backward) -- the shared question both
+// ask is identical ("does this chain of allowed ops connect `branch_start`
+// to `target`"), only the direction differs. Mirrors pruning.py's own
+// _walk_gate_branch.
+std::optional<std::vector<onnx::NodeProto*>> WalkGateBranch(
+    onnx::NodeProto* first_node, const std::string& branch_start,
+    const std::string& target, const ConsumerMap& consumers_of,
+    const InitMap& init_map,
+    const std::unordered_set<std::string>& graph_outputs) {
+  std::vector<onnx::NodeProto*> nodes;
+  onnx::NodeProto* nxt = first_node;
+  std::string cur = branch_start;
+  for (int hop = 0; hop < kMaxGateBranchHops; ++hop) {
+    if (UnaryPassThroughOps().count(nxt->op_type()) != 0 &&
+        nxt->input_size() == 1 && nxt->input(0) == cur &&
+        nxt->output_size() == 1) {
+      // Ok -- unary, no operand of its own to check.
+    } else if (GateBranchBinaryOps().count(nxt->op_type()) != 0 &&
+               nxt->domain() == "" && nxt->input_size() == 2 &&
+               (nxt->input(0) == cur || nxt->input(1) == cur) &&
+               nxt->output_size() == 1) {
+      const std::string& other =
+          (nxt->input(0) == cur) ? nxt->input(1) : nxt->input(0);
+      if (other == cur || !ScalarFloatConst(other, init_map)) {
+        return std::nullopt;
+      }
+    } else {
+      return std::nullopt;
+    }
+    nodes.push_back(nxt);
+    const std::string& out = nxt->output(0);
+    if (graph_outputs.count(out)) {
+      return std::nullopt;
+    }
+    if (out == target) {
+      return nodes;
+    }
+    auto cit = consumers_of.find(out);
+    if (cit == consumers_of.end() || cit->second.size() != 1) {
+      return std::nullopt;
+    }
+    nxt = cit->second[0];
+    cur = out;
+  }
+  return std::nullopt;
+}
+
+struct SelfGatedMatch {
+  std::vector<onnx::NodeProto*> diamond_nodes;  // Forward order.
+  std::string final_out;
+};
+
+// If `cur` (a tensor with *exactly* two consumers) is the origin of a
+// self-gated activation decomposition -- see this section's own comment
+// above -- returns `(diamond_nodes, final_out)`: `diamond_nodes` every node
+// the diamond spans in forward order (the gate branch's own nodes, then the
+// self-gating Mul, then -- only for the erf-GELU shape -- one trailing
+// scalar-scale Mul); `final_out` the diamond's own true output tensor the
+// caller should continue walking from. Used by WalkToConsumer/
+// WalkToConvConsumer as a walk's very first hop only. Declines (nullopt)
+// unless `cur` has exactly two consumers, exactly one of which is a plain
+// `Mul(cur, branch_out)` with `branch_out` distinct from `cur` and not
+// itself a constant, `branch_out` has exactly one consumer and isn't a
+// graph output, and the remaining consumer, walked via WalkGateBranch,
+// resolves `cur` to `branch_out` exactly. A candidate optional trailing
+// scalar Mul is folded in whenever present; its absence (SiLU's own shape)
+// is not itself a decline. Mirrors pruning.py's own
+// _match_self_gated_activation.
+std::optional<SelfGatedMatch> MatchSelfGatedActivation(
+    const std::string& cur, const ConsumerMap& consumers_of,
+    const InitMap& init_map,
+    const std::unordered_set<std::string>& graph_outputs) {
+  auto cit = consumers_of.find(cur);
+  if (cit == consumers_of.end() || cit->second.size() != 2) {
+    return std::nullopt;
+  }
+  const std::vector<onnx::NodeProto*>& consumers = cit->second;
+
+  onnx::NodeProto* gate_node = nullptr;
+  std::string branch_out;
+  int gate_matches = 0;
+  for (onnx::NodeProto* c : consumers) {
+    if (c->op_type() == "Mul" && c->domain() == "" && c->input_size() == 2 &&
+        (c->input(0) == cur || c->input(1) == cur) && c->output_size() == 1) {
+      const std::string& other =
+          (c->input(0) == cur) ? c->input(1) : c->input(0);
+      if (other != cur && !init_map.count(other)) {
+        gate_node = c;
+        branch_out = other;
+        ++gate_matches;
+      }
+    }
+  }
+  if (gate_matches != 1) {
+    return std::nullopt;  // No gate Mul, or an ambiguous second candidate.
+  }
+
+  onnx::NodeProto* branch_first_node = nullptr;
+  int branch_first_count = 0;
+  for (onnx::NodeProto* c : consumers) {
+    if (c != gate_node) {
+      branch_first_node = c;
+      ++branch_first_count;
+    }
+  }
+  if (branch_first_count != 1) {
+    return std::nullopt;
+  }
+
+  if (graph_outputs.count(branch_out) ||
+      ConsumerCount(consumers_of, branch_out) != 1) {
+    return std::nullopt;
+  }
+
+  auto branch_nodes = WalkGateBranch(branch_first_node, cur, branch_out,
+                                     consumers_of, init_map, graph_outputs);
+  if (!branch_nodes) {
+    return std::nullopt;
+  }
+
+  SelfGatedMatch result;
+  result.diamond_nodes = std::move(*branch_nodes);
+  result.diamond_nodes.push_back(gate_node);
+  result.final_out = gate_node->output(0);
+
+  if (!graph_outputs.count(result.final_out) &&
+      ConsumerCount(consumers_of, result.final_out) == 1) {
+    onnx::NodeProto* trailing = consumers_of.at(result.final_out)[0];
+    if (trailing->op_type() == "Mul" && trailing->domain() == "" &&
+        trailing->input_size() == 2 &&
+        (trailing->input(0) == result.final_out ||
+         trailing->input(1) == result.final_out) &&
+        trailing->output_size() == 1) {
+      const std::string& scale = (trailing->input(0) == result.final_out)
+                                     ? trailing->input(1)
+                                     : trailing->input(0);
+      if (scale != result.final_out && ScalarFloatConst(scale, init_map)) {
+        result.diamond_nodes.push_back(trailing);
+        result.final_out = trailing->output(0);
+      }
+    }
+  }
+
+  return result;
+}
+
+struct SelfGatedBackwardMatch {
+  std::vector<onnx::NodeProto*> diamond_nodes;  // Forward order.
+  std::string origin;
+  onnx::NodeProto* gate_node;
+};
+
+// The backward-walk (WalkMatmulProducerBackward/WalkConvProducerBackward)
+// counterpart of MatchSelfGatedActivation: `cur` is the diamond's own
+// candidate *output* tensor (node_by_output[cur] either the self-gating Mul
+// itself, or -- for the erf-GELU shape -- the trailing scalar-scale Mul
+// wrapping it), and this resolves back to the diamond's own true *origin*
+// tensor. Returns `(diamond_nodes, origin, gate_node)` -- `diamond_nodes` in
+// the identical forward order MatchSelfGatedActivation returns them in (so
+// a caller building chain_ops in reverse-of-visit order can walk
+// `diamond_nodes` in reverse, the same as any other single node this walk
+// crosses); `gate_node` is `diamond_nodes`' own self-gating Mul specifically
+// (not necessarily its last element -- the erf-GELU shape's own trailing
+// scalar Mul sits after it), returned separately so the caller can record
+// `origin`'s own *two* real in-group consumers (the gate branch's own first
+// node and this Mul) as two `edges` entries without having to re-derive
+// which element of `diamond_nodes` is which.
+//
+// Since a Mul's two operands are unordered, both candidate origin/target
+// pairings are tried (WalkGateBranch, forward from the candidate origin --
+// the *same* function MatchSelfGatedActivation uses); a match is accepted
+// only when *exactly one* ordering resolves, the same "decline on
+// ambiguity" bar MatchSelfGatedActivation's own gate-candidate search
+// already applies. Mirrors pruning.py's own
+// _match_self_gated_activation_backward.
+std::optional<SelfGatedBackwardMatch> MatchSelfGatedActivationBackward(
+    const std::string& cur,
+    const std::unordered_map<std::string, onnx::NodeProto*>& node_by_output,
+    const ConsumerMap& consumers_of, const InitMap& init_map,
+    const std::unordered_set<std::string>& graph_outputs) {
+  auto nit = node_by_output.find(cur);
+  if (nit == node_by_output.end()) {
+    return std::nullopt;
+  }
+  onnx::NodeProto* node = nit->second;
+  if (node->op_type() != "Mul" || node->domain() != "" ||
+      node->input_size() != 2 || node->output_size() != 1 ||
+      node->output(0) != cur) {
+    return std::nullopt;
+  }
+
+  onnx::NodeProto* gate_node = node;
+  onnx::NodeProto* trailing_node = nullptr;
+  std::string a_name = node->input(0);
+  std::string b_name = node->input(1);
+  bool a_const = init_map.count(a_name) != 0;
+  bool b_const = init_map.count(b_name) != 0;
+  if (a_const != b_const) {
+    // A candidate trailing scalar-scale Mul (erf-GELU's own final `* 0.5`)
+    // -- its own non-constant operand must itself be a plain Mul (the real
+    // gate Mul) with no other consumer.
+    const std::string& const_name = a_const ? a_name : b_name;
+    const std::string& gate_out = a_const ? b_name : a_name;
+    if (!ScalarFloatConst(const_name, init_map)) {
+      return std::nullopt;
+    }
+    if (ConsumerCount(consumers_of, gate_out) != 1) {
+      return std::nullopt;
+    }
+    auto git = node_by_output.find(gate_out);
+    if (git == node_by_output.end()) {
+      return std::nullopt;
+    }
+    onnx::NodeProto* gate_candidate = git->second;
+    if (gate_candidate->op_type() != "Mul" || gate_candidate->domain() != "" ||
+        gate_candidate->input_size() != 2 ||
+        gate_candidate->output_size() != 1 ||
+        gate_candidate->output(0) != gate_out) {
+      return std::nullopt;
+    }
+    trailing_node = node;
+    gate_node = gate_candidate;
+    a_name = gate_node->input(0);
+    b_name = gate_node->input(1);
+    a_const = init_map.count(a_name) != 0;
+    b_const = init_map.count(b_name) != 0;
+  }
+
+  if (a_const || b_const || a_name == b_name) {
+    return std::nullopt;  // Not a genuine two-non-constant-operand gate Mul.
+  }
+
+  std::vector<onnx::NodeProto*> resolved_branch_nodes;
+  std::string resolved_origin;
+  int resolved_count = 0;
+  const std::pair<std::string, std::string> orderings[2] = {{a_name, b_name},
+                                                            {b_name, a_name}};
+  for (const auto& ordering : orderings) {
+    const std::string& origin_cand = ordering.first;
+    const std::string& target = ordering.second;
+    if (graph_outputs.count(target) ||
+        ConsumerCount(consumers_of, target) != 1) {
+      continue;
+    }
+    auto oit = consumers_of.find(origin_cand);
+    if (oit == consumers_of.end() || oit->second.size() != 2) {
+      continue;
+    }
+    onnx::NodeProto* first_node = nullptr;
+    int first_count = 0;
+    bool has_gate = false;
+    for (onnx::NodeProto* c : oit->second) {
+      if (c == gate_node) {
+        has_gate = true;
+      } else {
+        first_node = c;
+        ++first_count;
+      }
+    }
+    if (!has_gate || first_count != 1) {
+      continue;
+    }
+    auto branch_nodes = WalkGateBranch(first_node, origin_cand, target,
+                                       consumers_of, init_map, graph_outputs);
+    if (branch_nodes) {
+      resolved_branch_nodes = std::move(*branch_nodes);
+      resolved_origin = origin_cand;
+      ++resolved_count;
+    }
+  }
+  if (resolved_count != 1) {
+    return std::nullopt;  // No resolvable ordering, or an ambiguous second one.
+  }
+
+  SelfGatedBackwardMatch result;
+  result.diamond_nodes = std::move(resolved_branch_nodes);
+  result.diamond_nodes.push_back(gate_node);
+  if (trailing_node != nullptr) {
+    result.diamond_nodes.push_back(trailing_node);
+  }
+  result.origin = resolved_origin;
+  result.gate_node = gate_node;
+  return result;
+}
+
 std::pair<std::optional<ConsumerMatch>, std::vector<ChainOp>> WalkToConsumer(
     const std::string& start, const InitMap& init_map,
     const ConsumerMap& consumers_of,
@@ -711,11 +1463,54 @@ std::pair<std::optional<ConsumerMatch>, std::vector<ChainOp>> WalkToConsumer(
       // so more than one consumer is expected here -- the caller has
       // already picked this one specific consumer to resolve this branch
       // through. Every hop after the first still enforces the ordinary
-      // single-consumer bar unchanged below.
+      // single-consumer bar unchanged below. Neither the decomposed-
+      // LayerNorm nor the self-gated-activation hop below is ever attempted
+      // on this path -- see MatchDecomposedLayerNormPassThrough's/this
+      // file's own "Self-gated activation decomposition" section comment
+      // for why that composition is out of scope.
       nxt = forced_first_hop;
     } else {
+      // Tried before the ordinary "exactly one consumer" dispatch below,
+      // since a decomposed LayerNorm's own root tensor is read *twice* (by
+      // its first ReduceMean and its Sub) -- a shape that dispatch can
+      // never reach on its own. Declines instantly whenever `cur` doesn't
+      // have exactly two consumers, so this costs an ordinary hop nothing.
+      auto ln_match = MatchDecomposedLayerNormPassThrough(
+          cur, consumers_of, init_map, graph_outputs, n_channels);
+      if (ln_match) {
+        chain_ops.insert(chain_ops.end(), ln_match->chain_ops.begin(),
+                         ln_match->chain_ops.end());
+        cur = ln_match->out_name;
+        continue;
+      }
+
       auto cit = consumers_of.find(cur);
-      if (cit == consumers_of.end() || cit->second.size() != 1) {
+      const size_t num_candidates =
+          cit == consumers_of.end() ? 0 : cit->second.size();
+      if (num_candidates == 2) {
+        // A self-gated activation decomposition's own origin tensor -- see
+        // this file's own "Self-gated activation decomposition" section
+        // comment above. Recognized only here, at a walk's very first hop
+        // (`cur == start` the very first time this branch runs) -- every
+        // later hop only ever promotes `out2` to `cur` once its own
+        // single-consumer bar already holds, so `cur` can never
+        // legitimately have two consumers past hop 0.
+        auto diamond = MatchSelfGatedActivation(cur, consumers_of, init_map,
+                                                graph_outputs);
+        if (diamond) {
+          if (ConsumerCount(consumers_of, diamond->final_out) != 1 ||
+              graph_outputs.count(diamond->final_out)) {
+            break;
+          }
+          for (onnx::NodeProto* n : diamond->diamond_nodes) {
+            chain_ops.push_back(ChainOp{n, std::nullopt});
+          }
+          cur = diamond->final_out;
+          continue;
+        }
+        break;  // Two consumers but not this shape -- declined, as before.
+      }
+      if (num_candidates != 1) {
         break;
       }
       nxt = cit->second[0];
@@ -794,11 +1589,37 @@ std::pair<std::optional<ConsumerMatch>, std::vector<ChainOp>> WalkToConsumer(
     }
 
     const std::string& out2 = nxt->output(0);
-    if (ConsumerCount(consumers_of, out2) != 1 || graph_outputs.count(out2)) {
+    if (graph_outputs.count(out2)) {
       break;
     }
+    // Ordinarily `out2` must have exactly one consumer to safely become the
+    // walk's new `cur` -- but a decomposed LayerNorm's own root tensor is,
+    // by its own fixed shape, read *twice* (see
+    // MatchDecomposedLayerNormPassThrough's own comment), so an `out2` this
+    // hop produces right where such a sequence begins (e.g. a bias Add
+    // feeding both the sequence's own ReduceMean and Sub) would otherwise
+    // always fail this check and break the walk before ever reaching the
+    // top-of-loop dispatch that tries this hop for `cur` -- that dispatch
+    // only ever sees `cur` *after* a hop already committed to advancing past
+    // it. Trying the same matcher here first, before the ordinary
+    // single-consumer bar, closes that gap: every other multi-consumer
+    // `out2` still declines exactly as before.
+    std::optional<DecomposedLayerNormMatch> out2_ln;
+    if (ConsumerCount(consumers_of, out2) != 1) {
+      out2_ln = MatchDecomposedLayerNormPassThrough(
+          out2, consumers_of, init_map, graph_outputs, n_channels);
+      if (!out2_ln) {
+        break;
+      }
+    }
     chain_ops.push_back(ChainOp{nxt, const_name});
-    cur = out2;
+    if (out2_ln) {
+      chain_ops.insert(chain_ops.end(), out2_ln->chain_ops.begin(),
+                       out2_ln->chain_ops.end());
+      cur = out2_ln->out_name;
+    } else {
+      cur = out2;
+    }
   }
   return {consumer, chain_ops};
 }
@@ -813,9 +1634,6 @@ std::vector<Chain> FindChains(onnx::GraphProto* graph) {
   for (const auto& o : graph->output()) {
     graph_outputs.insert(o.name());
   }
-  auto is_internal = [&](const std::string& name) {
-    return ConsumerCount(consumers_of, name) == 1 && !graph_outputs.count(name);
-  };
 
   std::vector<Chain> chains;
   for (int i = 0; i < graph->node_size(); ++i) {
@@ -825,7 +1643,14 @@ std::vector<Chain> FindChains(onnx::GraphProto* graph) {
       continue;
     }
     const std::string& out_name = node->output(0);
-    if (!is_internal(out_name)) {
+    // MatmulWalkRootOk only rules out a graph output -- every other "is
+    // this safe to walk forward from" question (an ordinary single
+    // consumer, the decomposed-LayerNorm two-consumer root shape, or a
+    // self-gated activation decomposition's own two-consumer origin) is
+    // left entirely to WalkToConsumer's own hop-0 dispatch, which declines
+    // (same as before) if the actual consumers don't form a recognized
+    // shape.
+    if (!MatmulWalkRootOk(out_name, graph_outputs)) {
       continue;
     }
     auto [consumer, chain_ops] =
@@ -981,7 +1806,9 @@ std::vector<Chain> FindGatedChains(onnx::GraphProto* graph) {
     }
 
     const std::string& out_name = node->output(0);
-    if (!is_internal(out_name)) {
+    // See FindChains's own identical comment -- the gated combine's own raw
+    // output can be a decomposed-LayerNorm/self-gated-activation root too.
+    if (!MatmulWalkRootOk(out_name, graph_outputs)) {
       continue;
     }
     auto [consumer, chain_ops] =
@@ -1198,30 +2025,6 @@ std::optional<DepthwiseMatch> MatchCausalConvWithStatePassThrough(
     }
   }
   return DepthwiseMatch{w_name, bias, past_state};
-}
-
-// True if `name` names a constant FLOAT initializer shaped like a flat
-// per-channel vector (`prod(dims) == dims[-1]`) -- mirrors pruning.py's own
-// `_flat_channel_const` exactly: the self-consistency bar every per-channel
-// affine/bias/scale hop in this module checks before ever accepting a
-// tensor as a slice target. The real `dims[-1] == n_channels` check, once
-// the chain's real channel count is known, is left to the caller
-// (MatchGroupNormPassThrough).
-bool FlatChannelConst(const std::string& name, const InitMap& init_map) {
-  auto it = init_map.find(name);
-  if (it == init_map.end() ||
-      it->second->data_type() != onnx::TensorProto::FLOAT) {
-    return false;
-  }
-  const auto& dims = it->second->dims();
-  if (dims.size() == 0) {
-    return false;
-  }
-  int64_t prod = 1;
-  for (int64_t d : dims) {
-    prod *= d;
-  }
-  return prod == dims.Get(dims.size() - 1);
 }
 
 struct GroupNormMatch {
@@ -1591,11 +2394,37 @@ WalkToConvConsumer(const std::string& start, const InitMap& init_map,
     onnx::NodeProto* nxt;
     if (hop == 0 && forced_first_hop != nullptr) {
       // See WalkToConsumer's own matching parameter -- used only by
-      // ResolveConvFanoutBranches.
+      // ResolveConvFanoutBranches. The self-gated-activation hop below is
+      // never attempted on this path either -- see this file's own
+      // "Self-gated activation decomposition" section comment for why.
       nxt = forced_first_hop;
     } else {
       auto cit = consumers_of.find(cur);
-      if (cit == consumers_of.end() || cit->second.size() != 1) {
+      const size_t num_candidates =
+          cit == consumers_of.end() ? 0 : cit->second.size();
+      if (num_candidates == 2) {
+        // A self-gated activation decomposition's own origin tensor (SiLU/
+        // Swish, ubiquitous after Conv in YOLO-style backbones) -- see this
+        // file's own "Self-gated activation decomposition" section comment
+        // above WalkGateBranch. Recognized only at a walk's very first hop
+        // -- see that comment for why every later hop can never see a
+        // two-consumer `cur` in the first place.
+        auto diamond = MatchSelfGatedActivation(cur, consumers_of, init_map,
+                                                graph_outputs);
+        if (diamond) {
+          if (ConsumerCount(consumers_of, diamond->final_out) != 1 ||
+              graph_outputs.count(diamond->final_out)) {
+            break;
+          }
+          for (onnx::NodeProto* n : diamond->diamond_nodes) {
+            chain_ops.push_back(ChainOp{n, std::nullopt});
+          }
+          cur = diamond->final_out;
+          continue;
+        }
+        break;  // Two consumers but not this shape -- declined, as before.
+      }
+      if (num_candidates != 1) {
         break;
       }
       nxt = cit->second[0];
@@ -1773,9 +2602,6 @@ std::vector<Chain> FindConvChains(onnx::GraphProto* graph) {
   for (const auto& o : graph->output()) {
     graph_outputs.insert(o.name());
   }
-  auto is_internal = [&](const std::string& name) {
-    return ConsumerCount(consumers_of, name) == 1 && !graph_outputs.count(name);
-  };
 
   std::vector<Chain> chains;
   for (int i = 0; i < graph->node_size(); ++i) {
@@ -1785,7 +2611,19 @@ std::vector<Chain> FindConvChains(onnx::GraphProto* graph) {
       continue;
     }
     const std::string& out_name = node->output(0);
-    if (!is_internal(out_name)) {
+    // Ordinarily exactly one consumer -- but also admit exactly two, the
+    // shape a self-gated activation decomposition's own origin tensor
+    // takes (see this file's own "Self-gated activation decomposition"
+    // section comment above WalkGateBranch): WalkToConvConsumer decides, at
+    // its own first hop, whether those two consumers actually form that
+    // shape, declining (same as before) if not. Unlike FindChains's own
+    // MatmulWalkRootOk gate, this stays narrower (1 or 2 only, never a bare
+    // "not a graph output") -- the decomposed-LayerNorm hop is MatMul/Gemm-
+    // chain-only, so there's no analogous reason to admit an arbitrary
+    // consumer count here.
+    if (graph_outputs.count(out_name) ||
+        (ConsumerCount(consumers_of, out_name) != 1 &&
+         ConsumerCount(consumers_of, out_name) != 2)) {
       continue;
     }
     auto [consumer, chain_ops, pass_through, group_norm] = WalkToConvConsumer(
@@ -1960,7 +2798,7 @@ std::optional<InstanceNormMatch> MatchInstanceNormPassThroughSelf(
 ConvBackwardEdge WalkConvProducerBackward(
     const std::string& start,
     const std::unordered_map<std::string, onnx::NodeProto*>& node_by_output,
-    const InitMap& init_map,
+    const InitMap& init_map, const ConsumerMap& consumers_of,
     const std::unordered_set<std::string>& graph_outputs, int max_hops) {
   std::vector<ConvPassThrough> pass_through;  // Backward order.
   std::vector<onnx::NodeProto*> unary_ops;    // Backward order.
@@ -2057,6 +2895,31 @@ ConvBackwardEdge WalkConvProducerBackward(
       edges.push_back({node->input(0), node});
       cur = node->input(0);
       continue;
+    }
+
+    if (node->op_type() == "Mul" && node->domain() == "") {
+      // See WalkMatmulProducerBackward's own identical check for the full
+      // reasoning (checked here, ahead of nothing else in this Conv-chain
+      // walker -- unlike the MatMul/Gemm walk, there is no ordinary
+      // bias/scale Mul hop here to shadow). `origin`'s own two real
+      // in-group consumers (the gate branch's own first node, and the gate
+      // Mul itself) both become `edges` entries, tolerated natively by the
+      // `accounted` bookkeeping FindConvResidualChains builds from them.
+      // This is the reason this function gained a `consumers_of` parameter
+      // at all -- every other hop above reaches `cur`'s own producer purely
+      // via `node_by_output`, needing no forward-consumer lookups.
+      auto diamond = MatchSelfGatedActivationBackward(
+          cur, node_by_output, consumers_of, init_map, graph_outputs);
+      if (diamond) {
+        for (auto it = diamond->diamond_nodes.rbegin();
+             it != diamond->diamond_nodes.rend(); ++it) {
+          unary_ops.push_back(*it);
+        }
+        edges.push_back({diamond->origin, diamond->diamond_nodes.front()});
+        edges.push_back({diamond->origin, diamond->gate_node});
+        cur = diamond->origin;
+        continue;
+      }
     }
 
     if (IsEligibleAddMerge(*node, init_map)) {
@@ -2205,8 +3068,9 @@ std::vector<Chain> FindConvResidualChains(onnx::GraphProto* graph) {
   for (size_t idx = 0; idx < eligible_adds.size(); ++idx) {
     std::vector<ConvBackwardEdge> results;
     for (const auto& operand : eligible_adds[idx]->input()) {
-      ConvBackwardEdge edge = WalkConvProducerBackward(
-          operand, node_by_output, init_map, graph_outputs, kMaxChainHops);
+      ConvBackwardEdge edge =
+          WalkConvProducerBackward(operand, node_by_output, init_map,
+                                   consumers_of, graph_outputs, kMaxChainHops);
       if (edge.kind == BackwardEdgeKind::kFail) {
         poisoned.insert(static_cast<int>(idx));
       } else if (edge.kind == BackwardEdgeKind::kAdd) {
@@ -2619,6 +3483,38 @@ MatMulBackwardEdge WalkMatmulProducerBackward(
       edges.push_back({node->input(0), node});
       cur = node->input(0);
       continue;
+    }
+
+    if (node->op_type() == "Mul" && node->domain() == "") {
+      // Checked ahead of the ordinary Add/Mul dispatch below: a self-gated
+      // activation decomposition's own gate Mul (and, for erf-GELU, its
+      // trailing scalar-scale Mul) is otherwise indistinguishable from a
+      // plain bias/scale Mul hop by op type alone -- see this file's own
+      // "Self-gated activation decomposition" section comment above
+      // WalkGateBranch. The diamond's own origin tensor legitimately has
+      // two in-group consumers (the gate branch's own first node, and this
+      // Mul), so *two* `edges` entries share that one tensor -- the
+      // `accounted` bookkeeping every caller of this walk already builds
+      // tolerates that natively; the direct Concat-branch walk
+      // (BranchWalkHasFanout) does not, and simply declines a branch that
+      // crosses one, the same safe fallback a residual/merge fan-out
+      // already gets there before this feature existed.
+      auto diamond = MatchSelfGatedActivationBackward(
+          cur, node_by_output, consumers_of, init_map, graph_outputs);
+      if (diamond) {
+        for (auto it = diamond->diamond_nodes.rbegin();
+             it != diamond->diamond_nodes.rend(); ++it) {
+          chain_ops.push_back(ChainOp{*it, std::nullopt});
+        }
+        // `origin` has two real in-group consumers -- the gate branch's
+        // own first node and the gate Mul itself -- both recorded so
+        // neither is later mistaken for a stray extra consumer needing its
+        // own separate resolution.
+        edges.push_back({diamond->origin, diamond->diamond_nodes.front()});
+        edges.push_back({diamond->origin, diamond->gate_node});
+        cur = diamond->origin;
+        continue;
+      }
     }
 
     if ((node->op_type() == "Add" || node->op_type() == "Mul") &&
@@ -4692,7 +5588,7 @@ struct ResolvedConvResidualGroup {
 std::optional<ResolvedConvResidualGroup> ResolveConvResidualGroupForConcat(
     onnx::NodeProto* root,
     const std::unordered_map<std::string, onnx::NodeProto*>& node_by_output,
-    const InitMap& init_map,
+    const InitMap& init_map, const ConsumerMap& consumers_of,
     const std::unordered_set<std::string>& graph_outputs) {
   std::vector<onnx::NodeProto*> visited{root};
   std::unordered_set<onnx::NodeProto*> visited_ids{root};
@@ -4718,8 +5614,9 @@ std::optional<ResolvedConvResidualGroup> ResolveConvResidualGroupForConcat(
     }
     for (const auto& operand : add_node->input()) {
       mark_backbone(operand, add_node);
-      ConvBackwardEdge edge = WalkConvProducerBackward(
-          operand, node_by_output, init_map, graph_outputs, kMaxChainHops);
+      ConvBackwardEdge edge =
+          WalkConvProducerBackward(operand, node_by_output, init_map,
+                                   consumers_of, graph_outputs, kMaxChainHops);
       for (const auto& e : edge.edges) {
         mark_backbone(e.first, e.second);
       }
@@ -4804,9 +5701,6 @@ std::vector<ConcatChain> FindMatmulConcatChains(onnx::GraphProto* graph) {
     graph_outputs.insert(o.name());
   }
   auto value_info_by_name = ValueInfoByName(*graph);
-  auto is_internal = [&](const std::string& name) {
-    return ConsumerCount(consumers_of, name) == 1 && !graph_outputs.count(name);
-  };
 
   std::unordered_map<std::string, FullProducerMatch> producer_infos;
   for (int i = 0; i < graph->node_size(); ++i) {
@@ -4935,7 +5829,9 @@ std::vector<ConcatChain> FindMatmulConcatChains(onnx::GraphProto* graph) {
     }
 
     const std::string& out_name = node->output(0);
-    if (!is_internal(out_name)) {
+    // See FindChains's own identical comment -- the Concat merge's own raw
+    // output can be a decomposed-LayerNorm/self-gated-activation root too.
+    if (!MatmulWalkRootOk(out_name, graph_outputs)) {
       continue;
     }
     const int64_t total_n = offset;
@@ -5012,8 +5908,9 @@ std::vector<ConcatChain> FindConvConcatChains(onnx::GraphProto* graph) {
     int64_t offset = 0;
     bool declined = false;
     for (const auto& operand : node->input()) {
-      ConvBackwardEdge edge = WalkConvProducerBackward(
-          operand, node_by_output, init_map, graph_outputs, kMaxChainHops);
+      ConvBackwardEdge edge =
+          WalkConvProducerBackward(operand, node_by_output, init_map,
+                                   consumers_of, graph_outputs, kMaxChainHops);
       if (edge.kind == BackwardEdgeKind::kFail) {
         declined = true;
         break;
@@ -5024,7 +5921,8 @@ std::vector<ConcatChain> FindConvConcatChains(onnx::GraphProto* graph) {
       }
       if (edge.kind == BackwardEdgeKind::kAdd) {
         auto resolved = ResolveConvResidualGroupForConcat(
-            edge.add_node, node_by_output, init_map, graph_outputs);
+            edge.add_node, node_by_output, init_map, consumers_of,
+            graph_outputs);
         if (!resolved) {
           declined = true;
           break;
@@ -5704,7 +6602,9 @@ std::vector<SplitGatedChain> FindSplitGatedChains(onnx::GraphProto* graph) {
     const SplitMatch& sm = split_matches.at(split_a);
 
     const std::string& out_name = node->output(0);
-    if (!is_internal(out_name)) {
+    // See FindChains's own identical comment -- the combine's own raw
+    // output can be a decomposed-LayerNorm/self-gated-activation root too.
+    if (!MatmulWalkRootOk(out_name, graph_outputs)) {
       continue;
     }
     auto [consumer, chain_ops] = WalkToConsumer(

--- a/tests/test_structured_pruning_cpp.py
+++ b/tests/test_structured_pruning_cpp.py
@@ -4363,3 +4363,851 @@ def test_cpp_structured_pruning_matches_python_reference_output_with_if_subgraph
         y0_cpp, y1_cpp = _run(pruned_cpp, feeds)
         np.testing.assert_allclose(y0_py, y0_cpp, rtol=1e-5, atol=1e-5)
         np.testing.assert_allclose(y1_py, y1_cpp, rtol=1e-5, atol=1e-5)
+
+
+# --- Decomposed (not-yet-fused) LayerNorm pass-through, MatMul/Gemm chains --
+#
+# `LayerNormalization`'s own schema is only opset 17+, so an export at
+# opset <= 16 has no fused op to lower `nn.LayerNorm` to at all and emits its
+# canonical 9-node decomposition instead -- see `structured_pruning_entry.cpp`'s
+# own "Decomposed (not-yet-fused) LayerNorm pass-through" section comment
+# (mirroring `onnxsim/pruning.py`'s own `_match_decomposed_layer_norm_pass_
+# through`) for the full shape. Mirrors `tests/test_pruning.py`'s own
+# "apply_structured_pruning: *decomposed* (not-yet-fused) LayerNorm" section.
+
+
+def _decomposed_layer_norm_model(w1, gamma, beta, w2, axis=-1, opset=16, pow_exp=2.0):
+    K, C = w1.shape
+    Out = w2.shape[1]
+    initializer = [
+        _f32(w1, "W1"),
+        onnx.numpy_helper.from_array(np.array(pow_exp, dtype=np.float32), "Two"),
+        onnx.numpy_helper.from_array(np.array(1e-5, dtype=np.float32), "Eps"),
+        _f32(gamma, "Gamma"),
+        _f32(beta, "Beta"),
+        _f32(w2, "W2"),
+    ]
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          up = MatMul(X, W1)
+          mean = ReduceMean<axes=[{axis}]>(up)
+          centered = Sub(up, mean)
+          sq = Pow(centered, Two)
+          var = ReduceMean<axes=[{axis}]>(sq)
+          var_eps = Add(var, Eps)
+          std = Sqrt(var_eps)
+          normed = Div(centered, std)
+          scaled = Mul(normed, Gamma)
+          h = Add(scaled, Beta)
+          Y = MatMul(h, W2)
+        }}
+        """,
+        initializer=initializer,
+        opset=opset,
+    )
+
+
+def test_cpp_structured_pruning_decomposed_layer_norm_pass_through_shrinks_matched_layers():
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(6001)
+    w1 = rng.standard_normal((K, C)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    beta = rng.standard_normal((C,)).astype(np.float32)
+    w2 = rng.standard_normal((C, Out)).astype(np.float32)
+    model = _decomposed_layer_norm_model(w1, gamma, beta, w2)
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [K, C // 2]
+    assert list(inits["Gamma"].dims) == [C // 2]
+    assert list(inits["Beta"].dims) == [C // 2]
+    assert list(inits["W2"].dims) == [C // 2, Out]
+    # Every decomposition node itself is untouched (still the same 9 nodes,
+    # same op types/wiring) -- only the two per-channel constants shrink.
+    assert [n.op_type for n in pruned.graph.node] == [
+        "MatMul",
+        "ReduceMean",
+        "Sub",
+        "Pow",
+        "ReduceMean",
+        "Add",
+        "Sqrt",
+        "Div",
+        "Mul",
+        "Add",
+        "MatMul",
+    ]
+
+
+def test_cpp_structured_pruning_decomposed_layer_norm_pass_through_matches_oracle_adversarially():
+    # W1 engineered so the surviving `keep` set is deliberately not the
+    # first C//2 channels, Gamma/Beta spanning three orders of magnitude,
+    # strictly increasing by channel index -- a positional (rather than
+    # index-set) slice of Gamma/Beta would misapply a wildly-wrong-magnitude
+    # affine term to a kept channel, detectably wrong by orders of
+    # magnitude. Mirrors test_pruning.py's own identically-named test.
+    K, C, Out = 4, 8, 2
+    rng = np.random.default_rng(6002)
+    col_scale = np.linspace(0.1, 2.0, C).astype(np.float32)
+    w1 = (rng.standard_normal((K, C)) * col_scale).astype(np.float32)
+    gamma = (np.arange(1, C + 1, dtype=np.float64) * 0.001).astype(np.float32)
+    beta = (np.arange(1, C + 1, dtype=np.float64) * 1000.0).astype(np.float32)
+    w2 = rng.standard_normal((C, Out)).astype(np.float32)
+    model = _decomposed_layer_norm_model(w1, gamma, beta, w2)
+    onnx.checker.check_model(model)
+
+    keep_count = C // 2
+    keep = _oracle_keep_indices(w1, keep_count)
+    assert not np.array_equal(keep, np.arange(keep_count))  # confirm adversarial
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+
+    def _layer_norm(v, g, b, eps=1e-5):
+        mean = v.mean(axis=-1, keepdims=True)
+        var = v.var(axis=-1, keepdims=True)
+        return (v - mean) / np.sqrt(var + eps) * g + b
+
+    h_correct = _layer_norm(x @ w1[:, keep], gamma[keep], beta[keep])
+    y_correct = h_correct @ w2[keep, :]
+    np.testing.assert_allclose(y, y_correct, rtol=1e-4, atol=1e-4)
+
+    wrong_gamma = gamma[:keep_count]
+    wrong_beta = beta[:keep_count]
+    h_wrong = _layer_norm(x @ w1[:, keep], wrong_gamma, wrong_beta)
+    y_wrong = h_wrong @ w2[keep, :]
+    assert np.max(np.abs(y - y_wrong)) > 1e-2 * max(1.0, np.max(np.abs(y_correct)))
+
+
+def test_cpp_structured_pruning_decomposed_layer_norm_pow_exponent_not_two_is_declined():
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(6003)
+    w1 = rng.standard_normal((K, C)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    beta = rng.standard_normal((C,)).astype(np.float32)
+    w2 = rng.standard_normal((C, Out)).astype(np.float32)
+    model = _decomposed_layer_norm_model(w1, gamma, beta, w2, pow_exp=3.0)
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_structured_pruning_decomposed_layer_norm_axis_not_last_is_declined():
+    # axis=-2 on a rank-2 [batch, C] tensor normalizes over the batch axis,
+    # not the trailing channel axis being pruned.
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(6004)
+    w1 = rng.standard_normal((K, C)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    beta = rng.standard_normal((C,)).astype(np.float32)
+    w2 = rng.standard_normal((C, Out)).astype(np.float32)
+    model = _decomposed_layer_norm_model(w1, gamma, beta, w2, axis=-2)
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_structured_pruning_decomposed_layer_norm_extra_root_consumer_is_declined():
+    # `up` (the decomposition's own root tensor) must be read by *exactly*
+    # the ReduceMean/Sub pair this shape expects -- a third reader (here, an
+    # extra Identity tapping the same tensor for a second graph output)
+    # means the whole chain is declined outright, never partially matched.
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(6005)
+    w1 = rng.standard_normal((K, C)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    beta = rng.standard_normal((C,)).astype(np.float32)
+    w2 = rng.standard_normal((C, Out)).astype(np.float32)
+    initializer = [
+        _f32(w1, "W1"),
+        onnx.numpy_helper.from_array(np.array(2.0, dtype=np.float32), "Two"),
+        onnx.numpy_helper.from_array(np.array(1e-5, dtype=np.float32), "Eps"),
+        _f32(gamma, "Gamma"),
+        _f32(beta, "Beta"),
+        _f32(w2, "W2"),
+    ]
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y, float[batch,{C}] Extra)
+        {{
+          up = MatMul(X, W1)
+          Extra = Identity(up)
+          mean = ReduceMean<axes=[-1]>(up)
+          centered = Sub(up, mean)
+          sq = Pow(centered, Two)
+          var = ReduceMean<axes=[-1]>(sq)
+          var_eps = Add(var, Eps)
+          std = Sqrt(var_eps)
+          normed = Div(centered, std)
+          scaled = Mul(normed, Gamma)
+          h = Add(scaled, Beta)
+          Y = MatMul(h, W2)
+        }}
+        """,
+        initializer=initializer,
+        opset=16,
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_structured_pruning_decomposed_layer_norm_extra_centered_consumer_is_declined():
+    # `centered` (Sub's own output) must likewise be read by *exactly* the
+    # Pow/Div pair this shape expects.
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(6006)
+    w1 = rng.standard_normal((K, C)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    beta = rng.standard_normal((C,)).astype(np.float32)
+    w2 = rng.standard_normal((C, Out)).astype(np.float32)
+    initializer = [
+        _f32(w1, "W1"),
+        onnx.numpy_helper.from_array(np.array(2.0, dtype=np.float32), "Two"),
+        onnx.numpy_helper.from_array(np.array(1e-5, dtype=np.float32), "Eps"),
+        _f32(gamma, "Gamma"),
+        _f32(beta, "Beta"),
+        _f32(w2, "W2"),
+    ]
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y, float[batch,{C}] Extra)
+        {{
+          up = MatMul(X, W1)
+          mean = ReduceMean<axes=[-1]>(up)
+          centered = Sub(up, mean)
+          Extra = Identity(centered)
+          sq = Pow(centered, Two)
+          var = ReduceMean<axes=[-1]>(sq)
+          var_eps = Add(var, Eps)
+          std = Sqrt(var_eps)
+          normed = Div(centered, std)
+          scaled = Mul(normed, Gamma)
+          h = Add(scaled, Beta)
+          Y = MatMul(h, W2)
+        }}
+        """,
+        initializer=initializer,
+        opset=16,
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_structured_pruning_decomposed_layer_norm_after_bias_add_matches_oracle():
+    # The decomposition's own root tensor (`up`, read twice) sitting right
+    # after an ordinary preceding hop (a per-channel bias `Add`, itself
+    # producing a tensor read twice) -- confirms the fix composes with an
+    # already-established chain_ops hop (WalkToConsumer's own `out2`
+    # fallback), not just a bare producer output feeding the decomposition
+    # directly.
+    K, C, Out = 6, 12, 3
+    rng = np.random.default_rng(6007)
+    w1 = rng.standard_normal((K, C)).astype(np.float32)
+    b1 = rng.standard_normal((C,)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    beta = rng.standard_normal((C,)).astype(np.float32)
+    w2 = rng.standard_normal((C, Out)).astype(np.float32)
+    initializer = [
+        _f32(w1, "W1"),
+        _f32(b1, "B1"),
+        onnx.numpy_helper.from_array(np.array(2.0, dtype=np.float32), "Two"),
+        onnx.numpy_helper.from_array(np.array(1e-5, dtype=np.float32), "Eps"),
+        _f32(gamma, "Gamma"),
+        _f32(beta, "Beta"),
+        _f32(w2, "W2"),
+    ]
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          mm = MatMul(X, W1)
+          up = Add(mm, B1)
+          mean = ReduceMean<axes=[-1]>(up)
+          centered = Sub(up, mean)
+          sq = Pow(centered, Two)
+          var = ReduceMean<axes=[-1]>(sq)
+          var_eps = Add(var, Eps)
+          std = Sqrt(var_eps)
+          normed = Div(centered, std)
+          scaled = Mul(normed, Gamma)
+          h = Add(scaled, Beta)
+          Y = MatMul(h, W2)
+        }}
+        """,
+        initializer=initializer,
+        opset=16,
+    )
+    onnx.checker.check_model(model)
+
+    keep_count = C // 2
+    keep = _oracle_keep_indices(w1, keep_count)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Gamma"].dims) == [keep_count]
+
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+
+    def _layer_norm(v, g, b, eps=1e-5):
+        mean = v.mean(axis=-1, keepdims=True)
+        var = v.var(axis=-1, keepdims=True)
+        return (v - mean) / np.sqrt(var + eps) * g + b
+
+    up_ref = x @ w1[:, keep] + b1[keep]
+    h_correct = _layer_norm(up_ref, gamma[keep], beta[keep])
+    y_correct = h_correct @ w2[keep, :]
+    np.testing.assert_allclose(y, y_correct, rtol=1e-4, atol=1e-4)
+
+
+def test_cpp_structured_pruning_decomposed_layer_norm_matches_python_reference_output():
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(6008)
+    w1 = rng.standard_normal((K, C)).astype(np.float32)
+    gamma = rng.standard_normal((C,)).astype(np.float32)
+    beta = rng.standard_normal((C,)).astype(np.float32)
+    w2 = rng.standard_normal((C, Out)).astype(np.float32)
+    model = _decomposed_layer_norm_model(w1, gamma, beta, w2)
+
+    pruned_py = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    pruned_cpp = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_py)
+    onnx.checker.check_model(pruned_cpp)
+
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y_py,) = _run(pruned_py, {"X": x})
+    (y_cpp,) = _run(pruned_cpp, {"X": x})
+    np.testing.assert_allclose(y_py, y_cpp, rtol=1e-5, atol=1e-5)
+
+
+# --- Self-gated activation decomposition (SiLU/erf-GELU, unfused) ----------
+#
+# A raw export of `nn.SiLU()`/`nn.GELU()` -- below the fused op's own opset
+# floor -- emits the literal decomposition instead of the fused node: the
+# producer's own output tensor feeds *two* consumers at once (a gate branch,
+# and the `Mul` that combines it with that branch's own output). Mirrors
+# `structured_pruning_entry.cpp`'s own "Self-gated activation decomposition"
+# section comment (and `onnxsim/pruning.py`'s own identically-named one) --
+# see there for the exact two node shapes and the design rationale. Mirrors
+# `tests/test_pruning.py`'s own "Self-gated activation decomposition" test
+# sections (Conv-chain and MatMul/Gemm-chain).
+
+
+def _conv_silu_decomposed_pair_model(w1, w2, b1=None, spatial=10):
+    Cin, C2 = w1.shape[1], w2.shape[0]
+    initializer = [_f32(w1, "W1"), _f32(w2, "W2")]
+    if b1 is not None:
+        conv1 = "h = Conv<kernel_shape=[3,3]>(X, W1, B1)"
+        initializer.append(_f32(b1, "B1"))
+    else:
+        conv1 = "h = Conv<kernel_shape=[3,3]>(X, W1)"
+    out_spatial = spatial - 4
+    return _model(
+        f"""
+        g (float[N,{Cin},{spatial},{spatial}] X) => (float[N,{C2},{out_spatial},{out_spatial}] Y)
+        {{
+          {conv1}
+          s = Sigmoid(h)
+          a = Mul(h, s)
+          Y = Conv<kernel_shape=[3,3]>(a, W2)
+        }}
+        """,
+        initializer=initializer,
+    )
+
+
+def _conv_erf_gelu_decomposed_pair_model(w1, w2, b1=None, spatial=10):
+    Cin, C2 = w1.shape[1], w2.shape[0]
+    initializer = [_f32(w1, "W1"), _f32(w2, "W2")]
+    if b1 is not None:
+        conv1 = "h = Conv<kernel_shape=[3,3]>(X, W1, B1)"
+        initializer.append(_f32(b1, "B1"))
+    else:
+        conv1 = "h = Conv<kernel_shape=[3,3]>(X, W1)"
+    out_spatial = spatial - 4
+    return _model(
+        f"""
+        g (float[N,{Cin},{spatial},{spatial}] X) => (float[N,{C2},{out_spatial},{out_spatial}] Y)
+        <float Sqrt2 = {{1.4142135}}, float One = {{1.0}}, float Half = {{0.5}}>
+        {{
+          {conv1}
+          d = Div(h, Sqrt2)
+          e = Erf(d)
+          ao = Add(e, One)
+          m = Mul(h, ao)
+          a = Mul(m, Half)
+          Y = Conv<kernel_shape=[3,3]>(a, W2)
+        }}
+        """,
+        initializer=initializer,
+    )
+
+
+def test_cpp_structured_pruning_conv_chain_silu_decomposed_matches_oracle_exactly():
+    # Before this hop existed, this exact chain came out completely
+    # unpruned end to end -- `h`'s own two consumers broke the forward
+    # walk's single-consumer-per-tensor assumption outright.
+    Cin, C1, C2 = 3, 16, 8
+    rng = np.random.default_rng(6101)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    b1 = rng.standard_normal((C1,)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    model = _conv_silu_decomposed_pair_model(w1, w2, b1=b1)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [C1 // 2, Cin, 3, 3]
+    assert list(inits["W2"].dims) == [C2, C1 // 2, 3, 3]
+    pruned_node_types = sorted(n.op_type for n in pruned.graph.node)
+    assert pruned_node_types == sorted(n.op_type for n in model.graph.node)
+
+    keep = _oracle_keep_indices_conv(w1, C1 // 2)
+    oracle = _conv_silu_decomposed_pair_model(w1[keep], w2[:, keep], b1=b1[keep])
+
+    rng_x = np.random.default_rng(6102)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    assert np.isfinite(y).all()
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_conv_chain_erf_gelu_decomposed_matches_oracle_exactly():
+    Cin, C1, C2 = 3, 16, 8
+    rng = np.random.default_rng(6103)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    b1 = rng.standard_normal((C1,)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    model = _conv_erf_gelu_decomposed_pair_model(w1, w2, b1=b1)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [C1 // 2, Cin, 3, 3]
+    assert list(inits["W2"].dims) == [C2, C1 // 2, 3, 3]
+    pruned_node_types = sorted(n.op_type for n in pruned.graph.node)
+    assert pruned_node_types == sorted(n.op_type for n in model.graph.node)
+
+    keep = _oracle_keep_indices_conv(w1, C1 // 2)
+    oracle = _conv_erf_gelu_decomposed_pair_model(w1[keep], w2[:, keep], b1=b1[keep])
+
+    rng_x = np.random.default_rng(6104)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    assert np.isfinite(y).all()
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_conv_chain_fused_gelu_still_matches_oracle_exactly():
+    # Control case: the *fused* `Gelu` node (already unary/
+    # UnaryPassThroughOps()) must keep pruning correctly, unaffected by the
+    # new decomposition hop.
+    Cin, C1, C2 = 3, 16, 8
+    rng = np.random.default_rng(6105)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    b1 = rng.standard_normal((C1,)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    model = _conv_pair_model(w1, w2, b1=b1, activation="Gelu")
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [C1 // 2, Cin, 3, 3]
+    assert list(inits["W2"].dims) == [C2, C1 // 2, 3, 3]
+
+    keep = _oracle_keep_indices_conv(w1, C1 // 2)
+    oracle = _conv_pair_model(w1[keep], w2[:, keep], b1=b1[keep], activation="Gelu")
+
+    rng_x = np.random.default_rng(6106)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    assert np.isfinite(y).all()
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_conv_chain_erf_gelu_decomposed_declines_on_branch_fanout():
+    # `d` (the gate branch's own `Div` output) is *also* read by a second,
+    # spurious consumer (`Extra`, tapped as a second graph output) -- the
+    # gate branch is no longer a strict single-consumer chain, so
+    # WalkGateBranch must decline the whole diamond outright, leaving both
+    # weights completely untouched, never guessed at or partially cut.
+    Cin, C1, C2 = 3, 16, 8
+    rng = np.random.default_rng(6107)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{C2},6,6] Y, float[N,{C1},10,10] Extra)
+        <float Sqrt2 = {{1.4142135}}, float One = {{1.0}}, float Half = {{0.5}}>
+        {{
+          h = Conv<kernel_shape=[3,3]>(X, W1)
+          d = Div(h, Sqrt2)
+          Extra = Identity(d)
+          e = Erf(d)
+          ao = Add(e, One)
+          m = Mul(h, ao)
+          a = Mul(m, Half)
+          Y = Conv<kernel_shape=[3,3]>(a, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2")],
+    )
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+
+
+def test_cpp_structured_pruning_conv_residual_silu_decomposed_pass_through_matches_oracle():
+    # A decomposed SiLU diamond crossed by the *backward* walk
+    # (WalkConvProducerBackward/MatchSelfGatedActivationBackward), not just
+    # the forward one -- exercises the residual-chain insertion point and
+    # the two-in-group-consumers `edges`/`accounted` bookkeeping the diamond's
+    # own origin tensor needs.
+    Cin, C, Cout = 3, 16, 8
+    rng = np.random.default_rng(6108)
+    w_f = rng.standard_normal((C, Cin, 3, 3)).astype(np.float32)
+    w_s = rng.standard_normal((C, Cin, 3, 3)).astype(np.float32)
+    w_out = rng.standard_normal((Cout, C, 3, 3)).astype(np.float32)
+
+    def _mk(w_f, w_s, w_out):
+        return _model(
+            f"""
+            g (float[N,{Cin},10,10] X) => (float[N,{Cout},6,6] Y)
+            {{
+              f0 = Conv<kernel_shape=[3,3]>(X, WF)
+              fs = Sigmoid(f0)
+              f = Mul(f0, fs)
+              s = Conv<kernel_shape=[3,3]>(X, WS)
+              addr = Add(f, s)
+              r = Relu(addr)
+              Y = Conv<kernel_shape=[3,3]>(r, WOUT)
+            }}
+            """,
+            initializer=[
+                _f32(w_f, "WF"),
+                _f32(w_s, "WS"),
+                _f32(w_out, "WOUT"),
+            ],
+        )
+
+    model = _mk(w_f, w_s, w_out)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    importance = np.sqrt(
+        np.square(np.linalg.norm(w_f.reshape(C, -1).astype(np.float64), axis=1))
+        + np.square(np.linalg.norm(w_s.reshape(C, -1).astype(np.float64), axis=1))
+    )
+    keep = np.sort(np.argsort(-importance)[: C // 2])
+    oracle = _mk(w_f[keep], w_s[keep], w_out[:, keep])
+
+    rng_x = np.random.default_rng(6109)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+# --- Self-gated activation decomposition, MatMul/Gemm chains ---------------
+
+
+def _mlp_silu_decomposed_model(K, H, Out, bias=True, seed=0):
+    rng = np.random.default_rng(seed)
+    w1 = rng.standard_normal((K, H)).astype(np.float32)
+    w2 = rng.standard_normal((H, Out)).astype(np.float32)
+    initializer = [_f32(w1, "W1"), _f32(w2, "W2")]
+    if bias:
+        b1 = rng.standard_normal((H,)).astype(np.float32)
+        gemm1 = "h = Gemm(X, W1, B1)"
+        initializer.append(_f32(b1, "B1"))
+    else:
+        gemm1 = "h = MatMul(X, W1)"
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          {gemm1}
+          s = Sigmoid(h)
+          a = Mul(h, s)
+          Y = MatMul(a, W2)
+        }}
+        """,
+        initializer=initializer,
+    )
+    return model, w1, w2, (b1 if bias else None)
+
+
+def _mlp_erf_gelu_decomposed_model(K, H, Out, bias=True, seed=0):
+    rng = np.random.default_rng(seed)
+    w1 = rng.standard_normal((K, H)).astype(np.float32)
+    w2 = rng.standard_normal((H, Out)).astype(np.float32)
+    initializer = [_f32(w1, "W1"), _f32(w2, "W2")]
+    if bias:
+        b1 = rng.standard_normal((H,)).astype(np.float32)
+        gemm1 = "h = Gemm(X, W1, B1)"
+        initializer.append(_f32(b1, "B1"))
+    else:
+        gemm1 = "h = MatMul(X, W1)"
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        <float Sqrt2 = {{1.4142135}}, float One = {{1.0}}, float Half = {{0.5}}>
+        {{
+          {gemm1}
+          d = Div(h, Sqrt2)
+          e = Erf(d)
+          ao = Add(e, One)
+          m = Mul(h, ao)
+          a = Mul(m, Half)
+          Y = MatMul(a, W2)
+        }}
+        """,
+        initializer=initializer,
+    )
+    return model, w1, w2, (b1 if bias else None)
+
+
+def test_cpp_structured_pruning_matmul_silu_decomposed_matches_oracle_exactly():
+    K, H, Out = 8, 32, 4
+    model, w1, w2, b1 = _mlp_silu_decomposed_model(K, H, Out)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    keep_count = H // 2
+    assert list(inits["W1"].dims)[1] == keep_count
+    assert list(inits["W2"].dims)[0] == keep_count
+    pruned_node_types = sorted(n.op_type for n in pruned.graph.node)
+    assert pruned_node_types == sorted(n.op_type for n in model.graph.node)
+
+    keep = _oracle_keep_indices(w1, keep_count)
+    oracle = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          h = Gemm(X, W1, B1)
+          s = Sigmoid(h)
+          a = Mul(h, s)
+          Y = MatMul(a, W2)
+        }}
+        """,
+        initializer=[
+            _f32(w1[:, keep], "W1"),
+            _f32(w2[keep], "W2"),
+            _f32(b1[keep], "B1"),
+        ],
+    )
+
+    rng_x = np.random.default_rng(6111)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_matmul_erf_gelu_decomposed_matches_oracle_exactly():
+    K, H, Out = 8, 32, 4
+    model, w1, w2, b1 = _mlp_erf_gelu_decomposed_model(K, H, Out)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    keep_count = H // 2
+    assert list(inits["W1"].dims)[1] == keep_count
+    assert list(inits["W2"].dims)[0] == keep_count
+    pruned_node_types = sorted(n.op_type for n in pruned.graph.node)
+    assert pruned_node_types == sorted(n.op_type for n in model.graph.node)
+
+    keep = _oracle_keep_indices(w1, keep_count)
+    oracle = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        <float Sqrt2 = {{1.4142135}}, float One = {{1.0}}, float Half = {{0.5}}>
+        {{
+          h = Gemm(X, W1, B1)
+          d = Div(h, Sqrt2)
+          e = Erf(d)
+          ao = Add(e, One)
+          m = Mul(h, ao)
+          a = Mul(m, Half)
+          Y = MatMul(a, W2)
+        }}
+        """,
+        initializer=[
+            _f32(w1[:, keep], "W1"),
+            _f32(w2[keep], "W2"),
+            _f32(b1[keep], "B1"),
+        ],
+    )
+
+    rng_x = np.random.default_rng(6112)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_matmul_fused_gelu_still_matches_oracle_exactly():
+    # Control case: the *fused* `Gelu` node (already UnaryPassThroughOps())
+    # must keep pruning correctly, unaffected by the new decomposition hop.
+    K, H, Out = 8, 32, 4
+    rng = np.random.default_rng(6113)
+    w1 = rng.standard_normal((K, H)).astype(np.float32)
+    b1 = rng.standard_normal((H,)).astype(np.float32)
+    w2 = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          h = Gemm(X, W1, B1)
+          a = Gelu(h)
+          Y = MatMul(a, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(b1, "B1"), _f32(w2, "W2")],
+    )
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    keep_count = H // 2
+    assert list(inits["W1"].dims)[1] == keep_count
+    assert list(inits["W2"].dims)[0] == keep_count
+
+    keep = _oracle_keep_indices(w1, keep_count)
+    oracle = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          h = Gemm(X, W1, B1)
+          a = Gelu(h)
+          Y = MatMul(a, W2)
+        }}
+        """,
+        initializer=[
+            _f32(w1[:, keep], "W1"),
+            _f32(b1[keep], "B1"),
+            _f32(w2[keep], "W2"),
+        ],
+    )
+
+    rng_x = np.random.default_rng(6114)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_matmul_erf_gelu_decomposed_declines_on_nonconstant_scalar():
+    # `Sqrt2` (the gate branch's own `Div` divisor) fed by a non-constant
+    # node (an `Identity` of a graph input) rather than a genuine constant --
+    # this pass cannot confirm it's a channel-agnostic scalar without
+    # evaluating the graph, so the whole diamond must decline outright.
+    K, H, Out = 8, 32, 4
+    rng = np.random.default_rng(6115)
+    w1 = rng.standard_normal((K, H)).astype(np.float32)
+    w2 = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X, float Sqrt2In) => (float[batch,{Out}] Y)
+        <float One = {{1.0}}, float Half = {{0.5}}>
+        {{
+          h = MatMul(X, W1)
+          Sqrt2 = Identity(Sqrt2In)
+          d = Div(h, Sqrt2)
+          e = Erf(d)
+          ao = Add(e, One)
+          m = Mul(h, ao)
+          a = Mul(m, Half)
+          Y = MatMul(a, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2")],
+    )
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+
+
+def test_cpp_structured_pruning_matmul_residual_silu_decomposed_pass_through_matches_oracle():
+    # The MatMul/Gemm-chain analogue of the Conv residual test above --
+    # exercises WalkMatmulProducerBackward's own new Mul-ahead-of-
+    # _BINARY_CHANNEL_OPS dispatch.
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(6116)
+    w_f = rng.standard_normal((K, C)).astype(np.float32)
+    w_s = rng.standard_normal((K, C)).astype(np.float32)
+    w_out = rng.standard_normal((C, Out)).astype(np.float32)
+
+    def _mk(w_f, w_s, w_out):
+        return _model(
+            f"""
+            g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+            {{
+              f0 = MatMul(X, WF)
+              fs = Sigmoid(f0)
+              f = Mul(f0, fs)
+              s = MatMul(X, WS)
+              addr = Add(f, s)
+              r = Relu(addr)
+              Y = MatMul(r, WOUT)
+            }}
+            """,
+            initializer=[
+                _f32(w_f, "WF"),
+                _f32(w_s, "WS"),
+                _f32(w_out, "WOUT"),
+            ],
+        )
+
+    model = _mk(w_f, w_s, w_out)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    importance = np.sqrt(
+        np.square(np.linalg.norm(w_f.T.astype(np.float64), axis=1))
+        + np.square(np.linalg.norm(w_s.T.astype(np.float64), axis=1))
+    )
+    keep = np.sort(np.argsort(-importance)[: C // 2])
+    oracle = _mk(w_f[:, keep], w_s[:, keep], w_out[keep, :])
+
+    rng_x = np.random.default_rng(6117)
+    x = rng_x.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_matmul_silu_decomposed_matches_python_reference_output():
+    K, H, Out = 8, 32, 4
+    model, _w1, _w2, _b1 = _mlp_silu_decomposed_model(K, H, Out)
+
+    pruned_py = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    pruned_cpp = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_py)
+    onnx.checker.check_model(pruned_cpp)
+
+    rng = np.random.default_rng(6118)
+    x = rng.standard_normal((6, K)).astype(np.float32)
+    (y_py,) = _run(pruned_py, {"X": x})
+    (y_cpp,) = _run(pruned_cpp, {"X": x})
+    np.testing.assert_allclose(y_py, y_cpp, rtol=1e-5, atol=1e-5)

--- a/tests/test_structured_pruning_cpp.py
+++ b/tests/test_structured_pruning_cpp.py
@@ -15,6 +15,8 @@ plus a couple of tests confirming unmatched topologies are left untouched
 (never guessed at).
 """
 
+import os
+
 import numpy as np
 import onnx
 import onnx.helper
@@ -46,6 +48,25 @@ def _f32(array, name):
 
 
 def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _run27(model, feeds):
+    # `CausalConvWithState` is plain ai.onnx opset 27, which this
+    # environment's onnxruntime treats as "under development"
+    # (`ValidateOpsetForDomain` otherwise refuses to even load the graph --
+    # see onnxsim/pruning.py's own "Conv/pooling/Resize/Pad pass-through"
+    # section comment and tests/test_pruning.py's own identical `_run27`
+    # helper for the empirical finding). Setting this env var only relaxes
+    # that load-time opset-vintage check; it does not stub out or change the
+    # op's own real CPU kernel. Scoped to just this helper (not a
+    # module-level mutation) since only CausalConvWithState's own tests ever
+    # need it -- every other test in this file keeps using plain `_run`
+    # against a released opset unaffected either way.
+    os.environ["ALLOW_RELEASED_ONNX_OPSET_ONLY"] = "0"
     sess = ort.InferenceSession(
         model.SerializeToString(), providers=["CPUExecutionProvider"]
     )
@@ -3206,6 +3227,358 @@ def test_cpp_structured_pruning_conv_residual_pad_pass_through_hop_matches_oracl
     (y,) = _run(pruned, {"X": x})
     (y_oracle,) = _run(oracle, {"X": x})
     np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+# --- Conv chain: InstanceNormalization pass-through hop -----------------------
+#
+# `Conv -> InstanceNormalization -> Conv`: mirrors test_pruning.py's own
+# `_instance_norm_conv_pair_model` and its instance-norm-pass-through test
+# coverage. Unlike GroupNormalization above, InstanceNormalization carries no
+# `num_groups`/uniform-per-block constraint at all -- its own mean/variance
+# are computed per instance *per channel*, never pooled across a group, so an
+# arbitrary channel subset may be kept/dropped with no group-boundary-drift
+# risk to guard against, and `scale`/`B` are held to a *strictly* rank-1 bar
+# (not GroupNorm's own looser `FlatChannelConst`) since they are carried on a
+# plain ConvPassThrough, whose own slicing always slices axis 0 -- see
+# MatchInstanceNormPassThrough's own comment in structured_pruning_entry.cpp.
+
+
+def _instance_norm_conv_pair_model(w1, w2, in_scale, in_bias, b1=None, spatial=10):
+    Cin, C2 = w1.shape[1], w2.shape[0]
+    initializer = [
+        _f32(w1, "W1"),
+        _f32(w2, "W2"),
+        _f32(in_scale, "INScale"),
+        _f32(in_bias, "INBias"),
+    ]
+    if b1 is not None:
+        conv1 = "h = Conv<kernel_shape=[3,3]>(X, W1, B1)"
+        initializer.append(_f32(b1, "B1"))
+    else:
+        conv1 = "h = Conv<kernel_shape=[3,3]>(X, W1)"
+    out_spatial = spatial - 4  # two valid (no-pad) 3x3 convs
+    return _model(
+        f"""
+        g (float[N,{Cin},{spatial},{spatial}] X) => (float[N,{C2},{out_spatial},{out_spatial}] Y)
+        {{
+          {conv1}
+          n = InstanceNormalization<epsilon=1e-05>(h, INScale, INBias)
+          Y = Conv<kernel_shape=[3,3]>(n, W2)
+        }}
+        """,
+        initializer=initializer,
+    )
+
+
+def test_cpp_structured_pruning_instance_norm_pass_through_matches_oracle():
+    Cin, C1, C2 = 3, 16, 8
+    rng = np.random.default_rng(240)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    b1 = rng.standard_normal((C1,)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    in_scale = rng.standard_normal((C1,)).astype(np.float32)
+    in_bias = rng.standard_normal((C1,)).astype(np.float32)
+    model = _instance_norm_conv_pair_model(w1, w2, in_scale, in_bias, b1=b1)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    assert inits["W1"].shape[0] == C1 // 2
+    assert inits["INScale"].shape == inits["INBias"].shape == (C1 // 2,)
+    # No `group` attribute is ever added to a non-Conv hop node.
+    in_node = next(n for n in pruned.graph.node if n.op_type == "InstanceNormalization")
+    assert [a.name for a in in_node.attribute] == ["epsilon"]
+
+    keep = _oracle_keep_indices_conv(w1, C1 // 2)
+    oracle = _instance_norm_conv_pair_model(
+        w1[keep], w2[:, keep], in_scale[keep], in_bias[keep], b1=b1[keep]
+    )
+
+    rng_x = np.random.default_rng(241)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_cpp_structured_pruning_instance_norm_tied_scale_bias_declines():
+    # `scale`/`B` naming the *same* tensor -- double-slicing it would corrupt
+    # it, so the whole chain is declined outright, mirroring
+    # MatchInstanceNormPassThrough's own tied-name bar.
+    Cin, C1, C2 = 3, 8, 4
+    rng = np.random.default_rng(242)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    tied = rng.standard_normal((C1,)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{C2},6,6] Y)
+        {{
+          h = Conv<kernel_shape=[3,3]>(X, W1)
+          n = InstanceNormalization<epsilon=1e-05>(h, Tied, Tied)
+          Y = Conv<kernel_shape=[3,3]>(n, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2"), _f32(tied, "Tied")],
+    )
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+    np.testing.assert_array_equal(inits["Tied"], tied)
+
+
+def test_cpp_structured_pruning_instance_norm_non_1d_scale_declines():
+    # A `scale` shaped `[1, C1]` -- FlatChannelConst's own looser
+    # "prod(dims) == dims[-1]" bar would admit this (a real GroupNorm hop
+    # reuses that check), but MatchInstanceNormPassThrough deliberately holds
+    # InstanceNorm's own `scale`/`B` to a *strictly* rank-1 bar instead (see
+    # that matcher's own comment for why: this hop's `scale`/`B` are carried
+    # on a plain ConvPassThrough, whose own slicing always slices axis 0,
+    # which is only ever the right axis when rank == 1). Declined outright
+    # rather than mis-sliced.
+    Cin, C1, C2 = 3, 8, 4
+    rng = np.random.default_rng(243)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    in_scale_2d = rng.standard_normal((1, C1)).astype(np.float32)
+    in_bias = rng.standard_normal((C1,)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{C2},6,6] Y)
+        {{
+          h = Conv<kernel_shape=[3,3]>(X, W1)
+          n = InstanceNormalization<epsilon=1e-05>(h, INScale, INBias)
+          Y = Conv<kernel_shape=[3,3]>(n, W2)
+        }}
+        """,
+        initializer=[
+            _f32(w1, "W1"),
+            _f32(w2, "W2"),
+            _f32(in_scale_2d, "INScale"),
+            _f32(in_bias, "INBias"),
+        ],
+    )
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+    np.testing.assert_array_equal(inits["INScale"], in_scale_2d)
+    np.testing.assert_array_equal(inits["INBias"], in_bias)
+
+
+def test_cpp_structured_pruning_conv_residual_instance_norm_pass_through_matches_oracle():
+    # An InstanceNormalization hop crossed by the *backward* walk
+    # (WalkConvProducerBackward/MatchInstanceNormPassThroughSelf), not just
+    # the forward one every test above already covers -- exercises the
+    # residual-chain insertion point, mirroring
+    # test_cpp_structured_pruning_conv_residual_prelu_pass_through_hop_matches_oracle's
+    # own shape.
+    Cin, C, Cout = 3, 16, 8
+    rng = np.random.default_rng(244)
+    w_f = rng.standard_normal((C, Cin, 3, 3)).astype(np.float32)
+    in_scale = rng.standard_normal((C,)).astype(np.float32)
+    in_bias = rng.standard_normal((C,)).astype(np.float32)
+    w_s = rng.standard_normal((C, Cin, 3, 3)).astype(np.float32)
+    w_out = rng.standard_normal((Cout, C, 3, 3)).astype(np.float32)
+
+    def _mk(w_f, in_scale, in_bias, w_s, w_out):
+        return _model(
+            f"""
+            g (float[N,{Cin},10,10] X) => (float[N,{Cout},6,6] Y)
+            {{
+              f0 = Conv<kernel_shape=[3,3]>(X, WF)
+              f = InstanceNormalization<epsilon=1e-05>(f0, INScale, INBias)
+              s = Conv<kernel_shape=[3,3]>(X, WS)
+              addr = Add(f, s)
+              r = Relu(addr)
+              Y = Conv<kernel_shape=[3,3]>(r, WOUT)
+            }}
+            """,
+            initializer=[
+                _f32(w_f, "WF"),
+                _f32(in_scale, "INScale"),
+                _f32(in_bias, "INBias"),
+                _f32(w_s, "WS"),
+                _f32(w_out, "WOUT"),
+            ],
+        )
+
+    model = _mk(w_f, in_scale, in_bias, w_s, w_out)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    assert inits["WF"].shape[0] == C // 2
+    assert inits["INScale"].shape == inits["INBias"].shape == (C // 2,)
+    assert inits["WS"].shape[0] == C // 2
+
+    importance = np.sqrt(
+        np.square(np.linalg.norm(w_f.reshape(C, -1).astype(np.float64), axis=1))
+        + np.square(np.linalg.norm(w_s.reshape(C, -1).astype(np.float64), axis=1))
+    )
+    keep = np.sort(np.argsort(-importance)[: C // 2])
+    oracle = _mk(w_f[keep], in_scale[keep], in_bias[keep], w_s[keep], w_out[:, keep])
+
+    rng_x = np.random.default_rng(245)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+# --- CausalConvWithState pass-through (plain ai.onnx, opset 27) --------------
+#
+# `Conv -> CausalConvWithState(depthwise) -> Conv`: mirrors test_pruning.py's
+# own `_causal_conv_model` and its causal-conv-with-state-pass-through test
+# coverage. This op has a real CPU kernel in this environment's onnxruntime,
+# so every test below runs the real fused op end to end (via `_run27`, since
+# opset 27 is still "under development" per onnxruntime's own load-time
+# guard) rather than a decomposed-proxy fallback. Unlike a depthwise Conv,
+# this op also carries an optional `past_state` (input 3) -- sliceable only
+# when it's itself a constant of the documented rank-3 `(*, n_channels, *)`
+# shape (axis 1 == n_channels), see MatchCausalConvWithStatePassThrough's own
+# comment in structured_pruning_entry.cpp -- and a second output
+# (`present_state`) that is a runtime output, never a tensor this pass
+# slices.
+
+
+def _causal_conv_model(C=8, K=6, L=5, kernel=3, seed=0, past_state=None, bias=True):
+    # Conv(K -> C, kernel=3) -> CausalConvWithState(C, depthwise, kernel) ->
+    # Conv(C -> Out, kernel=1). `past_state`, if given, is a constant
+    # ``(1, C, kernel - 1)`` array wired as the op's own 4th input; ``None``
+    # leaves it unconnected (needs no slicing at all).
+    rng = np.random.default_rng(seed)
+    w0 = rng.standard_normal((C, K, 3)).astype(np.float32) * 0.5
+    b0 = rng.standard_normal((C,)).astype(np.float32) * 0.1
+    w1 = rng.standard_normal((C, 1, kernel)).astype(np.float32) * 0.5
+    b1 = rng.standard_normal((C,)).astype(np.float32) * 0.1
+    out = 5
+    w2 = rng.standard_normal((out, C, 1)).astype(np.float32) * 0.5
+    b2 = rng.standard_normal((out,)).astype(np.float32) * 0.1
+
+    initializer = [
+        _f32(w0, "W0"),
+        _f32(b0, "B0"),
+        _f32(w1, "W1"),
+        _f32(w2, "W2"),
+        _f32(b2, "B2"),
+    ]
+    cc_inputs = "h0, W1"
+    if bias:
+        initializer.append(_f32(b1, "B1"))
+        cc_inputs += ", B1"
+    else:
+        cc_inputs += ", "
+    if past_state is not None:
+        initializer.append(_f32(np.asarray(past_state), "PastState"))
+        cc_inputs += ", PastState"
+
+    body = f"""
+        g (float[1,{K},{L}] X) => (float[1,{out},{L}] Y)
+        {{
+          h0 = Conv<kernel_shape=[3], pads=[1,1]>(X, W0, B0)
+          h1, ps = CausalConvWithState<activation="none">({cc_inputs})
+          Y = Conv<kernel_shape=[1]>(h1, W2, B2)
+        }}
+        """
+    model = _model(body, opset=27)
+    model.graph.initializer.extend(initializer)
+    return model, dict(
+        C=C,
+        K=K,
+        L=L,
+        kernel=kernel,
+        out=out,
+        w0=w0,
+        b0=b0,
+        w1=w1,
+        b1=b1 if bias else None,
+        w2=w2,
+        b2=b2,
+    )
+
+
+def _causal_conv_node(model):
+    return next(n for n in model.graph.node if n.op_type == "CausalConvWithState")
+
+
+def test_cpp_structured_pruning_causal_conv_with_state_pass_through_matches_oracle():
+    model, cfg = _causal_conv_model(C=8, K=6, L=5, kernel=3, seed=250)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    # No `group` attribute is ever added to a non-Conv hop node.
+    node = _causal_conv_node(pruned)
+    assert [a.name for a in node.attribute] == ["activation"]
+
+    dims = {t.name: t.dims[0] for t in pruned.graph.initializer}
+    assert dims["W0"] == 4  # C halved
+    assert dims["W1"] == 4  # depthwise weight follows the same keep set
+    w2_in_channels = next(t for t in pruned.graph.initializer if t.name == "W2").dims[1]
+    assert w2_in_channels == 4  # consumer's in_channels axis
+
+    imp = np.linalg.norm(cfg["w0"].reshape(cfg["C"], -1), axis=1)
+    keep = np.sort(np.argsort(-imp)[: cfg["C"] // 2])
+
+    rng = np.random.default_rng(251)
+    x = rng.standard_normal((1, cfg["K"], cfg["L"])).astype(np.float32)
+    y_pruned = _run27(pruned, {"X": x})[0]
+
+    oracle, _ = _causal_conv_model(
+        C=len(keep), K=cfg["K"], L=cfg["L"], kernel=cfg["kernel"]
+    )
+    # Every tensor built here overrides the oracle model's own freshly
+    # (differently) randomized placeholder of the same name -- only the
+    # *shape* of that placeholder construction is actually used.
+    oracle_inits = {
+        "W0": cfg["w0"][keep],
+        "B0": cfg["b0"][keep],
+        "W1": cfg["w1"][keep],
+        "B1": cfg["b1"][keep],
+        "W2": cfg["w2"][:, keep, :],
+        "B2": cfg["b2"],  # Consumer's own out_channels axis is untouched.
+    }
+    for init in oracle.graph.initializer:
+        init.CopyFrom(onnx.numpy_helper.from_array(oracle_inits[init.name], init.name))
+    y_oracle = _run27(oracle, {"X": x})[0]
+    np.testing.assert_array_equal(y_pruned, y_oracle)
+
+
+def test_cpp_structured_pruning_causal_conv_with_state_constant_past_state_sliced():
+    C, kernel = 8, 3
+    rng = np.random.default_rng(252)
+    past = rng.standard_normal((1, C, kernel - 1)).astype(np.float32)
+    model, cfg = _causal_conv_model(
+        C=C, K=6, L=5, kernel=kernel, seed=252, past_state=past
+    )
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    imp = np.linalg.norm(cfg["w0"].reshape(C, -1), axis=1)
+    keep = np.sort(np.argsort(-imp)[: C // 2])
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["PastState"], past[:, keep, :])
+
+
+def test_cpp_structured_pruning_causal_conv_with_state_wrong_shape_past_state_declines():
+    # A constant `past_state` of any shape *other* than the documented
+    # rank-3 `(*, n_channels, *)` -- here, axis 1 deliberately doesn't equal
+    # `n_channels` -- declines the whole hop outright, never guessed at,
+    # mirroring MatchCausalConvWithStatePassThrough's own bar.
+    C, kernel = 8, 3
+    rng = np.random.default_rng(253)
+    wrong_past = rng.standard_normal((1, C + 1, kernel - 1)).astype(np.float32)
+    model, cfg = _causal_conv_model(
+        C=C, K=6, L=5, kernel=kernel, seed=253, past_state=wrong_past
+    )
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W0"], cfg["w0"])
+    np.testing.assert_array_equal(inits["W1"], cfg["w1"])
+    np.testing.assert_array_equal(inits["W2"], cfg["w2"])
+    np.testing.assert_array_equal(inits["PastState"], wrong_past)
 
 
 # --- Concat-merged (skip-connection) chains ----------------------------------


### PR DESCRIPTION
## Summary

Third round continuing the Python → C++ parity effort for `onnxsim/structured_pruning_entry.cpp` (see #1027, #1031). Closes four more gaps from `onnxsim/pruning.py`:

- **Decomposed (opset<=16) LayerNorm pass-through** — recognizes the literal 9-node `ReduceMean/Sub/Pow/ReduceMean/Add/Sqrt/Div/Mul/Add` decomposition `torch.onnx.export` emits pre-opset-17 as one hop on MatMul/Gemm chains, sliced like a fused LayerNorm's own scale/bias would be.
- **Decomposed SiLU/erf-GELU self-gated activations** — recognizes the `Sigmoid+Mul` (SiLU) and `Div,Erf,Add,Mul,Mul` (erf-GELU) "diamond" decompositions pre-fusion-opset exports emit, wired into all four chain walkers (Conv and MatMul/Gemm, forward and backward).
- **InstanceNorm pass-through** — constant, strictly-rank-1 `scale`/`B` sliced like a depthwise Conv weight, both forward and backward walks.
- **CausalConvWithState pass-through** (opset 27+) — depthwise-shaped weight/bias/optional-constant-`past_state` sliced like a depthwise Conv, with `present_state` tracked as stale value_info.

The first two both relax the walkers' shared "exactly one consumer" pre-walk gate (each diamond/decomposition reads its root tensor twice by construction) — ported together deliberately so that relaxation is coherent rather than two independent edits fighting over the same gating logic. The CausalConvWithState port also widens `MatchConvProducer`/`MatchConvConsumer`/depthwise-hop matching from hardcoded rank-4 (2-D) to any spatial rank >= 1, matching `pruning.py`'s own already-documented generality (this op is inherently 1-D) — purely additive, all existing rank-4 behavior unchanged.

## Testing

- `pip install --no-build-isolation -ve .`
- `python3 -m pytest -v tests/test_structured_pruning_cpp.py tests/test_attention_head_pruning_cpp.py tests/test_pruning_cpp.py` — 153 passed, 0 failed, including all pre-existing coverage (no regressions)
- `clang-format --dry-run --Werror` / `ruff format --check` / `ruff check` clean

## Scope / follow-up

Still missing from the C++ port: QDQ-quantized and MatMulNBits (int4)-quantized structured pruning support — a substantially larger, separate subsystem in the Python reference, left for dedicated future work rather than folded into this hop-porting series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4t6ntCm72RfFf64W9GYB1

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4t6ntCm72RfFf64W9GYB1)_