### PR TITLE
Port QOperator and DynamicQuantizeMatMul structured pruning to C++

### DIFF
--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -14208,6 +14208,887 @@ void ApplyFp4BlockQuantizedChains(onnx::GraphProto* graph,
   }
 }
 
+// --- QOperator (QLinearConv/QLinearMatMul/QGemm static-quantization)
+// --- structured pruning, mirroring pruning.py's own "QOperator
+// --- (QLinearConv/QLinearMatMul/QGemm static-quantization) structured
+// --- pruning" section (_QOpWeight through apply_structured_pruning_qoperator)
+//
+// A `QLinearConv`/`QLinearMatMul`/`com.microsoft::QGemm` node -- ONNX
+// Runtime's "QOperator" static-quantization format, the alternative to the
+// QDQ pattern the section above already handles -- takes/produces its own
+// quantized tensors directly, with its own `_scale`/`_zero_point` operand
+// pairs baked into the op's own input list, rather than a separate
+// `DequantizeLinear` node wrapping a plain op. Unlike the QDQ section, this
+// section needs no `DequantizeLinear`-walking resolution step at all: each
+// op's own dedicated `MatchQLinearConv`/`MatchQLinearMatMul`/`MatchQGemm`
+// unpacks its own input list directly into one shared `QOpWeightMatch`
+// shape (an `op_kind` discriminant rather than three separate structs,
+// mirroring pruning.py's own identical `_QOpWeight`/`op_kind` choice --
+// these three ops' pruning-relevant operands, a quantized weight, its own
+// scale/zero-point, an optional INT32 bias, are structurally identical once
+// each op's own input list is unpacked).
+//
+// Producer-role (output-channel, `N`-axis) pruning slices `w`'s own int8/
+// uint8 codes along `N` (axis 0 for `QLinearConv`, axis 1 or 0 for
+// `QLinearMatMul`/`QGemm` depending on `QGemm`'s own `transB` --
+// `QdqWeightAxis(/*producer_role=*/true, ...)`, reused directly: the QDQ
+// section's own per-tensor/per-channel axis convention is identical here,
+// there being no ConvTranspose-equivalent reversed layout for any of these
+// three ops). A per-channel `w_scale`/`w_zero_point` (rank-1, length `N`) is
+// co-sliced by the SAME `keep` set, in lockstep -- exactly the QDQ section's
+// own per-channel producer-role principle, reusing `SliceLastAxis`/
+// `ReadQuantCodes`/`SetQuantCodes`/`SliceAlongAxis` unchanged. A per-TENSOR
+// (scalar) `w_scale`/`w_zero_point` is left completely untouched -- not
+// shaped by channel count. `bias` (`QLinearConv`'s optional `B`, `QGemm`'s
+// optional `C`; `QLinearMatMul` has none at all), when present and not a
+// broadcasting scalar, is co-sliced identically -- its own values already
+// encode whatever per-channel scale the schema's own bias-quantization
+// formula describes, so this never recomputes it, only relocates existing
+// INT32 entries (`SliceLastAxisInt32`, the INT32 analogue of
+// `SliceLastAxis` this section needs since neither the QDQ section nor
+// anything else in this file has an INT32-dtype bias to slice before now).
+// A `C` given as a broadcasting SCALAR (rank 0 or `[1]`, `QGemm`'s own doc
+// explicitly allows this) is never sliced, mirroring the per-tensor-scale
+// reasoning above; any OTHER `C` shape is declined outright by the matcher.
+//
+// Consumer-role (reduction/input-channel, `K`-axis) pruning slices only
+// `w`'s own codes along `K` (`QdqWeightAxis(/*producer_role=*/false, ...)`)
+// -- `w_scale`/`w_zero_point`/bias are never indexed by `K` in any of the
+// three live schemas, so the consumer role touches nothing else at all,
+// simpler even than the QDQ section's own consumer role (no blockwise
+// granularity ever arises here -- nothing in any of the three schemas
+// describes a blocked/`block_size` quantization grain for any of these ops).
+//
+// Chain-finding (`FindQopChains`/`WalkToQopConsumer`) mirrors the QDQ
+// section's own `FindQdqChains`/`WalkToConsumerQdq` closely: a single
+// producer's output feeds, through zero or more shape-preserving unary
+// activations (`UnaryPassThroughOps`) with no other consumer anywhere along
+// that path, into exactly one downstream SAME-FAMILY node (`QLinearConv`
+// only pairs with `QLinearConv`; `QLinearMatMul`/`QGemm` only pair with
+// `QLinearMatMul`/`QGemm`, either combination) whose own `K` matches the
+// producer's own `N`. A `QLinearConv` producer feeding a `QLinearMatMul`/
+// `QGemm` consumer through a `Flatten`/`Reshape` reinterpretation (the real
+// shape a Conv-backbone classifier head takes) is a REAL, confirmed gap,
+// not an oversight -- see pruning.py's own section comment for the full
+// empirical round-trip this inherits verbatim; neither walker recognizes a
+// `Flatten`/`Reshape` hop at all. Unlike the QDQ section, no gated
+// (SwiGLU/GeGLU) pair is matched here either -- a genuine, deliberately
+// left-out follow-up, mirrored from pruning.py's own identical scope
+// boundary for this section.
+//
+// What's declined, deliberately, rather than guessed at (mirroring every
+// matcher elsewhere in this file, and pruning.py's own section comment):
+//
+//   * A non-constant `w`/`w_scale`/`w_zero_point`/bias, or any of the
+//     operands this section actually slices (`w`, `w_scale`/`w_zero_point`
+//     when per-channel, and a non-scalar bias) read by more than one node
+//     (a shared/tied tensor -- slicing it here would silently corrupt
+//     whatever else reads it). `x_scale`/`x_zero_point`/`y_scale`/
+//     `y_zero_point`/`a_scale`/`a_zero_point` are NEVER touched by either
+//     role, so a legitimately shared/reused activation scale across many
+//     quantized layers -- the realistic, common shape a real chain takes,
+//     since a producer's own `y_scale`/`y_zero_point` typically ARE the
+//     very same initializers its consumer's `x_scale`/`x_zero_point`/
+//     `a_scale`/`a_zero_point` read -- is never needlessly blocked.
+//   * A non-scalar `x_scale`/`x_zero_point`/`a_scale`/`a_zero_point`/
+//     `y_scale`/`y_zero_point` -- every live schema technically permits a
+//     wider activation-quantization granularity, but no real exporter this
+//     investigation found ever emits one; declined outright rather than
+//     built and verified against nothing.
+//   * A general grouped or depthwise `QLinearConv` (`group != 1`). No
+//     `QLinearConvTranspose` op exists in `ai.onnx` at all, so unlike the
+//     QDQ section's own Conv/ConvTranspose pairing, there is only ever one
+//     Conv-family QOperator op to match in the first place.
+//   * A `QGemm` with `transA != 0` or `alpha != 1.0` -- mirroring
+//     `MatchMatMulLikeRaw`'s own identical `transA`/`alpha`/`beta`
+//     restriction for plain `Gemm`.
+//   * A weight rank other than 4 for `QLinearConv` (2-D spatial Conv only)
+//     or other than 2 for `QLinearMatMul`/`QGemm` -- mirroring the QDQ
+//     section's own identical rank restriction.
+//   * Any residual/skip-connection merge, `Concat`-merged branch group, or
+//     gated (SwiGLU/GeGLU) pair -- only the plain single-producer/single-
+//     consumer/unary-hops-only topology above is matched.
+//   * Mixing a QOperator node with a QDQ-fed, plain-float, or
+//     `MatMulNBits`/block-quantized Fp4/Fp8 node on EITHER side of a chain
+//     -- every one of those is a genuinely different quantization scheme
+//     this investigation did not confirm composes safely, so a QOperator
+//     node feeding, or fed by, any of those is simply never matched as
+//     either role here (its own producer/consumer search only ever tries
+//     the other two QOperator ops).
+//
+// This entire section is a genuinely separate match: `QLinearConv`/
+// `QLinearMatMul`/`QGemm` are node types no other Find*Chains call in this
+// file's `ApplyStructuredPruning` recognizes at all, so `FindQopChains`
+// below can never double-match a tensor any other pass already claimed --
+// but it still shares this graph's own single `TouchedState` with every
+// other Apply* call, for the same "one shared conflict ledger per graph"
+// reason every other quantized-weight pass here already does.
+
+// --- INT32 tensor <-> flat buffer, the INT32 analogue of ReadFloatTensor/
+// SetFloatTensorData/SliceLastAxis -- needed only for QLinearConv's/
+// QGemm's own optional INT32 per-channel bias (`B`/`C`): "slice, don't
+// requantize" applies to it exactly as it does to the int8/uint8 weight
+// codes above -- its own values already encode whatever per-channel scale
+// the schema's own bias-quantization formula describes, so this never
+// recomputes them, only relocates existing entries. No other section in
+// this file has an INT32-dtype tensor to slice before now.
+std::vector<int32_t> ReadInt32Tensor(const onnx::TensorProto& t) {
+  int64_t numel = 1;
+  for (int64_t d : t.dims()) {
+    numel *= d;
+  }
+  std::vector<int32_t> out(static_cast<size_t>(numel));
+  if (t.has_raw_data()) {
+    std::memcpy(out.data(), t.raw_data().data(), out.size() * sizeof(int32_t));
+    if constexpr (!onnxsim::dlpack::kRawDataIsHostOrder) {
+      onnxsim::dlpack::SwapElementBytes(reinterpret_cast<uint8_t*>(out.data()),
+                                        out.size() * sizeof(int32_t),
+                                        sizeof(int32_t));
+    }
+  } else {
+    for (int64_t i = 0; i < numel; ++i) {
+      out[static_cast<size_t>(i)] = t.int32_data(static_cast<int>(i));
+    }
+  }
+  return out;
+}
+
+void SetInt32TensorData(onnx::TensorProto* t, const std::vector<int64_t>& dims,
+                        const std::vector<int32_t>& data) {
+  const std::string name = t->name();
+  t->Clear();
+  t->set_name(name);
+  t->set_data_type(onnx::TensorProto::INT32);
+  for (int64_t d : dims) {
+    t->add_dims(d);
+  }
+  std::string raw(data.size() * sizeof(int32_t), '\0');
+  std::memcpy(raw.data(), data.data(), raw.size());
+  if constexpr (!onnxsim::dlpack::kRawDataIsHostOrder) {
+    onnxsim::dlpack::SwapElementBytes(reinterpret_cast<uint8_t*>(raw.data()),
+                                      raw.size(), sizeof(int32_t));
+  }
+  t->set_raw_data(std::move(raw));
+}
+
+void SliceLastAxisInt32(onnx::TensorProto* t,
+                        const std::vector<int64_t>& keep) {
+  std::vector<int64_t> dims(t->dims().begin(), t->dims().end());
+  std::vector<int32_t> data = ReadInt32Tensor(*t);
+  std::vector<int32_t> out(keep.size());
+  for (size_t i = 0; i < keep.size(); ++i) {
+    out[i] = data[static_cast<size_t>(keep[i])];
+  }
+  std::vector<int64_t> new_dims = dims;
+  if (new_dims.empty()) {
+    new_dims.push_back(static_cast<int64_t>(keep.size()));
+  } else {
+    new_dims.back() = static_cast<int64_t>(keep.size());
+  }
+  SetInt32TensorData(t, new_dims, out);
+}
+
+// --- Matching, mirroring _QOpWeight/_match_qlinearconv/_match_qlinearmatmul/
+// _match_qgemm -----------------------------------------------------------
+
+enum class QOpKind { kConv, kMatMul, kGemm };
+
+// A matched QLinearConv/QLinearMatMul/QGemm node's own sliceable operands --
+// see this section's own top comment. `w_name` is QLinearConv's `w`,
+// QLinearMatMul's `b`, or QGemm's `B` -- the quantized weight, always INT8/
+// UINT8. `w_scale_name`/`w_zero_point_name` are its paired scale/zero-point
+// (always the same shape as each other: scalar when `per_channel` is
+// false, 1-D length `N` otherwise). `bias_name` is QLinearConv's optional
+// `B` or QGemm's optional `C` (always INT32, nullopt for QLinearMatMul --
+// which has no bias input at all -- or when genuinely absent);
+// `bias_is_scalar` is true only for a QGemm `C` given as a broadcasting
+// scalar (never sliced). `weight_transposed` is QGemm's own `transB`
+// (always false for QLinearConv/QLinearMatMul).
+struct QOpWeightMatch {
+  QOpKind op_kind;
+  std::string w_name;
+  std::string w_scale_name;
+  std::string w_zero_point_name;
+  std::optional<std::string> bias_name;
+  bool bias_is_scalar;
+  bool weight_transposed;
+  bool per_channel;
+  int64_t N;
+  int64_t K;
+};
+
+// True for a 0-D ([]) or single-element 1-D ([1]) shape -- the two ways a
+// per-tensor activation scale/zero-point might reasonably be exported.
+bool QopScalarDimsOk(const onnx::TensorProto& t) {
+  return t.dims_size() == 0 || (t.dims_size() == 1 && t.dims(0) == 1);
+}
+
+// Checks a weight's own (scale, zero_point) pair against the live schemas'
+// shared "scalar (per-tensor) or 1-D length N (per-channel)" rule --
+// returns false (per-tensor), true (per-channel), or nullopt (anything
+// else -- declined, see this section's own top comment).
+std::optional<bool> QopPerChannelScaleOk(const onnx::TensorProto& scale_init,
+                                         const onnx::TensorProto& zp_init,
+                                         int64_t n) {
+  if (scale_init.data_type() != onnx::TensorProto::FLOAT) {
+    return std::nullopt;
+  }
+  if (!DimsEqual(scale_init.dims(), zp_init.dims())) {
+    return std::nullopt;  // Schema: scale and zero_point must share one shape.
+  }
+  int64_t numel = 1;
+  for (int64_t d : scale_init.dims()) {
+    numel *= d;
+  }
+  if (numel == 1) {
+    return false;
+  }
+  if (scale_init.dims_size() == 1 && scale_init.dims(0) == n) {
+    return true;
+  }
+  return std::nullopt;
+}
+
+// If `node` is an ordinary (group=1) `QLinearConv` matching every scope
+// boundary this section's own top comment documents, returns the match.
+// nullopt whenever anything is ambiguous or out of the empirically-verified
+// scope, rather than guessing.
+std::optional<QOpWeightMatch> MatchQLinearConv(
+    const onnx::NodeProto& node, const InitMap& init_map,
+    const ConsumerMap& consumers_of) {
+  if (node.op_type() != "QLinearConv" || !node.domain().empty()) {
+    return std::nullopt;
+  }
+  if ((node.input_size() != 8 && node.input_size() != 9) ||
+      node.output_size() != 1) {
+    return std::nullopt;
+  }
+  const std::string& x_name = node.input(0);
+  const std::string& x_scale_name = node.input(1);
+  const std::string& x_zp_name = node.input(2);
+  const std::string& w_name = node.input(3);
+  const std::string& w_scale_name = node.input(4);
+  const std::string& w_zp_name = node.input(5);
+  const std::string& y_scale_name = node.input(6);
+  const std::string& y_zp_name = node.input(7);
+  if (x_name.empty() || x_scale_name.empty() || x_zp_name.empty() ||
+      w_name.empty() || w_scale_name.empty() || w_zp_name.empty() ||
+      y_scale_name.empty() || y_zp_name.empty()) {
+    return std::nullopt;
+  }
+  std::optional<std::string> bias_name;
+  if (node.input_size() == 9 && !node.input(8).empty()) {
+    bias_name = node.input(8);
+  }
+
+  if (ConvGroupAttr(node) != 1) {
+    return std::nullopt;  // Grouped/depthwise QLinearConv -- out of scope,
+                          // see this section's own top comment.
+  }
+
+  auto wit = init_map.find(w_name);
+  auto sit = init_map.find(w_scale_name);
+  auto zit = init_map.find(w_zp_name);
+  if (wit == init_map.end() || sit == init_map.end() || zit == init_map.end()) {
+    return std::nullopt;  // Non-constant w/w_scale/w_zero_point.
+  }
+  const onnx::TensorProto* w_init = wit->second;
+  const onnx::TensorProto* w_scale_init = sit->second;
+  const onnx::TensorProto* w_zp_init = zit->second;
+  if (w_init->data_type() != onnx::TensorProto::INT8 &&
+      w_init->data_type() != onnx::TensorProto::UINT8) {
+    return std::nullopt;
+  }
+  if (w_zp_init->data_type() != w_init->data_type()) {
+    return std::nullopt;  // Schema: w and w_zero_point share one type.
+  }
+  if (w_init->dims_size() != 4) {
+    return std::nullopt;  // 2-D spatial Conv only -- see this section's own
+                          // top comment.
+  }
+  const int64_t n = w_init->dims(0);
+  const int64_t k = w_init->dims(1);
+  if (n <= 0 || k <= 0) {
+    return std::nullopt;
+  }
+
+  auto per_channel = QopPerChannelScaleOk(*w_scale_init, *w_zp_init, n);
+  if (!per_channel) {
+    return std::nullopt;
+  }
+
+  for (const std::string& nm :
+       {x_scale_name, x_zp_name, y_scale_name, y_zp_name}) {
+    auto it = init_map.find(nm);
+    if (it == init_map.end() || !QopScalarDimsOk(*it->second)) {
+      return std::nullopt;  // Non-constant, or non-scalar, activation scale
+                            // -- declined, see this section's own top
+                            // comment.
+    }
+  }
+
+  if (bias_name) {
+    auto bit = init_map.find(*bias_name);
+    if (bit == init_map.end() ||
+        bit->second->data_type() != onnx::TensorProto::INT32) {
+      return std::nullopt;  // Non-constant, or dtype-mismatched, bias.
+    }
+    if (!(bit->second->dims_size() == 1 && bit->second->dims(0) == n)) {
+      return std::nullopt;
+    }
+  }
+
+  std::vector<std::string> sliced_names = {w_name};
+  if (*per_channel) {
+    sliced_names.push_back(w_scale_name);
+    sliced_names.push_back(w_zp_name);
+  }
+  if (bias_name) {
+    sliced_names.push_back(*bias_name);
+  }
+  for (const auto& nm : sliced_names) {
+    if (ConsumerCount(consumers_of, nm) != 1) {
+      return std::nullopt;  // Shared/tied tensor -- another node reads it
+                            // too.
+    }
+  }
+
+  return QOpWeightMatch{
+      QOpKind::kConv, w_name, w_scale_name, w_zp_name, bias_name,
+      false,          false,  *per_channel, n,         k};
+}
+
+// If `node` is a `QLinearMatMul` matching every scope boundary this
+// section's own top comment documents, returns the match. nullopt whenever
+// anything is ambiguous or out of the empirically-verified scope.
+std::optional<QOpWeightMatch> MatchQLinearMatMul(
+    const onnx::NodeProto& node, const InitMap& init_map,
+    const ConsumerMap& consumers_of) {
+  if (node.op_type() != "QLinearMatMul" || !node.domain().empty()) {
+    return std::nullopt;
+  }
+  if (node.input_size() != 8 || node.output_size() != 1) {
+    return std::nullopt;
+  }
+  const std::string& a_name = node.input(0);
+  const std::string& a_scale_name = node.input(1);
+  const std::string& a_zp_name = node.input(2);
+  const std::string& b_name = node.input(3);
+  const std::string& b_scale_name = node.input(4);
+  const std::string& b_zp_name = node.input(5);
+  const std::string& y_scale_name = node.input(6);
+  const std::string& y_zp_name = node.input(7);
+  if (a_name.empty() || a_scale_name.empty() || a_zp_name.empty() ||
+      b_name.empty() || b_scale_name.empty() || b_zp_name.empty() ||
+      y_scale_name.empty() || y_zp_name.empty()) {
+    return std::nullopt;
+  }
+
+  auto bit = init_map.find(b_name);
+  auto sit = init_map.find(b_scale_name);
+  auto zit = init_map.find(b_zp_name);
+  if (bit == init_map.end() || sit == init_map.end() || zit == init_map.end()) {
+    return std::nullopt;
+  }
+  const onnx::TensorProto* b_init = bit->second;
+  const onnx::TensorProto* b_scale_init = sit->second;
+  const onnx::TensorProto* b_zp_init = zit->second;
+  if (b_init->data_type() != onnx::TensorProto::INT8 &&
+      b_init->data_type() != onnx::TensorProto::UINT8) {
+    return std::nullopt;
+  }
+  if (b_zp_init->data_type() != b_init->data_type()) {
+    return std::nullopt;
+  }
+  if (b_init->dims_size() != 2) {
+    return std::nullopt;  // 2-D MatMul weight only, mirroring this file's
+                          // own MatchMatMulLikeRaw/MatchMatmulQdq rank bar.
+  }
+  const int64_t k = b_init->dims(0);
+  const int64_t n = b_init->dims(1);
+  if (n <= 0 || k <= 0) {
+    return std::nullopt;
+  }
+
+  auto per_channel = QopPerChannelScaleOk(*b_scale_init, *b_zp_init, n);
+  if (!per_channel) {
+    return std::nullopt;
+  }
+
+  for (const std::string& nm :
+       {a_scale_name, a_zp_name, y_scale_name, y_zp_name}) {
+    auto it = init_map.find(nm);
+    if (it == init_map.end() || !QopScalarDimsOk(*it->second)) {
+      return std::nullopt;  // Non-constant, or non-scalar (per-row/
+                            // per-column), activation scale -- declined.
+    }
+  }
+
+  std::vector<std::string> sliced_names = {b_name};
+  if (*per_channel) {
+    sliced_names.push_back(b_scale_name);
+    sliced_names.push_back(b_zp_name);
+  }
+  for (const auto& nm : sliced_names) {
+    if (ConsumerCount(consumers_of, nm) != 1) {
+      return std::nullopt;  // Shared/tied tensor -- another node reads it
+                            // too.
+    }
+  }
+
+  return QOpWeightMatch{QOpKind::kMatMul,
+                        b_name,
+                        b_scale_name,
+                        b_zp_name,
+                        std::nullopt,
+                        false,
+                        false,
+                        *per_channel,
+                        n,
+                        k};
+}
+
+// If `node` is a `com.microsoft::QGemm` with `transA=0`, `alpha=1.0`
+// (mirroring `MatchMatMulLikeRaw`'s own identical restriction for plain
+// `Gemm`) matching every other scope boundary this section's own top
+// comment documents, returns the match. nullopt whenever anything is
+// ambiguous or out of the empirically-verified scope.
+std::optional<QOpWeightMatch> MatchQGemm(const onnx::NodeProto& node,
+                                         const InitMap& init_map,
+                                         const ConsumerMap& consumers_of) {
+  if (node.op_type() != "QGemm" || node.domain() != kComMicrosoftDomain) {
+    return std::nullopt;
+  }
+  if (node.input_size() < 6 || node.output_size() != 1) {
+    return std::nullopt;
+  }
+  const std::string& a_name = node.input(0);
+  const std::string& a_scale_name = node.input(1);
+  const std::string& a_zp_name = node.input(2);
+  const std::string& b_name = node.input(3);
+  const std::string& b_scale_name = node.input(4);
+  const std::string& b_zp_name = node.input(5);
+  if (a_name.empty() || a_scale_name.empty() || a_zp_name.empty() ||
+      b_name.empty() || b_scale_name.empty() || b_zp_name.empty()) {
+    return std::nullopt;
+  }
+  std::optional<std::string> c_name;
+  if (node.input_size() > 6 && !node.input(6).empty()) {
+    c_name = node.input(6);
+  }
+  std::optional<std::string> y_scale_name;
+  if (node.input_size() > 7 && !node.input(7).empty()) {
+    y_scale_name = node.input(7);
+  }
+  std::optional<std::string> y_zp_name;
+  if (node.input_size() > 8 && !node.input(8).empty()) {
+    y_zp_name = node.input(8);
+  }
+
+  int64_t trans_a = 0, trans_b = 0;
+  double alpha = 1.0;
+  bool has_trans_a = false, has_alpha = false;
+  for (const auto& attr : node.attribute()) {
+    if (attr.name() == "transA") {
+      trans_a = attr.i();
+      has_trans_a = true;
+    } else if (attr.name() == "alpha") {
+      alpha = attr.f();
+      has_alpha = true;
+    } else if (attr.name() == "transB") {
+      trans_b = attr.i();
+    }
+  }
+  if (has_trans_a && trans_a != 0) {
+    return std::nullopt;
+  }
+  if (has_alpha && alpha != 1.0) {
+    return std::nullopt;
+  }
+  const bool weight_transposed = trans_b != 0;
+
+  auto bit = init_map.find(b_name);
+  auto sit = init_map.find(b_scale_name);
+  auto zit = init_map.find(b_zp_name);
+  if (bit == init_map.end() || sit == init_map.end() || zit == init_map.end()) {
+    return std::nullopt;
+  }
+  const onnx::TensorProto* b_init = bit->second;
+  const onnx::TensorProto* b_scale_init = sit->second;
+  const onnx::TensorProto* b_zp_init = zit->second;
+  if (b_init->data_type() != onnx::TensorProto::INT8 &&
+      b_init->data_type() != onnx::TensorProto::UINT8) {
+    return std::nullopt;
+  }
+  if (b_zp_init->data_type() != b_init->data_type()) {
+    return std::nullopt;
+  }
+  if (b_init->dims_size() != 2) {
+    return std::nullopt;
+  }
+  const int64_t n = weight_transposed ? b_init->dims(0) : b_init->dims(1);
+  const int64_t k = weight_transposed ? b_init->dims(1) : b_init->dims(0);
+  if (n <= 0 || k <= 0) {
+    return std::nullopt;
+  }
+
+  auto per_channel = QopPerChannelScaleOk(*b_scale_init, *b_zp_init, n);
+  if (!per_channel) {
+    return std::nullopt;
+  }
+
+  for (const std::string& nm : {a_scale_name, a_zp_name}) {
+    auto it = init_map.find(nm);
+    if (it == init_map.end() || !QopScalarDimsOk(*it->second)) {
+      return std::nullopt;
+    }
+  }
+  for (const auto& opt_nm : {y_scale_name, y_zp_name}) {
+    if (!opt_nm) {
+      continue;
+    }
+    auto it = init_map.find(*opt_nm);
+    if (it == init_map.end() || !QopScalarDimsOk(*it->second)) {
+      return std::nullopt;
+    }
+  }
+
+  std::optional<std::string> bias_name;
+  bool bias_is_scalar = false;
+  if (c_name) {
+    auto cit = init_map.find(*c_name);
+    if (cit == init_map.end() ||
+        cit->second->data_type() != onnx::TensorProto::INT32) {
+      return std::nullopt;  // Non-constant, or dtype-mismatched, bias.
+    }
+    const onnx::TensorProto* c_init = cit->second;
+    if (c_init->dims_size() == 0 ||
+        (c_init->dims_size() == 1 && c_init->dims(0) == 1)) {
+      bias_is_scalar = true;  // Broadcasting scalar -- never sliced, see
+                              // this section's own top comment.
+    } else if (!(c_init->dims_size() == 1 && c_init->dims(0) == n)) {
+      return std::nullopt;  // Ambiguous broadcast shape -- declined.
+    }
+    bias_name = c_name;
+  }
+
+  std::vector<std::string> sliced_names = {b_name};
+  if (*per_channel) {
+    sliced_names.push_back(b_scale_name);
+    sliced_names.push_back(b_zp_name);
+  }
+  if (c_name && !bias_is_scalar) {
+    sliced_names.push_back(*c_name);
+  }
+  for (const auto& nm : sliced_names) {
+    if (ConsumerCount(consumers_of, nm) != 1) {
+      return std::nullopt;  // Shared/tied tensor -- another node reads it
+                            // too.
+    }
+  }
+
+  return QOpWeightMatch{QOpKind::kGemm,
+                        b_name,
+                        b_scale_name,
+                        b_zp_name,
+                        bias_name,
+                        bias_is_scalar,
+                        weight_transposed,
+                        *per_channel,
+                        n,
+                        k};
+}
+
+// --- Chain data model + plain-chain walker/finder, mirroring _QOpChain and
+// _walk_to_qop_consumer/_find_qop_chains -----------------------------------
+
+struct QOpProducer {
+  onnx::NodeProto* node;
+  QOpWeightMatch w;
+};
+
+struct QOpConsumerMatch {
+  onnx::NodeProto* node;
+  QOpWeightMatch w;
+};
+
+struct QOpChain {
+  QOpProducer producer;
+  std::vector<onnx::NodeProto*> chain_ops;
+  QOpConsumerMatch consumer;
+  int64_t n_channels;
+};
+
+// From tensor `start`, walks forward through shape-preserving unary
+// activations (UnaryPassThroughOps) with no other consumer anywhere along
+// the way, until a same-family (QLinearConv-only when `is_conv`,
+// QLinearMatMul/QGemm-only otherwise) consumer is found whose own `K`
+// matches `n_channels`. Mirrors WalkToConsumerQdq closely -- see this
+// section's own top comment for why no Flatten/Reshape cross-family hop is
+// recognized. Returns nullopt if the walk runs out of hops, hits a branch,
+// or never reaches such a consumer -- including when the very next node IS
+// a same-family op but fails to match or has a mismatched K, mirroring
+// pruning.py's own `_walk_to_qop_consumer` returning None immediately in
+// that case rather than falling through to the unary-activation check.
+std::pair<std::optional<QOpConsumerMatch>, std::vector<onnx::NodeProto*>>
+WalkToQopConsumer(const std::string& start, bool is_conv,
+                  const InitMap& init_map, const ConsumerMap& consumers_of,
+                  const std::unordered_set<std::string>& graph_outputs,
+                  int64_t n_channels, int max_hops) {
+  std::vector<onnx::NodeProto*> chain_ops;
+  std::string cur = start;
+  for (int hop = 0; hop < max_hops; ++hop) {
+    auto cit = consumers_of.find(cur);
+    if (cit == consumers_of.end() || cit->second.size() != 1) {
+      return {std::nullopt, chain_ops};
+    }
+    onnx::NodeProto* nxt = cit->second[0];
+
+    if (is_conv) {
+      if (nxt->op_type() == "QLinearConv" && nxt->domain().empty() &&
+          nxt->input_size() > 0 && nxt->input(0) == cur) {
+        auto m = MatchQLinearConv(*nxt, init_map, consumers_of);
+        if (!m || m->K != n_channels) {
+          return {std::nullopt, chain_ops};
+        }
+        return {QOpConsumerMatch{nxt, *m}, chain_ops};
+      }
+    } else {
+      if (nxt->op_type() == "QLinearMatMul" && nxt->domain().empty() &&
+          nxt->input_size() > 0 && nxt->input(0) == cur) {
+        auto m = MatchQLinearMatMul(*nxt, init_map, consumers_of);
+        if (!m || m->K != n_channels) {
+          return {std::nullopt, chain_ops};
+        }
+        return {QOpConsumerMatch{nxt, *m}, chain_ops};
+      }
+      if (nxt->op_type() == "QGemm" && nxt->domain() == kComMicrosoftDomain &&
+          nxt->input_size() > 0 && nxt->input(0) == cur) {
+        auto m = MatchQGemm(*nxt, init_map, consumers_of);
+        if (!m || m->K != n_channels) {
+          return {std::nullopt, chain_ops};
+        }
+        return {QOpConsumerMatch{nxt, *m}, chain_ops};
+      }
+    }
+
+    const bool is_unary = UnaryPassThroughOps().count(nxt->op_type()) != 0 &&
+                          nxt->input_size() == 1 && nxt->input(0) == cur &&
+                          nxt->output_size() == 1;
+    if (!is_unary) {
+      return {std::nullopt, chain_ops};
+    }
+    const std::string& out2 = nxt->output(0);
+    auto oit = consumers_of.find(out2);
+    if (oit == consumers_of.end() || oit->second.size() != 1 ||
+        graph_outputs.count(out2)) {
+      return {std::nullopt, chain_ops};
+    }
+    chain_ops.push_back(nxt);
+    cur = out2;
+  }
+  return {std::nullopt, chain_ops};
+}
+
+// The QOperator analogue of FindQdqChains, restricted to the single-
+// producer/single-consumer/unary-hops-only, same-family-only topology
+// WalkToQopConsumer matches. Tries a QLinearConv producer, then a
+// QLinearMatMul producer, then a QGemm producer -- the three matchers' own
+// op_type checks are mutually exclusive, so this is never ambiguous.
+std::vector<QOpChain> FindQopChains(onnx::GraphProto* graph) {
+  InitMap init_map;
+  for (const auto& t : graph->initializer()) {
+    init_map[t.name()] = &t;
+  }
+  ConsumerMap consumers_of = ConsumersOf(graph);
+  std::unordered_set<std::string> graph_outputs;
+  for (const auto& o : graph->output()) {
+    graph_outputs.insert(o.name());
+  }
+  auto is_internal = [&](const std::string& name) {
+    auto it = consumers_of.find(name);
+    return it != consumers_of.end() && it->second.size() == 1 &&
+           !graph_outputs.count(name);
+  };
+
+  std::vector<QOpChain> chains;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    std::optional<QOpWeightMatch> m;
+    bool is_conv = false;
+    if (node->op_type() == "QLinearConv") {
+      m = MatchQLinearConv(*node, init_map, consumers_of);
+      is_conv = true;
+    } else if (node->op_type() == "QLinearMatMul") {
+      m = MatchQLinearMatMul(*node, init_map, consumers_of);
+    } else if (node->op_type() == "QGemm") {
+      m = MatchQGemm(*node, init_map, consumers_of);
+    } else {
+      continue;
+    }
+    if (!m) {
+      continue;
+    }
+
+    const std::string& out_name = node->output(0);
+    if (!is_internal(out_name)) {
+      continue;
+    }
+    auto [consumer, chain_ops] =
+        WalkToQopConsumer(out_name, is_conv, init_map, consumers_of,
+                          graph_outputs, m->N, kMaxChainHops);
+    if (!consumer) {
+      continue;
+    }
+
+    QOpChain chain;
+    chain.producer = QOpProducer{node, *m};
+    chain.chain_ops = std::move(chain_ops);
+    chain.consumer = *consumer;
+    chain.n_channels = m->N;
+    chains.push_back(std::move(chain));
+  }
+  return chains;
+}
+
+// --- Apply: slicing + ranking, mirroring _qop_dequantized_nk/
+// _slice_qop_producer/_slice_qop_consumer/apply_structured_pruning_qoperator
+
+// The full float64 (N, K) dequantized weight matrix `w` refers to, for
+// IMPORTANCE RANKING ONLY -- never written back to the graph (this
+// section's own "slice, don't recompute" principle). Reuses
+// PerChannelDequantFlat (the QDQ section's own per-channel dequant helper --
+// applies identically here, a QOperator weight's own scale/zero-point pair
+// being the same "scalar or 1-D length N" shape) and QdqWeightToNk (to
+// reshape/transpose into (N, K) row-major), mirroring pruning.py's own
+// `_qop_dequantized_nk` exactly.
+std::vector<double> QopDequantizedNk(const QOpWeightMatch& w,
+                                     const MutInitMap& init_map) {
+  const bool is_conv = w.op_kind == QOpKind::kConv;
+  const onnx::TensorProto* wt = init_map.at(w.w_name);
+  const std::vector<int64_t> dims(wt->dims().begin(), wt->dims().end());
+  const std::vector<int64_t> codes = ReadQuantCodes(*wt);
+  const std::vector<float> scale =
+      ReadFloatTensor(*init_map.at(w.w_scale_name));
+  const std::vector<int64_t> zp =
+      ReadQuantCodes(*init_map.at(w.w_zero_point_name));
+  const int64_t axis =
+      QdqWeightAxis(/*producer_role=*/true, w.weight_transposed, is_conv,
+                    /*is_conv_transpose=*/false);
+  const std::vector<double> flat =
+      PerChannelDequantFlat(codes, dims, scale, zp, w.per_channel, axis);
+  return QdqWeightToNk(flat, dims, w.weight_transposed, is_conv,
+                       /*is_conv_transpose=*/false);
+}
+
+// Slices `w`'s own N (output-channel) axis to `keep` (ascending indices) --
+// the producer role. See this section's own top comment for exactly which
+// of w/w_scale/w_zero_point/bias get co-sliced.
+void SliceQopProducer(const QOpWeightMatch& w, const std::vector<int64_t>& keep,
+                      MutInitMap& init_map) {
+  const bool is_conv = w.op_kind == QOpKind::kConv;
+  const int64_t axis =
+      QdqWeightAxis(/*producer_role=*/true, w.weight_transposed, is_conv,
+                    /*is_conv_transpose=*/false);
+
+  onnx::TensorProto* wt = init_map.at(w.w_name);
+  const std::vector<int64_t> dims(wt->dims().begin(), wt->dims().end());
+  const std::vector<int64_t> codes = ReadQuantCodes(*wt);
+  const std::vector<int64_t> new_codes =
+      SliceAlongAxis(codes, dims, axis, keep);
+  std::vector<int64_t> new_dims = dims;
+  new_dims[static_cast<size_t>(axis)] = static_cast<int64_t>(keep.size());
+  SetQuantCodes(wt, wt->data_type(), new_dims, new_codes);
+
+  if (w.per_channel) {
+    SliceLastAxis(init_map.at(w.w_scale_name), keep);
+    onnx::TensorProto* zt = init_map.at(w.w_zero_point_name);
+    const std::vector<int64_t> zdims(zt->dims().begin(), zt->dims().end());
+    const std::vector<int64_t> zcodes = ReadQuantCodes(*zt);
+    const std::vector<int64_t> new_z = SliceAlongAxis(zcodes, zdims, 0, keep);
+    std::vector<int64_t> new_zdims = zdims;
+    new_zdims[0] = static_cast<int64_t>(keep.size());
+    SetQuantCodes(zt, zt->data_type(), new_zdims, new_z);
+  }
+  if (w.bias_name && !w.bias_is_scalar) {
+    SliceLastAxisInt32(init_map.at(*w.bias_name), keep);
+  }
+}
+
+// Slices `w`'s own K (reduction/input-channel) axis to `keep` -- the
+// consumer role. Never touches scale/zero_point/bias -- none of the three
+// live schemas index any of them by K (see this section's own top comment).
+void SliceQopConsumer(const QOpWeightMatch& w, const std::vector<int64_t>& keep,
+                      MutInitMap& init_map) {
+  const bool is_conv = w.op_kind == QOpKind::kConv;
+  const int64_t axis =
+      QdqWeightAxis(/*producer_role=*/false, w.weight_transposed, is_conv,
+                    /*is_conv_transpose=*/false);
+  onnx::TensorProto* wt = init_map.at(w.w_name);
+  const std::vector<int64_t> dims(wt->dims().begin(), wt->dims().end());
+  const std::vector<int64_t> codes = ReadQuantCodes(*wt);
+  const std::vector<int64_t> new_codes =
+      SliceAlongAxis(codes, dims, axis, keep);
+  std::vector<int64_t> new_dims = dims;
+  new_dims[static_cast<size_t>(axis)] = static_cast<int64_t>(keep.size());
+  SetQuantCodes(wt, wt->data_type(), new_dims, new_codes);
+}
+
+// The apply body for QOperator chains, mirroring
+// `apply_structured_pruning_qoperator`'s own main loop over
+// `_find_qop_chains` -- see this section's own top comment for the
+// producer/consumer co-slicing rules this enforces.
+void ApplyQopChains(onnx::GraphProto* graph, std::vector<QOpChain>& chains,
+                    double sparsity, TouchedState& touched) {
+  MutInitMap init_map = BuildMutInitMap(graph);
+  auto& producer_touched = touched.producer;
+  auto& consumer_touched = touched.consumer;
+  auto& stale_value_info = touched.stale_value_info;
+
+  for (const auto& chain : chains) {
+    const QOpProducer& p = chain.producer;
+    const QOpConsumerMatch& c = chain.consumer;
+    const std::string& p_key = p.w.w_name;
+    const std::string& c_key = c.w.w_name;
+    if (p_key == c_key) {
+      continue;  // Degenerate (the same weight in both roles).
+    }
+    if (producer_touched.count(p_key) || consumer_touched.count(c_key)) {
+      continue;  // A shared/tied weight another chain already resized.
+    }
+
+    const int64_t n = chain.n_channels;
+    const int64_t keep_count = std::max<int64_t>(
+        1, n - std::llround(static_cast<double>(n) * sparsity));
+    if (keep_count >= n) {
+      continue;  // Rounds down to nothing for this layer -- no-op.
+    }
+
+    const std::vector<double> w_nk = QopDequantizedNk(p.w, init_map);
+    // NOT `p.w.K` -- for a QLinearConv weight the per-row flattened length
+    // (C*kH*kW) differs from `K` (just C, the reduction-CHANNEL count the
+    // matcher/consumer-role slicing use); mirrors ApplyQdqChains's own
+    // identical `w_nk.size() / n` derivation for the same reason.
+    const int64_t row_len = static_cast<int64_t>(w_nk.size()) / n;
+    const std::vector<double> importance =
+        QdqChannelImportanceL2(w_nk, n, row_len);
+    // Stable tie-break for the identical determinism reason
+    // ApplyQdqChains's own identical line documents.
+    const std::vector<int64_t> keep =
+        StableTopKIndicesAscending(importance, keep_count);
+
+    SliceQopProducer(p.w, keep, init_map);
+    SliceQopConsumer(c.w, keep, init_map);
+
+    producer_touched.insert(p_key);
+    consumer_touched.insert(c_key);
+    stale_value_info.insert(p.node->output(0));
+    for (onnx::NodeProto* op : chain.chain_ops) {
+      stale_value_info.insert(op->output(0));
+    }
+  }
+}
+
 // --- Subgraph recursion ------------------------------------------------
 //
 // Mirrors pruning.py's own `_iter_subgraphs` and the "Subgraph recursion"
@@ -15043,6 +15924,7 @@ onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
         FindFp8BlockQuantizedChains(graph);
     std::vector<Fp4Chain> fp4_block_quantized_chains =
         FindFp4BlockQuantizedChains(graph);
+    std::vector<QOpChain> qop_chains = FindQopChains(graph);
 
     TouchedState touched;
     if (!chains.empty()) {
@@ -15111,12 +15993,24 @@ onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
                                    touched);
     }
     if (!fp4_block_quantized_chains.empty()) {
-      // The ninth and final application pass over this graph -- `Fp8Weight`/
-      // `Fp4Weight` are never mixed with each other (see that section's own
-      // top comment), so this is always a genuinely separate match, still
-      // sharing `touched` with every call above for the same reason.
+      // `Fp8Weight`/`Fp4Weight` are never mixed with each other (see that
+      // section's own top comment), so this is always a genuinely separate
+      // match, still sharing `touched` with every call above for the same
+      // reason.
       ApplyFp4BlockQuantizedChains(graph, fp4_block_quantized_chains, sparsity,
                                    touched);
+    }
+    if (!qop_chains.empty()) {
+      // The tenth and final application pass over this graph -- QOperator
+      // (QLinearConv/QLinearMatMul/QGemm static-quantization) chains, see
+      // this file's own "QOperator (QLinearConv/QLinearMatMul/QGemm
+      // static-quantization) structured pruning" section comment. A
+      // genuinely separate match (QLinearConv/QLinearMatMul/QGemm are node
+      // types no other Find*Chains call above recognizes at all), still
+      // sharing `touched` with every call above for the same "one shared
+      // conflict ledger per graph" reason every other quantized-weight pass
+      // here does.
+      ApplyQopChains(graph, qop_chains, sparsity, touched);
     }
     if (!touched.stale_value_info.empty()) {
       google::protobuf::RepeatedPtrField<onnx::ValueInfoProto> kept;

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -15089,6 +15089,668 @@ void ApplyQopChains(onnx::GraphProto* graph, std::vector<QOpChain>& chains,
   }
 }
 
+// --- DynamicQuantizeMatMul / MatMulIntegerToFloat (ORT dynamic-quantization
+//     fusion) structured pruning, mirroring pruning.py's own section of the
+//     same name --------------------------------------------------------
+//
+// C++ port of pruning.py's own `_match_dynquant_weight_operands` through the
+// end of `apply_structured_pruning_dynamic_quantize_matmul` -- see that
+// section's own top comment for the full empirical investigation (live
+// schema introspection, the real fused node sequences reproduced via a
+// genuine `quantize_dynamic` -> `InferenceSession`-optimize round trip, and
+// why every scope boundary below is drawn where it is). Summary of the facts
+// this depends on:
+//
+//   * `com.microsoft::DynamicQuantizeMatMul(A, B, b_scale, b_zero_point?,
+//     bias?) -> Y`. `A` is the RAW FLOAT activation, quantized internally by
+//     the fused op itself -- unlike every OTHER quantized op this file
+//     already handles, there is no separate `a_scale`/`a_zero_point` input
+//     at all, so (unlike QDQ/MatMulNBits/MatMulBnb4/Fp4/Fp8) this pass never
+//     needs a live `DynamicQuantizeLinear` node in the graph to still be
+//     data-free -- the activation side is quantized fresh from the actual
+//     runtime input, needing no calibration data and no rewriting here.
+//   * `com.microsoft::MatMulIntegerToFloat(A, B, a_scale, b_scale,
+//     a_zero_point?, b_zero_point?, bias?) -> Y`. The "pre-quantized-`A`"
+//     variant: `a_scale`/`a_zero_point` are read only to index past them to
+//     `b_zero_point`/`bias` -- never validated or touched (they are never
+//     constant initializers in a real fusion output at all: a live
+//     `DynamicQuantizeLinear` node's own outputs).
+//   * `B`'s own storage layout: INT8/UINT8, always `[K, N]` UNCHANGED --
+//     plain, completely UNPACKED codes, no sub-byte packing at all (simpler
+//     than `MatMulNBits`/`MatMulBnb4`/the block-quantized Fp4/Fp8 ops
+//     elsewhere in this file -- no `block_size` on either live schema at
+//     all). Axis 1 is always the output-channel (`N`) axis -- neither op has
+//     a `transB`-equivalent attribute to ever flip that. `b_scale`/
+//     `b_zero_point` are scalar (per-tensor) or 1-D length `N` (per-channel)
+//     -- reusing DynQuantPerChannelScaleOk (mirrors QOperator's own
+//     `_qop_per_channel_scale_ok`/this file's own QdqWeightMatch scalar-or-
+//     length-N check). `bias`, when present, is PLAIN, UNQUANTIZED float
+//     `(N,)` -- a real, material difference from `QGemm`/`QLinearConv`'s own
+//     INT32, per-channel-scaled bias convention: no "slice, don't recompute"
+//     caveat about a scale it doesn't carry, sliced exactly like a plain
+//     float `Gemm`'s own bias (SliceLastAxis).
+//   * Consumer-role (`K`-axis) pruning is SIMPLER than every other quantized
+//     family here: `B`'s own codes are plain, unpacked, un-blocked, so there
+//     is no block-alignment precondition to check at all (unlike
+//     `MatMulNBits`/`MatMulBnb4`/Fp4/Fp8) -- a chain's own importance-ranked
+//     keep-set applies directly to BOTH sides, with no possibility of
+//     "declined -- not block-aligned". `b_scale`/`b_zero_point`/`bias` are
+//     never indexed by `K` (always sized by `N` or scalar), so the consumer
+//     role touches nothing but the weight's own codes.
+//   * Deliberately declined (mirroring pruning.py's own identical bars): a
+//     non-constant `B`/`b_scale`/`bias`, or any of those read by more than
+//     one node (shared/tied); `b_zero_point` absent entirely (schema-legal,
+//     but never confirmed safe by any real fixture); a `B` of rank other
+//     than 2, or a `bias` of any shape other than exactly `(N,)`; mixing
+//     this scheme with a QDQ/MatMulNBits/MatMulBnb4/Fp4/Fp8-fed node on
+//     either side of a chain; any gated (SwiGLU/GeGLU) pair, residual merge,
+//     or `Concat`-merged branch group.
+//
+// Every chain side (producer or consumer) may independently be EITHER a
+// `DynamicQuantizeMatMul`/`MatMulIntegerToFloat` node OR a plain-float
+// `MatMul`/vanilla-`Gemm` peer -- `DynQuantChainSide`, reusing
+// `PlainMatMulNBitsPeer`/`MatchPlainMatMulNBitsPeer` directly (structurally
+// identical "directly-constant FLOAT rank-2 weight, never QDQ-fed" shape
+// this section also needs, exactly mirroring pruning.py's own reuse of
+// `_PlainMatMulNBitsPeer` here rather than a fresh duplicate type), with the
+// chain-finder below requiring at least one side to actually be one of this
+// section's own two ops (an all-plain-float pair is FindChains's own job,
+// not duplicated here). This port's own established narrower-than-
+// pruning.py scope decisions (consistent with every quantized-weight
+// section above): `b_scale`/`bias` are admitted only as plain FLOAT
+// (float32) -- this file's own float-tensor helpers have no FLOAT16/
+// BFLOAT16 support anywhere yet, unlike pruning.py's own wider
+// `_is_supported_float_dtype`; the plain-float peer side only ever
+// recognizes bare `MatMul`/`Gemm` (MatchMatMulLikeRaw via
+// MatchPlainMatMulNBitsPeer), not pruning.py's own widened
+// `_match_matmul_like`. The chain-finding shape itself only ever crosses a
+// shape-preserving unary activation (UnaryPassThroughOps) -- no per-channel
+// Add/Mul/BiasGelu/PRelu/Clip hop, no branch -- mirroring
+// WalkToMatMulNBitsConsumer's own identical restriction.
+
+// Checks a weight's own `(scale, zero_point)` pair against the live schemas'
+// shared "scalar (per-tensor) or 1-D length `N` (per-channel)" rule --
+// `false` (per-tensor), `true` (per-channel), or `nullopt` (anything else --
+// declined). Mirrors pruning.py's own `_qop_per_channel_scale_ok`, reused
+// here rather than a QDQ-specific helper since neither op's own `b_scale`/
+// `b_zero_point` ever needs QdqWeightMatch's own axis/rank generality.
+std::optional<bool> DynQuantPerChannelScaleOk(
+    const onnx::TensorProto& scale_init, const onnx::TensorProto& zp_init,
+    int64_t n) {
+  if (scale_init.data_type() != onnx::TensorProto::FLOAT) {
+    return std::nullopt;  // Scope: FLOAT32 only, see this section's own top
+                          // comment.
+  }
+  if (!DimsEqual(scale_init.dims(), zp_init.dims())) {
+    return std::nullopt;  // Schema: scale and zero_point share one shape.
+  }
+  int64_t numel = 1;
+  for (int64_t d : scale_init.dims()) {
+    numel *= d;
+  }
+  if (numel == 1) {
+    return false;
+  }
+  if (scale_init.dims_size() == 1 && scale_init.dims(0) == n) {
+    return true;
+  }
+  return std::nullopt;
+}
+
+// A matched `com.microsoft::DynamicQuantizeMatMul`/`MatMulIntegerToFloat`
+// node's own sliceable operands -- see this section's own top comment for
+// the schema facts this depends on. `node` is safe to store as a pointer
+// for the identical reason MatMulNBitsWeight's own docstring gives (comes
+// from `graph->mutable_node(i)`, no node is ever inserted/removed by this
+// whole pass). `b_zero_point_name` is never empty -- an absent one declines
+// the whole match (see this section's own top comment).
+struct DynQuantMatMulWeight {
+  onnx::NodeProto* node = nullptr;
+  std::string b_name;
+  std::string b_scale_name;
+  std::string b_zero_point_name;
+  std::optional<std::string> bias_name;
+  bool per_channel = false;
+  int64_t N = 0;
+  int64_t K = 0;
+};
+
+// Shared `B`/`b_scale`/`b_zero_point`/`bias` validation for both
+// MatchDynamicQuantizeMatMul and MatchMatMulIntegerToFloat, once each has
+// unpacked its own op-specific input list -- mirrors pruning.py's own
+// `_match_dynquant_weight_operands` exactly.
+std::optional<DynQuantMatMulWeight> MatchDynquantWeightOperands(
+    onnx::NodeProto* node, const std::string& b_name,
+    const std::string& b_scale_name, const std::string& b_zp_name,
+    const std::string& bias_name, const InitMap& init_map,
+    const ConsumerMap& consumers_of) {
+  if (b_zp_name.empty()) {
+    return std::nullopt;  // Absent b_zero_point -- not empirically confirmed
+                          // safe, see this section's own top comment.
+  }
+
+  auto b_it = init_map.find(b_name);
+  auto s_it = init_map.find(b_scale_name);
+  auto z_it = init_map.find(b_zp_name);
+  if (b_it == init_map.end() || s_it == init_map.end() ||
+      z_it == init_map.end()) {
+    return std::nullopt;  // Non-constant B/b_scale/b_zero_point.
+  }
+  const onnx::TensorProto* b_init = b_it->second;
+  const onnx::TensorProto* s_init = s_it->second;
+  const onnx::TensorProto* z_init = z_it->second;
+  if (b_init->data_type() != onnx::TensorProto::INT8 &&
+      b_init->data_type() != onnx::TensorProto::UINT8) {
+    return std::nullopt;
+  }
+  if (z_init->data_type() != b_init->data_type()) {
+    return std::nullopt;  // Schema: B and b_zero_point share one type.
+  }
+  if (b_init->dims_size() != 2) {
+    return std::nullopt;  // 2-D MatMul weight only.
+  }
+  const int64_t k = b_init->dims(0), n = b_init->dims(1);
+  if (n <= 0 || k <= 0) {
+    return std::nullopt;
+  }
+
+  const auto per_channel_opt = DynQuantPerChannelScaleOk(*s_init, *z_init, n);
+  if (!per_channel_opt) {
+    return std::nullopt;
+  }
+  const bool per_channel = *per_channel_opt;
+
+  const bool has_bias = !bias_name.empty();
+  if (has_bias) {
+    auto bias_it = init_map.find(bias_name);
+    if (bias_it == init_map.end() ||
+        bias_it->second->data_type() != onnx::TensorProto::FLOAT ||
+        !MatMulNBitsDimsEqual(*bias_it->second, {n})) {
+      return std::nullopt;  // Non-constant, or wrong-shaped/dtyped, bias.
+    }
+  }
+
+  std::vector<std::string> shared_names;
+  if (per_channel) {
+    shared_names = {b_name, b_scale_name, b_zp_name};
+  } else {
+    shared_names = {b_name};
+  }
+  if (has_bias) {
+    shared_names.push_back(bias_name);
+  }
+  for (const auto& nm : shared_names) {
+    if (ConsumerCount(consumers_of, nm) != 1) {
+      return std::nullopt;  // Shared/tied tensor -- another node reads it
+                            // too.
+    }
+  }
+
+  DynQuantMatMulWeight w;
+  w.node = node;
+  w.b_name = b_name;
+  w.b_scale_name = b_scale_name;
+  w.b_zero_point_name = b_zp_name;
+  w.bias_name = has_bias ? std::optional<std::string>(bias_name) : std::nullopt;
+  w.per_channel = per_channel;
+  w.N = n;
+  w.K = k;
+  return w;
+}
+
+// If `node` is a `com.microsoft::DynamicQuantizeMatMul` matching every scope
+// boundary this section's own top comment documents, returns the match --
+// mirrors pruning.py's own `_match_dynamic_quantize_matmul`. Input order:
+// `A, B, b_scale, b_zero_point?, bias?` (live schema).
+std::optional<DynQuantMatMulWeight> MatchDynamicQuantizeMatMul(
+    onnx::NodeProto* node, const InitMap& init_map,
+    const ConsumerMap& consumers_of) {
+  if (node->op_type() != "DynamicQuantizeMatMul" ||
+      node->domain() != kComMicrosoftDomain) {
+    return std::nullopt;
+  }
+  if (node->input_size() < 3 || node->input_size() > 5 ||
+      node->output_size() != 1) {
+    return std::nullopt;
+  }
+  const std::string& a_name = node->input(0);
+  const std::string& b_name = node->input(1);
+  const std::string& b_scale_name = node->input(2);
+  if (a_name.empty() || b_name.empty() || b_scale_name.empty()) {
+    return std::nullopt;
+  }
+  const std::string b_zp_name =
+      (node->input_size() > 3) ? node->input(3) : std::string();
+  const std::string bias_name =
+      (node->input_size() > 4) ? node->input(4) : std::string();
+  return MatchDynquantWeightOperands(node, b_name, b_scale_name, b_zp_name,
+                                     bias_name, init_map, consumers_of);
+}
+
+// If `node` is a `com.microsoft::MatMulIntegerToFloat` matching every scope
+// boundary this section's own top comment documents, returns the match --
+// mirrors pruning.py's own `_match_matmul_integer_to_float`. Input order:
+// `A, B, a_scale, b_scale, a_zero_point?, b_zero_point?, bias?` (live
+// schema) -- `a_scale`/`a_zero_point` are read only to index past them,
+// never validated or touched (see this section's own top comment for why).
+std::optional<DynQuantMatMulWeight> MatchMatMulIntegerToFloat(
+    onnx::NodeProto* node, const InitMap& init_map,
+    const ConsumerMap& consumers_of) {
+  if (node->op_type() != "MatMulIntegerToFloat" ||
+      node->domain() != kComMicrosoftDomain) {
+    return std::nullopt;
+  }
+  if (node->input_size() < 4 || node->input_size() > 7 ||
+      node->output_size() != 1) {
+    return std::nullopt;
+  }
+  const std::string& a_name = node->input(0);
+  const std::string& b_name = node->input(1);
+  const std::string& a_scale_name = node->input(2);
+  const std::string& b_scale_name = node->input(3);
+  if (a_name.empty() || b_name.empty() || a_scale_name.empty() ||
+      b_scale_name.empty()) {
+    return std::nullopt;
+  }
+  const std::string b_zp_name =
+      (node->input_size() > 5 && !node->input(5).empty()) ? node->input(5)
+                                                          : std::string();
+  const std::string bias_name =
+      (node->input_size() > 6 && !node->input(6).empty()) ? node->input(6)
+                                                          : std::string();
+  return MatchDynquantWeightOperands(node, b_name, b_scale_name, b_zp_name,
+                                     bias_name, init_map, consumers_of);
+}
+
+// Dispatches to MatchDynamicQuantizeMatMul or MatchMatMulIntegerToFloat by
+// `node->op_type()` -- both ops are matched as EITHER a producer or a
+// consumer, see this section's own top comment for why. Mirrors
+// pruning.py's own `_match_dynquant_producer`.
+std::optional<DynQuantMatMulWeight> MatchDynquantProducer(
+    onnx::NodeProto* node, const InitMap& init_map,
+    const ConsumerMap& consumers_of) {
+  if (node->op_type() == "DynamicQuantizeMatMul") {
+    return MatchDynamicQuantizeMatMul(node, init_map, consumers_of);
+  }
+  if (node->op_type() == "MatMulIntegerToFloat") {
+    return MatchMatMulIntegerToFloat(node, init_map, consumers_of);
+  }
+  return std::nullopt;
+}
+
+// Mirrors pruning.py's own `_DynQuantMatMulChainSide = Union[
+// _DynQuantMatMulWeight, _PlainMatMulNBitsPeer]`.
+using DynQuantChainSide =
+    std::variant<DynQuantMatMulWeight, PlainMatMulNBitsPeer>;
+
+// Mirrors pruning.py's own `_dynquant_chain_side_key`.
+std::string DynQuantSideKey(const DynQuantChainSide& side) {
+  if (const auto* w = std::get_if<DynQuantMatMulWeight>(&side)) {
+    return w->b_name;
+  }
+  return std::get<PlainMatMulNBitsPeer>(side).w_name;
+}
+
+onnx::NodeProto* DynQuantSideNode(const DynQuantChainSide& side) {
+  if (const auto* w = std::get_if<DynQuantMatMulWeight>(&side)) {
+    return w->node;
+  }
+  return std::get<PlainMatMulNBitsPeer>(side).node;
+}
+
+// The full float64 `[N, K]` dequantized weight matrix `w` refers to, for
+// IMPORTANCE RANKING ONLY -- never written back to the graph. Mirrors
+// pruning.py's own `_dynquant_dequantized_nk`, specialized to this
+// section's own always-`(K, N)`-stored, never-transposed convention (no
+// `transB`-equivalent attribute on either op). `init_map` here is the Apply
+// phase's own MUTABLE name->TensorProto* map (only ever called from
+// ApplyDynQuantChains).
+std::vector<double> DynQuantDequantizedNk(
+    const DynQuantMatMulWeight& w,
+    const std::unordered_map<std::string, onnx::TensorProto*>& init_map) {
+  const onnx::TensorProto* b_init = init_map.at(w.b_name);
+  const onnx::TensorProto* scale_init = init_map.at(w.b_scale_name);
+  const onnx::TensorProto* zp_init = init_map.at(w.b_zero_point_name);
+  const std::vector<int64_t> codes = ReadQuantCodes(*b_init);  // [K, N].
+  const std::vector<float> scale = ReadFloatTensor(*scale_init);
+  const std::vector<int64_t> zp = ReadQuantCodes(*zp_init);
+
+  std::vector<double> nk(static_cast<size_t>(w.N * w.K));
+  for (int64_t k = 0; k < w.K; ++k) {
+    for (int64_t n = 0; n < w.N; ++n) {
+      const size_t sidx = w.per_channel ? static_cast<size_t>(n) : 0;
+      const double dq =
+          (static_cast<double>(codes[static_cast<size_t>(k * w.N + n)]) -
+           static_cast<double>(zp[sidx])) *
+          static_cast<double>(scale[sidx]);
+      nk[static_cast<size_t>(n * w.K + k)] = dq;
+    }
+  }
+  return nk;
+}
+
+// `[N, K]` float64 view of one chain PRODUCER's own weight, for IMPORTANCE
+// RANKING ONLY -- never written back. Mirrors pruning.py's own
+// `_dynquant_chain_producer_weight_nk` (identical structure to
+// NBitsSideProducerWeightNK, duplicated rather than templated over the two
+// distinct side-variant types for the same reason every other quantized
+// family in this file keeps its own copy).
+std::vector<double> DynQuantChainProducerWeightNk(
+    const DynQuantChainSide& side,
+    const std::unordered_map<std::string, onnx::TensorProto*>& init_map) {
+  if (const auto* w = std::get_if<DynQuantMatMulWeight>(&side)) {
+    return DynQuantDequantizedNk(*w, init_map);
+  }
+  const auto& p = std::get<PlainMatMulNBitsPeer>(side);
+  const onnx::TensorProto* wt = init_map.at(p.w_name);
+  const std::vector<float> data = ReadFloatTensor(*wt);
+  std::vector<float> nk = p.weight_transposed
+                              ? data
+                              : TransposeFlat(data, wt->dims(0), wt->dims(1));
+  return std::vector<double>(nk.begin(), nk.end());
+}
+
+// --- Slicing, mirroring _slice_dynquant_producer/_slice_dynquant_consumer/
+// _slice_dynquant_chain_producer/_slice_dynquant_chain_consumer -----------
+
+// Slices `w`'s own `N` (output-channel) axis to `keep` (ascending indices)
+// -- the producer role. `B` is always `[K, N]`, so `N` is axis 1 -- sliced
+// via ReadQuantCodes/SetQuantCodes (preserving B's own INT8-vs-UINT8 dtype,
+// unlike a hypothetical dtype-hardcoding helper). `b_scale`/`b_zero_point`
+// (co-sliced only when per-channel) and the plain-float `bias` (sliced
+// exactly like a plain float `Gemm`'s own bias -- no "slice, don't
+// recompute" caveat about a scale it doesn't carry, see this section's own
+// top comment) are both length `N`. Mirrors pruning.py's own
+// `_slice_dynquant_producer`.
+void SliceDynQuantProducer(
+    const DynQuantMatMulWeight& w,
+    const std::unordered_map<std::string, onnx::TensorProto*>& init_map,
+    const std::vector<int64_t>& keep) {
+  onnx::TensorProto* b = init_map.at(w.b_name);
+  const std::vector<int64_t> codes = ReadQuantCodes(*b);  // [K, N].
+  const std::vector<int64_t> new_codes =
+      SliceAlongAxis(codes, {w.K, w.N}, /*axis=*/1, keep);
+  SetQuantCodes(b, b->data_type(), {w.K, static_cast<int64_t>(keep.size())},
+                new_codes);
+
+  if (w.per_channel) {
+    SliceLastAxis(init_map.at(w.b_scale_name), keep);
+    onnx::TensorProto* zt = init_map.at(w.b_zero_point_name);
+    const std::vector<int64_t> zdims(zt->dims().begin(), zt->dims().end());
+    const std::vector<int64_t> zcodes = ReadQuantCodes(*zt);
+    const std::vector<int64_t> new_z = SliceAlongAxis(zcodes, zdims, 0, keep);
+    SetQuantCodes(zt, zt->data_type(), {static_cast<int64_t>(keep.size())},
+                  new_z);
+  }
+  if (w.bias_name) {
+    SliceLastAxis(init_map.at(*w.bias_name), keep);
+  }
+}
+
+// Slices `w`'s own `K` (reduction/input-channel) axis to `keep` -- the
+// consumer role. `B` is always `[K, N]`, so `K` is axis 0. Never touches
+// scale/zero_point/bias -- none of them are indexed by `K` (see this
+// section's own top comment). No block-alignment precondition to check at
+// all -- `B`'s own codes are plain, unpacked, un-blocked, simpler even than
+// `MatMulNBits`'s own consumer role. Mirrors pruning.py's own
+// `_slice_dynquant_consumer`.
+void SliceDynQuantConsumer(
+    const DynQuantMatMulWeight& w,
+    const std::unordered_map<std::string, onnx::TensorProto*>& init_map,
+    const std::vector<int64_t>& keep) {
+  onnx::TensorProto* b = init_map.at(w.b_name);
+  const std::vector<int64_t> codes = ReadQuantCodes(*b);  // [K, N].
+  const std::vector<int64_t> new_codes =
+      SliceAlongAxis(codes, {w.K, w.N}, /*axis=*/0, keep);
+  SetQuantCodes(b, b->data_type(), {static_cast<int64_t>(keep.size()), w.N},
+                new_codes);
+}
+
+// Slices one chain PRODUCER's own output channels to `keep` -- dispatches to
+// SliceDynQuantProducer for a `DynamicQuantizeMatMul`/`MatMulIntegerToFloat`
+// side, or a direct SliceProducerWeight (plus its own bias, if present) for
+// a plain-float peer. Mirrors pruning.py's own
+// `_slice_dynquant_chain_producer`.
+void SliceDynQuantChainProducer(
+    const DynQuantChainSide& side,
+    const std::unordered_map<std::string, onnx::TensorProto*>& init_map,
+    const std::vector<int64_t>& keep) {
+  if (const auto* w = std::get_if<DynQuantMatMulWeight>(&side)) {
+    SliceDynQuantProducer(*w, init_map, keep);
+    return;
+  }
+  const auto& p = std::get<PlainMatMulNBitsPeer>(side);
+  SliceProducerWeight(init_map.at(p.w_name), p.weight_transposed, keep, false);
+  if (p.bias_name) {
+    SliceLastAxis(init_map.at(*p.bias_name), keep);
+  }
+}
+
+// Slices one chain CONSUMER's own input channels to `keep` -- dispatches to
+// SliceDynQuantConsumer for a `DynamicQuantizeMatMul`/`MatMulIntegerToFloat`
+// side, or a direct SliceConsumerWeight for a plain-float peer. Mirrors
+// pruning.py's own `_slice_dynquant_chain_consumer`.
+void SliceDynQuantChainConsumer(
+    const DynQuantChainSide& side,
+    const std::unordered_map<std::string, onnx::TensorProto*>& init_map,
+    const std::vector<int64_t>& keep) {
+  if (const auto* w = std::get_if<DynQuantMatMulWeight>(&side)) {
+    SliceDynQuantConsumer(*w, init_map, keep);
+    return;
+  }
+  const auto& p = std::get<PlainMatMulNBitsPeer>(side);
+  SliceConsumerWeight(init_map.at(p.w_name), p.weight_transposed, keep, false);
+}
+
+// --- Chain finding, mirroring _walk_to_dynquant_consumer/
+// _find_dynquant_chains --------------------------------------------------
+
+struct DynQuantChain {
+  DynQuantChainSide producer;
+  std::vector<onnx::NodeProto*> chain_ops;
+  DynQuantChainSide consumer;
+  int64_t n_channels;
+};
+
+struct DynQuantWalkResult {
+  DynQuantChainSide consumer;
+  std::vector<onnx::NodeProto*> chain_ops;
+};
+
+// From tensor `start` (a `DynamicQuantizeMatMul`/`MatMulIntegerToFloat` OR
+// plain-float MatMul/Gemm producer's own output), walks forward through
+// shape-preserving unary activations (UnaryPassThroughOps) with no other
+// consumer anywhere along the way, until EITHER a `DynamicQuantizeMatMul`/
+// `MatMulIntegerToFloat` consumer OR a plain-float MatMul/vanilla-Gemm
+// consumer (MatchPlainMatMulNBitsPeer) is found whose input-channel count
+// matches `n_channels`. No gated pair, no branch. Mirrors pruning.py's own
+// `_walk_to_dynquant_consumer` exactly.
+std::optional<DynQuantWalkResult> WalkToDynQuantConsumer(
+    const std::string& start, const InitMap& init_map,
+    const ConsumerMap& consumers_of,
+    const std::unordered_set<std::string>& graph_outputs, int64_t n_channels,
+    int max_hops) {
+  std::vector<onnx::NodeProto*> chain_ops;
+  std::string cur = start;
+  for (int hop = 0; hop < max_hops; ++hop) {
+    auto cit = consumers_of.find(cur);
+    if (cit == consumers_of.end() || cit->second.size() != 1) {
+      return std::nullopt;
+    }
+    onnx::NodeProto* nxt = cit->second[0];
+
+    if ((nxt->op_type() == "DynamicQuantizeMatMul" ||
+         nxt->op_type() == "MatMulIntegerToFloat") &&
+        nxt->domain() == kComMicrosoftDomain && nxt->input_size() > 0 &&
+        nxt->input(0) == cur) {
+      auto w = MatchDynquantProducer(nxt, init_map, consumers_of);
+      if (!w || w->K != n_channels) {
+        return std::nullopt;
+      }
+      return DynQuantWalkResult{DynQuantChainSide(*w), std::move(chain_ops)};
+    }
+
+    auto mm = MatchMatMulLikeRaw(*nxt);
+    if (mm && mm->x_name == cur) {
+      auto peer = MatchPlainMatMulNBitsPeer(nxt, init_map, consumers_of);
+      if (!peer || peer->in_channels != n_channels) {
+        return std::nullopt;
+      }
+      return DynQuantWalkResult{DynQuantChainSide(*peer), std::move(chain_ops)};
+    }
+
+    if (!(UnaryPassThroughOps().count(nxt->op_type()) != 0 &&
+          nxt->input_size() == 1 && nxt->input(0) == cur &&
+          nxt->output_size() == 1)) {
+      return std::nullopt;
+    }
+    const std::string& out2 = nxt->output(0);
+    auto oc = consumers_of.find(out2);
+    if (oc == consumers_of.end() || oc->second.size() != 1 ||
+        graph_outputs.count(out2)) {
+      return std::nullopt;
+    }
+    chain_ops.push_back(nxt);
+    cur = out2;
+  }
+  return std::nullopt;
+}
+
+// Every producer/consumer pair connected by WalkToDynQuantConsumer where AT
+// LEAST ONE side is a `DynamicQuantizeMatMul`/`MatMulIntegerToFloat` node (a
+// plain-float-to-plain-float pair is FindChains's own job, not duplicated
+// here). Mirrors pruning.py's own `_find_dynquant_chains`.
+std::vector<DynQuantChain> FindDynQuantChains(onnx::GraphProto* graph) {
+  InitMap init_map;
+  for (const auto& t : graph->initializer()) {
+    init_map[t.name()] = &t;
+  }
+  ConsumerMap consumers_of = ConsumersOf(graph);
+  std::unordered_set<std::string> graph_outputs;
+  for (const auto& o : graph->output()) {
+    graph_outputs.insert(o.name());
+  }
+  auto is_internal = [&](const std::string& name) {
+    return ConsumerCount(consumers_of, name) == 1 && !graph_outputs.count(name);
+  };
+
+  std::vector<DynQuantChain> chains;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    std::optional<DynQuantChainSide> producer;
+    int64_t n_channels = 0;
+    if ((node->op_type() == "DynamicQuantizeMatMul" ||
+         node->op_type() == "MatMulIntegerToFloat") &&
+        node->domain() == kComMicrosoftDomain) {
+      auto w = MatchDynquantProducer(node, init_map, consumers_of);
+      if (!w) {
+        continue;
+      }
+      n_channels = w->N;
+      producer = DynQuantChainSide(*w);
+    } else {
+      auto peer = MatchPlainMatMulNBitsPeer(node, init_map, consumers_of);
+      if (!peer) {
+        continue;
+      }
+      n_channels = peer->out_channels;
+      producer = DynQuantChainSide(*peer);
+    }
+
+    const std::string& out_name = node->output(0);
+    if (!is_internal(out_name)) {
+      continue;
+    }
+    auto found =
+        WalkToDynQuantConsumer(out_name, init_map, consumers_of, graph_outputs,
+                               n_channels, kMaxChainHops);
+    if (!found) {
+      continue;
+    }
+    if (std::holds_alternative<PlainMatMulNBitsPeer>(*producer) &&
+        std::holds_alternative<PlainMatMulNBitsPeer>(found->consumer)) {
+      continue;  // Both plain float -- FindChains's own job.
+    }
+    chains.push_back(DynQuantChain{std::move(*producer),
+                                   std::move(found->chain_ops),
+                                   std::move(found->consumer), n_channels});
+  }
+  return chains;
+}
+
+// --- Apply, mirroring apply_structured_pruning_dynamic_quantize_matmul's
+// own per-chain loop ------------------------------------------------------
+
+// Ranks the producer's output channels by L2 norm of their own (dequantized,
+// for a `DynQuantMatMulWeight` producer) weight row, drops the lowest-
+// `sparsity`-fraction, and slices the producer's quantized weight/scale/
+// zero-point (co-sliced together only when per-channel; left untouched when
+// per-tensor)/bias together with the matching input channels of the
+// consumer's own weight -- no block-alignment concern on EITHER side (see
+// this section's own top comment), unlike ApplyMatMulNBitsChains/
+// ApplyFp8BlockQuantizedChains/ApplyFp4BlockQuantizedChains, so the same
+// `keep` set always applies to both sides directly. Shares `touched` with
+// every other chain family ApplyStructuredPruning already applies over this
+// same graph.
+void ApplyDynQuantChains(onnx::GraphProto* graph,
+                         std::vector<DynQuantChain>& chains, double sparsity,
+                         TouchedState& touched) {
+  std::unordered_map<std::string, onnx::TensorProto*> init_map;
+  for (int i = 0; i < graph->initializer_size(); ++i) {
+    onnx::TensorProto* t = graph->mutable_initializer(i);
+    init_map[t->name()] = t;
+  }
+
+  auto row_norms = [](const std::vector<double>& w_nk, int64_t n) {
+    const int64_t k = static_cast<int64_t>(w_nk.size()) / n;
+    std::vector<double> importance(static_cast<size_t>(n), 0.0);
+    for (int64_t c = 0; c < n; ++c) {
+      double sq = 0.0;
+      for (int64_t j = 0; j < k; ++j) {
+        const double v = w_nk[static_cast<size_t>(c * k + j)];
+        sq += v * v;
+      }
+      importance[static_cast<size_t>(c)] = std::sqrt(sq);
+    }
+    return importance;
+  };
+
+  for (auto& chain : chains) {
+    const std::string p_key = DynQuantSideKey(chain.producer);
+    const std::string c_key = DynQuantSideKey(chain.consumer);
+    if (p_key == c_key) {
+      continue;  // Degenerate (the same weight in both roles).
+    }
+    if (touched.producer.count(p_key) || touched.consumer.count(c_key)) {
+      continue;  // A shared/tied weight another chain already resized.
+    }
+
+    const int64_t n = chain.n_channels;
+    const int64_t keep_count = std::max<int64_t>(
+        1, n - std::llround(static_cast<double>(n) * sparsity));
+    if (keep_count >= n) {
+      continue;  // Rounds down to nothing for this layer -- no-op.
+    }
+
+    const std::vector<double> w_nk =
+        DynQuantChainProducerWeightNk(chain.producer, init_map);
+    std::vector<double> importance = row_norms(w_nk, n);
+    const std::vector<int64_t> keep =
+        TopKIndicesAscending(importance, keep_count);
+
+    SliceDynQuantChainProducer(chain.producer, init_map, keep);
+    SliceDynQuantChainConsumer(chain.consumer, init_map, keep);
+
+    touched.producer.insert(p_key);
+    touched.consumer.insert(c_key);
+    touched.stale_value_info.insert(
+        DynQuantSideNode(chain.producer)->output(0));
+    for (auto* op : chain.chain_ops) {
+      touched.stale_value_info.insert(op->output(0));
+    }
+  }
+}
+
 // --- Subgraph recursion ------------------------------------------------
 //
 // Mirrors pruning.py's own `_iter_subgraphs` and the "Subgraph recursion"
@@ -15925,6 +16587,7 @@ onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
     std::vector<Fp4Chain> fp4_block_quantized_chains =
         FindFp4BlockQuantizedChains(graph);
     std::vector<QOpChain> qop_chains = FindQopChains(graph);
+    std::vector<DynQuantChain> dynquant_chains = FindDynQuantChains(graph);
 
     TouchedState touched;
     if (!chains.empty()) {
@@ -16001,16 +16664,26 @@ onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
                                    touched);
     }
     if (!qop_chains.empty()) {
-      // The tenth and final application pass over this graph -- QOperator
-      // (QLinearConv/QLinearMatMul/QGemm static-quantization) chains, see
-      // this file's own "QOperator (QLinearConv/QLinearMatMul/QGemm
-      // static-quantization) structured pruning" section comment. A
+      // QOperator (QLinearConv/QLinearMatMul/QGemm static-quantization)
+      // chains, see this file's own "QOperator (QLinearConv/QLinearMatMul/
+      // QGemm static-quantization) structured pruning" section comment. A
       // genuinely separate match (QLinearConv/QLinearMatMul/QGemm are node
       // types no other Find*Chains call above recognizes at all), still
       // sharing `touched` with every call above for the same "one shared
       // conflict ledger per graph" reason every other quantized-weight pass
       // here does.
       ApplyQopChains(graph, qop_chains, sparsity, touched);
+    }
+    if (!dynquant_chains.empty()) {
+      // The eleventh and final application pass over this graph -- see this
+      // file's own "DynamicQuantizeMatMul / MatMulIntegerToFloat" section
+      // comment. Shares `touched` with every call above for the same "one
+      // shared conflict ledger per graph" reason every other quantized-
+      // weight pass here does: a plain-float weight this pass matches (as
+      // the OTHER side of a mixed chain) can never be double-resized by, or
+      // double-resize, an ordinary chain/MatMulNBits/QDQ/Bnb4/Fp8/Fp4/QOperator
+      // chain that already touched it.
+      ApplyDynQuantChains(graph, dynquant_chains, sparsity, touched);
     }
     if (!touched.stale_value_info.empty()) {
       google::protobuf::RepeatedPtrField<onnx::ValueInfoProto> kept;

--- a/tests/test_structured_pruning_cpp.py
+++ b/tests/test_structured_pruning_cpp.py
@@ -7710,3 +7710,765 @@ def test_cpp_structured_pruning_matmul_block_quantized_fp4_matches_python_refere
     py_bytes = {t.name: t.SerializeToString() for t in pruned_py.graph.initializer}
     cpp_bytes = {t.name: t.SerializeToString() for t in pruned_cpp.graph.initializer}
     assert py_bytes == cpp_bytes
+
+
+# --- QOperator (QLinearConv/QLinearMatMul/QGemm static-quantization) -------
+# --- structured pruning -----------------------------------------------------
+#
+# Mirrors ``tests/test_pruning.py``'s own "QOperator (QLinearConv/
+# QLinearMatMul/QGemm) structured pruning tests" coverage for
+# ``onnxsim.apply_structured_pruning_cpp`` -- the C++ port also runs these
+# QOperator chains (see ``onnxsim/structured_pruning_entry.cpp``'s own
+# "QOperator (QLinearConv/QLinearMatMul/QGemm static-quantization) structured
+# pruning" section comment), wired into the SAME entry point as the
+# plain-float/QDQ/etc. chains above (unlike ``onnxsim.pruning``, which keeps
+# ``apply_structured_pruning_qoperator`` a separate top-level function).
+# QLinearConv/QLinearMatMul/QGemm carry their own quantized weight/scale/
+# zero-point/bias directly as node inputs -- there is no DequantizeLinear
+# node to build through parser text the way the QDQ tests above do, and the
+# scale/zero-point/int32-bias tensors need real int8/uint8/int32 array data a
+# parser text literal can't spell out -- so, mirroring this file's own QDQ/
+# MatMulNBits/Fp4/Fp8 test helpers above (and ``test_pruning.py``'s own
+# identical choice for this same section), these models are built directly
+# via ``onnx.helper``, with real numpy-quantized tensors attached as
+# initializers.
+
+
+def _u8(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.uint8), name)
+
+
+def _i32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.int32), name)
+
+
+def _qop_quantize_per_channel_i8(w, axis):
+    """Independent (onnxsim-code-free) symmetric per-channel INT8
+    quantizer -- `axis` is the output-channel axis. Returns
+    ``(q, scale, zero_point)`` with `zero_point` all-zero (symmetric),
+    matching this repo's own ``quantize_qoperator``/``quantize_qoperator_gemm``
+    convention (see ``onnxsim/pruning.py``'s own "QOperator" section
+    comment).
+    """
+    absmax = np.max(np.abs(w), axis=tuple(i for i in range(w.ndim) if i != axis))
+    absmax = np.maximum(absmax, 1e-6)
+    scale = (absmax / 127.0).astype(np.float32)
+    shp = [1] * w.ndim
+    shp[axis] = -1
+    q = np.clip(np.round(w / scale.reshape(shp)), -127, 127).astype(np.int8)
+    zp = np.zeros_like(scale, dtype=np.int8)
+    return q, scale, zp
+
+
+def _qop_dequant(q, scale, zero_point, axis):
+    q = q.astype(np.float64)
+    scale = scale.astype(np.float64)
+    zp = zero_point.astype(np.float64)
+    if scale.ndim >= 1 and scale.size > 1:
+        shape = [1] * q.ndim
+        shape[axis] = -1
+        scale = scale.reshape(shape)
+        zp = zp.reshape(shape)
+    return (q - zp) * scale
+
+
+def _qlinearconv_node(
+    name,
+    x,
+    y,
+    w,
+    w_scale,
+    w_zp,
+    y_scale,
+    y_zp,
+    bias,
+    x_scale="x_scale",
+    x_zp="x_zp",
+    **attrs,
+):
+    inputs = [x, x_scale, x_zp, w, w_scale, w_zp, y_scale, y_zp]
+    if bias is not None:
+        inputs.append(bias)
+    return onnx.helper.make_node("QLinearConv", inputs, [y], name=name, **attrs)
+
+
+def _qlinearconv_chain_model(
+    N1=6, C1=3, N2=4, kh=3, kw=3, bias=True, per_channel=True, seed=0
+):
+    """Builds ``QLinearConv(n1) -> QLinearConv(n2)`` -- a same-family
+    QOperator chain -- with real, independently-quantized weights. Returns
+    ``(model, info)`` where `info` carries every quantized array needed to
+    hand-build an "already pruned" oracle.
+    """
+    rng = np.random.default_rng(seed)
+    W1 = rng.standard_normal((N1, C1, kh, kw)).astype(np.float32) * 0.3
+    W2 = rng.standard_normal((N2, N1, 1, 1)).astype(np.float32) * 0.3
+    B1f = (rng.standard_normal(N1).astype(np.float32) * 0.05) if bias else None
+    B2f = (rng.standard_normal(N2).astype(np.float32) * 0.05) if bias else None
+
+    x_scale = np.float32(0.02)
+    x_zp = np.uint8(120)
+
+    if per_channel:
+        W1q, W1s, W1zp = _qop_quantize_per_channel_i8(W1, axis=0)
+        W2q, W2s, W2zp = _qop_quantize_per_channel_i8(W2, axis=0)
+    else:
+        w1q_flat, w1s_flat, w1zp_flat = _qop_quantize_per_channel_i8(
+            W1.reshape(1, -1), axis=0
+        )
+        W1q, W1s, W1zp = w1q_flat.reshape(W1.shape), w1s_flat[0], w1zp_flat[0]
+        w2q_flat, w2s_flat, w2zp_flat = _qop_quantize_per_channel_i8(
+            W2.reshape(1, -1), axis=0
+        )
+        W2q, W2s, W2zp = w2q_flat.reshape(W2.shape), w2s_flat[0], w2zp_flat[0]
+
+    y1_scale = np.float32(0.03)
+    y1_zp = np.uint8(120)
+    y2_scale = np.float32(0.04)
+    y2_zp = np.uint8(120)
+
+    B1q = None
+    if B1f is not None:
+        b1_dequant_scale = x_scale.astype(np.float64) * W1s.astype(np.float64)
+        B1q = np.round(B1f.astype(np.float64) / b1_dequant_scale).astype(np.int32)
+    B2q = None
+    if B2f is not None:
+        b2_dequant_scale = y1_scale.astype(np.float64) * W2s.astype(np.float64)
+        B2q = np.round(B2f.astype(np.float64) / b2_dequant_scale).astype(np.int32)
+
+    inits = [
+        _f32(np.array(x_scale), "x_scale"),
+        _u8(np.array(x_zp), "x_zp"),
+        onnx.numpy_helper.from_array(W1q, "W1"),
+        _f32(np.atleast_1d(W1s) if per_channel else np.array(W1s), "W1_scale"),
+        _i8(np.atleast_1d(W1zp) if per_channel else np.array(W1zp), "W1_zp"),
+        _f32(np.array(y1_scale), "y1_scale"),
+        _u8(np.array(y1_zp), "y1_zp"),
+        onnx.numpy_helper.from_array(W2q, "W2"),
+        _f32(np.atleast_1d(W2s) if per_channel else np.array(W2s), "W2_scale"),
+        _i8(np.atleast_1d(W2zp) if per_channel else np.array(W2zp), "W2_zp"),
+        _f32(np.array(y2_scale), "y2_scale"),
+        _u8(np.array(y2_zp), "y2_zp"),
+    ]
+    if B1q is not None:
+        inits.append(_i32(B1q, "B1"))
+    if B2q is not None:
+        inits.append(_i32(B2q, "B2"))
+
+    n1 = _qlinearconv_node(
+        "n1",
+        "x_q",
+        "y1_q",
+        "W1",
+        "W1_scale",
+        "W1_zp",
+        "y1_scale",
+        "y1_zp",
+        "B1" if B1q is not None else None,
+        kernel_shape=[kh, kw],
+        pads=[0, 0, 0, 0],
+    )
+    n2 = _qlinearconv_node(
+        "n2",
+        "y1_q",
+        "y2_q",
+        "W2",
+        "W2_scale",
+        "W2_zp",
+        "y2_scale",
+        "y2_zp",
+        "B2" if B2q is not None else None,
+        x_scale="y1_scale",
+        x_zp="y1_zp",
+        kernel_shape=[1, 1],
+        pads=[0, 0, 0, 0],
+    )
+    spatial = 8
+    out_spatial = spatial - kh + 1
+    graph = onnx.helper.make_graph(
+        [n1, n2],
+        "g",
+        [
+            onnx.helper.make_tensor_value_info(
+                "x_q", onnx.TensorProto.UINT8, [1, C1, spatial, spatial]
+            )
+        ],
+        [
+            onnx.helper.make_tensor_value_info(
+                "y2_q", onnx.TensorProto.UINT8, [1, N2, out_spatial, out_spatial]
+            )
+        ],
+        initializer=inits,
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 17)]
+    )
+    model.ir_version = 10
+    return model, {
+        "W1": W1q,
+        "W1_scale": W1s,
+        "W1_zp": W1zp,
+        "B1": B1q,
+        "W2": W2q,
+        "W2_scale": W2s,
+        "W2_zp": W2zp,
+        "B2": B2q,
+        "x_scale": x_scale,
+        "spatial": spatial,
+        "C1": C1,
+    }
+
+
+def test_cpp_qlinearconv_chain_matches_oracle_via_real_inference_session():
+    # Byte-identity ("slice, don't recompute") AND a real onnxruntime
+    # end-to-end run against an independently reconstructed "already pruned"
+    # reference model, per this task's own correctness bar.
+    N1, C1, N2 = 6, 3, 4
+    model, info = _qlinearconv_chain_model(N1=N1, C1=C1, N2=N2, seed=2)
+    onnx.checker.check_model(model)
+
+    w1_dequant = _qop_dequant(info["W1"], info["W1_scale"], info["W1_zp"], axis=0)
+    keep = _oracle_keep_indices_conv(w1_dequant, N1 // 2)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [N1 // 2, C1, 3, 3]
+    assert list(inits["W1_scale"].dims) == [N1 // 2]
+    assert list(inits["W1_zp"].dims) == [N1 // 2]
+    assert list(inits["B1"].dims) == [N1 // 2]
+    assert list(inits["W2"].dims) == [N2, N1 // 2, 1, 1]
+
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["W1"]), info["W1"][keep]
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["W1_scale"]), info["W1_scale"][keep]
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["W1_zp"]), info["W1_zp"][keep]
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["B1"]), info["B1"][keep]
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["W2"]), info["W2"][:, keep]
+    )
+
+    ref_model, _ = _qlinearconv_chain_model(N1=len(keep), C1=C1, N2=N2, seed=1234567)
+    ref_inits = {t.name: t for t in ref_model.graph.initializer}
+    ref_inits["W1"].CopyFrom(onnx.numpy_helper.from_array(info["W1"][keep], "W1"))
+    ref_inits["W1_scale"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W1_scale"][keep], "W1_scale")
+    )
+    ref_inits["W1_zp"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W1_zp"][keep], "W1_zp")
+    )
+    ref_inits["B1"].CopyFrom(onnx.numpy_helper.from_array(info["B1"][keep], "B1"))
+    ref_inits["W2"].CopyFrom(onnx.numpy_helper.from_array(info["W2"][:, keep], "W2"))
+    ref_inits["W2_scale"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W2_scale"], "W2_scale")
+    )
+    ref_inits["W2_zp"].CopyFrom(onnx.numpy_helper.from_array(info["W2_zp"], "W2_zp"))
+    ref_inits["B2"].CopyFrom(onnx.numpy_helper.from_array(info["B2"], "B2"))
+
+    rng = np.random.default_rng(11)
+    spatial = info["spatial"]
+    xq = rng.integers(0, 255, size=(1, C1, spatial, spatial)).astype(np.uint8)
+    (y_pruned,) = _run(pruned, {"x_q": xq})
+    (y_ref,) = _run(ref_model, {"x_q": xq})
+    np.testing.assert_array_equal(y_pruned, y_ref)
+
+
+def test_cpp_qlinearconv_per_tensor_scale_left_untouched():
+    model, _info = _qlinearconv_chain_model(N1=6, C1=3, N2=4, per_channel=False, seed=3)
+    onnx.checker.check_model(model)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    # per-tensor scale/zero-point are scalars -- never sliced, regardless of
+    # channel count.
+    assert list(inits["W1_scale"].dims) == []
+    assert list(inits["W1_zp"].dims) == []
+    assert list(inits["W1"].dims) == [3, 3, 3, 3]
+    assert list(inits["B1"].dims) == [3]  # bias always co-sliced regardless
+
+
+def test_cpp_qlinearconv_declines_grouped_conv():
+    model, _info = _qlinearconv_chain_model(N1=6, C1=3, N2=4, seed=4)
+    for node in model.graph.node:
+        if node.name == "n1":
+            node.attribute.append(onnx.helper.make_attribute("group", 3))
+    onnx.checker.check_model(model)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    # nothing changes -- no matched chain to prune
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [6, 3, 3, 3]
+
+
+def test_cpp_qlinearconv_declines_shared_weight():
+    model, _info = _qlinearconv_chain_model(N1=6, C1=3, N2=4, seed=6)
+    # a second, unrelated node also reads W1 -- shared/tied, can't be sliced.
+    extra = onnx.helper.make_node("Identity", ["W1"], ["W1_alias"], name="alias")
+    model.graph.node.append(extra)
+    model.graph.output.append(
+        onnx.helper.make_tensor_value_info(
+            "W1_alias", onnx.TensorProto.INT8, [6, 3, 3, 3]
+        )
+    )
+    onnx.checker.check_model(model)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [6, 3, 3, 3]
+
+
+# --- QLinearMatMul --------------------------------------------------------
+
+
+def _qlinearmatmul_node(
+    name, a, y, b, b_scale, b_zp, y_scale, y_zp, a_scale="a_scale", a_zp="a_zp"
+):
+    return onnx.helper.make_node(
+        "QLinearMatMul",
+        [a, a_scale, a_zp, b, b_scale, b_zp, y_scale, y_zp],
+        [y],
+        name=name,
+    )
+
+
+def _qlinearmatmul_chain_model(K=8, H=6, Out=4, seed=0):
+    """Builds ``QLinearMatMul(n1) -> QLinearMatMul(n2)`` -- both real,
+    per-channel INT8 weights, matching this repo's own
+    ``quantize_qoperator`` convention (`b` stored ``[K, N]``, `b_scale`/
+    `b_zero_point` per-column).
+    """
+    rng = np.random.default_rng(seed)
+    W1 = rng.standard_normal((K, H)).astype(np.float32) * 0.3
+    W2 = rng.standard_normal((H, Out)).astype(np.float32) * 0.3
+    W1q, W1s, W1zp = _qop_quantize_per_channel_i8(W1, axis=1)
+    W2q, W2s, W2zp = _qop_quantize_per_channel_i8(W2, axis=1)
+
+    a_scale = np.float32(0.02)
+    a_zp = np.uint8(120)
+    y1_scale = np.float32(0.03)
+    y1_zp = np.uint8(120)
+    y2_scale = np.float32(0.04)
+    y2_zp = np.uint8(120)
+
+    inits = [
+        _f32(np.array(a_scale), "a_scale"),
+        _u8(np.array(a_zp), "a_zp"),
+        onnx.numpy_helper.from_array(W1q, "W1"),
+        _f32(W1s, "W1_scale"),
+        _i8(W1zp, "W1_zp"),
+        _f32(np.array(y1_scale), "y1_scale"),
+        _u8(np.array(y1_zp), "y1_zp"),
+        onnx.numpy_helper.from_array(W2q, "W2"),
+        _f32(W2s, "W2_scale"),
+        _i8(W2zp, "W2_zp"),
+        _f32(np.array(y2_scale), "y2_scale"),
+        _u8(np.array(y2_zp), "y2_zp"),
+    ]
+    n1 = _qlinearmatmul_node(
+        "n1", "x_q", "y1_q", "W1", "W1_scale", "W1_zp", "y1_scale", "y1_zp"
+    )
+    n2 = _qlinearmatmul_node(
+        "n2",
+        "y1_q",
+        "y2_q",
+        "W2",
+        "W2_scale",
+        "W2_zp",
+        "y2_scale",
+        "y2_zp",
+        a_scale="y1_scale",
+        a_zp="y1_zp",
+    )
+    graph = onnx.helper.make_graph(
+        [n1, n2],
+        "g",
+        [onnx.helper.make_tensor_value_info("x_q", onnx.TensorProto.UINT8, [2, K])],
+        [onnx.helper.make_tensor_value_info("y2_q", onnx.TensorProto.UINT8, [2, Out])],
+        initializer=inits,
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 21)]
+    )
+    model.ir_version = 10
+    return model, {
+        "W1": W1q,
+        "W1_scale": W1s,
+        "W1_zp": W1zp,
+        "W2": W2q,
+        "W2_scale": W2s,
+        "W2_zp": W2zp,
+    }
+
+
+def test_cpp_qlinearmatmul_chain_matches_oracle():
+    K, H, Out = 8, 6, 4
+    model, info = _qlinearmatmul_chain_model(K, H, Out, seed=10)
+    onnx.checker.check_model(model)
+
+    w1_dequant = _qop_dequant(info["W1"], info["W1_scale"], info["W1_zp"], axis=1)
+    keep = _oracle_keep_indices(w1_dequant, H // 2)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["W1"]), info["W1"][:, keep]
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["W1_scale"]), info["W1_scale"][keep]
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["W2"]), info["W2"][keep, :]
+    )
+
+    ref_model, _ = _qlinearmatmul_chain_model(K, len(keep), Out, seed=999)
+    ref_inits = {t.name: t for t in ref_model.graph.initializer}
+    ref_inits["W1"].CopyFrom(onnx.numpy_helper.from_array(info["W1"][:, keep], "W1"))
+    ref_inits["W1_scale"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W1_scale"][keep], "W1_scale")
+    )
+    ref_inits["W1_zp"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W1_zp"][keep], "W1_zp")
+    )
+    ref_inits["W2"].CopyFrom(onnx.numpy_helper.from_array(info["W2"][keep, :], "W2"))
+    ref_inits["W2_scale"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W2_scale"], "W2_scale")
+    )
+    ref_inits["W2_zp"].CopyFrom(onnx.numpy_helper.from_array(info["W2_zp"], "W2_zp"))
+
+    rng = np.random.default_rng(12)
+    xq = rng.integers(0, 255, size=(2, K)).astype(np.uint8)
+    (y_pruned,) = _run(pruned, {"x_q": xq})
+    (y_ref,) = _run(ref_model, {"x_q": xq})
+    np.testing.assert_array_equal(y_pruned, y_ref)
+
+
+def test_cpp_qlinearmatmul_declines_shared_weight():
+    model, _info = _qlinearmatmul_chain_model(K=8, H=6, Out=4, seed=13)
+    extra = onnx.helper.make_node("Identity", ["W1"], ["W1_alias"], name="alias")
+    model.graph.node.append(extra)
+    model.graph.output.append(
+        onnx.helper.make_tensor_value_info("W1_alias", onnx.TensorProto.INT8, [8, 6])
+    )
+    onnx.checker.check_model(model)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [8, 6]
+
+
+def test_cpp_qlinearmatmul_declines_flatten_crossing_conv_producer():
+    # The real onnxruntime.quantization.quantize_static(quant_format=
+    # QOperator) round trip this section's own top comment (see
+    # onnxsim/pruning.py) reproduces emits exactly QLinearConv -> Flatten ->
+    # QLinearMatMul -- confirmed NOT matched here (same-family-only walk,
+    # mirroring the QDQ section's own identical, pre-existing gap for
+    # Flatten-crossing chains).
+    conv_model, conv_info = _qlinearconv_chain_model(N1=6, C1=3, N2=4, seed=20)
+    n1 = [n for n in conv_model.graph.node if n.name == "n1"][0]
+    keep_inits = [
+        t
+        for t in conv_model.graph.initializer
+        if t.name
+        in ("x_scale", "x_zp", "W1", "W1_scale", "W1_zp", "y1_scale", "y1_zp", "B1")
+    ]
+    spatial = conv_info["spatial"]
+    out_spatial = spatial - 3 + 1
+    flat_dim = 6 * out_spatial * out_spatial
+    Kmm, Out = flat_dim, 4
+    rng = np.random.default_rng(21)
+    Wmm = rng.standard_normal((Kmm, Out)).astype(np.float32) * 0.3
+    Wmmq, Wmms, Wmmzp = _qop_quantize_per_channel_i8(Wmm, axis=1)
+    flatten = onnx.helper.make_node("Flatten", ["y1_q"], ["flat_q"], axis=1)
+    mm = _qlinearmatmul_node(
+        "mm",
+        "flat_q",
+        "y_q",
+        "Wmm",
+        "Wmm_scale",
+        "Wmm_zp",
+        "y2_scale",
+        "y2_zp",
+        a_scale="y1_scale",
+        a_zp="y1_zp",
+    )
+    inits = list(keep_inits) + [
+        onnx.numpy_helper.from_array(Wmmq, "Wmm"),
+        _f32(Wmms, "Wmm_scale"),
+        _i8(Wmmzp, "Wmm_zp"),
+        _f32(np.array(0.05, dtype=np.float32), "y2_scale"),
+        _u8(np.array(120, dtype=np.uint8), "y2_zp"),
+    ]
+    graph = onnx.helper.make_graph(
+        [n1, flatten, mm],
+        "g",
+        [
+            onnx.helper.make_tensor_value_info(
+                "x_q", onnx.TensorProto.UINT8, [1, 3, spatial, spatial]
+            )
+        ],
+        [onnx.helper.make_tensor_value_info("y_q", onnx.TensorProto.UINT8, [1, Out])],
+        initializer=inits,
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 17)]
+    )
+    model.ir_version = 10
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    # nothing changes -- no matched chain to prune (no Flatten-crossing hop).
+    inits_after = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits_after["W1"].dims) == [6, 3, 3, 3]
+
+
+# --- QGemm ------------------------------------------------------------
+
+
+def _qgemm_node(name, a, y, b, b_scale, b_zp, c, y_scale, y_zp, **attrs):
+    inputs = [a, "a_scale", "a_zp", b, b_scale, b_zp]
+    inputs.append(c or "")
+    inputs.append(y_scale or "")
+    inputs.append(y_zp or "")
+    while inputs and not inputs[-1]:
+        inputs.pop()
+    return onnx.helper.make_node(
+        "QGemm", inputs, [y], domain="com.microsoft", name=name, **attrs
+    )
+
+
+def _qgemm_chain_model(K=8, H=6, Out=4, transB1=0, transB2=0, bias=True, seed=0):
+    rng = np.random.default_rng(seed)
+    W1f = rng.standard_normal((H, K) if transB1 else (K, H)).astype(np.float32) * 0.3
+    W2f = (
+        rng.standard_normal((Out, H) if transB2 else (H, Out)).astype(np.float32) * 0.3
+    )
+    axis1 = 0 if transB1 else 1
+    axis2 = 0 if transB2 else 1
+    W1q, W1s, W1zp = _qop_quantize_per_channel_i8(W1f, axis=axis1)
+    W2q, W2s, W2zp = _qop_quantize_per_channel_i8(W2f, axis=axis2)
+
+    a_scale = np.float32(0.02)
+    a_zp = np.uint8(120)
+    y1_scale = np.float32(0.03)
+    y1_zp = np.uint8(120)
+    y2_scale = np.float32(0.04)
+    y2_zp = np.uint8(120)
+
+    C1f = (rng.standard_normal(H).astype(np.float32) * 0.05) if bias else None
+    C2f = (rng.standard_normal(Out).astype(np.float32) * 0.05) if bias else None
+    C1q = None
+    if C1f is not None:
+        c1_scale = a_scale.astype(np.float64) * W1s.astype(np.float64)
+        C1q = np.round(C1f.astype(np.float64) / c1_scale).astype(np.int32)
+    C2q = None
+    if C2f is not None:
+        c2_scale = y1_scale.astype(np.float64) * W2s.astype(np.float64)
+        C2q = np.round(C2f.astype(np.float64) / c2_scale).astype(np.int32)
+
+    inits = [
+        _f32(np.array(a_scale), "a_scale"),
+        _u8(np.array(a_zp), "a_zp"),
+        onnx.numpy_helper.from_array(W1q, "W1"),
+        _f32(W1s, "W1_scale"),
+        _i8(W1zp, "W1_zp"),
+        _f32(np.array(y1_scale), "y1_scale"),
+        _u8(np.array(y1_zp), "y1_zp"),
+        onnx.numpy_helper.from_array(W2q, "W2"),
+        _f32(W2s, "W2_scale"),
+        _i8(W2zp, "W2_zp"),
+        _f32(np.array(y2_scale), "y2_scale"),
+        _u8(np.array(y2_zp), "y2_zp"),
+    ]
+    if C1q is not None:
+        inits.append(_i32(C1q, "C1"))
+    if C2q is not None:
+        inits.append(_i32(C2q, "C2"))
+
+    n1 = _qgemm_node(
+        "n1",
+        "x_q",
+        "y1_q",
+        "W1",
+        "W1_scale",
+        "W1_zp",
+        "C1" if C1q is not None else None,
+        "y1_scale",
+        "y1_zp",
+        transB=transB1,
+    )
+    n2 = _qgemm_node(
+        "n2",
+        "y1_q",
+        "y2_q",
+        "W2",
+        "W2_scale",
+        "W2_zp",
+        "C2" if C2q is not None else None,
+        "y2_scale",
+        "y2_zp",
+        transB=transB2,
+    )
+    n2.input[1] = "y1_scale"
+    n2.input[2] = "y1_zp"
+    graph = onnx.helper.make_graph(
+        [n1, n2],
+        "g",
+        [onnx.helper.make_tensor_value_info("x_q", onnx.TensorProto.UINT8, [2, K])],
+        [onnx.helper.make_tensor_value_info("y2_q", onnx.TensorProto.UINT8, [2, Out])],
+        initializer=inits,
+    )
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 17),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    model.ir_version = 10
+    return model, {
+        "W1": W1q,
+        "W1_scale": W1s,
+        "W1_zp": W1zp,
+        "C1": C1q,
+        "W2": W2q,
+        "W2_scale": W2s,
+        "W2_zp": W2zp,
+        "C2": C2q,
+    }
+
+
+@pytest.mark.parametrize("transB1,transB2", [(0, 0), (1, 0), (0, 1), (1, 1)])
+def test_cpp_qgemm_chain_transb_matches_oracle(transB1, transB2):
+    K, H, Out = 8, 6, 4
+    model, info = _qgemm_chain_model(
+        K, H, Out, transB1=transB1, transB2=transB2, seed=30
+    )
+    onnx.checker.check_model(model)
+
+    axis1 = 0 if transB1 else 1
+    w1_dequant = _qop_dequant(info["W1"], info["W1_scale"], info["W1_zp"], axis=axis1)
+    w1_nk = w1_dequant if transB1 else w1_dequant.T
+    keep = np.sort(np.argsort(-np.linalg.norm(w1_nk, axis=1))[: H // 2])
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+
+    w1_expected = info["W1"][keep, :] if transB1 else info["W1"][:, keep]
+    w2_expected = info["W2"][:, keep] if transB2 else info["W2"][keep, :]
+    np.testing.assert_array_equal(onnx.numpy_helper.to_array(inits["W1"]), w1_expected)
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["W1_scale"]), info["W1_scale"][keep]
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["C1"]), info["C1"][keep]
+    )
+    np.testing.assert_array_equal(onnx.numpy_helper.to_array(inits["W2"]), w2_expected)
+
+    ref_model, _ = _qgemm_chain_model(
+        K, len(keep), Out, transB1=transB1, transB2=transB2, seed=555
+    )
+    ref_inits = {t.name: t for t in ref_model.graph.initializer}
+    ref_inits["W1"].CopyFrom(onnx.numpy_helper.from_array(w1_expected, "W1"))
+    ref_inits["W1_scale"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W1_scale"][keep], "W1_scale")
+    )
+    ref_inits["W1_zp"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W1_zp"][keep], "W1_zp")
+    )
+    ref_inits["C1"].CopyFrom(onnx.numpy_helper.from_array(info["C1"][keep], "C1"))
+    ref_inits["W2"].CopyFrom(onnx.numpy_helper.from_array(w2_expected, "W2"))
+    ref_inits["W2_scale"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W2_scale"], "W2_scale")
+    )
+    ref_inits["W2_zp"].CopyFrom(onnx.numpy_helper.from_array(info["W2_zp"], "W2_zp"))
+    ref_inits["C2"].CopyFrom(onnx.numpy_helper.from_array(info["C2"], "C2"))
+
+    rng = np.random.default_rng(31)
+    xq = rng.integers(0, 255, size=(2, K)).astype(np.uint8)
+    (y_pruned,) = _run(pruned, {"x_q": xq})
+    (y_ref,) = _run(ref_model, {"x_q": xq})
+    np.testing.assert_array_equal(y_pruned, y_ref)
+
+
+def test_cpp_qgemm_declines_shared_weight():
+    model, _info = _qgemm_chain_model(seed=44)
+    extra = onnx.helper.make_node("Identity", ["W1"], ["W1_alias"], name="alias")
+    model.graph.node.append(extra)
+    model.graph.output.append(
+        onnx.helper.make_tensor_value_info("W1_alias", onnx.TensorProto.INT8, [8, 6])
+    )
+    onnx.checker.check_model(model)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [8, 6]
+
+
+def test_cpp_qgemm_declines_trans_a_nonzero():
+    model, _info = _qgemm_chain_model(seed=40)
+    for node in model.graph.node:
+        if node.name == "n1":
+            node.attribute.append(onnx.helper.make_attribute("transA", 1))
+    onnx.checker.check_model(model)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [8, 6]
+
+
+def test_cpp_qgemm_declines_alpha_nonone():
+    model, _info = _qgemm_chain_model(seed=41)
+    for node in model.graph.node:
+        if node.name == "n1":
+            node.attribute.append(onnx.helper.make_attribute("alpha", 2.0))
+    onnx.checker.check_model(model)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [8, 6]
+
+
+def test_cpp_qgemm_scalar_bias_left_untouched():
+    K, H, Out = 8, 6, 4
+    model, _info = _qgemm_chain_model(K, H, Out, bias=True, seed=42)
+    inits = {t.name: t for t in model.graph.initializer}
+    inits["C1"].CopyFrom(_i32(np.array([7]), "C1"))
+    onnx.checker.check_model(model)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    pruned_inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(pruned_inits["C1"].dims) == [1]
+    np.testing.assert_array_equal(onnx.numpy_helper.to_array(pruned_inits["C1"]), [7])
+    assert list(pruned_inits["W1"].dims) == [K, H // 2]
+
+
+def test_cpp_qgemm_declines_ambiguous_bias_shape():
+    K, H, Out = 8, 6, 4
+    model, _info = _qgemm_chain_model(K, H, Out, bias=True, seed=43)
+    inits = {t.name: t for t in model.graph.initializer}
+    inits["C1"].CopyFrom(_i32(np.zeros((1, H)), "C1"))
+    onnx.checker.check_model(model)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    inits_after = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits_after["W1"].dims) == [K, H]
+
+
+def test_cpp_qoperator_matches_python_reference():
+    # Byte-for-byte parity between the Python `apply_structured_pruning_
+    # qoperator` reference and the C++-backed `apply_structured_pruning_cpp`
+    # entry point -- mirrors this file's own identical parity checks for
+    # every other quantized-weight chain family above.
+    K, H, Out = 8, 6, 4
+    model, _info = _qlinearmatmul_chain_model(K, H, Out, seed=61)
+    onnx.checker.check_model(model)
+
+    pruned_py = onnxsim.apply_structured_pruning_qoperator(model, sparsity=0.5)
+    pruned_cpp = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_py)
+    onnx.checker.check_model(pruned_cpp)
+
+    py_bytes = {t.name: t.SerializeToString() for t in pruned_py.graph.initializer}
+    cpp_bytes = {t.name: t.SerializeToString() for t in pruned_cpp.graph.initializer}
+    assert py_bytes == cpp_bytes

--- a/tests/test_structured_pruning_cpp.py
+++ b/tests/test_structured_pruning_cpp.py
@@ -16,6 +16,7 @@ plus a couple of tests confirming unmatched topologies are left untouched
 """
 
 import os
+import tempfile
 
 import ml_dtypes
 import numpy as np
@@ -8465,6 +8466,312 @@ def test_cpp_qoperator_matches_python_reference():
     onnx.checker.check_model(model)
 
     pruned_py = onnxsim.apply_structured_pruning_qoperator(model, sparsity=0.5)
+    pruned_cpp = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_py)
+    onnx.checker.check_model(pruned_cpp)
+
+    py_bytes = {t.name: t.SerializeToString() for t in pruned_py.graph.initializer}
+    cpp_bytes = {t.name: t.SerializeToString() for t in pruned_cpp.graph.initializer}
+    assert py_bytes == cpp_bytes
+
+
+# --- DynamicQuantizeMatMul / MatMulIntegerToFloat (ORT dynamic-quantization
+# --- fusion) structured pruning ---------------------------------------------
+#
+# Mirrors ``tests/test_pruning.py``'s own "DynamicQuantizeMatMul /
+# MatMulIntegerToFloat" coverage for ``onnxsim.apply_structured_pruning_cpp``
+# -- the C++ port also runs this chain family (see
+# ``onnxsim/structured_pruning_entry.cpp``'s own "DynamicQuantizeMatMul /
+# MatMulIntegerToFloat" section comment), wired into the SAME entry point as
+# every other chain family above (unlike ``onnxsim.pruning``, which keeps
+# ``apply_structured_pruning_dynamic_quantize_matmul`` a separate top-level
+# function). Fixture weights are quantized via the REAL
+# ``onnxruntime.quantization.quantize_dynamic`` tool -- never a hand-rolled
+# re-implementation of the quantization scheme -- by wrapping each weight in
+# a minimal ``Y = MatMul(X, W)`` model, running the real tool on it, and
+# reading back its own emitted ``W_quantized``/``W_scale``/``W_zero_point``
+# initializers, mirroring ``test_pruning.py``'s own identical
+# ``_quantize_dynamic_weight`` helper. Unlike the QDQ section above, these
+# oracle tests run the pruned graph through onnxruntime with DEFAULT graph
+# optimizations (plain ``_run``, not ``_run_unfused``): `DynamicQuantizeMatMul`
+# is already the fully-fused kernel itself -- there is no
+# `DequantizeLinear -> MatMul` pattern left for onnxruntime's own optimizer to
+# additionally re-fuse, so the "unfused vs. optimized accumulation order"
+# concern the QDQ section's own top comment describes does not apply here.
+# `DynamicQuantizeMatMul`'s own `A`-side quantization is computed FRESH from
+# the actual runtime input on every run (no calibration data, no rewriting
+# needed) -- since pruning only removes some of the PRODUCER's own output
+# columns (leaving `A`, and every surviving column's own int8 codes/scale/
+# zero-point, byte-for-byte unchanged -- "slice, don't recompute"), a kept
+# output column's value is mathematically identical whether or not its
+# sibling columns were dropped, so the oracle checks below hold to plain
+# float32 rounding tolerance.
+
+
+def _quantize_dynamic_weight(W, per_channel=True):
+    """Runs the REAL ``onnxruntime.quantization.quantize_dynamic`` tool on a
+    minimal ``Y = MatMul(X, W)`` wrapper model and returns the genuine
+    quantized ``(W_int8[K,N], W_scale, W_zero_point)`` triple it emits for
+    `W` -- never a hand-rolled re-implementation of the quantization scheme.
+    Mirrors ``test_pruning.py``'s own identical helper.
+    """
+    from onnxruntime.quantization import QuantType, quantize_dynamic
+
+    K, N = W.shape
+    src = _model(
+        f"""
+        g (float[1,{K}] X) => (float[1,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[_f32(W, "W")],
+        opset=21,
+    )
+    with tempfile.TemporaryDirectory() as d:
+        src_path = os.path.join(d, "src.onnx")
+        dst_path = os.path.join(d, "dst.onnx")
+        onnx.save(src, src_path)
+        quantize_dynamic(
+            src_path, dst_path, per_channel=per_channel, weight_type=QuantType.QInt8
+        )
+        q = onnx.load(dst_path)
+    inits = {t.name: t for t in q.graph.initializer}
+    Wq = onnx.numpy_helper.to_array(inits["W_quantized"]).copy()
+    Wscale = onnx.numpy_helper.to_array(inits["W_scale"]).copy()
+    Wzp = onnx.numpy_helper.to_array(inits["W_zero_point"]).copy()
+    return Wq, Wscale, Wzp
+
+
+def _dqmm_chain_model(
+    K, N1, N2, per_channel=True, activation="Relu", bias1=False, seed=0
+):
+    """Builds ``DynamicQuantizeMatMul(mm1) -> activation ->
+    DynamicQuantizeMatMul(mm2)`` -- a same-family chain -- from random float
+    weights, quantized via the real tool (:func:`_quantize_dynamic_weight`).
+    Returns ``(model, info)`` where `info` carries every float/quantized
+    array needed to hand-build an "already pruned" oracle.
+    """
+    rng = np.random.default_rng(seed)
+    W1f = (rng.standard_normal((K, N1)) * 0.3).astype(np.float32)
+    W2f = (rng.standard_normal((N1, N2)) * 0.3).astype(np.float32)
+    B1f = (rng.standard_normal(N1) * 0.05).astype(np.float32) if bias1 else None
+    W1q, W1s, W1zp = _quantize_dynamic_weight(W1f, per_channel)
+    W2q, W2s, W2zp = _quantize_dynamic_weight(W2f, per_channel)
+
+    bias_arg = ", B1" if B1f is not None else ""
+    body = f"""
+    g (float[1,{K}] X) => (float[1,{N2}] Y)
+    {{
+      h1 = com.microsoft.DynamicQuantizeMatMul(X, W1, W1_scale, W1_zero_point{bias_arg})
+      h1a = {activation}(h1)
+      Y = com.microsoft.DynamicQuantizeMatMul(h1a, W2, W2_scale, W2_zero_point)
+    }}
+    """
+    inits = [
+        onnx.numpy_helper.from_array(W1q, "W1"),
+        onnx.numpy_helper.from_array(W1s, "W1_scale"),
+        onnx.numpy_helper.from_array(W1zp, "W1_zero_point"),
+        onnx.numpy_helper.from_array(W2q, "W2"),
+        onnx.numpy_helper.from_array(W2s, "W2_scale"),
+        onnx.numpy_helper.from_array(W2zp, "W2_zero_point"),
+    ]
+    if B1f is not None:
+        inits.append(_f32(B1f, "B1"))
+    model = _nbits_model(body, initializer=inits, opset=21)
+    return model, {
+        "W1f": W1f,
+        "W2f": W2f,
+        "B1f": B1f,
+        "W1q": W1q,
+        "W1s": W1s,
+        "W1zp": W1zp,
+        "W2q": W2q,
+        "W2s": W2s,
+        "W2zp": W2zp,
+    }
+
+
+def _dqmm_importance_keep(W_q, W_s, W_zp, keep_count):
+    w_dequant = (
+        W_q.astype(np.float64) - W_zp.astype(np.float64)[None, :]
+    ) * W_s.astype(np.float64)[None, :]
+    importance = np.linalg.norm(w_dequant, axis=0)  # per output channel
+    return np.sort(np.argsort(-importance)[:keep_count])
+
+
+def test_cpp_dynamic_quantize_matmul_chain_matches_independently_requantized_oracle():
+    # The core correctness invariant this project's earlier rounds
+    # established, adapted from ``test_pruning.py``'s own
+    # ``test_dynamic_quantize_matmul_producer_matches_independently_
+    # requantized_subset``: a pruned model's output must match a reference
+    # built by quantizing the already-column-subset weight directly via the
+    # REAL quantizer -- NOT the full unpruned model's own output. Also
+    # confirms the `DynamicQuantizeMatMul` nodes themselves need no
+    # rewriting at all: both nodes survive pruning with their op_type/domain/
+    # input count completely unchanged, and the SECOND node (whose own `A`
+    # input is the first node's smaller, pruned output) still computes a
+    # correct result -- proof that its own internal dynamic quantization of
+    # the activation recomputes correctly against the smaller downstream
+    # weight with no help from this pass at all.
+    K, N1, N2 = 16, 24, 12
+    model, info = _dqmm_chain_model(K, N1, N2, per_channel=True, seed=2)
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+
+    dq_nodes = [n for n in pruned.graph.node if n.op_type == "DynamicQuantizeMatMul"]
+    assert len(dq_nodes) == 2  # neither node was removed, replaced, or split
+    assert {n.domain for n in dq_nodes} == {"com.microsoft"}
+
+    keep = _dqmm_importance_keep(info["W1q"], info["W1s"], info["W1zp"], N1 // 2)
+    assert list(inits["W1"].dims) == [K, N1 // 2]
+    assert list(inits["W1_scale"].dims) == [N1 // 2]
+    assert list(inits["W1_zero_point"].dims) == [N1 // 2]
+    assert list(inits["W2"].dims) == [N1 // 2, N2]
+
+    # "Slice, don't recompute": the pruned graph's own quantized codes/
+    # scale/zero_point are EXACTLY a hand-slice of the original ones.
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["W1"]), info["W1q"][:, keep]
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["W1_scale"]), info["W1s"][keep]
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["W1_zero_point"]), info["W1zp"][keep]
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["W2"]), info["W2q"][keep, :]
+    )
+
+    # Independently reconstructed "already pruned" reference model: the
+    # PRODUCER's kept-column weight is quantized FRESH via the real
+    # quantizer (per-channel quantization is column-independent, so this is
+    # byte-identical to the slice above). The CONSUMER's own weight is NEVER
+    # requantized -- its quantized CODES are sliced directly and its scale/
+    # zero-point copied UNCHANGED from the original, exactly what the
+    # consumer role itself does.
+    ref_model, _ = _dqmm_chain_model(K, len(keep), N2, per_channel=True, seed=987654)
+    ref_inits = {t.name: t for t in ref_model.graph.initializer}
+    # Overwrite the reference's own randomly-seeded producer weight with the
+    # REAL subset requantization of the ORIGINAL W1f -- not unrelated random
+    # data.
+    W1q_sub, W1s_sub, W1zp_sub = _quantize_dynamic_weight(
+        info["W1f"][:, keep], per_channel=True
+    )
+    ref_inits["W1"].CopyFrom(onnx.numpy_helper.from_array(W1q_sub, "W1"))
+    ref_inits["W1_scale"].CopyFrom(onnx.numpy_helper.from_array(W1s_sub, "W1_scale"))
+    ref_inits["W1_zero_point"].CopyFrom(
+        onnx.numpy_helper.from_array(W1zp_sub, "W1_zero_point")
+    )
+    ref_inits["W2"].CopyFrom(onnx.numpy_helper.from_array(info["W2q"][keep, :], "W2"))
+    ref_inits["W2_scale"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W2s"], "W2_scale")
+    )
+    ref_inits["W2_zero_point"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W2zp"], "W2_zero_point")
+    )
+
+    rng = np.random.default_rng(11)
+    x = rng.standard_normal((1, K)).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_ref,) = _run(ref_model, {"X": x})
+    np.testing.assert_array_equal(y_pruned, y_ref)
+
+
+def test_cpp_dynamic_quantize_matmul_per_tensor_scale_left_untouched():
+    K, N1, N2 = 16, 24, 12
+    model, _info = _dqmm_chain_model(K, N1, N2, per_channel=False, seed=3)
+    onnx.checker.check_model(model)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    # Per-tensor (scalar) scale/zero-point are never sliced, regardless of
+    # channel count -- byte-identical to the original.
+    assert list(inits["W1_scale"].dims) == []
+    assert list(inits["W1_zero_point"].dims) == []
+    assert list(inits["W1"].dims) == [K, N1 // 2]
+
+    rng = np.random.default_rng(12)
+    x = rng.standard_normal((1, K)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    assert y.shape == (1, N2)
+    assert np.all(np.isfinite(y))
+
+
+def test_cpp_dynamic_quantize_matmul_bias_is_sliced_as_plain_float():
+    K, N1, N2 = 16, 24, 12
+    model, info = _dqmm_chain_model(K, N1, N2, per_channel=True, bias1=True, seed=8)
+    onnx.checker.check_model(model)
+    keep = _dqmm_importance_keep(info["W1q"], info["W1s"], info["W1zp"], N1 // 2)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert inits["B1"].data_type == onnx.TensorProto.FLOAT
+    assert list(inits["B1"].dims) == [N1 // 2]
+    # Bias values are UNCHANGED (plain float, never quantized/rescaled) --
+    # unlike QGemm/QLinearConv's own quantized int32 bias.
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["B1"]), info["B1f"][keep]
+    )
+
+
+def test_cpp_dynamic_quantize_matmul_tied_weight_is_declined():
+    # A second, unrelated node also reads W1 -- shared/tied, can't be sliced
+    # -- mirrors ``test_pruning.py``'s own
+    # ``test_dynamic_quantize_matmul_tied_weight_is_declined``.
+    K, N1, N2 = 16, 24, 12
+    model, _info = _dqmm_chain_model(K, N1, N2, per_channel=True, seed=6)
+    extra = onnx.helper.make_node("Identity", ["W1"], ["W1_alias"], name="alias")
+    model.graph.node.append(extra)
+    model.graph.output.append(
+        onnx.helper.make_tensor_value_info("W1_alias", onnx.TensorProto.INT8, [K, N1])
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    # Left completely untouched -- W1 is shared, so this chain is declined.
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_dynamic_quantize_matmul_missing_zero_point_is_declined():
+    # `b_zero_point` is schema-optional, but never confirmed empirically to
+    # be omitted by any real fixture -- declined outright (see this file's
+    # own section comment above ApplyDynQuantChains in
+    # ``structured_pruning_entry.cpp``), mirroring ``test_pruning.py``'s own
+    # ``test_dynamic_quantize_matmul_missing_zero_point_is_declined``.
+    K, N1, N2 = 16, 24, 12
+    model, _info = _dqmm_chain_model(K, N1, N2, per_channel=True, seed=5)
+    for node in model.graph.node:
+        if node.output and node.output[0] == "h1":
+            node.input[3] = ""  # blank b_zero_point
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_dynamic_quantize_matmul_zero_sparsity_is_a_no_op():
+    K, N1, N2 = 16, 24, 12
+    model, _info = _dqmm_chain_model(K, N1, N2, per_channel=True, seed=13)
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.0)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_dynamic_quantize_matmul_matches_python_reference():
+    K, N1, N2 = 16, 24, 12
+    model, _info = _dqmm_chain_model(K, N1, N2, per_channel=True, seed=42)
+    onnx.checker.check_model(model)
+
+    pruned_py = onnxsim.apply_structured_pruning_dynamic_quantize_matmul(
+        model, sparsity=0.5
+    )
     pruned_cpp = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
     onnx.checker.check_model(pruned_py)
     onnx.checker.check_model(pruned_cpp)


### PR DESCRIPTION
## Summary

Eighth round continuing the Python → C++ parity effort (see #1027, #1031, #1034, #1044, #1049, #1051, #1052). Ports two more data-free quantized structured-pruning subsystems:

- **QOperator-quantized structured pruning** — `QLinearConv`, `QLinearMatMul`, `com.microsoft::QGemm`: fully-quantized ops that carry their own scale/zero-point operands directly (as opposed to QDQ's `DequantizeLinear`-wrapped-then-plain-op shape).
- **DynamicQuantizeMatMul / MatMulIntegerToFloat structured pruning** — ONNX Runtime's dynamic-quantization MatMul fusion: the weight side is pre-quantized to a constant int8/uint8 tensor, while the activation side is quantized fresh at runtime by the fused op itself, so this stays fully data-free (no calibration needed) despite touching a "dynamic" quantization op.

Both fold into the existing `ApplyStructuredPruning` dispatcher as two more passes (now eleven total), matching how every prior quantized-format port was wired in. They were ported independently in parallel and both landed at the same insertion point in the file, producing a fragmented ~15-hunk conflict on cherry-pick; resolved by extracting each side's pure insertion against their common parent and splicing them in directly (verified no symbol collisions, confirmed with a clean rebuild) rather than fighting the diff hunks piecemeal.

With this round, every data-free structural-pruning entry point in `onnxsim/pruning.py` now has a C++ counterpart. What remains out of scope is exclusively calibration-driven pruning (Wanda, SparseGPT, transformer-block pruning, MoE/QMoE whole-expert pruning) — each needs a live `onnxruntime.InferenceSession` to observe activations, and this C++ port has no ONNX Runtime linked into it at all (the wheel build never builds ORT — see `CLAUDE.md`), so porting any of them isn't a matter of more engineering time under this pattern; it needs a real design decision first.

## Testing

- `pip install --no-build-isolation -ve .`
- `python3 -m pytest -v tests/test_structured_pruning_cpp.py tests/test_attention_head_pruning_cpp.py tests/test_pruning_cpp.py tests/test_moe_pruning_cpp.py tests/test_qmoe_pruning_cpp.py tests/test_embedding_vocab_pruning_cpp.py` — **285 passed, 0 failed**, including all pre-existing coverage from every prior round (no regressions)
- `clang-format --dry-run --Werror` / `ruff format --check` / `ruff check` / `mypy` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4t6ntCm72RfFf64W9GYB1

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4t6ntCm72RfFf64W9GYB1)_