### PR TITLE
Add D2Quant: Dual-Scale Quantizer and Deviation-Aware Correction

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -35,6 +35,7 @@ from onnxsim.calibration import (
     quantize_static_int16,
 )
 from onnxsim.coreml_export import export_coreml
+from onnxsim.d2quant import apply_dac, apply_dsq
 from onnxsim.double_quantization import apply_double_quantization
 from onnxsim.duquant import apply_duquant
 from onnxsim.embedding_quantization import (
@@ -192,6 +193,8 @@ __all__ = [
     "apply_rptq_reorder",
     "apply_outlier_suppression_plus",
     "apply_outlier_suppression",
+    "apply_dsq",
+    "apply_dac",
     "apply_llm_int8",
     "apply_low_rank_compensation",
     "apply_mixed_precision_quantization",

--- a/onnxsim/d2quant.py
+++ b/onnxsim/d2quant.py
@@ -1,0 +1,548 @@
+r"""D2Quant (Yan, Bao, Li, Zhang, Zhang, Xie, Sun and Zhang, 2026, "D2Quant:
+Accurate Low-bit Post-Training Weight Quantization for LLMs",
+https://arxiv.org/abs/2602.02546, code at
+https://github.com/XIANGLONGYAN/D2Quant). A weight-only PTQ framework built
+around two independent techniques, both ported here:
+
+* **Dual-Scale Quantizer (DSQ)** (:func:`apply_dsq`) -- a weight-side fix
+  targeted specifically at down-projection matrices (the second Linear in a
+  SwiGLU/GLU-style MLP block, i.e. the one whose *input* is an elementwise-
+  gated activation). That gated activation has an unusually heavy-tailed
+  distribution, which is well documented as a quantization bottleneck for
+  the down-projection weight that consumes it -- a single group-wide scale
+  ends up stretched to cover a handful of outlier-aligned columns, blurring
+  every other column's precision.
+* **Deviation-Aware Correction (DAC)** (:func:`apply_dac`) -- an
+  activation-side fix: weight quantization shifts a layer's own output
+  *mean*, and this shift is measurably more pronounced and more consistently
+  directional (in the paper's own terms, higher "SNR") right after the
+  attention block than elsewhere. DAC estimates that per-channel mean shift
+  from calibration data and folds it directly into the bias of the
+  LayerNormalization that comes right after the shift was introduced.
+
+Both techniques share the same "absorbable"/zero-extra-node philosophy this
+repo's own :mod:`onnxsim.bias_correction` and :mod:`onnxsim.outlier_suppression`
+already use -- see each function's own docstring for exactly how.
+
+**Scope.** This ports the paper's two per-technique *mechanisms* faithfully,
+not its Algorithm 1 end-to-end block-wise pipeline (which interleaves DSQ,
+DAC, and attention/FFN quantization block-by-block, re-deriving calibration
+activations after each block is quantized so later blocks see the same drift
+inference will). Both :func:`apply_dsq` and :func:`apply_dac` are meant to
+compose with any of onnxsim's other own weight quantizers instead:
+
+1. Run :func:`apply_dsq` on the float model -- it quantizes every matched
+   down-projection directly (to the same INT4 block format
+   :func:`onnxsim.quantize_weight_only_int4` produces) and rescales its
+   paired up-projection's raw float weight in place, absorbing DSQ's own
+   auxiliary scale with zero new nodes.
+2. Quantize everything else (gate/up-projections, attention projections,
+   ...) with any onnxsim weight-only quantizer, e.g.
+   :func:`onnxsim.quantize_weight_only_int4` -- since step 1 already
+   rescaled the up-projection's raw values, that quantizer's own ordinary
+   per-channel scale absorbs DSQ's contribution automatically.
+3. Run :func:`apply_dac` (comparing the original float model against the
+   now-fully-quantized model from steps 1-2) to fold each LayerNormalization's
+   measured mean-shift deviation into its own bias.
+
+Also deliberately not ported: the paper's own equivalent up/down scaling
+derivation is presented as an exact closed-form alternating optimization
+against real (GPTQ-style) block-wise quantization error over 15 iterations
+against a specific baseline quantizer; :func:`apply_dsq` solves the same
+per-column-scale objective (``min_s ||W - Q(W / s) * s||`` over a plain
+per-channel-block symmetric quantizer, alternating between re-quantizing and
+a closed-form least-squares scale update) rather than reproducing that
+baseline's own exact solver line-for-line -- the same "faithful to the
+objective, not a specific reference implementation" stance
+:mod:`onnxsim.hqq` already takes for its own IRLS solver.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Sequence, Tuple, Union
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+
+from onnxsim import backend
+from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.calibration import Tensors, generate_random_calibration_data
+from onnxsim.smoothquant import _match_matmul_like
+
+_INT4 = onnx.TensorProto.INT4
+
+
+# ---------------------------------------------------------------------------
+# Dual-Scale Quantizer (DSQ)
+# ---------------------------------------------------------------------------
+
+
+def _quantize_int4_blockwise_symmetric(
+    w_nk: np.ndarray, block_size: int
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Ordinary symmetric INT4 block quantization -- one absmax-derived
+    scale per (output row, ``block_size``-wide slice of the reduction
+    dimension), matching :func:`onnxsim.quantize_weight_only_int4`'s own
+    scheme (codes in ``[-7, 7]``). Returns ``(codes_nk, scale_nb)``.
+    """
+    n, k = w_nk.shape
+    num_blocks = k // block_size
+    blocks = w_nk.reshape(n, num_blocks, block_size)
+    amax = np.max(np.abs(blocks), axis=2)
+    scale = np.maximum(amax / 7.0, 1e-12)
+    scale3 = scale[:, :, np.newaxis]
+    codes = np.clip(np.round(blocks / scale3), -7, 7)
+    return codes.reshape(n, k), scale
+
+
+def _dequantize_int4_blockwise_symmetric(
+    codes_nk: np.ndarray, scale_nb: np.ndarray, block_size: int
+) -> np.ndarray:
+    n, k = codes_nk.shape
+    num_blocks = k // block_size
+    codes3 = codes_nk.reshape(n, num_blocks, block_size)
+    scale3 = scale_nb[:, :, np.newaxis]
+    return (codes3 * scale3).reshape(n, k)
+
+
+def _dsq_optimize(
+    w_nk: np.ndarray, block_size: int, num_iterations: int
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Solves ``min_s ||W - Q(W / s) * s||_F^2`` for a per-column scale
+    ``s`` (one scalar per reduction-dimension column, shared by every output
+    row/block) by alternating: (a) freeze ``s``, re-quantize ``W / s`` with
+    the ordinary block quantizer above; (b) freeze the resulting integer
+    codes' dequantized values, re-solve ``s`` in closed form (per-column
+    weighted least squares: ``s[h] = sum_row(W[:,h] * dequant[:,h]) /
+    sum_row(dequant[:,h] ** 2)``). Returns ``(s, codes_nk, scale_nb)`` for
+    the ``W / s`` quantization from the final iteration.
+    """
+    k = w_nk.shape[1]
+    s_c = np.ones(k, dtype=np.float64)
+    codes = np.zeros_like(w_nk)
+    scale_blocks = np.zeros((w_nk.shape[0], k // block_size), dtype=np.float64)
+    for _ in range(max(num_iterations, 0)):
+        w_norm = w_nk / s_c[np.newaxis, :]
+        codes, scale_blocks = _quantize_int4_blockwise_symmetric(w_norm, block_size)
+        dequant_norm = _dequantize_int4_blockwise_symmetric(
+            codes, scale_blocks, block_size
+        )
+        num = np.sum(w_nk * dequant_norm, axis=0)
+        den = np.sum(dequant_norm * dequant_norm, axis=0)
+        s_c = np.where(den > 1e-20, num / den, s_c)
+    w_norm = w_nk / s_c[np.newaxis, :]
+    codes, scale_blocks = _quantize_int4_blockwise_symmetric(w_norm, block_size)
+    return s_c, codes, scale_blocks
+
+
+def _pack_int4_signed(codes: np.ndarray) -> bytes:
+    # Two's-complement nibble packing, low-nibble-first (ONNX's documented
+    # INT4 raw_data layout) -- same masking trick as
+    # onnxsim.hqq._pack_uint4, but the values here are already signed
+    # (numpy's bitwise AND on a signed dtype operates on its two's-complement
+    # bit pattern, so `& 0xF` recovers the correct nibble either way).
+    flat = codes.astype(np.int64).ravel()
+    nibbles = (flat & 0xF).astype(np.uint8)
+    lo = nibbles[0::2]
+    hi = nibbles[1::2]
+    packed = (lo | (hi << 4)).astype(np.uint8)
+    return packed.tobytes()
+
+
+def apply_dsq(
+    model: Union[str, onnx.ModelProto],
+    block_size: int = 32,
+    num_iterations: int = 15,
+) -> onnx.ModelProto:
+    """Applies the Dual-Scale Quantizer to every matched down-projection in
+    a SwiGLU/GLU-style MLP block -- see this module's own docstring for the
+    technique and :func:`onnxsim.apply_dsq`'s companion :func:`apply_dac`.
+
+    A "matched" block is a plain MatMul/vanilla-Gemm node (the down-proj)
+    whose activation input is produced by an elementwise ``Mul`` with
+    exactly two operands, one of which is *directly* (with no intervening
+    op) the output of another plain MatMul/vanilla-Gemm node (the up-proj)
+    -- the shape every SwiGLU MLP (``down(silu(gate(x)) * up(x))``) and
+    plain bilinear GLU takes, regardless of which operand carries the
+    nonlinearity (only the *unactivated* operand's producer can be safely
+    rescaled, since scaling before a nonlinearity does not commute with it).
+    Both the up-proj's own output and the gated (down-proj input) tensor
+    must have exactly one consumer and must not themselves be graph outputs
+    -- exactly the conservative "only fully-owned consumers get touched"
+    stance :mod:`onnxsim.outlier_suppression`'s own Gamma Migration takes,
+    for the same reason (an external/other consumer would silently observe
+    a rescaled value it never asked for).
+
+    The auxiliary per-column scale DSQ derives for the down-projection is
+    "absorbable": instead of inserting a node to multiply the down-proj's
+    dequantized output by it, the *reciprocal* is folded into the up-proj's
+    raw weight (its own output channels are exactly the down-proj's
+    reduction/input channels), so the gated activation is already correctly
+    pre-scaled by the time it reaches the down-proj -- no new runtime op
+    beyond the down-proj's own ``DequantizeLinear``.
+
+    :param model: the original (unquantized) onnx ModelProto or file path
+    :param block_size: elements per (output-channel, block) quantization
+            group along the down-projection's reduction dimension, matching
+            :func:`onnxsim.quantize_weight_only_int4`'s own default
+    :param num_iterations: alternating scale/re-quantization steps (the
+            paper's own default, ``15``, empirically saturates)
+    :returns: ``model`` with every matched down-projection weight replaced
+            by ``DequantizeLinear(Wq, Ws, axis=<reduction axis>,
+            block_size=block_size)`` (INT4 codes in ``[-7, 7]``, matching
+            :func:`onnxsim.quantize_weight_only_int4`'s own storage shape)
+            and every matched up-projection's raw float weight rescaled in
+            place -- feed the result to a weight-only quantizer (e.g.
+            :func:`onnxsim.quantize_weight_only_int4`) to quantize the rest
+            of the model; that quantizer's own per-channel scale absorbs the
+            rescaling for free. An opset below 21 (INT4 tensors and
+            ``DequantizeLinear``'s ``block_size`` both need it), or a model
+            with no matched block, is returned unchanged. Consider calling
+            :func:`onnxsim.simplify` afterward to drop the now-orphaned
+            float down-projection initializers.
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+
+    opset_ge_21 = any(
+        o.domain in ("", "ai.onnx") and o.version >= 21 for o in model.opset_import
+    )
+    if not opset_ge_21:
+        return model
+
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    graph = out.graph
+    initializer_map = {t.name: t for t in graph.initializer}
+    taken_names = _all_names(graph)
+    graph_output_names = {o.name for o in graph.output}
+
+    producer_of: Dict[str, onnx.NodeProto] = {}
+    consumer_count: Dict[str, int] = {}
+    for n in graph.node:
+        for out_name in n.output:
+            producer_of[out_name] = n
+        for in_name in n.input:
+            consumer_count[in_name] = consumer_count.get(in_name, 0) + 1
+
+    targets = []  # (down_node, down_w_init, down_transposed, up_w_init, up_transposed)
+    for down_node in graph.node:
+        match = _match_matmul_like(down_node)
+        if match is None:
+            continue
+        down_x, down_w, down_transposed = match
+        gate_mul = producer_of.get(down_x)
+        if (
+            gate_mul is None
+            or gate_mul.op_type != "Mul"
+            or len(gate_mul.input) != 2
+            or consumer_count.get(down_x, 0) != 1
+            or down_x in graph_output_names
+        ):
+            continue
+
+        up_info = None
+        for operand in gate_mul.input:
+            up_node = producer_of.get(operand)
+            if up_node is None:
+                continue
+            up_match = _match_matmul_like(up_node)
+            if up_match is None:
+                continue
+            _, up_w, up_transposed = up_match
+            if (
+                consumer_count.get(operand, 0) != 1
+                or operand in graph_output_names
+                or consumer_count.get(up_w, 0) != 1
+            ):
+                continue
+            up_info = (up_w, up_transposed)
+            break
+        if up_info is None:
+            continue
+        up_w, up_transposed = up_info
+
+        down_w_init = initializer_map.get(down_w)
+        up_w_init = initializer_map.get(up_w)
+        if (
+            down_w_init is None
+            or up_w_init is None
+            or down_w_init.data_type != onnx.TensorProto.FLOAT
+            or up_w_init.data_type != onnx.TensorProto.FLOAT
+            or len(down_w_init.dims) != 2
+            or len(up_w_init.dims) != 2
+        ):
+            continue
+
+        down_k = down_w_init.dims[1] if down_transposed else down_w_init.dims[0]
+        up_n = up_w_init.dims[0] if up_transposed else up_w_init.dims[1]
+        if down_k != up_n or down_k % block_size != 0:
+            continue
+
+        targets.append(
+            (down_node, down_w_init, down_transposed, up_w_init, up_transposed)
+        )
+
+    for down_node, down_w_init, down_transposed, up_w_init, up_transposed in targets:
+        w = onnx.numpy_helper.to_array(down_w_init).astype(np.float64)
+        dim0, dim1 = w.shape
+        w_nk = w if down_transposed else w.T  # [N=Dout, K=H]
+
+        s_c, codes_nk, scale_nb = _dsq_optimize(w_nk, block_size, num_iterations)
+
+        up_w = onnx.numpy_helper.to_array(up_w_init).astype(np.float64)
+        up_dim0, up_dim1 = up_w.shape
+        up_nk = up_w if up_transposed else up_w.T  # [N=H, K]
+        up_new_nk = up_nk * s_c[:, np.newaxis]
+        up_new = up_new_nk if up_transposed else up_new_nk.T
+        up_new = up_new.reshape(up_dim0, up_dim1).astype(np.float32)
+        up_w_init.CopyFrom(onnx.numpy_helper.from_array(up_new, name=up_w_init.name))
+
+        codes_orig = codes_nk if down_transposed else codes_nk.T
+        scale_orig = scale_nb if down_transposed else scale_nb.T
+        assert codes_orig.shape == (dim0, dim1)
+
+        wq = onnx.TensorProto()
+        wq.name = _unique_name(f"{down_w_init.name}_dsq_q", taken_names)
+        wq.data_type = _INT4
+        wq.dims.extend(codes_orig.shape)
+        wq.raw_data = _pack_int4_signed(codes_orig)
+        graph.initializer.append(wq)
+
+        ws = onnx.numpy_helper.from_array(
+            scale_orig.astype(np.float32),
+            name=_unique_name(f"{down_w_init.name}_dsq_scale", taken_names),
+        )
+        graph.initializer.append(ws)
+
+        reduction_axis = 1 if down_transposed else 0
+        dq_out = _unique_name(f"{down_w_init.name}_dsq_dq", taken_names)
+        dq_node = onnx.helper.make_node(
+            "DequantizeLinear",
+            [wq.name, ws.name],
+            [dq_out],
+            name=_unique_name(f"{down_w_init.name}_dsq_dequant", taken_names),
+            axis=reduction_axis,
+            block_size=block_size,
+        )
+        graph.node.insert(
+            next(i for i, n in enumerate(graph.node) if n is down_node), dq_node
+        )
+        for i, inp in enumerate(down_node.input):
+            if inp == down_w_init.name:
+                down_node.input[i] = dq_out
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Deviation-Aware Correction (DAC)
+# ---------------------------------------------------------------------------
+
+
+def _apply_ln_bias_correction(
+    graph: onnx.GraphProto,
+    ln_node: onnx.NodeProto,
+    correction: np.ndarray,
+    initializer_map: Dict[str, onnx.TensorProto],
+    taken_names: "set[str]",
+) -> None:
+    if len(ln_node.input) >= 3 and ln_node.input[2]:
+        bias_init = initializer_map.get(ln_node.input[2])
+        if (
+            bias_init is None
+            or bias_init.data_type != onnx.TensorProto.FLOAT
+            or list(bias_init.dims) != [correction.shape[0]]
+        ):
+            return
+        bias = onnx.numpy_helper.to_array(bias_init).astype(np.float64)
+        bias_init.CopyFrom(
+            onnx.numpy_helper.from_array(
+                (bias + correction).astype(np.float32), name=bias_init.name
+            )
+        )
+        return
+
+    new_bias = onnx.numpy_helper.from_array(
+        correction.astype(np.float32),
+        name=_unique_name(f"{ln_node.output[0]}_dac_bias", taken_names),
+    )
+    graph.initializer.append(new_bias)
+    initializer_map[new_bias.name] = new_bias
+    if len(ln_node.input) >= 3:
+        ln_node.input[2] = new_bias.name
+    else:
+        ln_node.input.append(new_bias.name)
+
+
+def apply_dac(
+    float_model: Union[str, onnx.ModelProto],
+    quantized_model: Union[str, onnx.ModelProto],
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_samples: int = 8,
+    seed: int = 0,
+    providers: Optional[Sequence[str]] = None,
+    min_expected_error_reduction: float = 0.5,
+    correction_threshold: float = 1e-12,
+) -> onnx.ModelProto:
+    """Empirically measures, per channel and per ``LayerNormalization``
+    node, how much of that channel's own quantization-induced output
+    deviation is a consistent, directional *mean* shift (as opposed to
+    unstructured noise), and folds the shift directly into that same
+    LayerNormalization's own bias for every channel where the shift
+    dominates -- see this module's own docstring for the technique.
+
+    This mirrors :func:`onnxsim.correct_bias`'s own measurement
+    machinery (run both models on the same calibration data, measure a
+    per-channel mean deviation at every matched node, present in both
+    models under the same output tensor name) but differs in exactly the
+    way the paper's own Deviation-Aware Correction differs from plain bias
+    correction: instead of adding a new correction term right after the
+    layer whose output was measured, it is folded into the *following*
+    LayerNormalization's own bias -- ``LayerNormalization`` already computes
+    ``normalize(x) * scale + bias``, and adding a per-channel constant
+    ``mu`` to its output is exactly equivalent to using ``bias + mu``, with
+    no new node needed (the same zero-new-node philosophy
+    :mod:`onnxsim.outlier_suppression`'s own Gamma Migration uses for its
+    own per-channel scale). A ``LayerNormalization`` with no bias input at
+    all gets one added (a plain new initializer, still no new node).
+
+    Unlike the paper -- which selects entire LayerNorm layers to correct by
+    hand, based on an empirical observation that post-attention layers see
+    a much more consistent shift than pre-attention ones -- this applies the
+    same underlying criterion the paper uses to justify that choice
+    (its own theoretical result that a channel's expected squared-error
+    reduction from correcting a mean shift is ``mu^2 / (mu^2 + sigma^2)``,
+    the deviation's own noise-to-signal ratio) directly, per channel, on
+    every ``LayerNormalization`` node present in both models: a channel is
+    corrected only when that ratio reaches ``min_expected_error_reduction``.
+    This generalizes to any transformer topology without needing to first
+    identify which LayerNorm is structurally "post-attention" -- a
+    pre-attention (or any other) LayerNorm's channels simply see a low
+    ratio in practice and are left uncorrected, the same outcome the
+    paper's own hand-picked selection produces.
+
+    :param float_model: the original (unquantized) onnx ModelProto or file
+            path
+    :param quantized_model: a quantized version of ``float_model`` (onnx
+            ModelProto or file path). Assumes ``quantized_model`` was
+            produced without renaming any ``LayerNormalization`` node's own
+            output tensor -- true of every onnxsim ``quantize_*``/``apply_*``
+            function, including :func:`apply_dsq`.
+    :param calibration_data: representative input batches to measure each
+            LayerNormalization's own deviation on. Each batch is a
+            ``{input_name: np.ndarray}`` dict matching ``float_model``'s
+            graph inputs -- see :func:`onnxsim.generate_random_calibration_data`
+            (the default when omitted) and
+            :func:`onnxsim.load_huggingface_calibration_data` (real data, a
+            much more representative correction than random input).
+    :param num_samples: random batches to generate when
+            ``calibration_data`` is omitted
+    :param seed: seed for the random calibration data (ignored if
+            ``calibration_data`` is supplied)
+    :param providers: onnxruntime execution providers to run both models on
+    :param min_expected_error_reduction: only correct a channel whose
+            measured deviation's own ``mu^2 / (mu^2 + sigma^2)`` reaches
+            this fraction (in ``[0, 1)``) -- the paper's own closed-form
+            expected squared-error reduction from applying the correction.
+            The default, ``0.5``, corrects a channel only when the mean
+            shift itself, not run-to-run noise, is the dominant source of
+            that channel's own deviation.
+    :param correction_threshold: skip a LayerNormalization whose largest
+            per-channel correction (after the ratio gate above) never
+            exceeds this in absolute value -- avoids a numerically-pointless
+            edit, not an accuracy knob.
+    :returns: ``quantized_model`` with a per-channel mean-shift correction
+            folded into every measurably-shifted, gated-in
+            ``LayerNormalization``'s own bias
+    """
+    if isinstance(float_model, str):
+        float_model = onnx.load(float_model, load_external_data=False)
+    if isinstance(quantized_model, str):
+        quantized_model = onnx.load(quantized_model, load_external_data=False)
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            float_model, num_samples=num_samples, seed=seed
+        )
+
+    quantized_ln_outputs = {
+        n.output[0]
+        for n in quantized_model.graph.node
+        if n.op_type == "LayerNormalization" and n.output
+    }
+    candidates = [
+        n.output[0]
+        for n in float_model.graph.node
+        if n.op_type == "LayerNormalization"
+        and n.output
+        and n.output[0] in quantized_ln_outputs
+    ]
+    if not candidates:
+        return quantized_model
+
+    float_probe = _add_probe_outputs(float_model, candidates)
+    quantized_probe = _add_probe_outputs(quantized_model, candidates)
+
+    sums: Dict[str, np.ndarray] = {}
+    sumsqs: Dict[str, np.ndarray] = {}
+    counts: Dict[str, int] = {}
+    for batch in calibration_data:
+        float_out = backend.run_model(float_probe, batch, providers=providers)
+        quantized_out = backend.run_model(quantized_probe, batch, providers=providers)
+        for name in candidates:
+            f = np.asarray(float_out[name], dtype=np.float64)
+            q = np.asarray(quantized_out[name], dtype=np.float64)
+            if f.shape != q.shape or f.ndim == 0:
+                continue
+            diff = f - q
+            reduce_axes = tuple(range(diff.ndim - 1))
+            s = diff.sum(axis=reduce_axes) if reduce_axes else diff
+            ssq = (diff * diff).sum(axis=reduce_axes) if reduce_axes else diff * diff
+            cnt = diff.size // diff.shape[-1]
+            if name in sums:
+                sums[name] = sums[name] + s
+                sumsqs[name] = sumsqs[name] + ssq
+                counts[name] += cnt
+            else:
+                sums[name] = s
+                sumsqs[name] = ssq
+                counts[name] = cnt
+
+    corrected = onnx.ModelProto()
+    corrected.CopyFrom(quantized_model)
+    graph = corrected.graph
+    initializer_map = {t.name: t for t in graph.initializer}
+    taken_names = _all_names(graph)
+    node_by_output = {
+        n.output[0]: n
+        for n in graph.node
+        if n.op_type == "LayerNormalization" and n.output
+    }
+
+    for name, total in sums.items():
+        cnt = counts[name]
+        mu = total / cnt
+        var = np.maximum(sumsqs[name] / cnt - mu * mu, 0.0)
+        expected_reduction = (mu * mu) / (mu * mu + var + 1e-12)
+        correction = np.where(
+            expected_reduction >= min_expected_error_reduction, mu, 0.0
+        )
+        if np.max(np.abs(correction)) <= correction_threshold:
+            continue
+        ln_node = node_by_output.get(name)
+        if ln_node is None or len(ln_node.input) < 2:
+            continue
+        gamma_init = initializer_map.get(ln_node.input[1])
+        if (
+            gamma_init is None
+            or gamma_init.data_type != onnx.TensorProto.FLOAT
+            or list(gamma_init.dims) != [correction.shape[0]]
+        ):
+            continue
+        _apply_ln_bias_correction(
+            graph, ln_node, correction.astype(np.float32), initializer_map, taken_names
+        )
+
+    return corrected

--- a/tests/test_d2quant.py
+++ b/tests/test_d2quant.py
@@ -1,0 +1,345 @@
+"""Tests for ``onnxsim.apply_dsq``/``onnxsim.apply_dac`` (D2Quant's Dual-Scale
+Quantizer and Deviation-Aware Correction, see ``onnxsim/d2quant.py``).
+
+Per this repo's own numerics convention: reconstruction of the INT4 codes
+this module writes is checked directly against the ONNX initializers via
+numpy, with a tight *relative* tolerance -- onnxruntime's own MatMul kernel
+reduction order is not bit-exact across CPU architectures, so any
+onnxruntime-based check here is kept separate and loose.
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(np.asarray(array, dtype=np.float32), name)
+
+
+def _run(model, feeds, output_names=None):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    names = output_names or [o.name for o in sess.get_outputs()]
+    return dict(zip(names, sess.run(names, feeds)))
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
+
+
+def _decode_int4_signed(t: onnx.TensorProto) -> np.ndarray:
+    dims = list(t.dims)
+    numel = int(np.prod(dims)) if dims else 0
+    raw = np.frombuffer(t.raw_data, dtype=np.uint8)
+    lo = raw & 0x0F
+    hi = (raw >> 4) & 0x0F
+    nibbles = np.empty(numel, dtype=np.uint8)
+    nibbles[0::2] = lo[: (numel + 1) // 2]
+    nibbles[1::2] = hi[: numel // 2]
+    signed = nibbles.astype(np.int64)
+    signed = np.where(signed >= 8, signed - 16, signed)
+    return signed.reshape(dims)
+
+
+# ---------------------------------------------------------------------------
+# DSQ
+# ---------------------------------------------------------------------------
+
+
+def _swiglu_model(D=8, H=16, Dout=6, extra_up_consumer=False, gemm_down=False, seed=0):
+    rng = np.random.default_rng(seed)
+    w_gate = rng.standard_normal((D, H)).astype(np.float32) * 0.3
+    w_up = rng.standard_normal((D, H)).astype(np.float32) * 0.3
+    w_down = rng.standard_normal((H, Dout)).astype(np.float32) * 0.3
+    # A few outlier-heavy columns in w_down -- DSQ's own target scenario.
+    w_down[:, 0] *= 6.0
+
+    down_body = (
+        "Y = MatMul(Gated, Wdown)"
+        if not gemm_down
+        else "Y = Gemm<transB = 1>(Gated, WdownT)"
+    )
+    w_down_for_graph = w_down if not gemm_down else w_down.T.copy()
+    down_init = _f32(w_down_for_graph, "WdownT" if gemm_down else "Wdown")
+
+    extra_output = ", float[batch,{H}] UpOut".format(H=H) if extra_up_consumer else ""
+    extra_line = "UpOut = Identity(UpProj)" if extra_up_consumer else ""
+
+    model = _model(
+        f"""
+        g (float[batch,{D}] X) => (float[batch,{Dout}] Y{extra_output})
+        {{
+          GateProj = MatMul(X, Wgate)
+          UpProj = MatMul(X, Wup)
+          Sig = Sigmoid(GateProj)
+          Silu = Mul(GateProj, Sig)
+          Gated = Mul(Silu, UpProj)
+          {down_body}
+          {extra_line}
+        }}
+        """,
+        [_f32(w_gate, "Wgate"), _f32(w_up, "Wup"), down_init],
+    )
+    return model, w_gate, w_up, w_down
+
+
+def test_apply_dsq_quantizes_down_proj_and_rescales_up_proj():
+    model, w_gate, w_up, w_down = _swiglu_model(D=8, H=16, Dout=6, seed=0)
+    dsq_model = onnxsim.apply_dsq(model, block_size=4, num_iterations=15)
+    onnx.checker.check_model(dsq_model)
+
+    down_node = next(
+        n for n in dsq_model.graph.node if n.op_type == "MatMul" and n.output[0] == "Y"
+    )
+    dq_node = next(n for n in dsq_model.graph.node if n.output[0] == down_node.input[1])
+    assert dq_node.op_type == "DequantizeLinear"
+    attrs = {a.name: a for a in dq_node.attribute}
+    assert attrs["axis"].i == 0
+    assert attrs["block_size"].i == 4
+
+    wq = next(t for t in dsq_model.graph.initializer if t.name == dq_node.input[0])
+    assert wq.data_type == onnx.TensorProto.INT4
+    assert list(wq.dims) == [16, 6]
+
+    up_init = next(t for t in dsq_model.graph.initializer if t.name == "Wup")
+    up_after = onnx.numpy_helper.to_array(up_init)
+    assert not np.allclose(up_after, w_up)
+    # Every column's rescale ratio must be a single constant down that
+    # column (only the up-proj's *output channel* -- H -- is rescaled).
+    ratio = up_after.astype(np.float64) / w_up.astype(np.float64)
+    assert np.allclose(ratio, ratio[0:1, :], rtol=1e-5)
+
+
+def test_apply_dsq_reconstruction_matches_original_weight():
+    D, H, Dout, block_size = 8, 16, 6, 4
+    model, _, w_up, w_down = _swiglu_model(D=D, H=H, Dout=Dout, seed=1)
+    dsq_model = onnxsim.apply_dsq(model, block_size=block_size, num_iterations=15)
+
+    down_node = next(
+        n for n in dsq_model.graph.node if n.op_type == "MatMul" and n.output[0] == "Y"
+    )
+    dq_node = next(n for n in dsq_model.graph.node if n.output[0] == down_node.input[1])
+    wq = next(t for t in dsq_model.graph.initializer if t.name == dq_node.input[0])
+    ws = next(t for t in dsq_model.graph.initializer if t.name == dq_node.input[1])
+    codes = _decode_int4_signed(wq).astype(np.float64)  # [H, Dout]
+    scale = onnx.numpy_helper.to_array(ws).astype(np.float64)  # [H/block_size, Dout]
+    num_blocks = H // block_size
+    dequant_normalized = (
+        codes.reshape(num_blocks, block_size, Dout) * scale[:, np.newaxis, :]
+    ).reshape(H, Dout)
+
+    up_init = next(t for t in dsq_model.graph.initializer if t.name == "Wup")
+    up_after = onnx.numpy_helper.to_array(up_init).astype(np.float64)
+    s_c_recovered = (up_after / w_up.astype(np.float64)).mean(axis=0)  # [H]
+
+    reconstructed = dequant_normalized * s_c_recovered[:, np.newaxis]
+    rel_err = np.linalg.norm(reconstructed - w_down) / np.linalg.norm(w_down)
+    assert rel_err < 0.1
+
+
+def test_apply_dsq_output_stays_close_to_float_via_onnxruntime():
+    model, *_ = _swiglu_model(D=8, H=16, Dout=6, seed=2)
+    dsq_model = onnxsim.apply_dsq(model, block_size=4, num_iterations=15)
+    onnx.checker.check_model(dsq_model)
+
+    rng = np.random.default_rng(3)
+    x = rng.standard_normal((5, 8)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x}, output_names=["Y"]).values()
+    (dsq_y,) = _run(dsq_model, {"X": x}, output_names=["Y"]).values()
+    assert np.all(np.isfinite(dsq_y))
+    assert _rel_l2(float_y, dsq_y) < 0.25
+
+
+def test_apply_dsq_gemm_transb_down_proj():
+    model, *_ = _swiglu_model(D=8, H=16, Dout=6, gemm_down=True, seed=4)
+    dsq_model = onnxsim.apply_dsq(model, block_size=4, num_iterations=15)
+    onnx.checker.check_model(dsq_model)
+
+    dq_nodes = [n for n in dsq_model.graph.node if n.op_type == "DequantizeLinear"]
+    assert len(dq_nodes) == 1
+    attrs = {a.name: a for a in dq_nodes[0].attribute}
+    assert attrs["axis"].i == 1  # transB=1 stores W as [N, K] -- reduction is axis 1
+
+    rng = np.random.default_rng(5)
+    x = rng.standard_normal((4, 8)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x}, output_names=["Y"]).values()
+    (dsq_y,) = _run(dsq_model, {"X": x}, output_names=["Y"]).values()
+    assert _rel_l2(float_y, dsq_y) < 0.25
+
+
+def test_apply_dsq_declines_when_up_proj_has_extra_consumer():
+    model, *_ = _swiglu_model(D=8, H=16, Dout=6, extra_up_consumer=True, seed=6)
+    dsq_model = onnxsim.apply_dsq(model, block_size=4, num_iterations=15)
+    assert dsq_model.SerializeToString() == model.SerializeToString()
+
+
+def test_apply_dsq_noop_when_no_swiglu_pattern():
+    model = _model(
+        """
+        g (float[4,16] X) => (float[4,6] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """,
+        [_f32(np.random.default_rng(7).standard_normal((16, 6)), "W")],
+    )
+    dsq_model = onnxsim.apply_dsq(model, block_size=4)
+    assert dsq_model.SerializeToString() == model.SerializeToString()
+
+
+def test_apply_dsq_noop_below_opset_21():
+    model, *_ = _swiglu_model(D=8, H=16, Dout=6, seed=8)
+    model.opset_import[0].version = 17
+    dsq_model = onnxsim.apply_dsq(model, block_size=4)
+    assert dsq_model.SerializeToString() == model.SerializeToString()
+
+
+# ---------------------------------------------------------------------------
+# DAC
+# ---------------------------------------------------------------------------
+
+
+def _ln_shift_models(K=16, shift=None, with_beta=True, seed=0):
+    rng = np.random.default_rng(seed)
+    gamma = (np.ones(K) + rng.standard_normal(K) * 0.05).astype(np.float32)
+    beta = (rng.standard_normal(K) * 0.1).astype(np.float32)
+    if shift is None:
+        shift = np.zeros(K, dtype=np.float32)
+
+    beta_arg = ", Beta" if with_beta else ""
+    beta_init = [_f32(beta, "Beta")] if with_beta else []
+
+    float_model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{K}] Y)
+        {{
+          Y = LayerNormalization<axis = -1>(X, Gamma{beta_arg})
+        }}
+        """,
+        [_f32(gamma, "Gamma")] + beta_init,
+        opset=17,
+    )
+    quantized_model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{K}] Y)
+        {{
+          Xq = Add(X, Shift)
+          Y = LayerNormalization<axis = -1>(Xq, Gamma{beta_arg})
+        }}
+        """,
+        [_f32(gamma, "Gamma"), _f32(shift, "Shift")] + beta_init,
+        opset=17,
+    )
+    return float_model, quantized_model, gamma, beta if with_beta else None
+
+
+def test_apply_dac_reduces_deviation_from_shifted_layernorm_input():
+    K = 16
+    shift = np.zeros(K, dtype=np.float32)
+    shift[3] = 2.0
+    shift[9] = -1.5
+    float_model, quantized_model, gamma, beta = _ln_shift_models(
+        K=K, shift=shift, seed=0
+    )
+
+    rng = np.random.default_rng(1)
+    calib = [{"X": rng.standard_normal((32, K)).astype(np.float32)} for _ in range(8)]
+
+    corrected = onnxsim.apply_dac(float_model, quantized_model, calibration_data=calib)
+    onnx.checker.check_model(corrected)
+
+    beta_after = onnx.numpy_helper.to_array(
+        next(t for t in corrected.graph.initializer if t.name == "Beta")
+    )
+    assert not np.allclose(beta_after, beta)
+    gamma_after = onnx.numpy_helper.to_array(
+        next(t for t in corrected.graph.initializer if t.name == "Gamma")
+    )
+    np.testing.assert_array_equal(gamma_after, gamma)  # DAC never touches gamma
+
+    eval_x = rng.standard_normal((64, K)).astype(np.float32)
+    (float_y,) = _run(float_model, {"X": eval_x}, output_names=["Y"]).values()
+    (before_y,) = _run(quantized_model, {"X": eval_x}, output_names=["Y"]).values()
+    (after_y,) = _run(corrected, {"X": eval_x}, output_names=["Y"]).values()
+    assert _rel_l2(float_y, after_y) < _rel_l2(float_y, before_y)
+
+
+def test_apply_dac_adds_bias_when_layernorm_has_none():
+    K = 16
+    shift = np.zeros(K, dtype=np.float32)
+    shift[2] = 3.0
+    float_model, quantized_model, _, _ = _ln_shift_models(
+        K=K, shift=shift, with_beta=False, seed=2
+    )
+    ln_node = next(
+        n for n in quantized_model.graph.node if n.op_type == "LayerNormalization"
+    )
+    assert len(ln_node.input) == 2
+
+    rng = np.random.default_rng(3)
+    calib = [{"X": rng.standard_normal((32, K)).astype(np.float32)} for _ in range(8)]
+    corrected = onnxsim.apply_dac(float_model, quantized_model, calibration_data=calib)
+    onnx.checker.check_model(corrected)
+
+    corrected_ln = next(
+        n for n in corrected.graph.node if n.op_type == "LayerNormalization"
+    )
+    assert len(corrected_ln.input) == 3
+    bias_init = next(
+        t for t in corrected.graph.initializer if t.name == corrected_ln.input[2]
+    )
+    assert onnx.numpy_helper.to_array(bias_init)[2] != 0.0
+
+
+def test_apply_dac_noop_when_no_deviation():
+    K = 16
+    float_model, quantized_model, _, beta = _ln_shift_models(K=K, shift=None, seed=4)
+
+    rng = np.random.default_rng(5)
+    calib = [{"X": rng.standard_normal((16, K)).astype(np.float32)} for _ in range(4)]
+    corrected = onnxsim.apply_dac(float_model, quantized_model, calibration_data=calib)
+
+    beta_after = onnx.numpy_helper.to_array(
+        next(t for t in corrected.graph.initializer if t.name == "Beta")
+    )
+    np.testing.assert_allclose(beta_after, beta)
+
+
+def test_apply_dac_noop_when_no_layernorm_present():
+    model = _model(
+        """
+        g (float[4,4] X) => (float[4,4] Y)
+        {
+          Y = Relu(X)
+        }
+        """,
+        opset=17,
+    )
+    corrected = onnxsim.apply_dac(
+        model, model, calibration_data=[{"X": np.zeros((4, 4), dtype=np.float32)}]
+    )
+    assert corrected.SerializeToString() == model.SerializeToString()


### PR DESCRIPTION
## Summary

Implements **D2Quant** (Yan, Bao, Li, Zhang, Zhang, Xie, Sun and Zhang, 2026, "D2Quant: Accurate Low-bit Post-Training Weight Quantization for LLMs", [arXiv:2602.02546](https://arxiv.org/abs/2602.02546), code at [XIANGLONGYAN/D2Quant](https://github.com/XIANGLONGYAN/D2Quant)) as a new `onnxsim/d2quant.py` module, with both of the paper's two techniques ported.

## What's added / scope

* **`apply_dsq`** — the paper's Dual-Scale Quantizer (DSQ), targeted at down-projection matrices in SwiGLU/GLU-style MLP blocks (the well-documented quantization bottleneck: the down-proj's *input* is an elementwise-gated, heavy-tailed activation). It:
  * Pattern-matches `down(gate_fn(gate(x)) * up(x))`-shaped blocks (a plain MatMul/vanilla-Gemm down-proj fed by an elementwise `Mul` whose one operand is *directly* another plain MatMul/vanilla-Gemm's output, with no intervening op — the operand that can safely be rescaled since scaling before a nonlinearity wouldn't commute).
  * Solves `min_s ||W - Q(W/s) * s||_F^2` for a per-column auxiliary scale `s`, alternating between re-quantizing (ordinary INT4 symmetric block quantization, matching `quantize_weight_only_int4`'s own scheme) and a closed-form least-squares scale update — 15 iterations by default, matching the paper.
  * Emits the down-proj as `DequantizeLinear(Wq, Ws, axis=..., block_size=...)` directly, and **absorbs** `s` by rescaling the paired up-projection's raw weight in place — zero extra runtime nodes, matching the paper's own "absorbable" claim.
* **`apply_dac`** — the paper's Deviation-Aware Correction (DAC): measures each `LayerNormalization` node's per-channel quantization-induced mean-shift deviation from calibration data (comparing a float model against a quantized one, mirroring `onnxsim.correct_bias`'s own measurement machinery) and folds it directly into that *same* LayerNormalization's own bias — no new node, the same zero-node philosophy `onnxsim.outlier_suppression`'s Gamma Migration already uses.
  * Rather than the paper's own hand-picked "post-attention LayerNorms only" selection, this applies the paper's own theoretical justification for that choice (a channel's expected squared-error reduction, `mu^2/(mu^2+sigma^2)`) directly as a per-channel gate on *any* `LayerNormalization`, so it generalizes across transformer topologies without needing to identify attention-block structure.

**Deliberately out of scope** (documented in the module's own docstring, same as how `onnxsim/outlier_suppression.py` flags its own deferred piece): the paper's end-to-end block-wise Algorithm 1 pipeline, which interleaves DSQ/DAC with attention/FFN quantization block-by-block and re-derives calibration activations after each block. `apply_dsq`/`apply_dac` are meant to compose with any of onnxsim's own weight-only quantizers instead (see the module docstring for the 3-step recipe). `apply_dsq`'s alternating solver also isn't a line-for-line port of the paper's own GPTQ-baseline-driven derivation — it solves the same per-column-scale objective against a plain block quantizer, the same "faithful to the objective, not to a specific reference implementation" stance `onnxsim/hqq.py` already takes for its own IRLS solver (documented explicitly in the docstring).

Registered in `onnxsim/__init__.py` (import + `__all__`), pure Python — no C++ changes.

## Test plan

New `tests/test_d2quant.py` (11 tests), all passing locally:
```
tests/test_d2quant.py::test_apply_dsq_quantizes_down_proj_and_rescales_up_proj PASSED
tests/test_d2quant.py::test_apply_dsq_reconstruction_matches_original_weight PASSED
tests/test_d2quant.py::test_apply_dsq_output_stays_close_to_float_via_onnxruntime PASSED
tests/test_d2quant.py::test_apply_dsq_gemm_transb_down_proj PASSED
tests/test_d2quant.py::test_apply_dsq_declines_when_up_proj_has_extra_consumer PASSED
tests/test_d2quant.py::test_apply_dsq_noop_when_no_swiglu_pattern PASSED
tests/test_d2quant.py::test_apply_dsq_noop_below_opset_21 PASSED
tests/test_d2quant.py::test_apply_dac_reduces_deviation_from_shifted_layernorm_input PASSED
tests/test_d2quant.py::test_apply_dac_adds_bias_when_layernorm_has_none PASSED
tests/test_d2quant.py::test_apply_dac_noop_when_no_deviation PASSED
tests/test_d2quant.py::test_apply_dac_noop_when_no_layernorm_present PASSED
============================== 11 passed in 0.82s ==============================
```
Per this repo's own numerics convention, the DSQ reconstruction check (`test_apply_dsq_reconstruction_matches_original_weight`) verifies the INT4 codes directly against the ONNX initializers via numpy with a tight relative tolerance (`< 0.1`), independently recovering the absorbed scale from the up-projection's own weight ratio; the onnxruntime-based checks are kept separate with a loose relative tolerance (`< 0.25`, matching `onnxsim/hqq.py`'s own precedent for genuine INT4 quantization noise).

No-regression checks on the modules this reuses code/patterns from, all passing:
```
tests/test_bias_correction.py ....... (7 passed)
tests/test_outlier_suppression.py ....... (7 passed)
tests/test_hqq.py ....... (7 passed)
```

Lint/type-check, clean on touched files:
```
ruff check onnxsim/d2quant.py tests/test_d2quant.py onnxsim/__init__.py   -> All checks passed!
ruff format --check (same files)                                         -> already formatted
mypy (pinned 1.18.2, matching .github/workflows/lint.yml)                -> Success: no issues found in 70 source files
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFsjHpjrBaUa9V9E4tTubj

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFsjHpjrBaUa9V9E4tTubj)_