### PR TITLE
Add IntactKV: keep pivot-token KV-cache entries at full precision

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -60,6 +60,7 @@ from onnxsim.hqq import quantize_weight_only_int4_hqq
 from onnxsim.ibert_gelu import apply_ibert_gelu
 from onnxsim.icquant import icquant_metadata_bits, quantize_weight_only_icquant
 from onnxsim.if4_quantization import quantize_weight_only_if4
+from onnxsim.intactkv import apply_intactkv
 from onnxsim.kmeans_quantization import quantize_weight_only_kmeans
 from onnxsim.kv_cache_quantization import quantize_kv_cache
 from onnxsim.llm_fp4 import FP4_FORMATS, quantize_weight_only_llm_fp4
@@ -316,6 +317,7 @@ __all__ = [
     "apply_double_quantization",
     "apply_double_quantization_cpp",
     "quantize_kv_cache",
+    "apply_intactkv",
     "apply_gear",
     "quantize_embedding_binary",
     "quantize_embedding_int8",

--- a/onnxsim/intactkv.py
+++ b/onnxsim/intactkv.py
@@ -1,0 +1,254 @@
+"""IntactKV (Liu, Zhang, Wang, Jin, Sun, Gu, Zeng, Zhu, Wei, Cheng, Chen,
+Zhang, 2024, "IntactKV: Improving Large Language Model Quantization by
+Keeping Pivot Tokens Intact", https://arxiv.org/abs/2403.01241).
+
+Distinguishing this module from every other KV-cache module already in this
+repo -- :mod:`onnxsim.kv_cache_quantization` (KIVI/KVQuant), its two
+siblings :mod:`onnxsim.rotatekv` and :mod:`onnxsim.gear`, and
+:mod:`onnxsim.qoq`'s :func:`onnxsim.apply_smooth_attention`: **every one of
+those four quantizes or transforms every cached token's own Key/Value.**
+``kv_cache_quantization`` picks a scale (per-channel for Key, per-token for
+Value) and quantizes every token with it; ``rotatekv`` conjugates every
+token's Key by a fitted rotation *before* that same quantization;
+``gear`` computes a low-rank-plus-sparse correction for the reconstruction
+error *every* quantized token leaves behind; ``apply_smooth_attention``
+migrates outlier magnitude out of *every* token's Key channel-by-channel.
+All four accept that every position in the cache pays a quantization cost
+and work to make that cost smaller. IntactKV's own finding is different in
+kind, not degree: a small, fixed set of **pivot tokens** -- in practice
+almost always the sequence's first few tokens (the well-documented
+"attention sink" phenomenon: a handful of early positions draw a
+disproportionate share of *every* later token's attention, essentially
+regardless of their own content, because softmax attention needs
+*somewhere* to route the score mass an irrelevant query has nowhere better
+to send) -- are disproportionately *sensitive* to KV-cache quantization
+error, out of proportion to their tiny share of the sequence. So instead of
+quantizing them better (the other four modules' shared strategy), this
+module simply **does not quantize them at all**: it identifies that fixed
+pivot prefix and keeps its Key/Value entries at exact float precision,
+computed once, forever -- letting a *separate* quantizer (any one of the
+four above, most naturally :func:`onnxsim.quantize_kv_cache`) handle every
+other position exactly as it already does. IntactKV is not a competing
+KV-cache quantizer; it is a *companion* that carves a quantization-exempt
+notch out of the cache for whichever quantizer runs after it.
+
+**Scope: a two-stream split, not a per-step re-slice.** The pivot tokens
+are, after the prompt's initial prefill pass, a *fixed* prefix -- always
+the same ``num_pivot_tokens`` entries, never revised, never grown --
+sitting in front of a cache that otherwise keeps growing one token per
+decode step. Splitting those two very differently-shaped pieces back out
+of one merged ``past_*`` tensor with a fresh ``Slice`` *every single decode
+step* would be pure wasted work repeated forever for a boundary that never
+moves. This module instead changes the KV-cache stream's own I/O contract,
+once, to expose the pivot prefix as its own separate, fixed-size stream
+from the start -- the same design :mod:`onnxsim.kv_cache_quantization`'s
+own Value-style rewrite already uses for its per-token scale (a second,
+independently-shaped tensor threaded alongside the codes, rather than
+packed into one tensor with the thing it's paired with). Concretely, for
+each matched ``Concat(past, new, axis=seq)`` stream (found with
+:mod:`onnxsim.kv_cache_quantization`'s own
+``_find_kv_cache_candidates`` -- the exact same structural pattern, not
+reimplemented here):
+
+    Before:
+      past_key: graph input, float32 [..., seq_past, head_dim]
+      new_key:  float32 [..., seq_new, head_dim]
+      present_key = Concat(past_key, new_key, axis=seq)   -- graph output,
+                    consumed by the attention math
+
+    After:
+      past_key_pivot: NEW graph input, float32 [..., num_pivot_tokens,
+                      head_dim] -- fixed size, holds the pivot tokens'
+                      exact Key (or Value), never revised after being set
+      past_key_rest:  past_key, renamed -- float32 [..., seq_past -
+                      num_pivot_tokens, head_dim], everything *but* the
+                      pivots; this is an ordinary
+                      ``Concat(past, new, axis=seq)`` stream in its own
+                      right, ready to be matched and quantized by
+                      whichever of this repo's other KV-cache quantizers
+                      the caller applies next
+      present_key_rest = Concat(past_key_rest, new_key, axis=seq)  --
+                      graph output, same tensor Concat node/output as the
+                      original, just renamed -- this is what
+                      :func:`onnxsim.quantize_kv_cache` (or
+                      :mod:`onnxsim.rotatekv`/:mod:`onnxsim.gear`) matches
+                      and quantizes when run *after* this module
+      present_key_pivot = Identity(past_key_pivot)  -- NEW graph output,
+                      exact passthrough: the pivot tokens are never
+                      recomputed or touched once set, so this is a
+                      bit-for-bit copy every single step
+      present_key = Concat(present_key_pivot, present_key_rest, axis=seq)
+                      -- same output name/binding as the original
+                      present_key, now produced by this reconstruction
+                      node instead of the original Concat; every original
+                      consumer (the attention math) is unaffected, since
+                      it already referred to ``present_key`` by name
+
+Composed with a following :func:`onnxsim.quantize_kv_cache` call, that
+quantizer's own rewrite changes ``past_key_rest``/``present_key_rest`` to
+INT8 and inserts a ``DequantizeLinear`` whose output feeds every consumer
+of the old float ``present_key_rest`` -- which, after this module has run,
+means the reconstruction ``Concat`` above. So ``present_key`` ends up
+built from an *exact* pivot half and a *lossily dequantized* rest half,
+which is exactly IntactKV's own claim.
+
+**What this module does not do.** It does not compute the pivot tokens'
+Key/Value in the first place -- an exported decoder step-graph already
+computes Key/Value for every prompt token during prefill, pivots included,
+as an ordinary consequence of running the model; this module only changes
+how a *later* step's cache I/O is shaped. Slicing the first
+``num_pivot_tokens`` entries off *that* prefill step's own float
+``present_key`` output, exactly once, and feeding the result back in as
+every subsequent step's ``past_key_pivot`` is cross-step, host-side
+bookkeeping -- deciding "this was the prefill step" is not information one
+exported step-graph has about itself -- and belongs in
+``tools/onnx-deploy/include/onnx_deploy/kv_cache_pipeline.h`` as a
+follow-up, exactly the same scope line
+:mod:`onnxsim.kv_cache_quantization`'s own docstring already draws around
+KIVI's residual-window bookkeeping for the identical reason. This module's
+own job stops at making sure the *graph* keeps that one-time slice's
+result untouched forever after -- not deciding when to take it.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Set, Union
+
+import onnx
+import onnx.helper
+
+from onnxsim.bias_correction import _all_names, _unique_name
+from onnxsim.kv_cache_quantization import _find_kv_cache_candidates, _KvCacheCandidate
+
+
+def apply_intactkv(
+    model: Union[str, onnx.ModelProto],
+    num_pivot_tokens: int = 4,
+) -> onnx.ModelProto:
+    """Splits every ``Concat(past, new, axis=seq)`` KV-cache stream this
+    module can find (the same pattern
+    :func:`onnxsim.quantize_kv_cache` matches -- see this module's own
+    docstring for the exact rewrite) into two independent streams: a fixed,
+    ``num_pivot_tokens``-long pivot prefix that this module guarantees
+    stays exact float32 forever, and the remaining, still-growing "rest" of
+    the cache, restructured as an ordinary same-shaped KV-cache stream of
+    its own -- ready for a *following* call to
+    :func:`onnxsim.quantize_kv_cache` (or :mod:`onnxsim.rotatekv`/
+    :mod:`onnxsim.gear`) to actually quantize. This module never quantizes
+    anything itself, the same way :func:`onnxsim.apply_smooth_attention`
+    only migrates and leaves quantizing to a later pipeline stage.
+
+    :param model: the original (unquantized) onnx ModelProto or file path
+    :param num_pivot_tokens: how many of each stream's leading (oldest)
+            cached tokens to exempt from quantization -- the paper's own
+            typical choice is 4; the caller is responsible for supplying
+            that many tokens' worth of pivot Key/Value (sliced once from
+            the prompt's own prefill-step output -- see this module's own
+            docstring) as each new ``*_pivot`` graph input from the first
+            decode step onward
+    :returns: ``model`` with every matched KV-cache stream split into a
+            ``*_pivot``/``*_rest`` pair of graph input/output streams (see
+            the module docstring's diagram) and the original
+            ``present_*`` output rebuilt as their ``Concat``; a model with
+            no matching ``Concat(past, new, axis=seq)`` pattern is returned
+            unchanged
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    graph = out.graph
+
+    candidates = _find_kv_cache_candidates(graph)
+    if not candidates:
+        return out
+
+    taken_names: Set[str] = _all_names(graph)
+    input_by_name = {i.name: i for i in graph.input}
+
+    for c in candidates:
+        _split_pivot_stream(graph, c, num_pivot_tokens, taken_names, input_by_name)
+
+    return out
+
+
+def _split_pivot_stream(
+    graph: onnx.GraphProto,
+    c: _KvCacheCandidate,
+    num_pivot_tokens: int,
+    taken_names: Set[str],
+    input_by_name: Dict[str, onnx.ValueInfoProto],
+) -> None:
+    past_input = input_by_name[c.past_name]
+
+    pivot_past_name = _unique_name(f"{c.past_name}_pivot", taken_names)
+    rest_past_name = _unique_name(f"{c.past_name}_rest", taken_names)
+    pivot_present_name = _unique_name(f"{c.present_name}_pivot", taken_names)
+    rest_present_name = _unique_name(f"{c.present_name}_rest", taken_names)
+
+    # New past_*_pivot graph input: same rank/leading dims as past_*, seq
+    # axis fixed to num_pivot_tokens -- read before past_input's own name
+    # is mutated below.
+    pivot_input = onnx.ValueInfoProto()
+    pivot_input.name = pivot_past_name
+    pivot_input.type.tensor_type.elem_type = onnx.TensorProto.FLOAT
+    for i, d in enumerate(past_input.type.tensor_type.shape.dim):
+        new_dim = pivot_input.type.tensor_type.shape.dim.add()
+        if i == c.seq_axis:
+            new_dim.dim_value = num_pivot_tokens
+        elif d.HasField("dim_value"):
+            new_dim.dim_value = d.dim_value
+        elif d.HasField("dim_param"):
+            new_dim.dim_param = d.dim_param
+    graph.input.append(pivot_input)
+
+    # Rename past_* -> past_*_rest in place: still consumed only by
+    # concat_node, still float32, now holding everything but the pivots.
+    past_input.name = rest_past_name
+    for i, inp in enumerate(c.concat_node.input):
+        if inp == c.past_name:
+            c.concat_node.input[i] = rest_past_name
+
+    # present_* -> present_*_rest in place: concat_node's own output,
+    # unchanged apart from the name, now a plain KV-cache stream in its
+    # own right for a following quantizer to match.
+    c.concat_node.output[0] = rest_present_name
+    rest_output = onnx.ValueInfoProto()
+    rest_output.name = rest_present_name
+    rest_output.type.CopyFrom(past_input.type)
+    # seq_past - num_pivot_tokens (statically unknown here, same as the
+    # original present_* declaration) -- clear any dim_value the pivot
+    # branch above would have copied and leave the seq axis symbolic.
+    rest_output.type.tensor_type.shape.dim[c.seq_axis].ClearField("dim_value")
+    rest_output.type.tensor_type.shape.dim[c.seq_axis].ClearField("dim_param")
+    graph.output.append(rest_output)
+
+    # present_*_pivot = Identity(past_*_pivot): exact passthrough, every
+    # step -- the pivot tokens are set once and never revised.
+    identity_node = onnx.helper.make_node(
+        "Identity",
+        [pivot_past_name],
+        [pivot_present_name],
+        name=_unique_name(f"{c.present_name}_intactkv_pivot", taken_names),
+    )
+    pivot_output = onnx.ValueInfoProto()
+    pivot_output.name = pivot_present_name
+    pivot_output.type.CopyFrom(pivot_input.type)
+    graph.output.append(pivot_output)
+
+    # present_* (original name/binding, untouched) = Concat(pivot, rest):
+    # every original consumer of present_* (the attention math) keeps
+    # referring to it by that same name, so nothing downstream needs
+    # rewiring.
+    reconstruct_node = onnx.helper.make_node(
+        "Concat",
+        [pivot_present_name, rest_present_name],
+        [c.present_name],
+        name=_unique_name(f"{c.present_name}_intactkv_reconstruct", taken_names),
+        axis=c.seq_axis,
+    )
+
+    concat_idx = next(i for i, n in enumerate(graph.node) if n is c.concat_node)
+    graph.node.insert(concat_idx + 1, identity_node)
+    graph.node.insert(concat_idx + 2, reconstruct_node)

--- a/tests/test_intactkv.py
+++ b/tests/test_intactkv.py
@@ -82,7 +82,9 @@ def test_intactkv_splits_stream_into_pivot_and_rest():
     assert pivot_in.type.tensor_type.shape.dim[2].dim_value == 4
 
     op_types = [n.op_type for n in m.graph.node]
-    assert op_types.count("Identity") == 1
+    # One Identity is the toy model's own new_key = Identity(new_key_raw);
+    # the other is apply_intactkv's own pivot passthrough.
+    assert op_types.count("Identity") == 2
     assert op_types.count("Concat") == 2  # rest stream + reconstruction
 
     reconstruct = next(

--- a/tests/test_intactkv.py
+++ b/tests/test_intactkv.py
@@ -1,0 +1,241 @@
+"""Tests for ``onnxsim.apply_intactkv`` -- see ``onnxsim/intactkv.py`` for
+the technique (splitting a decoder's ``Concat(past, new, axis=seq)``
+KV-cache stream into an exact, fixed-size pivot-token prefix and an
+ordinary, still-quantizable "rest" stream).
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(body, opset=13, ir_version=8):
+    return parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+
+
+def _kv_cache_model(batch=1, heads=2, head_dim=4, opset=13, symbolic_seq=True):
+    # Mirrors tests/test_kv_cache_quantization.py's own _kv_cache_model:
+    # new_key is routed through an Identity so the matcher can tell "the
+    # persistent cache" apart from "this step's fresh token".
+    seq_past = "seq_past" if symbolic_seq else 3
+    seq_present = "seq_present" if symbolic_seq else 4
+    return _model(
+        f"""
+        g (float[{batch},{heads},{seq_past},{head_dim}] past_key,
+           float[{batch},{heads},1,{head_dim}] new_key_raw)
+          => (float[{batch},{heads},{seq_present},{head_dim}] present_key,
+              float summary)
+        {{
+          new_key = Identity(new_key_raw)
+          present_key = Concat<axis = 2>(past_key, new_key)
+          summary = ReduceSum<keepdims = 0>(present_key)
+        }}
+        """,
+        opset=opset,
+    )
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
+
+
+def test_intactkv_splits_stream_into_pivot_and_rest():
+    model = _kv_cache_model()
+    m = onnxsim.apply_intactkv(model, num_pivot_tokens=4)
+    onnx.checker.check_model(m)
+
+    input_names = {i.name for i in m.graph.input}
+    output_names = {o.name for o in m.graph.output}
+
+    assert "past_key_pivot" in input_names
+    assert "past_key_rest" in input_names
+    assert "past_key" not in input_names  # renamed, not duplicated
+
+    assert "present_key_pivot" in output_names
+    assert "present_key_rest" in output_names
+    assert "present_key" in output_names  # original binding preserved
+
+    pivot_in = next(i for i in m.graph.input if i.name == "past_key_pivot")
+    assert pivot_in.type.tensor_type.shape.dim[2].dim_value == 4
+
+    op_types = [n.op_type for n in m.graph.node]
+    assert op_types.count("Identity") == 1
+    assert op_types.count("Concat") == 2  # rest stream + reconstruction
+
+    reconstruct = next(
+        n
+        for n in m.graph.node
+        if n.op_type == "Concat" and n.output[0] == "present_key"
+    )
+    assert list(reconstruct.input) == ["present_key_pivot", "present_key_rest"]
+
+    # The original attention-math consumer (ReduceSum) still reads
+    # present_key by name -- no rewiring needed, since the reconstruction
+    # node reuses that exact output binding.
+    reduce_node = next(n for n in m.graph.node if n.op_type == "ReduceSum")
+    assert reduce_node.input[0] == "present_key"
+
+
+def test_intactkv_noop_without_kv_cache_pattern():
+    model = _model(
+        """
+        g (float[4,4] x) => (float[4,4] y)
+        {
+          y = Relu(x)
+        }
+        """
+    )
+    result = onnxsim.apply_intactkv(model)
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_intactkv_declines_when_past_has_other_consumers():
+    model = _model(
+        """
+        g (float[1,2,3,4] past_key, float[1,2,1,4] new_key_raw)
+          => (float[1,2,4,4] present_key, float summary, float past_summary)
+        {
+          new_key = Identity(new_key_raw)
+          present_key = Concat<axis = 2>(past_key, new_key)
+          summary = ReduceSum<keepdims = 0>(present_key)
+          past_summary = ReduceSum<keepdims = 0>(past_key)
+        }
+        """
+    )
+    result = onnxsim.apply_intactkv(model)
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_intactkv_pivot_passthrough_is_bit_exact():
+    # Standalone (no downstream quantizer): the pivot stream must round-trip
+    # through Identity bit-for-bit -- the whole point of the technique.
+    batch, heads, head_dim = 1, 2, 4
+    model = _kv_cache_model(batch=batch, heads=heads, head_dim=head_dim)
+    m = onnxsim.apply_intactkv(model, num_pivot_tokens=4)
+    onnx.checker.check_model(m)
+
+    rng = np.random.default_rng(0)
+    pivot = rng.standard_normal((batch, heads, 4, head_dim)).astype(np.float32)
+    rest = np.zeros((batch, heads, 0, head_dim), dtype=np.float32)
+    new0 = rng.standard_normal((batch, heads, 1, head_dim)).astype(np.float32)
+
+    outputs = _run(
+        m,
+        {
+            "past_key_pivot": pivot,
+            "past_key_rest": rest,
+            "new_key_raw": new0,
+        },
+    )
+    # graph.output order: [present_key, summary, present_key_rest, present_key_pivot]
+    present_key, _summary, present_rest, present_pivot = outputs
+    np.testing.assert_array_equal(present_pivot, pivot)
+    np.testing.assert_array_equal(present_key[:, :, :4, :], pivot)
+    np.testing.assert_array_equal(present_rest, new0)
+
+
+def test_intactkv_composed_with_quantize_kv_cache_pivots_exact_rest_lossy():
+    # The end-to-end property that is the entire point of IntactKV: after
+    # composing apply_intactkv with quantize_kv_cache, the pivot positions
+    # of the reconstructed cache reconstruct EXACTLY (they never touch a
+    # quantizer at all), while the non-pivot positions go through ordinary
+    # lossy INT8 quantization.
+    batch, heads, head_dim = 1, 2, 8
+    num_pivot = 4
+    model = _kv_cache_model(batch=batch, heads=heads, head_dim=head_dim)
+    split = onnxsim.apply_intactkv(model, num_pivot_tokens=num_pivot)
+    q = onnxsim.quantize_kv_cache(split, num_samples=32, seed=2)
+    onnx.checker.check_model(q)
+
+    # present_key_rest must now be INT8 -- quantize_kv_cache matched and
+    # quantized exactly the stream apply_intactkv carved out for it.
+    rest_vi = next(o for o in q.graph.output if o.name == "present_key_rest")
+    assert rest_vi.type.tensor_type.elem_type == onnx.TensorProto.INT8
+    pivot_vi = next(o for o in q.graph.output if o.name == "present_key_pivot")
+    assert pivot_vi.type.tensor_type.elem_type == onnx.TensorProto.FLOAT
+
+    # Probe the dequantized rest tensor directly so we can compare it
+    # against float numpy math with a tight tolerance, rather than trusting
+    # an end-to-end onnxruntime run's own reduction order.
+    dequant_node = next(n for n in q.graph.node if n.op_type == "DequantizeLinear")
+    q_probe = onnx.ModelProto()
+    q_probe.CopyFrom(q)
+    q_probe.graph.output.append(onnx.ValueInfoProto(name=dequant_node.output[0]))
+
+    rng = np.random.default_rng(4)
+    pivot = rng.standard_normal((batch, heads, num_pivot, head_dim)).astype(np.float32)
+    empty_rest = np.zeros((batch, heads, 0, head_dim), dtype=np.int8)
+    new0 = rng.standard_normal((batch, heads, 1, head_dim)).astype(np.float32)
+    new1 = rng.standard_normal((batch, heads, 1, head_dim)).astype(np.float32)
+
+    # q_probe.graph.output order:
+    # [present_key, summary, present_key_rest, present_key_pivot, dequant]
+    outputs0 = _run(
+        q_probe,
+        {
+            "past_key_pivot": pivot,
+            "past_key_rest": empty_rest,
+            "new_key_raw": new0,
+        },
+    )
+    present_key0, _summary0, present_rest0, present_pivot0, rest_f0 = outputs0
+    assert present_rest0.dtype == np.int8
+
+    outputs1 = _run(
+        q_probe,
+        {
+            "past_key_pivot": present_pivot0,
+            "past_key_rest": present_rest0,
+            "new_key_raw": new1,
+        },
+    )
+    present_key1, _summary1, present_rest1, present_pivot1, rest_f1 = outputs1
+
+    # Pivot half: bit-for-bit exact, both steps -- never quantized, never
+    # revised.
+    np.testing.assert_array_equal(present_pivot0, pivot)
+    np.testing.assert_array_equal(present_pivot1, pivot)
+    np.testing.assert_array_equal(present_key1[:, :, :num_pivot, :], pivot)
+
+    # Rest half (post-dequantization): close to, but not exactly, the
+    # float reference -- ordinary lossy INT8 quantization error, checked
+    # with a loose relative tolerance (same generous bound
+    # tests/test_kv_cache_quantization.py's own round-trip test uses).
+    float_rest0, _ = _run(
+        model,
+        {
+            "past_key": np.zeros((batch, heads, 0, head_dim), np.float32),
+            "new_key_raw": new0,
+        },
+    )
+    float_rest1, _ = _run(model, {"past_key": float_rest0, "new_key_raw": new1})
+    assert _rel_l2(float_rest1, rest_f1) < 0.2
+    assert not np.array_equal(rest_f1, float_rest1)  # genuinely lossy
+
+    # And the reconstructed present_key really is pivot-exact ++ rest-lossy
+    # concatenated, matching the reconstruction Concat's own inputs.
+    np.testing.assert_array_equal(present_key1[:, :, :num_pivot, :], present_pivot1)
+    np.testing.assert_array_equal(present_key1[:, :, num_pivot:, :], rest_f1)


### PR DESCRIPTION
## Summary

Implements **IntactKV** (Liu et al., 2024, ["IntactKV: Improving Large Language Model Quantization by Keeping Pivot Tokens Intact"](https://arxiv.org/abs/2403.01241)) as a new `onnxsim.apply_intactkv` function.

Every existing KV-cache module in this repo (`kv_cache_quantization` / KIVI-KVQuant, `rotatekv`, `gear`, `qoq.apply_smooth_attention`) transforms or quantizes **every** cached token's own Key/Value. IntactKV's finding is different in kind: a small, fixed prefix of **pivot tokens** — almost always the sequence's first few tokens (the "attention sink" phenomenon) — is disproportionately sensitive to quantization error, so instead of quantizing them better, this module keeps them at exact float32 precision forever and lets a *separate* quantizer (any of the four above) handle everything else.

## What's added / scope

- `onnxsim/intactkv.py`: `apply_intactkv(model, num_pivot_tokens=4)`.
  - Reuses `onnxsim.kv_cache_quantization`'s own `_find_kv_cache_candidates` matcher (`Concat(past, new, axis=seq)`) rather than reimplementing it.
  - For each matched stream, splits the cache's I/O contract into two independent streams instead of re-slicing a merged tensor every decode step: a new, fixed-size `*_pivot` input/output pair (exact `Identity` passthrough) and the renamed `*_rest` stream (an ordinary KV-cache pattern of its own, ready for a following `quantize_kv_cache`/`rotatekv`/`gear` call to quantize). The original `present_*` output binding is rebuilt as `Concat(pivot, rest)`, so existing attention-math consumers need no rewiring.
  - This module never quantizes anything itself — it's a composable companion, the same relationship `apply_smooth_attention` has to `quantize_kv_cache`.
  - Deliberately out of scope (documented in the module docstring, same convention as `billm.py`): computing the pivot tokens' own Key/Value values (an ordinary consequence of running prefill) and deciding when to do the one-time slice of a prefill step's output into the `*_pivot` input is cross-step, host-side bookkeeping — the same scope line `kv_cache_quantization`'s own docstring draws around KIVI's residual-window bookkeeping.
- `onnxsim/__init__.py`: registers `apply_intactkv` (import + `__all__`).
- `tests/test_intactkv.py`: built with `onnx.parser.parse_model()` per this repo's convention, mirroring `tests/test_kv_cache_quantization.py`'s own toy `Concat(past, new, axis=seq)` model. Includes the key numerical claim: after composing `apply_intactkv` with `quantize_kv_cache`, the pivot positions of the reconstructed cache are bit-for-bit exact (verified with `np.testing.assert_array_equal` against the raw pivot tensor, across two decode steps) while the non-pivot positions go through ordinary lossy INT8 quantization (checked with a loose relative-L2 tolerance, matching this repo's existing convention for random-calibration-data checks).

## Test plan

- `pytest tests/test_intactkv.py -v` — 5 passed
- `pytest tests/test_kv_cache_quantization.py -v` — 11 passed (no regression)
- `ruff check` / `ruff format --check` on all touched files — clean
- `mypy` (full `onnxsim` package, 87 source files) — clean, no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0147oGBdEYNr5ZLRR1rHUzng

---
_Generated by [Claude Code](https://claude.ai/code/session_0147oGBdEYNr5ZLRR1rHUzng)_