### PR TITLE
Retire apply_transformer_block_pruning's Python implementation in favor of its verified-parity C++ port

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -31998,79 +31998,28 @@ def apply_transformer_block_pruning(
     subgraph is conservatively declined there even though the equivalent
     top-level-graph case would be handled -- a documented, conservative
     gap, not a correctness risk.
+
+    This pure-Python implementation has been retired in favor of the
+    verified-full-parity C++ port -- this is now a thin alias for
+    :func:`onnxsim.apply_transformer_block_pruning_cpp`
+    (``onnxsim/structured_pruning_entry.cpp``'s own ``ApplyTransformerBlockPruning``),
+    forwarding every argument unchanged. Imported lazily (inside the
+    function body, not at module scope) to avoid a circular import:
+    ``onnxsim.onnx_simplifier`` already imports from this module
+    (:class:`EmbeddingPruningResult`), so importing it back at module load
+    time here would deadlock the import machinery.
     """
-    if num_blocks_to_drop is not None:
-        if num_blocks_to_drop < 0:
-            raise ValueError(
-                f"num_blocks_to_drop must be >= 0, got {num_blocks_to_drop}"
-            )
-    elif not (0.0 <= sparsity <= 1.0):
-        raise ValueError(f"sparsity must be in [0, 1], got {sparsity}")
+    from onnxsim.onnx_simplifier import apply_transformer_block_pruning_cpp
 
-    if isinstance(model, str):
-        model = onnx.load(model, load_external_data=False)
-    if calibration_data is None:
-        calibration_data = generate_random_calibration_data(
-            model, num_samples=num_samples, seed=seed
-        )
-
-    out = onnx.ModelProto()
-    out.CopyFrom(model)
-
-    try:
-        inferred = onnx.shape_inference.infer_shapes(out, strict_mode=False)
-        top_value_info_by_name = _value_info_by_name(inferred.graph)
-    except Exception:
-        top_value_info_by_name = _value_info_by_name(out.graph)
-
-    # (graph, candidate, similarity) for every graph's own candidates,
-    # pooled together -- see this function's own docstring for why
-    # selection is pooled across the whole model while committing stays
-    # strictly per graph.
-    pooled: List[Tuple[onnx.GraphProto, _DroppableBlock, float]] = []
-    for graph in _iter_subgraphs(out.graph):
-        is_top = graph is out.graph
-        value_info_by_name = (
-            top_value_info_by_name if is_top else _value_info_by_name(graph)
-        )
-        candidates = _find_transformer_block_candidates(graph, value_info_by_name)
-        if not candidates:
-            continue
-        if is_top:
-            similarity = _transformer_block_similarity(
-                out, candidates, calibration_data, providers
-            )
-            pooled.extend((graph, c, similarity[i]) for i, c in enumerate(candidates))
-        else:
-            # Not probeable -- see this function's own docstring. Ranked
-            # last, never preferentially dropped, but still a real,
-            # committable candidate if `target` needs it.
-            pooled.extend((graph, c, float("-inf")) for c in candidates)
-
-    if not pooled:
-        return out
-
-    if num_blocks_to_drop is not None:
-        target = min(num_blocks_to_drop, len(pooled))
-    else:
-        target = int(round(sparsity * len(pooled)))
-    if target <= 0:
-        return out
-
-    ranked = [
-        (g, c) for g, c, _ in sorted(pooled, key=lambda item: item[2], reverse=True)
-    ]
-    committed = _select_droppable_blocks([c for _, c in ranked], target)
-    committed_by_graph: Dict[int, Tuple[onnx.GraphProto, List[_DroppableBlock]]] = {}
-    block_to_graph = {id(c): g for g, c in ranked}
-    for block in committed:
-        g = block_to_graph[id(block)]
-        entry = committed_by_graph.setdefault(id(g), (g, []))
-        entry[1].append(block)
-    for g, blocks in committed_by_graph.values():
-        _commit_transformer_block_drops(g, blocks)
-
-    return out
+    return apply_transformer_block_pruning_cpp(
+        model,
+        calibration_data=calibration_data,
+        num_samples=num_samples,
+        seed=seed,
+        sparsity=sparsity,
+        num_blocks_to_drop=num_blocks_to_drop,
+        providers=providers,
+    )
 
 
 # --- Dry-run pruning sensitivity analysis ---------------------------------

--- a/tests/test_transformer_block_pruning_cpp.py
+++ b/tests/test_transformer_block_pruning_cpp.py
@@ -18,7 +18,26 @@ bare ``Add`` and whose entry norm is a plain LayerNormalization/
 RMSNormalization/SimplifiedLayerNormalization node or a fused
 SkipLayerNormalization-family node's own optional fourth output) and the full
 set of decline conditions this file's tests cross-check against.
+
+``onnxsim.apply_transformer_block_pruning`` (the pure-Python name) is now
+itself a thin alias for :func:`onnxsim.apply_transformer_block_pruning_cpp`
+(full parity verified -- see pruning.py's own "Transformer block (depth)
+pruning" section comment), so the handful of tests below that used to call
+BOTH entry points and compare their live outputs would be tautological
+(literally the same code path twice) if left as-is. Those now instead
+compare the C++ port's output against a golden fixture captured from the
+real pure-Python implementation *before* it was deleted -- see
+``_GOLDEN_*`` below (base64-encoded serialized ``ModelProto`` bytes,
+inlined directly rather than as a checked-in ``.onnx`` file: this repo's
+own ``.gitignore`` excludes ``*.onnx`` outright, and there is no existing
+``tests/golden/``-style fixture-directory convention to follow instead --
+see CLAUDE.md's own "Prefer onnx.parser-based model construction in tests"
+note for the same "keep fixtures in the test file itself" spirit) --
+preserving the original regression coverage (did the behavior change?)
+without asserting a tautology.
 """
+
+import base64
 
 import numpy as np
 import onnx
@@ -31,6 +50,159 @@ from onnx import parser
 import onnxsim
 
 ort = pytest.importorskip("onnxruntime")
+
+
+def _golden(b64):
+    return onnx.load_from_string(base64.b64decode(b64))
+
+
+# Frozen from onnxsim.apply_transformer_block_pruning's own real pure-Python
+# implementation, on the exact model + calibration seed each corresponding
+# test below builds, before that implementation was deleted in favor of the
+# C++ port (see this file's own module docstring).
+_GOLDEN_DROPS_NEAR_IDENTITY_MLP_BLOCK = (
+    "CAo6qQcKSAoCeDAKCExuMVNjYWxlCgdMbjFCaWFzEgNsbjEiEkxheWVyTm9ybWFsaXphdGlvbioU"
+    "CgRheGlzGP///////////wGgAQI6AAoXCgNsbjEKAlcxEgJoMSIGTWF0TXVsOgAKEwoCeDAKAmgx"
+    "EgJ4MiIDQWRkOgAKEwoCeDISAXkiCElkZW50aXR5OgASAWcqMAgIEAFCCExuMFNjYWxlSiAAAIA/"
+    "AACAPwAAgD8AAIA/AACAPwAAgD8AAIA/AACAPyovCAgQAUIHTG4wQmlhc0ogAAAAAAAAAAAAAAAA"
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAqjQIICAgIEAFCAlcwSoACdgAHNLXYDbSC6Ss1c0XhM+vKD7U/"
+    "IcI0GgWvNek6fjVR6Dy1jdeptRhPJ7VlfjEzuQcctv/sarQtOae1CJFEtTEZErX2z6m0Ev7cNH3s"
+    "izVXAwq0VGe3NdSPMrUtt7w0AIZyNc/jyTPhlEe1fGx3tVy99bTGbmw0N4KHtb+ZYLRw9yq0oC4R"
+    "NQ19ZjQOyr40w4Ivte0rC7RiclI153HINSr9qLUGMss17aO0NVC7UTWB+o00OYmotDaxwzX7jAM2"
+    "tM/xNZ+CsDX93b80gy2itfgKmbGdODA1w+ustSoh1DQEyOY0sdc6NfztnrXbnzG1NE/qtBYCnbU6"
+    "dOk1uh4FtSowCAgQAUIITG4xU2NhbGVKIAAAgD8AAIA/AACAPwAAgD8AAIA/AACAPwAAgD8AAIA/"
+    "Ki8ICBABQgdMbjFCaWFzSiAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACqNAggICAgQ"
+    "AUICVzFKgAK1bqg+n2OEvj2vyj+XAak/ZiMiP04GDcBVHFU9DwYvP9CBgD8oLx6/qzfpP+IDqb/n"
+    "WSm/cF9vP37tSD0zJwBALQtBPgIZIr8BUMG+raqLvwaLo7+mYiE/SMcUPxq0pT/YLUG/rDTYP3sk"
+    "k742hsk/G5bdvqJIPL+9x38+qAaEP7LfJD445RW/Fq2rvwRls7/TrwA/1V19P9c8KL7KhIm/sX9f"
+    "P/Pjo7+hiza/B/seP1ACEMA80sU+auYUvwnO3z1nCZu9E/dOPkG1MT+FJEK/veK1P0jhOT/d/lc/"
+    "QxqVP2KfST+KFVg/09CaPYegtr9DSQq+6f5Ev2cctr/tU4Q+WhgKAngwEhIKEAgBEgwKAggBCgII"
+    "BAoCCAhiFwoBeRISChAIARIMCgIIAQoCCAQKAggIQgQKABAV"
+)
+
+
+_GOLDEN_SPARSITY_SELECTS_FRACTION = (
+    "CAo6yggKQgoCeDAKBVNjYWxlCgRCaWFzEgNsbjEiEkxheWVyTm9ybWFsaXphdGlvbioUCgRheGlz"
+    "GP///////////wGgAQI6AAoXCgNsbjEKAlcxEgJoMSIGTWF0TXVsOgAKEwoCeDAKAmgxEgJ4MiID"
+    "QWRkOgAKEwoCeDISAXkiCElkZW50aXR5OgASAWcqLQgIEAFCBVNjYWxlSiAAAIA/AACAPwAAgD8A"
+    "AIA/AACAPwAAgD8AAIA/AACAPyosCAgQAUIEQmlhc0ogAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    "AAAAAAAAAAAqjQIICAgIEAFCAlcwSoACufYINv6BK7YRd+A01WgYtaUD87Tmfme0GY8HthYJebT9"
+    "QGi1sgBfNsBvcjQ1Ub202QOXtMxTM7Wyno21R8/RtAlfATWPEoC0V4yANTGJVrRZY9AyAHrPNV5T"
+    "EjUOnwe1ZVJEtJsYETWP3AE2VsCQtHPCgrQ8h4Y1EPVttbmdnLSe52w1WckbNdeHxDM44TM1dcs9"
+    "ttYTiTUlzYC1V/XftWpqlDQUDTw1YMjutAZ5kLUeaeAyR4xis/ynvDV8oUg1pBtQNG0zlTW/rVy0"
+    "Vot4tS7IHDW8Xxw1uatmtDIiUrVZDXY0x1wntgNBOTWS5gM1tPbbtXPBgzM2ZoG11UNLNSqNAggI"
+    "CAgQAUICVzFKgALMLwLAUBxqvwmnNT/zBJQ/wxwKwBT//r5A8qc+l/Ubvxmayz8eepi/NoW1Picy"
+    "hr+Y9rM/612xvKCXvr587du/D0bXPxm2QD+P6UA/GKaRP9PNsj6qpSO/nNxMv+jZTL+IXq8/xe26"
+    "v6yrGL8VeqS+iAJmPhlKEz9p4p+/FXHdv0SlkLsPVps/j85BP4/TXD45YqK+uiKWPtUseb5zNFE/"
+    "52BLvzJ2CT6y4OK9mhkLP6QHZj7EMyNA69O/PxWVvz87hwLA+z2uvujNG79xYAg/ktsRwPlVlj/p"
+    "kog/QqqmvyiCer+cGU2/C1cxPa4WJD+REANAIy9Kvgx7RD/ZJR8+Ko0CCAgICBABQgJXMkqAAps2"
+    "7DWzOEc1Ca+3NaOkkLW5ak60BHJatZn9yTWsiDA1u9KjtLbq8rTrGQI1aE48tZXNebXuMAE1SUwl"
+    "NlckhLTONhW1pDCdtaEus7WT7Aw1vWJkNdmeHTLljLI00O34MyfhFDRt1sy1TPP1tGZm7zPQOlK1"
+    "Acj/tIPhW7VvC7O0JwFlNfpH2rSnNyW0TW5aNUYULTXjhuM1Q0oMtuYCZjVPdgG1zp8QNKPfYDVM"
+    "ZJE10X+LNWeLJjSXC9g1r+uXtNBgF7T/klY1BgIUtRYEETasy4g1GQASNj5m5LJKq820zl0zNLYv"
+    "RTW5rx210NnLNABZkLJn2tg1huQxtdhpjDVaGAoCeDASEgoQCAESDAoCCAEKAggECgIICGIXCgF5"
+    "EhIKEAgBEgwKAggBCgIIBAoCCAhCBAoAEBU="
+)
+
+
+_GOLDEN_NUM_BLOCKS_TO_DROP_CAPS = (
+    "CAo67AUKNwoCeDASAXkaJHkvdHJhbnNmb3JtZXJfYmxvY2tfcHJ1bmluZ19pZGVudGl0eSIISWRl"
+    "bnRpdHkSAWcqLQgIEAFCBVNjYWxlSiAAAIA/AACAPwAAgD8AAIA/AACAPwAAgD8AAIA/AACAPyos"
+    "CAgQAUIEQmlhc0ogAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAqjQIICAgIEAFCAlcw"
+    "SoACzDnUtDCwjTSJ+SI1KHuCtXwRTjXs7og0+C1SNeFAkjRM9ps1Ibp7tVJi7jXNYaE1ygwhtUk2"
+    "MTVdyO40+0/qtfPGHzVSJB21mTmGtK6zIbVr0+W0kgyaM+ezzzMNRNG1rUKQtFx/tLWYj6q18US6"
+    "tMqXZTUhWCk1yU8itb+zPrUtG161IkQZNBpuezUODJsykPY5NX5VqTRt48k1r6oGtuMCD7aoElW0"
+    "qt4qNXdp3LTaluQ0sYKdtRQIqbW4WkC1QtdhNWLtOjVadj+1t3lCNLvULbX9T6wy746VtQzzR7Og"
+    "gEW1y4U+swcIL7WllVy1g5fzMz5atbRrJ7oyof7gtCqNAggICAgQAUICVzFKgAIXwCQ1bvVatStc"
+    "TjVKxrI1pVuQtBg+6jXzNQg2xN/tNPU2trXS2ti1rb08tHxc7jXEOho1fXtLNUO1hrRiwUe1c6zH"
+    "NFnRlLWpd1O0HjYJNQVWGjPIzww1jm7vtJuSIDW6Ptk0emvdteLji7XqNEK1jPsvNZUtojSd7Zc0"
+    "Tq85NFTaKjXPw301zucUtVOH1bUwIjM1dt9gtBSeUTM6nzq0jlOVtZXByrVqbIE1YLaSNU36eTUb"
+    "l180NymQNEHp4LQfDpIzX0XYtNTxEbXRVVw0SerjNf7N/LWLdyE1Z141Na3+orU7SKg0bSHaM00Z"
+    "+bQmOwW1vru8tS8i5TXnih02WhgKAngwEhIKEAgBEgwKAggBCgIIBAoCCAhiFwoBeRISChAIARIM"
+    "CgIIAQoCCAQKAggIQgQKABAV"
+)
+
+
+_GOLDEN_INTERIOR_OVERLAP_SKIP = (
+    "CAo6xAcKRAoCeDIKBlNjYWxlQgoFQmlhc0ISA2xuQiISTGF5ZXJOb3JtYWxpemF0aW9uKhQKBGF4"
+    "aXMY////////////AaABAjoAChkKA2xuQgoDV0IyEgNoQjIiBk1hdE11bDoAChkKA2hCMgoCeDAS"
+    "B2hCRmluYWwiA0FkZDoAChcKAngyCgdoQkZpbmFsEgF5IgNBZGQ6ABIBZyouCAgQAUIGU2NhbGUw"
+    "SiAAAIA/AACAPwAAgD8AAIA/AACAPwAAgD8AAIA/AACAPyotCAgQAUIFQmlhczBKIAAAAAAAAAAA"
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKo0CCAgICBABQgJXQUqAAufvjj0JqLG9nf/rvINagD1r"
+    "+0Y+bdwNvsVf671rfRU9tdz+vRPO/71sZ609+gVePIt8or1L0Lo86WkAvX+skb21Q3C+W7eSPcuW"
+    "l72RNrG8hPsHvrq6Vj0ueMM94gIjPi5qOT2lh949I365vNyRBb6wOho+n631Ojb8nD2NRTW8HanY"
+    "PafXPj59YE492qD3PTEri7xnQBM+r39pPORctT06meS9JwExPctvxj3zkwA995B2vkHBm7yjDA8+"
+    "/mehvZtgFL2isYG9ZWphPUgo1r2wka+9ul6NPcFDib6+Qhe+GKQXvh+a2LvrVMC92hbZvRudf74j"
+    "Guu9G6NxvU6eLr4qLggIEAFCBlNjYWxlQkogAACAPwAAgD8AAIA/AACAPwAAgD8AAIA/AACAPwAA"
+    "gD8qLQgIEAFCBUJpYXNCSiAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACqOAggICAgQ"
+    "AUIDV0IySoACN1eEu3MfOT5PPDM+CJOSOtb8iry+L6G9dSlavOIE6L3Vfck7KDVNvNCuZb1HfZu9"
+    "Qx8OvI4DAr1GxcS9HZnJPcfTDT4HBH47cxqQvVMFWrupNaG8715NvaTvOL4wV809pmoSPsh43jyg"
+    "1ke9P/oFvUuZtj18zLq9INXeva07zr3TxI089t0wvF/Sbbu6yxg+LAs+Pd7fk7wde328ZdZjPuD8"
+    "1j1Tc0Q+doUnvBm9Mz7CQ9c9oHd8vWcQFr34aTC+OntKPOK7Wj2A7le9ozYmOyg0OD47Rr49pTmZ"
+    "PWC/D75sQBE9LYdgviKUBD6IlCS9mF8nu9uhSL0VsCS6vS1WvFoYCgJ4MBISChAIARIMCgIIAQoC"
+    "CAQKAggIWhgKAngyEhIKEAgBEgwKAggBCgIIBAoCCAhiFwoBeRISChAIARIMCgIIAQoCCAQKAggI"
+    "QgQKABAV"
+)
+
+
+_GOLDEN_MATCHES_RANDOM_MODEL = (
+    "CAo62RgKRAoCeDAKBlNjYWxlMQoFQmlhczESA2xuMSISTGF5ZXJOb3JtYWxpemF0aW9uKhQKBGF4"
+    "aXMY////////////AaABAjoAChcKA2xuMQoCVzESAmgxIgZNYXRNdWw6AAoTCgJ4MAoCaDESAngy"
+    "IgNBZGQ6AApECgJ4MgoGU2NhbGUzCgVCaWFzMxIDbG4zIhJMYXllck5vcm1hbGl6YXRpb24qFAoE"
+    "YXhpcxj///////////8BoAECOgAKFwoDbG4zCgJXMxICaDMiBk1hdE11bDoAChIKAngyCgJoMxIB"
+    "eSIDQWRkOgASAWcqPggMEAFCBlNjYWxlMEowAACAPwAAgD8AAIA/AACAPwAAgD8AAIA/AACAPwAA"
+    "gD8AAIA/AACAPwAAgD8AAIA/Kj0IDBABQgVCaWFzMEowAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKs0ECAwIDBABQgJXMErABA0Y3rRQWKqzjNtGtTl/27NZ"
+    "stu1AZ9vtfzSubNN3dw182JnNcUa0jTY/BMzr/vhMhlmArVO7T00cMw2ttvsVTXA6Ru1d0YRNaiF"
+    "pLUACl+0JSrotfbtIbXCFBs1S0idtWFMGrWaT0I2uqYpNP+8ozVyX3W1xemQtJw1BzbvZwE1UCKU"
+    "NXPSrzVIYHO1ZuLYtThTMbXmbPw0mJ5ztVHrLzYzIm6z230PNhf6jzSf3Ao1ul+1tcxEX7Sy4vm1"
+    "IUbatcLAszUtlQS1VsrSNOFn4jVWHTI1MexBNU5BwzWXcsU1N1qLNeGtxjSv66k1AQdttcueDTXC"
+    "PrU11PAVNS0FEjUyQjq2nGaZtYA/qrUeYxY03sWAtBb7wbU/ilM0osmNNUxF+jS10C+0a5uHtZ+8"
+    "S7ZY5JY0rNLmtOoVDbVqZpS0BlhttMZikjWr4pczQrAPtTFLwzUyO4y11xxjNVW577N5dSk1VP5N"
+    "NcSH5rQG0U+1UgLjs7l/jLSVJCm1WFgYtRBVqzUM7e61QwSfNRdEujWjphO05vbztbAwB7bQzvkz"
+    "kpQINUW0fbXE6e21230/tZKWJ7WAT9w001igtdW3tLVJw2A1pgMINTA8jLWElZK1K6qktd8PorVm"
+    "bjc15qK5NdNHdzUsjbA08fWotSZV0DS73XO15cNGNcrQWbRQU3i1x/16sz1sfTXG+yM14wKzteRN"
+    "x7T6SSSzWcrzNLuijzW7RfG0qq4UNH4CaLQ355O1Ek+bNUclT7Vmng21OQq2tSo+CAwQAUIGU2Nh"
+    "bGUxSjAAAIA/AACAPwAAgD8AAIA/AACAPwAAgD8AAIA/AACAPwAAgD8AAIA/AACAPwAAgD8qPQgM"
+    "EAFCBUJpYXMxSjAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    "AAAqzQQIDAgMEAFCAlcxSsAEn6Cnv0an3T5BF6e/a+blP1RVo7/N4wm/ju+evpt9+z/N1NA+ntVW"
+    "v91asD/1pG+/o/QpvsFEaT4Fhp2/MMHdPyDUgzyvvIc/V5FZveGPQT+4kk4/TBp4P41oEz530Yi+"
+    "3KjdPlqulb5YuZs/PkTHP3wOzr8zdnS/ukk/PvOF1j+ySDM/LmGdv0ohnr9vXPe+y/vkvhly17/y"
+    "r/k/3GkcP7e/IL831qK+C6NPvzJO6D6IQIU/UbpvP+BlAMDCDgQ/L1NbPk93vb3mVng9wYh5vt32"
+    "aL/3Fqa/cnZzvh4Slz6m5JU+qv+sPkRuij9y5M4/sXwPv1nTnr/EvUW/2VpZPZYMib8kKOq+rt1P"
+    "v1bb5D+ONbu+Xny8vlqPvzzqO+k/2uqPPluHjL7xDKu/vK9bPncTQj9LJqO/yujQPubLzD65ySk/"
+    "GTK+PtKQ3z783GI/qZ3zP7AEbD/q8Qo/+ws9vinyB0Cqz10/NHR1P7RWKL4XRBvAJbcBPyKnIr/W"
+    "bRk/l4FjP8xRi79lTNk+qq94v4yNmb9bM9y97sSOPrYA5T8O9BK+eOS6v5TPbT+vTro8B6ScPghq"
+    "RD+QonE/phqMvmAN0b+MT7G/0cNdvz7tU77QkYa/8Zvdvntc2r9b56g7Lo/gPsuC/r7abOM+uwZX"
+    "vnBTQz1mNDC/lTUKP+ZUXT9VNGu+QUy0v28EZr+sm7q+baC8P6VMlT+DDZu/ucNKv4KEzr4GLim/"
+    "DjVsPxBIF7/KOQC/A1O6vcfOJz97Vz4/Kj4IDBABQgZTY2FsZTJKMAAAgD8AAIA/AACAPwAAgD8A"
+    "AIA/AACAPwAAgD8AAIA/AACAPwAAgD8AAIA/AACAPyo9CAwQAUIFQmlhczJKMAAAAAAAAAAAAAAA"
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACrNBAgMCAwQAUICVzJKwASqS1C1"
+    "Hs2ENZtvDjWCJmE1K7lvNVTnijVmcgg19wD4NUSR8rQqG/Wz8LgOtd2F3TQyxs21VvZoNaaOR7TH"
+    "ZRc1oanktPVGQrVXX1m1r6p2NdTTqLVIDu6z1xQntvApI7WWZhk118vGtWppjbX8CxW1TVINtYVJ"
+    "gzU3Bte1I+qYtacK1zWWna60tsSvtZaHtzXcxb81uul1tfmpMbVN0sm0JyqONbxhoTWxtDK2C/oG"
+    "NPDx1DN9JCk14a2KNebSgbU1Y0ayRh/INWZnrrS8NCI2cJWBNXPAkbQe/IsyHZ0DtVSZl7RuSz81"
+    "dejHsw/DGbXW6rczdbEjNcM3x7T8ytQ0JutZteP88jUl17Q1EweHNX2atTXO7Bw2mJfBs+UvRrXu"
+    "waM0fhrgNJo3PzVSXgq1ow0xNdDwfbUxuUk1Z4t+tLm6xjUCUCA1ld2XtJx6e7VwFi001wpEs0ll"
+    "NzRak2A0DWdbNXwv8rVmMJG19Y6ONYDj7zJHOnOyGDArNSAhgTUcvpk1GWQhNWgjpbTHXNI1WwxJ"
+    "tOYUHzXBRb412/4pNHCtuzQntZo1GkkbNLTfqjRfSJk1VUOTtA9LpzXxjt+1QxJANT1Yj7V8FZs1"
+    "dNSftURHAzaUwRO14xXRs6l3MzV4HGG1wBmMs8DFlDRHNeezHwIWNW1OBLN6VKM13MvJNTOgv7R/"
+    "E2K0hkNHNXgiAbZfFam1iuejtXFhHLWtlGI1yLyxNAjOu7X/X8m1Qt5nNQQ22jUoQkc1XPVsNZeH"
+    "xjQqPggMEAFCBlNjYWxlM0owAACAPwAAgD8AAIA/AACAPwAAgD8AAIA/AACAPwAAgD8AAIA/AACA"
+    "PwAAgD8AAIA/Kj0IDBABQgVCaWFzM0owAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    "AAAAAAAAAAAAAAAAAAAAKs0ECAwIDBABQgJXM0rABOhj9L9GOQ6+V9EQv5Wy9j/IhF4/Kr+nPS7N"
+    "Mb+vryq/hrbpvr0O1D+4B1Y/zSaev1ooUUCZ9K4+S1hlv66gBb/JzlE9VK0TPEBB6z7jZbQ/Sd62"
+    "PuiWLEBcdoS/HaZMvwQMIj+ouN0+yfOZvxIvCT92rxy/qOaoPj0F4T7Cy/C+W7cDP8Vdk783qHO+"
+    "uFkeQC5Smz6X8FS+eqviPgP0H754rqG/4JK/PWbk9L3+3B0/dUaPvtg3tb/aMO6/3tYMP/YJIL/c"
+    "zP+/X6xJv38XmT9VL88/TfqLPNCuKb/G/kQ/Lcysv8H8qr8j2Ko/IRjgvv3Cuj7xpWA/TG6jvhXM"
+    "xL7mmTa/BaRAvu+CQT+ndyG+X5vAvky6gT9uS8o/iykKQHD2Or8ZQBs+lizwP9Ajxj9tb4a+bVcU"
+    "vj5WU7+5WzK+syZ1PdXlmL81HY0+z7CgvosIi7+MLCw/l1WdviDr4D/nKJg/+/UiP1kAij/e+Ni/"
+    "NmQLvplgvT88tHC859+Uv+l+eT4acDu8+rixPmMaYz/nNSq94gXwPofskz9Pl4e/I6rlv+SYxz8a"
+    "nIw/rmV0PEcsAj9hWcm/2PsaPuCEEL6R1Ui/kfR3P+4Mbj6G/7C/Xao+vLTHIL+uj1e/JCC+v0Y2"
+    "Xj4bgYA8VEQgP9sAcj88GqC/FJekPe/Kur6NvVS/6Qe/P0t0mr9aup0+Za6wP37oET93ONw+2AeD"
+    "v4W/mD142Q08CYd3v8HF6T14s+Q+CJ7uv2uXkr+0exi9oTlwv1oYCgJ4MBISChAIARIMCgIIAQoC"
+    "CAQKAggMYhcKAXkSEgoQCAESDAoCCAEKAggECgIIDEIECgAQFQ=="
+)
 
 
 def _model(body, initializer=(), opset=21):
@@ -139,12 +311,13 @@ def test_transformer_block_pruning_cpp_drops_near_identity_mlp_block_and_matches
     (ref_y,) = _run(ref, {"x0": x})
     np.testing.assert_array_equal(pruned_y, ref_y)
 
-    # Cross-check against the pure-Python reference on the identical model +
-    # calibration seed -- the primary port-correctness signal.
-    pruned_py = onnxsim.apply_transformer_block_pruning(
-        model, num_blocks_to_drop=1, seed=0, num_samples=4
-    )
-    assert pruned.SerializeToString() == pruned_py.SerializeToString()
+    # Cross-check against a golden fixture frozen from the pure-Python
+    # reference on the identical model + calibration seed, back when
+    # apply_transformer_block_pruning still had its own implementation (see
+    # this file's own module docstring) -- the primary port-correctness
+    # signal.
+    golden = _golden(_GOLDEN_DROPS_NEAR_IDENTITY_MLP_BLOCK)
+    assert pruned.SerializeToString() == golden.SerializeToString()
 
 
 def test_transformer_block_pruning_cpp_adversarial_ranking_prefers_more_redundant_block_regardless_of_position():
@@ -448,10 +621,8 @@ def test_transformer_block_pruning_cpp_sparsity_selects_fraction_of_matched_cand
     (ref_y,) = _run(ref, {"x0": x})
     np.testing.assert_array_equal(pruned_y, ref_y)
 
-    pruned_py = onnxsim.apply_transformer_block_pruning(
-        model, sparsity=2 / 3, seed=0, num_samples=4
-    )
-    assert pruned.SerializeToString() == pruned_py.SerializeToString()
+    golden = _golden(_GOLDEN_SPARSITY_SELECTS_FRACTION)
+    assert pruned.SerializeToString() == golden.SerializeToString()
 
 
 def test_transformer_block_pruning_cpp_num_blocks_to_drop_caps_at_matched_candidate_count():
@@ -496,10 +667,8 @@ def test_transformer_block_pruning_cpp_num_blocks_to_drop_caps_at_matched_candid
     (pruned_y,) = _run(pruned, {"x0": x})
     np.testing.assert_array_equal(pruned_y, x)
 
-    pruned_py = onnxsim.apply_transformer_block_pruning(
-        model, num_blocks_to_drop=10, seed=0, num_samples=4
-    )
-    assert pruned.SerializeToString() == pruned_py.SerializeToString()
+    golden = _golden(_GOLDEN_NUM_BLOCKS_TO_DROP_CAPS)
+    assert pruned.SerializeToString() == golden.SerializeToString()
 
 
 def test_transformer_block_pruning_cpp_num_blocks_to_drop_takes_priority_over_sparsity():
@@ -852,10 +1021,8 @@ def test_transformer_block_pruning_cpp_interior_overlap_skip_matches_python_refe
         model, calibration_data=calibration_data, num_blocks_to_drop=2
     )
     onnx.checker.check_model(pruned_cpp)
-    pruned_py = onnxsim.apply_transformer_block_pruning(
-        model, calibration_data=calibration_data, num_blocks_to_drop=2
-    )
-    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+    golden = _golden(_GOLDEN_INTERIOR_OVERLAP_SKIP)
+    assert pruned_cpp.SerializeToString() == golden.SerializeToString()
 
     # Confirm the graph really did change (at least one candidate was
     # committed) -- this isn't a "nothing matched" no-op.
@@ -922,11 +1089,9 @@ def test_transformer_block_pruning_cpp_matches_python_reference_random_model():
     pruned_cpp = onnxsim.apply_transformer_block_pruning_cpp(
         model, calibration_data=calibration_data, sparsity=0.5
     )
-    pruned_py = onnxsim.apply_transformer_block_pruning(
-        model, calibration_data=calibration_data, sparsity=0.5
-    )
     onnx.checker.check_model(pruned_cpp)
-    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+    golden = _golden(_GOLDEN_MATCHES_RANDOM_MODEL)
+    assert pruned_cpp.SerializeToString() == golden.SerializeToString()
     # Sanity: some real reduction happened.
     assert len(pruned_cpp.graph.node) < len(model.graph.node)
 


### PR DESCRIPTION
## Summary

Thirteenth round: begins retiring pure-Python pruning implementations in favor of their C++ ports, now that every `apply_*_pruning` function in `pruning.py` has a C++ counterpart (round 12, #1066).

This PR was scoped to 7 candidate functions initially believed to have full behavioral parity between the Python original and its `_cpp` port. A careful re-verification (reading the actual C++ matching/dtype logic, not just top-level Python signatures) found that **6 of the 7 have real, previously-undetected scope gaps** — the C++ ports are FLOAT32-only where the Python originals also match FLOAT16/BFLOAT16, and/or match a narrower set of producer node shapes (e.g. plain `Gather` only vs. Python's additional `com.microsoft::EmbedLayerNormalization`/`GatherBlockQuantized`/`FusedGemm` support). Per the "never silently narrow behavior" instruction those 6 were correctly left untouched:

- `apply_moe_expert_channel_pruning` / `apply_qmoe_expert_channel_pruning` / `apply_moe_whole_expert_pruning` / `apply_qmoe_whole_expert_pruning`: C++ matching (`MatchMoeProducer`) is FLOAT32-only; Python also supports FLOAT16/BFLOAT16.
- `apply_embedding_vocab_pruning` / `apply_embedding_vocab_magnitude_pruning`: C++ matching (`MatchEmbeddingGatherRaw`) is a plain FLOAT `Gather` only; Python also matches `EmbedLayerNormalization`/`GatherBlockQuantized` producers, `FusedGemm`/`GemmFastGelu` lm_heads, and FLOAT16/BFLOAT16.

Closing those 6 gaps (mostly: extend the C++ matchers to accept FLOAT16/BFLOAT16 with the established read-upcast/write-downcast pattern already used elsewhere in this file, plus widen embedding-producer matching) is separate follow-up work, tracked for a future round.

**Only `apply_transformer_block_pruning` actually has full parity** (verified directly: identical candidate-matching/similarity-ranking/selection/commit logic, and this pass never reads weight *values* at all — only graph topology — so there's no dtype-restriction axis to diverge on in the first place). This PR retires its Python implementation:

- `apply_transformer_block_pruning`'s body is now a thin, lazily-imported (to avoid a `pruning.py` ↔ `onnx_simplifier.py` circular import) delegation to `apply_transformer_block_pruning_cpp`, keeping its original public signature and docstring unchanged — existing callers see no change.
- Its own private helpers are left in place (`_analyze_transformer_block_pruning`, the dry-run sensitivity-analysis entry point, still uses them directly).
- 5 tests in `tests/test_transformer_block_pruning_cpp.py` that used to compare live Python vs. C++ output (now tautological, since they'd be the same code path) instead compare against a golden fixture frozen from the real pure-Python implementation before deletion — inlined as base64-encoded `ModelProto` bytes directly in the test file (this repo's `.gitignore` excludes `*.onnx` and there's no existing fixture-directory convention to use instead). `tests/test_pruning.py`'s own tests are untouched since they assert against hand-built oracles, not a second live implementation.

## Testing

- `pip install --no-build-isolation -ve .`
- `python3 -m pytest tests/test_pruning.py tests/test_moe_pruning_cpp.py tests/test_qmoe_pruning_cpp.py tests/test_embedding_vocab_pruning_cpp.py tests/test_transformer_block_pruning_cpp.py tests/test_moe_whole_expert_pruning_cpp.py -k "moe or qmoe or embedding_vocab or transformer_block"` — 238 passed
- Full suite (vendor-backend-dependent modules excluded, matching this repo's own CI ignore list) — **2240 passed, 63 skipped**, no regressions
- `ruff format --check` / `ruff check` / `mypy` all clean (no C++ files touched, so no `clang-format` diff either)
- Call-site grep for all 7 candidate function names across the repo: only `onnxsim/__init__.py`'s export and `tests/test_pruning.py`'s own oracle-based tests reference `apply_transformer_block_pruning`; no other call sites anywhere in the codebase for any of the 7.

## Scope / follow-up

Next round: close the 6 documented scope gaps above (FLOAT16/BFLOAT16 support in `MatchMoeProducer`, and widened embedding-producer matching), then retire those 6 Python implementations the same way once real parity is achieved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4t6ntCm72RfFf64W9GYB1

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4t6ntCm72RfFf64W9GYB1)_