### PR TITLE
Add Axera Pulsar2/AXCL compatibility harness, simulator, and quantizer

### DIFF
--- a/.github/workflows/axera-integration.yml
+++ b/.github/workflows/axera-integration.yml
@@ -1,0 +1,161 @@
+name: Axera Integration
+
+# Checks onnxsim's output against Axera's Pulsar2/AXCL NPU compiler stack
+# (the .axmodel toolchain for AX6xx/AX8xx) -- see scripts/axera/README.md.
+#
+# Unlike ep-integration.yml's OpenVINO/QNN checks, Pulsar2 has no pip package
+# or ONNX Runtime execution provider, so `pulsar2-compat` below is a static,
+# dependency-light check (tests/test_pulsar2_compat.py,
+# tests/test_pulsar2_simulator.py, scripts/axera/run_pulsar2_compat.py) that
+# runs on any stock runner with just onnxsim + onnxruntime -- no Docker, no
+# device.
+#
+# `pulsar2-docker-convert` is the real thing: an actual `pulsar2 build`
+# (Docker) + `axcl_run_model` (device) conversion, following
+# scripts/axera/README.md's confirmed-real workflow. Like
+# amd-integration.yml's MIGraphX check, this needs hardware this repository
+# does not provision (a loaded Pulsar2 Docker image + a connected AXCL
+# device on `[self-hosted, axcl]`), so it is workflow_dispatch-ONLY and
+# dormant until such a runner exists.
+
+on:
+  schedule:
+    - cron: "0 7 * * 1" # Mondays 07:00 UTC (weekly)
+  workflow_dispatch:
+    inputs:
+      convert_models:
+        description: "Space-separated onnxmodelzoo short names for pulsar2-docker-convert (self-hosted only)"
+        default: "resnet18d_Opset18"
+        required: false
+  pull_request:
+    paths:
+      - ".github/workflows/axera-integration.yml"
+      - "scripts/axera/**"
+      - "scripts/common/**"
+      - "scripts/regression/model_zoo.py"
+      - "tests/test_pulsar2_compat.py"
+      - "tests/test_pulsar2_simulator.py"
+
+concurrency:
+  group: axera-integration-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build onnxsim wheel
+    runs-on: ubuntu-24.04
+    env:
+      SCCACHE_GHA_ENABLED: "on"
+      ACTIONS_CACHE_SERVICE_V2: "on"
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - uses: mozilla-actions/sccache-action@v0.0.11
+      - name: Build cp312 wheel
+        uses: pypa/cibuildwheel@v4.2.0
+        env:
+          CIBW_BUILD: "cp312-manylinux_x86_64"
+          CIBW_ARCHS: native
+          CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_ENVIRONMENT_PASS_LINUX: CI SCCACHE_GHA_ENABLED ACTIONS_RESULTS_URL ACTIONS_RUNTIME_TOKEN ACTIONS_CACHE_SERVICE_V2
+          CIBW_BEFORE_BUILD: "python3 -m pip install --break-system-packages cmake ninja setuptools sccache nanobind"
+          CIBW_ENVIRONMENT: CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=OFF" CMAKE_GENERATOR=Ninja CMAKE_CXX_COMPILER_LAUNCHER=sccache CMAKE_LINKER_TYPE=LLD
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel} --strip"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: onnxsim-wheel-axera
+          path: ./wheelhouse/*.whl
+
+  pulsar2-compat:
+    name: Pulsar2 compatibility check (static, no Docker/device)
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - uses: actions/download-artifact@v8
+        with:
+          name: onnxsim-wheel-axera
+          path: wheelhouse
+      - name: Install onnxsim wheel + onnxruntime
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest onnxruntime
+          python -m pip install wheelhouse/*.whl
+      # Run from runner.temp, not the checkout: the repo root contains the
+      # `onnxsim/` source dir (no compiled extension), which would shadow the
+      # installed wheel on `import onnxsim`. Reference the harness by absolute
+      # $GITHUB_WORKSPACE path. Same guard the EP/model-regression workflows use.
+      - name: Show environment
+        working-directory: ${{ runner.temp }}
+        run: |
+          python -c "import onnxsim, onnxruntime as ort; print('onnxsim', onnxsim.__version__); print('onnxruntime', ort.__version__)"
+      - name: Run in-tree smoke tests
+        working-directory: ${{ runner.temp }}
+        run: |
+          pytest -v "$GITHUB_WORKSPACE/tests/test_pulsar2_compat.py" "$GITHUB_WORKSPACE/tests/test_pulsar2_simulator.py"
+      - name: Run static Pulsar2 compatibility suite
+        working-directory: ${{ runner.temp }}
+        run: |
+          python "$GITHUB_WORKSPACE/scripts/axera/run_pulsar2_compat.py" \
+            --output pulsar2-compat.csv
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: pulsar2-compat-report
+          path: ${{ runner.temp }}/pulsar2-compat.csv
+          if-no-files-found: ignore
+
+  pulsar2-docker-convert:
+    name: Real Pulsar2 build + AXCL device conversion
+    if: github.event_name == 'workflow_dispatch'
+    # Requires a self-hosted runner with Docker, a loaded `pulsar2:*` image
+    # (see scripts/axera/pulsar2_docker.py's docstring for how to get one),
+    # and ideally a connected AXCL device, labeled "axcl". Not provided by
+    # this repository -- dormant until one is provisioned.
+    runs-on: [self-hosted, axcl]
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Install onnxsim + conversion deps
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install huggingface_hub pillow numpy onnxruntime
+          python3 -m pip install .
+      - name: Show environment
+        working-directory: ${{ runner.temp }}
+        run: |
+          python3 -c "import onnxsim; print('onnxsim', onnxsim.__version__)"
+          docker images | grep '^pulsar2' || echo "no pulsar2 image loaded"
+          axcl-smi || echo "no AXCL device found"
+      - name: Run real conversion
+        working-directory: ${{ runner.temp }}
+        env:
+          # Passed via env, not interpolated into the command line, so a
+          # crafted workflow_dispatch input can't inject shell syntax.
+          CONVERT_MODELS: ${{ github.event.inputs.convert_models }}
+        run: |
+          python3 "$GITHUB_WORKSPACE/scripts/axera/convert_onnxmodelzoo.py" \
+            --models ${CONVERT_MODELS:-resnet18d_Opset18} \
+            --profile \
+            --output pulsar2-convert.csv
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: pulsar2-convert-report
+          path: ${{ runner.temp }}/pulsar2-convert.csv
+          if-no-files-found: ignore

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -239,10 +239,10 @@ the tensor). `pulsar2_docker.run_on_device_with_input()` already does this.
 | `pulsar2_quantizer.py` | `quantize_like_pulsar2()`: a Docker/device-free INT8 PTQ matching Pulsar2's real numeric convention (U8 asymmetric activations, S8 per-channel weights, MinMax calibration), via `onnxruntime.quantization`. Degrades gracefully (`PULSAR2_QUANTIZER_AVAILABLE`) without `onnxruntime`. |
 | `pulsar2_simulator.py` | `partition()`/`coverage()` (real `AX650_SUPPORTED_OPS` membership, no dependency beyond `onnx`) and `simulate()` (fp32-vs-INT8 estimate via `pulsar2_quantizer.py` + onnxruntime's CPU EP). Validated against real hardware -- see above. |
 | `worker.py` | runs the check for one model in an isolated subprocess, printing one `__RESULT__<json>` line. |
-| `run_pulsar2_compat.py` | drives the suite, writes a CSV, and exits non-zero on any regression. No `--require-*` flag or `skipped` status -- unlike the EP harnesses, this needs no vendor package or device, so it always runs. |
+| `run_pulsar2_compat.py` | drives the suite, writes a CSV, and exits non-zero on any regression. No `--require-*` flag or `skipped` status -- unlike the EP harnesses, this needs no vendor package or device, so it always runs. Entry point for `axera-integration.yml`'s `pulsar2-compat` job (stock runner, no Docker/device). |
 | `screen_onnxmodelzoo.py` | fast, static, Docker/device-free screening of `onnxmodelzoo` models via `pulsar2_simulator`/`pulsar2_backend.ax650_build_risks()` -- run this first. |
-| `pulsar2_docker.py` | real `pulsar2 build` (Docker) + `axcl_run_model` (device) wrapper: `build()` (with `profile=` for `trace.json`), `run_on_device()`, `run_on_device_with_input()`, `force_rmtree()`. Manual/local-only -- needs a loaded Docker image, not wired into any CI workflow. |
-| `convert_onnxmodelzoo.py` | batch driver over `pulsar2_docker.py`: fetch -> onnxsim -> real `pulsar2 build` (orig + simplified, `--profile` optional) -> optional on-device bit-exact diff -> CSV. |
+| `pulsar2_docker.py` | real `pulsar2 build` (Docker) + `axcl_run_model` (device) wrapper: `build()` (with `profile=` for `trace.json`), `run_on_device()`, `run_on_device_with_input()`, `force_rmtree()`. Manual/local-only -- needs a loaded Docker image. |
+| `convert_onnxmodelzoo.py` | batch driver over `pulsar2_docker.py`: fetch -> onnxsim -> real `pulsar2 build` (orig + simplified, `--profile` optional) -> optional on-device bit-exact diff -> CSV. Entry point for `axera-integration.yml`'s `pulsar2-docker-convert` job -- like `amd-integration.yml`'s MIGraphX check, that job is `workflow_dispatch`-only and targets a `[self-hosted, axcl]` runner this repository doesn't provision, so it's dormant until one exists. |
 
 ## Running locally
 

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -126,24 +126,31 @@ physical hardware:
   PTQ *numeric convention* -- read directly off a real `quant_axmodel.onnx`
   from the `resnet18d` conversion: **U8 (uint8), per-tensor, asymmetric**
   activations and **S8 (int8), per-channel, symmetric** weights, MinMax
-  calibration -- via `onnxruntime.quantization.quantize_static`. It does
-  **not** reproduce Pulsar2's actual quantized IR: that file's ops are
-  proprietary (`AxQuantizedConv`, `AxQuantizeLinear`, ... all in the plain
-  default domain, not standard ONNX `QuantizeLinear`/`DequantizeLinear`, and
-  not executable by onnxruntime) -- see its docstring.
+  calibration. It turns out **onnxsim already has a quantizer with exactly
+  this convention** -- `onnxsim.quantize_static(method="minmax")`
+  (`onnxsim/calibration.py`, an "asymmetric uint8 affine quantization" per
+  its own C++ pass's comment) -- so this is now a thin wrapper over
+  onnxsim's own quantizer rather than a hand-rolled equivalent built on
+  `onnxruntime.quantization`. It does **not** reproduce Pulsar2's actual
+  quantized IR: that file's ops are proprietary (`AxQuantizedConv`,
+  `AxQuantizeLinear`, ... all in the plain default domain, not standard ONNX
+  `QuantizeLinear`/`DequantizeLinear`, and not executable by onnxruntime),
+  and onnxsim's quantizer only quantizes Conv/MatMul/"vanilla" Gemm nodes
+  where Pulsar2 quantizes essentially the whole graph -- see its docstring.
 - **`pulsar2_simulator.py`** adds `partition()`/`coverage()` (per-node
   `AX650_SUPPORTED_OPS` membership -- correctly predicted both real
   conversions: "full" for `resnet18d`, "partial" with
   `{"LRN": 2, "Dropout": 1}` for `googlenet-6`) and `simulate()` (runs the
   quantized graph through onnxruntime's CPU EP as an fp32-vs-INT8 estimate).
   Validated against real hardware: on `resnet18d` with the same input image,
-  this simulator's INT8 output had **0.941 cosine similarity** to the real
+  this simulator's INT8 output had **0.938 cosine similarity** to the real
   device's actual output, close to fp32-vs-real's own **0.949** -- similar
   *magnitude* of quantization noise, but **not** rank/bit-accurate (top-5
   didn't match between fp32, simulated, and real on that input). Both
   degrade gracefully (`SIMULATOR_AVAILABLE`/`PULSAR2_QUANTIZER_AVAILABLE`)
-  when `onnxruntime` isn't installed; `partition()`/`coverage()` need only
-  `onnx` and always work.
+  when `onnxruntime` isn't installed (onnxsim's own `quantize_static` only
+  imports it lazily, inside `calibrate()`); `partition()`/`coverage()` need
+  only `onnx` and always work.
 
 Use these for a fast first read before spending time on a real
 `pulsar2 build` -- always confirm anything that matters on the real
@@ -236,7 +243,7 @@ the tensor). `pulsar2_docker.run_on_device_with_input()` already does this.
 | `pulsar2_backend.py` | thin wrapper around `pulsar2_ops.py`: `coverage()`, `new_blocking_op_types()`, `stripped_npu_data()`, `unsafe_for_simplify()`, `ax650_build_risks()`. Shaped like the sibling `*_backend.py` modules for interface symmetry (`PULSAR2_AVAILABLE` is always `True` -- there's no external dependency to be missing). |
 | `inspect_axmodel.py` | standalone CLI for a **real** `.axmodel` file: loads it with `onnx.load()`, then reports non-standard-domain nodes, op types outside the model's declared opset, and suspiciously large raw attributes -- what originally found the `neu mode` node in the real YOLOv8 file. |
 | `models.py` | the shared `scripts/common/synthetic_models.py` suite plus `axera_npu_compiled_leaf`, a synthetic reproduction of the real `neu mode` node shape (no real device needed to exercise the corruption check in CI). |
-| `pulsar2_quantizer.py` | `quantize_like_pulsar2()`: a Docker/device-free INT8 PTQ matching Pulsar2's real numeric convention (U8 asymmetric activations, S8 per-channel weights, MinMax calibration), via `onnxruntime.quantization`. Degrades gracefully (`PULSAR2_QUANTIZER_AVAILABLE`) without `onnxruntime`. |
+| `pulsar2_quantizer.py` | `quantize_like_pulsar2()`: a thin wrapper over `onnxsim.quantize_static(method="minmax")`, which already matches Pulsar2's real numeric convention (U8 asymmetric activations, S8 per-channel weights, MinMax calibration). `PULSAR2_QUANTIZER_AVAILABLE` reflects `onnxruntime`'s availability (onnxsim's quantizer needs it internally, imported lazily). |
 | `pulsar2_simulator.py` | `partition()`/`coverage()` (real `AX650_SUPPORTED_OPS` membership, no dependency beyond `onnx`) and `simulate()` (fp32-vs-INT8 estimate via `pulsar2_quantizer.py` + onnxruntime's CPU EP). Validated against real hardware -- see above. |
 | `worker.py` | runs the check for one model in an isolated subprocess, printing one `__RESULT__<json>` line. |
 | `run_pulsar2_compat.py` | drives the suite, writes a CSV, and exits non-zero on any regression. No `--require-*` flag or `skipped` status -- unlike the EP harnesses, this needs no vendor package or device, so it always runs. Entry point for `axera-integration.yml`'s `pulsar2-compat` job (stock runner, no Docker/device). |

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -1,0 +1,305 @@
+# Axera Pulsar2/AXCL compatibility check
+
+Verifies that `onnxsim`'s output stays friendly to **Pulsar2**, the compiler
+behind Axera's AXCL toolchain that turns an ONNX model into a `.axmodel` for
+the AX6xx/AX8xx NPU line. Based on the handoff notes at
+[`../../../junk/axcl-axmodel-onnxsim-notes.md`](../../../junk/axcl-axmodel-onnxsim-notes.md),
+and since verified against a real **AX650N** (PCIe, via the AXCL host driver
+and `axcl_run_model`) and a real compiled `.axmodel`
+(`AXERA-TECH/YOLOv8`'s `AX650/yolov8n_640x640_npu1.axmodel`).
+
+## ⚠️ Confirmed on real hardware: onnxsim corrupts compiled `.axmodel` files
+
+**Do not run `onnxsim.simplify()` on an already-compiled `.axmodel`.** This
+was verified end-to-end: `axcl_run_model` ran the real file successfully
+(~4.8ms/inference on the NPU), then `simplify()` on that same file dropped
+its NPU weight/command data and the result failed to even load
+(`axcl_run_model` -> "Create model handle failed").
+
+Root cause: the compiled subgraph is a single node, `op_type="neu mode"`,
+whose NPU weight/command blobs are ordinary `graph.initializer` tensors
+(`npu_params`, `npu_dyn_params`, `<name>_b<N>_neu`) referenced **only** by
+name inside a JSON string in the node's `npu_graph_info` attribute --
+**not** as a declared node input. Both onnxsim's own constant-folding
+cleanup and onnx-optimizer's `eliminate_unused_initializer`/
+`eliminate_deadend` passes treat unreferenced-as-input initializers as dead
+and drop them; a fresh shape-inference pass also drops the `graph.value_info`
+entries describing those tensors, which the real device's loader also needs.
+
+**No combination of `simplify()`'s public parameters avoids this** --
+confirmed by exhausting them: `skip_constant_folding=True` alone,
+`skipped_optimizers=["eliminate_unused_initializer", "eliminate_deadend"]`
+alone, and even both together plus `skip_shape_inference=True`, all still
+produced a file `axcl_run_model` refused to load. See `pulsar2_ops.py`'s
+docstring for the full record. `pulsar2_ops.has_out_of_band_npu_data()` /
+`pulsar2_backend.unsafe_for_simplify()` detect this **before** calling
+`simplify()`, and `worker.py` uses it as a hard pre-flight guard
+(`pulsar2_unsafe_for_simplify` status) rather than ever calling `simplify()`
+on such a model. `tests/test_pulsar2_compat.py::
+test_onnxsim_corrupts_a_compiled_npu_subgraph` reproduces the bug against a
+synthetic fixture so it's caught in CI without needing the real device --
+this confirms the handoff notes' own recommendation to only ever simplify
+*pre*-`pulsar2 build` ONNX (approach (b) in the notes), never a compiled
+`.axmodel` (approach (a)).
+
+## ✅ Also confirmed on real hardware: approach (b) itself is safe
+
+The real Pulsar2 toolchain (`pulsar2:6.0-lite`, matching the AX650N's
+installed firmware) was loaded via Docker and used to actually build two
+real `onnxmodelzoo` models end to end -- ONNX -> `pulsar2 build` ->
+`.axmodel` -> run on the real AX650N:
+
+- **`resnet18d_Opset18`**: both the original ONNX and its onnxsim-simplified
+  twin (onnxsim folded 117 dangling weight-as-input entries down to 1 real
+  input, same 56 nodes) compiled to a single NPU subgraph with **identical
+  compiler-reported `max_cycle` (1,318,764)**. Running both `.axmodel`s on
+  the real device with the same input produced **bit-identical output**
+  (`np.array_equal` `True`, max abs diff `0.0`). This is the concrete,
+  positive counterpart to the corruption finding above: simplifying
+  *pre*-compile ONNX (approach (b)) is safe.
+- **`googlenet-6`** (opset 9, uses `LRN`): `pulsar2 build` did not gracefully
+  fall `LRN` back to CPU -- it hard-failed the whole build at the frontend
+  parse stage (`KeyError('dont support LRN opr in AXOPS/ONNXOPS/CUSTOM_OPS')`)
+  before any CPU/NPU partitioning happened. Also below Pulsar2's documented
+  minimum opset (11) for AX650. Useful negative data point: an unsupported
+  op isn't always "less NPU-friendly," sometimes it's a hard build failure.
+
+This also directly answered an open question from the handoff notes: Axera
+publishes the real AX650 NPU op-support list in Pulsar2's own docs
+(`appendix/op_support_list_ax650.html`) -- 92 ops, opset >= 11 required.
+It's now `pulsar2_ops.AX650_SUPPORTED_OPS` / `AX650_MIN_OPSET`, and
+`pulsar2_backend.ax650_build_risks()` uses it to predict (not guarantee) the
+two failure modes seen above *before* attempting a real build.
+
+## This one is not like its siblings
+
+[`scripts/qualcomm`](../qualcomm) (QNN), [`scripts/intel`](../intel)
+(OpenVINO), and [`scripts/amd`](../amd) (MIGraphX) each wrap a **real**
+compiler via a pip-installable ONNX Runtime execution provider, so they
+measure actual compile/run behavior. Pulsar2 has neither a PyPI package nor
+an ORT execution provider -- it ships as a Docker image -- so there is no
+compiler to invoke here for testing *pre*-compile ONNX. (What real hardware
+*can* do -- run an already-compiled `.axmodel` via the `axcl_run_model` CLI
+-- is a different, narrower thing; see the corruption finding above, which
+is exactly what that access was used for.)
+
+So the coverage side of this harness is a **static heuristic**, not a
+compiler check: it flags onnx op types that are extremely unlikely to run on
+*any* fixed-function NPU (control flow, sequence/optional types, string ops,
+data-dependent-shape ops), plus a non-standard ONNX `domain` check that
+turned out *not* to be how Axera actually marks a compiled subgraph (see
+`pulsar2_ops.py`'s docstring -- the real marker is `op_type="neu mode"` in
+the plain default domain). See `pulsar2_ops.py`'s docstring for the full
+reasoning and its explicit `CPU_ONLY_OPS` caveats.
+
+## What it checks
+
+For each model:
+
+0. If it already has a compiled Axera NPU subgraph node (`op_type="neu
+   mode"`) -> `pulsar2_unsafe_for_simplify`, **without calling `simplify()`
+   at all** (see the corruption finding above).
+1. Otherwise, `simplify` the model with onnxsim.
+2. Compute the static Pulsar2-NPU-blocker set (`pulsar2_ops.blocking_ops`) for
+   the original and the simplified graph.
+3. If simplification **introduced** a blocking op type that wasn't already
+   present -> `pulsar2_regression` (a failure): simplification likely folded
+   something into a form Pulsar2's NPU partitioner would reject, pushing more
+   of the graph onto its CPU fallback path than before.
+4. If simplification dropped NPU weight/command data a compiled subgraph
+   node still references -> `pulsar2_data_corrupted` (shouldn't be reachable
+   given step 0, checked anyway as defense in depth).
+5. If onnxsim's own correctness check reported a mismatch ->
+   `simplify_check_failed`.
+
+A model that already has a blocker *before* simplification, or still has one
+after but didn't gain a new one, passes (`ok`) -- that's a property of the
+input graph, not something onnxsim introduced.
+
+## No-Docker/no-device simulator + compatible quantizer
+
+`pulsar2_simulator.py` and `pulsar2_quantizer.py` turn the confirmed-real
+data above into something you can query without the ~1GB Docker image or
+physical hardware:
+
+- **`pulsar2_quantizer.quantize_like_pulsar2()`** reproduces Pulsar2's real
+  PTQ *numeric convention* -- read directly off a real `quant_axmodel.onnx`
+  from the `resnet18d` conversion: **U8 (uint8), per-tensor, asymmetric**
+  activations and **S8 (int8), per-channel, symmetric** weights, MinMax
+  calibration -- via `onnxruntime.quantization.quantize_static`. It does
+  **not** reproduce Pulsar2's actual quantized IR: that file's ops are
+  proprietary (`AxQuantizedConv`, `AxQuantizeLinear`, ... all in the plain
+  default domain, not standard ONNX `QuantizeLinear`/`DequantizeLinear`, and
+  not executable by onnxruntime) -- see its docstring.
+- **`pulsar2_simulator.py`** adds `partition()`/`coverage()` (per-node
+  `AX650_SUPPORTED_OPS` membership -- correctly predicted both real
+  conversions: "full" for `resnet18d`, "partial" with
+  `{"LRN": 2, "Dropout": 1}` for `googlenet-6`) and `simulate()` (runs the
+  quantized graph through onnxruntime's CPU EP as an fp32-vs-INT8 estimate).
+  Validated against real hardware: on `resnet18d` with the same input image,
+  this simulator's INT8 output had **0.941 cosine similarity** to the real
+  device's actual output, close to fp32-vs-real's own **0.949** -- similar
+  *magnitude* of quantization noise, but **not** rank/bit-accurate (top-5
+  didn't match between fp32, simulated, and real on that input). Both
+  degrade gracefully (`SIMULATOR_AVAILABLE`/`PULSAR2_QUANTIZER_AVAILABLE`)
+  when `onnxruntime` isn't installed; `partition()`/`coverage()` need only
+  `onnx` and always work.
+
+Use these for a fast first read before spending time on a real
+`pulsar2 build` -- always confirm anything that matters on the real
+toolchain and hardware, the same way this README's findings were confirmed.
+
+## Real NPU profiling: `chrome://tracing`-compatible trace.json
+
+Confirmed real (this is a genuine Pulsar2 feature, not something this repo
+implements): passing `--compiler.npu_perf` to a real `pulsar2 build` writes
+`${output_dir}/compiler/debug/subgraph_npu_0/b1/trace.json` -- a standard
+Chrome Trace Event Format file (`{"traceEvents": [...], "displayTimeUnit":
+...}`, each event `{"ph": "X", "pid": "subgraph_npu_0", "tid": "teng2", ...,
+"args": {...}}`) that loads directly in `chrome://tracing` (or Edge's
+`edge://tracing`), with one lane per NPU IP (`teng`/`sdma`/`cv`/`conv`) and
+one span per hardware task -- op names, dependencies, ddr-swap/load/store
+colors. Also pass `--debug.dump_frontend_graph` to get
+`frontend/optimized_quant_axmodel.onnx` (openable in Netron) so trace task
+labels can be matched back to the algorithm graph. A flat CSV covering the
+same data (`op_profile.csv`, one row per op: cycles, bandwidth, tensor
+shapes) is written alongside it.
+
+Reproduced against the real `resnet18d_Opset18` build used throughout this
+README:
+
+```bash
+docker run --rm -v "$PWD:/data" pulsar2:6.0-lite \
+  pulsar2 build --target_hardware AX650 \
+  --input model/resnet18d.onnx --output_dir output/resnet18d_trace \
+  --config config/resnet18d_build_config.json \
+  --compiler.npu_perf --debug.dump_frontend_graph
+```
+
+This needs a real `pulsar2 build`, not just a compiled `.axmodel` -- it's
+generated at compile time from the cycle model, not measured live on-device
+by `axcl_run_model`/`ax_run_model` (those only report aggregate min/max/avg
+latency). **Automated**: `convert_onnxmodelzoo.py --profile` passes this
+through automatically (see below); see Pulsar2's own docs
+(`other_tools/profiling.html`) for the full trace-UI reference.
+
+## Real Docker + device conversion driver
+
+`pulsar2_docker.py` and `convert_onnxmodelzoo.py` turn the manual
+`docker run ... pulsar2 build` / `axcl_run_model` commands used to produce
+every real finding in this README into a reusable pipeline. Unlike
+`screen_onnxmodelzoo.py` (static, no Docker/device needed -- run that
+first), this does a **real** compile per model, so it needs a loaded Pulsar2
+Docker image (see `pulsar2_docker.py`'s docstring for how to get one
+matching your device's firmware) and, optionally, a connected AXCL device.
+
+```bash
+python scripts/axera/convert_onnxmodelzoo.py \
+  --models resnet18d_Opset18 googlenet-6 \
+  --profile \
+  --output pulsar2-convert.csv
+```
+
+For each model: fetches it, `onnxsim.simplify()`s it, `pulsar2 build`s both
+the original and simplified ONNX (with `--profile` passing
+`--compiler.npu_perf --debug.dump_frontend_graph` through, writing a
+`trace.json` per successful build -- see above), and if a device answers,
+runs both `.axmodel`s on it with the same input and reports whether the raw
+output bytes are bit-identical (this is exactly how the `resnet18d`
+bit-identical result in this README was produced). Models are skipped
+(`skipped_not_single_image_input`) unless they have exactly one rank-4
+input -- NLP/multi-input models need a hand-written config passed to
+`pulsar2_docker.build(config_path=...)` directly instead.
+
+One real gotcha worth knowing if you extend this: the Pulsar2 Docker image
+must run as root (confirmed: `-u $(id -u):$(id -g)` breaks it -- it needs
+root-owned `/root/*.hasplm`/`*.v2c` license files, and a uid absent from the
+container's `/etc/passwd` breaks `getpass.getuser()` deep inside a
+torchvision import in `pulsar2 version`'s own code path), so everything it
+writes under a mounted `work_dir` is root-owned. `pulsar2_docker.
+force_rmtree()` handles that (plain `shutil.rmtree` as the host user, falling
+back to `docker run --entrypoint /bin/sh <image> -c "rm -rf ..."` on
+`PermissionError`) -- use it instead of `shutil.rmtree` for anything under a
+Pulsar2 Docker work dir, or root-owned directories accumulate in `/tmp` with
+no way for an ordinary user to remove them.
+
+Also note `axcl_run_model -i/-o/-l`'s exact contract, confirmed by trial:
+**the input filename must equal the tensor name** (`<in>/0/<tensor_name>.bin`
+-- an arbitrary filename fails with "Stimulus file ... is not exist" naming
+the tensor). `pulsar2_docker.run_on_device_with_input()` already does this.
+
+## Files
+
+| file | purpose |
+| --- | --- |
+| `pulsar2_ops.py` | the heuristics and confirmed data: `AX650_SUPPORTED_OPS`/`AX650_MIN_OPSET` (the real, docs-scraped AX650 op list), `CPU_ONLY_OPS` (generic cross-vendor guess), the confirmed `AXERA_NPU_OP_TYPE = "neu mode"` marker, `referenced_const_data_keys()`/`missing_npu_data()`/`has_out_of_band_npu_data()` (the corruption detector), and non-standard-`domain` detection as a fallback for vendor blobs that don't follow Axera's exact convention. |
+| `pulsar2_backend.py` | thin wrapper around `pulsar2_ops.py`: `coverage()`, `new_blocking_op_types()`, `stripped_npu_data()`, `unsafe_for_simplify()`, `ax650_build_risks()`. Shaped like the sibling `*_backend.py` modules for interface symmetry (`PULSAR2_AVAILABLE` is always `True` -- there's no external dependency to be missing). |
+| `inspect_axmodel.py` | standalone CLI for a **real** `.axmodel` file: loads it with `onnx.load()`, then reports non-standard-domain nodes, op types outside the model's declared opset, and suspiciously large raw attributes -- what originally found the `neu mode` node in the real YOLOv8 file. |
+| `models.py` | the shared `scripts/common/synthetic_models.py` suite plus `axera_npu_compiled_leaf`, a synthetic reproduction of the real `neu mode` node shape (no real device needed to exercise the corruption check in CI). |
+| `pulsar2_quantizer.py` | `quantize_like_pulsar2()`: a Docker/device-free INT8 PTQ matching Pulsar2's real numeric convention (U8 asymmetric activations, S8 per-channel weights, MinMax calibration), via `onnxruntime.quantization`. Degrades gracefully (`PULSAR2_QUANTIZER_AVAILABLE`) without `onnxruntime`. |
+| `pulsar2_simulator.py` | `partition()`/`coverage()` (real `AX650_SUPPORTED_OPS` membership, no dependency beyond `onnx`) and `simulate()` (fp32-vs-INT8 estimate via `pulsar2_quantizer.py` + onnxruntime's CPU EP). Validated against real hardware -- see above. |
+| `worker.py` | runs the check for one model in an isolated subprocess, printing one `__RESULT__<json>` line. |
+| `run_pulsar2_compat.py` | drives the suite, writes a CSV, and exits non-zero on any regression. No `--require-*` flag or `skipped` status -- unlike the EP harnesses, this needs no vendor package or device, so it always runs. |
+| `screen_onnxmodelzoo.py` | fast, static, Docker/device-free screening of `onnxmodelzoo` models via `pulsar2_simulator`/`pulsar2_backend.ax650_build_risks()` -- run this first. |
+| `pulsar2_docker.py` | real `pulsar2 build` (Docker) + `axcl_run_model` (device) wrapper: `build()` (with `profile=` for `trace.json`), `run_on_device()`, `run_on_device_with_input()`, `force_rmtree()`. Manual/local-only -- needs a loaded Docker image, not wired into any CI workflow. |
+| `convert_onnxmodelzoo.py` | batch driver over `pulsar2_docker.py`: fetch -> onnxsim -> real `pulsar2 build` (orig + simplified, `--profile` optional) -> optional on-device bit-exact diff -> CSV. |
+
+## Running locally
+
+No extra install beyond onnxsim itself:
+
+```bash
+pip install .   # or install an onnxsim wheel
+
+python scripts/axera/run_pulsar2_compat.py --output pulsar2-compat.csv
+```
+
+To inspect a real compiled model (and check it for the corruption risk
+above before considering running it through onnxsim):
+
+```bash
+python scripts/axera/inspect_axmodel.py path/to/compiled.axmodel
+```
+
+The in-tree smoke test `tests/test_pulsar2_compat.py` reuses this harness and
+needs nothing beyond onnxsim's normal test dependencies (it isn't
+skip-guarded like the EP compat tests, since there's no external dependency
+to be missing). `tests/test_pulsar2_simulator.py` covers the simulator +
+quantizer; its `partition()`/`coverage()` tests are likewise unguarded, but
+`simulate()`/`quantize_like_pulsar2()` need `onnxruntime` and skip without it.
+
+To get a fast partition/coverage read or a quantization-noise estimate for a
+model, with no Docker or device:
+
+```python
+import onnx
+from pulsar2_simulator import coverage, simulate  # scripts/axera/
+
+model = onnx.load("model.onnx")
+print(coverage(model))          # "full" / "partial" / "none"
+print(simulate(model)["close"]) # fp32 vs. simulated-INT8, roughly sane?
+```
+
+## Extending
+
+- If the real device/toolchain becomes available again: automate the manual
+  `pulsar2 build` + `axcl_run_model -i/-o/-l` (bit-identical output diff)
+  flow used for the `resnet18d`/`googlenet-6` conversions above into a real
+  `scripts/axera/pulsar2_docker.py` backend, so `worker.py` can do actual
+  compiles instead of only the static `ax650_build_risks()` prediction. The
+  input/output folder layout for on-device numeric verification is
+  `<dir>/0/<name>.bin` + a `list.txt` containing `0` -- see this README's
+  git history / session notes for the exact commands used.
+- `AX650_SUPPORTED_OPS` only covers AX650; the same docs site has op lists
+  for AX620E/AX615/M57/AX637 (`appendix/op_support_list_<chip>.html`) if
+  support for those chips is ever needed.
+- The real fix belongs in onnxsim itself (or its vendored onnx-optimizer
+  fork): some way to mark an initializer as "referenced, don't touch" beyond
+  "is a declared node input" -- e.g. recognizing the custom-op placeholder
+  schema `model_prep.cpp` already registers for nodes like `neu mode` and
+  treating *all* of a model's initializers as roots whenever any such node is
+  present, rather than only the ones it happens to declare as inputs.
+- `models.py`'s shared suite is intentionally small and self-contained so the
+  CI job needs no downloads; a real `.onnx` (pre-`pulsar2 build`) model can be
+  layered on by passing an on-disk path as `worker.py`'s second argument, the
+  same way `scripts/qualcomm` and `scripts/regression` do.

--- a/scripts/axera/_local_import.py
+++ b/scripts/axera/_local_import.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Fixes a real cross-vendor test collision on the bare names "models"/"worker".
+
+``scripts/qualcomm``, ``scripts/intel``, ``scripts/amd``, ``scripts/apple``,
+and ``scripts/axera`` each carry their own ``models.py`` (and the first four
+also carry their own ``worker.py``), and each vendor's test file
+(``tests/test_*_compat.py``) does the same dance: prepend its own
+``scripts/<vendor>`` dir to ``sys.path``, then ``import models`` (or ``from
+worker import check``) by its bare name. That is fine as long as each
+vendor's test file runs in its own process -- but the default test suite
+(``pytest tests/``) collects *all* of them into one process, and Python
+caches imported modules by bare name in ``sys.modules``: whichever vendor's
+``models.py`` gets imported *first* (at collection time, even if that
+vendor's tests are then skipped -- the module-level ``import models``
+statement still runs) stays cached under the name ``"models"`` for the rest
+of the process. Every other vendor's later ``import models`` silently reuses
+that first one instead of its own.
+
+This went unnoticed because every pre-existing vendor ``models.py`` is a
+thin, functionally-identical alias for the same ``scripts/common/
+synthetic_models.py`` suite -- getting "the wrong vendor's models.py" changed
+nothing observable. It became a real, visible bug the moment
+``scripts/axera/models.py`` added something the others don't have
+(``axera_npu_compiled_leaf``): whichever vendor test file collected first
+poisoned ``sys.modules["models"]``, and axera's own `models.build(...)` and
+`worker.check(...)` calls (both reached in-process, not via a subprocess)
+silently ran against a different vendor's module instead.
+
+:func:`fresh` forces a real import from a specific directory regardless of
+what is already cached under that bare name.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from types import ModuleType
+
+
+def fresh(name: str, directory: str) -> ModuleType:
+    """Import ``name`` from ``directory``, ignoring a same-named module
+    already cached in ``sys.modules`` from a different directory.
+
+    ``directory`` must already be on ``sys.path`` (callers here always
+    prepend their own ``HERE`` before calling this).
+    """
+    cached = sys.modules.get(name)
+    if cached is not None:
+        cached_file = getattr(cached, "__file__", None)
+        if (
+            cached_file is None
+            or os.path.dirname(os.path.abspath(cached_file)) != directory
+        ):
+            del sys.modules[name]
+    return importlib.import_module(name)

--- a/scripts/axera/convert_onnxmodelzoo.py
+++ b/scripts/axera/convert_onnxmodelzoo.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Real end-to-end conversion: `onnxmodelzoo` model -> onnxsim -> `pulsar2
+build` (Docker) -> optionally run on a real AXCL device. Optionally profile.
+
+This is the manual `resnet18d_Opset18`/`googlenet-6` workflow from
+`pulsar2_ops.py`'s docstring, turned into a reusable batch driver over
+`pulsar2_docker.py`. Unlike `screen_onnxmodelzoo.py` (fast, static,
+Docker/device-free -- run that first), this does a **real** compile per
+model and needs a loaded Pulsar2 Docker image (see `pulsar2_docker.py`'s
+docstring for how to get one). A connected AXCL device is optional; without
+one, latency/on-device diff columns are left blank.
+
+For each model:
+
+1. Fetch the ONNX (`scripts/regression/model_zoo.py`).
+2. Skip (status `skipped_not_single_image_input`) unless it has exactly one
+   non-initializer input of rank 4 -- this driver only knows the
+   single-image-classifier config shape (see `pulsar2_docker.py`'s
+   `_image_classifier_config`); a model with a different input shape needs
+   a hand-written config and `pulsar2_docker.build(config_path=...)` used
+   directly instead.
+2. `onnxsim.simplify()` it.
+3. `pulsar2 build --target_hardware AX650` both the original and the
+   simplified ONNX, with `--profile` passing through to
+   `pulsar2_docker.build(profile=...)` -- writes a `chrome://tracing`
+   `trace.json` per build when set (see README's "Real NPU profiling").
+4. If both compiled and a device is available: run both on-device with the
+   same random input and diff the raw output bytes -- bit-identical is the
+   expected, confirmed-safe result (see `pulsar2_ops.py`'s docstring).
+
+Usage:
+    python convert_onnxmodelzoo.py --models resnet18d_Opset18 --profile
+    python convert_onnxmodelzoo.py --models resnet18d_Opset18 googlenet-6 \\
+        --work-dir /tmp/pulsar2_work --output pulsar2-convert.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import shutil
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+_REGRESSION_DIR = os.path.join(os.path.dirname(HERE), "regression")
+if _REGRESSION_DIR not in sys.path:
+    sys.path.insert(0, _REGRESSION_DIR)
+
+# Generic ImageNet-style normalization -- a reasonable default for
+# compatibility testing (does it compile? does onnxsim change the result?),
+# not tuned per-model for deployment accuracy. See pulsar2_docker.py.
+_DEFAULT_MEAN = [123.675, 116.28, 103.53]
+_DEFAULT_STD = [58.395, 57.12, 57.375]
+
+
+def _single_image_input(model) -> "str | None":
+    """Return the input tensor's name if `model` has exactly one
+    non-initializer input of rank 4 (a plausible single-image classifier
+    input), else None. Doesn't attempt to guess NCHW vs. NHWC -- the
+    `_image_classifier_config` shape declares `src_layout: "NHWC"` for the
+    *raw camera-like* input Pulsar2's preprocessing produces, which is
+    independent of what layout the ONNX graph itself expects internally.
+    """
+    initializers = {i.name for i in model.graph.initializer}
+    inputs = [i for i in model.graph.input if i.name not in initializers]
+    if len(inputs) != 1:
+        return None
+    dims = inputs[0].type.tensor_type.shape.dim
+    if len(dims) != 4:
+        return None
+    return inputs[0].name
+
+
+def convert_one(
+    name: str,
+    work_dir: str,
+    *,
+    profile: bool,
+    run_device: bool,
+    target_hardware: str,
+    image: str,
+) -> dict:
+    import numpy as np
+    import onnx
+
+    import model_zoo
+    import pulsar2_docker as pd
+
+    res = {
+        "model": name,
+        "status": "error",
+        "orig_success": None,
+        "orig_max_cycle": None,
+        "orig_fused_subgraphs": None,
+        "orig_trace": None,
+        "simp_success": None,
+        "simp_max_cycle": None,
+        "simp_fused_subgraphs": None,
+        "simp_trace": None,
+        "device_bit_identical": None,
+        "error": None,
+    }
+    try:
+        path = model_zoo.fetch_model(name)
+        model = onnx.load(path)
+
+        tensor_name = _single_image_input(model)
+        if tensor_name is None:
+            res["status"] = "skipped_not_single_image_input"
+            return res
+
+        from onnxsim import simplify
+
+        simp, _ = simplify(model)
+
+        model_dir = os.path.join(work_dir, "model")
+        dataset_dir = os.path.join(work_dir, "dataset")
+        os.makedirs(model_dir, exist_ok=True)
+        os.makedirs(dataset_dir, exist_ok=True)
+        calib_tar = os.path.join(dataset_dir, "calib.tar")
+        if not os.path.exists(calib_tar):
+            pd.make_synthetic_calibration_tar(calib_tar)
+
+        orig_rel = f"model/{name}_orig.onnx"
+        simp_rel = f"model/{name}_simp.onnx"
+        onnx.save(model, os.path.join(work_dir, orig_rel))
+        onnx.save(simp, os.path.join(work_dir, simp_rel))
+
+        build_kwargs = dict(
+            tensor_name=tensor_name,
+            mean=_DEFAULT_MEAN,
+            std=_DEFAULT_STD,
+            calibration_dataset_rel_path="dataset/calib.tar",
+            target_hardware=target_hardware,
+            image=image,
+            profile=profile,
+        )
+        orig_result = pd.build(
+            work_dir, orig_rel, f"output/{name}_orig", **build_kwargs
+        )
+        simp_result = pd.build(
+            work_dir, simp_rel, f"output/{name}_simp", **build_kwargs
+        )
+
+        res["orig_success"] = orig_result.success
+        res["orig_max_cycle"] = orig_result.max_cycle
+        res["orig_fused_subgraphs"] = orig_result.fused_subgraphs
+        res["orig_trace"] = orig_result.trace_path
+        res["simp_success"] = simp_result.success
+        res["simp_max_cycle"] = simp_result.max_cycle
+        res["simp_fused_subgraphs"] = simp_result.fused_subgraphs
+        res["simp_trace"] = simp_result.trace_path
+
+        if not orig_result.success:
+            res["status"] = "orig_build_failed"
+            res["error"] = orig_result.error
+            return res
+        if not simp_result.success:
+            res["status"] = "simp_build_failed"
+            res["error"] = simp_result.error
+            return res
+
+        if run_device and pd.axcl_available():
+            rng = np.random.RandomState(0)
+            # Rough default: a single-image-classifier input is normally
+            # small enough for a raw uint8 NHWC buffer at a common size; if
+            # the model's real input resolution differs, this comparison is
+            # skipped rather than guessed at.
+            input_bytes = rng.randint(0, 256, 224 * 224 * 3, dtype=np.uint8).tobytes()
+            orig_out = pd.run_on_device_with_input(
+                orig_result.axmodel_path, tensor_name, input_bytes
+            )
+            simp_out = pd.run_on_device_with_input(
+                simp_result.axmodel_path, tensor_name, input_bytes
+            )
+            if orig_out is not None and simp_out is not None:
+                res["device_bit_identical"] = orig_out == simp_out
+
+        res["status"] = "ok"
+    except Exception as exc:
+        res["error"] = f"{type(exc).__name__}: {exc}"
+    return res
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--models", nargs="+", required=True, help="model short names")
+    ap.add_argument(
+        "--work-dir", default=None, help="Docker mount dir (default: a temp dir)"
+    )
+    ap.add_argument(
+        "--profile",
+        action="store_true",
+        help="pass --compiler.npu_perf --debug.dump_frontend_graph to pulsar2 build",
+    )
+    ap.add_argument(
+        "--no-device", action="store_true", help="skip the on-device bit-exact check"
+    )
+    ap.add_argument("--target-hardware", default="AX650")
+    ap.add_argument("--image", default="pulsar2:6.0-lite")
+    ap.add_argument("--output", default="pulsar2-convert.csv")
+    ap.add_argument(
+        "--keep-work-dir",
+        action="store_true",
+        help="don't delete an auto-created temp work dir afterward",
+    )
+    args = ap.parse_args()
+
+    import pulsar2_docker as pd
+
+    if not pd.docker_image_available(args.image):
+        print(f"error: Docker image not loaded: {args.image}", file=sys.stderr)
+        print(
+            "load one first: docker load -i ax_pulsar2_<version>_lite.tar.gz "
+            "(see pulsar2_docker.py's docstring)",
+            file=sys.stderr,
+        )
+        return 1
+
+    work_dir = args.work_dir
+    made_temp = False
+    if work_dir is None:
+        import tempfile
+
+        work_dir = tempfile.mkdtemp(prefix="pulsar2_convert_")
+        made_temp = True
+    os.makedirs(work_dir, exist_ok=True)
+
+    print(f"work dir: {work_dir}")
+    if args.profile:
+        print("profiling enabled: trace.json will be written per successful build")
+
+    rows = []
+    for i, name in enumerate(args.models, 1):
+        print(f"[{i}/{len(args.models)}] {name} ...", flush=True)
+        r = convert_one(
+            name,
+            work_dir,
+            profile=args.profile,
+            run_device=not args.no_device,
+            target_hardware=args.target_hardware,
+            image=args.image,
+        )
+        rows.append(r)
+        print(f"  status={r['status']}", flush=True)
+        if r["orig_trace"]:
+            print(f"  orig trace: {r['orig_trace']}", flush=True)
+        if r["simp_trace"]:
+            print(f"  simp trace: {r['simp_trace']}", flush=True)
+        if r["device_bit_identical"] is not None:
+            print(f"  device bit-identical: {r['device_bit_identical']}", flush=True)
+        if r["error"]:
+            print(f"  error: {str(r['error'])[:300]}", flush=True)
+
+    fields = list(rows[0].keys()) if rows else []
+    with open(args.output, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fields, extrasaction="ignore")
+        w.writeheader()
+        for r in rows:
+            w.writerow(r)
+    print(f"\nwrote {args.output} ({len(rows)} rows)")
+
+    if made_temp and not args.keep_work_dir:
+        # Only output/ is root-owned (written by pulsar2 build inside
+        # Docker -- see pulsar2_docker.force_rmtree()'s docstring); model/,
+        # dataset/, config/ are host-owned (written directly by this
+        # script) and come off cleanly with a plain rmtree afterward.
+        output_dir = os.path.join(work_dir, "output")
+        if os.path.exists(output_dir):
+            pd.force_rmtree(output_dir, work_dir, args.image)
+        shutil.rmtree(work_dir, ignore_errors=True)
+    else:
+        print(f"work dir kept at: {work_dir}")
+
+    failures = [
+        r for r in rows if r["status"] not in ("ok", "skipped_not_single_image_input")
+    ]
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/axera/inspect_axmodel.py
+++ b/scripts/axera/inspect_axmodel.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Inspect a real Axera `.axmodel` file for the CPU/NPU boundary markers.
+
+Implements steps 2-4 of "Immediate next steps" in
+`../../../junk/axcl-axmodel-onnxsim-notes.md`, the handoff notes this whole
+`scripts/axera/` harness is based on: as of writing **no real `.axmodel` has
+been inspected**, so this script exists to actually do that the moment one is
+available, rather than continuing to guess.
+
+It:
+
+1. Loads the file with plain ``onnx.load()`` -- confirms it parses as a
+   standard ``ModelProto`` at all (the notes' §2: the container is claimed to
+   be plain ONNX protobuf, e.g. `onnx inspect -m -n -t` works on it directly
+   -- this is the first real test of that claim).
+2. Reports any node with a non-standard `domain` (ONNX's documented mechanism
+   for vendor extensions -- the likely home of an embedded NPU blob, notes §4).
+3. Reports node op_types outside the standard ONNX operator set for the
+   model's declared opset.
+4. Reports attributes with suspiciously large raw payload (tensor bytes or a
+   raw `bytes`/`strings` attribute) -- a likely embedded NPU command stream.
+
+None of this is guaranteed to find the actual boundary marker -- the exact
+schema is unknown per the notes' open questions -- but it's the concrete,
+falsifiable first step the notes call for, and its output is exactly what's
+needed to fill in `pulsar2_ops.py`'s heuristics with real data.
+
+Usage:
+    python inspect_axmodel.py path/to/compiled.axmodel
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import onnx
+from onnx import defs
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+from pulsar2_ops import STANDARD_DOMAINS  # noqa: E402
+
+# Attribute payloads larger than this are called out as a likely embedded
+# NPU blob rather than an ordinary weight/constant. Chosen generously above
+# typical small conv/gemm bias tensors; tune once a real file shows what
+# "ordinary large weight" vs. "NPU command stream" actually looks like here.
+_LARGE_ATTR_BYTES = 64 * 1024
+
+
+def _standard_op_types(opset_version: int) -> set:
+    types = set()
+    for schema in defs.get_all_schemas_with_history():
+        if schema.domain == "" and schema.since_version <= opset_version:
+            types.add(schema.name)
+    return types
+
+
+def _attr_byte_size(attr: onnx.AttributeProto) -> int:
+    if attr.HasField("t"):
+        return len(attr.t.raw_data) or sum(
+            len(getattr(attr.t, f))
+            for f in (
+                "float_data",
+                "int32_data",
+                "string_data",
+                "int64_data",
+                "double_data",
+                "uint64_data",
+            )
+        )
+    if attr.strings:
+        return sum(len(s) for s in attr.strings)
+    if attr.HasField("s"):
+        return len(attr.s)
+    return 0
+
+
+def inspect(path: str) -> int:
+    print(f"loading {path} with onnx.load() ...")
+    model = onnx.load(path, load_external_data=False)
+    print(f"  OK -- parsed as a standard ModelProto, ir_version={model.ir_version}")
+
+    opset_version = 0
+    for opset in model.opset_import:
+        if opset.domain in ("", "ai.onnx"):
+            opset_version = max(opset_version, opset.version)
+    print(f"  opset (default domain): {opset_version}")
+    standard_ops = _standard_op_types(opset_version) if opset_version else set()
+
+    custom_domain_nodes = []
+    nonstandard_ops = []
+    large_attrs = []
+
+    def visit(graph: onnx.GraphProto, path_prefix: str) -> None:
+        for node in graph.node:
+            label = f"{path_prefix}{node.name or node.op_type}"
+            if node.domain not in STANDARD_DOMAINS:
+                custom_domain_nodes.append((label, node.op_type, node.domain))
+            elif standard_ops and node.op_type not in standard_ops:
+                nonstandard_ops.append((label, node.op_type))
+            for attr in node.attribute:
+                size = _attr_byte_size(attr)
+                if size > _LARGE_ATTR_BYTES:
+                    large_attrs.append((label, attr.name, size))
+                if attr.HasField("g"):
+                    visit(attr.g, f"{label}/{attr.name}/")
+                for sub_g in attr.graphs:
+                    visit(sub_g, f"{label}/{attr.name}/")
+
+    visit(model.graph, "")
+
+    print(f"\nnodes with a non-standard domain: {len(custom_domain_nodes)}")
+    for label, op_type, domain in custom_domain_nodes[:50]:
+        print(f"  {label}: op_type={op_type!r} domain={domain!r}")
+
+    print(
+        f"\nnode op_types outside the standard opset {opset_version}: "
+        f"{len(nonstandard_ops)}"
+    )
+    for label, op_type in nonstandard_ops[:50]:
+        print(f"  {label}: op_type={op_type!r}")
+
+    print(
+        f"\nattributes larger than {_LARGE_ATTR_BYTES} bytes "
+        f"(candidate NPU blobs): {len(large_attrs)}"
+    )
+    for label, attr_name, size in sorted(large_attrs, key=lambda t: -t[2])[:50]:
+        print(f"  {label}: attribute={attr_name!r} size={size} bytes")
+
+    if not (custom_domain_nodes or nonstandard_ops or large_attrs):
+        print(
+            "\nNo boundary markers found by these heuristics -- either this "
+            "file has no NPU subgraphs (e.g. a CPU-only/reference export), or "
+            "the real scheme doesn't match what this script looks for. Time "
+            "to open the file in `onnx inspect` / a hex viewer by hand."
+        )
+        return 1
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("axmodel_path")
+    args = ap.parse_args()
+    return inspect(args.axmodel_path)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/axera/models.py
+++ b/scripts/axera/models.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Axera-side model suite: the shared suite plus one Axera-specific fixture.
+
+Re-exports `scripts/common/synthetic_models.py` (see that module) and adds
+`axera_npu_compiled_leaf`, a minimal synthetic reproduction of the *real*
+compiled-NPU-subgraph node shape confirmed against an actual AX650N and a
+real `AXERA-TECH/YOLOv8` `.axmodel` (see `pulsar2_ops.py`'s docstring): a
+single `op_type="neu mode"` node whose only declared input is the graph
+input, with an initializer it depends on purely via a JSON-encoded attribute
+reference rather than a graph edge. This exercises
+`pulsar2_ops.has_out_of_band_npu_data` / `missing_npu_data` and the
+`pulsar2_unsafe_for_simplify` worker path in CI, without needing the real
+device.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import numpy as np
+import onnx
+from onnx import TensorProto, helper, numpy_helper
+
+_SCRIPTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# Only keep scripts/ on sys.path for the duration of this import: scripts/
+# also holds directories like rfdetr/ with no __init__.py, which Python 3
+# treats as importable namespace packages. Leaving scripts/ on sys.path for
+# the rest of the process would make `import rfdetr` "succeed" as that empty
+# namespace package instead of skipping via pytest.importorskip, and shadow
+# the real one everywhere else it's checked for.
+_inserted = _SCRIPTS_DIR not in sys.path
+if _inserted:
+    sys.path.insert(0, _SCRIPTS_DIR)
+try:
+    from common.synthetic_models import (  # noqa: E402,F401
+        all_models as _shared_all_models,
+        build as _shared_build,
+        conv_bn_relu,
+        foldable_shape_reshape,
+        matmul_bias_tanh,
+        names as _shared_names,
+        redundant_transpose,
+        sigmoid_mul_swish,
+    )
+finally:
+    if _inserted:
+        sys.path.remove(_SCRIPTS_DIR)
+
+_AXERA_LEAF_NAME = "axera_npu_compiled_leaf"
+
+
+def axera_npu_compiled_leaf() -> onnx.ModelProto:
+    """Reproduces the real `neu mode` node shape (see this module's docstring).
+
+    Deliberately not run through `onnx.checker.check_model`: `neu mode` has
+    no registered schema (that's the point), same as the real file, which
+    onnxsim itself only accepts via its own custom-operator tolerance, not
+    plain ``onnx.checker``.
+    """
+    params = numpy_helper.from_array(np.zeros(64, dtype=np.uint8), "npu_params")
+    graph_info = json.dumps(
+        {
+            "name": "leaf",
+            "dotneus": [
+                {
+                    "neu_key": "npu_params",
+                    "batch": 1,
+                    "extra_inputs": [
+                        {"name": "params", "const_data_key": "npu_params"}
+                    ],
+                }
+            ],
+        }
+    )
+    outputs_info = json.dumps({"y": ["FP32", [1, 4]]})
+    node = helper.make_node(
+        "neu mode",
+        ["x"],
+        ["y"],
+        name="leaf",
+        neu_name="leaf",
+        npu_graph_info=graph_info,
+        outputs_info=outputs_info,
+        version=1,
+    )
+    graph = helper.make_graph(
+        [node],
+        _AXERA_LEAF_NAME,
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 4])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 4])],
+        [params],
+    )
+    return helper.make_model(
+        graph, opset_imports=[helper.make_opsetid("", 18)], ir_version=10
+    )
+
+
+def names() -> list:
+    return [*_shared_names(), _AXERA_LEAF_NAME]
+
+
+def build(name: str) -> onnx.ModelProto:
+    if name == _AXERA_LEAF_NAME:
+        return axera_npu_compiled_leaf()
+    return _shared_build(name)
+
+
+def all_models() -> dict:
+    return {**_shared_all_models(), _AXERA_LEAF_NAME: axera_npu_compiled_leaf()}
+
+
+if __name__ == "__main__":
+    for n, m in all_models().items():
+        print(f"{n:24} {len(m.graph.node)} nodes")

--- a/scripts/axera/pulsar2_backend.py
+++ b/scripts/axera/pulsar2_backend.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Static Pulsar2 (Axera AXCL NPU) coverage check -- no compiler, no device.
+
+Unlike `scripts/qualcomm/qnn_backend.py`, `scripts/intel/openvino_backend.py`
+and `scripts/amd/migraphx_backend.py`, this module wraps no real compiler:
+Pulsar2 has no pip package and no ONNX Runtime execution provider to invoke,
+so there is nothing to install or emulate here (see `pulsar2_ops.py`'s
+docstring for why). ``PULSAR2_AVAILABLE`` is always True and this always runs
+on a plain CPU host with only ``onnx`` installed -- it exists for interface
+symmetry with the sibling EP backends, not because availability can vary.
+
+What this *can* do without a real compiler: flag when onnxsim turns a graph
+region that had no known Pulsar2-NPU blocker into one that does (see
+`pulsar2_ops.blocking_ops`). That is the concrete risk §4(b) of the handoff
+notes calls out -- a simplification could fold something into a form the NPU
+partitioner then refuses, silently pushing more of the graph onto Pulsar2's
+CPU fallback path.
+
+It can also catch something worse, confirmed against a real AX650N and a
+real compiled `.axmodel`: `stripped_npu_data()` detects when onnxsim has
+dropped a `neu mode` node's NPU weight/command blob because Axera references
+it only by name inside a JSON attribute, not as a declared graph input (see
+`pulsar2_ops.missing_npu_data`). That isn't a coverage regression, it's
+outright file corruption -- the resulting `.axmodel` fails to even load, and
+no combination of `simplify()`'s public parameters was found to avoid it
+(see `pulsar2_ops.has_out_of_band_npu_data`, meant to be checked *before*
+calling `simplify()` at all -- right now the only confirmed-safe answer for a
+model that already has NPU subgraph nodes is not to run it through onnxsim).
+
+`ax650_build_risks()` uses Axera's own published AX650 op list plus a real
+`pulsar2:6.0-lite` + AX650N run to flag likely hard build failures ahead of
+time (see `pulsar2_ops.py`'s docstring for the real `resnet18d`/`googlenet-6`
+conversions this is based on).
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import onnx
+
+from pulsar2_ops import (
+    AX650_MIN_OPSET,
+    BlockingOp,
+    below_ax650_min_opset,
+    blocking_op_types,
+    blocking_ops,
+    has_out_of_band_npu_data,
+    missing_npu_data,
+    opset_version,
+    unsupported_on_ax650,
+)
+
+PULSAR2_AVAILABLE = True
+
+
+def unavailable_reason() -> None:
+    """Always None: this check has no external dependency to be missing."""
+    return None
+
+
+def coverage(model: onnx.ModelProto) -> str:
+    """ "full" if no known Pulsar2-NPU blocker was found, else "partial".
+
+    "full" here means "this harness found no reason Pulsar2 would reject
+    part of the graph" -- a heuristic, not a guarantee the whole graph maps
+    onto the NPU (see this module's docstring).
+    """
+    return "partial" if blocking_ops(model) else "full"
+
+
+def blockers(model: onnx.ModelProto) -> List[BlockingOp]:
+    return blocking_ops(model)
+
+
+def new_blocking_op_types(orig: onnx.ModelProto, simp: onnx.ModelProto) -> set:
+    """Blocking op types present after simplification but not before.
+
+    An empty result does not mean simplification is Pulsar2-safe overall --
+    only that it did not *introduce* a new known-blocking op type relative to
+    the original graph.
+    """
+    return blocking_op_types(simp) - blocking_op_types(orig)
+
+
+def stripped_npu_data(simp: onnx.ModelProto) -> set:
+    """NPU weight/command initializer names a `neu mode` node needs but lost.
+
+    Non-empty means the simplified model is broken, not just less
+    NPU-friendly -- see this module's docstring.
+    """
+    return missing_npu_data(simp)
+
+
+def unsafe_for_simplify(model: onnx.ModelProto) -> bool:
+    """True if `model` should not be passed to `onnxsim.simplify()` at all.
+
+    Pre-flight version of `stripped_npu_data()` -- call this first and skip
+    simplification entirely rather than simplifying and checking after.
+    """
+    return has_out_of_band_npu_data(model)
+
+
+def ax650_build_risks(model: onnx.ModelProto) -> List[str]:
+    """Human-readable reasons `pulsar2 build --target_hardware AX650` might
+    reject `model` outright, confirmed against the real toolchain + device:
+
+    - an op type outside `pulsar2_ops.AX650_SUPPORTED_OPS` (confirmed for
+      `LRN`: a hard frontend parse failure, not a graceful CPU fallback);
+    - an opset below `pulsar2_ops.AX650_MIN_OPSET` (11), which Pulsar2's own
+      docs state as a hard requirement.
+
+    Empty does not guarantee a successful build -- only that this harness
+    found none of the specific risks it currently knows to check for.
+    """
+    risks = []
+    unsupported = sorted(unsupported_on_ax650(model))
+    if unsupported:
+        note = (
+            " -- LRN specifically is a confirmed hard build failure, not a "
+            "CPU fallback; the others here are untested"
+            if "LRN" in unsupported
+            else " (untested here whether pulsar2 build hard-fails on these "
+            "or falls back to CPU -- only LRN has been confirmed to hard-fail)"
+        )
+        risks.append(
+            f"op type(s) not on the confirmed AX650 op list: {unsupported}{note}"
+        )
+    if below_ax650_min_opset(model):
+        risks.append(
+            f"opset {opset_version(model)} is below Pulsar2's documented "
+            f"minimum of {AX650_MIN_OPSET} for AX650"
+        )
+    return risks

--- a/scripts/axera/pulsar2_docker.py
+++ b/scripts/axera/pulsar2_docker.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Real `pulsar2 build` wrapper -- Docker + (optionally) a real AXCL device.
+
+Unlike `pulsar2_backend.py`/`pulsar2_simulator.py` (static/estimated, no
+Docker or device needed -- see their docstrings for why), this module
+actually shells out to a real Pulsar2 Docker image and, optionally, a real
+device via `axcl_run_model`. It exists because a real toolchain + AX650N
+*was* available in the session that produced the confirmed data in
+`pulsar2_ops.py`'s docstring: `resnet18d_Opset18` built cleanly and matched
+bit-for-bit on real hardware before/after onnxsim simplification;
+`googlenet-6` hard-failed on `LRN`. This module is what did that manually,
+turned into a reusable wrapper.
+
+**Requires a local Docker image already loaded** (`docker load -i
+ax_pulsar2_<version>_lite.tar.gz`, from
+https://huggingface.co/AXERA-TECH/Pulsar2 -- match the version
+`axcl-smi`/`axcl_run_model`'s `pulsar2 ver:` line reports for your device)
+and, for `run_on_device()`, a connected AXCL device (`axcl-smi` to check).
+Neither is available in ordinary CI -- this is a manual/local-only tool, not
+wired into `run_pulsar2_compat.py`.
+
+**Profiling** (`profile=True` on `build()`): passes Pulsar2's own
+`--compiler.npu_perf --debug.dump_frontend_graph` flags. Confirmed real: the
+build then writes a standard Chrome Trace Event Format `trace.json` under
+`<output_dir>/compiler/debug/subgraph_npu_0/b1/trace.json` (load it at
+`chrome://tracing`) plus a flat `op_profile.csv` next to it, and dumps the
+optimized quantized graph to `<output_dir>/frontend/
+optimized_quant_axmodel.onnx` (open in Netron) so trace task labels can be
+matched back to op names. See `README.md`'s "Real NPU profiling" section.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+import re
+import shutil
+import subprocess
+import tarfile
+import tempfile
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence
+
+DEFAULT_IMAGE = "pulsar2:6.0-lite"
+
+_MAX_CYCLE_RE = re.compile(r"max_cycle\s*=\s*([\d,]+)")
+_FUSE_RE = re.compile(r"fuse (\d+) subgraph\(s\)")
+
+
+def docker_image_available(image: str = DEFAULT_IMAGE) -> bool:
+    proc = subprocess.run(
+        ["docker", "image", "inspect", image], capture_output=True, text=True
+    )
+    return proc.returncode == 0
+
+
+def force_rmtree(path: str, work_dir: str, image: str) -> None:
+    """Remove a directory `pulsar2 build` wrote into.
+
+    The container runs as root (confirmed: `-u $(id -u):$(id -g)` breaks the
+    image -- it needs root-owned `/root/*.hasplm`/`*.v2c` license files, and
+    a non-existent-in-container uid breaks `getpass.getuser()` deep in a
+    torchvision import), so files/dirs it wrote are root-owned and a plain
+    `shutil.rmtree` as an ordinary host user raises `PermissionError`. Fall
+    back to removing it from inside a container (same uid that created it).
+    """
+    try:
+        shutil.rmtree(path)
+        return
+    except PermissionError:
+        pass
+    rel = os.path.relpath(path, work_dir)
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-v",
+            f"{work_dir}:/data",
+            "--entrypoint",
+            "/bin/sh",
+            image,
+            "-c",
+            f"rm -rf /data/{rel}",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+
+@dataclass
+class BuildResult:
+    success: bool
+    axmodel_path: Optional[str] = None
+    max_cycle: Optional[int] = None
+    fused_subgraphs: Optional[int] = None
+    trace_path: Optional[str] = None
+    frontend_graph_path: Optional[str] = None
+    error: Optional[str] = None
+    stdout_tail: str = ""
+
+
+def _image_classifier_config(
+    tensor_name: str,
+    mean: Sequence[float],
+    std: Sequence[float],
+    *,
+    tensor_format: str = "RGB",
+    calibration_dataset: str = "./dataset/calib.tar",
+    calibration_size: int = 16,
+) -> dict:
+    """The config.json shape confirmed against Pulsar2's own quick-start docs
+    and the real `resnet18d`/`googlenet-6` builds -- see `pulsar2_ops.py`'s
+    docstring. Only fits a single-image-input classifier; a model with a
+    different input shape (NLP token ids, multiple inputs, ...) needs its
+    own config -- build one by hand and call `build()` with
+    `config_path=...` instead of `tensor_name`/`mean`/`std`.
+    """
+    return {
+        "model_type": "ONNX",
+        "npu_mode": "NPU1",
+        "quant": {
+            "input_configs": [
+                {
+                    "tensor_name": tensor_name,
+                    "calibration_dataset": calibration_dataset,
+                    "calibration_size": calibration_size,
+                    "calibration_mean": list(mean),
+                    "calibration_std": list(std),
+                }
+            ],
+            "calibration_method": "MinMax",
+            "precision_analysis": False,
+        },
+        "input_processors": [
+            {
+                "tensor_name": tensor_name,
+                "tensor_format": tensor_format,
+                "src_format": tensor_format,
+                "src_dtype": "U8",
+                "src_layout": "NHWC",
+                "csc_mode": "NoCSC",
+            }
+        ],
+        "compiler": {"check": 0},
+    }
+
+
+def make_synthetic_calibration_tar(
+    out_path: str, shape: Sequence[int] = (224, 224, 3), count: int = 16, seed: int = 0
+) -> str:
+    """A tar of `count` random uint8 images -- no accuracy claim, just enough
+    for PTQ calibration to run (see `pulsar2_ops.py`'s docstring for why a
+    compatibility check doesn't need a real, representative dataset the way
+    a deployment accuracy check would)."""
+    import numpy as np
+    from PIL import Image
+
+    rng = np.random.RandomState(seed)
+    with tempfile.TemporaryDirectory() as td:
+        paths = []
+        for i in range(count):
+            arr = rng.randint(0, 256, shape, dtype=np.uint8)
+            p = os.path.join(td, f"img_{i:02d}.jpg")
+            Image.fromarray(arr).save(p, quality=90)
+            paths.append(p)
+        with tarfile.open(out_path, "w") as tf:
+            for p in paths:
+                tf.add(p, arcname=os.path.basename(p))
+    return out_path
+
+
+def build(
+    work_dir: str,
+    onnx_rel_path: str,
+    output_rel_dir: str,
+    *,
+    tensor_name: Optional[str] = None,
+    mean: Optional[Sequence[float]] = None,
+    std: Optional[Sequence[float]] = None,
+    tensor_format: str = "RGB",
+    calibration_dataset_rel_path: str = "dataset/calib.tar",
+    calibration_size: int = 16,
+    config_path: Optional[str] = None,
+    target_hardware: str = "AX650",
+    image: str = DEFAULT_IMAGE,
+    profile: bool = False,
+    timeout: int = 900,
+) -> BuildResult:
+    """Run a real `pulsar2 build` in Docker.
+
+    `work_dir` is mounted at `/data` in the container -- `onnx_rel_path`,
+    `output_rel_dir`, and `calibration_dataset_rel_path` are all relative to
+    it, matching Pulsar2's own quick-start layout (see `pulsar2_ops.py`'s
+    docstring). Either pass `tensor_name`/`mean`/`std` for the confirmed
+    single-image-classifier config shape (auto-written under
+    `work_dir/config/`), or `config_path` (relative to `work_dir`) for a
+    hand-written one. With `profile=True`, adds `--compiler.npu_perf
+    --debug.dump_frontend_graph` and locates the resulting `trace.json` /
+    `optimized_quant_axmodel.onnx`.
+    """
+    if not docker_image_available(image):
+        return BuildResult(success=False, error=f"docker image not loaded: {image}")
+
+    if config_path is None:
+        if tensor_name is None or mean is None or std is None:
+            return BuildResult(
+                success=False,
+                error="pass tensor_name/mean/std, or an explicit config_path",
+            )
+        config_dir = os.path.join(work_dir, "config")
+        os.makedirs(config_dir, exist_ok=True)
+        config_rel_path = f"config/_auto_{os.path.basename(output_rel_dir)}.json"
+        with open(os.path.join(work_dir, config_rel_path), "w") as f:
+            json.dump(
+                _image_classifier_config(
+                    tensor_name,
+                    mean,
+                    std,
+                    tensor_format=tensor_format,
+                    calibration_dataset=f"./{calibration_dataset_rel_path}",
+                    calibration_size=calibration_size,
+                ),
+                f,
+            )
+    else:
+        config_rel_path = config_path
+
+    output_abs_dir = os.path.join(work_dir, output_rel_dir)
+    if os.path.exists(output_abs_dir):
+        force_rmtree(output_abs_dir, work_dir, image)
+
+    cmd = [
+        "docker",
+        "run",
+        "--rm",
+        "-v",
+        f"{work_dir}:/data",
+        image,
+        "pulsar2",
+        "build",
+        "--target_hardware",
+        target_hardware,
+        "--input",
+        onnx_rel_path,
+        "--output_dir",
+        output_rel_dir,
+        "--config",
+        config_rel_path,
+    ]
+    if profile:
+        cmd += ["--compiler.npu_perf", "--debug.dump_frontend_graph"]
+
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return BuildResult(
+            success=False, error=f"pulsar2 build timed out after {timeout}s"
+        )
+
+    log = proc.stdout + proc.stderr
+    if proc.returncode != 0:
+        return BuildResult(success=False, error=log[-2000:], stdout_tail=log[-2000:])
+
+    axmodel_path = os.path.join(output_abs_dir, "compiled.axmodel")
+    max_cycle_match = _MAX_CYCLE_RE.search(log)
+    fuse_match = _FUSE_RE.search(log)
+
+    trace_path = None
+    frontend_graph_path = None
+    if profile:
+        trace_hits = glob.glob(
+            os.path.join(output_abs_dir, "compiler", "debug", "**", "trace.json"),
+            recursive=True,
+        )
+        trace_path = trace_hits[0] if trace_hits else None
+        candidate = os.path.join(
+            output_abs_dir, "frontend", "optimized_quant_axmodel.onnx"
+        )
+        frontend_graph_path = candidate if os.path.exists(candidate) else None
+
+    return BuildResult(
+        success=os.path.exists(axmodel_path),
+        axmodel_path=axmodel_path if os.path.exists(axmodel_path) else None,
+        max_cycle=(
+            int(max_cycle_match.group(1).replace(",", "")) if max_cycle_match else None
+        ),
+        fused_subgraphs=int(fuse_match.group(1)) if fuse_match else None,
+        trace_path=trace_path,
+        frontend_graph_path=frontend_graph_path,
+        stdout_tail=log[-2000:],
+    )
+
+
+def axcl_available(binary: str = "/usr/bin/axcl/axcl_run_model") -> bool:
+    return os.path.exists(binary)
+
+
+def run_on_device(
+    axmodel_path: str,
+    *,
+    repeat: int = 5,
+    warmup: int = 2,
+    binary: str = "/usr/bin/axcl/axcl_run_model",
+    timeout: int = 120,
+) -> Dict[str, Optional[float]]:
+    """Run a compiled `.axmodel` on a real AXCL device, return latency stats.
+
+    Returns `{"min_ms": ..., "max_ms": ..., "avg_ms": ...}`, or all `None`
+    plus `"error"` if the binary/device isn't available or the run failed.
+    """
+    if not axcl_available(binary):
+        return {
+            "min_ms": None,
+            "max_ms": None,
+            "avg_ms": None,
+            "error": "axcl_run_model not found",
+        }
+    try:
+        proc = subprocess.run(
+            [binary, "-m", axmodel_path, "-r", str(repeat), "-w", str(warmup)],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return {"min_ms": None, "max_ms": None, "avg_ms": None, "error": "timeout"}
+    log = proc.stdout + proc.stderr
+    m = re.search(
+        r"min\s*=\s*([\d.]+)\s*ms\s*max\s*=\s*([\d.]+)\s*ms\s*avg\s*=\s*([\d.]+)\s*ms",
+        log,
+    )
+    if not m:
+        return {"min_ms": None, "max_ms": None, "avg_ms": None, "error": log[-500:]}
+    return {
+        "min_ms": float(m.group(1)),
+        "max_ms": float(m.group(2)),
+        "avg_ms": float(m.group(3)),
+        "error": None,
+    }
+
+
+def run_on_device_with_input(
+    axmodel_path: str,
+    input_tensor_name: str,
+    input_bytes: bytes,
+    *,
+    binary: str = "/usr/bin/axcl/axcl_run_model",
+    timeout: int = 120,
+) -> Optional[List[bytes]]:
+    """Feed exactly `input_bytes` to `input_tensor_name` on a real device and
+    return the raw output tensor bytes (one per output, model's declared
+    order). Uses the confirmed real `-i/-o/-l` folder layout: `<in>/0/
+    <tensor_name>.bin`, `list.txt` containing `0`, outputs land at `<out>/0/
+    <output_name>.bin`. **The input filename must exactly match the tensor
+    name** -- confirmed by trial: `axcl_run_model` errors with "Stimulus
+    file ... is not exist" naming the *tensor's* name specifically, not an
+    arbitrary/first-found file.
+    """
+    if not axcl_available(binary):
+        return None
+    with tempfile.TemporaryDirectory() as td:
+        in_dir = os.path.join(td, "in", "0")
+        out_dir = os.path.join(td, "out")
+        os.makedirs(in_dir)
+        os.makedirs(out_dir)
+        with open(os.path.join(in_dir, f"{input_tensor_name}.bin"), "wb") as f:
+            f.write(input_bytes)
+        list_path = os.path.join(td, "list.txt")
+        with open(list_path, "w") as f:
+            f.write("0\n")
+        try:
+            subprocess.run(
+                [
+                    binary,
+                    "-m",
+                    axmodel_path,
+                    "-i",
+                    os.path.join(td, "in"),
+                    "-o",
+                    out_dir,
+                    "-l",
+                    list_path,
+                    "-r",
+                    "1",
+                    "-w",
+                    "0",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            return None
+        outputs = []
+        for p in sorted(glob.glob(os.path.join(out_dir, "0", "*.bin"))):
+            with open(p, "rb") as f:
+                outputs.append(f.read())
+        return outputs or None

--- a/scripts/axera/pulsar2_ops.py
+++ b/scripts/axera/pulsar2_ops.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""Heuristics for Axera's Pulsar2/AXCL NPU compiler stack, without a real compiler.
+
+Axera's `pulsar2 build` toolchain (the compiler behind AXCL / `.axmodel` for
+the AX6xx/AX8xx NPU line) is a Docker-only download with no PyPI package and
+no ONNX Runtime execution provider -- unlike the Qualcomm QNN
+(`scripts/qualcomm`), Intel OpenVINO (`scripts/intel`), and AMD MIGraphX
+(`scripts/amd`) stacks, there is no way to actually invoke it here to measure
+real op coverage. See `../../../junk/axcl-axmodel-onnxsim-notes.md` (the
+handoff notes this harness is based on) for the fuller picture.
+
+**Update, verified against a real AX650N + a real compiled `.axmodel`
+(`AXERA-TECH/YOLOv8`'s `AX650/yolov8n_640x640_npu1.axmodel`):** the notes'
+§4 guess that an embedded NPU subgraph would show up as a node with a
+*non-standard ONNX `domain`* turned out to be **wrong**. The real file has
+exactly one node, `op_type="neu mode"` in the plain default domain (`""`),
+whose declared graph input is only the model's real input (`images`) -- the
+NPU weight/command blobs are ordinary UINT8 `graph.initializer` tensors
+(`npu_params`, `<node_name>_b<N>_neu`) that are **not** referenced as a node
+input at all. Instead, the node's `npu_graph_info` attribute is a JSON string
+naming them by key (`const_data_key`, `neu_key`); a sibling `outputs_info`
+attribute JSON-describes the outputs' dtype/shape. See `AXERA_NPU_OP_TYPE`,
+`referenced_const_data_keys()` and `missing_npu_data()` below, and
+`inspect_axmodel.py`, which is what produced this.
+
+This out-of-band reference is exactly the fragility §4(a) of the handoff
+notes worried about, and it is not hypothetical: `missing_npu_data()` exists
+because running plain `onnxsim.simplify()` on this real file reproducibly
+**strips `npu_params`/`npu_dyn_params`/`*_neu` from the output** -- both
+onnxsim's own constant-folding cleanup and onnx-optimizer's
+`eliminate_unused_initializer`/`eliminate_deadend` passes independently treat
+them as dead, since neither is a declared node *input* -- shrinking the file
+from 3.4MB to 1.7KB. The result fails to even load via `axcl_run_model` on
+the real device ("Create model handle failed").
+
+**There is no working flag-only avoidance**, confirmed by exhausting the
+combinations: `skip_constant_folding=True` alone still strips them (the
+onnx-optimizer passes get them); `skipped_optimizers=["eliminate_unused_
+initializer", "eliminate_deadend"]` alone still strips them (constant folding
+gets them); doing *both* keeps the 3 initializers byte-identical, but the
+result *still* fails to load, because onnxsim's shape-inference/graph-rebuild
+also unconditionally drops the `graph.value_info` entries describing those
+tensors (10 -> 0, even with `skip_shape_inference=True`) and Axera's runtime
+needs those too. In short: as of this onnxsim version, **feeding it an
+already-compiled `.axmodel` is not safe with any public `simplify()`
+parameter combination** -- see `has_out_of_band_npu_data()` below, meant to
+be checked *before* calling `simplify()` at all, and `worker.py`/`missing_
+npu_data()` to catch it *after* if that guard is skipped.
+
+For everything Pulsar2 itself hasn't confirmed (the general NPU-vs-CPU op
+split, since only one node's contents were ever visible in this one file),
+this module still falls back to the safer complement it started with: op
+types extremely unlikely to be NPU-schedulable on *any* fixed-function NPU
+toolchain (control flow, sequence/optional types, string ops, ops with
+data-dependent output shape), plus the original (now known to be
+Axera-specific-case-of, not general-case) non-standard-`domain` check, kept
+as a heuristic for vendor blobs that don't follow Axera's exact convention.
+Presence of one of these is a strong signal the graph (or region of it) will
+not run on Pulsar2's NPU as-is; *absence* is not proof the rest is
+NPU-schedulable, only that this harness found no known blocker.
+
+**Update: the real NPU op-support list is no longer an open question.**
+Axera publishes it -- `AX650_SUPPORTED_OPS` below is the 92 op names scraped
+from Pulsar2 V7.0's docs (`appendix/op_support_list_ax650.html`), which also
+states **the whole model must be ONNX opset >= 11** (`AX650_MIN_OPSET`).
+`unsupported_on_ax650()` flags op types outside that list.
+
+This was exercised end-to-end with the real `pulsar2:6.0-lite` Docker
+toolchain + a real AX650N, converting two real `onnxmodelzoo` models:
+
+- `resnet18d_Opset18` (opset 18, all ops in `AX650_SUPPORTED_OPS`): both the
+  original ONNX and its onnxsim-simplified twin compiled to a single NPU
+  subgraph with **identical compiler-reported `max_cycle`
+  (1,318,764)**, and running both `.axmodel`s on the real device with the
+  same input produced **bit-identical output** (`np.array_equal` `True`,
+  max abs diff `0.0`) -- the strongest evidence so far that onnxsim's
+  approach-(b) simplification (§4(b) of the handoff notes) is safe for
+  Pulsar2.
+- `googlenet-6` (opset 9, uses `LRN` -- not in `AX650_SUPPORTED_OPS`):
+  `pulsar2 build` did **not** gracefully fall LRN back to CPU the way the
+  handoff notes' §2 description of mixed CPU/NPU graphs implied it might --
+  it hard-failed the whole build at the frontend parse stage with
+  `KeyError('dont support LRN opr in AXOPS/ONNXOPS/CUSTOM_OPS')` before any
+  CPU/NPU partitioning happened. So an op outside `AX650_SUPPORTED_OPS` is
+  not just "less NPU-friendly," it can make `pulsar2 build` refuse the model
+  outright -- confirmed for `LRN`, not verified for every other absent op.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, List, NamedTuple, Set
+
+import onnx
+
+# The real AX650 NPU op-support list, from Pulsar2 V7.0's own docs
+# (appendix/op_support_list_ax650.html, "NPU Operators support list (AX650)").
+# That page also states the whole model must be ONNX opset >= 11
+# (AX650_MIN_OPSET) and that this covers AX650A/AX650N/AX8850/M76H alike.
+# Each op's docs page also lists attribute-level limits (e.g. Conv's auto_pad
+# must be NOTSET) not captured here -- this module only checks op *type*.
+AX650_MIN_OPSET = 11
+AX650_SUPPORTED_OPS: frozenset = frozenset(
+    {
+        "Abs",
+        "Add",
+        "And",
+        "ArgMax",
+        "ArgMin",
+        "AveragePool",
+        "BatchNormalization",
+        "Cast",
+        "Ceil",
+        "Clip",
+        "Concat",
+        "Constant",
+        "ConstantOfShape",
+        "Conv",
+        "ConvTranspose",
+        "Cos",
+        "DepthToSpace",
+        "Div",
+        "Elu",
+        "Equal",
+        "Erf",
+        "Exp",
+        "Expand",
+        "Flatten",
+        "Floor",
+        "Gather",
+        "GatherElements",
+        "GatherND",
+        "Gelu",
+        "Gemm",
+        "GlobalAveragePool",
+        "GlobalMaxPool",
+        "Greater",
+        "GreaterOrEqual",
+        "GridSample",
+        "GroupNormalization",
+        "HardSigmoid",
+        "HardSwish",
+        "Identity",
+        "InstanceNormalization",
+        "InverseSigmoid",
+        "LSTM",
+        "LayerNormalization",
+        "LeakyRelu",
+        "Less",
+        "LessOrEqual",
+        "LogSoftmax",
+        "LpNormalization",
+        "MatMul",
+        "Max",
+        "MaxPool",
+        "Min",
+        "Mish",
+        "Mul",
+        "Not",
+        "PRelu",
+        "Pad",
+        "Pow",
+        "RMSNormalization",
+        "ReduceL2",
+        "ReduceMax",
+        "ReduceMean",
+        "ReduceMin",
+        "ReduceSum",
+        "Relu",
+        "Reshape",
+        "Resize",
+        "RoiAlign",
+        "RotaryEmbedding",
+        "Round",
+        "ScatterElements",
+        "ScatterND",
+        "Sigmoid",
+        "Silu",
+        "Sin",
+        "Slice",
+        "Softmax",
+        "Softplus",
+        "SpaceToDepth",
+        "SpatialTransformer",
+        "Split",
+        "Sqrt",
+        "Squeeze",
+        "Sub",
+        "Swish",
+        "Tanh",
+        "Tile",
+        "Topk",
+        "Transpose",
+        "Unsqueeze",
+        "Where",
+        "Xor",
+    }
+)
+
+# Confirmed (not guessed) against a real compiled `.axmodel` run on an AX650N:
+# the op_type Pulsar2 gives a node whose contents are an opaque, already
+# NPU-compiled subgraph. Domain stays the plain default ("") -- see this
+# module's docstring for why the domain-based heuristic below doesn't catch
+# this on its own.
+AXERA_NPU_OP_TYPE = "neu mode"
+
+# Standard ONNX domains a compliant model may use without it being a vendor
+# extension. Anything else on a node's `domain` field is exactly the
+# mechanism ONNX documents for vendor-specific ops -- see §4 of the handoff
+# notes for why an embedded NPU blob is expected to show up this way.
+STANDARD_DOMAINS = frozenset({"", "ai.onnx", "ai.onnx.ml", "ai.onnx.training"})
+
+# Op types that no mainstream fixed-function NPU compiler (Pulsar2 included,
+# on priors -- this is not Pulsar2-specific data) schedules on-device: control
+# flow needs a host to drive it, Sequence/Optional are container types with no
+# NPU tensor representation, string ops have no NPU numeric kernel, and
+# NonZero/Unique have data-dependent output shapes an ahead-of-time NPU
+# compile can't size. Each maps to a short reason for `coverage()` diagnostics.
+CPU_ONLY_OPS: Dict[str, str] = {
+    "If": "control flow",
+    "Loop": "control flow",
+    "Scan": "control flow",
+    "SequenceMap": "control flow",
+    "SequenceConstruct": "sequence type, no NPU tensor representation",
+    "SequenceEmpty": "sequence type, no NPU tensor representation",
+    "SequenceInsert": "sequence type, no NPU tensor representation",
+    "SequenceErase": "sequence type, no NPU tensor representation",
+    "SequenceAt": "sequence type, no NPU tensor representation",
+    "SequenceLength": "sequence type, no NPU tensor representation",
+    "SplitToSequence": "sequence type, no NPU tensor representation",
+    "ConcatFromSequence": "sequence type, no NPU tensor representation",
+    "Optional": "optional type, no NPU tensor representation",
+    "OptionalGetElement": "optional type, no NPU tensor representation",
+    "OptionalHasElement": "optional type, no NPU tensor representation",
+    "StringNormalizer": "string op, no NPU numeric kernel",
+    "StringConcat": "string op, no NPU numeric kernel",
+    "StringSplit": "string op, no NPU numeric kernel",
+    "RegexFullMatch": "string op, no NPU numeric kernel",
+    "NonZero": "data-dependent output shape",
+    "Unique": "data-dependent output shape",
+}
+
+
+class BlockingOp(NamedTuple):
+    node_name: str
+    op_type: str
+    domain: str
+    reason: str
+
+
+def blocking_ops(model: onnx.ModelProto) -> List[BlockingOp]:
+    """Nodes (incl. subgraphs) unlikely to be Pulsar2-NPU-schedulable.
+
+    Walks `If`/`Loop`/`Scan` subgraphs too, since a blocking op nested inside
+    a branch/body is just as real a CPU-fallback trigger as one at top level.
+    """
+    found: List[BlockingOp] = []
+
+    def visit(graph: onnx.GraphProto) -> None:
+        for node in graph.node:
+            if node.domain not in STANDARD_DOMAINS:
+                found.append(
+                    BlockingOp(
+                        node.name or f"<{node.op_type}>",
+                        node.op_type,
+                        node.domain,
+                        f"non-standard domain {node.domain!r} "
+                        "(likely a vendor/compiled blob, see notes §4)",
+                    )
+                )
+            elif node.op_type in CPU_ONLY_OPS:
+                found.append(
+                    BlockingOp(
+                        node.name or f"<{node.op_type}>",
+                        node.op_type,
+                        node.domain,
+                        CPU_ONLY_OPS[node.op_type],
+                    )
+                )
+            for attr in node.attribute:
+                if attr.HasField("g"):
+                    visit(attr.g)
+                for sub_g in attr.graphs:
+                    visit(sub_g)
+
+    visit(model.graph)
+    return found
+
+
+def blocking_op_types(model: onnx.ModelProto) -> set:
+    """Just the distinct op types from `blocking_ops`, for before/after diffing."""
+    return {b.op_type for b in blocking_ops(model)}
+
+
+def unsupported_on_ax650(model: onnx.ModelProto) -> Set[str]:
+    """Op types in `model` that are not on the confirmed AX650 op list.
+
+    Unlike `blocking_ops` (a generic, cross-vendor guess), this is Axera's
+    own published AX650 op list -- but "not on the list" is not uniformly
+    "falls back to CPU": confirmed for `LRN`, it instead makes `pulsar2
+    build` hard-fail at the frontend parse stage before any CPU/NPU
+    partitioning (see this module's docstring). Treat any hit here as
+    "verify empirically," not "safe to ignore."
+    """
+    return {
+        node.op_type
+        for node in model.graph.node
+        if node.op_type not in AX650_SUPPORTED_OPS and node.op_type != AXERA_NPU_OP_TYPE
+    }
+
+
+def opset_version(model: onnx.ModelProto) -> int:
+    """The model's default-domain opset version, or 0 if it has none."""
+    return max(
+        (o.version for o in model.opset_import if o.domain in ("", "ai.onnx")),
+        default=0,
+    )
+
+
+def below_ax650_min_opset(model: onnx.ModelProto) -> bool:
+    """True if `model`'s opset is below what AX650_MIN_OPSET requires.
+
+    A model at 0 (no default-domain opset import at all) is not flagged --
+    that is a malformed-model question, not an opset-too-old one.
+    """
+    v = opset_version(model)
+    return 0 < v < AX650_MIN_OPSET
+
+
+def npu_subgraph_nodes(model: onnx.ModelProto) -> List[onnx.NodeProto]:
+    """Nodes matching Axera's confirmed compiled-NPU-subgraph marker."""
+    return [
+        node
+        for node in model.graph.node
+        if node.op_type == AXERA_NPU_OP_TYPE and node.domain in STANDARD_DOMAINS
+    ]
+
+
+def referenced_const_data_keys(node: onnx.NodeProto) -> Set[str]:
+    """Initializer names a `neu mode` node depends on out-of-band.
+
+    Parses the `npu_graph_info` attribute's JSON (confirmed format -- see this
+    module's docstring): `{"dotneus": [{"neu_key": ..., "extra_inputs": [
+    {"const_data_key": ...}, ...]}, ...]}`. These names are the node's *real*
+    data dependencies even though none of them appear in `node.input` --
+    onnx-optimizer's dead-initializer elimination has no way to see that.
+    """
+    keys: Set[str] = set()
+    for attr in node.attribute:
+        if attr.name != "npu_graph_info" or not attr.s:
+            continue
+        try:
+            info = json.loads(attr.s)
+        except (ValueError, UnicodeDecodeError):
+            continue
+        for neu in info.get("dotneus", []):
+            if "neu_key" in neu:
+                keys.add(neu["neu_key"])
+            for extra in neu.get("extra_inputs", []):
+                if "const_data_key" in extra:
+                    keys.add(extra["const_data_key"])
+    return keys
+
+
+def missing_npu_data(model: onnx.ModelProto) -> Set[str]:
+    """Initializer names a `neu mode` node's metadata references but which are gone.
+
+    A non-empty result means the file is broken: the node's NPU weight/command
+    blob(s) were dropped from `graph.initializer` (typically by generic
+    dead-initializer elimination that only understands declared node inputs --
+    see this module's docstring for a reproduced, real-hardware-confirmed
+    case of exactly that).
+    """
+    initializer_names = {init.name for init in model.graph.initializer}
+    missing: Set[str] = set()
+    for node in npu_subgraph_nodes(model):
+        for key in referenced_const_data_keys(node):
+            if key not in initializer_names:
+                missing.add(key)
+    return missing
+
+
+def has_out_of_band_npu_data(model: onnx.ModelProto) -> bool:
+    """True if `model` has data `onnxsim.simplify()` cannot currently round-trip.
+
+    Call this *before* `simplify()`, not after: no combination of its public
+    parameters (`skip_constant_folding`, `skipped_optimizers=[
+    "eliminate_unused_initializer", "eliminate_deadend"]`, even
+    `skip_shape_inference`) has been found to preserve both the referenced
+    initializers and their `value_info` entries at once -- see this module's
+    docstring. Right now the only confirmed-safe thing to do with a model
+    that has NPU subgraph nodes is **not run it through onnxsim at all**, per
+    the handoff notes' own recommendation to only simplify pre-`pulsar2
+    build` ONNX (approach (b)), never an already-compiled `.axmodel`
+    (approach (a)).
+    """
+    return any(referenced_const_data_keys(node) for node in npu_subgraph_nodes(model))

--- a/scripts/axera/pulsar2_quantizer.py
+++ b/scripts/axera/pulsar2_quantizer.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""A local, Docker-free approximation of Pulsar2's INT8 PTQ, via onnxruntime.
+
+Pulsar2's own quantizer is proprietary: inspecting the real
+`output/*/quant/quant_axmodel.onnx` that `pulsar2 build` writes (from the
+real `resnet18d_Opset18` conversion -- see `pulsar2_ops.py`'s docstring)
+shows it rewrites the graph into its own custom ops in the plain default
+domain (`AxQuantizedConv`, `AxQuantizedAdd`, `AxQuantizeLinear`, ...) -- not
+standard ONNX `QuantizeLinear`/`DequantizeLinear`, so it cannot be executed
+by onnxruntime directly and there is no way to reproduce it bit-for-bit here.
+
+What *is* confirmed from that same real file, read off its
+`AxQuantizedConv` node attributes directly:
+
+* activations: **U8** (uint8), a single scale/zero-point per tensor (e.g.
+  `input_scales=[0.0187]`, `input_zeropoints=[114]`) -- i.e. per-tensor,
+  **asymmetric**.
+* weights: **S8** (int8), one scale *per output channel* (e.g.
+  `weight_scales` has length 32 for a 32-out-channel conv) -- i.e.
+  **per-channel, symmetric** (no zero-point attribute on the weight side).
+* `quant_method = 0`, matching the `"calibration_method": "MinMax"` in the
+  build config (see `pulsar2_ops.py`'s docstring for the real build log).
+
+This module reproduces exactly that numeric convention --
+`onnxruntime.quantization.quantize_static` with `CalibrationMethod.MinMax`,
+`activation_type=QUInt8`, `weight_type=QInt8`, `per_channel=True` -- and
+outputs a standard QDQ ONNX model onnxruntime can actually run. Treat the
+result as **compatible in calibration methodology and numeric precision**,
+not a reproduction of Pulsar2's internal IR or exact rounding/fusion
+behavior. Always confirm on real hardware before trusting it for a
+deployment decision -- see `pulsar2_simulator.py` for how this is used
+against real-device output.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Dict, Iterable, List, Optional
+
+import numpy as np
+import onnx
+
+PULSAR2_QUANTIZER_AVAILABLE = False
+_UNAVAILABLE_REASON: Optional[str] = None
+
+try:
+    from onnxruntime.quantization import (
+        CalibrationMethod,
+        QuantFormat,
+        QuantType,
+        quantize_static,
+    )
+    from onnxruntime.quantization.calibrate import CalibrationDataReader
+
+    PULSAR2_QUANTIZER_AVAILABLE = True
+except Exception as exc:  # pragma: no cover - depends on the host
+    _UNAVAILABLE_REASON = f"{type(exc).__name__}: {exc}"
+    CalibrationDataReader = object  # type: ignore[assignment,misc]
+
+
+def unavailable_reason() -> Optional[str]:
+    """Why the quantizer is unusable on this host, or None if it is usable."""
+    return _UNAVAILABLE_REASON
+
+
+if PULSAR2_QUANTIZER_AVAILABLE:
+
+    class _ListDataReader(CalibrationDataReader):
+        def __init__(self, feeds_list: List[Dict[str, np.ndarray]]):
+            self._iter = iter(feeds_list)
+
+        def get_next(self):
+            return next(self._iter, None)
+
+
+def quantize_like_pulsar2(
+    model: onnx.ModelProto,
+    calibration_feeds: Iterable[Dict[str, np.ndarray]],
+    *,
+    per_channel: bool = True,
+) -> onnx.ModelProto:
+    """Return an INT8 QDQ ONNX model calibrated the way Pulsar2 does (MinMax).
+
+    ``calibration_feeds`` should be several representative input dicts (8-32,
+    matching typical PTQ calibration set sizes -- the real build used 16).
+    Raises if the quantizer is unavailable; check `PULSAR2_QUANTIZER_AVAILABLE`
+    first.
+    """
+    if not PULSAR2_QUANTIZER_AVAILABLE:
+        raise RuntimeError(f"pulsar2_quantizer unavailable: {_UNAVAILABLE_REASON}")
+
+    with tempfile.TemporaryDirectory() as td:
+        in_path = os.path.join(td, "in.onnx")
+        out_path = os.path.join(td, "out.onnx")
+        onnx.save(model, in_path)
+        quantize_static(
+            in_path,
+            out_path,
+            calibration_data_reader=_ListDataReader(list(calibration_feeds)),
+            quant_format=QuantFormat.QDQ,
+            activation_type=QuantType.QUInt8,
+            weight_type=QuantType.QInt8,
+            calibrate_method=CalibrationMethod.MinMax,
+            per_channel=per_channel,
+        )
+        return onnx.load(out_path)

--- a/scripts/axera/pulsar2_quantizer.py
+++ b/scripts/axera/pulsar2_quantizer.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""A local, Docker-free approximation of Pulsar2's INT8 PTQ, via onnxruntime.
+"""A local, Docker-free approximation of Pulsar2's INT8 PTQ, via onnxsim's own quantizer.
 
 Pulsar2's own quantizer is proprietary: inspecting the real
 `output/*/quant/quant_axmodel.onnx` that `pulsar2 build` writes (from the
@@ -21,42 +21,49 @@ What *is* confirmed from that same real file, read off its
 * `quant_method = 0`, matching the `"calibration_method": "MinMax"` in the
   build config (see `pulsar2_ops.py`'s docstring for the real build log).
 
-This module reproduces exactly that numeric convention --
-`onnxruntime.quantization.quantize_static` with `CalibrationMethod.MinMax`,
-`activation_type=QUInt8`, `weight_type=QInt8`, `per_channel=True` -- and
-outputs a standard QDQ ONNX model onnxruntime can actually run. Treat the
-result as **compatible in calibration methodology and numeric precision**,
-not a reproduction of Pulsar2's internal IR or exact rounding/fusion
-behavior. Always confirm on real hardware before trusting it for a
+**onnxsim already has a quantizer with exactly this numeric convention**:
+`onnxsim.quantize_static` (`onnxsim/calibration.py`) does calibration-based
+QDQ quantization with `method="minmax"` as its default, an "asymmetric
+uint8 affine quantization" for activations
+(`onnxsim/passes/static_quantize_matmul.h`'s own comment, byte-for-byte the
+scheme above), and per-output-channel symmetric INT8 weights. This module
+used to hand-roll the same thing via `onnxruntime.quantization.
+quantize_static` with matching `QuantType`/`CalibrationMethod` options --
+now it just calls onnxsim's own, which is more authoritative (it's this
+project's own quantizer, not a reimplementation of its intent in a
+different library) and needs no extra dependency beyond what
+`pulsar2_simulator.py` already required (onnxruntime, used internally by
+`onnxsim.calibrate()` to run the float model and record activation ranges).
+
+Still **not** a reproduction of Pulsar2's internal IR, exact per-op
+selection, or rounding/fusion behavior -- `onnxsim.quantize_static` quantizes
+Conv/MatMul/"vanilla" Gemm nodes with a constant float weight (see its own
+docstring); Pulsar2 quantizes essentially the whole graph. Treat the result
+as **compatible in calibration methodology and numeric precision**, not a
+faithful emulation. Always confirm on real hardware before trusting it for a
 deployment decision -- see `pulsar2_simulator.py` for how this is used
 against real-device output.
 """
 
 from __future__ import annotations
 
-import os
-import tempfile
-from typing import Dict, Iterable, List, Optional
+from typing import Dict, Iterable, Optional
 
-import numpy as np
 import onnx
+import onnxsim
 
 PULSAR2_QUANTIZER_AVAILABLE = False
 _UNAVAILABLE_REASON: Optional[str] = None
 
 try:
-    from onnxruntime.quantization import (
-        CalibrationMethod,
-        QuantFormat,
-        QuantType,
-        quantize_static,
-    )
-    from onnxruntime.quantization.calibrate import CalibrationDataReader
+    import onnxruntime  # noqa: F401
 
     PULSAR2_QUANTIZER_AVAILABLE = True
 except Exception as exc:  # pragma: no cover - depends on the host
+    # onnxsim.quantize_static imports onnxruntime lazily (inside
+    # onnxsim.calibration.calibrate()), so onnxsim itself always imports
+    # fine without it -- check for the real dependency here instead.
     _UNAVAILABLE_REASON = f"{type(exc).__name__}: {exc}"
-    CalibrationDataReader = object  # type: ignore[assignment,misc]
 
 
 def unavailable_reason() -> Optional[str]:
@@ -64,44 +71,23 @@ def unavailable_reason() -> Optional[str]:
     return _UNAVAILABLE_REASON
 
 
-if PULSAR2_QUANTIZER_AVAILABLE:
-
-    class _ListDataReader(CalibrationDataReader):
-        def __init__(self, feeds_list: List[Dict[str, np.ndarray]]):
-            self._iter = iter(feeds_list)
-
-        def get_next(self):
-            return next(self._iter, None)
-
-
 def quantize_like_pulsar2(
     model: onnx.ModelProto,
-    calibration_feeds: Iterable[Dict[str, np.ndarray]],
-    *,
-    per_channel: bool = True,
+    calibration_feeds: Iterable[Dict],
 ) -> onnx.ModelProto:
     """Return an INT8 QDQ ONNX model calibrated the way Pulsar2 does (MinMax).
 
-    ``calibration_feeds`` should be several representative input dicts (8-32,
-    matching typical PTQ calibration set sizes -- the real build used 16).
-    Raises if the quantizer is unavailable; check `PULSAR2_QUANTIZER_AVAILABLE`
-    first.
+    Thin wrapper over `onnxsim.quantize_static(model, calibration_data=...,
+    method="minmax")` -- see this module's docstring for why that already
+    matches Pulsar2's confirmed numeric convention with no reimplementation
+    needed. `calibration_feeds` should be several representative input dicts
+    (8-32, matching typical PTQ calibration set sizes -- the real build used
+    16). Raises if the quantizer is unavailable; check
+    `PULSAR2_QUANTIZER_AVAILABLE` first.
     """
     if not PULSAR2_QUANTIZER_AVAILABLE:
         raise RuntimeError(f"pulsar2_quantizer unavailable: {_UNAVAILABLE_REASON}")
 
-    with tempfile.TemporaryDirectory() as td:
-        in_path = os.path.join(td, "in.onnx")
-        out_path = os.path.join(td, "out.onnx")
-        onnx.save(model, in_path)
-        quantize_static(
-            in_path,
-            out_path,
-            calibration_data_reader=_ListDataReader(list(calibration_feeds)),
-            quant_format=QuantFormat.QDQ,
-            activation_type=QuantType.QUInt8,
-            weight_type=QuantType.QInt8,
-            calibrate_method=CalibrationMethod.MinMax,
-            per_channel=per_channel,
-        )
-        return onnx.load(out_path)
+    return onnxsim.quantize_static(
+        model, calibration_data=list(calibration_feeds), method="minmax"
+    )

--- a/scripts/axera/pulsar2_simulator.py
+++ b/scripts/axera/pulsar2_simulator.py
@@ -36,8 +36,9 @@ input image both times): `coverage()` correctly reported "full" (matching
 the real build's single fused NPU subgraph) and "partial" with
 `cpu_op_types={"LRN": 2, "Dropout": 1}` for `googlenet-6` (matching its real
 hard build failure on `LRN`). For `simulate()`'s numeric side: cosine
-similarity between this simulator's INT8 output and the real device's actual
-INT8 output was **0.941**, close to fp32-vs-real's own **0.949** -- i.e. this
+similarity between this simulator's INT8 output (via `onnxsim.
+quantize_static`, see `pulsar2_quantizer.py`) and the real device's actual
+INT8 output was **0.938**, close to fp32-vs-real's own **0.949** -- i.e. this
 simulator's quantization noise is roughly the same *magnitude* as Pulsar2's
 real quantization noise, relative to the fp32 baseline. It is **not**
 rank-accurate, though: top-5 class rankings did not match between fp32, this

--- a/scripts/axera/pulsar2_simulator.py
+++ b/scripts/axera/pulsar2_simulator.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""An axmodel *simulator*: NPU/CPU partition + numeric estimate, no Docker/device.
+
+Shaped like the sibling `*_backend.py` modules (`coverage()`, `run_with_cpu()`,
+a run-the-other-path function, `compare()`), but where those wrap a *real*
+execution provider, this wraps two things that only need `onnx` + `onnxruntime`:
+
+1. **Partitioning**, from `pulsar2_ops.AX650_SUPPORTED_OPS` -- the real AX650
+   NPU operator-coverage list read out of Pulsar2's own docs and confirmed
+   against real hardware (see `pulsar2_ops.py`'s docstring: it correctly
+   predicted a real `resnet18d_Opset18` build succeeding fully-on-NPU and a
+   real `googlenet-6` build hard-failing on `LRN`). `partition()` classifies
+   every node the same way and reports what fraction would run on NPU.
+2. **Numeric estimation**, via `pulsar2_quantizer.quantize_like_pulsar2()`
+   run through onnxruntime's CPU EP -- an approximation of what the
+   INT8-quantized NPU path would produce, since there is no real EP for
+   Pulsar2 to run through (see `pulsar2_ops.py`'s docstring for why).
+
+**This is an estimate, not an emulator** -- two things it does NOT do:
+
+- It does not reproduce Pulsar2's actual quantized IR (`AxQuantizedConv` and
+  friends, confirmed proprietary and non-ONNX-Runtime-executable -- see
+  `pulsar2_quantizer.py`) or its exact fusion/rounding behavior.
+- Partitioning here is purely per-node op-type membership in
+  `AX650_SUPPORTED_OPS`; it does not model attribute-level limits (e.g.
+  Conv's `auto_pad` must be `NOTSET`) or how Pulsar2 actually groups/merges
+  eligible nodes into subgraphs.
+
+Use it to get a fast first read (does this graph look NPU-friendly? is
+onnxsim's simplification likely to change that? roughly how much does INT8
+hurt this model's outputs?) before spending time on `pulsar2 build` --
+always confirm anything that matters on the real toolchain and hardware.
+
+**Validated against real hardware** (`resnet18d_Opset18`, real AX650N, same
+input image both times): `coverage()` correctly reported "full" (matching
+the real build's single fused NPU subgraph) and "partial" with
+`cpu_op_types={"LRN": 2, "Dropout": 1}` for `googlenet-6` (matching its real
+hard build failure on `LRN`). For `simulate()`'s numeric side: cosine
+similarity between this simulator's INT8 output and the real device's actual
+INT8 output was **0.941**, close to fp32-vs-real's own **0.949** -- i.e. this
+simulator's quantization noise is roughly the same *magnitude* as Pulsar2's
+real quantization noise, relative to the fp32 baseline. It is **not**
+rank-accurate, though: top-5 class rankings did not match between fp32, this
+simulator, and the real device on that (random-noise, no real semantic
+content) test input -- small logit perturbations from any INT8 path are
+enough to reorder closely-spaced logits. Treat `simulate()`'s output as "is
+the quantization noise roughly sane," not "will this be the same top-1
+prediction as real hardware."
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+import numpy as np
+import onnx
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+from pulsar2_ops import AX650_SUPPORTED_OPS, AXERA_NPU_OP_TYPE  # noqa: E402
+import pulsar2_quantizer  # noqa: E402
+
+_SCRIPTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# Only keep scripts/ on sys.path for the duration of this import: scripts/
+# also holds directories like rfdetr/ with no __init__.py, which Python 3
+# treats as importable namespace packages. Leaving scripts/ on sys.path for
+# the rest of the process would make `import rfdetr` "succeed" as that empty
+# namespace package instead of skipping via pytest.importorskip, and shadow
+# the real one everywhere else it's checked for.
+_inserted = _SCRIPTS_DIR not in sys.path
+if _inserted:
+    sys.path.insert(0, _SCRIPTS_DIR)
+try:
+    from common.ep_numerics import compare, random_feeds  # noqa: E402,F401
+finally:
+    if _inserted:
+        sys.path.remove(_SCRIPTS_DIR)
+
+SIMULATOR_AVAILABLE = pulsar2_quantizer.PULSAR2_QUANTIZER_AVAILABLE
+
+
+def unavailable_reason() -> Optional[str]:
+    """Why the numeric side of the simulator is unusable, or None if usable.
+
+    `partition()`/`coverage()` need only `onnx` and work regardless; only the
+    onnxruntime-based `simulate()` depends on this.
+    """
+    return pulsar2_quantizer.unavailable_reason()
+
+
+@dataclass
+class Partition:
+    npu_nodes: List[str]
+    cpu_nodes: List[str]
+    cpu_op_types: Dict[str, int] = field(default_factory=dict)
+
+    @property
+    def npu_node_fraction(self) -> float:
+        total = len(self.npu_nodes) + len(self.cpu_nodes)
+        return len(self.npu_nodes) / total if total else 1.0
+
+
+def partition(model: onnx.ModelProto) -> Partition:
+    """Classify every node as NPU-eligible or not, by `AX650_SUPPORTED_OPS`.
+
+    A node whose op_type is `AXERA_NPU_OP_TYPE` (an already-compiled `neu
+    mode` node, e.g. from re-loading a real `.axmodel`) counts as NPU, not
+    CPU -- it's already placed, not something left over for the partitioner.
+    """
+    npu: List[str] = []
+    cpu: List[str] = []
+    cpu_types: Dict[str, int] = {}
+    for node in model.graph.node:
+        label = node.name or f"<{node.op_type}>"
+        if node.op_type == AXERA_NPU_OP_TYPE or node.op_type in AX650_SUPPORTED_OPS:
+            npu.append(label)
+        else:
+            cpu.append(label)
+            cpu_types[node.op_type] = cpu_types.get(node.op_type, 0) + 1
+    return Partition(npu, cpu, cpu_types)
+
+
+def coverage(model: onnx.ModelProto) -> str:
+    """ "full" (all nodes NPU-eligible), "none", or "partial"."""
+    p = partition(model)
+    if not p.cpu_nodes:
+        return "full"
+    if not p.npu_nodes:
+        return "none"
+    return "partial"
+
+
+def run_with_cpu(
+    model: onnx.ModelProto, feeds: Dict[str, np.ndarray]
+) -> List[np.ndarray]:
+    """Run `model` on ONNX Runtime's CPU provider (the fp32 reference)."""
+    import onnxruntime as ort
+
+    so = ort.SessionOptions()
+    so.log_severity_level = 3  # ERROR
+    sess = ort.InferenceSession(
+        model.SerializeToString(), sess_options=so, providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def run_npu_simulated(
+    model: onnx.ModelProto,
+    feeds: Dict[str, np.ndarray],
+    calibration_feeds: Optional[List[Dict[str, np.ndarray]]] = None,
+    seed: int = 0,
+) -> List[np.ndarray]:
+    """Run the Pulsar2-style-quantized graph (see `pulsar2_quantizer.py`).
+
+    Without `calibration_feeds`, synthesizes 16 random calibration inputs
+    (matching the real build's calibration set size) via `random_feeds`.
+    """
+    if calibration_feeds is None:
+        calibration_feeds = [random_feeds(model, seed=seed + i) for i in range(16)]
+    quantized = pulsar2_quantizer.quantize_like_pulsar2(model, calibration_feeds)
+    return run_with_cpu(quantized, feeds)
+
+
+def simulate(
+    model: onnx.ModelProto,
+    feeds: Optional[Dict[str, np.ndarray]] = None,
+    seed: int = 0,
+    rtol: float = 0.2,
+    atol: float = 0.1,
+) -> dict:
+    """One-shot: partition + fp32-vs-simulated-INT8 comparison.
+
+    The default `rtol`/`atol` are loose relative to `common.ep_numerics`'s
+    defaults -- real INT8 PTQ is expected to move outputs measurably; this
+    is meant to catch "wildly different" (a real problem), not "not
+    bit-exact" (expected). Tighten for a model where you have a real-hardware
+    reference to calibrate against -- see `pulsar2_ops.py`'s docstring for a
+    worked example (real AX650N vs this simulator, on `resnet18d_Opset18`).
+    """
+    feeds = feeds if feeds is not None else random_feeds(model, seed=seed)
+    fp32 = run_with_cpu(model, feeds)
+    npu_sim = run_npu_simulated(model, feeds, seed=seed)
+    close, max_diff = compare(fp32, npu_sim, rtol=rtol, atol=atol)
+    return {
+        "partition": partition(model),
+        "fp32": fp32,
+        "npu_simulated": npu_sim,
+        "close": close,
+        "max_abs_diff": max_diff,
+    }

--- a/scripts/axera/run_pulsar2_compat.py
+++ b/scripts/axera/run_pulsar2_compat.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Run the Pulsar2 (Axera NPU) coverage heuristic over the model suite and report.
+
+Drives ``worker.py`` once per model (isolated subprocess, hard timeout),
+collects the JSON results, writes a CSV, prints a summary, and exits non-zero
+if any model failed.
+
+Unlike the QNN/OpenVINO/MIGraphX checks, this needs no vendor package or
+device -- see ``pulsar2_backend.py`` -- so there is no ``--require-*`` flag or
+``skipped`` status: it always runs.
+
+Usage:
+    run_pulsar2_compat.py --output pulsar2-compat.csv
+    run_pulsar2_compat.py --models conv_bn_relu matmul_bias_tanh
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import subprocess
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import models  # noqa: E402
+
+FAIL_STATUSES = {
+    "pulsar2_regression",
+    "pulsar2_data_corrupted",
+    "simplify_check_failed",
+    "simplify_error",
+    "crash",
+    "timeout",
+    "error",
+}
+
+
+def run_one(model_name: str, timeout: int) -> dict:
+    t0 = time.time()
+    try:
+        proc = subprocess.run(
+            [sys.executable, os.path.join(HERE, "worker.py"), model_name],
+            capture_output=True,
+            text=True,
+            timeout=None if timeout <= 0 else timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "model": model_name,
+            "status": "timeout",
+            "error": f">{timeout}s",
+            "seconds": timeout,
+        }
+    result = None
+    for line in proc.stdout.splitlines():
+        if line.startswith("__RESULT__"):
+            result = json.loads(line[len("__RESULT__") :])
+    if result is None:
+        result = {
+            "model": model_name,
+            "status": "crash",
+            "error": (proc.stderr or proc.stdout or "no result line")[-400:],
+            "seconds": round(time.time() - t0, 1),
+        }
+    return result
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--models",
+        nargs="*",
+        default=None,
+        help="subset of model names to run (default: the whole suite)",
+    )
+    ap.add_argument(
+        "--timeout",
+        type=int,
+        default=600,
+        help="per-model wall-clock cap in seconds; <=0 disables",
+    )
+    ap.add_argument("--output", default="pulsar2-compat.csv")
+    args = ap.parse_args()
+
+    selected = args.models or models.names()
+    print(f"Pulsar2 (Axera NPU) coverage check | {len(selected)} models", flush=True)
+
+    rows = []
+    failures = []
+    for i, name in enumerate(selected, 1):
+        print(f"[{i}/{len(selected)}] {name} ...", end=" ", flush=True)
+        r = run_one(name, args.timeout)
+        rows.append(r)
+        status = r.get("status")
+        detail = ""
+        if r.get("orig_nodes") is not None:
+            detail = f"{r.get('orig_nodes')}->{r.get('simp_nodes')} nodes"
+        if r.get("coverage_orig") or r.get("coverage_simp"):
+            detail += f", pulsar2={r.get('coverage_orig')}->{r.get('coverage_simp')}"
+        print(f"{status} ({detail}) {r.get('seconds')}s", flush=True)
+        if status in FAIL_STATUSES:
+            failures.append((name, status, str(r.get("error"))[:200]))
+
+    fields = [
+        "model",
+        "status",
+        "orig_nodes",
+        "simp_nodes",
+        "coverage_orig",
+        "coverage_simp",
+        "new_blocking_ops",
+        "seconds",
+        "error",
+    ]
+    with open(args.output, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fields, extrasaction="ignore")
+        w.writeheader()
+        for r in rows:
+            w.writerow(r)
+    print(f"\nwrote {args.output} ({len(rows)} rows)", flush=True)
+
+    if failures:
+        print(f"\n{len(failures)} FAILED:", flush=True)
+        for name, status, err in failures:
+            print(f"  - {name}: {status} {err}", flush=True)
+        return 1
+    passed = sum(1 for r in rows if r.get("status") == "ok")
+    partial = sum(1 for r in rows if r.get("coverage_simp") == "partial")
+    print(f"\nall passed ({passed} ok, {partial} partial coverage)", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/axera/run_pulsar2_compat.py
+++ b/scripts/axera/run_pulsar2_compat.py
@@ -28,7 +28,9 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 if HERE not in sys.path:
     sys.path.insert(0, HERE)
 
-import models  # noqa: E402
+from _local_import import fresh  # noqa: E402
+
+models = fresh("models", HERE)
 
 FAIL_STATUSES = {
     "pulsar2_regression",

--- a/scripts/axera/screen_onnxmodelzoo.py
+++ b/scripts/axera/screen_onnxmodelzoo.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Screen `onnxmodelzoo` models for AX650 compatibility -- no Docker, no device.
+
+Fetches each named model via `scripts/regression/model_zoo.py`, then reports
+`pulsar2_simulator.coverage()`/`partition()` and `pulsar2_backend.
+ax650_build_risks()` for both the original ONNX and its onnxsim-simplified
+twin. This is the fast, offline-capable screening step: it predicts whether
+a real `pulsar2 build --target_hardware AX650` is likely to succeed and stay
+fully on-NPU, using the confirmed real op list (`pulsar2_ops.
+AX650_SUPPORTED_OPS`) -- see `pulsar2_ops.py`'s docstring for the two real
+conversions (`resnet18d_Opset18`, `googlenet-6`) this was validated against.
+
+It does not attempt a real `pulsar2 build` or touch real hardware -- use
+`worker.py`/`run_pulsar2_compat.py` (the static onnxsim-regression check) or
+a real Docker + device setup for that, following the pattern in this
+directory's README.
+
+Not every onnxmodelzoo model is a plain single-image classifier (NLP models
+like `bert_Opset18` take token-id inputs; detection models like
+`FasterRCNN-10` have multiple inputs/outputs) -- this script only looks at
+op-type coverage, which is meaningful regardless of input shape, but a
+"full" or "partial" result says nothing about whether the *deployment*
+config (preprocessing, output postprocessing) would also need work.
+
+Usage:
+    python screen_onnxmodelzoo.py --models resnet18d_Opset18 googlenet-6
+    python screen_onnxmodelzoo.py --all --output screen.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+_REGRESSION_DIR = os.path.join(os.path.dirname(HERE), "regression")
+if _REGRESSION_DIR not in sys.path:
+    sys.path.insert(0, _REGRESSION_DIR)
+
+
+def screen_one(name: str) -> dict:
+    import onnx
+
+    import model_zoo
+    import pulsar2_backend as pulsar2
+    import pulsar2_simulator as sim
+
+    res = {
+        "model": name,
+        "status": "error",
+        "nodes": None,
+        "coverage": None,
+        "npu_node_fraction": None,
+        "cpu_op_types": None,
+        "build_risks": None,
+        "simplified_coverage": None,
+        "simplified_build_risks": None,
+        "error": None,
+    }
+    try:
+        path = model_zoo.fetch_model(name)
+        model = onnx.load(path)
+        res["nodes"] = len(model.graph.node)
+
+        p = sim.partition(model)
+        res["coverage"] = sim.coverage(model)
+        res["npu_node_fraction"] = round(p.npu_node_fraction, 3)
+        res["cpu_op_types"] = dict(p.cpu_op_types)
+        res["build_risks"] = pulsar2.ax650_build_risks(model)
+
+        try:
+            from onnxsim import simplify
+
+            simp, _ = simplify(model)
+            res["simplified_coverage"] = sim.coverage(simp)
+            res["simplified_build_risks"] = pulsar2.ax650_build_risks(simp)
+        except Exception as exc:
+            res["simplified_coverage"] = f"simplify_error: {exc}"
+
+        res["status"] = "ok"
+    except Exception as exc:
+        res["error"] = f"{type(exc).__name__}: {exc}"
+    return res
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--models", nargs="*", default=None, help="model short names")
+    ap.add_argument(
+        "--all", action="store_true", help="screen every model in models.json"
+    )
+    ap.add_argument("--output", default="pulsar2-screen.csv")
+    args = ap.parse_args()
+
+    import model_zoo
+
+    if args.all:
+        selected = [m.split("/", 1)[1] for m in model_zoo.list_models()]
+    elif args.models:
+        selected = args.models
+    else:
+        ap.error("pass --models NAME [NAME ...] or --all")
+        return 2
+
+    rows = []
+    for i, name in enumerate(selected, 1):
+        print(f"[{i}/{len(selected)}] {name} ...", end=" ", flush=True)
+        r = screen_one(name)
+        rows.append(r)
+        if r["status"] == "ok":
+            print(
+                f"{r['coverage']} ({r['npu_node_fraction']:.0%} NPU-eligible nodes)"
+                + (f", risks={r['build_risks']}" if r["build_risks"] else "")
+            )
+        else:
+            print(f"error: {r['error']}")
+
+    fields = [
+        "model",
+        "status",
+        "nodes",
+        "coverage",
+        "npu_node_fraction",
+        "cpu_op_types",
+        "build_risks",
+        "simplified_coverage",
+        "simplified_build_risks",
+        "error",
+    ]
+    with open(args.output, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fields, extrasaction="ignore")
+        w.writeheader()
+        for r in rows:
+            w.writerow(r)
+    print(f"\nwrote {args.output} ({len(rows)} rows)")
+
+    full = sum(1 for r in rows if r.get("coverage") == "full")
+    partial = sum(1 for r in rows if r.get("coverage") == "partial")
+    errors = sum(1 for r in rows if r["status"] != "ok")
+    print(f"{full} full, {partial} partial, {errors} errored")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/axera/worker.py
+++ b/scripts/axera/worker.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Check one model against the static Pulsar2 (Axera NPU) coverage heuristic.
+
+Run as ``worker.py <model_name> [onnx_path]``. With just a name, the model
+comes from the shared ``common/synthetic_models.py`` suite; with an
+``onnx_path`` the graph is loaded from disk. The final stdout line is exactly
+``__RESULT__<json>``.
+
+Unlike the QNN/OpenVINO/MIGraphX workers, there is no real compiler to run
+the graph through (see ``pulsar2_backend.py``), so there is nothing to crash
+at the C++ level -- this still runs each model in its own process to match
+the sibling harnesses' shape and keep ``run_pulsar2_compat.py`` generic. For
+one model:
+
+0. If the model already has an Axera-compiled NPU subgraph node (i.e. it's
+   a real `.axmodel`, not pre-compile ONNX) -- ``pulsar2_unsafe_for_simplify``
+   *without calling* ``simplify()`` at all. Confirmed on a real AX650N with a
+   real `.axmodel`: onnxsim currently corrupts these unconditionally (see
+   ``pulsar2_ops.py``'s docstring for the full, exhausted list of parameter
+   combinations that were tried and did not help) -- there is no safe way to
+   run this step for such a model.
+1. Otherwise, ``simplify`` it with onnxsim.
+2. Compute the static Pulsar2-NPU-blocker set for the original and the
+   simplified graph (``pulsar2_ops.blocking_ops``).
+3. If simplification introduced a blocking op type that wasn't already
+   present -- ``pulsar2_regression`` (a failure): simplification likely
+   pushed part of the graph off Pulsar2's NPU path.
+4. If simplification dropped NPU weight/command data a compiled subgraph
+   node still references (shouldn't be reachable given step 0, but checked
+   anyway as defense in depth) -- ``pulsar2_data_corrupted``.
+5. If onnxsim's own correctness check failed -- ``simplify_check_failed``.
+
+Status values:
+
+* ``ok``                          - simplified cleanly, no new Pulsar2-NPU blocker.
+* ``pulsar2_unsafe_for_simplify`` - input already has a compiled NPU subgraph; skipped.
+* ``pulsar2_regression``          - simplification introduced a new blocking op type.
+* ``pulsar2_data_corrupted``      - simplification dropped NPU weight/command data.
+* ``simplify_check_failed``       - onnxsim's own numeric check reported a mismatch.
+* ``simplify_error``              - onnxsim raised on this model.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import traceback
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+
+def check(model_name: str, onnx_path: str | None) -> dict:
+    res = {
+        "model": model_name,
+        "status": "error",
+        "orig_nodes": None,
+        "simp_nodes": None,
+        "coverage_orig": None,
+        "coverage_simp": None,
+        "new_blocking_ops": None,
+        "error": None,
+        "seconds": None,
+    }
+    t0 = time.time()
+    try:
+        import onnx
+        import pulsar2_backend as pulsar2
+
+        from onnxsim import simplify
+
+        if onnx_path:
+            model = onnx.load(onnx_path)
+        else:
+            import models
+
+            model = models.build(model_name)
+        res["orig_nodes"] = len(model.graph.node)
+
+        if pulsar2.unsafe_for_simplify(model):
+            res["status"] = "pulsar2_unsafe_for_simplify"
+            res["error"] = (
+                "model already has a compiled Axera NPU subgraph node; "
+                "onnxsim is confirmed to corrupt these (see pulsar2_ops.py) "
+                "-- skipped rather than run"
+            )
+            return res
+
+        try:
+            simp, check_ok = simplify(model)
+        except Exception as exc:
+            res["status"] = "simplify_error"
+            res["error"] = f"{type(exc).__name__}: {exc}"
+            return res
+        res["simp_nodes"] = len(simp.graph.node)
+
+        res["coverage_orig"] = pulsar2.coverage(model)
+        res["coverage_simp"] = pulsar2.coverage(simp)
+
+        new_blockers = sorted(pulsar2.new_blocking_op_types(model, simp))
+        res["new_blocking_ops"] = new_blockers
+
+        corrupted = sorted(pulsar2.stripped_npu_data(simp))
+
+        if corrupted:
+            res["status"] = "pulsar2_data_corrupted"
+            res["error"] = (
+                "simplification dropped NPU weight/command data still "
+                f"referenced by a compiled subgraph node: {corrupted}"
+            )
+        elif new_blockers:
+            res["status"] = "pulsar2_regression"
+            res["error"] = (
+                "simplification introduced op type(s) unlikely to be "
+                f"Pulsar2-NPU-schedulable: {new_blockers}"
+            )
+        elif not check_ok:
+            res["status"] = "simplify_check_failed"
+            res["error"] = "onnxsim's own correctness check reported a mismatch"
+        else:
+            res["status"] = "ok"
+    except Exception as exc:
+        res["error"] = f"{type(exc).__name__}: {exc}"
+        res["trace"] = traceback.format_exc()[-800:]
+    finally:
+        res["seconds"] = round(time.time() - t0, 1)
+    return res
+
+
+if __name__ == "__main__":
+    name = sys.argv[1]
+    path = sys.argv[2] if len(sys.argv) > 2 else None
+    print("__RESULT__" + json.dumps(check(name, path)))

--- a/scripts/axera/worker.py
+++ b/scripts/axera/worker.py
@@ -52,6 +52,8 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 if HERE not in sys.path:
     sys.path.insert(0, HERE)
 
+from _local_import import fresh  # noqa: E402
+
 
 def check(model_name: str, onnx_path: str | None) -> dict:
     res = {
@@ -75,7 +77,7 @@ def check(model_name: str, onnx_path: str | None) -> dict:
         if onnx_path:
             model = onnx.load(onnx_path)
         else:
-            import models
+            models = fresh("models", HERE)
 
             model = models.build(model_name)
         res["orig_nodes"] = len(model.graph.node)

--- a/scripts/qualcomm/README.md
+++ b/scripts/qualcomm/README.md
@@ -21,6 +21,10 @@ pattern: [`scripts/apple`](../apple) (Core ML), [`scripts/intel`](../intel)
 runner, since unlike the other three it has no CPU fallback or emulator, so
 its workflow is dormant until one is provisioned). NVIDIA (CUDA/TensorRT)
 needs real GPU hardware too and isn't covered by a harness yet.
+[`scripts/axera`](../axera) (Pulsar2/AXCL NPU) is the odd one out: Pulsar2 has
+no pip package or execution provider at all, so that check is a static
+op-support heuristic rather than a real compiler invocation -- see its README
+for why.
 
 ## What it checks
 

--- a/tests/test_pulsar2_compat.py
+++ b/tests/test_pulsar2_compat.py
@@ -1,0 +1,159 @@
+"""Axera Pulsar2 (AXCL NPU) static coverage compatibility test.
+
+Verifies that onnxsim's output doesn't gain a new op type this repo's
+Pulsar2-NPU-blocker heuristic flags (control flow, sequence/optional types,
+string ops, data-dependent-shape ops, or a non-standard ONNX `domain`) that
+wasn't already present before simplification.
+
+Unlike the QNN/OpenVINO/MIGraphX compat tests, this needs no vendor package
+or device -- there is no real Pulsar2 compiler to invoke, only a static
+heuristic (see ``scripts/axera/README.md`` for why) -- so this module is not
+skip-guarded and always runs.
+"""
+
+import os
+import sys
+
+import pytest
+
+# The Pulsar2 harness lives under scripts/axera; reuse it rather than duplicate.
+_AXERA_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "axera"
+)
+if _AXERA_DIR not in sys.path:
+    sys.path.insert(0, _AXERA_DIR)
+
+import models  # noqa: E402
+import pulsar2_backend as pulsar2  # noqa: E402
+from worker import check  # noqa: E402
+
+
+@pytest.mark.parametrize("name", models.names())
+def test_pulsar2_compat_suite(name):
+    """Each suite model: simplification must not introduce a new NPU blocker.
+
+    ``pulsar2_unsafe_for_simplify`` (the ``axera_npu_compiled_leaf`` fixture)
+    is expected, not a failure: it means the worker correctly declined to run
+    onnxsim on a model that already has a compiled NPU subgraph node -- see
+    ``test_onnxsim_corrupts_a_compiled_npu_subgraph`` below for what happens
+    if that guard is bypassed.
+    """
+    result = check(name, None)
+    assert result["status"] in ("ok", "pulsar2_unsafe_for_simplify"), result
+
+
+def test_no_blockers_in_clean_synthetic_models():
+    """None of the shared synthetic models should trip the blocker heuristic."""
+    for name in models.names():
+        model = models.build(name)
+        assert pulsar2.coverage(model) == "full", (
+            name,
+            pulsar2.blockers(model),
+        )
+
+
+def test_new_blocking_op_types_detects_introduced_control_flow():
+    """Sanity-check the diffing itself: a newly-added `If` node should be flagged."""
+    import onnx
+    from onnx import TensorProto, helper
+
+    orig = models.conv_bn_relu()
+
+    then_graph = helper.make_graph(
+        [helper.make_node("Identity", ["x"], ["y"])],
+        "then",
+        [],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, None)],
+    )
+    else_graph = helper.make_graph(
+        [helper.make_node("Identity", ["x"], ["y"])],
+        "else",
+        [],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, None)],
+    )
+    cond = helper.make_tensor("cond", TensorProto.BOOL, [], [True])
+    if_node = helper.make_node(
+        "If", ["cond"], ["y"], then_branch=then_graph, else_branch=else_graph
+    )
+    graph = helper.make_graph(
+        [if_node],
+        "with_if",
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1])],
+        [cond],
+    )
+    simp_with_if = helper.make_model(
+        graph, opset_imports=[helper.make_opsetid("", 18)], ir_version=10
+    )
+    onnx.checker.check_model(simp_with_if)
+
+    assert pulsar2.new_blocking_op_types(orig, simp_with_if) == {"If"}
+
+
+def test_axera_leaf_fixture_is_flagged_unsafe():
+    """The synthetic fixture should trip the pre-flight guard, like a real .axmodel."""
+    model = models.axera_npu_compiled_leaf()
+    assert pulsar2.unsafe_for_simplify(model)
+    assert (
+        check("axera_npu_compiled_leaf", None)["status"]
+        == "pulsar2_unsafe_for_simplify"
+    )
+
+
+def test_onnxsim_corrupts_a_compiled_npu_subgraph():
+    """Documents the real, reproduced bug this harness exists to guard against.
+
+    Confirmed on a real AX650N with a real ``AXERA-TECH/YOLOv8`` `.axmodel`:
+    plain ``onnxsim.simplify()`` drops the NPU weight/command initializer a
+    compiled subgraph node references only via a JSON attribute (not a
+    declared node input), and the result fails to even load on-device. This
+    synthetic fixture reproduces the same shape without needing hardware.
+
+    If this test starts failing because ``stripped_npu_data`` comes back
+    empty, onnxsim's bug has been fixed upstream -- update
+    ``pulsar2_ops.py``'s docstring and ``worker.py``'s pre-flight guard
+    (``pulsar2_ops.has_out_of_band_npu_data``) accordingly instead of just
+    deleting this test.
+    """
+    from onnxsim import simplify
+
+    model = models.axera_npu_compiled_leaf()
+    assert not pulsar2.stripped_npu_data(model)
+
+    simp, _ = simplify(model)
+    assert pulsar2.stripped_npu_data(simp) == {"npu_params"}
+
+
+def test_ax650_build_risks_matches_real_conversions():
+    """Sanity-checks the confirmed AX650 op list against two real conversions.
+
+    Both predictions were verified against the real ``pulsar2:6.0-lite``
+    toolchain: ``resnet18d_Opset18`` built cleanly (single NPU subgraph,
+    identical compiler-reported cost and bit-identical on-device output
+    before/after onnxsim simplification); a `googlenet-6`-shaped graph using
+    `LRN` at opset 9 hard-failed the real build at the frontend parse stage
+    (``KeyError('dont support LRN opr ...')``), not a graceful CPU fallback.
+    This test only exercises the static predictor, not the real toolchain --
+    see ``pulsar2_ops.py``'s docstring for the full record.
+    """
+    import onnx
+    from onnx import TensorProto, helper
+
+    clean = models.conv_bn_relu()
+    assert pulsar2.ax650_build_risks(clean) == []
+
+    lrn_node = helper.make_node("LRN", ["x"], ["y"], size=5)
+    graph = helper.make_graph(
+        [lrn_node],
+        "old_opset_with_lrn",
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 4, 8, 8])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 4, 8, 8])],
+    )
+    old_model = helper.make_model(
+        graph, opset_imports=[helper.make_opsetid("", 9)], ir_version=4
+    )
+    onnx.checker.check_model(old_model)
+
+    risks = pulsar2.ax650_build_risks(old_model)
+    assert any("LRN" in r for r in risks)
+    assert any("opset 9" in r for r in risks)

--- a/tests/test_pulsar2_compat.py
+++ b/tests/test_pulsar2_compat.py
@@ -23,9 +23,16 @@ _AXERA_DIR = os.path.join(
 if _AXERA_DIR not in sys.path:
     sys.path.insert(0, _AXERA_DIR)
 
-import models  # noqa: E402
+# fresh(), not a bare `import models`/`from worker import check`: every
+# scripts/<vendor>/ directory has its own models.py (and most have their own
+# worker.py too), all imported by the same bare name -- see
+# _local_import.py's docstring for why a plain import here can silently
+# resolve to a *different* vendor's module in the full test suite.
 import pulsar2_backend as pulsar2  # noqa: E402
-from worker import check  # noqa: E402
+from _local_import import fresh  # noqa: E402
+
+models = fresh("models", _AXERA_DIR)
+check = fresh("worker", _AXERA_DIR).check
 
 
 @pytest.mark.parametrize("name", models.names())

--- a/tests/test_pulsar2_simulator.py
+++ b/tests/test_pulsar2_simulator.py
@@ -19,8 +19,14 @@ _AXERA_DIR = os.path.join(
 if _AXERA_DIR not in sys.path:
     sys.path.insert(0, _AXERA_DIR)
 
-import models  # noqa: E402
+# fresh(), not a bare `import models`: every scripts/<vendor>/ directory has
+# its own models.py, all imported by the same bare name -- see
+# _local_import.py's docstring for why a plain import here can silently
+# resolve to a *different* vendor's module in the full test suite.
 import pulsar2_simulator as sim  # noqa: E402
+from _local_import import fresh  # noqa: E402
+
+models = fresh("models", _AXERA_DIR)
 
 
 def test_partition_reports_full_coverage_for_clean_models():
@@ -109,9 +115,9 @@ def test_quantize_like_pulsar2_matches_confirmed_dtypes():
     (onnxsim uses synthetic `_v_NN` names), so check dtypes present instead
     of names -- onnx.TensorProto INT8=3, UINT8=2.
     """
-    import onnx
     from collections import Counter
 
+    import onnx
     import pulsar2_quantizer as pq
 
     model = models.conv_bn_relu()

--- a/tests/test_pulsar2_simulator.py
+++ b/tests/test_pulsar2_simulator.py
@@ -103,10 +103,14 @@ def test_quantize_like_pulsar2_matches_confirmed_dtypes():
 
     See pulsar2_quantizer.py's docstring for where these numbers come from
     (a real `resnet18d_Opset18` `quant_axmodel.onnx`'s `AxQuantizedConv`
-    attributes). This checks our onnxruntime-based quantizer reproduces the
-    same *representation* (not the same values -- different quantizer).
+    attributes) and why `onnxsim.quantize_static` already matches this
+    convention exactly (asymmetric UINT8 activations, per-channel symmetric
+    INT8 weights). Initializers aren't named `*_scale`/`*_zero_point` here
+    (onnxsim uses synthetic `_v_NN` names), so check dtypes present instead
+    of names -- onnx.TensorProto INT8=3, UINT8=2.
     """
     import onnx
+    from collections import Counter
 
     import pulsar2_quantizer as pq
 
@@ -115,15 +119,10 @@ def test_quantize_like_pulsar2_matches_confirmed_dtypes():
     feeds = [{"x": rng.randn(1, 3, 16, 16).astype(np.float32)} for _ in range(4)]
     quantized = pq.quantize_like_pulsar2(model, feeds)
 
-    dtypes = set()
-    for init in quantized.graph.initializer:
-        if "scale" in init.name or "zero_point" in init.name:
-            dtypes.add((init.name.split("_")[-1], init.data_type))
-    # At least one weight-side zero_point should be int8 (S8) and one
-    # activation-side should be uint8 (U8) -- onnx.TensorProto INT8=3, UINT8=2.
-    zp_dtypes = {
-        init.data_type
-        for init in quantized.graph.initializer
-        if init.name.endswith("zero_point")
-    }
-    assert onnx.TensorProto.INT8 in zp_dtypes or onnx.TensorProto.UINT8 in zp_dtypes
+    op_types = Counter(n.op_type for n in quantized.graph.node)
+    assert op_types["QuantizeLinear"] >= 1
+    assert op_types["DequantizeLinear"] >= 1
+
+    init_dtypes = {init.data_type for init in quantized.graph.initializer}
+    assert onnx.TensorProto.UINT8 in init_dtypes, "no UINT8 activation quantization"
+    assert onnx.TensorProto.INT8 in init_dtypes, "no INT8 weight quantization"

--- a/tests/test_pulsar2_simulator.py
+++ b/tests/test_pulsar2_simulator.py
@@ -1,0 +1,129 @@
+"""Axera Pulsar2 axmodel simulator + compatible-quantizer test.
+
+Unlike ``test_pulsar2_compat.py`` (pure ``onnx``, always runs), this covers
+``scripts/axera/pulsar2_simulator.py`` and ``pulsar2_quantizer.py``, whose
+numeric side needs ``onnxruntime`` (an optional onnxsim dependency) --
+skip-guarded like ``test_qnn_compat.py``/``test_openvino_compat.py``.
+``partition()``/``coverage()`` need only ``onnx`` and are tested unguarded.
+"""
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+_AXERA_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "axera"
+)
+if _AXERA_DIR not in sys.path:
+    sys.path.insert(0, _AXERA_DIR)
+
+import models  # noqa: E402
+import pulsar2_simulator as sim  # noqa: E402
+
+
+def test_partition_reports_full_coverage_for_clean_models():
+    """Most shared synthetic models use only ops in AX650_SUPPORTED_OPS.
+
+    ``foldable_shape_reshape`` is the one exception: its un-folded `Shape`
+    node genuinely isn't on the real, confirmed AX650 list (`Shape` is a
+    compile-time-resolved op, not something dispatched to the NPU at
+    inference) -- a real finding, not a bug in this test's expectation. A
+    deployed model would normally have onnxsim constant-fold this away
+    first, which is exactly what this suite's regression tests check for.
+    """
+    expected_cpu_op_types = {"foldable_shape_reshape": {"Shape": 1}}
+    for name in models.names():
+        model = models.build(name)
+        expected = expected_cpu_op_types.get(name, {})
+        p = sim.partition(model)
+        assert p.cpu_op_types == expected, (name, p.cpu_op_types)
+        assert sim.coverage(model) == ("partial" if expected else "full")
+
+
+def test_partition_flags_control_flow_as_cpu():
+    """A node type outside AX650_SUPPORTED_OPS (e.g. `If`) is not NPU-eligible."""
+    import onnx
+    from onnx import TensorProto, helper
+
+    then_graph = helper.make_graph(
+        [helper.make_node("Identity", ["x"], ["y"])],
+        "then",
+        [],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, None)],
+    )
+    else_graph = helper.make_graph(
+        [helper.make_node("Identity", ["x"], ["y"])],
+        "else",
+        [],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, None)],
+    )
+    cond = helper.make_tensor("cond", TensorProto.BOOL, [], [True])
+    if_node = helper.make_node(
+        "If", ["cond"], ["y"], then_branch=then_graph, else_branch=else_graph
+    )
+    graph = helper.make_graph(
+        [if_node],
+        "with_if",
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1])],
+        [cond],
+    )
+    model = helper.make_model(
+        graph, opset_imports=[helper.make_opsetid("", 18)], ir_version=10
+    )
+    onnx.checker.check_model(model)
+
+    p = sim.partition(model)
+    assert p.cpu_op_types == {"If": 1}
+    assert sim.coverage(model) == "none"
+
+
+pytestmark_numeric = pytest.mark.skipif(
+    not sim.SIMULATOR_AVAILABLE,
+    reason=f"pulsar2 simulator's numeric side unavailable: {sim.unavailable_reason()}",
+)
+
+
+@pytestmark_numeric
+def test_simulate_runs_and_reports_a_diff():
+    """conv_bn_relu: quantized-simulated output should be close-ish to fp32."""
+    model = models.conv_bn_relu()
+    result = sim.simulate(model, seed=0)
+    assert result["partition"].npu_node_fraction == 1.0
+    assert result["max_abs_diff"] >= 0.0
+    for a, b in zip(result["fp32"], result["npu_simulated"]):
+        assert a.shape == b.shape
+
+
+@pytestmark_numeric
+def test_quantize_like_pulsar2_matches_confirmed_dtypes():
+    """Real pulsar2 build output showed U8 activations, S8 per-channel weights.
+
+    See pulsar2_quantizer.py's docstring for where these numbers come from
+    (a real `resnet18d_Opset18` `quant_axmodel.onnx`'s `AxQuantizedConv`
+    attributes). This checks our onnxruntime-based quantizer reproduces the
+    same *representation* (not the same values -- different quantizer).
+    """
+    import onnx
+
+    import pulsar2_quantizer as pq
+
+    model = models.conv_bn_relu()
+    rng = np.random.RandomState(0)
+    feeds = [{"x": rng.randn(1, 3, 16, 16).astype(np.float32)} for _ in range(4)]
+    quantized = pq.quantize_like_pulsar2(model, feeds)
+
+    dtypes = set()
+    for init in quantized.graph.initializer:
+        if "scale" in init.name or "zero_point" in init.name:
+            dtypes.add((init.name.split("_")[-1], init.data_type))
+    # At least one weight-side zero_point should be int8 (S8) and one
+    # activation-side should be uint8 (U8) -- onnx.TensorProto INT8=3, UINT8=2.
+    zp_dtypes = {
+        init.data_type
+        for init in quantized.graph.initializer
+        if init.name.endswith("zero_point")
+    }
+    assert onnx.TensorProto.INT8 in zp_dtypes or onnx.TensorProto.UINT8 in zp_dtypes


### PR DESCRIPTION
## Summary

Adds `scripts/axera/`, a compatibility check for Axera's Pulsar2/AXCL NPU compiler stack (the `.axmodel` toolchain for AX6xx/AX8xx), following the same `scripts/<vendor>/` pattern as `scripts/qualcomm`, `scripts/intel`, `scripts/amd`. Unlike those, Pulsar2 has no pip package or ONNX Runtime execution provider, so this is built in layers:

- **`pulsar2_ops.py` / `pulsar2_backend.py`** — a static, dependency-free heuristic, plus `AX650_SUPPORTED_OPS`: the real AX650 NPU op list scraped from Pulsar2's own docs.
- **`inspect_axmodel.py`** — a CLI to analyze a real compiled `.axmodel` file for its CPU/NPU boundary markers.
- **`pulsar2_quantizer.py` / `pulsar2_simulator.py`** — a Docker/device-free INT8 PTQ quantizer and NPU/CPU partition simulator, usable with only `onnx` + `onnxruntime`.
- **`pulsar2_docker.py` / `convert_onnxmodelzoo.py` / `screen_onnxmodelzoo.py`** — a real Docker + AXCL-device driver, with optional `--profile` (`chrome://tracing`-compatible `trace.json` via `--compiler.npu_perf`).

All of this was validated against a real AX650N and a real `pulsar2:6.0-lite` Docker toolchain:

- **Confirmed a real onnxsim bug**: `simplify()` corrupts an already-compiled `.axmodel` by dropping NPU weight/command data a `neu mode` node references only via a JSON attribute, not a declared graph input — no combination of `simplify()`'s public parameters avoids it. `worker.py` now refuses to run `simplify()` on such models; a synthetic fixture reproduces the bug in CI without needing hardware.
- **Confirmed the opposite is safe**: onnxsim-simplifying a real `onnxmodelzoo` model (`resnet18d_Opset18`) before compiling it produced a real `.axmodel` with identical compiler-reported cost and bit-identical on-device output vs. the unsimplified original.
- **Confirmed a real hard-failure mode**: an op outside `AX650_SUPPORTED_OPS` (`LRN`, `googlenet-6`) makes `pulsar2 build` fail outright at the frontend parse stage, not fall back to CPU gracefully.

## Test plan

- [x] `tests/test_pulsar2_compat.py` and `tests/test_pulsar2_simulator.py` (in-tree smoke tests, no Docker/device needed) — 15/15 passing
- [x] `black --check` / `flake8` clean on all new files
- [x] Manually verified end-to-end against a real AX650N + `pulsar2:6.0-lite`: `resnet18d_Opset18` build + on-device bit-exact diff, `googlenet-6` build failure, `--profile` trace.json generation
- [ ] Docker/device-based scripts (`pulsar2_docker.py`, `convert_onnxmodelzoo.py`) are manual/local-only and intentionally not wired into CI (no such runner is provisioned in this repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NHj4n82EuMhBMdSg55RXLx