### PR TITLE
Recognize decomposed (not-yet-fused) RMSNorm as a pass-through hop

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -348,6 +348,78 @@ projection or an attention block's own output projection, with no LayerNorm
 in between at all -- see that function's own section comment) and never a
 Conv-chain concept, for the identical reason the fused case already isn't.
 
+RMSNorm has its own decomposed shape too, structurally distinct from
+LayerNorm's own above (no mean-centering `Sub` step at all -- RMSNorm's own
+`variance` is `mean(x ** 2)`, never `mean((x - mean(x)) ** 2)`, so `x` itself,
+not a centered intermediate, is what both the squaring `Pow` and the final
+combining `Mul` read directly), and reached by two different real export
+paths rather than one: `RMSNormalization`'s own schema is likewise a late
+opset (23+, confirmed live the same way as `LayerNormalization`'s own
+opset-17 floor above), but PyTorch's own default/legacy (TorchScript-based)
+exporter has *no* decomposition path for `nn.RMSNorm` at all, at any opset --
+confirmed live, `torch.onnx.export(nn.RMSNorm(C), ..., dynamo=False)` fails
+outright (`UnsupportedOperatorError: Exporting the operator 'aten::rms_norm'
+...`) -- unlike `nn.LayerNorm`, which always has *some* decomposition
+available through that same exporter regardless of opset. This isn't a dead
+end in practice, though: essentially every real HuggingFace Llama/Mistral/
+Qwen2/Gemma-family model hand-rolls its own RMSNorm module (an `nn.Module`
+subclass computing the same math directly, `LlamaRMSNorm` and its many
+by-name copies throughout the `transformers` codebase) rather than using
+`nn.RMSNorm` -- precisely *because* the built-in module doesn't export via
+the legacy path -- so the legacy exporter's own decomposition of that
+hand-rolled module's textbook math (confirmed live,
+`torch.onnx.export(..., dynamo=False, opset_version=17)` on a module
+computing `variance = x.pow(2).mean(-1, keepdim=True); x = x *
+torch.rsqrt(variance + eps); return weight * x`, matching real HuggingFace
+`modeling_*.py` source) is, if anything, *more* common in real exported LLMs
+than the fused op itself -- the same "real gap this module already closed for
+LayerNorm" shape its own paragraph above describes. Confirmed live to be
+exactly: ``variance = Pow(x, 2.0); mean_var = ReduceMean(variance,
+axes=[-1]); var_eps = Add(mean_var, eps); std = Sqrt(var_eps); inv_std =
+Div(1.0, std); scaled = Mul(x, inv_std); out = Mul(scaled, weight)`` -- `x`
+read twice (by `Pow` and by `scaled`'s own `Mul`), every other intermediate
+tensor read once; `torch.rsqrt` lowers to `Div(1.0, std)` via this exporter.
+A second, structurally identical variant -- confirmed live via
+``torch.onnx.export(nn.RMSNorm(C), ..., dynamo=True, opset_version=<23)``,
+PyTorch's newer `torch.export`-based exporter, which *does* have a
+decomposition for `aten::rms_norm` unlike the legacy path above -- lowers
+`torch.rsqrt` to `Reciprocal(std)` instead of `Div(1.0, std)`; at
+`opset_version=23`+ the same call instead emits the *fused* `RMSNormalization`
+node directly (confirmed live), so this decomposition and the fused-node hop
+above are additive, never overlapping, for the same module, mirroring
+decomposed LayerNorm's own opset<=16-vs-17+ split.
+:func:`_match_decomposed_rms_norm_pass_through` recognizes *both* variants as
+one more `_walk_to_consumer` hop (tried at the identical two call sites as
+:func:`_match_decomposed_layer_norm_pass_through`, for the identical
+twice-read-root reason, and already covered by
+:func:`_matmul_walk_root_ok`'s own existing relaxation with no further change
+needed there -- see that function's own docstring), folding all 7 nodes into
+`chain_ops` in one hop -- only the final `Mul`'s own `weight` operand has
+anything sliced (`_flat_channel_const`/`dims[-1] == n_channels`, the same bar
+as decomposed LayerNorm's own `gamma`/`beta`); the `Pow` exponent, `eps`, and
+the `Div`'s own `1.0` numerator are all scalars, never sliced at all
+(:func:`_flat_scalar_float_const_equals`, factored out of what was originally
+:func:`_decomposed_layer_norm_pow_exponent_is_two`'s own `2.0`-specific check
+so both this hop's `2.0` exponent check and its own `1.0`-numerator check
+share the identical scalar-constant bar). `Reciprocal` is deliberately *not*
+added to `_UNARY_PASS_THROUGH` for this -- unlike `QuickGelu`/`Swish`/`Erf`
+there, which are unconditionally shape-preserving wherever they appear,
+`Reciprocal(std)` only means anything channel-pruning-safe in this one fixed
+position (immediately after this sequence's own `Sqrt`, feeding this
+sequence's own combining `Mul`); it is instead checked only inline, exactly
+where this hop's own fixed shape expects it. Declines outright, never
+partially matched, on any deviation from this exact 7-node shape (either
+variant): an extra reader of `x` beyond the `Pow`/`Mul` pair it expects, any
+other intermediate tensor read more than once or itself a graph output, a
+`Pow` exponent that isn't confirmed a constant scalar `2.0`, `ReduceMean`'s
+own `axes` not resolving to exactly the tensor's last axis, a `Div` whose
+numerator isn't confirmed a constant scalar `1.0` or whose operand order is
+swapped, `inv_std` and `x` feeding two *different* `Mul` nodes rather than the
+same one, or a non-constant/wrongly-shaped `weight` -- the same conservative
+bar every other hop in this module already holds itself to. Like decomposed
+LayerNorm, this is a MatMul/Gemm-chain-only hop, never a Conv-chain concept,
+for the identical reason.
+
 That same raw, not-yet-optimizer-fused export has one more gap the
 `BiasGelu`/`FastGelu`/`QuickGelu` fusions above don't close: the fused
 `Gelu`/`com.microsoft::Gelu` op itself needs a late opset (native `Gelu`
@@ -4436,21 +4508,23 @@ def _reduce_mean_axis_is_last(
     return _axis_resolves_to_last(axes_attr[0], input_name, value_info_by_name)
 
 
-def _decomposed_layer_norm_pow_exponent_is_two(
-    name: str, initializer_map: Dict[str, onnx.TensorProto]
+def _flat_scalar_float_const_equals(
+    name: str, initializer_map: Dict[str, onnx.TensorProto], value: float
 ) -> bool:
     """True iff `name` names a constant float *scalar* initializer (`dims`
     exactly ``[]``/``[1]``, mirroring :func:`_match_clip_channel_pass_through`'s
-    own `min`/`max` scalar bar) whose value is exactly ``2.0``. ``Pow``'s own
-    schema (``X, Y -> X ** Y``, a fixed operand order, never commutative)
-    makes `name` its second input; per
-    :func:`_match_decomposed_layer_norm_pass_through`'s own docstring, this
-    confirms the node genuinely computes ``(x - mean) ** 2`` -- LayerNorm's
-    own variance term -- rather than some other exponent this pass has no
-    basis for treating as channel-pruning-safe (it never inspects a
-    surviving weight's own numeric *values* to justify a hop shape the way
-    it does here). Declines (``False``) on a non-constant, non-float,
-    non-scalar, or not-exactly-``2.0`` value -- never guessed at.
+    own `min`/`max` scalar bar) whose value is exactly `value`. Factored out
+    of what was originally :func:`_decomposed_layer_norm_pow_exponent_is_two`
+    (now simply this, called with ``2.0``) so
+    :func:`_match_decomposed_rms_norm_pass_through`'s own ``Div``-numerator
+    check (a genuine ``1.0``, per that function's own docstring) can reuse the
+    identical scalar-constant bar rather than duplicating it -- same schema
+    fact (a fixed, non-per-channel operand whose own numeric value this pass
+    *does* need to inspect, unlike an operand like `eps` whose value never
+    matters, see :func:`_flat_scalar_float_const`), same check, regardless of
+    which node or which expected value. Declines (``False``) on a
+    non-constant, non-float, non-scalar, or not-exactly-`value` value --
+    never guessed at.
     """
     init = initializer_map.get(name)
     if (
@@ -4460,7 +4534,26 @@ def _decomposed_layer_norm_pow_exponent_is_two(
     ):
         return False
     values = onnx.numpy_helper.to_array(init).reshape(-1).tolist()
-    return len(values) == 1 and float(values[0]) == 2.0
+    return len(values) == 1 and float(values[0]) == value
+
+
+def _decomposed_layer_norm_pow_exponent_is_two(
+    name: str, initializer_map: Dict[str, onnx.TensorProto]
+) -> bool:
+    """True iff `name` names a constant float scalar initializer
+    (:func:`_flat_scalar_float_const_equals`) whose value is exactly ``2.0``.
+    ``Pow``'s own schema (``X, Y -> X ** Y``, a fixed operand order, never
+    commutative) makes `name` its second input; per
+    :func:`_match_decomposed_layer_norm_pass_through`'s own docstring (and,
+    identically, :func:`_match_decomposed_rms_norm_pass_through`'s -- RMSNorm's
+    own decomposition squares its input the same way), this confirms the node
+    genuinely computes ``(x - mean) ** 2``/``x ** 2`` -- LayerNorm's/RMSNorm's
+    own variance term -- rather than some other exponent this pass has no
+    basis for treating as channel-pruning-safe (it never inspects a surviving
+    weight's own numeric *values* to justify a hop shape the way it does
+    here).
+    """
+    return _flat_scalar_float_const_equals(name, initializer_map, 2.0)
 
 
 def _flat_scalar_float_const(
@@ -4750,37 +4843,366 @@ def _match_decomposed_layer_norm_pass_through(
     return out_name, chain_ops
 
 
+# Decomposed (not-yet-fused) RMSNorm -- the RMSNorm-own analogue of decomposed
+# LayerNorm just above, recognized by
+# :func:`_match_decomposed_rms_norm_pass_through` as a *third* multi-node
+# `_walk_to_consumer` hop alongside `_NORM_PASS_THROUGH_OPS`'s single-node one
+# and the decomposed-LayerNorm 9-node one. `RMSNormalization`'s own schema is
+# only opset 23+ (confirmed live: `_NORM_PASS_THROUGH_OPS`'s own comment), so
+# a raw `torch.onnx.export` at any earlier/default opset has no fused op to
+# lower `nn.RMSNorm`/a hand-rolled RMSNorm module to at all -- but unlike
+# `nn.LayerNorm`, which always has *some* decomposition available regardless
+# of opset, `nn.RMSNorm` specifically has no decomposition path through
+# PyTorch's own default/legacy (TorchScript-based) exporter at all: confirmed
+# live, `torch.onnx.export(nn.RMSNorm(C), ..., dynamo=False)` fails outright
+# (`UnsupportedOperatorError: Exporting the operator 'aten::rms_norm' ...`),
+# regardless of opset -- there is no legacy-exporter decomposition for this
+# module the way LayerNorm's own always-available textbook decomposition
+# exists. This is *not* a dead end in practice, though: essentially every real
+# HuggingFace Llama/Mistral/Qwen2/Gemma-family model hand-rolls its own
+# RMSNorm module (`nn.Module` subclass computing the same math directly,
+# `LlamaRMSNorm` and its many by-name copies throughout the `transformers`
+# codebase) rather than using `nn.RMSNorm` -- precisely *because* the built-in
+# module doesn't export via the legacy path -- so the legacy exporter's own
+# *textbook* RMSNorm decomposition (below) is, if anything, more common in
+# real exported LLMs than the fused op itself, the same "real gap this module
+# already closed for LayerNorm" shape as its own section comment describes.
+#
+# Two concrete shapes, both confirmed live (not assumed from the math) and
+# both structurally different from decomposed LayerNorm's own 9-node shape in
+# one respect: RMSNorm has no mean-centering `Sub` step at all (`variance` is
+# `mean(x**2)`, never `mean((x - mean(x))**2)`), so `x` itself -- not a
+# centered intermediate -- is what both the `Pow` and the final combining
+# `Mul` read directly:
+#
+# 1. A literal `LlamaRMSNorm`-equivalent hand-rolled module (`variance =
+#    x.pow(2).mean(-1, keepdim=True); x = x * torch.rsqrt(variance + eps);
+#    return weight * x`, matching real HuggingFace `modeling_*.py` source,
+#    minus the dtype-upcast/downcast `Cast` pair some real model families add
+#    around it -- immaterial to this shape, see below), exported via
+#    `torch.onnx.export(..., dynamo=False, opset_version=17)`, lowers
+#    `torch.rsqrt` to `Div(1.0, Sqrt(...))` -- confirmed live to produce
+#    exactly:
+#
+#      variance = Pow(x, 2.0); mean_var = ReduceMean(variance, axes=[-1]);
+#      var_eps = Add(mean_var, eps); std = Sqrt(var_eps);
+#      inv_std = Div(1.0, std); scaled = Mul(x, inv_std);
+#      out = Mul(scaled, weight)
+#
+#    `x` read twice (by `Pow` and by `scaled`'s own `Mul`), every other
+#    intermediate tensor read exactly once. This is the shape that matters
+#    most in practice -- it's what a real, unmodified HuggingFace Llama/
+#    Mistral/Qwen2/Gemma-family export actually contains.
+# 2. `torch.onnx.export(nn.RMSNorm(C), ..., dynamo=True, opset_version=<23)`
+#    -- PyTorch's newer `torch.export`-based exporter, which *does* have a
+#    decomposition for `aten::rms_norm` (unlike the legacy path above) --
+#    confirmed live to produce the identical topology, just
+#    `Reciprocal(std)` in place of `Div(1.0, std)` (`torch.rsqrt` lowered
+#    differently by this exporter): `... ; inv_std = Reciprocal(std); ...`.
+#    At `opset_version=23`+, the same call instead emits the *fused*
+#    `RMSNormalization` node directly (confirmed live), so -- exactly like
+#    decomposed LayerNorm's own opset<=16-vs-17+ split -- this decomposition
+#    and the fused-node hop above are additive, never overlapping, for the
+#    same module.
+#
+# Optional dtype-upcast/downcast `Cast` nodes some real model families wrap
+# this in (`hidden_states.to(torch.float32)` before, `.to(input_dtype)`
+# after -- confirmed live to appear when a hand-rolled module includes that
+# explicit cast dance, absent from the minimal module above) are *not* part
+# of this hop's own fixed shape -- they don't need to be: `Cast` is already in
+# `_UNARY_PASS_THROUGH`, so a leading one is walked through by
+# :func:`_walk_to_consumer`'s own ordinary per-iteration dispatch before ever
+# reaching this hop (`x_name` becomes the leading `Cast`'s own output), and a
+# trailing one sitting between `scaled` and the final weight `Mul` simply
+# means this hop's own fixed-adjacency bar (`scaled` read by *exactly* the
+# weight `Mul` -- see below) declines that specific chain, the same
+# conservative way it declines anything else not matching the exact shape;
+# the ordinary dispatch never gets a second chance to pick up the trailing
+# `Cast` + weight-`Mul` on its own once this hop has already committed to
+# `x_name`'s own two-consumer root, since `_walk_to_consumer` never re-enters
+# ordinary dispatch mid-multi-node-hop. This composes exactly like decomposed
+# LayerNorm's own -- fine in practice, since none of the concrete shapes
+# above (nor a raw, unmodified `nn.RMSNorm`/hand-rolled-module export at any
+# opset this hop targets) include such a `Cast`.
+#
+# `Reciprocal` (unlike `Div`) is *not* added to `_UNARY_PASS_THROUGH` for this
+# -- unlike `QuickGelu`/`Swish`/`Erf` above, which are unconditionally
+# shape-preserving wherever they appear, `Reciprocal(std)` only means
+# anything channel-pruning-safe in this one fixed position (immediately after
+# this sequence's own `Sqrt`, feeding this sequence's own combining `Mul`);
+# adding it to that set would make it a transparent hop *everywhere* a
+# MatMul/Gemm or Conv chain crosses one, a strictly wider and unverified claim
+# this section has no basis for. It is instead checked only inline, exactly
+# where this hop's own fixed shape expects it -- the same "recognize this
+# exact topology, decline everything else" discipline
+# :func:`_match_fused_bias_gelu`'s own two fused ops and every other
+# multi-node hop in this module already holds itself to.
+#
+# Before this hop existed, a `MatMul -> {either decomposition above} ->
+# MatMul` chain went completely unpruned end to end (confirmed independently
+# against this task's own base commit), while the identical chain built with
+# the *fused* `RMSNormalization` node instead pruned correctly -- isolating
+# the gap to the decomposition specifically, the same way every other
+# decomposition gap in this module was confirmed before its own fix.
+
+
+def _match_decomposed_rms_norm_pass_through(
+    x_name: str,
+    consumers_of: Dict[str, List[onnx.NodeProto]],
+    initializer_map: Dict[str, onnx.TensorProto],
+    graph_outputs: Set[str],
+    n_channels: int,
+    value_info_by_name: Optional[Dict[str, onnx.ValueInfoProto]],
+) -> Optional[Tuple[str, Tuple[Tuple[onnx.NodeProto, Optional[str]], ...]]]:
+    """If `x_name` is the root of exactly the fixed 7-node decomposed-RMSNorm
+    sequence documented in this section's own comment above -- confirmed live
+    via both a hand-rolled `LlamaRMSNorm`-equivalent module's own
+    `torch.onnx.export(..., dynamo=False, opset_version=17)` (the `Div(1.0,
+    std)` variant) and `torch.onnx.export(nn.RMSNorm(C), ..., dynamo=True,
+    opset_version=<23)` (the `Reciprocal(std)` variant) -- returns
+    ``(out_name, chain_ops)``: `out_name` the sequence's own true final output
+    (the tensor :func:`_walk_to_consumer` should continue walking from),
+    `chain_ops` all 7 nodes in walk order as ``(node, const_name_or_None)``
+    pairs ready to fold directly into a :class:`_Chain`'s own `chain_ops`
+    field -- only the final `Mul`'s own weight operand has anything to slice;
+    every other node's own entry carries ``None`` (the `Pow` exponent and
+    variance-``Add``'s own `eps`, like decomposed LayerNorm's identical two
+    operands, are scalars, never sliced at all, and the `Div`'s own numerator
+    is likewise a scalar never sliced -- see
+    :func:`_decomposed_layer_norm_pow_exponent_is_two`'s/
+    :func:`_flat_scalar_float_const`'s/:func:`_flat_scalar_float_const_equals`'s
+    own comments).
+
+    Mirrors :func:`_match_decomposed_layer_norm_pass_through` in every
+    structural respect but the shape itself: `x_name` itself (not just some
+    node's `.input[0]`) is the thing being matched, called by
+    :func:`_walk_to_consumer` at the identical two points (before its own
+    ordinary "exactly one consumer" dispatch, and again as a fallback
+    wherever an *ordinary* hop's own output would otherwise fail that
+    dispatch's single-consumer bar) for the identical reason (`x_name` is read
+    *twice* by design -- here, by the sequence's own `Pow` and by the final
+    combining `Mul`, RMSNorm having no centering step to read `x_name` a
+    *third* way the way LayerNorm's `Sub` does). Every other tensor inside the
+    sequence is held to the same "no stray fan-out" bar every other hop in
+    this module already applies -- exactly one consumer, and not itself a
+    graph output (`graph_outputs`). Declines (``None``, never partially
+    matched) on:
+
+    - `x_name` read by anything other than exactly one ``Pow`` and one
+      ``Mul`` (in particular, a *third* reader of any kind).
+    - `Pow`'s own inputs not exactly ``(x_name, <scalar 2.0>)``
+      (:func:`_decomposed_layer_norm_pow_exponent_is_two`) in that fixed,
+      schema-mandated order.
+    - The ``ReduceMean`` reading `Pow`'s own output not confirmed to reduce
+      exactly that tensor's own last axis (:func:`_reduce_mean_axis_is_last`)
+      -- the axis this pass is actually pruning.
+    - The variance ``Add`` not exactly ``Add(var, eps)`` (either operand
+      order -- `Add` is commutative) with `eps` a genuine scalar constant
+      (:func:`_flat_scalar_float_const`) distinct from `var`.
+    - ``Sqrt``'s own input not exactly the variance ``Add``'s own output.
+    - `std` (``Sqrt``'s output) not read by *exactly* one node, and that node
+      not exactly either ``Div(<scalar 1.0>, std)`` (in that fixed,
+      schema-mandated order -- `Div` is never commutative;
+      :func:`_flat_scalar_float_const_equals` confirms the numerator is
+      genuinely `1.0`, not merely a scalar) or ``Reciprocal(std)`` (its own
+      single input).
+    - `inv_std` (the `Div`/`Reciprocal`'s own output) not read by *the exact
+      same* `Mul` node already identified above as `x_name`'s own second
+      reader -- ruling out a graph that merely happens to have *a* `Mul` node
+      consuming `inv_std`, a different one from the one consuming `x_name`
+      (mirrors decomposed LayerNorm's own identical `std`-must-feed-the-same-
+      `Div` check).
+    - That `Mul`'s own inputs not exactly ``(x_name, inv_std)`` (either
+      operand order -- `Mul` is commutative).
+    - `scaled` (that `Mul`'s own output) not read by *exactly* one further
+      `Mul` node.
+    - That final `Mul`'s own inputs not exactly ``(scaled, weight)`` (either
+      operand order) with `weight` a genuine constant float flat per-channel
+      vector (:func:`_flat_channel_const`, the same bar
+      :func:`_match_decomposed_layer_norm_pass_through`'s own `gamma`/`beta`
+      already use) whose `dims[-1]` matches `n_channels` -- the real
+      channel-count check every hop in this module ultimately applies to its
+      own per-channel operand, distinct from `scaled`.
+    - Any intermediate tensor along the way (`variance`, `mean_var`,
+      `var_eps`, `std`, `inv_std`, `scaled`) itself a graph output, or read by
+      anything other than the one node this sequence's own fixed shape
+      expects.
+
+    The sequence's own true final output (the final `Mul`'s own output) is
+    *not* itself checked against `graph_outputs`/single-consumer here --
+    exactly like decomposed LayerNorm's own trailing `Add`, that check is the
+    caller's (:func:`_walk_to_consumer`'s own per-iteration "cur" check),
+    applied uniformly whether `cur` arrived via an ordinary hop or this one.
+    """
+    x_consumers = consumers_of.get(x_name, [])
+    if len(x_consumers) != 2:
+        return None
+    pow_node: Optional[onnx.NodeProto] = None
+    mul_node: Optional[onnx.NodeProto] = None
+    for cand in x_consumers:
+        if cand.op_type == "Pow" and pow_node is None:
+            pow_node = cand
+        elif cand.op_type == "Mul" and mul_node is None:
+            mul_node = cand
+    if pow_node is None or mul_node is None or pow_node is mul_node:
+        return None
+
+    if (
+        pow_node.domain != ""
+        or len(pow_node.input) != 2
+        or pow_node.input[0] != x_name
+        or len(pow_node.output) != 1
+        or not pow_node.output[0]
+        or not _decomposed_layer_norm_pow_exponent_is_two(
+            pow_node.input[1], initializer_map
+        )
+    ):
+        return None
+    sq_name = pow_node.output[0]
+    if sq_name in graph_outputs or len(consumers_of.get(sq_name, [])) != 1:
+        return None
+
+    reduce_mean = consumers_of[sq_name][0]
+    if len(reduce_mean.output) != 1 or not reduce_mean.output[0]:
+        return None
+    if not _reduce_mean_axis_is_last(reduce_mean, sq_name, value_info_by_name):
+        return None
+    var_name = reduce_mean.output[0]
+    if var_name in graph_outputs or len(consumers_of.get(var_name, [])) != 1:
+        return None
+
+    add_eps = consumers_of[var_name][0]
+    if (
+        add_eps.op_type != "Add"
+        or add_eps.domain != ""
+        or len(add_eps.input) != 2
+        or var_name not in add_eps.input
+        or len(add_eps.output) != 1
+        or not add_eps.output[0]
+    ):
+        return None
+    eps_name = add_eps.input[1] if add_eps.input[0] == var_name else add_eps.input[0]
+    if eps_name == var_name or not _flat_scalar_float_const(eps_name, initializer_map):
+        return None
+    var_eps_name = add_eps.output[0]
+    if var_eps_name in graph_outputs or len(consumers_of.get(var_eps_name, [])) != 1:
+        return None
+
+    sqrt_node = consumers_of[var_eps_name][0]
+    if (
+        sqrt_node.op_type != "Sqrt"
+        or sqrt_node.domain != ""
+        or list(sqrt_node.input) != [var_eps_name]
+        or len(sqrt_node.output) != 1
+        or not sqrt_node.output[0]
+    ):
+        return None
+    std_name = sqrt_node.output[0]
+    if std_name in graph_outputs or len(consumers_of.get(std_name, [])) != 1:
+        return None
+
+    inv_node = consumers_of[std_name][0]
+    if inv_node.domain != "" or len(inv_node.output) != 1 or not inv_node.output[0]:
+        return None
+    if inv_node.op_type == "Div":
+        if len(inv_node.input) != 2 or inv_node.input[1] != std_name:
+            return None
+        if not _flat_scalar_float_const_equals(inv_node.input[0], initializer_map, 1.0):
+            return None
+    elif inv_node.op_type == "Reciprocal":
+        if list(inv_node.input) != [std_name]:
+            return None
+    else:
+        return None
+    inv_std_name = inv_node.output[0]
+    if inv_std_name in graph_outputs or len(consumers_of.get(inv_std_name, [])) != 1:
+        return None
+    if consumers_of[inv_std_name][0] is not mul_node:
+        return None  # inv_std must feed the *same* Mul node x_name forked to
+
+    if (
+        mul_node.domain != ""
+        or len(mul_node.input) != 2
+        or x_name not in mul_node.input
+        or len(mul_node.output) != 1
+        or not mul_node.output[0]
+    ):
+        return None
+    scaled_name = mul_node.output[0]
+    if scaled_name in graph_outputs or len(consumers_of.get(scaled_name, [])) != 1:
+        return None
+
+    final_mul = consumers_of[scaled_name][0]
+    if (
+        final_mul.op_type != "Mul"
+        or final_mul.domain != ""
+        or len(final_mul.input) != 2
+        or scaled_name not in final_mul.input
+        or len(final_mul.output) != 1
+        or not final_mul.output[0]
+    ):
+        return None
+    weight_name = (
+        final_mul.input[1] if final_mul.input[0] == scaled_name else final_mul.input[0]
+    )
+    if (
+        weight_name == scaled_name
+        or not _flat_channel_const(weight_name, initializer_map)
+        or initializer_map[weight_name].dims[-1] != n_channels
+    ):
+        return None
+
+    out_name = final_mul.output[0]
+    chain_ops: Tuple[Tuple[onnx.NodeProto, Optional[str]], ...] = (
+        (pow_node, None),
+        (reduce_mean, None),
+        (add_eps, None),
+        (sqrt_node, None),
+        (inv_node, None),
+        (mul_node, None),
+        (final_mul, weight_name),
+    )
+    return out_name, chain_ops
+
+
 def _matmul_walk_root_ok(name: str, graph_outputs: Set[str]) -> bool:
     """True unless `name` is itself a graph output -- the one condition
     :func:`_walk_to_consumer` can never itself recover from once called (a
     caller-observed tensor's own shape must never silently change out from
     under it). Every *other* "is this safe to walk forward from" question --
-    an ordinary single consumer, or the decomposed-LayerNorm-root
-    *two*-consumer shape :func:`_match_decomposed_layer_norm_pass_through`
-    recognizes -- is left entirely to :func:`_walk_to_consumer`'s own hop-0
-    dispatch, which declines (returns no consumer, `(None, ())`) exactly the
-    same way skipping the call here already did for every case this module
-    supported before that hop existed: a tensor with zero consumers, or two
-    or more that don't happen to match the decomposed-LayerNorm shape,
-    still makes the very first hop's own dispatch fail immediately, with no
-    wasted walking.
+    an ordinary single consumer, or either of the two decomposed-norm-root
+    *two*-consumer shapes :func:`_match_decomposed_layer_norm_pass_through`/
+    :func:`_match_decomposed_rms_norm_pass_through` recognize -- is left
+    entirely to :func:`_walk_to_consumer`'s own hop-0 dispatch, which declines
+    (returns no consumer, `(None, ())`) exactly the same way skipping the
+    call here already did for every case this module supported before either
+    hop existed: a tensor with zero consumers, or two or more that don't
+    happen to match either decomposed-norm shape, still makes the very first
+    hop's own dispatch fail immediately, with no wasted walking. Confirmed by
+    construction, not merely asserted: this function's own body needs no
+    RMSNorm-specific change at all to already cover
+    :func:`_match_decomposed_rms_norm_pass_through`'s own two-consumer root
+    for free -- it was already agnostic to *which* shape a non-graph-output,
+    multi-consumer tensor might turn out to match, deferring that entirely to
+    the caller, the same way it was already agnostic to decomposed
+    LayerNorm's own specific shape.
 
     Used, in place of a plain `_is_internal(out_name)` single-consumer gate,
     by every :func:`_find_chains`/:func:`_find_gated_chains`/
     :func:`_find_split_gated_chains`/:func:`_find_matmul_concat_chains` call
     site that hands `_walk_to_consumer` a producer's, a gated combine's, or
     a `Concat`'s own raw output as `start` -- the shape a decomposed
-    LayerNorm sitting *directly* on that root (no ordinary hop first) needs,
-    since its own root tensor is read twice by design and a strict
-    single-consumer gate would otherwise always reject it before the walk
-    ever got a chance to try (mirroring the identical fallback
+    LayerNorm/RMSNorm sequence sitting *directly* on that root (no ordinary
+    hop first) needs, since its own root tensor is read twice by design and a
+    strict single-consumer gate would otherwise always reject it before the
+    walk ever got a chance to try (mirroring the identical fallback
     :func:`_walk_to_consumer` itself already needs for an *ordinary* hop's
     own output landing on such a root -- see its own top-of-loop and `out2`
     comments). Never used ahead of a `forced_first_hop` call
     (:func:`_resolve_matmul_fanout_branches`'s own extra-branch resolution):
-    `forced_first_hop` always takes hop 0's own dispatch directly, so this
-    hop can never be reached there regardless -- that composition is
-    deliberately out of this hop's scope, see
+    `forced_first_hop` always takes hop 0's own dispatch directly, so neither
+    hop can ever be reached there regardless -- that composition is
+    deliberately out of both hops' scope, see
     :func:`_match_decomposed_layer_norm_pass_through`'s own docstring.
     """
     return name not in graph_outputs
@@ -5264,11 +5686,14 @@ def _walk_to_consumer(
     :func:`_match_fused_bias_gelu` -- a plain `_NORM_PASS_THROUGH_OPS`
     node whose own ``axis`` normalizes exactly `cur`'s last axis -- see that
     constant's own comment, :func:`_norm_axis_is_last`, and
-    :func:`_norm_pass_through_const_names` -- or the *decomposed*, not-yet-
-    fused LayerNorm sequence a raw opset <= 16 export emits instead of a
-    fused `_NORM_PASS_THROUGH_OPS` node (see the section comment above
-    `_ConsumerMatch` and :func:`_match_decomposed_layer_norm_pass_through`)
-    -- a ``PRelu`` node (see :func:`_match_prelu_pass_through_matmul`): a
+    :func:`_norm_pass_through_const_names` -- or either of two *decomposed*,
+    not-yet-fused norm sequences a raw export emits instead of a fused
+    `_NORM_PASS_THROUGH_OPS` node: LayerNorm's own opset <= 16 canonical
+    decomposition (see the section comment above `_ConsumerMatch` and
+    :func:`_match_decomposed_layer_norm_pass_through`) or RMSNorm's own
+    (see the section comment above :func:`_match_decomposed_rms_norm_pass_through`
+    and that function's own docstring -- either its `Div(1.0, std)` or
+    `Reciprocal(std)` variant) -- a ``PRelu`` node (see :func:`_match_prelu_pass_through_matmul`): a
     *scalar* or single-shared-parameter `slope` (every dimension size 1)
     needs no operand of its own sliced, the same shape a plain unary
     activation hop already gets; a *per-channel* `slope` (flat,
@@ -5324,7 +5749,17 @@ def _walk_to_consumer(
             # attempted alongside `forced_first_hop` (`_hop == 0` there
             # always takes the branch above instead) -- see
             # :func:`_match_decomposed_layer_norm_pass_through`'s own
-            # docstring; that composition is out of this hop's scope.
+            # docstring; that composition is out of this hop's scope. The
+            # decomposed-RMSNorm shape (:func:`_match_decomposed_rms_norm_pass_through`,
+            # see its own section comment) is tried right alongside it, for
+            # the identical reason -- its own root is read twice too (by its
+            # `Pow` and its own combining `Mul`, not LayerNorm's `Sub`), so it
+            # needs the identical two call sites; the two shapes never
+            # overlap (LayerNorm's root is read by a `ReduceMean` and a
+            # `Sub`, RMSNorm's by a `Pow` and a `Mul` -- no graph matches both
+            # matchers' own node-type requirements at once), so trying both
+            # here costs nothing beyond one more declining call whenever
+            # neither shape is actually present.
             ln_match = _match_decomposed_layer_norm_pass_through(
                 cur,
                 consumers_of,
@@ -5333,6 +5768,15 @@ def _walk_to_consumer(
                 n_channels,
                 value_info_by_name,
             )
+            if ln_match is None:
+                ln_match = _match_decomposed_rms_norm_pass_through(
+                    cur,
+                    consumers_of,
+                    initializer_map,
+                    graph_outputs,
+                    n_channels,
+                    value_info_by_name,
+                )
             if ln_match is not None:
                 ln_out_name, ln_chain_ops = ln_match
                 chain_ops.extend(ln_chain_ops)
@@ -5479,7 +5923,9 @@ def _walk_to_consumer(
         # *after* a hop already committed to advancing past it. Trying the
         # same matcher here first, before the ordinary single-consumer bar,
         # closes that gap: every other multi-consumer `out2` still declines
-        # exactly as before.
+        # exactly as before. Tries the decomposed-RMSNorm shape too, the same
+        # way and for the same reason as this function's own hop-0 dispatch
+        # above.
         ln_match = None
         if len(consumers_of.get(out2, [])) != 1:
             ln_match = _match_decomposed_layer_norm_pass_through(
@@ -5490,6 +5936,15 @@ def _walk_to_consumer(
                 n_channels,
                 value_info_by_name,
             )
+            if ln_match is None:
+                ln_match = _match_decomposed_rms_norm_pass_through(
+                    out2,
+                    consumers_of,
+                    initializer_map,
+                    graph_outputs,
+                    n_channels,
+                    value_info_by_name,
+                )
             if ln_match is None:
                 break
         chain_ops.append((nxt, const_name))

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -3368,6 +3368,332 @@ def test_structured_pruning_decomposed_layer_norm_after_bias_add_matches_oracle(
     np.testing.assert_allclose(y, y_correct, rtol=1e-4, atol=1e-4)
 
 
+# --- apply_structured_pruning: *decomposed* (not-yet-fused) RMSNorm ---------
+#
+# `RMSNormalization`'s own schema is only opset 23+ (confirmed live:
+# `onnx.defs.get_schema("RMSNormalization").since_version == 23`), so a raw
+# export at any earlier/default opset has no fused op to lower `nn.RMSNorm`/a
+# hand-rolled RMSNorm module to at all. Unlike `nn.LayerNorm`, PyTorch's own
+# default/legacy (TorchScript-based) exporter has *no* decomposition path for
+# `nn.RMSNorm` at all -- confirmed live,
+# `torch.onnx.export(nn.RMSNorm(C), ..., dynamo=False)` fails outright
+# (`UnsupportedOperatorError: Exporting the operator 'aten::rms_norm' ...`),
+# regardless of opset. In practice this doesn't matter: essentially every real
+# HuggingFace Llama/Mistral/Qwen2/Gemma-family model hand-rolls its own
+# RMSNorm module rather than using `nn.RMSNorm` (precisely because the
+# built-in module doesn't export via the legacy path), and that hand-rolled
+# module's own textbook RMSNorm math -- `variance = x.pow(2).mean(-1,
+# keepdim=True); x = x * torch.rsqrt(variance + eps); return weight * x` --
+# exports (confirmed live, `torch.onnx.export(..., dynamo=False,
+# opset_version=17)`) to exactly the 7-node sequence below, `x` read twice (by
+# `Pow` and by `scaled`'s own `Mul`, RMSNorm having no mean-centering step to
+# read `x` a third way the way LayerNorm's own `Sub` does): `torch.rsqrt`
+# lowers to `Div(1.0, Sqrt(...))` here -- the "Div" variant below. A second,
+# structurally identical variant -- confirmed live via
+# `torch.onnx.export(nn.RMSNorm(C), ..., dynamo=True, opset_version=<23)`,
+# PyTorch's newer `torch.export`-based exporter, which *does* have a
+# decomposition for `aten::rms_norm` -- lowers `torch.rsqrt` to
+# `Reciprocal(std)` instead. `_match_decomposed_rms_norm_pass_through`
+# recognizes both as one more `_walk_to_consumer` hop; before this pass gained
+# it, this exact "MatMul -> decomposed RMSNorm -> MatMul" chain went
+# completely unpruned (confirmed independently against this task's own base
+# commit before this feature existed), while the identical chain built with
+# the *fused* `RMSNormalization` node instead pruned correctly.
+
+
+def _decomposed_rms_norm_model(
+    w1, weight, w2, variant="div", axis=-1, opset=17, pow_exp=2.0
+):
+    K, C = w1.shape
+    Out = w2.shape[1]
+    initializer = [
+        _f32(w1, "W1"),
+        onnx.numpy_helper.from_array(np.array(pow_exp, dtype=np.float32), "Two"),
+        onnx.numpy_helper.from_array(np.array(1e-5, dtype=np.float32), "Eps"),
+        _f32(weight, "Weight"),
+        _f32(w2, "W2"),
+    ]
+    if variant == "div":
+        initializer.append(
+            onnx.numpy_helper.from_array(np.array(1.0, dtype=np.float32), "One")
+        )
+        inv_std_line = "invstd = Div(One, std)"
+    elif variant == "reciprocal":
+        inv_std_line = "invstd = Reciprocal(std)"
+    else:
+        raise ValueError(variant)
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          x = MatMul(X, W1)
+          variance = Pow(x, Two)
+          meanvar = ReduceMean<axes=[{axis}]>(variance)
+          vareps = Add(meanvar, Eps)
+          std = Sqrt(vareps)
+          {inv_std_line}
+          scaled = Mul(x, invstd)
+          h = Mul(scaled, Weight)
+          Y = MatMul(h, W2)
+        }}
+        """,
+        initializer=initializer,
+        opset=opset,
+    )
+
+
+def _rms_norm_oracle(v, w, eps=1e-5):
+    rms = np.sqrt(np.mean(np.square(v), axis=-1, keepdims=True) + eps)
+    return (v / rms) * w
+
+
+def test_structured_pruning_decomposed_rms_norm_div_variant_shrinks_matched_layers():
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(340)
+    w1 = rng.standard_normal((K, C)).astype(np.float32)
+    weight = rng.standard_normal((C,)).astype(np.float32)
+    w2 = rng.standard_normal((C, Out)).astype(np.float32)
+    model = _decomposed_rms_norm_model(w1, weight, w2, variant="div")
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [K, C // 2]
+    assert list(inits["Weight"].dims) == [C // 2]
+    assert list(inits["W2"].dims) == [C // 2, Out]
+    # Every decomposition node itself is untouched (still the same 7 nodes,
+    # same op types/wiring) -- only Weight and the two MatMul weights shrink.
+    assert [n.op_type for n in pruned.graph.node] == [
+        "MatMul",
+        "Pow",
+        "ReduceMean",
+        "Add",
+        "Sqrt",
+        "Div",
+        "Mul",
+        "Mul",
+        "MatMul",
+    ]
+
+
+def test_structured_pruning_decomposed_rms_norm_div_variant_matches_oracle_adversarially():
+    # Mirrors test_structured_pruning_decomposed_layer_norm_pass_through_matches_oracle_adversarially
+    # for the decomposed RMSNorm shape: W1 engineered so the surviving `keep`
+    # set is deliberately not the first C//2 channels, Weight spanning three
+    # orders of magnitude, strictly increasing by channel index -- a
+    # positional (rather than index-set) slice of Weight would misapply a
+    # wildly-wrong-magnitude affine term to a kept channel, detectably wrong
+    # by orders of magnitude. The reference is built from scratch (never a
+    # post-hoc slice of the full unpruned model's own output), run through
+    # real onnxruntime.
+    K, C, Out = 4, 8, 2
+    rng = np.random.default_rng(341)
+    col_scale = np.linspace(0.1, 2.0, C).astype(np.float32)
+    w1 = (rng.standard_normal((K, C)) * col_scale).astype(np.float32)
+    weight = (np.arange(1, C + 1, dtype=np.float64) * 0.001).astype(np.float32)
+    w2 = rng.standard_normal((C, Out)).astype(np.float32)
+    model = _decomposed_rms_norm_model(w1, weight, w2, variant="div")
+    onnx.checker.check_model(model)
+
+    keep_count = C // 2
+    keep = _oracle_keep_indices(w1, keep_count)
+    assert not np.array_equal(keep, np.arange(keep_count))  # confirm adversarial
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+
+    h_correct = _rms_norm_oracle(x @ w1[:, keep], weight[keep])
+    y_correct = h_correct @ w2[keep, :]
+    np.testing.assert_allclose(y, y_correct, rtol=1e-4, atol=1e-4)
+
+    wrong_weight = weight[:keep_count]
+    h_wrong = _rms_norm_oracle(x @ w1[:, keep], wrong_weight)
+    y_wrong = h_wrong @ w2[keep, :]
+    assert np.max(np.abs(y - y_wrong)) > 1e-2 * max(1.0, np.max(np.abs(y_correct)))
+
+
+def test_structured_pruning_decomposed_rms_norm_reciprocal_variant_matches_oracle():
+    # The `torch.export`-based (dynamo=True) exporter's own decomposition of
+    # `nn.RMSNorm` at opset < 23 lowers `torch.rsqrt` to `Reciprocal(std)`
+    # rather than `Div(1.0, std)` -- structurally identical otherwise, and
+    # held to the identical bar.
+    K, C, Out = 6, 12, 3
+    rng = np.random.default_rng(342)
+    w1 = rng.standard_normal((K, C)).astype(np.float32)
+    weight = (rng.standard_normal((C,)).astype(np.float32)) * 2.0 + 1.0
+    w2 = rng.standard_normal((C, Out)).astype(np.float32)
+    model = _decomposed_rms_norm_model(w1, weight, w2, variant="reciprocal")
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    keep_count = C // 2
+    assert list(inits["Weight"].dims) == [keep_count]
+    assert [n.op_type for n in pruned.graph.node].count("Reciprocal") == 1
+
+    keep = _oracle_keep_indices(w1, keep_count)
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+
+    h_correct = _rms_norm_oracle(x @ w1[:, keep], weight[keep])
+    y_correct = h_correct @ w2[keep, :]
+    np.testing.assert_allclose(y, y_correct, rtol=1e-4, atol=1e-4)
+
+
+def test_structured_pruning_decomposed_rms_norm_pow_exponent_not_two_is_declined():
+    # Pow's own exponent must be confirmed a genuine constant scalar 2 (the
+    # variance term RMSNorm's own math actually computes) -- any other
+    # exponent is declined outright, never guessed at.
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(343)
+    w1 = rng.standard_normal((K, C)).astype(np.float32)
+    weight = rng.standard_normal((C,)).astype(np.float32)
+    w2 = rng.standard_normal((C, Out)).astype(np.float32)
+    model = _decomposed_rms_norm_model(w1, weight, w2, variant="div", pow_exp=3.0)
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
+def test_structured_pruning_decomposed_rms_norm_wrong_div_numerator_is_declined():
+    # Div's own first operand must be confirmed a genuine constant scalar 1.0
+    # (`Div`'s own schema is non-commutative, `X / Y` -- inv_std = 1.0 / std)
+    # -- any other numerator (here 2.0) computes a different value than
+    # RMSNorm's own reciprocal-std, and is declined the same conservative way.
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(344)
+    w1 = rng.standard_normal((K, C)).astype(np.float32)
+    weight = rng.standard_normal((C,)).astype(np.float32)
+    w2 = rng.standard_normal((C, Out)).astype(np.float32)
+    initializer = [
+        _f32(w1, "W1"),
+        onnx.numpy_helper.from_array(np.array(2.0, dtype=np.float32), "Two"),
+        onnx.numpy_helper.from_array(np.array(1e-5, dtype=np.float32), "Eps"),
+        onnx.numpy_helper.from_array(np.array(2.0, dtype=np.float32), "NotOne"),
+        _f32(weight, "Weight"),
+        _f32(w2, "W2"),
+    ]
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          x = MatMul(X, W1)
+          variance = Pow(x, Two)
+          meanvar = ReduceMean<axes=[-1]>(variance)
+          vareps = Add(meanvar, Eps)
+          std = Sqrt(vareps)
+          invstd = Div(NotOne, std)
+          scaled = Mul(x, invstd)
+          h = Mul(scaled, Weight)
+          Y = MatMul(h, W2)
+        }}
+        """,
+        initializer=initializer,
+        opset=17,
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
+def test_structured_pruning_decomposed_rms_norm_non_constant_weight_is_declined():
+    # The final Mul's own `weight` operand must be a genuine constant
+    # per-channel initializer -- a runtime-computed (graph-input-fed) operand
+    # is declined the same conservative way as a missing/non-constant
+    # `gamma`/`beta` on the LayerNorm decomposition.
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(345)
+    w1 = rng.standard_normal((K, C)).astype(np.float32)
+    w2 = rng.standard_normal((C, Out)).astype(np.float32)
+    initializer = [
+        _f32(w1, "W1"),
+        onnx.numpy_helper.from_array(np.array(2.0, dtype=np.float32), "Two"),
+        onnx.numpy_helper.from_array(np.array(1e-5, dtype=np.float32), "Eps"),
+        onnx.numpy_helper.from_array(np.array(1.0, dtype=np.float32), "One"),
+        _f32(w2, "W2"),
+    ]
+    model = _model(
+        f"""
+        g (float[batch,{K}] X, float[{C}] Weight) => (float[batch,{Out}] Y)
+        {{
+          x = MatMul(X, W1)
+          variance = Pow(x, Two)
+          meanvar = ReduceMean<axes=[-1]>(variance)
+          vareps = Add(meanvar, Eps)
+          std = Sqrt(vareps)
+          invstd = Div(One, std)
+          scaled = Mul(x, invstd)
+          h = Mul(scaled, Weight)
+          Y = MatMul(h, W2)
+        }}
+        """,
+        initializer=initializer,
+        opset=17,
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
+def test_structured_pruning_decomposed_rms_norm_inv_std_and_x_feed_different_muls_is_declined():
+    # `x` (the decomposition's own root) must be read by exactly one `Pow`
+    # and one `Mul`, and `inv_std` must feed *that exact same* `Mul` node --
+    # here `x`'s own second reader (`combine`) multiplies it by an unrelated
+    # constant instead of `invstd`, while `invstd` itself feeds a *different*
+    # Mul (`stray`, kept alive via a second graph output) -- not the shape
+    # this hop recognizes, so the chain must be left completely untouched,
+    # never partially matched.
+    K, C, Out = 8, 16, 4
+    rng = np.random.default_rng(346)
+    w1 = rng.standard_normal((K, C)).astype(np.float32)
+    weight = rng.standard_normal((C,)).astype(np.float32)
+    w2 = rng.standard_normal((C, Out)).astype(np.float32)
+    other = rng.standard_normal((C,)).astype(np.float32)
+    other2 = rng.standard_normal((C,)).astype(np.float32)
+    initializer = [
+        _f32(w1, "W1"),
+        onnx.numpy_helper.from_array(np.array(2.0, dtype=np.float32), "Two"),
+        onnx.numpy_helper.from_array(np.array(1e-5, dtype=np.float32), "Eps"),
+        onnx.numpy_helper.from_array(np.array(1.0, dtype=np.float32), "One"),
+        _f32(weight, "Weight"),
+        _f32(other, "Other"),
+        _f32(other2, "Other2"),
+        _f32(w2, "W2"),
+    ]
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y, float[batch,{C}] Extra)
+        {{
+          x = MatMul(X, W1)
+          variance = Pow(x, Two)
+          meanvar = ReduceMean<axes=[-1]>(variance)
+          vareps = Add(meanvar, Eps)
+          std = Sqrt(vareps)
+          invstd = Div(One, std)
+          combine = Mul(x, Other)
+          stray = Mul(invstd, Other2)
+          Extra = Identity(stray)
+          h = Mul(combine, Weight)
+          Y = MatMul(h, W2)
+        }}
+        """,
+        initializer=initializer,
+        opset=17,
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
 def test_structured_pruning_gated_ffn_layer_norm_pass_through_matches_oracle():
     # Composition check: a gated (SwiGLU-style) combine feeding a plain
     # LayerNormalization before the down-projection -- confirms the hop


### PR DESCRIPTION
## Summary

The module recognizes the *fused* `RMSNormalization` (opset 23+) op, but not RMSNorm's own decomposed shape — a structurally different topology from LayerNorm's decomposition (already covered) since RMSNorm has no centering `Sub` step at all. This matters more than it might first appear: RMSNorm's fused op is *only* reachable via PyTorch's newer dynamo exporter at opset ≥23 using `nn.RMSNorm` specifically — real HuggingFace Llama/Mistral/Qwen2/Gemma-family models don't use `nn.RMSNorm`, they hand-roll it (`variance = x.pow(2).mean(-1); x = x * rsqrt(variance+eps); x = weight * x`), which both the legacy exporter and dynamo below opset 23 always decompose. `nn.RMSNorm` itself even *fails to export at all* via the legacy path.

## Empirically confirmed facts

- `onnx.defs.get_schema("RMSNormalization").since_version == 23` — re-confirmed independently.
- `torch.onnx.export(nn.RMSNorm(...), dynamo=False)` fails outright (`aten::rms_norm` unsupported) — re-confirmed.
- `torch.onnx.export(nn.RMSNorm(...), dynamo=True, opset_version<23)` → `Reciprocal(std)` variant; `opset_version>=23` → native fused op — re-confirmed.
- A literal HF-style `LlamaRMSNorm` module's real `torch.onnx.export(dynamo=False, opset_version=17)` → exactly `Pow→ReduceMean→Add→Sqrt→Div(1.0,std)→Mul→Mul`, `x` read twice — **I independently reproduced this myself** (not just re-running the committed tests) with a fresh `Linear→LlamaRMSNorm→Linear` module and inspected the raw exported node list; it matches exactly.
- I independently reproduced the actual bug and fix via `apply_structured_pruning`: a hand-built `MatMul→{decomposition}→MatMul` model came back completely unpruned at the base commit; the fused-op control model pruned correctly.
- I independently re-ran the full verification suite: `pytest tests/test_pruning.py -q` → **840 passed** (833 → 840, +7 new tests), `ruff format --check`/`ruff check` clean, `mypy onnxsim/pruning.py` (exact scoped command) → **0 errors**, matching baseline.

## What's added / scope

- `_match_decomposed_rms_norm_pass_through`, mirroring `_match_decomposed_layer_norm_pass_through`'s exact discipline for the no-centering shape: `x_name` read by exactly one `Pow`(constant exponent `2.0`) and one `Mul` (the final `x * inv_std` combine); recognizes both the `Div(1.0, std)` (legacy/hand-rolled) and `Reciprocal(std)` (dynamo) variants; only the trailing `Mul`'s own `weight` operand is sliced (no `beta`/bias — RMSNorm has none).
- Refactored `_decomposed_layer_norm_pow_exponent_is_two` into a reusable `_flat_scalar_float_const_equals(name, initializer_map, value)`, shared with the new hop's `Div` numerator (`==1.0`) check.
- Wired into `_walk_to_consumer` at the identical two points `_match_decomposed_layer_norm_pass_through` already uses. Confirmed `_matmul_walk_root_ok`'s existing relaxation already covers this new hop for free (its body only checks "not a graph output"); updated its docstring to say so explicitly.
- `Reciprocal` deliberately **not** added to `_UNARY_PASS_THROUGH` — checked inline only, at its one fixed position in this hop, consistent with the module's existing precedent of not widening a general-purpose set for a shape-specific need.
- MatMul/Gemm-chain-only (never wired into Conv-chain walkers), matching LayerNorm's own decomposed-shape scope.

## Test plan

- [x] `Div(1.0, std)` variant prunes correctly, output matches an independently-reconstructed already-pruned reference model via real onnxruntime execution.
- [x] `Reciprocal(std)` variant, same bar.
- [x] Decline cases: wrong `Pow` exponent, wrong `Div` numerator, non-constant `weight`, `inv_std`/`x` feeding two different `Mul` nodes.
- [x] Existing fused `RMSNormalization`/`SimplifiedLayerNormalization` cases unaffected (no regression).
- [x] `pytest tests/test_pruning.py -q`: 833 → 840 passed.
- [x] `ruff format --check .` / `ruff check .`: clean.
- [x] `mypy onnxsim/pruning.py` (exact scoped command): 0 errors, matching baseline.

I independently re-verified this PR after implementation: reviewed the full matcher diff line by line, independently reproduced the real HuggingFace-style `LlamaRMSNorm` export shape myself in a fresh script, re-ran the entire verification suite fresh in the worktree, and confirmed the working tree was clean with everything properly committed.

**Separately** (not part of this PR's own scope, reported to the user directly rather than addressed here): while verifying this PR end-to-end through the full `torch.onnx.export → onnxsim.simplify() → apply_structured_pruning` pipeline, I found that `onnxsim.simplify()`'s `extract_constant_to_initializer` optimizer pass — despite being listed as a default pass and having C++ code that appears designed to convert bare `Constant` nodes into `graph.initializer` entries — does not actually do so in practice (confirmed in the simplest possible reproduction, a lone `Constant` feeding an `Add`, and in this PR's own realistic export pipeline). This module's docstrings (this hop's own, plus the Clip/ReLU6, decomposed-LayerNorm, and decomposed-GroupNorm hops from rounds 10-12) all state an assumption that such Constant-fed scalar/shape operands are "already folded into initializers by the time onnxsim's own optimizer pipeline is done" — an assumption this finding calls into question for real `simplify()`-processed models, separate from this hop's own test suite (which uses `onnx.parser`-built initializers directly and is therefore unaffected). This is a pre-existing, cross-cutting issue in onnxsim's own C++ optimizer, not something this PR introduces or should try to work around in `pruning.py`'s own Python code.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_