### PR TITLE
Port MoE and QMoE expert-channel structured pruning to C++

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -63,6 +63,7 @@ from onnxsim.omniquant import apply_omniquant
 from onnxsim.onnx_simplifier import (
     apply_attention_head_pruning_cpp,
     apply_double_quantization_cpp,
+    apply_moe_expert_channel_pruning_cpp,
     apply_qmoe_expert_channel_pruning_cpp,
     apply_quarot_cpp,
     apply_structured_pruning_cpp,
@@ -205,6 +206,7 @@ __all__ = [
     "apply_attention_head_pruning_cpp",
     "apply_attention_head_wanda_pruning",
     "apply_moe_expert_channel_pruning",
+    "apply_moe_expert_channel_pruning_cpp",
     "apply_moe_whole_expert_pruning",
     "apply_qmoe_expert_channel_pruning",
     "apply_qmoe_expert_channel_pruning_cpp",

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -63,6 +63,7 @@ from onnxsim.omniquant import apply_omniquant
 from onnxsim.onnx_simplifier import (
     apply_attention_head_pruning_cpp,
     apply_double_quantization_cpp,
+    apply_qmoe_expert_channel_pruning_cpp,
     apply_quarot_cpp,
     apply_structured_pruning_cpp,
     cross_layer_equalize,
@@ -206,6 +207,7 @@ __all__ = [
     "apply_moe_expert_channel_pruning",
     "apply_moe_whole_expert_pruning",
     "apply_qmoe_expert_channel_pruning",
+    "apply_qmoe_expert_channel_pruning_cpp",
     "apply_qmoe_whole_expert_pruning",
     "apply_embedding_vocab_pruning",
     "apply_embedding_vocab_magnitude_pruning",

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -636,6 +636,24 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
       },
       "model_bytes"_a, "sparsity"_a);
 
+  // QMoE expert-channel pruning: removes intermediate (inter_size) channels
+  // from every expert of a matched com.microsoft::QMoE node -- the
+  // quantized-weight counterpart of apply_structured_pruning. See
+  // ApplyQMoEExpertChannelPruning in onnxsim.h.
+  m.def(
+      "apply_qmoe_expert_channel_pruning",
+      [](const py::bytes& model_proto_bytes, double sparsity) -> py::bytes {
+        InitEnv();
+        ONNX_NAMESPACE::ModelProto model;
+        ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
+                            model_proto_bytes.size());
+        const auto result = ApplyQMoEExpertChannelPruning(model, sparsity);
+        std::string out;
+        result.SerializeToString(&out);
+        return py::bytes(out.data(), out.size());
+      },
+      "model_bytes"_a, "sparsity"_a);
+
   // QuaRot (Ashkboos et al., 2024): rotation preprocessing plus INT4
   // round-to-nearest quantization of both the weight and the activation of
   // every MatMul/vanilla-Gemm layer. Data-free. See ApplyQuarot in

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -636,6 +636,25 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
       },
       "model_bytes"_a, "sparsity"_a);
 
+  // MoE expert-intermediate-channel pruning: removes intermediate
+  // (`inter_size`) channels from every expert of a matched
+  // `com.microsoft::MoE` node at once -- real structural pruning, data-free.
+  // Whole-expert pruning (shrinking `num_experts` itself) is NOT ported --
+  // see ApplyMoeExpertChannelPruning in structured_pruning_entry.h.
+  m.def(
+      "apply_moe_expert_channel_pruning",
+      [](const py::bytes& model_proto_bytes, double sparsity) -> py::bytes {
+        InitEnv();
+        ONNX_NAMESPACE::ModelProto model;
+        ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
+                            model_proto_bytes.size());
+        const auto result = ApplyMoeExpertChannelPruning(model, sparsity);
+        std::string out;
+        result.SerializeToString(&out);
+        return py::bytes(out.data(), out.size());
+      },
+      "model_bytes"_a, "sparsity"_a);
+
   // QMoE expert-channel pruning: removes intermediate (inter_size) channels
   // from every expert of a matched com.microsoft::QMoE node -- the
   // quantized-weight counterpart of apply_structured_pruning. See

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -1419,6 +1419,69 @@ def apply_attention_head_pruning_cpp(
     )
 
 
+def apply_moe_expert_channel_pruning_cpp(
+    model: Union[str, onnx.ModelProto],
+    sparsity: float = 0.5,
+) -> onnx.ModelProto:
+    """
+    C++-backed port of :func:`onnxsim.apply_moe_expert_channel_pruning`:
+    removes intermediate (``inter_size``) channels from every expert of a
+    matched ``com.microsoft::MoE`` node at once -- real structural pruning
+    (smaller ``fc1_experts_weights``/``fc2_experts_weights``, smaller
+    per-expert matmuls on any runtime), as opposed to value-only zeroing.
+
+    For every matched ``MoE`` node: ranks every ``inter_size`` index by
+    combined (root-sum-square) L2 norm of ``fc1_experts_weights``' own row
+    (across every expert and ``hidden_size`` at once) and
+    ``fc2_experts_weights``' own column (same reduction), plus
+    ``fc1_experts_bias``'s own entry when present, drops the lowest-
+    ``sparsity``-fraction of indices (at least one is always kept), and
+    removes the matching row from ``fc1_experts_weights``/
+    ``fc1_experts_bias`` and column from ``fc2_experts_weights``, identically
+    across every expert. ``num_experts``, ``k``, and every node attribute are
+    untouched -- pruning ``inter_size`` changes no other tensor's shape
+    anywhere in the graph, including the node's own output (always equal to
+    ``input``'s shape).
+
+    A node with ``fc3_experts_weights`` present, a ``swiglu``/unrecognized
+    ``activation_type`` (or nonzero ``swiglu_fusion``), a non-constant or
+    tied/shared ``fc1``/``fc2`` weight (or bias), or a shape this pass
+    doesn't recognize (e.g. mismatched ``hidden_size`` between
+    ``fc1_experts_weights``/``fc2_experts_weights``) is left completely
+    untouched -- the same conservative "decline rather than mis-slice" bar
+    every other chain-matcher in this codebase holds.
+
+    Unlike the pure-Python :func:`onnxsim.apply_moe_expert_channel_pruning`,
+    ``fc1_experts_weights``/``fc2_experts_weights``/``fc1_experts_bias`` are
+    admitted only as plain FLOAT (float32) tensors here, not also FLOAT16/
+    BFLOAT16 -- matching this codebase's own established narrower-than-
+    pruning.py C++-port scope decision elsewhere (e.g.
+    :func:`onnxsim.apply_structured_pruning_cpp`'s own ``MatMulNBits``
+    ``scales``/``zero_points``/``bias`` restriction). Whole-expert pruning
+    (shrinking ``num_experts`` itself -- :func:`onnxsim.apply_moe_whole_expert_
+    pruning`, which needs runtime calibration data via an
+    ``onnxruntime.InferenceSession`` observing router activations) is a
+    deliberately separate, NOT-ported feature: this C++ port has no ONNX
+    Runtime linked into it at all.
+
+    This is a single, self-contained graph rewrite: unlike :func:`simplify`,
+    it does not run shape inference, constant folding, or any other pass.
+
+    :param model: the original onnx ModelProto or file path
+    :param sparsity: target fraction of each matched node's ``inter_size``
+            channels to remove (at least one channel is always kept); must
+            be in ``[0, 1)``
+    :returns: ``model`` with every matched ``MoE`` node's ``fc1``/``fc2``
+            tensors resized in place; anything not matching the exact
+            topology above is left completely untouched
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    return onnx.load_from_string(
+        C.apply_moe_expert_channel_pruning(model.SerializeToString(), sparsity)
+    )
+
+
 def apply_qmoe_expert_channel_pruning_cpp(
     model: Union[str, onnx.ModelProto],
     sparsity: float = 0.5,

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -1419,6 +1419,76 @@ def apply_attention_head_pruning_cpp(
     )
 
 
+def apply_qmoe_expert_channel_pruning_cpp(
+    model: Union[str, onnx.ModelProto],
+    sparsity: float = 0.5,
+) -> onnx.ModelProto:
+    """
+    C++-backed port of :func:`onnxsim.apply_qmoe_expert_channel_pruning`:
+    removes intermediate (``inter_size``) channels from every expert of a
+    matched ``com.microsoft::QMoE`` node at once -- the quantized-weight
+    counterpart of :func:`onnxsim.apply_structured_pruning_cpp`, targeting
+    ``QMoE``'s own packed ``uint8`` ``fc1_experts_weights``/
+    ``fc2_experts_weights`` (plus their ``scales``/``zero_points``/
+    ``global_scale`` operands, co-sliced in lockstep) instead of plain float
+    weights.
+
+    Supports ``quant_type='int'`` (``expert_weight_bits`` in ``{2, 4, 8}``,
+    with no ``block_size`` -- whole-row per-channel scale -- or a groupwise
+    ``block_size``) and ``quant_type='nvfp4'`` (E2M1-packed weights,
+    ``float8e4m3fn`` per-block scales, a required per-expert ``float32``
+    global scale, ``block_size`` fixed at 16 -- schema-derived only, since no
+    onnxruntime build has a CPU kernel for any FP4/FP8 ``quant_type`` to
+    verify against). ``'fp4'``, ``'fp8'``, and ``'wfp4afp8'`` remain out of
+    scope, as does ``fc3_experts_weights``, ``router_weights``, a
+    ``swiglu``/unrecognized ``activation_type``, and a CUTLASS-prepacked
+    (``weights_prepacked`` outside ``{-1, 0}``) weight layout.
+
+    Ranks every ``inter_size`` index by combined (root-sum-square) L2 norm of
+    ``fc1_experts_weights``'/``fc2_experts_weights``' own DEQUANTIZED row/
+    column (never written back -- the actual rewrite always slices the
+    existing packed codes/scales/zero_points in place, re-packing a
+    sub-byte-packed axis rather than ever re-quantizing a sliced float
+    weight from scratch) plus ``fc1_experts_bias``'s own entry when present,
+    drops the lowest-``sparsity``-fraction of indices (at least one always
+    kept, floored to a multiple of ``8 / expert_weight_bits`` -- or, with
+    ``block_size`` set, to whole ``block_size``-sized groups, since
+    ``fc2_experts_weights``' own quantization blocks group along
+    ``inter_size`` and a value can't be dropped out of a shared-scale group
+    without re-quantizing it), and removes the matching row from ``fc1``'s
+    own weight/scales/bias/zero_points and column from ``fc2``'s own weight
+    (plus, only when ``block_size`` is set, ``fc2``'s own scales/
+    zero_points too), identically across every expert. ``num_experts``, `k`,
+    and every node attribute are untouched.
+
+    Unlike :func:`onnxsim.apply_qmoe_expert_channel_pruning`, this port only
+    admits FLOAT32 (not FLOAT16/BFLOAT16) ``fc1``/``fc2`` scales and bias,
+    matching this codebase's C++-port scope decision for
+    :func:`onnxsim.apply_structured_pruning_matmul_nbits` above; and does
+    not include the complementary whole-expert-removal pass
+    (:func:`onnxsim.apply_qmoe_whole_expert_pruning`), which needs runtime
+    calibration data (an ONNX Runtime inference session observing router
+    activations) this C++ port has no ONNX Runtime linked into at all.
+
+    This is a single, self-contained graph rewrite: unlike :func:`simplify`,
+    it does not run shape inference, constant folding, or any other pass.
+
+    :param model: the original onnx ModelProto or file path
+    :param sparsity: target fraction of each matched node's `inter_size`
+            channels (or, with `block_size` set, `block_size`-sized groups)
+            to remove (at least one channel is always kept); must be in
+            ``[0, 1)``
+    :returns: ``model`` with every matched ``QMoE`` node's `fc1`/`fc2`
+            tensors resized in place; anything not matching the exact
+            topology above is left completely untouched
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    return onnx.load_from_string(
+        C.apply_qmoe_expert_channel_pruning(model.SerializeToString(), sparsity)
+    )
+
+
 def apply_quarot_cpp(
     model: Union[str, onnx.ModelProto],
     seed: int = 0,

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -645,6 +645,40 @@ onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
 onnx::ModelProto ApplyAttentionHeadPruning(const onnx::ModelProto& model,
                                            double sparsity);
 
+// MoE expert-intermediate-channel pruning: removes intermediate
+// (``inter_size``) channels from every expert of a matched
+// ``com.microsoft::MoE`` node at once -- real structural pruning (smaller
+// ``fc1_experts_weights``/``fc2_experts_weights``, smaller per-expert
+// matmuls on any runtime), data-free.
+//
+// Ranks every ``inter_size`` index by combined (root-sum-square) L2 norm of
+// ``fc1_experts_weights``' own row (across every expert and ``hidden_size``
+// at once) and ``fc2_experts_weights``' own column (same reduction), plus
+// ``fc1_experts_bias``'s own entry when present, drops the lowest-
+// ``sparsity``-fraction of indices (at least one is always kept), and
+// removes the matching row from ``fc1_experts_weights``/
+// ``fc1_experts_bias`` and column from ``fc2_experts_weights``, identically
+// across every expert -- ``num_experts``, ``k``, and every node attribute
+// are untouched, since pruning ``inter_size`` changes no other tensor's
+// shape anywhere in the graph, including the node's own output.
+//
+// A node with ``fc3_experts_weights`` present, a ``swiglu``/unrecognized
+// ``activation_type``, a non-constant or tied/shared weight, or any other
+// shape this pass doesn't recognize is left completely untouched. This is
+// the C++ port of ``onnxsim.apply_moe_expert_channel_pruning`` --
+// whole-expert pruning (shrinking ``num_experts`` itself, which needs
+// runtime calibration data this build has no ONNX Runtime linked in to
+// provide) is a deliberately separate, NOT-ported feature. See
+// ``structured_pruning_entry.cpp``'s own "MoE (com.microsoft::MoE)
+// expert-intermediate-channel pruning" section comment for the full scope
+// and safety argument.
+//
+// Unlike ``Simplify``, this does not run shape inference, constant folding or
+// any other simplification pass. ``sparsity`` must be in [0, 1); throws
+// ``std::invalid_argument`` otherwise.
+onnx::ModelProto ApplyMoeExpertChannelPruning(const onnx::ModelProto& model,
+                                              double sparsity);
+
 // QMoE expert-channel pruning: removes intermediate (``inter_size``)
 // channels from every expert of a matched ``com.microsoft::QMoE`` node at
 // once -- the quantized-weight counterpart of ``ApplyStructuredPruning``,

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -645,6 +645,57 @@ onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
 onnx::ModelProto ApplyAttentionHeadPruning(const onnx::ModelProto& model,
                                            double sparsity);
 
+// QMoE expert-channel pruning: removes intermediate (``inter_size``)
+// channels from every expert of a matched ``com.microsoft::QMoE`` node at
+// once -- the quantized-weight counterpart of ``ApplyStructuredPruning``,
+// targeting ``QMoE``'s own packed ``uint8`` ``fc1_experts_weights``/
+// ``fc2_experts_weights`` (plus their ``scales``/``zero_points``/
+// ``global_scale`` operands, co-sliced in lockstep) instead of plain float
+// weights. See ``structured_pruning_entry.cpp``'s own "QMoE (com.microsoft,
+// quantized-weight Mixture-of-Experts) expert-channel structured pruning"
+// section comment for the exact matched topology.
+//
+// Supports ``quant_type='int'`` (``expert_weight_bits`` in {2, 4, 8}, with
+// no ``block_size`` -- whole-row per-channel scale -- or a groupwise
+// ``block_size``) and ``quant_type='nvfp4'`` (E2M1-packed weights,
+// ``float8e4m3fn`` per-block scales, a required per-expert ``float32``
+// global scale, ``block_size`` fixed at 16); ``'fp4'``, ``'fp8'``, and
+// ``'wfp4afp8'`` remain out of scope, as does ``fc3_experts_weights``,
+// ``router_weights``, a ``swiglu``/unrecognized ``activation_type``, and a
+// CUTLASS-prepacked (``weights_prepacked`` outside {-1, 0}) weight layout.
+//
+// Ranks every ``inter_size`` index by combined (root-sum-square) L2 norm of
+// ``fc1_experts_weights``'/``fc2_experts_weights``' own DEQUANTIZED row/
+// column (never written back -- the actual rewrite always slices the
+// existing packed codes/scales/zero_points in place, re-packing a sub-byte-
+// packed axis rather than ever re-quantizing a sliced float weight from
+// scratch) plus ``fc1_experts_bias``'s own entry when present, drops the
+// lowest-``sparsity``-fraction of indices (at least one always kept,
+// floored to a multiple of ``8 / expert_weight_bits`` -- or, with
+// ``block_size`` set, to whole ``block_size``-sized groups, since
+// ``fc2_experts_weights``' own quantization blocks group along
+// ``inter_size`` and a value can't be dropped out of a shared-scale group
+// without re-quantizing it), and removes the matching row from ``fc1``'s
+// own weight/scales/bias/zero_points and column from ``fc2``'s own weight
+// (plus, only when ``block_size`` is set, ``fc2``'s own scales/
+// zero_points too), identically across every expert. ``num_experts``, `k`,
+// and every node attribute are untouched.
+//
+// Unlike pruning.py's own ``apply_qmoe_expert_channel_pruning``, this port
+// only admits FLOAT32 (not FLOAT16/BFLOAT16) ``fc1``/``fc2`` scales and
+// bias, matching this codebase's C++-port scope decision for MatMulNBits
+// above; and does not include the complementary whole-expert-removal pass
+// (``onnxsim.apply_qmoe_whole_expert_pruning``), which needs runtime
+// calibration data (an ONNX Runtime inference session observing router
+// activations) this C++ port has no ONNX Runtime linked into at all.
+//
+// Unlike ``Simplify``, this does not run shape inference, constant folding
+// or any other simplification pass. ``sparsity`` must be in [0, 1); throws
+// ``std::invalid_argument`` otherwise. Anything not matching the exact
+// topology above is left completely untouched.
+onnx::ModelProto ApplyQMoEExpertChannelPruning(const onnx::ModelProto& model,
+                                               double sparsity);
+
 // Lists the activation tensor names that ``QuantizeStatic`` could quantize in
 // ``model`` -- the first input of every MatMul, every "vanilla" Gemm
 // (transA=0, alpha=1, beta=1), and every Conv, whose weight is a constant

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -11425,6 +11425,346 @@ void ApplyMatMulBnb4Chains(onnx::GraphProto* graph,
   }
 }
 
+// --- MoE (com.microsoft::MoE) expert-intermediate-channel pruning --------
+//
+// C++ port of pruning.py's own apply_moe_expert_channel_pruning -- see that
+// function's own section comment (the "MoE expert-intermediate-channel
+// pruning" block just above `class _MoEChain` in pruning.py) for the full
+// safety argument: `fc1_experts_weights`/`fc2_experts_weights` each carry a
+// clean `[num_experts, ...]` leading axis (`inter_size` living on fc1's own
+// axis 1 -- `[num_experts, inter_size, hidden_size]` -- and fc2's own axis 2
+// -- `[num_experts, hidden_size, inter_size]`), so dropping the same
+// `inter_size` index from both, identically across every expert, needs no
+// upstream producer, no downstream consumer, and no attribute update at all
+// (`num_experts`/`k`/`activation_type` are untouched, and the node's own
+// output shape always equals its input's) -- the "narrowest safe slice" of
+// NVIDIA's "Iterative Puzzle" paper (arXiv:2607.04371) this module can
+// precisely justify.
+//
+// Two scope boundaries, both already decided (and empirically verified
+// against a real onnxruntime CPU MoE kernel) on the Python side and simply
+// carried over unchanged here, never re-derived:
+//   * `fc3_experts_weights` (present) and `swiglu`/unrecognized
+//     `activation_type` (or nonzero `swiglu_fusion`) are declined outright --
+//     see pruning.py's own comment for why (no CPU execution provider in
+//     this environment implements fc3; a real fused-swiglu fc1 doubles its
+//     own row count, which the `fc1.dims(1) == fc2.dims(2)` shape check
+//     below already declines structurally, without even reading
+//     `swiglu_fusion`).
+//   * Whole-expert pruning (shrinking `num_experts` itself, pruning.py's own
+//     separate "MoE whole-expert pruning" section right after this one) is
+//     NOT ported here -- it needs runtime calibration data (an
+//     `onnxruntime.InferenceSession` observing router activations over a
+//     representative batch) to rank experts by usage, and this C++ port has
+//     no ONNX Runtime linked into it at all (see CLAUDE.md: the wheel build
+//     always passes `-DONNXSIM_BUILTIN_ORT=OFF`). This section stays
+//     entirely within the data-free, fully structural `inter_size` slice.
+//
+// `fc1_experts_weights`/`fc2_experts_weights`/`fc1_experts_bias` are
+// admitted only as plain FLOAT (float32) tensors here -- this file's own
+// float-tensor helpers (ReadFloatTensor/SetFloatTensorData) have no
+// FLOAT16/BFLOAT16 support anywhere yet, unlike pruning.py's own
+// `_is_supported_float_dtype`, which additionally admits both. Mirrors this
+// file's own already-established narrower-than-pruning.py scope decision
+// (e.g. the "MatMulNBits" section's identical restriction on its own
+// scales/zero_points/bias tensors) -- a FLOAT16/BFLOAT16 MoE export is
+// simply never matched here (declined, not mis-handled).
+//
+// This is exposed as its own top-level entry point (ApplyMoeExpertChannel
+// Pruning, alongside ApplyStructuredPruning/ApplyAttentionHeadPruning at the
+// bottom of this file) rather than folded into ApplyStructuredPruning's own
+// per-graph dispatch: `fc1_experts_weights`/`fc2_experts_weights`/
+// `fc1_experts_bias` are 3-D tensors that no other chain family in this file
+// could ever also match (every other chain-finder requires a rank-2 MatMul/
+// Gemm-shaped or rank-4 Conv-shaped weight), so there is no shared/tied-
+// initializer conflict to guard against between this pass and any of
+// ApplyStructuredPruning's own six chain families -- the touched-initializer
+// bookkeeping below only ever needs to guard MoE nodes against each other
+// (mirrors pruning.py's own `_apply_moe_chains`, whose own local
+// `touched: Set[str]` is likewise never shared with `_TouchedState`).
+
+struct MoEChain {
+  onnx::NodeProto* node;
+  std::string fc1_w;
+  std::optional<std::string> fc1_b;
+  std::string fc2_w;
+  std::optional<std::string> fc2_b;
+  int64_t num_experts;
+  int64_t inter_size;
+  int64_t hidden_size;
+};
+
+const std::unordered_set<std::string>& MoeActivations() {
+  static const std::unordered_set<std::string> kOps = {"relu", "identity",
+                                                       "silu", "gelu"};
+  return kOps;
+}
+
+// One optional-bias input (`fc1_experts_bias`/`fc2_experts_bias`) match
+// result, mirroring pruning.py's own `_optional_bias`'s
+// `Tuple[bool, Optional[str]]` return convention: `ok=false` means the
+// input is PRESENT but fails one of its own checks (declining the WHOLE
+// node, not just that bias), while `ok=true, name=nullopt` means the input
+// is simply absent (a well-formed unbiased MoE node).
+struct MoeOptionalBiasResult {
+  bool ok;
+  std::optional<std::string> name;
+};
+
+MoeOptionalBiasResult MatchMoeOptionalBias(const onnx::NodeProto& node,
+                                           int index, int64_t expected_dim0,
+                                           int64_t expected_dim1,
+                                           const InitMap& init_map,
+                                           const ConsumerMap& consumers_of) {
+  if (node.input_size() <= index || node.input(index).empty()) {
+    return {true, std::nullopt};
+  }
+  const std::string& name = node.input(index);
+  auto it = init_map.find(name);
+  if (it == init_map.end() ||
+      it->second->data_type() != onnx::TensorProto::FLOAT ||
+      it->second->dims_size() != 2 || it->second->dims(0) != expected_dim0 ||
+      it->second->dims(1) != expected_dim1 ||
+      ConsumerCount(consumers_of, name) != 1) {
+    return {false, std::nullopt};
+  }
+  return {true, name};
+}
+
+// If `node` is a `com.microsoft::MoE` node this pass can safely prune the
+// `inter_size` axis of, returns the matched MoEChain -- mirrors pruning.py's
+// own `_match_moe_producer` exactly, check for check, in the same order (see
+// that function's own docstring for the full per-check safety argument).
+std::optional<MoEChain> MatchMoeProducer(onnx::NodeProto* node,
+                                         const InitMap& init_map,
+                                         const ConsumerMap& consumers_of) {
+  if (node->domain() != kComMicrosoftDomain || node->op_type() != "MoE") {
+    return std::nullopt;
+  }
+
+  std::string activation = "relu";
+  int64_t swiglu_fusion = 0;
+  for (const auto& attr : node->attribute()) {
+    if (attr.name() == "activation_type") {
+      activation = attr.s();
+    } else if (attr.name() == "swiglu_fusion") {
+      swiglu_fusion = attr.i();
+    }
+  }
+  if (!MoeActivations().count(activation) || swiglu_fusion != 0) {
+    return std::nullopt;
+  }
+
+  if (node->input_size() > 6 && !node->input(6).empty()) {
+    return std::nullopt;  // fc3_experts_weights present -- no CPU oracle, see
+                          // above.
+  }
+  if (node->input_size() < 5 || node->input(2).empty() ||
+      node->input(4).empty()) {
+    return std::nullopt;
+  }
+  const std::string fc1_w_name = node->input(2);
+  const std::string fc2_w_name = node->input(4);
+  auto fc1_it = init_map.find(fc1_w_name);
+  auto fc2_it = init_map.find(fc2_w_name);
+  if (fc1_it == init_map.end() || fc2_it == init_map.end() ||
+      fc1_it->second->data_type() != onnx::TensorProto::FLOAT ||
+      fc2_it->second->data_type() != onnx::TensorProto::FLOAT ||
+      fc1_it->second->dims_size() != 3 || fc2_it->second->dims_size() != 3 ||
+      ConsumerCount(consumers_of, fc1_w_name) != 1 ||
+      ConsumerCount(consumers_of, fc2_w_name) != 1) {
+    return std::nullopt;
+  }
+  const onnx::TensorProto* fc1_w = fc1_it->second;
+  const onnx::TensorProto* fc2_w = fc2_it->second;
+  const int64_t num_experts = fc1_w->dims(0);
+  const int64_t inter_size = fc1_w->dims(1);
+  const int64_t hidden_size = fc1_w->dims(2);
+  if (fc2_w->dims(0) != num_experts || fc2_w->dims(1) != hidden_size ||
+      fc2_w->dims(2) != inter_size) {
+    return std::nullopt;  // also rules out a fused-swiglu fc1 (doubled row
+                          // count)
+  }
+
+  MoeOptionalBiasResult fc1_b = MatchMoeOptionalBias(
+      *node, 3, num_experts, inter_size, init_map, consumers_of);
+  if (!fc1_b.ok) {
+    return std::nullopt;
+  }
+  MoeOptionalBiasResult fc2_b = MatchMoeOptionalBias(
+      *node, 5, num_experts, hidden_size, init_map, consumers_of);
+  if (!fc2_b.ok) {
+    return std::nullopt;
+  }
+
+  return MoEChain{node,       fc1_w_name,  fc1_b.name, fc2_w_name,
+                  fc2_b.name, num_experts, inter_size, hidden_size};
+}
+
+std::vector<MoEChain> FindMoeChains(onnx::GraphProto* graph) {
+  InitMap init_map;
+  for (const auto& t : graph->initializer()) {
+    init_map[t.name()] = &t;
+  }
+  ConsumerMap consumers_of = ConsumersOf(graph);
+
+  std::vector<MoEChain> chains;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    auto chain = MatchMoeProducer(node, init_map, consumers_of);
+    if (chain) {
+      chains.push_back(std::move(*chain));
+    }
+  }
+  return chains;
+}
+
+// Combined (root-sum-square) L2-norm importance per `inter_size` channel
+// index, accumulated in float64 (mirrors this file's own established
+// accumulate-then-sqrt-once convention, e.g. ApplyChains's own `importance`
+// loop) over every expert and the full `hidden_size` axis at once -- index
+// `j` is one shared row of fc1 (and, if present, fc1_experts_bias) and one
+// shared column of fc2, across EVERY expert simultaneously (the node's own
+// `[num_experts, inter_size, ...]`/`[num_experts, ..., inter_size]` layout
+// gives every expert the identical `inter_size` axis, with no independent
+// per-expert choice possible), mirroring pruning.py's own `_moe_importance`
+// exactly.
+std::vector<double> MoeImportance(const MoEChain& chain,
+                                  const MutInitMap& init_map) {
+  const int64_t e_n = chain.num_experts;
+  const int64_t inter = chain.inter_size;
+  const int64_t hidden = chain.hidden_size;
+  std::vector<double> squared(static_cast<size_t>(inter), 0.0);
+
+  const std::vector<float> fc1_w = ReadFloatTensor(*init_map.at(chain.fc1_w));
+  for (int64_t e = 0; e < e_n; ++e) {
+    for (int64_t j = 0; j < inter; ++j) {
+      double sq = 0.0;
+      for (int64_t h = 0; h < hidden; ++h) {
+        const double v =
+            fc1_w[static_cast<size_t>((e * inter + j) * hidden + h)];
+        sq += v * v;
+      }
+      squared[static_cast<size_t>(j)] += sq;
+    }
+  }
+
+  const std::vector<float> fc2_w = ReadFloatTensor(*init_map.at(chain.fc2_w));
+  for (int64_t e = 0; e < e_n; ++e) {
+    for (int64_t h = 0; h < hidden; ++h) {
+      for (int64_t j = 0; j < inter; ++j) {
+        const double v =
+            fc2_w[static_cast<size_t>((e * hidden + h) * inter + j)];
+        squared[static_cast<size_t>(j)] += v * v;
+      }
+    }
+  }
+
+  if (chain.fc1_b) {
+    const std::vector<float> fc1_b =
+        ReadFloatTensor(*init_map.at(*chain.fc1_b));
+    for (int64_t e = 0; e < e_n; ++e) {
+      for (int64_t j = 0; j < inter; ++j) {
+        const double v = fc1_b[static_cast<size_t>(e * inter + j)];
+        squared[static_cast<size_t>(j)] += v * v;
+      }
+    }
+  }
+
+  std::vector<double> importance(squared.size());
+  for (size_t i = 0; i < squared.size(); ++i) {
+    importance[i] = std::sqrt(squared[i]);
+  }
+  return importance;
+}
+
+// The actual apply step, mirroring pruning.py's own `_apply_moe_chains`:
+// ranks every `inter_size` index by MoeImportance, drops the lowest-
+// `sparsity`-fraction (at least one always kept), and removes the matching
+// row from fc1_experts_weights/fc1_experts_bias and column from
+// fc2_experts_weights, identically across every expert. `fc2_experts_bias`
+// indexes `hidden_size` (fc2's own *output* axis, not `inter_size`), so it
+// is never sliced here -- exactly like the Python original.
+//
+// `touched` guards only against another MoE node in this SAME graph sharing
+// one of these weights (see this section's own top comment for why that is
+// never a cross-pass concern here) -- a fresh, empty set per call, mirroring
+// pruning.py's own local `touched: Set[str]` inside `_apply_moe_chains`
+// (never the module-wide `_TouchedState` `apply_structured_pruning` uses).
+void ApplyMoeChains(onnx::GraphProto* graph, std::vector<MoEChain>& chains,
+                    double sparsity) {
+  MutInitMap init_map = BuildMutInitMap(graph);
+  std::unordered_set<std::string> touched;
+
+  for (const auto& chain : chains) {
+    std::unordered_set<std::string> weight_names{chain.fc1_w, chain.fc2_w};
+    if (chain.fc1_b) {
+      weight_names.insert(*chain.fc1_b);
+    }
+    bool conflict = false;
+    for (const auto& w : weight_names) {
+      if (touched.count(w)) {
+        conflict = true;
+        break;
+      }
+    }
+    if (conflict) {
+      continue;  // A shared/tied initializer another MoE node already resized.
+    }
+    touched.insert(weight_names.begin(), weight_names.end());
+
+    const int64_t n = chain.inter_size;
+    const int64_t keep_count = std::max<int64_t>(
+        1, n - std::llround(static_cast<double>(n) * sparsity));
+    if (keep_count >= n) {
+      continue;  // Rounds down to nothing for this layer -- no-op.
+    }
+
+    const std::vector<double> importance = MoeImportance(chain, init_map);
+    const std::vector<int64_t> keep =
+        TopKIndicesAscending(importance, keep_count);
+    const int64_t kc = static_cast<int64_t>(keep.size());
+
+    // fc1_experts_weights: [num_experts, inter_size, hidden_size] -- SliceAxis1
+    // slices exactly its own middle (`inter_size`) axis, `inner = hidden_size`.
+    {
+      onnx::TensorProto* fc1_w = init_map.at(chain.fc1_w);
+      const std::vector<float> data = ReadFloatTensor(*fc1_w);
+      const std::vector<float> out = SliceAxis1(
+          data, chain.num_experts, chain.inter_size, chain.hidden_size, keep);
+      SetFloatTensorData(fc1_w, {chain.num_experts, kc, chain.hidden_size},
+                         out);
+    }
+
+    // fc2_experts_weights: [num_experts, hidden_size, inter_size] --
+    // `inter_size` is the LAST axis here; row-major layout makes this
+    // byte-identical to a flat [num_experts * hidden_size, inter_size]
+    // matrix, so the same SliceAxis1 (dim1 = inter_size, inner = 1) slices
+    // exactly that trailing axis without any new slicing routine.
+    {
+      onnx::TensorProto* fc2_w = init_map.at(chain.fc2_w);
+      const std::vector<float> data = ReadFloatTensor(*fc2_w);
+      const std::vector<float> out =
+          SliceAxis1(data, chain.num_experts * chain.hidden_size,
+                     chain.inter_size, 1, keep);
+      SetFloatTensorData(fc2_w, {chain.num_experts, chain.hidden_size, kc},
+                         out);
+    }
+
+    if (chain.fc1_b) {
+      // fc1_experts_bias: [num_experts, inter_size] -- same trailing-axis
+      // shape SliceAxis1 already handles (inner = 1), no reshape needed.
+      onnx::TensorProto* fc1_b = init_map.at(*chain.fc1_b);
+      const std::vector<float> data = ReadFloatTensor(*fc1_b);
+      const std::vector<float> out =
+          SliceAxis1(data, chain.num_experts, chain.inter_size, 1, keep);
+      SetFloatTensorData(fc1_b, {chain.num_experts, kc}, out);
+    }
+    // fc2_experts_bias indexes hidden_size, fc2's own *output* axis --
+    // unaffected by an inter_size cut, so it is never sliced here.
+  }
+}
+
 // --- QMoE (com.microsoft, quantized-weight Mixture-of-Experts) expert-
 // channel structured pruning -------------------------------------------
 //
@@ -12960,6 +13300,37 @@ onnx::ModelProto ApplyAttentionHeadPruning(const onnx::ModelProto& model,
         FindMatMulNBitsQkvChains(graph);
     if (!matmul_nbits_qkv_chains.empty()) {
       ApplyMatMulNBitsQkvChains(graph, matmul_nbits_qkv_chains, sparsity);
+    }
+  }
+  return out;
+}
+
+onnx::ModelProto ApplyMoeExpertChannelPruning(const onnx::ModelProto& model,
+                                              double sparsity) {
+  if (!(sparsity >= 0.0 && sparsity < 1.0)) {
+    throw std::invalid_argument(
+        "ApplyMoeExpertChannelPruning: sparsity must be in [0, 1), got " +
+        std::to_string(sparsity));
+  }
+  onnx::ModelProto out = model;
+
+  // Subgraph-aware (IterSubgraphs, see this file's own "Subgraph recursion"
+  // section comment above): every `com.microsoft::MoE` node is matched and
+  // pruned inside a nested If/Loop/Scan/BeamSearch-family subgraph, at any
+  // nesting depth, exactly as if that subgraph were its own top-level graph
+  // -- each returned GraphProto* gets its own fresh FindMoeChains call and
+  // its own fresh ApplyMoeChains-local `touched` set, mirroring pruning.py's
+  // own `apply_moe_expert_channel_pruning` loop over
+  // `_iter_subgraphs(out.graph)` exactly. Unlike ApplyStructuredPruning/
+  // ApplyAttentionHeadPruning, there is no shared per-graph TouchedState to
+  // thread through here -- see the "MoE (com.microsoft::MoE) expert-
+  // intermediate-channel pruning" section comment above for why no other
+  // chain family in this file could ever also match one of these 3-D
+  // weights.
+  for (onnx::GraphProto* graph : IterSubgraphs(out.mutable_graph())) {
+    std::vector<MoEChain> chains = FindMoeChains(graph);
+    if (!chains.empty()) {
+      ApplyMoeChains(graph, chains, sparsity);
     }
   }
   return out;

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -78,6 +78,7 @@
 #include <cstdint>
 #include <cstring>
 #include <functional>
+#include <limits>
 #include <numeric>
 #include <optional>
 #include <stdexcept>
@@ -11424,6 +11425,1274 @@ void ApplyMatMulBnb4Chains(onnx::GraphProto* graph,
   }
 }
 
+// --- QMoE (com.microsoft, quantized-weight Mixture-of-Experts) expert-
+// channel structured pruning -------------------------------------------
+//
+// Port of pruning.py's own "QMoE (quantized-weight MoE) pruning" section --
+// see that section's own top comment there for the full schema/packing
+// derivation (re-derived from QMoE's own live onnxruntime schema and real
+// CPU `onnxruntime.InferenceSession` runs, not assumed from its name or
+// from a superficially similar op). Only the EXPERT-CHANNEL half
+// (`apply_qmoe_expert_channel_pruning`, narrowing every expert's own
+// `inter_size` identically across all experts) is ported here -- the
+// complementary WHOLE-EXPERT half (`apply_qmoe_whole_expert_pruning`)
+// needs runtime calibration data (an ONNX Runtime inference session
+// observing router activations), which this C++ port has no ONNX Runtime
+// linked into at all (see CLAUDE.md: the wheel build never builds ORT) --
+// so it stays out of scope here, exactly like every other calibration-
+// driven pass this file's own established precedent already excludes
+// (Wanda-style importance, whole-expert usage-based pruning, ...).
+//
+// *** THE CORE INVARIANT: SLICE CODES DIRECTLY, NEVER DEQUANT-REQUANT ***.
+// Exactly like this file's own MatMulNBits/MatMulBnb4/QDQ sections above:
+// `fc1_experts_weights`/`fc2_experts_weights` are never dequantized and
+// re-quantized from a sliced float weight. QMoEDequantizeInt/
+// QMoEDequantizeNvfp4 exist ONLY to rank channels by importance -- the
+// actual channel removal (QMoESlice*Axis1/QMoESlice*Axis2, and the packed-
+// axis unpack/select/repack helpers) always row/column-selects (and, for a
+// sub-byte-packed axis, unpacks codes to bytes, re-selects, and re-packs)
+// the EXISTING quantized codes. A pruned model's surviving channels must
+// therefore produce BIT-IDENTICAL results to the unpruned model's own real
+// quantization, not merely numerically close ones -- re-quantizing a
+// sliced float weight from scratch would recompute a different scale
+// wherever the dropped values happened to hold that row's own max (see
+// pruning.py's own test suite, and tests/test_qmoe_pruning_cpp.py's own
+// "hand-built presliced reference" tests here, which check exactly this:
+// the pruned graph's own tensors must equal a HAND-SLICE of the ORIGINAL
+// quantized codes, never a re-quantization of the sliced float weight).
+//
+// *** THE BLOCK-ALIGNMENT CONSTRAINT ***. With `block_size` set (groupwise
+// quantization), `fc2_experts_weights`' own quantization blocks group
+// along `inter_size` -- this pass's own pruned axis -- so every value in
+// one `block_size`-sized group shares one `(scale, zero_point)` pair an
+// individual channel cannot be dropped out of without re-quantizing the
+// whole group (out of scope: this module never invents a new quantized
+// value). So the keep-set is resolved to WHOLE `block_size`-sized groups
+// from the very start (QMoEBlockAlignedKeep ranks and keeps *blocks*, not
+// individual channels, by the same combined-L2-norm criterion aggregated
+// one level up) -- never a channel-level keep-set checked for alignment
+// after the fact, so the result is always block-aligned by construction,
+// never partial. `fc1_experts_weights`' own blocks, by contrast, group
+// along `hidden_size` (an axis this pass never touches), so `fc1`'s own
+// slicing needs no such alignment check either way -- mirrors
+// MatMulNBitsBlockAlignedKeepBlocks's own precedent for `MatMulNBits`'
+// analogous K-axis case, just resolved eagerly here rather than validated
+// against an already-chosen keep-set.
+//
+// Covers `quant_type='int'` (both with no `block_size` -- whole-row
+// per-channel scale -- and with a groupwise `block_size`) and
+// `quant_type='nvfp4'` (E2M1-packed weights, `float8e4m3fn` per-block
+// scales, a required per-expert `float32` global scale, `block_size` fixed
+// at 16 -- schema-derived only, since this environment's onnxruntime has
+// no CPU kernel for any FP4/FP8 `quant_type` to verify against at all; see
+// pruning.py's own section comment, point 9, for the full reasoning).
+// `'fp4'`, `'fp8'`, and `'wfp4afp8'` remain explicitly out of scope, same
+// as pruning.py's own Python reference.
+//
+// Two deliberate, narrower-than-pruning.py scope decisions specific to
+// this C++ port (both consistent with this file's own established
+// narrower-subset-of-pruning.py precedent elsewhere, e.g. MatMulNBits'
+// own FLOAT-only scales/zero_points/bias above):
+//   * `fc1_experts_scales`/`fc2_experts_scales` (quant_type='int') and
+//     `fc1_experts_bias`/`fc2_experts_bias` (either quant_type) are
+//     admitted only as plain FLOAT (float32) tensors -- this file's own
+//     float-tensor helpers have no FLOAT16/BFLOAT16 support anywhere yet,
+//     unlike pruning.py's own `_is_supported_float_dtype`. A FLOAT16/
+//     BFLOAT16-quantized export is simply never matched here (declined,
+//     not mis-handled).
+//   * `expert_weight_bits` (`quant_type='int'`) is supported for every
+//     value pruning.py's own reference supports (2, 4, 8) -- QMoE's own
+//     sub-byte packing generalizes to `bits` in {2, 4, 8} unlike
+//     MatMulNBits' own {4, 8}-only packing, so this section writes its own
+//     generic QMoEUnpackSubbyte/QMoEPackSubbyte rather than reusing
+//     MatMulNBits' UnpackNibblesLastAxis/UnpackCodesLastAxis (bits=4/8
+//     only) -- see those functions' own comments.
+//
+// The E2M1 (`quant_type='nvfp4'`) magnitude table below (QMoEE2M1Table) is
+// its OWN table, independently re-derived from pruning.py's own
+// `_e2m1_decode`/`_E2M1_MAGNITUDE` -- NOT the same table as this file's own
+// `MatMulBnb4Fp4Codes()` above (bitsandbytes' own FP4 format, a completely
+// different, non-IEEE-754-shaped 16-value codebook -- {0, 0.0052, 0.667,
+// 1.0, 0.333, 0.5, 0.167, 0.25, ...} -- verified by comparing the two
+// tables' own raw values, not assumed compatible just because both are
+// "4-bit float weights"). QMoE's own E2M1 format is the standard, publicly
+// documented OCP Microscaling (MX) spec 4-bit float element: 1 sign + 2
+// exponent + 1 mantissa bit, magnitude {0, 0.5, 1, 1.5, 2, 3, 4, 6} indexed
+// by the code's own low 3 bits, sign the top bit -- a fresh table, since
+// bnb4's own table is for an unrelated, differently-shaped format.
+//
+// FLOAT8E4M3FN (nvfp4's own block-scale dtype) has no existing support
+// anywhere else in this file (no FP8-quantized pruning pass is ported to
+// C++ yet) -- QMoEFloat8E4M3Table (256 entries, code -> double, generated
+// once from the OCP FP8 E4M3FN spec: sign/4-bit-exponent(bias 7)/
+// 3-bit-mantissa, no infinities, 0x7F/0xFF reserved for NaN) is this
+// section's own, used ONLY for IMPORTANCE RANKING (QMoEDequantizeNvfp4) --
+// the actual `fc1_scales`/`fc2_scales` bytes are always sliced as opaque
+// raw bytes (QMoESliceFloat8Axis1/QMoESliceFloat8Axis2), never decoded and
+// re-encoded, so a single-bit table error here could only ever bias which
+// channels get RANKED higher, never corrupt what gets WRITTEN back.
+
+enum class QMoEQuantType { kInt, kNvfp4 };
+
+const std::unordered_set<std::string>& QMoEActivations() {
+  static const std::unordered_set<std::string> kSet = {"relu", "identity",
+                                                       "silu", "gelu"};
+  return kSet;
+}
+
+std::string QMoEStringAttrOr(const onnx::NodeProto& node,
+                             const std::string& name,
+                             const std::string& default_value) {
+  for (const auto& attr : node.attribute()) {
+    if (attr.name() == name) {
+      return attr.s();
+    }
+  }
+  return default_value;
+}
+
+bool QMoEDimsEqual(const onnx::TensorProto& t,
+                   const std::vector<int64_t>& expected) {
+  if (static_cast<size_t>(t.dims_size()) != expected.size()) {
+    return false;
+  }
+  for (int i = 0; i < t.dims_size(); ++i) {
+    if (t.dims(i) != expected[static_cast<size_t>(i)]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// `2 ** (bits - 1)` -- the schema's own documented default `zero_point`
+// for whichever of `fc1_zero_points`/`fc2_zero_points` is absent.
+int64_t QMoEDefaultZeroPoint(int64_t bits) { return int64_t{1} << (bits - 1); }
+
+// Generic sub-byte pack/unpack, LOW INDEX IN LOW BITS -- QMoE's own raw
+// (`weights_prepacked` in {-1, 0}) storage convention for
+// `fc1_experts_weights`/`fc2_experts_weights` and `fc1_zero_points`/
+// `fc2_zero_points` alike (empirically confirmed in pruning.py's own
+// section comment, point 2), for `bits` in {2, 4, 8} -- unlike this file's
+// own MatMulNBits UnpackNibblesLastAxis/UnpackCodesLastAxis (bits in
+// {4, 8} only, since MatMulNBits itself never admits 2), QMoE's own
+// `expert_weight_bits` also admits 2, so this is written fresh rather than
+// reused. `outer` independent packed rows sharing one packing granularity
+// (an expert's own N channels, or an (expert, channel) pair's own K
+// values, depending on caller); mirrors pruning.py's own `_unpack_subbyte`
+// exactly, including its own "drop the unused top slot" trim to
+// `logical_len`.
+std::vector<uint8_t> QMoEUnpackSubbyte(const std::vector<uint8_t>& packed,
+                                       int64_t outer, int64_t packed_width,
+                                       int64_t logical_len, int64_t bits) {
+  const int64_t pack = 8 / bits;
+  const uint8_t mask = static_cast<uint8_t>((1 << bits) - 1);
+  std::vector<uint8_t> out(static_cast<size_t>(outer * logical_len));
+  for (int64_t r = 0; r < outer; ++r) {
+    const uint8_t* prow = packed.data() + r * packed_width;
+    uint8_t* orow = out.data() + r * logical_len;
+    for (int64_t j = 0; j < logical_len; ++j) {
+      const int64_t byte_idx = j / pack;
+      const int64_t slot = j % pack;
+      orow[j] = static_cast<uint8_t>((prow[byte_idx] >> (bits * slot)) & mask);
+    }
+  }
+  return out;
+}
+
+// Inverse of QMoEUnpackSubbyte -- pads `count` up to a whole number of
+// `8 / bits` values with zeros (the same "one wasted slot" case
+// QMoEUnpackSubbyte trims away), mirrors pruning.py's own `_pack_subbyte`.
+std::vector<uint8_t> QMoEPackSubbyte(const std::vector<uint8_t>& vals,
+                                     int64_t outer, int64_t count,
+                                     int64_t bits) {
+  const int64_t pack = 8 / bits;
+  const int64_t packed_width = (count + pack - 1) / pack;
+  const uint8_t mask = static_cast<uint8_t>((1 << bits) - 1);
+  std::vector<uint8_t> out(static_cast<size_t>(outer * packed_width), 0);
+  for (int64_t r = 0; r < outer; ++r) {
+    const uint8_t* vrow = vals.data() + r * count;
+    uint8_t* orow = out.data() + r * packed_width;
+    for (int64_t j = 0; j < count; ++j) {
+      const int64_t byte_idx = j / pack;
+      const int64_t slot = j % pack;
+      orow[byte_idx] = static_cast<uint8_t>(
+          orow[byte_idx] | ((vrow[j] & mask) << (bits * slot)));
+    }
+  }
+  return out;
+}
+
+// E2M1 (1 sign + 2 exponent + 1 mantissa bit) magnitude table, code's own
+// low 3 bits -> magnitude, top bit -> sign -- the OCP Microscaling (MX)
+// spec's own FP4 element format `quant_type` in {'fp4', 'nvfp4'} uses. See
+// this section's own top comment for why this is a FRESH table, not
+// `MatMulBnb4Fp4Codes()` (a completely different, bitsandbytes-specific
+// 16-value codebook). Mirrors pruning.py's own `_E2M1_MAGNITUDE`/
+// `_e2m1_decode` exactly.
+const std::array<double, 16>& QMoEE2M1Table() {
+  static const std::array<double, 16> kTable = {
+      0.0,  0.5,  1.0,  1.5,  2.0,  3.0,  4.0,  6.0,
+      -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0,
+  };
+  return kTable;
+}
+
+// OCP FP8 E4M3FN (`float8e4m3fn`) code -> double, all 256 codes -- nvfp4's
+// own `fc1_scales`/`fc2_scales` block-scale dtype. Generated once (offline,
+// via `ml_dtypes.float8_e4m3fn`, the same reference library
+// tests/test_qmoe_pruning_cpp.py itself uses to build test tensors) rather
+// than computed from the sign/exponent/mantissa formula inline, so a
+// transcription error here is directly checkable by inspection against
+// that same reference rather than trusted to a from-scratch bit-twiddling
+// implementation. NaN entries (codes 0x7F/0xFF -- E4M3FN has no infinity,
+// unlike standard IEEE-754) use quiet_NaN(); this table is used ONLY for
+// IMPORTANCE RANKING (QMoEDequantizeNvfp4), never written back, so a NaN
+// input byte (never produced by a real quantizer) can only ever bias
+// ranking, not corrupt output.
+const std::array<double, 256>& QMoEFloat8E4M3Table() {
+  static const double kNaN = std::numeric_limits<double>::quiet_NaN();
+  static const std::array<double, 256> kTable = {
+      0.0,          0.001953125,  0.00390625,   0.005859375,  0.0078125,
+      0.009765625,  0.01171875,   0.013671875,  0.015625,     0.017578125,
+      0.01953125,   0.021484375,  0.0234375,    0.025390625,  0.02734375,
+      0.029296875,  0.03125,      0.03515625,   0.0390625,    0.04296875,
+      0.046875,     0.05078125,   0.0546875,    0.05859375,   0.0625,
+      0.0703125,    0.078125,     0.0859375,    0.09375,      0.1015625,
+      0.109375,     0.1171875,    0.125,        0.140625,     0.15625,
+      0.171875,     0.1875,       0.203125,     0.21875,      0.234375,
+      0.25,         0.28125,      0.3125,       0.34375,      0.375,
+      0.40625,      0.4375,       0.46875,      0.5,          0.5625,
+      0.625,        0.6875,       0.75,         0.8125,       0.875,
+      0.9375,       1.0,          1.125,        1.25,         1.375,
+      1.5,          1.625,        1.75,         1.875,        2.0,
+      2.25,         2.5,          2.75,         3.0,          3.25,
+      3.5,          3.75,         4.0,          4.5,          5.0,
+      5.5,          6.0,          6.5,          7.0,          7.5,
+      8.0,          9.0,          10.0,         11.0,         12.0,
+      13.0,         14.0,         15.0,         16.0,         18.0,
+      20.0,         22.0,         24.0,         26.0,         28.0,
+      30.0,         32.0,         36.0,         40.0,         44.0,
+      48.0,         52.0,         56.0,         60.0,         64.0,
+      72.0,         80.0,         88.0,         96.0,         104.0,
+      112.0,        120.0,        128.0,        144.0,        160.0,
+      176.0,        192.0,        208.0,        224.0,        240.0,
+      256.0,        288.0,        320.0,        352.0,        384.0,
+      416.0,        448.0,        kNaN,         -0.0,         -0.001953125,
+      -0.00390625,  -0.005859375, -0.0078125,   -0.009765625, -0.01171875,
+      -0.013671875, -0.015625,    -0.017578125, -0.01953125,  -0.021484375,
+      -0.0234375,   -0.025390625, -0.02734375,  -0.029296875, -0.03125,
+      -0.03515625,  -0.0390625,   -0.04296875,  -0.046875,    -0.05078125,
+      -0.0546875,   -0.05859375,  -0.0625,      -0.0703125,   -0.078125,
+      -0.0859375,   -0.09375,     -0.1015625,   -0.109375,    -0.1171875,
+      -0.125,       -0.140625,    -0.15625,     -0.171875,    -0.1875,
+      -0.203125,    -0.21875,     -0.234375,    -0.25,        -0.28125,
+      -0.3125,      -0.34375,     -0.375,       -0.40625,     -0.4375,
+      -0.46875,     -0.5,         -0.5625,      -0.625,       -0.6875,
+      -0.75,        -0.8125,      -0.875,       -0.9375,      -1.0,
+      -1.125,       -1.25,        -1.375,       -1.5,         -1.625,
+      -1.75,        -1.875,       -2.0,         -2.25,        -2.5,
+      -2.75,        -3.0,         -3.25,        -3.5,         -3.75,
+      -4.0,         -4.5,         -5.0,         -5.5,         -6.0,
+      -6.5,         -7.0,         -7.5,         -8.0,         -9.0,
+      -10.0,        -11.0,        -12.0,        -13.0,        -14.0,
+      -15.0,        -16.0,        -18.0,        -20.0,        -22.0,
+      -24.0,        -26.0,        -28.0,        -30.0,        -32.0,
+      -36.0,        -40.0,        -44.0,        -48.0,        -52.0,
+      -56.0,        -60.0,        -64.0,        -72.0,        -80.0,
+      -88.0,        -96.0,        -104.0,       -112.0,       -120.0,
+      -128.0,       -144.0,       -160.0,       -176.0,       -192.0,
+      -208.0,       -224.0,       -240.0,       -256.0,       -288.0,
+      -320.0,       -352.0,       -384.0,       -416.0,       -448.0,
+      kNaN,
+  };
+  return kTable;
+}
+
+// Overwrites `t` in place with a FLOAT8E4M3FN tensor of `dims`/`data` (raw
+// bytes, one per element -- no endianness concerns, mirrors
+// SetUint8TensorData exactly but for this dtype).
+void SetFloat8E4M3TensorData(onnx::TensorProto* t,
+                             const std::vector<int64_t>& dims,
+                             const std::vector<uint8_t>& data) {
+  const std::string name = t->name();
+  t->Clear();
+  t->set_name(name);
+  t->set_data_type(onnx::TensorProto::FLOAT8E4M3FN);
+  for (int64_t d : dims) {
+    t->add_dims(d);
+  }
+  t->set_raw_data(
+      std::string(reinterpret_cast<const char*>(data.data()), data.size()));
+}
+
+struct QMoEChannelChain {
+  onnx::NodeProto* node = nullptr;
+  std::string fc1_w;
+  std::string fc1_scale;
+  std::optional<std::string> fc1_bias;
+  std::optional<std::string> fc1_zp;
+  std::string fc2_w;
+  std::string fc2_scale;
+  std::optional<std::string> fc2_bias;
+  std::optional<std::string> fc2_zp;
+  int64_t num_experts = 0;
+  int64_t inter_size = 0;
+  int64_t hidden_size = 0;
+  int64_t bits = 4;
+  int64_t block_size = 0;
+  QMoEQuantType quant_type = QMoEQuantType::kInt;
+  std::optional<std::string> fc1_global_scale;
+  std::optional<std::string> fc2_global_scale;
+};
+
+// {true, name} for a present-and-well-formed optional FLOAT input, {true,
+// nullopt} for a genuinely absent one, {false, _} to decline the whole
+// chain -- mirrors pruning.py's own `_optional_float` closure inside
+// `_match_qmoe_producer` exactly (used for `fc1_experts_bias`/
+// `fc2_experts_bias`, either quant_type).
+bool QMoEOptionalFloatInput(const onnx::NodeProto& node, int idx,
+                            const std::vector<int64_t>& expected_dims,
+                            const InitMap& init_map,
+                            const ConsumerMap& consumers_of,
+                            std::optional<std::string>* out_name) {
+  if (idx >= node.input_size() || node.input(idx).empty()) {
+    *out_name = std::nullopt;
+    return true;
+  }
+  const std::string& name = node.input(idx);
+  auto it = init_map.find(name);
+  if (it == init_map.end() ||
+      it->second->data_type() != onnx::TensorProto::FLOAT ||
+      !QMoEDimsEqual(*it->second, expected_dims) ||
+      ConsumerCount(consumers_of, name) != 1) {
+    return false;
+  }
+  *out_name = name;
+  return true;
+}
+
+// The UINT8 analogue of QMoEOptionalFloatInput -- mirrors pruning.py's own
+// `_optional_uint8` closure (used for `fc1_zero_points`/`fc2_zero_points`,
+// `quant_type='int'` only).
+bool QMoEOptionalUint8Input(const onnx::NodeProto& node, int idx,
+                            const std::vector<int64_t>& expected_dims,
+                            const InitMap& init_map,
+                            const ConsumerMap& consumers_of,
+                            std::optional<std::string>* out_name) {
+  if (idx >= node.input_size() || node.input(idx).empty()) {
+    *out_name = std::nullopt;
+    return true;
+  }
+  const std::string& name = node.input(idx);
+  auto it = init_map.find(name);
+  if (it == init_map.end() ||
+      it->second->data_type() != onnx::TensorProto::UINT8 ||
+      !QMoEDimsEqual(*it->second, expected_dims) ||
+      ConsumerCount(consumers_of, name) != 1) {
+    return false;
+  }
+  *out_name = name;
+  return true;
+}
+
+// If `node` is a `com.microsoft::QMoE` node this pass can safely prune the
+// `inter_size` axis of, returns the matched QMoEChannelChain -- mirrors
+// pruning.py's own `_match_qmoe_producer` exactly (see this section's own
+// top comment, and pruning.py's own section comment points 1-5/9, for the
+// full derivation of every check below).
+std::optional<QMoEChannelChain> MatchQMoEProducer(
+    onnx::NodeProto* node, const InitMap& init_map,
+    const ConsumerMap& consumers_of) {
+  if (node->domain() != kComMicrosoftDomain || node->op_type() != "QMoE") {
+    return std::nullopt;
+  }
+
+  const std::string activation =
+      QMoEStringAttrOr(*node, "activation_type", "relu");
+  const int64_t swiglu_fusion = MatMulNBitsIntAttrOr(*node, "swiglu_fusion", 0);
+  const std::string quant_type_s = QMoEStringAttrOr(*node, "quant_type", "int");
+  int64_t bits = MatMulNBitsIntAttrOr(*node, "expert_weight_bits", 4);
+  int64_t block_size = MatMulNBitsIntAttrOr(*node, "block_size", 0);
+  const int64_t weights_prepacked =
+      MatMulNBitsIntAttrOr(*node, "weights_prepacked", -1);
+
+  if (!QMoEActivations().count(activation) || swiglu_fusion != 0) {
+    return std::nullopt;
+  }
+  if (quant_type_s != "int" && quant_type_s != "nvfp4") {
+    return std::nullopt;  // 'fp4'/'fp8'/'wfp4afp8' -- out of scope, see
+    // this section's own top comment.
+  }
+  if (weights_prepacked != -1 && weights_prepacked != 0) {
+    return std::nullopt;  // A CUTLASS mixed-GEMM prepacked byte layout, not
+    // the raw [N, K/pack] storage this pass slices.
+  }
+
+  auto has_input = [&](int idx) {
+    return idx < node->input_size() && !node->input(idx).empty();
+  };
+  if (has_input(8)) {
+    return std::nullopt;  // fc3_experts_weights present -- no CPU oracle.
+  }
+  if (has_input(14)) {
+    return std::nullopt;  // router_weights present -- DeepSeek-style
+    // combine-weight topology, out of scope.
+  }
+
+  // Matches `fc1_experts_weights`/`fc2_experts_weights` (inputs 2/5): both
+  // constant UINT8 rank-3 initializers, single consumer, agreeing on
+  // `num_experts` and on `hidden_size`/`inter_size` once `pack` codes/byte
+  // is accounted for -- shared by both quant_type paths below, since the
+  // raw weight shape/packing convention is identical either way (`bits=4`,
+  // `pack=2` for nvfp4; `pack = 8 / expert_weight_bits` for 'int').
+  auto match_weight_pair =
+      [&](int64_t pack) -> std::optional<std::array<int64_t, 3>> {
+    if (node->input_size() < 7 || !has_input(2) || !has_input(5)) {
+      return std::nullopt;
+    }
+    const std::string& fc1_name = node->input(2);
+    const std::string& fc2_name = node->input(5);
+    auto it1 = init_map.find(fc1_name);
+    auto it2 = init_map.find(fc2_name);
+    if (it1 == init_map.end() || it2 == init_map.end() ||
+        it1->second->data_type() != onnx::TensorProto::UINT8 ||
+        it2->second->data_type() != onnx::TensorProto::UINT8 ||
+        it1->second->dims_size() != 3 || it2->second->dims_size() != 3 ||
+        ConsumerCount(consumers_of, fc1_name) != 1 ||
+        ConsumerCount(consumers_of, fc2_name) != 1) {
+      return std::nullopt;
+    }
+    const int64_t num_experts = it1->second->dims(0);
+    const int64_t inter_size = it1->second->dims(1);
+    const int64_t fc1_k_packed = it1->second->dims(2);
+    const int64_t fc2_num_experts = it2->second->dims(0);
+    const int64_t hidden_size = it2->second->dims(1);
+    const int64_t fc2_k_packed = it2->second->dims(2);
+    if (fc2_num_experts != num_experts || fc1_k_packed * pack != hidden_size ||
+        fc2_k_packed * pack != inter_size) {
+      return std::nullopt;  // Also rules out a fused-swiglu fc1 (doubled
+      // row count).
+    }
+    return std::array<int64_t, 3>{num_experts, inter_size, hidden_size};
+  };
+
+  if (quant_type_s == "int") {
+    for (int idx = 15; idx <= 20; ++idx) {
+      if (has_input(idx)) {
+        return std::nullopt;  // FP4/FP8/global-scale/activation-scale
+        // inputs -- naturally absent for quant_type='int', checked
+        // explicitly rather than assumed.
+      }
+    }
+    if (bits != 2 && bits != 4 && bits != 8) {
+      return std::nullopt;
+    }
+    const int64_t pack = 8 / bits;
+    if (block_size != 0) {
+      if (block_size < 16) {
+        return std::nullopt;  // The CPU kernel's own floor.
+      }
+      if (block_size % pack != 0) {
+        return std::nullopt;  // Not byte-aligned to the sub-byte packing
+        // width -- every real block_size this op's kernel accepts already
+        // is, so this excludes no genuine configuration.
+      }
+    }
+
+    auto weight_shape = match_weight_pair(pack);
+    if (!weight_shape) {
+      return std::nullopt;
+    }
+    const int64_t num_experts = (*weight_shape)[0];
+    const int64_t inter_size = (*weight_shape)[1];
+    const int64_t hidden_size = (*weight_shape)[2];
+    if (block_size != 0 &&
+        (hidden_size % block_size != 0 || inter_size % block_size != 0)) {
+      return std::nullopt;  // Partial/padded final block -- declined; also
+      // transitively enforces "hidden_size/inter_size divisible by
+      // block_size * pack_size" via the zero_points shape checks below.
+    }
+
+    if (!has_input(3) || !has_input(6)) {
+      return std::nullopt;  // fc1_scales/fc2_scales required by this pass,
+      // even though the schema itself marks them optional.
+    }
+    const std::string& fc1_scale_name = node->input(3);
+    const std::string& fc2_scale_name = node->input(6);
+
+    int64_t hidden_blocks = 0, inter_blocks = 0;
+    std::vector<int64_t> fc1_scale_dims, fc2_scale_dims;
+    if (block_size != 0) {
+      hidden_blocks = hidden_size / block_size;
+      inter_blocks = inter_size / block_size;
+      fc1_scale_dims = {num_experts, inter_size, hidden_blocks};
+      fc2_scale_dims = {num_experts, hidden_size, inter_blocks};
+    } else {
+      fc1_scale_dims = {num_experts, inter_size};
+      fc2_scale_dims = {num_experts, hidden_size};
+    }
+    auto s1 = init_map.find(fc1_scale_name);
+    auto s2 = init_map.find(fc2_scale_name);
+    if (s1 == init_map.end() || s2 == init_map.end() ||
+        s1->second->data_type() != onnx::TensorProto::FLOAT ||
+        s2->second->data_type() != onnx::TensorProto::FLOAT ||
+        !QMoEDimsEqual(*s1->second, fc1_scale_dims) ||
+        !QMoEDimsEqual(*s2->second, fc2_scale_dims) ||
+        ConsumerCount(consumers_of, fc1_scale_name) != 1 ||
+        ConsumerCount(consumers_of, fc2_scale_name) != 1) {
+      return std::nullopt;
+    }
+
+    std::optional<std::string> fc1_bias, fc2_bias, fc1_zp, fc2_zp;
+    if (!QMoEOptionalFloatInput(*node, 4, {num_experts, inter_size}, init_map,
+                                consumers_of, &fc1_bias)) {
+      return std::nullopt;
+    }
+    if (!QMoEOptionalFloatInput(*node, 7, {num_experts, hidden_size}, init_map,
+                                consumers_of, &fc2_bias)) {
+      return std::nullopt;
+    }
+    // `zero_points`' own packed axis moves from N (whole-row case) to the
+    // trailing K-block axis (blockwise case) -- see pruning.py's own
+    // section comment, point 3.
+    std::vector<int64_t> fc1_zp_dims, fc2_zp_dims;
+    if (block_size != 0) {
+      fc1_zp_dims = {num_experts, inter_size, hidden_blocks / pack};
+      fc2_zp_dims = {num_experts, hidden_size, inter_blocks / pack};
+    } else {
+      fc1_zp_dims = {num_experts, inter_size / pack};
+      fc2_zp_dims = {num_experts, hidden_size / pack};
+    }
+    if (!QMoEOptionalUint8Input(*node, 11, fc1_zp_dims, init_map, consumers_of,
+                                &fc1_zp)) {
+      return std::nullopt;
+    }
+    if (!QMoEOptionalUint8Input(*node, 12, fc2_zp_dims, init_map, consumers_of,
+                                &fc2_zp)) {
+      return std::nullopt;
+    }
+
+    QMoEChannelChain chain;
+    chain.node = node;
+    chain.fc1_w = node->input(2);
+    chain.fc1_scale = fc1_scale_name;
+    chain.fc1_bias = fc1_bias;
+    chain.fc1_zp = fc1_zp;
+    chain.fc2_w = node->input(5);
+    chain.fc2_scale = fc2_scale_name;
+    chain.fc2_bias = fc2_bias;
+    chain.fc2_zp = fc2_zp;
+    chain.num_experts = num_experts;
+    chain.inter_size = inter_size;
+    chain.hidden_size = hidden_size;
+    chain.bits = bits;
+    chain.block_size = block_size;
+    chain.quant_type = QMoEQuantType::kInt;
+    return chain;
+  }
+
+  // quant_type == "nvfp4" -- see pruning.py's own section comment, point 9,
+  // for the full schema-derived (never real-kernel-confirmed -- there is no
+  // CPU kernel for this quant_type in this environment) reasoning below.
+  if (bits != 4) {
+    return std::nullopt;  // E2M1 is inherently 4-bit; must agree (or
+    // default) for pack=2 to match "2 values per byte".
+  }
+  if (block_size != 0 && block_size != 16) {
+    return std::nullopt;  // nvfp4 is normalized to block_size=16 regardless
+    // of the attribute; declined defensively for any other explicit value.
+  }
+  block_size = 16;  // The effective value the schema says the kernel
+  // always uses for nvfp4, even when the attribute itself is 0/absent.
+
+  for (int idx : {11, 12, 13}) {  // fc1/fc2/fc3_zero_points -- no zero-point
+    // concept for a signed E2M1 code.
+    if (has_input(idx)) {
+      return std::nullopt;
+    }
+  }
+  for (int idx : {17, 18, 19, 20}) {  // FP8-activation-only inputs -- nvfp4
+    // keeps float/fp16/bf16 activations.
+    if (has_input(idx)) {
+      return std::nullopt;
+    }
+  }
+
+  auto weight_shape = match_weight_pair(2);
+  if (!weight_shape) {
+    return std::nullopt;
+  }
+  const int64_t num_experts = (*weight_shape)[0];
+  const int64_t inter_size = (*weight_shape)[1];
+  const int64_t hidden_size = (*weight_shape)[2];
+  if (hidden_size % block_size != 0 || inter_size % block_size != 0) {
+    return std::nullopt;  // Partial/padded final block -- declined,
+    // mirroring the int blockwise case.
+  }
+
+  if (!has_input(3) || !has_input(6)) {
+    return std::nullopt;
+  }
+  const std::string& fc1_scale_name = node->input(3);
+  const std::string& fc2_scale_name = node->input(6);
+  const int64_t hidden_blocks = hidden_size / block_size;
+  const int64_t inter_blocks = inter_size / block_size;
+  const std::vector<int64_t> fc1_scale_dims = {num_experts, inter_size,
+                                               hidden_blocks};
+  const std::vector<int64_t> fc2_scale_dims = {num_experts, hidden_size,
+                                               inter_blocks};
+  auto s1 = init_map.find(fc1_scale_name);
+  auto s2 = init_map.find(fc2_scale_name);
+  if (s1 == init_map.end() || s2 == init_map.end() ||
+      s1->second->data_type() != onnx::TensorProto::FLOAT8E4M3FN ||
+      s2->second->data_type() != onnx::TensorProto::FLOAT8E4M3FN ||
+      !QMoEDimsEqual(*s1->second, fc1_scale_dims) ||
+      !QMoEDimsEqual(*s2->second, fc2_scale_dims) ||
+      ConsumerCount(consumers_of, fc1_scale_name) != 1 ||
+      ConsumerCount(consumers_of, fc2_scale_name) != 1) {
+    return std::nullopt;
+  }
+
+  if (node->input_size() <= 16 || !has_input(15) || !has_input(16)) {
+    return std::nullopt;  // fc1/fc2_global_scale -- required present for
+    // nvfp4 per the live schema's own input doc.
+  }
+  const std::string& fc1_gs_name = node->input(15);
+  const std::string& fc2_gs_name = node->input(16);
+  auto g1 = init_map.find(fc1_gs_name);
+  auto g2 = init_map.find(fc2_gs_name);
+  if (g1 == init_map.end() || g2 == init_map.end() ||
+      g1->second->data_type() != onnx::TensorProto::FLOAT ||
+      g2->second->data_type() != onnx::TensorProto::FLOAT ||
+      !QMoEDimsEqual(*g1->second, {num_experts}) ||
+      !QMoEDimsEqual(*g2->second, {num_experts}) ||
+      ConsumerCount(consumers_of, fc1_gs_name) != 1 ||
+      ConsumerCount(consumers_of, fc2_gs_name) != 1) {
+    return std::nullopt;
+  }
+
+  std::optional<std::string> fc1_bias, fc2_bias;
+  if (!QMoEOptionalFloatInput(*node, 4, {num_experts, inter_size}, init_map,
+                              consumers_of, &fc1_bias)) {
+    return std::nullopt;
+  }
+  if (!QMoEOptionalFloatInput(*node, 7, {num_experts, hidden_size}, init_map,
+                              consumers_of, &fc2_bias)) {
+    return std::nullopt;
+  }
+
+  QMoEChannelChain chain;
+  chain.node = node;
+  chain.fc1_w = node->input(2);
+  chain.fc1_scale = fc1_scale_name;
+  chain.fc1_bias = fc1_bias;
+  chain.fc1_zp = std::nullopt;
+  chain.fc2_w = node->input(5);
+  chain.fc2_scale = fc2_scale_name;
+  chain.fc2_bias = fc2_bias;
+  chain.fc2_zp = std::nullopt;
+  chain.num_experts = num_experts;
+  chain.inter_size = inter_size;
+  chain.hidden_size = hidden_size;
+  chain.bits = 4;
+  chain.block_size = block_size;
+  chain.quant_type = QMoEQuantType::kNvfp4;
+  chain.fc1_global_scale = fc1_gs_name;
+  chain.fc2_global_scale = fc2_gs_name;
+  return chain;
+}
+
+std::vector<QMoEChannelChain> FindQMoEChains(onnx::GraphProto* graph) {
+  InitMap init_map;
+  for (const auto& t : graph->initializer()) {
+    init_map[t.name()] = &t;
+  }
+  ConsumerMap consumers_of = ConsumersOf(graph);
+  std::vector<QMoEChannelChain> chains;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    auto chain = MatchQMoEProducer(node, init_map, consumers_of);
+    if (chain) {
+      chains.push_back(std::move(*chain));
+    }
+  }
+  return chains;
+}
+
+// Dequantizes a QMoE `quant_type='int'` fc1/fc2 weight tensor to a
+// float64 `[E, N, K]` array, for IMPORTANCE RANKING ONLY -- never written
+// back (this section's own top comment's "slice codes directly, never
+// dequant-requant" invariant). Mirrors pruning.py's own `_qmoe_dequantize`
+// exactly: `w` raw `[E, N, K/pack]` storage; `scale` `[E, N]`
+// (block_size==0) or `[E, N, K/block_size]` (block_size set);
+// `zero_points`, when present, packs along N (block_size==0) or the
+// trailing K-block axis (block_size set) -- see pruning.py's own section
+// comment, point 3.
+std::vector<double> QMoEDequantizeInt(const onnx::TensorProto& w,
+                                      const onnx::TensorProto& scale,
+                                      const onnx::TensorProto* zero_points,
+                                      int64_t bits, int64_t k,
+                                      int64_t block_size) {
+  const int64_t e = w.dims(0);
+  const int64_t n = w.dims(1);
+  const int64_t kp = w.dims(2);
+  const std::vector<uint8_t> packed = ReadUint8Tensor(w);  // [E*N, kp]
+  const std::vector<uint8_t> codes =
+      QMoEUnpackSubbyte(packed, e * n, kp, k, bits);  // [E*N, K]
+  const std::vector<float> scale_data = ReadFloatTensor(scale);
+  const double default_zp = static_cast<double>(QMoEDefaultZeroPoint(bits));
+  std::vector<double> out(static_cast<size_t>(e * n * k));
+
+  if (block_size > 0) {
+    const int64_t k_blocks = k / block_size;
+    std::vector<double> zp(static_cast<size_t>(e * n * k_blocks), default_zp);
+    if (zero_points != nullptr) {
+      const int64_t zp_packed_width = zero_points->dims(2);
+      const std::vector<uint8_t> zp_packed = ReadUint8Tensor(*zero_points);
+      const std::vector<uint8_t> zp_codes =
+          QMoEUnpackSubbyte(zp_packed, e * n, zp_packed_width, k_blocks, bits);
+      for (size_t i = 0; i < zp.size(); ++i) {
+        zp[i] = static_cast<double>(zp_codes[i]);
+      }
+    }
+    for (int64_t en = 0; en < e * n; ++en) {
+      for (int64_t kb = 0; kb < k_blocks; ++kb) {
+        const double s = static_cast<double>(
+            scale_data[static_cast<size_t>(en * k_blocks + kb)]);
+        const double z = zp[static_cast<size_t>(en * k_blocks + kb)];
+        for (int64_t j = 0; j < block_size; ++j) {
+          const int64_t idx = en * k + kb * block_size + j;
+          out[static_cast<size_t>(idx)] =
+              (static_cast<double>(codes[static_cast<size_t>(idx)]) - z) * s;
+        }
+      }
+    }
+  } else {
+    std::vector<double> zp(static_cast<size_t>(e * n), default_zp);
+    if (zero_points != nullptr) {
+      const int64_t zp_packed_width = zero_points->dims(1);
+      const std::vector<uint8_t> zp_packed = ReadUint8Tensor(*zero_points);
+      const std::vector<uint8_t> zp_codes =
+          QMoEUnpackSubbyte(zp_packed, e, zp_packed_width, n, bits);  // [E, N]
+      for (size_t i = 0; i < zp.size(); ++i) {
+        zp[i] = static_cast<double>(zp_codes[i]);
+      }
+    }
+    for (int64_t en = 0; en < e * n; ++en) {
+      const double s = static_cast<double>(scale_data[static_cast<size_t>(en)]);
+      const double z = zp[static_cast<size_t>(en)];
+      for (int64_t j = 0; j < k; ++j) {
+        const int64_t idx = en * k + j;
+        out[static_cast<size_t>(idx)] =
+            (static_cast<double>(codes[static_cast<size_t>(idx)]) - z) * s;
+      }
+    }
+  }
+  return out;
+}
+
+// Dequantizes a QMoE `quant_type='nvfp4'` fc1/fc2 weight tensor to a
+// float64 `[E, N, K]` array, IMPORTANCE RANKING ONLY. Mirrors pruning.py's
+// own `_qmoe_dequantize_nvfp4` exactly: `dequantized[e, n, k] =
+// e2m1_decode(code[e, n, k]) * block_scale[e, n, k // 16] * global_scale[e]`
+// -- `block_size` fixed at 16.
+std::vector<double> QMoEDequantizeNvfp4(const onnx::TensorProto& w,
+                                        const onnx::TensorProto& block_scale,
+                                        const onnx::TensorProto& global_scale,
+                                        int64_t k) {
+  constexpr int64_t kBlockSize = 16;
+  const int64_t e = w.dims(0);
+  const int64_t n = w.dims(1);
+  const int64_t kp = w.dims(2);
+  const std::vector<uint8_t> packed = ReadUint8Tensor(w);
+  const std::vector<uint8_t> codes =
+      QMoEUnpackSubbyte(packed, e * n, kp, k, 4);  // [E*N, K] E2M1 codes.
+  const int64_t k_blocks = k / kBlockSize;
+  const std::vector<uint8_t> bs_raw = ReadUint8Tensor(block_scale);
+  const std::vector<float> gs = ReadFloatTensor(global_scale);
+  const auto& f8_table = QMoEFloat8E4M3Table();
+  const auto& e2m1_table = QMoEE2M1Table();
+
+  std::vector<double> out(static_cast<size_t>(e * n * k));
+  for (int64_t ei = 0; ei < e; ++ei) {
+    const double g = static_cast<double>(gs[static_cast<size_t>(ei)]);
+    for (int64_t ni = 0; ni < n; ++ni) {
+      const int64_t en = ei * n + ni;
+      for (int64_t kb = 0; kb < k_blocks; ++kb) {
+        const double bscale =
+            f8_table[bs_raw[static_cast<size_t>(en * k_blocks + kb)]];
+        for (int64_t j = 0; j < kBlockSize; ++j) {
+          const int64_t idx = en * k + kb * kBlockSize + j;
+          const uint8_t code = codes[static_cast<size_t>(idx)];
+          out[static_cast<size_t>(idx)] = e2m1_table[code] * bscale * g;
+        }
+      }
+    }
+  }
+  return out;
+}
+
+// Dispatches to QMoEDequantizeInt/QMoEDequantizeNvfp4 for `which` fc1/fc2 of
+// `chain` -- mirrors pruning.py's own `_qmoe_dequantize_fc`.
+std::vector<double> QMoEDequantizeFc(
+    const QMoEChannelChain& chain,
+    const std::unordered_map<std::string, onnx::TensorProto*>& init_map,
+    bool is_fc1) {
+  const std::string& w_name = is_fc1 ? chain.fc1_w : chain.fc2_w;
+  const std::string& scale_name = is_fc1 ? chain.fc1_scale : chain.fc2_scale;
+  const int64_t k = is_fc1 ? chain.hidden_size : chain.inter_size;
+  const onnx::TensorProto* w = init_map.at(w_name);
+  const onnx::TensorProto* scale = init_map.at(scale_name);
+  if (chain.quant_type == QMoEQuantType::kNvfp4) {
+    const std::string& gs_name =
+        is_fc1 ? *chain.fc1_global_scale : *chain.fc2_global_scale;
+    return QMoEDequantizeNvfp4(*w, *scale, *init_map.at(gs_name), k);
+  }
+  const std::optional<std::string>& zp_name =
+      is_fc1 ? chain.fc1_zp : chain.fc2_zp;
+  const onnx::TensorProto* zp = zp_name ? init_map.at(*zp_name) : nullptr;
+  return QMoEDequantizeInt(*w, *scale, zp, chain.bits, k, chain.block_size);
+}
+
+// Combined (root-sum-square) L2-norm importance per `inter_size` channel
+// index -- mirrors pruning.py's own `_qmoe_channel_importance` exactly:
+// `fc1`'s own dequantized row (across every expert and `hidden_size` at
+// once) plus `fc2`'s own dequantized column (same reduction), plus
+// `fc1_experts_bias`'s own entry when present.
+std::vector<double> QMoEChannelImportance(
+    const QMoEChannelChain& chain,
+    const std::unordered_map<std::string, onnx::TensorProto*>& init_map) {
+  const int64_t e = chain.num_experts;
+  const int64_t inter = chain.inter_size;
+  const int64_t hidden = chain.hidden_size;
+  const std::vector<double> fc1_dq =
+      QMoEDequantizeFc(chain, init_map, true);  // [E, inter, hidden]
+  const std::vector<double> fc2_dq =
+      QMoEDequantizeFc(chain, init_map, false);  // [E, hidden, inter]
+
+  std::vector<double> squared(static_cast<size_t>(inter), 0.0);
+  for (int64_t ei = 0; ei < e; ++ei) {
+    for (int64_t ni = 0; ni < inter; ++ni) {
+      double sq = 0.0;
+      const double* row = fc1_dq.data() + (ei * inter + ni) * hidden;
+      for (int64_t h = 0; h < hidden; ++h) {
+        sq += row[h] * row[h];
+      }
+      squared[static_cast<size_t>(ni)] += sq;
+    }
+  }
+  for (int64_t ei = 0; ei < e; ++ei) {
+    for (int64_t h = 0; h < hidden; ++h) {
+      const double* row = fc2_dq.data() + (ei * hidden + h) * inter;
+      for (int64_t ni = 0; ni < inter; ++ni) {
+        squared[static_cast<size_t>(ni)] += row[ni] * row[ni];
+      }
+    }
+  }
+  if (chain.fc1_bias) {
+    const std::vector<float> bias =
+        ReadFloatTensor(*init_map.at(*chain.fc1_bias));
+    for (int64_t ei = 0; ei < e; ++ei) {
+      for (int64_t ni = 0; ni < inter; ++ni) {
+        const double v =
+            static_cast<double>(bias[static_cast<size_t>(ei * inter + ni)]);
+        squared[static_cast<size_t>(ni)] += v * v;
+      }
+    }
+  }
+  std::vector<double> importance(static_cast<size_t>(inter));
+  for (int64_t ni = 0; ni < inter; ++ni) {
+    importance[static_cast<size_t>(ni)] =
+        std::sqrt(squared[static_cast<size_t>(ni)]);
+  }
+  return importance;
+}
+
+// Resolves a target `inter_size` keep-set to whole `block_size`-sized
+// groups: aggregates `importance` into one combined (root-sum-square)
+// score per block, ranks BLOCKS (not individual channels) by that score,
+// and keeps the top
+// `max(1, n / block_size - round(n / block_size * sparsity))` of them --
+// mirrors pruning.py's own `_qmoe_block_aligned_keep` exactly (see this
+// section's own top comment, "THE BLOCK-ALIGNMENT CONSTRAINT"). Ranking at
+// block granularity from the start (rather than computing a channel-level
+// keep-set and checking alignment after the fact) means the result is
+// ALWAYS block-aligned by construction. Returns nullopt when every block
+// would be kept (rounds down to nothing to prune for this layer). The
+// returned indices are ascending and, since blocks are visited in
+// ascending block-id order, each kept block contributes exactly
+// `block_size` CONSECUTIVE entries -- the caller (ApplyQMoEChannelChains)
+// relies on this to recover `keep_block_idx` cheaply (`keep[i] /
+// block_size` for `i` stepping by `block_size`) rather than a separate
+// dedup pass.
+std::optional<std::vector<int64_t>> QMoEBlockAlignedKeep(
+    const std::vector<double>& importance, int64_t n, int64_t block_size,
+    double sparsity) {
+  const int64_t num_blocks = n / block_size;
+  std::vector<double> block_importance(static_cast<size_t>(num_blocks));
+  for (int64_t b = 0; b < num_blocks; ++b) {
+    double sq = 0.0;
+    for (int64_t j = 0; j < block_size; ++j) {
+      const double v = importance[static_cast<size_t>(b * block_size + j)];
+      sq += v * v;
+    }
+    block_importance[static_cast<size_t>(b)] = std::sqrt(sq);
+  }
+  const int64_t keep_blocks_count = std::max<int64_t>(
+      1, num_blocks - std::llround(static_cast<double>(num_blocks) * sparsity));
+  if (keep_blocks_count >= num_blocks) {
+    return std::nullopt;
+  }
+  const std::vector<int64_t> keep_block_idx =
+      StableTopKIndicesAscending(block_importance, keep_blocks_count);
+  std::vector<int64_t> keep;
+  keep.reserve(static_cast<size_t>(keep_blocks_count * block_size));
+  for (int64_t b : keep_block_idx) {
+    for (int64_t j = 0; j < block_size; ++j) {
+      keep.push_back(b * block_size + j);
+    }
+  }
+  return keep;
+}
+
+// Per-expert row (axis 1) index-select of a FLOAT tensor shaped `[E, N]`
+// (`force_rank3 == false`, `row_width` always 1) or `[E, N, row_width]`
+// (`force_rank3 == true`) -- used for `fc1/fc2_experts_bias` (always
+// rank-2) and, for `quant_type='int'`, `fc1/fc2_scales` (rank-2 whole-row,
+// rank-3 blockwise). `force_rank3` is passed explicitly by the caller
+// rather than inferred from `row_width == 1` -- `row_width` (`hidden_blocks`
+// for `fc1_scales`) can genuinely equal 1 in the BLOCKWISE case too
+// (`hidden_size == block_size`), which must still come back rank-3 (a real
+// shape this op's own schema documents, re-confirmed live in pruning.py's
+// own section comment) rather than collapsing to the whole-row tensor's
+// own rank-2 shape.
+void QMoESliceFloatAxis1(onnx::TensorProto* t, int64_t e, int64_t n,
+                         int64_t row_width, const std::vector<int64_t>& keep,
+                         bool force_rank3) {
+  const std::vector<float> data = ReadFloatTensor(*t);  // [E, N, row_width]
+  const int64_t kc = static_cast<int64_t>(keep.size());
+  std::vector<float> out(static_cast<size_t>(e * kc * row_width));
+  for (int64_t ei = 0; ei < e; ++ei) {
+    for (int64_t i = 0; i < kc; ++i) {
+      std::memcpy(
+          out.data() + (ei * kc + i) * row_width,
+          data.data() + (ei * n + keep[static_cast<size_t>(i)]) * row_width,
+          static_cast<size_t>(row_width) * sizeof(float));
+    }
+  }
+  const std::vector<int64_t> dims = force_rank3
+                                        ? std::vector<int64_t>{e, kc, row_width}
+                                        : std::vector<int64_t>{e, kc};
+  SetFloatTensorData(t, dims, out);
+}
+
+// The FLOAT8E4M3FN analogue of QMoESliceFloatAxis1 -- used for
+// `quant_type='nvfp4'`'s own `fc1_scales` (always rank-3, `row_width` =
+// `hidden_blocks`). Raw-byte slice, no decode/re-encode (1-byte dtype, no
+// endianness concern either).
+void QMoESliceFloat8Axis1(onnx::TensorProto* t, int64_t e, int64_t n,
+                          int64_t row_width, const std::vector<int64_t>& keep) {
+  const std::vector<uint8_t> data = ReadUint8Tensor(*t);
+  const int64_t kc = static_cast<int64_t>(keep.size());
+  std::vector<uint8_t> out(static_cast<size_t>(e * kc * row_width));
+  for (int64_t ei = 0; ei < e; ++ei) {
+    for (int64_t i = 0; i < kc; ++i) {
+      std::memcpy(
+          out.data() + (ei * kc + i) * row_width,
+          data.data() + (ei * n + keep[static_cast<size_t>(i)]) * row_width,
+          static_cast<size_t>(row_width));
+    }
+  }
+  SetFloat8E4M3TensorData(t, {e, kc, row_width}, out);
+}
+
+// The UINT8 analogue -- used for `fc1_experts_weights` (`row_width` = the
+// packed `K/pack` width, an axis-1 index-select since the pruned
+// `inter_size` axis is never the packed one for `fc1`) and, when
+// `block_size` is set, `fc1_zero_points` (whose own packed axis has moved
+// off `inter_size` entirely, so it too is a plain index-select here).
+void QMoESliceUint8Axis1(onnx::TensorProto* t, int64_t e, int64_t n,
+                         int64_t row_width, const std::vector<int64_t>& keep,
+                         const std::vector<int64_t>& out_dims) {
+  const std::vector<uint8_t> data = ReadUint8Tensor(*t);
+  const int64_t kc = static_cast<int64_t>(keep.size());
+  std::vector<uint8_t> out(static_cast<size_t>(e * kc * row_width));
+  for (int64_t ei = 0; ei < e; ++ei) {
+    for (int64_t i = 0; i < kc; ++i) {
+      std::memcpy(
+          out.data() + (ei * kc + i) * row_width,
+          data.data() + (ei * n + keep[static_cast<size_t>(i)]) * row_width,
+          static_cast<size_t>(row_width));
+    }
+  }
+  SetUint8TensorData(t, out_dims, out);
+}
+
+// Per-expert, per-`hidden_size`-row, LAST-axis (block-index) select of a
+// FLOAT tensor shaped `[E, hidden, num_blocks]` -- `quant_type='int'`'s own
+// `fc2_scales` in the blockwise case, sliced by *block* index
+// (`keep_block_idx`), not channel index, since `fc2`'s own blocks group
+// along `inter_size` (this pass's own pruned axis) -- see this section's
+// own top comment.
+void QMoESliceFloatAxis2(onnx::TensorProto* t, int64_t e, int64_t hidden,
+                         int64_t num_blocks,
+                         const std::vector<int64_t>& keep_block_idx) {
+  const std::vector<float> data =
+      ReadFloatTensor(*t);  // [E, hidden, num_blocks]
+  const int64_t kb = static_cast<int64_t>(keep_block_idx.size());
+  std::vector<float> out(static_cast<size_t>(e * hidden * kb));
+  for (int64_t r = 0; r < e * hidden; ++r) {
+    for (int64_t i = 0; i < kb; ++i) {
+      out[static_cast<size_t>(r * kb + i)] = data[static_cast<size_t>(
+          r * num_blocks + keep_block_idx[static_cast<size_t>(i)])];
+    }
+  }
+  SetFloatTensorData(t, {e, hidden, kb}, out);
+}
+
+// The FLOAT8E4M3FN analogue of QMoESliceFloatAxis2 -- `quant_type='nvfp4'`'s
+// own `fc2_scales`.
+void QMoESliceFloat8Axis2(onnx::TensorProto* t, int64_t e, int64_t hidden,
+                          int64_t num_blocks,
+                          const std::vector<int64_t>& keep_block_idx) {
+  const std::vector<uint8_t> data = ReadUint8Tensor(*t);
+  const int64_t kb = static_cast<int64_t>(keep_block_idx.size());
+  std::vector<uint8_t> out(static_cast<size_t>(e * hidden * kb));
+  for (int64_t r = 0; r < e * hidden; ++r) {
+    for (int64_t i = 0; i < kb; ++i) {
+      out[static_cast<size_t>(r * kb + i)] = data[static_cast<size_t>(
+          r * num_blocks + keep_block_idx[static_cast<size_t>(i)])];
+    }
+  }
+  SetFloat8E4M3TensorData(t, {e, hidden, kb}, out);
+}
+
+// The actual apply step -- mirrors pruning.py's own
+// `_apply_qmoe_channel_chains` exactly, including its own two distinct
+// slicing shapes (whole-row/`pack`-floored vs. block-aligned) and every
+// per-tensor packing special case documented on each call site below. A
+// standalone application pass (not sharing state with
+// ApplyStructuredPruning's own combined TouchedState -- `com.microsoft::
+// QMoE`'s own weight names can never collide with any plain-float/
+// MatMulNBits/QDQ/MatMulBnb4 chain this file's other passes match, so a
+// local `touched` set mirroring pruning.py's own is all that's needed).
+void ApplyQMoEChannelChains(onnx::GraphProto* graph,
+                            std::vector<QMoEChannelChain>& chains,
+                            double sparsity) {
+  std::unordered_map<std::string, onnx::TensorProto*> init_map;
+  for (int i = 0; i < graph->initializer_size(); ++i) {
+    onnx::TensorProto* t = graph->mutable_initializer(i);
+    init_map[t->name()] = t;
+  }
+  std::unordered_set<std::string> touched;
+
+  for (auto& chain : chains) {
+    std::vector<std::string> weight_names = {chain.fc1_w, chain.fc2_w,
+                                             chain.fc1_scale};
+    if (chain.fc1_bias) weight_names.push_back(*chain.fc1_bias);
+    if (chain.fc1_zp) weight_names.push_back(*chain.fc1_zp);
+    if (chain.block_size) {
+      // Blockwise fc2_scales -- and fc2_zero_points, if present -- are now
+      // also mutated below (their own trailing axis is inter_size-block-
+      // indexed), unlike the whole-row case where neither depends on
+      // inter_size at all.
+      weight_names.push_back(chain.fc2_scale);
+      if (chain.fc2_zp) weight_names.push_back(*chain.fc2_zp);
+    }
+    bool already_touched = false;
+    for (const auto& nm : weight_names) {
+      if (touched.count(nm)) {
+        already_touched = true;
+        break;
+      }
+    }
+    if (already_touched) {
+      continue;  // A shared/tied initializer another QMoE node already
+      // resized.
+    }
+    for (const auto& nm : weight_names) {
+      touched.insert(nm);
+    }
+
+    const int64_t n = chain.inter_size;
+    const int64_t pack = 8 / chain.bits;
+    const int64_t block_size = chain.block_size;
+    const int64_t e = chain.num_experts;
+    const int64_t hidden = chain.hidden_size;
+
+    std::vector<int64_t> keep;
+    std::vector<int64_t> keep_block_idx;
+    if (block_size > 0) {
+      // Resolved at block granularity from the start -- see
+      // QMoEBlockAlignedKeep. A block is always a multiple of `pack` (the
+      // matcher itself requires `block_size % pack == 0`), so this also
+      // transitively satisfies the same "survivor count is a multiple of
+      // `pack`" constraint the whole-row case floors to separately below.
+      const std::vector<double> importance =
+          QMoEChannelImportance(chain, init_map);
+      auto keep_opt = QMoEBlockAlignedKeep(importance, n, block_size, sparsity);
+      if (!keep_opt) {
+        continue;  // Rounds down to nothing for this layer -- no-op.
+      }
+      keep = std::move(*keep_opt);
+      keep_block_idx.reserve(keep.size() / static_cast<size_t>(block_size));
+      for (size_t i = 0; i < keep.size();
+           i += static_cast<size_t>(block_size)) {
+        keep_block_idx.push_back(keep[i] / block_size);
+      }
+    } else {
+      int64_t keep_count = std::max<int64_t>(
+          1, n - std::llround(static_cast<double>(n) * sparsity));
+      // The survivor count must itself stay an exact multiple of `pack`:
+      // this environment's own QMoE kernel derives `inter_size` purely
+      // from `fc2_experts_weights`' own packed last axis length times
+      // `pack` -- it has no way to represent "the last packed byte's own
+      // high nibble is unused padding". So a survivor count that isn't
+      // itself a multiple of `pack` is rounded DOWN to the nearest one
+      // here (floored at `pack`, never below it), mirroring pruning.py's
+      // own `_apply_qmoe_channel_chains` exactly.
+      keep_count = std::max<int64_t>(pack, (keep_count / pack) * pack);
+      if (keep_count >= n) {
+        continue;  // Rounds down to nothing for this layer -- no-op.
+      }
+      const std::vector<double> importance =
+          QMoEChannelImportance(chain, init_map);
+      keep = StableTopKIndicesAscending(importance, keep_count);
+    }
+
+    // fc1_experts_weights: [E, inter_size, hidden_size/pack] -- the pruned
+    // axis (1) is the UNPACKED one (packing lives on axis 2, untouched), so
+    // this is a plain per-expert row index-select, no unpack/repack needed
+    // at all -- unaffected by block_size (fc1's own blocks, if any, group
+    // along hidden_size, an axis this pass never touches).
+    {
+      onnx::TensorProto* fc1_w = init_map.at(chain.fc1_w);
+      const int64_t kp = fc1_w->dims(2);
+      const int64_t kc = static_cast<int64_t>(keep.size());
+      QMoESliceUint8Axis1(fc1_w, e, n, kp, keep, {e, kc, kp});
+    }
+
+    // fc1_scales: [E, inter_size] (whole-row) or [E, inter_size,
+    // hidden_blocks] (blockwise) -- `keep` always indexes axis 1 either
+    // way. FLOAT for quant_type='int', FLOAT8E4M3FN for quant_type='nvfp4'.
+    {
+      onnx::TensorProto* fc1_scale = init_map.at(chain.fc1_scale);
+      const int64_t row_width = block_size > 0 ? (hidden / block_size) : 1;
+      if (chain.quant_type == QMoEQuantType::kNvfp4) {
+        QMoESliceFloat8Axis1(fc1_scale, e, n, row_width, keep);
+      } else {
+        QMoESliceFloatAxis1(fc1_scale, e, n, row_width, keep, block_size > 0);
+      }
+    }
+
+    if (chain.fc1_bias) {
+      onnx::TensorProto* fc1_bias = init_map.at(*chain.fc1_bias);
+      QMoESliceFloatAxis1(fc1_bias, e, n, 1, keep, /*force_rank3=*/false);
+    }
+
+    if (chain.fc1_zp) {
+      onnx::TensorProto* fc1_zp = init_map.at(*chain.fc1_zp);
+      const int64_t kc = static_cast<int64_t>(keep.size());
+      if (block_size > 0) {
+        // fc1_zero_points: [E, inter_size, hidden_blocks/pack] -- blockwise
+        // moves the packed axis off of N entirely, so slicing N (axis 1)
+        // is now a plain index-select, no unpack/repack needed at all.
+        const int64_t hb = hidden / block_size;
+        QMoESliceUint8Axis1(fc1_zp, e, n, hb / pack, keep, {e, kc, hb / pack});
+      } else {
+        // fc1_zero_points: [E, inter_size/pack] -- packed along the SAME
+        // axis being pruned, so this genuinely needs unpack/select/repack.
+        const int64_t zp_packed_width = fc1_zp->dims(1);
+        const std::vector<uint8_t> packed = ReadUint8Tensor(*fc1_zp);
+        const std::vector<uint8_t> unpacked = QMoEUnpackSubbyte(
+            packed, e, zp_packed_width, n, chain.bits);  // [E, N]
+        std::vector<uint8_t> selected(static_cast<size_t>(e * kc));
+        for (int64_t ei = 0; ei < e; ++ei) {
+          for (int64_t i = 0; i < kc; ++i) {
+            selected[static_cast<size_t>(ei * kc + i)] =
+                unpacked[static_cast<size_t>(ei * n +
+                                             keep[static_cast<size_t>(i)])];
+          }
+        }
+        const std::vector<uint8_t> repacked =
+            QMoEPackSubbyte(selected, e, kc, chain.bits);
+        const int64_t new_pw = (kc + pack - 1) / pack;
+        SetUint8TensorData(fc1_zp, {e, new_pw}, repacked);
+      }
+    }
+
+    // fc2_experts_weights: [E, hidden_size, inter_size/pack] -- the pruned
+    // axis (inter_size) IS the packed one here, so this needs a real
+    // unpack/select/repack round trip. Packing is flat/block-boundary-
+    // oblivious (confirmed empirically in pruning.py's own section
+    // comment, point 3), so this is unaffected by block_size beyond `keep`
+    // itself already being block-aligned.
+    {
+      onnx::TensorProto* fc2_w = init_map.at(chain.fc2_w);
+      const int64_t packed_width = fc2_w->dims(2);
+      const int64_t kc = static_cast<int64_t>(keep.size());
+      const std::vector<uint8_t> packed = ReadUint8Tensor(*fc2_w);
+      const std::vector<uint8_t> unpacked = QMoEUnpackSubbyte(
+          packed, e * hidden, packed_width, n, chain.bits);  // [E*hidden, n]
+      std::vector<uint8_t> selected(static_cast<size_t>(e * hidden * kc));
+      for (int64_t r = 0; r < e * hidden; ++r) {
+        for (int64_t i = 0; i < kc; ++i) {
+          selected[static_cast<size_t>(r * kc + i)] =
+              unpacked[static_cast<size_t>(r * n +
+                                           keep[static_cast<size_t>(i)])];
+        }
+      }
+      const std::vector<uint8_t> repacked =
+          QMoEPackSubbyte(selected, e * hidden, kc, chain.bits);
+      const int64_t new_pw = (kc + pack - 1) / pack;
+      SetUint8TensorData(fc2_w, {e, hidden, new_pw}, repacked);
+    }
+
+    if (block_size > 0) {
+      // fc2_scales/fc2_zero_points: [E, hidden_size, inter_blocks(/pack)]
+      // -- unlike the whole-row case, these now DO depend on inter_size,
+      // via the block axis, so they must be cut too -- by BLOCK index
+      // (`keep_block_idx`), not channel index (`keep`).
+      onnx::TensorProto* fc2_scale = init_map.at(chain.fc2_scale);
+      const int64_t inter_blocks = n / block_size;
+      if (chain.quant_type == QMoEQuantType::kNvfp4) {
+        QMoESliceFloat8Axis2(fc2_scale, e, hidden, inter_blocks,
+                             keep_block_idx);
+      } else {
+        QMoESliceFloatAxis2(fc2_scale, e, hidden, inter_blocks, keep_block_idx);
+      }
+      if (chain.fc2_zp) {
+        onnx::TensorProto* fc2_zp = init_map.at(*chain.fc2_zp);
+        const int64_t zp_packed_width = fc2_zp->dims(2);
+        const std::vector<uint8_t> packed = ReadUint8Tensor(*fc2_zp);
+        const std::vector<uint8_t> unpacked = QMoEUnpackSubbyte(
+            packed, e * hidden, zp_packed_width, inter_blocks, chain.bits);
+        const int64_t kb = static_cast<int64_t>(keep_block_idx.size());
+        std::vector<uint8_t> selected(static_cast<size_t>(e * hidden * kb));
+        for (int64_t r = 0; r < e * hidden; ++r) {
+          for (int64_t i = 0; i < kb; ++i) {
+            selected[static_cast<size_t>(r * kb + i)] =
+                unpacked[static_cast<size_t>(
+                    r * inter_blocks + keep_block_idx[static_cast<size_t>(i)])];
+          }
+        }
+        const std::vector<uint8_t> repacked =
+            QMoEPackSubbyte(selected, e * hidden, kb, chain.bits);
+        const int64_t new_pw = (kb + pack - 1) / pack;
+        SetUint8TensorData(fc2_zp, {e, hidden, new_pw}, repacked);
+      }
+    }
+    // fc2_experts_bias always indexes hidden_size, fc2's own OUTPUT axis --
+    // unaffected by an inter_size cut regardless of block_size, the same
+    // reasoning plain MoE's own fc2 bias already gets -- never sliced
+    // here. fc1/fc2_global_scale (nvfp4 only) are per-EXPERT, not
+    // per-channel -- expert-channel pruning never touches these either. In
+    // the whole-row case (block_size == 0), fc2_scales/fc2_zero_points are
+    // the same "indexes hidden_size only" shape and are likewise never
+    // sliced.
+  }
+}
+
 // --- Subgraph recursion ------------------------------------------------
 //
 // Mirrors pruning.py's own `_iter_subgraphs` and the "Subgraph recursion"
@@ -11691,6 +12960,48 @@ onnx::ModelProto ApplyAttentionHeadPruning(const onnx::ModelProto& model,
         FindMatMulNBitsQkvChains(graph);
     if (!matmul_nbits_qkv_chains.empty()) {
       ApplyMatMulNBitsQkvChains(graph, matmul_nbits_qkv_chains, sparsity);
+    }
+  }
+  return out;
+}
+
+// QMoE expert-channel pruning: removes intermediate (`inter_size`) channels
+// from every expert of a matched `com.microsoft::QMoE` node at once -- the
+// quantized-weight counterpart of ApplyStructuredPruning's own plain-float
+// channel pruning, targeting QMoE's own packed `uint8` `fc1`/`fc2` weights
+// (plus their `scales`/`zero_points`/`global_scale`, co-sliced in lockstep)
+// instead of plain floats. See this file's own "QMoE (com.microsoft,
+// quantized-weight Mixture-of-Experts) expert-channel structured pruning"
+// section comment above (MatchQMoEProducer/ApplyQMoEChannelChains) for the
+// exact matched topology, every empirically-confirmed decline, and why
+// whole-expert removal (needing runtime calibration data this C++ port has
+// no ONNX Runtime linked in to gather) stays out of scope. A standalone
+// entry point -- unlike MatMulNBits/MatMulBnb4/QDQ above, QMoE is not
+// folded into ApplyStructuredPruning's own combined pass, since it targets
+// a wholly disjoint node type (`com.microsoft::QMoE`) that can never
+// collide with anything that pass already matches; mirrors pruning.py's
+// own separate `apply_qmoe_expert_channel_pruning` top-level function.
+onnx::ModelProto ApplyQMoEExpertChannelPruning(const onnx::ModelProto& model,
+                                               double sparsity) {
+  if (!(sparsity >= 0.0 && sparsity < 1.0)) {
+    throw std::invalid_argument(
+        "ApplyQMoEExpertChannelPruning: sparsity must be in [0, 1), got " +
+        std::to_string(sparsity));
+  }
+  onnx::ModelProto out = model;
+
+  // Subgraph-aware (IterSubgraphs, see this file's own "Subgraph
+  // recursion" section comment above): every `QMoE` node is matched and
+  // pruned inside a nested If/Loop/Scan/BeamSearch-family subgraph, at any
+  // nesting depth, exactly as if that subgraph were its own top-level
+  // graph -- each returned GraphProto* gets its own fresh FindQMoEChains
+  // call and its own local `touched` state inside ApplyQMoEChannelChains,
+  // mirroring pruning.py's own `apply_qmoe_expert_channel_pruning` loop
+  // over `_iter_subgraphs(out.graph)` exactly.
+  for (onnx::GraphProto* graph : IterSubgraphs(out.mutable_graph())) {
+    std::vector<QMoEChannelChain> chains = FindQMoEChains(graph);
+    if (!chains.empty()) {
+      ApplyQMoEChannelChains(graph, chains, sparsity);
     }
   }
   return out;

--- a/onnxsim/structured_pruning_entry.h
+++ b/onnxsim/structured_pruning_entry.h
@@ -23,5 +23,18 @@ onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
 onnx::ModelProto ApplyAttentionHeadPruning(const onnx::ModelProto& model,
                                            double sparsity);
 
+// Removes intermediate (`inter_size`) channels from every expert of a
+// matched `com.microsoft::MoE` node at once -- real structural pruning
+// (smaller fc1/fc2 weight tensors, smaller per-expert matmuls on any
+// runtime), the C++ port of pruning.py's own
+// `apply_moe_expert_channel_pruning`. `num_experts` (whole-expert pruning,
+// which needs runtime calibration data this build has no ONNX Runtime to
+// provide -- see CLAUDE.md) is out of scope; see
+// structured_pruning_entry.cpp's own "MoE (com.microsoft::MoE) expert-
+// intermediate-channel pruning" section comment for the full scope and
+// safety argument.
+onnx::ModelProto ApplyMoeExpertChannelPruning(const onnx::ModelProto& model,
+                                              double sparsity);
+
 onnx::ModelProto ApplyQMoEExpertChannelPruning(const onnx::ModelProto& model,
                                                double sparsity);

--- a/onnxsim/structured_pruning_entry.h
+++ b/onnxsim/structured_pruning_entry.h
@@ -22,3 +22,6 @@ onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
 
 onnx::ModelProto ApplyAttentionHeadPruning(const onnx::ModelProto& model,
                                            double sparsity);
+
+onnx::ModelProto ApplyQMoEExpertChannelPruning(const onnx::ModelProto& model,
+                                               double sparsity);

--- a/tests/test_moe_pruning_cpp.py
+++ b/tests/test_moe_pruning_cpp.py
@@ -1,0 +1,513 @@
+"""Tests for ``onnxsim.apply_moe_expert_channel_pruning_cpp`` -- the C++-backed
+port of ``onnxsim.apply_moe_expert_channel_pruning`` (see
+``onnxsim/structured_pruning_entry.cpp``'s "MoE (com.microsoft::MoE)
+expert-intermediate-channel pruning" section). Data-free/structural only --
+whole-expert pruning (``onnxsim.apply_moe_whole_expert_pruning``, which needs
+runtime calibration data via an ``onnxruntime.InferenceSession`` observing
+router activations) is NOT ported, matching this codebase's established
+C++-port scope decision (this build has no ONNX Runtime linked into it at
+all -- see the repo's own CLAUDE.md).
+
+Tests here are adapted from ``tests/test_pruning.py``'s own
+``apply_moe_expert_channel_pruning`` coverage (search
+"MoE expert-intermediate-channel pruning" there) -- NOT its separate
+"MoE whole-expert pruning" section, which is out of scope here. Every test
+that actually prunes something runs the result through a real onnxruntime
+CPU session, exactly like the Python-side tests do: confirmed, empirically,
+to be the one real oracle available for ``com.microsoft::MoE`` in this
+environment.
+"""
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(body, initializer=(), opset=21):
+    # Pinning ir_version: 10, same as tests/test_pruning.py's own _model --
+    # matches the older onnxruntime bundled with some CI wheels (which cap
+    # at IR version 11); _run below runs these models through onnxruntime.
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _moe_model(
+    fc1_w,
+    fc2_w,
+    fc1_b=None,
+    fc2_b=None,
+    fc3_w=None,
+    activation="relu",
+    swiglu_fusion=0,
+    k=2,
+    tokens=6,
+):
+    num_experts, inter, hidden = fc1_w.shape
+    fc1_b_arg = "FC1B" if fc1_b is not None else ""
+    fc2_b_arg = "FC2B" if fc2_b is not None else ""
+    fc3_w_arg = "FC3W" if fc3_w is not None else ""
+    model = _model(
+        f"""
+        g (float[{tokens},{hidden}] X, float[{tokens},{num_experts}] R) => (float[{tokens},{hidden}] Y)
+        {{
+          Y = com.microsoft.MoE <k={k}, activation_type="{activation}", swiglu_fusion={swiglu_fusion}> (X, R, FC1W, {fc1_b_arg}, FC2W, {fc2_b_arg}, {fc3_w_arg})
+        }}
+        """,
+        opset=18,
+    )
+    inits = [_f32(fc1_w, "FC1W"), _f32(fc2_w, "FC2W")]
+    if fc1_b is not None:
+        inits.append(_f32(fc1_b, "FC1B"))
+    if fc2_b is not None:
+        inits.append(_f32(fc2_b, "FC2B"))
+    if fc3_w is not None:
+        inits.append(_f32(fc3_w, "FC3W"))
+    model.graph.initializer.extend(inits)
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+    return model
+
+
+def _moe_inits(model):
+    return {t.name: onnx.numpy_helper.to_array(t) for t in model.graph.initializer}
+
+
+def test_moe_expert_channel_pruning_cpp_matches_ort_masking_oracle():
+    # Physically removing the lowest-importance `inter_size` channels must be
+    # numerically identical to *zeroing* those same channels (fc1's own row,
+    # fc1_experts_bias's own entry, fc2's own column) in a same-shape model --
+    # the real onnxruntime CPU-execution oracle this pass's own safety
+    # argument rests on (mirrors
+    # test_pruning.py::test_moe_expert_channel_pruning_matches_ort_masking_oracle).
+    E, hidden, inter = 5, 10, 12
+    rng = np.random.default_rng(3)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.5).astype(np.float32)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.5).astype(np.float32)
+    fc1_b = rng.standard_normal((E, inter)).astype(np.float32)
+    fc2_b = rng.standard_normal((E, hidden)).astype(np.float32)
+    model = _moe_model(fc1_w, fc2_w, fc1_b=fc1_b, fc2_b=fc2_b)
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_moe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = _moe_inits(pruned)
+    assert inits["FC1W"].shape == (E, 6, hidden)
+    assert inits["FC2W"].shape == (E, hidden, 6)
+    assert inits["FC1B"].shape == (E, 6)
+    np.testing.assert_array_equal(
+        inits["FC2B"], fc2_b
+    )  # indexes hidden_size, untouched
+
+    sq = (
+        np.sum(fc1_w**2, axis=(0, 2))
+        + np.sum(fc2_w**2, axis=(0, 1))
+        + np.sum(fc1_b**2, axis=0)
+    )
+    keep = np.sort(np.argsort(-np.sqrt(sq))[:6])
+    drop = np.setdiff1d(np.arange(inter), keep)
+    np.testing.assert_allclose(inits["FC1W"], fc1_w[:, keep, :])
+    np.testing.assert_allclose(inits["FC2W"], fc2_w[:, :, keep])
+    np.testing.assert_allclose(inits["FC1B"], fc1_b[:, keep])
+
+    fc1_w_masked = fc1_w.copy()
+    fc1_w_masked[:, drop, :] = 0
+    fc1_b_masked = fc1_b.copy()
+    fc1_b_masked[:, drop] = 0
+    fc2_w_masked = fc2_w.copy()
+    fc2_w_masked[:, :, drop] = 0
+    masked = _moe_model(fc1_w_masked, fc2_w_masked, fc1_b=fc1_b_masked, fc2_b=fc2_b)
+
+    rng2 = np.random.default_rng(7)
+    tokens = 6
+    feeds = {
+        "X": rng2.standard_normal((tokens, hidden)).astype(np.float32),
+        "R": rng2.standard_normal((tokens, E)).astype(np.float32),
+    }
+    (out_pruned,) = _run(pruned, feeds)
+    (out_masked,) = _run(masked, feeds)
+    np.testing.assert_allclose(out_pruned, out_masked, rtol=1e-5, atol=1e-5)
+
+
+def test_moe_expert_channel_pruning_cpp_adversarial_conflicting_fc1_fc2_importance():
+    # Deliberately conflicting per-channel importance: channel A has a large
+    # fc1 row but a tiny fc2 column, channel B the reverse, and channel C is
+    # tiny on both. A bug that ranked by only one of fc1/fc2 (instead of the
+    # documented combined root-sum-square of both) would keep A or B, not
+    # both -- this catches that by making the *combined* score of A and B
+    # comparably large while C is small on both, so only C should be dropped
+    # at sparsity=1/3.
+    E, hidden, inter = 3, 4, 3
+    rng = np.random.default_rng(11)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.01).astype(np.float32)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.01).astype(np.float32)
+    fc1_w[:, 0, :] = 5.0  # channel 0 (A): large fc1, tiny fc2 (left as noise)
+    fc2_w[:, :, 1] = 5.0  # channel 1 (B): tiny fc1 (noise), large fc2
+    # channel 2 (C) stays small noise on both -- the one channel expected to
+    # be dropped.
+    model = _moe_model(fc1_w, fc2_w)
+
+    pruned = onnxsim.apply_moe_expert_channel_pruning_cpp(model, sparsity=1.0 / 3.0)
+    onnx.checker.check_model(pruned)
+    inits = _moe_inits(pruned)
+    assert inits["FC1W"].shape == (E, 2, hidden)
+    np.testing.assert_allclose(inits["FC1W"], fc1_w[:, [0, 1], :])
+    np.testing.assert_allclose(inits["FC2W"], fc2_w[:, :, [0, 1]])
+
+
+def test_moe_expert_channel_pruning_cpp_zero_sparsity_is_a_no_op():
+    E, hidden, inter = 3, 6, 5
+    rng = np.random.default_rng(13)
+    fc1_w = rng.standard_normal((E, inter, hidden)).astype(np.float32)
+    fc2_w = rng.standard_normal((E, hidden, inter)).astype(np.float32)
+    model = _moe_model(fc1_w, fc2_w)
+    pruned = onnxsim.apply_moe_expert_channel_pruning_cpp(model, sparsity=0.0)
+    inits = _moe_inits(pruned)
+    np.testing.assert_array_equal(inits["FC1W"], fc1_w)
+    np.testing.assert_array_equal(inits["FC2W"], fc2_w)
+
+
+def test_moe_expert_channel_pruning_cpp_invalid_sparsity_raises():
+    E, hidden, inter = 3, 6, 5
+    rng = np.random.default_rng(97)
+    fc1_w = rng.standard_normal((E, inter, hidden)).astype(np.float32)
+    fc2_w = rng.standard_normal((E, hidden, inter)).astype(np.float32)
+    model = _moe_model(fc1_w, fc2_w)
+    with pytest.raises(Exception):
+        onnxsim.apply_moe_expert_channel_pruning_cpp(model, sparsity=1.0)
+    with pytest.raises(Exception):
+        onnxsim.apply_moe_expert_channel_pruning_cpp(model, sparsity=-0.1)
+
+
+def test_moe_expert_channel_pruning_cpp_declines_fc3():
+    # com.microsoft::MoE's own CPU execution provider, in this environment,
+    # raises "FC3 is not implemented for CPU MoE" for any activation_type --
+    # confirmed empirically, see pruning.py's own section comment -- so a
+    # node with fc3_experts_weights present is left completely untouched
+    # rather than pruned against a shape this environment has no real
+    # runtime to validate.
+    E, hidden, inter = 3, 6, 5
+    rng = np.random.default_rng(17)
+    fc1_w = rng.standard_normal((E, inter, hidden)).astype(np.float32)
+    fc2_w = rng.standard_normal((E, hidden, inter)).astype(np.float32)
+    fc3_w = rng.standard_normal((E, inter, hidden)).astype(np.float32)
+    model = _moe_model(fc1_w, fc2_w, fc3_w=fc3_w, activation="silu")
+    onnx.checker.check_model(model)
+    pruned = onnxsim.apply_moe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    inits = _moe_inits(pruned)
+    np.testing.assert_array_equal(inits["FC1W"], fc1_w)
+    np.testing.assert_array_equal(inits["FC2W"], fc2_w)
+    np.testing.assert_array_equal(inits["FC3W"], fc3_w)
+
+
+def test_moe_expert_channel_pruning_cpp_declines_swiglu_activation():
+    E, hidden, inter = 3, 6, 5
+    rng = np.random.default_rng(19)
+    fc1_w = rng.standard_normal((E, inter, hidden)).astype(np.float32)
+    fc2_w = rng.standard_normal((E, hidden, inter)).astype(np.float32)
+    model = _moe_model(fc1_w, fc2_w, activation="swiglu")
+    pruned = onnxsim.apply_moe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    inits = _moe_inits(pruned)
+    np.testing.assert_array_equal(inits["FC1W"], fc1_w)
+    np.testing.assert_array_equal(inits["FC2W"], fc2_w)
+
+
+def test_moe_expert_channel_pruning_cpp_declines_nonzero_swiglu_fusion():
+    E, hidden, inter = 3, 6, 5
+    rng = np.random.default_rng(23)
+    fc1_w = rng.standard_normal((E, inter, hidden)).astype(np.float32)
+    fc2_w = rng.standard_normal((E, hidden, inter)).astype(np.float32)
+    model = _moe_model(fc1_w, fc2_w, swiglu_fusion=1)
+    pruned = onnxsim.apply_moe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    inits = _moe_inits(pruned)
+    np.testing.assert_array_equal(inits["FC1W"], fc1_w)
+    np.testing.assert_array_equal(inits["FC2W"], fc2_w)
+
+
+def test_moe_expert_channel_pruning_cpp_declines_fused_swiglu_shape():
+    # A real fused-swiglu fc1 doubles its own row count (fusion_size=2) --
+    # fc1's axis-1 size then never equals fc2's own axis-2 size, so this
+    # declines via the shape-consistency check alone, without even needing
+    # to read swiglu_fusion/activation_type.
+    E, hidden, inter = 3, 6, 5
+    rng = np.random.default_rng(29)
+    fc1_w = rng.standard_normal((E, 2 * inter, hidden)).astype(np.float32)
+    fc2_w = rng.standard_normal((E, hidden, inter)).astype(np.float32)
+    model = _moe_model(fc1_w, fc2_w, activation="swiglu", swiglu_fusion=1)
+    pruned = onnxsim.apply_moe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    inits = _moe_inits(pruned)
+    np.testing.assert_array_equal(inits["FC1W"], fc1_w)
+    np.testing.assert_array_equal(inits["FC2W"], fc2_w)
+
+
+def test_moe_expert_channel_pruning_cpp_declines_tied_fc1_weight():
+    # fc1_experts_weights reused by a second node -- an in-place resize
+    # would corrupt that other consumer, so this is declined outright, the
+    # same tied-weight guard every other chain-matcher in this codebase
+    # applies via its own consumer map.
+    E, hidden, inter = 3, 6, 5
+    rng = np.random.default_rng(31)
+    fc1_w = rng.standard_normal((E, inter, hidden)).astype(np.float32)
+    fc2_w = rng.standard_normal((E, hidden, inter)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[6,{hidden}] X, float[6,{E}] R) => (float[6,{hidden}] Y, float[{E},{inter},{hidden}] Z)
+        {{
+          Y = com.microsoft.MoE <k=2, activation_type="relu"> (X, R, FC1W, , FC2W)
+          Z = Identity(FC1W)
+        }}
+        """,
+        initializer=[_f32(fc1_w, "FC1W"), _f32(fc2_w, "FC2W")],
+        opset=18,
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+    pruned = onnxsim.apply_moe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    inits = _moe_inits(pruned)
+    np.testing.assert_array_equal(inits["FC1W"], fc1_w)
+    np.testing.assert_array_equal(inits["FC2W"], fc2_w)
+
+
+def test_moe_expert_channel_pruning_cpp_declines_non_constant_weight():
+    # fc1_experts_weights fed by a graph input (not an initializer) --
+    # there's nothing to slice in place, so the node is left untouched
+    # rather than raising.
+    E, hidden, inter = 3, 6, 5
+    rng = np.random.default_rng(37)
+    fc2_w = rng.standard_normal((E, hidden, inter)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[6,{hidden}] X, float[6,{E}] R, float[{E},{inter},{hidden}] FC1W) => (float[6,{hidden}] Y)
+        {{
+          Y = com.microsoft.MoE <k=2, activation_type="relu"> (X, R, FC1W, , FC2W)
+        }}
+        """,
+        initializer=[_f32(fc2_w, "FC2W")],
+        opset=18,
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+    pruned = onnxsim.apply_moe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    inits = _moe_inits(pruned)
+    np.testing.assert_array_equal(inits["FC2W"], fc2_w)
+
+
+def test_moe_expert_channel_pruning_cpp_declines_mismatched_hidden_size():
+    E, hidden, inter = 3, 6, 5
+    rng = np.random.default_rng(41)
+    fc1_w = rng.standard_normal((E, inter, hidden)).astype(np.float32)
+    fc2_w = rng.standard_normal((E, hidden + 1, inter)).astype(np.float32)  # mismatched
+    model = _model(
+        f"""
+        g (float[6,{hidden}] X, float[6,{E}] R) => (float[6,{hidden + 1}] Y)
+        {{
+          Y = com.microsoft.MoE <k=2, activation_type="relu"> (X, R, FC1W, , FC2W)
+        }}
+        """,
+        initializer=[_f32(fc1_w, "FC1W"), _f32(fc2_w, "FC2W")],
+        opset=18,
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+    pruned = onnxsim.apply_moe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    inits = _moe_inits(pruned)
+    np.testing.assert_array_equal(inits["FC1W"], fc1_w)
+    np.testing.assert_array_equal(inits["FC2W"], fc2_w)
+
+
+def test_moe_expert_channel_pruning_cpp_no_bias_matches_ort_masking_oracle():
+    E, hidden, inter = 4, 8, 10
+    rng = np.random.default_rng(43)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.5).astype(np.float32)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.5).astype(np.float32)
+    model = _moe_model(fc1_w, fc2_w, activation="gelu")
+    pruned = onnxsim.apply_moe_expert_channel_pruning_cpp(model, sparsity=0.4)
+    onnx.checker.check_model(pruned)
+    inits = _moe_inits(pruned)
+    keep_count = inits["FC1W"].shape[1]
+    assert keep_count == 6
+
+    sq = np.sum(fc1_w**2, axis=(0, 2)) + np.sum(fc2_w**2, axis=(0, 1))
+    keep = np.sort(np.argsort(-np.sqrt(sq))[:keep_count])
+    drop = np.setdiff1d(np.arange(inter), keep)
+    fc1_w_masked = fc1_w.copy()
+    fc1_w_masked[:, drop, :] = 0
+    fc2_w_masked = fc2_w.copy()
+    fc2_w_masked[:, :, drop] = 0
+    masked = _moe_model(fc1_w_masked, fc2_w_masked, activation="gelu")
+
+    rng2 = np.random.default_rng(47)
+    tokens = 6
+    feeds = {
+        "X": rng2.standard_normal((tokens, hidden)).astype(np.float32),
+        "R": rng2.standard_normal((tokens, E)).astype(np.float32),
+    }
+    (out_pruned,) = _run(pruned, feeds)
+    (out_masked,) = _run(masked, feeds)
+    np.testing.assert_allclose(out_pruned, out_masked, rtol=1e-4, atol=1e-4)
+
+
+def test_moe_expert_channel_pruning_cpp_multiple_nodes_pruned_independently():
+    E1, hidden1, inter1 = 3, 4, 6
+    E2, hidden2, inter2 = 2, 5, 8
+    rng = np.random.default_rng(53)
+    fc1_w1 = rng.standard_normal((E1, inter1, hidden1)).astype(np.float32)
+    fc2_w1 = rng.standard_normal((E1, hidden1, inter1)).astype(np.float32)
+    fc1_w2 = rng.standard_normal((E2, inter2, hidden2)).astype(np.float32)
+    fc2_w2 = rng.standard_normal((E2, hidden2, inter2)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[6,{hidden1}] X1, float[6,{E1}] R1, float[6,{hidden2}] X2, float[6,{E2}] R2)
+            => (float[6,{hidden1}] Y1, float[6,{hidden2}] Y2)
+        {{
+          Y1 = com.microsoft.MoE <k=1, activation_type="relu"> (X1, R1, FC1W1, , FC2W1)
+          Y2 = com.microsoft.MoE <k=1, activation_type="relu"> (X2, R2, FC1W2, , FC2W2)
+        }}
+        """,
+        initializer=[
+            _f32(fc1_w1, "FC1W1"),
+            _f32(fc2_w1, "FC2W1"),
+            _f32(fc1_w2, "FC1W2"),
+            _f32(fc2_w2, "FC2W2"),
+        ],
+        opset=18,
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+    pruned = onnxsim.apply_moe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = _moe_inits(pruned)
+    assert inits["FC1W1"].shape == (E1, 3, hidden1)
+    assert inits["FC1W2"].shape == (E2, 4, hidden2)
+
+
+def test_moe_expert_channel_pruning_cpp_matches_python_port():
+    # The C++ port and the pure-Python reference implementation must agree
+    # bit-for-bit on a plain (in-scope) MoE node: same importance ranking,
+    # same keep set, same sliced values. `inter` is deliberately even so
+    # `inter * sparsity` is an exact integer, not a .5 tie -- Python's
+    # `round()` (round-half-to-even) and C++'s `std::llround()` (round-half-
+    # away-from-zero) can legitimately disagree exactly at such a tie (the
+    # same tie-breaking caveat TopKIndicesAscending's own comment and
+    # test_attention_head_pruning_cpp.py's own cross-check test -- which
+    # compares execution OUTPUT, not raw tensors, for exactly this reason --
+    # already document), which is not a bug in either port.
+    E, hidden, inter = 4, 7, 8
+    rng = np.random.default_rng(59)
+    fc1_w = rng.standard_normal((E, inter, hidden)).astype(np.float32)
+    fc2_w = rng.standard_normal((E, hidden, inter)).astype(np.float32)
+    fc1_b = rng.standard_normal((E, inter)).astype(np.float32)
+    model = _moe_model(fc1_w, fc2_w, fc1_b=fc1_b)
+
+    pruned_py = onnxsim.apply_moe_expert_channel_pruning(model, sparsity=0.5)
+    pruned_cpp = onnxsim.apply_moe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    inits_py = _moe_inits(pruned_py)
+    inits_cpp = _moe_inits(pruned_cpp)
+    np.testing.assert_array_equal(inits_py["FC1W"], inits_cpp["FC1W"])
+    np.testing.assert_array_equal(inits_py["FC2W"], inits_cpp["FC2W"])
+    np.testing.assert_array_equal(inits_py["FC1B"], inits_cpp["FC1B"])
+
+
+def test_moe_expert_channel_pruning_cpp_prunes_inside_if_subgraph():
+    # Subgraph-aware (IterSubgraphs, see structured_pruning_entry.cpp's own
+    # "Subgraph recursion" section comment): a com.microsoft::MoE node nested
+    # inside an `If` node's `then_branch` is matched and pruned exactly as if
+    # that subgraph were its own top-level graph.
+    # `inter` deliberately even -- see test_moe_expert_channel_pruning_cpp_
+    # matches_python_port's own comment on why sparsity=0.5 needs an even
+    # `inter` for an unambiguous (non-tied) expected keep_count.
+    E, hidden, inter = 3, 6, 6
+    rng = np.random.default_rng(61)
+    fc1_w = rng.standard_normal((E, inter, hidden)).astype(np.float32)
+    fc2_w = rng.standard_normal((E, hidden, inter)).astype(np.float32)
+
+    then_graph = onnx.helper.make_graph(
+        [
+            onnx.helper.make_node(
+                "MoE",
+                ["X", "R", "FC1W", "", "FC2W"],
+                ["Y"],
+                domain="com.microsoft",
+                k=1,
+                activation_type="relu",
+            )
+        ],
+        "then_graph",
+        [],
+        [onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [6, hidden])],
+        initializer=[_f32(fc1_w, "FC1W"), _f32(fc2_w, "FC2W")],
+    )
+    else_graph = onnx.helper.make_graph(
+        [onnx.helper.make_node("Identity", ["X"], ["Y"])],
+        "else_graph",
+        [],
+        [onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [6, hidden])],
+    )
+    model = onnx.helper.make_model(
+        onnx.helper.make_graph(
+            [
+                onnx.helper.make_node(
+                    "If",
+                    ["Cond"],
+                    ["Out"],
+                    then_branch=then_graph,
+                    else_branch=else_graph,
+                )
+            ],
+            "g",
+            [
+                onnx.helper.make_tensor_value_info("Cond", onnx.TensorProto.BOOL, []),
+                onnx.helper.make_tensor_value_info(
+                    "X", onnx.TensorProto.FLOAT, [6, hidden]
+                ),
+                onnx.helper.make_tensor_value_info("R", onnx.TensorProto.FLOAT, [6, E]),
+            ],
+            [
+                onnx.helper.make_tensor_value_info(
+                    "Out", onnx.TensorProto.FLOAT, [6, hidden]
+                )
+            ],
+        ),
+        opset_imports=[
+            onnx.helper.make_opsetid("", 18),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    model.ir_version = 10
+    # `If`'s own then/else branches implicitly capture `X`/`R` from the
+    # enclosing graph's own inputs -- valid ONNX (the same "implicit
+    # capture" shape structured_pruning_entry.cpp's own "Subgraph recursion"
+    # section comment documents), so this model is deliberately left without
+    # a checker call (the checker requires every implicitly-captured name to
+    # actually resolve in an enclosing scope at check time, which is
+    # satisfied here, but is beside this test's own point).
+
+    pruned = onnxsim.apply_moe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    then_attr = next(
+        a for a in pruned.graph.node[0].attribute if a.name == "then_branch"
+    )
+    fc1w_pruned = onnx.numpy_helper.to_array(
+        next(t for t in then_attr.g.initializer if t.name == "FC1W")
+    )
+    assert fc1w_pruned.shape == (E, 3, hidden)

--- a/tests/test_qmoe_pruning_cpp.py
+++ b/tests/test_qmoe_pruning_cpp.py
@@ -1,0 +1,1307 @@
+"""Tests for ``onnxsim.apply_qmoe_expert_channel_pruning_cpp`` -- the C++-
+backed port of ``onnxsim.apply_qmoe_expert_channel_pruning`` (see
+``onnxsim/structured_pruning_entry.cpp``'s own "QMoE (com.microsoft,
+quantized-weight Mixture-of-Experts) expert-channel structured pruning"
+section). Scope note: only the EXPERT-CHANNEL half is ported -- the
+complementary WHOLE-EXPERT half (``apply_qmoe_whole_expert_pruning``) needs
+runtime calibration data (a real ONNX Runtime inference session observing
+router activations), which this C++ port has no ONNX Runtime linked into at
+all (see the repo's own CLAUDE.md: the wheel build never builds ORT), so it
+stays out of scope here too.
+
+Covers ``quant_type='int'`` (whole-row and blockwise) and
+``quant_type='nvfp4'`` (schema-derived only -- see below). Tests here mirror
+``tests/test_pruning.py``'s own QMoE expert-channel coverage (the Python
+reference this C++ pass is a port of), reusing the exact same
+"onnxsim-code-free" reference quantizers/model builders that file already
+established (each one re-derived independently, never importing anything
+from ``onnxsim.pruning`` itself, so a test comparing against it is a genuine
+cross-check).
+
+QMoE has no ``onnx.reference`` fallback (a custom-domain op with no
+decomposition attached), so every ``quant_type='int'`` test that actually
+prunes something runs the result through a real ``onnxruntime`` CPU
+session -- the only real oracle available for this op. QMoE also can't be
+built via ``onnx.parser``'s text format at all (a custom-domain op whose
+``fc1``/``fc2`` weights are packed ``uint8`` tensors -- the parser's own
+tensor-literal syntax encodes ``float_data``, not ``raw_data``, and has no
+uint8 literal syntax either), so every QMoE model below is built via
+``onnx.helper.make_node``/``make_tensor`` directly, per CLAUDE.md's own
+documented fallback for exactly this kind of case.
+
+This environment's onnxruntime (1.29.0) has NO CPU kernel at all for
+``quant_type='nvfp4'`` (confirmed directly: a hand-built, otherwise
+schema-valid ``QMoE('nvfp4')`` node fails at
+``onnxruntime.InferenceSession(...)`` construction with "NOT_IMPLEMENTED").
+So, unlike the ``quant_type='int'`` tests (each run through a real ORT CPU
+session), every nvfp4 test instead checks (a) that this pass's own output is
+byte-exact-identical to slicing the already-quantized reference tensors
+directly (never re-derived), the same "slice, don't recompute" bar every
+other test in this file is held to, and (b) that dequantizing the pruned
+tensors reproduces exactly what slicing the full dequantized reference would
+give -- the "slice commutes with dequant" property this quant_type's own
+packed/block-scaled format needs to hold for pruning to be safe at all.
+"""
+
+import ml_dtypes
+import numpy as np
+import onnx
+import onnx.checker
+import onnx.helper
+import onnx.numpy_helper
+import pytest
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _u8(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.uint8), name)
+
+
+def _f8e4m3(array, name):
+    return onnx.numpy_helper.from_array(array.astype(ml_dtypes.float8_e4m3fn), name)
+
+
+# --- quant_type='int' reference quantizer/packer (onnxsim-code-free) -------
+
+
+def _qmoe_quantize_channel(w, bits, zero_point=None):
+    """Reference per-channel symmetric QMoE quantizer: `w` is one expert's
+    own ``[N, K]`` float weight. Returns ``(packed [N, K/pack] uint8, scale
+    [N] float32, dequant [N, K] float32)`` -- packed low-index-in-low-bits,
+    ``8 // bits`` values per byte, this op's own confirmed-live raw storage
+    convention. `zero_point`, when given, is a per-channel ``[N]`` int
+    array; otherwise every channel uses the schema's own documented
+    default, ``2 ** (bits - 1)``.
+    """
+    n, k = w.shape
+    pack = 8 // bits
+    qmin, qmax = -(1 << (bits - 1)), (1 << (bits - 1)) - 1
+    default_zp = 1 << (bits - 1)
+    zp = (
+        np.full(n, default_zp, dtype=np.int64)
+        if zero_point is None
+        else np.asarray(zero_point, dtype=np.int64)
+    )
+    scale = np.abs(w).max(axis=1) / float(-qmin)
+    scale = np.maximum(scale, np.finfo(np.float32).eps).astype(np.float32)
+    q = np.clip(np.round(w / scale[:, None]), qmin, qmax).astype(np.int64) + zp[:, None]
+    q = np.clip(q, 0, (1 << bits) - 1).astype(np.uint8)
+    parts = [(q[:, i::pack] & ((1 << bits) - 1)) for i in range(pack)]
+    packed = np.zeros_like(parts[0])
+    for i, p in enumerate(parts):
+        packed = packed | (p << (bits * i))
+    packed = packed.astype(np.uint8)
+    dequant = (q.astype(np.float32) - zp[:, None].astype(np.float32)) * scale[:, None]
+    return packed, scale, dequant
+
+
+def _qmoe_quantize(w, bits, zero_point=None):
+    """Batched (per-expert) :func:`_qmoe_quantize_channel`: `w` is
+    ``[E, N, K]``. Returns ``(packed [E, N, K/pack], scale [E, N], dequant
+    [E, N, K])``.
+    """
+    e, n, k = w.shape
+    pack = 8 // bits
+    packed = np.zeros((e, n, k // pack), dtype=np.uint8)
+    scale = np.zeros((e, n), dtype=np.float32)
+    dequant = np.zeros_like(w)
+    for ei in range(e):
+        packed[ei], scale[ei], dequant[ei] = _qmoe_quantize_channel(
+            w[ei], bits, zero_point=None if zero_point is None else zero_point[ei]
+        )
+    return packed, scale, dequant
+
+
+def _qmoe_quantize_channel_blockwise(w, bits, block_size, zero_point=None):
+    """Reference per-``block_size``-group symmetric QMoE quantizer for
+    `block_size` set: `w` is one expert's own ``[N, K]`` float weight,
+    quantized independently per ``block_size``-sized group along `K`.
+    Returns ``(packed [N, K/pack] uint8, scale [N, K // block_size]
+    float32, dequant [N, K] float32)`` -- weight packing is still the flat,
+    block-boundary-oblivious low-index-in-low-bits convention, not
+    restarted at each block.
+    """
+    n, k = w.shape
+    pack = 8 // bits
+    kb = k // block_size
+    qmin, qmax = -(1 << (bits - 1)), (1 << (bits - 1)) - 1
+    default_zp = 1 << (bits - 1)
+    zp = (
+        np.full((n, kb), default_zp, dtype=np.int64)
+        if zero_point is None
+        else np.asarray(zero_point, dtype=np.int64)
+    )
+    w_blocks = w.reshape(n, kb, block_size)
+    scale = np.abs(w_blocks).max(axis=-1) / float(-qmin)
+    scale = np.maximum(scale, np.finfo(np.float32).eps).astype(np.float32)
+    q = (
+        np.clip(np.round(w_blocks / scale[..., None]), qmin, qmax).astype(np.int64)
+        + zp[..., None]
+    )
+    q = np.clip(q, 0, (1 << bits) - 1).astype(np.uint8)
+    q_flat = q.reshape(n, k)
+    parts = [(q_flat[:, i::pack] & ((1 << bits) - 1)) for i in range(pack)]
+    packed = np.zeros_like(parts[0])
+    for i, p in enumerate(parts):
+        packed = packed | (p << (bits * i))
+    packed = packed.astype(np.uint8)
+    dequant = (q.astype(np.float32) - zp[..., None].astype(np.float32)) * scale[
+        ..., None
+    ]
+    dequant = dequant.reshape(n, k)
+    return packed, scale, dequant
+
+
+def _qmoe_quantize_blockwise(w, bits, block_size, zero_point=None):
+    """Batched (per-expert) :func:`_qmoe_quantize_channel_blockwise`."""
+    e, n, k = w.shape
+    pack = 8 // bits
+    kb = k // block_size
+    packed = np.zeros((e, n, k // pack), dtype=np.uint8)
+    scale = np.zeros((e, n, kb), dtype=np.float32)
+    dequant = np.zeros_like(w)
+    for ei in range(e):
+        packed[ei], scale[ei], dequant[ei] = _qmoe_quantize_channel_blockwise(
+            w[ei],
+            bits,
+            block_size,
+            zero_point=None if zero_point is None else zero_point[ei],
+        )
+    return packed, scale, dequant
+
+
+def _pack_vals(vals, bits):
+    """Independent sub-byte packer for a generic array of already-
+    quantized ``uint8`` values in ``[0, 2**bits)`` on its own last axis --
+    used to build `fc1_zero_points`/`fc2_zero_points` test tensors directly.
+    """
+    pack = 8 // bits
+    vals = np.asarray(vals, dtype=np.uint8)
+    n = vals.shape[-1]
+    pad = (-n) % pack
+    if pad:
+        vals = np.pad(vals, [(0, 0)] * (vals.ndim - 1) + [(0, pad)])
+    reshaped = vals.reshape(*vals.shape[:-1], -1, pack)
+    out = np.zeros(reshaped.shape[:-1], dtype=np.uint8)
+    for i in range(pack):
+        out = out | (reshaped[..., i] << (bits * i))
+    return out.astype(np.uint8)
+
+
+def _unpack_vals(packed, bits, logical_len):
+    """Independent unpacker, inverse of :func:`_pack_vals`."""
+    pack = 8 // bits
+    mask = (1 << bits) - 1
+    parts = [(packed >> (bits * i)) & mask for i in range(pack)]
+    unpacked = np.stack(parts, axis=-1).reshape(
+        *packed.shape[:-1], packed.shape[-1] * pack
+    )
+    return unpacked[..., :logical_len]
+
+
+def _qmoe_model(
+    fc1_q,
+    fc1_scale,
+    fc2_q,
+    fc2_scale,
+    bits,
+    fc1_bias=None,
+    fc2_bias=None,
+    fc1_zp=None,
+    fc2_zp=None,
+    fc3_q=None,
+    fc3_scale=None,
+    activation="relu",
+    swiglu_fusion=0,
+    k=2,
+    tokens=6,
+    quant_type="int",
+    block_size=0,
+    weights_prepacked=None,
+    router_weights=False,
+    tied_fc1_weight_elsewhere=False,
+    extra_nodes=(),
+    extra_outputs=(),
+):
+    # A router-logit input R feeds a real com.microsoft::QMoE node -- see
+    # this file's own top comment for why the onnx.parser text format
+    # can't express QMoE's packed uint8 operands.
+    num_experts, inter, hidden_packed = fc1_q.shape
+    hidden = hidden_packed * (8 // bits)
+    inputs = [
+        onnx.helper.make_tensor_value_info(
+            "X", onnx.TensorProto.FLOAT, [tokens, hidden]
+        ),
+        onnx.helper.make_tensor_value_info(
+            "R", onnx.TensorProto.FLOAT, [tokens, num_experts]
+        ),
+    ]
+    outputs = [
+        onnx.helper.make_tensor_value_info(
+            "Y", onnx.TensorProto.FLOAT, [tokens, hidden]
+        )
+    ]
+    inits = [
+        _u8(fc1_q, "FC1Q"),
+        _f32(fc1_scale, "FC1S"),
+        _u8(fc2_q, "FC2Q"),
+        _f32(fc2_scale, "FC2S"),
+    ]
+    node_inputs = ["X", "R", "FC1Q", "FC1S", "", "FC2Q", "FC2S", ""]
+    if fc1_bias is not None:
+        node_inputs[4] = "FC1B"
+        inits.append(_f32(fc1_bias, "FC1B"))
+    if fc2_bias is not None:
+        node_inputs[7] = "FC2B"
+        inits.append(_f32(fc2_bias, "FC2B"))
+    while len(node_inputs) < 13:
+        node_inputs.append("")
+    if fc3_q is not None:
+        node_inputs[8] = "FC3Q"
+        node_inputs[9] = "FC3S"
+        inits += [_u8(fc3_q, "FC3Q"), _f32(fc3_scale, "FC3S")]
+    if fc1_zp is not None:
+        node_inputs[11] = "FC1ZP"
+        inits.append(_u8(fc1_zp, "FC1ZP"))
+    if fc2_zp is not None:
+        node_inputs[12] = "FC2ZP"
+        inits.append(_u8(fc2_zp, "FC2ZP"))
+    if router_weights:
+        while len(node_inputs) < 15:
+            node_inputs.append("")
+        node_inputs[14] = "RWEIGHTS"
+        inits.append(_f32(np.ones((tokens, num_experts), np.float32), "RWEIGHTS"))
+
+    extra_nodes = list(extra_nodes)
+    if tied_fc1_weight_elsewhere:
+        extra_nodes.append(onnx.helper.make_node("Identity", ["FC1Q"], ["FC1Q2"]))
+        extra_outputs = list(extra_outputs) + [
+            onnx.helper.make_tensor_value_info(
+                "FC1Q2", onnx.TensorProto.UINT8, list(fc1_q.shape)
+            )
+        ]
+
+    kwargs = dict(
+        k=k,
+        activation_type=activation,
+        swiglu_fusion=swiglu_fusion,
+        expert_weight_bits=bits,
+        quant_type=quant_type,
+    )
+    if block_size:
+        kwargs["block_size"] = block_size
+    if weights_prepacked is not None:
+        kwargs["weights_prepacked"] = weights_prepacked
+    node = onnx.helper.make_node(
+        "QMoE", node_inputs, ["Y"], domain="com.microsoft", name="qmoe", **kwargs
+    )
+    graph = onnx.helper.make_graph(
+        [node, *extra_nodes],
+        "g",
+        inputs,
+        [*outputs, *extra_outputs],
+        initializer=inits,
+    )
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 18),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    model.ir_version = 10
+    return model
+
+
+def _qmoe_inits(model):
+    return {t.name: onnx.numpy_helper.to_array(t) for t in model.graph.initializer}
+
+
+def _qmoe_block_keep_reference(importance, n, block_size, sparsity):
+    # Independent re-derivation of QMoEBlockAlignedKeep's own algorithm.
+    num_blocks = n // block_size
+    block_importance = np.sqrt(
+        np.sum(importance.reshape(num_blocks, block_size) ** 2, axis=1)
+    )
+    keep_blocks_count = max(1, num_blocks - round(num_blocks * sparsity))
+    keep_block_idx = np.sort(np.argsort(-block_importance)[:keep_blocks_count])
+    keep = np.arange(n).reshape(num_blocks, block_size)[keep_block_idx].reshape(-1)
+    return keep, keep_block_idx
+
+
+# --- quant_type='nvfp4' reference quantizer/packer (onnxsim-code-free) -----
+
+_E2M1_LUT = np.array(
+    [
+        0.0,
+        0.5,
+        1.0,
+        1.5,
+        2.0,
+        3.0,
+        4.0,
+        6.0,
+        -0.0,
+        -0.5,
+        -1.0,
+        -1.5,
+        -2.0,
+        -3.0,
+        -4.0,
+        -6.0,
+    ],
+    dtype=np.float64,
+)
+
+
+def _e2m1_encode_nearest(values):
+    values = np.asarray(values, dtype=np.float64)
+    flat = values.reshape(-1)
+    codes = np.argmin(np.abs(_E2M1_LUT[None, :] - flat[:, None]), axis=1)
+    return codes.reshape(values.shape).astype(np.uint8)
+
+
+def _e2m1_decode(codes):
+    return _E2M1_LUT[np.asarray(codes).astype(np.int64)]
+
+
+def _qmoe_nvfp4_quantize_channel_blockwise(w, global_scale, block_size=16):
+    n, k = w.shape
+    kb = k // block_size
+    w_blocks = w.reshape(n, kb, block_size).astype(np.float64)
+    amax = np.maximum(np.abs(w_blocks).max(axis=-1), 1e-12)
+    block_scale_f64 = amax / (6.0 * global_scale)  # 6.0 == E2M1's own max magnitude
+    block_scale_f8 = block_scale_f64.astype(ml_dtypes.float8_e4m3fn)
+    block_scale_rt = block_scale_f8.astype(np.float64)
+    codes = _e2m1_encode_nearest(w_blocks / (block_scale_rt[..., None] * global_scale))
+    packed = _pack_vals(codes.reshape(n, k), 4)
+    dequant = (_e2m1_decode(codes) * block_scale_rt[..., None] * global_scale).reshape(
+        n, k
+    )
+    return packed, block_scale_f8, dequant
+
+
+def _qmoe_nvfp4_quantize_blockwise(w, global_scale, block_size=16):
+    e, n, k = w.shape
+    kb = k // block_size
+    packed = np.zeros((e, n, k // 2), dtype=np.uint8)
+    block_scale = np.zeros((e, n, kb), dtype=ml_dtypes.float8_e4m3fn)
+    dequant = np.zeros((e, n, k), dtype=np.float64)
+    for ei in range(e):
+        packed[ei], block_scale[ei], dequant[ei] = (
+            _qmoe_nvfp4_quantize_channel_blockwise(
+                w[ei], float(global_scale[ei]), block_size
+            )
+        )
+    return packed, block_scale, dequant
+
+
+def _qmoe_nvfp4_dequantize(packed, block_scale, global_scale, block_size=16):
+    e, n, k_packed = packed.shape
+    k = k_packed * 2
+    codes = _unpack_vals(packed, 4, k).astype(np.int64)
+    mag = _e2m1_decode(codes)
+    kb = k // block_size
+    bs = block_scale.astype(np.float64)
+    gs = np.asarray(global_scale, dtype=np.float64)
+    mag_blocks = mag.reshape(e, n, kb, block_size)
+    dequant = mag_blocks * bs[:, :, :, None] * gs[:, None, None, None]
+    return dequant.reshape(e, n, k)
+
+
+def _qmoe_nvfp4_model(
+    fc1_q,
+    fc1_scale,
+    fc2_q,
+    fc2_scale,
+    fc1_global_scale,
+    fc2_global_scale,
+    fc1_bias=None,
+    fc2_bias=None,
+    activation="relu",
+    k=2,
+    tokens=6,
+    block_size=16,
+    quant_type="nvfp4",
+    fc1_zp=None,
+):
+    num_experts, inter, hidden_packed = fc1_q.shape
+    hidden = hidden_packed * 2
+    inputs = [
+        onnx.helper.make_tensor_value_info(
+            "X", onnx.TensorProto.FLOAT, [tokens, hidden]
+        ),
+        onnx.helper.make_tensor_value_info(
+            "R", onnx.TensorProto.FLOAT, [tokens, num_experts]
+        ),
+    ]
+    outputs = [
+        onnx.helper.make_tensor_value_info(
+            "Y", onnx.TensorProto.FLOAT, [tokens, hidden]
+        )
+    ]
+    inits = [
+        _u8(fc1_q, "FC1Q"),
+        _f8e4m3(fc1_scale, "FC1S"),
+        _u8(fc2_q, "FC2Q"),
+        _f8e4m3(fc2_scale, "FC2S"),
+    ]
+    node_inputs = ["X", "R", "FC1Q", "FC1S", "", "FC2Q", "FC2S", ""]
+    if fc1_bias is not None:
+        node_inputs[4] = "FC1B"
+        inits.append(_f32(fc1_bias, "FC1B"))
+    if fc2_bias is not None:
+        node_inputs[7] = "FC2B"
+        inits.append(_f32(fc2_bias, "FC2B"))
+    while len(node_inputs) < 12:
+        node_inputs.append("")
+    if fc1_zp is not None:
+        node_inputs[11] = "FC1ZP"
+        inits.append(_u8(fc1_zp, "FC1ZP"))
+    while len(node_inputs) < 16:
+        node_inputs.append("")
+    if fc1_global_scale is not None:
+        node_inputs[15] = "FC1GS"
+        inits.append(_f32(fc1_global_scale, "FC1GS"))
+    node_inputs.append("FC2GS" if fc2_global_scale is not None else "")
+    if fc2_global_scale is not None:
+        inits.append(_f32(fc2_global_scale, "FC2GS"))
+    node = onnx.helper.make_node(
+        "QMoE",
+        node_inputs,
+        ["Y"],
+        domain="com.microsoft",
+        name="qmoe",
+        k=k,
+        activation_type=activation,
+        expert_weight_bits=4,
+        quant_type=quant_type,
+        block_size=block_size,
+    )
+    graph = onnx.helper.make_graph([node], "g", inputs, outputs, initializer=inits)
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 18),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    model.ir_version = 10
+    return model
+
+
+def _if_wrap(inner_model):
+    """Wraps `inner_model`'s own graph as BOTH branches of a new top-level
+    `If` node -- verifies the C++ port's own subgraph-recursion (IterSubgraphs)
+    reaches a QMoE node nested inside an If branch, mirroring
+    tests/test_pruning.py's own identical helper.
+    """
+    g = inner_model.graph
+
+    def _branch(name):
+        return onnx.helper.make_graph(
+            list(g.node),
+            name,
+            [],
+            list(g.output),
+            initializer=list(g.initializer),
+            value_info=list(g.value_info),
+        )
+
+    then_graph = _branch("then_graph")
+    else_graph = _branch("else_graph")
+    top_out_names = [f"top__{o.name}" for o in g.output]
+    if_node = onnx.helper.make_node(
+        "If", ["cond"], top_out_names, then_branch=then_graph, else_branch=else_graph
+    )
+    cond = onnx.helper.make_tensor_value_info("cond", onnx.TensorProto.BOOL, [])
+    top_outputs = []
+    for name, o in zip(top_out_names, g.output):
+        vi = onnx.ValueInfoProto()
+        vi.CopyFrom(o)
+        vi.name = name
+        top_outputs.append(vi)
+
+    wrap_graph = onnx.helper.make_graph([if_node], "g", [*g.input, cond], top_outputs)
+    wrap_model = onnx.helper.make_model(
+        wrap_graph, opset_imports=list(inner_model.opset_import)
+    )
+    wrap_model.ir_version = max(inner_model.ir_version, 10)
+    onnx.checker.check_model(wrap_model)
+    return wrap_model
+
+
+def _if_branches(wrapped_model):
+    if_node = next(n for n in wrapped_model.graph.node if n.op_type == "If")
+    then_g = else_g = None
+    for attr in if_node.attribute:
+        if attr.name == "then_branch":
+            then_g = attr.g
+        elif attr.name == "else_branch":
+            else_g = attr.g
+    return then_g, else_g
+
+
+# --- quant_type='int', whole-row (no block_size) ----------------------------
+
+
+def test_qmoe_expert_channel_pruning_cpp_matches_hand_built_presliced_reference():
+    # A dedicated, independently hand-built "already pruned" reference QMoE
+    # node -- fc1/fc2 re-quantized from scratch from the *sliced* float
+    # weights (never touching the C++ port's own pruned bytes), including a
+    # non-default per-channel fc1_zero_points operand, so this exercises the
+    # packed zero_point slicing path too, not just the default-omitted case.
+    E, hidden, inter, bits, tokens = 3, 8, 12, 4, 6
+    rng = np.random.default_rng(211)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float32)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float32)
+    fc1_b = rng.standard_normal((E, inter)).astype(np.float32)
+    fc1_zp_vals = rng.integers(4, 12, size=(E, inter))
+
+    fc1_q, fc1_s, fc1_dq = _qmoe_quantize(fc1_w, bits, zero_point=fc1_zp_vals)
+    fc2_q, fc2_s, fc2_dq = _qmoe_quantize(fc2_w, bits)
+    fc1_zp = _pack_vals(fc1_zp_vals, bits)
+
+    model = _qmoe_model(
+        fc1_q,
+        fc1_s,
+        fc2_q,
+        fc2_s,
+        bits,
+        fc1_bias=fc1_b,
+        fc1_zp=fc1_zp,
+        k=2,
+        tokens=tokens,
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_qmoe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    sq = (
+        np.sum(fc1_dq**2, axis=(0, 2))
+        + np.sum(fc2_dq**2, axis=(0, 1))
+        + np.sum(fc1_b**2, axis=0)
+    )
+    keep = np.sort(np.argsort(-np.sqrt(sq))[:6])  # 12 - round(12*0.5) = 6
+
+    inits = _qmoe_inits(pruned)
+    np.testing.assert_array_equal(inits["FC1Q"], fc1_q[:, keep, :])
+    np.testing.assert_array_equal(inits["FC1S"], fc1_s[:, keep])
+    np.testing.assert_array_equal(inits["FC1B"], fc1_b[:, keep])
+    np.testing.assert_array_equal(
+        inits["FC1ZP"], _pack_vals(fc1_zp_vals[:, keep], bits)
+    )
+    expected_fc2_q = _pack_vals(_unpack_vals(fc2_q, bits, inter)[:, :, keep], bits)
+    np.testing.assert_array_equal(inits["FC2Q"], expected_fc2_q)
+
+    fc1_q_ref, fc1_s_ref, _ = _qmoe_quantize(
+        fc1_w[:, keep, :], bits, zero_point=fc1_zp_vals[:, keep]
+    )
+    reference = _qmoe_model(
+        fc1_q_ref,
+        fc1_s_ref,
+        expected_fc2_q,
+        fc2_s,
+        bits,
+        fc1_bias=fc1_b[:, keep],
+        fc1_zp=_pack_vals(fc1_zp_vals[:, keep], bits),
+        k=2,
+        tokens=tokens,
+    )
+    onnx.checker.check_model(reference)
+
+    feed_rng = np.random.default_rng(213)
+    feeds = {
+        "X": (feed_rng.standard_normal((tokens, hidden)) * 0.2).astype(np.float32),
+        "R": feed_rng.standard_normal((tokens, E)).astype(np.float32),
+    }
+    (out_pruned,) = _run(pruned, feeds)
+    (out_ref,) = _run(reference, feeds)
+    np.testing.assert_allclose(out_pruned, out_ref, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize("bits", [2, 8])
+def test_qmoe_expert_channel_pruning_cpp_matches_hand_built_reference_other_bit_widths(
+    bits,
+):
+    # bits=8 has no packing at all (pack=1, a plain index-select on both
+    # fc1/fc2), bits=2 packs four values per byte -- both go through the
+    # exact same production code path (QMoEUnpackSubbyte/QMoEPackSubbyte,
+    # parametrized on `bits`), so this confirms it generalizes correctly.
+    E, hidden, inter, tokens = 2, 8, 8, 5
+    rng = np.random.default_rng(220 + bits)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float32)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float32)
+    fc1_q, fc1_s, fc1_dq = _qmoe_quantize(fc1_w, bits)
+    fc2_q, fc2_s, fc2_dq = _qmoe_quantize(fc2_w, bits)
+    model = _qmoe_model(fc1_q, fc1_s, fc2_q, fc2_s, bits, k=1, tokens=tokens)
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_qmoe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    sq = np.sum(fc1_dq**2, axis=(0, 2)) + np.sum(fc2_dq**2, axis=(0, 1))
+    keep = np.sort(np.argsort(-np.sqrt(sq))[:4])  # 8 - round(8*0.5) = 4
+
+    inits = _qmoe_inits(pruned)
+    np.testing.assert_array_equal(inits["FC1Q"], fc1_q[:, keep, :])
+    expected_fc2_q = _pack_vals(_unpack_vals(fc2_q, bits, inter)[:, :, keep], bits)
+    np.testing.assert_array_equal(inits["FC2Q"], expected_fc2_q)
+
+    fc1_q_ref, fc1_s_ref, _ = _qmoe_quantize(fc1_w[:, keep, :], bits)
+    reference = _qmoe_model(
+        fc1_q_ref, fc1_s_ref, expected_fc2_q, fc2_s, bits, k=1, tokens=tokens
+    )
+    onnx.checker.check_model(reference)
+
+    feed_rng = np.random.default_rng(223)
+    feeds = {
+        "X": (feed_rng.standard_normal((tokens, hidden)) * 0.2).astype(np.float32),
+        "R": feed_rng.standard_normal((tokens, E)).astype(np.float32),
+    }
+    (out_pruned,) = _run(pruned, feeds)
+    (out_ref,) = _run(reference, feeds)
+    np.testing.assert_allclose(out_pruned, out_ref, rtol=1e-5, atol=1e-5)
+
+
+def test_qmoe_expert_channel_pruning_cpp_survivor_count_floored_to_pack_multiple():
+    # inter_size=10 at bits=4 (pack=2): sparsity=0.7 would naively ask for
+    # 10 - round(10*0.7) = 3 survivors -- not a multiple of pack. The real
+    # QMoE CPU kernel has no way to represent a partial trailing byte, so
+    # this pass must round the survivor count DOWN to the nearest multiple
+    # of pack (here, 2).
+    E, hidden, inter, bits, tokens = 2, 6, 10, 4, 5
+    rng = np.random.default_rng(229)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float32)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float32)
+    fc1_q, fc1_s, fc1_dq = _qmoe_quantize(fc1_w, bits)
+    fc2_q, fc2_s, fc2_dq = _qmoe_quantize(fc2_w, bits)
+    model = _qmoe_model(fc1_q, fc1_s, fc2_q, fc2_s, bits, k=1, tokens=tokens)
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_qmoe_expert_channel_pruning_cpp(model, sparsity=0.7)
+    onnx.checker.check_model(pruned)  # would fail below if survivor count
+    # weren't pack-aligned.
+
+    inits = _qmoe_inits(pruned)
+    assert inits["FC1Q"].shape == (E, 2, hidden // 2)  # floored 3 -> 2
+    assert inits["FC2Q"].shape == (E, hidden, 1)
+
+    sq = np.sum(fc1_dq**2, axis=(0, 2)) + np.sum(fc2_dq**2, axis=(0, 1))
+    keep = np.sort(np.argsort(-np.sqrt(sq))[:2])
+    np.testing.assert_array_equal(inits["FC1Q"], fc1_q[:, keep, :])
+
+    feed_rng = np.random.default_rng(233)
+    feeds = {
+        "X": (feed_rng.standard_normal((tokens, hidden)) * 0.2).astype(np.float32),
+        "R": feed_rng.standard_normal((tokens, E)).astype(np.float32),
+    }
+    (out_pruned,) = _run(pruned, feeds)
+    assert not np.isnan(out_pruned).any()
+
+
+def test_qmoe_expert_channel_pruning_cpp_zero_sparsity_is_a_no_op():
+    E, hidden, inter, bits = 2, 8, 8, 4
+    rng = np.random.default_rng(240)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float32)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float32)
+    fc1_q, fc1_s, _ = _qmoe_quantize(fc1_w, bits)
+    fc2_q, fc2_s, _ = _qmoe_quantize(fc2_w, bits)
+    model = _qmoe_model(fc1_q, fc1_s, fc2_q, fc2_s, bits)
+    pruned = onnxsim.apply_qmoe_expert_channel_pruning_cpp(model, sparsity=0.0)
+    inits = _qmoe_inits(pruned)
+    np.testing.assert_array_equal(inits["FC1Q"], fc1_q)
+    np.testing.assert_array_equal(inits["FC2Q"], fc2_q)
+
+
+def test_qmoe_expert_channel_pruning_cpp_invalid_sparsity_raises():
+    E, hidden, inter, bits = 2, 8, 8, 4
+    rng = np.random.default_rng(241)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float32)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float32)
+    fc1_q, fc1_s, _ = _qmoe_quantize(fc1_w, bits)
+    fc2_q, fc2_s, _ = _qmoe_quantize(fc2_w, bits)
+    model = _qmoe_model(fc1_q, fc1_s, fc2_q, fc2_s, bits)
+    with pytest.raises(Exception):
+        onnxsim.apply_qmoe_expert_channel_pruning_cpp(model, sparsity=1.0)
+    with pytest.raises(Exception):
+        onnxsim.apply_qmoe_expert_channel_pruning_cpp(model, sparsity=-0.1)
+
+
+def test_qmoe_expert_channel_pruning_cpp_multiple_nodes_pruned_independently():
+    # Two independent QMoE nodes (disjoint weights) in one graph -- each
+    # pruned to its own importance-ranked keep-set, confirming this pass
+    # doesn't confuse one node's own tensors with the other's, and that the
+    # touched-set bookkeeping doesn't spuriously skip the second node.
+    E, hidden, inter, bits, tokens = 2, 8, 8, 4, 5
+    rng = np.random.default_rng(250)
+    fc1_w_a = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float32)
+    fc2_w_a = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float32)
+    fc1_w_b = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float32)
+    fc2_w_b = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float32)
+    fc1_q_a, fc1_s_a, fc1_dq_a = _qmoe_quantize(fc1_w_a, bits)
+    fc2_q_a, fc2_s_a, fc2_dq_a = _qmoe_quantize(fc2_w_a, bits)
+    fc1_q_b, fc1_s_b, fc1_dq_b = _qmoe_quantize(fc1_w_b, bits)
+    fc2_q_b, fc2_s_b, fc2_dq_b = _qmoe_quantize(fc2_w_b, bits)
+
+    node_a_inputs = ["X", "R", "FC1QA", "FC1SA", "", "FC2QA", "FC2SA", ""]
+    node_b_inputs = ["Y0", "R", "FC1QB", "FC1SB", "", "FC2QB", "FC2SB", ""]
+    node_a = onnx.helper.make_node(
+        "QMoE",
+        node_a_inputs,
+        ["Y0"],
+        domain="com.microsoft",
+        name="qmoe_a",
+        k=1,
+        activation_type="relu",
+        expert_weight_bits=bits,
+        quant_type="int",
+    )
+    node_b = onnx.helper.make_node(
+        "QMoE",
+        node_b_inputs,
+        ["Y"],
+        domain="com.microsoft",
+        name="qmoe_b",
+        k=1,
+        activation_type="relu",
+        expert_weight_bits=bits,
+        quant_type="int",
+    )
+    inits = [
+        _u8(fc1_q_a, "FC1QA"),
+        _f32(fc1_s_a, "FC1SA"),
+        _u8(fc2_q_a, "FC2QA"),
+        _f32(fc2_s_a, "FC2SA"),
+        _u8(fc1_q_b, "FC1QB"),
+        _f32(fc1_s_b, "FC1SB"),
+        _u8(fc2_q_b, "FC2QB"),
+        _f32(fc2_s_b, "FC2SB"),
+    ]
+    inputs = [
+        onnx.helper.make_tensor_value_info(
+            "X", onnx.TensorProto.FLOAT, [tokens, hidden]
+        ),
+        onnx.helper.make_tensor_value_info("R", onnx.TensorProto.FLOAT, [tokens, E]),
+    ]
+    outputs = [
+        onnx.helper.make_tensor_value_info(
+            "Y", onnx.TensorProto.FLOAT, [tokens, hidden]
+        )
+    ]
+    graph = onnx.helper.make_graph(
+        [node_a, node_b], "g", inputs, outputs, initializer=inits
+    )
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 18),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    model.ir_version = 10
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_qmoe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    sq_a = np.sum(fc1_dq_a**2, axis=(0, 2)) + np.sum(fc2_dq_a**2, axis=(0, 1))
+    keep_a = np.sort(np.argsort(-np.sqrt(sq_a))[:4])
+    sq_b = np.sum(fc1_dq_b**2, axis=(0, 2)) + np.sum(fc2_dq_b**2, axis=(0, 1))
+    keep_b = np.sort(np.argsort(-np.sqrt(sq_b))[:4])
+
+    out = _qmoe_inits(pruned)
+    np.testing.assert_array_equal(out["FC1QA"], fc1_q_a[:, keep_a, :])
+    np.testing.assert_array_equal(out["FC1QB"], fc1_q_b[:, keep_b, :])
+
+
+# --- quant_type='int', blockwise ---------------------------------------
+
+
+def test_qmoe_expert_channel_pruning_cpp_blockwise_int_matches_hand_built_presliced_reference():
+    E, hidden, inter, bits, block_size, tokens = 2, 16, 32, 4, 16, 5
+    rng = np.random.default_rng(260)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float32)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float32)
+    fc1_q, fc1_s, fc1_dq = _qmoe_quantize_blockwise(fc1_w, bits, block_size)
+    fc2_q, fc2_s, fc2_dq = _qmoe_quantize_blockwise(fc2_w, bits, block_size)
+    model = _qmoe_model(
+        fc1_q, fc1_s, fc2_q, fc2_s, bits, block_size=block_size, k=2, tokens=tokens
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_qmoe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    importance = np.sqrt(
+        np.sum(fc1_dq**2, axis=(0, 2)) + np.sum(fc2_dq**2, axis=(0, 1))
+    )
+    # inter=32, block_size=16 -> 2 blocks; sparsity=0.5 -> keep 1 block.
+    keep, keep_block_idx = _qmoe_block_keep_reference(
+        importance, inter, block_size, 0.5
+    )
+    assert len(keep) == block_size  # block-aligned.
+
+    inits = _qmoe_inits(pruned)
+    np.testing.assert_array_equal(inits["FC1Q"], fc1_q[:, keep, :])
+    np.testing.assert_array_equal(inits["FC1S"], fc1_s[:, keep, :])
+    expected_fc2_q = _pack_vals(_unpack_vals(fc2_q, bits, inter)[:, :, keep], bits)
+    np.testing.assert_array_equal(inits["FC2Q"], expected_fc2_q)
+    np.testing.assert_array_equal(inits["FC2S"], fc2_s[:, :, keep_block_idx])
+
+    fc1_q_ref, fc1_s_ref, _ = _qmoe_quantize_blockwise(
+        fc1_w[:, keep, :], bits, block_size
+    )
+    reference = _qmoe_model(
+        fc1_q_ref,
+        fc1_s_ref,
+        expected_fc2_q,
+        fc2_s[:, :, keep_block_idx],
+        bits,
+        block_size=block_size,
+        k=2,
+        tokens=tokens,
+    )
+    onnx.checker.check_model(reference)
+
+    feed_rng = np.random.default_rng(261)
+    feeds = {
+        "X": (feed_rng.standard_normal((tokens, hidden)) * 0.2).astype(np.float32),
+        "R": feed_rng.standard_normal((tokens, E)).astype(np.float32),
+    }
+    (out_pruned,) = _run(pruned, feeds)
+    (out_ref,) = _run(reference, feeds)
+    np.testing.assert_allclose(out_pruned, out_ref, rtol=1e-5, atol=1e-5)
+
+
+def test_qmoe_expert_channel_pruning_cpp_blockwise_int_keep_set_floored_to_block_multiple():
+    # inter=48, block_size=16 (3 blocks), sparsity=0.4 -> naive channel-level
+    # target = 48 - round(48*0.4) = 29 -- not a multiple of block_size (16).
+    # The block-granularity computation (3 - round(3*0.4) = 2 blocks kept)
+    # correctly resolves to 32 survivors, never 29.
+    E, hidden, inter, bits, block_size, tokens = 2, 16, 48, 4, 16, 5
+    rng = np.random.default_rng(262)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float32)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float32)
+    fc1_q, fc1_s, fc1_dq = _qmoe_quantize_blockwise(fc1_w, bits, block_size)
+    fc2_q, fc2_s, fc2_dq = _qmoe_quantize_blockwise(fc2_w, bits, block_size)
+    model = _qmoe_model(
+        fc1_q, fc1_s, fc2_q, fc2_s, bits, block_size=block_size, k=1, tokens=tokens
+    )
+    onnx.checker.check_model(model)
+
+    naive_channel_target = inter - round(inter * 0.4)
+    assert naive_channel_target % block_size != 0  # the hazard this test guards.
+
+    pruned = onnxsim.apply_qmoe_expert_channel_pruning_cpp(model, sparsity=0.4)
+    onnx.checker.check_model(pruned)
+
+    inits = _qmoe_inits(pruned)
+    new_inter = inits["FC1Q"].shape[1]
+    assert new_inter == 32
+    assert new_inter % block_size == 0
+
+    importance = np.sqrt(
+        np.sum(fc1_dq**2, axis=(0, 2)) + np.sum(fc2_dq**2, axis=(0, 1))
+    )
+    keep, keep_block_idx = _qmoe_block_keep_reference(
+        importance, inter, block_size, 0.4
+    )
+    np.testing.assert_array_equal(inits["FC1Q"], fc1_q[:, keep, :])
+    expected_fc2_q = _pack_vals(_unpack_vals(fc2_q, bits, inter)[:, :, keep], bits)
+    np.testing.assert_array_equal(inits["FC2Q"], expected_fc2_q)
+    np.testing.assert_array_equal(inits["FC2S"], fc2_s[:, :, keep_block_idx])
+
+
+def test_qmoe_expert_channel_pruning_cpp_blockwise_int_zero_sparsity_is_a_no_op():
+    E, hidden, inter, bits, block_size = 2, 16, 32, 4, 16
+    rng = np.random.default_rng(263)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float32)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float32)
+    fc1_q, fc1_s, _ = _qmoe_quantize_blockwise(fc1_w, bits, block_size)
+    fc2_q, fc2_s, _ = _qmoe_quantize_blockwise(fc2_w, bits, block_size)
+    model = _qmoe_model(fc1_q, fc1_s, fc2_q, fc2_s, bits, block_size=block_size)
+    pruned = onnxsim.apply_qmoe_expert_channel_pruning_cpp(model, sparsity=0.0)
+    inits = _qmoe_inits(pruned)
+    np.testing.assert_array_equal(inits["FC1Q"], fc1_q)
+    np.testing.assert_array_equal(inits["FC2S"], fc2_s)
+
+
+# --- declines (quant_type='int') ---------------------------------------
+
+
+def test_qmoe_expert_channel_pruning_cpp_declines_fc3():
+    E, hidden, inter, bits = 2, 8, 8, 4
+    rng = np.random.default_rng(270)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float32)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float32)
+    fc3_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float32)
+    fc1_q, fc1_s, _ = _qmoe_quantize(fc1_w, bits)
+    fc2_q, fc2_s, _ = _qmoe_quantize(fc2_w, bits)
+    fc3_q, fc3_s, _ = _qmoe_quantize(fc3_w, bits)
+    model = _qmoe_model(fc1_q, fc1_s, fc2_q, fc2_s, bits, fc3_q=fc3_q, fc3_scale=fc3_s)
+    pruned = onnxsim.apply_qmoe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    inits = _qmoe_inits(pruned)
+    np.testing.assert_array_equal(inits["FC1Q"], fc1_q)
+
+
+def test_qmoe_expert_channel_pruning_cpp_declines_swiglu_activation():
+    E, hidden, inter, bits = 2, 8, 8, 4
+    rng = np.random.default_rng(271)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float32)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float32)
+    fc1_q, fc1_s, _ = _qmoe_quantize(fc1_w, bits)
+    fc2_q, fc2_s, _ = _qmoe_quantize(fc2_w, bits)
+    model = _qmoe_model(fc1_q, fc1_s, fc2_q, fc2_s, bits, activation="swiglu")
+    pruned = onnxsim.apply_qmoe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    inits = _qmoe_inits(pruned)
+    np.testing.assert_array_equal(inits["FC1Q"], fc1_q)
+
+
+def test_qmoe_expert_channel_pruning_cpp_declines_block_size_below_kernel_floor():
+    # block_size=8 is below the CPU kernel's own floor ("block_size must be
+    # >= 16 when provided") -- declined outright.
+    E, hidden, inter, bits = 2, 32, 16, 4
+    rng = np.random.default_rng(272)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float32)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float32)
+    block_size = 8
+    fc1_q, fc1_s, _ = _qmoe_quantize_blockwise(fc1_w, bits, block_size)
+    fc2_q, fc2_s, _ = _qmoe_quantize_blockwise(fc2_w, bits, block_size)
+    model = _qmoe_model(fc1_q, fc1_s, fc2_q, fc2_s, bits, block_size=block_size)
+    pruned = onnxsim.apply_qmoe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    inits = _qmoe_inits(pruned)
+    np.testing.assert_array_equal(inits["FC1Q"], fc1_q)
+
+
+def test_qmoe_expert_channel_pruning_cpp_declines_block_size_not_dividing_evenly():
+    # A non-block-aligned shape: block_size=16 doesn't divide inter_size=24
+    # evenly (a partial/padded final block) -- declined the same way every
+    # other shape mismatch in this pass is (fc2_scales' own expected
+    # block-axis shape never matches).
+    E, hidden, inter, bits, block_size = 2, 32, 24, 4, 16
+    rng = np.random.default_rng(273)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float32)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float32)
+    fc1_q, fc1_s, _ = _qmoe_quantize(fc1_w, bits)
+    fc2_q, fc2_s, _ = _qmoe_quantize(fc2_w, bits)
+    model = _qmoe_model(fc1_q, fc1_s, fc2_q, fc2_s, bits, block_size=block_size)
+    pruned = onnxsim.apply_qmoe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    inits = _qmoe_inits(pruned)
+    np.testing.assert_array_equal(inits["FC1Q"], fc1_q)
+
+
+def test_qmoe_expert_channel_pruning_cpp_declines_non_int_nvfp4_quant_type():
+    # 'fp8' is a genuinely different tensor format from either 'int' or
+    # 'nvfp4' -- declined outright, an unsupported quantization variant.
+    E, hidden, inter, bits = 2, 8, 8, 4
+    rng = np.random.default_rng(274)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float32)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float32)
+    fc1_q, fc1_s, _ = _qmoe_quantize(fc1_w, bits)
+    fc2_q, fc2_s, _ = _qmoe_quantize(fc2_w, bits)
+    model = _qmoe_model(fc1_q, fc1_s, fc2_q, fc2_s, bits, quant_type="fp8")
+    pruned = onnxsim.apply_qmoe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    inits = _qmoe_inits(pruned)
+    np.testing.assert_array_equal(inits["FC1Q"], fc1_q)
+
+
+def test_qmoe_expert_channel_pruning_cpp_declines_weights_prepacked_nonraw():
+    E, hidden, inter, bits = 2, 8, 8, 4
+    rng = np.random.default_rng(275)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float32)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float32)
+    fc1_q, fc1_s, _ = _qmoe_quantize(fc1_w, bits)
+    fc2_q, fc2_s, _ = _qmoe_quantize(fc2_w, bits)
+    model = _qmoe_model(fc1_q, fc1_s, fc2_q, fc2_s, bits, weights_prepacked=1)
+    pruned = onnxsim.apply_qmoe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    inits = _qmoe_inits(pruned)
+    np.testing.assert_array_equal(inits["FC1Q"], fc1_q)
+
+
+def test_qmoe_expert_channel_pruning_cpp_declines_router_weights_present():
+    E, hidden, inter, bits = 2, 8, 8, 4
+    rng = np.random.default_rng(276)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float32)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float32)
+    fc1_q, fc1_s, _ = _qmoe_quantize(fc1_w, bits)
+    fc2_q, fc2_s, _ = _qmoe_quantize(fc2_w, bits)
+    model = _qmoe_model(fc1_q, fc1_s, fc2_q, fc2_s, bits, router_weights=True)
+    pruned = onnxsim.apply_qmoe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    inits = _qmoe_inits(pruned)
+    np.testing.assert_array_equal(inits["FC1Q"], fc1_q)
+
+
+def test_qmoe_expert_channel_pruning_cpp_declines_tied_fc1_weight():
+    # fc1_experts_weights read by a second (Identity) consumer besides the
+    # QMoE node itself -- an in-place resize would corrupt that other
+    # consumer, so the whole chain is declined.
+    E, hidden, inter, bits = 3, 6, 6, 4
+    rng = np.random.default_rng(277)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float32)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float32)
+    fc1_q, fc1_s, _ = _qmoe_quantize(fc1_w, bits)
+    fc2_q, fc2_s, _ = _qmoe_quantize(fc2_w, bits)
+    model = _qmoe_model(
+        fc1_q, fc1_s, fc2_q, fc2_s, bits, tied_fc1_weight_elsewhere=True
+    )
+    pruned = onnxsim.apply_qmoe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    inits = _qmoe_inits(pruned)
+    np.testing.assert_array_equal(inits["FC1Q"], fc1_q)
+
+
+# --- quant_type='nvfp4' -------------------------------------------------
+
+
+def test_qmoe_nvfp4_expert_channel_pruning_cpp_matches_hand_built_presliced_reference():
+    # Confirms production's own packed-bytes/block-scale slice is
+    # byte-exact-identical to slicing the already-quantized reference
+    # directly (never re-derived), AND that dequantizing the pruned tensors
+    # reproduces exactly what slicing the full dequantized reference gives
+    # -- the "slice commutes with dequant" property this format needs to
+    # hold for pruning to be safe. fc1_global_scale/fc2_global_scale are
+    # per-expert, not per-channel, so must come back completely untouched.
+    E, hidden, inter, block_size, tokens = 3, 32, 64, 16, 6
+    rng = np.random.default_rng(411)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float64)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float64)
+    fc1_b = rng.standard_normal((E, inter)).astype(np.float32)
+    fc1_gs = np.array([1.0, 0.5, 2.0], dtype=np.float32)
+    fc2_gs = np.array([1.5, 1.0, 0.8], dtype=np.float32)
+
+    fc1_q, fc1_s, fc1_dq = _qmoe_nvfp4_quantize_blockwise(fc1_w, fc1_gs, block_size)
+    fc2_q, fc2_s, fc2_dq = _qmoe_nvfp4_quantize_blockwise(fc2_w, fc2_gs, block_size)
+
+    model = _qmoe_nvfp4_model(
+        fc1_q,
+        fc1_s,
+        fc2_q,
+        fc2_s,
+        fc1_gs,
+        fc2_gs,
+        fc1_bias=fc1_b,
+        block_size=block_size,
+        k=2,
+        tokens=tokens,
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_qmoe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    importance = np.sqrt(
+        np.sum(fc1_dq**2, axis=(0, 2))
+        + np.sum(fc2_dq**2, axis=(0, 1))
+        + np.sum(fc1_b.astype(np.float64) ** 2, axis=0)
+    )
+    keep, keep_block_idx = _qmoe_block_keep_reference(
+        importance, inter, block_size, 0.5
+    )
+    assert len(keep) == 32
+
+    inits = _qmoe_inits(pruned)
+    np.testing.assert_array_equal(inits["FC1Q"], fc1_q[:, keep, :])
+    np.testing.assert_array_equal(inits["FC1S"], fc1_s[:, keep, :])
+    np.testing.assert_array_equal(inits["FC1B"], fc1_b[:, keep])
+    expected_fc2_q = _pack_vals(_unpack_vals(fc2_q, 4, inter)[:, :, keep], 4)
+    np.testing.assert_array_equal(inits["FC2Q"], expected_fc2_q)
+    np.testing.assert_array_equal(inits["FC2S"], fc2_s[:, :, keep_block_idx])
+    np.testing.assert_array_equal(inits["FC1GS"], fc1_gs)
+    np.testing.assert_array_equal(inits["FC2GS"], fc2_gs)
+
+    full_fc1_dequant = _qmoe_nvfp4_dequantize(fc1_q, fc1_s, fc1_gs, block_size)
+    pruned_fc1_dequant = _qmoe_nvfp4_dequantize(
+        inits["FC1Q"], inits["FC1S"], inits["FC1GS"], block_size
+    )
+    np.testing.assert_array_equal(pruned_fc1_dequant, full_fc1_dequant[:, keep, :])
+
+    full_fc2_dequant = _qmoe_nvfp4_dequantize(fc2_q, fc2_s, fc2_gs, block_size)
+    pruned_fc2_dequant = _qmoe_nvfp4_dequantize(
+        inits["FC2Q"], inits["FC2S"], inits["FC2GS"], block_size
+    )
+    np.testing.assert_array_equal(pruned_fc2_dequant, full_fc2_dequant[:, :, keep])
+
+
+def test_qmoe_nvfp4_expert_channel_pruning_cpp_keep_set_floored_to_block_multiple():
+    # inter=48, block_size=16 (3 blocks), sparsity=0.4 -> naive channel-level
+    # target = 48 - round(48*0.4) = 29 -- not a multiple of block_size. The
+    # actual block-granularity computation resolves to 32 survivors.
+    E, hidden, inter, block_size, tokens = 2, 32, 48, 16, 5
+    rng = np.random.default_rng(419)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float64)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float64)
+    fc1_gs = np.array([1.0, 0.7], dtype=np.float32)
+    fc2_gs = np.array([1.2, 0.9], dtype=np.float32)
+    fc1_q, fc1_s, fc1_dq = _qmoe_nvfp4_quantize_blockwise(fc1_w, fc1_gs, block_size)
+    fc2_q, fc2_s, fc2_dq = _qmoe_nvfp4_quantize_blockwise(fc2_w, fc2_gs, block_size)
+    model = _qmoe_nvfp4_model(
+        fc1_q,
+        fc1_s,
+        fc2_q,
+        fc2_s,
+        fc1_gs,
+        fc2_gs,
+        block_size=block_size,
+        k=1,
+        tokens=tokens,
+    )
+    onnx.checker.check_model(model)
+
+    naive_channel_target = inter - round(inter * 0.4)
+    assert naive_channel_target % block_size != 0
+
+    pruned = onnxsim.apply_qmoe_expert_channel_pruning_cpp(model, sparsity=0.4)
+    onnx.checker.check_model(pruned)
+
+    inits = _qmoe_inits(pruned)
+    new_inter = inits["FC1Q"].shape[1]
+    assert new_inter == 32
+    assert new_inter % block_size == 0
+
+    importance = np.sqrt(
+        np.sum(fc1_dq**2, axis=(0, 2)) + np.sum(fc2_dq**2, axis=(0, 1))
+    )
+    keep, keep_block_idx = _qmoe_block_keep_reference(
+        importance, inter, block_size, 0.4
+    )
+    np.testing.assert_array_equal(inits["FC1Q"], fc1_q[:, keep, :])
+    expected_fc2_q = _pack_vals(_unpack_vals(fc2_q, 4, inter)[:, :, keep], 4)
+    np.testing.assert_array_equal(inits["FC2Q"], expected_fc2_q)
+    np.testing.assert_array_equal(inits["FC2S"], fc2_s[:, :, keep_block_idx])
+
+
+def test_qmoe_expert_channel_pruning_cpp_declines_fp8_quant_type_with_nvfp4_shape():
+    # quant_type='fp8' remains out of scope even when every other input is
+    # shaped exactly like a valid nvfp4 chain -- the matcher's own
+    # quant_type check runs before any of those shapes are even inspected.
+    E, hidden, inter, block_size = 2, 32, 32, 16
+    rng = np.random.default_rng(421)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float64)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float64)
+    fc1_gs = np.array([1.0, 1.0], dtype=np.float32)
+    fc2_gs = np.array([1.0, 1.0], dtype=np.float32)
+    fc1_q, fc1_s, _ = _qmoe_nvfp4_quantize_blockwise(fc1_w, fc1_gs, block_size)
+    fc2_q, fc2_s, _ = _qmoe_nvfp4_quantize_blockwise(fc2_w, fc2_gs, block_size)
+    model = _qmoe_nvfp4_model(
+        fc1_q,
+        fc1_s,
+        fc2_q,
+        fc2_s,
+        fc1_gs,
+        fc2_gs,
+        block_size=block_size,
+        quant_type="fp8",
+    )
+    pruned = onnxsim.apply_qmoe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    inits = _qmoe_inits(pruned)
+    np.testing.assert_array_equal(inits["FC1Q"], fc1_q)
+
+
+def test_qmoe_expert_channel_pruning_cpp_declines_nvfp4_zero_points_present():
+    # A signed/symmetric E2M1 code has no zero-point concept -- fc1_zero_points
+    # present on an otherwise-valid nvfp4 chain is declined outright.
+    E, hidden, inter, block_size = 2, 16, 16, 16
+    rng = np.random.default_rng(431)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float64)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float64)
+    fc1_gs = np.array([1.0, 1.0], dtype=np.float32)
+    fc2_gs = np.array([1.0, 1.0], dtype=np.float32)
+    fc1_q, fc1_s, _ = _qmoe_nvfp4_quantize_blockwise(fc1_w, fc1_gs, block_size)
+    fc2_q, fc2_s, _ = _qmoe_nvfp4_quantize_blockwise(fc2_w, fc2_gs, block_size)
+    fc1_zp = _pack_vals(np.zeros((E, inter), dtype=np.uint8), 4)
+    model = _qmoe_nvfp4_model(
+        fc1_q,
+        fc1_s,
+        fc2_q,
+        fc2_s,
+        fc1_gs,
+        fc2_gs,
+        block_size=block_size,
+        fc1_zp=fc1_zp,
+    )
+    pruned = onnxsim.apply_qmoe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    inits = _qmoe_inits(pruned)
+    np.testing.assert_array_equal(inits["FC1Q"], fc1_q)
+
+
+def test_qmoe_expert_channel_pruning_cpp_declines_nvfp4_missing_global_scale():
+    # fc1_global_scale/fc2_global_scale are required PRESENT for nvfp4 (the
+    # schema's own "must be provided" language) -- absent, the whole chain
+    # is declined.
+    E, hidden, inter, block_size = 2, 16, 16, 16
+    rng = np.random.default_rng(432)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float64)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float64)
+    fc1_gs = np.array([1.0, 1.0], dtype=np.float32)
+    fc2_gs = np.array([1.0, 1.0], dtype=np.float32)
+    fc1_q, fc1_s, _ = _qmoe_nvfp4_quantize_blockwise(fc1_w, fc1_gs, block_size)
+    fc2_q, fc2_s, _ = _qmoe_nvfp4_quantize_blockwise(fc2_w, fc2_gs, block_size)
+    model = _qmoe_nvfp4_model(
+        fc1_q,
+        fc1_s,
+        fc2_q,
+        fc2_s,
+        None,
+        None,
+        block_size=block_size,
+    )
+    pruned = onnxsim.apply_qmoe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    inits = _qmoe_inits(pruned)
+    np.testing.assert_array_equal(inits["FC1Q"], fc1_q)
+
+
+# --- subgraph recursion --------------------------------------------------
+
+
+def test_qmoe_expert_channel_pruning_cpp_prunes_node_inside_if_branch():
+    # The exact hand-built-presliced-reference fixture, nested inside an
+    # `If` -- verifies IterSubgraphs reaches a QMoE node nested at depth 1,
+    # checked via byte-level initializer equality (a full InferenceSession
+    # round trip is disproportionate here -- the top-level test already
+    # covers that byte-packing math end-to-end).
+    E, hidden, inter, bits, tokens = 3, 8, 12, 4, 6
+    rng = np.random.default_rng(211)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float32)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float32)
+    fc1_b = rng.standard_normal((E, inter)).astype(np.float32)
+
+    fc1_q, fc1_s, fc1_dq = _qmoe_quantize(fc1_w, bits)
+    fc2_q, fc2_s, fc2_dq = _qmoe_quantize(fc2_w, bits)
+    inner = _qmoe_model(
+        fc1_q, fc1_s, fc2_q, fc2_s, bits, fc1_bias=fc1_b, k=2, tokens=tokens
+    )
+    wrapped = _if_wrap(inner)
+
+    pruned = onnxsim.apply_qmoe_expert_channel_pruning_cpp(wrapped, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    sq = (
+        np.sum(fc1_dq**2, axis=(0, 2))
+        + np.sum(fc2_dq**2, axis=(0, 1))
+        + np.sum(fc1_b**2, axis=0)
+    )
+    keep = np.sort(np.argsort(-np.sqrt(sq))[:6])
+    expected_fc2_q = _pack_vals(_unpack_vals(fc2_q, bits, inter)[:, :, keep], bits)
+
+    then_g, else_g = _if_branches(pruned)
+    for branch_g in (then_g, else_g):
+        inits = {t.name: onnx.numpy_helper.to_array(t) for t in branch_g.initializer}
+        np.testing.assert_array_equal(inits["FC1Q"], fc1_q[:, keep, :])
+        np.testing.assert_array_equal(inits["FC1S"], fc1_s[:, keep])
+        np.testing.assert_array_equal(inits["FC1B"], fc1_b[:, keep])
+        np.testing.assert_array_equal(inits["FC2Q"], expected_fc2_q)


### PR DESCRIPTION
## Summary

Sixth round continuing the Python → C++ parity effort for `onnxsim`'s structured pruning (see #1027, #1031, #1034, #1044, #1049). Ports Mixture-of-Experts **expert-channel** pruning, both plain and quantized:

- **MoE expert-channel pruning** — `com.microsoft::MoE`, shrinks every expert's `inter_size` (`fc1`/`fc2` weight tensors, `fc1` bias) identically across all experts, ranked by combined L2 norm. New standalone entry point `apply_moe_expert_channel_pruning_cpp` (not folded into `apply_structured_pruning_cpp`, since `MoE` is a disjoint node type).
- **QMoE expert-channel pruning** — the quantized-weight counterpart, `com.microsoft::QMoE`. Supports `quant_type='int'` (2/4/8-bit, whole-row or blockwise) and `quant_type='nvfp4'` (E2M1-packed + `float8e4m3fn` block scales). Same "slice packed codes directly, never dequant-requant" invariant as every other quantized-pruning port in this file. New standalone entry point `apply_qmoe_expert_channel_pruning_cpp`.

Both were ported independently in parallel and needed conflict resolution to merge (both added their own top-level entry point and new-helper section near the same place in the file) — resolved by extracting each side's pure insertion and splicing them together after verifying no name collisions, rather than fighting the diff hunks piecemeal.

**Deliberately out of scope**, both here and for any future round: **whole-expert pruning** (shrinking `num_experts` itself, for both `MoE` and `QMoE`) — that variant ranks experts by mean router gate weight observed over calibration data, which needs a live `onnxruntime.InferenceSession`. This C++ port has no ONNX Runtime linked into it at all (the wheel build never builds ORT — see `CLAUDE.md`), so porting it isn't a matter of more engineering time under this pattern; it would need a real design decision about how (or whether) to support calibration-driven passes in this C++ port at all.

## Testing

- `pip install --no-build-isolation -ve .`
- `python3 -m pytest -v tests/test_moe_pruning_cpp.py tests/test_qmoe_pruning_cpp.py tests/test_structured_pruning_cpp.py tests/test_attention_head_pruning_cpp.py tests/test_pruning_cpp.py` — **231 passed, 0 failed**, including all pre-existing coverage from every prior round (no regressions)
- `clang-format --dry-run --Werror` / `ruff format --check` / `ruff check` / `mypy` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4t6ntCm72RfFf64W9GYB1

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4t6ntCm72RfFf64W9GYB1)_