### PR TITLE
Document a Conv/MatMul op-format comparison plus external hardware corroboration

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -287,6 +287,130 @@ instruction stream from that dataflow graph -- real quantization, tiling,
 scheduling, and codegen into an undocumented ISA -- still requires
 Pulsar2's own (obfuscated) compiler backend.
 
+### What's op-specific vs. boilerplate, across real Conv/MatMul variants
+
+The single-model dig above raises an obvious question: how much of that
+FlatBuffers offset table and instruction stream is generic wrapper vs.
+op-specific? Answered by compiling 9 small, hand-built ONNX graphs (plain
+`MatMul`, `Gemm` with bias, dense `Conv` 3x3, 1x1 pointwise, depthwise
+(`group=C`), grouped (`group=2`), stride-2, dilation-2, and a batched
+(rank-3) `MatMul`) through the same real `pulsar2 build --compiler.npu_perf`
+and inspecting each result the same way:
+
+- **The FlatBuffers field-name table is identical across every one of the
+  9 models**: always exactly `params`, `<input>_offset`, `<output>_offset`,
+  `_ocm_base`, and the graph name -- regardless of kernel size, stride,
+  dilation, groups, or op family. **No op parameter ever shows up as a
+  named field.** Conv's stride/padding/dilation/group and Gemm's alpha/
+  beta/transpose flags are entirely opaque, baked into the unlabeled
+  instruction bytes -- this table is pure I/O bookkeeping, not a
+  semantically rich IR.
+- **`ddr_swap` is a real, conditional field**, not a fixed part of the
+  schema: present in the earlier 28-layer LLM build (something spilled to
+  DRAM), absent from all 9 of these small models (everything fit in OCM).
+- **Exactly two compute "primitive families" appear**, cleanly split by op
+  family: every `Conv` variant -- dense, 1x1, depthwise, grouped, strided,
+  dilated, no exceptions -- lowers to `Pre_AxTranspose` -> `AxQuantizedConv`
+  (x6 tiles) -> `Post_AxTranspose` (almost certainly a NCHW<->NHWC layout
+  swap around a channel-last-native conv engine); `MatMul` lowers to
+  `onnx.FullyConnected` instead. Op parameters change *within* those
+  primitives (invisibly) but never *which* primitive gets picked.
+- Trace event **naming isn't fully consistent**: `matmul2d`'s compute
+  events are labeled `op_1:onnx.FullyConnected_<tile>_<tile>` (primitive
+  name visible), but `gemm_bias`'s and the batched `matmul_batched3d`'s are
+  labeled directly after their own output tensor (`y_0_0`, `y_1_2`, ...) --
+  the same underlying compute, differently named depending on some
+  internal fusion/naming decision, not a reliable way to detect op type
+  from the trace alone.
+- **Cycle cost and weight-blob size don't scale the way FLOP count would
+  predict, at this tiny (16x16, 4-8 channel) test size.** 1x1 pointwise
+  conv costs nearly as many cycles as full dense 3x3 (2052 vs. 2096) --
+  fixed per-tile overhead dominates raw MAC count here. Most strikingly,
+  **dilated conv's stored weight blob is 2.6x larger than a plain conv with
+  the identical (8,4,3,3) kernel shape** (3.66KB vs. ~1.4KB) despite having
+  the same number of logical weight values -- strong evidence the compiler
+  materializes a real, zero-expanded ("atrous") kernel footprint for
+  dilation rather than an actually-sparse dilated MAC pattern, and it's
+  also the most expensive op tested by cycle count (2228).
+- Every model tiles into a small, similar instruction count regardless of
+  large parameter differences at this scale: all 6 `Conv` variants compile
+  to exactly 6 `AxQuantizedConv` sub-tiles each; `matmul2d` to 6
+  `FullyConnected` sub-tiles; the batched matmul to 7. Tiling granularity
+  here looks governed by fixed hardware tile-size constants more than by
+  the specific op's shape/parameters -- this may well change at larger,
+  more realistic tensor sizes where tiling actually has to split work up.
+
+### External corroboration: a real hardware teardown
+
+An independent third-party writeup --
+[jas-hacks.blogspot.com's AX650N/Sipeed M4N teardown](https://jas-hacks.blogspot.com/2024/09/ax650n-sipeed-maix-iv-axerapi-pro-npu.html)
+(not Axera's own documentation; treat specific numbers as one outside
+source's reporting, and any interpretive claims -- explicitly flagged
+below -- as that author's own inference, not confirmed fact) -- gives real
+names and numbers for the hardware this repo's own trace.json digging
+above only inferred generically:
+
+- The NPU ("Neutron") is described as 13 execution units + 3 SDMA units:
+  3 Convolution Units (handling depthwise/grouped conv, dilation, and
+  ConvTranspose), 3 Computer Vision Units (image normalize/resize/clip/
+  warp), 3 Tensor Units (activation, pooling, elementwise, reduction), and
+  a single Matrix Arithmetic Unit (int8/int16 in, fp16/fp32 out). This
+  lines up with this repo's own trace.json engine names in outline --
+  `conv0`/`conv1` for the Convolution Units, `sdma4` for an SDMA unit --
+  but not exactly: our own LLM trace's `cv3` engine ran RMSNorm/RoPE
+  elementwise math, which reads as "Tensor Unit" work by this source's own
+  description, not "Computer Vision Unit" work, and we never observed a
+  distinct engine for the single Matrix Arithmetic Unit despite compiling
+  real `MatMul`/`Gemm` graphs above (both engine-name schemes may not be
+  directly comparable, or the compiler may route elementwise math onto
+  whichever engine family has spare capacity rather than a fixed
+  CV-vs-tensor split). Reported, not reconciled -- a real open question
+  for anyone digging further.
+- **On-chip memory (OCM): reported as 11.5MB, address space ending at
+  `0xAFFFFF`.** `0xAFFFFF + 1 = 0xB00000 = 11,534,336` bytes = exactly
+  11MiB by that address range -- close to but not exactly the "11.5MB"
+  figure quoted; direct, checkable confirmation that `ocm_base`'s byte
+  offsets seen in this repo's own trace.json digging above (all under
+  ~3.2MB in our tiny test models) sit well inside a real, multi-megabyte
+  on-chip SRAM, not some other memory space.
+- 8GB total SoC RAM, split 4GB Linux / 4GB "CMM" (Contiguous Memory Model)
+  for peripherals -- CMM is almost certainly what this repo's own findings
+  call `params`/DRAM-resident weight storage and `ddr_swap` staging.
+- Claimed performance: 72 TOPS mixed precision (18.0 TOPS@INT8, 43.2
+  TOPS@INT4 and 10.8 TOPS@INT8 "from NPU alone" per Axera's own SDK docs,
+  per that source). **The author's own interpretation** (not a measured
+  fact): a single Matrix Arithmetic Unit instance may bottleneck LLM
+  inference, since every `MatMul`/`Gemm` in a transformer routes through
+  it. That's a plausible complementary explanation for *why* LLM inference
+  is slow on this hardware, alongside (not instead of) the very different,
+  independently-confirmed bottleneck this repo's own `demo_hf_llm_chat.py`
+  measured: `axcl_run_model`'s ~700ms-per-invocation process/model-reload
+  overhead, which has nothing to do with the NPU's own compute engines at
+  all and would dominate regardless of how many Matrix Arithmetic Units
+  existed.
+- Real production reference point (**not comparable to
+  `demo_hf_llm_chat.py`'s own measured tokens/sec** -- different
+  measurement entirely: real `ax-llm` + KV-cache decode via Pulsar2's own
+  `llm_build()` path, not this repo's re-run-the-whole-model-per-token
+  `build_from_hf_checkpoint()` path, and no per-call CLI-reload overhead
+  since it's a persistent server): Phi-3 Mini reported at ~4.4 tokens/sec
+  on the AX650N, vs. ~6.46 tokens/sec on an RK3588 for comparison.
+- Confirms real ONNX-level `.axmodel` structure from an outside source
+  independently: "axmodel files contain a mix of ONNX data and an internal
+  graph representation" sent to the NPU kernel driver -- matching this
+  repo's own finding of an ordinary ONNX container wrapping an opaque,
+  FlatBuffers-framed internal representation.
+- **Confirmed, and more specific than reported**: `gemm_bias` above used
+  default `alpha=1.0, beta=1.0` and compiled fine; a `Gemm` with
+  non-default values (`alpha=2.0, beta=0.5`) **fails outright**, not
+  merely "restricted" -- a real `pulsar2 build` on that graph throws
+  `KeyError: 'dont support AxQuantizedGemm opr in AXOPS/ONNXOPS/
+  CUSTOM_OPS'` before quantization even runs. Default-alpha/beta `Gemm`
+  apparently lowers to the same path as a plain `MatMul` + bias-add (hence
+  `gemm_bias` succeeding above); any other `alpha`/`beta` maps to a
+  distinct, entirely unimplemented `AxQuantizedGemm` op. Confirms the
+  blog's suspicion with a precise, reproducible mechanism.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`


### PR DESCRIPTION
## Summary

Follow-up to #1082 (already merged). Documentation-only, no code changes.

Compiled 9 real, hand-built ONNX graphs (`MatMul`, `Gemm`+bias, dense/1x1/depthwise/grouped/strided/dilated `Conv`, batched `MatMul`) through the real `pulsar2 build --compiler.npu_perf`, comparing each compiled `.axmodel`'s FlatBuffers offset table and trace.json against the earlier single-LLM dig from #1082:

- The offset-table field names (`params`/`<in>_offset`/`<out>_offset`/`_ocm_base`) are identical across all 9 models regardless of op type or parameters -- no conv stride/padding/dilation/group or gemm alpha/beta ever appears as a named field, confirming they're opaque, unlabeled instruction operands.
- `ddr_swap` is confirmed conditional: present in the earlier 28-layer LLM build, absent from all 9 small models here (nothing needed DRAM staging).
- Exactly two compute primitive families: every `Conv` variant (dense, 1x1, depthwise, grouped, strided, dilated) lowers to `Pre_AxTranspose` -> `AxQuantizedConv` -> `Post_AxTranspose`; `MatMul` lowers to `onnx.FullyConnected` instead. Op parameters never change which primitive gets picked.
- Dilated conv's stored weight blob is 2.6x larger than an identically-shaped non-dilated kernel (3.66KB vs ~1.4KB) -- evidence the compiler materializes a real zero-expanded kernel footprint for dilation, not a sparse dilated MAC pattern.
- Confirmed, more precisely than suspected: `Gemm` with non-default `alpha`/`beta` fails outright (`KeyError: 'dont support AxQuantizedGemm opr'`), not merely restricted -- default-alpha/beta `Gemm` lowers through the same path as `MatMul`+bias-add instead.

Also cross-references an independent third-party AX650N teardown ([jas-hacks.blogspot.com](https://jas-hacks.blogspot.com/2024/09/ax650n-sipeed-maix-iv-axerapi-pro-npu.html)), which supplies real hardware numbers this repo's own trace.json digging could only infer generically: a heterogeneous 13-EU+3-SDMA "Neutron" NPU (3 Conv units, 3 CV units, 3 Tensor units, 1 Matrix Arithmetic Unit), an 11.5MB OCM ending at `0xAFFFFF` (independently computed here as exactly 11MiB by that address range), 8GB SoC RAM split Linux/CMM, and a real production Phi-3 Mini ~4.4 tok/s reference point -- explicitly flagged as not comparable to this repo's own tok/s measurement (different decode strategy and no per-call CLI-reload overhead).

## Test plan
- [x] All 9 test models compiled successfully against the real `pulsar2:6.0-lite` image.
- [x] Gemm alpha/beta failure independently reproduced and confirmed with the exact error text quoted.
- [x] `python -m pytest tests/test_pulsar2_hf_to_axmodel.py tests/test_pulsar2_compat.py tests/test_pulsar2_simulator.py -q` -- 19 passed, no regressions (documentation-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UC8vhJgE71RLFF4DgdSP9P