### PR TITLE
Add RotateKV outlier-aware per-stream rotation for KV-cache Key quantization

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -160,6 +160,7 @@ from onnxsim.qoq import apply_smooth_attention, quantize_weight_only_qoq
 from onnxsim.quantease import apply_quantease
 from onnxsim.quarot import apply_quarot
 from onnxsim.quip_sharp import apply_quip_sharp
+from onnxsim.rotatekv import apply_rotatekv
 from onnxsim.rptq import apply_rptq_reorder
 from onnxsim.slim_llm import apply_slim_llm
 from onnxsim.smoothquant import apply_smoothquant
@@ -223,6 +224,7 @@ __all__ = [
     "apply_duquant",
     "apply_zeroquant",
     "apply_spinquant",
+    "apply_rotatekv",
     "apply_omniquant",
     "apply_affinequant",
     "apply_magnitude_pruning",

--- a/onnxsim/rotatekv.py
+++ b/onnxsim/rotatekv.py
@@ -1,0 +1,346 @@
+"""RotateKV (Su, Wan, Zhu, Yang, Kang, Chen, Peng, Shao, He, Chen, Sui, Ma,
+Yang, 2025, "RotateKV: Accurate and Robust 2-Bit KV Cache Quantization for
+LLMs via Outlier-Aware Adaptive Rotations", https://arxiv.org/abs/2501.16383).
+onnxsim ports the algorithm, not the paper's own CUDA fast-Hadamard
+kernels, per the same rationale as
+:mod:`onnxsim.spinquant`/:mod:`onnxsim.quip_sharp` (no ONNX export path
+for the paper's own reference implementation).
+
+Distinguishing this module from its two nearest siblings, both already in
+this repo:
+
+- :mod:`onnxsim.kv_cache_quantization` (KIVI/KVQuant) already quantizes
+  Key **per channel**, static, calibrated -- but it never touches the
+  values themselves before quantizing, only picks a scale for whatever
+  per-channel range the calibration data happens to show. When a handful
+  of channels are persistent, large-magnitude outliers (KIVI's own
+  motivating finding), a shared per-channel scale still has to cover that
+  whole range, wasting precision on every *other*, non-outlier channel
+  sharing the same scale.
+- :mod:`onnxsim.qoq`'s :func:`onnxsim.apply_smooth_attention` (QServe's
+  SmoothAttention) already addresses that outlier-channel problem for
+  attention's Key -- but only with a **diagonal scale** migrated between
+  Key and Query (``K_j /= s_j``, ``Q_j *= s_j`` per channel ``j``), the
+  same ``(X/s)@(W*s)==X@W`` identity :mod:`onnxsim.smoothquant` uses for
+  weights. A diagonal rescaling can shrink an outlier channel's
+  *magnitude* but can never change *which* channels the outlier mass lands
+  on -- it is fundamentally channel-preserving.
+
+RotateKV's own distinguishing mechanism is a **rotation**, not a scale:
+conjugating Key (and compensating Query) by an orthogonal matrix, the same
+"rotate before quantizing to spread outlier mass across every channel
+evenly" idea :mod:`onnxsim.spinquant`/:mod:`onnxsim.quip_sharp` already
+use for *weights* -- but applied here to the **KV-cache activation
+stream** itself, and, per the paper's own title ("Outlier-Aware Adaptive
+Rotations"), *fit* per structural unit from that unit's own calibration
+statistics (this module's closed-form substitute for the paper's own more
+elaborate optimization -- see below) rather than either a single
+fixed/random Hadamard rotation shared by the whole model (QuIP#-style) or
+one whole-model learned rotation (SpinQuant's own "R1" -- one rotation for
+the entire residual stream). A rotation, unlike a diagonal scale, can
+redistribute outlier *mass* across channels, not merely rescale it --
+exactly the paper's own reason for preferring it over SmoothAttention-
+style migration when pushing Key down to its own aggressive (2-bit)
+target.
+
+Fitting: like :mod:`onnxsim.spinquant` (see that module's own docstring
+for the rationale), this module substitutes the paper's own more involved,
+non-closed-form outlier-aware construction (channel reordering plus a
+Hadamard-based rotation, calibration-driven but fit via an optimization
+procedure, not an eigendecomposition) with the same classical, closed-
+form, independently-verifiable stand-in :mod:`onnxsim.spinquant` already
+uses elsewhere in this repo: the eigenvector basis of the calibration
+activation's own covariance (``numpy.linalg.eigh``) -- fit **per matched
+KV-cache stream** (see below for what counts as one structural unit here)
+from that stream's own calibration-activation statistics alone, literally
+adaptive to (and only to) that one stream's own outlier structure -- the
+paper's own core "outlier-aware, adaptive" claim minus its bespoke
+optimizer, exactly like :mod:`onnxsim.spinquant` fits one rotation per
+layer rather than reusing the paper's own gradient-based joint fit.
+
+Scope/simplification relative to the paper (documented explicitly, the
+same way :mod:`onnxsim.billm`'s own docstring documents its own scoped-
+down simplification): the paper fits one rotation **per attention head**,
+which requires splitting a fused/flat QKV projection's output channels
+into per-head blocks first. Doing that split structurally in an arbitrary
+ONNX graph (locating the Reshape/Transpose that turns one flat
+``[..., num_heads * head_dim]`` projection output into per-head
+``[..., num_heads, head_dim]`` tensors, for an unknown ``num_heads``) is
+out of scope for this module; instead, this module fits and applies one
+rotation per matched KV-cache stream
+(:mod:`onnxsim.kv_cache_quantization`'s own
+``Concat(past, new, axis=seq)`` pattern) -- which is exactly "one rotation
+per head" whenever a graph already keeps each attention head's Key stream
+as its own separate KV-cache Concat (a common decomposed-per-head export
+shape), and is otherwise still a sound, exact, purely-additive "one
+rotation per matched Key tensor" contribution -- the same "single-
+rotation-per-Key-tensor" scoping this project already treats as a
+legitimate, mergeable, scoped-down contribution on its own.
+
+Graph rewrite -- per matched Key-style KV-cache stream (see
+:mod:`onnxsim.kv_cache_quantization` for what "Key-style" means and how it
+is matched) whose ``present_name`` also feeds -- directly, or through
+exactly one ``Transpose`` (the common shape when the cache's own head-dim
+axis is last but the attention math needs it second-to-last for
+``QK^T``) -- some attention subgraph's ``QK^T`` MatMul
+(:mod:`onnxsim.attention_quantization`'s own decomposed attention pattern)
+as its ``Kt`` operand. A stream with no such attention consumer is left
+untouched entirely: rotating Key alone with no way to compensate Query
+would silently change the attention scores, and this module never does
+that.
+
+    Before:
+      new_key: float32 [..., seq_new, head_dim]   -- this step's fresh Key
+      present_key = Concat(past_key, new_key, axis=seq)   -- feeds the cache
+      Kt = present_key, or Transpose(present_key)          -- feeds QK^T
+      scores = MatMul(Q, Kt)
+
+    After:
+      R: initializer, float32 [head_dim, head_dim]   -- the fitted rotation
+      new_key_rotated = MatMul(new_key, R)
+      present_key = Concat(past_key, new_key_rotated, axis=seq)  -- Concat
+                    node itself unchanged; now carries rotated data for
+                    every token cached through this same (modified) graph
+      Q_rotated = MatMul(Q, R)
+      scores = MatMul(Q_rotated, Kt)     -- Kt still reads present_key
+                    exactly as before, now transparently rotated
+
+Exactness: for any orthogonal ``R`` (``R^T @ R == I``), rotating a
+tensor's own head-dim axis by ``R`` and then transposing it commutes with
+rotating the other, un-transposed operand of a dot product by that exact
+same ``R`` on its own head-dim axis --
+``(Q @ R) @ (X @ R)^T == (Q @ R) @ (R^T @ X^T) == Q @ (R @ R^T) @ X^T ==
+Q @ X^T`` -- so the migration is provably exact (up to floating-point
+rounding), the same "provably exact migration, then quantize" contract
+:mod:`onnxsim.spinquant`/:mod:`onnxsim.smoothquant`/:mod:`onnxsim.qoq`
+already use. This module only performs that migration -- it returns a
+float-equivalent model, no quantization happens here at all -- meant to
+run immediately before :func:`onnxsim.quantize_kv_cache` (Key-style, the
+default) in a pipeline, the same relationship
+:func:`onnxsim.apply_smooth_attention` already has with it:
+:func:`onnxsim.quantize_kv_cache` then quantizes the *rotated* Key stream,
+unaware anything changed -- this module never reimplements KV-cache
+quantization itself.
+
+A past-cache consistency note, shared with every other calibrated
+KV-cache technique in this repo: ``R`` is a single fixed constant baked
+into the graph, applied identically to *every* step's own freshly
+computed Key for as long as this modified graph is used for one
+generation -- so a genuinely empty starting cache (``seq_past == 0``) and
+a cache populated entirely by prior calls to this same modified graph both
+end up consistently rotated throughout. A cache spliced in from outside
+this modified graph (e.g. from an unrotated run) would not be, but that is
+already true of every other calibrated per-channel scale in
+:mod:`onnxsim.kv_cache_quantization`, not something new here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Union
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+
+from onnxsim import backend
+from onnxsim.attention_quantization import _find_attention_candidates
+from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.calibration import Tensors, generate_random_calibration_data
+from onnxsim.kv_cache_quantization import (
+    _find_kv_cache_candidates,
+    _is_value_style,
+    _KvCacheCandidate,
+)
+
+
+def _resolve_kt_source(
+    kt_name: str, producer_by_output: Dict[str, onnx.NodeProto]
+) -> str:
+    """Unwraps at most one ``Transpose`` hop: ``Kt = Transpose(X)`` (the
+    shape a KV-cache stream's own head-dim-last layout needs to become the
+    head-dim-second-to-last layout ``QK^T`` wants) resolves to ``X``.
+    Anything else -- no producer (a graph input/output), a non-Transpose
+    producer, or a multi-input node -- resolves to ``kt_name`` itself,
+    unchanged.
+    """
+    node = producer_by_output.get(kt_name)
+    if node is not None and node.op_type == "Transpose" and len(node.input) == 1:
+        return node.input[0]
+    return kt_name
+
+
+@dataclass
+class _RotateKvTarget:
+    kv_candidate: _KvCacheCandidate
+    q_name: str
+    qk_matmul: onnx.NodeProto
+
+
+def _find_rotatekv_targets(graph: onnx.GraphProto) -> List[_RotateKvTarget]:
+    kv_candidates = [
+        c
+        for c in _find_kv_cache_candidates(graph)
+        if not _is_value_style(c.present_name, None)
+    ]
+    if not kv_candidates:
+        return []
+
+    producer_by_output: Dict[str, onnx.NodeProto] = {}
+    for node in graph.node:
+        for out in node.output:
+            producer_by_output[out] = node
+
+    attention_candidates = []
+    seen = set()
+    for a in _find_attention_candidates(graph):
+        if id(a.qk_matmul) in seen:
+            continue
+        seen.add(id(a.qk_matmul))
+        attention_candidates.append(a)
+
+    kt_source_by_matmul = {
+        id(a.qk_matmul): _resolve_kt_source(a.qk_matmul.input[1], producer_by_output)
+        for a in attention_candidates
+    }
+
+    targets = []
+    for c in kv_candidates:
+        match = next(
+            (
+                a
+                for a in attention_candidates
+                if kt_source_by_matmul[id(a.qk_matmul)] == c.present_name
+            ),
+            None,
+        )
+        if match is None:
+            continue  # no attention consumer found -- can't compensate Query
+        targets.append(
+            _RotateKvTarget(
+                kv_candidate=c,
+                q_name=match.qk_matmul.input[0],
+                qk_matmul=match.qk_matmul,
+            )
+        )
+    return targets
+
+
+def apply_rotatekv(
+    model: Union[str, onnx.ModelProto],
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_samples: int = 8,
+    seed: int = 0,
+    providers: Optional[Sequence[str]] = None,
+) -> onnx.ModelProto:
+    """Applies RotateKV-style outlier-aware rotation preprocessing (a
+    closed-form per-stream rotation, fit from calibration data -- see this
+    module's own docstring) to every matched Key-style KV-cache stream
+    whose ``present_name`` also feeds some attention subgraph's ``QK^T``
+    MatMul (see the module docstring for the exact match).
+
+    :param model: the original (unquantized) onnx ModelProto or file path
+    :param calibration_data: representative input batches (each a
+            ``{input_name: np.ndarray}`` dict matching ``model``'s graph
+            inputs) used to fit each matched stream's own rotation from its
+            own freshly computed Key activation -- see
+            :func:`onnxsim.generate_random_calibration_data` (the default
+            when omitted) and
+            :func:`onnxsim.load_huggingface_calibration_data` (real data,
+            a more representative rotation fit than random input)
+    :param num_samples: random batches to generate when ``calibration_data``
+            is omitted
+    :param seed: seed for the random calibration data (ignored if
+            ``calibration_data`` is supplied)
+    :param providers: onnxruntime execution providers to calibrate on
+    :returns: ``model`` with every matched stream's fresh Key activation
+            and its compensating Query tensor each replaced by
+            ``MatMul(_, R)`` (the same fitted ``R`` for both -- see the
+            module docstring's exactness argument), feeding the original
+            Concat/QK^T nodes unchanged; a stream with no matching
+            attention consumer, or whose calibration activation never
+            appeared in any batch, is left untouched, as is the whole
+            model when no stream matches at all
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    graph = out.graph
+
+    targets = _find_rotatekv_targets(graph)
+    if not targets:
+        return out
+
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            model, num_samples=num_samples, seed=seed
+        )
+
+    probe_names = sorted({t.kv_candidate.new_name for t in targets})
+    probe_model = _add_probe_outputs(out, probe_names)
+
+    samples: Dict[str, List[np.ndarray]] = {name: [] for name in probe_names}
+    for batch in calibration_data:
+        result = backend.run_model(probe_model, batch, providers=providers)
+        for name in probe_names:
+            arr = np.asarray(result[name], dtype=np.float64)
+            if arr.ndim == 0:
+                continue
+            samples[name].append(arr.reshape(-1, arr.shape[-1]))
+
+    taken_names = _all_names(graph)
+
+    for t in targets:
+        c = t.kv_candidate
+        batches = samples.get(c.new_name, [])
+        if not batches:
+            continue  # this stream's activation never appeared in any batch
+        x = np.concatenate(batches, axis=0)
+        head_dim = x.shape[1]
+        if head_dim < 2:
+            continue  # nothing to rotate
+
+        # Closed-form, classical eigenvector-basis rotation -- see module
+        # docstring. eigh always returns an orthonormal basis for any real
+        # symmetric matrix, so this is exact and well-defined even for a
+        # rank-deficient (few-sample) covariance.
+        cov = x.T @ x / x.shape[0]  # [head_dim, head_dim]
+        _eigvals, r = np.linalg.eigh(cov)  # r: [head_dim, head_dim], orthogonal
+        r32 = r.astype(np.float32)
+
+        prefix = f"{c.present_name}_rotatekv"
+        r_name = _unique_name(f"{prefix}_r", taken_names)
+        graph.initializer.append(onnx.numpy_helper.from_array(r32, name=r_name))
+
+        new_key_rot_name = _unique_name(f"{c.new_name}_rotatekv", taken_names)
+        new_key_node = onnx.helper.make_node(
+            "MatMul",
+            [c.new_name, r_name],
+            [new_key_rot_name],
+            name=_unique_name(f"{prefix}_new_key_node", taken_names),
+        )
+
+        q_rot_name = _unique_name(f"{t.q_name}_rotatekv", taken_names)
+        q_node = onnx.helper.make_node(
+            "MatMul",
+            [t.q_name, r_name],
+            [q_rot_name],
+            name=_unique_name(f"{prefix}_q_node", taken_names),
+        )
+
+        if c.new_is_first_input:
+            c.concat_node.input[0] = new_key_rot_name
+        else:
+            c.concat_node.input[1] = new_key_rot_name
+        t.qk_matmul.input[0] = q_rot_name
+
+        concat_idx = next(i for i, n in enumerate(graph.node) if n is c.concat_node)
+        graph.node.insert(concat_idx, new_key_node)
+
+        qk_idx = next(i for i, n in enumerate(graph.node) if n is t.qk_matmul)
+        graph.node.insert(qk_idx, q_node)
+
+    return out

--- a/tests/test_rotatekv.py
+++ b/tests/test_rotatekv.py
@@ -1,0 +1,292 @@
+"""Tests for RotateKV (see ``onnxsim/rotatekv.py``): outlier-aware,
+per-stream rotation preprocessing for a decoder's KV-cache Key stream,
+meant to run before ``onnxsim.quantize_kv_cache``.
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(body, initializer=(), opset=18, ir_version=9):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _run(model, feeds, output_names=None):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    names = output_names or [o.name for o in sess.get_outputs()]
+    return dict(zip(names, sess.run(names, feeds)))
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
+
+
+def _attn_kv_cache_model(seq_past=3, seq_q=2, head_dim=8):
+    # new_key is deliberately routed through an Identity node rather than
+    # being a bare graph input -- same rationale as
+    # tests/test_kv_cache_quantization.py's own _kv_cache_model: a real
+    # exported decoder's "new" Key is always a freshly computed
+    # activation, never a raw model input. present_key both feeds the
+    # attention math directly (via one Transpose, to get head_dim into the
+    # second-to-last axis QK^T needs) and is a graph output, per
+    # onnxsim.kv_cache_quantization's own module docstring ("present_key
+    # -- graph output, and consumed by the attention math").
+    return _model(
+        f"""
+        g (float[{seq_past},{head_dim}] past_key,
+           float[1,{head_dim}] new_key_raw,
+           float[{seq_q},{head_dim}] Q,
+           float[{seq_past + 1},{head_dim}] V)
+          => (float[{seq_past + 1},{head_dim}] present_key,
+              float[{seq_q},{head_dim}] Out)
+        {{
+          new_key = Identity(new_key_raw)
+          present_key = Concat<axis = 0>(past_key, new_key)
+          Kt = Transpose(present_key)
+          scores = MatMul(Q, Kt)
+          probs = Softmax<axis = -1>(scores)
+          Out = MatMul(probs, V)
+        }}
+        """
+    )
+
+
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def _attn_kv_cache_model_dotted_name(seq_past=3, seq_q=2, head_dim=8):
+    # Mirrors _attn_kv_cache_model, but named to match this repo's own
+    # present.{i}.decoder.value-style convention (containing the literal
+    # substring ".value") -- onnx.parser's text format has no syntax for
+    # identifiers containing "." (see tests/test_kv_cache_quantization.py's
+    # own _vi docstring), so this one stays on
+    # onnx.helper.make_graph/make_model construction.
+    present_name = "present.0.value"
+    seq_present = seq_past + 1
+    nodes = [
+        onnx.helper.make_node("Identity", ["new_key_raw"], ["new_key"]),
+        onnx.helper.make_node(
+            "Concat", ["past_key", "new_key"], [present_name], axis=0
+        ),
+        onnx.helper.make_node("Transpose", [present_name], ["Kt"]),
+        onnx.helper.make_node("MatMul", ["Q", "Kt"], ["scores"]),
+        onnx.helper.make_node("Softmax", ["scores"], ["probs"], axis=-1),
+        onnx.helper.make_node("MatMul", ["probs", "V"], ["Out"]),
+    ]
+    graph = onnx.helper.make_graph(
+        nodes,
+        "g",
+        [
+            _vi("past_key", [seq_past, head_dim]),
+            _vi("new_key_raw", [1, head_dim]),
+            _vi("Q", [seq_q, head_dim]),
+            _vi("V", [seq_present, head_dim]),
+        ],
+        [_vi(present_name, [seq_present, head_dim]), _vi("Out", [seq_q, head_dim])],
+        [],
+    )
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 18)], ir_version=9
+    )
+
+
+def _calibration(seq_past=3, head_dim=8, num_samples=16, seed=0):
+    rng = np.random.default_rng(seed)
+    batches = []
+    for _ in range(num_samples):
+        batches.append(
+            {
+                "past_key": rng.standard_normal((seq_past, head_dim)).astype(
+                    np.float32
+                ),
+                "new_key_raw": rng.standard_normal((1, head_dim)).astype(np.float32),
+                "Q": rng.standard_normal((2, head_dim)).astype(np.float32),
+                "V": rng.standard_normal((seq_past + 1, head_dim)).astype(np.float32),
+            }
+        )
+    return batches
+
+
+def test_rotatekv_inserts_rotation_matmuls_with_orthogonal_r():
+    head_dim = 8
+    model = _attn_kv_cache_model(head_dim=head_dim)
+    calibration_data = _calibration(head_dim=head_dim)
+
+    rk_model = onnxsim.apply_rotatekv(model, calibration_data=calibration_data)
+    onnx.checker.check_model(rk_model)
+
+    op_types = [n.op_type for n in rk_model.graph.node]
+    # two new MatMul nodes (Key-side and Query-side rotation) on top of the
+    # two original MatMul nodes (QK^T and probs@V).
+    assert op_types.count("MatMul") == 4
+
+    concat_node = next(n for n in rk_model.graph.node if n.op_type == "Concat")
+    new_key_input = concat_node.input[1]
+    new_key_matmul = next(
+        n
+        for n in rk_model.graph.node
+        if n.op_type == "MatMul" and n.output[0] == new_key_input
+    )
+    r = onnx.numpy_helper.to_array(
+        next(t for t in rk_model.graph.initializer if t.name == new_key_matmul.input[1])
+    ).astype(np.float64)
+    assert r.shape == (head_dim, head_dim)
+    assert np.allclose(r.T @ r, np.eye(head_dim), atol=1e-4)
+
+    qk_matmul = next(
+        n
+        for n in rk_model.graph.node
+        if n.op_type == "MatMul" and n.output[0] == "scores"
+    )
+    assert qk_matmul.input[0] != "Q"
+    q_matmul = next(
+        n
+        for n in rk_model.graph.node
+        if n.op_type == "MatMul" and n.output[0] == qk_matmul.input[0]
+    )
+    assert q_matmul.input[0] == "Q"
+    # Same rotation reused for both Key and Query -- see module docstring's
+    # exactness argument.
+    assert q_matmul.input[1] == new_key_matmul.input[1]
+
+
+def test_rotatekv_exact_dot_product_identity():
+    # The algebraic claim this module's docstring makes directly:
+    # (Q @ R) @ (X @ R)^T == Q @ X^T for the fitted orthogonal R -- checked
+    # in plain numpy against the model's own written R, independent of
+    # onnxruntime, per this project's platform-numerics convention. Unlike
+    # a diagonal-scale migration (where the scale cancels algebraically
+    # regardless of its own rounding), this identity relies on R @ R.T
+    # actually equalling the identity matrix -- which only holds up to
+    # *R's own storage precision* (float32 here), not to float64 machine
+    # epsilon, so the tolerance is set accordingly rather than at 1e-9.
+    head_dim = 8
+    model = _attn_kv_cache_model(seq_past=0, head_dim=head_dim)
+    calibration_data = _calibration(seq_past=0, head_dim=head_dim, seed=1)
+
+    rk_model = onnxsim.apply_rotatekv(model, calibration_data=calibration_data)
+
+    r_init = next(t for t in rk_model.graph.initializer if "_rotatekv_r" in t.name)
+    r = onnx.numpy_helper.to_array(r_init).astype(np.float64)
+
+    feed = calibration_data[0]
+    q = feed["Q"].astype(np.float64)
+    new_key = feed["new_key_raw"].astype(np.float64)  # seq_past=0 -> present == new
+
+    original = q @ new_key.T
+    migrated = (q @ r) @ (new_key @ r).T
+    assert np.allclose(original, migrated, rtol=1e-6, atol=1e-6)
+
+
+def test_rotatekv_output_matches_float_via_onnxruntime():
+    # Loose, onnxruntime-based end-to-end sanity check -- kept separate
+    # from (and much looser than) the numpy-exact check above, per this
+    # project's platform-numerics convention (onnxruntime's own execution
+    # is not bit-exact across CPU architectures).
+    head_dim = 8
+    model = _attn_kv_cache_model(seq_past=0, head_dim=head_dim)
+    calibration_data = _calibration(seq_past=0, head_dim=head_dim, seed=2)
+
+    rk_model = onnxsim.apply_rotatekv(model, calibration_data=calibration_data)
+
+    feed = calibration_data[0]
+    float_out = _run(model, feed, output_names=["Out"])
+    rk_out = _run(rk_model, feed, output_names=["Out"])
+    assert np.all(np.isfinite(rk_out["Out"]))
+    assert _rel_l2(float_out["Out"], rk_out["Out"]) < 1e-2
+
+
+def test_rotatekv_then_quantize_kv_cache_reuses_existing_quantizer():
+    # This module's own contribution is only the rotation migration --
+    # verifies the intended pipeline usage, feeding the rotated model into
+    # onnxsim.quantize_kv_cache rather than reimplementing quantization.
+    head_dim = 8
+    model = _attn_kv_cache_model(head_dim=head_dim)
+    calibration_data = _calibration(head_dim=head_dim, seed=3)
+
+    rk_model = onnxsim.apply_rotatekv(model, calibration_data=calibration_data)
+    quantized = onnxsim.quantize_kv_cache(rk_model, calibration_data=calibration_data)
+    onnx.checker.check_model(quantized)
+
+    past_key_input = next(i for i in quantized.graph.input if i.name == "past_key")
+    assert past_key_input.type.tensor_type.elem_type == onnx.TensorProto.INT8
+    present_key_output = next(
+        o for o in quantized.graph.output if o.name == "present_key"
+    )
+    assert present_key_output.type.tensor_type.elem_type == onnx.TensorProto.INT8
+    # The Concat's own "new" operand should be the rotated Key, not the
+    # original -- i.e. quantize_kv_cache quantized RotateKV's own output.
+    concat_node = next(n for n in quantized.graph.node if n.op_type == "Concat")
+    assert "_rotatekv" in concat_node.input[1] or "_kv_q" in concat_node.input[1]
+
+
+def test_rotatekv_declines_stream_with_no_attention_consumer():
+    # A Key-style KV-cache stream whose present output is never consumed
+    # by any QK^T MatMul -- rotating it alone (with no way to compensate
+    # Query) would silently change attention scores, so this module
+    # declines rather than guess.
+    model = _model(
+        """
+        g (float[3,8] past_key, float[1,8] new_key_raw)
+          => (float[4,8] present_key, float summary)
+        {
+          new_key = Identity(new_key_raw)
+          present_key = Concat<axis = 0>(past_key, new_key)
+          summary = ReduceSum<keepdims = 0>(present_key)
+        }
+        """
+    )
+    result = onnxsim.apply_rotatekv(
+        model,
+        calibration_data=[
+            {
+                "past_key": np.zeros((3, 8), dtype=np.float32),
+                "new_key_raw": np.zeros((1, 8), dtype=np.float32),
+            }
+        ],
+    )
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_rotatekv_skips_value_style_stream():
+    model = _attn_kv_cache_model_dotted_name(head_dim=8)
+    calibration_data = _calibration(head_dim=8, seed=4)
+    result = onnxsim.apply_rotatekv(model, calibration_data=calibration_data)
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_rotatekv_noop_when_no_kv_cache_pattern():
+    model = _model(
+        """
+        g (float[4,4] X) => (float[4,4] Y)
+        {
+          Y = Relu(X)
+        }
+        """
+    )
+    result = onnxsim.apply_rotatekv(
+        model, calibration_data=[{"X": np.zeros((4, 4), dtype=np.float32)}]
+    )
+    assert result.SerializeToString() == model.SerializeToString()


### PR DESCRIPTION
## Summary

Adds RotateKV (Su, Wan, Zhu, Yang, Kang, Chen, Peng, Shao, He, Chen, Sui, Ma, Yang, 2025, "RotateKV: Accurate and Robust 2-Bit KV Cache Quantization for LLMs via Outlier-Aware Adaptive Rotations", https://arxiv.org/abs/2501.16383) as a new technique in `onnxsim/rotatekv.py` (`onnxsim.apply_rotatekv` + `tests/test_rotatekv.py`), following this repo's established one-module-per-paper convention.

Confirmed via a repo-wide grep before starting that RotateKV did not already exist under this or any other name.

## What's added / scope

`onnxsim.apply_rotatekv`'s own distinguishing mechanism is a **rotation**, not a scale, which is what separates it from its two nearest siblings already in this repo:

- `onnxsim.kv_cache_quantization` (KIVI/KVQuant) quantizes Key per channel, static/calibrated, but never touches the values themselves before quantizing — a shared per-channel scale still has to cover whatever range an outlier channel shows.
- `onnxsim.qoq`'s `apply_smooth_attention` (QServe's SmoothAttention) already migrates Key's outlier-channel difficulty into Query, but only via a **diagonal scale** (`K_j /= s_j`, `Q_j *= s_j`) — channel-preserving, it can shrink an outlier channel's magnitude but never redistribute *which* channels the outlier mass lands on.

RotateKV instead conjugates Key (and compensates Query) by an **orthogonal rotation**, the same "rotate to spread outlier mass" idea `onnxsim.spinquant`/`onnxsim.quip_sharp` already use for weights, applied here to the KV-cache activation stream itself. Per the paper's own title, the rotation is fit **adaptively per structural unit** (here: per matched KV-cache stream) from that unit's own calibration statistics — this module's closed-form substitute for the paper's own more elaborate outlier-aware optimization is the same stand-in `onnxsim.spinquant` already uses elsewhere in this repo: the eigenvector basis of the calibration activation's own covariance (`numpy.linalg.eigh`).

**Scope/simplification** (documented in the module's own docstring, the same way `onnxsim.billm`'s docstring documents its own scoped-down simplification): the paper fits one rotation per attention head, which needs splitting a fused/flat QKV projection's output channels into per-head blocks — out of scope for an arbitrary ONNX graph with unknown `num_heads`. Instead, this module fits and applies one rotation per matched KV-cache stream (`onnxsim.kv_cache_quantization`'s own `Concat(past, new, axis=seq)` pattern), matched together with the corresponding `QK^T` attention subgraph (`onnxsim.attention_quantization`'s own decomposed-attention matcher) so Query can be exactly compensated — this is "one rotation per head" whenever a graph already keeps each head's Key stream as its own Concat, and is otherwise still a sound, exact, "one rotation per matched Key tensor" contribution on its own. A KV-cache stream with no matching attention consumer (no way to compensate Query) is left untouched rather than guessed at.

The rotation is applied to the fresh Key activation feeding `Concat(past, new)` and to the compensating Query tensor at the matching `QK^T` MatMul via two new `MatMul` nodes — `(Q @ R) @ (new_key @ R)^T == Q @ new_key^T` for orthogonal `R`, a provably exact migration (up to floating-point rounding), the same contract `onnxsim.spinquant`/`onnxsim.smoothquant`/`onnxsim.qoq` already use. This module performs only that migration; `onnxsim.quantize_kv_cache` is meant to run immediately afterward to actually quantize the now-rotated Key stream — reused directly, not reimplemented.

Registered in `onnxsim/__init__.py` (import + `__all__`), placed next to `apply_spinquant`.

## Test plan

All commands run in this session against the built wheel (`pip install -e . --no-build-isolation`, after initializing git submodules recursively — `git submodule update --init --recursive`, since the nested `third_party/onnx-optimizer/third_party/onnx` submodule was not checked out in this container).

- `pytest tests/test_rotatekv.py -v` → **7 passed** (rotation nodes inserted with an orthogonal `R`; exact dot-product identity checked directly against the model's own `R` initializer via numpy at float32-appropriate tolerance, per this project's platform-numerics convention; loose onnxruntime end-to-end sanity check; the `apply_rotatekv` → `quantize_kv_cache` pipeline reuse; decline-don't-guess when a KV-cache stream has no attention consumer; Value-style streams skipped; no-op with no KV-cache pattern at all).
- `pytest tests/test_kv_cache_quantization.py tests/test_qoq.py tests/test_spinquant.py -q` → **32 passed** (no regression in neighboring modules).
- `pytest tests/ -q` (excluding `test_gan.py`/`test_python_api.py`/`test_simple.py`/`test_timm.py`/`test_torch_export_integration.py`, which fail to even *collect* in this container because optional `torch`/`timm` aren't installed — unrelated to this change) → **2312 passed, 98 skipped**, no failures.
- `ruff check` / `ruff format --check` on `onnxsim/rotatekv.py`, `onnxsim/__init__.py`, `tests/test_rotatekv.py` → all clean.
- `mypy` (whole `onnxsim` package, per `pyproject.toml`'s `files = ["onnxsim"]`) → **no issues found in 73 source files** (same as before this change — baseline error count not increased).

Per this repo's own platform-numerics lesson, the exactness test decodes the `R` initializer directly via numpy and compares against the model's own Q/Key calibration arrays at a tolerance reflecting `R`'s own float32 storage precision (not float64 machine epsilon — `R @ R.T` is only exactly the identity up to how precisely `R` itself is stored), rather than round-tripping through onnxruntime with an absolute tolerance; the onnxruntime-based check is kept as a separate, much looser end-to-end relative-L2 sanity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JrgAzH2MnedYgAzANNpfH

---
_Generated by [Claude Code](https://claude.ai/code/session_018JrgAzH2MnedYgAzANNpfH)_