### PR TITLE
Validate GroupQueryAttention's in-op q_norm_weight/k_norm_weight before pruning

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -18435,13 +18435,16 @@ def apply_structured_pruning_matmul_bnb4(
 #     in-op `q_norm_weight`/`k_norm_weight` pair (indices 14/15) -- distinct
 #     from the external `Reshape` -> `SimplifiedLayerNormalization` ->
 #     `Reshape` "per-head norm" sandwich :func:`_walk_back_through_qk_norm_rope`
-#     already matches -- that this module's own `GroupQueryAttention`
-#     matching does *not* yet read at all. That gap is genuinely out of
-#     scope for this `PagedAttention`-focused pass (fixing it doesn't change
-#     anything about what's matched or sliced here, since -- by the same
-#     reasoning above -- the fix would be "validate paired presence and
-#     shape, slice nothing," not a new slicing rule) and is left for a
-#     future pass to close on `GroupQueryAttention` directly.
+#     already matches. That gap was genuinely out of scope for this
+#     `PagedAttention`-focused pass (fixing it doesn't change anything about
+#     what's matched or sliced here, since -- by the same reasoning above --
+#     the fix is "validate paired presence and shape, slice nothing," not a
+#     new slicing rule) and has since been closed on `GroupQueryAttention`
+#     directly: :func:`_match_gqa_producer` now validates the same
+#     paired-presence rule at indices 14/15, and :func:`_find_gqa_chains`
+#     passes `qk_norm_weight_indices=(14, 15)` to
+#     :func:`_find_separate_qkv_chains` for the deferred exact-shape check,
+#     mirroring this section's own `PagedAttention` wiring exactly.
 #   * `k_scale`/`v_scale` (indices 14/15 -- a different pair of positions
 #     from `GroupQueryAttention`'s own 12/13) share the identical
 #     PER_TENSOR/PER_CHANNEL treatment, but this op's own doc gives
@@ -19654,6 +19657,26 @@ def _match_gqa_producer(
     (declined otherwise, rather than guessed at), a dynamic one left alone
     as always. :func:`_apply_one_gqa_chain` performs the actual slice(s) of
     both once a match succeeds.
+
+    `q_norm_weight`/`k_norm_weight` (indices 14/15), documented shape
+    ``(head_size,)`` and required by the schema to "be provided together" --
+    an RMSNorm gain applied identically to every head before rotary
+    embedding, confirmed live off this environment's installed onnxruntime
+    schema (``onnxruntime.capi.onnxruntime_pybind11_state.get_all_operator_schema()``)
+    to be a genuine, independent in-op pair distinct from the external
+    `Reshape` -> `SimplifiedLayerNormalization` -> `Reshape` "per-head norm"
+    sandwich :func:`_walk_back_through_qk_norm_rope` already matches. Since
+    `head_size` never changes under this module's own whole-head/KV-group
+    pruning, neither tensor ever needs slicing once connected -- this
+    function only validates the schema's own paired-presence rule here
+    (declining a match where exactly one is connected), the same check
+    :func:`_match_paged_attention_producer` already performs for its own
+    analogous pair; :func:`_find_gqa_chains` passes
+    `qk_norm_weight_indices=(14, 15)` to :func:`_find_separate_qkv_chains`,
+    which performs the deferred exact-``(head_size,)``-shape check once
+    `head_size` itself is known, declining the whole match otherwise (the
+    same "don't guess" idiom `PagedAttention`'s own analogous pair already
+    gets).
     """
     if node.domain != _ATTENTION_DOMAIN or node.op_type != "GroupQueryAttention":
         return None
@@ -19686,6 +19709,11 @@ def _match_gqa_producer(
         sink_init = initializer_map.get(node.input[11])
         if sink_init is not None and list(sink_init.dims) != [num_heads]:
             return None  # not the schema's own (num_heads,) shape
+
+    q_norm_name = node.input[14] if len(node.input) > 14 else ""
+    k_norm_name = node.input[15] if len(node.input) > 15 else ""
+    if bool(q_norm_name) != bool(k_norm_name):
+        return None  # schema: "must be provided together"
 
     return num_heads, kv_num_heads
 
@@ -20438,9 +20466,11 @@ def _match_paged_attention_producer(
 #   `dt_bias`/`decay_scale` per-head weights by `keep_groups`, mirroring how
 #   `_walk_back_through_qk_norm_rope` already recognizes a per-head Q/K-norm
 #   sandwich) would close this gap, but is genuinely new machinery beyond
-#   this feature's own scope -- left for a future pass, exactly like
-#   `GroupQueryAttention`'s own in-op `q_norm_weight`/`k_norm_weight` gap
-#   this module's own comment already names as future work.
+#   this feature's own scope -- left for a future pass, the same kind of
+#   scoped-out future work `GroupQueryAttention`'s own in-op
+#   `q_norm_weight`/`k_norm_weight` gap once was, before this module's
+#   `_match_gqa_producer`/`_find_gqa_chains` closed it (see this module's
+#   "Attention-head pruning" section comment for that wiring).
 # - `scale` (float, default 0.0 -- "derives d_k... and uses 1/sqrt(d_k)")
 #   and `chunk_size` (int, "tuning hint; does not affect output correctness")
 #   are both entirely head-count-independent -- neither is ever read or
@@ -22259,8 +22289,23 @@ def _find_gqa_chains(
     graph: onnx.GraphProto,
     value_info_by_name: Optional[Dict[str, onnx.ValueInfoProto]] = None,
 ) -> List[_GQAChain]:
+    """See :func:`_find_separate_qkv_chains` (the shared body) and
+    :func:`_match_gqa_producer` (what's matched and why it's declined
+    otherwise). Passes ``qk_norm_weight_indices=(14, 15)`` --
+    `GroupQueryAttention`'s own `q_norm_weight`/`k_norm_weight` input
+    indices (confirmed live off this environment's installed onnxruntime
+    schema), the same deferred exact-``(head_size,)``-shape check
+    :func:`_find_paged_attention_chains` already wires up for
+    `PagedAttention`'s own analogous pair at indices 12/13 -- see
+    :class:`_GQAChain`'s own docstring for why neither is ever sliced
+    despite this deferred check.
+    """
     return _find_separate_qkv_chains(
-        graph, _match_gqa_producer, "num_heads", value_info_by_name
+        graph,
+        _match_gqa_producer,
+        "num_heads",
+        value_info_by_name,
+        qk_norm_weight_indices=(14, 15),
     )
 
 

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -13032,6 +13032,8 @@ def _gqa_model(
     # initializer (mutually exclusive with `attention_bias`) -- a str entry
     # becomes a named symbolic dim_param (e.g. "H"), an int a concrete one.
     head_sink=None,  # constant head_sink array (shape (H,)), or None (unconnected)
+    q_norm_weight=None,  # constant q_norm_weight array (shape (D,)), or None (unconnected)
+    k_norm_weight=None,  # constant k_norm_weight array (shape (D,)), or None (unconnected)
 ):
     # Real ONNX Runtime CPU kernels for GroupQueryAttention require
     # head_size to be a multiple of 8 (verified empirically -- a smaller
@@ -13126,19 +13128,21 @@ def _gqa_model(
         operands += ["", ""]
     operands += ["SeqLensK", "TotalSeq"]
 
-    # `attention_bias`/`head_sink`/`k_scale`/`v_scale` (GQA input indices
-    # 10/11/12/13) sit behind three other optional inputs
-    # (cos_cache/sin_cache/position_ids, indices 7-9, always left
-    # unconnected here -- none of this module's own matching/slicing
-    # touches them) that must be threaded through as empty positional
-    # placeholders for the text format's positional-input convention to
-    # reach index 10 at all.
+    # `attention_bias`/`head_sink`/`k_scale`/`v_scale`/`q_norm_weight`/
+    # `k_norm_weight` (GQA input indices 10/11/12/13/14/15) sit behind three
+    # other optional inputs (cos_cache/sin_cache/position_ids, indices 7-9,
+    # always left unconnected here -- none of this module's own
+    # matching/slicing touches them) that must be threaded through as empty
+    # positional placeholders for the text format's positional-input
+    # convention to reach index 10 at all.
     if (
         attention_bias is not None
         or attention_bias_dynamic_shape is not None
         or head_sink is not None
         or k_scale is not None
         or v_scale is not None
+        or q_norm_weight is not None
+        or k_norm_weight is not None
     ):
         operands += [""] * 3  # cos_cache, sin_cache, position_ids
         if attention_bias is not None:
@@ -13163,6 +13167,16 @@ def _gqa_model(
         if v_scale is not None:
             initializer.append(_f32(np.asarray(v_scale), "VScale"))
             operands.append("VScale")
+        else:
+            operands.append("")
+        if q_norm_weight is not None:
+            initializer.append(_f32(np.asarray(q_norm_weight), "QNorm"))
+            operands.append("QNorm")
+        else:
+            operands.append("")
+        if k_norm_weight is not None:
+            initializer.append(_f32(np.asarray(k_norm_weight), "KNorm"))
+            operands.append("KNorm")
         else:
             operands.append("")
 
@@ -13225,6 +13239,8 @@ def _gqa_model(
         v_scale=v_scale,
         attention_bias=attention_bias,
         head_sink=head_sink,
+        q_norm_weight=q_norm_weight,
+        k_norm_weight=k_norm_weight,
     )
 
 
@@ -14267,6 +14283,103 @@ def test_gqa_pruning_malformed_head_sink_shape_is_declined():
     }
     for name in inits_before:
         np.testing.assert_array_equal(inits_before[name], inits_after[name])
+
+
+def test_gqa_pruning_qk_norm_weight_paired_presence_required():
+    # `GroupQueryAttention`'s own `q_norm_weight`/`k_norm_weight` (indices
+    # 14/15) share the identical "must be provided together" schema rule
+    # `PagedAttention`'s own analogous pair already gets (see
+    # `test_paged_attention_pruning_qk_norm_weight_paired_presence_required`)
+    # -- `k_norm_weight` deliberately omitted here declines the whole match,
+    # leaving the node entirely untouched.
+    K, H, KVH, D, Out = 8, 4, 2, 8, 6
+    q_norm = np.ones(D, dtype=np.float32)
+    model, cfg = _gqa_model(
+        K=K, H=H, KVH=KVH, D=D, Out=Out, seed=67, q_norm_weight=q_norm
+    )
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    node = _gqa_node(pruned)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    assert (num_heads, kv_num_heads) == (H, KVH)  # left untouched
+
+
+def test_gqa_pruning_qk_norm_weight_wrong_shape_is_declined():
+    # A connected `q_norm_weight`/`k_norm_weight` pair not exactly
+    # `(head_size,)`-shaped is a real, previously-unvalidated correctness
+    # risk this fix closes: before `_find_gqa_chains` passed
+    # `qk_norm_weight_indices=(14, 15)` to `_find_separate_qkv_chains`, a
+    # `GroupQueryAttention` node like this one would have been silently
+    # pruned without ever checking whether the norm weight's own shape was
+    # even head-count-invariant. Now the whole match is declined instead,
+    # the node left completely untouched.
+    K, H, KVH, D, Out = 8, 4, 2, 8, 6
+    model, cfg = _gqa_model(
+        K=K,
+        H=H,
+        KVH=KVH,
+        D=D,
+        Out=Out,
+        seed=68,
+        q_norm_weight=np.ones(D + 1, dtype=np.float32),
+        k_norm_weight=np.ones(D + 1, dtype=np.float32),
+    )
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    node = _gqa_node(pruned)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    assert (num_heads, kv_num_heads) == (H, KVH)  # left untouched
+
+    inits_before = {
+        t.name: onnx.numpy_helper.to_array(t) for t in model.graph.initializer
+    }
+    inits_after = {
+        t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer
+    }
+    for name in inits_before:
+        np.testing.assert_array_equal(inits_before[name], inits_after[name])
+
+
+def test_gqa_pruning_qk_norm_weight_both_present_matches_oracle():
+    # `q_norm_weight`/`k_norm_weight` are `(head_size,)`-shaped -- constant
+    # across heads -- so they never need slicing under whole-head/KV-group
+    # pruning: this confirms a real match/prune still happens (the positive,
+    # pre-existing-behavior-preserving case this fix must not regress),
+    # Wq/Wk/Wv genuinely shrink, and QNorm/KNorm stay byte-identical.
+    # `GroupQueryAttention`'s own CPU kernel rejects a node with either
+    # input connected at all ("q_norm_weight / k_norm_weight inputs are not
+    # supported... implemented only on the CUDA and WebGPU EPs", confirmed
+    # empirically against this environment's installed onnxruntime), so
+    # unlike the plain attention_bias/head_sink tests above, this is checked
+    # structurally rather than by running the pruned model through a real
+    # `InferenceSession` -- the same CPU-kernel-unavailable fallback
+    # `test_paged_attention_pruning_qk_norm_weight_both_present_left_unsliced`
+    # already uses for its own analogous pair.
+    K, H, KVH, D, Out = 8, 4, 2, 8, 6
+    q_norm = np.arange(D, dtype=np.float32)
+    k_norm = np.arange(D, dtype=np.float32) * 2.0
+    model, cfg = _gqa_model(
+        K=K,
+        H=H,
+        KVH=KVH,
+        D=D,
+        Out=Out,
+        seed=69,
+        q_norm_weight=q_norm,
+        k_norm_weight=k_norm,
+    )
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    node = _gqa_node(pruned)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    assert (num_heads, kv_num_heads) != (H, KVH)  # a real match/prune happened
+    assert kv_num_heads == 1
+    assert num_heads == 2
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["QNorm"], q_norm)
+    np.testing.assert_array_equal(inits["KNorm"], k_norm)
+    assert inits["Wq"].shape == (K, num_heads * D)
+    assert inits["Wk"].shape == (K, kv_num_heads * D)
+    assert inits["Wv"].shape == (K, kv_num_heads * D)
 
 
 def test_gqa_wanda_pruning_matches_oracle_exactly():


### PR DESCRIPTION
## Summary

`com.microsoft::GroupQueryAttention` has its own in-op `q_norm_weight`/`k_norm_weight` inputs (an RMSNorm gain applied identically to every head, before rotary embedding) — a genuine, independent mechanism distinct from the external `Reshape → SimplifiedLayerNormalization → Reshape` "per-head norm" sandwich `_walk_back_through_qk_norm_rope` already matches. `_match_gqa_producer`/`_find_gqa_chains` had no awareness of these two inputs at all — meaning a `GroupQueryAttention` node with a genuine, non-empty `q_norm_weight`/`k_norm_weight` (a real Qwen3/Gemma2-style GQA-with-fused-in-op-norm export) got pruned **without ever validating that weight's shape is actually head-count-invariant** — a real, silent correctness risk this module's own documented philosophy says should be validated and declined-if-inconsistent, not assumed safe. `PagedAttention` already has the identical check for its own analogous `q_norm_weight`/`k_norm_weight` pair (at different indices) — this PR closes the same gap for `GroupQueryAttention`, a scope boundary the module's own comments already explicitly named as future work.

## Empirically confirmed facts

Live-queried `onnxruntime.capi.onnxruntime_pybind11_state.get_all_operator_schema()` for `com.microsoft::GroupQueryAttention`: `q_norm_weight` is input index 14, `k_norm_weight` is index 15 — confirmed independently, matching the module's existing comment. Both are documented `(head_size,)`-shaped and required by the schema to "be provided together." Also confirmed via a real `InferenceSession` run that the CPU execution provider rejects the node outright once either is connected ("implemented only on the CUDA and WebGPU EPs") — which shaped the test methodology below (structural verification rather than end-to-end `InferenceSession` parity for the positive case, matching how `PagedAttention`'s own analogous test already handles this same CPU-kernel limitation).

## What's added

- `_match_gqa_producer`: added the schema's paired-presence check at indices 14/15 (declines when exactly one of `q_norm_weight`/`k_norm_weight` is connected), mirroring `_match_paged_attention_producer`'s existing check for its own 12/13 pair.
- `_find_gqa_chains`: now passes `qk_norm_weight_indices=(14, 15)` to `_find_separate_qkv_chains`, reusing the existing deferred exact-`(head_size,)`-shape check verbatim — no changes needed to the shared body. Since `head_size` never changes under whole-head/KV-group pruning, neither tensor is ever sliced; this is purely a safety validation.
- Updated two comment blocks that previously described this as open "future work" to instead point at the new wiring.

## Test plan

- [x] `pytest tests/test_pruning.py -q` — 865 passed (862 baseline + 3 new); the same 21 pre-existing, unrelated failures remain (`apply_transformer_block_pruning` missing from this environment's stale compiled C++ extension — confirmed identical before/after; CI builds fresh)
- [x] `ruff format --check` / `ruff check` on both touched files — clean
- [x] `mypy onnxsim/pruning.py` — 0 errors
- [x] Independently re-confirmed the 14/15 indices myself directly against the installed onnxruntime schema
- [x] Independently re-verified via a revert-only-`pruning.py` check: the 2 decline tests fail against the pre-change code (previously-silent, unvalidated pruning — e.g. a wrong-shape norm weight left connected while Q/K/V were sliced anyway); the "both present, correct shape" test correctly passes either way (it exercises the pre-existing correct case, not new validation logic); restored and confirmed all 3 pass again

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_