### PR TITLE
Add JAX/Flax ONNX export integration tests + rewrite_bool_where pass

### DIFF
--- a/.github/workflows/backend-integration.yml
+++ b/.github/workflows/backend-integration.yml
@@ -397,11 +397,14 @@ jobs:
       # as `<5`: transformers 5.0 dropped its Flax model implementations
       # entirely, so the newest transformers with FlaxViTModel /
       # FlaxGPT2LMHeadModel still importable must be pinned explicitly here
-      # rather than left to just "transformers" resolving to latest.
-      - name: Install onnxsim wheel + jax2onnx + transformers (Flax models)
+      # rather than left to just "transformers" resolving to latest. gemma
+      # is Google DeepMind's own actively-maintained Flax NNX package
+      # (that test's model needs onnxsim's rewrite_bool_where pass to even
+      # load on ORT -- see tests/test_rewrite_bool_where.py).
+      - name: Install onnxsim wheel + jax2onnx + transformers (Flax models) + gemma
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest jax2onnx "transformers<5"
+          python -m pip install pytest jax2onnx "transformers<5" gemma
           python -m pip install wheelhouse/*.whl
       - name: Verify the installed wheel is used (not the source tree)
         working-directory: ${{ runner.temp }}
@@ -409,6 +412,7 @@ jobs:
           python -c "import onnxsim, onnxsim.onnxsim_cpp2py_export as m; print(onnxsim.__version__, m.__file__)"
           python -c "import jax, jax2onnx; print('jax', jax.__version__, 'jax2onnx', jax2onnx.__file__)"
           python -c "import transformers; print('transformers', transformers.__version__, transformers.FlaxViTModel)"
+          python -c "import gemma; print('gemma', gemma.__version__)"
       # Run from a neutral directory so the repo root's ./onnxsim source package
       # (without the compiled extension) does not shadow the installed wheel.
       - name: Run JAX export integration tests

--- a/.github/workflows/backend-integration.yml
+++ b/.github/workflows/backend-integration.yml
@@ -9,7 +9,8 @@ name: Backend Integration
 # tests/test_halide_integration.py, tests/test_tinygrad_integration.py,
 # tests/test_torch_integration.py, tests/test_mlx_integration.py,
 # tests/test_modelopt_integration.py, tests/test_mmdeploy_integration.py,
-# tests/test_jax_export_integration.py. See docs/dlpack-executor.md, which frames
+# tests/test_jax_export_integration.py, tests/test_jax_real_model_integration.py.
+# See docs/dlpack-executor.md, which frames
 # the DLPack executor boundary as an "embeddability" seam for stacks like these.
 # The xnnpack job below is the odd one out: it exercises
 # GetXnnpackModelExecutor() (onnxsim/xnnpack_executor_test.cpp) directly via a
@@ -49,6 +50,7 @@ on:
       - "tests/test_modelopt_integration.py"
       - "tests/test_mmdeploy_integration.py"
       - "tests/test_jax_export_integration.py"
+      - "tests/test_jax_real_model_integration.py"
       - ".github/workflows/backend-integration.yml"
       - "onnxsim/onnx_simplifier.py"
       - "onnxsim/onnxsim.cpp"
@@ -390,22 +392,30 @@ jobs:
           path: wheelhouse
       # jax2onnx pulls in jax, flax, onnxruntime, and its own onnx/onnx-ir
       # copies as ordinary dependencies -- no extra install step needed
-      # beyond it.
-      - name: Install onnxsim wheel + jax2onnx
+      # beyond it. transformers is only needed for
+      # test_jax_real_model_integration.py's real ViT/GPT-2 models, and only
+      # as `<5`: transformers 5.0 dropped its Flax model implementations
+      # entirely, so the newest transformers with FlaxViTModel /
+      # FlaxGPT2LMHeadModel still importable must be pinned explicitly here
+      # rather than left to just "transformers" resolving to latest.
+      - name: Install onnxsim wheel + jax2onnx + transformers (Flax models)
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest jax2onnx
+          python -m pip install pytest jax2onnx "transformers<5"
           python -m pip install wheelhouse/*.whl
       - name: Verify the installed wheel is used (not the source tree)
         working-directory: ${{ runner.temp }}
         run: |
           python -c "import onnxsim, onnxsim.onnxsim_cpp2py_export as m; print(onnxsim.__version__, m.__file__)"
           python -c "import jax, jax2onnx; print('jax', jax.__version__, 'jax2onnx', jax2onnx.__file__)"
+          python -c "import transformers; print('transformers', transformers.__version__, transformers.FlaxViTModel)"
       # Run from a neutral directory so the repo root's ./onnxsim source package
       # (without the compiled extension) does not shadow the installed wheel.
       - name: Run JAX export integration tests
         working-directory: ${{ runner.temp }}
-        run: pytest -v "$GITHUB_WORKSPACE/tests/test_jax_export_integration.py"
+        run: |
+          pytest -v "$GITHUB_WORKSPACE/tests/test_jax_export_integration.py"
+          pytest -v "$GITHUB_WORKSPACE/tests/test_jax_real_model_integration.py"
 
   xnnpack:
     name: XNNPACK ModelExecutor backend (native)

--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -59,6 +59,7 @@
 #include "passes/quantize_fp8.h"
 #include "passes/quarot.h"
 #include "passes/rewrite_arg_reduce_select_last_index.h"
+#include "passes/rewrite_bool_where.h"
 #include "passes/static_quantize_conv.h"
 #include "passes/static_quantize_int16_conv.h"
 #include "passes/static_quantize_int16_matmul.h"
@@ -150,6 +151,7 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::QuantizeFp8Pass>(registry);
     RegisterOrReplace<p::Quarot>(registry);
     RegisterOrReplace<p::RewriteArgReduceSelectLastIndex>(registry);
+    RegisterOrReplace<p::RewriteBoolWhere>(registry);
     RegisterOrReplace<p::StaticQuantizeConv>(registry);
     RegisterOrReplace<p::StaticQuantizeInt16Conv>(registry);
     RegisterOrReplace<p::StaticQuantizeInt16MatMul>(registry);

--- a/onnxsim/passes/rewrite_bool_where.h
+++ b/onnxsim/passes/rewrite_bool_where.h
@@ -1,0 +1,118 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+// Rewrites `Where(cond, x, y)` when its two *data* operands (`x`/`y` -- not
+// `cond`, which the ONNX spec always types `bool`) are themselves bool
+// tensors, into an equivalent computation that never runs `Where` on `bool`
+// data:
+//
+//   Where(cond, x, y)   -- x, y: bool
+//     == Cast<to=BOOL>(Where(cond, Cast<to=INT32>(x), Cast<to=INT32>(y)))
+//
+// `bool` is a legal type for `Where`'s `T` (data operand) type constraint
+// per the ONNX operator spec -- opset 9 and the current opset 16 both list
+// it -- but ONNX Runtime's CPU execution provider only registers a `Where`
+// kernel for `string`/`float`/`double`/`int32`/`int64`/`uint8`
+// (onnxruntime/core/providers/cpu/cpu_execution_provider.cc); `bool` (along
+// with float16/bfloat16/int8/int16/uint16/uint32/uint64/complex64/
+// complex128) has no CPU kernel at all, so a graph with a bool-operand
+// `Where` fails to *load* on ORT's CPU EP with "NOT_IMPLEMENTED ... Could
+// not find an implementation for Where". `int32` does have a kernel, and a
+// bool<->int32 `Cast` is a trivial, universally-supported 0/1
+// reinterpretation, so routing the select through `int32` and casting the
+// result back is enough to dodge the gap without changing what the graph
+// computes: this is portability, not optimization, exactly like
+// RewriteArgReduceSelectLastIndex before it.
+//
+// A bool-operand `Where` shows up in practice combining two boolean masks
+// (e.g. a causal-attention mask built from more than one condition) ahead of
+// a later cast to a float bias -- a pattern XLA's own `Select` op has no
+// trouble with, so it is invisible in JAX itself and only surfaces once
+// lowered to ONNX (observed from jax2onnx's export of Flax/Gemma-style
+// attention masking).
+struct RewriteBoolWhere final : public PredicateBasedPass {
+  explicit RewriteBoolWhere()
+      : PredicateBasedPass(PassType::Nop, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+
+  std::string getPassName() const override { return "rewrite_bool_where"; }
+
+  bool patternMatchPredicate(Node* node) override {
+    if (node->kind() != Symbol("Where") || node->inputs().size() != 3) {
+      return false;
+    }
+    Value* x = node->input(1);
+    Value* y = node->input(2);
+    return x->elemType() == TensorProto_DataType_BOOL &&
+           y->elemType() == TensorProto_DataType_BOOL;
+  }
+
+  bool runTransform(Node* node, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    Value* cond = node->input(0);
+    Value* x = node->input(1);
+    Value* y = node->input(2);
+
+    auto cast_to = [&](Value* v, TensorProto_DataType to) -> Value* {
+      Node* cast = graph.create(kCast, 1);
+      cast->i_(kto, static_cast<int64_t>(to));
+      cast->addInput(v);
+      cast->insertBefore(node);
+      cast->output()->setElemType(to);
+      if (!v->sizes().empty()) {
+        cast->output()->setSizes(v->sizes());
+      }
+      return cast->output();
+    };
+
+    Value* x_i32 = cast_to(x, TensorProto_DataType_INT32);
+    Value* y_i32 = cast_to(y, TensorProto_DataType_INT32);
+
+    Node* where_i32 = graph.create(Symbol("Where"), 1);
+    where_i32->addInput(cond);
+    where_i32->addInput(x_i32);
+    where_i32->addInput(y_i32);
+    where_i32->insertBefore(node);
+    where_i32->output()->setElemType(TensorProto_DataType_INT32);
+    if (!node->output()->sizes().empty()) {
+      where_i32->output()->setSizes(node->output()->sizes());
+    }
+
+    Node* cast_back = graph.create(kCast, 1);
+    cast_back->i_(kto, static_cast<int64_t>(TensorProto_DataType_BOOL));
+    cast_back->addInput(where_i32->output());
+    cast_back->insertBefore(node);
+    cast_back->output()->setElemType(TensorProto_DataType_BOOL);
+    if (!node->output()->sizes().empty()) {
+      cast_back->output()->setSizes(node->output()->sizes());
+    }
+
+    const bool replacing_success =
+        tryReplacingAllUsesWith(node->output(), cast_back->output());
+    if (!replacing_success) {
+      return false;
+    }
+    destroy_current = NodeDestroyType::DestroyOne;
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/tests/test_jax_real_model_integration.py
+++ b/tests/test_jax_real_model_integration.py
@@ -35,6 +35,16 @@ ONNX Runtime rejects at load time. That is a jax2onnx/transformers
 interaction issue, not something onnxsim can be expected to compensate for,
 so it is left out here rather than adding a test pinned to a known-broken
 upstream lowering.
+
+A third model, ``test_jax_export_gemma_dummy_model`` below, covers Google
+DeepMind's own actively-maintained ``gemma`` package (PyPI) -- RoPE,
+grouped-query attention, and RMSNorm, none of which the two transformers
+models above exercise. It needed onnxsim's own
+``rewrite_bool_where`` pass (onnxsim/passes/rewrite_bool_where.h) to become
+loadable on ONNX Runtime at all: Gemma's attention-mask construction
+combines two boolean masks via a jax `where` whose *data* operands are
+themselves bool, which ORT's CPU execution provider has no kernel for --
+see that pass's doc comment.
 """
 
 import numpy as np
@@ -124,4 +134,54 @@ def test_jax_export_gpt2_causal_lm():
     orig_out = _run(onnx_model, {input_name: input_ids})[output_name]
     sim_out = _run(sim_model, {input_name: input_ids})[output_name]
     np.testing.assert_allclose(orig_out, expected, rtol=1e-3, atol=1e-4)
+    np.testing.assert_allclose(sim_out, expected, rtol=1e-3, atol=1e-4)
+
+
+def test_jax_export_gemma_dummy_model():
+    gm = pytest.importorskip("gemma.gm")
+
+    # gm.testing.DummyGemma is the Gemma package's own tiny (1-layer,
+    # embed_dim=32) architecture instance built specifically for tests like
+    # this one -- the same "real model class, tiny/random config, no
+    # checkpoint download" shape as the two transformers models above.
+    model = gm.testing.DummyGemma()
+    params = model.init(
+        jax.random.PRNGKey(0), tokens=jnp.zeros((1, 8), dtype=jnp.int32)
+    )
+    # Gemma's default param dtype is bfloat16 (the shipped-checkpoint dtype);
+    # ONNX Runtime's CPU EP has no kernel for a bfloat16 Einsum operand
+    # (separately from the bool-Where issue this test also exercises), so
+    # cast to float32 -- a real CPU deployment would need to do the same.
+    params = jax.tree_util.tree_map(lambda x: x.astype(jnp.float32), params)
+
+    def f(tokens):
+        return model.apply(params, tokens=tokens).logits
+
+    tokens = np.random.RandomState(0).randint(0, 13, size=(1, 8)).astype(np.int32)
+    # Computed *before* to_onnx: jax2onnx monkey-patches jax.numpy primitives
+    # (including jnp.sqrt, which Gemma's embedder calls directly) globally
+    # while tracing, and does not restore them, so calling `f` again after
+    # exporting raises inside jax2onnx's own patched primitive instead of
+    # running plain JAX.
+    expected = np.asarray(f(jnp.asarray(tokens)))
+    onnx_model = to_onnx(f, [jnp.asarray(tokens)])
+
+    # Anchor for why this needs onnxsim's rewrite_bool_where pass: the
+    # original export combines two boolean attention-mask tensors through a
+    # bool-operand Where, which ORT's CPU EP cannot even load.
+    assert "Where" in [n.op_type for n in onnx_model.graph.node]
+    with pytest.raises(Exception, match="Where"):
+        _run(onnx_model, {onnx_model.graph.input[0].name: tokens})
+
+    # check_n=0: see the analogous note in test_rewrite_bool_where.py --
+    # onnxsim's own correctness check would run the *original* model through
+    # the same (onnxruntime) backend, hitting the exact load failure just
+    # confirmed above.
+    sim_model, check_ok = onnxsim.simplify(onnx_model, check_n=0)
+    assert check_ok
+    onnx.checker.check_model(sim_model)
+
+    input_name = onnx_model.graph.input[0].name
+    output_name = onnx_model.graph.output[0].name
+    sim_out = _run(sim_model, {input_name: tokens})[output_name]
     np.testing.assert_allclose(sim_out, expected, rtol=1e-3, atol=1e-4)

--- a/tests/test_jax_real_model_integration.py
+++ b/tests/test_jax_real_model_integration.py
@@ -1,0 +1,127 @@
+"""Real-model counterpart to tests/test_jax_export_integration.py: exports two
+actual Hugging Face Transformers *Flax* model implementations -- a Vision
+Transformer (`FlaxViTModel`) and a GPT-2 causal decoder (`FlaxGPT2LMHeadModel`)
+-- via jax2onnx, then feeds the result through onnxsim.simplify(). Where that
+other file exercises small, hand-written functions/modules targeting specific
+lowering patterns, this one exercises complete, real transformer
+architectures: patch embedding, multi-head self-attention (bidirectional for
+ViT, causal for GPT-2), GELU-activated MLP blocks, and LayerNormalization,
+all wired together the way transformers' own modeling code wires them --
+matching the "build a small instance of the real model class with random
+weights, no checkpoint download" convention used by e.g.
+tests/test_rfdetr.py.
+
+Both models use a tiny/random-weight config (2 layers, small hidden size),
+so this stays fast and fully offline while exercising the same graph shapes
+production configs produce.
+
+Hugging Face Transformers removed its Flax (and TensorFlow) model
+implementations entirely as of transformers 5.0 -- ``FlaxViTModel`` and
+``FlaxGPT2LMHeadModel`` no longer exist on that or later versions. This
+module therefore needs ``transformers < 5`` specifically (not just
+"transformers"), on top of jax2onnx's own dependencies, so it skips cleanly
+whenever the installed transformers is too new (or missing) rather than
+failing on an AttributeError. To run locally::
+
+    pip install jax2onnx "transformers<5"
+    pip install --force-reinstall --no-deps .   # the onnxsim under test
+    pytest tests/test_jax_real_model_integration.py -v
+
+A note on why this doesn't also cover FlaxBertModel: as of transformers
+4.49.0, exporting it through jax2onnx 0.16.1 hits a jax2onnx bug -- one of
+the attention block's internal broadcast tensors is lowered to an ONNX
+Einsum input typed int32 against a float32 softmax-output operand, which
+ONNX Runtime rejects at load time. That is a jax2onnx/transformers
+interaction issue, not something onnxsim can be expected to compensate for,
+so it is left out here rather than adding a test pinned to a known-broken
+upstream lowering.
+"""
+
+import numpy as np
+import onnx
+import pytest
+
+import onnxsim
+
+jax = pytest.importorskip("jax")
+jnp = pytest.importorskip("jax.numpy")
+jax2onnx = pytest.importorskip("jax2onnx")
+onnxruntime = pytest.importorskip("onnxruntime")
+transformers = pytest.importorskip("transformers")
+
+FlaxViTModel = getattr(transformers, "FlaxViTModel", None)
+FlaxGPT2LMHeadModel = getattr(transformers, "FlaxGPT2LMHeadModel", None)
+if FlaxViTModel is None or FlaxGPT2LMHeadModel is None:
+    pytest.skip(
+        "transformers >= 5 dropped its Flax model implementations "
+        "(FlaxViTModel/FlaxGPT2LMHeadModel); install transformers < 5 to "
+        "run this module",
+        allow_module_level=True,
+    )
+
+to_onnx = jax2onnx.to_onnx
+
+
+def _simplify(model):
+    sim_model, check_ok = onnxsim.simplify(model, check_n=3)
+    assert check_ok
+    onnx.checker.check_model(sim_model)
+    return sim_model
+
+
+def _run(model, feeds):
+    sess = onnxruntime.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    out_names = [o.name for o in sess.get_outputs()]
+    return dict(zip(out_names, sess.run(out_names, feeds)))
+
+
+def test_jax_export_vit_model():
+    config = transformers.ViTConfig(
+        image_size=32,
+        patch_size=8,
+        num_channels=3,
+        hidden_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        intermediate_size=37,
+    )
+    model = FlaxViTModel(config, seed=0)
+
+    def f(pixel_values):
+        return model(pixel_values=pixel_values).last_hidden_state
+
+    x = np.random.RandomState(0).randn(2, 3, 32, 32).astype(np.float32)
+    onnx_model = to_onnx(f, [jnp.asarray(x)])
+    sim_model = _simplify(onnx_model)
+
+    input_name = onnx_model.graph.input[0].name
+    output_name = onnx_model.graph.output[0].name
+    expected = np.asarray(f(jnp.asarray(x)))
+    orig_out = _run(onnx_model, {input_name: x})[output_name]
+    sim_out = _run(sim_model, {input_name: x})[output_name]
+    np.testing.assert_allclose(orig_out, expected, rtol=1e-3, atol=1e-4)
+    np.testing.assert_allclose(sim_out, expected, rtol=1e-3, atol=1e-4)
+
+
+def test_jax_export_gpt2_causal_lm():
+    config = transformers.GPT2Config(
+        vocab_size=99, n_positions=64, n_embd=32, n_layer=2, n_head=4
+    )
+    model = FlaxGPT2LMHeadModel(config, seed=0)
+
+    def f(input_ids):
+        return model(input_ids=input_ids).logits
+
+    input_ids = np.random.RandomState(1).randint(0, 99, size=(2, 8)).astype(np.int32)
+    onnx_model = to_onnx(f, [jnp.asarray(input_ids)])
+    sim_model = _simplify(onnx_model)
+
+    input_name = onnx_model.graph.input[0].name
+    output_name = onnx_model.graph.output[0].name
+    expected = np.asarray(f(jnp.asarray(input_ids)))
+    orig_out = _run(onnx_model, {input_name: input_ids})[output_name]
+    sim_out = _run(sim_model, {input_name: input_ids})[output_name]
+    np.testing.assert_allclose(orig_out, expected, rtol=1e-3, atol=1e-4)
+    np.testing.assert_allclose(sim_out, expected, rtol=1e-3, atol=1e-4)

--- a/tests/test_rewrite_bool_where.py
+++ b/tests/test_rewrite_bool_where.py
@@ -1,0 +1,138 @@
+"""Tests for the ``rewrite_bool_where`` C++ pass
+(onnxsim/passes/rewrite_bool_where.h).
+
+ONNX's operator spec allows a ``Where`` node's two *data* operands (``x``/
+``y`` -- not ``cond``, which the spec always types ``bool``) to themselves be
+``bool`` tensors. ONNX Runtime's CPU execution provider, however, only
+registers a ``Where`` kernel for
+``string``/``float``/``double``/``int32``/``int64``/``uint8`` -- confirmed
+straight from ``onnxruntime/core/providers/cpu/cpu_execution_provider.cc`` --
+so a spec-legal, ``onnx.checker``-clean model with a bool-operand ``Where``
+fails to even *load* on ORT's CPU EP with "NOT_IMPLEMENTED ... Could not find
+an implementation for Where". onnxsim rewrites such a node into
+``Cast<to=BOOL>(Where(cond, Cast<to=INT32>(x), Cast<to=INT32>(y)))``, which
+computes the same result through a type ORT's CPU EP does support.
+
+This surfaces in practice via jax2onnx's export of JAX/Flax attention-mask
+code that combines two boolean masks with a ``jnp.where`` ahead of a later
+cast to a float bias (see tests/test_jax_real_model_integration.py's comment
+on why FlaxBertModel/Gemma aren't covered there yet).
+"""
+
+import numpy as np
+import onnx
+import pytest
+from onnx import parser
+
+import onnxsim
+
+# A bare ``import onnxruntime`` would fail collection (not skip the test) on
+# platforms onnxruntime doesn't ship wheels for (e.g. s390x).
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(body, initializer=(), opset=13, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _ort_session(model):
+    return ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+
+
+def test_bool_where_fails_to_load_on_ort_before_the_rewrite():
+    # Anchor for the bug this pass works around: a spec-legal, checker-clean
+    # bool-operand Where is rejected by ORT's CPU EP at session-creation time,
+    # not merely slow or numerically off.
+    model = _model(
+        """
+        g (bool[4] cond, bool[4] x, bool[4] y) => (bool[4] z)
+        {
+          z = Where(cond, x, y)
+        }
+        """
+    )
+    onnx.checker.check_model(model)
+    with pytest.raises(Exception, match="Where"):
+        _ort_session(model)
+
+
+def test_bool_where_operands_rewritten_for_ort():
+    model = _model(
+        """
+        g (bool[4] cond, bool[4] x, bool[4] y) => (bool[4] z)
+        {
+          z = Where(cond, x, y)
+        }
+        """
+    )
+    onnx.checker.check_model(model)
+
+    # check_n=0: onnxsim's own correctness check runs the *original* model
+    # through the same (onnxruntime) backend for comparison, which would hit
+    # the exact same load failure this pass exists to route around -- that
+    # limitation is orthogonal to this pass, which only needs to fix the
+    # *simplified* output. Numeric correctness is instead checked directly
+    # below, against plain numpy.
+    sim_model, check_ok = onnxsim.simplify(model, check_n=0)
+    assert check_ok
+    onnx.checker.check_model(sim_model)
+
+    # No Where node should still have bool data operands: either the node is
+    # gone (fully constant-folded, not expected here since cond/x/y are graph
+    # inputs) or it now reads/writes int32 around Cast<BOOL> nodes.
+    value_types = {
+        vi.name: vi.type.tensor_type.elem_type
+        for vi in list(sim_model.graph.input)
+        + list(sim_model.graph.value_info)
+        + list(sim_model.graph.output)
+    }
+    for node in sim_model.graph.node:
+        if node.op_type != "Where":
+            continue
+        for data_input in node.input[1:]:
+            assert value_types.get(data_input) != onnx.TensorProto.BOOL
+
+    sess = _ort_session(sim_model)
+    cond = np.array([True, False, True, False])
+    x = np.array([True, True, False, False])
+    y = np.array([False, False, True, True])
+    (out,) = sess.run(None, {"cond": cond, "x": x, "y": y})
+    np.testing.assert_array_equal(out, np.where(cond, x, y))
+
+
+def test_bool_where_broadcasting_preserved():
+    # cond/x/y have different (numpy-broadcastable) shapes; the rewrite must
+    # not disturb Where's own broadcasting -- only the two data operands'
+    # dtype changes, never their shape.
+    model = _model(
+        """
+        g (bool[1,4] cond, bool[4] x, bool[3,1] y) => (bool[3,4] z)
+        {
+          z = Where(cond, x, y)
+        }
+        """
+    )
+    onnx.checker.check_model(model)
+
+    sim_model, check_ok = onnxsim.simplify(model, check_n=0)
+    assert check_ok
+    onnx.checker.check_model(sim_model)
+
+    sess = _ort_session(sim_model)
+    cond = np.array([[True, False, True, False]])
+    x = np.array([True, True, False, False])
+    y = np.array([[True], [False], [True]])
+    (out,) = sess.run(None, {"cond": cond, "x": x, "y": y})
+    np.testing.assert_array_equal(out, np.where(cond, x, y))


### PR DESCRIPTION
## Summary

Adds integration tests exporting ONNX models from JAX/Flax via the third-party [jax2onnx](https://github.com/enpasos/jax2onnx) converter and simplifying them with `onnxsim.simplify()` — JAX has no first-party ONNX exporter — plus a new onnxsim optimizer pass discovered and fixed along the way.

## Key changes

**`tests/test_jax_export_integration.py`** — synthetic op-pattern tests: a plain `jax.numpy` function, a Flax NNX `Conv+BatchNorm+Relu` module (checks `fuse_bn_into_conv` fires through jax2onnx's NHWC↔NCHW layout `Transpose`s), a symbolic-batch-dimension reshape chain, and `jax.lax.cond` → ONNX `If`.

**`tests/test_jax_real_model_integration.py`** — real model architectures, tiny/random-weight configs, no checkpoint download (matching `tests/test_rfdetr.py`'s convention):
- `FlaxViTModel` (Vision Transformer)
- `FlaxGPT2LMHeadModel` (causal decoder)
- Google DeepMind's `gemma` package (`gm.testing.DummyGemma`) — RoPE, grouped-query attention, RMSNorm

**`onnxsim/passes/rewrite_bool_where.h`** (new pass, registered in `custom_optimizer_passes.{h,cpp}`) — Gemma's attention-mask construction lowers to a `Where` node whose data operands are themselves `bool`, which is spec-legal ONNX but has no CPU kernel in ONNX Runtime (confirmed from `onnxruntime/core/providers/cpu/cpu_execution_provider.cc` — `Where` is only registered for `string`/`float`/`double`/`int32`/`int64`/`uint8`), so the model fails to even *load* on ORT's CPU EP. The pass rewrites it to `Cast<BOOL>(Where(cond, Cast<INT32>(x), Cast<INT32>(y)))`, modeled on the existing `rewrite_arg_reduce_select_last_index` pass (same `PredicateBasedPass`/`PassType::Nop` shape, auto-included by default). `tests/test_rewrite_bool_where.py` reproduces the original ORT load failure directly, then verifies the fix, including under broadcasting.

**`.github/workflows/backend-integration.yml`** — new `jax` job installing `jax2onnx`, `transformers<5` (transformers 5.0 dropped its Flax model code), and `gemma`, running all three new test files.

## Verification

Initialized the git submodules and built the real C++ extension in this sandbox (previously not checked out) rather than shipping the new pass unverified:
- `rewrite_bool_where` compiles cleanly and fires correctly.
- All 10 new JAX integration tests pass, including the Gemma one (which explicitly demonstrates the bug and the fix: original export still has the `bool`-`Where`, ORT session creation raises; simplified model loads and matches JAX's own output numerically).
- Ran a broader slice of the existing suite for regressions: 901 passed, 2 pre-existing failures unrelated to this change (missing `onnxscript` dependency for `dynamo=True` torch export tests).

## Test plan

- [x] `rewrite_bool_where` pass compiles and is registered
- [x] `tests/test_rewrite_bool_where.py` passes (3 tests, including a broadcasting case)
- [x] `tests/test_jax_export_integration.py` passes (4 tests)
- [x] `tests/test_jax_real_model_integration.py` passes (3 tests: ViT, GPT-2, Gemma)
- [x] Existing suite has no new regressions (`test_simple.py`, `test_qoperator_quantize_where.py`, `test_fuse_attention.py`, `test_model_checking.py`, `test_pruning.py`)
- [ ] CI (`jax` job in `backend-integration.yml`) builds the wheel and runs these for real

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zcBW9jMr7Whe2ex5s8BXH

---
_Generated by [Claude Code](https://claude.ai/code/session_011zcBW9jMr7Whe2ex5s8BXH)_