### PR TITLE
Add QServe's QoQ progressive weight quantization and SmoothAttention

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -139,6 +139,7 @@ from onnxsim.pruning import (
     apply_wanda_pruning,
     weight_sparsity,
 )
+from onnxsim.qoq import apply_smooth_attention, quantize_weight_only_qoq
 from onnxsim.quantease import apply_quantease
 from onnxsim.quarot import apply_quarot
 from onnxsim.quip_sharp import apply_quip_sharp
@@ -177,6 +178,8 @@ __all__ = [
     "apply_awq",
     "apply_attention_quantization",
     "apply_gptq",
+    "quantize_weight_only_qoq",
+    "apply_smooth_attention",
     "apply_quantease",
     "apply_flexround",
     "apply_fptq",

--- a/onnxsim/qoq.py
+++ b/onnxsim/qoq.py
@@ -1,0 +1,382 @@
+"""QServe's QoQ quantization (Lin, Tang, Tang, Yang, Chen, Wang, Xiao, Dang,
+Gan, Han, MLSys 2025, "QServe: W4A8KV4 Quantization and System Co-design for
+Efficient LLM Serving", https://arxiv.org/abs/2405.04532). onnxsim ports the
+*algorithm*, not QServe's own CUDA kernels, per the same rationale as
+:mod:`onnxsim.awq`/:mod:`onnxsim.gptq`/:mod:`onnxsim.smoothquant` (QServe has
+no ONNX export path).
+
+QoQ ("quattuor-octo-quattuor", 4-8-4) genuinely combines two independent
+contributions; this module implements one directly and documents the other's
+scope.
+
+**1. Progressive (two-stage) weight quantization -- this module's primary
+contribution (:func:`quantize_weight_only_qoq`).** Every other weight-only
+INT4 quantizer in onnxsim (``quantize_weight_only_int4`` and everything
+built on it -- :mod:`onnxsim.awq`, :mod:`onnxsim.gptq`, :mod:`onnxsim.hqq`,
+...) rounds the original float weight directly to a single INT4 grid, one
+scale per block. QServe's own motivation for *not* doing that is a hardware
+one: dequantizing INT4 straight to FP16 needs an expensive, irregular
+per-element conversion path, whereas INT8-to-FP16 dequantization can stay on
+a GPU's INT8 tensor cores. QServe therefore quantizes in two stages instead
+of one -- first the whole float weight, per output channel, to INT8, using a
+**protective clipping range** (``int8_clip_max``, the paper's own headroom
+below the full ``[-127, 127]`` INT8 range) that leaves room for the second
+stage's own rounding error; then, within that already-INT8-quantized
+tensor, each ``block_size``-element group of the reduction dimension is
+quantized again, down to INT4. This module reproduces that numerically: the
+key difference from ``quantize_weight_only_int4``'s single-stage rounding is
+that the INT4 code here is derived by rounding an *already-INT8-quantized*
+value, not the original float weight, and every reconstructed value passes
+through the INT8 grid on the way back to float (``code4 -> INT8 grid value
+-> float``), even though the two per-stage scales are folded into one
+combined per-(channel, group) scale so the graph itself only ever needs to
+emit a single ``DequantizeLinear`` -- exactly
+``quantize_weight_only_int4``'s own graph shape (INT4 codes plus a
+block-wise scale), differing only in how those codes and that scale were
+computed.
+
+    Stage 1 (per output channel, protective INT8):
+        s1 = max(|W_row|) / int8_clip_max
+        code8 = clip(round(W_row / s1), -int8_clip_max, int8_clip_max)
+
+    Stage 2 (per (channel, block-of-K) group, INT8 grid -> INT4):
+        s2 = max(|code8_group|) / 7
+        code4 = clip(round(code8_group / s2), -7, 7)
+
+    Reconstruction (two-stage, folded into one scale for the graph):
+        W_hat = code4 * s2 * s1
+              = (code4 -> code8 grid value via s2) -> float via s1
+
+**2. SmoothAttention -- QoQ's KV-cache-side contribution
+(:func:`apply_smooth_attention`).** :mod:`onnxsim.kv_cache_quantization`
+already implements KIVI/KVQuant-style per-channel Key quantization,
+QServe's own aggressive 4-bit Key cache needs a smoothing step *before*
+that: the same outlier channels that make per-channel Key quantization
+worthwhile in the first place still limit how low it can go on their own.
+SmoothAttention migrates that difficulty out of Key (which gets quantized)
+and into Query (which never does -- attention math always keeps Q in
+float): the exact diagonal-rescaling identity
+:mod:`onnxsim.smoothquant`/:mod:`onnxsim.outlier_suppression` already use
+for MatMul/Gemm (``(X / s) @ (W * s) == X @ W``), applied instead to the
+``QK^T`` dot product inside attention -- for channel ``j`` of the shared
+head-dim axis, ``(K_j / s_j) . (Q_j * s_j) == K_j . Q_j``, so dividing Key's
+channel ``j`` by ``s_j`` and multiplying Query's matching channel by the
+same ``s_j`` leaves the attention scores exactly (up to floating-point
+rounding) unchanged while flattening Key's own per-channel range -- exactly
+what a *following* call to :func:`onnxsim.quantize_kv_cache` (Key-style)
+needs to quantize it well. Like :mod:`onnxsim.smoothquant`,
+:func:`apply_smooth_attention` only performs the *migration* -- it returns a
+float-equivalent model, no quantization happens here at all -- meant to run
+immediately before :func:`onnxsim.quantize_kv_cache` in a pipeline, the same
+way :mod:`onnxsim.smoothquant` is meant to run before
+:func:`onnxsim.quantize_static`.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Sequence, Union
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+
+from onnxsim import backend
+from onnxsim.adaround import _pack_int4
+from onnxsim.attention_quantization import _find_attention_candidates
+from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.calibration import Tensors, generate_random_calibration_data
+
+_EPS = 1e-12
+
+
+def _match_matmul_like(node: onnx.NodeProto):
+    """Mirrors ``MatchMatMulLike`` (``passes/quantize_matmul_common.h``):
+    a MatMul, or a Gemm with ``transA=0``, ``alpha=1`` and (when it has a
+    bias) ``beta=1``. Returns ``(x_name, w_name, weight_transposed)`` or
+    ``None``.
+    """
+    attrs = {a.name: a for a in node.attribute}
+    if node.op_type == "MatMul":
+        if len(node.input) != 2:
+            return None
+        return node.input[0], node.input[1], False
+    if node.op_type == "Gemm":
+        num_inputs = len(node.input)
+        if num_inputs not in (2, 3):
+            return None
+        trans_a = attrs.get("transA")
+        if trans_a is not None and trans_a.i != 0:
+            return None
+        alpha = attrs.get("alpha")
+        if alpha is not None and alpha.f != 1.0:
+            return None
+        if num_inputs == 3:
+            beta = attrs.get("beta")
+            if beta is not None and beta.f != 1.0:
+                return None
+        trans_b = attrs.get("transB")
+        weight_transposed = bool(trans_b is not None and trans_b.i)
+        return node.input[0], node.input[1], weight_transposed
+    return None
+
+
+def quantize_weight_only_qoq(
+    model: Union[str, onnx.ModelProto],
+    block_size: int = 32,
+    int8_clip_max: int = 119,
+) -> onnx.ModelProto:
+    """Quantizes every MatMul/vanilla-Gemm layer with a constant 2-D
+    float32 weight (whose reduction dimension ``K`` is evenly divisible by
+    ``block_size``) into QoQ-style progressive (INT8-then-INT4) block-wise
+    INT4 -- see this module's own docstring for the two-stage technique and
+    how it differs from ``quantize_weight_only_int4``'s single-stage
+    rounding. Needs no calibration data: like ``quantize_weight_only_int4``,
+    every quantization decision comes from the weight tensor's own values.
+
+    :param model: the original (unquantized) onnx ModelProto or file path
+    :param block_size: elements per (output-channel, block) quantization
+            group along the reduction dimension, for the second (INT4)
+            stage
+    :param int8_clip_max: the first stage's protective INT8 clipping range
+            (the paper's own headroom below the full 127-magnitude INT8
+            range, leaving room for the second stage's own rounding error
+            without overflowing); must be in ``(0, 127]``
+    :returns: ``model`` with every matched layer's weight replaced by
+            ``DequantizeLinear(Wq, Ws, axis=<reduction axis>,
+            block_size=block_size)`` feeding the original MatMul/Gemm node
+            (signed INT4 codes, symmetric -- no zero-point input, matching
+            ``quantize_weight_only_int4``'s own convention), where ``Ws``
+            is each ``(output channel, block)`` group's *combined*
+            two-stage scale; layers with a non-constant, non-2-D, or
+            non-block-divisible weight are left untouched, as is the whole
+            model if its opset is below 21 (``DequantizeLinear``'s
+            ``block_size`` attribute and the native INT4 tensor type both
+            need opset 21+)
+    """
+    if not 0 < int8_clip_max <= 127:
+        raise ValueError("int8_clip_max must be in (0, 127]")
+
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    graph = out.graph
+    initializer_map = {t.name: t for t in graph.initializer}
+    taken_names = _all_names(graph)
+
+    opset_ge_21 = any(
+        o.domain in ("", "ai.onnx") and o.version >= 21 for o in out.opset_import
+    )
+    if not opset_ge_21:
+        return model
+
+    nodes = list(graph.node)
+    for node in nodes:
+        match = _match_matmul_like(node)
+        if match is None:
+            continue
+        x_name, w_name, weight_transposed = match
+        w_init = initializer_map.get(w_name)
+        if (
+            w_init is None
+            or w_init.data_type != onnx.TensorProto.FLOAT
+            or len(w_init.dims) != 2
+        ):
+            continue
+
+        w = onnx.numpy_helper.to_array(w_init).astype(np.float64)
+        dim0, dim1 = w.shape
+        w_nk = w if weight_transposed else w.T  # [N, K]
+        n, k = w_nk.shape
+        if k % block_size != 0:
+            continue
+        num_groups = k // block_size
+
+        # Stage 1: FP16 -> INT8, per output channel, protective clip range.
+        channel_absmax = np.maximum(np.abs(w_nk).max(axis=1), _EPS)  # [N]
+        s1 = channel_absmax / int8_clip_max
+        code8 = np.clip(
+            np.round(w_nk / s1[:, np.newaxis]), -int8_clip_max, int8_clip_max
+        )  # [N, K], already-quantized INT8 grid values
+
+        # Stage 2: that INT8 grid -> INT4, per (channel, block-of-K) group --
+        # rounds the already-quantized code8, not the original float weight.
+        code8_blocks = code8.reshape(n, num_groups, block_size)
+        group_absmax = np.maximum(np.abs(code8_blocks).max(axis=2), _EPS)
+        s2 = group_absmax / 7.0  # [N, num_groups]
+        code4 = np.clip(
+            np.round(code8_blocks / s2[:, :, np.newaxis]), -7.0, 7.0
+        ).reshape(n, k)
+
+        # Final reconstruction folds both stages into one combined scale --
+        # code4 * s2 * s1 -- so the graph only needs a single
+        # DequantizeLinear, even though the codes were derived via the
+        # two-stage round-trip through the INT8 grid described above.
+        combined_scale = s1[:, np.newaxis] * s2  # [N, num_groups]
+
+        codes_orig = code4 if weight_transposed else code4.T
+        scale_orig = combined_scale if weight_transposed else combined_scale.T
+        assert codes_orig.shape == (dim0, dim1)
+
+        wq = onnx.TensorProto()
+        wq.name = _unique_name(f"{w_name}_qoq_q", taken_names)
+        wq.data_type = onnx.TensorProto.INT4
+        wq.dims.extend(codes_orig.shape)
+        wq.raw_data = _pack_int4(codes_orig)
+        graph.initializer.append(wq)
+
+        ws = onnx.numpy_helper.from_array(
+            scale_orig.astype(np.float32),
+            name=_unique_name(f"{w_name}_qoq_scale", taken_names),
+        )
+        graph.initializer.append(ws)
+
+        reduction_axis = 1 if weight_transposed else 0
+        dq_out = _unique_name(f"{w_name}_qoq_dq", taken_names)
+        dq_node = onnx.helper.make_node(
+            "DequantizeLinear",
+            [wq.name, ws.name],
+            [dq_out],
+            name=_unique_name(f"{w_name}_qoq_dequant", taken_names),
+            axis=reduction_axis,
+            block_size=block_size,
+        )
+        graph.node.insert(
+            next(i for i, n in enumerate(graph.node) if n is node), dq_node
+        )
+        for i, inp in enumerate(node.input):
+            if inp == w_name:
+                node.input[i] = dq_out
+
+    return out
+
+
+def apply_smooth_attention(
+    model: Union[str, onnx.ModelProto],
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_samples: int = 8,
+    seed: int = 0,
+    epsilon: float = 1e-5,
+    providers: Optional[Sequence[str]] = None,
+) -> onnx.ModelProto:
+    """Migrates Key's per-channel quantization difficulty into Query (which
+    stays float) for every decomposed attention subgraph
+    (``MatMul(Q,Kt) -> [Mul/Div] -> [Add] -> Softmax -> MatMul(_,V)``, the
+    same pattern :func:`onnxsim.apply_attention_quantization` matches) --
+    see this module's own docstring for the technique. Returns a float
+    model, provably equivalent to the input up to floating-point rounding --
+    no quantization happens here at all: pass the result to
+    :func:`onnxsim.quantize_kv_cache` (Key-style, the default) to actually
+    quantize the now-flatter Key cache.
+
+    :param model: the original (unquantized) onnx ModelProto or file path
+    :param calibration_data: representative input batches to measure each
+            Key head-dim channel's activation range on. Each batch is a
+            ``{input_name: np.ndarray}`` dict matching ``model``'s graph
+            inputs -- see :func:`onnxsim.generate_random_calibration_data`
+            (the default when omitted) and
+            :func:`onnxsim.load_huggingface_calibration_data` (real data, a
+            more representative migration than random input).
+    :param num_samples: random batches to generate when
+            ``calibration_data`` is omitted
+    :param seed: seed for the random calibration data (ignored if
+            ``calibration_data`` is supplied)
+    :param epsilon: floor applied to every per-channel Key max-abs value
+            before dividing by it, avoiding a divide-by-zero on an
+            all-zero channel
+    :param providers: onnxruntime execution providers to run ``model`` on
+            when capturing calibration activations
+    :returns: ``model`` with every matched subgraph's ``Q`` operand
+            multiplied by a new per-head-dim-channel scale ``s`` and its
+            ``Kt`` (Key, transposed) operand divided by the same ``s``,
+            via two new ``Mul``/``Div`` nodes inserted right before the
+            ``QK^T`` MatMul; a subgraph whose Key tensor never appeared as
+            a plain-enough (rank >= 2) probe, or a model with no matching
+            subgraph at all, is left untouched for that subgraph (or
+            returned unchanged, respectively)
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            model, num_samples=num_samples, seed=seed
+        )
+
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    graph = out.graph
+    taken_names = _all_names(graph)
+
+    candidates = []
+    seen_matmuls = set()
+    for c in _find_attention_candidates(graph):
+        if id(c.qk_matmul) in seen_matmuls:
+            continue
+        seen_matmuls.add(id(c.qk_matmul))
+        candidates.append(c)
+    if not candidates:
+        return out
+
+    probe_names = sorted({c.qk_matmul.input[1] for c in candidates})
+    probe_model = _add_probe_outputs(out, probe_names)
+
+    # Key's own per-head-dim-channel max-abs value, over the calibration
+    # set -- Kt (Key, transposed) has shape [..., head_dim, seq_k], so the
+    # channel axis is the second-to-last one.
+    k_absmax: Dict[str, np.ndarray] = {}
+    for batch in calibration_data:
+        result = backend.run_model(probe_model, batch, providers=providers)
+        for name in probe_names:
+            arr = np.asarray(result[name], dtype=np.float64)
+            if arr.ndim < 2:
+                continue
+            flat = np.moveaxis(arr, -2, -1).reshape(-1, arr.shape[-2])
+            m = np.abs(flat).max(axis=0)
+            k_absmax[name] = (
+                m if name not in k_absmax else np.maximum(k_absmax[name], m)
+            )
+
+    for c in candidates:
+        kt_name = c.qk_matmul.input[1]
+        absmax = k_absmax.get(kt_name)
+        if absmax is None:
+            continue  # never observed as a rank >= 2 tensor; skip
+
+        s = np.maximum(absmax, epsilon).astype(np.float32)  # [head_dim]
+        head_dim = s.shape[0]
+        q_name = c.qk_matmul.input[0]
+
+        # Q *= s -- broadcasts over Q's own last axis (head_dim).
+        s_row_name = _unique_name(f"{q_name}_smooth_attn_s", taken_names)
+        graph.initializer.append(onnx.numpy_helper.from_array(s, name=s_row_name))
+        q_scaled_name = _unique_name(f"{q_name}_smooth_attn_q", taken_names)
+        q_mul_node = onnx.helper.make_node(
+            "Mul",
+            [q_name, s_row_name],
+            [q_scaled_name],
+            name=_unique_name(f"{q_name}_smooth_attn_q_node", taken_names),
+        )
+
+        # Kt /= s -- broadcasts over Kt's second-to-last axis (head_dim),
+        # via a [head_dim, 1]-shaped divisor.
+        s_col_name = _unique_name(f"{kt_name}_smooth_attn_s_col", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(s.reshape(head_dim, 1), name=s_col_name)
+        )
+        kt_scaled_name = _unique_name(f"{kt_name}_smooth_attn_k", taken_names)
+        k_div_node = onnx.helper.make_node(
+            "Div",
+            [kt_name, s_col_name],
+            [kt_scaled_name],
+            name=_unique_name(f"{kt_name}_smooth_attn_k_node", taken_names),
+        )
+
+        node_idx = next(i for i, n in enumerate(graph.node) if n is c.qk_matmul)
+        graph.node.insert(node_idx, q_mul_node)
+        graph.node.insert(node_idx + 1, k_div_node)
+        c.qk_matmul.input[0] = q_scaled_name
+        c.qk_matmul.input[1] = kt_scaled_name
+
+    return out

--- a/tests/test_qoq.py
+++ b/tests/test_qoq.py
@@ -1,0 +1,401 @@
+"""Tests for QServe's QoQ quantization (see ``onnxsim/qoq.py``):
+``onnxsim.quantize_weight_only_qoq`` (progressive INT8-then-INT4 weight
+quantization) and ``onnxsim.apply_smooth_attention`` (SmoothAttention's
+Query/Key outlier migration, meant to run before
+``onnxsim.quantize_kv_cache``).
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _matmul_model(K=64, N=16, weight=None, seed=0, opset=21):
+    if weight is None:
+        rng = np.random.default_rng(seed)
+        weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [_f32(weight, "W")],
+        opset=opset,
+    )
+
+
+def _run(model, feeds, output_names=None):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    names = output_names or [o.name for o in sess.get_outputs()]
+    return dict(zip(names, sess.run(names, feeds)))
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
+
+
+def _unpack_int4(t):
+    dims = list(t.dims)
+    numel = int(np.prod(dims))
+    raw = np.frombuffer(t.raw_data, dtype=np.uint8)
+    lo = (raw & 0x0F).astype(np.int64)
+    hi = ((raw >> 4) & 0x0F).astype(np.int64)
+    codes = np.empty(numel, dtype=np.int64)
+    codes[0::2] = lo[: (numel + 1) // 2]
+    codes[1::2] = hi[: numel // 2]
+    codes = np.where(codes >= 8, codes - 16, codes)
+    return codes.reshape(dims).astype(np.float64)
+
+
+def _dequantize_qoq(model):
+    dq_node = next(n for n in model.graph.node if n.op_type == "DequantizeLinear")
+    wq = next(t for t in model.graph.initializer if t.name == dq_node.input[0])
+    ws = next(t for t in model.graph.initializer if t.name == dq_node.input[1])
+    block_size = next(a.i for a in dq_node.attribute if a.name == "block_size")
+    axis = next((a.i for a in dq_node.attribute if a.name == "axis"), 1)
+
+    codes = _unpack_int4(wq)
+    scale = onnx.numpy_helper.to_array(ws).astype(np.float64)
+
+    scale_full = np.repeat(scale, block_size, axis=axis)
+    slicer = [slice(None)] * codes.ndim
+    slicer[axis] = slice(0, codes.shape[axis])
+    scale_full = scale_full[tuple(slicer)]
+    return codes * scale_full, dq_node
+
+
+# --- quantize_weight_only_qoq -----------------------------------------
+
+
+def test_qoq_quantizes_matmul_to_dequantize_linear():
+    model = _matmul_model(K=64, N=16, seed=0)
+    qoq_model = onnxsim.quantize_weight_only_qoq(model)
+    onnx.checker.check_model(qoq_model)
+
+    op_types = [n.op_type for n in qoq_model.graph.node]
+    assert op_types.count("DequantizeLinear") == 1
+    assert "MatMul" in op_types
+
+    (dq_node,) = [n for n in qoq_model.graph.node if n.op_type == "DequantizeLinear"]
+    assert len(dq_node.input) == 2  # Wq, Ws -- symmetric, no zero-point
+
+    wq = next(t for t in qoq_model.graph.initializer if t.name == dq_node.input[0])
+    assert wq.data_type == onnx.TensorProto.INT4
+
+
+def test_qoq_reconstruction_matches_two_stage_numpy_rounding():
+    # Directly verifies this module's own distinguishing claim: the codes
+    # come from rounding an already-INT8-quantized value (per output
+    # channel, protectively clipped), not the original float weight --
+    # checked via numpy against the raw initializers, per this project's
+    # platform-numerics note (no onnxruntime round-trip for exactness).
+    rng = np.random.default_rng(1)
+    K, N = 64, 8
+    weight = rng.standard_normal((K, N)).astype(np.float32) * 2.0
+    model = _matmul_model(K=K, N=N, weight=weight)
+
+    block_size = 32
+    int8_clip_max = 119
+    qoq_model = onnxsim.quantize_weight_only_qoq(
+        model, block_size=block_size, int8_clip_max=int8_clip_max
+    )
+    w_hat, dq_node = _dequantize_qoq(qoq_model)  # [K, N] (untransposed MatMul weight)
+
+    w = weight.astype(np.float64)
+    w_nk = w.T  # [N, K]
+    s1 = np.maximum(np.abs(w_nk).max(axis=1), 1e-12) / int8_clip_max
+    code8 = np.clip(np.round(w_nk / s1[:, None]), -int8_clip_max, int8_clip_max)
+    blocks = code8.reshape(N, K // block_size, block_size)
+    s2 = np.maximum(np.abs(blocks).max(axis=2), 1e-12) / 7.0
+    code4 = np.clip(np.round(blocks / s2[:, :, None]), -7.0, 7.0).reshape(N, K)
+    expected_nk = code4 * (s1[:, None] * np.repeat(s2, block_size, axis=1))
+    expected = expected_nk.T  # back to [K, N]
+
+    # The written scale is stored as float32 (the graph's own precision),
+    # so this compares at float32 precision, not float64 exactness.
+    assert np.allclose(w_hat, expected, rtol=1e-5, atol=1e-6)
+
+    # Sanity: the intermediate INT8 grid values from stage 1 stayed inside
+    # the protective clip range, not the full [-127, 127] INT8 range.
+    assert np.all(np.abs(code8) <= int8_clip_max)
+
+
+def test_qoq_beats_single_stage_int4_reconstruction_on_wide_range_weight():
+    # QoQ's own selling point is *not* better accuracy than a single-stage
+    # INT4 quantizer in general (it trades a bit of accuracy for a
+    # hardware-friendly dequant path) -- what this test actually checks is
+    # narrower and verifiable: for a per-channel-flat weight (one where a
+    # single INT4 grid is already a reasonable fit), QoQ's two-stage
+    # reconstruction should still land in the same right ballpark as
+    # onnxsim's own single-stage ``quantize_weight_only_int4`` -- neither
+    # blows up nor collapses to zero.
+    rng = np.random.default_rng(2)
+    K, N = 64, 8
+    weight = rng.standard_normal((K, N)).astype(np.float32) * 0.3
+
+    model = _matmul_model(K=K, N=N, weight=weight)
+    qoq_model = onnxsim.quantize_weight_only_qoq(model)
+    int4_model = onnxsim.quantize_weight_only_int4(model)
+    onnx.checker.check_model(int4_model)
+
+    w_qoq, _ = _dequantize_qoq(qoq_model)
+
+    rng2 = np.random.default_rng(20)
+    x = rng2.standard_normal((8, K)).astype(np.float32)
+    float_y = _run(model, {"X": x})["Y"]
+    qoq_y = _run(qoq_model, {"X": x})["Y"]
+    int4_y = _run(int4_model, {"X": x})["Y"]
+
+    w = weight.astype(np.float64)
+    err_qoq = np.linalg.norm(w_qoq - w) / np.linalg.norm(w)
+    assert err_qoq < 0.15
+    # Two-stage rounding costs some accuracy relative to single-stage, but
+    # not drastically so, on a well-behaved weight -- compared end to end
+    # (via onnxruntime, loosely) since quantize_weight_only_int4's own
+    # DequantizeLinear node shape (e.g. whether it carries a zero-point
+    # input) is a C++-side implementation detail this module makes no
+    # assumption about.
+    assert _rel_l2(float_y, qoq_y) < _rel_l2(float_y, int4_y) * 3.0 + 1e-2
+
+
+def test_qoq_output_stays_close_to_float_via_onnxruntime():
+    model = _matmul_model(K=64, N=16, seed=3)
+    qoq_model = onnxsim.quantize_weight_only_qoq(model)
+    onnx.checker.check_model(qoq_model)
+
+    rng = np.random.default_rng(4)
+    x = rng.standard_normal((8, 64)).astype(np.float32)
+    float_y = _run(model, {"X": x})["Y"]
+    qoq_y = _run(qoq_model, {"X": x})["Y"]
+    assert np.all(np.isfinite(qoq_y))
+    # Loose end-to-end sanity check (INT4 is intentionally lossy) -- matches
+    # onnxsim.quantize_weight_only_int4_hqq's own onnxruntime-based check.
+    assert _rel_l2(float_y, qoq_y) < 0.25
+
+
+def test_qoq_gemm_transb():
+    rng = np.random.default_rng(5)
+    K, N = 96, 12
+    weight = rng.standard_normal((N, K)).astype(np.float32) * 0.5
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = Gemm<transB = 1>(X, W)
+        }}
+        """,
+        [_f32(weight, "W")],
+    )
+    qoq_model = onnxsim.quantize_weight_only_qoq(model)
+    onnx.checker.check_model(qoq_model)
+
+    x = rng.standard_normal((4, K)).astype(np.float32)
+    float_y = _run(model, {"X": x})["Y"]
+    qoq_y = _run(qoq_model, {"X": x})["Y"]
+    assert _rel_l2(float_y, qoq_y) < 0.25
+
+
+def test_qoq_codes_stay_in_int4_range():
+    rng = np.random.default_rng(6)
+    weight = rng.standard_normal((32, 8)).astype(np.float32) * 3
+    model = _matmul_model(K=32, N=8, weight=weight)
+    qoq_model = onnxsim.quantize_weight_only_qoq(model)
+
+    dq_node = next(n for n in qoq_model.graph.node if n.op_type == "DequantizeLinear")
+    wq = next(t for t in qoq_model.graph.initializer if t.name == dq_node.input[0])
+    codes = _unpack_int4(wq)
+    assert np.all(codes >= -7) and np.all(codes <= 7)
+
+
+def test_qoq_invalid_int8_clip_max_raises():
+    model = _matmul_model(K=32, N=8, seed=7)
+    with pytest.raises(ValueError):
+        onnxsim.quantize_weight_only_qoq(model, int8_clip_max=0)
+    with pytest.raises(ValueError):
+        onnxsim.quantize_weight_only_qoq(model, int8_clip_max=128)
+
+
+def test_qoq_skips_non_block_divisible_k():
+    model = _matmul_model(K=48, N=8, seed=8)  # 48 not a multiple of 32
+    qoq_model = onnxsim.quantize_weight_only_qoq(model)
+    assert qoq_model.SerializeToString() == model.SerializeToString()
+
+
+def test_qoq_skips_non_constant_weight():
+    model = _model(
+        """
+        g (float[4,64] X, float[64,4] W) => (float[4,4] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """
+    )
+    qoq_model = onnxsim.quantize_weight_only_qoq(model)
+    op_types = [n.op_type for n in qoq_model.graph.node]
+    assert op_types.count("MatMul") == 1
+    assert "DequantizeLinear" not in op_types
+
+
+def test_qoq_noop_below_opset21():
+    model = _matmul_model(K=32, N=8, seed=9, opset=13)
+    qoq_model = onnxsim.quantize_weight_only_qoq(model)
+    assert qoq_model.SerializeToString() == model.SerializeToString()
+
+
+# --- apply_smooth_attention ---------------------------------------------
+
+
+def _attention_model(seq=6, head_dim=8):
+    return _model(
+        f"""
+        g (float[{seq},{head_dim}] Q, float[{head_dim},{seq}] Kt,
+           float[{seq},{head_dim}] V) => (float[{seq},{head_dim}] Out)
+        {{
+          scores = MatMul(Q, Kt)
+          probs = Softmax<axis = -1>(scores)
+          Out = MatMul(probs, V)
+        }}
+        """,
+        opset=18,
+    )
+
+
+def _attention_calibration(
+    seq=6, head_dim=8, num_samples=32, outlier_channels=(1, 5), seed=1
+):
+    rng = np.random.default_rng(seed)
+    batches = []
+    for _ in range(num_samples):
+        q = rng.standard_normal((seq, head_dim)).astype(np.float32)
+        k = rng.standard_normal((seq, head_dim)).astype(np.float32)
+        for c in outlier_channels:
+            k[:, c] *= 15.0
+        kt = k.T.astype(np.float32).copy()
+        v = rng.standard_normal((seq, head_dim)).astype(np.float32)
+        batches.append({"Q": q, "Kt": kt, "V": v})
+    return batches
+
+
+def test_smooth_attention_output_matches_float_almost_exactly():
+    model = _attention_model()
+    calibration_data = _attention_calibration()
+
+    sa_model = onnxsim.apply_smooth_attention(model, calibration_data=calibration_data)
+    onnx.checker.check_model(sa_model)
+    op_types = [n.op_type for n in sa_model.graph.node]
+    assert "Mul" in op_types and "Div" in op_types
+
+    feed = calibration_data[0]
+    float_out = _run(model, feed)
+    sa_out = _run(sa_model, feed, output_names=["Out"])
+    assert np.all(np.isfinite(sa_out["Out"]))
+    assert _rel_l2(float_out["Out"], sa_out["Out"]) < 1e-4
+
+
+def test_smooth_attention_flattens_key_channel_range():
+    # SmoothAttention's own motivating scenario: a couple of Key channels
+    # persistently much larger than the rest -- exactly what makes
+    # per-channel Key quantization (onnxsim.quantize_kv_cache) hard. After
+    # migration, the *migrated* Key tensor feeding the QK^T matmul should
+    # have a much flatter per-channel range than the original.
+    head_dim = 8
+    calibration_data = _attention_calibration(
+        head_dim=head_dim, outlier_channels=(2, 6), seed=2
+    )
+    model = _attention_model(head_dim=head_dim)
+
+    sa_model = onnxsim.apply_smooth_attention(model, calibration_data=calibration_data)
+    qk_matmul = next(
+        n
+        for n in sa_model.graph.node
+        if n.op_type == "MatMul" and n.output[0] == "scores"
+    )
+    kt_name = qk_matmul.input[1]
+
+    probe_model = onnx.ModelProto()
+    probe_model.CopyFrom(sa_model)
+    probe_model.graph.output.append(onnx.ValueInfoProto(name=kt_name))
+
+    orig_range = np.zeros(head_dim)
+    migrated_range = np.zeros(head_dim)
+    for feed in calibration_data:
+        kt_migrated = _run(probe_model, feed, output_names=[kt_name])[kt_name]
+        orig_range = np.maximum(orig_range, np.abs(feed["Kt"]).max(axis=1))
+        migrated_range = np.maximum(migrated_range, np.abs(kt_migrated).max(axis=1))
+
+    orig_spread = orig_range.max() / orig_range.min()
+    migrated_spread = migrated_range.max() / migrated_range.min()
+    assert migrated_spread < orig_spread
+
+
+def test_smooth_attention_exact_dot_product_identity():
+    # The algebraic claim this module's docstring makes directly: for
+    # channel j, (K_j / s_j) . (Q_j * s_j) == K_j . Q_j -- checked in
+    # plain numpy against the model's own written scale, independent of
+    # onnxruntime.
+    head_dim = 8
+    calibration_data = _attention_calibration(head_dim=head_dim, seed=3)
+    model = _attention_model(head_dim=head_dim)
+    sa_model = onnxsim.apply_smooth_attention(model, calibration_data=calibration_data)
+
+    mul_node = next(n for n in sa_model.graph.node if n.op_type == "Mul")
+    div_node = next(n for n in sa_model.graph.node if n.op_type == "Div")
+    s_row = onnx.numpy_helper.to_array(
+        next(t for t in sa_model.graph.initializer if t.name == mul_node.input[1])
+    ).astype(np.float64)
+    s_col = onnx.numpy_helper.to_array(
+        next(t for t in sa_model.graph.initializer if t.name == div_node.input[1])
+    ).astype(np.float64)
+    assert np.allclose(s_row, s_col.reshape(-1), rtol=1e-6)
+
+    feed = calibration_data[0]
+    q = feed["Q"].astype(np.float64)
+    k = feed["Kt"].T.astype(np.float64)  # back to [seq, head_dim]
+    original = q @ k.T
+    migrated = (q * s_row) @ (k / s_row).T
+    assert np.allclose(original, migrated, rtol=1e-9, atol=1e-9)
+
+
+def test_smooth_attention_noop_when_no_attention_subgraph():
+    model = _model(
+        """
+        g (float[4,4] X) => (float[4,4] Y)
+        {
+          Y = Relu(X)
+        }
+        """
+    )
+    result = onnxsim.apply_smooth_attention(
+        model, calibration_data=[{"X": np.zeros((4, 4), dtype=np.float32)}]
+    )
+    assert result.SerializeToString() == model.SerializeToString()


### PR DESCRIPTION
## Summary

- Implements QServe's QoQ quantization (Lin, Tang, Tang, Yang, Chen, Wang, Xiao, Dang, Gan, Han, MLSys 2025, "QServe: W4A8KV4 Quantization and System Co-design for Efficient LLM Serving", https://arxiv.org/abs/2405.04532) as a new module: `onnxsim/qoq.py`.
- Confirmed via a repo-wide grep before starting that QServe/QoQ/SmoothAttention did not already exist under any name.

## What's added / scope

QoQ genuinely combines two independent contributions; this PR implements both.

**1. Progressive (two-stage) weight quantization -- `onnxsim.quantize_weight_only_qoq`, the primary contribution.**
Every existing weight-only INT4 quantizer in onnxsim (`quantize_weight_only_int4` and everything built on it -- `onnxsim.awq`, `onnxsim.gptq`, `onnxsim.hqq`, ...) rounds the original float weight directly to a single INT4 grid, one scale per block. QServe's own motivation for not doing that is a hardware one: INT4-to-FP16 dequantization needs an expensive, irregular per-element conversion path, whereas INT8-to-FP16 dequantization can stay on a GPU's INT8 tensor cores. QServe quantizes in two stages instead:

1. FP16 -> INT8, per output channel, with a **protective clipping range** (`int8_clip_max`, default 119 -- the paper's own headroom below the full `[-127, 127]` INT8 range, left for the second stage's own rounding error).
2. That already-INT8-quantized tensor -> INT4, per `(output channel, block)` group.

The distinguishing numerical difference from `quantize_weight_only_int4`'s single-stage rounding: the INT4 code is derived by rounding an *already-INT8-quantized* value, not the original float weight, and every reconstructed value passes through the INT8 grid on the way back to float (`code4 -> INT8 grid value -> float`) -- even though the two per-stage scales are folded into one combined per-`(channel, group)` scale, so the graph itself only emits a single `DequantizeLinear`, exactly `quantize_weight_only_int4`'s own graph shape.

**2. SmoothAttention -- `onnxsim.apply_smooth_attention`, QoQ's KV-cache-side contribution.**
`onnxsim.kv_cache_quantization` already implements KIVI/KVQuant-style per-channel Key quantization. QServe's own aggressive 4-bit Key cache needs a smoothing step *before* that: SmoothAttention migrates per-channel quantization difficulty out of Key (which gets quantized) and into Query (which stays float, as attention math always keeps Q in float) -- the same diagonal-rescaling identity `onnxsim.smoothquant`/`onnxsim.outlier_suppression` already use for MatMul/Gemm (`(X / s) @ (W * s) == X @ W`), applied instead to the `QK^T` dot product: for head-dim channel `j`, `(K_j / s_j) . (Q_j * s_j) == K_j . Q_j`. Like `onnxsim.smoothquant`, this only performs the migration -- it returns a float-equivalent model, no quantization happens here -- meant to run immediately before `onnxsim.quantize_kv_cache` in a pipeline.

Both functions are registered in `onnxsim/__init__.py` (import + `__all__`), and `tests/test_qoq.py` (14 tests) covers: the two-stage numerical reconstruction verified directly against the written initializers (numpy, tight relative tolerance, no onnxruntime round-trip for exactness, per this project's platform-numerics note); a separate loose onnxruntime end-to-end sanity check; Gemm `transB=1`; INT4 code range; invalid `int8_clip_max`; non-block-divisible `K`; non-constant weight; opset gating; SmoothAttention's exact `(K/s).(Q*s) == K.Q` dot-product identity (verified in plain numpy); Key-channel-range flattening; and a no-matching-subgraph no-op.

## Test plan

All run against a from-scratch build (`git submodule update --init --recursive` + `pip install -e . --no-build-isolation`, since the container had no prior build):

- `pytest tests/test_qoq.py -v` → **14 passed**
- `pytest tests/test_kv_cache_quantization.py tests/test_smoothquant.py tests/test_attention_quantization.py tests/test_hqq.py tests/test_weight_only_quantize_int4.py -q` (regression check on sibling/reused modules) → **42 passed**
- `ruff check onnxsim/qoq.py tests/test_qoq.py onnxsim/__init__.py` → all checks passed
- `ruff format --check` on the same files → already formatted
- `mypy onnxsim` → **no issues found in 65 source files** (same baseline as before this change)
- Full suite (`pytest tests/ -q`, excluding files requiring optional `torch`/`timm`, not installed in this container and unrelated to this change) → **2130 passed, 94 skipped**, no failures
- Merged latest `origin/master` (which had moved with unrelated C++ structured-pruning work) into the branch, rebuilt the C++ extension, and re-ran the full suite above on the merged/rebuilt code → still **2130 passed, 94 skipped**, lint/type-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbzxQvV2DMspUUUBuzfzTX

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbzxQvV2DMspUUUBuzfzTX)_