### PR TITLE
Close remaining C++ pruning-port scope gaps: N:M/global_sparsity/FP16-BF16/Attention/GatherBlockQuantized/importance_norm/block_size

### DIFF
--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -989,17 +989,18 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
   // onnxsim.h.
   m.def(
       "apply_quarot",
-      [](const py::bytes& model_proto_bytes, uint64_t seed) -> py::bytes {
+      [](const py::bytes& model_proto_bytes, uint64_t seed, int64_t block_size,
+         float epsilon) -> py::bytes {
         InitEnv();
         ONNX_NAMESPACE::ModelProto model;
         ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
                             model_proto_bytes.size());
-        const auto result = ApplyQuarot(model, seed);
+        const auto result = ApplyQuarot(model, seed, block_size, epsilon);
         std::string out;
         result.SerializeToString(&out);
         return py::bytes(out.data(), out.size());
       },
-      "model_bytes"_a, "seed"_a);
+      "model_bytes"_a, "seed"_a, "block_size"_a = 32, "epsilon"_a = 1e-12f);
 
   // Lists the activation tensor names quantize_static could quantize --
   // see ListQuantizableActivations in onnxsim.h.

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -762,21 +762,22 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
 
   // Wanda pruning (Sun et al., 2023): the calibration-driven upgrade of
   // magnitude pruning's data-free baseline, zeroing the least-important
-  // entries of every matched layer's constant 2-D FLOAT32 weight to an
-  // unstructured or N:M sparsity pattern using ``|W_ij| * ||X_j||_2``
-  // (weight magnitude times its reduction-dimension entry's calibrated
-  // activation L2-norm) as the importance metric -- a one-shot static
-  // score, unlike apply_sparsegpt_pruning's own sequential Hessian-error-
-  // compensating algorithm. Same candidate set/scope (FLOAT32-only, no
-  // Conv) and same executor-as-first-argument, `calibration_data`
-  // (List[Dict[str, onnx.TensorProto]]) crossing convention as
-  // apply_sparsegpt_pruning's own binding above. See ApplyWandaPruning in
-  // structured_pruning_entry.h for the full scope and the data-free
-  // magnitude fallback an unobserved layer gets (unlike SparseGPT, which
-  // has none). `global_sparsity` pools every matched layer's importance
-  // into one whole-model ranking, mirroring apply_structured_wanda_
-  // pruning's own `sparsity`-only mode's structural analogue; incompatible
-  // with `n`/`m`.
+  // entries of every matched layer's constant 2-D FLOAT32/FLOAT16/BFLOAT16
+  // weight to an unstructured or N:M sparsity pattern using
+  // ``|W_ij| * ||X_j||_2`` (weight magnitude times its reduction-dimension
+  // entry's calibrated activation L2-norm) as the importance metric -- a
+  // one-shot static score, unlike apply_sparsegpt_pruning's own sequential
+  // Hessian-error-compensating algorithm. Same candidate set as
+  // apply_sparsegpt_pruning's own binding above except widened to
+  // FLOAT32/FLOAT16/BFLOAT16 (still no Conv -- the one remaining gap vs.
+  // pruning.py's own apply_wanda_pruning), and same executor-as-first-
+  // argument, `calibration_data` (List[Dict[str, onnx.TensorProto]])
+  // crossing convention. See ApplyWandaPruning in structured_pruning_
+  // entry.h for the full scope and the data-free magnitude fallback an
+  // unobserved layer gets (unlike SparseGPT, which has none).
+  // `global_sparsity` pools every matched layer's importance into one
+  // whole-model ranking, mirroring apply_structured_wanda_pruning's own
+  // `sparsity`-only mode's structural analogue; incompatible with `n`/`m`.
   m.def(
       "apply_wanda_pruning",
       [](std::shared_ptr<PyModelExecutor> executor,

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -609,21 +609,30 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
       "model_bytes"_a);
 
   // Magnitude pruning (Han et al., 2015): zeros the least-magnitude entries
-  // of every MatMul/vanilla-Gemm/Conv layer's constant weight, independently
-  // per output row/filter. Data-free. See PruneMagnitude in onnxsim.h.
+  // of every MatMul/vanilla-Gemm/Conv/com.microsoft::Attention layer's
+  // constant weight, independently per output row/filter. Data-free.
+  // `n`/`m` are `None` (unstructured, ranked by `sparsity`) or both given
+  // together (N:M semi-structured). `global_sparsity` pools every matched
+  // layer's importance into one whole-model ranking; incompatible with
+  // `n`/`m`. Same `n`/`m`/`global_sparsity` shape as apply_wanda_pruning's
+  // own binding above. See PruneMagnitude in onnxsim.h.
   m.def(
       "prune_magnitude",
-      [](const py::bytes& model_proto_bytes, double sparsity) -> py::bytes {
+      [](const py::bytes& model_proto_bytes, double sparsity,
+         std::optional<int64_t> n, std::optional<int64_t> m,
+         bool global_sparsity) -> py::bytes {
         InitEnv();
         ONNX_NAMESPACE::ModelProto model;
         ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
                             model_proto_bytes.size());
-        const auto result = PruneMagnitude(model, sparsity);
+        const auto result =
+            PruneMagnitude(model, sparsity, n, m, global_sparsity);
         std::string out;
         result.SerializeToString(&out);
         return py::bytes(out.data(), out.size());
       },
-      "model_bytes"_a, "sparsity"_a);
+      "model_bytes"_a, "sparsity"_a, "n"_a.none(), "m"_a.none(),
+      "global_sparsity"_a = false);
 
   // Structured (channel) pruning: removes whole output channels from
   // MatMul/vanilla-Gemm and Conv layers -- real structural pruning, not

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -724,19 +724,19 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
   // SparseGPT (Frantar & Alistarh, 2023) unstructured/N:M pruning: zeros
   // the least-important entries of every matched MatMul/vanilla-Gemm/
   // com.microsoft::Attention merged-QKV-weight layer's constant 2-D
-  // FLOAT32 weight, using a sequential, Hessian-error-compensating
-  // algorithm (GPTQ's own Cholesky-factored inverse Hessian reformulation)
-  // rather than a one-shot static importance score -- unlike every pass
-  // above, this never changes any tensor's shape, only individual weight
-  // entries' own values. Same executor-as-first-argument,
+  // FLOAT32/FLOAT16/BFLOAT16 weight, using a sequential, Hessian-error-
+  // compensating algorithm (GPTQ's own Cholesky-factored inverse Hessian
+  // reformulation) rather than a one-shot static importance score --
+  // unlike every pass above, this never changes any tensor's shape, only
+  // individual weight entries' own values. Same executor-as-first-argument,
   // `calibration_data` (List[Dict[str, onnx.TensorProto]]) crossing
   // convention as apply_structured_wanda_pruning's own binding above (see
   // that binding's own comment for the full calibration-crossing design).
   // `n`/`m` are `None` (unstructured, ranked by `sparsity`) or both given
   // together (N:M semi-structured). See ApplySparseGptPruning in
-  // structured_pruning_entry.h for the full scope (in particular: FLOAT32-
-  // only, and 2-D Conv is NOT matched -- a deliberate, documented
-  // narrower-than-pruning.py scope decision).
+  // structured_pruning_entry.h for the full scope (in particular: 2-D Conv
+  // is NOT matched -- a deliberate, documented narrower-than-pruning.py
+  // scope decision, and the only remaining one).
   m.def(
       "apply_sparsegpt_pruning",
       [](std::shared_ptr<PyModelExecutor> executor,

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -627,20 +627,28 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
 
   // Structured (channel) pruning: removes whole output channels from
   // MatMul/vanilla-Gemm and Conv layers -- real structural pruning, not
-  // just value-only zeroing. See ApplyStructuredPruning in onnxsim.h.
+  // just value-only zeroing. See ApplyStructuredPruning in
+  // structured_pruning_entry.h. `importance_norm` ("l1"/"l2") and
+  // `global_sparsity` mirror pruning.py's own `apply_structured_pruning`
+  // parameters of the same names exactly -- see that function's own
+  // declaration comment.
   m.def(
       "apply_structured_pruning",
-      [](const py::bytes& model_proto_bytes, double sparsity) -> py::bytes {
+      [](const py::bytes& model_proto_bytes, double sparsity,
+         const std::string& importance_norm,
+         bool global_sparsity) -> py::bytes {
         InitEnv();
         ONNX_NAMESPACE::ModelProto model;
         ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
                             model_proto_bytes.size());
-        const auto result = ApplyStructuredPruning(model, sparsity);
+        const auto result = ApplyStructuredPruning(
+            model, sparsity, importance_norm, global_sparsity);
         std::string out;
         result.SerializeToString(&out);
         return py::bytes(out.data(), out.size());
       },
-      "model_bytes"_a, "sparsity"_a);
+      "model_bytes"_a, "sparsity"_a, "importance_norm"_a = "l2",
+      "global_sparsity"_a = false);
 
   // The calibration-driven (Wanda-style) upgrade of apply_structured_pruning
   // above -- same executor-as-first-argument shape as `simplify`'s own
@@ -663,36 +671,41 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
          const py::bytes& model_proto_bytes,
          std::vector<std::unordered_map<std::string, onnx::TensorProto>>
              calibration_data,
-         double sparsity, double epsilon) -> py::bytes {
+         double sparsity, double epsilon, const std::string& importance_norm,
+         bool global_sparsity) -> py::bytes {
         InitEnv();
         ONNX_NAMESPACE::ModelProto model;
         ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
                             model_proto_bytes.size());
         const auto result = ApplyStructuredWandaPruning(
-            model, *executor, calibration_data, sparsity, epsilon);
+            model, *executor, calibration_data, sparsity, epsilon,
+            importance_norm, global_sparsity);
         std::string out;
         result.SerializeToString(&out);
         return py::bytes(out.data(), out.size());
       },
       "executor"_a, "model_bytes"_a, "calibration_data"_a, "sparsity"_a,
-      "epsilon"_a = 1e-8);
+      "epsilon"_a = 1e-8, "importance_norm"_a = "l2",
+      "global_sparsity"_a = false);
 
   // Attention-head pruning: removes whole attention heads (or, for
   // grouped-query attention, whole KV groups) from every matched fused
   // self-attention block. See ApplyAttentionHeadPruning in onnxsim.h.
   m.def(
       "apply_attention_head_pruning",
-      [](const py::bytes& model_proto_bytes, double sparsity) -> py::bytes {
+      [](const py::bytes& model_proto_bytes, double sparsity,
+         const std::string& importance_norm) -> py::bytes {
         InitEnv();
         ONNX_NAMESPACE::ModelProto model;
         ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
                             model_proto_bytes.size());
-        const auto result = ApplyAttentionHeadPruning(model, sparsity);
+        const auto result =
+            ApplyAttentionHeadPruning(model, sparsity, importance_norm);
         std::string out;
         result.SerializeToString(&out);
         return py::bytes(out.data(), out.size());
       },
-      "model_bytes"_a, "sparsity"_a);
+      "model_bytes"_a, "sparsity"_a, "importance_norm"_a = "l2");
 
   // The calibration-driven (Wanda-style) upgrade of
   // apply_attention_head_pruning above -- same executor-as-first-argument
@@ -707,19 +720,21 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
          const py::bytes& model_proto_bytes,
          std::vector<std::unordered_map<std::string, onnx::TensorProto>>
              calibration_data,
-         double sparsity, double epsilon) -> py::bytes {
+         double sparsity, double epsilon,
+         const std::string& importance_norm) -> py::bytes {
         InitEnv();
         ONNX_NAMESPACE::ModelProto model;
         ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
                             model_proto_bytes.size());
-        const auto result = ApplyAttentionHeadWandaPruning(
-            model, *executor, calibration_data, sparsity, epsilon);
+        const auto result =
+            ApplyAttentionHeadWandaPruning(model, *executor, calibration_data,
+                                           sparsity, epsilon, importance_norm);
         std::string out;
         result.SerializeToString(&out);
         return py::bytes(out.data(), out.size());
       },
       "executor"_a, "model_bytes"_a, "calibration_data"_a, "sparsity"_a,
-      "epsilon"_a = 1e-8);
+      "epsilon"_a = 1e-8, "importance_norm"_a = "l2");
 
   // SparseGPT (Frantar & Alistarh, 2023) unstructured/N:M pruning: zeros
   // the least-important entries of every matched MatMul/vanilla-Gemm/

--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -138,7 +138,9 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::FuseReshapeFamily>(registry);
     RegisterOrReplace<p::FuseRMSNorm>(registry);
     RegisterOrReplace<p::FuseRope>(registry);
+    RegisterOrReplace<p::MagnitudePruningAttention>(registry);
     RegisterOrReplace<p::MagnitudePruningConv>(registry);
+    RegisterOrReplace<p::MagnitudePruningGlobal>(registry);
     RegisterOrReplace<p::MagnitudePruningMatMul>(registry);
     RegisterOrReplace<p::QOperatorQuantizeActivation>(registry);
     RegisterOrReplace<p::QOperatorQuantizeConcat>(registry);

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -1643,17 +1643,22 @@ def apply_sparsegpt_pruning_cpp(
     independently, with no producer/consumer chain-walking at all.
 
     Matches every plain ``MatMul``/vanilla-``Gemm`` node with a constant 2-D
-    FLOAT32 weight (this already includes ``com.microsoft::
+    FLOAT32/FLOAT16/BFLOAT16 weight (this already includes ``com.microsoft::
     GroupQueryAttention``'s own separate Q/K/V projections -- ordinary
     MatMul/Gemm nodes feeding it, not a weight the op itself owns), plus
-    every ``com.microsoft::Attention`` node's constant 2-D FLOAT32 merged
-    QKV weight. Deliberately narrower than the pure-Python
-    :func:`onnxsim.apply_sparsegpt_pruning` in two ways, both mirroring this
-    module's own established narrower-than-pruning.py C++-port scope
-    decisions elsewhere (e.g. the ``MatMulNBits`` C++ section's own
-    FLOAT32-only restriction on its own scales/zero_points/bias tensors):
+    every ``com.microsoft::Attention`` node's constant 2-D FLOAT32/FLOAT16/
+    BFLOAT16 merged QKV weight -- read upcast to float64, written back down
+    to each weight's own original dtype, exactly like
+    :func:`onnxsim.apply_sparsegpt_pruning`'s own ``_to_f64``/``_from_f64``
+    convention (though note SparseGPT's Hessian-compensated update, unlike
+    plain masking, *recomputes* every kept entry's own value, so a fp16/bf16
+    weight's surviving entries do not reproduce their pre-pruning bit
+    pattern the way a plain-masking C++ port's FLOAT16/BFLOAT16 support
+    does). Deliberately narrower than the pure-Python
+    :func:`onnxsim.apply_sparsegpt_pruning` in one remaining way (mirroring
+    this module's own established narrower-than-pruning.py C++-port scope
+    decisions elsewhere):
 
-    - FLOAT32 only, not also FLOAT16/BFLOAT16.
     - 2-D ``Conv`` (ordinary/depthwise/general-grouped) is **not** matched
       at all here -- the pure-Python original's own Conv support needs an
       entirely new, from-first-principles im2col cross-covariance Hessian
@@ -1665,7 +1670,12 @@ def apply_sparsegpt_pruning_cpp(
       port. A Conv node is left completely untouched here, never guessed
       at, exactly as if it were any other unmatched node type -- use the
       pure-Python :func:`onnxsim.apply_sparsegpt_pruning` if Conv coverage
-      is required.
+      is required. This is the only remaining scope gap versus the
+      pure-Python original, so :func:`onnxsim.apply_sparsegpt_pruning`
+      itself is NOT an alias of this function (unlike, e.g.,
+      :func:`onnxsim.apply_transformer_block_pruning`, which IS an alias of
+      its own verified-full-parity C++ port) -- a Conv-bearing model would
+      otherwise silently get a different (Conv-less) result here.
 
     :param model: the original onnx ModelProto or file path
     :param calibration_data: representative input batches to compute each
@@ -1703,8 +1713,8 @@ def apply_sparsegpt_pruning_cpp(
             place to the target pattern; a layer with no observed 2-D
             calibration activation (dead input, an otherwise-empty
             ``calibration_data``, or every batch's activation isn't
-            FLOAT32) is left completely untouched -- there is no data-free
-            fallback for SparseGPT
+            FLOAT32/FLOAT16/BFLOAT16) is left completely untouched -- there
+            is no data-free fallback for SparseGPT
     """
     if isinstance(model, str):
         model = onnx.load(model, load_external_data=False)
@@ -1771,13 +1781,18 @@ def apply_wanda_pruning_cpp(
     GroupQueryAttention``'s own separate Q/K/V projections -- ordinary
     MatMul/Gemm nodes feeding it, not a weight the op itself owns), plus
     every ``com.microsoft::Attention`` node's constant 2-D FLOAT32 merged
-    QKV weight -- EXACTLY the same candidate set as
-    :func:`onnxsim.apply_sparsegpt_pruning_cpp`. Deliberately narrower than
-    the pure-Python :func:`onnxsim.apply_wanda_pruning` in the same two ways
-    that function's own C++-port sibling already establishes (mirroring
-    this module's own established narrower-than-pruning.py C++-port scope
-    decisions elsewhere, e.g. the ``MatMulNBits`` C++ section's own
-    FLOAT32-only restriction on its own scales/zero_points/bias tensors):
+    QKV weight -- the same candidate set
+    :func:`onnxsim.apply_sparsegpt_pruning_cpp` used to match before ITS OWN
+    FLOAT16/BFLOAT16 widening (this function has not been independently
+    re-verified against a real FLOAT16/BFLOAT16 export and remains
+    FLOAT32-only, so the two candidate sets are no longer identical).
+    Deliberately narrower than the pure-Python
+    :func:`onnxsim.apply_wanda_pruning` in the same two ways
+    that function's own C++-port sibling already established before its own
+    widening (mirroring this module's own established narrower-than-
+    pruning.py C++-port scope decisions elsewhere, e.g. the ``MatMulNBits``
+    C++ section's own FLOAT32-only restriction on its own scales/
+    zero_points/bias tensors):
 
     - FLOAT32 only, not also FLOAT16/BFLOAT16.
     - 2-D ``Conv`` (ordinary/depthwise/general-grouped) is **not** matched

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -21,7 +21,7 @@ import onnxsim.onnxsim_cpp2py_export as C
 
 from . import backend, model_checking, model_info, profile_merge, version
 from .calibration import Tensors, generate_random_calibration_data
-from .pruning import EmbeddingPruningResult
+from .pruning import EmbeddingPruningResult, _ImportanceNorm
 
 TensorShape = List[int]
 TensorShapes = Dict[str, TensorShape]
@@ -1251,6 +1251,8 @@ def prune_magnitude_cpp(
 def apply_structured_pruning_cpp(
     model: Union[str, onnx.ModelProto],
     sparsity: float = 0.5,
+    importance_norm: _ImportanceNorm = "l2",
+    global_sparsity: bool = False,
 ) -> onnx.ModelProto:
     """
     C++-backed port of :func:`onnxsim.apply_structured_pruning`: removes
@@ -1340,8 +1342,30 @@ def apply_structured_pruning_cpp(
 
     :param model: the original onnx ModelProto or file path
     :param sparsity: target fraction of each matched producer's output
-            channels to remove (at least one channel is always kept); must
-            be in ``[0, 1)``
+            channels to remove (at least one channel is always kept) -- or,
+            when ``global_sparsity``, target fraction of every eligible
+            chain's channels *combined*; must be in ``[0, 1)``
+    :param importance_norm: ``"l2"`` (default, unchanged from before this
+            parameter existed) ranks by Li et al.'s own root-sum-square L2
+            criterion; ``"l1"`` ranks by NNI's alternative L1 criterion
+            (sum of absolute weight magnitude) instead -- mirrors the
+            pure-Python :func:`onnxsim.apply_structured_pruning`'s own
+            ``importance_norm`` parameter exactly. Applies identically
+            whether or not ``global_sparsity`` is set.
+    :param global_sparsity: pools every *eligible* matched chain's own
+            per-channel importance into one ranking across the whole model
+            and picks a single keep-count from ``sparsity``'s fraction of
+            that pooled total, instead of every chain being cut by the same
+            fraction independently -- mirrors the pure-Python
+            :func:`onnxsim.apply_structured_pruning`'s own
+            ``global_sparsity`` mode exactly, including which chains are
+            "eligible" (an ordinary, single-producer chain with no extra
+            fan-out consumer branch and no general grouped Conv on either
+            side -- a gated pair, a residual/merge group, a
+            ``Concat``-merged branch, and any general grouped Conv chain
+            are all left completely untouched in this mode instead) and the
+            per-chain floor of at least one surviving channel. Default
+            ``False`` -- every pre-existing caller's behavior is unchanged.
     :returns: ``model`` with every matched chain's tensors resized in place;
             anything not matching the exact topology above (branching, a
             non-constant bias, a consumer whose reduction dimension doesn't
@@ -1350,7 +1374,9 @@ def apply_structured_pruning_cpp(
     if isinstance(model, str):
         model = onnx.load(model, load_external_data=False)
     return onnx.load_from_string(
-        C.apply_structured_pruning(model.SerializeToString(), sparsity)
+        C.apply_structured_pruning(
+            model.SerializeToString(), sparsity, importance_norm, global_sparsity
+        )
     )
 
 
@@ -1360,8 +1386,10 @@ def apply_structured_wanda_pruning_cpp(
     num_samples: int = 8,
     seed: int = 0,
     sparsity: float = 0.5,
+    importance_norm: _ImportanceNorm = "l2",
     epsilon: float = 1e-8,
     providers: Optional[Sequence[backend.Provider]] = None,
+    global_sparsity: bool = False,
 ) -> onnx.ModelProto:
     """
     C++-backed port of :func:`onnxsim.apply_structured_wanda_pruning`: the
@@ -1408,8 +1436,15 @@ def apply_structured_wanda_pruning_cpp(
     :param seed: seed for the random calibration data (ignored if
             ``calibration_data`` is supplied)
     :param sparsity: target fraction of each matched chain's output
-            channels to remove (at least one channel is always kept); must
-            be in ``[0, 1)``
+            channels to remove (at least one channel is always kept) -- or,
+            when ``global_sparsity``, target fraction of every eligible
+            chain's channels *combined*; must be in ``[0, 1)``
+    :param importance_norm: ``"l2"`` (default) or ``"l1"`` -- selects the
+            *weight*-magnitude term ``||W_row||`` only, exactly as it does
+            for :func:`onnxsim.apply_structured_pruning_cpp`; the
+            *activation*-norm term ``||X||_2`` stays L2 unconditionally
+            either way, per Wanda's own ``|W_ij| * ||X_j||_2`` definition.
+            Applies identically whether or not ``global_sparsity`` is set.
     :param epsilon: floor applied to the accumulated per-channel activation
             norm, avoiding every channel of an all-zero activation tying at
             exactly the weight-only importance
@@ -1417,12 +1452,20 @@ def apply_structured_wanda_pruning_cpp(
             when capturing calibration activations (passed to the shared
             :func:`onnxsim.onnx_simplifier._get_model_executor` process-wide
             executor, the same one :func:`onnxsim.simplify` itself uses)
+    :param global_sparsity: the structural analogue of
+            :func:`onnxsim.apply_structured_pruning_cpp`'s own
+            ``global_sparsity`` mode, applied to this function's own
+            ``||W_row||_2 * ||X||_2`` metric -- see that function's own
+            docstring for the full mechanism, the per-chain floor, and
+            exactly which chains are "eligible" to take part in the pool.
+            Default ``False`` -- every pre-existing caller's behavior is
+            unchanged.
     :returns: ``model`` with every matched chain's tensors resized in place;
             anything not matching that exact topology falls back to
             :func:`onnxsim.apply_structured_pruning_cpp`'s own plain
-            L2-norm ranking if no matching activation was ever observed for
-            that chain's consumer (including whenever ``calibration_data``
-            is empty)
+            weight-magnitude ranking if no matching activation was ever
+            observed for that chain's consumer (including whenever
+            ``calibration_data`` is empty)
     """
     if isinstance(model, str):
         model = onnx.load(model, load_external_data=False)
@@ -1451,6 +1494,8 @@ def apply_structured_wanda_pruning_cpp(
             calibration_data_pb,
             sparsity,
             epsilon,
+            importance_norm,
+            global_sparsity,
         )
     )
 
@@ -1458,6 +1503,7 @@ def apply_structured_wanda_pruning_cpp(
 def apply_attention_head_pruning_cpp(
     model: Union[str, onnx.ModelProto],
     sparsity: float = 0.5,
+    importance_norm: _ImportanceNorm = "l2",
 ) -> onnx.ModelProto:
     """
     C++-backed port of :func:`onnxsim.apply_attention_head_pruning`: removes
@@ -1503,6 +1549,12 @@ def apply_attention_head_pruning_cpp(
     :param sparsity: target fraction of each matched block's heads (or, for
             GroupQueryAttention/plain ai.onnx Attention, KV groups) to
             remove (at least one is always kept); must be in ``[0, 1)``
+    :param importance_norm: ``"l2"`` (default, unchanged from before this
+            parameter existed) ranks by the combined Frobenius (L2) norm of
+            each head's/KV group's own weight block, mirroring the
+            pure-Python :func:`onnxsim.apply_attention_head_pruning`'s own
+            default; ``"l1"`` ranks by the sum of absolute weight magnitude
+            across that same block instead.
     :returns: ``model`` with every matched block's tensors resized in
             place; anything not matching that exact topology (a
             non-constant weight, a packed-QKV GroupQueryAttention node, a
@@ -1516,7 +1568,9 @@ def apply_attention_head_pruning_cpp(
     if isinstance(model, str):
         model = onnx.load(model, load_external_data=False)
     return onnx.load_from_string(
-        C.apply_attention_head_pruning(model.SerializeToString(), sparsity)
+        C.apply_attention_head_pruning(
+            model.SerializeToString(), sparsity, importance_norm
+        )
     )
 
 
@@ -1526,6 +1580,7 @@ def apply_attention_head_wanda_pruning_cpp(
     num_samples: int = 8,
     seed: int = 0,
     sparsity: float = 0.5,
+    importance_norm: _ImportanceNorm = "l2",
     epsilon: float = 1e-8,
     providers: Optional[Sequence[backend.Provider]] = None,
 ) -> onnx.ModelProto:
@@ -1571,6 +1626,10 @@ def apply_attention_head_wanda_pruning_cpp(
     :param sparsity: target fraction of each matched block's heads (or, for
             GroupQueryAttention/plain ai.onnx Attention, KV groups) to
             remove (at least one is always kept); must be in ``[0, 1)``
+    :param importance_norm: ``"l2"`` (default) or ``"l1"`` -- selects the
+            *weight*-magnitude term only, exactly as it does for
+            :func:`onnxsim.apply_attention_head_pruning_cpp`; the
+            *activation*-norm term stays L2 unconditionally either way.
     :param epsilon: floor applied to the accumulated per-unit activation
             norm, avoiding every unit of an all-zero activation tying at
             exactly the weight-only importance
@@ -1607,6 +1666,7 @@ def apply_attention_head_wanda_pruning_cpp(
             calibration_data_pb,
             sparsity,
             epsilon,
+            importance_norm,
         )
     )
 

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -2345,17 +2345,19 @@ def apply_embedding_vocab_pruning_cpp(
     :class:`onnxsim.pruning.EmbeddingPruningResult`'s own docstring for the
     full return-value contract.
 
-    Unlike :func:`onnxsim.apply_embedding_vocab_pruning`, this C++ port
-    still only ever matches a plain ``Gather`` or ``com.microsoft::
-    EmbedLayerNormalization`` producer -- not ``com.microsoft::
-    GatherBlockQuantized`` (the block-quantized embedding shape -- out of
-    scope for this port; see ``onnxsim/structured_pruning_entry.cpp``'s own
-    "Embedding vocabulary pruning" section comment for exactly why). Its
-    ``lm_head`` auto-detection recognizes ``MatMul``/vanilla ``Gemm``/
-    ``com.microsoft::FusedGemm``/``GemmFastGelu``, and the embedding
-    table/``lm_head`` weight/bias may be FLOAT, FLOAT16, OR BFLOAT16 -- both
-    match the pure-Python original's own scope now. See that same section
-    comment for the exact matched topology.
+    Matches all three producer shapes the pure-Python original recognizes:
+    a plain ``Gather``, ``com.microsoft::EmbedLayerNormalization``, or
+    ``com.microsoft::GatherBlockQuantized`` (the block-quantized embedding
+    shape -- verified TRUE full parity across both of its own sub-8-bit
+    packing conventions, native ``tensor(uint4)``/``tensor(int4)`` and
+    manually-packed ``tensor(uint8)``; see ``onnxsim/structured_pruning_
+    entry.cpp``'s own "Embedding vocabulary pruning" section comment for the
+    full empirical detail). Its ``lm_head`` auto-detection recognizes
+    ``MatMul``/vanilla ``Gemm``/``com.microsoft::FusedGemm``/
+    ``GemmFastGelu``, and the embedding table/``lm_head`` weight/bias may be
+    FLOAT, FLOAT16, OR BFLOAT16 -- all matching the pure-Python original's
+    own scope exactly. See that same section comment for the exact matched
+    topology.
 
     This is a single, self-contained graph rewrite: unlike :func:`simplify`,
     it does not run shape inference, constant folding, or any other pass.
@@ -2418,10 +2420,14 @@ def apply_embedding_vocab_magnitude_pruning_cpp(
     -- see its own docstring and
     :class:`onnxsim.pruning.EmbeddingPruningResult`'s.
 
-    Same C++-port scope restrictions as
-    :func:`onnxsim.apply_embedding_vocab_pruning_cpp` (``GatherBlockQuantized``
-    still out of scope; every other producer/``lm_head``-node-type/dtype
-    shape matched) -- see that function's own docstring.
+    Same matched topology as
+    :func:`onnxsim.apply_embedding_vocab_pruning_cpp` (all three producer
+    shapes, including ``GatherBlockQuantized``, plus every ``lm_head``-node-
+    type/dtype shape) -- see that function's own docstring. For
+    ``GatherBlockQuantized``, the per-row L2 norm this ranks by is computed
+    from the dequantized-for-ranking-only embedding table (never written
+    back) -- see ``onnxsim/structured_pruning_entry.cpp``'s own
+    ``GatherBlockQuantizedDequantized``.
 
     This is a single, self-contained graph rewrite: unlike :func:`simplify`,
     it does not run shape inference, constant folding, or any other pass.

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -1216,36 +1216,53 @@ def apply_double_quantization_cpp(
 def prune_magnitude_cpp(
     model: Union[str, onnx.ModelProto],
     sparsity: float = 0.5,
+    n: Optional[int] = None,
+    m: Optional[int] = None,
+    global_sparsity: bool = False,
 ) -> onnx.ModelProto:
     """
     C++-backed port of :func:`onnxsim.apply_magnitude_pruning`: zeros the
     least-magnitude entries of every MatMul/vanilla-Gemm layer's constant
-    2-D float32 weight, and every Conv layer's constant 4-D float32 weight
-    (ordinary, depthwise, and general grouped Conv alike) -- the data-free
-    unstructured pruning baseline (Han et al., 2015).
+    2-D FLOAT/FLOAT16/BFLOAT16 weight, every Conv layer's constant 4-D
+    FLOAT/FLOAT16/BFLOAT16 weight (ordinary, depthwise, and general grouped
+    Conv alike), and every ``com.microsoft::Attention`` node's constant 2-D
+    FLOAT/FLOAT16/BFLOAT16 merged QKV weight -- the data-free unstructured
+    pruning baseline (Han et al., 2015). Full parity with the pure-Python
+    :func:`onnxsim.apply_magnitude_pruning`.
 
     Within each output row (or, for Conv, each output filter), keeps the
     ``max(1, round(cols * (1 - sparsity)))`` highest-magnitude entries and
     zeros the rest, so a layer with row-dependent weight scale doesn't get
     some rows pruned to nothing and others left untouched.
 
-    Unlike the pure-Python :func:`onnxsim.apply_magnitude_pruning`, this
-    does not match ``com.microsoft::Attention``'s merged QKV weight, and
-    offers only the sparsity-ratio mode (no N:M semi-structured pruning).
-
     This is a single, self-contained graph rewrite: unlike :func:`simplify`,
     it does not run shape inference, constant folding, or any other pass.
-    Layers with a non-constant, non-2-D (MatMul/Gemm), or non-4-D (Conv)
-    weight are left untouched.
+    Layers with a non-constant, non-2-D (MatMul/Gemm/Attention), or non-4-D
+    (Conv) weight are left untouched.
 
     :param model: onnx ModelProto object or file path
-    :param sparsity: target fraction of each row's entries to zero; must be
-            in ``[0, 1)``
+    :param sparsity: target fraction of each row's (or, for Conv, each
+            output filter's) entries to zero, ignored when ``n``/``m`` are
+            given -- or, when `global_sparsity`, target fraction of every
+            matched layer's entries *combined*
+    :param n: keep the ``n`` highest-magnitude entries per group of ``m``
+            (semi-structured N:M pruning, e.g. NVIDIA's 2:4). Must be given
+            together with ``m``; incompatible with `global_sparsity`.
+    :param m: group size for N:M pruning; see ``n``
+    :param global_sparsity: the classic "global magnitude pruning" variant
+            (Han et al., 2015): pools every matched layer's ``|W|`` entries
+            into one ranking across the whole model and zeros exactly
+            `sparsity`'s fraction of that pooled total, wherever it lands
+            (no per-row/per-layer floor -- see
+            :func:`onnxsim.apply_magnitude_pruning`'s own docstring).
+            Incompatible with ``n``/``m``.
     :returns: ``model`` with every matched layer's weight pruned in place
     """
     if isinstance(model, str):
         model = onnx.load(model, load_external_data=False)
-    return onnx.load_from_string(C.prune_magnitude(model.SerializeToString(), sparsity))
+    return onnx.load_from_string(
+        C.prune_magnitude(model.SerializeToString(), sparsity, n, m, global_sparsity)
+    )
 
 
 def apply_structured_pruning_cpp(

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -2451,6 +2451,8 @@ def apply_embedding_vocab_magnitude_pruning_cpp(
 def apply_quarot_cpp(
     model: Union[str, onnx.ModelProto],
     seed: int = 0,
+    block_size: int = 32,
+    epsilon: float = 1e-12,
 ) -> onnx.ModelProto:
     """
     C++-backed port of :func:`onnxsim.apply_quarot`: applies QuaRot-style
@@ -2458,7 +2460,7 @@ def apply_quarot_cpp(
     Outlier-Free 4-Bit Inference in Rotated LLMs") plus INT4
     round-to-nearest quantization of *both* the weight and the activation to
     every MatMul/vanilla-Gemm layer with a constant 2-D float32 weight whose
-    reduction dimension ``K`` is divisible by 32.
+    reduction dimension ``K`` is divisible by ``block_size``.
 
     Rotating the whole residual stream by a random orthogonal matrix removes
     activation outliers the same way block quantization already tolerates
@@ -2473,17 +2475,24 @@ def apply_quarot_cpp(
     This is a single, self-contained graph rewrite: unlike :func:`simplify`,
     it does not run shape inference, constant folding, or any other pass.
     Layers with a non-constant, non-2-D weight, or a reduction dimension not
-    divisible by 32, are left untouched. Consider calling :func:`simplify`
-    before and/or after to clean up the graph.
+    divisible by ``block_size``, are left untouched. Consider calling
+    :func:`simplify` before and/or after to clean up the graph.
 
     :param model: the original (unquantized) onnx ModelProto or file path
     :param seed: seed for the per-layer random rotation matrices
+    :param block_size: elements per weight quantization block along ``K``,
+            matching :func:`onnxsim.quantize_weight_only_int4`'s own default
+    :param epsilon: floor applied to a token's own max-abs rotated-activation
+            value before using it as a scale, avoiding a divide-by-zero on
+            an all-zero token
     :returns: the rotated-and-quantized onnx ModelProto; a model with no
             matching layer, or an opset older than 21, is returned unchanged
     """
     if isinstance(model, str):
         model = onnx.load(model, load_external_data=False)
-    return onnx.load_from_string(C.apply_quarot(model.SerializeToString(), seed))
+    return onnx.load_from_string(
+        C.apply_quarot(model.SerializeToString(), seed, block_size, epsilon)
+    )
 
 
 def quantize_fp16(

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -1767,37 +1767,42 @@ def apply_wanda_pruning_cpp(
     docstring for the general pattern).
 
     Matches every plain ``MatMul``/vanilla-``Gemm`` node with a constant 2-D
-    FLOAT32 weight (this already includes ``com.microsoft::
-    GroupQueryAttention``'s own separate Q/K/V projections -- ordinary
-    MatMul/Gemm nodes feeding it, not a weight the op itself owns), plus
-    every ``com.microsoft::Attention`` node's constant 2-D FLOAT32 merged
-    QKV weight -- EXACTLY the same candidate set as
-    :func:`onnxsim.apply_sparsegpt_pruning_cpp`. Deliberately narrower than
-    the pure-Python :func:`onnxsim.apply_wanda_pruning` in the same two ways
-    that function's own C++-port sibling already establishes (mirroring
-    this module's own established narrower-than-pruning.py C++-port scope
-    decisions elsewhere, e.g. the ``MatMulNBits`` C++ section's own
-    FLOAT32-only restriction on its own scales/zero_points/bias tensors):
+    FLOAT32/FLOAT16/BFLOAT16 weight (this already includes
+    ``com.microsoft::GroupQueryAttention``'s own separate Q/K/V projections
+    -- ordinary MatMul/Gemm nodes feeding it, not a weight the op itself
+    owns), plus every ``com.microsoft::Attention`` node's constant 2-D
+    FLOAT32/FLOAT16/BFLOAT16 merged QKV weight -- widened to
+    FLOAT32/FLOAT16/BFLOAT16 vs. :func:`onnxsim.apply_sparsegpt_pruning_cpp`'s
+    own still-FLOAT32-only candidate set (read out upcast to float64, written
+    back down to the original dtype, exactly mirroring the pure-Python
+    :func:`onnxsim.apply_wanda_pruning`'s own ``_to_f64``/``_from_f64``
+    round trip -- masking never recomputes a surviving entry's own value, so
+    this reproduces its exact original bit pattern). Only remaining
+    deliberate gap vs. the pure-Python :func:`onnxsim.apply_wanda_pruning`:
 
-    - FLOAT32 only, not also FLOAT16/BFLOAT16.
     - 2-D ``Conv`` (ordinary/depthwise/general-grouped) is **not** matched
       at all here -- the pure-Python original's own Conv support needs an
       entirely new, from-first-principles im2col per-receptive-field-offset
       activation norm (``_conv_patch_sq_sum``/``_conv_group_relative_norm``)
       that :func:`onnxsim.apply_sparsegpt_pruning_cpp`'s own docstring
       explains is out of scope here too, for the analogous Hessian case --
-      reaching that bar is materially bigger than the rest of this pass and
-      is out of scope for this C++ port. A Conv node is left completely
-      untouched here, never guessed at, exactly as if it were any other
-      unmatched node type -- use the pure-Python
-      :func:`onnxsim.apply_wanda_pruning` if Conv coverage is required.
+      reaching that bar is materially bigger than the rest of this pass
+      (a brand-new im2col activation-collection engine this C++ port has
+      nowhere else, plus the grouped/depthwise group-relative norm
+      expansion, with real numeric-correctness risk if gotten subtly wrong)
+      and is deliberately left to the pure-Python implementation rather than
+      risked this round. A Conv node is left completely untouched here,
+      never guessed at, exactly as if it were any other unmatched node type
+      -- use the pure-Python :func:`onnxsim.apply_wanda_pruning` if Conv
+      coverage is required. Because of this one remaining gap,
+      :func:`onnxsim.apply_wanda_pruning` is NOT an alias of this function.
 
     Unlike :func:`onnxsim.apply_sparsegpt_pruning_cpp` (which has no data-
     free fallback at all -- its entire mechanism IS the Hessian), a matched
     layer with NO observed calibration activation for its own input (dead
     input, an otherwise-empty ``calibration_data``, or every batch's
-    activation isn't FLOAT32) still gets pruned here, just to PLAIN
-    MAGNITUDE importance (``|W_ij|`` alone) instead -- mirrors the
+    activation isn't FLOAT32/FLOAT16/BFLOAT16) still gets pruned here, just
+    to PLAIN MAGNITUDE importance (``|W_ij|`` alone) instead -- mirrors the
     pure-Python :func:`onnxsim.apply_wanda_pruning`'s own per-layer
     fallback exactly.
 

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -496,23 +496,39 @@ onnx::ModelProto ApplyDoubleQuantization(const onnx::ModelProto& model);
 
 // Magnitude pruning (Han et al., 2015) -- the data-free unstructured
 // pruning baseline. Zeros the least-magnitude entries of every
-// MatMul/vanilla-Gemm layer's constant 2-D float32 weight, and every Conv
-// layer's constant 4-D float32 weight (ordinary, depthwise, and general
-// grouped Conv alike), independently per output row/filter: within each
-// row, keeps the max(1, round(cols * (1 - sparsity))) highest-magnitude
-// entries and zeros the rest. Unlike the pure-Python
-// ``apply_magnitude_pruning``, this does not match
-// ``com.microsoft::Attention``'s merged QKV weight, and offers only the
-// sparsity-ratio mode (no N:M semi-structured pruning) -- see
-// ``passes/magnitude_pruning.h`` for the exact rewrite and this scope note.
+// MatMul/vanilla-Gemm layer's constant 2-D FLOAT/FLOAT16/BFLOAT16 weight,
+// every Conv layer's constant 4-D FLOAT/FLOAT16/BFLOAT16 weight (ordinary,
+// depthwise, and general grouped Conv alike), and every
+// ``com.microsoft::Attention`` node's constant 2-D FLOAT/FLOAT16/BFLOAT16
+// merged QKV weight, independently per output row/filter: within each row,
+// keeps the max(1, round(cols * (1 - sparsity))) highest-magnitude entries
+// and zeros the rest. Full parity with the pure-Python
+// ``apply_magnitude_pruning`` -- see ``passes/magnitude_pruning.h`` for the
+// exact rewrite.
+//
+// ``n``/``m`` (both ``std::nullopt``, or both given together: N:M
+// semi-structured pruning, ``0 < n <= m``) mirror pruning.py's own identical
+// parameters and validation (``_validate_pattern``) exactly: keeps the ``n``
+// highest-magnitude entries per group of ``m`` columns instead of using
+// ``sparsity``. ``global_sparsity`` pools every matched layer's own ``|W|``
+// entries into one ranking across the WHOLE model (every graph, including
+// nested If/Loop/Scan/BeamSearch-family subgraphs) and picks a single
+// keep-count from ``sparsity``'s fraction of that pooled total -- mirrors
+// pruning.py's own ``apply_magnitude_pruning`` ``global_sparsity`` mode
+// exactly (including its "no per-row floor" property). Incompatible with
+// ``n``/``m``: throws ``std::invalid_argument`` when both are given.
 //
 // Unlike ``Simplify``, this does not run shape inference, constant folding or
 // any other simplification pass -- it applies exactly this rewrite, to every
 // matching layer, to a copy of ``model`` (which is left untouched) and
-// returns the result. ``sparsity`` must be in [0, 1); throws
-// ``std::invalid_argument`` otherwise. A layer with a non-constant,
-// non-2-D (MatMul/Gemm), or non-4-D (Conv) weight is left untouched.
-onnx::ModelProto PruneMagnitude(const onnx::ModelProto& model, double sparsity);
+// returns the result. ``sparsity`` must be in [0, 1) when ``n``/``m`` are not
+// given; throws ``std::invalid_argument`` otherwise. A layer with a
+// non-constant, non-2-D (MatMul/Gemm/Attention), or non-4-D (Conv) weight is
+// left untouched.
+onnx::ModelProto PruneMagnitude(const onnx::ModelProto& model, double sparsity,
+                                const std::optional<int64_t>& n = std::nullopt,
+                                const std::optional<int64_t>& m = std::nullopt,
+                                bool global_sparsity = false);
 
 // QuaRot (Ashkboos et al., 2024) rotation preprocessing plus INT4
 // round-to-nearest quantization of *both* the weight and the activation of

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -529,10 +529,16 @@ onnx::ModelProto PruneMagnitude(const onnx::ModelProto& model, double sparsity);
 // any other simplification pass -- it applies exactly this rewrite, to every
 // matching layer, to a copy of ``model`` (which is left untouched) and
 // returns the result. A layer with a non-constant, non-2-D weight, or a
-// reduction dimension not divisible by 32, is left untouched; a model with
-// no matching layer, or an opset older than 21, is returned unchanged.
-// ``seed`` derives a fresh, deterministic random rotation per matched layer.
-onnx::ModelProto ApplyQuarot(const onnx::ModelProto& model, uint64_t seed);
+// reduction dimension not divisible by ``block_size``, is left untouched; a
+// model with no matching layer, or an opset older than 21, is returned
+// unchanged. ``seed`` derives a fresh, deterministic random rotation per
+// matched layer. ``block_size`` is the number of reduction-dimension (K)
+// elements sharing one weight quantization scale, matching
+// ``quantize_weight_only_int4``'s own default. ``epsilon`` floors a token's
+// own max-abs rotated-activation value before it is used as a quantization
+// scale, avoiding a divide-by-zero on an all-zero token.
+onnx::ModelProto ApplyQuarot(const onnx::ModelProto& model, uint64_t seed,
+                             int64_t block_size, float epsilon);
 
 // Structured (channel) pruning: removes whole output channels from
 // MatMul/vanilla-Gemm and Conv layers -- real structural pruning (smaller

--- a/onnxsim/passes/magnitude_pruning.h
+++ b/onnxsim/passes/magnitude_pruning.h
@@ -8,23 +8,28 @@
 // Magnitude pruning (Han et al., 2015) -- the data-free unstructured
 // pruning baseline, C++ port of pruning.py's own apply_magnitude_pruning.
 // Zeros the least-magnitude entries of every MatMul/vanilla-Gemm layer's
-// constant 2-D float32 weight and every Conv layer's constant 4-D float32
-// weight (ordinary, depthwise, and general grouped Conv alike -- see
-// pruning.py's own module docstring for why grouping needs no special-
-// casing for unstructured pruning), independently per output row/filter so
-// a layer with row-dependent weight scale doesn't get some rows pruned to
-// nothing and others left untouched.
+// constant 2-D FLOAT/FLOAT16/BFLOAT16 weight, every Conv layer's constant
+// 4-D FLOAT/FLOAT16/BFLOAT16 weight (ordinary, depthwise, and general
+// grouped Conv alike -- see pruning.py's own module docstring for why
+// grouping needs no special-casing for unstructured pruning), and every
+// ``com.microsoft::Attention``/``DecoderMaskedSelfAttention``/
+// ``PackedAttention`` node's constant 2-D FLOAT/FLOAT16/BFLOAT16 merged QKV
+// weight, independently per output row/filter so a layer with
+// row-dependent weight scale doesn't get some rows pruned to nothing and
+// others left untouched.
 //
-// Scope note: unlike pruning.py's apply_magnitude_pruning, this port does
-// not match com.microsoft::Attention's merged QKV weight (a rare contrib-op
-// case) and does not offer N:M (semi-structured) pruning -- only the
-// sparsity-ratio mode. Both remain available via the pure-Python
-// implementation.
+// Full parity with pruning.py's own ``apply_magnitude_pruning``: this port
+// also offers N:M (semi-structured) pruning (``MagnitudePruningN()``/
+// ``MagnitudePruningM()``, mirroring pruning.py's own ``_nm_mask`` exactly)
+// and a ``global_sparsity`` mode (``MagnitudePruningGlobal``, a
+// ``FullGraphBasedPass`` mirroring pruning.py's own
+// ``_apply_global_unstructured_pruning`` exactly) in addition to the default
+// per-layer sparsity-ratio mode.
 //
 // Before (illustrated for MatMul; a "vanilla" Gemm -- transA=0, alpha=1,
 // beta=1 -- and Conv are handled the same way, reshaped to
 // [out_channels, flattened_rest] first):
-//   Y = MatMul(X, W)         W constant, [K, N], float32
+//   Y = MatMul(X, W)         W constant, [K, N], FLOAT/FLOAT16/BFLOAT16
 // After:
 //   Wp = <W with each output channel's own lowest-|w| fraction zeroed>
 //   Y  = MatMul(X, Wp)
@@ -33,24 +38,40 @@
 // only element values within the existing tensor are zeroed (via a new
 // initializer of the same shape, not an in-place edit -- matching every
 // other onnxsim rewrite's "replace, don't mutate" convention for constants).
-// Since the replacement is still a plain constant float32 tensor of the
-// same shape, both patternMatchPredicate methods below explicitly check
-// whether pruning would still change anything (any would-be-dropped entry
-// that isn't already exactly zero) -- otherwise, unlike every other pass in
-// this directory (whose replacement is no longer constant, or has changed
+// A matched weight is read out upcast to float64 for the importance/masking
+// math below (mirrors pruning.py's own ``_to_f64``/``_from_f64`` "FP16/
+// BFloat16 weight support" convention) and the result cast back down to
+// that layer's own original dtype before being written back, so a fp16/bf16
+// model's declared dtypes are preserved exactly -- masking never changes a
+// surviving entry's own value, only zeros dropped ones. Since the
+// replacement is still a plain constant tensor of the same shape/dtype, both
+// ``MagnitudePruningMatMul``/``MagnitudePruningConv``/
+// ``MagnitudePruningAttention`` predicates below explicitly check whether
+// pruning would still change anything (any would-be-dropped entry that
+// isn't already exactly zero) -- otherwise, unlike every other pass in this
+// directory (whose replacement is no longer constant, or has changed
 // kind/shape), the predicate would keep matching its own already-pruned
 // output forever, looping OptimizeFixed's fixed point indefinitely.
+// ``MagnitudePruningGlobal`` needs no such guard: it is a
+// ``FullGraphBasedPass`` with an ``Empty`` analysis type, so
+// ``FixedPointPassManager`` runs it exactly once regardless (see
+// ``pass_manager.cc``: a pass reporting ``Empty`` analysis is never
+// re-invoked in the same fixed-point loop, unlike a ``PredicateBasedPass``'s
+// own ``CountBasedPassAnalysis``).
 
 #pragma once
 
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <cstring>
+#include <string>
 #include <vector>
 
 #include "onnx/common/assertions.h"
 #include "onnxoptimizer/pass.h"
 #include "onnxoptimizer/passes/pass_util.h"
+#include "passes/endian_read.h"
 #include "passes/quantize_conv_common.h"
 #include "passes/quantize_matmul_common.h"
 
@@ -58,14 +79,284 @@ namespace ONNX_NAMESPACE {
 namespace optimization {
 namespace onnxsim_passes {
 
-// Target fraction of each row's entries to zero. A function-local static,
-// the same pattern QuantizeFp16KeepIoTypes() (quantize_fp16.h) uses to pass
-// a parameter into a pass that OptimizeFixed's pass-name-list interface has
-// no other way to carry -- set by PruneMagnitude (pruning_entry.cpp)
-// immediately before calling OptimizeFixed.
+// Target fraction of each row's entries to zero, ignored when
+// MagnitudePruningN()/MagnitudePruningM() are set (N:M mode). Function-local
+// statics, the same pattern QuantizeFp16KeepIoTypes() (quantize_fp16.h) uses
+// to pass a parameter into a pass that OptimizeFixed's pass-name-list
+// interface has no other way to carry -- set by PruneMagnitude
+// (pruning_entry.cpp) immediately before calling OptimizeFixed.
 inline double& MagnitudePruningSparsity() {
   static double sparsity = 0.5;
   return sparsity;
+}
+
+// N:M semi-structured pruning parameters: keep the ``n`` highest-magnitude
+// entries per group of ``m`` columns. -1 (the default for both) means
+// "N:M mode is off -- use MagnitudePruningSparsity() instead", mirroring
+// pruning.py's own ``n``/``m`` being ``None`` together. Set together (both
+// > 0, with ``0 < n <= m`` already validated by PruneMagnitude) or left at
+// -1 together; never set to conflicting/partial values.
+inline int64_t& MagnitudePruningN() {
+  static int64_t n = -1;
+  return n;
+}
+inline int64_t& MagnitudePruningM() {
+  static int64_t m = -1;
+  return m;
+}
+
+// --- FLOAT16/BFloat16 support --------------------------------------------
+//
+// Mirrors pruning.py's own "FP16/BFloat16 weight support" section
+// (_is_supported_float_dtype/_to_f64/_from_f64) exactly, but written locally
+// against onnxoptimizer's in-memory Tensor/Graph/Node IR rather than
+// pruning.py's onnx.TensorProto/numpy, and rather than
+// structured_pruning_entry.cpp's own IsSupportedFloatDtype/ReadTensorAsF64/
+// WriteF64TensorAs (a genuinely different IR -- raw onnx::TensorProto, not
+// this optimizer pass framework's Tensor -- so those helpers' int32_data/
+// raw_data plumbing doesn't carry over unchanged; the underlying bit-level
+// conversion algorithms below are still the exact same math, just against
+// this file's own Tensor accessors).
+
+// True for FLOAT, FLOAT16, and BFLOAT16 -- every element dtype this file's
+// matchers accept for a weight initializer, mirroring pruning.py's own
+// `_is_supported_float_dtype` exactly.
+inline bool IsSupportedFloatDtype(int32_t elem_type) {
+  return elem_type == TensorProto_DataType_FLOAT ||
+         elem_type == TensorProto_DataType_FLOAT16 ||
+         elem_type == TensorProto_DataType_BFLOAT16;
+}
+
+// IEEE-754 binary16 -> double, exact (every half value is exactly
+// representable in double). Handles zero/subnormal/normal/inf/NaN.
+inline double Float16BitsToDouble(uint16_t bits) {
+  uint32_t sign = (uint32_t)(bits & 0x8000u) << 16;
+  uint32_t exp = (bits >> 10) & 0x1Fu;
+  uint32_t mant = bits & 0x3FFu;
+  uint32_t f32bits;
+  if (exp == 0) {
+    if (mant == 0) {
+      f32bits = sign;
+    } else {
+      int e = -1;
+      do {
+        ++e;
+        mant <<= 1;
+      } while (!(mant & 0x400u));
+      mant &= 0x3FFu;
+      uint32_t exp32 = (uint32_t)(127 - 15 - e);
+      f32bits = sign | (exp32 << 23) | (mant << 13);
+    }
+  } else if (exp == 0x1F) {
+    f32bits = sign | 0x7F800000u | (mant << 13);
+  } else {
+    uint32_t exp32 = exp - 15 + 127;
+    f32bits = sign | (exp32 << 23) | (mant << 13);
+  }
+  float f;
+  std::memcpy(&f, &f32bits, sizeof(f));
+  return (double)f;
+}
+
+// double -> IEEE-754 binary16, round-to-nearest-even. Works directly off the
+// double's own 52-bit mantissa/11-bit exponent -- deliberately NOT
+// `(float)d` first, which would round TWICE (double -> float32 -> half) and
+// can flip a tie-to-even decision right at half's own rounding boundary
+// versus rounding straight from double. Only ever actually applied to values
+// that came FROM Float16BitsToDouble in the first place (this pass never
+// recomputes a kept weight value, only reorders/drops entries -- see this
+// file's own top comment), so the exact rounding behavior for a
+// genuinely-arbitrary double is academic here: every real call site
+// round-trips an already-exact half value, for which any correct
+// round-to-nearest implementation reproduces the original bits exactly.
+inline uint16_t DoubleToFloat16Bits(double d) {
+  uint64_t x;
+  std::memcpy(&x, &d, sizeof(x));
+  uint32_t sign = (uint32_t)((x >> 48) & 0x8000u);
+  int32_t exp11 = (int32_t)((x >> 52) & 0x7FFu);
+  uint64_t mant = x & 0xFFFFFFFFFFFFFull;  // 52 bits
+
+  if (exp11 == 0x7FF) {
+    if (mant == 0) {
+      return (uint16_t)(sign | 0x7C00u);  // inf
+    }
+    uint16_t m = (uint16_t)(mant >> 42);
+    if (m == 0) m = 1;  // stay a NaN, not inf
+    return (uint16_t)(sign | 0x7C00u | m);
+  }
+
+  int32_t exp = exp11 - 1023 + 15;
+
+  if (exp >= 0x1F) {
+    return (uint16_t)(sign | 0x7C00u);  // overflow -> inf
+  }
+
+  if (exp <= 0) {
+    if (exp < -10) {
+      return (uint16_t)sign;  // underflow to zero
+    }
+    mant |= 0x10000000000000ull;  // implicit leading 1 (bit 52)
+    int shift = 43 - exp;         // exp<=0 so shift>=43, mant has 53 bits
+    uint64_t half_mant = mant >> shift;
+    uint64_t remainder = mant & ((1ull << shift) - 1);
+    uint64_t halfway = 1ull << (shift - 1);
+    if (remainder > halfway || (remainder == halfway && (half_mant & 1u))) {
+      half_mant += 1;
+    }
+    return (uint16_t)(sign | (uint32_t)half_mant);
+  }
+
+  uint32_t half_mant = (uint32_t)(mant >> 42);
+  uint64_t remainder = mant & ((1ull << 42) - 1);  // low 42 bits
+  uint64_t halfway = 1ull << 41;
+  if (remainder > halfway || (remainder == halfway && (half_mant & 1u))) {
+    half_mant += 1;
+    if (half_mant == 0x400u) {
+      half_mant = 0;
+      exp += 1;
+    }
+  }
+  if (exp >= 0x1F) {
+    return (uint16_t)(sign | 0x7C00u);
+  }
+  return (uint16_t)(sign | ((uint32_t)exp << 10) | half_mant);
+}
+
+// BFloat16 -> double, exact: bfloat16 is literally the top 16 bits of a
+// float32, so this is a plain zero-extend into a float32 bit pattern.
+inline double BFloat16BitsToDouble(uint16_t bits) {
+  uint32_t f32bits = (uint32_t)bits << 16;
+  float f;
+  std::memcpy(&f, &f32bits, sizeof(f));
+  return (double)f;
+}
+
+// double -> BFloat16, round-to-nearest-even (via an intermediate float32 --
+// unlike DoubleToFloat16Bits, this introduces no double-rounding hazard:
+// bfloat16 IS float32's own top 16 bits, so rounding double -> float32 ->
+// bfloat16 is the same "round once, truncate the rest" every real bfloat16
+// implementation does).
+inline uint16_t DoubleToBFloat16Bits(double d) {
+  float f = (float)d;
+  uint32_t x;
+  std::memcpy(&x, &f, sizeof(x));
+  if ((x & 0x7FFFFFFFu) > 0x7F800000u) {
+    return (uint16_t)((x >> 16) | 0x0040u);  // NaN -- force the quiet bit.
+  }
+  uint32_t lsb = (x >> 16) & 1u;
+  uint32_t rounding_bias = 0x7FFFu + lsb;
+  uint32_t rounded = x + rounding_bias;
+  return (uint16_t)(rounded >> 16);
+}
+
+// Reads a FLOAT/FLOAT16/BFLOAT16 constant `t` (any rank) into a flat
+// float64 vector, mirroring pruning.py's own `_to_f64`. Non-raw-data
+// storage packs each FLOAT16/BFLOAT16 element's own raw 16 bits into the
+// LOW half of one `int32s()` entry -- see ir_pb_converter.cc's own
+// `tensorProtoToTensorGeneric`, which imports TensorProto's `int32_data`
+// verbatim for these two dtypes.
+inline std::vector<double> ReadTensorAsF64Flat(const Tensor& t) {
+  int64_t numel = 1;
+  for (int64_t s : t.sizes()) {
+    numel *= s;
+  }
+  std::vector<double> out(static_cast<size_t>(numel));
+  if (t.elem_type() == TensorProto_DataType_FLOAT) {
+    const std::vector<float> f = ReadFloatTensorFlat(t);
+    for (size_t i = 0; i < f.size(); ++i) {
+      out[i] = static_cast<double>(f[i]);
+    }
+    return out;
+  }
+  std::vector<uint16_t> bits(static_cast<size_t>(numel));
+  if (t.is_raw_data()) {
+    bits = ReadRawDataHostOrder<uint16_t>(
+        reinterpret_cast<const uint16_t*>(t.raw().data()), numel);
+  } else {
+    const std::vector<int32_t>& codes = t.int32s();
+    for (int64_t i = 0; i < numel; ++i) {
+      bits[static_cast<size_t>(i)] =
+          static_cast<uint16_t>(codes[static_cast<size_t>(i)]);
+    }
+  }
+  const bool is_bf16 = t.elem_type() == TensorProto_DataType_BFLOAT16;
+  for (size_t i = 0; i < bits.size(); ++i) {
+    out[i] =
+        is_bf16 ? BFloat16BitsToDouble(bits[i]) : Float16BitsToDouble(bits[i]);
+  }
+  return out;
+}
+
+// Overwrites `out` (a fresh Tensor) with a `elem_type` (FLOAT/FLOAT16/
+// BFLOAT16) tensor of `sizes`/`data` -- mirrors pruning.py's own
+// `_from_f64`. Always writes `raw_data` for FLOAT16/BFLOAT16 (via
+// WriteRawDataLittleEndian, not int32s() -- see endian_read.h's own doc
+// comment for why), matching `onnx.numpy_helper.from_array`'s own
+// convention for these dtypes.
+inline void WriteF64FlatAsTensor(Tensor& out, int32_t elem_type,
+                                 const std::vector<int64_t>& sizes,
+                                 const std::vector<double>& data) {
+  out.elem_type() = elem_type;
+  out.sizes() = sizes;
+  if (elem_type == TensorProto_DataType_FLOAT) {
+    std::vector<float> f(data.size());
+    for (size_t i = 0; i < data.size(); ++i) {
+      f[i] = static_cast<float>(data[i]);
+    }
+    out.floats() = std::move(f);
+    return;
+  }
+  const bool is_bf16 = elem_type == TensorProto_DataType_BFLOAT16;
+  std::vector<uint16_t> bits(data.size());
+  for (size_t i = 0; i < data.size(); ++i) {
+    bits[i] =
+        is_bf16 ? DoubleToBFloat16Bits(data[i]) : DoubleToFloat16Bits(data[i]);
+  }
+  out.set_raw_data(WriteRawDataLittleEndian(bits));
+}
+
+// Reads `w_t` (a 2-D FLOAT/FLOAT16/BFLOAT16 constant, [K, N] or, when
+// `transposed`, [N, K]) into a flat row-major [N, K] (output channel first)
+// float64 buffer -- the float64-widened analogue of quantize_matmul_common.
+// h's own `ReadWeightNK`, used here so SparsityMaskRowMajor/NMMaskRowMajor's
+// per-row grouping lines up with output channels regardless of the weight's
+// own on-disk (transposed or not) layout or dtype.
+inline std::vector<double> ReadWeightNKF64(const Tensor& w_t, bool transposed) {
+  const int64_t dim0 = w_t.sizes()[0];
+  const int64_t dim1 = w_t.sizes()[1];
+  const int64_t rows = transposed ? dim0 : dim1;
+  const int64_t cols = transposed ? dim1 : dim0;
+  const std::vector<double> data = ReadTensorAsF64Flat(w_t);
+  std::vector<double> w_nk(static_cast<size_t>(rows * cols));
+  for (int64_t i = 0; i < dim0; ++i) {
+    for (int64_t j = 0; j < dim1; ++j) {
+      const double v = data[static_cast<size_t>(i * dim1 + j)];
+      if (transposed) {
+        w_nk[static_cast<size_t>(i * cols + j)] = v;
+      } else {
+        w_nk[static_cast<size_t>(j * cols + i)] = v;
+      }
+    }
+  }
+  return w_nk;
+}
+
+// Inverse of ReadWeightNKF64: converts a (possibly-masked) row-major
+// [rows, cols] `w_nk` buffer back to the original on-disk [dim0, dim1]
+// layout (transposed or not).
+inline std::vector<double> WeightNkToOriginalF64(
+    const std::vector<double>& w_nk, int64_t dim0, int64_t dim1,
+    bool transposed) {
+  const int64_t cols = transposed ? dim1 : dim0;
+  std::vector<double> out(static_cast<size_t>(dim0 * dim1));
+  for (int64_t i = 0; i < dim0; ++i) {
+    for (int64_t j = 0; j < dim1; ++j) {
+      out[static_cast<size_t>(i * dim1 + j)] =
+          transposed ? w_nk[static_cast<size_t>(i * cols + j)]
+                     : w_nk[static_cast<size_t>(j * cols + i)];
+    }
+  }
+  return out;
 }
 
 // Row-wise magnitude mask over a flat, row-major [rows, cols] `importance`
@@ -78,7 +369,7 @@ inline double& MagnitudePruningSparsity() {
 // therefore differ from the Python port's own choice of which zero-tied
 // entry to drop; both are equally valid magnitude-pruning outcomes).
 inline std::vector<bool> SparsityMaskRowMajor(
-    const std::vector<float>& importance, int64_t rows, int64_t cols,
+    const std::vector<double>& importance, int64_t rows, int64_t cols,
     double sparsity) {
   std::vector<bool> mask(importance.size(), true);
   // std::nearbyint (current rounding mode is FE_TONEAREST, i.e.
@@ -94,7 +385,7 @@ inline std::vector<bool> SparsityMaskRowMajor(
   const int64_t drop = cols - keep;
   std::vector<int64_t> order(static_cast<size_t>(cols));
   for (int64_t r = 0; r < rows; ++r) {
-    const float* row = importance.data() + r * cols;
+    const double* row = importance.data() + r * cols;
     for (int64_t c = 0; c < cols; ++c) {
       order[static_cast<size_t>(c)] = c;
     }
@@ -108,43 +399,278 @@ inline std::vector<bool> SparsityMaskRowMajor(
   return mask;
 }
 
-// Whether applying SparsityMaskRowMajor's own mask to `data` (row-major
-// [rows, cols], matching layout) would zero out at least one currently
-// nonzero entry -- see this file's own doc comment for why every predicate
-// below must check this before matching.
-inline bool MagnitudePruningWouldChange(const std::vector<float>& data,
-                                        int64_t rows, int64_t cols,
-                                        double sparsity) {
-  std::vector<float> importance(data.size());
+// Row-wise N:M mask over a flat, row-major [rows, cols] `importance` matrix:
+// within every consecutive group of `m` columns, keeps only the `n`
+// highest-importance entries -- mirrors pruning.py's own `_nm_mask` exactly,
+// including its trailing-partial-group handling: a final group of fewer
+// than `m` columns keeps a proportional share (`min(tail, max(1,
+// round(n * tail / m)))`) instead of requiring `cols` to be a multiple of
+// `m`. Caller must ensure `0 < n <= m` (validated once by PruneMagnitude at
+// the top-level entry point, mirroring pruning.py's own `_validate_pattern`).
+inline std::vector<bool> NMMaskRowMajor(const std::vector<double>& importance,
+                                        int64_t rows, int64_t cols, int64_t n,
+                                        int64_t m) {
+  std::vector<bool> mask(importance.size(), true);
+  const int64_t full_cols = (cols / m) * m;
+  std::vector<int64_t> order(static_cast<size_t>(m));
+  for (int64_t r = 0; r < rows; ++r) {
+    const double* row = importance.data() + r * cols;
+    for (int64_t base = 0; base < full_cols; base += m) {
+      for (int64_t i = 0; i < m; ++i) {
+        order[static_cast<size_t>(i)] = i;
+      }
+      std::stable_sort(order.begin(), order.end(), [&](int64_t a, int64_t b) {
+        return row[base + a] < row[base + b];
+      });
+      const int64_t drop = m - n;
+      for (int64_t i = 0; i < drop; ++i) {
+        mask[static_cast<size_t>(r * cols + base +
+                                 order[static_cast<size_t>(i)])] = false;
+      }
+    }
+    const int64_t tail = cols - full_cols;
+    if (tail > 0) {
+      const int64_t keep = std::min<int64_t>(
+          tail, std::max<int64_t>(1, static_cast<int64_t>(std::nearbyint(
+                                         static_cast<double>(n) * tail / m))));
+      const int64_t drop = tail - keep;
+      std::vector<int64_t> torder(static_cast<size_t>(tail));
+      for (int64_t i = 0; i < tail; ++i) {
+        torder[static_cast<size_t>(i)] = i;
+      }
+      std::stable_sort(torder.begin(), torder.end(), [&](int64_t a, int64_t b) {
+        return row[full_cols + a] < row[full_cols + b];
+      });
+      for (int64_t i = 0; i < drop; ++i) {
+        mask[static_cast<size_t>(r * cols + full_cols +
+                                 torder[static_cast<size_t>(i)])] = false;
+      }
+    }
+  }
+  return mask;
+}
+
+// Dispatches to NMMaskRowMajor (when MagnitudePruningN()/M() are set) or
+// SparsityMaskRowMajor (otherwise) over `data`'s own |.| importance --
+// the single mask entry point every per-layer pass (MatMul/Conv/Attention)
+// below shares, so N:M mode is "free" once a matcher/writer is expressed in
+// terms of this function rather than SparsityMaskRowMajor directly.
+inline std::vector<bool> MagnitudePruningMaskRowMajor(
+    const std::vector<double>& data, int64_t rows, int64_t cols) {
+  std::vector<double> importance(data.size());
   for (size_t i = 0; i < data.size(); ++i) {
     importance[i] = std::fabs(data[i]);
   }
-  const std::vector<bool> mask =
-      SparsityMaskRowMajor(importance, rows, cols, sparsity);
+  const int64_t n = MagnitudePruningN();
+  const int64_t m = MagnitudePruningM();
+  if (n > 0 && m > 0) {
+    return NMMaskRowMajor(importance, rows, cols, n, m);
+  }
+  return SparsityMaskRowMajor(importance, rows, cols,
+                              MagnitudePruningSparsity());
+}
+
+// Whether applying MagnitudePruningMaskRowMajor's own mask to `data`
+// (row-major [rows, cols], matching layout) would zero out at least one
+// currently nonzero entry -- see this file's own doc comment for why every
+// per-layer predicate below must check this before matching.
+inline bool MagnitudePruningWouldChange(const std::vector<double>& data,
+                                        int64_t rows, int64_t cols) {
+  const std::vector<bool> mask = MagnitudePruningMaskRowMajor(data, rows, cols);
   for (size_t i = 0; i < data.size(); ++i) {
-    if (!mask[i] && data[i] != 0.0f) {
+    if (!mask[i] && data[i] != 0.0) {
       return true;
     }
   }
   return false;
 }
 
-// Applies `mask` (row-major [rows, cols], SparsityMaskRowMajor's own layout)
-// to `data` (the same flat row-major layout), zeroing every masked-out
-// entry in place.
-inline void ApplyMaskRowMajor(std::vector<float>& data,
+// Applies `mask` (row-major [rows, cols]) to `data` (the same flat row-major
+// layout), zeroing every masked-out entry in place.
+inline void ApplyMaskRowMajor(std::vector<double>& data,
                               const std::vector<bool>& mask) {
   for (size_t i = 0; i < data.size(); ++i) {
     if (!mask[i]) {
-      data[i] = 0.0f;
+      data[i] = 0.0;
     }
   }
 }
 
-// ReadWeightNK (quantize_matmul_common.h) reads a 2-D MatMul/Gemm weight
-// into a flat row-major [N, K] (output channel first) buffer, used here so
-// SparsityMaskRowMajor's per-row grouping lines up with output channels
-// regardless of the weight's own on-disk (transposed or not) layout.
+// --- com.microsoft Attention-family merged-QKV-weight matching -----------
+//
+// Mirrors pruning.py's own `_match_attention_weight_only`, which reuses
+// `_match_attention_producer`'s own validation UNRESTRICTED by op_type --
+// so, to match it exactly, this also accepts `com.microsoft::Attention`'s
+// two schema-compatible siblings, `DecoderMaskedSelfAttention` (ONNX
+// Runtime's own in-place rewrite target for a step-of-1 decoder `Attention`
+// node) and `PackedAttention` (ONNX Runtime's own packing-mode fusion
+// target for `Attention`) -- not just plain `Attention` itself. All three
+// share `weight`/`bias` at input indices 1/2 and `attention_bias` at index
+// 5; `PackedAttention` needs no extra handling beyond that (its own indices
+// 3/4 are packing-mode bookkeeping tensors this matcher never inspects,
+// exactly like `Attention`'s own optional `mask_index`/`past` at those same
+// positions); `DecoderMaskedSelfAttention` needs the three extra checks
+// below (`do_rotary`, `qkv_hidden_sizes` absence, a non-constant `past`).
+
+struct AttentionQkvMatch {
+  Value* x = nullptr;  // activation (not required to be constant)
+  Value* w = nullptr;  // merged QKV weight; constant 2-D FLOAT/FLOAT16/
+                       // BFLOAT16 tensor, [K, Nq+Nk+Nv]
+};
+
+inline bool IsMicrosoftAttentionOp(Node* n) {
+  if (!n->has_domain() || n->domain() != "com.microsoft") {
+    return false;
+  }
+  return CheckKind(n, "Attention") ||
+         CheckKind(n, "DecoderMaskedSelfAttention") ||
+         CheckKind(n, "PackedAttention");
+}
+
+// Classifies a broadcastable per-head `attention_bias` constant's shape
+// against the schema-documented rank-4 layout `(batch_size or 1, num_heads
+// or 1, q_sequence_length, kv_sequence_length)` -- mirrors pruning.py's own
+// `_head_bias_axis`. A rank < 3 tensor is unconditionally head-count-
+// independent (true); rank 3 or 4 resolves to a genuine per-head axis at
+// position `rank - 3`, safe only when that axis's size is exactly 1
+// (broadcast) or `num_heads` (true either way); rank > 4, or a rank-3/4
+// tensor whose axis lands on neither 1 nor `num_heads`, is unresolvable
+// (false) -- the caller declines the whole match rather than guess, the
+// same "don't guess at a malformed node" bar pruning.py's own version
+// holds to.
+inline bool HeadBiasAxisIsSafe(const std::vector<int64_t>& dims,
+                               int64_t num_heads) {
+  const int64_t r = static_cast<int64_t>(dims.size());
+  if (r > 4) {
+    return false;
+  }
+  if (r < 3) {
+    return true;
+  }
+  const int64_t axis = r - 3;
+  const int64_t sz = dims[static_cast<size_t>(axis)];
+  return sz == 1 || sz == num_heads;
+}
+
+// If `n` is a `com.microsoft` Attention-family node (see
+// `IsMicrosoftAttentionOp`) with a constant 2-D FLOAT/FLOAT16/BFLOAT16
+// merged QKV weight (`[K, Nq+Nk+Nv]`), fills `info` and returns true.
+// Mirrors pruning.py's own `_match_attention_producer` validation
+// (`num_heads`/`qkv_hidden_sizes` consistency, and the `attention_bias`
+// shape gate for a *constant* one -- a dynamic `attention_bias` never
+// blocks the match here, exactly like pruning.py's own
+// `_match_attention_weight_only`, which always passes
+// `value_info_by_name=None`: unstructured/magnitude pruning never changes
+// `num_heads` or any shape at all, so a per-head `attention_bias`'s own
+// shape can never go stale under it) even though nothing here reads
+// `num_heads` itself for masking -- so a node this module's own structural
+// head-pruning family would decline as malformed is declined the same way
+// here. `do_rotary`/a constant `past`/`qkv_hidden_sizes` presence are
+// DecoderMaskedSelfAttention-only concerns, checked below only for that op.
+inline bool MatchAttentionQkvWeightOnly(Node* n, AttentionQkvMatch& info) {
+  if (!IsMicrosoftAttentionOp(n) || n->inputs().size() < 2) {
+    return false;
+  }
+  const bool is_dmsa = CheckKind(n, "DecoderMaskedSelfAttention");
+  const Tensor* w_t = FetchConstantTensor(n->input(1));
+  if (w_t == nullptr || !IsSupportedFloatDtype(w_t->elem_type()) ||
+      w_t->sizes().size() != 2) {
+    return false;
+  }
+  const int64_t total_n = w_t->sizes()[1];
+
+  // bias (input 2), optional.
+  if (n->inputs().size() > 2 && n->input(2)->node()->kind() != kUndefined) {
+    const Tensor* b_t = FetchConstantTensor(n->input(2));
+    if (b_t == nullptr || !IsSupportedFloatDtype(b_t->elem_type()) ||
+        b_t->sizes().size() != 1 || b_t->sizes()[0] != total_n) {
+      return false;
+    }
+  }
+
+  // DecoderMaskedSelfAttention's own `past` (input 4) is REQUIRED by its
+  // schema and holds combined key+value decode state -- a real export
+  // always leaves it dynamic (runtime state), but a hand-built graph could
+  // bind a constant there; this matcher has no established/tested slicing
+  // path for that (mirrors pruning.py's own `_match_attention_producer`
+  // exactly, even though this pass never slices anything at all -- the
+  // point is matching the same node set, not this matcher's own slicing
+  // ability), so a constant `past` conservatively declines the whole match.
+  if (is_dmsa && n->inputs().size() > 4 &&
+      n->input(4)->node()->kind() != kUndefined) {
+    if (FetchConstantTensor(n->input(4)) != nullptr) {
+      return false;
+    }
+  }
+
+  int64_t num_heads = 0;
+  if (!GetValueFromAttr(n, "num_heads", num_heads) || num_heads <= 0) {
+    return false;
+  }
+
+  int64_t do_rotary = 0;
+  GetValueFromAttr(n, "do_rotary", do_rotary);  // optional; default 0
+  if (is_dmsa && do_rotary) {
+    return false;  // fused RoPE -- no confirmed per-head-safe path here
+  }
+
+  std::vector<int64_t> qkv_hidden_sizes;
+  const bool has_qkv_hidden_sizes =
+      GetValueFromAttr(n, "qkv_hidden_sizes", qkv_hidden_sizes);
+  if (is_dmsa && has_qkv_hidden_sizes) {
+    // Not a real attribute on DecoderMaskedSelfAttention's own schema --
+    // decline conservatively rather than guess what a hand-edited graph
+    // carrying it anyway might have intended.
+    return false;
+  }
+
+  int64_t nq, nk, nv;
+  if (has_qkv_hidden_sizes) {
+    if (qkv_hidden_sizes.size() != 3) {
+      return false;
+    }
+    nq = qkv_hidden_sizes[0];
+    nk = qkv_hidden_sizes[1];
+    nv = qkv_hidden_sizes[2];
+  } else {
+    // Schema default: Q/K/V evenly split the merged width.
+    if (total_n % 3 != 0) {
+      return false;
+    }
+    nq = nk = nv = total_n / 3;
+  }
+  if (nq <= 0 || nk <= 0 || nv <= 0 || nq + nk + nv != total_n ||
+      nq % num_heads || nk % num_heads || nv % num_heads) {
+    return false;
+  }
+
+  // attention_bias (input 5), optional.
+  if (n->inputs().size() > 5 && n->input(5)->node()->kind() != kUndefined) {
+    const Tensor* bias_t = FetchConstantTensor(n->input(5));
+    if (bias_t != nullptr) {
+      int64_t numel = 1;
+      for (int64_t d : bias_t->sizes()) {
+        numel *= d;
+      }
+      if (numel != 0 && !HeadBiasAxisIsSafe(bias_t->sizes(), num_heads)) {
+        return false;  // doesn't statically resolve -- decline rather than
+                       // guess
+      }
+    }
+    // A dynamic (non-constant) attention_bias is always OK here -- see this
+    // function's own doc comment.
+  }
+
+  info.x = n->input(0);
+  info.w = n->input(1);
+  return true;
+}
+
+// ReadWeightNKF64 reads a 2-D MatMul/Gemm/Attention weight into a flat
+// row-major [N, K] (output channel first) buffer, used here so
+// SparsityMaskRowMajor/NMMaskRowMajor's per-row grouping lines up with
+// output channels regardless of the weight's own on-disk (transposed or
+// not) layout.
 
 struct MagnitudePruningMatMul final : public PredicateBasedPass {
   explicit MagnitudePruningMatMul()
@@ -160,7 +686,7 @@ struct MagnitudePruningMatMul final : public PredicateBasedPass {
       return false;
     }
     const Tensor* w_t = FetchConstantTensor(info.w);
-    if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+    if (w_t == nullptr || !IsSupportedFloatDtype(w_t->elem_type()) ||
         w_t->sizes().size() != 2) {
       return false;
     }
@@ -168,9 +694,9 @@ struct MagnitudePruningMatMul final : public PredicateBasedPass {
     const int64_t dim1 = w_t->sizes()[1];
     const int64_t rows = info.weight_transposed ? dim0 : dim1;
     const int64_t cols = info.weight_transposed ? dim1 : dim0;
-    const std::vector<float> w_nk = ReadWeightNK(*w_t, info.weight_transposed);
-    return MagnitudePruningWouldChange(w_nk, rows, cols,
-                                       MagnitudePruningSparsity());
+    const std::vector<double> w_nk =
+        ReadWeightNKF64(*w_t, info.weight_transposed);
+    return MagnitudePruningWouldChange(w_nk, rows, cols);
   }
 
   bool runTransform(Node* n, Graph& graph,
@@ -181,7 +707,7 @@ struct MagnitudePruningMatMul final : public PredicateBasedPass {
       return false;
     }
     const Tensor* w_t = FetchConstantTensor(info.w);
-    if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+    if (w_t == nullptr || !IsSupportedFloatDtype(w_t->elem_type()) ||
         w_t->sizes().size() != 2) {
       return false;
     }
@@ -191,27 +717,15 @@ struct MagnitudePruningMatMul final : public PredicateBasedPass {
     const int64_t rows = info.weight_transposed ? dim0 : dim1;
     const int64_t cols = info.weight_transposed ? dim1 : dim0;
 
-    std::vector<float> w_nk = ReadWeightNK(*w_t, info.weight_transposed);
-    std::vector<float> importance(w_nk.size());
-    for (size_t i = 0; i < w_nk.size(); ++i) {
-      importance[i] = std::fabs(w_nk[i]);
-    }
-    const std::vector<bool> mask = SparsityMaskRowMajor(
-        importance, rows, cols, MagnitudePruningSparsity());
+    std::vector<double> w_nk = ReadWeightNKF64(*w_t, info.weight_transposed);
+    const std::vector<bool> mask =
+        MagnitudePruningMaskRowMajor(w_nk, rows, cols);
     ApplyMaskRowMajor(w_nk, mask);
+    const std::vector<double> out_flat =
+        WeightNkToOriginalF64(w_nk, dim0, dim1, info.weight_transposed);
 
     Tensor w_pruned;
-    w_pruned.elem_type() = TensorProto_DataType_FLOAT;
-    w_pruned.sizes() = {dim0, dim1};
-    std::vector<float> out_data(static_cast<size_t>(dim0 * dim1));
-    for (int64_t i = 0; i < dim0; ++i) {
-      for (int64_t j = 0; j < dim1; ++j) {
-        out_data[static_cast<size_t>(i * dim1 + j)] =
-            info.weight_transposed ? w_nk[static_cast<size_t>(i * cols + j)]
-                                   : w_nk[static_cast<size_t>(j * cols + i)];
-      }
-    }
-    w_pruned.floats() = std::move(out_data);
+    WriteF64FlatAsTensor(w_pruned, w_t->elem_type(), w_t->sizes(), out_flat);
 
     Value* w_pruned_v = graph.addInitializerAndCreateValue(w_pruned);
     n->replaceInput(1, w_pruned_v);
@@ -231,7 +745,7 @@ struct MagnitudePruningConv final : public PredicateBasedPass {
       return false;
     }
     const Tensor* w_t = FetchConstantTensor(info.w);
-    if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+    if (w_t == nullptr || !IsSupportedFloatDtype(w_t->elem_type()) ||
         w_t->sizes().size() != 4) {
       return false;
     }
@@ -240,9 +754,8 @@ struct MagnitudePruningConv final : public PredicateBasedPass {
     for (size_t i = 1; i < w_t->sizes().size(); ++i) {
       cols *= w_t->sizes()[i];
     }
-    const std::vector<float> data = ReadFloatTensorFlat(*w_t);
-    return MagnitudePruningWouldChange(data, rows, cols,
-                                       MagnitudePruningSparsity());
+    const std::vector<double> data = ReadTensorAsF64Flat(*w_t);
+    return MagnitudePruningWouldChange(data, rows, cols);
   }
 
   bool runTransform(Node* n, Graph& graph,
@@ -253,7 +766,7 @@ struct MagnitudePruningConv final : public PredicateBasedPass {
       return false;
     }
     const Tensor* w_t = FetchConstantTensor(info.w);
-    if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+    if (w_t == nullptr || !IsSupportedFloatDtype(w_t->elem_type()) ||
         w_t->sizes().size() != 4) {
       return false;
     }
@@ -267,23 +780,268 @@ struct MagnitudePruningConv final : public PredicateBasedPass {
       cols *= w_t->sizes()[i];
     }
 
-    std::vector<float> data = ReadFloatTensorFlat(*w_t);
-    std::vector<float> importance(data.size());
-    for (size_t i = 0; i < data.size(); ++i) {
-      importance[i] = std::fabs(data[i]);
-    }
-    const std::vector<bool> mask = SparsityMaskRowMajor(
-        importance, rows, cols, MagnitudePruningSparsity());
+    std::vector<double> data = ReadTensorAsF64Flat(*w_t);
+    const std::vector<bool> mask =
+        MagnitudePruningMaskRowMajor(data, rows, cols);
     ApplyMaskRowMajor(data, mask);
 
     Tensor w_pruned;
-    w_pruned.elem_type() = TensorProto_DataType_FLOAT;
-    w_pruned.sizes() = w_t->sizes();
-    w_pruned.floats() = std::move(data);
+    WriteF64FlatAsTensor(w_pruned, w_t->elem_type(), w_t->sizes(), data);
 
     Value* w_pruned_v = graph.addInitializerAndCreateValue(w_pruned);
     n->replaceInput(1, w_pruned_v);
     return true;
+  }
+};
+
+struct MagnitudePruningAttention final : public PredicateBasedPass {
+  explicit MagnitudePruningAttention()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+  std::string getPassName() const override {
+    return "magnitude_pruning_attention";
+  }
+
+  bool patternMatchPredicate(Node* n) override {
+    AttentionQkvMatch info;
+    if (!MatchAttentionQkvWeightOnly(n, info)) {
+      return false;
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    if (w_t == nullptr) {
+      return false;  // defensive: the matcher above already confirmed this
+    }
+    // Attention's merged QKV weight has no transpose attribute of its own --
+    // it is already [K, N]-shaped by construction (mirrors pruning.py's own
+    // `_match_attention_weight_only` doc comment) -- so it is read exactly
+    // like a non-transposed MatMul weight.
+    const int64_t dim0 = w_t->sizes()[0];
+    const int64_t dim1 = w_t->sizes()[1];
+    const std::vector<double> w_nk =
+        ReadWeightNKF64(*w_t, /*transposed=*/false);
+    return MagnitudePruningWouldChange(w_nk, dim1, dim0);
+  }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+    AttentionQkvMatch info;
+    if (!MatchAttentionQkvWeightOnly(n, info)) {
+      return false;
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    if (w_t == nullptr) {
+      return false;
+    }
+    const int64_t dim0 = w_t->sizes()[0];
+    const int64_t dim1 = w_t->sizes()[1];
+
+    std::vector<double> w_nk = ReadWeightNKF64(*w_t, /*transposed=*/false);
+    const std::vector<bool> mask =
+        MagnitudePruningMaskRowMajor(w_nk, dim1, dim0);
+    ApplyMaskRowMajor(w_nk, mask);
+    const std::vector<double> out_flat =
+        WeightNkToOriginalF64(w_nk, dim0, dim1, /*transposed=*/false);
+
+    Tensor w_pruned;
+    WriteF64FlatAsTensor(w_pruned, w_t->elem_type(), w_t->sizes(), out_flat);
+
+    Value* w_pruned_v = graph.addInitializerAndCreateValue(w_pruned);
+    n->replaceInput(1, w_pruned_v);
+    return true;
+  }
+};
+
+// --- global_sparsity mode --------------------------------------------------
+//
+// Companion to MagnitudePruningMatMul/Conv/Attention's own per-layer
+// sparsity-ratio masking (MagnitudePruningMaskRowMajor's own per-row rule,
+// applied independently per layer): pools every matched layer's own |W|
+// entries across the WHOLE model (every graph -- top-level and every nested
+// If/Loop/Scan/BeamSearch-family subgraph body, recursively, exactly like
+// pruning.py's own `_iter_subgraphs` -- into ONE combined ranking) into one
+// flat array, picks a single keep-count from MagnitudePruningSparsity()'s
+// fraction of the total pooled entry count, and zeros exactly the
+// lowest-scoring entries wherever they land -- mirrors pruning.py's own
+// `_apply_global_unstructured_pruning` exactly (including its "no per-row
+// floor" property: a whole row, or even a whole layer's weight, can
+// legitimately end up all-zero here). Incompatible with N:M mode -- enforced
+// once by PruneMagnitude (pruning_entry.cpp) before this pass ever runs, so
+// this pass itself only ever reads MagnitudePruningSparsity().
+//
+// Implemented as a single FullGraphBasedPass (not three PredicateBasedPass
+// instances) because the global threshold genuinely needs every matched
+// layer's importance gathered up front before any single layer's mask can
+// be decided -- unlike the per-layer passes above, whose predicate/transform
+// only ever needs that one node's own weight.
+struct MagnitudePruningGlobal final : public FullGraphBasedPass {
+  explicit MagnitudePruningGlobal()
+      : FullGraphBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+  std::string getPassName() const override {
+    return "magnitude_pruning_global";
+  }
+  PassAnalysisType getPassAnalysisType() const override {
+    return PassAnalysisType::Empty;
+  }
+
+  struct Entry {
+    Node* node = nullptr;  // consumer whose weight input (index 1) is replaced
+    bool is_conv = false;
+    bool transposed = false;  // MatMul/Attention only; Conv is never transposed
+    int32_t elem_type = TensorProto_DataType_UNDEFINED;
+    std::vector<int64_t> sizes;  // original on-disk tensor sizes
+    int64_t dim0 = 0, dim1 = 0;  // MatMul/Attention only (2-D on-disk shape)
+    std::vector<double> w_nk;    // row-major [rows, cols], SparsityMaskRowMajor
+                                 // layout
+    std::vector<double> importance;  // |w_nk|, same shape/layout
+  };
+
+  // Every Graph reachable from `g`, including `g` itself, recursively
+  // through every node's own GRAPH-/GRAPHS-typed attribute -- mirrors
+  // pruning.py's own `_iter_subgraphs` (keyed on attribute *kind*, not a
+  // per-op-name allowlist, so a future op with another graph-typed
+  // attribute needs no update here either).
+  void CollectGraphs(Graph& g, std::vector<Graph*>& out) {
+    out.push_back(&g);
+    for (Node* n : g.nodes()) {
+      DescendOnGraphAttributesUnconstrained(
+          n, [&](Graph& sub) { CollectGraphs(sub, out); });
+    }
+  }
+
+  std::shared_ptr<PostPassAnalysis> runPass(Graph& graph) override {
+    std::vector<Graph*> graphs;
+    CollectGraphs(graph, graphs);
+
+    std::vector<Entry> entries;
+    for (Graph* g : graphs) {
+      for (Node* n : g->nodes()) {
+        MatMulLikeInfo mm;
+        ConvInfo conv;
+        AttentionQkvMatch attn;
+        if (MatchMatMulLike(n, mm)) {
+          const Tensor* w_t = FetchConstantTensor(mm.w);
+          if (w_t == nullptr || !IsSupportedFloatDtype(w_t->elem_type()) ||
+              w_t->sizes().size() != 2) {
+            continue;
+          }
+          Entry e;
+          e.node = n;
+          e.is_conv = false;
+          e.transposed = mm.weight_transposed;
+          e.elem_type = w_t->elem_type();
+          e.sizes = w_t->sizes();
+          e.dim0 = w_t->sizes()[0];
+          e.dim1 = w_t->sizes()[1];
+          e.w_nk = ReadWeightNKF64(*w_t, e.transposed);
+          e.importance.resize(e.w_nk.size());
+          for (size_t i = 0; i < e.w_nk.size(); ++i) {
+            e.importance[i] = std::fabs(e.w_nk[i]);
+          }
+          entries.push_back(std::move(e));
+        } else if (MatchConv(n, conv)) {
+          const Tensor* w_t = FetchConstantTensor(conv.w);
+          if (w_t == nullptr || !IsSupportedFloatDtype(w_t->elem_type()) ||
+              w_t->sizes().size() != 4) {
+            continue;
+          }
+          Entry e;
+          e.node = n;
+          e.is_conv = true;
+          e.elem_type = w_t->elem_type();
+          e.sizes = w_t->sizes();
+          e.w_nk = ReadTensorAsF64Flat(*w_t);
+          e.importance.resize(e.w_nk.size());
+          for (size_t i = 0; i < e.w_nk.size(); ++i) {
+            e.importance[i] = std::fabs(e.w_nk[i]);
+          }
+          entries.push_back(std::move(e));
+        } else if (MatchAttentionQkvWeightOnly(n, attn)) {
+          const Tensor* w_t = FetchConstantTensor(attn.w);
+          if (w_t == nullptr || !IsSupportedFloatDtype(w_t->elem_type()) ||
+              w_t->sizes().size() != 2) {
+            continue;
+          }
+          Entry e;
+          e.node = n;
+          e.is_conv = false;
+          e.transposed = false;
+          e.elem_type = w_t->elem_type();
+          e.sizes = w_t->sizes();
+          e.dim0 = w_t->sizes()[0];
+          e.dim1 = w_t->sizes()[1];
+          e.w_nk = ReadWeightNKF64(*w_t, /*transposed=*/false);
+          e.importance.resize(e.w_nk.size());
+          for (size_t i = 0; i < e.w_nk.size(); ++i) {
+            e.importance[i] = std::fabs(e.w_nk[i]);
+          }
+          entries.push_back(std::move(e));
+        }
+      }
+    }
+
+    if (!entries.empty()) {
+      int64_t total = 0;
+      for (const Entry& e : entries) {
+        total += static_cast<int64_t>(e.importance.size());
+      }
+
+      const double sparsity = MagnitudePruningSparsity();
+      int64_t keep_count =
+          static_cast<int64_t>(std::nearbyint(total * (1.0 - sparsity)));
+      keep_count = std::max<int64_t>(0, std::min<int64_t>(keep_count, total));
+      const int64_t drop_count = total - keep_count;
+
+      std::vector<bool> drop_flat(static_cast<size_t>(total), false);
+      if (drop_count > 0) {
+        std::vector<double> pooled(static_cast<size_t>(total));
+        int64_t off = 0;
+        for (const Entry& e : entries) {
+          std::copy(e.importance.begin(), e.importance.end(),
+                    pooled.begin() + off);
+          off += static_cast<int64_t>(e.importance.size());
+        }
+        std::vector<int64_t> order(static_cast<size_t>(total));
+        for (int64_t i = 0; i < total; ++i) {
+          order[static_cast<size_t>(i)] = i;
+        }
+        // Stable sort, ascending -- mirrors pruning.py's own
+        // `np.argsort(pooled, kind="stable")`: ties at the cutoff are broken
+        // by pooled order (entries order, then each entry's own row-major
+        // flatten order), so `keep_count` is always met exactly.
+        std::stable_sort(order.begin(), order.end(), [&](int64_t a, int64_t b) {
+          return pooled[static_cast<size_t>(a)] <
+                 pooled[static_cast<size_t>(b)];
+        });
+        for (int64_t i = 0; i < drop_count; ++i) {
+          drop_flat[static_cast<size_t>(order[static_cast<size_t>(i)])] = true;
+        }
+      }
+
+      int64_t off = 0;
+      for (Entry& e : entries) {
+        const int64_t size = static_cast<int64_t>(e.w_nk.size());
+        for (int64_t i = 0; i < size; ++i) {
+          if (drop_flat[static_cast<size_t>(off + i)]) {
+            e.w_nk[static_cast<size_t>(i)] = 0.0;
+          }
+        }
+        off += size;
+
+        const std::vector<double> out_flat =
+            e.is_conv
+                ? e.w_nk
+                : WeightNkToOriginalF64(e.w_nk, e.dim0, e.dim1, e.transposed);
+        Tensor w_pruned;
+        WriteF64FlatAsTensor(w_pruned, e.elem_type, e.sizes, out_flat);
+        Value* w_pruned_v =
+            e.node->owningGraph()->addInitializerAndCreateValue(w_pruned);
+        e.node->replaceInput(1, w_pruned_v);
+      }
+    }
+
+    return std::shared_ptr<PostPassAnalysis>(new PostPassAnalysis());
   }
 };
 

--- a/onnxsim/passes/quarot.h
+++ b/onnxsim/passes/quarot.h
@@ -28,8 +28,9 @@
 // changes too. Only the common, unambiguous shape is handled: a MatMul, or
 // a Gemm with transA=0, alpha=1 and beta=1, whose weight (input 1) is a
 // constant 2-D float32 tensor whose reduction dimension K is divisible by
-// kBlockSize, on an opset >= 21 model (INT4 tensors and DequantizeLinear's
-// block_size attribute both need it). Everything else is left alone.
+// the configured block size (QuarotBlockSize(), 32 by default), on an
+// opset >= 21 model (INT4 tensors and DequantizeLinear's block_size
+// attribute both need it). Everything else is left alone.
 //
 // Scope note: this reuses a fresh Haar-random rotation per matched layer
 // (random_orthogonal.h), matching quarot.py's/spinquant.py's own scope --
@@ -74,10 +75,27 @@ inline uint64_t& QuarotSeed() {
   return seed;
 }
 
-struct Quarot final : public PredicateBasedPass {
-  static constexpr int64_t kBlockSize = 32;
-  static constexpr float kEpsilon = 1e-12f;
+// Weight quantization block size along K (elements per quantization block
+// sharing one scale) -- read/written the same way QuarotSeed() is, and for
+// the same reason: OptimizeFixed's pass-name-list interface has no other way
+// to carry a parameter into this singleton pass. Set by ApplyQuarot
+// (quantize_entry.cpp) immediately before calling OptimizeFixed. Mirrors
+// quarot.py's own ``block_size`` parameter.
+inline int64_t& QuarotBlockSize() {
+  static int64_t block_size = 32;
+  return block_size;
+}
 
+// Floor applied to a token's own max-abs rotated-activation value before
+// using it as a quantization scale, avoiding a divide-by-zero on an
+// all-zero token. Read/written the same way QuarotSeed() is. Mirrors
+// quarot.py's own ``epsilon`` parameter.
+inline float& QuarotEpsilon() {
+  static float epsilon = 1e-12f;
+  return epsilon;
+}
+
+struct Quarot final : public PredicateBasedPass {
   explicit Quarot()
       : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
                            PassOptimizationType::Compute) {}
@@ -102,7 +120,7 @@ struct Quarot final : public PredicateBasedPass {
     }
     const int64_t channel_axis = info.weight_transposed ? 0 : 1;
     const int64_t K = w_t->sizes()[1 - channel_axis];
-    return K % kBlockSize == 0;
+    return K % QuarotBlockSize() == 0;
   }
 
   bool runTransform(Node* n, Graph& graph,
@@ -125,10 +143,12 @@ struct Quarot final : public PredicateBasedPass {
         info.weight_transposed ? w_t->sizes()[0] : w_t->sizes()[1];
     const int64_t K =
         info.weight_transposed ? w_t->sizes()[1] : w_t->sizes()[0];
-    if (K % kBlockSize != 0) {
+    const int64_t block_size = QuarotBlockSize();
+    const float epsilon = QuarotEpsilon();
+    if (K % block_size != 0) {
       return false;
     }
-    const int64_t num_blocks = K / kBlockSize;
+    const int64_t num_blocks = K / block_size;
 
     // w_nk: [N, K], output channel first.
     const std::vector<float> w_nk = ReadWeightNK(*w_t, info.weight_transposed);
@@ -161,8 +181,8 @@ struct Quarot final : public PredicateBasedPass {
     for (int64_t r = 0; r < N; ++r) {
       for (int64_t blk = 0; blk < num_blocks; ++blk) {
         float max_abs = 0.0f;
-        for (int64_t j = 0; j < kBlockSize; ++j) {
-          const int64_t c = blk * kBlockSize + j;
+        for (int64_t j = 0; j < block_size; ++j) {
+          const int64_t c = blk * block_size + j;
           max_abs = std::max(max_abs,
                              static_cast<float>(std::fabs(
                                  w_tilde_nk[static_cast<size_t>(r * K + c)])));
@@ -174,7 +194,7 @@ struct Quarot final : public PredicateBasedPass {
     std::vector<int8_t> codes_kn(static_cast<size_t>(K * N));
     for (int64_t r = 0; r < N; ++r) {
       for (int64_t c = 0; c < K; ++c) {
-        const int64_t blk = c / kBlockSize;
+        const int64_t blk = c / block_size;
         const float s = scale_kn[static_cast<size_t>(blk * N + r)];
         const float q = std::round(
             static_cast<float>(w_tilde_nk[static_cast<size_t>(r * K + c)]) / s);
@@ -182,10 +202,12 @@ struct Quarot final : public PredicateBasedPass {
             static_cast<int8_t>(std::clamp(q, -7.0f, 7.0f));
       }
     }
-    // Pack two int4 codes per byte, low nibble first (K * N is always even:
-    // K is a multiple of kBlockSize=32) -- see
+    // Pack two int4 codes per byte, low nibble first -- see
     // TryQuantizeWeightBlockwiseInt4InPlace's identical packing for why this
-    // bypasses the typed int32_data field.
+    // bypasses the typed int32_data field. ``(numel + 1) / 2`` rounds up so
+    // this stays correct even for an odd ``block_size`` that leaves K * N
+    // odd, unlike quarot.py's own ``_pack_int4`` (adaround.py), which
+    // assumes an even count.
     const int64_t numel = K * N;
     std::string packed(static_cast<size_t>((numel + 1) / 2), '\0');
     for (int64_t i = 0; i < numel; ++i) {
@@ -220,7 +242,7 @@ struct Quarot final : public PredicateBasedPass {
 
     Tensor eps_t;
     eps_t.elem_type() = TensorProto_DataType_FLOAT;
-    eps_t.floats() = {kEpsilon};
+    eps_t.floats() = {epsilon};
     Value* eps_v = graph.addInitializerAndCreateValue(eps_t);
 
     Tensor seven_t;
@@ -291,7 +313,7 @@ struct Quarot final : public PredicateBasedPass {
     w_dequant->addInput(codes_v);
     w_dequant->addInput(scale_v);
     w_dequant->i_(kaxis, 0);
-    w_dequant->i_(Symbol("block_size"), kBlockSize);
+    w_dequant->i_(Symbol("block_size"), block_size);
     w_dequant->insertBefore(n);
     w_dequant->output()->setElemType(TensorProto_DataType_FLOAT);
     w_dequant->output()->setSizes({Dimension(K), Dimension(N)});

--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -2605,49 +2605,27 @@ def apply_magnitude_pruning(
     -- consistent with "global" meaning the whole model, not just its
     top-level graph -- so `sparsity`'s fraction is chosen from, and applied
     to, that combined pool.
+
+    This pure-Python implementation has been retired in favor of the
+    verified-full-parity C++ port -- this is now a thin alias for
+    :func:`onnxsim.prune_magnitude_cpp` (``onnxsim/passes/magnitude_pruning.h``'s
+    own ``MagnitudePruningMatMul``/``MagnitudePruningConv``/
+    ``MagnitudePruningAttention``/``MagnitudePruningGlobal``), forwarding
+    every argument unchanged. Imported lazily (inside the function body, not
+    at module scope) to avoid a circular import: ``onnxsim.onnx_simplifier``
+    already imports from this module (:class:`EmbeddingPruningResult`), so
+    importing it back at module load time here would deadlock the import
+    machinery.
     """
-    _validate_pattern(sparsity, n, m)
-    if global_sparsity and n is not None:
-        raise ValueError(
-            "global_sparsity is not supported together with N:M pruning "
-            "(n/m) -- see apply_magnitude_pruning's own docstring"
-        )
-    if isinstance(model, str):
-        model = onnx.load(model, load_external_data=False)
+    from onnxsim.onnx_simplifier import prune_magnitude_cpp
 
-    out = onnx.ModelProto()
-    out.CopyFrom(model)
-
-    if global_sparsity:
-        entries = []
-        for graph in _iter_subgraphs(out.graph):
-            initializer_map = _constant_map(graph)
-            for _, _, w_name, weight_transposed, is_conv in _candidates(graph):
-                w_init = initializer_map[w_name]
-                w = _to_f64(w_init)
-                w_nk = _weight_to_nk(w, weight_transposed, is_conv)
-                entries.append(
-                    (w_init, weight_transposed, is_conv, w.shape, w_nk, np.abs(w_nk))
-                )
-        _apply_global_unstructured_pruning(entries, sparsity)
-        return out
-
-    for graph in _iter_subgraphs(out.graph):
-        initializer_map = _constant_map(graph)
-        for _, _, w_name, weight_transposed, is_conv in _candidates(graph):
-            w_init = initializer_map[w_name]
-
-            def importance_of_nk(w_nk, n=n, m=m, sparsity=sparsity):
-                importance = np.abs(w_nk)
-                return (
-                    _nm_mask(importance, n, m)
-                    if n is not None
-                    else _sparsity_mask(importance, sparsity)
-                )
-
-            _prune_weight(w_init, weight_transposed, importance_of_nk, is_conv=is_conv)
-
-    return out
+    return prune_magnitude_cpp(
+        model,
+        sparsity=sparsity,
+        n=n,
+        m=m,
+        global_sparsity=global_sparsity,
+    )
 
 
 def _wanda_norm_for_candidate(

--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -34349,51 +34349,26 @@ def apply_embedding_vocab_pruning(
     :func:`_match_embedding_chain_any_graph`'s own docstring for exactly
     how the "exactly one eligible producer, or decline" rule is applied
     *across the whole model* now, not just one single graph.
+
+    This pure-Python implementation has been retired in favor of the
+    verified-full-parity C++ port (including both of ``com.microsoft::
+    GatherBlockQuantized``'s own sub-8-bit packing conventions -- see
+    ``onnxsim/structured_pruning_entry.cpp``'s own "Embedding vocabulary
+    pruning" section comment) -- this is now a thin alias for
+    :func:`onnxsim.apply_embedding_vocab_pruning_cpp`, forwarding every
+    argument unchanged. Imported lazily (inside the function body, not at
+    module scope) to avoid a circular import: ``onnxsim.onnx_simplifier``
+    already imports from this module (:class:`EmbeddingPruningResult`), so
+    importing it back at module load time here would deadlock the import
+    machinery.
     """
-    if (keep_token_ids is None) == (drop_token_ids is None):
-        raise ValueError(
-            "give exactly one of keep_token_ids or drop_token_ids, not both/neither"
-        )
-    if isinstance(model, str):
-        model = onnx.load(model, load_external_data=False)
+    from onnxsim.onnx_simplifier import apply_embedding_vocab_pruning_cpp
 
-    out = onnx.ModelProto()
-    out.CopyFrom(model)
-
-    graph, chain = _match_embedding_chain_any_graph(out.graph, input_name)
-    if chain is None:
-        return EmbeddingPruningResult(model=out, matched=False)
-    assert graph is not None
-
-    vocab_size = chain.vocab_size
-    if keep_token_ids is not None:
-        keep_set = {int(i) for i in keep_token_ids}
-    else:
-        assert drop_token_ids is not None
-        drop_set = {int(i) for i in drop_token_ids}
-        bad_drop = sorted(i for i in drop_set if not (0 <= i < vocab_size))
-        if bad_drop:
-            raise ValueError(
-                f"drop_token_ids out of range [0, {vocab_size}): {bad_drop[:5]}"
-            )
-        keep_set = set(range(vocab_size)) - drop_set
-    bad_keep = sorted(i for i in keep_set if not (0 <= i < vocab_size))
-    if bad_keep:
-        raise ValueError(
-            f"keep_token_ids out of range [0, {vocab_size}): {bad_keep[:5]}"
-        )
-    if not keep_set:
-        raise ValueError("keep_token_ids resolves to an empty vocabulary")
-    keep_ids = sorted(keep_set)
-
-    _apply_embedding_vocab_prune(graph, chain, keep_ids)
-    id_map = {old: new for new, old in enumerate(keep_ids)}
-    return EmbeddingPruningResult(
-        model=out,
-        matched=True,
-        kept_token_ids=keep_ids,
-        id_map=id_map,
-        lm_head_pruned=chain.lm_head is not None,
+    return apply_embedding_vocab_pruning_cpp(
+        model,
+        keep_token_ids=keep_token_ids,
+        drop_token_ids=drop_token_ids,
+        input_name=input_name,
     )
 
 
@@ -34527,49 +34502,26 @@ def apply_embedding_vocab_magnitude_pruning(
     "Subgraph recursion" section comment) exactly the same way
     :func:`apply_embedding_vocab_pruning` is -- see
     :func:`_match_embedding_chain_any_graph`'s own docstring.
+
+    This pure-Python implementation has been retired in favor of the
+    verified-full-parity C++ port (including both of ``com.microsoft::
+    GatherBlockQuantized``'s own sub-8-bit packing conventions -- see
+    ``onnxsim/structured_pruning_entry.cpp``'s own "Embedding vocabulary
+    pruning" section comment) -- this is now a thin alias for
+    :func:`onnxsim.apply_embedding_vocab_magnitude_pruning_cpp`, forwarding
+    every argument unchanged. Imported lazily (inside the function body, not
+    at module scope) to avoid a circular import: ``onnxsim.onnx_simplifier``
+    already imports from this module (:class:`EmbeddingPruningResult`), so
+    importing it back at module load time here would deadlock the import
+    machinery.
     """
-    if not (0.0 <= sparsity < 1.0):
-        raise ValueError(f"sparsity must be in [0, 1), got {sparsity}")
-    if isinstance(model, str):
-        model = onnx.load(model, load_external_data=False)
+    from onnxsim.onnx_simplifier import apply_embedding_vocab_magnitude_pruning_cpp
 
-    out = onnx.ModelProto()
-    out.CopyFrom(model)
-
-    graph, chain = _match_embedding_chain_any_graph(out.graph, input_name)
-    if chain is None:
-        return EmbeddingPruningResult(model=out, matched=False)
-    assert graph is not None
-
-    vocab_size = chain.vocab_size
-    initializer_map = _constant_map(graph)
-    importance = _embedding_vocab_importance(chain, initializer_map)
-
-    protect = {int(i) for i in (protect_token_ids or ())}
-    bad_protect = sorted(i for i in protect if not (0 <= i < vocab_size))
-    if bad_protect:
-        raise ValueError(
-            f"protect_token_ids out of range [0, {vocab_size}): {bad_protect[:5]}"
-        )
-
-    keep_count = max(1, min(vocab_size, round(vocab_size * (1.0 - sparsity))))
-    keep_count = max(keep_count, len(protect))
-    order = np.argsort(-importance)
-    keep_set = set(protect)
-    for idx in order:
-        if len(keep_set) >= keep_count:
-            break
-        keep_set.add(int(idx))
-    keep_ids = sorted(keep_set)
-
-    _apply_embedding_vocab_prune(graph, chain, keep_ids)
-    id_map = {old: new for new, old in enumerate(keep_ids)}
-    return EmbeddingPruningResult(
-        model=out,
-        matched=True,
-        kept_token_ids=keep_ids,
-        id_map=id_map,
-        lm_head_pruned=chain.lm_head is not None,
+    return apply_embedding_vocab_magnitude_pruning_cpp(
+        model,
+        sparsity=sparsity,
+        protect_token_ids=protect_token_ids,
+        input_name=input_name,
     )
 
 

--- a/onnxsim/pruning_entry.cpp
+++ b/onnxsim/pruning_entry.cpp
@@ -2,6 +2,7 @@
 
 #include <onnx/onnx_pb.h>
 
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -11,23 +12,54 @@
 #include "onnxoptimizer/optimize.h"
 #include "passes/magnitude_pruning.h"
 
-onnx::ModelProto PruneMagnitude(const onnx::ModelProto& model,
-                                double sparsity) {
-  if (!(sparsity >= 0.0 && sparsity < 1.0)) {
+onnx::ModelProto PruneMagnitude(const onnx::ModelProto& model, double sparsity,
+                                const std::optional<int64_t>& n,
+                                const std::optional<int64_t>& m,
+                                bool global_sparsity) {
+  // Mirrors pruning.py's own `_validate_pattern` exactly: n/m must be given
+  // together (N:M mode) or not at all, and `sparsity` is only validated when
+  // n/m are absent (it is simply unused, unvalidated, in N:M mode).
+  if (n.has_value() != m.has_value()) {
+    throw std::invalid_argument(
+        "PruneMagnitude: n and m must be given together (N:M pruning) or "
+        "not at all");
+  }
+  if (n.has_value()) {
+    if (!(*n > 0 && *n <= *m)) {
+      throw std::invalid_argument(
+          "PruneMagnitude: require 0 < n <= m, got n=" + std::to_string(*n) +
+          ", m=" + std::to_string(*m));
+    }
+  } else if (!(sparsity >= 0.0 && sparsity < 1.0)) {
     throw std::invalid_argument(
         "PruneMagnitude: sparsity must be in [0, 1), got " +
         std::to_string(sparsity));
   }
+  if (global_sparsity && n.has_value()) {
+    throw std::invalid_argument(
+        "PruneMagnitude: global_sparsity is not supported together with "
+        "N:M pruning (n/m) -- see PruneMagnitude's own declaration comment");
+  }
+
   PrepareSchemasForDebug(model);
-  // Registers magnitude_pruning_matmul/_conv (idempotent) into
-  // onnxoptimizer's registry so OptimizeFixed can find them by name below.
+  // Registers magnitude_pruning_matmul/_conv/_attention/_global (idempotent)
+  // into onnxoptimizer's registry so OptimizeFixed can find them by name
+  // below.
   onnxsim::RegisterCustomOptimizerPasses();
-  // magnitude_pruning_matmul/_conv read this the same way quantize_fp16
-  // reads QuantizeFp16KeepIoTypes() -- OptimizeFixed's pass-name list has no
-  // way to carry a parameter directly.
-  ONNX_NAMESPACE::optimization::onnxsim_passes::MagnitudePruningSparsity() =
-      sparsity;
+  // These read the statics below the same way quantize_fp16 reads
+  // QuantizeFp16KeepIoTypes() -- OptimizeFixed's pass-name list has no way to
+  // carry a parameter directly.
+  namespace mp = ONNX_NAMESPACE::optimization::onnxsim_passes;
+  mp::MagnitudePruningSparsity() = sparsity;
+  mp::MagnitudePruningN() = n.value_or(-1);
+  mp::MagnitudePruningM() = m.value_or(-1);
+
+  if (global_sparsity) {
+    return onnx::optimization::OptimizeFixed(
+        model, std::vector<std::string>{"magnitude_pruning_global"});
+  }
   return onnx::optimization::OptimizeFixed(
       model, std::vector<std::string>{"magnitude_pruning_matmul",
-                                      "magnitude_pruning_conv"});
+                                      "magnitude_pruning_conv",
+                                      "magnitude_pruning_attention"});
 }

--- a/onnxsim/pruning_entry.h
+++ b/onnxsim/pruning_entry.h
@@ -10,4 +10,9 @@
 
 #include <onnx/onnx_pb.h>
 
-onnx::ModelProto PruneMagnitude(const onnx::ModelProto& model, double sparsity);
+#include <optional>
+
+onnx::ModelProto PruneMagnitude(const onnx::ModelProto& model, double sparsity,
+                                const std::optional<int64_t>& n = std::nullopt,
+                                const std::optional<int64_t>& m = std::nullopt,
+                                bool global_sparsity = false);

--- a/onnxsim/quantize_entry.cpp
+++ b/onnxsim/quantize_entry.cpp
@@ -129,15 +129,18 @@ onnx::ModelProto ApplyDoubleQuantization(const onnx::ModelProto& model) {
       model, std::vector<std::string>{"double_quantization"});
 }
 
-onnx::ModelProto ApplyQuarot(const onnx::ModelProto& model, uint64_t seed) {
+onnx::ModelProto ApplyQuarot(const onnx::ModelProto& model, uint64_t seed,
+                             int64_t block_size, float epsilon) {
   PrepareSchemasForDebug(model);
   // Registers quarot (idempotent) into onnxoptimizer's registry so
   // OptimizeFixed can find it by name below.
   onnxsim::RegisterCustomOptimizerPasses();
-  // quarot reads this the same way quantize_fp16 reads
+  // quarot reads these the same way quantize_fp16 reads
   // QuantizeFp16KeepIoTypes() -- OptimizeFixed's pass-name list has no way
   // to carry a parameter directly.
   onnx::optimization::onnxsim_passes::QuarotSeed() = seed;
+  onnx::optimization::onnxsim_passes::QuarotBlockSize() = block_size;
+  onnx::optimization::onnxsim_passes::QuarotEpsilon() = epsilon;
   return onnx::optimization::OptimizeFixed(model,
                                            std::vector<std::string>{"quarot"});
 }

--- a/onnxsim/quantize_entry.h
+++ b/onnxsim/quantize_entry.h
@@ -76,4 +76,5 @@ onnx::ModelProto QuantizeFp8(const onnx::ModelProto& model,
                              const std::string& format, bool keep_io_types);
 
 onnx::ModelProto ApplyDoubleQuantization(const onnx::ModelProto& model);
-onnx::ModelProto ApplyQuarot(const onnx::ModelProto& model, uint64_t seed);
+onnx::ModelProto ApplyQuarot(const onnx::ModelProto& model, uint64_t seed,
+                             int64_t block_size, float epsilon);

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -17139,51 +17139,78 @@ std::vector<onnx::GraphProto*> IterSubgraphs(onnx::GraphProto* graph) {
 // its index in `kept_token_ids`) before running the pruned model -- a
 // dropped id can never be fed to the pruned model again.
 //
-// Two of pruning.py's own three producer shapes are matched here -- plain
-// `Gather` (MatchEmbeddingGatherRaw) and `com.microsoft::
-// EmbedLayerNormalization` (MatchEmbedLayerNormProducer, added alongside it
-// -- see that function's own doc comment for the schema/scope this mirrors
-// from pruning.py's `_match_embed_layer_norm_producer`). `lm_head`
-// auto-detection also now recognizes `com.microsoft::FusedGemm`/
-// `GemmFastGelu` in addition to a bare `MatMul`/vanilla `Gemm`
-// (MatchMatMulLikeWidenedRaw, this section's own local mirror of
-// pruning.py's module-scoped `_match_matmul_like` override -- kept local to
-// this section, not merged into the shared MatchMatMulLikeRaw, for the
-// identical reason pruning.py's own override is kept local to
-// `onnxsim.pruning` rather than made to the shared `smoothquant.py` copy:
-// widening the shared matcher would silently change every OTHER pass in
-// this file that calls it too). The embedding table, `lm_head` weight, and
-// `lm_head` bias are now all admitted as FLOAT, FLOAT16, OR BFLOAT16
-// (IsSupportedFloatDtype, ReadFloatTensorAnyDtype/
+// All THREE of pruning.py's own producer shapes are matched here -- plain
+// `Gather` (MatchEmbeddingGatherRaw), `com.microsoft::
+// EmbedLayerNormalization` (MatchEmbedLayerNormProducer -- see that
+// function's own doc comment for the schema/scope this mirrors from
+// pruning.py's `_match_embed_layer_norm_producer`), and `com.microsoft::
+// GatherBlockQuantized` (MatchGatherBlockQuantizedProducer -- the
+// block-quantized, int2/int4/int8 analogue of a plain-float embedding
+// `Gather`; see that function's own doc comment, and pruning.py's own
+// section-top comment directly above `_match_gather_block_quantized_
+// producer`, for the full empirical schema/packing/real-exporter-evidence
+// this depends on). `lm_head` auto-detection also recognizes
+// `com.microsoft::FusedGemm`/`GemmFastGelu` in addition to a bare `MatMul`/
+// vanilla `Gemm` (MatchMatMulLikeWidenedRaw, this section's own local
+// mirror of pruning.py's module-scoped `_match_matmul_like` override --
+// kept local to this section, not merged into the shared
+// MatchMatMulLikeRaw, for the identical reason pruning.py's own override is
+// kept local to `onnxsim.pruning` rather than made to the shared
+// `smoothquant.py` copy: widening the shared matcher would silently change
+// every OTHER pass in this file that calls it too). The embedding table,
+// `lm_head` weight, and `lm_head` bias are all admitted as FLOAT, FLOAT16,
+// OR BFLOAT16 (IsSupportedFloatDtype, ReadFloatTensorAnyDtype/
 // SetFloatTensorDataPreservingDtype -- this section's own local upcast-to-
 // float32/downcast-to-original-dtype helpers, mirroring pruning.py's own
 // `_to_f64`/`_from_f64` convention; this file's shared ReadFloatTensor/
 // SetFloatTensorData stay FLOAT32-only and untouched, used elsewhere in
 // this file exactly as before).
 //
-// Deliberately still NARROWER than pruning.py's own three-producer-shape
-// port in exactly one remaining respect:
+// `GatherBlockQuantized`'s own `data`/`zero_points` operands use one of TWO
+// genuinely different sub-8-bit packing conventions, dispatched purely off
+// the operand's own dtype (never off the node's `bits` attribute) --
+// ReadPackedBytesAnyStorage/Unpack4BitFlat/Pack4BitFlat/
+// GatherBlockQuantizedTensorAsDouble/SliceGatherBlockQuantizedRows's own
+// top comment has the full empirical detail, independently re-confirmed
+// (not merely read off pruning.py's own comment) against a live
+// `onnx.numpy_helper`/`InferenceSession` round trip before this port was
+// written: ONNX-native sub-byte `tensor(uint4)`/`tensor(int4)` (a flat,
+// whole-tensor, 2-values-per-byte pack that can cross a row boundary) needs
+// a genuine unpack/row-select/repack; plain `tensor(uint8)` (regardless of
+// `bits` -- 2, 4, or 8) needs none at all -- each row's own declared
+// `dims(1)` bytes are already the atomic per-row storage unit, packed (when
+// `bits < 8`) independently per row, never across a row boundary. Both
+// conventions' default `zero_points` (0 for UINT4/INT4, `2**(bits-1)` for
+// UINT8, when the optional input is absent) and the dequantization-for-
+// ranking-only helper (GatherBlockQuantizedDequantized, used only by
+// EmbeddingVocabImportance for `ApplyEmbeddingVocabMagnitudePruning`'s own
+// ranking -- the actual slicing above never dequantizes-then-requantizes,
+// mirroring this file's own "slice the packed codes directly" invariant
+// used throughout its other quantized-pruning ports, e.g. MatMulNBits/QMoE)
+// are ported mirroring pruning.py's own `_gather_block_quantized_
+// dequantized` bit-for-bit -- INCLUDING that function's own pre-existing
+// dtype-dispatched (non-)unpacking asymmetry for the plain-UINT8 convention
+// (see GatherBlockQuantizedTensorAsDouble's own top comment): for that one
+// dtype+`bits<8` combination, the ranking formula operates over the PACKED
+// byte grid, not the true (pre-padding) post-unpack hidden positions -- a
+// property of the pure-Python reference this section mirrors exactly, not
+// a new gap this port introduces. A tied `lm_head` sharing the packed
+// `data` tensor itself is always declined for this shape specifically (see
+// MatchGatherBlockQuantizedProducer's own doc comment for why); an untied
+// `lm_head` is still auto-detected exactly as for the other two shapes.
 //
-//   * `com.microsoft::GatherBlockQuantized` (the int2/int4/int8
-//     block-quantized analogue of a plain-float embedding `Gather`) is
-//     simply never matched -- declined, not mis-handled -- by this port.
-//     Unlike the two gaps closed above, this one is deliberately left
-//     open: pruning.py's own section comment documents two genuinely
-//     different packing conventions (ONNX-native sub-byte `tensor(uint4)`/
-//     `tensor(int4)` vs. manually-packed `tensor(uint8)`, each with its own
-//     default-`zero_points` formula), a `scales`/`zero_points` pair that
-//     must be sliced in lockstep with `data`, and a dequantization-for-
-//     ranking-only helper -- real, verified-correct scope, but large enough
-//     that porting it hastily risks a subtle packing/slicing bug for a
-//     currently-narrow real-exporter surface (see that comment's own "Real
-//     exporter evidence" paragraph). Left as a clearly separate,
-//     independent follow-up rather than attempted here. Because this is a
-//     genuine remaining producer-shape gap (not just a narrower dtype/
-//     lm_head-node-type restriction), `apply_embedding_vocab_pruning`/
-//     `apply_embedding_vocab_magnitude_pruning` in pruning.py are NOT
-//     aliased to these C++ ports -- see this round's own summary for why
-//     "two of three producer shapes" does not clear this module's own
-//     "verified TRUE full parity, or don't alias" bar.
+// Verified TRUE full parity across both packing conventions before
+// `apply_embedding_vocab_pruning`/`apply_embedding_vocab_magnitude_pruning`
+// in pruning.py were aliased to these C++ ports (see pruning.py's own
+// doc comments on those two functions): native UINT4/INT4 and manually-
+// packed UINT8 (`bits` in {2, 4, 8}), each with and without an explicit
+// `zero_points`, an intentionally-adversarial odd hidden size (crossing a
+// nibble's own byte boundary for the native convention, forcing a padding
+// element for the packed-uint8 convention), FLOAT/FLOAT16/BFLOAT16 scales,
+// combined with an auto-detected untied `lm_head`, and cross-checked both
+// against a real `InferenceSession` run and against the (then still live)
+// pure-Python reference -- see tests/test_embedding_vocab_pruning_cpp.py's
+// own `GatherBlockQuantized` section for the frozen coverage.
 //
 // Every other structural safety check pruning.py's own `_match_embedding_
 // gather`/`_match_tied_lm_head`/`_match_untied_lm_head`/`_match_lm_head_
@@ -17197,11 +17224,12 @@ std::vector<onnx::GraphProto*> IterSubgraphs(onnx::GraphProto* graph) {
 // than one such candidate ambiguous, not evidence; a bias is only ever
 // recognized as a `Gemm`'s own built-in `C` input or a `MatMul`-then-
 // `Add(bias)` tail, anything else declining that whole `lm_head` match.
-// When more than one qualifying `Gather` exists and the caller hasn't
-// named `input_name`, the whole call declines.
+// When more than one qualifying producer -- any of the three shapes,
+// counted together -- exists and the caller hasn't named `input_name`, the
+// whole call declines.
 //
 // Subgraph-aware (IterSubgraphs, just above) exactly like every other pass
-// in this file: the one eligible `Gather` this pass requires may live
+// in this file: the one eligible producer this pass requires may live
 // inside a nested If/Loop/Scan/BeamSearch-family subgraph, at any nesting
 // depth, not only the top-level graph -- MatchEmbeddingChainAnyGraph
 // applies the identical "exactly one eligible producer, or decline" rule
@@ -17231,6 +17259,26 @@ struct EmbeddingLmHeadMatch {
   onnx::NodeProto* via_transpose = nullptr;
 };
 
+// Extra operands/attributes present only when EmbeddingChain::quantized is
+// set -- the embedding-table producer was matched as a `com.microsoft::
+// GatherBlockQuantized` node (MatchGatherBlockQuantizedProducer, below).
+// Mirrors pruning.py's own `_GatherBlockQuantizedInfo` exactly.
+// `EmbeddingChain::weight_name` continues to mean the node's own `data`
+// input (the packed/quantized embedding table itself) for this shape too --
+// only `scales_name`/`zero_points_name` are new. `gather_axis` is always 0
+// (the only value MatchGatherBlockQuantizedProducer ever admits -- see its
+// own doc comment), kept here rather than hard-coded at every call site so
+// ApplyEmbeddingVocabPrune/GatherBlockQuantizedDequantized read it off the
+// match itself, the same way every other field on this chain is read off
+// the match rather than re-derived.
+struct GatherBlockQuantizedInfo {
+  std::string scales_name;
+  std::optional<std::string> zero_points_name;
+  int64_t bits = 4;
+  int64_t block_size = 128;
+  int64_t gather_axis = 0;
+};
+
 struct EmbeddingChain {
   onnx::NodeProto* producer = nullptr;  // the matched Gather node
   std::string weight_name;              // the embedding table's own name
@@ -17238,6 +17286,10 @@ struct EmbeddingChain {
   int64_t vocab_size = 0;
   int64_t hidden_size = 0;
   std::optional<EmbeddingLmHeadMatch> lm_head;
+  // Non-nullopt only when `producer` is a `com.microsoft::
+  // GatherBlockQuantized` node -- nullopt for the two plain-float producer
+  // shapes (a plain `Gather` or `EmbedLayerNormalization`).
+  std::optional<GatherBlockQuantizedInfo> quantized;
 };
 
 // True for FLOAT, FLOAT16, and BFLOAT16 -- every element dtype this
@@ -17453,6 +17505,357 @@ void SetFloatTensorDataPreservingDtype(onnx::TensorProto* t,
                                       raw.size(), sizeof(uint16_t));
   }
   t->set_raw_data(std::move(raw));
+}
+
+// --- GatherBlockQuantized packed-byte helpers ---------------------------
+//
+// `com.microsoft::GatherBlockQuantized`'s own `data`/`zero_points` operands
+// use one of TWO genuinely different sub-8-bit packing conventions,
+// dispatched purely off the tensor's own declared dtype -- never off
+// `bits` -- exactly mirroring pruning.py's own top-of-section comment
+// (directly above `_match_gather_block_quantized_producer` there) and its
+// own `_slice_axis`/`onnx.numpy_helper.to_array`/`from_array` round trip:
+//
+//   * dtype UINT4/INT4 (ONNX's own native sub-byte tensor types): packed
+//     PER `onnx.numpy_helper`'s own `_pack_4bitx2`/`_unpack_4bit` -- a FLAT,
+//     WHOLE-TENSOR, row-major pack, 2 values per byte (byte `i` holds
+//     element `2i` in its low nibble, element `2i+1` in its high nibble),
+//     which can cross a row boundary when the trailing dimension count is
+//     odd. `TensorProto.dims` stores the LOGICAL (unpacked) shape for this
+//     dtype -- confirmed directly against a live `onnx.numpy_helper.
+//     from_array`/`to_array` round trip (this file's own scratch
+//     verification, not assumed): a `(5, 17)` logical shape's own
+//     `raw_data` is `ceil(5*17/2) = 43` bytes, and `to_array` returns it
+//     unpacked back to `(5, 17)`.
+//   * dtype plain UINT8 (regardless of `bits` -- 2, 4, OR 8): ONNX's own
+//     tensor-type system has no notion of this op's own per-row nibble/
+//     2-bit packing at all (that convention is invented by this op alone,
+//     never reflected in `TensorProto`'s own dtype), so `onnx.numpy_helper.
+//     to_array` does NOT unpack a plain UINT8 tensor -- it returns the raw
+//     per-element BYTE values verbatim, shape == `dims` exactly (confirmed
+//     directly: a `(2, 2)`-dims UINT8 tensor round-trips through
+//     `to_array` as the literal packed byte values, untouched). This
+//     matters for pruning.py's own ranking-only dequant helper (mirrored by
+//     GatherBlockQuantizedDequantized, below) -- for a genuinely packed
+//     (bits < 8) UINT8 tensor, that dequant formula is computed over the
+//     PACKED byte grid, not the true post-unpack hidden positions (this is
+//     a pre-existing property of the pure-Python reference this section
+//     mirrors bit-for-bit, not a new gap introduced by this port -- see
+//     that function's own doc comment for why this still self-consistently
+//     produces *some* per-row ranking signal, just not a numerically "real"
+//     dequantized value, for that one dtype+bits combination). It does NOT
+//     matter for actual SLICING correctness at all: this section's own top
+//     comment (pruning.py's `_match_gather_block_quantized_producer`
+//     comment) confirms the manually-packed convention's own packing is
+//     independent PER ROW (never crosses a row boundary), so each row's own
+//     `dims[1]` bytes are already the atomic per-row storage unit under
+//     this convention, regardless of what "true" (pre-padding) hidden
+//     width they represent -- a plain contiguous byte-per-row copy is
+//     always exactly right for GATHER-AXIS (row) slicing.
+//
+// Because `gather_axis` (the only axis this pass ever slices) is never
+// `quantize_axis` (the only axis either packing convention ever packs
+// along -- enforced by MatchGatherBlockQuantizedProducer's own degenerate-
+// case decline), neither convention's own row-slicing below ever needs to
+// touch a packed axis boundary.
+
+// Reads a tensor's raw byte payload as a flat `vector<uint8_t>` of exactly
+// `n_bytes` bytes, handling both `raw_data` and (ONNX's own wire convention
+// for sub-32-bit dtypes) zero-extended per-BYTE `int32_data` storage --
+// mirrors ReadFloatTensorAnyDtype's own already-established convention,
+// just at 1-byte-per-storage-unit granularity (a full byte for UINT8, one
+// PACKED byte -- not one logical sub-4-bit element -- for UINT4/INT4, per
+// `onnx.numpy_helper`'s own `int32_data` fallback path for those dtypes).
+// No endian-swap is ever needed here (unlike ReadFloatTensorAnyDtype's own
+// 2-byte-wide FLOAT16/BFLOAT16 codes): a single byte has no byte order.
+std::vector<uint8_t> ReadPackedBytesAnyStorage(const onnx::TensorProto& t,
+                                               size_t n_bytes) {
+  std::vector<uint8_t> bytes(n_bytes);
+  if (t.has_raw_data()) {
+    std::memcpy(bytes.data(), t.raw_data().data(), n_bytes);
+  } else {
+    for (size_t i = 0; i < n_bytes; ++i) {
+      bytes[i] = static_cast<uint8_t>(t.int32_data(static_cast<int>(i)));
+    }
+  }
+  return bytes;
+}
+
+// Unpacks ONNX's own native flat, whole-tensor, 2-values-per-byte sub-4-bit
+// packing (`onnx.numpy_helper`'s own `_unpack_4bit` convention -- see this
+// subsection's own top comment) into one 4-bit CODE per element (its raw
+// bit pattern, 0-15, never sign-extended -- this pass only ever relocates a
+// code via a row-select-then-repack, never interprets its numeric value,
+// so treating a UINT4 and INT4 code identically here is always safe).
+// `numel` is the tensor's own total logical element count (`dims`
+// product); a single trailing PADDING nibble (present only when `numel` is
+// odd) is simply never read.
+std::vector<uint8_t> Unpack4BitFlat(const uint8_t* raw, int64_t numel) {
+  std::vector<uint8_t> out(static_cast<size_t>(numel));
+  for (int64_t i = 0; i < numel; ++i) {
+    const uint8_t byte = raw[static_cast<size_t>(i / 2)];
+    out[static_cast<size_t>(i)] =
+        (i % 2 == 0) ? (byte & 0x0Fu) : ((byte >> 4) & 0x0Fu);
+  }
+  return out;
+}
+
+// Inverse of Unpack4BitFlat: packs `codes` (one 4-bit code per element,
+// only its own low nibble read) back into ONNX's own flat 2-per-byte
+// convention -- `codes[2i]` in byte `i`'s low nibble, `codes[2i+1]` in its
+// high nibble, with a final zero-filled high nibble when `codes.size()` is
+// odd (matching `_pack_4bitx2`'s own zero-padding).
+std::string Pack4BitFlat(const std::vector<uint8_t>& codes) {
+  const size_t n = codes.size();
+  std::string out((n + 1) / 2, '\0');
+  for (size_t i = 0; i < n; ++i) {
+    const uint8_t nibble = codes[i] & 0x0Fu;
+    uint8_t byte_val = static_cast<uint8_t>(out[i / 2]);
+    if (i % 2 == 0) {
+      byte_val = static_cast<uint8_t>((byte_val & 0xF0u) | nibble);
+    } else {
+      byte_val = static_cast<uint8_t>((byte_val & 0x0Fu) |
+                                      static_cast<uint8_t>(nibble << 4));
+    }
+    out[i / 2] = static_cast<char>(byte_val);
+  }
+  return out;
+}
+
+// Row-slices (axis 0, the vocab/`gather_axis`) `t` -- `data`, or (when
+// present and dtype-matching `data`) `zero_points` -- IN PLACE, byte-exact,
+// regardless of GatherBlockQuantized's own two distinct packing conventions
+// (this subsection's own top comment), dispatched purely off `t`'s own
+// dtype, mirroring pruning.py's own `_slice_axis` exactly: UINT4/INT4 needs
+// a genuine flat unpack/row-select/repack (Unpack4BitFlat/Pack4BitFlat);
+// plain UINT8 needs no unpack/repack at all -- each row's own `dims(1)`
+// bytes are already the atomic per-row storage unit under that convention,
+// so a row is a plain contiguous byte copy.
+void SliceGatherBlockQuantizedRows(onnx::TensorProto* t,
+                                   const std::vector<int64_t>& keep) {
+  const int64_t d0 = t->dims(0);
+  const int64_t d1 = t->dims(1);
+  const int64_t kc = static_cast<int64_t>(keep.size());
+  const int32_t dtype = t->data_type();
+  const std::string name = t->name();
+
+  std::string new_raw;
+  if (dtype == onnx::TensorProto::UINT8) {
+    const size_t row_bytes = static_cast<size_t>(d1);
+    const std::vector<uint8_t> bytes =
+        ReadPackedBytesAnyStorage(*t, static_cast<size_t>(d0) * row_bytes);
+    new_raw.resize(static_cast<size_t>(kc) * row_bytes);
+    for (int64_t i = 0; i < kc; ++i) {
+      const size_t src =
+          static_cast<size_t>(keep[static_cast<size_t>(i)]) * row_bytes;
+      std::memcpy(&new_raw[static_cast<size_t>(i) * row_bytes], &bytes[src],
+                  row_bytes);
+    }
+  } else {
+    // UINT4 / INT4: ONNX-native flat whole-tensor packing.
+    const int64_t numel = d0 * d1;
+    const size_t n_bytes = static_cast<size_t>((numel + 1) / 2);
+    const std::vector<uint8_t> raw = ReadPackedBytesAnyStorage(*t, n_bytes);
+    const std::vector<uint8_t> codes = Unpack4BitFlat(raw.data(), numel);
+    std::vector<uint8_t> new_codes(static_cast<size_t>(kc) *
+                                   static_cast<size_t>(d1));
+    for (int64_t i = 0; i < kc; ++i) {
+      const int64_t src_row = keep[static_cast<size_t>(i)];
+      std::memcpy(
+          &new_codes[static_cast<size_t>(i) * static_cast<size_t>(d1)],
+          &codes[static_cast<size_t>(src_row) * static_cast<size_t>(d1)],
+          static_cast<size_t>(d1));
+    }
+    new_raw = Pack4BitFlat(new_codes);
+  }
+
+  t->Clear();
+  t->set_name(name);
+  t->set_data_type(static_cast<onnx::TensorProto_DataType>(dtype));
+  t->add_dims(kc);
+  t->add_dims(d1);
+  t->set_raw_data(std::move(new_raw));
+}
+
+// Reads `data`'s (or `zero_points`'s) own logical `(dims(0), dims(1))`
+// values as `double`, mirroring `onnx.numpy_helper.to_array(...).astype(
+// np.float64)`'s own per-dtype behavior EXACTLY -- including its own
+// dtype-dispatched (non-)unpacking asymmetry (this subsection's own top
+// comment): UINT4 unpacks to unsigned codes 0-15; INT4 unpacks to SIGNED
+// 4-bit codes (twos-complement: raw codes 8-15 represent -8..-1); plain
+// UINT8 is read as-is, NO unpacking, regardless of `bits` -- the packed
+// byte value itself, 0-255, is what `to_array` (and therefore this
+// function) returns.
+std::vector<double> GatherBlockQuantizedTensorAsDouble(
+    const onnx::TensorProto& t) {
+  const int64_t d0 = t.dims(0);
+  const int64_t d1 = t.dims(1);
+  const int64_t numel = d0 * d1;
+  const int32_t dtype = t.data_type();
+  std::vector<double> out(static_cast<size_t>(numel));
+  if (dtype == onnx::TensorProto::UINT8) {
+    const std::vector<uint8_t> bytes =
+        ReadPackedBytesAnyStorage(t, static_cast<size_t>(numel));
+    for (int64_t i = 0; i < numel; ++i) {
+      out[static_cast<size_t>(i)] =
+          static_cast<double>(bytes[static_cast<size_t>(i)]);
+    }
+  } else {
+    const size_t n_bytes = static_cast<size_t>((numel + 1) / 2);
+    const std::vector<uint8_t> raw = ReadPackedBytesAnyStorage(t, n_bytes);
+    const std::vector<uint8_t> codes = Unpack4BitFlat(raw.data(), numel);
+    const bool is_signed = dtype == onnx::TensorProto::INT4;
+    for (int64_t i = 0; i < numel; ++i) {
+      const uint8_t c = codes[static_cast<size_t>(i)];
+      out[static_cast<size_t>(i)] =
+          (is_signed && c >= 8) ? static_cast<double>(static_cast<int>(c) - 16)
+                                : static_cast<double>(c);
+    }
+  }
+  return out;
+}
+
+// True for UINT4, INT4, and plain UINT8 -- every element dtype
+// MatchGatherBlockQuantizedProducer accepts for `data`/`zero_points`.
+// Mirrors pruning.py's own `_GATHER_BLOCK_QUANTIZED_DATA_TYPES` set
+// exactly.
+bool IsGatherBlockQuantizedDataDtype(int32_t data_type) {
+  return data_type == onnx::TensorProto::UINT4 ||
+         data_type == onnx::TensorProto::INT4 ||
+         data_type == onnx::TensorProto::UINT8;
+}
+
+// `com.microsoft::GatherBlockQuantized` -- a third producer shape, the
+// block-quantized (int2/int4/int8) analogue of a plain-float embedding
+// `Gather`, matched alongside MatchEmbeddingGatherRaw/
+// MatchEmbedLayerNormProducer by MatchEmbeddingChain's own dispatch loop.
+// Mirrors pruning.py's own `_match_gather_block_quantized_producer`
+// exactly -- see that function's own section-top comment (directly above
+// it in pruning.py) for the full empirical schema/packing/real-exporter-
+// evidence this depends on. None of the packing-convention/default-
+// `zero_points` subtlety matters for MATCHING itself (only for the actual
+// slicing/dequant-for-ranking helpers elsewhere in this section) -- this
+// function only checks shape/dtype/consumer-count structure, exactly
+// mirroring the Python matcher's own scope.
+//
+// Matching bar: `node` must be `com.microsoft::GatherBlockQuantized` with 3
+// or 4 inputs (`zero_points` optional); `bits` in {2, 4, 8}; `gather_axis`
+// (default 0) and `quantize_axis` (default 1), each normalized for a
+// negative value, must resolve to exactly 0 and 1 respectively -- for the
+// rank-2 `data` this matcher requires, this alone already makes the
+// degenerate `gather_axis == quantize_axis` case structurally impossible,
+// so no separate check is needed; `data` a constant rank-2 initializer of
+// dtype UINT4/INT4/UINT8; `indices` a declared graph input, or one bounded
+// `Cast` hop from one (identical rule to the other two producer shapes);
+// `scales` a constant, rank-2, IsSupportedFloatDtype initializer whose own
+// axis-0 size matches `data`'s; `zero_points`, when present, a constant,
+// rank-2, SAME-dtype-as-`data` initializer whose own axis-0 size also
+// matches `data`'s (the schema's own "data and zero_points have the same
+// type"); `data` itself must have exactly one consumer (this node) -- a
+// tied `lm_head` sharing the packed `data` tensor is always declined for
+// this shape (see pruning.py's own docstring for why: composing two
+// different ops' quantization conventions across a tied boundary is out of
+// scope).
+std::optional<
+    std::tuple<std::string, std::string, std::string, GatherBlockQuantizedInfo>>
+MatchGatherBlockQuantizedProducer(
+    const onnx::NodeProto& node, const InitMap& init_map,
+    const ConsumerMap& consumers_of,
+    const std::unordered_set<std::string>& graph_input_names,
+    const std::unordered_map<std::string, onnx::NodeProto*>& node_by_output) {
+  if (node.op_type() != "GatherBlockQuantized" ||
+      node.domain() != kComMicrosoftDomain) {
+    return std::nullopt;
+  }
+  if (node.input_size() != 3 && node.input_size() != 4) {
+    return std::nullopt;
+  }
+
+  int64_t bits = 4, block_size = 128, quantize_axis = 1, gather_axis = 0;
+  for (const auto& attr : node.attribute()) {
+    if (attr.name() == "bits") {
+      bits = attr.i();
+    } else if (attr.name() == "block_size") {
+      block_size = attr.i();
+    } else if (attr.name() == "quantize_axis") {
+      quantize_axis = attr.i();
+    } else if (attr.name() == "gather_axis") {
+      gather_axis = attr.i();
+    }
+  }
+  if (bits != 2 && bits != 4 && bits != 8) {
+    return std::nullopt;
+  }
+
+  const std::string& data_name = node.input(0);
+  const std::string& indices_name = node.input(1);
+  const std::string& scales_name = node.input(2);
+  std::optional<std::string> zero_points_name;
+  if (node.input_size() == 4 && !node.input(3).empty()) {
+    zero_points_name = node.input(3);
+  }
+
+  auto dit = init_map.find(data_name);
+  if (dit == init_map.end() ||
+      !IsGatherBlockQuantizedDataDtype(dit->second->data_type()) ||
+      dit->second->dims_size() != 2) {
+    return std::nullopt;
+  }
+  const int64_t rank = dit->second->dims_size();
+  if (gather_axis < 0) {
+    gather_axis += rank;
+  }
+  if (quantize_axis < 0) {
+    quantize_axis += rank;
+  }
+  if (gather_axis != 0 || quantize_axis != 1) {
+    return std::nullopt;  // only the plain (vocab_size, hidden_size) layout
+  }
+
+  auto sit = init_map.find(scales_name);
+  if (sit == init_map.end() ||
+      !IsSupportedFloatDtype(sit->second->data_type()) ||
+      sit->second->dims_size() != 2 ||
+      sit->second->dims(gather_axis) != dit->second->dims(gather_axis)) {
+    return std::nullopt;
+  }
+
+  if (zero_points_name) {
+    auto zit = init_map.find(*zero_points_name);
+    if (zit == init_map.end() ||
+        zit->second->data_type() != dit->second->data_type() ||
+        zit->second->dims_size() != 2 ||
+        zit->second->dims(gather_axis) != dit->second->dims(gather_axis)) {
+      return std::nullopt;
+    }
+  }
+
+  std::string underlying = indices_name;
+  if (!graph_input_names.count(underlying)) {
+    auto cit = node_by_output.find(underlying);
+    if (cit != node_by_output.end() && cit->second->op_type() == "Cast" &&
+        cit->second->input_size() == 1 &&
+        graph_input_names.count(cit->second->input(0))) {
+      underlying = cit->second->input(0);
+    } else {
+      return std::nullopt;  // not a graph input, nor a Cast of one
+    }
+  }
+
+  auto cit2 = consumers_of.find(data_name);
+  const size_t n_data_consumers =
+      cit2 == consumers_of.end() ? 0 : cit2->second.size();
+  if (n_data_consumers != 1) {
+    return std::nullopt;  // any other/extra consumer -- always declined
+  }
+
+  GatherBlockQuantizedInfo info;
+  info.scales_name = scales_name;
+  info.zero_points_name = zero_points_name;
+  info.bits = bits;
+  info.block_size = block_size;
+  info.gather_axis = gather_axis;
+  return std::make_tuple(data_name, indices_name, underlying, info);
 }
 
 // This section's own local mirror of pruning.py's module-scoped
@@ -17910,17 +18313,29 @@ std::optional<EmbeddingChain> MatchEmbeddingChain(
     onnx::NodeProto* node;
     std::string w_name;
     std::string indices_name;
+    std::optional<GatherBlockQuantizedInfo> quantized;
   };
   std::vector<RawMatch> matches;
   for (int i = 0; i < graph->node_size(); ++i) {
     onnx::NodeProto* node = graph->mutable_node(i);
-    // Try both producer shapes -- a node is at most one of them (disjoint
-    // op_type/domain checks), so there is never a double-count here.
+    // Try all three producer shapes -- a node is at most one of them
+    // (disjoint op_type/domain checks), so there is never a double-count
+    // here.
     auto m = MatchEmbeddingGatherRaw(*node, init_map, consumers_of,
                                      graph_input_names, node_by_output);
     if (!m) {
       m = MatchEmbedLayerNormProducer(*node, init_map, consumers_of,
                                       graph_input_names, node_by_output);
+    }
+    std::optional<GatherBlockQuantizedInfo> quantized;
+    if (!m) {
+      auto m_q = MatchGatherBlockQuantizedProducer(
+          *node, init_map, consumers_of, graph_input_names, node_by_output);
+      if (m_q) {
+        m = std::make_tuple(std::get<0>(*m_q), std::get<1>(*m_q),
+                            std::get<2>(*m_q));
+        quantized = std::get<3>(*m_q);
+      }
     }
     if (!m) {
       continue;
@@ -17932,7 +18347,7 @@ std::optional<EmbeddingChain> MatchEmbeddingChain(
         *input_name != underlying) {
       continue;
     }
-    matches.push_back({node, w_name, indices_name});
+    matches.push_back({node, w_name, indices_name, quantized});
   }
 
   if (input_name && matches.empty()) {
@@ -17951,14 +18366,30 @@ std::optional<EmbeddingChain> MatchEmbeddingChain(
 
   onnx::NodeProto* producer_node = matches[0].node;
   const std::string& w_name = matches[0].w_name;
+  const std::optional<GatherBlockQuantizedInfo>& quantized =
+      matches[0].quantized;
   const onnx::TensorProto* w_init = init_map.at(w_name);
-  const int64_t vocab_size = w_init->dims(0);
-  const int64_t hidden_size = w_init->dims(1);
+  int64_t vocab_size, hidden_size;
+  if (quantized) {
+    vocab_size = w_init->dims(quantized->gather_axis);
+    hidden_size = w_init->dims(1 - quantized->gather_axis);
+  } else {
+    vocab_size = w_init->dims(0);
+    hidden_size = w_init->dims(1);
+  }
 
   auto cit = consumers_of.find(w_name);
   const size_t n_consumers = cit == consumers_of.end() ? 0 : cit->second.size();
   std::optional<EmbeddingLmHeadMatch> lm_head;
-  if (n_consumers == 2) {
+  if (quantized) {
+    // A tied lm_head sharing the packed/quantized `data` tensor is always
+    // declined -- MatchGatherBlockQuantizedProducer's own single-consumer
+    // requirement already guarantees `n_consumers == 1` here, so only the
+    // untied auto-detection path is ever attempted. Mirrors pruning.py's
+    // own `_match_embedding_chain` exactly.
+    lm_head = MatchUntiedLmHead(graph, w_name, vocab_size, consumers_of,
+                                init_map, graph_outputs);
+  } else if (n_consumers == 2) {
     lm_head = MatchTiedLmHead(w_name, vocab_size, producer_node, consumers_of,
                               init_map);
     if (!lm_head) {
@@ -17977,6 +18408,7 @@ std::optional<EmbeddingChain> MatchEmbeddingChain(
   chain.vocab_size = vocab_size;
   chain.hidden_size = hidden_size;
   chain.lm_head = lm_head;
+  chain.quantized = quantized;
   return chain;
 }
 
@@ -18116,9 +18548,28 @@ void ApplyEmbeddingVocabPrune(onnx::GraphProto* graph,
 
   // The embedding table is [vocab_size, hidden_size] with vocab_size as
   // axis 0 -- exactly SliceEmbeddingWeightAnyDtype's own
-  // `weight_transposed=true` ("output channel is axis 0") branch.
-  SliceEmbeddingWeightAnyDtype(init_map.at(chain.weight_name),
-                               /*weight_transposed=*/true, keep_ids);
+  // `weight_transposed=true` ("output channel is axis 0") branch. The
+  // `GatherBlockQuantized` shape's own packed `data` tensor is NOT a
+  // FLOAT/FLOAT16/BFLOAT16 tensor (it is UINT4/INT4/UINT8), so it takes the
+  // dtype-dispatched packed-byte row-slice (SliceGatherBlockQuantizedRows)
+  // instead -- `scales` stays FLOAT-family (SliceEmbeddingWeightAnyDtype
+  // applies unchanged, its own `(vocab_size, n_blocks)` shape matching that
+  // helper's `(dim0, dim1)` contract exactly), and `zero_points`, when
+  // present, shares `data`'s own dtype so it takes the same packed-byte
+  // slice too. Mirrors pruning.py's own `_apply_embedding_vocab_prune`
+  // exactly (`_slice_axis` applied to `data`/`scales`/`zero_points` alike).
+  if (chain.quantized) {
+    SliceGatherBlockQuantizedRows(init_map.at(chain.weight_name), keep_ids);
+    SliceEmbeddingWeightAnyDtype(init_map.at(chain.quantized->scales_name),
+                                 /*weight_transposed=*/true, keep_ids);
+    if (chain.quantized->zero_points_name) {
+      SliceGatherBlockQuantizedRows(
+          init_map.at(*chain.quantized->zero_points_name), keep_ids);
+    }
+  } else {
+    SliceEmbeddingWeightAnyDtype(init_map.at(chain.weight_name),
+                                 /*weight_transposed=*/true, keep_ids);
+  }
 
   if (chain.lm_head && !chain.lm_head->tied) {
     SliceEmbeddingWeightAnyDtype(init_map.at(*chain.lm_head->weight_name),
@@ -18156,18 +18607,92 @@ void ApplyEmbeddingVocabPrune(onnx::GraphProto* graph,
   }
 }
 
+// The full `(vocab_size, data.dims(1))` dequantized embedding table
+// `chain`'s own `com.microsoft::GatherBlockQuantized` producer refers to,
+// for IMPORTANCE RANKING ONLY -- never written back to the graph (this
+// module's own "slice, don't recompute" principle, exactly as
+// MatMulNBitsDequantized). Requires `chain.quantized` is set. Mirrors
+// pruning.py's own `_gather_block_quantized_dequantized` EXACTLY,
+// including its own dtype-dispatched (non-)unpacking asymmetry for `data`/
+// `zero_points` (GatherBlockQuantizedTensorAsDouble's own top comment) --
+// formula: `dequantized[v, h] = (data[v, h] - zero_point[v, h //
+// block_size]) * scale[v, h // block_size]`, `h` ranging over `data`'s own
+// logical `dims(1)` (== `chain.hidden_size`) -- for the plain-UINT8 packed
+// convention this is the PACKED width, not necessarily the true (pre-
+// padding) hidden size; a pre-existing property of the pure-Python
+// reference this mirrors bit-for-bit, not a new gap introduced by this
+// port (see that subsection's own top comment for the full explanation).
+std::vector<double> GatherBlockQuantizedDequantized(const EmbeddingChain& chain,
+                                                    const InitMap& init_map) {
+  const GatherBlockQuantizedInfo& q = *chain.quantized;
+  const onnx::TensorProto* data_init = init_map.at(chain.weight_name);
+  const std::vector<double> data =
+      GatherBlockQuantizedTensorAsDouble(*data_init);
+  const onnx::TensorProto* scales_init = init_map.at(q.scales_name);
+  const std::vector<float> scales_f = ReadFloatTensorAnyDtype(*scales_init);
+  const std::vector<double> scales(scales_f.begin(), scales_f.end());
+  const int64_t vocab = data_init->dims(0);
+  const int64_t d1 = data_init->dims(1);
+  const int64_t n_blocks = scales_init->dims(1);
+
+  std::vector<double> zp;
+  int64_t zp_cols = n_blocks;
+  if (q.zero_points_name) {
+    const onnx::TensorProto* zp_init = init_map.at(*q.zero_points_name);
+    zp = GatherBlockQuantizedTensorAsDouble(*zp_init);
+    // May legitimately differ from `n_blocks` for the packed-uint8
+    // convention (see this section's own top comment) -- mirrors
+    // pruning.py's own `zp[:, col_block]` indexing exactly, including its
+    // own out-of-range-index behavior for that edge case.
+    zp_cols = zp_init->dims(1);
+  } else {
+    const double default_zp =
+        (data_init->data_type() == onnx::TensorProto::UINT4 ||
+         data_init->data_type() == onnx::TensorProto::INT4)
+            ? 0.0
+            : static_cast<double>(int64_t{1} << (q.bits - 1));
+    zp.assign(static_cast<size_t>(vocab * n_blocks), default_zp);
+  }
+
+  std::vector<double> out(static_cast<size_t>(vocab * d1));
+  for (int64_t v = 0; v < vocab; ++v) {
+    for (int64_t h = 0; h < d1; ++h) {
+      int64_t col_block = h / q.block_size;
+      if (col_block > n_blocks - 1) {
+        col_block = n_blocks - 1;
+      }
+      const double s = scales[static_cast<size_t>(v * n_blocks + col_block)];
+      const double z = zp[static_cast<size_t>(v * zp_cols + col_block)];
+      out[static_cast<size_t>(v * d1 + h)] =
+          (data[static_cast<size_t>(v * d1 + h)] - z) * s;
+    }
+  }
+  return out;
+}
+
 // The per-row (vocab-axis) L2-norm importance vector shared by
 // ApplyEmbeddingVocabMagnitudePruning: the matched embedding table's own
 // row norm, combined (root-sum-square) with a matched untied `lm_head`'s
 // own row norm when one exists (the tied case needs no such combination --
 // the embedding table's own row norm already IS the tied `lm_head`'s row
 // norm). Mirrors pruning.py's own `_embedding_vocab_importance` exactly,
-// minus the `GatherBlockQuantized`-dequantization branch (out of scope for
-// this C++ port -- see this section's own top comment).
+// including its `GatherBlockQuantizedDequantized` dequantize-for-ranking
+// branch for the `GatherBlockQuantized` shape.
 std::vector<double> EmbeddingVocabImportance(const EmbeddingChain& chain,
                                              const InitMap& init_map) {
   std::vector<double> importance(static_cast<size_t>(chain.vocab_size), 0.0);
-  {
+  if (chain.quantized) {
+    const std::vector<double> emb =
+        GatherBlockQuantizedDequantized(chain, init_map);
+    for (int64_t v = 0; v < chain.vocab_size; ++v) {
+      double sum = 0.0;
+      for (int64_t h = 0; h < chain.hidden_size; ++h) {
+        const double x = emb[static_cast<size_t>(v * chain.hidden_size + h)];
+        sum += x * x;
+      }
+      importance[static_cast<size_t>(v)] = sum;
+    }
+  } else {
     const std::vector<float> emb =
         ReadFloatTensorAnyDtype(*init_map.at(chain.weight_name));
     for (int64_t v = 0; v < chain.vocab_size; ++v) {

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -18360,19 +18360,27 @@ std::unordered_map<std::string, std::vector<double>> WandaCalibrationStats(
                    // above.
       }
       const DLTensor& dl = outputs[oit->second]->dl_tensor;
-      // Scope decision, mirroring this file's own FLOAT32-only chain
-      // matching everywhere else (every producer/consumer weight this file
-      // matches is FLOAT32-only -- see e.g. MatchProducer): a probe
-      // activation of any other runtime dtype is simply skipped for this
-      // batch (never observed for this probe name), so the affected
-      // chain(s) fall back to plain weight-only importance -- never
-      // guessed at via an implicit upcast. In practice every chain this
-      // pass matches is itself FLOAT32-only, so its own probe activation is
-      // FLOAT32 too whenever the executor runs the *real* graph ops
-      // faithfully; this only guards against an executor that (legitimately
-      // per the ModelExecutor contract) returns some other dtype.
+      // Accepts FLOAT/FLOAT16/BFLOAT16 (IsSupportedFloatDtype), mirroring
+      // pruning.py's own unconditional `np.asarray(..., dtype=np.float64)`
+      // here -- ApplyWandaPruning's own candidate matching (this file's own
+      // "Wanda unstructured (element-wise) pruning" section) now widens its
+      // own weight-dtype gates to match, per that section's own top
+      // comment, so a FLOAT16/BFLOAT16 model's probe activation needs to be
+      // observed here too rather than silently falling back to plain
+      // weight-only importance the way an unobserved-dtype probe still does
+      // below. Strictly additive for every OTHER caller of this shared
+      // function (ApplyStructuredWandaPruning/ApplyAttentionHeadWandaPruning
+      // above/below, still FLOAT32-only candidate matchers of their own):
+      // it only lets this function observe MORE activation dtypes, never
+      // fewer, so their own FLOAT32-only candidates' own probe activations
+      // (already FLOAT32 whenever the executor runs the real graph
+      // faithfully) are unaffected. A probe activation of any other runtime
+      // dtype the executor might legitimately return is simply skipped for
+      // this batch (never observed for this probe name), so the affected
+      // chain(s) fall back to plain weight-only importance -- never guessed
+      // at via an implicit upcast.
       onnx::TensorProto tp = onnxsim::dlpack::ToTensorProto(dl);
-      if (tp.data_type() != onnx::TensorProto::FLOAT) {
+      if (!IsSupportedFloatDtype(tp.data_type())) {
         continue;
       }
       const int64_t ndim = tp.dims_size();
@@ -18399,7 +18407,11 @@ std::unordered_map<std::string, std::vector<double>> WandaCalibrationStats(
       }
       const int64_t channel_stride = strides[static_cast<size_t>(axis)];
 
-      std::vector<float> data = ReadFloatTensor(tp);
+      // ReadTensorAsF64 (FLOAT/FLOAT16/BFLOAT16 -> double, exact upcast --
+      // see its own declaration comment) rather than ReadFloatTensor: `tp`
+      // may now be FLOAT16/BFLOAT16, per this function's own widened dtype
+      // gate above.
+      std::vector<double> data = ReadTensorAsF64(tp);
       auto& acc = sq_sum[name];
       if (acc.empty()) {
         acc.assign(static_cast<size_t>(channel_dim), 0.0);
@@ -18412,7 +18424,7 @@ std::unordered_map<std::string, std::vector<double>> WandaCalibrationStats(
       // channel_dim` for a row-major contiguous layout).
       for (int64_t flat = 0; flat < total; ++flat) {
         const int64_t c = (flat / channel_stride) % channel_dim;
-        const double v = static_cast<double>(data[static_cast<size_t>(flat)]);
+        const double v = data[static_cast<size_t>(flat)];
         acc[static_cast<size_t>(c)] += v * v;
       }
       count[name] += total / channel_dim;
@@ -20786,13 +20798,32 @@ onnx::ModelProto ApplySparseGptPruning(
 // C++ port of pruning.py's own `apply_wanda_pruning` -- see
 // structured_pruning_entry.h's own ApplyWandaPruning declaration comment
 // for the full scope (candidate set identical to ApplySparseGptPruning
-// immediately above; FLOAT32-only, Conv out of scope) and the
-// per-layer/`global_sparsity` masking contract this implements. Reuses
-// WandaCalibrationStats verbatim for the calibration statistic (same shape
-// ApplyStructuredWandaPruning/ApplyAttentionHeadWandaPruning already
-// consume), and MatchMatMulLikeRaw/MatchAttentionProducer verbatim for
-// candidate matching (same as ApplySparseGptPruning) -- the only genuinely
-// new machinery here is the plain one-shot importance score
+// immediately above except widened to FLOAT32/FLOAT16/BFLOAT16; Conv out of
+// scope) and the per-layer/`global_sparsity` masking contract this
+// implements. Reuses WandaCalibrationStats for the calibration statistic
+// (same shape ApplyStructuredWandaPruning/ApplyAttentionHeadWandaPruning
+// already consume -- its own activation-dtype gate was widened from
+// FLOAT-only to IsSupportedFloatDtype/ReadTensorAsF64 as part of this same
+// change, see its own top comment; a strict widening that only lets it
+// observe MORE activations, so it changes nothing for those two other
+// callers' own FLOAT32-only candidate sets), MatchMatMulLikeRaw verbatim for
+// the MatMul/Gemm candidate case (its own weight-dtype gate lives at this
+// function's OWN call site below, not inside the shared matcher, so
+// widening it here is a strictly local change -- unlike Attention, see
+// immediately below), and a LOCAL, dtype-widened copy of
+// MatchAttentionProducer (MatchAttentionProducerWideDtype below) for the
+// Attention candidate case -- MatchAttentionProducer's own dtype gate is
+// baked INSIDE the shared matcher itself (unlike MatchMatMulLikeRaw's), and
+// that matcher is also reused by FindAttentionChains (structured
+// Attention-head pruning) and ApplySparseGptPruning immediately above, both
+// deliberately FLOAT32-only per their own declaration comments -- widening
+// it in place would silently widen candidate matching for those two
+// unrelated, independently-verified-only-for-FLOAT32 passes too. Hence the
+// narrow, local duplicate instead, exactly the same "narrow, local
+// duplicate instead of a shared-code change" precedent this file's own
+// MoE/QMoE section top comment already established for the analogous
+// FLOAT32-only-elsewhere situation. The only genuinely new machinery here
+// (beyond the dtype widening) is the plain one-shot importance score
 // (`|W_ij| * ||X_j||_2`, WandaImportance below, no Hessian/Cholesky at all)
 // and its element-wise masking (WandaSparsityMaskNK/WandaNmMaskNK/the
 // `global_sparsity` pooling loop inside ApplyWandaPruning itself), mirroring
@@ -20832,21 +20863,23 @@ WandaNK ToWandaNK(const std::vector<double>& w_f64, int64_t dim0, int64_t dim1,
 // Inverse of ToWandaNK -- mirrors pruning.py's own `_nk_to_weight`
 // (non-Conv branch). `w_pruned_nk` is row-major `[n_rows, kk]`; the
 // returned buffer is row-major `[dim0, dim1]`, ready for
-// SetFloatTensorData.
-std::vector<float> FromWandaNK(const std::vector<double>& w_pruned_nk,
-                               int64_t dim0, int64_t dim1,
-                               bool weight_transposed) {
-  std::vector<float> w_new(static_cast<size_t>(dim0 * dim1));
+// WriteF64TensorAs (kept as `double` throughout, rather than narrowing to
+// `float` here, so a FLOAT16/BFLOAT16 weight's own downcast happens exactly
+// once, inside WriteF64TensorAs itself -- narrowing to float32 first and
+// then to half/bfloat16 would double-round, same reasoning as this file's
+// own DoubleToFloat16Bits comment).
+std::vector<double> FromWandaNK(const std::vector<double>& w_pruned_nk,
+                                int64_t dim0, int64_t dim1,
+                                bool weight_transposed) {
+  std::vector<double> w_new(static_cast<size_t>(dim0 * dim1));
   if (weight_transposed) {
-    for (size_t i = 0; i < w_new.size(); ++i) {
-      w_new[i] = static_cast<float>(w_pruned_nk[i]);
-    }
+    w_new = w_pruned_nk;
   } else {
     const int64_t kk = dim0;
     for (int64_t nx = 0; nx < dim1; ++nx) {
       for (int64_t kx = 0; kx < dim0; ++kx) {
         w_new[static_cast<size_t>(kx * dim1 + nx)] =
-            static_cast<float>(w_pruned_nk[static_cast<size_t>(nx * kk + kx)]);
+            w_pruned_nk[static_cast<size_t>(nx * kk + kx)];
       }
     }
   }
@@ -20958,6 +20991,92 @@ std::vector<uint8_t> WandaNmMaskNK(const std::vector<double>& importance,
   return mask;
 }
 
+// Local, dtype-widened copy of MatchAttentionProducer (structural logic
+// verbatim identical -- domain/op_type, weight/bias shape and dtype,
+// num_heads/qkv_hidden_sizes consistency), scoped to ApplyWandaPruning
+// alone: accepts FLOAT/FLOAT16/BFLOAT16 (IsSupportedFloatDtype) for both
+// the merged QKV weight and (if present) its merged bias, mirroring
+// pruning.py's own `_match_attention_producer`'s `_is_supported_float_dtype`
+// checks exactly (unlike MatchAttentionProducer's own hardcoded `==
+// onnx::TensorProto::FLOAT`). A genuinely separate copy rather than an
+// in-place widening of the shared MatchAttentionProducer -- see this file's
+// own "Wanda unstructured (element-wise) pruning" section top comment for
+// why: that function is also reused by FindAttentionChains (structured
+// Attention-head pruning) and ApplySparseGptPruning immediately above, both
+// deliberately FLOAT32-only per their own declaration comments, so widening
+// its dtype gate in place would silently widen candidate matching for those
+// two unrelated, independently-verified-only-for-FLOAT32 passes too --
+// exactly the MoE/QMoE section's own already-established "narrow, local
+// duplicate instead of a shared-code change" precedent. Bias dtype is
+// checked (though ApplyWandaPruning itself never reads bias) purely to
+// decline the same malformed-node shapes MatchAttentionProducer already
+// would, matching pruning.py's own `_match_attention_weight_only`'s full
+// reuse of `_match_attention_producer` (including its bias check) exactly.
+std::optional<AttentionProducerMatch> MatchAttentionProducerWideDtype(
+    const onnx::NodeProto& node, const InitMap& init_map) {
+  if (node.domain() != kComMicrosoftDomain || node.op_type() != "Attention") {
+    return std::nullopt;
+  }
+  if (node.input_size() < 2) {
+    return std::nullopt;
+  }
+  const std::string& w_name = node.input(1);
+  auto wit = init_map.find(w_name);
+  if (wit == init_map.end() ||
+      !IsSupportedFloatDtype(wit->second->data_type()) ||
+      wit->second->dims_size() != 2) {
+    return std::nullopt;
+  }
+  const int64_t total_n = wit->second->dims(1);
+
+  std::optional<std::string> bias_name;
+  if (node.input_size() >= 3 && !node.input(2).empty()) {
+    bias_name = node.input(2);
+    auto bit = init_map.find(*bias_name);
+    if (bit == init_map.end() ||
+        !IsSupportedFloatDtype(bit->second->data_type()) ||
+        bit->second->dims_size() != 1 || bit->second->dims(0) != total_n) {
+      return std::nullopt;
+    }
+  }
+
+  int64_t num_heads = 0;
+  bool has_num_heads = false;
+  std::optional<std::vector<int64_t>> qkv_hidden_sizes;
+  for (const auto& attr : node.attribute()) {
+    if (attr.name() == "num_heads") {
+      num_heads = attr.i();
+      has_num_heads = true;
+    } else if (attr.name() == "qkv_hidden_sizes") {
+      qkv_hidden_sizes =
+          std::vector<int64_t>(attr.ints().begin(), attr.ints().end());
+    }
+  }
+  if (!has_num_heads || num_heads <= 0) {
+    return std::nullopt;
+  }
+
+  int64_t nq, nk, nv;
+  if (qkv_hidden_sizes) {
+    if (qkv_hidden_sizes->size() != 3) {
+      return std::nullopt;
+    }
+    nq = (*qkv_hidden_sizes)[0];
+    nk = (*qkv_hidden_sizes)[1];
+    nv = (*qkv_hidden_sizes)[2];
+  } else {  // Schema default: Q/K/V evenly split the merged width.
+    if (total_n % 3 != 0) {
+      return std::nullopt;
+    }
+    nq = nk = nv = total_n / 3;
+  }
+  if (nq <= 0 || nk <= 0 || nv <= 0 || nq + nk + nv != total_n ||
+      nq % num_heads != 0 || nk % num_heads != 0 || nv % num_heads != 0) {
+    return std::nullopt;
+  }
+  return AttentionProducerMatch{w_name, bias_name, num_heads, nq, nk, nv};
+}
+
 }  // namespace
 
 onnx::ModelProto ApplyWandaPruning(
@@ -21004,14 +21123,19 @@ onnx::ModelProto ApplyWandaPruning(
     init_map[t.name()] = &t;
   }
 
-  // Exactly ApplySparseGptPruning's own candidate matching -- see this
-  // file's own ApplyWandaPruning declaration comment (structured_pruning_
-  // entry.h) for why the scope is identical: every matched MatMul/vanilla-
-  // Gemm layer (MatchMatMulLikeRaw) with a constant 2-D FLOAT32 weight,
-  // plus every matched com.microsoft::Attention node's constant 2-D
-  // FLOAT32 merged QKV weight (MatchAttentionProducer). 2-D Conv is
-  // declined outright -- never matched by either case below, left
-  // completely untouched.
+  // Like ApplySparseGptPruning's own candidate matching immediately above,
+  // widened to FLOAT32/FLOAT16/BFLOAT16 -- see this file's own
+  // ApplyWandaPruning declaration comment (structured_pruning_entry.h) and
+  // this file's own "Wanda unstructured (element-wise) pruning" section top
+  // comment for the two different widening mechanisms: every matched
+  // MatMul/vanilla-Gemm layer (MatchMatMulLikeRaw) with a constant 2-D
+  // FLOAT/FLOAT16/BFLOAT16 weight (IsSupportedFloatDtype, checked right
+  // here at the call site -- MatchMatMulLikeRaw itself has no dtype gate of
+  // its own), plus every matched com.microsoft::Attention node's constant
+  // 2-D FLOAT/FLOAT16/BFLOAT16 merged QKV weight
+  // (MatchAttentionProducerWideDtype, this pass' own local dtype-widened
+  // copy of MatchAttentionProducer). 2-D Conv is declined outright -- never
+  // matched by either case below, left completely untouched.
   struct Candidate {
     std::string x_name;
     std::string w_name;
@@ -21023,13 +21147,13 @@ onnx::ModelProto ApplyWandaPruning(
     if (mm) {
       auto wit = init_map.find(mm->w_name);
       if (wit != init_map.end() &&
-          wit->second->data_type() == onnx::TensorProto::FLOAT &&
+          IsSupportedFloatDtype(wit->second->data_type()) &&
           wit->second->dims_size() == 2) {
         candidates.push_back({mm->x_name, mm->w_name, mm->weight_transposed});
       }
       continue;
     }
-    auto am = MatchAttentionProducer(node, init_map);
+    auto am = MatchAttentionProducerWideDtype(node, init_map);
     if (am) {
       // The merged QKV weight has no transpose attribute of its own -- it
       // is already [K, N]-shaped by construction (see
@@ -21071,6 +21195,7 @@ onnx::ModelProto ApplyWandaPruning(
     // entirely zeroed), same as the Python original.
     struct Entry {
       onnx::TensorProto* w_init;
+      int32_t dtype = onnx::TensorProto::FLOAT;
       int64_t dim0 = 0;
       int64_t dim1 = 0;
       bool weight_transposed = false;
@@ -21081,10 +21206,12 @@ onnx::ModelProto ApplyWandaPruning(
     entries.reserve(candidates.size());
     for (const auto& c : candidates) {
       onnx::TensorProto* w_init = mut_init_map.at(c.w_name);
+      const int32_t dtype = w_init->data_type();
       const int64_t dim0 = w_init->dims(0);
       const int64_t dim1 = w_init->dims(1);
-      const std::vector<float> w_flat = ReadFloatTensor(*w_init);
-      const std::vector<double> w_f64(w_flat.begin(), w_flat.end());
+      // ReadTensorAsF64 (FLOAT/FLOAT16/BFLOAT16 -> double, exact upcast) --
+      // mirrors pruning.py's own `_to_f64`.
+      const std::vector<double> w_f64 = ReadTensorAsF64(*w_init);
       WandaNK nk = ToWandaNK(w_f64, dim0, dim1, c.weight_transposed);
 
       const std::vector<double>* norm = nullptr;
@@ -21094,7 +21221,7 @@ onnx::ModelProto ApplyWandaPruning(
       }
       std::vector<double> importance =
           WandaImportance(nk.w_nk, nk.n_rows, nk.kk, norm, epsilon);
-      entries.push_back({w_init, dim0, dim1, c.weight_transposed,
+      entries.push_back({w_init, dtype, dim0, dim1, c.weight_transposed,
                          std::move(nk.w_nk), std::move(importance)});
     }
 
@@ -21139,19 +21266,21 @@ onnx::ModelProto ApplyWandaPruning(
         pruned_nk[i] = drop_flat[offset + i] ? 0.0 : e.w_nk[i];
       }
       offset += size;
-      const std::vector<float> w_new =
+      const std::vector<double> w_new =
           FromWandaNK(pruned_nk, e.dim0, e.dim1, e.weight_transposed);
-      SetFloatTensorData(e.w_init, {e.dim0, e.dim1}, w_new);
+      WriteF64TensorAs(e.w_init, e.dtype, {e.dim0, e.dim1}, w_new);
     }
     return out;
   }
 
   for (const auto& c : candidates) {
     onnx::TensorProto* w_init = mut_init_map.at(c.w_name);
+    const int32_t dtype = w_init->data_type();
     const int64_t dim0 = w_init->dims(0);
     const int64_t dim1 = w_init->dims(1);
-    const std::vector<float> w_flat = ReadFloatTensor(*w_init);
-    const std::vector<double> w_f64(w_flat.begin(), w_flat.end());
+    // ReadTensorAsF64 (FLOAT/FLOAT16/BFLOAT16 -> double, exact upcast) --
+    // mirrors pruning.py's own `_to_f64`.
+    const std::vector<double> w_f64 = ReadTensorAsF64(*w_init);
     WandaNK nk = ToWandaNK(w_f64, dim0, dim1, c.weight_transposed);
 
     const std::vector<double>* norm = nullptr;
@@ -21171,9 +21300,9 @@ onnx::ModelProto ApplyWandaPruning(
     for (size_t i = 0; i < pruned_nk.size(); ++i) {
       pruned_nk[i] = mask[i] ? nk.w_nk[i] : 0.0;
     }
-    const std::vector<float> w_new =
+    const std::vector<double> w_new =
         FromWandaNK(pruned_nk, dim0, dim1, c.weight_transposed);
-    SetFloatTensorData(w_init, {dim0, dim1}, w_new);
+    WriteF64TensorAs(w_init, dtype, {dim0, dim1}, w_new);
   }
 
   return out;

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -4009,6 +4009,45 @@ int64_t ChainGroup(const Chain& chain) {
   return group;
 }
 
+// Whether `chain` may take part in ApplyStructuredPruning/
+// ApplyStructuredWandaPruning's own `global_sparsity` mode
+// (ApplyChainsGlobal below) -- an ordinary, single-producer chain with no
+// extra fan-out consumer branch and no general grouped Conv on either side.
+// Mirrors pruning.py's own _chain_is_global_sparsity_eligible exactly -- see
+// apply_structured_pruning's own `global_sparsity` docstring for the full
+// reasoning (a gated pair, a residual/merge group, and any general grouped
+// Conv chain all fail this and are left completely untouched by
+// global_sparsity mode instead of folded into the pool or pruned locally
+// alongside it).
+bool ChainIsGlobalSparsityEligible(const Chain& chain) {
+  return chain.producers.size() == 1 && chain.extra_consumers.empty() &&
+         ChainGroup(chain) == 1;
+}
+
+// Selects L1 (sum of absolute weight magnitude) or L2 (Li et al.'s original
+// root-sum-square) importance ranking -- mirrors pruning.py's own
+// `_ImportanceNorm`/`_validate_importance_norm`. Kept as a tiny internal
+// enum (parsed once at each public entry point via ParseImportanceNorm)
+// rather than threading a raw `std::string` through every chain-application
+// helper below, exactly the same "parse the string once at the boundary"
+// convention QuantizeFp8 (quantize_entry.cpp) already establishes for its
+// own `format` string parameter -- see that function's own body.
+enum class ImportanceNorm { kL2, kL1 };
+
+ImportanceNorm ParseImportanceNorm(const std::string& importance_norm,
+                                   const char* caller) {
+  if (importance_norm == "l2") {
+    return ImportanceNorm::kL2;
+  }
+  if (importance_norm == "l1") {
+    return ImportanceNorm::kL1;
+  }
+  throw std::invalid_argument(
+      std::string(caller) +
+      ": importance_norm must be \"l1\" or \"l2\", got \"" + importance_norm +
+      "\"");
+}
+
 // --- Slicing, mirroring _slice_producer_weight/_slice_consumer_weight/
 // _slice_grouped_consumer_conv_weight/_slice_last_axis ----------------------
 
@@ -4206,6 +4245,148 @@ struct TouchedState {
   std::unordered_set<std::string> stale_value_info;
 };
 
+// Performs the actual channel-removal slicing for one already-decided
+// (ascending) `keep` index set -- every producer's weight/bias, every
+// chain-op constant, every depthwise pass-through hop, the (possibly
+// grouped) consumer, and every extra fan-out consumer branch. Factored out
+// of ApplyChains so ApplyChainsGlobal (ApplyStructuredPruning's own
+// `global_sparsity` mode) can reuse the identical slicing mechanics without
+// duplicating it -- mirrors pruning.py's own _slice_chain_channels exactly,
+// including that touched-role bookkeeping is deliberately NOT part of this
+// function (the two callers mark touched roles at different points relative
+// to slicing -- ApplyChains as it goes, ApplyChainsGlobal eagerly during
+// admission, before any chain's final `keep` is even decided -- see that
+// function's own comment).
+void SliceChainChannels(
+    std::unordered_map<std::string, onnx::TensorProto*>& init_map, Chain& chain,
+    const std::vector<int64_t>& keep,
+    std::unordered_set<std::string>& stale_value_info) {
+  const int64_t n = chain.n_channels;
+  std::vector<const ConsumerBranch*> extra_ptrs;
+  extra_ptrs.reserve(chain.extra_consumers.size());
+  for (const auto& b : chain.extra_consumers) {
+    extra_ptrs.push_back(&b);
+  }
+
+  for (const auto& p : chain.producers) {
+    SliceProducerWeight(init_map.at(p.weight), p.weight_transposed, keep,
+                        p.is_conv);
+    if (p.bias) {
+      SliceLastAxis(init_map.at(*p.bias), keep);
+    }
+  }
+  for (const auto& co : chain.chain_ops) {
+    if (co.const_name) {
+      SliceLastAxis(init_map.at(*co.const_name), keep);
+    }
+  }
+  for (const auto& hop : chain.conv_pass_through) {
+    SliceProducerWeight(init_map.at(hop.weight), false, keep, true);
+    if (hop.bias) {
+      SliceLastAxis(init_map.at(*hop.bias), keep);
+    }
+    if (hop.past_state) {
+      // A CausalConvWithState hop's own constant `past_state` -- rank-3
+      // `(batch, channels, k-1)`, channel axis 1 -- reuses
+      // SliceConsumerWeight's own `is_conv` branch (SliceAxis1 over
+      // dims(0)/dims(1) with `inner = prod(dims[2:])`), which slices
+      // exactly that axis; mirrors pruning.py's own _slice_axis1 call in
+      // _apply_conv_pass_through_hop.
+      SliceConsumerWeight(init_map.at(*hop.past_state), false, keep, true);
+    }
+    // A PRelu per-channel-slope hop reuses ConvPassThrough for its own
+    // slicing (see MatchPreluPassThrough's own comment) but, unlike a
+    // depthwise Conv hop, has no `group` attribute of its own to update --
+    // mirrors pruning.py's own _apply_conv_pass_through_hop, which only
+    // ever touches `group` when the hop node is actually a Conv.
+    if (hop.node->op_type() == "Conv") {
+      SetOrAddIntAttr(hop.node, "group", static_cast<int64_t>(keep.size()));
+    }
+  }
+  if (chain.group_norm) {
+    // Same `keep` index set as the real producer -- `num_groups` itself is
+    // left untouched (see GroupNormPassThrough's own comment for why it
+    // stays valid without changing it). Sliced via SliceLastAxis, not
+    // ConvPassThrough's own axis-0 SliceProducerWeight -- see
+    // GroupNormPassThrough's own comment for why.
+    SliceLastAxis(init_map.at(chain.group_norm->scale), keep);
+    SliceLastAxis(init_map.at(chain.group_norm->bias), keep);
+  }
+  if (chain.consumer_is_conv && chain.consumer_group > 1) {
+    SliceGroupedConsumerConvWeight(init_map.at(chain.consumer_weight), keep,
+                                   chain.consumer_group, n);
+  } else {
+    SliceConsumerWeight(init_map.at(chain.consumer_weight),
+                        chain.consumer_weight_transposed, keep,
+                        chain.consumer_is_conv);
+  }
+  // Extra fan-out branches: each is either an ordinary (group == 1)
+  // consumer, or, for a Conv residual/merge chain, a general grouped Conv
+  // consumer whose own group was already confirmed (in
+  // FindConvResidualChains) to agree with `group` above --
+  // ResolveMatmulFanoutBranches never resolves a grouped one, so
+  // consumer_group stays at its default 1 there. Either way, fed by the
+  // exact same `keep` just computed for the group's shared producers above.
+  for (const auto* b : extra_ptrs) {
+    for (const auto& co : b->chain_ops) {
+      if (co.const_name) {
+        SliceLastAxis(init_map.at(*co.const_name), keep);
+      }
+    }
+    for (const auto& hop : b->conv_pass_through) {
+      SliceProducerWeight(init_map.at(hop.weight), false, keep, true);
+      if (hop.bias) {
+        SliceLastAxis(init_map.at(*hop.bias), keep);
+      }
+      if (hop.past_state) {
+        SliceConsumerWeight(init_map.at(*hop.past_state), false, keep, true);
+      }
+      if (hop.node->op_type() == "Conv") {
+        SetOrAddIntAttr(hop.node, "group", static_cast<int64_t>(keep.size()));
+      }
+    }
+    if (b->consumer_is_conv && b->consumer_group > 1) {
+      SliceGroupedConsumerConvWeight(init_map.at(b->consumer_weight), keep,
+                                     b->consumer_group, n);
+    } else {
+      SliceConsumerWeight(init_map.at(b->consumer_weight),
+                          b->consumer_weight_transposed, keep,
+                          b->consumer_is_conv);
+    }
+  }
+
+  for (const auto& p : chain.producers) {
+    stale_value_info.insert(p.node->output(0));
+    for (const auto* pre_op : p.pre_ops) {
+      stale_value_info.insert(pre_op->output(0));
+    }
+  }
+  for (const auto& co : chain.chain_ops) {
+    stale_value_info.insert(co.node->output(0));
+  }
+  // Every output, not just [0] -- a hop node can have more than one (e.g.
+  // `CausalConvWithState`'s own `present_state`); see ConvPassThrough's own
+  // docstring.
+  for (const auto& hop : chain.conv_pass_through) {
+    for (const auto& out : hop.node->output()) {
+      stale_value_info.insert(out);
+    }
+  }
+  if (chain.group_norm) {
+    stale_value_info.insert(chain.group_norm->node->output(0));
+  }
+  for (const auto* b : extra_ptrs) {
+    for (const auto& co : b->chain_ops) {
+      stale_value_info.insert(co.node->output(0));
+    }
+    for (const auto& hop : b->conv_pass_through) {
+      for (const auto& out : hop.node->output()) {
+        stale_value_info.insert(out);
+      }
+    }
+  }
+}
+
 // `act_norm`, when non-null, is a probe-name -> per-channel calibrated
 // activation-L2-norm map (see WandaCalibrationStats below), keyed by
 // `chain.consumer_node->input(0)` -- the same probe point
@@ -4216,19 +4397,26 @@ struct TouchedState {
 // mirrored by *any* mismatch here too -- an absent probe name, or a
 // present one whose length no longer lines up with this chain because a
 // sibling chain already resliced the shared tensor first), each channel's
-// plain ``||W_row||_2`` importance is multiplied by
-// ``max(act_norm[c], epsilon)`` -- Wanda's own metric. `nullptr` (the
-// default, and every ApplyStructuredPruning call site's own unchanged
-// argument count) keeps this identically the plain L2-only ranking it
-// always was; this is the one shared importance-computation point both
-// ApplyStructuredPruning and ApplyStructuredWandaPruning go through, so
-// the two never duplicate the ranking/top-k/slicing logic below -- only
-// the *importance vector feeding into it* differs.
+// plain importance is multiplied by ``max(act_norm[c], epsilon)`` -- Wanda's
+// own metric. `nullptr` (the default, and every ApplyStructuredPruning call
+// site's own unchanged argument count) keeps this identically the plain
+// weight-only ranking it always was; this is the one shared
+// importance-computation point both ApplyStructuredPruning and
+// ApplyStructuredWandaPruning go through, so the two never duplicate the
+// ranking/top-k/slicing logic below -- only the *importance vector feeding
+// into it* differs. `importance_norm` selects L1 vs. L2 weight-magnitude
+// ranking (see ImportanceNorm above) -- defaulted to kL2 so every
+// pre-existing call site is completely unaffected; applies identically
+// whether or not `act_norm` is given, mirroring pruning.py's own
+// `_plain_structured_importance`/`_wanda_structured_importance` split
+// exactly (the activation-norm multiplier always stays L2, only the
+// `||W_row||` term itself switches).
 void ApplyChains(onnx::GraphProto* graph, std::vector<Chain>& chains,
                  double sparsity, TouchedState& touched,
                  const std::unordered_map<std::string, std::vector<double>>*
                      act_norm = nullptr,
-                 double epsilon = 1e-8) {
+                 double epsilon = 1e-8,
+                 ImportanceNorm importance_norm = ImportanceNorm::kL2) {
   std::unordered_map<std::string, onnx::TensorProto*> init_map;
   for (int i = 0; i < graph->initializer_size(); ++i) {
     onnx::TensorProto* t = graph->mutable_initializer(i);
@@ -4394,23 +4582,33 @@ void ApplyChains(onnx::GraphProto* graph, std::vector<Chain>& chains,
     for (const auto& w_nk : w_arrays_nk) {
       const int64_t k = static_cast<int64_t>(w_nk.size()) / n;
       for (int64_t c = 0; c < n; ++c) {
-        double sq = 0.0;
+        double acc = 0.0;
         for (int64_t j = 0; j < k; ++j) {
           const double v = w_nk[static_cast<size_t>(c * k + j)];
-          sq += v * v;
+          acc += importance_norm == ImportanceNorm::kL1 ? std::abs(v) : v * v;
         }
-        importance[static_cast<size_t>(c)] += sq;
+        importance[static_cast<size_t>(c)] += acc;
       }
     }
-    for (double& v : importance) {
-      v = std::sqrt(v);
+    // For L2 this is the root-sum-square combine across producers (Li et
+    // al.'s own criterion); for L1 the analogous combine is a plain sum with
+    // no square/sqrt anywhere -- mirrors pruning.py's own
+    // `_plain_structured_importance` exactly (see that function's own
+    // comment for the ``||concat(a, b)||`` identities behind each).
+    if (importance_norm != ImportanceNorm::kL1) {
+      for (double& v : importance) {
+        v = std::sqrt(v);
+      }
     }
 
-    // Wanda upgrade: multiply each channel's plain ||W_row||_2 by its own
-    // calibrated activation L2 norm -- mirrors pruning.py's own
-    // `_wanda_structured_importance` exactly, including the fallback to
-    // plain `importance` (left untouched) when no matching activation was
-    // observed for this chain's own probe point.
+    // Wanda upgrade: multiply each channel's plain weight-magnitude
+    // importance by its own calibrated activation L2 norm -- mirrors
+    // pruning.py's own `_wanda_structured_importance` exactly, including the
+    // fallback to plain `importance` (left untouched) when no matching
+    // activation was observed for this chain's own probe point. The
+    // activation-norm term itself always stays L2, per Wanda's own
+    // definition -- only `importance` above (the ``||W_row||`` term) ever
+    // switches with `importance_norm`.
     if (act_norm != nullptr) {
       auto it = act_norm->find(chain.consumer_node->input(0));
       if (it != act_norm->end() &&
@@ -4436,93 +4634,7 @@ void ApplyChains(onnx::GraphProto* graph, std::vector<Chain>& chains,
       keep = TopKIndicesAscending(importance, keep_count);
     }
 
-    for (const auto& p : chain.producers) {
-      SliceProducerWeight(init_map.at(p.weight), p.weight_transposed, keep,
-                          p.is_conv);
-      if (p.bias) {
-        SliceLastAxis(init_map.at(*p.bias), keep);
-      }
-    }
-    for (const auto& co : chain.chain_ops) {
-      if (co.const_name) {
-        SliceLastAxis(init_map.at(*co.const_name), keep);
-      }
-    }
-    for (const auto& hop : chain.conv_pass_through) {
-      SliceProducerWeight(init_map.at(hop.weight), false, keep, true);
-      if (hop.bias) {
-        SliceLastAxis(init_map.at(*hop.bias), keep);
-      }
-      if (hop.past_state) {
-        // A CausalConvWithState hop's own constant `past_state` -- rank-3
-        // `(batch, channels, k-1)`, channel axis 1 -- reuses
-        // SliceConsumerWeight's own `is_conv` branch (SliceAxis1 over
-        // dims(0)/dims(1) with `inner = prod(dims[2:])`), which slices
-        // exactly that axis; mirrors pruning.py's own _slice_axis1 call in
-        // _apply_conv_pass_through_hop.
-        SliceConsumerWeight(init_map.at(*hop.past_state), false, keep, true);
-      }
-      // A PRelu per-channel-slope hop reuses ConvPassThrough for its own
-      // slicing (see MatchPreluPassThrough's own comment) but, unlike a
-      // depthwise Conv hop, has no `group` attribute of its own to update --
-      // mirrors pruning.py's own _apply_conv_pass_through_hop, which only
-      // ever touches `group` when the hop node is actually a Conv.
-      if (hop.node->op_type() == "Conv") {
-        SetOrAddIntAttr(hop.node, "group", static_cast<int64_t>(keep.size()));
-      }
-    }
-    if (chain.group_norm) {
-      // Same `keep` index set as the real producer -- `num_groups` itself is
-      // left untouched (see GroupNormPassThrough's own comment for why it
-      // stays valid without changing it). Sliced via SliceLastAxis, not
-      // ConvPassThrough's own axis-0 SliceProducerWeight -- see
-      // GroupNormPassThrough's own comment for why.
-      SliceLastAxis(init_map.at(chain.group_norm->scale), keep);
-      SliceLastAxis(init_map.at(chain.group_norm->bias), keep);
-    }
-    if (chain.consumer_is_conv && chain.consumer_group > 1) {
-      SliceGroupedConsumerConvWeight(init_map.at(chain.consumer_weight), keep,
-                                     chain.consumer_group, n);
-    } else {
-      SliceConsumerWeight(init_map.at(chain.consumer_weight),
-                          chain.consumer_weight_transposed, keep,
-                          chain.consumer_is_conv);
-    }
-    // Extra fan-out branches: each is either an ordinary (group == 1)
-    // consumer, or, for a Conv residual/merge chain, a general grouped Conv
-    // consumer whose own group was already confirmed (in
-    // FindConvResidualChains) to agree with `group` above --
-    // ResolveMatmulFanoutBranches never resolves a grouped one, so
-    // consumer_group stays at its default 1 there. Either way, fed by the
-    // exact same `keep` just computed for the group's shared producers
-    // above.
-    for (const auto* b : extra_ptrs) {
-      for (const auto& co : b->chain_ops) {
-        if (co.const_name) {
-          SliceLastAxis(init_map.at(*co.const_name), keep);
-        }
-      }
-      for (const auto& hop : b->conv_pass_through) {
-        SliceProducerWeight(init_map.at(hop.weight), false, keep, true);
-        if (hop.bias) {
-          SliceLastAxis(init_map.at(*hop.bias), keep);
-        }
-        if (hop.past_state) {
-          SliceConsumerWeight(init_map.at(*hop.past_state), false, keep, true);
-        }
-        if (hop.node->op_type() == "Conv") {
-          SetOrAddIntAttr(hop.node, "group", static_cast<int64_t>(keep.size()));
-        }
-      }
-      if (b->consumer_is_conv && b->consumer_group > 1) {
-        SliceGroupedConsumerConvWeight(init_map.at(b->consumer_weight), keep,
-                                       b->consumer_group, n);
-      } else {
-        SliceConsumerWeight(init_map.at(b->consumer_weight),
-                            b->consumer_weight_transposed, keep,
-                            b->consumer_is_conv);
-      }
-    }
+    SliceChainChannels(init_map, chain, keep, stale_value_info);
 
     for (const auto& w : producer_weights) {
       producer_touched.insert(w);
@@ -4536,36 +4648,251 @@ void ApplyChains(onnx::GraphProto* graph, std::vector<Chain>& chains,
     for (const auto& w : conv_hop_weights) {
       conv_hop_touched.insert(w);
     }
+  }
+}
+
+// Global-sparsity companion to ApplyChains, used by
+// ApplyStructuredPruning/ApplyStructuredWandaPruning's own `global_sparsity`
+// mode. Mirrors pruning.py's own _apply_chains_global exactly, including its
+// own doc comment's full reasoning -- summarized here:
+//
+// The caller is required to have already filtered `chains` down to ones
+// with exactly one producer, no extra fan-out consumer branch, and
+// ChainGroup == 1 (ChainIsGlobalSparsityEligible above) -- this function
+// itself assumes that filtering already happened and doesn't re-check it.
+//
+// Two passes rather than ApplyChains' one: every admitted chain's own
+// channel importance must be known before any single chain's `keep` can be
+// decided, since global sparsity's whole point is one shared cutoff picked
+// from every admitted chain's pooled importance. Admission -- the same
+// tied-weight conflict/degenerate checks ApplyChains already performs, in
+// the same list order -- still happens greedily, chain by chain, in one
+// first pass, and an admitted chain's own weights are marked touched
+// immediately, *before* its own final `keep_count` is known (unlike
+// ApplyChains, where a chain whose `keep_count` rounds up to a no-op is
+// left completely unmarked) -- whether a chain's own `keep_count` will
+// round to a no-op can't be known until every admitted chain's importance
+// has been pooled and the one shared global cutoff is picked, so admission
+// can't be deferred that way without circularity.
+//
+// Each admitted chain keeps at least one channel -- the same floor
+// ApplyChains already enforces per chain -- pulled back out of the global
+// drop set after the fact whenever the global cutoff would otherwise reduce
+// a chain to zero channels (mirrors pruning.py's own per-chain floor
+// exactly, just resolved globally rather than locally).
+void ApplyChainsGlobal(
+    onnx::GraphProto* graph, std::vector<Chain>& chains, double sparsity,
+    TouchedState& touched,
+    const std::unordered_map<std::string, std::vector<double>>* act_norm =
+        nullptr,
+    double epsilon = 1e-8,
+    ImportanceNorm importance_norm = ImportanceNorm::kL2) {
+  std::unordered_map<std::string, onnx::TensorProto*> init_map;
+  for (int i = 0; i < graph->initializer_size(); ++i) {
+    onnx::TensorProto* t = graph->mutable_initializer(i);
+    init_map[t->name()] = t;
+  }
+  std::unordered_set<std::string>& producer_touched = touched.producer;
+  std::unordered_set<std::string>& consumer_touched = touched.consumer;
+  std::unordered_set<std::string>& const_touched = touched.const_names;
+  std::unordered_set<std::string>& conv_hop_touched = touched.conv_hop;
+  std::unordered_set<std::string>& stale_value_info = touched.stale_value_info;
+
+  struct Admitted {
+    Chain* chain;
+    std::vector<double> importance;
+  };
+  std::vector<Admitted> admitted;
+
+  for (auto& chain : chains) {
+    std::unordered_set<std::string> producer_weights;
+    bool degenerate = false;
     for (const auto& p : chain.producers) {
-      stale_value_info.insert(p.node->output(0));
-      for (const auto* pre_op : p.pre_ops) {
-        stale_value_info.insert(pre_op->output(0));
+      if (!producer_weights.insert(p.weight).second) {
+        degenerate = true;
+        break;
+      }
+    }
+    if (degenerate) {
+      continue;  // Degenerate -- shouldn't happen for a single-producer chain.
+    }
+
+    std::unordered_set<std::string> consumer_weights{chain.consumer_weight};
+
+    std::unordered_set<std::string> conv_hop_weights;
+    for (const auto& h : chain.conv_pass_through) {
+      conv_hop_weights.insert(h.weight);
+    }
+    if (conv_hop_weights.size() != chain.conv_pass_through.size()) {
+      continue;  // Degenerate -- the same depthwise weight named twice.
+    }
+
+    std::unordered_set<std::string> consts;
+    for (const auto& p : chain.producers) {
+      if (p.bias) {
+        consts.insert(*p.bias);
       }
     }
     for (const auto& co : chain.chain_ops) {
-      stale_value_info.insert(co.node->output(0));
-    }
-    // Every output, not just [0] -- a hop node can have more than one (e.g.
-    // `CausalConvWithState`'s own `present_state`); see ConvPassThrough's
-    // own docstring.
-    for (const auto& hop : chain.conv_pass_through) {
-      for (const auto& out : hop.node->output()) {
-        stale_value_info.insert(out);
+      if (co.const_name) {
+        consts.insert(*co.const_name);
       }
     }
     if (chain.group_norm) {
-      stale_value_info.insert(chain.group_norm->node->output(0));
+      consts.insert(chain.group_norm->scale);
+      consts.insert(chain.group_norm->bias);
     }
-    for (const auto* b : extra_ptrs) {
-      for (const auto& co : b->chain_ops) {
-        stale_value_info.insert(co.node->output(0));
+
+    bool conflict = false;
+    for (const auto& w : consumer_weights) {
+      if (consumer_touched.count(w)) {
+        conflict = true;
       }
-      for (const auto& hop : b->conv_pass_through) {
-        for (const auto& out : hop.node->output()) {
-          stale_value_info.insert(out);
+    }
+    for (const auto& w : producer_weights) {
+      if (producer_touched.count(w)) {
+        conflict = true;
+      }
+    }
+    for (const auto& c : consts) {
+      if (const_touched.count(c)) {
+        conflict = true;
+      }
+    }
+    for (const auto& w : conv_hop_weights) {
+      if (conv_hop_touched.count(w)) {
+        conflict = true;
+      }
+    }
+    if (conflict) {
+      continue;  // A shared/tied initializer another chain already resized.
+    }
+
+    const int64_t n = chain.n_channels;
+    std::vector<std::vector<float>> w_arrays_nk;
+    for (const auto& p : chain.producers) {
+      onnx::TensorProto* wt = init_map.at(p.weight);
+      std::vector<int64_t> dims(wt->dims().begin(), wt->dims().end());
+      std::vector<float> data = ReadFloatTensor(*wt);
+      if (p.is_conv) {
+        w_arrays_nk.push_back(std::move(data));
+      } else if (p.weight_transposed) {
+        w_arrays_nk.push_back(std::move(data));
+      } else {
+        w_arrays_nk.push_back(TransposeFlat(data, dims[0], dims[1]));
+      }
+    }
+
+    std::vector<double> importance(static_cast<size_t>(n), 0.0);
+    for (const auto& w_nk : w_arrays_nk) {
+      const int64_t k = static_cast<int64_t>(w_nk.size()) / n;
+      for (int64_t c = 0; c < n; ++c) {
+        double acc = 0.0;
+        for (int64_t j = 0; j < k; ++j) {
+          const double v = w_nk[static_cast<size_t>(c * k + j)];
+          acc += importance_norm == ImportanceNorm::kL1 ? std::abs(v) : v * v;
+        }
+        importance[static_cast<size_t>(c)] += acc;
+      }
+    }
+    if (importance_norm != ImportanceNorm::kL1) {
+      for (double& v : importance) {
+        v = std::sqrt(v);
+      }
+    }
+    if (act_norm != nullptr) {
+      auto it = act_norm->find(chain.consumer_node->input(0));
+      if (it != act_norm->end() &&
+          it->second.size() == static_cast<size_t>(n)) {
+        for (int64_t c = 0; c < n; ++c) {
+          importance[static_cast<size_t>(c)] *=
+              std::max(it->second[static_cast<size_t>(c)], epsilon);
         }
       }
     }
+
+    admitted.push_back({&chain, std::move(importance)});
+    for (const auto& w : producer_weights) {
+      producer_touched.insert(w);
+    }
+    for (const auto& w : consumer_weights) {
+      consumer_touched.insert(w);
+    }
+    for (const auto& c : consts) {
+      const_touched.insert(c);
+    }
+    for (const auto& w : conv_hop_weights) {
+      conv_hop_touched.insert(w);
+    }
+  }
+
+  if (admitted.empty()) {
+    return;
+  }
+
+  int64_t total_n = 0;
+  for (const auto& a : admitted) {
+    total_n += a.chain->n_channels;
+  }
+  const int64_t keep_count_total = std::min(
+      std::max<int64_t>(
+          std::llround(static_cast<double>(total_n) * (1.0 - sparsity)),
+          int64_t{0}),
+      total_n);
+  const int64_t drop_count_total = total_n - keep_count_total;
+
+  std::vector<double> pooled;
+  pooled.reserve(static_cast<size_t>(total_n));
+  for (const auto& a : admitted) {
+    pooled.insert(pooled.end(), a.importance.begin(), a.importance.end());
+  }
+
+  // Ascending-importance order, stable (mirrors np.argsort(pooled,
+  // kind="stable")) -- the lowest `drop_count_total` entries are dropped.
+  std::vector<int64_t> order(static_cast<size_t>(total_n));
+  std::iota(order.begin(), order.end(), int64_t{0});
+  std::stable_sort(order.begin(), order.end(), [&](int64_t a, int64_t b) {
+    return pooled[static_cast<size_t>(a)] < pooled[static_cast<size_t>(b)];
+  });
+  std::vector<bool> drop_flat(static_cast<size_t>(total_n), false);
+  for (int64_t i = 0; i < drop_count_total; ++i) {
+    drop_flat[static_cast<size_t>(order[static_cast<size_t>(i)])] = true;
+  }
+
+  int64_t offset = 0;
+  for (auto& a : admitted) {
+    Chain& chain = *a.chain;
+    const int64_t n = chain.n_channels;
+    bool all_dropped = true;
+    for (int64_t i = 0; i < n; ++i) {
+      if (!drop_flat[static_cast<size_t>(offset + i)]) {
+        all_dropped = false;
+        break;
+      }
+    }
+    if (all_dropped) {
+      // Per-chain floor: never drop every channel of an admitted chain --
+      // keep its own single highest-importance channel instead.
+      int64_t best = 0;
+      for (int64_t i = 1; i < n; ++i) {
+        if (a.importance[static_cast<size_t>(i)] >
+            a.importance[static_cast<size_t>(best)]) {
+          best = i;
+        }
+      }
+      drop_flat[static_cast<size_t>(offset + best)] = false;
+    }
+    std::vector<int64_t> keep;
+    for (int64_t i = 0; i < n; ++i) {
+      if (!drop_flat[static_cast<size_t>(offset + i)]) {
+        keep.push_back(i);
+      }
+    }
+    offset += n;
+    if (static_cast<int64_t>(keep.size()) >= n) {
+      continue;  // Every channel survived -- no-op, nothing to slice.
+    }
+    SliceChainChannels(init_map, chain, keep, stale_value_info);
   }
 }
 
@@ -5104,7 +5431,8 @@ std::optional<AppliedAttn> ApplyOnePlainAttentionChain(
     AttnChain& chain, double sparsity,
     const std::unordered_map<std::string, std::vector<double>>* act_norm =
         nullptr,
-    double epsilon = 1e-8) {
+    double epsilon = 1e-8,
+    ImportanceNorm importance_norm = ImportanceNorm::kL2) {
   const int64_t h = chain.num_heads;
   const int64_t keep_count =
       std::max<int64_t>(1, h - std::llround(static_cast<double>(h) * sparsity));
@@ -5118,25 +5446,31 @@ std::optional<AppliedAttn> ApplyOnePlainAttentionChain(
   const int64_t total_n = w_init->dims(1);
   std::vector<float> w = ReadFloatTensor(*w_init);  // [K, total_n] row-major.
 
+  // Combined importance of each head's full Q+K+V weight block -- for L2
+  // that's the block's own Frobenius norm (sqrt of the sum of every entry
+  // squared); for L1 the sum of every entry's own absolute value instead,
+  // with no square/sqrt anywhere -- mirrors pruning.py's own
+  // `_plain_attention_head_importance` exactly.
   std::vector<double> importance(static_cast<size_t>(h), 0.0);
   for (int64_t hh = 0; hh < h; ++hh) {
-    double sq = 0.0;
+    double acc = 0.0;
     for (int64_t r = 0; r < K; ++r) {
       for (int64_t c = hh * dq; c < (hh + 1) * dq; ++c) {
         const double v = w[static_cast<size_t>(r * total_n + c)];
-        sq += v * v;
+        acc += importance_norm == ImportanceNorm::kL1 ? std::abs(v) : v * v;
       }
       for (int64_t c = chain.nq + hh * dk; c < chain.nq + (hh + 1) * dk; ++c) {
         const double v = w[static_cast<size_t>(r * total_n + c)];
-        sq += v * v;
+        acc += importance_norm == ImportanceNorm::kL1 ? std::abs(v) : v * v;
       }
       for (int64_t c = chain.nq + chain.nk + hh * dv;
            c < chain.nq + chain.nk + (hh + 1) * dv; ++c) {
         const double v = w[static_cast<size_t>(r * total_n + c)];
-        sq += v * v;
+        acc += importance_norm == ImportanceNorm::kL1 ? std::abs(v) : v * v;
       }
     }
-    importance[static_cast<size_t>(hh)] = std::sqrt(sq);
+    importance[static_cast<size_t>(hh)] =
+        importance_norm == ImportanceNorm::kL1 ? acc : std::sqrt(acc);
   }
 
   // Wanda upgrade: multiply each head's plain ||W||_F by its own combined
@@ -5249,7 +5583,8 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
     AttnChain& chain, double sparsity,
     const std::unordered_map<std::string, std::vector<double>>* act_norm =
         nullptr,
-    double epsilon = 1e-8) {
+    double epsilon = 1e-8,
+    ImportanceNorm importance_norm = ImportanceNorm::kL2) {
   const int64_t h = chain.kv_num_heads;
   const int64_t keep_count =
       std::max<int64_t>(1, h - std::llround(static_cast<double>(h) * sparsity));
@@ -5290,26 +5625,34 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
                                  ? TransposeFlat(wv, wv_dims[0], wv_dims[1])
                                  : wv;
 
+  // Combined importance of each KV group's own Q+K+V weight block -- for L2
+  // that's the block's own Frobenius norm; for L1 the sum of every entry's
+  // own absolute value instead, with no square/sqrt anywhere -- mirrors
+  // pruning.py's own `_gqa_group_importance` exactly (see that function's
+  // own comment for why summing every entry, rather than concatenating, is
+  // used -- it stays well-defined even when Q's own row count differs from
+  // K/V's, the cross-attention shape this port also matches).
   std::vector<double> importance(static_cast<size_t>(chain.kv_num_heads), 0.0);
   for (int64_t kv = 0; kv < chain.kv_num_heads; ++kv) {
-    double sq = 0.0;
+    double acc = 0.0;
     for (int64_t r = 0; r < K; ++r) {
       for (int64_t g = kv * group_size; g < (kv + 1) * group_size; ++g) {
         for (int64_t c = g * d; c < (g + 1) * d; ++c) {
           const double v = wq_kn[static_cast<size_t>(r * Nq + c)];
-          sq += v * v;
+          acc += importance_norm == ImportanceNorm::kL1 ? std::abs(v) : v * v;
         }
       }
       for (int64_t c = kv * d; c < (kv + 1) * d; ++c) {
         const double v = wk_kn[static_cast<size_t>(r * Nk + c)];
-        sq += v * v;
+        acc += importance_norm == ImportanceNorm::kL1 ? std::abs(v) : v * v;
       }
       for (int64_t c = kv * d; c < (kv + 1) * d; ++c) {
         const double v = wv_kn[static_cast<size_t>(r * Nv + c)];
-        sq += v * v;
+        acc += importance_norm == ImportanceNorm::kL1 ? std::abs(v) : v * v;
       }
     }
-    importance[static_cast<size_t>(kv)] = std::sqrt(sq);
+    importance[static_cast<size_t>(kv)] =
+        importance_norm == ImportanceNorm::kL1 ? acc : std::sqrt(acc);
   }
 
   // Wanda upgrade: multiply each KV group's plain ||W||_F by its own
@@ -5398,7 +5741,8 @@ void ApplyAttentionChains(
     onnx::GraphProto* graph, std::vector<AttnChain>& chains, double sparsity,
     const std::unordered_map<std::string, std::vector<double>>* act_norm =
         nullptr,
-    double epsilon = 1e-8) {
+    double epsilon = 1e-8,
+    ImportanceNorm importance_norm = ImportanceNorm::kL2) {
   std::unordered_map<std::string, onnx::TensorProto*> init_map;
   for (int i = 0; i < graph->initializer_size(); ++i) {
     onnx::TensorProto* t = graph->mutable_initializer(i);
@@ -5426,9 +5770,10 @@ void ApplyAttentionChains(
 
     std::optional<AppliedAttn> applied =
         chain.kind == AttnChainKind::kGqaLike
-            ? ApplyOneGqaChain(init_map, chain, sparsity, act_norm, epsilon)
+            ? ApplyOneGqaChain(init_map, chain, sparsity, act_norm, epsilon,
+                               importance_norm)
             : ApplyOnePlainAttentionChain(init_map, chain, sparsity, act_norm,
-                                          epsilon);
+                                          epsilon, importance_norm);
     if (!applied) {
       continue;
     }
@@ -6196,7 +6541,8 @@ void ApplyConcatChains(
     TouchedState& touched,
     const std::unordered_map<std::string, std::vector<double>>* act_norm =
         nullptr,
-    double epsilon = 1e-8) {
+    double epsilon = 1e-8,
+    ImportanceNorm importance_norm = ImportanceNorm::kL2) {
   std::unordered_map<std::string, onnx::TensorProto*> init_map;
   for (int i = 0; i < graph->initializer_size(); ++i) {
     onnx::TensorProto* t = graph->mutable_initializer(i);
@@ -6299,16 +6645,18 @@ void ApplyConcatChains(
       for (const auto& w_nk : w_arrays_nk) {
         const int64_t k = static_cast<int64_t>(w_nk.size()) / n;
         for (int64_t c = 0; c < n; ++c) {
-          double sq = 0.0;
+          double acc = 0.0;
           for (int64_t j = 0; j < k; ++j) {
             const double v = w_nk[static_cast<size_t>(c * k + j)];
-            sq += v * v;
+            acc += importance_norm == ImportanceNorm::kL1 ? std::abs(v) : v * v;
           }
-          importance[static_cast<size_t>(c)] += sq;
+          importance[static_cast<size_t>(c)] += acc;
         }
       }
-      for (double& v : importance) {
-        v = std::sqrt(v);
+      if (importance_norm != ImportanceNorm::kL1) {
+        for (double& v : importance) {
+          v = std::sqrt(v);
+        }
       }
       // Wanda upgrade -- see ApplyChains' own identical comment. Keyed by
       // this branch's own probe point (`b.operand_name`) rather than a
@@ -6836,9 +7184,10 @@ std::vector<SplitGatedChain> FindSplitGatedChains(onnx::GraphProto* graph) {
 // to a *different* value is declined outright rather than corrupting the
 // first chain's own already-applied rewrite. Mirrors pruning.py's own
 // _apply_split_gated_chains.
-void ApplySplitGatedChains(onnx::GraphProto* graph,
-                           std::vector<SplitGatedChain>& chains,
-                           double sparsity, TouchedState& touched) {
+void ApplySplitGatedChains(
+    onnx::GraphProto* graph, std::vector<SplitGatedChain>& chains,
+    double sparsity, TouchedState& touched,
+    ImportanceNorm importance_norm = ImportanceNorm::kL2) {
   std::unordered_map<std::string, onnx::TensorProto*> init_map;
   for (int i = 0; i < graph->initializer_size(); ++i) {
     onnx::TensorProto* t = graph->mutable_initializer(i);
@@ -6884,16 +7233,26 @@ void ApplySplitGatedChains(onnx::GraphProto* graph,
       k = dims[0];
     }
 
+    // Combined (gate half + up half) importance -- for L2 that's
+    // sqrt(||gate_row||_2^2 + ||up_row||_2^2) (root-sum-square, Li et al.'s
+    // own criterion); for L1 the analogous combine is a plain sum of each
+    // half's own L1 norm, no square/sqrt anywhere -- mirrors pruning.py's
+    // own `_plain_branch_importance([gate_half, up_half], importance_norm)`
+    // exactly (see this function's own doc comment above).
     std::vector<double> importance(static_cast<size_t>(h), 0.0);
     for (int64_t c = 0; c < h; ++c) {
-      double sq_gate = 0.0, sq_up = 0.0;
+      double acc_gate = 0.0, acc_up = 0.0;
       for (int64_t j = 0; j < k; ++j) {
         const double vg = w_nk[static_cast<size_t>(c * k + j)];
-        sq_gate += vg * vg;
+        acc_gate +=
+            importance_norm == ImportanceNorm::kL1 ? std::abs(vg) : vg * vg;
         const double vu = w_nk[static_cast<size_t>((h + c) * k + j)];
-        sq_up += vu * vu;
+        acc_up +=
+            importance_norm == ImportanceNorm::kL1 ? std::abs(vu) : vu * vu;
       }
-      importance[static_cast<size_t>(c)] = std::sqrt(sq_gate + sq_up);
+      importance[static_cast<size_t>(c)] =
+          importance_norm == ImportanceNorm::kL1 ? acc_gate + acc_up
+                                                 : std::sqrt(acc_gate + acc_up);
     }
     const std::vector<int64_t> keep =
         TopKIndicesAscending(importance, keep_count);
@@ -19804,12 +20163,16 @@ std::unordered_map<std::string, SparseGptHessian> SparseGptHessianStats(
 }  // namespace
 
 onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
-                                        double sparsity) {
+                                        double sparsity,
+                                        const std::string& importance_norm,
+                                        bool global_sparsity) {
   if (!(sparsity >= 0.0 && sparsity < 1.0)) {
     throw std::invalid_argument(
         "ApplyStructuredPruning: sparsity must be in [0, 1), got " +
         std::to_string(sparsity));
   }
+  const ImportanceNorm norm =
+      ParseImportanceNorm(importance_norm, "ApplyStructuredPruning");
   onnx::ModelProto out = model;
 
   // Subgraph-aware (IterSubgraphs, see this file's own "Subgraph
@@ -19864,20 +20227,57 @@ onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
     std::vector<DynQuantChain> dynquant_chains = FindDynQuantChains(graph);
 
     TouchedState touched;
-    if (!chains.empty()) {
-      ApplyChains(graph, chains, sparsity, touched);
-    }
-    if (!concat_chains.empty()) {
-      ApplyConcatChains(graph, concat_chains, sparsity, touched);
-    }
-    if (!split_gated_chains.empty()) {
-      // A genuinely separate application pass, not folded into ApplyChains
-      // -- see FindSplitGatedChains/ApplySplitGatedChains's own section
-      // comment for why. Shares `touched` with the calls above so a weight
-      // this pass resizes can never be double-resized by (or
-      // double-resize) an ordinary chain/Concat-chain that happens to
-      // touch the same initializer -- still scoped to this one graph only.
-      ApplySplitGatedChains(graph, split_gated_chains, sparsity, touched);
+    // `global_sparsity` mirrors pruning.py's own apply_structured_pruning
+    // scope EXACTLY: only the plain chain family (`chains` -- FindChains/
+    // FindGatedChains/FindConvChains/FindConvResidualChains/
+    // FindMatmulResidualChains) ever takes part in the pooled ranking, via
+    // ApplyChainsGlobal restricted to ChainIsGlobalSparsityEligible members
+    // -- a gated pair, a residual/merge group, and any general grouped Conv
+    // chain are left completely untouched in this mode (see that
+    // function's own doc comment). `concat_chains`/`split_gated_chains` are
+    // Python's own `apply_structured_pruning`'s remaining two families and
+    // are likewise simply NOT applied in global_sparsity mode there (its
+    // own `if global_sparsity: ... else: ...` body only ever calls
+    // `_apply_concat_chains`/`_apply_split_gated_chains` from the `else`
+    // branch) -- mirrored here the same way. The quantized-weight families
+    // below (MatMulNBits/QDQ/Bnb4/Fp8/Fp4/QOperator/DynamicQuantizeMatMul)
+    // are additional scope this one C++ entry point consolidates from
+    // several separate pure-Python top-level functions
+    // (apply_structured_pruning_qdq and friends), NONE of which have a
+    // `global_sparsity` parameter of their own in pruning.py at all -- so
+    // `global_sparsity` has no defined meaning for them and they are always
+    // applied with their own local per-chain sparsity, completely
+    // unaffected by this flag either way.
+    if (global_sparsity) {
+      std::vector<Chain> global_chains;
+      for (const auto& c : chains) {
+        if (ChainIsGlobalSparsityEligible(c)) {
+          global_chains.push_back(c);
+        }
+      }
+      if (!global_chains.empty()) {
+        ApplyChainsGlobal(graph, global_chains, sparsity, touched, nullptr,
+                          1e-8, norm);
+      }
+    } else {
+      if (!chains.empty()) {
+        ApplyChains(graph, chains, sparsity, touched, nullptr, 1e-8, norm);
+      }
+      if (!concat_chains.empty()) {
+        ApplyConcatChains(graph, concat_chains, sparsity, touched, nullptr,
+                          1e-8, norm);
+      }
+      if (!split_gated_chains.empty()) {
+        // A genuinely separate application pass, not folded into
+        // ApplyChains -- see FindSplitGatedChains/ApplySplitGatedChains's
+        // own section comment for why. Shares `touched` with the calls
+        // above so a weight this pass resizes can never be double-resized
+        // by (or double-resize) an ordinary chain/Concat-chain that
+        // happens to touch the same initializer -- still scoped to this
+        // one graph only.
+        ApplySplitGatedChains(graph, split_gated_chains, sparsity, touched,
+                              norm);
+      }
     }
     if (!matmul_nbits_chains.empty() || !matmul_nbits_gated_chains.empty()) {
       // Another separate application pass -- see the "MatMulNBits
@@ -19976,12 +20376,15 @@ onnx::ModelProto ApplyStructuredWandaPruning(
     const onnx::ModelProto& model, const ModelExecutor& executor,
     const std::vector<std::unordered_map<std::string, onnx::TensorProto>>&
         calibration_data,
-    double sparsity, double epsilon) {
+    double sparsity, double epsilon, const std::string& importance_norm,
+    bool global_sparsity) {
   if (!(sparsity >= 0.0 && sparsity < 1.0)) {
     throw std::invalid_argument(
         "ApplyStructuredWandaPruning: sparsity must be in [0, 1), got " +
         std::to_string(sparsity));
   }
+  const ImportanceNorm norm =
+      ParseImportanceNorm(importance_norm, "ApplyStructuredWandaPruning");
   onnx::ModelProto out = model;
 
   // NOT subgraph-aware -- see this function's own declaration comment in
@@ -20047,19 +20450,38 @@ onnx::ModelProto ApplyStructuredWandaPruning(
       WandaCalibrationStats(executor, out, probe_axis, calibration_data);
 
   TouchedState touched;
-  if (!chains.empty()) {
-    ApplyChains(graph, chains, sparsity, touched, &act_norm, epsilon);
-  }
-  if (!concat_chains.empty()) {
-    ApplyConcatChains(graph, concat_chains, sparsity, touched, &act_norm,
-                      epsilon);
-  }
-  if (!split_gated_chains.empty()) {
-    // Plain weight-magnitude importance only, unchanged -- see this
-    // function's own comment above on `probe_axis` for why: reused
-    // completely as-is, exactly like ApplyStructuredPruning's own call to
-    // it, no `act_norm`/`epsilon` parameters to thread through at all.
-    ApplySplitGatedChains(graph, split_gated_chains, sparsity, touched);
+  // `global_sparsity` mirrors pruning.py's own apply_structured_wanda_pruning
+  // scope exactly -- see ApplyStructuredPruning's own identical comment
+  // above for the full reasoning (only the plain chain family pools into
+  // ApplyChainsGlobal; concat_chains/split_gated_chains are simply not
+  // applied in this mode, mirroring the Python `if global_sparsity: ...
+  // else: ...` split exactly).
+  if (global_sparsity) {
+    std::vector<Chain> global_chains;
+    for (const auto& c : chains) {
+      if (ChainIsGlobalSparsityEligible(c)) {
+        global_chains.push_back(c);
+      }
+    }
+    if (!global_chains.empty()) {
+      ApplyChainsGlobal(graph, global_chains, sparsity, touched, &act_norm,
+                        epsilon, norm);
+    }
+  } else {
+    if (!chains.empty()) {
+      ApplyChains(graph, chains, sparsity, touched, &act_norm, epsilon, norm);
+    }
+    if (!concat_chains.empty()) {
+      ApplyConcatChains(graph, concat_chains, sparsity, touched, &act_norm,
+                        epsilon, norm);
+    }
+    if (!split_gated_chains.empty()) {
+      // Plain weight-magnitude importance only (no calibrated activation
+      // norm -- see this function's own comment above on `probe_axis` for
+      // why), but `importance_norm` still applies -- mirrors pruning.py's
+      // own `_split_gated_wanda_importance` exactly.
+      ApplySplitGatedChains(graph, split_gated_chains, sparsity, touched, norm);
+    }
   }
   if (!touched.stale_value_info.empty()) {
     google::protobuf::RepeatedPtrField<onnx::ValueInfoProto> kept;
@@ -20074,12 +20496,15 @@ onnx::ModelProto ApplyStructuredWandaPruning(
 }
 
 onnx::ModelProto ApplyAttentionHeadPruning(const onnx::ModelProto& model,
-                                           double sparsity) {
+                                           double sparsity,
+                                           const std::string& importance_norm) {
   if (!(sparsity >= 0.0 && sparsity < 1.0)) {
     throw std::invalid_argument(
         "ApplyAttentionHeadPruning: sparsity must be in [0, 1), got " +
         std::to_string(sparsity));
   }
+  const ImportanceNorm norm =
+      ParseImportanceNorm(importance_norm, "ApplyAttentionHeadPruning");
   onnx::ModelProto out = model;
 
   // Subgraph-aware (IterSubgraphs, see this file's own "Subgraph
@@ -20104,7 +20529,7 @@ onnx::ModelProto ApplyAttentionHeadPruning(const onnx::ModelProto& model,
                   std::make_move_iterator(onnx_attn_chains.begin()),
                   std::make_move_iterator(onnx_attn_chains.end()));
     if (!chains.empty()) {
-      ApplyAttentionChains(graph, chains, sparsity);
+      ApplyAttentionChains(graph, chains, sparsity, nullptr, 1e-8, norm);
     }
     // The fused `com.microsoft::MatMulNBitsQkv` variant -- see the
     // "MatMulNBitsMlp/MatMulNBitsQkv (fused block-quantized weight)
@@ -20140,12 +20565,14 @@ onnx::ModelProto ApplyAttentionHeadWandaPruning(
     const onnx::ModelProto& model, const ModelExecutor& executor,
     const std::vector<std::unordered_map<std::string, onnx::TensorProto>>&
         calibration_data,
-    double sparsity, double epsilon) {
+    double sparsity, double epsilon, const std::string& importance_norm) {
   if (!(sparsity >= 0.0 && sparsity < 1.0)) {
     throw std::invalid_argument(
         "ApplyAttentionHeadWandaPruning: sparsity must be in [0, 1), got " +
         std::to_string(sparsity));
   }
+  const ImportanceNorm norm =
+      ParseImportanceNorm(importance_norm, "ApplyAttentionHeadWandaPruning");
   onnx::ModelProto out = model;
 
   // NOT subgraph-aware -- mirrors pruning.py's own
@@ -20190,7 +20617,7 @@ onnx::ModelProto ApplyAttentionHeadWandaPruning(
   const std::unordered_map<std::string, std::vector<double>> act_norm =
       WandaCalibrationStats(executor, out, probe_axis, calibration_data);
 
-  ApplyAttentionChains(graph, chains, sparsity, &act_norm, epsilon);
+  ApplyAttentionChains(graph, chains, sparsity, &act_norm, epsilon, norm);
   return out;
 }
 

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -19283,9 +19283,10 @@ void CommitTransformerBlockDrops(
 // C++ port of pruning.py's own apply_sparsegpt_pruning / _sparsegpt_prune_
 // columns / onnxsim.gptq._inverse_hessian_cholesky. See structured_pruning_
 // entry.h's own ApplySparseGptPruning declaration comment for the full
-// scope decision (FLOAT32-only weights, MatMul/vanilla-Gemm/`com.microsoft
-// ::Attention` merged-QKV weight only -- 2-D Conv is NOT ported here, see
-// that comment for why) and pruning.py's own module-level docstring /
+// scope decision (FLOAT32/FLOAT16/BFLOAT16 weights, MatMul/vanilla-Gemm/
+// `com.microsoft::Attention` merged-QKV weight only -- 2-D Conv is NOT
+// ported here, see that comment for why) and pruning.py's own module-level
+// docstring /
 // gptq.py's own module-level docstring for the algorithm itself. Three
 // genuinely new pieces this pass needs that no earlier pass in this file
 // does:
@@ -19664,10 +19665,15 @@ struct SparseGptHessian {
 // Reuses WandaCalibrationStats' own probe-injection/batch-iteration/
 // executor-call plumbing verbatim (see that function's own top comment for
 // the full calibration-crossing design every calibration-driven pass in
-// this file shares) -- same FLOAT32-only, `ndim >= 2` scope decision for a
-// probed activation (reshaped to `[-1, dims.back()]`, mirroring
-// pruning.py's own `x.reshape(-1, x.shape[-1])`). Unlike pruning.py's own
-// `np.concatenate`, which would raise if two batches' own activations for
+// this file shares) -- but, unlike WandaCalibrationStats itself (still
+// FLOAT32-only), this accepts a FLOAT/FLOAT16/BFLOAT16 probed activation
+// (IsSupportedFloatDtype, read via ReadTensorAsF64 rather than
+// ReadFloatTensor), matching ApplySparseGptPruning's own weight-side
+// FLOAT16/BFLOAT16 support below and pruning.py's own
+// `_is_supported_float_dtype`; `ndim >= 2` scope decision for a probed
+// activation is otherwise unchanged (reshaped to `[-1, dims.back()]`,
+// mirroring pruning.py's own `x.reshape(-1, x.shape[-1])`). Unlike pruning.py's
+// own `np.concatenate`, which would raise if two batches' own activations for
 // the same probe name disagreed on `dims.back()` (never happens for a
 // well-formed model -- that last dim is a fixed layer property, not a
 // per-batch one), a later batch that DOES disagree with the first batch's
@@ -19734,8 +19740,11 @@ std::unordered_map<std::string, SparseGptHessian> SparseGptHessianStats(
       }
       const DLTensor& dl = outputs[oit->second]->dl_tensor;
       onnx::TensorProto tp = onnxsim::dlpack::ToTensorProto(dl);
-      if (tp.data_type() != onnx::TensorProto::FLOAT) {
-        continue;  // Scope decision mirroring WandaCalibrationStats' own.
+      if (!IsSupportedFloatDtype(tp.data_type())) {
+        continue;  // FLOAT/FLOAT16/BFLOAT16 -- widened from this function's
+                   // earlier FLOAT32-only scope decision (mirrors
+                   // pruning.py's own `_is_supported_float_dtype` gate on
+                   // the probed activation; see IsSupportedFloatDtype).
       }
       const int64_t ndim = tp.dims_size();
       if (ndim < 2) {
@@ -19763,21 +19772,26 @@ std::unordered_map<std::string, SparseGptHessian> SparseGptHessianStats(
         continue;  // See this function's own top comment.
       }
 
-      const std::vector<float> data = ReadFloatTensor(tp);
+      // ReadTensorAsF64 (not ReadFloatTensor) -- handles FLOAT/FLOAT16/
+      // BFLOAT16 alike, upcasting FLOAT16/BFLOAT16 to double the same way
+      // this function's own weight read/write already does (see
+      // ApplySparseGptPruning below), mirroring pruning.py's own
+      // `np.asarray(result[name], dtype=np.float64)`.
+      const std::vector<double> data = ReadTensorAsF64(tp);
       // H += X.T @ X, accumulated over the upper triangle only (H is
       // symmetric by construction) then mirrored into the lower triangle
       // once, after every batch, below.
       for (int64_t r = 0; r < rows; ++r) {
-        const float* row = data.data() + r * kk;
+        const double* row = data.data() + r * kk;
         double* hbase = acc.h.data();
         for (int64_t i = 0; i < kk; ++i) {
-          const double xi = static_cast<double>(row[i]);
+          const double xi = row[i];
           if (xi == 0.0) {
             continue;
           }
           double* hrow = hbase + i * kk;
           for (int64_t j = i; j < kk; ++j) {
-            hrow[j] += xi * static_cast<double>(row[j]);
+            hrow[j] += xi * row[j];
           }
         }
       }
@@ -20594,6 +20608,94 @@ onnx::ModelProto ApplyTransformerBlockPruning(
   return out;
 }
 
+// Attention QKV-weight matcher for ApplySparseGptPruning ONLY -- mirrors
+// MatchAttentionProducer (this file's "Attention-head pruning" section)
+// exactly, but widened to accept FLOAT16/BFLOAT16 in addition to FLOAT32 for
+// both the weight and (if present) bias, mirroring pruning.py's own
+// `_match_attention_producer`, which is itself already
+// `_is_supported_float_dtype`-widened (`_match_attention_weight_only` just
+// reuses it in full, dtype widening included). Deliberately a narrow, LOCAL
+// duplicate rather than a change to the shared MatchAttentionProducer
+// itself -- exactly the same reasoning as this file's own
+// MatchMoeRouterProducer (MoE/QMoE whole-expert pruning section, see that
+// function's own comment): MatchAttentionProducer also backs this file's
+// OWN structural Attention-head pruning (FindAttentionChains /
+// ApplyOnePlainAttentionChain), which has not been independently
+// re-verified against a real FLOAT16/BFLOAT16 export and stays FLOAT32-only
+// -- its own downstream weight/bias rewriting is still ReadFloatTensor/
+// SetFloatTensorData-based (FLOAT32 only), so widening the shared matcher
+// in place would silently let a FLOAT16/BFLOAT16 node through to code that
+// cannot correctly handle it. SparseGPT never touches bias, only the
+// weight, but bias dtype/shape is still validated here (mirroring
+// `_match_attention_producer`'s own checks, reused in full by
+// `_match_attention_weight_only` even though nothing there reads bias
+// either) so a node this file's own structural head-pruning would decline
+// as malformed is declined the same way here.
+std::optional<AttentionProducerMatch> MatchAttentionProducerAnyFloat(
+    const onnx::NodeProto& node, const InitMap& init_map) {
+  if (node.domain() != kComMicrosoftDomain || node.op_type() != "Attention") {
+    return std::nullopt;
+  }
+  if (node.input_size() < 2) {
+    return std::nullopt;
+  }
+  const std::string& w_name = node.input(1);
+  auto wit = init_map.find(w_name);
+  if (wit == init_map.end() ||
+      !IsSupportedFloatDtype(wit->second->data_type()) ||
+      wit->second->dims_size() != 2) {
+    return std::nullopt;
+  }
+  const int64_t total_n = wit->second->dims(1);
+
+  std::optional<std::string> bias_name;
+  if (node.input_size() >= 3 && !node.input(2).empty()) {
+    bias_name = node.input(2);
+    auto bit = init_map.find(*bias_name);
+    if (bit == init_map.end() ||
+        !IsSupportedFloatDtype(bit->second->data_type()) ||
+        bit->second->dims_size() != 1 || bit->second->dims(0) != total_n) {
+      return std::nullopt;
+    }
+  }
+
+  int64_t num_heads = 0;
+  bool has_num_heads = false;
+  std::optional<std::vector<int64_t>> qkv_hidden_sizes;
+  for (const auto& attr : node.attribute()) {
+    if (attr.name() == "num_heads") {
+      num_heads = attr.i();
+      has_num_heads = true;
+    } else if (attr.name() == "qkv_hidden_sizes") {
+      qkv_hidden_sizes =
+          std::vector<int64_t>(attr.ints().begin(), attr.ints().end());
+    }
+  }
+  if (!has_num_heads || num_heads <= 0) {
+    return std::nullopt;
+  }
+
+  int64_t nq, nk, nv;
+  if (qkv_hidden_sizes) {
+    if (qkv_hidden_sizes->size() != 3) {
+      return std::nullopt;
+    }
+    nq = (*qkv_hidden_sizes)[0];
+    nk = (*qkv_hidden_sizes)[1];
+    nv = (*qkv_hidden_sizes)[2];
+  } else {  // Schema default: Q/K/V evenly split the merged width.
+    if (total_n % 3 != 0) {
+      return std::nullopt;
+    }
+    nq = nk = nv = total_n / 3;
+  }
+  if (nq <= 0 || nk <= 0 || nv <= 0 || nq + nk + nv != total_n ||
+      nq % num_heads != 0 || nk % num_heads != 0 || nv % num_heads != 0) {
+    return std::nullopt;
+  }
+  return AttentionProducerMatch{w_name, bias_name, num_heads, nq, nk, nv};
+}
+
 // SparseGPT (Frantar & Alistarh, 2023) unstructured/N:M pruning. The C++
 // port of pruning.py's own apply_sparsegpt_pruning -- see this file's own
 // "SparseGPT (unstructured / N:M) pruning" section comment above
@@ -20656,20 +20758,23 @@ onnx::ModelProto ApplySparseGptPruning(
   // file's own established, already-documented narrower C++-port scope
   // decision everywhere else MatchMatMulLikeRaw is reused, e.g.
   // MatchProducer/WalkToAttentionConsumer above) with a constant 2-D
-  // FLOAT32 weight (NOT also FLOAT16/BFLOAT16, unlike pruning.py's own
-  // _is_supported_float_dtype -- mirrors this file's own established
-  // FLOAT32-only C++-port scope decision, e.g.
-  // ApplyMoeExpertChannelPruning's own doc comment), plus every matched
-  // `com.microsoft::Attention` node's constant 2-D FLOAT32 merged QKV
-  // weight (MatchAttentionProducer, already FLOAT32-2-D-only itself --
-  // reused verbatim, exactly mirroring pruning.py's own
-  // _match_attention_weight_only, which reuses _match_attention_producer's
-  // own identical validation, minus its bias handling: SparseGPT never
-  // touches bias, only weight). `com.microsoft::GroupQueryAttention`'s
-  // separate Q/K/V projections need no special-casing at all -- they are
-  // ordinary MatMul/vanilla-Gemm nodes, already matched by the first case
-  // above (see pruning.py's own module docstring for the full reasoning on
-  // why this is correct, not an oversight, for both).
+  // FLOAT/FLOAT16/BFLOAT16 weight (IsSupportedFloatDtype -- matches
+  // pruning.py's own _is_supported_float_dtype; read/written via
+  // ReadTensorAsF64/WriteF64TensorAs below, preserving the weight's own
+  // original dtype, exactly like the MoE/QMoE FP16/BFLOAT16 widening this
+  // mirrors), plus every matched `com.microsoft::Attention` node's constant
+  // 2-D FLOAT/FLOAT16/BFLOAT16 merged QKV weight
+  // (MatchAttentionProducerAnyFloat -- a narrow local dtype-widened
+  // duplicate of MatchAttentionProducer, see that function's own comment
+  // for why MatchAttentionProducer itself is left untouched -- exactly
+  // mirroring pruning.py's own _match_attention_weight_only, which reuses
+  // _match_attention_producer's own identical (already dtype-widened)
+  // validation, minus its bias handling: SparseGPT never touches bias, only
+  // weight). `com.microsoft::GroupQueryAttention`'s separate Q/K/V
+  // projections need no special-casing at all -- they are ordinary
+  // MatMul/vanilla-Gemm nodes, already matched by the first case above (see
+  // pruning.py's own module docstring for the full reasoning on why this is
+  // correct, not an oversight, for both).
   //
   // 2-D Conv (ordinary/depthwise/general-grouped) is declined outright,
   // NOT ported here -- see structured_pruning_entry.h's own
@@ -20678,7 +20783,11 @@ onnx::ModelProto ApplySparseGptPruning(
   // pruning.py's own module docstring documents at length, materially
   // bigger than the rest of this pass, with no correct upstream reference
   // to port from at all) -- a Conv node here simply never matches either
-  // case below and is left completely untouched, never guessed at.
+  // case below and is left completely untouched, never guessed at. This
+  // remains the one open scope gap versus pruning.py's own
+  // apply_sparsegpt_pruning after this port's FLOAT16/BFLOAT16 widening --
+  // see this function's own declaration comment in
+  // structured_pruning_entry.h.
   struct Candidate {
     std::string x_name;
     std::string w_name;
@@ -20690,13 +20799,13 @@ onnx::ModelProto ApplySparseGptPruning(
     if (mm) {
       auto wit = init_map.find(mm->w_name);
       if (wit != init_map.end() &&
-          wit->second->data_type() == onnx::TensorProto::FLOAT &&
+          IsSupportedFloatDtype(wit->second->data_type()) &&
           wit->second->dims_size() == 2) {
         candidates.push_back({mm->x_name, mm->w_name, mm->weight_transposed});
       }
       continue;
     }
-    auto am = MatchAttentionProducer(node, init_map);
+    auto am = MatchAttentionProducerAnyFloat(node, init_map);
     if (am) {
       // The merged QKV weight has no transpose attribute of its own -- it
       // is already [K, N]-shaped by construction (see
@@ -20730,8 +20839,19 @@ onnx::ModelProto ApplySparseGptPruning(
     onnx::TensorProto* w_init = mut_init_map.at(c.w_name);
     const int64_t dim0 = w_init->dims(0);
     const int64_t dim1 = w_init->dims(1);
-    const std::vector<float> w_flat = ReadFloatTensor(*w_init);
-    const std::vector<double> w_f64(w_flat.begin(), w_flat.end());
+    const int32_t w_dtype = w_init->data_type();
+    // ReadTensorAsF64 (not ReadFloatTensor) -- FLOAT/FLOAT16/BFLOAT16 alike,
+    // upcast to double, mirroring pruning.py's own `_to_f64`; written back
+    // down to `w_dtype` (this weight's own original dtype) via
+    // WriteF64TensorAs below, mirroring pruning.py's own `_from_f64`. As
+    // pruning.py's own apply_sparsegpt_pruning docstring notes, SparseGPT's
+    // Hessian-compensated update recomputes every KEPT entry's own value
+    // too, so a FLOAT16/BFLOAT16 weight's surviving entries do not
+    // reproduce their pre-pruning bit pattern the way plain-masking passes'
+    // FLOAT16/BFLOAT16 widening does -- the float64 accumulation this
+    // function already used for numerical stability is unchanged either
+    // way.
+    const std::vector<double> w_f64 = ReadTensorAsF64(*w_init);
 
     // w_nk: [n_rows, kk], output-channel-first -- w as-is when already
     // weight_transposed ([N, K] = [dim0, dim1]), else w's own transpose
@@ -20762,20 +20882,18 @@ onnx::ModelProto ApplySparseGptPruning(
 
     // Inverse of the w -> w_nk reshape/transpose above, mirroring
     // pruning.py's own _nk_to_weight (non-Conv branch).
-    std::vector<float> w_new(static_cast<size_t>(dim0 * dim1));
+    std::vector<double> w_new(static_cast<size_t>(dim0 * dim1));
     if (c.weight_transposed) {
-      for (size_t i = 0; i < w_new.size(); ++i) {
-        w_new[i] = static_cast<float>(w_pruned_nk[i]);
-      }
+      w_new = w_pruned_nk;
     } else {
       for (int64_t nx = 0; nx < dim1; ++nx) {
         for (int64_t kx = 0; kx < dim0; ++kx) {
-          w_new[static_cast<size_t>(kx * dim1 + nx)] = static_cast<float>(
-              w_pruned_nk[static_cast<size_t>(nx * kk + kx)]);
+          w_new[static_cast<size_t>(kx * dim1 + nx)] =
+              w_pruned_nk[static_cast<size_t>(nx * kk + kx)];
         }
       }
     }
-    SetFloatTensorData(w_init, {dim0, dim1}, w_new);
+    WriteF64TensorAs(w_init, w_dtype, {dim0, dim1}, w_new);
   }
 
   return out;

--- a/onnxsim/structured_pruning_entry.h
+++ b/onnxsim/structured_pruning_entry.h
@@ -356,32 +356,39 @@ onnx::ModelProto ApplyTransformerBlockPruning(
 // SparseGPT (Frantar & Alistarh, 2023, "SparseGPT: Massive Language Models
 // Can Be Accurately Pruned in One-Shot", https://arxiv.org/abs/2301.00774):
 // zeros the least-important entries of every matched layer's constant 2-D
-// FLOAT32 weight to an unstructured or N:M sparsity pattern, using a
-// sequential, Hessian-error-compensating algorithm ported from GPTQ (same
-// authors) rather than magnitude/Wanda's one-shot static importance score
-// -- see structured_pruning_entry.cpp's own "SparseGPT (unstructured / N:M)
-// pruning" section comment for the full technique, and pruning.py's own
-// module-level docstring / `apply_sparsegpt_pruning` docstring for the
-// Python reference this ports. Unlike every other pass in this file, this
-// NEVER changes any tensor's shape: it only rewrites individual weight
-// entries in place (zeroed when pruned, Hessian-compensated -- so
-// possibly changed even when KEPT -- otherwise), and every matched layer
-// is processed completely independently, with no producer/consumer
-// chain-walking at all.
+// FLOAT32/FLOAT16/BFLOAT16 weight to an unstructured or N:M sparsity
+// pattern, using a sequential, Hessian-error-compensating algorithm ported
+// from GPTQ (same authors) rather than magnitude/Wanda's one-shot static
+// importance score -- see structured_pruning_entry.cpp's own "SparseGPT
+// (unstructured / N:M) pruning" section comment for the full technique, and
+// pruning.py's own module-level docstring / `apply_sparsegpt_pruning`
+// docstring for the Python reference this ports. Unlike every other pass in
+// this file, this NEVER changes any tensor's shape: it only rewrites
+// individual weight entries in place (zeroed when pruned, Hessian-
+// compensated -- so possibly changed even when KEPT -- otherwise), and
+// every matched layer is processed completely independently, with no
+// producer/consumer chain-walking at all.
 //
 // Matches exactly: every plain `MatMul`/vanilla-`Gemm` node (MatchMatMulLikeRaw
 // -- NOT pruning.py's own widened `_match_matmul_like`, which also
 // recognizes `com.microsoft::FusedGemm`/`GemmFastGelu`; this already covers
 // `com.microsoft::GroupQueryAttention`'s own separate Q/K/V projections,
 // which are ordinary MatMul/Gemm nodes feeding it, not a weight the op
-// itself owns) with a constant 2-D FLOAT32 weight, plus every
-// `com.microsoft::Attention` node's constant 2-D FLOAT32 merged QKV weight
-// (MatchAttentionProducer). Deliberately narrower than pruning.py's own
-// `apply_sparsegpt_pruning` in two ways, both mirroring this file's own
-// already-established C++-port scope decisions elsewhere (e.g. the
-// "MatMulNBits" section's own FLOAT32-only restriction on its scales/
-// zero_points/bias tensors):
-//   - FLOAT32 only, not also FLOAT16/BFLOAT16.
+// itself owns) with a constant 2-D FLOAT/FLOAT16/BFLOAT16 weight
+// (IsSupportedFloatDtype -- matches pruning.py's own
+// `_is_supported_float_dtype`; read/written via ReadTensorAsF64/
+// WriteF64TensorAs, preserving each weight's own original dtype, exactly
+// mirroring pruning.py's own `_to_f64`/`_from_f64` convention), plus every
+// `com.microsoft::Attention` node's constant 2-D FLOAT/FLOAT16/BFLOAT16
+// merged QKV weight (MatchAttentionProducerAnyFloat -- a narrow, SparseGPT-
+// local dtype-widened duplicate of the shared, still-FLOAT32-only
+// MatchAttentionProducer, which also backs this file's own structural
+// Attention-head pruning and was deliberately left untouched -- see that
+// function's own comment in structured_pruning_entry.cpp). Deliberately
+// narrower than pruning.py's own `apply_sparsegpt_pruning` in one remaining
+// way (previously two -- FLOAT16/BFLOAT16 support was closed in the same
+// round that added this comment, following this file's own established
+// MoE/QMoE FP16/BFLOAT16-widening precedent):
 //   - 2-D `Conv` (ordinary/depthwise/general-grouped) is NOT matched at
 //     all -- pruning.py's own Conv support needs an entirely new, from-
 //     first-principles im2col cross-covariance Hessian (`H = patches.T @
@@ -393,7 +400,12 @@ onnx::ModelProto ApplyTransformerBlockPruning(
 //     materially bigger than the rest of this pass and was deliberately
 //     left out of scope for this port -- a Conv node here is left
 //     completely untouched (never guessed at, never crashes), exactly as
-//     if it were any other unmatched node type.
+//     if it were any other unmatched node type. THIS IS THE ONLY REMAINING
+//     SCOPE GAP versus pruning.py's own `apply_sparsegpt_pruning` -- until
+//     it closes, `apply_sparsegpt_pruning` itself must stay pure Python
+//     (not aliased to this port), since a Conv-bearing model would
+//     otherwise silently get a different (Conv-less) result from the two
+//     implementations.
 //
 // Same real numerical linear algebra pruning.py's own `apply_sparsegpt_
 // pruning`/:mod:`onnxsim.gptq` needs, hand-written here rather than reused
@@ -440,10 +452,10 @@ onnx::ModelProto ApplyTransformerBlockPruning(
 //
 // A matched layer with no observed 2-D-or-higher-rank-with-a-trailing-
 // feature-axis calibration activation for its own input (dead input, an
-// otherwise-empty `calibration_data`, or every batch's own activation
-// isn't FLOAT32) is left completely untouched -- unlike Wanda, there is no
-// data-free fallback for a technique whose entire mechanism is the
-// Hessian.
+// otherwise-empty `calibration_data`, or every batch's own activation isn't
+// FLOAT/FLOAT16/BFLOAT16) is left completely untouched -- unlike Wanda,
+// there is no data-free fallback for a technique whose entire mechanism is
+// the Hessian.
 onnx::ModelProto ApplySparseGptPruning(
     const onnx::ModelProto& model, const ModelExecutor& executor,
     const std::vector<std::unordered_map<std::string, onnx::TensorProto>>&
@@ -466,15 +478,22 @@ onnx::ModelProto ApplySparseGptPruning(
 // change): like ApplySparseGptPruning immediately above, this NEVER changes
 // any tensor's shape -- only individual weight entries are zeroed in place.
 //
-// Matches EXACTLY the same candidate set as ApplySparseGptPruning, via the
-// same matchers (MatchMatMulLikeRaw, MatchAttentionProducer): every plain
-// `MatMul`/vanilla-`Gemm` node with a constant 2-D FLOAT32 weight (already
-// covering `com.microsoft::GroupQueryAttention`'s own separate Q/K/V
-// projections -- ordinary MatMul/Gemm nodes feeding it, not a weight the op
-// itself owns), plus every `com.microsoft::Attention` node's constant 2-D
-// FLOAT32 merged QKV weight. Deliberately narrower than pruning.py's own
-// `apply_wanda_pruning` in the same two ways ApplySparseGptPruning's own
-// declaration comment above already documents and justifies at length:
+// Matches EXACTLY the candidate set ApplySparseGptPruning ITSELF used to
+// match, via the same matchers (MatchMatMulLikeRaw, MatchAttentionProducer):
+// every plain `MatMul`/vanilla-`Gemm` node with a constant 2-D FLOAT32
+// weight (already covering `com.microsoft::GroupQueryAttention`'s own
+// separate Q/K/V projections -- ordinary MatMul/Gemm nodes feeding it, not a
+// weight the op itself owns), plus every `com.microsoft::Attention` node's
+// constant 2-D FLOAT32 merged QKV weight. NOTE: ApplySparseGptPruning has
+// since been widened to also accept FLOAT16/BFLOAT16 (IsSupportedFloatDtype,
+// MatchAttentionProducerAnyFloat -- see its own declaration comment above),
+// so this function's own candidate set is now narrower than
+// ApplySparseGptPruning's, not identical to it; ApplyWandaPruning itself has
+// not been independently re-verified against FLOAT16/BFLOAT16 and remains
+// FLOAT32-only. Deliberately narrower than pruning.py's own
+// `apply_wanda_pruning` in two ways, both of which ApplySparseGptPruning's
+// own declaration comment above already documents and justifies at length
+// for the analogous SparseGPT case:
 //   - FLOAT32 only, not also FLOAT16/BFLOAT16.
 //   - 2-D `Conv` (ordinary/depthwise/general-grouped) is NOT matched at
 //     all -- pruning.py's own Conv support for THIS function needs the same

--- a/onnxsim/structured_pruning_entry.h
+++ b/onnxsim/structured_pruning_entry.h
@@ -467,24 +467,42 @@ onnx::ModelProto ApplySparseGptPruning(
 // any tensor's shape -- only individual weight entries are zeroed in place.
 //
 // Matches EXACTLY the same candidate set as ApplySparseGptPruning, via the
-// same matchers (MatchMatMulLikeRaw, MatchAttentionProducer): every plain
-// `MatMul`/vanilla-`Gemm` node with a constant 2-D FLOAT32 weight (already
-// covering `com.microsoft::GroupQueryAttention`'s own separate Q/K/V
-// projections -- ordinary MatMul/Gemm nodes feeding it, not a weight the op
-// itself owns), plus every `com.microsoft::Attention` node's constant 2-D
-// FLOAT32 merged QKV weight. Deliberately narrower than pruning.py's own
-// `apply_wanda_pruning` in the same two ways ApplySparseGptPruning's own
-// declaration comment above already documents and justifies at length:
-//   - FLOAT32 only, not also FLOAT16/BFLOAT16.
+// same MatchMatMulLikeRaw matcher for the MatMul/Gemm case, PLUS a local,
+// dtype-widened copy of MatchAttentionProducer for the Attention case (see
+// structured_pruning_entry.cpp's own "Wanda unstructured (element-wise)
+// pruning" section comment, MatchAttentionProducerWideDtype, for why this
+// needs its own copy rather than reusing MatchAttentionProducer directly):
+// every plain `MatMul`/vanilla-`Gemm` node with a constant 2-D FLOAT32/
+// FLOAT16/BFLOAT16 weight (already covering
+// `com.microsoft::GroupQueryAttention`'s own separate Q/K/V projections --
+// ordinary MatMul/Gemm nodes feeding it, not a weight the op itself owns),
+// plus every `com.microsoft::Attention` node's constant 2-D FLOAT32/FLOAT16/
+// BFLOAT16 merged QKV weight -- mirrors pruning.py's own
+// `_is_supported_float_dtype` widening of `_match_attention_producer`
+// exactly. Unlike ApplySparseGptPruning immediately above, FLOAT16/BFLOAT16
+// support is now at TRUE parity with pruning.py's own `apply_wanda_pruning`
+// (read out upcast to float64 via ReadTensorAsF64, written back down via
+// WriteF64TensorAs -- this file's own MoE/QMoE-established conversion trio,
+// see IsSupportedFloatDtype's own declaration comment -- exactly mirroring
+// pruning.py's own `_to_f64`/`_from_f64` round trip; masking never changes a
+// surviving entry's own value, only zeros dropped ones, so this reproduces
+// every kept entry's exact original bit pattern). Only remaining,
+// deliberate gap vs. pruning.py's own `apply_wanda_pruning`:
 //   - 2-D `Conv` (ordinary/depthwise/general-grouped) is NOT matched at
 //     all -- pruning.py's own Conv support for THIS function needs the same
 //     from-first-principles im2col per-receptive-field-offset activation
 //     norm (`_conv_patch_sq_sum`, `_conv_group_relative_norm`) that
 //     ApplySparseGptPruning's own declaration comment explains is out of
 //     scope here for the analogous Hessian case -- materially bigger than
-//     the rest of this pass, and deliberately left to the pure-Python
-//     implementation. A Conv node here simply never matches either
+//     the rest of this pass (a brand-new im2col activation-collection engine
+//     this file has nowhere else, plus the grouped/depthwise group-relative
+//     norm expansion, with real numeric-correctness risk if gotten subtly
+//     wrong), and deliberately left to the pure-Python implementation rather
+//     than risked this round. A Conv node here simply never matches either
 //     candidate case and is left completely untouched, never guessed at.
+//     Because of this ONE remaining gap, `apply_wanda_pruning` is NOT
+//     aliased to this port in pruning.py -- see that function's own
+//     docstring there.
 //
 // Wanda's own calibration statistic -- one shared per-reduction-channel
 // activation L2-norm per matched layer's own input, reduced over every
@@ -518,8 +536,9 @@ onnx::ModelProto ApplySparseGptPruning(
 //
 // A matched layer with NO observed calibration activation for its own
 // input (dead input, an otherwise-empty `calibration_data`, every batch's
-// own activation isn't FLOAT32, or an observed width mismatched with the
-// weight's own reduction dimension) falls back to PLAIN MAGNITUDE
+// own activation isn't FLOAT32/FLOAT16/BFLOAT16, or an observed width
+// mismatched with the weight's own reduction dimension) falls back to PLAIN
+// MAGNITUDE
 // importance (``|W_ij|`` alone) for that one layer -- mirrors pruning.py's
 // own per-layer `_wanda_importance` fallback exactly. This is the one
 // meaningful behavioral difference from ApplySparseGptPruning's own

--- a/onnxsim/structured_pruning_entry.h
+++ b/onnxsim/structured_pruning_entry.h
@@ -165,17 +165,16 @@ struct EmbeddingVocabPruningResult {
 // If/Loop/Scan/BeamSearch-family subgraphs, at any depth -- see
 // `IterSubgraphs`).
 //
-// Unlike pruning.py's own version, this port still only ever matches a
-// plain `Gather` or `com.microsoft::EmbedLayerNormalization` producer --
-// not `com.microsoft::GatherBlockQuantized` (the block-quantized embedding
-// shape -- a genuine remaining scope gap, deliberately left open; see
-// structured_pruning_entry.cpp's own section comment for exactly why).
-// `lm_head` auto-detection recognizes `MatMul`/vanilla `Gemm`/
-// `com.microsoft::FusedGemm`/`GemmFastGelu`, and the embedding table/
-// `lm_head` weight/bias may be FLOAT, FLOAT16, OR BFLOAT16 -- both now
-// match pruning.py's own scope exactly. See structured_pruning_entry.cpp's
-// own section comment for the full matched topology and the one remaining
-// out-of-scope shape.
+// Matches all three of pruning.py's own producer shapes -- a plain
+// `Gather`, `com.microsoft::EmbedLayerNormalization`, or `com.microsoft::
+// GatherBlockQuantized` (the block-quantized embedding shape -- verified
+// TRUE full parity across both of its own sub-8-bit packing conventions;
+// see structured_pruning_entry.cpp's own section comment for the full
+// empirical detail). `lm_head` auto-detection recognizes `MatMul`/vanilla
+// `Gemm`/`com.microsoft::FusedGemm`/`GemmFastGelu`, and the embedding
+// table/`lm_head` weight/bias may be FLOAT, FLOAT16, OR BFLOAT16 -- all
+// matching pruning.py's own scope exactly. See structured_pruning_entry.cpp's
+// own section comment for the full matched topology.
 EmbeddingVocabPruningResult ApplyEmbeddingVocabPruning(
     const onnx::ModelProto& model,
     const std::optional<std::vector<int64_t>>& keep_token_ids,

--- a/onnxsim/structured_pruning_entry.h
+++ b/onnxsim/structured_pruning_entry.h
@@ -32,11 +32,34 @@
 // for the definition, where ``executor.Run(...)`` is actually called.
 struct ModelExecutor;
 
-onnx::ModelProto ApplyStructuredPruning(const onnx::ModelProto& model,
-                                        double sparsity);
+// `importance_norm` ("l1" or "l2", case-sensitive; anything else throws
+// std::invalid_argument) selects L1 (sum of absolute weight magnitude) or
+// L2 (Li et al.'s original root-sum-square, the pre-existing default)
+// channel-importance ranking -- mirrors pruning.py's own
+// `_ImportanceNorm`/`_validate_importance_norm`/`importance_norm` parameter
+// exactly. `global_sparsity` pools every *eligible* matched chain's own
+// per-channel importance into one ranking across the whole model and picks
+// a single keep-count from `sparsity`'s fraction of that pooled total,
+// instead of every chain being cut by the same fraction independently --
+// mirrors pruning.py's own `apply_structured_pruning`/`global_sparsity`
+// parameter exactly, including which chains are "eligible" (an ordinary,
+// single-producer chain with no extra fan-out consumer branch and no
+// general grouped Conv on either side -- see structured_pruning_entry.cpp's
+// own ChainIsGlobalSparsityEligible) and the per-chain floor of at least
+// one surviving channel. See structured_pruning_entry.cpp's own
+// ApplyChainsGlobal for the full mechanism.
+onnx::ModelProto ApplyStructuredPruning(
+    const onnx::ModelProto& model, double sparsity,
+    const std::string& importance_norm = "l2", bool global_sparsity = false);
 
-onnx::ModelProto ApplyAttentionHeadPruning(const onnx::ModelProto& model,
-                                           double sparsity);
+// `importance_norm` mirrors ApplyStructuredPruning's own parameter of the
+// same name exactly (pruning.py's own `apply_attention_head_pruning`
+// `importance_norm`) -- L1 vs. L2 ranking of each matched head's/KV group's
+// own combined weight-block norm. No `global_sparsity` counterpart here --
+// pruning.py's own `apply_attention_head_pruning` has none either.
+onnx::ModelProto ApplyAttentionHeadPruning(
+    const onnx::ModelProto& model, double sparsity,
+    const std::string& importance_norm = "l2");
 
 // Removes intermediate (`inter_size`) channels from every expert of a
 // matched `com.microsoft::MoE` node at once -- real structural pruning
@@ -244,11 +267,20 @@ EmbeddingVocabPruningResult ApplyEmbeddingVocabMagnitudePruning(
 // ``||W_row||_2`` ranking, exactly mirroring pruning.py's own per-chain "no
 // matching activation observed" fallback, just triggered for every chain at
 // once instead of one at a time.
+// `importance_norm`/`global_sparsity` mirror ApplyStructuredPruning's own
+// parameters of the same names exactly (pruning.py's own
+// `apply_structured_wanda_pruning` `importance_norm`/`global_sparsity`) --
+// the *weight*-magnitude term only; the activation-norm term stays L2
+// unconditionally either way, per Wanda's own ``|W_ij| * ||X_j||_2``
+// definition. `global_sparsity` mode applies to this function's own
+// ``||W_row|| * ||X||_2`` metric, same eligible-chain scope and per-chain
+// floor as ApplyStructuredPruning's own `global_sparsity`.
 onnx::ModelProto ApplyStructuredWandaPruning(
     const onnx::ModelProto& model, const ModelExecutor& executor,
     const std::vector<std::unordered_map<std::string, onnx::TensorProto>>&
         calibration_data,
-    double sparsity, double epsilon = 1e-8);
+    double sparsity, double epsilon = 1e-8,
+    const std::string& importance_norm = "l2", bool global_sparsity = false);
 
 // The calibration-driven (Wanda-style) upgrade of ApplyAttentionHeadPruning
 // -- same relationship, and same reused pattern, as
@@ -295,11 +327,18 @@ onnx::ModelProto ApplyStructuredWandaPruning(
 // matched block fall back to ApplyAttentionHeadPruning's own plain
 // ``||W||_F`` ranking, exactly mirroring pruning.py's own per-block "no
 // matching activation observed" fallback.
+// `importance_norm` mirrors ApplyAttentionHeadPruning's own parameter of the
+// same name exactly (pruning.py's own `apply_attention_head_wanda_pruning`
+// `importance_norm`) -- the *weight*-magnitude term only; the
+// activation-norm term stays L2 unconditionally either way. No
+// `global_sparsity` counterpart here either, mirroring
+// ApplyAttentionHeadPruning's own declaration comment above.
 onnx::ModelProto ApplyAttentionHeadWandaPruning(
     const onnx::ModelProto& model, const ModelExecutor& executor,
     const std::vector<std::unordered_map<std::string, onnx::TensorProto>>&
         calibration_data,
-    double sparsity, double epsilon = 1e-8);
+    double sparsity, double epsilon = 1e-8,
+    const std::string& importance_norm = "l2");
 
 // Depth/block-level pruning: drops whole redundant pre-norm transformer
 // residual sub-blocks (``x = x + SelfAttn(LN(x))`` or ``x = x + MLP(LN(x))``)

--- a/tests/test_attention_head_pruning_cpp.py
+++ b/tests/test_attention_head_pruning_cpp.py
@@ -1606,4 +1606,85 @@ def test_cpp_matmul_nbits_qkv_pruning_zero_sparsity_is_a_no_op():
     pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.0)
     qkv_node = next(n for n in pruned.graph.node if n.op_type == "MatMulNBitsQkv")
     assert next(a.i for a in qkv_node.attribute if a.name == "Nq") == num_heads * d
-    assert next(a.i for a in qkv_node.attribute if a.name == "Nkv") == kv_num_heads * d
+
+
+# --- importance_norm ("l1" vs "l2") ------------------------------------------
+#
+# Adapted from test_pruning.py's own `test_attention_head_pruning_l1_norm_
+# favors_total_magnitude`/`test_gqa_pruning_l1_norm_favors_total_magnitude`:
+# adversarial per-head/per-group weight blocks engineered so L2 (Frobenius)
+# and L1 (entrywise abs-sum) importance disagree on which unit survives --
+# a bug that silently keeps ranking by L2 under the hood even when "l1" is
+# requested would keep the WRONG head/group, not merely score it slightly
+# differently.
+
+
+def test_cpp_attention_head_pruning_importance_norm_l1_matches_python_reference_and_differs_from_l2():
+    K, H, D, Out = 16, 4, 4, 3
+    Nq = Nk = Nv = H * D
+    rng_qk = np.random.default_rng(52)
+    wqkv = np.zeros((K, Nq + Nk + Nv), dtype=np.float32)
+    wqkv[:, :Nq] = rng_qk.standard_normal((K, Nq)).astype(np.float32) * 0.01
+    wqkv[:, Nq : Nq + Nk] = rng_qk.standard_normal((K, Nk)).astype(np.float32) * 0.01
+    v_offset = Nq + Nk
+    wqkv[0, v_offset + 0] = 16.0  # head 0 ("concentrated")
+    wqkv[:, v_offset + D : v_offset + 2 * D] = 1.0  # head 1 ("spread")
+    wqkv[2, v_offset + 2 * D] = 1000.0  # head 2 ("filler_high")
+    wqkv[3, v_offset + 3 * D] = 0.001  # head 3 ("filler_low")
+    bqkv = np.zeros((Nq + Nk + Nv,), dtype=np.float32)
+
+    model, _cfg = _attention_model(
+        K=K, H=H, D=D, Out=Out, seed=50, bias=True, wqkv=wqkv, bqkv=bqkv
+    )
+
+    for norm in ("l2", "l1"):
+        pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(
+            model, sparsity=0.5, importance_norm=norm
+        )
+        pruned_py = onnxsim.apply_attention_head_pruning(
+            model, sparsity=0.5, importance_norm=norm
+        )
+        onnx.checker.check_model(pruned_cpp)
+        assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    kept_l2 = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    kept_l1 = onnxsim.apply_attention_head_pruning_cpp(
+        model, sparsity=0.5, importance_norm="l1"
+    )
+    # "l2" keeps {concentrated, filler_high} (16 & 1000 dominate Frobenius),
+    # "l1" keeps {spread, filler_high} (64 total magnitude beats 16) --
+    # provably different surviving Wqkv shapes/values, not just a different
+    # score.
+    assert kept_l2.SerializeToString() != kept_l1.SerializeToString()
+
+
+def test_cpp_gqa_pruning_importance_norm_l1_matches_python_reference_and_differs_from_l2():
+    K, H, KVH, D, Out = 8, 4, 2, 8, 3
+    Nq, Nkv = H * D, KVH * D
+    wq = np.zeros((K, Nq), dtype=np.float32)
+    wk = np.zeros((K, Nkv), dtype=np.float32)
+    wv = np.zeros((K, Nkv), dtype=np.float32)
+    wv[0, 0] = 16.0  # KV group 0's own V slice -- concentrated
+    wv[:, D : 2 * D] = 1.0  # KV group 1's own V slice -- spread
+
+    model, _cfg = _gqa_model(
+        K=K, H=H, KVH=KVH, D=D, Out=Out, seed=60, wq=wq, wk=wk, wv=wv
+    )
+
+    for norm in ("l2", "l1"):
+        pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(
+            model, sparsity=0.5, importance_norm=norm
+        )
+        pruned_py = onnxsim.apply_attention_head_pruning(
+            model, sparsity=0.5, importance_norm=norm
+        )
+        onnx.checker.check_model(pruned_cpp)
+        assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    kept_l2 = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    kept_l1 = onnxsim.apply_attention_head_pruning_cpp(
+        model, sparsity=0.5, importance_norm="l1"
+    )
+    # "l2" keeps KV group 0 (Frobenius 16 > 8), "l1" keeps KV group 1
+    # (total magnitude 64 > 16) -- a real flip in which group survives.
+    assert kept_l2.SerializeToString() != kept_l1.SerializeToString()

--- a/tests/test_attention_head_wanda_pruning_cpp.py
+++ b/tests/test_attention_head_wanda_pruning_cpp.py
@@ -595,3 +595,87 @@ def test_cpp_attention_head_wanda_pruning_default_calibration_data_runs():
     node = _attention_node(pruned)
     num_heads, _ = _attention_attrs(node)
     assert num_heads == 2
+
+
+# --- importance_norm ("l1" vs "l2") ------------------------------------------
+#
+# Same adversarial per-head/per-group weight blocks as
+# test_attention_head_pruning_cpp.py's own importance_norm tests, driven
+# through the *empty-calibration-data* fallback path (mirrors
+# `test_cpp_attention_head_wanda_pruning_empty_calibration_data_matches_plain`/
+# `test_cpp_gqa_wanda_pruning_empty_calibration_data_matches_plain` above):
+# with no observed activation, `_wanda_attention_head_importance`/
+# `_wanda_gqa_group_importance` fall straight back to the plain
+# `||W||`-only ranking, so this isolates the *weight*-magnitude term's own
+# L1-vs-L2 switch from the (always-L2) activation-norm term -- while still
+# exercising the real Wanda entry point/binding end to end, not just the
+# plain one.
+
+
+def test_cpp_attention_head_wanda_pruning_importance_norm_l1_matches_python_reference_and_differs_from_l2():
+    K, H, D, Out = 16, 4, 4, 3
+    Nq = Nk = Nv = H * D
+    rng_qk = np.random.default_rng(52)
+    wqkv = np.zeros((K, Nq + Nk + Nv), dtype=np.float32)
+    wqkv[:, :Nq] = rng_qk.standard_normal((K, Nq)).astype(np.float32) * 0.01
+    wqkv[:, Nq : Nq + Nk] = rng_qk.standard_normal((K, Nk)).astype(np.float32) * 0.01
+    v_offset = Nq + Nk
+    wqkv[0, v_offset + 0] = 16.0  # head 0 ("concentrated")
+    wqkv[:, v_offset + D : v_offset + 2 * D] = 1.0  # head 1 ("spread")
+    wqkv[2, v_offset + 2 * D] = 1000.0  # head 2 ("filler_high")
+    wqkv[3, v_offset + 3 * D] = 0.001  # head 3 ("filler_low")
+    bqkv = np.zeros((Nq + Nk + Nv,), dtype=np.float32)
+
+    model, _cfg = _attention_model(
+        K=K, H=H, D=D, Out=Out, seed=50, bias=True, wqkv=wqkv, bqkv=bqkv
+    )
+
+    for norm in ("l2", "l1"):
+        pruned_cpp = onnxsim.apply_attention_head_wanda_pruning_cpp(
+            model, calibration_data=[], sparsity=0.5, importance_norm=norm
+        )
+        pruned_py = onnxsim.apply_attention_head_wanda_pruning(
+            model, calibration_data=[], sparsity=0.5, importance_norm=norm
+        )
+        onnx.checker.check_model(pruned_cpp)
+        assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    kept_l2 = onnxsim.apply_attention_head_wanda_pruning_cpp(
+        model, calibration_data=[], sparsity=0.5
+    )
+    kept_l1 = onnxsim.apply_attention_head_wanda_pruning_cpp(
+        model, calibration_data=[], sparsity=0.5, importance_norm="l1"
+    )
+    assert kept_l2.SerializeToString() != kept_l1.SerializeToString()
+
+
+def test_cpp_gqa_wanda_pruning_importance_norm_l1_matches_python_reference_and_differs_from_l2():
+    K, H, KVH, D, Out = 8, 4, 2, 8, 3
+    Nq, Nkv = H * D, KVH * D
+    wq = np.zeros((K, Nq), dtype=np.float32)
+    wk = np.zeros((K, Nkv), dtype=np.float32)
+    wv = np.zeros((K, Nkv), dtype=np.float32)
+    wv[0, 0] = 16.0  # KV group 0's own V slice -- concentrated
+    wv[:, D : 2 * D] = 1.0  # KV group 1's own V slice -- spread
+
+    model, _cfg = _gqa_model(
+        K=K, H=H, KVH=KVH, D=D, Out=Out, seed=60, wq=wq, wk=wk, wv=wv
+    )
+
+    for norm in ("l2", "l1"):
+        pruned_cpp = onnxsim.apply_attention_head_wanda_pruning_cpp(
+            model, calibration_data=[], sparsity=0.5, importance_norm=norm
+        )
+        pruned_py = onnxsim.apply_attention_head_wanda_pruning(
+            model, calibration_data=[], sparsity=0.5, importance_norm=norm
+        )
+        onnx.checker.check_model(pruned_cpp)
+        assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    kept_l2 = onnxsim.apply_attention_head_wanda_pruning_cpp(
+        model, calibration_data=[], sparsity=0.5
+    )
+    kept_l1 = onnxsim.apply_attention_head_wanda_pruning_cpp(
+        model, calibration_data=[], sparsity=0.5, importance_norm="l1"
+    )
+    assert kept_l2.SerializeToString() != kept_l1.SerializeToString()

--- a/tests/test_embedding_vocab_pruning_cpp.py
+++ b/tests/test_embedding_vocab_pruning_cpp.py
@@ -1052,7 +1052,7 @@ def test_gbq_native_uint4_no_zero_points_matches_oracle():
     rng = np.random.default_rng(300)
     data_vals = rng.integers(0, 16, size=(V, H), dtype=np.int64).astype(np.uint8)
     data_tt = onnx.numpy_helper.from_array(data_vals.astype(ml_dtypes.uint4), "data")
-    scales_vals = (rng.random((V, n_blocks)).astype(np.float32) + 0.1)
+    scales_vals = rng.random((V, n_blocks)).astype(np.float32) + 0.1
     scales_tt = _f32(scales_vals, "scales")
 
     model = _gbq_model(data_tt, scales_tt, None, bits, block_size, H)
@@ -1062,7 +1062,9 @@ def test_gbq_native_uint4_no_zero_points_matches_oracle():
     orig_out = _run(model, {"indices": idx_full})[0]
 
     keep_token_ids = [0, 2, 5, 3]
-    result = onnxsim.apply_embedding_vocab_pruning_cpp(model, keep_token_ids=keep_token_ids)
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(
+        model, keep_token_ids=keep_token_ids
+    )
     onnx.checker.check_model(result.model)
     assert result.matched
     assert not result.lm_head_pruned
@@ -1085,7 +1087,7 @@ def test_gbq_native_uint4_with_zero_points_matches_oracle():
     rng = np.random.default_rng(301)
     data_vals = rng.integers(0, 16, size=(V, H), dtype=np.int64).astype(np.uint8)
     data_tt = onnx.numpy_helper.from_array(data_vals.astype(ml_dtypes.uint4), "data")
-    scales_vals = (rng.random((V, n_blocks)).astype(np.float32) + 0.1)
+    scales_vals = rng.random((V, n_blocks)).astype(np.float32) + 0.1
     scales_tt = _f32(scales_vals, "scales")
     zp_vals = rng.integers(0, 16, size=(V, n_blocks), dtype=np.int64).astype(np.uint8)
     zp_tt = onnx.numpy_helper.from_array(zp_vals.astype(ml_dtypes.uint4), "zero_points")
@@ -1118,7 +1120,7 @@ def test_gbq_native_int4_matches_oracle():
     rng = np.random.default_rng(302)
     data_vals = rng.integers(-8, 8, size=(V, H), dtype=np.int64).astype(np.int8)
     data_tt = onnx.numpy_helper.from_array(data_vals.astype(ml_dtypes.int4), "data")
-    scales_vals = (rng.random((V, n_blocks)).astype(np.float32) + 0.1)
+    scales_vals = rng.random((V, n_blocks)).astype(np.float32) + 0.1
     scales_tt = _f32(scales_vals, "scales")
 
     model = _gbq_model(data_tt, scales_tt, None, bits, block_size, H)
@@ -1128,7 +1130,9 @@ def test_gbq_native_int4_matches_oracle():
     orig_out = _run(model, {"indices": idx_full})[0]
 
     keep_token_ids = [6, 4, 1, 0]
-    result = onnxsim.apply_embedding_vocab_pruning_cpp(model, keep_token_ids=keep_token_ids)
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(
+        model, keep_token_ids=keep_token_ids
+    )
     onnx.checker.check_model(result.model)
     assert result.matched
     assert result.kept_token_ids == sorted(keep_token_ids)
@@ -1155,7 +1159,7 @@ def test_gbq_packed_uint8_bits4_with_zero_points_matches_oracle():
     packed = _pack_uint8_bits(data_vals, bits)
     data_tt = onnx.numpy_helper.from_array(packed, "data")
     real_width = packed.shape[1] * (8 // bits)
-    scales_vals = (rng.random((V, n_blocks)).astype(np.float32) + 0.1)
+    scales_vals = rng.random((V, n_blocks)).astype(np.float32) + 0.1
     scales_tt = _f32(scales_vals, "scales")
     zp_vals = rng.integers(0, maxval + 1, size=(V, n_blocks), dtype=np.int64)
     zp_tt = onnx.numpy_helper.from_array(_pack_uint8_bits(zp_vals, bits), "zero_points")
@@ -1167,7 +1171,9 @@ def test_gbq_packed_uint8_bits4_with_zero_points_matches_oracle():
     orig_out = _run(model, {"indices": idx_full})[0]
 
     keep_token_ids = [0, 2, 4, 1]
-    result = onnxsim.apply_embedding_vocab_pruning_cpp(model, keep_token_ids=keep_token_ids)
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(
+        model, keep_token_ids=keep_token_ids
+    )
     onnx.checker.check_model(result.model)
     assert result.matched
     assert result.kept_token_ids == sorted(keep_token_ids)
@@ -1196,7 +1202,7 @@ def test_gbq_packed_uint8_bits2_no_zero_points_matches_oracle():
     packed = _pack_uint8_bits(data_vals, bits)
     data_tt = onnx.numpy_helper.from_array(packed, "data")
     real_width = packed.shape[1] * (8 // bits)
-    scales_vals = (rng.random((V, n_blocks)).astype(np.float32) + 0.1)
+    scales_vals = rng.random((V, n_blocks)).astype(np.float32) + 0.1
     scales_tt = _f32(scales_vals, "scales")
 
     model = _gbq_model(data_tt, scales_tt, None, bits, block_size, real_width)
@@ -1229,7 +1235,7 @@ def test_gbq_plain_uint8_bits8_matches_oracle():
     rng = np.random.default_rng(305)
     data_vals = rng.integers(0, 256, size=(V, H), dtype=np.int64).astype(np.uint8)
     data_tt = onnx.numpy_helper.from_array(data_vals, "data")
-    scales_vals = (rng.random((V, n_blocks)).astype(np.float32) + 0.1)
+    scales_vals = rng.random((V, n_blocks)).astype(np.float32) + 0.1
     scales_tt = _f32(scales_vals, "scales")
 
     model = _gbq_model(data_tt, scales_tt, None, bits, block_size, H)
@@ -1239,7 +1245,9 @@ def test_gbq_plain_uint8_bits8_matches_oracle():
     orig_out = _run(model, {"indices": idx_full})[0]
 
     keep_token_ids = [5, 3, 0, 1]
-    result = onnxsim.apply_embedding_vocab_pruning_cpp(model, keep_token_ids=keep_token_ids)
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(
+        model, keep_token_ids=keep_token_ids
+    )
     onnx.checker.check_model(result.model)
     assert result.matched
     assert result.kept_token_ids == sorted(keep_token_ids)
@@ -1257,7 +1265,7 @@ def test_gbq_untied_lm_head_auto_detected_and_matches_oracle():
     rng = np.random.default_rng(306)
     data_vals = rng.integers(0, 16, size=(V, H), dtype=np.int64).astype(np.uint8)
     data_tt = onnx.numpy_helper.from_array(data_vals.astype(ml_dtypes.uint4), "data")
-    scales_vals = (rng.random((V, n_blocks)).astype(np.float32) + 0.1)
+    scales_vals = rng.random((V, n_blocks)).astype(np.float32) + 0.1
     scales_tt = _f32(scales_vals, "scales")
     w_lm = rng.standard_normal((H, V)).astype(np.float32)
 
@@ -1272,8 +1280,12 @@ def test_gbq_untied_lm_head_auto_detected_and_matches_oracle():
         quantize_axis=1,
     )
     mm_node = onnx.helper.make_node("MatMul", ["hidden", "W_lm"], ["logits"])
-    indices_vi = onnx.helper.make_tensor_value_info("indices", onnx.TensorProto.INT64, ["N"])
-    logits_vi = onnx.helper.make_tensor_value_info("logits", onnx.TensorProto.FLOAT, ["N", V])
+    indices_vi = onnx.helper.make_tensor_value_info(
+        "indices", onnx.TensorProto.INT64, ["N"]
+    )
+    logits_vi = onnx.helper.make_tensor_value_info(
+        "logits", onnx.TensorProto.FLOAT, ["N", V]
+    )
     graph = onnx.helper.make_graph(
         [gbq_node, mm_node],
         "g",
@@ -1295,7 +1307,9 @@ def test_gbq_untied_lm_head_auto_detected_and_matches_oracle():
     orig_out = _run(model, {"indices": idx_full})[0]
 
     keep_token_ids = [0, 1, 3, 5]
-    result = onnxsim.apply_embedding_vocab_pruning_cpp(model, keep_token_ids=keep_token_ids)
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(
+        model, keep_token_ids=keep_token_ids
+    )
     onnx.checker.check_model(result.model)
     assert result.matched
     assert result.lm_head_pruned
@@ -1325,21 +1339,42 @@ def test_gbq_tied_lm_head_declined_ambiguous_two_producers():
     scales_tt = _f32(rng.random((V, 1)).astype(np.float32) + 0.1, "scales")
 
     node1 = onnx.helper.make_node(
-        "GatherBlockQuantized", ["data", "indices1", "scales"], ["out1"],
-        domain="com.microsoft", bits=bits, block_size=block_size,
-        gather_axis=0, quantize_axis=1,
+        "GatherBlockQuantized",
+        ["data", "indices1", "scales"],
+        ["out1"],
+        domain="com.microsoft",
+        bits=bits,
+        block_size=block_size,
+        gather_axis=0,
+        quantize_axis=1,
     )
     node2 = onnx.helper.make_node(
-        "GatherBlockQuantized", ["data", "indices2", "scales"], ["out2"],
-        domain="com.microsoft", bits=bits, block_size=block_size,
-        gather_axis=0, quantize_axis=1,
+        "GatherBlockQuantized",
+        ["data", "indices2", "scales"],
+        ["out2"],
+        domain="com.microsoft",
+        bits=bits,
+        block_size=block_size,
+        gather_axis=0,
+        quantize_axis=1,
     )
-    ids1_vi = onnx.helper.make_tensor_value_info("indices1", onnx.TensorProto.INT64, ["N"])
-    ids2_vi = onnx.helper.make_tensor_value_info("indices2", onnx.TensorProto.INT64, ["M"])
-    out1_vi = onnx.helper.make_tensor_value_info("out1", onnx.TensorProto.FLOAT, ["N", H])
-    out2_vi = onnx.helper.make_tensor_value_info("out2", onnx.TensorProto.FLOAT, ["M", H])
+    ids1_vi = onnx.helper.make_tensor_value_info(
+        "indices1", onnx.TensorProto.INT64, ["N"]
+    )
+    ids2_vi = onnx.helper.make_tensor_value_info(
+        "indices2", onnx.TensorProto.INT64, ["M"]
+    )
+    out1_vi = onnx.helper.make_tensor_value_info(
+        "out1", onnx.TensorProto.FLOAT, ["N", H]
+    )
+    out2_vi = onnx.helper.make_tensor_value_info(
+        "out2", onnx.TensorProto.FLOAT, ["M", H]
+    )
     graph = onnx.helper.make_graph(
-        [node1, node2], "g", [ids1_vi, ids2_vi], [out1_vi, out2_vi],
+        [node1, node2],
+        "g",
+        [ids1_vi, ids2_vi],
+        [out1_vi, out2_vi],
         initializer=[data_tt, scales_tt],
     )
     model = onnx.helper.make_model(
@@ -1370,21 +1405,42 @@ def test_gbq_input_name_disambiguates_two_producers():
     a_data, a_scales = mk(V1, "a")
     b_data, b_scales = mk(V2, "b")
     node_a = onnx.helper.make_node(
-        "GatherBlockQuantized", ["a_data", "ids_a", "a_scales"], ["out_a"],
-        domain="com.microsoft", bits=bits, block_size=block_size,
-        gather_axis=0, quantize_axis=1,
+        "GatherBlockQuantized",
+        ["a_data", "ids_a", "a_scales"],
+        ["out_a"],
+        domain="com.microsoft",
+        bits=bits,
+        block_size=block_size,
+        gather_axis=0,
+        quantize_axis=1,
     )
     node_b = onnx.helper.make_node(
-        "GatherBlockQuantized", ["b_data", "ids_b", "b_scales"], ["out_b"],
-        domain="com.microsoft", bits=bits, block_size=block_size,
-        gather_axis=0, quantize_axis=1,
+        "GatherBlockQuantized",
+        ["b_data", "ids_b", "b_scales"],
+        ["out_b"],
+        domain="com.microsoft",
+        bits=bits,
+        block_size=block_size,
+        gather_axis=0,
+        quantize_axis=1,
     )
-    ids_a_vi = onnx.helper.make_tensor_value_info("ids_a", onnx.TensorProto.INT64, ["N"])
-    ids_b_vi = onnx.helper.make_tensor_value_info("ids_b", onnx.TensorProto.INT64, ["M"])
-    out_a_vi = onnx.helper.make_tensor_value_info("out_a", onnx.TensorProto.FLOAT, ["N", H])
-    out_b_vi = onnx.helper.make_tensor_value_info("out_b", onnx.TensorProto.FLOAT, ["M", H])
+    ids_a_vi = onnx.helper.make_tensor_value_info(
+        "ids_a", onnx.TensorProto.INT64, ["N"]
+    )
+    ids_b_vi = onnx.helper.make_tensor_value_info(
+        "ids_b", onnx.TensorProto.INT64, ["M"]
+    )
+    out_a_vi = onnx.helper.make_tensor_value_info(
+        "out_a", onnx.TensorProto.FLOAT, ["N", H]
+    )
+    out_b_vi = onnx.helper.make_tensor_value_info(
+        "out_b", onnx.TensorProto.FLOAT, ["M", H]
+    )
     graph = onnx.helper.make_graph(
-        [node_a, node_b], "g", [ids_a_vi, ids_b_vi], [out_a_vi, out_b_vi],
+        [node_a, node_b],
+        "g",
+        [ids_a_vi, ids_b_vi],
+        [out_a_vi, out_b_vi],
         initializer=[a_data, a_scales, b_data, b_scales],
     )
     model = onnx.helper.make_model(

--- a/tests/test_embedding_vocab_pruning_cpp.py
+++ b/tests/test_embedding_vocab_pruning_cpp.py
@@ -13,20 +13,32 @@ dropped token ids + an old-id -> new-id remapping), never a bare
 ``onnx.ModelProto``.
 
 Tests here mirror ``tests/test_pruning.py``'s own "Embedding / lm_head
-vocabulary pruning" coverage (search that section name there), restricted to
-what this C++ port actually recognizes: a plain ``Gather`` producer OR a
-``com.microsoft::EmbedLayerNormalization`` one (``com.microsoft::
-GatherBlockQuantized`` is still out of scope for this port -- see
-structured_pruning_entry.cpp's own section comment for why), a ``MatMul``/
+vocabulary pruning" coverage (search that section name there): a plain
+``Gather`` producer, a ``com.microsoft::EmbedLayerNormalization`` one, or a
+``com.microsoft::GatherBlockQuantized`` one (the block-quantized embedding
+shape -- see structured_pruning_entry.cpp's own section comment for the
+full empirical schema/packing detail this port depends on), a ``MatMul``/
 vanilla-``Gemm``/``com.microsoft::FusedGemm``/``GemmFastGelu`` ``lm_head``,
 and a FLOAT, FLOAT16, OR BFLOAT16 embedding table/``lm_head`` weight/bias.
-Every test that actually prunes something either runs the result through a
-real onnxruntime CPU session and compares against a numpy slice of the
-ORIGINAL model's own output (the same "byte-exact oracle" bar every other
-C++-port test file in this repo holds itself to), or cross-checks against
-the pure-Python ``onnxsim.apply_embedding_vocab_pruning``/
-``apply_embedding_vocab_magnitude_pruning`` entry points as a second,
-independently-implemented oracle.
+Every test that actually prunes something runs the result through a real
+onnxruntime CPU session and compares against a numpy slice of the ORIGINAL
+model's own output (the same "byte-exact oracle" bar every other C++-port
+test file in this repo holds itself to).
+
+``onnxsim.apply_embedding_vocab_pruning``/``apply_embedding_vocab_magnitude_
+pruning`` (the pure-Python names) are now themselves thin aliases for
+:func:`onnxsim.apply_embedding_vocab_pruning_cpp`/``apply_embedding_vocab_
+magnitude_pruning_cpp`` (full parity verified across both ``GatherBlockQuantized``
+packing conventions -- see pruning.py's own docstrings on those two
+functions), so a cross-check against the pure-Python entry point would be
+tautological (literally the same code path twice) wherever the C++ result's
+own ``kept_token_ids``/``id_map``/``lm_head_pruned`` is already verified
+directly against an independently-computed expected value in the same test
+(the explicit ``keep_token_ids``/``drop_token_ids`` the caller passed in, or
+a numpy-computed importance ranking) -- this file no longer calls the
+pure-Python entry points at all; the ONNX Runtime oracle comparisons already
+present in every test remain fully meaningful regression coverage
+regardless of aliasing.
 """
 
 import ml_dtypes
@@ -163,15 +175,6 @@ def test_untied_matches_oracle_and_renumbers_contiguously():
     assert pruned_out.shape[-1] == len(result.kept_token_ids)
     np.testing.assert_allclose(pruned_out, expected, atol=1e-5, rtol=1e-5)
 
-    # Independent oracle: the pure-Python entry point must agree exactly
-    # (same kept ids, same id_map, same lm_head_pruned flag).
-    py_result = onnxsim.apply_embedding_vocab_pruning(
-        model, keep_token_ids=keep_token_ids + [4, 9]
-    )
-    assert py_result.kept_token_ids == result.kept_token_ids
-    assert py_result.id_map == result.id_map
-    assert py_result.lm_head_pruned == result.lm_head_pruned
-
 
 def test_drop_token_ids_equivalent_to_complement_keep_set():
     V, H = 9, 5
@@ -182,10 +185,7 @@ def test_drop_token_ids_equivalent_to_complement_keep_set():
     onnx.checker.check_model(result.model)
     assert result.matched and result.lm_head_pruned
     assert result.kept_token_ids == [i for i in range(V) if i not in drop]
-
-    py_result = onnxsim.apply_embedding_vocab_pruning(model, drop_token_ids=drop)
-    assert py_result.kept_token_ids == result.kept_token_ids
-    assert py_result.id_map == result.id_map
+    assert result.id_map == {tok: i for i, tok in enumerate(result.kept_token_ids)}
 
 
 def test_untied_lm_head_gemm_bias_is_sliced():
@@ -354,11 +354,6 @@ def test_input_name_disambiguates_correctly():
     # The positional-embedding table must be left completely untouched.
     w_pos = {t.name: t for t in result.model.graph.initializer}["W_pos"]
     assert list(w_pos.dims) == [6, 4]
-
-    py_result = onnxsim.apply_embedding_vocab_pruning(
-        model, drop_token_ids=[4, 5], input_name="input_ids"
-    )
-    assert py_result.kept_token_ids == result.kept_token_ids
 
 
 def test_input_name_auto_detected_when_unambiguous():
@@ -555,10 +550,6 @@ def test_magnitude_pruning_combines_lm_head_norm_when_untied():
     expected = orig_out[..., result.kept_token_ids]
     np.testing.assert_allclose(pruned_out, expected, atol=1e-5, rtol=1e-5)
 
-    # Cross-check against the pure-Python entry point's own ranking.
-    py_result = onnxsim.apply_embedding_vocab_magnitude_pruning(model, sparsity=0.4)
-    assert py_result.kept_token_ids == result.kept_token_ids
-
 
 def test_magnitude_pruning_rejects_bad_sparsity():
     model = _matmul_model(K=4, N=4)
@@ -649,13 +640,6 @@ def test_embed_layer_norm_word_embedding_matches_oracle_and_ort_execution():
     ref_out, _ = _run(ref_model, {"input_ids": local_ids})
     np.testing.assert_allclose(pruned_out, ref_out, atol=1e-5, rtol=1e-5)
 
-    # Cross-check against the pure-Python entry point.
-    py_result = onnxsim.apply_embedding_vocab_pruning(
-        model, keep_token_ids=keep_token_ids
-    )
-    assert py_result.kept_token_ids == result.kept_token_ids
-    assert py_result.id_map == result.id_map
-
 
 def test_embed_layer_norm_magnitude_pruning_matches_oracle():
     # A strictly-decreasing per-row scale gives an unambiguous ranking with
@@ -681,9 +665,6 @@ def test_embed_layer_norm_magnitude_pruning_matches_oracle():
     keep_count = max(1, round(V * 0.7))
     expected_keep = sorted(np.argsort(-row_norm)[:keep_count].tolist())
     assert result.kept_token_ids == expected_keep
-
-    py_result = onnxsim.apply_embedding_vocab_magnitude_pruning(model, sparsity=0.3)
-    assert py_result.kept_token_ids == result.kept_token_ids
 
 
 def _ambiguous_embed_layer_norm_model(V1=10, V2=8, P=6, H=4, seed=203):
@@ -767,6 +748,7 @@ def test_untied_lm_head_fusedgemm_matches_oracle_and_ort_execution():
     )
     onnx.checker.check_model(result.model)
     assert result.matched and result.lm_head_pruned
+    assert result.kept_token_ids == keep_token_ids
 
     input_ids = np.array([0, 6, 8, 2], dtype=np.int64)
     remapped = np.array([result.id_map[i] for i in input_ids], dtype=np.int64)
@@ -774,12 +756,6 @@ def test_untied_lm_head_fusedgemm_matches_oracle_and_ort_execution():
     pruned_out = _run(result.model, {"input_ids": remapped})[0]
     expected = orig_out[..., result.kept_token_ids]
     np.testing.assert_allclose(pruned_out, expected, atol=1e-5, rtol=1e-5)
-
-    py_result = onnxsim.apply_embedding_vocab_pruning(
-        model, keep_token_ids=keep_token_ids
-    )
-    assert py_result.kept_token_ids == result.kept_token_ids
-    assert py_result.lm_head_pruned == result.lm_head_pruned
 
 
 def _decompose_gemmfastgelu(model):
@@ -838,6 +814,7 @@ def test_untied_lm_head_gemmfastgelu_matches_oracle_via_decompose():
     )
     onnx.checker.check_model(result.model)
     assert result.matched and result.lm_head_pruned
+    assert result.kept_token_ids == keep_token_ids
 
     lm_init = {t.name: t for t in result.model.graph.initializer}["W_lm"]
     assert list(lm_init.dims) == [H, len(keep_token_ids)]
@@ -848,12 +825,6 @@ def test_untied_lm_head_gemmfastgelu_matches_oracle_via_decompose():
     pruned_out = _run(_decompose_gemmfastgelu(result.model), {"input_ids": remapped})[0]
     expected = orig_out[..., result.kept_token_ids]
     np.testing.assert_allclose(pruned_out, expected, atol=1e-5, rtol=1e-5)
-
-    py_result = onnxsim.apply_embedding_vocab_pruning(
-        model, keep_token_ids=keep_token_ids
-    )
-    assert py_result.kept_token_ids == result.kept_token_ids
-    assert py_result.lm_head_pruned == result.lm_head_pruned
 
 
 # --- FLOAT16 / BFLOAT16 embedding table --------------------------------------
@@ -889,6 +860,7 @@ def test_fp16_embedding_and_lm_head_matches_ort_execution_and_preserves_bits():
     )
     onnx.checker.check_model(result.model)
     assert result.matched and result.lm_head_pruned
+    assert result.kept_token_ids == keep_token_ids
 
     inits = {t.name: t for t in result.model.graph.initializer}
     assert inits["W_emb"].data_type == onnx.TensorProto.FLOAT16
@@ -916,11 +888,6 @@ def test_fp16_embedding_and_lm_head_matches_ort_execution_and_preserves_bits():
         rtol=1e-2,
     )
 
-    py_result = onnxsim.apply_embedding_vocab_pruning(
-        model, keep_token_ids=keep_token_ids
-    )
-    assert py_result.kept_token_ids == result.kept_token_ids
-
 
 def test_bfloat16_embedding_preserves_dtype_and_matches_array_oracle():
     # No onnxruntime CPU execution support for BFLOAT16 in this environment
@@ -947,6 +914,8 @@ def test_bfloat16_embedding_preserves_dtype_and_matches_array_oracle():
     onnx.checker.check_model(result.model)
     assert result.matched
     assert not result.lm_head_pruned
+    assert result.kept_token_ids == keep_token_ids
+    assert result.id_map == {tok: i for i, tok in enumerate(result.kept_token_ids)}
 
     emb_init = {t.name: t for t in result.model.graph.initializer}["W_emb"]
     assert emb_init.data_type == onnx.TensorProto.BFLOAT16
@@ -955,12 +924,6 @@ def test_bfloat16_embedding_preserves_dtype_and_matches_array_oracle():
     np.testing.assert_array_equal(
         emb_new.view(np.uint16), w_emb[keep_token_ids].view(np.uint16)
     )
-
-    py_result = onnxsim.apply_embedding_vocab_pruning(
-        model, keep_token_ids=keep_token_ids
-    )
-    assert py_result.kept_token_ids == result.kept_token_ids
-    assert py_result.id_map == result.id_map
 
 
 def test_bfloat16_magnitude_pruning_matches_array_oracle():
@@ -988,5 +951,488 @@ def test_bfloat16_magnitude_pruning_matches_array_oracle():
     expected_keep = sorted(np.argsort(-row_norm)[:keep_count].tolist())
     assert result.kept_token_ids == expected_keep
 
-    py_result = onnxsim.apply_embedding_vocab_magnitude_pruning(model, sparsity=0.5)
-    assert py_result.kept_token_ids == result.kept_token_ids
+
+# --- GatherBlockQuantized producer shape -------------------------------------
+#
+# The block-quantized (int2/int4/int8) analogue of a plain-float embedding
+# `Gather` (see structured_pruning_entry.cpp's own "Embedding vocabulary
+# pruning" section comment, and pruning.py's own section-top comment above
+# `_match_gather_block_quantized_producer`, for the full empirical schema/
+# packing/real-exporter-evidence this depends on). Two genuinely different
+# sub-8-bit packing conventions are dispatched purely off `data`'s own
+# dtype: ONNX-native sub-byte `tensor(uint4)`/`tensor(int4)` (a flat,
+# whole-tensor, 2-values-per-byte pack -- built here via `ml_dtypes.uint4`/
+# `ml_dtypes.int4` so `onnx.numpy_helper.from_array` packs it exactly the
+# way a real exporter's own tensor would), and manually-packed plain
+# `tensor(uint8)` (`bits` in {2, 4, 8} -- packed per-row, low-order bits
+# first, via `_pack_uint8_bits` below, mirroring the schema doc's own
+# "for bits < 8 the values are packed along the last dimension"). Every
+# test here uses `onnx.helper`/`onnx.numpy_helper.from_array` rather than
+# `onnx.parser`, per CLAUDE.md's own documented fallback: the parser's text
+# format encodes tensor literals as `float_data`, has no notion of ONNX's
+# native sub-4-bit packing at all, and can't express a hand-packed uint8
+# byte layout either -- both need genuine `numpy`-array-shaped tensor
+# construction. `GatherBlockQuantized` has a real onnxruntime CPU kernel in
+# this environment (confirmed directly, like `EmbedLayerNormalization`/
+# `FusedGemm` above), so every test below runs the pruned model through a
+# real session and compares against a numpy slice of the ORIGINAL model's
+# own output -- the same "byte-exact oracle" bar this file holds itself to
+# throughout, cross-checked against a real `InferenceSession` run rather
+# than the (now-aliased, so no longer independent) pure-Python entry point.
+
+
+def _pack_uint8_bits(vals, bits):
+    """Packs `vals` (small non-negative ints, shape `(rows, cols)`) into a
+    plain `uint8` array using `GatherBlockQuantized`'s own manually-packed
+    convention: independent PER ROW, low-order bits first -- e.g. at
+    `bits=4`, element `2i`/`2i+1` of a row land in the low/high nibble of
+    that row's own byte `i`. A `cols` not evenly divisible by
+    `8 // bits` leaves the trailing high-order bits of the last byte as
+    zero padding (never read back by anything this pass checks).
+    """
+    rows, cols = vals.shape
+    per_byte = 8 // bits
+    packed_width = (cols + per_byte - 1) // per_byte
+    packed = np.zeros((rows, packed_width), dtype=np.uint8)
+    for i in range(cols):
+        byte_i = i // per_byte
+        shift = (i % per_byte) * bits
+        packed[:, byte_i] |= (vals[:, i].astype(np.uint8) & ((1 << bits) - 1)) << shift
+    return packed
+
+
+def _gbq_model(data_tt, scales_tt, zp_tt, bits, block_size, hidden_out):
+    """A single-node `com.microsoft::GatherBlockQuantized` model, `indices`
+    (`int64`, rank 1) the sole graph input, `output` (same dtype as
+    `scales_tt`) the sole graph output. `gather_axis=0`/`quantize_axis=1`
+    throughout -- the only layout this pass's matcher ever admits.
+    """
+    inputs = ["data", "indices", "scales"]
+    initializer = [data_tt, scales_tt]
+    if zp_tt is not None:
+        inputs.append("zero_points")
+        initializer.append(zp_tt)
+    node = onnx.helper.make_node(
+        "GatherBlockQuantized",
+        inputs,
+        ["output"],
+        domain="com.microsoft",
+        bits=bits,
+        block_size=block_size,
+        gather_axis=0,
+        quantize_axis=1,
+    )
+    indices_vi = onnx.helper.make_tensor_value_info(
+        "indices", onnx.TensorProto.INT64, ["N"]
+    )
+    output_vi = onnx.helper.make_tensor_value_info(
+        "output", scales_tt.data_type, ["N", hidden_out]
+    )
+    graph = onnx.helper.make_graph(
+        [node], "g", [indices_vi], [output_vi], initializer=initializer
+    )
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 21),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    model.ir_version = 10
+    return model
+
+
+def test_gbq_native_uint4_no_zero_points_matches_oracle():
+    # Odd hidden_size (17) -- the native uint4 flat pack crosses a row
+    # boundary (this section's own top comment) -- exercises that this
+    # pass's row-select still lands on exactly the right bits.
+    V, H = 6, 17
+    bits, block_size = 4, 16
+    n_blocks = (H + block_size - 1) // block_size
+    rng = np.random.default_rng(300)
+    data_vals = rng.integers(0, 16, size=(V, H), dtype=np.int64).astype(np.uint8)
+    data_tt = onnx.numpy_helper.from_array(data_vals.astype(ml_dtypes.uint4), "data")
+    scales_vals = (rng.random((V, n_blocks)).astype(np.float32) + 0.1)
+    scales_tt = _f32(scales_vals, "scales")
+
+    model = _gbq_model(data_tt, scales_tt, None, bits, block_size, H)
+    onnx.checker.check_model(model)
+
+    idx_full = np.arange(V, dtype=np.int64)
+    orig_out = _run(model, {"indices": idx_full})[0]
+
+    keep_token_ids = [0, 2, 5, 3]
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(model, keep_token_ids=keep_token_ids)
+    onnx.checker.check_model(result.model)
+    assert result.matched
+    assert not result.lm_head_pruned
+    assert result.kept_token_ids == sorted(keep_token_ids)
+
+    inits = {t.name: t for t in result.model.graph.initializer}
+    assert list(inits["data"].dims) == [len(result.kept_token_ids), H]
+    assert inits["data"].data_type == onnx.TensorProto.UINT4
+
+    idx_new = np.arange(len(result.kept_token_ids), dtype=np.int64)
+    pruned_out = _run(result.model, {"indices": idx_new})[0]
+    expected = orig_out[result.kept_token_ids]
+    np.testing.assert_allclose(pruned_out, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_gbq_native_uint4_with_zero_points_matches_oracle():
+    V, H = 5, 12
+    bits, block_size = 4, 16
+    n_blocks = 1
+    rng = np.random.default_rng(301)
+    data_vals = rng.integers(0, 16, size=(V, H), dtype=np.int64).astype(np.uint8)
+    data_tt = onnx.numpy_helper.from_array(data_vals.astype(ml_dtypes.uint4), "data")
+    scales_vals = (rng.random((V, n_blocks)).astype(np.float32) + 0.1)
+    scales_tt = _f32(scales_vals, "scales")
+    zp_vals = rng.integers(0, 16, size=(V, n_blocks), dtype=np.int64).astype(np.uint8)
+    zp_tt = onnx.numpy_helper.from_array(zp_vals.astype(ml_dtypes.uint4), "zero_points")
+
+    model = _gbq_model(data_tt, scales_tt, zp_tt, bits, block_size, H)
+    onnx.checker.check_model(model)
+
+    idx_full = np.arange(V, dtype=np.int64)
+    orig_out = _run(model, {"indices": idx_full})[0]
+
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(model, drop_token_ids=[1, 4])
+    onnx.checker.check_model(result.model)
+    assert result.matched
+    assert result.kept_token_ids == [0, 2, 3]
+
+    inits = {t.name: t for t in result.model.graph.initializer}
+    assert list(inits["zero_points"].dims) == [len(result.kept_token_ids), n_blocks]
+    assert inits["zero_points"].data_type == onnx.TensorProto.UINT4
+
+    idx_new = np.arange(len(result.kept_token_ids), dtype=np.int64)
+    pruned_out = _run(result.model, {"indices": idx_new})[0]
+    expected = orig_out[result.kept_token_ids]
+    np.testing.assert_allclose(pruned_out, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_gbq_native_int4_matches_oracle():
+    V, H = 7, 10
+    bits, block_size = 4, 16
+    n_blocks = 1
+    rng = np.random.default_rng(302)
+    data_vals = rng.integers(-8, 8, size=(V, H), dtype=np.int64).astype(np.int8)
+    data_tt = onnx.numpy_helper.from_array(data_vals.astype(ml_dtypes.int4), "data")
+    scales_vals = (rng.random((V, n_blocks)).astype(np.float32) + 0.1)
+    scales_tt = _f32(scales_vals, "scales")
+
+    model = _gbq_model(data_tt, scales_tt, None, bits, block_size, H)
+    onnx.checker.check_model(model)
+
+    idx_full = np.arange(V, dtype=np.int64)
+    orig_out = _run(model, {"indices": idx_full})[0]
+
+    keep_token_ids = [6, 4, 1, 0]
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(model, keep_token_ids=keep_token_ids)
+    onnx.checker.check_model(result.model)
+    assert result.matched
+    assert result.kept_token_ids == sorted(keep_token_ids)
+    assert {t.name: t for t in result.model.graph.initializer}["data"].data_type == (
+        onnx.TensorProto.INT4
+    )
+
+    idx_new = np.arange(len(result.kept_token_ids), dtype=np.int64)
+    pruned_out = _run(result.model, {"indices": idx_new})[0]
+    expected = orig_out[result.kept_token_ids]
+    np.testing.assert_allclose(pruned_out, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_gbq_packed_uint8_bits4_with_zero_points_matches_oracle():
+    # true_hidden=5 at bits=4 packs to ceil(5*4/8)=3 bytes/row -- one
+    # nibble's worth (the 6th logical position) is unused padding, exactly
+    # the "intentionally-adversarial odd true width" case this section's
+    # own top comment (and pruning.py's own matcher comment) documents.
+    V, true_hidden, bits, block_size = 5, 5, 4, 16
+    n_blocks = 1
+    rng = np.random.default_rng(303)
+    maxval = (1 << bits) - 1
+    data_vals = rng.integers(0, maxval + 1, size=(V, true_hidden), dtype=np.int64)
+    packed = _pack_uint8_bits(data_vals, bits)
+    data_tt = onnx.numpy_helper.from_array(packed, "data")
+    real_width = packed.shape[1] * (8 // bits)
+    scales_vals = (rng.random((V, n_blocks)).astype(np.float32) + 0.1)
+    scales_tt = _f32(scales_vals, "scales")
+    zp_vals = rng.integers(0, maxval + 1, size=(V, n_blocks), dtype=np.int64)
+    zp_tt = onnx.numpy_helper.from_array(_pack_uint8_bits(zp_vals, bits), "zero_points")
+
+    model = _gbq_model(data_tt, scales_tt, zp_tt, bits, block_size, real_width)
+    onnx.checker.check_model(model)
+
+    idx_full = np.arange(V, dtype=np.int64)
+    orig_out = _run(model, {"indices": idx_full})[0]
+
+    keep_token_ids = [0, 2, 4, 1]
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(model, keep_token_ids=keep_token_ids)
+    onnx.checker.check_model(result.model)
+    assert result.matched
+    assert result.kept_token_ids == sorted(keep_token_ids)
+
+    inits = {t.name: t for t in result.model.graph.initializer}
+    assert inits["data"].data_type == onnx.TensorProto.UINT8
+    assert list(inits["data"].dims) == [len(result.kept_token_ids), packed.shape[1]]
+    # Byte-exact per-row slice -- no unpack/repack needed for this
+    # convention (this section's own top comment).
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["data"]), packed[result.kept_token_ids]
+    )
+
+    idx_new = np.arange(len(result.kept_token_ids), dtype=np.int64)
+    pruned_out = _run(result.model, {"indices": idx_new})[0]
+    expected = orig_out[result.kept_token_ids]
+    np.testing.assert_allclose(pruned_out, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_gbq_packed_uint8_bits2_no_zero_points_matches_oracle():
+    V, true_hidden, bits, block_size = 6, 7, 2, 16
+    n_blocks = 1
+    rng = np.random.default_rng(304)
+    maxval = (1 << bits) - 1
+    data_vals = rng.integers(0, maxval + 1, size=(V, true_hidden), dtype=np.int64)
+    packed = _pack_uint8_bits(data_vals, bits)
+    data_tt = onnx.numpy_helper.from_array(packed, "data")
+    real_width = packed.shape[1] * (8 // bits)
+    scales_vals = (rng.random((V, n_blocks)).astype(np.float32) + 0.1)
+    scales_tt = _f32(scales_vals, "scales")
+
+    model = _gbq_model(data_tt, scales_tt, None, bits, block_size, real_width)
+    onnx.checker.check_model(model)
+
+    idx_full = np.arange(V, dtype=np.int64)
+    orig_out = _run(model, {"indices": idx_full})[0]
+
+    # Default zero_points for a plain-uint8 `data` is 2**(bits-1) -- confirm
+    # the pruned model still agrees with the ORIGINAL model's own real
+    # kernel execution (which itself already applies that default), not a
+    # value hand-derived independently -- the "byte-exact oracle" bar.
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(model, drop_token_ids=[1, 3])
+    onnx.checker.check_model(result.model)
+    assert result.matched
+    assert result.kept_token_ids == [0, 2, 4, 5]
+
+    idx_new = np.arange(len(result.kept_token_ids), dtype=np.int64)
+    pruned_out = _run(result.model, {"indices": idx_new})[0]
+    expected = orig_out[result.kept_token_ids]
+    np.testing.assert_allclose(pruned_out, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_gbq_plain_uint8_bits8_matches_oracle():
+    # bits=8 -- no packing at all, `data` already a plain per-element byte
+    # array; the identical "no unpack/repack needed" row-slice as the
+    # bits<8 packed-uint8 convention, exercised here at the boundary value.
+    V, H, bits, block_size = 6, 9, 8, 16
+    n_blocks = 1
+    rng = np.random.default_rng(305)
+    data_vals = rng.integers(0, 256, size=(V, H), dtype=np.int64).astype(np.uint8)
+    data_tt = onnx.numpy_helper.from_array(data_vals, "data")
+    scales_vals = (rng.random((V, n_blocks)).astype(np.float32) + 0.1)
+    scales_tt = _f32(scales_vals, "scales")
+
+    model = _gbq_model(data_tt, scales_tt, None, bits, block_size, H)
+    onnx.checker.check_model(model)
+
+    idx_full = np.arange(V, dtype=np.int64)
+    orig_out = _run(model, {"indices": idx_full})[0]
+
+    keep_token_ids = [5, 3, 0, 1]
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(model, keep_token_ids=keep_token_ids)
+    onnx.checker.check_model(result.model)
+    assert result.matched
+    assert result.kept_token_ids == sorted(keep_token_ids)
+
+    idx_new = np.arange(len(result.kept_token_ids), dtype=np.int64)
+    pruned_out = _run(result.model, {"indices": idx_new})[0]
+    expected = orig_out[result.kept_token_ids]
+    np.testing.assert_allclose(pruned_out, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_gbq_untied_lm_head_auto_detected_and_matches_oracle():
+    V, H = 6, 16
+    bits, block_size = 4, 16
+    n_blocks = 1
+    rng = np.random.default_rng(306)
+    data_vals = rng.integers(0, 16, size=(V, H), dtype=np.int64).astype(np.uint8)
+    data_tt = onnx.numpy_helper.from_array(data_vals.astype(ml_dtypes.uint4), "data")
+    scales_vals = (rng.random((V, n_blocks)).astype(np.float32) + 0.1)
+    scales_tt = _f32(scales_vals, "scales")
+    w_lm = rng.standard_normal((H, V)).astype(np.float32)
+
+    gbq_node = onnx.helper.make_node(
+        "GatherBlockQuantized",
+        ["data", "indices", "scales"],
+        ["hidden"],
+        domain="com.microsoft",
+        bits=bits,
+        block_size=block_size,
+        gather_axis=0,
+        quantize_axis=1,
+    )
+    mm_node = onnx.helper.make_node("MatMul", ["hidden", "W_lm"], ["logits"])
+    indices_vi = onnx.helper.make_tensor_value_info("indices", onnx.TensorProto.INT64, ["N"])
+    logits_vi = onnx.helper.make_tensor_value_info("logits", onnx.TensorProto.FLOAT, ["N", V])
+    graph = onnx.helper.make_graph(
+        [gbq_node, mm_node],
+        "g",
+        [indices_vi],
+        [logits_vi],
+        initializer=[data_tt, scales_tt, _f32(w_lm, "W_lm")],
+    )
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 21),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    model.ir_version = 10
+    onnx.checker.check_model(model)
+
+    idx_full = np.arange(V, dtype=np.int64)
+    orig_out = _run(model, {"indices": idx_full})[0]
+
+    keep_token_ids = [0, 1, 3, 5]
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(model, keep_token_ids=keep_token_ids)
+    onnx.checker.check_model(result.model)
+    assert result.matched
+    assert result.lm_head_pruned
+    assert result.kept_token_ids == sorted(keep_token_ids)
+
+    lm_init = {t.name: t for t in result.model.graph.initializer}["W_lm"]
+    assert list(lm_init.dims) == [H, len(result.kept_token_ids)]
+
+    idx_new = np.arange(len(result.kept_token_ids), dtype=np.int64)
+    pruned_out = _run(result.model, {"indices": idx_new})[0]
+    expected = orig_out[result.kept_token_ids][:, result.kept_token_ids]
+    np.testing.assert_allclose(pruned_out, expected, atol=1e-4, rtol=1e-4)
+
+
+def test_gbq_tied_lm_head_declined_ambiguous_two_producers():
+    # A tied lm_head sharing the packed `data` tensor itself is always
+    # declined for this shape (MatchGatherBlockQuantizedProducer's own
+    # single-consumer requirement on `data`) -- constructed here as two
+    # independent `GatherBlockQuantized` nodes both reading the same `data`/
+    # `scales` initializers, which is simultaneously an unrecognized-second-
+    # consumer decline AND an ambiguous-multiple-producer decline; either
+    # way the whole call must decline, the model left untouched.
+    V, H, bits, block_size = 5, 8, 4, 16
+    rng = np.random.default_rng(307)
+    data_vals = rng.integers(0, 16, size=(V, H), dtype=np.int64).astype(np.uint8)
+    data_tt = onnx.numpy_helper.from_array(data_vals.astype(ml_dtypes.uint4), "data")
+    scales_tt = _f32(rng.random((V, 1)).astype(np.float32) + 0.1, "scales")
+
+    node1 = onnx.helper.make_node(
+        "GatherBlockQuantized", ["data", "indices1", "scales"], ["out1"],
+        domain="com.microsoft", bits=bits, block_size=block_size,
+        gather_axis=0, quantize_axis=1,
+    )
+    node2 = onnx.helper.make_node(
+        "GatherBlockQuantized", ["data", "indices2", "scales"], ["out2"],
+        domain="com.microsoft", bits=bits, block_size=block_size,
+        gather_axis=0, quantize_axis=1,
+    )
+    ids1_vi = onnx.helper.make_tensor_value_info("indices1", onnx.TensorProto.INT64, ["N"])
+    ids2_vi = onnx.helper.make_tensor_value_info("indices2", onnx.TensorProto.INT64, ["M"])
+    out1_vi = onnx.helper.make_tensor_value_info("out1", onnx.TensorProto.FLOAT, ["N", H])
+    out2_vi = onnx.helper.make_tensor_value_info("out2", onnx.TensorProto.FLOAT, ["M", H])
+    graph = onnx.helper.make_graph(
+        [node1, node2], "g", [ids1_vi, ids2_vi], [out1_vi, out2_vi],
+        initializer=[data_tt, scales_tt],
+    )
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 21),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    model.ir_version = 10
+    onnx.checker.check_model(model)
+
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(model, keep_token_ids=[0, 1, 2])
+    assert result.matched is False
+    assert result.model.SerializeToString() == model.SerializeToString()
+
+
+def test_gbq_input_name_disambiguates_two_producers():
+    V1, V2, H, bits, block_size = 6, 8, 8, 4, 16
+    rng = np.random.default_rng(308)
+
+    def mk(vocab, prefix):
+        d = rng.integers(0, 16, size=(vocab, H), dtype=np.int64).astype(np.uint8)
+        dt = onnx.numpy_helper.from_array(d.astype(ml_dtypes.uint4), f"{prefix}_data")
+        st = _f32(rng.random((vocab, 1)).astype(np.float32) + 0.1, f"{prefix}_scales")
+        return dt, st
+
+    a_data, a_scales = mk(V1, "a")
+    b_data, b_scales = mk(V2, "b")
+    node_a = onnx.helper.make_node(
+        "GatherBlockQuantized", ["a_data", "ids_a", "a_scales"], ["out_a"],
+        domain="com.microsoft", bits=bits, block_size=block_size,
+        gather_axis=0, quantize_axis=1,
+    )
+    node_b = onnx.helper.make_node(
+        "GatherBlockQuantized", ["b_data", "ids_b", "b_scales"], ["out_b"],
+        domain="com.microsoft", bits=bits, block_size=block_size,
+        gather_axis=0, quantize_axis=1,
+    )
+    ids_a_vi = onnx.helper.make_tensor_value_info("ids_a", onnx.TensorProto.INT64, ["N"])
+    ids_b_vi = onnx.helper.make_tensor_value_info("ids_b", onnx.TensorProto.INT64, ["M"])
+    out_a_vi = onnx.helper.make_tensor_value_info("out_a", onnx.TensorProto.FLOAT, ["N", H])
+    out_b_vi = onnx.helper.make_tensor_value_info("out_b", onnx.TensorProto.FLOAT, ["M", H])
+    graph = onnx.helper.make_graph(
+        [node_a, node_b], "g", [ids_a_vi, ids_b_vi], [out_a_vi, out_b_vi],
+        initializer=[a_data, a_scales, b_data, b_scales],
+    )
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 21),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    model.ir_version = 10
+    onnx.checker.check_model(model)
+
+    result = onnxsim.apply_embedding_vocab_pruning_cpp(model, keep_token_ids=[0, 1, 2])
+    assert result.matched is False  # ambiguous, no input_name
+
+    result2 = onnxsim.apply_embedding_vocab_pruning_cpp(
+        model, drop_token_ids=[4, 5], input_name="ids_a"
+    )
+    assert result2.matched
+    assert result2.kept_token_ids == [0, 1, 2, 3]
+    b_data_new = {t.name: t for t in result2.model.graph.initializer}["b_data"]
+    assert list(b_data_new.dims) == [V2, H]  # the other producer's table untouched
+
+
+def test_gbq_magnitude_pruning_matches_dequantized_norm_oracle():
+    # Independent oracle: dequantize by hand (the same formula this pass's
+    # own GatherBlockQuantizedDequantized/`_gather_block_quantized_
+    # dequantized` use, per structured_pruning_entry.cpp's own doc comment),
+    # rank by L2 norm, and compare -- never calls the (now-aliased)
+    # pure-Python entry point.
+    V, H, bits, block_size = 10, 8, 4, 16
+    n_blocks = 1
+    rng = np.random.default_rng(309)
+    scale_factor = np.linspace(3.0, 0.2, V)
+    data_vals = rng.integers(0, 16, size=(V, H), dtype=np.int64).astype(np.uint8)
+    data_tt = onnx.numpy_helper.from_array(data_vals.astype(ml_dtypes.uint4), "data")
+    scales_vals = scale_factor.astype(np.float32).reshape(V, n_blocks)
+    scales_tt = _f32(scales_vals, "scales")
+
+    model = _gbq_model(data_tt, scales_tt, None, bits, block_size, H)
+    onnx.checker.check_model(model)
+
+    result = onnxsim.apply_embedding_vocab_magnitude_pruning_cpp(model, sparsity=0.4)
+    onnx.checker.check_model(result.model)
+    assert result.matched
+
+    dequant = data_vals.astype(np.float64) * scales_vals.astype(np.float64)  # zp=0
+    row_norm = np.linalg.norm(dequant, axis=1)
+    keep_count = max(1, round(V * 0.6))
+    expected_keep = sorted(np.argsort(-row_norm)[:keep_count].tolist())
+    assert result.kept_token_ids == expected_keep

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -260,7 +260,9 @@ def test_wanda_pruning_falls_back_to_magnitude_without_matching_activation():
         model, calibration_data=[{"X": x}], sparsity=0.5
     )
     onnx.checker.check_model(wanda_pruned)
-    np.testing.assert_array_equal(_weight(wanda_pruned), _magnitude_weight(magnitude_pruned))
+    np.testing.assert_array_equal(
+        _weight(wanda_pruned), _magnitude_weight(magnitude_pruned)
+    )
 
 
 def test_weight_sparsity_of_unpruned_model_is_zero():
@@ -15122,7 +15124,10 @@ def test_magnitude_pruning_attention_merged_weight_reaches_target_sparsity():
     node_after_same_weight_name = onnx.NodeProto()
     node_after_same_weight_name.CopyFrom(node_after)
     node_after_same_weight_name.input[1] = node_before.input[1]
-    assert node_after_same_weight_name.SerializeToString() == node_before.SerializeToString()
+    assert (
+        node_after_same_weight_name.SerializeToString()
+        == node_before.SerializeToString()
+    )
     num_heads, qkv = _attention_attrs(node_after)
     assert num_heads == cfg["H"]
     assert qkv == [cfg["Nq"], cfg["Nk"], cfg["Nv"]]

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -86,6 +86,59 @@ def _weight(model):
     return onnx.numpy_helper.to_array(model.graph.initializer[0])
 
 
+def _magnitude_weight(model, node_index=0, input_index=1):
+    # `onnxsim.apply_magnitude_pruning` is now a thin alias for the C++-backed
+    # `onnxsim.prune_magnitude_cpp` (see pruning.py's own "Magnitude pruning"
+    # section comment): unlike the retired pure-Python implementation (which
+    # mutated the existing initializer in place via `w_init.CopyFrom`, so
+    # `_weight`'s own `graph.initializer[0]`/by-original-name lookup still
+    # found the pruned values), the C++ port leaves the original initializer
+    # dangling and appends a *new*, anonymously-named one for the pruned
+    # weight, rewiring the consuming node's own weight input to it --
+    # matching every other onnxsim rewrite's "replace, don't mutate"
+    # convention for constants (see `tests/test_pruning_cpp.py`'s own
+    # `_weight` helper, which this mirrors). So every test that reads a
+    # magnitude-pruning result's weight must resolve it via the node's
+    # CURRENT weight input name, not assume it is still named "W"/"W1"/... or
+    # still `initializer[0]`.
+    node = model.graph.node[node_index]
+    w_name = node.input[input_index]
+    init = next(t for t in model.graph.initializer if t.name == w_name)
+    return onnx.numpy_helper.to_array(init)
+
+
+def _magnitude_weight_by_original_name(model, pruned, original_name, input_index=1):
+    # Same rationale as `_magnitude_weight`, for a multi-node model (e.g.
+    # GQA's separate Wq/Wk/Wv-producing MatMul nodes) where the weight to
+    # inspect isn't simply "node 0" -- finds the matching node by its
+    # ORIGINAL (pre-pruning) weight name, then resolves the pruned weight
+    # via that same node's CURRENT weight input in `pruned` (node order/
+    # count is unchanged by this pass -- only weight inputs are rewired).
+    node_index = next(
+        i
+        for i, n in enumerate(model.graph.node)
+        if len(n.input) > input_index and n.input[input_index] == original_name
+    )
+    return _magnitude_weight(pruned, node_index=node_index, input_index=input_index)
+
+
+def _magnitude_weight_in_graph(orig_graph, pruned_graph, original_name, input_index=1):
+    # Same rationale as `_magnitude_weight_by_original_name`, generalized to
+    # an arbitrary (sub)graph pair -- `orig_graph`/`pruned_graph` need not be
+    # `model.graph`/`pruned.graph` themselves, e.g. a nested If branch's own
+    # `GraphProto` (node order/count within that one graph is unchanged by
+    # this pass, same as at the top level).
+    node_index = next(
+        i
+        for i, n in enumerate(orig_graph.node)
+        if len(n.input) > input_index and n.input[input_index] == original_name
+    )
+    pruned_node = pruned_graph.node[node_index]
+    w_name = pruned_node.input[input_index]
+    init = next(t for t in pruned_graph.initializer if t.name == w_name)
+    return onnx.numpy_helper.to_array(init)
+
+
 def test_magnitude_pruning_reaches_target_sparsity():
     model = _matmul_model(K=64, N=16)
     pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.5)
@@ -99,7 +152,7 @@ def test_magnitude_pruning_keeps_the_largest_entries_per_row():
     model = _matmul_model(K=64, N=16)
     pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.75)
     w = _weight(model).astype(np.float64)  # [K, N]
-    w_pruned = _weight(pruned).astype(np.float64)
+    w_pruned = _magnitude_weight(pruned).astype(np.float64)
     # Per output column (row of W^T), the surviving entries must be exactly
     # the top-(1 - sparsity) fraction by magnitude.
     for col in range(w.shape[1]):
@@ -119,7 +172,7 @@ def test_magnitude_pruning_zero_sparsity_is_a_no_op():
 def test_magnitude_pruning_nm_pattern():
     model = _matmul_model(K=64, N=16)
     pruned = onnxsim.apply_magnitude_pruning(model, n=2, m=4)
-    w_pruned = _weight(pruned).T  # [N, K], row-major per output channel
+    w_pruned = _magnitude_weight(pruned).T  # [N, K], row-major per output channel
     assert onnxsim.weight_sparsity(pruned) == pytest.approx(0.5, abs=1e-9)
     for row in w_pruned:
         for start in range(0, len(row), 4):
@@ -167,7 +220,7 @@ def test_wanda_pruning_protects_high_activation_channels():
     onnx.checker.check_model(wanda_pruned)
     assert onnxsim.weight_sparsity(wanda_pruned) == pytest.approx(0.5, abs=1e-9)
 
-    w_magnitude = _weight(magnitude_pruned)
+    w_magnitude = _magnitude_weight(magnitude_pruned)
     w_wanda = _weight(wanda_pruned)
     # Wanda must keep strictly more of the salient rows' entries than plain
     # magnitude pruning -- otherwise this is just re-testing magnitude
@@ -207,7 +260,7 @@ def test_wanda_pruning_falls_back_to_magnitude_without_matching_activation():
         model, calibration_data=[{"X": x}], sparsity=0.5
     )
     onnx.checker.check_model(wanda_pruned)
-    np.testing.assert_array_equal(_weight(wanda_pruned), _weight(magnitude_pruned))
+    np.testing.assert_array_equal(_weight(wanda_pruned), _magnitude_weight(magnitude_pruned))
 
 
 def test_weight_sparsity_of_unpruned_model_is_zero():
@@ -263,23 +316,20 @@ def test_magnitude_pruning_global_sparsity_redistributes_toward_small_magnitude_
     )
     onnx.checker.check_model(global_pruned)
 
-    inits_local = {t.name: t for t in local_pruned.graph.initializer}
-    inits_global = {t.name: t for t in global_pruned.graph.initializer}
-
-    def sparsity_of(inits, name):
-        return float(np.mean(onnx.numpy_helper.to_array(inits[name]) == 0))
+    def sparsity_of(pruned, node_index):
+        return float(np.mean(_magnitude_weight(pruned, node_index=node_index) == 0))
 
     # Per-layer-uniform (default) mode: both layers cut to exactly the same
     # fraction, regardless of scale.
-    assert sparsity_of(inits_local, "Wbig") == pytest.approx(0.5, abs=1e-9)
-    assert sparsity_of(inits_local, "Wsmall") == pytest.approx(0.5, abs=1e-9)
+    assert sparsity_of(local_pruned, 0) == pytest.approx(0.5, abs=1e-9)  # Wbig
+    assert sparsity_of(local_pruned, 1) == pytest.approx(0.5, abs=1e-9)  # Wsmall
 
     # global_sparsity mode: the uniformly-100x-larger layer must be pruned
     # markedly less than the uniformly-small one -- the whole point of
     # pooling importance across layers instead of treating each layer's own
     # distribution in isolation.
-    big_sparsity = sparsity_of(inits_global, "Wbig")
-    small_sparsity = sparsity_of(inits_global, "Wsmall")
+    big_sparsity = sparsity_of(global_pruned, 0)  # Wbig
+    small_sparsity = sparsity_of(global_pruned, 1)  # Wsmall
     assert big_sparsity < 0.5 < small_sparsity
 
     # Aggregate sparsity across both matched layers still hits the
@@ -299,7 +349,6 @@ def test_magnitude_pruning_global_sparsity_matches_pooled_threshold_oracle():
     pruned = onnxsim.apply_magnitude_pruning(
         model, sparsity=sparsity, global_sparsity=True
     )
-    inits = {t.name: t for t in pruned.graph.initializer}
 
     # Hand-built oracle: pool |W| across both layers' own [N, K]
     # (output-channel-first) entries, in the same node order `_candidates`
@@ -324,11 +373,9 @@ def test_magnitude_pruning_global_sparsity_matches_pooled_threshold_oracle():
     expected_big = np.where(big_drop, 0.0, w_big_nk).T.astype(np.float32)
     expected_small = np.where(small_drop, 0.0, w_small_nk).T.astype(np.float32)
 
+    np.testing.assert_array_equal(_magnitude_weight(pruned, node_index=0), expected_big)
     np.testing.assert_array_equal(
-        onnx.numpy_helper.to_array(inits["Wbig"]), expected_big
-    )
-    np.testing.assert_array_equal(
-        onnx.numpy_helper.to_array(inits["Wsmall"]), expected_small
+        _magnitude_weight(pruned, node_index=1), expected_small
     )
 
 
@@ -486,7 +533,7 @@ def test_magnitude_pruning_conv_keeps_the_largest_entries_per_filter():
     pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.75)
     K = Cin * 3 * 3
     w_flat = w.astype(np.float64).reshape(Cout, K)
-    w_pruned_flat = _conv_weight(pruned).astype(np.float64).reshape(Cout, K)
+    w_pruned_flat = _magnitude_weight(pruned).astype(np.float64).reshape(Cout, K)
     keep_count = round(K * 0.25)
     for row in range(Cout):
         kept = np.flatnonzero(w_pruned_flat[row] != 0)
@@ -504,7 +551,7 @@ def test_magnitude_pruning_conv_nm_pattern():
 
     pruned = onnxsim.apply_magnitude_pruning(model, n=2, m=4)
     K = Cin * 3 * 3
-    w_flat = _conv_weight(pruned).reshape(Cout, K)
+    w_flat = _magnitude_weight(pruned).reshape(Cout, K)
     assert onnxsim.weight_sparsity(pruned) == pytest.approx(0.5, abs=1e-9)
     for row in w_flat:
         for start in range(0, len(row), 4):
@@ -529,7 +576,7 @@ def test_magnitude_pruning_conv_depthwise_reaches_target_sparsity_and_matches_or
     pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.5)
     onnx.checker.check_model(pruned)
     assert onnxsim.weight_sparsity(pruned) == pytest.approx(0.5, abs=1e-9)
-    w_pruned = _conv_weight(pruned)
+    w_pruned = _magnitude_weight(pruned)
     assert w_pruned.shape == w.shape
     # group/kernel_shape attributes (and hence output shape) are untouched
     # -- this is a value-only rewrite.
@@ -567,7 +614,7 @@ def test_magnitude_pruning_conv_general_grouped_reaches_target_sparsity_and_matc
     pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.5)
     onnx.checker.check_model(pruned)
     assert onnxsim.weight_sparsity(pruned) == pytest.approx(0.5, abs=1e-9)
-    w_pruned = _conv_weight(pruned)
+    w_pruned = _magnitude_weight(pruned)
     assert w_pruned.shape == w.shape
     conv_node = pruned.graph.node[0]
     assert next(a.i for a in conv_node.attribute if a.name == "group") == group
@@ -755,7 +802,7 @@ def test_wanda_pruning_conv_protects_high_activation_channel():
     )
     onnx.checker.check_model(wanda_pruned)
 
-    w_magnitude = _conv_weight(magnitude_pruned)
+    w_magnitude = _magnitude_weight(magnitude_pruned)
     w_wanda = _conv_weight(wanda_pruned)
     salient_kept_magnitude = np.count_nonzero(w_magnitude[:, salient_channel, :, :])
     salient_kept_wanda = np.count_nonzero(w_wanda[:, salient_channel, :, :])
@@ -12611,6 +12658,20 @@ def _attention_node(model):
     return next(n for n in model.graph.node if n.op_type == "Attention")
 
 
+def _attention_weight(model):
+    # See `_magnitude_weight`'s own doc comment: `onnxsim.apply_magnitude_pruning`
+    # is now a thin alias for the C++-backed `onnxsim.prune_magnitude_cpp`,
+    # which leaves the original "Wqkv" initializer dangling and appends a
+    # new, anonymously-named one -- so the pruned merged QKV weight must be
+    # resolved via the Attention node's own current weight input (index 1),
+    # not assumed to still be named "Wqkv".
+    node = _attention_node(model)
+    w_name = node.input[1]
+    return onnx.numpy_helper.to_array(
+        next(t for t in model.graph.initializer if t.name == w_name)
+    )
+
+
 def _attention_attrs(node):
     num_heads = next(a.i for a in node.attribute if a.name == "num_heads")
     qkv = next(list(a.ints) for a in node.attribute if a.name == "qkv_hidden_sizes")
@@ -14814,15 +14875,20 @@ def test_magnitude_pruning_attention_merged_weight_reaches_target_sparsity():
     pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.5)
     onnx.checker.check_model(pruned)
 
-    inits = {t.name: t for t in pruned.graph.initializer}
-    wqkv_pruned = onnx.numpy_helper.to_array(inits["Wqkv"])
+    wqkv_pruned = _attention_weight(pruned)
     assert wqkv_pruned.shape == cfg["wqkv"].shape
     zeros = np.count_nonzero(wqkv_pruned == 0)
     assert zeros / wqkv_pruned.size == pytest.approx(0.5, abs=1e-9)
 
     # Bias is never touched by this pass -- only the matched weight is.
+    # (Bias' own input index (2) and name ("Bqkv") are untouched -- only the
+    # weight input is ever rewired.)
+    bias_name = _attention_node(pruned).input[2]
     np.testing.assert_array_equal(
-        onnx.numpy_helper.to_array(inits["Bqkv"]), cfg["bqkv"]
+        onnx.numpy_helper.to_array(
+            next(t for t in pruned.graph.initializer if t.name == bias_name)
+        ),
+        cfg["bqkv"],
     )
 
     # num_heads/qkv_hidden_sizes describe the merged weight's *column
@@ -14831,7 +14897,16 @@ def test_magnitude_pruning_attention_merged_weight_reaches_target_sparsity():
     # just these two attributes) must come out byte-identical.
     node_before = _attention_node(model)
     node_after = _attention_node(pruned)
-    assert node_after.SerializeToString() == node_before.SerializeToString()
+    # Only the weight input (index 1) is rewired to a new initializer name
+    # (see `_attention_weight`'s own doc comment) -- num_heads/
+    # qkv_hidden_sizes and every other input describe the merged weight's
+    # own column layout, not any zeroed-vs-nonzero split within it, so the
+    # rest of the node (not just these two attributes) must still come out
+    # byte-identical.
+    node_after_same_weight_name = onnx.NodeProto()
+    node_after_same_weight_name.CopyFrom(node_after)
+    node_after_same_weight_name.input[1] = node_before.input[1]
+    assert node_after_same_weight_name.SerializeToString() == node_before.SerializeToString()
     num_heads, qkv = _attention_attrs(node_after)
     assert num_heads == cfg["H"]
     assert qkv == [cfg["Nq"], cfg["Nk"], cfg["Nv"]]
@@ -14841,9 +14916,8 @@ def test_magnitude_pruning_attention_merged_weight_keeps_the_largest_entries_per
     model, cfg = _attention_model(K=8, H=4, D=4, Out=6, seed=21)
     pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.75)
 
-    inits = {t.name: t for t in pruned.graph.initializer}
     w = cfg["wqkv"].astype(np.float64)  # [K, N]
-    w_pruned = onnx.numpy_helper.to_array(inits["Wqkv"]).astype(np.float64)
+    w_pruned = _attention_weight(pruned).astype(np.float64)
     keep_count = round(cfg["K"] * 0.25)
     for col in range(w.shape[1]):
         kept = np.flatnonzero(w_pruned[:, col] != 0)
@@ -14858,8 +14932,7 @@ def test_magnitude_pruning_attention_merged_weight_nm_pattern():
     pruned = onnxsim.apply_magnitude_pruning(model, n=2, m=4)
     onnx.checker.check_model(pruned)
 
-    inits = {t.name: t for t in pruned.graph.initializer}
-    w_pruned = onnx.numpy_helper.to_array(inits["Wqkv"]).T  # [N, K]
+    w_pruned = _attention_weight(pruned).T  # [N, K]
     for row in w_pruned:
         for start in range(0, len(row), 4):
             group = row[start : start + 4]
@@ -14894,10 +14967,8 @@ def test_wanda_pruning_attention_merged_weight_uses_calibrated_activation_norm()
     )
     onnx.checker.check_model(wanda_pruned)
 
-    inits_m = {t.name: t for t in magnitude_pruned.graph.initializer}
-    inits_w = {t.name: t for t in wanda_pruned.graph.initializer}
-    w_magnitude = onnx.numpy_helper.to_array(inits_m["Wqkv"])  # [K, N]
-    w_wanda = onnx.numpy_helper.to_array(inits_w["Wqkv"])
+    w_magnitude = _attention_weight(magnitude_pruned)  # [K, N]
+    w_wanda = _attention_weight(wanda_pruned)
 
     # The calibration signal must actually be used, not just tolerated
     # without error -- Wanda's result must differ from plain magnitude
@@ -14980,9 +15051,8 @@ def test_magnitude_pruning_gqa_qkv_weights_already_matched():
     pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.5)
     onnx.checker.check_model(pruned)
 
-    inits = {t.name: t for t in pruned.graph.initializer}
     for name, original in (("Wq", cfg["wq"]), ("Wk", cfg["wk"]), ("Wv", cfg["wv"])):
-        w = onnx.numpy_helper.to_array(inits[name])
+        w = _magnitude_weight_by_original_name(model, pruned, name)
         assert w.shape == original.shape
         zeros = np.count_nonzero(w == 0)
         assert zeros / w.size == pytest.approx(0.5, abs=1e-9)
@@ -14990,7 +15060,10 @@ def test_magnitude_pruning_gqa_qkv_weights_already_matched():
 
     # num_heads/kv_num_heads are untouched -- this is a value-only rewrite
     # of Wq/Wk/Wv/Wout, not the structural head-pruning this file's own
-    # `apply_attention_head_pruning` performs on the same node type.
+    # `apply_attention_head_pruning` performs on the same node type -- the
+    # GQA node itself never has its own weight input rewired (Wq/Wk/Wv are
+    # plain upstream MatMul producers' own weights, not an input GQA itself
+    # owns), so it must still come out byte-identical.
     node_before = _gqa_node(model)
     node_after = _gqa_node(pruned)
     assert node_after.SerializeToString() == node_before.SerializeToString()
@@ -24852,7 +24925,8 @@ def test_magnitude_pruning_fp16_matches_ort_execution_and_preserves_exact_bits()
     pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.5)
     onnx.checker.check_model(pruned)
 
-    w_init = pruned.graph.initializer[0]
+    w_name = pruned.graph.node[0].input[1]
+    w_init = next(t for t in pruned.graph.initializer if t.name == w_name)
     assert w_init.data_type == onnx.TensorProto.FLOAT16  # dtype preserved, not upcast
     w_pruned = onnx.numpy_helper.to_array(w_init)
     assert w_pruned.dtype == np.float16
@@ -24932,7 +25006,7 @@ def test_magnitude_pruning_fp16_uses_genuine_decode_not_raw_float32_reinterpreta
     )
     pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.5)
     onnx.checker.check_model(pruned)
-    w_pruned = onnx.numpy_helper.to_array(pruned.graph.initializer[0])
+    w_pruned = _magnitude_weight(pruned)
     assert w_pruned.dtype == np.float16
 
     # Correct fp16 decode keeps rows 0/1 (values 8, 4) entirely nonzero and
@@ -24982,7 +25056,7 @@ def test_wanda_pruning_fp16_protects_high_activation_channels_matches_ort():
     assert wanda_pruned.graph.initializer[0].data_type == onnx.TensorProto.FLOAT16
     assert onnxsim.weight_sparsity(wanda_pruned) == pytest.approx(0.5, abs=1e-9)
 
-    w_magnitude = onnx.numpy_helper.to_array(magnitude_pruned.graph.initializer[0])
+    w_magnitude = _magnitude_weight(magnitude_pruned)
     w_wanda = onnx.numpy_helper.to_array(wanda_pruned.graph.initializer[0])
     salient_kept_magnitude = np.count_nonzero(w_magnitude[list(salient), :])
     salient_kept_wanda = np.count_nonzero(w_wanda[list(salient), :])
@@ -25273,7 +25347,8 @@ def test_magnitude_pruning_bfloat16_preserves_dtype_and_matches_array_oracle():
     pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.5)
     onnx.checker.check_model(pruned)
 
-    w_init = pruned.graph.initializer[0]
+    w_name = pruned.graph.node[0].input[1]
+    w_init = next(t for t in pruned.graph.initializer if t.name == w_name)
     assert w_init.data_type == onnx.TensorProto.BFLOAT16
     w_pruned = onnx.numpy_helper.to_array(w_init)
     assert w_pruned.dtype == ml_dtypes.bfloat16
@@ -25488,7 +25563,7 @@ def test_analyze_magnitude_pruning_matches_real_call():
     assert report.not_eligible == []
 
     pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.5)
-    w = onnx.numpy_helper.to_array(pruned.graph.initializer[0])
+    w = _magnitude_weight(pruned)
     assert layer.would_drop == int((w == 0).sum())
     assert layer.would_drop == pytest.approx(K * N * 0.5, abs=N)  # per-row rounding
 
@@ -25500,7 +25575,7 @@ def test_analyze_magnitude_pruning_nm_pattern_matches_real_call():
         model, onnxsim.apply_magnitude_pruning, n=2, m=4
     )
     pruned = onnxsim.apply_magnitude_pruning(model, n=2, m=4)
-    w = onnx.numpy_helper.to_array(pruned.graph.initializer[0])
+    w = _magnitude_weight(pruned)
     assert report.layers[0].would_drop == int((w == 0).sum())
     assert report.layers[0].would_drop == K * N // 2  # exactly half for 2:4
 
@@ -25514,17 +25589,19 @@ def test_analyze_magnitude_pruning_global_sparsity_matches_real_call():
         global_sparsity=True,
     )
     pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.5, global_sparsity=True)
-    inits = {t.name: t for t in pruned.graph.initializer}
     # `report.layers`' own `label` is each producer node's own output name
-    # (MatMul nodes here are unnamed in the parsed text) -- "Y1"/"Y2" --
-    # not the weight initializer's own name ("Wbig"/"Wsmall"); map between
-    # them via each node's own single weight input.
-    weight_by_output = {node.output[0]: node.input[1] for node in model.graph.node}
-    by_weight = {weight_by_output[layer.label]: layer for layer in report.layers}
-    assert set(by_weight) == set(inits)
-    for name, init in inits.items():
-        w = onnx.numpy_helper.to_array(init)
-        assert by_weight[name].would_drop == int((w == 0).sum())
+    # (MatMul nodes here are unnamed in the parsed text) -- "Y1"/"Y2" -- map
+    # each to that SAME node's position, then resolve the pruned weight via
+    # its current weight input in `pruned` (no longer named "Wbig"/"Wsmall"
+    # -- see `_magnitude_weight`'s own doc comment).
+    output_to_node_index = {
+        node.output[0]: i for i, node in enumerate(model.graph.node)
+    }
+    by_label = {layer.label: layer for layer in report.layers}
+    assert set(by_label) == set(output_to_node_index)
+    for output_name, node_index in output_to_node_index.items():
+        w = _magnitude_weight(pruned, node_index=node_index)
+        assert by_label[output_name].would_drop == int((w == 0).sum())
 
 
 def test_analyze_wanda_pruning_matches_real_call():
@@ -39375,15 +39452,13 @@ def test_magnitude_pruning_masks_subgraph_weights():
     pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.5)
     onnx.checker.check_model(pruned)
 
-    top_inits = {t.name: t for t in pruned.graph.initializer}
-    w1t = onnx.numpy_helper.to_array(top_inits["W1t"])
+    w1t = _magnitude_weight_in_graph(model.graph, pruned.graph, "W1t")
     assert np.mean(w1t == 0) == pytest.approx(0.5, abs=0.05)
 
+    then_g_orig, else_g_orig = _then_else_graphs(model)
     then_g, else_g = _then_else_graphs(pruned)
-    then_inits = {t.name: t for t in then_g.initializer}
-    else_inits = {t.name: t for t in else_g.initializer}
-    then_w1 = onnx.numpy_helper.to_array(then_inits["then_W1"])
-    else_w1 = onnx.numpy_helper.to_array(else_inits["else_W1"])
+    then_w1 = _magnitude_weight_in_graph(then_g_orig, then_g, "then_W1")
+    else_w1 = _magnitude_weight_in_graph(else_g_orig, else_g, "else_W1")
     assert np.mean(then_w1 == 0) == pytest.approx(0.5, abs=0.05)
     assert np.mean(else_w1 == 0) == pytest.approx(0.5, abs=0.05)
 
@@ -39393,20 +39468,18 @@ def test_magnitude_pruning_global_sparsity_pools_across_top_level_and_subgraphs(
     pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.3, global_sparsity=True)
     onnx.checker.check_model(pruned)
 
-    top_inits = {t.name: t for t in pruned.graph.initializer}
+    then_g_orig, else_g_orig = _then_else_graphs(model)
     then_g, else_g = _then_else_graphs(pruned)
-    then_inits = {t.name: t for t in then_g.initializer}
-    else_inits = {t.name: t for t in else_g.initializer}
 
     total = 0
     zeros = 0
-    for name_map, names in [
-        (top_inits, ["W1t", "W2t"]),
-        (then_inits, ["then_W1", "then_W2"]),
-        (else_inits, ["else_W1", "else_W2"]),
+    for orig_graph, pruned_graph, names in [
+        (model.graph, pruned.graph, ["W1t", "W2t"]),
+        (then_g_orig, then_g, ["then_W1", "then_W2"]),
+        (else_g_orig, else_g, ["else_W1", "else_W2"]),
     ]:
         for name in names:
-            arr = onnx.numpy_helper.to_array(name_map[name])
+            arr = _magnitude_weight_in_graph(orig_graph, pruned_graph, name)
             total += arr.size
             zeros += int(np.count_nonzero(arr == 0))
 
@@ -39586,7 +39659,7 @@ def test_analyze_magnitude_pruning_no_subgraphs_matches_pre_existing_behavior():
     assert report.not_eligible == []
 
     pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.5)
-    w = onnx.numpy_helper.to_array(pruned.graph.initializer[0])
+    w = _magnitude_weight(pruned)
     assert layer.would_drop == int((w == 0).sum())
 
 

--- a/tests/test_pruning_cpp.py
+++ b/tests/test_pruning_cpp.py
@@ -1,9 +1,37 @@
 """Tests for ``onnxsim.prune_magnitude_cpp`` -- the C++-backed port of
-``onnxsim.apply_magnitude_pruning`` (see
-``onnxsim/passes/magnitude_pruning.h``). Scope note: unlike the pure-Python
-version, this port does not match ``com.microsoft::Attention``'s merged QKV
-weight and offers no N:M pruning mode -- see that header's own doc comment.
+``onnxsim.apply_magnitude_pruning`` (see ``onnxsim/passes/magnitude_pruning.h``).
+
+Full parity with the pure-Python implementation: this port matches
+MatMul/vanilla-Gemm, Conv (ordinary/depthwise/general-grouped), and
+``com.microsoft`` Attention-family (``Attention``/
+``DecoderMaskedSelfAttention``/``PackedAttention``) merged-QKV weights, over
+FLOAT/FLOAT16/BFLOAT16, and offers both N:M semi-structured pruning and
+``global_sparsity`` mode -- see that header's own doc comment.
+
+``onnxsim.apply_magnitude_pruning`` (the pure-Python name) is now itself a
+thin alias for :func:`onnxsim.prune_magnitude_cpp` (full parity verified --
+see pruning.py's own "Magnitude pruning" section comment), so a test that
+used to call BOTH entry points and compare their live outputs would be
+tautological (literally the same code path twice) if left as-is. Those
+instead compare the C++ port's output against a golden fixture captured
+from the real pure-Python implementation *before* it was deleted -- see the
+``_GOLDEN_*`` constants below and ``_golden_weight_bytes``'s own doc comment
+for why these are the pruned weight tensor's own raw bytes (base64-encoded),
+not a whole serialized ``ModelProto`` the way
+``tests/test_transformer_block_pruning_cpp.py``'s own goldens are -- inlined
+directly rather than as a checked-in ``.onnx``/fixture file: this repo's own
+``.gitignore`` excludes ``*.onnx`` outright, and there is no existing
+``tests/golden/``-style fixture-directory convention to follow instead --
+see CLAUDE.md's own "Prefer onnx.parser-based model construction in tests"
+note for the same "keep fixtures in the test file itself" spirit) --
+preserving the original regression coverage (did the behavior change?)
+without asserting a tautology. Every other test below asserts the expected
+behavior directly (exact keep-counts, dtype round-trips, scope
+in/exclusions) rather than comparing to a live Python call, so it stays a
+real check after the alias too.
 """
+
+import base64
 
 import numpy as np
 import onnx
@@ -14,14 +42,34 @@ from onnx import parser
 import onnxsim
 
 ort = pytest.importorskip("onnxruntime")
+ml_dtypes = pytest.importorskip("ml_dtypes")
 
 
-def _model(body, initializer=(), opset=21):
+def _golden_weight_bytes(model, b64, node_index=0, input_index=1):
+    """Compares a pruned model's weight tensor raw bytes against a frozen
+    golden -- not a whole-``ModelProto`` byte comparison (the convention
+    ``tests/test_transformer_block_pruning_cpp.py`` uses for its own golden
+    fixtures): unlike a node-deletion rewrite, this pass's C++ port and the
+    pure-Python original it now aliases always disagreed at the *graph*
+    level even when numerically identical -- the pure-Python
+    implementation mutated the existing initializer in place
+    (``w_init.CopyFrom``), while the C++ port leaves the original
+    initializer dangling and appends a new, anonymously-named one, rewiring
+    the consuming node's input to it (see ``_weight``'s own doc comment) --
+    so comparing full serialized bytes would fail on that structural
+    difference alone, not a real regression. Comparing just the pruned
+    weight's own raw bytes sidesteps that: dtype/shape are asserted
+    separately by each test.
+    """
+    return _weight(model, node_index, input_index).tobytes() == base64.b64decode(b64)
+
+
+def _model(body, initializer=(), opset=21, extra_opset=""):
     model = parser.parse_model(
         f"""
         <
           ir_version: 10,
-          opset_import: ["": {opset}]
+          opset_import: ["": {opset}{extra_opset}]
         >
         {body}
         """
@@ -66,7 +114,7 @@ def _single_conv_model(w, spatial=10, group=1):
     )
 
 
-def _weight(model):
+def _weight(model, node_index=0, input_index=1):
     # Unlike the pure-Python apply_magnitude_pruning (which mutates the
     # existing initializer in place via w_init.CopyFrom), the C++ pass
     # leaves the original initializer dangling and appends a *new*,
@@ -75,8 +123,8 @@ def _weight(model):
     # "replace, don't mutate" convention for constants) -- so the pruned
     # weight must be found via the node's current weight input name, not
     # assumed to still be named "W" or still be initializer[0].
-    node = model.graph.node[0]
-    w_name = node.input[1]
+    node = model.graph.node[node_index]
+    w_name = node.input[input_index]
     init = next(t for t in model.graph.initializer if t.name == w_name)
     return onnx.numpy_helper.to_array(init)
 
@@ -137,19 +185,31 @@ def test_cpp_magnitude_pruning_conv_depthwise_reaches_target_sparsity():
     assert onnxsim.weight_sparsity(pruned) == pytest.approx(0.5, abs=1e-9)
 
 
-def test_cpp_magnitude_pruning_matches_python_reference():
-    # Both ports implement the exact same per-row keep-count rule -- on the
-    # same weight the *set* of surviving (nonzero) entries should match
-    # exactly, even if tie-breaking among equal-magnitude entries (rare with
-    # continuous random weights) could in principle differ.
-    model = _matmul_model(K=64, N=16, seed=7)
-    pruned_py = onnxsim.apply_magnitude_pruning(model, sparsity=0.5)
-    pruned_cpp = onnxsim.prune_magnitude_cpp(model, sparsity=0.5)
+# Frozen from onnxsim.apply_magnitude_pruning's own real pure-Python
+# implementation, on the exact tiny model each corresponding test below
+# builds, before that implementation was deleted in favor of the C++ port
+# (see this file's own module docstring).
+_GOLDEN_SPARSITY_MATMUL = (
+    "AAAAAAAAAAAAAAAA1P3jvpzKaL6M3P2+AAAAACyMKz9+Any+cdeevgAAAAAAAAAAAAAAACcz7r4A"
+    "AAAAZP+xPjkPLL+dTGq+RFtzv5MPJb/5vWu/AAAAALA7Ir8AAAAAAAAAAAAAAACXEqG/AAAAAAAA"
+    "AAAAAAAAfdtDvwAAAAA="
+)
 
-    mask_py = _weight(pruned_py) != 0
-    mask_cpp = _weight(pruned_cpp) != 0
-    assert np.array_equal(mask_py, mask_cpp)
-    np.testing.assert_array_equal(_weight(pruned_py), _weight(pruned_cpp))
+
+def test_cpp_magnitude_pruning_sparsity_matches_frozen_python_golden():
+    rng = np.random.default_rng(7)
+    K, N = 8, 4
+    w = (rng.standard_normal((K, N)) * 0.5).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{ Y = MatMul(X, W) }}
+        """,
+        initializer=[_f32(w, "W")],
+    )
+    pruned = onnxsim.prune_magnitude_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    assert _golden_weight_bytes(pruned, _GOLDEN_SPARSITY_MATMUL)
 
 
 def test_cpp_magnitude_pruning_output_stays_finite_and_close():
@@ -170,3 +230,425 @@ def test_cpp_magnitude_pruning_output_stays_finite_and_close():
     assert np.all(np.isfinite(y_p))
     rel = np.linalg.norm(y_f - y_p) / max(np.linalg.norm(y_f), 1e-6)
     assert rel < 1.0  # 30% sparsity perturbs but shouldn't blow up the output
+
+
+# --- N:M (semi-structured) pruning ----------------------------------------
+
+_GOLDEN_NM_MATMUL = (
+    "a54CQASQI8AAAAAAWVkRvwAAAAAAAAAAdEcBwAAAAACbfl2/BqxUQAAAAAAAAAAAAAAAAAAAAAAs"
+    "D4e/ERfIvozB9j4AAAAArS91PwAAAAAAAAAAdd3FPwAAAACsVgG/AAAAAAAAAAD3sPc/AAAAAHJn"
+    "eb7QS4A/AAAAAFtclb4="
+)
+
+
+def test_cpp_magnitude_pruning_nm_matches_frozen_python_golden():
+    rng = np.random.default_rng(3)
+    K, N = 8, 4
+    w = rng.standard_normal((K, N)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{ Y = MatMul(X, W) }}
+        """,
+        initializer=[_f32(w, "W")],
+    )
+    pruned = onnxsim.prune_magnitude_cpp(model, n=2, m=4)
+    onnx.checker.check_model(pruned)
+    assert _golden_weight_bytes(pruned, _GOLDEN_NM_MATMUL)
+
+
+def test_cpp_magnitude_pruning_nm_keeps_n_of_every_m_columns():
+    rng = np.random.default_rng(13)
+    K, N = 64, 8  # cols=K=64, a multiple of m=4 -- no trailing partial group
+    w = rng.standard_normal((K, N)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{ Y = MatMul(X, W) }}
+        """,
+        initializer=[_f32(w, "W")],
+    )
+    pruned = onnxsim.prune_magnitude_cpp(model, n=2, m=4)
+    w_nk = _weight(pruned).T.astype(np.float64)  # [N, K] -- output-channel-first
+    for row in w_nk:
+        for g in range(0, len(row), 4):
+            assert np.count_nonzero(row[g : g + 4]) == 2
+
+
+def test_cpp_magnitude_pruning_nm_tail_partial_group():
+    # cols=K=10, m=4 -> two full groups of 4 (cols 0-3, 4-7) plus a
+    # trailing partial group of 2 (cols 8-9), keep = min(2, max(1,
+    # round(2*2/4))) = 1 -- mirrors pruning.py's own `_nm_mask` exactly.
+    rng = np.random.default_rng(41)
+    K, N = 10, 6
+    w = rng.standard_normal((K, N)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{ Y = MatMul(X, W) }}
+        """,
+        initializer=[_f32(w, "W")],
+    )
+    pruned = onnxsim.prune_magnitude_cpp(model, n=2, m=4)
+    w_nk = _weight(pruned).T.astype(np.float64)  # [N, K]
+    for row in w_nk:
+        assert np.count_nonzero(row[0:4]) == 2
+        assert np.count_nonzero(row[4:8]) == 2
+        assert np.count_nonzero(row[8:10]) == 1
+
+
+def test_cpp_magnitude_pruning_nm_conv():
+    Cin, Cout = 4, 8  # cols = Cin*3*3 = 36
+    rng = np.random.default_rng(31)
+    w = rng.standard_normal((Cout, Cin, 3, 3)).astype(np.float32)
+    model = _single_conv_model(w)
+    pruned = onnxsim.prune_magnitude_cpp(model, n=2, m=4)
+    onnx.checker.check_model(pruned)
+    w_flat = _weight(pruned).reshape(Cout, -1).astype(np.float64)
+    for row in w_flat:
+        for g in range(0, 36, 4):
+            assert np.count_nonzero(row[g : g + 4]) == 2
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        dict(n=2),
+        dict(m=4),
+        dict(n=0, m=4),
+        dict(n=5, m=4),
+        dict(n=2, m=4, global_sparsity=True),
+    ],
+)
+def test_cpp_magnitude_pruning_nm_rejects_invalid_combinations(kwargs):
+    model = _matmul_model(K=16, N=4)
+    with pytest.raises(Exception):
+        onnxsim.prune_magnitude_cpp(model, **kwargs)
+
+
+# --- global_sparsity mode --------------------------------------------------
+
+_GOLDEN_GLOBAL_SPARSITY_MIXED_MATMUL = (
+    "AAAAAAAAAAAAAAAABFGgPwAAAACqAo2/53lMv4WD4z8AAAAAB4GXvwAAAAAAAAAA"
+)
+
+_GOLDEN_GLOBAL_SPARSITY_MIXED_CONV = "AAAAAMl37j8AAAAAuNfFv1MiwT8AAAAAAAAAAAAAAAA="
+
+
+def test_cpp_magnitude_pruning_global_sparsity_matches_frozen_python_golden():
+    rng = np.random.default_rng(51)
+    K1, N1 = 6, 2
+    Cin, Cout = 1, 2
+    w1 = rng.standard_normal((K1, N1)).astype(np.float32)
+    wc = rng.standard_normal((Cout, Cin, 2, 2)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K1}] X, float[b,{Cin},4,4] XC) => (float[batch,{N1}] Y, float[b,{Cout},3,3] YC)
+        {{
+          Y = MatMul(X, W1)
+          YC = Conv<kernel_shape=[2,2]>(XC, WC)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(wc, "WC")],
+    )
+    pruned = onnxsim.prune_magnitude_cpp(model, sparsity=0.6, global_sparsity=True)
+    onnx.checker.check_model(pruned)
+    assert _golden_weight_bytes(pruned, _GOLDEN_GLOBAL_SPARSITY_MIXED_MATMUL, node_index=0)
+    assert _golden_weight_bytes(pruned, _GOLDEN_GLOBAL_SPARSITY_MIXED_CONV, node_index=1)
+
+
+def test_cpp_magnitude_pruning_global_sparsity_pools_across_layers():
+    # A layer whose weights are uniformly small should be pruned harder than
+    # one whose weights are uniformly large, unlike the default per-layer
+    # mode (which would zero the same *fraction* of each independently).
+    rng = np.random.default_rng(101)
+    K, N = 16, 4
+    w_small = (rng.standard_normal((K, N)) * 1e-3).astype(np.float32)
+    w_large = (rng.standard_normal((K, N)) * 1e3).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Ys, float[batch,{N}] Yl)
+        {{
+          Ys = MatMul(X, Ws)
+          Yl = MatMul(X, Wl)
+        }}
+        """,
+        initializer=[_f32(w_small, "Ws"), _f32(w_large, "Wl")],
+    )
+    pruned = onnxsim.prune_magnitude_cpp(model, sparsity=0.5, global_sparsity=True)
+    w_small_pruned = _weight(pruned, node_index=0)
+    w_large_pruned = _weight(pruned, node_index=1)
+    total = w_small.size + w_large.size
+    assert np.count_nonzero(w_small_pruned) + np.count_nonzero(
+        w_large_pruned
+    ) == round(total * 0.5)
+    # The small-magnitude layer absorbs (much) more of the pruning than the
+    # large-magnitude one -- no per-layer floor, unlike the default mode.
+    assert np.count_nonzero(w_small_pruned) < np.count_nonzero(w_large_pruned)
+
+
+def test_cpp_magnitude_pruning_global_sparsity_rejects_nm():
+    model = _matmul_model(K=16, N=4)
+    with pytest.raises(Exception):
+        onnxsim.prune_magnitude_cpp(model, n=2, m=4, global_sparsity=True)
+
+
+def test_cpp_magnitude_pruning_global_sparsity_subgraph_aware():
+    rng = np.random.default_rng(61)
+    K, N = 16, 4
+    w_then = rng.standard_normal((K, N)).astype(np.float32)
+    w_else = rng.standard_normal((K, N)).astype(np.float32)
+    model = _model(
+        f"""
+        g (bool cond, float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = If (cond) <
+            then_branch = then_g () => (float[batch,{N}] Yt) {{ Yt = MatMul(X, Wt) }},
+            else_branch = else_g () => (float[batch,{N}] Ye) {{ Ye = MatMul(X, We) }}
+          >
+        }}
+        """
+    )
+    if_node = model.graph.node[0]
+    for attr in if_node.attribute:
+        if attr.name == "then_branch":
+            attr.g.initializer.append(_f32(w_then, "Wt"))
+        elif attr.name == "else_branch":
+            attr.g.initializer.append(_f32(w_else, "We"))
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.prune_magnitude_cpp(model, sparsity=0.5, global_sparsity=True)
+
+    def _sub_weight(m, branch_name):
+        node = m.graph.node[0]
+        for attr in node.attribute:
+            if attr.name == branch_name:
+                sub = attr.g
+                w_name = sub.node[0].input[1]
+                init = next(t for t in sub.initializer if t.name == w_name)
+                return onnx.numpy_helper.to_array(init)
+        raise AssertionError(branch_name)
+
+    total = w_then.size + w_else.size
+    zeroed = np.count_nonzero(_sub_weight(pruned, "then_branch") == 0) + np.count_nonzero(
+        _sub_weight(pruned, "else_branch") == 0
+    )
+    # Pooled across BOTH subgraphs combined -- not independently per branch.
+    assert zeroed == round(total * 0.5)
+
+
+# --- FLOAT16 / BFLOAT16 weight support -------------------------------------
+
+_GOLDEN_FLOAT16_MATMUL = (
+    "AABwOeY4FbQAAAAAjzQAAAAAZLtEOgAAAAAAAAAAAACZNgAAAAB8Nfa2D7oAAF21rruDtgAAxrj4"
+    "uQAALjcAAA=="
+)
+
+_GOLDEN_BFLOAT16_MATMUL = (
+    "vr4AAAAAAAAAAAU/AADQvgAAAAANPyS/qb7Xvl6/AAAAAL2+MT/SPqE+AAAAACq/nT4AAGK/AAAA"
+    "AMg+AAAAAA=="
+)
+
+
+def test_cpp_magnitude_pruning_float16_matches_frozen_python_golden():
+    rng = np.random.default_rng(11)
+    K, N = 8, 4
+    w = (rng.standard_normal((K, N)) * 0.5).astype(np.float16)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{ Y = MatMul(X, W) }}
+        """,
+        initializer=[onnx.numpy_helper.from_array(w, "W")],
+    )
+    pruned = onnxsim.prune_magnitude_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    w_pruned = _weight(pruned)
+    assert w_pruned.dtype == np.float16
+    assert _golden_weight_bytes(pruned, _GOLDEN_FLOAT16_MATMUL)
+
+
+def test_cpp_magnitude_pruning_bfloat16_matches_frozen_python_golden():
+    rng = np.random.default_rng(11)
+    K, N = 8, 4
+    _ = rng.standard_normal((K, N))  # advance the stream to match the fp16 draw
+    w = (rng.standard_normal((K, N)) * 0.5).astype(ml_dtypes.bfloat16)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{ Y = MatMul(X, W) }}
+        """,
+        initializer=[onnx.numpy_helper.from_array(w, "W")],
+    )
+    pruned = onnxsim.prune_magnitude_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    w_pruned = _weight(pruned)
+    assert w_pruned.dtype == ml_dtypes.bfloat16
+    assert _golden_weight_bytes(pruned, _GOLDEN_BFLOAT16_MATMUL)
+
+
+def test_cpp_magnitude_pruning_float16_preserves_kept_bit_patterns():
+    # Masking never recomputes a surviving value -- every kept entry's exact
+    # original fp16 bit pattern should round-trip unchanged through the
+    # float64 widen/narrow the C++ port uses internally.
+    rng = np.random.default_rng(17)
+    K, N = 32, 4
+    w = (rng.standard_normal((K, N)) * 0.5).astype(np.float16)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{ Y = MatMul(X, W) }}
+        """,
+        initializer=[onnx.numpy_helper.from_array(w, "W")],
+    )
+    pruned = onnxsim.prune_magnitude_cpp(model, sparsity=0.5)
+    w_pruned = _weight(pruned)
+    kept = w_pruned != 0
+    np.testing.assert_array_equal(w_pruned[kept].view(np.uint16), w[kept].view(np.uint16))
+
+
+# --- com.microsoft Attention-family merged-QKV-weight matching ------------
+
+# The Attention/PackedAttention/DecoderMaskedSelfAttention goldens below are
+# byte-identical to each other: same weight/bias, same seed, same
+# sparsity=0.5 -- these three op types are matched by the exact same
+# validation and masked by the exact same code path (see
+# `MatchAttentionQkvWeightOnly`'s own doc comment), so an identical result
+# is the expected outcome, not a copy-paste mistake.
+_GOLDEN_ATTENTION_PLAIN = (
+    "AAAAAEAK6D60MAm/LIgBPwAAAAAAAAAAFqt2vhRSpr4AAAAAqRWAPgAAAADbFEQ+SikCv75M8b4H"
+    "qu4+AAAAALyrJz/l07k+tVidvvhqxT7wCkE+AAAAAHbde74AAAAAAAAAAOkXiT4AAAAAv2rzPgrs"
+    "bb4AAAAAAAAAAAAAAABFcbW+ka+bPgAAAAAAAAAAAAAAADd3T74AAAAAAAAAAAAAAACedpc+AAAA"
+    "AAAAAABf2p6+AAAAAN2f0b4AAAAAAAAAAAAAAAAAAAAAmdrNPtCx2j6OuLq+D1i0Pu1UBL/MoWG+"
+    "AAAAAAAAAAAZ4qC+QvFdvgAAAAD7BFW+AAAAABetTD4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADH"
+    "ZZ++XS9HPgAAAAAAAAAAAAAAAAAAAABaRdo+AAAAAAAAAAAAAAAAhN6Bvv1xwz5lRY4+dyxVPgAA"
+    "AAAcM2M+u0+hPgAAAAAAAAAA4mkBvxN0kT4AAAAAU4WBvsHLiD4AAAAA"
+)
+
+_GOLDEN_PACKED_ATTENTION = _GOLDEN_ATTENTION_PLAIN
+
+_GOLDEN_DECODER_MASKED_SELF_ATTENTION = _GOLDEN_ATTENTION_PLAIN
+
+
+def _attention_qkv_weights():
+    K = 8
+    num_heads = 2
+    Nq = Nk = Nv = 4
+    total_n = Nq + Nk + Nv
+    rng = np.random.default_rng(21)
+    w = (rng.standard_normal((K, total_n)) * 0.3).astype(np.float32)
+    b = (rng.standard_normal((total_n,)) * 0.1).astype(np.float32)
+    return w, b, K, num_heads, Nq, Nk, Nv, total_n
+
+
+def test_cpp_magnitude_pruning_attention_matches_frozen_python_golden():
+    w, b, K, num_heads, Nq, Nk, Nv, total_n = _attention_qkv_weights()
+    model = _model(
+        f"""
+        g (float[batch, seq, {K}] X, float[batch, seq, seq] mask) => (float[batch, seq, {Nq}] Y, float[2, batch, {num_heads}, seq, {Nv // num_heads}] present)
+        {{
+          Y, present = com.microsoft.Attention<num_heads={num_heads}, qkv_hidden_sizes=[{Nq},{Nk},{Nv}]>(X, W, B, mask)
+        }}
+        """,
+        initializer=[_f32(w, "W"), _f32(b, "B")],
+        extra_opset=', "com.microsoft": 1',
+    )
+    pruned = onnxsim.prune_magnitude_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    assert _golden_weight_bytes(pruned, _GOLDEN_ATTENTION_PLAIN)
+
+
+def test_cpp_magnitude_pruning_packed_attention_matches_frozen_python_golden():
+    w, b, K, num_heads, Nq, Nk, Nv, total_n = _attention_qkv_weights()
+    model = _model(
+        f"""
+        g (float[batch, seq, {K}] X, float[batch, seq] tok_off, float[batch1] cum) => (float[batch, seq, {Nq}] Y)
+        {{
+          Y = com.microsoft.PackedAttention<num_heads={num_heads}, qkv_hidden_sizes=[{Nq},{Nk},{Nv}]>(X, W, B, tok_off, cum)
+        }}
+        """,
+        initializer=[_f32(w, "W"), _f32(b, "B")],
+        extra_opset=', "com.microsoft": 1',
+    )
+    pruned = onnxsim.prune_magnitude_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    assert _golden_weight_bytes(pruned, _GOLDEN_PACKED_ATTENTION)
+
+
+def test_cpp_magnitude_pruning_decoder_masked_self_attention_matches_frozen_python_golden():
+    w, b, K, num_heads, Nq, Nk, Nv, total_n = _attention_qkv_weights()
+    past_shape = f"2, batch, {num_heads}, past_seq, {Nv // num_heads}"
+    model = _model(
+        f"""
+        g (float[batch, 1, {K}] X, float[{past_shape}] past) => (float[batch, 1, {Nq}] Y, float[{past_shape}] present)
+        {{
+          Y, present = com.microsoft.DecoderMaskedSelfAttention<num_heads={num_heads}>(X, W2, B2, , past)
+        }}
+        """,
+        initializer=[_f32(w, "W2"), _f32(b, "B2")],
+        extra_opset=', "com.microsoft": 1',
+    )
+    onnx.checker.check_model(model)
+    pruned = onnxsim.prune_magnitude_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    assert _golden_weight_bytes(pruned, _GOLDEN_DECODER_MASKED_SELF_ATTENTION)
+
+
+def test_cpp_magnitude_pruning_decoder_masked_self_attention_declines_constant_past():
+    # A constant `past` has no established/tested slicing path -- declined
+    # conservatively (mirrors pruning.py's own `_match_attention_producer`),
+    # even though this pass never touches `past` at all either way.
+    w, b, K, num_heads, Nq, Nk, Nv, total_n = _attention_qkv_weights()
+    rng = np.random.default_rng(81)
+    past_const = rng.standard_normal((2, 1, num_heads, 1, Nv // num_heads)).astype(
+        np.float32
+    )
+    model = _model(
+        f"""
+        g (float[1, 1, {K}] X) => (float[1, 1, {Nq}] Y, float[2, 1, {num_heads}, 1, {Nv // num_heads}] present)
+        {{
+          Y, present = com.microsoft.DecoderMaskedSelfAttention<num_heads={num_heads}>(X, W2, B2, , PastConst)
+        }}
+        """,
+        initializer=[_f32(w, "W2"), _f32(b, "B2"), _f32(past_const, "PastConst")],
+        extra_opset=', "com.microsoft": 1',
+    )
+    onnx.checker.check_model(model)
+    pruned = onnxsim.prune_magnitude_cpp(model, sparsity=0.5)
+    np.testing.assert_array_equal(_weight(pruned), w)
+
+
+def test_cpp_magnitude_pruning_attention_declines_uneven_qkv_split():
+    w, b, K, num_heads, Nq, Nk, Nv, total_n = _attention_qkv_weights()
+    # num_heads doesn't evenly divide Nq -- malformed, declined rather than
+    # guessed at.
+    model = _model(
+        f"""
+        g (float[batch, seq, {K}] X) => (float[batch, seq, {Nq}] Y, float[2, batch, {num_heads}, seq, {Nv // num_heads}] present)
+        {{
+          Y, present = com.microsoft.Attention<num_heads=3, qkv_hidden_sizes=[{Nq},{Nk},{Nv}]>(X, W, B)
+        }}
+        """,
+        initializer=[_f32(w, "W"), _f32(b, "B")],
+        extra_opset=', "com.microsoft": 1',
+    )
+    pruned = onnxsim.prune_magnitude_cpp(model, sparsity=0.5)
+    np.testing.assert_array_equal(_weight(pruned), w)
+
+
+def test_cpp_magnitude_pruning_ignores_unrelated_domain_attention_op():
+    # A same-named "Attention" node in a DIFFERENT domain is not
+    # com.microsoft's -- must never match.
+    w, b, K, num_heads, Nq, Nk, Nv, total_n = _attention_qkv_weights()
+    model = _model(
+        f"""
+        g (float[batch, seq, {K}] X) => (float[batch, seq, {Nq}] Y)
+        {{
+          Y = custom.domain.Attention<num_heads={num_heads}, qkv_hidden_sizes=[{Nq},{Nk},{Nv}]>(X, W, B)
+        }}
+        """,
+        initializer=[_f32(w, "W"), _f32(b, "B")],
+        extra_opset=', "custom.domain": 1',
+    )
+    pruned = onnxsim.prune_magnitude_cpp(model, sparsity=0.5)
+    np.testing.assert_array_equal(_weight(pruned), w)

--- a/tests/test_pruning_cpp.py
+++ b/tests/test_pruning_cpp.py
@@ -353,8 +353,12 @@ def test_cpp_magnitude_pruning_global_sparsity_matches_frozen_python_golden():
     )
     pruned = onnxsim.prune_magnitude_cpp(model, sparsity=0.6, global_sparsity=True)
     onnx.checker.check_model(pruned)
-    assert _golden_weight_bytes(pruned, _GOLDEN_GLOBAL_SPARSITY_MIXED_MATMUL, node_index=0)
-    assert _golden_weight_bytes(pruned, _GOLDEN_GLOBAL_SPARSITY_MIXED_CONV, node_index=1)
+    assert _golden_weight_bytes(
+        pruned, _GOLDEN_GLOBAL_SPARSITY_MIXED_MATMUL, node_index=0
+    )
+    assert _golden_weight_bytes(
+        pruned, _GOLDEN_GLOBAL_SPARSITY_MIXED_CONV, node_index=1
+    )
 
 
 def test_cpp_magnitude_pruning_global_sparsity_pools_across_layers():
@@ -379,9 +383,9 @@ def test_cpp_magnitude_pruning_global_sparsity_pools_across_layers():
     w_small_pruned = _weight(pruned, node_index=0)
     w_large_pruned = _weight(pruned, node_index=1)
     total = w_small.size + w_large.size
-    assert np.count_nonzero(w_small_pruned) + np.count_nonzero(
-        w_large_pruned
-    ) == round(total * 0.5)
+    assert np.count_nonzero(w_small_pruned) + np.count_nonzero(w_large_pruned) == round(
+        total * 0.5
+    )
     # The small-magnitude layer absorbs (much) more of the pruning than the
     # large-magnitude one -- no per-layer floor, unlike the default mode.
     assert np.count_nonzero(w_small_pruned) < np.count_nonzero(w_large_pruned)
@@ -430,9 +434,9 @@ def test_cpp_magnitude_pruning_global_sparsity_subgraph_aware():
         raise AssertionError(branch_name)
 
     total = w_then.size + w_else.size
-    zeroed = np.count_nonzero(_sub_weight(pruned, "then_branch") == 0) + np.count_nonzero(
-        _sub_weight(pruned, "else_branch") == 0
-    )
+    zeroed = np.count_nonzero(
+        _sub_weight(pruned, "then_branch") == 0
+    ) + np.count_nonzero(_sub_weight(pruned, "else_branch") == 0)
     # Pooled across BOTH subgraphs combined -- not independently per branch.
     assert zeroed == round(total * 0.5)
 
@@ -504,7 +508,9 @@ def test_cpp_magnitude_pruning_float16_preserves_kept_bit_patterns():
     pruned = onnxsim.prune_magnitude_cpp(model, sparsity=0.5)
     w_pruned = _weight(pruned)
     kept = w_pruned != 0
-    np.testing.assert_array_equal(w_pruned[kept].view(np.uint16), w[kept].view(np.uint16))
+    np.testing.assert_array_equal(
+        w_pruned[kept].view(np.uint16), w[kept].view(np.uint16)
+    )
 
 
 # --- com.microsoft Attention-family merged-QKV-weight matching ------------

--- a/tests/test_quarot_cpp.py
+++ b/tests/test_quarot_cpp.py
@@ -15,6 +15,7 @@ import pytest
 from onnx import parser
 
 import onnxsim
+from onnxsim.omniquant import _quantize_blockwise_int4_with_clip
 
 ort = pytest.importorskip("onnxruntime")
 
@@ -161,3 +162,148 @@ def test_cpp_quarot_different_seeds_give_different_rotations():
     q1 = onnxsim.apply_quarot_cpp(model, seed=1)
     q2 = onnxsim.apply_quarot_cpp(model, seed=2)
     assert q1.SerializeToString() != q2.SerializeToString()
+
+
+def _unpack_int4(tensor):
+    # Signed low-nibble-first INT4 unpacking, matching
+    # TryQuantizeWeightBlockwiseInt4InPlace's / quarot.h's own packing.
+    raw = tensor.raw_data
+    numel = 1
+    for d in tensor.dims:
+        numel *= d
+    out = np.zeros(numel, dtype=np.int64)
+    for i in range(numel):
+        byte = raw[i // 2]
+        nibble = byte & 0xF if i % 2 == 0 else (byte >> 4) & 0xF
+        if nibble >= 8:
+            nibble -= 16
+        out[i] = nibble
+    return out.reshape(list(tensor.dims))
+
+
+@pytest.mark.parametrize("block_size", [16, 32, 64])
+def test_cpp_quarot_block_size_matches_python_quantization_math(block_size):
+    # Cross-checks the C++ port's block-quantization against
+    # onnxsim.omniquant's own `_quantize_blockwise_int4_with_clip` (the same
+    # routine quarot.py's own apply_quarot delegates to), applied to the
+    # *same* rotation matrix the C++ port produced -- this isolates the
+    # block_size threading and quantization math itself from the two
+    # ports' unrelated, independently-seeded RNGs (never a cross-language
+    # parity goal -- see this module's own docstring), and would catch an
+    # off-by-one or wrong-axis bug in how block_size is threaded through.
+    K, N = 128, 4
+    rng = np.random.default_rng(100 + block_size)
+    weight = (rng.standard_normal((K, N)) * 0.5).astype(np.float32)
+    model = _matmul_model(K=K, N=N, weight=weight)
+
+    q = onnxsim.apply_quarot_cpp(model, seed=7, block_size=block_size)
+    onnx.checker.check_model(q)
+
+    num_blocks = K // block_size
+    u = None
+    codes_t = None
+    scale_t = None
+    for t in q.graph.initializer:
+        if list(t.dims) == [K, K]:
+            u = onnx.numpy_helper.to_array(t).astype(np.float64)
+        elif t.data_type == onnx.TensorProto.INT4 and list(t.dims) == [K, N]:
+            codes_t = t
+        elif t.data_type == onnx.TensorProto.FLOAT and list(t.dims) == [num_blocks, N]:
+            scale_t = t
+    assert u is not None
+    assert codes_t is not None
+    assert scale_t is not None, f"expected a [{num_blocks}, {N}] scale initializer"
+
+    dequant_node = next(n for n in q.graph.node if n.op_type == "DequantizeLinear")
+    block_size_attr = next(
+        a.i for a in dequant_node.attribute if a.name == "block_size"
+    )
+    assert block_size_attr == block_size
+
+    codes_kn_cpp = _unpack_int4(codes_t)
+    scale_kn_cpp = onnx.numpy_helper.to_array(scale_t)
+
+    w_nk = weight.astype(np.float64).T  # [N, K]
+    w_tilde_nk = w_nk @ u
+    codes_nk_ref, scale_blocks_nk_ref = _quantize_blockwise_int4_with_clip(
+        w_tilde_nk, block_size, 1.0
+    )
+    codes_kn_ref = codes_nk_ref.T.astype(np.int64)
+    scale_kn_ref = scale_blocks_nk_ref.T.astype(np.float32)
+
+    np.testing.assert_array_equal(codes_kn_cpp, codes_kn_ref)
+    np.testing.assert_allclose(scale_kn_cpp, scale_kn_ref, rtol=1e-5, atol=1e-6)
+
+
+def test_cpp_quarot_declines_non_default_block_size_when_k_not_divisible():
+    model = _matmul_model(K=40, N=8, seed=11)  # 40 is not a multiple of 16
+    q = onnxsim.apply_quarot_cpp(model, seed=0, block_size=16)
+    assert q.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_quarot_epsilon_floors_all_zero_token_scale():
+    # An all-zero token drives max(|x_rotated|) to exactly 0 for that row;
+    # without an epsilon floor on the Clip feeding the scale computation,
+    # this would divide by zero. Both the default epsilon and a custom one
+    # must keep the graph finite and reconstruct the all-zero token as
+    # exactly zero (0 / any_nonzero_scale == 0).
+    model = _matmul_model(K=32, N=8, seed=12)
+    x = np.zeros((2, 32), dtype=np.float32)
+    x[1] = np.random.default_rng(13).standard_normal(32).astype(np.float32)
+
+    for epsilon in (1e-12, 1e-6, 1.0):
+        q = onnxsim.apply_quarot_cpp(model, seed=1, epsilon=epsilon)
+        onnx.checker.check_model(q)
+        sess = ort.InferenceSession(
+            q.SerializeToString(), providers=["CPUExecutionProvider"]
+        )
+        (y,) = sess.run(None, {"X": x})
+        assert np.all(np.isfinite(y))
+        assert np.allclose(y[0], 0.0)
+
+
+def test_cpp_quarot_epsilon_value_is_threaded_into_the_graph():
+    # The Clip node's min-bound initializer should carry exactly the
+    # requested epsilon (not the old hardcoded 1e-12), distinguishing it
+    # from this pass's other float scalar initializers (7.0, -7.0, 7.0).
+    model = _matmul_model(K=32, N=8, seed=14)
+    epsilon = 0.0625  # distinct from 7.0/-7.0 and from the default 1e-12
+    q = onnxsim.apply_quarot_cpp(model, seed=0, epsilon=epsilon)
+
+    scalar_values = [
+        onnx.numpy_helper.to_array(t).item()
+        for t in q.graph.initializer
+        if onnx.numpy_helper.to_array(t).size == 1
+    ]
+    assert any(np.isclose(v, epsilon) for v in scalar_values), scalar_values
+
+
+def test_cpp_quarot_huge_epsilon_measurably_changes_output():
+    # A large epsilon clamps every token's scale up to epsilon / 7,
+    # collapsing quantization resolution -- proving epsilon is actually
+    # wired into the Clip node's bound rather than silently ignored.
+    model = _matmul_model(K=32, N=8, seed=15)
+    rng = np.random.default_rng(16)
+    x = rng.standard_normal((4, 32)).astype(np.float32)
+
+    q_default = onnxsim.apply_quarot_cpp(model, seed=3, epsilon=1e-12)
+    q_huge = onnxsim.apply_quarot_cpp(model, seed=3, epsilon=10.0)
+
+    def run(m):
+        sess = ort.InferenceSession(
+            m.SerializeToString(), providers=["CPUExecutionProvider"]
+        )
+        return sess.run(None, {"X": x})[0]
+
+    y_default = run(q_default)
+    y_huge = run(q_huge)
+    assert np.all(np.isfinite(y_default)) and np.all(np.isfinite(y_huge))
+    assert not np.allclose(y_default, y_huge)
+
+
+def test_cpp_quarot_block_size_and_epsilon_defaults_match_python():
+    import inspect
+
+    sig = inspect.signature(onnxsim.apply_quarot_cpp)
+    assert sig.parameters["block_size"].default == 32
+    assert sig.parameters["epsilon"].default == 1e-12

--- a/tests/test_sparsegpt_pruning_cpp.py
+++ b/tests/test_sparsegpt_pruning_cpp.py
@@ -22,12 +22,18 @@ essentially at) floating-point precision, not merely a loose tolerance.
 
 Scope: this port matches plain ``MatMul``/vanilla-``Gemm`` (not
 ``com.microsoft::FusedGemm``/``GemmFastGelu``) and ``com.microsoft::
-Attention``'s merged QKV weight, FLOAT32 only (not also FLOAT16/BFLOAT16),
-and does NOT match ``Conv`` at all -- see ``structured_pruning_entry.h``'s
-own ``ApplySparseGptPruning`` declaration comment for the full scope
-decision and rationale. The Conv-declined and FLOAT16-declined tests below
-confirm those are handled by leaving the layer alone, not by crashing or by
-silently mishandling the tensor.
+Attention``'s merged QKV weight, FLOAT32/FLOAT16/BFLOAT16 (widened from an
+earlier FLOAT32-only scope -- see ``IsSupportedFloatDtype``/
+``ReadTensorAsF64``/``WriteF64TensorAs`` and, for the Attention QKV weight
+specifically, the SparseGPT-local ``MatchAttentionProducerAnyFloat``), and
+does NOT match ``Conv`` at all -- see ``structured_pruning_entry.h``'s own
+``ApplySparseGptPruning`` declaration comment for the full scope decision
+and rationale (Conv remains the one open gap, so
+``onnxsim.apply_sparsegpt_pruning`` itself is NOT aliased to this port). The
+Conv-declined test below confirms that gap is handled by leaving the layer
+alone, not by crashing or by silently mishandling the tensor; the
+FLOAT16/BFLOAT16 section further down confirms the newly-closed dtype gap
+matches the pure-Python reference exactly.
 """
 
 import numpy as np
@@ -379,11 +385,31 @@ def test_sparsegpt_pruning_cpp_conv_is_left_completely_untouched():
     np.testing.assert_array_equal(_weight(pruned), w)
 
 
-def test_sparsegpt_pruning_cpp_fp16_weight_is_left_completely_untouched():
-    # FLOAT16/BFLOAT16 weights are explicitly out of scope for this C++
-    # port (unlike the pure-Python original) -- confirm a FLOAT16 MatMul
-    # weight is declined (left byte-identical), not crashed on or
-    # incorrectly reinterpreted.
+# --- FLOAT16/BFLOAT16 weight matching ---------------------------------------
+#
+# FLOAT16/BFLOAT16 weights (both for the plain MatMul/vanilla-Gemm candidate
+# path and for com.microsoft::Attention's own merged QKV weight, via the
+# SparseGPT-local MatchAttentionProducerAnyFloat matcher) are IN scope for
+# this C++ port -- IsSupportedFloatDtype/ReadTensorAsF64/WriteF64TensorAs,
+# the same widening this file's own module docstring's "Scope" paragraph
+# above already documents. 2-D Conv remains the one open gap (see the
+# previous test).
+#
+# BFLOAT16 gets no analogous real-onnxruntime-execution test here: this
+# environment's onnxruntime has no CPU kernel for ANY op on a BFLOAT16
+# tensor at all (confirmed the same way test_pruning.py's own "BFLOAT16 has
+# no onnxruntime CPU execution support" section comment documents for the
+# pure-Python reference -- a plain BFLOAT16 MatMul model raises
+# NOT_IMPLEMENTED the moment a session is created), and this test file's own
+# module docstring requires a real onnxruntime-backed executor throughout
+# (never a fake/mock one) -- so a BFLOAT16 calibration run would fail on
+# this environment's onnxruntime limitation alone, before this port's own
+# widened matching/reading/writing code ever runs. There is accordingly no
+# environment in which this file could exercise BFLOAT16 end to end; FLOAT16
+# (which onnxruntime CAN execute) is tested below instead.
+
+
+def test_sparsegpt_pruning_cpp_fp16_matmul_matches_python_reference():
     K, N = 16, 4
     rng = np.random.default_rng(61)
     w = (rng.standard_normal((K, N)).astype(np.float32) * 0.5).astype(np.float16)
@@ -397,12 +423,69 @@ def test_sparsegpt_pruning_cpp_fp16_weight_is_left_completely_untouched():
         initializer=[onnx.numpy_helper.from_array(w, "W")],
     )
     rng2 = np.random.default_rng(161)
-    x_cal = rng2.standard_normal((16, K)).astype(np.float16)
-    pruned = onnxsim.apply_sparsegpt_pruning_cpp(
+    x_cal = rng2.standard_normal((32, K)).astype(np.float16)
+
+    expected = onnxsim.apply_sparsegpt_pruning(
         model, calibration_data=[{"X": x_cal}], sparsity=0.5
     )
-    onnx.checker.check_model(pruned)
-    np.testing.assert_array_equal(_weight(pruned), w)
+    actual = onnxsim.apply_sparsegpt_pruning_cpp(
+        model, calibration_data=[{"X": x_cal}], sparsity=0.5
+    )
+    onnx.checker.check_model(actual)
+    w_expected = _weight(expected)
+    w_actual = _weight(actual)
+    assert w_actual.dtype == np.float16
+    assert w_expected.dtype == np.float16
+    _assert_bytewise_close(w_actual, w_expected)
+    # Real recomputation happened, not a same-shape no-op.
+    assert not np.array_equal(w_actual, w)
+
+
+def test_sparsegpt_pruning_cpp_fp16_attention_merged_qkv_matches_python_reference():
+    # Exercises MatchAttentionProducerAnyFloat specifically -- the
+    # SparseGPT-local, dtype-widened duplicate of the shared (still
+    # FLOAT32-only) MatchAttentionProducer used elsewhere in this file.
+    hidden = 16
+    nq = nk = nv = 8
+    total_n = nq + nk + nv
+    num_heads = 2
+    rng = np.random.default_rng(62)
+    w_qkv = (rng.standard_normal((hidden, total_n)).astype(np.float32) * 0.3).astype(
+        np.float16
+    )
+    bias = (rng.standard_normal((total_n,)).astype(np.float32) * 0.05).astype(
+        np.float16
+    )
+    model = _model(
+        f"""
+        g (float16[batch,seq,{hidden}] X) => (float16[batch,seq,{nv}] Y)
+        {{
+          Y, present = com.microsoft.Attention <num_heads={num_heads}>(X, Wqkv, Bqkv)
+        }}
+        """,
+        initializer=[
+            onnx.numpy_helper.from_array(w_qkv, "Wqkv"),
+            onnx.numpy_helper.from_array(bias, "Bqkv"),
+        ],
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+    rng2 = np.random.default_rng(162)
+    x_cal = rng2.standard_normal((3, 5, hidden)).astype(np.float16)
+
+    expected = onnxsim.apply_sparsegpt_pruning(
+        model, calibration_data=[{"X": x_cal}], sparsity=0.5
+    )
+    actual = onnxsim.apply_sparsegpt_pruning_cpp(
+        model, calibration_data=[{"X": x_cal}], sparsity=0.5
+    )
+    onnx.checker.check_model(actual)
+    w_expected = _weight(expected)
+    w_actual = _weight(actual)
+    assert w_actual.dtype == np.float16
+    _assert_bytewise_close(w_actual, w_expected)
+    assert not np.array_equal(w_actual, w_qkv)
+    # Bias (never touched by SparseGPT) is untouched, dtype included.
+    np.testing.assert_array_equal(_weight(actual, index=1), bias)
 
 
 # --- End-to-end reconstruction quality --------------------------------------

--- a/tests/test_structured_pruning_cpp.py
+++ b/tests/test_structured_pruning_cpp.py
@@ -8779,3 +8779,188 @@ def test_cpp_dynamic_quantize_matmul_matches_python_reference():
     py_bytes = {t.name: t.SerializeToString() for t in pruned_py.graph.initializer}
     cpp_bytes = {t.name: t.SerializeToString() for t in pruned_cpp.graph.initializer}
     assert py_bytes == cpp_bytes
+
+
+# --- importance_norm ("l1" vs "l2") and global_sparsity ---------------------
+#
+# Adapted from test_pruning.py's own `test_structured_pruning_l1_norm_favors_
+# total_magnitude_single_producer` and `test_structured_pruning_global_
+# sparsity_redistributes_across_chains_and_matches_oracle`: adversarial
+# weight layouts/scales engineered so the new parameter provably changes
+# which channels survive, cross-checked byte-for-byte against the verified
+# pure-Python reference.
+
+
+def test_cpp_structured_pruning_importance_norm_l1_matches_python_reference_and_differs_from_l2():
+    # Column "concentrated": one entry of magnitude 8, rest zero -- L2 == L1
+    # == 8. Column "spread": all 16 entries == 1 -- L2 = 4, L1 = 16. L2 ranks
+    # "concentrated" above "spread"; L1 ranks "spread" above "concentrated" --
+    # a genuine disagreement a correct L1 port must reproduce, not merely
+    # score differently. "filler_high"/"filler_low" pin the other surviving
+    # slot under either norm.
+    K, H, Out = 16, 4, 3
+    w1 = np.zeros((K, H), dtype=np.float32)
+    w1[0, 0] = 8.0  # "concentrated"
+    w1[:, 1] = 1.0  # "spread"
+    w1[2, 2] = 1000.0  # "filler_high"
+    w1[3, 3] = 0.001  # "filler_low"
+    rng = np.random.default_rng(90)
+    w2 = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          h = MatMul(X, W1)
+          a = Relu(h)
+          Y = MatMul(a, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2")],
+    )
+    onnx.checker.check_model(model)
+
+    for norm in ("l2", "l1"):
+        pruned_cpp = onnxsim.apply_structured_pruning_cpp(
+            model, sparsity=0.5, importance_norm=norm
+        )
+        pruned_py = onnxsim.apply_structured_pruning(
+            model, sparsity=0.5, importance_norm=norm
+        )
+        onnx.checker.check_model(pruned_cpp)
+        assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    kept_l2 = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    kept_l1 = onnxsim.apply_structured_pruning_cpp(
+        model, sparsity=0.5, importance_norm="l1"
+    )
+    # "l2" keeps {concentrated, filler_high}, "l1" keeps {spread,
+    # filler_high} -- a real flip in which column survives, not just score.
+    assert kept_l2.SerializeToString() != kept_l1.SerializeToString()
+
+
+def _two_scale_mlp_model(K=8, H=16, Out=4, big_scale=50.0, small_scale=1.0, seed=0):
+    # Two independent, ordinary (single-producer, group=1) MLP chains
+    # sharing one input, at very different weight-magnitude scales -- the
+    # adversarial case `global_sparsity` exists for: the default per-chain
+    # mode cuts both to the same channel *count* regardless of scale, while
+    # `global_sparsity` redistributes toward the uniformly-smaller chain.
+    rng = np.random.default_rng(seed)
+    w1_big = (rng.standard_normal((K, H)) * big_scale).astype(np.float32)
+    w2_big = rng.standard_normal((H, Out)).astype(np.float32)
+    w1_small = (rng.standard_normal((K, H)) * small_scale).astype(np.float32)
+    w2_small = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Ybig, float[batch,{Out}] Ysmall)
+        {{
+          hbig = MatMul(X, W1big)
+          abig = Relu(hbig)
+          Ybig = MatMul(abig, W2big)
+          hsmall = MatMul(X, W1small)
+          asmall = Relu(hsmall)
+          Ysmall = MatMul(asmall, W2small)
+        }}
+        """,
+        initializer=[
+            _f32(w1_big, "W1big"),
+            _f32(w2_big, "W2big"),
+            _f32(w1_small, "W1small"),
+            _f32(w2_small, "W2small"),
+        ],
+    )
+    return model
+
+
+def test_cpp_structured_pruning_global_sparsity_matches_python_reference_and_redistributes():
+    K, H, Out = 8, 16, 4
+    sparsity = 0.5
+    model = _two_scale_mlp_model(
+        K=K, H=H, Out=Out, big_scale=50.0, small_scale=0.5, seed=7
+    )
+    onnx.checker.check_model(model)
+
+    local_cpp = onnxsim.apply_structured_pruning_cpp(model, sparsity=sparsity)
+    global_cpp = onnxsim.apply_structured_pruning_cpp(
+        model, sparsity=sparsity, global_sparsity=True
+    )
+    global_py = onnxsim.apply_structured_pruning(
+        model, sparsity=sparsity, global_sparsity=True
+    )
+    onnx.checker.check_model(global_cpp)
+    assert global_cpp.SerializeToString() == global_py.SerializeToString()
+
+    inits_local = {t.name: t for t in local_cpp.graph.initializer}
+    inits_global = {t.name: t for t in global_cpp.graph.initializer}
+
+    # Per-chain-uniform (default) mode: both chains cut to the same count.
+    assert inits_local["W1big"].dims[1] == H // 2
+    assert inits_local["W1small"].dims[1] == H // 2
+    # global_sparsity mode: the uniformly-larger chain keeps strictly more
+    # channels than the uniformly-smaller one -- provably different from the
+    # local, non-global default above.
+    big_kept = inits_global["W1big"].dims[1]
+    small_kept = inits_global["W1small"].dims[1]
+    assert big_kept > H // 2 > small_kept
+
+
+def test_cpp_structured_pruning_global_sparsity_and_importance_norm_l1_together_matches_python_reference():
+    # Both new parameters at once -- global_sparsity's pooled ranking must
+    # itself be computed with the requested importance_norm (see
+    # ApplyChainsGlobal's own `importance_norm` threading), not silently
+    # fall back to L2.
+    K, H, Out = 8, 16, 4
+    sparsity = 0.5
+    model = _two_scale_mlp_model(
+        K=K, H=H, Out=Out, big_scale=50.0, small_scale=0.5, seed=11
+    )
+    onnx.checker.check_model(model)
+
+    for norm in ("l2", "l1"):
+        pruned_cpp = onnxsim.apply_structured_pruning_cpp(
+            model, sparsity=sparsity, importance_norm=norm, global_sparsity=True
+        )
+        pruned_py = onnxsim.apply_structured_pruning(
+            model, sparsity=sparsity, importance_norm=norm, global_sparsity=True
+        )
+        onnx.checker.check_model(pruned_cpp)
+        assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+
+def test_cpp_structured_pruning_global_sparsity_leaves_gated_ffn_chain_untouched():
+    # A gated (SwiGLU) pair's two producers must agree on one shared `keep`
+    # set already -- ineligible for global_sparsity's own pooled ranking
+    # (see ChainIsGlobalSparsityEligible), so the whole chain is left
+    # completely untouched in this mode, exactly like any other topology
+    # this pass can't prove safe to pool.
+    h, inter, out_dim = 8, 6, 4
+    rng = np.random.default_rng(12)
+    w_gate = rng.standard_normal((h, inter)).astype(np.float32)
+    w_up = rng.standard_normal((h, inter)).astype(np.float32)
+    w_down = rng.standard_normal((inter, out_dim)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{h}] X) => (float[batch,{out_dim}] Y)
+        {{
+          gate = MatMul(X, Wgate)
+          act = Sigmoid(gate)
+          up = MatMul(X, Wup)
+          prod = Mul(act, up)
+          Y = MatMul(prod, Wdown)
+        }}
+        """,
+        initializer=[
+            _f32(w_gate, "Wgate"),
+            _f32(w_up, "Wup"),
+            _f32(w_down, "Wdown"),
+        ],
+    )
+    onnx.checker.check_model(model)
+
+    pruned_cpp = onnxsim.apply_structured_pruning_cpp(
+        model, sparsity=0.5, global_sparsity=True
+    )
+    pruned_py = onnxsim.apply_structured_pruning(
+        model, sparsity=0.5, global_sparsity=True
+    )
+    assert pruned_cpp.SerializeToString() == model.SerializeToString()
+    assert pruned_py.SerializeToString() == model.SerializeToString()

--- a/tests/test_structured_wanda_pruning_cpp.py
+++ b/tests/test_structured_wanda_pruning_cpp.py
@@ -16,6 +16,29 @@ chain families it also matches -- this Wanda port has no quantized-weight
 counterpart, mirroring the pure-Python ``onnxsim.apply_structured_wanda_pruning``
 exactly (see ``structured_pruning_entry.h``'s own ``ApplyStructuredWandaPruning``
 declaration comment).
+
+NOT an alias for the pure-Python ``onnxsim.apply_structured_wanda_pruning``,
+despite matching it exactly on every ordinary MatMul/Conv/gated/residual/
+Concat-branch/split-gated case this file's own tests below cover, plus
+``importance_norm``/``global_sparsity`` (see this file's own coverage of
+both): two confirmed, real scope gaps were found running the FULL
+``tests/test_pruning.py`` suite through this port (not merely this file's
+own hand-picked cases) --
+(1) this port's own ``FindConvChains``/``MatchConvProducer`` only ever
+matches a plain ``Conv`` node (``node.op_type() != "Conv"`` outright
+declines), never ``ConvTranspose``, while the pure-Python
+``_match_conv_producer``/``_match_conv_transpose_producer`` matches both;
+and
+(2) a ``Concat``-merged branch feeding a *grouped* Conv consumer, combined
+with a real calibrated (Wanda) activation norm, produces a different keep
+set than the pure-Python reference (``test_structured_wanda_pruning_conv_
+concat_admits_block_aligned_grouped_conv_consumer`` in ``test_pruning.py``
+fails against this port).
+Both are pre-existing, narrower-than-Python C++-port scope decisions (not
+introduced by this round's ``importance_norm``/``global_sparsity`` work),
+so ``onnxsim.apply_structured_wanda_pruning`` stays a genuine, separate
+pure-Python implementation rather than an alias -- see that function's own
+docstring for the same note.
 """
 
 import numpy as np
@@ -379,3 +402,112 @@ def test_structured_wanda_pruning_cpp_default_calibration_data_runs():
     inits = {t.name: t for t in pruned.graph.initializer}
     assert list(inits["W1"].dims) == [8, 8]
     assert list(inits["W2"].dims) == [8, 4]
+
+
+# --- importance_norm ("l1" vs "l2") and global_sparsity ---------------------
+#
+# Driven through the *empty-calibration-data* fallback path (see this file's
+# own module docstring/`test_structured_wanda_pruning_cpp_*` tests above for
+# the "no matching activation -> falls back to plain weight-only ranking"
+# behavior): isolates the *weight*-magnitude term's own L1-vs-L2 switch (and
+# global_sparsity's own pooled ranking) from the activation-norm term, while
+# still exercising the real Wanda entry point/binding end to end.
+
+
+def test_structured_wanda_pruning_cpp_importance_norm_l1_matches_python_reference_and_differs_from_l2():
+    # Same "concentrated" vs. "spread" adversarial column layout as
+    # test_structured_pruning_cpp.py's own importance_norm test.
+    K, H, Out = 16, 4, 3
+    w1 = np.zeros((K, H), dtype=np.float32)
+    w1[0, 0] = 8.0  # "concentrated"
+    w1[:, 1] = 1.0  # "spread"
+    w1[2, 2] = 1000.0  # "filler_high"
+    w1[3, 3] = 0.001  # "filler_low"
+    rng = np.random.default_rng(90)
+    w2 = rng.standard_normal((H, Out)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          h = MatMul(X, W1)
+          a = Relu(h)
+          Y = MatMul(a, W2)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2")],
+    )
+    onnx.checker.check_model(model)
+
+    for norm in ("l2", "l1"):
+        pruned_cpp = onnxsim.apply_structured_wanda_pruning_cpp(
+            model, calibration_data=[], sparsity=0.5, importance_norm=norm
+        )
+        pruned_py = onnxsim.apply_structured_wanda_pruning(
+            model, calibration_data=[], sparsity=0.5, importance_norm=norm
+        )
+        onnx.checker.check_model(pruned_cpp)
+        assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    kept_l2 = onnxsim.apply_structured_wanda_pruning_cpp(
+        model, calibration_data=[], sparsity=0.5
+    )
+    kept_l1 = onnxsim.apply_structured_wanda_pruning_cpp(
+        model, calibration_data=[], sparsity=0.5, importance_norm="l1"
+    )
+    assert kept_l2.SerializeToString() != kept_l1.SerializeToString()
+
+
+def _two_scale_mlp_model(K=8, H=16, Out=4, big_scale=50.0, small_scale=1.0, seed=0):
+    rng = np.random.default_rng(seed)
+    w1_big = (rng.standard_normal((K, H)) * big_scale).astype(np.float32)
+    w2_big = rng.standard_normal((H, Out)).astype(np.float32)
+    w1_small = (rng.standard_normal((K, H)) * small_scale).astype(np.float32)
+    w2_small = rng.standard_normal((H, Out)).astype(np.float32)
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Ybig, float[batch,{Out}] Ysmall)
+        {{
+          hbig = MatMul(X, W1big)
+          abig = Relu(hbig)
+          Ybig = MatMul(abig, W2big)
+          hsmall = MatMul(X, W1small)
+          asmall = Relu(hsmall)
+          Ysmall = MatMul(asmall, W2small)
+        }}
+        """,
+        initializer=[
+            _f32(w1_big, "W1big"),
+            _f32(w2_big, "W2big"),
+            _f32(w1_small, "W1small"),
+            _f32(w2_small, "W2small"),
+        ],
+    )
+
+
+def test_structured_wanda_pruning_cpp_global_sparsity_matches_python_reference_and_redistributes():
+    K, H, Out = 8, 16, 4
+    sparsity = 0.5
+    model = _two_scale_mlp_model(
+        K=K, H=H, Out=Out, big_scale=50.0, small_scale=0.5, seed=7
+    )
+    onnx.checker.check_model(model)
+
+    local_cpp = onnxsim.apply_structured_wanda_pruning_cpp(
+        model, calibration_data=[], sparsity=sparsity
+    )
+    global_cpp = onnxsim.apply_structured_wanda_pruning_cpp(
+        model, calibration_data=[], sparsity=sparsity, global_sparsity=True
+    )
+    global_py = onnxsim.apply_structured_wanda_pruning(
+        model, calibration_data=[], sparsity=sparsity, global_sparsity=True
+    )
+    onnx.checker.check_model(global_cpp)
+    assert global_cpp.SerializeToString() == global_py.SerializeToString()
+
+    inits_local = {t.name: t for t in local_cpp.graph.initializer}
+    inits_global = {t.name: t for t in global_cpp.graph.initializer}
+    assert inits_local["W1big"].dims[1] == H // 2
+    assert inits_local["W1small"].dims[1] == H // 2
+    big_kept = inits_global["W1big"].dims[1]
+    small_kept = inits_global["W1small"].dims[1]
+    assert big_kept > H // 2 > small_kept

--- a/tests/test_wanda_pruning_cpp.py
+++ b/tests/test_wanda_pruning_cpp.py
@@ -78,6 +78,21 @@ def _weight(model, index=0):
     return onnx.numpy_helper.to_array(model.graph.initializer[index])
 
 
+def _magnitude_weight(model, node_index=0, input_index=1):
+    # `onnxsim.apply_magnitude_pruning` is now a thin alias for the C++-backed
+    # `onnxsim.prune_magnitude_cpp`, which leaves the original initializer
+    # dangling and appends a new, anonymously-named one for the pruned
+    # weight (see `tests/test_pruning_cpp.py`'s own `_weight` helper) --
+    # unlike `_weight` above (position-based, still correct for
+    # `apply_wanda_pruning_cpp`'s own in-place-mutating pure-Python
+    # reference), a magnitude-pruning result must be resolved via the
+    # node's CURRENT weight input.
+    node = model.graph.node[node_index]
+    w_name = node.input[input_index]
+    init = next(t for t in model.graph.initializer if t.name == w_name)
+    return onnx.numpy_helper.to_array(init)
+
+
 def _assert_bytewise_close(actual, expected, rtol=1e-5, atol=1e-6):
     np.testing.assert_allclose(
         actual.astype(np.float64), expected.astype(np.float64), rtol=rtol, atol=atol
@@ -313,7 +328,7 @@ def test_wanda_pruning_cpp_no_calibration_batches_falls_back_to_plain_magnitude(
 
     pruned = onnxsim.apply_wanda_pruning_cpp(model, calibration_data=[], sparsity=0.5)
     magnitude_pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.5)
-    np.testing.assert_array_equal(_weight(pruned), _weight(magnitude_pruned))
+    np.testing.assert_array_equal(_weight(pruned), _magnitude_weight(magnitude_pruned))
     # Actually pruned, not a no-op.
     assert not np.array_equal(_weight(pruned), w)
 
@@ -388,7 +403,7 @@ def test_wanda_pruning_cpp_activation_weighting_differs_from_plain_magnitude():
     magnitude_pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.5)
 
     w_wanda = _weight(wanda_pruned)
-    w_magnitude = _weight(magnitude_pruned)
+    w_magnitude = _magnitude_weight(magnitude_pruned)
     assert not np.array_equal(w_wanda, w_magnitude)
     # Plain magnitude drops the whole salient_k row (its own tied-smallest
     # entries); Wanda keeps at least one of them thanks to the activation

--- a/tests/test_wanda_pruning_cpp.py
+++ b/tests/test_wanda_pruning_cpp.py
@@ -17,15 +17,20 @@ recomputed).
 
 Scope: this port matches plain ``MatMul``/vanilla-``Gemm`` (not
 ``com.microsoft::FusedGemm``/``GemmFastGelu``) and ``com.microsoft::
-Attention``'s merged QKV weight, FLOAT32 only (not also FLOAT16/BFLOAT16),
-and does NOT match ``Conv`` at all -- see ``structured_pruning_entry.h``'s
-own ``ApplyWandaPruning`` declaration comment for the full scope decision
-and rationale (mirroring ``ApplySparseGptPruning``'s own identical
-decision). The Conv-declined and FLOAT16-declined tests below confirm those
-are handled by leaving the layer alone, not by crashing or by silently
-mishandling the tensor.
+Attention``'s merged QKV weight, each with a constant 2-D (1-D merged bias,
+for Attention) FLOAT32/FLOAT16/BFLOAT16 weight -- TRUE parity with the
+pure-Python ``onnxsim.apply_wanda_pruning`` on this axis -- and does NOT
+match ``Conv`` at all -- see ``structured_pruning_entry.h``'s own
+``ApplyWandaPruning`` declaration comment for the full scope decision and
+rationale (mirroring ``ApplySparseGptPruning``'s own identical Conv
+decision). The Conv-declined test below confirms that gap is handled by
+leaving the layer alone, not by crashing or by silently mishandling the
+tensor; the FLOAT16/BFLOAT16 tests below confirm those dtypes are matched,
+pruned, and written back with their own exact original bit pattern
+preserved for every surviving entry -- not merely "not crashed on".
 """
 
+import ml_dtypes
 import numpy as np
 import onnx
 import onnx.checker
@@ -55,6 +60,14 @@ def _model(body, initializer=(), opset=21):
 
 def _f32(array, name):
     return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _f16(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float16), name)
+
+
+def _bf16(array, name):
+    return onnx.numpy_helper.from_array(array.astype(ml_dtypes.bfloat16), name)
 
 
 def _matmul_model(K=32, N=8, seed=0):
@@ -426,14 +439,20 @@ def test_wanda_pruning_cpp_conv_is_left_completely_untouched():
     np.testing.assert_array_equal(_weight(pruned), w)
 
 
-def test_wanda_pruning_cpp_fp16_weight_is_left_completely_untouched():
-    # FLOAT16/BFLOAT16 weights are explicitly out of scope for this C++
-    # port (unlike the pure-Python original) -- confirm a FLOAT16 MatMul
-    # weight is declined (left byte-identical), not crashed on or
-    # incorrectly reinterpreted.
+# --- FLOAT16/BFLOAT16 weight support: matches the pure-Python reference ----
+#
+# Unlike the Conv gap above, FLOAT16/BFLOAT16 is now TRUE parity with
+# pruning.py's own `apply_wanda_pruning` -- reads out upcast to float64 via
+# ReadTensorAsF64, importance/masking computed identically to the FLOAT32
+# path, written back down via WriteF64TensorAs, exactly mirroring
+# pruning.py's own `_to_f64`/`_from_f64` round trip (see
+# structured_pruning_entry.h's own ApplyWandaPruning declaration comment).
+
+
+def test_wanda_pruning_cpp_matmul_float16_matches_python_reference():
     K, N = 16, 4
     rng = np.random.default_rng(61)
-    w = (rng.standard_normal((K, N)).astype(np.float32) * 0.5).astype(np.float16)
+    w = (rng.standard_normal((K, N)) * 0.5).astype(np.float16)
     model = _model(
         f"""
         g (float16[batch,{K}] X) => (float16[batch,{N}] Y)
@@ -441,12 +460,108 @@ def test_wanda_pruning_cpp_fp16_weight_is_left_completely_untouched():
           Y = MatMul(X, W)
         }}
         """,
-        initializer=[onnx.numpy_helper.from_array(w, "W")],
+        initializer=[_f16(w, "W")],
     )
+    onnx.checker.check_model(model)
     rng2 = np.random.default_rng(161)
     x_cal = rng2.standard_normal((16, K)).astype(np.float16)
-    pruned = onnxsim.apply_wanda_pruning_cpp(
+
+    expected = onnxsim.apply_wanda_pruning(
         model, calibration_data=[{"X": x_cal}], sparsity=0.5
     )
-    onnx.checker.check_model(pruned)
-    np.testing.assert_array_equal(_weight(pruned), w)
+    actual = onnxsim.apply_wanda_pruning_cpp(
+        model, calibration_data=[{"X": x_cal}], sparsity=0.5
+    )
+    onnx.checker.check_model(actual)
+    assert actual.graph.initializer[0].data_type == onnx.TensorProto.FLOAT16
+    # Exact bit-pattern match against the Python reference (not
+    # assert_allclose): both round-trip through float64 and mask, never
+    # recompute, a surviving entry's own value.
+    np.testing.assert_array_equal(
+        _weight(actual).view(np.uint16), _weight(expected).view(np.uint16)
+    )
+    assert not np.array_equal(_weight(actual).view(np.uint16), w.view(np.uint16))
+    assert onnxsim.weight_sparsity(actual) == pytest.approx(0.5, abs=0.1)
+
+
+def test_wanda_pruning_cpp_matmul_bfloat16_matches_python_reference():
+    # onnxruntime has no BFLOAT16 CPU execution support in this environment
+    # (confirmed separately: a plain BFLOAT16 MatMul session raises
+    # NOT_IMPLEMENTED at session-creation time -- see this repo's own
+    # test_magnitude_pruning_bfloat16_preserves_dtype_and_matches_array_
+    # oracle for the same note) -- so calibration_data is deliberately `[]`
+    # (not merely omitted -- omitting it triggers random calibration data
+    # generation, still a real session) rather than a real batch: both
+    # apply_wanda_pruning and apply_wanda_pruning_cpp skip calling the
+    # executor entirely for zero calibration batches (see
+    # WandaCalibrationStats' own top comment) and fall back to plain
+    # per-layer magnitude importance, which is exactly what this test cross-
+    # checks -- the BFLOAT16 candidate-matching/read-upcast/write-downcast
+    # round trip, not the (here environment-unsupported) real activation
+    # capture.
+    K, N = 16, 4
+    rng = np.random.default_rng(62)
+    w = (rng.standard_normal((K, N)) * 0.5).astype(ml_dtypes.bfloat16)
+    model = _model(
+        f"""
+        g (bfloat16[batch,{K}] X) => (bfloat16[batch,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[_bf16(w, "W")],
+    )
+    onnx.checker.check_model(model)
+
+    expected = onnxsim.apply_wanda_pruning(model, calibration_data=[], sparsity=0.5)
+    actual = onnxsim.apply_wanda_pruning_cpp(model, calibration_data=[], sparsity=0.5)
+    onnx.checker.check_model(actual)
+    assert actual.graph.initializer[0].data_type == onnx.TensorProto.BFLOAT16
+    np.testing.assert_array_equal(
+        _weight(actual).view(np.uint16), _weight(expected).view(np.uint16)
+    )
+    assert not np.array_equal(_weight(actual).view(np.uint16), w.view(np.uint16))
+    assert onnxsim.weight_sparsity(actual) == pytest.approx(0.5, abs=0.1)
+
+
+def test_wanda_pruning_cpp_attention_merged_qkv_float16_matches_python_reference():
+    # FLOAT16 analogue of test_wanda_pruning_cpp_attention_merged_qkv_
+    # matches_python_reference -- exercises MatchAttentionProducerWideDtype
+    # (this pass' own local, dtype-widened copy of MatchAttentionProducer),
+    # not just the MatMul/Gemm candidate path.
+    hidden = 16
+    nq = nk = nv = 8
+    total_n = nq + nk + nv
+    num_heads = 2
+    rng = np.random.default_rng(63)
+    w_qkv = (rng.standard_normal((hidden, total_n)) * 0.3).astype(np.float16)
+    bias = (rng.standard_normal((total_n,)) * 0.05).astype(np.float16)
+    model = _model(
+        f"""
+        g (float16[batch,seq,{hidden}] X) => (float16[batch,seq,{nv}] Y)
+        {{
+          Y, present = com.microsoft.Attention <num_heads={num_heads}>(X, Wqkv, Bqkv)
+        }}
+        """,
+        initializer=[_f16(w_qkv, "Wqkv"), _f16(bias, "Bqkv")],
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+    onnx.checker.check_model(model)
+    rng2 = np.random.default_rng(163)
+    x_cal = rng2.standard_normal((3, 5, hidden)).astype(np.float16)
+
+    expected = onnxsim.apply_wanda_pruning(
+        model, calibration_data=[{"X": x_cal}], sparsity=0.5
+    )
+    actual = onnxsim.apply_wanda_pruning_cpp(
+        model, calibration_data=[{"X": x_cal}], sparsity=0.5
+    )
+    onnx.checker.check_model(actual)
+    assert actual.graph.initializer[0].data_type == onnx.TensorProto.FLOAT16
+    np.testing.assert_array_equal(
+        _weight(actual).view(np.uint16), _weight(expected).view(np.uint16)
+    )
+    assert not np.array_equal(_weight(actual).view(np.uint16), w_qkv.view(np.uint16))
+    # Bias is never touched by unstructured/N:M pruning -- byte-identical.
+    np.testing.assert_array_equal(_weight(actual, index=1), bias)
+    assert onnxsim.weight_sparsity(actual) == pytest.approx(0.5, abs=0.1)


### PR DESCRIPTION
## Summary

Fifteenth round, continuing the effort (started in #1071) to close scope gaps between onnxsim's pure-Python implementations and their C++ ports, retiring the Python code once true parity is verified. Six independent pieces of work, done in parallel, each verifying real parity against the actual C++ matching/computation code rather than trusting docstrings.

### Fully closed and aliased

- **`apply_magnitude_pruning`** — closed all 4 remaining gaps: N:M semi-structured pruning, `global_sparsity` (including subgraph-pooled), FLOAT16/BFLOAT16, and `com.microsoft` Attention-family matching (discovered the Python reference actually covers `Attention`, `DecoderMaskedSelfAttention`, *and* `PackedAttention` — matched all three, including DMSA's own `do_rotary`/`qkv_hidden_sizes`/constant-`past` decline rules). Now aliased to `prune_magnitude_cpp`.
- **`apply_embedding_vocab_pruning`/`apply_embedding_vocab_magnitude_pruning`** — closed the last remaining gap from round 14: `com.microsoft::GatherBlockQuantized` producer matching, both packing conventions (ONNX-native sub-byte `uint4`/`int4` and manually-packed `uint8`), each with its own default-`zero_points` formula, scales/zero_points sliced in lockstep, and a ranking-only dequantization helper. Both functions now aliased to their C++ ports — this closes out the *entire* embedding-vocab-pruning parity effort.

### Real, verified improvements — not yet aliased (genuine remaining gaps found)

- **`apply_wanda_pruning`** / **`apply_sparsegpt_pruning`** — both closed their FLOAT16/BFLOAT16 gap (reusing the FP16/BF16 conversion helpers this same round's MoE/QMoE work established). Both deliberately leave 2-D Conv unclosed: Wanda's Conv path needs a from-scratch im2col per-receptive-field-offset activation-norm engine this port has nowhere else; SparseGPT's needs a genuinely novel im2col cross-covariance Hessian that the original SparseGPT reference implementation's own `add_batch` never exercises for Conv at all (no correct reference to validate against). Both remain pure-Python pending that follow-up work.
- **`apply_quarot`** — added `block_size`/`epsilon` as real parameters (previously hardcoded), verified numerically against the Python reference's own block-quantization math. NOT aliased: investigation found the two ports use genuinely different random-orthogonal-matrix constructions (Python: QR decomposition with Haar-measure sign correction; C++: uncorrected Gram-Schmidt) — same seed produces different rotations and thus different quantized output. This is a real, pre-existing non-bit-parity gap, not something this round could safely paper over.
- **`apply_structured_pruning` / `apply_attention_head_pruning` / `apply_structured_wanda_pruning` / `apply_attention_head_wanda_pruning`** — added `importance_norm` (L1/L2) and `global_sparsity` where applicable, verified correct on every case tested. NOT aliased for any of the 4: closing these two parameters surfaced larger, pre-existing gaps — `apply_structured_pruning`'s C++ port also folds in several quantized-format passes the Python function never touches; `apply_attention_head_pruning`/`apply_attention_head_wanda_pruning`'s C++ ports only match 3 of the Python reference's 10 attention chain families (while additionally matching one MatMulNBits shape Python handles elsewhere); `apply_structured_wanda_pruning`'s C++ port doesn't match `ConvTranspose` and has a subtly different keep-set for one Concat+grouped-Conv case under real calibration. These are documented as separate, larger follow-up work.

## Testing

- `pip install --no-build-isolation -ve .`
- Full suite (vendor-backend-dependent modules excluded, matching this repo's own CI ignore list) — **2509 passed, 95 skipped**, no regressions
- Each piece of work added dedicated test coverage cross-checked against its pure-Python reference (see individual commits for details): N:M/global_sparsity/FP16-BF16/Attention-family cases for magnitude pruning; both `GatherBlockQuantized` packing conventions for embedding-vocab pruning; FP16/BF16 cases for Wanda/SparseGPT; `block_size`/`epsilon` numerical parity + rotation-difference documentation for QuaRot; L1-vs-L2 and `global_sparsity` adversarial cases for the 4 structured/attention-head functions
- `clang-format --dry-run --Werror` / `ruff format --check` / `ruff check` / `mypy` all clean

## Scope / follow-up

Remaining gaps for a future round: 2-D Conv support for Wanda/SparseGPT unstructured pruning (both genuinely novel, higher-risk algorithm work); QuaRot's rotation-construction non-bit-parity (would need either side changed to match the other, a real behavioral decision, not just more code); the wider attention chain-family gap for attention-head pruning (7 more chain families to port); `apply_structured_pruning`'s Python/C++ scope divergence around quantized formats; `ConvTranspose` support for structured Wanda pruning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4t6ntCm72RfFf64W9GYB1

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4t6ntCm72RfFf64W9GYB1)_