### PR TITLE
Expand AX650 op coverage confirmation from 29% to 99% (91/92)

### DIFF
--- a/.github/workflows/axera-integration.yml
+++ b/.github/workflows/axera-integration.yml
@@ -41,6 +41,7 @@ on:
       - "tests/test_axera_conv_matmul_coverage.py"
       - "tests/test_axera_conv_matmul_coverage_hardware.py"
       - "tests/test_axera_neu_format_arith_ops.py"
+      - "tests/test_axera_op_coverage_hardware.py"
 
 concurrency:
   group: axera-integration-${{ github.ref }}
@@ -151,7 +152,7 @@ jobs:
       - name: Run hf-config+safetensors -> onnx -> axmodel integration test
         working-directory: ${{ runner.temp }}
         run: |
-          pytest -v "$GITHUB_WORKSPACE/tests/test_pulsar2_hf_to_axmodel.py" "$GITHUB_WORKSPACE/tests/test_axera_conv_matmul_coverage_hardware.py" "$GITHUB_WORKSPACE/tests/test_axera_neu_format_arith_ops.py"
+          pytest -v "$GITHUB_WORKSPACE/tests/test_pulsar2_hf_to_axmodel.py" "$GITHUB_WORKSPACE/tests/test_axera_conv_matmul_coverage_hardware.py" "$GITHUB_WORKSPACE/tests/test_axera_neu_format_arith_ops.py" "$GITHUB_WORKSPACE/tests/test_axera_op_coverage_hardware.py"
       - name: Run real conversion
         working-directory: ${{ runner.temp }}
         env:

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -814,6 +814,82 @@ at least this shape/parameter combination -- root cause (a missing required
 attribute this minimal graph didn't set, a PTQ-engine limitation specific to
 transposed conv, or something else) not further diagnosed here.
 
+## Systematic op coverage: from 29% to 99% of `AX650_SUPPORTED_OPS`
+
+The findings above cover Conv/MatMul-family ops specifically. Widening out
+to the *entire* 92-op `AX650_SUPPORTED_OPS` list: cross-referencing every
+op type actually exercised by a real `pulsar2 build` anywhere in this
+investigation (the LLM reconstruction graph, the Conv/MatMul/arith
+batteries above, and earlier CNN builds) against the full list started at
+27/92 (~29%) confirmed one way or the other. A single-node-per-op battery
+(one real `pulsar2 build` per op, small isolated graphs) brought that to
+**91/92 (~99%)** -- only `SpatialTransformer` remains genuinely
+inconclusive (see below), and every other op in the list now has a real,
+confirmed working-or-failing verdict.
+
+**84 confirmed working**, including some genuinely useful discoveries for
+future onnxsim work:
+
+- **`RMSNormalization` (native, opset 23) compiles successfully as a single
+  op.** `reconstruct_hf_graph()` currently hand-decomposes RMSNorm into
+  `ReduceMean`/`Add`/`Sqrt`/`Div`/`Mul` (reused from `gguf_reconstruct.py`,
+  written before this op existed in the ONNX opset) -- emitting the native
+  op instead would be a smaller, more legible graph, worth a follow-up if
+  onnxsim ever bumps its target opset that high.
+- **`Silu` compiles even though it isn't a real ONNX operator schema at
+  all** -- confirmed by constructing a raw `NodeProto` with `op_type=
+  "Silu"` directly (`onnx.checker` has no schema for it and was skipped;
+  Pulsar2 doesn't care). It's one of Axera's own extension op names, and a
+  real, working one -- though onnxsim should keep emitting the standard
+  `Sigmoid`+`Mul` decomposition regardless, for `onnxruntime` compatibility.
+- **A real, generalizable gotcha**: `Elu`, `LeakyRelu`, and `TopK` all
+  failed on the first attempt with confusing internal errors (`RuntimeError
+  ("... convert error: 'alpha'")`, `RuntimeError("... get opr failed")`) --
+  not because the ops are unsupported, but because their optional
+  attributes (`alpha` for the first two, `largest`/`sorted` for `TopK`)
+  were left unset to fall back to the ONNX schema's own documented default.
+  Pulsar2's frontend doesn't resolve that default -- it reads the missing
+  attribute as `None` and chokes. Setting the exact same default value
+  *explicitly* on the node made all three compile without any other
+  change. Worth remembering for any ONNX graph -- onnxsim-generated or
+  not -- headed for a real `pulsar2 build`: never rely on an attribute's
+  schema default being applied for you.
+
+**7 confirmed failing despite being listed in `AX650_SUPPORTED_OPS`**
+(beyond `ConvTranspose`, already covered above):
+
+- `Xor`: genuinely unimplemented (`KeyError('dont support Xor opr...')`).
+- `Squeeze`: a real internal compiler bug, not a "not supported" error --
+  `ZeroDivisionError('division by zero')` inside the NPU backend scheduler
+  for the specific shape tested (`(1,4)` squeezed to `(4,)`); other shapes
+  may not trigger it.
+- `LpNormalization`: fails deep in quantization with an internal exception
+  on a U8-quantized intermediate tensor.
+- `RotaryEmbedding` (native, opset 23): fails even after applying the
+  same "set attributes explicitly" fix confirmed above for `Elu`/
+  `LeakyRelu`/`TopK` (`interleaved=0, rotary_embedding_dim=0` explicit) --
+  genuinely unimplemented, not an attribute-defaulting issue this time.
+  `reconstruct_hf_graph()`'s hand-decomposed RoPE (`Sin`/`Cos`/`Mul`/
+  `Concat`/`Neg`/`Slice`) remains the only working path.
+- `Swish`: a real ONNX op since opset 24 (distinct from the working
+  `HardSwish`/`Silu`), but genuinely unimplemented here (`"Swish, {'alpha':
+  1.0} get opr failed"` even with `alpha` explicit).
+- `InverseSigmoid`: not a real ONNX operator schema (like `Silu`, likely
+  an Axera extension name) -- but unlike `Silu`, fails
+  (`"InverseSigmoid, pyrun failed"`).
+
+**`SpatialTransformer` -- inconclusive, not simply untested.** Also not a
+real ONNX schema. The first attempt (passing `theta` as a graph input
+tensor) failed with a very specific, informative internal error naming
+six *scalar attributes* it expected instead: `theta_1_1` through
+`theta_2_3` (a 2x3 affine matrix baked into the node as six named floats,
+not a runtime tensor -- confirming this op is designed for a compile-time-
+constant spatial transform). Rebuilding with those six attributes set gets
+past that error, but then fails differently (`IndexError('list index out
+of range')`) -- a second real, distinct internal issue, not chased further
+here since this is an exotic, rarely-relevant op for this project's
+CNN/LLM focus.
+
 ## Files
 
 | file | purpose |

--- a/scripts/axera/pulsar2_backend.py
+++ b/scripts/axera/pulsar2_backend.py
@@ -38,13 +38,13 @@ from __future__ import annotations
 from typing import List
 
 import onnx
-
 from pulsar2_ops import (
     AX650_MIN_OPSET,
     BlockingOp,
     below_ax650_min_opset,
     blocking_op_types,
     blocking_ops,
+    confirmed_broken_on_ax650,
     has_out_of_band_npu_data,
     missing_npu_data,
     opset_version,
@@ -107,6 +107,10 @@ def ax650_build_risks(model: onnx.ModelProto) -> List[str]:
 
     - an op type outside `pulsar2_ops.AX650_SUPPORTED_OPS` (confirmed for
       `LRN`: a hard frontend parse failure, not a graceful CPU fallback);
+    - an op type confirmed broken *despite* being listed in
+      `pulsar2_ops.AX650_SUPPORTED_OPS` (`pulsar2_ops.AX650_CONFIRMED_BROKEN_OPS`
+      -- 7 ops confirmed via a real single-node-per-op hardware sweep, see
+      that module's docstring);
     - an opset below `pulsar2_ops.AX650_MIN_OPSET` (11), which Pulsar2's own
       docs state as a hard requirement.
 
@@ -125,6 +129,12 @@ def ax650_build_risks(model: onnx.ModelProto) -> List[str]:
         )
         risks.append(
             f"op type(s) not on the confirmed AX650 op list: {unsupported}{note}"
+        )
+    broken = confirmed_broken_on_ax650(model)
+    for op_type, reason in sorted(broken.items()):
+        risks.append(
+            f"op type {op_type!r} is listed in AX650_SUPPORTED_OPS but "
+            f"confirmed to hard-fail a real build: {reason}"
         )
     if below_ax650_min_opset(model):
         risks.append(

--- a/scripts/axera/pulsar2_ops.py
+++ b/scripts/axera/pulsar2_ops.py
@@ -133,6 +133,23 @@ command/timing):
   initializers -> 0).
 - Both a per-layer file and the post model ran successfully on the real
   AX650N via `axcl_run_model` (~1.5ms and ~9ms respectively).
+
+**Update: systematic single-node-per-op coverage sweep, 29% -> 99%
+(91/92).** A single-node-per-op battery run against a real
+`pulsar2:6.0-lite` build took confirmed coverage of `AX650_SUPPORTED_OPS`
+from 27/92 to 91/92. Most confirmed working; a real, generalizable gotcha
+surfaced along the way (an ONNX attribute left unset to take its schema
+default -- e.g. `Elu.alpha`, `LeakyRelu.alpha`, `TopK.largest`/`sorted` --
+is read as `None` by Pulsar2's frontend and crashes with a confusing
+internal error, not a graceful fallback; setting the same value explicitly
+fixes it). Most importantly for this module: **7 ops confirmed to hard-fail
+despite being listed in `AX650_SUPPORTED_OPS`** -- see
+`AX650_CONFIRMED_BROKEN_OPS` and `confirmed_broken_on_ax650()` below, now
+wired into `pulsar2_backend.ax650_build_risks()` and
+`pulsar2_simulator.partition()` so both flag these correctly instead of
+treating "in AX650_SUPPORTED_OPS" as sufficient. See README.md's
+"Systematic op coverage: from 29% to 99% of AX650_SUPPORTED_OPS" section for
+the full sweep.
 """
 
 from __future__ import annotations
@@ -246,6 +263,38 @@ AX650_SUPPORTED_OPS: frozenset = frozenset(
     }
 )
 
+# Op types that ARE in `AX650_SUPPORTED_OPS` above (i.e. Axera's own docs
+# list them as supported) but that a real `pulsar2:6.0-lite` build was
+# confirmed to hard-fail on anyway, via a single-node-per-op battery run
+# against real hardware -- see README.md's "Systematic op coverage: from 29%
+# to 99% of AX650_SUPPORTED_OPS" section for the full sweep (91/92 ops
+# confirmed; these 7 are the confirmed-broken exceptions). This is a
+# *different* source of truth from `AX650_SUPPORTED_OPS` (docs vs. this
+# project's own real-hardware results) -- kept separate rather than removing
+# these from `AX650_SUPPORTED_OPS`, so that dict continues to mean exactly
+# "what Axera's docs claim." Values are the confirmed real failure mode.
+AX650_CONFIRMED_BROKEN_OPS: Dict[str, str] = {
+    "ConvTranspose": ("real RuntimeError('Op Execution Error...') during quantization"),
+    "Xor": "KeyError('dont support Xor opr in AXOPS/ONNXOPS/CUSTOM_OPS')",
+    "Squeeze": (
+        "internal compiler bug: ZeroDivisionError('division by zero') in "
+        "the NPU backend scheduler (confirmed for a (1,4)->(4,) reshape)"
+    ),
+    "LpNormalization": "internal exception on a U8-quantized intermediate tensor",
+    "RotaryEmbedding": (
+        "fails even with explicit interleaved/rotary_embedding_dim attributes "
+        "-- genuinely unimplemented, not the attribute-defaulting issue below"
+    ),
+    "Swish": (
+        "\"Swish, {'alpha': 1.0} get opr failed\" even with alpha explicit "
+        "-- distinct from the working HardSwish"
+    ),
+    "InverseSigmoid": (
+        "not a real ONNX operator schema (like the working Silu extension "
+        'op), but this name fails: "InverseSigmoid, pyrun failed"'
+    ),
+}
+
 # Confirmed (not guessed) against a real compiled `.axmodel` run on an AX650N:
 # the op_type Pulsar2 gives a node whose contents are an opaque, already
 # NPU-compiled subgraph. Domain stays the plain default ("") -- see this
@@ -355,6 +404,21 @@ def unsupported_on_ax650(model: onnx.ModelProto) -> Set[str]:
         node.op_type
         for node in model.graph.node
         if node.op_type not in AX650_SUPPORTED_OPS and node.op_type != AXERA_NPU_OP_TYPE
+    }
+
+
+def confirmed_broken_on_ax650(model: onnx.ModelProto) -> Dict[str, str]:
+    """Op types in `model` that are confirmed, via real hardware, to fail a
+    real `pulsar2 build` despite being listed in `AX650_SUPPORTED_OPS`.
+
+    Maps each present op type to its confirmed real failure mode (see
+    `AX650_CONFIRMED_BROKEN_OPS`). Unlike `unsupported_on_ax650()`, every hit
+    here is a *confirmed* hard failure, not an "untested" one.
+    """
+    return {
+        node.op_type: AX650_CONFIRMED_BROKEN_OPS[node.op_type]
+        for node in model.graph.node
+        if node.op_type in AX650_CONFIRMED_BROKEN_OPS
     }
 
 

--- a/scripts/axera/pulsar2_simulator.py
+++ b/scripts/axera/pulsar2_simulator.py
@@ -22,9 +22,18 @@ execution provider, this wraps two things that only need `onnx` + `onnxruntime`:
   friends, confirmed proprietary and non-ONNX-Runtime-executable -- see
   `pulsar2_quantizer.py`) or its exact fusion/rounding behavior.
 - Partitioning here is purely per-node op-type membership in
-  `AX650_SUPPORTED_OPS`; it does not model attribute-level limits (e.g.
-  Conv's `auto_pad` must be `NOTSET`) or how Pulsar2 actually groups/merges
-  eligible nodes into subgraphs.
+  `AX650_SUPPORTED_OPS` (minus `AX650_CONFIRMED_BROKEN_OPS`, see below); it
+  does not model attribute-level limits (e.g. Conv's `auto_pad` must be
+  `NOTSET`) or how Pulsar2 actually groups/merges eligible nodes into
+  subgraphs.
+
+**Update, from the 91/92-op real-hardware coverage sweep:** 7 ops listed in
+`AX650_SUPPORTED_OPS` (`ConvTranspose`, `Xor`, `Squeeze`, `LpNormalization`,
+`RotaryEmbedding`, `Swish`, `InverseSigmoid`) are confirmed via real
+`pulsar2 build` to hard-fail anyway -- see
+`pulsar2_ops.AX650_CONFIRMED_BROKEN_OPS`. `partition()` now places these on
+the CPU side (tracked in `Partition.confirmed_broken_op_types`) instead of
+treating docs-list membership alone as NPU-eligible.
 
 Use it to get a fast first read (does this graph look NPU-friendly? is
 onnxsim's simplification likely to change that? roughly how much does INT8
@@ -63,8 +72,12 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 if HERE not in sys.path:
     sys.path.insert(0, HERE)
 
-from pulsar2_ops import AX650_SUPPORTED_OPS, AXERA_NPU_OP_TYPE  # noqa: E402
 import pulsar2_quantizer  # noqa: E402
+from pulsar2_ops import (  # noqa: E402
+    AX650_CONFIRMED_BROKEN_OPS,
+    AX650_SUPPORTED_OPS,
+    AXERA_NPU_OP_TYPE,
+)
 
 _SCRIPTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Only keep scripts/ on sys.path for the duration of this import: scripts/
@@ -99,6 +112,14 @@ class Partition:
     npu_nodes: List[str]
     cpu_nodes: List[str]
     cpu_op_types: Dict[str, int] = field(default_factory=dict)
+    # Subset of `cpu_op_types` that ARE in AX650_SUPPORTED_OPS but were
+    # placed on the CPU side anyway because a real single-node-per-op
+    # hardware sweep confirmed they hard-fail a real build -- see
+    # `pulsar2_ops.AX650_CONFIRMED_BROKEN_OPS`. Surfaced separately from the
+    # rest of `cpu_op_types` (ops never claimed to be supported at all)
+    # since these represent a confirmed gap in the docs-scraped list, not
+    # just an ordinary CPU-fallback op.
+    confirmed_broken_op_types: Dict[str, int] = field(default_factory=dict)
 
     @property
     def npu_node_fraction(self) -> float:
@@ -112,18 +133,32 @@ def partition(model: onnx.ModelProto) -> Partition:
     A node whose op_type is `AXERA_NPU_OP_TYPE` (an already-compiled `neu
     mode` node, e.g. from re-loading a real `.axmodel`) counts as NPU, not
     CPU -- it's already placed, not something left over for the partitioner.
+
+    An op type in `AX650_CONFIRMED_BROKEN_OPS` is placed on the CPU side
+    even though it's also in `AX650_SUPPORTED_OPS`: a real hardware sweep
+    confirmed these hard-fail a real build despite being docs-listed as
+    supported (see `pulsar2_ops.py`'s docstring). Tracked separately in
+    `Partition.confirmed_broken_op_types` so callers can distinguish "not
+    docs-supported" from "docs-supported but confirmed broken."
     """
     npu: List[str] = []
     cpu: List[str] = []
     cpu_types: Dict[str, int] = {}
+    broken_types: Dict[str, int] = {}
     for node in model.graph.node:
         label = node.name or f"<{node.op_type}>"
-        if node.op_type == AXERA_NPU_OP_TYPE or node.op_type in AX650_SUPPORTED_OPS:
+        if node.op_type == AXERA_NPU_OP_TYPE:
+            npu.append(label)
+        elif node.op_type in AX650_CONFIRMED_BROKEN_OPS:
+            cpu.append(label)
+            cpu_types[node.op_type] = cpu_types.get(node.op_type, 0) + 1
+            broken_types[node.op_type] = broken_types.get(node.op_type, 0) + 1
+        elif node.op_type in AX650_SUPPORTED_OPS:
             npu.append(label)
         else:
             cpu.append(label)
             cpu_types[node.op_type] = cpu_types.get(node.op_type, 0) + 1
-    return Partition(npu, cpu, cpu_types)
+    return Partition(npu, cpu, cpu_types, broken_types)
 
 
 def coverage(model: onnx.ModelProto) -> str:

--- a/tests/test_axera_conv_matmul_coverage.py
+++ b/tests/test_axera_conv_matmul_coverage.py
@@ -189,11 +189,31 @@ def test_conv_variants_are_indistinguishable_to_the_heuristic():
     """`partition()` reports full NPU coverage for every plain-float Conv
     shape, regardless of group/dilation/stride/auto_pad/rank -- it only looks
     at `node.op_type`. This is the exact "does not model attribute-level
-    limits" gap `pulsar2_simulator.py`'s own docstring already calls out."""
+    limits" gap `pulsar2_simulator.py`'s own docstring already calls out.
+
+    `conv_transpose` is excluded: `ConvTranspose` is one of the 7 ops
+    confirmed via real hardware to hard-fail despite being listed in
+    `AX650_SUPPORTED_OPS` (`pulsar2_ops.AX650_CONFIRMED_BROKEN_OPS`), so the
+    heuristic now correctly distinguishes it -- see the dedicated test below.
+    """
     for name in _CONV_VARIANTS:
+        if name == "conv_transpose":
+            continue
         model = _build(name)
         assert sim.coverage(model) == "full", name
         assert backend.ax650_build_risks(model) == [], name
+
+
+def test_conv_transpose_is_flagged_as_confirmed_broken():
+    """Unlike the other Conv variants above, `ConvTranspose` IS distinguished
+    by the heuristic now: it's listed in `AX650_SUPPORTED_OPS` but confirmed
+    via real hardware to hard-fail a real build anyway (real
+    `RuntimeError("Op Execution Error...")` during quantization -- see
+    `pulsar2_ops.AX650_CONFIRMED_BROKEN_OPS`)."""
+    model = _build("conv_transpose")
+    assert sim.coverage(model) == "none"
+    risks = backend.ax650_build_risks(model)
+    assert any("ConvTranspose" in r and "confirmed to hard-fail" in r for r in risks)
 
 
 def test_matmul_variants_are_indistinguishable_to_the_heuristic():

--- a/tests/test_axera_op_coverage_hardware.py
+++ b/tests/test_axera_op_coverage_hardware.py
@@ -1,0 +1,298 @@
+"""Real-hardware follow-up to the Conv/MatMul-specific coverage tests:
+widens out to the full 92-op `AX650_SUPPORTED_OPS` list. Compiling a
+single-node-per-op battery through a real `pulsar2 build` took confirmed
+coverage from 27/92 (~29%) to 91/92 (~99%) -- see scripts/axera/README.md's
+"Systematic op coverage: from 29% to 99% of AX650_SUPPORTED_OPS" section
+for the full narrative and the complete pass/fail list.
+
+This file locks in only the most valuable, generalizable, or surprising
+findings from that sweep as real regression tests -- not all 91 confirmed
+ops, which would be a lot of low-value maintenance for simple ops unlikely
+to regress. In particular: a real, generalizable gotcha (Pulsar2 doesn't
+resolve an ONNX attribute's schema default -- it must be set explicitly on
+the node or the build fails with a confusing internal error, not a graceful
+"unsupported" one), a native op newly confirmed useful for future onnxsim
+reconstruction work (RMSNormalization), and a few confirmed-failing ops
+despite being listed in AX650_SUPPORTED_OPS.
+
+Needs a loaded `pulsar2:*` Docker image -- skip-guarded like
+tests/test_pulsar2_hf_to_axmodel.py.
+"""
+
+import os
+import sys
+
+import numpy as np
+import onnx
+import pytest
+from onnx import helper, numpy_helper
+
+_AXERA_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "axera"
+)
+if _AXERA_DIR not in sys.path:
+    sys.path.insert(0, _AXERA_DIR)
+
+import pulsar2_docker  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    not pulsar2_docker.docker_image_available(),
+    reason=f"pulsar2 Docker image not loaded: {pulsar2_docker.DEFAULT_IMAGE}",
+)
+
+
+def _const(name, arr):
+    return numpy_helper.from_array(np.asarray(arr), name=name)
+
+
+def _single_node_model(
+    op_type,
+    node_inputs,
+    node_outputs,
+    out_shapes,
+    initializers=(),
+    attrs=None,
+    opset=17,
+):
+    attrs = attrs or {}
+    node = helper.make_node(op_type, node_inputs, node_outputs, **attrs)
+    graph = helper.make_graph(
+        [node],
+        f"g_{op_type}",
+        [helper.make_tensor_value_info("x", onnx.TensorProto.FLOAT, [1, 4])],
+        [
+            helper.make_tensor_value_info(o, onnx.TensorProto.FLOAT, list(sh))
+            for o, sh in zip(node_outputs, out_shapes)
+        ],
+        initializer=list(initializers),
+    )
+    return helper.make_model(graph, opset_imports=[helper.make_opsetid("", opset)])
+
+
+def _build(tmp_path, name, model):
+    work_dir = os.path.join(str(tmp_path), name)
+    os.makedirs(work_dir, exist_ok=True)
+    onnx.save(model, os.path.join(work_dir, "model.onnx"))
+    rng = np.random.default_rng(0)
+    os.makedirs(os.path.join(work_dir, "dataset"), exist_ok=True)
+    samples = [rng.standard_normal((1, 4)).astype(np.float32) for _ in range(4)]
+    pulsar2_docker.make_numpy_calibration_tar(
+        os.path.join(work_dir, "dataset", "calib_x.tar"), samples
+    )
+    cfg = {
+        "model_type": "ONNX",
+        "npu_mode": "NPU1",
+        "quant": {
+            "input_configs": [
+                {
+                    "tensor_name": "x",
+                    "calibration_dataset": "./dataset/calib_x.tar",
+                    "calibration_format": "Numpy",
+                    "calibration_size": 4,
+                }
+            ],
+            "calibration_method": "MinMax",
+            "precision_analysis": False,
+        },
+        "compiler": {"check": 0},
+    }
+    os.makedirs(os.path.join(work_dir, "config"), exist_ok=True)
+    import json
+
+    with open(os.path.join(work_dir, "config", "cfg.json"), "w") as f:
+        json.dump(cfg, f)
+    return pulsar2_docker.build(
+        work_dir, "model.onnx", "output", config_path="config/cfg.json"
+    )
+
+
+@pytest.mark.parametrize(
+    "op_type,default_attrs,explicit_attrs",
+    [
+        ("Elu", {}, {"alpha": 1.0}),
+        ("LeakyRelu", {}, {"alpha": 0.01}),
+    ],
+)
+def test_unset_default_attribute_crashes_but_explicit_value_compiles(
+    tmp_path, op_type, default_attrs, explicit_attrs
+):
+    """Confirmed real, generalizable gotcha: Pulsar2's frontend does not
+    resolve an ONNX attribute's own schema default when the attribute is
+    left unset on the node -- it reads it as None and crashes with a
+    confusing internal error, not a graceful 'unsupported' one. Setting
+    the exact same default value explicitly fixes it."""
+    model_default = _single_node_model(
+        op_type, ["x"], ["y"], [(1, 4)], attrs=default_attrs
+    )
+    result_default = _build(tmp_path, f"{op_type}_default", model_default)
+    assert not result_default.success
+
+    model_explicit = _single_node_model(
+        op_type, ["x"], ["y"], [(1, 4)], attrs=explicit_attrs
+    )
+    result_explicit = _build(tmp_path, f"{op_type}_explicit", model_explicit)
+    assert result_explicit.success, result_explicit.error
+
+
+def test_topk_unset_largest_sorted_crashes_but_explicit_compiles(tmp_path):
+    k_init = _const("k", np.array([2], dtype=np.int64))
+
+    model_default = _single_node_model(
+        "TopK",
+        ["x", "k"],
+        ["values", "indices"],
+        [(1, 2), (1, 2)],
+        initializers=[k_init],
+        attrs={"axis": 1},
+    )
+    # values/indices have different dtypes; patch indices output dtype
+    model_default.graph.output[1].type.tensor_type.elem_type = onnx.TensorProto.INT64
+    result_default = _build(tmp_path, "topk_default", model_default)
+    assert not result_default.success
+
+    model_explicit = _single_node_model(
+        "TopK",
+        ["x", "k"],
+        ["values", "indices"],
+        [(1, 2), (1, 2)],
+        initializers=[k_init],
+        attrs={"axis": 1, "largest": 1, "sorted": 1},
+    )
+    model_explicit.graph.output[1].type.tensor_type.elem_type = onnx.TensorProto.INT64
+    result_explicit = _build(tmp_path, "topk_explicit", model_explicit)
+    assert result_explicit.success, result_explicit.error
+
+
+def test_rms_normalization_native_op_compiles(tmp_path):
+    """Confirmed real: the native ONNX RMSNormalization op (opset 23)
+    compiles successfully as a single op -- reconstruct_hf_graph()
+    currently hand-decomposes RMSNorm into ReduceMean/Add/Sqrt/Div/Mul
+    instead (written before this op existed in the ONNX opset)."""
+    model = _single_node_model(
+        "RMSNormalization",
+        ["x", "scale"],
+        ["y"],
+        [(1, 4)],
+        initializers=[_const("scale", np.ones(4, dtype=np.float32))],
+        attrs={"axis": -1, "epsilon": 1e-5},
+        opset=23,
+    )
+    model.ir_version = 10
+    onnx.checker.check_model(model)
+    result = _build(tmp_path, "rms_norm", model)
+    assert result.success, result.error
+
+
+def test_silu_nonstandard_op_compiles(tmp_path):
+    """Confirmed real: Silu isn't a real ONNX operator schema at all (no
+    onnx.checker validation possible), but it's a real, working Axera
+    extension op name -- Pulsar2 recognizes it directly. onnxsim should
+    still keep emitting the standard Sigmoid+Mul decomposition for
+    onnxruntime compatibility; this just confirms the raw op works."""
+    model = _single_node_model("Silu", ["x"], ["y"], [(1, 4)])
+    result = _build(tmp_path, "silu_raw", model)
+    assert result.success, result.error
+
+
+@pytest.mark.parametrize("op_type", ["Xor", "Swish"])
+def test_listed_op_fails_as_unimplemented(tmp_path, op_type):
+    """Confirmed real: these are listed in AX650_SUPPORTED_OPS but fail
+    outright on a real build -- a real, confirmed gap between the
+    doc-scraped list and what actually compiles."""
+    if op_type == "Xor":
+        model = _single_node_model(
+            "Xor",
+            ["x", "c"],
+            ["y"],
+            [(1, 4)],
+            initializers=[_const("c", np.ones((4,), dtype=bool))],
+        )
+        model.graph.input[0].type.tensor_type.elem_type = onnx.TensorProto.BOOL
+        model.graph.output[0].type.tensor_type.elem_type = onnx.TensorProto.BOOL
+    else:
+        model = _single_node_model(
+            "Swish", ["x"], ["y"], [(1, 4)], attrs={"alpha": 1.0}, opset=24
+        )
+        model.ir_version = 10
+
+    result = _build(tmp_path, f"{op_type.lower()}_fails", model)
+    assert not result.success
+
+
+def test_rotary_embedding_fails_even_with_explicit_attributes(tmp_path):
+    """Confirmed real: unlike Elu/LeakyRelu/TopK above, setting
+    RotaryEmbedding's optional attributes explicitly (interleaved=0,
+    rotary_embedding_dim=0) does NOT fix it -- genuinely unimplemented,
+    not an attribute-defaulting issue this time.
+    reconstruct_hf_graph()'s hand-decomposed RoPE remains the only working
+    path for real hardware."""
+    batch, num_heads, seq_len, head_dim = 1, 1, 8, 8
+    cos_cache = np.ones((seq_len, head_dim // 2), dtype=np.float32)
+    sin_cache = np.zeros((seq_len, head_dim // 2), dtype=np.float32)
+    node = helper.make_node(
+        "RotaryEmbedding",
+        ["x", "cos_cache", "sin_cache"],
+        ["y"],
+        num_heads=num_heads,
+        interleaved=0,
+        rotary_embedding_dim=0,
+    )
+    graph = helper.make_graph(
+        [node],
+        "g_rope",
+        [
+            helper.make_tensor_value_info(
+                "x", onnx.TensorProto.FLOAT, [batch, num_heads, seq_len, head_dim]
+            )
+        ],
+        [
+            helper.make_tensor_value_info(
+                "y", onnx.TensorProto.FLOAT, [batch, num_heads, seq_len, head_dim]
+            )
+        ],
+        initializer=[_const("cos_cache", cos_cache), _const("sin_cache", sin_cache)],
+    )
+    model = helper.make_model(
+        graph, opset_imports=[helper.make_opsetid("", 23)], ir_version=10
+    )
+    onnx.checker.check_model(model)
+
+    work_dir = tmp_path / "rope_work"
+    work_dir.mkdir()
+    onnx.save(model, str(work_dir / "model.onnx"))
+    rng = np.random.default_rng(0)
+    (work_dir / "dataset").mkdir()
+    samples = [
+        rng.standard_normal((batch, num_heads, seq_len, head_dim)).astype(np.float32)
+        for _ in range(4)
+    ]
+    pulsar2_docker.make_numpy_calibration_tar(
+        str(work_dir / "dataset" / "calib_x.tar"), samples
+    )
+    import json
+
+    cfg = {
+        "model_type": "ONNX",
+        "npu_mode": "NPU1",
+        "quant": {
+            "input_configs": [
+                {
+                    "tensor_name": "x",
+                    "calibration_dataset": "./dataset/calib_x.tar",
+                    "calibration_format": "Numpy",
+                    "calibration_size": 4,
+                }
+            ],
+            "calibration_method": "MinMax",
+            "precision_analysis": False,
+        },
+        "compiler": {"check": 0},
+    }
+    (work_dir / "config").mkdir()
+    with open(work_dir / "config" / "cfg.json", "w") as f:
+        json.dump(cfg, f)
+
+    result = pulsar2_docker.build(
+        str(work_dir), "model.onnx", "output", config_path="config/cfg.json"
+    )
+    assert not result.success

--- a/tests/test_pulsar2_compat.py
+++ b/tests/test_pulsar2_compat.py
@@ -192,3 +192,35 @@ def test_ax650_build_risks_matches_real_conversions():
     risks = pulsar2.ax650_build_risks(old_model)
     assert any("LRN" in r for r in risks)
     assert any("opset 9" in r for r in risks)
+
+
+def test_ax650_build_risks_flags_confirmed_broken_listed_ops():
+    """`Xor` is in AX650_SUPPORTED_OPS (Axera's own docs list it) but a real
+    single-node-per-op hardware sweep confirmed it hard-fails a real build
+    anyway (``KeyError('dont support Xor opr ...')``) -- see
+    ``pulsar2_ops.AX650_CONFIRMED_BROKEN_OPS``. `ax650_build_risks()` must
+    flag this even though `Xor` would pass the plain docs-list check.
+    """
+    import onnx
+    from onnx import TensorProto, helper
+
+    xor_node = helper.make_node("Xor", ["x", "y"], ["z"])
+    graph = helper.make_graph(
+        [xor_node],
+        "confirmed_broken_xor",
+        [
+            helper.make_tensor_value_info("x", TensorProto.BOOL, [1, 4]),
+            helper.make_tensor_value_info("y", TensorProto.BOOL, [1, 4]),
+        ],
+        [helper.make_tensor_value_info("z", TensorProto.BOOL, [1, 4])],
+    )
+    model = helper.make_model(
+        graph, opset_imports=[helper.make_opsetid("", 18)], ir_version=10
+    )
+    onnx.checker.check_model(model)
+
+    # Not flagged by the plain docs-list check: Xor IS in AX650_SUPPORTED_OPS.
+    assert not pulsar2.unsupported_on_ax650(model)
+
+    risks = pulsar2.ax650_build_risks(model)
+    assert any("Xor" in r and "confirmed to hard-fail" in r for r in risks)

--- a/tests/test_pulsar2_simulator.py
+++ b/tests/test_pulsar2_simulator.py
@@ -86,6 +86,38 @@ def test_partition_flags_control_flow_as_cpu():
     assert sim.coverage(model) == "none"
 
 
+def test_partition_flags_confirmed_broken_listed_ops_as_cpu():
+    """`Xor` is in AX650_SUPPORTED_OPS but confirmed via real hardware to
+    hard-fail a real build anyway (see `pulsar2_ops.AX650_CONFIRMED_BROKEN_OPS`).
+    `partition()` must place it on the CPU side and report it separately in
+    `confirmed_broken_op_types`, not silently count it as NPU-eligible."""
+    import onnx
+    from onnx import TensorProto, helper
+
+    xor_node = helper.make_node("Xor", ["x", "y"], ["z"])
+    graph = helper.make_graph(
+        [xor_node],
+        "confirmed_broken_xor",
+        [
+            helper.make_tensor_value_info("x", TensorProto.BOOL, [1, 4]),
+            helper.make_tensor_value_info("y", TensorProto.BOOL, [1, 4]),
+        ],
+        [helper.make_tensor_value_info("z", TensorProto.BOOL, [1, 4])],
+    )
+    model = helper.make_model(
+        graph, opset_imports=[helper.make_opsetid("", 18)], ir_version=10
+    )
+    onnx.checker.check_model(model)
+
+    assert "Xor" in sim.AX650_SUPPORTED_OPS
+
+    p = sim.partition(model)
+    assert p.cpu_op_types == {"Xor": 1}
+    assert p.confirmed_broken_op_types == {"Xor": 1}
+    assert p.npu_node_fraction == 0.0
+    assert sim.coverage(model) == "none"
+
+
 pytestmark_numeric = pytest.mark.skipif(
     not sim.SIMULATOR_AVAILABLE,
     reason=f"pulsar2 simulator's numeric side unavailable: {sim.unavailable_reason()}",


### PR DESCRIPTION


## Update: wire these findings into the static simulator

The 7 confirmed-broken-despite-listed ops above were only recorded as narrative + hardware-gated tests -- the static, no-Docker `pulsar2_simulator.py`/`pulsar2_backend.py` heuristics still treated "in `AX650_SUPPORTED_OPS`" as sufficient and would call these NPU-eligible/risk-free. Added `AX650_CONFIRMED_BROKEN_OPS` + `confirmed_broken_on_ax650()` to `pulsar2_ops.py` (a separate source of truth from the docs-scraped `AX650_SUPPORTED_OPS`, not a replacement for it), wired into `pulsar2_simulator.partition()` (now buckets these as CPU-side, tracked separately in `Partition.confirmed_broken_op_types`) and `pulsar2_backend.ax650_build_risks()` (flags them with their confirmed real failure mode). New static regression tests confirm `Xor`/`ConvTranspose` are now correctly flagged despite being docs-listed.

- [x] `python -m pytest tests/test_pulsar2_compat.py tests/test_pulsar2_simulator.py tests/test_axera_conv_matmul_coverage.py -q` -- 25 passed.
- [x] `ruff check` / `ruff format --check` clean.
