### PR TITLE
Add view-op aliasing to the activation memory planner

### DIFF
--- a/docs/activation-memory-planning.md
+++ b/docs/activation-memory-planning.md
@@ -84,6 +84,16 @@ logical storage. Honoring that part of the plan means actually running that
 node's kernel in place — writing its output over the input's own buffer —
 not just treating a repeated offset as "safe to reuse afterward."
 
+A second, separate allowlist (`IsViewOp`) covers pure view ops — `Reshape`,
+`Flatten`, `Squeeze`, `Unsqueeze` — that reinterpret the same bytes under a
+different shape with no computation at all: ONNX requires row-major/
+contiguous tensor layout, and none of these ops permute element order, so
+their output is byte-for-byte identical to their input whenever the sizes
+actually agree (checked the same way as every other candidate). A chain may
+freely mix both allowlists — e.g. `Reshape -> Relu -> Flatten` all collapse
+into one group — since the eligibility conditions and the resulting
+placement are identical either way.
+
 ## What's in `MemoryPlan`
 
 - **`tensor_offsets`** — `{name: (offset, size)}` for every planned tensor.

--- a/onnxsim/memory_planning.cpp
+++ b/onnxsim/memory_planning.cpp
@@ -33,9 +33,10 @@ bool Disjoint(const Interval& a, const Interval& b) {
 // place, with no numerical difference from writing to a separate buffer.
 // This is a curated allowlist, not a schema query (nothing here parses
 // attributes or checks the actual input/output types), so it deliberately
-// excludes anything with an exception -- e.g. not "Reshape", which changes
-// rank/strides even though its byte size matches, and whose output some
-// executors treat as view metadata rather than a copy.
+// excludes anything with an exception -- e.g. not "Transpose", whose output
+// (unless the permutation happens to be the identity, which nothing here
+// checks) physically reorders elements rather than computing the same
+// index in place.
 bool IsInPlaceSafeOp(const std::string& op_type) {
   static const std::set<std::string> kSafeOps = {
       "Relu",     "Sigmoid",  "Tanh",        "LeakyRelu",  "Elu",      "Selu",
@@ -44,6 +45,28 @@ bool IsInPlaceSafeOp(const std::string& op_type) {
       "Celu",     "Round",    "Ceil",        "Floor",      "Sign",
   };
   return kSafeOps.count(op_type) > 0;
+}
+
+// Ops that reinterpret their first input's element sequence under a
+// different shape without moving any bytes -- ONNX requires row-major/
+// C-contiguous tensor layout, and none of these ops permute element order
+// (they only regroup, split, or insert/remove size-1 dimensions), so their
+// output is byte-for-byte identical to their input whenever the sizes
+// TensorBytes() reports actually agree (checked the same as every other
+// candidate, at the call site). This is a *stronger* guarantee than
+// IsInPlaceSafeOp's "safe to compute in place" -- these ops need no
+// computation at all, the output is a pure view -- but it is folded into
+// the same union-find aliasing pass since the resulting placement is
+// identical: one shared slot for input and output alike. Not "Transpose"
+// (see IsInPlaceSafeOp) or "Expand"/"Tile" (which do move/duplicate bytes).
+bool IsViewOp(const std::string& op_type) {
+  static const std::set<std::string> kViewOps = {
+      "Reshape",
+      "Flatten",
+      "Squeeze",
+      "Unsqueeze",
+  };
+  return kViewOps.count(op_type) > 0;
 }
 
 // Union-find (disjoint-set) over tensor names, path-compressed, used to
@@ -127,8 +150,9 @@ MemoryPlan ComputeActivationMemoryPlan(const GraphView& graph) {
     }
   }
 
-  // In-place aliasing: union a safe unary op's input[0] with its output[0]
-  // (see IsInPlaceSafeOp) whenever doing so is provably safe --
+  // In-place aliasing: union a safe unary/view op's input[0] with its
+  // output[0] (see IsInPlaceSafeOp and IsViewOp) whenever doing so is
+  // provably safe --
   //   * not a weight, a graph input, or a declared graph output (an
   //     externally-owned buffer, or one the caller reads only after the
   //     whole graph finishes, so overwriting it mid-run would be observed
@@ -139,10 +163,12 @@ MemoryPlan ComputeActivationMemoryPlan(const GraphView& graph) {
   //     well-formed model; checked anyway as a defensive belt-and-braces).
   // A chain of such ops unions transitively into one group -- Find() on any
   // member returns the same root -- that needs only a single slot for its
-  // entire span, rather than one slot per node.
+  // entire span, rather than one slot per node. The chain may freely mix
+  // both categories (e.g. Reshape -> Relu -> Flatten): the eligibility
+  // conditions and the resulting placement are identical either way.
   UnionFind uf;
   for (const NodeView& node : graph.nodes) {
-    if (!IsInPlaceSafeOp(node.op_type)) continue;
+    if (!IsInPlaceSafeOp(node.op_type) && !IsViewOp(node.op_type)) continue;
     if (node.inputs.empty() || node.outputs.size() != 1) continue;
     const std::string& in0 = node.inputs[0];
     const std::string& out0 = node.outputs[0];

--- a/onnxsim/memory_planning.h
+++ b/onnxsim/memory_planning.h
@@ -26,19 +26,24 @@
 // at all -- the baseline "compression ratio" is measured against).
 //
 // On top of that liveness-only reuse, an in-place-aliasing pass (see
-// IsInPlaceSafeOp in memory_planning.cpp) unions a safe elementwise op's
+// IsInPlaceSafeOp and IsViewOp in memory_planning.cpp) unions a safe op's
 // input with its output whenever overwriting the input in place is provably
 // correct -- the input is not a weight/graph input/graph output, and this
-// node is its only consumer. A chain of such ops (e.g. Relu -> Sigmoid ->
-// Tanh) all collapse into one placement group needing a single slot for the
-// whole chain's span, rather than one slot per node, so the arena for a long
-// elementwise chain stays roughly constant instead of growing with its
-// length; TestInPlaceAliasingCollapsesWholeChain in memory_planning_test.cpp
-// demonstrates this directly. Aliased tensors report the identical
-// (offset, size) in `offsets` -- a downstream consumer honours the plan by
-// actually running that node's kernel in place (writing its output over the
-// input's own buffer), not merely by treating same-offset as "safe to reuse
-// after the fact" the way two disjoint-interval tensors are.
+// node is its only consumer. This covers two categories: ops that can
+// *compute* their output by overwriting the input (Relu, Sigmoid, Tanh, ...)
+// and pure view ops that reinterpret the same bytes under a different shape
+// with no computation at all (Reshape, Flatten, Squeeze, Unsqueeze). A chain
+// mixing either kind (e.g. Reshape -> Relu -> Flatten) all collapses into
+// one placement group needing a single slot for the whole chain's span,
+// rather than one slot per node, so the arena for a long chain stays roughly
+// constant instead of growing with its length;
+// TestInPlaceAliasingCollapsesWholeChain in memory_planning_test.cpp
+// demonstrates this directly. Aliased tensors report the identical (offset,
+// size) in `offsets` -- a downstream consumer honours the plan by actually
+// running that node's kernel in place (writing its output over the input's own
+// buffer, or for a view op simply treating input and output as the same buffer
+// under different shape metadata), not merely by treating same-offset as "safe
+// to reuse after the fact" the way two disjoint-interval tensors are.
 //
 // v1 scope, deliberately:
 //   * Concrete shapes only. A tensor whose size cannot be resolved to a

--- a/onnxsim/memory_planning_test.cpp
+++ b/onnxsim/memory_planning_test.cpp
@@ -142,6 +142,88 @@ void TestInPlaceAliasingCollapsesWholeChain() {
   assert(off.at("d") == off.at("out"));
 }
 
+// A chain of pure view ops -- Reshape -> Squeeze -> Unsqueeze -> Flatten --
+// reinterprets the same 100 bytes under a different shape at every step with
+// no computation at all, so they union into one group exactly like the
+// in-place-safe unary chain above; x (a graph input) stays separate. Real
+// Reshape/Squeeze/Unsqueeze also take a second (shape/axes) input, which
+// this test's Reshape node includes ("s") -- it is never a shape/dtype
+// candidate for anything and correctly plays no role in the plan.
+void TestViewOpsAliasWholeChain() {
+  GraphView g;
+  for (const char* n : {"x", "a", "b", "c", "out"}) {
+    g.shapes[n] = {SymExpr(25)};
+    g.dtypes[n] = 4;  // 100 bytes each
+  }
+  g.inputs = {"x"};
+  g.outputs = {"out"};
+
+  NodeView reshape, squeeze, unsqueeze, flatten;
+  reshape.op_type = "Reshape";
+  reshape.inputs = {"x",
+                    "s"};  // "s" (the shape tensor) is deliberately unmodeled
+  reshape.outputs = {"a"};
+  squeeze.op_type = "Squeeze";
+  squeeze.inputs = {"a"};
+  squeeze.outputs = {"b"};
+  unsqueeze.op_type = "Unsqueeze";
+  unsqueeze.inputs = {"b"};
+  unsqueeze.outputs = {"c"};
+  flatten.op_type = "Flatten";
+  flatten.inputs = {"c"};
+  flatten.outputs = {"out"};
+  g.nodes = {reshape, squeeze, unsqueeze, flatten};
+
+  const MemoryPlan plan = ComputeActivationMemoryPlan(g);
+  assert(plan.unplanned.empty());
+  assert(plan.naive_bytes == 500);  // 5 tensors x 100 bytes (x, a, b, c, out)
+  assert(plan.arena_bytes == 200);  // x's slot + one shared slot
+
+  const auto& off = plan.offsets;
+  assert(off.at("x").first != off.at("a").first);
+  assert(off.at("a") == off.at("b"));
+  assert(off.at("b") == off.at("c"));
+  assert(off.at("c") == off.at("out"));
+}
+
+// View ops (IsViewOp) and in-place-safe compute ops (IsInPlaceSafeOp) freely
+// mix in the same union-find group: x -> Reshape -> a -> Relu -> b ->
+// Flatten -> out. x is a graph input and stays separate (Reshape's own
+// aliasing is blocked the same way any other op's would be); a, b and out
+// all end up in one group despite two different op categories producing the
+// edges between them.
+void TestViewAndInPlaceOpsShareOneGroup() {
+  GraphView g;
+  for (const char* n : {"x", "a", "b", "out"}) {
+    g.shapes[n] = {SymExpr(25)};
+    g.dtypes[n] = 4;  // 100 bytes each
+  }
+  g.inputs = {"x"};
+  g.outputs = {"out"};
+
+  NodeView reshape, relu, flatten;
+  reshape.op_type = "Reshape";
+  reshape.inputs = {"x", "s"};
+  reshape.outputs = {"a"};
+  relu.op_type = "Relu";
+  relu.inputs = {"a"};
+  relu.outputs = {"b"};
+  flatten.op_type = "Flatten";
+  flatten.inputs = {"b"};
+  flatten.outputs = {"out"};
+  g.nodes = {reshape, relu, flatten};
+
+  const MemoryPlan plan = ComputeActivationMemoryPlan(g);
+  assert(plan.unplanned.empty());
+  assert(plan.naive_bytes == 400);  // 4 tensors x 100 bytes
+  assert(plan.arena_bytes == 200);  // x's slot + one shared slot
+
+  const auto& off = plan.offsets;
+  assert(off.at("x").first != off.at("a").first);
+  assert(off.at("a") == off.at("b"));
+  assert(off.at("b") == off.at("out"));
+}
+
 // `a` feeds two separate in-place-eligible ops (Neg -> y1, Sigmoid -> y2).
 // Without the "sole consumer" guard in the aliasing pass, both would try to
 // alias `a` away, incorrectly merging y1 and y2 into the same slot despite
@@ -202,6 +284,8 @@ int main() {
   TestSingleNodeNoReuse();
   TestChainReuse();
   TestInPlaceAliasingCollapsesWholeChain();
+  TestViewOpsAliasWholeChain();
+  TestViewAndInPlaceOpsShareOneGroup();
   TestInPlaceAliasingBlockedByMultipleConsumers();
   TestSymbolicShapeUnplanned();
   std::cout << "all memory_planning tests passed\n";

--- a/tests/test_memory_planning.py
+++ b/tests/test_memory_planning.py
@@ -36,6 +36,10 @@ def _weight(shape, name):
     return numpy_helper.from_array(np.zeros(shape, np.float32), name)
 
 
+def _int64(values, name):
+    return numpy_helper.from_array(np.array(values, dtype=np.int64), name)
+
+
 def _metadata(proto):
     return {entry.key: entry.value for entry in proto.metadata_props}
 
@@ -95,6 +99,62 @@ def test_in_place_aliasing_collapses_whole_chain():
     off = plan.tensor_offsets
     assert off["x"][0] != off["a"][0]
     assert off["a"] == off["b"] == off["c"] == off["d"] == off["out"]
+
+
+def test_view_ops_alias_whole_chain():
+    # A chain of pure view ops -- Reshape -> Squeeze -> Unsqueeze -> Flatten
+    # -- reinterprets the same 100 bytes under a different shape at every
+    # step with no computation at all, so they union into one group exactly
+    # like an in-place-safe unary chain; x (a graph input) stays separate.
+    # See memory_planning_test.cpp's TestViewOpsAliasWholeChain.
+    body = """
+    g (float[25] x) => (float[25] out)
+    {
+      a = Reshape(x, s)
+      b = Squeeze(a, axes0)
+      c = Unsqueeze(b, axes0)
+      out = Flatten(c)
+    }
+    """
+    model = _model(
+        body,
+        [_int64([1, 25], "s"), _int64([0], "axes0")],
+    )
+    plan = plan_activation_memory(model)
+
+    assert plan.unplanned == []
+    assert plan.naive_bytes == 500  # 5 tensors x 100 bytes (x, a, b, c, out)
+    assert plan.arena_bytes == 200  # x's slot + one shared slot
+
+    off = plan.tensor_offsets
+    assert off["x"][0] != off["a"][0]
+    assert off["a"] == off["b"] == off["c"] == off["out"]
+
+
+def test_view_and_in_place_ops_share_one_group():
+    # View ops and in-place-safe compute ops freely mix in the same group:
+    # x -> Reshape -> a -> Relu -> b -> Flatten -> out. x (a graph input)
+    # stays separate; a, b and out end up in one group despite two
+    # different op categories producing the edges between them. See
+    # memory_planning_test.cpp's TestViewAndInPlaceOpsShareOneGroup.
+    body = """
+    g (float[25] x) => (float[25] out)
+    {
+      a = Reshape(x, s)
+      b = Relu(a)
+      out = Flatten(b)
+    }
+    """
+    model = _model(body, [_int64([25], "s")])
+    plan = plan_activation_memory(model)
+
+    assert plan.unplanned == []
+    assert plan.naive_bytes == 400  # 4 tensors x 100 bytes
+    assert plan.arena_bytes == 200  # x's slot + one shared slot
+
+    off = plan.tensor_offsets
+    assert off["x"][0] != off["a"][0]
+    assert off["a"] == off["b"] == off["out"]
 
 
 def test_in_place_aliasing_blocked_by_multiple_consumers():


### PR DESCRIPTION
## Summary

Follow-up to the in-place-aliasing pass (merged in #1075): extends `plan_activation_memory`'s aliasing pass with a second, independent eligibility category — pure view ops.

## What changed

- **`onnxsim/memory_planning.cpp`**: `Reshape`, `Flatten`, `Squeeze` and `Unsqueeze` reinterpret their input's element sequence under a different shape with no computation and no element reordering — ONNX requires row-major/contiguous tensor layout, so their output is byte-for-byte identical to their input whenever the sizes actually agree (checked the same way as every other candidate). This is a *stronger* guarantee than `IsInPlaceSafeOp`'s "safe to compute in place," but folds into the same union-find pass since the resulting placement is identical: one shared slot for input and output alike.
- A chain may freely mix both allowlists (e.g. `Reshape -> Relu -> Flatten` all collapse into one group) — the union loop's condition is now `IsInPlaceSafeOp(op) || IsViewOp(op)`; everything else about the pass (weight/graph-input/graph-output exclusion, sole-consumer check, byte-size verification) is unchanged and shared.
- New tests: `TestViewOpsAliasWholeChain` (a pure Reshape/Squeeze/Unsqueeze/Flatten chain collapses to one group) and `TestViewAndInPlaceOpsShareOneGroup` (a mixed chain unions across both categories), mirrored in `tests/test_memory_planning.py` against real ONNX shape inference.
- `docs/activation-memory-planning.md` updated to describe the new category.

## Test plan

- [x] Standalone C++ test (`g++ ... memory_planning_test.cpp && ./a.out`) — all pass, including the two new cases.
- [x] `pytest tests/test_memory_planning.py` — 15 passed.
- [x] Full suite sweep — 371 passed; the 10 remaining failures are confirmed pre-existing on `master` (reproduced identically with this change stashed out): 3 fusion-pattern tests, 1 gatherelements-to-gather test, 6 `ppq`-compat tests needing an uninstalled `ppq` package.
- [x] `ruff format --check` / `ruff check` — clean.
- [x] `mypy` — same pre-existing errors as a fresh `master` checkout, zero new (confirmed by diffing the error list against this branch's base).
- [x] `clang-format --dry-run --Werror` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UFQG9xTf4YexUPryTjccoH

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFQG9xTf4YexUPryTjccoH)_