### PR TITLE
Add HF-config-to-ONNX reconstruction and an optional PPQ quantization bridge

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -50,6 +50,7 @@ from onnxsim.gguf_reconstruct import (
 )
 from onnxsim.gptq import apply_gptq
 from onnxsim.gptvq import quantize_weight_only_gptvq
+from onnxsim.hf_reconstruct import read_hf_config, reconstruct_hf_graph
 from onnxsim.hqq import quantize_weight_only_int4_hqq
 from onnxsim.kmeans_quantization import quantize_weight_only_kmeans
 from onnxsim.kv_cache_quantization import quantize_kv_cache
@@ -106,6 +107,7 @@ from onnxsim.outlier_suppression import apply_outlier_suppression
 from onnxsim.outlier_suppression_plus import apply_outlier_suppression_plus
 from onnxsim.owq import apply_owq
 from onnxsim.pb_llm import quantize_weight_only_pb_llm
+from onnxsim.ppq_integration import quantize_with_ppq
 from onnxsim.precision_estimator import (
     ModelQuantizationEstimate,
     estimate_model_quantization_drop,
@@ -181,6 +183,7 @@ __all__ = [
     "apply_flexround",
     "apply_fptq",
     "apply_owq",
+    "quantize_with_ppq",
     "apply_smoothquant",
     "apply_rptq_reorder",
     "apply_outlier_suppression_plus",
@@ -294,6 +297,8 @@ __all__ = [
     "load_model",
     "read_gguf_metadata",
     "reconstruct_gguf_graph",
+    "reconstruct_hf_graph",
+    "read_hf_config",
     "UnsupportedArchitectureError",
     "export_transformers_model",
     "export_mlir",

--- a/onnxsim/hf_reconstruct.py
+++ b/onnxsim/hf_reconstruct.py
@@ -1,0 +1,473 @@
+"""Builds a runnable ONNX graph *and* its weights directly from a
+HuggingFace Transformers checkpoint directory (``config.json`` +
+``*.safetensors``), for the same Llama-family block shape
+:mod:`onnxsim.gguf_reconstruct` supports -- RMSNorm, rotary position
+embeddings, grouped-query attention, a SwiGLU FFN -- plus Qwen3's per-head
+QK-RMSNorm, confirmed against the real ``transformers`` source
+(``modeling_qwen3.py``, fetched from the ``huggingface/transformers`` repo
+at the time this was written): ``query_states = self.q_norm(self.q_proj(
+hidden_states).view(hidden_shape)).transpose(1, 2)`` -- i.e. project, reshape
+to per-head vectors, RMSNorm *each head's own* ``head_dim`` slice (not the
+whole hidden state), *then* transpose and apply RoPE. Same for
+``key_states``/``k_norm``. Qwen3 also decouples ``head_dim`` from
+``hidden_size // num_attention_heads`` -- confirmed for real against a
+`Qwen/Qwen3-0.6B` checkpoint (``hidden_size=1024``,
+``num_attention_heads=16`` would imply 64, but the checkpoint's own
+``config.json`` sets ``head_dim=128``) -- so ``head_dim`` is read from the
+config with that fallback, never computed unconditionally.
+
+Complements :mod:`onnxsim.gguf_reconstruct`: same graph-building approach
+(construct the topology from declared hyperparameters, then attach the
+checkpoint's own tensors as initializers), applied to the source format
+most LLM checkpoints actually ship as -- a raw HuggingFace directory --
+rather than requiring a GGUF conversion first. Reuses that module's
+op-building helpers (``_Builder``, ``_linear``, ``_rmsnorm``,
+``_apply_rope``, ...) unchanged, so both builders produce structurally
+identical graphs for the same architecture family.
+
+Supported ``config.json`` ``"model_type"``: ``"llama"``, ``"mistral"``,
+``"qwen2"``, ``"qwen3"``. Same "known architecture template, fail clearly
+otherwise" philosophy as :mod:`onnxsim.gguf_reconstruct` -- see that
+module's docstring for why. No MoE support (unlike that module's Mixtral
+path): HF's per-expert tensor layout (``mlp.experts.{i}.gate_proj.weight``,
+one initializer per expert) differs from GGUF's fused-expert tensors
+``_moe_ffn`` expects (one tensor stacking every expert), and adapting that
+function to the HF layout hasn't been done here -- ``num_local_experts``/
+``num_experts`` present in the config raises :class:`UnsupportedArchitectureError`.
+
+Reads ``*.safetensors`` with a small self-contained parser (the format: an
+8-byte little-endian header-length prefix, a JSON header describing each
+tensor's dtype/shape/byte-offset, then the raw tensor data) -- no
+``safetensors`` package dependency, matching how
+:mod:`onnxsim.gguf_reconstruct` parses GGUF's own binary format directly
+rather than depending on a ``gguf`` package. Handles both a single
+``model.safetensors`` and a sharded checkpoint (``model.safetensors.index.
+json`` + ``model-NNNNN-of-MMMMM.safetensors``), reading only the bytes for
+tensors this graph actually declares, not the whole checkpoint into memory
+at once.
+
+Scope note on shapes, same as :mod:`onnxsim.gguf_reconstruct`:
+``batch_size``/``seq_len`` are concrete, caller-chosen static dimensions,
+not dynamic axes, and there is no KV-cache-aware incremental-decode graph
+here -- a single-shape prefill-style forward pass only.
+
+Precision note, confirmed for real against `Qwen/Qwen3-0.6B` (stored as
+BF16 end to end, ~1.5GB): every non-FLOAT32-dtype weight gets an explicit
+``Cast`` to FLOAT32 in the graph, right after being declared (see
+``declare()``). This was tried two ways, in order:
+
+1. Upcast the *stored initializer bytes* themselves (BF16 -> FLOAT32) on
+   read, keeping every op's input already FLOAT32 with no extra node. This
+   is what GGUF's own raw-dtype path does *not* need, but was tried here
+   first for symmetry with it -- and confirmed necessary regardless: the
+   op-building helpers reused from ``gguf_reconstruct`` (``_rmsnorm``,
+   ``_apply_rope``, the causal mask/``inv_sqrt_d`` constants, ...) build
+   every constant as FLOAT32, so a *preserved*-BF16 weight reaching one of
+   those ops is a mixed-dtype node onnxruntime rejects outright (``Type
+   Error: ... (Add) bound to different types (tensor(bfloat16) and
+   tensor(float))``).
+2. But upcasting the stored bytes roughly doubles the model's total size --
+   confirmed to matter, not just in principle: `Qwen/Qwen3-0.6B`'s real
+   ~1.5GB BF16 checkpoint upcasts to ~3.0GB, over protobuf's ~2.1GB
+   (``2**31 - 1``) single-message serialization limit, and
+   ``onnx.checker.check_model``/``model.SerializeToString()`` failed
+   outright (``EncodeError: Failed to serialize proto``) on the resulting
+   model. So the *initializer* stays the checkpoint's own compact dtype
+   (BF16 stays BF16-sized), and a graph-level ``Cast`` node upcasts the
+   *value* to FLOAT32 at first use instead -- same fix for the mixed-dtype
+   problem, none of the size blowup.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import struct
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import onnx
+import onnx.helper
+
+from onnxsim.gguf_reconstruct import (
+    _IR_VERSION,
+    _OPSET,
+    UnsupportedArchitectureError,
+    _apply_rope,
+    _Builder,
+    _linear,
+    _rmsnorm,
+    _unsqueeze,
+)
+
+_SAFETENSORS_DTYPE_TO_ONNX: Dict[str, Tuple[int, np.dtype]] = {
+    "F64": (onnx.TensorProto.DOUBLE, np.dtype("<f8")),
+    "F32": (onnx.TensorProto.FLOAT, np.dtype("<f4")),
+    "F16": (onnx.TensorProto.FLOAT16, np.dtype("<f2")),
+    "I64": (onnx.TensorProto.INT64, np.dtype("<i8")),
+    "I32": (onnx.TensorProto.INT32, np.dtype("<i4")),
+    "I16": (onnx.TensorProto.INT16, np.dtype("<i2")),
+    "I8": (onnx.TensorProto.INT8, np.dtype("i1")),
+    "U8": (onnx.TensorProto.UINT8, np.dtype("u1")),
+    "BOOL": (onnx.TensorProto.BOOL, np.dtype("?")),
+    # BF16 has no native numpy dtype and is upcast to FLOAT32 on read
+    # instead (a confirmed-necessary special case, not an oversight) --
+    # see _read_tensor.
+}
+
+_SUPPORTED_MODEL_TYPES = frozenset({"llama", "mistral", "qwen2", "qwen3"})
+
+
+class _SafetensorsEntry:
+    __slots__ = ("file_path", "dtype", "shape", "start", "end")
+
+    def __init__(
+        self, file_path: str, dtype: str, shape: List[int], start: int, end: int
+    ):
+        self.file_path = file_path
+        self.dtype = dtype
+        self.shape = shape
+        self.start = start
+        self.end = end
+
+
+def _read_safetensors_header(path: str) -> Dict[str, dict]:
+    """The JSON header of one ``.safetensors`` file: ``{tensor_name: {"dtype":
+    str, "shape": [int, ...], "data_offsets": [start, end]}}`` (plus a
+    ``"__metadata__"`` entry this ignores) -- no tensor byte data read."""
+    with open(path, "rb") as f:
+        (header_len,) = struct.unpack("<Q", f.read(8))
+        header = json.loads(f.read(header_len))
+    header.pop("__metadata__", None)
+    return header
+
+
+def _index_safetensors_checkpoint(hf_dir: str) -> Dict[str, _SafetensorsEntry]:
+    """Map every tensor name in `hf_dir` to the file/byte-range holding it,
+    across either a single ``model.safetensors`` or a sharded checkpoint
+    (``model.safetensors.index.json`` + ``model-NNNNN-of-MMMMM.safetensors``).
+    Data offsets in a safetensors header are relative to the *end of the
+    header itself* within that file, so each entry's ``start``/``end`` here
+    are already adjusted to be absolute file offsets.
+    """
+    index_path = os.path.join(hf_dir, "model.safetensors.index.json")
+    if os.path.exists(index_path):
+        with open(index_path) as f:
+            weight_map = json.load(f)["weight_map"]
+        file_names = sorted(set(weight_map.values()))
+    else:
+        single = os.path.join(hf_dir, "model.safetensors")
+        if not os.path.exists(single):
+            raise FileNotFoundError(
+                f"no model.safetensors or model.safetensors.index.json under {hf_dir!r}"
+            )
+        file_names = ["model.safetensors"]
+        weight_map = None
+
+    entries: Dict[str, _SafetensorsEntry] = {}
+    for file_name in file_names:
+        file_path = os.path.join(hf_dir, file_name)
+        with open(file_path, "rb") as f:
+            (header_len,) = struct.unpack("<Q", f.read(8))
+        header_end = 8 + header_len
+        header = _read_safetensors_header(file_path)
+        for name, info in header.items():
+            if weight_map is not None and weight_map.get(name) != file_name:
+                continue
+            start, end = info["data_offsets"]
+            entries[name] = _SafetensorsEntry(
+                file_path,
+                info["dtype"],
+                info["shape"],
+                header_end + start,
+                header_end + end,
+            )
+    return entries
+
+
+def _read_tensor(entry: _SafetensorsEntry, name: str) -> onnx.TensorProto:
+    """Read one tensor's raw bytes and wrap them as an ONNX initializer,
+    preserving the checkpoint's own dtype (e.g. real BF16 weights stay
+    BF16-sized in the initializer -- see ``declare()``'s own docstring for
+    why the *graph*, not the stored bytes, is where this gets upcast to
+    FLOAT32 for actual computation).
+    """
+    with open(entry.file_path, "rb") as f:
+        f.seek(entry.start)
+        raw = f.read(entry.end - entry.start)
+    if entry.dtype == "BF16":
+        return onnx.helper.make_tensor(
+            name, onnx.TensorProto.BFLOAT16, entry.shape, vals=raw, raw=True
+        )
+    if entry.dtype not in _SAFETENSORS_DTYPE_TO_ONNX:
+        raise UnsupportedArchitectureError(
+            f"tensor {name!r} has safetensors dtype {entry.dtype!r}, which "
+            "this reconstructor cannot decode (supported: F64/F32/F16/BF16/"
+            "I64/I32/I16/I8/U8/BOOL)"
+        )
+    onnx_dtype, np_dtype = _SAFETENSORS_DTYPE_TO_ONNX[entry.dtype]
+    arr = np.frombuffer(raw, dtype=np_dtype).reshape(entry.shape)
+    return onnx.numpy_helper.from_array(arr, name=name)
+
+
+def read_hf_config(hf_dir: str) -> dict:
+    """``config.json`` from a HuggingFace checkpoint directory, as a plain
+    dict -- no ``transformers`` dependency, this is just JSON."""
+    with open(os.path.join(hf_dir, "config.json")) as f:
+        return json.load(f)
+
+
+def _reconstruct_llama_family_hf(
+    config: dict, entries: Dict[str, _SafetensorsEntry], batch_size: int, seq_len: int
+) -> onnx.GraphProto:
+    model_type = config["model_type"]
+
+    n_embd = int(config["hidden_size"])
+    n_layer = int(config["num_hidden_layers"])
+    n_head = int(config["num_attention_heads"])
+    n_head_kv = int(config.get("num_key_value_heads", n_head))
+    eps = float(config.get("rms_norm_eps", 1e-5))
+    freq_base = float(config.get("rope_theta", 10000.0))
+    attention_bias = bool(config.get("attention_bias", False))
+    vocab_size = int(config["vocab_size"])
+    tie_word_embeddings = bool(config.get("tie_word_embeddings", False))
+
+    for key in ("num_local_experts", "num_experts"):
+        if config.get(key):
+            raise UnsupportedArchitectureError(
+                f"config has {key}={config[key]!r} -- MoE HF checkpoints are "
+                "not supported (see this module's docstring for why)"
+            )
+
+    if n_embd % n_head != 0 and "head_dim" not in config:
+        raise UnsupportedArchitectureError(
+            f"hidden_size={n_embd} is not divisible by "
+            f"num_attention_heads={n_head}, and config has no explicit "
+            "head_dim to fall back to"
+        )
+    head_dim = int(config.get("head_dim") or (n_embd // n_head))
+    if n_head % n_head_kv != 0:
+        raise UnsupportedArchitectureError(
+            f"num_attention_heads={n_head} is not a multiple of "
+            f"num_key_value_heads={n_head_kv} (grouped-query attention "
+            "requires an integer head-repeat factor)"
+        )
+    n_rep = n_head // n_head_kv
+    use_qk_norm = model_type == "qwen3"
+
+    b = _Builder()
+
+    def declare(name: str) -> str:
+        """Declare weight `name` as an initializer and return the name to
+        actually *use* as a graph value -- which is a `Cast`-to-FLOAT32
+        node's output, not the initializer itself, whenever the checkpoint's
+        own dtype isn't already FLOAT32. See this module's docstring for
+        why the cast lives in the graph rather than in the stored bytes.
+        """
+        entry = entries.get(name)
+        if entry is None:
+            raise UnsupportedArchitectureError(
+                f"checkpoint is missing required tensor {name!r} for "
+                f"model_type={model_type!r}"
+            )
+        b.initializers.append(_read_tensor(entry, name))
+        if entry.dtype == "F32":
+            return name
+        return b.op("Cast", [name], f"{name}.f32", to=onnx.TensorProto.FLOAT)
+
+    def declare_optional(name: str) -> Optional[str]:
+        return declare(name) if name in entries else None
+
+    token_embd = declare("model.embed_tokens.weight")
+
+    input_ids = "input_ids"
+    position_ids = "position_ids"
+    graph_inputs = [
+        onnx.helper.make_tensor_value_info(
+            input_ids, onnx.TensorProto.INT64, [batch_size, seq_len]
+        ),
+        onnx.helper.make_tensor_value_info(
+            position_ids, onnx.TensorProto.INT64, [batch_size, seq_len]
+        ),
+    ]
+
+    x = b.op("Gather", [token_embd, input_ids], "embed", axis=0)
+
+    # RoPE cos/sin: identical across every layer -- computed once, same as
+    # gguf_reconstruct._reconstruct_llama_family.
+    inv_freq = 1.0 / (
+        freq_base ** (np.arange(0, head_dim, 2, dtype=np.float64) / head_dim)
+    )
+    inv_freq_c = b.const(
+        inv_freq.reshape(1, 1, -1).astype(np.float32), prefix="inv_freq"
+    )
+    pos_f = b.op("Cast", [position_ids], "pos_f", to=onnx.TensorProto.FLOAT)
+    pos_unsq = _unsqueeze(b, pos_f, [-1], "pos_unsq")
+    freqs = b.op("Mul", [pos_unsq, inv_freq_c], "freqs")
+    emb = b.op("Concat", [freqs, freqs], "rope_emb", axis=-1)
+    cos = b.op("Cos", [emb], "rope_cos")
+    sin = b.op("Sin", [emb], "rope_sin")
+    cos_b = _unsqueeze(b, cos, [1], "rope_cos_b")
+    sin_b = _unsqueeze(b, sin, [1], "rope_sin_b")
+
+    causal_mask = np.triu(np.full((seq_len, seq_len), -1e9, dtype=np.float32), k=1)
+    mask_c = b.const(causal_mask, prefix="causal_mask")
+    inv_sqrt_d = b.const(
+        np.array(1.0 / np.sqrt(head_dim), dtype=np.float32), prefix="inv_sqrt_d"
+    )
+
+    def reshape(t: str, dims: List[int], prefix: str) -> str:
+        return b.op("Reshape", [t, b.shape_const(dims)], prefix)
+
+    for i in range(n_layer):
+        p = f"model.layers.{i}"
+        resid = x
+        h = _rmsnorm(
+            b, x, declare(f"{p}.input_layernorm.weight"), eps, f"{p}.attn_norm"
+        )
+
+        q = _linear(
+            b,
+            h,
+            declare(f"{p}.self_attn.q_proj.weight"),
+            declare_optional(f"{p}.self_attn.q_proj.bias") if attention_bias else None,
+            f"{p}.q_proj",
+        )
+        k = _linear(
+            b,
+            h,
+            declare(f"{p}.self_attn.k_proj.weight"),
+            declare_optional(f"{p}.self_attn.k_proj.bias") if attention_bias else None,
+            f"{p}.k_proj",
+        )
+        v = _linear(
+            b,
+            h,
+            declare(f"{p}.self_attn.v_proj.weight"),
+            declare_optional(f"{p}.self_attn.v_proj.bias") if attention_bias else None,
+            f"{p}.v_proj",
+        )
+
+        q = reshape(q, [batch_size, seq_len, n_head, head_dim], f"{p}.q_r")
+        k = reshape(k, [batch_size, seq_len, n_head_kv, head_dim], f"{p}.k_r")
+        v = reshape(v, [batch_size, seq_len, n_head_kv, head_dim], f"{p}.v_r")
+
+        if use_qk_norm:
+            # Confirmed against real transformers/models/qwen3/modeling_qwen3.py:
+            # RMSNorm is applied to each head's own head_dim slice *before*
+            # the transpose to [B, H, S, D] -- i.e. on the still-[B, S, H,
+            # D]-shaped tensor, exactly where this module docstring says.
+            q = _rmsnorm(
+                b, q, declare(f"{p}.self_attn.q_norm.weight"), eps, f"{p}.q_norm"
+            )
+            k = _rmsnorm(
+                b, k, declare(f"{p}.self_attn.k_norm.weight"), eps, f"{p}.k_norm"
+            )
+
+        q = b.op("Transpose", [q], f"{p}.q_t", perm=[0, 2, 1, 3])
+        k = b.op("Transpose", [k], f"{p}.k_t", perm=[0, 2, 1, 3])
+        v = b.op("Transpose", [v], f"{p}.v_t", perm=[0, 2, 1, 3])
+
+        q = _apply_rope(b, q, cos_b, sin_b, head_dim, f"{p}.q_rope")
+        k = _apply_rope(b, k, cos_b, sin_b, head_dim, f"{p}.k_rope")
+
+        # Grouped-query attention via broadcasting -- same design as
+        # gguf_reconstruct._reconstruct_llama_family, see its own comment.
+        q5 = reshape(q, [batch_size, n_head_kv, n_rep, seq_len, head_dim], f"{p}.q5")
+        k5 = _unsqueeze(b, k, [2], f"{p}.k5")
+        v5 = _unsqueeze(b, v, [2], f"{p}.v5")
+
+        k5t = b.op("Transpose", [k5], f"{p}.k5t", perm=[0, 1, 2, 4, 3])
+        scores = b.op("MatMul", [q5, k5t], f"{p}.scores")
+        scores = b.op("Mul", [scores, inv_sqrt_d], f"{p}.scores_scaled")
+        scores = b.op("Add", [scores, mask_c], f"{p}.scores_masked")
+        attn = b.op("Softmax", [scores], f"{p}.softmax", axis=-1)
+        out5 = b.op("MatMul", [attn, v5], f"{p}.attn_out5")
+
+        out = reshape(out5, [batch_size, n_head, seq_len, head_dim], f"{p}.out_r")
+        out = b.op("Transpose", [out], f"{p}.out_t", perm=[0, 2, 1, 3])
+        out = reshape(out, [batch_size, seq_len, n_head * head_dim], f"{p}.out_flat")
+        out = _linear(
+            b,
+            out,
+            declare(f"{p}.self_attn.o_proj.weight"),
+            declare_optional(f"{p}.self_attn.o_proj.bias") if attention_bias else None,
+            f"{p}.o_proj",
+        )
+        x = b.op("Add", [resid, out], f"{p}.attn_resid")
+
+        resid = x
+        h = _rmsnorm(
+            b, x, declare(f"{p}.post_attention_layernorm.weight"), eps, f"{p}.ffn_norm"
+        )
+        gate = _linear(
+            b, h, declare(f"{p}.mlp.gate_proj.weight"), None, f"{p}.gate_proj"
+        )
+        up = _linear(b, h, declare(f"{p}.mlp.up_proj.weight"), None, f"{p}.up_proj")
+        silu = b.op("Sigmoid", [gate], f"{p}.silu_sig")
+        silu = b.op("Mul", [gate, silu], f"{p}.silu")
+        act = b.op("Mul", [silu, up], f"{p}.act")
+        ffn_out = _linear(
+            b, act, declare(f"{p}.mlp.down_proj.weight"), None, f"{p}.down_proj"
+        )
+        x = b.op("Add", [resid, ffn_out], f"{p}.ffn_resid")
+
+    x = _rmsnorm(b, x, declare("model.norm.weight"), eps, "output_norm")
+
+    if not tie_word_embeddings and "lm_head.weight" in entries:
+        lm_head = declare("lm_head.weight")
+    else:
+        # Tied embeddings: reuse token_embd (already declared above), same
+        # fallback gguf_reconstruct._reconstruct_llama_family uses.
+        lm_head = token_embd
+    logits = _linear(b, x, lm_head, None, "lm_head")
+
+    return onnx.helper.make_graph(
+        b.nodes,
+        f"hf_{model_type}",
+        graph_inputs,
+        [
+            onnx.helper.make_tensor_value_info(
+                logits, onnx.TensorProto.FLOAT, [batch_size, seq_len, vocab_size]
+            )
+        ],
+        initializer=b.initializers,
+    )
+
+
+def reconstruct_hf_graph(
+    hf_dir: str, batch_size: int = 1, seq_len: int = 8
+) -> onnx.ModelProto:
+    """Build a runnable ONNX graph -- structure *and* weights -- directly
+    from a HuggingFace checkpoint directory, for a recognized architecture
+    (``model_type`` "llama", "mistral", "qwen2", or "qwen3" -- see this
+    module's docstring).
+
+    :param hf_dir: path to the checkpoint directory (containing
+            ``config.json`` and either ``model.safetensors`` or
+            ``model.safetensors.index.json`` + shards)
+    :param batch_size: static batch dimension baked into the returned
+            graph's input/output shapes (not a dynamic axis -- see this
+            module's docstring's scope note)
+    :param seq_len: static sequence-length dimension, likewise baked in
+    :returns: the constructed, hydrated model (inputs ``input_ids``/
+            ``position_ids``, both ``int64[batch_size, seq_len]``; output
+            ``logits``, ``float32[batch_size, seq_len, vocab_size]``)
+    :raises UnsupportedArchitectureError: if ``model_type`` is not one this
+            builder has a template for, a required tensor is missing, or
+            the checkpoint is MoE
+    """
+    config = read_hf_config(hf_dir)
+    model_type = config.get("model_type")
+    if model_type not in _SUPPORTED_MODEL_TYPES:
+        raise UnsupportedArchitectureError(
+            f"model_type={model_type!r} has no graph template here -- "
+            f"supported: {sorted(_SUPPORTED_MODEL_TYPES)}"
+        )
+    entries = _index_safetensors_checkpoint(hf_dir)
+    graph = _reconstruct_llama_family_hf(config, entries, batch_size, seq_len)
+    return onnx.helper.make_model(
+        graph,
+        opset_imports=[onnx.helper.make_opsetid("", _OPSET)],
+        ir_version=_IR_VERSION,
+    )

--- a/onnxsim/ppq_compat.py
+++ b/onnxsim/ppq_compat.py
@@ -1,0 +1,261 @@
+"""A PPQ-API-shaped quantization shim backed entirely by onnxsim's own
+:func:`onnxsim.quantize_static` -- no PPQ install required or even
+possible (see :mod:`onnxsim.ppq_integration`'s module docstring: PPQ 0.6.6,
+its latest PyPI release as of this writing, cannot be imported at all
+alongside a modern ``onnx``/``protobuf``, and appears unmaintained -- its
+last release predates both of those incompatibilities being introduced
+upstream).
+
+Rather than trying to get the real PPQ running, this module reproduces the
+small, commonly-used slice of PPQ's own public calling convention --
+``quantize_onnx_model()``, ``export_ppq_graph()``,
+``TargetPlatform.ONNXRUNTIME``, ``QuantizationSettingFactory.
+default_setting()`` (names and parameter lists read directly from PPQ
+0.6.6's own ``ppq/api/interface.py`` and ``ppq/api/setting.py`` source) --
+so an existing PPQ-based calibration script can switch to onnxsim with a
+one-line import change:
+
+    # before
+    from ppq.api import quantize_onnx_model, export_ppq_graph
+    from ppq.api.setting import QuantizationSettingFactory
+    from ppq.core import TargetPlatform
+
+    # after
+    from onnxsim.ppq_compat import quantize_onnx_model, export_ppq_graph
+    from onnxsim.ppq_compat import QuantizationSettingFactory, TargetPlatform
+
+    graph = quantize_onnx_model(
+        onnx_import_file="model.onnx",
+        calib_dataloader=my_loader,
+        calib_steps=32,
+        input_shape=[1, 3, 224, 224],
+        platform=TargetPlatform.ONNXRUNTIME,
+    )
+    export_ppq_graph(graph, TargetPlatform.ONNXRUNTIME, "model.quant")
+
+with the call sites otherwise unchanged. The actual quantization math is
+entirely onnxsim's own ``quantize_static`` (MinMax/entropy/mse calibration,
+asymmetric UINT8 activations + per-output-channel symmetric INT8 weights),
+not a reimplementation of PPQ's own algorithms.
+
+**Scope, deliberately narrower than real PPQ:**
+
+- Only ``TargetPlatform.ONNXRUNTIME`` (PPQ's own QDQ-format ONNX Runtime
+  export target) is supported -- real PPQ has ~20 target platforms for
+  per-vendor backend-specific formats (PPL_CUDA_INT8, SNPE_INT8, ...) with
+  no onnxsim equivalent. Any other platform raises ``NotImplementedError``.
+- No custom per-layer dispatch table, mixed-precision policy, or graph
+  optimization passes -- ``QuantizationSetting``'s only field this shim
+  reads is ``calib_algorithm`` (mapped to ``quantize_static``'s
+  ``method=`` parameter); every other PPQ setting field is a no-op here.
+- ``quantize_onnx_model`` returns a plain ``onnx.ModelProto`` (onnxsim's
+  own QDQ-quantized graph), not PPQ's own ``ppq.IR.BaseGraph`` -- there is
+  no PPQ installed to construct one. ``export_ppq_graph`` therefore just
+  calls ``onnx.save`` under the hood.
+- No torch dependency: ``calib_dataloader`` may yield ``numpy.ndarray``,
+  ``dict``/``list``/``tuple`` of them, or (duck-typed, via ``.detach()``)
+  ``torch.Tensor`` -- whatever an existing PPQ calibration loader already
+  produces -- converted to onnxsim's own ``{input_name: np.ndarray}``
+  calibration-batch convention.
+
+This module and :mod:`onnxsim.ppq_integration` (the real, optional bridge
+to an actually-installed PPQ, confirmed broken today) solve the same
+problem from opposite directions; unless you specifically need PPQ's own
+richer dispatch/optimization machinery in an environment where its two
+confirmed import failures have been separately worked around, prefer this
+module -- it always works, with no extra install.
+"""
+
+from __future__ import annotations
+
+import itertools
+from enum import IntEnum
+from typing import Any, Callable, Dict, Iterable, List, Optional, Union
+
+import numpy as np
+import onnx
+
+from onnxsim.calibration import quantize_static
+
+
+class TargetPlatform(IntEnum):
+    """A minimal stand-in for PPQ's own ``ppq.core.TargetPlatform`` --
+    only the one member this shim actually supports, kept at PPQ's own
+    real numeric value (confirmed from ``ppq/core/quant.py``) so a direct
+    integer comparison against a real PPQ ``TargetPlatform.ONNXRUNTIME``
+    still holds true.
+    """
+
+    ONNXRUNTIME = -7
+
+
+class QuantizationSetting:
+    """A minimal stand-in for PPQ's own (much richer, deeply nested)
+    ``ppq.api.setting.QuantizationSetting``. Only ``calib_algorithm`` is
+    read by :func:`quantize_onnx_model` here; every other attribute a
+    caller may set has no effect -- this shim has no dispatcher, no
+    per-layer optimization passes, and no mixed-precision policy to
+    configure.
+    """
+
+    def __init__(self) -> None:
+        self.calib_algorithm: str = "minmax"
+
+
+class QuantizationSettingFactory:
+    """Stand-in for PPQ's own ``ppq.api.setting.QuantizationSettingFactory``."""
+
+    @staticmethod
+    def default_setting() -> QuantizationSetting:
+        return QuantizationSetting()
+
+
+def _method_from_setting(setting: Optional[Any]) -> str:
+    """Best-effort mapping from a ``QuantizationSetting``'s calibration
+    method to one of ``quantize_static``'s ``method=`` values. Looked up
+    defensively via ``getattr`` (rather than an isinstance check against
+    this module's own ``QuantizationSetting``) so a real PPQ
+    ``QuantizationSetting`` -- whose equivalent field actually lives
+    nested under ``setting.quantize_activation_setting.calib_algorithm``,
+    per PPQ 0.6.6's own ``ppq/api/setting.py`` -- degrades to onnxsim's
+    default rather than raising, since PPQ can't be installed in this
+    environment to confirm that nested path against a real instance.
+    """
+    if setting is None:
+        return "minmax"
+    algo = getattr(setting, "calib_algorithm", None)
+    if algo is None:
+        nested = getattr(setting, "quantize_activation_setting", None)
+        algo = getattr(nested, "calib_algorithm", None) if nested is not None else None
+    if algo is None:
+        return "minmax"
+    algo = str(algo).lower()
+    if algo in ("kl", "entropy", "klqf"):
+        return "entropy"
+    if algo == "mse":
+        return "mse"
+    return "minmax"
+
+
+def _to_numpy(value: Any) -> np.ndarray:
+    if isinstance(value, np.ndarray):
+        return value
+    if hasattr(value, "detach"):  # duck-typed torch.Tensor -- no hard torch import
+        return value.detach().cpu().numpy()
+    return np.asarray(value)
+
+
+def _batch_to_calibration_dict(
+    batch: Any, input_names: List[str]
+) -> Dict[str, np.ndarray]:
+    if isinstance(batch, dict):
+        return {name: _to_numpy(v) for name, v in batch.items()}
+    if isinstance(batch, (list, tuple)):
+        if len(batch) != len(input_names):
+            raise ValueError(
+                f"calib_dataloader yielded {len(batch)} arrays but the model "
+                f"has {len(input_names)} inputs {input_names!r}"
+            )
+        return {name: _to_numpy(v) for name, v in zip(input_names, batch)}
+    if len(input_names) != 1:
+        raise ValueError(
+            f"calib_dataloader yielded a single array but the model has "
+            f"{len(input_names)} inputs {input_names!r} -- yield a dict or "
+            f"a list/tuple of arrays per batch instead, one per input."
+        )
+    return {input_names[0]: _to_numpy(batch)}
+
+
+def quantize_onnx_model(
+    onnx_import_file: Union[str, onnx.ModelProto],
+    calib_dataloader: Optional[Iterable[Any]] = None,
+    calib_steps: Optional[int] = None,
+    input_shape: Optional[List[int]] = None,
+    platform: TargetPlatform = TargetPlatform.ONNXRUNTIME,
+    input_dtype: Optional[Any] = None,
+    inputs: Optional[List[Any]] = None,
+    setting: Optional[QuantizationSetting] = None,
+    collate_fn: Optional[Callable[[Any], Any]] = None,
+    device: str = "cpu",
+    verbose: int = 0,
+    do_quantize: bool = True,
+) -> onnx.ModelProto:
+    """Drop-in-callable-shaped replacement for PPQ's own
+    ``ppq.api.quantize_onnx_model`` (same parameter names/order, read from
+    PPQ 0.6.6's own source), backed by :func:`onnxsim.quantize_static`
+    instead of PPQ's quantizer -- see this module's docstring for the
+    scope this narrows PPQ's own behavior down to.
+
+    ``input_shape``/``input_dtype``/``inputs``/``device`` are accepted for
+    call-site compatibility but unused: onnxsim's own quantizer traces
+    calibration shapes/dtypes directly from ``calib_dataloader``'s batches
+    and always runs on CPU.
+
+    :raises NotImplementedError: if ``platform`` is anything other than
+            ``TargetPlatform.ONNXRUNTIME``.
+    :raises TypeError: if ``do_quantize`` is true and ``calib_dataloader``
+            or ``calib_steps`` is omitted -- matching real PPQ's own error
+            for the same condition.
+    """
+    if platform != TargetPlatform.ONNXRUNTIME:
+        raise NotImplementedError(
+            f"onnxsim.ppq_compat only supports platform=TargetPlatform.ONNXRUNTIME "
+            f"(QDQ-format quantization); got {platform!r}. Real PPQ's other target "
+            f"platforms have no onnxsim equivalent -- see this module's docstring."
+        )
+
+    model = (
+        onnx.load(onnx_import_file)
+        if isinstance(onnx_import_file, str)
+        else onnx_import_file
+    )
+
+    if not do_quantize:
+        return model
+
+    if calib_dataloader is None or calib_steps is None:
+        raise TypeError(
+            "Quantization needs a valid calib_dataloader and calib_steps setting."
+        )
+
+    input_names = [inp.name for inp in model.graph.input]
+    batches = []
+    for batch in itertools.islice(calib_dataloader, calib_steps):
+        if collate_fn is not None:
+            batch = collate_fn(batch)
+        batches.append(_batch_to_calibration_dict(batch, input_names))
+
+    method = _method_from_setting(setting)
+    return quantize_static(model, calibration_data=batches, method=method)
+
+
+def export_ppq_graph(
+    graph: onnx.ModelProto,
+    platform: TargetPlatform = TargetPlatform.ONNXRUNTIME,
+    graph_save_to: Optional[str] = None,
+    config_save_to: Optional[str] = None,
+    copy_graph: bool = True,
+    **kwargs: Any,
+) -> None:
+    """Drop-in-callable-shaped replacement for PPQ's own
+    ``ppq.api.export_ppq_graph``. ``graph`` here is a plain
+    ``onnx.ModelProto`` (this module's ``quantize_onnx_model`` return
+    value, not PPQ's own ``ppq.IR.BaseGraph``), so this is just
+    ``onnx.save`` -- matching real PPQ's own behavior of appending the
+    ``.onnx`` extension for you when ``graph_save_to`` doesn't already end
+    with one.
+
+    ``config_save_to`` and ``copy_graph`` are accepted for call-site
+    compatibility but unused: onnxsim's QDQ nodes carry their own
+    quantization parameters directly in the graph, so there is no separate
+    quantization-config file to write.
+    """
+    if platform != TargetPlatform.ONNXRUNTIME:
+        raise NotImplementedError(
+            f"onnxsim.ppq_compat only supports platform=TargetPlatform.ONNXRUNTIME; "
+            f"got {platform!r}."
+        )
+    if graph_save_to is None:
+        raise ValueError("graph_save_to is required")
+    path = graph_save_to if graph_save_to.endswith(".onnx") else graph_save_to + ".onnx"
+    onnx.save(graph, path)

--- a/onnxsim/ppq_integration.py
+++ b/onnxsim/ppq_integration.py
@@ -4,6 +4,14 @@ calibration-based static quantization via PPQ's own calibration/observer
 algorithms and quantization scheduler instead of onnxsim's own
 :func:`onnxsim.quantize_static`.
 
+**PPQ itself appears unmaintained and is confirmed broken against any
+current environment (see below) -- for a PPQ-API-shaped interface that
+actually works today, with no PPQ install at all, prefer
+:mod:`onnxsim.ppq_compat` instead of this module.** This module remains
+for whoever specifically needs real PPQ's own dispatch/optimization
+machinery in an environment where its incompatibilities have been
+separately worked around.
+
 **Confirmed, not speculative: the latest PyPI release (``ppq==0.6.6`` at the
 time this was written) cannot be imported at all in an environment with the
 modern ``onnx``/``protobuf`` versions onnxsim itself requires.** Verified by

--- a/onnxsim/ppq_integration.py
+++ b/onnxsim/ppq_integration.py
@@ -1,0 +1,140 @@
+"""Optional bridge to PPQ (OpenPPL's PyTorch Post-Training Quantization
+framework, https://github.com/OpenPPL/ppq -- ``pip install ppq``), for
+calibration-based static quantization via PPQ's own calibration/observer
+algorithms and quantization scheduler instead of onnxsim's own
+:func:`onnxsim.quantize_static`.
+
+**Confirmed, not speculative: the latest PyPI release (``ppq==0.6.6`` at the
+time this was written) cannot be imported at all in an environment with the
+modern ``onnx``/``protobuf`` versions onnxsim itself requires.** Verified by
+directly attempting the import in this repo's own dev environment -- two
+independent, unrelated failures, either one fatal on its own:
+
+1. ``import ppq`` -> ``TypeError: Descriptors cannot be created directly.``
+   from ``ppq/parser/caffe/ppl_caffe_pb2.py`` -- that file is protoc-
+   generated code frozen against a pre-3.19 ``protobuf`` runtime API; modern
+   ``protobuf`` (needed by current ``onnx``/``onnxruntime``, both already
+   onnxsim dependencies) rejects it outright.
+2. Even with ``PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python`` set to work
+   around (1): ``ppq/parser/onnx_parser.py`` does ``from onnx import
+   helper, mapping, numpy_helper`` -- ``onnx.mapping`` was removed from the
+   public ``onnx`` package (renamed internal to ``onnx._mapping``) in a
+   version newer than PPQ has ever been updated against.
+
+So this module's ``PPQ_AVAILABLE`` will be ``False`` in any environment
+that also has a current ``onnx`` installed -- which, since onnxsim itself
+requires one, means essentially always right now. **The integration code
+below is written directly against PPQ's real, documented top-level API
+(``ppq.api.quantize_onnx_model``/``export_ppq_graph``, read from the
+installed package's own source) but has NOT been executed end to end in
+this session, because PPQ cannot be imported to run it against.** Treat it
+as a best-effort bridge for whoever runs this in an environment where PPQ's
+own incompatibilities have been worked around (e.g. a separate, older-
+``onnx``/``protobuf`` virtualenv) -- not as confirmed-working code the way
+the rest of this project's claims are.
+
+PPQ's own quantization execution is PyTorch-based (it JIT-traces the ONNX
+graph through its own ``TorchExecutor``, not onnxruntime), so this needs a
+real ``torch`` install too, on top of ``ppq`` -- both optional, checked
+lazily, same graceful-degradation convention as
+``scripts/axera/pulsar2_quantizer.py``'s onnxruntime dependency.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import tempfile
+from typing import Dict, Iterable, Optional
+
+import numpy as np
+import onnx
+
+PPQ_AVAILABLE = False
+_UNAVAILABLE_REASON: Optional[str] = None
+
+# PPQ prints its own ASCII-art banner as a side effect of `import ppq`, even
+# on the failing import this module confirmed is the normal case today (see
+# this module's docstring) -- silence it so a caller importing onnxsim
+# doesn't get that banner unexpectedly in its own logs.
+with contextlib.redirect_stdout(io.StringIO()):
+    try:
+        import torch
+        from ppq.api import export_ppq_graph, quantize_onnx_model
+        from ppq.api.setting import QuantizationSettingFactory
+        from ppq.core import TargetPlatform
+
+        PPQ_AVAILABLE = True
+    except Exception as exc:  # pragma: no cover - confirmed to always fail today
+        _UNAVAILABLE_REASON = f"{type(exc).__name__}: {exc}"
+
+
+def unavailable_reason() -> Optional[str]:
+    """Why the PPQ bridge is unusable on this host, or None if usable.
+
+    See this module's docstring: confirmed to always be unusable today
+    against any environment with a current ``onnx`` install.
+    """
+    return _UNAVAILABLE_REASON
+
+
+def quantize_with_ppq(
+    model: onnx.ModelProto,
+    calibration_data: Iterable[Dict[str, np.ndarray]],
+    *,
+    calib_steps: int = 16,
+) -> onnx.ModelProto:
+    """Statically quantize ``model`` using PPQ's own calibration/quantization
+    pipeline, targeting ``TargetPlatform.ONNXRUNTIME`` (PPQ's QDQ-format
+    ONNX Runtime export target) with PPQ's default quantization setting.
+
+    ``calibration_data`` is a sequence of ``{input_name: np.ndarray}``
+    batches, matching every other calibration-data convention in this
+    project (see e.g. ``onnxsim.calibration.generate_random_calibration_
+    data``) -- converted here to the ``dict``-of-``torch.Tensor`` form
+    PPQ's own executor accepts for a multi-input graph (confirmed from
+    ``BaseQuantizer.quantize``'s own type hints: ``inputs: Union[torch.
+    Tensor, list, dict]``).
+
+    Runs entirely on CPU (``device="cpu"``) -- no CUDA requirement.
+
+    Raises if PPQ is unavailable (see this module's docstring for why that
+    is the confirmed, expected outcome today); check `PPQ_AVAILABLE` first.
+    """
+    if not PPQ_AVAILABLE:
+        raise RuntimeError(f"PPQ unavailable: {_UNAVAILABLE_REASON}")
+
+    calibration_data = list(calibration_data)
+    if not calibration_data:
+        raise ValueError("calibration_data must have at least one batch")
+
+    def to_torch(batch: Dict[str, np.ndarray]) -> Dict[str, "torch.Tensor"]:
+        return {name: torch.from_numpy(np.asarray(arr)) for name, arr in batch.items()}
+
+    torch_batches = [to_torch(batch) for batch in calibration_data]
+    dummy_inputs = torch_batches[0]
+
+    with tempfile.TemporaryDirectory() as td:
+        in_path = os.path.join(td, "in.onnx")
+        onnx.save(model, in_path)
+
+        quantized_graph = quantize_onnx_model(
+            onnx_import_file=in_path,
+            calib_dataloader=torch_batches,
+            calib_steps=min(calib_steps, len(torch_batches)),
+            input_shape=None,
+            inputs=dummy_inputs,
+            platform=TargetPlatform.ONNXRUNTIME,
+            setting=QuantizationSettingFactory.default_setting(),
+            device="cpu",
+        )
+
+        out_prefix = os.path.join(td, "out")
+        export_ppq_graph(
+            graph=quantized_graph,
+            platform=TargetPlatform.ONNXRUNTIME,
+            graph_save_to=out_prefix,
+        )
+        out_path = out_prefix if out_prefix.endswith(".onnx") else out_prefix + ".onnx"
+        return onnx.load(out_path)

--- a/tests/test_hf_reconstruct.py
+++ b/tests/test_hf_reconstruct.py
@@ -1,0 +1,451 @@
+"""Tests for ``onnxsim.reconstruct_hf_graph`` -- building an ONNX graph
+*and* hydrating its weights directly from a HuggingFace checkpoint
+directory's own declared architecture (see onnxsim/hf_reconstruct.py's
+module docstring for the design).
+
+Same rigor as test_gguf_reconstruct.py: the core claim under test is that
+the graph this builds computes the same function a Llama-family
+transformer described by the same hyperparameters does, checked against an
+*independent* from-scratch numpy implementation (not a reuse of anything in
+hf_reconstruct.py itself), run against the identical hand-written
+safetensors checkpoint and compared to the ONNX graph's own output via
+``onnx.reference.ReferenceEvaluator``.
+"""
+
+import json
+import struct
+
+import numpy as np
+import onnx
+import pytest
+from onnx.reference import ReferenceEvaluator
+
+import onnxsim
+from onnxsim.gguf_reconstruct import UnsupportedArchitectureError
+
+
+def _write_safetensors(path, tensors):
+    """A real, valid ``.safetensors`` file: an 8-byte little-endian
+    header-length prefix, a JSON header (name -> dtype/shape/byte-offset),
+    then the raw tensor bytes back to back -- the exact format
+    hf_reconstruct.py's own ``_read_safetensors_header``/``_read_tensor``
+    parse, written independently here rather than via the ``safetensors``
+    package (kept out of this project's test dependencies)."""
+    header = {}
+    offset = 0
+    blobs = []
+    for name, arr in tensors.items():
+        nbytes = arr.nbytes
+        header[name] = {
+            "dtype": "F32",
+            "shape": list(arr.shape),
+            "data_offsets": [offset, offset + nbytes],
+        }
+        offset += nbytes
+        blobs.append(arr.astype("<f4").tobytes())
+    header_bytes = json.dumps(header).encode("utf-8")
+    with open(path, "wb") as f:
+        f.write(struct.pack("<Q", len(header_bytes)))
+        f.write(header_bytes)
+        for b in blobs:
+            f.write(b)
+
+
+def _rmsnorm(x, w, eps):
+    var = np.mean(x * x, axis=-1, keepdims=True)
+    return x / np.sqrt(var + eps) * w
+
+
+def _rotate_half(x):
+    half = x.shape[-1] // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return np.concatenate([-x2, x1], axis=-1)
+
+
+def _silu(x):
+    return x / (1.0 + np.exp(-x))
+
+
+def _build_tiny_hf_checkpoint(
+    tmp_path,
+    model_type,
+    n_head,
+    n_head_kv,
+    tie_word_embeddings,
+    use_qk_norm=False,
+    head_dim_override=None,
+    seed=0,
+):
+    """A tiny (2-layer) HF-shaped checkpoint directory (config.json +
+    model.safetensors), plus the weight dict and config needed to compute
+    an independent numpy reference forward pass for it."""
+    rng = np.random.default_rng(seed)
+    n_embd = 8
+    head_dim = head_dim_override or (n_embd // n_head)
+    n_layer = 2
+    n_ff = 16
+    vocab = 12
+    eps = 1e-5
+    freq_base = 10000.0
+    n_embd_q = n_head * head_dim
+    n_embd_kv = n_head_kv * head_dim
+
+    def rand(*shape):
+        return rng.standard_normal(shape).astype(np.float32) * 0.1
+
+    weights = {"model.embed_tokens.weight": rand(vocab, n_embd)}
+    for i in range(n_layer):
+        p = f"model.layers.{i}"
+        weights[f"{p}.input_layernorm.weight"] = rand(n_embd) + 1.0
+        weights[f"{p}.self_attn.q_proj.weight"] = rand(n_embd_q, n_embd)
+        weights[f"{p}.self_attn.k_proj.weight"] = rand(n_embd_kv, n_embd)
+        weights[f"{p}.self_attn.v_proj.weight"] = rand(n_embd_kv, n_embd)
+        weights[f"{p}.self_attn.o_proj.weight"] = rand(n_embd, n_embd_q)
+        if use_qk_norm:
+            weights[f"{p}.self_attn.q_norm.weight"] = rand(head_dim) + 1.0
+            weights[f"{p}.self_attn.k_norm.weight"] = rand(head_dim) + 1.0
+        weights[f"{p}.post_attention_layernorm.weight"] = rand(n_embd) + 1.0
+        weights[f"{p}.mlp.gate_proj.weight"] = rand(n_ff, n_embd)
+        weights[f"{p}.mlp.up_proj.weight"] = rand(n_ff, n_embd)
+        weights[f"{p}.mlp.down_proj.weight"] = rand(n_embd, n_ff)
+    weights["model.norm.weight"] = rand(n_embd) + 1.0
+    if not tie_word_embeddings:
+        weights["lm_head.weight"] = rand(vocab, n_embd)
+
+    hf_dir = tmp_path / "tiny_hf"
+    hf_dir.mkdir()
+    config = {
+        "model_type": model_type,
+        "hidden_size": n_embd,
+        "num_hidden_layers": n_layer,
+        "intermediate_size": n_ff,
+        "num_attention_heads": n_head,
+        "num_key_value_heads": n_head_kv,
+        "rms_norm_eps": eps,
+        "rope_theta": freq_base,
+        "vocab_size": vocab,
+        "tie_word_embeddings": tie_word_embeddings,
+        "attention_bias": False,
+    }
+    if head_dim_override is not None:
+        config["head_dim"] = head_dim_override
+    with open(hf_dir / "config.json", "w") as f:
+        json.dump(config, f)
+    _write_safetensors(str(hf_dir / "model.safetensors"), weights)
+
+    ref_config = dict(
+        n_embd=n_embd,
+        head_dim=head_dim,
+        n_layer=n_layer,
+        vocab=vocab,
+        eps=eps,
+        freq_base=freq_base,
+        n_head=n_head,
+        n_head_kv=n_head_kv,
+        tie_embeddings=tie_word_embeddings,
+        use_qk_norm=use_qk_norm,
+    )
+    return str(hf_dir), weights, ref_config
+
+
+def _reference_forward(weights, config, input_ids, position_ids):
+    """Independent from-scratch numpy implementation of the same tiny
+    Llama-family (optionally Qwen3-style QK-normed) transformer --
+    deliberately not sharing any code with onnxsim/hf_reconstruct.py."""
+    head_dim = config["head_dim"]
+    n_head, n_head_kv = config["n_head"], config["n_head_kv"]
+    n_layer, eps, freq_base = config["n_layer"], config["eps"], config["freq_base"]
+    seq = input_ids.shape[1]
+    batch = input_ids.shape[0]
+
+    x = weights["model.embed_tokens.weight"][input_ids]
+
+    inv_freq = 1.0 / (freq_base ** (np.arange(0, head_dim, 2) / head_dim))
+    freqs = position_ids[..., None].astype(np.float64) * inv_freq[None, None, :]
+    emb = np.concatenate([freqs, freqs], axis=-1)
+    cos = np.cos(emb).astype(np.float32)[:, None, :, :]
+    sin = np.sin(emb).astype(np.float32)[:, None, :, :]
+
+    n_rep = n_head // n_head_kv
+    causal_mask = np.triu(np.full((seq, seq), -1e9, dtype=np.float32), k=1)
+
+    for i in range(n_layer):
+        p = f"model.layers.{i}"
+        resid = x
+        h = _rmsnorm(x, weights[f"{p}.input_layernorm.weight"], eps)
+
+        q = h @ weights[f"{p}.self_attn.q_proj.weight"].T
+        k = h @ weights[f"{p}.self_attn.k_proj.weight"].T
+        v = h @ weights[f"{p}.self_attn.v_proj.weight"].T
+
+        q = q.reshape(batch, seq, n_head, head_dim)
+        k = k.reshape(batch, seq, n_head_kv, head_dim)
+        v = v.reshape(batch, seq, n_head_kv, head_dim)
+
+        if config["use_qk_norm"]:
+            q = _rmsnorm(q, weights[f"{p}.self_attn.q_norm.weight"], eps)
+            k = _rmsnorm(k, weights[f"{p}.self_attn.k_norm.weight"], eps)
+
+        q = q.transpose(0, 2, 1, 3)
+        k = k.transpose(0, 2, 1, 3)
+        v = v.transpose(0, 2, 1, 3)
+
+        q = q * cos + _rotate_half(q) * sin
+        k = k * cos + _rotate_half(k) * sin
+
+        k_rep = np.repeat(k, n_rep, axis=1)
+        v_rep = np.repeat(v, n_rep, axis=1)
+
+        scores = q @ k_rep.transpose(0, 1, 3, 2) / np.sqrt(head_dim)
+        scores = scores + causal_mask
+        attn = np.exp(scores - scores.max(axis=-1, keepdims=True))
+        attn = attn / attn.sum(axis=-1, keepdims=True)
+        out = attn @ v_rep
+
+        out = out.transpose(0, 2, 1, 3).reshape(batch, seq, n_head * head_dim)
+        out = out @ weights[f"{p}.self_attn.o_proj.weight"].T
+        x = resid + out
+
+        resid = x
+        h = _rmsnorm(x, weights[f"{p}.post_attention_layernorm.weight"], eps)
+        gate = h @ weights[f"{p}.mlp.gate_proj.weight"].T
+        up = h @ weights[f"{p}.mlp.up_proj.weight"].T
+        act = _silu(gate) * up
+        down = act @ weights[f"{p}.mlp.down_proj.weight"].T
+        x = resid + down
+
+    x = _rmsnorm(x, weights["model.norm.weight"], eps)
+    lm_head = (
+        weights["model.embed_tokens.weight"]
+        if config["tie_embeddings"]
+        else weights["lm_head.weight"]
+    )
+    return x @ lm_head.T
+
+
+@pytest.mark.parametrize("model_type", ["llama", "mistral", "qwen2"])
+@pytest.mark.parametrize("n_head,n_head_kv", [(2, 2), (2, 1)], ids=["mha", "gqa"])
+@pytest.mark.parametrize("tie_word_embeddings", [False, True], ids=["untied", "tied"])
+def test_reconstructed_graph_matches_independent_reference(
+    tmp_path, model_type, n_head, n_head_kv, tie_word_embeddings
+):
+    hf_dir, weights, config = _build_tiny_hf_checkpoint(
+        tmp_path, model_type, n_head, n_head_kv, tie_word_embeddings
+    )
+    batch, seq = 1, 5
+
+    model = onnxsim.reconstruct_hf_graph(hf_dir, batch_size=batch, seq_len=seq)
+    onnx.checker.check_model(model)
+
+    rng = np.random.default_rng(1)
+    input_ids = rng.integers(0, config["vocab"], size=(batch, seq)).astype(np.int64)
+    position_ids = np.arange(seq, dtype=np.int64)[None, :].repeat(batch, axis=0)
+
+    sess = ReferenceEvaluator(model)
+    (onnx_logits,) = sess.run(
+        None, {"input_ids": input_ids, "position_ids": position_ids}
+    )
+    ref_logits = _reference_forward(weights, config, input_ids, position_ids)
+
+    assert onnx_logits.shape == (batch, seq, config["vocab"])
+    np.testing.assert_allclose(onnx_logits, ref_logits, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.parametrize("n_head,n_head_kv", [(4, 4), (4, 2)], ids=["mha", "gqa"])
+def test_qwen3_qk_norm_and_head_dim_override_match_reference(
+    tmp_path, n_head, n_head_kv
+):
+    """Qwen3's two real differences from the shared Llama-family shape,
+    confirmed against the real ``transformers`` ``modeling_qwen3.py``
+    source (see hf_reconstruct.py's module docstring): per-head QK-RMSNorm,
+    and ``head_dim`` decoupled from ``hidden_size // num_attention_heads``
+    (here: hidden_size=8, num_attention_heads=4 would imply head_dim=2, but
+    the config explicitly overrides it to 6 -- mirroring the real
+    Qwen/Qwen3-0.6B checkpoint, whose head_dim=128 similarly isn't
+    hidden_size // num_attention_heads)."""
+    hf_dir, weights, config = _build_tiny_hf_checkpoint(
+        tmp_path,
+        "qwen3",
+        n_head,
+        n_head_kv,
+        tie_word_embeddings=False,
+        use_qk_norm=True,
+        head_dim_override=6,
+    )
+    batch, seq = 1, 5
+
+    model = onnxsim.reconstruct_hf_graph(hf_dir, batch_size=batch, seq_len=seq)
+    onnx.checker.check_model(model)
+
+    rng = np.random.default_rng(1)
+    input_ids = rng.integers(0, config["vocab"], size=(batch, seq)).astype(np.int64)
+    position_ids = np.arange(seq, dtype=np.int64)[None, :].repeat(batch, axis=0)
+
+    sess = ReferenceEvaluator(model)
+    (onnx_logits,) = sess.run(
+        None, {"input_ids": input_ids, "position_ids": position_ids}
+    )
+    ref_logits = _reference_forward(weights, config, input_ids, position_ids)
+    np.testing.assert_allclose(onnx_logits, ref_logits, atol=1e-3, rtol=1e-3)
+
+
+def test_bf16_weight_matches_float32_reference_after_cast(tmp_path):
+    """Confirmed real bug this guards against (see hf_reconstruct.py's
+    module docstring): a real Qwen/Qwen3-0.6B checkpoint stores every
+    weight as BF16, and mixing a preserved-BF16 initializer into this
+    module's FLOAT32-only op-building helpers produced a mixed-dtype node
+    onnxruntime rejected outright. The fix casts each non-FLOAT32 weight to
+    FLOAT32 in the graph (declare()) rather than upcasting the stored
+    bytes (which would double the model's size -- also confirmed to matter
+    for a real ~1.5GB checkpoint, see the same docstring). This test
+    represents one weight as BF16 (rounding a hand-picked exact-in-BF16
+    value) and checks the reconstructed graph's output exactly matches an
+    all-FLOAT32 checkpoint with the same (BF16-representable) values --
+    i.e. the Cast is wired in correctly, not merely present.
+    """
+    hf_dir, weights, config = _build_tiny_hf_checkpoint(
+        tmp_path, "llama", 2, 2, tie_word_embeddings=False
+    )
+    # Round layer-0's input_layernorm weight to values exactly representable
+    # in BF16 (truncate the low 16 mantissa bits), so the BF16 round-trip
+    # introduces no precision loss relative to the FLOAT32 reference this
+    # is compared against.
+    name = "model.layers.0.input_layernorm.weight"
+    f32 = weights[name].astype("<f4")
+    bf16_bits = (f32.view("<u4") >> 16).astype("<u2")
+    weights[name] = (bf16_bits.astype("<u4") << 16).view("<f4")
+
+    header = {}
+    offset = 0
+    blobs = []
+    for tensor_name, arr in weights.items():
+        if tensor_name == name:
+            nbytes = arr.size * 2
+            header[tensor_name] = {
+                "dtype": "BF16",
+                "shape": list(arr.shape),
+                "data_offsets": [offset, offset + nbytes],
+            }
+            blobs.append(bf16_bits.tobytes())
+        else:
+            nbytes = arr.nbytes
+            header[tensor_name] = {
+                "dtype": "F32",
+                "shape": list(arr.shape),
+                "data_offsets": [offset, offset + nbytes],
+            }
+            blobs.append(arr.astype("<f4").tobytes())
+        offset += nbytes
+    header_bytes = json.dumps(header).encode("utf-8")
+    with open(f"{hf_dir}/model.safetensors", "wb") as f:
+        f.write(struct.pack("<Q", len(header_bytes)))
+        f.write(header_bytes)
+        for b in blobs:
+            f.write(b)
+
+    batch, seq = 1, 5
+    model = onnxsim.reconstruct_hf_graph(hf_dir, batch_size=batch, seq_len=seq)
+    onnx.checker.check_model(model)
+
+    rng = np.random.default_rng(1)
+    input_ids = rng.integers(0, config["vocab"], size=(batch, seq)).astype(np.int64)
+    position_ids = np.arange(seq, dtype=np.int64)[None, :].repeat(batch, axis=0)
+
+    sess = ReferenceEvaluator(model)
+    (onnx_logits,) = sess.run(
+        None, {"input_ids": input_ids, "position_ids": position_ids}
+    )
+    ref_logits = _reference_forward(weights, config, input_ids, position_ids)
+    np.testing.assert_allclose(onnx_logits, ref_logits, atol=1e-4, rtol=1e-4)
+
+
+def test_sharded_checkpoint_loads_correctly(tmp_path):
+    """A checkpoint split across model-NNNNN-of-MMMMM.safetensors shards,
+    indexed by model.safetensors.index.json -- the layout real large HF
+    checkpoints ship as (a single model.safetensors, used everywhere else
+    in this file, only fits small checkpoints)."""
+    hf_dir, weights, config = _build_tiny_hf_checkpoint(
+        tmp_path, "llama", 2, 2, tie_word_embeddings=False
+    )
+    import os
+
+    single_path = f"{hf_dir}/model.safetensors"
+    names = list(weights.keys())
+    half = len(names) // 2
+    shard_names = {
+        "model-00001-of-00002.safetensors": names[:half],
+        "model-00002-of-00002.safetensors": names[half:],
+    }
+    weight_map = {}
+    for shard, shard_tensor_names in shard_names.items():
+        _write_safetensors(
+            f"{hf_dir}/{shard}", {n: weights[n] for n in shard_tensor_names}
+        )
+        for n in shard_tensor_names:
+            weight_map[n] = shard
+    with open(f"{hf_dir}/model.safetensors.index.json", "w") as f:
+        json.dump({"metadata": {}, "weight_map": weight_map}, f)
+    os.remove(single_path)
+
+    batch, seq = 1, 5
+    model = onnxsim.reconstruct_hf_graph(hf_dir, batch_size=batch, seq_len=seq)
+    onnx.checker.check_model(model)
+
+    rng = np.random.default_rng(1)
+    input_ids = rng.integers(0, config["vocab"], size=(batch, seq)).astype(np.int64)
+    position_ids = np.arange(seq, dtype=np.int64)[None, :].repeat(batch, axis=0)
+    sess = ReferenceEvaluator(model)
+    (onnx_logits,) = sess.run(
+        None, {"input_ids": input_ids, "position_ids": position_ids}
+    )
+    ref_logits = _reference_forward(weights, config, input_ids, position_ids)
+    np.testing.assert_allclose(onnx_logits, ref_logits, atol=1e-3, rtol=1e-3)
+
+
+def test_unrecognized_model_type_raises(tmp_path):
+    hf_dir = tmp_path / "gpt2"
+    hf_dir.mkdir()
+    with open(hf_dir / "config.json", "w") as f:
+        json.dump({"model_type": "gpt2"}, f)
+    _write_safetensors(str(hf_dir / "model.safetensors"), {})
+    with pytest.raises(UnsupportedArchitectureError, match="gpt2"):
+        onnxsim.reconstruct_hf_graph(str(hf_dir))
+
+
+def test_missing_required_tensor_raises(tmp_path):
+    hf_dir = tmp_path / "no_tensors"
+    hf_dir.mkdir()
+    config = {
+        "model_type": "llama",
+        "hidden_size": 8,
+        "num_hidden_layers": 1,
+        "intermediate_size": 16,
+        "num_attention_heads": 2,
+        "vocab_size": 12,
+    }
+    with open(hf_dir / "config.json", "w") as f:
+        json.dump(config, f)
+    _write_safetensors(str(hf_dir / "model.safetensors"), {})
+    with pytest.raises(UnsupportedArchitectureError, match="embed_tokens"):
+        onnxsim.reconstruct_hf_graph(str(hf_dir))
+
+
+def test_moe_config_raises():
+    """HF's per-expert tensor layout (mlp.experts.{i}.*) differs from
+    GGUF's fused-expert tensors this module's reused _moe_ffn expects, and
+    hasn't been adapted -- see hf_reconstruct.py's module docstring."""
+    with pytest.raises(UnsupportedArchitectureError, match="num_local_experts"):
+        onnxsim.hf_reconstruct._reconstruct_llama_family_hf(
+            {
+                "model_type": "qwen3",
+                "hidden_size": 8,
+                "num_hidden_layers": 1,
+                "intermediate_size": 16,
+                "num_attention_heads": 2,
+                "vocab_size": 12,
+                "num_local_experts": 4,
+            },
+            {},
+            batch_size=1,
+            seq_len=1,
+        )

--- a/tests/test_ppq_compat.py
+++ b/tests/test_ppq_compat.py
@@ -1,0 +1,211 @@
+"""Tests for onnxsim.ppq_compat -- the PPQ-API-shaped shim backed entirely
+by onnxsim.quantize_static (see that module's docstring for why this
+exists instead of trying to get the real, confirmed-broken PPQ running).
+
+Unlike tests/test_ppq_integration.py (which can only test a graceful
+failure, since real PPQ can't be imported here), this module needs no
+optional dependency at all and its actual quantization behavior is fully
+testable.
+"""
+
+import numpy as np
+import onnx
+import pytest
+from onnx import parser
+
+from onnxsim import ppq_compat
+
+
+def _matmul_model():
+    return parser.parse_model(
+        """
+        <ir_version: 10, opset_import: ["": 17]>
+        agraph (float[N,4] x) => (float[N,4] y)
+        <float[4,4] w = {1.0, 0.0, 0.0, 0.0,
+                         0.0, 1.0, 0.0, 0.0,
+                         0.0, 0.0, 1.0, 0.0,
+                         0.0, 0.0, 0.0, 1.0}>
+        {
+            y = MatMul(x, w)
+        }
+        """
+    )
+
+
+def _two_input_model():
+    return parser.parse_model(
+        """
+        <ir_version: 10, opset_import: ["": 17]>
+        agraph (float[N,4] x, float[N,4] z) => (float[N,4] y)
+        <float[4,4] w = {1.0, 0.0, 0.0, 0.0,
+                         0.0, 1.0, 0.0, 0.0,
+                         0.0, 0.0, 1.0, 0.0,
+                         0.0, 0.0, 0.0, 1.0}>
+        {
+            m = MatMul(x, w)
+            y = Add(m, z)
+        }
+        """
+    )
+
+
+def _has_qdq(model) -> bool:
+    op_types = {n.op_type for n in model.graph.node}
+    return "QuantizeLinear" in op_types and "DequantizeLinear" in op_types
+
+
+def test_quantize_onnx_model_with_dict_batches():
+    rng = np.random.default_rng(0)
+    loader = [{"x": rng.standard_normal((2, 4)).astype(np.float32)} for _ in range(4)]
+
+    quantized = ppq_compat.quantize_onnx_model(
+        onnx_import_file=_matmul_model(),
+        calib_dataloader=loader,
+        calib_steps=4,
+        input_shape=None,
+        platform=ppq_compat.TargetPlatform.ONNXRUNTIME,
+    )
+    onnx.checker.check_model(quantized)
+    assert _has_qdq(quantized)
+
+
+def test_quantize_onnx_model_with_raw_array_batches_single_input():
+    """Real PPQ's own single-input convention: calib_dataloader yields raw
+    arrays (no dict wrapper) when the model has exactly one input."""
+    rng = np.random.default_rng(0)
+    loader = [rng.standard_normal((2, 4)).astype(np.float32) for _ in range(4)]
+
+    quantized = ppq_compat.quantize_onnx_model(
+        onnx_import_file=_matmul_model(),
+        calib_dataloader=loader,
+        calib_steps=4,
+    )
+    onnx.checker.check_model(quantized)
+    assert _has_qdq(quantized)
+
+
+def test_quantize_onnx_model_with_tuple_batches_multi_input():
+    rng = np.random.default_rng(0)
+    loader = [
+        (
+            rng.standard_normal((2, 4)).astype(np.float32),
+            rng.standard_normal((2, 4)).astype(np.float32),
+        )
+        for _ in range(4)
+    ]
+
+    quantized = ppq_compat.quantize_onnx_model(
+        onnx_import_file=_two_input_model(),
+        calib_dataloader=loader,
+        calib_steps=4,
+    )
+    onnx.checker.check_model(quantized)
+
+
+def test_raw_array_batch_with_multi_input_model_raises():
+    rng = np.random.default_rng(0)
+    loader = [rng.standard_normal((2, 4)).astype(np.float32) for _ in range(2)]
+
+    with pytest.raises(ValueError, match="has 2 inputs"):
+        ppq_compat.quantize_onnx_model(
+            onnx_import_file=_two_input_model(),
+            calib_dataloader=loader,
+            calib_steps=2,
+        )
+
+
+def test_collate_fn_is_applied():
+    rng = np.random.default_rng(0)
+    raw_loader = [rng.standard_normal((2, 4)).astype(np.float32) for _ in range(3)]
+    calls = []
+
+    def collate(batch):
+        calls.append(batch)
+        return {"x": batch}
+
+    quantized = ppq_compat.quantize_onnx_model(
+        onnx_import_file=_matmul_model(),
+        calib_dataloader=raw_loader,
+        calib_steps=3,
+        collate_fn=collate,
+    )
+    onnx.checker.check_model(quantized)
+    assert len(calls) == 3
+
+
+def test_calib_steps_limits_batches_consumed():
+    rng = np.random.default_rng(0)
+    consumed = []
+
+    def loader():
+        for _ in range(100):
+            batch = rng.standard_normal((2, 4)).astype(np.float32)
+            consumed.append(batch)
+            yield {"x": batch}
+
+    ppq_compat.quantize_onnx_model(
+        onnx_import_file=_matmul_model(),
+        calib_dataloader=loader(),
+        calib_steps=5,
+    )
+    assert len(consumed) == 5
+
+
+def test_unsupported_platform_raises():
+    with pytest.raises(NotImplementedError, match="ONNXRUNTIME"):
+        ppq_compat.quantize_onnx_model(
+            onnx_import_file=_matmul_model(),
+            calib_dataloader=[{"x": np.zeros((1, 4), dtype=np.float32)}],
+            calib_steps=1,
+            platform=999,
+        )
+
+
+def test_missing_calib_dataloader_raises_type_error():
+    with pytest.raises(TypeError, match="calib_dataloader"):
+        ppq_compat.quantize_onnx_model(onnx_import_file=_matmul_model())
+
+
+def test_do_quantize_false_returns_model_unchanged():
+    model = _matmul_model()
+    result = ppq_compat.quantize_onnx_model(onnx_import_file=model, do_quantize=False)
+    assert not _has_qdq(result)
+    assert result is model
+
+
+def test_setting_calib_algorithm_entropy_is_accepted():
+    rng = np.random.default_rng(0)
+    loader = [{"x": rng.standard_normal((2, 4)).astype(np.float32)} for _ in range(8)]
+    setting = ppq_compat.QuantizationSettingFactory.default_setting()
+    setting.calib_algorithm = "kl"
+
+    quantized = ppq_compat.quantize_onnx_model(
+        onnx_import_file=_matmul_model(),
+        calib_dataloader=loader,
+        calib_steps=8,
+        setting=setting,
+    )
+    onnx.checker.check_model(quantized)
+    assert _has_qdq(quantized)
+
+
+def test_export_ppq_graph_appends_onnx_extension(tmp_path):
+    model = _matmul_model()
+    out_prefix = str(tmp_path / "quantized")
+
+    ppq_compat.export_ppq_graph(
+        model, ppq_compat.TargetPlatform.ONNXRUNTIME, out_prefix
+    )
+
+    reloaded = onnx.load(out_prefix + ".onnx")
+    assert reloaded.graph.node[0].op_type == "MatMul"
+
+
+def test_export_ppq_graph_unsupported_platform_raises(tmp_path):
+    with pytest.raises(NotImplementedError, match="ONNXRUNTIME"):
+        ppq_compat.export_ppq_graph(_matmul_model(), 999, str(tmp_path / "out"))
+
+
+def test_target_platform_onnxruntime_matches_real_ppq_value():
+    """Confirmed from PPQ 0.6.6's own ppq/core/quant.py."""
+    assert int(ppq_compat.TargetPlatform.ONNXRUNTIME) == -7

--- a/tests/test_ppq_integration.py
+++ b/tests/test_ppq_integration.py
@@ -1,0 +1,65 @@
+"""Tests for onnxsim.ppq_integration.
+
+PPQ itself (``pip install ppq``) is confirmed, not speculatively, unusable
+in any environment with the modern ``onnx``/``protobuf`` versions onnxsim
+requires -- see onnxsim/ppq_integration.py's module docstring for the two
+independent import failures found by actually attempting the import in
+this repo's own dev environment. That makes ``PPQ_AVAILABLE`` false here,
+so these tests exercise the graceful-degradation contract (the same
+contract ``scripts/axera/pulsar2_quantizer.py`` follows for its own
+optional onnxruntime dependency) rather than PPQ's actual quantization
+path, which cannot be run in this environment.
+"""
+
+import numpy as np
+import onnx
+import pytest
+
+from onnxsim import ppq_integration
+
+
+def test_ppq_unavailable_in_this_environment():
+    """Documents the confirmed state of this dev environment: PPQ 0.6.6
+    cannot be imported alongside a current onnx/protobuf, so the bridge
+    reports itself unavailable rather than silently no-op'ing."""
+    assert ppq_integration.PPQ_AVAILABLE is False
+    reason = ppq_integration.unavailable_reason()
+    assert reason is not None
+    assert isinstance(reason, str) and reason
+
+
+def test_quantize_with_ppq_raises_clear_error_when_unavailable():
+    graph = onnx.helper.make_graph(
+        [onnx.helper.make_node("Identity", ["x"], ["y"])],
+        "g",
+        [onnx.helper.make_tensor_value_info("x", onnx.TensorProto.FLOAT, [1])],
+        [onnx.helper.make_tensor_value_info("y", onnx.TensorProto.FLOAT, [1])],
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 17)]
+    )
+
+    with pytest.raises(RuntimeError, match="PPQ unavailable"):
+        ppq_integration.quantize_with_ppq(
+            model, [{"x": np.zeros((1,), dtype=np.float32)}]
+        )
+
+
+def test_quantize_with_ppq_reports_unavailable_reason_in_error():
+    """The raised error should surface *why* PPQ is unusable (one of the
+    two confirmed import failures), not just that it is."""
+    graph = onnx.helper.make_graph(
+        [onnx.helper.make_node("Identity", ["x"], ["y"])],
+        "g",
+        [onnx.helper.make_tensor_value_info("x", onnx.TensorProto.FLOAT, [1])],
+        [onnx.helper.make_tensor_value_info("y", onnx.TensorProto.FLOAT, [1])],
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 17)]
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        ppq_integration.quantize_with_ppq(
+            model, [{"x": np.zeros((1,), dtype=np.float32)}]
+        )
+    assert ppq_integration.unavailable_reason() in str(exc_info.value)


### PR DESCRIPTION
## Summary
- `onnxsim.reconstruct_hf_graph()` builds a runnable ONNX graph directly from a HuggingFace checkpoint directory (`config.json` + safetensors, no GGUF conversion step), covering the llama/mistral/qwen2/qwen3 family. Qwen3's per-head QK-RMSNorm and its config-decoupled `head_dim` are confirmed against the real `transformers/models/qwen3/modeling_qwen3.py` source, and the whole thing is verified bit-exact against an independent numpy reference for synthetic checkpoints, plus a full end-to-end run (checker + onnxruntime) against the real `Qwen/Qwen3-0.6B` checkpoint.
- That real-checkpoint run surfaced two genuine bugs, both fixed here: a BF16/FLOAT32 dtype mismatch (fixed with a per-weight `Cast`-to-FLOAT32 graph node rather than upcasting the stored bytes), and — on the naive "upcast at rest" fix — a ~3GB serialized model tripping protobuf's ~2.1GB message-size limit.
- `onnxsim.quantize_with_ppq()` (in `onnxsim/ppq_integration.py`) bridges to real PPQ (OpenPPL's PyTorch PTQ framework) as an alternative to onnxsim's own `quantize_static()`, written directly against PPQ's real public API. **PPQ 0.6.6 (its latest PyPI release) is confirmed not importable** in any environment with the modern onnx/protobuf onnxsim itself requires (two independent failures: stale protoc-generated caffe parser code rejected by modern protobuf, and an `onnx.mapping` import removed from current onnx) — documented in the module docstring, and the bridge degrades gracefully (`PPQ_AVAILABLE`/`unavailable_reason()`), matching the convention `scripts/axera/pulsar2_quantizer.py` already uses for its own optional onnxruntime dependency.
- Since PPQ itself appears unmaintained and unusable today, `onnxsim.ppq_compat` (new) instead reproduces the small, commonly-used slice of PPQ's own public calling convention (`quantize_onnx_model`/`export_ppq_graph`/`TargetPlatform.ONNXRUNTIME`/`QuantizationSettingFactory.default_setting()`, names and parameters read from PPQ 0.6.6's own source) entirely on top of `onnxsim.quantize_static` — no PPQ install needed or possible. An existing PPQ-based calibration script can switch to it with a one-line import change. Scope is deliberately narrower than real PPQ (only the ONNXRUNTIME/QDQ target platform, no custom dispatch/mixed-precision settings), documented in its module docstring.

## Test plan
- [x] `tests/test_hf_reconstruct.py`: bit-exact vs. independent numpy reference across llama/mistral/qwen2 x MHA/GQA x tied/untied embeddings; Qwen3 QK-norm + head_dim-override correctness; BF16-weight Cast-insertion correctness; sharded (`index.json`) checkpoint loading; negative tests for unrecognized `model_type`, missing required tensor, and MoE config rejection.
- [x] `tests/test_ppq_integration.py`: graceful-degradation contract for the real-PPQ bridge (PPQ is confirmed unusable in this environment, so only that path is testable here).
- [x] `tests/test_ppq_compat.py`: full behavioral coverage of the PPQ-compatible shim (dict/raw-array/tuple calibration-batch conventions, `collate_fn`, `calib_steps` limiting, unsupported-platform errors, `do_quantize=False`, calibration-method mapping, `export_ppq_graph`'s extension handling) — no optional dependency needed, so this is fully exercised.
- [x] `ruff check` / `ruff format --check` clean on all changed files.
- [x] `python -m pytest tests/test_hf_reconstruct.py tests/test_ppq_integration.py tests/test_ppq_compat.py tests/test_gguf_reconstruct.py -q` — 53 passed, no regressions.
- [x] Manually verified `reconstruct_hf_graph` end-to-end against the real `Qwen/Qwen3-0.6B` checkpoint (checker + onnxruntime execution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)