### PR TITLE
Add AffineQuant weight-only quantization

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -11,6 +11,7 @@ from onnxsim.accuracy import (
 )
 from onnxsim.adaquant import apply_adaquant
 from onnxsim.adaround import apply_adaround
+from onnxsim.affinequant import apply_affinequant
 from onnxsim.aqlm import quantize_weight_only_aqlm
 from onnxsim.attention_quantization import apply_attention_quantization
 from onnxsim.autoquant import AutoQuantResult, auto_quantize_int4
@@ -183,6 +184,7 @@ __all__ = [
     "apply_zeroquant",
     "apply_spinquant",
     "apply_omniquant",
+    "apply_affinequant",
     "apply_magnitude_pruning",
     "prune_magnitude_cpp",
     "apply_wanda_pruning",

--- a/onnxsim/affinequant.py
+++ b/onnxsim/affinequant.py
@@ -1,0 +1,500 @@
+"""AffineQuant (Ma et al., 2024, ICLR, "AffineQuant: Affine Transformation
+Quantization for Large Language Models", https://arxiv.org/abs/2403.12544).
+onnxsim ports the algorithm, not any framework's code, per the same
+rationale as :mod:`onnxsim.omniquant` (AffineQuant's own reference
+implementation, like OmniQuant's, optimizes live PyTorch modules with
+backpropagation, with no ONNX export path).
+
+**Relationship to :mod:`onnxsim.omniquant`.** AffineQuant is explicitly
+framed by its own paper as a generalization of OmniQuant's Learnable
+Equivalent Transformation (LET): OmniQuant (and, before it,
+:mod:`onnxsim.smoothquant`) migrates activation quantization difficulty
+into the weight via a *diagonal* per-channel transform -- a single scale
+(and, for OmniQuant, a shift) applied independently to each activation
+channel, with no mixing across channels. AffineQuant instead optimizes a
+full *invertible affine transformation matrix* jointly with the
+quantization: because a general matrix can also rotate/mix channels
+against each other (not just rescale each one on its own), it has
+strictly more representational freedom to reduce quantization error than
+any diagonal transform can reach, at higher compensation cost (a matrix
+multiply on the activation side and a matrix-weight product on the weight
+side, instead of an elementwise scale). A diagonal matrix is a special
+case of an affine matrix, so this module's own search is set up to never
+do worse than :mod:`onnxsim.omniquant`'s own diagonal LET on the same
+layer -- see "Search strategy" below.
+
+**Scope: block-diagonal, not dense.** The paper's own experiments use a
+*fully dense* per-layer transformation matrix, optimized end-to-end by
+gradient descent. A dense ``[K, K]`` matrix does not fit this repo's
+closed-form/grid-search style (see :mod:`onnxsim.omniquant`'s own
+docstring for why this series prefers that over a hand-rolled autodiff
+loop): choosing a good dense ``K x K`` matrix without gradients means
+solving a ``K``-dimensional optimization problem, and *compensating* it
+means inverting a dense ``K x K`` matrix, which for a real transformer's
+hidden size (thousands) is both numerically fragile (a poorly-conditioned
+dense inverse can blow up the compensated weight's dynamic range, making
+quantization *worse*, not better) and expensive to insert as a runtime
+``MatMul``. This module instead restricts the transform to
+**block-diagonal**: the ``K`` activation channels are partitioned into
+fixed-size blocks (``affine_block_size``, default 8; configurable), and
+each block gets its own small, independently-invertible square matrix,
+with zero coupling across blocks. This keeps the search per-block (a
+handful of channels at a time, tractable to search or solve in closed
+form) and the compensation an efficient block-diagonal matrix multiply
+(a ``[K, K]`` matrix that is mostly zero, structurally similar to grouped
+convolution) rather than a dense ``K x K`` solve. It is a strictly less
+expressive family than the paper's own dense matrix, but strictly more
+expressive than OmniQuant's diagonal one -- a deliberate middle point
+documented here as this module's own tractability tradeoff.
+
+**Search strategy.** Per compensated layer, three transform families are
+tried and the empirically-best one (lowest weight reconstruction error
+against real calibration activations, exactly as :mod:`onnxsim.omniquant`
+already measures) is kept:
+
+1. **No transform** -- plain Learnable Weight Clipping (LWC) only, reusing
+   :mod:`onnxsim.omniquant`'s own grid-searched per-block clip ratio
+   unchanged.
+2. **Diagonal LET** -- :mod:`onnxsim.omniquant`'s own closed-form shift
+   plus alpha-grid-searched per-channel scale, unchanged.
+3. **Block-affine LET** -- this module's own contribution: within each
+   ``affine_block_size``-channel block, the block's own calibration
+   activation covariance (after the same closed-form mean-shift as (2))
+   is diagonalized via ``numpy.linalg.eigh``, giving an orthonormal basis
+   (a rotation) for that block. Stacking these per-block rotations along
+   the diagonal gives a block-diagonal orthogonal matrix ``R`` for the
+   whole layer -- trivially and exactly invertible (``R^-1 = R^T``, no
+   numerical solve needed, unlike an arbitrary invertible matrix) by
+   construction, which is what keeps this restriction numerically stable.
+   OmniQuant's own alpha-grid-searched per-channel scale is then
+   recomputed *in the rotated basis* (on the rotated activation and
+   rotated weight column statistics) and searched exactly as in (2).
+   Because a rotation is orthogonal, family (2) is exactly family (3)
+   restricted to ``R = I`` (or, when ``affine_block_size == 1``, every
+   block's "rotation" is a trivial ``1x1`` matrix that cannot mix
+   anything) -- so trying (3) can only match or beat (2), and (2) can
+   only match or beat (1), on the same reconstruction-error objective
+   this module measures. This mirrors :mod:`onnxsim.omniquant`'s own
+   "each stage's first candidate reproduces the previous stage" guarantee
+   that keeps it never worse than plain RTN.
+
+Like OmniQuant, and unlike a pure migration module such as
+:mod:`onnxsim.outlier_suppression`/:mod:`onnxsim.smoothquant`, this
+module does not return a float model for a later, separate quantizer to
+consume: the paper's own design (following OmniQuant's LET framework
+directly) jointly optimizes the equivalent transformation *against* the
+weight-only INT4 quantization error itself, so the transform choice and
+the quantization it enables are inseparable here -- exactly the same
+scope and non-float-migration contract :mod:`onnxsim.omniquant` already
+documents and this module deliberately keeps, for the same reason.
+
+This targets the same shape :mod:`onnxsim.omniquant` targets: every
+``quantize_weight_only_int4``-quantized MatMul/Gemm layer (by node output
+name) present in both a float model and its quantized counterpart, whose
+activation input is a plain 2-D tensor.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Set, Union
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+
+from onnxsim import backend
+from onnxsim.adaround import _find_int4_matmul_candidates, _node_outputs, _pack_int4
+from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.calibration import Tensors, generate_random_calibration_data
+from onnxsim.omniquant import _quantize_blockwise_int4_with_clip
+
+
+@dataclass
+class _AffineQuantRewrite:
+    output_name: str
+    activation_name: str
+    wq_name: str
+    ws_name: str
+    codes: np.ndarray  # int8, original (Wq's) layout/shape
+    scale: np.ndarray  # float32, original (Ws's) layout/shape
+    channel_scale: Optional[np.ndarray]  # None means no LET transform needed
+    shift: Optional[np.ndarray]  # [K]; paired with channel_scale
+    rotation: Optional[np.ndarray]  # [K, K] block-diagonal; None means diagonal-only
+    bias_correction: Optional[np.ndarray]  # [N]; paired with channel_scale
+
+
+def _block_diagonal_rotation(
+    x_centered: np.ndarray, affine_block_size: int
+) -> np.ndarray:
+    """Builds the ``[K, K]`` block-diagonal orthogonal rotation matrix used
+    by this module's block-affine LET candidate: each ``affine_block_size``
+    -channel block gets the eigenvectors of that block's own calibration
+    covariance (over ``x_centered``, already mean-shifted) as its local
+    orthonormal basis. Orthogonal by construction (``numpy.linalg.eigh``
+    always returns orthonormal eigenvectors of a symmetric matrix), so the
+    result is exactly invertible via its own transpose -- no matrix solve.
+    """
+    num_samples, k = x_centered.shape
+    rotation = np.zeros((k, k), dtype=np.float64)
+    for start in range(0, k, affine_block_size):
+        stop = min(start + affine_block_size, k)
+        block = x_centered[:, start:stop]
+        cov = (block.T @ block) / max(num_samples, 1)
+        # eigh: cov is symmetric PSD by construction (a Gram matrix), so
+        # its eigenvectors are real and orthonormal.
+        _, eigvecs = np.linalg.eigh(cov)
+        rotation[start:stop, start:stop] = eigvecs
+    return rotation
+
+
+def _diagonal_scale_grid(
+    weight_col_absmax: np.ndarray, act_col_absmax: np.ndarray, alphas: np.ndarray
+):
+    """Yields, for each ``alpha``, the same SmoothQuant/OmniQuant-style
+    closed-form per-channel scale ``s_j = act_j**alpha / weight_j**(1 -
+    alpha)`` (renormalized to unit geometric mean) that
+    :func:`onnxsim.apply_omniquant`'s own LET stage already computes,
+    reused verbatim here in whatever basis the caller passes in.
+    """
+    for alpha in alphas:
+        raw = act_col_absmax**alpha / weight_col_absmax ** (1.0 - alpha)
+        yield raw / np.exp(np.mean(np.log(raw)))
+
+
+def _reconstruction_error(
+    x: np.ndarray,
+    y_float: np.ndarray,
+    w_hat_nk: np.ndarray,
+    shift,
+    rotation,
+    channel_scale,
+    bias_correction,
+) -> float:
+    if channel_scale is None:
+        y_hat = x @ w_hat_nk.T
+    else:
+        x_centered = x - shift[np.newaxis, :]
+        x_rot = x_centered @ rotation if rotation is not None else x_centered
+        x_transformed = x_rot / channel_scale[np.newaxis, :]
+        y_hat = x_transformed @ w_hat_nk.T + bias_correction[np.newaxis, :]
+    return float(np.mean((y_float - y_hat) ** 2))
+
+
+def apply_affinequant(
+    float_model: Union[str, onnx.ModelProto],
+    quantized_model: Union[str, onnx.ModelProto],
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_samples: int = 8,
+    seed: int = 0,
+    num_clip_steps: int = 20,
+    num_alpha_steps: int = 20,
+    min_clip_ratio: float = 0.5,
+    affine_block_size: int = 8,
+    providers: Optional[Sequence[str]] = None,
+) -> onnx.ModelProto:
+    """Applies AffineQuant-style learnable weight clipping and block-affine
+    learnable equivalent transformation to every
+    ``quantize_weight_only_int4``-quantized MatMul/Gemm layer present (by
+    node output name) in both ``float_model`` and ``quantized_model``,
+    using real activations captured from ``float_model``. See this
+    module's own docstring for the technique and how it generalizes
+    :func:`onnxsim.apply_omniquant`'s diagonal transform.
+
+    :param float_model: the original (unquantized) onnx ModelProto or file
+            path
+    :param quantized_model: a quantized version of ``float_model`` (onnx
+            ModelProto or file path), produced by
+            :func:`onnxsim.quantize_weight_only_int4`. Layers quantized by
+            any other scheme (or left unquantized), or whose activation
+            input isn't a plain 2-D tensor, are left untouched.
+    :param calibration_data: representative input batches to search and
+            measure the transform on. Each batch is a
+            ``{input_name: np.ndarray}`` dict matching ``float_model``'s
+            graph inputs -- see :func:`onnxsim.generate_random_calibration_data`
+            (the default when omitted) and
+            :func:`onnxsim.load_huggingface_calibration_data` (real data).
+    :param num_samples: random batches to generate when
+            ``calibration_data`` is omitted
+    :param seed: seed for the random calibration data (ignored if
+            ``calibration_data`` is supplied)
+    :param num_clip_steps: grid points for the LWC clip ratio, evenly
+            spaced over ``[min_clip_ratio, 1.0]`` inclusive (``1.0``,
+            i.e. plain min/max scaling, is always the grid's last point,
+            so a block LWC can't improve keeps its original scale)
+    :param num_alpha_steps: grid points for the LET migration-strength
+            exponent, evenly spaced over ``[0, 1]`` inclusive (``0``,
+            i.e. no scale/shift transform at all, is always the grid's
+            first point), used identically for both the diagonal and the
+            block-affine candidate
+    :param min_clip_ratio: the LWC grid's lower bound
+    :param affine_block_size: the size of each independently-rotated block
+            of activation channels in the block-affine candidate (see this
+            module's own "Scope" docstring section). Larger blocks can
+            capture more cross-channel structure but cost a bigger
+            per-block eigendecomposition and a bigger inserted block of
+            the compensating ``MatMul``; must be a positive divisor
+            consideration only -- layers whose K isn't evenly divisible by
+            it simply skip the block-affine candidate (falling back to (2)
+            or (1)) rather than erroring.
+    :param providers: onnxruntime execution providers to run ``float_model``
+            on when capturing calibration activations
+    :returns: ``quantized_model`` with every layer AffineQuant measurably
+            improved rewritten: its INT4 weight/scale replaced by the
+            LWC-reclipped, LET-transformed-and-requantized versions, and
+            (only when a diagonal or block-affine transform was found to
+            help) a new ``Sub``/(optionally ``MatMul``)/``Mul`` inserted
+            before it transforming its activation input plus a new
+            ``Add`` folding in the constant bias correction after it. A
+            layer AffineQuant found no LET improvement for still gets its
+            LWC-only reclipping, with no inserted activation-side nodes.
+    """
+    if isinstance(float_model, str):
+        float_model = onnx.load(float_model, load_external_data=False)
+    if isinstance(quantized_model, str):
+        quantized_model = onnx.load(quantized_model, load_external_data=False)
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            float_model, num_samples=num_samples, seed=seed
+        )
+
+    candidates = _find_int4_matmul_candidates(float_model, quantized_model)
+    if not candidates:
+        return quantized_model
+
+    probe_names = [c.float_node.input[0] for c in candidates]
+    float_probe = _add_probe_outputs(float_model, probe_names)
+
+    activations: Dict[str, List[np.ndarray]] = {name: [] for name in probe_names}
+    for batch in calibration_data:
+        out = backend.run_model(float_probe, batch, providers=providers)
+        for name in probe_names:
+            activations[name].append(np.asarray(out[name], dtype=np.float64))
+
+    clip_ratios = np.linspace(min_clip_ratio, 1.0, num_clip_steps)[::-1]  # 1.0 first
+    alphas = np.linspace(0.0, 1.0, num_alpha_steps)
+
+    rewrites: List[_AffineQuantRewrite] = []
+    for c in candidates:
+        acts = [a for a in activations[c.float_node.input[0]] if a.ndim == 2]
+        if not acts:
+            continue
+        x = np.concatenate(acts, axis=0)
+
+        w = onnx.numpy_helper.to_array(c.w_float_init).astype(np.float64)
+        dim0, dim1 = w.shape
+        w_nk = w if c.weight_transposed else w.T  # [N, K]
+        if x.shape[1] != w_nk.shape[1]:
+            continue
+        k = w_nk.shape[1]
+
+        y_float = x @ w_nk.T
+
+        # Candidate 1: LWC only (no LET) -- clip_ratio=1.0 is always tried
+        # first and is exactly quantize_weight_only_int4's own scale, so
+        # this candidate can only match or improve on plain RTN.
+        best_codes_nk, best_scale_blocks = _quantize_blockwise_int4_with_clip(
+            w_nk, c.block_size, 1.0
+        )
+        best_err = _reconstruction_error(
+            x,
+            y_float,
+            best_codes_nk * np.repeat(best_scale_blocks, c.block_size, axis=1),
+            None,
+            None,
+            None,
+            None,
+        )
+        best_clip_ratio = 1.0
+        for clip_ratio in clip_ratios[1:]:
+            codes_nk, scale_blocks = _quantize_blockwise_int4_with_clip(
+                w_nk, c.block_size, clip_ratio
+            )
+            w_hat_nk = codes_nk * np.repeat(scale_blocks, c.block_size, axis=1)
+            err = _reconstruction_error(x, y_float, w_hat_nk, None, None, None, None)
+            if err < best_err:
+                best_err = err
+                best_clip_ratio = clip_ratio
+                best_codes_nk, best_scale_blocks = codes_nk, scale_blocks
+
+        shift = np.mean(x, axis=0)  # [K]
+        x_centered = x - shift[np.newaxis, :]
+
+        best_channel_scale = None
+        best_shift = None
+        best_rotation = None
+        best_bias_correction = None
+
+        # Candidate 2: diagonal LET (OmniQuant's own transform) on top of
+        # the best LWC ratio found -- alpha == 0 (no transform) is
+        # already covered by candidate 1, so only alpha > 0 is tried.
+        weight_col_absmax = np.maximum(np.abs(w_nk).max(axis=0), 1e-12)  # [K]
+        act_col_absmax = np.maximum(np.abs(x_centered).mean(axis=0), 1e-12)  # [K]
+        bias_correction = w_nk @ shift  # [N]
+        for channel_scale in _diagonal_scale_grid(
+            weight_col_absmax, act_col_absmax, alphas[1:]
+        ):
+            w_scaled_nk = w_nk * channel_scale[np.newaxis, :]
+            codes_nk, scale_blocks = _quantize_blockwise_int4_with_clip(
+                w_scaled_nk, c.block_size, best_clip_ratio
+            )
+            w_hat_nk = codes_nk * np.repeat(scale_blocks, c.block_size, axis=1)
+            err = _reconstruction_error(
+                x, y_float, w_hat_nk, shift, None, channel_scale, bias_correction
+            )
+            if err < best_err:
+                best_err = err
+                best_codes_nk, best_scale_blocks = codes_nk, scale_blocks
+                best_channel_scale = channel_scale
+                best_shift = shift
+                best_rotation = None
+                best_bias_correction = bias_correction
+
+        # Candidate 3: block-affine LET -- this module's own contribution.
+        # Only attempted when K divides evenly into affine_block_size
+        # blocks (see the "Scope" docstring section); otherwise this
+        # candidate is skipped and the search falls back to whichever of
+        # (1)/(2) already won above.
+        if affine_block_size >= 1 and k % affine_block_size == 0:
+            rotation = _block_diagonal_rotation(x_centered, affine_block_size)
+            x_rot = x_centered @ rotation
+            w_rot_nk = w_nk @ rotation
+            weight_col_absmax_rot = np.maximum(np.abs(w_rot_nk).max(axis=0), 1e-12)
+            act_col_absmax_rot = np.maximum(np.abs(x_rot).mean(axis=0), 1e-12)
+            for channel_scale in _diagonal_scale_grid(
+                weight_col_absmax_rot, act_col_absmax_rot, alphas[1:]
+            ):
+                w_hat_rot_nk = w_rot_nk * channel_scale[np.newaxis, :]
+                codes_nk, scale_blocks = _quantize_blockwise_int4_with_clip(
+                    w_hat_rot_nk, c.block_size, best_clip_ratio
+                )
+                w_hat_nk = codes_nk * np.repeat(scale_blocks, c.block_size, axis=1)
+                err = _reconstruction_error(
+                    x,
+                    y_float,
+                    w_hat_nk,
+                    shift,
+                    rotation,
+                    channel_scale,
+                    bias_correction,
+                )
+                if err < best_err:
+                    best_err = err
+                    best_codes_nk, best_scale_blocks = codes_nk, scale_blocks
+                    best_channel_scale = channel_scale
+                    best_shift = shift
+                    best_rotation = rotation
+                    best_bias_correction = bias_correction
+
+        codes_orig = best_codes_nk if c.weight_transposed else best_codes_nk.T
+        scale_orig = best_scale_blocks if c.weight_transposed else best_scale_blocks.T
+        assert codes_orig.shape == (dim0, dim1)
+        rewrites.append(
+            _AffineQuantRewrite(
+                output_name=c.output_name,
+                activation_name=c.float_node.input[0],
+                wq_name=c.wq_name,
+                ws_name=c.ws_init.name,
+                codes=codes_orig.astype(np.int8),
+                scale=scale_orig.astype(np.float32),
+                channel_scale=best_channel_scale,
+                shift=best_shift,
+                rotation=best_rotation,
+                bias_correction=best_bias_correction,
+            )
+        )
+
+    if not rewrites:
+        return quantized_model
+
+    corrected = onnx.ModelProto()
+    corrected.CopyFrom(quantized_model)
+
+    codes_by_name = {r.wq_name: r.codes for r in rewrites}
+    scale_by_name = {r.ws_name: r.scale for r in rewrites}
+    for t in corrected.graph.initializer:
+        codes = codes_by_name.get(t.name)
+        if codes is not None:
+            t.raw_data = _pack_int4(codes)
+        scale = scale_by_name.get(t.name)
+        if scale is not None:
+            t.CopyFrom(onnx.numpy_helper.from_array(scale, name=t.name))
+
+    taken_names: Set[str] = _all_names(corrected.graph)
+    q_by_output = _node_outputs(corrected.graph)
+    for r in rewrites:
+        if r.channel_scale is None or r.shift is None or r.bias_correction is None:
+            continue
+        qn = q_by_output[r.output_name]
+        act_input = r.activation_name
+        inv_scale = (1.0 / r.channel_scale).astype(np.float32)
+
+        shift_name = _unique_name(f"{act_input}_affinequant_shift", taken_names)
+        corrected.graph.initializer.append(
+            onnx.numpy_helper.from_array(r.shift.astype(np.float32), name=shift_name)
+        )
+        centered_name = _unique_name(f"{act_input}_affinequant_centered", taken_names)
+        sub_node = onnx.helper.make_node(
+            "Sub",
+            [act_input, shift_name],
+            [centered_name],
+            name=_unique_name(f"{act_input}_affinequant_sub", taken_names),
+        )
+        node_idx = next(i for i, n in enumerate(corrected.graph.node) if n is qn)
+        corrected.graph.node.insert(node_idx, sub_node)
+        node_idx += 1
+
+        rotated_name = centered_name
+        if r.rotation is not None:
+            rotation_name = _unique_name(
+                f"{act_input}_affinequant_rotation", taken_names
+            )
+            corrected.graph.initializer.append(
+                onnx.numpy_helper.from_array(
+                    r.rotation.astype(np.float32), name=rotation_name
+                )
+            )
+            rotated_name = _unique_name(f"{act_input}_affinequant_rotated", taken_names)
+            matmul_node = onnx.helper.make_node(
+                "MatMul",
+                [centered_name, rotation_name],
+                [rotated_name],
+                name=_unique_name(f"{act_input}_affinequant_matmul", taken_names),
+            )
+            corrected.graph.node.insert(node_idx, matmul_node)
+            node_idx += 1
+
+        inv_scale_name = _unique_name(f"{act_input}_affinequant_inv_scale", taken_names)
+        corrected.graph.initializer.append(
+            onnx.numpy_helper.from_array(inv_scale, name=inv_scale_name)
+        )
+        scaled_name = _unique_name(f"{act_input}_affinequant_scaled", taken_names)
+        mul_node = onnx.helper.make_node(
+            "Mul",
+            [rotated_name, inv_scale_name],
+            [scaled_name],
+            name=_unique_name(f"{act_input}_affinequant_mul", taken_names),
+        )
+        corrected.graph.node.insert(node_idx, mul_node)
+        qn.input[0] = scaled_name
+
+        old_output = qn.output[0]
+        base_name = _unique_name(f"{r.output_name}_affinequant_base", taken_names)
+        qn.output[0] = base_name
+        bias_name = _unique_name(f"{r.output_name}_affinequant_bias", taken_names)
+        corrected.graph.initializer.append(
+            onnx.numpy_helper.from_array(
+                r.bias_correction.astype(np.float32), name=bias_name
+            )
+        )
+        add_node = onnx.helper.make_node(
+            "Add",
+            [base_name, bias_name],
+            [old_output],
+            name=_unique_name(f"{r.output_name}_affinequant_bias_add", taken_names),
+        )
+        qn_idx = next(i for i, n in enumerate(corrected.graph.node) if n is qn)
+        corrected.graph.node.insert(qn_idx + 1, add_node)
+
+    return corrected

--- a/tests/test_affinequant.py
+++ b/tests/test_affinequant.py
@@ -1,0 +1,321 @@
+"""Tests for ``onnxsim.apply_affinequant`` (AffineQuant, see
+``onnxsim/affinequant.py``) -- grid-searches a per-block Learnable Weight
+Clipping ratio, then chooses among a no-transform, a diagonal (OmniQuant
+-equivalent), or a block-diagonal-affine Learnable Equivalent
+Transformation, on top of an existing ``quantize_weight_only_int4``
+-quantized model.
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
+
+
+def _matmul_model(K=64, N=16, weight=None, seed=0):
+    if weight is None:
+        rng = np.random.default_rng(seed)
+        weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [_f32(weight, "W")],
+    )
+
+
+def _correlated_outlier_calibration(K=64, num_samples=64, outlier_dims=(3, 7), seed=1):
+    # A calibration set with a nonzero per-channel mean (the shift should
+    # help), a couple of channels with much larger magnitude (LWC's
+    # clipping and the diagonal scale should help), and cross-channel
+    # correlation baked in (adjacent channels are linear combinations of a
+    # shared latent factor) -- a case a *diagonal* transform structurally
+    # cannot exploit (it can only rescale each channel on its own) but a
+    # block-affine transform can, by rotating into the block's own
+    # covariance eigenbasis.
+    rng = np.random.default_rng(seed)
+    num_blocks = K // 8
+    latent = rng.standard_normal((num_samples, num_blocks)).astype(np.float32)
+    mixing = rng.standard_normal((num_blocks, 8)).astype(np.float32)
+    x = (latent[:, :, None] * mixing[None, :, :]).reshape(num_samples, K)
+    x = x + rng.standard_normal((num_samples, K)).astype(np.float32) * 0.05
+    x = x.astype(np.float32) + 2.0
+    for c in outlier_dims:
+        x[:, c] *= 20.0
+    return x
+
+
+def _dequantize_int4(model):
+    dq_node = next(n for n in model.graph.node if n.op_type == "DequantizeLinear")
+    wq = next(t for t in model.graph.initializer if t.name == dq_node.input[0])
+    ws = next(t for t in model.graph.initializer if t.name == dq_node.input[1])
+    block_size = next(a.i for a in dq_node.attribute if a.name == "block_size")
+    axis = next((a.i for a in dq_node.attribute if a.name == "axis"), 1)
+
+    codes = onnx.numpy_helper.to_array(wq).astype(np.float64)
+    scale = onnx.numpy_helper.to_array(ws).astype(np.float64)
+    scale_full = np.repeat(scale, block_size, axis=axis)
+    slicer = [slice(None)] * codes.ndim
+    slicer[axis] = slice(0, codes.shape[axis])
+    return codes * scale_full[tuple(slicer)]
+
+
+def test_affinequant_reduces_reconstruction_error_with_correlated_outliers():
+    model = _matmul_model(K=64, N=16, seed=0)
+    x = _correlated_outlier_calibration(K=64, num_samples=64, seed=1)
+    calibration_data = [{"X": x}]
+
+    quant = onnxsim.quantize_weight_only_int4(model)
+    w_float = onnx.numpy_helper.to_array(model.graph.initializer[0]).astype(np.float64)
+    w_rtn = _dequantize_int4(quant)
+    y_float = x.astype(np.float64) @ w_float
+    y_rtn = x.astype(np.float64) @ w_rtn
+    rtn_err = np.linalg.norm(y_float - y_rtn)
+
+    aq_model = onnxsim.apply_affinequant(
+        model, quant, calibration_data=calibration_data, affine_block_size=8
+    )
+    onnx.checker.check_model(aq_model)
+
+    (float_y,) = _run(model, {"X": x})
+    (aq_y,) = _run(aq_model, {"X": x})
+    aq_err = np.linalg.norm(y_float - aq_y.astype(np.float64))
+    assert aq_err < rtn_err
+
+
+def test_affinequant_output_stays_close_to_float_via_onnxruntime():
+    model = _matmul_model(K=64, N=16, seed=2)
+    x = _correlated_outlier_calibration(K=64, num_samples=32, seed=3)
+    calibration_data = [{"X": x}]
+
+    aq_model = onnxsim.apply_affinequant(
+        model,
+        onnxsim.quantize_weight_only_int4(model),
+        calibration_data=calibration_data,
+        affine_block_size=8,
+    )
+    onnx.checker.check_model(aq_model)
+
+    (float_y,) = _run(model, {"X": x})
+    (aq_y,) = _run(aq_model, {"X": x})
+    assert np.all(np.isfinite(aq_y))
+    assert _rel_l2(float_y, aq_y) < 0.25
+
+
+def test_affinequant_never_worse_than_diagonal_omniquant():
+    # AffineQuant's own block-affine candidate is a strict superset of
+    # OmniQuant's diagonal LET (R=I is always reachable as a degenerate
+    # block-affine choice, and is exactly what candidate 2 already
+    # searches on its own), so AffineQuant's chosen reconstruction error
+    # can never exceed OmniQuant's, on the same data/model/search grid.
+    model = _matmul_model(K=64, N=16, seed=4)
+    x = _correlated_outlier_calibration(K=64, num_samples=48, seed=5)
+    calibration_data = [{"X": x}]
+
+    quant = onnxsim.quantize_weight_only_int4(model)
+    w_float = onnx.numpy_helper.to_array(model.graph.initializer[0]).astype(np.float64)
+    y_float = x.astype(np.float64) @ w_float
+
+    oq_model = onnxsim.apply_omniquant(model, quant, calibration_data=calibration_data)
+    aq_model = onnxsim.apply_affinequant(
+        model, quant, calibration_data=calibration_data, affine_block_size=8
+    )
+
+    (oq_y,) = _run(oq_model, {"X": x})
+    (aq_y,) = _run(aq_model, {"X": x})
+    oq_err = np.linalg.norm(y_float - oq_y.astype(np.float64))
+    aq_err = np.linalg.norm(y_float - aq_y.astype(np.float64))
+    assert aq_err <= oq_err + 1e-6
+
+
+def test_affinequant_never_worse_than_plain_rtn():
+    # Every candidate this module searches (LWC-only, diagonal LET,
+    # block-affine LET) always includes "no change" / "no transform" as a
+    # reachable choice (clip_ratio=1.0 for LWC, alpha=0 for both LET
+    # variants), so the chosen reconstruction error can never be worse
+    # than plain RTN's, only equal or better -- mirroring
+    # ``onnxsim.apply_omniquant``'s own analogous guarantee.
+    model = _matmul_model(K=32, N=8, seed=6)
+    rng = np.random.default_rng(7)
+    x = rng.standard_normal((16, 32)).astype(np.float32)  # zero-mean, no outliers
+    calibration_data = [{"X": x}]
+
+    quant = onnxsim.quantize_weight_only_int4(model)
+    aq_model = onnxsim.apply_affinequant(
+        model, quant, calibration_data=calibration_data, affine_block_size=8
+    )
+
+    w_float = onnx.numpy_helper.to_array(model.graph.initializer[0]).astype(np.float64)
+    y_float = x.astype(np.float64) @ w_float
+    w_rtn = _dequantize_int4(quant)
+    rtn_err = np.linalg.norm(y_float - x.astype(np.float64) @ w_rtn)
+
+    (aq_y,) = _run(aq_model, {"X": x})
+    aq_err = np.linalg.norm(y_float - aq_y.astype(np.float64))
+    assert aq_err <= rtn_err + 1e-6
+
+
+def test_affinequant_rotation_matrix_is_block_diagonal_and_orthogonal():
+    # Directly verifies the numerical contract this module's docstring
+    # promises: the inserted rotation is exactly block-diagonal (zero
+    # outside affine_block_size x affine_block_size blocks along the
+    # diagonal) and exactly orthogonal (R @ R.T == I), checked against the
+    # ONNX initializers themselves with a tight relative tolerance -- not
+    # via an onnxruntime round trip, since onnxruntime's own MatMul kernel
+    # reduction order is not bit-exact across CPU architectures.
+    K, N, block = 32, 8, 8
+    model = _matmul_model(K=K, N=N, seed=8)
+    x = _correlated_outlier_calibration(
+        K=K, num_samples=64, outlier_dims=(2, 9), seed=9
+    )
+    calibration_data = [{"X": x}]
+
+    quant = onnxsim.quantize_weight_only_int4(model)
+    aq_model = onnxsim.apply_affinequant(
+        model, quant, calibration_data=calibration_data, affine_block_size=block
+    )
+    onnx.checker.check_model(aq_model)
+
+    matmul_nodes = [n for n in aq_model.graph.node if n.op_type == "MatMul"]
+    assert len(matmul_nodes) == 1
+    rotation_name = matmul_nodes[0].input[1]
+    rotation = onnx.numpy_helper.to_array(
+        next(t for t in aq_model.graph.initializer if t.name == rotation_name)
+    ).astype(np.float64)
+
+    assert rotation.shape == (K, K)
+    np.testing.assert_allclose(rotation @ rotation.T, np.eye(K), atol=1e-4, rtol=1e-4)
+    off_block = rotation.copy()
+    for start in range(0, K, block):
+        stop = start + block
+        off_block[start:stop, start:stop] = 0.0
+    np.testing.assert_allclose(off_block, np.zeros((K, K)), atol=1e-6)
+
+
+def test_affinequant_odd_k_skips_block_affine_candidate():
+    # K=48 is not evenly divisible by affine_block_size=32, so the
+    # block-affine candidate must be skipped for that layer (falling back
+    # to the diagonal or LWC-only candidate) rather than erroring.
+    model = _matmul_model(K=48, N=8, seed=10)
+    x = _correlated_outlier_calibration(
+        K=48, num_samples=32, outlier_dims=(4,), seed=11
+    )
+    calibration_data = [{"X": x}]
+
+    quant = onnxsim.quantize_weight_only_int4(model)
+    aq_model = onnxsim.apply_affinequant(
+        model, quant, calibration_data=calibration_data, affine_block_size=32
+    )
+    onnx.checker.check_model(aq_model)
+    assert not any(n.op_type == "MatMul" for n in aq_model.graph.node)
+
+
+def test_affinequant_gemm_transb():
+    rng = np.random.default_rng(12)
+    K, N = 96, 12
+    weight = rng.standard_normal((N, K)).astype(np.float32) * 0.5
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = Gemm<transB = 1>(X, W)
+        }}
+        """,
+        [_f32(weight, "W")],
+    )
+    quant = onnxsim.quantize_weight_only_int4(model)
+    onnx.checker.check_model(quant)
+
+    x = _correlated_outlier_calibration(
+        K=K, num_samples=32, outlier_dims=(10, 50), seed=13
+    )
+    calibration_data = [{"X": x}]
+
+    aq_model = onnxsim.apply_affinequant(
+        model, quant, calibration_data=calibration_data, affine_block_size=8
+    )
+    onnx.checker.check_model(aq_model)
+
+    (float_y,) = _run(model, {"X": x})
+    (aq_y,) = _run(aq_model, {"X": x})
+    assert _rel_l2(float_y, aq_y) < 0.25
+
+
+def test_affinequant_codes_stay_in_range():
+    model = _matmul_model(K=32, N=8, seed=14)
+    x = _correlated_outlier_calibration(
+        K=32, num_samples=16, outlier_dims=(1,), seed=15
+    )
+    calibration_data = [{"X": x}]
+
+    quant = onnxsim.quantize_weight_only_int4(model)
+    aq_model = onnxsim.apply_affinequant(
+        model, quant, calibration_data=calibration_data, affine_block_size=8
+    )
+    wq = next(
+        t for t in aq_model.graph.initializer if t.data_type == onnx.TensorProto.INT4
+    )
+    numel = int(np.prod(list(wq.dims)))
+    raw = np.frombuffer(wq.raw_data, dtype=np.uint8)
+    lo = (raw & 0x0F).astype(np.int8)
+    hi = ((raw >> 4) & 0x0F).astype(np.int8)
+    lo = np.where(lo >= 8, lo - 16, lo)
+    hi = np.where(hi >= 8, hi - 16, hi)
+    codes = np.empty(numel, dtype=np.int8)
+    codes[0::2] = lo[: (numel + 1) // 2]
+    codes[1::2] = hi[: numel // 2]
+    assert np.all(codes >= -7) and np.all(codes <= 7)
+
+
+def test_affinequant_noop_when_no_int4_matmul_present():
+    model = _model(
+        """
+        g (float[4,4] X) => (float[4,4] Y)
+        {
+          Y = Relu(X)
+        }
+        """
+    )
+    result = onnxsim.apply_affinequant(
+        model, model, calibration_data=[{"X": np.zeros((4, 4), dtype=np.float32)}]
+    )
+    assert result.SerializeToString() == model.SerializeToString()

--- a/tests/test_affinequant.py
+++ b/tests/test_affinequant.py
@@ -194,18 +194,71 @@ def test_affinequant_never_worse_than_plain_rtn():
     assert aq_err <= rtn_err + 1e-6
 
 
-def test_affinequant_rotation_matrix_is_block_diagonal_and_orthogonal():
+def test_block_diagonal_rotation_is_orthogonal_and_block_diagonal():
     # Directly verifies the numerical contract this module's docstring
-    # promises: the inserted rotation is exactly block-diagonal (zero
-    # outside affine_block_size x affine_block_size blocks along the
-    # diagonal) and exactly orthogonal (R @ R.T == I), checked against the
-    # ONNX initializers themselves with a tight relative tolerance -- not
-    # via an onnxruntime round trip, since onnxruntime's own MatMul kernel
-    # reduction order is not bit-exact across CPU architectures.
-    K, N, block = 32, 8, 8
-    model = _matmul_model(K=K, N=N, seed=8)
-    x = _correlated_outlier_calibration(
-        K=K, num_samples=64, outlier_dims=(2, 9), seed=9
+    # promises for its own core building block: the rotation is exactly
+    # orthogonal (R @ R.T == I -- so its inverse, used to compensate the
+    # weight side, is exactly its own transpose, no numerical solve
+    # needed) and exactly block-diagonal (zero outside each
+    # affine_block_size x affine_block_size block along the diagonal),
+    # checked directly against the returned numpy array with a tight
+    # tolerance -- not via an onnxruntime round trip, since onnxruntime's
+    # own MatMul kernel reduction order is not bit-exact across CPU
+    # architectures.
+    from onnxsim.affinequant import _block_diagonal_rotation
+
+    rng = np.random.default_rng(0)
+    k, block = 32, 8
+    x_centered = rng.standard_normal((64, k))
+
+    rotation = _block_diagonal_rotation(x_centered, block)
+
+    assert rotation.shape == (k, k)
+    np.testing.assert_allclose(rotation @ rotation.T, np.eye(k), atol=1e-8, rtol=1e-8)
+    off_block = rotation.copy()
+    for start in range(0, k, block):
+        stop = start + block
+        off_block[start:stop, start:stop] = 0.0
+    np.testing.assert_allclose(off_block, np.zeros((k, k)), atol=0.0)
+
+
+def _block_correlated_calibration(
+    K, block, num_samples, outlier_dims, seed, noise=0.005
+):
+    # Within each block, every channel is (up to small noise) a shared
+    # scalar latent factor times its own per-channel mixing weight -- a
+    # case a *diagonal* transform structurally cannot exploit (it can
+    # only rescale each channel on its own, not combine correlated ones),
+    # but a block-affine transform can, by rotating into the block's own
+    # covariance eigenbasis and concentrating the block's real variance
+    # into as few post-rotation channels as possible.
+    rng = np.random.default_rng(seed)
+    num_blocks = K // block
+    latent = rng.standard_normal((num_samples, num_blocks)).astype(np.float32)
+    mixing = rng.standard_normal((num_blocks, block)).astype(np.float32)
+    x = (latent[:, :, None] * mixing[None, :, :]).reshape(num_samples, K)
+    x = x + rng.standard_normal((num_samples, K)).astype(np.float32) * noise
+    x = x.astype(np.float32) + 2.0
+    for c in outlier_dims:
+        x[:, c] *= 20.0
+    return x
+
+
+def test_affinequant_block_affine_beats_diagonal_omniquant_on_correlated_channels():
+    # A scenario deliberately constructed to demonstrate this module's
+    # own core claim over onnxsim.apply_omniquant: with strongly
+    # correlated (not just independently-scaled) activation channels
+    # within a block, the block-affine LET candidate is chosen over the
+    # diagonal one and measurably reduces reconstruction error further
+    # than OmniQuant's diagonal-only transform can reach on the same
+    # data/model. (This complements
+    # ``test_affinequant_never_worse_than_diagonal_omniquant``, which
+    # only checks the "never worse" direction on data without deliberate
+    # cross-channel structure.)
+    K, N, block = 64, 16, 16
+    model = _matmul_model(K=K, N=N, seed=7)
+    x = _block_correlated_calibration(
+        K, block, num_samples=64, outlier_dims=(3, 7), seed=11
     )
     calibration_data = [{"X": x}]
 
@@ -215,20 +268,33 @@ def test_affinequant_rotation_matrix_is_block_diagonal_and_orthogonal():
     )
     onnx.checker.check_model(aq_model)
 
-    matmul_nodes = [n for n in aq_model.graph.node if n.op_type == "MatMul"]
-    assert len(matmul_nodes) == 1
-    rotation_name = matmul_nodes[0].input[1]
+    # There are two MatMul nodes in the final graph: the original
+    # activation-times-dequantized-weight computation (present in every
+    # quantized model, affine transform or not) and this module's own
+    # inserted rotation MatMul -- identified by name, not by being the
+    # only MatMul present.
+    rotation_matmuls = [
+        n
+        for n in aq_model.graph.node
+        if n.op_type == "MatMul" and "affinequant_matmul" in n.name
+    ]
+    assert len(rotation_matmuls) == 1
+    rotation_name = rotation_matmuls[0].input[1]
     rotation = onnx.numpy_helper.to_array(
         next(t for t in aq_model.graph.initializer if t.name == rotation_name)
     ).astype(np.float64)
-
     assert rotation.shape == (K, K)
     np.testing.assert_allclose(rotation @ rotation.T, np.eye(K), atol=1e-4, rtol=1e-4)
-    off_block = rotation.copy()
-    for start in range(0, K, block):
-        stop = start + block
-        off_block[start:stop, start:stop] = 0.0
-    np.testing.assert_allclose(off_block, np.zeros((K, K)), atol=1e-6)
+
+    w_float = onnx.numpy_helper.to_array(model.graph.initializer[0]).astype(np.float64)
+    y_float = x.astype(np.float64) @ w_float
+
+    oq_model = onnxsim.apply_omniquant(model, quant, calibration_data=calibration_data)
+    (oq_y,) = _run(oq_model, {"X": x})
+    (aq_y,) = _run(aq_model, {"X": x})
+    oq_err = np.linalg.norm(y_float - oq_y.astype(np.float64))
+    aq_err = np.linalg.norm(y_float - aq_y.astype(np.float64))
+    assert aq_err < oq_err * 0.5
 
 
 def test_affinequant_odd_k_skips_block_affine_candidate():
@@ -246,7 +312,10 @@ def test_affinequant_odd_k_skips_block_affine_candidate():
         model, quant, calibration_data=calibration_data, affine_block_size=32
     )
     onnx.checker.check_model(aq_model)
-    assert not any(n.op_type == "MatMul" for n in aq_model.graph.node)
+    # The base computation MatMul is always present; only this module's
+    # own rotation MatMul must be absent when the block-affine candidate
+    # is skipped.
+    assert not any("affinequant_matmul" in n.name for n in aq_model.graph.node)
 
 
 def test_affinequant_gemm_transb():


### PR DESCRIPTION
## Summary

Adds `onnxsim.apply_affinequant` (AffineQuant, Ma et al., 2024, ICLR, "AffineQuant: Affine Transformation Quantization for Large Language Models", https://arxiv.org/abs/2403.12544) — a new weight-only INT4 quantization refinement pass, a direct sibling of `onnxsim.apply_omniquant`.

AffineQuant's own paper frames it explicitly as a generalization of OmniQuant's Learnable Equivalent Transformation (LET): where OmniQuant (and SmoothQuant before it) migrates activation quantization difficulty into the weight via a *diagonal* per-channel scale/shift, AffineQuant optimizes a full *invertible affine transformation matrix*, which can also mix/rotate channels against each other, not just rescale each one independently — strictly more representational freedom at higher compensation cost.

## What's added / scope

- `onnxsim/affinequant.py` — `apply_affinequant(float_model, quantized_model, ...)`, targeting the exact same shape `onnxsim/omniquant.py` targets: every `quantize_weight_only_int4`-quantized MatMul/Gemm layer (2-D activation input), by node output name, present in both the float and quantized model.
- **Scope tradeoff (documented in the module docstring):** the paper's own dense per-layer transformation matrix doesn't fit this repo's closed-form/grid-search style (no autodiff loop) — a dense `K x K` matrix is expensive to search without gradients and numerically fragile to invert for compensation. This module instead restricts the transform to **block-diagonal** (configurable `affine_block_size`, default 8): each block gets its own small, independently-invertible square matrix, with zero cross-block coupling. This keeps the per-block search/solve tractable and the weight-side compensation an efficient block-diagonal matrix multiply.
- **Search strategy:** per layer, three candidates are tried and the empirically-best (lowest weight reconstruction error against real calibration activations) is kept:
  1. No transform — LWC-only (`onnxsim.omniquant`'s own grid-searched clip ratio, reused unchanged).
  2. Diagonal LET — `onnxsim.omniquant`'s own closed-form shift + alpha-grid-searched per-channel scale, reused unchanged.
  3. Block-affine LET (this module's own contribution) — a closed-form block-diagonal *orthogonal* rotation (eigenvectors of each block's own calibration activation covariance via `numpy.linalg.eigh`, so it's exactly invertible via its own transpose, no numerical solve) followed by the same alpha-grid-searched diagonal scale, now computed in the rotated basis.
  Because a rotation is orthogonal, candidate 2 is exactly candidate 3 restricted to `R = I`, so candidate 3 can only match or beat candidate 2, which can only match or beat candidate 1 — the same "never worse than the previous stage" guarantee `onnxsim.omniquant` already has relative to plain RTN.
- Like `onnxsim.apply_omniquant` (and unlike a pure migration module such as `onnxsim.smoothquant`/`onnxsim.outlier_suppression`), this does not return a plain float model for a separate later quantizer — the transform choice is optimized jointly against the INT4 quantization error itself, matching both papers' own LET framework. This is called out explicitly in the module docstring as a deliberate scope choice.
- Registered in `onnxsim/__init__.py` (import + `__all__`), immediately after `apply_omniquant`.
- `tests/test_affinequant.py` — built with `onnx.parser.parse_model()` per this repo's convention, mirroring `tests/test_omniquant.py`'s structure (10 tests): reconstruction-error reduction vs. plain RTN, onnxruntime sanity check, "never worse than diagonal OmniQuant" and "never worse than plain RTN" invariants, a direct unit test of the rotation-building helper (orthogonality + block-diagonal structure), a deterministic scenario demonstrating block-affine beating diagonal OmniQuant by >2x on correlated activation channels, Gemm `transB=1` support, INT4 code range, and a no-op case.

## Test plan

All commands run from a full local build (`git submodule update --init --recursive && pip install -e . --no-build-isolation -v`, no ONNX Runtime C++ build required per this repo's `CLAUDE.md`).

- `pytest tests/test_affinequant.py -v` → **10 passed**
- `pytest tests/test_omniquant.py -v` → **6 passed** (no regression in the sibling module)
- `ruff check onnxsim/affinequant.py tests/test_affinequant.py onnxsim/__init__.py` → **All checks passed!**
- `ruff format --check onnxsim/affinequant.py tests/test_affinequant.py` → **2 files already formatted**
- `mypy onnxsim/affinequant.py` → **Success: no issues found in 1 source file**

Merged `origin/master` in (no conflicts; the incoming changes were an unrelated C++ structured-pruning entry point and workflow tweaks) and re-ran the full test/lint suite above against the merged tree with the same results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeRWvBCUG9E25V445Hc5H5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QeRWvBCUG9E25V445Hc5H5)_