### PR TITLE
Add in-place/alias-aware placement to the activation memory planner

### DIFF
--- a/docs/activation-memory-planning.md
+++ b/docs/activation-memory-planning.md
@@ -53,8 +53,36 @@ Two intervals are only ever placed at overlapping offsets when they are
 **not** simultaneously live — and the overlap check is conservative at
 interval boundaries: a tensor whose last use is node `i` and one produced by
 node `i` itself still count as overlapping, since a node's own output isn't
-generally safe to alias with its inputs' storage (only true in-place ops
-allow that, and this allocator has no notion of which ops are in-place-safe).
+generally safe to alias with its inputs' storage in general. That's exactly
+the exception the next pass carves out, explicitly, for the ops it's actually
+safe for.
+
+## In-place aliasing
+
+Before the two passes above run, a separate pass unions a safe elementwise
+op's input with its output whenever overwriting the input in place is
+provably correct:
+
+- the op is on a curated allowlist of shape-/dtype-preserving elementwise ops
+  (`Relu`, `Sigmoid`, `Tanh`, `Neg`, `Identity`, `Clip`, ... — see
+  `IsInPlaceSafeOp` in `onnxsim/memory_planning.cpp` for the exact list);
+- the input isn't a weight, a graph input, or a declared graph output (an
+  externally-owned buffer, or one the caller only reads after the whole
+  graph finishes — overwriting either mid-run would be observed as
+  corruption, not reused space);
+- the input is consumed exactly once, by this node — the only read of the
+  original value, so overwriting it can't corrupt some other node's read.
+
+A chain of such ops (`Relu -> Sigmoid -> Tanh -> ...`) unions transitively
+into one group that needs a single slot for its *entire* span, rather than
+one slot per node — so a long elementwise chain's arena stays roughly
+constant instead of growing with its length, even though `naive_bytes` still
+grows with every tensor in it. Aliased tensors report the **identical**
+`(offset, size)` in `tensor_offsets` on purpose: unlike two disjoint-interval
+tensors (which merely may reuse each other's freed space), they're the same
+logical storage. Honoring that part of the plan means actually running that
+node's kernel in place — writing its output over the input's own buffer —
+not just treating a repeated offset as "safe to reuse afterward."
 
 ## What's in `MemoryPlan`
 

--- a/onnxsim/memory_planning.cpp
+++ b/onnxsim/memory_planning.cpp
@@ -19,11 +19,64 @@ struct Interval {
 // offset space. Conservative at the boundary: a tensor whose last use is node
 // i and one produced by node i itself still count as overlapping (`a.end ==
 // b.start` is not `<`), since a node's own output is not guaranteed safe to
-// alias with its inputs' storage in general (only true in-place ops allow
-// that, and this allocator has no notion of which ops are in-place-safe).
+// alias with its inputs' storage in general -- that exception is handled
+// separately and explicitly by the in-place-aliasing pass below, for the
+// specific ops it is actually safe for.
 bool Disjoint(const Interval& a, const Interval& b) {
   return a.end < b.start || b.end < a.start;
 }
+
+// Ops whose ONNX semantics guarantee a single output that is strictly
+// shape- and dtype-identical to their first input, computed purely
+// elementwise (output[i] depends only on input[i]) -- so an executor can
+// always compute the output by overwriting the input's own storage in
+// place, with no numerical difference from writing to a separate buffer.
+// This is a curated allowlist, not a schema query (nothing here parses
+// attributes or checks the actual input/output types), so it deliberately
+// excludes anything with an exception -- e.g. not "Reshape", which changes
+// rank/strides even though its byte size matches, and whose output some
+// executors treat as view metadata rather than a copy.
+bool IsInPlaceSafeOp(const std::string& op_type) {
+  static const std::set<std::string> kSafeOps = {
+      "Relu",     "Sigmoid",  "Tanh",        "LeakyRelu",  "Elu",      "Selu",
+      "Softplus", "Softsign", "HardSigmoid", "Clip",       "Neg",      "Abs",
+      "Sqrt",     "Exp",      "Log",         "Reciprocal", "Identity", "Erf",
+      "Celu",     "Round",    "Ceil",        "Floor",      "Sign",
+  };
+  return kSafeOps.count(op_type) > 0;
+}
+
+// Union-find (disjoint-set) over tensor names, path-compressed, used to
+// coalesce a chain of in-place-eligible ops (e.g. Relu -> Sigmoid -> Tanh)
+// into one placement group that needs a single slot for its whole span
+// rather than one slot per tensor. Passes/returns names by value (plain
+// std::string copies) rather than references into `parent_`, since Find()
+// mutates that same map recursively -- returning a reference into a std::map
+// entry that a nested call may go on to overwrite is the kind of aliasing
+// hazard worth just not risking for a data structure this small.
+class UnionFind {
+ public:
+  std::string Find(const std::string& name) {
+    auto it = parent_.find(name);
+    if (it == parent_.end()) {
+      parent_[name] = name;
+      return name;
+    }
+    if (it->second == name) return name;
+    const std::string root = Find(it->second);
+    parent_[name] = root;  // path compression
+    return root;
+  }
+
+  void Union(const std::string& a, const std::string& b) {
+    const std::string ra = Find(a);
+    const std::string rb = Find(b);
+    if (ra != rb) parent_[ra] = rb;
+  }
+
+ private:
+  std::map<std::string, std::string> parent_;
+};
 
 }  // namespace
 
@@ -32,6 +85,10 @@ MemoryPlan ComputeActivationMemoryPlan(const GraphView& graph) {
 
   const std::set<std::string> weights(graph.initializers.begin(),
                                       graph.initializers.end());
+  const std::set<std::string> graph_inputs(graph.inputs.begin(),
+                                           graph.inputs.end());
+  const std::set<std::string> graph_outputs(graph.outputs.begin(),
+                                            graph.outputs.end());
 
   // Last node index consuming each tensor; a graph output is "consumed" at
   // `end` so it stays live through the whole pass -- the same liveness
@@ -59,12 +116,71 @@ MemoryPlan ComputeActivationMemoryPlan(const GraphView& graph) {
     }
   }
 
-  // Pass 1: one Interval per plannable tensor (known concrete size);
-  // everything else goes to `unplanned`. An unconsumed intermediate (no
-  // `last_use` entry, not a graph output) defaults to staying live through
-  // `end` -- the same "never freed" fallback the live-set walk behind
-  // PeakMemoryFootprint implicitly applies to it.
-  std::vector<Interval> intervals;
+  // How many (node, input-slot) pairs consume each tensor across the whole
+  // graph -- the in-place-aliasing pass below only aliases a tensor whose
+  // sole consumer is the one candidate node, so overwriting it can never
+  // corrupt a read some other node still needs.
+  std::map<std::string, int> consumer_count;
+  for (const NodeView& node : graph.nodes) {
+    for (const std::string& name : node.inputs) {
+      if (!name.empty()) ++consumer_count[name];
+    }
+  }
+
+  // In-place aliasing: union a safe unary op's input[0] with its output[0]
+  // (see IsInPlaceSafeOp) whenever doing so is provably safe --
+  //   * not a weight, a graph input, or a declared graph output (an
+  //     externally-owned buffer, or one the caller reads only after the
+  //     whole graph finishes, so overwriting it mid-run would be observed
+  //     as corruption rather than reused space);
+  //   * consumed exactly once, by this node -- the only read of the
+  //     original value;
+  //   * input and output agree on size (always true for these ops on a
+  //     well-formed model; checked anyway as a defensive belt-and-braces).
+  // A chain of such ops unions transitively into one group -- Find() on any
+  // member returns the same root -- that needs only a single slot for its
+  // entire span, rather than one slot per node.
+  UnionFind uf;
+  for (const NodeView& node : graph.nodes) {
+    if (!IsInPlaceSafeOp(node.op_type)) continue;
+    if (node.inputs.empty() || node.outputs.size() != 1) continue;
+    const std::string& in0 = node.inputs[0];
+    const std::string& out0 = node.outputs[0];
+    if (in0.empty() || out0.empty()) continue;
+    if (weights.count(in0) || graph_inputs.count(in0) ||
+        graph_outputs.count(in0)) {
+      continue;
+    }
+    const auto cit = consumer_count.find(in0);
+    if (cit == consumer_count.end() || cit->second != 1) continue;
+
+    const auto in_bytes = TensorBytes(in0, graph.shapes, graph.dtypes);
+    const auto out_bytes = TensorBytes(out0, graph.shapes, graph.dtypes);
+    if (!in_bytes || !out_bytes || in_bytes->is_symbolic() ||
+        out_bytes->is_symbolic()) {
+      continue;
+    }
+    if (in_bytes->to_int() != out_bytes->to_int()) continue;
+
+    uf.Union(in0, out0);
+  }
+
+  // Pass 1: one Interval per plannable *group* -- a group is a single
+  // tensor, or several coalesced by the aliasing pass above -- with
+  // everything unplannable going to `unplanned`. An unconsumed intermediate
+  // (no `last_use` entry, not a graph output) defaults to staying live
+  // through `end`, the same "never freed" fallback the live-set walk behind
+  // PeakMemoryFootprint implicitly applies to it. `naive_bytes` is summed
+  // per tensor regardless of grouping: it is the no-optimization-at-all
+  // baseline, not affected by how well this planner happens to pack things.
+  struct GroupSpan {
+    int64_t size = 0;
+    int start = 0;
+    int end = 0;
+    bool seen = false;
+  };
+  std::map<std::string, GroupSpan> groups;  // keyed by union-find root
+
   for (const auto& [name, start] : produced_at) {
     const auto bytes = TensorBytes(name, graph.shapes, graph.dtypes);
     if (!bytes || bytes->is_symbolic()) {
@@ -72,18 +188,33 @@ MemoryPlan ComputeActivationMemoryPlan(const GraphView& graph) {
       continue;
     }
     const auto it = last_use.find(name);
-    intervals.push_back({name, bytes->to_int(), start,
-                         it == last_use.end() ? end : it->second});
+    const int last = it == last_use.end() ? end : it->second;
     plan.naive_bytes += bytes->to_int();
+
+    GroupSpan& g = groups[uf.Find(name)];
+    if (!g.seen) {
+      g = {bytes->to_int(), start, last, true};
+    } else {
+      g.start = std::min(g.start, start);
+      g.end = std::max(g.end, last);
+      g.size = std::max(g.size, bytes->to_int());
+    }
   }
 
-  // Pass 2: greedy best-fit placement, largest tensor first (ties broken by
-  // name for determinism) -- the standard linear-scan/greedy-by-size register
-  // allocation heuristic, which is what makes this "fragmentation-aware"
-  // rather than a naive bump allocator. For each tensor, gather the offset
-  // ranges of every already-placed tensor whose liveness overlaps it (the
-  // ranges it must avoid), then take the smallest gap between/around them
-  // that fits, falling back to appending after the last blocker.
+  std::vector<Interval> intervals;
+  intervals.reserve(groups.size());
+  for (const auto& [root, g] : groups) {
+    intervals.push_back({root, g.size, g.start, g.end});
+  }
+
+  // Pass 2: greedy best-fit placement, largest group first (ties broken by
+  // root name for determinism) -- the standard linear-scan/greedy-by-size
+  // register allocation heuristic, which is what makes this
+  // "fragmentation-aware" rather than a naive bump allocator. For each
+  // group, gather the offset ranges of every already-placed group whose
+  // liveness overlaps it (the ranges it must avoid), then take the smallest
+  // gap between/around them that fits, falling back to appending after the
+  // last blocker.
   std::sort(intervals.begin(), intervals.end(),
             [](const Interval& a, const Interval& b) {
               if (a.size != b.size) return a.size > b.size;
@@ -93,6 +224,7 @@ MemoryPlan ComputeActivationMemoryPlan(const GraphView& graph) {
   std::vector<Interval> placed;
   std::vector<std::pair<int64_t, int64_t>>
       placed_ranges;  // parallel: [off, off+size)
+  std::map<std::string, std::pair<int64_t, int64_t>> group_offsets;
 
   for (const Interval& iv : intervals) {
     std::vector<std::pair<int64_t, int64_t>> blocking;
@@ -115,10 +247,19 @@ MemoryPlan ComputeActivationMemoryPlan(const GraphView& graph) {
     if (best_offset < 0)
       best_offset = cursor;  // no gap fit; append after every blocker
 
-    plan.offsets[iv.name] = {best_offset, iv.size};
+    group_offsets[iv.name] = {best_offset, iv.size};
     placed.push_back(iv);
     placed_ranges.push_back({best_offset, best_offset + iv.size});
     plan.arena_bytes = std::max(plan.arena_bytes, best_offset + iv.size);
+  }
+
+  // Expand each group's single placement to every tensor that was coalesced
+  // into it -- an aliased tensor and the value(s) it shares storage with all
+  // report the identical (offset, size).
+  for (const auto& [name, start] : produced_at) {
+    (void)start;
+    const auto it = group_offsets.find(uf.Find(name));
+    if (it != group_offsets.end()) plan.offsets[name] = it->second;
   }
 
   return plan;

--- a/onnxsim/memory_planning.h
+++ b/onnxsim/memory_planning.h
@@ -25,6 +25,21 @@
 // <= `naive_bytes` (every tensor given its own permanent slot, i.e. no reuse
 // at all -- the baseline "compression ratio" is measured against).
 //
+// On top of that liveness-only reuse, an in-place-aliasing pass (see
+// IsInPlaceSafeOp in memory_planning.cpp) unions a safe elementwise op's
+// input with its output whenever overwriting the input in place is provably
+// correct -- the input is not a weight/graph input/graph output, and this
+// node is its only consumer. A chain of such ops (e.g. Relu -> Sigmoid ->
+// Tanh) all collapse into one placement group needing a single slot for the
+// whole chain's span, rather than one slot per node, so the arena for a long
+// elementwise chain stays roughly constant instead of growing with its
+// length; TestInPlaceAliasingCollapsesWholeChain in memory_planning_test.cpp
+// demonstrates this directly. Aliased tensors report the identical
+// (offset, size) in `offsets` -- a downstream consumer honours the plan by
+// actually running that node's kernel in place (writing its output over the
+// input's own buffer), not merely by treating same-offset as "safe to reuse
+// after the fact" the way two disjoint-interval tensors are.
+//
 // v1 scope, deliberately:
 //   * Concrete shapes only. A tensor whose size cannot be resolved to a
 //     concrete (non-symbolic) byte count -- unknown shape/dtype, or a
@@ -44,7 +59,10 @@ struct MemoryPlan {
   // name -> (offset, size in bytes) within the shared arena, one entry per
   // planned tensor (graph inputs, node outputs, graph outputs with a
   // concrete size). Two entries' [offset, offset + size) ranges only overlap
-  // when their liveness intervals do not.
+  // when their liveness intervals do not -- except a set of tensors the
+  // in-place-aliasing pass unioned together (see the module comment above),
+  // which report the identical (offset, size) on purpose: they are the same
+  // logical storage, not merely two tensors sharing recycled space.
   std::map<std::string, std::pair<int64_t, int64_t>> offsets;
   // Size of the arena this plan requires: the high-water mark of every
   // offset + size above. 0 when there is nothing to plan.

--- a/onnxsim/memory_planning_test.cpp
+++ b/onnxsim/memory_planning_test.cpp
@@ -53,14 +53,16 @@ void TestSingleNodeNoReuse() {
 }
 
 // A 3-node Relu chain x -> a -> b -> y (graph output), all tensors the same
-// size S=100 bytes. Every tensor overlaps only its immediate neighbor in the
-// chain (produced by the node that consumes the previous one), so
-// non-adjacent tensors (x/b, x/y, a/y) are free to share offsets while
-// adjacent ones (x/a, a/b, b/y) may not -- worked out by hand in the PR
-// description: greedy best-fit (processed in name order a, b, x, y, since
-// all four are the same size) lands on arena_bytes == 200 (half of the 400
-// a naive "one slot per tensor" allocation would need), with a and y sharing
-// offset 0 and b and x sharing offset 100.
+// size S=100 bytes. Relu is in-place-safe (see IsInPlaceSafeOp), so a and b
+// are each the sole input of the next Relu and neither is a weight/graph
+// input/graph output -- they union into one group with y (Relu(b) -> y
+// unions b into y too). x stays its own group: it is a graph input, which
+// the aliasing pass never overwrites. The two groups still overlap at the
+// x/a boundary under the same-node-boundary conservative rule, so they still
+// need separate slots -- arena_bytes is unchanged at 200 (half of the 400 a
+// naive "one slot per tensor" allocation would need) -- but now via one
+// slot for x and one *shared* slot for {a, b, y}, rather than the
+// non-aliased packing's two independently-reused slots.
 void TestChainReuse() {
   GraphView g;
   for (const char* n : {"x", "a", "b", "y"}) {
@@ -83,19 +85,92 @@ void TestChainReuse() {
   const MemoryPlan plan = ComputeActivationMemoryPlan(g);
   assert(plan.unplanned.empty());
   assert(plan.naive_bytes == 400);
-  assert(plan.arena_bytes == 200);  // 2x compression from reuse
+  assert(plan.arena_bytes == 200);  // 2x compression, now via aliasing
 
   const auto& off = plan.offsets;
-  assert(off.at("a").first == 0);
-  assert(off.at("y").first == 0);  // shares a's freed slot
-  assert(off.at("b").first == 100);
-  assert(off.at("x").first == 100);  // shares b's (later-claimed) slot
+  assert(off.at("x").first != off.at("a").first);  // still can't share with x
+  assert(off.at("a") == off.at("b"));  // a, b, y are literally one group now
+  assert(off.at("b") == off.at("y"));
+}
 
-  // No two simultaneously-live tensors may share an offset range: check the
-  // three adjacent (overlapping) pairs landed at different offsets.
+// A pure elementwise chain with no graph-input/output boundary in the
+// middle -- x -> Relu -> a -> Sigmoid -> b -> Tanh -> c -> Neg -> d ->
+// Identity -> out -- unions a, b, c, d and out into a single group (each is
+// the sole consumer of the previous value, and none is a weight/graph
+// input/graph output), leaving only x (a graph input, never aliased) in a
+// group of its own. So the arena is exactly 2 slots regardless of how long
+// the chain is, while naive_bytes keeps growing with every tensor -- the
+// asymptotic case aliasing is for, versus TestChainReuse's short chain where
+// disjoint-interval reuse alone already got to the same arena size.
+void TestInPlaceAliasingCollapsesWholeChain() {
+  GraphView g;
+  for (const char* n : {"x", "a", "b", "c", "d", "out"}) {
+    g.shapes[n] = {SymExpr(25)};
+    g.dtypes[n] = 4;  // 100 bytes each
+  }
+  g.inputs = {"x"};
+  g.outputs = {"out"};
+
+  NodeView relu, sigmoid, tanh, neg, identity;
+  relu.op_type = "Relu";
+  relu.inputs = {"x"};
+  relu.outputs = {"a"};
+  sigmoid.op_type = "Sigmoid";
+  sigmoid.inputs = {"a"};
+  sigmoid.outputs = {"b"};
+  tanh.op_type = "Tanh";
+  tanh.inputs = {"b"};
+  tanh.outputs = {"c"};
+  neg.op_type = "Neg";
+  neg.inputs = {"c"};
+  neg.outputs = {"d"};
+  identity.op_type = "Identity";
+  identity.inputs = {"d"};
+  identity.outputs = {"out"};
+  g.nodes = {relu, sigmoid, tanh, neg, identity};
+
+  const MemoryPlan plan = ComputeActivationMemoryPlan(g);
+  assert(plan.unplanned.empty());
+  assert(plan.naive_bytes == 600);  // 6 tensors x 100 bytes, no reuse credit
+  assert(plan.arena_bytes == 200);  // just x's slot + one shared slot
+
+  const auto& off = plan.offsets;
   assert(off.at("x").first != off.at("a").first);
-  assert(off.at("a").first != off.at("b").first);
-  assert(off.at("b").first != off.at("y").first);
+  assert(off.at("a") == off.at("b"));
+  assert(off.at("b") == off.at("c"));
+  assert(off.at("c") == off.at("d"));
+  assert(off.at("d") == off.at("out"));
+}
+
+// `a` feeds two separate in-place-eligible ops (Neg -> y1, Sigmoid -> y2).
+// Without the "sole consumer" guard in the aliasing pass, both would try to
+// alias `a` away, incorrectly merging y1 and y2 into the same slot despite
+// both being live simultaneously (both are graph outputs, live through the
+// end) -- corrupting whichever one a real executor computed second.
+void TestInPlaceAliasingBlockedByMultipleConsumers() {
+  GraphView g;
+  for (const char* n : {"x", "a", "y1", "y2"}) {
+    g.shapes[n] = {SymExpr(4)};
+    g.dtypes[n] = 4;  // 16 bytes each
+  }
+  g.inputs = {"x"};
+  g.outputs = {"y1", "y2"};
+
+  NodeView relu, neg, sigmoid;
+  relu.op_type = "Relu";
+  relu.inputs = {"x"};
+  relu.outputs = {"a"};
+  neg.op_type = "Neg";
+  neg.inputs = {"a"};
+  neg.outputs = {"y1"};
+  sigmoid.op_type = "Sigmoid";
+  sigmoid.inputs = {"a"};
+  sigmoid.outputs = {"y2"};
+  g.nodes = {relu, neg, sigmoid};
+
+  const MemoryPlan plan = ComputeActivationMemoryPlan(g);
+  assert(plan.unplanned.empty());
+  assert(plan.offsets.at("y1").first != plan.offsets.at("y2").first);
 }
 
 // A tensor with a symbolic (dynamic) dimension has no concrete byte size, so
@@ -126,6 +201,8 @@ void TestSymbolicShapeUnplanned() {
 int main() {
   TestSingleNodeNoReuse();
   TestChainReuse();
+  TestInPlaceAliasingCollapsesWholeChain();
+  TestInPlaceAliasingBlockedByMultipleConsumers();
   TestSymbolicShapeUnplanned();
   std::cout << "all memory_planning tests passed\n";
   return 0;

--- a/tests/test_memory_planning.py
+++ b/tests/test_memory_planning.py
@@ -2,10 +2,7 @@
 
 Every model is built via ``onnx.parser.parse_model`` (the ONNX text format).
 The chain-reuse expectations mirror ``onnxsim/memory_planning_test.cpp``'s
-``TestChainReuse``, worked out by hand there: with four equally-sized tensors
-in a linear chain, only immediate neighbors are simultaneously live, so a
-greedy best-fit allocator (processed largest-first, ties broken by name) can
-pack the whole chain into half the naive (no-reuse) size.
+corresponding C++ tests, worked out by hand there.
 """
 
 import numpy as np
@@ -44,10 +41,12 @@ def _metadata(proto):
 
 
 def test_chain_reuse():
-    # x -> a -> b -> y, each [25] float32 = 100 bytes; only immediate
-    # neighbors overlap in liveness, so half the tensors can share offsets
-    # with a non-adjacent one -- see memory_planning_test.cpp's TestChainReuse
-    # for the interval math.
+    # x -> a -> b -> y, each [25] float32 = 100 bytes. Relu is in-place-safe
+    # (see IsInPlaceSafeOp), and a/b are each the sole input of the next
+    # Relu, so a, b and y union into one group; x stays separate (a graph
+    # input is never aliased away) -- see memory_planning_test.cpp's
+    # TestChainReuse for the derivation. Net effect: 2x compression as
+    # before, now via one shared slot for {a, b, y} plus x's own slot.
     body = """
     g (float[25] x) => (float[25] y)
     {
@@ -64,10 +63,57 @@ def test_chain_reuse():
     assert plan.compression_ratio == 0.5
 
     off = plan.tensor_offsets
-    assert off["a"][0] == off["y"][0]  # a and y share a freed slot
-    assert off["b"][0] == off["x"][0]  # b and x share a freed slot
-    assert off["a"][0] != off["b"][0]  # but adjacent (overlapping) pairs differ
+    assert off["a"] == off["b"] == off["y"]  # literally one group now
+    assert off["x"][0] != off["a"][0]  # still can't share with x
     assert off["x"][1] == off["a"][1] == off["b"][1] == off["y"][1] == 100
+
+
+def test_in_place_aliasing_collapses_whole_chain():
+    # A pure elementwise chain with no graph-input/output boundary in the
+    # middle: x -> Relu -> a -> Sigmoid -> b -> Tanh -> c -> Neg -> d ->
+    # Identity -> out. Every internal tensor is the sole consumer of the
+    # previous one, so a/b/c/d/out all union into a single group; only x (a
+    # graph input) stays separate. The arena is 2 slots regardless of chain
+    # length, while naive_bytes keeps growing -- see
+    # memory_planning_test.cpp's TestInPlaceAliasingCollapsesWholeChain.
+    body = """
+    g (float[25] x) => (float[25] out)
+    {
+      a = Relu(x)
+      b = Sigmoid(a)
+      c = Tanh(b)
+      d = Neg(c)
+      out = Identity(d)
+    }
+    """
+    plan = plan_activation_memory(_model(body))
+
+    assert plan.unplanned == []
+    assert plan.naive_bytes == 600  # 6 tensors x 100 bytes
+    assert plan.arena_bytes == 200  # x's slot + one shared slot
+
+    off = plan.tensor_offsets
+    assert off["x"][0] != off["a"][0]
+    assert off["a"] == off["b"] == off["c"] == off["d"] == off["out"]
+
+
+def test_in_place_aliasing_blocked_by_multiple_consumers():
+    # `a` feeds two separate in-place-eligible ops (Neg -> y1, Sigmoid ->
+    # y2). Without the "sole consumer" guard, both would try to alias `a`
+    # away, incorrectly merging y1 and y2 -- which are both graph outputs,
+    # both live simultaneously -- into the same slot.
+    body = """
+    g (float[4] x) => (float[4] y1, float[4] y2)
+    {
+      a = Relu(x)
+      y1 = Neg(a)
+      y2 = Sigmoid(a)
+    }
+    """
+    plan = plan_activation_memory(_model(body))
+
+    assert plan.unplanned == []
+    assert plan.tensor_offsets["y1"][0] != plan.tensor_offsets["y2"][0]
 
 
 def test_weights_excluded_and_no_reuse_when_overlapping():


### PR DESCRIPTION
## Summary

Follow-up to `plan_activation_memory` / `annotate_memory_plan` (merged in #1063): adds a second, complementary placement technique to the greedy best-fit activation memory allocator — in-place/alias-aware placement, the same family of technique real NN memory planners (MXNet, XLA/TVM) use alongside plain liveness-based reuse.

## What changed

- **`onnxsim/memory_planning.cpp`**: before the existing liveness pass runs, a new pass unions a safe elementwise op's input with its output into one placement group whenever it's provably correct to compute the output by overwriting the input in place:
  - the op is on a curated allowlist of shape-/dtype-preserving elementwise ops (`Relu`, `Sigmoid`, `Tanh`, `Neg`, `Identity`, `Clip`, ... — see `IsInPlaceSafeOp`);
  - the input is not a weight, a graph input, or a declared graph output (external/read-after-the-run buffers must never be overwritten mid-run);
  - the input is consumed exactly once, by this node — the only read of the original value, so overwriting it can't corrupt some other node's read.

  A chain of such ops (`Relu -> Sigmoid -> Tanh -> ...`) unions transitively into one group via a small union-find, so a long elementwise chain's arena stays roughly constant instead of growing with its length — `TestInPlaceAliasingCollapsesWholeChain` demonstrates this directly (6 tensors, `naive_bytes=600`, `arena_bytes` stays at 200).

- Aliased tensors report the **identical** `(offset, size)` in `tensor_offsets`: unlike two disjoint-interval tensors (which merely *may* reuse each other's freed space), they're the same logical storage. Honoring that part of the plan means actually running that node's kernel in place, not just treating a repeated offset as "safe to reuse afterward." Documented as such in `memory_planning.h` and `docs/activation-memory-planning.md`.

- Existing tests updated for the new (still-correct, sometimes better) offsets this produces on graphs that happen to contain safe unary chains (`TestChainReuse` / `test_chain_reuse`); new tests cover the full-chain-collapse case and the multi-consumer guard specifically — without that guard, two ops reading the same value would incorrectly alias two simultaneously-live outputs into the same slot.

## Test plan

- [x] Standalone C++ test (`g++ ... memory_planning_test.cpp && ./a.out`) — all pass, including the new `TestInPlaceAliasingCollapsesWholeChain` and `TestInPlaceAliasingBlockedByMultipleConsumers`.
- [x] `pytest tests/test_memory_planning.py` — 13 passed.
- [x] Full suite sweep — 358 passed; only pre-existing, unrelated failures remain (3 fusion-pattern tests, 6 `ppq`-compat tests needing an uninstalled `ppq` package — both confirmed pre-existing on `master`, not caused by this change).
- [x] `ruff format --check` / `ruff check` — clean.
- [x] `mypy` — same 23 pre-existing errors as `master`, zero new.
- [x] `clang-format --dry-run --Werror` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UFQG9xTf4YexUPryTjccoH

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFQG9xTf4YexUPryTjccoH)_