### PR TITLE
Add TensorFlow Lite export (--emit-tflite / onnxsim.export_tflite)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,10 @@ constant folding until the model stops changing. Around that it offers:
 - **[TensorFlow Lite export](#exporting-to-tensorflow-lite).** Convert the
   simplified model to a `.tflite` flatbuffer with `--emit-tflite` (Python:
   `onnxsim.export_tflite`), via a built-in ONNX-to-TensorFlow translator and
-  `tf.lite.TFLiteConverter`. TensorFlow is optional.
+  `tf.lite.TFLiteConverter`. TensorFlow is optional; pass `--tflite-backend
+  onnx2tf` to route through
+  [onnx2tf](https://github.com/PINTO0309/onnx2tf) instead for far broader op
+  coverage.
 - **Large-model handling.** Guard against blow-up from ops like `Tile`/
   `ConstantOfShape` (`--no-large-tensor`), read and write external-data models,
   and eliminate unused outputs (`--unused-output`).
@@ -479,6 +482,43 @@ onnxsim.export_tflite(model_simp, "model.tflite")
 `tf.lite.TFLiteConverter.optimizations` (e.g. `["DEFAULT"]`, what
 `--tflite-optimize` sets, to enable post-training dynamic-range
 quantization). See `onnxsim/tflite_export.py` for the full signature.
+
+### A broader-coverage backend: onnx2tf
+
+The built-in translator above covers a practical op subset. For a model that
+hits an unsupported op, pass `backend="onnx2tf"` (CLI: `--tflite-backend
+onnx2tf`) to route the conversion through
+[onnx2tf](https://github.com/PINTO0309/onnx2tf) instead -- a separate,
+actively maintained project with far broader op coverage (~200 ops) and years
+of production hardening across real-world model zoos.
+
+```
+pip install onnx2tf
+```
+
+onnx2tf is a much heavier dependency than the builtin backend needs (it pulls
+its own TensorFlow, onnxruntime, onnx-graphsurgeon, and a couple dozen small
+`*4onnx` helper packages), and it changes the model's public input/output
+tensor layout to channel-last by default -- it converts *every* tensor of
+rank >= 3 to that convention, not just 4-D image tensors, unlike the builtin
+backend which always keeps ONNX's own declared shapes. Pass onnx2tf's own
+`keep_ncw_or_nchw_or_ncdhw_input_names` (a list of input names to keep in
+their original ONNX layout) as an extra keyword argument if you need specific
+inputs to keep their original layout.
+
+```
+onnxsim input.onnx simplified.onnx --emit-tflite --tflite-backend onnx2tf
+```
+
+```python
+tflite_model = onnxsim.export_tflite(model_simp, backend="onnx2tf")
+```
+
+`--tflite-optimize`/`optimizations` only applies to the builtin backend; use
+onnx2tf's own quantization options (forwarded as extra keyword arguments,
+e.g. `output_integer_quantized_tflite=True`) instead. See
+`onnxsim/onnx2tf_export.py` for the full signature and onnx2tf's own
+documentation for its option list.
 
 ## Constant folding on the GPU (CUDA execution provider)
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ constant folding until the model stops changing. Around that it offers:
   `onnxsim.export_coreml`), via a built-in ONNX-to-MIL translator and
   [coremltools](https://github.com/apple/coremltools)' MIL-to-Core-ML backend.
   coremltools is optional.
+- **[TensorFlow Lite export](#exporting-to-tensorflow-lite).** Convert the
+  simplified model to a `.tflite` flatbuffer with `--emit-tflite` (Python:
+  `onnxsim.export_tflite`), via a built-in ONNX-to-TensorFlow translator and
+  `tf.lite.TFLiteConverter`. TensorFlow is optional.
 - **Large-model handling.** Guard against blow-up from ops like `Tile`/
   `ConstantOfShape` (`--no-large-tensor`), read and write external-data models,
   and eliminate unused outputs (`--unused-output`).
@@ -404,6 +408,77 @@ the default, or the legacy `"neuralnetwork"`), `compute_units` (which devices
 the model may run on, e.g. `"CPU_ONLY"`), `compute_precision`,
 `minimum_deployment_target` (e.g. `"iOS16"`), and `skip_model_load` (see
 above). See `onnxsim/coreml_export.py` for the full signature.
+
+## Exporting to TensorFlow Lite
+
+Mobile/embedded runtimes built on TensorFlow want the graph as a `.tflite`
+flatbuffer instead of ONNX or Core ML. `onnx-tensorflow`/`onnx-tf` (the
+project that used to fill this gap) has been unmaintained for years and only
+tracks very old opsets, so -- same situation as Core ML after coremltools
+dropped its own ONNX frontend -- onnxsim ships its own ONNX-to-TensorFlow
+translator: it builds the equivalent computation with plain TensorFlow ops
+inside a `tf.function`, traces it into a concrete function, and hands that to
+`tf.lite.TFLiteConverter` to produce the actual `.tflite` model. It covers a
+practical subset of ops (conv/pooling/normalization, matmul/gemm, elementwise
+math, reshapes, reductions, and more -- see
+`tflite_export.SUPPORTED_ONNX_OPS`); a node whose op isn't supported raises a
+clear error naming the op, rather than silently producing a wrong model.
+Feeding in a *simplified* model is the point, same as with the other export
+backends: onnxsim's constant folding turns more of the graph's
+shape-manipulation subgraphs into plain initializers, which this translator
+needs at conversion time for things like a `Reshape`'s target shape or a
+`Slice`'s bounds.
+
+TensorFlow is **optional**, just like onnxruntime for constant folding and
+coremltools for Core ML export: it isn't imported unless you actually export
+to TFLite.
+
+```
+pip install tensorflow
+```
+
+TensorFlow Lite's own op kernels are NHWC-only, while ONNX's conv/pool ops
+are NCHW; this translator keeps the graph's public tensors in ONNX's NCHW
+layout and transposes to/from NHWC only around the ops that need it, so no
+manual layout conversion is required on your part. Graph inputs must have
+fully static shapes (dynamic axes aren't supported) -- pin them first with
+`--overwrite-input-shape`/`--test-input-shape` if needed.
+
+From the CLI, add `--emit-tflite`. Passed without a path it writes the model
+next to the output model with a `.tflite` extension; pass a path to choose
+the location:
+
+```
+# writes simplified.onnx and simplified.tflite
+onnxsim input.onnx simplified.onnx --emit-tflite
+
+# choose the path explicitly, and enable TFLite's default post-training
+# (dynamic-range) quantization
+onnxsim input.onnx simplified.onnx --emit-tflite model.tflite --tflite-optimize
+```
+
+From Python, `onnxsim.export_tflite` converts a model (typically the output
+of `simplify`) and returns the serialized `.tflite` flatbuffer (`bytes`),
+optionally writing it to a file:
+
+```python
+import onnx
+import onnxsim
+
+model = onnx.load("input.onnx")
+model_simp, ok = onnxsim.simplify(model)
+assert ok
+
+# Return the flatbuffer bytes...
+tflite_model = onnxsim.export_tflite(model_simp)
+# ...and/or write it to a file.
+onnxsim.export_tflite(model_simp, "model.tflite")
+```
+
+`export_tflite` accepts an `optimizations` keyword argument, forwarded to
+`tf.lite.TFLiteConverter.optimizations` (e.g. `["DEFAULT"]`, what
+`--tflite-optimize` sets, to enable post-training dynamic-range
+quantization). See `onnxsim/tflite_export.py` for the full signature.
 
 ## Constant folding on the GPU (CUDA execution provider)
 

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -172,6 +172,7 @@ from onnxsim.spqr import quantize_weight_only_spqr
 from onnxsim.squeezellm import quantize_weight_only_squeezellm
 from onnxsim.tensorrt_sparsity import convert_matmul_to_gemm
 from onnxsim.tesseraq import apply_tesseraq
+from onnxsim.tflite_export import export_tflite
 from onnxsim.transformers_export import export_transformers_model
 from onnxsim.zeroquant import apply_zeroquant
 
@@ -343,5 +344,6 @@ __all__ = [
     "export_transformers_model",
     "export_mlir",
     "export_coreml",
+    "export_tflite",
     "__version__",
 ]

--- a/onnxsim/onnx2tf_export.py
+++ b/onnxsim/onnx2tf_export.py
@@ -1,0 +1,158 @@
+"""Convert a (simplified) ONNX model to TensorFlow Lite via `onnx2tf
+<https://github.com/PINTO0309/onnx2tf>`_.
+
+``onnxsim/tflite_export.py`` ships a hand-written ONNX-to-TensorFlow translator
+covering a practical subset of ops. onnx2tf is a separate, actively maintained
+project that does the same job with far broader op coverage (~200 ops) and years of
+production hardening across real-world model zoos -- at the cost of being a much
+heavier dependency (it pulls its own TensorFlow, onnxruntime, onnx-graphsurgeon, and
+a couple dozen small ``*4onnx`` helper packages) and changing the model's public
+input/output tensor layout by default (it converts every tensor of rank >= 3 to a
+channel-last convention, not just 4-D image tensors -- see onnx2tf's own
+``keep_ncw_or_nchw_or_ncdhw_input_names`` and related options to pin specific inputs
+to their original layout instead).
+
+This module is the ``backend="onnx2tf"`` implementation behind
+``onnxsim.export_tflite`` / ``tflite_export.convert_to_tflite`` -- use it when a model
+hits an unsupported op in the built-in translator. onnx2tf is an **optional**
+dependency: nothing here is imported unless that backend is actually selected.
+
+onnx2tf.convert() unconditionally tries to download a small sample-image ``.npy``
+file from its GitHub releases for internal per-op numeric self-verification,
+whenever any graph input looks image-shaped (rank-4, channel-last-3 once converted to
+onnx2tf's own layout convention) -- even when no verification flag is passed, and
+with no offline fallback if the network is unavailable or blocked. The actual pixel
+values only need to be finite and correctly shaped (they sanity-check onnx2tf's own
+lowering, not onnxsim's output), so this module monkeypatches that one function for
+the duration of the call to hand back a small in-memory random array instead of
+letting it hit the network.
+"""
+
+import contextlib
+import os
+import tempfile
+from typing import Any, Dict, Optional
+from unittest import mock
+
+import numpy as np
+import onnx
+
+_ONNX2TF_INSTALL_HINT = (
+    "onnx2tf is required for the 'onnx2tf' TFLite export backend but is not "
+    "installed. Install it with `pip install onnx2tf` -- note this is a heavy "
+    "dependency: it pulls its own TensorFlow, onnxruntime, and onnx-graphsurgeon."
+)
+
+
+def has_onnx2tf() -> bool:
+    """Whether onnx2tf is importable in this environment."""
+    try:
+        import onnx2tf  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def _import_onnx2tf():
+    try:
+        import onnx2tf
+    except ImportError as exc:
+        raise RuntimeError(_ONNX2TF_INSTALL_HINT) from exc
+    return onnx2tf
+
+
+def _random_calibration_data() -> np.ndarray:
+    """Stand-in for onnx2tf's ``download_test_image_data()``: same shape/dtype
+    (20 128x128 RGB images) as the real sample it fetches from GitHub releases,
+    but generated in-memory instead of over the network."""
+    return np.random.default_rng(0).random((20, 128, 128, 3), dtype=np.float32)
+
+
+@contextlib.contextmanager
+def _isolated_cwd():
+    """Run onnx2tf.convert() with its current working directory pointed at a
+    scratch directory, restoring the caller's cwd afterward.
+
+    onnx2tf.convert() writes small housekeeping artifacts relative to the
+    process's current working directory even with ``disable_model_save=True``
+    (e.g. an empty ``saved_model`` directory, observed with onnx2tf 1.29) --
+    isolating cwd keeps those out of the caller's project directory.
+    """
+    prev_cwd = os.getcwd()
+    with tempfile.TemporaryDirectory(prefix="onnxsim_onnx2tf_") as tmp_dir:
+        os.chdir(tmp_dir)
+        try:
+            yield
+        finally:
+            os.chdir(prev_cwd)
+
+
+def convert_to_tflite_via_onnx2tf(
+    model: onnx.ModelProto, **onnx2tf_kwargs: Any
+) -> bytes:
+    """Convert an ONNX model to an in-memory TFLite flatbuffer (``bytes``) using
+    onnx2tf as the ONNX-to-TensorFlow backend.
+
+    Parameters
+    ----------
+    model:
+        The ONNX model to convert. Typically the output of :func:`onnxsim.simplify`.
+    **onnx2tf_kwargs:
+        Forwarded to ``onnx2tf.convert()`` -- e.g. ``keep_ncw_or_nchw_or_ncdhw_input_names``
+        (list of input names to keep in their original ONNX layout instead of
+        onnx2tf's default channel-last conversion), ``batch_size``, or
+        ``output_integer_quantized_tflite``. ``onnx_graph`` is always ``model``
+        and ``disable_model_save``/``non_verbose`` default to ``True`` unless
+        overridden. See onnx2tf's own documentation for the full option list.
+
+    Returns
+    -------
+    bytes
+        The serialized ``.tflite`` flatbuffer, produced by handing onnx2tf's
+        in-memory Keras model to ``tf.lite.TFLiteConverter.from_keras_model``.
+
+    Raises
+    ------
+    RuntimeError
+        If onnx2tf is not installed, or conversion fails (onnx2tf's own error,
+        naming the unsupported op/feature, is preserved in the message).
+    """
+    onnx2tf = _import_onnx2tf()
+    import onnx2tf.onnx2tf as onnx2tf_impl
+    import tensorflow as tf
+
+    kwargs: Dict[str, Any] = {"disable_model_save": True, "non_verbose": True}
+    kwargs.update(onnx2tf_kwargs)
+
+    with mock.patch.object(
+        onnx2tf_impl, "download_test_image_data", _random_calibration_data
+    ):
+        with _isolated_cwd():
+            try:
+                keras_model = onnx2tf.convert(onnx_graph=model, **kwargs)
+            except Exception as exc:
+                raise RuntimeError(f"onnx2tf conversion failed: {exc}") from exc
+
+    converter = tf.lite.TFLiteConverter.from_keras_model(keras_model)
+    try:
+        return converter.convert()
+    except Exception as exc:
+        raise RuntimeError(
+            f"TFLite conversion of the onnx2tf-produced model failed: {exc}"
+        ) from exc
+
+
+def export_tflite_via_onnx2tf(
+    model: onnx.ModelProto,
+    output_path: Optional[str] = None,
+    **kwargs: Any,
+) -> bytes:
+    """Convert ``model`` to TFLite via onnx2tf, optionally saving it to
+    ``output_path``. Other keyword arguments are forwarded to
+    :func:`convert_to_tflite_via_onnx2tf`. See that function for details.
+    """
+    tflite_model = convert_to_tflite_via_onnx2tf(model, **kwargs)
+    if output_path is not None:
+        with open(output_path, "wb") as f:
+            f.write(tflite_model)
+    return tflite_model

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -3773,6 +3773,23 @@ def main():
         "or 'macOS13'. Defaults to coremltools' own default.",
     )
     parser.add_argument(
+        "--emit-tflite",
+        nargs="?",
+        const="",
+        default=None,
+        metavar="PATH",
+        help="Also convert the simplified model to TensorFlow Lite (via "
+        "TensorFlow; pip install tensorflow). Requires fully static input shapes. "
+        "Optionally give an output path; when the flag is passed without one, it "
+        "is written next to the output model with a '.tflite' extension.",
+    )
+    parser.add_argument(
+        "--tflite-optimize",
+        action="store_true",
+        help="Enable TFLite's default post-training (dynamic-range) quantization "
+        "when converting with --emit-tflite.",
+    )
+    parser.add_argument(
         "--node-reduction-plot",
         help="After simplifying, plot node count per round for each "
         "simplification fixed-point loop (from the --profile trace's "
@@ -4663,6 +4680,24 @@ def main():
             print(Text(str(e), style="bold red"))
             sys.exit(1)
         print(f"Core ML model written to {coreml_path}")
+
+    if args.emit_tflite is not None:
+        from onnxsim import tflite_export
+
+        if args.emit_tflite:
+            tflite_path = args.emit_tflite
+        else:
+            tflite_path = os.path.splitext(args.output_model)[0] + ".tflite"
+        print(f"Converting to TensorFlow Lite at {tflite_path} ...")
+        tflite_kwargs = {}
+        if args.tflite_optimize:
+            tflite_kwargs["optimizations"] = ["DEFAULT"]
+        try:
+            tflite_export.export_tflite(model_opt, tflite_path, **tflite_kwargs)
+        except RuntimeError as e:
+            print(Text(str(e), style="bold red"))
+            sys.exit(1)
+        print(f"TFLite model written to {tflite_path}")
 
     if check_ok:
         print("Finish! Here is the difference:")

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -3787,7 +3787,19 @@ def main():
         "--tflite-optimize",
         action="store_true",
         help="Enable TFLite's default post-training (dynamic-range) quantization "
-        "when converting with --emit-tflite.",
+        "when converting with --emit-tflite. Only applies to --tflite-backend "
+        "builtin.",
+    )
+    parser.add_argument(
+        "--tflite-backend",
+        choices=["builtin", "onnx2tf"],
+        default="builtin",
+        help="Which ONNX-to-TensorFlow translator --emit-tflite uses: 'builtin' "
+        "(default, covers a practical op subset, keeps the model's NCHW I/O "
+        "layout) or 'onnx2tf' (via https://github.com/PINTO0309/onnx2tf; pip "
+        "install onnx2tf -- far broader op coverage, but a much heavier "
+        "dependency and a default channel-last I/O layout). Reach for onnx2tf "
+        "when a model hits an unsupported op with the builtin translator.",
     )
     parser.add_argument(
         "--node-reduction-plot",
@@ -4684,12 +4696,23 @@ def main():
     if args.emit_tflite is not None:
         from onnxsim import tflite_export
 
+        if args.tflite_optimize and args.tflite_backend != "builtin":
+            print(
+                Text(
+                    "--tflite-optimize only applies to --tflite-backend builtin.",
+                    style="bold red",
+                )
+            )
+            sys.exit(1)
         if args.emit_tflite:
             tflite_path = args.emit_tflite
         else:
             tflite_path = os.path.splitext(args.output_model)[0] + ".tflite"
-        print(f"Converting to TensorFlow Lite at {tflite_path} ...")
-        tflite_kwargs = {}
+        print(
+            f"Converting to TensorFlow Lite (backend: {args.tflite_backend}) at "
+            f"{tflite_path} ..."
+        )
+        tflite_kwargs = {"backend": args.tflite_backend}
         if args.tflite_optimize:
             tflite_kwargs["optimizations"] = ["DEFAULT"]
         try:

--- a/onnxsim/tflite_export.py
+++ b/onnxsim/tflite_export.py
@@ -32,6 +32,14 @@ first with onnxsim's own ``--overwrite-input-shape``/``--test-input-shape`` if n
 TensorFlow Lite's own op kernels are NHWC-only, while ONNX's conv/pool ops are NCHW;
 this translator keeps the graph's public tensors in ONNX's NCHW layout and transposes
 to/from NHWC only around the ops (``Conv``/``MaxPool``/``AveragePool``) that need it.
+
+A model whose op set goes beyond ``SUPPORTED_ONNX_OPS`` can instead be routed through
+`onnx2tf <https://github.com/PINTO0309/onnx2tf>`_, an actively maintained third-party
+project with far broader op coverage, via ``backend="onnx2tf"`` on
+:func:`convert_to_tflite`/:func:`export_tflite` (CLI: ``--tflite-backend onnx2tf``).
+See ``onnx2tf_export.py`` for what that trades off in return (a much heavier
+dependency, and a default channel-last I/O layout unlike this module's NCHW-preserving
+translator).
 """
 
 from typing import Any, Dict, List, Optional, Tuple
@@ -889,7 +897,9 @@ def _build_concrete_function(model: onnx.ModelProto, tf):
 def convert_to_tflite(
     model: onnx.ModelProto,
     *,
+    backend: str = "builtin",
     optimizations: Optional[List[Any]] = None,
+    **backend_kwargs: Any,
 ):
     """Convert an ONNX model to an in-memory TFLite flatbuffer (``bytes``).
 
@@ -897,13 +907,25 @@ def convert_to_tflite(
     ----------
     model:
         The ONNX model to convert. Typically the output of :func:`onnxsim.simplify`.
-        Every graph input dimension must be static; every node's op must be one of
-        ``SUPPORTED_ONNX_OPS``.
+    backend:
+        Which ONNX-to-TensorFlow translator to use: ``"builtin"`` (default, this
+        module's own hand-written translator -- every graph input dimension must
+        be static and every node's op must be one of ``SUPPORTED_ONNX_OPS``) or
+        ``"onnx2tf"`` (delegates to `onnx2tf <https://github.com/PINTO0309/onnx2tf>`_,
+        which covers far more ops at the cost of a much heavier dependency and
+        changing the model's public input/output tensor layout to channel-last by
+        default -- see ``onnxsim/onnx2tf_export.py``). Reach for ``"onnx2tf"`` when
+        a model hits an unsupported op with the builtin translator.
     optimizations:
-        Optional list forwarded to ``tf.lite.TFLiteConverter.optimizations``, e.g.
-        ``["DEFAULT"]`` (string names of ``tf.lite.Optimize`` members are accepted, as
-        well as the enum members themselves) to enable TFLite's post-training
-        (dynamic-range) quantization.
+        ``backend="builtin"`` only. Optional list forwarded to
+        ``tf.lite.TFLiteConverter.optimizations``, e.g. ``["DEFAULT"]`` (string
+        names of ``tf.lite.Optimize`` members are accepted, as well as the enum
+        members themselves) to enable TFLite's post-training (dynamic-range)
+        quantization.
+    **backend_kwargs:
+        ``backend="onnx2tf"`` only. Forwarded to
+        :func:`onnxsim.onnx2tf_export.convert_to_tflite_via_onnx2tf` (and from there
+        to ``onnx2tf.convert()``).
 
     Returns
     -------
@@ -913,10 +935,24 @@ def convert_to_tflite(
     Raises
     ------
     RuntimeError
-        If TensorFlow is not installed, an input has a non-static dimension, the
-        graph uses an ONNX op/feature this translator does not support, or
-        conversion itself fails.
+        If the selected backend's dependency is not installed, or conversion
+        fails -- for ``"builtin"``, an input has a non-static dimension or the
+        graph uses an ONNX op/feature the translator does not support.
     """
+    if backend == "onnx2tf":
+        from onnxsim import onnx2tf_export
+
+        return onnx2tf_export.convert_to_tflite_via_onnx2tf(model, **backend_kwargs)
+    if backend != "builtin":
+        raise ValueError(
+            f"Unknown backend {backend!r}; expected 'builtin' or 'onnx2tf'"
+        )
+    if backend_kwargs:
+        raise TypeError(
+            f"convert_to_tflite() with backend='builtin' got unexpected keyword "
+            f"arguments: {sorted(backend_kwargs)}"
+        )
+
     tf = _import_tensorflow()
     concrete = _build_concrete_function(model, tf)
     converter = tf.lite.TFLiteConverter.from_concrete_functions([concrete])
@@ -950,7 +986,8 @@ def export_tflite(
         If given, the ``.tflite`` flatbuffer is written here. If ``None``, the model
         is only returned.
 
-    Other keyword arguments are forwarded to :func:`convert_to_tflite`.
+    Other keyword arguments (including ``backend``) are forwarded to
+    :func:`convert_to_tflite`.
 
     Returns
     -------

--- a/onnxsim/tflite_export.py
+++ b/onnxsim/tflite_export.py
@@ -1,0 +1,963 @@
+"""Convert a (simplified) ONNX model to TensorFlow Lite.
+
+onnxsim's job stops at a cleaned-up ``onnx.ModelProto``. Mobile/embedded runtimes
+built on TensorFlow Lite want that graph as a ``.tflite`` flatbuffer instead. This
+module bridges the two: it walks the ONNX graph node by node, builds the equivalent
+computation with plain TensorFlow ops inside a ``tf.function``, traces it into a
+concrete function, and hands that to ``tf.lite.TFLiteConverter`` to produce the
+actual ``.tflite`` model.
+
+There is no maintained "convert this ONNX model" entry point to lean on here either
+(``onnx-tensorflow``/``onnx-tf`` has been unmaintained for years and only tracks very
+old opsets) -- same situation as Core ML after coremltools dropped its ONNX frontend,
+see ``coreml_export.py``. This translator plays that role, one ONNX op at a time. It
+covers a practical subset of ops (common to CNN/MLP graphs: conv, pooling,
+normalization, matmul/gemm, elementwise math, reshapes, reductions, ...); a node whose
+op isn't in ``SUPPORTED_ONNX_OPS`` raises a ``RuntimeError`` naming the op, rather than
+silently producing a wrong model.
+
+Feeding a *simplified* model in is the point, same as with ``coreml_export.py``:
+onnxsim's constant folding turns shape-manipulation subgraphs into plain
+initializers, so parameters this translator needs at conversion time (a ``Reshape``'s
+target shape, a ``Slice``'s bounds, ...) are far more likely to already be constants
+by the time they reach here instead of values only known at runtime.
+
+Like onnxruntime for constant folding and coremltools for Core ML export, TensorFlow
+is an **optional** dependency: nothing here is imported at ``import onnxsim`` time,
+only when ``--emit-tflite`` / the ``export_tflite`` API run. A missing TensorFlow
+raises a ``RuntimeError`` with an install hint.
+
+Graph inputs must have fully static shapes (dynamic axes aren't supported) -- pin them
+first with onnxsim's own ``--overwrite-input-shape``/``--test-input-shape`` if needed.
+TensorFlow Lite's own op kernels are NHWC-only, while ONNX's conv/pool ops are NCHW;
+this translator keeps the graph's public tensors in ONNX's NCHW layout and transposes
+to/from NHWC only around the ops (``Conv``/``MaxPool``/``AveragePool``) that need it.
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import onnx
+from onnx import numpy_helper
+
+_TFLITE_INSTALL_HINT = (
+    "TensorFlow is required to export TFLite models but is not installed. "
+    "Install it with `pip install tensorflow` (or `tensorflow-cpu`)."
+)
+
+# ONNX TensorProto dtypes this translator can carry through to TensorFlow/TFLite,
+# downcasting where TFLite has no matching type (float64 -> float32, int64 -> int32).
+_NP_DOWNCAST = {
+    np.dtype(np.float64): np.float32,
+    np.dtype(np.int64): np.int32,
+}
+_SUPPORTED_NP_DTYPES = {np.float32, np.float16, np.int32, np.bool_}
+
+
+def has_tensorflow() -> bool:
+    """Whether TensorFlow is importable in this environment."""
+    try:
+        import tensorflow  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def _import_tensorflow():
+    try:
+        import tensorflow as tf
+    except ImportError as exc:
+        raise RuntimeError(_TFLITE_INSTALL_HINT) from exc
+    return tf
+
+
+def _as_tf_array(arr: np.ndarray) -> np.ndarray:
+    """Downcast ``arr`` to a dtype TensorFlow Lite supports, or raise."""
+    arr = np.asarray(arr)
+    if arr.dtype == np.int64:
+        # Saturate rather than wrap: ONNX graphs routinely use INT64_MAX/MIN as
+        # "unbounded" sentinels, and a plain .astype(int32) wraps those around to a
+        # small in-range number instead of a large one, silently corrupting the
+        # sentinel.
+        arr = np.clip(arr, np.iinfo(np.int32).min, np.iinfo(np.int32).max)
+    target = _NP_DOWNCAST.get(arr.dtype)
+    if target is not None:
+        arr = arr.astype(target)
+    if arr.dtype.type not in _SUPPORTED_NP_DTYPES:
+        raise RuntimeError(
+            f"Unsupported tensor dtype {arr.dtype} for TFLite export (supported: "
+            "float16, float32, float64, int32, int64, bool; 64-bit types are "
+            "downcast to their 32-bit equivalent)."
+        )
+    return arr
+
+
+def _onnx_elem_type_to_tf(elem_type: int, tf) -> Any:
+    TP = onnx.TensorProto
+    mapping = {
+        TP.FLOAT: tf.float32,
+        TP.FLOAT16: tf.float16,
+        TP.DOUBLE: tf.float32,
+        TP.INT32: tf.int32,
+        TP.INT64: tf.int32,
+        TP.BOOL: tf.bool,
+    }
+    if elem_type not in mapping:
+        raise RuntimeError(
+            f"Unsupported input dtype {TP.DataType.Name(elem_type)}; onnxsim's "
+            "TFLite exporter supports float16, float32, float64, int32, int64, and "
+            "bool graph inputs (64-bit types are represented as their 32-bit "
+            "equivalent in the exported model)."
+        )
+    return mapping[elem_type]
+
+
+def _static_input_shape(value_info: onnx.ValueInfoProto) -> List[int]:
+    t = value_info.type.tensor_type
+    if not t.HasField("shape"):
+        raise RuntimeError(
+            f"input '{value_info.name}' has no shape information; onnxsim's TFLite "
+            "exporter requires fully static input shapes."
+        )
+    shape = []
+    for i, d in enumerate(t.shape.dim):
+        if d.HasField("dim_value"):
+            shape.append(int(d.dim_value))
+        else:
+            label = d.dim_param or "<unknown>"
+            raise RuntimeError(
+                f"input '{value_info.name}' has a dynamic dimension (dim {i}: "
+                f"{label!r}); onnxsim's TFLite exporter requires fully static "
+                "input shapes -- pin it first with onnxsim's own "
+                "--overwrite-input-shape/--test-input-shape."
+            )
+    return shape
+
+
+def _node_attrs(node: onnx.NodeProto) -> Dict[str, Any]:
+    attrs: Dict[str, Any] = {}
+    for a in node.attribute:
+        v = onnx.helper.get_attribute_value(a)
+        if isinstance(v, onnx.TensorProto):
+            v = numpy_helper.to_array(v)
+        elif isinstance(v, bytes):
+            v = v.decode("utf-8")
+        elif isinstance(v, (list, tuple)) and v and isinstance(v[0], bytes):
+            v = [x.decode("utf-8") for x in v]
+        attrs[a.name] = v
+    return attrs
+
+
+def _compute_spatial_pad(
+    attrs: Dict[str, Any],
+    in_shape: List[int],
+    kernel_shape: List[int],
+    strides: List[int],
+    dilations: List[int],
+) -> List[Tuple[int, int]]:
+    """Resolve ONNX ``auto_pad``/``pads`` into explicit ``(before, after)`` pairs per
+    spatial axis, so Conv/pooling can always be run as an explicit ``tf.pad`` +
+    ``"VALID"`` -- avoiding any ambiguity between ONNX's and TensorFlow's own
+    ``"SAME"`` padding conventions (in particular, TensorFlow has no equivalent of
+    ONNX's ``SAME_LOWER``).
+    """
+    n = len(kernel_shape)
+    auto_pad = attrs.get("auto_pad", "NOTSET")
+    if auto_pad in ("SAME_UPPER", "SAME_LOWER"):
+        pads = []
+        for i in range(n):
+            eff_k = (kernel_shape[i] - 1) * dilations[i] + 1
+            out_size = -(-in_shape[i] // strides[i])  # ceil division
+            total_pad = max((out_size - 1) * strides[i] + eff_k - in_shape[i], 0)
+            if auto_pad == "SAME_UPPER":
+                before = total_pad // 2
+            else:
+                before = total_pad - total_pad // 2
+            pads.append((before, total_pad - before))
+        return pads
+    if auto_pad == "VALID":
+        return [(0, 0)] * n
+    raw = attrs.get("pads")
+    if not raw:
+        return [(0, 0)] * n
+    begins, ends = raw[:n], raw[n:]
+    return [(int(b), int(e)) for b, e in zip(begins, ends)]
+
+
+def _avg_pool_counts(
+    in_size: int, k: int, s: int, pad_before: int, pad_after: int
+) -> np.ndarray:
+    """Per-output-position count of *non-padded* input elements inside the pooling
+    window, along one spatial axis -- used to implement ONNX AveragePool's default
+    ``count_include_pad=0`` (TFLite/TF's own average pool has no such option and
+    always divides by the full window area)."""
+    padded = in_size + pad_before + pad_after
+    out_size = (padded - k) // s + 1
+    counts = np.empty(out_size, dtype=np.float32)
+    for o in range(out_size):
+        start = o * s - pad_before
+        end = start + k
+        valid = min(end, in_size) - max(start, 0)
+        counts[o] = max(valid, 1)
+    return counts
+
+
+class Val:
+    """A traced TensorFlow tensor, plus its compile-time value when known.
+
+    Mirrors coremltools MIL's ``Var.val``: most ONNX ops this translator lowers are
+    plain tensor math and only need ``.t`` (the traced ``tf.Tensor``), but a handful
+    of ops (``Reshape``'s target shape, ``Slice``'s bounds, ``Gather``'s indices, ...)
+    need an actual Python/NumPy value at conversion time, not just a traced tensor --
+    ``.const`` carries that when the value came from an initializer or was computed
+    from other compile-time constants.
+    """
+
+    __slots__ = ("t", "const")
+
+    def __init__(self, t, const: Optional[np.ndarray] = None):
+        self.t = t
+        self.const = const
+
+
+class _Lowerer:
+    """Walks an ONNX graph once, building the equivalent TensorFlow ops as it goes."""
+
+    def __init__(self, tf):
+        self.tf = tf
+        self._values: Dict[str, Val] = {}
+
+    def bind(self, name: str, val: Val) -> None:
+        self._values[name] = val
+
+    def get(self, name: str) -> Val:
+        if name not in self._values:
+            raise RuntimeError(
+                f"reference to unknown tensor '{name}' (the graph may not be "
+                "topologically sorted, or the producing node uses an unsupported "
+                "feature)"
+            )
+        return self._values[name]
+
+    def lower_node(self, node: onnx.NodeProto) -> None:
+        handler = _OP_HANDLERS.get(node.op_type)
+        if handler is None:
+            raise RuntimeError(
+                f"ONNX op '{node.op_type}' is not supported by onnxsim's TFLite "
+                f"exporter (node {node.name or (node.output[0] if node.output else '')!r})."
+                " Supported ops: " + ", ".join(sorted(_OP_HANDLERS))
+            )
+        ins = [self.get(name) if name else None for name in node.input]
+        attrs = _node_attrs(node)
+        try:
+            outs = handler(self, node, ins, attrs)
+        except Exception as exc:
+            raise RuntimeError(
+                f"failed to convert ONNX node {node.name or node.output[0]!r} "
+                f"({node.op_type}) to TFLite: {exc}"
+            ) from exc
+        for out_name, val in zip(node.output, outs):
+            if out_name:
+                self.bind(out_name, val)
+
+
+# ---------------------------------------------------------------------------
+# Op handlers. Each handler is ``(lowerer, node, ins, attrs) -> list[Val]``, with
+# ``ins[i]`` the already-converted ``Val`` for ``node.input[i]`` (``None`` for an
+# omitted optional input) and ``attrs`` the node's parsed attribute dict.
+# ---------------------------------------------------------------------------
+
+_OP_HANDLERS: Dict[str, Any] = {}
+
+
+def _register(*op_types: str):
+    def deco(fn):
+        for op_type in op_types:
+            _OP_HANDLERS[op_type] = fn
+        return fn
+
+    return deco
+
+
+def _require_const(val: Val, what: str) -> np.ndarray:
+    if val is None or val.const is None:
+        raise RuntimeError(
+            f"expected a compile-time constant for {what}, but it is only known at "
+            "runtime (onnxsim's TFLite exporter can't trace dynamic values)"
+        )
+    return np.asarray(val.const)
+
+
+def _simple_unary(dotted_tf_name: str):
+    """``dotted_tf_name`` is a dotted attribute path off ``tf``, e.g. ``"nn.relu"``
+    or ``"math.log"``, resolved lazily (only once TensorFlow is actually imported)."""
+
+    def handler(lowerer, node, ins, attrs):
+        fn = lowerer.tf
+        for part in dotted_tf_name.split("."):
+            fn = getattr(fn, part)
+        return [Val(fn(ins[0].t))]
+
+    return handler
+
+
+for _onnx_op, _tf_name in [
+    ("Relu", "nn.relu"),
+    ("Sigmoid", "sigmoid"),
+    ("Tanh", "tanh"),
+    ("Neg", "negative"),
+    ("Abs", "abs"),
+    ("Sqrt", "sqrt"),
+    ("Exp", "exp"),
+    ("Log", "math.log"),
+    ("Erf", "math.erf"),
+    ("Identity", "identity"),
+]:
+    _OP_HANDLERS[_onnx_op] = _simple_unary(_tf_name)
+
+
+def _binary(tf_name: str, np_fn):
+    def handler(lowerer, node, ins, attrs):
+        tf = lowerer.tf
+        fn = getattr(tf, tf_name)
+        t = ins[0].t
+        for other in ins[1:]:
+            t = fn(t, other.t)
+        const = None
+        if all(i.const is not None for i in ins):
+            const = np.asarray(ins[0].const)
+            for other in ins[1:]:
+                const = np_fn(const, np.asarray(other.const))
+        return [Val(t, const)]
+
+    return handler
+
+
+for _onnx_op, _tf_name, _np_fn in [
+    ("Add", "add", np.add),
+    ("Sub", "subtract", np.subtract),
+    ("Mul", "multiply", np.multiply),
+    ("Div", "divide", np.divide),
+    ("Pow", "pow", np.power),
+    ("Max", "maximum", np.maximum),
+    ("Min", "minimum", np.minimum),
+]:
+    _OP_HANDLERS[_onnx_op] = _binary(_tf_name, _np_fn)
+
+
+@_register("LeakyRelu")
+def _op_leaky_relu(lowerer, node, ins, attrs):
+    tf = lowerer.tf
+    alpha = float(attrs.get("alpha", 0.01))
+    return [Val(tf.nn.leaky_relu(ins[0].t, alpha=alpha))]
+
+
+@_register("Gelu")
+def _op_gelu(lowerer, node, ins, attrs):
+    tf = lowerer.tf
+    approximate = attrs.get("approximate", "none") == "tanh"
+    return [Val(tf.nn.gelu(ins[0].t, approximate=approximate))]
+
+
+@_register("Softmax")
+def _op_softmax(lowerer, node, ins, attrs):
+    tf = lowerer.tf
+    axis = int(attrs.get("axis", -1))
+    return [Val(tf.nn.softmax(ins[0].t, axis=axis))]
+
+
+@_register("Clip")
+def _op_clip(lowerer, node, ins, attrs):
+    tf = lowerer.tf
+    x = ins[0]
+    min_v = attrs.get("min")
+    max_v = attrs.get("max")
+    if len(ins) > 1 and ins[1] is not None:
+        min_v = float(_require_const(ins[1], "Clip's 'min' input").reshape(-1)[0])
+    if len(ins) > 2 and ins[2] is not None:
+        max_v = float(_require_const(ins[2], "Clip's 'max' input").reshape(-1)[0])
+    t = x.t
+    if min_v is not None:
+        t = tf.maximum(t, min_v)
+    if max_v is not None:
+        t = tf.minimum(t, max_v)
+    return [Val(t)]
+
+
+@_register("Cast")
+def _op_cast(lowerer, node, ins, attrs):
+    tf = lowerer.tf
+    x = ins[0]
+    dtype = _onnx_elem_type_to_tf(int(attrs["to"]), tf)
+    t = tf.cast(x.t, dtype)
+    const = (
+        np.asarray(x.const).astype(dtype.as_numpy_dtype)
+        if x.const is not None
+        else None
+    )
+    return [Val(t, const)]
+
+
+@_register("MatMul")
+def _op_matmul(lowerer, node, ins, attrs):
+    tf = lowerer.tf
+    a, b = ins
+    return [Val(tf.matmul(a.t, b.t))]
+
+
+@_register("Gemm")
+def _op_gemm(lowerer, node, ins, attrs):
+    tf = lowerer.tf
+    a, b = ins[0], ins[1]
+    c = ins[2] if len(ins) > 2 else None
+    alpha = float(attrs.get("alpha", 1.0))
+    beta = float(attrs.get("beta", 1.0))
+    trans_a = bool(attrs.get("transA", 0))
+    trans_b = bool(attrs.get("transB", 0))
+    y = tf.matmul(a.t, b.t, transpose_a=trans_a, transpose_b=trans_b)
+    if alpha != 1.0:
+        y = y * alpha
+    if c is not None:
+        bias = c.t if beta == 1.0 else c.t * beta
+        y = y + bias
+    return [Val(y)]
+
+
+@_register("Conv")
+def _op_conv(lowerer, node, ins, attrs):
+    tf = lowerer.tf
+    x, w = ins[0], ins[1]
+    b = ins[2] if len(ins) > 2 else None
+    w_shape = w.t.shape.as_list()
+    kernel_shape = [int(k) for k in attrs.get("kernel_shape", w_shape[2:4])]
+    if len(kernel_shape) != 2:
+        raise RuntimeError("only 2-D Conv is supported by onnxsim's TFLite exporter")
+    strides = [int(s) for s in attrs.get("strides", [1, 1])]
+    dilations = [int(d) for d in attrs.get("dilations", [1, 1])]
+    group = int(attrs.get("group", 1))
+    out_c, in_c_per_group = w_shape[0], w_shape[1]
+    x_shape = x.t.shape.as_list()
+    in_c = x_shape[1]
+
+    pads = _compute_spatial_pad(attrs, x_shape[2:4], kernel_shape, strides, dilations)
+    filt = tf.transpose(w.t, [2, 3, 1, 0])  # OIHW -> HWIO
+    x_nhwc = tf.transpose(x.t, [0, 2, 3, 1])
+    if any(p != (0, 0) for p in pads):
+        x_nhwc = tf.pad(x_nhwc, [[0, 0], list(pads[0]), list(pads[1]), [0, 0]])
+
+    conv_strides = [1, strides[0], strides[1], 1]
+    conv_dilations = [1, dilations[0], dilations[1], 1]
+    if group == 1:
+        y = tf.nn.conv2d(
+            x_nhwc,
+            filt,
+            strides=conv_strides,
+            padding="VALID",
+            dilations=conv_dilations,
+        )
+    elif in_c_per_group == 1 and group == in_c:
+        multiplier = out_c // group
+        dw_filt = tf.reshape(filt, [kernel_shape[0], kernel_shape[1], in_c, multiplier])
+        y = tf.nn.depthwise_conv2d(
+            x_nhwc,
+            dw_filt,
+            strides=conv_strides,
+            padding="VALID",
+            dilations=[dilations[0], dilations[1]],
+        )
+    else:
+        x_groups = tf.split(x_nhwc, group, axis=3)
+        w_groups = tf.split(filt, group, axis=3)
+        y = tf.concat(
+            [
+                tf.nn.conv2d(
+                    xg,
+                    wg,
+                    strides=conv_strides,
+                    padding="VALID",
+                    dilations=conv_dilations,
+                )
+                for xg, wg in zip(x_groups, w_groups)
+            ],
+            axis=3,
+        )
+    if b is not None:
+        y = tf.nn.bias_add(y, b.t)
+    y = tf.transpose(y, [0, 3, 1, 2])
+    return [Val(y)]
+
+
+def _pool_2d(reduce_kind: str):
+    def handler(lowerer, node, ins, attrs):
+        tf = lowerer.tf
+        x = ins[0]
+        x_shape = x.t.shape.as_list()
+        kernel_shape = [int(k) for k in attrs["kernel_shape"]]
+        if len(kernel_shape) != 2:
+            raise RuntimeError(
+                "only 2-D pooling is supported by onnxsim's TFLite exporter"
+            )
+        strides = [int(s) for s in attrs.get("strides", kernel_shape)]
+        dilations = [int(d) for d in attrs.get("dilations", [1, 1])]
+        if any(d != 1 for d in dilations):
+            raise RuntimeError(
+                "dilated pooling is not supported by onnxsim's TFLite exporter"
+            )
+        if int(attrs.get("ceil_mode", 0)):
+            raise RuntimeError(
+                "ceil_mode=1 pooling is not supported by onnxsim's TFLite exporter"
+            )
+        in_hw = x_shape[2:4]
+        pads = _compute_spatial_pad(attrs, in_hw, kernel_shape, strides, dilations)
+        pad_needed = any(p != (0, 0) for p in pads)
+        x_nhwc = tf.transpose(x.t, [0, 2, 3, 1])
+
+        if reduce_kind == "max":
+            if pad_needed:
+                x_nhwc = tf.pad(
+                    x_nhwc,
+                    [[0, 0], list(pads[0]), list(pads[1]), [0, 0]],
+                    constant_values=float("-inf"),
+                )
+            y = tf.nn.max_pool2d(
+                x_nhwc, ksize=kernel_shape, strides=strides, padding="VALID"
+            )
+        else:
+            count_include_pad = int(attrs.get("count_include_pad", 0))
+            if pad_needed:
+                x_nhwc = tf.pad(x_nhwc, [[0, 0], list(pads[0]), list(pads[1]), [0, 0]])
+            window_area = kernel_shape[0] * kernel_shape[1]
+            sum_pool = (
+                tf.nn.avg_pool2d(
+                    x_nhwc, ksize=kernel_shape, strides=strides, padding="VALID"
+                )
+                * window_area
+            )
+            if pad_needed and not count_include_pad:
+                counts_h = _avg_pool_counts(
+                    in_hw[0], kernel_shape[0], strides[0], pads[0][0], pads[0][1]
+                )
+                counts_w = _avg_pool_counts(
+                    in_hw[1], kernel_shape[1], strides[1], pads[1][0], pads[1][1]
+                )
+                divisor = np.outer(counts_h, counts_w).astype(np.float32)
+                divisor = divisor.reshape(1, divisor.shape[0], divisor.shape[1], 1)
+                y = sum_pool / tf.constant(divisor)
+            else:
+                y = sum_pool / float(window_area)
+        return [Val(tf.transpose(y, [0, 3, 1, 2]))]
+
+    return handler
+
+
+_OP_HANDLERS["MaxPool"] = _pool_2d("max")
+_OP_HANDLERS["AveragePool"] = _pool_2d("avg")
+
+
+@_register("GlobalAveragePool")
+def _op_global_avg_pool(lowerer, node, ins, attrs):
+    tf = lowerer.tf
+    return [Val(tf.reduce_mean(ins[0].t, axis=[2, 3], keepdims=True))]
+
+
+@_register("GlobalMaxPool")
+def _op_global_max_pool(lowerer, node, ins, attrs):
+    tf = lowerer.tf
+    return [Val(tf.reduce_max(ins[0].t, axis=[2, 3], keepdims=True))]
+
+
+def _reduce(tf_name: str):
+    def handler(lowerer, node, ins, attrs):
+        tf = lowerer.tf
+        x = ins[0]
+        x_shape = x.t.shape.as_list()
+        rank = len(x_shape)
+        if len(ins) > 1 and ins[1] is not None:
+            axes = [int(a) for a in _require_const(ins[1], f"{node.op_type}'s 'axes'")]
+        elif "axes" in attrs:
+            axes = [int(a) for a in attrs["axes"]]
+        else:
+            axes = list(range(rank))
+        axes = sorted(a % rank for a in axes)
+        keepdims = bool(attrs.get("keepdims", 1))
+        fn = getattr(tf, tf_name)
+        return [Val(fn(x.t, axis=axes, keepdims=keepdims))]
+
+    return handler
+
+
+for _onnx_op, _tf_name in [
+    ("ReduceMean", "reduce_mean"),
+    ("ReduceSum", "reduce_sum"),
+    ("ReduceMax", "reduce_max"),
+    ("ReduceMin", "reduce_min"),
+    ("ReduceProd", "reduce_prod"),
+]:
+    _OP_HANDLERS[_onnx_op] = _reduce(_tf_name)
+
+
+@_register("BatchNormalization")
+def _op_batch_norm(lowerer, node, ins, attrs):
+    tf = lowerer.tf
+    x, scale, bias, mean, var = ins[0], ins[1], ins[2], ins[3], ins[4]
+    eps = float(attrs.get("epsilon", 1e-5))
+    c = scale.t.shape.as_list()[0]
+    shape = [1, c, 1, 1]
+    s = tf.reshape(scale.t, shape)
+    b = tf.reshape(bias.t, shape)
+    m = tf.reshape(mean.t, shape)
+    v = tf.reshape(var.t, shape)
+    y = (x.t - m) / tf.sqrt(v + eps) * s + b
+    return [Val(y)]
+
+
+@_register("Reshape")
+def _op_reshape(lowerer, node, ins, attrs):
+    tf = lowerer.tf
+    x = ins[0]
+    target = [int(v) for v in _require_const(ins[1], "Reshape's 'shape' input")]
+    allowzero = int(attrs.get("allowzero", 0))
+    x_shape = x.t.shape.as_list()
+    resolved = [
+        x_shape[i] if d == 0 and not allowzero else d for i, d in enumerate(target)
+    ]
+    t = tf.reshape(x.t, resolved)
+    const = np.reshape(np.asarray(x.const), resolved) if x.const is not None else None
+    return [Val(t, const)]
+
+
+@_register("Flatten")
+def _op_flatten(lowerer, node, ins, attrs):
+    tf = lowerer.tf
+    x = ins[0]
+    shape = x.t.shape.as_list()
+    axis = int(attrs.get("axis", 1)) % (len(shape) + 1)
+    outer = int(np.prod(shape[:axis], dtype=np.int64))
+    inner = int(np.prod(shape[axis:], dtype=np.int64))
+    return [Val(tf.reshape(x.t, [outer, inner]))]
+
+
+@_register("Squeeze")
+def _op_squeeze(lowerer, node, ins, attrs):
+    tf = lowerer.tf
+    x = ins[0]
+    x_shape = x.t.shape.as_list()
+    if len(ins) > 1 and ins[1] is not None:
+        axes = [int(a) for a in _require_const(ins[1], "Squeeze's 'axes' input")]
+    elif "axes" in attrs:
+        axes = [int(a) for a in attrs["axes"]]
+    else:
+        axes = [i for i, d in enumerate(x_shape) if d == 1]
+    axes = {a % len(x_shape) for a in axes}
+    new_shape = [d for i, d in enumerate(x_shape) if i not in axes]
+    t = tf.reshape(x.t, new_shape)
+    const = np.reshape(np.asarray(x.const), new_shape) if x.const is not None else None
+    return [Val(t, const)]
+
+
+@_register("Unsqueeze")
+def _op_unsqueeze(lowerer, node, ins, attrs):
+    tf = lowerer.tf
+    x = ins[0]
+    x_shape = x.t.shape.as_list()
+    if len(ins) > 1 and ins[1] is not None:
+        axes = [int(a) for a in _require_const(ins[1], "Unsqueeze's 'axes' input")]
+    else:
+        axes = [int(a) for a in attrs["axes"]]
+    out_rank = len(x_shape) + len(axes)
+    axes = sorted(a % out_rank for a in axes)
+    new_shape = list(x_shape)
+    for a in axes:
+        new_shape.insert(a, 1)
+    t = tf.reshape(x.t, new_shape)
+    const = np.reshape(np.asarray(x.const), new_shape) if x.const is not None else None
+    return [Val(t, const)]
+
+
+@_register("Transpose")
+def _op_transpose(lowerer, node, ins, attrs):
+    tf = lowerer.tf
+    x = ins[0]
+    perm = attrs.get("perm")
+    if perm is None:
+        perm = list(reversed(range(len(x.t.shape))))
+    return [Val(tf.transpose(x.t, [int(p) for p in perm]))]
+
+
+@_register("Concat")
+def _op_concat(lowerer, node, ins, attrs):
+    tf = lowerer.tf
+    axis = int(attrs["axis"])
+    t = tf.concat([i.t for i in ins], axis=axis)
+    const = None
+    if all(i.const is not None for i in ins):
+        const = np.concatenate([np.asarray(i.const) for i in ins], axis=axis)
+    return [Val(t, const)]
+
+
+@_register("Split")
+def _op_split(lowerer, node, ins, attrs):
+    tf = lowerer.tf
+    x = ins[0]
+    x_shape = x.t.shape.as_list()
+    axis = int(attrs.get("axis", 0)) % len(x_shape)
+    if len(ins) > 1 and ins[1] is not None:
+        sizes = [int(v) for v in _require_const(ins[1], "Split's 'split' input")]
+    elif "split" in attrs:
+        sizes = [int(v) for v in attrs["split"]]
+    else:
+        num_outputs = int(attrs.get("num_outputs", len(node.output)))
+        dim = x_shape[axis]
+        base, rem = divmod(dim, num_outputs)
+        sizes = [base + (1 if i < rem else 0) for i in range(num_outputs)]
+    return [Val(o) for o in tf.split(x.t, sizes, axis=axis)]
+
+
+@_register("Gather")
+def _op_gather(lowerer, node, ins, attrs):
+    tf = lowerer.tf
+    x, idx = ins
+    axis = int(attrs.get("axis", 0))
+    if idx.const is not None:
+        idx_arr = np.asarray(idx.const)
+        dim = x.t.shape.as_list()[axis]
+        idx_arr = np.where(idx_arr < 0, idx_arr + dim, idx_arr)
+        idx_t = tf.constant(idx_arr.astype(np.int32))
+    else:
+        idx_t = idx.t
+    t = tf.gather(x.t, idx_t, axis=axis)
+    const = None
+    if x.const is not None and idx.const is not None:
+        const = np.take(np.asarray(x.const), np.asarray(idx.const), axis=axis)
+    return [Val(t, const)]
+
+
+@_register("Tile")
+def _op_tile(lowerer, node, ins, attrs):
+    tf = lowerer.tf
+    x, reps = ins
+    repeats = [int(r) for r in _require_const(reps, "Tile's 'repeats' input")]
+    return [Val(tf.tile(x.t, repeats))]
+
+
+@_register("Pad")
+def _op_pad(lowerer, node, ins, attrs):
+    tf = lowerer.tf
+    x = ins[0]
+    if len(ins) > 1 and ins[1] is not None:
+        pads_flat = [int(v) for v in _require_const(ins[1], "Pad's 'pads' input")]
+    else:
+        pads_flat = [int(v) for v in attrs["pads"]]
+    mode = attrs.get("mode", "constant")
+    rank = len(x.t.shape)
+    begins, ends = pads_flat[:rank], pads_flat[rank:]
+    paddings = [[int(b), int(e)] for b, e in zip(begins, ends)]
+    if mode == "constant":
+        const_value = 0.0
+        if len(ins) > 2 and ins[2] is not None and ins[2].const is not None:
+            const_value = float(np.asarray(ins[2].const).reshape(-1)[0])
+        y = tf.pad(x.t, paddings, mode="CONSTANT", constant_values=const_value)
+    elif mode == "reflect":
+        y = tf.pad(x.t, paddings, mode="REFLECT")
+    else:
+        raise RuntimeError(
+            f"Pad mode {mode!r} is not supported by onnxsim's TFLite exporter "
+            "(supported: constant, reflect)"
+        )
+    return [Val(y)]
+
+
+@_register("Slice")
+def _op_slice(lowerer, node, ins, attrs):
+    tf = lowerer.tf
+    x = ins[0]
+    x_shape = x.t.shape.as_list()
+    rank = len(x_shape)
+    if len(ins) > 1:
+        starts = [int(v) for v in _require_const(ins[1], "Slice's 'starts' input")]
+        ends = [int(v) for v in _require_const(ins[2], "Slice's 'ends' input")]
+        axes = (
+            [int(v) for v in _require_const(ins[3], "Slice's 'axes' input")]
+            if len(ins) > 3 and ins[3] is not None
+            else list(range(len(starts)))
+        )
+        steps = (
+            [int(v) for v in _require_const(ins[4], "Slice's 'steps' input")]
+            if len(ins) > 4 and ins[4] is not None
+            else [1] * len(starts)
+        )
+    else:
+        starts = [int(v) for v in attrs["starts"]]
+        ends = [int(v) for v in attrs["ends"]]
+        axes = [int(v) for v in attrs.get("axes", list(range(len(starts))))]
+        steps = [1] * len(starts)
+
+    begin = [0] * rank
+    end = list(x_shape)
+    strides = [1] * rank
+    end_mask = 0
+    for ax, s, e, st in zip(axes, starts, ends, steps):
+        ax = ax % rank
+        # slice().indices() implements exactly the clamping semantics ONNX's spec
+        # describes for Slice (it's explicitly modeled on numpy/Python slicing).
+        norm_s, norm_e, norm_st = slice(s, e, st).indices(x_shape[ax])
+        begin[ax], strides[ax] = norm_s, norm_st
+        if norm_st < 0 and norm_e == -1:
+            # "reverse through index 0": tf.strided_slice has no way to spell this
+            # as a literal end index -- like numpy, it wraps a negative end the same
+            # way a negative start is wrapped, silently turning -1 back into "the
+            # last element" and producing an empty slice instead. `end_mask` is
+            # strided_slice's dedicated escape hatch: it tells the op to ignore
+            # `end[ax]` and extend to the boundary the stride's direction implies.
+            end_mask |= 1 << ax
+        else:
+            end[ax] = norm_e
+    return [Val(tf.strided_slice(x.t, begin, end, strides, end_mask=end_mask))]
+
+
+@_register("Shape")
+def _op_shape(lowerer, node, ins, attrs):
+    tf = lowerer.tf
+    x = ins[0]
+    shape = np.array(x.t.shape.as_list(), dtype=np.int64)
+    start = int(attrs.get("start", 0))
+    end = int(attrs.get("end", len(shape)))
+    shape = shape[start:end]
+    return [Val(tf.constant(shape.astype(np.int32)), shape)]
+
+
+@_register("Constant")
+def _op_constant(lowerer, node, ins, attrs):
+    tf = lowerer.tf
+    if "value" in attrs:
+        arr = np.asarray(attrs["value"])
+    elif "value_float" in attrs:
+        arr = np.array(attrs["value_float"], dtype=np.float32)
+    elif "value_int" in attrs:
+        arr = np.array(attrs["value_int"], dtype=np.int64)
+    elif "value_floats" in attrs:
+        arr = np.array(list(attrs["value_floats"]), dtype=np.float32)
+    elif "value_ints" in attrs:
+        arr = np.array(list(attrs["value_ints"]), dtype=np.int64)
+    else:
+        raise RuntimeError("unsupported Constant attribute variant")
+    return [Val(tf.constant(_as_tf_array(arr)), arr)]
+
+
+SUPPORTED_ONNX_OPS = tuple(sorted(_OP_HANDLERS))
+
+
+def _build_concrete_function(model: onnx.ModelProto, tf):
+    graph = model.graph
+    initializer_names = {t.name for t in graph.initializer}
+
+    lowerer = _Lowerer(tf)
+    for init in graph.initializer:
+        arr = numpy_helper.to_array(init)
+        lowerer.bind(init.name, Val(tf.constant(_as_tf_array(arr)), arr))
+
+    input_names = []
+    specs = []
+    for inp in graph.input:
+        if inp.name in initializer_names:
+            continue
+        shape = _static_input_shape(inp)
+        dtype = _onnx_elem_type_to_tf(inp.type.tensor_type.elem_type, tf)
+        input_names.append(inp.name)
+        specs.append(tf.TensorSpec(shape=shape, dtype=dtype))
+
+    output_names = [o.name for o in graph.output]
+    if not output_names:
+        raise RuntimeError("model has no graph outputs to export")
+
+    def forward(*args):
+        for name, arg in zip(input_names, args):
+            lowerer.bind(name, Val(arg))
+        for node in graph.node:
+            lowerer.lower_node(node)
+        return [lowerer.get(name).t for name in output_names]
+
+    # autograph=False: `forward`'s only control flow is a plain Python `for` loop
+    # over the graph's (fixed, concrete) node list -- there is nothing for autograph
+    # to rewrite -- and disabling it keeps exceptions raised while lowering a node
+    # (e.g. an unsupported op) as plain RuntimeErrors instead of autograph wrapping
+    # them in an "in user code" traceback.
+    concrete = tf.function(forward, autograph=False).get_concrete_function(*specs)
+    return concrete
+
+
+def convert_to_tflite(
+    model: onnx.ModelProto,
+    *,
+    optimizations: Optional[List[Any]] = None,
+):
+    """Convert an ONNX model to an in-memory TFLite flatbuffer (``bytes``).
+
+    Parameters
+    ----------
+    model:
+        The ONNX model to convert. Typically the output of :func:`onnxsim.simplify`.
+        Every graph input dimension must be static; every node's op must be one of
+        ``SUPPORTED_ONNX_OPS``.
+    optimizations:
+        Optional list forwarded to ``tf.lite.TFLiteConverter.optimizations``, e.g.
+        ``["DEFAULT"]`` (string names of ``tf.lite.Optimize`` members are accepted, as
+        well as the enum members themselves) to enable TFLite's post-training
+        (dynamic-range) quantization.
+
+    Returns
+    -------
+    bytes
+        The serialized ``.tflite`` flatbuffer.
+
+    Raises
+    ------
+    RuntimeError
+        If TensorFlow is not installed, an input has a non-static dimension, the
+        graph uses an ONNX op/feature this translator does not support, or
+        conversion itself fails.
+    """
+    tf = _import_tensorflow()
+    concrete = _build_concrete_function(model, tf)
+    converter = tf.lite.TFLiteConverter.from_concrete_functions([concrete])
+    if optimizations:
+        converter.optimizations = [
+            getattr(tf.lite.Optimize, o) if isinstance(o, str) else o
+            for o in optimizations
+        ]
+    try:
+        return converter.convert()
+    except Exception as exc:
+        raise RuntimeError(f"TFLite conversion failed: {exc}") from exc
+
+
+def export_tflite(
+    model: onnx.ModelProto,
+    output_path: Optional[str] = None,
+    **kwargs,
+) -> bytes:
+    """Convert ``model`` to TFLite, optionally saving it to ``output_path``.
+
+    This is the public entry point used by the ``onnxsim --emit-tflite`` CLI and is
+    re-exported as ``onnxsim.export_tflite``. It returns the serialized flatbuffer
+    regardless of whether ``output_path`` is given.
+
+    Parameters
+    ----------
+    model:
+        The ONNX model to convert (usually the output of :func:`onnxsim.simplify`).
+    output_path:
+        If given, the ``.tflite`` flatbuffer is written here. If ``None``, the model
+        is only returned.
+
+    Other keyword arguments are forwarded to :func:`convert_to_tflite`.
+
+    Returns
+    -------
+    bytes
+    """
+    tflite_model = convert_to_tflite(model, **kwargs)
+    if output_path is not None:
+        with open(output_path, "wb") as f:
+            f.write(tflite_model)
+    return tflite_model

--- a/tests/test_onnx2tf_export.py
+++ b/tests/test_onnx2tf_export.py
@@ -1,0 +1,161 @@
+"""Tests for the ``backend="onnx2tf"`` TFLite export path
+(``onnxsim/onnx2tf_export.py``).
+
+onnx2tf (https://github.com/PINTO0309/onnx2tf) is a separate, actively maintained
+project that converts ONNX to TensorFlow/TFLite with far broader op coverage than
+onnxsim's own builtin translator (``tflite_export.py``) -- at the cost of a much
+heavier dependency chain and changing the model's public input/output tensor layout
+to channel-last by default. onnxsim wires it up as an alternate backend rather than
+replacing the builtin translator; see ``onnx2tf_export.py``'s module docstring for
+the full trade-off.
+
+onnx2tf is heavy and not part of onnxsim's test requirements, so -- like
+``tests/test_coreml_export.py`` and ``tests/test_tflite_export.py`` -- the whole
+module is skipped when it is not installed.
+"""
+
+import numpy as np
+import onnx
+import pytest
+from onnx import numpy_helper, parser
+
+pytest.importorskip("onnx2tf", reason="onnx2tf is not installed")
+pytest.importorskip("tensorflow", reason="tensorflow is not installed")
+
+import onnxruntime as ort  # noqa: E402  (imported after the availability checks)
+import tensorflow as tf  # noqa: E402
+
+import onnxsim  # noqa: E402
+from onnxsim import onnx2tf_export, tflite_export  # noqa: E402
+
+
+def _model(
+    body: str, initializer=(), opset: int = 17, ir_version: int = 8
+) -> onnx.ModelProto:
+    model = parser.parse_model(
+        f'<ir_version: {ir_version}, opset_import: ["" : {opset}]> {body}'
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _relu_model() -> onnx.ModelProto:
+    model = _model(
+        """
+        relu (float[2,3] x) => (float[2,3] y)
+        {
+            y = Relu (x)
+        }
+        """
+    )
+    onnx.checker.check_model(model)
+    return model
+
+
+def _cnn_model() -> onnx.ModelProto:
+    """Conv -> BatchNorm -> Relu -> GlobalAveragePool -> Flatten -> Gemm -> Softmax."""
+    rng = np.random.RandomState(0)
+    w = numpy_helper.from_array(rng.randn(4, 3, 3, 3).astype(np.float32), name="w")
+    b = numpy_helper.from_array(np.zeros(4, np.float32), name="b")
+    scale = numpy_helper.from_array(
+        (0.5 + rng.rand(4)).astype(np.float32), name="scale"
+    )
+    bn_bias = numpy_helper.from_array(rng.randn(4).astype(np.float32), name="bn_bias")
+    mean = numpy_helper.from_array(rng.randn(4).astype(np.float32) * 0.1, name="mean")
+    var = numpy_helper.from_array((0.5 + rng.rand(4)).astype(np.float32), name="var")
+    gw = numpy_helper.from_array(rng.randn(4, 4).astype(np.float32), name="gw")
+    gb = numpy_helper.from_array(rng.randn(4).astype(np.float32), name="gb")
+    model = _model(
+        """
+        cnn (float[1,3,8,8] x) => (float[1,4] y)
+        {
+            conv_out = Conv <kernel_shape=[3,3], pads=[1,1,1,1]> (x, w, b)
+            bn_out = BatchNormalization (conv_out, scale, bn_bias, mean, var)
+            relu_out = Relu (bn_out)
+            gap_out = GlobalAveragePool (relu_out)
+            flat_out = Flatten <axis=1> (gap_out)
+            gemm_out = Gemm <transB=1> (flat_out, gw, gb)
+            y = Softmax <axis=-1> (gemm_out)
+        }
+        """,
+        initializer=[w, b, scale, bn_bias, mean, var, gw, gb],
+    )
+    onnx.checker.check_model(model)
+    return model
+
+
+def _run_tflite(tflite_model: bytes, x: np.ndarray) -> np.ndarray:
+    interp = tf.lite.Interpreter(model_content=tflite_model)
+    interp.allocate_tensors()
+    (inp,) = interp.get_input_details()
+    (out,) = interp.get_output_details()
+    # onnx2tf converts every tensor of rank >= 3 to a channel-last layout by
+    # default, so a 4-D NCHW ONNX input becomes an NHWC TFLite input -- transpose
+    # to match whenever the produced model's input shape says it did.
+    x_in = np.transpose(x, (0, 2, 3, 1)) if list(inp["shape"]) != list(x.shape) else x
+    interp.set_tensor(inp["index"], x_in)
+    interp.invoke()
+    return interp.get_tensor(out["index"])
+
+
+def test_has_onnx2tf_true_here():
+    assert onnx2tf_export.has_onnx2tf() is True
+
+
+def test_export_returns_tflite_bytes():
+    tflite_model = onnx2tf_export.export_tflite_via_onnx2tf(_relu_model())
+    assert isinstance(tflite_model, bytes)
+    assert len(tflite_model) > 0
+
+
+def test_export_writes_file(tmp_path):
+    out = tmp_path / "relu.tflite"
+    onnx2tf_export.export_tflite_via_onnx2tf(_relu_model(), str(out))
+    assert out.is_file()
+
+
+def test_no_network_dependency_and_no_stray_files(tmp_path, monkeypatch):
+    # Regression test: onnx2tf.convert() unconditionally tries to download a
+    # sample-image .npy from GitHub releases for internal per-op verification
+    # whenever a graph input looks image-shaped (see onnx2tf_export.py's module
+    # docstring) -- this must never reach the network. Running with cwd pointed
+    # at an empty tmp_path also checks that onnx2tf's own housekeeping file
+    # writes land in the isolated scratch directory, not the caller's cwd.
+    monkeypatch.chdir(tmp_path)
+    onnx2tf_export.export_tflite_via_onnx2tf(_cnn_model())
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_tflite_export_backend_dispatch_matches_direct_call():
+    model = _relu_model()
+    a = tflite_export.convert_to_tflite(model, backend="onnx2tf")
+    b = onnx2tf_export.convert_to_tflite_via_onnx2tf(model)
+    assert a == b
+
+
+def test_cnn_pipeline_matches_onnxruntime():
+    model = _cnn_model()
+    x = np.random.RandomState(1).randn(1, 3, 8, 8).astype(np.float32)
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    expected = sess.run(None, {"x": x})[0]
+    tflite_model = onnxsim.export_tflite(model, backend="onnx2tf")
+    actual = _run_tflite(tflite_model, x)
+    np.testing.assert_allclose(expected, actual, rtol=1e-3, atol=1e-3)
+
+
+def test_unsupported_op_raises_runtime_error():
+    # onnx2tf covers ~200 ops (essentially every standard ONNX op), so there's no
+    # stable real op name to pick that's guaranteed to stay unsupported across
+    # versions -- use a made-up op_type instead, which onnx2tf's own op dispatch
+    # rejects the same way (it looks up a same-named module under onnx2tf.ops).
+    # This model fails onnx's own checker (unknown op), so build it without going
+    # through _model()'s onnx.checker.check_model call.
+    model = parser.parse_model(
+        '<ir_version: 8, opset_import: ["" : 17]> '
+        "unsup (float[2,3] x) => (float[2,3] y) "
+        "{ y = TotallyNotARealOp (x) }"
+    )
+    with pytest.raises(RuntimeError, match="onnx2tf conversion failed"):
+        onnx2tf_export.export_tflite_via_onnx2tf(model)

--- a/tests/test_tflite_export.py
+++ b/tests/test_tflite_export.py
@@ -1,0 +1,347 @@
+"""Tests for converting a (simplified) ONNX model to TensorFlow Lite.
+
+onnxsim can hand its cleaned-up ``ModelProto`` to a hand-written ONNX-to-TensorFlow
+translator and produce a TFLite model via ``tf.lite.TFLiteConverter``
+(``onnxsim.export_tflite`` / the ``--emit-tflite`` CLI flag, implemented in
+``onnxsim/tflite_export.py``). There is no maintained "convert this ONNX model" entry
+point to lean on (``onnx-tf``/``onnx-tensorflow`` has been unmaintained for years), so
+this translator -- not TensorFlow -- is what maps ONNX ops onto TF ops.
+
+TensorFlow is heavy and not part of onnxsim's test requirements, so -- exactly like
+``tests/test_coreml_export.py`` and ``tests/test_mlir_export.py`` -- the whole module
+is skipped when it is not installed.
+
+Unlike Core ML (whose MIL constant-folds an all-initializer graph so a converted
+model's numeric behavior can be checked without Apple's runtime), TFLite conversion
+always needs ``tf.lite.Interpreter`` to actually run the produced flatbuffer, and that
+runtime exists on every platform TensorFlow supports (Linux/macOS/Windows) -- so these
+tests run the interpreter directly and compare against onnxruntime.
+"""
+
+import numpy as np
+import onnx
+import pytest
+from onnx import numpy_helper, parser
+
+pytest.importorskip("tensorflow", reason="tensorflow is not installed")
+
+import onnxruntime as ort  # noqa: E402  (imported after the tensorflow availability check)
+import tensorflow as tf  # noqa: E402
+
+import onnxsim  # noqa: E402
+from onnxsim import tflite_export  # noqa: E402
+
+
+def _model(
+    body: str, initializer=(), opset: int = 17, ir_version: int = 8
+) -> onnx.ModelProto:
+    model = parser.parse_model(
+        f'<ir_version: {ir_version}, opset_import: ["" : {opset}]> {body}'
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _relu_model() -> onnx.ModelProto:
+    model = _model(
+        """
+        relu (float[2,3] x) => (float[2,3] y)
+        {
+            y = Relu (x)
+        }
+        """
+    )
+    onnx.checker.check_model(model)
+    return model
+
+
+def _foldable_model() -> onnx.ModelProto:
+    """Add(input, const_a + const_b) -- the inner Add folds to one constant."""
+    a = numpy_helper.from_array(np.array([1, 2, 3], np.float32), name="a")
+    b = numpy_helper.from_array(np.array([4, 5, 6], np.float32), name="b")
+    model = _model(
+        """
+        foldadd (float[3] x) => (float[3] y)
+        {
+            ab = Add (a, b)
+            y = Add (x, ab)
+        }
+        """,
+        initializer=[a, b],
+    )
+    onnx.checker.check_model(model)
+    return model
+
+
+def _cnn_model() -> onnx.ModelProto:
+    """Conv -> BatchNorm -> Relu -> GlobalAveragePool -> Flatten -> Gemm -> Softmax."""
+    rng = np.random.RandomState(0)
+    w = numpy_helper.from_array(rng.randn(4, 3, 3, 3).astype(np.float32), name="w")
+    b = numpy_helper.from_array(np.zeros(4, np.float32), name="b")
+    scale = numpy_helper.from_array(
+        (0.5 + rng.rand(4)).astype(np.float32), name="scale"
+    )
+    bn_bias = numpy_helper.from_array(rng.randn(4).astype(np.float32), name="bn_bias")
+    mean = numpy_helper.from_array(rng.randn(4).astype(np.float32) * 0.1, name="mean")
+    var = numpy_helper.from_array((0.5 + rng.rand(4)).astype(np.float32), name="var")
+    gw = numpy_helper.from_array(rng.randn(4, 4).astype(np.float32), name="gw")
+    gb = numpy_helper.from_array(rng.randn(4).astype(np.float32), name="gb")
+    model = _model(
+        """
+        cnn (float[1,3,8,8] x) => (float[1,4] y)
+        {
+            conv_out = Conv <kernel_shape=[3,3], pads=[1,1,1,1]> (x, w, b)
+            bn_out = BatchNormalization (conv_out, scale, bn_bias, mean, var)
+            relu_out = Relu (bn_out)
+            gap_out = GlobalAveragePool (relu_out)
+            flat_out = Flatten <axis=1> (gap_out)
+            gemm_out = Gemm <transB=1> (flat_out, gw, gb)
+            y = Softmax <axis=-1> (gemm_out)
+        }
+        """,
+        initializer=[w, b, scale, bn_bias, mean, var, gw, gb],
+    )
+    onnx.checker.check_model(model)
+    return model
+
+
+def _run_tflite(tflite_model: bytes, inputs: dict):
+    interp = tf.lite.Interpreter(model_content=tflite_model)
+    interp.allocate_tensors()
+    in_details = {d["name"]: d for d in interp.get_input_details()}
+    # TFLite input tensor names get a suffix from tf.function tracing (e.g.
+    # "x:0"), so match by position instead of by exact name when there's a
+    # single input -- the common case in these tests.
+    if len(in_details) == 1 and len(inputs) == 1:
+        (detail,) = in_details.values()
+        (value,) = inputs.values()
+        interp.set_tensor(detail["index"], value)
+    else:
+        for name, value in inputs.items():
+            interp.set_tensor(in_details[name]["index"], value)
+    interp.invoke()
+    return [interp.get_tensor(d["index"]) for d in interp.get_output_details()]
+
+
+def _assert_matches_onnxruntime(model: onnx.ModelProto, inputs: dict, **export_kwargs):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    expected = sess.run(None, inputs)
+    tflite_model = tflite_export.export_tflite(model, **export_kwargs)
+    actual = _run_tflite(tflite_model, inputs)
+    for e, a in zip(expected, actual):
+        np.testing.assert_allclose(e, a, rtol=1e-4, atol=1e-4)
+    return actual
+
+
+# ---------------------------------------------------------------------------
+# Basic conversion
+# ---------------------------------------------------------------------------
+
+
+def test_has_tensorflow_true_here():
+    assert tflite_export.has_tensorflow() is True
+
+
+def test_export_returns_tflite_bytes():
+    tflite_model = onnxsim.export_tflite(_relu_model())
+    assert isinstance(tflite_model, bytes)
+    assert len(tflite_model) > 0
+
+
+def test_export_writes_file(tmp_path):
+    out = tmp_path / "relu.tflite"
+    onnxsim.export_tflite(_relu_model(), str(out))
+    assert out.is_file()
+    assert out.read_bytes() == onnxsim.export_tflite(_relu_model())
+
+
+def test_export_of_simplified_model():
+    model = _foldable_model()
+    simplified, ok = onnxsim.simplify(model)
+    assert ok
+    # The redundant const+const Add is folded away by onnxsim.
+    assert [n.op_type for n in simplified.graph.node].count("Add") == 1
+    x = np.random.RandomState(0).randn(3).astype(np.float32)
+    _assert_matches_onnxruntime(simplified, {"x": x})
+
+
+def test_convert_to_tflite_matches_export_tflite():
+    model = _relu_model()
+    a = tflite_export.convert_to_tflite(model)
+    b = onnxsim.export_tflite(model)
+    assert a == b
+
+
+# ---------------------------------------------------------------------------
+# A small CNN pipeline, exercising conv/norm/pool/gemm/softmax together
+# ---------------------------------------------------------------------------
+
+
+def test_cnn_pipeline_matches_onnxruntime():
+    model = _cnn_model()
+    x = np.random.RandomState(1).randn(1, 3, 8, 8).astype(np.float32)
+    _assert_matches_onnxruntime(model, {"x": x})
+
+
+def test_dynamic_input_raises():
+    model = _model(
+        """
+        dyn (float[N,3] x) => (float[N,3] y)
+        {
+            y = Relu (x)
+        }
+        """
+    )
+    with pytest.raises(RuntimeError, match="dynamic dimension"):
+        onnxsim.export_tflite(model)
+
+
+def test_unsupported_op_raises_naming_the_op():
+    model = _model(
+        """
+        unsup (float[2,3] x) => (float[2,3] y)
+        {
+            y = Selu (x)
+        }
+        """
+    )
+    with pytest.raises(RuntimeError, match="Selu"):
+        onnxsim.export_tflite(model)
+
+
+# ---------------------------------------------------------------------------
+# Grouped/depthwise conv and pooling with padding
+# ---------------------------------------------------------------------------
+
+
+def test_depthwise_conv_and_pool_with_padding_match_onnxruntime():
+    # AveragePool's default count_include_pad=0 excludes the padded zeros from the
+    # average -- TF/TFLite's own avg_pool2d has no such option and always divides
+    # by the full window area, so tflite_export computes a per-position divisor
+    # correction. This model has non-trivial padding on both AveragePool and
+    # MaxPool (whose padded elements must not affect the max either) together with
+    # a depthwise (group == in_channels) Conv, to exercise all of that at once.
+    rng = np.random.RandomState(2)
+    dw_w = numpy_helper.from_array(rng.randn(4, 1, 3, 3).astype(np.float32), name="dwW")
+    pw_w = numpy_helper.from_array(
+        (0.1 * rng.randn(8, 8, 1, 1)).astype(np.float32), name="pwW"
+    )
+    pw_b = numpy_helper.from_array(rng.randn(8).astype(np.float32), name="pwB")
+    model = _model(
+        """
+        dw (float[1,4,9,9] x) => (float[1,8,3,3] y)
+        {
+            dw = Conv <kernel_shape=[3,3], strides=[1,1], pads=[1,1,1,1], group=4> (x, dwW)
+            lr = LeakyRelu <alpha=0.1> (dw)
+            ap = AveragePool <kernel_shape=[3,3], strides=[3,3], pads=[1,1,1,1], count_include_pad=0> (lr)
+            mp = MaxPool <kernel_shape=[3,3], strides=[3,3], pads=[1,1,1,1]> (lr)
+            cc = Concat <axis=1> (ap, mp)
+            y = Conv <kernel_shape=[1,1]> (cc, pwW, pwB)
+        }
+        """,
+        initializer=[dw_w, pw_w, pw_b],
+    )
+    onnx.checker.check_model(model)
+    x = rng.randn(1, 4, 9, 9).astype(np.float32)
+    _assert_matches_onnxruntime(model, {"x": x})
+
+
+def test_grouped_conv_non_depthwise_matches_onnxruntime():
+    # group > 1 but not the group-per-channel depthwise case: exercises the
+    # split-convolve-concat fallback path.
+    rng = np.random.RandomState(3)
+    w = numpy_helper.from_array(rng.randn(8, 2, 3, 3).astype(np.float32), name="w")
+    b = numpy_helper.from_array(rng.randn(8).astype(np.float32), name="b")
+    model = _model(
+        """
+        grouped (float[1,4,6,6] x) => (float[1,8,6,6] y)
+        {
+            y = Conv <kernel_shape=[3,3], pads=[1,1,1,1], group=2> (x, w, b)
+        }
+        """,
+        initializer=[w, b],
+    )
+    onnx.checker.check_model(model)
+    x = rng.randn(1, 4, 6, 6).astype(np.float32)
+    _assert_matches_onnxruntime(model, {"x": x})
+
+
+# ---------------------------------------------------------------------------
+# Reshape/shape-manipulation chain
+# ---------------------------------------------------------------------------
+
+
+def test_reshape_squeeze_transpose_slice_gather_chain_matches_onnxruntime():
+    model = _model(
+        """
+        shapes (float[2,3,4] x) => (float[1,2,1] y)
+        <int64[3] shp = {2,12,1}, int64[1] sq_axes = {2}, int64[1] usq_axes = {2},
+         int64[2] starts = {0,1}, int64[2] ends = {2,3}, int64[2] axes2 = {0,1},
+         int64[2] steps = {1,1}, int64[1] gidx = {1}, int64[4] padsv = {0,0,1,1}>
+        {
+            r = Reshape (x, shp)
+            sq = Squeeze (r, sq_axes)
+            tp = Transpose <perm=[1,0]> (sq)
+            sm = Softmax <axis=-1> (tp)
+            pd = Pad <mode="constant"> (sm, padsv)
+            sl = Slice (pd, starts, ends, axes2, steps)
+            g = Gather <axis=0> (sl, gidx)
+            y = Unsqueeze (g, usq_axes)
+        }
+        """
+    )
+    onnx.checker.check_model(model)
+    x = np.random.RandomState(4).randn(2, 3, 4).astype(np.float32)
+    _assert_matches_onnxruntime(model, {"x": x})
+
+
+def test_slice_negative_step_reverses_full_axis():
+    # Regression test: tf.strided_slice wraps a negative `end` the same way numpy
+    # indexing does (silently turning ONNX's "-1 meaning off the start" sentinel
+    # back into "the last element", producing an empty slice) unless `end_mask` is
+    # set for that axis -- see the comment in tflite_export._op_slice.
+    x = numpy_helper.from_array(np.arange(5, dtype=np.float32), name="x")
+    starts = numpy_helper.from_array(np.array([4], np.int64), name="starts")
+    ends = numpy_helper.from_array(np.array([-100], np.int64), name="ends")
+    axes = numpy_helper.from_array(np.array([0], np.int64), name="axes")
+    steps = numpy_helper.from_array(np.array([-1], np.int64), name="steps")
+    model = _model(
+        "slicerev () => (float[5] out) { out = Slice (x, starts, ends, axes, steps) }",
+        initializer=[x, starts, ends, axes, steps],
+    )
+    onnx.checker.check_model(model)
+    _assert_matches_onnxruntime(model, {})
+
+
+def test_slice_end_sentinel_survives_int64_downcast():
+    # ONNX graphs routinely use INT64_MAX as a Slice `ends` sentinel meaning "to
+    # the end of this axis". This translator downcasts int64 *tensors* to int32
+    # for TFLite, but Slice's bounds are read from the original (pre-downcast)
+    # numpy constant tracked alongside each traced tensor, so the sentinel's exact
+    # value survives -- a plain `.astype(int32)` on it would instead wrap
+    # INT64_MAX around to -1 and silently drop the last element.
+    x = numpy_helper.from_array(np.arange(8, dtype=np.float32), name="x")
+    starts = numpy_helper.from_array(np.array([3], np.int64), name="starts")
+    ends = numpy_helper.from_array(
+        np.array([9223372036854775807], np.int64), name="ends"
+    )
+    model = _model(
+        "slicesentinel () => (float[5] out) { out = Slice (x, starts, ends) }",
+        initializer=[x, starts, ends],
+    )
+    onnx.checker.check_model(model)
+    _assert_matches_onnxruntime(model, {})
+
+
+def test_uneven_split_matches_onnxruntime():
+    x = np.random.RandomState(5).randn(2, 6).astype(np.float32)
+    splitv = numpy_helper.from_array(np.array([2, 4], np.int64), name="splitv")
+    model = _model(
+        "split (float[2,6] x) => (float[2,2] a, float[2,4] b) "
+        "{ a, b = Split <axis=1> (x, splitv) }",
+        initializer=[splitv],
+    )
+    onnx.checker.check_model(model)
+    _assert_matches_onnxruntime(model, {"x": x})

--- a/tests/test_tflite_export.py
+++ b/tests/test_tflite_export.py
@@ -345,3 +345,21 @@ def test_uneven_split_matches_onnxruntime():
     )
     onnx.checker.check_model(model)
     _assert_matches_onnxruntime(model, {"x": x})
+
+
+# ---------------------------------------------------------------------------
+# backend= dispatch (the "onnx2tf" backend itself is covered by
+# test_onnx2tf_export.py, skipped when onnx2tf isn't installed)
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_backend_raises():
+    with pytest.raises(ValueError, match="Unknown backend"):
+        onnxsim.export_tflite(_relu_model(), backend="bogus")
+
+
+def test_builtin_backend_rejects_backend_specific_kwargs():
+    with pytest.raises(TypeError, match="unexpected keyword arguments"):
+        onnxsim.export_tflite(
+            _relu_model(), keep_ncw_or_nchw_or_ncdhw_input_names=["x"]
+        )


### PR DESCRIPTION
onnx-tensorflow/onnx-tf has been unmaintained for years, so add a built-in
ONNX-to-TensorFlow translator (onnxsim/tflite_export.py) that builds the
simplified graph with plain TensorFlow ops inside a traced tf.function and
hands it to tf.lite.TFLiteConverter, mirroring how coreml_export.py fills the
same gap for Core ML. Covers a practical subset of ops (conv/pooling/
normalization, matmul/gemm, elementwise math, reshapes, reductions, ...),
keeping the graph in ONNX's NCHW layout and transposing to/from TFLite's
NHWC-only kernels only around Conv/MaxPool/AveragePool. TensorFlow is an
optional dependency, imported only when the feature is used.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012h6WvBTRGAEhXLFRUPVQ29