### PR TITLE
Recognize packed-QKV producer in decomposed attention head pruning

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -22626,12 +22626,31 @@ def _find_sparse_attention_chains(
 #   `torch.onnx.export` -> `onnxsim.simplify()` ->
 #   `apply_attention_head_pruning` pipeline test), leaving the calibrated
 #   and dry-run variants for a future pass to extend.
-# - Packed-QKV (:func:`_match_packed_qkv_split`'s own shape), Q/K-norm+RoPE
-#   pass-through, and cross-attention (Q's own source tensor distinct from
-#   K's/V's) are none of them recognized here -- every one of them is a
-#   real, separate shape this section does not attempt; a graph combining
-#   any of them with this section's own decomposed shape simply declines
-#   the match (never guessed at), same as any other unrecognized topology.
+# - Packed-QKV (:func:`_match_packed_qkv_split`'s own shape -- one shared
+#   MatMul/vanilla-Gemm projection feeding a `Split` into Q-then-K-then-V
+#   column ranges, each of which then independently feeds this section's
+#   own `Reshape -> Transpose -> [repeat_kv]` head-split chain, the common
+#   GPT-2/GPT-J/GPT-NeoX/BLOOM/Falcon-style `c_attn`-family projection) IS
+#   recognized here -- see :class:`_DecomposedGQAChain`'s own
+#   `packed_split_sizes` field and :func:`_apply_one_decomposed_gqa_chain`'s
+#   own packed branch, which mirror :class:`_GQAChain`'s/
+#   :func:`_apply_one_gqa_chain`'s own analogous fused-node handling of this
+#   exact shape verbatim: a KV group's pruning removes that group's own Q/K/V
+#   column ranges from the *one* shared packed weight (and packed bias, if
+#   any) in a single combined slice, and shrinks the `Split` node's own
+#   split-sizes constant to match. Both the equal-split (plain MHA, e.g.
+#   GPT-2's `c_attn`) and unequal-split (GQA/MQA, e.g. Falcon's packed
+#   `query_key_value`) cases are handled -- `_match_packed_qkv_split` itself
+#   makes no MHA/GQA distinction, and this section's own combined-index-set
+#   slicing generalizes to any `nq`/`nk`/`nv` the same way the fused-node
+#   packed branch already does. Q/K-norm+RoPE pass-through and cross-
+#   attention (Q's own source tensor distinct from K's/V's) remain
+#   unrecognized here -- both are real, separate shapes this section does
+#   not attempt (nothing in the confirmed decomposed-export shape this
+#   section targets ever combines them with a packed producer); a graph
+#   combining either of them with this section's own decomposed shape simply
+#   declines the match (never guessed at), same as any other unrecognized
+#   topology.
 
 
 @dataclass(frozen=True)
@@ -22724,6 +22743,39 @@ class _DecomposedGQAChain:
     consumer_node: onnx.NodeProto
     consumer_weight: str
     consumer_weight_transposed: bool
+    packed_split_sizes: Optional[str] = None
+    # Set exactly when Q's/K's/V's own raw projection output all trace back
+    # to the *same* packed-QKV-then-``Split`` producer (see
+    # :func:`_match_packed_qkv_split`) rather than three independent
+    # MatMul/Gemm producers -- the decomposed-shape analogue of
+    # :class:`_GQAChain`'s own field of the same name (see that class's own
+    # field for the fused-node case this mirrors). When set, `q_weight`,
+    # `k_weight`, and `v_weight` all name the identical shared packed
+    # tensor (and `q_bias`/`k_bias`/`v_bias`, if not all ``None``, the
+    # identical shared packed bias) -- a column-range *view* into one
+    # ``[K, Nq+Nk+Nv]``-or-``[Nq+Nk+Nv, K]`` tensor rather than three
+    # separately-stored arrays -- and this field itself names the upstream
+    # ``Split`` node's own ``[nq, nk, nv]`` split-sizes initializer,
+    # rewritten post-pruning to the new column widths in
+    # :func:`_apply_one_decomposed_gqa_chain`'s own packed branch, mirroring
+    # :func:`_apply_one_gqa_chain`'s own `chain.packed_split_sizes` branch
+    # verbatim (see that function's own docstring for the exact combined-
+    # column-index-set construction both share).
+    packed_flatten_reshape: Optional[onnx.NodeProto] = None
+    packed_flatten_reshape_shape: Optional[str] = None
+    # Both set together, and only alongside `packed_split_sizes`, when the
+    # packed producer's own raw output is reshaped back to its original
+    # rank (`torch.onnx.export`'s own "flatten batch*seq before a Gemm"
+    # artifact -- see :func:`_match_decomposed_packed_qkv_producer`'s own
+    # docstring for the confirmed real export shape) before feeding the
+    # `Split` node -- `None`/`None` when the packed producer feeds `Split`
+    # directly (the onnxruntime-genai-model-builder shape
+    # :func:`_match_packed_qkv_split` was originally confirmed against).
+    # `packed_flatten_reshape_shape` names this `Reshape`'s own
+    # shape-constant input, whose LAST entry (the packed weight's own
+    # `nq + nk + nv` real output width) :func:`_apply_one_decomposed_gqa_chain`
+    # rewrites post-pruning via the same `_rewrite_shape_dim` clone-safety
+    # helper every other shape constant this chain owns already uses.
 
 
 # Either kind of matched whole-KV-group-pruned chain -- :func:`_gqa_group_importance`'s
@@ -22942,6 +22994,121 @@ def _match_decomposed_repeat_kv(
         merge_reshape_shape=reshape.input[1],
     )
     return branch, raw_name, kv_num_heads, n_rep
+
+
+def _match_decomposed_packed_qkv_producer(
+    split_node: onnx.NodeProto,
+    consumers_of: Dict[str, List[onnx.NodeProto]],
+    graph_outputs: Set[str],
+    node_by_output: Dict[str, onnx.NodeProto],
+    initializer_map: Dict[str, onnx.TensorProto],
+) -> Optional[
+    Tuple[
+        str,
+        bool,
+        Optional[str],
+        int,
+        int,
+        int,
+        str,
+        Optional[onnx.NodeProto],
+        Optional[str],
+    ]
+]:
+    """Resolves `split_node` -- already confirmed by the caller to be the
+    single shared producer of Q's/K's/V's own raw (pre-reshape) projection
+    outputs -- as this module's own packed-QKV producer
+    (:func:`_match_packed_qkv_split`'s own shape), optionally through one
+    intervening pass-through ``Reshape`` sitting directly between the
+    packed MatMul/Gemm projection and this `Split` node.
+
+    That extra ``Reshape`` -- absent from :func:`_match_packed_qkv_split`'s
+    own confirmed onnxruntime-genai-model-builder export (which wires the
+    packed projection's raw output into `Split` directly) -- is a
+    genuinely different, ALSO real artifact: onnxsim's own
+    `fuse_matmul_add_bias_into_gemm` optimizer pass flattens a packed
+    projection's rank-3 `MatMul`/`Add` into a rank-2 `Gemm` (mirroring
+    every other producer this module's "Decomposed (un-fused) attention
+    head pruning" section already handles -- see this module's own section
+    comment above :func:`_match_decomposed_head_split`), then reshapes that
+    `Gemm`'s own raw 2-D output back to the original rank-3 shape whenever
+    its immediate real consumer isn't itself a plain `Reshape` the pass can
+    trivially absorb into one combined target -- true for a `Split`
+    (confirmed empirically via a real `torch.onnx.export` of a GPT-2-style
+    packed `c_attn` `Linear` run through `onnxsim.simplify()`, not merely
+    hypothesized -- see `tests/test_pruning.py`'s own
+    `test_decomposed_packed_qkv_real_torch_export_pipeline`). This function
+    handles both: when `split_node.input[0]` is produced directly by a
+    `_match_producer`-accepted node, it behaves identically to
+    :func:`_match_packed_qkv_split` (a plain delegating call, no behavior
+    change for that already-working shape); when it is instead produced by
+    exactly this pass-through `Reshape`, it resolves one hop further back
+    before delegating, and additionally confirms the `Reshape`'s own target
+    shape is a fully resolved literal whose last entry equals the packed
+    weight's own real output width (`nq + nk + nv`) -- never guessed at
+    otherwise.
+
+    Returns :func:`_match_packed_qkv_split`'s own 7-tuple plus two more
+    entries, `(flatten_reshape, flatten_reshape_shape)` -- both ``None``
+    when no such `Reshape` was crossed (the direct case), otherwise the
+    crossed node and the name of its own shape-constant input for
+    :func:`_apply_one_decomposed_gqa_chain`'s own post-pruning rewrite (its
+    own real output width shrinks in lock-step with the packed weight's
+    own, so this constant's last entry must be rewritten too, via the
+    identical `_rewrite_shape_dim` clone-safety mechanism every other shape
+    constant this chain owns already uses) -- or ``None`` if neither shape
+    matches.
+    """
+    if split_node.op_type != "Split" or not split_node.input or not split_node.input[0]:
+        return None
+    data_name = split_node.input[0]
+
+    direct = _match_packed_qkv_split(
+        split_node, initializer_map, consumers_of, node_by_output
+    )
+    if direct is not None:
+        return direct + (None, None)
+
+    # Not a direct MatMul/Gemm-to-Split producer -- try resolving one
+    # pass-through `Reshape` hop first (see this function's own docstring).
+    # `data_name`'s own "exactly one consumer" bar (the ordinary
+    # single-consumer/not-a-graph-output invariant every hop in this
+    # module already holds) is checked here explicitly, since the
+    # delegating call below checks that same bar against the *reshape's*
+    # own input, not `data_name` itself.
+    if data_name in graph_outputs or len(consumers_of.get(data_name, [])) != 1:
+        return None
+    reshape = node_by_output.get(data_name)
+    if (
+        reshape is None
+        or reshape.domain != ""
+        or reshape.op_type != "Reshape"
+        or len(reshape.input) != 2
+        or not reshape.input[0]
+        or not reshape.input[1]
+        or len(reshape.output) != 1
+        or reshape.output[0] != data_name
+    ):
+        return None
+
+    synthetic = onnx.NodeProto()
+    synthetic.CopyFrom(split_node)
+    synthetic.input[0] = reshape.input[0]
+    resolved = _match_packed_qkv_split(
+        synthetic, initializer_map, consumers_of, node_by_output
+    )
+    if resolved is None:
+        return None
+    _, _, _, nq, nk, nv, _ = resolved
+
+    shape_init = initializer_map.get(reshape.input[1])
+    if shape_init is None or shape_init.data_type != onnx.TensorProto.INT64:
+        return None
+    dims = onnx.numpy_helper.to_array(shape_init)
+    if dims.size == 0 or int(dims[-1]) != nq + nk + nv:
+        return None
+
+    return resolved + (reshape, reshape.input[1])
 
 
 def _resolve_decomposed_qk_root(
@@ -23326,22 +23493,73 @@ def _find_decomposed_gqa_chains(
         v_prod_node = node_by_output.get(v_proj_out)
         if q_prod_node is None or k_prod_node is None or v_prod_node is None:
             continue
-        if (
+        packed_split_sizes: Optional[str] = None
+        packed_flatten_reshape: Optional[onnx.NodeProto] = None
+        packed_flatten_reshape_shape: Optional[str] = None
+        if q_prod_node is k_prod_node and q_prod_node is v_prod_node:
+            # All three raw projection outputs trace back to the exact
+            # same node -- either the packed-QKV-then-`Split` shape
+            # :func:`_match_decomposed_packed_qkv_producer` recognizes (see
+            # this module's own "Decomposed (un-fused) attention head
+            # pruning" section comment and :class:`_DecomposedGQAChain`'s
+            # own `packed_split_sizes` field docstring), or a genuinely
+            # degenerate share (three reshape/transpose chains all reading
+            # one tensor that ISN'T such a `Split`) this pass still can't
+            # independently slice.
+            packed = (
+                _match_decomposed_packed_qkv_producer(
+                    q_prod_node,
+                    consumers_of,
+                    graph_outputs,
+                    node_by_output,
+                    initializer_map,
+                )
+                if q_prod_node.op_type == "Split"
+                else None
+            )
+            if packed is None or list(q_prod_node.output) != [
+                q_proj_out,
+                k_proj_out,
+                v_proj_out,
+            ]:
+                # Either not the packed-QKV shape at all, or its three
+                # outputs aren't Q-then-K-then-V in that exact order --
+                # required here since the packed weight's own column
+                # offsets (`nq`-then-`nk`-then-`nv`, see
+                # :func:`_apply_one_decomposed_gqa_chain`) are only valid
+                # for that order; never guessed at otherwise.
+                continue
+            (
+                w_name,
+                w_transposed,
+                bias_name,
+                nq,
+                nk,
+                nv,
+                packed_split_sizes,
+                packed_flatten_reshape,
+                packed_flatten_reshape_shape,
+            ) = packed
+            wq = wk = wv = w_name
+            wq_t = wk_t = wv_t = w_transposed
+            bq = bk = bv = bias_name
+        elif (
             q_prod_node is k_prod_node
             or q_prod_node is v_prod_node
             or k_prod_node is v_prod_node
         ):
             continue  # degenerate -- shared producer, can't independently slice
-        q_info = _match_producer(q_prod_node, initializer_map)
-        k_info = _match_producer(k_prod_node, initializer_map)
-        v_info = _match_producer(v_prod_node, initializer_map)
-        if q_info is None or k_info is None or v_info is None:
-            continue
-        wq, wq_t, bq, nq = q_info
-        wk, wk_t, bk, nk = k_info
-        wv, wv_t, bv, nv = v_info
-        if wq == wk or wq == wv or wk == wv:
-            continue  # degenerate -- shared producer weight
+        else:
+            q_info = _match_producer(q_prod_node, initializer_map)
+            k_info = _match_producer(k_prod_node, initializer_map)
+            v_info = _match_producer(v_prod_node, initializer_map)
+            if q_info is None or k_info is None or v_info is None:
+                continue
+            wq, wq_t, bq, nq = q_info
+            wk, wk_t, bk, nk = k_info
+            wv, wv_t, bv, nv = v_info
+            if wq == wk or wq == wv or wk == wv:
+                continue  # degenerate -- shared producer weight
         if nq != num_heads * head_size or nk != kv_num_heads * head_size:
             continue
         if nv != kv_num_heads * v_head_size:
@@ -23407,6 +23625,9 @@ def _find_decomposed_gqa_chains(
                 consumer_node=consumer_node,
                 consumer_weight=cw_name,
                 consumer_weight_transposed=cw_transposed,
+                packed_split_sizes=packed_split_sizes,
+                packed_flatten_reshape=packed_flatten_reshape,
+                packed_flatten_reshape_shape=packed_flatten_reshape_shape,
             )
         )
     return chains
@@ -23445,6 +23666,20 @@ def _apply_one_decomposed_gqa_chain(
     target shape as this pass's own combine-back reshape) this protects
     against.
 
+    When `chain.packed_split_sizes` is set (a packed-QKV-then-`Split`
+    producer feeding all three of Q's/K's/V's own reshape/transpose
+    head-split chains -- see :class:`_DecomposedGQAChain`'s own field
+    docstring and :func:`_match_packed_qkv_split`), Q's/K's/V's "own
+    separate weight" below is the *same* single packed tensor for all
+    three, sliced exactly once by a combined column-index set (Q's own
+    kept columns, then K's shifted by the pre-pruning `nq_orig`, then V's
+    shifted by `nq_orig + nk_orig`) instead of three independent
+    :func:`_slice_producer_weight` calls, and the upstream `Split` node's
+    own split-sizes constant is rewritten to the three new (post-pruning)
+    column widths in the same Q-then-K-then-V order -- mirroring
+    :func:`_apply_one_gqa_chain`'s own `chain.packed_split_sizes` branch
+    verbatim (the fused-node analogue of this exact shape).
+
     Returns ``(producer_weight_names, consumer_weight_name,
     stale_output_names)`` on success, or ``None`` if `sparsity` rounds to no
     groups dropped for this block (a no-op, left for the caller to skip).
@@ -23458,18 +23693,41 @@ def _apply_one_decomposed_gqa_chain(
     dv = chain.v_head_size
     group_size = chain.num_heads // chain.kv_num_heads
 
+    # Pre-pruning flat widths of Q's/K's own producer weight -- needed by
+    # the packed-QKV branch below (a column-range view into, and later a
+    # combined-index slice of, one shared tensor) whenever
+    # `chain.packed_split_sizes` is set.
+    nq_orig = chain.num_heads * d
+    nk_orig = chain.kv_num_heads * d
+
     wq_init = initializer_map[chain.q_weight]
     wk_init = initializer_map[chain.k_weight]
     wv_init = initializer_map[chain.v_weight]
-    wq_kn = _to_f64(wq_init)
-    wk_kn = _to_f64(wk_init)
-    wv_kn = _to_f64(wv_init)
-    if chain.q_weight_transposed:
-        wq_kn = wq_kn.T
-    if chain.k_weight_transposed:
-        wk_kn = wk_kn.T
-    if chain.v_weight_transposed:
-        wv_kn = wv_kn.T
+    if chain.packed_split_sizes is not None:
+        # `.q_weight`, `.k_weight`, and `.v_weight` all name the *same*
+        # underlying packed tensor (`wq_init is wk_init is wv_init`), one
+        # contiguous `[K, Nq+Nk+Nv]` (or `[Nq+Nk+Nv, K]`, if
+        # `.q_weight_transposed`) storage split Q-then-K-then-V by column
+        # -- so `wq_kn`/`wk_kn`/`wv_kn` are column-range *views* into that
+        # one ``[K, N]`` array, computed from the chain's own original
+        # (before this call's own pruning) head counts, rather than three
+        # independently-stored arrays.
+        w_kn = _to_f64(wq_init)
+        if chain.q_weight_transposed:
+            w_kn = w_kn.T  # [K, Nq+Nk+Nv]
+        wq_kn = w_kn[:, :nq_orig]
+        wk_kn = w_kn[:, nq_orig : nq_orig + nk_orig]
+        wv_kn = w_kn[:, nq_orig + nk_orig :]
+    else:
+        wq_kn = _to_f64(wq_init)
+        wk_kn = _to_f64(wk_init)
+        wv_kn = _to_f64(wv_init)
+        if chain.q_weight_transposed:
+            wq_kn = wq_kn.T
+        if chain.k_weight_transposed:
+            wk_kn = wk_kn.T
+        if chain.v_weight_transposed:
+            wv_kn = wv_kn.T
 
     importance = compute_group_importance(chain, wq_kn, wk_kn, wv_kn)
     keep_groups = np.sort(np.argsort(-importance)[:keep_count])
@@ -23481,15 +23739,34 @@ def _apply_one_decomposed_gqa_chain(
     v_idx = _head_column_indices(keep_groups, dv)
     y_idx = _head_column_indices(keep_q_heads, dv)
 
-    _slice_producer_weight(wq_init, chain.q_weight_transposed, q_idx)
-    _slice_producer_weight(wk_init, chain.k_weight_transposed, k_idx)
-    _slice_producer_weight(wv_init, chain.v_weight_transposed, v_idx)
-    if chain.q_bias is not None:
-        _slice_last_axis(initializer_map[chain.q_bias], q_idx)
-    if chain.k_bias is not None:
-        _slice_last_axis(initializer_map[chain.k_bias], k_idx)
-    if chain.v_bias is not None:
-        _slice_last_axis(initializer_map[chain.v_bias], v_idx)
+    if chain.packed_split_sizes is not None:
+        # One shared tensor: a single combined-column slice (Q's own
+        # range, then K's shifted by the *original* `nq_orig`, then V's
+        # shifted by `nq_orig + nk_orig`) rather than three independent
+        # `_slice_producer_weight` calls, which would each invalidate the
+        # column offsets the other two still need to read from the same
+        # underlying storage.
+        full_idx = np.concatenate([q_idx, k_idx + nq_orig, v_idx + nq_orig + nk_orig])
+        _slice_producer_weight(wq_init, chain.q_weight_transposed, full_idx)
+        if chain.q_bias is not None:
+            _slice_last_axis(initializer_map[chain.q_bias], full_idx)
+        sizes_init = initializer_map[chain.packed_split_sizes]
+        sizes_init.CopyFrom(
+            onnx.numpy_helper.from_array(
+                np.array([len(q_idx), len(k_idx), len(v_idx)], dtype=np.int64),
+                name=sizes_init.name,
+            )
+        )
+    else:
+        _slice_producer_weight(wq_init, chain.q_weight_transposed, q_idx)
+        _slice_producer_weight(wk_init, chain.k_weight_transposed, k_idx)
+        _slice_producer_weight(wv_init, chain.v_weight_transposed, v_idx)
+        if chain.q_bias is not None:
+            _slice_last_axis(initializer_map[chain.q_bias], q_idx)
+        if chain.k_bias is not None:
+            _slice_last_axis(initializer_map[chain.k_bias], k_idx)
+        if chain.v_bias is not None:
+            _slice_last_axis(initializer_map[chain.v_bias], v_idx)
 
     _slice_consumer_weight(
         initializer_map[chain.consumer_weight], chain.consumer_weight_transposed, y_idx
@@ -23530,6 +23807,22 @@ def _apply_one_decomposed_gqa_chain(
             shape_init.CopyFrom(
                 onnx.numpy_helper.from_array(dims, name=shape_init.name)
             )
+
+    if (
+        chain.packed_flatten_reshape is not None
+        and chain.packed_flatten_reshape_shape is not None
+    ):
+        # The packed producer's own pass-through `Reshape` (see
+        # :func:`_match_decomposed_packed_qkv_producer`'s own docstring) --
+        # its own real output width shrinks from `nq_orig + nk_orig +
+        # (total width - nq_orig - nk_orig)` to the new post-pruning total
+        # in lock-step with the packed weight's own combined slice above.
+        _rewrite_shape_dim(
+            chain.packed_flatten_reshape_shape,
+            (chain.packed_flatten_reshape,),
+            -1,
+            len(q_idx) + len(k_idx) + len(v_idx),
+        )
 
     _rewrite_shape_dim(chain.q_reshape_shape, (chain.q_reshape,), 2, new_num_heads)
     if chain.k_reshape_shape == chain.v_reshape_shape:
@@ -23618,6 +23911,7 @@ def _apply_one_decomposed_gqa_chain(
 
     stale: Set[str] = set()
     for maybe_node in (
+        chain.packed_flatten_reshape,
         chain.q_transpose,
         chain.q_reshape,
         chain.k_transpose,

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -41406,3 +41406,597 @@ def test_decomposed_attention_real_torch_export_pipeline():
     oracle_out = linear(ctx, wo, bo)
 
     np.testing.assert_allclose(ort_out, oracle_out, rtol=1e-3, atol=1e-3)
+
+
+# Decomposed (un-fused) attention head pruning -- packed QKV producer
+# ---------------------------------------------------------------------------
+# `_packed_decomposed_gqa_model` mirrors `_decomposed_gqa_model`'s own
+# scaffolding above, but replaces its three independent Wq/Wk/Wv MatMul/Gemm
+# producers with one packed MatMul/Gemm producer feeding a `Split` node --
+# the same packed-QKV shape `_gqa_packed_model` above builds for the
+# *fused*-node family, applied here to the *decomposed* (un-fused)
+# reshape/transpose/repeat_kv head-split chain instead. See
+# onnxsim/pruning.py's own "Decomposed (un-fused) attention head pruning"
+# section comment and `_match_decomposed_packed_qkv_producer`'s own
+# docstring for the exact topology and the two confirmed real export shapes:
+# a packed projection feeding `Split` directly (GPT-2/GPT-J/GPT-NeoX/BLOOM
+# `c_attn`-family, no `flatten_reshape`), and the same shape with one
+# intervening pass-through `Reshape` (`flatten_reshape=True` -- the
+# `fuse_matmul_add_bias_into_gemm` optimizer artifact confirmed via a real
+# `torch.onnx.export`, see `test_decomposed_attention_packed_qkv_real_torch_
+# export_pipeline` below).
+def _packed_decomposed_gqa_model(
+    K=16,
+    H=4,
+    KVH=2,
+    D=8,
+    Out=16,
+    batch=1,
+    seq=4,
+    seed=0,
+    bias=True,
+    wqkv=None,
+    bqkv=None,
+    wout=None,
+    bout=None,
+    split_sizes=None,
+    split_outputs=("q0", "k0", "v0"),
+    head_split_inputs=None,
+    flatten_reshape=False,
+    extra_foreign_flatten_reshape_consumer=False,
+):
+    rng = np.random.default_rng(seed)
+    Nq, Nk, Nv = H * D, KVH * D, KVH * D
+    if wqkv is None:
+        wqkv = rng.standard_normal((K, Nq + Nk + Nv)).astype(np.float32)
+    if wout is None:
+        wout = rng.standard_normal((H * D, Out)).astype(np.float32)
+
+    def _i64(arr, name):
+        return onnx.numpy_helper.from_array(np.array(arr, dtype=np.int64), name)
+
+    initializer = [_f32(wqkv, "Wqkv"), _f32(wout, "Wout")]
+    initializer.append(_i64([batch * seq, K], "XFlatShape"))
+    lines = ["xf = Reshape(X, XFlatShape)"]
+    qkv_op, o_op = "MatMul(xf, Wqkv)", "MatMul(ctx2, Wout)"
+    if bias:
+        if bqkv is None:
+            bqkv = rng.standard_normal((Nq + Nk + Nv,)).astype(np.float32)
+        if bout is None:
+            bout = rng.standard_normal((Out,)).astype(np.float32)
+        initializer += [_f32(bqkv, "Bqkv"), _f32(bout, "Bout")]
+        qkv_op, o_op = "Gemm(xf, Wqkv, Bqkv)", "Gemm(ctx2, Wout, Bout)"
+
+    if split_sizes is None:
+        split_sizes = [Nq, Nk, Nv]
+    initializer.append(_i64(split_sizes, "SplitSizes"))
+
+    lines.append("qkv0 = " + qkv_op)
+    split_data = "qkv0"
+    if flatten_reshape:
+        # The `fuse_matmul_add_bias_into_gemm` optimizer artifact this
+        # section's own `_match_decomposed_packed_qkv_producer` resolves
+        # through: the packed Gemm's raw rank-2 `[batch*seq, Nq+Nk+Nv]`
+        # output reshaped back to rank-3 `[batch, seq, Nq+Nk+Nv]` before
+        # feeding `Split` (never absorbed into one combined reshape the
+        # way a *direct* head-split `Reshape` consumer would be, since
+        # `Split` isn't a `Reshape` this pass's own optimizer can merge
+        # into).
+        initializer.append(_i64([batch, seq, Nq + Nk + Nv], "QkvFlatBackShape"))
+        lines.append("qkv0f = Reshape(qkv0, QkvFlatBackShape)")
+        split_data = "qkv0f"
+        if extra_foreign_flatten_reshape_consumer:
+            # A second, wholly unrelated `Reshape` reading the SAME shape
+            # constant as the flatten-back reshape -- simulates cross-layer
+            # CSE merging two textually-identical shape constants (mirrors
+            # `_decomposed_gqa_model`'s own
+            # `extra_foreign_q_reshape_consumer`). Reshapes a dedicated,
+            # otherwise-unused constant (rather than `qkv0` itself, which
+            # must keep exactly one consumer -- this `Reshape` -- for
+            # `_match_decomposed_packed_qkv_producer`'s own pass-through
+            # resolution to match at all) with the right total element
+            # count (`batch*seq*(Nq+Nk+Nv)`).
+            initializer.append(
+                _f32(
+                    rng.standard_normal((batch * seq * (Nq + Nk + Nv),)),
+                    "ForeignQkvData",
+                )
+            )
+            lines.append("foreign_qkv_out = Reshape(ForeignQkvData, QkvFlatBackShape)")
+
+    split_out = ", ".join(split_outputs)
+    lines.append(f"{split_out} = Split <axis=-1> ({split_data}, SplitSizes)")
+
+    # `head_split_inputs` -- when given -- names which of `Split`'s own
+    # three (still-`split_outputs`-named) outputs feeds Q's/K's/V's own
+    # downstream head-split `Reshape`, independent of `split_outputs`'s own
+    # LITERAL declared position order on the `Split` node itself (position 0
+    # always gets the `SplitSizes`-sized-`Nq` range, position 1 `Nk`,
+    # position 2 `Nv`, regardless of what name is used for it). Defaults to
+    # `split_outputs` itself (the ordinary, self-consistent case); a caller
+    # passing a genuinely different order here (see
+    # `test_decomposed_packed_qkv_pruning_wrong_output_order_is_declined`)
+    # builds a graph where Q's own real downstream chain reads a `Split`
+    # output that ISN'T at position 0 of the node's own declared output
+    # list -- exactly the adversarial shape
+    # `_find_decomposed_gqa_chains`'s own ``list(q_prod_node.output) ==
+    # [q_proj_out, k_proj_out, v_proj_out]`` check exists to decline.
+    q_name, k_name, v_name = head_split_inputs or split_outputs
+    initializer.append(_i64([batch, seq, H, D], "Sq"))
+    lines += [
+        f"qr = Reshape({q_name}, Sq)",
+        "qt = Transpose<perm=[0,2,1,3]>(qr)",
+    ]
+
+    initializer.append(_i64([batch, seq, KVH, D], "Skv"))
+    lines += [f"kr = Reshape({k_name}, Skv)", f"vr = Reshape({v_name}, Skv)"]
+
+    n_rep = H // KVH
+    if KVH == H:
+        lines.append("kt = Transpose<perm=[0,2,3,1]>(kr)")
+        lines.append("vt = Transpose<perm=[0,2,1,3]>(vr)")
+    else:
+        assert H % KVH == 0
+        initializer.append(_i64([2], "Ax2"))
+        initializer.append(_i64([batch, KVH, n_rep, seq, D], "KExpandShape"))
+        initializer.append(_i64([batch, H, seq, D], "KMergeShape"))
+        initializer.append(_i64([batch, KVH, n_rep, seq, D], "VExpandShape"))
+        initializer.append(_i64([batch, H, seq, D], "VMergeShape"))
+        lines += [
+            "kt0 = Transpose<perm=[0,2,1,3]>(kr)",
+            "ku = Unsqueeze(kt0, Ax2)",
+            "ke = Expand(ku, KExpandShape)",
+            "kre = Reshape(ke, KMergeShape)",
+            "kt = Transpose<perm=[0,1,3,2]>(kre)",
+            "vt0 = Transpose<perm=[0,2,1,3]>(vr)",
+            "vu = Unsqueeze(vt0, Ax2)",
+            "ve = Expand(vu, VExpandShape)",
+            "vt = Reshape(ve, VMergeShape)",
+        ]
+
+    initializer.append(_f32(np.array(D**-0.5, dtype=np.float32), "Scale"))
+    lines += ["qk = MatMul(qt, kt)", "scaled = Mul(qk, Scale)"]
+    lines.append("attn = Softmax<axis=-1>(scaled)")
+    lines.append("ctx0 = MatMul(attn, vt)")
+    lines.append("ctx1 = Transpose<perm=[0,2,1,3]>(ctx0)")
+    initializer.append(_i64([batch * seq, H * D], "OutShape"))
+    initializer.append(_i64([batch, seq, Out], "YShape"))
+    lines.append("ctx2 = Reshape(ctx1, OutShape)")
+    lines.append("y0 = " + o_op)
+    lines.append("Y = Reshape(y0, YShape)")
+
+    body_lines = "\n          ".join(lines)
+    model = _model(
+        f"""
+        g (float[{batch},{seq},{K}] X) => (float[{batch},{seq},{Out}] Y)
+        {{
+          {body_lines}
+        }}
+        """,
+        initializer=initializer,
+        opset=17,
+    )
+    return model, dict(
+        K=K,
+        H=H,
+        KVH=KVH,
+        D=D,
+        Out=Out,
+        batch=batch,
+        seq=seq,
+        wqkv=wqkv,
+        bqkv=bqkv,
+        wout=wout,
+        bout=bout,
+        Nq=Nq,
+        Nk=Nk,
+        Nv=Nv,
+    )
+
+
+def _packed_decomposed_separate_oracle(
+    K, H, KVH, D, Out, seed, batch, seq, wq, wk, wv, wout, bq, bk, bv, bout
+):
+    # The oracle: `_decomposed_gqa_model`'s own three-separate-producer
+    # shape, fed the packed model's own already-sliced per-Q/K/V weight
+    # views -- the same "independently-reconstructed ground truth" bar
+    # `test_gqa_packed_qkv_split_pruning_matches_oracle_exactly` holds the
+    # fused-node packed shape to.
+    return _decomposed_gqa_model(
+        K=K,
+        H=H,
+        KVH=KVH,
+        D=D,
+        Out=Out,
+        seed=seed,
+        wq=wq,
+        wk=wk,
+        wv=wv,
+        wout=wout,
+        bq=bq,
+        bk=bk,
+        bv=bv,
+        bout=bout,
+        batch=batch,
+        seq=seq,
+    )
+
+
+def _run_packed_decomposed_oracle_check(model, cfg, sparsity=0.5, seed=2):
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=sparsity)
+    onnx.checker.check_model(pruned)
+
+    H, KVH, D = cfg["H"], cfg["KVH"], cfg["D"]
+    Nq, Nk = cfg["Nq"], cfg["Nk"]
+    wqkv = cfg["wqkv"]
+    wq, wk, wv = wqkv[:, :Nq], wqkv[:, Nq : Nq + Nk], wqkv[:, Nq + Nk :]
+
+    group_size = H // KVH
+    new_kv = max(1, KVH - round(KVH * sparsity))
+    keep_groups = _oracle_keep_groups(wq, wk, wv, H, KVH, D, new_kv)
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    q_idx, kv_idx = _head_idx(keep_q_heads, D), _head_idx(keep_groups, D)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    expected_wqkv = np.concatenate([wq[:, q_idx], wk[:, kv_idx], wv[:, kv_idx]], axis=1)
+    np.testing.assert_array_equal(inits["Wqkv"], expected_wqkv)
+    np.testing.assert_array_equal(
+        inits["SplitSizes"],
+        np.array([len(q_idx), len(kv_idx), len(kv_idx)], dtype=np.int64),
+    )
+
+    bq = bk = bv = bout = None
+    if cfg["bqkv"] is not None:
+        bqkv = cfg["bqkv"]
+        bq, bk, bv = (
+            bqkv[:Nq][q_idx],
+            bqkv[Nq : Nq + Nk][kv_idx],
+            bqkv[Nq + Nk :][kv_idx],
+        )
+        bout = cfg["bout"]
+        expected_bqkv = np.concatenate(
+            [bqkv[:Nq][q_idx], bqkv[Nq : Nq + Nk][kv_idx], bqkv[Nq + Nk :][kv_idx]]
+        )
+        np.testing.assert_array_equal(inits["Bqkv"], expected_bqkv)
+
+    oracle, _ = _packed_decomposed_separate_oracle(
+        K=cfg["K"],
+        H=len(keep_q_heads),
+        KVH=new_kv,
+        D=D,
+        Out=cfg["Out"],
+        seed=1,
+        batch=cfg["batch"],
+        seq=cfg["seq"],
+        wq=wq[:, q_idx],
+        wk=wk[:, kv_idx],
+        wv=wv[:, kv_idx],
+        wout=cfg["wout"][q_idx, :],
+        bq=bq,
+        bk=bk,
+        bv=bv,
+        bout=bout,
+    )
+    rng = np.random.default_rng(seed)
+    x = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+    return pruned
+
+
+def test_decomposed_packed_qkv_mha_pruning_matches_oracle_exactly():
+    # Equal Q/K/V split (KVH == H, GPT-2/GPT-J-style `c_attn`) -- the packed
+    # projection feeds `Split` directly, no intervening `Reshape`.
+    model, cfg = _packed_decomposed_gqa_model(K=16, H=4, KVH=4, D=8, Out=16, seed=1)
+    assert len(onnxsim.pruning._find_decomposed_gqa_chains(model.graph)) == 1
+    _run_packed_decomposed_oracle_check(model, cfg)
+
+
+def test_decomposed_packed_qkv_gqa_pruning_matches_oracle_exactly():
+    # Unequal Q/K/V split (KVH < H, Falcon-style packed `query_key_value`
+    # with a genuine GQA/MQA head-count split) -- Q's own packed segment is
+    # wider than K's/V's, so the combined-column-index-set slicing must
+    # apply each of the three at its own offset (`nq_orig`, `nq_orig +
+    # nk_orig`) rather than assume an equal three-way split.
+    model, cfg = _packed_decomposed_gqa_model(K=16, H=8, KVH=2, D=8, Out=16, seed=3)
+    assert len(onnxsim.pruning._find_decomposed_gqa_chains(model.graph)) == 1
+    _run_packed_decomposed_oracle_check(model, cfg)
+
+
+def test_decomposed_packed_qkv_pruning_with_flatten_reshape_matches_oracle_exactly():
+    # The real `torch.onnx.export`-then-`onnxsim.simplify()` artifact (see
+    # `_match_decomposed_packed_qkv_producer`'s own docstring): a
+    # pass-through `Reshape` sits between the packed Gemm and `Split`. Its
+    # own shape constant's last entry (the packed weight's own `Nq+Nk+Nv`
+    # real output width) must be rewritten to the new post-pruning total in
+    # lock-step with the packed weight's own combined slice, or the pruned
+    # graph would be shape-invalid.
+    model, cfg = _packed_decomposed_gqa_model(
+        K=16, H=8, KVH=2, D=8, Out=16, seed=5, flatten_reshape=True
+    )
+    chains = onnxsim.pruning._find_decomposed_gqa_chains(model.graph)
+    assert len(chains) == 1
+    assert chains[0].packed_flatten_reshape is not None
+
+    pruned = _run_packed_decomposed_oracle_check(model, cfg)
+
+    flatten_reshape = next(
+        n for n in pruned.graph.node if n.output and n.output[0] == "qkv0f"
+    )
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    new_total = inits["Wqkv"].shape[1]
+    assert list(inits[flatten_reshape.input[1]]) == [
+        cfg["batch"],
+        cfg["seq"],
+        new_total,
+    ]
+
+
+def test_decomposed_packed_qkv_pruning_clones_flatten_reshape_shape_shared_with_foreign_reader():
+    # The flatten-back `Reshape`'s own shape constant is ALSO read by a
+    # wholly unrelated `Reshape` (`foreign_qkv_out`, simulating cross-layer
+    # CSE) -- editing it in place would silently corrupt that unrelated
+    # node too, so `_apply_one_decomposed_gqa_chain`'s own
+    # `_rewrite_shape_dim` must clone a fresh tensor for this chain's own
+    # flatten-reshape instead, leaving the original -- and
+    # `foreign_qkv_out`'s own shape -- completely untouched. Mirrors
+    # `test_decomposed_gqa_pruning_clones_shape_constant_shared_with_foreign_reader`.
+    model, cfg = _packed_decomposed_gqa_model(
+        K=16,
+        H=8,
+        KVH=2,
+        D=8,
+        Out=16,
+        seed=7,
+        flatten_reshape=True,
+        extra_foreign_flatten_reshape_consumer=True,
+    )
+    assert any(n.output and n.output[0] == "foreign_qkv_out" for n in model.graph.node)
+    shape_before = next(
+        t for t in model.graph.initializer if t.name == "QkvFlatBackShape"
+    )
+
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    # The original shape constant must be byte-identical to before -- still
+    # read by `foreign_qkv_out`'s own Reshape, which must keep working at
+    # the ORIGINAL (unpruned) total width.
+    shape_after = next(
+        t for t in pruned.graph.initializer if t.name == "QkvFlatBackShape"
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(shape_after),
+        onnx.numpy_helper.to_array(shape_before),
+    )
+    foreign_after = next(
+        n for n in pruned.graph.node if n.output and n.output[0] == "foreign_qkv_out"
+    )
+    assert foreign_after.input[1] == "QkvFlatBackShape"  # still reads the original
+
+    # The chain's own flatten-reshape must have been rewired to a NEW,
+    # cloned tensor instead.
+    flatten_reshape = next(
+        n for n in pruned.graph.node if n.output and n.output[0] == "qkv0f"
+    )
+    assert flatten_reshape.input[1] != "QkvFlatBackShape"
+    cloned = next(
+        t for t in pruned.graph.initializer if t.name == flatten_reshape.input[1]
+    )
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    assert list(onnx.numpy_helper.to_array(cloned)) == [
+        cfg["batch"],
+        cfg["seq"],
+        inits["Wqkv"].shape[1],
+    ]
+
+    rng = np.random.default_rng(8)
+    x = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    assert y.shape == (cfg["batch"], cfg["seq"], cfg["Out"])
+    assert np.all(np.isfinite(y))
+
+
+def test_decomposed_packed_qkv_pruning_zero_sparsity_is_a_no_op():
+    model, cfg = _packed_decomposed_gqa_model(K=16, H=8, KVH=2, D=8, Out=16, seed=9)
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.0)
+    before = {
+        t.name: onnx.numpy_helper.to_array(t).shape for t in model.graph.initializer
+    }
+    after = {
+        t.name: onnx.numpy_helper.to_array(t).shape for t in pruned.graph.initializer
+    }
+    assert before == after
+
+
+def test_decomposed_packed_qkv_pruning_wrong_output_order_is_declined():
+    # Adversarial (mirrors `test_gqa_packed_qkv_split_wrong_output_order_is_
+    # declined`): `Split`'s own three outputs are literally named
+    # ``k0, q0, v0`` (that declared position order -- position 0 always
+    # gets the `SplitSizes`-sized-`Nq` range regardless of name), but Q's
+    # own downstream head-split `Reshape` is wired (via `head_split_inputs`)
+    # to read "q0" -- `Split`'s own SECOND output, not its first. This is
+    # declined outright by `_find_decomposed_gqa_chains`'s own
+    # ``list(q_prod_node.output) == [q_proj_out, k_proj_out, v_proj_out]``
+    # check, rather than a naive offset-by-position implementation
+    # mis-slicing K's own column range into Q's or vice versa. Equal-split
+    # (KVH == H) here purely to keep the three ranges the same width, so
+    # the graph is a genuinely valid (if semantically scrambled) ONNX graph
+    # rather than one with a broken element count -- the adversarial part
+    # is only the name-order mismatch this check exists to catch.
+    model, cfg = _packed_decomposed_gqa_model(
+        K=16,
+        H=4,
+        KVH=4,
+        D=8,
+        Out=16,
+        seed=11,
+        split_outputs=("k0", "q0", "v0"),
+        head_split_inputs=("q0", "k0", "v0"),
+    )
+    assert onnxsim.pruning._find_decomposed_gqa_chains(model.graph) == []
+
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
+def test_decomposed_packed_qkv_pruning_slices_packed_bias():
+    model, cfg = _packed_decomposed_gqa_model(
+        K=16, H=4, KVH=2, D=8, Out=16, seed=13, bias=True
+    )
+    pruned = _run_packed_decomposed_oracle_check(model, cfg)
+    onnx.checker.check_model(pruned)
+
+
+def test_decomposed_attention_packed_qkv_real_torch_export_pipeline():
+    """The real end-to-end pipeline for the packed-QKV shape: a GPT-2-style
+    eager-attention `nn.Module` with a single packed `c_attn` Linear (the
+    common real-world `c_attn`-family projection this section's own
+    docstring names), `torch.onnx.export -> onnxsim.simplify() ->
+    apply_attention_head_pruning`, confirming (1) the packed+decomposed
+    shape survives `simplify()` un-fused with the `Split` node intact, (2)
+    pruning genuinely fires, and (3) the pruned model's output matches an
+    independently-computed numpy oracle built directly from the PRUNED
+    model's own (already-sliced) tensors, run through a real
+    `onnxruntime.InferenceSession` -- mirrors
+    `test_decomposed_attention_real_torch_export_pipeline`'s own bar for
+    the separate-producer shape, applied to the packed one.
+    """
+    torch = pytest.importorskip("torch")
+    pytest.importorskip("onnxruntime")
+    import torch.nn as nn  # noqa: E402  (after the torch importorskip guard)
+
+    hidden, num_heads, head_dim, seq, batch = 32, 4, 8, 4, 1
+
+    class GPT2StyleAttention(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.num_heads = num_heads
+            self.head_dim = head_dim
+            self.c_attn = nn.Linear(hidden, 3 * num_heads * head_dim, bias=True)
+            self.c_proj = nn.Linear(num_heads * head_dim, hidden, bias=True)
+            self.scaling = head_dim**-0.5
+
+        def forward(self, hidden_states, attn_mask):
+            b, s, _ = hidden_states.shape
+            qkv = self.c_attn(hidden_states)
+            q, k, v = qkv.split(self.num_heads * self.head_dim, dim=-1)
+            q = q.view(b, s, self.num_heads, self.head_dim).transpose(1, 2)
+            k = k.view(b, s, self.num_heads, self.head_dim).transpose(1, 2)
+            v = v.view(b, s, self.num_heads, self.head_dim).transpose(1, 2)
+            attn_weights = torch.matmul(q, k.transpose(2, 3)) * self.scaling
+            attn_weights = attn_weights + attn_mask
+            attn_weights = torch.softmax(attn_weights, dim=-1)
+            attn_output = torch.matmul(attn_weights, v)
+            attn_output = attn_output.transpose(1, 2).contiguous().reshape(b, s, -1)
+            return self.c_proj(attn_output)
+
+    m = GPT2StyleAttention()
+    m.eval()
+    x = torch.randn(batch, seq, hidden)
+    mask = torch.triu(torch.full((seq, seq), float("-inf")), diagonal=1)[
+        None, None, :, :
+    ]
+
+    buf = io.BytesIO()
+    torch.onnx.export(
+        m,
+        (x, mask),
+        buf,
+        input_names=["hidden_states", "attn_mask"],
+        output_names=["output"],
+        opset_version=17,
+        dynamo=False,
+    )
+    raw = onnx.load_from_string(buf.getvalue())
+
+    simplified, ok = onnxsim.onnx_simplifier.simplify(raw)
+    assert ok
+
+    # Sanity check this test isn't vacuous: the decomposed+packed shape
+    # genuinely reached `apply_attention_head_pruning` un-fused, with the
+    # packed `Split` node still intact (neither onnxsim's own
+    # `fuse_attention`/`fuse_gqa` optimizer pass, nor any existing
+    # fused-node matcher in onnxsim/pruning.py, ever produces or recognizes
+    # a fused attention op for this shape).
+    assert not any(
+        n.op_type
+        in ("Attention", "GroupQueryAttention", "MultiHeadAttention", "PagedAttention")
+        for n in simplified.graph.node
+    )
+    assert any(n.op_type == "Split" for n in simplified.graph.node)
+
+    pruned = onnxsim.apply_attention_head_pruning(simplified, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    def _find_gemm(model, bias_substr):
+        for n in model.graph.node:
+            if n.op_type == "Gemm" and len(n.input) == 3 and bias_substr in n.input[2]:
+                return n
+        raise AssertionError(f"no Gemm found for {bias_substr!r}")
+
+    def _init(model, name):
+        for t in model.graph.initializer:
+            if t.name == name:
+                return onnx.numpy_helper.to_array(t)
+        for n in model.graph.node:
+            if n.op_type == "Constant" and n.output[0] == name:
+                for a in n.attribute:
+                    if a.name == "value":
+                        return onnx.numpy_helper.to_array(a.t)
+        raise AssertionError(f"no initializer/Constant found for {name!r}")
+
+    qkv_gemm = _find_gemm(pruned, "c_attn.bias")
+    o_gemm = _find_gemm(pruned, "c_proj.bias")
+    wqkv, bqkv = _init(pruned, qkv_gemm.input[1]), _init(pruned, qkv_gemm.input[2])
+    wo, bo = _init(pruned, o_gemm.input[1]), _init(pruned, o_gemm.input[2])
+
+    new_total = wqkv.shape[1]
+    assert new_total % 3 == 0
+    new_nq = new_total // 3
+    new_num_heads = new_nq // head_dim
+    # Pruning must have actually fired -- the whole point of this test.
+    assert new_num_heads < num_heads
+
+    wq, wk, wv = wqkv[:, :new_nq], wqkv[:, new_nq : 2 * new_nq], wqkv[:, 2 * new_nq :]
+    bq, bk, bv = bqkv[:new_nq], bqkv[new_nq : 2 * new_nq], bqkv[2 * new_nq :]
+
+    rng = np.random.default_rng(0)
+    hidden_states = rng.standard_normal((batch, seq, hidden)).astype(np.float32)
+    mask_np = mask.numpy().astype(np.float32)
+
+    sess = ort.InferenceSession(
+        pruned.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    (ort_out,) = sess.run(None, {"hidden_states": hidden_states, "attn_mask": mask_np})
+
+    def linear(x, w, b):
+        return x @ w + b
+
+    q = (
+        linear(hidden_states, wq, bq)
+        .reshape(batch, seq, new_num_heads, head_dim)
+        .transpose(0, 2, 1, 3)
+    )
+    k = (
+        linear(hidden_states, wk, bk)
+        .reshape(batch, seq, new_num_heads, head_dim)
+        .transpose(0, 2, 1, 3)
+    )
+    v = (
+        linear(hidden_states, wv, bv)
+        .reshape(batch, seq, new_num_heads, head_dim)
+        .transpose(0, 2, 1, 3)
+    )
+    scale = head_dim**-0.5
+    scores = np.matmul(q, k.transpose(0, 1, 3, 2)) * scale
+    scores = scores + mask_np
+    scores = scores - scores.max(axis=-1, keepdims=True)
+    exp = np.exp(scores)
+    attn = exp / exp.sum(axis=-1, keepdims=True)
+    ctx = np.matmul(attn, v)
+    ctx = ctx.transpose(0, 2, 1, 3).reshape(batch, seq, new_num_heads * head_dim)
+    oracle_out = linear(ctx, wo, bo)
+
+    np.testing.assert_allclose(ort_out, oracle_out, rtol=1e-3, atol=1e-3)


### PR DESCRIPTION
## Summary

The "Decomposed (un-fused) attention head pruning" feature (#1077) required each of Q's/K's/V's own raw projection output to come from three *independent* `MatMul`/`Gemm` producers, and explicitly declined the common **packed-QKV** shape (a single shared `MatMul`/`Gemm` feeding a `Split` into Q/K/V column ranges — GPT-2/GPT-J/GPT-NeoX/BLOOM/Falcon-style `c_attn`/`query_key_value` projections). This module already has a matcher for exactly this shape for the *fused*-attention-node family (`_match_packed_qkv_split`), but the decomposed family didn't reuse it — so any GPT-2-family model exported without ORT's transformer-fusion pass got **zero attention-head pruning** for this extremely common projection shape.

## What's added

- `_match_decomposed_packed_qkv_producer` (new): resolves a `Split` node as `_match_packed_qkv_split`'s own shape, either directly or through one intervening pass-through `Reshape` — a second real artifact discovered during this round: onnxsim's own `fuse_matmul_add_bias_into_gemm` pass flattens a packed projection's rank-3 `MatMul`/`Add` into a rank-2 `Gemm`, then reshapes that `Gemm`'s raw output back to rank-3 before it can feed `Split` (confirmed empirically via a real `torch.onnx.export` of a GPT-2-style packed `c_attn` `Linear`, not merely hypothesized).
- `_DecomposedGQAChain`: new `packed_split_sizes`/`packed_flatten_reshape`/`packed_flatten_reshape_shape` fields, the decomposed-shape analogue of `_GQAChain`'s own `packed_split_sizes` field for the fused-node case.
- `_find_decomposed_gqa_chains`: producer-resolution extended with a packed-producer branch (falls back to the existing per-producer path unchanged when no shared `Split` producer is found).
- `_apply_one_decomposed_gqa_chain`: packed-aware branch — a single combined-column-index slice of the one shared packed weight/bias (Q's kept columns, then K's shifted by the pre-pruning `nq_orig`, then V's shifted by `nq_orig + nk_orig`), the `Split` node's own split-sizes constant rewritten to the new column widths, and (when present) the flatten-`Reshape`'s own shape constant rewritten via the existing clone-on-shared-reader `_rewrite_shape_dim` helper. This mirrors `_apply_one_gqa_chain`'s own analogous fused-node packed branch.

**Scope**: full MHA + GQA/MQA support (not narrowed to MHA-only) — the offset-aware column slicing directly mirrors the fused-node case's already-battle-tested packed branch, which already handles unequal `nq`/`nk`/`nv`; verified numerically for both equal-split (MHA) and unequal-split (GQA-style) cases against independently-reconstructed oracle models.

## Test plan

- [x] `pytest tests/test_pruning.py -q` — 845 passed (837 baseline + 8 new); the same 21 pre-existing, unrelated failures remain (`apply_transformer_block_pruning` missing from this environment's stale compiled C++ extension — confirmed identical before/after; CI builds fresh)
- [x] `ruff format --check` / `ruff check` on both touched files — clean
- [x] `mypy onnxsim/pruning.py` — 0 errors
- [x] Independently re-verified via a revert-only-`pruning.py` check: 6 of the 8 new tests fail against the pre-change code (the other 2 are decline/no-op negative tests, correctly invariant either way); restored and confirmed all 8 pass again
- [x] Verified against a real `torch.onnx.export → onnxsim.simplify() → apply_attention_head_pruning` pipeline for a GPT-2-style eager-attention module with a packed `c_attn` `Linear`: confirmed `Split` survives simplification (no fused attention op appears), pruning fires (4→2 heads), and the pruned ONNX Runtime output matches an independently-computed numpy oracle to 5.96e-08 max abs diff

## Risks for a reviewer to double check

1. The column-offset math (`nq_orig = num_heads*head_size`, `nk_orig = kv_num_heads*head_size`, concatenated index set) is copied from `_apply_one_gqa_chain`'s own fused packed branch — worth re-verifying against `_find_decomposed_gqa_chains`'s producer-resolution block.
2. The `list(q_prod_node.output) != [q_proj_out, k_proj_out, v_proj_out]` order check is required for the column offsets to stay valid; covered by a dedicated wrong-output-order decline test but subtle.
3. The flatten-reshape's own shape-constant rewrite is the most novel part of this change (only discovered via the real end-to-end pipeline test — a naive packed match without it would produce a shape-invalid graph); covered by two tests.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_