### PR TITLE
Add LayerNorm/RMSNorm pass-through to DynamicQuantizeMatMul and MatMulNBits chain walkers

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -17178,7 +17178,7 @@ def _slice_matmul_nbits_chain_consumer(
 @dataclass(frozen=True)
 class _MatMulNBitsChain:
     producer: _MatMulNBitsChainSide
-    chain_ops: Tuple[onnx.NodeProto, ...]
+    chain_ops: Tuple[Tuple[onnx.NodeProto, Optional[str]], ...]
     consumer: _MatMulNBitsChainSide
     n_channels: int
 
@@ -17204,7 +17204,7 @@ class _MatMulNBitsGatedChain:
     producer_a_pre_ops: Tuple[onnx.NodeProto, ...]
     producer_b: _MatMulNBitsChainSide
     producer_b_pre_ops: Tuple[onnx.NodeProto, ...]
-    chain_ops: Tuple[onnx.NodeProto, ...]
+    chain_ops: Tuple[Tuple[onnx.NodeProto, Optional[str]], ...]
     consumer: _MatMulNBitsChainSide
     n_channels: int
 
@@ -17216,25 +17216,75 @@ def _walk_to_matmul_nbits_consumer(
     graph_outputs: Set[str],
     n_channels: int,
     max_hops: int,
-) -> Optional[Tuple[_MatMulNBitsChainSide, Tuple[onnx.NodeProto, ...]]]:
+    value_info_by_name: Optional[Dict[str, onnx.ValueInfoProto]] = None,
+) -> Optional[
+    Tuple[_MatMulNBitsChainSide, Tuple[Tuple[onnx.NodeProto, Optional[str]], ...]]
+]:
     """From tensor `start` (a ``MatMulNBits`` OR plain-float MatMul/Gemm
     producer's own output), walks forward through shape-preserving unary
-    activations (`_UNARY_PASS_THROUGH`) with no other consumer anywhere
-    along the way, until EITHER a ``MatMulNBits`` consumer OR a plain-float
-    MatMul/vanilla-Gemm consumer (:func:`_match_plain_matmul_nbits_peer`)
-    is found whose input-channel count matches `n_channels` -- the
-    ``MatMulNBits``/plain-float union this section's own top comment
-    describes, the analogue of :func:`_walk_to_consumer_qdq`'s own float/
-    QDQ union but restricted to ``MatMulNBits``/plain-float (never QDQ).
-    No gated pair, no branch. Returns ``None`` if the walk runs out of
-    hops, hits a branch, or never reaches such a consumer. The caller
+    activations (`_UNARY_PASS_THROUGH`), a plain `_NORM_PASS_THROUGH_OPS`
+    node whose own `axis` normalizes exactly `cur`'s last axis (see that
+    constant's own comment, :func:`_norm_axis_is_last`, and
+    :func:`_norm_pass_through_const_names` -- mirrors
+    :func:`_walk_to_consumer`'s own identical single-node norm hop), or
+    either of the two *decomposed*, not-yet-fused norm sequences a raw
+    export emits instead of a fused `_NORM_PASS_THROUGH_OPS` node
+    (:func:`_match_decomposed_layer_norm_pass_through`/
+    :func:`_match_decomposed_rms_norm_pass_through`, reused verbatim, the
+    identical two matchers :func:`_walk_to_consumer` tries) -- with no other
+    consumer anywhere along the way, until EITHER a ``MatMulNBits`` consumer
+    OR a plain-float MatMul/vanilla-Gemm consumer
+    (:func:`_match_plain_matmul_nbits_peer`) is found whose input-channel
+    count matches `n_channels` -- the ``MatMulNBits``/plain-float union this
+    section's own top comment describes, the analogue of
+    :func:`_walk_to_consumer_qdq`'s own float/QDQ union but restricted to
+    ``MatMulNBits``/plain-float (never QDQ). No gated pair (self-gated
+    activation/tanh-GELU), no branch, no ``PRelu``/``Clip``/fused-bias-GELU
+    hop -- unlike :func:`_walk_to_consumer`, only the norm hop above is
+    added here. Returns ``None`` if the walk runs out of hops, hits a
+    branch, or never reaches such a consumer. The caller
     (:func:`_find_matmul_nbits_chains`) is responsible for discarding a
     plain-float-to-plain-float result -- that pairing is
     :func:`apply_structured_pruning`'s own job, not duplicated here.
+
+    `value_info_by_name`, when given, lets a positive-`axis`
+    `_NORM_PASS_THROUGH_OPS` hop confirm that axis against the tensor's own
+    known rank (:func:`_norm_axis_is_last`), mirroring
+    :func:`_walk_to_consumer`'s own identical parameter. Left ``None``, only
+    the unambiguous ``axis == -1`` case of that hop is still recognized.
     """
-    chain_ops: List[onnx.NodeProto] = []
+    chain_ops: List[Tuple[onnx.NodeProto, Optional[str]]] = []
     cur = start
     for _hop in range(max_hops):
+        # Tried before the ordinary "exactly one consumer" dispatch below,
+        # since a decomposed LayerNorm/RMSNorm's own root tensor is read
+        # *twice* -- see :func:`_walk_to_consumer`'s own identical hop-0
+        # dispatch for why. Declines instantly (returns ``None`` from both
+        # matchers) whenever `cur` doesn't have exactly two consumers, so
+        # this costs an ordinary hop nothing.
+        ln_match = _match_decomposed_layer_norm_pass_through(
+            cur,
+            consumers_of,
+            initializer_map,
+            graph_outputs,
+            n_channels,
+            value_info_by_name,
+        )
+        if ln_match is None:
+            ln_match = _match_decomposed_rms_norm_pass_through(
+                cur,
+                consumers_of,
+                initializer_map,
+                graph_outputs,
+                n_channels,
+                value_info_by_name,
+            )
+        if ln_match is not None:
+            ln_out_name, ln_chain_ops = ln_match
+            chain_ops.extend(ln_chain_ops)
+            cur = ln_out_name
+            continue
+
         candidates = consumers_of.get(cur, [])
         if len(candidates) != 1:
             return None
@@ -17253,27 +17303,98 @@ def _walk_to_matmul_nbits_consumer(
                 return None
             return peer, tuple(chain_ops)
 
-        if not (
+        const_name: Optional[str] = None
+        extra_const_name: Optional[str] = None
+        if (
             nxt.op_type in _UNARY_PASS_THROUGH
             and list(nxt.input) == [cur]
             and len(nxt.output) == 1
         ):
+            pass
+        elif nxt.op_type in _NORM_PASS_THROUGH_OPS and nxt.domain == "":
+            if not nxt.input or nxt.input[0] != cur:
+                return None
+            if not _norm_axis_is_last(nxt, cur, value_info_by_name):
+                return None
+            names = _norm_pass_through_const_names(nxt, initializer_map)
+            if names is None:
+                return None
+            scale_name, bias_name = names
+            if initializer_map[scale_name].dims[-1] != n_channels:
+                return None
+            if (
+                bias_name is not None
+                and initializer_map[bias_name].dims[-1] != n_channels
+            ):
+                return None
+            # Training-only secondary outputs -- see
+            # :func:`_walk_to_consumer`'s own identical check on this same
+            # hop for why a consumed one is declined here.
+            if any(
+                nxt.output[i]
+                and (consumers_of.get(nxt.output[i]) or nxt.output[i] in graph_outputs)
+                for i in range(1, len(nxt.output))
+            ):
+                return None
+            const_name = scale_name
+            extra_const_name = bias_name
+        else:
             return None
+
         out2 = nxt.output[0]
-        if len(consumers_of.get(out2, [])) != 1 or out2 in graph_outputs:
+        if out2 in graph_outputs:
             return None
-        chain_ops.append(nxt)
-        cur = out2
+        # See :func:`_walk_to_consumer`'s own identical re-check: `out2`
+        # might itself be a decomposed LayerNorm/RMSNorm sequence's own root
+        # (read twice), which the ordinary single-consumer bar below would
+        # otherwise reject before the top-of-loop dispatch ever sees it.
+        ln_match = None
+        if len(consumers_of.get(out2, [])) != 1:
+            ln_match = _match_decomposed_layer_norm_pass_through(
+                out2,
+                consumers_of,
+                initializer_map,
+                graph_outputs,
+                n_channels,
+                value_info_by_name,
+            )
+            if ln_match is None:
+                ln_match = _match_decomposed_rms_norm_pass_through(
+                    out2,
+                    consumers_of,
+                    initializer_map,
+                    graph_outputs,
+                    n_channels,
+                    value_info_by_name,
+                )
+            if ln_match is None:
+                return None
+        chain_ops.append((nxt, const_name))
+        if extra_const_name is not None:
+            chain_ops.append((nxt, extra_const_name))
+        if ln_match is not None:
+            ln_out_name, ln_chain_ops = ln_match
+            chain_ops.extend(ln_chain_ops)
+            cur = ln_out_name
+        else:
+            cur = out2
     return None
 
 
-def _find_matmul_nbits_chains(graph: onnx.GraphProto) -> List[_MatMulNBitsChain]:
+def _find_matmul_nbits_chains(
+    graph: onnx.GraphProto,
+    value_info_by_name: Optional[Dict[str, onnx.ValueInfoProto]] = None,
+) -> List[_MatMulNBitsChain]:
     """The ``MatMulNBits`` analogue of :func:`_find_qdq_chains`: every
     producer/consumer pair connected by :func:`_walk_to_matmul_nbits_consumer`
     where AT LEAST ONE side is a ``MatMulNBits`` node (a plain-float-to-
     plain-float pair is :func:`apply_structured_pruning`'s own job, not
     duplicated here -- mirrors :func:`_find_qdq_chains`'s identical
     at-least-one-quantized filter).
+
+    `value_info_by_name`, when given, is threaded straight through to
+    :func:`_walk_to_matmul_nbits_consumer` -- see its own identical
+    parameter.
     """
     initializer_map = _constant_map(graph)
     consumers_of = _consumers_of(graph)
@@ -17307,6 +17428,7 @@ def _find_matmul_nbits_chains(graph: onnx.GraphProto) -> List[_MatMulNBitsChain]
             graph_outputs,
             n_channels,
             _MAX_CHAIN_HOPS,
+            value_info_by_name,
         )
         if found is None:
             continue
@@ -17382,6 +17504,7 @@ def _matmul_nbits_gated_channel_importance(
 
 def _find_matmul_nbits_gated_chains(
     graph: onnx.GraphProto,
+    value_info_by_name: Optional[Dict[str, onnx.ValueInfoProto]] = None,
 ) -> List[_MatMulNBitsGatedChain]:
     """The ``MatMulNBits`` analogue of :func:`_find_qdq_gated_chains` (and,
     ultimately, of :func:`_find_gated_chains` itself): recognizes the same
@@ -17398,6 +17521,10 @@ def _find_matmul_nbits_gated_chains(
     single-producer case uses), requiring at least one of the three to
     actually be ``MatMulNBits`` (an all-plain-float triple is
     :func:`_find_gated_chains`'s own job, not duplicated here).
+
+    `value_info_by_name`, when given, is threaded straight through to
+    :func:`_walk_to_matmul_nbits_consumer` -- see its own identical
+    parameter.
     """
     initializer_map = _constant_map(graph)
     consumers_of = _consumers_of(graph)
@@ -17475,7 +17602,13 @@ def _find_matmul_nbits_gated_chains(
             continue
 
         found = _walk_to_matmul_nbits_consumer(
-            out_name, initializer_map, consumers_of, graph_outputs, n_a, _MAX_CHAIN_HOPS
+            out_name,
+            initializer_map,
+            consumers_of,
+            graph_outputs,
+            n_a,
+            _MAX_CHAIN_HOPS,
+            value_info_by_name,
         )
         if found is None:
             continue
@@ -17663,24 +17796,35 @@ def apply_structured_pruning_matmul_nbits(
         value_info_by_name = (
             top_value_info_by_name if graph is out.graph else _value_info_by_name(graph)
         )
-        chains = _find_matmul_nbits_chains(graph)
-        mlp_chains = _find_matmul_nbits_mlp_chains(graph)
+        initializer_map = _constant_map(graph)
+        chains = _find_matmul_nbits_chains(graph, value_info_by_name)
+        mlp_chains = _find_matmul_nbits_mlp_chains(graph, value_info_by_name)
         qkv_chains = _find_matmul_nbits_qkv_chains(graph, value_info_by_name)
-        gated_chains = _find_matmul_nbits_gated_chains(graph)
+        gated_chains = _find_matmul_nbits_gated_chains(graph, value_info_by_name)
         if not chains and not mlp_chains and not qkv_chains and not gated_chains:
             continue
 
         producer_touched: Set[str] = set()
         consumer_touched: Set[str] = set()
+        const_touched: Set[str] = set()
         stale_value_info: Set[str] = set()
 
         for chain in chains:
             p, c = chain.producer, chain.consumer
             p_key = _matmul_nbits_chain_side_key(p)
             c_key = _matmul_nbits_chain_side_key(c)
+            consts = {
+                const_name
+                for _, const_name in chain.chain_ops
+                if const_name is not None
+            }
             if p_key == c_key:
                 continue  # degenerate (the same weight in both roles)
-            if p_key in producer_touched or c_key in consumer_touched:
+            if (
+                p_key in producer_touched
+                or c_key in consumer_touched
+                or (consts & const_touched)
+            ):
                 continue  # a shared/tied weight another chain already resized
 
             n = chain.n_channels
@@ -17719,23 +17863,33 @@ def apply_structured_pruning_matmul_nbits(
 
             _slice_matmul_nbits_chain_producer(p, keep)
             _slice_matmul_nbits_chain_consumer(c, consumer_keep)
+            for _, const_name in chain.chain_ops:
+                if const_name is not None:
+                    _slice_last_axis(initializer_map[const_name], keep)
 
             producer_touched.add(p_key)
             consumer_touched.add(c_key)
+            const_touched.update(consts)
             stale_value_info.add(p.node.output[0])
-            stale_value_info.update(op.output[0] for op in chain.chain_ops)
+            stale_value_info.update(op.output[0] for op, _ in chain.chain_ops)
 
         for gchain in gated_chains:
             pa, pb, c = gchain.producer_a, gchain.producer_b, gchain.consumer
             pa_key = _matmul_nbits_chain_side_key(pa)
             pb_key = _matmul_nbits_chain_side_key(pb)
             c_key = _matmul_nbits_chain_side_key(c)
+            gconsts = {
+                const_name
+                for _, const_name in gchain.chain_ops
+                if const_name is not None
+            }
             if pa_key == pb_key or pa_key == c_key or pb_key == c_key:
                 continue  # degenerate (a weight tied across two roles)
             if (
                 pa_key in producer_touched
                 or pb_key in producer_touched
                 or c_key in consumer_touched
+                or (gconsts & const_touched)
             ):
                 continue  # a shared/tied weight another chain already resized
 
@@ -17768,15 +17922,19 @@ def apply_structured_pruning_matmul_nbits(
             _slice_matmul_nbits_chain_producer(pa, keep)
             _slice_matmul_nbits_chain_producer(pb, keep)
             _slice_matmul_nbits_chain_consumer(c, consumer_keep)
+            for _, const_name in gchain.chain_ops:
+                if const_name is not None:
+                    _slice_last_axis(initializer_map[const_name], keep)
 
             producer_touched.add(pa_key)
             producer_touched.add(pb_key)
             consumer_touched.add(c_key)
+            const_touched.update(gconsts)
             stale_value_info.add(pa.node.output[0])
             stale_value_info.update(op.output[0] for op in gchain.producer_a_pre_ops)
             stale_value_info.add(pb.node.output[0])
             stale_value_info.update(op.output[0] for op in gchain.producer_b_pre_ops)
-            stale_value_info.update(op.output[0] for op in gchain.chain_ops)
+            stale_value_info.update(op.output[0] for op, _ in gchain.chain_ops)
 
         _apply_matmul_nbits_mlp_chains(
             graph,
@@ -17785,7 +17943,9 @@ def apply_structured_pruning_matmul_nbits(
             importance_norm,
             producer_touched,
             consumer_touched,
+            const_touched,
             stale_value_info,
+            initializer_map,
         )
         _apply_matmul_nbits_qkv_chains(
             graph,
@@ -27178,12 +27338,15 @@ def _matmul_nbits_mlp_gated_importance(
 @dataclass(frozen=True)
 class _MatMulNBitsMlpChain:
     producer: _MatMulNBitsMlpWeight
-    chain_ops: Tuple[onnx.NodeProto, ...]
+    chain_ops: Tuple[Tuple[onnx.NodeProto, Optional[str]], ...]
     consumer: _MatMulNBitsChainSide
     n_channels: int
 
 
-def _find_matmul_nbits_mlp_chains(graph: onnx.GraphProto) -> List[_MatMulNBitsMlpChain]:
+def _find_matmul_nbits_mlp_chains(
+    graph: onnx.GraphProto,
+    value_info_by_name: Optional[Dict[str, onnx.ValueInfoProto]] = None,
+) -> List[_MatMulNBitsMlpChain]:
     """The ``MatMulNBitsMlp`` analogue of :func:`_find_matmul_nbits_chains`:
     every matched fused-gated-MLP node whose `Y` output feeds, through zero
     or more shape-preserving unary activations with no other consumer along
@@ -27191,7 +27354,14 @@ def _find_matmul_nbits_mlp_chains(graph: onnx.GraphProto) -> List[_MatMulNBitsMl
     reusing :func:`_walk_to_matmul_nbits_consumer` verbatim, the exact same
     walk an ordinary single-``MatMulNBits``-producer chain uses (this fused
     node's own `Y` is no different a producer, from the consumer's own
-    point of view, than a plain ``MatMulNBits`` node's output).
+    point of view, than a plain ``MatMulNBits`` node's output) -- so this
+    automatically also gets that walk's own norm-hop recognition (a fused
+    `_NORM_PASS_THROUGH_OPS` node or either decomposed LayerNorm/RMSNorm
+    sequence) with no separate wiring of its own needed.
+
+    `value_info_by_name`, when given, is threaded straight through to
+    :func:`_walk_to_matmul_nbits_consumer` -- see its own identical
+    parameter.
     """
     initializer_map = _constant_map(graph)
     consumers_of = _consumers_of(graph)
@@ -27209,7 +27379,13 @@ def _find_matmul_nbits_mlp_chains(graph: onnx.GraphProto) -> List[_MatMulNBitsMl
         if not _is_internal(out_name):
             continue
         found = _walk_to_matmul_nbits_consumer(
-            out_name, initializer_map, consumers_of, graph_outputs, w.N, _MAX_CHAIN_HOPS
+            out_name,
+            initializer_map,
+            consumers_of,
+            graph_outputs,
+            w.N,
+            _MAX_CHAIN_HOPS,
+            value_info_by_name,
         )
         if found is None:
             continue
@@ -27225,7 +27401,9 @@ def _apply_matmul_nbits_mlp_chains(
     importance_norm: str,
     producer_touched: Set[str],
     consumer_touched: Set[str],
+    const_touched: Set[str],
     stale_value_info: Set[str],
+    initializer_map: Dict[str, onnx.TensorProto],
 ) -> None:
     """Applies whole-output-channel pruning to every matched
     ``MatMulNBitsMlp`` chain in place -- co-slicing `gate`'s and `up`'s own
@@ -27235,18 +27413,28 @@ def _apply_matmul_nbits_mlp_chains(
     :func:`apply_structured_pruning_matmul_nbits`'s own per-chain loop
     exactly (block-alignment decline for a ``MatMulNBits`` consumer, direct
     application for a plain-float one). `producer_touched`/
-    `consumer_touched`/`stale_value_info` are the caller's own running sets,
-    shared across every ``MatMulNBits``-family chain kind so a tensor
-    played as one role by an earlier chain (of ANY of the three kinds) is
-    never resized twice.
+    `consumer_touched`/`const_touched`/`stale_value_info` are the caller's
+    own running sets, shared across every ``MatMulNBits``-family chain kind
+    so a tensor played as one role by an earlier chain (of ANY of the three
+    kinds) is never resized twice. `initializer_map` slices any norm
+    `scale`/`bias` a mid-chain hop carries (:func:`_slice_last_axis`), the
+    same way :func:`apply_structured_pruning_matmul_nbits`'s own per-chain
+    loop already does for its `chain_ops`.
     """
     for chain in chains:
         p, c = chain.producer, chain.consumer
         p_keys = {p.gate_b.name, p.up_b.name}
         c_key = _matmul_nbits_chain_side_key(c)
+        consts = {
+            const_name for _, const_name in chain.chain_ops if const_name is not None
+        }
         if c_key in p_keys:
             continue  # degenerate (the same weight in both roles)
-        if p_keys & producer_touched or c_key in consumer_touched:
+        if (
+            p_keys & producer_touched
+            or c_key in consumer_touched
+            or (consts & const_touched)
+        ):
             continue  # a shared/tied weight another chain already resized
 
         n = chain.n_channels
@@ -27277,11 +27465,15 @@ def _apply_matmul_nbits_mlp_chains(
         _slice_matmul_nbits_rows_no_zp(p.up_b, p.up_scales, p.up_bias, keep)
         _set_matmul_nbits_int_attr(p.node, "N", len(keep))
         _slice_matmul_nbits_chain_consumer(c, consumer_keep)
+        for _, const_name in chain.chain_ops:
+            if const_name is not None:
+                _slice_last_axis(initializer_map[const_name], keep)
 
         producer_touched.update(p_keys)
         consumer_touched.add(c_key)
+        const_touched.update(consts)
         stale_value_info.add(p.node.output[0])
-        stale_value_info.update(op.output[0] for op in chain.chain_ops)
+        stale_value_info.update(op.output[0] for op, _ in chain.chain_ops)
 
 
 def _walk_to_matmul_nbits_attention_consumer(
@@ -33217,7 +33409,7 @@ def _slice_dynquant_chain_consumer(
 @dataclass(frozen=True)
 class _DynQuantMatMulChain:
     producer: _DynQuantMatMulChainSide
-    chain_ops: Tuple[onnx.NodeProto, ...]
+    chain_ops: Tuple[Tuple[onnx.NodeProto, Optional[str]], ...]
     consumer: _DynQuantMatMulChainSide
     n_channels: int
 
@@ -33229,24 +33421,74 @@ def _walk_to_dynquant_consumer(
     graph_outputs: Set[str],
     n_channels: int,
     max_hops: int,
-) -> Optional[Tuple[_DynQuantMatMulChainSide, Tuple[onnx.NodeProto, ...]]]:
+    value_info_by_name: Optional[Dict[str, onnx.ValueInfoProto]] = None,
+) -> Optional[
+    Tuple[_DynQuantMatMulChainSide, Tuple[Tuple[onnx.NodeProto, Optional[str]], ...]]
+]:
     """From tensor `start` (a `DynamicQuantizeMatMul`/`MatMulIntegerToFloat`
     OR plain-float MatMul/Gemm producer's own output), walks forward
-    through shape-preserving unary activations (`_UNARY_PASS_THROUGH`) with
-    no other consumer anywhere along the way, until EITHER a
-    `DynamicQuantizeMatMul`/`MatMulIntegerToFloat` consumer OR a plain-float
-    MatMul/vanilla-Gemm consumer (:func:`_match_plain_matmul_nbits_peer`) is
-    found whose input-channel count matches `n_channels` -- mirrors
+    through shape-preserving unary activations (`_UNARY_PASS_THROUGH`), a
+    plain `_NORM_PASS_THROUGH_OPS` node whose own `axis` normalizes exactly
+    `cur`'s last axis (see that constant's own comment,
+    :func:`_norm_axis_is_last`, and :func:`_norm_pass_through_const_names`
+    -- mirrors :func:`_walk_to_consumer`'s own identical single-node norm
+    hop), or either of the two *decomposed*, not-yet-fused norm sequences a
+    raw export emits instead of a fused `_NORM_PASS_THROUGH_OPS` node
+    (:func:`_match_decomposed_layer_norm_pass_through`/
+    :func:`_match_decomposed_rms_norm_pass_through`, reused verbatim -- the
+    identical two matchers :func:`_walk_to_consumer`/
+    :func:`_walk_to_matmul_nbits_consumer` try), with no other consumer
+    anywhere along the way, until EITHER a `DynamicQuantizeMatMul`/
+    `MatMulIntegerToFloat` consumer OR a plain-float MatMul/vanilla-Gemm
+    consumer (:func:`_match_plain_matmul_nbits_peer`) is found whose
+    input-channel count matches `n_channels` -- mirrors
     :func:`_walk_to_matmul_nbits_consumer` closely (the identical
-    quantized-or-plain-float union), see this section's own top comment for
-    why. No gated pair, no branch. Returns ``None`` if the walk runs out of
-    hops, hits a branch, or never reaches such a consumer. The caller
-    (:func:`_find_dynquant_chains`) is responsible for discarding a plain-
-    float-to-plain-float result.
+    quantized-or-plain-float union, and now the identical norm hop too),
+    see this section's own top comment for why. No gated pair, no branch,
+    no ``PRelu``/``Clip``/fused-bias-GELU hop -- unlike
+    :func:`_walk_to_consumer`, only the norm hop above is added here.
+    Returns ``None`` if the walk runs out of hops, hits a branch, or never
+    reaches such a consumer. The caller (:func:`_find_dynquant_chains`) is
+    responsible for discarding a plain-float-to-plain-float result.
+
+    `value_info_by_name`, when given, lets a positive-`axis`
+    `_NORM_PASS_THROUGH_OPS` hop confirm that axis against the tensor's own
+    known rank (:func:`_norm_axis_is_last`), mirroring
+    :func:`_walk_to_matmul_nbits_consumer`'s own identical parameter. Left
+    ``None``, only the unambiguous ``axis == -1`` case of that hop is still
+    recognized.
     """
-    chain_ops: List[onnx.NodeProto] = []
+    chain_ops: List[Tuple[onnx.NodeProto, Optional[str]]] = []
     cur = start
     for _hop in range(max_hops):
+        # Tried before the ordinary "exactly one consumer" dispatch below --
+        # see :func:`_walk_to_matmul_nbits_consumer`'s own identical hop-0
+        # dispatch for why (a decomposed LayerNorm/RMSNorm's own root tensor
+        # is read *twice*). Declines instantly whenever `cur` doesn't have
+        # exactly two consumers, so this costs an ordinary hop nothing.
+        ln_match = _match_decomposed_layer_norm_pass_through(
+            cur,
+            consumers_of,
+            initializer_map,
+            graph_outputs,
+            n_channels,
+            value_info_by_name,
+        )
+        if ln_match is None:
+            ln_match = _match_decomposed_rms_norm_pass_through(
+                cur,
+                consumers_of,
+                initializer_map,
+                graph_outputs,
+                n_channels,
+                value_info_by_name,
+            )
+        if ln_match is not None:
+            ln_out_name, ln_chain_ops = ln_match
+            chain_ops.extend(ln_chain_ops)
+            cur = ln_out_name
+            continue
+
         candidates = consumers_of.get(cur, [])
         if len(candidates) != 1:
             return None
@@ -33269,27 +33511,98 @@ def _walk_to_dynquant_consumer(
                 return None
             return peer, tuple(chain_ops)
 
-        if not (
+        const_name: Optional[str] = None
+        extra_const_name: Optional[str] = None
+        if (
             nxt.op_type in _UNARY_PASS_THROUGH
             and list(nxt.input) == [cur]
             and len(nxt.output) == 1
         ):
+            pass
+        elif nxt.op_type in _NORM_PASS_THROUGH_OPS and nxt.domain == "":
+            if not nxt.input or nxt.input[0] != cur:
+                return None
+            if not _norm_axis_is_last(nxt, cur, value_info_by_name):
+                return None
+            names = _norm_pass_through_const_names(nxt, initializer_map)
+            if names is None:
+                return None
+            scale_name, bias_name = names
+            if initializer_map[scale_name].dims[-1] != n_channels:
+                return None
+            if (
+                bias_name is not None
+                and initializer_map[bias_name].dims[-1] != n_channels
+            ):
+                return None
+            # Training-only secondary outputs -- see
+            # :func:`_walk_to_consumer`'s own identical check on this same
+            # hop for why a consumed one is declined here.
+            if any(
+                nxt.output[i]
+                and (consumers_of.get(nxt.output[i]) or nxt.output[i] in graph_outputs)
+                for i in range(1, len(nxt.output))
+            ):
+                return None
+            const_name = scale_name
+            extra_const_name = bias_name
+        else:
             return None
+
         out2 = nxt.output[0]
-        if len(consumers_of.get(out2, [])) != 1 or out2 in graph_outputs:
+        if out2 in graph_outputs:
             return None
-        chain_ops.append(nxt)
-        cur = out2
+        # See :func:`_walk_to_matmul_nbits_consumer`'s own identical
+        # re-check: `out2` might itself be a decomposed LayerNorm/RMSNorm
+        # sequence's own root (read twice), which the ordinary
+        # single-consumer bar below would otherwise reject before the
+        # top-of-loop dispatch ever sees it.
+        ln_match = None
+        if len(consumers_of.get(out2, [])) != 1:
+            ln_match = _match_decomposed_layer_norm_pass_through(
+                out2,
+                consumers_of,
+                initializer_map,
+                graph_outputs,
+                n_channels,
+                value_info_by_name,
+            )
+            if ln_match is None:
+                ln_match = _match_decomposed_rms_norm_pass_through(
+                    out2,
+                    consumers_of,
+                    initializer_map,
+                    graph_outputs,
+                    n_channels,
+                    value_info_by_name,
+                )
+            if ln_match is None:
+                return None
+        chain_ops.append((nxt, const_name))
+        if extra_const_name is not None:
+            chain_ops.append((nxt, extra_const_name))
+        if ln_match is not None:
+            ln_out_name, ln_chain_ops = ln_match
+            chain_ops.extend(ln_chain_ops)
+            cur = ln_out_name
+        else:
+            cur = out2
     return None
 
 
-def _find_dynquant_chains(graph: onnx.GraphProto) -> List[_DynQuantMatMulChain]:
+def _find_dynquant_chains(
+    graph: onnx.GraphProto,
+    value_info_by_name: Optional[Dict[str, onnx.ValueInfoProto]] = None,
+) -> List[_DynQuantMatMulChain]:
     """Every producer/consumer pair connected by
     :func:`_walk_to_dynquant_consumer` where AT LEAST ONE side is a
     `DynamicQuantizeMatMul`/`MatMulIntegerToFloat` node (a plain-float-to-
     plain-float pair is :func:`apply_structured_pruning`'s own job, not
     duplicated here -- mirrors :func:`_find_matmul_nbits_chains`'s identical
     at-least-one-quantized filter).
+
+    `value_info_by_name`, when given, is threaded straight through to
+    :func:`_walk_to_dynquant_consumer` -- see its own identical parameter.
     """
     initializer_map = _constant_map(graph)
     consumers_of = _consumers_of(graph)
@@ -33323,6 +33636,7 @@ def _find_dynquant_chains(graph: onnx.GraphProto) -> List[_DynQuantMatMulChain]:
             graph_outputs,
             n_channels,
             _MAX_CHAIN_HOPS,
+            value_info_by_name,
         )
         if found is None:
             continue
@@ -33402,23 +33716,38 @@ def apply_structured_pruning_dynamic_quantize_matmul(
         model = onnx.load(model, load_external_data=False)
     out = onnx.ModelProto()
     out.CopyFrom(model)
+    top_value_info_by_name = _shape_inferred_value_info_by_name(out)
 
     for graph in _iter_subgraphs(out.graph):
-        chains = _find_dynquant_chains(graph)
+        value_info_by_name = (
+            top_value_info_by_name if graph is out.graph else _value_info_by_name(graph)
+        )
+        initializer_map = _constant_map(graph)
+        chains = _find_dynquant_chains(graph, value_info_by_name)
         if not chains:
             continue
 
         producer_touched: Set[str] = set()
         consumer_touched: Set[str] = set()
+        const_touched: Set[str] = set()
         stale_value_info: Set[str] = set()
 
         for chain in chains:
             p, c = chain.producer, chain.consumer
             p_key = _dynquant_chain_side_key(p)
             c_key = _dynquant_chain_side_key(c)
+            consts = {
+                const_name
+                for _, const_name in chain.chain_ops
+                if const_name is not None
+            }
             if p_key == c_key:
                 continue  # degenerate (the same weight in both roles)
-            if p_key in producer_touched or c_key in consumer_touched:
+            if (
+                p_key in producer_touched
+                or c_key in consumer_touched
+                or (consts & const_touched)
+            ):
                 continue  # a shared/tied weight another chain already resized
 
             n = chain.n_channels
@@ -33436,11 +33765,15 @@ def apply_structured_pruning_dynamic_quantize_matmul(
 
             _slice_dynquant_chain_producer(p, keep)
             _slice_dynquant_chain_consumer(c, keep)
+            for _, const_name in chain.chain_ops:
+                if const_name is not None:
+                    _slice_last_axis(initializer_map[const_name], keep)
 
             producer_touched.add(p_key)
             consumer_touched.add(c_key)
+            const_touched.update(consts)
             stale_value_info.add(p.node.output[0])
-            stale_value_info.update(op.output[0] for op in chain.chain_ops)
+            stale_value_info.update(op.output[0] for op, _ in chain.chain_ops)
 
         if stale_value_info:
             kept = [vi for vi in graph.value_info if vi.name not in stale_value_info]
@@ -38356,10 +38689,10 @@ def _analyze_structured_pruning_matmul_nbits(
             if graph is model.graph
             else _value_info_by_name(graph)
         )
-        chains = _find_matmul_nbits_chains(graph)
-        mlp_chains = _find_matmul_nbits_mlp_chains(graph)
+        chains = _find_matmul_nbits_chains(graph, value_info_by_name)
+        mlp_chains = _find_matmul_nbits_mlp_chains(graph, value_info_by_name)
         qkv_chains = _find_matmul_nbits_qkv_chains(graph, value_info_by_name)
-        gated_chains = _find_matmul_nbits_gated_chains(graph)
+        gated_chains = _find_matmul_nbits_gated_chains(graph, value_info_by_name)
         not_eligible.extend(
             _matmul_nbits_not_eligible(
                 graph, chains, mlp_chains, qkv_chains, gated_chains
@@ -40516,11 +40849,17 @@ def _analyze_structured_pruning_dynamic_quantize_matmul(
     if isinstance(model, str):
         model = onnx.load(model, load_external_data=False)
 
+    top_value_info_by_name = _shape_inferred_value_info_by_name(model)
     layers: List[PruningLayerSensitivity] = []
     not_eligible: List[str] = []
 
     for graph in _iter_subgraphs(model.graph):
-        chains = _find_dynquant_chains(graph)
+        value_info_by_name = (
+            top_value_info_by_name
+            if graph is model.graph
+            else _value_info_by_name(graph)
+        )
+        chains = _find_dynquant_chains(graph, value_info_by_name)
         not_eligible.extend(_dynquant_not_eligible(graph, chains))
         if not chains:
             continue

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -32110,6 +32110,208 @@ def test_matmul_nbits_pruning_producer_and_consumer_match_independent_reference_
     np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-3, atol=1e-3)
 
 
+# --- MatMulNBits: mid-chain LayerNorm/RMSNorm pass-through -----------------
+#
+# Regression coverage mirroring the DynamicQuantizeMatMul section's own
+# identical addition (see its own top comment): `_walk_to_matmul_nbits_consumer`
+# previously recognized only `_UNARY_PASS_THROUGH` activations as a
+# mid-chain hop, never a `_NORM_PASS_THROUGH_OPS` node, so a real
+# ``MatMulNBits(mm1) -> LayerNormalization -> MatMulNBits(mm2)`` block was
+# silently left completely unpruned. Uses `onnx.helper`
+# (`_nbits_chain_norm_model`, mirroring `_nbits_chain_model` above) rather
+# than `onnx.parser` -- this section's own established pattern, since the
+# packed int4 ``B``/``scales``/``zero_points`` tensors need real array data
+# a parser text literal can't spell out (see this file's own top-of-section
+# comment for `_nbits_chain_model`).
+
+
+def _nbits_chain_norm_model(N1, K1, N2, block_size, W1, W2, norm_op, gamma, beta=None):
+    """Builds ``A -> MatMulNBits(mm1) -> norm_op(Gamma[, Beta]) ->
+    MatMulNBits(mm2) -> Y`` -- the norm-pass-through chain shape, both
+    MatMul nodes real, bit-packed int4-quantized ``com.microsoft::
+    MatMulNBits`` nodes. Mirrors :func:`_nbits_chain_model` exactly
+    (bits=4, packed zero_points), just with a mid-chain norm node standing
+    in for the plain activation. Returns ``(model, info)`` the same shape
+    :func:`_nbits_chain_model` does.
+    """
+    bits = 4
+    K2 = N1
+    assert K2 % block_size == 0
+    qcodes1, scales1, zp1, kb1 = _nbits_quantize_block(W1, block_size, bits)
+    qcodes2, scales2, zp2, kb2 = _nbits_quantize_block(W2, block_size, bits)
+    B1 = _nbits_pack_B(qcodes1, N1, kb1, block_size, bits)
+    B2 = _nbits_pack_B(qcodes2, N2, kb2, block_size, bits)
+
+    initializer = [
+        onnx.numpy_helper.from_array(B1, name="B1"),
+        onnx.numpy_helper.from_array(scales1, name="scales1"),
+        onnx.numpy_helper.from_array(_nbits_pack_codes(zp1, bits), name="zp1"),
+        onnx.numpy_helper.from_array(B2, name="B2"),
+        onnx.numpy_helper.from_array(scales2, name="scales2"),
+        onnx.numpy_helper.from_array(_nbits_pack_codes(zp2, bits), name="zp2"),
+        onnx.numpy_helper.from_array(gamma, name="Gamma"),
+    ]
+    norm_inputs = ["h1", "Gamma"]
+    if beta is not None:
+        initializer.append(onnx.numpy_helper.from_array(beta, name="Beta"))
+        norm_inputs.append("Beta")
+
+    node1 = _nbits_node(
+        "mm1", "A", "h1", "B1", "scales1", "zp1", None, N1, K1, block_size, bits
+    )
+    norm_node = onnx.helper.make_node(norm_op, norm_inputs, ["h1n"], axis=-1)
+    node2 = _nbits_node(
+        "mm2", "h1n", "Y", "B2", "scales2", "zp2", None, N2, K2, block_size, bits
+    )
+
+    M = 3
+    graph = onnx.helper.make_graph(
+        [node1, norm_node, node2],
+        "g",
+        inputs=[
+            onnx.helper.make_tensor_value_info("A", onnx.TensorProto.FLOAT, [M, K1])
+        ],
+        outputs=[
+            onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [M, N2])
+        ],
+        initializer=initializer,
+    )
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 21),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    model.ir_version = 10
+    return model, dict(
+        qcodes1=qcodes1,
+        scales1=scales1,
+        zp1=zp1,
+        kb1=kb1,
+        qcodes2=qcodes2,
+        scales2=scales2,
+        zp2=zp2,
+        kb2=kb2,
+        K2=K2,
+    )
+
+
+def test_matmul_nbits_layer_norm_pass_through_is_matched_and_prunes():
+    # N1=32 output channels, block_size=16 -- rows 0-15 engineered
+    # large-magnitude (kept), 16-31 small (dropped), so the L2-importance
+    # keep-set lands on exactly block 0, the same block-aligned setup
+    # `test_matmul_nbits_pruning_producer_and_consumer_match_independent_reference_oracle`
+    # above uses.
+    N1, K1, N2, block_size = 32, 64, 8, 16
+    rng = np.random.default_rng(300)
+    W1 = rng.standard_normal((N1, K1)).astype(np.float32) * 0.2
+    W1[:16] *= 6.0
+    W2 = rng.standard_normal((N2, N1)).astype(np.float32) * 0.2
+    gamma = (rng.standard_normal(N1) * 0.5 + 1.0).astype(np.float32)
+    beta = (rng.standard_normal(N1) * 0.1).astype(np.float32)
+
+    model, info = _nbits_chain_norm_model(
+        N1, K1, N2, block_size, W1, W2, "LayerNormalization", gamma, beta
+    )
+    onnx.checker.check_model(model)
+
+    # Before this section's own fix, this returned 0 chains.
+    chains = onnxsim.pruning._find_matmul_nbits_chains(model.graph)
+    assert len(chains) == 1
+    assert chains[0].n_channels == N1
+
+    pruned = onnxsim.apply_structured_pruning_matmul_nbits(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep = np.arange(16)  # expected keep-set: rows 0-15 (block 0)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["B1"].dims) == [16, info["kb1"], block_size * 4 // 8]
+    assert list(inits["Gamma"].dims) == [16]
+    assert list(inits["Beta"].dims) == [16]
+    assert list(inits["B2"].dims) == [N2, 1, block_size * 4 // 8]
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Gamma"]), gamma[keep]
+    )
+    np.testing.assert_array_equal(onnx.numpy_helper.to_array(inits["Beta"]), beta[keep])
+
+    # Independently-constructed, ALREADY-PRUNED reference model, mirroring
+    # this section's own oracle test above: re-quantizes W1[keep]/W2[:, keep]
+    # from float, a genuinely independent construction from the pass's own
+    # slice-of-existing-codes.
+    ref_model, _ = _nbits_chain_norm_model(
+        16,
+        K1,
+        N2,
+        block_size,
+        W1[keep],
+        W2[:, keep],
+        "LayerNormalization",
+        gamma[keep],
+        beta[keep],
+    )
+    onnx.checker.check_model(ref_model)
+
+    rng2 = np.random.default_rng(301)
+    x = rng2.standard_normal((3, K1)).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"A": x})
+    (y_ref,) = _run(ref_model, {"A": x})
+    np.testing.assert_allclose(y_pruned, y_ref, rtol=1e-2, atol=1e-2)
+
+
+def test_matmul_nbits_rms_norm_pass_through_is_matched_and_prunes():
+    # `SimplifiedLayerNormalization` -- no `beta`/`Beta` input at all, unlike
+    # `LayerNormalization` above. `onnx.checker`'s own schema database
+    # doesn't know this op under the default domain at all (an
+    # onnxruntime-only registration, not a plain-ONNX one -- see
+    # `test_structured_pruning_simplified_layer_norm_pass_through_matches_oracle`'s
+    # own identical note), so `onnx.checker.check_model` is skipped here;
+    # onnxruntime itself still runs it fine, which the oracle comparison
+    # below actually exercises.
+    N1, K1, N2, block_size = 32, 64, 8, 16
+    rng = np.random.default_rng(302)
+    W1 = rng.standard_normal((N1, K1)).astype(np.float32) * 0.2
+    W1[:16] *= 6.0
+    W2 = rng.standard_normal((N2, N1)).astype(np.float32) * 0.2
+    gamma = (rng.standard_normal(N1) * 0.5 + 1.0).astype(np.float32)
+
+    model, info = _nbits_chain_norm_model(
+        N1, K1, N2, block_size, W1, W2, "SimplifiedLayerNormalization", gamma
+    )
+
+    chains = onnxsim.pruning._find_matmul_nbits_chains(model.graph)
+    assert len(chains) == 1
+    assert chains[0].n_channels == N1
+
+    pruned = onnxsim.apply_structured_pruning_matmul_nbits(model, sparsity=0.5)
+
+    keep = np.arange(16)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["B1"].dims) == [16, info["kb1"], block_size * 4 // 8]
+    assert list(inits["Gamma"].dims) == [16]
+    assert list(inits["B2"].dims) == [N2, 1, block_size * 4 // 8]
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Gamma"]), gamma[keep]
+    )
+
+    ref_model, _ = _nbits_chain_norm_model(
+        16,
+        K1,
+        N2,
+        block_size,
+        W1[keep],
+        W2[:, keep],
+        "SimplifiedLayerNormalization",
+        gamma[keep],
+    )
+
+    rng2 = np.random.default_rng(303)
+    x = rng2.standard_normal((3, K1)).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"A": x})
+    (y_ref,) = _run(ref_model, {"A": x})
+    np.testing.assert_allclose(y_pruned, y_ref, rtol=1e-2, atol=1e-2)
+
+
 def test_matmul_nbits_pruning_producer_odd_kept_row_count_zero_points_has_no_repack_hazard():
     # This directly tests :func:`onnxsim.pruning._slice_matmul_nbits_producer_rows`
     # (rather than the public ``apply_structured_pruning_matmul_nbits``,
@@ -34991,6 +35193,73 @@ def test_matmul_nbits_mlp_pruning_matches_decomposed_oracle():
     y_ref = np.maximum(gate_ref, 0) * up_ref
 
     np.testing.assert_allclose(y_actual, y_ref, rtol=1e-3, atol=1e-3)
+
+
+def test_matmul_nbits_mlp_norm_pass_through_is_matched_and_prunes():
+    # Confirms `_MatMulNBitsMlpChain` automatically inherits the norm-hop
+    # fix above with NO separate wiring of its own:
+    # `_find_matmul_nbits_mlp_chains` reuses `_walk_to_matmul_nbits_consumer`
+    # verbatim (see its own docstring), so a `LayerNormalization` node
+    # standing between `MatMulNBitsMlp`'s own `Y` and a downstream plain
+    # ``MatMul`` is recognized exactly like the plain single-producer chain
+    # case above, with no code change needed in this fused-op section at
+    # all.
+    N, K, N2, block_size = 8, 32, 5, 32
+    rng = np.random.default_rng(9101)
+    W_gate = (rng.standard_normal((N, K)) * 0.3).astype(np.float32)
+    W_up = (rng.standard_normal((N, K)) * 0.3).astype(np.float32)
+    W_gate[:4] *= 8.0
+    W_up[:4] *= 8.0
+    W_gate[4:] *= 0.05
+    W_up[4:] *= 0.05
+    bias_gate = (rng.standard_normal(N) * 0.05).astype(np.float32)
+    bias_up = (rng.standard_normal(N) * 0.05).astype(np.float32)
+    gamma = (rng.standard_normal(N) * 0.5 + 1.0).astype(np.float32)
+    beta = (rng.standard_normal(N) * 0.1).astype(np.float32)
+
+    model, info = _matmul_nbits_mlp_model(
+        N, K, N2, block_size, W_gate, W_up, bias_gate, bias_up
+    )
+    # Splice a `LayerNormalization(Gamma, Beta)` node between the fused
+    # MLP's own `Y` output and the downstream plain `MatMul(down)` --
+    # everything else about the model is identical to
+    # `_matmul_nbits_mlp_model`'s own construction.
+    down_node = next(n for n in model.graph.node if n.name == "down")
+    down_node.input[0] = "Yn"
+    norm_node = onnx.helper.make_node(
+        "LayerNormalization", ["Y", "Gamma", "Beta"], ["Yn"], axis=-1
+    )
+    model.graph.node.insert(1, norm_node)
+    model.graph.initializer.extend(
+        [
+            onnx.numpy_helper.from_array(gamma, name="Gamma"),
+            onnx.numpy_helper.from_array(beta, name="Beta"),
+        ]
+    )
+    onnx.checker.check_model(model)
+
+    # Before this section's own fix (via `_walk_to_matmul_nbits_consumer`),
+    # this returned 0 chains -- the norm node defeated the walk entirely.
+    mlp_chains = onnxsim.pruning._find_matmul_nbits_mlp_chains(model.graph)
+    assert len(mlp_chains) == 1
+
+    pruned = onnxsim.apply_structured_pruning_matmul_nbits(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep = np.array([0, 1, 2, 3])
+    inits = {t.name: t for t in pruned.graph.initializer}
+    mlp_node = next(n for n in pruned.graph.node if n.name == "mlp")
+    assert next(a.i for a in mlp_node.attribute if a.name == "N") == 4
+    assert list(inits["Gamma"].dims) == [4]
+    assert list(inits["Beta"].dims) == [4]
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Gamma"]), gamma[keep]
+    )
+    np.testing.assert_array_equal(onnx.numpy_helper.to_array(inits["Beta"]), beta[keep])
+    assert list(inits["down_w"].dims) == [4, N2]
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["down_w"]), info["down_w"][keep]
+    )
 
 
 def _matmul_nbits_qkv_model(
@@ -38854,6 +39123,218 @@ def test_dynamic_quantize_matmul_producer_matches_independently_requantized_subs
 
     rng = np.random.default_rng(11)
     x = rng.standard_normal((1, K)).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_ref,) = _run(ref_model, {"X": x})
+    np.testing.assert_array_equal(y_pruned, y_ref)
+
+
+# --- DynamicQuantizeMatMul: mid-chain LayerNorm/RMSNorm pass-through -------
+#
+# Regression coverage for the gap the task that added this section closed:
+# `_walk_to_dynquant_consumer` previously recognized only
+# `_UNARY_PASS_THROUGH` activations as a mid-chain hop, never a
+# `_NORM_PASS_THROUGH_OPS` node -- so a real
+# ``DynamicQuantizeMatMul(W1) -> LayerNormalization -> DynamicQuantizeMatMul(W2)``
+# block (the single most common pre-LN transformer sub-block shape, now
+# quantized) was silently left completely unpruned: `_find_dynquant_chains`
+# returned zero chains for it. Mirrors `_walk_to_consumer`'s own established
+# norm-hop tests (see this file's own "mid-chain LayerNorm/RMSNorm
+# pass-through" section far above) but through a genuinely quantized
+# producer/consumer pair, weights quantized via the real `quantize_dynamic`
+# tool exactly like every other test in this section.
+
+
+def _dqmm_norm_model_from_weights(
+    K, N1, N2, W1f, W2f, norm_op, gamma, beta=None, per_channel=True, axis=-1
+):
+    """Builds ``DynamicQuantizeMatMul(mm1) -> norm_op(Gamma[, Beta]) ->
+    DynamicQuantizeMatMul(mm2)`` -- the norm-pass-through chain shape --
+    from explicit float weights, quantized via the real tool
+    (:func:`_quantize_dynamic_weight`). Mirrors
+    :func:`_dqmm_model_from_weights` exactly, just with a mid-chain norm
+    node (`LayerNormalization`/`SimplifiedLayerNormalization`) standing in
+    for the plain activation.
+    """
+    W1q, W1s, W1zp = _quantize_dynamic_weight(W1f, per_channel)
+    W2q, W2s, W2zp = _quantize_dynamic_weight(W2f, per_channel)
+
+    if beta is None:
+        norm_call = f"{norm_op}<axis={axis}>(h1, Gamma)"
+        norm_inits = [_f32(gamma, "Gamma")]
+    else:
+        norm_call = f"{norm_op}<axis={axis}>(h1, Gamma, Beta)"
+        norm_inits = [_f32(gamma, "Gamma"), _f32(beta, "Beta")]
+
+    body = f"""
+    g (float[1,{K}] X) => (float[1,{N2}] Y)
+    {{
+      h1 = com.microsoft.DynamicQuantizeMatMul(X, W1, W1_scale, W1_zero_point)
+      h1n = {norm_call}
+      Y = com.microsoft.DynamicQuantizeMatMul(h1n, W2, W2_scale, W2_zero_point)
+    }}
+    """
+    inits = [
+        onnx.numpy_helper.from_array(W1q, "W1"),
+        onnx.numpy_helper.from_array(W1s, "W1_scale"),
+        onnx.numpy_helper.from_array(W1zp, "W1_zero_point"),
+        *norm_inits,
+        onnx.numpy_helper.from_array(W2q, "W2"),
+        onnx.numpy_helper.from_array(W2s, "W2_scale"),
+        onnx.numpy_helper.from_array(W2zp, "W2_zero_point"),
+    ]
+    model = _model(body, initializer=inits, opset=21)
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+    return model, {
+        "W1f": W1f,
+        "W2f": W2f,
+        "gamma": gamma,
+        "beta": beta,
+        "W1q": W1q,
+        "W1s": W1s,
+        "W1zp": W1zp,
+        "W2q": W2q,
+        "W2s": W2s,
+        "W2zp": W2zp,
+    }
+
+
+def test_dynamic_quantize_matmul_layer_norm_pass_through_is_matched_and_prunes():
+    K, N1, N2 = 16, 24, 12
+    rng = np.random.default_rng(41)
+    W1f = (rng.standard_normal((K, N1)) * 0.3).astype(np.float32)
+    W2f = (rng.standard_normal((N1, N2)) * 0.3).astype(np.float32)
+    gamma = (rng.standard_normal(N1) * 0.5 + 1.0).astype(np.float32)
+    beta = (rng.standard_normal(N1) * 0.1).astype(np.float32)
+    model, info = _dqmm_norm_model_from_weights(
+        K, N1, N2, W1f, W2f, "LayerNormalization", gamma, beta, per_channel=True
+    )
+    onnx.checker.check_model(model)
+
+    # Before this section's own fix, this returned 0 chains (the confirmed
+    # bug this task closes) -- a norm node mid-chain silently defeated the
+    # walk entirely.
+    chains = onnxsim.pruning._find_dynquant_chains(model.graph)
+    assert len(chains) == 1
+    assert chains[0].n_channels == N1
+
+    pruned = onnxsim.apply_structured_pruning_dynamic_quantize_matmul(
+        model, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned)
+    keep_count = N1 - round(N1 * 0.5)
+    keep = _dqmm_importance_keep(info["W1q"], info["W1s"], info["W1zp"], keep_count)
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [K, keep_count]
+    assert list(inits["Gamma"].dims) == [keep_count]
+    assert list(inits["Beta"].dims) == [keep_count]
+    assert list(inits["W2"].dims) == [keep_count, N2]
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Gamma"]), gamma[keep]
+    )
+    np.testing.assert_array_equal(onnx.numpy_helper.to_array(inits["Beta"]), beta[keep])
+
+    # Independently reconstructed "already pruned" reference model, the same
+    # pattern this section's own oracle test above uses: the producer's
+    # kept-column weight is quantized FRESH via the real quantizer
+    # (per-channel quantization is column-independent, so this is
+    # byte-identical to slicing); the consumer's own codes are sliced
+    # directly and its scale/zero-point copied UNCHANGED.
+    ref_model, _ = _dqmm_norm_model_from_weights(
+        K,
+        keep_count,
+        N2,
+        W1f[:, keep],
+        W2f[keep, :],  # shape placeholder only -- overwritten below
+        "LayerNormalization",
+        gamma[keep],
+        beta[keep],
+        per_channel=True,
+    )
+    ref_inits = {t.name: t for t in ref_model.graph.initializer}
+    ref_inits["W2"].CopyFrom(onnx.numpy_helper.from_array(info["W2q"][keep, :], "W2"))
+    ref_inits["W2_scale"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W2s"], "W2_scale")
+    )
+    ref_inits["W2_zero_point"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W2zp"], "W2_zero_point")
+    )
+
+    rng2 = np.random.default_rng(42)
+    x = rng2.standard_normal((1, K)).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_ref,) = _run(ref_model, {"X": x})
+    np.testing.assert_array_equal(y_pruned, y_ref)
+
+
+def test_dynamic_quantize_matmul_rms_norm_pass_through_is_matched_and_prunes():
+    # `SimplifiedLayerNormalization` -- onnxruntime's own RMSNorm-equivalent
+    # fused op, registered under the *default* ONNX domain (see this file's
+    # own "mid-chain LayerNorm/RMSNorm pass-through" section comment far
+    # above) -- has no `bias`/`Beta` input at all, unlike `LayerNormalization`.
+    # `onnx.checker`'s own schema database doesn't know this op under the
+    # default domain at all (an onnxruntime-only registration, not a plain-
+    # ONNX one -- see `test_structured_pruning_simplified_layer_norm_pass_through_matches_oracle`'s
+    # own identical note), so `onnx.checker.check_model` is skipped here;
+    # onnxruntime itself still runs it fine, which the oracle comparison
+    # below actually exercises.
+    K, N1, N2 = 16, 24, 12
+    rng = np.random.default_rng(43)
+    W1f = (rng.standard_normal((K, N1)) * 0.3).astype(np.float32)
+    W2f = (rng.standard_normal((N1, N2)) * 0.3).astype(np.float32)
+    gamma = (rng.standard_normal(N1) * 0.5 + 1.0).astype(np.float32)
+    model, info = _dqmm_norm_model_from_weights(
+        K,
+        N1,
+        N2,
+        W1f,
+        W2f,
+        "SimplifiedLayerNormalization",
+        gamma,
+        beta=None,
+        per_channel=True,
+    )
+
+    chains = onnxsim.pruning._find_dynquant_chains(model.graph)
+    assert len(chains) == 1
+    assert chains[0].n_channels == N1
+
+    pruned = onnxsim.apply_structured_pruning_dynamic_quantize_matmul(
+        model, sparsity=0.5
+    )
+    keep_count = N1 - round(N1 * 0.5)
+    keep = _dqmm_importance_keep(info["W1q"], info["W1s"], info["W1zp"], keep_count)
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [K, keep_count]
+    assert list(inits["Gamma"].dims) == [keep_count]
+    assert list(inits["W2"].dims) == [keep_count, N2]
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Gamma"]), gamma[keep]
+    )
+
+    ref_model, _ = _dqmm_norm_model_from_weights(
+        K,
+        keep_count,
+        N2,
+        W1f[:, keep],
+        W2f[keep, :],  # shape placeholder only -- overwritten below
+        "SimplifiedLayerNormalization",
+        gamma[keep],
+        beta=None,
+        per_channel=True,
+    )
+    ref_inits = {t.name: t for t in ref_model.graph.initializer}
+    ref_inits["W2"].CopyFrom(onnx.numpy_helper.from_array(info["W2q"][keep, :], "W2"))
+    ref_inits["W2_scale"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W2s"], "W2_scale")
+    )
+    ref_inits["W2_zero_point"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W2zp"], "W2_zero_point")
+    )
+
+    rng2 = np.random.default_rng(44)
+    x = rng2.standard_normal((1, K)).astype(np.float32)
     (y_pruned,) = _run(pruned, {"X": x})
     (y_ref,) = _run(ref_model, {"X": x})
     np.testing.assert_array_equal(y_pruned, y_ref)


### PR DESCRIPTION
## Summary

The plain-float MatMul/Gemm chain walker (`_walk_to_consumer`) already recognizes a `LayerNormalization`/`RMSNormalization`/`SimplifiedLayerNormalization` node (fused or decomposed, pre-opset-17) as a transparent pass-through hop — letting a `Linear → LayerNorm/RMSNorm → Linear` block (the single most common transformer sub-block shape: every pre-LN/pre-RMSNorm transformer layer has this) get pruned straight through the norm. The **quantized** MatMul-chain walkers never had this hop at all — they only passed through `_UNARY_PASS_THROUGH` (elementwise activations). This made `DynamicQuantizeMatMul`/`MatMulIntegerToFloat` and `MatMulNBits`-based pruning a silent no-op on this shape.

## Empirically confirmed facts

- Built a real `X → DynamicQuantizeMatMul(W1) → LayerNormalization → DynamicQuantizeMatMul(W2) → Y` model (W1/W2 quantized via the real `onnxruntime.quantization.quantize_dynamic` tool): `_find_dynquant_chains` returned 0 chains, and `apply_structured_pruning_dynamic_quantize_matmul` left both weights completely untouched before this change.
- `MatMulNBitsMlp` chains reuse `_walk_to_matmul_nbits_consumer` verbatim, so they **automatically** gain this norm-hop recognition with no separate wiring — confirmed with a new regression test. `MatMulNBitsQkv` uses a separate walker (`_walk_to_matmul_nbits_attention_consumer`) and is explicitly **out of scope** for this PR (it has its own, already-documented per-head Q/K-norm+RoPE hop elsewhere).

## What's added

- `onnxsim/pruning.py`: `_walk_to_dynquant_consumer` and `_walk_to_matmul_nbits_consumer` both gained the exact same pass-through recognition `_walk_to_consumer` already has — a fused `_NORM_PASS_THROUGH_OPS` node (reusing `_norm_axis_is_last`/`_norm_pass_through_const_names` verbatim) plus the two decomposed (pre-opset-17) LayerNorm/RMSNorm node-sequence matchers (`_match_decomposed_layer_norm_pass_through`/`_match_decomposed_rms_norm_pass_through`, reused as-is) — mechanical reuse of already-tested logic, no new matching primitives. Both walkers gained a `value_info_by_name` parameter for axis resolution, threaded through their callers (`_find_dynquant_chains`, `_find_matmul_nbits_chains`, `_find_matmul_nbits_gated_chains`, `_find_matmul_nbits_mlp_chains`, and their dry-run `_analyze_*` mirrors).
- `apply_structured_pruning_matmul_nbits` / `apply_structured_pruning_dynamic_quantize_matmul`: slice the norm's `scale`/`bias` initializers by the chain's `keep` set, with `const_touched` bookkeeping (mirroring the existing tied-const conflict handling) so a shared norm weight is never resized twice.
- **Deliberately out of scope for this round**: `QLinearMatMul`/`QGemm`, QDQ MatMul, FP8/FP4, `MatMulBnb4`, and `MatMulNBitsQkv` — same mechanical fix, deferred to a follow-up to keep this PR bounded.
- `tests/test_pruning.py`: 5 new tests — LayerNorm and RMSNorm pass-through for both `DynamicQuantizeMatMul` (weights via real `quantize_dynamic`) and `MatMulNBits` (via existing block-quantization helpers), each oracle-checked against a real `InferenceSession`, plus one confirming the `MatMulNBitsMlp` auto-benefit.

## Test plan

- [x] New tests fail on the pre-fix code and pass after the fix (verified independently via a before/after checkout — baseline 108 failed/819 passed vs. fixed 103 failed/824 passed: exactly the 5 new tests flip, nothing else changes)
- [x] `pytest tests/test_pruning.py -k "dynamic_quantize_matmul or dynquant or matmul_nbits"` — 60 passed
- [x] `pytest tests/test_pruning.py -q` (full suite) — 824 passed, same 103 pre-existing failures (stale compiled C++ extension — a concurrently-merged `prune_magnitude` C++ port changed its Python-callable signature, unrelated to this change, confirmed identical on the pre-change commit)
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — no new issues

## Risks for reviewer

- Widest-blast-radius change of the recent pass-through-hop fixes: touches 2 walkers, 4 chain-finder functions, their dry-run mirrors, and both `apply_structured_pruning_*` rewrite functions, adding `const_touched` bookkeeping alongside the existing `producer_touched`/`consumer_touched` sets.
- `MatMulNBitsQkv`/QOperator/QDQ/FP8/FP4/Bnb4 are unaffected — same gap, deferred to a follow-up round.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_