### PR TITLE
Add binary operand donation to the activation memory planner

### DIFF
--- a/docs/activation-memory-planning.md
+++ b/docs/activation-memory-planning.md
@@ -84,6 +84,24 @@ logical storage. Honoring that part of the plan means actually running that
 node's kernel in place — writing its output over the input's own buffer —
 not just treating a repeated offset as "safe to reuse afterward."
 
+A second, independent category extends this to **binary operand donation**:
+an elementwise binary op (`Add`, `Sub`, `Mul`, `Div`, `Max`, `Min`, `And`,
+`Or`, `Xor`, `Mod` — see `IsInPlaceSafeBinaryOp`) can compute its output by
+overwriting *one* of its two operands, the same way real NN memory planners
+(MXNet, XLA) donate an operand's buffer to a binary kernel's output. The
+candidate operand must clear the exact same bar as the unary pass's input —
+not a weight/graph input/graph output, consumed exactly once, and matching
+the output's byte size — checked against **each** operand in turn (`input[0]`
+then `input[1]`), aliasing **at most one** of them. Matching the output's byte
+size is what rules out a *broadcast* operand: ONNX broadcasts a smaller
+operand up to the output's shape, so a genuinely broadcast operand's byte
+size never equals the output's, and it is correctly left un-aliased no
+matter how eligible it otherwise looks. The operand that isn't donated (if
+any) is simply left for the ordinary liveness pass to place, same as any
+other tensor. Because this unions into the very same `UnionFind` as the
+unary pass, a chain mixing unary and binary in-place-safe ops (e.g.
+`Relu -> Add -> Sigmoid`) still collapses into one group end to end.
+
 ## What's in `MemoryPlan`
 
 - **`tensor_offsets`** — `{name: (offset, size)}` for every planned tensor.

--- a/onnxsim/memory_planning.cpp
+++ b/onnxsim/memory_planning.cpp
@@ -46,6 +46,22 @@ bool IsInPlaceSafeOp(const std::string& op_type) {
   return kSafeOps.count(op_type) > 0;
 }
 
+// Elementwise *binary* ops whose ONNX semantics compute output[i] purely from
+// (input0[i], input1[i]) -- so, absent broadcasting (checked separately: the
+// candidate operand's byte size must equal the output's), an executor can
+// compute the output by overwriting either operand's own storage in place,
+// same as IsInPlaceSafeOp's unary allowlist but with two candidate operands
+// instead of one. A curated allowlist for the same reason as the unary one:
+// nothing here parses attributes or checks broadcast shapes itself, so it
+// only lists ops that are unconditionally elementwise-safe when the shapes
+// already match.
+bool IsInPlaceSafeBinaryOp(const std::string& op_type) {
+  static const std::set<std::string> kSafeBinaryOps = {
+      "Add", "Sub", "Mul", "Div", "Max", "Min", "And", "Or", "Xor", "Mod",
+  };
+  return kSafeBinaryOps.count(op_type) > 0;
+}
+
 // Union-find (disjoint-set) over tensor names, path-compressed, used to
 // coalesce a chain of in-place-eligible ops (e.g. Relu -> Sigmoid -> Tanh)
 // into one placement group that needs a single slot for its whole span
@@ -127,17 +143,43 @@ MemoryPlan ComputeActivationMemoryPlan(const GraphView& graph) {
     }
   }
 
-  // In-place aliasing: union a safe unary op's input[0] with its output[0]
-  // (see IsInPlaceSafeOp) whenever doing so is provably safe --
+  // Shared eligibility check for a candidate operand `cand` to be aliased
+  // (unioned) with a node's output `out0`:
   //   * not a weight, a graph input, or a declared graph output (an
   //     externally-owned buffer, or one the caller reads only after the
   //     whole graph finishes, so overwriting it mid-run would be observed
   //     as corruption rather than reused space);
   //   * consumed exactly once, by this node -- the only read of the
   //     original value;
-  //   * input and output agree on size (always true for these ops on a
-  //     well-formed model; checked anyway as a defensive belt-and-braces).
-  // A chain of such ops unions transitively into one group -- Find() on any
+  //   * `cand` and `out0` agree on byte size -- always true for the unary
+  //     pass's ops on a well-formed model (checked anyway as a defensive
+  //     belt-and-braces); for the binary pass below, this is also exactly
+  //     what rules out a *broadcast* operand (a smaller operand ONNX would
+  //     broadcast up to the output's shape never matches the output's byte
+  //     size, so it is correctly rejected here rather than aliased).
+  // Shared by both the unary and binary in-place-aliasing passes.
+  const auto is_alias_eligible = [&](const std::string& cand,
+                                     const std::string& out0) {
+    if (cand.empty() || out0.empty()) return false;
+    if (weights.count(cand) || graph_inputs.count(cand) ||
+        graph_outputs.count(cand)) {
+      return false;
+    }
+    const auto cit = consumer_count.find(cand);
+    if (cit == consumer_count.end() || cit->second != 1) return false;
+
+    const auto cand_bytes = TensorBytes(cand, graph.shapes, graph.dtypes);
+    const auto out_bytes = TensorBytes(out0, graph.shapes, graph.dtypes);
+    if (!cand_bytes || !out_bytes || cand_bytes->is_symbolic() ||
+        out_bytes->is_symbolic()) {
+      return false;
+    }
+    return cand_bytes->to_int() == out_bytes->to_int();
+  };
+
+  // In-place aliasing: union a safe unary op's input[0] with its output[0]
+  // (see IsInPlaceSafeOp) whenever `is_alias_eligible` says it's safe. A
+  // chain of such ops unions transitively into one group -- Find() on any
   // member returns the same root -- that needs only a single slot for its
   // entire span, rather than one slot per node.
   UnionFind uf;
@@ -146,23 +188,34 @@ MemoryPlan ComputeActivationMemoryPlan(const GraphView& graph) {
     if (node.inputs.empty() || node.outputs.size() != 1) continue;
     const std::string& in0 = node.inputs[0];
     const std::string& out0 = node.outputs[0];
-    if (in0.empty() || out0.empty()) continue;
-    if (weights.count(in0) || graph_inputs.count(in0) ||
-        graph_outputs.count(in0)) {
-      continue;
-    }
-    const auto cit = consumer_count.find(in0);
-    if (cit == consumer_count.end() || cit->second != 1) continue;
-
-    const auto in_bytes = TensorBytes(in0, graph.shapes, graph.dtypes);
-    const auto out_bytes = TensorBytes(out0, graph.shapes, graph.dtypes);
-    if (!in_bytes || !out_bytes || in_bytes->is_symbolic() ||
-        out_bytes->is_symbolic()) {
-      continue;
-    }
-    if (in_bytes->to_int() != out_bytes->to_int()) continue;
+    if (!is_alias_eligible(in0, out0)) continue;
 
     uf.Union(in0, out0);
+  }
+
+  // Binary in-place aliasing / operand donation: for a safe elementwise
+  // binary op (see IsInPlaceSafeBinaryOp) with exactly two inputs and one
+  // output, union its output with *at most one* of its two operands -- try
+  // input[0] first, then input[1] only if input[0] didn't qualify. The other
+  // operand (donated or not) is left as an ordinary, separately-tracked
+  // tensor; the existing liveness pass already places it correctly on its
+  // own. Reuses the exact same `is_alias_eligible` conditions as the unary
+  // pass above, so a broadcast operand (byte size differs from the output's)
+  // or a multiply-consumed one is never aliased, and this coalesces into the
+  // same UnionFind, so a value can be donated through a chain mixing unary
+  // and binary in-place-safe ops (e.g. Relu -> Add -> Sigmoid).
+  for (const NodeView& node : graph.nodes) {
+    if (!IsInPlaceSafeBinaryOp(node.op_type)) continue;
+    if (node.inputs.size() != 2 || node.outputs.size() != 1) continue;
+    const std::string& in0 = node.inputs[0];
+    const std::string& in1 = node.inputs[1];
+    const std::string& out0 = node.outputs[0];
+
+    if (is_alias_eligible(in0, out0)) {
+      uf.Union(in0, out0);
+    } else if (is_alias_eligible(in1, out0)) {
+      uf.Union(in1, out0);
+    }
   }
 
   // Pass 1: one Interval per plannable *group* -- a group is a single

--- a/onnxsim/memory_planning.h
+++ b/onnxsim/memory_planning.h
@@ -38,7 +38,13 @@
 // (offset, size) in `offsets` -- a downstream consumer honours the plan by
 // actually running that node's kernel in place (writing its output over the
 // input's own buffer), not merely by treating same-offset as "safe to reuse
-// after the fact" the way two disjoint-interval tensors are.
+// after the fact" the way two disjoint-interval tensors are. A second,
+// independent aliasing category (see IsInPlaceSafeBinaryOp) extends this to
+// binary elementwise ops -- Add, Mul, and the like -- which may instead union
+// their output with *one* of their two operands ("operand donation"), the
+// candidate operand held to the exact same bar as above (checked against
+// each operand in turn, aliasing at most one; a broadcast operand's byte
+// size never matches the output's, so it is never a candidate).
 //
 // v1 scope, deliberately:
 //   * Concrete shapes only. A tensor whose size cannot be resolved to a

--- a/onnxsim/memory_planning_test.cpp
+++ b/onnxsim/memory_planning_test.cpp
@@ -173,6 +173,200 @@ void TestInPlaceAliasingBlockedByMultipleConsumers() {
   assert(plan.offsets.at("y1").first != plan.offsets.at("y2").first);
 }
 
+// Binary in-place aliasing / operand donation: x -> Relu -> a, then
+// y = Add(a, w) with w a weight. `a` is the sole consumer of x's Relu output
+// and the sole consumer feeding Add, so it is eligible to donate into y
+// (see IsInPlaceSafeBinaryOp); w is a weight, never planned at all.
+//   produced_at: x=-1, a=0, y=1 (w excluded, it's a weight)
+//   last_use:    x=0 (consumed by Relu), a=1 (consumed by Add), y=end=2
+//   union(a, y) -> one group spanning [min(0,1), max(1,2)] = [0,2], size S
+//   x's own group: [-1,0], size S
+// x and the {a,y} group still block each other under the conservative
+// same-node-boundary rule (x.end==0 == group.start==0), so they still need
+// separate slots -- but arena_bytes is 2*S (x's slot + one shared slot for
+// {a,y}) rather than 3*S (one slot each for x, a, y with no donation), i.e.
+// donating `a` into `y` shrinks the arena versus the naive baseline.
+void TestBinaryInPlaceAliasingDonatesOperand() {
+  GraphView g;
+  for (const char* n : {"x", "a", "y"}) {
+    g.shapes[n] = {SymExpr(25)};
+    g.dtypes[n] = 4;  // 100 bytes each
+  }
+  g.shapes["w"] = {SymExpr(25)};
+  g.dtypes["w"] = 4;
+  g.inputs = {"x"};
+  g.outputs = {"y"};
+  g.initializers = {"w"};
+
+  NodeView relu, add;
+  relu.op_type = "Relu";
+  relu.inputs = {"x"};
+  relu.outputs = {"a"};
+  add.op_type = "Add";
+  add.inputs = {"a", "w"};
+  add.outputs = {"y"};
+  g.nodes = {relu, add};
+
+  const MemoryPlan plan = ComputeActivationMemoryPlan(g);
+  assert(plan.unplanned.empty());
+  assert(plan.offsets.count("w") == 0);  // weights are never planned
+  assert(plan.naive_bytes == 300);       // x + a + y, 100 bytes each
+  assert(plan.arena_bytes == 200);       // x's slot + one shared {a, y} slot
+
+  const auto& off = plan.offsets;
+  assert(off.at("a") == off.at("y"));  // donated into one group
+  assert(off.at("x").first != off.at("a").first);
+}
+
+// Both operands of the Add are otherwise alias-eligible (each the sole
+// consumer of its own Relu), but at most one may be donated: input[0] (`a`)
+// is tried first and succeeds, so `b` is left as an ordinary, independently
+// tracked tensor rather than also being folded into the group.
+//   nodes: Relu(x1)->a, Relu(x2)->b, Add(a,b)->y
+//   produced_at: x1=-1, x2=-1, a=0, b=1, y=2
+//   last_use:    x1=0, x2=1, a=2 (consumed by Add), b=2 (consumed by Add),
+//                y=end=3
+//   union(a, y) only -- b is never unioned with anything
+//   groups (all size S=100): x1=[-1,0], x2=[-1,1], b=[1,2], {a,y}=[0,3]
+//   greedy best-fit, largest-first/name tie-break order b, x1, x2, {a,y}:
+//     b       -> offset 0                       (no blockers)
+//     x1      -> offset 0   (disjoint from b: x1 ends at 0, b starts at 1)
+//     x2      -> offset 100 (overlaps both b and x1)
+//     {a,y}   -> offset 200 (overlaps b, x1, and x2)
+//   arena_bytes = 300, naive_bytes = 5*100 = 500 (x1, x2, a, b, y)
+void TestBinaryInPlaceAliasingOtherOperandStillTracked() {
+  GraphView g;
+  for (const char* n : {"x1", "x2", "a", "b", "y"}) {
+    g.shapes[n] = {SymExpr(25)};
+    g.dtypes[n] = 4;  // 100 bytes each
+  }
+  g.inputs = {"x1", "x2"};
+  g.outputs = {"y"};
+
+  NodeView relu1, relu2, add;
+  relu1.op_type = "Relu";
+  relu1.inputs = {"x1"};
+  relu1.outputs = {"a"};
+  relu2.op_type = "Relu";
+  relu2.inputs = {"x2"};
+  relu2.outputs = {"b"};
+  add.op_type = "Add";
+  add.inputs = {"a", "b"};
+  add.outputs = {"y"};
+  g.nodes = {relu1, relu2, add};
+
+  const MemoryPlan plan = ComputeActivationMemoryPlan(g);
+  assert(plan.unplanned.empty());
+  assert(plan.naive_bytes == 500);
+  assert(plan.arena_bytes == 300);
+
+  const auto& off = plan.offsets;
+  assert(off.at("a") == off.at("y"));  // a donated into y's group
+  assert(off.at("b") != off.at("a"));  // b is its own, separate group
+  assert(off.at("b") != off.at("y"));
+  assert(off.at("b").first == 0);
+  assert(off.at("a").first == 200);
+  assert(off.at("y").first == 200);
+}
+
+// `scale` ([1], 4 bytes) broadcasts up to the output's shape ([25], 100
+// bytes) under ONNX's Add semantics, so its byte size never matches the
+// output's -- it must never be aliased, no matter how eligible it otherwise
+// looks (sole consumer, not a weight/input/output). `a` ([25], 100 bytes) is
+// the exact-shape operand and is still eligible, so this also exercises the
+// "input[0] doesn't qualify -> fall back to input[1]" order, since `scale`
+// is input[0] here.
+//   nodes: Relu(s0)->scale, Relu(x)->a, Add(scale,a)->y
+//   produced_at: s0=-1, x=-1, scale=0, a=1, y=2
+//   last_use:    s0=0, x=1, scale=2 (consumed by Add), a=2 (consumed by Add),
+//                y=end=3
+//   union(a, y) only -- scale's bytes (4) != y's bytes (100), so it's
+//   rejected regardless of being tried first
+//   groups: s0=[-1,0] (4B), x=[-1,1] (100B), scale=[0,2] (4B),
+//           {a,y}=[1,3] (100B)
+//   greedy best-fit, largest-first (100B: x, {a,y}; then 4B: s0, scale):
+//     x       -> offset 0
+//     {a,y}   -> offset 100 (overlaps x)
+//     s0      -> offset 100 (disjoint from x's *time* interval; only
+//                overlaps in fallback bookkeeping, see below)
+//     scale   -> offset 200 (overlaps x, {a,y}, and s0)
+//   arena_bytes = 204, naive_bytes = 4 + 100 + 4 + 100 + 100 = 308
+void TestBinaryInPlaceAliasingSkipsBroadcastOperand() {
+  GraphView g;
+  g.shapes["s0"] = {SymExpr(1)};
+  g.shapes["scale"] = {SymExpr(1)};
+  g.dtypes["s0"] = g.dtypes["scale"] = 4;  // 4 bytes each
+  for (const char* n : {"x", "a", "y"}) {
+    g.shapes[n] = {SymExpr(25)};
+    g.dtypes[n] = 4;  // 100 bytes each
+  }
+  g.inputs = {"s0", "x"};
+  g.outputs = {"y"};
+
+  NodeView relu_s, relu_x, add;
+  relu_s.op_type = "Relu";
+  relu_s.inputs = {"s0"};
+  relu_s.outputs = {"scale"};
+  relu_x.op_type = "Relu";
+  relu_x.inputs = {"x"};
+  relu_x.outputs = {"a"};
+  add.op_type = "Add";
+  add.inputs = {"scale", "a"};
+  add.outputs = {"y"};
+  g.nodes = {relu_s, relu_x, add};
+
+  const MemoryPlan plan = ComputeActivationMemoryPlan(g);
+  assert(plan.unplanned.empty());
+  assert(plan.naive_bytes == 308);
+  assert(plan.arena_bytes == 204);
+
+  const auto& off = plan.offsets;
+  assert(off.at("a") == off.at("y"));      // a still donated (input[1])
+  assert(off.at("scale") != off.at("y"));  // broadcast operand never aliased
+  assert(off.at("scale").second == 4);
+  assert(off.at("y").second == 100);
+}
+
+// `a` is consumed by two nodes -- Neg(a) -> y1, and Add(a, a) -> y2, the
+// latter using the *same* tensor as both operands. The consumer-count guard
+// counts (node, input-slot) pairs, so Add(a, a) alone contributes two
+// consumer events for `a` (consumer_count["a"] ends up 3: one for Neg, two
+// for Add), well past the "consumed exactly once" bar -- so neither the
+// unary nor the binary aliasing pass ever touches `a`, and this is safe
+// (never double-aliases `a` into both y1 and y2, which are simultaneously
+// live graph outputs) without any special-casing for the repeated operand.
+void TestBinaryInPlaceAliasingBlockedByMultipleConsumers() {
+  GraphView g;
+  for (const char* n : {"x", "a", "y1", "y2"}) {
+    g.shapes[n] = {SymExpr(25)};
+    g.dtypes[n] = 4;  // 100 bytes each
+  }
+  g.inputs = {"x"};
+  g.outputs = {"y1", "y2"};
+
+  NodeView relu, neg, add;
+  relu.op_type = "Relu";
+  relu.inputs = {"x"};
+  relu.outputs = {"a"};
+  neg.op_type = "Neg";
+  neg.inputs = {"a"};
+  neg.outputs = {"y1"};
+  add.op_type = "Add";
+  add.inputs = {"a", "a"};  // same tensor as both operands
+  add.outputs = {"y2"};
+  g.nodes = {relu, neg, add};
+
+  const MemoryPlan plan = ComputeActivationMemoryPlan(g);
+  assert(plan.unplanned.empty());
+  assert(plan.naive_bytes == 400);
+  assert(plan.arena_bytes == 300);  // no donation possible anywhere
+
+  const auto& off = plan.offsets;
+  assert(off.at("a") != off.at("y1"));
+  assert(off.at("a") != off.at("y2"));
+  assert(off.at("y1") != off.at("y2"));  // both live simultaneously
+}
+
 // A tensor with a symbolic (dynamic) dimension has no concrete byte size, so
 // it must be excluded from the plan (`unplanned`) rather than guessed, and
 // must not contribute to naive_bytes/arena_bytes.
@@ -203,6 +397,10 @@ int main() {
   TestChainReuse();
   TestInPlaceAliasingCollapsesWholeChain();
   TestInPlaceAliasingBlockedByMultipleConsumers();
+  TestBinaryInPlaceAliasingDonatesOperand();
+  TestBinaryInPlaceAliasingOtherOperandStillTracked();
+  TestBinaryInPlaceAliasingSkipsBroadcastOperand();
+  TestBinaryInPlaceAliasingBlockedByMultipleConsumers();
   TestSymbolicShapeUnplanned();
   std::cout << "all memory_planning tests passed\n";
   return 0;

--- a/tests/test_memory_planning.py
+++ b/tests/test_memory_planning.py
@@ -116,6 +116,114 @@ def test_in_place_aliasing_blocked_by_multiple_consumers():
     assert plan.tensor_offsets["y1"][0] != plan.tensor_offsets["y2"][0]
 
 
+def test_binary_in_place_aliasing_donates_operand():
+    # x -> Relu -> a, then y = Add(a, w) with w a weight. `a` is the sole
+    # consumer feeding Add, so it donates into y (see IsInPlaceSafeBinaryOp);
+    # w is a weight and never planned at all. See memory_planning_test.cpp's
+    # TestBinaryInPlaceAliasingDonatesOperand for the byte-offset derivation:
+    # arena is 2 slots (x's own, plus one shared {a, y} slot) rather than 3.
+    body = """
+    g (float[25] x) => (float[25] y)
+    {
+      a = Relu(x)
+      y = Add(a, w)
+    }
+    """
+    plan = plan_activation_memory(_model(body, [_weight([25], "w")]))
+
+    assert plan.unplanned == []
+    assert "w" not in plan.tensor_offsets
+    assert plan.naive_bytes == 300  # x + a + y, 100 bytes each
+    assert plan.arena_bytes == 200
+
+    off = plan.tensor_offsets
+    assert off["a"] == off["y"]
+    assert off["x"][0] != off["a"][0]
+
+
+def test_binary_in_place_aliasing_other_operand_still_tracked():
+    # Both operands of Add are otherwise alias-eligible (each the sole
+    # consumer of its own Relu), but at most one is donated: input[0] (`a`)
+    # is tried first and succeeds, so `b` stays an ordinary, independently
+    # tracked tensor. See memory_planning_test.cpp's
+    # TestBinaryInPlaceAliasingOtherOperandStillTracked for the full
+    # byte-offset derivation.
+    body = """
+    g (float[25] x1, float[25] x2) => (float[25] y)
+    {
+      a = Relu(x1)
+      b = Relu(x2)
+      y = Add(a, b)
+    }
+    """
+    plan = plan_activation_memory(_model(body))
+
+    assert plan.unplanned == []
+    assert plan.naive_bytes == 500  # x1, x2, a, b, y, 100 bytes each
+    assert plan.arena_bytes == 300
+
+    off = plan.tensor_offsets
+    assert off["a"] == off["y"]  # a donated into y's group
+    assert off["b"] != off["a"]  # b is its own, separate group
+    assert off["b"] != off["y"]
+
+
+def test_binary_in_place_aliasing_skips_broadcast_operand():
+    # `scale` ([1], 4 bytes) broadcasts up to the output's shape ([25], 100
+    # bytes), so its byte size never matches the output's -- it must never be
+    # aliased no matter how eligible it otherwise looks. `a` ([25], 100
+    # bytes) is the exact-shape operand and is still eligible, exercising the
+    # "input[0] doesn't qualify -> fall back to input[1]" order since `scale`
+    # is input[0] here. See memory_planning_test.cpp's
+    # TestBinaryInPlaceAliasingSkipsBroadcastOperand for the derivation.
+    body = """
+    g (float[1] s0, float[25] x) => (float[25] y)
+    {
+      scale = Relu(s0)
+      a = Relu(x)
+      y = Add(scale, a)
+    }
+    """
+    plan = plan_activation_memory(_model(body))
+
+    assert plan.unplanned == []
+    assert plan.naive_bytes == 308  # 4 + 100 + 4 + 100 + 100
+    assert plan.arena_bytes == 204
+
+    off = plan.tensor_offsets
+    assert off["a"] == off["y"]  # a still donated (input[1])
+    assert off["scale"] != off["y"]  # broadcast operand never aliased
+    assert off["scale"][1] == 4
+    assert off["y"][1] == 100
+
+
+def test_binary_in_place_aliasing_blocked_by_multiple_consumers():
+    # `a` is consumed by Neg(a) -> y1 and Add(a, a) -> y2, the latter using
+    # the same tensor as both operands. The consumer-count guard counts
+    # (node, input-slot) pairs, so Add(a, a) alone contributes two consumer
+    # events -- well past the "consumed exactly once" bar -- so neither the
+    # unary nor the binary aliasing pass ever touches `a`, and y1/y2 (both
+    # simultaneously live graph outputs) are never incorrectly merged.
+    body = """
+    g (float[25] x) => (float[25] y1, float[25] y2)
+    {
+      a = Relu(x)
+      y1 = Neg(a)
+      y2 = Add(a, a)
+    }
+    """
+    plan = plan_activation_memory(_model(body))
+
+    assert plan.unplanned == []
+    assert plan.naive_bytes == 400
+    assert plan.arena_bytes == 300  # no donation possible anywhere
+
+    off = plan.tensor_offsets
+    assert off["a"] != off["y1"]
+    assert off["a"] != off["y2"]
+    assert off["y1"] != off["y2"]
+
+
 def test_weights_excluded_and_no_reuse_when_overlapping():
     # A single Conv reads x while producing y, so under the allocator's
     # conservative same-node-boundary rule they can never share space: the


### PR DESCRIPTION
## Summary

Extends the in-place-aliasing pass added for the activation memory planner (`onnxsim/memory_planning.h`/`.cpp`) with a second, independent eligibility category: **binary in-place aliasing / operand donation**.

The existing pass already unions a safe *unary* op's input with its output (`IsInPlaceSafeOp`: `Relu`, `Sigmoid`, `Tanh`, `Clip`, ...). This adds the binary equivalent — real NN memory planners (MXNet, XLA) also let a binary elementwise op compute its output by overwriting one of its *two* operands:

- New allowlist `IsInPlaceSafeBinaryOp`: `Add`, `Sub`, `Mul`, `Div`, `Max`, `Min`, `And`, `Or`, `Xor`, `Mod`.
- For each such node, both operands (`input[0]` then `input[1]`) are checked as aliasing candidates, in that fixed order — at most **one** is ever donated; the other is left for the existing liveness pass to place on its own.
- Reuses the exact same eligibility bar the unary pass uses for its candidate: not a weight/graph input/graph output, consumed exactly once across the whole graph, and byte size matching the output's exactly. This is factored out into a shared `is_alias_eligible` lambda so the two passes can't drift apart.
- Matching the output's byte size is what rejects a **broadcast** operand: ONNX broadcasts a smaller operand up to the output's shape, so a genuinely broadcast operand's byte size never equals the output's, and it's correctly never aliased no matter how eligible it otherwise looks.
- Donations union into the *same* `UnionFind` as the unary pass, so a value can be donated through a chain mixing unary and binary in-place-safe ops (e.g. `Relu -> Add -> Sigmoid`).
- Purely additive: `IsInPlaceSafeOp`'s existing unary allowlist is untouched, and the unary aliasing loop's behavior is unchanged (only refactored to share the eligibility check).

## Verification

**Standalone C++ core** (`memory_planning_test.cpp`, ONNX-free):
```
cd onnxsim && g++ -std=c++20 -I. memory_planning.cpp model_metrics.cpp sym_expr.cpp memory_planning_test.cpp -o /tmp/t && /tmp/t
```
All tests pass, including 4 new ones with hand-derived byte offsets:
- `TestBinaryInPlaceAliasingDonatesOperand` — donating one operand shrinks the arena vs. the naive baseline.
- `TestBinaryInPlaceAliasingOtherOperandStillTracked` — the non-donated operand is still tracked correctly and not incorrectly merged.
- `TestBinaryInPlaceAliasingSkipsBroadcastOperand` — a broadcast operand is never aliased (also exercises the input[0]-fails → input[1]-succeeds fallback).
- `TestBinaryInPlaceAliasingBlockedByMultipleConsumers` — a multi-consumer operand (including the same tensor used as *both* operands of one node, e.g. `Add(a, a)`) is correctly never aliased.

**Full wheel build + Python suite**:
```
git submodule update --init --recursive
CMAKE_GENERATOR=Ninja pip3 install -e . --no-build-isolation
python3 -m pytest tests/test_memory_planning.py -v   # 17 passed (4 new)
python3 -m pytest tests/ -q --continue-on-collection-errors -k "not torch"   # 373 passed
```
No new failures beyond the pre-existing, unrelated baseline in this environment: 3 `test_fusion_patterns.py` tests, 6 `test_ppq_compat.py` tests (missing `ppq`), 1 `test_gatherelements_to_gather.py` test (unrelated ONNX-reference-evaluator version mismatch), and 8 collection errors from missing `torch`.

**Lint**: `ruff format --check`, `ruff check`, and `mypy` all clean; `clang-format --style=file:onnxsim/.clang-format --dry-run --Werror` clean on the touched C++ files.

**Docs**: `docs/activation-memory-planning.md`'s "In-place aliasing" section (and the header comment in `memory_planning.h`) updated to describe the binary-operand-donation category.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UFQG9xTf4YexUPryTjccoH

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFQG9xTf4YexUPryTjccoH)_