### PR TITLE
Fix cross-vendor models/worker import collision in EP compat tests

### DIFF
--- a/scripts/axera/_local_import.py
+++ b/scripts/axera/_local_import.py
@@ -27,30 +27,37 @@ poisoned ``sys.modules["models"]``, and axera's own `models.build(...)` and
 silently ran against a different vendor's module instead.
 
 :func:`fresh` forces a real import from a specific directory regardless of
-what is already cached under that bare name.
+what is already cached under that bare name -- and regardless of ``sys.path``
+order. An earlier version of this function re-imported by bare name
+(``importlib.import_module(name)``) after evicting a wrong cache entry, which
+is not enough on its own once more than one vendor directory needs to be on
+``sys.path`` at the same time (e.g. every caller of :func:`fresh` also needs
+this module's own directory on ``sys.path`` to reach ``_local_import``
+itself): ``import_module`` still resolves the bare name against ``sys.path``
+in order and can land back on a *different* directory's same-named file,
+independent of which ``directory`` was actually asked for. Loading directly
+from ``directory`` by file path removes that ambiguity entirely.
 """
 
 from __future__ import annotations
 
-import importlib
+import importlib.util
 import os
 import sys
 from types import ModuleType
 
 
 def fresh(name: str, directory: str) -> ModuleType:
-    """Import ``name`` from ``directory``, ignoring a same-named module
-    already cached in ``sys.modules`` from a different directory.
-
-    ``directory`` must already be on ``sys.path`` (callers here always
-    prepend their own ``HERE`` before calling this).
+    """Import ``<directory>/<name>.py`` as module ``name``, bypassing both
+    ``sys.modules`` caching and ``sys.path`` search-order ambiguity -- the
+    result is always the file at that exact path, never a same-named module
+    some other directory on ``sys.path`` happens to also provide.
     """
-    cached = sys.modules.get(name)
-    if cached is not None:
-        cached_file = getattr(cached, "__file__", None)
-        if (
-            cached_file is None
-            or os.path.dirname(os.path.abspath(cached_file)) != directory
-        ):
-            del sys.modules[name]
-    return importlib.import_module(name)
+    path = os.path.join(directory, f"{name}.py")
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {name!r} from {path!r}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module

--- a/tests/test_coreml_compat.py
+++ b/tests/test_coreml_compat.py
@@ -22,10 +22,23 @@ _APPLE_DIR = os.path.join(
 )
 if _APPLE_DIR not in sys.path:
     sys.path.insert(0, _APPLE_DIR)
+_AXERA_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "axera"
+)
+if _AXERA_DIR not in sys.path:
+    sys.path.insert(0, _AXERA_DIR)
 
 import coreml_backend as coreml  # noqa: E402
-import models  # noqa: E402
-from worker import check  # noqa: E402
+
+# fresh(), not a bare `import models`/`from worker import check`: every
+# scripts/<vendor>/ directory has its own models.py (and most have their own
+# worker.py too), all imported by the same bare name -- see
+# scripts/axera/_local_import.py's docstring for why a plain import here can
+# silently resolve to a *different* vendor's module in the full test suite.
+from _local_import import fresh  # noqa: E402
+
+models = fresh("models", _APPLE_DIR)
+check = fresh("worker", _APPLE_DIR).check
 
 pytestmark = pytest.mark.skipif(
     not coreml.COREML_AVAILABLE,

--- a/tests/test_migraphx_compat.py
+++ b/tests/test_migraphx_compat.py
@@ -25,10 +25,23 @@ _AMD_DIR = os.path.join(
 )
 if _AMD_DIR not in sys.path:
     sys.path.insert(0, _AMD_DIR)
+_AXERA_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "axera"
+)
+if _AXERA_DIR not in sys.path:
+    sys.path.insert(0, _AXERA_DIR)
 
 import migraphx_backend as migraphx  # noqa: E402
-import models  # noqa: E402
-from worker import check  # noqa: E402
+
+# fresh(), not a bare `import models`/`from worker import check`: every
+# scripts/<vendor>/ directory has its own models.py (and most have their own
+# worker.py too), all imported by the same bare name -- see
+# scripts/axera/_local_import.py's docstring for why a plain import here can
+# silently resolve to a *different* vendor's module in the full test suite.
+from _local_import import fresh  # noqa: E402
+
+models = fresh("models", _AMD_DIR)
+check = fresh("worker", _AMD_DIR).check
 
 pytestmark = pytest.mark.skipif(
     not migraphx.MIGRAPHX_AVAILABLE,

--- a/tests/test_openvino_compat.py
+++ b/tests/test_openvino_compat.py
@@ -23,10 +23,23 @@ _INTEL_DIR = os.path.join(
 )
 if _INTEL_DIR not in sys.path:
     sys.path.insert(0, _INTEL_DIR)
+_AXERA_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "axera"
+)
+if _AXERA_DIR not in sys.path:
+    sys.path.insert(0, _AXERA_DIR)
 
-import models  # noqa: E402
 import openvino_backend as openvino  # noqa: E402
-from worker import check  # noqa: E402
+
+# fresh(), not a bare `import models`/`from worker import check`: every
+# scripts/<vendor>/ directory has its own models.py (and most have their own
+# worker.py too), all imported by the same bare name -- see
+# scripts/axera/_local_import.py's docstring for why a plain import here can
+# silently resolve to a *different* vendor's module in the full test suite.
+from _local_import import fresh  # noqa: E402
+
+models = fresh("models", _INTEL_DIR)
+check = fresh("worker", _INTEL_DIR).check
 
 pytestmark = pytest.mark.skipif(
     not openvino.OPENVINO_AVAILABLE,

--- a/tests/test_qnn_compat.py
+++ b/tests/test_qnn_compat.py
@@ -25,10 +25,23 @@ _QUALCOMM_DIR = os.path.join(
 )
 if _QUALCOMM_DIR not in sys.path:
     sys.path.insert(0, _QUALCOMM_DIR)
+_AXERA_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "axera"
+)
+if _AXERA_DIR not in sys.path:
+    sys.path.insert(0, _AXERA_DIR)
 
-import models  # noqa: E402
 import qnn_backend as qnn  # noqa: E402
-from worker import check  # noqa: E402
+
+# fresh(), not a bare `import models`/`from worker import check`: every
+# scripts/<vendor>/ directory has its own models.py (and most have their own
+# worker.py too), all imported by the same bare name -- see
+# scripts/axera/_local_import.py's docstring for why a plain import here can
+# silently resolve to a *different* vendor's module in the full test suite.
+from _local_import import fresh  # noqa: E402
+
+models = fresh("models", _QUALCOMM_DIR)
+check = fresh("worker", _QUALCOMM_DIR).check
 
 pytestmark = pytest.mark.skipif(
     not qnn.QNN_AVAILABLE,


### PR DESCRIPTION
## Summary

- `tests/test_coreml_compat.py`, `test_migraphx_compat.py`, `test_openvino_compat.py`, and `test_qnn_compat.py` each prepend their own `scripts/<vendor>` directory to `sys.path` and do a bare `import models` / `from worker import check`. But `scripts/apple`, `scripts/amd`, `scripts/intel`, and `scripts/qualcomm` all name their own harness modules exactly `"models"`/`"worker"` too, and Python caches imports by that bare name in `sys.modules` — whichever vendor's `models.py` the full test suite happens to import first stays cached for the rest of the process, so every other vendor's later `import models` silently reuses it instead of its own.
- This went unnoticed as long as every `models.py` was a functionally identical thin alias for the shared `scripts/common/synthetic_models` suite (`scripts/axera/_local_import.py`'s own docstring already diagnosed this exact class of bug). It became visible the moment `scripts/axera/models.py` added `axera_npu_compiled_leaf`/`axera_llm_layer_leaf`, which the other vendors' status-value assertions don't expect — reproduced as `test_coreml_compat_suite[axera_npu_compiled_leaf]` failing on the `Build wheel cp311 on macos-15` CI job on multiple unrelated, in-flight PRs (asserting `status in ("ok", "unsupported")` against axera's `pulsar2_unsafe_for_simplify` fixture, run through Core ML's own harness by mistake).
- `test_pulsar2_compat.py` already worked around this for its own import via `_local_import.fresh()`, but `fresh()` itself wasn't fully collision-proof: it re-imported by bare name (`importlib.import_module`) after evicting a stale cache entry, which still resolves against `sys.path` order rather than the requested directory. That was fine as long as only axera's own directory needed to be on `sys.path` at once; it breaks once every vendor's test file also needs `scripts/axera` on `sys.path` to reach the shared `_local_import` helper. Rewrote `fresh()` to load the target file directly via `importlib.util.spec_from_file_location`, independent of `sys.path` order, and adopted it in the four other vendor compat test files.

## Test plan

- [x] Standalone repro script confirms the bug directly: after `scripts/axera/models.py` is cached under `sys.modules["models"]`, a naive `import models` (simulating the old `test_coreml_compat.py`) returns axera's module, with `axera_npu_compiled_leaf` in its `names()`.
- [x] The same repro with the fixed `fresh()` correctly returns each vendor's own 5-model list regardless of which vendor's module was cached first.
- [x] `pytest --collect-only` on all 5 compat test files together, in both file orders (alphabetical and reversed) — each vendor's `test_*_compat_suite` now only ever parametrizes over its own models; only `test_pulsar2_compat.py` shows the two axera-specific fixtures.
- [x] `pytest tests/test_coreml_compat.py tests/test_migraphx_compat.py tests/test_openvino_compat.py tests/test_qnn_compat.py tests/test_pulsar2_compat.py tests/test_pulsar2_simulator.py tests/test_pulsar2_hf_to_axmodel.py` — 15 passed, 29 skipped (EPs unavailable on this Linux runner), no failures.
- [x] `ruff format --check` / `ruff check` clean on all touched files.
- [x] `mypy` — 24 pre-existing errors matching the current `master` baseline, none in touched files.
- [x] Full suite sweep (`pytest tests/ -q --continue-on-collection-errors -k "not torch"`) — same pre-existing failures/collection errors as a clean `master` checkout, no new regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UFQG9xTf4YexUPryTjccoH

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFQG9xTf4YexUPryTjccoH)_