### PR TITLE
Wire decomposed GQA/attention chains into Wanda pruning and dry-run report

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -19071,34 +19071,36 @@ class _GQAChain:
 # separate-Q/K/V-producer shape and whole-KV-group pruning unit are
 # identical to `GroupQueryAttention`'s own.
 #
-# The original two-member alias, kept under its own name for
-# :func:`_attention_not_eligible`/:func:`_analyze_attention_chains` (the
-# dry-run sensitivity-report family, :func:`analyze_pruning_sensitivity`'s
-# own "Attention-head family" section below) -- deliberately NOT widened to
-# include :class:`_DecomposedGQAChain` (see this module's own "Decomposed
-# (un-fused) attention head pruning" section comment for why that family
-# isn't wired up to recognize the decomposed shape yet): both functions
-# switch on `isinstance(chain, _GQAChain)` and otherwise assume
-# `_AttentionChain`'s own `.weight`/`.nq`/`.nk`/`.nv` fields, which
-# :class:`_DecomposedGQAChain` has no equivalent of at all, so a real type
-# checker correctly flags that `else` branch once the wider alias below is
-# used there -- narrower here is the honest fix, not a workaround.
-_FusedAttnLikeChain = Union[_AttentionChain, _GQAChain]
-
 # A *third* matched shape, :class:`_DecomposedGQAChain` (see this module's
 # own "Decomposed (un-fused) attention head pruning" section comment,
-# further down), is folded into this WIDER alias -- used by
-# :func:`_apply_attention_chains`/:func:`apply_attention_head_pruning`,
-# which do dispatch on it -- via a plain string forward reference: that
-# class is defined much later in the file (after every fused-node matcher
-# it partially mirrors), and `_AttnLikeChain` itself is a runtime
-# `Union[...]` assignment, evaluated at import time, not merely a type
-# annotation -- unlike this module's usual `from __future__ import
-# annotations`-deferred annotations, a bare string element inside `Union[]`
-# is never resolved at runtime at all (only by a static type checker, which
-# resolves it against the whole module regardless of definition order), so
-# this is safe regardless of where :class:`_DecomposedGQAChain` itself ends
-# up defined.
+# further down), is folded into this alias -- used by every "Attention-head
+# pruning" entry point, real (:func:`_apply_attention_chains`/
+# :func:`apply_attention_head_pruning`/
+# :func:`apply_attention_head_wanda_pruning`) and dry-run
+# (:func:`_attention_not_eligible`/:func:`_analyze_attention_chains`, the
+# family behind :func:`analyze_pruning_sensitivity`'s own "Attention-head
+# family" section) alike, all of which dispatch on it -- via a plain string
+# forward reference: that class is defined much later in the file (after
+# every fused-node matcher it partially mirrors), and `_AttnLikeChain`
+# itself is a runtime `Union[...]` assignment, evaluated at import time, not
+# merely a type annotation -- unlike this module's usual `from __future__
+# import annotations`-deferred annotations, a bare string element inside
+# `Union[]` is never resolved at runtime at all (only by a static type
+# checker, which resolves it against the whole module regardless of
+# definition order), so this is safe regardless of where
+# :class:`_DecomposedGQAChain` itself ends up defined.
+#
+# :class:`_DecomposedGQAChain` shares every `_GQAChain`-side field
+# (`.q_weight`/`.k_weight`/`.v_weight`/`.kv_num_heads`/`.head_size`/
+# `.v_head_size`/`.consumer_weight`/`.consumer_node`) every dispatch site
+# below reads for it, but has no `.node` field at all (its matched shape has
+# no single fused node) -- every dispatch site that would otherwise read
+# `.node` (`_attention_not_eligible`'s own `matched_ids` set,
+# `_analyze_attention_chains`'s own `label`) special-cases
+# `isinstance(chain, _DecomposedGQAChain)` first, using `.softmax_node` (the
+# chain's own defining anchor node) in `_analyze_attention_chains`'s case,
+# or excluding it from a fused-op-only `id()` set in
+# `_attention_not_eligible`'s.
 _AttnLikeChain = Union[_AttentionChain, _GQAChain, "_DecomposedGQAChain"]
 
 
@@ -22617,21 +22619,35 @@ def _find_sparse_attention_chains(
 #   classify declines the whole chain.
 # - The scale (if any) must be a scalar `Mul` or `Div`-by-constant -- never
 #   inspected/touched beyond that (a global scalar has no per-head axis).
-# - Not (yet) wired into :func:`apply_attention_head_wanda_pruning` (the
-#   Wanda-calibrated variant) or the dry-run sensitivity-report family
-#   (:func:`_analyze_attention_head_pruning` and friends) -- a deliberate
-#   scope decision for this pass's first cut, not an oversight: get
-#   plain-L1/L2-ranked pruning genuinely correct and well-verified first
-#   (see `tests/test_pruning.py`'s own real end-to-end
-#   `torch.onnx.export` -> `onnxsim.simplify()` ->
-#   `apply_attention_head_pruning` pipeline test), leaving the calibrated
-#   and dry-run variants for a future pass to extend.
-# - Packed-QKV (:func:`_match_packed_qkv_split`'s own shape), Q/K-norm+RoPE
-#   pass-through, and cross-attention (Q's own source tensor distinct from
-#   K's/V's) are none of them recognized here -- every one of them is a
-#   real, separate shape this section does not attempt; a graph combining
-#   any of them with this section's own decomposed shape simply declines
-#   the match (never guessed at), same as any other unrecognized topology.
+# - Wired into every entry point in this module's own "Attention-head
+#   pruning" family: :func:`apply_attention_head_pruning` (plain L1/L2),
+#   :func:`apply_attention_head_wanda_pruning` (the Wanda-calibrated
+#   variant), and the dry-run sensitivity-report family
+#   (:func:`_analyze_attention_head_pruning`/
+#   :func:`_analyze_attention_head_wanda_pruning`, via
+#   :func:`_analyze_attention_chains` -- reported under its own
+#   ``"attention_decomposed_group"`` family string). All three route matched
+#   :class:`_DecomposedGQAChain` chains through the exact same
+#   :func:`_gqa_group_importance`-based ranking (plain or Wanda-wrapped) and
+#   :func:`_apply_one_decomposed_gqa_chain` slicing this section already
+#   built for the plain variant -- pure wiring, no matching/slicing logic
+#   specific to either the calibrated or dry-run path.
+# - Packed-QKV (:func:`_match_packed_qkv_split`'s own shape) and Q/K-norm+RoPE
+#   pass-through are not recognized here -- both are real, separate shapes
+#   this section does not attempt; a graph combining either of them with
+#   this section's own decomposed shape simply declines the match (never
+#   guessed at), same as any other unrecognized topology. Cross-attention
+#   (Q's own source tensor distinct from K's/V's, including a genuinely
+#   different `seq_len` between the two) *is* recognized here, despite an
+#   earlier draft of this comment claiming otherwise: neither
+#   :func:`_find_decomposed_gqa_chains` nor :func:`_gqa_group_importance`
+#   ever ties Q's own producer weight (or its row count/source tensor) to
+#   K's/V's own -- confirmed empirically with a hand-built decomposed graph
+#   whose Q branch reads one input tensor and whose K/V branches read a
+#   second, differently-shaped one (see
+#   `test_decomposed_attention_cross_attention_matches_oracle_exactly` in
+#   `tests/test_pruning.py`), which matches and prunes correctly with zero
+#   code changes needed.
 
 
 @dataclass(frozen=True)
@@ -24576,9 +24592,11 @@ def apply_attention_head_pruning(
     passes decline to fuse it either -- see this module's own "Decomposed
     (un-fused) attention head pruning" section comment for the full scope,
     empirical shape, and why this is a common, not merely hypothetical,
-    real-world export path). Not (yet) matched by
-    :func:`apply_attention_head_wanda_pruning`'s own calibrated variant --
-    see that same section comment.
+    real-world export path). Also matched by
+    :func:`apply_attention_head_wanda_pruning`'s own calibrated variant and
+    by :func:`analyze_pruning_sensitivity`'s own dry-run report (family
+    string ``"attention_decomposed_group"``) -- see that same section
+    comment.
 
     :param model: the original onnx ModelProto or file path
     :param sparsity: target fraction of each matched block's heads (or, for
@@ -24695,14 +24713,15 @@ def apply_attention_head_pruning(
 def _wanda_attention_calibration_stats(
     out: onnx.ModelProto,
     # `Sequence`, not `List` -- read-only here (only ever iterated, never
-    # mutated), so this accepts either `_apply_attention_head_wanda_pruning`'s
-    # own `List[_AttnLikeChain]` (all four chain kinds) or
-    # `_analyze_attention_head_wanda_pruning`'s own narrower
-    # `List[_FusedAttnLikeChain]` (see this module's own comment above
-    # `_FusedAttnLikeChain`'s definition) without a covariance mismatch --
-    # `List[...]` itself is invariant, `Sequence[...]` is not, and every
-    # chain kind this function is ever handed shares the one field it
-    # actually reads (`.consumer_node`).
+    # mutated). Both real callers (`apply_attention_head_wanda_pruning` and
+    # `_analyze_attention_head_wanda_pruning`) now pass a
+    # `List[_AttnLikeChain]` (all four chain kinds, since both were widened
+    # to also collect `_DecomposedGQAChain` via
+    # `_find_decomposed_gqa_chains`) -- `Sequence` here is `List[...]`'s own
+    # read-only supertype, kept rather than `List[_AttnLikeChain]` outright
+    # purely to signal that intent, not to paper over an actual type
+    # mismatch between the two call sites. Every chain kind this function is
+    # ever handed shares the one field it actually reads (`.consumer_node`).
     chains: Sequence[_AttnLikeChain],
     calibration_data: Sequence[Tensors],
     providers: Optional[Sequence[str]],
@@ -24775,7 +24794,12 @@ def apply_attention_head_wanda_pruning(
     how :func:`_gqa_group_importance` combines that same group's weight norm
     across Q+K+V -- all three matched separate-Q/K/V-producer ops share that
     one importance function (and this one calibrated wrapper around it)
-    unmodified.
+    unmodified. Also matches the *decomposed* (not-yet-fused) attention
+    block :func:`apply_attention_head_pruning`'s own docstring describes --
+    see this module's own "Decomposed (un-fused) attention head pruning"
+    section comment -- at the identical whole-KV-group granularity, ranked
+    by the same calibrated importance, since :class:`_DecomposedGQAChain`
+    shares every field :func:`_gqa_group_importance` and this wrapper read.
 
     :param model: the original onnx ModelProto or file path
     :param calibration_data: representative input batches to measure each
@@ -24840,6 +24864,7 @@ def apply_attention_head_wanda_pruning(
         *_find_paged_attention_chains(graph, value_info_by_name),
         *_find_linear_attention_chains(graph, value_info_by_name),
         *_find_sparse_attention_chains(graph, value_info_by_name),
+        *_find_decomposed_gqa_chains(graph, value_info_by_name),
     ]
     if not chains:
         return out
@@ -34113,11 +34138,16 @@ class PruningLayerSensitivity:
             group granularity -- it genuinely supports `kv_num_heads !=
             num_heads`, the same real GQA-style grouping
             `GroupQueryAttention` itself supports, unlike
-            `MultiHeadAttention`) for attention pruning (shared by
-            :func:`apply_attention_head_pruning` and its Wanda-calibrated
-            counterpart :func:`apply_attention_head_wanda_pruning` alike --
-            `family` names the topology a unit was matched by, not the
-            calibration method used to rank it, exactly as unstructured/
+            `MultiHeadAttention`)/``"attention_decomposed_group"`` (a
+            *decomposed*, not-yet-fused attention block -- see this module's
+            own "Decomposed (un-fused) attention head pruning" section
+            comment -- whole-KV-group granularity, identical to
+            ``"attention_gqa_group"``'s own but reported under its own
+            string since no single fused node backs it) for attention
+            pruning (shared by :func:`apply_attention_head_pruning` and its
+            Wanda-calibrated counterpart :func:`apply_attention_head_wanda_pruning`
+            alike -- `family` names the topology a unit was matched by, not
+            the calibration method used to rank it, exactly as unstructured/
             structured pruning's own plain-vs-Wanda variants already share
             their family strings above); ``"moe_expert_channel"`` for
             :func:`apply_moe_expert_channel_pruning`; ``"moe_whole_expert"``
@@ -35722,9 +35752,15 @@ def _analyze_structured_pruning_matmul_bnb4(
 
 
 def _attention_not_eligible(
-    graph: onnx.GraphProto, chains: List[_FusedAttnLikeChain]
+    graph: onnx.GraphProto, chains: List[_AttnLikeChain]
 ) -> List[str]:
-    matched_ids = {id(c.node) for c in chains}
+    # `_DecomposedGQAChain` has no `.node` field at all (see this module's
+    # own comment above `_AttnLikeChain`'s definition) -- excluded here, not
+    # just skipped over, since its own anchor node is a plain `Softmax`,
+    # never one of the fused op types `is_attn_like` below checks for, so it
+    # could never have appeared in `matched_ids` for a real fused node
+    # anyway.
+    matched_ids = {id(c.node) for c in chains if not isinstance(c, _DecomposedGQAChain)}
     not_eligible = []
     for node in graph.node:
         is_attn_like = (
@@ -35753,7 +35789,7 @@ def _attention_not_eligible(
 
 def _analyze_attention_chains(
     graph: onnx.GraphProto,
-    chains: List[_FusedAttnLikeChain],
+    chains: List[_AttnLikeChain],
     sparsity: float,
     compute_importance: Callable[..., np.ndarray],
     compute_group_importance: Callable[..., np.ndarray],
@@ -35772,6 +35808,16 @@ def _analyze_attention_chains(
     :func:`_gqa_group_importance` (optionally wrapped, as
     :func:`_analyze_attention_head_wanda_pruning` does, to fold in a
     calibrated activation norm) unmodified.
+
+    `chains` also carries :class:`_DecomposedGQAChain` (see this module's
+    own "Decomposed (un-fused) attention head pruning" section comment),
+    reported under its own ``"attention_decomposed_group"`` family string:
+    it shares every `_GQAChain`-side field this function reads
+    (`.q_weight`/`.k_weight`/`.v_weight`/`.kv_num_heads`/`.head_size`/
+    `.v_head_size`/`.consumer_weight`) but has no `.node` field at all (its
+    matched shape has no single fused node), so `label` is taken from
+    `.softmax_node` -- the chain's own defining anchor node,
+    :func:`_find_decomposed_gqa_chains`'s own match point -- instead.
     """
     initializer_map = _constant_map(graph)
     producer_touched: Set[str] = set()
@@ -35779,8 +35825,17 @@ def _analyze_attention_chains(
     layers: List[PruningLayerSensitivity] = []
 
     for chain in chains:
-        label = _node_label(chain.node)
-        if isinstance(chain, _GQAChain):
+        if isinstance(chain, _DecomposedGQAChain):
+            # No `.node` field at all (its matched shape has no single
+            # fused node) -- `.softmax_node`, the chain's own defining
+            # anchor node, stands in for it here, same as
+            # :func:`_find_decomposed_gqa_chains`'s own match point.
+            label = _node_label(chain.softmax_node)
+            producer_names = {chain.q_weight, chain.k_weight, chain.v_weight}
+            h = chain.kv_num_heads
+            family = "attention_decomposed_group"
+        elif isinstance(chain, _GQAChain):
+            label = _node_label(chain.node)
             producer_names = {chain.q_weight, chain.k_weight, chain.v_weight}
             h = chain.kv_num_heads
             # `MultiHeadAttention` has no separate `kv_num_heads` at all
@@ -35834,6 +35889,7 @@ def _analyze_attention_chains(
             else:
                 family = "attention_gqa_group"
         else:
+            label = _node_label(chain.node)
             producer_names = {chain.weight}
             h = chain.num_heads
             family = "attention_head"
@@ -35870,12 +35926,20 @@ def _analyze_attention_chains(
             )
             continue
 
-        if isinstance(chain, _GQAChain):
+        if isinstance(chain, (_GQAChain, _DecomposedGQAChain)):
             d = chain.head_size
             wq_init = initializer_map[chain.q_weight]
             wk_init = initializer_map[chain.k_weight]
             wv_init = initializer_map[chain.v_weight]
-            if chain.packed_split_sizes is not None:
+            # `_DecomposedGQAChain` has no `packed_split_sizes` field at all
+            # (that packed-QKV shape is a `_GQAChain`-only match -- see this
+            # module's own "Decomposed (un-fused) attention head pruning"
+            # section comment, the packed-QKV scope bullet) -- only checked
+            # for an actual `_GQAChain`.
+            packed_split_sizes = (
+                chain.packed_split_sizes if isinstance(chain, _GQAChain) else None
+            )
+            if packed_split_sizes is not None:
                 nq_orig = chain.num_heads * d
                 nk_orig = chain.kv_num_heads * d
                 w_kn = onnx.numpy_helper.to_array(wq_init).astype(np.float64)
@@ -35974,7 +36038,7 @@ def _analyze_attention_head_pruning(
             if graph is model.graph
             else _value_info_by_name(graph)
         )
-        chains: List[_FusedAttnLikeChain] = [
+        chains: List[_AttnLikeChain] = [
             *_find_attention_chains(graph, value_info_by_name),
             *_find_gqa_chains(graph, value_info_by_name),
             *_find_onnx_attention_chains(graph, value_info_by_name),
@@ -35984,6 +36048,7 @@ def _analyze_attention_head_pruning(
             *_find_paged_attention_chains(graph, value_info_by_name),
             *_find_linear_attention_chains(graph, value_info_by_name),
             *_find_sparse_attention_chains(graph, value_info_by_name),
+            *_find_decomposed_gqa_chains(graph, value_info_by_name),
         ]
         layers.extend(
             _analyze_attention_chains(
@@ -36037,7 +36102,7 @@ def _analyze_attention_head_wanda_pruning(
     graph = model.graph
     value_info_by_name = _shape_inferred_value_info_by_name(model)
 
-    chains: List[_FusedAttnLikeChain] = [
+    chains: List[_AttnLikeChain] = [
         *_find_attention_chains(graph, value_info_by_name),
         *_find_gqa_chains(graph, value_info_by_name),
         *_find_onnx_attention_chains(graph, value_info_by_name),
@@ -36047,6 +36112,7 @@ def _analyze_attention_head_wanda_pruning(
         *_find_paged_attention_chains(graph, value_info_by_name),
         *_find_linear_attention_chains(graph, value_info_by_name),
         *_find_sparse_attention_chains(graph, value_info_by_name),
+        *_find_decomposed_gqa_chains(graph, value_info_by_name),
     ]
     if not chains:
         return PruningSensitivityReport(

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -41406,3 +41406,244 @@ def test_decomposed_attention_real_torch_export_pipeline():
     oracle_out = linear(ctx, wo, bo)
 
     np.testing.assert_allclose(ort_out, oracle_out, rtol=1e-3, atol=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# Decomposed (un-fused) attention -- Wanda-calibrated pruning and dry-run
+# sensitivity-report wiring
+# ---------------------------------------------------------------------------
+# `_find_decomposed_gqa_chains` (see the section above) is now also wired
+# into `apply_attention_head_wanda_pruning`'s own chain-collection list and
+# `_analyze_attention_chains`'s own (backing `analyze_pruning_sensitivity`'s
+# dry-run report) -- previously it fed only the plain (non-calibrated)
+# `apply_attention_head_pruning`. `_DecomposedGQAChain` shares every field
+# `_gqa_group_importance`/the Wanda-calibrated wrapper around it reads with
+# `_GQAChain`, so this is pure wiring: the tests below mirror
+# `test_gqa_wanda_pruning_matches_oracle_exactly`/
+# `test_analyze_attention_head_wanda_pruning_gqa_matches_real_call`/
+# `test_analyze_attention_head_pruning_gqa_gemma_rope_matches_real_call`
+# exactly, just against `_decomposed_gqa_model` instead of `_gqa_model`.
+
+
+def test_decomposed_gqa_wanda_pruning_matches_oracle_exactly():
+    model, cfg = _decomposed_gqa_model(K=16, H=8, KVH=2, D=8, Out=16, seed=101)
+
+    rng = np.random.default_rng(102)
+    x_cal = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    calibration_data = [{"X": x_cal}]
+
+    pruned = onnxsim.apply_attention_head_wanda_pruning(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned)
+
+    # `ctx2` -- the flattened `[batch*seq, H*Dv]` tensor feeding the
+    # O-projection Gemm -- is exactly `chain.consumer_node.input[0]`, the
+    # tensor `_wanda_attention_calibration_stats` probes for every chain
+    # kind uniformly (see that function's own docstring).
+    probe_model = onnx.ModelProto()
+    probe_model.CopyFrom(model)
+    probe_model.graph.output.append(onnx.ValueInfoProto(name="ctx2"))
+    (_, ctx2_cal) = _run(probe_model, {"X": x_cal})
+    act_norm = np.sqrt(np.mean(np.square(ctx2_cal.astype(np.float64)), axis=0))
+
+    d = cfg["D"]
+    group_size = cfg["H"] // cfg["KVH"]
+    importance = np.zeros(cfg["KVH"])
+    for kv in range(cfg["KVH"]):
+        q_block = np.concatenate(
+            [
+                cfg["wq"][:, h * d : (h + 1) * d]
+                for h in range(kv * group_size, (kv + 1) * group_size)
+            ],
+            axis=1,
+        )
+        k_block = cfg["wk"][:, kv * d : (kv + 1) * d]
+        v_block = cfg["wv"][:, kv * d : (kv + 1) * d]
+        base = np.linalg.norm(np.concatenate([q_block, k_block, v_block], axis=1))
+        act_group = np.linalg.norm(
+            act_norm[kv * group_size * d : (kv + 1) * group_size * d]
+        )
+        importance[kv] = base * max(act_group, 1e-8)
+    keep_groups = np.sort(np.argsort(-importance)[:1])  # max(1, 2 - round(2*0.5)) == 1
+
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    q_idx, kv_idx = _head_idx(keep_q_heads, d), _head_idx(keep_groups, d)
+
+    oracle, _ = _decomposed_gqa_model(
+        K=cfg["K"],
+        H=len(keep_q_heads),
+        KVH=len(keep_groups),
+        D=d,
+        Out=cfg["Out"],
+        seed=101,
+        wq=cfg["wq"][:, q_idx],
+        wk=cfg["wk"][:, kv_idx],
+        wv=cfg["wv"][:, kv_idx],
+        wout=cfg["wout"][q_idx, :],
+        bq=cfg["bq"][q_idx],
+        bk=cfg["bk"][kv_idx],
+        bv=cfg["bv"][kv_idx],
+        bout=cfg["bout"],
+        batch=cfg["batch"],
+        seq=cfg["seq"],
+    )
+
+    x = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_decomposed_gqa_wanda_pruning_falls_back_to_plain_with_no_calibration_batches():
+    model, cfg = _decomposed_gqa_model(K=16, H=8, KVH=2, D=8, Out=16, seed=103)
+    plain = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    wanda = onnxsim.apply_attention_head_wanda_pruning(
+        model, calibration_data=[], sparsity=0.5
+    )
+    inits_plain = {
+        t.name: onnx.numpy_helper.to_array(t) for t in plain.graph.initializer
+    }
+    inits_wanda = {
+        t.name: onnx.numpy_helper.to_array(t) for t in wanda.graph.initializer
+    }
+    for name in inits_plain:
+        np.testing.assert_array_equal(inits_plain[name], inits_wanda[name])
+
+
+def test_analyze_attention_head_pruning_decomposed_gqa_matches_real_call():
+    model, cfg = _decomposed_gqa_model(K=16, H=8, KVH=2, D=8, Out=16, seed=104)
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_attention_head_pruning, sparsity=0.5
+    )
+    assert len(report.layers) == 1
+    layer = report.layers[0]
+    assert layer.family == "attention_decomposed_group"
+    assert layer.total == cfg["KVH"]
+    assert report.not_eligible == []
+
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    wq_new, wk_new, wv_new, _wo_new = _decomposed_weight_shapes(pruned)
+    kept_groups = cfg["KVH"] - layer.would_drop
+    group_size = cfg["H"] // cfg["KVH"]
+    assert wq_new.shape[1] == kept_groups * group_size * cfg["D"]
+    assert wk_new.shape[1] == kept_groups * cfg["D"]
+    assert wv_new.shape[1] == kept_groups * cfg["D"]
+
+
+def test_analyze_attention_head_wanda_pruning_decomposed_gqa_matches_real_call():
+    model, cfg = _decomposed_gqa_model(K=16, H=8, KVH=2, D=8, Out=16, seed=105)
+    rng = np.random.default_rng(106)
+    x_cal = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    calibration_data = [{"X": x_cal}]
+
+    report = onnxsim.analyze_pruning_sensitivity(
+        model,
+        onnxsim.apply_attention_head_wanda_pruning,
+        calibration_data=calibration_data,
+        sparsity=0.5,
+    )
+    assert len(report.layers) == 1
+    layer = report.layers[0]
+    assert layer.family == "attention_decomposed_group"
+    assert layer.total == cfg["KVH"]
+
+    pruned = onnxsim.apply_attention_head_wanda_pruning(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    wq_new, wk_new, wv_new, _wo_new = _decomposed_weight_shapes(pruned)
+    kept_groups = cfg["KVH"] - layer.would_drop
+    group_size = cfg["H"] // cfg["KVH"]
+    assert wq_new.shape[1] == kept_groups * group_size * cfg["D"]
+    assert wk_new.shape[1] == kept_groups * cfg["D"]
+    assert wv_new.shape[1] == kept_groups * cfg["D"]
+
+
+def test_decomposed_attention_cross_attention_matches_oracle_exactly():
+    # Locks in this module's own corrected "Decomposed (un-fused) attention
+    # head pruning" section comment: cross-attention (Q's own source tensor
+    # distinct from K's/V's, with a genuinely different seq_len between the
+    # two) is recognized and correctly pruned by
+    # `_find_decomposed_gqa_chains`/`apply_attention_head_pruning` -- NOT
+    # new logic. Neither that matcher nor `_gqa_group_importance` ever ties
+    # Q's own producer weight (row count/source tensor) to K's/V's own; this
+    # test only confirms already-existing matcher/ranking/slicing behavior
+    # on a decomposed (not fused) cross-attention shape, mirroring
+    # `test_gqa_pruning_cross_attention_matches_oracle_exactly`'s own
+    # confirmation for the fused `GroupQueryAttention` shape.
+    batch, seq_q, seq_kv, H, D, K_dec, K_enc, Out = 1, 3, 5, 4, 4, 6, 5, 8
+    rng = np.random.default_rng(500)
+    wq = rng.standard_normal((K_dec, H * D)).astype(np.float32)
+    wk = rng.standard_normal((K_enc, H * D)).astype(np.float32)
+    wv = rng.standard_normal((K_enc, H * D)).astype(np.float32)
+    wout = rng.standard_normal((H * D, Out)).astype(np.float32)
+
+    def _cross_model(wq, wk, wv, wout, h):
+        initializer = [
+            _f32(wq, "Wq"),
+            _f32(wk, "Wk"),
+            _f32(wv, "Wv"),
+            _f32(wout, "Wout"),
+            onnx.numpy_helper.from_array(
+                np.array([batch, seq_q, h, D], dtype=np.int64), "Sq"
+            ),
+            onnx.numpy_helper.from_array(
+                np.array([batch, seq_kv, h, D], dtype=np.int64), "Skv"
+            ),
+            onnx.numpy_helper.from_array(
+                np.array([batch, seq_q, h * D], dtype=np.int64), "OutShape"
+            ),
+            _f32(np.array(D**-0.5, dtype=np.float32), "Scale"),
+        ]
+        return _model(
+            f"""
+            g (float[{batch},{seq_q},{K_dec}] Xdec, float[{batch},{seq_kv},{K_enc}] Xenc) => (float[{batch},{seq_q},{Out}] Y)
+            {{
+              q0 = MatMul(Xdec, Wq)
+              qr = Reshape(q0, Sq)
+              qt = Transpose<perm=[0,2,1,3]>(qr)
+              k0 = MatMul(Xenc, Wk)
+              kr = Reshape(k0, Skv)
+              kt = Transpose<perm=[0,2,3,1]>(kr)
+              v0 = MatMul(Xenc, Wv)
+              vr = Reshape(v0, Skv)
+              vt = Transpose<perm=[0,2,1,3]>(vr)
+              qk = MatMul(qt, kt)
+              scaled = Mul(qk, Scale)
+              attn = Softmax<axis=-1>(scaled)
+              ctx0 = MatMul(attn, vt)
+              ctx1 = Transpose<perm=[0,2,1,3]>(ctx0)
+              ctx2 = Reshape(ctx1, OutShape)
+              Y = MatMul(ctx2, Wout)
+            }}
+            """,
+            initializer=initializer,
+            opset=17,
+        )
+
+    model = _cross_model(wq, wk, wv, wout, H)
+    chains = onnxsim.pruning._find_decomposed_gqa_chains(model.graph)
+    assert len(chains) == 1
+
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep_count = max(1, H - round(H * 0.5))
+    keep_heads = _oracle_keep_groups_cross(wq, wk, wv, H, H, D, keep_count)
+    idx = _head_idx(keep_heads, D)
+
+    oracle = _cross_model(
+        wq[:, idx], wk[:, idx], wv[:, idx], wout[idx, :], len(keep_heads)
+    )
+
+    xdec = rng.standard_normal((batch, seq_q, K_dec)).astype(np.float32)
+    xenc = rng.standard_normal((batch, seq_kv, K_enc)).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"Xdec": xdec, "Xenc": xenc})
+    (y_oracle,) = _run(oracle, {"Xdec": xdec, "Xenc": xenc})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+    # Sanity: Q and K/V really are independently sourced, not accidentally
+    # both reading the same tensor -- perturbing Xenc alone (Xdec held
+    # fixed) must still change the output.
+    (y_pruned2,) = _run(pruned, {"Xdec": xdec, "Xenc": xenc + 1.0})
+    assert not np.allclose(y_pruned, y_pruned2)


### PR DESCRIPTION
## Summary

The "Decomposed (un-fused) attention head pruning" feature (#1077) was scoped, deliberately, to only `apply_attention_head_pruning` (plain L1/L2) for its first cut — its own section comment documented this as "leaving the calibrated and dry-run variants for a future pass." This PR is that follow-up: it wires `_find_decomposed_gqa_chains` into `apply_attention_head_wanda_pruning` (the Wanda-calibrated variant) and into `_analyze_attention_chains`/`analyze_pruning_sensitivity`'s dry-run report family. It also corrects a stale claim in that same section comment (see below).

## What's added

- `apply_attention_head_wanda_pruning`: added `_find_decomposed_gqa_chains(...)` to its chain-collection list. No other logic change needed — `_apply_attention_chains`'s dispatch already handled `_DecomposedGQAChain` (checked first via `isinstance`), and the Wanda importance closure only reads fields `_DecomposedGQAChain` already shares with `_GQAChain` via the `_HeadGroupChain` alias.
- `_analyze_attention_chains`/`_attention_not_eligible`: widened from the narrower `_FusedAttnLikeChain` alias to the full `_AttnLikeChain` (which already included `_DecomposedGQAChain`, just unused by this family until now); removed the now-dead `_FusedAttnLikeChain` alias. This needed one real addition beyond pure wiring: `_DecomposedGQAChain` has no `.node` field (no single fused node backs its match), so `_analyze_attention_chains`'s label line and `_attention_not_eligible`'s `matched_ids` set needed an `isinstance(chain, _DecomposedGQAChain)` branch — using `.softmax_node` (the chain's own match anchor) for the label, reported under a new `"attention_decomposed_group"` family string.
- `_analyze_attention_head_pruning`/`_analyze_attention_head_wanda_pruning`: added `_find_decomposed_gqa_chains(...)` to both their chain-collection lists.
- **Stale doc-comment fix**: that section's own comment previously claimed cross-attention (Q from a different source tensor than K/V) was "not recognized here." Independently re-verified this is false — neither `_find_decomposed_gqa_chains` nor `_gqa_group_importance` ever ties Q's own producer/row-count/source tensor to K's/V's own. Confirmed with a hand-built decomposed graph (Q from one input, K/V from a second, differently-shaped input) that matches and prunes correctly with **zero code changes**, locked in by `test_decomposed_attention_cross_attention_matches_oracle_exactly` (which passes identically before and after this PR's code changes, since it exercises pre-existing behavior, not new logic).

## Test plan

- [x] `pytest tests/test_pruning.py -q` — 842 passed (837 baseline + 5 new); the same 21 pre-existing, unrelated failures remain (`apply_transformer_block_pruning` missing from this environment's stale compiled C++ extension — confirmed identical before/after; CI builds fresh)
- [x] `ruff format --check` / `ruff check` on both touched files — clean
- [x] `mypy onnxsim/pruning.py` — 0 errors
- [x] Independently re-verified via a revert-only-`pruning.py` check: the 4 wiring tests fail against the pre-change code, and the cross-attention doc-fix test correctly still passes either way (confirming it tests pre-existing behavior, not new logic); restored and confirmed all 5 pass again

## Note for reviewer

The family string `"attention_decomposed_group"` is a new name with no prior convention to match against (this path was previously unwired) — worth a sanity check against any downstream consumer expectations of `PruningLayerSensitivity.family` values.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_