### PR TITLE
Add Norm Tweaking: closed-form LayerNorm recalibration after quantization

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -83,6 +83,7 @@ from onnxsim.mlir_export import export_mlir
 from onnxsim.moequant import apply_moequant
 from onnxsim.mx_quantization import MXFP4_CODEBOOK, quantize_weight_only_mxfp4
 from onnxsim.nf4 import NF4_CODEBOOK, quantize_weight_only_nf4
+from onnxsim.norm_tweaking import apply_norm_tweaking
 from onnxsim.olive import quantize_weight_only_olive
 from onnxsim.omniquant import apply_omniquant
 from onnxsim.onnx_simplifier import (
@@ -233,6 +234,7 @@ __all__ = [
     "apply_dac",
     "apply_llm_int8",
     "apply_low_rank_compensation",
+    "apply_norm_tweaking",
     "MemoryPlan",
     "plan_activation_memory",
     "print_memory_plan",

--- a/onnxsim/norm_tweaking.py
+++ b/onnxsim/norm_tweaking.py
@@ -1,0 +1,230 @@
+"""Norm Tweaking (Li, Xu, Ni, Chen, Ye, Sun, 2023, "Norm Tweaking:
+High-performance Low-bit Quantization of Large Language Models",
+https://arxiv.org/abs/2309.02784). onnxsim ports the algorithm, not any
+framework's code, per the same rationale as :mod:`onnxsim.awq`/
+:mod:`onnxsim.gptq` (the paper's own reference implementation tweaks live
+PyTorch ``nn.LayerNorm`` modules with no ONNX export path).
+
+Every weight-quantization pass already in onnxsim -- ``quantize_weight_only_
+int4`` and everything built on it -- changes what a MatMul/Gemm/Conv
+computes, but leaves every LayerNormalization node in the graph completely
+untouched: its own ``scale``/``bias`` parameters were fit (during original
+model training) to the *float* activation distribution flowing into it, and
+nothing about weight quantization updates them to match the now-shifted
+distribution a quantized upstream layer actually produces. Norm Tweaking's
+own observation: a LayerNormalization node's ``scale``/``bias`` are exactly
+the right (and only) knobs to correct that shift with, because they're the
+very last operation before the corrected distribution needs to be correct,
+and the correction is nearly free -- one channel-wise scale and one
+channel-wise shift per LayerNormalization node, no gradient descent, no
+extra graph nodes, unlike a full reconstruction pass (:mod:`onnxsim.adaround`
+/:mod:`onnxsim.gptq`) or an inserted correction op (:mod:`onnxsim.
+bias_correction`, which adds a new ``Add`` node after a Conv/Gemm/MatMul
+instead of ever touching an existing parameter).
+
+This module's own version of the technique (a reproduction of the paper's
+own described mechanism -- match the quantized model's LayerNorm *output*
+distribution back to the float model's own, per channel -- not a
+transcription of the paper's own reported per-model results, which this
+module does not claim to reproduce): for every ``LayerNormalization`` node
+present (by output tensor name) in both ``float_model`` and
+``quantized_model``, this runs both models on the same calibration data and
+measures that node's own output tensor's per-channel (last axis) mean
+``mu`` and standard deviation ``sigma``, in both models. Because
+``LayerNormalization``'s own definition is
+``scale * normalize(x) + bias`` (``normalize`` is exactly mean-0/std-1 per
+instance, so ``scale``/``bias`` are the *only* remaining source of any
+distributional difference in a well-formed graph), a single closed-form
+per-channel affine transform recovers the float distribution exactly on the
+calibration data seen: solving
+``alpha * quantized_output + beta == float_output`` for matching first and
+second moments gives ``alpha = sigma_float / sigma_quantized`` and
+``beta = mu_float - alpha * mu_quantized``, and because
+``alpha * (scale * normalize(x) + bias) + beta
+    == (alpha * scale) * normalize(x) + (alpha * bias + beta)``,
+that correction folds directly into a new ``scale`` / ``bias`` for the same
+node -- exactly the paper's own "tweak the norm's own parameters in place"
+mechanism, with no extra graph nodes needed at all (unlike this repo's own
+:func:`onnxsim.correct_bias`, whose correction targets a Conv/Gemm/MatMul's
+additive output bias instead, a different operator with no built-in
+post-normalization affine to fold into).
+
+**Scope note**: only ``LayerNormalization`` nodes (opset 17+'s single fused
+op) with a 1-D ``scale`` (and optional ``bias``) whose length matches the
+node's own output last-axis size are handled -- the overwhelmingly common
+shape for a transformer's per-token normalization (``axis=-1``, the
+default). A LayerNorm normalizing over more than one trailing axis, or a
+graph still using the older ``ReduceMean``/``Sub``/``Pow``/... decomposition
+instead of the fused op, is left untouched rather than guessed at.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Sequence, Tuple, Union
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+
+from onnxsim import backend
+from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.calibration import Tensors, generate_random_calibration_data
+
+
+def apply_norm_tweaking(
+    float_model: Union[str, onnx.ModelProto],
+    quantized_model: Union[str, onnx.ModelProto],
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_samples: int = 8,
+    seed: int = 0,
+    providers: Optional[Sequence[str]] = None,
+    eps: float = 1e-6,
+) -> onnx.ModelProto:
+    """Recalibrates every matched ``LayerNormalization`` node's own
+    ``scale``/``bias`` parameters in ``quantized_model`` so its output
+    distribution's per-channel mean and standard deviation, measured on
+    ``calibration_data``, matches ``float_model``'s own -- see this
+    module's own docstring for the closed-form derivation.
+
+    :param float_model: the original (unquantized) onnx ModelProto or file
+            path
+    :param quantized_model: a quantized version of ``float_model`` (onnx
+            ModelProto or file path), e.g. from
+            :func:`onnxsim.quantize_weight_only_int4` or any ``quantize_*``
+            function. Assumes ``quantized_model`` was produced from
+            ``float_model`` without renaming any ``LayerNormalization``
+            node's own output tensor -- true of every onnxsim ``quantize_*``
+            function.
+    :param calibration_data: representative input batches to measure each
+            node's own float-vs-quantized output distribution on -- see
+            :func:`onnxsim.correct_bias`'s own parameter of the same name
+    :param num_samples: random batches to generate when
+            ``calibration_data`` is omitted
+    :param seed: seed for the random calibration data (ignored if
+            ``calibration_data`` is supplied)
+    :param providers: onnxruntime execution providers to run both models on
+    :param eps: added to the measured quantized-side standard deviation
+            before dividing, to avoid blowing up on a (near-)constant
+            channel
+    :returns: ``quantized_model`` with every matched ``LayerNormalization``
+            node's ``scale``/``bias`` initializers replaced by tweaked
+            copies (new initializers, uniquely named -- the originals are
+            left in the model only if some other node still references
+            them)
+    """
+    if isinstance(float_model, str):
+        float_model = onnx.load(float_model, load_external_data=False)
+    if isinstance(quantized_model, str):
+        quantized_model = onnx.load(quantized_model, load_external_data=False)
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            float_model, num_samples=num_samples, seed=seed
+        )
+
+    quantized_by_output: Dict[str, onnx.NodeProto] = {}
+    for n in quantized_model.graph.node:
+        if n.op_type == "LayerNormalization" and n.output:
+            quantized_by_output[n.output[0]] = n
+
+    q_initializers = {t.name: t for t in quantized_model.graph.initializer}
+
+    candidates: List[Tuple[str, onnx.NodeProto]] = []
+    for n in float_model.graph.node:
+        if n.op_type != "LayerNormalization" or not n.output:
+            continue
+        q_node = quantized_by_output.get(n.output[0])
+        if q_node is None or len(q_node.input) < 2:
+            continue
+        scale_init = q_initializers.get(q_node.input[1])
+        if scale_init is None or len(scale_init.dims) != 1:
+            continue
+        candidates.append((n.output[0], q_node))
+    if not candidates:
+        return quantized_model
+
+    names = [name for name, _ in candidates]
+    float_probe = _add_probe_outputs(float_model, names)
+    quantized_probe = _add_probe_outputs(quantized_model, names)
+
+    f_sum: Dict[str, np.ndarray] = {}
+    f_sumsq: Dict[str, np.ndarray] = {}
+    q_sum: Dict[str, np.ndarray] = {}
+    q_sumsq: Dict[str, np.ndarray] = {}
+    counts: Dict[str, int] = {}
+
+    for batch in calibration_data:
+        f_out = backend.run_model(float_probe, batch, providers=providers)
+        q_out = backend.run_model(quantized_probe, batch, providers=providers)
+        for name in names:
+            f = np.asarray(f_out[name], dtype=np.float64)
+            q = np.asarray(q_out[name], dtype=np.float64)
+            if f.shape != q.shape or f.ndim == 0:
+                continue
+            channels = f.shape[-1]
+            f2 = f.reshape(-1, channels)
+            q2 = q.reshape(-1, channels)
+            if name in counts:
+                f_sum[name] += f2.sum(axis=0)
+                f_sumsq[name] += np.square(f2).sum(axis=0)
+                q_sum[name] += q2.sum(axis=0)
+                q_sumsq[name] += np.square(q2).sum(axis=0)
+                counts[name] += f2.shape[0]
+            else:
+                f_sum[name] = f2.sum(axis=0)
+                f_sumsq[name] = np.square(f2).sum(axis=0)
+                q_sum[name] = q2.sum(axis=0)
+                q_sumsq[name] = np.square(q2).sum(axis=0)
+                counts[name] = f2.shape[0]
+
+    corrected = onnx.ModelProto()
+    corrected.CopyFrom(quantized_model)
+    taken_names = _all_names(corrected.graph)
+    initializer_index = {t.name: i for i, t in enumerate(corrected.graph.initializer)}
+    node_by_output = {
+        n.output[0]: n
+        for n in corrected.graph.node
+        if n.op_type == "LayerNormalization" and n.output
+    }
+
+    for name in names:
+        if name not in counts:
+            continue
+        n = counts[name]
+        mu_f = f_sum[name] / n
+        var_f = np.maximum(f_sumsq[name] / n - mu_f**2, 0.0)
+        sigma_f = np.sqrt(var_f)
+        mu_q = q_sum[name] / n
+        var_q = np.maximum(q_sumsq[name] / n - mu_q**2, 0.0)
+        sigma_q = np.sqrt(var_q)
+
+        alpha = sigma_f / (sigma_q + eps)
+        beta = mu_f - alpha * mu_q
+
+        q_node = node_by_output[name]
+        scale_init = corrected.graph.initializer[initializer_index[q_node.input[1]]]
+        old_scale = onnx.numpy_helper.to_array(scale_init).astype(np.float64)
+        new_scale = (old_scale * alpha).astype(np.float32)
+        new_scale_name = _unique_name(f"{name}_norm_tweak_scale", taken_names)
+        corrected.graph.initializer.append(
+            onnx.numpy_helper.from_array(new_scale, name=new_scale_name)
+        )
+        q_node.input[1] = new_scale_name
+
+        if len(q_node.input) >= 3 and q_node.input[2]:
+            old_bias_init = corrected.graph.initializer[
+                initializer_index[q_node.input[2]]
+            ]
+            old_bias = onnx.numpy_helper.to_array(old_bias_init).astype(np.float64)
+            new_bias = (alpha * old_bias + beta).astype(np.float32)
+        else:
+            new_bias = beta.astype(np.float32)
+        new_bias_name = _unique_name(f"{name}_norm_tweak_bias", taken_names)
+        corrected.graph.initializer.append(
+            onnx.numpy_helper.from_array(new_bias, name=new_bias_name)
+        )
+        if len(q_node.input) >= 3:
+            q_node.input[2] = new_bias_name
+        else:
+            q_node.input.append(new_bias_name)
+
+    return corrected

--- a/tests/test_norm_tweaking.py
+++ b/tests/test_norm_tweaking.py
@@ -1,0 +1,169 @@
+"""Tests for ``onnxsim.apply_norm_tweaking`` (Norm Tweaking, see
+``onnxsim/norm_tweaking.py``) -- recalibrates a LayerNormalization node's
+own ``scale``/``bias`` parameters in place so its output distribution
+matches the float model's, correcting for the distribution shift a
+quantized upstream layer introduces.
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(np.asarray(array, dtype=np.float32), name)
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-9)
+
+
+def _matmul_ln_model(w, scale, bias, K, N, batch=8):
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          M = MatMul(X, W)
+          Y = LayerNormalization<axis = -1>(M, scale, bias)
+        }}
+        """,
+        initializer=[_f32(w, "W"), _f32(scale, "scale"), _f32(bias, "bias")],
+    )
+
+
+def _random_calibration(K, num_samples, batch=8, seed=0):
+    rng = np.random.default_rng(seed)
+    return [
+        {"X": rng.standard_normal((batch, K)).astype(np.float32)}
+        for _ in range(num_samples)
+    ]
+
+
+def test_norm_tweaking_recovers_known_scale_bias_corruption():
+    # The pre-LayerNorm activation (M = MatMul(X, W)) is identical between
+    # float_model and quantized_model here -- only the LayerNorm's own
+    # scale/bias were deliberately corrupted, simulating "wrong" norm
+    # parameters. Since normalize(x) is then exactly the same in both
+    # models, the closed-form moment-matching correction should recover the
+    # float model's output almost exactly.
+    rng = np.random.default_rng(0)
+    K, N = 16, 12
+    w = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    scale = rng.uniform(0.5, 1.5, N).astype(np.float32)
+    bias = rng.standard_normal(N).astype(np.float32)
+    float_model = _matmul_ln_model(w, scale, bias, K, N)
+
+    corrupted_scale = scale * rng.uniform(0.3, 3.0, N).astype(np.float32)
+    corrupted_bias = bias + rng.standard_normal(N).astype(np.float32) * 2.0
+    quantized_model = _matmul_ln_model(w, corrupted_scale, corrupted_bias, K, N)
+
+    calibration_data = _random_calibration(K, num_samples=32, seed=1)
+    tweaked = onnxsim.apply_norm_tweaking(
+        float_model, quantized_model, calibration_data=calibration_data
+    )
+    onnx.checker.check_model(tweaked)
+
+    x = np.concatenate([b["X"] for b in calibration_data], axis=0)
+    (float_y,) = _run(float_model, {"X": x})
+    (corrupted_y,) = _run(quantized_model, {"X": x})
+    (tweaked_y,) = _run(tweaked, {"X": x})
+
+    corrupted_err = _rel_l2(float_y, corrupted_y)
+    tweaked_err = _rel_l2(float_y, tweaked_y)
+    assert tweaked_err < 1e-4
+    assert tweaked_err < corrupted_err
+
+
+def test_norm_tweaking_reduces_error_after_real_int4_quantization():
+    # A realistic scenario: only the preceding MatMul's weight is actually
+    # quantized (via quantize_weight_only_int4), which leaves the
+    # LayerNorm's own scale/bias completely untouched even though the
+    # distribution flowing into it has shifted. Fit the tweak on one
+    # calibration batch and evaluate on a *held-out* batch, so this isn't
+    # just checking that the closed form reproduces its own fitting data.
+    rng = np.random.default_rng(2)
+    K, N = 32, 16
+    w = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    scale = rng.uniform(0.5, 1.5, N).astype(np.float32)
+    bias = rng.standard_normal(N).astype(np.float32)
+    float_model = _matmul_ln_model(w, scale, bias, K, N)
+
+    quant = onnxsim.quantize_weight_only_int4(float_model)
+    # quantize_weight_only_int4 must not have touched the LayerNorm node.
+    assert any(n.op_type == "LayerNormalization" for n in quant.graph.node)
+
+    fit_data = _random_calibration(K, num_samples=64, seed=3)
+    tweaked = onnxsim.apply_norm_tweaking(float_model, quant, calibration_data=fit_data)
+    onnx.checker.check_model(tweaked)
+
+    held_out = _random_calibration(K, num_samples=1, batch=256, seed=4)[0]["X"]
+    (float_y,) = _run(float_model, {"X": held_out})
+    (quant_y,) = _run(quant, {"X": held_out})
+    (tweaked_y,) = _run(tweaked, {"X": held_out})
+
+    quant_err = _rel_l2(float_y, quant_y)
+    tweaked_err = _rel_l2(float_y, tweaked_y)
+    assert tweaked_err < quant_err
+
+
+def test_norm_tweaking_preserves_scale_and_bias_shape():
+    rng = np.random.default_rng(5)
+    K, N = 8, 6
+    w = rng.standard_normal((K, N)).astype(np.float32)
+    scale = rng.uniform(0.5, 1.5, N).astype(np.float32)
+    bias = rng.standard_normal(N).astype(np.float32)
+    float_model = _matmul_ln_model(w, scale, bias, K, N, batch=4)
+    quant = onnxsim.quantize_weight_only_int4(float_model)
+
+    tweaked = onnxsim.apply_norm_tweaking(
+        float_model, quant, calibration_data=_random_calibration(K, 8, batch=4, seed=6)
+    )
+    ln_node = next(n for n in tweaked.graph.node if n.op_type == "LayerNormalization")
+    scale_t = next(t for t in tweaked.graph.initializer if t.name == ln_node.input[1])
+    bias_t = next(t for t in tweaked.graph.initializer if t.name == ln_node.input[2])
+    assert list(scale_t.dims) == [N]
+    assert list(bias_t.dims) == [N]
+
+
+def test_norm_tweaking_noop_when_no_layernorm_present():
+    model = _model(
+        """
+        g (float[4,4] X) => (float[4,4] Y)
+        {
+          Y = Relu(X)
+        }
+        """
+    )
+    result = onnxsim.apply_norm_tweaking(
+        model, model, calibration_data=[{"X": np.zeros((4, 4), dtype=np.float32)}]
+    )
+    assert result.SerializeToString() == model.SerializeToString()


### PR DESCRIPTION
## Summary

Adds `onnxsim.apply_norm_tweaking`, porting Norm Tweaking (Li, Xu, Ni, Chen, Ye, Sun, 2023, "Norm Tweaking: High-performance Low-bit Quantization of Large Language Models", https://arxiv.org/abs/2309.02784).

Every weight-quantization pass in onnxsim changes what a MatMul/Gemm/Conv computes, but leaves every `LayerNormalization` node's own `scale`/`bias` untouched, even though those were fit to the *float* activation distribution flowing into them. Norm Tweaking's own idea: since `LayerNormalization`'s definition is `scale * normalize(x) + bias` and `normalize(x)` is exactly mean-0/std-1 per instance, `scale`/`bias` are the only remaining source of any distributional difference in a well-formed graph -- so a cheap, closed-form per-channel affine correction, folded directly into new `scale`/`bias` values, recovers the float model's output distribution with no gradient descent and no extra graph nodes.

## What's added / scope

- `onnxsim/norm_tweaking.py`: `apply_norm_tweaking(float_model, quantized_model, calibration_data=None, ...)`. For every `LayerNormalization` node present (by output tensor name) in both models, measures that node's own output per-channel mean/std on calibration data in both models, and folds the closed-form moment-matching correction (`alpha = sigma_float / sigma_quantized`, `beta = mu_float - alpha * mu_quantized`) directly into new `scale`/`bias` initializers (`new_scale = alpha * scale`, `new_bias = alpha * bias + beta`).
- Scope note (stated in the module docstring): only handles the fused opset-17+ `LayerNormalization` op with a 1-D `scale`/`bias` matching the output's last-axis size -- the standard shape for a transformer's per-token norm. A LayerNorm normalizing over more than one trailing axis, or the older `ReduceMean`/`Sub`/`Pow`/... decomposition, is left untouched.
- `onnxsim/__init__.py`: exports `apply_norm_tweaking`.
- `tests/test_norm_tweaking.py`: 4 tests (built with `onnx.parser.parse_model`, per this repo's convention):
  - exact recovery of a deliberately-corrupted `scale`/`bias` when the pre-LayerNorm activation is otherwise identical between the two models (closed-form mechanism check, `rel_l2 < 1e-4`);
  - reduced error vs. an untweaked model after real `quantize_weight_only_int4` quantization of the preceding MatMul, fit on one calibration batch and evaluated on a *held-out* batch;
  - `scale`/`bias` shape preservation;
  - no-op when no `LayerNormalization` node is present.

## Empirically confirmed facts

Per this repo's practice of verifying rather than assuming: the "exact recovery" test confirms the closed-form derivation is correct to `< 1e-4` relative L2 (not just "close"), and the held-out-batch test confirms the correction actually generalizes beyond its own fitting data rather than only reproducing what it was fit on.

## Test plan

- `pytest tests/test_norm_tweaking.py -q` -- 4 passed
- `pytest tests/test_norm_tweaking.py tests/test_gptq.py tests/test_awq.py tests/test_bias_correction.py -q` -- 24 passed, no regression
- `ruff check onnxsim/norm_tweaking.py tests/test_norm_tweaking.py` -- clean
- `ruff format --check onnxsim/norm_tweaking.py tests/test_norm_tweaking.py` -- clean
- `mypy onnxsim/norm_tweaking.py` -- no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxBPwkiTv7m32wAZtAubyc

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxBPwkiTv7m32wAZtAubyc)_