### PR TITLE
Add LayerNorm/RMSNorm pass-through hop to QDQ, FP8, FP4, and Bnb4 chain walkers

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -15451,7 +15451,7 @@ class _QDQConsumer:
 @dataclass(frozen=True)
 class _QDQChain:
     producer: _QDQProducer
-    chain_ops: Tuple[onnx.NodeProto, ...]
+    chain_ops: Tuple[Tuple[onnx.NodeProto, Optional[str]], ...]
     consumer: _QDQConsumer
     n_channels: int
 
@@ -15466,7 +15466,7 @@ class _QDQGatedChain:
 
     producer_a: _QDQProducer
     producer_b: _QDQProducer
-    chain_ops: Tuple[onnx.NodeProto, ...]
+    chain_ops: Tuple[Tuple[onnx.NodeProto, Optional[str]], ...]
     consumer: _QDQConsumer
     n_channels: int
 
@@ -15600,17 +15600,31 @@ def _walk_to_consumer_qdq(
     graph_outputs: Set[str],
     n_channels: int,
     max_hops: int,
-) -> Optional[Tuple[_QDQConsumer, Tuple[onnx.NodeProto, ...]]]:
+    value_info_by_name: Optional[Dict[str, onnx.ValueInfoProto]] = None,
+) -> Optional[Tuple[_QDQConsumer, Tuple[Tuple[onnx.NodeProto, Optional[str]], ...]]]:
     """From tensor `start`, walks forward through shape-preserving unary
-    activations (`_UNARY_PASS_THROUGH`) with no other consumer anywhere
-    along the way, until a same-family (Conv/ConvTranspose-only or
-    MatMul/Gemm-only, matching `is_conv`) consumer is found whose
-    input-channel count matches `n_channels`. No per-channel Add/Mul
-    bias/scale hop, no depthwise Conv pass-through, no branch -- narrower
-    than :func:`_walk_to_consumer`/:func:`_walk_to_conv_consumer` by
-    design, see this section's own top-of-section comment. Returns
-    ``None`` if the walk runs out of hops, hits a branch, or never reaches
-    such a consumer.
+    activations (`_UNARY_PASS_THROUGH`), and -- MatMul/Gemm family only
+    (`not is_conv`; a norm hop is a Linear-adjacent concept, mirroring
+    :func:`_walk_to_conv_consumer`'s own identical restriction of
+    ``GroupNormalization`` to the Conv family, never the other way around)
+    -- a plain `_NORM_PASS_THROUGH_OPS` node whose own `axis` normalizes
+    exactly `cur`'s last axis (see that constant's own comment,
+    :func:`_norm_axis_is_last`, and :func:`_norm_pass_through_const_names`
+    -- mirrors :func:`_walk_to_consumer`'s own identical single-node norm
+    hop), or either of the two *decomposed* pre-opset-17 LayerNorm/RMSNorm
+    node sequences a raw export emits instead of a fused
+    `_NORM_PASS_THROUGH_OPS` node (:func:`_match_decomposed_layer_norm_pass_through`/
+    :func:`_match_decomposed_rms_norm_pass_through`, reused verbatim -- the
+    identical two matchers :func:`_walk_to_consumer`/
+    :func:`_walk_to_matmul_nbits_consumer`/:func:`_walk_to_dynquant_consumer`
+    try) -- with no other consumer anywhere along the way, until a
+    same-family (Conv/ConvTranspose-only or MatMul/Gemm-only, matching
+    `is_conv`) consumer is found whose input-channel count matches
+    `n_channels`. No per-channel Add/Mul bias/scale hop, no depthwise Conv
+    pass-through, no branch -- narrower than
+    :func:`_walk_to_consumer`/:func:`_walk_to_conv_consumer` by design, see
+    this section's own top-of-section comment. Returns ``None`` if the walk
+    runs out of hops, hits a branch, or never reaches such a consumer.
 
     Within the `is_conv` family, a ``Conv`` consumer and a ``ConvTranspose``
     consumer are both tried, in that order, regardless of which one this
@@ -15620,10 +15634,47 @@ def _walk_to_consumer_qdq(
     Conv producer before a ``ConvTranspose`` one, and
     :func:`_walk_to_conv_consumer`, which tries a Conv consumer before a
     ``ConvTranspose`` one, independently of the producer's own family).
+
+    `value_info_by_name`, when given, lets a positive-`axis`
+    `_NORM_PASS_THROUGH_OPS` hop confirm that axis against the tensor's own
+    known rank (:func:`_norm_axis_is_last`), mirroring
+    :func:`_walk_to_consumer`'s own identical parameter. Left ``None``, only
+    the unambiguous ``axis == -1`` case of that hop is still recognized.
     """
-    chain_ops: List[onnx.NodeProto] = []
+    chain_ops: List[Tuple[onnx.NodeProto, Optional[str]]] = []
     cur = start
     for _hop in range(max_hops):
+        if not is_conv:
+            # Tried before the ordinary "exactly one consumer" dispatch
+            # below -- see :func:`_walk_to_matmul_nbits_consumer`'s own
+            # identical hop-0 dispatch for why (a decomposed LayerNorm/
+            # RMSNorm's own root tensor is read *twice*). Declines instantly
+            # whenever `cur` doesn't have exactly two consumers, so this
+            # costs an ordinary hop nothing. Never tried for the Conv
+            # family -- see this function's own docstring.
+            ln_match = _match_decomposed_layer_norm_pass_through(
+                cur,
+                consumers_of,
+                initializer_map,
+                graph_outputs,
+                n_channels,
+                value_info_by_name,
+            )
+            if ln_match is None:
+                ln_match = _match_decomposed_rms_norm_pass_through(
+                    cur,
+                    consumers_of,
+                    initializer_map,
+                    graph_outputs,
+                    n_channels,
+                    value_info_by_name,
+                )
+            if ln_match is not None:
+                ln_out_name, ln_chain_ops = ln_match
+                chain_ops.extend(ln_chain_ops)
+                cur = ln_out_name
+                continue
+
         candidates = consumers_of.get(cur, [])
         if len(candidates) != 1:
             return None
@@ -15652,21 +15703,91 @@ def _walk_to_consumer_qdq(
                     chain_ops
                 )
 
-        if not (
+        const_name: Optional[str] = None
+        extra_const_name: Optional[str] = None
+        if (
             nxt.op_type in _UNARY_PASS_THROUGH
             and list(nxt.input) == [cur]
             and len(nxt.output) == 1
         ):
+            pass
+        elif not is_conv and nxt.op_type in _NORM_PASS_THROUGH_OPS and nxt.domain == "":
+            if not nxt.input or nxt.input[0] != cur:
+                return None
+            if not _norm_axis_is_last(nxt, cur, value_info_by_name):
+                return None
+            names = _norm_pass_through_const_names(nxt, initializer_map)
+            if names is None:
+                return None
+            scale_name, bias_name = names
+            if initializer_map[scale_name].dims[-1] != n_channels:
+                return None
+            if (
+                bias_name is not None
+                and initializer_map[bias_name].dims[-1] != n_channels
+            ):
+                return None
+            # Training-only secondary outputs -- see :func:`_walk_to_consumer`'s
+            # own identical check on this same hop for why a consumed one is
+            # declined here.
+            if any(
+                nxt.output[i]
+                and (consumers_of.get(nxt.output[i]) or nxt.output[i] in graph_outputs)
+                for i in range(1, len(nxt.output))
+            ):
+                return None
+            const_name = scale_name
+            extra_const_name = bias_name
+        else:
             return None
+
         out2 = nxt.output[0]
-        if len(consumers_of.get(out2, [])) != 1 or out2 in graph_outputs:
+        if out2 in graph_outputs:
             return None
-        chain_ops.append(nxt)
-        cur = out2
+        # See :func:`_walk_to_matmul_nbits_consumer`'s own identical re-check:
+        # `out2` might itself be a decomposed LayerNorm/RMSNorm sequence's own
+        # root (read twice), which the ordinary single-consumer bar below
+        # would otherwise reject before the top-of-loop dispatch ever sees
+        # it. Never applicable for the Conv family.
+        ln_match = None
+        if len(consumers_of.get(out2, [])) != 1:
+            if is_conv:
+                return None
+            ln_match = _match_decomposed_layer_norm_pass_through(
+                out2,
+                consumers_of,
+                initializer_map,
+                graph_outputs,
+                n_channels,
+                value_info_by_name,
+            )
+            if ln_match is None:
+                ln_match = _match_decomposed_rms_norm_pass_through(
+                    out2,
+                    consumers_of,
+                    initializer_map,
+                    graph_outputs,
+                    n_channels,
+                    value_info_by_name,
+                )
+            if ln_match is None:
+                return None
+        chain_ops.append((nxt, const_name))
+        if extra_const_name is not None:
+            chain_ops.append((nxt, extra_const_name))
+        if ln_match is not None:
+            ln_out_name, ln_chain_ops = ln_match
+            chain_ops.extend(ln_chain_ops)
+            cur = ln_out_name
+        else:
+            cur = out2
     return None
 
 
-def _find_qdq_chains(graph: onnx.GraphProto) -> List[_QDQChain]:
+def _find_qdq_chains(
+    graph: onnx.GraphProto,
+    value_info_by_name: Optional[Dict[str, onnx.ValueInfoProto]] = None,
+) -> List[_QDQChain]:
     """The QDQ analogue of :func:`_find_chains`/:func:`_find_conv_chains`,
     restricted to the single-producer/single-consumer/unary-hops-only
     topology :func:`_walk_to_consumer_qdq` matches, and requiring at least
@@ -15677,6 +15798,9 @@ def _find_qdq_chains(graph: onnx.GraphProto) -> List[_QDQChain]:
     ambiguous) a ``ConvTranspose`` producer, mirroring
     :func:`_find_conv_chains`'s own identical producer-matching order for
     the plain-float case.
+
+    `value_info_by_name`, when given, is threaded straight through to
+    :func:`_walk_to_consumer_qdq` -- see its own identical parameter.
     """
     initializer_map = _constant_map(graph)
     consumers_of = _consumers_of(graph)
@@ -15728,6 +15852,7 @@ def _find_qdq_chains(graph: onnx.GraphProto) -> List[_QDQChain]:
             graph_outputs,
             out_channels,
             _MAX_CHAIN_HOPS,
+            value_info_by_name,
         )
         if found is None:
             continue
@@ -15824,7 +15949,10 @@ def _qdq_gated_channel_importance(
     )
 
 
-def _find_qdq_gated_chains(graph: onnx.GraphProto) -> List[_QDQGatedChain]:
+def _find_qdq_gated_chains(
+    graph: onnx.GraphProto,
+    value_info_by_name: Optional[Dict[str, onnx.ValueInfoProto]] = None,
+) -> List[_QDQGatedChain]:
     """The QDQ analogue of :func:`_find_gated_chains`: recognizes the same
     gated (SwiGLU/GeGLU) MatMul/vanilla-Gemm pair -- gate_proj/up_proj
     sharing one input, combined via a plain elementwise ``Mul`` of two
@@ -15843,6 +15971,9 @@ def _find_qdq_gated_chains(graph: onnx.GraphProto) -> List[_QDQGatedChain]:
     activation decomposed into more than one node isn't recognized here
     either, for the identical reason :func:`_find_gated_chains`'s own
     docstring gives -- that block is safely left untouched.
+
+    `value_info_by_name`, when given, is threaded straight through to
+    :func:`_walk_to_consumer_qdq` -- see its own identical parameter.
     """
     initializer_map = _constant_map(graph)
     consumers_of = _consumers_of(graph)
@@ -15941,6 +16072,7 @@ def _find_qdq_gated_chains(graph: onnx.GraphProto) -> List[_QDQGatedChain]:
             graph_outputs,
             n_a,
             _MAX_CHAIN_HOPS,
+            value_info_by_name,
         )
         if found is None:
             continue
@@ -16120,25 +16252,39 @@ def apply_structured_pruning_qdq(
         model = onnx.load(model, load_external_data=False)
     out = onnx.ModelProto()
     out.CopyFrom(model)
+    top_value_info_by_name = _shape_inferred_value_info_by_name(out)
 
     for graph in _iter_subgraphs(out.graph):
-        chains = _find_qdq_chains(graph)
-        gated_chains = _find_qdq_gated_chains(graph)
+        value_info_by_name = (
+            top_value_info_by_name if graph is out.graph else _value_info_by_name(graph)
+        )
+        chains = _find_qdq_chains(graph, value_info_by_name)
+        gated_chains = _find_qdq_gated_chains(graph, value_info_by_name)
         if not chains and not gated_chains:
             continue
 
         initializer_map = _constant_map(graph)
         producer_touched: Set[str] = set()
         consumer_touched: Set[str] = set()
+        const_touched: Set[str] = set()
         stale_value_info: Set[str] = set()
 
         for chain in chains:
             p, c = chain.producer, chain.consumer
             p_key = _weight_ref_key(p.ref)
             c_key = _weight_ref_key(c.ref)
+            consts = {
+                const_name
+                for _, const_name in chain.chain_ops
+                if const_name is not None
+            }
             if p_key == c_key:
                 continue  # degenerate (the same weight in both roles)
-            if p_key in producer_touched or c_key in consumer_touched:
+            if (
+                p_key in producer_touched
+                or c_key in consumer_touched
+                or (consts & const_touched)
+            ):
                 continue  # a shared/tied weight another chain already resized
 
             n = chain.n_channels
@@ -16187,11 +16333,15 @@ def apply_structured_pruning_qdq(
                 _slice_consumer_weight_qdq(
                     c.ref, c.weight_transposed, keep, c.is_conv, c.is_conv_transpose
                 )
+            for _, const_name in chain.chain_ops:
+                if const_name is not None:
+                    _slice_last_axis(initializer_map[const_name], keep)
 
             producer_touched.add(p_key)
             consumer_touched.add(c_key)
+            const_touched.update(consts)
             stale_value_info.add(p.node.output[0])
-            stale_value_info.update(op.output[0] for op in chain.chain_ops)
+            stale_value_info.update(op.output[0] for op, _ in chain.chain_ops)
             if p.ref.qdq is not None:
                 stale_value_info.add(p.ref.qdq.dq_node.output[0])
             elif p.ref.qdq_block is not None:
@@ -16206,12 +16356,18 @@ def apply_structured_pruning_qdq(
             pa_key = _weight_ref_key(pa.ref)
             pb_key = _weight_ref_key(pb.ref)
             c_key = _weight_ref_key(c.ref)
+            gconsts = {
+                const_name
+                for _, const_name in gchain.chain_ops
+                if const_name is not None
+            }
             if pa_key == pb_key or pa_key == c_key or pb_key == c_key:
                 continue  # degenerate (a weight tied across two roles)
             if (
                 pa_key in producer_touched
                 or pb_key in producer_touched
                 or c_key in consumer_touched
+                or (gconsts & const_touched)
             ):
                 continue  # a shared/tied weight another chain already resized
 
@@ -16252,15 +16408,19 @@ def apply_structured_pruning_qdq(
                 _slice_consumer_weight_qdq_block(c.ref.qdq_block, keep, keep_blocks)
             else:
                 _slice_consumer_weight_qdq(c.ref, c.weight_transposed, keep, False)
+            for _, const_name in gchain.chain_ops:
+                if const_name is not None:
+                    _slice_last_axis(initializer_map[const_name], keep)
 
             producer_touched.add(pa_key)
             producer_touched.add(pb_key)
             consumer_touched.add(c_key)
+            const_touched.update(gconsts)
             stale_value_info.add(pa.node.output[0])
             stale_value_info.update(op.output[0] for op in pa.pre_ops)
             stale_value_info.add(pb.node.output[0])
             stale_value_info.update(op.output[0] for op in pb.pre_ops)
-            stale_value_info.update(op.output[0] for op in gchain.chain_ops)
+            stale_value_info.update(op.output[0] for op, _ in gchain.chain_ops)
             for p in (pa, pb):
                 if p.ref.qdq is not None:
                     stale_value_info.add(p.ref.qdq.dq_node.output[0])
@@ -18363,7 +18523,7 @@ def _slice_matmul_bnb4_producer_rows(w: _MatMulBnb4Weight, keep: np.ndarray) -> 
 @dataclass(frozen=True)
 class _MatMulBnb4Chain:
     producer: _MatMulBnb4Weight
-    chain_ops: Tuple[onnx.NodeProto, ...]
+    chain_ops: Tuple[Tuple[onnx.NodeProto, Optional[str]], ...]
     consumer: _PlainMatMulNBitsPeer
     n_channels: int
 
@@ -18375,9 +18535,24 @@ def _walk_to_matmul_bnb4_consumer(
     graph_outputs: Set[str],
     n_channels: int,
     max_hops: int,
-) -> Optional[Tuple[_PlainMatMulNBitsPeer, Tuple[onnx.NodeProto, ...]]]:
+    value_info_by_name: Optional[Dict[str, onnx.ValueInfoProto]] = None,
+) -> Optional[
+    Tuple[_PlainMatMulNBitsPeer, Tuple[Tuple[onnx.NodeProto, Optional[str]], ...]]
+]:
     """From tensor `start` (a ``MatMulBnb4`` producer's own output), walks
-    forward through shape-preserving unary activations (`_UNARY_PASS_THROUGH`)
+    forward through shape-preserving unary activations (`_UNARY_PASS_THROUGH`),
+    a plain `_NORM_PASS_THROUGH_OPS` node whose own `axis` normalizes exactly
+    `cur`'s last axis (see that constant's own comment,
+    :func:`_norm_axis_is_last`, and :func:`_norm_pass_through_const_names`
+    -- mirrors :func:`_walk_to_consumer`'s own identical single-node norm
+    hop), or either of the two *decomposed* pre-opset-17 LayerNorm/RMSNorm
+    node sequences a raw export emits instead of a fused
+    `_NORM_PASS_THROUGH_OPS` node (:func:`_match_decomposed_layer_norm_pass_through`/
+    :func:`_match_decomposed_rms_norm_pass_through`, reused verbatim -- the
+    identical two matchers :func:`_walk_to_matmul_nbits_consumer`/
+    :func:`_walk_to_dynquant_consumer` try, sound here for the identical
+    reason: this op's own `A`/`Y` are always float32/float16/bfloat16,
+    never themselves quantized -- see this section's own top comment) --
     with no other consumer anywhere along the way, until a plain-float
     (directly-constant weight) ``MatMul``/vanilla-``Gemm`` consumer
     (:func:`_match_plain_matmul_nbits_peer` -- reused directly here, fully
@@ -18388,10 +18563,45 @@ def _walk_to_matmul_bnb4_consumer(
     K-axis pruning of a ``MatMulBnb4`` weight remains out of scope. Returns
     ``None`` if the walk runs out of hops, hits a branch, or never reaches
     such a consumer.
+
+    `value_info_by_name`, when given, lets a positive-`axis`
+    `_NORM_PASS_THROUGH_OPS` hop confirm that axis against the tensor's own
+    known rank (:func:`_norm_axis_is_last`), mirroring
+    :func:`_walk_to_matmul_nbits_consumer`'s own identical parameter. Left
+    ``None``, only the unambiguous ``axis == -1`` case of that hop is still
+    recognized.
     """
-    chain_ops: List[onnx.NodeProto] = []
+    chain_ops: List[Tuple[onnx.NodeProto, Optional[str]]] = []
     cur = start
     for _hop in range(max_hops):
+        # Tried before the ordinary "exactly one consumer" dispatch below --
+        # see :func:`_walk_to_matmul_nbits_consumer`'s own identical hop-0
+        # dispatch for why (a decomposed LayerNorm/RMSNorm's own root tensor
+        # is read *twice*). Declines instantly whenever `cur` doesn't have
+        # exactly two consumers, so this costs an ordinary hop nothing.
+        ln_match = _match_decomposed_layer_norm_pass_through(
+            cur,
+            consumers_of,
+            initializer_map,
+            graph_outputs,
+            n_channels,
+            value_info_by_name,
+        )
+        if ln_match is None:
+            ln_match = _match_decomposed_rms_norm_pass_through(
+                cur,
+                consumers_of,
+                initializer_map,
+                graph_outputs,
+                n_channels,
+                value_info_by_name,
+            )
+        if ln_match is not None:
+            ln_out_name, ln_chain_ops = ln_match
+            chain_ops.extend(ln_chain_ops)
+            cur = ln_out_name
+            continue
+
         candidates = consumers_of.get(cur, [])
         if len(candidates) != 1:
             return None
@@ -18404,25 +18614,96 @@ def _walk_to_matmul_bnb4_consumer(
                 return None
             return peer, tuple(chain_ops)
 
-        if not (
+        const_name: Optional[str] = None
+        extra_const_name: Optional[str] = None
+        if (
             nxt.op_type in _UNARY_PASS_THROUGH
             and list(nxt.input) == [cur]
             and len(nxt.output) == 1
         ):
+            pass
+        elif nxt.op_type in _NORM_PASS_THROUGH_OPS and nxt.domain == "":
+            if not nxt.input or nxt.input[0] != cur:
+                return None
+            if not _norm_axis_is_last(nxt, cur, value_info_by_name):
+                return None
+            names = _norm_pass_through_const_names(nxt, initializer_map)
+            if names is None:
+                return None
+            scale_name, bias_name = names
+            if initializer_map[scale_name].dims[-1] != n_channels:
+                return None
+            if (
+                bias_name is not None
+                and initializer_map[bias_name].dims[-1] != n_channels
+            ):
+                return None
+            # Training-only secondary outputs -- see :func:`_walk_to_consumer`'s
+            # own identical check on this same hop for why a consumed one is
+            # declined here.
+            if any(
+                nxt.output[i]
+                and (consumers_of.get(nxt.output[i]) or nxt.output[i] in graph_outputs)
+                for i in range(1, len(nxt.output))
+            ):
+                return None
+            const_name = scale_name
+            extra_const_name = bias_name
+        else:
             return None
+
         out2 = nxt.output[0]
-        if len(consumers_of.get(out2, [])) != 1 or out2 in graph_outputs:
+        if out2 in graph_outputs:
             return None
-        chain_ops.append(nxt)
-        cur = out2
+        # See :func:`_walk_to_matmul_nbits_consumer`'s own identical
+        # re-check: `out2` might itself be a decomposed LayerNorm/RMSNorm
+        # sequence's own root (read twice), which the ordinary
+        # single-consumer bar below would otherwise reject before the
+        # top-of-loop dispatch ever sees it.
+        ln_match = None
+        if len(consumers_of.get(out2, [])) != 1:
+            ln_match = _match_decomposed_layer_norm_pass_through(
+                out2,
+                consumers_of,
+                initializer_map,
+                graph_outputs,
+                n_channels,
+                value_info_by_name,
+            )
+            if ln_match is None:
+                ln_match = _match_decomposed_rms_norm_pass_through(
+                    out2,
+                    consumers_of,
+                    initializer_map,
+                    graph_outputs,
+                    n_channels,
+                    value_info_by_name,
+                )
+            if ln_match is None:
+                return None
+        chain_ops.append((nxt, const_name))
+        if extra_const_name is not None:
+            chain_ops.append((nxt, extra_const_name))
+        if ln_match is not None:
+            ln_out_name, ln_chain_ops = ln_match
+            chain_ops.extend(ln_chain_ops)
+            cur = ln_out_name
+        else:
+            cur = out2
     return None
 
 
-def _find_matmul_bnb4_chains(graph: onnx.GraphProto) -> List[_MatMulBnb4Chain]:
+def _find_matmul_bnb4_chains(
+    graph: onnx.GraphProto,
+    value_info_by_name: Optional[Dict[str, onnx.ValueInfoProto]] = None,
+) -> List[_MatMulBnb4Chain]:
     """Every ``MatMulBnb4`` producer -> [unary hops] -> plain-float consumer
     pair :func:`_walk_to_matmul_bnb4_consumer` connects -- see this section's
     own top comment for why the consumer side is always plain-float (never
     another ``MatMulBnb4``/``MatMulNBits`` node).
+
+    `value_info_by_name`, when given, is threaded straight through to
+    :func:`_walk_to_matmul_bnb4_consumer` -- see its own identical parameter.
     """
     initializer_map = _constant_map(graph)
     consumers_of = _consumers_of(graph)
@@ -18446,6 +18727,7 @@ def _find_matmul_bnb4_chains(graph: onnx.GraphProto) -> List[_MatMulBnb4Chain]:
             graph_outputs,
             producer.N,
             _MAX_CHAIN_HOPS,
+            value_info_by_name,
         )
         if found is None:
             continue
@@ -18511,20 +18793,35 @@ def apply_structured_pruning_matmul_bnb4(
         model = onnx.load(model, load_external_data=False)
     out = onnx.ModelProto()
     out.CopyFrom(model)
+    top_value_info_by_name = _shape_inferred_value_info_by_name(out)
 
     for graph in _iter_subgraphs(out.graph):
-        chains = _find_matmul_bnb4_chains(graph)
+        value_info_by_name = (
+            top_value_info_by_name if graph is out.graph else _value_info_by_name(graph)
+        )
+        initializer_map = _constant_map(graph)
+        chains = _find_matmul_bnb4_chains(graph, value_info_by_name)
         if not chains:
             continue
 
         producer_touched: Set[str] = set()
         consumer_touched: Set[str] = set()
+        const_touched: Set[str] = set()
         stale_value_info: Set[str] = set()
 
         for chain in chains:
             p, c = chain.producer, chain.consumer
             p_key, c_key = p.b_init.name, c.w_init.name
-            if p_key in producer_touched or c_key in consumer_touched:
+            consts = {
+                const_name
+                for _, const_name in chain.chain_ops
+                if const_name is not None
+            }
+            if (
+                p_key in producer_touched
+                or c_key in consumer_touched
+                or (consts & const_touched)
+            ):
                 continue  # a shared/tied weight another chain already resized
 
             n = chain.n_channels
@@ -18543,11 +18840,15 @@ def apply_structured_pruning_matmul_bnb4(
 
             _slice_matmul_bnb4_producer_rows(p, keep)
             _slice_consumer_weight(c.w_init, c.weight_transposed, keep, is_conv=False)
+            for _, const_name in chain.chain_ops:
+                if const_name is not None:
+                    _slice_last_axis(initializer_map[const_name], keep)
 
             producer_touched.add(p_key)
             consumer_touched.add(c_key)
+            const_touched.update(consts)
             stale_value_info.add(p.node.output[0])
-            stale_value_info.update(op.output[0] for op in chain.chain_ops)
+            stale_value_info.update(op.output[0] for op, _ in chain.chain_ops)
 
         if stale_value_info:
             kept = [vi for vi in graph.value_info if vi.name not in stale_value_info]
@@ -31539,7 +31840,7 @@ def _slice_fp4_chain_consumer(side: _Fp4ChainSide, keep: np.ndarray) -> None:
 @dataclass(frozen=True)
 class _BlockQuantizedFp8Chain:
     producer: _Fp8ChainSide
-    chain_ops: Tuple[onnx.NodeProto, ...]
+    chain_ops: Tuple[Tuple[onnx.NodeProto, Optional[str]], ...]
     consumer: _Fp8ChainSide
     n_channels: int
 
@@ -31547,7 +31848,7 @@ class _BlockQuantizedFp8Chain:
 @dataclass(frozen=True)
 class _BlockQuantizedFp4Chain:
     producer: _Fp4ChainSide
-    chain_ops: Tuple[onnx.NodeProto, ...]
+    chain_ops: Tuple[Tuple[onnx.NodeProto, Optional[str]], ...]
     consumer: _Fp4ChainSide
     n_channels: int
 
@@ -31559,18 +31860,69 @@ def _walk_to_fp8_consumer(
     graph_outputs: Set[str],
     n_channels: int,
     max_hops: int,
-) -> Optional[Tuple[_Fp8ChainSide, Tuple[onnx.NodeProto, ...]]]:
+    value_info_by_name: Optional[Dict[str, onnx.ValueInfoProto]] = None,
+) -> Optional[Tuple[_Fp8ChainSide, Tuple[Tuple[onnx.NodeProto, Optional[str]], ...]]]:
     """Mirrors :func:`_walk_to_matmul_nbits_consumer`: from tensor `start`,
-    walks forward through shape-preserving unary activations with no other
-    consumer anywhere along the way, until EITHER a
-    ``MatMulBlockQuantizedFp8Weight`` consumer OR a plain-float
-    MatMul/vanilla-Gemm consumer is found whose input-channel count matches
-    `n_channels`. No gated pair, no branch, never a ``Fp4Weight``/
-    ``MatMulNBits``/QDQ consumer (see this section's own top comment).
+    walks forward through shape-preserving unary activations, a plain
+    `_NORM_PASS_THROUGH_OPS` node whose own `axis` normalizes exactly
+    `cur`'s last axis (see that constant's own comment,
+    :func:`_norm_axis_is_last`, and :func:`_norm_pass_through_const_names`
+    -- mirrors :func:`_walk_to_consumer`'s own identical single-node norm
+    hop), or either of the two *decomposed* pre-opset-17 LayerNorm/RMSNorm
+    node sequences a raw export emits instead of a fused
+    `_NORM_PASS_THROUGH_OPS` node (:func:`_match_decomposed_layer_norm_pass_through`/
+    :func:`_match_decomposed_rms_norm_pass_through`, reused verbatim -- the
+    identical two matchers :func:`_walk_to_matmul_nbits_consumer`/
+    :func:`_walk_to_dynquant_consumer` try) -- both sound here exactly as
+    they are for those two weight-only-quantized walkers, this op's own `A`/
+    `Y` staying float16/bfloat16 throughout, never itself quantized (unlike
+    the QOperator family's own fully-activation-quantized int8/uint8 `Y` --
+    see :func:`_walk_to_qop_consumer`'s own docstring for why that walker is
+    the one exception in this round) -- with no other consumer anywhere
+    along the way, until EITHER a ``MatMulBlockQuantizedFp8Weight`` consumer
+    OR a plain-float MatMul/vanilla-Gemm consumer is found whose
+    input-channel count matches `n_channels`. No gated pair, no branch,
+    never a ``Fp4Weight``/``MatMulNBits``/QDQ consumer (see this section's
+    own top comment).
+
+    `value_info_by_name`, when given, lets a positive-`axis`
+    `_NORM_PASS_THROUGH_OPS` hop confirm that axis against the tensor's own
+    known rank (:func:`_norm_axis_is_last`), mirroring
+    :func:`_walk_to_matmul_nbits_consumer`'s own identical parameter. Left
+    ``None``, only the unambiguous ``axis == -1`` case of that hop is still
+    recognized.
     """
-    chain_ops: List[onnx.NodeProto] = []
+    chain_ops: List[Tuple[onnx.NodeProto, Optional[str]]] = []
     cur = start
     for _hop in range(max_hops):
+        # Tried before the ordinary "exactly one consumer" dispatch below --
+        # see :func:`_walk_to_matmul_nbits_consumer`'s own identical hop-0
+        # dispatch for why (a decomposed LayerNorm/RMSNorm's own root tensor
+        # is read *twice*). Declines instantly whenever `cur` doesn't have
+        # exactly two consumers, so this costs an ordinary hop nothing.
+        ln_match = _match_decomposed_layer_norm_pass_through(
+            cur,
+            consumers_of,
+            initializer_map,
+            graph_outputs,
+            n_channels,
+            value_info_by_name,
+        )
+        if ln_match is None:
+            ln_match = _match_decomposed_rms_norm_pass_through(
+                cur,
+                consumers_of,
+                initializer_map,
+                graph_outputs,
+                n_channels,
+                value_info_by_name,
+            )
+        if ln_match is not None:
+            ln_out_name, ln_chain_ops = ln_match
+            chain_ops.extend(ln_chain_ops)
+            cur = ln_out_name
+            continue
+
         candidates = consumers_of.get(cur, [])
         if len(candidates) != 1:
             return None
@@ -31594,17 +31946,82 @@ def _walk_to_fp8_consumer(
                 return None
             return peer, tuple(chain_ops)
 
-        if not (
+        const_name: Optional[str] = None
+        extra_const_name: Optional[str] = None
+        if (
             nxt.op_type in _UNARY_PASS_THROUGH
             and list(nxt.input) == [cur]
             and len(nxt.output) == 1
         ):
+            pass
+        elif nxt.op_type in _NORM_PASS_THROUGH_OPS and nxt.domain == "":
+            if not nxt.input or nxt.input[0] != cur:
+                return None
+            if not _norm_axis_is_last(nxt, cur, value_info_by_name):
+                return None
+            names = _norm_pass_through_const_names(nxt, initializer_map)
+            if names is None:
+                return None
+            scale_name, bias_name = names
+            if initializer_map[scale_name].dims[-1] != n_channels:
+                return None
+            if (
+                bias_name is not None
+                and initializer_map[bias_name].dims[-1] != n_channels
+            ):
+                return None
+            # Training-only secondary outputs -- see :func:`_walk_to_consumer`'s
+            # own identical check on this same hop for why a consumed one is
+            # declined here.
+            if any(
+                nxt.output[i]
+                and (consumers_of.get(nxt.output[i]) or nxt.output[i] in graph_outputs)
+                for i in range(1, len(nxt.output))
+            ):
+                return None
+            const_name = scale_name
+            extra_const_name = bias_name
+        else:
             return None
+
         out2 = nxt.output[0]
-        if len(consumers_of.get(out2, [])) != 1 or out2 in graph_outputs:
+        if out2 in graph_outputs:
             return None
-        chain_ops.append(nxt)
-        cur = out2
+        # See :func:`_walk_to_matmul_nbits_consumer`'s own identical
+        # re-check: `out2` might itself be a decomposed LayerNorm/RMSNorm
+        # sequence's own root (read twice), which the ordinary
+        # single-consumer bar below would otherwise reject before the
+        # top-of-loop dispatch ever sees it.
+        ln_match = None
+        if len(consumers_of.get(out2, [])) != 1:
+            ln_match = _match_decomposed_layer_norm_pass_through(
+                out2,
+                consumers_of,
+                initializer_map,
+                graph_outputs,
+                n_channels,
+                value_info_by_name,
+            )
+            if ln_match is None:
+                ln_match = _match_decomposed_rms_norm_pass_through(
+                    out2,
+                    consumers_of,
+                    initializer_map,
+                    graph_outputs,
+                    n_channels,
+                    value_info_by_name,
+                )
+            if ln_match is None:
+                return None
+        chain_ops.append((nxt, const_name))
+        if extra_const_name is not None:
+            chain_ops.append((nxt, extra_const_name))
+        if ln_match is not None:
+            ln_out_name, ln_chain_ops = ln_match
+            chain_ops.extend(ln_chain_ops)
+            cur = ln_out_name
+        else:
+            cur = out2
     return None
 
 
@@ -31615,13 +32032,38 @@ def _walk_to_fp4_consumer(
     graph_outputs: Set[str],
     n_channels: int,
     max_hops: int,
-) -> Optional[Tuple[_Fp4ChainSide, Tuple[onnx.NodeProto, ...]]]:
+    value_info_by_name: Optional[Dict[str, onnx.ValueInfoProto]] = None,
+) -> Optional[Tuple[_Fp4ChainSide, Tuple[Tuple[onnx.NodeProto, Optional[str]], ...]]]:
     """``Fp4Weight`` analogue of :func:`_walk_to_fp8_consumer` -- see that
-    function's own docstring.
+    function's own docstring, including its identical norm-hop recognition
+    and `value_info_by_name` parameter.
     """
-    chain_ops: List[onnx.NodeProto] = []
+    chain_ops: List[Tuple[onnx.NodeProto, Optional[str]]] = []
     cur = start
     for _hop in range(max_hops):
+        ln_match = _match_decomposed_layer_norm_pass_through(
+            cur,
+            consumers_of,
+            initializer_map,
+            graph_outputs,
+            n_channels,
+            value_info_by_name,
+        )
+        if ln_match is None:
+            ln_match = _match_decomposed_rms_norm_pass_through(
+                cur,
+                consumers_of,
+                initializer_map,
+                graph_outputs,
+                n_channels,
+                value_info_by_name,
+            )
+        if ln_match is not None:
+            ln_out_name, ln_chain_ops = ln_match
+            chain_ops.extend(ln_chain_ops)
+            cur = ln_out_name
+            continue
+
         candidates = consumers_of.get(cur, [])
         if len(candidates) != 1:
             return None
@@ -31645,27 +32087,88 @@ def _walk_to_fp4_consumer(
                 return None
             return peer, tuple(chain_ops)
 
-        if not (
+        const_name: Optional[str] = None
+        extra_const_name: Optional[str] = None
+        if (
             nxt.op_type in _UNARY_PASS_THROUGH
             and list(nxt.input) == [cur]
             and len(nxt.output) == 1
         ):
+            pass
+        elif nxt.op_type in _NORM_PASS_THROUGH_OPS and nxt.domain == "":
+            if not nxt.input or nxt.input[0] != cur:
+                return None
+            if not _norm_axis_is_last(nxt, cur, value_info_by_name):
+                return None
+            names = _norm_pass_through_const_names(nxt, initializer_map)
+            if names is None:
+                return None
+            scale_name, bias_name = names
+            if initializer_map[scale_name].dims[-1] != n_channels:
+                return None
+            if (
+                bias_name is not None
+                and initializer_map[bias_name].dims[-1] != n_channels
+            ):
+                return None
+            if any(
+                nxt.output[i]
+                and (consumers_of.get(nxt.output[i]) or nxt.output[i] in graph_outputs)
+                for i in range(1, len(nxt.output))
+            ):
+                return None
+            const_name = scale_name
+            extra_const_name = bias_name
+        else:
             return None
+
         out2 = nxt.output[0]
-        if len(consumers_of.get(out2, [])) != 1 or out2 in graph_outputs:
+        if out2 in graph_outputs:
             return None
-        chain_ops.append(nxt)
-        cur = out2
+        ln_match = None
+        if len(consumers_of.get(out2, [])) != 1:
+            ln_match = _match_decomposed_layer_norm_pass_through(
+                out2,
+                consumers_of,
+                initializer_map,
+                graph_outputs,
+                n_channels,
+                value_info_by_name,
+            )
+            if ln_match is None:
+                ln_match = _match_decomposed_rms_norm_pass_through(
+                    out2,
+                    consumers_of,
+                    initializer_map,
+                    graph_outputs,
+                    n_channels,
+                    value_info_by_name,
+                )
+            if ln_match is None:
+                return None
+        chain_ops.append((nxt, const_name))
+        if extra_const_name is not None:
+            chain_ops.append((nxt, extra_const_name))
+        if ln_match is not None:
+            ln_out_name, ln_chain_ops = ln_match
+            chain_ops.extend(ln_chain_ops)
+            cur = ln_out_name
+        else:
+            cur = out2
     return None
 
 
 def _find_fp8_block_quantized_chains(
     graph: onnx.GraphProto,
+    value_info_by_name: Optional[Dict[str, onnx.ValueInfoProto]] = None,
 ) -> List[_BlockQuantizedFp8Chain]:
     """Mirrors :func:`_find_matmul_nbits_chains`: every producer/consumer
     pair connected by :func:`_walk_to_fp8_consumer` where AT LEAST ONE side
     is a ``MatMulBlockQuantizedFp8Weight`` node (a plain-float-to-plain-
     float pair is :func:`apply_structured_pruning`'s own job).
+
+    `value_info_by_name`, when given, is threaded straight through to
+    :func:`_walk_to_fp8_consumer` -- see its own identical parameter.
     """
     initializer_map = _constant_map(graph)
     consumers_of = _consumers_of(graph)
@@ -31702,6 +32205,7 @@ def _find_fp8_block_quantized_chains(
             graph_outputs,
             n_channels,
             _MAX_CHAIN_HOPS,
+            value_info_by_name,
         )
         if found is None:
             continue
@@ -31718,6 +32222,7 @@ def _find_fp8_block_quantized_chains(
 
 def _find_fp4_block_quantized_chains(
     graph: onnx.GraphProto,
+    value_info_by_name: Optional[Dict[str, onnx.ValueInfoProto]] = None,
 ) -> List[_BlockQuantizedFp4Chain]:
     """``Fp4Weight`` analogue of :func:`_find_fp8_block_quantized_chains`."""
     initializer_map = _constant_map(graph)
@@ -31755,6 +32260,7 @@ def _find_fp4_block_quantized_chains(
             graph_outputs,
             n_channels,
             _MAX_CHAIN_HOPS,
+            value_info_by_name,
         )
         if found is None:
             continue
@@ -31828,23 +32334,38 @@ def apply_structured_pruning_matmul_block_quantized_fp8(
         model = onnx.load(model, load_external_data=False)
     out = onnx.ModelProto()
     out.CopyFrom(model)
+    top_value_info_by_name = _shape_inferred_value_info_by_name(out)
 
     for graph in _iter_subgraphs(out.graph):
-        chains = _find_fp8_block_quantized_chains(graph)
+        value_info_by_name = (
+            top_value_info_by_name if graph is out.graph else _value_info_by_name(graph)
+        )
+        initializer_map = _constant_map(graph)
+        chains = _find_fp8_block_quantized_chains(graph, value_info_by_name)
         if not chains:
             continue
 
         producer_touched: Set[str] = set()
         consumer_touched: Set[str] = set()
+        const_touched: Set[str] = set()
         stale_value_info: Set[str] = set()
 
         for chain in chains:
             p, c = chain.producer, chain.consumer
             p_key = _fp8_chain_side_key(p)
             c_key = _fp8_chain_side_key(c)
+            consts = {
+                const_name
+                for _, const_name in chain.chain_ops
+                if const_name is not None
+            }
             if p_key == c_key:
                 continue  # degenerate (the same weight in both roles)
-            if p_key in producer_touched or c_key in consumer_touched:
+            if (
+                p_key in producer_touched
+                or c_key in consumer_touched
+                or (consts & const_touched)
+            ):
                 continue  # a shared/tied weight another chain already resized
 
             n = chain.n_channels
@@ -31873,11 +32394,15 @@ def apply_structured_pruning_matmul_block_quantized_fp8(
 
             _slice_fp8_chain_producer(p, keep)
             _slice_fp8_chain_consumer(c, consumer_keep)
+            for _, const_name in chain.chain_ops:
+                if const_name is not None:
+                    _slice_last_axis(initializer_map[const_name], keep)
 
             producer_touched.add(p_key)
             consumer_touched.add(c_key)
+            const_touched.update(consts)
             stale_value_info.add(p.node.output[0])
-            stale_value_info.update(op.output[0] for op in chain.chain_ops)
+            stale_value_info.update(op.output[0] for op, _ in chain.chain_ops)
 
         if stale_value_info:
             kept = [vi for vi in graph.value_info if vi.name not in stale_value_info]
@@ -31923,23 +32448,38 @@ def apply_structured_pruning_matmul_block_quantized_fp4(
         model = onnx.load(model, load_external_data=False)
     out = onnx.ModelProto()
     out.CopyFrom(model)
+    top_value_info_by_name = _shape_inferred_value_info_by_name(out)
 
     for graph in _iter_subgraphs(out.graph):
-        chains = _find_fp4_block_quantized_chains(graph)
+        value_info_by_name = (
+            top_value_info_by_name if graph is out.graph else _value_info_by_name(graph)
+        )
+        initializer_map = _constant_map(graph)
+        chains = _find_fp4_block_quantized_chains(graph, value_info_by_name)
         if not chains:
             continue
 
         producer_touched: Set[str] = set()
         consumer_touched: Set[str] = set()
+        const_touched: Set[str] = set()
         stale_value_info: Set[str] = set()
 
         for chain in chains:
             p, c = chain.producer, chain.consumer
             p_key = _fp4_chain_side_key(p)
             c_key = _fp4_chain_side_key(c)
+            consts = {
+                const_name
+                for _, const_name in chain.chain_ops
+                if const_name is not None
+            }
             if p_key == c_key:
                 continue
-            if p_key in producer_touched or c_key in consumer_touched:
+            if (
+                p_key in producer_touched
+                or c_key in consumer_touched
+                or (consts & const_touched)
+            ):
                 continue
 
             n = chain.n_channels
@@ -31963,11 +32503,15 @@ def apply_structured_pruning_matmul_block_quantized_fp4(
 
             _slice_fp4_chain_producer(p, keep)
             _slice_fp4_chain_consumer(c, consumer_keep)
+            for _, const_name in chain.chain_ops:
+                if const_name is not None:
+                    _slice_last_axis(initializer_map[const_name], keep)
 
             producer_touched.add(p_key)
             consumer_touched.add(c_key)
+            const_touched.update(consts)
             stale_value_info.add(p.node.output[0])
-            stale_value_info.update(op.output[0] for op in chain.chain_ops)
+            stale_value_info.update(op.output[0] for op, _ in chain.chain_ops)
 
         if stale_value_info:
             kept = [vi for vi in graph.value_info if vi.name not in stale_value_info]
@@ -32716,6 +33260,38 @@ def _walk_to_qop_consumer(
     -- see this section's own top comment for why no `Flatten`/`Reshape`
     cross-family hop is recognized. Returns ``None`` if the walk runs out of
     hops, hits a branch, or never reaches such a consumer.
+
+    UNLIKE :func:`_walk_to_consumer_qdq`/:func:`_walk_to_dynquant_consumer`/
+    :func:`_walk_to_matmul_nbits_consumer`, this walker deliberately does
+    NOT recognize a `_NORM_PASS_THROUGH_OPS` (LayerNorm/RMSNorm) mid-chain
+    hop, even on the MatMul/Gemm family -- confirmed live via
+    ``onnx.defs.get_schema("QLinearMatMul")``/``get_schema("QLinearConv")``
+    and ``onnxruntime``'s own ``QGemm`` schema: unlike every other
+    quantized-MatMul-chain walker in this module (all of them weight-only
+    quantization, `A` and the compute op's own output staying float/float16/
+    bfloat16 throughout), a QOperator producer's OWN OUTPUT tensor `Y`
+    shares its `y_zero_point` operand's int8/uint8 type constraint -- this
+    is a genuinely, fully activation-quantized scheme, not merely a
+    quantized weight feeding a float MatMul. `cur` at this walk's every hop
+    is therefore an int8/uint8 tensor, and `_NORM_PASS_THROUGH_OPS`'s three
+    ops (`LayerNormalization`/`RMSNormalization`/
+    `SimplifiedLayerNormalization`) all require a float-family `X`input per
+    their own live schemas -- a real exporter emitting a norm between two
+    QOperator nodes must always sandwich it behind its own
+    ``DequantizeLinear``/``QuantizeLinear`` pair (confirmed against
+    ``onnxruntime.quantization``'s own static-quantization behavior around
+    an unquantized op), never feed the norm the raw quantized tensor
+    directly -- so the exact same single-node hop the other four walkers
+    added would be unreachable dead code here (no valid ONNX graph could
+    ever trigger it: onnx.checker's own type-constraint validation, and
+    onnxruntime's own kernel lookup, both reject a `LayerNormalization`
+    consuming an int8/uint8 input outright), not a narrower-but-sound
+    version of the same fix. Recognizing the REAL topology -- hopping
+    through a `DequantizeLinear`/`QuantizeLinear` pair around the norm --
+    would need a new pass-through primitive this round's own scope
+    (mechanical reuse of the already-merged norm hop, no new matching logic)
+    deliberately excludes; left as a known, separately-scoped gap rather
+    than an unsound fit forced into this walker.
     """
     chain_ops: List[onnx.NodeProto] = []
     cur = start
@@ -38347,12 +38923,18 @@ def _analyze_structured_pruning_qdq(
     if isinstance(model, str):
         model = onnx.load(model, load_external_data=False)
 
+    top_value_info_by_name = _shape_inferred_value_info_by_name(model)
     layers: List[PruningLayerSensitivity] = []
     not_eligible: List[str] = []
 
     for graph in _iter_subgraphs(model.graph):
-        chains = _find_qdq_chains(graph)
-        gated_chains = _find_qdq_gated_chains(graph)
+        value_info_by_name = (
+            top_value_info_by_name
+            if graph is model.graph
+            else _value_info_by_name(graph)
+        )
+        chains = _find_qdq_chains(graph, value_info_by_name)
+        gated_chains = _find_qdq_gated_chains(graph, value_info_by_name)
         not_eligible.extend(_qdq_not_eligible(graph, chains, gated_chains))
         if not chains and not gated_chains:
             continue
@@ -38967,11 +39549,17 @@ def _analyze_structured_pruning_matmul_bnb4(
     if isinstance(model, str):
         model = onnx.load(model, load_external_data=False)
 
+    top_value_info_by_name = _shape_inferred_value_info_by_name(model)
     layers: List[PruningLayerSensitivity] = []
     not_eligible: List[str] = []
 
     for graph in _iter_subgraphs(model.graph):
-        chains = _find_matmul_bnb4_chains(graph)
+        value_info_by_name = (
+            top_value_info_by_name
+            if graph is model.graph
+            else _value_info_by_name(graph)
+        )
+        chains = _find_matmul_bnb4_chains(graph, value_info_by_name)
         not_eligible.extend(_matmul_bnb4_not_eligible(graph, chains))
         if not chains:
             continue
@@ -40443,11 +41031,17 @@ def _analyze_structured_pruning_matmul_block_quantized_fp8(
     if isinstance(model, str):
         model = onnx.load(model, load_external_data=False)
 
+    top_value_info_by_name = _shape_inferred_value_info_by_name(model)
     layers: List[PruningLayerSensitivity] = []
     not_eligible: List[str] = []
 
     for graph in _iter_subgraphs(model.graph):
-        chains = _find_fp8_block_quantized_chains(graph)
+        value_info_by_name = (
+            top_value_info_by_name
+            if graph is model.graph
+            else _value_info_by_name(graph)
+        )
+        chains = _find_fp8_block_quantized_chains(graph, value_info_by_name)
         not_eligible.extend(_block_quantized_fp8_not_eligible(graph, chains))
         if not chains:
             continue
@@ -40563,11 +41157,17 @@ def _analyze_structured_pruning_matmul_block_quantized_fp4(
     if isinstance(model, str):
         model = onnx.load(model, load_external_data=False)
 
+    top_value_info_by_name = _shape_inferred_value_info_by_name(model)
     layers: List[PruningLayerSensitivity] = []
     not_eligible: List[str] = []
 
     for graph in _iter_subgraphs(model.graph):
-        chains = _find_fp4_block_quantized_chains(graph)
+        value_info_by_name = (
+            top_value_info_by_name
+            if graph is model.graph
+            else _value_info_by_name(graph)
+        )
+        chains = _find_fp4_block_quantized_chains(graph, value_info_by_name)
         not_eligible.extend(_block_quantized_fp4_not_eligible(graph, chains))
         if not chains:
             continue

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -30692,6 +30692,133 @@ def test_qdq_structured_pruning_invalid_sparsity_raises():
         onnxsim.apply_structured_pruning_qdq(model, sparsity=-0.1)
 
 
+def _qdq_producer_norm_model(K, H, Out, norm_op, gamma, beta=None, seed=0):
+    # QDQ (per-channel INT8) MatMul producer (Wq/Wscale) -> norm_op(Gamma[,
+    # Beta]) -> plain float MatMul consumer (W2) -- the
+    # Linear -> LayerNorm/RMSNorm -> Linear shape this section's own norm-hop
+    # fix (mirroring the just-merged DynamicQuantizeMatMul/MatMulNBits fix)
+    # now recognizes, where before it silently returned zero chains. Mirrors
+    # :func:`_matmul_qdq_producer_model` (the producer-role QDQ shape this
+    # test file already establishes) with a mid-chain norm node standing in
+    # for the plain MatMul-to-MatMul direct hop.
+    rng = np.random.default_rng(seed)
+    Wq = rng.integers(-100, 100, size=(K, H)).astype(np.int8)
+    Wscale = np.abs(rng.standard_normal(H)).astype(np.float32) * 0.02 + 0.001
+    W2 = rng.standard_normal((H, Out)).astype(np.float32)
+    initializer = [
+        _i8(Wq, "Wq"),
+        _f32(Wscale, "Wscale"),
+        _f32(W2, "W2"),
+        _f32(gamma, "Gamma"),
+    ]
+    if beta is not None:
+        norm_call = f"{norm_op}<axis=-1>(h, Gamma, Beta)"
+        initializer.append(_f32(beta, "Beta"))
+    else:
+        norm_call = f"{norm_op}<axis=-1>(h, Gamma)"
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{Out}] Y)
+        {{
+          Wdq = DequantizeLinear<axis=1>(Wq, Wscale)
+          h = MatMul(X, Wdq)
+          hn = {norm_call}
+          Y = MatMul(hn, W2)
+        }}
+        """,
+        initializer=initializer,
+    )
+    return model, Wq, Wscale, W2
+
+
+def test_qdq_structured_pruning_layer_norm_pass_through_matches_oracle():
+    # Before this section's own norm-hop fix, _find_qdq_chains returned zero
+    # chains for this shape -- the same silent no-op the just-merged
+    # DynamicQuantizeMatMul/MatMulNBits fix addressed for those two schemes.
+    K, H, Out = 8, 16, 4
+    rng = np.random.default_rng(400)
+    gamma = (rng.standard_normal(H) * 0.5 + 1.0).astype(np.float32)
+    beta = (rng.standard_normal(H) * 0.1).astype(np.float32)
+    model, Wq, Wscale, W2 = _qdq_producer_norm_model(
+        K, H, Out, "LayerNormalization", gamma, beta, seed=400
+    )
+    onnx.checker.check_model(model)
+
+    chains = onnxsim.pruning._find_qdq_chains(model.graph)
+    assert len(chains) == 1
+    assert chains[0].n_channels == H
+
+    pruned = onnxsim.apply_structured_pruning_qdq(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Wq"].dims) == [K, H // 2]
+    assert list(inits["Gamma"].dims) == [H // 2]
+    assert list(inits["Beta"].dims) == [H // 2]
+    assert list(inits["W2"].dims) == [H // 2, Out]
+
+    w_dequant = _qdq_dequant(Wq, Wscale, None, axis=1)
+    keep = _oracle_keep_indices(w_dequant, H // 2)
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Gamma"]), gamma[keep]
+    )
+    np.testing.assert_array_equal(onnx.numpy_helper.to_array(inits["Beta"]), beta[keep])
+
+    rng2 = np.random.default_rng(401)
+    x = rng2.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run_unfused(pruned, {"X": x})
+
+    h = x @ w_dequant[:, keep]
+    mean = h.mean(axis=-1, keepdims=True)
+    var = h.var(axis=-1, keepdims=True)
+    hn = (h - mean) / np.sqrt(var + 1e-5) * gamma[keep] + beta[keep]
+    y_oracle = hn @ W2[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_qdq_structured_pruning_rms_norm_pass_through_matches_oracle():
+    # com.microsoft::SimplifiedLayerNormalization -- no `beta`/`Beta` input at
+    # all, unlike LayerNormalization above (mirrors
+    # test_matmul_nbits_rms_norm_pass_through_is_matched_and_prunes's own
+    # identical note); onnx.checker's own schema database doesn't know this
+    # op under the default domain at all, so check_model is skipped for the
+    # unpruned model -- onnxruntime itself still runs it fine, which the
+    # oracle comparison below actually exercises.
+    K, H, Out = 8, 16, 4
+    rng = np.random.default_rng(410)
+    gamma = (rng.standard_normal(H) * 0.5 + 1.0).astype(np.float32)
+    model, Wq, Wscale, W2 = _qdq_producer_norm_model(
+        K, H, Out, "SimplifiedLayerNormalization", gamma, seed=410
+    )
+
+    chains = onnxsim.pruning._find_qdq_chains(model.graph)
+    assert len(chains) == 1
+    assert chains[0].n_channels == H
+
+    pruned = onnxsim.apply_structured_pruning_qdq(model, sparsity=0.5)
+
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Wq"].dims) == [K, H // 2]
+    assert list(inits["Gamma"].dims) == [H // 2]
+    assert list(inits["W2"].dims) == [H // 2, Out]
+
+    w_dequant = _qdq_dequant(Wq, Wscale, None, axis=1)
+    keep = _oracle_keep_indices(w_dequant, H // 2)
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Gamma"]), gamma[keep]
+    )
+
+    rng2 = np.random.default_rng(411)
+    x = rng2.standard_normal((5, K)).astype(np.float32)
+    (y,) = _run_unfused(pruned, {"X": x})
+
+    h = x @ w_dequant[:, keep]
+    rms = np.sqrt(np.mean(np.square(h), axis=-1, keepdims=True) + 1e-5)
+    hn = (h / rms) * gamma[keep]
+    y_oracle = hn @ W2[keep, :]
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+
 def test_qdq_weight_left_untouched_by_unstructured_pruning():
     # Direction (a)'s declined case: unstructured (magnitude) pruning of a
     # QDQ weight is a fundamentally different, much harder problem (see this
@@ -33641,6 +33768,162 @@ def test_matmul_bnb4_pruning_invalid_sparsity_raises():
         onnxsim.apply_structured_pruning_matmul_bnb4(model, sparsity=-0.1)
 
 
+def _bnb4_chain_norm_model(
+    K, N1, N2, block_size, quant_type, W1, W2, norm_op, gamma, beta=None
+):
+    """Like :func:`_bnb4_chain_model`, but with a mid-chain norm node
+    (`Gamma`[, `Beta`]) standing in for the plain activation -- the
+    Linear -> LayerNorm/RMSNorm -> Linear shape this section's own norm-hop
+    fix now recognizes.
+    """
+    B1, absmax1 = _bnb4_quantize(W1, quant_type, block_size)
+    if beta is None:
+        norm_call = f"{norm_op}<axis=-1>(h1, Gamma)"
+        initializer = [
+            onnx.numpy_helper.from_array(B1, name="B1"),
+            onnx.numpy_helper.from_array(absmax1, name="absmax1"),
+            _f32(W2, "W2"),
+            _f32(gamma, "Gamma"),
+        ]
+    else:
+        norm_call = f"{norm_op}<axis=-1>(h1, Gamma, Beta)"
+        initializer = [
+            onnx.numpy_helper.from_array(B1, name="B1"),
+            onnx.numpy_helper.from_array(absmax1, name="absmax1"),
+            _f32(W2, "W2"),
+            _f32(gamma, "Gamma"),
+            _f32(beta, "Beta"),
+        ]
+    model = _model(
+        f"""
+        g (float[3,{K}] A) => (float[3,{N2}] Y)
+        {{
+          h1 = com.microsoft.MatMulBnb4 <K={K}, N={N1}, block_size={block_size}, quant_type={quant_type}> (A, B1, absmax1)
+          h1n = {norm_call}
+          Y = MatMul(h1n, W2)
+        }}
+        """,
+        initializer=initializer,
+        opset=21,
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+    return model
+
+
+def test_matmul_bnb4_layer_norm_pass_through_is_matched_and_prunes():
+    # Before this section's own norm-hop fix (mirroring the just-merged
+    # DynamicQuantizeMatMul/MatMulNBits fix), _find_matmul_bnb4_chains
+    # returned zero chains for this shape.
+    K, N1, N2, block_size = 64, 32, 8, 16
+    quant_type = 1  # NF4
+    rng = np.random.default_rng(2030)
+    W1 = rng.uniform(-1, 1, size=(K, N1)).astype(np.float32)
+    W1 = W1 * np.linspace(0.1, 3.0, N1, dtype=np.float32)[None, :]
+    W2 = rng.uniform(-1, 1, size=(N1, N2)).astype(np.float32)
+    gamma = (rng.standard_normal(N1) * 0.5 + 1.0).astype(np.float32)
+    beta = (rng.standard_normal(N1) * 0.1).astype(np.float32)
+
+    model = _bnb4_chain_norm_model(
+        K, N1, N2, block_size, quant_type, W1, W2, "LayerNormalization", gamma, beta
+    )
+    onnx.checker.check_model(model)
+
+    chains = onnxsim.pruning._find_matmul_bnb4_chains(model.graph)
+    assert len(chains) == 1
+    assert chains[0].n_channels == N1
+
+    pruned = onnxsim.apply_structured_pruning_matmul_bnb4(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    mm1 = next(n for n in pruned.graph.node if n.op_type == "MatMulBnb4")
+    assert {a.name: a.i for a in mm1.attribute}["N"] == 16
+
+    col_norms = np.linalg.norm(W1, axis=0)
+    keep = np.sort(np.argsort(-col_norms, kind="stable")[:16])
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Gamma"].dims) == [16]
+    assert list(inits["Beta"].dims) == [16]
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Gamma"]), gamma[keep]
+    )
+    np.testing.assert_array_equal(onnx.numpy_helper.to_array(inits["Beta"]), beta[keep])
+
+    ref_model = _bnb4_chain_norm_model(
+        K,
+        len(keep),
+        N2,
+        block_size,
+        quant_type,
+        W1[:, keep],
+        W2[keep, :],
+        "LayerNormalization",
+        gamma[keep],
+        beta[keep],
+    )
+    onnx.checker.check_model(ref_model)
+
+    A = rng.uniform(-1, 1, size=(3, K)).astype(np.float32)
+    pruned_out = _run(pruned, {"A": A})[0]
+    ref_out = _run(ref_model, {"A": A})[0]
+    # Mirrors test_matmul_bnb4_pruning_producer_matches_independently_
+    # requantized_subset's own identical byte-identity invariant: a bnb4
+    # producer-row-slice is a plain byte-range copy of the original
+    # quantizer's own output, so this composes byte-identically with an
+    # independently re-quantized/re-sliced reference too.
+    np.testing.assert_array_equal(pruned_out, ref_out)
+
+
+def test_matmul_bnb4_rms_norm_pass_through_is_matched_and_prunes():
+    # com.microsoft::SimplifiedLayerNormalization -- no `beta`/`Beta` input
+    # at all, unlike LayerNormalization above; onnx.checker's own schema
+    # database doesn't know this op under the default domain at all, so
+    # check_model is skipped for the unpruned model -- onnxruntime itself
+    # still runs it fine, which the byte-identity comparison below actually
+    # exercises.
+    K, N1, N2, block_size = 64, 32, 8, 16
+    quant_type = 0  # FP4
+    rng = np.random.default_rng(2040)
+    W1 = rng.uniform(-1, 1, size=(K, N1)).astype(np.float32)
+    W1 = W1 * np.linspace(0.1, 3.0, N1, dtype=np.float32)[None, :]
+    W2 = rng.uniform(-1, 1, size=(N1, N2)).astype(np.float32)
+    gamma = (rng.standard_normal(N1) * 0.5 + 1.0).astype(np.float32)
+
+    model = _bnb4_chain_norm_model(
+        K, N1, N2, block_size, quant_type, W1, W2, "SimplifiedLayerNormalization", gamma
+    )
+
+    chains = onnxsim.pruning._find_matmul_bnb4_chains(model.graph)
+    assert len(chains) == 1
+    assert chains[0].n_channels == N1
+
+    pruned = onnxsim.apply_structured_pruning_matmul_bnb4(model, sparsity=0.5)
+
+    col_norms = np.linalg.norm(W1, axis=0)
+    keep = np.sort(np.argsort(-col_norms, kind="stable")[:16])
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Gamma"].dims) == [16]
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Gamma"]), gamma[keep]
+    )
+
+    ref_model = _bnb4_chain_norm_model(
+        K,
+        len(keep),
+        N2,
+        block_size,
+        quant_type,
+        W1[:, keep],
+        W2[keep, :],
+        "SimplifiedLayerNormalization",
+        gamma[keep],
+    )
+
+    A = rng.uniform(-1, 1, size=(3, K)).astype(np.float32)
+    pruned_out = _run(pruned, {"A": A})[0]
+    ref_out = _run(ref_model, {"A": A})[0]
+    np.testing.assert_array_equal(pruned_out, ref_out)
+
+
 @pytest.mark.parametrize("quant_type", [0, 1])
 def test_matmul_bnb4_dequantized_matches_real_inference_session(quant_type):
     # Independently re-derives this section's own top-comment round-trip as
@@ -34298,6 +34581,206 @@ def test_block_quantized_fp8_pruning_invalid_sparsity_raises():
         onnxsim.apply_structured_pruning_matmul_block_quantized_fp8(model, sparsity=1.0)
 
 
+def _fp8bw_chain_norm_model(N1, K1, N2, block_size, w1, w2, norm_op, gamma, beta=None):
+    """Builds ``A -> MatMulBlockQuantizedFp8Weight(mm1) -> norm_op(Gamma[,
+    Beta]) -> MatMulBlockQuantizedFp8Weight(mm2) -> Y`` -- the norm-pass-
+    through chain shape, mirroring :func:`_fp8bw_chain_model` exactly with a
+    mid-chain norm node standing in for the plain ``Relu``. This op's own
+    `A`/`Y` stay float16 throughout (weight-only quantization -- see
+    :func:`_walk_to_fp8_consumer`'s own docstring for why that makes this
+    hop sound here, unlike the QOperator family).
+    """
+    assert N1 % block_size == 0  # else the consumer would never match
+    b1_f8, s1, dq1 = _fp8bw_quantize(w1, block_size)
+    b2_f8, s2, dq2 = _fp8bw_quantize(w2, block_size)
+    node1 = _fp8bw_node("mm1", "A", "T", "B1", "S1", None, None, block_size)
+    norm_inputs = ["T", "Gamma"]
+    initializer = [
+        onnx.numpy_helper.from_array(b1_f8, name="B1"),
+        _f32(s1, "S1"),
+        onnx.numpy_helper.from_array(b2_f8, name="B2"),
+        _f32(s2, "S2"),
+        _f16(gamma, "Gamma"),
+    ]
+    if beta is not None:
+        norm_inputs.append("Beta")
+        initializer.append(_f16(beta, "Beta"))
+    norm_node = onnx.helper.make_node(norm_op, norm_inputs, ["R"], axis=-1)
+    node2 = _fp8bw_node("mm2", "R", "Y", "B2", "S2", None, None, block_size)
+    graph = onnx.helper.make_graph(
+        [node1, norm_node, node2],
+        "g",
+        [onnx.helper.make_tensor_value_info("A", onnx.TensorProto.FLOAT16, [2, K1])],
+        [onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT16, [2, N2])],
+        initializer=initializer,
+    )
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 21),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    model.ir_version = 10
+    return model, {"dequant1": dq1, "dequant2": dq2}
+
+
+def test_block_quantized_fp8_layer_norm_pass_through_is_matched_and_prunes():
+    # Before this section's own norm-hop fix (mirroring the just-merged
+    # DynamicQuantizeMatMul/MatMulNBits fix), _find_fp8_block_quantized_chains
+    # returned zero chains for this shape. No CPU kernel exists for
+    # MatMulBlockQuantizedFp8Weight in this environment (see
+    # test_block_quantized_fp8_pruning_decomposed_topology_matches_real_cpu_execution's
+    # own identical note), so the oracle check below dequantizes the pruned
+    # model's own producer/consumer weights (:func:`_matmul_block_quantized_fp8_dequantized`)
+    # and composes the chain numerically, rather than through a real
+    # InferenceSession run of the fused op itself.
+    N1, K1, N2, block_size = 16, 32, 8, 8
+    rng = np.random.default_rng(500)
+    w1 = (rng.standard_normal((N1, K1)) * 0.2).astype(np.float32)
+    w1[:8] *= 6.0  # first half of rows clearly more important
+    w2 = (rng.standard_normal((N2, N1)) * 0.2).astype(np.float32)
+    gamma = (rng.standard_normal(N1) * 0.5 + 1.0).astype(np.float32)
+    beta = (rng.standard_normal(N1) * 0.1).astype(np.float32)
+    model, info = _fp8bw_chain_norm_model(
+        N1, K1, N2, block_size, w1, w2, "LayerNormalization", gamma, beta
+    )
+    onnx.checker.check_model(model)
+
+    chains = onnxsim.pruning._find_fp8_block_quantized_chains(model.graph)
+    assert len(chains) == 1
+    assert chains[0].n_channels == N1
+
+    pruned = onnxsim.apply_structured_pruning_matmul_block_quantized_fp8(
+        model, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned)
+
+    keep = np.arange(8)  # expected keep-set: rows 0-7 (engineered important)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["B1"].dims) == [8, K1]
+    assert list(inits["Gamma"].dims) == [8]
+    assert list(inits["Beta"].dims) == [8]
+    assert list(inits["B2"].dims) == [N2, 8]
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Gamma"]), gamma[keep].astype(np.float16)
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Beta"]), beta[keep].astype(np.float16)
+    )
+
+    from onnxsim.pruning import (
+        _consumers_of,
+        _match_matmul_block_quantized_fp8,
+        _matmul_block_quantized_fp8_dequantized,
+    )
+
+    initializer_map = {t.name: t for t in pruned.graph.initializer}
+    consumers_of = _consumers_of(pruned.graph)
+    mm1 = next(n for n in pruned.graph.node if n.name == "mm1")
+    mm2 = next(n for n in pruned.graph.node if n.name == "mm2")
+    w1_dequant = _matmul_block_quantized_fp8_dequantized(
+        _match_matmul_block_quantized_fp8(mm1, initializer_map, consumers_of)
+    )
+    w2_dequant = _matmul_block_quantized_fp8_dequantized(
+        _match_matmul_block_quantized_fp8(mm2, initializer_map, consumers_of)
+    )
+    # byte-identity: the pruned producer/consumer dequantize to an EXACT
+    # hand-slice of the ORIGINAL (unpruned) dequantized reference -- never
+    # re-quantized.
+    np.testing.assert_array_equal(w1_dequant, info["dequant1"][keep])
+    np.testing.assert_array_equal(w2_dequant, info["dequant2"][:, keep])
+
+    rng2 = np.random.default_rng(501)
+    x = rng2.standard_normal((3, K1)).astype(np.float64)
+    gamma_f64 = gamma[keep].astype(np.float16).astype(np.float64)
+    beta_f64 = beta[keep].astype(np.float16).astype(np.float64)
+    h = x @ w1_dequant.T
+    mean = h.mean(axis=-1, keepdims=True)
+    var = h.var(axis=-1, keepdims=True)
+    hn = (h - mean) / np.sqrt(var + 1e-5) * gamma_f64 + beta_f64
+    y_oracle = hn @ w2_dequant.T
+
+    # The same forward pass, but composed entirely from the ORIGINAL
+    # (unpruned) dequantized weights sliced by `keep` -- an independent
+    # construction confirming the pruned chain's own end-to-end numerics,
+    # not merely its per-operand slicing.
+    h_ref = x @ info["dequant1"][keep].T
+    mean_ref = h_ref.mean(axis=-1, keepdims=True)
+    var_ref = h_ref.var(axis=-1, keepdims=True)
+    hn_ref = (h_ref - mean_ref) / np.sqrt(var_ref + 1e-5) * gamma_f64 + beta_f64
+    y_ref = hn_ref @ info["dequant2"][:, keep].T
+    np.testing.assert_allclose(y_oracle, y_ref, rtol=1e-6, atol=1e-6)
+
+
+def test_block_quantized_fp8_rms_norm_pass_through_is_matched_and_prunes():
+    # SimplifiedLayerNormalization -- no `beta`/`Beta` input at all, unlike
+    # LayerNormalization above (mirrors
+    # test_matmul_nbits_rms_norm_pass_through_is_matched_and_prunes's own
+    # identical note); onnx.checker's own schema database doesn't know this
+    # op under the default domain at all, so check_model is skipped for the
+    # unpruned model.
+    N1, K1, N2, block_size = 16, 32, 8, 8
+    rng = np.random.default_rng(510)
+    w1 = (rng.standard_normal((N1, K1)) * 0.2).astype(np.float32)
+    w1[:8] *= 6.0
+    w2 = (rng.standard_normal((N2, N1)) * 0.2).astype(np.float32)
+    gamma = (rng.standard_normal(N1) * 0.5 + 1.0).astype(np.float32)
+    model, info = _fp8bw_chain_norm_model(
+        N1, K1, N2, block_size, w1, w2, "SimplifiedLayerNormalization", gamma
+    )
+
+    chains = onnxsim.pruning._find_fp8_block_quantized_chains(model.graph)
+    assert len(chains) == 1
+    assert chains[0].n_channels == N1
+
+    pruned = onnxsim.apply_structured_pruning_matmul_block_quantized_fp8(
+        model, sparsity=0.5
+    )
+
+    keep = np.arange(8)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["B1"].dims) == [8, K1]
+    assert list(inits["Gamma"].dims) == [8]
+    assert list(inits["B2"].dims) == [N2, 8]
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Gamma"]), gamma[keep].astype(np.float16)
+    )
+
+    from onnxsim.pruning import (
+        _consumers_of,
+        _match_matmul_block_quantized_fp8,
+        _matmul_block_quantized_fp8_dequantized,
+    )
+
+    initializer_map = {t.name: t for t in pruned.graph.initializer}
+    consumers_of = _consumers_of(pruned.graph)
+    mm1 = next(n for n in pruned.graph.node if n.name == "mm1")
+    mm2 = next(n for n in pruned.graph.node if n.name == "mm2")
+    w1_dequant = _matmul_block_quantized_fp8_dequantized(
+        _match_matmul_block_quantized_fp8(mm1, initializer_map, consumers_of)
+    )
+    w2_dequant = _matmul_block_quantized_fp8_dequantized(
+        _match_matmul_block_quantized_fp8(mm2, initializer_map, consumers_of)
+    )
+    np.testing.assert_array_equal(w1_dequant, info["dequant1"][keep])
+    np.testing.assert_array_equal(w2_dequant, info["dequant2"][:, keep])
+
+    rng2 = np.random.default_rng(511)
+    x = rng2.standard_normal((3, K1)).astype(np.float64)
+    gamma_f64 = gamma[keep].astype(np.float16).astype(np.float64)
+    h = x @ w1_dequant.T
+    rms = np.sqrt(np.mean(np.square(h), axis=-1, keepdims=True) + 1e-5)
+    hn = (h / rms) * gamma_f64
+    y_oracle = hn @ w2_dequant.T
+
+    h_ref = x @ info["dequant1"][keep].T
+    rms_ref = np.sqrt(np.mean(np.square(h_ref), axis=-1, keepdims=True) + 1e-5)
+    hn_ref = (h_ref / rms_ref) * gamma_f64
+    y_ref = hn_ref @ info["dequant2"][:, keep].T
+    np.testing.assert_allclose(y_oracle, y_ref, rtol=1e-6, atol=1e-6)
+
+
 def test_analyze_block_quantized_fp8_pruning_matches_real_call():
     N1, K1, N2, block_size = 16, 32, 8, 8
     rng = np.random.default_rng(11)
@@ -34651,6 +35134,191 @@ def test_decode_e4m3_bytes_matches_known_values():
     raw = np.array([0x00, 0x38, 0x40], dtype=np.uint8).reshape(1, 3)
     got = _decode_e4m3_bytes(raw)
     np.testing.assert_allclose(got, [[0.0, 1.0, 2.0]])
+
+
+def _fp4bw_chain_norm_model(
+    N1, K1, N2, block_size, w1, gs1, w2, gs2, norm_op, gamma, beta=None
+):
+    """``Fp4Weight`` analogue of :func:`_fp8bw_chain_norm_model` -- builds
+    ``A -> MatMulBlockQuantizedFp4Weight(mm1) -> norm_op(Gamma[, Beta]) ->
+    MatMulBlockQuantizedFp4Weight(mm2) -> Y``, mirroring
+    :func:`_fp4bw_chain_model` with a mid-chain norm node standing in for
+    the plain ``Relu``. Sound for the identical reason
+    :func:`_fp8bw_chain_norm_model`'s own docstring gives: this op's `A`/`Y`
+    stay float16 throughout, never themselves quantized.
+    """
+    assert N1 % block_size == 0
+    p1, bs1, dq1 = _qmoe_nvfp4_quantize_channel_blockwise(w1, gs1, block_size)
+    p2, bs2, dq2 = _qmoe_nvfp4_quantize_channel_blockwise(w2, gs2, block_size)
+    node1 = _fp4bw_node("mm1", "A", "T", "B1", "WS1", "WS21", None, None, block_size)
+    norm_inputs = ["T", "Gamma"]
+    initializer = [
+        onnx.numpy_helper.from_array(p1, name="B1"),
+        _u8(_e4m3_view_u8(bs1), "WS1"),
+        _f32(np.array([gs1], dtype=np.float32), "WS21"),
+        onnx.numpy_helper.from_array(p2, name="B2"),
+        _u8(_e4m3_view_u8(bs2), "WS2"),
+        _f32(np.array([gs2], dtype=np.float32), "WS22"),
+        _f16(gamma, "Gamma"),
+    ]
+    if beta is not None:
+        norm_inputs.append("Beta")
+        initializer.append(_f16(beta, "Beta"))
+    norm_node = onnx.helper.make_node(norm_op, norm_inputs, ["R"], axis=-1)
+    node2 = _fp4bw_node("mm2", "R", "Y", "B2", "WS2", "WS22", None, None, block_size)
+    graph = onnx.helper.make_graph(
+        [node1, norm_node, node2],
+        "g",
+        [onnx.helper.make_tensor_value_info("A", onnx.TensorProto.FLOAT16, [2, K1])],
+        [onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT16, [2, N2])],
+        initializer=initializer,
+    )
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 21),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    model.ir_version = 10
+    return model, {"dequant1": dq1, "dequant2": dq2}
+
+
+def test_block_quantized_fp4_layer_norm_pass_through_is_matched_and_prunes():
+    # Before this section's own norm-hop fix, _find_fp4_block_quantized_chains
+    # returned zero chains for this shape -- see
+    # test_block_quantized_fp8_layer_norm_pass_through_is_matched_and_prunes's
+    # own identical note on why the oracle below dequantizes the pruned
+    # model's own weights rather than running the fused op through a real
+    # InferenceSession (no CPU kernel for it in this environment).
+    N1, K1, N2, block_size = 16, 32, 8, 8
+    rng = np.random.default_rng(520)
+    w1 = (rng.standard_normal((N1, K1)) * 0.2).astype(np.float32)
+    w1[:8] *= 6.0
+    w2 = (rng.standard_normal((N2, N1)) * 0.2).astype(np.float32)
+    gamma = (rng.standard_normal(N1) * 0.5 + 1.0).astype(np.float32)
+    beta = (rng.standard_normal(N1) * 0.1).astype(np.float32)
+    model, info = _fp4bw_chain_norm_model(
+        N1, K1, N2, block_size, w1, 1.0, w2, 1.0, "LayerNormalization", gamma, beta
+    )
+    onnx.checker.check_model(model)
+
+    chains = onnxsim.pruning._find_fp4_block_quantized_chains(model.graph)
+    assert len(chains) == 1
+    assert chains[0].n_channels == N1
+
+    pruned = onnxsim.apply_structured_pruning_matmul_block_quantized_fp4(
+        model, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned)
+
+    keep = np.arange(8)  # expected keep-set: rows 0-7 (engineered important)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Gamma"].dims) == [8]
+    assert list(inits["Beta"].dims) == [8]
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Gamma"]), gamma[keep].astype(np.float16)
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Beta"]), beta[keep].astype(np.float16)
+    )
+
+    from onnxsim.pruning import (
+        _consumers_of,
+        _match_matmul_block_quantized_fp4,
+        _matmul_block_quantized_fp4_dequantized,
+    )
+
+    initializer_map = {t.name: t for t in pruned.graph.initializer}
+    consumers_of = _consumers_of(pruned.graph)
+    mm1 = next(n for n in pruned.graph.node if n.name == "mm1")
+    mm2 = next(n for n in pruned.graph.node if n.name == "mm2")
+    w1_dequant = _matmul_block_quantized_fp4_dequantized(
+        _match_matmul_block_quantized_fp4(mm1, initializer_map, consumers_of)
+    )
+    w2_dequant = _matmul_block_quantized_fp4_dequantized(
+        _match_matmul_block_quantized_fp4(mm2, initializer_map, consumers_of)
+    )
+    np.testing.assert_array_equal(w1_dequant, info["dequant1"][keep])
+    np.testing.assert_array_equal(w2_dequant, info["dequant2"][:, keep])
+
+    rng2 = np.random.default_rng(521)
+    x = rng2.standard_normal((3, K1)).astype(np.float64)
+    gamma_f64 = gamma[keep].astype(np.float16).astype(np.float64)
+    beta_f64 = beta[keep].astype(np.float16).astype(np.float64)
+    h_ref = x @ info["dequant1"][keep].T
+    mean_ref = h_ref.mean(axis=-1, keepdims=True)
+    var_ref = h_ref.var(axis=-1, keepdims=True)
+    hn_ref = (h_ref - mean_ref) / np.sqrt(var_ref + 1e-5) * gamma_f64 + beta_f64
+    y_ref = hn_ref @ info["dequant2"][:, keep].T
+
+    h = x @ w1_dequant.T
+    mean = h.mean(axis=-1, keepdims=True)
+    var = h.var(axis=-1, keepdims=True)
+    hn = (h - mean) / np.sqrt(var + 1e-5) * gamma_f64 + beta_f64
+    y_oracle = hn @ w2_dequant.T
+    np.testing.assert_allclose(y_oracle, y_ref, rtol=1e-6, atol=1e-6)
+
+
+def test_block_quantized_fp4_rms_norm_pass_through_is_matched_and_prunes():
+    # SimplifiedLayerNormalization -- no `beta`/`Beta` input at all.
+    N1, K1, N2, block_size = 16, 32, 8, 8
+    rng = np.random.default_rng(530)
+    w1 = (rng.standard_normal((N1, K1)) * 0.2).astype(np.float32)
+    w1[:8] *= 6.0
+    w2 = (rng.standard_normal((N2, N1)) * 0.2).astype(np.float32)
+    gamma = (rng.standard_normal(N1) * 0.5 + 1.0).astype(np.float32)
+    model, info = _fp4bw_chain_norm_model(
+        N1, K1, N2, block_size, w1, 1.0, w2, 1.0, "SimplifiedLayerNormalization", gamma
+    )
+
+    chains = onnxsim.pruning._find_fp4_block_quantized_chains(model.graph)
+    assert len(chains) == 1
+    assert chains[0].n_channels == N1
+
+    pruned = onnxsim.apply_structured_pruning_matmul_block_quantized_fp4(
+        model, sparsity=0.5
+    )
+
+    keep = np.arange(8)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Gamma"].dims) == [8]
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Gamma"]), gamma[keep].astype(np.float16)
+    )
+
+    from onnxsim.pruning import (
+        _consumers_of,
+        _match_matmul_block_quantized_fp4,
+        _matmul_block_quantized_fp4_dequantized,
+    )
+
+    initializer_map = {t.name: t for t in pruned.graph.initializer}
+    consumers_of = _consumers_of(pruned.graph)
+    mm1 = next(n for n in pruned.graph.node if n.name == "mm1")
+    mm2 = next(n for n in pruned.graph.node if n.name == "mm2")
+    w1_dequant = _matmul_block_quantized_fp4_dequantized(
+        _match_matmul_block_quantized_fp4(mm1, initializer_map, consumers_of)
+    )
+    w2_dequant = _matmul_block_quantized_fp4_dequantized(
+        _match_matmul_block_quantized_fp4(mm2, initializer_map, consumers_of)
+    )
+    np.testing.assert_array_equal(w1_dequant, info["dequant1"][keep])
+    np.testing.assert_array_equal(w2_dequant, info["dequant2"][:, keep])
+
+    rng2 = np.random.default_rng(531)
+    x = rng2.standard_normal((3, K1)).astype(np.float64)
+    gamma_f64 = gamma[keep].astype(np.float16).astype(np.float64)
+    h_ref = x @ info["dequant1"][keep].T
+    rms_ref = np.sqrt(np.mean(np.square(h_ref), axis=-1, keepdims=True) + 1e-5)
+    hn_ref = (h_ref / rms_ref) * gamma_f64
+    y_ref = hn_ref @ info["dequant2"][:, keep].T
+
+    h = x @ w1_dequant.T
+    rms = np.sqrt(np.mean(np.square(h), axis=-1, keepdims=True) + 1e-5)
+    hn = (h / rms) * gamma_f64
+    y_oracle = hn @ w2_dequant.T
+    np.testing.assert_allclose(y_oracle, y_ref, rtol=1e-6, atol=1e-6)
 
 
 def test_analyze_block_quantized_fp4_pruning_matches_real_call():


### PR DESCRIPTION
## Summary

Follow-up to #1114, which added a `LayerNormalization`/`RMSNormalization`/`SimplifiedLayerNormalization` pass-through hop to the `DynamicQuantizeMatMul`/`MatMulIntegerToFloat` and `MatMulNBits` chain walkers, fixing a silent no-op on the single most common transformer sub-block shape (`Linear → LayerNorm/RMSNorm → Linear`). The identical gap existed in every other quantized-MatMul-chain walker in this module. This PR closes it for four of the five remaining walkers.

## What's added

Mechanical reuse of the already-merged, already-tested hop (fused `_NORM_PASS_THROUGH_OPS` node via `_norm_axis_is_last`/`_norm_pass_through_const_names`, plus the two decomposed pre-opset-17 LayerNorm/RMSNorm matchers) across:

- `_walk_to_consumer_qdq` (QDQ MatMul) — gated to `not is_conv` only, mirroring `_walk_to_conv_consumer`'s own identical restriction of `GroupNormalization` to the Conv family (a norm hop is a Linear-adjacent concept).
- `_walk_to_fp8_consumer` / `_walk_to_fp4_consumer` (block-quantized FP8/FP4) — added unconditionally (no Conv variant exists for these).
- `_walk_to_matmul_bnb4_consumer` (MatMulBnb4) — added unconditionally.

Each gained a `value_info_by_name` parameter and a `chain_ops` type change to `(NodeProto, Optional[str])` pairs (carrying the norm's scale/bias const name), threaded through their chain-finder functions, `apply_structured_pruning_*` rewrite functions (with `const_touched` bookkeeping mirroring the existing tied-weight-conflict handling, plus actual `_slice_last_axis` calls on the norm's initializers), and their dry-run `_analyze_*` mirrors.

## `_walk_to_qop_consumer` deliberately left unchanged

`QLinearMatMul`/`QGemm`/`QLinearConv` is the one walker in this family that is **fully activation-quantized** — confirmed live via `onnx.defs.get_schema("QLinearMatMul")`/`get_schema("QLinearConv")` and ORT's own `QGemm` schema, a producer's own output tensor shares its `y_zero_point`'s int8/uint8 type constraint. `LayerNormalization`/`RMSNormalization`/`SimplifiedLayerNormalization` all require a float-family `X` input per their own live schemas (confirmed: `{tensor(float), tensor(double), tensor(float16), tensor(bfloat16)}`, no int8/uint8) — so no valid ONNX graph could ever place a norm directly adjacent to a QOperator node's quantized output; the identical hop would be unreachable dead code here, not a narrower-but-sound fit. A real exporter would sandwich such a norm behind its own `DequantizeLinear`/`QuantizeLinear` pair instead — recognizing that real topology needs a new pass-through primitive, deliberately out of this round's mechanical-reuse scope, and is left as a separately-scoped, documented gap (see `_walk_to_qop_consumer`'s own updated docstring).

## Test plan

- [x] 8 new tests (2 per remaining walker: LayerNorm + RMSNorm) fail on the pre-fix code and pass after the fix (verified independently via a before/after checkout)
- [x] `pytest tests/test_pruning.py -k "qdq_structured_pruning_layer_norm or qdq_structured_pruning_rms_norm or block_quantized_fp8_layer_norm or block_quantized_fp8_rms_norm or block_quantized_fp4_layer_norm or block_quantized_fp4_rms_norm or matmul_bnb4_layer_norm or matmul_bnb4_rms_norm"` — 8 passed
- [x] `pytest tests/test_pruning.py -q` (full suite) — 832 passed (824 baseline + 8 new), same 103 pre-existing failures (stale compiled C++ extension — a concurrently-merged `prune_magnitude`/`apply_qmoe_whole_expert_pruning` C++ port changed Python-callable signatures, unrelated to this change, confirmed identical on the pre-change commit)
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — no new issues

## Risks for reviewer

- Large diff (touches 4 walkers, their chain-finders, apply functions, and analyze mirrors), but each piece is a direct mirror of the already-merged #1114 pattern — no new matching primitives.
- `_walk_to_qop_consumer` is untouched by design (see above) — please confirm the QOperator type-constraint reasoning holds.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_