### PR TITLE
Add I-BERT's i-GELU: polynomial erf approximation for integer-only GELU

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -57,6 +57,7 @@ from onnxsim.gptq import apply_gptq
 from onnxsim.gptvq import quantize_weight_only_gptvq
 from onnxsim.hf_reconstruct import read_hf_config, reconstruct_hf_graph
 from onnxsim.hqq import quantize_weight_only_int4_hqq
+from onnxsim.ibert_gelu import apply_ibert_gelu
 from onnxsim.icquant import icquant_metadata_bits, quantize_weight_only_icquant
 from onnxsim.if4_quantization import quantize_weight_only_if4
 from onnxsim.kmeans_quantization import quantize_weight_only_kmeans
@@ -291,6 +292,7 @@ __all__ = [
     "quantize_weight_only_billm",
     "quantize_weight_only_pb_llm",
     "quantize_weight_only_int4_hqq",
+    "apply_ibert_gelu",
     "quantize_weight_only_icquant",
     "icquant_metadata_bits",
     "quantize_weight_only_kmeans",

--- a/onnxsim/ibert_gelu.py
+++ b/onnxsim/ibert_gelu.py
@@ -1,0 +1,211 @@
+"""I-BERT (Kim, Gholami, Yao, Mahoney, Keutzer, 2021, ICML 2021, "I-BERT:
+Integer-only BERT Quantization", https://arxiv.org/abs/2101.01321) -- the
+paper's own "i-GELU" piece. onnxsim ports the *algorithm* (the closed-form
+polynomial itself), not any framework's code, per the same rationale as
+:mod:`onnxsim.awq`/:mod:`onnxsim.gptq` (I-BERT's own reference
+implementation quantizes live PyTorch modules with no ONNX export path).
+
+Every other quantizer already in onnxsim targets the same kind of node:
+a MatMul/Gemm/Conv whose *weight* (and sometimes activation) gets
+quantized, while the *nonlinear* activation functions in between
+(``Erf``/``Gelu``, ``Softmax``, ``LayerNorm``) stay exactly as the float
+model computed them -- QDQ quantization (:func:`onnxsim.quantize_static`
+and friends) wraps a calibrated integer range *around* those nonlinear
+ops without changing what they compute internally. I-BERT's own
+contribution is different in kind: it replaces the nonlinear function's
+own *computation* with an integer-arithmetic-friendly polynomial
+approximation, so a genuinely integer-only accelerator (no floating-point
+unit at all) can evaluate it -- not just quantize its input/output like
+every other technique in this repo does.
+
+This module ports the paper's own **i-GELU** piece specifically: GELU is
+almost universally exported as ``0.5 * x * (1 + Erf(x / sqrt(2)))``
+(BERT/RoBERTa/GPT-family transformers' own standard decomposition, present
+as a plain ``Erf`` node in the exported graph), and ``Erf`` is the one
+piece of that formula with no polynomial-friendly closed form. The paper's
+own idea: fit a second-order polynomial to ``erf`` of the shape
+
+    L(x) = sign(x) * (a * (clip(|x|, max=-b) + b)**2 + c)
+
+(clipped so the polynomial only has to fit the region where ``erf`` is not
+already saturated at +-1), and substitute ``L(x)`` for ``Erf(x)``
+everywhere. Two of the three coefficients are fixed by ``L``'s own
+boundary behavior, not free: continuity at ``x = 0`` (where ``sign``
+itself jumps from -1 to +1) forces ``c = -a * b**2``, and matching
+``erf``'s own asymptote of +-1 past the clip point forces ``c = 1`` --
+together pinning ``a = -1 / b**2`` for *any* choice of ``b``. This module
+fits the one remaining free parameter, ``b``, by a numeric min-max search
+minimizing ``L``'s worst-case absolute error against the true ``erf`` over
+``[-4, 4]`` (``b ~= -1.691``, ``a ~= -0.3495``, max error ~= 0.021) --
+this repo's own from-scratch numeric fit of the paper's *functional form*
+(the same "port the algorithm's shape, verify the actual behavior rather
+than trust an unverifiable literature constant" practice this project has
+followed since its own MSE-calibration threshold and BWA-PTQ EM search),
+not a transcription of the paper's own reported coefficients, which this
+module does not claim to reproduce exactly. Because every operation in
+``L(x)`` (``Abs``, ``Clip``, ``Add``, ``Mul``, ``Sign``) is itself already
+piecewise-linear or low-order-polynomial, this is the piece an
+integer-only accelerator can evaluate with fixed-point arithmetic instead
+of a hardware ``erf``/transcendental unit -- the paper's own point.
+
+**Deliberately not ported**: I-BERT's other two pieces, integer-only
+Softmax (a polynomial approximation of ``exp`` plus an integer-only
+iterative reciprocal for the normalization) and integer-only LayerNorm
+(an integer-only iterative reciprocal square root) -- both need an
+iterative fixed-point division/rsqrt loop with a paper-specified iteration
+count, materially more involved than i-GELU's own single closed-form
+polynomial, and are left as a follow-up rather than risked here without
+the same level of confidence in the exact reproduced constants.
+
+This module represents ``L(x)`` using ordinary float32 ONNX ops (the same
+simplification :mod:`onnxsim.mx_quantization`/:mod:`onnxsim.nf4` already
+make for their own packed-bit formats): the *polynomial shape* the paper
+introduces is reproduced exactly, but the actual fixed-point/dyadic
+integer arithmetic a real integer-only accelerator would use to evaluate
+it is not -- onnxsim has no lower-than-float32 arithmetic ONNX op to
+express that reproduction in anyway (the same reason
+:func:`onnxsim.quantize_static`'s own QDQ nodes still compute in float32
+between a `QuantizeLinear`/`DequantizeLinear` pair).
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional, Union
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+
+from onnxsim.bias_correction import _all_names, _unique_name
+
+# This module's own numeric min-max fit of the paper's L(x) functional
+# form (see the module docstring): `b` is the one free parameter (found by
+# grid search minimizing max|L(x) - erf(x)| over [-4, 4]); `a` and `c` are
+# then pinned by L(x)'s own continuity-at-0 and asymptote-at-+-1
+# constraints (c = 1, a = -1/b**2) -- not independently fit.
+_IBERT_GELU_B = -1.69148
+_IBERT_GELU_A = -1.0 / (_IBERT_GELU_B**2)
+_IBERT_GELU_C = 1.0
+
+
+def apply_ibert_gelu(
+    model: Union[str, onnx.ModelProto],
+    skip_names: Optional[Iterable[str]] = None,
+) -> onnx.ModelProto:
+    """Replaces every standalone ``Erf`` node (the ``erf`` in GELU's
+    standard ``0.5 * x * (1 + Erf(x / sqrt(2)))`` export decomposition,
+    among any other use) with I-BERT's own closed-form polynomial
+    approximation -- see this module's own docstring for the technique and
+    its derivation. Needs no calibration data: the polynomial's own
+    coefficients are fixed by the paper, not fit to any particular
+    model's data.
+
+    :param model: the original (unquantized) onnx ModelProto or file path
+    :param skip_names: ``Erf`` node names to leave untouched even if
+            otherwise eligible
+    :returns: ``model`` with every matched ``Erf(x)`` node's output fed by
+            ``Mul(Sign(x), Add(Mul(a, Mul(t, t)), c))`` where
+            ``t = Add(Clip(Abs(x), 0, -b), b)`` -- ordinary ONNX ops only
+            (``Abs``/``Clip``/``Add``/``Mul``/``Sign``), opset 11+ (the
+            2-input/3-input ``Clip`` form). ``Erf`` nodes named in
+            ``skip_names`` are left untouched.
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    skip_names = set(skip_names) if skip_names is not None else frozenset()
+
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    graph = out.graph
+    taken_names = _all_names(graph)
+
+    nodes = list(graph.node)
+    for node in nodes:
+        if node.op_type != "Erf" or len(node.input) != 1:
+            continue
+        if node.name in skip_names:
+            continue
+
+        x_name = node.input[0]
+        erf_out = node.output[0]
+        prefix = _unique_name(f"{erf_out}_ibert_gelu", taken_names)
+
+        abs_out = _unique_name(f"{prefix}_abs", taken_names)
+        abs_node = onnx.helper.make_node("Abs", [x_name], [abs_out])
+
+        clip_min_name = _unique_name(f"{prefix}_clip_min", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(
+                np.asarray(0.0, dtype=np.float32), name=clip_min_name
+            )
+        )
+        clip_max_name = _unique_name(f"{prefix}_clip_max", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(
+                np.asarray(-_IBERT_GELU_B, dtype=np.float32), name=clip_max_name
+            )
+        )
+        clip_out = _unique_name(f"{prefix}_clip", taken_names)
+        clip_node = onnx.helper.make_node(
+            "Clip", [abs_out, clip_min_name, clip_max_name], [clip_out]
+        )
+
+        b_name = _unique_name(f"{prefix}_b", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(
+                np.asarray(_IBERT_GELU_B, dtype=np.float32), name=b_name
+            )
+        )
+        shifted_out = _unique_name(f"{prefix}_shifted", taken_names)
+        add_b_node = onnx.helper.make_node("Add", [clip_out, b_name], [shifted_out])
+
+        squared_out = _unique_name(f"{prefix}_squared", taken_names)
+        square_node = onnx.helper.make_node(
+            "Mul", [shifted_out, shifted_out], [squared_out]
+        )
+
+        a_name = _unique_name(f"{prefix}_a", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(
+                np.asarray(_IBERT_GELU_A, dtype=np.float32), name=a_name
+            )
+        )
+        scaled_out = _unique_name(f"{prefix}_scaled", taken_names)
+        scale_node = onnx.helper.make_node("Mul", [squared_out, a_name], [scaled_out])
+
+        c_name = _unique_name(f"{prefix}_c", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(
+                np.asarray(_IBERT_GELU_C, dtype=np.float32), name=c_name
+            )
+        )
+        poly_out = _unique_name(f"{prefix}_poly", taken_names)
+        add_c_node = onnx.helper.make_node("Add", [scaled_out, c_name], [poly_out])
+
+        sign_out = _unique_name(f"{prefix}_sign", taken_names)
+        sign_node = onnx.helper.make_node("Sign", [x_name], [sign_out])
+
+        result_node = onnx.helper.make_node(
+            "Mul",
+            [sign_out, poly_out],
+            [erf_out],
+            name=_unique_name(f"{prefix}_result", taken_names),
+        )
+
+        insertion_point = next(i for i, n in enumerate(graph.node) if n is node)
+        for new_node in (
+            abs_node,
+            clip_node,
+            add_b_node,
+            square_node,
+            scale_node,
+            add_c_node,
+            sign_node,
+            result_node,
+        ):
+            graph.node.insert(insertion_point, new_node)
+            insertion_point += 1
+        graph.node.remove(node)
+
+    return out

--- a/tests/test_ibert_gelu.py
+++ b/tests/test_ibert_gelu.py
@@ -1,0 +1,148 @@
+"""Tests for ``onnxsim.apply_ibert_gelu`` (I-BERT's own "i-GELU", see
+``onnxsim/ibert_gelu.py``) -- replaces every standalone ``Erf`` node with
+the paper's closed-form second-order polynomial approximation
+(``sign(x) * (a*(clip(|x|, max=-b)+b)**2 + c)``), the piece of GELU's
+standard ``0.5*x*(1+Erf(x/sqrt(2)))`` export decomposition an
+integer-only accelerator can't evaluate directly.
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(body, initializer=(), opset=13, ir_version=8):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _erf_model():
+    return _model(
+        """
+        g (float[N] X) => (float[N] Y)
+        {
+          Y = Erf(X)
+        }
+        """
+    )
+
+
+def _gelu_decomposed_model():
+    # The standard export decomposition: 0.5 * x * (1 + erf(x / sqrt(2))).
+    return _model(
+        """
+        g (float[N] X) => (float[N] Y)
+        {
+          Sqrt2 = Constant<value = float[1] {1.4142135}>()
+          Half = Constant<value = float[1] {0.5}>()
+          One = Constant<value = float[1] {1.0}>()
+          Scaled = Div(X, Sqrt2)
+          Erfed = Erf(Scaled)
+          Shifted = Add(Erfed, One)
+          Weighted = Mul(X, Shifted)
+          Y = Mul(Weighted, Half)
+        }
+        """
+    )
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def test_ibert_gelu_replaces_erf_node():
+    model = _erf_model()
+    q = onnxsim.apply_ibert_gelu(model)
+    onnx.checker.check_model(q)
+    assert not any(n.op_type == "Erf" for n in q.graph.node)
+    assert any(n.op_type == "Sign" for n in q.graph.node)
+
+
+def test_ibert_gelu_polynomial_approximates_real_erf_closely():
+    model = _erf_model()
+    q = onnxsim.apply_ibert_gelu(model)
+
+    x = np.linspace(-4.0, 4.0, 401).astype(np.float32)
+    (float_out,) = _run(model, {"X": x})
+    (approx_out,) = _run(q, {"X": x})
+
+    # This module's own numeric min-max fit achieves ~0.021 worst-case
+    # absolute error against real erf over this exact range (verified
+    # directly against math.erf) -- allow a little headroom for float32
+    # rounding in the ONNX graph vs. the fit's own float64 computation.
+    assert np.max(np.abs(float_out - approx_out)) < 0.025
+
+
+def test_ibert_gelu_exact_at_zero_and_saturates_at_extremes():
+    model = _erf_model()
+    q = onnxsim.apply_ibert_gelu(model)
+
+    x = np.array([0.0, 5.0, -5.0], dtype=np.float32)
+    (approx_out,) = _run(q, {"X": x})
+    assert approx_out[0] == pytest.approx(0.0, abs=1e-6)
+    # Far from zero the polynomial saturates at +-1, matching erf's own
+    # asymptotic behavior (a*(-b+b)**2 + c == c == 1.0).
+    assert approx_out[1] == pytest.approx(1.0, abs=1e-6)
+    assert approx_out[2] == pytest.approx(-1.0, abs=1e-6)
+
+
+def test_ibert_gelu_end_to_end_on_decomposed_gelu():
+    model = _gelu_decomposed_model()
+    q = onnxsim.apply_ibert_gelu(model)
+    onnx.checker.check_model(q)
+    assert not any(n.op_type == "Erf" for n in q.graph.node)
+
+    x = np.linspace(-3.0, 3.0, 61).astype(np.float32)
+    (float_out,) = _run(model, {"X": x})
+    (approx_out,) = _run(q, {"X": x})
+
+    # GELU(x) = 0.5*x*(1+erf(x/sqrt2)); erf's own approximation error
+    # scales by 0.5*|x|, so allow a correspondingly larger absolute bound.
+    assert np.max(np.abs(float_out - approx_out)) < 0.5 * 3.0 * 0.025 + 1e-3
+
+    # Sanity: GELU is (approximately) monotonic and passes through the
+    # origin the same way the exact function does.
+    zero_idx = len(x) // 2
+    assert x[zero_idx] == pytest.approx(0.0, abs=1e-6)
+    assert approx_out[zero_idx] == pytest.approx(0.0, abs=1e-5)
+
+
+def test_ibert_gelu_skip_names_leaves_matched_node_untouched():
+    model = _erf_model()
+    erf_name = "my_erf_node"
+    for n in model.graph.node:
+        if n.op_type == "Erf":
+            n.name = erf_name
+    q = onnxsim.apply_ibert_gelu(model, skip_names={erf_name})
+    assert q.SerializeToString() == model.SerializeToString()
+
+
+def test_ibert_gelu_noop_when_no_erf_present():
+    model = _model(
+        """
+        g (float[4] X) => (float[4] Y)
+        {
+          Y = Relu(X)
+        }
+        """
+    )
+    q = onnxsim.apply_ibert_gelu(model)
+    assert q.SerializeToString() == model.SerializeToString()


### PR DESCRIPTION
## Summary

- Adds `onnxsim.apply_ibert_gelu`, porting the "i-GELU" piece of I-BERT (Kim, Gholami, Yao, Mahoney, Keutzer, 2021, ICML 2021, "I-BERT: Integer-only BERT Quantization", https://arxiv.org/abs/2101.01321).
- **Genuinely new kind of contribution for this repo**: every existing onnxsim quantizer targets a MatMul/Gemm/Conv's weight/activation, quantizing *around* the nonlinear ops (`Erf`/`Softmax`/`LayerNorm`) without changing what they compute. I-BERT does the opposite for GELU: it replaces `Erf`'s own computation with a continuous, saturating second-order polynomial an integer-only accelerator (no FPU) can evaluate.
- GELU is almost universally exported as `0.5 * x * (1 + Erf(x / sqrt(2)))`; this module replaces every standalone `Erf` node with `sign(x) * (a*(clip(|x|,max=-b)+b)^2 + c)`.

## Empirically confirmed facts

- My first attempt used specific literature-recalled coefficients (`a=-0.2888, b=-1.769, c=1.0`) -- verified against `math.erf` directly and found a **discontinuity at x=0** (a ~0.19 jump), since those constants don't satisfy the polynomial's own continuity constraint. Rather than ship possibly-misremembered constants, I derived the correct relationship: continuity at `x=0` forces `c = -a*b^2`, and matching `erf`'s own asymptote of ±1 forces `c=1`, together pinning `a = -1/b^2` for any `b`. I then numerically min-max-fit the one remaining free parameter (`b ≈ -1.69148`, giving `a ≈ -0.3495`) against real `erf` over `[-4,4]`, verified directly against `math.erf`: **~0.021 worst-case absolute error**, continuous everywhere, exact at the asymptotes by construction.

## What's added / scope

- `onnxsim/ibert_gelu.py`: `apply_ibert_gelu(model, skip_names=None)`. Needs no calibration data -- the polynomial's coefficients are fixed by construction, not fit to any model's data.
- Deliberately not ported: I-BERT's other two pieces, integer-only Softmax (polynomial `exp` + integer-only iterative reciprocal) and integer-only LayerNorm (integer-only iterative rsqrt) -- both need a materially more involved iterative fixed-point loop; documented as a follow-up in the module's own docstring rather than risked without the same verification confidence.
- `onnxsim/__init__.py`: registers `apply_ibert_gelu` (import + `__all__`).
- `tests/test_ibert_gelu.py`: verifies the polynomial replaces `Erf` correctly, matches real `erf` closely (checked against onnxruntime's own `Erf` op, not just my own numpy reference), is exact at `x=0` and at the saturating extremes, works end-to-end on the standard decomposed-GELU export shape, plus skip/no-op coverage -- built with `onnx.parser.parse_model`, per repo convention.

## Test plan

- [x] `pytest tests/test_ibert_gelu.py -v` -- 6/6 passed
- [x] `ruff check` / `ruff format --check` -- clean
- [x] `mypy onnxsim/ibert_gelu.py` -- no new errors
- Pure Python change -- no C++ extension rebuild needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxBPwkiTv7m32wAZtAubyc

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxBPwkiTv7m32wAZtAubyc)_