### PR TITLE
Add PB-LLM partial binarization weight-only quantizer

### DIFF
--- a/docs/pb-llm-quantization.md
+++ b/docs/pb-llm-quantization.md
@@ -1,0 +1,125 @@
+# PB-LLM: partial binarization (`quantize_weight_only_pb_llm`)
+
+## What this is
+
+`onnxsim.quantize_weight_only_pb_llm` is a genuine **lossy PTQ quantizer**
+that splits each matched layer's weight columns into two precisions: a
+small, salience-selected fraction stays INT8, and every other column is
+pushed to ~1 bit/element. It reuses `onnxsim.billm._sign` for the
+binarization primitive and reads like a structured cousin of
+`onnxsim.quantize_weight_only_billm`, but the two solve genuinely different
+problems -- read `onnxsim/pb_llm.py`'s own module docstring for the full
+comparison; the short version:
+
+- `onnxsim.quantize_weight_only_billm` binarizes **the entire weight**:
+  every column ends up represented by one or two binary (`{-1, +1}`)
+  levels. Its own salient/non-salient split only decides *how many* binary
+  levels a column gets (two, via a residual, for salient columns; one for
+  everything else) -- the whole layer stays close-to-1-bit-average
+  regardless of the split.
+- `onnxsim.quantize_weight_only_pb_llm`'s salient fraction is **not
+  binarized at all** -- it is quantized to genuine INT8, the same
+  precision `onnxsim.quantize_weight_only_int8_block` produces for a whole
+  layer. Only the non-salient remainder is binarized. `salient_ratio=0.0`
+  degenerates to plain per-column binarization; `salient_ratio=1.0`
+  degenerates to plain per-column INT8 -- BiLLM has no comparable "all
+  INT8" limit, since every one of its own output columns is always binary.
+
+It's also a different axis from `onnxsim.apply_mixed_precision_quantization`,
+which dispatches a bit-width **per whole layer** (INT8 vs. INT4, via an
+INT4-reconstruction-MSE-times-activation-energy score) and never splits
+precision within one layer's own weight matrix. PB-LLM's split is per
+**column**, inside a single layer, driven by a direct
+Hessian-diagonal-weighted-magnitude salience score --
+`salience_j = mean_n(|W[n, j]|) * diag(H)_j` (`H = X^T X`, the same
+calibration-derived Hessian `onnxsim.gptq`/`onnxsim.billm`/`onnxsim.owq`
+already build) -- with **no Hessian inversion**, unlike `onnxsim.owq`'s own
+Optimal-Brain-Surgeon-style score.
+
+```
+Before:
+  Y = MatMul(X, W) [+ bias]        -- W constant, [K, N], float32
+
+After:
+  Code: initializer, int8, [K, N]  -- full INT8 value for a salient
+                                       column, {-1, +1} for a non-salient
+                                       one
+  Scale: initializer, float32, [K, 1]  -- per-column scale
+  What_hat = Mul(Cast(Code, float), Scale)
+  Y = MatMul(X, What_hat) [+ bias]
+```
+
+Because an INT8 code and a `{-1, +1}` code both reconstruct the same way
+(`value = code * scale`), one matched layer needs only a single code
+tensor and a single per-column scale tensor -- no `Add` of a second term
+the way `onnxsim.quantize_weight_only_billm`'s two-level salient path
+needs. Ordinary ONNX ops only (`Cast`/`Mul`), opset 11+.
+
+## Where this comes from
+
+[PB-LLM](https://arxiv.org/abs/2310.00034) (Shang, Yuan, Wu and Dong, 2024,
+ICLR 2024) observes that pushing every weight of an LLM to 1 bit collapses
+accuracy, because a small fraction of weights carry disproportionate
+importance to the layer's output (the same premise GPTQ/SparseGPT/OWQ-style
+salience metrics are built on). Its fix: identify that salient fraction (the
+paper's own metric is a Hessian-diagonal-weighted magnitude, in the same
+family as GPTQ/SparseGPT/OWQ's own pruning/quantization salience metrics),
+keep it at a higher precision, and binarize the rest. This module implements
+that structure -- the salience score, the salient/non-salient split, INT8
+for the salient side, `sign(W) * mean(|W|)` binarization (`onnxsim.billm`'s
+own single-level `_binary` primitive, applied per column) for the
+non-salient side. Not ported: the paper's own "Optimal"-mode residual
+refinement (Section 4.2), which adds a second binarization level on top of
+the non-salient columns' own residual for extra accuracy -- a reasonable
+future addition (it would reuse `onnxsim.billm._binary`'s residual pattern
+directly, the same way `onnxsim.billm` itself applies it to *its own*
+salient columns), not attempted here since the paper's simpler "Naive" mode
+(what this module implements) already recovers most of PB-LLM's accuracy
+gain over full binarization.
+
+## Scope
+
+Handled:
+- `MatMul(X, W)` / `Gemm(X, W[, B], transA=0, alpha=1, beta=1)` with `W` a
+  constant 2-D float32 tensor and `X` a plain 2-D activation that appears
+  (as a 2-D tensor) in the supplied calibration data.
+- `transB` may be 0 or 1.
+- Opsets >= 11 (only `Cast`/`Mul` are needed).
+
+Left untouched (safe no-op, node passes through as-is):
+- Non-constant, non-2-D, or non-float32 weights.
+- A layer whose activation input never produced a plain 2-D tensor in the
+  calibration data (no Hessian diagonal to compute).
+- Weight names listed in `skip_names`.
+
+Needs calibration data (unlike `quantize_weight_only_nf4`/
+`quantize_weight_only_kmeans`, which need none): PB-LLM's salience score is
+inherently Hessian-based. `calibration_data` defaults to
+`onnxsim.generate_random_calibration_data`; pass real representative
+batches (e.g. via `onnxsim.load_huggingface_calibration_data`) for a
+salience ranking that actually reflects deployment-time activation
+statistics.
+
+## Usage
+
+```python
+import onnx
+import onnxsim
+
+model = onnx.load("model.onnx")
+quantized = onnxsim.quantize_weight_only_pb_llm(
+    model,
+    calibration_data=onnxsim.load_huggingface_calibration_data(model, ...),
+    salient_ratio=0.15,
+)
+onnx.save(quantized, "model.pb_llm.onnx")
+```
+
+`tests/test_pb_llm.py` covers: reconstruction error improving over a fully
+binary (`salient_ratio=0.0`) baseline on a weight/calibration scenario with
+genuine outlier structure; codes spanning both the full INT8 range (salient
+columns) and the plain `{-1, +1}` range (non-salient columns); the
+`salient_ratio=0.0`/`1.0` degenerate cases (fully binary / fully INT8);
+end-to-end float closeness (a loose tolerance, matching how lossy the
+binarized fraction is by design); `Gemm transB=1`; and a no-op on a
+non-matching layer.

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -98,6 +98,7 @@ from onnxsim.ort_matmul_nbits_workaround import workaround_ort_matmul_nbits_axis
 from onnxsim.outlier_suppression import apply_outlier_suppression
 from onnxsim.outlier_suppression_plus import apply_outlier_suppression_plus
 from onnxsim.owq import apply_owq
+from onnxsim.pb_llm import quantize_weight_only_pb_llm
 from onnxsim.precision_estimator import (
     ModelQuantizationEstimate,
     estimate_model_quantization_drop,
@@ -221,6 +222,7 @@ __all__ = [
     "quantize_weight_only",
     "quantize_weight_only_int4",
     "quantize_weight_only_billm",
+    "quantize_weight_only_pb_llm",
     "quantize_weight_only_int4_hqq",
     "quantize_weight_only_kmeans",
     "quantize_weight_only_nf4",

--- a/onnxsim/pb_llm.py
+++ b/onnxsim/pb_llm.py
@@ -1,0 +1,332 @@
+"""PB-LLM (Shang, Yuan, Wu, Dong, 2024, ICLR 2024, "PB-LLM: Partially
+Binarized Large Language Models", https://arxiv.org/abs/2310.00034) --
+a **structured mixed-precision binarizer**: per matched layer, a small
+salience-selected fraction of input channels (columns) stays at INT8,
+every other column is pushed to ~1 bit/element, and both live in the same
+``Code``/``Scale`` initializer pair so the graph rewrite needs only a
+single ``Cast``/``Mul``.
+
+Relationship to :mod:`onnxsim.billm` (the repo's other weight binarizer --
+read that module's own docstring first). BiLLM binarizes **the entire
+weight matrix**: every column ends up represented by one or two binary
+(``{-1,+1}``) levels, and the salient/non-salient split there only decides
+*how many* binary levels a column gets (two, via a residual, for salient
+columns; one for everything else) -- the whole layer stays in the
+"BiLLM"-shaped, close-to-1-bit-average family regardless of the split.
+PB-LLM is a different point in the design space: its salient fraction is
+not binarized *at all* -- it is quantized to genuine INT8, the same
+precision :func:`onnxsim.quantize_weight_only_int8_block` already produces
+for a whole layer -- and only the *remaining*, non-salient fraction is
+binarized. So where BiLLM's split is "1-bit vs. 2-bit", PB-LLM's split is
+"8-bit vs. ~1-bit": a real mixed high/low bit-width layer, exactly the
+"Partially-Binarized" property the paper's own name describes, not a
+finer-grained flavor of full binarization. The two are complementary
+points on a spectrum rather than one subsuming the other:
+``salient_ratio=0.0`` degenerates PB-LLM to a plain per-column binarizer
+(no INT8 columns at all, the same *shape* of output BiLLM's own
+non-salient path produces, though still via a single flat per-column scale
+rather than BiLLM's own block-searched, residual-compensated scheme), and
+``salient_ratio=1.0`` degenerates it to plain per-column INT8 (no
+binarization at all) -- BiLLM has no comparable "all INT8" limit, since
+every one of its output columns is always binary.
+
+Relationship to :mod:`onnxsim.mixed_precision` (the repo's other
+salience-driven bit-width dispatcher -- read that module's own docstring
+too). That module picks a bit-width **per whole layer**
+(:func:`onnxsim.apply_mixed_precision_quantization` sends the top
+``high_bits_fraction`` of *layers*, ranked by an INT4-reconstruction-MSE-
+times-activation-energy score, to block-wise INT8, and every other whole
+layer to block-wise INT4) -- it never splits precision *within* one
+layer's own weight matrix. PB-LLM's split is per **column**, inside a
+single layer, and its salience score is a different quantity entirely:
+:mod:`onnxsim.mixed_precision` asks "how much does this whole layer's
+*output* degrade if INT4-quantized" (an MSE-of-reconstruction proxy);
+PB-LLM asks "how much does *this column* already matter" via a direct
+Hessian-diagonal-weighted-magnitude score,
+
+    salience_j = mean_n(|W[n, j]|) * diag(H)_j,   H = X^T X
+
+the same style of score GPTQ/SparseGPT/OWQ (:mod:`onnxsim.owq`) build on,
+but -- unlike OWQ's own Optimal-Brain-Surgeon score
+(``mean_n[(W[n,j] - RTN(W[n,j]))^2] / [H^-1]_jj``, read
+:mod:`onnxsim.owq`'s own docstring) -- computed directly from ``diag(H)``
+with **no Hessian inversion at all**: ``diag(H)_j`` is just each input
+channel's own calibration activation energy (``sum_samples(X[:, j]^2)``),
+a cheap, always-well-defined proxy for "how strongly this channel actually
+gets excited", multiplied by the weight column's own average magnitude
+("how much does the weight there matter if it does get excited"). OWQ's
+own score additionally needs an *existing* quantization (its own RTN
+residual) to rank against and a damped Cholesky solve of ``H^-1``; PB-LLM's
+runs directly off the original float weight and a plain sum of squares,
+and -- unlike OWQ, which restores its selected columns to *exact* float32
+via a correction term added on top of someone else's already-INT4-
+quantized model -- PB-LLM quantizes the whole layer itself, in one pass,
+straight from the float model.
+
+**The technique**, one matched layer at a time:
+
+1. **Salience** (as above): ``salience_j = mean_n(|W[n, j]|) * diag(H)_j``
+   for each input channel ``j``, ``H = X^T X`` from real calibration
+   activations (the same Hessian construction :mod:`onnxsim.gptq`/
+   :mod:`onnxsim.billm`/:mod:`onnxsim.owq` all use).
+
+2. **Split**: the top ``salient_ratio`` fraction of columns by salience
+   (rounded to the nearest column count, paper's own experiments sweep
+   roughly 10-30%) form the salient set; every other column is
+   non-salient.
+
+3. **Salient columns -> INT8**: per-column symmetric round-to-nearest,
+   ``scale_j = max_n(|W[n, j]|) / 127``, ``code_{n,j} = round(W[n,j] /
+   scale_j)`` clipped to ``[-127, 127]`` -- the same granularity
+   :func:`onnxsim.quantize_weight_only_int8_block` uses for a whole block,
+   specialized here to a single column (the natural per-column limit of a
+   block-wise scale).
+
+4. **Non-salient columns -> ~1 bit**: ``scale_j = mean_n(|W[n, j]|)``,
+   ``code_{n,j} = sign(W[n, j])`` (reusing :func:`onnxsim.billm._sign`, the
+   paper's own ``sign(x) = 1 if x >= 0 else -1`` convention) -- a plain
+   per-column flavor of :mod:`onnxsim.billm`'s own single-level
+   ``_binary`` primitive (mean-abs scale, elementwise sign), computed
+   per-column here rather than over :mod:`onnxsim.billm`'s own
+   block-of-columns group, since PB-LLM's salient/non-salient split is
+   already per-column and needs no further block-search step of its own.
+   This is a deliberate simplification of the paper's own "Optimal"-mode
+   residual refinement (Section 4.2), which adds a second binarization
+   level on top of the non-salient columns' own residual for extra
+   accuracy, the same way :mod:`onnxsim.billm` applies a residual to *its
+   own* salient columns -- a reasonable future addition (it would reuse
+   :func:`onnxsim.billm._binary`'s residual pattern directly), not
+   attempted here since the paper reports its simpler "Naive" binarization
+   mode (what this module implements) already recovers most of PB-LLM's
+   accuracy gain over full binarization.
+
+Because an INT8 code and a ~1-bit ``{-1, +1}`` code both reconstruct the
+same way (``value = code * scale``, just over a different code range), one
+matched layer needs only a **single** code tensor and a **single**
+per-column scale tensor -- no separate branches to merge in-graph:
+
+    Before:
+      Y = MatMul(X, W) [+ bias]        -- W constant, [K, N], float32
+
+    After:
+      Code: initializer, int8, [K, N]  -- per-element code: a full INT8
+            value (``[-127, 127]``) for a salient column, ``{-1, +1}`` for
+            a non-salient one
+      Scale: initializer, float32, [K, 1]  -- per-column scale
+      What_hat = Mul(Cast(Code, float), Scale)
+      Y = MatMul(X, What_hat) [+ bias]
+
+No ``Gather``/codebook lookup (the code cast to float already *is* the
+reconstructed value up to the per-column scale, the same reasoning
+:mod:`onnxsim.billm`'s own docstring gives for its own encoding) and no
+``Add`` of a second term (unlike :mod:`onnxsim.billm`'s two-level salient
+path -- PB-LLM's salient columns are single-level INT8, not a binary
+residual pair). Ordinary ONNX ops only (``Cast``/``Mul``), opset 11+.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Optional, Sequence, Union
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+
+from onnxsim import backend
+from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.billm import _sign
+from onnxsim.calibration import Tensors, generate_random_calibration_data
+from onnxsim.quip_sharp import _match_matmul_like
+
+
+def _pb_llm_quantize_columns(
+    w_nk: np.ndarray, diag_h: np.ndarray, salient_ratio: float
+) -> "tuple[np.ndarray, np.ndarray]":
+    """Splits ``w_nk``'s ([N, K], output channel first) columns into a
+    salient (INT8) and non-salient (~1-bit) set by
+    ``mean_n(|w|) * diag_h`` per column (see this module's own docstring),
+    and quantizes each column accordingly. Returns ``(code_nk, scale_k)``:
+    an ``[N, K]`` int8 code array and a length-``K`` per-column float64
+    scale array.
+    """
+    n, k = w_nk.shape
+    code = np.empty((n, k), dtype=np.int8)
+    scale = np.empty(k, dtype=np.float64)
+    if k == 0:
+        return code, scale
+
+    col_mag = np.mean(np.abs(w_nk), axis=0)
+    salience = col_mag * diag_h
+    order = np.argsort(-salience)
+    num_salient = int(round(salient_ratio * k))
+    num_salient = max(0, min(k, num_salient))
+    salient_cols = order[:num_salient]
+    nonsalient_cols = order[num_salient:]
+
+    if salient_cols.size > 0:
+        w_sal = w_nk[:, salient_cols]
+        scale_sal = np.maximum(np.abs(w_sal).max(axis=0), 1e-12) / 127.0
+        code_sal = np.clip(np.round(w_sal / scale_sal), -127, 127)
+        code[:, salient_cols] = code_sal.astype(np.int8)
+        scale[salient_cols] = scale_sal
+
+    if nonsalient_cols.size > 0:
+        w_ns = w_nk[:, nonsalient_cols]
+        scale_ns = np.mean(np.abs(w_ns), axis=0)
+        code_ns = _sign(w_ns)
+        code[:, nonsalient_cols] = code_ns.astype(np.int8)
+        scale[nonsalient_cols] = scale_ns
+
+    return code, scale
+
+
+def quantize_weight_only_pb_llm(
+    model: Union[str, onnx.ModelProto],
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_samples: int = 8,
+    seed: int = 0,
+    salient_ratio: float = 0.15,
+    skip_names: Optional[Iterable[str]] = None,
+    providers: Optional[Sequence[str]] = None,
+) -> onnx.ModelProto:
+    """Partially binarizes every MatMul/vanilla-Gemm layer with a constant
+    2-D float32 weight: the ``salient_ratio`` fraction of input channels
+    with the highest Hessian-diagonal-weighted magnitude stay INT8, every
+    other channel is binarized to ~1 bit/element -- see this module's own
+    docstring for the technique and how it differs from
+    :mod:`onnxsim.billm` (full binarization) and
+    :mod:`onnxsim.mixed_precision` (whole-layer, not per-column,
+    bit-width dispatch).
+
+    Needs real calibration activations to compute each layer's
+    Hessian-diagonal salience, the same as :mod:`onnxsim.gptq`/
+    :mod:`onnxsim.billm`/:mod:`onnxsim.owq`.
+
+    :param model: the original (unquantized) onnx ModelProto or file path
+    :param calibration_data: representative input batches to compute each
+            layer's Hessian diagonal from -- see
+            :func:`onnxsim.gptq.apply_gptq`'s own parameter of the same
+            name
+    :param num_samples: random batches to generate when
+            ``calibration_data`` is omitted
+    :param seed: seed for the random calibration data (ignored if
+            ``calibration_data`` is supplied)
+    :param salient_ratio: fraction of each layer's input columns (by
+            count, most salient first) kept at INT8; the rest are
+            binarized. ``0.0`` binarizes every column, ``1.0`` quantizes
+            every column to INT8 -- see this module's own docstring for
+            both limits
+    :param skip_names: weight initializer names to leave unquantized even
+            if otherwise eligible
+    :param providers: onnxruntime execution providers to run ``model`` on
+            when capturing calibration activations
+    :returns: ``model`` with every matched layer's weight replaced by
+            ``Mul(Cast(Code), Scale)`` feeding the original MatMul/Gemm
+            node -- ordinary ONNX ops only, opset 11+. Layers with a
+            non-constant, non-2-D, or non-float32 weight, or whose
+            activation input isn't a plain 2-D tensor, are left untouched.
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    skip_names = set(skip_names) if skip_names is not None else frozenset()
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            model, num_samples=num_samples, seed=seed
+        )
+
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    graph = out.graph
+    initializer_map = {t.name: t for t in graph.initializer}
+    taken_names = _all_names(graph)
+
+    candidates = []
+    for node in graph.node:
+        match = _match_matmul_like(node)
+        if match is None:
+            continue
+        x_name, w_name, _bias_name, weight_transposed = match
+        if w_name in skip_names:
+            continue
+        w_init = initializer_map.get(w_name)
+        if (
+            w_init is None
+            or w_init.data_type != onnx.TensorProto.FLOAT
+            or len(w_init.dims) != 2
+        ):
+            continue
+        candidates.append((node, x_name, w_name, weight_transposed))
+
+    if not candidates:
+        return out
+
+    probe_names = [c[1] for c in candidates]
+    probe_model = _add_probe_outputs(model, probe_names)
+
+    activations: Dict[str, List[np.ndarray]] = {name: [] for name in probe_names}
+    for batch in calibration_data:
+        result = backend.run_model(probe_model, batch, providers=providers)
+        for name in probe_names:
+            activations[name].append(np.asarray(result[name], dtype=np.float64))
+
+    for node, x_name, w_name, weight_transposed in candidates:
+        acts = [a for a in activations[x_name] if a.ndim == 2]
+        if not acts:
+            continue  # not a plain 2-D activation; skip
+        x = np.concatenate(acts, axis=0)
+
+        w_init = initializer_map[w_name]
+        w = onnx.numpy_helper.to_array(w_init).astype(np.float64)
+        dim0, dim1 = w.shape
+        w_nk = w if weight_transposed else w.T  # [N, K]
+        n, k = w_nk.shape
+        if x.shape[1] != k:
+            continue  # activation's feature dim doesn't match K; skip
+
+        diag_h = np.sum(x**2, axis=0)  # [K]
+        code_nk, scale_k = _pb_llm_quantize_columns(w_nk, diag_h, salient_ratio)
+
+        code_orig = code_nk if weight_transposed else code_nk.T
+        assert code_orig.shape == (dim0, dim1)
+
+        # scale_k is indexed along K (the reduction dim). When
+        # weight_transposed (W is [N, K], K last), it broadcasts against W
+        # as-is; otherwise (W is [K, N], K first) it needs a trailing
+        # size-1 axis to broadcast against axis 0 instead of axis -1 --
+        # the same reasoning onnxsim.billm's own quantize_weight_only_billm
+        # uses for its own per-column scale.
+        scale_orig = scale_k if weight_transposed else scale_k[:, np.newaxis]
+
+        prefix = f"{w_name}_pb_llm"
+        code_name = _unique_name(f"{prefix}_code", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(code_orig.astype(np.int8), name=code_name)
+        )
+        scale_name = _unique_name(f"{prefix}_scale", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(scale_orig.astype(np.float32), name=scale_name)
+        )
+
+        cast_out = _unique_name(f"{prefix}_code_f", taken_names)
+        cast_node = onnx.helper.make_node(
+            "Cast", [code_name], [cast_out], to=onnx.TensorProto.FLOAT
+        )
+        dq_out = _unique_name(f"{prefix}_dq", taken_names)
+        mul_node = onnx.helper.make_node(
+            "Mul",
+            [cast_out, scale_name],
+            [dq_out],
+            name=_unique_name(f"{prefix}_dequant", taken_names),
+        )
+
+        insertion_point = next(i for i, n in enumerate(graph.node) if n is node)
+        for new_node in (cast_node, mul_node):
+            graph.node.insert(insertion_point, new_node)
+            insertion_point += 1
+
+        for i, inp in enumerate(node.input):
+            if inp == w_name:
+                node.input[i] = dq_out
+
+    return out

--- a/tests/test_pb_llm.py
+++ b/tests/test_pb_llm.py
@@ -1,0 +1,250 @@
+"""Tests for ``onnxsim.quantize_weight_only_pb_llm`` (PB-LLM, see
+``onnxsim/pb_llm.py``) -- salience-driven per-column split between INT8
+(salient columns) and ~1-bit binarization (everything else), for an
+ordinary dense float32 MatMul/Gemm weight.
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
+
+
+def _matmul_model(K=64, N=8, seed=0):
+    rng = np.random.default_rng(seed)
+    weight = rng.standard_normal((K, N)).astype(np.float32) * 0.3
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [_f32(weight, "W")],
+    ), weight
+
+
+def _gemm_transb_model(K=48, N=8, seed=2):
+    rng = np.random.default_rng(seed)
+    # transB=1 -> weight stored [N, K]
+    weight = rng.standard_normal((N, K)).astype(np.float32) * 0.3
+    bias = rng.standard_normal((N,)).astype(np.float32) * 0.1
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = Gemm<transB=1>(X, W, B)
+        }}
+        """,
+        [_f32(weight, "W"), _f32(bias, "B")],
+    ), weight
+
+
+def _salient_calibration(K, num_samples=48, salient_channels=(2, 9), seed=1):
+    # A handful of input channels with much larger activation magnitude
+    # than the rest -- PB-LLM's own motivating case, since
+    # salience_j = mean(|w_j|) * diag(H)_j depends on both the weight
+    # column's own magnitude and how strongly the channel is actually
+    # excited by real activations (via H = X^T X).
+    rng = np.random.default_rng(seed)
+    x = rng.standard_normal((num_samples, K)).astype(np.float32)
+    for c in salient_channels:
+        x[:, c] *= 25.0
+    return x
+
+
+def _outlier_weight(K=64, N=8, outlier_cols=(2, 9), seed=0):
+    rng = np.random.default_rng(seed)
+    weight = rng.standard_normal((K, N)).astype(np.float64) * 0.05
+    for c in outlier_cols:
+        weight[c, :] = rng.standard_normal(N) * 3.0
+    return weight.astype(np.float32)
+
+
+def _decode_pb_llm_weight(model, w_name, orig_shape):
+    prefix = f"{w_name}_pb_llm"
+    by_name = {t.name: t for t in model.graph.initializer}
+    code = onnx.numpy_helper.to_array(by_name[f"{prefix}_code"]).astype(np.float64)
+    scale = onnx.numpy_helper.to_array(by_name[f"{prefix}_scale"]).astype(np.float64)
+    recon = code * scale
+    assert recon.shape == orig_shape
+    return recon, code
+
+
+def test_reconstruction_error_improves_on_salient_outliers():
+    K, N = 64, 8
+    outlier_cols = (2, 9)
+    model, weight = _matmul_model(K=K, N=N, seed=0)
+    weight = _outlier_weight(K=K, N=N, outlier_cols=outlier_cols, seed=0)
+    model.graph.initializer[0].CopyFrom(_f32(weight, "W"))
+
+    calib = [{"X": _salient_calibration(K, salient_channels=outlier_cols)}]
+    quantized = onnxsim.quantize_weight_only_pb_llm(
+        model, calibration_data=calib, salient_ratio=0.1
+    )
+
+    recon, code = _decode_pb_llm_weight(quantized, "W", weight.shape)
+    pb_llm_err = np.linalg.norm(weight.astype(np.float64) - recon)
+
+    # The outlier columns should have been selected salient (a full INT8
+    # code range there), not just given a plain +-1 binary code.
+    assert np.any(np.abs(code[outlier_cols[0], :]) > 1)
+    assert np.any(np.abs(code[outlier_cols[1], :]) > 1)
+
+    # A naive all-binary reconstruction (salient_ratio=0) should do
+    # noticeably worse on the outlier columns than PB-LLM's own split.
+    fully_binary = onnxsim.quantize_weight_only_pb_llm(
+        model, calibration_data=calib, salient_ratio=0.0
+    )
+    naive_recon, naive_code = _decode_pb_llm_weight(fully_binary, "W", weight.shape)
+    assert set(np.unique(naive_code).tolist()) <= {-1, 1}
+    naive_err = np.linalg.norm(weight.astype(np.float64) - naive_recon)
+
+    assert pb_llm_err < naive_err
+
+
+def test_codes_are_in_valid_discrete_set():
+    K, N = 40, 6
+    model, weight = _matmul_model(K=K, N=N, seed=3)
+    calib = [{"X": _salient_calibration(K, salient_channels=(1, 5), seed=4)}]
+    quantized = onnxsim.quantize_weight_only_pb_llm(
+        model, calibration_data=calib, salient_ratio=0.2
+    )
+
+    by_name = {t.name: t for t in quantized.graph.initializer}
+    code = onnx.numpy_helper.to_array(by_name["W_pb_llm_code"])
+    assert code.dtype == np.int8
+    assert np.all(code >= -127) and np.all(code <= 127)
+
+    # At least one column should have taken the full INT8 range (salient)
+    # and at least one should be the plain +-1 binary code (non-salient).
+    per_col_abs_max = np.abs(code).max(axis=1)
+    assert np.any(per_col_abs_max > 1)
+    assert np.any(per_col_abs_max == 1)
+
+
+def test_salient_ratio_zero_is_fully_binary():
+    K, N = 32, 4
+    model, weight = _matmul_model(K=K, N=N, seed=6)
+    calib = [{"X": _salient_calibration(K, salient_channels=(3, 10), seed=7)}]
+    quantized = onnxsim.quantize_weight_only_pb_llm(
+        model, calibration_data=calib, salient_ratio=0.0
+    )
+    by_name = {t.name: t for t in quantized.graph.initializer}
+    code = onnx.numpy_helper.to_array(by_name["W_pb_llm_code"])
+    assert set(np.unique(code).tolist()) <= {-1, 1}
+
+
+def test_salient_ratio_one_is_full_int8():
+    K, N = 32, 4
+    model, weight = _matmul_model(K=K, N=N, seed=8)
+    calib = [{"X": _salient_calibration(K, salient_channels=(3, 10), seed=9)}]
+    quantized = onnxsim.quantize_weight_only_pb_llm(
+        model, calibration_data=calib, salient_ratio=1.0
+    )
+    recon, code = _decode_pb_llm_weight(quantized, "W", weight.shape)
+
+    # Full INT8 round-to-nearest should reconstruct closely everywhere.
+    rel_err = np.linalg.norm(weight.astype(np.float64) - recon) / np.linalg.norm(
+        weight.astype(np.float64)
+    )
+    assert rel_err < 0.05
+
+
+def test_end_to_end_float_closeness():
+    K, N = 64, 8
+    model, weight = _matmul_model(K=K, N=N, seed=5)
+    calib = [{"X": _salient_calibration(K, salient_channels=(3, 20), seed=6)}]
+    quantized = onnxsim.quantize_weight_only_pb_llm(
+        model, calibration_data=calib, salient_ratio=0.15
+    )
+
+    x = np.random.default_rng(7).standard_normal((4, K)).astype(np.float32)
+    (float_out,) = _run(model, {"X": x})
+    (quant_out,) = _run(quantized, {"X": x})
+
+    # A mostly-binary quantizer is aggressively lossy by design -- not
+    # remotely INT4-level closeness -- but should still be well within the
+    # same order of magnitude as the float output, not noise.
+    assert _rel_l2(float_out, quant_out) < 0.9
+
+
+def test_gemm_transb_weight():
+    # transB=1 stores W as [N, K] rather than MatMul's [K, N] -- exercises
+    # the other branch of the scale-broadcast-shape logic (see
+    # quantize_weight_only_pb_llm's own comment on weight_transposed).
+    K, N = 48, 8
+    model, weight = _gemm_transb_model(K=K, N=N, seed=8)
+    calib = [{"X": _salient_calibration(K, salient_channels=(4, 15), seed=9)}]
+    quantized = onnxsim.quantize_weight_only_pb_llm(
+        model, calibration_data=calib, salient_ratio=0.15
+    )
+
+    recon, code = _decode_pb_llm_weight(quantized, "W", weight.shape)
+    assert np.all(code >= -127) and np.all(code <= 127)
+
+    x = _salient_calibration(K, num_samples=3, salient_channels=(4, 15), seed=10)
+    (float_out,) = _run(model, {"X": x})
+    (quant_out,) = _run(quantized, {"X": x})
+    assert _rel_l2(float_out, quant_out) < 0.9
+
+
+def test_noop_on_non_matching_layer():
+    K, N = 32, 4
+    model, weight = _matmul_model(K=K, N=N, seed=11)
+    calib = [{"X": _salient_calibration(K, salient_channels=(1, 6), seed=12)}]
+
+    quantized = onnxsim.quantize_weight_only_pb_llm(
+        model, calibration_data=calib, skip_names={"W"}
+    )
+    assert quantized.SerializeToString() == model.SerializeToString()
+
+    # Also a layer whose weight isn't a plain constant 2-D float32 tensor
+    # (a 1-D bias-shaped initializer here) shouldn't be touched at all.
+    conv_like = _model(
+        """
+        g (float[1,4] X) => (float[1,4] Y)
+        {
+          Y = Add(X, Bias)
+        }
+        """,
+        [_f32(np.zeros(4, dtype=np.float32), "Bias")],
+    )
+    out = onnxsim.quantize_weight_only_pb_llm(conv_like, calibration_data=calib)
+    assert out.SerializeToString() == conv_like.SerializeToString()


### PR DESCRIPTION
## Summary

Adds `onnxsim.quantize_weight_only_pb_llm`, implementing PB-LLM (Shang, Yuan, Wu, Dong, 2024, ICLR 2024, ["PB-LLM: Partially Binarized Large Language Models"](https://arxiv.org/abs/2310.00034)) as a new weight-only quantization technique.

A repo-wide grep (`onnxsim/`, `tests/`, `README.md`, `docs/`) turned up no existing PB-LLM implementation, so this is a new module rather than a duplicate.

## What's added / scope

- **`onnxsim/pb_llm.py`** — `quantize_weight_only_pb_llm(model, calibration_data=None, num_samples=8, seed=0, salient_ratio=0.15, skip_names=None, providers=None)`. For every matched `MatMul`/vanilla-`Gemm` layer with a constant 2-D float32 weight:
  1. Computes a per-column salience score `salience_j = mean_n(|W[n,j]|) * diag(H)_j`, with `H = X^T X` from calibration activations (no Hessian inversion needed, unlike `onnxsim.owq`/`onnxsim.billm`).
  2. The top `salient_ratio` fraction of columns (by count) stay INT8 (per-column symmetric round-to-nearest); every other column is binarized to `sign(W) * mean(|W|)`, reusing `onnxsim.billm._sign`.
  3. Both precisions share a single `Code`(int8)/`Scale`(float32) initializer pair per layer, reconstructed with just `Mul(Cast(Code), Scale)` — no `Gather`/codebook, no second `Add` term.

  **How this differs from the two closest existing modules** (documented at length in the module's own docstring, mirroring how `onnxsim/outlier_suppression.py` documents its own relationship to its nearest sibling):
  - `onnxsim.billm` (BiLLM) binarizes the **entire** weight matrix — its own salient/non-salient split only decides how many binary levels (1 vs. 2) a column gets. PB-LLM's salient fraction is never binarized at all; it's genuine INT8. `salient_ratio=0.0`/`1.0` degenerate PB-LLM to plain binarization / plain INT8 respectively — limits BiLLM has no equivalent of.
  - `onnxsim.mixed_precision` dispatches a bit-width **per whole layer** via an INT4-reconstruction-MSE-times-activation-energy score. PB-LLM's split is **per column** within one layer, via a direct Hessian-diagonal-weighted-magnitude score (no MSE, no per-layer granularity).

- **`onnxsim/__init__.py`** — registers `quantize_weight_only_pb_llm` (import + `__all__`).
- **`tests/test_pb_llm.py`** — built with `onnx.parser.parse_model()` per this repo's `CLAUDE.md` convention, mirroring `tests/test_billm.py`'s structure. Covers: reconstruction error improving over a fully-binary baseline on an outlier-column scenario; codes spanning both the full INT8 range and the plain `{-1,+1}` range; the `salient_ratio=0.0`/`1.0` degenerate cases; end-to-end float closeness via onnxruntime (loose relative tolerance, appropriate for a lossy binarizer); `Gemm transB=1`; no-op on non-matching layers.
- **`docs/pb-llm-quantization.md`** — following the existing per-technique doc convention (e.g. `docs/billm-quantization.md`).

Per this repo's `CLAUDE.md`, the wheel build doesn't compile ONNX Runtime — this is a pure-Python addition, no C++ touched.

## Test plan

All commands run in this session against the built wheel (`pip install -e . --no-build-isolation`, after `git submodule update --init --recursive`):

- `pytest tests/test_pb_llm.py -v` → **7 passed**
- `pytest tests/test_billm.py tests/test_owq.py tests/test_mixed_precision.py -v` (regression check for the modules this reuses patterns from) → **20 passed**, no regressions
- After merging `origin/master` (which had moved — added structured-pruning C++ porting, unrelated to this change): re-ran the full set above → **27 passed**
- `ruff check onnxsim/pb_llm.py tests/test_pb_llm.py onnxsim/__init__.py` → all checks passed
- `ruff format --check onnxsim/pb_llm.py tests/test_pb_llm.py onnxsim/__init__.py` → all formatted
- `mypy` (full run) → **25 errors, 60 files checked** both before and after this change (baseline unchanged; no new mypy errors from `pb_llm.py`)

Weight reconstruction (INT8 codes and binary codes) was verified directly in numpy against the ONNX initializers (`_decode_pb_llm_weight` in the test file), not via onnxruntime round-tripping — the onnxruntime-based checks in the test file use a loose relative-tolerance (`< 0.9`, appropriate for a mostly-binary quantizer) end-to-end closeness check only, per the platform-numerics lesson that onnxruntime execution isn't bit-exact across CPU architectures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGfPocAziAENYbnu3HKy95

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGfPocAziAENYbnu3HKy95)_