### PR TITLE
Add JAX/Flax ONNX export integration tests via jax2onnx

### DIFF
--- a/.github/workflows/backend-integration.yml
+++ b/.github/workflows/backend-integration.yml
@@ -4,11 +4,12 @@ name: Backend Integration
 # ONNX-consuming compiler/runtime stacks (Apache TVM, nncase, Halide, tinygrad,
 # PyTorch via onnx2torch, Apple's MLX), quantize-then-simplify pipelines
 # (NVIDIA ModelOpt), or a deployment toolbox's own backend runtime wrapper
-# (OpenMMLab mmdeploy) — tests/test_tvm_integration.py,
-# tests/test_nncase_integration.py, tests/test_halide_integration.py,
-# tests/test_tinygrad_integration.py, tests/test_torch_integration.py,
-# tests/test_mlx_integration.py, tests/test_modelopt_integration.py,
-# tests/test_mmdeploy_integration.py. See docs/dlpack-executor.md, which frames
+# (OpenMMLab mmdeploy), or a JAX/Flax ONNX frontend (jax2onnx) —
+# tests/test_tvm_integration.py, tests/test_nncase_integration.py,
+# tests/test_halide_integration.py, tests/test_tinygrad_integration.py,
+# tests/test_torch_integration.py, tests/test_mlx_integration.py,
+# tests/test_modelopt_integration.py, tests/test_mmdeploy_integration.py,
+# tests/test_jax_export_integration.py. See docs/dlpack-executor.md, which frames
 # the DLPack executor boundary as an "embeddability" seam for stacks like these.
 # The xnnpack job below is the odd one out: it exercises
 # GetXnnpackModelExecutor() (onnxsim/xnnpack_executor_test.cpp) directly via a
@@ -25,10 +26,11 @@ name: Backend Integration
 # for its shards.
 #
 # None of apache-tvm / nncase / halide / tinygrad / torch+onnx2torch / mlx /
-# nvidia-modelopt / mmdeploy are part of onnxsim's test requirements (nncase
-# needs the .NET runtime; modelopt, the torch job, and mmdeploy all drag in
-# torch + CUDA wheels), so this runs in its own workflow instead of the
-# build-and-test matrix. Runs on PRs that touch the harness or the simplifier,
+# nvidia-modelopt / mmdeploy / jax2onnx are part of onnxsim's test
+# requirements (nncase needs the .NET runtime; modelopt, the torch job,
+# mmdeploy, and jax2onnx all drag in torch/jax + CUDA wheels), so this runs
+# in its own workflow instead of the build-and-test matrix. Runs on PRs that
+# touch the harness or the simplifier,
 # on a daily schedule to catch new releases of the downstream tools, and on
 # demand.
 
@@ -46,6 +48,7 @@ on:
       - "tests/test_mlx_integration.py"
       - "tests/test_modelopt_integration.py"
       - "tests/test_mmdeploy_integration.py"
+      - "tests/test_jax_export_integration.py"
       - ".github/workflows/backend-integration.yml"
       - "onnxsim/onnx_simplifier.py"
       - "onnxsim/onnxsim.cpp"
@@ -370,6 +373,39 @@ jobs:
       - name: Run mmdeploy integration tests
         working-directory: ${{ runner.temp }}
         run: pytest -v "$GITHUB_WORKSPACE/tests/test_mmdeploy_integration.py"
+
+  jax:
+    name: Simplify ONNX exported from JAX/Flax (jax2onnx)
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - uses: actions/download-artifact@v8
+        with:
+          name: onnxsim-wheel-backend
+          path: wheelhouse
+      # jax2onnx pulls in jax, flax, onnxruntime, and its own onnx/onnx-ir
+      # copies as ordinary dependencies -- no extra install step needed
+      # beyond it.
+      - name: Install onnxsim wheel + jax2onnx
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest jax2onnx
+          python -m pip install wheelhouse/*.whl
+      - name: Verify the installed wheel is used (not the source tree)
+        working-directory: ${{ runner.temp }}
+        run: |
+          python -c "import onnxsim, onnxsim.onnxsim_cpp2py_export as m; print(onnxsim.__version__, m.__file__)"
+          python -c "import jax, jax2onnx; print('jax', jax.__version__, 'jax2onnx', jax2onnx.__file__)"
+      # Run from a neutral directory so the repo root's ./onnxsim source package
+      # (without the compiled extension) does not shadow the installed wheel.
+      - name: Run JAX export integration tests
+        working-directory: ${{ runner.temp }}
+        run: pytest -v "$GITHUB_WORKSPACE/tests/test_jax_export_integration.py"
 
   xnnpack:
     name: XNNPACK ModelExecutor backend (native)

--- a/tests/test_jax_export_integration.py
+++ b/tests/test_jax_export_integration.py
@@ -1,0 +1,161 @@
+"""Integration tests exporting ONNX models from JAX -- and from Flax NNX
+modules built on top of it -- via the third-party `jax2onnx
+<https://github.com/enpasos/jax2onnx>`_ converter, then feeding that ONNX
+graph through onnxsim.simplify().
+
+JAX has no official/first-party ONNX exporter (see
+https://github.com/jax-ml/jax/issues/7629); jax2onnx traces JAX code through
+the same jaxpr machinery XLA compiles and lowers it directly to ONNX. That
+makes it a genuinely independent onnx-producing frontend from the
+torch.onnx.export-based fixtures most of this suite's other export
+integration tests (test_torch_export_integration.py,
+test_mmdeploy_integration.py) are built on, with its own lowering quirks
+worth exercising end-to-end:
+
+- Flax's channels-last (NHWC) convolution convention is lowered to ONNX's
+  NCHW-only Conv wrapped in explicit, non-identity NHWC<->NCHW Transposes --
+  a fusion (BatchNormalization into Conv) has to fire straight through them.
+- A reshape depending on a symbolic batch dimension lowers to a
+  Shape/Gather/Concat/Reshape chain that must keep working (not get folded
+  into a wrong static shape) for every batch size after simplification.
+- jax.lax.cond lowers to an ONNX `If`.
+
+jax2onnx is not part of onnxsim's test requirements (it drags in jax, flax,
+onnxruntime, and a handful of other heavy packages as its own dependencies),
+so the whole module is skipped when it is not installed. To run locally::
+
+    pip install jax2onnx
+    pip install --force-reinstall --no-deps .   # the onnxsim under test
+    pytest tests/test_jax_export_integration.py -v
+"""
+
+import numpy as np
+import onnx
+import pytest
+
+import onnxsim
+
+jax = pytest.importorskip("jax")
+jnp = pytest.importorskip("jax.numpy")
+nnx = pytest.importorskip("flax.nnx")
+jax2onnx = pytest.importorskip("jax2onnx")
+onnxruntime = pytest.importorskip("onnxruntime")
+
+to_onnx = jax2onnx.to_onnx
+
+
+def _simplify(model):
+    sim_model, check_ok = onnxsim.simplify(model, check_n=3)
+    assert check_ok
+    onnx.checker.check_model(sim_model)
+    return sim_model
+
+
+def _run(model, feeds):
+    sess = onnxruntime.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    out_names = [o.name for o in sess.get_outputs()]
+    return dict(zip(out_names, sess.run(out_names, feeds)))
+
+
+def test_jax_export_basic_function():
+    # A plain jax.numpy function, with no Flax module in the picture at all.
+    def f(x):
+        return jnp.tanh(x @ x.T) + 1.0
+
+    x = np.random.RandomState(0).randn(4, 4).astype(np.float32)
+    model = to_onnx(f, [(4, 4)])
+    sim_model = _simplify(model)
+
+    input_name = model.graph.input[0].name
+    output_name = model.graph.output[0].name
+    expected = np.asarray(f(jnp.asarray(x)))
+    actual = _run(sim_model, {input_name: x})[output_name]
+    np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
+
+
+class _ConvBnRelu(nnx.Module):
+    def __init__(self, *, rngs):
+        self.conv = nnx.Conv(3, 8, kernel_size=(3, 3), padding="SAME", rngs=rngs)
+        self.bn = nnx.BatchNorm(8, use_running_average=True, rngs=rngs)
+
+    def __call__(self, x):
+        return nnx.relu(self.bn(self.conv(x)))
+
+
+def test_jax_export_conv_bn_relu_fuses():
+    # fuse_bn_into_conv must fire straight through jax2onnx's NHWC<->NCHW
+    # layout Transposes: Flax convs are channels-last, so jax2onnx wraps the
+    # ONNX (NCHW-only) Conv in a Transpose on the way in and one on the way
+    # out. Those two Transposes use non-identity permutations and must
+    # survive simplification untouched; only the BatchNormalization should
+    # disappear, folded into the Conv.
+    module = _ConvBnRelu(rngs=nnx.Rngs(0))
+    x = np.random.RandomState(1).randn(2, 8, 8, 3).astype(np.float32)  # NHWC
+
+    model = to_onnx(module, [(2, 8, 8, 3)])
+    orig_op_types = [n.op_type for n in model.graph.node]
+    assert "BatchNormalization" in orig_op_types
+    assert orig_op_types.count("Transpose") == 2
+
+    sim_model = _simplify(model)
+    sim_op_types = [n.op_type for n in sim_model.graph.node]
+    assert "BatchNormalization" not in sim_op_types
+    assert "Conv" in sim_op_types
+    assert sim_op_types.count("Transpose") == 2
+
+    input_name = model.graph.input[0].name
+    output_name = model.graph.output[0].name
+    expected = np.asarray(module(jnp.asarray(x)))
+    orig_out = _run(model, {input_name: x})[output_name]
+    sim_out = _run(sim_model, {input_name: x})[output_name]
+    np.testing.assert_allclose(orig_out, expected, rtol=1e-4, atol=1e-5)
+    np.testing.assert_allclose(sim_out, expected, rtol=1e-4, atol=1e-5)
+
+
+def test_jax_export_preserves_dynamic_batch_dimension():
+    # jax2onnx's counterpart of test_dynamo_export_preserves_dynamic_batch
+    # (tests/test_torch_export_integration.py): a symbolic batch dimension
+    # ("B") makes `x.reshape(x.shape[0], -1)` lower to a genuine
+    # Shape/Gather/.../Reshape chain reading the runtime batch size, rather
+    # than a literal target-shape constant. onnxsim must not fold that chain
+    # into a shape baked in for one particular batch size.
+    def f(x):
+        return x.reshape(x.shape[0], -1)
+
+    model = to_onnx(f, [("B", 3, 4)])
+    sim_model = _simplify(model)
+
+    in_dim0 = sim_model.graph.input[0].type.tensor_type.shape.dim[0]
+    out_dim0 = sim_model.graph.output[0].type.tensor_type.shape.dim[0]
+    assert in_dim0.dim_value == 0 and in_dim0.dim_param
+    assert out_dim0.dim_value == 0 and out_dim0.dim_param
+
+    input_name = sim_model.graph.input[0].name
+    output_name = sim_model.graph.output[0].name
+    for batch_size in (1, 2, 5):
+        x = np.random.RandomState(batch_size).randn(batch_size, 3, 4).astype(np.float32)
+        expected = np.asarray(f(jnp.asarray(x)))
+        actual = _run(sim_model, {input_name: x})[output_name]
+        np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
+
+
+def test_jax_export_control_flow():
+    # jax.lax.cond lowers to an ONNX `If`, jax2onnx's equivalent of the
+    # torch.cond-based test_dynamo_export_with_control_flow.
+    def f(x):
+        return jax.lax.cond(jnp.sum(x) > 0, lambda t: t * 2.0, lambda t: t * -2.0, x)
+
+    model = to_onnx(f, [(3, 4)])
+    sim_model = _simplify(model)
+    assert "If" in [n.op_type for n in sim_model.graph.node]
+
+    input_name = sim_model.graph.input[0].name
+    output_name = sim_model.graph.output[0].name
+    positive = np.ones((3, 4), dtype=np.float32)
+    negative = -np.ones((3, 4), dtype=np.float32)
+    for x in (positive, negative):
+        expected = np.asarray(f(jnp.asarray(x)))
+        actual = _run(sim_model, {input_name: x})[output_name]
+        np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)


### PR DESCRIPTION
## Summary

Adds comprehensive integration tests for simplifying ONNX models exported from JAX and Flax code via the `jax2onnx` converter. This exercises onnxsim's simplification pipeline on a genuinely independent ONNX-producing frontend with its own lowering quirks distinct from the torch.onnx.export-based tests.

## Key Changes

- **New test module** (`tests/test_jax_export_integration.py`): Four integration tests covering:
  - Basic JAX function export and simplification
  - Conv+BatchNorm+ReLU fusion through Flax's NHWC→NCHW layout Transposes (verifies fusion fires correctly despite non-identity Transposes wrapping the Conv)
  - Dynamic batch dimension preservation in reshape chains (symbolic "B" dimension must survive simplification, not get folded into a static shape)
  - Control flow via `jax.lax.cond` lowering to ONNX `If` nodes
  
- **CI workflow update** (`.github/workflows/backend-integration.yml`): 
  - Added new `jax` job that installs jax2onnx and runs the new test suite
  - Updated documentation comments to mention jax2onnx as a JAX/Flax ONNX frontend alongside existing backends
  - Added test file to the path filter for PR-triggered runs

## Implementation Details

- Tests use `pytest.importorskip()` to gracefully skip the entire module when jax2onnx is not installed (it's not a core test requirement due to heavy dependencies: jax, flax, onnxruntime)
- Helper functions (`_simplify()`, `_run()`) encapsulate common patterns: simplification with correctness checking and ONNX Runtime inference
- Each test validates both that simplification succeeds and that numerical outputs remain correct across the original and simplified models
- The dynamic batch dimension test exercises multiple batch sizes (1, 2, 5) to ensure the symbolic dimension handling is robust

https://claude.ai/code/session_011zcBW9jMr7Whe2ex5s8BXH