### PR TITLE
Differential analysis: how Add/Sub/Mul/Div constants and Conv bias get encoded in a compiled axmodel

### DIFF
--- a/.github/workflows/axera-integration.yml
+++ b/.github/workflows/axera-integration.yml
@@ -40,6 +40,7 @@ on:
       - "tests/test_pulsar2_hf_to_axmodel.py"
       - "tests/test_axera_conv_matmul_coverage.py"
       - "tests/test_axera_conv_matmul_coverage_hardware.py"
+      - "tests/test_axera_neu_format_arith_ops.py"
 
 concurrency:
   group: axera-integration-${{ github.ref }}
@@ -150,7 +151,7 @@ jobs:
       - name: Run hf-config+safetensors -> onnx -> axmodel integration test
         working-directory: ${{ runner.temp }}
         run: |
-          pytest -v "$GITHUB_WORKSPACE/tests/test_pulsar2_hf_to_axmodel.py" "$GITHUB_WORKSPACE/tests/test_axera_conv_matmul_coverage_hardware.py"
+          pytest -v "$GITHUB_WORKSPACE/tests/test_pulsar2_hf_to_axmodel.py" "$GITHUB_WORKSPACE/tests/test_axera_conv_matmul_coverage_hardware.py" "$GITHUB_WORKSPACE/tests/test_axera_neu_format_arith_ops.py"
       - name: Run real conversion
         working-directory: ${{ runner.temp }}
         env:

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -411,6 +411,98 @@ above only inferred generically:
   distinct, entirely unimplemented `AxQuantizedGemm` op. Confirms the
   blog's suspicion with a precise, reproducible mechanism.
 
+### Differential analysis: how elementwise ops and Conv bias get encoded
+
+The dig above characterizes one model's compiled output; this pushes
+further with **differential analysis** -- compiling many near-identical
+graphs and byte-diffing the results to locate exactly where a specific,
+controlled value ends up. Test graph throughout: `Add`/`Sub`/`Mul`/`Div`
+between a `float[1,4]` input and a uniform-broadcast constant, or a `Conv`
+with a bias term -- varying only the constant/bias value between builds.
+
+**A "trivial" fast-path exists for small uniform constants, scale=1,
+zero_point=0, storing the constant's own integer value as a raw byte** --
+but confirmed real by testing across all four ops, **the trivial *set*
+is op-specific, not a shared threshold**:
+
+- `Add`: exactly the uniform values `{0, 1, 2}` are trivial; `3` and up,
+  any negative value, and any non-integer are not.
+- `Sub`: only `{0, 1}` -- `Sub(x, 2.0)` is *not* trivial, unlike
+  `Add(x, 2.0)`. Not simply "`Sub(x, c)` lowers to `Add(x, -c)`" either:
+  that would predict `Sub(x, 1.0)` (i.e. `Add(x, -1.0)`) to behave like
+  `Add`'s confirmed-non-trivial negative case, but it doesn't -- it's
+  trivial, storing `01 01 01 01` same as `Add(x, 1.0)`.
+  `Mul`: every uniform value tried (`0`, `2`, `3`) was trivial -- no
+  "rich" encoding observed for `Mul` at all.
+- `Div`: triviality depends on **the constant's reciprocal**, not the
+  constant itself -- `Div(x, 0.5)` (reciprocal `2.0`) is trivial, storing
+  `02 02 02 02`, while `Div(x, 2.0)` and `Div(x, 3.0)` (reciprocals `0.5`,
+  `0.333...`, non-integer) saturate every element to `0xff`. Consistent
+  with `Div(x, c)` being compiled as `Mul(x, 1/c)` internally.
+
+**Any non-integer value saturates every element to `0xff` (255)**,
+regardless of magnitude -- confirmed across `Add`/`Sub`/`Div`'s non-integer
+cases (`0.5`, `3.14159`, and `Div`'s non-integer effective reciprocals).
+It's specifically about exact integer-valuedness of whatever value is
+actually being quantized (the reciprocal, for `Div`) -- not "small enough."
+
+**A uniform broadcast is required for the trivial path, even when every
+individual element already qualifies**: `Add` with the mixed constant
+`[1, 1, 2, 2]` (every element in the "trivial" set `{0,1,2}`) still gets
+the non-trivial encoding, because the *tensor* isn't a uniform single-value
+broadcast. Mixed constants still store their exact literal integer values
+per element in the non-trivial path (`[1,2,3,4]` -> `01 02 03 04`), so
+"non-trivial" doesn't mean "imprecise" -- it means "not the degenerate
+single-value fast path."
+
+**Confirmed real, reproducible compiler bug**: `Mul(x, 1.0)` and
+`Div(x, 1.0)` both crash a real `pulsar2 build` with the identical
+`NotImplementedError: Seems config of input(y) doesn't exist`. Multiplying
+or dividing by the identity constant appears to get eliminated by
+Pulsar2's own frontend graph optimizer (`x*1=x`, `x/1=x`) before
+quantization runs, leaving the declared graph output with no producing
+node. `tests/test_axera_neu_format_arith_ops.py::
+test_mul_and_div_by_one_crash_the_real_build` locks this in.
+
+**`Div(x, 0.0)` doesn't error -- it stores literal IEEE-754 `+Infinity`**:
+`00 00 80 7f` (float32 `+inf`) repeated once per element, a third,
+distinct byte-length class from the other two, and the only case found
+where this field holds genuine float32 data instead of an integer code --
+a sensible fallback once the "true" quantized value is undefined.
+
+**A field that resists decoding, isolated but not solved**: `Add`/`Sub`'s
+non-trivial encoding appends 4 extra bytes past the per-element values.
+Ten-plus decodings were tried and rejected (float32, uint32, a `bf16`
+pair, an `fp16` pair, `xxhash32`/`xxhash64` of several byte encodings of
+the constant, a hand-computed asymmetric output-quantization scale/
+zero-point from the real calibration data) -- none matched. What *is*
+confirmed: holding the constant fixed (`c=99`) and varying only the
+input's calibration scale (x1, x100, x0.01) changed these bytes
+completely while the constant's own quantized bytes stayed identical --
+so the field depends on the input/output's calibration range, not the
+constant alone. The two 16-bit halves are also mathematically coupled:
+treating them as `(pair1, pair2)`, `pair2 * scale_y ≈ pair1` held to
+within rounding across all three calibration scales, where `scale_y` is
+the real `(max-min)/255` output range independently computed from the
+actual calibration samples used. A real, non-arbitrary (value,
+value-expressed-in-quantization-units) pair -- just one whose absolute
+unit/format wasn't identified.
+
+**`Conv`'s bias term, by contrast, decodes cleanly**: byte-diffing five
+otherwise-identical `Conv` builds that differ only in bias value locates
+the bias-dependent region precisely, and it holds two 4-element
+(one per output channel) plain `float32` arrays -- not further-obfuscated
+integer codes. One array is small (~0.0026-0.0037) and shrinks
+monotonically as the bias value grows, consistent with a per-channel
+requantization multiplier `M_channel = input_scale * weight_scale_channel
+/ output_scale` (a larger bias widens the calibrated output range, so
+`output_scale` grows and `M_channel` shrinks) -- exactly the standard
+quantized-conv parameterization real edge-inference runtimes use. The
+other array (larger magnitude, ~-159 to 242) plausibly holds a quantized
+bias term but wasn't independently re-derived from scratch. Real,
+recognizable structure here, in clear contrast to `Add`/`Sub`'s still-
+opaque field above.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/tests/test_axera_neu_format_arith_ops.py
+++ b/tests/test_axera_neu_format_arith_ops.py
@@ -1,0 +1,191 @@
+"""Real-hardware differential analysis of onnxsim/pulsar2_docker.py's
+compiled `.axmodel` `neu mode` format: how Add/Sub/Mul/Div constants and
+Conv bias terms get encoded in the `npu_params` initializer blob.
+
+See scripts/axera/README.md's "Differential analysis: how elementwise ops
+and Conv bias get encoded" section for the full narrative writeup this
+locks in -- including the parts of that investigation (a still-undecoded
+4-byte field in Add/Sub's non-trivial encoding) this file does NOT attempt
+to test, since their exact bit-level format was never identified.
+
+Needs a loaded `pulsar2:*` Docker image -- skip-guarded like
+tests/test_pulsar2_hf_to_axmodel.py.
+"""
+
+import json
+import os
+import sys
+
+import numpy as np
+import onnx
+import pytest
+from onnx import numpy_helper, parser
+
+_AXERA_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "axera"
+)
+if _AXERA_DIR not in sys.path:
+    sys.path.insert(0, _AXERA_DIR)
+
+import pulsar2_docker  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    not pulsar2_docker.docker_image_available(),
+    reason=f"pulsar2 Docker image not loaded: {pulsar2_docker.DEFAULT_IMAGE}",
+)
+
+
+def _model(op, const_val, opset=17, ir_version=10):
+    model = parser.parse_model(
+        f'<ir_version: {ir_version}, opset_import: ["": {opset}]> '
+        f"agraph (float[1,4] x) => (float[1,4] y) "
+        f"{{ y = {op}(x, c) }}"
+    )
+    arr = np.full((4,), const_val, dtype=np.float32)
+    model.graph.initializer.append(numpy_helper.from_array(arr, name="c"))
+    onnx.checker.check_model(model)
+    return model
+
+
+def _generic_quant_config(input_specs, calibration_size=4):
+    return {
+        "model_type": "ONNX",
+        "npu_mode": "NPU1",
+        "quant": {
+            "input_configs": [
+                {
+                    "tensor_name": name,
+                    "calibration_dataset": f"./dataset/calib_{name}.tar",
+                    "calibration_format": "Numpy",
+                    "calibration_size": calibration_size,
+                }
+                for name, _shape, _dtype in input_specs
+            ],
+            "calibration_method": "MinMax",
+            "precision_analysis": False,
+        },
+        "compiler": {"check": 0},
+    }
+
+
+def _build(tmp_path, name, model, input_specs, calibration_size=4, seed=0):
+    work_dir = os.path.join(str(tmp_path), name)
+    os.makedirs(work_dir, exist_ok=True)
+    onnx.save(model, os.path.join(work_dir, "model.onnx"))
+
+    rng = np.random.default_rng(seed)
+    os.makedirs(os.path.join(work_dir, "dataset"), exist_ok=True)
+    for tname, shape, dtype in input_specs:
+        samples = [
+            rng.standard_normal(shape).astype(dtype) for _ in range(calibration_size)
+        ]
+        pulsar2_docker.make_numpy_calibration_tar(
+            os.path.join(work_dir, "dataset", f"calib_{tname}.tar"), samples
+        )
+
+    os.makedirs(os.path.join(work_dir, "config"), exist_ok=True)
+    with open(os.path.join(work_dir, "config", "cfg.json"), "w") as f:
+        json.dump(_generic_quant_config(input_specs, calibration_size), f)
+
+    return pulsar2_docker.build(
+        work_dir, "model.onnx", "output", config_path="config/cfg.json"
+    )
+
+
+def _npu_params_bytes(axmodel_path):
+    compiled = onnx.load(axmodel_path)
+    neu_node = next(n for n in compiled.graph.node if n.op_type == "neu mode")
+    inits = {i.name: i for i in compiled.graph.initializer}
+    info = None
+    for attr in neu_node.attribute:
+        if attr.name == "npu_graph_info":
+            info = json.loads(attr.s.decode())
+    params_key = info["dotneus"][0]["extra_inputs"][0]["const_data_key"]
+    return bytes(inits[params_key].raw_data)
+
+
+def test_mul_and_div_by_one_crash_the_real_build(tmp_path):
+    """Confirmed real, reproducible compiler bug: multiplying or dividing
+    by the identity constant 1.0 gets eliminated by Pulsar2's own frontend
+    graph optimizer (x*1=x, x/1=x) before quantization runs, leaving the
+    declared graph output with no producing node."""
+    for op in ("Mul", "Div"):
+        model = _model(op, 1.0)
+        result = _build(
+            tmp_path, f"{op.lower()}_by_one", model, [("x", (1, 4), np.float32)]
+        )
+        assert not result.success
+        assert "Seems config of input(y) doesn't exist" in result.error
+
+
+@pytest.mark.parametrize(
+    "value,expect_trivial",
+    [(0.0, True), (1.0, True), (2.0, True), (3.0, False), (-1.0, False), (0.5, False)],
+)
+def test_add_trivial_set_is_exactly_0_1_2(tmp_path, value, expect_trivial):
+    model = _model("Add", value)
+    result = _build(tmp_path, f"add_{value}", model, [("x", (1, 4), np.float32)])
+    assert result.success, result.error
+    params = _npu_params_bytes(result.axmodel_path)
+    assert (len(params) == 44) == expect_trivial, (value, len(params))
+
+
+@pytest.mark.parametrize(
+    "value,expect_trivial", [(0.0, True), (1.0, True), (2.0, False), (3.0, False)]
+)
+def test_sub_trivial_set_is_only_0_1(tmp_path, value, expect_trivial):
+    """Confirmed narrower than Add's {0,1,2} -- Sub(x, 2.0) is not trivial,
+    unlike Add(x, 2.0)."""
+    model = _model("Sub", value)
+    result = _build(tmp_path, f"sub_{value}", model, [("x", (1, 4), np.float32)])
+    assert result.success, result.error
+    params = _npu_params_bytes(result.axmodel_path)
+    assert (len(params) == 44) == expect_trivial, (value, len(params))
+
+
+def test_div_triviality_depends_on_the_reciprocal(tmp_path):
+    """Div(x, 0.5) (reciprocal 2.0, an integer) is trivial; Div(x, 2.0)
+    and Div(x, 3.0) (reciprocals 0.5, 0.333..., non-integer) saturate to
+    0xff -- consistent with Div(x, c) compiling as Mul(x, 1/c)."""
+    model_half = _model("Div", 0.5)
+    result_half = _build(tmp_path, "div_half", model_half, [("x", (1, 4), np.float32)])
+    assert result_half.success, result_half.error
+    params_half = _npu_params_bytes(result_half.axmodel_path)
+    assert params_half[:4] == bytes([2, 2, 2, 2])
+
+    for value in (2.0, 3.0):
+        model = _model("Div", value)
+        result = _build(tmp_path, f"div_{value}", model, [("x", (1, 4), np.float32)])
+        assert result.success, result.error
+        params = _npu_params_bytes(result.axmodel_path)
+        assert params[:4] == bytes([0xFF] * 4), (value, params[:4].hex())
+
+
+def test_div_by_zero_stores_literal_float32_infinity(tmp_path):
+    model = _model("Div", 0.0)
+    result = _build(tmp_path, "div_zero", model, [("x", (1, 4), np.float32)])
+    assert result.success, result.error
+    params = _npu_params_bytes(result.axmodel_path)
+    inf_bytes = np.float32(np.inf).tobytes()
+    assert params[:16] == inf_bytes * 4
+
+
+def test_mixed_constant_is_never_trivial_even_if_every_element_qualifies(tmp_path):
+    """Add's trivial fast path needs the whole tensor to be a uniform
+    single-value broadcast, not just small per-element values: [1,1,2,2]
+    (every element individually in {0,1,2}) is still non-trivial, but the
+    exact literal integer values are still preserved per element."""
+    model = parser.parse_model(
+        '<ir_version: 10, opset_import: ["": 17]> '
+        "agraph (float[1,4] x) => (float[1,4] y) { y = Add(x, c) }"
+    )
+    model.graph.initializer.append(
+        numpy_helper.from_array(np.array([1, 1, 2, 2], dtype=np.float32), name="c")
+    )
+    onnx.checker.check_model(model)
+
+    result = _build(tmp_path, "add_mixed_1122", model, [("x", (1, 4), np.float32)])
+    assert result.success, result.error
+    params = _npu_params_bytes(result.axmodel_path)
+    assert len(params) != 44
+    assert params[:4] == bytes([1, 1, 2, 2])


### PR DESCRIPTION
## Summary

Continues the `neu mode` format investigation from #1082/#1089 with **differential analysis**: compiling many near-identical `Add`/`Sub`/`Mul`/`Div`-by-constant and `Conv`-with-bias graphs through a real `pulsar2 build`, then byte-diffing the results to locate exactly where controlled values end up in `npu_params`.

- A "trivial" fast path (scale=1, zero_point=0, raw byte = value) exists for small uniform constants, but **the trivial set is op-specific**: `Add` is exactly `{0,1,2}`; `Sub` is only `{0,1}` (`Sub(x,2.0)` is *not* trivial, unlike `Add(x,2.0)` -- and it's not simply "Add with a negated constant" either, since `Sub(x,1.0)` stays trivial, which `Add(x,-1.0)` does not); `Mul` showed no non-trivial encoding at all for `{0,2,3}`; `Div`'s triviality depends on **the reciprocal** (`Div(x,0.5)` -> reciprocal `2.0` -> trivial; `Div(x,2.0)`/`Div(x,3.0)` -> non-integer reciprocals -> saturate), consistent with `Div(x,c)` compiling as `Mul(x,1/c)`.
- Any non-integer value saturates every element to `0xff` regardless of magnitude.
- A uniform broadcast is required for the trivial path even when every individual element already qualifies (`Add`'s `[1,1,2,2]` stays non-trivial), though non-trivial still preserves exact literal values per element.
- **Confirmed real, reproducible compiler bug**: `Mul(x,1.0)` and `Div(x,1.0)` both crash a real `pulsar2 build` identically (`NotImplementedError: Seems config of input(y) doesn't exist`) -- Pulsar2's own frontend optimizer eliminates the identity op before quantization runs.
- `Div(x,0.0)` doesn't error -- it stores literal IEEE-754 `+Infinity` (`00 00 80 7f` per element), a third distinct byte-length class and the only case found with real float32 data in this field.
- `Add`/`Sub`'s non-trivial encoding appends a still-undecoded 4-byte field (10+ decodings tried and rejected). Confirmed to depend on the input's calibration range (not the constant alone), and its two 16-bit halves are mathematically coupled (`pair2 * scale_y ~= pair1` across three calibration scales) -- just not identified in absolute terms. Documented honestly as unresolved.
- `Conv`'s bias term, by contrast, **decodes cleanly**: byte-diffing bias=0..3 locates two real per-output-channel `float32` arrays -- one shrinking monotonically with bias (consistent with a per-channel requantization multiplier `M = input_scale * weight_scale / output_scale`) and one larger-magnitude array plausibly holding a quantized bias term.

`tests/test_axera_neu_format_arith_ops.py` locks in the reproducible parts of this (trivial-set boundaries, the `Mul`/`Div`-by-one crash, `Div`-by-zero's literal infinity) against a real `pulsar2 build`; the still-undecoded 4-byte field is documented but deliberately not asserted against.

## Test plan
- [x] All 14 new tests run for real against the real `pulsar2:6.0-lite` image + AX650N -- 14 passed.
- [x] `python -m pytest tests/test_axera_neu_format_arith_ops.py tests/test_axera_conv_matmul_coverage.py tests/test_axera_conv_matmul_coverage_hardware.py tests/test_pulsar2_hf_to_axmodel.py tests/test_pulsar2_compat.py tests/test_pulsar2_simulator.py -q` -- 49 passed, no regressions.
- [x] `ruff check` / `ruff format --check` clean.
- [x] YAML-validated `axera-integration.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UC8vhJgE71RLFF4DgdSP9P