### PR TITLE
Add real LLM support for Axera Pulsar2: llm_build() wrapper + confirm no onnxsim hook exists

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -190,6 +190,54 @@ latency). **Automated**: `convert_onnxmodelzoo.py --profile` passes this
 through automatically (see below); see Pulsar2's own docs
 (`other_tools/profiling.html`) for the full trace-UI reference.
 
+## LLMs: a separate pipeline onnxsim has no hook into
+
+**Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`
+checkpoint + the real AX650N): Axera compiles LLMs through a **completely
+different** subcommand, `pulsar2 llm_build` (Pulsar2's newer docs call it
+`llm_build2` with a slightly different flag set -- v6.0 only has
+`llm_build`; see `pulsar2_docker.llm_build()`'s docstring for the exact
+confirmed flags). This is *not* a variant of `pulsar2 build` with an LLM
+config -- **`--input_path` is a raw HuggingFace checkpoint directory**
+(`*.safetensors`/`pytorch_model.bin` + `config.json`), not an ONNX model.
+There is no ONNX step anywhere in this pipeline: the public `ax-llm-build`
+project (github.com/AXERA-TECH/ax-llm-build) that Pulsar2's own docs point
+to for this workflow contains no model-tracing/export code at all, only
+per-architecture config JSONs and small pre/post-processing helper scripts
+around the actual (closed-source) `pulsar2 llm_build` call.
+
+**So onnxsim has no direct integration point in Axera's LLM ingestion
+path** -- there is no ONNX graph for `onnxsim.simplify()` or any of
+onnxsim's GPTQ/AWQ/NF4/`auto_quantize_int4`-family quantizers to act on
+before Pulsar2 ever sees the model. `pulsar2 llm_build`'s own
+`--weight_type` (`s8` by default, `s4` available) is Pulsar2's own built-in
+weight quantization -- unrelated to, and not replaceable by,
+`pulsar2_quantizer.py`.
+
+What *is* confirmed and now supported by this harness:
+
+- `pulsar2_docker.llm_build()` wraps the real command. Verified against
+  `Qwen/Qwen3-0.6B`: ~7-8 minutes end to end on a 32-core host with
+  `--parallel 8`, producing one `<name>_p<prefill_len>_l<N>_together.axmodel`
+  per transformer layer (28 for this model) plus one `<name>_post.axmodel`
+  (the LM head) -- confirming the original handoff notes' guess that LLMs
+  compile to "a directory of small, structurally similar single-block
+  graphs," not one big graph.
+- Each per-layer file has **two** `neu mode` nodes, not one: a decode
+  subgraph (batch-1 shapes) and a prefill subgraph (`prefill_len`-batch
+  shapes), sharing one `npu_params` initializer, each with explicit
+  `K_cache`/`V_cache` graph inputs *and* `*_out` outputs -- the KV cache is
+  ordinary graph tensors the host runtime (`ax-llm`/`axllm`) persists
+  between calls, not something hidden inside the compiled blob.
+- `pulsar2_ops.py`'s corruption detectors (`has_out_of_band_npu_data()`/
+  `missing_npu_data()`) already handle multiple NPU nodes per graph
+  correctly with no changes needed. Verified: `onnxsim.simplify()` corrupts
+  a real per-layer LLM `.axmodel` the exact same way as the CNN case (3
+  initializers -> 0). `models.axera_llm_layer_leaf()` reproduces this shape
+  in CI without needing hardware or a real LLM download.
+- A per-layer file and the post model both ran successfully on the real
+  AX650N via `axcl_run_model` (~1.5ms and ~9ms respectively).
+
 ## Real Docker + device conversion driver
 
 `pulsar2_docker.py` and `convert_onnxmodelzoo.py` turn the manual
@@ -242,13 +290,13 @@ the tensor). `pulsar2_docker.run_on_device_with_input()` already does this.
 | `pulsar2_ops.py` | the heuristics and confirmed data: `AX650_SUPPORTED_OPS`/`AX650_MIN_OPSET` (the real, docs-scraped AX650 op list), `CPU_ONLY_OPS` (generic cross-vendor guess), the confirmed `AXERA_NPU_OP_TYPE = "neu mode"` marker, `referenced_const_data_keys()`/`missing_npu_data()`/`has_out_of_band_npu_data()` (the corruption detector), and non-standard-`domain` detection as a fallback for vendor blobs that don't follow Axera's exact convention. |
 | `pulsar2_backend.py` | thin wrapper around `pulsar2_ops.py`: `coverage()`, `new_blocking_op_types()`, `stripped_npu_data()`, `unsafe_for_simplify()`, `ax650_build_risks()`. Shaped like the sibling `*_backend.py` modules for interface symmetry (`PULSAR2_AVAILABLE` is always `True` -- there's no external dependency to be missing). |
 | `inspect_axmodel.py` | standalone CLI for a **real** `.axmodel` file: loads it with `onnx.load()`, then reports non-standard-domain nodes, op types outside the model's declared opset, and suspiciously large raw attributes -- what originally found the `neu mode` node in the real YOLOv8 file. |
-| `models.py` | the shared `scripts/common/synthetic_models.py` suite plus `axera_npu_compiled_leaf`, a synthetic reproduction of the real `neu mode` node shape (no real device needed to exercise the corruption check in CI). |
+| `models.py` | the shared `scripts/common/synthetic_models.py` suite plus `axera_npu_compiled_leaf` (real CNN `neu mode` node shape) and `axera_llm_layer_leaf` (real per-layer LLM shape: two `neu mode` nodes sharing one initializer) -- no real device needed to exercise the corruption check in CI. |
 | `pulsar2_quantizer.py` | `quantize_like_pulsar2()`: a thin wrapper over `onnxsim.quantize_static(method="minmax")`, which already matches Pulsar2's real numeric convention (U8 asymmetric activations, S8 per-channel weights, MinMax calibration). `PULSAR2_QUANTIZER_AVAILABLE` reflects `onnxruntime`'s availability (onnxsim's quantizer needs it internally, imported lazily). |
 | `pulsar2_simulator.py` | `partition()`/`coverage()` (real `AX650_SUPPORTED_OPS` membership, no dependency beyond `onnx`) and `simulate()` (fp32-vs-INT8 estimate via `pulsar2_quantizer.py` + onnxruntime's CPU EP). Validated against real hardware -- see above. |
 | `worker.py` | runs the check for one model in an isolated subprocess, printing one `__RESULT__<json>` line. |
 | `run_pulsar2_compat.py` | drives the suite, writes a CSV, and exits non-zero on any regression. No `--require-*` flag or `skipped` status -- unlike the EP harnesses, this needs no vendor package or device, so it always runs. Entry point for `axera-integration.yml`'s `pulsar2-compat` job (stock runner, no Docker/device). |
 | `screen_onnxmodelzoo.py` | fast, static, Docker/device-free screening of `onnxmodelzoo` models via `pulsar2_simulator`/`pulsar2_backend.ax650_build_risks()` -- run this first. |
-| `pulsar2_docker.py` | real `pulsar2 build` (Docker) + `axcl_run_model` (device) wrapper: `build()` (with `profile=` for `trace.json`), `run_on_device()`, `run_on_device_with_input()`, `force_rmtree()`. Manual/local-only -- needs a loaded Docker image. |
+| `pulsar2_docker.py` | real `pulsar2 build` (Docker) + `axcl_run_model` (device) wrapper: `build()` (with `profile=` for `trace.json`), `llm_build()` (the separate, ONNX-free `pulsar2 llm_build` LLM path -- see above), `run_on_device()`, `run_on_device_with_input()`, `force_rmtree()`. Manual/local-only -- needs a loaded Docker image. |
 | `convert_onnxmodelzoo.py` | batch driver over `pulsar2_docker.py`: fetch -> onnxsim -> real `pulsar2 build` (orig + simplified, `--profile` optional) -> optional on-device bit-exact diff -> CSV. Entry point for `axera-integration.yml`'s `pulsar2-docker-convert` job -- like `amd-integration.yml`'s MIGraphX check, that job is `workflow_dispatch`-only and targets a `[self-hosted, axcl]` runner this repository doesn't provision, so it's dormant until one exists. |
 
 ## Running locally

--- a/scripts/axera/models.py
+++ b/scripts/axera/models.py
@@ -1,16 +1,24 @@
 #!/usr/bin/env python3
-"""Axera-side model suite: the shared suite plus one Axera-specific fixture.
+"""Axera-side model suite: the shared suite plus two Axera-specific fixtures.
 
-Re-exports `scripts/common/synthetic_models.py` (see that module) and adds
-`axera_npu_compiled_leaf`, a minimal synthetic reproduction of the *real*
-compiled-NPU-subgraph node shape confirmed against an actual AX650N and a
-real `AXERA-TECH/YOLOv8` `.axmodel` (see `pulsar2_ops.py`'s docstring): a
-single `op_type="neu mode"` node whose only declared input is the graph
-input, with an initializer it depends on purely via a JSON-encoded attribute
-reference rather than a graph edge. This exercises
-`pulsar2_ops.has_out_of_band_npu_data` / `missing_npu_data` and the
-`pulsar2_unsafe_for_simplify` worker path in CI, without needing the real
-device.
+Re-exports `scripts/common/synthetic_models.py` (see that module) and adds:
+
+- `axera_npu_compiled_leaf`: a minimal synthetic reproduction of the *real*
+  compiled-NPU-subgraph node shape confirmed against an actual AX650N and a
+  real `AXERA-TECH/YOLOv8` `.axmodel` (see `pulsar2_ops.py`'s docstring): a
+  single `op_type="neu mode"` node whose only declared input is the graph
+  input, with an initializer it depends on purely via a JSON-encoded
+  attribute reference rather than a graph edge.
+- `axera_llm_layer_leaf`: the real per-transformer-layer `.axmodel` shape
+  confirmed against a real `Qwen/Qwen3-0.6B` build (see
+  `pulsar2_docker.llm_build()`'s docstring): **two** `neu mode` nodes in one
+  graph (decode + prefill), sharing one `npu_params` initializer, each with
+  its own `K_cache`/`V_cache` graph inputs and `*_out` outputs.
+
+Both exercise `pulsar2_ops.has_out_of_band_npu_data`/`missing_npu_data` and
+the `pulsar2_unsafe_for_simplify` worker path in CI, without needing the
+real device -- `axera_llm_layer_leaf` specifically checks the multi-NPU-node
+case the CNN-only leaf never exercises.
 """
 
 from __future__ import annotations
@@ -97,18 +105,108 @@ def axera_npu_compiled_leaf() -> onnx.ModelProto:
     )
 
 
+_AXERA_LLM_LAYER_NAME = "axera_llm_layer_leaf"
+
+
+def _neu_node(suffix: str, batch_shape: list) -> tuple:
+    """One `neu mode` node + its matching value_info, in the confirmed real
+    per-layer shape (decode `suffix=""`, prefill `suffix="_1"`)."""
+    neu_key = f"subgraph_npu{suffix}_b1_neu"
+    graph_info = json.dumps(
+        {
+            "name": f"subgraph_npu{suffix}",
+            "dotneus": [
+                {
+                    "neu_key": neu_key,
+                    "batch": 1,
+                    "extra_inputs": [
+                        {"name": "params", "const_data_key": "npu_params"}
+                    ],
+                }
+            ],
+        }
+    )
+    out_name = f"output{suffix}"
+    outputs_info = json.dumps({out_name: ["BF16", batch_shape]})
+    node = helper.make_node(
+        "neu mode",
+        [f"K_cache{suffix}", f"V_cache{suffix}", f"input{suffix}"],
+        [f"K_cache_out{suffix}", f"V_cache_out{suffix}", out_name],
+        name=f"subgraph_npu{suffix}",
+        neu_name=f"subgraph_npu{suffix}",
+        npu_graph_info=graph_info,
+        outputs_info=outputs_info,
+        version=1,
+    )
+    return node, neu_key
+
+
+def axera_llm_layer_leaf() -> onnx.ModelProto:
+    """Reproduces the real per-layer LLM `.axmodel` shape (see this module's
+    docstring): two `neu mode` nodes (decode + prefill) sharing one
+    `npu_params` initializer, each with its own `K_cache`/`V_cache` I/O.
+    """
+    decode_node, decode_key = _neu_node("", [1, 1, 8])
+    prefill_node, prefill_key = _neu_node("_1", [1, 4, 8])
+
+    # Real files have one initializer per referenced key: the shared weight
+    # blob (npu_params) plus each subgraph's own per-neu blob (*_b1_neu).
+    params = numpy_helper.from_array(np.zeros(64, dtype=np.uint8), "npu_params")
+    decode_neu = numpy_helper.from_array(np.zeros(8, dtype=np.uint8), decode_key)
+    prefill_neu = numpy_helper.from_array(np.zeros(8, dtype=np.uint8), prefill_key)
+
+    def cache_io(suffix: str, shape: list) -> tuple:
+        return (
+            helper.make_tensor_value_info(f"K_cache{suffix}", TensorProto.FLOAT, shape),
+            helper.make_tensor_value_info(f"V_cache{suffix}", TensorProto.FLOAT, shape),
+            helper.make_tensor_value_info(f"input{suffix}", TensorProto.FLOAT, shape),
+        )
+
+    decode_io = cache_io("", [1, 1, 8])
+    prefill_io = cache_io("_1", [1, 4, 8])
+
+    graph = helper.make_graph(
+        [decode_node, prefill_node],
+        _AXERA_LLM_LAYER_NAME,
+        [*decode_io, *prefill_io],
+        [
+            helper.make_tensor_value_info("K_cache_out", TensorProto.FLOAT, [1, 1, 8]),
+            helper.make_tensor_value_info("V_cache_out", TensorProto.FLOAT, [1, 1, 8]),
+            helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, 1, 8]),
+            helper.make_tensor_value_info(
+                "K_cache_out_1", TensorProto.FLOAT, [1, 4, 8]
+            ),
+            helper.make_tensor_value_info(
+                "V_cache_out_1", TensorProto.FLOAT, [1, 4, 8]
+            ),
+            helper.make_tensor_value_info("output_1", TensorProto.FLOAT, [1, 4, 8]),
+        ],
+        [params, decode_neu, prefill_neu],
+    )
+    assert decode_key != prefill_key  # both keys must be distinct, like the real file
+    return helper.make_model(
+        graph, opset_imports=[helper.make_opsetid("", 18)], ir_version=10
+    )
+
+
 def names() -> list:
-    return [*_shared_names(), _AXERA_LEAF_NAME]
+    return [*_shared_names(), _AXERA_LEAF_NAME, _AXERA_LLM_LAYER_NAME]
 
 
 def build(name: str) -> onnx.ModelProto:
     if name == _AXERA_LEAF_NAME:
         return axera_npu_compiled_leaf()
+    if name == _AXERA_LLM_LAYER_NAME:
+        return axera_llm_layer_leaf()
     return _shared_build(name)
 
 
 def all_models() -> dict:
-    return {**_shared_all_models(), _AXERA_LEAF_NAME: axera_npu_compiled_leaf()}
+    return {
+        **_shared_all_models(),
+        _AXERA_LEAF_NAME: axera_npu_compiled_leaf(),
+        _AXERA_LLM_LAYER_NAME: axera_llm_layer_leaf(),
+    }
 
 
 if __name__ == "__main__":

--- a/scripts/axera/pulsar2_docker.py
+++ b/scripts/axera/pulsar2_docker.py
@@ -27,6 +27,42 @@ build then writes a standard Chrome Trace Event Format `trace.json` under
 optimized quantized graph to `<output_dir>/frontend/
 optimized_quant_axmodel.onnx` (open in Netron) so trace task labels can be
 matched back to op names. See `README.md`'s "Real NPU profiling" section.
+
+**`llm_build()`**: wraps `pulsar2 llm_build`, confirmed real end-to-end
+against `Qwen/Qwen3-0.6B` (a real HF checkpoint) on this same toolchain +
+AX650N. Unlike `build()`, this does **not** take an ONNX model at all --
+`--input_path` is a raw HuggingFace checkpoint directory (`*.safetensors` or
+`pytorch_model.bin` + `config.json`), and there is no ONNX step anywhere in
+the pipeline: the public `ax-llm-build` project
+(https://github.com/AXERA-TECH/ax-llm-build) that Pulsar2's own docs point
+to for this workflow contains no model-tracing/export code at all, only
+per-architecture config JSONs and small pre/post-processing shell/Python
+helpers around the actual (closed-source) `pulsar2 llm_build` call. So
+**onnxsim has no direct integration point in this ingestion path** -- there
+is no ONNX graph to simplify or quantize before Pulsar2 ever sees it.
+
+Also note the CLI surface differs from Pulsar2's own V7.0 docs, which
+document a `llm_build2` subcommand with `--max_context`/
+`--prefill_step_size`/`--decode_step_size`: the `pulsar2:6.0-lite` image
+this was verified against only has `llm_build` (no "2"), with
+`--kv_cache_len` instead of those three flags -- `llm_build()`'s defaults
+match this confirmed real v6.0 surface, not the newer docs.
+
+Confirmed real output shape (`Qwen3-0.6B`, `--chip AX650 --prefill_len 512`):
+one `<name>_p<prefill_len>_l<N>_together.axmodel` per transformer layer (28
+for this model) plus one `<name>_post.axmodel` (the LM head). Each per-layer
+file is **two** `neu mode` nodes in one graph, not one -- `subgraph_npu_0`
+(decode, batch-1 shapes) and `subgraph_npu_1` (prefill, `prefill_len`-batch
+shapes), both sharing the same `npu_params` initializer and each with
+explicit `K_cache`/`V_cache` graph inputs *and* `K_cache_out`/`V_cache_out`
+outputs -- the KV cache is passed as ordinary graph tensors the host runtime
+(`ax-llm`/`axllm`) persists between calls, not hidden inside the compiled
+blob. `pulsar2_ops.has_out_of_band_npu_data()`/`missing_npu_data()` (see
+that module's docstring) already generalize correctly to this two-node
+shape with no changes needed -- verified: `onnxsim.simplify()` corrupts a
+real per-layer `.axmodel` the same way it does the CNN case (3 initializers
+-> 0). Both a decode-shaped layer and the post model ran successfully on the
+real AX650N via `axcl_run_model` (~1.5ms and ~9ms respectively).
 """
 
 from __future__ import annotations
@@ -39,7 +75,7 @@ import shutil
 import subprocess
 import tarfile
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Sequence
 
 DEFAULT_IMAGE = "pulsar2:6.0-lite"
@@ -289,6 +325,105 @@ def build(
         fused_subgraphs=int(fuse_match.group(1)) if fuse_match else None,
         trace_path=trace_path,
         frontend_graph_path=frontend_graph_path,
+        stdout_tail=log[-2000:],
+    )
+
+
+@dataclass
+class LLMBuildResult:
+    success: bool
+    output_dir: Optional[str] = None
+    layer_axmodels: List[str] = field(default_factory=list)
+    embed_files: List[str] = field(default_factory=list)
+    post_axmodel: Optional[str] = None
+    error: Optional[str] = None
+    stdout_tail: str = ""
+
+
+def llm_build(
+    work_dir: str,
+    hf_checkpoint_rel_path: str,
+    output_rel_dir: str,
+    *,
+    hidden_state_type: str = "bf16",
+    weight_type: str = "s8",
+    prefill_len: int = 512,
+    kv_cache_len: int = 1023,
+    chip: str = "AX650",
+    parallel: int = 8,
+    image: str = DEFAULT_IMAGE,
+    timeout: int = 3600,
+) -> LLMBuildResult:
+    """Run a real `pulsar2 llm_build` in Docker on a HuggingFace checkpoint.
+
+    See this module's docstring for the confirmed real facts this wraps:
+    `hf_checkpoint_rel_path` (relative to `work_dir`, mounted at `/data`) is
+    a raw HF checkpoint directory, not an ONNX model or a `pulsar2 build`
+    config -- there is no config.json equivalent here, Pulsar2 reads the
+    checkpoint's own `config.json` directly. `weight_type="s8"` matches
+    Pulsar2's own default (its built-in quantization, not
+    `pulsar2_quantizer.py` -- onnxsim has no role in this path).
+
+    Confirmed real timing: ~7-8 minutes for a 0.6B model with `parallel=8`
+    on a 32-core host.
+    """
+    if not docker_image_available(image):
+        return LLMBuildResult(success=False, error=f"docker image not loaded: {image}")
+
+    output_abs_dir = os.path.join(work_dir, output_rel_dir)
+    if os.path.exists(output_abs_dir):
+        force_rmtree(output_abs_dir, work_dir, image)
+
+    cmd = [
+        "docker",
+        "run",
+        "--rm",
+        "-v",
+        f"{work_dir}:/data",
+        image,
+        "pulsar2",
+        "llm_build",
+        "--input_path",
+        hf_checkpoint_rel_path,
+        "--output_path",
+        output_rel_dir,
+        "--hidden_state_type",
+        hidden_state_type,
+        "--weight_type",
+        weight_type,
+        "--prefill_len",
+        str(prefill_len),
+        "--kv_cache_len",
+        str(kv_cache_len),
+        "--chip",
+        chip,
+        "--parallel",
+        str(parallel),
+    ]
+
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return LLMBuildResult(
+            success=False, error=f"pulsar2 llm_build timed out after {timeout}s"
+        )
+
+    log = proc.stdout + proc.stderr
+    if proc.returncode != 0:
+        return LLMBuildResult(success=False, error=log[-2000:], stdout_tail=log[-2000:])
+
+    layer_axmodels = sorted(
+        glob.glob(os.path.join(output_abs_dir, "*_l*_together.axmodel"))
+    )
+    post_hits = glob.glob(os.path.join(output_abs_dir, "*_post.axmodel"))
+    embed_files = sorted(glob.glob(os.path.join(output_abs_dir, "*embed_tokens*")))
+
+    return LLMBuildResult(
+        success=bool(layer_axmodels) and bool(post_hits),
+        output_dir=output_abs_dir,
+        layer_axmodels=layer_axmodels,
+        embed_files=embed_files,
+        post_axmodel=post_hits[0] if post_hits else None,
         stdout_tail=log[-2000:],
     )
 

--- a/scripts/axera/pulsar2_ops.py
+++ b/scripts/axera/pulsar2_ops.py
@@ -84,6 +84,46 @@ toolchain + a real AX650N, converting two real `onnxmodelzoo` models:
   CPU/NPU partitioning happened. So an op outside `AX650_SUPPORTED_OPS` is
   not just "less NPU-friendly," it can make `pulsar2 build` refuse the model
   outright -- confirmed for `LRN`, not verified for every other absent op.
+
+**Update: LLMs, resolving the handoff notes' §3.** `pulsar2 build` (this
+module's focus so far) is not how Axera compiles LLMs at all -- that's a
+completely separate subcommand, `pulsar2 llm_build` (the real `pulsar2:
+6.0-lite` toolchain's name; Pulsar2's own newer docs describe a
+`llm_build2` with a slightly different flag set, e.g.
+`--max_context`/`--prefill_step_size` instead of `--kv_cache_len` -- v6.0
+only has `llm_build`). Confirmed by actually running it, on a real
+`Qwen/Qwen3-0.6B` checkpoint through the real toolchain, then on the real
+AX650N (see `pulsar2_docker.llm_build()`'s docstring for the full
+command/timing):
+
+- **`--input_path` is a raw HuggingFace checkpoint directory**
+  (`*.safetensors`/`pytorch_model.bin` + `config.json`) -- there is no ONNX
+  step anywhere in this pipeline. The public `ax-llm-build` project Pulsar2's
+  docs point to for this workflow (github.com/AXERA-TECH/ax-llm-build)
+  contains no model-tracing/export code at all, only per-architecture config
+  JSONs and small helper scripts around the actual (closed-source)
+  `pulsar2 llm_build` call. **onnxsim has no direct integration point in
+  this ingestion path** -- there is no ONNX graph for it to simplify or
+  quantize before Pulsar2 ever sees the model. `-w`/`--weight_type` (default
+  `s8`) is Pulsar2's *own* built-in weight quantization, entirely separate
+  from `pulsar2_quantizer.py`.
+- Output is **one compiled `.axmodel` per transformer layer** (28 for this
+  0.6B model) plus one `_post.axmodel` (the LM head) -- confirming the
+  handoff notes' guess that LLMs are "a directory of small, structurally
+  similar single-block graphs," not one big graph.
+- Each per-layer file has **two** `AXERA_NPU_OP_TYPE` nodes, not one: a
+  decode subgraph (batch-1 shapes) and a prefill subgraph
+  (`prefill_len`-batch shapes), both sharing one `npu_params` initializer.
+  Both also carry explicit `K_cache`/`V_cache` graph inputs *and*
+  `K_cache_out`/`V_cache_out` outputs -- the KV cache is ordinary graph
+  tensors the host runtime persists between calls, not something opaque
+  inside the compiled blob. `npu_subgraph_nodes()`/`has_out_of_band_npu_data()`/
+  `missing_npu_data()` below already handle multiple NPU nodes per graph
+  correctly with no changes needed -- verified: `onnxsim.simplify()`
+  corrupts a real per-layer `.axmodel` the same way as the CNN case (3
+  initializers -> 0).
+- Both a per-layer file and the post model ran successfully on the real
+  AX650N via `axcl_run_model` (~1.5ms and ~9ms respectively).
 """
 
 from __future__ import annotations

--- a/tests/test_pulsar2_compat.py
+++ b/tests/test_pulsar2_compat.py
@@ -131,6 +131,34 @@ def test_onnxsim_corrupts_a_compiled_npu_subgraph():
     assert pulsar2.stripped_npu_data(simp) == {"npu_params"}
 
 
+def test_llm_layer_leaf_fixture_multi_node_detection():
+    """The same corruption bug, confirmed on a real per-layer LLM `.axmodel`.
+
+    A real `Qwen/Qwen3-0.6B` build (see `pulsar2_docker.llm_build()`'s and
+    `pulsar2_ops.py`'s docstrings) compiles each transformer layer to a
+    graph with *two* `neu mode` nodes (decode + prefill), not one --
+    `axera_llm_layer_leaf` reproduces that shape. Checks the detector
+    handles multiple NPU nodes sharing one initializer correctly, both
+    before (nothing missing) and after (everything referenced gets
+    stripped) simplification.
+    """
+    from onnxsim import simplify
+
+    model = models.axera_llm_layer_leaf()
+    assert pulsar2.unsafe_for_simplify(model)
+    assert not pulsar2.stripped_npu_data(model)
+    assert (
+        check("axera_llm_layer_leaf", None)["status"] == "pulsar2_unsafe_for_simplify"
+    )
+
+    simp, _ = simplify(model)
+    assert pulsar2.stripped_npu_data(simp) == {
+        "npu_params",
+        "subgraph_npu_b1_neu",
+        "subgraph_npu_1_b1_neu",
+    }
+
+
 def test_ax650_build_risks_matches_real_conversions():
     """Sanity-checks the confirmed AX650 op list against two real conversions.
 


### PR DESCRIPTION
## Summary

Follow-up to #1036. Investigated whether onnxsim's LLM quantization features (GPTQ/AWQ/NF4/`auto_quantize_int4`/etc.) could plug into Axera's LLM compile path the way `pulsar2_quantizer.py` does for the CNN path.

**Confirmed, by actually running it end to end** against a real `Qwen/Qwen3-0.6B` checkpoint on the real `pulsar2:6.0-lite` toolchain + AX650N, **that they cannot**: Axera compiles LLMs through a completely separate subcommand, `pulsar2 llm_build` (Pulsar2's newer docs call it `llm_build2` with a different flag set; the real v6.0 toolchain only has `llm_build`). `--input_path` is a **raw HuggingFace checkpoint directory** (`*.safetensors`/`pytorch_model.bin` + `config.json`) — there is no ONNX step anywhere in this pipeline. Confirmed by reading the actual open-source [`ax-llm-build`](https://github.com/AXERA-TECH/ax-llm-build) project Pulsar2's docs point to: it contains no model-tracing/export code at all, only config JSONs and small helper scripts around the closed-source `pulsar2 llm_build` call itself.

So there is no ONNX graph for onnxsim to simplify or quantize before Pulsar2 ever sees an LLM, and `--weight_type` is Pulsar2's own built-in quantization, unrelated to `pulsar2_quantizer.py`.

## What's added

- **`pulsar2_docker.llm_build()`**: a wrapper around the real `pulsar2 llm_build`, verified end-to-end (real checkpoint download, real Docker build, ~7-8 minutes for 0.6B on a 32-core host) — confirmed to produce the expected 28 per-layer `.axmodel` files + 1 post/LM-head `.axmodel`.
- **Confirmed schema**: each per-layer file has **two** `neu mode` nodes (decode + prefill subgraphs), not one, sharing a single `npu_params` initializer, each with explicit `K_cache`/`V_cache` graph I/O. `pulsar2_ops.py`'s corruption detectors (`has_out_of_band_npu_data`/`missing_npu_data`) already handle this multi-node case correctly with no changes needed — verified: `onnxsim.simplify()` corrupts a real per-layer LLM `.axmodel` the same way as the CNN case.
- **`models.axera_llm_layer_leaf()`**: a synthetic fixture reproducing this exact multi-node shape, so the corruption-bug regression test now covers it in CI without needing a real LLM download or device.
- Documented all of this in `pulsar2_ops.py`'s and `pulsar2_docker.py`'s docstrings and a new README section, closing out the original handoff notes' LLM open questions with confirmed facts instead of guesses.

## Test plan

- [x] `tests/test_pulsar2_compat.py` and `tests/test_pulsar2_simulator.py` (17/17, no Docker/device needed)
- [x] `ruff check`/`ruff format --check` clean
- [x] Manually verified end-to-end against a real AX650N + `pulsar2:6.0-lite`: real `Qwen/Qwen3-0.6B` build via `pulsar2_docker.llm_build()`, both a per-layer `.axmodel` and the post model run successfully on-device via `axcl_run_model`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NHj4n82EuMhBMdSg55RXLx