### PR TITLE
Recognize depthwise ConvInteger as mid-chain pass-through hop

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -33322,7 +33322,13 @@ def apply_structured_pruning_dynamic_quantize_matmul(
 # shape-preserving unary hops, ``_UNARY_PASS_THROUGH``, plus a
 # channel-agnostic ``Clip`` -- :func:`_match_clip_channel_pass_through`, the
 # same helper :func:`_walk_to_conv_consumer` already uses for the identical
-# ReLU6 shape on a plain-float Conv chain) is matched -- a plain float
+# ReLU6 shape on a plain-float Conv chain -- plus a depthwise ``ConvInteger``
+# mid-chain hop, reached through its own dedicated ``DynamicQuantizeLinear``
+# producer (see :func:`_match_conv_integer_depthwise_pass_through`/
+# :class:`_ConvIntegerPassThrough`): the canonical MobileNetV1/V2/V3
+# ``pointwise -> depthwise -> pointwise`` unit, mirroring exactly how this
+# module's plain-float Conv family already treats a depthwise ``Conv`` hop
+# (:func:`_match_depthwise_conv_pass_through`) -- is matched -- a plain float
 # ``Conv`` peer on either side is declined outright, not attempted.
 # This is a real, deliberate scope narrowing (see this module's own
 # docstring on drawing scope where it was actually verified, not where it
@@ -33350,9 +33356,13 @@ def apply_structured_pruning_dynamic_quantize_matmul(
 #     so an absent one is simply outside what was empirically confirmed
 #     safe, the same bar the ``DynamicQuantizeMatMul`` section's own top
 #     comment already applies to an absent `b_zero_point`.
-#   * A general grouped or depthwise ``ConvInteger`` (`group != 1`), or a
-#     weight of rank other than 4 (2-D spatial Conv only) -- mirrors the
-#     QOperator/QDQ sections' own identical restrictions for ``QLinearConv``.
+#   * A general grouped or depthwise ``ConvInteger`` (`group != 1`) reached
+#     as a chain's own producer or consumer ENDPOINT, or a weight of rank
+#     other than 4 (2-D spatial Conv only) -- mirrors the QOperator/QDQ
+#     sections' own identical restrictions for ``QLinearConv``. (A depthwise
+#     ``ConvInteger`` reached MID-CHAIN, between two ordinary `group == 1`
+#     endpoints, *is* matched -- see :func:`_match_conv_integer_depthwise_pass_through`
+#     above.)
 #   * A ``Cast`` rescaling to anything other than plain ``FLOAT`` -- never
 #     confirmed for a `FLOAT16`/`BFLOAT16` Conv output, so declined outright
 #     rather than guessed at.
@@ -33608,6 +33618,245 @@ def _match_conv_integer(
     )
 
 
+@dataclass(frozen=True)
+class _ConvIntegerPassThrough:
+    """A depthwise ``ConvInteger`` node (``group == in_channels ==
+    out_channels == n_channels``, weight shape ``[n_channels, 1, kH, kW]``)
+    sitting MID-CHAIN between two ordinary (``group == 1``) ``ConvInteger``-
+    based Conv layers -- the canonical MobileNetV1/V2/V3 depthwise-separable-
+    conv unit (``pointwise -> depthwise -> pointwise``) after real dynamic
+    quantization. This is the quantized analogue of :class:`_ConvPassThrough`'s
+    own depthwise plain-``Conv`` hop (see :func:`_match_depthwise_conv_pass_through`):
+    a depthwise Conv mixes no channels at all -- output channel ``i``
+    depends only on input channel ``i`` -- so it needs no independent
+    importance ranking of its own, and is carried on the matched
+    :class:`_ConvIntegerChain` purely so
+    :func:`apply_structured_pruning_dynamic_quantize_conv` can slice its own
+    int8 ``[n_channels, 1, kH, kW]`` weight (axis 0) and, if present, plain
+    float ``[n_channels]`` bias by the *same* `keep` index set the chain's
+    real producer/consumer already use, then shrink its own ``group``
+    attribute to the new channel count via :func:`_set_conv_group_attr` --
+    mirrors :func:`_apply_conv_pass_through_hop`'s identical depthwise-Conv
+    treatment exactly, just against an int8 weight instead of a float one.
+
+    `w_scale`/`w_zero_point` are always per-tensor scalar here (the identical
+    empirically-confirmed fact this section's own top comment already
+    documents for a terminal ``ConvInteger`` -- ORT's ``ConvInteger``
+    quantizer never emits a per-channel scale/zero-point for a depthwise
+    node either), so neither is ever sliced -- only `w_init`/`bias_init` are
+    kept here at all. `node` is the depthwise ``ConvInteger`` itself;
+    `cast_node`/`rescale_mul_node`/`bias_add_node` are kept only so
+    :func:`apply_structured_pruning_dynamic_quantize_conv` can mark their own
+    (now-stale-shaped) outputs for `value_info` cleanup, exactly like the
+    chain's real producer already does for its own identical trio -- their
+    own tensors are never written to (this hop's `group`/weight/bias update
+    is the only rewrite it needs; the always-per-tensor `scale` and the
+    `Reshape`'s shape initializer need no adjustment at all, mirroring
+    :func:`_slice_conv_integer_producer`'s own identical bias treatment).
+    See :func:`_match_conv_integer_depthwise_pass_through`.
+    """
+
+    node: onnx.NodeProto
+    cast_node: onnx.NodeProto
+    rescale_mul_node: onnx.NodeProto
+    bias_add_node: Optional[onnx.NodeProto]
+    w_init: onnx.TensorProto
+    bias_init: Optional[onnx.TensorProto]
+
+
+def _match_conv_integer_depthwise_pass_through(
+    node: onnx.NodeProto,
+    initializer_map: Dict[str, onnx.TensorProto],
+    consumers_of: Dict[str, List[onnx.NodeProto]],
+    producers_of: Dict[str, onnx.NodeProto],
+    n_channels: int,
+    expected_dq_node: onnx.NodeProto,
+) -> Optional[Tuple[_ConvIntegerPassThrough, str]]:
+    """If `node` is a depthwise ``ConvInteger`` (``group == in_channels ==
+    out_channels == n_channels``, weight shape ``[n_channels, 1, kH, kW]``,
+    scalar `w_scale`/`w_zero_point` -- the same per-tensor bar
+    :func:`_match_conv_integer` already holds a terminal ``ConvInteger`` to)
+    reached via `expected_dq_node` (its own dedicated
+    ``DynamicQuantizeLinear`` producer, already resolved by the caller,
+    :func:`_walk_to_conv_integer_consumer`, as the sole consumer of the
+    walk's current tensor), followed by the same ``Cast`` -> rescale ``Mul``
+    -> optional bias ``Reshape``/``Add`` neighborhood a terminal
+    ``ConvInteger`` has (see this section's own top comment) -- returns the
+    matched :class:`_ConvIntegerPassThrough` together with the tensor name
+    this depthwise unit's own logical output is (the bias ``Add``'s output
+    when a bias was matched, the rescale ``Mul``'s output otherwise), for
+    the caller to continue walking forward from. Mirrors
+    :func:`_match_depthwise_conv_pass_through`'s identical shape check for
+    the plain-float case. ``None`` whenever anything is ambiguous,
+    non-constant, shared, or otherwise out of the empirically-verified
+    scope, never guessed at.
+    """
+    if node.op_type != "ConvInteger" or node.domain != "":
+        return None
+    if len(node.input) != 4 or len(node.output) != 1:
+        return None
+    x_name, w_name, x_zp_name, w_zp_name = node.input
+    if not (x_name and w_name and x_zp_name and w_zp_name):
+        return None
+
+    group = _matmul_nbits_int_attr(node, "group", 1)
+    if group != n_channels:
+        return None  # not this chain's own depthwise hop (an ordinary
+        # group == 1 node is handled by _match_conv_integer instead; any
+        # other group is a general grouped ConvInteger, out of scope, see
+        # this section's own top comment)
+
+    w_init = initializer_map.get(w_name)
+    if w_init is None or w_init.data_type not in (
+        onnx.TensorProto.INT8,
+        onnx.TensorProto.UINT8,
+    ):
+        return None  # non-constant, or wrong-dtype, w
+    dims = list(w_init.dims)
+    if len(dims) != 4 or dims[0] != n_channels or dims[1] != 1:
+        return None  # not the depthwise [n_channels, 1, kH, kW] shape
+    if len(consumers_of.get(w_name, [])) != 1:
+        return None  # shared/tied weight -- another node reads it too
+
+    w_zp_init = initializer_map.get(w_zp_name)
+    if w_zp_init is None or w_zp_init.data_type != w_init.data_type:
+        return None  # non-constant, or dtype-mismatched, w_zero_point
+    if list(w_zp_init.dims) not in ([], [1]):
+        return None  # non-scalar w_zero_point -- never confirmed
+        # empirically (see this section's own top comment), declined
+
+    dq_node = producers_of.get(x_name)
+    if (
+        dq_node is None
+        or dq_node is not expected_dq_node
+        or dq_node.op_type != "DynamicQuantizeLinear"
+        or dq_node.domain != ""
+        or len(dq_node.input) != 1
+        or len(dq_node.output) != 3
+        or dq_node.output[0] != x_name
+        or dq_node.output[2] != x_zp_name
+    ):
+        return None  # x/x_zero_point don't resolve to the expected shared
+        # DynamicQuantizeLinear producer
+
+    x_scale_name = dq_node.output[1]
+    scale_consumers = consumers_of.get(x_scale_name, [])
+    if len(scale_consumers) != 1:
+        return None
+    scales_mul_node = scale_consumers[0]
+    if scales_mul_node.op_type != "Mul" or len(scales_mul_node.input) != 2:
+        return None
+    sm_in0, sm_in1 = scales_mul_node.input
+    if sm_in0 == x_scale_name:
+        w_scale_name = sm_in1
+    elif sm_in1 == x_scale_name:
+        w_scale_name = sm_in0
+    else:
+        return None  # scale-combining Mul doesn't actually read x_scale
+
+    w_scale_init = initializer_map.get(w_scale_name)
+    if (
+        w_scale_init is None
+        or w_scale_init.data_type != onnx.TensorProto.FLOAT
+        or list(w_scale_init.dims) not in ([], [1])
+    ):
+        return None  # non-constant, wrong-dtype, or non-scalar w_scale
+    if len(scales_mul_node.output) != 1:
+        return None
+    combined_scale_name = scales_mul_node.output[0]
+
+    ci_out = node.output[0]
+    ci_consumers = consumers_of.get(ci_out, [])
+    if len(ci_consumers) != 1:
+        return None
+    cast_node = ci_consumers[0]
+    if (
+        cast_node.op_type != "Cast"
+        or list(cast_node.input) != [ci_out]
+        or len(cast_node.output) != 1
+    ):
+        return None
+    to_attr = next((a.i for a in cast_node.attribute if a.name == "to"), None)
+    if to_attr != onnx.TensorProto.FLOAT:
+        return None  # never confirmed for a FLOAT16/BFLOAT16 rescale target
+
+    cast_out = cast_node.output[0]
+    cast_consumers = consumers_of.get(cast_out, [])
+    if len(cast_consumers) != 1:
+        return None
+    rescale_mul_node = cast_consumers[0]
+    if (
+        rescale_mul_node.op_type != "Mul"
+        or len(rescale_mul_node.input) != 2
+        or len(rescale_mul_node.output) != 1
+    ):
+        return None
+    if {rescale_mul_node.input[0], rescale_mul_node.input[1]} != {
+        cast_out,
+        combined_scale_name,
+    }:
+        return None  # rescale Mul doesn't actually combine the cast Conv
+        # output with the scale-combining Mul's own output
+
+    rescale_out = rescale_mul_node.output[0]
+    bias_add_node: Optional[onnx.NodeProto] = None
+    bias_init: Optional[onnx.TensorProto] = None
+    final_out = rescale_out
+    rescale_consumers = consumers_of.get(rescale_out, [])
+    if len(rescale_consumers) == 1:
+        candidate_add = rescale_consumers[0]
+        if (
+            candidate_add.op_type == "Add"
+            and len(candidate_add.input) == 2
+            and len(candidate_add.output) == 1
+        ):
+            add_in0, add_in1 = candidate_add.input
+            other = None
+            if add_in0 == rescale_out:
+                other = add_in1
+            elif add_in1 == rescale_out:
+                other = add_in0
+            if other is not None:
+                reshape_candidate = producers_of.get(other)
+                if (
+                    reshape_candidate is not None
+                    and reshape_candidate.op_type == "Reshape"
+                    and len(reshape_candidate.input) == 2
+                    and len(reshape_candidate.output) == 1
+                    and reshape_candidate.output[0] == other
+                    and len(consumers_of.get(other, [])) == 1
+                ):
+                    bias_name, shape_name = reshape_candidate.input
+                    cand_bias = initializer_map.get(bias_name)
+                    shape_init = initializer_map.get(shape_name)
+                    if (
+                        cand_bias is not None
+                        and shape_init is not None
+                        and _is_supported_float_dtype(cand_bias.data_type)
+                        and list(cand_bias.dims) == [n_channels]
+                        and len(consumers_of.get(bias_name, [])) == 1
+                    ):
+                        bias_add_node = candidate_add
+                        bias_init = cand_bias
+                        final_out = candidate_add.output[0]
+                    # else: doesn't match the confirmed bias shape -- treated
+                    # as bias-absent below, not an error (mirrors
+                    # _match_conv_integer's own identical "best-effort, else
+                    # no bias" bar)
+
+    return (
+        _ConvIntegerPassThrough(
+            node=node,
+            cast_node=cast_node,
+            rescale_mul_node=rescale_mul_node,
+            bias_add_node=bias_add_node,
+            w_init=w_init,
+            bias_init=bias_init,
+        ),
+        final_out,
+    )
+
+
 def _conv_integer_dequantized_nk(w: _ConvIntegerConv) -> np.ndarray:
     """The full float64 ``(N, C*kH*kW)`` dequantized weight matrix `w`
     refers to, for IMPORTANCE RANKING ONLY -- never written back to the
@@ -33653,6 +33902,11 @@ class _ConvIntegerChain:
     chain_ops: Tuple[onnx.NodeProto, ...]
     consumer: _ConvIntegerConv
     n_channels: int
+    # Depthwise ConvInteger hops the chain walk crossed transparently between
+    # the real producer and the real consumer (see
+    # :class:`_ConvIntegerPassThrough`); empty for the common case of no
+    # depthwise mid-chain hop.
+    conv_pass_through: Tuple[_ConvIntegerPassThrough, ...] = ()
 
 
 def _walk_to_conv_integer_consumer(
@@ -33663,7 +33917,13 @@ def _walk_to_conv_integer_consumer(
     graph_outputs: Set[str],
     n_channels: int,
     max_hops: int,
-) -> Optional[Tuple[_ConvIntegerConv, Tuple[onnx.NodeProto, ...]]]:
+) -> Optional[
+    Tuple[
+        _ConvIntegerConv,
+        Tuple[onnx.NodeProto, ...],
+        Tuple[_ConvIntegerPassThrough, ...],
+    ]
+]:
     """From tensor `start` (a matched ``ConvInteger`` Conv layer's own
     logical output, :func:`_conv_integer_final_output`), walks forward
     through shape-preserving unary activations (`_UNARY_PASS_THROUGH`) --
@@ -33671,9 +33931,13 @@ def _walk_to_conv_integer_consumer(
     the same helper :func:`_walk_to_conv_consumer` already uses for the
     identical ReLU6 shape on a plain-float Conv chain -- MobileNet/
     EfficientNet-Lite's `Conv -> Clip(0, 6) -> ConvInteger` dynamically-
-    quantized topology needs the exact same transparent hop) -- with
-    no other consumer anywhere along the way, until a same-family
-    ``ConvInteger``-based consumer (reached through its own
+    quantized topology needs the exact same transparent hop) -- plus a
+    depthwise ``ConvInteger`` mid-chain hop, reached through its own
+    dedicated ``DynamicQuantizeLinear`` producer (see
+    :func:`_match_conv_integer_depthwise_pass_through` -- the canonical
+    MobileNetV1/V2/V3 `pointwise -> depthwise -> pointwise` unit) -- with
+    no other consumer anywhere along the way, until a same-family, ordinary
+    (`group == 1`) ``ConvInteger``-based consumer (reached through its own
     ``DynamicQuantizeLinear`` producer) is found whose own `K` matches
     `n_channels` -- mirrors :func:`_walk_to_qop_consumer`'s own
     ``QLinearConv``-only walk, DELIBERATELY narrower than
@@ -33684,6 +33948,7 @@ def _walk_to_conv_integer_consumer(
     such a consumer.
     """
     chain_ops: List[onnx.NodeProto] = []
+    conv_pass_through: List[_ConvIntegerPassThrough] = []
     cur = start
     for _hop in range(max_hops):
         candidates = consumers_of.get(cur, [])
@@ -33699,11 +33964,30 @@ def _walk_to_conv_integer_consumer(
             y_name = nxt.output[0]
             y_consumers = consumers_of.get(y_name, [])
             if len(y_consumers) == 1 and y_consumers[0].op_type == "ConvInteger":
+                ci_node = y_consumers[0]
                 m = _match_conv_integer(
-                    y_consumers[0], initializer_map, consumers_of, producers_of
+                    ci_node, initializer_map, consumers_of, producers_of
                 )
                 if m is not None and m.dq_node is nxt and m.K == n_channels:
-                    return m, tuple(chain_ops)
+                    return m, tuple(chain_ops), tuple(conv_pass_through)
+                depthwise = _match_conv_integer_depthwise_pass_through(
+                    ci_node,
+                    initializer_map,
+                    consumers_of,
+                    producers_of,
+                    n_channels,
+                    nxt,
+                )
+                if depthwise is not None:
+                    hop, final_out = depthwise
+                    if (
+                        len(consumers_of.get(final_out, [])) != 1
+                        or final_out in graph_outputs
+                    ):
+                        return None
+                    conv_pass_through.append(hop)
+                    cur = final_out
+                    continue
             return None
 
         if (
@@ -33772,8 +34056,12 @@ def _find_conv_integer_chains(graph: onnx.GraphProto) -> List[_ConvIntegerChain]
         )
         if found is None:
             continue
-        consumer, chain_ops = found
-        chains.append(_ConvIntegerChain(m, chain_ops, consumer, m.N))
+        consumer, chain_ops, conv_pass_through = found
+        chains.append(
+            _ConvIntegerChain(
+                m, chain_ops, consumer, m.N, conv_pass_through=conv_pass_through
+            )
+        )
     return chains
 
 
@@ -33807,6 +34095,20 @@ def apply_structured_pruning_dynamic_quantize_conv(
     input channels of the consumer's own weight. The producer's own PLAIN
     FLOAT bias (never quantized) is sliced directly, with no rescale step
     at all.
+
+    A depthwise ``ConvInteger`` (``group == in_channels == out_channels``)
+    sitting MID-CHAIN between the producer and the consumer -- the canonical
+    MobileNetV1/V2/V3 ``pointwise -> depthwise -> pointwise`` unit -- is
+    recognized transparently (see :class:`_ConvIntegerPassThrough`/
+    :func:`_match_conv_integer_depthwise_pass_through`) and has its own int8
+    weight (axis 0) and plain-float bias (if present) sliced by the *same*
+    `keep` index set, with its own ``group`` attribute shrunk to match --
+    mirroring exactly how this module's plain-float Conv family already
+    handles a depthwise ``Conv`` hop (see :func:`_apply_conv_pass_through_hop`).
+    A depthwise ``ConvInteger`` reached as the chain's own producer or
+    consumer ENDPOINT (rather than a mid-chain hop) is still declined, as
+    before -- only a general ``group == 1`` ``ConvInteger`` is ever matched
+    in that role.
 
     Unlike :func:`apply_structured_pruning_dynamic_quantize_matmul`, a
     plain-float ``Conv`` peer on either side of a chain is never matched --
@@ -33869,6 +34171,24 @@ def apply_structured_pruning_dynamic_quantize_conv(
 
             _slice_conv_integer_producer(p, keep)
             _slice_conv_integer_consumer(c, keep)
+
+            for hop in chain.conv_pass_through:
+                # Mirrors _apply_conv_pass_through_hop's identical
+                # depthwise-Conv treatment: axis-0 weight slice, bias slice
+                # (if present), group shrunk to the new channel count.
+                # w_scale/w_zero_point are always per-tensor scalar (see
+                # _ConvIntegerPassThrough's own docstring), so never touched.
+                _slice_producer_weight(
+                    hop.w_init, weight_transposed=False, keep=keep, is_conv=True
+                )
+                if hop.bias_init is not None:
+                    _slice_last_axis(hop.bias_init, keep)
+                _set_conv_group_attr(hop.node, keep_count)
+                stale_value_info.add(hop.node.output[0])
+                stale_value_info.add(hop.cast_node.output[0])
+                stale_value_info.add(hop.rescale_mul_node.output[0])
+                if hop.bias_add_node is not None:
+                    stale_value_info.add(hop.bias_add_node.output[0])
 
             producer_touched.add(p_key)
             consumer_touched.add(c_key)

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -45119,6 +45119,312 @@ def test_dynamic_quantize_conv_clip_relu6_pass_through_matches_and_prunes():
     np.testing.assert_array_equal(y_pruned, y_ref)
 
 
+def _dqconv_depthwise_chain_model_from_weights(
+    c,
+    m1,
+    m2,
+    w1f,
+    wdf,
+    w2f,
+    b1f=None,
+    bdf=None,
+    spatial=8,
+    activation="Relu",
+):
+    """The `_dqconv_model_from_weights` analogue for a full ``pointwise
+    ConvInteger -> depthwise ConvInteger -> pointwise ConvInteger`` chain --
+    the canonical MobileNetV1/V2/V3 depthwise-separable-conv unit -- after
+    real dynamic quantization. `w1f`/`w2f` are ordinary (`group == 1`)
+    pointwise (``1x1``) Conv weights; `wdf` is the depthwise stage's own
+    ``[m1, 1, khd, kwd]`` weight (`group == m1`). Every weight is quantized
+    via the REAL ``onnxruntime.quantization.quantize_dynamic`` tool
+    (`_quantize_dynamic_conv_weight`, reused as-is for `wdf` too -- the
+    quantizer only ever sees a plain tensor to quantize, never the source
+    ``Conv``'s own `group` semantics, so the genuine int8 codes/scale/
+    zero-point it emits for that shape are identical regardless of which
+    Conv the wrapper model around it declares). Returns ``(model, info)``
+    mirroring `_dqconv_model_from_weights`'s own convention, `info`
+    additionally carrying the depthwise stage's own float/quantized arrays
+    (`Wdf`/`Wdq`/`Wds`/`Wdzp`/`Bdf`).
+    """
+    w1q, w1s, w1zp = _quantize_dynamic_conv_weight(w1f, spatial=spatial)
+    wdq, wds, wdzp = _quantize_dynamic_conv_weight(wdf, spatial=spatial)
+    w2q, w2s, w2zp = _quantize_dynamic_conv_weight(w2f, spatial=spatial)
+
+    khd, kwd = wdf.shape[2], wdf.shape[3]
+    phd, pwd = (khd - 1) // 2, (kwd - 1) // 2
+
+    if b1f is not None:
+        bias1_ops = """
+          b1r = Reshape(b1, b1_shape)
+          c1 = Add(c1s, b1r)
+        """
+        c1_out = "c1"
+    else:
+        bias1_ops = ""
+        c1_out = "c1s"
+
+    if bdf is not None:
+        biasd_ops = """
+          bdr = Reshape(bd, bd_shape)
+          cd = Add(cds, bdr)
+        """
+        cd_out = "cd"
+    else:
+        biasd_ops = ""
+        cd_out = "cds"
+
+    body = f"""
+    g (float[1,{c},{spatial},{spatial}] x) => (float[1,{m2},{spatial},{spatial}] y)
+    {{
+      xq, x_scale, x_zero_point = DynamicQuantizeLinear(x)
+      combined_scale1 = Mul(x_scale, w1_scale)
+      c1i = ConvInteger<kernel_shape=[1,1]>(xq, w1_quantized, x_zero_point, w1_zero_point)
+      c1f = Cast<to=1>(c1i)
+      c1s = Mul(c1f, combined_scale1)
+      {bias1_ops}
+      h1 = {activation}({c1_out})
+      rq, r_scale, r_zero_point = DynamicQuantizeLinear(h1)
+      combined_scaled = Mul(r_scale, wd_scale)
+      cdi = ConvInteger<kernel_shape=[{khd},{kwd}], pads=[{phd},{pwd},{phd},{pwd}], group={m1}>(rq, wd_quantized, r_zero_point, wd_zero_point)
+      cdf = Cast<to=1>(cdi)
+      cds = Mul(cdf, combined_scaled)
+      {biasd_ops}
+      hd = {activation}({cd_out})
+      rq2, r_scale2, r_zero_point2 = DynamicQuantizeLinear(hd)
+      combined_scale2 = Mul(r_scale2, w2_scale)
+      c2i = ConvInteger<kernel_shape=[1,1]>(rq2, w2_quantized, r_zero_point2, w2_zero_point)
+      c2f = Cast<to=1>(c2i)
+      y = Mul(c2f, combined_scale2)
+    }}
+    """
+    inits = [
+        onnx.numpy_helper.from_array(w1q, "w1_quantized"),
+        onnx.numpy_helper.from_array(w1s, "w1_scale"),
+        onnx.numpy_helper.from_array(w1zp, "w1_zero_point"),
+        onnx.numpy_helper.from_array(wdq, "wd_quantized"),
+        onnx.numpy_helper.from_array(wds, "wd_scale"),
+        onnx.numpy_helper.from_array(wdzp, "wd_zero_point"),
+        onnx.numpy_helper.from_array(w2q, "w2_quantized"),
+        onnx.numpy_helper.from_array(w2s, "w2_scale"),
+        onnx.numpy_helper.from_array(w2zp, "w2_zero_point"),
+    ]
+    if b1f is not None:
+        inits.append(_f32(b1f, "b1"))
+        inits.append(
+            onnx.numpy_helper.from_array(
+                np.array([1, -1, 1, 1], dtype=np.int64), "b1_shape"
+            )
+        )
+    if bdf is not None:
+        inits.append(_f32(bdf, "bd"))
+        inits.append(
+            onnx.numpy_helper.from_array(
+                np.array([1, -1, 1, 1], dtype=np.int64), "bd_shape"
+            )
+        )
+    model = _model(body, initializer=inits, opset=21)
+    return model, {
+        "W1f": w1f,
+        "Wdf": wdf,
+        "W2f": w2f,
+        "B1f": b1f,
+        "Bdf": bdf,
+        "W1q": w1q,
+        "W1s": w1s,
+        "W1zp": w1zp,
+        "Wdq": wdq,
+        "Wds": wds,
+        "Wdzp": wdzp,
+        "W2q": w2q,
+        "W2s": w2s,
+        "W2zp": w2zp,
+        "spatial": spatial,
+    }
+
+
+def _dqconv_depthwise_chain_model(
+    c, m1, m2, khd=3, kwd=3, bias1=False, biasd=False, spatial=8, seed=0
+):
+    rng = np.random.default_rng(seed)
+    w1f = (rng.standard_normal((m1, c, 1, 1)) * 0.3).astype(np.float32)
+    wdf = (rng.standard_normal((m1, 1, khd, kwd)) * 0.3).astype(np.float32)
+    w2f = (rng.standard_normal((m2, m1, 1, 1)) * 0.3).astype(np.float32)
+    b1f = (rng.standard_normal(m1) * 0.05).astype(np.float32) if bias1 else None
+    bdf = (rng.standard_normal(m1) * 0.05).astype(np.float32) if biasd else None
+    return _dqconv_depthwise_chain_model_from_weights(
+        c, m1, m2, w1f, wdf, w2f, b1f=b1f, bdf=bdf, spatial=spatial
+    )
+
+
+def test_dynamic_quantize_conv_depthwise_mid_chain_is_matched_and_prunes():
+    # The canonical MobileNetV1/V2/V3 `pointwise -> depthwise -> pointwise`
+    # unit, after real dynamic quantization: `_walk_to_conv_integer_consumer`
+    # must recognize the depthwise ConvInteger as a transparent mid-chain
+    # hop (via `_match_conv_integer_depthwise_pass_through`) rather than
+    # ending the walk there, and the whole three-layer chain must be pruned
+    # end to end -- the regression this task targets.
+    c, m1, m2 = 4, 6, 5
+    model, info = _dqconv_depthwise_chain_model(
+        c, m1, m2, bias1=True, biasd=True, seed=30
+    )
+    onnx.checker.check_model(model)
+
+    chains = onnxsim.pruning._find_conv_integer_chains(model.graph)
+    assert len(chains) == 1
+    assert chains[0].n_channels == m1
+    assert len(chains[0].conv_pass_through) == 1
+    hop = chains[0].conv_pass_through[0]
+    assert hop.node.op_type == "ConvInteger"
+    assert hop.node.input[1] == "wd_quantized"
+    assert onnxsim.pruning._matmul_nbits_int_attr(hop.node, "group", 1) == m1
+
+    pruned = onnxsim.apply_structured_pruning_dynamic_quantize_conv(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    keep_count = m1 // 2
+
+    # The producer, the depthwise mid-chain hop, and the consumer all track
+    # the SAME keep-index set -- a depthwise conv's own channel count is
+    # fixed by definition, so it must shrink in lockstep with its neighbors.
+    assert list(inits["w1_quantized"].dims) == [keep_count, c, 1, 1]
+    assert list(inits["wd_quantized"].dims) == [keep_count, 1, 3, 3]
+    assert list(inits["w2_quantized"].dims) == [m2, keep_count, 1, 1]
+    assert list(inits["wd_scale"].dims) == []  # always per-tensor, untouched
+    assert list(inits["wd_zero_point"].dims) == []
+    assert list(inits["bd"].dims) == [keep_count]
+    assert list(inits["b1"].dims) == [keep_count]
+
+    depthwise_node = next(
+        n
+        for n in pruned.graph.node
+        if n.op_type == "ConvInteger" and n.input[1] == "wd_quantized"
+    )
+    assert (
+        onnxsim.pruning._matmul_nbits_int_attr(depthwise_node, "group", 1) == keep_count
+    )
+
+    rng = np.random.default_rng(31)
+    spatial = info["spatial"]
+    x = rng.standard_normal((1, c, spatial, spatial)).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"x": x})
+    assert y_pruned.shape == (1, m2, spatial, spatial)
+    assert np.all(np.isfinite(y_pruned))
+
+
+def test_dynamic_quantize_conv_depthwise_mid_chain_matches_independent_oracle_via_real_inference_session():
+    # This project's established quantized-section correctness bar (see
+    # `test_dynamic_quantize_conv_producer_matches_independent_oracle_via_
+    # real_inference_session`'s own identical structure): a pruned model's
+    # output must match a reference built from an INDEPENDENTLY
+    # reconstructed "already pruned" model, both run through a real
+    # onnxruntime InferenceSession.
+    c, m1, m2 = 4, 6, 5
+    model, info = _dqconv_depthwise_chain_model(
+        c, m1, m2, bias1=True, biasd=True, seed=32
+    )
+    onnx.checker.check_model(model)
+    keep = _dqconv_importance_keep(info["W1q"], info["W1s"], info["W1zp"], m1 // 2)
+
+    pruned = onnxsim.apply_structured_pruning_dynamic_quantize_conv(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+
+    # "slice, don't recompute": the pruned graph's own quantized codes/bias
+    # (producer, depthwise hop, and consumer alike) are EXACTLY a hand-slice
+    # of the original ones; the always-per-tensor scale/zero-point are
+    # copied UNCHANGED (never resampled).
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["w1_quantized"]), info["W1q"][keep]
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["wd_quantized"]), info["Wdq"][keep]
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["w2_quantized"]), info["W2q"][:, keep]
+    )
+    assert onnx.numpy_helper.to_array(inits["wd_scale"]) == pytest.approx(
+        float(info["Wds"])
+    )
+    assert onnx.numpy_helper.to_array(inits["wd_zero_point"]) == float(info["Wdzp"])
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["bd"]), info["Bdf"][keep]
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["b1"]), info["B1f"][keep]
+    )
+
+    ref_model, _ = _dqconv_depthwise_chain_model_from_weights(
+        c,
+        len(keep),
+        m2,
+        info["W1f"][keep],
+        info["Wdf"][keep],
+        info["W2f"][:, keep],
+        b1f=info["B1f"][keep],
+        bdf=info["Bdf"][keep],
+        spatial=info["spatial"],
+    )
+    ref_inits = {t.name: t for t in ref_model.graph.initializer}
+    ref_inits["w1_quantized"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W1q"][keep], "w1_quantized")
+    )
+    ref_inits["w1_scale"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W1s"], "w1_scale")
+    )
+    ref_inits["w1_zero_point"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W1zp"], "w1_zero_point")
+    )
+    ref_inits["wd_quantized"].CopyFrom(
+        onnx.numpy_helper.from_array(info["Wdq"][keep], "wd_quantized")
+    )
+    ref_inits["wd_scale"].CopyFrom(
+        onnx.numpy_helper.from_array(info["Wds"], "wd_scale")
+    )
+    ref_inits["wd_zero_point"].CopyFrom(
+        onnx.numpy_helper.from_array(info["Wdzp"], "wd_zero_point")
+    )
+    ref_inits["w2_quantized"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W2q"][:, keep], "w2_quantized")
+    )
+    ref_inits["w2_scale"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W2s"], "w2_scale")
+    )
+    ref_inits["w2_zero_point"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W2zp"], "w2_zero_point")
+    )
+    onnx.checker.check_model(ref_model)
+
+    rng = np.random.default_rng(33)
+    spatial = info["spatial"]
+    x = rng.standard_normal((1, c, spatial, spatial)).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"x": x})
+    (y_ref,) = _run(ref_model, {"x": x})
+    np.testing.assert_array_equal(y_pruned, y_ref)
+
+
+def test_dynamic_quantize_conv_depthwise_endpoint_still_declined():
+    # `test_dynamic_quantize_conv_grouped_is_declined`'s own coverage (a
+    # general grouped ConvInteger reached as the chain's own producer/
+    # consumer ENDPOINT) must keep declining -- only a depthwise ConvInteger
+    # reached MID-CHAIN, between two ordinary endpoints, is ever matched
+    # (see `_match_conv_integer_depthwise_pass_through`). Here the chain's
+    # own FIRST ConvInteger (the producer role) is itself made depthwise
+    # (`group == m1 == out_channels`, weight `[m1, 1, kh, kw]`) with no
+    # preceding pointwise stage at all -- a fundamentally different shape
+    # from the mid-chain case the new hop targets, and still out of scope.
+    c, m1, m2 = 6, 6, 5
+    rng = np.random.default_rng(34)
+    w1f = (rng.standard_normal((m1, 1, 3, 3)) * 0.3).astype(np.float32)
+    w2f = (rng.standard_normal((m2, m1, 1, 1)) * 0.3).astype(np.float32)
+    model, _info = _dqconv_model_from_weights(c, m1, m2, w1f, w2f, seed=35)
+    for node in model.graph.node:
+        if node.op_type == "ConvInteger" and node.output[0] == "c1i":
+            node.attribute.append(onnx.helper.make_attribute("group", m1))
+    chains = onnxsim.pruning._find_conv_integer_chains(model.graph)
+    assert chains == []
+
+
 def test_dynamic_quantize_conv_clip_nonscalar_min_declines():
     # A `Clip` with a per-channel-shaped (`[m1]`) `min` between two
     # `ConvInteger` chains must be declined, never guessed at -- mirrors


### PR DESCRIPTION
## Summary

The `DynamicQuantizeConv` (`ConvInteger`) chain-finding walker, `_walk_to_conv_integer_consumer`, terminates the walk as soon as it hits a depthwise `ConvInteger` (`group == in_channels == out_channels`) — `_match_conv_integer` hard-declines any `group != 1` node. Since a `pointwise → depthwise → pointwise` unit is the canonical MobileNetV1/V2/V3 depthwise-separable-conv block, this made the **entire dynamic-quantization-Conv pruning pass a no-op on the dominant mobile/edge CNN architecture family** — exactly the models dynamic quantization is typically applied to.

## Empirically confirmed facts

- Built a real `pointwise → depthwise → pointwise` block, ran ORT's actual `quantize_dynamic` + `ORT_ENABLE_ALL` graph optimization: produces 3 `ConvInteger` nodes (`group=1`, `group=8` (depthwise), `group=1`). Before this change, `_find_conv_integer_chains` found **0 chains** for this topology (the depthwise node killed the walk). After: 1 chain, prunes end-to-end.
- Confirmed ORT's `ConvInteger` quantizer still emits scalar (not per-channel) `w_zero_point`/`w_scale` for the depthwise node too, matching this module's own documented "ConvInteger is always per-tensor" fact — so the hop needs no per-channel-scale handling.
- The existing plain-float Conv family already solves this exact problem for non-quantized chains via `_match_depthwise_conv_pass_through`/`_apply_conv_pass_through_hop`/`_set_conv_group_attr`. This PR mirrors that proven design for the `ConvInteger` family rather than inventing new machinery.

## What's added

- `onnxsim/pruning.py`: `_ConvIntegerPassThrough` (dataclass) + `_match_conv_integer_depthwise_pass_through`, recognizing a depthwise `ConvInteger` reached via its own dedicated `DynamicQuantizeLinear` producer (same `DynamicQuantizeLinear → ConvInteger → Cast → Mul → [Reshape+Add]` neighborhood shape a terminal `ConvInteger` already has). `_walk_to_conv_integer_consumer` now tries this match whenever the ordinary (`group==1`) match fails, and continues the walk through it. `_ConvIntegerChain` carries the matched hops; `apply_structured_pruning_dynamic_quantize_conv` slices each hop's own int8 weight (axis 0) and float bias (if present) by the chain's `keep` set and shrinks its `group` attribute — exactly mirroring the plain-float depthwise treatment, just against an int8 weight.
- A depthwise/grouped `ConvInteger` reached as a chain's own producer/consumer **endpoint** (rather than mid-chain) is still declined, unchanged.
- `tests/test_pruning.py`: three new regression tests (`onnx.parser`-based, with weights quantized via the real `onnxruntime.quantization.quantize_dynamic` tool) — matching+pruning the 3-layer depthwise-separable chain, an independent-oracle numeric check via a real `InferenceSession`, and confirming the existing endpoint-decline behavior (distinct from the pre-existing `test_dynamic_quantize_conv_grouped_is_declined`, left untouched) is preserved.

## Test plan

- [x] New tests fail on the pre-fix code (0 chains matched, or shape/value mismatch) and pass after the fix (verified independently via a before/after checkout)
- [x] `pytest tests/test_pruning.py -k "conv_integer or dynamic_quantize_conv"` — 19 passed
- [x] `pytest tests/test_pruning.py -q` (full suite) — 867 passed, same 52 pre-existing failures (stale compiled C++ extension noise, unrelated, confirmed identical on the pre-change commit)
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — no new issues

## Risks for reviewer

- Scoped strictly to the `ConvInteger` family; the plain-float Conv/MatMul walkers and the DynamicQuantizeMatMul/MatMulIntegerToFloat family are untouched.
- The depthwise hop only ever activates mid-chain (between two real `group==1` endpoints); a depthwise `ConvInteger` as the chain's own endpoint keeps the exact same decline behavior as before.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_