### PR TITLE
Recognize Einsum QK^T/AV products in decomposed attention pruning

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -22607,7 +22607,39 @@ def _find_sparse_attention_chains(
 #   peephole optimization (`fuseConsecutiveTransposes`) collapses them into.
 #   `repeat_kv` (when present) always sits between the two, breaking that
 #   adjacency, so only the separate-transpose shape is ever tried once
-#   `repeat_kv` has matched.
+#   `repeat_kv` has matched. This is all `MatMul`-only: neither of these two
+#   `Transpose`-based shapes is even reachable for the QK^T product's own
+#   `Einsum` alternative below, since `Einsum` never needs an explicit
+#   dot-product transpose in the first place (its own `equation` already
+#   contracts K's natural, un-transposed layout directly).
+# - The QK^T product and the AV product are each *independently* allowed to
+#   be a literal `Einsum` node instead of `MatMul` -- confirmed empirically
+#   (via `torch.onnx.export`, see `_einsum_equation_is_batched_matmul`'s own
+#   test suite) to be exactly what PyTorch's ONNX exporter emits for a
+#   `torch.einsum`-written attention block (common in `x-transformers`/
+#   `vit-pytorch`/`performer-pytorch`-style reimplementations, and for
+#   `tf2onnx`-exported `tf.einsum` code), where neither product ever goes
+#   through `MatMul` at all -- e.g. `"bhid,bhjd->bhij"` for the QK^T
+#   product, `"bhij,bhjd->bhid"` for the AV product, and a batch+head-merged
+#   3-D variant, e.g. `"bid,bjd->bij"`, for code that flattens batch/head
+#   into one axis before the einsum. Recognized via
+#   :func:`_einsum_equation_is_batched_matmul` -- a from-scratch equation-
+#   string parse (split on `"->"`, split each side on `","`, validate the
+#   actual index-label roles) that accepts an `Einsum` node here ONLY when
+#   its equation is provably equivalent to the identical batched matmul the
+#   `MatMul` case already requires (batch/head axes passed through
+#   unchanged in position, exactly the one shared axis contracted, no axis
+#   repeated/broadcast/diagonal-extracted in a way plain `MatMul` semantics
+#   wouldn't also do) -- never guessed at from a hardcoded string list, since
+#   real code varies its own subscript letters/axis order freely (the ONNX
+#   schema places no constraint on either, confirmed via
+#   `onnx.defs.get_schema("Einsum").doc`). Purely additive from that point
+#   on: an accepted `Einsum` node is treated identically to a `MatMul` node
+#   by every downstream check (shape/consumer-count/graph-output, mask/scale
+#   resolution, Q's/K's/V's own producer-weight and shape-plumbing
+#   resolution) -- the weight-slicing math a KV-group-pruning chain needs
+#   never touches the QK^T/AV product nodes themselves, only Q's/K's/V's own
+#   producer weights and the reshape/transpose shape-plumbing around them.
 # - The additive mask (if any), applied *before* `Softmax` and *after* the
 #   optional scale (HF's own fixed `scores = (q @ k.T) * scale; scores =
 #   scores + mask` order -- the reverse order is never tried) is handled by
@@ -22702,22 +22734,32 @@ class _DecomposedGQAChain:
     :func:`_apply_one_gqa_chain` (built for a single fused node's own
     `num_heads`/`kv_num_heads` *attribute*) has no equivalent of at all.
 
-    `k_headsplit_transpose` is ``None`` exactly when K's own dot-product
-    transpose is the single pre-composed ``perm=[0,2,3,1])`` shape (see this
-    module's own section comment above) -- there is then no separate
-    head-split `Transpose` node to track for stale-`value_info` purposes
-    beyond `k_transpose` itself. `k_repeat_kv`/`v_repeat_kv` are
-    independently ``None``/set (both always agree on `kv_num_heads`, already
-    enforced at match time, but are two distinct matched node groups on two
-    distinct branches).
+    `k_headsplit_transpose` is ``None`` in either of two cases: K's own
+    dot-product transpose is the single pre-composed ``perm=[0,2,3,1])``
+    shape (see this module's own section comment above) -- there is then no
+    separate head-split `Transpose` node to track for stale-`value_info`
+    purposes beyond `k_transpose` itself -- OR `qk_matmul` is a literal
+    `Einsum` node (see this module's own section comment above), which has
+    no dot-product transpose of any kind at all; `k_transpose` there names
+    K's own (sole) head-split `Transpose` directly, the same repurposing
+    the pre-composed-``perm`` case above already does. `k_repeat_kv`/
+    `v_repeat_kv` are independently ``None``/set (both always agree on
+    `kv_num_heads`, already enforced at match time, but are two distinct
+    matched node groups on two distinct branches).
 
     `mask_node`/`mask_idx` are both ``None`` when no additive mask was
     matched; otherwise `mask_idx` is the index within `mask_node.input` of
     the mask operand itself (the *other* index resolves back toward the
-    QK^T `MatMul`) -- the exact `(node, idx)` shape
+    QK^T product) -- the exact `(node, idx)` shape
     :func:`_slice_or_gather_head_bias` already expects. `scale_node` is
     ``None`` when no scale hop was matched; never itself touched either way
-    (see this module's own section comment above).
+    (see this module's own section comment above). `qk_matmul`/`av_matmul`
+    are each either a plain `MatMul` node or an equation-validated `Einsum`
+    one (see this module's own section comment above,
+    :func:`_einsum_equation_is_batched_matmul`) -- indistinguishable from
+    this point on, since every remaining use of either field (below, and in
+    :func:`_apply_one_decomposed_gqa_chain`) only ever reads `.input`/
+    `.output`, never `.op_type`.
     """
 
     q_weight: str
@@ -23125,6 +23167,142 @@ def _match_decomposed_packed_qkv_producer(
     return resolved + (reshape, reshape.input[1])
 
 
+def _einsum_equation_attr(node: onnx.NodeProto) -> Optional[str]:
+    """Returns an ``Einsum`` node's own required ``equation`` string
+    attribute, or ``None`` if absent/mistyped -- never raises. Values are
+    ASCII-safe by the ONNX schema's own documented alphabet (lower-case
+    letters, comma, ``->``, space -- see ``onnx.defs.get_schema("Einsum")``'s
+    own doc string), so plain ``.decode("ascii")`` with a permissive
+    fallback is enough; anything that fails to decode cleanly is treated
+    the same as absent (declined by the caller, never guessed at).
+    """
+    for attr in node.attribute:
+        if attr.name == "equation" and attr.type == onnx.AttributeProto.STRING:
+            try:
+                return attr.s.decode("ascii")
+            except UnicodeDecodeError:
+                return None
+    return None
+
+
+def _einsum_equation_is_batched_matmul(
+    equation: str,
+    transposed_second_operand: bool,
+    first_operand_index: int = 0,
+) -> bool:
+    """Returns whether `equation` -- an ``Einsum`` node's own ``equation``
+    attribute -- is PROVABLY equivalent to a batched matrix multiplication
+    of its own two operands, contracting exactly one shared axis, with
+    every other axis (zero or more shared leading "batch" axes, plus
+    exactly one "free" axis of its own per operand) passed straight
+    through, unchanged in position, from operand to output. Declines
+    (returns ``False``, never guesses) on anything not provably exactly
+    that shape.
+
+    This is the equation-string half of recognizing a plain
+    ``torch.einsum``/``tf.einsum`` call as either the QK^T product or the
+    AV product a decomposed attention export can use in place of a plain
+    ``MatMul`` for either -- see this module's own "Decomposed (un-fused)
+    attention head pruning" section comment for the full empirical
+    background (the exact equation strings a real ``torch.onnx.export``
+    was confirmed, via this module's own test suite, to emit for each).
+    Everything else about either chain (Q's/K's/V's own producer weights,
+    the ``Reshape``/``Transpose``/``repeat_kv`` shape-plumbing around them,
+    the mask/scale/consumer checks) is untouched by which of ``MatMul``/
+    ``Einsum`` produced the product -- this function only ever answers
+    "is this equation ALSO just a batched matmul", nothing more.
+
+    Two operand terms are compared positionally: `first_operand_index`
+    (0 or 1) selects which of the node's own two ``input`` slots must play
+    the role whose own contracted axis is ALWAYS its own LAST label (Q's
+    role for the QK^T product, always index 0 there since the existing
+    ``MatMul`` path already assumes that fixed order unconditionally;
+    attention-weights' role for the AV product, whichever index
+    ``Softmax``'s own output actually landed in -- callers already resolve
+    that the identical way for a plain ``MatMul`` AV node, since ``MatMul``
+    is exactly as order-flexible here). `transposed_second_operand`
+    selects which of the two batched-matmul shapes the OTHER operand
+    (`1 - first_operand_index`) must be: ``True`` requires its own
+    contracted axis to be its own LAST label too -- the "Q @ K^T" shape,
+    e.g. ``"bhid,bhjd->bhij"`` (PyTorch's own confirmed literal equation
+    for a ``torch.einsum``-written QK^T score: `d`, Q's own `head_size`, is
+    the last label of BOTH operands' own terms -- matching the fact that
+    neither Q's nor K's own raw per-head tensor is transposed before
+    feeding this node, unlike the plain ``MatMul`` shape this module
+    already matches elsewhere, which needs an explicit ``Transpose`` first
+    specifically because ``MatMul`` has no way to contract a non-last axis
+    of its own second operand). ``False`` requires the other operand's own
+    contracted axis to be its own SECOND-TO-LAST label instead -- the
+    plain "A @ B" shape, e.g. ``"bhij,bhjd->bhid"`` (the confirmed literal
+    AV-product equation: `j`, the shared `seq_k`/key-sequence axis, is the
+    first operand's own last label but the second operand's own
+    second-to-last one -- exactly V's own natural ``[..., seq_k,
+    head_size]`` layout, no transpose needed either).
+
+    Declines on any of (see this function's own unit tests for a concrete
+    case of each): no explicit ``"->"`` (an implicit-output-order
+    equation -- well-defined by the ONNX spec even without one, but this
+    function does not attempt that inference); anything other than
+    exactly two comma-separated operand terms; an ellipsis (``"..."``)
+    anywhere; any character besides an ASCII lower-case letter/comma/
+    arrow/space (the ONNX schema's own documented alphabet); the two
+    operand terms' own rank (label count) disagreeing with each other or
+    with the output term's, or not being 3 or 4 (this module only ever
+    matches batch-plus-head-merged 3-D or BHSD 4-D attention tensors); a
+    repeated label within either operand's own term (a diagonal
+    extraction plain ``MatMul`` semantics can't express) or within the
+    output term; the two operands' own leading (batch) labels disagreeing
+    in identity or order, or not reproduced unchanged as the output's own
+    leading labels; either operand's own free axis colliding with the
+    other operand's own labels (an accidental alias, not a genuine
+    per-operand free axis); the contracted label reappearing in the
+    output at all (would mean it isn't actually contracted -- zero
+    contracted axes is an elementwise/broadcast product, plain ``MatMul``
+    semantics can't express that either); or the output's own last two
+    labels not being exactly (first operand's own free label, second
+    operand's own free label) in that order.
+    """
+    eq = equation.replace(" ", "")
+    if "..." in eq or "->" not in eq:
+        return False
+    lhs, _, rhs = eq.partition("->")
+    if "->" in rhs:
+        return False  # more than one "->" -- not a well-formed equation
+    terms = lhs.split(",")
+    if len(terms) != 2:
+        return False
+    t1, t2 = terms
+    if first_operand_index == 1:
+        t1, t2 = t2, t1
+    if not t1 or not t2 or not rhs:
+        return False
+    for term in (t1, t2, rhs):
+        if not all("a" <= ch <= "z" for ch in term):
+            return False
+
+    rank = len(t1)
+    if rank not in (3, 4) or len(t2) != rank or len(rhs) != rank:
+        return False
+    if len(set(t1)) != rank or len(set(t2)) != rank or len(set(rhs)) != rank:
+        return False  # a repeated label within one term -- diagonal, not matmul
+
+    batch = t1[:-2]
+    if t2[:-2] != batch or rhs[:-2] != batch:
+        return False  # batch axes must pass through unchanged, same order
+
+    free1, c1 = t1[-2], t1[-1]
+    if transposed_second_operand:
+        free2, c2 = t2[-2], t2[-1]
+    else:
+        c2, free2 = t2[-2], t2[-1]
+
+    if c1 != c2 or free1 == free2:
+        return False
+    if free1 in t2 or free2 in t1 or c1 in rhs:
+        return False  # contracted label must vanish; free axes must be unique
+    return rhs[-2:] == free1 + free2
+
+
 def _resolve_decomposed_qk_root(
     smax_input: str,
     consumers_of: Dict[str, List[onnx.NodeProto]],
@@ -23219,11 +23397,35 @@ def _resolve_decomposed_qk_root(
     qk_matmul = node_by_output.get(cur)
     if (
         qk_matmul is None
-        or qk_matmul.op_type != "MatMul"
         or qk_matmul.domain != ""
         or len(qk_matmul.input) != 2
         or qk_matmul.output[0] != cur
     ):
+        return None
+    if qk_matmul.op_type == "Einsum":
+        # A literal `Einsum` node is accepted here in place of `MatMul`
+        # ONLY when its own `equation` is provably equivalent to the
+        # identical Q @ K^T batched matmul this function's own `MatMul`
+        # branch already recognizes -- see
+        # :func:`_einsum_equation_is_batched_matmul`'s own docstring for
+        # the exact equivalence this checks and this module's own section
+        # comment for the empirically-confirmed real equation strings
+        # (e.g. `"bhid,bhjd->bhij"`) this closes a real gap for: a plain
+        # `torch.einsum`-written attention block (common in `x-transformers`/
+        # `vit-pytorch`/`performer-pytorch`-style reimplementations, and
+        # `tf2onnx`-exported `tf.einsum` code) never emits the `MatMul`
+        # this module otherwise requires here at all. Q is always input[0]
+        # here (`first_operand_index=0`, the default) -- the same fixed
+        # order this function's own caller already assumes unconditionally
+        # for the `MatMul` case (`q_bhsd_name, k_operand =
+        # qk_matmul.input`, no order-flexibility check at all there
+        # either).
+        equation = _einsum_equation_attr(qk_matmul)
+        if equation is None or not _einsum_equation_is_batched_matmul(
+            equation, transposed_second_operand=True
+        ):
+            return None
+    elif qk_matmul.op_type != "MatMul":
         return None
     return qk_matmul, mask_node, mask_operand, scale_node
 
@@ -23286,42 +23488,25 @@ def _find_decomposed_gqa_chains(
         if not _is_internal(q_bhsd_name) or not _is_internal(k_operand):
             continue
 
-        # ---- K's own dot-product transpose: combined or separate form ----
-        k_transpose = node_by_output.get(k_operand)
-        if (
-            k_transpose is None
-            or k_transpose.domain != ""
-            or k_transpose.op_type != "Transpose"
-        ):
-            continue
-        k_perm: Optional[List[int]] = None
-        for attr in k_transpose.attribute:
-            if attr.name == "perm":
-                k_perm = list(attr.ints)
-
+        # ---- K's own dot-product transpose: combined or separate form
+        # (`MatMul` only) -- or, for `Einsum`, no separate dot-product
+        # transpose at all ----
+        k_transpose: Optional[onnx.NodeProto]
         k_headsplit_transpose: Optional[onnx.NodeProto]
         k_repeat_kv: Optional[_RepeatKVBranch] = None
-        if k_perm == [0, 2, 3, 1]:
-            k_split = _match_decomposed_head_split(
-                k_operand,
-                consumers_of,
-                graph_outputs,
-                node_by_output,
-                initializer_map,
-                (0, 2, 3, 1),
-            )
-            if k_split is None:
-                continue
-            _, k_reshape, kv_num_heads, head_size_k, k_reshape_shape, k_proj_out = (
-                k_split
-            )
-            k_headsplit_transpose = None
-        elif k_perm == [0, 1, 3, 2]:
-            k_bhsd_name = k_transpose.input[0] if len(k_transpose.input) == 1 else None
-            if not k_bhsd_name or not _is_internal(k_bhsd_name):
-                continue
+        if qk_matmul.op_type == "Einsum":
+            # An `Einsum` QK^T product's own `equation` (already confirmed
+            # batched-matmul-equivalent by :func:`_resolve_decomposed_qk_root`)
+            # contracts K's own natural `[..., seq_k, head_size]` layout
+            # directly -- that's the entire reason a real export uses
+            # `Einsum` here instead of `MatMul` in the first place, see
+            # this module's own section comment above. So `k_operand` is
+            # resolved exactly like `q_bhsd_name` is below: optional
+            # `repeat_kv`, then a plain head-split -- never either of the
+            # `MatMul`-only combined-perm/separate-perm dot-product-
+            # transpose cases just below.
             repeat = _match_decomposed_repeat_kv(
-                k_bhsd_name,
+                k_operand,
                 consumers_of,
                 graph_outputs,
                 node_by_output,
@@ -23332,10 +23517,7 @@ def _find_decomposed_gqa_chains(
                 if not _is_internal(k_raw_name):
                     continue
             else:
-                k_raw_name, kv_num_heads = (
-                    k_bhsd_name,
-                    None,
-                )  # resolved via head-split below
+                k_raw_name, kv_num_heads = k_operand, None
             k_split = _match_decomposed_head_split(
                 k_raw_name,
                 consumers_of,
@@ -23347,7 +23529,7 @@ def _find_decomposed_gqa_chains(
             if k_split is None:
                 continue
             (
-                k_headsplit_transpose,
+                k_transpose,
                 k_reshape,
                 resolved_kv_heads,
                 head_size_k,
@@ -23358,8 +23540,81 @@ def _find_decomposed_gqa_chains(
                 kv_num_heads = resolved_kv_heads
             elif kv_num_heads != resolved_kv_heads:
                 continue
+            k_headsplit_transpose = None
         else:
-            continue
+            k_transpose = node_by_output.get(k_operand)
+            if (
+                k_transpose is None
+                or k_transpose.domain != ""
+                or k_transpose.op_type != "Transpose"
+            ):
+                continue
+            k_perm: Optional[List[int]] = None
+            for attr in k_transpose.attribute:
+                if attr.name == "perm":
+                    k_perm = list(attr.ints)
+
+            if k_perm == [0, 2, 3, 1]:
+                k_split = _match_decomposed_head_split(
+                    k_operand,
+                    consumers_of,
+                    graph_outputs,
+                    node_by_output,
+                    initializer_map,
+                    (0, 2, 3, 1),
+                )
+                if k_split is None:
+                    continue
+                _, k_reshape, kv_num_heads, head_size_k, k_reshape_shape, k_proj_out = (
+                    k_split
+                )
+                k_headsplit_transpose = None
+            elif k_perm == [0, 1, 3, 2]:
+                k_bhsd_name = (
+                    k_transpose.input[0] if len(k_transpose.input) == 1 else None
+                )
+                if not k_bhsd_name or not _is_internal(k_bhsd_name):
+                    continue
+                repeat = _match_decomposed_repeat_kv(
+                    k_bhsd_name,
+                    consumers_of,
+                    graph_outputs,
+                    node_by_output,
+                    initializer_map,
+                )
+                if repeat is not None:
+                    k_repeat_kv, k_raw_name, kv_num_heads, _n_rep = repeat
+                    if not _is_internal(k_raw_name):
+                        continue
+                else:
+                    k_raw_name, kv_num_heads = (
+                        k_bhsd_name,
+                        None,
+                    )  # resolved via head-split below
+                k_split = _match_decomposed_head_split(
+                    k_raw_name,
+                    consumers_of,
+                    graph_outputs,
+                    node_by_output,
+                    initializer_map,
+                    (0, 2, 1, 3),
+                )
+                if k_split is None:
+                    continue
+                (
+                    k_headsplit_transpose,
+                    k_reshape,
+                    resolved_kv_heads,
+                    head_size_k,
+                    k_reshape_shape,
+                    k_proj_out,
+                ) = k_split
+                if kv_num_heads is None:
+                    kv_num_heads = resolved_kv_heads
+                elif kv_num_heads != resolved_kv_heads:
+                    continue
+            else:
+                continue
         # Always a definite int by this point -- either unpacked directly
         # from `k_split` (the combined-perm branch), from `repeat` (the
         # repeat_kv branch), or resolved from `resolved_kv_heads` just above
@@ -23389,19 +23644,39 @@ def _find_decomposed_gqa_chains(
         if num_heads % kv_num_heads != 0:
             continue
 
-        # ---- forward: AV MatMul, output Transpose, combine-back Reshape ----
+        # ---- forward: AV MatMul/Einsum, output Transpose, combine-back
+        # Reshape ----
         av_matmul = consumers_of[smax_out][0]
         if (
-            av_matmul.op_type != "MatMul"
-            or av_matmul.domain != ""
+            av_matmul.domain != ""
             or len(av_matmul.input) != 2
             or smax_out not in av_matmul.input
             or len(av_matmul.output) != 1
         ):
             continue
-        v_bhsd_name = (
-            av_matmul.input[1] if av_matmul.input[0] == smax_out else av_matmul.input[0]
-        )
+        attn_is_first = av_matmul.input[0] == smax_out
+        if av_matmul.op_type == "Einsum":
+            # Symmetric to the QK^T `Einsum` case above (see
+            # :func:`_resolve_decomposed_qk_root`'s own comment) -- a real
+            # `torch.einsum`-written AV product (e.g.
+            # `"bhij,bhjd->bhid"`, confirmed empirically) never emits a
+            # `MatMul` either, so this closes the identical gap for the
+            # second product. Unlike the QK^T case, the attention-weights
+            # operand (`smax_out`) may legitimately land in EITHER input
+            # slot -- exactly as flexibly as the `MatMul` case just below
+            # already handles via `attn_is_first` -- so
+            # `first_operand_index` is passed through accordingly rather
+            # than assumed to be 0.
+            equation = _einsum_equation_attr(av_matmul)
+            if equation is None or not _einsum_equation_is_batched_matmul(
+                equation,
+                transposed_second_operand=False,
+                first_operand_index=0 if attn_is_first else 1,
+            ):
+                continue
+        elif av_matmul.op_type != "MatMul":
+            continue
+        v_bhsd_name = av_matmul.input[1] if attn_is_first else av_matmul.input[0]
         if v_bhsd_name == smax_out or not _is_internal(v_bhsd_name):
             continue
         av_out = av_matmul.output[0]

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -41408,6 +41408,616 @@ def test_decomposed_attention_real_torch_export_pipeline():
     np.testing.assert_allclose(ort_out, oracle_out, rtol=1e-3, atol=1e-3)
 
 
+def test_decomposed_attention_einsum_real_torch_export_pipeline():
+    """The `torch.einsum` analogue of
+    `test_decomposed_attention_real_torch_export_pipeline`: identical GQA +
+    causal-mask `nn.Module`, except BOTH the QK^T product and the AV
+    product are written as literal `torch.einsum` calls (the style real
+    reimplementations like `x-transformers`/`vit-pytorch`/
+    `performer-pytorch` commonly use instead of `torch.matmul`) --
+    confirming empirically, via a real `torch.onnx.export`, that PyTorch's
+    exporter emits a literal `Einsum` node for each (never decomposing it
+    into `Transpose`+`MatMul`), that `onnxsim.simplify()` leaves both
+    intact, and that `apply_attention_head_pruning` genuinely prunes both
+    products' own Q/K/V producers through the new `Einsum`-recognition
+    path this module adds -- not just declining silently the way it did
+    before. The pruned model's output is checked against an
+    independently-computed numpy oracle built from the pruned model's own
+    (already-sliced) tensors, run through a real
+    `onnxruntime.InferenceSession`, exactly mirroring the `MatMul` sibling
+    test's own verification shape.
+    """
+    torch = pytest.importorskip("torch")
+    pytest.importorskip("onnxruntime")
+    import torch.nn as nn  # noqa: E402  (after the torch importorskip guard)
+
+    hidden, num_heads, num_kv_heads, head_dim, seq, batch = 32, 8, 2, 8, 4, 1
+
+    class EinsumGQA(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.num_heads = num_heads
+            self.num_kv_heads = num_kv_heads
+            self.head_dim = head_dim
+            self.q_proj = nn.Linear(hidden, num_heads * head_dim, bias=True)
+            self.k_proj = nn.Linear(hidden, num_kv_heads * head_dim, bias=True)
+            self.v_proj = nn.Linear(hidden, num_kv_heads * head_dim, bias=True)
+            self.o_proj = nn.Linear(num_heads * head_dim, hidden, bias=True)
+            self.scaling = head_dim**-0.5
+
+        def _repeat_kv(self, x, n_rep):
+            if n_rep == 1:
+                return x
+            b, kvh, s, d = x.shape
+            x = x[:, :, None, :, :].expand(b, kvh, n_rep, s, d)
+            return x.reshape(b, kvh * n_rep, s, d)
+
+        def forward(self, hidden_states, attn_mask):
+            b, s, _ = hidden_states.shape
+            q = (
+                self.q_proj(hidden_states)
+                .view(b, s, self.num_heads, self.head_dim)
+                .transpose(1, 2)
+            )
+            k = (
+                self.k_proj(hidden_states)
+                .view(b, s, self.num_kv_heads, self.head_dim)
+                .transpose(1, 2)
+            )
+            v = (
+                self.v_proj(hidden_states)
+                .view(b, s, self.num_kv_heads, self.head_dim)
+                .transpose(1, 2)
+            )
+            n_rep = self.num_heads // self.num_kv_heads
+            k = self._repeat_kv(k, n_rep)
+            v = self._repeat_kv(v, n_rep)
+            # `x-transformers`-style: both products written via
+            # `torch.einsum` rather than `torch.matmul`/`Tensor.transpose`.
+            attn_weights = torch.einsum("bhid,bhjd->bhij", q, k) * self.scaling
+            attn_weights = attn_weights + attn_mask
+            attn_weights = torch.softmax(attn_weights, dim=-1)
+            attn_output = torch.einsum("bhij,bhjd->bhid", attn_weights, v)
+            attn_output = attn_output.transpose(1, 2).contiguous().reshape(b, s, -1)
+            return self.o_proj(attn_output)
+
+    m = EinsumGQA()
+    m.eval()
+    x = torch.randn(batch, seq, hidden)
+    mask = torch.triu(torch.full((seq, seq), float("-inf")), diagonal=1)[
+        None, None, :, :
+    ]
+
+    buf = io.BytesIO()
+    torch.onnx.export(
+        m,
+        (x, mask),
+        buf,
+        input_names=["hidden_states", "attn_mask"],
+        output_names=["output"],
+        opset_version=17,
+        dynamo=False,
+    )
+    raw = onnx.load_from_string(buf.getvalue())
+    # Empirical confirmation (see onnxsim/pruning.py's own section comment):
+    # PyTorch's exporter emits `Einsum` directly here, never `MatMul`.
+    assert any(n.op_type == "Einsum" for n in raw.graph.node)
+
+    simplified, ok = onnxsim.onnx_simplifier.simplify(raw)
+    assert ok
+
+    einsum_nodes = [n for n in simplified.graph.node if n.op_type == "Einsum"]
+    assert len(einsum_nodes) == 2
+    equations = set()
+    for n in einsum_nodes:
+        for a in n.attribute:
+            if a.name == "equation":
+                equations.add(a.s.decode())
+    assert equations == {"bhid,bhjd->bhij", "bhij,bhjd->bhid"}
+    assert not any(
+        n.op_type
+        in ("Attention", "GroupQueryAttention", "MultiHeadAttention", "PagedAttention")
+        for n in simplified.graph.node
+    )
+
+    pruned = onnxsim.apply_attention_head_pruning(simplified, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    def _find_gemm(model, bias_substr):
+        for n in model.graph.node:
+            if n.op_type == "Gemm" and len(n.input) == 3 and bias_substr in n.input[2]:
+                return n
+        raise AssertionError(f"no Gemm found for {bias_substr!r}")
+
+    def _init(model, name):
+        for t in model.graph.initializer:
+            if t.name == name:
+                return onnx.numpy_helper.to_array(t)
+        for n in model.graph.node:
+            if n.op_type == "Constant" and n.output[0] == name:
+                for a in n.attribute:
+                    if a.name == "value":
+                        return onnx.numpy_helper.to_array(a.t)
+        raise AssertionError(f"no initializer/Constant found for {name!r}")
+
+    q_gemm = _find_gemm(pruned, "q_proj.bias")
+    k_gemm = _find_gemm(pruned, "k_proj.bias")
+    v_gemm = _find_gemm(pruned, "v_proj.bias")
+    o_gemm = _find_gemm(pruned, "o_proj.bias")
+    wq, bq = _init(pruned, q_gemm.input[1]), _init(pruned, q_gemm.input[2])
+    wk, bk = _init(pruned, k_gemm.input[1]), _init(pruned, k_gemm.input[2])
+    wv, bv = _init(pruned, v_gemm.input[1]), _init(pruned, v_gemm.input[2])
+    wo, bo = _init(pruned, o_gemm.input[1]), _init(pruned, o_gemm.input[2])
+
+    new_num_heads = wq.shape[1] // head_dim
+    new_kv_num_heads = wk.shape[1] // head_dim
+    new_v_head_dim = wv.shape[1] // new_kv_num_heads
+    # Pruning must have actually fired through the new `Einsum` path --
+    # the whole point of this test (before this module's change, both
+    # `Einsum` products would decline the chain outright, leaving these
+    # shapes unchanged).
+    assert new_num_heads < num_heads
+    assert new_kv_num_heads < num_kv_heads
+    assert new_num_heads // new_kv_num_heads == num_heads // num_kv_heads
+
+    rng = np.random.default_rng(0)
+    hidden_states = rng.standard_normal((batch, seq, hidden)).astype(np.float32)
+    mask_np = mask.numpy().astype(np.float32)
+
+    sess = ort.InferenceSession(
+        pruned.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    (ort_out,) = sess.run(None, {"hidden_states": hidden_states, "attn_mask": mask_np})
+
+    def linear(x, w, b):
+        return x @ w + b
+
+    q = (
+        linear(hidden_states, wq, bq)
+        .reshape(batch, seq, new_num_heads, head_dim)
+        .transpose(0, 2, 1, 3)
+    )
+    k = (
+        linear(hidden_states, wk, bk)
+        .reshape(batch, seq, new_kv_num_heads, head_dim)
+        .transpose(0, 2, 1, 3)
+    )
+    v = (
+        linear(hidden_states, wv, bv)
+        .reshape(batch, seq, new_kv_num_heads, new_v_head_dim)
+        .transpose(0, 2, 1, 3)
+    )
+    n_rep = new_num_heads // new_kv_num_heads
+    if n_rep > 1:
+        k = np.repeat(k, n_rep, axis=1)
+        v = np.repeat(v, n_rep, axis=1)
+    scale = head_dim**-0.5
+    scores = np.matmul(q, k.transpose(0, 1, 3, 2)) * scale
+    scores = scores + mask_np
+    scores = scores - scores.max(axis=-1, keepdims=True)
+    exp = np.exp(scores)
+    attn = exp / exp.sum(axis=-1, keepdims=True)
+    ctx = np.matmul(attn, v)
+    ctx = ctx.transpose(0, 2, 1, 3).reshape(batch, seq, new_num_heads * new_v_head_dim)
+    oracle_out = linear(ctx, wo, bo)
+
+    np.testing.assert_allclose(ort_out, oracle_out, rtol=1e-3, atol=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# Decomposed (un-fused) attention -- QK^T/AV product as a literal `Einsum`
+# node (instead of `MatMul`)
+# ---------------------------------------------------------------------------
+# See onnxsim/pruning.py's own "Decomposed (un-fused) attention head
+# pruning" section comment and `_einsum_equation_is_batched_matmul`'s own
+# docstring for the full empirical background. The hand-built-model tests
+# below mirror `test_decomposed_gqa_pruning_matches_oracle_exactly`'s own
+# oracle-rebuild shape exactly, just against `_decomposed_gqa_model_einsum`
+# instead of `_decomposed_gqa_model` -- confirmed against a REAL
+# `torch.onnx.export` pipeline first, immediately above
+# (`test_decomposed_attention_einsum_real_torch_export_pipeline`), so these
+# hand-built fixtures target already-confirmed ground truth.
+
+
+def _decomposed_gqa_model_einsum(
+    K=16,
+    H=8,
+    KVH=2,
+    D=8,
+    Out=16,
+    batch=1,
+    seq=4,
+    seed=0,
+    qk_via_einsum=True,
+    av_via_einsum=True,
+    qk_equation="bhid,bhjd->bhij",
+    av_equation="bhij,bhjd->bhid",
+    wq=None,
+    wk=None,
+    wv=None,
+    wout=None,
+    bq=None,
+    bk=None,
+    bv=None,
+    bout=None,
+):
+    """The `torch.einsum`-written analogue of `_decomposed_gqa_model`:
+    identical `Linear(Q/K/V) -> Reshape(to heads) -> Transpose(to BHSD) ->
+    [repeat_kv, GQA only]` producer branches and `Transpose(back) ->
+    Reshape(back to hidden) -> Linear(O)` consumer tail, but the QK^T
+    product and/or the AV product is a literal `Einsum` node instead of
+    `MatMul`, toggled independently via `qk_via_einsum`/`av_via_einsum`
+    (each `True` by default, matching the real `torch.einsum`-written
+    attention block this closes a pruning gap for).
+
+    When `qk_via_einsum` is set, K's own separate dot-product `Transpose`
+    is never built at all -- the `Einsum`'s own `equation` contracts K's
+    raw, un-transposed head-split output directly, exactly what a real
+    `torch.einsum("bhid,bhjd->bhij", q, k)` export produces (see this
+    module's own section comment above `_decomposed_gqa_model` for why
+    `MatMul` always needs that extra `Transpose` and `Einsum` never does).
+    `qk_equation`/`av_equation` let a caller substitute a non-equivalent
+    equation to build a decline-path fixture (see
+    `test_decomposed_gqa_pruning_qk_einsum_wrong_axis_order_declines`
+    below) -- the graph is still perfectly valid ONNX either way since
+    `seq_q == seq_k == seq` here (self-attention), so a swapped-order
+    equation changes no tensor's *shape*, only whether the *pruning pass*
+    can prove it's a real matmul.
+
+    V's own branch is IDENTICAL regardless of `av_via_einsum` (V is never
+    transposed for either op -- same section comment) -- only the AV
+    product node itself differs.
+    """
+    rng = np.random.default_rng(seed)
+    Nq, Nk, Nv = H * D, KVH * D, KVH * D
+    if wq is None:
+        wq = rng.standard_normal((K, Nq)).astype(np.float32)
+    if wk is None:
+        wk = rng.standard_normal((K, Nk)).astype(np.float32)
+    if wv is None:
+        wv = rng.standard_normal((K, Nv)).astype(np.float32)
+    if wout is None:
+        wout = rng.standard_normal((H * D, Out)).astype(np.float32)
+    if bq is None:
+        bq = rng.standard_normal((Nq,)).astype(np.float32)
+    if bk is None:
+        bk = rng.standard_normal((Nk,)).astype(np.float32)
+    if bv is None:
+        bv = rng.standard_normal((Nv,)).astype(np.float32)
+    if bout is None:
+        bout = rng.standard_normal((Out,)).astype(np.float32)
+
+    def _i64(arr, name):
+        return onnx.numpy_helper.from_array(np.array(arr, dtype=np.int64), name)
+
+    initializer = [
+        _f32(wq, "Wq"),
+        _f32(wk, "Wk"),
+        _f32(wv, "Wv"),
+        _f32(wout, "Wout"),
+        _f32(bq, "Bq"),
+        _f32(bk, "Bk"),
+        _f32(bv, "Bv"),
+        _f32(bout, "Bout"),
+        _i64([batch * seq, K], "XFlatShape"),
+        _i64([batch, seq, H, D], "Sq"),
+        _i64([batch, seq, KVH, D], "Skv"),
+    ]
+    lines = [
+        "xf = Reshape(X, XFlatShape)",
+        "q0 = Gemm(xf, Wq, Bq)",
+        "k0 = Gemm(xf, Wk, Bk)",
+        "v0 = Gemm(xf, Wv, Bv)",
+        "qr = Reshape(q0, Sq)",
+        "qt = Transpose<perm=[0,2,1,3]>(qr)",
+        "kr = Reshape(k0, Skv)",
+        "vr = Reshape(v0, Skv)",
+        "kbh = Transpose<perm=[0,2,1,3]>(kr)",
+        "vbh = Transpose<perm=[0,2,1,3]>(vr)",
+    ]
+    k_for_qk, v_for_av = "kbh", "vbh"
+
+    if KVH < H:
+        assert H % KVH == 0
+        n_rep = H // KVH
+        initializer += [
+            _i64([2], "Ax2"),
+            _i64([batch, KVH, n_rep, seq, D], "ExpandShape"),
+            _i64([batch, H, seq, D], "MergeShape"),
+        ]
+        lines += [
+            "ku = Unsqueeze(kbh, Ax2)",
+            "ke = Expand(ku, ExpandShape)",
+            "krep = Reshape(ke, MergeShape)",
+            "vu = Unsqueeze(vbh, Ax2)",
+            "ve = Expand(vu, ExpandShape)",
+            "vrep = Reshape(ve, MergeShape)",
+        ]
+        k_for_qk, v_for_av = "krep", "vrep"
+
+    if qk_via_einsum:
+        lines.append(f'qk = Einsum<equation="{qk_equation}">(qt, {k_for_qk})')
+    else:
+        lines.append(f"ktT = Transpose<perm=[0,1,3,2]>({k_for_qk})")
+        lines.append("qk = MatMul(qt, ktT)")
+
+    initializer.append(_f32(np.array(D**-0.5, dtype=np.float32), "Scale"))
+    lines.append("scaled = Mul(qk, Scale)")
+    lines.append("attn = Softmax<axis=-1>(scaled)")
+
+    if av_via_einsum:
+        lines.append(f'ctx0 = Einsum<equation="{av_equation}">(attn, {v_for_av})')
+    else:
+        lines.append(f"ctx0 = MatMul(attn, {v_for_av})")
+
+    initializer += [
+        _i64([batch * seq, H * D], "OutShape"),
+        _i64([batch, seq, Out], "YShape"),
+    ]
+    lines += [
+        "ctx1 = Transpose<perm=[0,2,1,3]>(ctx0)",
+        "ctx2 = Reshape(ctx1, OutShape)",
+        "y0 = Gemm(ctx2, Wout, Bout)",
+        "Y = Reshape(y0, YShape)",
+    ]
+
+    body_lines = "\n          ".join(lines)
+    model = _model(
+        f"""
+        g (float[{batch},{seq},{K}] X) => (float[{batch},{seq},{Out}] Y)
+        {{
+          {body_lines}
+        }}
+        """,
+        initializer=initializer,
+        opset=17,
+    )
+    return model, dict(
+        K=K,
+        H=H,
+        KVH=KVH,
+        D=D,
+        Out=Out,
+        batch=batch,
+        seq=seq,
+        wq=wq,
+        wk=wk,
+        wv=wv,
+        wout=wout,
+        bq=bq,
+        bk=bk,
+        bv=bv,
+        bout=bout,
+    )
+
+
+def _assert_decomposed_einsum_pruning_matches_oracle(
+    *, qk_via_einsum, av_via_einsum, seed
+):
+    model, cfg = _decomposed_gqa_model_einsum(
+        K=16,
+        H=8,
+        KVH=2,
+        D=8,
+        Out=16,
+        seed=seed,
+        qk_via_einsum=qk_via_einsum,
+        av_via_einsum=av_via_einsum,
+    )
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    wq_new, wk_new, wv_new, wo_new = _decomposed_weight_shapes(pruned)
+    group_size = cfg["H"] // cfg["KVH"]
+    new_kv = cfg["KVH"] - round(cfg["KVH"] * 0.5)
+    # Pruning must have actually fired -- the whole point of these tests
+    # (before this module's change, an `Einsum` QK^T/AV product declined
+    # the chain outright, leaving these shapes unchanged).
+    assert wk_new.shape[1] == new_kv * cfg["D"]
+    assert wq_new.shape[1] == new_kv * group_size * cfg["D"]
+
+    keep_groups = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], cfg["H"], cfg["KVH"], cfg["D"], new_kv
+    )
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    d = cfg["D"]
+    q_idx, kv_idx = _head_idx(keep_q_heads, d), _head_idx(keep_groups, d)
+
+    oracle, _ = _decomposed_gqa_model_einsum(
+        K=cfg["K"],
+        H=len(keep_q_heads),
+        KVH=new_kv,
+        D=d,
+        Out=cfg["Out"],
+        seed=seed,
+        qk_via_einsum=qk_via_einsum,
+        av_via_einsum=av_via_einsum,
+        wq=cfg["wq"][:, q_idx],
+        wk=cfg["wk"][:, kv_idx],
+        wv=cfg["wv"][:, kv_idx],
+        wout=cfg["wout"][q_idx, :],
+        bq=cfg["bq"][q_idx],
+        bk=cfg["bk"][kv_idx],
+        bv=cfg["bv"][kv_idx],
+        bout=cfg["bout"],
+    )
+
+    rng = np.random.default_rng(seed + 1)
+    x = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_decomposed_gqa_pruning_qk_einsum_matches_oracle_exactly():
+    # QK^T via `Einsum` (`"bhid,bhjd->bhij"`), AV via plain `MatMul` --
+    # confirms the QK^T `Einsum` recognition path alone, independent of
+    # the AV one.
+    _assert_decomposed_einsum_pruning_matches_oracle(
+        qk_via_einsum=True, av_via_einsum=False, seed=201
+    )
+
+
+def test_decomposed_gqa_pruning_av_einsum_matches_oracle_exactly():
+    # AV via `Einsum` (`"bhij,bhjd->bhid"`), QK^T via plain `MatMul` --
+    # confirms the AV `Einsum` recognition path alone, independent of the
+    # QK^T one.
+    _assert_decomposed_einsum_pruning_matches_oracle(
+        qk_via_einsum=False, av_via_einsum=True, seed=202
+    )
+
+
+def test_decomposed_gqa_pruning_both_products_einsum_matches_oracle_exactly():
+    # Both products via `Einsum` -- the real `torch.einsum`-written
+    # attention block shape confirmed by
+    # `test_decomposed_attention_einsum_real_torch_export_pipeline` above.
+    _assert_decomposed_einsum_pruning_matches_oracle(
+        qk_via_einsum=True, av_via_einsum=True, seed=203
+    )
+
+
+def test_decomposed_gqa_pruning_qk_einsum_wrong_axis_order_declines():
+    # `"bhid,bhjd->bhji"` -- K's own free axis (`j`, `seq_k`) and Q's own
+    # free axis (`i`, `seq_q`) land in the OUTPUT in the wrong order
+    # relative to the operands' own positions (swapped from the correct
+    # `"...->bhij"`). Since this fixture's `seq_q == seq_k` (plain
+    # self-attention), the graph is still perfectly valid ONNX -- no
+    # shape actually changes -- but the equation is NOT provably
+    # equivalent to a batched matmul with axis roles preserved (it would
+    # actually compute K @ Q^T, transposed relative to what this chain's
+    # own downstream `Softmax`/AV-product expects), so
+    # `_einsum_equation_is_batched_matmul` must decline it, and the whole
+    # chain -- Q's/K's/V's own producer weights included -- must be left
+    # completely untouched rather than mis-sliced.
+    model, cfg = _decomposed_gqa_model_einsum(
+        K=16,
+        H=4,
+        KVH=4,
+        D=8,
+        Out=16,
+        seed=204,
+        qk_via_einsum=True,
+        av_via_einsum=False,
+        qk_equation="bhid,bhjd->bhji",
+    )
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    wq_new, wk_new, wv_new, wo_new = _decomposed_weight_shapes(pruned)
+    assert wq_new.shape == cfg["wq"].shape
+    assert wk_new.shape == cfg["wk"].shape
+    assert wv_new.shape == cfg["wv"].shape
+    assert wo_new.shape == cfg["wout"].shape
+
+
+def test_decomposed_gqa_pruning_av_einsum_repeated_output_subscript_declines():
+    # `"bhij,bhjd->bhijd"` -- the output term is rank 5 (a repeated/extra
+    # axis relative to the rank-4 operands), which this function already
+    # declines via its own rank check before any label-role reasoning --
+    # included here as the integration-level analogue of this module's
+    # own "repeated output subscript" unit-test case (see
+    # `test_einsum_equation_is_batched_matmul_declines_on_bad_equations`
+    # below for the direct, equation-string-only version of this check).
+    model, cfg = _decomposed_gqa_model_einsum(
+        K=16,
+        H=4,
+        KVH=4,
+        D=8,
+        Out=16,
+        seed=205,
+        qk_via_einsum=False,
+        av_via_einsum=True,
+        av_equation="bhij,bhjd->bhijd",
+    )
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    wq_new, wk_new, wv_new, wo_new = _decomposed_weight_shapes(pruned)
+    assert wq_new.shape == cfg["wq"].shape
+    assert wk_new.shape == cfg["wk"].shape
+    assert wv_new.shape == cfg["wv"].shape
+    assert wo_new.shape == cfg["wout"].shape
+
+
+def test_einsum_equation_is_batched_matmul_accepts_qk_and_av_shapes():
+    from onnxsim.pruning import _einsum_equation_is_batched_matmul as _check
+
+    # The two literal equations confirmed via a real `torch.onnx.export`
+    # (see `test_decomposed_attention_einsum_real_torch_export_pipeline`).
+    assert _check("bhid,bhjd->bhij", transposed_second_operand=True) is True
+    assert _check("bhij,bhjd->bhid", transposed_second_operand=False) is True
+    # A batch+head-merged 3-D variant (confirmed empirically too -- code
+    # that flattens batch/head into one axis before the einsum, e.g. some
+    # `x-transformers`-style call sites).
+    assert _check("bid,bjd->bij", transposed_second_operand=True) is True
+    assert _check("bij,bjd->bid", transposed_second_operand=False) is True
+    # A valid-but-differently-lettered equivalent equation -- the ONNX
+    # schema places no constraint on which letters are used (confirmed via
+    # `onnx.defs.get_schema("Einsum").doc`), so a real export using a
+    # different subscript alphabet must be accepted identically.
+    assert _check("xyzw,xyvw->xyzv", transposed_second_operand=True) is True
+    assert _check("xyzw,xywv->xyzv", transposed_second_operand=False) is True
+    # Spaces are cosmetic per the ONNX spec's own doc string -- stripped
+    # before parsing, so formatting alone never changes the verdict.
+    assert _check("bhid, bhjd -> bhij", transposed_second_operand=True) is True
+    # `first_operand_index=1` -- the AV product's own attention-weights
+    # operand landing in the SECOND `Einsum` input slot (V first) is
+    # mathematically identical to swapping the equation's own two LHS
+    # terms (einsum is symmetric in operand order).
+    assert (
+        _check(
+            "bhjd,bhij->bhid", transposed_second_operand=False, first_operand_index=1
+        )
+        is True
+    )
+
+
+def test_einsum_equation_is_batched_matmul_declines_on_bad_equations():
+    from onnxsim.pruning import _einsum_equation_is_batched_matmul as _check
+
+    # Batch-mismatched axis order: K's own leading two labels ("hb") are
+    # in the opposite order from Q's/the output's own ("bh") -- not
+    # actually the same batch axes passed straight through.
+    assert _check("bhid,hbjd->bhij", transposed_second_operand=True) is False
+    # Repeated output subscript: `i` appears twice in the output term.
+    assert _check("bhid,bhjd->bhii", transposed_second_operand=True) is False
+    # Contracting the wrong axis: swaps the QK^T product's own output
+    # axis order (`"...->bhji"` instead of `"...->bhij"`) -- a real
+    # `MatMul`-equivalent QK^T never has K's own free axis land before
+    # Q's own in the output.
+    assert _check("bhid,bhjd->bhji", transposed_second_operand=True) is False
+    # Zero contracted axes -- an elementwise/broadcast product (every
+    # label of both operands reappears in the output), not a matmul at
+    # all.
+    assert _check("bhid,bhid->bhid", transposed_second_operand=True) is False
+    assert _check("bhid,bhid->bhid", transposed_second_operand=False) is False
+    # No explicit "->" -- implicit-output-order einsum, declined rather
+    # than re-implementing that inference.
+    assert _check("bhid,bhjd", transposed_second_operand=True) is False
+    # An ellipsis -- broadcasting semantics this function never reasons
+    # about.
+    assert _check("...id,...jd->...ij", transposed_second_operand=True) is False
+    # Not exactly two comma-separated operand terms.
+    assert _check("bhid,bhjd,bhkd->bhij", transposed_second_operand=True) is False
+    assert _check("bhid->bhid", transposed_second_operand=True) is False
+    # A non-lowercase-letter character (schema's own alphabet is lower-case
+    # letters, comma, arrow, space only).
+    assert _check("bhiD,bhjd->bhij", transposed_second_operand=True) is False
+    assert _check("bhi1,bhjd->bhij", transposed_second_operand=True) is False
+    # Wrong rank (not 3 or 4).
+    assert _check("id,jd->ij", transposed_second_operand=True) is False
+    assert _check("abhid,abhjd->abhij", transposed_second_operand=True) is False
+    # The two operand terms' own ranks disagreeing.
+    assert _check("bhid,bhjde->bhij", transposed_second_operand=True) is False
+    # A repeated label within one operand's own term (diagonal extraction).
+    assert _check("bhii,bhjd->bhij", transposed_second_operand=True) is False
+    # An operand's own free axis colliding with the other operand's own
+    # label (an accidental alias, not a genuine per-operand free axis).
+    assert _check("bhid,bhjd->bhii", transposed_second_operand=True) is False
+    assert _check("bhid,bhid->bhii", transposed_second_operand=True) is False
+    # The AV-shape check (`transposed_second_operand=False`) rejects a
+    # QK^T-shape equation, and vice versa -- neither flag guesses past a
+    # equation that's actually the OTHER shape.
+    assert _check("bhid,bhjd->bhij", transposed_second_operand=False) is False
+    assert _check("bhij,bhjd->bhid", transposed_second_operand=True) is False
+
+
 # ---------------------------------------------------------------------------
 # Decomposed (un-fused) attention -- Wanda-calibrated pruning and dry-run
 # sensitivity-report wiring


### PR DESCRIPTION
## Summary

The "Decomposed (un-fused) attention head pruning" feature's QK^T-product and AV-product resolution both hard-required a literal `MatMul` node, declining outright on anything else. When attention math is written using `torch.einsum`/`tf.einsum` instead of plain matrix multiplication — a common style in widely-used research reimplementations (lucidrains' `x-transformers`/`vit-pytorch`/`performer-pytorch`), some HF relative-position-attention code, and TensorFlow-originated models exported via tf2onnx — PyTorch's/TF's exporter emits a literal `Einsum` node for either product instead, so any such attention block got **zero attention-head pruning**, even though the underlying math is identical to the already-handled `MatMul` case.

## Empirically confirmed facts

Confirmed live via `torch.onnx.export` (both legacy TorchScript and newer exporters) and `onnx.defs.get_schema("Einsum")`'s own doc string:
- QK^T product: `"bhid,bhjd->bhij"` (both operands' contracted axis, `head_size`, is their own last label — no transpose needed, unlike the `MatMul` shape this module already matches, which needs an explicit `Transpose` first specifically because `MatMul` can't contract a non-last axis).
- AV product: `"bhij,bhjd->bhid"` (the shared `seq_k` axis is the first operand's last label but the second operand's second-to-last — V's natural layout, no transpose needed).
- A batch+head-merged 3-D variant also confirmed: `"bid,bjd->bij"`.
- The ONNX schema places no constraint on which letters are used or their order beyond standard einsum semantics — so a real classifier needs to parse the equation string's actual structure, not pattern-match against a hardcoded string list.

## What's added

- `_einsum_equation_is_batched_matmul(equation, transposed_second_operand, first_operand_index=0)`: a from-scratch equation-string parser proving an `Einsum` equation is provably equivalent to batched matmul with axis roles preserved (batch axes pass through unchanged, exactly one contracted axis vanishes from the output, free axes land in the expected output positions). Declines on: no `"->"`, non-2-operand, ellipsis, non-lowercase characters, rank mismatch/not-3-or-4, a repeated label in any term, batch-axis mismatch, zero/multiple/aliased contracted or free axes, wrong output axis order.
- `_einsum_equation_attr()`: safely reads the `equation` attribute.
- Wired into `_resolve_decomposed_qk_root` (QK^T site) and the AV-product resolution in `_find_decomposed_gqa_chains`, plus a restructured K-branch (an `Einsum` QK^T product skips the `MatMul`-only dot-product-transpose cases entirely, going straight to optional `repeat_kv` + head-split, mirroring Q's own branch, since `Einsum` contracts K's natural layout directly with no transpose needed). Purely additive downstream — nothing else in the chain (weight slicing, mask/scale handling, shape-plumbing) reads `qk_matmul`/`av_matmul`'s own `op_type`.

## Test plan

- [x] `pytest tests/test_pruning.py -q` — 858 passed (850 baseline + 8 new); the same 21 pre-existing, unrelated failures remain (`apply_transformer_block_pruning` missing from this environment's stale compiled C++ extension — confirmed identical before/after; CI builds fresh)
- [x] `ruff format --check` / `ruff check` on both touched files — clean
- [x] `mypy onnxsim/pruning.py` — 0 errors
- [x] Independently re-verified via a revert-only-`pruning.py` check: 6 of the 8 new tests fail against the pre-change code (the other 2 are decline tests, correctly invariant either way); restored and confirmed all 8 pass again
- [x] Direct unit tests for `_einsum_equation_is_batched_matmul`'s own edge cases (batch-mismatched axis order, repeated output subscript, wrong contracted axis, a valid-but-differently-lettered equivalent equation), independent of the end-to-end model tests
- [x] Verified against a real `torch.onnx.export → onnxsim.simplify() → apply_attention_head_pruning` pipeline for a `torch.einsum`-based attention module (both products via einsum, GQA + mask): pruning fires correctly and the pruned output matches an independently-built numpy oracle

## Risks for a reviewer to double check

1. The classifier's mutual-exclusivity assumption between the "Q@K^T" shape (`transposed_second_operand=True`) and the "A@B" shape (`False`) relies on the second operand's two candidate label positions always differing — guaranteed by the per-term label-uniqueness check, but worth an independent trace-through.
2. The AV product's `first_operand_index`-based operand-order flexibility (mirrors, but doesn't literally reuse, the existing `MatMul` path's `attn_is_first` flexibility) — worth checking against the "operand order swap" acceptance test and the AV decline test together.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_