### PR TITLE
Fix big-endian TensorProto conversion in hf_reconstruct's safetensors reader

### DIFF
--- a/onnxsim/hf_reconstruct.py
+++ b/onnxsim/hf_reconstruct.py
@@ -207,6 +207,20 @@ def _read_tensor(entry: _SafetensorsEntry, name: str) -> onnx.TensorProto:
         )
     onnx_dtype, np_dtype = _SAFETENSORS_DTYPE_TO_ONNX[entry.dtype]
     arr = np.frombuffer(raw, dtype=np_dtype).reshape(entry.shape)
+    # safetensors is always little-endian on disk, so np_dtype above is
+    # explicitly "<..." regardless of host order -- correct for *decoding*
+    # `raw` (frombuffer reinterprets those bytes as little-endian
+    # regardless of host order), but on a big-endian host the resulting
+    # array's own dtype object stays tagged "<..." too, and
+    # onnx.numpy_helper.from_array's dtype->TensorProto lookup only
+    # recognizes a *native*-order dtype (np.dtype("f4") is "<f4" on a
+    # little-endian host, so this was never visible there) -- confirmed via
+    # this module's own big-endian CI. astype() to the platform's native
+    # byte order both fixes that lookup and -- unlike a bare view/reinterpret
+    # -- correctly byte-swaps the underlying bytes so the decoded values
+    # themselves are unchanged (a single-byte dtype like I8/U8/BOOL has no
+    # byte order to normalize, so this is a harmless no-op copy for those).
+    arr = arr.astype(arr.dtype.newbyteorder("="))
     return onnx.numpy_helper.from_array(arr, name=name)
 
 


### PR DESCRIPTION
## Summary

`onnxsim/hf_reconstruct.py`'s `_SAFETENSORS_DTYPE_TO_ONNX` maps safetensors dtypes to explicitly little-endian numpy dtypes (`"<f4"` etc.) — correct for `np.frombuffer` to decode safetensors' own always-little-endian on-disk bytes regardless of host byte order. But the resulting array keeps that explicit `"<..."` dtype tag, and `onnx.numpy_helper.from_array`'s dtype→`TensorProto` lookup only recognizes a *native*-order dtype. On a little-endian host `"<..."` already *is* native, so this was invisible there; on a big-endian host it's a hard `ValueError: Unable to convert type dtype('<f4') into TensorProto element type.`

Fixed by `astype()`-ing to the platform's native byte order right after decoding — this both fixes the lookup and correctly byte-swaps the underlying bytes, so decoded values are unchanged on either host.

Found via [PR #1059](https://github.com/onnxsim/onnxsim/pull/1059)'s own big-endian CI run (triggered by an unrelated change touching `onnxsim.h`, tested against current `master`) — not a regression in that PR's own diff, which doesn't touch this file at all.

## Testing

- Reproduced the exact reported error locally by manually tagging a float32 array with the opposite-of-native byte order and confirming `onnx.numpy_helper.from_array` raises the identical `ValueError`; confirmed the fix resolves it while round-tripping to identical values.
- `python3 -m pytest tests/test_hf_reconstruct.py -q` — 19 passed (unaffected on this little-endian host, where the fix is a no-op, as expected).
- `ruff format --check` / `ruff check` / `mypy` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4t6ntCm72RfFf64W9GYB1

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4t6ntCm72RfFf64W9GYB1)_