### PR TITLE
Port QDQ-quantized and MatMulNBits (int4) structured pruning to C++

### DIFF
--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -1315,6 +1315,24 @@ def apply_structured_pruning_cpp(
     self-attention op boundary, declines the *entire* group, never partially
     pruned.
 
+    Also prunes ``com.microsoft::MatMulNBits`` (block-quantized, weight-only
+    int4/int8) chains -- the plain (producer -> consumer) and gated
+    (SwiGLU/GeGLU) families only, a C++-port subset of
+    :func:`onnxsim.apply_structured_pruning_matmul_nbits` (its fused
+    ``MatMulNBitsMlp``/``MatMulNBitsQkv`` variants and ``MatMulBnb4`` are not
+    ported here). Either side of a matched chain may independently be a
+    ``MatMulNBits`` node or a plain-float MatMul/vanilla-Gemm peer (at least
+    one side must be ``MatMulNBits``); the producer's output channels are
+    ranked by L2 norm of their own DEQUANTIZED weight row (never written
+    back -- the actual rewrite always row/column-slices the existing packed
+    ``B``/``scales``/``zero_points`` codes in place, re-packing a nibble-
+    packed axis rather than ever re-quantizing a sliced float weight from
+    scratch), and -- only when the consumer is itself ``MatMulNBits`` --
+    that keep-set must land on whole ``block_size``-sized blocks of the
+    consumer's own quantized ``K`` axis, or the whole chain is left
+    untouched (an individual K-column can't be dropped without
+    re-quantizing its block, out of scope).
+
     This is a single, self-contained graph rewrite: unlike :func:`simplify`,
     it does not run shape inference, constant folding, or any other pass.
 

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -74,6 +74,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <cstring>
 #include <functional>
 #include <numeric>
@@ -84,6 +85,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "dlpack_dtype.h"
@@ -6789,6 +6791,1337 @@ void ApplySplitGatedChains(onnx::GraphProto* graph,
   }
 }
 
+// --- MatMulNBits (com.microsoft, block-quantized weight) structured -------
+// --- pruning -----------------------------------------------------------
+//
+// C++ port of pruning.py's own "MatMulNBits (block-quantized weight)
+// structured pruning" section -- specifically just its PLAIN
+// (_find_matmul_nbits_chains) and GATED (_find_matmul_nbits_gated_chains)
+// chain families, i.e. everything from that section's own
+// `_matmul_nbits_int_attr` through the end of
+// `apply_structured_pruning_matmul_nbits`. Deliberately NOT ported here (see
+// pruning.py's own section comments for each): `com.microsoft::MatMulBnb4`
+// (a different quantization format -- bitsandbytes FP4/NF4, not this
+// section's int4/int8 packing), and the fused `MatMulNBitsMlp`/
+// `MatMulNBitsQkv` WebGPU-EP-targeted variants (a separate, much larger
+// section further into pruning.py) -- both out of scope for this port.
+//
+// `com.microsoft::MatMulNBits` packs a `[N, K]` weight-only-quantized Linear
+// layer's weight as `B` (`uint8[N, k_blocks, block_size * bits / 8]` --
+// `bits`-wide codes, `bits == 4` two nibbles per byte LOW NIBBLE FIRST,
+// `bits == 8` one full byte per code, no packing at all), `scales`
+// (`float[N, k_blocks]`, one scale per `(output channel, K-block)`), and an
+// OPTIONAL `zero_points` (`uint8[N, ceil(k_blocks * bits / 8)]` nibble/byte-
+// packed along the k_blocks axis the same way `B` is packed along its own
+// block_size axis, OR an unpacked `float[N, k_blocks]` -- the schema's own
+// two documented encodings), defaulting to `2 ** (bits - 1)` when absent.
+// Every one of these empirical facts (packing order, default zero point,
+// the schema's own two zero_points encodings) is pruning.py's own section
+// comment's finding, confirmed there against a real onnxruntime
+// InferenceSession round-trip -- not re-derived here.
+//
+// *** THE CORE CORRECTNESS INVARIANT: "slice codes directly, never
+// dequant-requant" ***. This module -- exactly like pruning.py's own -- only
+// ever DEQUANTIZES a matched weight (MatMulNBitsDequantized, below) for
+// IMPORTANCE RANKING: deciding which output channels to keep. The actual
+// rewrite always operates on the ORIGINAL packed `B`/`scales`/`zero_points`
+// bytes -- row/column-selecting (and, for a nibble-packed axis, unpacking
+// codes to bytes, re-selecting, and re-packing -- never a raw byte slice at
+// the wrong granularity) the EXISTING int4/int8 codes, never re-quantizing a
+// sliced float weight from scratch. This matters because re-quantization
+// would introduce different rounding at every surviving output channel's
+// own scale/zero-point choice -- a pruned model's surviving channels must
+// produce BIT-IDENTICAL results to the unpruned model's own (real hardware/
+// kernel) quantization, not merely numerically close ones. See
+// tests/test_structured_pruning_cpp.py's own MatMulNBits coverage, which
+// checks this exactly: the pruned graph's own tensors must equal a
+// HAND-SLICE of the ORIGINAL quantized codes, never a re-quantization of the
+// sliced float weight.
+//
+// *** THE BLOCK-ALIGNMENT CONSTRAINT ***. A `MatMulNBits` CONSUMER's own `K`
+// (input-channel) axis is quantized in whole `block_size`-sized blocks --
+// every K-value within one block shares one `(scale, zero_point)` pair, so
+// an individual K-column cannot be dropped on its own without re-quantizing
+// its entire block (out of scope: this module never invents new quantized
+// values). So whenever the CONSUMER side of a chain is itself `MatMulNBits`,
+// the producer's own importance-ranked keep-set is checked
+// (MatMulNBitsBlockAlignedKeepBlocks) against that consumer's own block
+// boundaries: every `block_size`-sized block must be either wholly kept or
+// wholly dropped. When it isn't -- an "unlucky" ranking that keeps some but
+// not all of a block's K-positions -- the WHOLE chain (producer AND
+// consumer) is left completely untouched, never forced into a partial-block
+// re-quantization or a producer/consumer keep-set mismatch. A plain-float
+// consumer has no such block structure, so any keep-set applies to it
+// directly. (The producer's own `N` axis has no such constraint at all --
+// dropping some output channels never touches any OTHER channel's own
+// `(scale, zero_point)`, since those are computed independently per row.)
+//
+// Every chain side (producer or consumer) may independently be EITHER a
+// `MatMulNBits` node OR a plain-float (directly-constant weight, never
+// QDQ-fed) `MatMul`/`Gemm` -- `NBitsSide`, a `std::variant` mirroring
+// pruning.py's own `_MatMulNBitsChainSide = Union[_MatMulNBitsWeight,
+// _PlainMatMulNBitsPeer]` -- covering the "quantized transformer block
+// feeding an unquantized lm_head" (and the symmetric "unquantized embedding
+// feeding the first quantized block") export shapes, with the chain-finders
+// below requiring at least one side to actually be `MatMulNBits` (an
+// all-plain-float pair is FindChains/FindGatedChains's own job, not
+// duplicated here -- mirrors pruning.py's own identical filter).
+//
+// Two deliberate, narrower-than-pruning.py scope decisions specific to this
+// C++ port (both consistent with this file's own established narrower-
+// subset-of-pruning.py precedent elsewhere):
+//   * `scales`/`zero_points` (when unpacked)/`bias` are admitted only as
+//     plain `FLOAT` (float32) tensors here -- this file's own float-tensor
+//     helpers (ReadFloatTensor/SetFloatTensorData) have no FLOAT16/BFLOAT16
+//     support anywhere yet, unlike pruning.py's own `_is_supported_float_
+//     dtype`, which additionally admits both. A FLOAT16/BFLOAT16-quantized
+//     export is simply never matched here (declined, not mis-handled).
+//   * The plain-float peer side only ever recognizes bare `MatMul`/`Gemm`
+//     (via the existing MatchMatMulLikeRaw), not pruning.py's own widened
+//     `_match_matmul_like` (which also recognizes `com.microsoft::
+//     FusedGemm`/`GemmFastGelu`) -- mirroring MatchProducer's own identical,
+//     already-established restriction elsewhere in this file.
+//
+// The chain-finding shape itself is deliberately NARROWER than the plain
+// float FindChains/FindGatedChains above: WalkToMatMulNBitsConsumer only
+// ever crosses a shape-preserving unary activation (UnaryPassThroughOps) --
+// no per-channel Add/Mul/BiasGelu/PRelu/Clip hop, no decomposed-LayerNorm or
+// self-gated-activation recognition, no grouped/depthwise structure, no
+// residual/Concat-merge topology -- mirroring pruning.py's own
+// `_walk_to_matmul_nbits_consumer` exactly (itself deliberately narrower
+// than its own `_walk_to_consumer`/`_walk_to_consumer_qdq`, per that
+// function's own docstring).
+
+// The live schema's own supported `block_size` values -- this environment's
+// real CPU kernel rejects anything outside this set at run time (see
+// pruning.py's own section comment for the empirical confirmation).
+const std::unordered_set<int64_t>& MatMulNBitsValidBlockSizes() {
+  static const std::unordered_set<int64_t> kSizes = {16, 32, 64, 128, 256};
+  return kSizes;
+}
+
+std::optional<int64_t> MatMulNBitsIntAttr(const onnx::NodeProto& node,
+                                          const std::string& name) {
+  for (const auto& attr : node.attribute()) {
+    if (attr.name() == name) {
+      return attr.i();
+    }
+  }
+  return std::nullopt;
+}
+
+int64_t MatMulNBitsIntAttrOr(const onnx::NodeProto& node,
+                             const std::string& name, int64_t default_value) {
+  auto v = MatMulNBitsIntAttr(node, name);
+  return v.has_value() ? *v : default_value;
+}
+
+bool MatMulNBitsDimsEqual(const onnx::TensorProto& t,
+                          std::initializer_list<int64_t> expected) {
+  if (static_cast<size_t>(t.dims_size()) != expected.size()) {
+    return false;
+  }
+  int i = 0;
+  for (int64_t e : expected) {
+    if (t.dims(i) != e) {
+      return false;
+    }
+    ++i;
+  }
+  return true;
+}
+
+// A `com.microsoft::MatMulNBits` node's block-quantized weight operands,
+// matched by MatchMatMulNBits -- see this section's own top comment for the
+// schema facts and packing layout this depends on. Every tensor is stored by
+// NAME (not a TensorProto*) -- mirroring ProducerMatch/ConsumerMatch's own
+// established convention elsewhere in this file: matching happens against a
+// read-only InitMap built from `graph->initializer()`, while the later
+// Apply step rebuilds its own MUTABLE name->TensorProto* map from
+// `graph->mutable_initializer()` to actually slice, so a match can never
+// hold a stale/const pointer across that phase boundary. `node` itself
+// (needed later to rewrite its own `N`/`K` attribute) is safe to store as a
+// pointer: it comes from `graph->mutable_node(i)`, and no node is ever
+// inserted or removed by this whole pruning pass. `zero_points_packed`
+// mirrors pruning.py's own `_MatMulNBitsWeight.zero_points_packed`: `true`
+// for nibble/byte-packed uint8 (same per-row layout as `b_name`, along the
+// `k_blocks` axis), `false` for one unpacked float value per block (same
+// dtype as `scales_name`). Meaningless when `zero_points_name` is unset.
+struct MatMulNBitsWeight {
+  onnx::NodeProto* node = nullptr;
+  std::string b_name;
+  std::string scales_name;
+  std::optional<std::string> zero_points_name;
+  bool zero_points_packed = false;
+  std::optional<std::string> bias_name;
+  int64_t N = 0;
+  int64_t K = 0;
+  int64_t bits = 0;
+  int64_t block_size = 0;
+  int64_t k_blocks = 0;
+};
+
+// A plain-float `MatMul`/vanilla-`Gemm` node's own weight, matched
+// (MatchPlainMatMulNBitsPeer) as the OTHER side of a MIXED `MatMulNBits`/
+// plain-float chain -- see this section's own top comment for the real
+// export shape this covers. Deliberately supports ONLY a directly-constant
+// float weight, never a QDQ one (mixing a QDQ scheme with `MatMulNBits`
+// remains out of scope, mirroring pruning.py's own identical restriction).
+struct PlainMatMulNBitsPeer {
+  onnx::NodeProto* node = nullptr;
+  std::string w_name;
+  bool weight_transposed = false;
+  std::optional<std::string> bias_name;
+  int64_t out_channels = 0;
+  int64_t in_channels = 0;
+};
+
+// Mirrors pruning.py's own `_MatMulNBitsChainSide = Union[_MatMulNBitsWeight,
+// _PlainMatMulNBitsPeer]`.
+using NBitsSide = std::variant<MatMulNBitsWeight, PlainMatMulNBitsPeer>;
+
+// Mirrors pruning.py's own `_matmul_nbits_chain_side_key`: a name uniquely
+// identifying the underlying weight tensor `side` resolves to, used by
+// ApplyMatMulNBitsChains to detect a shared/tied weight playing the same
+// role in more than one chain (and shared, via TouchedState, with every
+// other chain family this file already applies over the same graph).
+std::string NBitsSideKey(const NBitsSide& side) {
+  if (const auto* w = std::get_if<MatMulNBitsWeight>(&side)) {
+    return w->b_name;
+  }
+  return std::get<PlainMatMulNBitsPeer>(side).w_name;
+}
+
+onnx::NodeProto* NBitsSideNode(const NBitsSide& side) {
+  if (const auto* w = std::get_if<MatMulNBitsWeight>(&side)) {
+    return w->node;
+  }
+  return std::get<PlainMatMulNBitsPeer>(side).node;
+}
+
+// If `node` is a `com.microsoft::MatMulNBits` node matching every scope
+// boundary this section's own top comment documents, returns the match --
+// mirrors pruning.py's own `_match_matmul_nbits` exactly. `None`/`nullopt`
+// whenever anything is ambiguous or out of scope, rather than guessing.
+std::optional<MatMulNBitsWeight> MatchMatMulNBits(
+    onnx::NodeProto* node, const InitMap& init_map,
+    const ConsumerMap& consumers_of) {
+  if (node->op_type() != "MatMulNBits" ||
+      node->domain() != kComMicrosoftDomain) {
+    return std::nullopt;
+  }
+  if (node->input_size() < 3 || node->output_size() != 1) {
+    return std::nullopt;
+  }
+  const std::string& a_name = node->input(0);
+  const std::string& b_name = node->input(1);
+  const std::string& scales_name = node->input(2);
+  if (a_name.empty() || b_name.empty() || scales_name.empty()) {
+    return std::nullopt;
+  }
+  const std::string zp_name =
+      (node->input_size() > 3) ? node->input(3) : std::string();
+  const std::string g_idx_name =
+      (node->input_size() > 4) ? node->input(4) : std::string();
+  const std::string bias_name =
+      (node->input_size() > 5) ? node->input(5) : std::string();
+  if (!g_idx_name.empty()) {
+    return std::nullopt;  // GPTQ-style permutation -- declined, out of scope.
+  }
+
+  const auto block_size_opt = MatMulNBitsIntAttr(*node, "block_size");
+  const auto n_opt = MatMulNBitsIntAttr(*node, "N");
+  const auto k_opt = MatMulNBitsIntAttr(*node, "K");
+  if (!block_size_opt || !n_opt || !k_opt || *n_opt <= 0 || *k_opt <= 0) {
+    return std::nullopt;
+  }
+  const int64_t block_size = *block_size_opt;
+  const int64_t N = *n_opt;
+  const int64_t K = *k_opt;
+  if (!MatMulNBitsValidBlockSizes().count(block_size)) {
+    return std::nullopt;
+  }
+  if (K % block_size != 0) {
+    return std::nullopt;  // Padded/partial final block -- declined.
+  }
+  const int64_t bits =
+      MatMulNBitsIntAttrOr(*node, "bits", 4);  // schema default.
+  if (bits != 4 && bits != 8) {
+    return std::nullopt;  // Only 4-bit/8-bit packing empirically verified.
+  }
+  if (MatMulNBitsIntAttrOr(*node, "weight_prepacked", 0) != 0) {
+    return std::nullopt;  // EP-specific opaque prepacked layout -- declined.
+  }
+
+  const int64_t k_blocks = K / block_size;
+  const int64_t blob_size = block_size * bits / 8;
+
+  auto b_it = init_map.find(b_name);
+  auto s_it = init_map.find(scales_name);
+  if (b_it == init_map.end() || s_it == init_map.end()) {
+    return std::nullopt;  // Non-constant B/scales -- can't safely slice them.
+  }
+  const onnx::TensorProto* b_init = b_it->second;
+  const onnx::TensorProto* scales_init = s_it->second;
+  if (b_init->data_type() != onnx::TensorProto::UINT8) {
+    return std::nullopt;
+  }
+  if (!MatMulNBitsDimsEqual(*b_init, {N, k_blocks, blob_size})) {
+    return std::nullopt;
+  }
+  // Scope: FLOAT32 only -- see this section's own top comment.
+  if (scales_init->data_type() != onnx::TensorProto::FLOAT) {
+    return std::nullopt;
+  }
+  if (!MatMulNBitsDimsEqual(*scales_init, {N, k_blocks})) {
+    return std::nullopt;
+  }
+
+  const bool has_zp = !zp_name.empty();
+  bool zp_packed = false;
+  if (has_zp) {
+    auto zp_it = init_map.find(zp_name);
+    if (zp_it == init_map.end()) {
+      return std::nullopt;  // Non-constant zero_points -- can't safely slice
+                            // it.
+    }
+    const onnx::TensorProto* zp_init = zp_it->second;
+    const int64_t zp_bytes = (k_blocks * bits + 7) / 8;
+    if (zp_init->data_type() == onnx::TensorProto::UINT8) {
+      if (!MatMulNBitsDimsEqual(*zp_init, {N, zp_bytes})) {
+        return std::nullopt;
+      }
+      zp_packed = true;
+    } else if (zp_init->data_type() == scales_init->data_type()) {
+      if (!MatMulNBitsDimsEqual(*zp_init, {N, k_blocks})) {
+        return std::nullopt;
+      }
+      zp_packed = false;
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  const bool has_bias = !bias_name.empty();
+  if (has_bias) {
+    auto bias_it = init_map.find(bias_name);
+    if (bias_it == init_map.end() ||
+        bias_it->second->data_type() != scales_init->data_type()) {
+      return std::nullopt;  // Non-constant, or dtype-mismatched, bias.
+    }
+    if (!MatMulNBitsDimsEqual(*bias_it->second, {N})) {
+      return std::nullopt;
+    }
+  }
+
+  std::vector<std::string> shared_names = {b_name, scales_name};
+  if (has_zp) {
+    shared_names.push_back(zp_name);
+  }
+  if (has_bias) {
+    shared_names.push_back(bias_name);
+  }
+  for (const auto& nm : shared_names) {
+    if (ConsumerCount(consumers_of, nm) != 1) {
+      return std::nullopt;  // Shared/tied tensor -- another node reads it too.
+    }
+  }
+
+  MatMulNBitsWeight w;
+  w.node = node;
+  w.b_name = b_name;
+  w.scales_name = scales_name;
+  w.zero_points_name =
+      has_zp ? std::optional<std::string>(zp_name) : std::nullopt;
+  w.zero_points_packed = zp_packed;
+  w.bias_name = has_bias ? std::optional<std::string>(bias_name) : std::nullopt;
+  w.N = N;
+  w.K = K;
+  w.bits = bits;
+  w.block_size = block_size;
+  w.k_blocks = k_blocks;
+  return w;
+}
+
+// If `node` is a MatMul/vanilla-Gemm (MatchMatMulLikeRaw) whose weight is a
+// directly-constant FLOAT rank-2 initializer (never a QDQ-fed one), returns
+// the match -- mirrors pruning.py's own `_match_plain_matmul_nbits_peer`
+// (narrowed to FLOAT32/MatMul-Gemm-only per this section's own top comment).
+std::optional<PlainMatMulNBitsPeer> MatchPlainMatMulNBitsPeer(
+    onnx::NodeProto* node, const InitMap& init_map,
+    const ConsumerMap& consumers_of) {
+  auto m = MatchMatMulLikeRaw(*node);
+  if (!m) {
+    return std::nullopt;
+  }
+  auto w_it = init_map.find(m->w_name);
+  if (w_it == init_map.end() ||
+      w_it->second->data_type() != onnx::TensorProto::FLOAT) {
+    return std::nullopt;  // Absent, non-constant, wrong dtype, or QDQ-fed.
+  }
+  if (w_it->second->dims_size() != 2) {
+    return std::nullopt;
+  }
+  const int axis = m->weight_transposed ? 0 : 1;
+  const int64_t out_channels = w_it->second->dims(axis);
+  const int64_t in_channels = w_it->second->dims(1 - axis);
+
+  std::optional<std::string> bias_name;
+  if (node->op_type() == "Gemm" && node->input_size() == 3 &&
+      !node->input(2).empty()) {
+    bias_name = node->input(2);
+    auto bias_it = init_map.find(*bias_name);
+    if (bias_it == init_map.end() ||
+        bias_it->second->data_type() != onnx::TensorProto::FLOAT) {
+      return std::nullopt;  // Non-constant bias -- can't safely slice it.
+    }
+    if (!MatMulNBitsDimsEqual(*bias_it->second, {out_channels})) {
+      return std::nullopt;
+    }
+  }
+
+  std::vector<std::string> shared_names = {m->w_name};
+  if (bias_name) {
+    shared_names.push_back(*bias_name);
+  }
+  for (const auto& nm : shared_names) {
+    if (ConsumerCount(consumers_of, nm) != 1) {
+      return std::nullopt;  // Shared/tied tensor -- another node reads it too.
+    }
+  }
+
+  PlainMatMulNBitsPeer p;
+  p.node = node;
+  p.w_name = m->w_name;
+  p.weight_transposed = m->weight_transposed;
+  p.bias_name = bias_name;
+  p.out_channels = out_channels;
+  p.in_channels = in_channels;
+  return p;
+}
+
+// --- Bit-packing, mirroring _unpack_nbits_nibbles/_pack_nbits_nibbles (4-bit
+// specifically) and _unpack_nbits_codes/_pack_nbits_codes (bits-aware
+// generalization: bits==8 delegates to a plain truncating slice/identity
+// copy -- one full byte per code, no packing at all -- bits==4 to the
+// nibble pack/unpack). Every function here operates on a flat
+// `[outer, packed_width]` uint8 buffer (row-major, `outer` independent
+// packed rows sharing one packing granularity) -- the shared shape both a
+// producer-role N-axis slice (whole rows are independent quantization
+// blocks: `outer = N`) and a consumer-role k_blocks-axis slice (`outer = N`
+// too, but now COLUMN-selecting `count` positions out of each of those N
+// packed rows) actually need, so one implementation covers both `B`'s own
+// zero_points and every fused-op zero_points site this section might one
+// day extend to.
+
+// Unpacks the last axis of `packed` (`[outer, nbytes]`) into `[outer,
+// count]` codes in [0, 15], 2 per byte, LOW NIBBLE FIRST -- the schema's own
+// documented layout, empirically confirmed (see this section's own top
+// comment). Drops the last, padding, half-byte when `count` is odd.
+std::vector<uint8_t> UnpackNibblesLastAxis(const std::vector<uint8_t>& packed,
+                                           int64_t outer, int64_t nbytes,
+                                           int64_t count) {
+  std::vector<uint8_t> out(static_cast<size_t>(outer * count), 0);
+  for (int64_t r = 0; r < outer; ++r) {
+    const uint8_t* prow = packed.data() + r * nbytes;
+    uint8_t* orow = out.data() + r * count;
+    for (int64_t j = 0; j < count; ++j) {
+      const uint8_t byte = prow[j / 2];
+      orow[j] = (j % 2 == 0) ? (byte & 0x0F) : ((byte >> 4) & 0x0F);
+    }
+  }
+  return out;
+}
+
+// Inverse of UnpackNibblesLastAxis -- this, rather than a raw byte-slice of
+// the original packed tensor, is exactly why this section re-packs instead
+// of slicing bytes directly: dropping an ODD number of rows/blocks from the
+// MIDDLE of a nibble-packed axis shifts every subsequent kept value's
+// nibble parity, silently corrupting the result if not accounted for. Pads
+// an odd trailing `count` with a zero high nibble.
+std::vector<uint8_t> PackNibblesLastAxis(const std::vector<uint8_t>& vals,
+                                         int64_t outer, int64_t count) {
+  const int64_t nbytes = (count + 1) / 2;
+  std::vector<uint8_t> out(static_cast<size_t>(outer * nbytes), 0);
+  for (int64_t r = 0; r < outer; ++r) {
+    const uint8_t* vrow = vals.data() + r * count;
+    uint8_t* prow = out.data() + r * nbytes;
+    for (int64_t j = 0; j < nbytes; ++j) {
+      const uint8_t lo = vrow[2 * j] & 0x0F;
+      const uint8_t hi = (2 * j + 1 < count) ? (vrow[2 * j + 1] & 0x0F) : 0;
+      prow[j] = lo | (hi << 4);
+    }
+  }
+  return out;
+}
+
+// `bits`-aware generalization of UnpackNibblesLastAxis -- MatchMatMulNBits
+// only ever admits bits in {4, 8}.
+std::vector<uint8_t> UnpackCodesLastAxis(const std::vector<uint8_t>& packed,
+                                         int64_t outer, int64_t packed_width,
+                                         int64_t count, int64_t bits) {
+  if (bits == 8) {
+    std::vector<uint8_t> out(static_cast<size_t>(outer * count));
+    for (int64_t r = 0; r < outer; ++r) {
+      std::memcpy(out.data() + r * count, packed.data() + r * packed_width,
+                  static_cast<size_t>(count));
+    }
+    return out;
+  }
+  return UnpackNibblesLastAxis(packed, outer, packed_width, count);
+}
+
+// `bits`-aware generalization of PackNibblesLastAxis.
+std::vector<uint8_t> PackCodesLastAxis(const std::vector<uint8_t>& vals,
+                                       int64_t outer, int64_t count,
+                                       int64_t bits) {
+  if (bits == 8) {
+    return vals;  // Already [outer, count] -- one byte per code, no packing.
+  }
+  return PackNibblesLastAxis(vals, outer, count);
+}
+
+// Column-select (axis 1) of a fully unpacked-then-repacked `[rows, count]`
+// code matrix stored packed along its own LAST axis -- the genuine
+// nibble-repack hazard this section's own top comment documents: dropping
+// blocks from the MIDDLE of the packed axis shifts every subsequent kept
+// block's own nibble parity unless unpacked/resliced/repacked, which is
+// exactly what this does. Used by SliceMatMulNBitsConsumerBlocks for a
+// packed `zero_points`' own k_blocks axis.
+std::vector<uint8_t> RepackColumnSelect(const std::vector<uint8_t>& packed,
+                                        int64_t rows, int64_t packed_width,
+                                        int64_t count, int64_t bits,
+                                        const std::vector<int64_t>& keep_cols) {
+  const std::vector<uint8_t> unpacked =
+      UnpackCodesLastAxis(packed, rows, packed_width, count, bits);
+  const int64_t new_count = static_cast<int64_t>(keep_cols.size());
+  std::vector<uint8_t> selected(static_cast<size_t>(rows * new_count));
+  for (int64_t r = 0; r < rows; ++r) {
+    for (int64_t j = 0; j < new_count; ++j) {
+      selected[static_cast<size_t>(r * new_count + j)] =
+          unpacked[static_cast<size_t>(r * count + keep_cols[j])];
+    }
+  }
+  return PackCodesLastAxis(selected, rows, new_count, bits);
+}
+
+// --- Tensor <-> flat uint8 buffer, the UINT8 analogue of ReadFloatTensor/
+// SetFloatTensorData above (no endianness concerns -- a single-byte dtype).
+
+std::vector<uint8_t> ReadUint8Tensor(const onnx::TensorProto& t) {
+  int64_t numel = 1;
+  for (int64_t d : t.dims()) {
+    numel *= d;
+  }
+  std::vector<uint8_t> out(static_cast<size_t>(numel));
+  if (t.has_raw_data()) {
+    std::memcpy(out.data(), t.raw_data().data(), out.size());
+  } else {
+    // Per the ONNX spec, UINT8 (like INT8/INT16/UINT16/BOOL) is stored in
+    // `int32_data`, not a dedicated field, when raw_data isn't used.
+    for (int64_t i = 0; i < numel; ++i) {
+      out[static_cast<size_t>(i)] =
+          static_cast<uint8_t>(t.int32_data(static_cast<int>(i)));
+    }
+  }
+  return out;
+}
+
+void SetUint8TensorData(onnx::TensorProto* t, const std::vector<int64_t>& dims,
+                        const std::vector<uint8_t>& data) {
+  const std::string name = t->name();
+  t->Clear();
+  t->set_name(name);
+  t->set_data_type(onnx::TensorProto::UINT8);
+  for (int64_t d : dims) {
+    t->add_dims(d);
+  }
+  t->set_raw_data(
+      std::string(reinterpret_cast<const char*>(data.data()), data.size()));
+}
+
+// The full float64 `[N, K]` dequantized weight matrix `w` refers to, for
+// IMPORTANCE RANKING ONLY -- never written back to the graph (this
+// section's own top comment: the "slice codes directly, never dequant-
+// requant" invariant). `dequant[n, k] = (code[n, k] - zero_point[n, k /
+// block_size]) * scale[n, k / block_size]` -- mirrors pruning.py's own
+// `_matmul_nbits_dequantized` exactly. `init_map` here is the Apply phase's
+// own MUTABLE name->TensorProto* map (this function is only ever called
+// from ApplyMatMulNBitsChains, never during matching).
+std::vector<double> MatMulNBitsDequantized(
+    const MatMulNBitsWeight& w,
+    const std::unordered_map<std::string, onnx::TensorProto*>& init_map) {
+  const onnx::TensorProto* b_init = init_map.at(w.b_name);
+  const onnx::TensorProto* scales_init = init_map.at(w.scales_name);
+  const int64_t blob_size = w.block_size * w.bits / 8;
+
+  const std::vector<uint8_t> b_raw =
+      ReadUint8Tensor(*b_init);  // [N, k_blocks, blob_size]
+  // Unpacking the whole [N * k_blocks, blob_size] buffer at once yields
+  // exactly the [N, k_blocks, block_size] == [N, K] code matrix, row-major.
+  const std::vector<uint8_t> codes = UnpackCodesLastAxis(
+      b_raw, w.N * w.k_blocks, blob_size, w.block_size, w.bits);
+  const std::vector<float> scales =
+      ReadFloatTensor(*scales_init);  // [N, k_blocks]
+
+  std::vector<double> zp(static_cast<size_t>(w.N * w.k_blocks));
+  if (w.zero_points_name) {
+    const onnx::TensorProto* zp_init = init_map.at(*w.zero_points_name);
+    if (w.zero_points_packed) {
+      const std::vector<uint8_t> zp_raw =
+          ReadUint8Tensor(*zp_init);  // [N, zp_bytes]
+      const int64_t zp_bytes = (w.k_blocks * w.bits + 7) / 8;
+      const std::vector<uint8_t> zp_codes =
+          UnpackCodesLastAxis(zp_raw, w.N, zp_bytes, w.k_blocks, w.bits);
+      for (size_t i = 0; i < zp.size(); ++i) {
+        zp[i] = static_cast<double>(zp_codes[i]);
+      }
+    } else {
+      const std::vector<float> zp_f =
+          ReadFloatTensor(*zp_init);  // [N, k_blocks]
+      for (size_t i = 0; i < zp.size(); ++i) {
+        zp[i] = static_cast<double>(zp_f[i]);
+      }
+    }
+  } else {
+    // Schema's own documented default: 2 ** (bits - 1).
+    std::fill(zp.begin(), zp.end(),
+              static_cast<double>(int64_t{1} << (w.bits - 1)));
+  }
+
+  std::vector<double> out(static_cast<size_t>(w.N * w.K));
+  for (int64_t n = 0; n < w.N; ++n) {
+    for (int64_t kb = 0; kb < w.k_blocks; ++kb) {
+      const double z = zp[static_cast<size_t>(n * w.k_blocks + kb)];
+      const double s =
+          static_cast<double>(scales[static_cast<size_t>(n * w.k_blocks + kb)]);
+      for (int64_t j = 0; j < w.block_size; ++j) {
+        const int64_t idx = n * w.K + kb * w.block_size + j;
+        const double code =
+            static_cast<double>(codes[static_cast<size_t>(idx)]);
+        out[static_cast<size_t>(idx)] = (code - z) * s;
+      }
+    }
+  }
+  return out;
+}
+
+// `[N, K]` float64 view of one chain PRODUCER's own weight, for IMPORTANCE
+// RANKING ONLY -- never written back. A `MatMulNBits` side dequantizes via
+// MatMulNBitsDequantized; a plain-float peer is read directly, transposed
+// only when NOT already stored `[N, K]` -- mirrors pruning.py's own
+// `_matmul_nbits_chain_producer_weight_nk`.
+std::vector<double> NBitsSideProducerWeightNK(
+    const NBitsSide& side,
+    const std::unordered_map<std::string, onnx::TensorProto*>& init_map) {
+  if (const auto* w = std::get_if<MatMulNBitsWeight>(&side)) {
+    return MatMulNBitsDequantized(*w, init_map);
+  }
+  const auto& p = std::get<PlainMatMulNBitsPeer>(side);
+  const onnx::TensorProto* wt = init_map.at(p.w_name);
+  const std::vector<float> data = ReadFloatTensor(*wt);
+  std::vector<float> nk = p.weight_transposed
+                              ? data
+                              : TransposeFlat(data, wt->dims(0), wt->dims(1));
+  return std::vector<double>(nk.begin(), nk.end());
+}
+
+// --- Slicing, mirroring _slice_matmul_nbits_producer_rows/
+// _slice_matmul_nbits_consumer_blocks/_slice_matmul_nbits_chain_producer/
+// _slice_matmul_nbits_chain_consumer -----------------------------------
+
+// Slices `w`'s own N (output-channel) axis to `keep` (ascending indices) --
+// the producer role. `B`/`scales`/`bias` (if present) are all row-sliced
+// directly (their leading dim IS `N`); `zero_points` (if present) is
+// row-sliced directly when unpacked, or unpacked/row-sliced/re-packed when
+// packed (whole-row-safe, no nibble-parity hazard for THIS axis -- see this
+// section's own top comment -- but still always re-derived through the
+// same unpack/repack path as the genuinely hazardous consumer-block axis
+// below, rather than special-cased, mirroring pruning.py's own identical
+// choice not to special-case it either). Updates the node's own `N`
+// attribute to `len(keep)`.
+void SliceMatMulNBitsProducerRows(
+    const MatMulNBitsWeight& w,
+    const std::unordered_map<std::string, onnx::TensorProto*>& init_map,
+    const std::vector<int64_t>& keep) {
+  const int64_t blob_size = w.block_size * w.bits / 8;
+  const int64_t row_width = w.k_blocks * blob_size;
+  const int64_t kc = static_cast<int64_t>(keep.size());
+
+  onnx::TensorProto* b = init_map.at(w.b_name);
+  const std::vector<uint8_t> b_data = ReadUint8Tensor(*b);
+  std::vector<uint8_t> b_out(static_cast<size_t>(kc * row_width));
+  for (int64_t i = 0; i < kc; ++i) {
+    std::memcpy(b_out.data() + i * row_width,
+                b_data.data() + keep[i] * row_width,
+                static_cast<size_t>(row_width));
+  }
+  SetUint8TensorData(b, {kc, w.k_blocks, blob_size}, b_out);
+
+  onnx::TensorProto* scales = init_map.at(w.scales_name);
+  const std::vector<float> s_data = ReadFloatTensor(*scales);
+  std::vector<float> s_out(static_cast<size_t>(kc * w.k_blocks));
+  for (int64_t i = 0; i < kc; ++i) {
+    std::memcpy(s_out.data() + i * w.k_blocks,
+                s_data.data() + keep[i] * w.k_blocks,
+                static_cast<size_t>(w.k_blocks) * sizeof(float));
+  }
+  SetFloatTensorData(scales, {kc, w.k_blocks}, s_out);
+
+  if (w.zero_points_name) {
+    onnx::TensorProto* zp = init_map.at(*w.zero_points_name);
+    if (w.zero_points_packed) {
+      const int64_t zp_bytes = (w.k_blocks * w.bits + 7) / 8;
+      const std::vector<uint8_t> zp_data = ReadUint8Tensor(*zp);
+      const std::vector<uint8_t> unpacked =
+          UnpackCodesLastAxis(zp_data, w.N, zp_bytes, w.k_blocks, w.bits);
+      std::vector<uint8_t> kept(static_cast<size_t>(kc * w.k_blocks));
+      for (int64_t i = 0; i < kc; ++i) {
+        std::memcpy(kept.data() + i * w.k_blocks,
+                    unpacked.data() + keep[i] * w.k_blocks,
+                    static_cast<size_t>(w.k_blocks));
+      }
+      const std::vector<uint8_t> repacked =
+          PackCodesLastAxis(kept, kc, w.k_blocks, w.bits);
+      SetUint8TensorData(zp, {kc, zp_bytes}, repacked);
+    } else {
+      const std::vector<float> zp_data = ReadFloatTensor(*zp);
+      std::vector<float> zp_out(static_cast<size_t>(kc * w.k_blocks));
+      for (int64_t i = 0; i < kc; ++i) {
+        std::memcpy(zp_out.data() + i * w.k_blocks,
+                    zp_data.data() + keep[i] * w.k_blocks,
+                    static_cast<size_t>(w.k_blocks) * sizeof(float));
+      }
+      SetFloatTensorData(zp, {kc, w.k_blocks}, zp_out);
+    }
+  }
+
+  if (w.bias_name) {
+    SliceLastAxis(init_map.at(*w.bias_name), keep);
+  }
+
+  SetOrAddIntAttr(w.node, "N", kc);
+}
+
+// Returns the ascending block indices (into the consumer's own
+// `k_blocks`-sized block axis) that `keep` (ascending element indices into
+// its `K`-length input axis) corresponds to when every `block_size`-sized
+// block is either wholly present in `keep` or wholly absent -- or
+// `nullopt` when some block is only partially kept, meaning this consumer
+// cannot be safely pruned to this exact `keep` set at all -- mirrors
+// pruning.py's own `_matmul_nbits_block_aligned_keep_blocks`. Since
+// MatchMatMulNBits already declines any `K` not an exact multiple of
+// `block_size`, every block here is full-width -- there is no partial
+// FINAL block to special-case.
+std::optional<std::vector<int64_t>> MatMulNBitsBlockAlignedKeepBlocks(
+    const std::vector<int64_t>& keep, int64_t k_blocks, int64_t block_size) {
+  std::unordered_set<int64_t> keep_set(keep.begin(), keep.end());
+  std::vector<int64_t> keep_blocks;
+  for (int64_t kb = 0; kb < k_blocks; ++kb) {
+    const int64_t k0 = kb * block_size;
+    int64_t overlap = 0;
+    for (int64_t k = k0; k < k0 + block_size; ++k) {
+      if (keep_set.count(k)) {
+        ++overlap;
+      }
+    }
+    if (overlap == block_size) {
+      keep_blocks.push_back(kb);
+    } else if (overlap > 0) {
+      return std::nullopt;  // Partial block -- not block-aligned, decline.
+    }
+  }
+  return keep_blocks;
+}
+
+// Drops entire `k_blocks`-axis blocks NOT in `keep_blocks` (ascending block
+// indices) from `w`'s own `B`/`scales`/`zero_points` -- the consumer role.
+// Never invoked with a non-block-aligned `keep_blocks` (see
+// MatMulNBitsBlockAlignedKeepBlocks, which computes and validates it before
+// this is ever called). `B` needs only a whole-block byte copy per
+// `(n, kept k_block)` pair (each `blob_size`-byte group is already a
+// self-contained packed block, safe to reorder/drop as a unit); a packed
+// `zero_points` genuinely must be unpacked/resliced/repacked (RepackColumn
+// Select) -- the block axis IS ITS OWN packed axis (unlike `B`, whose
+// packing is along `block_size`, an entirely different axis untouched by
+// this slice). Updates the node's own `K` attribute to `len(keep_blocks) *
+// block_size`. Mirrors pruning.py's own `_slice_matmul_nbits_consumer_
+// blocks`.
+void SliceMatMulNBitsConsumerBlocks(
+    const MatMulNBitsWeight& w,
+    const std::unordered_map<std::string, onnx::TensorProto*>& init_map,
+    const std::vector<int64_t>& keep_blocks) {
+  const int64_t blob_size = w.block_size * w.bits / 8;
+  const int64_t new_kb = static_cast<int64_t>(keep_blocks.size());
+
+  onnx::TensorProto* b = init_map.at(w.b_name);
+  const std::vector<uint8_t> b_data =
+      ReadUint8Tensor(*b);  // [N, k_blocks, blob_size]
+  std::vector<uint8_t> b_out(static_cast<size_t>(w.N * new_kb * blob_size));
+  for (int64_t n = 0; n < w.N; ++n) {
+    for (int64_t j = 0; j < new_kb; ++j) {
+      const uint8_t* src =
+          b_data.data() + (n * w.k_blocks + keep_blocks[j]) * blob_size;
+      uint8_t* dst = b_out.data() + (n * new_kb + j) * blob_size;
+      std::memcpy(dst, src, static_cast<size_t>(blob_size));
+    }
+  }
+  SetUint8TensorData(b, {w.N, new_kb, blob_size}, b_out);
+
+  onnx::TensorProto* scales = init_map.at(w.scales_name);
+  const std::vector<float> s_data = ReadFloatTensor(*scales);  // [N, k_blocks]
+  std::vector<float> s_out(static_cast<size_t>(w.N * new_kb));
+  for (int64_t n = 0; n < w.N; ++n) {
+    for (int64_t j = 0; j < new_kb; ++j) {
+      s_out[static_cast<size_t>(n * new_kb + j)] =
+          s_data[static_cast<size_t>(n * w.k_blocks + keep_blocks[j])];
+    }
+  }
+  SetFloatTensorData(scales, {w.N, new_kb}, s_out);
+
+  if (w.zero_points_name) {
+    onnx::TensorProto* zp = init_map.at(*w.zero_points_name);
+    if (w.zero_points_packed) {
+      const int64_t zp_bytes = (w.k_blocks * w.bits + 7) / 8;
+      const std::vector<uint8_t> zp_data = ReadUint8Tensor(*zp);
+      const std::vector<uint8_t> repacked = RepackColumnSelect(
+          zp_data, w.N, zp_bytes, w.k_blocks, w.bits, keep_blocks);
+      const int64_t new_zp_bytes = (new_kb * w.bits + 7) / 8;
+      SetUint8TensorData(zp, {w.N, new_zp_bytes}, repacked);
+    } else {
+      const std::vector<float> zp_data = ReadFloatTensor(*zp);  // [N, k_blocks]
+      std::vector<float> zp_out(static_cast<size_t>(w.N * new_kb));
+      for (int64_t n = 0; n < w.N; ++n) {
+        for (int64_t j = 0; j < new_kb; ++j) {
+          zp_out[static_cast<size_t>(n * new_kb + j)] =
+              zp_data[static_cast<size_t>(n * w.k_blocks + keep_blocks[j])];
+        }
+      }
+      SetFloatTensorData(zp, {w.N, new_kb}, zp_out);
+    }
+  }
+
+  SetOrAddIntAttr(w.node, "K", new_kb * w.block_size);
+}
+
+// Slices one chain PRODUCER's own output channels to `keep` -- dispatches
+// to SliceMatMulNBitsProducerRows for a `MatMulNBits` side, or a direct
+// SliceProducerWeight (plus its own bias, if present) for a plain-float
+// peer. Mirrors pruning.py's own `_slice_matmul_nbits_chain_producer`.
+void SliceNBitsSideProducer(
+    const NBitsSide& side,
+    const std::unordered_map<std::string, onnx::TensorProto*>& init_map,
+    const std::vector<int64_t>& keep) {
+  if (const auto* w = std::get_if<MatMulNBitsWeight>(&side)) {
+    SliceMatMulNBitsProducerRows(*w, init_map, keep);
+    return;
+  }
+  const auto& p = std::get<PlainMatMulNBitsPeer>(side);
+  SliceProducerWeight(init_map.at(p.w_name), p.weight_transposed, keep, false);
+  if (p.bias_name) {
+    SliceLastAxis(init_map.at(*p.bias_name), keep);
+  }
+}
+
+// Slices one chain CONSUMER's own input channels to `keep` -- a
+// `MatMulNBits` side requires `keep` to already be whole, block-aligned
+// BLOCK indices (checked by the caller via MatMulNBitsBlockAlignedKeepBlocks
+// before this is ever invoked for that side) and dispatches to
+// SliceMatMulNBitsConsumerBlocks; a plain-float peer has no block structure
+// at all, so `keep` there is ordinary element indices, dispatched straight
+// to SliceConsumerWeight. Mirrors pruning.py's own `_slice_matmul_nbits_
+// chain_consumer`.
+void SliceNBitsSideConsumer(
+    const NBitsSide& side,
+    const std::unordered_map<std::string, onnx::TensorProto*>& init_map,
+    const std::vector<int64_t>& keep) {
+  if (const auto* w = std::get_if<MatMulNBitsWeight>(&side)) {
+    SliceMatMulNBitsConsumerBlocks(*w, init_map, keep);
+    return;
+  }
+  const auto& p = std::get<PlainMatMulNBitsPeer>(side);
+  SliceConsumerWeight(init_map.at(p.w_name), p.weight_transposed, keep, false);
+}
+
+// --- MatMul/Gemm-chain plain and gated chain finding, mirroring
+// _walk_to_matmul_nbits_consumer/_find_matmul_nbits_chains/
+// _trace_gate_producer_backward_matmul_nbits/_find_matmul_nbits_gated_chains
+
+// From tensor `start` (a `MatMulNBits` OR plain-float MatMul/Gemm
+// producer's own output), walks forward through shape-preserving unary
+// activations (UnaryPassThroughOps) with no other consumer anywhere along
+// the way, until EITHER a `MatMulNBits` consumer OR a plain-float MatMul/
+// vanilla-Gemm consumer (MatchPlainMatMulNBitsPeer) is found whose
+// input-channel count matches `n_channels`. No per-channel Add/Mul/
+// BiasGelu/PRelu/Clip hop, no decomposed-LayerNorm/self-gated-activation
+// recognition, no branch -- narrower than WalkToConsumer above, mirroring
+// pruning.py's own `_walk_to_matmul_nbits_consumer` exactly (see this
+// section's own top comment). Returns `nullopt` if the walk runs out of
+// hops, hits a branch, or never reaches such a consumer.
+struct MatMulNBitsWalkResult {
+  NBitsSide consumer;
+  std::vector<onnx::NodeProto*> chain_ops;
+};
+
+std::optional<MatMulNBitsWalkResult> WalkToMatMulNBitsConsumer(
+    const std::string& start, const InitMap& init_map,
+    const ConsumerMap& consumers_of,
+    const std::unordered_set<std::string>& graph_outputs, int64_t n_channels,
+    int max_hops) {
+  std::vector<onnx::NodeProto*> chain_ops;
+  std::string cur = start;
+  for (int hop = 0; hop < max_hops; ++hop) {
+    auto cit = consumers_of.find(cur);
+    if (cit == consumers_of.end() || cit->second.size() != 1) {
+      return std::nullopt;
+    }
+    onnx::NodeProto* nxt = cit->second[0];
+
+    if (nxt->op_type() == "MatMulNBits" && nxt->input_size() > 0 &&
+        nxt->input(0) == cur) {
+      auto w = MatchMatMulNBits(nxt, init_map, consumers_of);
+      if (!w || w->K != n_channels) {
+        return std::nullopt;
+      }
+      return MatMulNBitsWalkResult{NBitsSide(*w), std::move(chain_ops)};
+    }
+
+    auto mm = MatchMatMulLikeRaw(*nxt);
+    if (mm && mm->x_name == cur) {
+      auto peer = MatchPlainMatMulNBitsPeer(nxt, init_map, consumers_of);
+      if (!peer || peer->in_channels != n_channels) {
+        return std::nullopt;
+      }
+      return MatMulNBitsWalkResult{NBitsSide(*peer), std::move(chain_ops)};
+    }
+
+    if (!(UnaryPassThroughOps().count(nxt->op_type()) != 0 &&
+          nxt->input_size() == 1 && nxt->input(0) == cur &&
+          nxt->output_size() == 1)) {
+      return std::nullopt;
+    }
+    const std::string& out2 = nxt->output(0);
+    auto oc = consumers_of.find(out2);
+    if (oc == consumers_of.end() || oc->second.size() != 1 ||
+        graph_outputs.count(out2)) {
+      return std::nullopt;
+    }
+    chain_ops.push_back(nxt);
+    cur = out2;
+  }
+  return std::nullopt;
+}
+
+struct MatMulNBitsChain {
+  NBitsSide producer;
+  std::vector<onnx::NodeProto*> chain_ops;
+  NBitsSide consumer;
+  int64_t n_channels;
+};
+
+// The `MatMulNBits` analogue of FindChains: every producer/consumer pair
+// connected by WalkToMatMulNBitsConsumer where AT LEAST ONE side is a
+// `MatMulNBits` node (a plain-float-to-plain-float pair is FindChains's own
+// job, not duplicated here). Mirrors pruning.py's own `_find_matmul_nbits_
+// chains`.
+std::vector<MatMulNBitsChain> FindMatMulNBitsChains(onnx::GraphProto* graph) {
+  InitMap init_map;
+  for (const auto& t : graph->initializer()) {
+    init_map[t.name()] = &t;
+  }
+  ConsumerMap consumers_of = ConsumersOf(graph);
+  std::unordered_set<std::string> graph_outputs;
+  for (const auto& o : graph->output()) {
+    graph_outputs.insert(o.name());
+  }
+  auto is_internal = [&](const std::string& name) {
+    return ConsumerCount(consumers_of, name) == 1 && !graph_outputs.count(name);
+  };
+
+  std::vector<MatMulNBitsChain> chains;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    std::optional<NBitsSide> producer;
+    int64_t n_channels = 0;
+    if (node->op_type() == "MatMulNBits") {
+      auto w = MatchMatMulNBits(node, init_map, consumers_of);
+      if (!w) {
+        continue;
+      }
+      n_channels = w->N;
+      producer = NBitsSide(*w);
+    } else {
+      auto peer = MatchPlainMatMulNBitsPeer(node, init_map, consumers_of);
+      if (!peer) {
+        continue;
+      }
+      n_channels = peer->out_channels;
+      producer = NBitsSide(*peer);
+    }
+
+    const std::string& out_name = node->output(0);
+    if (!is_internal(out_name)) {
+      continue;
+    }
+    auto found =
+        WalkToMatMulNBitsConsumer(out_name, init_map, consumers_of,
+                                  graph_outputs, n_channels, kMaxChainHops);
+    if (!found) {
+      continue;
+    }
+    if (std::holds_alternative<PlainMatMulNBitsPeer>(*producer) &&
+        std::holds_alternative<PlainMatMulNBitsPeer>(found->consumer)) {
+      continue;  // Both plain float -- FindChains's own job.
+    }
+    chains.push_back(MatMulNBitsChain{std::move(*producer),
+                                      std::move(found->chain_ops),
+                                      std::move(found->consumer), n_channels});
+  }
+  return chains;
+}
+
+struct NBitsProducerInfo {
+  onnx::NodeProto* node;
+  NBitsSide side;
+  int64_t n_channels;
+};
+
+// The `MatMulNBits` analogue of TraceGateProducerBackward: walks backward
+// from `tensor_name` through unary activation ops until it resolves to a
+// `MatMulNBits`-or-plain-float MatMul/vanilla-Gemm producer's raw output
+// (`producer_infos`, built from MatchMatMulNBits/MatchPlainMatMulNBitsPeer
+// -- see FindMatMulNBitsGatedChains). Duplicated rather than shared with the
+// plain-float walker above for the identical reason FindGatedChains's own
+// duplication exists (structurally different `producer_infos` value type).
+std::optional<std::pair<NBitsProducerInfo, std::vector<onnx::NodeProto*>>>
+TraceGateProducerBackwardNBits(
+    const std::string& tensor_name,
+    const std::unordered_map<std::string, onnx::NodeProto*>& node_by_output,
+    const std::unordered_map<std::string, NBitsProducerInfo>& producer_infos,
+    const ConsumerMap& consumers_of,
+    const std::unordered_set<std::string>& graph_outputs, int max_hops) {
+  std::vector<onnx::NodeProto*> pre_ops;
+  std::string cur = tensor_name;
+  for (int hop = 0; hop < max_hops; ++hop) {
+    if (ConsumerCount(consumers_of, cur) != 1 || graph_outputs.count(cur)) {
+      return std::nullopt;
+    }
+    auto pit = producer_infos.find(cur);
+    if (pit != producer_infos.end()) {
+      std::reverse(pre_ops.begin(), pre_ops.end());
+      return std::make_pair(pit->second, std::move(pre_ops));
+    }
+    auto nit = node_by_output.find(cur);
+    if (nit == node_by_output.end()) {
+      return std::nullopt;
+    }
+    onnx::NodeProto* producer_node = nit->second;
+    if (!(UnaryPassThroughOps().count(producer_node->op_type()) != 0 &&
+          producer_node->input_size() == 1 &&
+          producer_node->output_size() == 1)) {
+      return std::nullopt;
+    }
+    pre_ops.push_back(producer_node);
+    cur = producer_node->input(0);
+  }
+  return std::nullopt;
+}
+
+struct MatMulNBitsGatedChain {
+  NBitsSide producer_a;
+  std::vector<onnx::NodeProto*> producer_a_pre_ops;
+  NBitsSide producer_b;
+  std::vector<onnx::NodeProto*> producer_b_pre_ops;
+  std::vector<onnx::NodeProto*> chain_ops;
+  NBitsSide consumer;
+  int64_t n_channels;
+};
+
+// The `MatMulNBits` analogue of FindGatedChains: recognizes the same gated
+// (SwiGLU/GeGLU) MatMul/vanilla-Gemm pair -- gate_proj/up_proj sharing one
+// input, combined via a plain elementwise `Mul` of two non-constant
+// operands (each optionally through its own UnaryPassThroughOps activation)
+// or the native `SwiGLU` node -- feeding into exactly one downstream
+// consumer whose input-channel count matches (WalkToMatMulNBitsConsumer),
+// except gate_proj/up_proj/down_proj may now each independently be EITHER a
+// `MatMulNBits` node OR a plain-float MatMul/vanilla-Gemm peer, requiring at
+// least one of the three to actually be `MatMulNBits` (an all-plain-float
+// triple is FindGatedChains's own job, not duplicated here). Mirrors
+// pruning.py's own `_find_matmul_nbits_gated_chains`.
+std::vector<MatMulNBitsGatedChain> FindMatMulNBitsGatedChains(
+    onnx::GraphProto* graph) {
+  InitMap init_map;
+  for (const auto& t : graph->initializer()) {
+    init_map[t.name()] = &t;
+  }
+  ConsumerMap consumers_of = ConsumersOf(graph);
+  std::unordered_set<std::string> graph_outputs;
+  for (const auto& o : graph->output()) {
+    graph_outputs.insert(o.name());
+  }
+  auto is_internal = [&](const std::string& name) {
+    return ConsumerCount(consumers_of, name) == 1 && !graph_outputs.count(name);
+  };
+
+  std::unordered_map<std::string, onnx::NodeProto*> node_by_output;
+  std::unordered_map<std::string, NBitsProducerInfo> producer_infos;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    for (const auto& out : node->output()) {
+      node_by_output[out] = node;
+    }
+    if (node->op_type() == "MatMulNBits") {
+      auto w = MatchMatMulNBits(node, init_map, consumers_of);
+      if (w) {
+        producer_infos[node->output(0)] =
+            NBitsProducerInfo{node, NBitsSide(*w), w->N};
+      }
+    } else {
+      auto peer = MatchPlainMatMulNBitsPeer(node, init_map, consumers_of);
+      if (peer) {
+        producer_infos[node->output(0)] =
+            NBitsProducerInfo{node, NBitsSide(*peer), peer->out_channels};
+      }
+    }
+  }
+
+  std::vector<MatMulNBitsGatedChain> chains;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    std::optional<NBitsProducerInfo> info_a, info_b;
+    std::vector<onnx::NodeProto*> pre_a, pre_b;
+
+    if (node->op_type() == "Mul" && node->input_size() == 2 &&
+        node->output_size() == 1) {
+      const std::string& a_name = node->input(0);
+      const std::string& b_name = node->input(1);
+      if (a_name == b_name || init_map.count(a_name) ||
+          init_map.count(b_name)) {
+        continue;
+      }
+      auto trace_a = TraceGateProducerBackwardNBits(
+          a_name, node_by_output, producer_infos, consumers_of, graph_outputs,
+          kMaxChainHops);
+      auto trace_b = TraceGateProducerBackwardNBits(
+          b_name, node_by_output, producer_infos, consumers_of, graph_outputs,
+          kMaxChainHops);
+      if (!trace_a || !trace_b) {
+        continue;
+      }
+      info_a = trace_a->first;
+      pre_a = std::move(trace_a->second);
+      info_b = trace_b->first;
+      pre_b = std::move(trace_b->second);
+    } else if (node->op_type() == "SwiGLU" && node->input_size() == 2 &&
+               node->output_size() == 1) {
+      const std::string& a_name = node->input(0);
+      const std::string& b_name = node->input(1);
+      if (init_map.count(a_name) || init_map.count(b_name)) {
+        continue;
+      }
+      if (!(is_internal(a_name) && is_internal(b_name))) {
+        continue;
+      }
+      auto ait = producer_infos.find(a_name);
+      auto bit = producer_infos.find(b_name);
+      if (ait == producer_infos.end() || bit == producer_infos.end()) {
+        continue;
+      }
+      info_a = ait->second;
+      info_b = bit->second;
+    } else {
+      continue;
+    }
+
+    if (info_a->node == info_b->node ||
+        info_a->n_channels != info_b->n_channels) {
+      continue;
+    }
+
+    const std::string& out_name = node->output(0);
+    if (!is_internal(out_name)) {
+      continue;
+    }
+    auto found = WalkToMatMulNBitsConsumer(out_name, init_map, consumers_of,
+                                           graph_outputs, info_a->n_channels,
+                                           kMaxChainHops);
+    if (!found) {
+      continue;
+    }
+
+    if (std::holds_alternative<PlainMatMulNBitsPeer>(info_a->side) &&
+        std::holds_alternative<PlainMatMulNBitsPeer>(info_b->side) &&
+        std::holds_alternative<PlainMatMulNBitsPeer>(found->consumer)) {
+      continue;  // All plain float -- FindGatedChains's own job.
+    }
+
+    chains.push_back(
+        MatMulNBitsGatedChain{info_a->side, std::move(pre_a), info_b->side,
+                              std::move(pre_b), std::move(found->chain_ops),
+                              std::move(found->consumer), info_a->n_channels});
+  }
+  return chains;
+}
+
+// --- Apply, mirroring apply_structured_pruning_matmul_nbits's own plain and
+// gated per-chain loops (the fused MLP/QKV loops it also drives are out of
+// scope here, per this section's own top comment) ------------------------
+
+// Applies both plain (`chains`) and gated (`gated_chains`) MatMulNBits
+// chains -- ranks the producer's output channels by L2 norm of their own
+// (dequantized, for a `MatMulNBits` producer) weight row, drops the
+// lowest-`sparsity`-fraction, and -- only when the CONSUMER side is itself
+// `MatMulNBits` -- requires that keep-set to land on whole `block_size`
+// blocks (MatMulNBitsBlockAlignedKeepBlocks), declining the WHOLE chain
+// otherwise (see this section's own top comment for why). Shares `touched`
+// with every other chain family ApplyStructuredPruning already applies over
+// this same graph, so a weight already resized by an ordinary MatMul/Conv
+// chain (or vice versa) can never be double-resized here.
+void ApplyMatMulNBitsChains(onnx::GraphProto* graph,
+                            std::vector<MatMulNBitsChain>& chains,
+                            std::vector<MatMulNBitsGatedChain>& gated_chains,
+                            double sparsity, TouchedState& touched) {
+  std::unordered_map<std::string, onnx::TensorProto*> init_map;
+  for (int i = 0; i < graph->initializer_size(); ++i) {
+    onnx::TensorProto* t = graph->mutable_initializer(i);
+    init_map[t->name()] = t;
+  }
+
+  auto row_norms = [](const std::vector<double>& w_nk, int64_t n) {
+    const int64_t k = static_cast<int64_t>(w_nk.size()) / n;
+    std::vector<double> importance(static_cast<size_t>(n), 0.0);
+    for (int64_t c = 0; c < n; ++c) {
+      double sq = 0.0;
+      for (int64_t j = 0; j < k; ++j) {
+        const double v = w_nk[static_cast<size_t>(c * k + j)];
+        sq += v * v;
+      }
+      importance[static_cast<size_t>(c)] = sq;
+    }
+    return importance;
+  };
+
+  for (auto& chain : chains) {
+    const std::string p_key = NBitsSideKey(chain.producer);
+    const std::string c_key = NBitsSideKey(chain.consumer);
+    if (p_key == c_key) {
+      continue;  // Degenerate (the same weight in both roles).
+    }
+    if (touched.producer.count(p_key) || touched.consumer.count(c_key)) {
+      continue;  // A shared/tied weight another chain already resized.
+    }
+
+    const int64_t n = chain.n_channels;
+    const int64_t keep_count = std::max<int64_t>(
+        1, n - std::llround(static_cast<double>(n) * sparsity));
+    if (keep_count >= n) {
+      continue;  // Rounds down to nothing for this layer -- no-op.
+    }
+
+    const std::vector<double> w_nk =
+        NBitsSideProducerWeightNK(chain.producer, init_map);
+    std::vector<double> importance = row_norms(w_nk, n);
+    for (double& v : importance) {
+      v = std::sqrt(v);
+    }
+    const std::vector<int64_t> keep =
+        TopKIndicesAscending(importance, keep_count);
+
+    std::vector<int64_t> consumer_keep;
+    if (const auto* cw = std::get_if<MatMulNBitsWeight>(&chain.consumer)) {
+      auto keep_blocks =
+          MatMulNBitsBlockAlignedKeepBlocks(keep, cw->k_blocks, cw->block_size);
+      if (!keep_blocks) {
+        continue;  // Non-block-aligned request -- decline, see top comment.
+      }
+      consumer_keep = std::move(*keep_blocks);
+    } else {
+      consumer_keep = keep;  // Plain-float consumer -- no block structure.
+    }
+
+    SliceNBitsSideProducer(chain.producer, init_map, keep);
+    SliceNBitsSideConsumer(chain.consumer, init_map, consumer_keep);
+
+    touched.producer.insert(p_key);
+    touched.consumer.insert(c_key);
+    touched.stale_value_info.insert(NBitsSideNode(chain.producer)->output(0));
+    for (auto* op : chain.chain_ops) {
+      touched.stale_value_info.insert(op->output(0));
+    }
+  }
+
+  for (auto& gchain : gated_chains) {
+    const std::string pa_key = NBitsSideKey(gchain.producer_a);
+    const std::string pb_key = NBitsSideKey(gchain.producer_b);
+    const std::string c_key = NBitsSideKey(gchain.consumer);
+    if (pa_key == pb_key || pa_key == c_key || pb_key == c_key) {
+      continue;  // Degenerate (a weight tied across two roles).
+    }
+    if (touched.producer.count(pa_key) || touched.producer.count(pb_key) ||
+        touched.consumer.count(c_key)) {
+      continue;  // A shared/tied weight another chain already resized.
+    }
+
+    const int64_t n = gchain.n_channels;
+    const int64_t keep_count = std::max<int64_t>(
+        1, n - std::llround(static_cast<double>(n) * sparsity));
+    if (keep_count >= n) {
+      continue;  // Rounds down to nothing for this layer -- no-op.
+    }
+
+    const std::vector<double> wa_nk =
+        NBitsSideProducerWeightNK(gchain.producer_a, init_map);
+    const std::vector<double> wb_nk =
+        NBitsSideProducerWeightNK(gchain.producer_b, init_map);
+    // Combined (root-sum-square) importance across both producers -- mirrors
+    // pruning.py's own `_matmul_nbits_gated_channel_importance` (L2 branch
+    // only; this C++ port has no `importance_norm` choice, always L2,
+    // matching this file's own established scope elsewhere).
+    std::vector<double> sq_a = row_norms(wa_nk, n);
+    const std::vector<double> sq_b = row_norms(wb_nk, n);
+    std::vector<double> importance(static_cast<size_t>(n));
+    for (int64_t c = 0; c < n; ++c) {
+      importance[static_cast<size_t>(c)] = std::sqrt(
+          sq_a[static_cast<size_t>(c)] + sq_b[static_cast<size_t>(c)]);
+    }
+    const std::vector<int64_t> keep =
+        TopKIndicesAscending(importance, keep_count);
+
+    std::vector<int64_t> consumer_keep;
+    if (const auto* cw = std::get_if<MatMulNBitsWeight>(&gchain.consumer)) {
+      auto keep_blocks =
+          MatMulNBitsBlockAlignedKeepBlocks(keep, cw->k_blocks, cw->block_size);
+      if (!keep_blocks) {
+        continue;  // Non-block-aligned -- decline the whole gated group.
+      }
+      consumer_keep = std::move(*keep_blocks);
+    } else {
+      consumer_keep = keep;  // Plain-float consumer -- no block structure.
+    }
+
+    SliceNBitsSideProducer(gchain.producer_a, init_map, keep);
+    SliceNBitsSideProducer(gchain.producer_b, init_map, keep);
+    SliceNBitsSideConsumer(gchain.consumer, init_map, consumer_keep);
+
+    touched.producer.insert(pa_key);
+    touched.producer.insert(pb_key);
+    touched.consumer.insert(c_key);
+    touched.stale_value_info.insert(
+        NBitsSideNode(gchain.producer_a)->output(0));
+    for (auto* op : gchain.producer_a_pre_ops) {
+      touched.stale_value_info.insert(op->output(0));
+    }
+    touched.stale_value_info.insert(
+        NBitsSideNode(gchain.producer_b)->output(0));
+    for (auto* op : gchain.producer_b_pre_ops) {
+      touched.stale_value_info.insert(op->output(0));
+    }
+    for (auto* op : gchain.chain_ops) {
+      touched.stale_value_info.insert(op->output(0));
+    }
+  }
+}
+
 // --- Subgraph recursion ------------------------------------------------
 //
 // Mirrors pruning.py's own `_iter_subgraphs` and the "Subgraph recursion"
@@ -6923,6 +8256,10 @@ onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
                          std::make_move_iterator(conv_concat_chains.end()));
     std::vector<SplitGatedChain> split_gated_chains =
         FindSplitGatedChains(graph);
+    std::vector<MatMulNBitsChain> matmul_nbits_chains =
+        FindMatMulNBitsChains(graph);
+    std::vector<MatMulNBitsGatedChain> matmul_nbits_gated_chains =
+        FindMatMulNBitsGatedChains(graph);
 
     TouchedState touched;
     if (!chains.empty()) {
@@ -6939,6 +8276,17 @@ onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
       // double-resize) an ordinary chain/Concat-chain that happens to
       // touch the same initializer -- still scoped to this one graph only.
       ApplySplitGatedChains(graph, split_gated_chains, sparsity, touched);
+    }
+    if (!matmul_nbits_chains.empty() || !matmul_nbits_gated_chains.empty()) {
+      // Another separate application pass -- see the "MatMulNBits
+      // (com.microsoft, block-quantized weight) structured pruning" section
+      // comment above. Shares `touched` with every call above for the same
+      // reason ApplySplitGatedChains does: a plain-float weight this pass
+      // also happens to match (as the OTHER side of a mixed chain) can never
+      // be double-resized by, or double-resize, an ordinary chain that
+      // already touched it.
+      ApplyMatMulNBitsChains(graph, matmul_nbits_chains,
+                             matmul_nbits_gated_chains, sparsity, touched);
     }
     if (!touched.stale_value_info.empty()) {
       google::protobuf::RepeatedPtrField<onnx::ValueInfoProto> kept;

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -8122,6 +8122,1697 @@ void ApplyMatMulNBitsChains(onnx::GraphProto* graph,
   }
 }
 
+// --- QDQ (quantized-weight) structured pruning, mirroring pruning.py's own
+// "QDQ (quantized-weight) structured pruning" section (_QDQWeight through
+// apply_structured_pruning_qdq) -------------------------------------------
+//
+// A Conv/ConvTranspose (group=1) or MatMul/vanilla-Gemm weight statically
+// quantized in the QDQ pattern -- a constant int8/uint8 (per-tensor or
+// per-channel) or int4/uint4 (opset 21+ blockwise) initializer fed through a
+// single-consumer `DequantizeLinear` node -- can be structurally pruned the
+// same way this file's plain-float chains already are, as long as the
+// int8/int4 CODES are sliced directly and their own scale/zero-point are
+// either co-sliced in lockstep (when they are indexed by the axis being cut)
+// or left completely untouched (when they are not) -- NEVER dequantized,
+// pruned as a float array, and requantized from scratch. That last approach
+// would silently change every kept value's own quantization error (a fresh
+// round-trip through a different candidate weight distribution), which is
+// exactly what this pass must not do: the whole point of pruning a model
+// that is already QDQ-quantized, rather than quantizing an already-pruned
+// float model, is to preserve the original quantization exactly for every
+// channel that survives. So: **slice the codes, don't recompute them** --
+// the single most important correctness property of everything below, the
+// direct analogue of this file's own FP16/BFloat16 "slice, don't recompute"
+// precedent for a *quantization* metadata pair instead of a *dtype* one.
+//
+// Which of `Wq`'s own scale/zero-point get touched splits cleanly by role:
+//   * Producer role (this weight's own OUTPUT channels are being cut): a
+//     per-channel `Ws`/`Wzp` (each `[out_channels]`) is indexed by the exact
+//     axis being cut, so it is co-sliced by the same `keep` set, in lockstep
+//     with `Wq`. A per-tensor (scalar) `Ws`/`Wzp` isn't shaped by channel
+//     count at all, so only `Wq` is sliced.
+//   * Consumer role (this weight's own INPUT/reduction channels are being
+//     cut): `Ws`/`Wzp` are indexed by the OUTPUT-channel axis, never the
+//     input axis being cut here, so they are always left completely
+//     untouched -- only `Wq` is sliced, along its reduction axis.
+//   * Blockwise (opset 21+ INT4/UINT4, `block_size` on the reduction axis)
+//     reverses which role is "simple": the producer's own output-channel
+//     axis is never blocked, so `Wq`/`Ws`/`Wzp` co-slice exactly like the
+//     per-channel producer case above, no alignment concern. The consumer's
+//     own input axis IS the blocked axis, so an individual input channel
+//     can't be dropped without re-quantizing its whole block -- out of
+//     scope, this pass never invents new quantized values. Instead, the
+//     candidate `keep` set (computed once per chain, shared with the
+//     producer) is checked for block alignment (QdqBlockAlignedKeepBlocks):
+//     every `block_size`-sized block of the consumer's own reduction axis
+//     either wholly survives or wholly drops. When aligned, `Wq` is sliced
+//     element-wise by `keep` (blocks stay contiguous by construction) and
+//     `Ws`/`Wzp` are sliced by BLOCK index; when not aligned, the WHOLE
+//     chain (producer and consumer alike) is left completely untouched
+//     rather than forcing a partial-block re-quantization or a disagreeing
+//     keep-set between producer and consumer.
+//
+// A `ConvTranspose` weight's own reversed layout (`[in_channels,
+// out_channels/group, ...]`, `out_channels` on axis 1 rather than 0) needs
+// only a different `expected_axis` threaded through the exact same
+// MatchDequantizeLinearWeight[Blockwise]/slicing machinery Conv already
+// uses -- see QdqWeightAxis. Every Conv/ConvTranspose/MatMul/Gemm match here
+// is restricted to `group == 1` on both sides (a general grouped/depthwise
+// QDQ Conv is out of scope -- already a materially bigger project for the
+// plain-float case, before QDQ's extra scale/zero-point bookkeeping enters
+// at all), and the forward walk (WalkToConsumerQdq) only ever crosses zero
+// or more shape-preserving UNARY activations with no per-channel Add/Mul
+// bias/scale hop -- narrower than the plain-float chain walk above, by
+// design, for this section's own deliberately narrow first cut. A gated
+// (SwiGLU/GeGLU) MatMul/Gemm pair IS matched (FindQdqGatedChains), with
+// either or both producers and/or the consumer independently QDQ or plain
+// float -- Conv/ConvTranspose never take part in a gated pair, mirroring
+// FindGatedChains's own restriction.
+//
+// Only INT8/UINT8 (per-tensor or per-channel, via MatchDequantizeLinearWeight)
+// and INT4/UINT4 blockwise-on-the-reduction-axis (via
+// MatchDequantizeLinearWeightBlockwise) are matched; FLOAT8 codes, a
+// non-default `output_dtype`, blocked quantization on the output-channel
+// axis or with INT8/UINT8 codes, a non-exact-multiple block dimension, or
+// any `x`/`x_scale`/`x_zero_point` read by more than one node (a shared/tied
+// quantized tensor whose slicing here would silently corrupt whatever else
+// reads it) are all declined outright by the matchers, never guessed at --
+// the same conservative bar every matcher elsewhere in this file holds
+// itself to. Unlike the plain-float MatMul/Gemm producer, this port matches
+// only `"MatMul"`/`"Gemm"` (not `"FusedGemm"`/`"GemmFastGelu"`) and only
+// `"Conv"` (not `"FusedConv"`) -- mirroring MatchMatMulLikeRaw/
+// MatchConvProducer's own established scope in this file (which does not
+// support those op types anywhere either), a narrower surface than
+// pruning.py's own QDQ section but consistent with the rest of this port.
+// Only a plain FLOAT (not FLOAT16/BFLOAT16) direct initializer is resolved
+// on the non-QDQ side of a mixed chain, for the identical reason: this
+// port's plain-float chains never support FLOAT16/BFLOAT16 either.
+//
+// This entire section is additive: FindQdqChains/FindQdqGatedChains only
+// ever match a chain where at least one side is QDQ-quantized (a plain
+// float/float pair is FindChains/FindGatedChains's own job, never
+// duplicated here), so ApplyQdqChains below can never double-slice a tensor
+// FindChains/FindGatedChains/FindConvChains already claimed -- but it still
+// shares this graph's own single `TouchedState` with every other Apply*
+// call in ApplyStructuredPruning, for the same "one shared conflict ledger
+// per graph" reason those calls already share it with each other.
+
+// --- Tensor <-> flat int64 code buffer, mirroring onnx.numpy_helper's own
+// transparent INT8/UINT8/INT4/UINT4 (ml_dtypes) round-trip -----------------
+
+int64_t TensorNumEl(const onnx::TensorProto& t) {
+  int64_t n = 1;
+  for (int64_t d : t.dims()) {
+    n *= d;
+  }
+  return n;
+}
+
+bool DimsEqual(const google::protobuf::RepeatedField<int64_t>& a,
+               const google::protobuf::RepeatedField<int64_t>& b) {
+  if (a.size() != b.size()) {
+    return false;
+  }
+  for (int i = 0; i < a.size(); ++i) {
+    if (a.Get(i) != b.Get(i)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Returns `nbytes` raw bytes for `t`'s own codes, from `raw_data` when
+// present or, for a hand-built (onnx.helper.make_tensor-style) tensor
+// instead, from `int32_data` -- which ONNX's own wire format also uses to
+// carry one *packed* byte per entry for INT4/UINT4 (mirroring `raw_data`'s
+// own packing exactly, just one byte per `int32_data` slot instead of
+// concatenated), so this one path handles every constant-tensor
+// construction style uniformly for INT8/UINT8/INT4/UINT4 alike.
+std::vector<uint8_t> RawOrPackedBytes(const onnx::TensorProto& t,
+                                      int64_t nbytes) {
+  std::vector<uint8_t> bytes(static_cast<size_t>(nbytes));
+  if (t.has_raw_data()) {
+    std::memcpy(bytes.data(), t.raw_data().data(), static_cast<size_t>(nbytes));
+  } else {
+    for (int64_t i = 0; i < nbytes; ++i) {
+      bytes[static_cast<size_t>(i)] =
+          static_cast<uint8_t>(t.int32_data(static_cast<int>(i)));
+    }
+  }
+  return bytes;
+}
+
+// Unpacks an INT8/UINT8/INT4/UINT4 TensorProto's own codes into a flat,
+// row-major (matching `t.dims()`) int64 buffer -- INT4/UINT4 two codes per
+// byte, low nibble first (`byte = code[2i] | (code[2i+1] << 4)`), matching
+// onnx.numpy_helper's own `_pack_4bitx2`/`_unpack_4bit` convention exactly
+// (confirmed empirically -- see this section's own top comment).
+std::vector<int64_t> ReadQuantCodes(const onnx::TensorProto& t) {
+  const int64_t numel = TensorNumEl(t);
+  const bool is4bit = t.data_type() == onnx::TensorProto::INT4 ||
+                      t.data_type() == onnx::TensorProto::UINT4;
+  const bool is_signed = t.data_type() == onnx::TensorProto::INT8 ||
+                         t.data_type() == onnx::TensorProto::INT4;
+  const int64_t nbytes = is4bit ? (numel + 1) / 2 : numel;
+  const std::vector<uint8_t> bytes = RawOrPackedBytes(t, nbytes);
+  std::vector<int64_t> out(static_cast<size_t>(numel));
+  for (int64_t i = 0; i < numel; ++i) {
+    int64_t val;
+    if (is4bit) {
+      const uint8_t byte = bytes[static_cast<size_t>(i / 2)];
+      val = (i % 2 == 0) ? (byte & 0x0F) : ((byte >> 4) & 0x0F);
+      if (is_signed && val >= 8) {
+        val -= 16;
+      }
+    } else {
+      const uint8_t byte = bytes[static_cast<size_t>(i)];
+      val = is_signed ? static_cast<int64_t>(static_cast<int8_t>(byte))
+                      : static_cast<int64_t>(byte);
+    }
+    out[static_cast<size_t>(i)] = val;
+  }
+  return out;
+}
+
+// Overwrites `t` in place with a fresh INT8/UINT8/INT4/UINT4 tensor of
+// `dims`/`codes` (`codes` already the target dtype's own two's-complement
+// representation, e.g. -2 for INT8/INT4 alike), keeping its existing name --
+// mirrors SetFloatTensorData's own "replace, don't mutate a live view"
+// convention. Always writes `raw_data` (matching onnx.numpy_helper.
+// from_array's own convention), regardless of how `t` was originally
+// encoded.
+void SetQuantCodes(onnx::TensorProto* t, int32_t dtype,
+                   const std::vector<int64_t>& dims,
+                   const std::vector<int64_t>& codes) {
+  const bool is4bit =
+      dtype == onnx::TensorProto::INT4 || dtype == onnx::TensorProto::UINT4;
+  const int64_t numel = static_cast<int64_t>(codes.size());
+  const std::string name = t->name();
+  t->Clear();
+  t->set_name(name);
+  t->set_data_type(static_cast<onnx::TensorProto::DataType>(dtype));
+  for (int64_t d : dims) {
+    t->add_dims(d);
+  }
+  if (is4bit) {
+    std::string raw(static_cast<size_t>((numel + 1) / 2), '\0');
+    for (int64_t i = 0; i < numel; ++i) {
+      const uint8_t nibble =
+          static_cast<uint8_t>(codes[static_cast<size_t>(i)]) & 0x0F;
+      uint8_t& byte =
+          reinterpret_cast<uint8_t&>(raw[static_cast<size_t>(i / 2)]);
+      if (i % 2 == 0) {
+        byte = nibble;
+      } else {
+        byte = static_cast<uint8_t>(byte | (nibble << 4));
+      }
+    }
+    t->set_raw_data(std::move(raw));
+  } else {
+    std::string raw(static_cast<size_t>(numel), '\0');
+    for (int64_t i = 0; i < numel; ++i) {
+      raw[static_cast<size_t>(i)] = static_cast<char>(
+          static_cast<uint8_t>(codes[static_cast<size_t>(i)]));
+    }
+    t->set_raw_data(std::move(raw));
+  }
+}
+
+std::vector<int64_t> RowMajorStrides(const std::vector<int64_t>& dims) {
+  std::vector<int64_t> strides(dims.size());
+  int64_t acc = 1;
+  for (int64_t i = static_cast<int64_t>(dims.size()) - 1; i >= 0; --i) {
+    strides[static_cast<size_t>(i)] = acc;
+    acc *= dims[static_cast<size_t>(i)];
+  }
+  return strides;
+}
+
+// Gathers `keep` (ascending indices) along `axis` of a row-major `dims`-
+// shaped flat buffer -- the generic building block every QDQ slicer below
+// uses, for both int64 codes and float32 scale/zero-point alike, at
+// whichever axis/rank the specific role (producer/consumer, per-channel/
+// blockwise) needs. Exactly `numpy`'s own `np.take(data, keep, axis=axis)`.
+template <typename T>
+std::vector<T> SliceAlongAxis(const std::vector<T>& data,
+                              const std::vector<int64_t>& dims, int64_t axis,
+                              const std::vector<int64_t>& keep) {
+  int64_t outer = 1;
+  for (int64_t i = 0; i < axis; ++i) {
+    outer *= dims[static_cast<size_t>(i)];
+  }
+  const int64_t axis_dim = dims[static_cast<size_t>(axis)];
+  int64_t inner = 1;
+  for (size_t i = static_cast<size_t>(axis) + 1; i < dims.size(); ++i) {
+    inner *= dims[i];
+  }
+  std::vector<T> out(static_cast<size_t>(outer) * keep.size() *
+                     static_cast<size_t>(inner));
+  for (int64_t o = 0; o < outer; ++o) {
+    for (size_t k = 0; k < keep.size(); ++k) {
+      const T* src = data.data() +
+                     (static_cast<size_t>(o) * static_cast<size_t>(axis_dim) +
+                      static_cast<size_t>(keep[k])) *
+                         static_cast<size_t>(inner);
+      T* dst = out.data() + (static_cast<size_t>(o) * keep.size() + k) *
+                                static_cast<size_t>(inner);
+      std::copy(src, src + inner, dst);
+    }
+  }
+  return out;
+}
+
+// --- Dequantization for IMPORTANCE RANKING ONLY -- never written back to the
+// graph. The actual mutation always slices the int8/int4 codes/scale/
+// zero-point directly (see this section's own top comment); these two
+// helpers exist purely so a QDQ producer's output channels can be ranked by
+// the same L2-norm-of-dequantized-row criterion a plain float producer's
+// already are (QdqChannelImportanceL2), without the ranking caring which
+// quantization scheme the weight came from. -------------------------------
+
+std::vector<double> PerChannelDequantFlat(const std::vector<int64_t>& codes,
+                                          const std::vector<int64_t>& dims,
+                                          const std::vector<float>& scale,
+                                          const std::vector<int64_t>& zp,
+                                          bool per_channel, int64_t axis) {
+  const int64_t numel = static_cast<int64_t>(codes.size());
+  std::vector<double> out(static_cast<size_t>(numel));
+  if (!per_channel) {
+    const double s = static_cast<double>(scale[0]);
+    const double zpv = zp.empty() ? 0.0 : static_cast<double>(zp[0]);
+    for (int64_t i = 0; i < numel; ++i) {
+      out[static_cast<size_t>(i)] =
+          (static_cast<double>(codes[static_cast<size_t>(i)]) - zpv) * s;
+    }
+    return out;
+  }
+  const std::vector<int64_t> strides = RowMajorStrides(dims);
+  const int64_t axis_dim = dims[static_cast<size_t>(axis)];
+  const int64_t axis_stride = strides[static_cast<size_t>(axis)];
+  for (int64_t i = 0; i < numel; ++i) {
+    const int64_t a = (i / axis_stride) % axis_dim;
+    const double zpv =
+        zp.empty() ? 0.0 : static_cast<double>(zp[static_cast<size_t>(a)]);
+    out[static_cast<size_t>(i)] =
+        (static_cast<double>(codes[static_cast<size_t>(i)]) - zpv) *
+        static_cast<double>(scale[static_cast<size_t>(a)]);
+  }
+  return out;
+}
+
+// The blockwise analogue: `scale`/`zp` are full-rank (same rank as `dims`),
+// full-size on every axis except `block_axis`, where their own size is
+// `num_blocks` -- each block's own scalar broadcasts to every element of its
+// own `block_size`-sized span along `block_axis`.
+std::vector<double> BlockwiseDequantFlat(const std::vector<int64_t>& codes,
+                                         const std::vector<int64_t>& dims,
+                                         const std::vector<float>& scale,
+                                         const std::vector<int64_t>& zp,
+                                         int64_t block_axis, int64_t block_size,
+                                         int64_t num_blocks) {
+  std::vector<int64_t> scale_dims = dims;
+  scale_dims[static_cast<size_t>(block_axis)] = num_blocks;
+  const std::vector<int64_t> strides = RowMajorStrides(dims);
+  const std::vector<int64_t> scale_strides = RowMajorStrides(scale_dims);
+  const int64_t numel = static_cast<int64_t>(codes.size());
+  std::vector<double> out(static_cast<size_t>(numel));
+  std::vector<int64_t> multi(dims.size());
+  for (int64_t idx = 0; idx < numel; ++idx) {
+    int64_t rem = idx;
+    for (size_t d = 0; d < dims.size(); ++d) {
+      multi[d] = rem / strides[d];
+      rem %= strides[d];
+    }
+    int64_t sidx = 0;
+    for (size_t d = 0; d < dims.size(); ++d) {
+      const int64_t sd = (static_cast<int64_t>(d) == block_axis)
+                             ? multi[d] / block_size
+                             : multi[d];
+      sidx += sd * scale_strides[d];
+    }
+    const double zpv =
+        zp.empty() ? 0.0 : static_cast<double>(zp[static_cast<size_t>(sidx)]);
+    out[static_cast<size_t>(idx)] =
+        (static_cast<double>(codes[static_cast<size_t>(idx)]) - zpv) *
+        static_cast<double>(scale[static_cast<size_t>(sidx)]);
+  }
+  return out;
+}
+
+// `[out_channels, in_channels, kH, kW]` -> `[N, K]` for a Conv weight (or
+// its ConvTranspose analogue, `[in_channels, out_channels, kH, kW]`, moved
+// to output-channel-first before the same flatten), or a plain 2-D
+// MatMul/Gemm weight transposed to `[N, K]` when it isn't already -- the
+// double-precision analogue of this file's own (float) TransposeFlat, for
+// the exact same "the ranking machinery works over one directly comparable
+// [N, K] layout" reason. Mirrors pruning.py's own `_weight_to_nk`.
+std::vector<double> QdqWeightToNk(const std::vector<double>& data,
+                                  const std::vector<int64_t>& dims,
+                                  bool weight_transposed, bool is_conv,
+                                  bool is_conv_transpose) {
+  if (is_conv) {
+    if (!is_conv_transpose) {
+      return data;  // Already [Cout, rest] flattened row-major.
+    }
+    const int64_t cin = dims[0], cout = dims[1];
+    const int64_t inner = dims[2] * dims[3];
+    std::vector<double> out(data.size());
+    for (int64_t ci = 0; ci < cin; ++ci) {
+      for (int64_t co = 0; co < cout; ++co) {
+        const double* src = data.data() + (ci * cout + co) * inner;
+        double* dst = out.data() + (co * cin + ci) * inner;
+        std::copy(src, src + inner, dst);
+      }
+    }
+    return out;
+  }
+  const int64_t dim0 = dims[0], dim1 = dims[1];
+  if (weight_transposed) {
+    return data;  // Already [N, K].
+  }
+  std::vector<double> out(data.size());
+  for (int64_t i = 0; i < dim0; ++i) {
+    for (int64_t j = 0; j < dim1; ++j) {
+      out[static_cast<size_t>(j * dim0 + i)] =
+          data[static_cast<size_t>(i * dim1 + j)];
+    }
+  }
+  return out;
+}
+
+// L2 norm of each output channel's own (dequantized) weight row -- the
+// single-producer QDQ analogue of ApplyChains's own inline importance
+// computation. Only L2 is supported (this port, unlike pruning.py's own
+// wider `importance_norm` parameter, has no L1 option anywhere -- neither
+// does ApplyStructuredPruning's own plain-float path, so this is a
+// consistent, not a novel, scope narrowing).
+std::vector<double> QdqChannelImportanceL2(const std::vector<double>& w_nk,
+                                           int64_t n, int64_t k) {
+  std::vector<double> importance(static_cast<size_t>(n), 0.0);
+  for (int64_t c = 0; c < n; ++c) {
+    double sq = 0.0;
+    for (int64_t j = 0; j < k; ++j) {
+      const double v = w_nk[static_cast<size_t>(c * k + j)];
+      sq += v * v;
+    }
+    importance[static_cast<size_t>(c)] = std::sqrt(sq);
+  }
+  return importance;
+}
+
+// The STABLE analogue of this file's own TopKIndicesAscending
+// (std::partial_sort there is not stable for ties) -- mirrors pruning.py's
+// own `np.argsort(-importance, kind="stable")[:keep_count]` exactly. Matters
+// specifically here (unlike most other ranking call sites in this file):
+// with exactly-tied importances, an unstable tie-break can select a keep set
+// that no longer aligns to a blockwise consumer's own block boundaries
+// (QdqBlockAlignedKeepBlocks), flipping a would-have-been-aligned chain to
+// "declined" nondeterministically. A stable sort preserves ascending
+// channel-index order among ties, matching this port's own test oracles
+// (and pruning.py's own reference behavior) deterministically.
+std::vector<int64_t> StableTopKIndicesAscending(
+    const std::vector<double>& importance, int64_t keep_count) {
+  const int64_t n = static_cast<int64_t>(importance.size());
+  std::vector<int64_t> idx(static_cast<size_t>(n));
+  std::iota(idx.begin(), idx.end(), int64_t{0});
+  std::stable_sort(idx.begin(), idx.end(), [&](int64_t a, int64_t b) {
+    return importance[static_cast<size_t>(a)] >
+           importance[static_cast<size_t>(b)];
+  });
+  idx.resize(static_cast<size_t>(keep_count));
+  std::sort(idx.begin(), idx.end());
+  return idx;
+}
+
+// --- Matching: per-tensor/per-channel and blockwise DequantizeLinear-fed
+// weights, mirroring _match_dequantize_linear_weight/
+// _match_dequantize_linear_weight_blockwise/_resolve_weight_ref ------------
+
+using DqMap = std::unordered_map<std::string, onnx::NodeProto*>;
+
+struct QdqWeightMatch {
+  onnx::NodeProto* dq_node;
+  std::string q_name;
+  std::string scale_name;
+  std::optional<std::string> zp_name;
+  int64_t axis;  // This weight's own output-channel axis.
+  bool per_channel;
+  std::vector<int64_t> dims;
+};
+
+// If `weight_name` is fed by a `DequantizeLinear` node from a constant
+// int8/uint8 initializer, with a constant FLOAT scale that is either a
+// scalar (per-tensor) or a 1-D vector of length `dims[expected_axis]`
+// (per-channel, on exactly `expected_axis`) with a matching `axis`
+// attribute, returns the match. `rank` is the expected weight rank (4 for
+// Conv/ConvTranspose, 2 for MatMul/Gemm). Declines (nullopt) whenever
+// anything is ambiguous -- see this section's own top comment.
+std::optional<QdqWeightMatch> MatchDequantizeLinearWeight(
+    const std::string& weight_name, int64_t rank, int64_t expected_axis,
+    const InitMap& init_map, const DqMap& dq_of,
+    const ConsumerMap& consumers_of) {
+  auto dit = dq_of.find(weight_name);
+  if (dit == dq_of.end()) {
+    return std::nullopt;
+  }
+  onnx::NodeProto* dq = dit->second;
+  if (dq->op_type() != "DequantizeLinear" || dq->output_size() != 1) {
+    return std::nullopt;
+  }
+  if (ConsumerCount(consumers_of, weight_name) != 1) {
+    return std::nullopt;  // DQ output must feed only this one weight use.
+  }
+  if (dq->input_size() != 2 && dq->input_size() != 3) {
+    return std::nullopt;
+  }
+  const std::string& q_name = dq->input(0);
+  const std::string& scale_name = dq->input(1);
+  std::optional<std::string> zp_name;
+  if (dq->input_size() == 3 && !dq->input(2).empty()) {
+    zp_name = dq->input(2);
+  }
+  if (q_name.empty() || scale_name.empty()) {
+    return std::nullopt;
+  }
+
+  auto qit = init_map.find(q_name);
+  auto sit = init_map.find(scale_name);
+  if (qit == init_map.end() || sit == init_map.end()) {
+    return std::nullopt;  // Non-constant q/scale -- can't safely slice it.
+  }
+  const onnx::TensorProto* q_init = qit->second;
+  const onnx::TensorProto* scale_init = sit->second;
+  if (q_init->data_type() != onnx::TensorProto::INT8 &&
+      q_init->data_type() != onnx::TensorProto::UINT8) {
+    return std::nullopt;
+  }
+  if (scale_init->data_type() != onnx::TensorProto::FLOAT) {
+    return std::nullopt;
+  }
+  if (q_init->dims_size() != rank) {
+    return std::nullopt;
+  }
+
+  if (zp_name) {
+    auto zit = init_map.find(*zp_name);
+    if (zit == init_map.end()) {
+      return std::nullopt;
+    }
+    const onnx::TensorProto* zp_init = zit->second;
+    if (zp_init->data_type() != q_init->data_type()) {
+      return std::nullopt;
+    }
+    if (!DimsEqual(zp_init->dims(), scale_init->dims())) {
+      return std::nullopt;
+    }
+  }
+
+  if (ConsumerCount(consumers_of, q_name) != 1 ||
+      ConsumerCount(consumers_of, scale_name) != 1 ||
+      (zp_name && ConsumerCount(consumers_of, *zp_name) != 1)) {
+    return std::nullopt;  // Shared/tied quantized tensor.
+  }
+
+  for (const auto& attr : dq->attribute()) {
+    if (attr.name() == "block_size" && attr.i() != 0) {
+      return std::nullopt;  // Blocked quantization --
+                            // MatchDequantizeLinearWeightBlockwise's own job.
+    }
+    if (attr.name() == "output_dtype" && attr.i() != 0) {
+      return std::nullopt;
+    }
+  }
+
+  int64_t axis = 1;  // DequantizeLinear's own schema default.
+  for (const auto& attr : dq->attribute()) {
+    if (attr.name() == "axis") {
+      axis = attr.i();
+      break;
+    }
+  }
+  if (axis < 0) {
+    axis += rank;
+  }
+
+  const std::vector<int64_t> q_dims(q_init->dims().begin(),
+                                    q_init->dims().end());
+  std::vector<int64_t> scale_dims(scale_init->dims().begin(),
+                                  scale_init->dims().end());
+  int64_t numel = 1;
+  for (int64_t d : scale_dims) {
+    numel *= d;
+  }
+  bool per_channel;
+  if (numel == 1) {
+    per_channel = false;
+  } else if (scale_dims.size() == 1) {
+    if (axis != expected_axis ||
+        scale_dims[0] != q_dims[static_cast<size_t>(expected_axis)]) {
+      return std::nullopt;
+    }
+    per_channel = true;
+  } else {
+    return std::nullopt;
+  }
+
+  return QdqWeightMatch{dq,          q_name, scale_name, zp_name, expected_axis,
+                        per_channel, q_dims};
+}
+
+struct QdqBlockwiseWeightMatch {
+  onnx::NodeProto* dq_node;
+  std::string q_name;
+  std::string scale_name;
+  std::optional<std::string> zp_name;
+  int64_t out_axis;
+  int64_t block_axis;
+  int64_t block_size;
+  int64_t num_blocks;
+  std::vector<int64_t> dims;
+};
+
+// The blockwise INT4/UINT4 analogue of MatchDequantizeLinearWeight -- see
+// this section's own top comment. `block_axis` is always `1 - expected_axis`
+// (this weight's own reduction axis, never its output-channel one).
+std::optional<QdqBlockwiseWeightMatch> MatchDequantizeLinearWeightBlockwise(
+    const std::string& weight_name, int64_t rank, int64_t expected_axis,
+    const InitMap& init_map, const DqMap& dq_of,
+    const ConsumerMap& consumers_of) {
+  auto dit = dq_of.find(weight_name);
+  if (dit == dq_of.end()) {
+    return std::nullopt;
+  }
+  onnx::NodeProto* dq = dit->second;
+  if (dq->op_type() != "DequantizeLinear" || dq->output_size() != 1) {
+    return std::nullopt;
+  }
+  if (ConsumerCount(consumers_of, weight_name) != 1) {
+    return std::nullopt;
+  }
+  if (dq->input_size() != 2 && dq->input_size() != 3) {
+    return std::nullopt;
+  }
+  const std::string& q_name = dq->input(0);
+  const std::string& scale_name = dq->input(1);
+  std::optional<std::string> zp_name;
+  if (dq->input_size() == 3 && !dq->input(2).empty()) {
+    zp_name = dq->input(2);
+  }
+  if (q_name.empty() || scale_name.empty()) {
+    return std::nullopt;
+  }
+
+  auto qit = init_map.find(q_name);
+  auto sit = init_map.find(scale_name);
+  if (qit == init_map.end() || sit == init_map.end()) {
+    return std::nullopt;
+  }
+  const onnx::TensorProto* q_init = qit->second;
+  const onnx::TensorProto* scale_init = sit->second;
+  if (q_init->data_type() != onnx::TensorProto::INT4 &&
+      q_init->data_type() != onnx::TensorProto::UINT4) {
+    return std::nullopt;
+  }
+  if (scale_init->data_type() != onnx::TensorProto::FLOAT) {
+    return std::nullopt;
+  }
+  if (q_init->dims_size() != rank) {
+    return std::nullopt;
+  }
+
+  if (zp_name) {
+    auto zit = init_map.find(*zp_name);
+    if (zit == init_map.end()) {
+      return std::nullopt;
+    }
+    const onnx::TensorProto* zp_init = zit->second;
+    if (zp_init->data_type() != q_init->data_type()) {
+      return std::nullopt;
+    }
+    if (!DimsEqual(zp_init->dims(), scale_init->dims())) {
+      return std::nullopt;
+    }
+  }
+
+  if (ConsumerCount(consumers_of, q_name) != 1 ||
+      ConsumerCount(consumers_of, scale_name) != 1 ||
+      (zp_name && ConsumerCount(consumers_of, *zp_name) != 1)) {
+    return std::nullopt;
+  }
+
+  int64_t block_size = 0, output_dtype = 0;
+  for (const auto& attr : dq->attribute()) {
+    if (attr.name() == "block_size") {
+      block_size = attr.i();
+    } else if (attr.name() == "output_dtype") {
+      output_dtype = attr.i();
+    }
+  }
+  if (block_size <= 0) {
+    return std::nullopt;  // Not blockwise -- MatchDequantizeLinearWeight's own
+                          // job.
+  }
+  if (output_dtype != 0) {
+    return std::nullopt;
+  }
+
+  int64_t axis = 1;
+  for (const auto& attr : dq->attribute()) {
+    if (attr.name() == "axis") {
+      axis = attr.i();
+      break;
+    }
+  }
+  if (axis < 0) {
+    axis += rank;
+  }
+
+  const int64_t block_axis = 1 - expected_axis;
+  if (axis != block_axis) {
+    return std::nullopt;
+  }
+
+  const std::vector<int64_t> dims(q_init->dims().begin(), q_init->dims().end());
+  const int64_t block_dim = dims[static_cast<size_t>(block_axis)];
+  if (block_dim % block_size != 0) {
+    return std::nullopt;  // Padded/partial final block -- declined.
+  }
+  const int64_t num_blocks = block_dim / block_size;
+
+  std::vector<int64_t> expected_scale_dims = dims;
+  expected_scale_dims[static_cast<size_t>(block_axis)] = num_blocks;
+  const std::vector<int64_t> scale_dims(scale_init->dims().begin(),
+                                        scale_init->dims().end());
+  if (scale_dims != expected_scale_dims) {
+    return std::nullopt;
+  }
+
+  return QdqBlockwiseWeightMatch{dq,         q_name,        scale_name,
+                                 zp_name,    expected_axis, block_axis,
+                                 block_size, num_blocks,    dims};
+}
+
+// A Conv/ConvTranspose/MatMul/Gemm weight resolved from one of three
+// sources -- a direct FLOAT initializer, a per-tensor/per-channel QDQ one,
+// or a blockwise INT4/UINT4 QDQ one -- mirroring pruning.py's own
+// `_WeightRef`/`_resolve_weight_ref`. Exactly one of `float_name`/`qdq`/
+// `qdq_block` is set; `dims` is always populated regardless of which.
+struct WeightRefMatch {
+  std::optional<std::string> float_name;
+  std::optional<QdqWeightMatch> qdq;
+  std::optional<QdqBlockwiseWeightMatch> qdq_block;
+  std::vector<int64_t> dims;
+
+  bool is_qdq() const { return qdq.has_value() || qdq_block.has_value(); }
+
+  // A name uniquely identifying the underlying tensor this resolves to --
+  // the int8/int4 `q_init`'s own name for a QDQ weight (per-tensor/
+  // per-channel or blockwise alike), or the float initializer's own name
+  // otherwise. Used to detect a shared/tied weight playing the same role in
+  // more than one chain -- mirrors pruning.py's own `_weight_ref_key`.
+  std::string key() const {
+    if (qdq) {
+      return qdq->q_name;
+    }
+    if (qdq_block) {
+      return qdq_block->q_name;
+    }
+    return *float_name;
+  }
+};
+
+std::optional<WeightRefMatch> ResolveWeightRef(
+    const std::string& weight_name, int64_t rank, int64_t expected_axis,
+    const InitMap& init_map, const DqMap& dq_of,
+    const ConsumerMap& consumers_of) {
+  auto it = init_map.find(weight_name);
+  if (it != init_map.end()) {
+    const onnx::TensorProto* w = it->second;
+    if (w->data_type() == onnx::TensorProto::FLOAT && w->dims_size() == rank) {
+      WeightRefMatch ref;
+      ref.float_name = weight_name;
+      ref.dims.assign(w->dims().begin(), w->dims().end());
+      return ref;
+    }
+    return std::nullopt;
+  }
+  auto qdq = MatchDequantizeLinearWeight(weight_name, rank, expected_axis,
+                                         init_map, dq_of, consumers_of);
+  if (qdq) {
+    WeightRefMatch ref;
+    ref.dims = qdq->dims;
+    ref.qdq = std::move(qdq);
+    return ref;
+  }
+  auto qdq_block = MatchDequantizeLinearWeightBlockwise(
+      weight_name, rank, expected_axis, init_map, dq_of, consumers_of);
+  if (qdq_block) {
+    WeightRefMatch ref;
+    ref.dims = qdq_block->dims;
+    ref.qdq_block = std::move(qdq_block);
+    return ref;
+  }
+  return std::nullopt;
+}
+
+// --- Per-op-family matchers built on ResolveWeightRef, mirroring
+// _match_conv_qdq/_match_conv_transpose_qdq/_match_matmul_qdq --------------
+
+struct QdqConvMatch {
+  WeightRefMatch ref;
+  std::optional<std::string> bias;
+  int64_t out_channels;
+  int64_t in_channels;
+};
+
+std::optional<QdqConvMatch> MatchConvQdq(const onnx::NodeProto& node,
+                                         const InitMap& init_map,
+                                         const DqMap& dq_of,
+                                         const ConsumerMap& consumers_of) {
+  if (node.op_type() != "Conv" || node.input_size() < 2) {
+    return std::nullopt;
+  }
+  if (ConvGroupAttr(node) != 1) {
+    return std::nullopt;  // Grouped/depthwise QDQ Conv -- out of scope.
+  }
+  auto ref =
+      ResolveWeightRef(node.input(1), 4, 0, init_map, dq_of, consumers_of);
+  if (!ref) {
+    return std::nullopt;
+  }
+  const int64_t out_channels = ref->dims[0];
+  const int64_t in_channels = ref->dims[1];
+  std::optional<std::string> bias;
+  if (node.input_size() == 3 && !node.input(2).empty()) {
+    bias = node.input(2);
+    auto bit = init_map.find(*bias);
+    if (bit == init_map.end() ||
+        bit->second->data_type() != onnx::TensorProto::FLOAT) {
+      return std::nullopt;  // Non-constant bias -- can't safely slice it.
+    }
+  }
+  return QdqConvMatch{*ref, bias, out_channels, in_channels};
+}
+
+struct QdqConvTransposeMatch {
+  WeightRefMatch ref;
+  std::optional<std::string> bias;
+  int64_t out_channels;
+  int64_t in_channels;
+};
+
+// The ConvTranspose analogue of MatchConvQdq -- see this section's own top
+// comment for the reversed-layout ([in_channels, out_channels, kH, kW])
+// reasoning. `expected_axis=1` is the ONE difference from MatchConvQdq.
+std::optional<QdqConvTransposeMatch> MatchConvTransposeQdq(
+    const onnx::NodeProto& node, const InitMap& init_map, const DqMap& dq_of,
+    const ConsumerMap& consumers_of) {
+  if (node.op_type() != "ConvTranspose" || node.input_size() < 2) {
+    return std::nullopt;
+  }
+  if (ConvGroupAttr(node) != 1) {
+    return std::nullopt;
+  }
+  auto ref =
+      ResolveWeightRef(node.input(1), 4, 1, init_map, dq_of, consumers_of);
+  if (!ref) {
+    return std::nullopt;
+  }
+  const int64_t in_channels = ref->dims[0];
+  const int64_t out_channels = ref->dims[1];
+  std::optional<std::string> bias;
+  if (node.input_size() == 3 && !node.input(2).empty()) {
+    bias = node.input(2);
+    auto bit = init_map.find(*bias);
+    if (bit == init_map.end() ||
+        bit->second->data_type() != onnx::TensorProto::FLOAT) {
+      return std::nullopt;
+    }
+  }
+  return QdqConvTransposeMatch{*ref, bias, out_channels, in_channels};
+}
+
+struct QdqMatmulMatch {
+  std::string x_name;
+  WeightRefMatch ref;
+  bool weight_transposed;
+  std::optional<std::string> bias;
+  int64_t out_channels;
+  int64_t in_channels;
+};
+
+std::optional<QdqMatmulMatch> MatchMatmulQdq(const onnx::NodeProto& node,
+                                             const InitMap& init_map,
+                                             const DqMap& dq_of,
+                                             const ConsumerMap& consumers_of) {
+  auto m = MatchMatMulLikeRaw(node);
+  if (!m) {
+    return std::nullopt;
+  }
+  const int64_t axis = m->weight_transposed ? 0 : 1;
+  auto ref =
+      ResolveWeightRef(m->w_name, 2, axis, init_map, dq_of, consumers_of);
+  if (!ref) {
+    return std::nullopt;
+  }
+  const int64_t out_channels = ref->dims[static_cast<size_t>(axis)];
+  const int64_t in_channels = ref->dims[static_cast<size_t>(1 - axis)];
+  std::optional<std::string> bias;
+  if (node.op_type() == "Gemm" && node.input_size() == 3 &&
+      !node.input(2).empty()) {
+    bias = node.input(2);
+    auto bit = init_map.find(*bias);
+    if (bit == init_map.end() ||
+        bit->second->data_type() != onnx::TensorProto::FLOAT) {
+      return std::nullopt;
+    }
+  }
+  return QdqMatmulMatch{m->x_name, *ref,         m->weight_transposed,
+                        bias,      out_channels, in_channels};
+}
+
+// --- Chain data model + plain-chain walker/finder, mirroring _QDQProducer/
+// _QDQConsumer/_QDQChain/_QDQGatedChain and _walk_to_consumer_qdq/
+// _find_qdq_chains ----------------------------------------------------------
+
+struct QdqProducer {
+  onnx::NodeProto* node;
+  WeightRefMatch ref;
+  std::optional<std::string> bias;
+  bool weight_transposed;
+  bool is_conv;
+  bool is_conv_transpose;
+  // Activation nodes between this producer's raw output and the point it
+  // combines with another producer -- a gated pair only, see
+  // FindQdqGatedChains; empty for a plain single-producer chain.
+  std::vector<onnx::NodeProto*> pre_ops;
+};
+
+struct QdqConsumerMatch {
+  onnx::NodeProto* node;
+  WeightRefMatch ref;
+  bool weight_transposed;
+  bool is_conv;
+  bool is_conv_transpose = false;
+};
+
+struct QdqChain {
+  QdqProducer producer;
+  std::vector<onnx::NodeProto*> chain_ops;
+  QdqConsumerMatch consumer;
+  int64_t n_channels;
+};
+
+struct QdqGatedChain {
+  QdqProducer producer_a;
+  QdqProducer producer_b;
+  std::vector<onnx::NodeProto*> chain_ops;
+  QdqConsumerMatch consumer;
+  int64_t n_channels;
+};
+
+// From tensor `start`, walks forward through shape-preserving unary
+// activations (UnaryPassThroughOps) with no other consumer anywhere along
+// the way, until a same-family (Conv/ConvTranspose-only or MatMul/Gemm-only,
+// matching `is_conv`) consumer is found whose input-channel count matches
+// `n_channels`. No per-channel Add/Mul bias/scale hop, no depthwise Conv
+// pass-through, no branch -- narrower than WalkToConsumer by design, see
+// this section's own top comment. Mirrors pruning.py's own
+// `_walk_to_consumer_qdq` exactly, including trying a Conv consumer before a
+// ConvTranspose one regardless of which family the producer itself was.
+std::pair<std::optional<QdqConsumerMatch>, std::vector<onnx::NodeProto*>>
+WalkToConsumerQdq(const std::string& start, bool is_conv,
+                  const InitMap& init_map, const DqMap& dq_of,
+                  const ConsumerMap& consumers_of,
+                  const std::unordered_set<std::string>& graph_outputs,
+                  int64_t n_channels, int max_hops) {
+  std::vector<onnx::NodeProto*> chain_ops;
+  std::string cur = start;
+  for (int hop = 0; hop < max_hops; ++hop) {
+    auto cit = consumers_of.find(cur);
+    if (cit == consumers_of.end() || cit->second.size() != 1) {
+      return {std::nullopt, chain_ops};
+    }
+    onnx::NodeProto* nxt = cit->second[0];
+
+    if (is_conv) {
+      if (nxt->op_type() == "Conv" && nxt->input_size() > 0 &&
+          nxt->input(0) == cur) {
+        auto m = MatchConvQdq(*nxt, init_map, dq_of, consumers_of);
+        if (!m || m->in_channels != n_channels) {
+          return {std::nullopt, chain_ops};
+        }
+        return {QdqConsumerMatch{nxt, m->ref, false, true, false}, chain_ops};
+      }
+      if (nxt->op_type() == "ConvTranspose" && nxt->input_size() > 0 &&
+          nxt->input(0) == cur) {
+        auto m = MatchConvTransposeQdq(*nxt, init_map, dq_of, consumers_of);
+        if (!m || m->in_channels != n_channels) {
+          return {std::nullopt, chain_ops};
+        }
+        return {QdqConsumerMatch{nxt, m->ref, false, true, true}, chain_ops};
+      }
+    } else {
+      auto mm = MatchMatmulQdq(*nxt, init_map, dq_of, consumers_of);
+      if (mm && mm->x_name == cur) {
+        if (mm->in_channels != n_channels) {
+          return {std::nullopt, chain_ops};
+        }
+        return {
+            QdqConsumerMatch{nxt, mm->ref, mm->weight_transposed, false, false},
+            chain_ops};
+      }
+    }
+
+    const bool is_unary = UnaryPassThroughOps().count(nxt->op_type()) != 0 &&
+                          nxt->input_size() == 1 && nxt->input(0) == cur &&
+                          nxt->output_size() == 1;
+    if (!is_unary) {
+      return {std::nullopt, chain_ops};
+    }
+    const std::string& out2 = nxt->output(0);
+    auto oit = consumers_of.find(out2);
+    if (oit == consumers_of.end() || oit->second.size() != 1 ||
+        graph_outputs.count(out2)) {
+      return {std::nullopt, chain_ops};
+    }
+    chain_ops.push_back(nxt);
+    cur = out2;
+  }
+  return {std::nullopt, chain_ops};
+}
+
+std::vector<QdqChain> FindQdqChains(onnx::GraphProto* graph) {
+  InitMap init_map;
+  for (const auto& t : graph->initializer()) {
+    init_map[t.name()] = &t;
+  }
+  ConsumerMap consumers_of = ConsumersOf(graph);
+  DqMap dq_of;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* n = graph->mutable_node(i);
+    if (n->op_type() == "DequantizeLinear" && n->output_size() == 1) {
+      dq_of[n->output(0)] = n;
+    }
+  }
+  std::unordered_set<std::string> graph_outputs;
+  for (const auto& o : graph->output()) {
+    graph_outputs.insert(o.name());
+  }
+  auto is_internal = [&](const std::string& name) {
+    auto it = consumers_of.find(name);
+    return it != consumers_of.end() && it->second.size() == 1 &&
+           !graph_outputs.count(name);
+  };
+
+  std::vector<QdqChain> chains;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    bool is_conv_transpose = false;
+    std::optional<WeightRefMatch> ref;
+    std::optional<std::string> bias_name;
+    int64_t out_channels = 0;
+    bool weight_transposed = false;
+    bool is_conv;
+
+    if (node->op_type() == "Conv") {
+      auto m = MatchConvQdq(*node, init_map, dq_of, consumers_of);
+      if (!m) {
+        continue;
+      }
+      ref = m->ref;
+      bias_name = m->bias;
+      out_channels = m->out_channels;
+      is_conv = true;
+    } else if (node->op_type() == "ConvTranspose") {
+      auto m = MatchConvTransposeQdq(*node, init_map, dq_of, consumers_of);
+      if (!m) {
+        continue;
+      }
+      ref = m->ref;
+      bias_name = m->bias;
+      out_channels = m->out_channels;
+      is_conv = true;
+      is_conv_transpose = true;
+    } else {
+      auto mm = MatchMatmulQdq(*node, init_map, dq_of, consumers_of);
+      if (!mm) {
+        continue;
+      }
+      ref = mm->ref;
+      bias_name = mm->bias;
+      out_channels = mm->out_channels;
+      weight_transposed = mm->weight_transposed;
+      is_conv = false;
+    }
+
+    const std::string& out_name = node->output(0);
+    if (!is_internal(out_name)) {
+      continue;
+    }
+    auto [consumer, chain_ops] =
+        WalkToConsumerQdq(out_name, is_conv, init_map, dq_of, consumers_of,
+                          graph_outputs, out_channels, kMaxChainHops);
+    if (!consumer) {
+      continue;
+    }
+    if (!(ref->is_qdq() || consumer->ref.is_qdq())) {
+      continue;  // Both plain float -- FindChains's own job.
+    }
+
+    QdqChain chain;
+    chain.producer = QdqProducer{
+        node, *ref, bias_name, weight_transposed, is_conv, is_conv_transpose,
+        {}};
+    chain.chain_ops = std::move(chain_ops);
+    chain.consumer = *consumer;
+    chain.n_channels = out_channels;
+    chains.push_back(std::move(chain));
+  }
+  return chains;
+}
+
+// --- Gated (SwiGLU/GeGLU) chains, mirroring _trace_gate_producer_backward_qdq/
+// _qdq_gated_channel_importance/_find_qdq_gated_chains ----------------------
+
+struct QdqFullProducerMatch {
+  onnx::NodeProto* node;
+  WeightRefMatch ref;
+  bool weight_transposed;
+  std::optional<std::string> bias;
+  int64_t n_channels;
+};
+
+// Walks backward from `tensor_name` through unary activation ops until it
+// resolves to a QDQ-or-plain-float MatMul/vanilla-Gemm producer's raw
+// output. Mirrors TraceGateProducerBackward's own float-only walk, kept
+// separate (rather than shared) since `producer_infos` here holds a
+// resolved WeightRefMatch rather than a bare weight name -- the same
+// "duplicated for a structurally different producer_infos" choice
+// pruning.py's own comment gives for its identical Python split.
+std::optional<std::pair<QdqFullProducerMatch, std::vector<onnx::NodeProto*>>>
+TraceGateProducerBackwardQdq(
+    const std::string& tensor_name,
+    const std::unordered_map<std::string, onnx::NodeProto*>& node_by_output,
+    const std::unordered_map<std::string, QdqFullProducerMatch>& producer_infos,
+    const ConsumerMap& consumers_of,
+    const std::unordered_set<std::string>& graph_outputs, int max_hops) {
+  std::vector<onnx::NodeProto*> pre_ops;
+  std::string cur = tensor_name;
+  for (int hop = 0; hop < max_hops; ++hop) {
+    if (ConsumerCount(consumers_of, cur) != 1 || graph_outputs.count(cur)) {
+      return std::nullopt;
+    }
+    auto pit = producer_infos.find(cur);
+    if (pit != producer_infos.end()) {
+      std::reverse(pre_ops.begin(), pre_ops.end());
+      return std::make_pair(pit->second, std::move(pre_ops));
+    }
+    auto nit = node_by_output.find(cur);
+    if (nit == node_by_output.end()) {
+      return std::nullopt;
+    }
+    onnx::NodeProto* producer_node = nit->second;
+    if (!(UnaryPassThroughOps().count(producer_node->op_type()) != 0 &&
+          producer_node->input_size() == 1 &&
+          producer_node->output_size() == 1)) {
+      return std::nullopt;
+    }
+    pre_ops.push_back(producer_node);
+    cur = producer_node->input(0);
+  }
+  return std::nullopt;
+}
+
+std::vector<QdqGatedChain> FindQdqGatedChains(onnx::GraphProto* graph) {
+  InitMap init_map;
+  for (const auto& t : graph->initializer()) {
+    init_map[t.name()] = &t;
+  }
+  ConsumerMap consumers_of = ConsumersOf(graph);
+  DqMap dq_of;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* n = graph->mutable_node(i);
+    if (n->op_type() == "DequantizeLinear" && n->output_size() == 1) {
+      dq_of[n->output(0)] = n;
+    }
+  }
+  std::unordered_set<std::string> graph_outputs;
+  for (const auto& o : graph->output()) {
+    graph_outputs.insert(o.name());
+  }
+  auto is_internal = [&](const std::string& name) {
+    auto it = consumers_of.find(name);
+    return it != consumers_of.end() && it->second.size() == 1 &&
+           !graph_outputs.count(name);
+  };
+
+  std::unordered_map<std::string, onnx::NodeProto*> node_by_output;
+  std::unordered_map<std::string, QdqFullProducerMatch> producer_infos;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    for (const auto& out : node->output()) {
+      node_by_output[out] = node;
+    }
+    auto mm = MatchMatmulQdq(*node, init_map, dq_of, consumers_of);
+    if (mm) {
+      producer_infos[node->output(0)] = QdqFullProducerMatch{
+          node, mm->ref, mm->weight_transposed, mm->bias, mm->out_channels};
+    }
+  }
+
+  std::vector<QdqGatedChain> chains;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    std::optional<QdqFullProducerMatch> info_a, info_b;
+    std::vector<onnx::NodeProto*> pre_a, pre_b;
+
+    if (node->op_type() == "Mul" && node->input_size() == 2 &&
+        node->output_size() == 1) {
+      const std::string& a_name = node->input(0);
+      const std::string& b_name = node->input(1);
+      if (a_name == b_name || init_map.count(a_name) ||
+          init_map.count(b_name)) {
+        continue;
+      }
+      auto trace_a = TraceGateProducerBackwardQdq(a_name, node_by_output,
+                                                  producer_infos, consumers_of,
+                                                  graph_outputs, kMaxChainHops);
+      auto trace_b = TraceGateProducerBackwardQdq(b_name, node_by_output,
+                                                  producer_infos, consumers_of,
+                                                  graph_outputs, kMaxChainHops);
+      if (!trace_a || !trace_b) {
+        continue;
+      }
+      info_a = trace_a->first;
+      pre_a = std::move(trace_a->second);
+      info_b = trace_b->first;
+      pre_b = std::move(trace_b->second);
+    } else if (node->op_type() == "SwiGLU" && node->input_size() == 2 &&
+               node->output_size() == 1) {
+      const std::string& a_name = node->input(0);
+      const std::string& b_name = node->input(1);
+      if (init_map.count(a_name) || init_map.count(b_name)) {
+        continue;
+      }
+      if (!(is_internal(a_name) && is_internal(b_name))) {
+        continue;
+      }
+      auto ait = producer_infos.find(a_name);
+      auto bit = producer_infos.find(b_name);
+      if (ait == producer_infos.end() || bit == producer_infos.end()) {
+        continue;
+      }
+      info_a = ait->second;
+      info_b = bit->second;
+    } else {
+      continue;
+    }
+
+    if (info_a->node == info_b->node ||
+        info_a->n_channels != info_b->n_channels) {
+      continue;
+    }
+
+    const std::string& out_name = node->output(0);
+    if (!is_internal(out_name)) {
+      continue;
+    }
+    auto [consumer, chain_ops] =
+        WalkToConsumerQdq(out_name, false, init_map, dq_of, consumers_of,
+                          graph_outputs, info_a->n_channels, kMaxChainHops);
+    if (!consumer) {
+      continue;
+    }
+
+    QdqProducer pa{info_a->node,      info_a->ref,
+                   info_a->bias,      info_a->weight_transposed,
+                   false /*is_conv*/, false,
+                   std::move(pre_a)};
+    QdqProducer pb{info_b->node,      info_b->ref,
+                   info_b->bias,      info_b->weight_transposed,
+                   false /*is_conv*/, false,
+                   std::move(pre_b)};
+    if (!(pa.ref.is_qdq() || pb.ref.is_qdq() || consumer->ref.is_qdq())) {
+      continue;  // All plain float -- FindGatedChains's own job.
+    }
+
+    QdqGatedChain chain;
+    chain.producer_a = std::move(pa);
+    chain.producer_b = std::move(pb);
+    chain.chain_ops = std::move(chain_ops);
+    chain.consumer = *consumer;
+    chain.n_channels = info_a->n_channels;
+    chains.push_back(std::move(chain));
+  }
+  return chains;
+}
+
+// --- Apply: slicing, mirroring _slice_producer_weight_qdq[_block]/
+// _slice_consumer_weight_qdq[_block]/_qdq_block_aligned_keep_blocks/
+// apply_structured_pruning_qdq ----------------------------------------------
+
+using MutInitMap = std::unordered_map<std::string, onnx::TensorProto*>;
+
+MutInitMap BuildMutInitMap(onnx::GraphProto* graph) {
+  MutInitMap m;
+  for (int i = 0; i < graph->initializer_size(); ++i) {
+    onnx::TensorProto* t = graph->mutable_initializer(i);
+    m[t->name()] = t;
+  }
+  return m;
+}
+
+struct DequantResult {
+  std::vector<double> data;
+  std::vector<int64_t> dims;
+};
+
+// The full float64 array `ref` refers to, for IMPORTANCE RANKING ONLY -- see
+// this section's own top comment. Never written back to the graph.
+DequantResult DequantizeWeightRefForRanking(const WeightRefMatch& ref,
+                                            const MutInitMap& init_map) {
+  if (ref.float_name) {
+    const onnx::TensorProto* t = init_map.at(*ref.float_name);
+    const std::vector<float> f = ReadFloatTensor(*t);
+    return {std::vector<double>(f.begin(), f.end()), ref.dims};
+  }
+  if (ref.qdq) {
+    const QdqWeightMatch& q = *ref.qdq;
+    const onnx::TensorProto* qt = init_map.at(q.q_name);
+    const onnx::TensorProto* st = init_map.at(q.scale_name);
+    const std::vector<int64_t> codes = ReadQuantCodes(*qt);
+    const std::vector<float> scale = ReadFloatTensor(*st);
+    std::vector<int64_t> zp;
+    if (q.zp_name) {
+      zp = ReadQuantCodes(*init_map.at(*q.zp_name));
+    }
+    return {
+        PerChannelDequantFlat(codes, q.dims, scale, zp, q.per_channel, q.axis),
+        q.dims};
+  }
+  const QdqBlockwiseWeightMatch& qb = *ref.qdq_block;
+  const onnx::TensorProto* qt = init_map.at(qb.q_name);
+  const onnx::TensorProto* st = init_map.at(qb.scale_name);
+  const std::vector<int64_t> codes = ReadQuantCodes(*qt);
+  const std::vector<float> scale = ReadFloatTensor(*st);
+  std::vector<int64_t> zp;
+  if (qb.zp_name) {
+    zp = ReadQuantCodes(*init_map.at(*qb.zp_name));
+  }
+  return {BlockwiseDequantFlat(codes, qb.dims, scale, zp, qb.block_axis,
+                               qb.block_size, qb.num_blocks),
+          qb.dims};
+}
+
+// This weight's own output-channel axis (`producer_role`) or input/reduction
+// axis (consumer role), within its OWN `q_init`/float initializer's dims --
+// mirrors pruning.py's own identical branching in `_slice_producer_weight_qdq`/
+// `_slice_consumer_weight_qdq`.
+int64_t QdqWeightAxis(bool producer_role, bool weight_transposed, bool is_conv,
+                      bool is_conv_transpose) {
+  if (is_conv) {
+    if (producer_role) {
+      return is_conv_transpose ? 1 : 0;
+    }
+    return is_conv_transpose ? 0 : 1;
+  }
+  if (producer_role) {
+    return weight_transposed ? 0 : 1;
+  }
+  return weight_transposed ? 1 : 0;
+}
+
+// Slices `ref`'s own output channels to `keep` (ascending indices) -- the
+// producer role. See this section's own top comment for exactly which of
+// Wq/Ws/Wzp get co-sliced for each of the three WeightRefMatch sources.
+void SliceProducerWeightQdq(const WeightRefMatch& ref, bool weight_transposed,
+                            const std::vector<int64_t>& keep, bool is_conv,
+                            bool is_conv_transpose, MutInitMap& init_map) {
+  if (ref.float_name) {
+    onnx::TensorProto* wt = init_map.at(*ref.float_name);
+    if (!is_conv_transpose) {
+      SliceProducerWeight(wt, weight_transposed, keep, is_conv);
+      return;
+    }
+    // ConvTranspose float producer: [Cin, Cout, kH, kW], axis 1.
+    const std::vector<int64_t> dims(wt->dims().begin(), wt->dims().end());
+    const std::vector<float> data = ReadFloatTensor(*wt);
+    int64_t inner = 1;
+    for (size_t i = 2; i < dims.size(); ++i) {
+      inner *= dims[i];
+    }
+    const std::vector<float> out =
+        SliceAxis1(data, dims[0], dims[1], inner, keep);
+    std::vector<int64_t> new_dims = dims;
+    new_dims[1] = static_cast<int64_t>(keep.size());
+    SetFloatTensorData(wt, new_dims, out);
+    return;
+  }
+
+  const int64_t axis =
+      QdqWeightAxis(true, weight_transposed, is_conv, is_conv_transpose);
+  if (ref.qdq) {
+    const QdqWeightMatch& q = *ref.qdq;
+    onnx::TensorProto* qt = init_map.at(q.q_name);
+    const std::vector<int64_t> codes = ReadQuantCodes(*qt);
+    const std::vector<int64_t> new_codes =
+        SliceAlongAxis(codes, q.dims, axis, keep);
+    std::vector<int64_t> new_dims = q.dims;
+    new_dims[static_cast<size_t>(axis)] = static_cast<int64_t>(keep.size());
+    SetQuantCodes(qt, qt->data_type(), new_dims, new_codes);
+
+    if (q.per_channel) {
+      SliceLastAxis(init_map.at(q.scale_name), keep);
+      if (q.zp_name) {
+        onnx::TensorProto* zt = init_map.at(*q.zp_name);
+        const std::vector<int64_t> zdims(zt->dims().begin(), zt->dims().end());
+        const std::vector<int64_t> zcodes = ReadQuantCodes(*zt);
+        const std::vector<int64_t> new_z =
+            SliceAlongAxis(zcodes, zdims, 0, keep);
+        std::vector<int64_t> new_zdims = zdims;
+        new_zdims[0] = static_cast<int64_t>(keep.size());
+        SetQuantCodes(zt, zt->data_type(), new_zdims, new_z);
+      }
+    }
+    return;
+  }
+
+  // Blockwise: out_axis never blocked, so codes/scale/zero_point co-slice by
+  // `keep` in lockstep, no alignment concern (see this section's own top
+  // comment).
+  const QdqBlockwiseWeightMatch& qb = *ref.qdq_block;
+  onnx::TensorProto* qt = init_map.at(qb.q_name);
+  const std::vector<int64_t> codes = ReadQuantCodes(*qt);
+  const std::vector<int64_t> new_codes =
+      SliceAlongAxis(codes, qb.dims, qb.out_axis, keep);
+  std::vector<int64_t> new_dims = qb.dims;
+  new_dims[static_cast<size_t>(qb.out_axis)] =
+      static_cast<int64_t>(keep.size());
+  SetQuantCodes(qt, qt->data_type(), new_dims, new_codes);
+
+  onnx::TensorProto* st = init_map.at(qb.scale_name);
+  const std::vector<int64_t> sdims(st->dims().begin(), st->dims().end());
+  const std::vector<float> scale = ReadFloatTensor(*st);
+  const std::vector<float> new_scale =
+      SliceAlongAxis(scale, sdims, qb.out_axis, keep);
+  std::vector<int64_t> new_sdims = sdims;
+  new_sdims[static_cast<size_t>(qb.out_axis)] =
+      static_cast<int64_t>(keep.size());
+  SetFloatTensorData(st, new_sdims, new_scale);
+
+  if (qb.zp_name) {
+    onnx::TensorProto* zt = init_map.at(*qb.zp_name);
+    const std::vector<int64_t> zdims(zt->dims().begin(), zt->dims().end());
+    const std::vector<int64_t> zcodes = ReadQuantCodes(*zt);
+    const std::vector<int64_t> new_z =
+        SliceAlongAxis(zcodes, zdims, qb.out_axis, keep);
+    std::vector<int64_t> new_zdims = zdims;
+    new_zdims[static_cast<size_t>(qb.out_axis)] =
+        static_cast<int64_t>(keep.size());
+    SetQuantCodes(zt, zt->data_type(), new_zdims, new_z);
+  }
+}
+
+// Slices `ref`'s own input (reduction) channels to `keep` -- the consumer
+// role for a plain float or per-tensor/per-channel QDQ weight only (never a
+// blockwise one -- see SliceConsumerWeightQdqBlock below). Never touches
+// scale/zero_point: they are indexed by the OUTPUT channel axis (or are a
+// scalar), never by the input axis sliced here.
+void SliceConsumerWeightQdq(const WeightRefMatch& ref, bool weight_transposed,
+                            const std::vector<int64_t>& keep, bool is_conv,
+                            bool is_conv_transpose, MutInitMap& init_map) {
+  if (ref.float_name) {
+    onnx::TensorProto* wt = init_map.at(*ref.float_name);
+    if (!is_conv_transpose) {
+      SliceConsumerWeight(wt, weight_transposed, keep, is_conv);
+      return;
+    }
+    // ConvTranspose float consumer: [Cin, Cout, kH, kW], axis 0, flat (any
+    // group).
+    const std::vector<int64_t> dims(wt->dims().begin(), wt->dims().end());
+    const std::vector<float> data = ReadFloatTensor(*wt);
+    int64_t inner = 1;
+    for (size_t i = 1; i < dims.size(); ++i) {
+      inner *= dims[i];
+    }
+    const std::vector<float> out = SliceAxis0(data, dims[0], inner, keep);
+    std::vector<int64_t> new_dims = dims;
+    new_dims[0] = static_cast<int64_t>(keep.size());
+    SetFloatTensorData(wt, new_dims, out);
+    return;
+  }
+  const QdqWeightMatch& q = *ref.qdq;
+  const int64_t axis =
+      QdqWeightAxis(false, weight_transposed, is_conv, is_conv_transpose);
+  onnx::TensorProto* qt = init_map.at(q.q_name);
+  const std::vector<int64_t> codes = ReadQuantCodes(*qt);
+  const std::vector<int64_t> new_codes =
+      SliceAlongAxis(codes, q.dims, axis, keep);
+  std::vector<int64_t> new_dims = q.dims;
+  new_dims[static_cast<size_t>(axis)] = static_cast<int64_t>(keep.size());
+  SetQuantCodes(qt, qt->data_type(), new_dims, new_codes);
+}
+
+// Returns the ascending block indices `keep` corresponds to when every
+// `block_size`-sized block of a `block_dim`-length axis is either wholly
+// present in `keep` or wholly absent -- or nullopt when some block is only
+// partially kept (this chain's consumer cannot be safely pruned to this
+// exact `keep` set). Mirrors pruning.py's own `_qdq_block_aligned_keep_blocks`.
+std::optional<std::vector<int64_t>> QdqBlockAlignedKeepBlocks(
+    const std::vector<int64_t>& keep, int64_t block_dim, int64_t block_size) {
+  const std::unordered_set<int64_t> keep_set(keep.begin(), keep.end());
+  const int64_t num_blocks = block_dim / block_size;
+  std::vector<int64_t> keep_blocks;
+  for (int64_t b = 0; b < num_blocks; ++b) {
+    const int64_t lo = b * block_size;
+    bool all = true, any = false;
+    for (int64_t p = lo; p < lo + block_size; ++p) {
+      const bool in = keep_set.count(p) != 0;
+      all = all && in;
+      any = any || in;
+    }
+    if (all) {
+      keep_blocks.push_back(b);
+    } else if (any) {
+      return std::nullopt;
+    }
+  }
+  return keep_blocks;
+}
+
+// Slices `qb`'s own input/reduction (`block_axis`) axis -- the consumer role
+// for a blockwise-quantized weight. Never called with a non-block-aligned
+// `keep`; `keep_blocks` (QdqBlockAlignedKeepBlocks) is validated by the
+// caller first. `q_init` is sliced element-wise by `keep`; `scale`/
+// `zero_point` are indexed by BLOCK, so sliced by `keep_blocks` instead,
+// along the same `block_axis`.
+void SliceConsumerWeightQdqBlock(const QdqBlockwiseWeightMatch& qb,
+                                 const std::vector<int64_t>& keep,
+                                 const std::vector<int64_t>& keep_blocks,
+                                 MutInitMap& init_map) {
+  onnx::TensorProto* qt = init_map.at(qb.q_name);
+  const std::vector<int64_t> codes = ReadQuantCodes(*qt);
+  const std::vector<int64_t> new_codes =
+      SliceAlongAxis(codes, qb.dims, qb.block_axis, keep);
+  std::vector<int64_t> new_dims = qb.dims;
+  new_dims[static_cast<size_t>(qb.block_axis)] =
+      static_cast<int64_t>(keep.size());
+  SetQuantCodes(qt, qt->data_type(), new_dims, new_codes);
+
+  onnx::TensorProto* st = init_map.at(qb.scale_name);
+  const std::vector<int64_t> sdims(st->dims().begin(), st->dims().end());
+  const std::vector<float> scale = ReadFloatTensor(*st);
+  const std::vector<float> new_scale =
+      SliceAlongAxis(scale, sdims, qb.block_axis, keep_blocks);
+  std::vector<int64_t> new_sdims = sdims;
+  new_sdims[static_cast<size_t>(qb.block_axis)] =
+      static_cast<int64_t>(keep_blocks.size());
+  SetFloatTensorData(st, new_sdims, new_scale);
+
+  if (qb.zp_name) {
+    onnx::TensorProto* zt = init_map.at(*qb.zp_name);
+    const std::vector<int64_t> zdims(zt->dims().begin(), zt->dims().end());
+    const std::vector<int64_t> zcodes = ReadQuantCodes(*zt);
+    const std::vector<int64_t> new_z =
+        SliceAlongAxis(zcodes, zdims, qb.block_axis, keep_blocks);
+    std::vector<int64_t> new_zdims = zdims;
+    new_zdims[static_cast<size_t>(qb.block_axis)] =
+        static_cast<int64_t>(keep_blocks.size());
+    SetQuantCodes(zt, zt->data_type(), new_zdims, new_z);
+  }
+}
+
+// The shared apply body for both plain and gated QDQ chains, mirroring
+// `apply_structured_pruning_qdq`'s own main loop over
+// `_find_qdq_chains`/`_find_qdq_gated_chains` -- see this section's own top
+// comment for the producer/consumer co-slicing rules this enforces.
+void ApplyQdqChains(onnx::GraphProto* graph, std::vector<QdqChain>& chains,
+                    std::vector<QdqGatedChain>& gated_chains, double sparsity,
+                    TouchedState& touched) {
+  MutInitMap init_map = BuildMutInitMap(graph);
+  auto& producer_touched = touched.producer;
+  auto& consumer_touched = touched.consumer;
+  auto& stale_value_info = touched.stale_value_info;
+
+  auto mark_dq_stale = [&](const WeightRefMatch& ref) {
+    if (ref.qdq) {
+      stale_value_info.insert(ref.qdq->dq_node->output(0));
+    } else if (ref.qdq_block) {
+      stale_value_info.insert(ref.qdq_block->dq_node->output(0));
+    }
+  };
+
+  for (const auto& chain : chains) {
+    const QdqProducer& p = chain.producer;
+    const QdqConsumerMatch& c = chain.consumer;
+    const std::string p_key = p.ref.key();
+    const std::string c_key = c.ref.key();
+    if (p_key == c_key) {
+      continue;  // Degenerate (the same weight in both roles).
+    }
+    if (producer_touched.count(p_key) || consumer_touched.count(c_key)) {
+      continue;  // A shared/tied weight another chain already resized.
+    }
+
+    const int64_t n = chain.n_channels;
+    const int64_t keep_count = std::max<int64_t>(
+        1, n - std::llround(static_cast<double>(n) * sparsity));
+    if (keep_count >= n) {
+      continue;  // Rounds down to nothing for this layer -- no-op.
+    }
+
+    const DequantResult w = DequantizeWeightRefForRanking(p.ref, init_map);
+    const std::vector<double> w_nk = QdqWeightToNk(
+        w.data, w.dims, p.weight_transposed, p.is_conv, p.is_conv_transpose);
+    const int64_t k = static_cast<int64_t>(w_nk.size()) / n;
+    const std::vector<double> importance = QdqChannelImportanceL2(w_nk, n, k);
+    // Stable tie-break matters here specifically -- see
+    // StableTopKIndicesAscending's own comment: an unstable tie-break can
+    // flip a would-have-been block-aligned consumer to "declined"
+    // nondeterministically.
+    const std::vector<int64_t> keep =
+        StableTopKIndicesAscending(importance, keep_count);
+
+    std::optional<std::vector<int64_t>> keep_blocks;
+    if (c.ref.qdq_block) {
+      keep_blocks =
+          QdqBlockAlignedKeepBlocks(keep, n, c.ref.qdq_block->block_size);
+      if (!keep_blocks) {
+        continue;  // Non-block-aligned keep set -- decline the whole chain.
+      }
+    }
+
+    SliceProducerWeightQdq(p.ref, p.weight_transposed, keep, p.is_conv,
+                           p.is_conv_transpose, init_map);
+    if (p.bias) {
+      SliceLastAxis(init_map.at(*p.bias), keep);
+    }
+    if (keep_blocks) {
+      SliceConsumerWeightQdqBlock(*c.ref.qdq_block, keep, *keep_blocks,
+                                  init_map);
+    } else {
+      SliceConsumerWeightQdq(c.ref, c.weight_transposed, keep, c.is_conv,
+                             c.is_conv_transpose, init_map);
+    }
+
+    producer_touched.insert(p_key);
+    consumer_touched.insert(c_key);
+    stale_value_info.insert(p.node->output(0));
+    for (onnx::NodeProto* op : chain.chain_ops) {
+      stale_value_info.insert(op->output(0));
+    }
+    mark_dq_stale(p.ref);
+    mark_dq_stale(c.ref);
+  }
+
+  for (const auto& gchain : gated_chains) {
+    const QdqProducer& pa = gchain.producer_a;
+    const QdqProducer& pb = gchain.producer_b;
+    const QdqConsumerMatch& c = gchain.consumer;
+    const std::string pa_key = pa.ref.key();
+    const std::string pb_key = pb.ref.key();
+    const std::string c_key = c.ref.key();
+    if (pa_key == pb_key || pa_key == c_key || pb_key == c_key) {
+      continue;  // Degenerate (a weight tied across two roles).
+    }
+    if (producer_touched.count(pa_key) || producer_touched.count(pb_key) ||
+        consumer_touched.count(c_key)) {
+      continue;
+    }
+
+    const int64_t n = gchain.n_channels;
+    const int64_t keep_count = std::max<int64_t>(
+        1, n - std::llround(static_cast<double>(n) * sparsity));
+    if (keep_count >= n) {
+      continue;
+    }
+
+    const DequantResult wa = DequantizeWeightRefForRanking(pa.ref, init_map);
+    const DequantResult wb = DequantizeWeightRefForRanking(pb.ref, init_map);
+    const std::vector<double> wa_nk =
+        QdqWeightToNk(wa.data, wa.dims, pa.weight_transposed, false, false);
+    const std::vector<double> wb_nk =
+        QdqWeightToNk(wb.data, wb.dims, pb.weight_transposed, false, false);
+    const int64_t k = static_cast<int64_t>(wa_nk.size()) / n;
+    const std::vector<double> imp_a = QdqChannelImportanceL2(wa_nk, n, k);
+    const std::vector<double> imp_b = QdqChannelImportanceL2(wb_nk, n, k);
+    std::vector<double> importance(static_cast<size_t>(n));
+    for (int64_t i = 0; i < n; ++i) {
+      importance[static_cast<size_t>(i)] = std::sqrt(
+          imp_a[static_cast<size_t>(i)] * imp_a[static_cast<size_t>(i)] +
+          imp_b[static_cast<size_t>(i)] * imp_b[static_cast<size_t>(i)]);
+    }
+    const std::vector<int64_t> keep =
+        StableTopKIndicesAscending(importance, keep_count);
+
+    std::optional<std::vector<int64_t>> keep_blocks;
+    if (c.ref.qdq_block) {
+      keep_blocks =
+          QdqBlockAlignedKeepBlocks(keep, n, c.ref.qdq_block->block_size);
+      if (!keep_blocks) {
+        continue;
+      }
+    }
+
+    SliceProducerWeightQdq(pa.ref, pa.weight_transposed, keep, false, false,
+                           init_map);
+    if (pa.bias) {
+      SliceLastAxis(init_map.at(*pa.bias), keep);
+    }
+    SliceProducerWeightQdq(pb.ref, pb.weight_transposed, keep, false, false,
+                           init_map);
+    if (pb.bias) {
+      SliceLastAxis(init_map.at(*pb.bias), keep);
+    }
+    if (keep_blocks) {
+      SliceConsumerWeightQdqBlock(*c.ref.qdq_block, keep, *keep_blocks,
+                                  init_map);
+    } else {
+      SliceConsumerWeightQdq(c.ref, c.weight_transposed, keep, false, false,
+                             init_map);
+    }
+
+    producer_touched.insert(pa_key);
+    producer_touched.insert(pb_key);
+    consumer_touched.insert(c_key);
+    stale_value_info.insert(pa.node->output(0));
+    for (onnx::NodeProto* op : pa.pre_ops) {
+      stale_value_info.insert(op->output(0));
+    }
+    stale_value_info.insert(pb.node->output(0));
+    for (onnx::NodeProto* op : pb.pre_ops) {
+      stale_value_info.insert(op->output(0));
+    }
+    for (onnx::NodeProto* op : gchain.chain_ops) {
+      stale_value_info.insert(op->output(0));
+    }
+    mark_dq_stale(pa.ref);
+    mark_dq_stale(pb.ref);
+    mark_dq_stale(c.ref);
+  }
+}
+
 // --- Subgraph recursion ------------------------------------------------
 //
 // Mirrors pruning.py's own `_iter_subgraphs` and the "Subgraph recursion"
@@ -8260,6 +9951,8 @@ onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
         FindMatMulNBitsChains(graph);
     std::vector<MatMulNBitsGatedChain> matmul_nbits_gated_chains =
         FindMatMulNBitsGatedChains(graph);
+    std::vector<QdqChain> qdq_chains = FindQdqChains(graph);
+    std::vector<QdqGatedChain> qdq_gated_chains = FindQdqGatedChains(graph);
 
     TouchedState touched;
     if (!chains.empty()) {
@@ -8287,6 +9980,16 @@ onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
       // already touched it.
       ApplyMatMulNBitsChains(graph, matmul_nbits_chains,
                              matmul_nbits_gated_chains, sparsity, touched);
+    }
+    if (!qdq_chains.empty() || !qdq_gated_chains.empty()) {
+      // QDQ-quantized chains -- see this file's own "QDQ (quantized-weight)
+      // structured pruning" section comment. Additive and (per
+      // FindQdqChains/FindQdqGatedChains's own "at least one side QDQ"
+      // requirement) never targets a tensor any plain-float pass above could
+      // also match, but still shares `touched` with them for the same
+      // "one shared conflict ledger per graph" reason ApplySplitGatedChains
+      // does.
+      ApplyQdqChains(graph, qdq_chains, qdq_gated_chains, sparsity, touched);
     }
     if (!touched.stale_value_info.empty()) {
       google::protobuf::RepeatedPtrField<onnx::ValueInfoProto> kept;

--- a/tests/test_structured_pruning_cpp.py
+++ b/tests/test_structured_pruning_cpp.py
@@ -17,10 +17,12 @@ plus a couple of tests confirming unmatched topologies are left untouched
 
 import os
 
+import ml_dtypes
 import numpy as np
 import onnx
 import onnx.helper
 import onnx.numpy_helper
+import onnx.reference
 import pytest
 from onnx import parser
 
@@ -5840,3 +5842,851 @@ def test_cpp_structured_pruning_matmul_nbits_matches_python_reference_output():
     (y_py,) = _run(pruned_py, {"A": x})
     (y_cpp,) = _run(pruned_cpp, {"A": x})
     np.testing.assert_allclose(y_py, y_cpp, rtol=1e-5, atol=1e-5)
+
+
+# --- QDQ (quantized-weight) structured pruning -----------------------------
+#
+# Mirrors ``tests/test_pruning.py``'s own "apply_structured_pruning_qdq"
+# coverage for ``onnxsim.apply_structured_pruning_cpp`` -- the C++ port also
+# runs the QDQ-quantized chain families (see
+# ``onnxsim/structured_pruning_entry.cpp``'s own "QDQ (quantized-weight)
+# structured pruning" section comment), wired into the SAME entry point as
+# the plain-float chains above (unlike ``onnxsim.pruning``, which keeps
+# ``apply_structured_pruning_qdq`` a separate top-level function). Numeric-
+# oracle tests below run the pruned QDQ graph through onnxruntime with graph
+# optimizations disabled (``_run_unfused``), not the default-optimization
+# ``_run`` every other test in this file uses -- confirmed empirically (see
+# ``test_pruning.py``'s own identical comment): with default optimizations,
+# onnxruntime's own QDQ-aware graph optimizer fuses the
+# DequantizeLinear->MatMul/Conv pattern into an internal integer kernel whose
+# accumulation order differs from naive float dequantize-then-matmul,
+# changing the result by more than float32 rounding -- an onnxruntime
+# *optimization* artifact orthogonal to this pass's own correctness.
+
+
+def _i8(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.int8), name)
+
+
+def _int4(array, name):
+    return onnx.numpy_helper.from_array(
+        array.astype(np.int8).astype(ml_dtypes.int4), name
+    )
+
+
+def _uint4(array, name):
+    return onnx.numpy_helper.from_array(
+        array.astype(np.uint8).astype(ml_dtypes.uint4), name
+    )
+
+
+def _run_unfused(model, feeds):
+    so = ort.SessionOptions()
+    so.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL
+    sess = ort.InferenceSession(
+        model.SerializeToString(), sess_options=so, providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _qdq_dequant(q, scale, zero_point, axis):
+    # Independent reference dequantization -- mirrors the ONNX
+    # DequantizeLinear formula `y = (x - x_zero_point) * x_scale` directly,
+    # not anything from onnxsim itself.
+    q = q.astype(np.float64)
+    scale = scale.astype(np.float64)
+    if scale.ndim == 1:
+        shape = [1] * q.ndim
+        shape[axis] = -1
+        scale = scale.reshape(shape)
+    if zero_point is not None:
+        zp = zero_point.astype(np.float64)
+        if zp.ndim == 1:
+            shape = [1] * q.ndim
+            shape[axis] = -1
+            zp = zp.reshape(shape)
+        q = q - zp
+    return q * scale
+
+
+def _qdq_block_dequant(q, scale, zero_point, axis, block_size):
+    # Independent reference for BLOCKWISE dequantization -- mirrors opset
+    # 21's own `DequantizeLinear` formula with a `block_size` attribute.
+    q = q.astype(np.float64)
+    scale = np.repeat(scale.astype(np.float64), block_size, axis=axis)
+    slicer = [slice(None)] * q.ndim
+    slicer[axis] = slice(0, q.shape[axis])
+    scale = scale[tuple(slicer)]
+    if zero_point is not None:
+        zp = np.repeat(zero_point.astype(np.float64), block_size, axis=axis)
+        zp = zp[tuple(slicer)]
+        q = q - zp
+    return q * scale
+
+
+def _requantize_symmetric_int8_per_channel(w_float):
+    # An independent "dequantize-then-prune-then-REQUANTIZE-from-scratch"
+    # oracle -- NOT what this pass does (it slices the ORIGINAL codes/scale
+    # unchanged, see this file's own section comment above), used only to
+    # positively confirm "slice, don't recompute": a fresh symmetric
+    # per-output-channel INT8 quantization fit to the pruned float
+    # submatrix's own max-abs generally derives a numerically DIFFERENT
+    # scale than the original tensor's own (unrelated) scale values, so if
+    # the pass's own pruned scale matched THIS oracle instead of
+    # `Wscale[keep]`, that would be conclusive evidence of a
+    # dequant-requant bug rather than a direct slice.
+    amax = np.max(np.abs(w_float), axis=0)
+    scale = np.where(amax > 0, amax / 127.0, 1.0).astype(np.float32)
+    codes = np.clip(np.round(w_float / scale), -127, 127).astype(np.int8)
+    return codes, scale
+
+
+def _matmul_qdq_producer_model(K=8, H=16, Out=4, seed=0, zero_point=False):
+    rng = np.random.default_rng(seed)
+    Wq = rng.integers(-100, 100, size=(K, H)).astype(np.int8)
+    Wscale = np.abs(rng.standard_normal(H)).astype(np.float32) * 0.02 + 0.001
+    W2 = rng.standard_normal((H, Out)).astype(np.float32)
+    initializer = [_i8(Wq, "Wq"), _f32(Wscale, "Wscale"), _f32(W2, "W2")]
+    zp_input = ""
+    Wzp = None
+    if zero_point:
+        Wzp = rng.integers(-20, 20, size=H).astype(np.int8)
+        initializer.append(_i8(Wzp, "Wzp"))
+        zp_input = ", Wzp"
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          Wdq = DequantizeLinear<axis=1>(Wq, Wscale{zp_input})
+          h = MatMul(X, Wdq)
+          Y = MatMul(h, W2)
+        }}
+        """,
+        initializer=initializer,
+    )
+    return model, Wq, Wscale, Wzp, W2
+
+
+def test_cpp_qdq_structured_pruning_matmul_producer_per_channel_matches_oracle():
+    # Per-channel INT8 QDQ MatMul producer feeding a plain float MatMul
+    # consumer -- co-sliced Wq/Wscale, verified end to end AND confirmed to
+    # be a genuine slice rather than a dequant-prune-requantize round trip
+    # (per this task's own verification bar).
+    K, H, Out = 8, 16, 4
+    model, Wq, Wscale, _Wzp, W2 = _matmul_qdq_producer_model(K, H, Out, seed=0)
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Wq"].dims) == [K, H // 2]
+    assert list(inits["Wscale"].dims) == [H // 2]
+    assert list(inits["W2"].dims) == [H // 2, Out]
+
+    w_dequant = _qdq_dequant(Wq, Wscale, None, axis=1)
+    keep = _oracle_keep_indices(w_dequant, H // 2)
+
+    rng = np.random.default_rng(9)
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run_unfused(pruned, {"X": x})
+    h = x @ w_dequant[:, keep]
+    y_oracle = h @ W2[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+    # "Slice, don't recompute": the pruned Wq/Wscale are BIT-IDENTICAL to
+    # the original tensors at the surviving indices, never anything derived
+    # from a fresh quantization of the pruned float weight.
+    wq_pruned = onnx.numpy_helper.to_array(inits["Wq"])
+    wscale_pruned = onnx.numpy_helper.to_array(inits["Wscale"])
+    np.testing.assert_array_equal(wq_pruned, Wq[:, keep])
+    np.testing.assert_allclose(wscale_pruned, Wscale[keep])
+
+    # Oracle cross-check: an independent dequantize-prune-REQUANTIZE pass
+    # over the SAME pruned float submatrix derives a scale that generally
+    # differs from the pass's own (original, sliced) scale -- confirming
+    # the equality above is a genuine "slice, don't recompute" result, not
+    # a coincidence of a requantization oracle landing on the same values.
+    _requant_codes, requant_scale = _requantize_symmetric_int8_per_channel(
+        w_dequant[:, keep]
+    )
+    assert not np.allclose(wscale_pruned, requant_scale)
+
+
+def test_cpp_qdq_structured_pruning_matmul_producer_asymmetric_zero_point_matches_oracle():
+    K, H, Out = 8, 16, 4
+    model, Wq, Wscale, Wzp, W2 = _matmul_qdq_producer_model(
+        K, H, Out, seed=1, zero_point=True
+    )
+    onnx.checker.check_model(model)
+    assert Wzp is not None
+    assert np.any(Wzp != 0)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Wzp"].dims) == [H // 2]
+
+    w_dequant = _qdq_dequant(Wq, Wscale, Wzp, axis=1)
+    keep = _oracle_keep_indices(w_dequant, H // 2)
+
+    rng = np.random.default_rng(10)
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run_unfused(pruned, {"X": x})
+    h = x @ w_dequant[:, keep]
+    y_oracle = h @ W2[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+    wzp_pruned = onnx.numpy_helper.to_array(inits["Wzp"])
+    np.testing.assert_array_equal(wzp_pruned, Wzp[keep])
+
+
+def test_cpp_qdq_structured_pruning_matmul_consumer_matches_oracle_and_leaves_scale_untouched():
+    # Plain float producer (W1) feeding a QDQ (per-channel) MatMul consumer
+    # -- only Wq's own input/reduction axis is sliced; Wscale (indexed by
+    # the consumer's own OUTPUT channel) must come out byte-identical.
+    K, H, Out = 8, 16, 4
+    rng = np.random.default_rng(4)
+    W1 = rng.standard_normal((K, H)).astype(np.float32)
+    Wq = rng.integers(-100, 100, size=(H, Out)).astype(np.int8)
+    Wscale = np.abs(rng.standard_normal(Out)).astype(np.float32) * 0.03 + 0.001
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          h = MatMul(X, W1)
+          Wdq = DequantizeLinear<axis=1>(Wq, Wscale)
+          Y = MatMul(h, Wdq)
+        }}
+        """,
+        initializer=[_f32(W1, "W1"), _i8(Wq, "Wq"), _f32(Wscale, "Wscale")],
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Wq"].dims) == [H // 2, Out]
+    np.testing.assert_array_equal(onnx.numpy_helper.to_array(inits["Wscale"]), Wscale)
+
+    keep = _oracle_keep_indices(W1, H // 2)
+    w_dequant = _qdq_dequant(Wq, Wscale, None, axis=1)
+
+    rng2 = np.random.default_rng(5)
+    x = rng2.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run_unfused(pruned, {"X": x})
+    h = x @ W1[:, keep]
+    y_oracle = h @ w_dequant[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_cpp_qdq_structured_pruning_per_tensor_scale_left_untouched():
+    # Per-tensor (scalar) QDQ weight on the producer side: only Wq is
+    # sliced -- the scalar Wscale is byte-identical regardless of channel
+    # count.
+    K, H, Out = 8, 16, 4
+    rng = np.random.default_rng(6)
+    Wq = rng.integers(-100, 100, size=(K, H)).astype(np.int8)
+    Wscale = np.array(0.05, dtype=np.float32)
+    W2 = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          Wdq = DequantizeLinear(Wq, Wscale)
+          h = MatMul(X, Wdq)
+          Y = MatMul(h, W2)
+        }}
+        """,
+        initializer=[_i8(Wq, "Wq"), _f32(Wscale, "Wscale"), _f32(W2, "W2")],
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Wq"].dims) == [K, H // 2]
+    assert onnx.numpy_helper.to_array(inits["Wscale"]) == pytest.approx(0.05)
+
+    w_dequant = Wq.astype(np.float64) * 0.05
+    keep = _oracle_keep_indices(w_dequant, H // 2)
+    rng2 = np.random.default_rng(7)
+    x = rng2.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run_unfused(pruned, {"X": x})
+    y_oracle = (x @ w_dequant[:, keep]) @ W2[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_cpp_qdq_structured_pruning_conv_both_sides_qdq_matches_oracle():
+    Cin, Cmid, Cout = 4, 8, 4
+    rng = np.random.default_rng(8)
+    Wq1 = rng.integers(-100, 100, size=(Cmid, Cin, 1, 1)).astype(np.int8)
+    Wscale1 = np.abs(rng.standard_normal(Cmid)).astype(np.float32) * 0.02 + 0.001
+    Wq2 = rng.integers(-100, 100, size=(Cout, Cmid, 1, 1)).astype(np.int8)
+    Wscale2 = np.abs(rng.standard_normal(Cout)).astype(np.float32) * 0.02 + 0.001
+    model = _model(
+        f"""
+        g (float[1,{Cin},4,4] X) => (float[1,{Cout},4,4] Y)
+        {{
+          W1dq = DequantizeLinear<axis=0>(Wq1, Wscale1)
+          h = Conv(X, W1dq)
+          W2dq = DequantizeLinear<axis=0>(Wq2, Wscale2)
+          Y = Conv(h, W2dq)
+        }}
+        """,
+        initializer=[
+            _i8(Wq1, "Wq1"),
+            _f32(Wscale1, "Wscale1"),
+            _i8(Wq2, "Wq2"),
+            _f32(Wscale2, "Wscale2"),
+        ],
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Wq1"].dims) == [Cmid // 2, Cin, 1, 1]
+    assert list(inits["Wscale1"].dims) == [Cmid // 2]
+    assert list(inits["Wq2"].dims) == [Cout, Cmid // 2, 1, 1]
+    assert list(inits["Wscale2"].dims) == [Cout]  # consumer's own scale untouched
+
+    w1_dequant = _qdq_dequant(Wq1, Wscale1, None, axis=0)
+    w2_dequant = _qdq_dequant(Wq2, Wscale2, None, axis=0)
+    w1_nk = w1_dequant.reshape(Cmid, -1)
+    keep = _oracle_keep_indices(w1_nk.T, Cmid // 2)
+
+    rng2 = np.random.default_rng(11)
+    x = rng2.standard_normal((1, Cin, 4, 4)).astype(np.float32)
+    (y,) = _run_unfused(pruned, {"X": x})
+
+    ref_model = onnx.helper.make_model(
+        onnx.helper.make_graph(
+            [
+                onnx.helper.make_node("Conv", ["X", "W1"], ["h"]),
+                onnx.helper.make_node("Conv", ["h", "W2"], ["Y"]),
+            ],
+            "oracle",
+            [onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, None)],
+            [onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, None)],
+            initializer=[
+                onnx.numpy_helper.from_array(
+                    w1_dequant[keep].astype(np.float32), name="W1"
+                ),
+                onnx.numpy_helper.from_array(
+                    w2_dequant[:, keep].astype(np.float32), name="W2"
+                ),
+            ],
+        ),
+        opset_imports=[onnx.helper.make_opsetid("", 21)],
+        ir_version=10,
+    )
+    (y_oracle,) = onnx.reference.ReferenceEvaluator(ref_model).run(None, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_cpp_qdq_structured_pruning_declines_grouped_conv():
+    # A general grouped/depthwise QDQ Conv is out of scope -- see this
+    # file's own section comment above; must be left completely untouched.
+    Cin, Cout, group = 8, 8, 4
+    rng = np.random.default_rng(13)
+    Wq = rng.integers(-100, 100, size=(Cout, Cin // group, 1, 1)).astype(np.int8)
+    Wscale = np.abs(rng.standard_normal(Cout)).astype(np.float32) * 0.02 + 0.001
+    model = _model(
+        f"""
+        g (float[1,{Cin},2,2] X) => (float[1,{Cout},2,2] Y)
+        {{
+          Wdq = DequantizeLinear<axis=0>(Wq, Wscale)
+          Y = Conv<group={group}>(X, Wdq)
+        }}
+        """,
+        initializer=[_i8(Wq, "Wq"), _f32(Wscale, "Wscale")],
+    )
+    onnx.checker.check_model(model)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Wq"].dims) == list(Wq.shape)
+
+
+def test_cpp_qdq_structured_pruning_declines_shared_quantized_weight():
+    # The same int8 initializer feeding two independent DequantizeLinear
+    # consumers -- slicing it for one chain would silently corrupt the
+    # other's own use of the identical tensor, so it must be declined.
+    K, H, Out = 8, 16, 4
+    model, Wq, _Wscale, _Wzp, _W2 = _matmul_qdq_producer_model(K, H, Out, seed=14)
+    extra_dq = onnx.helper.make_node(
+        "DequantizeLinear", ["Wq", "Wscale"], ["Wdq2"], axis=1
+    )
+    extra_identity = onnx.helper.make_node("Identity", ["Wdq2"], ["Wdq2_out"])
+    model.graph.node.extend([extra_dq, extra_identity])
+    model.graph.output.append(
+        onnx.helper.make_tensor_value_info("Wdq2_out", onnx.TensorProto.FLOAT, [K, H])
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Wq"].dims) == [K, H]  # untouched -- Wq is shared
+
+
+def test_cpp_qdq_structured_pruning_both_sides_float_is_a_no_op():
+    # A plain float/float chain never touches the QDQ pass's own matchers --
+    # already exercised by ApplyChains above, confirmed here for the same
+    # single combined entry point.
+    model = _mlp_model(K=8, H=16, Out=4)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [8, 8]  # halved by the plain-float pass
+
+
+# --- QDQ: opset 21+ blockwise INT4/UINT4 ------------------------------------
+
+
+def _matmul_qdq_blockwise_producer_model(
+    K=8, H=16, Out=4, block_size=4, seed=0, zero_point=False, uint4=False
+):
+    rng = np.random.default_rng(seed)
+    k_blocks = K // block_size
+    lo, hi = (0, 16) if uint4 else (-8, 8)
+    pack = _uint4 if uint4 else _int4
+    Wq = rng.integers(lo, hi, size=(K, H)).astype(np.int8)
+    Wscale = (
+        np.abs(rng.standard_normal((k_blocks, H))).astype(np.float32) * 0.02 + 0.001
+    )
+    W2 = rng.standard_normal((H, Out)).astype(np.float32)
+    initializer = [pack(Wq, "Wq"), _f32(Wscale, "Wscale"), _f32(W2, "W2")]
+    zp_input = ""
+    Wzp = None
+    if zero_point:
+        Wzp = rng.integers(lo, hi, size=(k_blocks, H)).astype(np.int8)
+        initializer.append(pack(Wzp, "Wzp"))
+        zp_input = ", Wzp"
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          Wdq = DequantizeLinear<axis=0, block_size={block_size}>(Wq, Wscale{zp_input})
+          h = MatMul(X, Wdq)
+          Y = MatMul(h, W2)
+        }}
+        """,
+        initializer=initializer,
+    )
+    return model, Wq, Wscale, Wzp, W2
+
+
+def test_cpp_qdq_blockwise_int4_producer_matches_oracle():
+    K, H, Out, block_size = 8, 16, 4, 4
+    model, Wq, Wscale, _Wzp, W2 = _matmul_qdq_blockwise_producer_model(
+        K, H, Out, block_size, seed=100
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Wq"].dims) == [K, H // 2]
+    assert list(inits["Wscale"].dims) == [K // block_size, H // 2]
+    assert list(inits["W2"].dims) == [H // 2, Out]
+
+    w_dequant = _qdq_block_dequant(Wq, Wscale, None, axis=0, block_size=block_size)
+    keep = _oracle_keep_indices(w_dequant, H // 2)
+
+    rng = np.random.default_rng(101)
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run_unfused(pruned, {"X": x})
+    h = x @ w_dequant[:, keep]
+    y_oracle = h @ W2[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+    wq_pruned = onnx.numpy_helper.to_array(inits["Wq"]).astype(np.int8)
+    wscale_pruned = onnx.numpy_helper.to_array(inits["Wscale"])
+    np.testing.assert_array_equal(wq_pruned, Wq[:, keep])
+    np.testing.assert_allclose(wscale_pruned, Wscale[:, keep])
+
+
+def test_cpp_qdq_blockwise_uint4_producer_with_zero_point_matches_oracle():
+    K, H, Out, block_size = 8, 16, 4, 4
+    model, Wq, Wscale, Wzp, W2 = _matmul_qdq_blockwise_producer_model(
+        K, H, Out, block_size, seed=102, zero_point=True, uint4=True
+    )
+    onnx.checker.check_model(model)
+    assert Wzp is not None
+    assert np.any(Wzp != 0)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Wzp"].dims) == [K // block_size, H // 2]
+
+    w_dequant = _qdq_block_dequant(Wq, Wscale, Wzp, axis=0, block_size=block_size)
+    keep = _oracle_keep_indices(w_dequant, H // 2)
+
+    rng = np.random.default_rng(103)
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run_unfused(pruned, {"X": x})
+    h = x @ w_dequant[:, keep]
+    y_oracle = h @ W2[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+    wzp_pruned = onnx.numpy_helper.to_array(inits["Wzp"]).astype(np.uint8)
+    np.testing.assert_array_equal(wzp_pruned, Wzp[:, keep])
+
+
+def _block_grouped_column_weight(
+    rng, rows, n_blocks, block_size, high_block_idx, lo=1.0, hi=6.0
+):
+    # A float weight whose column magnitude is constant WITHIN each
+    # `block_size`-sized group of columns (large for every block index in
+    # `high_block_idx`, small otherwise) -- so the top-L2-norm importance
+    # ranking always drops/keeps whole blocks together, making a "consumer
+    # block-aligned" test deterministic rather than relying on chance
+    # alignment.
+    cols = n_blocks * block_size
+    base = rng.standard_normal((rows, cols)).astype(np.float64) * 0.1
+    for b in range(n_blocks):
+        mag = hi if b in high_block_idx else lo
+        base[:, b * block_size : (b + 1) * block_size] += mag * np.sign(
+            rng.standard_normal((rows, block_size))
+        )
+    return base.astype(np.float32)
+
+
+def _matmul_qdq_blockwise_consumer_model(
+    K, H, Out, block_size, seed=0, zero_point=False, uint4=False, W1=None
+):
+    rng = np.random.default_rng(seed)
+    h_blocks = H // block_size
+    lo, hi = (0, 16) if uint4 else (-8, 8)
+    pack = _uint4 if uint4 else _int4
+    if W1 is None:
+        W1 = rng.standard_normal((K, H)).astype(np.float32)
+    Wq = rng.integers(lo, hi, size=(H, Out)).astype(np.int8)
+    Wscale = (
+        np.abs(rng.standard_normal((h_blocks, Out))).astype(np.float32) * 0.02 + 0.001
+    )
+    initializer = [_f32(W1, "W1"), pack(Wq, "Wq"), _f32(Wscale, "Wscale")]
+    zp_input = ""
+    Wzp = None
+    if zero_point:
+        Wzp = rng.integers(lo, hi, size=(h_blocks, Out)).astype(np.int8)
+        initializer.append(pack(Wzp, "Wzp"))
+        zp_input = ", Wzp"
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          h = MatMul(X, W1)
+          Wdq = DequantizeLinear<axis=0, block_size={block_size}>(Wq, Wscale{zp_input})
+          Y = MatMul(h, Wdq)
+        }}
+        """,
+        initializer=initializer,
+    )
+    return model, W1, Wq, Wscale, Wzp
+
+
+def test_cpp_qdq_blockwise_consumer_block_aligned_matches_oracle():
+    K, H, Out, block_size = 4, 16, 4, 4
+    n_blocks = H // block_size
+    rng = np.random.default_rng(104)
+    W1 = _block_grouped_column_weight(
+        rng, K, n_blocks, block_size, high_block_idx={0, 2}
+    )
+    model, W1, Wq, Wscale, _Wzp = _matmul_qdq_blockwise_consumer_model(
+        K, H, Out, block_size, seed=105, W1=W1
+    )
+    onnx.checker.check_model(model)
+
+    keep = _oracle_keep_indices(W1, H // 2)
+    keep_blocks = sorted({int(k) // block_size for k in keep})
+    assert keep_blocks == [0, 2]  # engineered, genuinely block-aligned
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Wq"].dims) == [H // 2, Out]
+    assert list(inits["Wscale"].dims) == [n_blocks // 2, Out]
+
+    w_dequant = _qdq_block_dequant(Wq, Wscale, None, axis=0, block_size=block_size)
+    rng2 = np.random.default_rng(106)
+    x = rng2.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run_unfused(pruned, {"X": x})
+    h = x @ W1[:, keep]
+    y_oracle = h @ w_dequant[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+    # Scale sliced by BLOCK index, not element -- confirms co-slicing
+    # against the correct (coarser) axis.
+    wscale_pruned = onnx.numpy_helper.to_array(inits["Wscale"])
+    np.testing.assert_array_equal(wscale_pruned, Wscale[keep_blocks, :])
+
+
+def test_cpp_qdq_blockwise_consumer_non_block_aligned_declines():
+    # keep_count (6) is not a multiple of block_size (4) -- no whole-block
+    # partition of a 16-element axis can ever produce exactly 6 kept
+    # elements, so this chain's consumer is unconditionally non-block-
+    # aligned; the real call must decline the whole chain.
+    K, H, Out, block_size = 4, 16, 4, 4
+    model, W1, Wq, _Wscale, _Wzp = _matmul_qdq_blockwise_consumer_model(
+        K, H, Out, block_size, seed=107
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.625)  # keep 6 of 16
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [K, H]  # left completely untouched
+    assert list(inits["Wq"].dims) == [H, Out]
+    np.testing.assert_array_equal(onnx.numpy_helper.to_array(inits["W1"]), W1)
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Wq"]).astype(np.int8), Wq
+    )
+
+
+def test_cpp_qdq_blockwise_conv_producer_matches_oracle():
+    # Blockwise INT4 quantization on a Conv weight: axis=1 blocks the
+    # in_channels axis, exercised as the producer's own reduction axis
+    # while its OUTPUT channels (axis=0) are what gets pruned.
+    Cin, Cmid, Cout, block_size = 8, 8, 4, 4
+    cin_blocks = Cin // block_size
+    rng = np.random.default_rng(112)
+    Wq1 = rng.integers(-8, 8, size=(Cmid, Cin, 1, 1)).astype(np.int8)
+    Wscale1 = (
+        np.abs(rng.standard_normal((Cmid, cin_blocks, 1, 1))).astype(np.float32) * 0.02
+        + 0.001
+    )
+    Wq2 = rng.integers(-100, 100, size=(Cout, Cmid, 1, 1)).astype(np.int8)
+    Wscale2 = np.abs(rng.standard_normal(Cout)).astype(np.float32) * 0.02 + 0.001
+    model = _model(
+        f"""
+        g (float[1,{Cin},4,4] X) => (float[1,{Cout},4,4] Y)
+        {{
+          W1dq = DequantizeLinear<axis=1, block_size={block_size}>(W1q, W1s)
+          h = Conv(X, W1dq)
+          W2dq = DequantizeLinear<axis=0>(W2q, W2s)
+          Y = Conv(h, W2dq)
+        }}
+        """,
+        initializer=[
+            _int4(Wq1, "W1q"),
+            _f32(Wscale1, "W1s"),
+            _i8(Wq2, "W2q"),
+            _f32(Wscale2, "W2s"),
+        ],
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1q"].dims) == [Cmid // 2, Cin, 1, 1]
+    assert list(inits["W1s"].dims) == [Cmid // 2, cin_blocks, 1, 1]
+    assert list(inits["W2q"].dims) == [Cout, Cmid // 2, 1, 1]
+
+    w1_dequant = _qdq_block_dequant(Wq1, Wscale1, None, axis=1, block_size=block_size)
+    w2_dequant = _qdq_dequant(Wq2, Wscale2, None, axis=0)
+    w1_nk = w1_dequant.reshape(Cmid, -1)
+    keep = _oracle_keep_indices(w1_nk.T, Cmid // 2)
+
+    rng2 = np.random.default_rng(113)
+    x = rng2.standard_normal((1, Cin, 4, 4)).astype(np.float32)
+    (y,) = _run_unfused(pruned, {"X": x})
+
+    ref_model = onnx.helper.make_model(
+        onnx.helper.make_graph(
+            [
+                onnx.helper.make_node("Conv", ["X", "W1"], ["h"]),
+                onnx.helper.make_node("Conv", ["h", "W2"], ["Y"]),
+            ],
+            "oracle",
+            [onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, None)],
+            [onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, None)],
+            initializer=[
+                onnx.numpy_helper.from_array(
+                    w1_dequant[keep].astype(np.float32), name="W1"
+                ),
+                onnx.numpy_helper.from_array(
+                    w2_dequant[:, keep].astype(np.float32), name="W2"
+                ),
+            ],
+        ),
+        opset_imports=[onnx.helper.make_opsetid("", 21)],
+        ir_version=10,
+    )
+    (y_oracle,) = onnx.reference.ReferenceEvaluator(ref_model).run(None, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_cpp_qdq_blockwise_declines_non_exact_multiple_block_dim():
+    # A reduction-axis dim that isn't an exact multiple of block_size (a
+    # padded/partial final block) is out of scope -- declined by the
+    # matcher itself, not just by the block-alignment check.
+    K, H, Out, block_size = 6, 8, 4, 4  # K=6 not a multiple of block_size=4
+    rng = np.random.default_rng(114)
+    Wq = rng.integers(-8, 8, size=(K, H)).astype(np.int8)
+    Wscale = np.abs(rng.standard_normal((2, H))).astype(np.float32) * 0.02 + 0.001
+    # 2 blocks is wrong for K=6/block_size=4 (ceil is 2, but 6 % 4 != 0) --
+    # deliberately mismatched/declined regardless of the scale shape chosen.
+    W2 = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          Wdq = DequantizeLinear<axis=0, block_size={block_size}>(Wq, Wscale)
+          h = MatMul(X, Wdq)
+          Y = MatMul(h, W2)
+        }}
+        """,
+        initializer=[_int4(Wq, "Wq"), _f32(Wscale, "Wscale"), _f32(W2, "W2")],
+    )
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Wq"].dims) == [K, H]  # left completely untouched
+
+
+# --- QDQ: gated (SwiGLU/GeGLU) pair ------------------------------------------
+
+
+def _qdq_gated_mlp_model(K=8, H=16, Out=4, gate_activation="Sigmoid", seed=0):
+    rng = np.random.default_rng(seed)
+    Wgq = rng.integers(-100, 100, size=(K, H)).astype(np.int8)
+    Wgscale = np.abs(rng.standard_normal(H)).astype(np.float32) * 0.02 + 0.001
+    Wuq = rng.integers(-100, 100, size=(K, H)).astype(np.int8)
+    Wuscale = np.abs(rng.standard_normal(H)).astype(np.float32) * 0.02 + 0.001
+    Wd = rng.standard_normal((H, Out)).astype(np.float32)
+    initializer = [
+        _i8(Wgq, "Wgq"),
+        _f32(Wgscale, "Wgscale"),
+        _i8(Wuq, "Wuq"),
+        _f32(Wuscale, "Wuscale"),
+        _f32(Wd, "Wd"),
+    ]
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          Wgdq = DequantizeLinear<axis=1>(Wgq, Wgscale)
+          gate = MatMul(X, Wgdq)
+          gate_act = {gate_activation}(gate)
+          Wudq = DequantizeLinear<axis=1>(Wuq, Wuscale)
+          up = MatMul(X, Wudq)
+          h = Mul(gate_act, up)
+          Y = MatMul(h, Wd)
+        }}
+        """,
+        initializer=initializer,
+    )
+    return model, Wgq, Wgscale, Wuq, Wuscale, Wd
+
+
+def test_cpp_qdq_structured_pruning_gated_ffn_matches_oracle():
+    K, H, Out = 8, 16, 4
+    model, Wgq, Wgscale, Wuq, Wuscale, Wd = _qdq_gated_mlp_model(K, H, Out, seed=21)
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Wgq"].dims) == [K, H // 2]
+    assert list(inits["Wgscale"].dims) == [H // 2]
+    assert list(inits["Wuq"].dims) == [K, H // 2]
+    assert list(inits["Wuscale"].dims) == [H // 2]
+    assert list(inits["Wd"].dims) == [H // 2, Out]
+
+    wg_dequant = _qdq_dequant(Wgq, Wgscale, None, axis=1)
+    wu_dequant = _qdq_dequant(Wuq, Wuscale, None, axis=1)
+    keep = _combined_keep_indices(wg_dequant, wu_dequant, H // 2)
+
+    # Exact co-slice: both producers' own int8 codes AND scales sliced by
+    # the identical `keep` set, never independently re-derived.
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Wgq"]), Wgq[:, keep]
+    )
+    np.testing.assert_allclose(
+        onnx.numpy_helper.to_array(inits["Wgscale"]), Wgscale[keep]
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Wuq"]), Wuq[:, keep]
+    )
+    np.testing.assert_allclose(
+        onnx.numpy_helper.to_array(inits["Wuscale"]), Wuscale[keep]
+    )
+
+    rng = np.random.default_rng(22)
+    x = rng.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run_unfused(pruned, {"X": x})
+
+    gate = 1.0 / (1.0 + np.exp(-(x @ wg_dequant[:, keep])))
+    up = x @ wu_dequant[:, keep]
+    y_oracle = (gate * up) @ Wd[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_cpp_qdq_structured_pruning_gated_ffn_prunes_both_branches_to_same_channels():
+    K, H, Out = 8, 20, 4
+    model, Wgq, Wgscale, Wuq, Wuscale, _Wd = _qdq_gated_mlp_model(K, H, Out, seed=23)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.3)
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+
+    wg_dequant = _qdq_dequant(Wgq, Wgscale, None, axis=1)
+    wu_dequant = _qdq_dequant(Wuq, Wuscale, None, axis=1)
+    keep = _combined_keep_indices(wg_dequant, wu_dequant, H - round(H * 0.3))
+
+    np.testing.assert_array_equal(inits["Wgq"], Wgq[:, keep])
+    np.testing.assert_array_equal(inits["Wuq"], Wuq[:, keep])
+
+
+def test_cpp_qdq_structured_pruning_gelu_gated_ffn_matches_oracle():
+    # GeGLU: the gate activation is Gelu (tanh approximation) rather than
+    # Sigmoid -- exercises FindQdqGatedChains's own reuse of the plain-float
+    # gated matcher's unary-activation set.
+    K, H, Out = 8, 16, 4
+    rng = np.random.default_rng(24)
+    Wgq = rng.integers(-100, 100, size=(K, H)).astype(np.int8)
+    Wgscale = np.abs(rng.standard_normal(H)).astype(np.float32) * 0.02 + 0.001
+    Wuq = rng.integers(-100, 100, size=(K, H)).astype(np.int8)
+    Wuscale = np.abs(rng.standard_normal(H)).astype(np.float32) * 0.02 + 0.001
+    Wd = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          Wgdq = DequantizeLinear<axis=1>(Wgq, Wgscale)
+          gate = MatMul(X, Wgdq)
+          gate_act = Gelu<approximate = "tanh">(gate)
+          Wudq = DequantizeLinear<axis=1>(Wuq, Wuscale)
+          up = MatMul(X, Wudq)
+          h = Mul(gate_act, up)
+          Y = MatMul(h, Wd)
+        }}
+        """,
+        initializer=[
+            _i8(Wgq, "Wgq"),
+            _f32(Wgscale, "Wgscale"),
+            _i8(Wuq, "Wuq"),
+            _f32(Wuscale, "Wuscale"),
+            _f32(Wd, "Wd"),
+        ],
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    wg_dequant = _qdq_dequant(Wgq, Wgscale, None, axis=1)
+    wu_dequant = _qdq_dequant(Wuq, Wuscale, None, axis=1)
+    keep = _combined_keep_indices(wg_dequant, wu_dequant, H // 2)
+
+    rng2 = np.random.default_rng(25)
+    x = rng2.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run_unfused(pruned, {"X": x})
+
+    def gelu_tanh(v):
+        return 0.5 * v * (1.0 + np.tanh(np.sqrt(2.0 / np.pi) * (v + 0.044715 * v**3)))
+
+    gate = gelu_tanh(x @ wg_dequant[:, keep])
+    up = x @ wu_dequant[:, keep]
+    y_oracle = (gate * up) @ Wd[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-3, atol=1e-3)

--- a/tests/test_structured_pruning_cpp.py
+++ b/tests/test_structured_pruning_cpp.py
@@ -5211,3 +5211,632 @@ def test_cpp_structured_pruning_matmul_silu_decomposed_matches_python_reference_
     (y_py,) = _run(pruned_py, {"X": x})
     (y_cpp,) = _run(pruned_cpp, {"X": x})
     np.testing.assert_allclose(y_py, y_cpp, rtol=1e-5, atol=1e-5)
+
+
+# --- MatMulNBits (com.microsoft, block-quantized weight) structured -------
+# --- pruning ------------------------------------------------------------
+#
+# Tests for the plain and gated MatMulNBits chain families
+# (onnxsim/structured_pruning_entry.cpp's own "MatMulNBits" section),
+# mirroring tests/test_pruning.py's own MatMulNBits coverage (see that
+# file's own `_nbits_*` helpers, independently re-implemented here rather
+# than imported -- this file's own established "no cross-import between
+# test files" precedent). Models are built via onnx.parser (per CLAUDE.md's
+# convention); the packed uint8 `B`/`scales`/`zero_points` initializers are
+# attached programmatically via onnx.numpy_helper.from_array afterward
+# (CLAUDE.md's documented exception: these must be byte-exact, not spelled
+# out as text literals -- the parser encodes tensor literals as
+# `float_data`/`int32_data`, not `raw_data`).
+
+
+def _nbits_model(body, initializer=(), opset=21):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": {opset}, "com.microsoft": 1]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _nbits_quantize_block(w, block_size, bits=4):
+    """Independent reference block quantizer for a ``[N, K]`` float weight
+    matrix -- standard asymmetric affine quantization per ``(n, k_block)``,
+    zero-inclusive range. Returns ``(qcodes uint8 [N, K], scales float32
+    [N, k_blocks], zero_points uint8 [N, k_blocks] UNPACKED, k_blocks)``.
+    """
+    n, k = w.shape
+    assert k % block_size == 0
+    k_blocks = k // block_size
+    qmax = (1 << bits) - 1
+    scales = np.zeros((n, k_blocks), dtype=np.float32)
+    zero_points = np.zeros((n, k_blocks), dtype=np.uint8)
+    qcodes = np.zeros((n, k), dtype=np.uint8)
+    for row in range(n):
+        for kb in range(k_blocks):
+            k0, k1 = kb * block_size, (kb + 1) * block_size
+            block = w[row, k0:k1]
+            vmin = min(float(block.min()), 0.0)
+            vmax = max(float(block.max()), 0.0)
+            scale = (vmax - vmin) / qmax if vmax > vmin else 1.0
+            zp = int(np.clip(round(-vmin / scale), 0, qmax))
+            scales[row, kb] = scale
+            zero_points[row, kb] = zp
+            qcodes[row, k0:k1] = (
+                np.round(block / scale + zp).clip(0, qmax).astype(np.uint8)
+            )
+    return qcodes, scales, zero_points, k_blocks
+
+
+def _nbits_pack_nibbles(vals):
+    """Independent reference nibble packer: last axis (uint8 in [0, 15]),
+    2-per-byte, LOW nibble first -- the schema's own documented layout.
+    """
+    count = vals.shape[-1]
+    nbytes = (count + 1) // 2
+    out = np.zeros(vals.shape[:-1] + (nbytes,), dtype=np.uint8)
+    for j in range(nbytes):
+        lo = vals[..., 2 * j]
+        hi = vals[..., 2 * j + 1] if 2 * j + 1 < count else np.zeros_like(lo)
+        out[..., j] = (lo & 0xF) | ((hi & 0xF) << 4)
+    return out
+
+
+def _nbits_pack_codes(vals, bits):
+    """``bits=8`` is a plain dtype cast (one full byte per code, no packing
+    at all); ``bits=4`` delegates to :func:`_nbits_pack_nibbles`.
+    """
+    if bits == 8:
+        return vals.astype(np.uint8)
+    assert bits == 4, bits
+    return _nbits_pack_nibbles(vals)
+
+
+def _nbits_pack_b(qcodes, n, k_blocks, block_size, bits=4):
+    blob_size = block_size * bits // 8
+    b = np.zeros((n, k_blocks, blob_size), dtype=np.uint8)
+    for kb in range(k_blocks):
+        k0 = kb * block_size
+        b[:, kb, :] = _nbits_pack_codes(qcodes[:, k0 : k0 + block_size], bits)
+    return b
+
+
+def _nbits_dequant(qcodes, scales, zero_points, block_size, bits=4):
+    """Independent reference dequantizer -- ``zero_points=None`` uses the
+    schema's own documented default, ``2 ** (bits - 1)``.
+    """
+    n, k = qcodes.shape
+    k_blocks = k // block_size
+    out = np.zeros((n, k), dtype=np.float64)
+    default_zp = float(1 << (bits - 1))
+    for row in range(n):
+        for kb in range(k_blocks):
+            k0, k1 = kb * block_size, (kb + 1) * block_size
+            zp = float(zero_points[row, kb]) if zero_points is not None else default_zp
+            out[row, k0:k1] = (qcodes[row, k0:k1].astype(np.float64) - zp) * scales[
+                row, kb
+            ]
+    return out
+
+
+def _nbits_weight_initializers(w, block_size, prefix, bits=4, zp_mode="packed"):
+    """Quantizes ``w`` (``[N, K]``) and returns ``(initializer_list,
+    info_dict)`` -- `info_dict` carries the independently-computed
+    quantization artifacts (`qcodes`, `scales`, `zp` UNPACKED, `k_blocks`)
+    needed to hand-build an oracle, plus the actual initializer names used
+    (`b_name`/`scales_name`/`zp_name` -- the last ``None`` for
+    ``zp_mode="absent"``). ``zp_mode``: ``"packed"`` (nibble/byte-packed
+    uint8, the schema's own PRIMARY documented `zero_points` encoding),
+    ``"unpacked"`` (float32, same dtype as `scales`, the schema's OTHER
+    documented encoding), or ``"absent"`` (no `zero_points` input at all --
+    schema default ``2 ** (bits - 1)`` applies).
+    """
+    qcodes, scales, zp, k_blocks = _nbits_quantize_block(w, block_size, bits)
+    b = _nbits_pack_b(qcodes, w.shape[0], k_blocks, block_size, bits)
+    inits = [
+        onnx.numpy_helper.from_array(b, name=f"{prefix}_B"),
+        onnx.numpy_helper.from_array(scales, name=f"{prefix}_scales"),
+    ]
+    zp_name = None
+    if zp_mode == "packed":
+        inits.append(
+            onnx.numpy_helper.from_array(
+                _nbits_pack_codes(zp, bits), name=f"{prefix}_zp"
+            )
+        )
+        zp_name = f"{prefix}_zp"
+    elif zp_mode == "unpacked":
+        inits.append(
+            onnx.numpy_helper.from_array(zp.astype(np.float32), name=f"{prefix}_zp")
+        )
+        zp_name = f"{prefix}_zp"
+    else:
+        assert zp_mode == "absent", zp_mode
+    return inits, dict(
+        qcodes=qcodes,
+        scales=scales,
+        zp=zp,
+        k_blocks=k_blocks,
+        b_name=f"{prefix}_B",
+        scales_name=f"{prefix}_scales",
+        zp_name=zp_name,
+    )
+
+
+def test_cpp_structured_pruning_matmul_nbits_plain_chain_matches_oracle():
+    # bits=4, zero_points PACKED (nibble), both nodes biased. N1=32,
+    # block_size=16 -> the consumer's own K2=N1=32 axis is exactly 2 blocks.
+    # W1's rows are engineered so the pass's own L2-norm importance ranking
+    # keeps EXACTLY rows 0-15 (block 0) -- a real, non-trivial keep-set that
+    # also happens to land on a whole-block boundary.
+    N1, K1, N2, block_size = 32, 64, 8, 16
+    rng = np.random.default_rng(9001)
+    w1 = rng.standard_normal((N1, K1)).astype(np.float32) * 0.2
+    w1[:16] *= 6.0  # rows 0-15 large (kept), 16-31 small (dropped)
+    w2 = rng.standard_normal((N2, N1)).astype(np.float32) * 0.2
+    bias1 = (rng.standard_normal(N1) * 0.05).astype(np.float32)
+    bias2 = (rng.standard_normal(N2) * 0.05).astype(np.float32)
+
+    inits1, info1 = _nbits_weight_initializers(w1, block_size, "w1")
+    inits2, info2 = _nbits_weight_initializers(w2, block_size, "w2")
+
+    model = _nbits_model(
+        f"""
+        g (float[batch,{K1}] A) => (float[batch,{N2}] Y)
+        {{
+          h1 = com.microsoft.MatMulNBits<K={K1},N={N1},bits=4,block_size={block_size}>(A, {info1["b_name"]}, {info1["scales_name"]}, {info1["zp_name"]}, , bias1)
+          h1a = Relu(h1)
+          Y = com.microsoft.MatMulNBits<K={N1},N={N2},bits=4,block_size={block_size}>(h1a, {info2["b_name"]}, {info2["scales_name"]}, {info2["zp_name"]}, , bias2)
+        }}
+        """,
+        initializer=[*inits1, *inits2, _f32(bias1, "bias1"), _f32(bias2, "bias2")],
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep = np.arange(16)
+    keep_blocks = np.array([0])
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits[info1["b_name"]].dims) == [
+        16,
+        info1["k_blocks"],
+        block_size * 4 // 8,
+    ]
+    assert list(inits[info1["scales_name"]].dims) == [16, info1["k_blocks"]]
+    assert list(inits["bias1"].dims) == [16]
+    assert list(inits[info2["b_name"]].dims) == [N2, 1, block_size * 4 // 8]
+    assert list(inits[info2["scales_name"]].dims) == [N2, 1]
+
+    # Exact (byte-level, not merely close) "slice, don't recompute" checks --
+    # the pruned graph's own tensors must equal a HAND-SLICE of the ORIGINAL
+    # quantized codes, never a re-quantization of the sliced float weight.
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits[info1["b_name"]]),
+        _nbits_pack_b(info1["qcodes"][keep], 16, info1["k_blocks"], block_size),
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits[info1["zp_name"]]),
+        _nbits_pack_codes(info1["zp"][keep], 4),
+    )
+    np.testing.assert_allclose(onnx.numpy_helper.to_array(inits["bias1"]), bias1[keep])
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits[info2["b_name"]]),
+        _nbits_pack_b(info2["qcodes"][:, keep], N2, 1, block_size),
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits[info2["zp_name"]]),
+        _nbits_pack_codes(info2["zp"][:, keep_blocks], 4),
+    )
+
+    rng2 = np.random.default_rng(9002)
+    x = rng2.standard_normal((3, K1)).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"A": x})
+
+    w1_dequant = _nbits_dequant(
+        info1["qcodes"], info1["scales"], info1["zp"], block_size
+    )
+    w2_dequant = _nbits_dequant(
+        info2["qcodes"], info2["scales"], info2["zp"], block_size
+    )
+    h1 = np.maximum(x.astype(np.float64) @ w1_dequant[keep].T + bias1[keep], 0.0)
+    y_oracle = h1 @ w2_dequant[:, keep].T + bias2
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-3, atol=1e-3)
+
+
+def test_cpp_structured_pruning_matmul_nbits_bits8_chain_matches_oracle():
+    # bits=8: one full byte per code, no nibble packing at all -- a
+    # different, independently-verified code path than bits=4. First
+    # node's own `zero_points` is ABSENT (schema default 2**(bits-1)
+    # applies); second node's is PACKED (a plain byte-per-code identity
+    # "pack" for bits=8, still routed through the same code path as bits=4).
+    N1, K1, N2, block_size, bits = 32, 32, 4, 16, 8
+    rng = np.random.default_rng(9010)
+    w1 = rng.standard_normal((N1, K1)).astype(np.float32) * 0.2
+    w1[:16] *= 6.0
+    w2 = rng.standard_normal((N2, N1)).astype(np.float32) * 0.2
+    inits1, info1 = _nbits_weight_initializers(
+        w1, block_size, "w1b8", bits=bits, zp_mode="absent"
+    )
+    inits2, info2 = _nbits_weight_initializers(
+        w2, block_size, "w2b8", bits=bits, zp_mode="packed"
+    )
+
+    model = _nbits_model(
+        f"""
+        g (float[batch,{K1}] A) => (float[batch,{N2}] Y)
+        {{
+          h1 = com.microsoft.MatMulNBits<K={K1},N={N1},bits={bits},block_size={block_size}>(A, {info1["b_name"]}, {info1["scales_name"]})
+          h1a = Relu(h1)
+          Y = com.microsoft.MatMulNBits<K={N1},N={N2},bits={bits},block_size={block_size}>(h1a, {info2["b_name"]}, {info2["scales_name"]}, {info2["zp_name"]})
+        }}
+        """,
+        initializer=[*inits1, *inits2],
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep = np.arange(16)
+    keep_blocks = np.array([0])
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits[info1["b_name"]].dims) == [
+        16,
+        info1["k_blocks"],
+        block_size * bits // 8,
+    ]
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits[info1["b_name"]]),
+        _nbits_pack_b(info1["qcodes"][keep], 16, info1["k_blocks"], block_size, bits),
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits[info2["b_name"]]),
+        _nbits_pack_b(info2["qcodes"][:, keep], N2, 1, block_size, bits),
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits[info2["zp_name"]]),
+        _nbits_pack_codes(info2["zp"][:, keep_blocks], bits),
+    )
+
+    rng2 = np.random.default_rng(9011)
+    x = rng2.standard_normal((3, K1)).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"A": x})
+    w1_dequant = _nbits_dequant(
+        info1["qcodes"], info1["scales"], None, block_size, bits
+    )
+    w2_dequant = _nbits_dequant(
+        info2["qcodes"], info2["scales"], info2["zp"], block_size, bits
+    )
+    h1 = np.maximum(x.astype(np.float64) @ w1_dequant[keep].T, 0.0)
+    y_oracle = h1 @ w2_dequant[:, keep].T
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-3, atol=1e-3)
+
+
+def test_cpp_structured_pruning_matmul_nbits_unpacked_float_zero_points_matches_oracle():
+    # zero_points as an UNPACKED float32 tensor (same dtype as scales, shape
+    # [N, k_blocks]) -- the live schema's OTHER documented encoding.
+    N1, K1, N2, block_size = 32, 64, 8, 16
+    rng = np.random.default_rng(9020)
+    w1 = rng.standard_normal((N1, K1)).astype(np.float32) * 0.2
+    w1[:16] *= 6.0
+    w2 = rng.standard_normal((N2, N1)).astype(np.float32) * 0.2
+    inits1, info1 = _nbits_weight_initializers(
+        w1, block_size, "w1u", zp_mode="unpacked"
+    )
+    inits2, info2 = _nbits_weight_initializers(
+        w2, block_size, "w2u", zp_mode="unpacked"
+    )
+
+    model = _nbits_model(
+        f"""
+        g (float[batch,{K1}] A) => (float[batch,{N2}] Y)
+        {{
+          h1 = com.microsoft.MatMulNBits<K={K1},N={N1},bits=4,block_size={block_size}>(A, {info1["b_name"]}, {info1["scales_name"]}, {info1["zp_name"]})
+          h1a = Relu(h1)
+          Y = com.microsoft.MatMulNBits<K={N1},N={N2},bits=4,block_size={block_size}>(h1a, {info2["b_name"]}, {info2["scales_name"]}, {info2["zp_name"]})
+        }}
+        """,
+        initializer=[*inits1, *inits2],
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep = np.arange(16)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert inits[info1["zp_name"]].data_type == onnx.TensorProto.FLOAT
+    np.testing.assert_allclose(
+        onnx.numpy_helper.to_array(inits[info1["zp_name"]]),
+        info1["zp"][keep].astype(np.float32),
+    )
+
+    rng2 = np.random.default_rng(9021)
+    x = rng2.standard_normal((3, K1)).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"A": x})
+    w1_dequant = _nbits_dequant(
+        info1["qcodes"], info1["scales"], info1["zp"], block_size
+    )
+    w2_dequant = _nbits_dequant(
+        info2["qcodes"], info2["scales"], info2["zp"], block_size
+    )
+    h1 = np.maximum(x.astype(np.float64) @ w1_dequant[keep].T, 0.0)
+    y_oracle = h1 @ w2_dequant[:, keep].T
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-3, atol=1e-3)
+
+
+def test_cpp_structured_pruning_matmul_nbits_gated_ffn_matches_oracle():
+    # gate_proj/up_proj (both MatMulNBits, bits=4) combined by Mul, feeding
+    # down_proj (also MatMulNBits) -- H=32 output channels, block_size=16 ->
+    # down_proj's own K2=H=32 axis is exactly 2 blocks. Both W_gate/W_up
+    # engineered so the combined L2-norm importance keeps EXACTLY rows 0-15
+    # (block 0), landing on a whole-block boundary.
+    K, H, Out, block_size = 16, 32, 4, 16
+    rng = np.random.default_rng(9030)
+    w_gate = (rng.standard_normal((H, K)) * 0.2).astype(np.float32)
+    w_gate[:16] *= 6.0
+    w_up = (rng.standard_normal((H, K)) * 0.2).astype(np.float32)
+    w_up[:16] *= 6.0
+    w_down = (rng.standard_normal((Out, H)) * 0.2).astype(np.float32)
+
+    inits_g, info_g = _nbits_weight_initializers(w_gate, block_size, "wg")
+    inits_u, info_u = _nbits_weight_initializers(w_up, block_size, "wu")
+    inits_d, info_d = _nbits_weight_initializers(w_down, block_size, "wd")
+
+    model = _nbits_model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          gate = com.microsoft.MatMulNBits<K={K},N={H},bits=4,block_size={block_size}>(X, {info_g["b_name"]}, {info_g["scales_name"]}, {info_g["zp_name"]})
+          gate_act = Sigmoid(gate)
+          up = com.microsoft.MatMulNBits<K={K},N={H},bits=4,block_size={block_size}>(X, {info_u["b_name"]}, {info_u["scales_name"]}, {info_u["zp_name"]})
+          h = Mul(gate_act, up)
+          Y = com.microsoft.MatMulNBits<K={H},N={Out},bits=4,block_size={block_size}>(h, {info_d["b_name"]}, {info_d["scales_name"]}, {info_d["zp_name"]})
+        }}
+        """,
+        initializer=[*inits_g, *inits_u, *inits_d],
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep = np.arange(16)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits[info_g["b_name"]].dims) == [
+        16,
+        info_g["k_blocks"],
+        block_size * 4 // 8,
+    ]
+    assert list(inits[info_d["b_name"]].dims) == [Out, 1, block_size * 4 // 8]
+
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits[info_g["b_name"]]),
+        _nbits_pack_b(info_g["qcodes"][keep], 16, info_g["k_blocks"], block_size),
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits[info_u["b_name"]]),
+        _nbits_pack_b(info_u["qcodes"][keep], 16, info_u["k_blocks"], block_size),
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits[info_d["b_name"]]),
+        _nbits_pack_b(info_d["qcodes"][:, keep], Out, 1, block_size),
+    )
+
+    wg_dequant = _nbits_dequant(
+        info_g["qcodes"], info_g["scales"], info_g["zp"], block_size
+    )
+    wu_dequant = _nbits_dequant(
+        info_u["qcodes"], info_u["scales"], info_u["zp"], block_size
+    )
+    wd_dequant = _nbits_dequant(
+        info_d["qcodes"], info_d["scales"], info_d["zp"], block_size
+    )
+
+    rng2 = np.random.default_rng(9031)
+    x = rng2.standard_normal((3, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    gate_lin = x.astype(np.float64) @ wg_dequant[keep].T
+    gate = 1.0 / (1.0 + np.exp(-gate_lin))
+    up_lin = x.astype(np.float64) @ wu_dequant[keep].T
+    h = gate * up_lin
+    y_oracle = h @ wd_dequant[:, keep].T
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-3, atol=1e-3)
+
+
+def test_cpp_structured_pruning_matmul_nbits_declines_non_block_aligned():
+    # Interleaved importance (even rows large, odd rows small) makes the
+    # top-keep_count-by-norm set straddle every block boundary -- the pass
+    # must decline this chain entirely (both nodes' B/scales/zero_points
+    # left byte-for-byte unchanged), never force a partial-block
+    # re-quantization or a mismatched producer/consumer keep-set.
+    N1, K1, N2, block_size = 32, 64, 8, 16
+    rng = np.random.default_rng(9040)
+    w1 = rng.standard_normal((N1, K1)).astype(np.float32) * 0.2
+    w1[0::2] *= 8.0  # even rows large ("important"), odd rows small
+    w2 = rng.standard_normal((N2, N1)).astype(np.float32) * 0.2
+    inits1, info1 = _nbits_weight_initializers(w1, block_size, "w1d")
+    inits2, info2 = _nbits_weight_initializers(w2, block_size, "w2d")
+
+    model = _nbits_model(
+        f"""
+        g (float[batch,{K1}] A) => (float[batch,{N2}] Y)
+        {{
+          h1 = com.microsoft.MatMulNBits<K={K1},N={N1},bits=4,block_size={block_size}>(A, {info1["b_name"]}, {info1["scales_name"]}, {info1["zp_name"]})
+          h1a = Relu(h1)
+          Y = com.microsoft.MatMulNBits<K={N1},N={N2},bits=4,block_size={block_size}>(h1a, {info2["b_name"]}, {info2["scales_name"]}, {info2["zp_name"]})
+        }}
+        """,
+        initializer=[*inits1, *inits2],
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    before = {t.name: t.SerializeToString() for t in model.graph.initializer}
+    after = {t.name: t.SerializeToString() for t in pruned.graph.initializer}
+    assert before == after
+
+
+def test_cpp_structured_pruning_matmul_nbits_mixed_producer_plain_consumer_matches_oracle():
+    # MatMulNBits producer -> Relu -> plain-float MatMul consumer: the
+    # "quantized transformer-block layer feeding an unquantized lm_head"
+    # export shape. A plain-float CONSUMER has no block structure at all,
+    # so the producer's own top-keep_count-by-norm keep-set (rows 0-15
+    # here) applies directly -- no block-alignment check needed.
+    N1, K1, Out, block_size = 32, 64, 8, 16
+    rng = np.random.default_rng(9050)
+    w1 = rng.standard_normal((N1, K1)).astype(np.float32) * 0.2
+    w1[:16] *= 6.0
+    bias1 = (rng.standard_normal(N1) * 0.05).astype(np.float32)
+    w2 = rng.standard_normal((N1, Out)).astype(np.float32) * 0.3  # [K, N] storage
+
+    inits1, info1 = _nbits_weight_initializers(w1, block_size, "w1m")
+
+    model = _nbits_model(
+        f"""
+        g (float[batch,{K1}] A) => (float[batch,{Out}] Y)
+        {{
+          h1 = com.microsoft.MatMulNBits<K={K1},N={N1},bits=4,block_size={block_size}>(A, {info1["b_name"]}, {info1["scales_name"]}, {info1["zp_name"]}, , bias1)
+          h1a = Relu(h1)
+          Y = MatMul(h1a, W2)
+        }}
+        """,
+        initializer=[*inits1, _f32(bias1, "bias1"), _f32(w2, "W2")],
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep = np.arange(16)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits[info1["b_name"]].dims) == [
+        16,
+        info1["k_blocks"],
+        block_size * 4 // 8,
+    ]
+    assert list(inits["W2"].dims) == [16, Out]
+    np.testing.assert_array_equal(onnx.numpy_helper.to_array(inits["W2"]), w2[keep])
+
+    rng2 = np.random.default_rng(9051)
+    x = rng2.standard_normal((3, K1)).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"A": x})
+    w1_dequant = _nbits_dequant(
+        info1["qcodes"], info1["scales"], info1["zp"], block_size
+    )
+    h1 = np.maximum(x.astype(np.float64) @ w1_dequant[keep].T + bias1[keep], 0.0)
+    y_oracle = h1 @ w2[keep].astype(np.float64)
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-3, atol=1e-3)
+
+
+def test_cpp_structured_pruning_matmul_nbits_mixed_plain_producer_declines_non_block_aligned():
+    # The mixed-chain analogue of the decline test above: a plain-float
+    # PRODUCER (no block structure of its own) feeding a MatMulNBits
+    # CONSUMER whose own block-alignment requirement still applies -- the
+    # pass must decline the whole chain, never force a partial-block
+    # re-quantization or a mismatched producer/consumer keep-set.
+    N1, K1, N2, block_size = 32, 64, 8, 16
+    rng = np.random.default_rng(9080)
+    w1 = rng.standard_normal((K1, N1)).astype(np.float32) * 0.2
+    w1[:, 0::2] *= 8.0  # even output channels large, odd small
+
+    w2 = rng.standard_normal((N2, N1)).astype(np.float32) * 0.2
+    inits2, info2 = _nbits_weight_initializers(w2, block_size, "w2mp")
+
+    model = _nbits_model(
+        f"""
+        g (float[batch,{K1}] A) => (float[batch,{N2}] Y)
+        {{
+          h1 = MatMul(A, W1)
+          h1a = Relu(h1)
+          Y = com.microsoft.MatMulNBits<K={N1},N={N2},bits=4,block_size={block_size}>(h1a, {info2["b_name"]}, {info2["scales_name"]}, {info2["zp_name"]})
+        }}
+        """,
+        initializer=[*inits2, _f32(w1, "W1")],
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    before_w1 = onnx.numpy_helper.to_array(
+        next(t for t in model.graph.initializer if t.name == "W1")
+    )
+    after_w1 = onnx.numpy_helper.to_array(
+        next(t for t in pruned.graph.initializer if t.name == "W1")
+    )
+    np.testing.assert_array_equal(before_w1, after_w1)
+    before = {t.name: t.SerializeToString() for t in model.graph.initializer}
+    after = {t.name: t.SerializeToString() for t in pruned.graph.initializer}
+    assert before == after
+
+
+def test_cpp_structured_pruning_matmul_nbits_declines_shared_weight():
+    # The same B/scales tensors read by two different MatMulNBits nodes --
+    # slicing them for one chain would silently corrupt the other reader.
+    N1, K1, N2, block_size = 32, 64, 8, 16
+    rng = np.random.default_rng(9070)
+    w1 = rng.standard_normal((N1, K1)).astype(np.float32) * 0.2
+    w1[:16] *= 6.0
+    w2 = rng.standard_normal((N2, N1)).astype(np.float32) * 0.2
+    inits1, info1 = _nbits_weight_initializers(w1, block_size, "w1s")
+    inits2, info2 = _nbits_weight_initializers(w2, block_size, "w2s")
+
+    model = _nbits_model(
+        f"""
+        g (float[batch,{K1}] A) => (float[batch,{N2}] Y, float[batch,{N1}] Y2)
+        {{
+          h1 = com.microsoft.MatMulNBits<K={K1},N={N1},bits=4,block_size={block_size}>(A, {info1["b_name"]}, {info1["scales_name"]}, {info1["zp_name"]})
+          h1a = Relu(h1)
+          Y = com.microsoft.MatMulNBits<K={N1},N={N2},bits=4,block_size={block_size}>(h1a, {info2["b_name"]}, {info2["scales_name"]}, {info2["zp_name"]})
+          Y2 = com.microsoft.MatMulNBits<K={K1},N={N1},bits=4,block_size={block_size}>(A, {info1["b_name"]}, {info1["scales_name"]})
+        }}
+        """,
+        initializer=[*inits1, *inits2],
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    before = {t.name: t.SerializeToString() for t in model.graph.initializer}
+    after = {t.name: t.SerializeToString() for t in pruned.graph.initializer}
+    assert before == after
+
+
+def test_cpp_structured_pruning_matmul_nbits_matches_python_reference_output():
+    N1, K1, N2, block_size = 32, 64, 8, 16
+    rng = np.random.default_rng(9060)
+    w1 = rng.standard_normal((N1, K1)).astype(np.float32) * 0.2
+    w1[:16] *= 6.0
+    w2 = rng.standard_normal((N2, N1)).astype(np.float32) * 0.2
+    bias1 = (rng.standard_normal(N1) * 0.05).astype(np.float32)
+
+    inits1, info1 = _nbits_weight_initializers(w1, block_size, "w1p")
+    inits2, info2 = _nbits_weight_initializers(w2, block_size, "w2p")
+
+    model = _nbits_model(
+        f"""
+        g (float[batch,{K1}] A) => (float[batch,{N2}] Y)
+        {{
+          h1 = com.microsoft.MatMulNBits<K={K1},N={N1},bits=4,block_size={block_size}>(A, {info1["b_name"]}, {info1["scales_name"]}, {info1["zp_name"]}, , bias1)
+          h1a = Relu(h1)
+          Y = com.microsoft.MatMulNBits<K={N1},N={N2},bits=4,block_size={block_size}>(h1a, {info2["b_name"]}, {info2["scales_name"]}, {info2["zp_name"]})
+        }}
+        """,
+        initializer=[*inits1, *inits2, _f32(bias1, "bias1")],
+    )
+    onnx.checker.check_model(model)
+
+    pruned_py = onnxsim.apply_structured_pruning_matmul_nbits(model, sparsity=0.5)
+    pruned_cpp = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_py)
+    onnx.checker.check_model(pruned_cpp)
+
+    rng2 = np.random.default_rng(9061)
+    x = rng2.standard_normal((4, K1)).astype(np.float32)
+    (y_py,) = _run(pruned_py, {"A": x})
+    (y_cpp,) = _run(pruned_cpp, {"A": x})
+    np.testing.assert_allclose(y_py, y_cpp, rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
## Summary

Fourth round continuing the Python → C++ parity effort for `onnxsim/structured_pruning_entry.cpp` (see #1027, #1031, #1034). This round is a bigger step than the previous "single hop" rounds: it ports two entire quantized-weight structured-pruning subsystems from `onnxsim/pruning.py`.

- **QDQ-quantized structured pruning** — Conv/ConvTranspose/MatMul chains (plain + gated) where the weight is fed through a `QuantizeLinear`/`DequantizeLinear` pair, per-tensor, per-channel, or blockwise INT8/INT4/UINT8/UINT4. Slices the quantized codes (and, where relevant, scale/zero-point) directly — never dequantizes, prunes, and requantizes, which would silently drift the model's own calibrated quantization.
- **MatMulNBits (int4) structured pruning** — `com.microsoft::MatMulNBits` plain + gated chains, packed-nibble weights with block-wise scale/optional zero-point, same "slice the packed codes directly" invariant. Scoped to exclude the separate `bnb4` format and the larger fused MLP/MoE `MatMulNBitsMlp`/`MatMulNBitsQkv` variants, left for dedicated future work.

Both were ported independently in parallel (different quantization representations, disjoint code regions) and then merged — the merge itself needed real conflict resolution since both inserted their new section and their own driver call at the same point in the file; both feature sets are fully preserved (verified by test-name spot-checks for each, not just an aggregate pass count).

## Testing

- `pip install --no-build-isolation -ve .`
- `python3 -m pytest -v tests/test_structured_pruning_cpp.py tests/test_attention_head_pruning_cpp.py tests/test_pruning_cpp.py` — **179 passed, 0 failed**, including all pre-existing coverage from every prior round (no regressions)
- `clang-format --dry-run --Werror` / `ruff format --check` / `ruff check` / `mypy` all clean

## Scope / follow-up

Still out of scope after this round: `MatMulBnb4`-quantized pruning, the fused `MatMulNBitsMlp`/`MatMulNBitsQkv` MoE variants, and FLOAT16/BFLOAT16 operands on either quantized path (this C++ port has no FP16/BF16 tensor support anywhere yet, a pre-existing limitation, not new to this round). Left for further rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4t6ntCm72RfFf64W9GYB1

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4t6ntCm72RfFf64W9GYB1)_