### PR TITLE
Add ICQuant weight-only quantization module

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -56,6 +56,7 @@ from onnxsim.gptq import apply_gptq
 from onnxsim.gptvq import quantize_weight_only_gptvq
 from onnxsim.hf_reconstruct import read_hf_config, reconstruct_hf_graph
 from onnxsim.hqq import quantize_weight_only_int4_hqq
+from onnxsim.icquant import icquant_metadata_bits, quantize_weight_only_icquant
 from onnxsim.if4_quantization import quantize_weight_only_if4
 from onnxsim.kmeans_quantization import quantize_weight_only_kmeans
 from onnxsim.kv_cache_quantization import quantize_kv_cache
@@ -287,6 +288,8 @@ __all__ = [
     "quantize_weight_only_billm",
     "quantize_weight_only_pb_llm",
     "quantize_weight_only_int4_hqq",
+    "quantize_weight_only_icquant",
+    "icquant_metadata_bits",
     "quantize_weight_only_kmeans",
     "quantize_weight_only_lo_bcq",
     "quantize_weight_only_nf4",

--- a/onnxsim/icquant.py
+++ b/onnxsim/icquant.py
@@ -1,0 +1,382 @@
+"""ICQuant (Li, Hanna, Fragouli, Diggavi, 2025, "ICQuant: Index Coding
+enables Low-bit LLM Quantization", https://arxiv.org/abs/2505.00850, COLM
+2025; code at https://github.com/Avery-xl/ICQuant). onnxsim ports the
+algorithm, not any framework's code, per the same rationale as
+:mod:`onnxsim.awq`/:mod:`onnxsim.gptq`/:mod:`onnxsim.spinquant` (ICQuant's
+own reference implementation quantizes live PyTorch weights, with no ONNX
+export path).
+
+Like :mod:`onnxsim.owq` and :mod:`onnxsim.spqr`, this module separates a
+small fraction of "salient" weight elements from the rest of each
+quantization group so the group's own scale is no longer inflated by them,
+then quantizes the remaining elements to a tighter grid. **ICQuant's own
+distinguishing contribution is not a new way to decide which elements are
+outliers** -- this module reuses the same ordinary per-group top-magnitude
+criterion :mod:`onnxsim.spqr` already uses (any of this repo's other
+magnitude/Hessian-based salience criteria would work just as well here).
+ICQuant's contribution is a **cheaper way to communicate which positions
+were chosen** once decided:
+
+* :mod:`onnxsim.owq` stores an explicit list of the chosen column indices
+  (``k * ceil(log2(K))`` bits for ``k`` chosen columns out of ``K``).
+* :mod:`onnxsim.spqr` stores an explicit ``[row, col]`` pair per outlier
+  (again a plain index list, ``num_outliers * (ceil(log2(N)) +
+  ceil(log2(K)))`` bits).
+
+Both are, information-theoretically, using far more bits than necessary: a
+naive **bitmask** of ``n`` bits (one per group element, marking outlier or
+not) already overspends -- it can represent ``2^n`` distinct
+outlier/non-outlier patterns when there are only ``C(n, k)`` patterns with
+exactly ``k`` outliers, and a plain index list overspends similarly by
+picking an ordering-sensitive encoding. ICQuant's own idea, borrowed from
+**index coding** in information theory, is to instead number the ``C(n,
+k)`` possible ``k``-of-``n`` outlier subsets ``0, 1, ..., C(n, k) - 1`` via
+the classical **combinatorial number system** ("combinadics" -- see
+:func:`_combinadic_rank`/:func:`_combinadic_unrank` below) and store a
+single integer rank in that range: ``ceil(log2(C(n, k)))`` bits, versus a
+naive scheme's ``n`` bits (bitmask) or ``k * ceil(log2(n))`` bits (index
+list). For the paper's own typical setting -- groups of ``n = 32`` with
+``k = 1`` or ``2`` outliers -- this is roughly 5 or 9 bits per group
+(``0.16`` or ``0.28`` bits/element) versus a naive bitmask's 32 bits/group
+(``1.0`` bit/element): see :func:`icquant_metadata_bits` and this module's
+own tests for the exact numbers, matching the paper's reported ~0.3
+bits/element overhead to shrink the quantization range the same way a
+naive ~1-bit/element scheme would.
+
+**What this module actually emits.** ONNX has no combinatorial-decoding
+op, and none of onnxsim's other quantizers decode anything at runtime
+either -- they all bake plain, already-resolved indices into the graph as
+ordinary initializers. So here too: at quantization time (in Python), each
+group's chosen outlier positions are combinadic-encoded into one rank
+integer *and immediately decoded back* via :func:`_combinadic_unrank`
+(exercising the actual encode/decode round trip this module's docstring
+claims, not just asserting it), and it is that decoded, explicit index
+list which is baked into the emitted graph's ``ScatterND`` indices --
+exactly the same graph shape :mod:`onnxsim.spqr` already uses to
+reconstruct its own sparse correction:
+
+    Before:
+      Y = MatMul(X, W) [+ bias]                  -- W constant, [K, N], float32
+
+    After:
+      Wq  = <int4, per-(group, row) symmetric, outlier positions excluded
+             from each group's own scale>
+      Ws  = <float32, [K/group_size, N]>
+      Wdq = DequantizeLinear(Wq, Ws, axis=0, block_size=group_size)  -- float32
+      Wreconstructed = ScatterND(Wdq, outlier_indices, outlier_values)
+      Y = MatMul(X, Wreconstructed) [+ bias]
+
+Unlike :mod:`onnxsim.spqr` (which ``Add``s an exact *residual* on top of
+the dequantized value, because SpQR's outliers can be anywhere in the
+matrix and its correction must cancel whatever the block-quantized value
+there happened to round to), ICQuant's outlier value is written directly
+in full precision at each chosen position, so a plain overwrite
+(``ScatterND``'s default, non-accumulating semantics) already reconstructs
+it exactly -- no residual arithmetic needed.
+
+Deliberately not ported: ICQuant's own incoherence-processing preprocessing
+step (a random orthogonal/Hadamard rotation applied before outlier
+selection, in the same family as :mod:`onnxsim.quip_sharp`'s own
+incoherence processing) -- out of scope here so this module can isolate
+and demonstrate ICQuant's own distinguishing contribution (the index-coding
+metadata scheme) cleanly on top of plain magnitude-based outlier selection,
+the same scope boundary :mod:`onnxsim.owq`/:mod:`onnxsim.spqr` draw around
+their own outlier-selection criteria.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import List, Sequence, Union
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+
+from onnxsim.adaround import _pack_int4
+from onnxsim.bias_correction import _all_names, _unique_name
+from onnxsim.quip_sharp import _match_matmul_like
+
+
+def _has_min_opset(model: onnx.ModelProto, min_version: int) -> bool:
+    return any(
+        o.domain in ("", "ai.onnx") and o.version >= min_version
+        for o in model.opset_import
+    )
+
+
+def _combinadic_rank(combo: Sequence[int], n: int) -> int:
+    """Ranks a ``k``-element subset of ``{0, ..., n - 1}`` to its unique
+    integer in ``[0, C(n, k))`` via the combinatorial number system: for
+    ``combo`` sorted descending ``c_k > c_{k-1} > ... > c_1``, the rank is
+    ``sum_i C(c_i, i)`` (1-indexed from the top element down to 1). This is
+    the standard "combinadic" bijection between ``k``-of-``n`` subsets and
+    ``[0, C(n, k))`` -- see :func:`_combinadic_unrank` for its inverse.
+
+    :param combo: the chosen element indices (any order, each in
+            ``[0, n)``, no duplicates)
+    :param n: size of the ground set the subset was chosen from
+    :returns: the subset's unique rank in ``[0, C(n, len(combo)))``
+    """
+    k = len(combo)
+    combo_desc = sorted(combo, reverse=True)
+    return sum(math.comb(c, k - i) for i, c in enumerate(combo_desc))
+
+
+def _combinadic_unrank(rank: int, k: int, n: int) -> List[int]:
+    """Inverse of :func:`_combinadic_rank`: recovers the ``k``-element
+    subset of ``{0, ..., n - 1}`` with the given combinadic ``rank``, via
+    the classical greedy digit-by-digit decomposition (find the largest
+    ``c`` with ``C(c, i) <= remaining_rank``, for ``i`` from ``k`` down to
+    ``1``).
+
+    :param rank: a combinadic rank in ``[0, C(n, k))``
+    :param k: subset size
+    :param n: size of the ground set
+    :returns: the subset, as a list of ``k`` indices sorted ascending
+    """
+    combo = []
+    remaining = rank
+    for i in range(k, 0, -1):
+        c = i - 1
+        while math.comb(c + 1, i) <= remaining:
+            c += 1
+        combo.append(c)
+        remaining -= math.comb(c, i)
+    return sorted(combo)
+
+
+def icquant_metadata_bits(group_size: int, num_outliers: int) -> dict:
+    """Compares the per-group metadata cost of ICQuant's combinadic
+    encoding against the two naive alternatives it replaces (see this
+    module's own docstring), for a group of ``group_size`` elements with
+    exactly ``num_outliers`` outliers.
+
+    :returns: a dict with ``combinadic_bits`` (``ceil(log2(C(group_size,
+            num_outliers)))``, or ``0`` when ``num_outliers`` is 0),
+            ``bitmask_bits`` (``group_size``), ``index_list_bits``
+            (``num_outliers * ceil(log2(group_size))``), and each scheme's
+            per-element overhead (the above divided by ``group_size``)
+            under ``*_bits_per_element`` keys
+    """
+    if num_outliers <= 0:
+        combinadic_bits = 0
+    else:
+        combinadic_bits = max(
+            1, math.ceil(math.log2(math.comb(group_size, num_outliers)))
+        )
+    bitmask_bits = group_size
+    index_list_bits = (
+        num_outliers * max(1, math.ceil(math.log2(group_size)))
+        if num_outliers > 0
+        else 0
+    )
+    return {
+        "combinadic_bits": combinadic_bits,
+        "bitmask_bits": bitmask_bits,
+        "index_list_bits": index_list_bits,
+        "combinadic_bits_per_element": combinadic_bits / group_size,
+        "bitmask_bits_per_element": bitmask_bits / group_size,
+        "index_list_bits_per_element": index_list_bits / group_size,
+    }
+
+
+def quantize_weight_only_icquant(
+    model: Union[str, onnx.ModelProto],
+    group_size: int = 32,
+    num_outliers: int = 1,
+) -> onnx.ModelProto:
+    """Applies ICQuant-style outlier-aware block-wise INT4 quantization
+    (see this module's own docstring) to every MatMul/vanilla-Gemm layer
+    with a constant 2-D float32 weight whose reduction dimension ``K`` is
+    divisible by ``group_size``.
+
+    :param model: the original (unquantized) onnx ModelProto or file path
+    :param group_size: elements per quantization group along ``K``,
+            matching :func:`onnxsim.quantize_weight_only_spqr`'s own
+            ``block_size`` granularity -- the paper's own typical choice is
+            32
+    :param num_outliers: number of largest-magnitude elements excluded
+            from each group's own scale computation and stored at full
+            precision instead, communicated via one combinadic rank per
+            group (see this module's own docstring); the paper's own
+            typical choice is 1 or 2. ``0`` degenerates to plain
+            group-wise INT4 quantization with no outlier handling.
+    :returns: ``model`` with every matched layer's weight replaced by
+            group-wise INT4 codes plus exact per-group outlier values
+            reconstructed via ``ScatterND`` (see the module docstring's
+            diagram); output tensor name unchanged. Layers with a
+            non-constant, non-2-D weight, a reduction dimension not
+            divisible by ``group_size``, or ``num_outliers >=
+            group_size``, are left untouched; a model with no matching
+            layer, or an opset older than 21 (INT4's tensor type and
+            ``DequantizeLinear``'s ``block_size`` attribute both need
+            opset 21), is returned unchanged
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    if not _has_min_opset(model, 21):
+        return model
+    if num_outliers < 0:
+        raise ValueError("num_outliers must be >= 0")
+
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    graph = out.graph
+    initializer_map = {t.name: t for t in graph.initializer}
+    taken_names = _all_names(graph)
+
+    nodes = list(graph.node)
+    candidates = []
+    for node in nodes:
+        match = _match_matmul_like(node)
+        if match is None:
+            continue
+        x_name, w_name, bias_name, weight_transposed = match
+        w_init = initializer_map.get(w_name)
+        if (
+            w_init is None
+            or w_init.data_type != onnx.TensorProto.FLOAT
+            or len(w_init.dims) != 2
+        ):
+            continue
+        candidates.append((node, x_name, w_name, bias_name, weight_transposed))
+
+    if not candidates:
+        return out
+
+    for node, x_name, w_name, bias_name, weight_transposed in candidates:
+        w_init = initializer_map[w_name]
+        w = onnx.numpy_helper.to_array(w_init).astype(np.float64)
+        w_nk = w if weight_transposed else w.T  # [N, K], output channel first
+        n_rows, k = w_nk.shape
+        if k % group_size != 0 or num_outliers >= group_size or n_rows == 0 or k == 0:
+            continue
+
+        num_blocks = k // group_size
+        blocks = w_nk.reshape(n_rows, num_blocks, group_size)
+        abs_blocks = np.abs(blocks)
+        mask = np.ones((n_rows, num_blocks, group_size), dtype=bool)
+
+        outlier_rows: List[int] = []
+        outlier_cols: List[int] = []
+        outlier_values: List[float] = []
+
+        if num_outliers > 0:
+            # Vectorized top-`num_outliers` selection per group, then a
+            # per-group combinadic encode/decode round trip -- see this
+            # module's own docstring for why the decode step (not just the
+            # rank) is what actually gets baked into the graph below.
+            top_unsorted = np.argpartition(-abs_blocks, num_outliers - 1, axis=2)[
+                :, :, :num_outliers
+            ]
+            for r in range(n_rows):
+                for b in range(num_blocks):
+                    combo = sorted(int(i) for i in top_unsorted[r, b])
+                    rank = _combinadic_rank(combo, group_size)
+                    decoded = _combinadic_unrank(rank, num_outliers, group_size)
+                    assert decoded == combo
+                    for pos in decoded:
+                        mask[r, b, pos] = False
+                        outlier_rows.append(r)
+                        outlier_cols.append(b * group_size + pos)
+                        outlier_values.append(float(blocks[r, b, pos]))
+
+        abs_masked = np.where(mask, abs_blocks, 0.0)
+        scale_blocks = np.maximum(abs_masked.max(axis=2), 1e-12) / 7.0
+        scale_full = np.repeat(scale_blocks, group_size, axis=1)  # [N, K]
+
+        codes_nk = np.clip(np.round(w_nk / scale_full), -7.0, 7.0)
+
+        prefix = f"{w_name}_icquant"
+        codes_kn = codes_nk.T.astype(np.int64)  # [K, N]
+        scale_kn = scale_blocks.T.astype(np.float32)  # [K/group_size, N]
+
+        codes_name = _unique_name(f"{prefix}_codes", taken_names)
+        codes_tensor = onnx.TensorProto()
+        codes_tensor.name = codes_name
+        codes_tensor.data_type = onnx.TensorProto.INT4
+        codes_tensor.dims.extend([k, n_rows])
+        codes_tensor.raw_data = _pack_int4(codes_kn)
+        graph.initializer.append(codes_tensor)
+
+        scale_name = _unique_name(f"{prefix}_scale", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(scale_kn, name=scale_name)
+        )
+
+        new_nodes: List[onnx.NodeProto] = []
+
+        def _new(op_type, inputs, out_suffix, **attrs):
+            out_name = _unique_name(f"{prefix}_{out_suffix}", taken_names)
+            n_ = onnx.helper.make_node(
+                op_type,
+                inputs,
+                [out_name],
+                name=_unique_name(f"{prefix}_{out_suffix}_node", taken_names),
+                **attrs,
+            )
+            new_nodes.append(n_)
+            return out_name
+
+        w_dequant = _new(
+            "DequantizeLinear",
+            [codes_name, scale_name],
+            "w_dequant",
+            axis=0,
+            block_size=group_size,
+        )
+
+        if outlier_values:
+            # [K, N]-layout indices, matching codes_kn/scale_kn's own
+            # transposed storage: index[i] = [k_pos, n_pos].
+            outlier_indices_kn = np.stack(
+                [np.asarray(outlier_cols), np.asarray(outlier_rows)], axis=1
+            )
+
+            indices_name = _unique_name(f"{prefix}_outlier_indices", taken_names)
+            graph.initializer.append(
+                onnx.numpy_helper.from_array(
+                    outlier_indices_kn.astype(np.int64), name=indices_name
+                )
+            )
+            values_name = _unique_name(f"{prefix}_outlier_values", taken_names)
+            graph.initializer.append(
+                onnx.numpy_helper.from_array(
+                    np.asarray(outlier_values, dtype=np.float32), name=values_name
+                )
+            )
+            w_reconstructed = _new(
+                "ScatterND",
+                [w_dequant, indices_name, values_name],
+                "w_reconstructed",
+            )
+        else:
+            w_reconstructed = w_dequant
+
+        core = _new("MatMul", [x_name, w_reconstructed], "core")
+
+        old_output = node.output[0]
+        if bias_name is not None:
+            final = onnx.helper.make_node(
+                "Add",
+                [core, bias_name],
+                [old_output],
+                name=_unique_name(f"{prefix}_bias_add_node", taken_names),
+            )
+        else:
+            final = onnx.helper.make_node(
+                "Identity",
+                [core],
+                [old_output],
+                name=_unique_name(f"{prefix}_identity_node", taken_names),
+            )
+        new_nodes.append(final)
+
+        node_idx = next(i for i, n_ in enumerate(graph.node) if n_ is node)
+        for offset, new_node in enumerate(new_nodes):
+            graph.node.insert(node_idx + offset, new_node)
+        del graph.node[node_idx + len(new_nodes)]
+
+    return out

--- a/tests/test_icquant.py
+++ b/tests/test_icquant.py
@@ -1,0 +1,261 @@
+"""Tests for ``onnxsim.quantize_weight_only_icquant`` -- see
+``onnxsim/icquant.py`` for the technique: per-group outlier-aware
+block-wise INT4 quantization, like ``onnxsim.spqr``, but communicating
+each group's chosen outlier positions via a combinadic ("index coding")
+rank instead of a dense bitmask or an explicit index list.
+"""
+
+import itertools
+import math
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+from onnxsim.icquant import _combinadic_rank, _combinadic_unrank
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _matmul_model(K=32, N=8, weight=None, seed=0, opset=21):
+    if weight is None:
+        rng = np.random.default_rng(seed)
+        weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [_f32(weight, "W")],
+        opset=opset,
+    )
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
+
+
+# --- Combinadic rank/unrank -------------------------------------------------
+
+
+@pytest.mark.parametrize("n", [4, 5, 6, 8])
+def test_combinadic_rank_unrank_is_a_bijection(n):
+    for k in range(1, n + 1):
+        combos = list(itertools.combinations(range(n), k))
+        ranks = [_combinadic_rank(c, n) for c in combos]
+        # Every C(n, k) combination gets a distinct rank covering
+        # [0, C(n, k)) exactly -- no rank is skipped or reused.
+        assert sorted(ranks) == list(range(math.comb(n, k)))
+        for combo, rank in zip(combos, ranks):
+            assert _combinadic_unrank(rank, k, n) == list(combo)
+
+
+def test_combinadic_k1_rank_is_the_index_itself():
+    # A 1-of-n subset's combinadic rank degenerates to the chosen index --
+    # a sanity check on the general bijection's base case.
+    for i in range(10):
+        assert _combinadic_rank([i], 10) == i
+        assert _combinadic_unrank(i, 1, 10) == [i]
+
+
+# --- Metadata bit cost -------------------------------------------------------
+
+
+def test_icquant_metadata_bits_matches_paper_claim():
+    # group_size=32, k=1: C(32, 1) = 32 -> 5 bits/group = 0.15625 bits/element.
+    stats = onnxsim.icquant_metadata_bits(group_size=32, num_outliers=1)
+    assert stats["combinadic_bits"] == 5
+    assert stats["combinadic_bits_per_element"] == pytest.approx(5 / 32)
+    assert stats["bitmask_bits_per_element"] == pytest.approx(1.0)
+
+    # group_size=32, k=2: C(32, 2) = 496 -> ceil(log2(496)) = 9 bits/group
+    # = 0.28125 bits/element, matching the paper's own reported ~0.3
+    # bits/element overhead (vs. a naive ~1 bit/element bitmask).
+    stats2 = onnxsim.icquant_metadata_bits(group_size=32, num_outliers=2)
+    assert math.comb(32, 2) == 496
+    assert stats2["combinadic_bits"] == 9
+    assert stats2["combinadic_bits_per_element"] == pytest.approx(9 / 32)
+    assert stats2["combinadic_bits_per_element"] < 0.3
+    # Both naive alternatives cost strictly more per element than the
+    # combinadic encoding -- ICQuant's own point.
+    assert stats2["combinadic_bits"] < stats2["bitmask_bits"]
+    assert stats2["combinadic_bits"] < stats2["index_list_bits"]
+
+
+def test_icquant_metadata_bits_zero_outliers_is_free():
+    stats = onnxsim.icquant_metadata_bits(group_size=32, num_outliers=0)
+    assert stats["combinadic_bits"] == 0
+    assert stats["index_list_bits"] == 0
+
+
+# --- End-to-end quantization -------------------------------------------------
+
+
+def test_icquant_output_stays_close_to_float_via_onnxruntime():
+    model = _matmul_model(K=32, N=8, seed=0)
+    q = onnxsim.quantize_weight_only_icquant(model, group_size=8, num_outliers=1)
+    onnx.checker.check_model(q)
+
+    op_types = [n.op_type for n in q.graph.node]
+    assert "DequantizeLinear" in op_types
+    assert "ScatterND" in op_types
+
+    rng = np.random.default_rng(2)
+    x = rng.standard_normal((8, 32)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x})
+    (q_y,) = _run(q, {"X": x})
+    assert np.all(np.isfinite(q_y))
+    assert _rel_l2(float_y, q_y) < 0.3
+
+
+def test_icquant_outlier_positions_reconstruct_exactly_via_numpy():
+    # Verify reconstruction directly against the emitted initializers with
+    # numpy (a tight *relative* tolerance), rather than round-tripping
+    # through onnxruntime -- onnxruntime's MatMul reduction order isn't
+    # bit-exact across CPU architectures, so it isn't the right tool to
+    # confirm codes reconstruct the original weight exactly.
+    rng = np.random.default_rng(3)
+    weight = rng.standard_normal((32, 8)).astype(np.float32) * 0.1
+    weight[0, 0] = 50.0  # row 0 (of W.T's [N, K] view: N=col 0, K=row 0)
+    model = _matmul_model(K=32, N=8, weight=weight)
+    q = onnxsim.quantize_weight_only_icquant(model, group_size=8, num_outliers=1)
+    onnx.checker.check_model(q)
+
+    init_map = {t.name: onnx.numpy_helper.to_array(t) for t in q.graph.initializer}
+    codes_name = next(n for n in init_map if n.endswith("_icquant_codes"))
+    scale_name = next(n for n in init_map if n.endswith("_icquant_scale"))
+    idx_name = next(n for n in init_map if n.endswith("_icquant_outlier_indices"))
+    val_name = next(n for n in init_map if n.endswith("_icquant_outlier_values"))
+
+    codes = init_map[codes_name].astype(np.float64)  # [K, N]
+    scale = init_map[scale_name].astype(np.float64)  # [K/group_size, N]
+    dequant = codes * np.repeat(scale, 8, axis=0)  # [K, N]
+
+    indices = init_map[idx_name]  # [num_outliers, 2] as [k_pos, n_pos]
+    values = init_map[val_name].astype(np.float64)
+    dequant[indices[:, 0], indices[:, 1]] = values
+
+    assert np.any((indices[:, 0] == 0) & (indices[:, 1] == 0))
+    reconstructed_outlier = dequant[0, 0]
+    assert reconstructed_outlier == pytest.approx(50.0, rel=1e-6)
+
+    # Every other element quantized to within its own group's scale/2.
+    non_outlier_mask = np.ones_like(dequant, dtype=bool)
+    non_outlier_mask[indices[:, 0], indices[:, 1]] = False
+    w_kn = weight.astype(np.float64)  # already [K, N]
+    err = np.abs(w_kn - dequant)[non_outlier_mask]
+    scale_full = np.repeat(scale, 8, axis=0)[non_outlier_mask]
+    assert np.all(err <= scale_full / 2 + 1e-9)
+
+
+def test_icquant_reduces_max_error_vs_zero_outliers():
+    rng = np.random.default_rng(6)
+    weight = rng.standard_normal((32, 8)).astype(np.float32) * 0.1
+    weight[0, 0] = 40.0
+    weight[5, 3] = -35.0
+
+    model = _matmul_model(K=32, N=8, weight=weight)
+    q_plain = onnxsim.quantize_weight_only_icquant(model, group_size=8, num_outliers=0)
+    q_ic = onnxsim.quantize_weight_only_icquant(model, group_size=8, num_outliers=1)
+
+    probe = np.eye(32, dtype=np.float32)
+    (plain_y,) = _run(q_plain, {"X": probe})
+    (ic_y,) = _run(q_ic, {"X": probe})
+
+    w64 = weight.astype(np.float64)
+    plain_err = np.abs(w64 - plain_y.astype(np.float64))
+    ic_err = np.abs(w64 - ic_y.astype(np.float64))
+    assert ic_err.max() < plain_err.max()
+
+
+def test_icquant_declines_when_k_not_divisible_by_group_size():
+    model = _matmul_model(K=20, N=4, seed=9)  # 20 is not a multiple of 8
+    q = onnxsim.quantize_weight_only_icquant(model, group_size=8)
+    assert q.SerializeToString() == model.SerializeToString()
+
+
+def test_icquant_declines_when_num_outliers_too_large():
+    model = _matmul_model(K=32, N=8, seed=9)
+    q = onnxsim.quantize_weight_only_icquant(
+        model, group_size=8, num_outliers=8
+    )  # num_outliers must be < group_size
+    assert q.SerializeToString() == model.SerializeToString()
+
+
+def test_icquant_declines_non_constant_weight():
+    model = _model(
+        """
+        g (float[4,32] X, float[32,4] W) => (float[4,4] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """
+    )
+    q = onnxsim.quantize_weight_only_icquant(model)
+    assert q.SerializeToString() == model.SerializeToString()
+
+
+def test_icquant_noop_when_no_matmul_present():
+    model = _model(
+        """
+        g (float[4,4] X) => (float[4,4] Y)
+        {
+          Y = Relu(X)
+        }
+        """
+    )
+    result = onnxsim.quantize_weight_only_icquant(model)
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_icquant_declines_below_opset21():
+    model = _matmul_model(K=32, N=8, opset=13)
+    result = onnxsim.quantize_weight_only_icquant(model)
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_icquant_zero_outliers_skips_scatternd():
+    model = _matmul_model(K=32, N=8, seed=10)
+    q = onnxsim.quantize_weight_only_icquant(model, group_size=8, num_outliers=0)
+    onnx.checker.check_model(q)
+    op_types = [n.op_type for n in q.graph.node]
+    assert "ScatterND" not in op_types
+    assert "DequantizeLinear" in op_types
+
+
+def test_icquant_rejects_negative_num_outliers():
+    model = _matmul_model(K=32, N=8, seed=0)
+    with pytest.raises(ValueError):
+        onnxsim.quantize_weight_only_icquant(model, num_outliers=-1)


### PR DESCRIPTION
## Summary

Adds `onnxsim.quantize_weight_only_icquant`, implementing ICQuant (Li, Hanna, Fragouli, Diggavi, 2025, COLM 2025, ["ICQuant: Index Coding enables Low-bit LLM Quantization"](https://arxiv.org/abs/2505.00850), code at https://github.com/Avery-xl/ICQuant).

Like `onnxsim.owq` and `onnxsim.spqr`, this technique separates a small number of "salient" weight elements per quantization group from the rest so the group's own scale isn't inflated by them, then quantizes the remaining elements to a tighter grid. ICQuant's own distinguishing contribution is **not** a new way to decide which elements are outliers (this module reuses the same magnitude-based criterion `onnxsim.spqr` already uses) — it's a cheaper way to **communicate which positions were chosen**: instead of a dense per-element bitmask (`onnxsim.owq`/`onnxsim.spqr`'s implicit ~1 bit/element) or an explicit index list, ICQuant numbers the `C(n, k)` possible `k`-of-`n` outlier subsets via the classical **combinatorial number system** ("combinadics") and stores one integer rank, needing only `ceil(log2(C(n, k)))` bits — for the paper's own typical setting (groups of 32, 1-2 outliers) this is ~0.16-0.28 bits/element vs. a naive scheme's ~1 bit/element, matching the paper's reported ~0.3 bits/element overhead.

## What's added / scope

- `onnxsim/icquant.py`:
  - `_combinadic_rank` / `_combinadic_unrank`: the combinatorial-number-system bijection between a `k`-of-`n` subset and its integer rank in `[0, C(n, k))`.
  - `icquant_metadata_bits(group_size, num_outliers)`: compares the combinadic encoding's bit cost against the two naive alternatives it replaces (bitmask, explicit index list), used to justify the technique's own metadata-savings claim honestly.
  - `quantize_weight_only_icquant(model, group_size=32, num_outliers=1)`: for every MatMul/vanilla-Gemm layer with a constant 2-D float32 weight whose reduction dimension `K` is divisible by `group_size`, quantizes non-outlier group elements to block-wise INT4 (mirroring `onnxsim.spqr`'s own scheme) and reconstructs the top-`num_outliers`-magnitude group elements at full precision via `ScatterND` — a plain overwrite rather than `onnxsim.spqr`'s residual `Add`, since ICQuant's stored value is already the exact float, not a correction term.
  - At quantization time, each group's outlier positions are combinadic-encoded to a rank and immediately decoded back via `_combinadic_unrank` before being baked into the graph's plain `ScatterND` index initializers — exercising the actual encode/decode round trip, consistent with this repo's other quantizers never decoding anything at ONNX-graph runtime.
  - Deliberately out of scope: ICQuant's own incoherence-processing (Hadamard/orthogonal rotation) preprocessing step, to keep this module focused on demonstrating its own distinguishing contribution (the index-coding metadata scheme).
- `onnxsim/__init__.py`: registers `quantize_weight_only_icquant` and `icquant_metadata_bits` (import + `__all__`).
- `tests/test_icquant.py`: built with `onnx.parser.parse_model()` per this repo's convention. Covers the combinadic rank/unrank bijection (exhaustive for small `n`), the metadata bit-cost numbers against the paper's own claim, end-to-end quantization (both a loose onnxruntime output-closeness check and a tight numpy-direct check against the emitted initializers for exact outlier reconstruction, per this repo's platform-numerics convention of not relying on onnxruntime for exact-reconstruction assertions), and the standard no-op/decline paths (non-divisible `K`, non-constant weight, no matching op, opset < 21, `num_outliers` too large, negative `num_outliers`).

## Test plan

- `pytest tests/test_icquant.py -v` — 17 passed
- `pytest tests/test_owq.py tests/test_spqr.py -v` — 15 passed (no regression in the two nearest sibling modules)
- `ruff check` / `ruff format --check` on all touched files — clean
- `mypy onnxsim/icquant.py` — no new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017kSJQtUoDKw28MUdaJiCmC

---
_Generated by [Claude Code](https://claude.ai/code/session_017kSJQtUoDKw28MUdaJiCmC)_