### PR TITLE
Wire Clip (ReLU6) pass-through hop into ConvInteger chains

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -33185,8 +33185,11 @@ def apply_structured_pruning_dynamic_quantize_matmul(
 # closely, DELIBERATELY narrower than the ``DynamicQuantizeMatMul`` section's
 # own quantized-or-plain-float union: only a ``ConvInteger``-shaped producer
 # feeding a ``ConvInteger``-shaped consumer (through zero or more
-# shape-preserving unary hops, ``_UNARY_PASS_THROUGH``) is matched -- a plain
-# float ``Conv`` peer on either side is declined outright, not attempted.
+# shape-preserving unary hops, ``_UNARY_PASS_THROUGH``, plus a
+# channel-agnostic ``Clip`` -- :func:`_match_clip_channel_pass_through`, the
+# same helper :func:`_walk_to_conv_consumer` already uses for the identical
+# ReLU6 shape on a plain-float Conv chain) is matched -- a plain float
+# ``Conv`` peer on either side is declined outright, not attempted.
 # This is a real, deliberate scope narrowing (see this module's own
 # docstring on drawing scope where it was actually verified, not where it
 # looked plausible): matching a plain ``Conv`` peer here would mean reusing
@@ -33529,7 +33532,12 @@ def _walk_to_conv_integer_consumer(
 ) -> Optional[Tuple[_ConvIntegerConv, Tuple[onnx.NodeProto, ...]]]:
     """From tensor `start` (a matched ``ConvInteger`` Conv layer's own
     logical output, :func:`_conv_integer_final_output`), walks forward
-    through shape-preserving unary activations (`_UNARY_PASS_THROUGH`) with
+    through shape-preserving unary activations (`_UNARY_PASS_THROUGH`) --
+    plus a channel-agnostic ``Clip`` (see :func:`_match_clip_channel_pass_through`,
+    the same helper :func:`_walk_to_conv_consumer` already uses for the
+    identical ReLU6 shape on a plain-float Conv chain -- MobileNet/
+    EfficientNet-Lite's `Conv -> Clip(0, 6) -> ConvInteger` dynamically-
+    quantized topology needs the exact same transparent hop) -- with
     no other consumer anywhere along the way, until a same-family
     ``ConvInteger``-based consumer (reached through its own
     ``DynamicQuantizeLinear`` producer) is found whose own `K` matches
@@ -33563,6 +33571,21 @@ def _walk_to_conv_integer_consumer(
                 if m is not None and m.dq_node is nxt and m.K == n_channels:
                     return m, tuple(chain_ops)
             return None
+
+        if (
+            nxt.op_type == "Clip"
+            and nxt.domain == ""
+            and nxt.input
+            and nxt.input[0] == cur
+            and len(nxt.output) == 1
+            and _match_clip_channel_pass_through(nxt, initializer_map)
+        ):
+            out2 = nxt.output[0]
+            if len(consumers_of.get(out2, [])) != 1 or out2 in graph_outputs:
+                return None
+            chain_ops.append(nxt)
+            cur = out2
+            continue
 
         if not (
             nxt.op_type in _UNARY_PASS_THROUGH

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -44525,7 +44525,17 @@ def _quantize_dynamic_conv_weight(W, spatial=8, per_channel=False):
 
 
 def _dqconv_model_from_weights(
-    c, m1, m2, w1f, w2f, b1f=None, spatial=8, activation="Relu", seed=0
+    c,
+    m1,
+    m2,
+    w1f,
+    w2f,
+    b1f=None,
+    spatial=8,
+    activation="Relu",
+    seed=0,
+    activation_node=None,
+    extra_initializer=(),
 ):
     """Builds ``DynamicQuantizeLinear -> ConvInteger -> Cast -> Mul
     [-> Reshape -> Add] -> activation -> DynamicQuantizeLinear ->
@@ -44534,6 +44544,12 @@ def _dqconv_model_from_weights(
     (:func:`_quantize_dynamic_conv_weight`). Returns ``(model, info)`` where
     `info` carries every float/quantized array needed to hand-build an
     "already pruned" oracle.
+
+    `activation_node`, when given, is a complete ONNX-text node line
+    overriding the plain ``h1 = {activation}(...)`` node below -- e.g. a
+    ``Clip`` with explicit Min/Max operands (see
+    `_dqconv_clip_model_from_weights`) -- with `extra_initializer` carrying
+    whatever constant tensors that text line references.
     """
     w1q, w1s, w1zp = _quantize_dynamic_conv_weight(w1f, spatial=spatial)
     w2q, w2s, w2zp = _quantize_dynamic_conv_weight(w2f, spatial=spatial)
@@ -44553,6 +44569,12 @@ def _dqconv_model_from_weights(
         bias_ops = ""
         c1_out = "c1s"
 
+    activation_ops = (
+        activation_node
+        if activation_node is not None
+        else f"h1 = {activation}({c1_out})"
+    )
+
     body = f"""
     g (float[1,{c},{spatial},{spatial}] x) => (float[1,{m2},{spatial},{spatial}] y)
     {{
@@ -44562,7 +44584,7 @@ def _dqconv_model_from_weights(
       c1f = Cast<to=1>(c1i)
       c1s = Mul(c1f, combined_scale1)
       {bias_ops}
-      h1 = {activation}({c1_out})
+      {activation_ops}
       rq, r_scale, r_zero_point = DynamicQuantizeLinear(h1)
       combined_scale2 = Mul(r_scale, w2_scale)
       c2i = ConvInteger<kernel_shape=[{kh2},{kw2}], pads=[{ph2},{pw2},{ph2},{pw2}]>(rq, w2_quantized, r_zero_point, w2_zero_point)
@@ -44577,6 +44599,7 @@ def _dqconv_model_from_weights(
         onnx.numpy_helper.from_array(w2q, "w2_quantized"),
         onnx.numpy_helper.from_array(w2s, "w2_scale"),
         onnx.numpy_helper.from_array(w2zp, "w2_zero_point"),
+        *extra_initializer,
     ]
     if b1f is not None:
         inits.append(_f32(b1f, "b1"))
@@ -44598,6 +44621,71 @@ def _dqconv_model_from_weights(
         "W2zp": w2zp,
         "spatial": spatial,
     }
+
+
+def _dqconv_clip_model_from_weights(
+    c, m1, m2, w1f, w2f, b1f=None, spatial=8, min_val=0.0, max_val=6.0, seed=0
+):
+    """The `_dqconv_model_from_weights` analogue exercising
+    `_walk_to_conv_integer_consumer`'s own ``Clip`` pass-through hop (the
+    ReLU6 shape MobileNetV2/V3 and EfficientNet-Lite Conv chains use) in
+    place of a plain unary activation between the two ``ConvInteger``
+    chains -- `min_val`/`max_val` (each `None` or a Python float) become
+    scalar float32 `Min`/`Max` initializers, mirroring
+    `_clip_conv_pair_model`'s own identical convention for the plain-float
+    Conv walker's Clip hop.
+    """
+    extra_initializer = []
+    if min_val is not None:
+        extra_initializer.append(
+            onnx.numpy_helper.from_array(np.array(min_val, dtype=np.float32), "ClipMin")
+        )
+    if max_val is not None:
+        extra_initializer.append(
+            onnx.numpy_helper.from_array(np.array(max_val, dtype=np.float32), "ClipMax")
+        )
+    c1_out = "c1" if b1f is not None else "c1s"
+    if min_val is not None and max_val is not None:
+        clip_node = f"h1 = Clip({c1_out}, ClipMin, ClipMax)"
+    elif min_val is not None:
+        clip_node = f"h1 = Clip({c1_out}, ClipMin)"
+    elif max_val is not None:
+        clip_node = f"h1 = Clip({c1_out}, , ClipMax)"
+    else:
+        clip_node = f"h1 = Clip({c1_out})"
+    return _dqconv_model_from_weights(
+        c,
+        m1,
+        m2,
+        w1f,
+        w2f,
+        b1f=b1f,
+        spatial=spatial,
+        seed=seed,
+        activation_node=clip_node,
+        extra_initializer=extra_initializer,
+    )
+
+
+def _dqconv_clip_chain_model(
+    c, m1, m2, kh=3, kw=3, bias1=False, spatial=8, seed=0, min_val=0.0, max_val=6.0
+):
+    rng = np.random.default_rng(seed)
+    w1f = (rng.standard_normal((m1, c, kh, kw)) * 0.3).astype(np.float32)
+    w2f = (rng.standard_normal((m2, m1, kh, kw)) * 0.3).astype(np.float32)
+    b1f = (rng.standard_normal(m1) * 0.05).astype(np.float32) if bias1 else None
+    return _dqconv_clip_model_from_weights(
+        c,
+        m1,
+        m2,
+        w1f,
+        w2f,
+        b1f=b1f,
+        spatial=spatial,
+        min_val=min_val,
+        max_val=max_val,
+        seed=seed,
+    )
 
 
 def _dqconv_chain_model(c, m1, m2, kh=3, kw=3, bias1=False, spatial=8, seed=0):
@@ -44730,6 +44818,117 @@ def test_dynamic_quantize_conv_no_bias_chain_is_matched_and_prunes():
     (y_pruned,) = _run(pruned, {"x": x})
     assert y_pruned.shape == (1, m2, 8, 8)
     assert np.all(np.isfinite(y_pruned))
+
+
+def test_dynamic_quantize_conv_clip_relu6_pass_through_matches_and_prunes():
+    # Conv -> Clip(0, 6) -> Conv (ReLU6, the standard MobileNetV2/V3 and
+    # EfficientNet-Lite activation) -- after a real `quantize_dynamic` +
+    # `ORT_ENABLE_EXTENDED` graph-optimization round trip this produces the
+    # identical dynamically-quantized `ConvInteger` topology as the Relu
+    # case, just with `Clip` standing in for `Relu` between the two
+    # `ConvInteger` chains. Confirms `_walk_to_conv_integer_consumer` now
+    # crosses it transparently (reusing `_match_clip_channel_pass_through`,
+    # the same helper `_walk_to_conv_consumer` already uses for the
+    # identical plain-float-Conv shape) and that the chain is matched and
+    # pruned end-to-end.
+    c, m1, m2 = 4, 6, 5
+    model, info = _dqconv_clip_chain_model(c, m1, m2, bias1=True, seed=20)
+    onnx.checker.check_model(model)
+    chains = onnxsim.pruning._find_conv_integer_chains(model.graph)
+    assert len(chains) == 1
+    assert chains[0].n_channels == m1
+    # The Clip hop is folded into the chain exactly like a plain unary
+    # pass-through activation would be (`chain_ops`), not treated specially.
+    assert [op.op_type for op in chains[0].chain_ops] == ["Clip"]
+
+    pruned = onnxsim.apply_structured_pruning_dynamic_quantize_conv(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["w1_quantized"].dims) == [m1 // 2, c, 3, 3]
+    assert list(inits["w2_quantized"].dims) == [m2, m1 // 2, 3, 3]
+
+    # The Clip node itself is untouched -- still a plain scalar Min/Max --
+    # and needs no dedicated "carry it through the rewrite" logic at all:
+    # the existing chain_ops stale-value-info bookkeeping already covers it
+    # (see `apply_structured_pruning_dynamic_quantize_conv`'s own loop).
+    pruned_clip = next(n for n in pruned.graph.node if n.op_type == "Clip")
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits[pruned_clip.input[1]]), np.float32(0.0)
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits[pruned_clip.input[2]]), np.float32(6.0)
+    )
+
+    # Numeric correctness against an INDEPENDENTLY reconstructed "already
+    # pruned" oracle (this project's established quantized-section bar --
+    # see `test_dynamic_quantize_conv_producer_matches_independent_oracle_
+    # via_real_inference_session`'s own identical structure), not a
+    # post-hoc slice of the unpruned model's own output.
+    keep = _dqconv_importance_keep(info["W1q"], info["W1s"], info["W1zp"], m1 // 2)
+    ref_model, _ = _dqconv_clip_model_from_weights(
+        c,
+        len(keep),
+        m2,
+        info["W1f"][keep],
+        info["W2f"][:, keep],
+        b1f=info["B1f"][keep],
+        spatial=info["spatial"],
+        seed=987654,
+    )
+    ref_inits = {t.name: t for t in ref_model.graph.initializer}
+    ref_inits["w1_quantized"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W1q"][keep], "w1_quantized")
+    )
+    ref_inits["w1_scale"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W1s"], "w1_scale")
+    )
+    ref_inits["w1_zero_point"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W1zp"], "w1_zero_point")
+    )
+    ref_inits["w2_quantized"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W2q"][:, keep], "w2_quantized")
+    )
+    ref_inits["w2_scale"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W2s"], "w2_scale")
+    )
+    ref_inits["w2_zero_point"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W2zp"], "w2_zero_point")
+    )
+
+    rng = np.random.default_rng(21)
+    spatial = info["spatial"]
+    x = rng.standard_normal((1, c, spatial, spatial)).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"x": x})
+    (y_ref,) = _run(ref_model, {"x": x})
+    np.testing.assert_array_equal(y_pruned, y_ref)
+
+
+def test_dynamic_quantize_conv_clip_nonscalar_min_declines():
+    # A `Clip` with a per-channel-shaped (`[m1]`) `min` between two
+    # `ConvInteger` chains must be declined, never guessed at -- mirrors
+    # `test_structured_pruning_clip_nonscalar_min_declines`'s own identical
+    # bar for the plain-float Conv walker (`_match_clip_channel_pass_through`
+    # is shared by both, see that function's own docstring: trusted by
+    # confirmed shape, never by the schema's word alone).
+    c, m1, m2 = 4, 6, 5
+    rng = np.random.default_rng(23)
+    w1f = (rng.standard_normal((m1, c, 3, 3)) * 0.3).astype(np.float32)
+    w2f = (rng.standard_normal((m2, m1, 3, 3)) * 0.3).astype(np.float32)
+    min_per_channel = onnx.numpy_helper.from_array(
+        np.zeros((m1,), dtype=np.float32), "ClipMinPerChannel"
+    )
+    model, _info = _dqconv_model_from_weights(
+        c,
+        m1,
+        m2,
+        w1f,
+        w2f,
+        activation_node="h1 = Clip(c1s, ClipMinPerChannel)",
+        extra_initializer=[min_per_channel],
+        seed=24,
+    )
+    chains = onnxsim.pruning._find_conv_integer_chains(model.graph)
+    assert chains == []
 
 
 def test_dynamic_quantize_conv_scale_always_per_tensor():


### PR DESCRIPTION
## Summary

The `DynamicQuantizeConv` (`ConvInteger`) chain-finding walker, `_walk_to_conv_integer_consumer`, already passed through simple unary ops (`Relu`, `Cast`, ...) between two same-family `ConvInteger` Conv layers via `_UNARY_PASS_THROUGH`, but had no handling for `Clip` — the node ONNX export of `torch.nn.ReLU6` actually produces. Since ReLU6 is the standard activation in MobileNetV2/V3 and EfficientNet-Lite (exactly the CNN families most commonly deployed with dynamic Conv quantization), a `Conv → Clip(0, 6) → ConvInteger`-quantized chain silently matched zero chains and got no pruning at all.

## Empirically confirmed facts

- Built a real `Conv → Clip(0, 6) → Conv` net, ran ORT's actual `quantize_dynamic` + `ORT_ENABLE_EXTENDED` graph optimization: produces `ConvInteger → Cast → Mul → Clip → DynamicQuantizeLinear → ConvInteger`, identical in shape to the already-supported `Relu` case except for the op type.
- Before this change: `_find_conv_integer_chains` found 0 chains for this topology. After: 1 chain, prunes end-to-end.
- The existing plain-float `Conv` walker (`_walk_to_conv_consumer`) already has this exact hop via `_match_clip_channel_pass_through` (a domain/axis-agnostic helper proving `Clip`'s `min`/`max` are per-tensor scalars, not per-channel tensors needing slicing) — this PR reuses that same helper for the `ConvInteger` walker rather than reimplementing clip validation.

## What's added

- `onnxsim/pruning.py`: a `Clip` hop in `_walk_to_conv_integer_consumer`, calling the existing `_match_clip_channel_pass_through`, mirroring `_walk_to_conv_consumer`'s identical hop. No change needed in `_apply_structured_pruning_dynamic_quantize_conv` — it never touches pass-through node identity, only producer/consumer weights, so a `Clip` folded into `chain_ops` is handled for free.
- `tests/test_pruning.py`: two new regression tests (`onnx.parser`-based, per this repo's test-construction convention) — one confirming a `Conv → Clip(0,6) → ConvInteger` chain now matches and prunes end-to-end (verified numerically against an independent oracle via a real `InferenceSession`), one confirming a per-channel-shaped Clip `min`/`max` is still correctly rejected.

## Test plan

- [x] New tests fail on the pre-fix code (`0 == 1` chains matched) and pass after the fix
- [x] `pytest tests/test_pruning.py -k "conv_integer or dynamic_quantize_conv"` — 16 passed
- [x] `pytest tests/test_pruning.py -q` (full suite) — 857 passed (855 baseline + 2 new), same 52 pre-existing failures (stale compiled C++ extension, unrelated to this change, confirmed reproducing identically on the pre-change commit)
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — no new issues

## Risks for reviewer

- Scoped strictly to the `ConvInteger` family; the plain-float `Conv`/`MatMul` walkers are untouched.
- `_match_clip_channel_pass_through` is reused as-is (no changes to its own logic).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_