### PR TITLE
Recognize decomposed Llama/HF-style RoPE pass-through in un-fused attention pruning

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -22650,10 +22650,30 @@ def _find_sparse_attention_chains(
 #   makes no MHA/GQA distinction, and this section's own combined-index-set
 #   slicing generalizes to any `nq`/`nk`/`nv` the same way the fused-node
 #   packed branch already does.
-# - Q/K-norm+RoPE pass-through is not recognized here -- a real, separate
-#   shape this section does not attempt; a graph combining it with this
-#   section's own decomposed shape (packed-producer or not) simply declines
-#   the match (never guessed at), same as any other unrecognized topology.
+# - Decomposed RoPE pass-through IS recognized here (see
+#   :func:`_match_decomposed_rope_pass_through`/
+#   :func:`_walk_back_through_decomposed_rope` and this module's own comment
+#   directly above :class:`_DecomposedRopePassThrough` for the confirmed
+#   topology): a real `torch.onnx.export()` of a Llama/Mistral/Qwen/Gemma-
+#   style eager-attention module applies HuggingFace's own
+#   `apply_rotary_pos_emb`/`rotate_half` -- genuinely decomposed math here,
+#   no fused rotary op at all -- to Q and to K independently, between each
+#   branch's own head-split `Transpose` and (for Q) the QK^T `MatMul`'s own
+#   Q input or (for K) wherever K's own dot-product transpose resolution
+#   expects its input (before `repeat_kv`, when both are present). Recognized
+#   and passed through untouched -- no tensor this hop owns is ever sliced
+#   or rewritten, since neither `cos`/`sin` nor `rotate_half`'s own `Slice`
+#   bounds ever carry a `num_heads`/`kv_num_heads`-sized axis (see
+#   :class:`_DecomposedRopePassThrough`'s own docstring) -- matched
+#   independently for Q and K (a chain with RoPE on only one of the two
+#   still matches; every real export applies it to both, but nothing here
+#   requires that). **Q/K-norm pass-through is deliberately NOT recognized
+#   here** -- a real, separate shape (only Qwen3/Gemma2-style architectures
+#   apply one, ahead of RoPE) left for a future, dedicated pass rather than
+#   bundled into this one, per this feature's own scope note; a graph
+#   combining a per-head Q/K-norm with this section's own decomposed shape
+#   (packed-producer or not, RoPE or not) simply declines the match (never
+#   guessed at), same as any other unrecognized topology.
 #   Cross-attention (Q's own source tensor distinct from K's/V's, including
 #   a genuinely different `seq_len` between the two) *is* recognized here,
 #   despite an earlier draft of this comment claiming otherwise: neither
@@ -22790,6 +22810,24 @@ class _DecomposedGQAChain:
     # `nq + nk + nv` real output width) :func:`_apply_one_decomposed_gqa_chain`
     # rewrites post-pruning via the same `_rewrite_shape_dim` clone-safety
     # helper every other shape constant this chain owns already uses.
+    q_rope: Optional["_DecomposedRopePassThrough"] = None
+    k_rope: Optional["_DecomposedRopePassThrough"] = None
+    # Set exactly when :func:`_walk_back_through_decomposed_rope` crossed a
+    # decomposed RoPE application on Q's/K's own branch, between that
+    # branch's own head-split `Transpose` output and (for Q) the QK^T
+    # `MatMul`'s own Q input or (for K) wherever K's own dot-product
+    # transpose resolution expects its input -- see this module's own
+    # comment above :class:`_DecomposedRopePassThrough` for the exact
+    # topology and why it needs no slicing of any kind, unlike every other
+    # field this class names. Matched independently for Q and K (never
+    # required together) -- both are always present in a real RoPE-using
+    # export, but nothing here ties one branch's match to the other's, the
+    # same "independently None/set" treatment `k_repeat_kv`/`v_repeat_kv`
+    # already get. `k_rope` is always `None` when `k_headsplit_transpose`
+    # is (the combined-`perm=[0, 2, 3, 1]` shape) -- RoPE's own nodes
+    # always break the `Transpose`-`Transpose` adjacency that combined
+    # shape requires (see :func:`_find_decomposed_gqa_chains`'s own comment
+    # at its `k_perm` dispatch).
 
 
 # Either kind of matched whole-KV-group-pruned chain -- :func:`_gqa_group_importance`'s
@@ -23228,6 +23266,355 @@ def _resolve_decomposed_qk_root(
     return qk_matmul, mask_node, mask_operand, scale_node
 
 
+# Decomposed (un-fused) RoPE pass-through -- the decomposed-shape analogue of
+# :func:`_walk_back_through_qk_norm_rope`'s own `RotaryEmbedding`/
+# `MRotaryEmbedding` hop, for the genuinely different topology a plain
+# `torch.onnx.export()` of a Llama/Mistral/Qwen/Gemma-style eager-attention
+# module emits: there is no fused rotary op at all here, only HuggingFace's
+# own `apply_rotary_pos_emb`/`rotate_half` helpers decomposed into ordinary
+# ai.onnx nodes. Confirmed empirically (a hand-built module mirroring
+# `transformers.models.llama.modeling_llama`'s own `apply_rotary_pos_emb`/
+# `rotate_half`, `torch.onnx.export(..., opset_version=17, dynamo=False)`,
+# run through this module's own `onnxsim.simplify()` -- both a GQA/repeat_kv
+# case and a plain-MHA, no-repeat_kv case, since repeat_kv's presence turned
+# out not to affect this hop's own shape at all) to be the fixed, 7-node
+# sequence, applied identically and independently to Q and to K, each rooted
+# at that branch's own head-split `Transpose`'s output (`x`, the BHSD
+# tensor):
+#
+#     direct  = Mul(x, cos_operand)
+#     x1      = Slice(x, starts=[0],    ends=[half],      axes=[3], steps=[1])
+#     x2      = Slice(x, starts=[half], ends=[>= half],   axes=[3], steps=[1])
+#     neg     = Neg(x2)
+#     rotated_x = Concat(neg, x1, axis=-1_or_3)   # rotate_half(x) = cat(-x2, x1)
+#     rotated = Mul(rotated_x, sin_operand)
+#     result  = Add(direct, rotated)   # order confirmed: direct first, rotated second
+#
+# -- landing exactly on `result = x * cos + rotate_half(x) * sin`, HuggingFace's
+# own fixed formula, with `rotate_half`'s own `Slice` bounds resolving to a
+# clean, contiguous, non-overlapping split of the trailing (`head_size`) axis
+# into two equal halves (`half * 2 == head_size`, confirmed once `head_size`
+# itself is known -- see :func:`_decomposed_rope_hop_is_consistent`, the
+# deferred check this hop shares the idiom of with
+# :func:`_qk_norm_rope_hop_is_consistent`). `cos_operand`/`sin_operand` are
+# never inspected further -- confirmed to be, in different real exports,
+# either a graph input, a `Constant`, or fed by further upstream ops (e.g. a
+# `position_ids`-derived `Gather`); every one of those is safely treated as
+# one opaque per-position/per-half-head-dim operand this pass never needs to
+# resolve, since neither ever carries a `num_heads`/`kv_num_heads`-sized axis
+# to slice (broadcast over heads, sliced only along `head_size`, which whole-
+# head/KV-group pruning never touches). `cos_operand`/`sin_operand` are also
+# routinely the exact same shared tensor for Q's and K's own hop (confirmed
+# empirically -- both branches read `cos`/`sin` identically) -- harmless,
+# since neither is ever read by more than this fan-out, and neither is ever
+# written to.
+#
+# `x` itself (this branch's own pre-RoPE head-split `Transpose` output) is
+# read by exactly three consumers once RoPE is present -- the `direct` `Mul`
+# and both `Slice`s -- one more than the ordinary "single consumer" bar every
+# other hop in this section holds its own root to; checked explicitly here
+# (never guessed at) since fan-out any different from exactly this shape
+# means something this pass doesn't understand is also reading `x`.
+#
+# Q's and K's own matched node groups never share a single node with each
+# other (confirmed empirically -- distinct `Mul`/`Slice`/`Neg`/`Concat`/`Add`
+# nodes for each, operating on each branch's own distinct tensor), so no
+# `extra_stale_outputs`-style bookkeeping (:class:`_QKNormRopePassThrough`'s
+# own field for the *fused* family's analogous `GemmaRotaryEmbedding` sharing
+# case) is ever needed here.
+#
+# Unlike every hop :class:`_QKNormRopePassThrough` names, NOTHING here is a
+# shape constant carrying a literal head count: `cos_operand`/`sin_operand`
+# are per-position/per-half-head-dim (never per-head), and the `Slice` bounds
+# are fixed in terms of `head_size` alone, which whole-head/KV-group pruning
+# never changes -- only `num_heads`/`kv_num_heads` do. So this hop needs zero
+# rewriting of any kind post-pruning; :class:`_DecomposedRopePassThrough`
+# exists purely to name the matched nodes for stale-`value_info` bookkeeping,
+# the same purpose :class:`_QKNormRopePassThrough`'s own `nodes` field serves.
+@dataclass(frozen=True)
+class _DecomposedRopePassThrough:
+    """One matched Q- or K-branch decomposed RoPE application -- see this
+    module's own comment directly above for the exact topology and the
+    empirical confirmation behind it. `nodes` lists every node crossed (the
+    `Add`, both `Mul`s, the `Concat`/`Neg`/both `Slice`s of `rotate_half`, in
+    that order), purely for :func:`_apply_one_decomposed_gqa_chain`'s own
+    stale-`value_info` bookkeeping -- none of them ever need editing (see
+    this module's own comment above for why). `half` is the confirmed
+    `rotate_half` split point (`x1`'s own `Slice`'s `ends[0]`), threaded
+    through purely for :func:`_decomposed_rope_hop_is_consistent`'s own
+    deferred `half * 2 == head_size` check, run once `head_size` itself is
+    known (see that function's own docstring for why this can't be checked
+    any earlier -- the same deferred idiom :func:`_qk_norm_rope_hop_is_consistent`
+    already uses for the *fused* family's own analogous hop).
+    """
+
+    nodes: Tuple[onnx.NodeProto, ...]
+    half: int
+
+
+def _match_decomposed_rotate_half_slice(
+    name: str,
+    consumers_of: Dict[str, List[onnx.NodeProto]],
+    graph_outputs: Set[str],
+    node_by_output: Dict[str, onnx.NodeProto],
+    initializer_map: Dict[str, onnx.TensorProto],
+) -> Optional[
+    Tuple[onnx.NodeProto, onnx.NodeProto, onnx.NodeProto, onnx.NodeProto, str, int]
+]:
+    """Resolves `name` (already confirmed by the caller to be internal)
+    backward through the textbook HuggingFace ``rotate_half`` -- ``Concat(Neg(Slice(x,
+    second_half)), Slice(x, first_half), axis=-1)`` -- see this module's own
+    comment above :class:`_DecomposedRopePassThrough` for the exact
+    confirmed shape. Both ``Slice``s must share the identical root `x` and
+    resolve to a contiguous, non-overlapping, ``axes=[3]``-or-``[-1]``,
+    ``steps=[1]`` split (first half starting at 0, second half starting
+    exactly where the first ends and reaching at least that same point) --
+    the actual ``half * 2 == head_size`` cleanliness check is deferred to
+    :func:`_decomposed_rope_hop_is_consistent`, the same idiom
+    :func:`_match_decomposed_head_split` already defers its own shape
+    constant's fan-out safety to the caller for.
+
+    Returns ``(concat, neg, slice_first_half, slice_second_half, root_name,
+    half)`` on a match, ``None`` otherwise -- including whenever `name` isn't
+    produced by exactly this shape (a `Split`-based half, like
+    :func:`_match_rotate_half` matches for `GemmaRotaryEmbedding`'s own
+    output side, is a genuinely different topology and is not matched here).
+    """
+
+    def _is_internal(n: str) -> bool:
+        return len(consumers_of.get(n, [])) == 1 and n not in graph_outputs
+
+    concat = node_by_output.get(name)
+    if (
+        concat is None
+        or concat.domain != ""
+        or concat.op_type != "Concat"
+        or len(concat.input) != 2
+        or not concat.input[0]
+        or not concat.input[1]
+        or len(concat.output) != 1
+        or concat.output[0] != name
+    ):
+        return None
+    concat_axis = None
+    for attr in concat.attribute:
+        if attr.name == "axis":
+            concat_axis = attr.i
+    if concat_axis not in (-1, 3):
+        return None
+
+    neg_out, x1_out = concat.input
+    if neg_out == x1_out or not _is_internal(neg_out):
+        return None
+    neg = node_by_output.get(neg_out)
+    if (
+        neg is None
+        or neg.domain != ""
+        or neg.op_type != "Neg"
+        or len(neg.input) != 1
+        or not neg.input[0]
+        or len(neg.output) != 1
+        or neg.output[0] != neg_out
+    ):
+        return None
+    x2_out = neg.input[0]
+    if not x2_out or not _is_internal(x2_out):
+        return None
+
+    def _match_half_slice(
+        out_name: str,
+    ) -> Optional[Tuple[onnx.NodeProto, str, int, int]]:
+        s = node_by_output.get(out_name)
+        if (
+            s is None
+            or s.domain != ""
+            or s.op_type != "Slice"
+            or len(s.input) != 5
+            or not all(s.input)
+            or len(s.output) != 1
+            or s.output[0] != out_name
+        ):
+            return None
+        data_name, starts_n, ends_n, axes_n, steps_n = s.input
+        if not data_name:
+            return None
+        consts = [initializer_map.get(n) for n in (starts_n, ends_n, axes_n, steps_n)]
+        if any(c is None or c.data_type != onnx.TensorProto.INT64 for c in consts):
+            return None
+        starts, ends, axes, steps = (onnx.numpy_helper.to_array(c) for c in consts)
+        if (
+            starts.shape != (1,)
+            or ends.shape != (1,)
+            or axes.shape != (1,)
+            or steps.shape != (1,)
+        ):
+            return None
+        if int(axes[0]) not in (-1, 3) or int(steps[0]) != 1:
+            return None
+        return s, data_name, int(starts[0]), int(ends[0])
+
+    slice1 = _match_half_slice(x1_out)  # expected: x[..., :half]
+    if slice1 is None:
+        return None
+    slice1_node, root1, start1, end1 = slice1
+    slice2 = _match_half_slice(x2_out)  # expected: x[..., half:]
+    if slice2 is None:
+        return None
+    slice2_node, root2, start2, end2 = slice2
+
+    if root1 != root2 or root1 in graph_outputs:
+        return None
+    if start1 != 0 or end1 <= 0 or start2 != end1 or end2 < end1:
+        return None
+
+    return concat, neg, slice1_node, slice2_node, root1, end1
+
+
+def _match_decomposed_rope_pass_through(
+    name: str,
+    consumers_of: Dict[str, List[onnx.NodeProto]],
+    graph_outputs: Set[str],
+    node_by_output: Dict[str, onnx.NodeProto],
+    initializer_map: Dict[str, onnx.TensorProto],
+) -> Optional[Tuple[_DecomposedRopePassThrough, str]]:
+    """Resolves `name` (already confirmed by the caller to be internal --
+    exactly one consumer, not a graph output) backward through the fixed
+    7-node decomposed-RoPE shape :class:`_DecomposedRopePassThrough`'s own
+    docstring (and this module's own comment directly above it) describes.
+
+    Returns ``(hop, root_name)`` -- `root_name` the tensor immediately
+    upstream of every node crossed (expected, by the caller, to be this
+    branch's own head-split `Transpose` output) -- or ``None`` if `name`
+    isn't produced by exactly this shape, INCLUDING simply not being
+    produced by an ``Add`` at all (the common case for a chain with no RoPE
+    -- the caller falls back to treating `name` itself as the pre-RoPE root
+    when this declines, mirroring :func:`_match_decomposed_repeat_kv`'s own
+    "not this shape at all" fallback convention).
+    """
+
+    def _is_internal(n: str) -> bool:
+        return len(consumers_of.get(n, [])) == 1 and n not in graph_outputs
+
+    add = node_by_output.get(name)
+    if (
+        add is None
+        or add.domain != ""
+        or add.op_type != "Add"
+        or len(add.input) != 2
+        or not add.input[0]
+        or not add.input[1]
+        or len(add.output) != 1
+        or add.output[0] != name
+    ):
+        return None
+    a_name, b_name = add.input
+    if a_name == b_name:
+        return None
+
+    def _try_order(
+        direct_name: str, rotated_name: str
+    ) -> Optional[Tuple[_DecomposedRopePassThrough, str]]:
+        if not _is_internal(direct_name) or not _is_internal(rotated_name):
+            return None
+        mul_direct = node_by_output.get(direct_name)
+        mul_rotated = node_by_output.get(rotated_name)
+        for mul in (mul_direct, mul_rotated):
+            if (
+                mul is None
+                or mul.domain != ""
+                or mul.op_type != "Mul"
+                or len(mul.input) != 2
+                or not mul.input[0]
+                or not mul.input[1]
+                or len(mul.output) != 1
+            ):
+                return None
+        assert mul_direct is not None and mul_rotated is not None
+        if mul_direct.output[0] != direct_name or mul_rotated.output[0] != rotated_name:
+            return None
+
+        rot_a, rot_b = mul_rotated.input
+        for concat_name, sin_operand in ((rot_a, rot_b), (rot_b, rot_a)):
+            if concat_name == sin_operand or not _is_internal(concat_name):
+                continue
+            rotate_half = _match_decomposed_rotate_half_slice(
+                concat_name,
+                consumers_of,
+                graph_outputs,
+                node_by_output,
+                initializer_map,
+            )
+            if rotate_half is None:
+                continue
+            concat, neg, slice1, slice2, root_name, half = rotate_half
+
+            d_a, d_b = mul_direct.input
+            for root_cand, cos_operand in ((d_a, d_b), (d_b, d_a)):
+                if root_cand != root_name or root_cand == cos_operand:
+                    continue
+                # `root_name` must be read by exactly the three consumers
+                # this hop itself accounts for (the direct `Mul` plus both
+                # `Slice`s) -- see this module's own comment above
+                # :class:`_DecomposedRopePassThrough` for why this, unlike
+                # every other root this section's matchers resolve, is
+                # deliberately checked against 3 rather than 1.
+                if len(consumers_of.get(root_name, [])) != 3:
+                    continue
+                return (
+                    _DecomposedRopePassThrough(
+                        (add, mul_direct, mul_rotated, concat, neg, slice1, slice2),
+                        half,
+                    ),
+                    root_name,
+                )
+        return None
+
+    return _try_order(a_name, b_name) or _try_order(b_name, a_name)
+
+
+def _walk_back_through_decomposed_rope(
+    name: str,
+    consumers_of: Dict[str, List[onnx.NodeProto]],
+    graph_outputs: Set[str],
+    node_by_output: Dict[str, onnx.NodeProto],
+    initializer_map: Dict[str, onnx.TensorProto],
+) -> Tuple[str, Optional[_DecomposedRopePassThrough]]:
+    """Thin wrapper around :func:`_match_decomposed_rope_pass_through`
+    mirroring :func:`_walk_back_through_qk_norm_rope`'s own ``(root_name,
+    hop)`` return convention -- ``(name, None)`` when no RoPE hop was
+    crossed, so the caller can call :func:`_match_decomposed_head_split` on
+    the result uniformly regardless of whether RoPE was present.
+    """
+    matched = _match_decomposed_rope_pass_through(
+        name, consumers_of, graph_outputs, node_by_output, initializer_map
+    )
+    if matched is None:
+        return name, None
+    hop, root_name = matched
+    return root_name, hop
+
+
+def _decomposed_rope_hop_is_consistent(
+    hop: Optional[_DecomposedRopePassThrough], head_size: int
+) -> bool:
+    """Deferred correctness check for a
+    :func:`_walk_back_through_decomposed_rope` result, run only once
+    `head_size` (this branch's own, resolved by the caller's own
+    :func:`_match_decomposed_head_split` call on the returned root) is
+    itself known -- the same deferred idiom
+    :func:`_qk_norm_rope_hop_is_consistent` already uses for the *fused*
+    family's own analogous hop. `True` (nothing to check) when `hop` is
+    ``None``. Otherwise requires the matched ``rotate_half``'s own split
+    point to be an exact, clean half of `head_size` (``hop.half * 2 ==
+    head_size``) -- declined (``False``), never guessed at, on any
+    mismatch (e.g. a `Slice` that isn't actually splitting `head_size` in
+    half at all).
+    """
+    if hop is None:
+        return True
+    return hop.half * 2 == head_size
+
+
 def _find_decomposed_gqa_chains(
     graph: onnx.GraphProto,
     value_info_by_name: Optional[Dict[str, onnx.ValueInfoProto]] = None,
@@ -23301,6 +23688,16 @@ def _find_decomposed_gqa_chains(
 
         k_headsplit_transpose: Optional[onnx.NodeProto]
         k_repeat_kv: Optional[_RepeatKVBranch] = None
+        # RoPE, when present on K's own branch, always forces the separate-
+        # transpose form below: its own `Slice`/`Mul`/`Add` nodes sit
+        # between the head-split `Transpose` and the dot-product "swap"
+        # `Transpose`, breaking the node-adjacency PyTorch's own
+        # `fuseConsecutiveTransposes` peephole requires to collapse the two
+        # into this combined `perm=[0, 2, 3, 1]` shape (confirmed
+        # empirically -- see this module's own comment above
+        # :class:`_DecomposedRopePassThrough`) -- so this branch never
+        # crosses RoPE at all, `k_rope` stays `None` for it unconditionally.
+        k_rope: Optional[_DecomposedRopePassThrough] = None
         if k_perm == [0, 2, 3, 1]:
             k_split = _match_decomposed_head_split(
                 k_operand,
@@ -23336,8 +23733,11 @@ def _find_decomposed_gqa_chains(
                     k_bhsd_name,
                     None,
                 )  # resolved via head-split below
+            k_rope_root, k_rope = _walk_back_through_decomposed_rope(
+                k_raw_name, consumers_of, graph_outputs, node_by_output, initializer_map
+            )
             k_split = _match_decomposed_head_split(
-                k_raw_name,
+                k_rope_root,
                 consumers_of,
                 graph_outputs,
                 node_by_output,
@@ -23354,6 +23754,8 @@ def _find_decomposed_gqa_chains(
                 k_reshape_shape,
                 k_proj_out,
             ) = k_split
+            if not _decomposed_rope_hop_is_consistent(k_rope, head_size_k):
+                continue
             if kv_num_heads is None:
                 kv_num_heads = resolved_kv_heads
             elif kv_num_heads != resolved_kv_heads:
@@ -23371,8 +23773,11 @@ def _find_decomposed_gqa_chains(
         assert kv_num_heads is not None
 
         # ---- Q's own branch: plain head-split, never repeat_kv ----
+        q_rope_root, q_rope = _walk_back_through_decomposed_rope(
+            q_bhsd_name, consumers_of, graph_outputs, node_by_output, initializer_map
+        )
         q_split = _match_decomposed_head_split(
-            q_bhsd_name,
+            q_rope_root,
             consumers_of,
             graph_outputs,
             node_by_output,
@@ -23384,6 +23789,8 @@ def _find_decomposed_gqa_chains(
         q_transpose, q_reshape, num_heads, head_size, q_reshape_shape, q_proj_out = (
             q_split
         )
+        if not _decomposed_rope_hop_is_consistent(q_rope, head_size):
+            continue
         if head_size != head_size_k or num_heads <= 0 or kv_num_heads <= 0:
             continue
         if num_heads % kv_num_heads != 0:
@@ -23642,6 +24049,8 @@ def _find_decomposed_gqa_chains(
                 packed_split_sizes=packed_split_sizes,
                 packed_flatten_reshape=packed_flatten_reshape,
                 packed_flatten_reshape_shape=packed_flatten_reshape_shape,
+                q_rope=q_rope,
+                k_rope=k_rope,
             )
         )
     return chains
@@ -23948,6 +24357,15 @@ def _apply_one_decomposed_gqa_chain(
             stale.update(branch.unsqueeze.output)
             stale.update(branch.expand.output)
             stale.update(branch.merge_reshape.output)
+    # Q's/K's own decomposed RoPE pass-through, if either branch crossed one
+    # -- see this module's own comment above :class:`_DecomposedRopePassThrough`
+    # for why none of its own nodes ever need editing, only marking stale
+    # (every one of their own outputs is narrower after pruning, the same
+    # "nothing to rewrite, still stale" treatment `k_repeat_kv`/`v_repeat_kv`
+    # get for their own `unsqueeze`'s `axes` input).
+    for hop in (chain.q_rope, chain.k_rope):
+        if hop is not None:
+            stale.update(n.output[0] for n in hop.nodes if n.output and n.output[0])
 
     return (
         {chain.q_weight, chain.k_weight, chain.v_weight},

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -40585,6 +40585,7 @@ def _decomposed_gqa_model(
     out_reshape_wildcard=False,
     share_kv_reshape_shape=True,
     extra_foreign_q_reshape_consumer=False,
+    rope=False,
 ):
     """Builds the decomposed-attention graph:
     ``Linear(Q/K/V) -> Reshape(to heads) -> Transpose(to BHSD) ->
@@ -40611,6 +40612,20 @@ def _decomposed_gqa_model(
     adds a second, wholly unrelated `Reshape` reading Q's own head-split
     shape constant (simulating cross-layer CSE) to exercise the *cloning*
     path instead -- see that function's own docstring.
+
+    `rope` (default `False`) additionally applies the decomposed Llama/HF-
+    style RoPE hop :func:`_match_decomposed_rope_pass_through` recognizes
+    (see onnxsim/pruning.py's own comment above
+    :class:`_DecomposedRopePassThrough` for the confirmed shape) to Q's and
+    K's own branch, each independently, right after that branch's own
+    head-split `Transpose` and before (for K) `repeat_kv`/the dot-product
+    "swap" transpose -- two new graph inputs, `Cos`/`Sin` (`[batch, seq,
+    D]`), feed both hops identically (`Unsqueeze`d once, shared, exactly as
+    a real export's own common-subexpression elimination does). Forces K's
+    own dot-product transpose into the separate (never combined
+    `perm=[0, 2, 3, 1]`) form even when `KVH == H` -- RoPE's own nodes
+    always break the head-split/swap-transpose adjacency that combined form
+    requires, confirmed empirically (see that same section comment).
     """
     if Dv is None:
         Dv = D
@@ -40628,7 +40643,35 @@ def _decomposed_gqa_model(
     def _i64(arr, name):
         return onnx.numpy_helper.from_array(np.array(arr, dtype=np.int64), name)
 
+    def _rope_lines(prefix, src, out_name, d):
+        # `x * cos + rotate_half(x) * sin`, HuggingFace's own fixed formula
+        # -- see onnxsim/pruning.py's own comment above
+        # :class:`_DecomposedRopePassThrough` for the exact confirmed shape
+        # this mirrors, node for node.
+        return [
+            f"{prefix}direct = Mul({src}, CosU)",
+            f"{prefix}x1 = Slice({src}, SliceStart0, SliceHalf, SliceAxis3, SliceStep1)",
+            f"{prefix}x2 = Slice({src}, SliceHalf, SliceEnd, SliceAxis3, SliceStep1)",
+            f"{prefix}neg = Neg({prefix}x2)",
+            f"{prefix}rot = Concat<axis=-1>({prefix}neg, {prefix}x1)",
+            f"{prefix}rotated = Mul({prefix}rot, SinU)",
+            f"{out_name} = Add({prefix}direct, {prefix}rotated)",
+        ]
+
     initializer = [_f32(wq, "Wq"), _f32(wk, "Wk"), _f32(wv, "Wv"), _f32(wout, "Wout")]
+    extra_inputs = ""
+
+    if rope:
+        assert D % 2 == 0
+        initializer += [
+            _i64([0], "SliceStart0"),
+            _i64([D // 2], "SliceHalf"),
+            _i64([D], "SliceEnd"),
+            _i64([3], "SliceAxis3"),
+            _i64([1], "SliceStep1"),
+            _i64([1], "Ax1"),
+        ]
+        extra_inputs += f", float[{batch},{seq},{D}] Cos, float[{batch},{seq},{D}] Sin"
 
     # Gemm requires a rank-2 input (unlike MatMul, which happily broadcasts
     # over the leading batch/seq axes) -- flattening `X` to `[batch*seq, K]`
@@ -40640,6 +40683,8 @@ def _decomposed_gqa_model(
     # regardless of `bias`, with no separate code path for either case.
     initializer.append(_i64([batch * seq, K], "XFlatShape"))
     lines = ["xf = Reshape(X, XFlatShape)"]
+    if rope:
+        lines += ["CosU = Unsqueeze(Cos, Ax1)", "SinU = Unsqueeze(Sin, Ax1)"]
     q_op, k_op, v_op, o_op = (
         "MatMul(xf, Wq)",
         "MatMul(xf, Wk)",
@@ -40668,8 +40713,10 @@ def _decomposed_gqa_model(
     lines += [
         "q0 = " + q_op,
         "qr = Reshape(q0, Sq)",
-        "qt = Transpose<perm=[0,2,1,3]>(qr)",
+        ("qt0" if rope else "qt") + " = Transpose<perm=[0,2,1,3]>(qr)",
     ]
+    if rope:
+        lines += _rope_lines("q", "qt0", "qt", D)
 
     if extra_foreign_q_reshape_consumer:
         # A second, wholly unrelated Reshape reading the SAME shape
@@ -40696,39 +40743,59 @@ def _decomposed_gqa_model(
     lines += ["v0 = " + v_op, f"vr = Reshape(v0, {sv_name})"]
 
     n_rep = H // KVH
-    if KVH == H:
-        lines.append("kt = Transpose<perm=[0,2,3,1]>(kr)")
-        lines.append("vt = Transpose<perm=[0,2,1,3]>(vr)")
-    else:
+    needs_repeat_kv = KVH < H
+    # RoPE, when present, always forces the separate head-split-then-swap
+    # form for K's own dot-product transpose -- its own nodes sit between
+    # the two, breaking the adjacency the combined `perm=[0, 2, 3, 1]` form
+    # requires -- even when `KVH == H` leaves no genuine `repeat_kv` to also
+    # force it (see this function's own docstring).
+    needs_separate_k_transpose = needs_repeat_kv or rope
+    if needs_repeat_kv:
         assert H % KVH == 0
         initializer.append(_i64([2], "Ax2"))
         initializer.append(_i64([batch, KVH, n_rep, seq, D], "KExpandShape"))
         initializer.append(_i64([batch, H, seq, D], "KMergeShape"))
         initializer.append(_i64([batch, KVH, n_rep, seq, Dv], "VExpandShape"))
         initializer.append(_i64([batch, H, seq, Dv], "VMergeShape"))
+
+    if needs_separate_k_transpose:
+        lines.append("kt0 = Transpose<perm=[0,2,1,3]>(kr)")
+        k_src = "kt0"
+        if rope:
+            lines += _rope_lines("k", "kt0", "krope", D)
+            k_src = "krope"
+        if needs_repeat_kv:
+            lines += [
+                f"ku = Unsqueeze({k_src}, Ax2)",
+                "ke = Expand(ku, KExpandShape)",
+                "kre = Reshape(ke, KMergeShape)",
+                "kt = Transpose<perm=[0,1,3,2]>(kre)",
+            ]
+        else:
+            lines.append(f"kt = Transpose<perm=[0,1,3,2]>({k_src})")
+    else:
+        lines.append("kt = Transpose<perm=[0,2,3,1]>(kr)")
+
+    if needs_repeat_kv:
         lines += [
-            "kt0 = Transpose<perm=[0,2,1,3]>(kr)",
-            "ku = Unsqueeze(kt0, Ax2)",
-            "ke = Expand(ku, KExpandShape)",
-            "kre = Reshape(ke, KMergeShape)",
-            "kt = Transpose<perm=[0,1,3,2]>(kre)",
             "vt0 = Transpose<perm=[0,2,1,3]>(vr)",
             "vu = Unsqueeze(vt0, Ax2)",
             "ve = Expand(vu, VExpandShape)",
             "vt = Reshape(ve, VMergeShape)",
         ]
+    else:
+        lines.append("vt = Transpose<perm=[0,2,1,3]>(vr)")
 
     initializer.append(_f32(np.array(D**-0.5, dtype=np.float32), "Scale"))
     lines += ["qk = MatMul(qt, kt)", "scaled = Mul(qk, Scale)"]
 
-    extra_inputs = ""
     if masked:
         if mask is None:
             mask = np.triu(np.full((seq, seq), -1e4, dtype=np.float32), k=1)[
                 None, None, :, :
             ]
         if mask_dynamic:
-            extra_inputs = f", float[1,1,{seq},{seq}] Mask"
+            extra_inputs += f", float[1,1,{seq},{seq}] Mask"
         else:
             initializer.append(_f32(np.asarray(mask), "Mask"))
         lines.append("premask = Add(scaled, Mask)")
@@ -41406,6 +41473,332 @@ def test_decomposed_attention_real_torch_export_pipeline():
     oracle_out = linear(ctx, wo, bo)
 
     np.testing.assert_allclose(ort_out, oracle_out, rtol=1e-3, atol=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# Decomposed (un-fused) attention -- RoPE pass-through
+# ---------------------------------------------------------------------------
+# `_find_decomposed_gqa_chains` now also recognizes the decomposed Llama/HF-
+# style RoPE hop (`x * cos + rotate_half(x) * sin`) sitting between each
+# branch's own head-split `Transpose` and the QK^T `MatMul` (Q) or K's own
+# dot-product-transpose resolution (K) -- see onnxsim/pruning.py's own
+# comment above `_DecomposedGQAChain` and `class _DecomposedRopePassThrough`.
+
+
+def test_decomposed_attention_rope_real_torch_export_pipeline():
+    """The real end-to-end pipeline this feature targets, RoPE included:
+    ``torch.onnx.export -> onnxsim.simplify() -> apply_attention_head_pruning``
+    on an actual hand-written eager-attention `nn.Module` applying
+    HuggingFace's own `apply_rotary_pos_emb`/`rotate_half` to Q and K
+    between the head-split and the QK^T MatMul (GQA + a causal mask, the
+    common real-world Llama/Mistral/Qwen shape) -- confirming the RoPE
+    pass-through genuinely fires on a real export (not just a hand-built
+    fixture) and the pruned model's output matches an independently-computed
+    numpy oracle built directly from the PRUNED model's own (already-sliced)
+    tensors, run through a real `onnxruntime.InferenceSession`. Mirrors
+    `test_decomposed_attention_real_torch_export_pipeline` exactly, with
+    RoPE added to both Q's and K's own branch.
+    """
+    torch = pytest.importorskip("torch")
+    pytest.importorskip("onnxruntime")
+    import torch.nn as nn  # noqa: E402  (after the torch importorskip guard)
+
+    hidden, num_heads, num_kv_heads, head_dim, seq, batch = 32, 8, 2, 8, 4, 1
+
+    def rotate_half(x):
+        x1 = x[..., : x.shape[-1] // 2]
+        x2 = x[..., x.shape[-1] // 2 :]
+        return torch.cat((-x2, x1), dim=-1)
+
+    def apply_rotary_pos_emb(q, k, cos, sin):
+        cos = cos.unsqueeze(1)
+        sin = sin.unsqueeze(1)
+        q_embed = (q * cos) + (rotate_half(q) * sin)
+        k_embed = (k * cos) + (rotate_half(k) * sin)
+        return q_embed, k_embed
+
+    class EagerGQARope(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.num_heads = num_heads
+            self.num_kv_heads = num_kv_heads
+            self.head_dim = head_dim
+            self.q_proj = nn.Linear(hidden, num_heads * head_dim, bias=True)
+            self.k_proj = nn.Linear(hidden, num_kv_heads * head_dim, bias=True)
+            self.v_proj = nn.Linear(hidden, num_kv_heads * head_dim, bias=True)
+            self.o_proj = nn.Linear(num_heads * head_dim, hidden, bias=True)
+            self.scaling = head_dim**-0.5
+
+        def _repeat_kv(self, x, n_rep):
+            if n_rep == 1:
+                return x
+            b, kvh, s, d = x.shape
+            x = x[:, :, None, :, :].expand(b, kvh, n_rep, s, d)
+            return x.reshape(b, kvh * n_rep, s, d)
+
+        def forward(self, hidden_states, cos, sin, attn_mask):
+            b, s, _ = hidden_states.shape
+            q = (
+                self.q_proj(hidden_states)
+                .view(b, s, self.num_heads, self.head_dim)
+                .transpose(1, 2)
+            )
+            k = (
+                self.k_proj(hidden_states)
+                .view(b, s, self.num_kv_heads, self.head_dim)
+                .transpose(1, 2)
+            )
+            v = (
+                self.v_proj(hidden_states)
+                .view(b, s, self.num_kv_heads, self.head_dim)
+                .transpose(1, 2)
+            )
+            q, k = apply_rotary_pos_emb(q, k, cos, sin)
+            n_rep = self.num_heads // self.num_kv_heads
+            k = self._repeat_kv(k, n_rep)
+            v = self._repeat_kv(v, n_rep)
+            attn_weights = torch.matmul(q, k.transpose(2, 3)) * self.scaling
+            attn_weights = attn_weights + attn_mask
+            attn_weights = torch.softmax(attn_weights, dim=-1)
+            attn_output = torch.matmul(attn_weights, v)
+            attn_output = attn_output.transpose(1, 2).contiguous().reshape(b, s, -1)
+            return self.o_proj(attn_output)
+
+    m = EagerGQARope()
+    m.eval()
+    x = torch.randn(batch, seq, hidden)
+    cos = torch.randn(batch, seq, head_dim)
+    sin = torch.randn(batch, seq, head_dim)
+    mask = torch.triu(torch.full((seq, seq), float("-inf")), diagonal=1)[
+        None, None, :, :
+    ]
+
+    buf = io.BytesIO()
+    torch.onnx.export(
+        m,
+        (x, cos, sin, mask),
+        buf,
+        input_names=["hidden_states", "cos", "sin", "attn_mask"],
+        output_names=["output"],
+        opset_version=17,
+        dynamo=False,
+    )
+    raw = onnx.load_from_string(buf.getvalue())
+
+    simplified, ok = onnxsim.onnx_simplifier.simplify(raw)
+    assert ok
+
+    assert not any(
+        n.op_type
+        in ("Attention", "GroupQueryAttention", "MultiHeadAttention", "PagedAttention")
+        for n in simplified.graph.node
+    )
+
+    from onnxsim.pruning import (
+        _find_decomposed_gqa_chains,
+        _shape_inferred_value_info_by_name,
+    )
+
+    chains = _find_decomposed_gqa_chains(
+        simplified.graph, _shape_inferred_value_info_by_name(simplified)
+    )
+    assert len(chains) == 1
+    assert chains[0].q_rope is not None
+    assert chains[0].k_rope is not None
+
+    pruned = onnxsim.apply_attention_head_pruning(simplified, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    def _find_gemm(model, bias_substr):
+        for n in model.graph.node:
+            if n.op_type == "Gemm" and len(n.input) == 3 and bias_substr in n.input[2]:
+                return n
+        raise AssertionError(f"no Gemm found for {bias_substr!r}")
+
+    def _init(model, name):
+        for t in model.graph.initializer:
+            if t.name == name:
+                return onnx.numpy_helper.to_array(t)
+        for n in model.graph.node:
+            if n.op_type == "Constant" and n.output[0] == name:
+                for a in n.attribute:
+                    if a.name == "value":
+                        return onnx.numpy_helper.to_array(a.t)
+        raise AssertionError(f"no initializer/Constant found for {name!r}")
+
+    q_gemm = _find_gemm(pruned, "q_proj.bias")
+    k_gemm = _find_gemm(pruned, "k_proj.bias")
+    v_gemm = _find_gemm(pruned, "v_proj.bias")
+    o_gemm = _find_gemm(pruned, "o_proj.bias")
+    wq, bq = _init(pruned, q_gemm.input[1]), _init(pruned, q_gemm.input[2])
+    wk, bk = _init(pruned, k_gemm.input[1]), _init(pruned, k_gemm.input[2])
+    wv, bv = _init(pruned, v_gemm.input[1]), _init(pruned, v_gemm.input[2])
+    wo, bo = _init(pruned, o_gemm.input[1]), _init(pruned, o_gemm.input[2])
+
+    new_num_heads = wq.shape[1] // head_dim
+    new_kv_num_heads = wk.shape[1] // head_dim
+    new_v_head_dim = wv.shape[1] // new_kv_num_heads
+    assert new_num_heads < num_heads
+    assert new_kv_num_heads < num_kv_heads
+    assert new_num_heads // new_kv_num_heads == num_heads // num_kv_heads
+
+    rng = np.random.default_rng(0)
+    hidden_states = rng.standard_normal((batch, seq, hidden)).astype(np.float32)
+    cos_np = rng.standard_normal((batch, seq, head_dim)).astype(np.float32)
+    sin_np = rng.standard_normal((batch, seq, head_dim)).astype(np.float32)
+    mask_np = mask.numpy().astype(np.float32)
+
+    sess = ort.InferenceSession(
+        pruned.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    (ort_out,) = sess.run(
+        None,
+        {
+            "hidden_states": hidden_states,
+            "cos": cos_np,
+            "sin": sin_np,
+            "attn_mask": mask_np,
+        },
+    )
+
+    def linear(x, w, b):
+        return x @ w + b
+
+    def np_rotate_half(x):
+        x1 = x[..., : x.shape[-1] // 2]
+        x2 = x[..., x.shape[-1] // 2 :]
+        return np.concatenate([-x2, x1], axis=-1)
+
+    def np_apply_rope(q, k, cos, sin):
+        cos_ = cos[:, None, :, :]
+        sin_ = sin[:, None, :, :]
+        return (
+            q * cos_ + np_rotate_half(q) * sin_,
+            k * cos_ + np_rotate_half(k) * sin_,
+        )
+
+    q = (
+        linear(hidden_states, wq, bq)
+        .reshape(batch, seq, new_num_heads, head_dim)
+        .transpose(0, 2, 1, 3)
+    )
+    k = (
+        linear(hidden_states, wk, bk)
+        .reshape(batch, seq, new_kv_num_heads, head_dim)
+        .transpose(0, 2, 1, 3)
+    )
+    v = (
+        linear(hidden_states, wv, bv)
+        .reshape(batch, seq, new_kv_num_heads, new_v_head_dim)
+        .transpose(0, 2, 1, 3)
+    )
+    q, k = np_apply_rope(q, k, cos_np, sin_np)
+    n_rep = new_num_heads // new_kv_num_heads
+    if n_rep > 1:
+        k = np.repeat(k, n_rep, axis=1)
+        v = np.repeat(v, n_rep, axis=1)
+    scale = head_dim**-0.5
+    scores = np.matmul(q, k.transpose(0, 1, 3, 2)) * scale
+    scores = scores + mask_np
+    scores = scores - scores.max(axis=-1, keepdims=True)
+    exp = np.exp(scores)
+    attn = exp / exp.sum(axis=-1, keepdims=True)
+    ctx = np.matmul(attn, v)
+    ctx = ctx.transpose(0, 2, 1, 3).reshape(batch, seq, new_num_heads * new_v_head_dim)
+    oracle_out = linear(ctx, wo, bo)
+
+    np.testing.assert_allclose(ort_out, oracle_out, rtol=1e-3, atol=1e-3)
+
+
+def test_decomposed_gqa_rope_pruning_matches_oracle_exactly():
+    model, cfg = _decomposed_gqa_model(K=16, H=8, KVH=2, D=8, Out=16, seed=1, rope=True)
+    rng = np.random.default_rng(7)
+    cos = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["D"])).astype(np.float32)
+    sin = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["D"])).astype(np.float32)
+
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    wq_new, wk_new, wv_new, wo_new = _decomposed_weight_shapes(pruned)
+    group_size = cfg["H"] // cfg["KVH"]
+    new_kv = cfg["KVH"] - round(cfg["KVH"] * 0.5)
+    assert wk_new.shape[1] == new_kv * cfg["D"]
+    assert wq_new.shape[1] == new_kv * group_size * cfg["D"]
+
+    keep_groups = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], cfg["H"], cfg["KVH"], cfg["D"], new_kv
+    )
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    d = cfg["D"]
+    q_idx, kv_idx = _head_idx(keep_q_heads, d), _head_idx(keep_groups, d)
+
+    oracle, _ = _decomposed_gqa_model(
+        K=cfg["K"],
+        H=len(keep_q_heads),
+        KVH=new_kv,
+        D=d,
+        Out=cfg["Out"],
+        seed=1,
+        rope=True,
+        wq=cfg["wq"][:, q_idx],
+        wk=cfg["wk"][:, kv_idx],
+        wv=cfg["wv"][:, kv_idx],
+        wout=cfg["wout"][q_idx, :],
+        bq=cfg["bq"][q_idx],
+        bk=cfg["bk"][kv_idx],
+        bv=cfg["bv"][kv_idx],
+        bout=cfg["bout"],
+        batch=cfg["batch"],
+        seq=cfg["seq"],
+    )
+
+    rng2 = np.random.default_rng(2)
+    x = rng2.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    feed = {"X": x, "Cos": cos, "Sin": sin}
+    (y_pruned,) = _run(pruned, feed)
+    (y_oracle,) = _run(oracle, feed)
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_decomposed_gqa_rope_pruning_declines_on_unclean_half_split():
+    # `rotate_half`'s own `Slice` bounds must resolve to a clean, exact half
+    # of `head_size` (see `_decomposed_rope_hop_is_consistent`) -- shifting
+    # the shared split point off-center must decline the whole chain, never
+    # guessed at.
+    model, cfg = _decomposed_gqa_model(K=16, H=8, KVH=2, D=8, Out=16, seed=1, rope=True)
+    for t in model.graph.initializer:
+        if t.name == "SliceHalf":
+            t.CopyFrom(
+                onnx.numpy_helper.from_array(
+                    np.array([cfg["D"] // 2 + 1], dtype=np.int64), "SliceHalf"
+                )
+            )
+    before = {
+        t.name: onnx.numpy_helper.to_array(t).shape for t in model.graph.initializer
+    }
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    after = {
+        t.name: onnx.numpy_helper.to_array(t).shape for t in pruned.graph.initializer
+    }
+    assert before == after
+
+
+def test_decomposed_gqa_rope_pruning_declines_on_slice_root_mismatch():
+    # Both of `rotate_half`'s own `Slice`s must read the SAME root tensor --
+    # rewiring one to a different, unrelated tensor must decline the whole
+    # chain, never guessed at.
+    model, _ = _decomposed_gqa_model(K=16, H=8, KVH=2, D=8, Out=16, seed=1, rope=True)
+    for n in model.graph.node:
+        if n.output and n.output[0] == "qx2":
+            n.input[0] = "xf"  # unrelated tensor, not Q's own head-split output
+    before = {
+        t.name: onnx.numpy_helper.to_array(t).shape for t in model.graph.initializer
+    }
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    after = {
+        t.name: onnx.numpy_helper.to_array(t).shape for t in pruned.graph.initializer
+    }
+    assert before == after
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The "Decomposed (un-fused) attention head pruning" feature's own section comment explicitly documented "Q/K-norm+RoPE pass-through is not recognized here" as an open gap. This PR closes the RoPE half of that gap (Q/K-norm is deliberately deferred to a separate future pass — see below): a real `torch.onnx.export()` of a Llama/Mistral/Qwen/Gemma-style eager-attention module applies RoPE to Q and K *between* the head-split and the QK^T `MatMul`, with no fused rotary op anywhere in this export path — since this sits directly in the middle of the previously-recognized shape, any RoPE-using model exported without ORT's transformer-fusion pass got **zero attention-head pruning**, despite RoPE now being the dominant modern LLM position-encoding scheme.

## Empirically confirmed facts

Confirmed live via a hand-built module mirroring `transformers.models.llama.modeling_llama`'s own `apply_rotary_pos_emb`/`rotate_half`, exported with `torch.onnx.export(..., opset_version=17, dynamo=False)` and run through this module's own `onnxsim.simplify()` (both a GQA/repeat_kv case and a plain-MHA case — repeat_kv's presence doesn't change this hop's own shape):

```
direct    = Mul(x, cos_operand)
x1        = Slice(x, starts=[0], ends=[half], axes=[3], steps=[1])
x2        = Slice(x, starts=[half], ends=[...], axes=[3], steps=[1])
neg       = Neg(x2)
rotated_x = Concat(neg, x1, axis=-1_or_3)   # rotate_half(x) = cat(-x2, x1)
rotated   = Mul(rotated_x, sin_operand)
result    = Add(direct, rotated)
```

`cos_operand`/`sin_operand` are never inspected further (confirmed to appear, in different real exports, as a graph input, a `Constant`, or fed by further upstream ops like a `position_ids`-derived `Gather`) since neither ever carries a `num_heads`/`kv_num_heads`-sized axis. RoPE, when present on K's branch, always forces K's separate-transpose form (never the pre-composed `perm=[0,2,3,1]`) — its own nodes break the `Transpose`-adjacency PyTorch's `fuseConsecutiveTransposes` peephole needs. `rotate_half` here uses `Slice` (not `Split`, unlike the existing *fused*-family `GemmaRotaryEmbedding` matcher `_match_rotate_half`, which is a structurally distinct shape).

## What's added

- `_DecomposedRopePassThrough` dataclass, `_match_decomposed_rotate_half_slice`, `_match_decomposed_rope_pass_through`, `_walk_back_through_decomposed_rope` (mirrors `_walk_back_through_qk_norm_rope`'s `(root_name, hop)` return contract), `_decomposed_rope_hop_is_consistent` (the deferred `half*2 == head_size` check, run once `head_size` is known — same idiom as `_qk_norm_rope_hop_is_consistent` for the fused family).
- Wired into `_find_decomposed_gqa_chains` on Q's branch and K's separate-transpose branch (never K's combined-perm branch, which structurally can't carry RoPE); matched independently for Q and K (a chain with RoPE on only one side still matches, though every real export applies it to both).
- `_DecomposedGQAChain`: new `q_rope`/`k_rope` fields.
- `_apply_one_decomposed_gqa_chain`: needs zero new rewriting — RoPE's own nodes (`cos`/`sin`, `rotate_half`'s `Slice` bounds) are all in terms of `head_size`, which pruning never changes; only marked stale for `value_info` bookkeeping, the same treatment every other passed-through node group already gets.

**Q/K-norm pass-through is deliberately NOT included here** — a structurally distinct, smaller-value-alone shape (only Qwen3/Gemma2-style architectures apply one), left for a dedicated future pass per this round's own survey recommendation rather than bundled into an oversized diff.

## Test plan

- [x] `pytest tests/test_pruning.py -q` — 854 passed (850 baseline + 4 new); the same 21 pre-existing, unrelated failures remain (`apply_transformer_block_pruning` missing from this environment's stale compiled C++ extension — confirmed identical before/after; CI builds fresh)
- [x] `ruff format --check` / `ruff check` on both touched files — clean
- [x] `mypy onnxsim/pruning.py` — 0 errors
- [x] Independently re-verified via a revert-only-`pruning.py` check: the 2 oracle/real-pipeline tests fail against the pre-change code; the 2 decline tests correctly pass either way (they guard against *future* regressions in the root-match/half-split checks, since any RoPE-containing chain was already declined pre-fix — the positive tests carry the with/without-fix contrast); restored and confirmed all 4 pass again
- [x] Verified against a real `torch.onnx.export → onnxsim.simplify() → apply_attention_head_pruning` pipeline for a Llama-style eager-attention module with real RoPE applied, GQA included: pruning fires correctly and the pruned output matches an independently-built numpy oracle

## Risks for a reviewer to double check

1. `Slice`'s axis is accepted as either `3` or `-1`; only `axis=3` was ever observed empirically in this round's testing.
2. K-RoPE-forces-separate-transpose-form relies on an empirical "the peephole never fires across RoPE" finding, not a schema guarantee — a future PyTorch/onnxsim optimizer change could in principle alter this, in which case the chain would simply decline (never mis-slice) rather than silently break.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_