### PR TITLE
Add GEAR: low-rank + sparse KV-cache quantization residual compensation

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -46,6 +46,7 @@ from onnxsim.embedding_quantization import (
 from onnxsim.finetune import apply_pruning_finetune
 from onnxsim.flexround import apply_flexround
 from onnxsim.fptq import apply_fptq
+from onnxsim.gear import apply_gear
 from onnxsim.gguf_reconstruct import (
     UnsupportedArchitectureError,
     reconstruct_gguf_graph,
@@ -295,6 +296,7 @@ __all__ = [
     "apply_double_quantization",
     "apply_double_quantization_cpp",
     "quantize_kv_cache",
+    "apply_gear",
     "quantize_embedding_binary",
     "quantize_embedding_int8",
     "quantize_weight_only_matmul_nbits",

--- a/onnxsim/gear.py
+++ b/onnxsim/gear.py
@@ -1,0 +1,444 @@
+"""GEAR (Kang et al., 2024, "GEAR: An Efficient KV Cache Compression Recipe
+for Near-Lossless Generative Inference of LLM",
+https://arxiv.org/abs/2403.05527). onnxsim ports the algorithm, not any
+framework's code, per the same rationale as
+:mod:`onnxsim.kv_cache_quantization`/:mod:`onnxsim.rotatekv` (GEAR's own
+reference implementation quantizes live PyTorch KV-cache tensors inside a
+custom generation loop, with no ONNX export path).
+
+Distinguishing this module from its two nearest siblings, both already in
+this repo:
+
+- :mod:`onnxsim.kv_cache_quantization` (KIVI/KVQuant) quantizes a matched
+  ``Concat(past, new, axis=seq)`` KV-cache stream to INT8 -- per-channel for
+  Key, per-token for Value -- and stops there. Whatever reconstruction error
+  that quantization leaves behind is simply accepted; nothing in that module
+  measures or corrects it.
+- :mod:`onnxsim.low_rank_compensation` (LoRC, from ZeroQuant-V2) *does*
+  correct a quantizer's leftover reconstruction error, via the exact same
+  Eckart-Young truncated-SVD argument this module reuses below -- but only
+  for a **weight** matrix's error, which is a static, offline-known
+  quantity (``float_weight - dequantized_weight``, computed once with no
+  calibration data at all), and only with a **low-rank** term -- no sparse
+  component.
+
+GEAR's own distinguishing contribution, applied here to the KV cache (an
+*activation*, per :mod:`onnxsim.kv_cache_quantization`'s own docstring on
+why that already makes every KV-cache technique in this repo fundamentally
+different from a weight quantizer) rather than to a weight matrix: decompose
+the KV-cache quantizer's *own* reconstruction error into (1) a **low-rank**
+component -- the same truncated-SVD, Eckart-Young-optimal idea
+:mod:`onnxsim.low_rank_compensation` already uses, capturing the
+*coherent*, structured part of the error that is shared across many
+tokens/channels -- plus (2) a **sparse** component -- the error's own
+top-magnitude, *individually* large entries, which a low-rank approximation
+alone represents poorly (the same "outliers a shared correction can't
+reach" problem :mod:`onnxsim.spqr` already solves for weights, just fit
+here per-channel rather than per-element -- see below).
+
+**Why this has to be calibration-fit and static, not a genuine per-step
+SVD.** GEAR's own reference algorithm recomputes this whole decomposition
+fresh, from the *actual* current residual, at every decode step, over the
+*entire* growing cache -- an expensive, data-dependent recomputation the
+paper's own eager PyTorch loop can afford but a single static ONNX graph
+rewrite cannot express (there is no ONNX op for "run SVD on this runtime
+tensor"). Root cause, and the same one :mod:`onnxsim.kv_cache_quantization`
+already documents for why a past token's stored reconstruction is never
+revised: once a token is quantized into the INT8 cache, its original float
+value is gone -- for an *already-cached* ("past") token, there is no live
+tensor left in the graph to compute an exact residual from, so no runtime
+op could recompute GEAR's decomposition for it even in principle. This
+module therefore fits the low-rank subspace (a fixed ``[head_dim,
+head_dim]`` projector ``P``, rank ``r``) and the outlier-channel selection
+(a fixed ``[head_dim]`` 0/1 mask) **once, from calibration data** -- the
+same calibration-driven approach :mod:`onnxsim.kv_cache_quantization`
+already uses for its own static per-channel scale -- and applies that fixed
+operator, at every step, only to the **freshly produced ("new") token(s)**
+own *true* residual, which -- unlike a past token's -- genuinely is still a
+live tensor in the graph at the moment it is quantized, no calibration
+needed for *that* part. A past token's already-written reconstruction is
+never revisited or improved after the fact, exactly like
+:mod:`onnxsim.kv_cache_quantization`/:mod:`onnxsim.rotatekv`'s own past-cache
+notes. This is a documented, reasonable simplification given onnxsim's own
+static-graph-rewrite constraints, the same kind of honest scope note
+:mod:`onnxsim.billm`'s own docstring uses for its own simplification
+relative to its source paper.
+
+A second simplification, also documented: the paper applies its own
+quantizer (uniform or a custom "residual-friendly" scheme) to Key and Value
+alike, with no KIVI-style asymmetric per-channel-vs-per-token treatment.
+This module follows that: every matched
+:mod:`onnxsim.kv_cache_quantization` ``Concat(past, new, axis=seq)`` stream
+(Key- and Value-shaped alike, found via that module's own
+:func:`onnxsim.kv_cache_quantization._find_kv_cache_candidates` matcher,
+reused rather than reimplemented) gets the same static, per-channel INT8
+base quantization plus this module's own low-rank+sparse residual
+correction -- there is no separate Value-style code path here.
+
+**Fitting, from calibration data (see** :func:`generate_random_calibration_data`
+**/** :func:`load_huggingface_calibration_data` **):**
+
+1. Run calibration data through the float model, probing each matched
+   stream's ``new`` activation (this step's own freshly computed K/V, before
+   quantization) -- the same probe technique
+   :mod:`onnxsim.kv_cache_quantization`/:mod:`onnxsim.rotatekv` already use.
+2. Compute the same per-channel absmax/127 scale
+   :mod:`onnxsim.kv_cache_quantization`'s Key-style path uses, and, from it,
+   each calibration token's exact quantization residual
+   ``y = x - dequantize(quantize(x))`` (using numpy's round-half-to-even,
+   matching ``QuantizeLinear``'s own rounding mode exactly).
+3. **Low-rank:** the truncated SVD of the calibration residual matrix ``y``
+   (``[num_calibration_tokens, head_dim]``) -- the exact same Eckart-Young
+   argument :mod:`onnxsim.low_rank_compensation` already uses, here applied
+   to a KV-cache activation's calibration-measured residual instead of a
+   weight's exact one. Keeping the top ``rank`` right-singular vectors
+   ``V_r`` (``[head_dim, rank]``) gives the calibration data's own
+   dominant, shared error directions; ``P = V_r @ V_r.T`` is the orthogonal
+   projector onto that subspace, baked into the graph as one ``MatMul``
+   weight.
+4. **Sparse:** what the low-rank projection above still leaves behind on
+   that same calibration data (``y - y @ P``), averaged per channel. The
+   ``outlier_fraction`` channels with the largest leftover magnitude --
+   i.e. the ones the shared low-rank subspace represents worst -- become a
+   fixed 0/1 per-channel mask, baked into the graph as one elementwise
+   ``Mul``. Unlike :mod:`onnxsim.spqr` (whose outliers are individual,
+   scattered ``(row, col)`` weight positions, needing ``ScatterND`` plus
+   explicit index/value pairs to store efficiently), an outlier here is a
+   whole **channel** -- and a KV-cache stream's ``head_dim`` is always
+   small (a single attention head's own dimension, typically well under a
+   few hundred) -- so a plain dense ``[head_dim]`` mask is already as
+   compact as any sparse encoding would be, with far less graph machinery.
+
+Graph rewrite, per matched stream (see
+:mod:`onnxsim.kv_cache_quantization` for the exact ``Concat(past, new,
+axis=seq)`` match):
+
+    Before:
+      past: graph input, float32 [..., seq_past, head_dim]
+      new:  float32 [..., seq_new, head_dim]        -- this step's own K/V
+      present = Concat(past, new, axis=seq)          -- graph output, and
+                consumed by the attention math
+
+    After:
+      past: graph input, INT8 [..., seq_past, head_dim]     -- dtype changed
+      scale: initializer, float32 [head_dim]                   -- per-channel
+      zero_point: initializer, INT8 [head_dim], all zero       -- symmetric
+      p: initializer, float32 [head_dim, head_dim]      -- fitted rank-r
+         projector (present only when rank > 0)
+      sparse_mask: initializer, float32 [head_dim], 0/1  -- fitted outlier
+         mask (present only when outlier_fraction selects at least one
+         channel)
+      new_q = QuantizeLinear(new, scale, zero_point, axis=-1)
+      present = Concat(past, new_q, axis=seq)         -- INT8 graph output,
+                unchanged from onnxsim.kv_cache_quantization's own rewrite
+      past_dequant = DequantizeLinear(past, scale, zero_point, axis=-1)
+      new_dequant = DequantizeLinear(new_q, scale, zero_point, axis=-1)
+      new_residual = new - new_dequant                -- this step's *true*
+                     residual, exact (still has the live float `new` tensor)
+      low_rank_term = new_residual @ p                 -- coherent part
+      remainder = new_residual - low_rank_term
+      sparse_term = remainder * sparse_mask             -- outlier-channel part
+      new_corrected = new_dequant + low_rank_term + sparse_term
+      present_corrected = Concat(past_dequant, new_corrected, axis=seq)
+      <every other consumer of the old float present now reads
+       present_corrected instead>
+
+``past_dequant`` never gets ``low_rank_term``/``sparse_term`` added -- it is
+plain per-channel dequantization, identical to
+:mod:`onnxsim.kv_cache_quantization`'s own baseline, because (as above)
+there is no live float value left to compute a past token's true residual
+from. Only ``new_corrected`` -- this step's own freshly produced token(s) --
+ever receives the low-rank/sparse compensation, and whatever reconstruction
+a token gets when it is "new" is what it keeps forever afterward, the same
+"past is never revised" property :mod:`onnxsim.kv_cache_quantization`/
+:mod:`onnxsim.rotatekv` already document for their own calibrated rewrites.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Set, Union
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+
+from onnxsim import backend
+from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.calibration import Tensors, generate_random_calibration_data
+from onnxsim.kv_cache_quantization import _find_kv_cache_candidates, _KvCacheCandidate
+
+
+def _has_min_opset(model: onnx.ModelProto, min_version: int) -> bool:
+    return any(
+        o.domain in ("", "ai.onnx") and o.version >= min_version
+        for o in model.opset_import
+    )
+
+
+@dataclass
+class _GearFit:
+    scale: np.ndarray  # float32 [head_dim]
+    projector: Optional[np.ndarray]  # float32 [head_dim, head_dim] or None
+    sparse_mask: Optional[np.ndarray]  # float32 [head_dim] or None
+
+
+def _fit_gear(
+    candidates: Sequence[_KvCacheCandidate],
+    model: onnx.ModelProto,
+    calibration_data: Sequence[Tensors],
+    providers: Optional[Sequence[str]],
+    rank: int,
+    outlier_fraction: float,
+) -> Dict[str, _GearFit]:
+    probe_names = sorted({c.new_name for c in candidates})
+    probe = _add_probe_outputs(model, probe_names)
+
+    samples: Dict[str, List[np.ndarray]] = {name: [] for name in probe_names}
+    for batch in calibration_data:
+        outputs = backend.run_model(probe, batch, providers=providers)
+        for name in probe_names:
+            arr = np.asarray(outputs[name], dtype=np.float64)
+            if arr.ndim == 0:
+                continue
+            samples[name].append(arr.reshape(-1, arr.shape[-1]))
+
+    fits: Dict[str, _GearFit] = {}
+    for name, batches in samples.items():
+        if not batches:
+            continue
+        x = np.concatenate(batches, axis=0)  # [N, head_dim]
+        head_dim = x.shape[1]
+
+        channel_absmax = np.abs(x).max(axis=0)
+        scale = (np.maximum(channel_absmax, 1e-12) / 127.0).astype(np.float32)
+
+        codes = np.clip(np.round(x / scale), -128, 127)
+        dequant = codes * scale
+        residual = x - dequant  # [N, head_dim], exact simulated QDQ residual
+
+        r = max(0, min(rank, head_dim, x.shape[0]))
+        projector = None
+        remainder = residual
+        if r > 0:
+            _u, _s, vt = np.linalg.svd(residual, full_matrices=False)
+            v_r = vt[:r].T  # [head_dim, r]
+            projector = (v_r @ v_r.T).astype(np.float32)
+            remainder = residual - residual @ projector
+
+        sparse_mask = None
+        num_outliers = int(round(outlier_fraction * head_dim))
+        if num_outliers > 0:
+            channel_score = np.abs(remainder).mean(axis=0)
+            outlier_channels = np.argsort(channel_score)[-num_outliers:]
+            mask = np.zeros(head_dim, dtype=np.float32)
+            mask[outlier_channels] = 1.0
+            sparse_mask = mask
+
+        fits[name] = _GearFit(scale=scale, projector=projector, sparse_mask=sparse_mask)
+
+    return fits
+
+
+def _rewire_consumers(
+    graph: onnx.GraphProto, c: _KvCacheCandidate, replacement_name: str
+) -> None:
+    # See onnxsim.kv_cache_quantization._rewire_consumers for why this must
+    # run before any new node referencing c.present_name is inserted.
+    for node in graph.node:
+        if node is c.concat_node:
+            continue
+        for i, inp in enumerate(node.input):
+            if inp == c.present_name:
+                node.input[i] = replacement_name
+
+
+def _apply_gear(
+    graph: onnx.GraphProto,
+    c: _KvCacheCandidate,
+    fit: _GearFit,
+    taken_names: Set[str],
+    input_by_name: Dict[str, onnx.ValueInfoProto],
+    output_by_name: Dict[str, onnx.ValueInfoProto],
+) -> None:
+    prefix = f"{c.present_name}_gear"
+    num_channels = fit.scale.shape[0]
+
+    scale_name = _unique_name(f"{prefix}_scale", taken_names)
+    graph.initializer.append(onnx.numpy_helper.from_array(fit.scale, name=scale_name))
+    zp_name = _unique_name(f"{prefix}_zero_point", taken_names)
+    zp = np.zeros(num_channels, dtype=np.int8)
+    graph.initializer.append(onnx.numpy_helper.from_array(zp, name=zp_name))
+
+    # past: FLOAT -> INT8 (same shape) -- unchanged from
+    # onnxsim.kv_cache_quantization's own Key-style rewrite.
+    past_input = input_by_name[c.past_name]
+    past_input.type.tensor_type.elem_type = onnx.TensorProto.INT8
+
+    new_nodes: List[onnx.NodeProto] = []
+
+    def _new(op_type: str, inputs: List[str], out_suffix: str, **attrs) -> str:
+        out_name = _unique_name(f"{prefix}_{out_suffix}", taken_names)
+        node = onnx.helper.make_node(
+            op_type,
+            inputs,
+            [out_name],
+            name=_unique_name(f"{prefix}_{out_suffix}_node", taken_names),
+            **attrs,
+        )
+        new_nodes.append(node)
+        return out_name
+
+    new_q_name = _new(
+        "QuantizeLinear",
+        [c.new_name, scale_name, zp_name],
+        "new_q",
+        axis=c.channel_axis,
+    )
+    quantize_node = new_nodes.pop()
+
+    if c.new_is_first_input:
+        c.concat_node.input[0] = new_q_name
+    else:
+        c.concat_node.input[1] = new_q_name
+    present_output = output_by_name[c.present_name]
+    present_output.type.tensor_type.elem_type = onnx.TensorProto.INT8
+
+    past_dequant_name = _new(
+        "DequantizeLinear",
+        [c.past_name, scale_name, zp_name],
+        "past_dequant",
+        axis=c.channel_axis,
+    )
+    new_dequant_name = _new(
+        "DequantizeLinear",
+        [new_q_name, scale_name, zp_name],
+        "new_dequant",
+        axis=c.channel_axis,
+    )
+    residual_name = _new("Sub", [c.new_name, new_dequant_name], "new_residual")
+
+    correction_terms = []
+    remainder_name = residual_name
+    if fit.projector is not None:
+        p_name = _unique_name(f"{prefix}_p", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(fit.projector, name=p_name)
+        )
+        low_rank_name = _new("MatMul", [residual_name, p_name], "low_rank")
+        correction_terms.append(low_rank_name)
+        if fit.sparse_mask is not None:
+            remainder_name = _new("Sub", [residual_name, low_rank_name], "remainder")
+
+    if fit.sparse_mask is not None:
+        mask_name = _unique_name(f"{prefix}_sparse_mask", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(fit.sparse_mask, name=mask_name)
+        )
+        sparse_name = _new("Mul", [remainder_name, mask_name], "sparse")
+        correction_terms.append(sparse_name)
+
+    new_corrected_name = new_dequant_name
+    for term_name in correction_terms:
+        new_corrected_name = _new("Add", [new_corrected_name, term_name], "corrected")
+
+    if c.new_is_first_input:
+        concat_inputs = [new_corrected_name, past_dequant_name]
+    else:
+        concat_inputs = [past_dequant_name, new_corrected_name]
+    present_corrected_name = _new(
+        "Concat", concat_inputs, "present_corrected", axis=c.seq_axis
+    )
+
+    _rewire_consumers(graph, c, present_corrected_name)
+
+    concat_idx = next(i for i, n in enumerate(graph.node) if n is c.concat_node)
+    graph.node.insert(concat_idx, quantize_node)
+    for offset, node in enumerate(new_nodes):
+        graph.node.insert(concat_idx + 2 + offset, node)
+
+
+def apply_gear(
+    model: Union[str, onnx.ModelProto],
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_samples: int = 8,
+    seed: int = 0,
+    providers: Optional[Sequence[str]] = None,
+    rank: int = 4,
+    outlier_fraction: float = 0.05,
+) -> onnx.ModelProto:
+    """Applies GEAR-style low-rank-plus-sparse residual compensation (see
+    this module's own docstring) on top of static per-channel INT8
+    quantization, to every ``Concat(past, new, axis=seq)`` KV-cache stream
+    :mod:`onnxsim.kv_cache_quantization` can find (Key- and Value-shaped
+    streams alike -- see the module docstring for why there is no
+    asymmetric treatment here).
+
+    :param model: the original (unquantized) onnx ModelProto or file path
+    :param calibration_data: representative input batches (each a
+            ``{input_name: np.ndarray}`` dict matching ``model``'s graph
+            inputs) used to fit each matched stream's own per-channel scale,
+            low-rank projector, and outlier-channel mask -- see
+            :func:`onnxsim.generate_random_calibration_data` (the default
+            when omitted) and :func:`onnxsim.load_huggingface_calibration_data`
+            (real data, a more representative fit than random input)
+    :param num_samples: random batches to generate when ``calibration_data``
+            is omitted
+    :param seed: seed for the random calibration data (ignored if
+            ``calibration_data`` is supplied)
+    :param providers: onnxruntime execution providers to calibrate on
+    :param rank: the low-rank correction's rank (clamped to
+            ``min(rank, head_dim, num_calibration_tokens)`` per stream);
+            ``0`` disables the low-rank term entirely (sparse-only)
+    :param outlier_fraction: fraction of each stream's channels (by count,
+            rounded to the nearest whole channel) kept as an explicit sparse
+            correction after the low-rank term is subtracted; ``0.0``
+            disables the sparse term entirely (low-rank-only)
+    :returns: ``model`` with every matched stream's ``past_*`` graph input
+            and ``present_*`` graph output changed to INT8 (identical to
+            :func:`onnxsim.quantize_kv_cache`'s own Key-style rewrite), and
+            every other consumer of the old float ``present_*`` rewired to
+            a low-rank-plus-sparse-corrected reconstruction -- see the
+            module docstring's diagram; a stream whose calibration
+            activation never appeared in any batch is left untouched, as is
+            the whole model when no stream matches at all, or when
+            ``model``'s opset is older than 13 (``QuantizeLinear``/
+            ``DequantizeLinear``'s per-channel ``axis`` needs opset 13)
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+
+    if not _has_min_opset(model, 13):
+        return model
+
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    graph = out.graph
+
+    candidates = _find_kv_cache_candidates(graph)
+    if not candidates:
+        return out
+
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            model, num_samples=num_samples, seed=seed
+        )
+
+    fits = _fit_gear(
+        candidates, model, calibration_data, providers, rank, outlier_fraction
+    )
+    if not fits:
+        return out
+
+    taken_names: Set[str] = _all_names(graph)
+    input_by_name = {i.name: i for i in graph.input}
+    output_by_name = {o.name: o for o in graph.output}
+
+    for c in candidates:
+        fit = fits.get(c.new_name)
+        if fit is None:
+            continue
+        _apply_gear(graph, c, fit, taken_names, input_by_name, output_by_name)
+
+    return out

--- a/tests/test_gear.py
+++ b/tests/test_gear.py
@@ -1,0 +1,230 @@
+"""Tests for ``onnxsim.apply_gear`` -- see ``onnxsim/gear.py`` for the
+technique (GEAR-style low-rank-plus-sparse residual compensation layered on
+top of ``onnxsim.kv_cache_quantization``'s own static, per-channel INT8
+quantization of a decoder's ``Concat(past, new, axis=seq)`` KV-cache
+stream).
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(body, opset=13, ir_version=8):
+    return parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+
+
+def _kv_cache_model(batch=1, heads=2, head_dim=8, opset=13, symbolic_seq=True):
+    # new_key is routed through an Identity node rather than being a bare
+    # graph input, matching tests/test_kv_cache_quantization.py's own
+    # rationale: a real exported decoder's "new" K/V is always a freshly
+    # computed activation, never a raw model input, and the matcher can't
+    # otherwise tell "the persistent cache" apart from "this step's fresh
+    # token" when both Concat operands are plain graph inputs with a single
+    # consumer.
+    seq_past = "seq_past" if symbolic_seq else 3
+    seq_present = "seq_present" if symbolic_seq else 4
+    return _model(
+        f"""
+        g (float[{batch},{heads},{seq_past},{head_dim}] past_key,
+           float[{batch},{heads},1,{head_dim}] new_key_raw)
+          => (float[{batch},{heads},{seq_present},{head_dim}] present_key,
+              float summary)
+        {{
+          new_key = Identity(new_key_raw)
+          present_key = Concat<axis = 2>(past_key, new_key)
+          summary = ReduceSum<keepdims = 0>(present_key)
+        }}
+        """,
+        opset=opset,
+    )
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
+
+
+def test_gear_changes_input_and_output_to_int8():
+    model = _kv_cache_model()
+    q = onnxsim.apply_gear(model, num_samples=4, seed=0)
+    onnx.checker.check_model(q)
+
+    past_vi = next(i for i in q.graph.input if i.name == "past_key")
+    present_vi = next(o for o in q.graph.output if o.name == "present_key")
+    assert past_vi.type.tensor_type.elem_type == onnx.TensorProto.INT8
+    assert present_vi.type.tensor_type.elem_type == onnx.TensorProto.INT8
+    # new_key_raw/the Identity's "new_key" output are untouched float --
+    # only Concat's own operand is rewired to a freshly quantized tensor.
+    new_vi = next(i for i in q.graph.input if i.name == "new_key_raw")
+    assert new_vi.type.tensor_type.elem_type == onnx.TensorProto.FLOAT
+
+
+def test_gear_inserts_low_rank_and_sparse_correction_nodes():
+    model = _kv_cache_model()
+    q = onnxsim.apply_gear(model, num_samples=4, seed=0, rank=2, outlier_fraction=0.25)
+    op_types = [n.op_type for n in q.graph.node]
+    assert op_types.count("QuantizeLinear") == 1
+    assert op_types.count("DequantizeLinear") == 2  # past + new
+    assert "MatMul" in op_types  # low-rank projector
+    assert "Mul" in op_types  # sparse mask
+    assert op_types.count("Concat") == 2  # codes stream + corrected-float stream
+    assert op_types.count("Add") == 2  # dequant + low_rank, then + sparse
+
+    # ReduceSum (the "attention math" stand-in) must consume the corrected
+    # float reconstruction, not the raw int8 Concat output.
+    reduce_node = next(n for n in q.graph.node if n.op_type == "ReduceSum")
+    corrected_concat = [n for n in q.graph.node if n.op_type == "Concat"][-1]
+    assert reduce_node.input[0] == corrected_concat.output[0]
+
+
+def test_gear_rank_zero_skips_low_rank_term():
+    model = _kv_cache_model()
+    q = onnxsim.apply_gear(model, num_samples=4, seed=0, rank=0, outlier_fraction=0.25)
+    op_types = [n.op_type for n in q.graph.node]
+    assert "MatMul" not in op_types
+    assert "Mul" in op_types
+    assert op_types.count("Add") == 1  # only the sparse term is added
+
+
+def test_gear_outlier_fraction_zero_skips_sparse_term():
+    model = _kv_cache_model()
+    q = onnxsim.apply_gear(model, num_samples=4, seed=0, rank=2, outlier_fraction=0.0)
+    op_types = [n.op_type for n in q.graph.node]
+    assert "MatMul" in op_types
+    assert "Mul" not in op_types
+    assert op_types.count("Add") == 1  # only the low-rank term is added
+
+
+def test_gear_noop_without_kv_cache_pattern():
+    model = _model(
+        """
+        g (float[4,4] x) => (float[4,4] y)
+        {
+          y = Relu(x)
+        }
+        """
+    )
+    result = onnxsim.apply_gear(model)
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_gear_noop_below_opset13():
+    model = _kv_cache_model(opset=12)
+    result = onnxsim.apply_gear(model)
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_gear_declines_when_past_has_other_consumers():
+    model = _model(
+        """
+        g (float[1,2,3,8] past_key, float[1,2,1,8] new_key_raw)
+          => (float[1,2,4,8] present_key, float summary, float past_summary)
+        {
+          new_key = Identity(new_key_raw)
+          present_key = Concat<axis = 2>(past_key, new_key)
+          summary = ReduceSum<keepdims = 0>(present_key)
+          past_summary = ReduceSum<keepdims = 0>(past_key)
+        }
+        """
+    )
+    q = onnxsim.apply_gear(model)
+    assert q.SerializeToString() == model.SerializeToString()
+
+
+def test_gear_new_token_reconstruction_matches_numpy_reference():
+    # Verify the graph's own low-rank+sparse correction against a from-
+    # scratch numpy re-derivation of the same calibration fit, computed
+    # directly from the ONNX initializers this module wrote -- per this
+    # project's own numerics convention, a tight *relative* tolerance
+    # against numpy rather than a loose absolute tolerance against an
+    # onnxruntime round-trip (onnxruntime's own MatMul reduction order is
+    # not bit-exact across CPU architectures).
+    batch, heads, head_dim = 1, 2, 8
+    model = _kv_cache_model(batch=batch, heads=heads, head_dim=head_dim)
+    q = onnxsim.apply_gear(model, num_samples=32, seed=1, rank=2, outlier_fraction=0.25)
+    onnx.checker.check_model(q)
+
+    init = {t.name: onnx.numpy_helper.to_array(t) for t in q.graph.initializer}
+    scale = init["present_key_gear_scale"].astype(np.float64)
+    zero_point = init["present_key_gear_zero_point"].astype(np.float64)
+    projector = init["present_key_gear_p"].astype(np.float64)
+    mask = init["present_key_gear_sparse_mask"].astype(np.float64)
+
+    rng = np.random.default_rng(7)
+    empty_past = np.zeros((batch, heads, 0, head_dim), dtype=np.int8)
+    new0 = rng.standard_normal((batch, heads, 1, head_dim)).astype(np.float32)
+
+    corrected_concat = [n for n in q.graph.node if n.op_type == "Concat"][-1]
+    q_probe = onnx.ModelProto()
+    q_probe.CopyFrom(q)
+    q_probe.graph.output.append(onnx.ValueInfoProto(name=corrected_concat.output[0]))
+
+    _present0, _summary0, present0_corrected = _run(
+        q_probe, {"past_key": empty_past, "new_key_raw": new0}
+    )
+
+    new0_f64 = new0.astype(np.float64)
+    codes = np.clip(np.round(new0_f64 / scale), -128, 127)
+    new_dequant = (codes - zero_point) * scale
+    residual = new0_f64 - new_dequant
+    low_rank = residual @ projector
+    remainder = residual - low_rank
+    sparse = remainder * mask
+    expected = new_dequant + low_rank + sparse
+
+    rel_err = np.linalg.norm(present0_corrected - expected) / np.linalg.norm(expected)
+    assert rel_err < 1e-5
+
+
+def test_gear_two_step_round_trip_close_to_float():
+    batch, heads, head_dim = 1, 2, 8
+    model = _kv_cache_model(batch=batch, heads=heads, head_dim=head_dim)
+    q = onnxsim.apply_gear(model, num_samples=64, seed=2, rank=2, outlier_fraction=0.25)
+    corrected_concat = [n for n in q.graph.node if n.op_type == "Concat"][-1]
+    q_probe = onnx.ModelProto()
+    q_probe.CopyFrom(q)
+    q_probe.graph.output.append(onnx.ValueInfoProto(name=corrected_concat.output[0]))
+
+    rng = np.random.default_rng(4)
+    empty_past = np.zeros((batch, heads, 0, head_dim), dtype=np.float32)
+    new0 = rng.standard_normal((batch, heads, 1, head_dim)).astype(np.float32)
+    new1 = rng.standard_normal((batch, heads, 1, head_dim)).astype(np.float32)
+
+    float_present0, _ = _run(model, {"past_key": empty_past, "new_key_raw": new0})
+    float_present1, _ = _run(model, {"past_key": float_present0, "new_key_raw": new1})
+
+    empty_past_q = np.zeros((batch, heads, 0, head_dim), dtype=np.int8)
+    q_present0, _ = _run(q, {"past_key": empty_past_q, "new_key_raw": new0})
+    assert q_present0.dtype == np.int8
+    q_present1, _, q_present1_corrected = _run(
+        q_probe, {"past_key": q_present0, "new_key_raw": new1}
+    )
+    assert q_present1.dtype == np.int8
+
+    # A generous bound, not a tight one -- matches this project's own
+    # convention for a small random-calibration-set end-to-end check (see
+    # tests/test_kv_cache_quantization.py's own 0.2 bound).
+    assert _rel_l2(float_present1, q_present1_corrected) < 0.2


### PR DESCRIPTION
## Summary

Adds GEAR (Kang et al., 2024, "GEAR: An Efficient KV Cache Compression Recipe for Near-Lossless Generative Inference of LLM", https://arxiv.org/abs/2403.05527) as a new `onnxsim.apply_gear` technique: low-rank-plus-sparse compensation of a KV-cache quantizer's own reconstruction error, layered on top of the same static per-channel INT8 quantization `onnxsim.kv_cache_quantization` already uses.

## What's added / scope

- `onnxsim/gear.py`: `apply_gear(model, calibration_data=None, num_samples=8, seed=0, providers=None, rank=4, outlier_fraction=0.05)`.
  - Reuses `onnxsim.kv_cache_quantization._find_kv_cache_candidates` (no reimplementation of the `Concat(past, new, axis=seq)` matcher) and applies the same static, per-channel INT8 base quantization to **every** matched stream, Key- and Value-shaped alike (GEAR's own paper does not distinguish K vs. V the way KIVI does).
  - **Low-rank component**: truncated SVD of the calibration-measured quantization residual — the same Eckart-Young argument `onnxsim/low_rank_compensation.py` already uses for weights, applied here to a KV-cache *activation*'s residual instead. Produces a fixed `[head_dim, head_dim]` rank-`r` orthogonal projector baked in as one `MatMul`.
  - **Sparse component**: the per-channel leftover residual magnitude after the low-rank projection, from that same calibration data; the top `outlier_fraction` channels get a fixed 0/1 mask baked in as one `Mul`. (A dense per-channel mask, not `spqr.py`'s `ScatterND`/indices+values machinery — outliers here are whole channels, and `head_dim` is always small, so a dense mask is already as compact as any sparse encoding.)
  - Both `P` and the sparse mask are fit **once from calibration** and applied **identically every step**, and only ever correct the freshly produced ("new") token(s) — the module's docstring documents explicitly why this is the necessary, honest simplification relative to the paper's own per-step, whole-cache SVD: once a token is quantized into the INT8 cache, its original float value is gone, so no runtime op could recompute an exact residual for an already-cached ("past") token even in principle. A past token's stored reconstruction is therefore never revised, mirroring `kv_cache_quantization.py`/`rotatekv.py`'s own documented "past is never revised" property.
  - The module's docstring explicitly distinguishes it from its two nearest siblings: `kv_cache_quantization.py` (quantizes and stops — no residual compensation at all) and `low_rank_compensation.py` (low-rank-only, for a static weight's exact residual, no sparse term).
  - Registered in `onnxsim/__init__.py` (import + `__all__`).
- `tests/test_gear.py`: built with `onnx.parser.parse_model()` per this repo's convention, mirroring `tests/test_kv_cache_quantization.py`'s `_model`/`_kv_cache_model` helpers. Covers: INT8 dtype changes, node-shape assertions (low-rank `MatMul` / sparse `Mul` / `Add` counts) including `rank=0` and `outlier_fraction=0.0` degenerate cases, opset/no-pattern no-ops, the "past has other consumers" decline case, an exact numpy-vs-ONNX-initializer reconstruction check (tight relative tolerance, per this project's platform-numerics convention), and a two-step round-trip accuracy check against onnxruntime (loose relative tolerance).

## Test plan

- `pytest tests/test_gear.py -v` → **9 passed**
- `pytest tests/test_kv_cache_quantization.py tests/test_low_rank_compensation.py -q` → **17 passed** (no regression in the sibling modules)
- `ruff check onnxsim/gear.py tests/test_gear.py onnxsim/__init__.py` → all checks passed
- `ruff format --check onnxsim/gear.py tests/test_gear.py onnxsim/__init__.py` → all formatted
- `mypy onnxsim` → 27 pre-existing errors in 8 files, unchanged from before this change (0 from `gear.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnDV5QHjZAhoiwM8hRaBDq

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnDV5QHjZAhoiwM8hRaBDq)_