### PR TITLE
Add LLM-FP4: searched FP4 format + real-valued per-block scale

### DIFF
--- a/docs/llm-fp4.md
+++ b/docs/llm-fp4.md
@@ -1,0 +1,108 @@
+# LLM-FP4: searched FP4 format + real-valued per-block scale (`quantize_weight_only_llm_fp4`)
+
+## What this is
+
+`onnxsim.quantize_weight_only_llm_fp4` quantizes a layer's weight block-wise
+onto a **searched** standard sign/exponent/mantissa FP4 format: for each
+weight tensor, it tries every way to split FP4's 3 non-sign bits between
+exponent and mantissa (E1M2, E2M1, E3M0), and for each `(output channel,
+block)` group, a grid of real-valued scale candidates -- keeping whichever
+`(format, scale)` combination minimizes reconstruction MSE.
+
+```
+Before:
+  Y = MatMul(X, W) [+ bias]          -- W constant, [K, N], float32
+
+After:
+  Codebook: initializer, float32 [16]     -- winning format's 16 values
+  Wq: initializer, uint8 [K, N]           -- codebook index per element
+  Ws: initializer, float32 [K/block_size, N]  -- real-valued scale per block
+  What_hat = Reshape(Mul(Reshape(Gather(Codebook, Wq)), Ws), ...)
+  Y = MatMul(X, What_hat) [+ bias]
+```
+
+## Where this comes from
+
+[LLM-FP4](https://arxiv.org/abs/2310.16836) (Liu, Yuan, Yang, Cheng, Yang,
+Liu, Zhu and Xu, 2023, EMNLP) frames its quantizer's real-valued scale and
+its FP4 format's own exponent bias as the *same* degree of freedom
+("pre-shifted exponent bias"): scaling a block by `2^d` before quantizing to
+a fixed-bias FP4 codebook is identical to quantizing the unscaled block
+against a codebook whose bias has been shifted by `d`. The paper searches
+this freedom two ways -- a per-tensor search over the exponent/mantissa bit
+split, and a (for activations, per-channel; here, per weight-block)
+real-valued scale search -- rather than committing to one fixed format and a
+power-of-two scale the way `onnxsim.mx_quantization`'s MXFP4 does.
+
+This module realizes both searches directly:
+
+- **Format search**: `onnxsim.llm_fp4.FP4_FORMATS` enumerates E1M2, E2M1
+  (MXFP4's own element format), and E3M0 -- every way to split FP4's 3
+  non-sign bits. One format is chosen per weight tensor, by total
+  reconstruction MSE across every block.
+- **Scale search**: for each `(output channel, block)` group, a grid of
+  clip-ratio candidates (`min_clip_ratio` to `1.0`) is tried; the scale is
+  `max_abs_block * ratio / format_max_magnitude`, real-valued rather than
+  restricted to a power of two (`onnxsim.mx_quantization`'s own
+  restriction).
+
+Both searches minimize direct reconstruction MSE against the weight's own
+values -- the same "grid search over a small set of candidates against a
+direct error metric" shape `onnxsim.calibration`'s own `_entropy_threshold`
+already uses for INT8 range calibration (that function searches clip
+cutoffs against KL divergence; this module searches `(format, clip ratio)`
+pairs against MSE).
+
+## Scope
+
+**Weight-only.** The paper's other headline contribution -- migrating a
+per-channel real-valued *activation* scale into the preceding weight or
+LayerNormalization (via exactly the algebra `onnxsim.apply_smoothquant`/
+`onnxsim.apply_outlier_suppression` already implement), so that a single
+shared exponent bias suffices for a per-tensor FP4 *activation* quantizer,
+enabling full W4A4 -- is **not implemented here**. That migration machinery
+already exists in this repo and composes with this module unchanged (run
+either migration pass first); building the activation-side FP4 QDQ
+insertion itself (a new graph-run-time quantize/dequantize subgraph,
+analogous to `onnxsim.apply_zeroquant`'s own runtime INT8 activation
+quantization but emitting FP4 codes) is real additional scope, left as a
+follow-up. See `onnxsim/llm_fp4.py`'s own module docstring for the full
+rationale.
+
+Handled:
+
+- `MatMul(X, W)` with `W` a constant 2-D float32 tensor whose reduction
+  dimension `K` is divisible by `block_size`, or `Gemm(X, W)` with
+  `transA=0`, `alpha=1`, `beta=1`. `transB` may be 0 or 1.
+- Any opset -- the codebook lookup is built entirely from ordinary
+  `Gather`/`Reshape`/`Mul`/`Cast` (opset 11+).
+- `formats` to restrict (and speed up) the per-tensor search; `skip_names`
+  to leave specific matched weights unquantized.
+
+Left untouched (safe no-op, node passes through as-is):
+
+- Non-constant weights, non-2-D weights, or a reduction dimension not
+  divisible by `block_size`.
+
+## Usage
+
+```python
+import onnx
+import onnxsim
+
+model = onnx.load("model.onnx")
+quantized = onnxsim.quantize_weight_only_llm_fp4(model)  # block_size=32
+onnx.save(quantized, "model.llm_fp4.onnx")
+```
+
+Needs no calibration data: both the per-tensor format choice and the
+per-block scale are fit directly to each weight's own values, by exhaustive
+grid search minimizing reconstruction MSE.
+
+## Relationship to onnxsim's other 4-bit floating-point modules
+
+| | Format | Scale | Chosen how |
+|---|---|---|---|
+| `quantize_weight_only_mxfp4` | fixed E2M1 | power-of-two only | from the block's own max-abs |
+| `quantize_weight_only_nf4` | N/A (normal-distribution codebook, not sign/exp/mantissa) | absmax | from the block's own max-abs |
+| `quantize_weight_only_llm_fp4` | searched per tensor (E1M2/E2M1/E3M0) | real-valued, searched per block | grid search minimizing reconstruction MSE |

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -50,6 +50,7 @@ from onnxsim.gptq import apply_gptq
 from onnxsim.hqq import quantize_weight_only_int4_hqq
 from onnxsim.kmeans_quantization import quantize_weight_only_kmeans
 from onnxsim.kv_cache_quantization import quantize_kv_cache
+from onnxsim.llm_fp4 import FP4_FORMATS, quantize_weight_only_llm_fp4
 from onnxsim.llm_int8 import apply_llm_int8
 from onnxsim.low_rank_compensation import apply_low_rank_compensation
 from onnxsim.mixed_precision import apply_mixed_precision_quantization
@@ -225,6 +226,8 @@ __all__ = [
     "NF4_CODEBOOK",
     "quantize_weight_only_mxfp4",
     "MXFP4_CODEBOOK",
+    "quantize_weight_only_llm_fp4",
+    "FP4_FORMATS",
     "quantize_weight_only_squeezellm",
     "quantize_weight_only_aqlm",
     "quantize_weight_only_spqr",

--- a/onnxsim/llm_fp4.py
+++ b/onnxsim/llm_fp4.py
@@ -32,11 +32,14 @@ same representation :mod:`onnxsim.nf4` already uses for its own non-power-
 of-two scale), searched, together with the bit-split choice, by grid search
 against direct reconstruction MSE -- the same "hold everything else fixed,
 scan a small set of candidates, keep whichever minimizes a direct error
-metric" shape :func:`onnxsim.calibration._entropy_threshold` already uses
-for INT8 range calibration (that function scans candidate *clip cutoffs*
-against KL divergence; this module scans candidate *(format, clip ratio)*
-pairs against MSE -- a different search space and objective, same "grid
-search over candidates" shape).
+metric" shape :func:`onnxsim.calibration._mse_threshold`/:func:`onnxsim.
+calibration._entropy_threshold` already use for INT8 range calibration
+(``_mse_threshold`` scans candidate clip thresholds against *direct*
+reconstruction MSE -- the closer analogue to this module's own objective;
+``_entropy_threshold`` scans the same kind of candidates against a
+histogram-based KL divergence instead. This module scans candidate
+*(format, clip ratio)* pairs against MSE -- a different, two-dimensional
+search space, same "grid search over candidates" shape).
 
     Before:
       Y = MatMul(X, W) [+ bias]      -- W constant, [K, N], float32
@@ -208,8 +211,8 @@ def _search_llm_fp4_blockwise(
             # The "pre-shifted exponent bias" search, realized as a
             # real-valued per-block scale: r < 1 clips outliers harder but
             # sharpens resolution for the bulk of the block, exactly the
-            # clip-vs-resolution trade _entropy_threshold's own cutoff
-            # search makes for INT8 ranges.
+            # clip-vs-resolution trade _mse_threshold's own cutoff search
+            # makes for INT8 ranges.
             scale = np.maximum(max_abs * r / max_mag, 1e-30)  # [N, num_blocks]
             normalized = blocks / scale[:, :, np.newaxis]
             diffs = np.abs(normalized[..., np.newaxis] - codebook)

--- a/onnxsim/llm_fp4.py
+++ b/onnxsim/llm_fp4.py
@@ -1,0 +1,425 @@
+"""LLM-FP4 (Liu, Yuan, Yang, Cheng, Yang, Liu, Zhu and Xu, 2023, EMNLP,
+"LLM-FP4: 4-Bit Floating-Point Quantized Transformers",
+https://arxiv.org/abs/2310.16836). onnxsim ports the algorithm, not any
+framework's code, per the same rationale as :mod:`onnxsim.smoothquant`/
+:mod:`onnxsim.zeroquant`.
+
+**Relationship to onnxsim's other 4-bit floating-point modules.** onnxsim
+already has two other 4-bit *floating-point* codebook formats:
+:mod:`onnxsim.mx_quantization` (MXFP4: fixed E2M1 elements, per-block scale
+restricted to a **power of two**, per the OCP MX spec) and :mod:`onnxsim.nf4`
+(NormalFloat4: a fixed, data-*independent* 16-value codebook fit to a
+standard normal distribution's own quantile points, not a sign/exponent/
+mantissa format at all). LLM-FP4 is neither: it is a **standard**
+sign/exponent/mantissa FP4 format (like MXFP4's own E2M1), but
+
+1. its per-block scale is an ordinary **real-valued** float, not restricted
+   to a power of two (MXFP4's own restriction), and
+2. it does not fix the exponent/mantissa bit split at E2M1 -- it **searches**
+   a small set of splits (this module: E1M2, E2M1, E3M0 -- every way to
+   divide FP4's 3 non-sign bits between exponent and mantissa) per tensor,
+   picking whichever minimizes reconstruction error, rather than using one
+   format for every tensor unconditionally.
+
+Both properties come from the paper's own "pre-shifted exponent bias"
+framing: for a *floating-point* quantizer (unlike an affine INT4 quantizer),
+the per-block scale and the format's own exponent bias are two names for the
+same real-valued degree of freedom -- multiplying a block by ``2^d`` before
+quantizing to a fixed-bias FP4 codebook is identical to quantizing the
+unscaled block against a codebook whose bias has been shifted by ``d``. This
+module realizes that freedom directly as a per-block real-valued scale (the
+same representation :mod:`onnxsim.nf4` already uses for its own non-power-
+of-two scale), searched, together with the bit-split choice, by grid search
+against direct reconstruction MSE -- the same "hold everything else fixed,
+scan a small set of candidates, keep whichever minimizes a direct error
+metric" shape :func:`onnxsim.calibration._entropy_threshold` already uses
+for INT8 range calibration (that function scans candidate *clip cutoffs*
+against KL divergence; this module scans candidate *(format, clip ratio)*
+pairs against MSE -- a different search space and objective, same "grid
+search over candidates" shape).
+
+    Before:
+      Y = MatMul(X, W) [+ bias]      -- W constant, [K, N], float32
+
+    After:
+      Codebook: initializer, float32 [16]  -- winning format's 16 fixed
+                                               values (shared across every
+                                               layer that picks this format)
+      Wq: initializer, uint8 [K, N]        -- codebook index per element
+      Ws: initializer, float32 [K/block_size, N]  -- real-valued (not
+                                               power-of-two) scale per block
+      What_hat = Reshape(Mul(Reshape(Gather(Codebook, Wq)), Ws), ...)
+      Y = MatMul(X, What_hat) [+ bias]
+
+**Deliberately not ported: activation quantization (W4A4) via cross-layer
+exponent-bias migration.** The paper's other headline contribution is
+"pre-shifted exponent bias" applied to *activations*: transformer
+activations carry per-channel outliers (the same phenomenon
+:mod:`onnxsim.smoothquant`/:mod:`onnxsim.outlier_suppression` address for
+INT8), so the paper computes a per-channel real-valued scale from
+calibration data and migrates it algebraically into the preceding weight or
+LayerNormalization (exactly :mod:`onnxsim.smoothquant`'s and
+:mod:`onnxsim.outlier_suppression`'s own migration, with FP4's real-valued
+scale-as-bias standing in for those modules' INT8 quantization range) so
+that, after migration, a *single* shared exponent bias suffices for a
+straightforward per-tensor FP4 activation quantizer at graph-run time. That
+migration machinery already exists in this repo (:func:`onnxsim.
+apply_smoothquant`, :func:`onnxsim.apply_outlier_suppression`) and composes
+with this module unchanged: run either migration pass first, then quantize
+the migrated model's activations with a per-tensor FP4 QDQ-style insertion.
+Building that activation-side QDQ insertion itself -- the graph-run-time
+"quantize X to FP4, matmul against Wq" pipeline, analogous to
+:mod:`onnxsim.zeroquant`'s own runtime activation quantization but emitting
+FP4 codes instead of INT8 -- is real, non-trivial additional scope (a new
+runtime dequantization/quantization subgraph, not a data-flow migration),
+and is not implemented here. This module covers weight-only W4 quantization
+with the paper's own format-and-bias search as its differentiator from
+:mod:`onnxsim.mx_quantization`/:mod:`onnxsim.nf4`; W4A4 is a legitimate
+follow-up, not attempted in this module.
+
+ONNX has no native FP4 tensor type (as of this writing), so -- following the
+exact same approach :mod:`onnxsim.mx_quantization`/:mod:`onnxsim.nf4` already
+use for their own codebook formats -- this module builds the dequantization
+out of ordinary ONNX ops any opset-11+ runtime already supports: ``Gather``
+the per-element code out of a 16-entry constant codebook, then ``Mul`` by
+the per-block real-valued scale.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Union
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+
+from onnxsim.bias_correction import _all_names, _unique_name
+
+# Every way to split FP4's 3 non-sign bits between exponent and mantissa --
+# the paper's own candidate set for its per-tensor format search. Named
+# "eXmY" for X exponent bits, Y mantissa bits (X + Y == 3 always, since FP4
+# is 1 sign bit + 3 remaining bits).
+FP4_FORMATS: Dict[str, Tuple[int, int]] = {
+    "e1m2": (1, 2),
+    "e2m1": (2, 1),  # MXFP4's own element format (onnxsim.mx_quantization)
+    "e3m0": (3, 0),
+}
+
+
+def _fp4_magnitudes(e_bits: int, m_bits: int) -> List[float]:
+    """The 8 non-negative magnitudes an ``e_bits``-exponent/``m_bits``-
+    mantissa 4-bit float evaluates to, per the standard IEEE-754-style
+    definition (bias ``2^(e_bits-1) - 1``, exponent field 0 == subnormal).
+    Ascending, starting at ``0.0``. ``e_bits + m_bits`` must be 3 (FP4's 3
+    non-sign bits).
+    """
+    assert e_bits + m_bits == 3, "FP4 has 3 non-sign bits to split"
+    bias = (1 << (e_bits - 1)) - 1 if e_bits > 0 else 0
+    magnitudes = set()
+    for exp_field in range(1 << e_bits):
+        for mant_field in range(1 << m_bits):
+            frac = mant_field / float(1 << m_bits)
+            if exp_field == 0:
+                value = frac * (2.0 ** (1 - bias))  # subnormal
+            else:
+                value = (1.0 + frac) * (2.0 ** (exp_field - bias))  # normal
+            magnitudes.add(value)
+    return sorted(magnitudes)
+
+
+def _fp4_codebook(e_bits: int, m_bits: int) -> List[float]:
+    """The full 16 signed codes for an ``e_bits``/``m_bits`` FP4 format:
+    ``[-max, ..., -0.0, 0.0, ..., max]`` -- the same negatives-then-
+    positives-with-a-duplicate-zero layout :mod:`onnxsim.mx_quantization`'s
+    own ``MXFP4_CODEBOOK`` and :mod:`onnxsim.nf4`'s own ``NF4_CODEBOOK``
+    use, so ``_nearest_codebook_index``'s indexing convention matches
+    theirs.
+    """
+    magnitudes = _fp4_magnitudes(e_bits, m_bits)  # 8 ascending, [0] == 0.0
+    negatives = [-m for m in reversed(magnitudes)]  # -max ... -0.0
+    return negatives + magnitudes  # 16: -max...-0.0, 0.0...max
+
+
+def _match_matmul_like(node: onnx.NodeProto):
+    """Mirrors ``MatchMatMulLike`` (``passes/quantize_matmul_common.h``):
+    a MatMul, or a Gemm with ``transA=0``, ``alpha=1`` and (when it has a
+    bias) ``beta=1``. Returns ``(w_name, weight_transposed)`` or ``None``.
+    """
+    attrs = {a.name: a for a in node.attribute}
+    if node.op_type == "MatMul":
+        if len(node.input) != 2:
+            return None
+        return node.input[1], False
+    if node.op_type == "Gemm":
+        num_inputs = len(node.input)
+        if num_inputs not in (2, 3):
+            return None
+        trans_a = attrs.get("transA")
+        if trans_a is not None and trans_a.i != 0:
+            return None
+        alpha = attrs.get("alpha")
+        if alpha is not None and alpha.f != 1.0:
+            return None
+        if num_inputs == 3:
+            beta = attrs.get("beta")
+            if beta is not None and beta.f != 1.0:
+                return None
+        trans_b = attrs.get("transB")
+        weight_transposed = bool(trans_b is not None and trans_b.i)
+        return node.input[1], weight_transposed
+    return None
+
+
+def _search_llm_fp4_blockwise(
+    w_nk: np.ndarray,
+    block_size: int,
+    formats: Sequence[str],
+    clip_ratios: np.ndarray,
+) -> "tuple[str, np.ndarray, np.ndarray]":
+    """Searches, for ``w_nk`` ([N, K], output channel first), the ``formats``
+    x ``clip_ratios`` grid that minimizes total reconstruction MSE, per this
+    module's own docstring. Returns ``(best_format, codes_nk, scale_blocks)``:
+    codebook indices in ``[0, 15]`` (shape ``[N, K]``) and one real-valued
+    scale per ``(output channel, block-of-K)`` group (shape
+    ``[N, K // block_size]``) for the winning format. Assumes
+    ``K % block_size == 0`` and ``formats``/``clip_ratios`` non-empty.
+    """
+    n, k = w_nk.shape
+    num_blocks = k // block_size
+    blocks = w_nk.reshape(n, num_blocks, block_size)
+    max_abs = np.maximum(np.abs(blocks).max(axis=2), 1e-30)  # [N, num_blocks]
+
+    best_format = formats[0]
+    best_total_error = np.inf
+    best_codes = np.zeros((n, num_blocks, block_size), dtype=np.uint8)
+    best_scale = np.zeros((n, num_blocks))
+
+    for fmt in formats:
+        e_bits, m_bits = FP4_FORMATS[fmt]
+        codebook = np.asarray(_fp4_codebook(e_bits, m_bits), dtype=np.float64)
+        max_mag = codebook[-1]
+
+        fmt_best_error = np.full((n, num_blocks), np.inf)
+        fmt_best_scale = np.zeros((n, num_blocks))
+        fmt_best_codes = np.zeros((n, num_blocks, block_size), dtype=np.int64)
+
+        for r in clip_ratios:
+            # The "pre-shifted exponent bias" search, realized as a
+            # real-valued per-block scale: r < 1 clips outliers harder but
+            # sharpens resolution for the bulk of the block, exactly the
+            # clip-vs-resolution trade _entropy_threshold's own cutoff
+            # search makes for INT8 ranges.
+            scale = np.maximum(max_abs * r / max_mag, 1e-30)  # [N, num_blocks]
+            normalized = blocks / scale[:, :, np.newaxis]
+            diffs = np.abs(normalized[..., np.newaxis] - codebook)
+            codes = np.argmin(diffs, axis=-1)  # [N, num_blocks, block_size]
+            dequant_normalized = codebook[codes]
+            error = (
+                np.sum((dequant_normalized - normalized) ** 2, axis=-1) * scale**2
+            )  # [N, num_blocks], in the original (unnormalized) units
+
+            improved = error < fmt_best_error
+            fmt_best_error = np.where(improved, error, fmt_best_error)
+            fmt_best_scale = np.where(improved, scale, fmt_best_scale)
+            fmt_best_codes = np.where(improved[:, :, np.newaxis], codes, fmt_best_codes)
+
+        total_error = float(fmt_best_error.sum())
+        if total_error < best_total_error:
+            best_total_error = total_error
+            best_format = fmt
+            best_codes = fmt_best_codes
+            best_scale = fmt_best_scale
+
+    return best_format, best_codes.astype(np.uint8).reshape(n, k), best_scale
+
+
+def quantize_weight_only_llm_fp4(
+    model: Union[str, onnx.ModelProto],
+    block_size: int = 32,
+    formats: Sequence[str] = ("e1m2", "e2m1", "e3m0"),
+    num_scale_candidates: int = 17,
+    min_clip_ratio: float = 0.5,
+    skip_names: Optional[Iterable[str]] = None,
+) -> onnx.ModelProto:
+    """Quantizes every MatMul/vanilla-Gemm layer with a constant 2-D float32
+    weight (whose reduction dimension ``K`` is evenly divisible by
+    ``block_size``) into LLM-FP4's weight format -- see this module's own
+    docstring for the technique and its scope (weight-only; W4A4 activation
+    quantization is out of scope, but composes with this repo's existing
+    :func:`onnxsim.apply_smoothquant`/:func:`onnxsim.apply_outlier_suppression`
+    migrations, run first). Needs no calibration data: both the per-tensor
+    format choice and the per-block scale are fit directly to each weight's
+    own values, by exhaustive grid search minimizing reconstruction MSE.
+
+    :param model: the original (unquantized) onnx ModelProto or file path
+    :param block_size: elements per (output-channel, block) scale group
+            along the reduction dimension
+    :param formats: candidate FP4 exponent/mantissa bit splits to search per
+            tensor -- keys into :data:`FP4_FORMATS`. The paper's own
+            ablation set (every way to split FP4's 3 non-sign bits) is the
+            default; a subset restricts (and speeds up) the search
+    :param num_scale_candidates: number of per-block clip-ratio candidates
+            to grid-search (evenly spaced over ``[min_clip_ratio, 1.0]``)
+            for each format; more candidates costs more search time for a
+            finer-grained scale
+    :param min_clip_ratio: lower end of the per-block clip-ratio search
+            range -- ``1.0`` keeps the block's own max-abs element exactly
+            at the format's largest representable magnitude (no clipping);
+            values below ``1.0`` let the search trade a harder clip on
+            outliers for sharper resolution on the rest of the block
+    :param skip_names: weight initializer names to leave unquantized even
+            if otherwise eligible
+    :returns: ``model`` with every matched layer's weight replaced by
+            ``Mul(Reshape(Gather(codebook, Cast(Wq, INT64)), ...), Ws) ->
+            Reshape(..., original shape)`` feeding the original MatMul/Gemm
+            node -- ordinary ONNX ops only, no contrib op and no minimum
+            opset beyond what ``Gather``/``Cast``/``Reshape``/``Mul``
+            themselves need (opset 11+). Layers with a non-constant,
+            non-2-D, or non-block-divisible weight are left untouched.
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    skip_names = set(skip_names) if skip_names is not None else frozenset()
+    formats = list(formats)
+    if not formats or any(fmt not in FP4_FORMATS for fmt in formats):
+        raise ValueError(f"formats must be a non-empty subset of {sorted(FP4_FORMATS)}")
+    clip_ratios = np.linspace(min_clip_ratio, 1.0, max(num_scale_candidates, 1))
+
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    graph = out.graph
+    initializer_map = {t.name: t for t in graph.initializer}
+    taken_names = _all_names(graph)
+    codebook_names: Dict[str, str] = {}  # format -> initializer name, created lazily
+
+    nodes = list(graph.node)
+    for node in nodes:
+        match = _match_matmul_like(node)
+        if match is None:
+            continue
+        w_name, weight_transposed = match
+        if w_name in skip_names:
+            continue
+        w_init = initializer_map.get(w_name)
+        if (
+            w_init is None
+            or w_init.data_type != onnx.TensorProto.FLOAT
+            or len(w_init.dims) != 2
+        ):
+            continue
+
+        w = onnx.numpy_helper.to_array(w_init).astype(np.float64)
+        dim0, dim1 = w.shape
+        w_nk = w if weight_transposed else w.T  # [N, K]
+        n, k = w_nk.shape
+        if k % block_size != 0:
+            continue
+
+        fmt, codes_nk, scale_blocks = _search_llm_fp4_blockwise(
+            w_nk, block_size, formats, clip_ratios
+        )
+        codes_orig = codes_nk if weight_transposed else codes_nk.T
+        scale_orig = scale_blocks if weight_transposed else scale_blocks.T
+        assert codes_orig.shape == (dim0, dim1)
+
+        if fmt not in codebook_names:
+            e_bits, m_bits = FP4_FORMATS[fmt]
+            codebook_names[fmt] = _unique_name(f"llm_fp4_codebook_{fmt}", taken_names)
+            graph.initializer.append(
+                onnx.numpy_helper.from_array(
+                    np.asarray(_fp4_codebook(e_bits, m_bits), dtype=np.float32),
+                    name=codebook_names[fmt],
+                )
+            )
+        codebook_name = codebook_names[fmt]
+        num_blocks = k // block_size
+
+        wq = onnx.numpy_helper.from_array(
+            codes_orig.astype(np.uint8),
+            name=_unique_name(f"{w_name}_llmfp4_q", taken_names),
+        )
+        graph.initializer.append(wq)
+        ws = onnx.numpy_helper.from_array(
+            scale_orig.astype(np.float32),
+            name=_unique_name(f"{w_name}_llmfp4_scale", taken_names),
+        )
+        graph.initializer.append(ws)
+
+        if weight_transposed:
+            blocked_shape = [n, num_blocks, block_size]
+            scale_shape = [n, num_blocks, 1]
+        else:
+            blocked_shape = [num_blocks, block_size, n]
+            scale_shape = [num_blocks, 1, n]
+
+        cast_out = _unique_name(f"{w_name}_llmfp4_codes_i64", taken_names)
+        cast_node = onnx.helper.make_node(
+            "Cast", [wq.name], [cast_out], to=onnx.TensorProto.INT64
+        )
+
+        gather_out = _unique_name(f"{w_name}_llmfp4_gathered", taken_names)
+        gather_node = onnx.helper.make_node(
+            "Gather", [codebook_name, cast_out], [gather_out], axis=0
+        )
+
+        blocked_shape_name = _unique_name(f"{w_name}_llmfp4_blocked_shape", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(
+                np.asarray(blocked_shape, dtype=np.int64), name=blocked_shape_name
+            )
+        )
+        reshaped_out = _unique_name(f"{w_name}_llmfp4_reshaped", taken_names)
+        reshape1_node = onnx.helper.make_node(
+            "Reshape", [gather_out, blocked_shape_name], [reshaped_out]
+        )
+
+        scale_shape_name = _unique_name(f"{w_name}_llmfp4_scale_shape", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(
+                np.asarray(scale_shape, dtype=np.int64), name=scale_shape_name
+            )
+        )
+        scale_reshaped_out = _unique_name(
+            f"{w_name}_llmfp4_scale_reshaped", taken_names
+        )
+        reshape2_node = onnx.helper.make_node(
+            "Reshape", [ws.name, scale_shape_name], [scale_reshaped_out]
+        )
+
+        scaled_out = _unique_name(f"{w_name}_llmfp4_scaled", taken_names)
+        mul_node = onnx.helper.make_node(
+            "Mul", [reshaped_out, scale_reshaped_out], [scaled_out]
+        )
+
+        orig_shape_name = _unique_name(f"{w_name}_llmfp4_orig_shape", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(
+                np.asarray([dim0, dim1], dtype=np.int64), name=orig_shape_name
+            )
+        )
+        dq_out = _unique_name(f"{w_name}_llmfp4_dq", taken_names)
+        reshape3_node = onnx.helper.make_node(
+            "Reshape",
+            [scaled_out, orig_shape_name],
+            [dq_out],
+            name=_unique_name(f"{w_name}_llmfp4_dequant", taken_names),
+        )
+
+        insertion_point = next(i for i, n in enumerate(graph.node) if n is node)
+        for new_node in (
+            cast_node,
+            gather_node,
+            reshape1_node,
+            reshape2_node,
+            mul_node,
+            reshape3_node,
+        ):
+            graph.node.insert(insertion_point, new_node)
+            insertion_point += 1
+
+        for i, inp in enumerate(node.input):
+            if inp == w_name:
+                node.input[i] = dq_out
+
+    return out

--- a/tests/test_llm_fp4.py
+++ b/tests/test_llm_fp4.py
@@ -1,0 +1,324 @@
+"""Tests for ``onnxsim.quantize_weight_only_llm_fp4`` (LLM-FP4, see
+``onnxsim/llm_fp4.py``) -- block-wise quantization onto a searched
+sign/exponent/mantissa FP4 format (bit split searched per tensor) with a
+per-block *real-valued* scale (searched jointly, standing in for the
+paper's own "pre-shifted exponent bias"), represented in the ONNX graph via
+ordinary Gather/Reshape/Mul (no contrib op, no opset-21 features).
+
+Per this repo's own platform-numerics lesson (onnxruntime's MatMul kernel
+reduction order is not bit-exact across CPU architectures), value
+correctness is checked by dequantizing the written initializers directly in
+numpy and comparing against the original float weight with a tight
+*relative* tolerance -- never by comparing onnxruntime outputs with an
+absolute tolerance. Any onnxruntime round-trip check below is a separate,
+much looser sanity check.
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+from onnxsim.llm_fp4 import FP4_FORMATS, _fp4_codebook, _fp4_magnitudes
+from onnxsim.mx_quantization import MXFP4_CODEBOOK
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _model(body, initializer=(), opset=13, ir_version=8):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _matmul_model(K=64, N=16, weight=None, seed=0):
+    if weight is None:
+        rng = np.random.default_rng(seed)
+        weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[_f32(weight, "W")],
+    )
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
+
+
+def _codebook_used_by(model, w_name="W"):
+    gather = next(
+        n
+        for n in model.graph.node
+        if n.op_type == "Gather" and n.input[1] == f"{w_name}_llmfp4_codes_i64"
+    )
+    codebook_init = next(
+        t for t in model.graph.initializer if t.name == gather.input[0]
+    )
+    return onnx.numpy_helper.to_array(codebook_init).astype(np.float64)
+
+
+def _dequantize_llm_fp4_by_hand(model, w_name="W", block_size=32):
+    """Independent reference decode: reads Wq/Ws/the winning codebook
+    straight from the initializers and dequantizes via numpy, without using
+    any of the ops this module inserts into the graph.
+    """
+    wq = next(t for t in model.graph.initializer if t.name == f"{w_name}_llmfp4_q")
+    ws = next(t for t in model.graph.initializer if t.name == f"{w_name}_llmfp4_scale")
+    codes = onnx.numpy_helper.to_array(wq).astype(np.int64)
+    scale = onnx.numpy_helper.to_array(ws).astype(np.float64)
+    codebook = _codebook_used_by(model, w_name)
+
+    dim0, dim1 = codes.shape
+    num_blocks = scale.shape[0]
+    block_size_actual = dim0 // num_blocks
+    assert block_size_actual == block_size
+    values = codebook[codes]  # [dim0, dim1]
+    scale_full = np.repeat(scale, block_size, axis=0)  # [dim0, dim1]
+    return values * scale_full
+
+
+def test_llm_fp4_quantizes_matmul_with_standard_ops_only():
+    model = _matmul_model(K=64, N=16, seed=0)
+    q = onnxsim.quantize_weight_only_llm_fp4(model, block_size=32)
+    onnx.checker.check_model(q)
+
+    op_types = {n.op_type for n in q.graph.node}
+    assert op_types <= {"MatMul", "Cast", "Gather", "Reshape", "Mul"}
+    assert all(n.domain in ("", "ai.onnx") for n in q.graph.node)
+
+
+def test_llm_fp4_dequantized_values_match_hand_decoded_reference():
+    rng = np.random.default_rng(1)
+    weight = rng.standard_normal((64, 16)).astype(np.float32) * 0.3
+    model = _matmul_model(weight=weight)
+    q = onnxsim.quantize_weight_only_llm_fp4(model, block_size=32)
+
+    w_hand = _dequantize_llm_fp4_by_hand(q, block_size=32)
+    codebook = _codebook_used_by(q)
+    max_gap = np.max(np.diff(np.sort(codebook)))
+
+    ws = next(t for t in q.graph.initializer if t.name == "W_llmfp4_scale")
+    scale = onnx.numpy_helper.to_array(ws).astype(np.float64)
+    scale_full = np.repeat(scale, 32, axis=0)
+
+    # Every element's dequantization error must be within half the largest
+    # codebook gap scaled by that element's own block scale -- a real
+    # per-element correctness check against ground truth computed a
+    # completely different way (never via onnxruntime), per this repo's own
+    # cross-platform-numerics guidance.
+    assert np.all(
+        np.abs(w_hand - weight.astype(np.float64)) <= max_gap * scale_full / 2 + 1e-6
+    )
+
+
+def test_llm_fp4_output_stays_close_to_float_via_onnxruntime():
+    model = _matmul_model(K=64, N=16, seed=2)
+    q = onnxsim.quantize_weight_only_llm_fp4(model, block_size=32)
+    onnx.checker.check_model(q)
+
+    rng = np.random.default_rng(3)
+    x = rng.standard_normal((8, 64)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x})
+    (q_y,) = _run(q, {"X": x})
+    assert np.all(np.isfinite(q_y))
+    # Loose, absolute-precision-agnostic sanity check only -- the tight,
+    # authoritative correctness check is the numpy hand-decode above.
+    assert _rel_l2(float_y, q_y) < 0.3
+
+
+def test_llm_fp4_gemm_transb():
+    rng = np.random.default_rng(4)
+    K, N = 128, 12
+    weight = rng.standard_normal((N, K)).astype(np.float32) * 0.5
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = Gemm<transB = 1>(X, W)
+        }}
+        """,
+        initializer=[_f32(weight, "W")],
+    )
+    q = onnxsim.quantize_weight_only_llm_fp4(model, block_size=32)
+    onnx.checker.check_model(q)
+
+    x = rng.standard_normal((4, K)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x})
+    (q_y,) = _run(q, {"X": x})
+    assert _rel_l2(float_y, q_y) < 0.3
+
+
+def test_llm_fp4_codes_stay_in_range():
+    rng = np.random.default_rng(5)
+    weight = rng.standard_normal((64, 8)).astype(np.float32) * 3
+    model = _matmul_model(weight=weight)
+    q = onnxsim.quantize_weight_only_llm_fp4(model, block_size=32)
+    wq = next(t for t in q.graph.initializer if t.name == "W_llmfp4_q")
+    codes = onnx.numpy_helper.to_array(wq)
+    assert np.all(codes >= 0) and np.all(codes <= 15)
+
+
+def test_llm_fp4_skips_non_block_divisible_k():
+    model = _matmul_model(K=48, N=8, seed=6)  # 48 is not a multiple of 32
+    q = onnxsim.quantize_weight_only_llm_fp4(model, block_size=32)
+    assert q.SerializeToString() == model.SerializeToString()
+
+
+def test_llm_fp4_skip_names_leaves_matched_weight_untouched():
+    rng = np.random.default_rng(7)
+    w_base = rng.standard_normal((64, 16)).astype(np.float32) * 0.5
+    w_other = rng.standard_normal((64, 4)).astype(np.float32) * 0.1
+    model = _model(
+        """
+        g (float[batch,64] X) => (float[batch,16] Y, float[batch,4] H)
+        {
+          Y = MatMul(X, W)
+          H = MatMul(X, W_other)
+        }
+        """,
+        initializer=[_f32(w_base, "W"), _f32(w_other, "W_other")],
+    )
+    q = onnxsim.quantize_weight_only_llm_fp4(
+        model, block_size=32, skip_names=["W_other"]
+    )
+    onnx.checker.check_model(q)
+
+    names = {t.name for t in q.graph.initializer}
+    assert "W_llmfp4_q" in names
+    assert "W_other_llmfp4_q" not in names
+    other_out = next(
+        onnx.numpy_helper.to_array(t)
+        for t in q.graph.initializer
+        if t.name == "W_other"
+    )
+    assert np.array_equal(other_out, w_other)
+
+
+def test_llm_fp4_skips_non_constant_weight():
+    model = _model(
+        """
+        g (float[4,64] X, float[64,4] W) => (float[4,4] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """
+    )
+    q = onnxsim.quantize_weight_only_llm_fp4(model)
+    assert q.SerializeToString() == model.SerializeToString()
+
+
+def test_llm_fp4_rejects_unknown_format():
+    model = _matmul_model()
+    with pytest.raises(ValueError):
+        onnxsim.quantize_weight_only_llm_fp4(model, formats=["not_a_format"])
+
+
+def test_llm_fp4_e2m1_codebook_matches_mxfp4():
+    # E2M1 is exactly MXFP4's own element format -- the two codebooks must
+    # be identical sets of magnitudes (this module's own layout convention
+    # matches onnxsim.mx_quantization's, so they should be byte-identical).
+    e2m1 = np.asarray(_fp4_codebook(*FP4_FORMATS["e2m1"]))
+    mxfp4 = np.asarray(MXFP4_CODEBOOK)
+    assert np.array_equal(e2m1, mxfp4)
+
+
+def test_llm_fp4_formats_have_eight_magnitudes_each():
+    for e_bits, m_bits in FP4_FORMATS.values():
+        magnitudes = _fp4_magnitudes(e_bits, m_bits)
+        assert len(magnitudes) == 8
+        assert magnitudes[0] == 0.0
+        assert np.all(np.diff(magnitudes) > 0)  # strictly increasing
+
+
+def test_llm_fp4_codebooks_are_well_formed():
+    for fmt in FP4_FORMATS:
+        e_bits, m_bits = FP4_FORMATS[fmt]
+        codebook = np.asarray(_fp4_codebook(e_bits, m_bits))
+        assert codebook.shape == (16,)
+        assert np.all(np.diff(codebook) >= 0)  # non-decreasing (duplicate zero)
+        assert list(codebook).count(0.0) == 2  # +0.0 and -0.0
+        assert codebook[0] == -codebook[-1]  # symmetric
+
+
+def test_llm_fp4_scale_is_not_restricted_to_power_of_two():
+    # Unlike onnxsim.mx_quantization's MXFP4 (E8M0: power-of-two only), this
+    # module's own per-block scale is real-valued -- the whole point of
+    # realizing the paper's "pre-shifted exponent bias" as a per-block
+    # scale search rather than reusing MX's narrower E8M0 restriction.
+    rng = np.random.default_rng(9)
+    weight = rng.standard_normal((64, 16)).astype(np.float32) * 3.7
+    model = _matmul_model(weight=weight)
+    q = onnxsim.quantize_weight_only_llm_fp4(model, block_size=32)
+
+    ws = next(t for t in q.graph.initializer if t.name == "W_llmfp4_scale")
+    scale = onnx.numpy_helper.to_array(ws).astype(np.float64).ravel()
+    log2_scale = np.log2(scale)
+    assert not np.all(np.abs(log2_scale - np.round(log2_scale)) < 1e-9)
+
+
+def test_llm_fp4_format_search_beats_a_forced_single_format():
+    # A weight tailor-made to reconstruct much better under E3M0 (wide
+    # dynamic range, coarse mantissa -- octave-spaced magnitudes) than
+    # E1M2 (narrow range, fine mantissa): the full search (default
+    # `formats`) must find a reconstruction at least as good as forcing
+    # E1M2 alone, and strictly better on this adversarial tensor.
+    rng = np.random.default_rng(10)
+    exponents = rng.integers(-6, 7, size=(64, 16))
+    weight = (2.0**exponents).astype(np.float32) * rng.choice(
+        [-1.0, 1.0], size=(64, 16)
+    ).astype(np.float32)
+    model = _matmul_model(weight=weight)
+
+    q_search = onnxsim.quantize_weight_only_llm_fp4(model, block_size=32)
+    q_e1m2 = onnxsim.quantize_weight_only_llm_fp4(
+        model, block_size=32, formats=["e1m2"]
+    )
+
+    w_search = _dequantize_llm_fp4_by_hand(q_search, block_size=32)
+    w_e1m2 = _dequantize_llm_fp4_by_hand(q_e1m2, block_size=32)
+    w64 = weight.astype(np.float64)
+
+    err_search = np.sum((w_search - w64) ** 2)
+    err_e1m2 = np.sum((w_e1m2 - w64) ** 2)
+    assert err_search <= err_e1m2
+    assert err_search < err_e1m2 * 0.9  # strictly, meaningfully better
+
+
+def test_llm_fp4_restricting_formats_only_uses_requested_ones():
+    rng = np.random.default_rng(11)
+    weight = rng.standard_normal((64, 16)).astype(np.float32) * 0.5
+    model = _matmul_model(weight=weight)
+    q = onnxsim.quantize_weight_only_llm_fp4(model, block_size=32, formats=["e3m0"])
+
+    names = {t.name for t in q.graph.initializer}
+    assert "llm_fp4_codebook_e3m0" in names
+    assert "llm_fp4_codebook_e1m2" not in names
+    assert "llm_fp4_codebook_e2m1" not in names

--- a/tests/test_llm_fp4.py
+++ b/tests/test_llm_fp4.py
@@ -115,7 +115,20 @@ def test_llm_fp4_quantizes_matmul_with_standard_ops_only():
     assert all(n.domain in ("", "ai.onnx") for n in q.graph.node)
 
 
-def test_llm_fp4_dequantized_values_match_hand_decoded_reference():
+def test_llm_fp4_dequantized_values_match_independently_recomputed_nearest_codebook():
+    # Unlike onnxsim.mx_quantization/onnxsim.nf4 (whose block scale always
+    # keeps the block's own max-abs element within the codebook's range),
+    # this module's own scale search can deliberately choose a *tighter*
+    # scale that clips outliers in exchange for lower total MSE -- so a
+    # fixed "within half a codebook gap" per-element bound (those other
+    # modules' own test pattern) does not hold here. Instead: trust only
+    # the search's chosen per-block *scale* (Ws), and independently
+    # recompute -- via nearest-codebook-index search, entirely in numpy,
+    # not using any op this module inserts into the graph -- what the
+    # *codes* (Wq) should be for that scale. This still catches any bug in
+    # either the code assignment or the Gather/Reshape/Mul dequantization
+    # subgraph, without assuming anything about how tightly the search
+    # itself clips.
     rng = np.random.default_rng(1)
     weight = rng.standard_normal((64, 16)).astype(np.float32) * 0.3
     model = _matmul_model(weight=weight)
@@ -123,20 +136,26 @@ def test_llm_fp4_dequantized_values_match_hand_decoded_reference():
 
     w_hand = _dequantize_llm_fp4_by_hand(q, block_size=32)
     codebook = _codebook_used_by(q)
-    max_gap = np.max(np.diff(np.sort(codebook)))
 
     ws = next(t for t in q.graph.initializer if t.name == "W_llmfp4_scale")
     scale = onnx.numpy_helper.to_array(ws).astype(np.float64)
     scale_full = np.repeat(scale, 32, axis=0)
 
-    # Every element's dequantization error must be within half the largest
-    # codebook gap scaled by that element's own block scale -- a real
-    # per-element correctness check against ground truth computed a
-    # completely different way (never via onnxruntime), per this repo's own
-    # cross-platform-numerics guidance.
-    assert np.all(
-        np.abs(w_hand - weight.astype(np.float64)) <= max_gap * scale_full / 2 + 1e-6
+    normalized = weight.astype(np.float64) / scale_full
+    diffs = np.abs(normalized[..., np.newaxis] - codebook[np.newaxis, np.newaxis, :])
+    nearest_idx = np.argmin(diffs, axis=-1)
+    independent_dequant = codebook[nearest_idx] * scale_full
+
+    assert np.allclose(w_hand, independent_dequant, atol=1e-4, rtol=1e-4)
+
+    # A loose sanity bound on overall reconstruction quality (this weight's
+    # own measured relative L2 error is ~0.09) -- catches a search that
+    # regressed to picking wildly bad scales/formats, without pinning an
+    # exact number.
+    rel_l2 = np.linalg.norm(w_hand - weight.astype(np.float64)) / np.linalg.norm(
+        weight.astype(np.float64)
     )
+    assert rel_l2 < 0.2
 
 
 def test_llm_fp4_output_stays_close_to_float_via_onnxruntime():


### PR DESCRIPTION
## Summary

Adds `onnxsim.quantize_weight_only_llm_fp4` (`onnxsim/llm_fp4.py`): weight-only 4-bit floating-point quantization implementing LLM-FP4 (Liu et al., 2023, EMNLP, ["LLM-FP4: 4-Bit Floating-Point Quantized Transformers"](https://arxiv.org/abs/2310.16836)).

This repo already has two other 4-bit floating-point codebook formats -- `onnxsim.mx_quantization` (MXFP4: fixed E2M1, power-of-two-only block scale) and `onnxsim.nf4` (a fixed, data-independent normal-distribution codebook). LLM-FP4 is distinct from both: it's a standard sign/exponent/mantissa FP4 format whose key contribution is **searching**, per weight tensor:

1. which exponent/mantissa bit split (E1M2, E2M1, E3M0 -- every way to divide FP4's 3 non-sign bits) minimizes reconstruction error, and
2. a **real-valued** (not power-of-two) per-block scale -- the paper's own "pre-shifted exponent bias" framing, where the scale and the format's exponent bias are the same real-valued degree of freedom.

Both searches are grid searches minimizing direct reconstruction MSE, the same shape `onnxsim.calibration._mse_threshold`/`_entropy_threshold` already use for INT8 clip-range calibration.

## What's added / scope

- `onnxsim/llm_fp4.py`: `quantize_weight_only_llm_fp4(model, block_size=32, formats=(...), num_scale_candidates=17, min_clip_ratio=0.5, skip_names=None)`, plus `FP4_FORMATS` and the codebook helpers (`_fp4_magnitudes`, `_fp4_codebook`). Matches every existing block-wise codebook module's structure and I/O shape (`MatMul`/vanilla-`Gemm` with a constant 2-D float32 weight, block-divisible `K`; dequantized via `Gather`/`Reshape`/`Mul` -- no contrib op, no opset floor beyond 11).
- Registered in `onnxsim/__init__.py` (import + `__all__`): `quantize_weight_only_llm_fp4`, `FP4_FORMATS`.
- `tests/test_llm_fp4.py` (15 tests): standard-ops-only check, an independent-nearest-codebook-recomputation correctness check against the search's own chosen scale (not a fixed "half a codebook gap" bound, since this module's scale search can deliberately clip -- unlike MXFP4/NF4's own absmax-based scale), a loose onnxruntime round-trip sanity check, `Gemm(transB=1)`, codes-in-range, `skip_names`, non-constant/non-block-divisible-K no-ops, an unknown-format rejection, codebook well-formedness, confirmation that E2M1's codebook is byte-identical to `MXFP4_CODEBOOK`, confirmation the scale is *not* restricted to a power of two, an adversarial test proving the format search picks a meaningfully better format than a forced single format, and a `formats=` restriction test.
- `docs/llm-fp4.md`: module doc mirroring `docs/mxfp4.md`/`docs/zeroquant.md`'s structure.

**Scope**: weight-only. The paper's other contribution -- migrating a per-channel real-valued *activation* scale into the preceding weight/LayerNorm (via the same algebra `onnxsim.apply_smoothquant`/`onnxsim.apply_outlier_suppression` already implement) so a single shared exponent bias suffices for a per-tensor FP4 *activation* quantizer, enabling full W4A4 -- is **not implemented here**. That migration machinery already exists in this repo and composes with this module unchanged (run either migration pass first); building the activation-side FP4 QDQ insertion itself is real, non-trivial additional scope and is left as a follow-up. See the module's own docstring ("Deliberately not ported" section) for the full rationale.

## Test plan

All commands run against this branch after merging current `master`:

- `pytest tests/test_llm_fp4.py -v` -- **15 passed**
- `pytest tests/test_mx_quantization.py tests/test_nf4.py -q` -- **19 passed** (no regression in the closest neighboring modules)
- `pytest tests/test_mse_calibration.py -q` -- **6 passed** (sanity check against the concurrently-merged MSE calibration module this PR's docstring now cross-references)
- `ruff check onnxsim/llm_fp4.py tests/test_llm_fp4.py onnxsim/__init__.py` -- **all checks passed**
- `ruff format --check` on the same files -- **all formatted**
- `mypy` (bare, matching `.github/workflows/lint.yml`'s exact invocation -- ruff 0.14.0/mypy 1.18.2, no third-party deps installed) -- **Success: no issues found in 58 source files**
- Manual: independently verified in a standalone interpreter (bypassing the compiled `onnxsim_cpp2py_export` extension) that `_fp4_codebook(2, 1)` (E2M1) is byte-identical to `onnxsim.mx_quantization.MXFP4_CODEBOOK`, and that the format search picks E3M0 over a forced E1M2 on an octave-spaced adversarial weight with ~300x lower reconstruction MSE.

Per this repo's `CLAUDE.md` platform-numerics guidance, value correctness is checked by dequantizing the written ONNX initializers directly in numpy against a tight tolerance -- never via an onnxruntime round-trip with an absolute tolerance (that check is kept separate and loose, `< 0.3` relative L2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mU6YhVjYHNMib3eUW5G3d

---
_Generated by [Claude Code](https://claude.ai/code/session_016mU6YhVjYHNMib3eUW5G3d)_