### PR TITLE
Confirm on real hardware every Conv/MatMul variant the static coverage heuristic couldn't verify

### DIFF
--- a/.github/workflows/axera-integration.yml
+++ b/.github/workflows/axera-integration.yml
@@ -38,6 +38,8 @@ on:
       - "tests/test_pulsar2_compat.py"
       - "tests/test_pulsar2_simulator.py"
       - "tests/test_pulsar2_hf_to_axmodel.py"
+      - "tests/test_axera_conv_matmul_coverage.py"
+      - "tests/test_axera_conv_matmul_coverage_hardware.py"
 
 concurrency:
   group: axera-integration-${{ github.ref }}
@@ -105,7 +107,7 @@ jobs:
       - name: Run in-tree smoke tests
         working-directory: ${{ runner.temp }}
         run: |
-          pytest -v "$GITHUB_WORKSPACE/tests/test_pulsar2_compat.py" "$GITHUB_WORKSPACE/tests/test_pulsar2_simulator.py"
+          pytest -v "$GITHUB_WORKSPACE/tests/test_pulsar2_compat.py" "$GITHUB_WORKSPACE/tests/test_pulsar2_simulator.py" "$GITHUB_WORKSPACE/tests/test_axera_conv_matmul_coverage.py"
       - name: Run static Pulsar2 compatibility suite
         working-directory: ${{ runner.temp }}
         run: |
@@ -148,7 +150,7 @@ jobs:
       - name: Run hf-config+safetensors -> onnx -> axmodel integration test
         working-directory: ${{ runner.temp }}
         run: |
-          pytest -v "$GITHUB_WORKSPACE/tests/test_pulsar2_hf_to_axmodel.py"
+          pytest -v "$GITHUB_WORKSPACE/tests/test_pulsar2_hf_to_axmodel.py" "$GITHUB_WORKSPACE/tests/test_axera_conv_matmul_coverage_hardware.py"
       - name: Run real conversion
         working-directory: ${{ runner.temp }}
         env:

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -589,6 +589,43 @@ environment has to go on. `tests/test_axera_conv_matmul_coverage.py` builds
   way a missing `onnxruntime` already did, instead of taking the whole
   import down.
 
+### Confirmed on real hardware: which of these actually build
+
+A later session with real Docker/AX650N access compiled every variant the
+static-heuristic analysis above flagged as unverified, through a real
+`pulsar2 build`. Results (see
+`tests/test_axera_conv_matmul_coverage_hardware.py`):
+
+**Compile successfully, confirming the doc-scraped list under-claims
+nothing for these cases**: `Conv` with `auto_pad="SAME_UPPER"` (despite the
+docs page reportedly requiring `NOTSET` -- either that limit doesn't hold in
+practice for this case, or Pulsar2 silently resolves `auto_pad` to explicit
+`pads` before its own limit would apply), 1-D `Conv`, 3-D `Conv`, broadcasting
+`MatMul` (rank-3 `A` against a rank-2 `B`), and `Gemm` with `transB=1`.
+
+**Fail outright, with the same "not on `AX650_SUPPORTED_OPS`" mechanism the
+static heuristic already predicted**: `ConvInteger`, `QLinearConv`,
+`MatMulInteger`, `QLinearMatMul` -- all four real `pulsar2 build` runs threw
+the exact `KeyError('dont support <OpType> opr in AXOPS/ONNXOPS/CUSTOM_OPS')`
+pattern this repo has seen before (`LRN`, `AxQuantizedGemm` -- see above),
+confirming these standard ONNX quantized ops are genuinely unimplemented on
+this real toolchain, not merely absent from a possibly-incomplete
+docs-scraped list.
+
+**Fails, but with a real, different failure mode neither analysis
+predicted**: `ConvTranspose` -- despite being confirmed present in
+`AX650_SUPPORTED_OPS` (and passing `partition()`'s coverage check, correctly,
+since the op type genuinely is on the list) -- a plain `ConvTranspose`
+(kernel 3x3, default strides/padding, upsampling 8x8 -> 10x10) fails during
+real quantization with `RuntimeError("Op Execution Error: Y(TargetPlatform.
+UNSPECIFIED) - inputs:['X', 'W'], outputs:['Y']")`, not the "dont support"
+pattern above. This is exactly the failure mode the static heuristic
+structurally cannot see (op-type presence alone says nothing about it) and
+is a genuine confirmed gap in `AX650_SUPPORTED_OPS`'s "supported" claim for
+at least this shape/parameter combination -- root cause (a missing required
+attribute this minimal graph didn't set, a PTQ-engine limitation specific to
+transposed conv, or something else) not further diagnosed here.
+
 ## Files
 
 | file | purpose |

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -315,6 +315,59 @@ Also note `axcl_run_model -i/-o/-l`'s exact contract, confirmed by trial:
 -- an arbitrary filename fails with "Stimulus file ... is not exist" naming
 the tensor). `pulsar2_docker.run_on_device_with_input()` already does this.
 
+## Conv/MatMul variants: what the static heuristic can and can't tell you
+
+Prompted by "how does the axmodel format actually treat different kinds of
+Conv/MatMul" -- with no Docker image or AX650N in *this* environment (unlike
+the sessions that produced the real-hardware findings above), the honest
+thing to check is what the checked-in **static heuristic**
+(`pulsar2_ops.AX650_SUPPORTED_OPS` + `pulsar2_simulator.partition()`) can and
+can't distinguish, since that heuristic is all a Docker/device-free
+environment has to go on. `tests/test_axera_conv_matmul_coverage.py` builds
+~16 Conv/MatMul variants via `onnx.parser` and checks them against it:
+
+- **Standard, grouped, depthwise, dilated, strided, `auto_pad`-using, 1-D,
+  3-D Conv, and `ConvTranspose`** all read as identical, full NPU coverage.
+  So do plain `MatMul`, broadcasting/batched `MatMul`, and `Gemm` under every
+  combination of `alpha`/`beta`/`transA`/`transB`. This isn't a bug in the
+  test -- it's `partition()`'s own documented design: it classifies purely by
+  `node.op_type` membership in `AX650_SUPPORTED_OPS`, the same list
+  `inspect_axmodel.py`/`pulsar2_ops.py` scraped from Pulsar2's docs, which
+  says nothing about attributes. The docs page itself has per-op
+  attribute-level limits (e.g. Conv's `auto_pad` must be `NOTSET`) that
+  neither this list nor `partition()` encode -- confirmed absent, not
+  confirmed present, since there's no compiler here to check it against.
+  Extending `pulsar2_ops.py` with real attribute limits needs a source of
+  truth this environment doesn't have (the docs page or a real `pulsar2
+  build` failure); making that gap up would be exactly the kind of
+  unconfirmed guess this harness otherwise avoids.
+- **What *is* checkable without any of that**: none of ONNX's own quantized
+  conv/matmul ops (`QLinearConv`, `ConvInteger`, `QLinearMatMul`,
+  `MatMulInteger`) are in `AX650_SUPPORTED_OPS` at all, so `partition()`/
+  `ax650_build_risks()` flag them as an AX650 build risk regardless of shape.
+  This lines up with `pulsar2_quantizer.py`'s separately-confirmed finding
+  that Pulsar2's own real PTQ output uses proprietary `AxQuantizedConv`-family
+  ops, not standard ONNX quantized operators -- so a graph already quantized
+  with ONNX's own vocabulary (e.g. via `onnxsim.quantize_dynamic`, unlike
+  `pulsar2_quantizer.quantize_like_pulsar2()`, which stays in QDQ form) is
+  something Pulsar2's real frontend has never been confirmed to accept, and
+  this heuristic's answer (flag it) is at least consistent with that.
+- This also surfaced (and fixed) a real bug in the "no Docker/no-device
+  simulator" pitch above: `pulsar2_simulator.py`'s docstring and this
+  README both claim `partition()`/`coverage()` "need only `onnx` and work
+  regardless" -- but `pulsar2_simulator.py` unconditionally imported
+  `pulsar2_quantizer.py`, which unconditionally did `import onnxsim` at
+  module scope, so on a checkout where `onnxsim`'s own compiled extension
+  isn't built yet (this analysis' own environment, notably -- no real
+  `.axmodel`, Docker image, or device either), just importing
+  `pulsar2_simulator` for its `onnx`-only `partition()`/`coverage()` raised
+  `ModuleNotFoundError` before either function ever ran. Fixed by moving the
+  `import onnxsim` inside `pulsar2_quantizer.py`'s existing
+  `PULSAR2_QUANTIZER_AVAILABLE` try/except (alongside the `onnxruntime`
+  import already there), so a missing/unbuilt `onnxsim` degrades the same
+  way a missing `onnxruntime` already did, instead of taking the whole
+  import down.
+
 ## Files
 
 | file | purpose |
@@ -323,7 +376,7 @@ the tensor). `pulsar2_docker.run_on_device_with_input()` already does this.
 | `pulsar2_backend.py` | thin wrapper around `pulsar2_ops.py`: `coverage()`, `new_blocking_op_types()`, `stripped_npu_data()`, `unsafe_for_simplify()`, `ax650_build_risks()`. Shaped like the sibling `*_backend.py` modules for interface symmetry (`PULSAR2_AVAILABLE` is always `True` -- there's no external dependency to be missing). |
 | `inspect_axmodel.py` | standalone CLI for a **real** `.axmodel` file: loads it with `onnx.load()`, then reports non-standard-domain nodes, op types outside the model's declared opset, and suspiciously large raw attributes -- what originally found the `neu mode` node in the real YOLOv8 file. |
 | `models.py` | the shared `scripts/common/synthetic_models.py` suite plus `axera_npu_compiled_leaf` (real CNN `neu mode` node shape) and `axera_llm_layer_leaf` (real per-layer LLM shape: two `neu mode` nodes sharing one initializer) -- no real device needed to exercise the corruption check in CI. |
-| `pulsar2_quantizer.py` | `quantize_like_pulsar2()`: a thin wrapper over `onnxsim.quantize_static(method="minmax")`, which already matches Pulsar2's real numeric convention (U8 asymmetric activations, S8 per-channel weights, MinMax calibration). `PULSAR2_QUANTIZER_AVAILABLE` reflects `onnxruntime`'s availability (onnxsim's quantizer needs it internally, imported lazily). |
+| `pulsar2_quantizer.py` | `quantize_like_pulsar2()`: a thin wrapper over `onnxsim.quantize_static(method="minmax")`, which already matches Pulsar2's real numeric convention (U8 asymmetric activations, S8 per-channel weights, MinMax calibration). `PULSAR2_QUANTIZER_AVAILABLE` reflects both `onnxruntime`'s availability and `onnxsim` itself actually being importable (a checkout with `onnxsim`'s compiled extension not yet built fails `import onnxsim`, not just the lazy `onnxruntime` import inside it -- both are caught the same way so this degrades gracefully instead of taking `pulsar2_simulator.py`'s `import` down with it). |
 | `pulsar2_simulator.py` | `partition()`/`coverage()` (real `AX650_SUPPORTED_OPS` membership, no dependency beyond `onnx`) and `simulate()` (fp32-vs-INT8 estimate via `pulsar2_quantizer.py` + onnxruntime's CPU EP). Validated against real hardware -- see above. |
 | `worker.py` | runs the check for one model in an isolated subprocess, printing one `__RESULT__<json>` line. |
 | `run_pulsar2_compat.py` | drives the suite, writes a CSV, and exits non-zero on any regression. No `--require-*` flag or `skipped` status -- unlike the EP harnesses, this needs no vendor package or device, so it always runs. Entry point for `axera-integration.yml`'s `pulsar2-compat` job (stock runner, no Docker/device). |
@@ -354,6 +407,8 @@ skip-guarded like the EP compat tests, since there's no external dependency
 to be missing). `tests/test_pulsar2_simulator.py` covers the simulator +
 quantizer; its `partition()`/`coverage()` tests are likewise unguarded, but
 `simulate()`/`quantize_like_pulsar2()` need `onnxruntime` and skip without it.
+`tests/test_axera_conv_matmul_coverage.py` is the Conv/MatMul-variant
+heuristic analysis above -- also unguarded, needing only `onnx`.
 
 To get a fast partition/coverage read or a quantization-noise estimate for a
 model, with no Docker or device:

--- a/scripts/axera/pulsar2_quantizer.py
+++ b/scripts/axera/pulsar2_quantizer.py
@@ -50,19 +50,25 @@ from __future__ import annotations
 from typing import Dict, Iterable, Optional
 
 import onnx
-import onnxsim
 
 PULSAR2_QUANTIZER_AVAILABLE = False
 _UNAVAILABLE_REASON: Optional[str] = None
 
 try:
+    # `onnxsim` itself is imported here too, not just `onnxruntime`: a
+    # checkout that hasn't built onnxsim's compiled extension yet (e.g. this
+    # repo before `pip install .`/`setup.py build_ext`) fails `import
+    # onnxsim` outright, same failure mode as a missing `onnxruntime` --
+    # both must be caught here so callers only relying on
+    # `PULSAR2_QUANTIZER_AVAILABLE` (and, transitively, `pulsar2_simulator`'s
+    # `partition()`/`coverage()`, which are documented to need only `onnx`)
+    # degrade gracefully instead of failing to import at all.
     import onnxruntime  # noqa: F401
+
+    import onnxsim
 
     PULSAR2_QUANTIZER_AVAILABLE = True
 except Exception as exc:  # pragma: no cover - depends on the host
-    # onnxsim.quantize_static imports onnxruntime lazily (inside
-    # onnxsim.calibration.calibrate()), so onnxsim itself always imports
-    # fine without it -- check for the real dependency here instead.
     _UNAVAILABLE_REASON = f"{type(exc).__name__}: {exc}"
 
 

--- a/tests/test_axera_conv_matmul_coverage.py
+++ b/tests/test_axera_conv_matmul_coverage.py
@@ -1,0 +1,234 @@
+"""What Pulsar2's static AX650 coverage heuristic can and can't tell apart,
+across the many ONNX shapes that all lower to "a Conv" or "a MatMul."
+
+`scripts/axera/pulsar2_simulator.partition()` (see that module's own
+docstring) classifies a node as NPU-eligible purely by
+`pulsar2_ops.AX650_SUPPORTED_OPS` op-*type* membership -- it does not look at
+attributes at all. This is a known, already-documented limitation (Pulsar2's
+own docs mention per-op attribute limits, e.g. "Conv's auto_pad must be
+NOTSET", that this harness has never had real hardware/Docker access to
+verify). This suite makes the resulting blind spot concrete: standard,
+grouped, depthwise, dilated, strided and `auto_pad`-using Conv, 1-D and 3-D
+Conv, and `ConvTranspose` are all indistinguishable to `partition()` (all
+"npu", op_type `Conv`/`ConvTranspose`), and the same is true across `MatMul`,
+broadcasting/batched `MatMul`, and `Gemm` with any combination of
+`alpha`/`beta`/`transA`/`transB`.
+
+It also pins down one thing that *is* a real, checkable-without-hardware
+finding: Pulsar2's confirmed `AX650_SUPPORTED_OPS` list (scraped from its own
+public docs) does not include any of ONNX's own quantized conv/matmul ops
+(`QLinearConv`, `ConvInteger`, `QLinearMatMul`, `MatMulInteger`) -- consistent
+with `pulsar2_quantizer.py`'s docstring, which found that Pulsar2's real INT8
+pipeline quantizes to its own proprietary `AxQuantizedConv`-family ops, not
+standard ONNX quantized operators. A graph pre-quantized with those standard
+ops (e.g. via `onnxsim.quantize_dynamic`/`onnxruntime.quantization`) reads as
+an AX650 build risk under the current heuristic, op type by itself.
+
+No real Pulsar2/Docker/device access is used or claimed anywhere in this
+file -- every assertion below is reproducible from `scripts/axera/pulsar2_ops.py`
+and `pulsar2_simulator.py`'s existing, checked-in heuristic alone.
+"""
+
+import os
+import sys
+
+import onnx
+from onnx import parser
+
+_AXERA_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "axera"
+)
+if _AXERA_DIR not in sys.path:
+    sys.path.insert(0, _AXERA_DIR)
+
+import pulsar2_backend as backend  # noqa: E402
+import pulsar2_ops as ops  # noqa: E402
+import pulsar2_simulator as sim  # noqa: E402
+
+
+def _model(body, opset=13, ir_version=10):
+    return parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+
+
+# --- Conv-family variants: all opset-13, all group into the same op_type ---
+
+_CONV_VARIANTS = {
+    "conv_standard": """
+        g (float[1,8,10,10] X, float[8,8,3,3] W) => (float[1,8,8,8] Y)
+        { Y = Conv(X, W) }
+    """,
+    "conv_grouped": """
+        g (float[1,8,10,10] X, float[8,2,3,3] W) => (float[1,8,8,8] Y)
+        { Y = Conv<group = 4>(X, W) }
+    """,
+    "conv_depthwise": """
+        g (float[1,8,10,10] X, float[8,1,3,3] W) => (float[1,8,8,8] Y)
+        { Y = Conv<group = 8>(X, W) }
+    """,
+    "conv_dilated": """
+        g (float[1,8,10,10] X, float[8,8,3,3] W) => (float[1,8,6,6] Y)
+        { Y = Conv<dilations = [2, 2]>(X, W) }
+    """,
+    "conv_strided": """
+        g (float[1,8,10,10] X, float[8,8,3,3] W) => (float[1,8,4,4] Y)
+        { Y = Conv<strides = [2, 2]>(X, W) }
+    """,
+    "conv_same_upper": """
+        g (float[1,8,10,10] X, float[8,8,3,3] W) => (float[1,8,10,10] Y)
+        { Y = Conv<auto_pad = "SAME_UPPER">(X, W) }
+    """,
+    "conv_1d": """
+        g (float[1,8,10] X, float[8,8,3] W) => (float[1,8,8] Y)
+        { Y = Conv(X, W) }
+    """,
+    "conv_3d": """
+        g (float[1,8,10,10,10] X, float[8,8,3,3,3] W) => (float[1,8,8,8,8] Y)
+        { Y = Conv(X, W) }
+    """,
+    "conv_transpose": """
+        g (float[1,8,8,8] X, float[8,8,3,3] W) => (float[1,8,10,10] Y)
+        { Y = ConvTranspose(X, W) }
+    """,
+}
+
+# Quantized conv variants: standard ONNX quantized ops, not Pulsar2's own
+# proprietary AxQuantizedConv -- see this module's docstring.
+_QUANT_CONV_VARIANTS = {
+    "conv_integer": """
+        g (uint8[1,8,10,10] X, uint8[8,8,3,3] W) => (int32[1,8,8,8] Y)
+        { Y = ConvInteger(X, W) }
+    """,
+    "qlinear_conv": """
+        g (uint8[1,8,10,10] X) => (uint8[1,8,8,8] Y)
+        <
+          float x_scale = {0.5},
+          uint8 x_zero_point = {0},
+          float[8,8,3,3] w = {0.0},
+          float w_scale = {0.5},
+          uint8 w_zero_point = {0},
+          float y_scale = {0.5},
+          uint8 y_zero_point = {0}
+        >
+        { Y = QLinearConv(X, x_scale, x_zero_point, w, w_scale, w_zero_point, y_scale, y_zero_point) }
+    """,
+}
+
+_MATMUL_VARIANTS = {
+    "matmul_2d": """
+        g (float[4,8] A, float[8,16] B) => (float[4,16] Y)
+        { Y = MatMul(A, B) }
+    """,
+    "matmul_batched_broadcast": """
+        g (float[2,4,8] A, float[8,16] B) => (float[2,4,16] Y)
+        { Y = MatMul(A, B) }
+    """,
+    "gemm_no_trans": """
+        g (float[4,8] A, float[8,16] B) => (float[4,16] Y)
+        { Y = Gemm(A, B) }
+    """,
+    "gemm_transb": """
+        g (float[4,8] A, float[16,8] B) => (float[4,16] Y)
+        { Y = Gemm<transB = 1>(A, B) }
+    """,
+    "gemm_alpha_beta_bias": """
+        g (float[4,8] A, float[8,16] B, float[16] C) => (float[4,16] Y)
+        { Y = Gemm<alpha = 0.5, beta = 0.5>(A, B, C) }
+    """,
+}
+
+_QUANT_MATMUL_VARIANTS = {
+    "matmul_integer": """
+        g (uint8[4,8] A, uint8[8,16] B) => (int32[4,16] Y)
+        { Y = MatMulInteger(A, B) }
+    """,
+    "qlinear_matmul": """
+        g (uint8[4,8] A) => (uint8[4,16] Y)
+        <
+          float a_scale = {0.5},
+          uint8 a_zero_point = {0},
+          float[8,16] b = {0.0},
+          float b_scale = {0.5},
+          uint8 b_zero_point = {0},
+          float y_scale = {0.5},
+          uint8 y_zero_point = {0}
+        >
+        { Y = QLinearMatMul(A, a_scale, a_zero_point, b, b_scale, b_zero_point, y_scale, y_zero_point) }
+    """,
+}
+
+
+def _build(name: str) -> onnx.ModelProto:
+    body = {
+        **_CONV_VARIANTS,
+        **_QUANT_CONV_VARIANTS,
+        **_MATMUL_VARIANTS,
+        **_QUANT_MATMUL_VARIANTS,
+    }[name]
+    return _model(body)
+
+
+def test_all_variants_are_well_formed():
+    for name in {
+        **_CONV_VARIANTS,
+        **_QUANT_CONV_VARIANTS,
+        **_MATMUL_VARIANTS,
+        **_QUANT_MATMUL_VARIANTS,
+    }:
+        onnx.checker.check_model(_build(name))
+
+
+def test_conv_variants_are_indistinguishable_to_the_heuristic():
+    """`partition()` reports full NPU coverage for every plain-float Conv
+    shape, regardless of group/dilation/stride/auto_pad/rank -- it only looks
+    at `node.op_type`. This is the exact "does not model attribute-level
+    limits" gap `pulsar2_simulator.py`'s own docstring already calls out."""
+    for name in _CONV_VARIANTS:
+        model = _build(name)
+        assert sim.coverage(model) == "full", name
+        assert backend.ax650_build_risks(model) == [], name
+
+
+def test_matmul_variants_are_indistinguishable_to_the_heuristic():
+    """Same blind spot for the MatMul/Gemm family: broadcasting shape and
+    alpha/beta/transA/transB are all invisible to op-type-only partitioning."""
+    for name in _MATMUL_VARIANTS:
+        model = _build(name)
+        assert sim.coverage(model) == "full", name
+        assert backend.ax650_build_risks(model) == [], name
+
+
+def test_standard_onnx_quantized_conv_matmul_ops_are_not_on_ax650_list():
+    """`QLinearConv`/`ConvInteger`/`QLinearMatMul`/`MatMulInteger` (ONNX's own
+    quantized-op vocabulary) are absent from the real, docs-scraped
+    `AX650_SUPPORTED_OPS` -- consistent with `pulsar2_quantizer.py`'s finding
+    that Pulsar2's real PTQ output uses its own non-standard
+    `AxQuantizedConv`-family ops instead. A graph already quantized with
+    ONNX's standard quantized ops (e.g. via `onnxsim.quantize_dynamic`) reads
+    as an AX650 build risk under this heuristic today."""
+    for name in {**_QUANT_CONV_VARIANTS, **_QUANT_MATMUL_VARIANTS}:
+        model = _build(name)
+        op_type = model.graph.node[0].op_type
+        assert op_type not in ops.AX650_SUPPORTED_OPS, name
+        assert sim.coverage(model) == "none", name
+        risks = backend.ax650_build_risks(model)
+        assert any(op_type in risk for risk in risks), (name, risks)
+
+
+def test_plain_conv_and_matmul_op_types_are_on_ax650_list():
+    # Sanity check on the two op types this whole file is about: the
+    # unquantized forms are on the list (this is what makes the "full
+    # coverage regardless of attributes" finding above interesting rather
+    # than trivial -- if Conv/MatMul weren't supported at all, every variant
+    # would already read as "none").
+    assert "Conv" in ops.AX650_SUPPORTED_OPS
+    assert "ConvTranspose" in ops.AX650_SUPPORTED_OPS
+    assert "MatMul" in ops.AX650_SUPPORTED_OPS
+    assert "Gemm" in ops.AX650_SUPPORTED_OPS

--- a/tests/test_axera_conv_matmul_coverage_hardware.py
+++ b/tests/test_axera_conv_matmul_coverage_hardware.py
@@ -1,0 +1,259 @@
+"""Real-hardware follow-up to tests/test_axera_conv_matmul_coverage.py:
+that file documents what Pulsar2's *static* AX650 coverage heuristic can
+and can't tell apart, explicitly caveated as never verified against a real
+compiler (no Docker/device access in that session). This file compiles
+every variant it flagged as unverified through a real `pulsar2 build`.
+
+Needs a loaded `pulsar2:*` Docker image -- skip-guarded like
+tests/test_pulsar2_hf_to_axmodel.py. See scripts/axera/README.md's
+"Confirmed on real hardware: which of these actually build" section for
+the narrative writeup of these results.
+"""
+
+import json
+import os
+import sys
+
+import numpy as np
+import onnx
+import pytest
+from onnx import numpy_helper, parser
+
+_AXERA_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "axera"
+)
+if _AXERA_DIR not in sys.path:
+    sys.path.insert(0, _AXERA_DIR)
+
+import pulsar2_docker  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    not pulsar2_docker.docker_image_available(),
+    reason=f"pulsar2 Docker image not loaded: {pulsar2_docker.DEFAULT_IMAGE}",
+)
+
+
+def _model(body, weights=(), opset=13, ir_version=10):
+    model = parser.parse_model(
+        f'<ir_version: {ir_version}, opset_import: ["": {opset}]> {body}'
+    )
+    model.graph.initializer.extend(weights)
+    onnx.checker.check_model(model)
+    return model
+
+
+def _rand_weight(name, shape, seed=0):
+    rng = np.random.default_rng(seed)
+    arr = (rng.standard_normal(shape).astype(np.float32) * 0.1).astype("<f4")
+    return numpy_helper.from_array(arr, name=name)
+
+
+def _rand_uint8_weight(name, shape, seed=0):
+    rng = np.random.default_rng(seed)
+    arr = rng.integers(0, 4, size=shape).astype(np.uint8)
+    return numpy_helper.from_array(arr, name=name)
+
+
+def _generic_quant_config(input_specs, calibration_size=4):
+    return {
+        "model_type": "ONNX",
+        "npu_mode": "NPU1",
+        "quant": {
+            "input_configs": [
+                {
+                    "tensor_name": name,
+                    "calibration_dataset": f"./dataset/calib_{name}.tar",
+                    "calibration_format": "Numpy",
+                    "calibration_size": calibration_size,
+                }
+                for name, _shape, _dtype in input_specs
+            ],
+            "calibration_method": "MinMax",
+            "precision_analysis": False,
+        },
+        "compiler": {"check": 0},
+    }
+
+
+def _build_and_run(tmp_path, name, model, input_specs, calibration_size=4, seed=0):
+    work_dir = os.path.join(str(tmp_path), name)
+    os.makedirs(work_dir, exist_ok=True)
+    onnx.save(model, os.path.join(work_dir, "model.onnx"))
+
+    rng = np.random.default_rng(seed)
+    os.makedirs(os.path.join(work_dir, "dataset"), exist_ok=True)
+    for tname, shape, dtype in input_specs:
+        if np.issubdtype(dtype, np.floating):
+            samples = [
+                rng.standard_normal(shape).astype(dtype)
+                for _ in range(calibration_size)
+            ]
+        else:
+            samples = [
+                rng.integers(0, 4, size=shape).astype(dtype)
+                for _ in range(calibration_size)
+            ]
+        pulsar2_docker.make_numpy_calibration_tar(
+            os.path.join(work_dir, "dataset", f"calib_{tname}.tar"), samples
+        )
+
+    os.makedirs(os.path.join(work_dir, "config"), exist_ok=True)
+    with open(os.path.join(work_dir, "config", "cfg.json"), "w") as f:
+        json.dump(_generic_quant_config(input_specs, calibration_size), f)
+
+    return pulsar2_docker.build(
+        work_dir, "model.onnx", "output", config_path="config/cfg.json"
+    )
+
+
+@pytest.mark.parametrize(
+    "name,body,weight_shape,input_spec",
+    [
+        (
+            "conv_auto_pad_same_upper",
+            "g (float[1,4,10,10] X) => (float[1,4,10,10] Y) "
+            '{ Y = Conv<auto_pad="SAME_UPPER", kernel_shape=[3,3]>(X, W) }',
+            (4, 4, 3, 3),
+            ("X", (1, 4, 10, 10), np.float32),
+        ),
+        (
+            "conv_1d",
+            "g (float[1,4,10] X) => (float[1,4,8] Y) "
+            "{ Y = Conv<kernel_shape=[3]>(X, W) }",
+            (4, 4, 3),
+            ("X", (1, 4, 10), np.float32),
+        ),
+        (
+            "conv_3d",
+            "g (float[1,4,10,10,10] X) => (float[1,4,8,8,8] Y) "
+            "{ Y = Conv<kernel_shape=[3,3,3]>(X, W) }",
+            (4, 4, 3, 3, 3),
+            ("X", (1, 4, 10, 10, 10), np.float32),
+        ),
+    ],
+)
+def test_conv_variant_compiles(tmp_path, name, body, weight_shape, input_spec):
+    model = _model(body, weights=[_rand_weight("W", weight_shape)])
+    result = _build_and_run(tmp_path, name, model, [input_spec])
+    assert result.success, result.error
+
+
+def test_matmul_batched_broadcast_compiles(tmp_path):
+    model = _model(
+        "g (float[2,4,8] A) => (float[2,4,16] Y) { Y = MatMul(A, B) }",
+        weights=[_rand_weight("B", (8, 16))],
+    )
+    result = _build_and_run(
+        tmp_path, "matmul_batched_broadcast", model, [("A", (2, 4, 8), np.float32)]
+    )
+    assert result.success, result.error
+
+
+def test_gemm_transb_compiles(tmp_path):
+    model = _model(
+        "g (float[4,8] A) => (float[4,16] Y) { Y = Gemm<transB=1>(A, B) }",
+        weights=[_rand_weight("B", (16, 8))],
+    )
+    result = _build_and_run(tmp_path, "gemm_transb", model, [("A", (4, 8), np.float32)])
+    assert result.success, result.error
+
+
+def test_gemm_nondefault_alpha_beta_fails(tmp_path):
+    """Confirmed real, see scripts/axera/README.md: distinct from a
+    'not on the supported-op list' failure -- Gemm with non-default
+    alpha/beta lowers to a different, entirely unimplemented
+    AxQuantizedGemm op; default alpha=1.0/beta=1.0 (test_gemm_transb_compiles
+    above; test_axera_conv_matmul_coverage.py's gemm_transb) lowers through
+    the same path as MatMul + bias-add instead and compiles fine."""
+    model = _model(
+        "g (float[4,8] A) => (float[4,16] Y) "
+        "{ Y = Gemm<alpha=2.0, beta=0.5>(A, B, C) }",
+        weights=[_rand_weight("B", (8, 16)), _rand_weight("C", (16,))],
+    )
+    result = _build_and_run(
+        tmp_path, "gemm_nondefault_alpha_beta", model, [("A", (4, 8), np.float32)]
+    )
+    assert not result.success
+    assert "AxQuantizedGemm" in result.error
+
+
+@pytest.mark.parametrize(
+    "name,body,weight_shape,input_spec",
+    [
+        (
+            "conv_integer",
+            "g (uint8[1,4,10,10] X) => (int32[1,4,8,8] Y) { Y = ConvInteger(X, W) }",
+            (4, 4, 3, 3),
+            ("X", (1, 4, 10, 10), np.uint8),
+        ),
+        (
+            "matmul_integer",
+            "g (uint8[4,8] A) => (int32[4,16] Y) { Y = MatMulInteger(A, B) }",
+            (8, 16),
+            ("A", (4, 8), np.uint8),
+        ),
+    ],
+)
+def test_standard_quantized_op_fails_as_unimplemented(
+    tmp_path, name, body, weight_shape, input_spec
+):
+    op_type = body.split(" = ")[1].split("(")[0]
+    model = _model(
+        body, weights=[_rand_uint8_weight("W" if "W" in body else "B", weight_shape)]
+    )
+    result = _build_and_run(tmp_path, name, model, [input_spec])
+    assert not result.success
+    assert f"dont support {op_type} opr" in result.error
+
+
+def test_qlinear_conv_fails_as_unimplemented(tmp_path):
+    model = _model(
+        "g (uint8[1,4,10,10] X) => (uint8[1,4,8,8] Y) "
+        "<float x_scale = {0.5}, uint8 x_zero_point = {0}, "
+        "float w_scale = {0.5}, uint8 w_zero_point = {0}, "
+        "float y_scale = {0.5}, uint8 y_zero_point = {0}> "
+        "{ Y = QLinearConv(X, x_scale, x_zero_point, w, w_scale, w_zero_point, "
+        "y_scale, y_zero_point) }",
+        weights=[_rand_uint8_weight("w", (4, 4, 3, 3))],
+    )
+    result = _build_and_run(
+        tmp_path, "qlinear_conv", model, [("X", (1, 4, 10, 10), np.uint8)]
+    )
+    assert not result.success
+    assert "dont support QLinearConv opr" in result.error
+
+
+def test_qlinear_matmul_fails_as_unimplemented(tmp_path):
+    model = _model(
+        "g (uint8[4,8] A) => (uint8[4,16] Y) "
+        "<float a_scale = {0.5}, uint8 a_zero_point = {0}, "
+        "float b_scale = {0.5}, uint8 b_zero_point = {0}, "
+        "float y_scale = {0.5}, uint8 y_zero_point = {0}> "
+        "{ Y = QLinearMatMul(A, a_scale, a_zero_point, b, b_scale, b_zero_point, "
+        "y_scale, y_zero_point) }",
+        weights=[_rand_uint8_weight("b", (8, 16))],
+    )
+    result = _build_and_run(
+        tmp_path, "qlinear_matmul", model, [("A", (4, 8), np.uint8)]
+    )
+    assert not result.success
+    assert "dont support QLinearMatMul opr" in result.error
+
+
+def test_conv_transpose_fails_with_a_different_error(tmp_path):
+    """Confirmed real, distinct failure mode: ConvTranspose IS present in
+    AX650_SUPPORTED_OPS (test_axera_conv_matmul_coverage.py confirms
+    partition() reports full coverage for it), but a real build of this
+    plain shape fails during quantization, not with the
+    'dont support ... opr' pattern the genuinely-unimplemented ops above
+    hit -- a real gap in the static heuristic's "supported" claim."""
+    model = _model(
+        "g (float[1,4,8,8] X) => (float[1,4,10,10] Y) "
+        "{ Y = ConvTranspose<kernel_shape=[3,3]>(X, W) }",
+        weights=[_rand_weight("W", (4, 4, 3, 3))],
+    )
+    result = _build_and_run(
+        tmp_path, "conv_transpose", model, [("X", (1, 4, 8, 8), np.float32)]
+    )
+    assert not result.success
+    assert "dont support" not in result.error


### PR DESCRIPTION
## Summary

Continuation of `claude/axmodel-format-analysis-qkr1t6` (started in a session without Docker/device access, which added `tests/test_axera_conv_matmul_coverage.py` -- a purely static analysis of what Pulsar2's op-type-only `AX650_SUPPORTED_OPS` coverage heuristic can and can't distinguish across Conv/MatMul variants, explicitly caveated throughout as "never verified against a real compiler"). This session has real Docker + AX650N access, so it compiles every flagged-as-unverified variant through a real `pulsar2 build`:

- **Compile successfully**, confirming the doc-scraped list under-claims nothing here: `Conv` with `auto_pad="SAME_UPPER"`, 1-D `Conv`, 3-D `Conv`, broadcasting `MatMul`, `Gemm` with `transB=1`.
- **Fail as genuinely unimplemented**, confirming the static heuristic's prediction exactly (the same `KeyError('dont support <OpType> opr in AXOPS/ONNXOPS/CUSTOM_OPS')` pattern this repo has seen before for `LRN`/`AxQuantizedGemm`): `ConvInteger`, `QLinearConv`, `MatMulInteger`, `QLinearMatMul`.
- **Fails with a real, different failure mode neither analysis predicted**: `ConvTranspose` is present in `AX650_SUPPORTED_OPS` (and reads as full coverage, correctly, since the op type genuinely is listed) -- but a plain `ConvTranspose` (kernel 3x3, default strides/padding) fails during real quantization with a `RuntimeError`, not the "dont support" pattern above. A real, confirmed gap in the op-list's "supported" claim that the static heuristic structurally cannot see (op-type presence alone says nothing about it).

This also merges in the neu-mode binary-format work from #1082/#1089 (not yet on `master` when the original branch started) and wires both the static and real-hardware test files into `axera-integration.yml`'s `pulsar2-compat` (stock runner) and `pulsar2-docker-convert` (self-hosted, dormant) jobs respectively.

## Test plan
- [x] `tests/test_axera_conv_matmul_coverage_hardware.py`: all 11 tests run for real against the real `pulsar2:6.0-lite` image + AX650N -- 11 passed.
- [x] `python -m pytest tests/test_axera_conv_matmul_coverage.py tests/test_axera_conv_matmul_coverage_hardware.py tests/test_pulsar2_hf_to_axmodel.py tests/test_pulsar2_compat.py tests/test_pulsar2_simulator.py -q` -- 35 passed, no regressions.
- [x] `ruff check` / `ruff format --check` clean.
- [x] YAML-validated `axera-integration.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UC8vhJgE71RLFF4DgdSP9P