### PR TITLE
Recognize PyTorch's decomposed-GroupNorm export shape as a Conv-chain pass-through hop

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -4163,30 +4163,34 @@ def _apply_conv_pass_through_hop(
     A depthwise ``Conv`` hop's own `group` attribute (`== in_channels ==
     out_channels`) drops to the new channel count right alongside its
     weight/bias, via :func:`_set_conv_group_attr` -- none of
-    `CausalConvWithState`, `InstanceNormalization`, or `PRelu` has any such
-    attribute at all (confirmed via live schema introspection,
+    `CausalConvWithState`, `InstanceNormalization`, `PRelu`, or the decomposed-
+    GroupNorm hop's own trailing `Mul`/`Add` has any such attribute at all
+    (confirmed via live schema introspection,
     ``onnx.defs.get_schema("CausalConvWithState", domain="")``/
     ``onnx.defs.get_schema("InstanceNormalization")``/
-    ``onnx.defs.get_schema("PRelu")``: each of `CausalConvWithState`'s and
+    ``onnx.defs.get_schema("PRelu")``/``onnx.defs.get_schema("Mul")``/
+    ``onnx.defs.get_schema("Add")``: each of `CausalConvWithState`'s and
     `InstanceNormalization`'s own channel count is implied purely by its
-    `weight`/`scale`'s own axis-0 size, and `PRelu` has no
-    channel-count-describing attribute of any kind -- no `group`/
-    channel-count attribute exists on any of them to rewrite), so nothing is
-    rewritten there for any of them -- dispatched purely on
-    `hop.node.op_type`, since only these four op types ever reach this
-    function (see :func:`_match_depthwise_conv_pass_through`/
+    `weight`/`scale`'s own axis-0 size, and neither `PRelu` nor a plain
+    `Mul`/`Add` has any channel-count-describing attribute at all -- no
+    `group`/channel-count attribute exists on any of them to rewrite), so
+    nothing is rewritten there for any of them -- dispatched purely on
+    `hop.node.op_type`, since only these op types ever reach this function
+    (see :func:`_match_depthwise_conv_pass_through`/
     :func:`_match_causal_conv_with_state_pass_through`/
     :func:`_match_instance_norm_pass_through`/
     :func:`_match_instance_norm_pass_through_self`/
-    :func:`_match_prelu_pass_through`/:func:`_match_prelu_pass_through_self`,
-    the only matchers that ever construct a :class:`_ConvPassThrough`).
-    `hop.weight` -- an ``InstanceNormalization`` hop's own `scale`, strictly
-    rank-1 by :func:`_match_instance_norm_pass_through`'s own bar, or a
-    ``PRelu`` hop's own `slope`, ``[C, 1, ..., 1]`` -- is sliced by the same
-    axis-0 :func:`_slice_producer_weight` call below as a depthwise Conv's
-    weight; for a rank-1 tensor that is exactly the same slice
+    :func:`_match_prelu_pass_through`/:func:`_match_prelu_pass_through_self`/
+    :func:`_match_decomposed_group_norm_pass_through`, the only matchers that
+    ever construct a :class:`_ConvPassThrough`). `hop.weight` -- an
+    ``InstanceNormalization`` hop's own `scale`, strictly rank-1 by
+    :func:`_match_instance_norm_pass_through`'s own bar, a ``PRelu`` hop's own
+    `slope`, or the decomposed-GroupNorm hop's own `gamma`/`beta` (each of the
+    latter two ``[C, 1, ..., 1]``) -- is sliced by the same axis-0
+    :func:`_slice_producer_weight` call below as a depthwise Conv's weight;
+    for a rank-1 tensor that is exactly the same slice
     :func:`_slice_last_axis`'s own axis ``-1`` would produce, so no dedicated
-    branch is needed for either here.
+    branch is needed for any of them here.
     """
     _slice_producer_weight(initializer_map[hop.weight], False, keep, is_conv=True)
     if hop.bias is not None:

--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -712,6 +712,118 @@ docstring for why its own `scale`/`B` are held to a *narrower* shape bar
 (strictly rank-1) than GroupNorm's/LayerNorm's shared
 :func:`_flat_channel_const` check.
 
+PyTorch's own default/legacy (TorchScript-based) ONNX exporter never emits
+the native ``GroupNormalization`` op for ``nn.GroupNorm`` at all -- confirmed
+live via ``torch.onnx.export(nn.GroupNorm(G, C), ..., opset_version=N,
+dynamo=False)`` for `N` in ``{13, 17, 18, 20}``, all identical -- it instead
+lowers to GroupNorm's own canonical decomposition as five plain ops:
+``reshaped = Reshape(x, [0, G, -1]); inorm = InstanceNormalization(reshaped,
+ones[G], zeros[G]); back = Reshape(inorm, Shape(x)); scaled = Mul(back,
+gamma[C,1,1]); y = Add(scaled, beta[C,1,1])`` -- `x` read *twice* (by the
+first ``Reshape`` and by ``Shape``), the identical "root tensor read twice by
+design" shape the decomposed LayerNorm sequence above already needed a hop
+for, just on a Conv chain instead of a MatMul/Gemm one. (Only PyTorch's newer
+``dynamo=True`` export path emits the native op directly.) Neither this
+module's own ``onnx``/``onnx-optimizer`` fork's fusion passes fuse this
+decomposition into ``GroupNormalization`` either (confirmed:
+``grep -irl groupnorm third_party/onnx-optimizer`` has no hits), so a chain
+hitting it dead-ends at the first ``Reshape`` -- not a hop any Conv-chain
+walker recognized before this hop existed -- and came out completely
+unpruned end to end (confirmed empirically the same way as every other
+decomposition gap in this module: a ``Conv -> {this sequence} -> Conv`` model
+was left entirely untouched by :func:`apply_structured_pruning`, while the
+identical chain built with the *already-supported* bare
+``InstanceNormalization`` shape instead pruned correctly, isolating the gap
+to the decomposition specifically).
+
+:func:`_match_decomposed_group_norm_pass_through` recognizes this fixed
+5-node sequence exactly, folding all of it into one hop -- the Conv-chain
+analogue of :func:`_match_decomposed_layer_norm_pass_through` above, held to
+the identical discipline (recognize this exact topology, decline everything
+else, never partially matched). Three of its five nodes need no operand of
+their own sliced at all, for three separate reasons worth stating explicitly
+since none is quite the "nothing to slice" case a plain unary activation hop
+already is:
+
+- The first ``Reshape``'s own shape constant, ``[0|batch_dim, G, -1]``, never
+  needs rewriting the way a channel-*resizing* ``Resize``'s own `sizes`
+  would (see that hop's own declined case above) -- `0`/`batch_dim` names an
+  axis this pass never touches, `G` (`num_groups`) is exactly the block
+  count :func:`_chain_group`'s own uniform-per-block machinery already needs
+  (see below), and `-1` means "infer from what's actually there," which
+  automatically becomes the new, smaller per-group element count once the
+  *producer's* own output has fewer channels -- nothing to compute or
+  rewrite ahead of time.
+- The ``InstanceNormalization``'s own `scale`/`B` (length `G`, confirmed
+  live to be the trivial identity `ones`/`zeros` PyTorch's own exporter
+  always emits here, though this hop's own correctness argument below holds
+  for *any* constant per-group values, not just that trivial case) are never
+  touched at all -- not sliced, not even inspected beyond confirming they're
+  constant and length-`G` -- since `G` itself never changes.
+- The second ``Reshape``'s own shape operand, ``Shape(x)`` (`x` the same
+  tensor the first ``Reshape`` read), is computed dynamically from whatever
+  the (already-pruned, by the time this graph actually runs) upstream
+  producer emits -- unlike a stale constant needing rewriting, a ``Shape``
+  node's own *output* automatically reflects the new channel count at
+  runtime, needing no rewrite at all; this is strictly *easier* than
+  ``Resize``'s own declined `sizes` case above, which is a constant that
+  would need editing, not a dynamically-recomputed value that already tracks
+  the pruned graph on its own.
+
+Only the trailing ``Mul``'s `gamma` and ``Add``'s `beta` -- the *real*
+per-channel affine PyTorch applies after un-reshaping back to `NCHW`,
+entirely separate from the ``InstanceNormalization``'s own trivial per-group
+one -- have anything sliced, held to the same ``[C, 1, ..., 1]``
+per-channel-constant bar :func:`_match_prelu_pass_through`'s own per-channel
+branch already uses (reusing :class:`_ConvPassThrough`/
+:func:`_apply_conv_pass_through_hop` directly for the axis-0 slice, exactly
+as a ``PRelu`` hop's own per-channel `slope` already does, rather than
+:class:`_GroupNormPassThrough`'s own flat-``[C]``/`_slice_last_axis`
+treatment, which would slice the wrong axis on a ``[C, 1, 1]``-shaped
+tensor).
+
+The correctness question this hop needs answered, beyond what the native
+``GroupNormalization`` hop's own comment above already establishes
+(identical per-group mean/variance reasoning -- `keep` must select the exact
+same count from every one of `G` equal-sized blocks, reusing that same
+:func:`_chain_group` machinery via one more `num_groups`-carrying field on
+:class:`_Chain`), is whether composing an *arbitrary* (not necessarily
+trivial) per-group ``InstanceNormalization`` affine with the trailing
+per-channel `Mul`/`Add` still commutes safely with that same
+uniform-per-block channel subset. Confirmed empirically, not assumed: a real
+``onnxruntime.InferenceSession`` run, with the ``InstanceNormalization``'s
+own `scale`/`B` set to deliberately non-trivial values (not `1.0`/`0.0`) and
+a non-contiguous, uniform-per-group-count `keep` set (e.g. 2 of one group's 4
+channels, a *different* 2 of another group's 4), confirms that feeding the
+producer's own already-sliced output through the identical 5-node sequence
+-- `G` unchanged, the ``InstanceNormalization``'s own `scale`/`B` left
+untouched, `gamma`/`beta` sliced to `keep` -- matches a from-scratch NumPy
+reimplementation of the pruned sequence's own math to float32 noise (~4.7e-7
+max abs diff), while naively slicing the *unpruned* model's own output at the
+same indices diverges outright (~0.63 max abs diff) -- the same "match an
+independently-, already-pruned reference, never a run-then-slice one" bar
+every other hop in this module already holds itself to. This is what makes
+``InstanceNormalization``'s own per-group `scale`/`B` values genuinely
+irrelevant to this hop's own safety -- a per-group scalar affine applied
+uniformly to every element of a group commutes with *which* channels happen
+to survive inside that group, the same reason ``GroupNormalization``'s own
+per-group mean/variance reduction does.
+
+Scoped identically to the native ``GroupNormalization`` hop in every other
+respect too: recognized only by :func:`_walk_to_conv_consumer` (never
+:func:`_walk_conv_producer_backward`, which recognizes neither GroupNorm
+shape at all), only for :func:`_find_conv_chains`'s own plain
+single-producer/single-consumer topology (not a residual/merge fan-out
+branch or a Concat-branch-merge consumer), gated to at most one
+GroupNorm-family hop (native or decomposed) per chain, and declined outright
+-- the whole chain, never partially matched -- on any deviation: an extra
+consumer on any intermediate tensor, a non-constant/wrongly-shaped
+`gamma`/`beta`, a tied `gamma`/`beta`, a `G` that doesn't evenly divide
+`n_channels`, a reshape shape that isn't exactly the fixed `[batch, G, -1]`
+form, or a `num_groups` that disagrees with a same-chain grouped Conv
+producer's/consumer's own `group` (the identical reconciliation check
+:func:`_find_conv_chains` already applies to the native hop).
+
 A Conv chain also crosses five more op kinds transparently, each needing no
 weight of its own sliced (folded into `chain_ops` exactly like a unary
 activation, not a dedicated pass-through tuple) -- these close the two most
@@ -3549,6 +3661,20 @@ _GROUP_NORM_PASS_THROUGH_OP = "GroupNormalization"
 # :func:`_match_instance_norm_pass_through`.
 _INSTANCE_NORM_PASS_THROUGH_OP = "InstanceNormalization"
 
+# Decomposed GroupNorm -- the fixed 5-node ``Reshape -> InstanceNormalization
+# -> Reshape -> Mul -> Add`` sequence PyTorch's own default/legacy
+# (TorchScript-based) ONNX exporter emits for ``nn.GroupNorm`` in place of
+# the native ``GroupNormalization`` op above (confirmed live via
+# ``torch.onnx.export(nn.GroupNorm(G, C), ..., dynamo=False)`` at opsets 13,
+# 17, 18, and 20 -- all byte-identical). See this module's own docstring
+# (just above the "A Conv chain also crosses five more op kinds transparently"
+# paragraph) for the full empirical gap confirmation, the per-node "nothing
+# to slice" reasoning, and the empirical correctness argument for composing
+# an arbitrary per-group ``InstanceNormalization`` affine with the trailing
+# per-channel ``Mul``/``Add`` under the same `_chain_group` uniform-per-block
+# constraint the native hop above already enforces. See
+# :func:`_match_decomposed_group_norm_pass_through`.
+
 
 def _flat_channel_const(
     name: str, initializer_map: Dict[str, onnx.TensorProto]
@@ -3816,7 +3942,16 @@ class _ConvPassThrough:
     ``PRelu`` has any such attribute at all (each one's own channel count is
     implied purely by its `weight`/`scale`/`slope`'s own axis-0 size, or --
     for `PRelu` -- has no channel-count attribute at all, ever), so nothing
-    is rewritten there for any of them. See
+    is rewritten there for any of them. A fifth shape reuses this same class
+    for a *synthetic* per-hop weight-only entry rather than a node's own
+    literal weight/scale/slope: a decomposed GroupNorm hop's own trailing
+    ``Mul``/``Add`` each contribute their own entry (`node` the `Mul`/`Add`
+    itself, `weight` its own `gamma`/`beta`, `bias` left ``None``) -- *two*
+    entries, not one with `bias` set to the other, since both `gamma` and
+    `beta` share the identical ``[C, 1, ..., 1]`` axis-0-sliced shape a
+    `PRelu` hop's own `weight`-only entry already gets, and `bias` would
+    instead be sliced via `_slice_last_axis` -- wrong here (see
+    :func:`_match_decomposed_group_norm_pass_through`'s own docstring). See
     :func:`_walk_to_conv_consumer`.
     """
 
@@ -3891,6 +4026,24 @@ class _Chain:
     # `group` does -- see :class:`_GroupNormPassThrough` and
     # `_GROUP_NORM_PASS_THROUGH_OP`'s own comment for why that scope is safe.
     group_norm: Optional[_GroupNormPassThrough] = None
+    # `num_groups` from a mid-chain *decomposed* GroupNorm hop -- the fixed
+    # ``Reshape -> InstanceNormalization -> Reshape -> Mul -> Add`` sequence
+    # PyTorch's own default/legacy exporter emits for `nn.GroupNorm` (see
+    # :func:`_match_decomposed_group_norm_pass_through`'s own docstring and
+    # this module's own docstring) -- the chain walk crossed transparently
+    # (:func:`_find_conv_chains` only, for now, mirroring `group_norm`'s own
+    # scope restriction just above; always ``None`` for every other chain
+    # kind, and for a MatMul/Gemm chain). Unlike `group_norm`, this hop's own
+    # `gamma`/`beta` already ride on `conv_pass_through` above (their own
+    # ``[C, 1, ..., 1]`` shape needs the same axis-0 slice a depthwise Conv's
+    # own weight already gets, not `group_norm`'s flat-``[C]``/
+    # `_slice_last_axis` treatment -- see that matcher's own docstring), so
+    # this field carries *only* the block-count constraint itself, consulted
+    # by :func:`_chain_group` the identical way `group_norm.num_groups`
+    # already is. At most one of `group_norm`/`decomposed_group_norm_num_groups`
+    # is ever set on the same chain -- see :func:`_walk_to_conv_consumer`'s
+    # own mutual-exclusion gate.
+    decomposed_group_norm_num_groups: Optional[int] = None
     # The consumer's own ``group`` attribute (always 1 for a MatMul/Gemm
     # consumer, or an ordinary ``group=1`` Conv). > 1 for a general grouped
     # Conv consumer (see :func:`_match_conv_consumer`) -- unlike the
@@ -5963,6 +6116,296 @@ def _match_instance_norm_pass_through_self(
     return _match_instance_norm_pass_through(node, initializer_map, s_init.dims[0])
 
 
+def _decomposed_group_norm_reshape_num_groups(
+    shape_name: str, initializer_map: Dict[str, onnx.TensorProto], n_channels: int
+) -> Optional[int]:
+    """If `shape_name` names a constant ``int64`` initializer holding exactly
+    the group-split shape PyTorch's own default/legacy exporter emits for a
+    decomposed GroupNorm's own first ``Reshape`` -- ``[0|batch_dim,
+    num_groups, -1]`` (confirmed live: literally ``[0, G, -1]``, see this
+    module's own docstring) -- whose own `num_groups` (element 1) evenly
+    divides `n_channels`, returns `num_groups`. Declines (``None``) on
+    anything else: a missing/non-constant/non-``int64``/wrong-length shape,
+    element 2 not exactly ``-1`` (this hop's own safety argument depends on
+    the *entire* remainder folding into one axis, not some other split -- a
+    shape like ``[G, C // G, -1]`` or ``[-1, G, C // G]`` is a genuinely
+    different reshape this matcher does not attempt to reason about), a
+    non-positive `num_groups`, or `n_channels % num_groups != 0`.
+
+    Element 0 (the batch axis) is deliberately never inspected beyond being
+    non-negative -- whether it's the ``0`` "copy dimension from input"
+    sentinel PyTorch's own exporter emits or a literal hardcoded batch size,
+    this hop never touches axis 0 at all, so neither shape is any less safe
+    than the other; a negative value there (other than the position-2 ``-1``,
+    already checked separately) is declined only because ONNX's own Reshape
+    schema allows at most one ``-1`` entry, not because axis 0's own value
+    matters to this hop's own correctness.
+    """
+    init = initializer_map.get(shape_name)
+    if init is None or init.data_type != onnx.TensorProto.INT64:
+        return None
+    values = onnx.numpy_helper.to_array(init).reshape(-1).tolist()
+    if len(values) != 3:
+        return None
+    batch, num_groups, remainder = (int(v) for v in values)
+    if batch < 0 or remainder != -1:
+        return None
+    if num_groups < 1 or n_channels % num_groups != 0:
+        return None
+    return num_groups
+
+
+def _decomposed_group_norm_channel_const(
+    name: str, initializer_map: Dict[str, onnx.TensorProto], n_channels: int
+) -> bool:
+    """True iff `name` names a constant float initializer shaped exactly
+    ``[n_channels, 1, ..., 1]`` -- the strict per-channel Conv-chain constant
+    bar :func:`_match_prelu_pass_through`'s own per-channel branch already
+    uses (``dims[0] == n_channels``, every trailing dimension size 1),
+    *without* that function's own scalar/single-shared-parameter fallback:
+    unlike a PRelu `slope`, this hop's `gamma`/`beta` are GroupNorm's own
+    real per-channel affine (PyTorch's ``nn.GroupNorm`` own `weight`/`bias`
+    parameters) -- a genuinely single-shared-parameter shape here is not a
+    real case PyTorch's own exporter ever emits for `nn.GroupNorm` (unlike
+    `nn.PReLU(1)`'s own actually-scalar shape), so admitting it would be
+    guessing at a shape never confirmed live, not reusing an established
+    one -- declined like every other deviation this hop's own matcher holds
+    itself to, never guessed at.
+    """
+    init = initializer_map.get(name)
+    if init is None or not _is_supported_float_dtype(init.data_type):
+        return False
+    dims = list(init.dims)
+    return len(dims) >= 2 and dims[0] == n_channels and all(d == 1 for d in dims[1:])
+
+
+def _match_decomposed_group_norm_pass_through(
+    x_name: str,
+    consumers_of: Dict[str, List[onnx.NodeProto]],
+    initializer_map: Dict[str, onnx.TensorProto],
+    graph_outputs: Set[str],
+    n_channels: int,
+) -> Optional[
+    Tuple[
+        str,
+        Tuple[Tuple[onnx.NodeProto, None], ...],
+        Tuple[_ConvPassThrough, ...],
+        int,
+    ]
+]:
+    """If `x_name` is the root of exactly the fixed 5-node decomposed-
+    GroupNorm sequence documented in this module's own docstring and just
+    above `_INSTANCE_NORM_PASS_THROUGH_OP` -- confirmed live via
+    ``torch.onnx.export(nn.GroupNorm(G, C), ..., dynamo=False)`` -- returns
+    ``(out_name, chain_ops, pass_through, num_groups)``: `out_name` the
+    sequence's own true final output (the tensor
+    :func:`_walk_to_conv_consumer` should continue walking from), `chain_ops`
+    the four nodes with no operand of their own to slice (both `Reshape`
+    nodes, the `InstanceNormalization`, and the `Shape` node -- see this
+    module's own docstring for why none of the four needs one) as
+    ``(node, None)`` pairs, `pass_through` two :class:`_ConvPassThrough`
+    entries (the trailing `Mul`'s `gamma` and `Add`'s `beta`, each its own
+    entry -- *not* one entry with `gamma` as `weight` and `beta` as `bias`,
+    since :func:`_apply_conv_pass_through_hop` slices a hop's own `bias`
+    field via `_slice_last_axis`, which would slice the wrong axis on a
+    ``[C, 1, ..., 1]``-shaped `beta`; two `weight`-only entries each get the
+    correct axis-0 slice instead), and `num_groups` for the caller to carry
+    on :class:`_Chain.decomposed_group_norm_num_groups`.
+
+    Like :func:`_match_decomposed_layer_norm_pass_through`, `x_name` itself
+    (not just some node's `.input[0]`) is the very thing matched here -- a
+    *multi*-node hop, needed because this shape's own root tensor is read
+    *twice* (by the first `Reshape` and by `Shape`), a shape the ordinary
+    ``len(candidates) == 1`` dispatch in :func:`_walk_to_conv_consumer` can
+    never reach on its own. Every other tensor inside the sequence is held to
+    the exact same "no stray fan-out" bar every other hop in this module
+    already applies -- exactly one consumer, and not itself a graph output
+    (`graph_outputs`). Declines (``None``, never partially matched) on:
+
+    - `x_name` read by anything other than exactly one ``Reshape`` and one
+      ``Shape`` (in particular, a *third* reader of any kind).
+    - The ``Reshape``'s own inputs not exactly ``(x_name, shape_const)`` (in
+      that fixed, schema-mandated order), or `shape_const` not resolving to
+      the fixed `[batch, num_groups, -1]` form with `num_groups` evenly
+      dividing `n_channels` (:func:`_decomposed_group_norm_reshape_num_groups`).
+    - The reshaped tensor read by anything other than exactly one
+      ``InstanceNormalization``.
+    - That node's own inputs not exactly ``(reshaped, scale, B)`` (that fixed
+      order) with `scale`/`B` each a constant float initializer of exactly
+      `[num_groups]` -- their own *values* are never inspected (see this
+      module's own docstring for why).
+    - The ``InstanceNormalization``'s own output read by anything other than
+      exactly one node.
+    - The ``Shape`` node's own input not exactly `x_name`, or its own output
+      read by anything other than exactly one node.
+    - The `InstanceNormalization` output and the `Shape` output not feeding
+      *the exact same* second ``Reshape`` node -- ruling out a graph that
+      merely happens to have *a* second `Reshape`, a different one from the
+      one this sequence actually needs.
+    - That second ``Reshape``'s own inputs not exactly ``(inorm_out,
+      shape_out)`` in that fixed order, or its own output read by anything
+      other than exactly one node.
+    - The ``Mul``'s own inputs not exactly ``(back, gamma)`` (either operand
+      order) with `gamma` held to :func:`_decomposed_group_norm_channel_const`'s
+      own ``[n_channels, 1, ..., 1]`` bar, distinct from `back`.
+    - The ``Mul``'s own output read by anything other than exactly one node.
+    - The final ``Add``'s own inputs not exactly ``(scaled, beta)`` (either
+      operand order) with `beta` held to the identical bar as `gamma` above
+      -- distinct from `scaled` *and* from `gamma` itself (a tied
+      `gamma`/`beta` would be double-sliced by :func:`_apply_chains`'s own
+      per-hop loop, corrupting it, exactly the concern
+      `_match_group_norm_pass_through`'s own tied-`scale`/`bias` check
+      already guards against).
+
+    The sequence's own true final output (the last ``Add``'s own output) is
+    *not* itself checked against `graph_outputs`/single-consumer here --
+    exactly like an ordinary single-node hop's own `out2`, that check is the
+    caller's (:func:`_walk_to_conv_consumer`'s own per-iteration `cur`
+    check), applied uniformly whether `cur` arrived via an ordinary hop or
+    this one.
+    """
+    x_consumers = consumers_of.get(x_name, [])
+    if len(x_consumers) != 2:
+        return None
+    reshape1: Optional[onnx.NodeProto] = None
+    shape_node: Optional[onnx.NodeProto] = None
+    for cand in x_consumers:
+        if cand.op_type == "Reshape" and reshape1 is None:
+            reshape1 = cand
+        elif cand.op_type == "Shape" and shape_node is None:
+            shape_node = cand
+    if reshape1 is None or shape_node is None or reshape1 is shape_node:
+        return None
+
+    if (
+        reshape1.domain != ""
+        or len(reshape1.input) != 2
+        or reshape1.input[0] != x_name
+        or not reshape1.input[1]
+        or len(reshape1.output) != 1
+        or not reshape1.output[0]
+    ):
+        return None
+    num_groups = _decomposed_group_norm_reshape_num_groups(
+        reshape1.input[1], initializer_map, n_channels
+    )
+    if num_groups is None:
+        return None
+    reshaped_name = reshape1.output[0]
+    if reshaped_name in graph_outputs or len(consumers_of.get(reshaped_name, [])) != 1:
+        return None
+
+    inorm = consumers_of[reshaped_name][0]
+    if (
+        inorm.op_type != _INSTANCE_NORM_PASS_THROUGH_OP
+        or inorm.domain != ""
+        or len(inorm.input) != 3
+        or inorm.input[0] != reshaped_name
+        or not inorm.input[1]
+        or not inorm.input[2]
+        or len(inorm.output) != 1
+        or not inorm.output[0]
+    ):
+        return None
+    inorm_scale_init = initializer_map.get(inorm.input[1])
+    inorm_bias_init = initializer_map.get(inorm.input[2])
+    if (
+        inorm_scale_init is None
+        or inorm_bias_init is None
+        or not _is_supported_float_dtype(inorm_scale_init.data_type)
+        or not _is_supported_float_dtype(inorm_bias_init.data_type)
+        or list(inorm_scale_init.dims) != [num_groups]
+        or list(inorm_bias_init.dims) != [num_groups]
+    ):
+        return None
+    inorm_out = inorm.output[0]
+    if inorm_out in graph_outputs or len(consumers_of.get(inorm_out, [])) != 1:
+        return None
+
+    if (
+        shape_node.op_type != "Shape"
+        or shape_node.domain != ""
+        or list(shape_node.input) != [x_name]
+        or len(shape_node.output) != 1
+        or not shape_node.output[0]
+    ):
+        return None
+    shape_out = shape_node.output[0]
+    if shape_out in graph_outputs or len(consumers_of.get(shape_out, [])) != 1:
+        return None
+
+    reshape2 = consumers_of[inorm_out][0]
+    if reshape2 is not consumers_of[shape_out][0]:
+        return None  # inorm_out and shape_out must feed the SAME Reshape
+    if (
+        reshape2.op_type != "Reshape"
+        or reshape2.domain != ""
+        or list(reshape2.input) != [inorm_out, shape_out]
+        or len(reshape2.output) != 1
+        or not reshape2.output[0]
+    ):
+        return None
+    back_name = reshape2.output[0]
+    if back_name in graph_outputs or len(consumers_of.get(back_name, [])) != 1:
+        return None
+
+    mul_node = consumers_of[back_name][0]
+    if (
+        mul_node.op_type != "Mul"
+        or mul_node.domain != ""
+        or len(mul_node.input) != 2
+        or back_name not in mul_node.input
+        or len(mul_node.output) != 1
+        or not mul_node.output[0]
+    ):
+        return None
+    gamma_name = (
+        mul_node.input[1] if mul_node.input[0] == back_name else mul_node.input[0]
+    )
+    if gamma_name == back_name or not _decomposed_group_norm_channel_const(
+        gamma_name, initializer_map, n_channels
+    ):
+        return None
+    scaled_name = mul_node.output[0]
+    if scaled_name in graph_outputs or len(consumers_of.get(scaled_name, [])) != 1:
+        return None
+
+    add_node = consumers_of[scaled_name][0]
+    if (
+        add_node.op_type != "Add"
+        or add_node.domain != ""
+        or len(add_node.input) != 2
+        or scaled_name not in add_node.input
+        or len(add_node.output) != 1
+        or not add_node.output[0]
+    ):
+        return None
+    beta_name = (
+        add_node.input[1] if add_node.input[0] == scaled_name else add_node.input[0]
+    )
+    if (
+        beta_name == scaled_name
+        or beta_name == gamma_name  # tied gamma/beta -- would double-slice it
+        or not _decomposed_group_norm_channel_const(
+            beta_name, initializer_map, n_channels
+        )
+    ):
+        return None
+
+    out_name = add_node.output[0]
+    chain_ops: Tuple[Tuple[onnx.NodeProto, None], ...] = (
+        (reshape1, None),
+        (inorm, None),
+        (shape_node, None),
+        (reshape2, None),
+    )
+    pass_through: Tuple[_ConvPassThrough, ...] = (
+        _ConvPassThrough(mul_node, gamma_name, None),
+        _ConvPassThrough(add_node, beta_name, None),
+    )
+    return out_name, chain_ops, pass_through, num_groups
+
+
 def _match_resize_channel_pass_through(
     node: onnx.NodeProto, initializer_map: Dict[str, onnx.TensorProto]
 ) -> bool:
@@ -6339,11 +6782,13 @@ def _walk_to_conv_consumer(
     forced_first_hop: Optional[onnx.NodeProto] = None,
     allow_conv_transpose_consumer: bool = False,
     recognize_group_norm: bool = False,
+    recognize_decomposed_group_norm: bool = False,
 ) -> Tuple[
     Optional[Tuple[onnx.NodeProto, str, int, bool]],
     Tuple[Tuple[onnx.NodeProto, None], ...],
     Tuple[_ConvPassThrough, ...],
     Optional[_GroupNormPassThrough],
+    Optional[int],
 ]:
     """The Conv analogue of :func:`_walk_to_consumer`: from tensor `start`,
     walks forward through unary shape-preserving activations (see
@@ -6448,6 +6893,24 @@ def _walk_to_conv_consumer(
     is ever carried per chain (see :class:`_Chain.group_norm`'s own
     comment).
 
+    `recognize_decomposed_group_norm` is the analogous gate for the
+    *decomposed* GroupNorm shape (see :func:`_match_decomposed_group_norm_pass_through`
+    and this module's own docstring) -- scoped identically to
+    `recognize_group_norm` for the identical reason (only
+    :func:`_find_conv_chains` passes ``True``), and mutually exclusive with
+    it on any one chain: this hop is tried at whatever tensor `cur` is at the
+    top of each hop iteration below, the moment it has exactly two consumers
+    -- not only when `cur == start` -- unlike `recognize_group_norm`'s
+    ordinary node-op-type dispatch, since this shape's own root tensor is
+    read twice by design, the same reason
+    :func:`_match_decomposed_layer_norm_pass_through` needs its own "before
+    the ordinary dispatch" call site in :func:`_walk_to_consumer`, tried at
+    every hop there too, not only the walk's first. Tried when *neither* a
+    native `GroupNormalization` nor a decomposed one has already matched on
+    this walk, and vice versa --
+    so a chain can carry at most one GroupNorm-family hop, exactly like
+    `recognize_group_norm` alone already guaranteed for the native shape.
+
     `forced_first_hop`, when given, is used as the walk's very first hop
     instead of deriving it from `consumers_of[start]` -- every ordinary
     caller leaves it ``None`` and gets identical behavior to before this
@@ -6464,6 +6927,7 @@ def _walk_to_conv_consumer(
     chain_ops: List[Tuple[onnx.NodeProto, None]] = []
     conv_pass_through: List[_ConvPassThrough] = []
     group_norm: Optional[_GroupNormPassThrough] = None
+    decomposed_group_norm_num_groups: Optional[int] = None
     consumer: Optional[Tuple[onnx.NodeProto, str, int, bool]] = None
     cur = start
     for _hop in range(max_hops):
@@ -6472,6 +6936,29 @@ def _walk_to_conv_consumer(
         else:
             candidates = consumers_of.get(cur, [])
             if len(candidates) == 2:
+                # Tried before the self-gated-activation check below, since
+                # this shape's own root tensor is read *twice* (by the first
+                # `Reshape` and by `Shape`) -- a shape the ordinary
+                # single-consumer dispatch can never reach on its own. See
+                # `recognize_decomposed_group_norm`'s own docstring for the
+                # mutual-exclusion gate against `group_norm` above.
+                if (
+                    recognize_decomposed_group_norm
+                    and group_norm is None
+                    and decomposed_group_norm_num_groups is None
+                ):
+                    dgn_match = _match_decomposed_group_norm_pass_through(
+                        cur, consumers_of, initializer_map, graph_outputs, n_channels
+                    )
+                    if dgn_match is not None:
+                        dgn_out, dgn_chain_ops, dgn_pass_through, dgn_num_groups = (
+                            dgn_match
+                        )
+                        chain_ops.extend(dgn_chain_ops)
+                        conv_pass_through.extend(dgn_pass_through)
+                        decomposed_group_norm_num_groups = dgn_num_groups
+                        cur = dgn_out
+                        continue
                 diamond = _match_self_gated_activation(
                     cur, consumers_of, initializer_map, graph_outputs
                 )
@@ -6577,6 +7064,7 @@ def _walk_to_conv_consumer(
         if (
             recognize_group_norm
             and group_norm is None
+            and decomposed_group_norm_num_groups is None
             and nxt.op_type == _GROUP_NORM_PASS_THROUGH_OP
             and nxt.domain == ""
             and nxt.input
@@ -6678,7 +7166,13 @@ def _walk_to_conv_consumer(
         chain_ops.append((nxt, None))
         cur = out2
 
-    return consumer, tuple(chain_ops), tuple(conv_pass_through), group_norm
+    return (
+        consumer,
+        tuple(chain_ops),
+        tuple(conv_pass_through),
+        group_norm,
+        decomposed_group_norm_num_groups,
+    )
 
 
 def _find_conv_chains(graph: onnx.GraphProto) -> List[_Chain]:
@@ -6715,7 +7209,13 @@ def _find_conv_chains(graph: onnx.GraphProto) -> List[_Chain]:
         ):
             continue
 
-        consumer, chain_ops, conv_pass_through, group_norm = _walk_to_conv_consumer(
+        (
+            consumer,
+            chain_ops,
+            conv_pass_through,
+            group_norm,
+            decomposed_group_norm_num_groups,
+        ) = _walk_to_conv_consumer(
             out_name,
             initializer_map,
             consumers_of,
@@ -6724,6 +7224,7 @@ def _find_conv_chains(graph: onnx.GraphProto) -> List[_Chain]:
             _MAX_CHAIN_HOPS,
             allow_conv_transpose_consumer=True,
             recognize_group_norm=True,
+            recognize_decomposed_group_norm=True,
         )
         if consumer is None:
             continue
@@ -6746,16 +7247,24 @@ def _find_conv_chains(graph: onnx.GraphProto) -> List[_Chain]:
             # than guessed at. See this module's own docstring.
             continue
 
-        if group_norm is not None and (
-            (producer_group > 1 and producer_group != group_norm.num_groups)
-            or (consumer_group > 1 and consumer_group != group_norm.num_groups)
+        # A mid-chain GroupNorm-family hop's own `num_groups` -- native
+        # (`group_norm`) or decomposed (`decomposed_group_norm_num_groups`,
+        # mutually exclusive with `group_norm` on any one chain -- see
+        # `_walk_to_conv_consumer`'s own `recognize_decomposed_group_norm`
+        # docstring) -- must agree with a general grouped Conv producer's or
+        # consumer's own `group`, the identical "declined outright" bar the
+        # producer/consumer group mismatch above already gets, for the same
+        # reason: the two partitions' own block boundaries wouldn't
+        # generally align. See `_GROUP_NORM_PASS_THROUGH_OP`'s own comment.
+        effective_num_groups = (
+            group_norm.num_groups
+            if group_norm is not None
+            else decomposed_group_norm_num_groups
+        )
+        if effective_num_groups is not None and (
+            (producer_group > 1 and producer_group != effective_num_groups)
+            or (consumer_group > 1 and consumer_group != effective_num_groups)
         ):
-            # The mid-chain GroupNorm hop's own `num_groups` disagrees with
-            # a general grouped Conv producer's or consumer's own `group` --
-            # exactly the same "declined outright" bar the producer/consumer
-            # group mismatch above already gets, for the same reason: the
-            # two partitions' own block boundaries wouldn't generally align.
-            # See `_GROUP_NORM_PASS_THROUGH_OP`'s own comment.
             continue
 
         chains.append(
@@ -6779,6 +7288,7 @@ def _find_conv_chains(graph: onnx.GraphProto) -> List[_Chain]:
                 consumer_is_conv=True,
                 conv_pass_through=conv_pass_through,
                 group_norm=group_norm,
+                decomposed_group_norm_num_groups=decomposed_group_norm_num_groups,
                 consumer_group=consumer_group,
                 consumer_is_conv_transpose=consumer_is_conv_transpose,
             )
@@ -6956,8 +7466,10 @@ def _walk_conv_producer_backward(
     ``InstanceNormalization`` hops (see
     :func:`_match_instance_norm_pass_through_self` and
     `_INSTANCE_NORM_PASS_THROUGH_OP`'s own comment -- recognized
-    unconditionally here too, unlike the GroupNorm hop, which this backward
-    walk never recognizes at all), spatial pooling ops that never
+    unconditionally here too, unlike the GroupNorm hop -- native or
+    decomposed alike, see :func:`_match_decomposed_group_norm_pass_through`
+    -- either of which this backward walk never recognizes at all), spatial
+    pooling ops that never
     mix channels (``MaxPool``/``AveragePool``/``GlobalAveragePool``,
     unconditionally -- see `_CONV_POOL_PASS_THROUGH`'s own comment), a
     channel-axis-unaffected ``Resize``/``Pad`` (see
@@ -7221,24 +7733,29 @@ def _resolve_conv_fanout_branches(
             seen_nodes.add(id(consumer_node))
             if id(consumer_node) in accounted.get(tensor, ()):
                 continue  # already part of the group's own established wiring
-            resolved, br_chain_ops, br_pass_through, _br_group_norm = (
-                _walk_to_conv_consumer(
-                    tensor,
-                    initializer_map,
-                    consumers_of,
-                    graph_outputs,
-                    n_channels,
-                    _MAX_CHAIN_HOPS,
-                    forced_first_hop=consumer_node,
-                )
+            (
+                resolved,
+                br_chain_ops,
+                br_pass_through,
+                _br_group_norm,
+                _br_decomposed_group_norm,
+            ) = _walk_to_conv_consumer(
+                tensor,
+                initializer_map,
+                consumers_of,
+                graph_outputs,
+                n_channels,
+                _MAX_CHAIN_HOPS,
+                forced_first_hop=consumer_node,
             )
             if resolved is None:
                 return None
-            # `recognize_group_norm` was left at its default (False) above,
-            # so `_br_group_norm` is always `None` -- GroupNorm pass-through
-            # is deliberately out of scope for a residual/merge group's own
-            # fan-out branches for now (see _walk_to_conv_consumer's own
-            # docstring).
+            # `recognize_group_norm`/`recognize_decomposed_group_norm` were
+            # left at their defaults (False) above, so `_br_group_norm`/
+            # `_br_decomposed_group_norm` are always `None` -- GroupNorm
+            # pass-through (native or decomposed) is deliberately out of
+            # scope for a residual/merge group's own fan-out branches for now
+            # (see _walk_to_conv_consumer's own docstring).
             # `allow_conv_transpose_consumer` was left at its default
             # (False) above, so `_` here is always False -- ConvTranspose
             # is deliberately out of scope for a residual/merge group's own
@@ -10362,20 +10879,26 @@ def _find_conv_concat_chains(graph: onnx.GraphProto) -> List[_ConcatChain]:
         if not _is_internal(out_name):
             continue
         total_n = offset
-        consumer, fwd_chain_ops, fwd_pass_through, _fwd_group_norm = (
-            _walk_to_conv_consumer(
-                out_name,
-                initializer_map,
-                consumers_of,
-                graph_outputs,
-                total_n,
-                _MAX_CHAIN_HOPS,
-            )
+        (
+            consumer,
+            fwd_chain_ops,
+            fwd_pass_through,
+            _fwd_group_norm,
+            _fwd_decomposed_group_norm,
+        ) = _walk_to_conv_consumer(
+            out_name,
+            initializer_map,
+            consumers_of,
+            graph_outputs,
+            total_n,
+            _MAX_CHAIN_HOPS,
         )
-        # `recognize_group_norm` was left at its default (False) above, so
-        # `_fwd_group_norm` is always `None` -- GroupNorm pass-through is
-        # deliberately out of scope for a Concat-branch-merge chain's own
-        # consumer for now (see _walk_to_conv_consumer's own docstring).
+        # `recognize_group_norm`/`recognize_decomposed_group_norm` were left
+        # at their defaults (False) above, so `_fwd_group_norm`/
+        # `_fwd_decomposed_group_norm` are always `None` -- GroupNorm
+        # pass-through (native or decomposed) is deliberately out of scope
+        # for a Concat-branch-merge chain's own consumer for now (see
+        # _walk_to_conv_consumer's own docstring).
         if consumer is None:
             continue
         # `allow_conv_transpose_consumer` was left at its default (False)
@@ -11317,6 +11840,16 @@ def _chain_group(chain: _Chain) -> int:
     per-group statistics stay valid after pruning -- see
     `_GROUP_NORM_PASS_THROUGH_OP`'s own comment for why a uniform count per
     `num_groups` block is exactly the scope that's safe.
+
+    A mid-chain *decomposed* GroupNorm hop
+    (`chain.decomposed_group_norm_num_groups`, likewise only ever set by
+    :func:`_find_conv_chains` -- see that field's own comment) contributes
+    its own `num_groups` identically, and for the identical reason -- see
+    :func:`_match_decomposed_group_norm_pass_through`'s own docstring and
+    this module's own docstring. At most one of `chain.group_norm`/
+    `chain.decomposed_group_norm_num_groups` is ever set (see
+    :func:`_walk_to_conv_consumer`'s own mutual-exclusion gate), so checking
+    both in sequence is never ambiguous.
     """
     group = chain.consumer_group
     for p in chain.producers:
@@ -11325,6 +11858,8 @@ def _chain_group(chain: _Chain) -> int:
             break
     if chain.group_norm is not None:
         group = chain.group_norm.num_groups
+    if chain.decomposed_group_norm_num_groups is not None:
+        group = chain.decomposed_group_norm_num_groups
     return group
 
 
@@ -11835,7 +12370,12 @@ def apply_structured_pruning(
     equal-sized blocks whenever it's present, exactly like a general
     grouped Conv's own `group` already constrains `keep` (see
     `_GROUP_NORM_PASS_THROUGH_OP`'s own comment for the full empirical
-    finding and scope). No per-channel Add/Mul between two Convs (a Conv
+    finding and scope) -- or the *decomposed* 5-node
+    ``Reshape -> InstanceNormalization -> Reshape -> Mul -> Add`` sequence
+    PyTorch's own default/legacy exporter emits for `nn.GroupNorm` instead of
+    the native op (see :func:`_match_decomposed_group_norm_pass_through`'s
+    own docstring and this module's own docstring), scoped and constrained
+    identically. No per-channel Add/Mul between two Convs (a Conv
     already carries its own bias, and ``BatchNormalization`` is expected to
     already be fused into the preceding Conv by the time this pass runs).
 

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -6047,6 +6047,365 @@ def test_analyze_structured_pruning_instance_norm_pass_through_matches_real_call
     assert dims_after["INBias"][0] == kept
 
 
+# --- Conv chain: decomposed-GroupNorm pass-through hop -----------------------
+#
+# The fixed 5-node ``Reshape -> InstanceNormalization -> Reshape -> Mul ->
+# Add`` sequence PyTorch's own default/legacy (TorchScript-based) ONNX
+# exporter emits for `nn.GroupNorm` in place of the native
+# `GroupNormalization` node above -- see
+# `onnxsim.pruning._match_decomposed_group_norm_pass_through`'s own
+# docstring and this module's own top-of-file docstring for the full
+# empirical gap confirmation and correctness argument. `_model` can express
+# this shape directly (`Reshape`'s own int64 shape and `Shape`'s own dynamic
+# second `Reshape` operand are both just ordinary named initializers/nodes in
+# the text body -- no `ClearField`/byte-equality escape hatch needed the way
+# CLAUDE.md's own "rare case" carve-out anticipates), so no `onnx.helper`
+# fallback is needed here despite the `Reshape`/`Shape` dynamic-shape
+# dependency.
+
+
+def _decomposed_group_norm_conv_pair_model(
+    w1,
+    w2,
+    gamma,
+    beta,
+    num_groups,
+    in_scale=None,
+    in_bias=None,
+    reshape_shape=None,
+    group1=1,
+    b1=None,
+    spatial=10,
+):
+    """The decomposed analogue of `_group_norm_conv_pair_model`: the fixed
+    5-node sequence sits between the two Convs instead of a single native
+    `GroupNormalization` node. `in_scale`/`in_bias` (length `num_groups`)
+    default to arbitrary, deliberately non-trivial values (never `1.0`/
+    `0.0`) -- confirming this hop's own correctness doesn't depend on them
+    being the trivial identity a real PyTorch export always emits, the same
+    empirical claim this feature's own docstring makes. `reshape_shape`
+    defaults to the real, exact shape PyTorch's own exporter emits
+    (`[0, num_groups, -1]`); tests that need a *different* shape (to probe
+    the matcher's own decline behavior) override it directly.
+    """
+    C1, C2 = w1.shape[0], w2.shape[0]
+    Cin = w1.shape[1] * group1
+    if in_scale is None:
+        in_scale = np.full(num_groups, 1.7, dtype=np.float32)
+    if in_bias is None:
+        in_bias = np.full(num_groups, -0.4, dtype=np.float32)
+    if reshape_shape is None:
+        reshape_shape = [0, num_groups, -1]
+    initializer = [
+        _f32(w1, "W1"),
+        _f32(w2, "W2"),
+        onnx.numpy_helper.from_array(
+            np.array(reshape_shape, dtype=np.int64), "ReshapeShape"
+        ),
+        _f32(np.asarray(in_scale), "INScale"),
+        _f32(np.asarray(in_bias), "INBias"),
+        _f32(np.asarray(gamma).reshape(C1, 1, 1), "Gamma"),
+        _f32(np.asarray(beta).reshape(C1, 1, 1), "Beta"),
+    ]
+    g1 = f", group={group1}" if group1 != 1 else ""
+    if b1 is not None:
+        conv1 = f"h = Conv<kernel_shape=[3,3]{g1}>(X, W1, B1)"
+        initializer.append(_f32(b1, "B1"))
+    else:
+        conv1 = f"h = Conv<kernel_shape=[3,3]{g1}>(X, W1)"
+    out_spatial = spatial - 4  # two valid (no-pad) 3x3 convs
+    return _model(
+        f"""
+        g (float[N,{Cin},{spatial},{spatial}] X) => (float[N,{C2},{out_spatial},{out_spatial}] Y)
+        {{
+          {conv1}
+          reshaped = Reshape(h, ReshapeShape)
+          inorm = InstanceNormalization<epsilon=1e-05>(reshaped, INScale, INBias)
+          hshape = Shape(h)
+          back = Reshape(inorm, hshape)
+          scaled = Mul(back, Gamma)
+          gn = Add(scaled, Beta)
+          Y = Conv<kernel_shape=[3,3]>(gn, W2)
+        }}
+        """,
+        initializer=initializer,
+    )
+
+
+def test_structured_pruning_decomposed_group_norm_pass_through_matches_oracle_exactly():
+    # THE key correctness bar, identical to the native-node hop's own test:
+    # exact equivalence (float32 noise only) to an independently,
+    # already-pruned reference model -- never "matches the un-pruned model's
+    # own output sliced after the fact" (confirmed, empirically, to actually
+    # diverge -- see `_match_decomposed_group_norm_pass_through`'s own
+    # docstring). Also confirms, directly on the pruned model's own
+    # initializers, the two claims specific to this hop: `INScale`/`INBias`
+    # are left completely untouched (still length `num_groups`, still their
+    # original, deliberately non-trivial values), and `Gamma`/`Beta` (the
+    # *real* per-channel affine) are co-sliced by the exact same
+    # non-contiguous, per-group-uniform `keep` set the producer/consumer
+    # weights are.
+    Cin, C1, C2, num_groups = 3, 16, 8, 4
+    rng = np.random.default_rng(150)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    b1 = rng.standard_normal((C1,)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    gamma = rng.standard_normal((C1,)).astype(np.float32)
+    beta = rng.standard_normal((C1,)).astype(np.float32)
+    in_scale = (
+        rng.standard_normal((num_groups,)).astype(np.float32) + 2.0
+    )  # non-trivial
+    in_bias = rng.standard_normal((num_groups,)).astype(np.float32)
+    model = _decomposed_group_norm_conv_pair_model(
+        w1, w2, gamma, beta, num_groups, in_scale=in_scale, in_bias=in_bias, b1=b1
+    )
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    dims_after = _initializer_dims(pruned)
+    assert dims_after["W1"][0] % num_groups == 0
+    assert dims_after["W1"][0] < C1  # actually pruned, not a no-op
+
+    pruned_inits = {
+        t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer
+    }
+    np.testing.assert_array_equal(pruned_inits["INScale"], in_scale)
+    np.testing.assert_array_equal(pruned_inits["INBias"], in_bias)
+
+    keep = _oracle_keep_indices_conv_grouped(w1, num_groups, 0.5)
+    # Uniform-per-group, but not necessarily contiguous -- confirming this
+    # hop's own safety claim isn't accidentally only exercised by a
+    # contiguous "keep the first half of every group" special case.
+    block = C1 // num_groups
+    per_group_counts = {
+        gi: int(np.sum((keep >= gi * block) & (keep < (gi + 1) * block)))
+        for gi in range(num_groups)
+    }
+    assert len(set(per_group_counts.values())) == 1  # uniform per group
+
+    np.testing.assert_array_equal(pruned_inits["Gamma"].reshape(-1), gamma[keep])
+    np.testing.assert_array_equal(pruned_inits["Beta"].reshape(-1), beta[keep])
+
+    oracle = _decomposed_group_norm_conv_pair_model(
+        w1[keep],
+        w2[:, keep],
+        gamma[keep],
+        beta[keep],
+        num_groups,
+        in_scale=in_scale,
+        in_bias=in_bias,
+        b1=b1[keep],
+    )
+
+    rng_x = np.random.default_rng(151)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_decomposed_group_norm_num_groups_mismatch_with_grouped_conv_declines():
+    # The decomposed-hop analogue of
+    # `test_structured_pruning_group_norm_num_groups_mismatch_with_grouped_conv_declines`:
+    # `num_groups` disagreeing with a same-chain grouped Conv producer's own
+    # `group` is declined outright, never guessed at.
+    Cin, C1, C2, group1, num_groups = 4, 8, 8, 2, 4
+    rng = np.random.default_rng(152)
+    w1 = rng.standard_normal((C1, Cin // group1, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    gamma = rng.standard_normal((C1,)).astype(np.float32)
+    beta = rng.standard_normal((C1,)).astype(np.float32)
+    model = _decomposed_group_norm_conv_pair_model(
+        w1, w2, gamma, beta, num_groups, group1=group1
+    )
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+    np.testing.assert_array_equal(inits["Gamma"].reshape(-1), gamma)
+    np.testing.assert_array_equal(inits["Beta"].reshape(-1), beta)
+
+
+def test_structured_pruning_decomposed_group_norm_num_groups_not_dividing_declines():
+    # `num_groups` not evenly dividing `n_channels` -- declined outright by
+    # `_decomposed_group_norm_reshape_num_groups`, mirroring the native
+    # hop's own identical `n_channels % num_groups != 0` bar.
+    Cin, C1, C2, num_groups = 3, 8, 4, 3  # 8 % 3 != 0
+    rng = np.random.default_rng(153)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    gamma = rng.standard_normal((C1,)).astype(np.float32)
+    beta = rng.standard_normal((C1,)).astype(np.float32)
+    model = _decomposed_group_norm_conv_pair_model(w1, w2, gamma, beta, num_groups)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+
+
+@pytest.mark.parametrize(
+    "reshape_shape",
+    [
+        [4, 0, -1],  # num_groups/batch swapped
+        [0, 4, 2],  # no -1 at all -- not the fixed group-split form
+        [0, 4, -1, 1],  # wrong length
+    ],
+)
+def test_structured_pruning_decomposed_group_norm_wrong_reshape_shape_declines(
+    reshape_shape,
+):
+    # Any deviation from the exact `[0|batch_dim, num_groups, -1]` form is
+    # declined outright, never guessed at -- see
+    # `_decomposed_group_norm_reshape_num_groups`'s own docstring.
+    Cin, C1, C2, num_groups = 3, 8, 4, 4
+    rng = np.random.default_rng(154)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    gamma = rng.standard_normal((C1,)).astype(np.float32)
+    beta = rng.standard_normal((C1,)).astype(np.float32)
+    model = _decomposed_group_norm_conv_pair_model(
+        w1, w2, gamma, beta, num_groups, reshape_shape=reshape_shape
+    )
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+
+
+def test_structured_pruning_decomposed_group_norm_non_channel_gamma_declines():
+    # `Gamma`/`Beta` not held to the `[C, 1, ..., 1]` per-channel shape bar
+    # `_match_prelu_pass_through`'s own per-channel branch already uses --
+    # here, a bare `[C]` (this hop's own matcher, unlike a MatMul/Gemm
+    # chain's own last-axis convention, requires at least one trailing
+    # size-1 dimension, mirroring `_match_prelu_pass_through`'s own
+    # "a bare [C] slope is deliberately not per-channel here" bar) -- is
+    # declined outright, the whole chain left unpruned.
+    Cin, C1, C2, num_groups = 3, 8, 4, 4
+    rng = np.random.default_rng(155)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    gamma = rng.standard_normal((C1,)).astype(np.float32)
+    beta = rng.standard_normal((C1,)).astype(np.float32)
+    model = _decomposed_group_norm_conv_pair_model(w1, w2, gamma, beta, num_groups)
+    # Overwrite `Gamma` with a bare rank-1 `[C1]` shape instead of `[C1,1,1]`.
+    for init in model.graph.initializer:
+        if init.name == "Gamma":
+            init.CopyFrom(_f32(gamma, "Gamma"))
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+
+
+def test_structured_pruning_decomposed_group_norm_tied_gamma_beta_declines():
+    # A tied `Gamma`/`Beta` (the same initializer used for both) would be
+    # double-sliced by `_apply_chains`'s own per-hop loop, corrupting it --
+    # declined outright, mirroring `_match_group_norm_pass_through`'s own
+    # identical tied-`scale`/`bias` check.
+    Cin, C1, C2, num_groups = 3, 8, 4, 4
+    rng = np.random.default_rng(156)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    tied = rng.standard_normal((C1,)).astype(np.float32)
+    model = _decomposed_group_norm_conv_pair_model(w1, w2, tied, tied, num_groups)
+    # Point both Mul's and Add's own per-channel operand at the same name.
+    for node in model.graph.node:
+        if node.op_type == "Add" and list(node.input) == ["scaled", "Beta"]:
+            node.input[1] = "Gamma"
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+
+
+def test_structured_pruning_decomposed_group_norm_extra_consumer_on_root_declines():
+    # `h` (the producer Conv's own output, this sequence's own root) read by
+    # a THIRD consumer beyond the `Reshape`/`Shape` pair this shape expects
+    # -- declined outright, the same "no stray fan-out" bar every hop in
+    # this module already applies.
+    Cin, C1, C2, num_groups = 3, 8, 4, 4
+    rng = np.random.default_rng(157)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    gamma = rng.standard_normal((C1,)).astype(np.float32)
+    beta = rng.standard_normal((C1,)).astype(np.float32)
+    model = _decomposed_group_norm_conv_pair_model(w1, w2, gamma, beta, num_groups)
+    extra_out = onnx.helper.make_tensor_value_info(
+        "Extra", onnx.TensorProto.FLOAT, None
+    )
+    model.graph.node.append(onnx.helper.make_node("Relu", ["h"], ["Extra"]))
+    model.graph.output.append(extra_out)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+
+
+def test_analyze_structured_pruning_decomposed_group_norm_pass_through_matches_real_call():
+    # Dry-run/real-call cross-check for the decomposed-hop specifically,
+    # mirroring `test_analyze_structured_pruning_group_norm_pass_through_matches_real_call`.
+    Cin, C1, C2, num_groups = 3, 16, 8, 4
+    rng = np.random.default_rng(158)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    gamma = rng.standard_normal((C1,)).astype(np.float32)
+    beta = rng.standard_normal((C1,)).astype(np.float32)
+    model = _decomposed_group_norm_conv_pair_model(w1, w2, gamma, beta, num_groups)
+
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_structured_pruning, sparsity=0.5
+    )
+    assert len(report.layers) == 1
+    layer = report.layers[0]
+    assert layer.family == "conv_plain"
+    assert layer.total == C1
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    dims_after = _initializer_dims(pruned)
+    kept = C1 - layer.would_drop
+    assert dims_after["W1"][0] == kept
+    assert dims_after["W2"][1] == kept
+    assert dims_after["Gamma"][0] == kept
+    assert dims_after["Beta"][0] == kept
+
+
+def test_structured_pruning_native_and_decomposed_group_norm_still_supported_together():
+    # Regression check: the native `GroupNormalization` node (opset 21+) and
+    # the bare `InstanceNormalization` shape both remain unaffected by this
+    # hop's own addition -- each is a completely different op-type dispatch
+    # inside `_walk_to_conv_consumer`, gated by its own
+    # `recognize_group_norm`/`recognize_decomposed_group_norm` flag, mutually
+    # exclusive per chain (see that function's own docstring) -- confirmed
+    # here by running one of each shape through the same call and checking
+    # both still prune correctly.
+    Cin, C1, C2, num_groups = 3, 16, 8, 4
+    rng = np.random.default_rng(159)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    gn_scale = rng.standard_normal((C1,)).astype(np.float32)
+    gn_bias = rng.standard_normal((C1,)).astype(np.float32)
+    native_model = _group_norm_conv_pair_model(w1, w2, gn_scale, gn_bias, num_groups)
+    native_pruned = onnxsim.apply_structured_pruning(native_model, sparsity=0.5)
+    native_dims = _initializer_dims(native_pruned)
+    assert native_dims["W1"][0] < C1
+    assert native_dims["W1"][0] % num_groups == 0
+
+    w1b = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    w2b = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    in_scale = rng.standard_normal((C1,)).astype(np.float32)
+    in_bias = rng.standard_normal((C1,)).astype(np.float32)
+    instance_model = _instance_norm_conv_pair_model(w1b, w2b, in_scale, in_bias)
+    instance_pruned = onnxsim.apply_structured_pruning(instance_model, sparsity=0.5)
+    instance_dims = _initializer_dims(instance_pruned)
+    assert instance_dims["W1"][0] < C1
+
+
 # --- Conv chain: pooling/Resize/Pad pass-through hops -----------------------
 #
 # `MaxPool`/`AveragePool`/`GlobalAveragePool` (unconditional -- no weight of


### PR DESCRIPTION
## Summary

`pruning.py` recognizes GroupNorm in exactly two forms: the native `GroupNormalization` op (opset 21+) and a bare mid-chain `InstanceNormalization` node. Neither covers the shape PyTorch's default/legacy (TorchScript-based) ONNX exporter actually emits for `nn.GroupNorm` at **any** opset (confirmed live via `torch.onnx.export(nn.GroupNorm(G,C), ..., dynamo=False)` at opsets 13/17/18/20 — all identical):

```
reshaped = Reshape(x, [0, num_groups, -1])
inorm    = InstanceNormalization(reshaped, ones[num_groups], zeros[num_groups])   # trivial per-group affine
back     = Reshape(inorm, Shape(x))
scaled   = Mul(back, gamma)   # gamma: [C, 1, 1] -- the REAL per-channel affine
y        = Add(scaled, beta)  # beta:  [C, 1, 1]
```

Only PyTorch's newer `dynamo=True` export path emits the native op directly — the legacy path is still the default for torch < 2.9, and is what essentially every currently-shipping diffusion/U-Net export pipeline (Stable Diffusion/SDXL-style `ResnetBlock2D`, which use `nn.GroupNorm` pervasively) has used to date. `onnxsim`'s own `onnx-optimizer` fusion passes never fuse this pattern into `GroupNormalization` either (confirmed: no hits for `groupnorm` anywhere in `third_party/onnx-optimizer`), so running onnxsim's own `simplify()` ahead of pruning doesn't close the gap. `Reshape` isn't recognized by any existing Conv-chain hop, so a chain hitting this decomposition dead-ends at the first `Reshape` and comes out **completely unpruned**.

## Empirically confirmed facts

- Exporter shape re-confirmed live at multiple opsets, exactly as above.
- I independently reproduced the actual bug and its fix myself (not just re-running the committed tests): built a `Conv → {5-node decomposition} → Conv` model and ran `apply_structured_pruning(model, sparsity=0.5)` against this branch — correctly pruned (`W1: [16,3,3,3]→[8,3,3,3]`, `W2: [8,16,1,1]→[8,8,1,1]`, `Gamma`/`Beta: [16,1,1]→[8,1,1]`, `IScale`/`IBias` correctly left untouched at `[4]`).
- **I independently verified the core correctness claim myself** (this is the subtle part of the feature): I initially tried the wrong comparison methodology (slicing the *full* unpruned model's own output and comparing to the pruned model) and saw a real ~0.049 divergence — but this is *expected*, not a bug: GroupNorm's own per-group statistics are recomputed live from whichever channels survive, so "slice the full model's output" is exactly the anti-pattern this module's test suite explicitly avoids for any of its hops. I redid the comparison correctly — the pruned model's real output vs. an **independently pre-sliced reference model** (same topology, weights sliced *before* being embedded, so `InstanceNormalization` genuinely recomputes over the smaller reduced group) — and got **exactly 0.0 max abs diff**, with the recovered `keep` set (`[0,2,4,6,8,10,12,13]`) confirming 2-per-group uniformity was respected across all 4 groups.
- I independently re-ran the full verification suite in the worktree: `pytest tests/test_pruning.py -q` → **833 passed** (822 → 833, +11 new tests), `ruff format --check`/`ruff check` clean, `mypy onnxsim/pruning.py` (exact scoped command) → **0 errors**, matching baseline.

## What's added / scope

- `_match_decomposed_group_norm_pass_through` (plus helpers `_decomposed_group_norm_reshape_num_groups`, `_decomposed_group_norm_channel_const`): recognizes the exact 5-node sequence, declining on any deviation (wrong reshape shape, `num_groups` not dividing `n_channels`, non-constant/wrong-shaped `gamma`/`beta`, tied `gamma`/`beta`, any stray fan-out on an intermediate tensor, etc.).
- Wired into `_walk_to_conv_consumer` behind a new `recognize_decomposed_group_norm` flag (only `_find_conv_chains` sets it, mutually exclusive with the native `GroupNormalization` hop per chain — mirroring that hop's own scope).
- Reuses `_chain_group`'s existing uniform-per-block machinery for `num_groups` (a new `_Chain.decomposed_group_norm_num_groups` field feeds it, same as the native hop's own `group_norm.num_groups`) and `_ConvPassThrough` for `gamma`/`beta`'s axis-0 slice (two separate weight-only entries, since their real `[C,1,...,1]` shape needs axis-0 slicing, not the flat-`[C]`/`_slice_last_axis` treatment `group_norm`'s own `scale`/`bias` get).
- I found and fixed one real, if purely cosmetic, issue during my own review before pushing: `_apply_conv_pass_through_hop`'s own docstring (a shared function, not something the feature's own new code needed to touch functionally) had been left stale — still said "four genuinely different op types" — after `_ConvPassThrough`'s own class docstring was correctly updated to five; fixed to keep the module's own "exhaustive, accurate reaching-matchers list" convention intact. (The implementing agent's own follow-up session independently found and fixed the identical issue in parallel — both fixes were word-for-word identical, so no conflict.)

## Test plan

- [x] Decomposed-GroupNorm chain prunes correctly, output matches an independently-reconstructed already-pruned reference model via real onnxruntime execution (never the full unpruned model's own output — see the correctness-verification note above for why that specific comparison is the wrong one for this hop).
- [x] Decline cases: `num_groups` not dividing channel count, wrong reshape shapes, non-per-channel `gamma`, tied `gamma`/`beta`, extra consumer on the root tensor.
- [x] Dry-run/real-call cross-check.
- [x] Native `GroupNormalization` and bare `InstanceNormalization` cases remain unaffected (no regression).
- [x] `pytest tests/test_pruning.py -q`: 822 → 833 passed.
- [x] `ruff format --check .` / `ruff check .`: clean.
- [x] `mypy onnxsim/pruning.py` (exact scoped command): 0 errors, matching baseline.

I independently re-verified this PR after implementation: reviewed the full diff line by line, found and fixed the stale-docstring issue described above, and — most importantly — independently re-derived and re-ran the correctness verification myself from scratch rather than trusting the implementing agent's own report, catching my own initial wrong-methodology mistake along the way and confirming the actually-correct oracle-based comparison gives an exact 0.0 diff.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_