### PR TITLE
Close FP16/BFLOAT16 + producer-matching scope gaps for embedding-vocab and MoE/QMoE C++ pruning ports

### DIFF
--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -1650,8 +1650,8 @@ def apply_sparsegpt_pruning_cpp(
     QKV weight. Deliberately narrower than the pure-Python
     :func:`onnxsim.apply_sparsegpt_pruning` in two ways, both mirroring this
     module's own established narrower-than-pruning.py C++-port scope
-    decisions elsewhere (e.g. :func:`onnxsim.apply_moe_expert_channel_pruning_cpp`'s
-    own FLOAT32-only restriction):
+    decisions elsewhere (e.g. the ``MatMulNBits`` C++ section's own
+    FLOAT32-only restriction on its own scales/zero_points/bias tensors):
 
     - FLOAT32 only, not also FLOAT16/BFLOAT16.
     - 2-D ``Conv`` (ordinary/depthwise/general-grouped) is **not** matched
@@ -1776,8 +1776,8 @@ def apply_wanda_pruning_cpp(
     the pure-Python :func:`onnxsim.apply_wanda_pruning` in the same two ways
     that function's own C++-port sibling already establishes (mirroring
     this module's own established narrower-than-pruning.py C++-port scope
-    decisions elsewhere, e.g. :func:`onnxsim.apply_moe_expert_channel_pruning_cpp`'s
-    own FLOAT32-only restriction):
+    decisions elsewhere, e.g. the ``MatMulNBits`` C++ section's own
+    FLOAT32-only restriction on its own scales/zero_points/bias tensors):
 
     - FLOAT32 only, not also FLOAT16/BFLOAT16.
     - 2-D ``Conv`` (ordinary/depthwise/general-grouped) is **not** matched
@@ -1898,15 +1898,17 @@ def apply_moe_expert_channel_pruning_cpp(
     untouched -- the same conservative "decline rather than mis-slice" bar
     every other chain-matcher in this codebase holds.
 
-    Unlike the pure-Python :func:`onnxsim.apply_moe_expert_channel_pruning`,
-    ``fc1_experts_weights``/``fc2_experts_weights``/``fc1_experts_bias`` are
-    admitted only as plain FLOAT (float32) tensors here, not also FLOAT16/
-    BFLOAT16 -- matching this codebase's own established narrower-than-
-    pruning.py C++-port scope decision elsewhere (e.g.
-    :func:`onnxsim.apply_structured_pruning_cpp`'s own ``MatMulNBits``
-    ``scales``/``zero_points``/``bias`` restriction). Whole-expert pruning
-    (shrinking ``num_experts`` itself, calibration-driven) is a deliberately
-    separate entry point, :func:`onnxsim.apply_moe_whole_expert_pruning_cpp`.
+    ``fc1_experts_weights``/``fc2_experts_weights``/``fc1_experts_bias`` may
+    be FLOAT, FLOAT16, or BFLOAT16 -- full parity with the pure-Python
+    :func:`onnxsim.apply_moe_expert_channel_pruning` (itself now a thin
+    alias for this function; see IsSupportedFloatDtype/ReadTensorAsF64/
+    WriteF64TensorAs in ``onnxsim/structured_pruning_entry.cpp``'s own "MoE
+    expert-intermediate-channel pruning" section for the read-upcast/
+    write-downcast mechanics -- a surviving weight's own value is only ever
+    reordered/dropped, never recomputed, so this round-trips every
+    FLOAT16/BFLOAT16 bit pattern exactly). Whole-expert pruning (shrinking
+    ``num_experts`` itself, calibration-driven) is a deliberately separate
+    entry point, :func:`onnxsim.apply_moe_whole_expert_pruning_cpp`.
 
     This is a single, self-contained graph rewrite: unlike :func:`simplify`,
     it does not run shape inference, constant folding, or any other pass.
@@ -1968,12 +1970,13 @@ def apply_qmoe_expert_channel_pruning_cpp(
     zero_points too), identically across every expert. ``num_experts``, `k`,
     and every node attribute are untouched.
 
-    Unlike :func:`onnxsim.apply_qmoe_expert_channel_pruning`, this port only
-    admits FLOAT32 (not FLOAT16/BFLOAT16) ``fc1``/``fc2`` scales and bias,
-    matching this codebase's C++-port scope decision for
-    :func:`onnxsim.apply_structured_pruning_matmul_nbits` above. The
-    complementary whole-expert-removal pass is a separate entry point,
-    :func:`onnxsim.apply_qmoe_whole_expert_pruning_cpp`.
+    ``fc1``/``fc2`` scales and bias may be FLOAT, FLOAT16, or BFLOAT16 --
+    full parity with the pure-Python :func:`onnxsim.apply_qmoe_expert_
+    channel_pruning` (itself now a thin alias for this function; the packed
+    ``uint8`` `fc1`/`fc2` weights themselves, and `zero_points`, are
+    unaffected either way -- always UINT8 regardless of the *activation*/
+    scale dtype). The complementary whole-expert-removal pass is a separate
+    entry point, :func:`onnxsim.apply_qmoe_whole_expert_pruning_cpp`.
 
     This is a single, self-contained graph rewrite: unlike :func:`simplify`,
     it does not run shape inference, constant folding, or any other pass.
@@ -2350,9 +2353,9 @@ def apply_embedding_vocab_pruning_cpp(
     ``GemmFastGelu`` -- and only ever admits a plain FLOAT (float32)
     embedding table/``lm_head`` weight/bias, not also FLOAT16/BFLOAT16,
     matching this codebase's own established narrower-than-pruning.py
-    C++-port scope decision elsewhere (e.g.
-    :func:`onnxsim.apply_moe_expert_channel_pruning_cpp`'s own FLOAT32-only
-    restriction). See ``onnxsim/structured_pruning_entry.cpp``'s own
+    C++-port scope decision elsewhere (e.g. the ``MatMulNBits`` C++
+    section's own FLOAT32-only restriction on its own scales/zero_points/
+    bias tensors). See ``onnxsim/structured_pruning_entry.cpp``'s own
     "Embedding vocabulary pruning" section comment for the exact matched
     topology.
 

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -2343,18 +2343,16 @@ def apply_embedding_vocab_pruning_cpp(
     full return-value contract.
 
     Unlike :func:`onnxsim.apply_embedding_vocab_pruning`, this C++ port
-    only ever matches a plain ``Gather`` producer -- not
-    ``com.microsoft::EmbedLayerNormalization`` or ``com.microsoft::
-    GatherBlockQuantized`` -- only ever auto-detects a bare ``MatMul``/
-    vanilla ``Gemm`` ``lm_head`` -- not ``com.microsoft::FusedGemm``/
-    ``GemmFastGelu`` -- and only ever admits a plain FLOAT (float32)
-    embedding table/``lm_head`` weight/bias, not also FLOAT16/BFLOAT16,
-    matching this codebase's own established narrower-than-pruning.py
-    C++-port scope decision elsewhere (e.g.
-    :func:`onnxsim.apply_moe_expert_channel_pruning_cpp`'s own FLOAT32-only
-    restriction). See ``onnxsim/structured_pruning_entry.cpp``'s own
-    "Embedding vocabulary pruning" section comment for the exact matched
-    topology.
+    still only ever matches a plain ``Gather`` or ``com.microsoft::
+    EmbedLayerNormalization`` producer -- not ``com.microsoft::
+    GatherBlockQuantized`` (the block-quantized embedding shape -- out of
+    scope for this port; see ``onnxsim/structured_pruning_entry.cpp``'s own
+    "Embedding vocabulary pruning" section comment for exactly why). Its
+    ``lm_head`` auto-detection recognizes ``MatMul``/vanilla ``Gemm``/
+    ``com.microsoft::FusedGemm``/``GemmFastGelu``, and the embedding
+    table/``lm_head`` weight/bias may be FLOAT, FLOAT16, OR BFLOAT16 -- both
+    match the pure-Python original's own scope now. See that same section
+    comment for the exact matched topology.
 
     This is a single, self-contained graph rewrite: unlike :func:`simplify`,
     it does not run shape inference, constant folding, or any other pass.
@@ -2418,9 +2416,9 @@ def apply_embedding_vocab_magnitude_pruning_cpp(
     :class:`onnxsim.pruning.EmbeddingPruningResult`'s.
 
     Same C++-port scope restrictions as
-    :func:`onnxsim.apply_embedding_vocab_pruning_cpp` (plain ``Gather``
-    producer only, plain ``MatMul``/``Gemm`` ``lm_head`` only, FLOAT32-only
-    tensors) -- see that function's own docstring.
+    :func:`onnxsim.apply_embedding_vocab_pruning_cpp` (``GatherBlockQuantized``
+    still out of scope; every other producer/``lm_head``-node-type/dtype
+    shape matched) -- see that function's own docstring.
 
     This is a single, self-contained graph rewrite: unlike :func:`simplify`,
     it does not run shape inference, constant folding, or any other pass.

--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -24490,21 +24490,22 @@ def apply_moe_expert_channel_pruning(
     :func:`_apply_moe_chains`, so an `MoE` node's own tensors are never
     confused with a same-named-by-coincidence node in a sibling or
     ancestor graph.
+
+    This pure-Python implementation has been retired in favor of the
+    verified-full-parity C++ port -- this is now a thin alias for
+    :func:`onnxsim.apply_moe_expert_channel_pruning_cpp`
+    (``onnxsim/structured_pruning_entry.cpp``'s own
+    ``ApplyMoeExpertChannelPruning``, including its own FLOAT16/BFLOAT16
+    weight support, matching this function's own above), forwarding every
+    argument unchanged. Imported lazily (inside the function body, not at
+    module scope) to avoid a circular import: ``onnxsim.onnx_simplifier``
+    already imports from this module (:class:`EmbeddingPruningResult`), so
+    importing it back at module load time here would deadlock the import
+    machinery.
     """
-    if not (0.0 <= sparsity < 1.0):
-        raise ValueError(f"sparsity must be in [0, 1), got {sparsity}")
-    if isinstance(model, str):
-        model = onnx.load(model, load_external_data=False)
+    from onnxsim.onnx_simplifier import apply_moe_expert_channel_pruning_cpp
 
-    out = onnx.ModelProto()
-    out.CopyFrom(model)
-
-    for graph in _iter_subgraphs(out.graph):
-        chains = _find_moe_chains(graph)
-        if chains:
-            _apply_moe_chains(graph, chains, sparsity, _moe_importance)
-
-    return out
+    return apply_moe_expert_channel_pruning_cpp(model, sparsity=sparsity)
 
 
 # --- MoE whole-expert pruning ------------------------------------------------
@@ -24967,50 +24968,30 @@ def apply_moe_whole_expert_pruning(
     `calibration_data`) -- so a nested-subgraph `MoE` node is still
     correctly pruned, just by weight norm rather than measured router
     usage, never silently skipped.
+
+    This pure-Python implementation has been retired in favor of the
+    verified-full-parity C++ port -- this is now a thin alias for
+    :func:`onnxsim.apply_moe_whole_expert_pruning_cpp`
+    (``onnxsim/structured_pruning_entry.cpp``'s own
+    ``ApplyMoeWholeExpertPruning``, including its own FLOAT16/BFLOAT16
+    `fc1`/`fc2`/bias AND router-projection weight/bias support, plus a
+    dtype-agnostic router-gate calibration capture matching this
+    function's own above), forwarding every argument unchanged. Imported
+    lazily (inside the function body, not at module scope) to avoid a
+    circular import: ``onnxsim.onnx_simplifier`` already imports from this
+    module (:class:`EmbeddingPruningResult`), so importing it back at
+    module load time here would deadlock the import machinery.
     """
-    if not (0.0 <= sparsity < 1.0):
-        raise ValueError(f"sparsity must be in [0, 1), got {sparsity}")
-    if isinstance(model, str):
-        model = onnx.load(model, load_external_data=False)
-    if calibration_data is None:
-        calibration_data = generate_random_calibration_data(
-            model, num_samples=num_samples, seed=seed
-        )
+    from onnxsim.onnx_simplifier import apply_moe_whole_expert_pruning_cpp
 
-    out = onnx.ModelProto()
-    out.CopyFrom(model)
-
-    top_chains = _find_moe_whole_expert_chains(out.graph)
-    mean_gate_weight = (
-        _moe_router_gate_calibration_stats(out, top_chains, calibration_data, providers)
-        if top_chains
-        else {}
+    return apply_moe_whole_expert_pruning_cpp(
+        model,
+        calibration_data=calibration_data,
+        num_samples=num_samples,
+        seed=seed,
+        sparsity=sparsity,
+        providers=providers,
     )
-
-    def _importance(
-        chain: _MoEExpertChain, initializer_map: Dict[str, onnx.TensorProto]
-    ) -> np.ndarray:
-        gate = mean_gate_weight.get(chain.router_probs)
-        if gate is None or gate.shape[0] != chain.num_experts:
-            return _moe_expert_weight_importance(chain, initializer_map)
-        return gate
-
-    for graph in _iter_subgraphs(out.graph):
-        chains = (
-            top_chains if graph is out.graph else _find_moe_whole_expert_chains(graph)
-        )
-        if not chains:
-            continue
-
-        stale_value_info = _apply_moe_whole_expert_chains(
-            graph, chains, sparsity, _importance
-        )
-        if stale_value_info:
-            kept = [vi for vi in graph.value_info if vi.name not in stale_value_info]
-            del graph.value_info[:]
-            graph.value_info.extend(kept)
-
-    return out
 
 
 # --- QMoE (quantized-weight MoE) pruning -------------------------------------
@@ -26365,23 +26346,23 @@ def apply_qmoe_expert_channel_pruning(
     were its own top-level graph -- each graph gets its own
     :func:`_find_qmoe_chains` call and its own touched-role state inside
     :func:`_apply_qmoe_channel_chains`.
+
+    This pure-Python implementation has been retired in favor of the
+    verified-full-parity C++ port -- this is now a thin alias for
+    :func:`onnxsim.apply_qmoe_expert_channel_pruning_cpp`
+    (``onnxsim/structured_pruning_entry.cpp``'s own
+    ``ApplyQMoEExpertChannelPruning``, including its own FLOAT16/BFLOAT16
+    `fc1`/`fc2_scales`/bias support, matching this function's own
+    :func:`_is_supported_float_dtype` above), forwarding every argument
+    unchanged. Imported lazily (inside the function body, not at module
+    scope) to avoid a circular import: ``onnxsim.onnx_simplifier`` already
+    imports from this module (:class:`EmbeddingPruningResult`), so
+    importing it back at module load time here would deadlock the import
+    machinery.
     """
-    if not (0.0 <= sparsity < 1.0):
-        raise ValueError(f"sparsity must be in [0, 1), got {sparsity}")
-    if isinstance(model, str):
-        model = onnx.load(model, load_external_data=False)
+    from onnxsim.onnx_simplifier import apply_qmoe_expert_channel_pruning_cpp
 
-    out = onnx.ModelProto()
-    out.CopyFrom(model)
-
-    for graph in _iter_subgraphs(out.graph):
-        chains = _find_qmoe_chains(graph)
-        if chains:
-            _apply_qmoe_channel_chains(
-                graph, chains, sparsity, _qmoe_channel_importance
-            )
-
-    return out
+    return apply_qmoe_expert_channel_pruning_cpp(model, sparsity=sparsity)
 
 
 @dataclass(frozen=True)
@@ -26687,50 +26668,31 @@ def apply_qmoe_whole_expert_pruning(
     always falls back to :func:`_qmoe_expert_weight_importance` instead,
     so it is still correctly pruned, just by weight norm rather than
     measured router usage.
+
+    This pure-Python implementation has been retired in favor of the
+    verified-full-parity C++ port -- this is now a thin alias for
+    :func:`onnxsim.apply_qmoe_whole_expert_pruning_cpp`
+    (``onnxsim/structured_pruning_entry.cpp``'s own
+    ``ApplyQMoEWholeExpertPruning``, including its own FLOAT16/BFLOAT16
+    `fc1`/`fc2_scales`/bias AND router-projection weight/bias support, plus
+    a dtype-agnostic router-gate calibration capture matching
+    :func:`apply_moe_whole_expert_pruning`'s own identical retirement),
+    forwarding every argument unchanged. Imported lazily (inside the
+    function body, not at module scope) to avoid a circular import:
+    ``onnxsim.onnx_simplifier`` already imports from this module
+    (:class:`EmbeddingPruningResult`), so importing it back at module load
+    time here would deadlock the import machinery.
     """
-    if not (0.0 <= sparsity < 1.0):
-        raise ValueError(f"sparsity must be in [0, 1), got {sparsity}")
-    if isinstance(model, str):
-        model = onnx.load(model, load_external_data=False)
-    if calibration_data is None:
-        calibration_data = generate_random_calibration_data(
-            model, num_samples=num_samples, seed=seed
-        )
+    from onnxsim.onnx_simplifier import apply_qmoe_whole_expert_pruning_cpp
 
-    out = onnx.ModelProto()
-    out.CopyFrom(model)
-
-    top_chains = _find_qmoe_whole_expert_chains(out.graph)
-    mean_gate_weight = (
-        _moe_router_gate_calibration_stats(out, top_chains, calibration_data, providers)
-        if top_chains
-        else {}
+    return apply_qmoe_whole_expert_pruning_cpp(
+        model,
+        calibration_data=calibration_data,
+        num_samples=num_samples,
+        seed=seed,
+        sparsity=sparsity,
+        providers=providers,
     )
-
-    def _importance(
-        chain: _QMoEExpertChain, initializer_map: Dict[str, onnx.TensorProto]
-    ) -> np.ndarray:
-        gate = mean_gate_weight.get(chain.router_probs)
-        if gate is None or gate.shape[0] != chain.num_experts:
-            return _qmoe_expert_weight_importance(chain, initializer_map)
-        return gate
-
-    for graph in _iter_subgraphs(out.graph):
-        chains = (
-            top_chains if graph is out.graph else _find_qmoe_whole_expert_chains(graph)
-        )
-        if not chains:
-            continue
-
-        stale_value_info = _apply_qmoe_whole_expert_chains(
-            graph, chains, sparsity, _importance
-        )
-        if stale_value_info:
-            kept = [vi for vi in graph.value_info if vi.name not in stale_value_info]
-            del graph.value_info[:]
-            graph.value_info.extend(kept)
-
-    return out
 
 
 # --- MatMulBlockQuantizedFp4Weight/MatMulBlockQuantizedFp8Weight

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -17242,17 +17242,14 @@ struct EmbeddingChain {
 
 // True for FLOAT, FLOAT16, and BFLOAT16 -- every element dtype this
 // section's own matchers accept for a weight/bias initializer. Mirrors
-// pruning.py's own `_is_supported_float_dtype` exactly. Local to this
-// section: every OTHER matcher in this file that still checks
+// pruning.py's own `_is_supported_float_dtype` exactly. Reuses the
+// identical helper the MoE/QMoE section above already defines for the same
+// purpose (see that section's own comment) rather than redeclaring it here
+// -- every OTHER matcher in this file that still checks
 // `== onnx::TensorProto::FLOAT` directly is intentionally left alone (see
 // this file's own "narrower than pruning.py" scope-decision comments
 // elsewhere) -- widening those is a separate, unrelated decision this round
 // does not make.
-bool IsSupportedFloatDtype(int32_t data_type) {
-  return data_type == onnx::TensorProto::FLOAT ||
-         data_type == onnx::TensorProto::FLOAT16 ||
-         data_type == onnx::TensorProto::BFLOAT16;
-}
 
 // --- FLOAT16/BFLOAT16 <-> float32 bit conversion, and the
 // ReadFloatTensorAnyDtype/SetFloatTensorDataPreservingDtype pair built on

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -16765,33 +16765,51 @@ std::vector<onnx::GraphProto*> IterSubgraphs(onnx::GraphProto* graph) {
 // its index in `kept_token_ids`) before running the pruned model -- a
 // dropped id can never be fed to the pruned model again.
 //
-// Deliberately NARROWER than pruning.py's own three-producer-shape port
-// (plain `Gather`, `com.microsoft::EmbedLayerNormalization`,
-// `com.microsoft::GatherBlockQuantized`) -- consistent with this file's own
-// established "narrower subset of pruning.py, decline rather than guess
-// past what's ported" scope decisions elsewhere (MatMulNBits's own
-// FLOAT32-only scales/zero_points/bias, MoE/QMoE's own restrictions, ...):
+// Two of pruning.py's own three producer shapes are matched here -- plain
+// `Gather` (MatchEmbeddingGatherRaw) and `com.microsoft::
+// EmbedLayerNormalization` (MatchEmbedLayerNormProducer, added alongside it
+// -- see that function's own doc comment for the schema/scope this mirrors
+// from pruning.py's `_match_embed_layer_norm_producer`). `lm_head`
+// auto-detection also now recognizes `com.microsoft::FusedGemm`/
+// `GemmFastGelu` in addition to a bare `MatMul`/vanilla `Gemm`
+// (MatchMatMulLikeWidenedRaw, this section's own local mirror of
+// pruning.py's module-scoped `_match_matmul_like` override -- kept local to
+// this section, not merged into the shared MatchMatMulLikeRaw, for the
+// identical reason pruning.py's own override is kept local to
+// `onnxsim.pruning` rather than made to the shared `smoothquant.py` copy:
+// widening the shared matcher would silently change every OTHER pass in
+// this file that calls it too). The embedding table, `lm_head` weight, and
+// `lm_head` bias are now all admitted as FLOAT, FLOAT16, OR BFLOAT16
+// (IsSupportedFloatDtype, ReadFloatTensorAnyDtype/
+// SetFloatTensorDataPreservingDtype -- this section's own local upcast-to-
+// float32/downcast-to-original-dtype helpers, mirroring pruning.py's own
+// `_to_f64`/`_from_f64` convention; this file's shared ReadFloatTensor/
+// SetFloatTensorData stay FLOAT32-only and untouched, used elsewhere in
+// this file exactly as before).
 //
-//   * Only the plain `Gather(data, indices, axis=0)` producer shape is
-//     matched here. `EmbedLayerNormalization` (the fused BERT-family
-//     word+position+segment-embedding-plus-LayerNorm node onnxruntime's
-//     own graph optimizer emits) and `GatherBlockQuantized` (the
-//     int2/int4/int8 block-quantized analogue) are both simply never
-//     matched -- declined, not mis-handled -- by this port; see
-//     pruning.py's own section comment for their exact schema/scope if
-//     porting either is ever needed.
-//   * `lm_head` auto-detection only ever recognizes a bare `MatMul` or
-//     vanilla `Gemm` (MatchMatMulLikeRaw) -- not pruning.py's own widened
-//     `_match_matmul_like`, which additionally recognizes
-//     `com.microsoft::FusedGemm`/`GemmFastGelu` -- mirroring
-//     MatchProducer's own identical, already-established restriction
-//     elsewhere in this file (see its own comment, above).
-//   * The embedding table, `lm_head` weight, and `lm_head` bias are all
-//     admitted only as plain FLOAT (float32) tensors -- not also FLOAT16/
-//     BFLOAT16 -- matching ReadFloatTensor/SetFloatTensorData's own
-//     FLOAT32-only support (the same restriction, for the same reason, as
-//     the "Two deliberate, narrower-than-pruning.py scope decisions"
-//     comment above MatMulNBitsValidBlockSizes documents).
+// Deliberately still NARROWER than pruning.py's own three-producer-shape
+// port in exactly one remaining respect:
+//
+//   * `com.microsoft::GatherBlockQuantized` (the int2/int4/int8
+//     block-quantized analogue of a plain-float embedding `Gather`) is
+//     simply never matched -- declined, not mis-handled -- by this port.
+//     Unlike the two gaps closed above, this one is deliberately left
+//     open: pruning.py's own section comment documents two genuinely
+//     different packing conventions (ONNX-native sub-byte `tensor(uint4)`/
+//     `tensor(int4)` vs. manually-packed `tensor(uint8)`, each with its own
+//     default-`zero_points` formula), a `scales`/`zero_points` pair that
+//     must be sliced in lockstep with `data`, and a dequantization-for-
+//     ranking-only helper -- real, verified-correct scope, but large enough
+//     that porting it hastily risks a subtle packing/slicing bug for a
+//     currently-narrow real-exporter surface (see that comment's own "Real
+//     exporter evidence" paragraph). Left as a clearly separate,
+//     independent follow-up rather than attempted here. Because this is a
+//     genuine remaining producer-shape gap (not just a narrower dtype/
+//     lm_head-node-type restriction), `apply_embedding_vocab_pruning`/
+//     `apply_embedding_vocab_magnitude_pruning` in pruning.py are NOT
+//     aliased to these C++ ports -- see this round's own summary for why
+//     "two of three producer shapes" does not clear this module's own
+//     "verified TRUE full parity, or don't alias" bar.
 //
 // Every other structural safety check pruning.py's own `_match_embedding_
 // gather`/`_match_tied_lm_head`/`_match_untied_lm_head`/`_match_lm_head_
@@ -16848,13 +16866,291 @@ struct EmbeddingChain {
   std::optional<EmbeddingLmHeadMatch> lm_head;
 };
 
+// True for FLOAT, FLOAT16, and BFLOAT16 -- every element dtype this
+// section's own matchers accept for a weight/bias initializer. Mirrors
+// pruning.py's own `_is_supported_float_dtype` exactly. Local to this
+// section: every OTHER matcher in this file that still checks
+// `== onnx::TensorProto::FLOAT` directly is intentionally left alone (see
+// this file's own "narrower than pruning.py" scope-decision comments
+// elsewhere) -- widening those is a separate, unrelated decision this round
+// does not make.
+bool IsSupportedFloatDtype(int32_t data_type) {
+  return data_type == onnx::TensorProto::FLOAT ||
+         data_type == onnx::TensorProto::FLOAT16 ||
+         data_type == onnx::TensorProto::BFLOAT16;
+}
+
+// --- FLOAT16/BFLOAT16 <-> float32 bit conversion, and the
+// ReadFloatTensorAnyDtype/SetFloatTensorDataPreservingDtype pair built on
+// top of them -- this section's own local mirror of pruning.py's
+// `_to_f64`/`_from_f64` upcast-on-read/downcast-on-write convention (see
+// that pair's own doc comments in pruning.py's "FP16/BFloat16 weight
+// support" section). float32 stands in for Python's float64 here: it still
+// exactly represents every value either half-precision format can hold, and
+// every arithmetic helper already used by this file (SliceAxis0/SliceAxis1,
+// the L2-norm accumulation in EmbeddingVocabImportance below) already works
+// in float32/double, so no separate wide-precision path is needed. This
+// file's existing ReadFloatTensor/SetFloatTensorData (above) stay FLOAT32
+// -only and completely unchanged -- every other pass in this file that uses
+// them keeps its own established FLOAT32-only scope; these four helpers are
+// used ONLY by this section's own producer/lm_head matching and slicing.
+//
+// Lossless in both directions for the one case this pass ever needs it in:
+// decoding a value already stored as FLOAT16/BFLOAT16 into float32 never
+// rounds (float32 has strictly more precision than either half-precision
+// format), and re-encoding an UNMODIFIED (merely relocated by a row/column
+// slice, never arithmetically recomputed) float32 value back to its
+// original dtype reproduces the exact original bit pattern -- verified
+// directly in this round's own test suite, the same way pruning.py's
+// `_from_f64` docstring documents for its own float64 round trip.
+
+inline float Float16BitsToFloat(uint16_t bits) {
+  const uint32_t sign = static_cast<uint32_t>(bits & 0x8000u) << 16;
+  uint32_t exp = (bits >> 10) & 0x1Fu;
+  uint32_t mant = bits & 0x3FFu;
+  uint32_t out;
+  if (exp == 0) {
+    if (mant == 0) {
+      out = sign;  // +-0
+    } else {
+      // Subnormal float16 -> normalized float32: shift the mantissa left
+      // until its implicit leading bit lands, adjusting the exponent to
+      // match.
+      exp = 127 - 15 + 1;
+      while ((mant & 0x400u) == 0) {
+        mant <<= 1;
+        --exp;
+      }
+      mant &= 0x3FFu;
+      out = sign | (exp << 23) | (mant << 13);
+    }
+  } else if (exp == 0x1Fu) {
+    out = sign | 0x7F800000u | (mant << 13);  // Inf/NaN
+  } else {
+    out = sign | ((exp - 15 + 127) << 23) | (mant << 13);
+  }
+  float f;
+  std::memcpy(&f, &out, sizeof(f));
+  return f;
+}
+
+// Round-to-nearest-even float32 -> float16 bit pattern. An exact
+// float16-representable input (the only case this pass ever re-encodes,
+// see this subsection's own top comment) round-trips byte-for-byte
+// regardless of tie-breaking rule, since such a value never lands exactly
+// halfway between two representable float16 values.
+inline uint16_t FloatToFloat16Bits(float value) {
+  uint32_t bits;
+  std::memcpy(&bits, &value, sizeof(bits));
+  const uint32_t sign = (bits >> 16) & 0x8000u;
+  const uint32_t exp32 = (bits >> 23) & 0xFFu;
+  const uint32_t mant32 = bits & 0x7FFFFFu;
+  if (exp32 == 0xFFu) {
+    // Inf/NaN.
+    return static_cast<uint16_t>(sign | 0x7C00u | (mant32 ? 0x0200u : 0u));
+  }
+  int32_t exp16 = static_cast<int32_t>(exp32) - 127 + 15;
+  if (exp16 >= 0x1F) {
+    return static_cast<uint16_t>(sign | 0x7C00u);  // overflow -> Inf
+  }
+  if (exp16 <= 0) {
+    if (exp16 < -10) {
+      return static_cast<uint16_t>(sign);  // underflows to zero
+    }
+    const uint32_t m = mant32 | 0x800000u;  // add the implicit leading bit
+    const uint32_t shift = static_cast<uint32_t>(14 - exp16);
+    uint32_t half_mant = m >> shift;
+    const uint32_t remainder = m & ((1u << shift) - 1u);
+    const uint32_t halfway = 1u << (shift - 1u);
+    if (remainder > halfway ||
+        (remainder == halfway && (half_mant & 1u) != 0u)) {
+      half_mant += 1u;
+    }
+    return static_cast<uint16_t>(sign | half_mant);
+  }
+  uint32_t rounded = mant32 + 0x00001000u;  // half an ULP at kept precision
+  if (rounded & 0x00800000u) {
+    // Rounded mantissa carried into the implicit leading bit -- bump the
+    // exponent instead.
+    rounded = 0;
+    exp16 += 1;
+    if (exp16 >= 0x1F) {
+      return static_cast<uint16_t>(sign | 0x7C00u);
+    }
+  }
+  return static_cast<uint16_t>(sign | (static_cast<uint32_t>(exp16) << 10) |
+                               (rounded >> 13));
+}
+
+// bfloat16 is literally float32's own top 16 bits (1 sign + 8 exponent +
+// 7 mantissa) -- decode is a plain zero-extending left shift.
+inline float BFloat16BitsToFloat(uint16_t bits) {
+  const uint32_t full = static_cast<uint32_t>(bits) << 16;
+  float f;
+  std::memcpy(&f, &full, sizeof(f));
+  return f;
+}
+
+// Round-to-nearest-even float32 -> bfloat16 bit pattern (the standard
+// "add a rounding bias keyed off the bit being kept, then truncate"
+// algorithm). An exact bfloat16-representable input (this pass's only
+// re-encode case -- see this subsection's own top comment) has zero low 16
+// bits, so the rounding bias it adds can never carry into bit 16, and the
+// truncation reproduces the exact original top half byte-for-byte.
+inline uint16_t FloatToBFloat16Bits(float value) {
+  if (std::isnan(value)) {
+    return 0x7FC0u;  // canonical quiet NaN, upper half
+  }
+  uint32_t bits;
+  std::memcpy(&bits, &value, sizeof(bits));
+  const uint32_t rounding_bias = ((bits >> 16) & 1u) + 0x7FFFu;
+  return static_cast<uint16_t>((bits + rounding_bias) >> 16);
+}
+
+// Reads a FLOAT/FLOAT16/BFLOAT16 tensor as a flat float32 buffer -- see
+// this subsection's own top comment. FLOAT is a straight passthrough
+// through the existing (FLOAT32-only) ReadFloatTensor; FLOAT16/BFLOAT16
+// additionally decode each packed 16-bit code -- 2 raw bytes/element when
+// `raw_data` is set, or, ONNX's own wire convention for sub-32-bit numeric
+// dtypes, zero-extended into `int32_data` when it is absent (confirmed
+// directly against a live `onnx.TensorProto`/`onnx.numpy_helper.to_array`
+// round trip) -- through Float16BitsToFloat/BFloat16BitsToFloat.
+std::vector<float> ReadFloatTensorAnyDtype(const onnx::TensorProto& t) {
+  if (t.data_type() == onnx::TensorProto::FLOAT) {
+    return ReadFloatTensor(t);
+  }
+  int64_t numel = 1;
+  for (int64_t d : t.dims()) {
+    numel *= d;
+  }
+  std::vector<uint16_t> bits(static_cast<size_t>(numel));
+  if (t.has_raw_data()) {
+    std::memcpy(bits.data(), t.raw_data().data(),
+                bits.size() * sizeof(uint16_t));
+    if constexpr (!onnxsim::dlpack::kRawDataIsHostOrder) {
+      onnxsim::dlpack::SwapElementBytes(reinterpret_cast<uint8_t*>(bits.data()),
+                                        bits.size() * sizeof(uint16_t),
+                                        sizeof(uint16_t));
+    }
+  } else {
+    for (int64_t i = 0; i < numel; ++i) {
+      bits[static_cast<size_t>(i)] =
+          static_cast<uint16_t>(t.int32_data(static_cast<int>(i)));
+    }
+  }
+  std::vector<float> out(bits.size());
+  const bool is_bf16 = t.data_type() == onnx::TensorProto::BFLOAT16;
+  for (size_t i = 0; i < bits.size(); ++i) {
+    out[i] =
+        is_bf16 ? BFloat16BitsToFloat(bits[i]) : Float16BitsToFloat(bits[i]);
+  }
+  return out;
+}
+
+// Inverse of ReadFloatTensorAnyDtype: overwrites `t` in place with `data`
+// at `dims`, downcast to `t`'s OWN existing dtype (FLOAT/FLOAT16/BFLOAT16)
+// -- unlike SetFloatTensorData, which always produces a FLOAT tensor, this
+// preserves whatever dtype the embedding table/lm_head weight/bias already
+// had, exactly mirroring pruning.py's own `_from_f64`. Always writes
+// `raw_data` (never `int32_data`), the same "replace, don't mutate a live
+// view" convention SetFloatTensorData already uses.
+void SetFloatTensorDataPreservingDtype(onnx::TensorProto* t,
+                                       const std::vector<int64_t>& dims,
+                                       const std::vector<float>& data) {
+  const int32_t dtype = t->data_type();
+  if (dtype == onnx::TensorProto::FLOAT) {
+    SetFloatTensorData(t, dims, data);
+    return;
+  }
+  const std::string name = t->name();
+  t->Clear();
+  t->set_name(name);
+  t->set_data_type(static_cast<onnx::TensorProto_DataType>(dtype));
+  for (int64_t d : dims) {
+    t->add_dims(d);
+  }
+  const bool is_bf16 = dtype == onnx::TensorProto::BFLOAT16;
+  std::vector<uint16_t> bits(data.size());
+  for (size_t i = 0; i < data.size(); ++i) {
+    bits[i] =
+        is_bf16 ? FloatToBFloat16Bits(data[i]) : FloatToFloat16Bits(data[i]);
+  }
+  std::string raw(bits.size() * sizeof(uint16_t), '\0');
+  std::memcpy(raw.data(), bits.data(), raw.size());
+  if constexpr (!onnxsim::dlpack::kRawDataIsHostOrder) {
+    onnxsim::dlpack::SwapElementBytes(reinterpret_cast<uint8_t*>(raw.data()),
+                                      raw.size(), sizeof(uint16_t));
+  }
+  t->set_raw_data(std::move(raw));
+}
+
+// This section's own local mirror of pruning.py's module-scoped
+// `_match_matmul_like` override (see that function's own docstring): wraps
+// MatchMatMulLikeRaw to also recognize `com.microsoft::FusedGemm` (a plain
+// Gemm plus a trailing activation, ORT's own `GemmActivationFusion` result
+// -- `A`/`B`/`C`/`alpha`/`beta`/`transA`/`transB` are Gemm's own, verbatim)
+// and `com.microsoft::GemmFastGelu` (`GemmFastGelu(X, W, bias?) =
+// FastGelu(X @ W [+ bias])`, no attributes at all, `W` always stored NOT
+// transposed -- ORT's own `FusionGemmFastGelu` result). Kept LOCAL to this
+// section rather than merged into the shared MatchMatMulLikeRaw for the
+// same reason pruning.py's own override stays local to `onnxsim.pruning`
+// rather than widening the shared `smoothquant.py` copy: MatchMatMulLikeRaw
+// is reused by many other, unrelated passes in this file, and widening it
+// there would silently change their own behavior too, never verified here.
+std::optional<MatMulLikeMatch> MatchMatMulLikeWidenedRaw(
+    const onnx::NodeProto& node) {
+  if (node.op_type() == "FusedGemm") {
+    const int num_inputs = node.input_size();
+    if (num_inputs != 2 && num_inputs != 3) {
+      return std::nullopt;
+    }
+    bool has_trans_a = false, has_alpha = false, has_beta = false;
+    int64_t trans_a = 0, trans_b = 0;
+    double alpha = 1.0, beta = 1.0;
+    for (const auto& attr : node.attribute()) {
+      if (attr.name() == "transA") {
+        trans_a = attr.i();
+        has_trans_a = true;
+      } else if (attr.name() == "alpha") {
+        alpha = attr.f();
+        has_alpha = true;
+      } else if (attr.name() == "beta") {
+        beta = attr.f();
+        has_beta = true;
+      } else if (attr.name() == "transB") {
+        trans_b = attr.i();
+      }
+    }
+    if (has_trans_a && trans_a != 0) {
+      return std::nullopt;
+    }
+    if (has_alpha && alpha != 1.0) {
+      return std::nullopt;
+    }
+    if (num_inputs == 3 && has_beta && beta != 1.0) {
+      return std::nullopt;
+    }
+    return MatMulLikeMatch{node.input(0), node.input(1), trans_b != 0};
+  }
+  if (node.op_type() == "GemmFastGelu" &&
+      node.domain() == kComMicrosoftDomain) {
+    const int num_inputs = node.input_size();
+    if (num_inputs != 2 && num_inputs != 3) {
+      return std::nullopt;
+    }
+    return MatMulLikeMatch{node.input(0), node.input(1), false};
+  }
+  return MatchMatMulLikeRaw(node);
+}
+
 // If `node` is a well-formed embedding-table Gather (this section's own
 // comment above has the full matching criteria), returns
 // (weight_name, indices_name, underlying_input_name) -- `indices_name` is
 // `node`'s own literal `indices` operand, `underlying_input_name` is that
 // same tensor with one Cast hop unwrapped when present. Mirrors
-// pruning.py's own `_match_embedding_gather` exactly, minus the
-// `EmbedLayerNormalization`/`GatherBlockQuantized` producer shapes (out of
+// pruning.py's own `_match_embedding_gather` exactly (the
+// `EmbedLayerNormalization` producer shape is matched separately, by
+// MatchEmbedLayerNormProducer just below; `GatherBlockQuantized` is out of
 // scope for this C++ port -- see this section's own top comment). The
 // Python original also double-checks `node in consumers_of[w_name]`; that
 // is always true here by construction (ConsumersOf indexes every node
@@ -16882,7 +17178,7 @@ MatchEmbeddingGatherRaw(
   const std::string& indices_name = node.input(1);
   auto wit = init_map.find(w_name);
   if (wit == init_map.end() ||
-      wit->second->data_type() != onnx::TensorProto::FLOAT ||
+      !IsSupportedFloatDtype(wit->second->data_type()) ||
       wit->second->dims_size() != 2) {
     return std::nullopt;
   }
@@ -16908,20 +17204,84 @@ MatchEmbeddingGatherRaw(
   return std::make_tuple(w_name, indices_name, underlying);
 }
 
-// Resolves `node` (an already-matched MatMul/vanilla-Gemm producing
-// `vocab_size`-wide output) to its own bias, if any, and the node whose
-// *output* is the real, final logits tensor. Mirrors pruning.py's own
-// `_match_lm_head_tail` exactly: returns `std::nullopt` for the
-// `_LM_HEAD_BIAS_INVALID` sentinel case (a bias exists but not in a shape
-// this pass safely handles -- declined, never left silently stale), or a
-// present `(bias_name_or_nullopt, output_node)` pair otherwise.
+// The `com.microsoft::EmbedLayerNormalization` counterpart of
+// MatchEmbeddingGatherRaw -- same return contract exactly
+// ((weight_name, indices_name, underlying_input_name)), so
+// MatchEmbeddingChain's own matching loop can try this as a second producer
+// shape and treat whichever one succeeds identically from there on. Mirrors
+// pruning.py's own `_match_embed_layer_norm_producer` exactly -- see that
+// function's own docstring for the full empirical schema (inputs, in order:
+// `input_ids`, `segment_ids`?, `word_embedding`, `position_embedding`,
+// `segment_embedding`?, `gamma`, `beta`, `mask`?, `position_ids`?; at least
+// 7 required inputs) and the three scope decisions this reproduces exactly:
+// only `word_embedding` (indexed by `input_ids`, this function's own
+// `weight_name`) is ever vocab-axis-prunable -- `position_embedding`
+// (indexed by sequence position) and `segment_embedding` (indexed by
+// `segment_ids`, a different index space) are always left completely
+// untouched by every caller of this match, and neither `gamma`/`beta` (not
+// vocab-shaped) nor the optional `mask_index`/`embedding_sum` outputs
+// (neither's shape or value depends on `vocab_size`) need any special
+// handling here at all.
+std::optional<std::tuple<std::string, std::string, std::string>>
+MatchEmbedLayerNormProducer(
+    const onnx::NodeProto& node, const InitMap& init_map,
+    const ConsumerMap& consumers_of,
+    const std::unordered_set<std::string>& graph_input_names,
+    const std::unordered_map<std::string, onnx::NodeProto*>& node_by_output) {
+  if (node.op_type() != "EmbedLayerNormalization" ||
+      node.domain() != kComMicrosoftDomain) {
+    return std::nullopt;
+  }
+  if (node.input_size() < 7) {
+    return std::nullopt;
+  }
+  const std::string& input_ids = node.input(0);
+  const std::string& w_name = node.input(2);
+  if (input_ids.empty() || w_name.empty()) {
+    return std::nullopt;
+  }
+  auto wit = init_map.find(w_name);
+  if (wit == init_map.end() ||
+      !IsSupportedFloatDtype(wit->second->data_type()) ||
+      wit->second->dims_size() != 2) {
+    return std::nullopt;
+  }
+
+  std::string underlying = input_ids;
+  if (!graph_input_names.count(underlying)) {
+    auto cit = node_by_output.find(underlying);
+    if (cit != node_by_output.end() && cit->second->op_type() == "Cast" &&
+        cit->second->input_size() == 1 &&
+        graph_input_names.count(cit->second->input(0))) {
+      underlying = cit->second->input(0);
+    } else {
+      return std::nullopt;  // not a graph input, nor a Cast of one
+    }
+  }
+
+  auto cons_it = consumers_of.find(w_name);
+  const size_t n_consumers =
+      cons_it == consumers_of.end() ? 0 : cons_it->second.size();
+  if (n_consumers < 1 || n_consumers > 2) {
+    return std::nullopt;  // unexpected consumer count -- decline, don't guess
+  }
+  return std::make_tuple(w_name, input_ids, underlying);
+}
+
+// Resolves `node` (an already-matched MatMul/vanilla-Gemm/FusedGemm/
+// GemmFastGelu producing `vocab_size`-wide output) to its own bias, if any,
+// and the node whose *output* is the real, final logits tensor. Mirrors
+// pruning.py's own `_match_lm_head_tail` exactly: returns `std::nullopt`
+// for the `_LM_HEAD_BIAS_INVALID` sentinel case (a bias exists but not in a
+// shape this pass safely handles -- declined, never left silently stale),
+// or a present `(bias_name_or_nullopt, output_node)` pair otherwise.
 std::optional<std::pair<std::optional<std::string>, onnx::NodeProto*>>
 MatchLmHeadTail(onnx::NodeProto* node, const InitMap& init_map,
                 const ConsumerMap& consumers_of, int64_t vocab_size) {
   auto valid_bias = [&](const std::string& name) {
     auto it = init_map.find(name);
     if (it == init_map.end() ||
-        it->second->data_type() != onnx::TensorProto::FLOAT) {
+        !IsSupportedFloatDtype(it->second->data_type())) {
       return false;
     }
     const auto& dims = it->second->dims();
@@ -16934,8 +17294,18 @@ MatchLmHeadTail(onnx::NodeProto* node, const InitMap& init_map,
     return false;
   };
 
-  if (node->op_type() == "Gemm" && node->input_size() == 3 &&
-      !node->input(2).empty()) {
+  // `Gemm`'s own built-in `C` input carries straight over to `FusedGemm`
+  // (byte-identical `A`/`B`/`C` inputs, ORT's own `GemmActivationFusion`
+  // result) AND to `GemmFastGelu` (`GemmFastGelu(X, W, bias?)`'s own
+  // optional 3rd input, folded in by ORT's `FusionGemmFastGelu` from
+  // exactly the MatMul-then-Add(bias) shape the plain-`MatMul` branch below
+  // still resolves when the bias hasn't been folded into the node itself)
+  // -- mirrors pruning.py's own
+  // `node.op_type in ("Gemm", "FusedGemm", "GemmFastGelu")` membership
+  // check exactly.
+  if ((node->op_type() == "Gemm" || node->op_type() == "FusedGemm" ||
+       node->op_type() == "GemmFastGelu") &&
+      node->input_size() == 3 && !node->input(2).empty()) {
     const std::string bias_name = node->input(2);
     if (!valid_bias(bias_name)) {
       return std::nullopt;
@@ -17002,7 +17372,7 @@ std::optional<EmbeddingLmHeadMatch> MatchTiedLmHead(
   }
   onnx::NodeProto* other = others[0];
 
-  auto match = MatchMatMulLikeRaw(*other);
+  auto match = MatchMatMulLikeWidenedRaw(*other);
   if (match) {
     if (match->w_name == weight_name && match->weight_transposed) {
       auto tail = MatchLmHeadTail(other, init_map, consumers_of, vocab_size);
@@ -17035,7 +17405,7 @@ std::optional<EmbeddingLmHeadMatch> MatchTiedLmHead(
       return std::nullopt;
     }
     onnx::NodeProto* node2 = tcit->second[0];
-    auto match2 = MatchMatMulLikeRaw(*node2);
+    auto match2 = MatchMatMulLikeWidenedRaw(*node2);
     if (!match2 || match2->w_name != t_out || match2->weight_transposed) {
       // must consume the transposed [hidden, vocab] tensor untransposed
       return std::nullopt;
@@ -17056,7 +17426,8 @@ std::optional<EmbeddingLmHeadMatch> MatchTiedLmHead(
 }
 
 // Auto-detects a fully independent `lm_head` weight: exactly one
-// MatMul/vanilla-Gemm node in the whole graph whose constant 2-D weight is
+// MatMul/vanilla-Gemm/FusedGemm/GemmFastGelu node (MatchMatMulLikeWidenedRaw)
+// in the whole graph whose constant 2-D weight is
 // distinct from `embedding_weight_name`, has exactly one consumer,
 // produces `vocab_size`-wide output, and -- the one structural signal that
 // reliably distinguishes "the" vocab-logits projection from some unrelated
@@ -17079,7 +17450,7 @@ std::optional<EmbeddingLmHeadMatch> MatchUntiedLmHead(
   std::vector<Candidate> candidates;
   for (int i = 0; i < graph->node_size(); ++i) {
     onnx::NodeProto* node = graph->mutable_node(i);
-    auto match = MatchMatMulLikeRaw(*node);
+    auto match = MatchMatMulLikeWidenedRaw(*node);
     if (!match) {
       continue;
     }
@@ -17088,7 +17459,7 @@ std::optional<EmbeddingLmHeadMatch> MatchUntiedLmHead(
     }
     auto wit = init_map.find(match->w_name);
     if (wit == init_map.end() ||
-        wit->second->data_type() != onnx::TensorProto::FLOAT ||
+        !IsSupportedFloatDtype(wit->second->data_type()) ||
         wit->second->dims_size() != 2) {
       continue;
     }
@@ -17122,20 +17493,22 @@ std::optional<EmbeddingLmHeadMatch> MatchUntiedLmHead(
   return result;
 }
 
-// Finds the one token-embedding Gather this pass should act on in `graph`
-// alone, plus its tied/untied `lm_head`, if any. When `input_name` is
-// given, only a Gather whose token-id operand resolves to that exact graph
+// Finds the one token-embedding producer this pass should act on in
+// `graph` alone -- a plain `Gather` (MatchEmbeddingGatherRaw) or a
+// `com.microsoft::EmbedLayerNormalization` node (MatchEmbedLayerNormProducer)
+// -- plus its tied/untied `lm_head`, if any. When `input_name` is given,
+// only a producer whose token-id operand resolves to that exact graph
 // input is considered, and -- when `strict_input_name` -- it is an error
 // (`std::invalid_argument`, a caller mistake) if none does;
 // `strict_input_name=false` (only ever passed by
 // MatchEmbeddingChainAnyGraph) instead treats that same outcome as an
 // ordinary decline (`std::nullopt`, no exception), since `graph` here is
 // only one of possibly several graphs a whole-model search is trying in
-// turn. When `input_name` is omitted, exactly one qualifying Gather must
-// exist in the whole graph -- zero or more than one declines the whole
-// call. Mirrors pruning.py's own `_match_embedding_chain` exactly (minus
-// the `EmbedLayerNormalization`/`GatherBlockQuantized` producer shapes --
-// see this section's own top comment).
+// turn. When `input_name` is omitted, exactly one qualifying producer --
+// of EITHER shape, counted together -- must exist in the whole graph --
+// zero or more than one declines the whole call. Mirrors pruning.py's own
+// `_match_embedding_chain` exactly, minus the `GatherBlockQuantized`
+// producer shape -- see this section's own top comment.
 std::optional<EmbeddingChain> MatchEmbeddingChain(
     onnx::GraphProto* graph, const std::optional<std::string>& input_name,
     bool strict_input_name) {
@@ -17170,8 +17543,14 @@ std::optional<EmbeddingChain> MatchEmbeddingChain(
   std::vector<RawMatch> matches;
   for (int i = 0; i < graph->node_size(); ++i) {
     onnx::NodeProto* node = graph->mutable_node(i);
+    // Try both producer shapes -- a node is at most one of them (disjoint
+    // op_type/domain checks), so there is never a double-count here.
     auto m = MatchEmbeddingGatherRaw(*node, init_map, consumers_of,
                                      graph_input_names, node_by_output);
+    if (!m) {
+      m = MatchEmbedLayerNormProducer(*node, init_map, consumers_of,
+                                      graph_input_names, node_by_output);
+    }
     if (!m) {
       continue;
     }
@@ -17298,6 +17677,50 @@ bool UpdateVocabOutputShape(onnx::GraphProto* graph, const std::string& name,
   return false;
 }
 
+// Dtype-preserving (FLOAT/FLOAT16/BFLOAT16) analogue of SliceProducerWeight,
+// used ONLY by this section -- every OTHER caller of SliceProducerWeight
+// elsewhere in this file keeps its own established FLOAT32-only scope
+// completely unchanged. `weight_transposed=true` means axis 0 is the output
+// channel (the embedding table's own `[vocab_size, hidden_size]` layout,
+// and a tied/untied `Gemm(transB=1)`-style `[vocab_size, K]` lm_head
+// weight); `false` means axis 1 (a plain-`MatMul`-style `[K, vocab_size]`
+// lm_head weight).
+void SliceEmbeddingWeightAnyDtype(onnx::TensorProto* wt, bool weight_transposed,
+                                  const std::vector<int64_t>& keep) {
+  const std::vector<int64_t> dims(wt->dims().begin(), wt->dims().end());
+  const std::vector<float> data = ReadFloatTensorAnyDtype(*wt);
+  const int64_t dim0 = dims[0], dim1 = dims[1];
+  const int64_t kc = static_cast<int64_t>(keep.size());
+  std::vector<float> out;
+  std::vector<int64_t> new_dims;
+  if (weight_transposed) {
+    out = SliceAxis0(data, dim0, dim1, keep);
+    new_dims = {kc, dim1};
+  } else {
+    out = SliceAxis1(data, dim0, dim1, 1, keep);
+    new_dims = {dim0, kc};
+  }
+  SetFloatTensorDataPreservingDtype(wt, new_dims, out);
+}
+
+// Dtype-preserving (FLOAT/FLOAT16/BFLOAT16) analogue of SliceLastAxis, used
+// ONLY by this section -- for an `lm_head`'s own constant bias.
+void SliceLastAxisAnyDtype(onnx::TensorProto* t,
+                           const std::vector<int64_t>& keep) {
+  std::vector<int64_t> dims(t->dims().begin(), t->dims().end());
+  const std::vector<float> data = ReadFloatTensorAnyDtype(*t);
+  std::vector<float> out(keep.size());
+  for (size_t i = 0; i < keep.size(); ++i) {
+    out[i] = data[static_cast<size_t>(keep[i])];
+  }
+  if (dims.empty()) {
+    dims.push_back(static_cast<int64_t>(keep.size()));
+  } else {
+    dims.back() = static_cast<int64_t>(keep.size());
+  }
+  SetFloatTensorDataPreservingDtype(t, dims, out);
+}
+
 // Performs the actual slicing, IN PLACE on `graph`, for an already-decided
 // (ascending) `keep_ids` set: the embedding table's own vocab_size axis
 // (always axis 0 -- MatchEmbeddingGatherRaw's own `axis == 0` requirement),
@@ -17308,7 +17731,12 @@ bool UpdateVocabOutputShape(onnx::GraphProto* graph, const std::string& name,
 // matched in (MatchEmbeddingChainAnyGraph's own returned `graph`), so this
 // mutates that graph's own initializer/output/value_info in place, never a
 // different graph's. Mirrors pruning.py's own `_apply_embedding_vocab_
-// prune`/`_finalize_embedding_shapes` exactly.
+// prune`/`_finalize_embedding_shapes` exactly -- including its own
+// FLOAT/FLOAT16/BFLOAT16 dtype-preserving round trip (SliceEmbeddingWeight
+// AnyDtype/SliceLastAxisAnyDtype above, this section's own local mirror of
+// `_to_f64`/`_from_f64`), unlike this file's shared SliceProducerWeight/
+// SliceLastAxis (FLOAT32-only, untouched, used elsewhere in this file
+// exactly as before).
 void ApplyEmbeddingVocabPrune(onnx::GraphProto* graph,
                               const EmbeddingChain& chain,
                               const std::vector<int64_t>& keep_ids) {
@@ -17316,19 +17744,17 @@ void ApplyEmbeddingVocabPrune(onnx::GraphProto* graph,
   const int64_t new_v = static_cast<int64_t>(keep_ids.size());
 
   // The embedding table is [vocab_size, hidden_size] with vocab_size as
-  // axis 0 -- exactly SliceProducerWeight's own `weight_transposed=true`
-  // ("output channel is axis 0") branch, reused verbatim rather than
-  // duplicating an axis-0 row-slice helper.
-  SliceProducerWeight(init_map.at(chain.weight_name),
-                      /*weight_transposed=*/true, keep_ids, /*is_conv=*/false);
+  // axis 0 -- exactly SliceEmbeddingWeightAnyDtype's own
+  // `weight_transposed=true` ("output channel is axis 0") branch.
+  SliceEmbeddingWeightAnyDtype(init_map.at(chain.weight_name),
+                               /*weight_transposed=*/true, keep_ids);
 
   if (chain.lm_head && !chain.lm_head->tied) {
-    SliceProducerWeight(init_map.at(*chain.lm_head->weight_name),
-                        *chain.lm_head->weight_transposed, keep_ids,
-                        /*is_conv=*/false);
+    SliceEmbeddingWeightAnyDtype(init_map.at(*chain.lm_head->weight_name),
+                                 *chain.lm_head->weight_transposed, keep_ids);
   }
   if (chain.lm_head && chain.lm_head->bias) {
-    SliceLastAxis(init_map.at(*chain.lm_head->bias), keep_ids);
+    SliceLastAxisAnyDtype(init_map.at(*chain.lm_head->bias), keep_ids);
   }
 
   // Finalize shapes: chain.producer's own output shape never needs
@@ -17372,7 +17798,7 @@ std::vector<double> EmbeddingVocabImportance(const EmbeddingChain& chain,
   std::vector<double> importance(static_cast<size_t>(chain.vocab_size), 0.0);
   {
     const std::vector<float> emb =
-        ReadFloatTensor(*init_map.at(chain.weight_name));
+        ReadFloatTensorAnyDtype(*init_map.at(chain.weight_name));
     for (int64_t v = 0; v < chain.vocab_size; ++v) {
       double sum = 0.0;
       for (int64_t h = 0; h < chain.hidden_size; ++h) {
@@ -17384,7 +17810,7 @@ std::vector<double> EmbeddingVocabImportance(const EmbeddingChain& chain,
   }
   if (chain.lm_head && !chain.lm_head->tied && chain.lm_head->weight_name) {
     const onnx::TensorProto* lw = init_map.at(*chain.lm_head->weight_name);
-    const std::vector<float> lwd = ReadFloatTensor(*lw);
+    const std::vector<float> lwd = ReadFloatTensorAnyDtype(*lw);
     if (*chain.lm_head->weight_transposed) {
       // [vocab_size, K] -- row v is contiguous, direct read.
       const int64_t k = lw->dims(1);

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -4013,29 +4013,38 @@ int64_t ChainGroup(const Chain& chain) {
 // _slice_grouped_consumer_conv_weight/_slice_last_axis ----------------------
 
 // Keeps only rows in `keep` of a [rows, inner] row-major matrix.
-std::vector<float> SliceAxis0(const std::vector<float>& data, int64_t /*rows*/,
-                              int64_t inner, const std::vector<int64_t>& keep) {
-  std::vector<float> out(keep.size() * static_cast<size_t>(inner));
+// Templated (not just `float`) so the MoE/QMoE section's own FLOAT16/
+// BFLOAT16-widened `double` code path (ReadTensorAsF64/WriteF64TensorAs, see
+// that section's own top comment) can reuse this exact same byte-shuffling
+// logic via `SliceAxis0<double>`/`SliceAxis1<double>`, instead of a
+// hand-duplicated copy -- every existing caller below still passes
+// `std::vector<float>` and gets the identical instantiation/behavior as
+// before.
+template <typename T>
+std::vector<T> SliceAxis0(const std::vector<T>& data, int64_t /*rows*/,
+                          int64_t inner, const std::vector<int64_t>& keep) {
+  std::vector<T> out(keep.size() * static_cast<size_t>(inner));
   for (size_t i = 0; i < keep.size(); ++i) {
     std::memcpy(out.data() + i * inner, data.data() + keep[i] * inner,
-                static_cast<size_t>(inner) * sizeof(float));
+                static_cast<size_t>(inner) * sizeof(T));
   }
   return out;
 }
 
 // Keeps only columns in `keep` of a [dim0, dim1, inner] row-major tensor
 // (axis 1 sliced; `inner` is the flattened size of every trailing axis).
-std::vector<float> SliceAxis1(const std::vector<float>& data, int64_t dim0,
-                              int64_t dim1, int64_t inner,
-                              const std::vector<int64_t>& keep) {
-  std::vector<float> out(static_cast<size_t>(dim0) * keep.size() *
-                         static_cast<size_t>(inner));
+template <typename T>
+std::vector<T> SliceAxis1(const std::vector<T>& data, int64_t dim0,
+                          int64_t dim1, int64_t inner,
+                          const std::vector<int64_t>& keep) {
+  std::vector<T> out(static_cast<size_t>(dim0) * keep.size() *
+                     static_cast<size_t>(inner));
   for (int64_t i = 0; i < dim0; ++i) {
     for (size_t j = 0; j < keep.size(); ++j) {
       std::memcpy(
           out.data() + (static_cast<size_t>(i) * keep.size() + j) * inner,
           data.data() + (i * dim1 + keep[j]) * inner,
-          static_cast<size_t>(inner) * sizeof(float));
+          static_cast<size_t>(inner) * sizeof(T));
     }
   }
   return out;
@@ -11628,15 +11637,38 @@ void ApplyMatMulBnb4Chains(onnx::GraphProto* graph,
 //     the wheel build always passes `-DONNXSIM_BUILTIN_ORT=OFF`); the
 //     caller supplies whatever executor actually runs the model.
 //
-// `fc1_experts_weights`/`fc2_experts_weights`/`fc1_experts_bias` are
-// admitted only as plain FLOAT (float32) tensors here -- this file's own
-// float-tensor helpers (ReadFloatTensor/SetFloatTensorData) have no
-// FLOAT16/BFLOAT16 support anywhere yet, unlike pruning.py's own
-// `_is_supported_float_dtype`, which additionally admits both. Mirrors this
-// file's own already-established narrower-than-pruning.py scope decision
-// (e.g. the "MatMulNBits" section's identical restriction on its own
-// scales/zero_points/bias tensors) -- a FLOAT16/BFLOAT16 MoE export is
-// simply never matched here (declined, not mis-handled).
+// `fc1_experts_weights`/`fc2_experts_weights`/`fc1_experts_bias` accept
+// FLOAT, FLOAT16, and BFLOAT16 -- exactly pruning.py's own
+// `_is_supported_float_dtype` -- via IsSupportedFloatDtype/ReadTensorAsF64/
+// WriteF64TensorAs, this section's own dedicated numeric-conversion trio
+// (see their own comment right below, just above MoEChain). This is
+// deliberately scoped to ONLY these MoE/QMoE tensors (and, for whole-expert
+// pruning, the router projection's own weight/bias via the equally-scoped
+// MatchMoeRouterProducer/SliceMoeRouterWeight/SliceMoeRouterBias further
+// below) -- this file's OTHER passes/chain families still go through the
+// shared FLOAT32-only ReadFloatTensor/SetFloatTensorData/MatchProducer/
+// SliceProducerWeight/SliceLastAxis (e.g. the "MatMulNBits" section's
+// identical restriction on its own scales/zero_points/bias tensors)
+// completely unmodified: those are reused by a dozen OTHER, independently-
+// verified-only-for-FLOAT32 chain families elsewhere in this file (see
+// ApplyStructuredPruning's own six chain kinds), so widening them in place
+// would silently change behavior for every one of those callers too, not
+// just MoE/QMoE -- a correctness claim this section has no way to make on
+// their behalf. Hence the narrow, MoE/QMoE-local duplicates instead of a
+// shared-code change.
+//
+// FLOAT16/BFLOAT16 <-> float64 conversion is exact/lossless in the upcast
+// direction, and this pass never recomputes a surviving weight's own
+// value -- every rewrite below is pure index-selection/reordering (drop
+// some `inter_size`/`num_experts` indices, keep the rest byte-for-byte) --
+// so the round trip through float64 back to the tensor's own original dtype
+// reproduces the exact original bit pattern for every kept element,
+// verified empirically (exhaustive round-trip over all 65536 FLOAT16 and
+// all 65536 BFLOAT16 bit patterns, and cross-checked against numpy/
+// ml_dtypes for 200000 random values each) -- the same "slice, don't
+// recompute" invariant this file's own FP16/BFloat16-adjacent comments
+// elsewhere (e.g. the QDQ section's "read out upcast ... cast back down"
+// language) already describe for pruning.py's own identical convention.
 //
 // This is exposed as its own top-level entry point (ApplyMoeExpertChannel
 // Pruning, alongside ApplyStructuredPruning/ApplyAttentionHeadPruning at the
@@ -11650,6 +11682,236 @@ void ApplyMatMulBnb4Chains(onnx::GraphProto* graph,
 // bookkeeping below only ever needs to guard MoE nodes against each other
 // (mirrors pruning.py's own `_apply_moe_chains`, whose own local
 // `touched: Set[str]` is likewise never shared with `_TouchedState`).
+
+// --- FLOAT16/BFLOAT16 numeric conversion, scoped to MoE/QMoE's own
+// dtype-widened matcher/apply steps (see this section's own comment above)
+// -------------------------------------------------------------------------
+//
+// True for FLOAT, FLOAT16, and BFLOAT16 -- mirrors pruning.py's own
+// `_is_supported_float_dtype` exactly.
+bool IsSupportedFloatDtype(int32_t data_type) {
+  return data_type == onnx::TensorProto::FLOAT ||
+         data_type == onnx::TensorProto::FLOAT16 ||
+         data_type == onnx::TensorProto::BFLOAT16;
+}
+
+// IEEE-754 binary16 -> double, exact (every half value is exactly
+// representable in double). Handles zero/subnormal/normal/inf/NaN.
+double Float16BitsToDouble(uint16_t bits) {
+  uint32_t sign = (uint32_t)(bits & 0x8000u) << 16;
+  uint32_t exp = (bits >> 10) & 0x1Fu;
+  uint32_t mant = bits & 0x3FFu;
+  uint32_t f32bits;
+  if (exp == 0) {
+    if (mant == 0) {
+      f32bits = sign;
+    } else {
+      int e = -1;
+      do {
+        ++e;
+        mant <<= 1;
+      } while (!(mant & 0x400u));
+      mant &= 0x3FFu;
+      uint32_t exp32 = (uint32_t)(127 - 15 - e);
+      f32bits = sign | (exp32 << 23) | (mant << 13);
+    }
+  } else if (exp == 0x1F) {
+    f32bits = sign | 0x7F800000u | (mant << 13);
+  } else {
+    uint32_t exp32 = exp - 15 + 127;
+    f32bits = sign | (exp32 << 23) | (mant << 13);
+  }
+  float f;
+  std::memcpy(&f, &f32bits, sizeof(f));
+  return (double)f;
+}
+
+// double -> IEEE-754 binary16, round-to-nearest-even. Works directly off
+// the double's own 52-bit mantissa/11-bit exponent -- deliberately NOT
+// `(float)d` first, which would round TWICE (double -> float32 -> half) and
+// can flip a tie-to-even decision right at half's own rounding boundary
+// versus rounding straight from double (verified against numpy: the
+// double-rounding version disagreed with `np.float16(d)` for 13 of 200000
+// random cross-checked values; this direct version agreed for all of them,
+// and both this function and Float16BitsToDouble round-trip every one of
+// the 65536 possible FLOAT16 bit patterns exactly). Only ever actually
+// applied to values that came FROM Float16BitsToDouble in the first place
+// (this pass never recomputes a kept weight value, only reorders/drops
+// entries -- see this section's own top comment), so the exact rounding
+// behavior for a genuinely-arbitrary double is academic here: every real
+// call site round-trips an already-exact half value, for which any correct
+// round-to-nearest implementation reproduces the original bits exactly.
+uint16_t DoubleToFloat16Bits(double d) {
+  uint64_t x;
+  std::memcpy(&x, &d, sizeof(x));
+  uint32_t sign = (uint32_t)((x >> 48) & 0x8000u);
+  int32_t exp11 = (int32_t)((x >> 52) & 0x7FFu);
+  uint64_t mant = x & 0xFFFFFFFFFFFFFull;  // 52 bits
+
+  if (exp11 == 0x7FF) {
+    if (mant == 0) {
+      return (uint16_t)(sign | 0x7C00u);  // inf
+    }
+    uint16_t m = (uint16_t)(mant >> 42);
+    if (m == 0) m = 1;  // stay a NaN, not inf
+    return (uint16_t)(sign | 0x7C00u | m);
+  }
+
+  int32_t exp = exp11 - 1023 + 15;
+
+  if (exp >= 0x1F) {
+    return (uint16_t)(sign | 0x7C00u);  // overflow -> inf
+  }
+
+  if (exp <= 0) {
+    if (exp < -10) {
+      return (uint16_t)sign;  // underflow to zero
+    }
+    mant |= 0x10000000000000ull;  // implicit leading 1 (bit 52)
+    int shift = 43 - exp;         // exp<=0 so shift>=43, mant has 53 bits
+    uint64_t half_mant = mant >> shift;
+    uint64_t remainder = mant & ((1ull << shift) - 1);
+    uint64_t halfway = 1ull << (shift - 1);
+    if (remainder > halfway || (remainder == halfway && (half_mant & 1u))) {
+      half_mant += 1;
+    }
+    return (uint16_t)(sign | (uint32_t)half_mant);
+  }
+
+  uint32_t half_mant = (uint32_t)(mant >> 42);
+  uint64_t remainder = mant & ((1ull << 42) - 1);  // low 42 bits
+  uint64_t halfway = 1ull << 41;
+  if (remainder > halfway || (remainder == halfway && (half_mant & 1u))) {
+    half_mant += 1;
+    if (half_mant == 0x400u) {
+      half_mant = 0;
+      exp += 1;
+    }
+  }
+  if (exp >= 0x1F) {
+    return (uint16_t)(sign | 0x7C00u);
+  }
+  return (uint16_t)(sign | ((uint32_t)exp << 10) | half_mant);
+}
+
+// BFloat16 -> double, exact: bfloat16 is literally the top 16 bits of a
+// float32, so this is a plain zero-extend into a float32 bit pattern.
+double BFloat16BitsToDouble(uint16_t bits) {
+  uint32_t f32bits = (uint32_t)bits << 16;
+  float f;
+  std::memcpy(&f, &f32bits, sizeof(f));
+  return (double)f;
+}
+
+// double -> BFloat16, round-to-nearest-even (via an intermediate float32 --
+// unlike DoubleToFloat16Bits, this introduces no double-rounding hazard:
+// bfloat16 IS float32's own top 16 bits, so rounding double -> float32 ->
+// bfloat16 is the same "round once, truncate the rest" every real bfloat16
+// implementation does, confirmed to agree with `ml_dtypes.bfloat16` for
+// 200000 random cross-checked values).
+uint16_t DoubleToBFloat16Bits(double d) {
+  float f = (float)d;
+  uint32_t x;
+  std::memcpy(&x, &f, sizeof(x));
+  if ((x & 0x7FFFFFFFu) > 0x7F800000u) {
+    return (uint16_t)((x >> 16) | 0x0040u);  // NaN -- force the quiet bit.
+  }
+  uint32_t lsb = (x >> 16) & 1u;
+  uint32_t rounding_bias = 0x7FFFu + lsb;
+  uint32_t rounded = x + rounding_bias;
+  return (uint16_t)(rounded >> 16);
+}
+
+// Reads a FLOAT/FLOAT16/BFLOAT16 tensor `t` as a flat float64 vector --
+// mirrors pruning.py's own `_to_f64`. Non-raw-data storage packs each
+// FLOAT16/BFLOAT16 element's own raw 16 bits into the LOW half of one
+// `int32_data` entry (never byte-swapped -- these are already
+// protobuf-decoded ints, not a raw buffer), exactly like
+// `onnx.numpy_helper.to_array`'s own documented convention for these
+// dtypes.
+std::vector<double> ReadTensorAsF64(const onnx::TensorProto& t) {
+  int64_t numel = 1;
+  for (int64_t d : t.dims()) {
+    numel *= d;
+  }
+  std::vector<double> out(static_cast<size_t>(numel));
+  if (t.data_type() == onnx::TensorProto::FLOAT) {
+    const std::vector<float> f = ReadFloatTensor(t);
+    for (size_t i = 0; i < f.size(); ++i) {
+      out[i] = static_cast<double>(f[i]);
+    }
+    return out;
+  }
+  if (t.data_type() != onnx::TensorProto::FLOAT16 &&
+      t.data_type() != onnx::TensorProto::BFLOAT16) {
+    throw std::runtime_error("ReadTensorAsF64: unsupported tensor dtype " +
+                             std::to_string(static_cast<int>(t.data_type())));
+  }
+  std::vector<uint16_t> bits(static_cast<size_t>(numel));
+  if (t.has_raw_data()) {
+    std::memcpy(bits.data(), t.raw_data().data(),
+                bits.size() * sizeof(uint16_t));
+    if constexpr (!onnxsim::dlpack::kRawDataIsHostOrder) {
+      onnxsim::dlpack::SwapElementBytes(reinterpret_cast<uint8_t*>(bits.data()),
+                                        bits.size() * sizeof(uint16_t),
+                                        sizeof(uint16_t));
+    }
+  } else {
+    for (int64_t i = 0; i < numel; ++i) {
+      bits[static_cast<size_t>(i)] =
+          static_cast<uint16_t>(t.int32_data(static_cast<int>(i)));
+    }
+  }
+  const bool is_bf16 = t.data_type() == onnx::TensorProto::BFLOAT16;
+  for (size_t i = 0; i < bits.size(); ++i) {
+    out[i] =
+        is_bf16 ? BFloat16BitsToDouble(bits[i]) : Float16BitsToDouble(bits[i]);
+  }
+  return out;
+}
+
+// Overwrites `t` in place with a `data_type` (FLOAT/FLOAT16/BFLOAT16)
+// tensor of `dims`/`data`, keeping its existing name -- mirrors pruning.py's
+// own `_from_f64`/`w_init.CopyFrom(...)`. Always writes `raw_data`, exactly
+// like `onnx.numpy_helper.from_array`'s own convention this file's other
+// Set*TensorData helpers already follow.
+void WriteF64TensorAs(onnx::TensorProto* t, int32_t data_type,
+                      const std::vector<int64_t>& dims,
+                      const std::vector<double>& data) {
+  if (data_type == onnx::TensorProto::FLOAT) {
+    std::vector<float> f(data.size());
+    for (size_t i = 0; i < data.size(); ++i) {
+      f[i] = static_cast<float>(data[i]);
+    }
+    SetFloatTensorData(t, dims, f);
+    return;
+  }
+  if (data_type != onnx::TensorProto::FLOAT16 &&
+      data_type != onnx::TensorProto::BFLOAT16) {
+    throw std::runtime_error("WriteF64TensorAs: unsupported tensor dtype " +
+                             std::to_string(data_type));
+  }
+  const std::string name = t->name();
+  t->Clear();
+  t->set_name(name);
+  t->set_data_type(data_type);
+  for (int64_t d : dims) {
+    t->add_dims(d);
+  }
+  const bool is_bf16 = data_type == onnx::TensorProto::BFLOAT16;
+  std::vector<uint16_t> bits(data.size());
+  for (size_t i = 0; i < data.size(); ++i) {
+    bits[i] =
+        is_bf16 ? DoubleToBFloat16Bits(data[i]) : DoubleToFloat16Bits(data[i]);
+  }
+  std::string raw(bits.size() * sizeof(uint16_t), '\0');
+  std::memcpy(raw.data(), bits.data(), raw.size());
+  if constexpr (!onnxsim::dlpack::kRawDataIsHostOrder) {
+    onnxsim::dlpack::SwapElementBytes(reinterpret_cast<uint8_t*>(raw.data()),
+                                      raw.size(), sizeof(uint16_t));
+  }
+  t->set_raw_data(std::move(raw));
+}
 
 struct MoEChain {
   onnx::NodeProto* node;
@@ -11689,8 +11951,7 @@ MoeOptionalBiasResult MatchMoeOptionalBias(const onnx::NodeProto& node,
   }
   const std::string& name = node.input(index);
   auto it = init_map.find(name);
-  if (it == init_map.end() ||
-      it->second->data_type() != onnx::TensorProto::FLOAT ||
+  if (it == init_map.end() || !IsSupportedFloatDtype(it->second->data_type()) ||
       it->second->dims_size() != 2 || it->second->dims(0) != expected_dim0 ||
       it->second->dims(1) != expected_dim1 ||
       ConsumerCount(consumers_of, name) != 1) {
@@ -11736,8 +11997,8 @@ std::optional<MoEChain> MatchMoeProducer(onnx::NodeProto* node,
   auto fc1_it = init_map.find(fc1_w_name);
   auto fc2_it = init_map.find(fc2_w_name);
   if (fc1_it == init_map.end() || fc2_it == init_map.end() ||
-      fc1_it->second->data_type() != onnx::TensorProto::FLOAT ||
-      fc2_it->second->data_type() != onnx::TensorProto::FLOAT ||
+      !IsSupportedFloatDtype(fc1_it->second->data_type()) ||
+      !IsSupportedFloatDtype(fc2_it->second->data_type()) ||
       fc1_it->second->dims_size() != 3 || fc2_it->second->dims_size() != 3 ||
       ConsumerCount(consumers_of, fc1_w_name) != 1 ||
       ConsumerCount(consumers_of, fc2_w_name) != 1) {
@@ -11804,7 +12065,7 @@ std::vector<double> MoeImportance(const MoEChain& chain,
   const int64_t hidden = chain.hidden_size;
   std::vector<double> squared(static_cast<size_t>(inter), 0.0);
 
-  const std::vector<float> fc1_w = ReadFloatTensor(*init_map.at(chain.fc1_w));
+  const std::vector<double> fc1_w = ReadTensorAsF64(*init_map.at(chain.fc1_w));
   for (int64_t e = 0; e < e_n; ++e) {
     for (int64_t j = 0; j < inter; ++j) {
       double sq = 0.0;
@@ -11817,7 +12078,7 @@ std::vector<double> MoeImportance(const MoEChain& chain,
     }
   }
 
-  const std::vector<float> fc2_w = ReadFloatTensor(*init_map.at(chain.fc2_w));
+  const std::vector<double> fc2_w = ReadTensorAsF64(*init_map.at(chain.fc2_w));
   for (int64_t e = 0; e < e_n; ++e) {
     for (int64_t h = 0; h < hidden; ++h) {
       for (int64_t j = 0; j < inter; ++j) {
@@ -11829,8 +12090,8 @@ std::vector<double> MoeImportance(const MoEChain& chain,
   }
 
   if (chain.fc1_b) {
-    const std::vector<float> fc1_b =
-        ReadFloatTensor(*init_map.at(*chain.fc1_b));
+    const std::vector<double> fc1_b =
+        ReadTensorAsF64(*init_map.at(*chain.fc1_b));
     for (int64_t e = 0; e < e_n; ++e) {
       for (int64_t j = 0; j < inter; ++j) {
         const double v = fc1_b[static_cast<size_t>(e * inter + j)];
@@ -11895,13 +12156,18 @@ void ApplyMoeChains(onnx::GraphProto* graph, std::vector<MoEChain>& chains,
 
     // fc1_experts_weights: [num_experts, inter_size, hidden_size] -- SliceAxis1
     // slices exactly its own middle (`inter_size`) axis, `inner = hidden_size`.
+    // Read/written via ReadTensorAsF64/WriteF64TensorAs (FLOAT/FLOAT16/
+    // BFLOAT16, preserving this tensor's own original dtype) rather than
+    // ReadFloatTensor/SetFloatTensorData -- see this section's own top
+    // comment.
     {
       onnx::TensorProto* fc1_w = init_map.at(chain.fc1_w);
-      const std::vector<float> data = ReadFloatTensor(*fc1_w);
-      const std::vector<float> out = SliceAxis1(
+      const int32_t dtype = fc1_w->data_type();
+      const std::vector<double> data = ReadTensorAsF64(*fc1_w);
+      const std::vector<double> out = SliceAxis1(
           data, chain.num_experts, chain.inter_size, chain.hidden_size, keep);
-      SetFloatTensorData(fc1_w, {chain.num_experts, kc, chain.hidden_size},
-                         out);
+      WriteF64TensorAs(fc1_w, dtype, {chain.num_experts, kc, chain.hidden_size},
+                       out);
     }
 
     // fc2_experts_weights: [num_experts, hidden_size, inter_size] --
@@ -11911,22 +12177,24 @@ void ApplyMoeChains(onnx::GraphProto* graph, std::vector<MoEChain>& chains,
     // exactly that trailing axis without any new slicing routine.
     {
       onnx::TensorProto* fc2_w = init_map.at(chain.fc2_w);
-      const std::vector<float> data = ReadFloatTensor(*fc2_w);
-      const std::vector<float> out =
+      const int32_t dtype = fc2_w->data_type();
+      const std::vector<double> data = ReadTensorAsF64(*fc2_w);
+      const std::vector<double> out =
           SliceAxis1(data, chain.num_experts * chain.hidden_size,
                      chain.inter_size, 1, keep);
-      SetFloatTensorData(fc2_w, {chain.num_experts, chain.hidden_size, kc},
-                         out);
+      WriteF64TensorAs(fc2_w, dtype, {chain.num_experts, chain.hidden_size, kc},
+                       out);
     }
 
     if (chain.fc1_b) {
       // fc1_experts_bias: [num_experts, inter_size] -- same trailing-axis
       // shape SliceAxis1 already handles (inner = 1), no reshape needed.
       onnx::TensorProto* fc1_b = init_map.at(*chain.fc1_b);
-      const std::vector<float> data = ReadFloatTensor(*fc1_b);
-      const std::vector<float> out =
+      const int32_t dtype = fc1_b->data_type();
+      const std::vector<double> data = ReadTensorAsF64(*fc1_b);
+      const std::vector<double> out =
           SliceAxis1(data, chain.num_experts, chain.inter_size, 1, keep);
-      SetFloatTensorData(fc1_b, {chain.num_experts, kc}, out);
+      WriteF64TensorAs(fc1_b, dtype, {chain.num_experts, kc}, out);
     }
     // fc2_experts_bias indexes hidden_size, fc2's own *output* axis --
     // unaffected by an inter_size cut, so it is never sliced here.
@@ -11959,9 +12227,12 @@ void ApplyMoeChains(onnx::GraphProto* graph, std::vector<MoEChain>& chains,
 //      `num_experts_to_keep` is clamped to `max(k, ...)`, so a
 //      too-aggressive `sparsity` silently prunes fewer experts than
 //      requested rather than ever going below `k`.
-//   3. The router match (MatchProducer, reused outright from this file's
-//      own MatMul/Gemm chain-matching machinery) requires `router_probs` to
-//      be produced by exactly ONE plain, untied MatMul/vanilla-Gemm node
+//   3. The router match (MatchMoeRouterProducer -- a FLOAT16/BFLOAT16-
+//      widened, MoE/QMoE-local variant of this file's own shared
+//      MatchProducer MatMul/Gemm chain-matching machinery; see that
+//      function's own comment for why it is a narrow local duplicate rather
+//      than a change to the shared one) requires `router_probs` to be
+//      produced by exactly ONE plain, untied MatMul/vanilla-Gemm node
 //      (mirroring pruning.py's own `_match_producer`) with no other
 //      consumer -- a router expressed as more than one node (a separate
 //      bias Add, an intervening Reshape/Cast, ...), a tied/shared router
@@ -12002,6 +12273,89 @@ struct MoEExpertChain {
   bool router_w_transposed = false;
   std::optional<std::string> router_b;
 };
+
+// Router-projection matcher for MoE/QMoE whole-expert pruning ONLY --
+// mirrors MatchProducer (this file's "MatMul/Gemm plain chains" section)
+// exactly, but widened to accept FLOAT16/BFLOAT16 in addition to FLOAT32 for
+// the weight, since pruning.py's own `_match_producer` -- shared by every
+// ONE of its own callers, unlike this file's own MatchProducer, which stays
+// FLOAT32-only for its OTHER callers -- already does. Deliberately a narrow,
+// LOCAL duplicate rather than a change to the shared MatchProducer itself:
+// that function backs a dozen OTHER chain families in this file (see
+// ApplyStructuredPruning's own six chain kinds), none of which has been
+// independently re-verified against a real FLOAT16/BFLOAT16 export the way
+// this section's own numeric-conversion helpers just were -- widening
+// MatchProducer in place would silently change matching behavior for every
+// one of those OTHER callers too, not just the router path here. `bias` is
+// never dtype-checked at all, mirroring `_match_producer`'s/MatchProducer's
+// own identical lack of a bias dtype gate (only presence as a constant
+// initializer is required either way).
+std::optional<ProducerMatch> MatchMoeRouterProducer(const onnx::NodeProto& node,
+                                                    const InitMap& init_map) {
+  auto m = MatchMatMulLikeRaw(node);
+  if (!m) {
+    return std::nullopt;
+  }
+  auto it = init_map.find(m->w_name);
+  if (it == init_map.end() || !IsSupportedFloatDtype(it->second->data_type()) ||
+      it->second->dims_size() != 2) {
+    return std::nullopt;
+  }
+  std::optional<std::string> bias;
+  if (node.op_type() == "Gemm" && node.input_size() == 3) {
+    bias = node.input(2);
+    if (!init_map.count(*bias)) {
+      return std::nullopt;  // non-constant bias -- can't safely prune it.
+    }
+  }
+  const onnx::TensorProto* w = it->second;
+  const int64_t n_channels = m->weight_transposed ? w->dims(0) : w->dims(1);
+  return ProducerMatch{m->w_name, m->weight_transposed, bias, n_channels};
+}
+
+// The FLOAT/FLOAT16/BFLOAT16-widened analogue of SliceProducerWeight, used
+// ONLY for the router projection weight MatchMoeRouterProducer above
+// matches (MoE/QMoE whole-expert pruning) -- see that function's own
+// comment for why this stays a narrow local duplicate rather than a change
+// to the shared SliceProducerWeight. Never a Conv weight here -- a router
+// projection is always a plain 2-D MatMul/Gemm weight.
+void SliceMoeRouterWeight(onnx::TensorProto* wt, bool weight_transposed,
+                          const std::vector<int64_t>& keep) {
+  const std::vector<int64_t> dims(wt->dims().begin(), wt->dims().end());
+  const int32_t dtype = wt->data_type();
+  const std::vector<double> data = ReadTensorAsF64(*wt);
+  std::vector<double> out;
+  std::vector<int64_t> new_dims;
+  const int64_t kc = static_cast<int64_t>(keep.size());
+  const int64_t dim0 = dims[0], dim1 = dims[1];
+  if (weight_transposed) {  // [N, K] -- output channel is axis 0.
+    out = SliceAxis0(data, dim0, dim1, keep);
+    new_dims = {kc, dim1};
+  } else {  // [K, N] -- output channel is axis 1.
+    out = SliceAxis1(data, dim0, dim1, 1, keep);
+    new_dims = {dim0, kc};
+  }
+  WriteF64TensorAs(wt, dtype, new_dims, out);
+}
+
+// The FLOAT/FLOAT16/BFLOAT16-widened analogue of SliceLastAxis, used ONLY
+// for the router projection's own optional bias.
+void SliceMoeRouterBias(onnx::TensorProto* t,
+                        const std::vector<int64_t>& keep) {
+  const int32_t dtype = t->data_type();
+  const std::vector<double> data = ReadTensorAsF64(*t);
+  std::vector<double> out(keep.size());
+  for (size_t i = 0; i < keep.size(); ++i) {
+    out[i] = data[static_cast<size_t>(keep[i])];
+  }
+  std::vector<int64_t> dims(t->dims().begin(), t->dims().end());
+  if (dims.empty()) {
+    dims.push_back(static_cast<int64_t>(keep.size()));
+  } else {
+    dims.back() = static_cast<int64_t>(keep.size());
+  }
+  WriteF64TensorAs(t, dtype, dims, out);
+}
 
 // If `node` is a `com.microsoft::MoE` node this pass can safely prune whole
 // experts from, returns the matched MoEExpertChain -- mirrors pruning.py's
@@ -12047,7 +12401,7 @@ std::optional<MoEExpertChain> MatchMoeWholeExpertProducer(
   if (rit == node_by_output.end()) {
     return std::nullopt;
   }
-  auto router_info = MatchProducer(*rit->second, init_map);
+  auto router_info = MatchMoeRouterProducer(*rit->second, init_map);
   if (!router_info) {
     return std::nullopt;
   }
@@ -12120,13 +12474,13 @@ std::vector<double> MoeExpertWeightImportance(const MoEExpertChain& chain,
 
   auto accumulate = [&](const std::string& name) {
     const onnx::TensorProto* t = init_map.at(name);
-    const std::vector<float> data = ReadFloatTensor(*t);
+    const std::vector<double> data = ReadTensorAsF64(*t);
     const int64_t inner = static_cast<int64_t>(data.size()) / e_n;
     for (int64_t e = 0; e < e_n; ++e) {
-      const float* row = data.data() + e * inner;
+      const double* row = data.data() + e * inner;
       double sq = 0.0;
       for (int64_t j = 0; j < inner; ++j) {
-        sq += static_cast<double>(row[j]) * static_cast<double>(row[j]);
+        sq += row[j] * row[j];
       }
       squared[static_cast<size_t>(e)] += sq;
     }
@@ -12206,14 +12560,19 @@ std::unordered_set<std::string> ApplyMoeWholeExpertChains(
     const int64_t kc = static_cast<int64_t>(keep.size());
 
     // fc1_experts_weights: [num_experts, inter_size, hidden_size] -- plain
-    // leading-axis (expert) index-select.
+    // leading-axis (expert) index-select. Read/written via
+    // ReadTensorAsF64/WriteF64TensorAs (FLOAT/FLOAT16/BFLOAT16, preserving
+    // this tensor's own original dtype) rather than ReadFloatTensor/
+    // SetFloatTensorData -- see this file's own "MoE expert-intermediate-
+    // channel pruning" section top comment.
     {
       onnx::TensorProto* fc1_w = init_map.at(chain.fc1_w);
       std::vector<int64_t> dims(fc1_w->dims().begin(), fc1_w->dims().end());
       const int64_t inner = dims[1] * dims[2];
-      const std::vector<float> data = ReadFloatTensor(*fc1_w);
-      const std::vector<float> out = SliceAxis0(data, n, inner, keep);
-      SetFloatTensorData(fc1_w, {kc, dims[1], dims[2]}, out);
+      const int32_t dtype = fc1_w->data_type();
+      const std::vector<double> data = ReadTensorAsF64(*fc1_w);
+      const std::vector<double> out = SliceAxis0(data, n, inner, keep);
+      WriteF64TensorAs(fc1_w, dtype, {kc, dims[1], dims[2]}, out);
     }
     // fc2_experts_weights: [num_experts, hidden_size, inter_size] -- same
     // plain leading-axis index-select (unlike ApplyMoeChains' own
@@ -12222,9 +12581,10 @@ std::unordered_set<std::string> ApplyMoeWholeExpertChains(
       onnx::TensorProto* fc2_w = init_map.at(chain.fc2_w);
       std::vector<int64_t> dims(fc2_w->dims().begin(), fc2_w->dims().end());
       const int64_t inner = dims[1] * dims[2];
-      const std::vector<float> data = ReadFloatTensor(*fc2_w);
-      const std::vector<float> out = SliceAxis0(data, n, inner, keep);
-      SetFloatTensorData(fc2_w, {kc, dims[1], dims[2]}, out);
+      const int32_t dtype = fc2_w->data_type();
+      const std::vector<double> data = ReadTensorAsF64(*fc2_w);
+      const std::vector<double> out = SliceAxis0(data, n, inner, keep);
+      WriteF64TensorAs(fc2_w, dtype, {kc, dims[1], dims[2]}, out);
     }
     if (chain.fc1_b) {
       // fc1_experts_bias: [num_experts, inter_size] -- same leading-axis
@@ -12232,9 +12592,10 @@ std::unordered_set<std::string> ApplyMoeWholeExpertChains(
       onnx::TensorProto* fc1_b = init_map.at(*chain.fc1_b);
       std::vector<int64_t> dims(fc1_b->dims().begin(), fc1_b->dims().end());
       const int64_t inner = dims[1];
-      const std::vector<float> data = ReadFloatTensor(*fc1_b);
-      const std::vector<float> out = SliceAxis0(data, n, inner, keep);
-      SetFloatTensorData(fc1_b, {kc, dims[1]}, out);
+      const int32_t dtype = fc1_b->data_type();
+      const std::vector<double> data = ReadTensorAsF64(*fc1_b);
+      const std::vector<double> out = SliceAxis0(data, n, inner, keep);
+      WriteF64TensorAs(fc1_b, dtype, {kc, dims[1]}, out);
     }
     // fc2_experts_bias indexes hidden_size (fc2's own *output* axis),
     // unaffected by an expert-count cut -- never sliced here, same
@@ -12242,12 +12603,14 @@ std::unordered_set<std::string> ApplyMoeWholeExpertChains(
 
     // Router projection: the matching OUTPUT COLUMN (the router's own
     // `num_experts`-wide channel axis) is dropped from its weight (and
-    // bias, if present) -- SliceProducerWeight/SliceLastAxis, the exact
-    // same helpers this file's own plain-chain producer pruning uses.
-    SliceProducerWeight(init_map.at(chain.router_w), chain.router_w_transposed,
-                        keep, false);
+    // bias, if present) -- SliceMoeRouterWeight/SliceMoeRouterBias (the
+    // FLOAT16/BFLOAT16-widened, MoE/QMoE-local analogues of this file's own
+    // shared SliceProducerWeight/SliceLastAxis -- see MatchMoeRouterProducer's
+    // own comment above for why these stay narrow local duplicates).
+    SliceMoeRouterWeight(init_map.at(chain.router_w), chain.router_w_transposed,
+                         keep);
     if (chain.router_b) {
-      SliceLastAxis(init_map.at(*chain.router_b), keep);
+      SliceMoeRouterBias(init_map.at(*chain.router_b), keep);
     }
 
     stale_value_info.insert(chain.router_probs);
@@ -12575,11 +12938,13 @@ struct QMoEChannelChain {
   std::optional<std::string> fc2_global_scale;
 };
 
-// {true, name} for a present-and-well-formed optional FLOAT input, {true,
-// nullopt} for a genuinely absent one, {false, _} to decline the whole
-// chain -- mirrors pruning.py's own `_optional_float` closure inside
-// `_match_qmoe_producer` exactly (used for `fc1_experts_bias`/
-// `fc2_experts_bias`, either quant_type).
+// {true, name} for a present-and-well-formed optional FLOAT/FLOAT16/
+// BFLOAT16 input, {true, nullopt} for a genuinely absent one, {false, _} to
+// decline the whole chain -- mirrors pruning.py's own `_optional_float`
+// closure inside `_match_qmoe_producer` exactly (used for
+// `fc1_experts_bias`/`fc2_experts_bias`, either quant_type) -- including its
+// own `_is_supported_float_dtype` widening (see IsSupportedFloatDtype,
+// this file's own "MoE expert-intermediate-channel pruning" section).
 bool QMoEOptionalFloatInput(const onnx::NodeProto& node, int idx,
                             const std::vector<int64_t>& expected_dims,
                             const InitMap& init_map,
@@ -12591,8 +12956,7 @@ bool QMoEOptionalFloatInput(const onnx::NodeProto& node, int idx,
   }
   const std::string& name = node.input(idx);
   auto it = init_map.find(name);
-  if (it == init_map.end() ||
-      it->second->data_type() != onnx::TensorProto::FLOAT ||
+  if (it == init_map.end() || !IsSupportedFloatDtype(it->second->data_type()) ||
       !QMoEDimsEqual(*it->second, expected_dims) ||
       ConsumerCount(consumers_of, name) != 1) {
     return false;
@@ -12764,8 +13128,8 @@ std::optional<QMoEChannelChain> MatchQMoEProducer(
     auto s1 = init_map.find(fc1_scale_name);
     auto s2 = init_map.find(fc2_scale_name);
     if (s1 == init_map.end() || s2 == init_map.end() ||
-        s1->second->data_type() != onnx::TensorProto::FLOAT ||
-        s2->second->data_type() != onnx::TensorProto::FLOAT ||
+        !IsSupportedFloatDtype(s1->second->data_type()) ||
+        !IsSupportedFloatDtype(s2->second->data_type()) ||
         !QMoEDimsEqual(*s1->second, fc1_scale_dims) ||
         !QMoEDimsEqual(*s2->second, fc2_scale_dims) ||
         ConsumerCount(consumers_of, fc1_scale_name) != 1 ||
@@ -12969,7 +13333,7 @@ std::vector<double> QMoEDequantizeInt(const onnx::TensorProto& w,
   const std::vector<uint8_t> packed = ReadUint8Tensor(w);  // [E*N, kp]
   const std::vector<uint8_t> codes =
       QMoEUnpackSubbyte(packed, e * n, kp, k, bits);  // [E*N, K]
-  const std::vector<float> scale_data = ReadFloatTensor(scale);
+  const std::vector<double> scale_data = ReadTensorAsF64(scale);
   const double default_zp = static_cast<double>(QMoEDefaultZeroPoint(bits));
   std::vector<double> out(static_cast<size_t>(e * n * k));
 
@@ -12987,8 +13351,7 @@ std::vector<double> QMoEDequantizeInt(const onnx::TensorProto& w,
     }
     for (int64_t en = 0; en < e * n; ++en) {
       for (int64_t kb = 0; kb < k_blocks; ++kb) {
-        const double s = static_cast<double>(
-            scale_data[static_cast<size_t>(en * k_blocks + kb)]);
+        const double s = scale_data[static_cast<size_t>(en * k_blocks + kb)];
         const double z = zp[static_cast<size_t>(en * k_blocks + kb)];
         for (int64_t j = 0; j < block_size; ++j) {
           const int64_t idx = en * k + kb * block_size + j;
@@ -13009,7 +13372,7 @@ std::vector<double> QMoEDequantizeInt(const onnx::TensorProto& w,
       }
     }
     for (int64_t en = 0; en < e * n; ++en) {
-      const double s = static_cast<double>(scale_data[static_cast<size_t>(en)]);
+      const double s = scale_data[static_cast<size_t>(en)];
       const double z = zp[static_cast<size_t>(en)];
       for (int64_t j = 0; j < k; ++j) {
         const int64_t idx = en * k + j;
@@ -13120,12 +13483,11 @@ std::vector<double> QMoEChannelImportance(
     }
   }
   if (chain.fc1_bias) {
-    const std::vector<float> bias =
-        ReadFloatTensor(*init_map.at(*chain.fc1_bias));
+    const std::vector<double> bias =
+        ReadTensorAsF64(*init_map.at(*chain.fc1_bias));
     for (int64_t ei = 0; ei < e; ++ei) {
       for (int64_t ni = 0; ni < inter; ++ni) {
-        const double v =
-            static_cast<double>(bias[static_cast<size_t>(ei * inter + ni)]);
+        const double v = bias[static_cast<size_t>(ei * inter + ni)];
         squared[static_cast<size_t>(ni)] += v * v;
       }
     }
@@ -13185,35 +13547,41 @@ std::optional<std::vector<int64_t>> QMoEBlockAlignedKeep(
   return keep;
 }
 
-// Per-expert row (axis 1) index-select of a FLOAT tensor shaped `[E, N]`
-// (`force_rank3 == false`, `row_width` always 1) or `[E, N, row_width]`
-// (`force_rank3 == true`) -- used for `fc1/fc2_experts_bias` (always
-// rank-2) and, for `quant_type='int'`, `fc1/fc2_scales` (rank-2 whole-row,
-// rank-3 blockwise). `force_rank3` is passed explicitly by the caller
-// rather than inferred from `row_width == 1` -- `row_width` (`hidden_blocks`
-// for `fc1_scales`) can genuinely equal 1 in the BLOCKWISE case too
-// (`hidden_size == block_size`), which must still come back rank-3 (a real
-// shape this op's own schema documents, re-confirmed live in pruning.py's
-// own section comment) rather than collapsing to the whole-row tensor's
-// own rank-2 shape.
+// Per-expert row (axis 1) index-select of a FLOAT/FLOAT16/BFLOAT16 tensor
+// shaped `[E, N]` (`force_rank3 == false`, `row_width` always 1) or `[E, N,
+// row_width]` (`force_rank3 == true`) -- used for `fc1/fc2_experts_bias`
+// (always rank-2) and, for `quant_type='int'`, `fc1/fc2_scales` (rank-2
+// whole-row, rank-3 blockwise) -- every one of which pruning.py's own
+// `_match_qmoe_producer`/`_optional_float` admits as FLOAT, FLOAT16, or
+// BFLOAT16 (`_is_supported_float_dtype`; see IsSupportedFloatDtype), so this
+// reads/writes via ReadTensorAsF64/WriteF64TensorAs (preserving `t`'s own
+// original dtype) rather than ReadFloatTensor/SetFloatTensorData.
+// `force_rank3` is passed explicitly by the caller rather than inferred
+// from `row_width == 1` -- `row_width` (`hidden_blocks` for `fc1_scales`)
+// can genuinely equal 1 in the BLOCKWISE case too (`hidden_size ==
+// block_size`), which must still come back rank-3 (a real shape this op's
+// own schema documents, re-confirmed live in pruning.py's own section
+// comment) rather than collapsing to the whole-row tensor's own rank-2
+// shape.
 void QMoESliceFloatAxis1(onnx::TensorProto* t, int64_t e, int64_t n,
                          int64_t row_width, const std::vector<int64_t>& keep,
                          bool force_rank3) {
-  const std::vector<float> data = ReadFloatTensor(*t);  // [E, N, row_width]
+  const int32_t dtype = t->data_type();
+  const std::vector<double> data = ReadTensorAsF64(*t);  // [E, N, row_width]
   const int64_t kc = static_cast<int64_t>(keep.size());
-  std::vector<float> out(static_cast<size_t>(e * kc * row_width));
+  std::vector<double> out(static_cast<size_t>(e * kc * row_width));
   for (int64_t ei = 0; ei < e; ++ei) {
     for (int64_t i = 0; i < kc; ++i) {
       std::memcpy(
           out.data() + (ei * kc + i) * row_width,
           data.data() + (ei * n + keep[static_cast<size_t>(i)]) * row_width,
-          static_cast<size_t>(row_width) * sizeof(float));
+          static_cast<size_t>(row_width) * sizeof(double));
     }
   }
   const std::vector<int64_t> dims = force_rank3
                                         ? std::vector<int64_t>{e, kc, row_width}
                                         : std::vector<int64_t>{e, kc};
-  SetFloatTensorData(t, dims, out);
+  WriteF64TensorAs(t, dtype, dims, out);
 }
 
 // The FLOAT8E4M3FN analogue of QMoESliceFloatAxis1 -- used for
@@ -13259,25 +13627,28 @@ void QMoESliceUint8Axis1(onnx::TensorProto* t, int64_t e, int64_t n,
 }
 
 // Per-expert, per-`hidden_size`-row, LAST-axis (block-index) select of a
-// FLOAT tensor shaped `[E, hidden, num_blocks]` -- `quant_type='int'`'s own
-// `fc2_scales` in the blockwise case, sliced by *block* index
-// (`keep_block_idx`), not channel index, since `fc2`'s own blocks group
-// along `inter_size` (this pass's own pruned axis) -- see this section's
-// own top comment.
+// FLOAT/FLOAT16/BFLOAT16 tensor shaped `[E, hidden, num_blocks]` --
+// `quant_type='int'`'s own `fc2_scales` in the blockwise case, sliced by
+// *block* index (`keep_block_idx`), not channel index, since `fc2`'s own
+// blocks group along `inter_size` (this pass's own pruned axis) -- see this
+// section's own top comment. Reads/writes via ReadTensorAsF64/
+// WriteF64TensorAs (preserving `t`'s own original dtype), mirroring
+// QMoESliceFloatAxis1's own identical widening.
 void QMoESliceFloatAxis2(onnx::TensorProto* t, int64_t e, int64_t hidden,
                          int64_t num_blocks,
                          const std::vector<int64_t>& keep_block_idx) {
-  const std::vector<float> data =
-      ReadFloatTensor(*t);  // [E, hidden, num_blocks]
+  const int32_t dtype = t->data_type();
+  const std::vector<double> data =
+      ReadTensorAsF64(*t);  // [E, hidden, num_blocks]
   const int64_t kb = static_cast<int64_t>(keep_block_idx.size());
-  std::vector<float> out(static_cast<size_t>(e * hidden * kb));
+  std::vector<double> out(static_cast<size_t>(e * hidden * kb));
   for (int64_t r = 0; r < e * hidden; ++r) {
     for (int64_t i = 0; i < kb; ++i) {
       out[static_cast<size_t>(r * kb + i)] = data[static_cast<size_t>(
           r * num_blocks + keep_block_idx[static_cast<size_t>(i)])];
     }
   }
-  SetFloatTensorData(t, {e, hidden, kb}, out);
+  WriteF64TensorAs(t, dtype, {e, hidden, kb}, out);
 }
 
 // The FLOAT8E4M3FN analogue of QMoESliceFloatAxis2 -- `quant_type='nvfp4'`'s
@@ -13624,7 +13995,7 @@ std::optional<QMoEExpertChain> MatchQMoEWholeExpertProducer(
   if (rit == node_by_output.end()) {
     return std::nullopt;
   }
-  auto router_info = MatchProducer(*rit->second, init_map);
+  auto router_info = MatchMoeRouterProducer(*rit->second, init_map);
   if (!router_info) {
     return std::nullopt;
   }
@@ -13696,17 +14067,18 @@ std::vector<QMoEExpertChain> FindQMoEWholeExpertChains(
 
 // Generic per-expert (axis-0) index-select for any QMoE per-expert tensor's
 // own leading `num_experts` axis, dtype-dispatched over every element dtype
-// this pass' matched tensors can carry (FLOAT -- `fc1`/`fc2_scale` for
-// `quant_type='int'`, biases, `quant_type='nvfp4'`'s own `global_scale`;
-// UINT8 -- `fc1`/`fc2` packed weights and `quant_type='int'` zero_points;
-// FLOAT8E4M3FN -- `fc1`/`fc2_scale` for `quant_type='nvfp4'`). Mirrors
-// pruning.py's own `_slice_axis(init, keep, axis=0)` used throughout
-// `_apply_qmoe_whole_expert_chains`. Never touches packing -- this pass'
-// own pruned axis (`num_experts`) is never the packed one for ANY of these
-// tensors (see this section's own top comment) -- so this is always a
-// plain raw-element index-select, unlike ApplyQMoEChannelChains' own
-// per-tensor packing-aware slicing (QMoESliceUint8Axis1/QMoESliceFloatAxis2/
-// etc.).
+// this pass' matched tensors can carry (FLOAT/FLOAT16/BFLOAT16 -- `fc1`/
+// `fc2_scale` for `quant_type='int'`, biases, `quant_type='nvfp4'`'s own
+// `global_scale`; UINT8 -- `fc1`/`fc2` packed weights and `quant_type='int'`
+// zero_points; FLOAT8E4M3FN -- `fc1`/`fc2_scale` for `quant_type='nvfp4'`).
+// Mirrors pruning.py's own `_slice_axis(init, keep, axis=0)` used throughout
+// `_apply_qmoe_whole_expert_chains` -- including its own
+// `_is_supported_float_dtype` widening for the FLOAT-family case (see
+// IsSupportedFloatDtype). Never touches packing -- this pass' own pruned
+// axis (`num_experts`) is never the packed one for ANY of these tensors
+// (see this section's own top comment) -- so this is always a plain
+// raw-element index-select, unlike ApplyQMoEChannelChains' own per-tensor
+// packing-aware slicing (QMoESliceUint8Axis1/QMoESliceFloatAxis2/etc.).
 void QMoESliceExpertAxis0(onnx::TensorProto* t,
                           const std::vector<int64_t>& keep) {
   std::vector<int64_t> dims(t->dims().begin(), t->dims().end());
@@ -13718,13 +14090,14 @@ void QMoESliceExpertAxis0(onnx::TensorProto* t,
   if (!new_dims.empty()) {
     new_dims[0] = static_cast<int64_t>(keep.size());
   }
+  if (IsSupportedFloatDtype(t->data_type())) {
+    const int32_t dtype = t->data_type();
+    const std::vector<double> data = ReadTensorAsF64(*t);
+    const std::vector<double> out = SliceAxis0(data, dims[0], inner, keep);
+    WriteF64TensorAs(t, dtype, new_dims, out);
+    return;
+  }
   switch (t->data_type()) {
-    case onnx::TensorProto::FLOAT: {
-      const std::vector<float> data = ReadFloatTensor(*t);
-      const std::vector<float> out = SliceAxis0(data, dims[0], inner, keep);
-      SetFloatTensorData(t, new_dims, out);
-      break;
-    }
     case onnx::TensorProto::UINT8: {
       const std::vector<uint8_t> data = ReadUint8Tensor(*t);
       std::vector<uint8_t> out(keep.size() * static_cast<size_t>(inner));
@@ -13815,7 +14188,8 @@ std::vector<double> QMoEExpertWeightImportance(const QMoEExpertChain& chain,
     squared[static_cast<size_t>(ei)] = sq;
   }
   if (chain.fc1_bias) {
-    const std::vector<float> b = ReadFloatTensor(*init_map.at(*chain.fc1_bias));
+    const std::vector<double> b =
+        ReadTensorAsF64(*init_map.at(*chain.fc1_bias));
     for (int64_t ei = 0; ei < e; ++ei) {
       double sq = 0.0;
       for (int64_t j = 0; j < inter; ++j) {
@@ -13912,10 +14286,10 @@ std::unordered_set<std::string> ApplyQMoEWholeExpertChains(
       }
     }
 
-    SliceProducerWeight(init_map.at(chain.router_w), chain.router_w_transposed,
-                        keep, false);
+    SliceMoeRouterWeight(init_map.at(chain.router_w), chain.router_w_transposed,
+                         keep);
     if (chain.router_b) {
-      SliceLastAxis(init_map.at(*chain.router_b), keep);
+      SliceMoeRouterBias(init_map.at(*chain.router_b), keep);
     }
 
     stale_value_info.insert(chain.router_probs);
@@ -17656,8 +18030,13 @@ std::unordered_map<std::string, std::vector<double>> WandaCalibrationStats(
 // comment) chains -- oblivious to whether the node consuming that
 // `router_probs` is `MoE` or `QMoE`, exactly like pruning.py's own
 // `_HasRouterProbs` structural-typing trick (`router_probs` is always a
-// plain 2-D `[tokens, num_experts]` FLOAT tensor produced upstream of
-// either node's own family-specific machinery).
+// plain 2-D `[tokens, num_experts]` FLOAT/FLOAT16/BFLOAT16 tensor produced
+// upstream of either node's own family-specific machinery -- a Gemm/MatMul
+// router projection's own output dtype follows its own input dtypes, so a
+// FLOAT16/BFLOAT16-widened router weight, per this file's own MoE/QMoE
+// section top comment, produces a FLOAT16/BFLOAT16 `router_probs` too;
+// IsSupportedFloatDtype below accepts all three, matching pruning.py's own
+// unconditional `np.asarray(..., dtype=np.float64)` here).
 //
 // For each batch: `shifted = logits - logits.max(axis=-1, keepdims=True);
 // probs = softmax(shifted); sum_prob[name] += probs.sum(axis=0)` -- the
@@ -17666,11 +18045,12 @@ std::unordered_map<std::string, std::vector<double>> WandaCalibrationStats(
 // token count gives the TRUE mean over every token across every batch, not
 // an average-of-per-batch-averages (differs whenever batches have unequal
 // token counts). A probe never observed with rank exactly 2 (calibration_
-// data=[], or an unexpected activation rank) is simply absent from the
-// result, mirroring pruning.py's own `if logits.ndim != 2: continue` --
-// exactly the "no matching activation observed" condition
-// ApplyMoeWholeExpertChains/ApplyQMoEWholeExpertChains' own caller-supplied
-// `compute_importance` closure falls back to weight-norm importance on.
+// data=[], an unsupported dtype, or an unexpected activation rank) is
+// simply absent from the result, mirroring pruning.py's own `if logits.ndim
+// != 2: continue` -- exactly the "no matching activation observed"
+// condition ApplyMoeWholeExpertChains/ApplyQMoEWholeExpertChains' own
+// caller-supplied `compute_importance` closure falls back to weight-norm
+// importance on.
 std::unordered_map<std::string, std::vector<double>>
 MoeRouterGateCalibrationStats(
     const ModelExecutor& executor, const onnx::ModelProto& model,
@@ -17735,11 +18115,20 @@ MoeRouterGateCalibrationStats(
       }
       const DLTensor& dl = outputs[oit->second]->dl_tensor;
       onnx::TensorProto tp = onnxsim::dlpack::ToTensorProto(dl);
-      if (tp.data_type() != onnx::TensorProto::FLOAT) {
-        continue;  // Scope decision mirroring WandaCalibrationStats' own --
-                   // every chain this pass matches has a plain FLOAT
-                   // router_probs whenever the executor runs the real graph
-                   // ops faithfully.
+      if (!IsSupportedFloatDtype(tp.data_type())) {
+        continue;  // pruning.py's own `_moe_router_gate_calibration_stats`
+                   // has no dtype gate at all here (`np.asarray(...,
+                   // dtype=np.float64)` converts unconditionally) --
+                   // `router_probs` is FLOAT/FLOAT16/BFLOAT16 whenever the
+                   // matched MoE/QMoE node's own upstream router weight is
+                   // (a Gemm/MatMul's own output dtype follows its input
+                   // dtypes), so gating this to FLOAT-only would silently
+                   // fall back to weight-norm-only importance for every
+                   // FLOAT16/BFLOAT16 whole-expert model instead of the
+                   // real calibration-based ranking -- exactly the
+                   // FLOAT16/BFLOAT16 gap this file's own MoE/QMoE section
+                   // top comment (IsSupportedFloatDtype) closes elsewhere;
+                   // closed here too, rather than only for the matcher.
       }
       if (tp.dims_size() != 2) {
         continue;  // router_probs is always documented 2-D; skip if not.
@@ -17750,7 +18139,7 @@ MoeRouterGateCalibrationStats(
         continue;
       }
 
-      std::vector<float> data = ReadFloatTensor(tp);
+      std::vector<double> data = ReadTensorAsF64(tp);
       auto& acc = sum_prob[name];
       if (acc.empty()) {
         acc.assign(static_cast<size_t>(experts), 0.0);
@@ -17762,15 +18151,15 @@ MoeRouterGateCalibrationStats(
                    // of bounds.
       }
       for (int64_t t = 0; t < tokens; ++t) {
-        const float* row = data.data() + t * experts;
-        double max_v = static_cast<double>(row[0]);
+        const double* row = data.data() + t * experts;
+        double max_v = row[0];
         for (int64_t x = 1; x < experts; ++x) {
-          max_v = std::max(max_v, static_cast<double>(row[x]));
+          max_v = std::max(max_v, row[x]);
         }
         double sum_exp = 0.0;
         std::vector<double> exp_row(static_cast<size_t>(experts));
         for (int64_t x = 0; x < experts; ++x) {
-          const double e = std::exp(static_cast<double>(row[x]) - max_v);
+          const double e = std::exp(row[x] - max_v);
           exp_row[static_cast<size_t>(x)] = e;
           sum_exp += e;
         }

--- a/onnxsim/structured_pruning_entry.h
+++ b/onnxsim/structured_pruning_entry.h
@@ -172,9 +172,10 @@ struct EmbeddingVocabPruningResult {
 // `GemmFastGelu` -- and only ever admits a plain FLOAT (float32) embedding
 // table/lm_head weight/bias, not also FLOAT16/BFLOAT16, matching this
 // file's own established narrower-than-pruning.py C++-port scope decision
-// elsewhere (e.g. `ApplyMoeExpertChannelPruning`'s own FLOAT32-only
-// restriction). See structured_pruning_entry.cpp's own section comment for
-// the full list of deliberately out-of-scope shapes and why.
+// elsewhere (e.g. the "MatMulNBits" section's own FLOAT32-only restriction
+// on its scales/zero_points/bias tensors). See structured_pruning_entry.cpp's
+// own section comment for the full list of deliberately out-of-scope shapes
+// and why.
 EmbeddingVocabPruningResult ApplyEmbeddingVocabPruning(
     const onnx::ModelProto& model,
     const std::optional<std::vector<int64_t>>& keep_token_ids,
@@ -377,8 +378,9 @@ onnx::ModelProto ApplyTransformerBlockPruning(
 // `com.microsoft::Attention` node's constant 2-D FLOAT32 merged QKV weight
 // (MatchAttentionProducer). Deliberately narrower than pruning.py's own
 // `apply_sparsegpt_pruning` in two ways, both mirroring this file's own
-// already-established C++-port scope decisions elsewhere (e.g.
-// ApplyMoeExpertChannelPruning's own FLOAT32-only restriction):
+// already-established C++-port scope decisions elsewhere (e.g. the
+// "MatMulNBits" section's own FLOAT32-only restriction on its scales/
+// zero_points/bias tensors):
 //   - FLOAT32 only, not also FLOAT16/BFLOAT16.
 //   - 2-D `Conv` (ordinary/depthwise/general-grouped) is NOT matched at
 //     all -- pruning.py's own Conv support needs an entirely new, from-

--- a/onnxsim/structured_pruning_entry.h
+++ b/onnxsim/structured_pruning_entry.h
@@ -165,16 +165,17 @@ struct EmbeddingVocabPruningResult {
 // If/Loop/Scan/BeamSearch-family subgraphs, at any depth -- see
 // `IterSubgraphs`).
 //
-// Unlike pruning.py's own version, this port only ever matches a plain
-// `Gather` producer -- not `com.microsoft::EmbedLayerNormalization` or
-// `com.microsoft::GatherBlockQuantized` -- and only ever matches a bare
-// `MatMul`/vanilla-`Gemm` `lm_head` -- not `com.microsoft::FusedGemm`/
-// `GemmFastGelu` -- and only ever admits a plain FLOAT (float32) embedding
-// table/lm_head weight/bias, not also FLOAT16/BFLOAT16, matching this
-// file's own established narrower-than-pruning.py C++-port scope decision
-// elsewhere (e.g. `ApplyMoeExpertChannelPruning`'s own FLOAT32-only
-// restriction). See structured_pruning_entry.cpp's own section comment for
-// the full list of deliberately out-of-scope shapes and why.
+// Unlike pruning.py's own version, this port still only ever matches a
+// plain `Gather` or `com.microsoft::EmbedLayerNormalization` producer --
+// not `com.microsoft::GatherBlockQuantized` (the block-quantized embedding
+// shape -- a genuine remaining scope gap, deliberately left open; see
+// structured_pruning_entry.cpp's own section comment for exactly why).
+// `lm_head` auto-detection recognizes `MatMul`/vanilla `Gemm`/
+// `com.microsoft::FusedGemm`/`GemmFastGelu`, and the embedding table/
+// `lm_head` weight/bias may be FLOAT, FLOAT16, OR BFLOAT16 -- both now
+// match pruning.py's own scope exactly. See structured_pruning_entry.cpp's
+// own section comment for the full matched topology and the one remaining
+// out-of-scope shape.
 EmbeddingVocabPruningResult ApplyEmbeddingVocabPruning(
     const onnx::ModelProto& model,
     const std::optional<std::vector<int64_t>>& keep_token_ids,

--- a/tests/test_embedding_vocab_pruning_cpp.py
+++ b/tests/test_embedding_vocab_pruning_cpp.py
@@ -14,22 +14,26 @@ dropped token ids + an old-id -> new-id remapping), never a bare
 
 Tests here mirror ``tests/test_pruning.py``'s own "Embedding / lm_head
 vocabulary pruning" coverage (search that section name there), restricted to
-what this C++ port actually recognizes: a plain ``Gather`` producer (never
-``com.microsoft::EmbedLayerNormalization``/``GatherBlockQuantized``, both out
-of scope for this port -- see structured_pruning_entry.cpp's own section
-comment), and a bare ``MatMul``/vanilla-``Gemm`` ``lm_head`` (never
-``com.microsoft::FusedGemm``/``GemmFastGelu``). Every test that actually
-prunes something either runs the result through a real onnxruntime CPU
-session and compares against a numpy slice of the ORIGINAL model's own
-output (the same "byte-exact oracle" bar every other C++-port test file in
-this repo holds itself to), or cross-checks against the pure-Python
-``onnxsim.apply_embedding_vocab_pruning``/``apply_embedding_vocab_magnitude_
-pruning`` entry points as a second, independently-implemented oracle.
+what this C++ port actually recognizes: a plain ``Gather`` producer OR a
+``com.microsoft::EmbedLayerNormalization`` one (``com.microsoft::
+GatherBlockQuantized`` is still out of scope for this port -- see
+structured_pruning_entry.cpp's own section comment for why), a ``MatMul``/
+vanilla-``Gemm``/``com.microsoft::FusedGemm``/``GemmFastGelu`` ``lm_head``,
+and a FLOAT, FLOAT16, OR BFLOAT16 embedding table/``lm_head`` weight/bias.
+Every test that actually prunes something either runs the result through a
+real onnxruntime CPU session and compares against a numpy slice of the
+ORIGINAL model's own output (the same "byte-exact oracle" bar every other
+C++-port test file in this repo holds itself to), or cross-checks against
+the pure-Python ``onnxsim.apply_embedding_vocab_pruning``/
+``apply_embedding_vocab_magnitude_pruning`` entry points as a second,
+independently-implemented oracle.
 """
 
+import ml_dtypes
 import numpy as np
 import onnx
 import onnx.checker
+import onnx.helper
 import onnx.numpy_helper
 import pytest
 from onnx import parser
@@ -57,6 +61,14 @@ def _model(body, initializer=(), opset=21):
 
 def _f32(array, name):
     return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _f16(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float16), name)
+
+
+def _bf16(array, name):
+    return onnx.numpy_helper.from_array(array.astype(ml_dtypes.bfloat16), name)
 
 
 def _run(model, feeds):
@@ -559,3 +571,422 @@ def test_magnitude_pruning_declines_when_no_embedding_pattern_exists():
     result = onnxsim.apply_embedding_vocab_magnitude_pruning_cpp(model, sparsity=0.3)
     assert result.matched is False
     assert result.model.SerializeToString() == model.SerializeToString()
+
+
+# --- EmbedLayerNormalization producer shape ---------------------------------
+#
+# The fused ``com.microsoft::EmbedLayerNormalization`` producer shape (see
+# ``onnxsim/pruning.py``'s own `_match_embed_layer_norm_producer` docstring
+# and structured_pruning_entry.cpp's own `MatchEmbedLayerNormProducer`) --
+# newly matched by this C++ port. ``EmbedLayerNormalization`` has a real CPU
+# kernel in this environment (confirmed directly), so no decomposed-proxy
+# fallback is needed here, unlike the GemmFastGelu lm_head tests below.
+
+
+def _embed_layer_norm_model(word_emb, pos_emb, gamma, beta, batch=2, seq=3):
+    H = word_emb.shape[1]
+    model = _model(
+        f"""
+        g (int32[{batch},{seq}] input_ids) =>
+           (float[{batch},{seq},{H}] output, int32[{batch}] mask_index)
+        {{
+          output, mask_index = com.microsoft.EmbedLayerNormalization<epsilon=1e-12>(
+              input_ids, , word_embedding, position_embedding, , gamma, beta)
+        }}
+        """,
+        initializer=[
+            _f32(word_emb, "word_embedding"),
+            _f32(pos_emb, "position_embedding"),
+            _f32(gamma, "gamma"),
+            _f32(beta, "beta"),
+        ],
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+    return model
+
+
+def test_embed_layer_norm_word_embedding_matches_oracle_and_ort_execution():
+    V, P, H = 12, 16, 8
+    rng = np.random.default_rng(201)
+    word_emb = rng.standard_normal((V, H)).astype(np.float32)
+    pos_emb = rng.standard_normal((P, H)).astype(np.float32)
+    gamma = rng.standard_normal(H).astype(np.float32) * 0.5 + 1.0
+    beta = rng.standard_normal(H).astype(np.float32) * 0.1
+
+    model = _embed_layer_norm_model(word_emb, pos_emb, gamma, beta)
+    onnx.checker.check_model(model)
+
+    keep_token_ids = [1, 3, 4, 6, 8, 9, 11]
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(
+        model, keep_token_ids=keep_token_ids
+    )
+    onnx.checker.check_model(result.model)
+    assert result.matched
+    assert not result.lm_head_pruned
+    assert result.kept_token_ids == keep_token_ids
+
+    inits = {t.name: t for t in result.model.graph.initializer}
+    assert list(inits["word_embedding"].dims) == [len(keep_token_ids), H]
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["word_embedding"]), word_emb[keep_token_ids]
+    )
+    # position_embedding/gamma/beta: a different index space / not
+    # vocab-shaped at all -- must be left byte-identical, untouched.
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["position_embedding"]), pos_emb
+    )
+    np.testing.assert_array_equal(onnx.numpy_helper.to_array(inits["gamma"]), gamma)
+    np.testing.assert_array_equal(onnx.numpy_helper.to_array(inits["beta"]), beta)
+
+    # Independent reference model built directly from the pre-sliced
+    # word_embedding, never touching this pass's own matching/slicing code.
+    ref_model = _embed_layer_norm_model(word_emb[keep_token_ids], pos_emb, gamma, beta)
+    orig_ids = np.array([[1, 3, 4], [6, 8, 9]], dtype=np.int32)
+    local_ids = np.array(
+        [[result.id_map[int(t)] for t in row] for row in orig_ids], dtype=np.int32
+    )
+    pruned_out, _ = _run(result.model, {"input_ids": local_ids})
+    ref_out, _ = _run(ref_model, {"input_ids": local_ids})
+    np.testing.assert_allclose(pruned_out, ref_out, atol=1e-5, rtol=1e-5)
+
+    # Cross-check against the pure-Python entry point.
+    py_result = onnxsim.apply_embedding_vocab_pruning(
+        model, keep_token_ids=keep_token_ids
+    )
+    assert py_result.kept_token_ids == result.kept_token_ids
+    assert py_result.id_map == result.id_map
+
+
+def test_embed_layer_norm_magnitude_pruning_matches_oracle():
+    # A strictly-decreasing per-row scale gives an unambiguous ranking with
+    # no exactly-tied importances -- avoids relying on numpy's/std::stable_
+    # sort's own (potentially differing) tie-breaking, mirroring
+    # test_magnitude_pruning_matches_independent_oracle_ranking above.
+    V, P, H = 10, 8, 4
+    rng = np.random.default_rng(202)
+    scale = np.linspace(3.0, 0.1, V)
+    word_emb = (rng.standard_normal((V, H)) * scale[:, None]).astype(np.float32)
+    pos_emb = rng.standard_normal((P, H)).astype(np.float32)
+    gamma = np.ones(H, dtype=np.float32)
+    beta = np.zeros(H, dtype=np.float32)
+
+    model = _embed_layer_norm_model(word_emb, pos_emb, gamma, beta)
+    onnx.checker.check_model(model)
+
+    result = onnxsim.apply_embedding_vocab_magnitude_pruning_cpp(model, sparsity=0.3)
+    onnx.checker.check_model(result.model)
+    assert result.matched
+
+    row_norm = np.linalg.norm(word_emb.astype(np.float64), axis=1)
+    keep_count = max(1, round(V * 0.7))
+    expected_keep = sorted(np.argsort(-row_norm)[:keep_count].tolist())
+    assert result.kept_token_ids == expected_keep
+
+    py_result = onnxsim.apply_embedding_vocab_magnitude_pruning(model, sparsity=0.3)
+    assert py_result.kept_token_ids == result.kept_token_ids
+
+
+def _ambiguous_embed_layer_norm_model(V1=10, V2=8, P=6, H=4, seed=203):
+    rng = np.random.default_rng(seed)
+    w1 = rng.standard_normal((V1, H)).astype(np.float32)
+    w2 = rng.standard_normal((V2, H)).astype(np.float32)
+    pos_emb = rng.standard_normal((P, H)).astype(np.float32)
+    gamma = np.ones(H, dtype=np.float32)
+    beta = np.zeros(H, dtype=np.float32)
+    model = _model(
+        f"""
+        g (int32[2,3] input_ids_a, int32[2,3] input_ids_b) =>
+           (float[2,3,{H}] out_a, float[2,3,{H}] out_b)
+        {{
+          out_a, mask_a = com.microsoft.EmbedLayerNormalization<epsilon=1e-12>(
+              input_ids_a, , W1, Pos, , Gamma, Beta)
+          out_b, mask_b = com.microsoft.EmbedLayerNormalization<epsilon=1e-12>(
+              input_ids_b, , W2, Pos, , Gamma, Beta)
+        }}
+        """,
+        initializer=[
+            _f32(w1, "W1"),
+            _f32(w2, "W2"),
+            _f32(pos_emb, "Pos"),
+            _f32(gamma, "Gamma"),
+            _f32(beta, "Beta"),
+        ],
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+    return model
+
+
+def test_embed_layer_norm_declines_when_ambiguous_and_input_name_disambiguates():
+    model = _ambiguous_embed_layer_norm_model()
+    onnx.checker.check_model(model)
+
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(model, keep_token_ids=[0, 1, 2])
+    assert result.matched is False
+    assert result.model.SerializeToString() == model.SerializeToString()
+
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(
+        model, drop_token_ids=[4, 5], input_name="input_ids_a"
+    )
+    assert result.matched
+    assert result.kept_token_ids == [0, 1, 2, 3, 6, 7, 8, 9]
+    w2 = {t.name: t for t in result.model.graph.initializer}["W2"]
+    assert list(w2.dims) == [8, 4]  # the other producer's own table, untouched
+
+
+# --- FusedGemm / GemmFastGelu lm_head node types ----------------------------
+#
+# `lm_head` auto-detection now also recognizes `com.microsoft::FusedGemm`/
+# `GemmFastGelu` (MatchMatMulLikeWidenedRaw), not just a bare `MatMul`/
+# vanilla `Gemm`.
+
+
+def test_untied_lm_head_fusedgemm_matches_oracle_and_ort_execution():
+    # FusedGemm has a real CPU kernel in this environment, so this one runs
+    # directly (no decomposition needed), unlike GemmFastGelu below.
+    V, H = 9, 5
+    rng = np.random.default_rng(210)
+    w_emb = rng.standard_normal((V, H)).astype(np.float32)
+    w_lm = rng.standard_normal((V, H)).astype(np.float32)  # [N, K], transB=1
+    b_lm = rng.standard_normal(V).astype(np.float32)
+    model = _model(
+        f"""
+        g (int64[M] input_ids) => (float[M,{V}] logits)
+        {{
+          hidden = Gather<axis=0>(W_emb, input_ids)
+          logits = com.microsoft.FusedGemm<transB=1, activation="Relu">(hidden, W_lm, B_lm)
+        }}
+        """,
+        initializer=[_f32(w_emb, "W_emb"), _f32(w_lm, "W_lm"), _f32(b_lm, "B_lm")],
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+    onnx.checker.check_model(model)
+
+    keep_token_ids = [0, 2, 3, 5, 6, 8]
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(
+        model, keep_token_ids=keep_token_ids
+    )
+    onnx.checker.check_model(result.model)
+    assert result.matched and result.lm_head_pruned
+
+    input_ids = np.array([0, 6, 8, 2], dtype=np.int64)
+    remapped = np.array([result.id_map[i] for i in input_ids], dtype=np.int64)
+    orig_out = _run(model, {"input_ids": input_ids})[0]
+    pruned_out = _run(result.model, {"input_ids": remapped})[0]
+    expected = orig_out[..., result.kept_token_ids]
+    np.testing.assert_allclose(pruned_out, expected, atol=1e-5, rtol=1e-5)
+
+    py_result = onnxsim.apply_embedding_vocab_pruning(
+        model, keep_token_ids=keep_token_ids
+    )
+    assert py_result.kept_token_ids == result.kept_token_ids
+    assert py_result.lm_head_pruned == result.lm_head_pruned
+
+
+def _decompose_gemmfastgelu(model):
+    """Rewrites every `com.microsoft::GemmFastGelu` node into the literal
+    unfused `MatMul(X, W) -> FastGelu(h, bias?)` sequence it is byte-
+    identical to -- needed only because this environment's onnxruntime has
+    no CPU kernel for `GemmFastGelu` itself (confirmed directly: a plain
+    `InferenceSession` construction against it raises `NOT_IMPLEMENTED`),
+    mirroring ``tests/test_pruning.py``'s own `_decompose_gemmfastgelu`.
+    """
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    new_nodes = []
+    for node in out.graph.node:
+        if node.op_type != "GemmFastGelu" or node.domain != "com.microsoft":
+            new_nodes.append(node)
+            continue
+        x_name, w_name = node.input[0], node.input[1]
+        bias_name = node.input[2] if len(node.input) == 3 and node.input[2] else None
+        (y_name,) = node.output
+        h_name = f"{y_name}__gemmfastgelu_h"
+        new_nodes.append(onnx.helper.make_node("MatMul", [x_name, w_name], [h_name]))
+        fastgelu_inputs = [h_name, bias_name] if bias_name else [h_name]
+        new_nodes.append(
+            onnx.helper.make_node(
+                "FastGelu", fastgelu_inputs, [y_name], domain="com.microsoft"
+            )
+        )
+    del out.graph.node[:]
+    out.graph.node.extend(new_nodes)
+    return out
+
+
+def test_untied_lm_head_gemmfastgelu_matches_oracle_via_decompose():
+    V, H = 10, 6
+    rng = np.random.default_rng(211)
+    w_emb = rng.standard_normal((V, H)).astype(np.float32)
+    w_lm = rng.standard_normal((H, V)).astype(np.float32)  # [K, N], no transpose
+    b_lm = rng.standard_normal(V).astype(np.float32)
+    model = _model(
+        f"""
+        g (int64[M] input_ids) => (float[M,{V}] logits)
+        {{
+          hidden = Gather<axis=0>(W_emb, input_ids)
+          logits = com.microsoft.GemmFastGelu(hidden, W_lm, B_lm)
+        }}
+        """,
+        initializer=[_f32(w_emb, "W_emb"), _f32(w_lm, "W_lm"), _f32(b_lm, "B_lm")],
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+    onnx.checker.check_model(model)
+
+    keep_token_ids = [0, 1, 3, 5, 8, 9]
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(
+        model, keep_token_ids=keep_token_ids
+    )
+    onnx.checker.check_model(result.model)
+    assert result.matched and result.lm_head_pruned
+
+    lm_init = {t.name: t for t in result.model.graph.initializer}["W_lm"]
+    assert list(lm_init.dims) == [H, len(keep_token_ids)]
+
+    input_ids = np.array([0, 5, 9, 8], dtype=np.int64)
+    remapped = np.array([result.id_map[i] for i in input_ids], dtype=np.int64)
+    orig_out = _run(_decompose_gemmfastgelu(model), {"input_ids": input_ids})[0]
+    pruned_out = _run(_decompose_gemmfastgelu(result.model), {"input_ids": remapped})[0]
+    expected = orig_out[..., result.kept_token_ids]
+    np.testing.assert_allclose(pruned_out, expected, atol=1e-5, rtol=1e-5)
+
+    py_result = onnxsim.apply_embedding_vocab_pruning(
+        model, keep_token_ids=keep_token_ids
+    )
+    assert py_result.kept_token_ids == result.kept_token_ids
+    assert py_result.lm_head_pruned == result.lm_head_pruned
+
+
+# --- FLOAT16 / BFLOAT16 embedding table --------------------------------------
+#
+# FLOAT16 has a real onnxruntime CPU kernel here, so its own test runs the
+# pruned model through a real session; BFLOAT16 has none (confirmed
+# directly, mirroring tests/test_pruning.py's own "FP16/BFloat16 weight
+# support" section comment), so its own test checks correctness at the
+# array level (dtype preservation, exact per-element decode via
+# ``ml_dtypes.bfloat16``) instead.
+
+
+def test_fp16_embedding_and_lm_head_matches_ort_execution_and_preserves_bits():
+    V, H = 10, 6
+    rng = np.random.default_rng(220)
+    w_emb = (rng.standard_normal((V, H)) * 0.5).astype(np.float16)
+    w_lm = (rng.standard_normal((H, V)) * 0.5).astype(np.float16)
+    model = _model(
+        f"""
+        g (int64[M] input_ids) => (float16[M,{V}] logits)
+        {{
+          hidden = Gather<axis=0>(W_emb, input_ids)
+          logits = MatMul(hidden, W_lm)
+        }}
+        """,
+        initializer=[_f16(w_emb, "W_emb"), _f16(w_lm, "W_lm")],
+    )
+    onnx.checker.check_model(model)
+
+    keep_token_ids = [0, 2, 4, 6, 8, 9]
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(
+        model, keep_token_ids=keep_token_ids
+    )
+    onnx.checker.check_model(result.model)
+    assert result.matched and result.lm_head_pruned
+
+    inits = {t.name: t for t in result.model.graph.initializer}
+    assert inits["W_emb"].data_type == onnx.TensorProto.FLOAT16
+    assert inits["W_lm"].data_type == onnx.TensorProto.FLOAT16
+    # Value-preserving slice -- every surviving row/column must reproduce
+    # the exact original fp16 bit pattern, not a re-rounded one.
+    emb_new = onnx.numpy_helper.to_array(inits["W_emb"])
+    np.testing.assert_array_equal(
+        emb_new.view(np.uint16), w_emb[keep_token_ids].view(np.uint16)
+    )
+    lm_new = onnx.numpy_helper.to_array(inits["W_lm"])
+    np.testing.assert_array_equal(
+        lm_new.view(np.uint16), w_lm[:, keep_token_ids].view(np.uint16)
+    )
+
+    input_ids = np.array([0, 8, 4, 9], dtype=np.int64)
+    remapped = np.array([result.id_map[i] for i in input_ids], dtype=np.int64)
+    orig_out = _run(model, {"input_ids": input_ids})[0]
+    pruned_out = _run(result.model, {"input_ids": remapped})[0]
+    expected = orig_out[..., result.kept_token_ids]
+    np.testing.assert_allclose(
+        pruned_out.astype(np.float32),
+        expected.astype(np.float32),
+        atol=1e-2,
+        rtol=1e-2,
+    )
+
+    py_result = onnxsim.apply_embedding_vocab_pruning(
+        model, keep_token_ids=keep_token_ids
+    )
+    assert py_result.kept_token_ids == result.kept_token_ids
+
+
+def test_bfloat16_embedding_preserves_dtype_and_matches_array_oracle():
+    # No onnxruntime CPU execution support for BFLOAT16 in this environment
+    # (confirmed directly, mirroring tests/test_pruning.py's own bfloat16
+    # tests) -- checked via ml_dtypes decode instead of a real session run.
+    V, H = 10, 6
+    rng = np.random.default_rng(221)
+    w_emb = (rng.standard_normal((V, H)) * 0.5).astype(ml_dtypes.bfloat16)
+    model = _model(
+        f"""
+        g (int64[M] input_ids) => (bfloat16[M,{H}] hidden)
+        {{
+          hidden = Gather<axis=0>(W_emb, input_ids)
+        }}
+        """,
+        initializer=[_bf16(w_emb, "W_emb")],
+    )
+    onnx.checker.check_model(model)
+
+    keep_token_ids = [0, 2, 3, 5, 7, 9]
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(
+        model, keep_token_ids=keep_token_ids
+    )
+    onnx.checker.check_model(result.model)
+    assert result.matched
+    assert not result.lm_head_pruned
+
+    emb_init = {t.name: t for t in result.model.graph.initializer}["W_emb"]
+    assert emb_init.data_type == onnx.TensorProto.BFLOAT16
+    emb_new = onnx.numpy_helper.to_array(emb_init)
+    assert emb_new.dtype == ml_dtypes.bfloat16
+    np.testing.assert_array_equal(
+        emb_new.view(np.uint16), w_emb[keep_token_ids].view(np.uint16)
+    )
+
+    py_result = onnxsim.apply_embedding_vocab_pruning(
+        model, keep_token_ids=keep_token_ids
+    )
+    assert py_result.kept_token_ids == result.kept_token_ids
+    assert py_result.id_map == result.id_map
+
+
+def test_bfloat16_magnitude_pruning_matches_array_oracle():
+    V, H = 12, 6
+    rng = np.random.default_rng(222)
+    scale = np.linspace(3.0, 0.1, V)
+    w_emb = (rng.standard_normal((V, H)) * scale[:, None]).astype(ml_dtypes.bfloat16)
+    model = _model(
+        f"""
+        g (int64[M] input_ids) => (bfloat16[M,{H}] hidden)
+        {{
+          hidden = Gather<axis=0>(W_emb, input_ids)
+        }}
+        """,
+        initializer=[_bf16(w_emb, "W_emb")],
+    )
+    onnx.checker.check_model(model)
+
+    result = onnxsim.apply_embedding_vocab_magnitude_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(result.model)
+    assert result.matched
+
+    row_norm = np.linalg.norm(w_emb.astype(np.float64), axis=1)
+    keep_count = max(1, round(V * 0.5))
+    expected_keep = sorted(np.argsort(-row_norm)[:keep_count].tolist())
+    assert result.kept_token_ids == expected_keep
+
+    py_result = onnxsim.apply_embedding_vocab_magnitude_pruning(model, sparsity=0.5)
+    assert py_result.kept_token_ids == result.kept_token_ids

--- a/tests/test_moe_pruning_cpp.py
+++ b/tests/test_moe_pruning_cpp.py
@@ -16,8 +16,24 @@ that actually prunes something runs the result through a real onnxruntime
 CPU session, exactly like the Python-side tests do: confirmed, empirically,
 to be the one real oracle available for ``com.microsoft::MoE`` in this
 environment.
+
+``onnxsim.apply_moe_expert_channel_pruning`` (the pure-Python name) is now
+itself a thin alias for :func:`onnxsim.apply_moe_expert_channel_pruning_cpp`
+(full parity verified, including FLOAT16/BFLOAT16 weights -- see
+pruning.py's own "MoE expert-intermediate-channel pruning" section
+comment), so the one test below that used to call BOTH entry points and
+compare their live outputs would be tautological (literally the same code
+path twice) if left as-is -- it now instead compares the C++ port's output
+against a golden fixture captured from the real pure-Python implementation
+*before* it was deleted (see ``_GOLDEN_*`` below, base64-encoded serialized
+``ModelProto`` bytes, inlined directly per this repo's own established
+convention -- see ``tests/test_transformer_block_pruning_cpp.py``'s own
+identical precedent/module-docstring for the full rationale).
 """
 
+import base64
+
+import ml_dtypes
 import numpy as np
 import onnx
 import onnx.helper
@@ -28,6 +44,41 @@ from onnx import parser
 import onnxsim
 
 ort = pytest.importorskip("onnxruntime")
+
+
+def _golden(b64):
+    return onnx.load_from_string(base64.b64decode(b64))
+
+
+# Frozen from onnxsim.apply_moe_expert_channel_pruning's own real pure-Python
+# implementation, on the exact model + seed
+# test_moe_expert_channel_pruning_cpp_matches_python_port builds, before
+# that implementation was deleted in favor of the C++ port (see this file's
+# own module docstring).
+_GOLDEN_MOE_EXPERT_CHANNEL_MATCHES_PYTHON_PORT = (
+    "CAo6qQkKbQoBWAoBUgoERkMxVwoERkMxQgoERkMyVwoAEgFZIgNNb0UqCAoBaxgCoAECKhoKD2Fj"
+    "dGl2YXRpb25fdHlwZSIEcmVsdaABAyoUCg1zd2lnbHVfZnVzaW9uGACgAQI6DWNvbS5taWNyb3Nv"
+    "ZnQSAWcq0QMIBAgECAcQAUIERkMxV0rAA5QdML/aq6g/2tsEv+b3Xb/aCok/c3p1v4mni79qccg/"
+    "wlsMP0PY3r7H8Qm/Sjixv3WokT/S8JA+gcImv0W7uDwU7uM/os7FvwkMHMCNPCK+zVVcP36w0b7e"
+    "yxrAdMpmv6urZr8R6/K/yoooPzTAkj6qi9u9m0lOv4zuaz6z0pe98L1DPjJDcr7hr+w+oPKavSsE"
+    "9b/39iE/bp6pPi79O78btnY/cnfpPuUwEb4o1PA+QuiHP84iTT86rqI/LgRqvyUg1b9e5BG/xAS+"
+    "v0I8uj4oOxw/AMD3PxPAcr+qwRm/MhpmP201Qz9yFQ0/TJ7QvjXLmr+6XTg/2kU9P7x2L727O+e+"
+    "COAiPrYzKj73m8G/vSHvvvp8FT8KOOK+3U48Pk9i9r5QOlq/7/1HwHM/Bb9QBES/kYBCv8ELc7+P"
+    "foG/WlPGPxX0Cz/8f5w+RfxyPxSeiD4FgNs/TeGFPlKTJ79FzTU/R641v2uihz/6E7c/LpbZPW6G"
+    "wL976SHAh8KUP1Ae8j7hw+s+ojzrvPwNlb45cMs/MeauP2sjiD4eivQ/aa3dPhfiDT+DoB8/ObzX"
+    "vhcXJz++Rhc/PeFevxIC3L8q0QMIBAgHCAQQAUIERkMyV0rAAwdW0T30Soo/dhLcvxozSD/PFbk/"
+    "ShG4v0RcnL+bu88/iMyfvmH+ZT9Ly+k/RRiGP25pHT/OfAO+XtGnP0uxPD6tVAo+6ZcDP3s6sz59"
+    "Agq/4R9RvxsOwb58872/zvmOvhCveb+IxII9sfJ0vmZPqr6t1P0/vxmDPjQ4DUCFvWC+du2ev8C2"
+    "dL/154S/Bq23PyqDIz98n1a/cee5vz3AHz/HZvY+SQpJv3MQzb0vWsQ/p7jnv0vFiD9w8mY+ZIoX"
+    "P43vmj9ASBc+WkzkvsMlJT/BgmI/cX8SP6mYnD3NuDK/qOAIQLn/cr9cRKk+kqZgv8h4K78gDO4/"
+    "8g3Pvl2Ugz/v2aO/sOylPVmpPz6BJbq+oxdFPlg3rz2LgGS/g5oIP3XDTj/k7K6+aawkv3B/8T4o"
+    "WcQ+b9D4vinHDECruBm+b2lLvxshe7/hcWc//cg/vasnBECo6Pk+VmPCPkvjZz5Zme0+Ozihv76r"
+    "bT8p872/9B4PPqJJ/z6mV7e+Iw1VP91aob+P4fK8WR16P3zYgD46nam/XoJtP8U8TL/pWta/j866"
+    "vzigFMCCHck9eXLcP81cH79iSos/gVlQP7hQgb4qTggECAQQAUIERkMxQkpA1aqNP7Kh7r69uOi+"
+    "DS6yvka8ET/VSt6+5QO/vmRaNb5dIoO/0WefP9THsr/LLpo/H02AP2ZcGr/7/ii/D7thv1oTCgFY"
+    "Eg4KDAgBEggKAggGCgIIB1oTCgFSEg4KDAgBEggKAggGCgIIBGITCgFZEg4KDAgBEggKAggGCgII"
+    "B0IECgAQEkIRCg1jb20ubWljcm9zb2Z0EAE="
+)
 
 
 def _model(body, initializer=(), opset=21):
@@ -49,6 +100,14 @@ def _model(body, initializer=(), opset=21):
 
 def _f32(array, name):
     return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _f16(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float16), name)
+
+
+def _bf16(array, name):
+    return onnx.numpy_helper.from_array(array.astype(ml_dtypes.bfloat16), name)
 
 
 def _run(model, feeds):
@@ -413,6 +472,12 @@ def test_moe_expert_channel_pruning_cpp_matches_python_port():
     # test_attention_head_pruning_cpp.py's own cross-check test -- which
     # compares execution OUTPUT, not raw tensors, for exactly this reason --
     # already document), which is not a bug in either port.
+    #
+    # ``apply_moe_expert_channel_pruning`` is now itself an alias for the
+    # C++ port (see this file's own module docstring), so this compares
+    # against a golden fixture frozen from the real pure-Python
+    # implementation instead of calling it live (which would make this
+    # tautological).
     E, hidden, inter = 4, 7, 8
     rng = np.random.default_rng(59)
     fc1_w = rng.standard_normal((E, inter, hidden)).astype(np.float32)
@@ -420,13 +485,13 @@ def test_moe_expert_channel_pruning_cpp_matches_python_port():
     fc1_b = rng.standard_normal((E, inter)).astype(np.float32)
     model = _moe_model(fc1_w, fc2_w, fc1_b=fc1_b)
 
-    pruned_py = onnxsim.apply_moe_expert_channel_pruning(model, sparsity=0.5)
+    golden = _golden(_GOLDEN_MOE_EXPERT_CHANNEL_MATCHES_PYTHON_PORT)
     pruned_cpp = onnxsim.apply_moe_expert_channel_pruning_cpp(model, sparsity=0.5)
-    inits_py = _moe_inits(pruned_py)
+    inits_golden = _moe_inits(golden)
     inits_cpp = _moe_inits(pruned_cpp)
-    np.testing.assert_array_equal(inits_py["FC1W"], inits_cpp["FC1W"])
-    np.testing.assert_array_equal(inits_py["FC2W"], inits_cpp["FC2W"])
-    np.testing.assert_array_equal(inits_py["FC1B"], inits_cpp["FC1B"])
+    np.testing.assert_array_equal(inits_golden["FC1W"], inits_cpp["FC1W"])
+    np.testing.assert_array_equal(inits_golden["FC2W"], inits_cpp["FC2W"])
+    np.testing.assert_array_equal(inits_golden["FC1B"], inits_cpp["FC1B"])
 
 
 def test_moe_expert_channel_pruning_cpp_prunes_inside_if_subgraph():
@@ -511,3 +576,152 @@ def test_moe_expert_channel_pruning_cpp_prunes_inside_if_subgraph():
         next(t for t in then_attr.g.initializer if t.name == "FC1W")
     )
     assert fc1w_pruned.shape == (E, 3, hidden)
+
+
+# --- FP16/BFloat16 weight support -------------------------------------------
+#
+# MatchMoeProducer (structured_pruning_entry.cpp) used to hard-require
+# ``onnx.TensorProto.FLOAT`` for ``fc1_experts_weights``/
+# ``fc2_experts_weights``/``fc1_experts_bias``, silently declining any MoE
+# node whose weights were stored as FLOAT16 or BFLOAT16 -- narrower than
+# ``onnxsim.apply_moe_expert_channel_pruning``'s own ``_is_supported_float_
+# dtype`` (see that module's own "FP16/BFloat16 weight support" section
+# comment). Now widened via IsSupportedFloatDtype/ReadTensorAsF64/
+# WriteF64TensorAs (see structured_pruning_entry.cpp's own "MoE
+# expert-intermediate-channel pruning" section top comment) -- these two
+# tests mirror tests/test_pruning.py's own
+# ``test_moe_expert_channel_pruning_fp16_matches_ort_masking_oracle``/
+# BFLOAT16 array-oracle tests, against the C++-backed entry point.
+#
+# FLOAT16: onnxruntime's CPU MoE kernel genuinely executes FLOAT16 (confirmed
+# separately, same as the pure-Python test suite), so this runs a real
+# session. BFLOAT16 has no onnxruntime CPU execution support in this
+# environment at all (a plain BFLOAT16 MatMul session raises NOT_IMPLEMENTED
+# at session-creation time) -- so that test checks correctness at the array
+# level (dtype preservation, exact per-element bfloat16 decode) instead.
+
+
+def test_moe_expert_channel_pruning_cpp_fp16_matches_ort_masking_oracle():
+    E, hidden, inter, tokens, k = 5, 10, 12, 6, 2
+    rng = np.random.default_rng(1009)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float16)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float16)
+
+    model = _model(
+        f"""
+        g (float16[{tokens},{hidden}] X, float16[{tokens},{E}] R) => (float16[{tokens},{hidden}] Y)
+        {{
+          Y = com.microsoft.MoE <k={k}, activation_type="relu"> (X, R, FC1W, , FC2W)
+        }}
+        """,
+        initializer=[_f16(fc1_w, "FC1W"), _f16(fc2_w, "FC2W")],
+        opset=18,
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_moe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert inits["FC1W"].data_type == onnx.TensorProto.FLOAT16
+    assert list(inits["FC1W"].dims) == [E, 6, hidden]
+
+    fc1_w64 = fc1_w.astype(np.float64)
+    fc2_w64 = fc2_w.astype(np.float64)
+    sq = np.sum(fc1_w64**2, axis=(0, 2)) + np.sum(fc2_w64**2, axis=(0, 1))
+    keep = np.sort(np.argsort(-np.sqrt(sq))[:6])
+
+    fc1_w_pruned = onnx.numpy_helper.to_array(inits["FC1W"])
+    fc2_w_pruned = onnx.numpy_helper.to_array(inits["FC2W"])
+    # Exact bit-pattern match (not assert_allclose) -- this pass only ever
+    # slices/reorders existing rows/columns, never recomputes a surviving
+    # value, so the round trip through float64 must reproduce the original
+    # fp16 bits exactly.
+    np.testing.assert_array_equal(
+        fc1_w_pruned.view(np.uint16), fc1_w[:, keep, :].view(np.uint16)
+    )
+    np.testing.assert_array_equal(
+        fc2_w_pruned.view(np.uint16), fc2_w[:, :, keep].view(np.uint16)
+    )
+
+    rng2 = np.random.default_rng(1010)
+    x = rng2.standard_normal((tokens, hidden)).astype(np.float16)
+    r = rng2.standard_normal((tokens, E)).astype(np.float16)
+    (y_pruned,) = _run(pruned, {"X": x, "R": r})
+    assert y_pruned.dtype == np.float16
+
+    drop = np.setdiff1d(np.arange(inter), keep)
+    fc1_masked = fc1_w64.copy()
+    fc1_masked[:, drop, :] = 0.0
+    fc2_masked = fc2_w64.copy()
+    fc2_masked[:, :, drop] = 0.0
+    masked_model = _model(
+        f"""
+        g (float16[{tokens},{hidden}] X, float16[{tokens},{E}] R) => (float16[{tokens},{hidden}] Y)
+        {{
+          Y = com.microsoft.MoE <k={k}, activation_type="relu"> (X, R, FC1W, , FC2W)
+        }}
+        """,
+        initializer=[
+            _f16(fc1_masked.astype(np.float32), "FC1W"),
+            _f16(fc2_masked.astype(np.float32), "FC2W"),
+        ],
+        opset=18,
+    )
+    masked_model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+    (y_masked,) = _run(masked_model, {"X": x, "R": r})
+    np.testing.assert_allclose(
+        y_pruned.astype(np.float64), y_masked.astype(np.float64), rtol=5e-2, atol=5e-2
+    )
+
+
+def test_moe_expert_channel_pruning_cpp_bfloat16_preserves_dtype_and_matches_array_oracle():
+    E, hidden, inter = 5, 10, 12
+    rng = np.random.default_rng(1011)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(ml_dtypes.bfloat16)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(ml_dtypes.bfloat16)
+    fc1_b = rng.standard_normal((E, inter)).astype(ml_dtypes.bfloat16)
+
+    model = _model(
+        f"""
+        g (bfloat16[batch,{hidden}] X, bfloat16[batch,{E}] R) => (bfloat16[batch,{hidden}] Y)
+        {{
+          Y = com.microsoft.MoE <k=2, activation_type="relu"> (X, R, FC1W, FC1B, FC2W)
+        }}
+        """,
+        initializer=[_bf16(fc1_w, "FC1W"), _bf16(fc1_b, "FC1B"), _bf16(fc2_w, "FC2W")],
+        opset=18,
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_moe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert inits["FC1W"].data_type == onnx.TensorProto.BFLOAT16
+    assert inits["FC2W"].data_type == onnx.TensorProto.BFLOAT16
+    assert inits["FC1B"].data_type == onnx.TensorProto.BFLOAT16
+
+    fc1_w64 = fc1_w.astype(np.float64)
+    fc2_w64 = fc2_w.astype(np.float64)
+    fc1_b64 = fc1_b.astype(np.float64)
+    sq = (
+        np.sum(fc1_w64**2, axis=(0, 2))
+        + np.sum(fc2_w64**2, axis=(0, 1))
+        + np.sum(fc1_b64**2, axis=0)
+    )
+    keep = np.sort(np.argsort(-np.sqrt(sq))[:6])
+
+    fc1_w_pruned = onnx.numpy_helper.to_array(inits["FC1W"])
+    fc2_w_pruned = onnx.numpy_helper.to_array(inits["FC2W"])
+    fc1_b_pruned = onnx.numpy_helper.to_array(inits["FC1B"])
+    assert fc1_w_pruned.dtype == ml_dtypes.bfloat16
+    np.testing.assert_array_equal(
+        fc1_w_pruned.view(np.uint16), fc1_w[:, keep, :].view(np.uint16)
+    )
+    np.testing.assert_array_equal(
+        fc2_w_pruned.view(np.uint16), fc2_w[:, :, keep].view(np.uint16)
+    )
+    np.testing.assert_array_equal(
+        fc1_b_pruned.view(np.uint16), fc1_b[:, keep].view(np.uint16)
+    )

--- a/tests/test_moe_whole_expert_pruning_cpp.py
+++ b/tests/test_moe_whole_expert_pruning_cpp.py
@@ -17,8 +17,26 @@ itself shrinks, together with the upstream router projection's own matching
 output column -- see ``onnxsim/pruning.py``'s own "MoE whole-expert pruning"
 section comment for the full masking-equivalence safety argument this port
 carries over unchanged.
+
+``onnxsim.apply_moe_whole_expert_pruning``/``onnxsim.apply_qmoe_whole_expert_
+pruning`` (the pure-Python names) are now themselves thin aliases for
+:func:`onnxsim.apply_moe_whole_expert_pruning_cpp`/:func:`onnxsim.apply_qmoe_
+whole_expert_pruning_cpp` (full parity verified, including FLOAT16/BFLOAT16
+weights and the router projection -- see pruning.py's own "MoE whole-expert
+pruning"/"QMoE whole-expert pruning" section comments), so the handful of
+tests below that used to call BOTH entry points and compare their live
+outputs would be tautological (literally the same code path twice) if left
+as-is. Those now instead compare the C++ port's output against a golden
+fixture captured from the real pure-Python implementation *before* it was
+deleted -- see ``_GOLDEN_*`` below (base64-encoded serialized ``ModelProto``
+bytes, inlined directly per this repo's own established convention -- see
+``tests/test_transformer_block_pruning_cpp.py``'s own identical precedent/
+module-docstring for the full rationale).
 """
 
+import base64
+
+import ml_dtypes
 import numpy as np
 import onnx
 import onnx.checker
@@ -30,6 +48,186 @@ from onnx import parser
 import onnxsim
 
 ort = pytest.importorskip("onnxruntime")
+
+
+def _golden(b64):
+    return onnx.load_from_string(base64.b64decode(b64))
+
+
+# Frozen from onnxsim.apply_moe_whole_expert_pruning's/onnxsim.apply_qmoe_
+# whole_expert_pruning's own real pure-Python implementations, on the exact
+# model + calibration seed each corresponding test below builds, before
+# those implementations were deleted in favor of the C++ port (see this
+# file's own module docstring).
+_GOLDEN_MOE_WHOLE_EXPERT_MATCHES_PYTHON_REFERENCE = (
+    "CAo6uxgKFgoBWAoCUlcKAlJCEgFSIgRHZW1tOgAKbgoBWAoBUgoERkMxVwoERkMxQgoERkMyVxIB"
+    "WSIDTW9FKggKAWsYAqABAioaCg9hY3RpdmF0aW9uX3R5cGUiBHJlbHWgAQMqFwoQdXNlX3NwYXJz"
+    "ZV9taXhlchgAoAECOg1jb20ubWljcm9zb2Z0EgFnKpEKCAQICAgKEAFCBEZDMVdKgAoKd16/YkIQ"
+    "P/T83j0q4J69LlUdv3YqVD6wxMQ+dKCRv22AOr9NLJQ/UMlrv6ZdPD+WPru6EhLpvnvFhT8Qu8m+"
+    "lWmLv/84L8CJSEM+cbk9P5mPgL4SXuQ8SKBgvU3rpT8PVBRABGipv5ihw79O8ANAe8aZvVJQqT24"
+    "8y4/p7zGPlkU0r4C8ye/MDjEviRjZ79g8jE/45wQQIiq+r4vmba8IQyWvyAuf78egi+/2E1UvziN"
+    "1z5DsrA/fP2DPqz/Mz1JDck/GCyEv9/jWL5eC5M/npRQv9z5Z790lqE/48a2P72QWL9ZKeC+6VWZ"
+    "v3uZrD6JugU/wj0DvzRAHz/mGms/0hCIPwKqwT+Uc+S/URqLP63jLL+KUoi/DM+/vrJHrT8DvMC/"
+    "eVt2v30drz4HmIm/qlncvG95xb49dAC/ivy8P71WjD9xo6I/xbceP3X/jz8nj4A//gorv5RKdL8q"
+    "DSg+YrSoPztlfbx25t+/Z/Fwv1UgdT+9HR87w1S7v3u/DT/ViEC+X1Dwv1gFVD7a3ic/o23pPhYW"
+    "vz+BIqY/elhaPutW+z//ZQ5AdTdDPy3Q8r5bZ1g/TYEAPjPyO7+lN9S/gIzdP3OsEj7SzNA+6F2G"
+    "Pw7pNb86eoo+HJVjPve2Rz64jXU+wm65vwmFkj+V+nK/iHcBPxwTUz83EfE+UHcbv7Y/vL81O7y/"
+    "C3kpPy7go78p5+A/qD8VQId3bD4B1yS/ob8bPZKQ6z42diFALuKsvp0ENj+I4ti/Q3WhP1j9vz65"
+    "lUK/CuNsv70rUj9b9Zm+ymJbvjv1AL+yCa8/NiO8v36frD/PQWw+XbFIvbt7iT+up2G+CLyoPokP"
+    "RD6Mlre+B+PMvg5RnD4GZ7I/0rTXv+UnGr4dcdC+4e3eP90ZoL4n8V2/OTO/PjRpzrwARc8+jE20"
+    "P6rJDj8aDJW/ZxglwMommD/lraI/qOHFP/uY6DyzIQW/09NDPr3WPD/aoxm/8cWMPhrdxr9L/KW9"
+    "zlyBPqUtiL+mKFg/vXEqP1iMHr64l52/DoWIv/Gdqr6Asb6+RpaKPpuvKz5KpLg/H1Gtv2xRcT8o"
+    "S/S++XO4vx1fuT7Zu5+/mDHbv905e77fZJY++zRivQA7hj/imk89QzkMP9Vm6r5agkm+OCDqv/QF"
+    "fL+5hUq+r5myvrcXiL4LOeQ/meWuv2vjN7/w8oe/RTxKPh8Lh74t/A6/mytOPyZ0uT+Ov2k/wkLs"
+    "vQH9e79sAsU+VhrpvuNFgb5joEG/4zofPwxzuj93CnQ/wUQFvOO0mD+idmI/SzBEvyyiRrv2qQk+"
+    "mj8RPx0dOb8QnaO/4ITBPu+oyz2dL4W+xWSsPy7qrD8rTva+G+/DPz48JMBu2LQ+uhqPvJBhqL9R"
+    "4ji/7/trPoohfTuv1Ew9qqh+v2GFEr+wOa09hA8cO4o4SD6y5NS8KN1VPxa1kL3Blma/ZxNavgyk"
+    "3T8DuI++QOhMv+khHL+w4AW/GmsYP8Kh8D7z/Uw/AjTsvdMzm74nkvs/xpF2P0zJhj+KG2C/ZsvP"
+    "PtjqRj9xfLy+91Xsv9u9aT9CIye/6o04QCrwvb/1l12+Xq5/PwAepT+ivey/BupPP+l8Br/JUba+"
+    "9xAhQLoK/77Mr5W6cXIpPlOov749JMe/26jSPxMiF78oweu/Su9wP6Djar8EA1I/ZBC4PyfWqj8M"
+    "W+A/yqK2P9UyG8Aju0g98qQKPiqRCggECAoICBABQgRGQzJXSoAKDP0Uv3OnFz+uGxG9v+MAvu26"
+    "xD/eU9S/PnIVv0zdt77aMck+QaIyv/35Rz+iqJu/NYaOPzNOVD//Zoc/6ygfvzjlH7/Gre0+YK6i"
+    "v16QFb6hT4Y/bXs6vlDEHD8i0T0/dDBivgg7Mb9M3QC/RgK6v6joXj8kJhG/M2TtPnfzWb7bMGo+"
+    "aSIbPy8xQ74P2kU/8nNgvzk+TLw029y+ecYVv7d4aD/bgCA7BIrZv15NkjyRRfU+SFIJv5wCSb8W"
+    "KsI9QoELQEw2Dj9th3o+TlKSP/BdFT9mij4+Zs8KP1Aggj+lkG2+RZwlv5ZJXb8miss/YnNnP/f+"
+    "f7/SpKU/5pMLP0uWfr90fI+9bZuGP+6/jz94mqU+Qjqgv1psUMDaIpm+7P+Iv9RyKT+1JNM/lp2J"
+    "P6Jbh7+Qrm+/UU6rPdvuyb8iG3o+80uzP4dYuT5qMw0/+ef3vhlUYz+fxzg+UgYSP2iN9T62fWg/"
+    "wl07P809Vb0MRQw+OMGJv1yWqL+RdrA+YoUgvscnJ7465LI+xMn9PdFk0r8Jywo+Yh4LwDqGqT5j"
+    "yzG/RGkJQAI8lL7tcAK+putxv6q4Zb3EXPI/GiOOv6595D3aNFY/796fPz4FQj8Q4b8+td/5PNhV"
+    "or4CpVC/rdRnvzwCnj8BmtG+4PIwvzkoo78ljI4+Xvhyv8N/gr93QKG/9NDcP49GGT92lkw/TWqd"
+    "PLYjmD/TeZy+DVX6PuUKBMBZM5Y8quZLP249zD+8cgG/PVNbPxieWD9vdz4/t44qvp/yKr/2r98/"
+    "+I/cPoOsRT/+tiY/gzq0vy0u5z7Xpgq9r4x+P4TThb+6sTa/VIoFP4KHpj5Z+RnATNsjPyYcOr4t"
+    "Cns9dJnwPv7RnL/SAhe/di2mPxPR1L+oWUm/xxX3Pt9ljz/QPCY/s6UJv8jChD/Zn66/rh+UP1XY"
+    "ar5mehw/7krkPjv9d7+qlYM/R64IPyJIBL+804u/9oEyvw6X5r/AOmM/P6yzvxMYGD8i1Qk+6iwE"
+    "v5qbeD8Nt32/96//vwXJqz64Tk8++rOdvvZiMb8m760+1afcv7l5qj9iiAPADUmIv5k5xb9RFO8/"
+    "Xas9v4J+BD9cNLE/FNCPvh/ZYj5ATwG/Jjlcv5CuZL1C4Y2+sjO4P0EIpD6uj5i9NCY2v1aomj61"
+    "mQ0/3Mf2vXX4Wb3F3ag8ikNAP9Oinz4vWE4+1aiAvELvqT8yHuW/OoKDPoGNV7zYDhs/ZhMGPtnz"
+    "OT44aU0/GN4BP/WRJz62Sh7A+fPQPm0roT9v1xA+g76XP5lb4b1AzuU+v6U5P5Ih1j8YC1u/nCoO"
+    "vzwkCUB4vKU/zfK2P+EJjj7jbP+8ZmkkP/9K3z/8ZBjAvOSJPx4n8T2Vw4e/NXWDv2WZvD9LimA/"
+    "HN5ZvgR0EkCPYGK/4FwCwH19sr4cjos+6nSUPkwNIj7/Rw1Ao6Nxv+xbDj8dmg0+eYV/P/J94r+/"
+    "Q0q//btIv9tXuL4EuUg/nEJPvUkbdr6MkxY9PseGvzhqgb8gl7g+CJSTP7oQm77wXEs+F84Ov3Li"
+    "qT8YEmK/PRJYvp+W673dFT2/B0/Nv6VVoj7EWFM+6bfyv3j/v79WYig/WtoLP5kSxj0xspG/RXAv"
+    "wP0+/z33rdw+z47Qv1I+or/pTBQ/GR51v5Bvhb62s7y+WSGNvznepT5Mobo+pBeVP1CaKb4dzM2/"
+    "R3W2vghxFb4qrQEICggEEAFCAlJXSqABUJuRP+p/gr/a77s/arKQPxdyPb8dzqs+WkdWPwjx2z5V"
+    "EKQ+O4o5PlrCKb9YOMA/yyG2PysLwr9gvL++OVWuv3PIyr8pYki/opqmPgRQij+lmEs+gpmBPlmL"
+    "OD422mc/gVpWv2GLR752XpA+n03Cv3fAyT7sH8u++0TYvg8cd7+xU54+7e5zv+OZvj9ySP0+qQks"
+    "Puo/b7+ihHO/P2SwvyoaCAQQAUICUkJKEE+i/r6DrwQ/tpbAPtF8XT8qjwEIBAgIEAFCBEZDMUJK"
+    "gAFyrD4/5CBaP5Dunr8Xscs/iujev1IFXb9T/6++c6CwvyJEl77Cuvo/fO7dP0UY1L/BAQ2/2Vq+"
+    "PrvG6b4WPKW/m+Cev1E/8b7FDZI/GkNXv63aBj5kCZg/l/K3Pl4mUb8/uuO+ym9gvqERfz/8cmK9"
+    "vJXePy5h7L2pGOE/gxrqPloTCgFYEg4KDAgBEggKAggMCgIICmITCgFZEg4KDAgBEggKAggMCgII"
+    "CkIECgAQEkIRCg1jb20ubWljcm9zb2Z0EAE="
+)
+
+_GOLDEN_MOE_WHOLE_EXPERT_MATCHES_PYTHON_REFERENCE_EMPTY_CALIBRATION = (
+    "CAo6wwsKEgoBWAoCUlcSAVIiBEdlbW06AApqCgFYCgFSCgRGQzFXCgAKBEZDMlcSAVkiA01vRSoI"
+    "CgFrGAGgAQIqGgoPYWN0aXZhdGlvbl90eXBlIgRyZWx1oAEDKhcKEHVzZV9zcGFyc2VfbWl4ZXIY"
+    "AKABAjoNY29tLm1pY3Jvc29mdBIBZyrRBAgDCAYICBABQgRGQzFXSsAEAKG5vn2I6T8sNkO/0FIz"
+    "QEU2wT/lcC0+bFJ1P8/N4T52lJ0+tp3Zv5ED4T7l4oY/3w/Bv7vT/z8wkU2/RkSAv6BC47pEnUa+"
+    "hgIdP2gSgj/AGMe//2w5Pw4+dD7EMW2/BgbWPhaA3b42UpE/LN6UvqXtHsCUr6++Es6Nv8RLvb97"
+    "GtC/XbJIPzyBXz+k03A//SYHvL/JN74M6K+/my8YQGN+Pr6vncU+HjdYP1L4AL//5s4/n0mbPiB7"
+    "zD7hK6Q+1u+Cvl5LNL+/VKu/JOCCP3bqkb/7JAu9vooxvzBkqz/pcuk+5KB4v69QPb73goA/8UfT"
+    "P2zw97yhNpY/f68NP0dIlL9EI2++LOvnvvpKSz/2q+E/ugGlv5DpZD9Lksq/823avriYXj59DIQ/"
+    "b0hSQADZ6r+mRxM/9qb6PgACCUBiTW8/fZC7vROOEkBQshXAlsh4Pjifcr3RFpa/DRi3v5mbyT6y"
+    "344+GngMv+l4mr7GwH2/Q0mMvIDFB7/f8Ra/yKLvPtNGz748EHq/Ihv9PiBDJ787JH683CfhPoIi"
+    "nj9avRq/hDqJP/hpyr6DDZy97h7OP/M0sj79f0q/lK1SPojFvr9O0BzAEZ/Gv970Ar6Zmss+pYk2"
+    "v3p1Ir/wtKe+MOc3QM9vED4DKt0+RjSPvUvfDz1bIlA/6tKEPt3hkj4XwqG/iFe2v90cgz8HARG9"
+    "OwqJPzWyob80FYO/RkY1P9kKlL55Yza+ZTuJPn7rVj4Kqls+3/h7P/8U4L/9VaU+KtEECAMICAgG"
+    "EAFCBEZDMldKwAQ+sYq9BEZLv60MSb/ZyaQ/qtrUvnmrlz/K+Hq/jc5CP9Wt0L8NKBw+plI7v0J7"
+    "aL/wQtE/byOcPjt0jD+vawW/I8Kgv+eikb9U6qQ+GYJnP4ESyj6AI54+uPgrvnTYTz/pktA/vyB5"
+    "v0jvmb9dyNA/B/6dP7/6fb7cMpc/+EEUQLK7G79GZZA/T4mwP9yE0b9ReHc+oEyKPo1/C8Bsq/K8"
+    "w9wsvrQuWj8BHTi/q9cIPLvZl7wzCYQ/ifXNP0uDqT+MibU+MxmuPWQ5lz9eOEU/TfwAP8itOr9P"
+    "/ua8+3PRv53DBsB4GlW/JrqzP1fjFT9AurY/5odtP26sXr75JrC+UO+Pvw5Ppr63n4o/89AQPyWf"
+    "eT7djiW/wmRDvxQlJT8s6/6/+tufv2BP5r89V1E9To/yvvth+r2Kmdw+JM09PtERgz8xM3m+sirY"
+    "P/mI0L4S3o0+g4Ubv6o8/D8863a+LgeCP1MD8r7wyj0+Hnedvr3sgD9f04S/aX5kvoeJY74PBQ++"
+    "Av3KPrhENz9UNMi+aEmVPnwMD8BgXxg/PZeGv91Y6L8DvNU+OFyavxYOeb+CaVs/aJePPrTDGkCT"
+    "Z0+/IdFJPG1ZtT+fiTu/YgmLP3jcxz7WOcm9s+jwvq7LM78hbnk+CW6ZPhQ3vr/Wf8q+pz8APvYn"
+    "OT8Fe1g/s4mZPzTrN78anC1An+7GO9VG1D4K0P6/xidPP0uBCb+2Z/Q+J0nYvYrdKkCNoqe/YHcJ"
+    "v4+hMz9LORu/PexWPsmDUT8qbAgICAMQAUICUldKYHFIOL+FTs69SkW4vemV2r2Yn8y+mwdsv+Jj"
+    "lL4Dd4I+CSqvPxUcDD8d+8g/ZjgMv7pDUD+C4Ya/7Z8wvjl41TyLW/u+aM5sv6Fdpj+XjFM+E8hT"
+    "P1Iqyr7vl3M/MhSbvVoTCgFYEg4KDAgBEggKAggGCgIICGITCgFZEg4KDAgBEggKAggGCgIICEIE"
+    "CgAQEkIRCg1jb20ubWljcm9zb2Z0EAE="
+)
+
+_GOLDEN_QMOE_WHOLE_EXPERT_MATCHES_PYTHON_REFERENCE = (
+    "CAo6hAgKHAoBWAoCUlcKAlJCEgFSGgZyb3V0ZXIiBEdlbW0KtAEKAVgKAVIKBEZDMVEKBEZDMVMK"
+    "BEZDMUIKBEZDMlEKBEZDMlMKABIBWRoEcW1vZSIEUU1vRSoaCg9hY3RpdmF0aW9uX3R5cGUiBHJl"
+    "bHWgAQMqGQoSZXhwZXJ0X3dlaWdodF9iaXRzGASgAQIqCAoBaxgCoAECKhQKCnF1YW50X3R5cGUi"
+    "A2ludKABAyoXChB1c2Vfc3BhcnNlX21peGVyGACgAQI6DWNvbS5taWNyb3NvZnQSAWcqcAgECAYI"
+    "BBACQgRGQzFRSmD3qGeIVmsMqveIlfCob4BN+j/JoPRFViBJX39Me/mTAAWIUIVKbQbrswq3+gaL"
+    "yovxp3kWj/WOjCxfRoCtmd+2cP/G2feBaOr7uupK/tpwj117fPiEevlYEEh+c/9HvR8qbggECAYQ"
+    "AUIERkMxU0pg5UvkPWYw4D1lIII92Q6WPa8pST0ASD49aJF2PeIJgD0YKts8PKiAPYbbGj27aac9"
+    "5bkwPeGWkT3UNyU9UfiJPWmYRj33/Jo9onq0PRiqoj25ba49az+SPeG0Iz3ZfTA9KnAIBAgICAMQ"
+    "AkIERkMyUUpgbYgL33tZ2M4ICWS99zBJWECrRQbPuQOEzYB+3fS6eHz1+EYUu0f597WTuPebvkoO"
+    "wPQxc/Xtqmj49c35J/+MPGCf+ZyIl4uwkI6IBkBbvIYJAVrocKR7Nzuwwws4kbSPKo8BCAQICBAB"
+    "QgRGQzJTSoAB7gSGPczEyj2xkSY9lPRzPUgaKT1WQbU9FmlwPaa3yT38cWM9Ub5QPZBilT2nAew8"
+    "yfh5PacSmj11voU9eGNwPWhy7TzwYMI9WJKEPYbplj1+0KE97QufPbMonD1/arY9k5cqPfsFRz0d"
+    "+Do9zRQ5PdQzlj1ZEx49VnBUPRdwTT0qjQEICAgEEAFCAlJXSoABApm4OxViYL2m2sw9Mf0mvhsO"
+    "QD7giUk8cHWAvaLwYT6dLOW9WAIxvuU4lD1hYBm+M8m7vgo6j76zBiY9TyUtPkJI372AqTI9RGVb"
+    "vkt6W750bLS9oQ2HvnoPob60E8K9yHhuvrFgNT6NQa+7IeBwvnqzCL5Hk5u8KOoPu3oTILsqGggE"
+    "EAFCAlJCShARz68/zakWP9o6F0BWn3A/Km4IBAgGEAFCBEZDMUJKYC9Fjr7dasU+miRWP+fLCT6U"
+    "ZcU/tlzWv+M/ob8asvQ+ZBeiv0Z3kj/vay8/9bwJP0rotz4mYaE+Yt24P/eytT/w2ws+4ldHP1su"
+    "ALz9nMo+jzYMv2jNPr/2bj8+C92+v1oTCgFYEg4KDAgBEggKAggKCgIICGITCgFZEg4KDAgBEggK"
+    "AggKCgIICEIECgAQEkIRCg1jb20ubWljcm9zb2Z0EAE="
+)
+
+_GOLDEN_QMOE_WHOLE_EXPERT_MATCHES_PYTHON_REFERENCE_EMPTY_CALIBRATION = (
+    "CAo65gUKGgoBWAoCUlcSAVIaBnJvdXRlciIGTWF0TXVsCrABCgFYCgFSCgRGQzFRCgRGQzFTCgAK"
+    "BEZDMlEKBEZDMlMKABIBWRoEcW1vZSIEUU1vRSoaCg9hY3RpdmF0aW9uX3R5cGUiBHJlbHWgAQMq"
+    "GQoSZXhwZXJ0X3dlaWdodF9iaXRzGASgAQIqCAoBaxgBoAECKhQKCnF1YW50X3R5cGUiA2ludKAB"
+    "AyoXChB1c2Vfc3BhcnNlX21peGVyGACgAQI6DWNvbS5taWNyb3NvZnQSAWcqWAgDCAYIBBACQgRG"
+    "QzFRSkjirXYMg/iUVcP5s5eop478tptD9VlgdoQmtn99k/x5q5Q3D8HJT1+ebG8vNL5Ay6J1z8do"
+    "k/+JZ5FIj7cFF0tVu2eo99+RV0AqVggDCAYQAUIERkMxU0pIrveTPaScSD0OOY49Oxy2PR45hz0/"
+    "v5c9DzCnPbh6tz33XjQ9bKaMPZI1jj0cdRQ9OA/DPX+jhz3Zc1o96sXCPdZ7qT2inFo9KlgIAwgI"
+    "CAMQAkIERkMyUUpIZxCJ+GTOjvSPH3sIvXP1dd0MCyBMvEegRWCz8g3ZeNDsy6UQA9ZF1h+ch/iD"
+    "81xlTH9sjIz3BphXGiCQWAiGX3SfsKFcCFQrKm4IAwgIEAFCBEZDMlNKYMkCkT1CNlc91DWCPV7D"
+    "hT3akps9meRKPa/1IT1hnBo92OefPax1Lj0iTgI9nbuSPWPjiz0NLZU91H/ZPTaGTj1r2Z89Zhdf"
+    "Pf8mKT1NIzk99Y2CPeUUuz3q/o49AviCPSpsCAgIAxABQgJSV0pgLkAVvStDNL5SLdc8hzkDvmSs"
+    "G7ydC7E9njCWPhJmXr4XEro9wmEhvkptNj2d1ag+dlRGvqo6jT7XMGs8eedWPensKD687kG8fUhO"
+    "PnhUtT5Jr4m+zgxbPitOuT2APUW9WhMKAVgSDgoMCAESCAoCCAYKAggIYhMKAVkSDgoMCAESCAoC"
+    "CAYKAggIQgQKABASQhEKDWNvbS5taWNyb3NvZnQQAQ=="
+)
+
+_GOLDEN_QMOE_WHOLE_EXPERT_BLOCKWISE_MATCHES_PYTHON_REFERENCE = (
+    "CAo67xAKGgoBWAoCUlcSAVIaBnJvdXRlciIGTWF0TXVsCsMBCgFYCgFSCgRGQzFRCgRGQzFTCgAK"
+    "BEZDMlEKBEZDMlMKABIBWRoEcW1vZSIEUU1vRSoaCg9hY3RpdmF0aW9uX3R5cGUiBHJlbHWgAQMq"
+    "GQoSZXhwZXJ0X3dlaWdodF9iaXRzGASgAQIqCAoBaxgBoAECKhQKCnF1YW50X3R5cGUiA2ludKAB"
+    "AyoXChB1c2Vfc3BhcnNlX21peGVyGACgAQIqEQoKYmxvY2tfc2l6ZRgQoAECOg1jb20ubWljcm9z"
+    "b2Z0EgFnKpEECAIIEAgQEAJCBEZDMVFKgATwz2IX3BlsSFCqh3OWl36nH7JqyagIG+pYgJ1VI3l6"
+    "dpMzr0OG2BjxiTZJ/U+dRYWARFZqiX5TrSxU9WFLUIxFSVlW9cgzdLg0y+u2+qa6sW/kdVuJu0Z/"
+    "ZIB4Pq20iWWNqXlIf8tH9mzJCRGa5fX6i4uW92c4icMNe4ZoZSYpqXTIVWBYVoUiNaQo17XYf1/T"
+    "CELEg1bWkYay+GSKsbmAV6CUd7/498d1sJtm1F4LOm/gf4I3hFpv5sePbZhlr5aJuHxxn5nUGF6q"
+    "nFZvBI0EWIu8yzj3t7SFqlaPhEhGStqkek2gm1a9taYnVmypxp9baLaZpJm/U3H2N6h/M51lC7d8"
+    "/avmuYedhNqaCZZpdJ9cR6U39GVcNbdoileYCraXplrZBplSj8+RlqBvAlZDb+hvpFeF+9hheEYo"
+    "pG0JXEWnh66WYGlqRzk3Q6ngzPbo+JrK97h1vaNEB3GnjIuuq3n1mZY3amJsZ/t7pqOEyzj7mNqs"
+    "WYhMSgjyybN6mfwWXPjEf7uI53CWhbhlWEbWtLT7uy14d8i8nP/IS7e3Yz8Jicu4iJlodpe2t0b0"
+    "vJRzrU9ft5S9h5h52WepmVWfonec9qtoV5/4uTY1pGp7g42t63upe1KgfXL0TZ37I0yZuDDSRVtr"
+    "lRxruqkKYSvbhH94Z6J6bbquC5Zs4DnOpiqRAggCCBAIAhABQgRGQzFTSoACKmqQPUyg+T2kclg9"
+    "8NNsPc0Dlj0YEqw9guVgPV/8WT0ekcA98OfRPeKQjj06A689BuqTPaIneD0n/oA9tuqFPUTDzD0Z"
+    "K4M9Y1quPf6Zjz1WbJo9e5CZPTHioD2GFcM97veiPZVZmj1A8dE9u0+bPQnEkD1JxN49BLK/PW4q"
+    "jz2DzIY93PzZPS8RVz0UQrM973+9PVtlXT2wq8Y9fdSvPTIdyD2OOaY9cguoPfMdmz1uaq099G3J"
+    "PXxjmj1ijZk9jg6oPT9Msz3jrnk9wPpxPTinBT6igYw9EGqGPf/Xxz3/rKA9g3nTPXWRnj2Yjoc9"
+    "5ppsPaekkD0/2rI9cQ5KPSqRBAgCCCAICBACQgRGQzJRSoAE9pmsaZbFpox2OLcKpnc8bUlkFhVw"
+    "g2SCq7T1W0m4PD5m1LtXtYRvEL6PYCdXuoulP5prt5ca8yfJ5xmfdJoHU3j31zrezKqpGlqmBGpz"
+    "zDsXs5rnVI27BilWvKUKp472p4U1WyBnuXiY30/F2UNoqXxtN1aZawNpsZbct7WGCrpAy26Qf/WG"
+    "jFCF/hiXg3917LOsVw+dhBq3Szv5r4l6affHbSaKY/lclbd1DFN4mVhMmLwKOQx0PrlqX3umx3Yr"
+    "NQwmW5N/WWnHk752z7WJv1p+qH1/p3fEjfzAiTi4Z8aFZvhGXKfMJ4+5eYvCiok5mHiqf3zJl0dg"
+    "EMRMoyZcTWGQb/WqjbhxWsmWlbafxoNv6cCT+3m3tIz2KW6Jxjq6t+XHD60VNYq22bmN1do2Cb34"
+    "hmXC6nlKNXx6eovGaFC/ui5Fl+31gv54Vaa1e/aBqQhUVOujpQRQkEPOfKJ0FbIyl3i/KKRKL1kX"
+    "MpRnDJ548yfJVLxXo0N+pKX92YaaiWh517jva2dpebuVb01WWra0RVhXcGBIVgukTk4zlInLqifN"
+    "PwzjOgx6t3xJqparh5QIhc6kqGSpaqvIGIl4+H2JdbWZ+5WH5/Zkk7V2TIb7SXaE26CEyHYkl5yU"
+    "j6lSCNmnhqH6kNn/13BkJdiB/GVn0I96TWPZ1ISJBehHKmcqkQIIAgggCAEQAUIERkMyU0qAApTV"
+    "8T3Tj589CJuCPfc5oz2cWb49tJuHPRWYlT0KfqA9Ln+RPU+5pT04NIA9ED2rPdbeyT1KKcU9Z5al"
+    "PXsMmz2brmQ9nDdRPYxApj1Odr49HOq4PdwovT3CtJY94a27Pet9iz1Vi6w9oi+zPYCfyT2/3pc9"
+    "s7zSPTth4j2wHW49FylqPV0Moz1VSY09H4KAPXnorT02hLM9rLNsPXi4yD3teok9z0OCPULVtz3a"
+    "HT49jtyMPSvyIT27ZIc90x25PVEr2j1097k96hu+Pc0LpD2mSHA9AkaxPVWHyD30T7I9dJm3PQXC"
+    "vz2QXMY9Jk7YPbkMZz0P7Uo9eU82PbJ3oz0qjQIIIAgCEAFCAlJXSoACiPhWPnJZqj5bvIe7S/oI"
+    "vq7PLr639jW+PfGKvGZJr71gHx69bnndvvvJ0j5jPxc+mQ4nPWGQTb1Apye+gfxCPdwxzr2gQIu+"
+    "P+Z3voIZRD6Qgb8+WdHBPsNPzrtfqZm88Dg5PUHqBL2vA0K+0kzVuy+Ot739Voy9S3eyPlDzGb5G"
+    "lF8+gBK+PaEFDD2R7XK+0hKGvVylQD6jFnu9V4a2vXUFhr1iJwQ9ihsjvk5dub04TbY9c7w9vmmz"
+    "kD7sfes7R6iQvN37Hb5CeYW+dANOvkM/pr3puU6+Pv08Pncrsz0PFzS8N1saPS0mAj4CIqQ+ieA+"
+    "voFBB75IoBq+rJFXPFoTCgFYEg4KDAgBEggKAggICgIIIGITCgFZEg4KDAgBEggKAggICgIIIEIE"
+    "CgAQEkIRCg1jb20ubWljcm9zb2Z0EAE="
+)
 
 
 def _model(body, initializer=(), opset=18):
@@ -48,6 +246,27 @@ def _model(body, initializer=(), opset=18):
 
 def _f32(array, name):
     return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _f16(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float16), name)
+
+
+def _bf16(array, name):
+    return onnx.numpy_helper.from_array(array.astype(ml_dtypes.bfloat16), name)
+
+
+# Maps a numpy dtype (as passed to _moe_router_model's/_qmoe_router_model's
+# own `float_dtype`) to the matching (ONNX text-format type name, ONNX enum,
+# tensor-builder) triple -- lets both model builders build an
+# activation-dtype-FLOAT16/BFLOAT16 model for the FP16/BFloat16 weight
+# support tests below, while every existing FLOAT32 call site (the default)
+# is completely unaffected.
+_FLOAT_DTYPE_INFO = {
+    np.dtype(np.float32): ("float", onnx.TensorProto.FLOAT, _f32),
+    np.dtype(np.float16): ("float16", onnx.TensorProto.FLOAT16, _f16),
+    np.dtype(ml_dtypes.bfloat16): ("bfloat16", onnx.TensorProto.BFLOAT16, _bf16),
+}
 
 
 def _u8(array, name):
@@ -77,50 +296,74 @@ def _moe_router_model(
     k=2,
     tokens=6,
     use_sparse_mixer=0,
+    float_dtype=np.float32,
 ):
+    # `float_dtype` (FLOAT32 by default, every existing call site's own
+    # behavior unchanged) controls X/R/Y's own activation dtype and every
+    # FLOAT-family weight/bias's own storage dtype -- see the "FP16/BFloat16
+    # weight support" section below, which passes FLOAT16/BFLOAT16 here to
+    # build the widened-matcher (MatchMoeProducer AND MatchMoeRouterProducer)
+    # test models.
+    type_name, _, float_tensor = _FLOAT_DTYPE_INFO[np.dtype(float_dtype)]
     num_experts, inter, hidden = fc1_w.shape
     fc1_b_arg = "FC1B" if fc1_b is not None else ""
     router_call = "Gemm(X, RW, RB)" if router_b is not None else "Gemm(X, RW)"
     model = _model(
         f"""
-        g (float[{tokens},{hidden}] X) => (float[{tokens},{hidden}] Y)
+        g ({type_name}[{tokens},{hidden}] X) => ({type_name}[{tokens},{hidden}] Y)
         {{
           R = {router_call}
           Y = com.microsoft.MoE <k={k}, activation_type="relu", use_sparse_mixer={use_sparse_mixer}> (X, R, FC1W, {fc1_b_arg}, FC2W)
         }}
         """
     )
-    inits = [_f32(fc1_w, "FC1W"), _f32(fc2_w, "FC2W"), _f32(router_w, "RW")]
+    inits = [
+        float_tensor(fc1_w, "FC1W"),
+        float_tensor(fc2_w, "FC2W"),
+        float_tensor(router_w, "RW"),
+    ]
     if router_b is not None:
-        inits.append(_f32(router_b, "RB"))
+        inits.append(float_tensor(router_b, "RB"))
     if fc1_b is not None:
-        inits.append(_f32(fc1_b, "FC1B"))
+        inits.append(float_tensor(fc1_b, "FC1B"))
     model.graph.initializer.extend(inits)
     return model
 
 
 def _moe_router_masking_oracle(
-    fc1_w, fc2_w, router_w, router_b, dropped, k, fc1_b=None, tokens=6
+    fc1_w,
+    fc2_w,
+    router_w,
+    router_b,
+    dropped,
+    k,
+    fc1_b=None,
+    tokens=6,
+    float_dtype=np.float32,
 ):
     # Same-shape model with every `dropped` expert's routing logit forced to
-    # -1e9 (Softmax assigns it exactly 0 probability) and its own fc1/fc2
-    # (+fc1_b) rows zeroed -- see onnxsim/pruning.py's own section comment
-    # for why this is confirmed *exactly* equivalent to actually removing
-    # the expert.
+    # a large negative value (Softmax assigns it ~0 probability) and its own
+    # fc1/fc2 (+fc1_b) rows zeroed -- see onnxsim/pruning.py's own section
+    # comment for why this is confirmed *exactly* equivalent to actually
+    # removing the expert. -1e9 overflows to -inf in FLOAT16 (max magnitude
+    # ~65504) -- -6e4 stays finite and representable while still forcing the
+    # Softmax numerator to underflow to 0 given every other logit here is
+    # `O(1)`.
+    mask_value = -1e9 if np.dtype(float_dtype) == np.dtype(np.float32) else -6e4
     fc1_w_m = fc1_w.copy()
     fc2_w_m = fc2_w.copy()
     fc1_b_m = fc1_b.copy() if fc1_b is not None else None
     router_b_m = (
         router_b.copy()
         if router_b is not None
-        else np.zeros(fc1_w.shape[0], np.float32)
+        else np.zeros(fc1_w.shape[0], float_dtype)
     )
     for e in dropped:
         fc1_w_m[e] = 0
         fc2_w_m[e] = 0
         if fc1_b_m is not None:
             fc1_b_m[e] = 0
-        router_b_m[e] = -1e9
+        router_b_m[e] = mask_value
     return _moe_router_model(
         fc1_w_m,
         fc2_w_m,
@@ -129,6 +372,7 @@ def _moe_router_masking_oracle(
         fc1_b=fc1_b_m,
         k=k,
         tokens=tokens,
+        float_dtype=float_dtype,
     )
 
 
@@ -188,38 +432,37 @@ def _qmoe_router_model(
     k=2,
     tokens=6,
     use_sparse_mixer=0,
+    float_dtype=np.float32,
 ):
+    # `float_dtype` (FLOAT32 by default, every existing call site's own
+    # behavior unchanged) controls X/R/Y's own activation dtype and every
+    # FLOAT-family operand's own storage dtype (fc1/fc2 scale, fc1 bias,
+    # router weight/bias) -- see the "FP16/BFloat16 weight support" section
+    # below. `fc1_q`/`fc2_q` always stay UINT8 regardless.
+    _, onnx_dtype, float_tensor = _FLOAT_DTYPE_INFO[np.dtype(float_dtype)]
     num_experts, inter, hidden_packed = fc1_q.shape
     hidden = hidden_packed * (8 // bits)
-    inputs = [
-        onnx.helper.make_tensor_value_info(
-            "X", onnx.TensorProto.FLOAT, [tokens, hidden]
-        )
-    ]
-    outputs = [
-        onnx.helper.make_tensor_value_info(
-            "Y", onnx.TensorProto.FLOAT, [tokens, hidden]
-        )
-    ]
+    inputs = [onnx.helper.make_tensor_value_info("X", onnx_dtype, [tokens, hidden])]
+    outputs = [onnx.helper.make_tensor_value_info("Y", onnx_dtype, [tokens, hidden])]
     inits = [
         _u8(fc1_q, "FC1Q"),
-        _f32(fc1_scale, "FC1S"),
+        float_tensor(fc1_scale, "FC1S"),
         _u8(fc2_q, "FC2Q"),
-        _f32(fc2_scale, "FC2S"),
-        _f32(router_w, "RW"),
+        float_tensor(fc2_scale, "FC2S"),
+        float_tensor(router_w, "RW"),
     ]
     if router_b is not None:
         router_node = onnx.helper.make_node(
             "Gemm", ["X", "RW", "RB"], ["R"], name="router"
         )
-        inits.append(_f32(router_b, "RB"))
+        inits.append(float_tensor(router_b, "RB"))
     else:
         router_node = onnx.helper.make_node("MatMul", ["X", "RW"], ["R"], name="router")
 
     node_inputs = ["X", "R", "FC1Q", "FC1S", "", "FC2Q", "FC2S", ""]
     if fc1_bias is not None:
         node_inputs[4] = "FC1B"
-        inits.append(_f32(fc1_bias, "FC1B"))
+        inits.append(float_tensor(fc1_bias, "FC1B"))
 
     qmoe_node = onnx.helper.make_node(
         "QMoE",
@@ -259,21 +502,25 @@ def _qmoe_router_masking_oracle(
     k,
     fc1_bias=None,
     tokens=6,
+    float_dtype=np.float32,
 ):
+    # See _moe_router_masking_oracle's own comment for why the mask value
+    # differs by dtype (-1e9 overflows FLOAT16).
+    mask_value = -1e9 if np.dtype(float_dtype) == np.dtype(np.float32) else -6e4
     fc1_q_m = fc1_q.copy()
     fc2_q_m = fc2_q.copy()
     fc1_bias_m = fc1_bias.copy() if fc1_bias is not None else None
     router_b_m = (
         router_b.copy()
         if router_b is not None
-        else np.zeros(fc1_q.shape[0], np.float32)
+        else np.zeros(fc1_q.shape[0], float_dtype)
     )
     for e in dropped:
         fc1_q_m[e] = 0
         fc2_q_m[e] = 0
         if fc1_bias_m is not None:
             fc1_bias_m[e] = 0
-        router_b_m[e] = -1e9
+        router_b_m[e] = mask_value
     return _qmoe_router_model(
         fc1_q_m,
         fc1_scale,
@@ -285,6 +532,7 @@ def _qmoe_router_masking_oracle(
         fc1_bias=fc1_bias_m,
         k=k,
         tokens=tokens,
+        float_dtype=float_dtype,
     )
 
 
@@ -477,11 +725,9 @@ def test_moe_whole_expert_pruning_cpp_matches_python_reference():
     pruned_cpp = onnxsim.apply_moe_whole_expert_pruning_cpp(
         model, calibration_data=calibration_data, sparsity=0.4
     )
-    pruned_py = onnxsim.apply_moe_whole_expert_pruning(
-        model, calibration_data=calibration_data, sparsity=0.4
-    )
     onnx.checker.check_model(pruned_cpp)
-    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+    golden = _golden(_GOLDEN_MOE_WHOLE_EXPERT_MATCHES_PYTHON_REFERENCE)
+    assert pruned_cpp.SerializeToString() == golden.SerializeToString()
 
 
 def test_moe_whole_expert_pruning_cpp_matches_python_reference_empty_calibration():
@@ -502,10 +748,10 @@ def test_moe_whole_expert_pruning_cpp_matches_python_reference_empty_calibration
     pruned_cpp = onnxsim.apply_moe_whole_expert_pruning_cpp(
         model, calibration_data=[], sparsity=0.4
     )
-    pruned_py = onnxsim.apply_moe_whole_expert_pruning(
-        model, calibration_data=[], sparsity=0.4
+    golden = _golden(
+        _GOLDEN_MOE_WHOLE_EXPERT_MATCHES_PYTHON_REFERENCE_EMPTY_CALIBRATION
     )
-    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+    assert pruned_cpp.SerializeToString() == golden.SerializeToString()
 
 
 # --- Default (auto-generated) calibration data ------------------------------
@@ -705,11 +951,9 @@ def test_qmoe_whole_expert_pruning_cpp_matches_python_reference():
     pruned_cpp = onnxsim.apply_qmoe_whole_expert_pruning_cpp(
         model, calibration_data=calibration_data, sparsity=0.4
     )
-    pruned_py = onnxsim.apply_qmoe_whole_expert_pruning(
-        model, calibration_data=calibration_data, sparsity=0.4
-    )
     onnx.checker.check_model(pruned_cpp)
-    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+    golden = _golden(_GOLDEN_QMOE_WHOLE_EXPERT_MATCHES_PYTHON_REFERENCE)
+    assert pruned_cpp.SerializeToString() == golden.SerializeToString()
 
 
 def test_qmoe_whole_expert_pruning_cpp_matches_python_reference_empty_calibration():
@@ -730,10 +974,10 @@ def test_qmoe_whole_expert_pruning_cpp_matches_python_reference_empty_calibratio
     pruned_cpp = onnxsim.apply_qmoe_whole_expert_pruning_cpp(
         model, calibration_data=[], sparsity=0.4
     )
-    pruned_py = onnxsim.apply_qmoe_whole_expert_pruning(
-        model, calibration_data=[], sparsity=0.4
+    golden = _golden(
+        _GOLDEN_QMOE_WHOLE_EXPERT_MATCHES_PYTHON_REFERENCE_EMPTY_CALIBRATION
     )
-    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+    assert pruned_cpp.SerializeToString() == golden.SerializeToString()
 
 
 # --- Blockwise (block_size set) ---------------------------------------------
@@ -789,11 +1033,9 @@ def test_qmoe_whole_expert_pruning_cpp_blockwise_matches_python_reference():
     pruned_cpp = onnxsim.apply_qmoe_whole_expert_pruning_cpp(
         model, calibration_data=calibration_data, sparsity=0.4
     )
-    pruned_py = onnxsim.apply_qmoe_whole_expert_pruning(
-        model, calibration_data=calibration_data, sparsity=0.4
-    )
     onnx.checker.check_model(pruned_cpp)
-    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+    golden = _golden(_GOLDEN_QMOE_WHOLE_EXPERT_BLOCKWISE_MATCHES_PYTHON_REFERENCE)
+    assert pruned_cpp.SerializeToString() == golden.SerializeToString()
     inits = _inits(pruned_cpp)
     assert inits["FC1Q"].shape[0] == inits["FC1S"].shape[0]
 
@@ -813,3 +1055,426 @@ def test_moe_whole_expert_pruning_cpp_missing_calibration_input_raises():
         onnxsim.apply_moe_whole_expert_pruning_cpp(
             model, calibration_data=[bad_batch], sparsity=0.5
         )
+
+
+# =============================================================================
+# FP16/BFloat16 weight support
+# =============================================================================
+#
+# MatchMoeWholeExpertProducer/MatchQMoEWholeExpertProducer (structured_
+# pruning_entry.cpp) used to hard-require ``onnx.TensorProto.FLOAT`` for
+# fc1/fc2's own weight/bias (via MatchMoeProducer/MatchQMoEProducer) AND for
+# the router projection's own weight/bias (via the shared, FLOAT32-only
+# MatchProducer) -- silently declining any node whose weights were stored as
+# FLOAT16 or BFLOAT16, narrower than the pure-Python ``onnxsim.apply_moe_
+# whole_expert_pruning``/``onnxsim.apply_qmoe_whole_expert_pruning``'s own
+# ``_is_supported_float_dtype``. Now widened: fc1/fc2 via IsSupportedFloat
+# Dtype/ReadTensorAsF64/WriteF64TensorAs (see structured_pruning_entry.cpp's
+# own "MoE expert-intermediate-channel pruning" section top comment), and
+# the router projection specifically via the new, narrowly-scoped
+# MatchMoeRouterProducer/SliceMoeRouterWeight/SliceMoeRouterBias (see that
+# function's own comment for why this is a dedicated local duplicate of the
+# shared MatchProducer/SliceProducerWeight/SliceLastAxis rather than a
+# change to those functions themselves).
+#
+# FLOAT16: confirmed separately that onnxruntime's CPU MoE/QMoE kernels
+# execute genuine FLOAT16 end to end (matching test_moe_pruning_cpp.py's/
+# test_qmoe_pruning_cpp.py's own identical notes), so these tests run real
+# calibration through a real session, exactly like their FLOAT32 "matches_
+# ort_masking_oracle" siblings above. BFLOAT16 has no onnxruntime CPU
+# execution support in this environment at all -- so, since this pass
+# ALWAYS needs a real executor to observe router activations for any
+# non-empty ``calibration_data``, the BFLOAT16 tests below instead exercise
+# the "no matching activation observed" weight-norm-only fallback path
+# (``calibration_data=[]``, already covered for FLOAT32 by
+# test_moe_whole_expert_pruning_cpp_empty_calibration_falls_back_to_weight_
+# norm/its QMoE analogue) -- the executor is constructed but never actually
+# `Run`, so no BFLOAT16 execution is ever attempted, while still exercising
+# every matcher/slicer this section widened: fc1/fc2 weight+bias AND the
+# router projection's own weight+bias.
+
+
+def test_moe_whole_expert_pruning_cpp_fp16_matches_ort_masking_oracle():
+    E, hidden, inter, tokens = 5, 8, 6, 10
+    rng = np.random.default_rng(3001)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.4).astype(np.float16)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.4).astype(np.float16)
+    fc1_b = rng.standard_normal((E, inter)).astype(np.float16)
+    router_w = (rng.standard_normal((hidden, E)) * 0.2).astype(np.float16)
+    router_b = rng.standard_normal(E).astype(np.float16)
+    k = 2
+    model = _moe_router_model(
+        fc1_w,
+        fc2_w,
+        router_w,
+        router_b=router_b,
+        fc1_b=fc1_b,
+        k=k,
+        tokens=tokens,
+        float_dtype=np.float16,
+    )
+    onnx.checker.check_model(model)
+    inits_before = _inits(model)
+    assert inits_before["FC1W"].dtype == np.float16
+    assert inits_before["RW"].dtype == np.float16
+
+    calib_rng = np.random.default_rng(3003)
+    calibration_data = [
+        {"X": calib_rng.standard_normal((tokens, hidden)).astype(np.float16)}
+        for _ in range(4)
+    ]
+    pruned = onnxsim.apply_moe_whole_expert_pruning_cpp(
+        model,
+        calibration_data=calibration_data,
+        sparsity=0.4,  # keep 3 of 5
+    )
+    onnx.checker.check_model(pruned)
+    inits = _inits(pruned)
+    assert inits["FC1W"].dtype == np.float16
+    assert inits["FC1W"].shape == (3, inter, hidden)
+    assert inits["FC2W"].shape == (3, hidden, inter)
+    assert inits["RW"].dtype == np.float16
+    assert inits["RW"].shape == (hidden, 3)
+    assert inits["FC1B"].dtype == np.float16
+    assert inits["FC1B"].shape == (3, inter)
+
+    dropped = _dropped_experts(router_w, inits["RW"])
+    assert len(dropped) == 2
+    masked = _moe_router_masking_oracle(
+        fc1_w,
+        fc2_w,
+        router_w,
+        router_b,
+        dropped,
+        k,
+        fc1_b=fc1_b,
+        tokens=tokens,
+        float_dtype=np.float16,
+    )
+
+    feed_rng = np.random.default_rng(3007)
+    feeds = {"X": feed_rng.standard_normal((tokens, hidden)).astype(np.float16)}
+    (out_pruned,) = _run(pruned, feeds)
+    (out_masked,) = _run(masked, feeds)
+    np.testing.assert_allclose(
+        out_pruned.astype(np.float64),
+        out_masked.astype(np.float64),
+        rtol=5e-2,
+        atol=5e-2,
+    )
+
+
+def test_moe_whole_expert_pruning_cpp_fp16_adversarial_low_usage_expert_dropped():
+    # FLOAT16 analogue of test_moe_whole_expert_pruning_cpp_adversarial_low_
+    # usage_expert_dropped -- genuinely exercises the REAL calibration-based
+    # mean-gate-weight ranking (MoeRouterGateCalibrationStats), not merely
+    # the masking-equivalence safety property every other test above checks:
+    # fc1/fc2 are plain random noise, uncorrelated with router usage, so a
+    # bug that silently fell back to weight-norm-only importance for a
+    # FLOAT16 model (MoeRouterGateCalibrationStats used to hard-require
+    # FLOAT `router_probs`, dropping any FLOAT16 activation on the floor --
+    # see that function's own comment) would drop an essentially random
+    # expert here, not reliably the rarely-used one.
+    E, hidden, inter, tokens = 4, 6, 5, 8
+    rng = np.random.default_rng(3021)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float16)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float16)
+    router_w = (rng.standard_normal((hidden, E)) * 0.05).astype(np.float16)
+    router_b = np.zeros(E, dtype=np.float16)
+    router_b[0] = 8.0
+    router_b[E - 1] = -8.0
+    k = 1
+    model = _moe_router_model(
+        fc1_w,
+        fc2_w,
+        router_w,
+        router_b=router_b,
+        k=k,
+        tokens=tokens,
+        float_dtype=np.float16,
+    )
+
+    calib_rng = np.random.default_rng(3023)
+    calibration_data = [
+        {"X": calib_rng.standard_normal((tokens, hidden)).astype(np.float16)}
+        for _ in range(4)
+    ]
+    pruned = onnxsim.apply_moe_whole_expert_pruning_cpp(
+        model, calibration_data=calibration_data, sparsity=1.0 / E
+    )
+    inits = _inits(pruned)
+    assert inits["FC1W"].shape == (E - 1, inter, hidden)
+    dropped = _dropped_experts(router_w, inits["RW"])
+    assert dropped == [E - 1], f"expected the rarely-used expert dropped, got {dropped}"
+
+
+def test_moe_whole_expert_pruning_cpp_bfloat16_preserves_dtype_weight_norm_fallback():
+    # No calibration data at all -- falls back to MoeExpertWeightImportance
+    # (weight-norm-only ranking), so no BFLOAT16 execution is ever attempted
+    # (see this section's own top comment). Still exercises the widened
+    # fc1/fc2 weight+bias AND router weight+bias matcher/slicer end to end.
+    E, hidden, inter, tokens = 4, 6, 5, 8
+    rng = np.random.default_rng(3009)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(ml_dtypes.bfloat16)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(ml_dtypes.bfloat16)
+    fc1_b = rng.standard_normal((E, inter)).astype(ml_dtypes.bfloat16)
+    router_w = (rng.standard_normal((hidden, E)) * 0.2).astype(ml_dtypes.bfloat16)
+    router_b = rng.standard_normal(E).astype(ml_dtypes.bfloat16)
+    k = 1
+    model = _moe_router_model(
+        fc1_w,
+        fc2_w,
+        router_w,
+        router_b=router_b,
+        fc1_b=fc1_b,
+        k=k,
+        tokens=tokens,
+        float_dtype=ml_dtypes.bfloat16,
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_moe_whole_expert_pruning_cpp(
+        model, calibration_data=[], sparsity=0.4
+    )
+    onnx.checker.check_model(pruned)
+    inits = _inits(pruned)
+    # floor = max(1, min(k, E)) = 1; keep_count = max(floor, E - round(E*0.4))
+    # = max(1, 4 - 2) = 2.
+    keep_count = 2
+    assert inits["FC1W"].dtype == ml_dtypes.bfloat16
+    assert inits["FC1W"].shape == (keep_count, inter, hidden)
+    assert inits["RW"].dtype == ml_dtypes.bfloat16
+    assert inits["RW"].shape == (hidden, keep_count)
+    assert inits["FC1B"].dtype == ml_dtypes.bfloat16
+
+    # Independent re-derivation of MoeExpertWeightImportance's own
+    # weight-magnitude fallback ranking (root-sum-square over each expert's
+    # own fc1/fc2(+fc1_b) slice), computed in float64 off the correctly-
+    # decoded bfloat16 values.
+    fc1_w64 = fc1_w.astype(np.float64)
+    fc2_w64 = fc2_w.astype(np.float64)
+    fc1_b64 = fc1_b.astype(np.float64)
+    sq = (
+        np.sum(fc1_w64**2, axis=(1, 2))
+        + np.sum(fc2_w64**2, axis=(1, 2))
+        + np.sum(fc1_b64**2, axis=1)
+    )
+    keep = np.sort(np.argsort(-np.sqrt(sq))[:keep_count])
+
+    fc1_w_pruned = onnx.numpy_helper.to_array(
+        next(t for t in pruned.graph.initializer if t.name == "FC1W")
+    )
+    router_w_pruned = onnx.numpy_helper.to_array(
+        next(t for t in pruned.graph.initializer if t.name == "RW")
+    )
+    np.testing.assert_array_equal(
+        fc1_w_pruned.view(np.uint16), fc1_w[keep].view(np.uint16)
+    )
+    np.testing.assert_array_equal(
+        router_w_pruned.view(np.uint16), router_w[:, keep].view(np.uint16)
+    )
+
+
+def test_qmoe_whole_expert_pruning_cpp_fp16_matches_ort_masking_oracle():
+    E, hidden, inter, bits, tokens = 5, 8, 6, 4, 10
+    rng = np.random.default_rng(3011)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float32)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float32)
+    fc1_b = rng.standard_normal((E, inter)).astype(np.float16)
+    router_w = (rng.standard_normal((hidden, E)) * 0.2).astype(np.float16)
+    router_b = rng.standard_normal(E).astype(np.float16)
+    k = 2
+    fc1_q, fc1_s32 = _qmoe_quantize(fc1_w, bits)
+    fc2_q, fc2_s32 = _qmoe_quantize(fc2_w, bits)
+    fc1_s = fc1_s32.astype(np.float16)
+    fc2_s = fc2_s32.astype(np.float16)
+    model = _qmoe_router_model(
+        fc1_q,
+        fc1_s,
+        fc2_q,
+        fc2_s,
+        bits,
+        router_w,
+        router_b=router_b,
+        fc1_bias=fc1_b,
+        k=k,
+        tokens=tokens,
+        float_dtype=np.float16,
+    )
+    onnx.checker.check_model(model)
+    inits_before = _inits(model)
+    assert inits_before["FC1S"].dtype == np.float16
+    assert inits_before["RW"].dtype == np.float16
+
+    calib_rng = np.random.default_rng(3013)
+    calibration_data = [
+        {"X": calib_rng.standard_normal((tokens, hidden)).astype(np.float16)}
+        for _ in range(4)
+    ]
+    pruned = onnxsim.apply_qmoe_whole_expert_pruning_cpp(
+        model, calibration_data=calibration_data, sparsity=0.4
+    )
+    onnx.checker.check_model(pruned)
+    inits = _inits(pruned)
+    assert inits["FC1Q"].shape == (3, inter, hidden // 2)
+    assert inits["FC1S"].dtype == np.float16
+    assert inits["RW"].dtype == np.float16
+    assert inits["RW"].shape == (hidden, 3)
+    assert inits["FC1B"].dtype == np.float16
+
+    dropped = _dropped_experts(router_w, inits["RW"])
+    assert len(dropped) == 2
+    masked = _qmoe_router_masking_oracle(
+        fc1_q,
+        fc1_s,
+        fc2_q,
+        fc2_s,
+        bits,
+        router_w,
+        router_b,
+        dropped,
+        k,
+        fc1_bias=fc1_b,
+        tokens=tokens,
+        float_dtype=np.float16,
+    )
+    onnx.checker.check_model(masked)
+
+    feed_rng = np.random.default_rng(3017)
+    feeds = {"X": (feed_rng.standard_normal((tokens, hidden)) * 0.3).astype(np.float16)}
+    (out_pruned,) = _run(pruned, feeds)
+    (out_masked,) = _run(masked, feeds)
+    np.testing.assert_allclose(
+        out_pruned.astype(np.float64),
+        out_masked.astype(np.float64),
+        rtol=5e-2,
+        atol=5e-2,
+    )
+
+
+def test_qmoe_whole_expert_pruning_cpp_fp16_adversarial_low_usage_expert_dropped():
+    # QMoE analogue of test_moe_whole_expert_pruning_cpp_fp16_adversarial_
+    # low_usage_expert_dropped -- MoeRouterGateCalibrationStats is oblivious
+    # to whether router_probs came from a MoE or QMoE node (see that
+    # function's own comment), but this exercises the QMoE-specific match/
+    # apply path (MatchQMoEWholeExpertProducer/ApplyQMoEWholeExpertChains)
+    # end to end too, not just the shared calibration helper.
+    E, hidden, inter, bits, tokens = 4, 6, 4, 4, 8
+    rng = np.random.default_rng(3025)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float32)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float32)
+    router_w = (rng.standard_normal((hidden, E)) * 0.05).astype(np.float16)
+    router_b = np.zeros(E, dtype=np.float16)
+    router_b[0] = 8.0
+    router_b[E - 1] = -8.0
+    k = 1
+    fc1_q, fc1_s32 = _qmoe_quantize(fc1_w, bits)
+    fc2_q, fc2_s32 = _qmoe_quantize(fc2_w, bits)
+    model = _qmoe_router_model(
+        fc1_q,
+        fc1_s32.astype(np.float16),
+        fc2_q,
+        fc2_s32.astype(np.float16),
+        bits,
+        router_w,
+        router_b=router_b,
+        k=k,
+        tokens=tokens,
+        float_dtype=np.float16,
+    )
+
+    calib_rng = np.random.default_rng(3027)
+    calibration_data = [
+        {"X": calib_rng.standard_normal((tokens, hidden)).astype(np.float16)}
+        for _ in range(4)
+    ]
+    pruned = onnxsim.apply_qmoe_whole_expert_pruning_cpp(
+        model, calibration_data=calibration_data, sparsity=1.0 / E
+    )
+    inits = _inits(pruned)
+    assert inits["FC1Q"].shape == (E - 1, inter, hidden // 2)
+    dropped = _dropped_experts(router_w, inits["RW"])
+    assert dropped == [E - 1], f"expected the rarely-used expert dropped, got {dropped}"
+
+
+def test_qmoe_whole_expert_pruning_cpp_bfloat16_preserves_dtype_weight_norm_fallback():
+    # No calibration data at all -- falls back to QMoEExpertWeightImportance
+    # (weight-norm-only ranking over the DEQUANTIZED weight, see that
+    # function's own comment), so no BFLOAT16 execution is ever attempted.
+    E, hidden, inter, bits, tokens = 4, 8, 6, 4, 8
+    rng = np.random.default_rng(3019)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float32)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float32)
+    fc1_b = rng.standard_normal((E, inter)).astype(ml_dtypes.bfloat16)
+    router_w = (rng.standard_normal((hidden, E)) * 0.2).astype(ml_dtypes.bfloat16)
+    router_b = rng.standard_normal(E).astype(ml_dtypes.bfloat16)
+    k = 1
+    fc1_q, fc1_s32 = _qmoe_quantize(fc1_w, bits)
+    fc2_q, fc2_s32 = _qmoe_quantize(fc2_w, bits)
+    fc1_s = fc1_s32.astype(ml_dtypes.bfloat16)
+    fc2_s = fc2_s32.astype(ml_dtypes.bfloat16)
+    model = _qmoe_router_model(
+        fc1_q,
+        fc1_s,
+        fc2_q,
+        fc2_s,
+        bits,
+        router_w,
+        router_b=router_b,
+        fc1_bias=fc1_b,
+        k=k,
+        tokens=tokens,
+        float_dtype=ml_dtypes.bfloat16,
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_qmoe_whole_expert_pruning_cpp(
+        model, calibration_data=[], sparsity=0.4
+    )
+    onnx.checker.check_model(pruned)
+    inits = _inits(pruned)
+    # floor = max(1, min(k, E)) = 1; keep_count = max(floor, E - round(E*0.4))
+    # = max(1, 4 - 2) = 2.
+    keep_count = 2
+    assert inits["FC1Q"].shape == (keep_count, inter, hidden // 2)
+    assert inits["FC1S"].dtype == ml_dtypes.bfloat16
+    assert inits["RW"].dtype == ml_dtypes.bfloat16
+    assert inits["RW"].shape == (hidden, keep_count)
+    assert inits["FC1B"].dtype == ml_dtypes.bfloat16
+
+    # Independent re-derivation of QMoEExpertWeightImportance's own
+    # weight-magnitude fallback ranking: dequantize with the ACTUAL
+    # bfloat16-rounded scale/bias this model stores (not the internal
+    # float32 quantizer scale), matching what the C++ port itself reads
+    # back via ReadTensorAsF64. Mirrors this file's own inline `_dequant`
+    # helper in test_qmoe_whole_expert_pruning_cpp_empty_calibration_falls_
+    # back_to_weight_norm above.
+    def _dequant(q, s):
+        e, n, kp = q.shape
+        pack = 8 // bits
+        parts = [(q >> (bits * i)) & ((1 << bits) - 1) for i in range(pack)]
+        unpacked = np.stack(parts, axis=-1).reshape(e, n, kp * pack)
+        return (unpacked.astype(np.float64) - (1 << (bits - 1))) * s[..., None].astype(
+            np.float64
+        )
+
+    fc1_dq = _dequant(fc1_q, fc1_s)
+    fc2_dq = _dequant(fc2_q, fc2_s)
+    fc1_b64 = fc1_b.astype(np.float64)
+    sq = (
+        np.sum(fc1_dq**2, axis=(1, 2))
+        + np.sum(fc2_dq**2, axis=(1, 2))
+        + np.sum(fc1_b64**2, axis=1)
+    )
+    keep = np.sort(np.argsort(-np.sqrt(sq))[:keep_count])
+
+    fc1_q_pruned = onnx.numpy_helper.to_array(
+        next(t for t in pruned.graph.initializer if t.name == "FC1Q")
+    )
+    router_w_pruned = onnx.numpy_helper.to_array(
+        next(t for t in pruned.graph.initializer if t.name == "RW")
+    )
+    np.testing.assert_array_equal(fc1_q_pruned, fc1_q[keep])
+    np.testing.assert_array_equal(
+        router_w_pruned.view(np.uint16), router_w[:, keep].view(np.uint16)
+    )

--- a/tests/test_qmoe_pruning_cpp.py
+++ b/tests/test_qmoe_pruning_cpp.py
@@ -67,6 +67,26 @@ def _f32(array, name):
     return onnx.numpy_helper.from_array(array.astype(np.float32), name)
 
 
+def _f16(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float16), name)
+
+
+def _bf16(array, name):
+    return onnx.numpy_helper.from_array(array.astype(ml_dtypes.bfloat16), name)
+
+
+# Maps a numpy dtype (as passed to _qmoe_model's own `float_dtype`) to the
+# matching (ONNX enum, tensor-builder) pair -- lets _qmoe_model build an
+# activation-dtype-FLOAT16/BFLOAT16 QMoE model for the FP16/BFloat16 weight
+# support tests below, while every existing FLOAT32 call site (the default)
+# is completely unaffected.
+_FLOAT_DTYPE_INFO = {
+    np.dtype(np.float32): (onnx.TensorProto.FLOAT, _f32),
+    np.dtype(np.float16): (onnx.TensorProto.FLOAT16, _f16),
+    np.dtype(ml_dtypes.bfloat16): (onnx.TensorProto.BFLOAT16, _bf16),
+}
+
+
 def _u8(array, name):
     return onnx.numpy_helper.from_array(array.astype(np.uint8), name)
 
@@ -236,44 +256,45 @@ def _qmoe_model(
     tied_fc1_weight_elsewhere=False,
     extra_nodes=(),
     extra_outputs=(),
+    float_dtype=np.float32,
 ):
     # A router-logit input R feeds a real com.microsoft::QMoE node -- see
     # this file's own top comment for why the onnx.parser text format
-    # can't express QMoE's packed uint8 operands.
+    # can't express QMoE's packed uint8 operands. `float_dtype` (FLOAT32 by
+    # default, every existing call site's own behavior unchanged) controls
+    # X/R/Y's own activation dtype and every FLOAT-family operand's own
+    # storage dtype (fc1/fc2 scale and bias) -- see the "FP16/BFloat16
+    # weight support" section below, which passes FLOAT16/BFLOAT16 here to
+    # build the widened-matcher test models. `fc1_q`/`fc2_q`/zero_points
+    # always stay UINT8 regardless -- quantized weight codes have no
+    # separate float-family storage to widen.
+    onnx_dtype, float_tensor = _FLOAT_DTYPE_INFO[np.dtype(float_dtype)]
     num_experts, inter, hidden_packed = fc1_q.shape
     hidden = hidden_packed * (8 // bits)
     inputs = [
-        onnx.helper.make_tensor_value_info(
-            "X", onnx.TensorProto.FLOAT, [tokens, hidden]
-        ),
-        onnx.helper.make_tensor_value_info(
-            "R", onnx.TensorProto.FLOAT, [tokens, num_experts]
-        ),
+        onnx.helper.make_tensor_value_info("X", onnx_dtype, [tokens, hidden]),
+        onnx.helper.make_tensor_value_info("R", onnx_dtype, [tokens, num_experts]),
     ]
-    outputs = [
-        onnx.helper.make_tensor_value_info(
-            "Y", onnx.TensorProto.FLOAT, [tokens, hidden]
-        )
-    ]
+    outputs = [onnx.helper.make_tensor_value_info("Y", onnx_dtype, [tokens, hidden])]
     inits = [
         _u8(fc1_q, "FC1Q"),
-        _f32(fc1_scale, "FC1S"),
+        float_tensor(fc1_scale, "FC1S"),
         _u8(fc2_q, "FC2Q"),
-        _f32(fc2_scale, "FC2S"),
+        float_tensor(fc2_scale, "FC2S"),
     ]
     node_inputs = ["X", "R", "FC1Q", "FC1S", "", "FC2Q", "FC2S", ""]
     if fc1_bias is not None:
         node_inputs[4] = "FC1B"
-        inits.append(_f32(fc1_bias, "FC1B"))
+        inits.append(float_tensor(fc1_bias, "FC1B"))
     if fc2_bias is not None:
         node_inputs[7] = "FC2B"
-        inits.append(_f32(fc2_bias, "FC2B"))
+        inits.append(float_tensor(fc2_bias, "FC2B"))
     while len(node_inputs) < 13:
         node_inputs.append("")
     if fc3_q is not None:
         node_inputs[8] = "FC3Q"
         node_inputs[9] = "FC3S"
-        inits += [_u8(fc3_q, "FC3Q"), _f32(fc3_scale, "FC3S")]
+        inits += [_u8(fc3_q, "FC3Q"), float_tensor(fc3_scale, "FC3S")]
     if fc1_zp is not None:
         node_inputs[11] = "FC1ZP"
         inits.append(_u8(fc1_zp, "FC1ZP"))
@@ -1305,3 +1326,182 @@ def test_qmoe_expert_channel_pruning_cpp_prunes_node_inside_if_branch():
         np.testing.assert_array_equal(inits["FC1S"], fc1_s[:, keep])
         np.testing.assert_array_equal(inits["FC1B"], fc1_b[:, keep])
         np.testing.assert_array_equal(inits["FC2Q"], expected_fc2_q)
+
+
+# --- FP16/BFloat16 weight support -------------------------------------------
+#
+# MatchQMoEProducer (structured_pruning_entry.cpp) used to hard-require
+# ``onnx.TensorProto.FLOAT`` for `fc1_scales`/`fc2_scales` (and, via
+# QMoEOptionalFloatInput, `fc1_experts_bias`/`fc2_experts_bias`), silently
+# declining any QMoE node whose scale/bias tensors were stored as FLOAT16 or
+# BFLOAT16 -- narrower than ``onnxsim.apply_qmoe_expert_channel_pruning``'s
+# own ``_is_supported_float_dtype``. `fc1_experts_weights`/
+# `fc2_experts_weights` themselves are unaffected either way -- always
+# packed UINT8 regardless of the *activation*/scale dtype. Now widened via
+# IsSupportedFloatDtype/ReadTensorAsF64/WriteF64TensorAs (see
+# structured_pruning_entry.cpp's own "QMoE (com.microsoft, quantized-weight
+# Mixture-of-Experts) expert-channel structured pruning" section top
+# comment).
+#
+# FLOAT16: confirmed separately that onnxruntime's CPU QMoE kernel executes
+# genuine FLOAT16 activations/scales/bias, so this runs a real session,
+# mirroring test_qmoe_expert_channel_pruning_cpp_matches_hand_built_presliced_
+# reference's own "re-quantize the sliced float weights from scratch,
+# independently" cross-check. BFLOAT16 has no onnxruntime CPU execution
+# support in this environment at all (see
+# tests/test_moe_pruning_cpp.py's own identical note) -- checked at the
+# array level (dtype preservation, exact per-element bfloat16 decode)
+# instead.
+
+
+def test_qmoe_expert_channel_pruning_cpp_fp16_matches_hand_built_presliced_reference():
+    E, hidden, inter, bits, tokens = 4, 8, 12, 4, 6
+    rng = np.random.default_rng(2001)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float32)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float32)
+    fc1_b = rng.standard_normal((E, inter)).astype(np.float32)
+
+    fc1_q, fc1_s32, _ = _qmoe_quantize(fc1_w, bits)
+    fc2_q, fc2_s32, _ = _qmoe_quantize(fc2_w, bits)
+    # Scale/bias are stored as FLOAT16 in the model -- the importance ranking
+    # below must use the SAME (rounded) FLOAT16 values the C++ port will
+    # actually read back (via ReadTensorAsF64), not the internal FLOAT32
+    # quantizer scale, or a boundary case could rank differently.
+    fc1_s = fc1_s32.astype(np.float16)
+    fc2_s = fc2_s32.astype(np.float16)
+    fc1_b16 = fc1_b.astype(np.float16)
+
+    model = _qmoe_model(
+        fc1_q,
+        fc1_s,
+        fc2_q,
+        fc2_s,
+        bits,
+        fc1_bias=fc1_b16,
+        k=2,
+        tokens=tokens,
+        float_dtype=np.float16,
+    )
+    onnx.checker.check_model(model)
+    inits_before = _qmoe_inits(model)
+    assert inits_before["FC1S"].dtype == np.float16
+    assert inits_before["FC1B"].dtype == np.float16
+
+    pruned = onnxsim.apply_qmoe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = _qmoe_inits(pruned)
+    assert inits["FC1S"].dtype == np.float16
+    assert inits["FC1B"].dtype == np.float16
+    assert inits["FC2S"].dtype == np.float16  # untouched (indexes hidden_size)
+
+    default_zp = 1 << (bits - 1)
+    fc1_dq = (
+        _unpack_vals(fc1_q, bits, hidden).astype(np.float64) - default_zp
+    ) * fc1_s.astype(np.float64)[:, :, None]
+    fc2_dq = (
+        _unpack_vals(fc2_q, bits, inter).astype(np.float64) - default_zp
+    ) * fc2_s.astype(np.float64)[:, :, None]
+    sq = (
+        np.sum(fc1_dq**2, axis=(0, 2))
+        + np.sum(fc2_dq**2, axis=(0, 1))
+        + np.sum(fc1_b16.astype(np.float64) ** 2, axis=0)
+    )
+    keep = np.sort(np.argsort(-np.sqrt(sq))[:6])  # 12 - round(12*0.5) = 6
+
+    np.testing.assert_array_equal(inits["FC1Q"], fc1_q[:, keep, :])
+    np.testing.assert_array_equal(
+        inits["FC1S"].view(np.uint16), fc1_s[:, keep].view(np.uint16)
+    )
+    np.testing.assert_array_equal(
+        inits["FC1B"].view(np.uint16), fc1_b16[:, keep].view(np.uint16)
+    )
+    expected_fc2_q = _pack_vals(_unpack_vals(fc2_q, bits, inter)[:, :, keep], bits)
+    np.testing.assert_array_equal(inits["FC2Q"], expected_fc2_q)
+
+    # Independent cross-check: re-quantize the *sliced* float32 weights from
+    # scratch (never touching the C++ port's own pruned bytes) and confirm a
+    # real onnxruntime CPU FLOAT16 session agrees, mirroring
+    # test_qmoe_expert_channel_pruning_cpp_matches_hand_built_presliced_
+    # reference's own FLOAT32 cross-check.
+    fc1_q_ref, fc1_s_ref32, _ = _qmoe_quantize(fc1_w[:, keep, :], bits)
+    reference = _qmoe_model(
+        fc1_q_ref,
+        fc1_s_ref32.astype(np.float16),
+        expected_fc2_q,
+        fc2_s,
+        bits,
+        fc1_bias=fc1_b16[:, keep],
+        k=2,
+        tokens=tokens,
+        float_dtype=np.float16,
+    )
+    onnx.checker.check_model(reference)
+
+    feed_rng = np.random.default_rng(2003)
+    feeds = {
+        "X": (feed_rng.standard_normal((tokens, hidden)) * 0.2).astype(np.float16),
+        "R": feed_rng.standard_normal((tokens, E)).astype(np.float16),
+    }
+    (out_pruned,) = _run(pruned, feeds)
+    (out_ref,) = _run(reference, feeds)
+    np.testing.assert_allclose(
+        out_pruned.astype(np.float64), out_ref.astype(np.float64), rtol=5e-2, atol=5e-2
+    )
+
+
+def test_qmoe_expert_channel_pruning_cpp_bfloat16_preserves_dtype_and_matches_array_oracle():
+    E, hidden, inter, bits, tokens = 4, 8, 12, 4, 6
+    rng = np.random.default_rng(2005)
+    fc1_w = (rng.standard_normal((E, inter, hidden)) * 0.3).astype(np.float32)
+    fc2_w = (rng.standard_normal((E, hidden, inter)) * 0.3).astype(np.float32)
+    fc1_b = rng.standard_normal((E, inter)).astype(np.float32)
+
+    fc1_q, fc1_s32, _ = _qmoe_quantize(fc1_w, bits)
+    fc2_q, fc2_s32, _ = _qmoe_quantize(fc2_w, bits)
+    fc1_s = fc1_s32.astype(ml_dtypes.bfloat16)
+    fc2_s = fc2_s32.astype(ml_dtypes.bfloat16)
+    fc1_b16 = fc1_b.astype(ml_dtypes.bfloat16)
+
+    model = _qmoe_model(
+        fc1_q,
+        fc1_s,
+        fc2_q,
+        fc2_s,
+        bits,
+        fc1_bias=fc1_b16,
+        k=2,
+        tokens=tokens,
+        float_dtype=ml_dtypes.bfloat16,
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_qmoe_expert_channel_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = _qmoe_inits(pruned)
+    assert inits["FC1S"].dtype == ml_dtypes.bfloat16
+    assert inits["FC1B"].dtype == ml_dtypes.bfloat16
+    assert inits["FC2S"].dtype == ml_dtypes.bfloat16
+
+    default_zp = 1 << (bits - 1)
+    fc1_dq = (
+        _unpack_vals(fc1_q, bits, hidden).astype(np.float64) - default_zp
+    ) * fc1_s.astype(np.float64)[:, :, None]
+    fc2_dq = (
+        _unpack_vals(fc2_q, bits, inter).astype(np.float64) - default_zp
+    ) * fc2_s.astype(np.float64)[:, :, None]
+    sq = (
+        np.sum(fc1_dq**2, axis=(0, 2))
+        + np.sum(fc2_dq**2, axis=(0, 1))
+        + np.sum(fc1_b16.astype(np.float64) ** 2, axis=0)
+    )
+    keep = np.sort(np.argsort(-np.sqrt(sq))[:6])
+
+    np.testing.assert_array_equal(inits["FC1Q"], fc1_q[:, keep, :])
+    np.testing.assert_array_equal(
+        inits["FC1S"].view(np.uint16), fc1_s[:, keep].view(np.uint16)
+    )
+    np.testing.assert_array_equal(
+        inits["FC1B"].view(np.uint16), fc1_b16[:, keep].view(np.uint16)
+    )
+    expected_fc2_q = _pack_vals(_unpack_vals(fc2_q, bits, inter)[:, :, keep], bits)
+    np.testing.assert_array_equal(inits["FC2Q"], expected_fc2_q)


### PR DESCRIPTION
## Summary

Fourteenth round, continuing the effort (started in #1071) to close scope gaps between `pruning.py`'s pure-Python pruning implementations and their C++ ports, retiring the Python code once true parity is verified. Two independent pieces of work, done in parallel:

### 1. Embedding vocabulary pruning (`structured_pruning_entry.cpp`'s embedding-vocab matcher)

Widens the C++ `apply_embedding_vocab_pruning_cpp`/`apply_embedding_vocab_magnitude_pruning_cpp` matcher to close 3 of 4 previously-documented scope gaps:

- **`com.microsoft::EmbedLayerNormalization` producer shape** — new `MatchEmbedLayerNormProducer`, tried alongside the existing plain-`Gather` matcher.
- **`FusedGemm`/`GemmFastGelu` as `lm_head` node types** — new `MatchMatMulLikeWidenedRaw`, local to this section.
- **FLOAT16/BFLOAT16 dtype support** — added from scratch for this section (`IsSupportedFloatDtype` and a full FP16/BF16 ↔ float32 conversion/read/write helper set), mirroring `pruning.py`'s own `_to_f64`/`_from_f64` upcast/downcast convention.

**Remaining gap, deliberately not closed**: `com.microsoft::GatherBlockQuantized` producer support — two distinct sub-byte packing conventions and a `scales`/`zero_points` pair that must move in lockstep make this large enough to risk a subtle packing bug if rushed. Since this gap applies to both entry points, **neither Python function is aliased yet** — `apply_embedding_vocab_pruning`/`apply_embedding_vocab_magnitude_pruning` remain pure-Python pending a follow-up round.

### 2. MoE/QMoE expert-channel and whole-expert pruning

Closes the FLOAT16/BFLOAT16 gap for all 4 related functions, achieving **verified true full parity** on all of them — all 4 are now aliased to their C++ ports:

- `apply_moe_expert_channel_pruning`, `apply_qmoe_expert_channel_pruning`, `apply_moe_whole_expert_pruning`, `apply_qmoe_whole_expert_pruning`

Added a full FLOAT16/BFLOAT16 ↔ `double` numeric-conversion helper set to `MatchMoeProducer`/`MatchQMoEProducer` and everywhere that reads/writes matched weights, scales, and biases — exhaustively round-trip-verified over all 65536 FLOAT16 and all 65536 BFLOAT16 bit patterns, cross-checked against numpy/`ml_dtypes`. Closing this gap surfaced two additional, independent bugs beyond the dtype restriction itself, both found and fixed in the same pass:

- The whole-expert router weight/bias matcher/slicer was FLOAT32-only too (a separate code path from the fc1/fc2 matcher) — added a narrowly-scoped widened duplicate rather than touching the shared, still-FLOAT32-only general-purpose matcher other passes depend on.
- `MoeRouterGateCalibrationStats` hard-required FLOAT `router_probs`, silently falling back to weight-norm-only importance for any FLOAT16/BFLOAT16 whole-expert model even though the Python reference has no such gate — confirmed via a temporary revert-and-rerun that reproduced the wrong-expert-dropped failure, then fixed and re-verified.

## Testing

- `pip install --no-build-isolation -ve .`
- `python3 -m pytest tests/test_pruning.py tests/test_moe_pruning_cpp.py tests/test_qmoe_pruning_cpp.py tests/test_moe_whole_expert_pruning_cpp.py tests/test_embedding_vocab_pruning_cpp.py -k "moe or qmoe or embedding"` — 221 passed
- Full suite (vendor-backend-dependent modules excluded, matching this repo's own CI ignore list) — **2374 passed, 68 skipped**, no regressions
- New FP16 (real onnxruntime execution, including adversarial ranking tests that discriminate the real calibrated ranking from the weight-norm fallback) and BFLOAT16 (array-level; no onnxruntime BFLOAT16 CPU kernel here) coverage across `test_moe_pruning_cpp.py`, `test_qmoe_pruning_cpp.py`, `test_moe_whole_expert_pruning_cpp.py`, `test_embedding_vocab_pruning_cpp.py`
- Golden-snapshot fixtures (base64-encoded `ModelProto`, following the `apply_transformer_block_pruning` precedent from #1071) frozen for MoE/QMoE tests that would otherwise become tautological once aliased
- `clang-format --dry-run --Werror` / `ruff format --check` / `ruff check` / `mypy` all clean

## Scope / follow-up

Next: close the remaining `GatherBlockQuantized` gap for embedding-vocab pruning, then retire its two Python implementations the same way. That leaves the 8 originally-scoped functions (`apply_magnitude_pruning`, `apply_structured_pruning`, `apply_attention_head_pruning`, `apply_wanda_pruning`, `apply_sparsegpt_pruning`, `apply_structured_wanda_pruning`, `apply_attention_head_wanda_pruning`, `apply_quarot`) as the remaining C++-port scope gaps to close before this whole effort is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4t6ntCm72RfFf64W9GYB1