### PR TITLE
Document why no quantization knob reproduces llm_build()'s accuracy

### DIFF
--- a/.github/workflows/axera-integration.yml
+++ b/.github/workflows/axera-integration.yml
@@ -42,6 +42,7 @@ on:
       - "tests/test_axera_conv_matmul_coverage_hardware.py"
       - "tests/test_axera_neu_format_arith_ops.py"
       - "tests/test_axera_op_coverage_hardware.py"
+      - "tests/test_axera_quantonnx.py"
 
 concurrency:
   group: axera-integration-${{ github.ref }}
@@ -152,7 +153,7 @@ jobs:
       - name: Run hf-config+safetensors -> onnx -> axmodel integration test
         working-directory: ${{ runner.temp }}
         run: |
-          pytest -v "$GITHUB_WORKSPACE/tests/test_pulsar2_hf_to_axmodel.py" "$GITHUB_WORKSPACE/tests/test_axera_conv_matmul_coverage_hardware.py" "$GITHUB_WORKSPACE/tests/test_axera_neu_format_arith_ops.py" "$GITHUB_WORKSPACE/tests/test_axera_op_coverage_hardware.py"
+          pytest -v "$GITHUB_WORKSPACE/tests/test_pulsar2_hf_to_axmodel.py" "$GITHUB_WORKSPACE/tests/test_axera_conv_matmul_coverage_hardware.py" "$GITHUB_WORKSPACE/tests/test_axera_neu_format_arith_ops.py" "$GITHUB_WORKSPACE/tests/test_axera_op_coverage_hardware.py" "$GITHUB_WORKSPACE/tests/test_axera_quantonnx.py"
       - name: Run real conversion
         working-directory: ${{ runner.temp }}
         env:

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -679,6 +679,86 @@ before, plus a real accuracy caveat:
   build --config` currently applies -- `llm_build()` (above), Pulsar2's
   own dedicated LLM path, presumably has one; this generic path doesn't.
 
+### Mitigation attempts: none reproduce `llm_build()`'s accuracy via the generic path
+
+Given the depth-compounding diagnosis above, every quantization knob this
+harness has real access to was tried against the real `SmolLM2-135M` build
+to see if any of them close the gap to `llm_build()`'s weight-only accuracy.
+**None do.** In order tried:
+
+- **`quant.enable_smooth_quant`** (with default and explicit
+  threshold/strength): no measurable effect on output.
+- **`quant.highest_mix_precision`**: real `TileFailException` -- the
+  attention path's promoted-precision matmul tile doesn't fit the NPU's
+  memory budget, a hard failure rather than a partial improvement.
+- **`quant.layer_configs` with an FP32 override on `ReduceMean`/`Sqrt`**
+  (RMSNorm's own ops, the intuitive place to protect precision): confirmed
+  **silent no-op**, byte-identical compiled output with and without it.
+  Root-caused this session by fetching Pulsar2's own config schema docs
+  (`user_guides_advanced/advanced_build_guides.html`): `layer_configs`'
+  `data_type: "FP32"` is only valid for a specific, documented op list --
+  `LeakyRelu, Sigmoid, Relu, Add, Mul, Div, Sub, Concat, Softmax` -- and
+  silently does nothing for anything else, including `ReduceMean`/`Sqrt`.
+  Not a bug in this harness; an invalid config value that Pulsar2 doesn't
+  validate or warn about.
+- **`quant.layer_configs` retried with only doc-valid op types**
+  (`Softmax`, `Add`, `Mul`, `Div`, `Sub`, all set to `data_type: "FP32"`,
+  stacked incrementally): confirmed **real** this time -- `Add`/`Mul`/
+  `Div`/`Sub` overrides each produce a measurably different compiled
+  `quant_axmodel.onnx` and different real on-device output (different
+  bytes, different per-prompt cosine similarity) than the baseline.
+  `Softmax` alone is the one exception: it changes a few bytes of the
+  intermediate quantized IR (Pulsar2's own `AxSoftmax` op, not literally
+  `Softmax` by then) but produces **bit-identical** on-device output across
+  every test prompt -- Softmax's [0, 1]-bounded output is apparently
+  already well represented at whatever precision Pulsar2 was already using
+  for it. Stacking all four working overrides together does **not**
+  recover accuracy -- average cosine similarity across 5 real prompts got
+  *worse* (~-0.33 vs baseline's ~-0.20), still 0/5 top-1 matches. Protecting
+  a handful of elementwise nonlinearities can't compensate for the
+  dominant cost -- MatMul/Conv activations, which `layer_configs` cannot
+  set to FP32 at all (`data_type: "FP32"` isn't accepted for `MatMul` or
+  `Conv`; `Conv` only accepts a separate `output_data_type: "FP32"`).
+- **`quant.enable_adaround`**: never completed -- still running after 30
+  minutes on this model, abandoned as impractical for this investigation.
+- **Feeding a pre-quantized ONNX graph via `model_type: "QuantONNX"`**,
+  to bypass Pulsar2's own PTQ entirely and substitute onnxsim's own
+  quantizers instead (`onnxsim.quantize_weight_only()`, matching
+  `llm_build()`'s real weight-only S8 scheme exactly, and
+  `onnxsim.quantize_static()`, already confirmed elsewhere in this file to
+  match AX650's real U8-activation/S8-weight convention). `QuantONNX` is
+  confirmed to be a real, distinct ingestion path (`pulsar2 build` prints
+  `"... is a QuantONNX model, disable concat align config"` and skips
+  requesting calibration ranges for tensors that already carry
+  `QuantizeLinear`/`DequantizeLinear`) -- but it hits a real, reproducible
+  **Pulsar2-internal bug**: any `MatMul` whose weight input comes through a
+  `DequantizeLinear` (the standard ONNX QDQ per-channel weight-quantization
+  pattern -- exactly what both onnxsim quantizers above emit) crashes
+  Pulsar2's own PPQ-based `ax_quant_graph_optimize` pass with
+  `ValueError: Can not feed value to operation <node>, expects exact 2
+  inputs, however 1 was given` -- one of `MatMul`'s two inputs is silently
+  dropped during Pulsar2's own graph optimization, before either onnxsim
+  quantizer's choices could matter. **Isolated to a minimal, 2-node,
+  104-byte repro** (`MatMul(x, DequantizeLinear(wq, scale, zp))`, no LLM
+  structure involved at all) -- confirms this is a general `QuantONNX` +
+  quantized-`MatMul` limitation in Pulsar2 itself, not something specific
+  to `reconstruct_hf_graph()`'s output or a fixable onnxsim-side encoding
+  choice. Reproduced identically whether the activation side is also
+  quantized (`quantize_static()`'s full QDQ output) or left plain float
+  (`quantize_weight_only()`'s output) -- ruling out any interaction with
+  activation quantization specifically; the crash is purely about `MatMul`
+  plus a `DequantizeLinear`'d weight.
+
+**Verdict, after 7 distinct techniques**: the generic `pulsar2 build`
+(ONNX) ingestion path cannot currently reproduce `llm_build()`'s real,
+usable LLM accuracy on AX650, regardless of which quantization strategy is
+applied from the ONNX side -- Pulsar2's own exposed PTQ knobs don't fix the
+depth-compounding problem, and substituting a pre-quantized graph runs into
+a real toolchain bug for exactly the QDQ pattern that would reproduce
+`llm_build()`'s weight-only scheme. `llm_build()`'s separate, closed-source,
+non-ONNX ingestion (above) remains the only confirmed-accurate path to a
+real LLM `.axmodel` today.
+
 ## Real Docker + device conversion driver
 
 `pulsar2_docker.py` and `convert_onnxmodelzoo.py` turn the manual

--- a/tests/test_axera_quantonnx.py
+++ b/tests/test_axera_quantonnx.py
@@ -1,0 +1,124 @@
+"""Real-hardware follow-up to the SmolLM2-135M accuracy investigation
+(see scripts/axera/README.md's "Mitigation attempts: none reproduce
+llm_build()'s accuracy via the generic path"): locks in a real,
+reproducible Pulsar2-internal bug found while trying `model_type:
+"QuantONNX"` as a way to feed onnxsim's own weight-only/static quantizers
+(`onnxsim.quantize_weight_only()`, `onnxsim.quantize_static()`) to
+`pulsar2 build` instead of letting Pulsar2's own PTQ run.
+
+`QuantONNX` is a real, distinct ingestion path (confirmed: `pulsar2 build`
+prints `"... is a QuantONNX model, disable concat align config"` and skips
+requesting calibration ranges for tensors that already carry
+QuantizeLinear/DequantizeLinear) -- but any `MatMul` whose weight input
+comes through a `DequantizeLinear` (the standard ONNX QDQ per-channel
+weight-quantization pattern) crashes Pulsar2's own PPQ-based
+`ax_quant_graph_optimize` pass: one of MatMul's two inputs is silently
+dropped, and its executor then raises `ValueError: Can not feed value to
+operation <node>, expects exact 2 inputs, however 1 was given`. This file
+locks in the minimal, 2-node repro of that -- no LLM/onnxsim reconstruction
+involved at all, confirming it's a general `QuantONNX` + quantized-`MatMul`
+limitation in Pulsar2 itself.
+
+Needs a loaded `pulsar2:*` Docker image -- skip-guarded like
+tests/test_pulsar2_hf_to_axmodel.py.
+"""
+
+import json
+import os
+import sys
+
+import numpy as np
+import onnx
+import pytest
+from onnx import helper, numpy_helper
+
+_AXERA_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "axera"
+)
+if _AXERA_DIR not in sys.path:
+    sys.path.insert(0, _AXERA_DIR)
+
+import pulsar2_docker  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    not pulsar2_docker.docker_image_available(),
+    reason=f"pulsar2 Docker image not loaded: {pulsar2_docker.DEFAULT_IMAGE}",
+)
+
+
+def _weight_only_quantized_matmul_model() -> onnx.ModelProto:
+    """`y = MatMul(x, DequantizeLinear(wq, scale, zp))` -- the minimal shape
+    of what both `onnxsim.quantize_weight_only()` and
+    `onnxsim.quantize_static()` emit around a MatMul's weight."""
+    rng = np.random.RandomState(0)
+    w = rng.randn(8, 8).astype(np.float32)
+    wq = np.clip(np.round(w / 0.01), -127, 127).astype(np.int8)
+    scale = np.full((8,), 0.01, dtype=np.float32)
+    zp = np.zeros((8,), dtype=np.int8)
+
+    dq = helper.make_node("DequantizeLinear", ["wq", "scale", "zp"], ["w_dq"], axis=1)
+    mm = helper.make_node("MatMul", ["x", "w_dq"], ["y"])
+    graph = helper.make_graph(
+        [dq, mm],
+        "g_minimal_wo_quant",
+        [helper.make_tensor_value_info("x", onnx.TensorProto.FLOAT, [1, 8])],
+        [helper.make_tensor_value_info("y", onnx.TensorProto.FLOAT, [1, 8])],
+        initializer=[
+            numpy_helper.from_array(wq, name="wq"),
+            numpy_helper.from_array(scale, name="scale"),
+            numpy_helper.from_array(zp, name="zp"),
+        ],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    model.ir_version = 8
+    return model
+
+
+def test_quantonnx_matmul_with_dequantizelinear_weight_crashes(tmp_path):
+    """Confirmed real: `pulsar2 build --model_type QuantONNX` recognizes the
+    already-quantized graph (prints "is a QuantONNX model") but its own
+    internal PPQ graph-optimization pass crashes on a quantized-weight
+    MatMul specifically -- a real Pulsar2 bug, not something fixable from
+    the ONNX side. This is why feeding onnxsim's own weight-only/static
+    quantizer output as QuantONNX can't currently substitute for Pulsar2's
+    own (accuracy-losing, for deep transformers) PTQ."""
+    model = _weight_only_quantized_matmul_model()
+    onnx.checker.check_model(model)
+
+    work_dir = tmp_path / "quantonnx_minimal"
+    work_dir.mkdir()
+    onnx.save(model, str(work_dir / "model.onnx"))
+
+    rng = np.random.RandomState(0)
+    (work_dir / "dataset").mkdir()
+    samples = [rng.randn(1, 8).astype(np.float32) for _ in range(4)]
+    pulsar2_docker.make_numpy_calibration_tar(
+        str(work_dir / "dataset" / "x.tar"), samples
+    )
+
+    cfg = {
+        "model_type": "QuantONNX",
+        "npu_mode": "NPU1",
+        "quant": {
+            "input_configs": [
+                {
+                    "tensor_name": "x",
+                    "calibration_dataset": "./dataset/x.tar",
+                    "calibration_format": "Numpy",
+                    "calibration_size": 4,
+                }
+            ],
+            "calibration_method": "MinMax",
+            "precision_analysis": False,
+        },
+        "compiler": {"check": 0},
+    }
+    (work_dir / "config").mkdir()
+    with open(work_dir / "config" / "cfg.json", "w") as f:
+        json.dump(cfg, f)
+
+    result = pulsar2_docker.build(
+        str(work_dir), "model.onnx", "output", config_path="config/cfg.json"
+    )
+    assert not result.success
+    assert "expects exact 2 inputs" in result.error


### PR DESCRIPTION
## Summary

Continues the `SmolLM2-135M` accuracy investigation (from #1115, merged): tried every remaining exposed Pulsar2 quantization knob against the real generic `pulsar2 build` (ONNX) path to see if any of them close the accuracy gap to `llm_build()`'s weight-only scheme. None do -- this documents why, with two new real findings:

- **`quant.layer_configs`' `data_type: "FP32"` is only valid for a specific, documented op list** (`LeakyRelu, Sigmoid, Relu, Add, Mul, Div, Sub, Concat, Softmax`) -- fetched from Pulsar2's own config schema docs. This retroactively explains an earlier attempt's silent no-op (a `ReduceMean`/`Sqrt` override, RMSNorm's own ops): it wasn't a bug in this harness, just an invalid config value Pulsar2 doesn't validate or warn about. Retried with only doc-valid op types: `Add`/`Mul`/`Div`/`Sub` are confirmed to have a real effect on the compiled output; `Softmax` alone has zero effect on final on-device output (though it does perturb a few bytes of the intermediate quantized IR). Stacking all four working overrides together does **not** recover accuracy -- if anything, it gets slightly worse (avg cosine ~-0.33 vs baseline's ~-0.20 across 5 real prompts, still 0/5 top-1 matches).
- **`model_type: "QuantONNX"` (feeding a pre-quantized ONNX graph, meant to bypass Pulsar2's own PTQ)** is a real, distinct ingestion path -- confirmed via `pulsar2 build` printing `"... is a QuantONNX model, disable concat align config"`. The idea: feed onnxsim's own `quantize_weight_only()` (matches `llm_build()`'s real S8-weight-only scheme exactly) or `quantize_static()` (already confirmed elsewhere in this file to match AX650's real U8-activation/S8-weight convention) instead of letting Pulsar2's own naive PTQ run. But it hits a real, reproducible **Pulsar2-internal bug**: any `MatMul` whose weight input comes through a `DequantizeLinear` (the standard ONNX QDQ per-channel weight-quantization pattern -- exactly what both onnxsim quantizers emit) crashes Pulsar2's own PPQ-based graph-optimization pass with `ValueError: Can not feed value to operation <node>, expects exact 2 inputs, however 1 was given` -- one of MatMul's two inputs is silently dropped. Isolated to a minimal, 2-node, 104-byte repro (no LLM structure involved at all), and confirmed to happen identically whether the activation side is also quantized (full QDQ) or left plain float (weight-only) -- ruling out any interaction with activation quantization specifically.

**Verdict, after 7 distinct techniques tried across this investigation** (SmoothQuant, highest-mix-precision, layer_configs with invalid then valid op types, AdaRound, QuantONNX weight-only, QuantONNX full-QDQ): the generic `pulsar2 build` (ONNX) ingestion path cannot currently reproduce `llm_build()`'s real, usable LLM accuracy on AX650, regardless of quantization strategy applied from the ONNX side. `llm_build()`'s separate, closed-source, non-ONNX ingestion remains the only confirmed-accurate path to a real LLM `.axmodel` today.

`tests/test_axera_quantonnx.py` locks in the minimal `QuantONNX`+`MatMul`+`DequantizeLinear` crash as a real regression test -- cheap and fast (~11s), unlike the full 30-layer model experiments this narrative is built on.

## Test plan
- [x] `python -m pytest tests/test_axera_quantonnx.py -v` -- 1 passed, for real against the real `pulsar2:6.0-lite` image.
- [x] `python -m pytest tests/test_pulsar2_compat.py tests/test_pulsar2_simulator.py tests/test_axera_conv_matmul_coverage.py -q` -- 25 passed, no regressions.
- [x] `ruff check` / `ruff format --check` clean.
- [x] YAML-validated `axera-integration.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UC8vhJgE71RLFF4DgdSP9P