### PR TITLE
Port embedding vocabulary pruning and FP4/FP8 block-quantized structured pruning to C++

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -63,6 +63,8 @@ from onnxsim.omniquant import apply_omniquant
 from onnxsim.onnx_simplifier import (
     apply_attention_head_pruning_cpp,
     apply_double_quantization_cpp,
+    apply_embedding_vocab_magnitude_pruning_cpp,
+    apply_embedding_vocab_pruning_cpp,
     apply_moe_expert_channel_pruning_cpp,
     apply_qmoe_expert_channel_pruning_cpp,
     apply_quarot_cpp,
@@ -212,7 +214,9 @@ __all__ = [
     "apply_qmoe_expert_channel_pruning_cpp",
     "apply_qmoe_whole_expert_pruning",
     "apply_embedding_vocab_pruning",
+    "apply_embedding_vocab_pruning_cpp",
     "apply_embedding_vocab_magnitude_pruning",
+    "apply_embedding_vocab_magnitude_pruning_cpp",
     "EmbeddingPruningResult",
     "apply_transformer_block_pruning",
     "weight_sparsity",

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -673,6 +673,65 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
       },
       "model_bytes"_a, "sparsity"_a);
 
+  // Embedding vocabulary pruning: shrinks a matched token-embedding
+  // table's vocabulary axis (plus, where a tied/untied lm_head exists, its
+  // own vocab-logits projection too) down to a caller-supplied explicit
+  // keep/drop set. Unlike every `apply_*` binding above, the pruned model
+  // this returns does not accept the original model's own token ids -- see
+  // EmbeddingVocabPruningResult/ApplyEmbeddingVocabPruning in
+  // structured_pruning_entry.h. Returned as a
+  // (model_bytes, matched, kept_token_ids, lm_head_pruned) tuple rather
+  // than bare bytes -- reconstructed into the real, public
+  // `onnxsim.pruning.EmbeddingPruningResult` dataclass by the Python
+  // wrapper (onnx_simplifier.py's own
+  // apply_embedding_vocab_pruning_cpp), which also derives `id_map` from
+  // `kept_token_ids` (trivial: `{tok: i for i, tok in
+  // enumerate(kept_token_ids)}`) rather than this needing to also cross
+  // the nanobind boundary as a separate map.
+  m.def(
+      "apply_embedding_vocab_pruning",
+      [](const py::bytes& model_proto_bytes,
+         std::optional<std::vector<int64_t>> keep_token_ids,
+         std::optional<std::vector<int64_t>> drop_token_ids,
+         std::optional<std::string> input_name)
+          -> std::tuple<py::bytes, bool, std::vector<int64_t>, bool> {
+        InitEnv();
+        ONNX_NAMESPACE::ModelProto model;
+        ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
+                            model_proto_bytes.size());
+        const auto result = ApplyEmbeddingVocabPruning(
+            model, keep_token_ids, drop_token_ids, input_name);
+        std::string out;
+        result.model.SerializeToString(&out);
+        return {py::bytes(out.data(), out.size()), result.matched,
+                result.kept_token_ids, result.lm_head_pruned};
+      },
+      "model_bytes"_a, "keep_token_ids"_a.none(), "drop_token_ids"_a.none(),
+      "input_name"_a.none());
+
+  // The importance-ranked variant -- see EmbeddingVocabPruningResult/
+  // ApplyEmbeddingVocabMagnitudePruning in structured_pruning_entry.h.
+  // Same return shape as apply_embedding_vocab_pruning above.
+  m.def(
+      "apply_embedding_vocab_magnitude_pruning",
+      [](const py::bytes& model_proto_bytes, double sparsity,
+         std::optional<std::vector<int64_t>> protect_token_ids,
+         std::optional<std::string> input_name)
+          -> std::tuple<py::bytes, bool, std::vector<int64_t>, bool> {
+        InitEnv();
+        ONNX_NAMESPACE::ModelProto model;
+        ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
+                            model_proto_bytes.size());
+        const auto result = ApplyEmbeddingVocabMagnitudePruning(
+            model, sparsity, protect_token_ids, input_name);
+        std::string out;
+        result.model.SerializeToString(&out);
+        return {py::bytes(out.data(), out.size()), result.matched,
+                result.kept_token_ids, result.lm_head_pruned};
+      },
+      "model_bytes"_a, "sparsity"_a = 0.5, "protect_token_ids"_a.none(),
+      "input_name"_a.none());
+
   // QuaRot (Ashkboos et al., 2024): rotation preprocessing plus INT4
   // round-to-nearest quantization of both the weight and the activation of
   // every MatMul/vanilla-Gemm layer. Data-free. See ApplyQuarot in

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -20,6 +20,7 @@ from rich.text import Text
 import onnxsim.onnxsim_cpp2py_export as C
 
 from . import backend, model_checking, model_info, profile_merge, version
+from .pruning import EmbeddingPruningResult
 
 TensorShape = List[int]
 TensorShapes = Dict[str, TensorShape]
@@ -1550,6 +1551,161 @@ def apply_qmoe_expert_channel_pruning_cpp(
     return onnx.load_from_string(
         C.apply_qmoe_expert_channel_pruning(model.SerializeToString(), sparsity)
     )
+
+
+def _embedding_pruning_result_from_cpp(
+    model_bytes: bytes,
+    matched: bool,
+    kept_token_ids: List[int],
+    lm_head_pruned: bool,
+) -> EmbeddingPruningResult:
+    """Reconstructs the real, public :class:`onnxsim.pruning.EmbeddingPruningResult`
+    -- the exact same dataclass :func:`onnxsim.apply_embedding_vocab_pruning`/
+    :func:`onnxsim.apply_embedding_vocab_magnitude_pruning` already return --
+    from the C++ binding's own ``(model_bytes, matched, kept_token_ids,
+    lm_head_pruned)`` tuple. ``id_map`` (``{old_token_id: new_token_id}``) is
+    not carried across the nanobind boundary at all -- it is exactly
+    ``{tok: i for i, tok in enumerate(kept_token_ids)}``, trivial to
+    reconstruct here, so there is no reason for the C++ side to also
+    serialize an int64->int64 map.
+    """
+    model = onnx.load_from_string(model_bytes)
+    if not matched:
+        return EmbeddingPruningResult(model=model, matched=False)
+    id_map = {old: new for new, old in enumerate(kept_token_ids)}
+    return EmbeddingPruningResult(
+        model=model,
+        matched=True,
+        kept_token_ids=list(kept_token_ids),
+        id_map=id_map,
+        lm_head_pruned=lm_head_pruned,
+    )
+
+
+def apply_embedding_vocab_pruning_cpp(
+    model: Union[str, onnx.ModelProto],
+    keep_token_ids: Optional[Sequence[int]] = None,
+    drop_token_ids: Optional[Sequence[int]] = None,
+    input_name: Optional[str] = None,
+) -> EmbeddingPruningResult:
+    """C++-backed port of :func:`onnxsim.apply_embedding_vocab_pruning`:
+    shrinks a matched token-embedding table's vocabulary axis -- a plain
+    ``Gather``'s ``data`` input feeding a graph input's token-id tensor --
+    (and, where a tied or confidently-auto-identified untied ``lm_head``
+    exists, its own vocab-logits projection too) down to a caller-supplied,
+    explicit keep-set.
+
+    **Contract change, unmissable on purpose, identical to the pure-Python
+    original**: the pruned model this returns does **not** accept the same
+    ``input_ids`` values the original model did. Token id ``i`` is only
+    ever a valid input going forward if ``i in result.id_map`` -- feed
+    ``result.id_map[i]`` in its place before running ``result.model``. See
+    :class:`onnxsim.pruning.EmbeddingPruningResult`'s own docstring for the
+    full return-value contract.
+
+    Unlike :func:`onnxsim.apply_embedding_vocab_pruning`, this C++ port
+    only ever matches a plain ``Gather`` producer -- not
+    ``com.microsoft::EmbedLayerNormalization`` or ``com.microsoft::
+    GatherBlockQuantized`` -- only ever auto-detects a bare ``MatMul``/
+    vanilla ``Gemm`` ``lm_head`` -- not ``com.microsoft::FusedGemm``/
+    ``GemmFastGelu`` -- and only ever admits a plain FLOAT (float32)
+    embedding table/``lm_head`` weight/bias, not also FLOAT16/BFLOAT16,
+    matching this codebase's own established narrower-than-pruning.py
+    C++-port scope decision elsewhere (e.g.
+    :func:`onnxsim.apply_moe_expert_channel_pruning_cpp`'s own FLOAT32-only
+    restriction). See ``onnxsim/structured_pruning_entry.cpp``'s own
+    "Embedding vocabulary pruning" section comment for the exact matched
+    topology.
+
+    This is a single, self-contained graph rewrite: unlike :func:`simplify`,
+    it does not run shape inference, constant folding, or any other pass.
+
+    :param model: the original onnx ModelProto or file path
+    :param keep_token_ids: the exact set of original token ids to keep, in
+            any order/with any duplicates. Give exactly one of
+            ``keep_token_ids``/``drop_token_ids``.
+    :param drop_token_ids: the exact set of original token ids to drop;
+            every other id in ``range(vocab_size)`` is kept. Give exactly
+            one of ``keep_token_ids``/``drop_token_ids``.
+    :param input_name: when the graph has more than one structurally-
+            eligible embedding ``Gather``, names which one to target by its
+            token-id operand's graph input name. Required in that case --
+            omitted, an ambiguous graph declines the whole call rather than
+            guessing. A name that matches no eligible producer raises
+            ``ValueError``.
+    :returns: an :class:`onnxsim.pruning.EmbeddingPruningResult` -- see its
+            own docstring. ``matched`` is False (model left completely
+            untouched) for any topology this pass doesn't confidently
+            recognize.
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    result = C.apply_embedding_vocab_pruning(
+        model.SerializeToString(),
+        list(keep_token_ids) if keep_token_ids is not None else None,
+        list(drop_token_ids) if drop_token_ids is not None else None,
+        input_name,
+    )
+    return _embedding_pruning_result_from_cpp(*result)
+
+
+def apply_embedding_vocab_magnitude_pruning_cpp(
+    model: Union[str, onnx.ModelProto],
+    sparsity: float = 0.5,
+    protect_token_ids: Optional[Sequence[int]] = None,
+    input_name: Optional[str] = None,
+) -> EmbeddingPruningResult:
+    """C++-backed port of :func:`onnxsim.apply_embedding_vocab_magnitude_pruning`:
+    the importance-ranked variant of
+    :func:`onnxsim.apply_embedding_vocab_pruning_cpp` -- drops the lowest-
+    L2-norm ``sparsity`` fraction of vocabulary rows (combined,
+    root-sum-square, with a matched untied ``lm_head``'s own per-row weight
+    norm when one is identified), needing no calibration data at all.
+
+    **This mode's safety bar is meaningfully weaker than
+    :func:`onnxsim.apply_embedding_vocab_pruning_cpp`'s own explicit
+    keep-set** -- see that function's own docstring and
+    :func:`onnxsim.apply_embedding_vocab_magnitude_pruning`'s own (identical
+    caveat, ported verbatim): a small embedding-row norm means a token was
+    initialized/trained with small weights, not that it is safe to drop
+    from a real deployment's input space. ``protect_token_ids`` (below)
+    covers the common, cheap case of guaranteeing a known-important set
+    never gets ranked away by norm alone, but does not by itself make
+    norm-based ranking a safe substitute for the explicit-keep-set entry
+    point in general.
+
+    Same contract change as :func:`onnxsim.apply_embedding_vocab_pruning_cpp`
+    -- see its own docstring and
+    :class:`onnxsim.pruning.EmbeddingPruningResult`'s.
+
+    Same C++-port scope restrictions as
+    :func:`onnxsim.apply_embedding_vocab_pruning_cpp` (plain ``Gather``
+    producer only, plain ``MatMul``/``Gemm`` ``lm_head`` only, FLOAT32-only
+    tensors) -- see that function's own docstring.
+
+    This is a single, self-contained graph rewrite: unlike :func:`simplify`,
+    it does not run shape inference, constant folding, or any other pass.
+
+    :param model: the original onnx ModelProto or file path
+    :param sparsity: target fraction of ``vocab_size`` to drop (floored so
+            at least one row, and every ``protect_token_ids`` row, always
+            survives); must be in ``[0, 1)``
+    :param protect_token_ids: token ids to always keep regardless of their
+            own norm ranking
+    :param input_name: identical to
+            :func:`onnxsim.apply_embedding_vocab_pruning_cpp`'s own
+            ``input_name``
+    :returns: an :class:`onnxsim.pruning.EmbeddingPruningResult`
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    result = C.apply_embedding_vocab_magnitude_pruning(
+        model.SerializeToString(),
+        sparsity,
+        list(protect_token_ids) if protect_token_ids is not None else None,
+        input_name,
+    )
+    return _embedding_pruning_result_from_cpp(*result)
 
 
 def apply_quarot_cpp(

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -11,6 +11,14 @@
 #include <vector>
 
 #include "dlpack/dlpack.h"
+// Pulls in EmbeddingVocabPruningResult (needed below by
+// ApplyEmbeddingVocabPruning/ApplyEmbeddingVocabMagnitudePruning's own
+// declarations) -- unlike every other entry point in this header, which
+// duplicates a bare `onnx::ModelProto`-returning prototype verbatim rather
+// than including its own home header, sharing a single struct definition
+// (rather than a byte-for-byte duplicate struct body in each header) avoids
+// two independently-edited copies of the same type ever drifting apart.
+#include "structured_pruning_entry.h"
 
 // RAII owner for a DLManagedTensor: releasing it invokes the tensor's own
 // DLPack deleter exactly once (per the DLPack contract), which frees whatever
@@ -729,6 +737,35 @@ onnx::ModelProto ApplyMoeExpertChannelPruning(const onnx::ModelProto& model,
 // topology above is left completely untouched.
 onnx::ModelProto ApplyQMoEExpertChannelPruning(const onnx::ModelProto& model,
                                                double sparsity);
+
+// Embedding vocabulary pruning: shrinks a matched token-embedding table's
+// vocabulary axis (a plain ``Gather``'s ``data`` input feeding a graph
+// input's token-id tensor, plus, where a tied or confidently-auto-
+// identified untied ``lm_head`` exists, its own vocab-logits projection
+// too) down to a caller-supplied, explicit keep-set -- the C++ port of
+// pruning.py's own ``apply_embedding_vocab_pruning``. See
+// structured_pruning_entry.h's own ``EmbeddingVocabPruningResult``/
+// ``ApplyEmbeddingVocabPruning`` doc comments for the full contract
+// (**unlike every other pass in this header, the pruned model this
+// returns does not accept the original model's own token ids -- see
+// those doc comments**), and structured_pruning_entry.cpp's own
+// "Embedding vocabulary pruning" section comment for the exact matched
+// topology, scope, and the deliberately-narrower-than-pruning.py
+// restrictions this C++ port makes (plain ``Gather`` producer only, plain
+// ``MatMul``/``Gemm`` ``lm_head`` only, FLOAT32-only tensors).
+EmbeddingVocabPruningResult ApplyEmbeddingVocabPruning(
+    const onnx::ModelProto& model,
+    const std::optional<std::vector<int64_t>>& keep_token_ids,
+    const std::optional<std::vector<int64_t>>& drop_token_ids,
+    const std::optional<std::string>& input_name);
+
+// The importance-ranked variant -- see structured_pruning_entry.h's own
+// ``ApplyEmbeddingVocabMagnitudePruning`` doc comment, the C++ port of
+// pruning.py's own ``apply_embedding_vocab_magnitude_pruning``.
+EmbeddingVocabPruningResult ApplyEmbeddingVocabMagnitudePruning(
+    const onnx::ModelProto& model, double sparsity,
+    const std::optional<std::vector<int64_t>>& protect_token_ids,
+    const std::optional<std::string>& input_name);
 
 // Lists the activation tensor names that ``QuantizeStatic`` could quantize in
 // ``model`` -- the first input of every MatMul, every "vanilla" Gemm

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -13034,6 +13034,1180 @@ void ApplyQMoEChannelChains(onnx::GraphProto* graph,
   }
 }
 
+// --- MatMulBlockQuantizedFp4Weight/MatMulBlockQuantizedFp8Weight
+//     (NVFP4/FP8 block-quantized weight) structured pruning ----------------
+//
+// C++ port of pruning.py's own "MatMulBlockQuantizedFp4Weight/
+// MatMulBlockQuantizedFp8Weight (NVFP4/FP8 block-quantized weight)
+// structured pruning" section -- read that section's own top comment FIRST
+// (onnxsim/pruning.py, just above `_decode_e4m3_bytes`) for the full
+// empirical schema investigation (every input/output/attribute of both
+// `com.microsoft::MatMulBlockQuantizedFp8Weight`/`MatMulBlockQuantizedFp4
+// Weight`, confirmed live against onnxruntime rather than assumed) and the
+// full list of scope boundaries; this comment only covers what's specific
+// to (or narrowed further by) this C++ port.
+//
+// Both ops are weight-only block-quantized dense `MatMul` variants -- the
+// same *shape* of problem `MatMulNBits` (this file's own "MatMulNBits"
+// section, above) solves for int4/int8 weights -- for two different
+// low-precision FLOAT encodings instead: `Fp8Weight`'s `B` is one full
+// FLOAT8E4M3FN byte per weight element, `[N, K]`, no packing at all;
+// `Fp4Weight`'s `B` is `uint8[N, K/2]`, two E2M1 (4-bit) codes per byte, LOW
+// NIBBLE FIRST, packed FLAT across the WHOLE `K` axis -- unlike
+// `MatMulNBits`'s own `B`, which is packed BLOCK-RELATIVE (a fresh byte
+// boundary at every block start). This structural difference is why
+// `Fp4Weight`'s own consumer-role (K-axis) slice always unpacks/repacks a
+// FULL row's worth of `K` nibbles at once (SliceBlockQuantizedFp4Consumer
+// Blocks, below), never a per-block byte copy the way `MatMulNBits`'s own
+// consumer slice can get away with for its block-relative `B`. Both ops'
+// own scale table (`b_scale`/`weight_scale`) is one full value per
+// `(n, block)` pair -- never packed along ANY axis -- so slicing it is
+// always a plain row/column selection, no unpack/repack ever needed there.
+//
+// *** THE CORE CORRECTNESS INVARIANT, IDENTICAL TO `MatMulNBits`'s OWN ***:
+// "slice codes directly, never dequant-requant". A matched weight is only
+// ever DEQUANTIZED (BlockQuantizedFp8Dequantized/BlockQuantizedFp4
+// Dequantized, below) for IMPORTANCE RANKING; the rewrite always operates
+// on the ORIGINAL packed `B`/scale-table bytes.
+//
+// *** THE BLOCK-ALIGNMENT CONSTRAINT, IDENTICAL IN SPIRIT ***: a CONSUMER's
+// own `K` axis is quantized in whole `block_size`-sized blocks, so a
+// candidate keep-set is only ever applied to a quantized consumer when it
+// lands on whole block boundaries (MatMulNBitsBlockAlignedKeepBlocks,
+// REUSED UNCHANGED from the `MatMulNBits` section -- it depends only on
+// `keep`/`k_blocks`/`block_size` as plain integers, never on packing
+// details, so it applies here without modification). `Fp4Weight` adds ONE
+// extra condition (Fp4BlockAlignedKeepBlocks, below): the RESULTING `K`
+// (`len(keep_blocks) * block_size`) must itself be even, since the live
+// schema derives `K` as exactly `2 * B.shape[1]` with no padding-nibble
+// concept -- an odd resulting `K` cannot be honestly represented and is
+// declined the same way a non-block-aligned keep-set already is.
+//
+// Neither op's live schema documents a `block_size` power-of-two/minimum
+// constraint (unlike `MatMulNBits`'s explicit one) -- so, unlike
+// MatMulNBitsValidBlockSizes, this section does NOT restrict `block_size`
+// to a fixed set; any `block_size >= 1` is accepted so long as the
+// ORIGINAL `K` is an exact multiple of it (a padded/partial final block is
+// declined at the matcher level, mirroring `MatMulNBits`'s identical
+// stance for the identical reason: no verified kernel behavior for that
+// case). Neither op's matched struct needs to rewrite an `N`/`K` node
+// attribute after slicing either (unlike `MatMulNBits`, which stores both
+// as explicit attributes) -- both live schemas derive `N`/`K` purely from
+// `B`'s own tensor shape at graph-execution time, so resizing the tensor
+// alone is sufficient; `block_size` itself is never touched by a prune.
+//
+// A GLOBAL (not per-row/per-block) scalar operand -- `Fp8Weight`'s optional
+// `a_scale`, `Fp4Weight`'s required `weight_scale_2` and optional
+// `input_scale` -- is validated at match time (present, FLOAT32, scalar-or-
+// [1]-shaped) but NEVER sliced, in EITHER role, mirroring pruning.py's own
+// deliberate departure from `MatMulNBits`'s blanket single-consumer-tied-
+// tensor policy for these specific operands (see pruning.py's own section
+// comment for the full reasoning: none of these appears, at all, in either
+// op's own dequantization formula in a per-row/per-block way). `weight_
+// scale_2` (`Fp4Weight`'s own required global scale) is still READ, by
+// name, at Apply time for importance-ranking dequantization -- but the
+// tensor itself is left byte-for-byte untouched either way.
+//
+// `bias` is OUT OF SCOPE ENTIRELY in this C++ port, a real, deliberate
+// narrowing beyond pruning.py's own scope: both live schemas type `bias`
+// ALWAYS FLOAT16/BFLOAT16 (never FLOAT32, unlike every other bias
+// convention this file otherwise handles), and this file has NO FLOAT16/
+// BFLOAT16 tensor read/write support anywhere yet (see the `MatMulNBits`
+// section's own top comment for this same established precedent, and its
+// own identical narrowing for `scales`/`zero_points`/`bias`). A node with
+// any `bias` input present (a name at that position, non-empty) is simply
+// DECLINED at the matcher level -- never mishandled, never silently
+// dropped from a graph this pass otherwise touches.
+//
+// The E4M3 byte decode (`Fp8Weight`'s own `B`, already tagged
+// FLOAT8E4M3FN in-graph, AND `Fp4Weight`'s own `weight_scale`, raw `uint8`
+// bytes that are E4M3 codes per the live schema) reuses QMoEFloat8E4M3Table
+// UNCHANGED from the QMoE section, above -- the identical standard E4M3FN
+// codebook (byte value -> double), not a fresh table: `ReadUint8Tensor`
+// already reads raw bytes regardless of a tensor's own declared dtype (it
+// only ever looks at `raw_data`/`int32_data`, never the dtype tag), so no
+// FLOAT8E4M3FN-specific tensor reader is needed to decode `Fp8Weight`'s own
+// `B` this way either. `Fp4Weight`'s own E2M1 magnitude table reuses
+// QMoEE2M1Table UNCHANGED for the identical reason pruning.py's own
+// `_matmul_block_quantized_fp4_dequantized` reuses `_E2M1_MAGNITUDE`/
+// `_e2m1_decode` unchanged from its own QMoE nvfp4 section. `Fp4Weight`'s
+// own flat nibble packing reuses UnpackNibblesLastAxis/PackNibblesLastAxis
+// UNCHANGED from the `MatMulNBits` section (bits fixed at 4, no `bits`
+// parameter needed) -- both already operate on a `[outer, packed_width]`
+// flat buffer, exactly the shape `Fp4Weight`'s own flat-across-K `B`
+// needs, whether `outer` is `N` (producer-role whole-row copy, no
+// unpack/repack needed at all) or -- for the consumer-role slice -- still
+// `N`, now selecting `count` = the new `K` out of each row's full nibble
+// span. The plain-float peer side of a mixed chain reuses
+// PlainMatMulNBitsPeer/MatchPlainMatMulNBitsPeer UNCHANGED from the
+// `MatMulNBits` section too (same "quantized transformer block feeding an
+// unquantized lm_head" export shape that section's own top comment
+// motivates).
+//
+// `Fp8Weight` and `Fp4Weight` are NEVER mixed with each other, or with
+// `MatMulNBits`/`MatMulBnb4`/QDQ, in one chain -- two entirely separate
+// chain-finding passes below (FindFp8BlockQuantizedChains/
+// FindFp4BlockQuantizedChains), each requiring at least one side to
+// actually be its own op (an all-plain-float pair is FindChains's own job,
+// not duplicated here), mirroring pruning.py's own identical stance. No
+// grouped/gated (SwiGLU/GeGLU) pair, residual/Concat-merge topology, or
+// fused-MLP/QKV analogue is matched -- only the plain single producer ->
+// [zero or more shape-preserving unary activations] -> single consumer
+// chain, identical in spirit to `MatMulNBits`'s own base (non-gated,
+// non-fused) chain matching, and simpler: neither op has any such fused-op
+// analogue at all as of this writing (see pruning.py's own section comment).
+//
+// Wiring: pruning.py itself exposes these as two separate top-level
+// functions (`apply_structured_pruning_matmul_block_quantized_fp8`/`_fp4`),
+// but -- mirroring this port's own established `MatMulNBits`/`MatMulBnb4`/
+// QDQ precedent (each still just one more call inside `ApplyStructuredPruning`
+// despite having its own separately-named Python top-level function) -- both
+// are folded directly into `ApplyStructuredPruning`'s own existing
+// `TouchedState`/`IterSubgraphs` loop below (two more application passes
+// over each graph) rather than getting new standalone top-level C++ entry
+// points.
+
+// A matched `com.microsoft::MatMulBlockQuantizedFp8Weight` node's weight
+// operands -- see this section's own top comment for the schema facts this
+// depends on. Every tensor stored by NAME, mirroring MatMulNBitsWeight's
+// own established convention (a match is built against a read-only InitMap;
+// the later Apply step rebuilds its own mutable name->TensorProto* map).
+// `node` is safe to store as a pointer for the identical reason
+// MatMulNBitsWeight's own comment gives: it comes from
+// `graph->mutable_node(i)`, and no node is ever inserted/removed by this
+// whole pruning pass. Unlike MatMulNBitsWeight, there is no `N`/`K` node
+// attribute to rewrite after slicing (see this section's own top comment),
+// and no `bias`/`a_scale` field at all -- `bias` is declined entirely at
+// the matcher (see top comment), `a_scale` is validated but never stored
+// (never sliced in either role, and never needed for dequantization either
+// -- unlike `Fp4Weight`'s own `weight_scale_2`, `a_scale` doesn't even
+// appear in `Fp8Weight`'s own dequantization formula).
+struct BlockQuantizedFp8Weight {
+  onnx::NodeProto* node = nullptr;
+  std::string b_name;        // FLOAT8E4M3FN [N, K], no packing.
+  std::string b_scale_name;  // FLOAT [N, k_blocks].
+  int64_t N = 0;
+  int64_t K = 0;
+  int64_t block_size = 0;
+  int64_t k_blocks = 0;
+};
+
+// A matched `com.microsoft::MatMulBlockQuantizedFp4Weight` node's weight
+// operands -- see this section's own top comment. `weight_scale_2_name` is
+// stored (unlike `Fp8Weight`'s never-needed `a_scale`) because `Fp4Weight`'s
+// own dequantization formula DOES need this global scale's own value for
+// importance ranking (BlockQuantizedFp4Dequantized, below) -- the tensor
+// itself is still never resliced.
+struct BlockQuantizedFp4Weight {
+  onnx::NodeProto* node = nullptr;
+  std::string b_name;               // UINT8 [N, K/2], flat nibble-packed.
+  std::string weight_scale_name;    // UINT8 (raw E4M3 bytes) [N, k_blocks].
+  std::string weight_scale_2_name;  // FLOAT scalar (global scale).
+  int64_t N = 0;
+  int64_t K = 0;
+  int64_t block_size = 0;
+  int64_t k_blocks = 0;
+};
+
+// True for a 0-D (`[]`) or single-element 1-D (`[1]`) shape -- the two ways
+// a "scalar" global scale (`a_scale`/`weight_scale_2`/`input_scale`) might
+// reasonably be exported, mirroring pruning.py's own
+// `_block_quantized_scalar_dims_ok`.
+bool BlockQuantizedScalarDimsOk(const onnx::TensorProto& t) {
+  return t.dims_size() == 0 || (t.dims_size() == 1 && t.dims(0) == 1);
+}
+
+// If `node` is a `com.microsoft::MatMulBlockQuantizedFp8Weight` node
+// matching every scope boundary this section's own top comment documents,
+// returns the match -- mirrors pruning.py's own
+// `_match_matmul_block_quantized_fp8`. `nullopt` whenever anything is
+// ambiguous or out of the empirically-verified scope, rather than guessing.
+std::optional<BlockQuantizedFp8Weight> MatchMatMulBlockQuantizedFp8(
+    onnx::NodeProto* node, const InitMap& init_map,
+    const ConsumerMap& consumers_of) {
+  if (node->op_type() != "MatMulBlockQuantizedFp8Weight" ||
+      node->domain() != kComMicrosoftDomain) {
+    return std::nullopt;
+  }
+  if (node->input_size() < 3 || node->output_size() != 1) {
+    return std::nullopt;
+  }
+  const std::string& a_name = node->input(0);
+  const std::string& b_name = node->input(1);
+  const std::string& scale_name = node->input(2);
+  if (a_name.empty() || b_name.empty() || scale_name.empty()) {
+    return std::nullopt;
+  }
+  const std::string a_scale_name =
+      (node->input_size() > 3) ? node->input(3) : std::string();
+  const std::string bias_name =
+      (node->input_size() > 4) ? node->input(4) : std::string();
+  if (!bias_name.empty()) {
+    return std::nullopt;  // Always FLOAT16/BFLOAT16 -- unsupported here, see
+                          // this section's own top comment.
+  }
+
+  const int64_t block_size =
+      MatMulNBitsIntAttrOr(*node, "block_size", 128);  // schema default.
+  if (block_size < 1) {
+    return std::nullopt;
+  }
+
+  auto b_it = init_map.find(b_name);
+  auto s_it = init_map.find(scale_name);
+  if (b_it == init_map.end() || s_it == init_map.end()) {
+    return std::nullopt;  // Non-constant B/b_scale -- can't safely slice.
+  }
+  const onnx::TensorProto* b_init = b_it->second;
+  const onnx::TensorProto* scale_init = s_it->second;
+  if (b_init->data_type() != onnx::TensorProto::FLOAT8E4M3FN) {
+    return std::nullopt;
+  }
+  if (b_init->dims_size() != 2) {
+    return std::nullopt;
+  }
+  const int64_t n = b_init->dims(0);
+  const int64_t k = b_init->dims(1);
+  if (n <= 0 || k <= 0 || k % block_size != 0) {
+    return std::nullopt;  // Padded/partial final block -- declined.
+  }
+  const int64_t k_blocks = k / block_size;
+
+  if (scale_init->data_type() != onnx::TensorProto::FLOAT) {
+    return std::nullopt;
+  }
+  if (!MatMulNBitsDimsEqual(*scale_init, {n, k_blocks})) {
+    return std::nullopt;
+  }
+
+  if (!a_scale_name.empty()) {
+    auto as_it = init_map.find(a_scale_name);
+    if (as_it == init_map.end() ||
+        as_it->second->data_type() != onnx::TensorProto::FLOAT ||
+        !BlockQuantizedScalarDimsOk(*as_it->second)) {
+      return std::nullopt;  // Non-constant, dtype-mismatched, or non-scalar.
+    }
+    // a_scale is never sliced in either role (see this section's own top
+    // comment) -- deliberately NOT subject to the single-consumer bar below.
+  }
+
+  for (const auto& nm : {b_name, scale_name}) {
+    if (ConsumerCount(consumers_of, nm) != 1) {
+      return std::nullopt;  // Shared/tied tensor -- another node reads it.
+    }
+  }
+
+  BlockQuantizedFp8Weight w;
+  w.node = node;
+  w.b_name = b_name;
+  w.b_scale_name = scale_name;
+  w.N = n;
+  w.K = k;
+  w.block_size = block_size;
+  w.k_blocks = k_blocks;
+  return w;
+}
+
+// If `node` is a `com.microsoft::MatMulBlockQuantizedFp4Weight` node
+// matching every scope boundary this section's own top comment documents,
+// returns the match -- mirrors pruning.py's own
+// `_match_matmul_block_quantized_fp4`.
+std::optional<BlockQuantizedFp4Weight> MatchMatMulBlockQuantizedFp4(
+    onnx::NodeProto* node, const InitMap& init_map,
+    const ConsumerMap& consumers_of) {
+  if (node->op_type() != "MatMulBlockQuantizedFp4Weight" ||
+      node->domain() != kComMicrosoftDomain) {
+    return std::nullopt;
+  }
+  if (node->input_size() < 4 || node->output_size() != 1) {
+    return std::nullopt;
+  }
+  const std::string& a_name = node->input(0);
+  const std::string& b_name = node->input(1);
+  const std::string& ws_name = node->input(2);
+  const std::string& ws2_name = node->input(3);
+  if (a_name.empty() || b_name.empty() || ws_name.empty() || ws2_name.empty()) {
+    return std::nullopt;
+  }
+  const std::string input_scale_name =
+      (node->input_size() > 4) ? node->input(4) : std::string();
+  const std::string bias_name =
+      (node->input_size() > 5) ? node->input(5) : std::string();
+  if (!bias_name.empty()) {
+    return std::nullopt;  // Always FLOAT16/BFLOAT16 -- unsupported here.
+  }
+
+  const int64_t block_size =
+      MatMulNBitsIntAttrOr(*node, "block_size", 16);  // schema default.
+  if (block_size < 1) {
+    return std::nullopt;
+  }
+
+  auto b_it = init_map.find(b_name);
+  auto ws_it = init_map.find(ws_name);
+  auto ws2_it = init_map.find(ws2_name);
+  if (b_it == init_map.end() || ws_it == init_map.end() ||
+      ws2_it == init_map.end()) {
+    return std::nullopt;  // Non-constant B/weight_scale/weight_scale_2.
+  }
+  const onnx::TensorProto* b_init = b_it->second;
+  const onnx::TensorProto* ws_init = ws_it->second;
+  const onnx::TensorProto* ws2_init = ws2_it->second;
+  if (b_init->data_type() != onnx::TensorProto::UINT8) {
+    return std::nullopt;
+  }
+  if (b_init->dims_size() != 2) {
+    return std::nullopt;
+  }
+  const int64_t n = b_init->dims(0);
+  const int64_t half_k = b_init->dims(1);
+  const int64_t k = 2 * half_k;  // Schema: "K = 2 * B.shape[1]" -- always even.
+  if (n <= 0 || k <= 0 || k % block_size != 0) {
+    return std::nullopt;  // Padded/partial final block -- declined.
+  }
+  const int64_t k_blocks = k / block_size;
+
+  if (ws_init->data_type() != onnx::TensorProto::UINT8) {
+    return std::nullopt;  // Raw E4M3 bytes stored as uint8, per live schema.
+  }
+  if (!MatMulNBitsDimsEqual(*ws_init, {n, k_blocks})) {
+    return std::nullopt;
+  }
+
+  if (ws2_init->data_type() != onnx::TensorProto::FLOAT ||
+      !BlockQuantizedScalarDimsOk(*ws2_init)) {
+    return std::nullopt;
+  }
+
+  if (!input_scale_name.empty()) {
+    auto is_it = init_map.find(input_scale_name);
+    if (is_it == init_map.end() ||
+        is_it->second->data_type() != onnx::TensorProto::FLOAT ||
+        !BlockQuantizedScalarDimsOk(*is_it->second)) {
+      return std::nullopt;
+    }
+    // Never sliced -- a no-op on the weight-only path anyway, per the live
+    // schema's own doc string (see this section's own top comment).
+  }
+
+  for (const auto& nm : {b_name, ws_name}) {
+    if (ConsumerCount(consumers_of, nm) != 1) {
+      return std::nullopt;  // Shared/tied tensor -- another node reads it.
+    }
+  }
+
+  BlockQuantizedFp4Weight w;
+  w.node = node;
+  w.b_name = b_name;
+  w.weight_scale_name = ws_name;
+  w.weight_scale_2_name = ws2_name;
+  w.N = n;
+  w.K = k;
+  w.block_size = block_size;
+  w.k_blocks = k_blocks;
+  return w;
+}
+
+// Mirrors pruning.py's own `_Fp8ChainSide = Union[_BlockQuantizedFp8Weight,
+// _PlainMatMulNBitsPeer]`/`_Fp4ChainSide`.
+using Fp8ChainSide =
+    std::variant<BlockQuantizedFp8Weight, PlainMatMulNBitsPeer>;
+using Fp4ChainSide =
+    std::variant<BlockQuantizedFp4Weight, PlainMatMulNBitsPeer>;
+
+std::string Fp8ChainSideKey(const Fp8ChainSide& side) {
+  if (const auto* w = std::get_if<BlockQuantizedFp8Weight>(&side)) {
+    return w->b_name;
+  }
+  return std::get<PlainMatMulNBitsPeer>(side).w_name;
+}
+
+std::string Fp4ChainSideKey(const Fp4ChainSide& side) {
+  if (const auto* w = std::get_if<BlockQuantizedFp4Weight>(&side)) {
+    return w->b_name;
+  }
+  return std::get<PlainMatMulNBitsPeer>(side).w_name;
+}
+
+onnx::NodeProto* Fp8ChainSideNode(const Fp8ChainSide& side) {
+  if (const auto* w = std::get_if<BlockQuantizedFp8Weight>(&side)) {
+    return w->node;
+  }
+  return std::get<PlainMatMulNBitsPeer>(side).node;
+}
+
+onnx::NodeProto* Fp4ChainSideNode(const Fp4ChainSide& side) {
+  if (const auto* w = std::get_if<BlockQuantizedFp4Weight>(&side)) {
+    return w->node;
+  }
+  return std::get<PlainMatMulNBitsPeer>(side).node;
+}
+
+// The full float64 `[N, K]` dequantized weight matrix `w` refers to, for
+// IMPORTANCE RANKING ONLY -- never written back. `dequant[n, k] =
+// fp8_e4m3(B[n, k]) * b_scale[n, k / block_size]` -- mirrors pruning.py's
+// own `_matmul_block_quantized_fp8_dequantized`. `ReadUint8Tensor` reads
+// `B`'s own raw bytes regardless of its FLOAT8E4M3FN dtype tag (see this
+// section's own top comment), so `QMoEFloat8E4M3Table` decodes them
+// directly, the same way it already decodes QMoE's own FLOAT8E4M3FN block
+// scales.
+std::vector<double> BlockQuantizedFp8Dequantized(
+    const BlockQuantizedFp8Weight& w,
+    const std::unordered_map<std::string, onnx::TensorProto*>& init_map) {
+  const onnx::TensorProto* b_init = init_map.at(w.b_name);
+  const onnx::TensorProto* scale_init = init_map.at(w.b_scale_name);
+  const std::vector<uint8_t> b_raw = ReadUint8Tensor(*b_init);  // [N, K] bytes.
+  const std::vector<float> scales =
+      ReadFloatTensor(*scale_init);  // [N, k_blocks].
+  const auto& f8_table = QMoEFloat8E4M3Table();
+
+  std::vector<double> out(static_cast<size_t>(w.N * w.K));
+  for (int64_t n = 0; n < w.N; ++n) {
+    for (int64_t kb = 0; kb < w.k_blocks; ++kb) {
+      const double s =
+          static_cast<double>(scales[static_cast<size_t>(n * w.k_blocks + kb)]);
+      for (int64_t j = 0; j < w.block_size; ++j) {
+        const int64_t idx = n * w.K + kb * w.block_size + j;
+        out[static_cast<size_t>(idx)] =
+            f8_table[b_raw[static_cast<size_t>(idx)]] * s;
+      }
+    }
+  }
+  return out;
+}
+
+// The full float64 `[N, K]` dequantized weight matrix `w` refers to, for
+// IMPORTANCE RANKING ONLY -- never written back. `dequant[n, k] =
+// e2m1(B[n, k]) * weight_scale_2 * e4m3(weight_scale[n, k / block_size])` --
+// mirrors pruning.py's own `_matmul_block_quantized_fp4_dequantized`.
+// Reuses UnpackNibblesLastAxis (`B`'s own flat, whole-row nibble packing)
+// and QMoEE2M1Table/QMoEFloat8E4M3Table for the weight codes/block scale.
+std::vector<double> BlockQuantizedFp4Dequantized(
+    const BlockQuantizedFp4Weight& w,
+    const std::unordered_map<std::string, onnx::TensorProto*>& init_map) {
+  const onnx::TensorProto* b_init = init_map.at(w.b_name);
+  const onnx::TensorProto* ws_init = init_map.at(w.weight_scale_name);
+  const onnx::TensorProto* ws2_init = init_map.at(w.weight_scale_2_name);
+
+  const std::vector<uint8_t> b_raw = ReadUint8Tensor(*b_init);  // [N, K/2].
+  const std::vector<uint8_t> codes =
+      UnpackNibblesLastAxis(b_raw, w.N, w.K / 2, w.K);  // [N, K] in [0, 16).
+  const std::vector<uint8_t> ws_raw =
+      ReadUint8Tensor(*ws_init);  // [N, k_blocks] raw E4M3 bytes.
+  const std::vector<float> ws2 = ReadFloatTensor(*ws2_init);
+  const double global_scale = static_cast<double>(ws2.at(0));
+
+  const auto& e2m1_table = QMoEE2M1Table();
+  const auto& f8_table = QMoEFloat8E4M3Table();
+
+  std::vector<double> out(static_cast<size_t>(w.N * w.K));
+  for (int64_t n = 0; n < w.N; ++n) {
+    for (int64_t kb = 0; kb < w.k_blocks; ++kb) {
+      const double block_scale =
+          f8_table[ws_raw[static_cast<size_t>(n * w.k_blocks + kb)]];
+      for (int64_t j = 0; j < w.block_size; ++j) {
+        const int64_t idx = n * w.K + kb * w.block_size + j;
+        const double mag = e2m1_table[codes[static_cast<size_t>(idx)]];
+        out[static_cast<size_t>(idx)] = mag * block_scale * global_scale;
+      }
+    }
+  }
+  return out;
+}
+
+// `[N, K]` float64 view of one chain PRODUCER's own weight, for IMPORTANCE
+// RANKING ONLY -- mirrors pruning.py's own
+// `_fp8_chain_producer_weight_nk`/`_fp4_chain_producer_weight_nk`.
+std::vector<double> Fp8SideProducerWeightNK(
+    const Fp8ChainSide& side,
+    const std::unordered_map<std::string, onnx::TensorProto*>& init_map) {
+  if (const auto* w = std::get_if<BlockQuantizedFp8Weight>(&side)) {
+    return BlockQuantizedFp8Dequantized(*w, init_map);
+  }
+  const auto& p = std::get<PlainMatMulNBitsPeer>(side);
+  const onnx::TensorProto* wt = init_map.at(p.w_name);
+  const std::vector<float> data = ReadFloatTensor(*wt);
+  std::vector<float> nk = p.weight_transposed
+                              ? data
+                              : TransposeFlat(data, wt->dims(0), wt->dims(1));
+  return std::vector<double>(nk.begin(), nk.end());
+}
+
+std::vector<double> Fp4SideProducerWeightNK(
+    const Fp4ChainSide& side,
+    const std::unordered_map<std::string, onnx::TensorProto*>& init_map) {
+  if (const auto* w = std::get_if<BlockQuantizedFp4Weight>(&side)) {
+    return BlockQuantizedFp4Dequantized(*w, init_map);
+  }
+  const auto& p = std::get<PlainMatMulNBitsPeer>(side);
+  const onnx::TensorProto* wt = init_map.at(p.w_name);
+  const std::vector<float> data = ReadFloatTensor(*wt);
+  std::vector<float> nk = p.weight_transposed
+                              ? data
+                              : TransposeFlat(data, wt->dims(0), wt->dims(1));
+  return std::vector<double>(nk.begin(), nk.end());
+}
+
+// --- Slicing, mirroring _slice_block_quantized_fp8_producer_rows/
+// _slice_block_quantized_fp4_producer_rows/..._consumer_blocks -------------
+
+// Slices `w`'s own N (output-channel) axis to `keep` (ascending indices) --
+// the producer role. `B`/`b_scale` are both row-sliced directly (their
+// leading dim IS `N`, and NEITHER is packed along `N` at all -- see this
+// section's own top comment), a plain row-slice with no byte-parity hazard
+// whatsoever. No node attribute needs updating (see top comment).
+void SliceBlockQuantizedFp8ProducerRows(
+    const BlockQuantizedFp8Weight& w,
+    const std::unordered_map<std::string, onnx::TensorProto*>& init_map,
+    const std::vector<int64_t>& keep) {
+  const int64_t kc = static_cast<int64_t>(keep.size());
+
+  onnx::TensorProto* b = init_map.at(w.b_name);
+  const std::vector<uint8_t> b_data = ReadUint8Tensor(*b);  // [N, K].
+  std::vector<uint8_t> b_out(static_cast<size_t>(kc * w.K));
+  for (int64_t i = 0; i < kc; ++i) {
+    std::memcpy(b_out.data() + i * w.K, b_data.data() + keep[i] * w.K,
+                static_cast<size_t>(w.K));
+  }
+  SetFloat8E4M3TensorData(b, {kc, w.K}, b_out);
+
+  onnx::TensorProto* scale = init_map.at(w.b_scale_name);
+  const std::vector<float> s_data = ReadFloatTensor(*scale);  // [N, k_blocks].
+  std::vector<float> s_out(static_cast<size_t>(kc * w.k_blocks));
+  for (int64_t i = 0; i < kc; ++i) {
+    std::memcpy(s_out.data() + i * w.k_blocks,
+                s_data.data() + keep[i] * w.k_blocks,
+                static_cast<size_t>(w.k_blocks) * sizeof(float));
+  }
+  SetFloatTensorData(scale, {kc, w.k_blocks}, s_out);
+}
+
+// Slices `w`'s own N (output-channel) axis to `keep` -- the producer role.
+// `B` is packed FLAT across the whole `K` axis (per this section's own top
+// comment) but never ACROSS rows -- a byte never straddles two different
+// `N` rows -- so a row-slice is whole-byte-safe with no unpack/repack
+// needed at all. `weight_scale` is a plain row-slice too (not packed along
+// `N`).
+void SliceBlockQuantizedFp4ProducerRows(
+    const BlockQuantizedFp4Weight& w,
+    const std::unordered_map<std::string, onnx::TensorProto*>& init_map,
+    const std::vector<int64_t>& keep) {
+  const int64_t kc = static_cast<int64_t>(keep.size());
+  const int64_t half_k = w.K / 2;
+
+  onnx::TensorProto* b = init_map.at(w.b_name);
+  const std::vector<uint8_t> b_data = ReadUint8Tensor(*b);  // [N, K/2].
+  std::vector<uint8_t> b_out(static_cast<size_t>(kc * half_k));
+  for (int64_t i = 0; i < kc; ++i) {
+    std::memcpy(b_out.data() + i * half_k, b_data.data() + keep[i] * half_k,
+                static_cast<size_t>(half_k));
+  }
+  SetUint8TensorData(b, {kc, half_k}, b_out);
+
+  onnx::TensorProto* ws = init_map.at(w.weight_scale_name);
+  const std::vector<uint8_t> ws_data = ReadUint8Tensor(*ws);  // [N, k_blocks].
+  std::vector<uint8_t> ws_out(static_cast<size_t>(kc * w.k_blocks));
+  for (int64_t i = 0; i < kc; ++i) {
+    std::memcpy(ws_out.data() + i * w.k_blocks,
+                ws_data.data() + keep[i] * w.k_blocks,
+                static_cast<size_t>(w.k_blocks));
+  }
+  SetUint8TensorData(ws, {kc, w.k_blocks}, ws_out);
+}
+
+// Drops entire `k_blocks`-axis blocks NOT in `keep_blocks` (ascending block
+// indices) from `w`'s own `B`/`b_scale` -- the consumer role. `B` has NO
+// sub-byte packing at all for this op, so this is a whole-block byte copy
+// per `(n, kept k_block)` pair -- no unpack/repack needed, unlike
+// `Fp4Weight`'s own packed `B` below. Never invoked with a non-block-aligned
+// `keep_blocks` (MatMulNBitsBlockAlignedKeepBlocks already validates it).
+void SliceBlockQuantizedFp8ConsumerBlocks(
+    const BlockQuantizedFp8Weight& w,
+    const std::unordered_map<std::string, onnx::TensorProto*>& init_map,
+    const std::vector<int64_t>& keep_blocks) {
+  const int64_t new_kb = static_cast<int64_t>(keep_blocks.size());
+  const int64_t new_k = new_kb * w.block_size;
+
+  onnx::TensorProto* b = init_map.at(w.b_name);
+  const std::vector<uint8_t> b_data = ReadUint8Tensor(*b);  // [N, K].
+  std::vector<uint8_t> b_out(static_cast<size_t>(w.N * new_k));
+  for (int64_t n = 0; n < w.N; ++n) {
+    for (int64_t j = 0; j < new_kb; ++j) {
+      const uint8_t* src =
+          b_data.data() + n * w.K + keep_blocks[j] * w.block_size;
+      uint8_t* dst = b_out.data() + n * new_k + j * w.block_size;
+      std::memcpy(dst, src, static_cast<size_t>(w.block_size));
+    }
+  }
+  SetFloat8E4M3TensorData(b, {w.N, new_k}, b_out);
+
+  onnx::TensorProto* scale = init_map.at(w.b_scale_name);
+  const std::vector<float> s_data = ReadFloatTensor(*scale);  // [N, k_blocks].
+  std::vector<float> s_out(static_cast<size_t>(w.N * new_kb));
+  for (int64_t n = 0; n < w.N; ++n) {
+    for (int64_t j = 0; j < new_kb; ++j) {
+      s_out[static_cast<size_t>(n * new_kb + j)] =
+          s_data[static_cast<size_t>(n * w.k_blocks + keep_blocks[j])];
+    }
+  }
+  SetFloatTensorData(scale, {w.N, new_kb}, s_out);
+}
+
+// pruning.py's own `_fp4_block_aligned_keep_blocks`: wraps
+// MatMulNBitsBlockAlignedKeepBlocks with ONE additional `Fp4Weight`-specific
+// decline -- the resulting `K` (`len(keep_blocks) * block_size`) must
+// itself be even, since this op's own `B` has no padding-nibble concept
+// (the live schema derives `K` as exactly `2 * B.shape[1]`, see this
+// section's own top comment). Returns `nullopt` (the same "leave this chain
+// completely untouched" outcome a non-block-aligned keep-set already gets)
+// when either check fails.
+std::optional<std::vector<int64_t>> Fp4BlockAlignedKeepBlocks(
+    const std::vector<int64_t>& keep, int64_t k_blocks, int64_t block_size) {
+  auto keep_blocks =
+      MatMulNBitsBlockAlignedKeepBlocks(keep, k_blocks, block_size);
+  if (!keep_blocks) {
+    return std::nullopt;
+  }
+  if ((static_cast<int64_t>(keep_blocks->size()) * block_size) % 2 != 0) {
+    return std::nullopt;  // Resulting K would be odd -- declined.
+  }
+  return keep_blocks;
+}
+
+// Drops entire `k_blocks`-axis blocks NOT in `keep_blocks` from `w`'s own
+// `B`/`weight_scale` -- the consumer role. Never invoked with a keep-set
+// Fp4BlockAlignedKeepBlocks didn't already validate (block-aligned AND even
+// resulting K). Unlike the producer-side row-slice above, `B` genuinely
+// must be unpacked/re-sliced/re-packed here: its own nibble packing is FLAT
+// across the whole `K` axis (not block-relative like `MatMulNBits`'s own
+// `B`), so this always unpacks a FULL row's worth of `K` nibbles, takes the
+// kept element positions, and re-packs -- exact and padding-free because
+// Fp4BlockAlignedKeepBlocks already guarantees an even element count.
+// `weight_scale` has no packing along this axis at all, so it's a plain
+// block-index column slice.
+void SliceBlockQuantizedFp4ConsumerBlocks(
+    const BlockQuantizedFp4Weight& w,
+    const std::unordered_map<std::string, onnx::TensorProto*>& init_map,
+    const std::vector<int64_t>& keep_blocks) {
+  const int64_t new_kb = static_cast<int64_t>(keep_blocks.size());
+  const int64_t new_k = new_kb * w.block_size;  // Guaranteed even by caller.
+
+  std::vector<int64_t> keep_elems(static_cast<size_t>(new_k));
+  {
+    int64_t idx = 0;
+    for (int64_t j = 0; j < new_kb; ++j) {
+      const int64_t base = keep_blocks[j] * w.block_size;
+      for (int64_t e = 0; e < w.block_size; ++e) {
+        keep_elems[static_cast<size_t>(idx++)] = base + e;
+      }
+    }
+  }
+
+  onnx::TensorProto* b = init_map.at(w.b_name);
+  const std::vector<uint8_t> b_data = ReadUint8Tensor(*b);  // [N, K/2].
+  const std::vector<uint8_t> codes =
+      UnpackNibblesLastAxis(b_data, w.N, w.K / 2, w.K);
+  std::vector<uint8_t> selected(static_cast<size_t>(w.N * new_k));
+  for (int64_t n = 0; n < w.N; ++n) {
+    for (int64_t j = 0; j < new_k; ++j) {
+      selected[static_cast<size_t>(n * new_k + j)] =
+          codes[static_cast<size_t>(n * w.K + keep_elems[j])];
+    }
+  }
+  const std::vector<uint8_t> repacked =
+      PackNibblesLastAxis(selected, w.N, new_k);
+  SetUint8TensorData(b, {w.N, new_k / 2}, repacked);
+
+  onnx::TensorProto* ws = init_map.at(w.weight_scale_name);
+  const std::vector<uint8_t> ws_data = ReadUint8Tensor(*ws);  // [N, k_blocks].
+  std::vector<uint8_t> ws_out(static_cast<size_t>(w.N * new_kb));
+  for (int64_t n = 0; n < w.N; ++n) {
+    for (int64_t j = 0; j < new_kb; ++j) {
+      ws_out[static_cast<size_t>(n * new_kb + j)] =
+          ws_data[static_cast<size_t>(n * w.k_blocks + keep_blocks[j])];
+    }
+  }
+  SetUint8TensorData(ws, {w.N, new_kb}, ws_out);
+}
+
+// Slices one chain PRODUCER's own output channels to `keep` -- dispatches to
+// SliceBlockQuantizedFp8ProducerRows for a `Fp8Weight` side, or a direct
+// SliceProducerWeight (plus its own bias, if present -- the PLAIN-FLOAT
+// peer's own bias, always FLOAT32, unrelated to `Fp8Weight`'s own declined
+// FLOAT16/BFLOAT16 `bias`) for a plain-float peer. Mirrors pruning.py's own
+// `_slice_fp8_chain_producer`.
+void SliceFp8SideProducer(
+    const Fp8ChainSide& side,
+    const std::unordered_map<std::string, onnx::TensorProto*>& init_map,
+    const std::vector<int64_t>& keep) {
+  if (const auto* w = std::get_if<BlockQuantizedFp8Weight>(&side)) {
+    SliceBlockQuantizedFp8ProducerRows(*w, init_map, keep);
+    return;
+  }
+  const auto& p = std::get<PlainMatMulNBitsPeer>(side);
+  SliceProducerWeight(init_map.at(p.w_name), p.weight_transposed, keep, false);
+  if (p.bias_name) {
+    SliceLastAxis(init_map.at(*p.bias_name), keep);
+  }
+}
+
+void SliceFp4SideProducer(
+    const Fp4ChainSide& side,
+    const std::unordered_map<std::string, onnx::TensorProto*>& init_map,
+    const std::vector<int64_t>& keep) {
+  if (const auto* w = std::get_if<BlockQuantizedFp4Weight>(&side)) {
+    SliceBlockQuantizedFp4ProducerRows(*w, init_map, keep);
+    return;
+  }
+  const auto& p = std::get<PlainMatMulNBitsPeer>(side);
+  SliceProducerWeight(init_map.at(p.w_name), p.weight_transposed, keep, false);
+  if (p.bias_name) {
+    SliceLastAxis(init_map.at(*p.bias_name), keep);
+  }
+}
+
+// Slices one chain CONSUMER's own input channels to `keep` -- a quantized
+// side requires `keep` to already be whole, block-aligned BLOCK indices
+// (checked by the caller before this is ever invoked); a plain-float peer
+// has no block structure at all, dispatched straight to SliceConsumerWeight.
+// Mirrors pruning.py's own `_slice_fp8_chain_consumer`/`_slice_fp4_chain_
+// consumer`.
+void SliceFp8SideConsumer(
+    const Fp8ChainSide& side,
+    const std::unordered_map<std::string, onnx::TensorProto*>& init_map,
+    const std::vector<int64_t>& keep) {
+  if (const auto* w = std::get_if<BlockQuantizedFp8Weight>(&side)) {
+    SliceBlockQuantizedFp8ConsumerBlocks(*w, init_map, keep);
+    return;
+  }
+  const auto& p = std::get<PlainMatMulNBitsPeer>(side);
+  SliceConsumerWeight(init_map.at(p.w_name), p.weight_transposed, keep, false);
+}
+
+void SliceFp4SideConsumer(
+    const Fp4ChainSide& side,
+    const std::unordered_map<std::string, onnx::TensorProto*>& init_map,
+    const std::vector<int64_t>& keep) {
+  if (const auto* w = std::get_if<BlockQuantizedFp4Weight>(&side)) {
+    SliceBlockQuantizedFp4ConsumerBlocks(*w, init_map, keep);
+    return;
+  }
+  const auto& p = std::get<PlainMatMulNBitsPeer>(side);
+  SliceConsumerWeight(init_map.at(p.w_name), p.weight_transposed, keep, false);
+}
+
+// --- Chain finding, mirroring _walk_to_fp8_consumer/_find_fp8_block_
+// quantized_chains and their `_fp4_` analogues -----------------------------
+
+struct Fp8WalkResult {
+  Fp8ChainSide consumer;
+  std::vector<onnx::NodeProto*> chain_ops;
+};
+
+// From tensor `start` (a `Fp8Weight` OR plain-float MatMul/Gemm producer's
+// own output), walks forward through shape-preserving unary activations
+// with no other consumer anywhere along the way, until EITHER a
+// `MatMulBlockQuantizedFp8Weight` consumer OR a plain-float MatMul/vanilla-
+// Gemm consumer (MatchPlainMatMulNBitsPeer) is found whose input-channel
+// count matches `n_channels`. No gated pair, no branch, never a `Fp4Weight`/
+// `MatMulNBits`/QDQ consumer -- mirrors pruning.py's own `_walk_to_fp8_
+// consumer` exactly.
+std::optional<Fp8WalkResult> WalkToFp8Consumer(
+    const std::string& start, const InitMap& init_map,
+    const ConsumerMap& consumers_of,
+    const std::unordered_set<std::string>& graph_outputs, int64_t n_channels,
+    int max_hops) {
+  std::vector<onnx::NodeProto*> chain_ops;
+  std::string cur = start;
+  for (int hop = 0; hop < max_hops; ++hop) {
+    auto cit = consumers_of.find(cur);
+    if (cit == consumers_of.end() || cit->second.size() != 1) {
+      return std::nullopt;
+    }
+    onnx::NodeProto* nxt = cit->second[0];
+
+    if (nxt->op_type() == "MatMulBlockQuantizedFp8Weight" &&
+        nxt->domain() == kComMicrosoftDomain && nxt->input_size() > 0 &&
+        nxt->input(0) == cur) {
+      auto w = MatchMatMulBlockQuantizedFp8(nxt, init_map, consumers_of);
+      if (!w || w->K != n_channels) {
+        return std::nullopt;
+      }
+      return Fp8WalkResult{Fp8ChainSide(*w), std::move(chain_ops)};
+    }
+
+    auto mm = MatchMatMulLikeRaw(*nxt);
+    if (mm && mm->x_name == cur) {
+      auto peer = MatchPlainMatMulNBitsPeer(nxt, init_map, consumers_of);
+      if (!peer || peer->in_channels != n_channels) {
+        return std::nullopt;
+      }
+      return Fp8WalkResult{Fp8ChainSide(*peer), std::move(chain_ops)};
+    }
+
+    if (!(UnaryPassThroughOps().count(nxt->op_type()) != 0 &&
+          nxt->input_size() == 1 && nxt->input(0) == cur &&
+          nxt->output_size() == 1)) {
+      return std::nullopt;
+    }
+    const std::string& out2 = nxt->output(0);
+    auto oc = consumers_of.find(out2);
+    if (oc == consumers_of.end() || oc->second.size() != 1 ||
+        graph_outputs.count(out2)) {
+      return std::nullopt;
+    }
+    chain_ops.push_back(nxt);
+    cur = out2;
+  }
+  return std::nullopt;
+}
+
+struct Fp4WalkResult {
+  Fp4ChainSide consumer;
+  std::vector<onnx::NodeProto*> chain_ops;
+};
+
+// `Fp4Weight` analogue of WalkToFp8Consumer -- see that function's own
+// docstring. Mirrors pruning.py's own `_walk_to_fp4_consumer`.
+std::optional<Fp4WalkResult> WalkToFp4Consumer(
+    const std::string& start, const InitMap& init_map,
+    const ConsumerMap& consumers_of,
+    const std::unordered_set<std::string>& graph_outputs, int64_t n_channels,
+    int max_hops) {
+  std::vector<onnx::NodeProto*> chain_ops;
+  std::string cur = start;
+  for (int hop = 0; hop < max_hops; ++hop) {
+    auto cit = consumers_of.find(cur);
+    if (cit == consumers_of.end() || cit->second.size() != 1) {
+      return std::nullopt;
+    }
+    onnx::NodeProto* nxt = cit->second[0];
+
+    if (nxt->op_type() == "MatMulBlockQuantizedFp4Weight" &&
+        nxt->domain() == kComMicrosoftDomain && nxt->input_size() > 0 &&
+        nxt->input(0) == cur) {
+      auto w = MatchMatMulBlockQuantizedFp4(nxt, init_map, consumers_of);
+      if (!w || w->K != n_channels) {
+        return std::nullopt;
+      }
+      return Fp4WalkResult{Fp4ChainSide(*w), std::move(chain_ops)};
+    }
+
+    auto mm = MatchMatMulLikeRaw(*nxt);
+    if (mm && mm->x_name == cur) {
+      auto peer = MatchPlainMatMulNBitsPeer(nxt, init_map, consumers_of);
+      if (!peer || peer->in_channels != n_channels) {
+        return std::nullopt;
+      }
+      return Fp4WalkResult{Fp4ChainSide(*peer), std::move(chain_ops)};
+    }
+
+    if (!(UnaryPassThroughOps().count(nxt->op_type()) != 0 &&
+          nxt->input_size() == 1 && nxt->input(0) == cur &&
+          nxt->output_size() == 1)) {
+      return std::nullopt;
+    }
+    const std::string& out2 = nxt->output(0);
+    auto oc = consumers_of.find(out2);
+    if (oc == consumers_of.end() || oc->second.size() != 1 ||
+        graph_outputs.count(out2)) {
+      return std::nullopt;
+    }
+    chain_ops.push_back(nxt);
+    cur = out2;
+  }
+  return std::nullopt;
+}
+
+struct Fp8Chain {
+  Fp8ChainSide producer;
+  std::vector<onnx::NodeProto*> chain_ops;
+  Fp8ChainSide consumer;
+  int64_t n_channels;
+};
+
+struct Fp4Chain {
+  Fp4ChainSide producer;
+  std::vector<onnx::NodeProto*> chain_ops;
+  Fp4ChainSide consumer;
+  int64_t n_channels;
+};
+
+// Every producer/consumer pair connected by WalkToFp8Consumer where AT
+// LEAST ONE side is a `MatMulBlockQuantizedFp8Weight` node (an all-plain-
+// float pair is FindChains's own job, not duplicated here). Mirrors
+// pruning.py's own `_find_fp8_block_quantized_chains`.
+std::vector<Fp8Chain> FindFp8BlockQuantizedChains(onnx::GraphProto* graph) {
+  InitMap init_map;
+  for (const auto& t : graph->initializer()) {
+    init_map[t.name()] = &t;
+  }
+  ConsumerMap consumers_of = ConsumersOf(graph);
+  std::unordered_set<std::string> graph_outputs;
+  for (const auto& o : graph->output()) {
+    graph_outputs.insert(o.name());
+  }
+  auto is_internal = [&](const std::string& name) {
+    return ConsumerCount(consumers_of, name) == 1 && !graph_outputs.count(name);
+  };
+
+  std::vector<Fp8Chain> chains;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    std::optional<Fp8ChainSide> producer;
+    int64_t n_channels = 0;
+    if (node->op_type() == "MatMulBlockQuantizedFp8Weight" &&
+        node->domain() == kComMicrosoftDomain) {
+      auto w = MatchMatMulBlockQuantizedFp8(node, init_map, consumers_of);
+      if (!w) {
+        continue;
+      }
+      n_channels = w->N;
+      producer = Fp8ChainSide(*w);
+    } else {
+      auto peer = MatchPlainMatMulNBitsPeer(node, init_map, consumers_of);
+      if (!peer) {
+        continue;
+      }
+      n_channels = peer->out_channels;
+      producer = Fp8ChainSide(*peer);
+    }
+
+    const std::string& out_name = node->output(0);
+    if (!is_internal(out_name)) {
+      continue;
+    }
+    auto found = WalkToFp8Consumer(out_name, init_map, consumers_of,
+                                   graph_outputs, n_channels, kMaxChainHops);
+    if (!found) {
+      continue;
+    }
+    if (std::holds_alternative<PlainMatMulNBitsPeer>(*producer) &&
+        std::holds_alternative<PlainMatMulNBitsPeer>(found->consumer)) {
+      continue;  // Both plain float -- FindChains's own job.
+    }
+    chains.push_back(Fp8Chain{std::move(*producer), std::move(found->chain_ops),
+                              std::move(found->consumer), n_channels});
+  }
+  return chains;
+}
+
+// `Fp4Weight` analogue of FindFp8BlockQuantizedChains. Mirrors pruning.py's
+// own `_find_fp4_block_quantized_chains`.
+std::vector<Fp4Chain> FindFp4BlockQuantizedChains(onnx::GraphProto* graph) {
+  InitMap init_map;
+  for (const auto& t : graph->initializer()) {
+    init_map[t.name()] = &t;
+  }
+  ConsumerMap consumers_of = ConsumersOf(graph);
+  std::unordered_set<std::string> graph_outputs;
+  for (const auto& o : graph->output()) {
+    graph_outputs.insert(o.name());
+  }
+  auto is_internal = [&](const std::string& name) {
+    return ConsumerCount(consumers_of, name) == 1 && !graph_outputs.count(name);
+  };
+
+  std::vector<Fp4Chain> chains;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    std::optional<Fp4ChainSide> producer;
+    int64_t n_channels = 0;
+    if (node->op_type() == "MatMulBlockQuantizedFp4Weight" &&
+        node->domain() == kComMicrosoftDomain) {
+      auto w = MatchMatMulBlockQuantizedFp4(node, init_map, consumers_of);
+      if (!w) {
+        continue;
+      }
+      n_channels = w->N;
+      producer = Fp4ChainSide(*w);
+    } else {
+      auto peer = MatchPlainMatMulNBitsPeer(node, init_map, consumers_of);
+      if (!peer) {
+        continue;
+      }
+      n_channels = peer->out_channels;
+      producer = Fp4ChainSide(*peer);
+    }
+
+    const std::string& out_name = node->output(0);
+    if (!is_internal(out_name)) {
+      continue;
+    }
+    auto found = WalkToFp4Consumer(out_name, init_map, consumers_of,
+                                   graph_outputs, n_channels, kMaxChainHops);
+    if (!found) {
+      continue;
+    }
+    if (std::holds_alternative<PlainMatMulNBitsPeer>(*producer) &&
+        std::holds_alternative<PlainMatMulNBitsPeer>(found->consumer)) {
+      continue;
+    }
+    chains.push_back(Fp4Chain{std::move(*producer), std::move(found->chain_ops),
+                              std::move(found->consumer), n_channels});
+  }
+  return chains;
+}
+
+// --- Apply, mirroring apply_structured_pruning_matmul_block_quantized_fp8/
+// _fp4's own per-chain loop --------------------------------------------
+
+// Ranks the producer's output channels by L2 norm of their own (dequantized,
+// for a `Fp8Weight` producer) weight row, drops the lowest-`sparsity`-
+// fraction, and -- only when the CONSUMER side is itself `Fp8Weight` --
+// requires that keep-set to land on whole `block_size` blocks
+// (MatMulNBitsBlockAlignedKeepBlocks), declining the WHOLE chain otherwise.
+// Shares `touched` with every other chain family ApplyStructuredPruning
+// already applies over this same graph.
+void ApplyFp8BlockQuantizedChains(onnx::GraphProto* graph,
+                                  std::vector<Fp8Chain>& chains,
+                                  double sparsity, TouchedState& touched) {
+  std::unordered_map<std::string, onnx::TensorProto*> init_map;
+  for (int i = 0; i < graph->initializer_size(); ++i) {
+    onnx::TensorProto* t = graph->mutable_initializer(i);
+    init_map[t->name()] = t;
+  }
+
+  auto row_norms = [](const std::vector<double>& w_nk, int64_t n) {
+    const int64_t k = static_cast<int64_t>(w_nk.size()) / n;
+    std::vector<double> importance(static_cast<size_t>(n), 0.0);
+    for (int64_t c = 0; c < n; ++c) {
+      double sq = 0.0;
+      for (int64_t j = 0; j < k; ++j) {
+        const double v = w_nk[static_cast<size_t>(c * k + j)];
+        sq += v * v;
+      }
+      importance[static_cast<size_t>(c)] = std::sqrt(sq);
+    }
+    return importance;
+  };
+
+  for (auto& chain : chains) {
+    const std::string p_key = Fp8ChainSideKey(chain.producer);
+    const std::string c_key = Fp8ChainSideKey(chain.consumer);
+    if (p_key == c_key) {
+      continue;  // Degenerate (the same weight in both roles).
+    }
+    if (touched.producer.count(p_key) || touched.consumer.count(c_key)) {
+      continue;  // A shared/tied weight another chain already resized.
+    }
+
+    const int64_t n = chain.n_channels;
+    const int64_t keep_count = std::max<int64_t>(
+        1, n - std::llround(static_cast<double>(n) * sparsity));
+    if (keep_count >= n) {
+      continue;  // Rounds down to nothing for this layer -- no-op.
+    }
+
+    const std::vector<double> w_nk =
+        Fp8SideProducerWeightNK(chain.producer, init_map);
+    std::vector<double> importance = row_norms(w_nk, n);
+    const std::vector<int64_t> keep =
+        TopKIndicesAscending(importance, keep_count);
+
+    std::vector<int64_t> consumer_keep;
+    if (const auto* cw =
+            std::get_if<BlockQuantizedFp8Weight>(&chain.consumer)) {
+      auto keep_blocks =
+          MatMulNBitsBlockAlignedKeepBlocks(keep, cw->k_blocks, cw->block_size);
+      if (!keep_blocks) {
+        continue;  // Non-block-aligned -- decline, see section comment.
+      }
+      consumer_keep = std::move(*keep_blocks);
+    } else {
+      consumer_keep = keep;  // Plain-float consumer -- no block structure.
+    }
+
+    SliceFp8SideProducer(chain.producer, init_map, keep);
+    SliceFp8SideConsumer(chain.consumer, init_map, consumer_keep);
+
+    touched.producer.insert(p_key);
+    touched.consumer.insert(c_key);
+    touched.stale_value_info.insert(
+        Fp8ChainSideNode(chain.producer)->output(0));
+    for (auto* op : chain.chain_ops) {
+      touched.stale_value_info.insert(op->output(0));
+    }
+  }
+}
+
+// `Fp4Weight` analogue of ApplyFp8BlockQuantizedChains -- the one packing-
+// driven difference: a candidate consumer-side keep-set is checked via
+// Fp4BlockAlignedKeepBlocks rather than MatMulNBitsBlockAlignedKeepBlocks
+// directly, since this op's own flat (whole-row) nibble packing additionally
+// requires the resulting K to stay even.
+void ApplyFp4BlockQuantizedChains(onnx::GraphProto* graph,
+                                  std::vector<Fp4Chain>& chains,
+                                  double sparsity, TouchedState& touched) {
+  std::unordered_map<std::string, onnx::TensorProto*> init_map;
+  for (int i = 0; i < graph->initializer_size(); ++i) {
+    onnx::TensorProto* t = graph->mutable_initializer(i);
+    init_map[t->name()] = t;
+  }
+
+  auto row_norms = [](const std::vector<double>& w_nk, int64_t n) {
+    const int64_t k = static_cast<int64_t>(w_nk.size()) / n;
+    std::vector<double> importance(static_cast<size_t>(n), 0.0);
+    for (int64_t c = 0; c < n; ++c) {
+      double sq = 0.0;
+      for (int64_t j = 0; j < k; ++j) {
+        const double v = w_nk[static_cast<size_t>(c * k + j)];
+        sq += v * v;
+      }
+      importance[static_cast<size_t>(c)] = std::sqrt(sq);
+    }
+    return importance;
+  };
+
+  for (auto& chain : chains) {
+    const std::string p_key = Fp4ChainSideKey(chain.producer);
+    const std::string c_key = Fp4ChainSideKey(chain.consumer);
+    if (p_key == c_key) {
+      continue;
+    }
+    if (touched.producer.count(p_key) || touched.consumer.count(c_key)) {
+      continue;
+    }
+
+    const int64_t n = chain.n_channels;
+    const int64_t keep_count = std::max<int64_t>(
+        1, n - std::llround(static_cast<double>(n) * sparsity));
+    if (keep_count >= n) {
+      continue;
+    }
+
+    const std::vector<double> w_nk =
+        Fp4SideProducerWeightNK(chain.producer, init_map);
+    std::vector<double> importance = row_norms(w_nk, n);
+    const std::vector<int64_t> keep =
+        TopKIndicesAscending(importance, keep_count);
+
+    std::vector<int64_t> consumer_keep;
+    if (const auto* cw =
+            std::get_if<BlockQuantizedFp4Weight>(&chain.consumer)) {
+      auto keep_blocks =
+          Fp4BlockAlignedKeepBlocks(keep, cw->k_blocks, cw->block_size);
+      if (!keep_blocks) {
+        continue;  // Non-block-aligned, or odd resulting K -- decline.
+      }
+      consumer_keep = std::move(*keep_blocks);
+    } else {
+      consumer_keep = keep;  // Plain-float consumer -- no block structure.
+    }
+
+    SliceFp4SideProducer(chain.producer, init_map, keep);
+    SliceFp4SideConsumer(chain.consumer, init_map, consumer_keep);
+
+    touched.producer.insert(p_key);
+    touched.consumer.insert(c_key);
+    touched.stale_value_info.insert(
+        Fp4ChainSideNode(chain.producer)->output(0));
+    for (auto* op : chain.chain_ops) {
+      touched.stale_value_info.insert(op->output(0));
+    }
+  }
+}
+
 // --- Subgraph recursion ------------------------------------------------
 //
 // Mirrors pruning.py's own `_iter_subgraphs` and the "Subgraph recursion"
@@ -13865,6 +15039,10 @@ onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
     std::vector<QdqGatedChain> qdq_gated_chains = FindQdqGatedChains(graph);
     std::vector<MatMulBnb4Chain> matmul_bnb4_chains =
         FindMatMulBnb4Chains(graph);
+    std::vector<Fp8Chain> fp8_block_quantized_chains =
+        FindFp8BlockQuantizedChains(graph);
+    std::vector<Fp4Chain> fp4_block_quantized_chains =
+        FindFp4BlockQuantizedChains(graph);
 
     TouchedState touched;
     if (!chains.empty()) {
@@ -13914,15 +15092,31 @@ onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
       ApplyQdqChains(graph, qdq_chains, qdq_gated_chains, sparsity, touched);
     }
     if (!matmul_bnb4_chains.empty()) {
-      // The sixth and final application pass over this graph -- see this
-      // file's own "MatMulBnb4 (bitsandbytes FP4/NF4 block-quantized
-      // weight) structured pruning" section comment. Shares `touched` with
-      // every call above for the same "one shared conflict ledger per
-      // graph" reason ApplyMatMulNBitsChains/ApplyQdqChains both do: a
-      // plain-float consumer weight this pass matches can never be
+      // See this file's own "MatMulBnb4 (bitsandbytes FP4/NF4
+      // block-quantized weight) structured pruning" section comment. Shares
+      // `touched` with every call above for the same "one shared conflict
+      // ledger per graph" reason ApplyMatMulNBitsChains/ApplyQdqChains both
+      // do: a plain-float consumer weight this pass matches can never be
       // double-resized by, or double-resize, an ordinary chain/MatMulNBits/
       // QDQ chain that already touched it.
       ApplyMatMulBnb4Chains(graph, matmul_bnb4_chains, sparsity, touched);
+    }
+    if (!fp8_block_quantized_chains.empty()) {
+      // See this file's own "MatMulBlockQuantizedFp4Weight/MatMulBlock
+      // QuantizedFp8Weight (NVFP4/FP8 block-quantized weight) structured
+      // pruning" section comment. Shares `touched` with every call above
+      // for the same "one shared conflict ledger per graph" reason every
+      // other quantized-weight pass here does.
+      ApplyFp8BlockQuantizedChains(graph, fp8_block_quantized_chains, sparsity,
+                                   touched);
+    }
+    if (!fp4_block_quantized_chains.empty()) {
+      // The ninth and final application pass over this graph -- `Fp8Weight`/
+      // `Fp4Weight` are never mixed with each other (see that section's own
+      // top comment), so this is always a genuinely separate match, still
+      // sharing `touched` with every call above for the same reason.
+      ApplyFp4BlockQuantizedChains(graph, fp4_block_quantized_chains, sparsity,
+                                   touched);
     }
     if (!touched.stale_value_info.empty()) {
       google::protobuf::RepeatedPtrField<onnx::ValueInfoProto> kept;

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -81,6 +81,7 @@
 #include <limits>
 #include <numeric>
 #include <optional>
+#include <set>
 #include <stdexcept>
 #include <string>
 #include <tuple>
@@ -13122,6 +13123,693 @@ std::vector<onnx::GraphProto*> IterSubgraphs(onnx::GraphProto* graph) {
   return graphs;
 }
 
+// --- Embedding vocabulary pruning, mirroring pruning.py's own "Embedding /
+// lm_head vocabulary pruning" section (search that name in pruning.py) -----
+//
+// A GENUINELY DIFFERENT shape of pass from every chain family above: those
+// all prune a FEATURE/CHANNEL axis shared symmetrically by a producer and
+// its consumer(s). This prunes the VOCABULARY axis of a token-embedding
+// table -- axis 0 of a plain `Gather(data=[vocab_size, hidden_size],
+// indices=input_ids)`, the export shape of `torch.nn.Embedding` -- and,
+// where a tied or auto-identified untied `lm_head` (the output vocab-logits
+// projection) exists, its own matching axis too. `hidden_size` is never
+// touched, and (unlike every pass above) the pruned axis routinely reaches
+// a genuine graph OUTPUT (the `lm_head`'s own logits) -- so this is also
+// the first pass in this file that must actively correct a stale graph
+// OUTPUT shape (UpdateVocabOutputShape), not just drop an internal
+// value_info entry the way every chain family above's `stale_value_info`
+// handling does.
+//
+// Because which vocabulary rows are safe to keep is a question this pass
+// cannot answer from the graph alone (unlike a channel's activation
+// magnitude, calibration data can show a token id *was* used, never that it
+// is safe to drop), the primary entry point below
+// (ApplyEmbeddingVocabPruning) takes an explicit, caller-supplied keep/drop
+// set; ApplyEmbeddingVocabMagnitudePruning is a second, explicitly weaker
+// entry point ranking by embedding-row L2 norm -- mirroring pruning.py's
+// own two-entry-point split and its own safety caveats (see each
+// function's own doc comment in structured_pruning_entry.h).
+//
+// Whichever ids survive are RENUMBERED contiguously (kept id `i`'s new id
+// is its rank among the sorted kept ids), so -- exactly like the Python
+// original -- neither entry point returns a bare `onnx::ModelProto`:
+// `EmbeddingVocabPruningResult::kept_token_ids[i]` is the ORIGINAL id now
+// living at row/column `i` of the pruned model, and it is every caller's
+// own job to remap its input token ids through that mapping (old id ->
+// its index in `kept_token_ids`) before running the pruned model -- a
+// dropped id can never be fed to the pruned model again.
+//
+// Deliberately NARROWER than pruning.py's own three-producer-shape port
+// (plain `Gather`, `com.microsoft::EmbedLayerNormalization`,
+// `com.microsoft::GatherBlockQuantized`) -- consistent with this file's own
+// established "narrower subset of pruning.py, decline rather than guess
+// past what's ported" scope decisions elsewhere (MatMulNBits's own
+// FLOAT32-only scales/zero_points/bias, MoE/QMoE's own restrictions, ...):
+//
+//   * Only the plain `Gather(data, indices, axis=0)` producer shape is
+//     matched here. `EmbedLayerNormalization` (the fused BERT-family
+//     word+position+segment-embedding-plus-LayerNorm node onnxruntime's
+//     own graph optimizer emits) and `GatherBlockQuantized` (the
+//     int2/int4/int8 block-quantized analogue) are both simply never
+//     matched -- declined, not mis-handled -- by this port; see
+//     pruning.py's own section comment for their exact schema/scope if
+//     porting either is ever needed.
+//   * `lm_head` auto-detection only ever recognizes a bare `MatMul` or
+//     vanilla `Gemm` (MatchMatMulLikeRaw) -- not pruning.py's own widened
+//     `_match_matmul_like`, which additionally recognizes
+//     `com.microsoft::FusedGemm`/`GemmFastGelu` -- mirroring
+//     MatchProducer's own identical, already-established restriction
+//     elsewhere in this file (see its own comment, above).
+//   * The embedding table, `lm_head` weight, and `lm_head` bias are all
+//     admitted only as plain FLOAT (float32) tensors -- not also FLOAT16/
+//     BFLOAT16 -- matching ReadFloatTensor/SetFloatTensorData's own
+//     FLOAT32-only support (the same restriction, for the same reason, as
+//     the "Two deliberate, narrower-than-pruning.py scope decisions"
+//     comment above MatMulNBitsValidBlockSizes documents).
+//
+// Every other structural safety check pruning.py's own `_match_embedding_
+// gather`/`_match_tied_lm_head`/`_match_untied_lm_head`/`_match_lm_head_
+// tail` apply is reproduced here exactly: `axis` must be 0; `indices` must
+// be a declared graph input or one `Cast` hop of one; the embedding weight
+// must have exactly one (untied) or two (the second a structurally-
+// confirmed tied `lm_head`) consumers, an unexplained second consumer
+// declining the WHOLE match; an untied `lm_head` candidate is only ever
+// auto-identified when its own weight has exactly one consumer AND its
+// (bias-tail-resolved) output is itself a genuine graph output, with more
+// than one such candidate ambiguous, not evidence; a bias is only ever
+// recognized as a `Gemm`'s own built-in `C` input or a `MatMul`-then-
+// `Add(bias)` tail, anything else declining that whole `lm_head` match.
+// When more than one qualifying `Gather` exists and the caller hasn't
+// named `input_name`, the whole call declines.
+//
+// Subgraph-aware (IterSubgraphs, just above) exactly like every other pass
+// in this file: the one eligible `Gather` this pass requires may live
+// inside a nested If/Loop/Scan/BeamSearch-family subgraph, at any nesting
+// depth, not only the top-level graph -- MatchEmbeddingChainAnyGraph
+// applies the identical "exactly one eligible producer, or decline" rule
+// across the WHOLE model, mirroring pruning.py's own `_match_embedding_
+// chain_any_graph` exactly (confirmed against its own docstring before
+// porting, rather than assumed).
+
+struct EmbeddingLmHeadMatch {
+  // The *final* node whose output is the (pre-rename) [..., vocab_size]
+  // logits tensor -- the matched MatMul/Gemm itself, or, when
+  // MatchLmHeadTail recognized a MatMul-then-Add(bias) tail, the Add (its
+  // output, not the raw MatMul's own, is the tensor whose shape/graph-
+  // output status actually matters downstream).
+  onnx::NodeProto* node = nullptr;
+  // True when the projection's own weight IS the embedding table itself
+  // (already sliced once, as part of the embedding weight's own slice --
+  // `weight_name`/`weight_transposed` are then unused, left nullopt).
+  // False means an independent initializer this match's own caller must
+  // slice separately, using `weight_transposed`.
+  bool tied = false;
+  std::optional<std::string> weight_name;  // untied only
+  std::optional<bool> weight_transposed;   // untied only
+  std::optional<std::string> bias;         // either case, when matched
+  // The interposed Transpose node for the tied "Transpose then MatMul"
+  // sub-shape, else nullptr -- owns no weight of its own to slice, but its
+  // own now-stale output shape still needs invalidating after pruning.
+  onnx::NodeProto* via_transpose = nullptr;
+};
+
+struct EmbeddingChain {
+  onnx::NodeProto* producer = nullptr;  // the matched Gather node
+  std::string weight_name;              // the embedding table's own name
+  std::string indices_name;
+  int64_t vocab_size = 0;
+  int64_t hidden_size = 0;
+  std::optional<EmbeddingLmHeadMatch> lm_head;
+};
+
+// If `node` is a well-formed embedding-table Gather (this section's own
+// comment above has the full matching criteria), returns
+// (weight_name, indices_name, underlying_input_name) -- `indices_name` is
+// `node`'s own literal `indices` operand, `underlying_input_name` is that
+// same tensor with one Cast hop unwrapped when present. Mirrors
+// pruning.py's own `_match_embedding_gather` exactly, minus the
+// `EmbedLayerNormalization`/`GatherBlockQuantized` producer shapes (out of
+// scope for this C++ port -- see this section's own top comment). The
+// Python original also double-checks `node in consumers_of[w_name]`; that
+// is always true here by construction (ConsumersOf indexes every node
+// under every one of its own literal `input()` names, and `w_name` is
+// literally `node.input(0)`), so it is not re-checked.
+std::optional<std::tuple<std::string, std::string, std::string>>
+MatchEmbeddingGatherRaw(
+    const onnx::NodeProto& node, const InitMap& init_map,
+    const ConsumerMap& consumers_of,
+    const std::unordered_set<std::string>& graph_input_names,
+    const std::unordered_map<std::string, onnx::NodeProto*>& node_by_output) {
+  if (node.op_type() != "Gather" || node.input_size() != 2) {
+    return std::nullopt;
+  }
+  int64_t axis = 0;
+  for (const auto& attr : node.attribute()) {
+    if (attr.name() == "axis") {
+      axis = attr.i();
+    }
+  }
+  if (axis != 0) {
+    return std::nullopt;
+  }
+  const std::string& w_name = node.input(0);
+  const std::string& indices_name = node.input(1);
+  auto wit = init_map.find(w_name);
+  if (wit == init_map.end() ||
+      wit->second->data_type() != onnx::TensorProto::FLOAT ||
+      wit->second->dims_size() != 2) {
+    return std::nullopt;
+  }
+
+  std::string underlying = indices_name;
+  if (!graph_input_names.count(underlying)) {
+    auto cit = node_by_output.find(underlying);
+    if (cit != node_by_output.end() && cit->second->op_type() == "Cast" &&
+        cit->second->input_size() == 1 &&
+        graph_input_names.count(cit->second->input(0))) {
+      underlying = cit->second->input(0);
+    } else {
+      return std::nullopt;  // not a graph input, nor a Cast of one
+    }
+  }
+
+  auto cons_it = consumers_of.find(w_name);
+  const size_t n_consumers =
+      cons_it == consumers_of.end() ? 0 : cons_it->second.size();
+  if (n_consumers < 1 || n_consumers > 2) {
+    return std::nullopt;  // unexpected consumer count -- decline, don't guess
+  }
+  return std::make_tuple(w_name, indices_name, underlying);
+}
+
+// Resolves `node` (an already-matched MatMul/vanilla-Gemm producing
+// `vocab_size`-wide output) to its own bias, if any, and the node whose
+// *output* is the real, final logits tensor. Mirrors pruning.py's own
+// `_match_lm_head_tail` exactly: returns `std::nullopt` for the
+// `_LM_HEAD_BIAS_INVALID` sentinel case (a bias exists but not in a shape
+// this pass safely handles -- declined, never left silently stale), or a
+// present `(bias_name_or_nullopt, output_node)` pair otherwise.
+std::optional<std::pair<std::optional<std::string>, onnx::NodeProto*>>
+MatchLmHeadTail(onnx::NodeProto* node, const InitMap& init_map,
+                const ConsumerMap& consumers_of, int64_t vocab_size) {
+  auto valid_bias = [&](const std::string& name) {
+    auto it = init_map.find(name);
+    if (it == init_map.end() ||
+        it->second->data_type() != onnx::TensorProto::FLOAT) {
+      return false;
+    }
+    const auto& dims = it->second->dims();
+    if (dims.size() == 1 && dims[0] == vocab_size) {
+      return true;
+    }
+    if (dims.size() == 2 && dims[0] == 1 && dims[1] == vocab_size) {
+      return true;
+    }
+    return false;
+  };
+
+  if (node->op_type() == "Gemm" && node->input_size() == 3 &&
+      !node->input(2).empty()) {
+    const std::string bias_name = node->input(2);
+    if (!valid_bias(bias_name)) {
+      return std::nullopt;
+    }
+    return std::make_pair(std::optional<std::string>(bias_name), node);
+  }
+
+  const std::string& out_name = node->output(0);
+  auto cit = consumers_of.find(out_name);
+  if (cit == consumers_of.end() || cit->second.empty()) {
+    return std::make_pair(std::optional<std::string>(std::nullopt), node);
+  }
+  const std::vector<onnx::NodeProto*>& out_consumers = cit->second;
+  bool any_add = false;
+  for (onnx::NodeProto* c : out_consumers) {
+    if (c->op_type() == "Add") {
+      any_add = true;
+      break;
+    }
+  }
+  if (any_add) {
+    if (out_consumers.size() != 1 || out_consumers[0]->input_size() != 2) {
+      return std::nullopt;  // ambiguous fan-out -- decline
+    }
+    onnx::NodeProto* add_node = out_consumers[0];
+    const std::string other = add_node->input(1) == out_name
+                                  ? add_node->input(0)
+                                  : add_node->input(1);
+    if (!valid_bias(other)) {
+      return std::nullopt;
+    }
+    return std::make_pair(std::optional<std::string>(other), add_node);
+  }
+  return std::make_pair(std::optional<std::string>(std::nullopt),
+                        node);  // output feeds something else -- no bias here
+}
+
+// If the embedding table `weight_name` has a second consumer besides
+// `gather_node`, and that second consumer resolves to one of the two tied
+// `lm_head` sub-shapes this section's own top comment describes (direct
+// `Gemm(transB=1)`, or one `Transpose` then a plain `MatMul`/
+// `Gemm(transB=0)`), returns the matched `EmbeddingLmHeadMatch`
+// (`tied=true`). Returns `std::nullopt` both when there is no second
+// consumer at all (the caller falls back to MatchUntiedLmHead) and when
+// there IS one but it doesn't resolve to either recognized shape (an
+// unexplained second reader -- the caller must then decline the WHOLE
+// chain, not just skip lm_head detection). Mirrors pruning.py's own
+// `_match_tied_lm_head` exactly.
+std::optional<EmbeddingLmHeadMatch> MatchTiedLmHead(
+    const std::string& weight_name, int64_t vocab_size,
+    onnx::NodeProto* gather_node, const ConsumerMap& consumers_of,
+    const InitMap& init_map) {
+  auto cit = consumers_of.find(weight_name);
+  const std::vector<onnx::NodeProto*>& all =
+      cit == consumers_of.end() ? std::vector<onnx::NodeProto*>{} : cit->second;
+  std::vector<onnx::NodeProto*> others;
+  for (onnx::NodeProto* c : all) {
+    if (c != gather_node) {
+      others.push_back(c);
+    }
+  }
+  if (others.size() != 1) {
+    return std::nullopt;
+  }
+  onnx::NodeProto* other = others[0];
+
+  auto match = MatchMatMulLikeRaw(*other);
+  if (match) {
+    if (match->w_name == weight_name && match->weight_transposed) {
+      auto tail = MatchLmHeadTail(other, init_map, consumers_of, vocab_size);
+      if (!tail) {
+        return std::nullopt;
+      }
+      EmbeddingLmHeadMatch result;
+      result.node = tail->second;
+      result.tied = true;
+      result.bias = tail->first;
+      return result;
+    }
+    return std::nullopt;
+  }
+
+  if (other->op_type() == "Transpose" && other->input_size() == 1 &&
+      other->input(0) == weight_name) {
+    std::optional<std::vector<int64_t>> perm;
+    for (const auto& attr : other->attribute()) {
+      if (attr.name() == "perm") {
+        perm.emplace(attr.ints().begin(), attr.ints().end());
+      }
+    }
+    if (perm && !(perm->size() == 2 && (*perm)[0] == 1 && (*perm)[1] == 0)) {
+      return std::nullopt;
+    }
+    const std::string& t_out = other->output(0);
+    auto tcit = consumers_of.find(t_out);
+    if (tcit == consumers_of.end() || tcit->second.size() != 1) {
+      return std::nullopt;
+    }
+    onnx::NodeProto* node2 = tcit->second[0];
+    auto match2 = MatchMatMulLikeRaw(*node2);
+    if (!match2 || match2->w_name != t_out || match2->weight_transposed) {
+      // must consume the transposed [hidden, vocab] tensor untransposed
+      return std::nullopt;
+    }
+    auto tail = MatchLmHeadTail(node2, init_map, consumers_of, vocab_size);
+    if (!tail) {
+      return std::nullopt;
+    }
+    EmbeddingLmHeadMatch result;
+    result.node = tail->second;
+    result.tied = true;
+    result.bias = tail->first;
+    result.via_transpose = other;
+    return result;
+  }
+
+  return std::nullopt;
+}
+
+// Auto-detects a fully independent `lm_head` weight: exactly one
+// MatMul/vanilla-Gemm node in the whole graph whose constant 2-D weight is
+// distinct from `embedding_weight_name`, has exactly one consumer,
+// produces `vocab_size`-wide output, and -- the one structural signal that
+// reliably distinguishes "the" vocab-logits projection from some unrelated
+// layer of the same output width -- whose final (MatchLmHeadTail-resolved)
+// output is itself a genuine graph output. Zero or more than one such
+// candidate is declined, not guessed at; only ever called when
+// MatchTiedLmHead already found no tied lm_head to prefer. Mirrors
+// pruning.py's own `_match_untied_lm_head` exactly.
+std::optional<EmbeddingLmHeadMatch> MatchUntiedLmHead(
+    onnx::GraphProto* graph, const std::string& embedding_weight_name,
+    int64_t vocab_size, const ConsumerMap& consumers_of,
+    const InitMap& init_map,
+    const std::unordered_set<std::string>& graph_outputs) {
+  struct Candidate {
+    std::string w_name;
+    bool weight_transposed;
+    std::optional<std::string> bias;
+    onnx::NodeProto* output_node;
+  };
+  std::vector<Candidate> candidates;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    auto match = MatchMatMulLikeRaw(*node);
+    if (!match) {
+      continue;
+    }
+    if (match->w_name == embedding_weight_name) {
+      continue;  // handled by the tied path, not here
+    }
+    auto wit = init_map.find(match->w_name);
+    if (wit == init_map.end() ||
+        wit->second->data_type() != onnx::TensorProto::FLOAT ||
+        wit->second->dims_size() != 2) {
+      continue;
+    }
+    const int64_t n_channels =
+        match->weight_transposed ? wit->second->dims(0) : wit->second->dims(1);
+    auto cit = consumers_of.find(match->w_name);
+    const size_t n_consumers =
+        cit == consumers_of.end() ? 0 : cit->second.size();
+    if (n_channels != vocab_size || n_consumers != 1) {
+      continue;
+    }
+    auto tail = MatchLmHeadTail(node, init_map, consumers_of, vocab_size);
+    if (!tail) {
+      continue;  // not a confident candidate -- skip, don't guess
+    }
+    if (!graph_outputs.count(tail->second->output(0))) {
+      continue;
+    }
+    candidates.push_back(
+        {match->w_name, match->weight_transposed, tail->first, tail->second});
+  }
+  if (candidates.size() != 1) {
+    return std::nullopt;
+  }
+  EmbeddingLmHeadMatch result;
+  result.node = candidates[0].output_node;
+  result.tied = false;
+  result.weight_name = candidates[0].w_name;
+  result.weight_transposed = candidates[0].weight_transposed;
+  result.bias = candidates[0].bias;
+  return result;
+}
+
+// Finds the one token-embedding Gather this pass should act on in `graph`
+// alone, plus its tied/untied `lm_head`, if any. When `input_name` is
+// given, only a Gather whose token-id operand resolves to that exact graph
+// input is considered, and -- when `strict_input_name` -- it is an error
+// (`std::invalid_argument`, a caller mistake) if none does;
+// `strict_input_name=false` (only ever passed by
+// MatchEmbeddingChainAnyGraph) instead treats that same outcome as an
+// ordinary decline (`std::nullopt`, no exception), since `graph` here is
+// only one of possibly several graphs a whole-model search is trying in
+// turn. When `input_name` is omitted, exactly one qualifying Gather must
+// exist in the whole graph -- zero or more than one declines the whole
+// call. Mirrors pruning.py's own `_match_embedding_chain` exactly (minus
+// the `EmbedLayerNormalization`/`GatherBlockQuantized` producer shapes --
+// see this section's own top comment).
+std::optional<EmbeddingChain> MatchEmbeddingChain(
+    onnx::GraphProto* graph, const std::optional<std::string>& input_name,
+    bool strict_input_name) {
+  InitMap init_map;
+  for (const auto& t : graph->initializer()) {
+    init_map[t.name()] = &t;
+  }
+  ConsumerMap consumers_of = ConsumersOf(graph);
+  std::unordered_map<std::string, onnx::NodeProto*> node_by_output;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    for (const auto& out : node->output()) {
+      if (!out.empty()) {
+        node_by_output[out] = node;
+      }
+    }
+  }
+  std::unordered_set<std::string> graph_outputs;
+  for (const auto& o : graph->output()) {
+    graph_outputs.insert(o.name());
+  }
+  std::unordered_set<std::string> graph_input_names;
+  for (const auto& in : graph->input()) {
+    graph_input_names.insert(in.name());
+  }
+
+  struct RawMatch {
+    onnx::NodeProto* node;
+    std::string w_name;
+    std::string indices_name;
+  };
+  std::vector<RawMatch> matches;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    auto m = MatchEmbeddingGatherRaw(*node, init_map, consumers_of,
+                                     graph_input_names, node_by_output);
+    if (!m) {
+      continue;
+    }
+    const std::string& w_name = std::get<0>(*m);
+    const std::string& indices_name = std::get<1>(*m);
+    const std::string& underlying = std::get<2>(*m);
+    if (input_name && *input_name != indices_name &&
+        *input_name != underlying) {
+      continue;
+    }
+    matches.push_back({node, w_name, indices_name});
+  }
+
+  if (input_name && matches.empty()) {
+    if (!strict_input_name) {
+      return std::nullopt;
+    }
+    throw std::invalid_argument(
+        "MatchEmbeddingChain: no embedding Gather found reading graph "
+        "input '" +
+        *input_name + "'");
+  }
+  if (matches.size() != 1) {
+    return std::nullopt;  // zero, or ambiguous with no input_name to
+                          // disambiguate
+  }
+
+  onnx::NodeProto* producer_node = matches[0].node;
+  const std::string& w_name = matches[0].w_name;
+  const onnx::TensorProto* w_init = init_map.at(w_name);
+  const int64_t vocab_size = w_init->dims(0);
+  const int64_t hidden_size = w_init->dims(1);
+
+  auto cit = consumers_of.find(w_name);
+  const size_t n_consumers = cit == consumers_of.end() ? 0 : cit->second.size();
+  std::optional<EmbeddingLmHeadMatch> lm_head;
+  if (n_consumers == 2) {
+    lm_head = MatchTiedLmHead(w_name, vocab_size, producer_node, consumers_of,
+                              init_map);
+    if (!lm_head) {
+      return std::nullopt;  // unexplained second consumer -- decline, don't
+                            // guess
+    }
+  } else {
+    lm_head = MatchUntiedLmHead(graph, w_name, vocab_size, consumers_of,
+                                init_map, graph_outputs);
+  }
+
+  EmbeddingChain chain;
+  chain.producer = producer_node;
+  chain.weight_name = w_name;
+  chain.indices_name = matches[0].indices_name;
+  chain.vocab_size = vocab_size;
+  chain.hidden_size = hidden_size;
+  chain.lm_head = lm_head;
+  return chain;
+}
+
+// Subgraph-aware wrapper around MatchEmbeddingChain: tries every graph
+// IterSubgraphs(model_graph) returns -- `model_graph` itself first, then
+// every nested If/Loop/Scan/BeamSearch-family subgraph, at any nesting
+// depth -- independently (`strict_input_name=false`), and applies the
+// IDENTICAL "exactly one qualifying match, or decline" rule *across the
+// whole model* rather than one single graph. `std::invalid_argument` for
+// an unmatched `input_name` is thrown here instead, exactly once, only
+// after every graph has been tried and NONE contained a producer reading
+// it. Returns the `(graph, chain)` pair when exactly one match was found
+// -- `graph` is the same GraphProto* IterSubgraphs returned it as (never
+// copied), reachable from `out.mutable_graph()`, so the caller can mutate
+// it in place -- or `(nullptr, std::nullopt)` when the call should be
+// declined. Mirrors pruning.py's own `_match_embedding_chain_any_graph`
+// exactly.
+std::pair<onnx::GraphProto*, std::optional<EmbeddingChain>>
+MatchEmbeddingChainAnyGraph(onnx::GraphProto* model_graph,
+                            const std::optional<std::string>& input_name) {
+  onnx::GraphProto* found_graph = nullptr;
+  std::optional<EmbeddingChain> found_chain;
+  int n_found = 0;
+  for (onnx::GraphProto* graph : IterSubgraphs(model_graph)) {
+    auto chain =
+        MatchEmbeddingChain(graph, input_name, /*strict_input_name=*/false);
+    if (chain) {
+      ++n_found;
+      found_graph = graph;
+      found_chain = std::move(chain);
+    }
+  }
+  if (input_name && n_found == 0) {
+    throw std::invalid_argument(
+        "MatchEmbeddingChainAnyGraph: no embedding Gather found reading "
+        "graph input '" +
+        *input_name + "'");
+  }
+  if (n_found != 1) {
+    return {nullptr, std::nullopt};  // zero, or ambiguous across graphs
+  }
+  return {found_graph, std::move(found_chain)};
+}
+
+// If `name` is a declared graph output with a fixed (`dim_value`) last
+// shape dimension equal to `old_v`, updates it to `new_v` in place and
+// returns true. A symbolic (`dim_param`) or altogether absent last
+// dimension is left alone. Mirrors pruning.py's own
+// `_update_vocab_output_shape` exactly -- see this section's own top
+// comment for why this pass, unlike every chain family above, must
+// actively correct a stale graph OUTPUT shape rather than only ever drop
+// an internal value_info entry.
+bool UpdateVocabOutputShape(onnx::GraphProto* graph, const std::string& name,
+                            int64_t old_v, int64_t new_v) {
+  for (onnx::ValueInfoProto& o : *graph->mutable_output()) {
+    if (o.name() != name) {
+      continue;
+    }
+    auto* dims =
+        o.mutable_type()->mutable_tensor_type()->mutable_shape()->mutable_dim();
+    if (dims->size() >= 1) {
+      auto* last = dims->Mutable(dims->size() - 1);
+      if (last->has_dim_value() && last->dim_value() == old_v) {
+        last->set_dim_value(new_v);
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
+// Performs the actual slicing, IN PLACE on `graph`, for an already-decided
+// (ascending) `keep_ids` set: the embedding table's own vocab_size axis
+// (always axis 0 -- MatchEmbeddingGatherRaw's own `axis == 0` requirement),
+// and, for an untied `lm_head`, its own independent weight/bias. A tied
+// `lm_head`'s weight needs no separate slicing call: it IS the embedding
+// table (the exact same initializer), already fully accounted for by the
+// one slice below. `graph` must be whichever graph `chain` was actually
+// matched in (MatchEmbeddingChainAnyGraph's own returned `graph`), so this
+// mutates that graph's own initializer/output/value_info in place, never a
+// different graph's. Mirrors pruning.py's own `_apply_embedding_vocab_
+// prune`/`_finalize_embedding_shapes` exactly.
+void ApplyEmbeddingVocabPrune(onnx::GraphProto* graph,
+                              const EmbeddingChain& chain,
+                              const std::vector<int64_t>& keep_ids) {
+  MutInitMap init_map = BuildMutInitMap(graph);
+  const int64_t new_v = static_cast<int64_t>(keep_ids.size());
+
+  // The embedding table is [vocab_size, hidden_size] with vocab_size as
+  // axis 0 -- exactly SliceProducerWeight's own `weight_transposed=true`
+  // ("output channel is axis 0") branch, reused verbatim rather than
+  // duplicating an axis-0 row-slice helper.
+  SliceProducerWeight(init_map.at(chain.weight_name),
+                      /*weight_transposed=*/true, keep_ids, /*is_conv=*/false);
+
+  if (chain.lm_head && !chain.lm_head->tied) {
+    SliceProducerWeight(init_map.at(*chain.lm_head->weight_name),
+                        *chain.lm_head->weight_transposed, keep_ids,
+                        /*is_conv=*/false);
+  }
+  if (chain.lm_head && chain.lm_head->bias) {
+    SliceLastAxis(init_map.at(*chain.lm_head->bias), keep_ids);
+  }
+
+  // Finalize shapes: chain.producer's own output shape never needs
+  // touching (a plain Gather's output carries hidden_size only, unaffected
+  // by an axis=0 gather) -- only an lm_head's own (and, for the tied
+  // via-transpose sub-shape, the Transpose's own) output width changes.
+  if (chain.lm_head) {
+    std::unordered_set<std::string> stale;
+    const std::string& out_name = chain.lm_head->node->output(0);
+    if (!UpdateVocabOutputShape(graph, out_name, chain.vocab_size, new_v)) {
+      stale.insert(out_name);
+    }
+    if (chain.lm_head->via_transpose) {
+      const std::string& t_out = chain.lm_head->via_transpose->output(0);
+      if (!UpdateVocabOutputShape(graph, t_out, chain.vocab_size, new_v)) {
+        stale.insert(t_out);
+      }
+    }
+    if (!stale.empty()) {
+      google::protobuf::RepeatedPtrField<onnx::ValueInfoProto> kept;
+      for (const auto& vi : graph->value_info()) {
+        if (!stale.count(vi.name())) {
+          *kept.Add() = vi;
+        }
+      }
+      graph->mutable_value_info()->Swap(&kept);
+    }
+  }
+}
+
+// The per-row (vocab-axis) L2-norm importance vector shared by
+// ApplyEmbeddingVocabMagnitudePruning: the matched embedding table's own
+// row norm, combined (root-sum-square) with a matched untied `lm_head`'s
+// own row norm when one exists (the tied case needs no such combination --
+// the embedding table's own row norm already IS the tied `lm_head`'s row
+// norm). Mirrors pruning.py's own `_embedding_vocab_importance` exactly,
+// minus the `GatherBlockQuantized`-dequantization branch (out of scope for
+// this C++ port -- see this section's own top comment).
+std::vector<double> EmbeddingVocabImportance(const EmbeddingChain& chain,
+                                             const InitMap& init_map) {
+  std::vector<double> importance(static_cast<size_t>(chain.vocab_size), 0.0);
+  {
+    const std::vector<float> emb =
+        ReadFloatTensor(*init_map.at(chain.weight_name));
+    for (int64_t v = 0; v < chain.vocab_size; ++v) {
+      double sum = 0.0;
+      for (int64_t h = 0; h < chain.hidden_size; ++h) {
+        const double x = emb[static_cast<size_t>(v * chain.hidden_size + h)];
+        sum += x * x;
+      }
+      importance[static_cast<size_t>(v)] = sum;
+    }
+  }
+  if (chain.lm_head && !chain.lm_head->tied && chain.lm_head->weight_name) {
+    const onnx::TensorProto* lw = init_map.at(*chain.lm_head->weight_name);
+    const std::vector<float> lwd = ReadFloatTensor(*lw);
+    if (*chain.lm_head->weight_transposed) {
+      // [vocab_size, K] -- row v is contiguous, direct read.
+      const int64_t k = lw->dims(1);
+      for (int64_t v = 0; v < chain.vocab_size; ++v) {
+        double sum = 0.0;
+        for (int64_t j = 0; j < k; ++j) {
+          const double x = lwd[static_cast<size_t>(v * k + j)];
+          sum += x * x;
+        }
+        importance[static_cast<size_t>(v)] += sum;
+      }
+    } else {
+      // [K, vocab_size] -- row v is column v, strided read.
+      const int64_t k = lw->dims(0);
+      const int64_t vsz = lw->dims(1);
+      for (int64_t v = 0; v < chain.vocab_size; ++v) {
+        double sum = 0.0;
+        for (int64_t j = 0; j < k; ++j) {
+          const double x = lwd[static_cast<size_t>(j * vsz + v)];
+          sum += x * x;
+        }
+        importance[static_cast<size_t>(v)] += sum;
+      }
+    }
+  }
+  for (double& x : importance) {
+    x = std::sqrt(x);
+  }
+  return importance;
+}
+
 }  // namespace
 
 onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
@@ -13376,4 +14064,151 @@ onnx::ModelProto ApplyQMoEExpertChannelPruning(const onnx::ModelProto& model,
     }
   }
   return out;
+}
+
+EmbeddingVocabPruningResult ApplyEmbeddingVocabPruning(
+    const onnx::ModelProto& model,
+    const std::optional<std::vector<int64_t>>& keep_token_ids,
+    const std::optional<std::vector<int64_t>>& drop_token_ids,
+    const std::optional<std::string>& input_name) {
+  if (keep_token_ids.has_value() == drop_token_ids.has_value()) {
+    throw std::invalid_argument(
+        "ApplyEmbeddingVocabPruning: give exactly one of keep_token_ids or "
+        "drop_token_ids, not both/neither");
+  }
+  onnx::ModelProto out = model;
+
+  // Subgraph-aware (IterSubgraphs, see this file's own "Subgraph
+  // recursion" section comment above): the one eligible embedding Gather
+  // this function requires may live inside a nested If/Loop/Scan/
+  // BeamSearch-family subgraph, at any nesting depth -- see
+  // MatchEmbeddingChainAnyGraph's own comment for exactly how the
+  // "exactly one eligible producer, or decline" rule is applied across the
+  // whole model. Mirrors pruning.py's own `apply_embedding_vocab_pruning`.
+  auto [graph, chain] =
+      MatchEmbeddingChainAnyGraph(out.mutable_graph(), input_name);
+  if (!chain) {
+    return EmbeddingVocabPruningResult{std::move(out), false, {}, false};
+  }
+
+  const int64_t vocab_size = chain->vocab_size;
+  std::set<int64_t> keep_set;
+  if (keep_token_ids) {
+    keep_set.insert(keep_token_ids->begin(), keep_token_ids->end());
+  } else {
+    std::set<int64_t> drop_set(drop_token_ids->begin(), drop_token_ids->end());
+    std::vector<int64_t> bad_drop;
+    for (int64_t d : drop_set) {
+      if (!(d >= 0 && d < vocab_size)) {
+        bad_drop.push_back(d);
+      }
+    }
+    if (!bad_drop.empty()) {
+      throw std::invalid_argument(
+          "ApplyEmbeddingVocabPruning: drop_token_ids out of range [0, " +
+          std::to_string(vocab_size) + "), first offender " +
+          std::to_string(bad_drop.front()));
+    }
+    for (int64_t i = 0; i < vocab_size; ++i) {
+      if (!drop_set.count(i)) {
+        keep_set.insert(i);
+      }
+    }
+  }
+  for (int64_t k : keep_set) {
+    if (!(k >= 0 && k < vocab_size)) {
+      throw std::invalid_argument(
+          "ApplyEmbeddingVocabPruning: keep_token_ids out of range [0, " +
+          std::to_string(vocab_size) + "), first offender " +
+          std::to_string(k));
+    }
+  }
+  if (keep_set.empty()) {
+    throw std::invalid_argument(
+        "ApplyEmbeddingVocabPruning: keep_token_ids resolves to an empty "
+        "vocabulary");
+  }
+  const std::vector<int64_t> keep_ids(keep_set.begin(), keep_set.end());
+
+  ApplyEmbeddingVocabPrune(graph, *chain, keep_ids);
+  return EmbeddingVocabPruningResult{std::move(out), true, keep_ids,
+                                     chain->lm_head.has_value()};
+}
+
+EmbeddingVocabPruningResult ApplyEmbeddingVocabMagnitudePruning(
+    const onnx::ModelProto& model, double sparsity,
+    const std::optional<std::vector<int64_t>>& protect_token_ids,
+    const std::optional<std::string>& input_name) {
+  if (!(sparsity >= 0.0 && sparsity < 1.0)) {
+    throw std::invalid_argument(
+        "ApplyEmbeddingVocabMagnitudePruning: sparsity must be in [0, 1), "
+        "got " +
+        std::to_string(sparsity));
+  }
+  onnx::ModelProto out = model;
+
+  // Subgraph-aware exactly like ApplyEmbeddingVocabPruning above -- see
+  // MatchEmbeddingChainAnyGraph's own comment. Mirrors pruning.py's own
+  // `apply_embedding_vocab_magnitude_pruning`.
+  auto [graph, chain] =
+      MatchEmbeddingChainAnyGraph(out.mutable_graph(), input_name);
+  if (!chain) {
+    return EmbeddingVocabPruningResult{std::move(out), false, {}, false};
+  }
+
+  const int64_t vocab_size = chain->vocab_size;
+  InitMap init_map;
+  for (const auto& t : graph->initializer()) {
+    init_map[t.name()] = &t;
+  }
+  const std::vector<double> importance =
+      EmbeddingVocabImportance(*chain, init_map);
+
+  std::set<int64_t> protect;
+  if (protect_token_ids) {
+    protect.insert(protect_token_ids->begin(), protect_token_ids->end());
+  }
+  for (int64_t p : protect) {
+    if (!(p >= 0 && p < vocab_size)) {
+      throw std::invalid_argument(
+          "ApplyEmbeddingVocabMagnitudePruning: protect_token_ids out of "
+          "range [0, " +
+          std::to_string(vocab_size) + "), first offender " +
+          std::to_string(p));
+    }
+  }
+
+  int64_t keep_count = std::max<int64_t>(
+      1, std::min<int64_t>(vocab_size, static_cast<int64_t>(std::llround(
+                                           static_cast<double>(vocab_size) *
+                                           (1.0 - sparsity)))));
+  keep_count =
+      std::max<int64_t>(keep_count, static_cast<int64_t>(protect.size()));
+
+  // Descending-importance order, all `vocab_size` indices (not just the top
+  // `keep_count` -- `protect` ids can sit anywhere in the ranking and must
+  // still be found so the fill loop below can skip re-adding them). Ties
+  // broken by ascending original index (std::stable_sort) -- may differ
+  // from numpy's own default (unstable) argsort tie-breaking, the same
+  // caveat TopKIndicesAscending's own comment already documents elsewhere
+  // in this file.
+  std::vector<int64_t> order(static_cast<size_t>(vocab_size));
+  std::iota(order.begin(), order.end(), int64_t{0});
+  std::stable_sort(order.begin(), order.end(), [&](int64_t a, int64_t b) {
+    return importance[static_cast<size_t>(a)] >
+           importance[static_cast<size_t>(b)];
+  });
+
+  std::set<int64_t> keep_set(protect.begin(), protect.end());
+  for (int64_t idx : order) {
+    if (static_cast<int64_t>(keep_set.size()) >= keep_count) {
+      break;
+    }
+    keep_set.insert(idx);
+  }
+  const std::vector<int64_t> keep_ids(keep_set.begin(), keep_set.end());
+
+  ApplyEmbeddingVocabPrune(graph, *chain, keep_ids);
+  return EmbeddingVocabPruningResult{std::move(out), true, keep_ids,
+                                     chain->lm_head.has_value()};
 }

--- a/onnxsim/structured_pruning_entry.h
+++ b/onnxsim/structured_pruning_entry.h
@@ -17,6 +17,11 @@
 
 #include <onnx/onnx_pb.h>
 
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
 onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
                                         double sparsity);
 
@@ -38,3 +43,87 @@ onnx::ModelProto ApplyMoeExpertChannelPruning(const onnx::ModelProto& model,
 
 onnx::ModelProto ApplyQMoEExpertChannelPruning(const onnx::ModelProto& model,
                                                double sparsity);
+
+// Return type of ApplyEmbeddingVocabPruning/ApplyEmbeddingVocabMagnitude
+// Pruning -- the C++ mirror of pruning.py's own `EmbeddingPruningResult`
+// dataclass (see structured_pruning_entry.cpp's own "Embedding vocabulary
+// pruning" section comment for the full rationale). Unlike every other
+// entry point in this file/onnxsim.h, these two passes change what counts
+// as a valid model *input* (a vocabulary-pruned model only accepts
+// remapped token ids), so -- exactly like the Python original -- neither
+// one returns a bare `onnx::ModelProto`.
+//
+// Deliberately narrower than pruning.py's own dataclass: `id_map` (the
+// old-token-id -> new-token-id mapping) is NOT carried across this
+// boundary -- it is exactly `{kept_token_ids[i]: i for i in
+// range(len(kept_token_ids))}`, trivial for the Python wrapper
+// (onnx_simplifier.py) to reconstruct from `kept_token_ids` alone, so
+// there is no reason to also serialize an int64->int64 map through
+// nanobind. The Python wrapper builds the real, public
+// `onnxsim.pruning.EmbeddingPruningResult` (the exact same dataclass the
+// pure-Python entry points already return) from this struct's fields,
+// rather than inventing a second, C++-only result type Python callers
+// would need to know about -- one canonical return shape for both the
+// pure-Python and C++-backed entry points.
+struct EmbeddingVocabPruningResult {
+  onnx::ModelProto model;
+  bool matched = false;
+  // Ascending, original-vocabulary token ids that survive. Empty when
+  // `matched` is false (mirrors `kept_token_ids: Optional[List[int]] =
+  // None` in Python -- an empty vector here is likewise only ever
+  // meaningful when `matched` is true, since a non-empty keep-set is
+  // required by both entry points below).
+  std::vector<int64_t> kept_token_ids;
+  bool lm_head_pruned = false;
+};
+
+// Shrinks a matched token-embedding table's vocabulary axis (a plain
+// `Gather`'s `data` input feeding a graph input's token-id tensor, plus,
+// where a tied or confidently-auto-identified untied `lm_head` exists, its
+// own vocab-logits projection too) down to a caller-supplied, explicit
+// keep-set. The C++ port of pruning.py's own `apply_embedding_vocab_
+// pruning` -- give exactly one of `keep_token_ids`/`drop_token_ids`
+// (`std::nullopt` means "not given"; an empty-but-present vector is a
+// caller value, not "omitted"). See structured_pruning_entry.cpp's own
+// "Embedding vocabulary pruning" section comment for the full matched
+// topology/scope and structured_pruning_entry.cpp's own
+// `MatchEmbeddingChain` for exactly what is/isn't recognized.
+//
+// `input_name`, when given, names which graph input (by name) the target
+// `Gather`'s indices operand must resolve to -- required whenever more
+// than one structurally-eligible `Gather` producer exists; a name that
+// matches none throws `std::invalid_argument`. When omitted, the whole
+// call declines (`matched=false`) rather than guessing if more than one
+// eligible producer exists anywhere in the model (including nested
+// If/Loop/Scan/BeamSearch-family subgraphs, at any depth -- see
+// `IterSubgraphs`).
+//
+// Unlike pruning.py's own version, this port only ever matches a plain
+// `Gather` producer -- not `com.microsoft::EmbedLayerNormalization` or
+// `com.microsoft::GatherBlockQuantized` -- and only ever matches a bare
+// `MatMul`/vanilla-`Gemm` `lm_head` -- not `com.microsoft::FusedGemm`/
+// `GemmFastGelu` -- and only ever admits a plain FLOAT (float32) embedding
+// table/lm_head weight/bias, not also FLOAT16/BFLOAT16, matching this
+// file's own established narrower-than-pruning.py C++-port scope decision
+// elsewhere (e.g. `ApplyMoeExpertChannelPruning`'s own FLOAT32-only
+// restriction). See structured_pruning_entry.cpp's own section comment for
+// the full list of deliberately out-of-scope shapes and why.
+EmbeddingVocabPruningResult ApplyEmbeddingVocabPruning(
+    const onnx::ModelProto& model,
+    const std::optional<std::vector<int64_t>>& keep_token_ids,
+    const std::optional<std::vector<int64_t>>& drop_token_ids,
+    const std::optional<std::string>& input_name);
+
+// The importance-ranked variant of ApplyEmbeddingVocabPruning: drops the
+// lowest-L2-norm `sparsity` fraction of vocabulary rows (combined,
+// root-sum-square, with a matched untied `lm_head`'s own per-row weight
+// norm when one is identified), never dropping any id in
+// `protect_token_ids`. The C++ port of pruning.py's own
+// `apply_embedding_vocab_magnitude_pruning` -- same weaker-safety-bar
+// caveat as the Python original applies here too (see that function's own
+// docstring): a small row norm means small weights, not that a token is
+// safe to drop from a real deployment.
+EmbeddingVocabPruningResult ApplyEmbeddingVocabMagnitudePruning(
+    const onnx::ModelProto& model, double sparsity,
+    const std::optional<std::vector<int64_t>>& protect_token_ids,
+    const std::optional<std::string>& input_name);

--- a/tests/test_embedding_vocab_pruning_cpp.py
+++ b/tests/test_embedding_vocab_pruning_cpp.py
@@ -1,0 +1,561 @@
+"""Tests for ``onnxsim.apply_embedding_vocab_pruning_cpp``/
+``onnxsim.apply_embedding_vocab_magnitude_pruning_cpp`` -- the C++-backed
+ports of ``onnxsim.apply_embedding_vocab_pruning``/``onnxsim.apply_embedding_
+vocab_magnitude_pruning`` (see ``onnxsim/structured_pruning_entry.cpp``'s own
+"Embedding vocabulary pruning" section).
+
+Unlike every other prior C++-port test file in this repo, this one is NOT a
+subset of an existing feature's coverage grown incrementally -- embedding
+vocabulary pruning is a genuinely different shape of pass (it prunes a
+table's VOCABULARY axis, not a producer/consumer FEATURE-channel pair), and
+it returns an ``onnxsim.pruning.EmbeddingPruningResult`` (model + kept/
+dropped token ids + an old-id -> new-id remapping), never a bare
+``onnx.ModelProto``.
+
+Tests here mirror ``tests/test_pruning.py``'s own "Embedding / lm_head
+vocabulary pruning" coverage (search that section name there), restricted to
+what this C++ port actually recognizes: a plain ``Gather`` producer (never
+``com.microsoft::EmbedLayerNormalization``/``GatherBlockQuantized``, both out
+of scope for this port -- see structured_pruning_entry.cpp's own section
+comment), and a bare ``MatMul``/vanilla-``Gemm`` ``lm_head`` (never
+``com.microsoft::FusedGemm``/``GemmFastGelu``). Every test that actually
+prunes something either runs the result through a real onnxruntime CPU
+session and compares against a numpy slice of the ORIGINAL model's own
+output (the same "byte-exact oracle" bar every other C++-port test file in
+this repo holds itself to), or cross-checks against the pure-Python
+``onnxsim.apply_embedding_vocab_pruning``/``apply_embedding_vocab_magnitude_
+pruning`` entry points as a second, independently-implemented oracle.
+"""
+
+import numpy as np
+import onnx
+import onnx.checker
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(body, initializer=(), opset=21):
+    # Pinning ir_version: 10, same as tests/test_pruning.py's own _model --
+    # matches the older onnxruntime bundled with some CI wheels.
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _matmul_model(K=4, N=4):
+    # A plain MatMul with no Gather anywhere -- the "no embedding pattern at
+    # all" decline baseline, shared by several tests below.
+    rng = np.random.default_rng(0)
+    w = rng.standard_normal((K, N)).astype(np.float32)
+    return _model(
+        f"""
+        g (float[M,{K}] X) => (float[M,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[_f32(w, "W")],
+    )
+
+
+def _untied_model(V, H, seed=1):
+    rng = np.random.default_rng(seed)
+    w_emb = rng.standard_normal((V, H)).astype(np.float32)
+    w_lm = rng.standard_normal((H, V)).astype(np.float32)
+    model = _model(
+        f"""
+        g (int64[batch,seq] input_ids) => (float[batch,seq,{V}] logits)
+        {{
+          hidden = Gather<axis=0>(W_emb, input_ids)
+          logits = MatMul(hidden, W_lm)
+        }}
+        """,
+        initializer=[_f32(w_emb, "W_emb"), _f32(w_lm, "W_lm")],
+    )
+    onnx.checker.check_model(model)
+    return model
+
+
+def _ambiguous_embedding_model(V_tok=10, V_pos=6, H=4, seed=6):
+    rng = np.random.default_rng(seed)
+    w_tok = rng.standard_normal((V_tok, H)).astype(np.float32)
+    w_pos = rng.standard_normal((V_pos, H)).astype(np.float32)
+    model = _model(
+        f"""
+        g (int64[M] input_ids, int64[M] position_ids) => (float[M,{H}] out)
+        {{
+          tok = Gather<axis=0>(W_tok, input_ids)
+          pos = Gather<axis=0>(W_pos, position_ids)
+          out = Add(tok, pos)
+        }}
+        """,
+        initializer=[_f32(w_tok, "W_tok"), _f32(w_pos, "W_pos")],
+    )
+    onnx.checker.check_model(model)
+    return model
+
+
+# --- Explicit keep/drop-token-ids pruning -----------------------------------
+
+
+def test_untied_matches_oracle_and_renumbers_contiguously():
+    V, H = 12, 8
+    model = _untied_model(V, H, seed=1)
+
+    keep_token_ids = [9, 1, 4, 7, 3, 11]  # deliberately unsorted, with dups below
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(
+        model, keep_token_ids=keep_token_ids + [4, 9]
+    )
+    onnx.checker.check_model(result.model)
+
+    assert result.matched
+    assert result.lm_head_pruned
+    assert result.kept_token_ids == sorted(set(keep_token_ids))
+    assert result.id_map == {tok: i for i, tok in enumerate(result.kept_token_ids)}
+
+    emb_init = {t.name: t for t in result.model.graph.initializer}["W_emb"]
+    lm_init = {t.name: t for t in result.model.graph.initializer}["W_lm"]
+    assert list(emb_init.dims) == [len(result.kept_token_ids), H]
+    assert list(lm_init.dims) == [H, len(result.kept_token_ids)]
+
+    input_ids = np.array([[9, 4, 1, 7], [3, 11, 9, 1]], dtype=np.int64)
+    remapped = np.vectorize(result.id_map.get)(input_ids).astype(np.int64)
+
+    orig_out = _run(model, {"input_ids": input_ids})[0]
+    pruned_out = _run(result.model, {"input_ids": remapped})[0]
+    expected = orig_out[..., result.kept_token_ids]
+    assert pruned_out.shape[-1] == len(result.kept_token_ids)
+    np.testing.assert_allclose(pruned_out, expected, atol=1e-5, rtol=1e-5)
+
+    # Independent oracle: the pure-Python entry point must agree exactly
+    # (same kept ids, same id_map, same lm_head_pruned flag).
+    py_result = onnxsim.apply_embedding_vocab_pruning(
+        model, keep_token_ids=keep_token_ids + [4, 9]
+    )
+    assert py_result.kept_token_ids == result.kept_token_ids
+    assert py_result.id_map == result.id_map
+    assert py_result.lm_head_pruned == result.lm_head_pruned
+
+
+def test_drop_token_ids_equivalent_to_complement_keep_set():
+    V, H = 9, 5
+    model = _untied_model(V, H, seed=4)
+    drop = [2, 4, 7]
+
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(model, drop_token_ids=drop)
+    onnx.checker.check_model(result.model)
+    assert result.matched and result.lm_head_pruned
+    assert result.kept_token_ids == [i for i in range(V) if i not in drop]
+
+    py_result = onnxsim.apply_embedding_vocab_pruning(model, drop_token_ids=drop)
+    assert py_result.kept_token_ids == result.kept_token_ids
+    assert py_result.id_map == result.id_map
+
+
+def test_untied_lm_head_gemm_bias_is_sliced():
+    V, H = 10, 6
+    rng = np.random.default_rng(2)
+    w_emb = rng.standard_normal((V, H)).astype(np.float32)
+    w_lm = rng.standard_normal((V, H)).astype(np.float32)  # [N, K], transB=1
+    b_lm = rng.standard_normal(V).astype(np.float32)
+    model = _model(
+        f"""
+        g (int64[M] input_ids) => (float[M,{V}] logits)
+        {{
+          hidden = Gather<axis=0>(W_emb, input_ids)
+          logits = Gemm<transB=1>(hidden, W_lm, B_lm)
+        }}
+        """,
+        initializer=[_f32(w_emb, "W_emb"), _f32(w_lm, "W_lm"), _f32(b_lm, "B_lm")],
+    )
+    onnx.checker.check_model(model)
+
+    keep_token_ids = [0, 2, 3, 5, 8, 9]
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(
+        model, keep_token_ids=keep_token_ids
+    )
+    onnx.checker.check_model(result.model)
+    assert result.matched and result.lm_head_pruned
+
+    bias_init = {t.name: t for t in result.model.graph.initializer}["B_lm"]
+    assert list(bias_init.dims) == [len(keep_token_ids)]
+
+    input_ids = np.array([0, 5, 9, 2, 8], dtype=np.int64)
+    remapped = np.array([result.id_map[i] for i in input_ids], dtype=np.int64)
+
+    orig_out = _run(model, {"input_ids": input_ids})[0]
+    pruned_out = _run(result.model, {"input_ids": remapped})[0]
+    expected = orig_out[..., result.kept_token_ids]
+    np.testing.assert_allclose(pruned_out, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_tied_via_transpose_matches_oracle():
+    # Tied (weight-shared) embedding/lm_head, the "Transpose then MatMul"
+    # sub-shape -- the single shared initializer must be sliced exactly
+    # once, never independently twice.
+    V, H = 12, 8
+    rng = np.random.default_rng(3)
+    w_emb = rng.standard_normal((V, H)).astype(np.float32)
+    model = _model(
+        f"""
+        g (int64[batch,seq] input_ids) => (float[batch,seq,{V}] logits)
+        {{
+          hidden = Gather<axis=0>(W_emb, input_ids)
+          W_t = Transpose<perm=[1,0]>(W_emb)
+          logits = MatMul(hidden, W_t)
+        }}
+        """,
+        initializer=[_f32(w_emb, "W_emb")],
+    )
+    onnx.checker.check_model(model)
+    assert len(model.graph.initializer) == 1
+
+    keep_token_ids = [1, 2, 4, 6, 8, 10, 11]
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(
+        model, keep_token_ids=keep_token_ids
+    )
+    onnx.checker.check_model(result.model)
+
+    assert result.matched
+    assert result.lm_head_pruned
+    assert len(result.model.graph.initializer) == 1
+    emb_init = result.model.graph.initializer[0]
+    assert list(emb_init.dims) == [len(keep_token_ids), H]
+
+    input_ids = np.array([[1, 4, 8], [10, 2, 11]], dtype=np.int64)
+    remapped = np.vectorize(result.id_map.get)(input_ids).astype(np.int64)
+
+    orig_out = _run(model, {"input_ids": input_ids})[0]
+    pruned_out = _run(result.model, {"input_ids": remapped})[0]
+    expected = orig_out[..., result.kept_token_ids]
+    np.testing.assert_allclose(pruned_out, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_tied_direct_gemm_matches_oracle():
+    # The other tied sub-shape: a direct Gemm(transB=1) reusing the
+    # embedding table as its own [vocab, hidden] weight, no Transpose node.
+    V, H = 9, 5
+    rng = np.random.default_rng(4)
+    w_emb = rng.standard_normal((V, H)).astype(np.float32)
+    model = _model(
+        f"""
+        g (int64[M] input_ids) => (float[M,{V}] logits)
+        {{
+          hidden = Gather<axis=0>(W_emb, input_ids)
+          logits = Gemm<transB=1>(hidden, W_emb)
+        }}
+        """,
+        initializer=[_f32(w_emb, "W_emb")],
+    )
+    onnx.checker.check_model(model)
+    assert len(model.graph.initializer) == 1
+
+    keep_token_ids = [0, 1, 3, 5, 6, 8]
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(model, drop_token_ids=[2, 4, 7])
+    onnx.checker.check_model(result.model)
+    assert result.matched and result.lm_head_pruned
+    assert result.kept_token_ids == keep_token_ids
+    assert len(result.model.graph.initializer) == 1
+
+    input_ids = np.array([0, 5, 8, 3], dtype=np.int64)
+    remapped = np.array([result.id_map[i] for i in input_ids], dtype=np.int64)
+    orig_out = _run(model, {"input_ids": input_ids})[0]
+    pruned_out = _run(result.model, {"input_ids": remapped})[0]
+    expected = orig_out[..., result.kept_token_ids]
+    np.testing.assert_allclose(pruned_out, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_cast_hop_indices_still_matched():
+    V, H = 8, 4
+    rng = np.random.default_rng(5)
+    w_emb = rng.standard_normal((V, H)).astype(np.float32)
+    model = _model(
+        f"""
+        g (int32[M] input_ids) => (float[M,{H}] hidden)
+        {{
+          ids64 = Cast<to=7>(input_ids)
+          hidden = Gather<axis=0>(W_emb, ids64)
+        }}
+        """,
+        initializer=[_f32(w_emb, "W_emb")],
+    )
+    onnx.checker.check_model(model)
+
+    keep_token_ids = [0, 2, 3, 5, 7]
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(
+        model, keep_token_ids=keep_token_ids
+    )
+    onnx.checker.check_model(result.model)
+    assert result.matched
+    assert not result.lm_head_pruned
+
+    input_ids = np.array([0, 5, 2, 7], dtype=np.int32)
+    remapped = np.array([result.id_map[i] for i in input_ids], dtype=np.int32)
+    orig_out = _run(model, {"input_ids": input_ids})[0]
+    pruned_out = _run(result.model, {"input_ids": remapped})[0]
+    np.testing.assert_allclose(pruned_out, orig_out, atol=1e-6, rtol=1e-6)
+
+
+# --- input_name auto-detection / ambiguity ----------------------------------
+
+
+def test_declines_when_gather_is_ambiguous():
+    model = _ambiguous_embedding_model()
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(model, keep_token_ids=[0, 1, 2])
+    assert result.matched is False
+    assert result.kept_token_ids is None
+    assert result.id_map is None
+    assert result.model.SerializeToString() == model.SerializeToString()
+
+
+def test_input_name_disambiguates_correctly():
+    model = _ambiguous_embedding_model(V_tok=10, V_pos=6)
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(
+        model, drop_token_ids=[4, 5], input_name="input_ids"
+    )
+    assert result.matched
+    assert result.kept_token_ids == [0, 1, 2, 3, 6, 7, 8, 9]
+    # The positional-embedding table must be left completely untouched.
+    w_pos = {t.name: t for t in result.model.graph.initializer}["W_pos"]
+    assert list(w_pos.dims) == [6, 4]
+
+    py_result = onnxsim.apply_embedding_vocab_pruning(
+        model, drop_token_ids=[4, 5], input_name="input_ids"
+    )
+    assert py_result.kept_token_ids == result.kept_token_ids
+
+
+def test_input_name_auto_detected_when_unambiguous():
+    # A single eligible Gather -- input_name may be omitted entirely.
+    V, H = 8, 4
+    model = _untied_model(V, H, seed=9)
+    result_omitted = onnxsim.apply_embedding_vocab_pruning_cpp(
+        model, keep_token_ids=[0, 1, 2, 3]
+    )
+    result_named = onnxsim.apply_embedding_vocab_pruning_cpp(
+        model, keep_token_ids=[0, 1, 2, 3], input_name="input_ids"
+    )
+    assert result_omitted.matched and result_named.matched
+    assert result_omitted.kept_token_ids == result_named.kept_token_ids
+
+
+def test_unknown_input_name_raises():
+    model = _ambiguous_embedding_model()
+    with pytest.raises(ValueError, match="not_a_real_input"):
+        onnxsim.apply_embedding_vocab_pruning_cpp(
+            model, keep_token_ids=[0, 1], input_name="not_a_real_input"
+        )
+
+
+def test_declines_non_zero_gather_axis():
+    V, H, M = 10, 6, 3
+    rng = np.random.default_rng(7)
+    w_emb = rng.standard_normal((V, H)).astype(np.float32)
+    model = _model(
+        f"""
+        g (int64[{M}] input_ids) => (float[{V},{M}] out)
+        {{
+          out = Gather<axis=1>(W_emb, input_ids)
+        }}
+        """,
+        initializer=[_f32(w_emb, "W_emb")],
+    )
+    onnx.checker.check_model(model)
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(model, keep_token_ids=[0, 1])
+    assert result.matched is False
+    assert result.model.SerializeToString() == model.SerializeToString()
+
+
+def test_declines_unexpected_shared_consumer():
+    V, H, M = 10, 6, 3
+    rng = np.random.default_rng(8)
+    w_emb = rng.standard_normal((V, H)).astype(np.float32)
+    bias = rng.standard_normal((V, H)).astype(np.float32)
+    model = _model(
+        f"""
+        g (int64[{M}] input_ids) => (float[{M},{H}] hidden, float[{V},{H}] extra)
+        {{
+          hidden = Gather<axis=0>(W_emb, input_ids)
+          extra = Add(W_emb, Bias)
+        }}
+        """,
+        initializer=[_f32(w_emb, "W_emb"), _f32(bias, "Bias")],
+    )
+    onnx.checker.check_model(model)
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(model, keep_token_ids=[0, 1, 2])
+    assert result.matched is False
+    assert result.model.SerializeToString() == model.SerializeToString()
+
+
+def test_declines_when_no_embedding_pattern_exists():
+    model = _matmul_model(K=8, N=4)
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(model, keep_token_ids=[0])
+    assert result.matched is False
+    assert result.model.SerializeToString() == model.SerializeToString()
+
+
+# --- Argument validation ----------------------------------------------------
+
+
+def test_validates_keep_and_drop_arguments():
+    model = _untied_model(6, 3, seed=11)
+    with pytest.raises(ValueError):
+        onnxsim.apply_embedding_vocab_pruning_cpp(model)
+    with pytest.raises(ValueError):
+        onnxsim.apply_embedding_vocab_pruning_cpp(
+            model, keep_token_ids=[0], drop_token_ids=[1]
+        )
+
+
+def test_rejects_out_of_range_ids():
+    V = 6
+    model = _untied_model(V, 3, seed=12)
+    with pytest.raises(ValueError):
+        onnxsim.apply_embedding_vocab_pruning_cpp(model, keep_token_ids=[0, 100])
+    with pytest.raises(ValueError):
+        onnxsim.apply_embedding_vocab_pruning_cpp(model, drop_token_ids=[0, -1])
+    with pytest.raises(ValueError):
+        onnxsim.apply_embedding_vocab_pruning_cpp(model, drop_token_ids=list(range(V)))
+
+
+# --- Magnitude-based pruning -------------------------------------------------
+
+
+def test_magnitude_pruning_drops_lowest_norm_rows_and_protects():
+    V, H = 10, 4
+    w = np.full((V, H), 5.0, dtype=np.float32)
+    w[2] *= 0.001  # deliberately tiny-norm rows -- should be dropped first
+    w[7] *= 0.001
+    model = _model(
+        f"""
+        g (int64[M] input_ids) => (float[M,{H}] hidden)
+        {{
+          hidden = Gather<axis=0>(W_emb, input_ids)
+        }}
+        """,
+        initializer=[_f32(w, "W_emb")],
+    )
+    onnx.checker.check_model(model)
+
+    result = onnxsim.apply_embedding_vocab_magnitude_pruning_cpp(model, sparsity=0.3)
+    onnx.checker.check_model(result.model)
+    assert result.matched
+    assert not result.lm_head_pruned
+    assert len(result.kept_token_ids) == round(V * 0.7) == 7
+    assert 2 not in result.kept_token_ids
+    assert 7 not in result.kept_token_ids
+
+    protected = onnxsim.apply_embedding_vocab_magnitude_pruning_cpp(
+        model, sparsity=0.3, protect_token_ids=[2]
+    )
+    assert protected.matched
+    assert 2 in protected.kept_token_ids
+
+
+def test_magnitude_pruning_matches_independent_oracle_ranking():
+    # A strictly-decreasing per-row scale gives an unambiguous, hand-
+    # computable ranking -- the independent oracle here is a plain numpy
+    # L2-norm computation, not the pure-Python entry point (kept genuinely
+    # separate from the implementation under test).
+    V, H = 14, 6
+    rng = np.random.default_rng(13)
+    scale = np.linspace(3.0, 0.1, V)
+    w_emb = (rng.standard_normal((V, H)) * scale[:, None]).astype(np.float32)
+    model = _model(
+        f"""
+        g (int64[M] input_ids) => (float[M,{H}] hidden)
+        {{
+          hidden = Gather<axis=0>(W_emb, input_ids)
+        }}
+        """,
+        initializer=[_f32(w_emb, "W_emb")],
+    )
+    onnx.checker.check_model(model)
+
+    sparsity = 0.5
+    result = onnxsim.apply_embedding_vocab_magnitude_pruning_cpp(
+        model, sparsity=sparsity
+    )
+    assert result.matched
+
+    row_norm = np.linalg.norm(w_emb.astype(np.float64), axis=1)
+    keep_count = max(1, round(V * (1.0 - sparsity)))
+    expected_keep = sorted(np.argsort(-row_norm)[:keep_count].tolist())
+    assert result.kept_token_ids == expected_keep
+    assert len(result.kept_token_ids) == keep_count
+
+
+def test_magnitude_pruning_combines_lm_head_norm_when_untied():
+    V, H = 12, 8
+    rng = np.random.default_rng(12)
+    w_emb = (rng.standard_normal((V, H)) * np.linspace(2.0, 0.05, V)[:, None]).astype(
+        np.float32
+    )
+    w_lm = rng.standard_normal((H, V)).astype(np.float32)
+    model = _model(
+        f"""
+        g (int64[M] input_ids) => (float[M,{V}] logits)
+        {{
+          hidden = Gather<axis=0>(W_emb, input_ids)
+          logits = MatMul(hidden, W_lm)
+        }}
+        """,
+        initializer=[_f32(w_emb, "W_emb"), _f32(w_lm, "W_lm")],
+    )
+    onnx.checker.check_model(model)
+
+    result = onnxsim.apply_embedding_vocab_magnitude_pruning_cpp(model, sparsity=0.4)
+    onnx.checker.check_model(result.model)
+    assert result.matched and result.lm_head_pruned
+    assert len(result.kept_token_ids) == round(V * 0.6)
+    # Rows were scaled by a strictly decreasing factor -- the kept set must
+    # be exactly the lowest-index (highest-combined-norm) rows.
+    assert result.kept_token_ids == list(range(len(result.kept_token_ids)))
+
+    input_ids = np.array([0, 1, 2, 3], dtype=np.int64)
+    remapped = np.array([result.id_map[i] for i in input_ids], dtype=np.int64)
+    orig_out = _run(model, {"input_ids": input_ids})[0]
+    pruned_out = _run(result.model, {"input_ids": remapped})[0]
+    expected = orig_out[..., result.kept_token_ids]
+    np.testing.assert_allclose(pruned_out, expected, atol=1e-5, rtol=1e-5)
+
+    # Cross-check against the pure-Python entry point's own ranking.
+    py_result = onnxsim.apply_embedding_vocab_magnitude_pruning(model, sparsity=0.4)
+    assert py_result.kept_token_ids == result.kept_token_ids
+
+
+def test_magnitude_pruning_rejects_bad_sparsity():
+    model = _matmul_model(K=4, N=4)
+    with pytest.raises(ValueError, match="sparsity"):
+        onnxsim.apply_embedding_vocab_magnitude_pruning_cpp(model, sparsity=1.0)
+
+
+def test_magnitude_pruning_declines_when_no_embedding_pattern_exists():
+    model = _matmul_model(K=8, N=4)
+    result = onnxsim.apply_embedding_vocab_magnitude_pruning_cpp(model, sparsity=0.3)
+    assert result.matched is False
+    assert result.model.SerializeToString() == model.SerializeToString()

--- a/tests/test_structured_pruning_cpp.py
+++ b/tests/test_structured_pruning_cpp.py
@@ -7165,3 +7165,548 @@ def test_cpp_structured_pruning_matmul_bnb4_matches_python_reference_output():
     (y_py,) = _run(pruned_py, {"A": A})
     (y_cpp,) = _run(pruned_cpp, {"A": A})
     np.testing.assert_array_equal(y_py, y_cpp)
+
+
+# --- MatMulBlockQuantizedFp4Weight/MatMulBlockQuantizedFp8Weight -----------
+# --- (NVFP4/FP8 block-quantized weight) structured pruning ----------------
+#
+# Tests for the Fp8Weight/Fp4Weight plain chain families
+# (onnxsim/structured_pruning_entry.cpp's own "MatMulBlockQuantizedFp4Weight/
+# MatMulBlockQuantizedFp8Weight" section), mirroring tests/test_pruning.py's
+# own coverage for both ops (see that file's own `_fp8bw_*`/`_fp4bw_*`
+# helpers, independently re-implemented here rather than imported -- this
+# file's own established "no cross-import between test files" precedent).
+# Models are built via onnx.parser (per CLAUDE.md's convention); the packed
+# FLOAT8E4M3FN/uint8 `B`/scale-table initializers are attached
+# programmatically via onnx.numpy_helper.from_array afterward (CLAUDE.md's
+# documented exception -- these must be byte-exact, not spelled out as text
+# literals). Neither op has a real CPU kernel in this environment (see
+# onnxsim/pruning.py's own section comment for the empirical confirmation --
+# the same fact holds for this C++ port, which links the identical
+# onnxruntime), so every "oracle" test below uses the same decomposed-proxy-
+# topology methodology tests/test_pruning.py's own equivalent tests
+# establish: the pruned node's own packed tensors are dequantized BY HAND
+# (independently of onnxsim's own code) into a plain float32 weight, wired
+# into an equivalent plain Gemm/MatMul chain, and run through a REAL CPU
+# onnxruntime.InferenceSession against an independently-computed numpy
+# oracle.
+
+
+def _fp8bq_quantize(w, block_size):
+    """Independent (onnxsim-code-free) per-block E4M3 quantizer for one
+    ``MatMulBlockQuantizedFp8Weight``-style ``[N, K]`` float weight -- scale
+    chosen as ``amax(block) / 6.0``, a plausible representation (there is no
+    real kernel/reference quantizer to match, see this section's own top
+    comment). Returns ``(b_f8 [N, K] ml_dtypes.float8_e4m3fn, b_scale
+    [N, K // block_size] float32, dequant [N, K] float64)``.
+    """
+    n, k = w.shape
+    kb = k // block_size
+    w_blocks = w.reshape(n, kb, block_size).astype(np.float64)
+    amax = np.maximum(np.abs(w_blocks).max(axis=-1), 1e-8)
+    scale = (amax / 6.0).astype(np.float32)
+    scale_expanded = np.repeat(scale.astype(np.float64), block_size, axis=-1)
+    b_f8 = (w_blocks / scale_expanded.reshape(n, kb, block_size)).astype(
+        ml_dtypes.float8_e4m3fn
+    )
+    dequant = b_f8.astype(np.float64) * scale_expanded.reshape(n, kb, block_size)
+    return b_f8.reshape(n, k), scale, dequant.reshape(n, k)
+
+
+def _fp8bq_dequantize(b_f8, scale, block_size):
+    """Independent dequantizer -- inverse of :func:`_fp8bq_quantize`'s own
+    formula, used to re-dequantize the PRUNED node's own surviving tensors
+    (never the pass's own dequantize code) for the decomposed-proxy oracle.
+    """
+    n, k = b_f8.shape
+    scale_expanded = np.repeat(scale.astype(np.float64), block_size, axis=-1)
+    return b_f8.astype(np.float64) * scale_expanded
+
+
+_FP4BQ_E2M1_LUT = np.array(
+    [
+        0.0,
+        0.5,
+        1.0,
+        1.5,
+        2.0,
+        3.0,
+        4.0,
+        6.0,
+        -0.0,
+        -0.5,
+        -1.0,
+        -1.5,
+        -2.0,
+        -3.0,
+        -4.0,
+        -6.0,
+    ],
+    dtype=np.float64,
+)
+
+
+def _fp4bq_e2m1_encode_nearest(values):
+    values = np.asarray(values, dtype=np.float64)
+    flat = values.reshape(-1)
+    codes = np.argmin(np.abs(_FP4BQ_E2M1_LUT[None, :] - flat[:, None]), axis=1)
+    return codes.reshape(values.shape).astype(np.uint8)
+
+
+def _fp4bq_e2m1_decode(codes):
+    return _FP4BQ_E2M1_LUT[np.asarray(codes).astype(np.int64)]
+
+
+def _fp4bq_unpack_nibbles(packed, count):
+    """Independent inverse of :func:`_nbits_pack_nibbles` (defined above, in
+    this same file's own "MatMulNBits" section -- reused here unchanged,
+    same low-nibble-first convention, not a cross-file import): 2 codes per
+    byte, LOW nibble first. Drops the last, padding, half-byte when `count`
+    is odd.
+    """
+    packed = np.asarray(packed)
+    lo = packed & 0x0F
+    hi = (packed >> 4) & 0x0F
+    interleaved = np.stack([lo, hi], axis=-1).reshape(*packed.shape[:-1], -1)
+    return interleaved[..., :count].astype(np.uint8)
+
+
+def _fp4bq_quantize(w, global_scale, block_size):
+    """Independent (onnxsim-code-free) NVFP4 quantizer for one
+    ``MatMulBlockQuantizedFp4Weight``-style ``[N, K]`` float weight --
+    per-`block_size` E2M1 magnitude/sign code plus a ``float8e4m3fn`` block
+    scale, combined with a caller-supplied scalar `global_scale`. Returns
+    ``(packed uint8 [N, K/2] -- 2 codes/byte, low nibble first, flat across
+    the whole K axis, weight_scale uint8 [N, k_blocks] -- raw E4M3 bytes,
+    dequant [N, K] float64)``. Reuses :func:`_nbits_pack_nibbles` (defined
+    above in this same file) for the packing -- identical convention to
+    `Fp4Weight`'s own live schema, per onnxsim/pruning.py's own section
+    comment.
+    """
+    n, k = w.shape
+    kb = k // block_size
+    w_blocks = w.reshape(n, kb, block_size).astype(np.float64)
+    amax = np.maximum(np.abs(w_blocks).max(axis=-1), 1e-12)
+    block_scale_f64 = amax / (6.0 * global_scale)  # 6.0 == E2M1's own max magnitude
+    block_scale_f8 = block_scale_f64.astype(ml_dtypes.float8_e4m3fn)
+    block_scale_rt = block_scale_f8.astype(np.float64)
+    codes = _fp4bq_e2m1_encode_nearest(
+        w_blocks / (block_scale_rt[..., None] * global_scale)
+    )
+    packed = _nbits_pack_nibbles(codes.reshape(n, k))
+    dequant = (
+        _fp4bq_e2m1_decode(codes) * block_scale_rt[..., None] * global_scale
+    ).reshape(n, k)
+    return packed, block_scale_f8.view(np.uint8), dequant
+
+
+def _fp8bq_chain_model(N1, K1, N2, block_size, W1, W2):
+    """Builds ``A -> MatMulBlockQuantizedFp8Weight(mm1) -> Relu ->
+    MatMulBlockQuantizedFp8Weight(mm2) -> Y``, both nodes real. Returns
+    ``(model, info)`` where `info` carries the independently-quantized
+    artifacts needed to hand-build an oracle.
+    """
+    b1, s1, dq1 = _fp8bq_quantize(W1, block_size)
+    b2, s2, dq2 = _fp8bq_quantize(W2, block_size)
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 21, "com.microsoft": 1]
+        >
+        g (float16[3,{K1}] A) => (float16[3,{N2}] Y)
+        {{
+          h1 = com.microsoft.MatMulBlockQuantizedFp8Weight <block_size={block_size}> (A, B1, S1)
+          h1a = Relu(h1)
+          Y = com.microsoft.MatMulBlockQuantizedFp8Weight <block_size={block_size}> (h1a, B2, S2)
+        }}
+        """
+    )
+    model.graph.initializer.extend(
+        [
+            onnx.numpy_helper.from_array(b1, name="B1"),
+            _f32(s1, "S1"),
+            onnx.numpy_helper.from_array(b2, name="B2"),
+            _f32(s2, "S2"),
+        ]
+    )
+    return model, dict(b1=b1, s1=s1, dequant1=dq1, b2=b2, s2=s2, dequant2=dq2)
+
+
+def test_cpp_structured_pruning_matmul_block_quantized_fp8_chain_matches_oracle():
+    # The core "slice, don't recompute" correctness invariant: the pruned
+    # graph's own B/b_scale tensors must equal a byte-exact hand-slice of
+    # the ORIGINAL quantized codes, and running an equivalent decomposed
+    # plain-float Gemm chain (built from the PRUNED tensors' own dequantized
+    # values) through a real CPU onnxruntime session matches an
+    # independently-computed numpy oracle.
+    N1, K1, N2, block_size = 16, 32, 8, 8
+    rng = np.random.default_rng(41001)
+    W1 = (rng.standard_normal((N1, K1)) * 0.2).astype(np.float32)
+    W1[:8] *= 6.0  # first half of rows clearly more important
+    W2 = (rng.standard_normal((N2, N1)) * 0.2).astype(np.float32)
+    model, info = _fp8bq_chain_model(N1, K1, N2, block_size, W1, W2)
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep = np.sort(np.argsort(-np.abs(info["dequant1"]).sum(axis=1))[:8])
+    assert list(keep) == list(range(8))  # engineered: rows 0-7 are important
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    b1p = onnx.numpy_helper.to_array(inits["B1"])
+    s1p = onnx.numpy_helper.to_array(inits["S1"])
+    b2p = onnx.numpy_helper.to_array(inits["B2"])
+    assert b1p.shape == (8, K1)
+    assert s1p.shape == (8, K1 // block_size)
+    assert b2p.shape == (N2, 8)
+
+    np.testing.assert_array_equal(b1p.view(np.uint8), info["b1"].view(np.uint8)[keep])
+    np.testing.assert_array_equal(s1p, info["s1"][keep])
+    np.testing.assert_array_equal(
+        b2p.view(np.uint8), info["b2"].view(np.uint8)[:, keep]
+    )
+
+    proxy_graph = onnx.helper.make_graph(
+        [
+            onnx.helper.make_node("Gemm", ["A", "W1f"], ["T"], transB=1),
+            onnx.helper.make_node("Relu", ["T"], ["Ta"]),
+            onnx.helper.make_node("Gemm", ["Ta", "W2f"], ["Y"], transB=1),
+        ],
+        "g",
+        [onnx.helper.make_tensor_value_info("A", onnx.TensorProto.FLOAT, [3, K1])],
+        [onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [3, N2])],
+        initializer=[
+            _f32(info["dequant1"][keep].astype(np.float32), "W1f"),
+            _f32(info["dequant2"][:, keep].astype(np.float32), "W2f"),
+        ],
+    )
+    proxy_model = onnx.helper.make_model(
+        proxy_graph, opset_imports=[onnx.helper.make_opsetid("", 21)]
+    )
+    proxy_model.ir_version = 10
+    onnx.checker.check_model(proxy_model)
+
+    a = rng.standard_normal((3, K1)).astype(np.float32)
+    sess = ort.InferenceSession(
+        proxy_model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    (y,) = sess.run(None, {"A": a})
+    oracle = (
+        np.maximum(a.astype(np.float64) @ info["dequant1"][keep].T, 0.0)
+        @ info["dequant2"][:, keep].T
+    )
+    np.testing.assert_allclose(y.astype(np.float64), oracle, rtol=1e-3, atol=1e-3)
+
+
+def test_cpp_structured_pruning_matmul_block_quantized_fp8_declines_non_block_aligned():
+    # block_size=8, sparsity=0.25 -> keep_count=12, not a multiple of 8 --
+    # the consumer's own scale table can't represent a partial block, so the
+    # whole chain must be left byte-for-byte unchanged.
+    N1, K1, N2, block_size = 16, 32, 8, 8
+    rng = np.random.default_rng(41010)
+    W1 = (rng.standard_normal((N1, K1)) * 0.3).astype(np.float32)
+    W2 = (rng.standard_normal((N2, N1)) * 0.3).astype(np.float32)
+    model, _info = _fp8bq_chain_model(N1, K1, N2, block_size, W1, W2)
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.25)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_structured_pruning_matmul_block_quantized_fp8_declines_shared_weight():
+    # B1/S1 read by both the plain chain's own producer node AND an extra
+    # node -- slicing them for the chain would silently corrupt that extra
+    # reader, so the whole model must be left untouched.
+    N1, K1, N2, block_size = 16, 32, 8, 8
+    rng = np.random.default_rng(41020)
+    W1 = (rng.standard_normal((N1, K1)) * 0.3).astype(np.float32)
+    W2 = (rng.standard_normal((N2, N1)) * 0.3).astype(np.float32)
+    model, _info = _fp8bq_chain_model(N1, K1, N2, block_size, W1, W2)
+
+    extra = onnx.helper.make_node(
+        "MatMulBlockQuantizedFp8Weight",
+        inputs=["A", "B1", "S1"],
+        outputs=["Y2"],
+        domain="com.microsoft",
+        name="mm_extra",
+        block_size=block_size,
+    )
+    model.graph.node.append(extra)
+    model.graph.output.append(
+        onnx.helper.make_tensor_value_info("Y2", onnx.TensorProto.FLOAT16, [3, N1])
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_structured_pruning_matmul_block_quantized_fp8_matches_python_reference():
+    N1, K1, N2, block_size = 16, 32, 8, 8
+    rng = np.random.default_rng(41030)
+    W1 = (rng.standard_normal((N1, K1)) * 0.2).astype(np.float32)
+    W1[:8] *= 6.0
+    W2 = (rng.standard_normal((N2, N1)) * 0.2).astype(np.float32)
+    model, _info = _fp8bq_chain_model(N1, K1, N2, block_size, W1, W2)
+    onnx.checker.check_model(model)
+
+    pruned_py = onnxsim.apply_structured_pruning_matmul_block_quantized_fp8(
+        model, sparsity=0.5
+    )
+    pruned_cpp = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_py)
+    onnx.checker.check_model(pruned_cpp)
+
+    py_bytes = {t.name: t.SerializeToString() for t in pruned_py.graph.initializer}
+    cpp_bytes = {t.name: t.SerializeToString() for t in pruned_cpp.graph.initializer}
+    assert py_bytes == cpp_bytes
+
+
+def _fp4bq_chain_model(N1, K1, N2, block_size, W1, gs1, W2, gs2):
+    """``Fp4Weight`` analogue of :func:`_fp8bq_chain_model`."""
+    p1, ws1, dq1 = _fp4bq_quantize(W1, gs1, block_size)
+    p2, ws2, dq2 = _fp4bq_quantize(W2, gs2, block_size)
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 21, "com.microsoft": 1]
+        >
+        g (float16[3,{K1}] A) => (float16[3,{N2}] Y)
+        {{
+          h1 = com.microsoft.MatMulBlockQuantizedFp4Weight <block_size={block_size}> (A, B1, WS1, WS21)
+          h1a = Relu(h1)
+          Y = com.microsoft.MatMulBlockQuantizedFp4Weight <block_size={block_size}> (h1a, B2, WS2, WS22)
+        }}
+        """
+    )
+    model.graph.initializer.extend(
+        [
+            onnx.numpy_helper.from_array(p1, name="B1"),
+            onnx.numpy_helper.from_array(ws1, name="WS1"),
+            _f32(np.array([gs1], dtype=np.float32), "WS21"),
+            onnx.numpy_helper.from_array(p2, name="B2"),
+            onnx.numpy_helper.from_array(ws2, name="WS2"),
+            _f32(np.array([gs2], dtype=np.float32), "WS22"),
+        ]
+    )
+    return model, dict(p1=p1, ws1=ws1, dequant1=dq1, p2=p2, ws2=ws2, dequant2=dq2)
+
+
+def test_cpp_structured_pruning_matmul_block_quantized_fp4_chain_matches_oracle():
+    # Same "slice, don't recompute" invariant as the Fp8Weight test above --
+    # here the byte-identity check on B needs an unpack/repack (Fp4Weight's
+    # own flat, whole-row nibble packing, not block-relative like
+    # MatMulNBits's), which this test checks explicitly.
+    N1, K1, N2, block_size = 16, 32, 8, 8
+    rng = np.random.default_rng(41101)
+    W1 = (rng.standard_normal((N1, K1)) * 1.0).astype(np.float32)
+    W1[:8] *= 6.0
+    W2 = (rng.standard_normal((N2, N1)) * 1.0).astype(np.float32)
+    model, info = _fp4bq_chain_model(N1, K1, N2, block_size, W1, 1.0, W2, 1.0)
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep = np.sort(np.argsort(-np.abs(info["dequant1"]).sum(axis=1))[:8])
+    assert list(keep) == list(range(8))
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    b1p = onnx.numpy_helper.to_array(inits["B1"])
+    ws1p = onnx.numpy_helper.to_array(inits["WS1"])
+    b2p = onnx.numpy_helper.to_array(inits["B2"])
+    assert b1p.shape == (8, K1 // 2)
+    assert ws1p.shape == (8, K1 // block_size)
+    assert b2p.shape == (N2, 8 // 2)  # K axis co-pruned: 8 kept K-values -> 4 bytes
+
+    # B1 (producer role) is a plain whole-row byte slice -- no unpack needed.
+    np.testing.assert_array_equal(b1p, info["p1"][keep])
+    np.testing.assert_array_equal(ws1p, info["ws1"][keep])
+
+    # B2's own kept COLUMNS need an unpack/repack (flat-across-K packing).
+    orig_codes2 = _fp4bq_unpack_nibbles(info["p2"], N1)
+    expect_b2 = _nbits_pack_nibbles(orig_codes2[:, keep])
+    np.testing.assert_array_equal(b2p, expect_b2)
+
+    proxy_graph = onnx.helper.make_graph(
+        [
+            onnx.helper.make_node("Gemm", ["A", "W1f"], ["T"], transB=1),
+            onnx.helper.make_node("Relu", ["T"], ["Ta"]),
+            onnx.helper.make_node("Gemm", ["Ta", "W2f"], ["Y"], transB=1),
+        ],
+        "g",
+        [onnx.helper.make_tensor_value_info("A", onnx.TensorProto.FLOAT, [3, K1])],
+        [onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [3, N2])],
+        initializer=[
+            _f32(info["dequant1"][keep].astype(np.float32), "W1f"),
+            _f32(info["dequant2"][:, keep].astype(np.float32), "W2f"),
+        ],
+    )
+    proxy_model = onnx.helper.make_model(
+        proxy_graph, opset_imports=[onnx.helper.make_opsetid("", 21)]
+    )
+    proxy_model.ir_version = 10
+    onnx.checker.check_model(proxy_model)
+
+    a = rng.standard_normal((3, K1)).astype(np.float32)
+    sess = ort.InferenceSession(
+        proxy_model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    (y,) = sess.run(None, {"A": a})
+    oracle = (
+        np.maximum(a.astype(np.float64) @ info["dequant1"][keep].T, 0.0)
+        @ info["dequant2"][:, keep].T
+    )
+    np.testing.assert_allclose(y.astype(np.float64), oracle, rtol=1e-3, atol=1e-3)
+
+
+def test_cpp_structured_pruning_matmul_block_quantized_fp4_declines_non_block_aligned():
+    N1, K1, N2, block_size = 16, 32, 8, 8
+    rng = np.random.default_rng(41110)
+    W1 = (rng.standard_normal((N1, K1)) * 1.0).astype(np.float32)
+    W2 = (rng.standard_normal((N2, N1)) * 1.0).astype(np.float32)
+    model, _info = _fp4bq_chain_model(N1, K1, N2, block_size, W1, 1.0, W2, 1.0)
+    onnx.checker.check_model(model)
+
+    # sparsity=0.25 -> keep_count=12, not a multiple of block_size=8.
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.25)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_structured_pruning_matmul_block_quantized_fp4_declines_odd_resulting_k():
+    # block_size=3 (odd), N1=12 -> k_blocks=4. Engineered so the top-9-by-
+    # importance keep-set is EXACTLY channels {0..8} -- blocks {0, 1, 2}
+    # fully kept, block 3 fully dropped: perfectly block-aligned by the
+    # SHARED (MatMulNBits-style) check, but the resulting K (9) is odd,
+    # which Fp4Weight's own flat (non-block-relative) nibble packing cannot
+    # honestly represent (the live schema derives K as exactly
+    # 2 * B.shape[1]) -- declined on top of the shared check, per this
+    # section's own top comment.
+    N1, K1, N2, block_size = 12, 15, 4, 3  # K1=15 divisible by block_size=3 too
+    rng = np.random.default_rng(41120)
+    W1 = (rng.standard_normal((N1, K1)) * 0.2).astype(np.float32)
+    W1[:9] *= 6.0  # channels 0-8 important, 9-11 unimportant
+    W2 = (rng.standard_normal((N2, N1)) * 0.2).astype(np.float32)
+    model, info = _fp4bq_chain_model(N1, K1, N2, block_size, W1, 1.0, W2, 1.0)
+    onnx.checker.check_model(model)
+
+    keep = np.sort(np.argsort(-np.abs(info["dequant1"]).sum(axis=1))[:9])
+    assert list(keep) == list(range(9))  # exactly blocks {0, 1, 2} of block_size=3
+
+    # sparsity=0.25 -> keep_count = 12 - round(12*0.25) = 9.
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.25)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_structured_pruning_matmul_block_quantized_fp4_declines_shared_weight():
+    N1, K1, N2, block_size = 16, 32, 8, 8
+    rng = np.random.default_rng(41130)
+    W1 = (rng.standard_normal((N1, K1)) * 1.0).astype(np.float32)
+    W2 = (rng.standard_normal((N2, N1)) * 1.0).astype(np.float32)
+    model, _info = _fp4bq_chain_model(N1, K1, N2, block_size, W1, 1.0, W2, 1.0)
+
+    extra = onnx.helper.make_node(
+        "MatMulBlockQuantizedFp4Weight",
+        inputs=["A", "B1", "WS1", "WS21"],
+        outputs=["Y2"],
+        domain="com.microsoft",
+        name="mm_extra",
+        block_size=block_size,
+    )
+    model.graph.node.append(extra)
+    model.graph.output.append(
+        onnx.helper.make_tensor_value_info("Y2", onnx.TensorProto.FLOAT16, [3, N1])
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_structured_pruning_matmul_block_quantized_fp4_mixed_plain_float_producer_matches_oracle():
+    # A plain-float (directly-constant weight) MatMul producer feeding a
+    # quantized Fp4Weight consumer -- the "unquantized embedding feeding the
+    # first quantized block" export shape this section's own top comment
+    # motivates (MatchPlainMatMulNBitsPeer, reused unchanged from the
+    # MatMulNBits section). The plain-float peer side of THIS C++ port only
+    # ever recognizes a FLOAT32 weight (see the MatMulNBits section's own
+    # top comment for why), so A/W1 are declared FLOAT32 here -- the
+    # quantized consumer's own `A` input dtype is never actually inspected
+    # by the matcher (see this section's own top comment), so this is not a
+    # scope violation of the live schema, just this test's own choice of a
+    # graph that both the plain MatMul op (real ai.onnx schema, dtype-
+    # checked by onnx.checker) and the quantized consumer accept.
+    N1, K1, N2, block_size = 16, 32, 8, 8
+    rng = np.random.default_rng(41140)
+    W1 = (rng.standard_normal((K1, N1)) * 0.3).astype(
+        np.float32
+    )  # [K, N], untransposed
+    W1[:, :8] *= 6.0  # first half of N1 (producer's own output axis) important
+    W2 = (rng.standard_normal((N2, N1)) * 1.0).astype(np.float32)
+    p2, ws2, dq2 = _fp4bq_quantize(W2, 1.0, block_size)
+
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 21, "com.microsoft": 1]
+        >
+        g (float[3,{K1}] A) => (float16[3,{N2}] Y)
+        {{
+          T = MatMul(A, W1)
+          Y = com.microsoft.MatMulBlockQuantizedFp4Weight <block_size={block_size}> (T, B2, WS2, WS22)
+        }}
+        """
+    )
+    model.graph.initializer.extend(
+        [
+            _f32(W1, "W1"),
+            onnx.numpy_helper.from_array(p2, name="B2"),
+            onnx.numpy_helper.from_array(ws2, name="WS2"),
+            _f32(np.array([1.0], dtype=np.float32), "WS22"),
+        ]
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    w1p = onnx.numpy_helper.to_array(inits["W1"])
+    b2p = onnx.numpy_helper.to_array(inits["B2"])
+    assert w1p.shape == (K1, 8)  # plain-float producer sliced on axis 1 (col)
+    assert b2p.shape == (N2, 4)  # consumer's own K axis co-pruned (8/2 nibbles)
+
+    keep = np.sort(np.argsort(-np.linalg.norm(W1.astype(np.float64), axis=0))[:8])
+    assert list(keep) == list(range(8))
+    np.testing.assert_array_equal(
+        w1p.astype(np.float64), W1.astype(np.float64)[:, keep]
+    )
+
+    orig_codes2 = _fp4bq_unpack_nibbles(p2, N1)
+    expect_b2 = _nbits_pack_nibbles(orig_codes2[:, keep])
+    np.testing.assert_array_equal(b2p, expect_b2)
+
+
+def test_cpp_structured_pruning_matmul_block_quantized_fp4_matches_python_reference():
+    N1, K1, N2, block_size = 16, 32, 8, 8
+    rng = np.random.default_rng(41150)
+    W1 = (rng.standard_normal((N1, K1)) * 1.0).astype(np.float32)
+    W1[:8] *= 6.0
+    W2 = (rng.standard_normal((N2, N1)) * 1.0).astype(np.float32)
+    model, _info = _fp4bq_chain_model(N1, K1, N2, block_size, W1, 1.0, W2, 1.0)
+    onnx.checker.check_model(model)
+
+    pruned_py = onnxsim.apply_structured_pruning_matmul_block_quantized_fp4(
+        model, sparsity=0.5
+    )
+    pruned_cpp = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_py)
+    onnx.checker.check_model(pruned_cpp)
+
+    py_bytes = {t.name: t.SerializeToString() for t in pruned_py.graph.initializer}
+    cpp_bytes = {t.name: t.SerializeToString() for t in pruned_cpp.graph.initializer}
+    assert py_bytes == cpp_bytes


### PR DESCRIPTION
## Summary

Seventh round continuing the Python → C++ parity effort (see #1027, #1031, #1034, #1044, #1049, #1051). Ports two more subsystems:

- **Embedding vocabulary pruning** — a structurally different kind of pruning from every prior round: drops rows from an embedding table's *vocabulary* axis (with an optional tied/untied `lm_head` output projection co-pruned) rather than a producer/consumer *feature-channel* pair. Two new entry points, `apply_embedding_vocab_pruning_cpp` (explicit `keep_token_ids`/`drop_token_ids`) and `apply_embedding_vocab_magnitude_pruning_cpp` (`sparsity`-driven, L2-row-norm ranked, with `protect_token_ids`). Since the result changes what counts as a valid model input (remapped token ids), the C++ binding returns `(model_bytes, matched, kept_token_ids, lm_head_pruned)`, reconstructed on the Python side into the existing `onnxsim.pruning.EmbeddingPruningResult` dataclass rather than inventing a new one.
- **FP4/FP8 block-quantized structured pruning** — `MatMulBlockQuantizedFp8Weight` (FLOAT8E4M3FN) and `MatMulBlockQuantizedFp4Weight` (packed NVFP4/E2M1) chains, plain producer→consumer topology only (no gated/fused variants exist for these ops yet). Reuses the E4M3/E2M1 decode tables and nibble-packing helpers already added for the QMoE port. Folded into the existing `ApplyStructuredPruning` dispatcher, matching how MatMulNBits/MatMulBnb4/QDQ were each wired in.

## Testing

- `pip install --no-build-isolation -ve .`
- `python3 -m pytest -v tests/test_structured_pruning_cpp.py tests/test_attention_head_pruning_cpp.py tests/test_pruning_cpp.py tests/test_moe_pruning_cpp.py tests/test_qmoe_pruning_cpp.py tests/test_embedding_vocab_pruning_cpp.py` — **261 passed, 0 failed**, including all pre-existing coverage from every prior round (no regressions)
- `clang-format --dry-run --Werror` / `ruff format --check` / `ruff check` / `mypy` all clean

## Scope / follow-up

Remaining data-free gaps: `apply_structured_pruning_qoperator` (QLinearConv/QLinearMatMul-quantized structured pruning) and `apply_structured_pruning_dynamic_quantize_matmul` (DynamicQuantizeLinear-based). Everything calibration-driven (Wanda, SparseGPT, transformer-block pruning, MoE/QMoE whole-expert pruning) remains explicitly out of scope — those need a live `onnxruntime.InferenceSession`, and this C++ port has no ONNX Runtime linked into it at all (the wheel build never builds ORT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4t6ntCm72RfFf64W9GYB1

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4t6ntCm72RfFf64W9GYB1)_