### PR TITLE
Fix true-MQA (kv_num_heads=1) decomposed attention-head pruning no-op

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -23429,7 +23429,19 @@ def _find_sparse_attention_chains(
 #   :func:`_gqa_group_importance`-based ranking (plain or Wanda-wrapped) and
 #   :func:`_apply_one_decomposed_gqa_chain` slicing this section already
 #   built for the plain variant -- pure wiring, no matching/slicing logic
-#   specific to either the calibrated or dry-run path.
+#   specific to either the calibrated or dry-run path. True MQA
+#   (`kv_num_heads == 1`) shares :func:`_apply_one_gqa_chain`'s own dedicated
+#   fast path here too, not just for the fused-node family: KV-group
+#   granularity can never drop anything for it (there is only ever one
+#   group, so the group-keep-count formula is always a no-op), so
+#   individual query heads are ranked and dropped directly instead
+#   (:func:`_gqa_query_head_importance`/`_wanda_gqa_query_head_importance`,
+#   both fully reused, unmodified, since :class:`_DecomposedGQAChain` shares
+#   every field either reads off a chain), leaving the sole shared KV head --
+#   and both its own K/V producer weights and `kv_num_heads` itself --
+#   completely untouched. See :func:`_apply_one_gqa_chain`'s own docstring
+#   for the full reasoning and :func:`_apply_one_decomposed_gqa_chain`'s own
+#   for this family's version of it.
 # - Packed-QKV (:func:`_match_packed_qkv_split`'s own shape -- one shared
 #   MatMul/vanilla-Gemm projection feeding a `Split` into Q-then-K-then-V
 #   column ranges, each of which then independently feeds this section's
@@ -25565,6 +25577,7 @@ def _apply_one_decomposed_gqa_chain(
     sparsity: float,
     compute_group_importance,
     bias_ctx: _DynamicHeadBiasContext,
+    compute_query_importance=None,
 ) -> Optional[Tuple[Set[str], str, Set[str]]]:
     """Applies whole-KV-group pruning to one matched decomposed attention
     block -- the decomposed-shape analogue of :func:`_apply_one_gqa_chain`
@@ -25609,10 +25622,38 @@ def _apply_one_decomposed_gqa_chain(
     Returns ``(producer_weight_names, consumer_weight_name,
     stale_output_names)`` on success, or ``None`` if `sparsity` rounds to no
     groups dropped for this block (a no-op, left for the caller to skip).
+
+    True MQA (``chain.kv_num_heads == 1``) is the same dedicated fast path
+    :func:`_apply_one_gqa_chain` has -- see that function's own docstring
+    for the full reasoning. With exactly one KV group, the ordinary
+    group-granularity formula (``max(1, 1 - round(1 * sparsity))``) is
+    always `1 == kv_num_heads`, so it can never drop anything no matter how
+    many query heads (`chain.num_heads`) share that one KV head. This path
+    instead ranks and drops individual *query* heads directly
+    (`_gqa_query_head_importance`/`compute_query_importance`), leaving the
+    single shared KV head -- and both its own K/V producer weights and
+    `kv_num_heads` itself -- completely untouched: `keep_groups` stays fixed
+    at the sole surviving group (`[0]`, an identity slice of a size-1 axis),
+    and only `keep_q_heads`/`new_num_heads` are computed differently.
     """
+    if compute_query_importance is None:
+        # Default deferred to call time, not the function signature itself
+        # (unlike :func:`_apply_one_gqa_chain`'s own identical-looking
+        # default): `_gqa_query_head_importance` is defined later in this
+        # module than this function, so binding it directly as a parameter
+        # default would evaluate at *module import* time, before that name
+        # exists yet, and fail with a `NameError`.
+        compute_query_importance = _gqa_query_head_importance
     h = chain.kv_num_heads
     keep_count = max(1, h - round(h * sparsity))
-    if keep_count >= h:
+    is_mqa = h == 1 and chain.num_heads > 1
+    q_keep_count = 0
+    if is_mqa:
+        nq_total = chain.num_heads
+        q_keep_count = max(1, nq_total - round(nq_total * sparsity))
+        if q_keep_count >= nq_total:
+            return None  # no query heads prunable at this sparsity either
+    elif keep_count >= h:
         return None
 
     d = chain.head_size
@@ -25655,11 +25696,23 @@ def _apply_one_decomposed_gqa_chain(
         if chain.v_weight_transposed:
             wv_kn = wv_kn.T
 
-    importance = compute_group_importance(chain, wq_kn, wk_kn, wv_kn)
-    keep_groups = np.sort(np.argsort(-importance)[:keep_count])
-    keep_q_heads = np.concatenate(
-        [np.arange(g * group_size, (g + 1) * group_size) for g in keep_groups]
-    )
+    if is_mqa:
+        # Fixed at the sole surviving KV group -- `_head_column_indices`
+        # below turns this into an identity slice of K's/V's own
+        # size-`kv_num_heads * head_size`/`kv_num_heads * v_head_size` axes
+        # (`kv_num_heads == 1`), so K/V stay byte-for-byte untouched; ranked
+        # per query head instead, directly by `compute_query_importance`,
+        # rather than expanding whichever groups `compute_group_importance`
+        # would have kept (meaningless here -- there is only ever one group).
+        keep_groups = np.zeros(1, dtype=np.int64)
+        q_importance = compute_query_importance(chain, wq_kn)
+        keep_q_heads = np.sort(np.argsort(-q_importance)[:q_keep_count])
+    else:
+        importance = compute_group_importance(chain, wq_kn, wk_kn, wv_kn)
+        keep_groups = np.sort(np.argsort(-importance)[:keep_count])
+        keep_q_heads = np.concatenate(
+            [np.arange(g * group_size, (g + 1) * group_size) for g in keep_groups]
+        )
     q_idx = _head_column_indices(keep_q_heads, d)
     k_idx = _head_column_indices(keep_groups, d)
     v_idx = _head_column_indices(keep_groups, dv)
@@ -25698,7 +25751,13 @@ def _apply_one_decomposed_gqa_chain(
         initializer_map[chain.consumer_weight], chain.consumer_weight_transposed, y_idx
     )
 
-    new_num_heads = keep_count * group_size
+    # `len(keep_q_heads)` rather than `keep_count * group_size`: identical
+    # for the ordinary group-pruning path (`keep_q_heads` is built there as
+    # exactly `keep_count` groups of `group_size` heads each), but the only
+    # correct count for the MQA fast path above, where `keep_q_heads` is an
+    # arbitrary top-`q_keep_count` subset of individual query heads with no
+    # group structure to multiply out.
+    new_num_heads = len(keep_q_heads)
     new_kv_num_heads = keep_count
 
     graph = bias_ctx.graph
@@ -25706,8 +25765,26 @@ def _apply_one_decomposed_gqa_chain(
     consumers_of = _consumers_of(graph)
 
     def _rewrite_shape_dim(
-        shape_name: str, owner_nodes: Sequence[onnx.NodeProto], index: int, value: int
+        shape_name: str,
+        owner_nodes: Sequence[onnx.NodeProto],
+        *edits: Tuple[int, int],
     ) -> None:
+        # `*edits` -- one or more `(index, value)` pairs, applied together
+        # in a single clone-or-edit-in-place decision -- rather than a lone
+        # `(index, value)` pair: needed by the MQA fast path's own
+        # `k_repeat_kv`/`v_repeat_kv` `Expand` target shape below, which
+        # must rewrite *two* dimensions of the same shape constant (both
+        # `kv_num_heads`, index 1, and the broadcast repeat count `n_rep`,
+        # index 2 -- see this function's own caller for why `n_rep` only
+        # ever needs touching for that path). Calling this function twice in
+        # a row for the same `shape_name`, once per dimension, would be
+        # unsafe for the "clone" branch below: the first call's clone
+        # rewires `owner_nodes` away from `shape_name` onto a fresh tensor,
+        # so a second call still keyed on the old `shape_name` would find
+        # `owner_nodes` no longer reading it at all (already migrated),
+        # silently losing that second edit -- see this function's own
+        # in-place-vs-clone branch for the mechanism this sidesteps by
+        # applying every edit atomically instead.
         shape_init = initializer_map[shape_name]
         dims = onnx.numpy_helper.to_array(shape_init).copy()
         owner_ids = {id(n) for n in owner_nodes}
@@ -25720,7 +25797,8 @@ def _apply_one_decomposed_gqa_chain(
             # mutating the shared original.
             new_name = _mint_unique_name(f"{shape_name}_pruned", used_names)
             new_dims = dims.copy()
-            new_dims[index] = value
+            for index, value in edits:
+                new_dims[index] = value
             new_init = onnx.numpy_helper.from_array(new_dims, name=new_name)
             graph.initializer.append(new_init)
             initializer_map[new_name] = new_init
@@ -25729,7 +25807,8 @@ def _apply_one_decomposed_gqa_chain(
                     if inp == shape_name:
                         owner.input[i] = new_name
         else:
-            dims[index] = value
+            for index, value in edits:
+                dims[index] = value
             shape_init.CopyFrom(
                 onnx.numpy_helper.from_array(dims, name=shape_init.name)
             )
@@ -25746,25 +25825,41 @@ def _apply_one_decomposed_gqa_chain(
         _rewrite_shape_dim(
             chain.packed_flatten_reshape_shape,
             (chain.packed_flatten_reshape,),
-            -1,
-            len(q_idx) + len(k_idx) + len(v_idx),
+            (-1, len(q_idx) + len(k_idx) + len(v_idx)),
         )
 
-    _rewrite_shape_dim(chain.q_reshape_shape, (chain.q_reshape,), 2, new_num_heads)
+    _rewrite_shape_dim(chain.q_reshape_shape, (chain.q_reshape,), (2, new_num_heads))
     if chain.k_reshape_shape == chain.v_reshape_shape:
         _rewrite_shape_dim(
             chain.k_reshape_shape,
             (chain.k_reshape, chain.v_reshape),
-            2,
-            new_kv_num_heads,
+            (2, new_kv_num_heads),
         )
     else:
         _rewrite_shape_dim(
-            chain.k_reshape_shape, (chain.k_reshape,), 2, new_kv_num_heads
+            chain.k_reshape_shape, (chain.k_reshape,), (2, new_kv_num_heads)
         )
         _rewrite_shape_dim(
-            chain.v_reshape_shape, (chain.v_reshape,), 2, new_kv_num_heads
+            chain.v_reshape_shape, (chain.v_reshape,), (2, new_kv_num_heads)
         )
+    # `expand_edits`: index 1 (`kv_num_heads`) always needs (re)writing --
+    # a no-op value for the MQA fast path, where it is unchanged, but still
+    # safe/cheap to include unconditionally. Index 2 (`n_rep`, the
+    # broadcast repeat count each KV head is tiled to) is invariant for the
+    # ordinary group-pruning path -- dropping a whole KV group never changes
+    # `group_size` for any surviving one, so this dimension needs no edit
+    # there -- but the MQA fast path can shrink `new_num_heads` (unlike
+    # `new_kv_num_heads`, fixed at 1) independently of any group structure,
+    # so `n_rep == new_num_heads / new_kv_num_heads == new_num_heads` must
+    # be rewritten too, or the `Expand`'s own literal target shape goes
+    # stale and the graph becomes unrunnable (a real, confirmed failure
+    # mode, not a hypothetical -- see this module's own decomposed-MQA test
+    # suite). Both edits are applied together, in one `_rewrite_shape_dim`
+    # call, whenever `is_mqa` -- see that function's own docstring for why
+    # two separate calls against the same shape name would be unsafe.
+    expand_edits: List[Tuple[int, int]] = [(1, new_kv_num_heads)]
+    if is_mqa:
+        expand_edits.append((2, new_num_heads))
     if (
         chain.k_repeat_kv is not None
         and chain.v_repeat_kv is not None
@@ -25773,23 +25868,20 @@ def _apply_one_decomposed_gqa_chain(
         _rewrite_shape_dim(
             chain.k_repeat_kv.expand_shape,
             (chain.k_repeat_kv.expand, chain.v_repeat_kv.expand),
-            1,
-            new_kv_num_heads,
+            *expand_edits,
         )
     else:
         if chain.k_repeat_kv is not None:
             _rewrite_shape_dim(
                 chain.k_repeat_kv.expand_shape,
                 (chain.k_repeat_kv.expand,),
-                1,
-                new_kv_num_heads,
+                *expand_edits,
             )
         if chain.v_repeat_kv is not None:
             _rewrite_shape_dim(
                 chain.v_repeat_kv.expand_shape,
                 (chain.v_repeat_kv.expand,),
-                1,
-                new_kv_num_heads,
+                *expand_edits,
             )
     if (
         chain.k_repeat_kv is not None
@@ -25802,27 +25894,24 @@ def _apply_one_decomposed_gqa_chain(
         _rewrite_shape_dim(
             chain.k_repeat_kv.merge_reshape_shape,
             (chain.k_repeat_kv.merge_reshape, chain.v_repeat_kv.merge_reshape),
-            1,
-            new_num_heads,
+            (1, new_num_heads),
         )
     else:
         if chain.k_repeat_kv is not None:
             _rewrite_shape_dim(
                 chain.k_repeat_kv.merge_reshape_shape,
                 (chain.k_repeat_kv.merge_reshape,),
-                1,
-                new_num_heads,
+                (1, new_num_heads),
             )
         if chain.v_repeat_kv is not None:
             _rewrite_shape_dim(
                 chain.v_repeat_kv.merge_reshape_shape,
                 (chain.v_repeat_kv.merge_reshape,),
-                1,
-                new_num_heads,
+                (1, new_num_heads),
             )
     if chain.out_reshape_shape is not None:
         _rewrite_shape_dim(
-            chain.out_reshape_shape, (chain.out_reshape,), -1, new_num_heads * dv
+            chain.out_reshape_shape, (chain.out_reshape,), (-1, new_num_heads * dv)
         )
 
     if chain.mask_node is not None and chain.mask_idx is not None:
@@ -26807,7 +26896,12 @@ def _apply_attention_chains(
         applied: Optional[Tuple[Set[str], str, Set[str]]]
         if isinstance(chain, _DecomposedGQAChain):
             applied = _apply_one_decomposed_gqa_chain(
-                initializer_map, chain, sparsity, compute_group_importance, bias_ctx
+                initializer_map,
+                chain,
+                sparsity,
+                compute_group_importance,
+                bias_ctx,
+                compute_query_importance,
             )
         elif isinstance(chain, _GQAChain):
             applied = _apply_one_gqa_chain(
@@ -27134,6 +27228,11 @@ def apply_attention_head_wanda_pruning(
     section comment -- at the identical whole-KV-group granularity, ranked
     by the same calibrated importance, since :class:`_DecomposedGQAChain`
     shares every field :func:`_gqa_group_importance` and this wrapper read.
+    True MQA (``kv_num_heads == 1``) gets the identical dedicated
+    query-head-granularity fast path for this family too -- see
+    :func:`_apply_one_gqa_chain`'s own docstring for the full reasoning --
+    ranked by `_wanda_gqa_query_head_importance` below, reused unmodified
+    (it too only ever reads fields both chain types share).
 
     :param model: the original onnx ModelProto or file path
     :param calibration_data: representative input batches to measure each
@@ -39693,13 +39792,13 @@ def _analyze_attention_chains(
     :func:`_analyze_attention_head_wanda_pruning` does, to fold in a
     calibrated activation norm) unmodified. `compute_query_importance` takes
     ``(chain, wq)`` -- the same true-MQA (`chain.kv_num_heads == 1`)
-    query-head-granularity fast path :func:`_apply_one_gqa_chain` itself
-    has (see that function's own docstring): only ever called for a real
-    `_GQAChain` (never `_DecomposedGQAChain`, out of scope for that path)
-    whose `kv_num_heads == 1`, in place of `compute_group_importance`, so
-    this dry-run report predicts the same query-head-level drops a real
-    call would make instead of reporting the ordinary group-granularity
-    formula's permanent no-op for it.
+    query-head-granularity fast path :func:`_apply_one_gqa_chain` (and its
+    decomposed-shape analogue, :func:`_apply_one_decomposed_gqa_chain`)
+    itself has (see that function's own docstring): called for either a real
+    `_GQAChain` or a `_DecomposedGQAChain` whose `kv_num_heads == 1`, in
+    place of `compute_group_importance`, so this dry-run report predicts the
+    same query-head-level drops a real call would make instead of reporting
+    the ordinary group-granularity formula's permanent no-op for it.
 
     `chains` also carries :class:`_DecomposedGQAChain` (see this module's
     own "Decomposed (un-fused) attention head pruning" section comment),
@@ -39725,7 +39824,18 @@ def _analyze_attention_chains(
             label = _node_label(chain.softmax_node)
             producer_names = {chain.q_weight, chain.k_weight, chain.v_weight}
             h = chain.kv_num_heads
-            is_mqa = False
+            # True MQA (`kv_num_heads == 1`) fast path -- mirrors the
+            # `_GQAChain` branch below (and
+            # :func:`_apply_one_decomposed_gqa_chain`'s own `is_mqa`
+            # handling): KV-group granularity can never drop anything for
+            # it (there is only ever one group), so `h` is swapped here to
+            # the query head count and every downstream keep-count/
+            # importance/report computation below runs at query-head
+            # granularity instead, exactly the same switch
+            # :func:`_apply_one_decomposed_gqa_chain` itself makes.
+            is_mqa = h == 1 and chain.num_heads > 1
+            if is_mqa:
+                h = chain.num_heads
             family = "attention_decomposed_group"
         elif isinstance(chain, _GQAChain):
             label = _node_label(chain.node)
@@ -39738,10 +39848,10 @@ def _analyze_attention_chains(
             # every downstream keep-count/importance/report computation below
             # runs at query-head granularity instead, exactly the same
             # switch :func:`_apply_one_gqa_chain` itself makes -- see that
-            # function's own docstring for the full writeup. Scoped to a real
-            # `_GQAChain` only, never :class:`_DecomposedGQAChain` (out of
-            # scope -- see this module's "Decomposed (un-fused) attention
-            # head pruning" section comment).
+            # function's own docstring for the full writeup. The
+            # `_DecomposedGQAChain` branch above computes the identical
+            # `is_mqa`/`h` swap for its own family, mirroring
+            # :func:`_apply_one_decomposed_gqa_chain`'s own fast path.
             is_mqa = h == 1 and chain.num_heads > 1
             if is_mqa:
                 h = chain.num_heads

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -43720,6 +43720,227 @@ def test_decomposed_gqa_pruning_unsupported_transpose_perm_is_declined():
     assert before == after
 
 
+# --- True decomposed MQA (kv_num_heads == 1) query-head pruning fast path --
+#
+# Regression coverage mirroring this module's own fused-op "True MQA
+# (kv_num_heads == 1) query-head pruning fast path" section above, but for
+# `_DecomposedGQAChain`/`_apply_one_decomposed_gqa_chain`: before this fix,
+# `_apply_one_decomposed_gqa_chain` still had the old, unfixed KV-group-only
+# formula (`max(1, h - round(h * sparsity))` with `h = kv_num_heads = 1`,
+# always `1 == h`), making the WHOLE decomposed-attention pruning pass a
+# no-op for every real decomposed-MQA export (Falcon-7B/StarCoder/
+# PaLM-family-style plain `torch.onnx.export`, never post-processed by ONNX
+# Runtime's own transformer-fusion pass) -- confirmed empirically via a real
+# `torch.onnx.export` pipeline. `_apply_one_decomposed_gqa_chain` now has the
+# identical dedicated fast path `_apply_one_gqa_chain` already has: individual
+# query heads are ranked and dropped directly, leaving the sole KV head --
+# and both its own K/V producer weights and `kv_num_heads` itself --
+# completely untouched. `_oracle_keep_query_heads`/`_head_idx` (defined in
+# this module's own fused-MQA section above) are reused verbatim -- both are
+# already chain-shape-agnostic (plain numpy over a `wq` array).
+
+
+def test_decomposed_mqa_pruning_shrinks_query_heads_kv_fully_untouched():
+    model, cfg = _decomposed_gqa_model(K=16, H=8, KVH=1, D=8, Out=16, seed=201)
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    wq_new, wk_new, wv_new, wo_new = _decomposed_weight_shapes(pruned)
+    d = cfg["D"]
+    assert wq_new.shape[1] == 4 * d  # max(1, 8 - round(8*0.5)) query heads kept
+    assert wo_new.shape[0] == 4 * d
+    # K/V producer weights completely untouched -- same shape AND same
+    # values as the original, unpruned model (the confirmed-fixed bug's own
+    # "byte-identical in/out" no-op signature, but now scoped to just K/V,
+    # not the whole block).
+    np.testing.assert_array_equal(wk_new, cfg["wk"])
+    np.testing.assert_array_equal(wv_new, cfg["wv"])
+
+
+def test_decomposed_mqa_pruning_is_not_a_complete_no_op():
+    # The confirmed bug itself: before this fix, this call was byte-identical
+    # to `model` for any `sparsity` (since `kv_num_heads == 1` always forced
+    # the group formula's early exit). It must not be anymore.
+    model, cfg = _decomposed_gqa_model(K=16, H=8, KVH=1, D=8, Out=16, seed=202)
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.75)
+    assert pruned.SerializeToString() != model.SerializeToString()
+
+    wq_new, _wk_new, _wv_new, _wo_new = _decomposed_weight_shapes(pruned)
+    d = cfg["D"]
+    assert wq_new.shape[1] == 2 * d  # max(1, 8 - round(8*0.75)) < original 8
+
+
+def test_decomposed_mqa_pruning_zero_sparsity_is_a_no_op():
+    model, cfg = _decomposed_gqa_model(K=16, H=8, KVH=1, D=8, Out=16, seed=203)
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.0)
+    before = {
+        t.name: onnx.numpy_helper.to_array(t).shape for t in model.graph.initializer
+    }
+    after = {
+        t.name: onnx.numpy_helper.to_array(t).shape for t in pruned.graph.initializer
+    }
+    assert before == after
+    wq_new, wk_new, wv_new, _wo_new = _decomposed_weight_shapes(pruned)
+    np.testing.assert_array_equal(wq_new, cfg["wq"])
+    np.testing.assert_array_equal(wk_new, cfg["wk"])
+    np.testing.assert_array_equal(wv_new, cfg["wv"])
+
+
+def test_decomposed_mqa_pruning_matches_oracle_exactly():
+    model, cfg = _decomposed_gqa_model(K=16, H=8, KVH=1, D=8, Out=16, seed=205)
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    d = cfg["D"]
+    new_h = 4  # max(1, 8 - round(8*0.5))
+    keep_q_heads = _oracle_keep_query_heads(cfg["wq"], cfg["H"], d, new_h)
+    q_idx = _head_idx(keep_q_heads, d)
+
+    oracle, _ = _decomposed_gqa_model(
+        K=cfg["K"],
+        H=len(keep_q_heads),
+        KVH=cfg["KVH"],
+        D=d,
+        Out=cfg["Out"],
+        seed=205,
+        wq=cfg["wq"][:, q_idx],
+        wk=cfg["wk"],
+        wv=cfg["wv"],
+        wout=cfg["wout"][q_idx, :],
+        bq=cfg["bq"][q_idx],
+        bk=cfg["bk"],
+        bv=cfg["bv"],
+        bout=cfg["bout"],
+        batch=cfg["batch"],
+        seq=cfg["seq"],
+    )
+
+    rng = np.random.default_rng(206)
+    x = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_decomposed_mqa_wanda_pruning_matches_oracle_exactly():
+    # Wanda-calibrated variant of the same fast path -- mirrors
+    # `test_mqa_wanda_pruning_matches_oracle_exactly`'s own oracle
+    # construction (ranking individual query heads, no KV group to combine
+    # activation norms across) applied to the decomposed shape, the same way
+    # `test_decomposed_gqa_wanda_pruning_matches_oracle_exactly` mirrors
+    # `test_gqa_wanda_pruning_matches_oracle_exactly` for genuine GQA.
+    model, cfg = _decomposed_gqa_model(K=16, H=8, KVH=1, D=8, Out=16, seed=207)
+
+    rng = np.random.default_rng(208)
+    x_cal = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    calibration_data = [{"X": x_cal}]
+
+    pruned = onnxsim.apply_attention_head_wanda_pruning(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned)
+
+    _wq_new, wk_new, wv_new, _wo_new = _decomposed_weight_shapes(pruned)
+    np.testing.assert_array_equal(wk_new, cfg["wk"])
+    np.testing.assert_array_equal(wv_new, cfg["wv"])
+
+    # `ctx2` -- the flattened `[batch*seq, H*Dv]` tensor feeding the
+    # O-projection Gemm -- is exactly `chain.consumer_node.input[0]`, the
+    # tensor `_wanda_attention_calibration_stats` probes for every chain
+    # kind uniformly (see that function's own docstring).
+    probe_model = onnx.ModelProto()
+    probe_model.CopyFrom(model)
+    probe_model.graph.output.append(onnx.ValueInfoProto(name="ctx2"))
+    (_, ctx2_cal) = _run(probe_model, {"X": x_cal})
+    act_norm = np.sqrt(np.mean(np.square(ctx2_cal.astype(np.float64)), axis=0))
+
+    d = cfg["D"]
+    importance = np.zeros(cfg["H"])
+    for h in range(cfg["H"]):
+        base = np.linalg.norm(cfg["wq"][:, h * d : (h + 1) * d])
+        act_head = np.linalg.norm(act_norm[h * d : (h + 1) * d])
+        importance[h] = base * max(act_head, 1e-8)
+    keep_q_heads = np.sort(np.argsort(-importance)[:4])  # max(1, 8-round(8*0.5))
+    q_idx = _head_idx(keep_q_heads, d)
+
+    oracle, _ = _decomposed_gqa_model(
+        K=cfg["K"],
+        H=len(keep_q_heads),
+        KVH=cfg["KVH"],
+        D=d,
+        Out=cfg["Out"],
+        seed=207,
+        wq=cfg["wq"][:, q_idx],
+        wk=cfg["wk"],
+        wv=cfg["wv"],
+        wout=cfg["wout"][q_idx, :],
+        bq=cfg["bq"][q_idx],
+        bk=cfg["bk"],
+        bv=cfg["bv"],
+        bout=cfg["bout"],
+        batch=cfg["batch"],
+        seq=cfg["seq"],
+    )
+
+    x = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_analyze_attention_head_pruning_decomposed_mqa_reports_query_head_drops():
+    # Dry-run (`analyze_pruning_sensitivity`) vs. real-call parity for the
+    # decomposed-shape MQA fast path -- mirrors
+    # `test_analyze_attention_head_pruning_mqa_reports_query_head_drops`'s own
+    # pattern: the report must predict query-head-granularity drops, not the
+    # permanent zero-drop the ordinary KV-group formula would give for
+    # `kv_num_heads == 1` (see this section's own top comment).
+    model, cfg = _decomposed_gqa_model(K=16, H=8, KVH=1, D=8, Out=16, seed=209)
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_attention_head_pruning, sparsity=0.5
+    )
+    assert len(report.layers) == 1
+    layer = report.layers[0]
+    assert layer.family == "attention_decomposed_group"
+    assert layer.total == cfg["H"]  # query-head total, not kv_num_heads(1)
+    assert layer.would_drop == 4  # max(1, 8 - round(8*0.5)) kept -> 4 dropped
+
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    wq_new, wk_new, wv_new, _wo_new = _decomposed_weight_shapes(pruned)
+    d = cfg["D"]
+    assert wq_new.shape[1] == (cfg["H"] - layer.would_drop) * d
+    np.testing.assert_array_equal(wk_new, cfg["wk"])
+    np.testing.assert_array_equal(wv_new, cfg["wv"])
+
+
+def test_analyze_attention_head_wanda_pruning_decomposed_mqa_reports_query_head_drops():
+    model, cfg = _decomposed_gqa_model(K=16, H=8, KVH=1, D=8, Out=16, seed=210)
+    rng = np.random.default_rng(211)
+    x_cal = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    calibration_data = [{"X": x_cal}]
+
+    report = onnxsim.analyze_pruning_sensitivity(
+        model,
+        onnxsim.apply_attention_head_wanda_pruning,
+        calibration_data=calibration_data,
+        sparsity=0.5,
+    )
+    assert len(report.layers) == 1
+    layer = report.layers[0]
+    assert layer.family == "attention_decomposed_group"
+    assert layer.total == cfg["H"]
+    assert layer.would_drop == 4
+
+    pruned = onnxsim.apply_attention_head_wanda_pruning(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    wq_new, wk_new, wv_new, _wo_new = _decomposed_weight_shapes(pruned)
+    d = cfg["D"]
+    assert wq_new.shape[1] == (cfg["H"] - layer.would_drop) * d
+    np.testing.assert_array_equal(wk_new, cfg["wk"])
+    np.testing.assert_array_equal(wv_new, cfg["wv"])
+
+
 def test_decomposed_attention_real_torch_export_pipeline():
     """The real end-to-end pipeline this whole feature targets:
     ``torch.onnx.export -> onnxsim.simplify() -> apply_attention_head_pruning``


### PR DESCRIPTION
## Summary

A recent PR fixed true-MQA (`kv_num_heads == 1`) for the fused-op GQA family (`_GQAChain`/`_apply_one_gqa_chain`): the KV-group-granularity keep_count formula is always a no-op when there's only one KV group, regardless of how many query heads share it, so a dedicated per-query-head fast path was added. The "decomposed" (un-fused, plain `torch.onnx.export`) attention family (`_DecomposedGQAChain`/`_apply_one_decomposed_gqa_chain`) has the identical semantics but never got the fix — it was left with the old, unfixed formula, making the entire decomposed-attention pruning pass a no-op for every real decomposed-MQA export (Falcon-7B/StarCoder/PaLM-family-style plain `torch.onnx.export`, not ORT-fused).

## Empirically confirmed facts

- Built a real eager-GQA `nn.Module` with `num_kv_heads=1`, ran it through `torch.onnx.export` → `onnxsim.simplify()` → `onnxsim.apply_attention_head_pruning(sparsity=0.5)`: `num_heads` stayed completely unchanged despite `sparsity=0.5`, confirming the decomposed shape reaches the pruning pass unfused and is a complete no-op before this fix.
- The dry-run analysis code had a matching comment confirming `is_mqa` was hard-coded `False` for `_DecomposedGQAChain`, explicitly "out of scope" — a known, now-stale gap.
- `_gqa_query_head_importance`/`_wanda_gqa_query_head_importance` (the fused family's own MQA scorers) are reused **verbatim, unmodified** here — `_DecomposedGQAChain` already shares every field either function reads off a chain, so no structural mismatch existed and no decomposed-specific variant was needed.

## What's added

- `_apply_one_decomposed_gqa_chain`: the identical `is_mqa` fast path `_apply_one_gqa_chain` already has — `keep_groups` fixed at `[0]` (K/V untouched), `keep_q_heads`/`new_num_heads` computed from `chain.num_heads` directly via `compute_query_importance` instead of the KV-group formula.
- **A latent shape-rewrite bug caught and fixed by the new tests**: the decomposed shape's `repeat_kv` `Expand` target shape constant carries *two* literal dimensions — `kv_num_heads` (always rewritten) and the broadcast repeat count `n_rep = num_heads/kv_num_heads` (previously assumed invariant, since dropping a whole KV group never changes `group_size` for a surviving one). The MQA fast path breaks that assumption: `new_num_heads` can shrink independently of `new_kv_num_heads` (fixed at 1), so `n_rep` must be rewritten too, or the `Expand`'s literal target shape goes stale and the graph becomes unrunnable. `_rewrite_shape_dim` was generalized to accept multiple `(index, value)` edits applied atomically in one call (two sequential single-edit calls would be unsafe for the existing clone-on-foreign-reader-shape path: the first call's clone migrates `owner_nodes` off the old shape name, so a second call keyed on that old name would silently no-op).
- `_apply_attention_chains`/`apply_attention_head_wanda_pruning`/both dry-run `_analyze_attention_chains` mirrors: threaded `compute_query_importance` through to `_apply_one_decomposed_gqa_chain`, and removed the hard-coded `is_mqa = False` for `_DecomposedGQAChain` in the dry-run path.
- Updated stale docstrings/comments claiming an individual query head is never dropped, or that this fast path is fused-family-only.

## Scope

Only `kv_num_heads == 1` (true decomposed MQA). The general decomposed-GQA (`kv_num_heads > 1`) path is unaffected and already correct.

## Test plan

- [x] New tests (7: shrink+KV-untouched, non-no-op regression, zero-sparsity no-op, oracle-exact plain + Wanda, dry-run parity plain + Wanda) fail on the pre-fix code and pass after the fix (verified independently via a before/after checkout — 6 of 7 genuinely fail without the fix, the trivial zero-sparsity one passes either way as expected)
- [x] `pytest tests/test_pruning.py -k "decomposed_mqa or decomposed_gqa or mqa"` — 40 passed, no regressions
- [x] `pytest tests/test_pruning.py -q` (full suite) — 839 passed (832 baseline + 7 new), same 103 pre-existing failures (stale compiled C++ extension noise, unrelated, confirmed identical on the pre-change commit)
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — no new issues

## Risks for reviewer

- The `_rewrite_shape_dim` signature change (single edit → `*edits`) touches every existing call site in this function; all were mechanically updated to the new `(index, value)` tuple form with no behavior change for the non-MQA path (confirmed by the full non-MQA decomposed-GQA test suite passing unchanged).
- Please double-check the `n_rep` dimension reasoning in the `Expand` target shape comment — it's the one non-mechanical piece of this change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_