### PR TITLE
Add MSE calibration method: direct reconstruction-error clip search

### DIFF
--- a/onnxsim/calibration.py
+++ b/onnxsim/calibration.py
@@ -370,6 +370,71 @@ def _entropy_threshold(
     return best_threshold
 
 
+def _mse_threshold(
+    values: np.ndarray,
+    num_candidates: int = 100,
+    min_coverage: float = 0.5,
+) -> float:
+    """
+    Find the symmetric clip threshold ``T`` minimizing the *direct* mean
+    squared quantization error against ``values`` themselves (not a
+    histogram-binned KL-divergence proxy the way :func:`_entropy_threshold`
+    does) -- the "MSE calibration" family of clip-range search, e.g. the
+    percentile/MSE calibrators several PTQ toolkits ship, and specifically
+    the paper this repo's own :mod:`onnxsim.outlier_suppression` explicitly
+    declined to port: Outlier Suppression's own "Token-Wise Clipping" (Wei
+    et al., 2022, https://arxiv.org/abs/2209.13325) searches a clip range
+    the same way -- minimizing quantized reconstruction error directly --
+    rather than accepting a fixed min/max or an entropy-matched range.
+
+    The search: for ``num_candidates`` candidate thresholds ``t`` evenly
+    spaced between the ``min_coverage`` percentile of ``|values|`` and the
+    observed max, simulate symmetric INT8 quantization (``scale = t / 127``,
+    round-to-nearest, clip to ``[-127, 127]``, dequantize) of the *actual*
+    ``values`` (not a coarsened histogram) and measure the mean squared
+    error against the unquantized values. The threshold with the lowest MSE
+    wins. Unlike :func:`_entropy_threshold` (which only ever sees a
+    ``num_bins``-histogram approximation of the data), this measures the
+    real reconstruction error every candidate would actually produce, at
+    the cost of one full quantize-and-compare pass per candidate rather
+    than one histogram pass total.
+
+    ``min_coverage`` bounds the search from below (default: the search
+    never considers clipping away more than the top 50% by magnitude),
+    the same purpose :func:`_entropy_threshold`'s own ``min_coverage``
+    serves -- without it, a smooth, tail-free distribution (e.g. a raw
+    Gaussian) can still show a spuriously low MSE at a pathologically
+    small threshold purely from candidates degenerating together.
+
+    Falls back to the observed max (i.e. no clipping) when there is too
+    little data, or too little dynamic range, to search meaningfully.
+    """
+    v = values.astype(np.float64).ravel()
+    v = v[np.isfinite(v)]
+    if v.size == 0:
+        return 0.0
+    abs_v = np.abs(v)
+    abs_max = float(abs_v.max())
+    if abs_max <= 0.0:
+        return abs_max
+
+    floor = max(float(np.percentile(abs_v, min_coverage * 100.0)), abs_max * 1e-6)
+    if floor >= abs_max:
+        return abs_max
+
+    best_threshold = abs_max
+    best_mse = float("inf")
+    for t in np.linspace(floor, abs_max, num_candidates):
+        scale = t / 127.0
+        q = np.clip(np.round(v / scale), -127, 127) * scale
+        mse = float(np.mean((v - q) ** 2))
+        if mse < best_mse:
+            best_mse = mse
+            best_threshold = float(t)
+
+    return best_threshold
+
+
 def calibrate(
     model: Union[str, onnx.ModelProto],
     calibration_data: Sequence[Tensors],
@@ -377,6 +442,8 @@ def calibrate(
     method: str = "minmax",
     num_bins: int = 2048,
     num_quantized_bins: int = 128,
+    num_mse_candidates: int = 100,
+    mse_min_coverage: float = 0.5,
     extra_tensor_names: Optional[Sequence[str]] = None,
 ) -> Dict[str, Tuple[float, float]]:
     """
@@ -419,13 +486,30 @@ def calibrate(
             :func:`_entropy_threshold`. Left at INT8's 128 (one sign's worth)
             regardless of onnxsim's own uint8 range, matching the standard
             entropy-calibration convention this implements.
+            ``"mse"`` instead searches, per tensor, the symmetric clip
+            threshold minimizing quantized reconstruction error measured
+            directly against the observed values (see
+            :func:`_mse_threshold`) -- Outlier Suppression's own
+            "Token-Wise Clipping" (the technique :mod:`onnxsim.
+            outlier_suppression`'s own docstring explicitly declines to
+            port, since this function is where it belongs instead). Unlike
+            ``"entropy"``'s histogram-KL proxy, this measures real
+            reconstruction error at the cost of one full pass per candidate
+            threshold rather than one histogram pass total; needs the same
+            "at least a few hundred observed values per tensor" amount of
+            calibration data ``"entropy"`` does.
+    :param num_mse_candidates: (``"mse"`` only) number of candidate clip
+            thresholds the search evaluates -- see :func:`_mse_threshold`.
+    :param mse_min_coverage: (``"mse"`` only) floor on the search, as a
+            percentile of ``|values|`` below which no threshold is
+            considered -- see :func:`_mse_threshold`.
     :returns: ``{tensor_name: (min, max)}`` for every tensor
             ``onnxsim_cpp2py_export.list_quantizable_activations`` reports,
             plus ``extra_tensor_names`` if given
     """
     import onnxruntime as ort
 
-    if method not in ("minmax", "entropy"):
+    if method not in ("minmax", "entropy", "mse"):
         raise ValueError(f"unknown calibration method: {method!r}")
 
     if isinstance(model, str):
@@ -453,8 +537,9 @@ def calibrate(
     output_names = [o.name for o in sess.get_outputs()]
 
     ranges: Dict[str, Tuple[float, float]] = {}
-    # Only "entropy" needs every observed value kept around (to build a
-    # histogram from); "minmax" only ever needs a running (min, max).
+    # Only "entropy"/"mse" need every observed value kept around (to build a
+    # histogram from, or to measure reconstruction error against directly);
+    # "minmax" only ever needs a running (min, max).
     collected: Dict[str, List[np.ndarray]] = {}
     for batch in calibration_data:
         outputs = sess.run(output_names, batch)
@@ -471,7 +556,7 @@ def calibrate(
                 ranges[name] = (min(prev_min, batch_min), max(prev_max, batch_max))
             else:
                 ranges[name] = (batch_min, batch_max)
-            if method == "entropy":
+            if method in ("entropy", "mse"):
                 collected.setdefault(name, []).append(arr.ravel())
 
     if method == "entropy":
@@ -480,6 +565,15 @@ def calibrate(
                 np.concatenate(chunks),
                 num_bins=num_bins,
                 num_quantized_bins=num_quantized_bins,
+            )
+            obs_min, obs_max = ranges[name]
+            ranges[name] = (max(obs_min, -threshold), min(obs_max, threshold))
+    elif method == "mse":
+        for name, chunks in collected.items():
+            threshold = _mse_threshold(
+                np.concatenate(chunks),
+                num_candidates=num_mse_candidates,
+                min_coverage=mse_min_coverage,
             )
             obs_min, obs_max = ranges[name]
             ranges[name] = (max(obs_min, -threshold), min(obs_max, threshold))
@@ -523,9 +617,10 @@ def quantize_static(
             ``calibration_data`` is supplied)
     :param providers: onnxruntime execution providers to run calibration on
     :param method: calibration range method, passed through to
-            :func:`calibrate` -- ``"minmax"`` (default) or ``"entropy"``
-            (KL-divergence calibration; see that function for the tradeoff
-            and its extra data requirement).
+            :func:`calibrate` -- ``"minmax"`` (default), ``"entropy"``
+            (KL-divergence calibration), or ``"mse"`` (direct reconstruction-
+            error calibration); see that function for the tradeoffs and
+            their extra data requirement.
     :returns: the quantized onnx ModelProto
     """
     if isinstance(model, str):
@@ -572,9 +667,10 @@ def quantize_static_int16(
             ``calibration_data`` is supplied)
     :param providers: onnxruntime execution providers to run calibration on
     :param method: calibration range method, passed through to
-            :func:`calibrate` -- ``"minmax"`` (default) or ``"entropy"``
-            (KL-divergence calibration; see that function for the tradeoff
-            and its extra data requirement).
+            :func:`calibrate` -- ``"minmax"`` (default), ``"entropy"``
+            (KL-divergence calibration), or ``"mse"`` (direct reconstruction-
+            error calibration); see that function for the tradeoffs and
+            their extra data requirement.
     :returns: the quantized onnx ModelProto
     """
     if isinstance(model, str):
@@ -629,9 +725,10 @@ def quantize_qoperator(
             ``calibration_data`` is supplied)
     :param providers: onnxruntime execution providers to run calibration on
     :param method: calibration range method, passed through to
-            :func:`calibrate` -- ``"minmax"`` (default) or ``"entropy"``
-            (KL-divergence calibration; see that function for the tradeoff
-            and its extra data requirement).
+            :func:`calibrate` -- ``"minmax"`` (default), ``"entropy"``
+            (KL-divergence calibration), or ``"mse"`` (direct reconstruction-
+            error calibration); see that function for the tradeoffs and
+            their extra data requirement.
     :returns: the quantized onnx ModelProto
     """
     if isinstance(model, str):
@@ -702,9 +799,10 @@ def quantize_qoperator_elementwise(
             ``calibration_data`` is supplied)
     :param providers: onnxruntime execution providers to run calibration on
     :param method: calibration range method, passed through to
-            :func:`calibrate` -- ``"minmax"`` (default) or ``"entropy"``
-            (KL-divergence calibration; see that function for the tradeoff
-            and its extra data requirement).
+            :func:`calibrate` -- ``"minmax"`` (default), ``"entropy"``
+            (KL-divergence calibration), or ``"mse"`` (direct reconstruction-
+            error calibration); see that function for the tradeoffs and
+            their extra data requirement.
     :returns: the quantized onnx ModelProto
     """
     if isinstance(model, str):
@@ -765,9 +863,10 @@ def quantize_qoperator_activation(
             ``calibration_data`` is supplied)
     :param providers: onnxruntime execution providers to run calibration on
     :param method: calibration range method, passed through to
-            :func:`calibrate` -- ``"minmax"`` (default) or ``"entropy"``
-            (KL-divergence calibration; see that function for the tradeoff
-            and its extra data requirement).
+            :func:`calibrate` -- ``"minmax"`` (default), ``"entropy"``
+            (KL-divergence calibration), or ``"mse"`` (direct reconstruction-
+            error calibration); see that function for the tradeoffs and
+            their extra data requirement.
     :returns: the quantized onnx ModelProto
     """
     if isinstance(model, str):
@@ -828,9 +927,10 @@ def quantize_qoperator_concat(
             ``calibration_data`` is supplied)
     :param providers: onnxruntime execution providers to run calibration on
     :param method: calibration range method, passed through to
-            :func:`calibrate` -- ``"minmax"`` (default) or ``"entropy"``
-            (KL-divergence calibration; see that function for the tradeoff
-            and its extra data requirement).
+            :func:`calibrate` -- ``"minmax"`` (default), ``"entropy"``
+            (KL-divergence calibration), or ``"mse"`` (direct reconstruction-
+            error calibration); see that function for the tradeoffs and
+            their extra data requirement.
     :returns: the quantized onnx ModelProto
     """
     if isinstance(model, str):
@@ -899,9 +999,10 @@ def quantize_qoperator_softmax(
             ``calibration_data`` is supplied)
     :param providers: onnxruntime execution providers to run calibration on
     :param method: calibration range method, passed through to
-            :func:`calibrate` -- ``"minmax"`` (default) or ``"entropy"``
-            (KL-divergence calibration; see that function for the tradeoff
-            and its extra data requirement).
+            :func:`calibrate` -- ``"minmax"`` (default), ``"entropy"``
+            (KL-divergence calibration), or ``"mse"`` (direct reconstruction-
+            error calibration); see that function for the tradeoffs and
+            their extra data requirement.
     :returns: the quantized onnx ModelProto
     """
     if isinstance(model, str):
@@ -969,9 +1070,10 @@ def quantize_qoperator_pool(
             ``calibration_data`` is supplied)
     :param providers: onnxruntime execution providers to run calibration on
     :param method: calibration range method, passed through to
-            :func:`calibrate` -- ``"minmax"`` (default) or ``"entropy"``
-            (KL-divergence calibration; see that function for the tradeoff
-            and its extra data requirement).
+            :func:`calibrate` -- ``"minmax"`` (default), ``"entropy"``
+            (KL-divergence calibration), or ``"mse"`` (direct reconstruction-
+            error calibration); see that function for the tradeoffs and
+            their extra data requirement.
     :returns: the quantized onnx ModelProto
     """
     if isinstance(model, str):
@@ -1034,9 +1136,10 @@ def quantize_qoperator_where(
             ``calibration_data`` is supplied)
     :param providers: onnxruntime execution providers to run calibration on
     :param method: calibration range method, passed through to
-            :func:`calibrate` -- ``"minmax"`` (default) or ``"entropy"``
-            (KL-divergence calibration; see that function for the tradeoff
-            and its extra data requirement).
+            :func:`calibrate` -- ``"minmax"`` (default), ``"entropy"``
+            (KL-divergence calibration), or ``"mse"`` (direct reconstruction-
+            error calibration); see that function for the tradeoffs and
+            their extra data requirement.
     :returns: the quantized onnx ModelProto
     """
     if isinstance(model, str):
@@ -1112,9 +1215,10 @@ def quantize_qoperator_gemm(
             ``calibration_data`` is supplied)
     :param providers: onnxruntime execution providers to run calibration on
     :param method: calibration range method, passed through to
-            :func:`calibrate` -- ``"minmax"`` (default) or ``"entropy"``
-            (KL-divergence calibration; see that function for the tradeoff
-            and its extra data requirement).
+            :func:`calibrate` -- ``"minmax"`` (default), ``"entropy"``
+            (KL-divergence calibration), or ``"mse"`` (direct reconstruction-
+            error calibration); see that function for the tradeoffs and
+            their extra data requirement.
     :returns: the quantized onnx ModelProto
     """
     if isinstance(model, str):

--- a/tests/test_mse_calibration.py
+++ b/tests/test_mse_calibration.py
@@ -1,0 +1,185 @@
+"""Tests for MSE (direct reconstruction-error) calibration in
+``onnxsim.calibration`` -- ``method="mse"``. Unlike ``"entropy"`` (which
+minimizes KL divergence between the observed and simulated-quantized
+distributions via a histogram proxy), ``"mse"`` searches for the symmetric
+clip threshold minimizing quantized reconstruction error measured directly
+against the observed values -- the technique Outlier Suppression's own
+"Token-Wise Clipping" uses, and the gap ``onnxsim.outlier_suppression``'s
+own docstring explicitly leaves for this module. These tests check the
+threshold search in isolation, then the full ``quantize_static`` pipeline
+end-to-end through real ONNX Runtime inference, matching the pattern
+``test_entropy_calibration.py`` uses for its own method.
+"""
+
+import collections
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+from onnxsim.calibration import _mse_threshold
+
+# A bare ``import onnxruntime`` would fail collection (not skip the test) on
+# platforms onnxruntime doesn't ship wheels for (e.g. s390x).
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(body, initializer=(), opset=13, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _op_counts(model):
+    return collections.Counter(n.op_type for n in model.graph.node)
+
+
+def _assert_close(float_outputs, quant_outputs, threshold=0.1):
+    for f, q in zip(float_outputs, quant_outputs):
+        f = np.asarray(f, dtype=np.float64).ravel()
+        q = np.asarray(q, dtype=np.float64).ravel()
+        assert np.all(np.isfinite(q))
+        rel_l2 = np.linalg.norm(f - q) / max(np.linalg.norm(f), 1e-6)
+        assert rel_l2 < threshold, f"relative L2 error too large: {rel_l2:.4f}"
+
+
+def _quantize_mse(v, threshold):
+    scale = threshold / 127.0
+    return np.clip(np.round(v / scale), -127, 127) * scale
+
+
+def test_mse_threshold_clips_heavy_tailed_outliers():
+    rng = np.random.default_rng(0)
+    core = rng.normal(0, 1.0, size=20000)
+    outliers = rng.normal(0, 1.0, size=20) * 50
+    values = np.concatenate([core, outliers])
+
+    threshold = _mse_threshold(values, num_candidates=100, min_coverage=0.5)
+    raw_max = np.abs(values).max()
+    assert threshold < raw_max
+    # The core signal should survive essentially intact.
+    assert threshold > np.percentile(np.abs(core), 99.0)
+
+
+def test_mse_threshold_actually_minimizes_mse_among_candidates():
+    # The threshold the search returns should have reconstruction error no
+    # worse than every other candidate it considered, including the raw max
+    # (which is always one of the endpoints of the search grid).
+    rng = np.random.default_rng(1)
+    core = rng.normal(0, 1.0, size=5000)
+    outliers = rng.normal(0, 1.0, size=5) * 80
+    values = np.concatenate([core, outliers])
+
+    num_candidates = 50
+    threshold = _mse_threshold(values, num_candidates=num_candidates, min_coverage=0.5)
+    best_mse = np.mean((values - _quantize_mse(values, threshold)) ** 2)
+
+    abs_max = np.abs(values).max()
+    floor = max(np.percentile(np.abs(values), 50.0), abs_max * 1e-6)
+    for t in np.linspace(floor, abs_max, num_candidates):
+        mse = np.mean((values - _quantize_mse(values, t)) ** 2)
+        assert best_mse <= mse + 1e-9
+
+
+def test_mse_threshold_handles_sparse_data():
+    # Too few points that the floor/max collapse: falls back to the plain
+    # max rather than erroring or returning something degenerate.
+    values = np.array([1.0, -2.0, 3.0])
+    threshold = _mse_threshold(values, num_candidates=100, min_coverage=0.5)
+    assert threshold == pytest.approx(3.0)
+
+
+def test_mse_threshold_zero_values():
+    assert _mse_threshold(np.zeros(10000)) == 0.0
+
+
+def test_calibrate_mse_tighter_than_minmax_with_outliers():
+    # Unlike entropy calibration (which treats outliers as cheap-to-sacrifice
+    # low-probability-mass histogram bins and so clips even a single isolated
+    # spike), MSE calibration weighs candidates by *squared* magnitude -- a
+    # single extreme point contributes too much squared error to ever be
+    # worth clipping. So, matching
+    # ``test_mse_threshold_clips_heavy_tailed_outliers`` above, this uses a
+    # heavier tail (a handful of outlier batches, not just one) at a more
+    # moderate magnitude for MSE to show its own advantage on.
+    weight = _f32(np.random.default_rng(0).standard_normal((16, 8)), "W")
+    model = _model(
+        """
+        g (float[4,16] X) => (float[4,8] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """,
+        [weight],
+    )
+
+    rng = np.random.default_rng(1)
+    calibration_data = [
+        {"X": rng.standard_normal((4, 16)).astype(np.float32)} for _ in range(60)
+    ]
+    for _ in range(4):
+        spike = rng.standard_normal((4, 16)).astype(np.float32)
+        spike[0, 0] = 50.0
+        calibration_data.append({"X": spike})
+
+    minmax_ranges = onnxsim.calibrate(model, calibration_data, method="minmax")
+    mse_ranges = onnxsim.calibrate(model, calibration_data, method="mse")
+
+    minmax_lo, minmax_hi = minmax_ranges["X"]
+    mse_lo, mse_hi = mse_ranges["X"]
+    assert minmax_hi == pytest.approx(50.0)
+    assert mse_hi < minmax_hi
+    # Still wide enough to cover the actual (non-spike) signal.
+    assert mse_hi > 2.0
+
+
+def test_quantize_static_mse_method_end_to_end():
+    rng = np.random.default_rng(2)
+    K, N = 32, 16
+    weight = _f32(rng.standard_normal((K, N)) * 0.5, "W")
+    model = _model(
+        f"""
+        g (float[4,{K}] X) => (float[4,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [weight],
+    )
+
+    calibration_data = [
+        {"X": rng.standard_normal((4, K)).astype(np.float32)} for _ in range(128)
+    ]
+    quant = onnxsim.quantize_static(
+        model, calibration_data=calibration_data, method="mse"
+    )
+    onnx.checker.check_model(quant)
+    ops = _op_counts(quant)
+    assert ops["MatMul"] == 1
+    assert ops["QuantizeLinear"] == 1
+    assert ops["DequantizeLinear"] == 2
+
+    x = rng.standard_normal((4, K)).astype(np.float32)
+    _assert_close(_run(model, {"X": x}), _run(quant, {"X": x}))


### PR DESCRIPTION
## Summary

- Adds a third `onnxsim.calibrate()` method, `method="mse"`, alongside the existing `"minmax"` and `"entropy"`.
- `"mse"` searches, per tensor, the symmetric INT8 clip threshold that minimizes *direct* quantized reconstruction error (mean squared error) against the actually observed values -- not a histogram-binned KL-divergence proxy the way `"entropy"` does.
- This is the technique Outlier Suppression's own "Token-Wise Clipping" uses (Wei et al., 2022, https://arxiv.org/abs/2209.13325), and is the exact gap `onnxsim/outlier_suppression.py`'s own docstring explicitly left open: *"Token-Wise Clipping ... out of this module's own scope (`onnxsim.calibrate`'s existing `"minmax"`/`"entropy"` methods already cover the 'how to pick a clip range' question this repo answers elsewhere)."* This PR is that "elsewhere."

## How it works

`_mse_threshold(values, num_candidates=100, min_coverage=0.5)`: for `num_candidates` thresholds evenly spaced between the `min_coverage` percentile of `|values|` and the observed max, simulates symmetric INT8 quantization (`scale = t/127`, round-to-nearest, clip, dequantize) of the real values and measures MSE against the unquantized values directly. The threshold with lowest MSE wins; falls back to the observed max when there's too little data/dynamic range to search meaningfully.

`calibrate(..., method="mse")` wires this in the same shape as `"entropy"`: collects observed values per tensor across calibration batches, computes the MSE-minimizing threshold, and intersects `[-threshold, threshold]` with the observed `(min, max)`.

## Empirically confirmed facts

- MSE calibration and entropy calibration have a genuine, documented mathematical difference in how they treat outliers: entropy/KL-based clipping treats outliers as cheap-to-sacrifice low-probability-mass histogram bins and readily clips even a single isolated extreme point; MSE-based clipping weighs candidates by *squared* magnitude, so a single isolated outlier is too costly (in squared error) to clip away. Verified this directly -- a single 500x-magnitude outlier among ~4096 values does *not* move the MSE threshold off the raw max, while the same scenario is exactly what the existing entropy test demonstrates clipping on.
- With a heavier tail (multiple outlier batches, not just one) at a more moderate magnitude -- mirroring `test_mse_threshold_clips_heavy_tailed_outliers`'s own working 50x-magnitude/~0.1%-fraction scenario -- MSE calibration does produce a materially tighter range than min/max while still preserving the core signal's range.

## What's added / scope

- `onnxsim/calibration.py`: `_mse_threshold()`, `calibrate(method="mse", num_mse_candidates=100, mse_min_coverage=0.5)`, and docstring updates across the `quantize_static`/`quantize_qoperator*` family mentioning the new method.
- `tests/test_mse_calibration.py`: threshold-search unit tests (heavy-tailed outliers, actually-minimizes-MSE-among-candidates, sparse data, all-zero data) plus `calibrate()`/`quantize_static()` integration tests, matching `tests/test_entropy_calibration.py`'s established pattern (built via `onnx.parser.parse_model`, per repo convention).
- Pure Python change -- no C++ extension rebuild needed.

## Test plan

- [x] `pytest tests/test_mse_calibration.py -v` -- 6/6 passed
- [x] `pytest tests/test_entropy_calibration.py tests/test_mse_calibration.py -q` -- 16/16 passed (no regression in the sibling method)
- [x] `ruff check` / `ruff format --check` -- clean
- [x] `mypy onnxsim/calibration.py` -- no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxBPwkiTv7m32wAZtAubyc

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxBPwkiTv7m32wAZtAubyc)_