### PR TITLE
Wire GAP->Flatten->matmul classifier-head hop into ConvInteger/QDQ walkers

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -15640,6 +15640,20 @@ def _walk_to_consumer_qdq(
     known rank (:func:`_norm_axis_is_last`), mirroring
     :func:`_walk_to_consumer`'s own identical parameter. Left ``None``, only
     the unambiguous ``axis == -1`` case of that hop is still recognized.
+
+    Within the `is_conv` family only, a `GlobalAveragePool` node hit mid-walk
+    is additionally checked for the ``-> Flatten(axis=1) -> {MatMul, vanilla
+    Gemm}`` classifier-head shape :func:`_match_gap_flatten_matmul_consumer`
+    describes -- mirroring the plain-float Conv chain's own
+    `recognize_gap_flatten_matmul_consumer` hop (see
+    :func:`_walk_to_conv_consumer`'s own docstring), reused verbatim here
+    since that matcher is domain/quantization-agnostic. A match ends the
+    walk there with a `_QDQConsumer` wrapping a plain (never QDQ-quantized)
+    `_WeightRef` -- `is_conv=False`, since the matched consumer has no
+    Conv/ConvTranspose-vs-MatMul/Gemm concept of its own beyond that. Never
+    tried in the MatMul/Gemm (`not is_conv`) family -- `GlobalAveragePool`
+    itself requires a Conv-shaped 4-D producer upstream, so there is no
+    equivalent shape to recognize there at all.
     """
     chain_ops: List[Tuple[onnx.NodeProto, Optional[str]]] = []
     cur = start
@@ -15693,6 +15707,55 @@ def _walk_to_consumer_qdq(
                     return None
                 ref, _bias, _out, _in = m
                 return _QDQConsumer(nxt, ref, False, True, True), tuple(chain_ops)
+            if (
+                nxt.op_type == "GlobalAveragePool"
+                and nxt.domain == ""
+                and list(nxt.input) == [cur]
+                and len(nxt.output) == 1
+            ):
+                # Mirrors the plain-float Conv chain's own
+                # `recognize_gap_flatten_matmul_consumer` hop (see
+                # :func:`_walk_to_conv_consumer`'s own docstring) -- the
+                # narrowly-scoped classifier-head shape
+                # :func:`_match_gap_flatten_matmul_consumer` describes,
+                # reused verbatim (it is domain/quantization-agnostic).
+                # Only tried on the `is_conv` (Conv/ConvTranspose-producer)
+                # side, never the MatMul/Gemm one -- `GlobalAveragePool`
+                # itself requires a Conv-shaped 4-D producer upstream, so
+                # there is no equivalent shape to recognize there at all,
+                # mirroring how the plain-float hop is scoped to
+                # :func:`_find_conv_chains` only. The matched consumer is
+                # always a plain, constant float weight (never QDQ-quantized
+                # -- the matcher only ever matches a plain float
+                # initializer), so it is wrapped in a plain `_WeightRef`
+                # (`ref.is_qdq` False), sliced by the ordinary
+                # :func:`_slice_consumer_weight` inside
+                # :func:`_slice_consumer_weight_qdq`'s own `ref.float_init`
+                # branch, exactly like any other plain-float QDQ-chain
+                # consumer.
+                gap_flatten_match = _match_gap_flatten_matmul_consumer(
+                    nxt.output[0],
+                    consumers_of,
+                    initializer_map,
+                    graph_outputs,
+                    n_channels,
+                )
+                if gap_flatten_match is not None:
+                    flatten_node, mm_node, mm_weight, mm_weight_transposed = (
+                        gap_flatten_match
+                    )
+                    mm_ref = _WeightRef(float_init=initializer_map[mm_weight])
+                    chain_ops.append((nxt, None))
+                    chain_ops.append((flatten_node, None))
+                    return (
+                        _QDQConsumer(mm_node, mm_ref, mm_weight_transposed, False),
+                        tuple(chain_ops),
+                    )
+                # No recognized Flatten(axis=1) -> {MatMul, vanilla Gemm}
+                # right after this GlobalAveragePool -- falls through to the
+                # ordinary handling below, exactly as if this check didn't
+                # exist (declines, since GlobalAveragePool isn't itself a
+                # recognized unary/norm hop for this walker).
         else:
             mm = _match_matmul_qdq(nxt, initializer_map, dq_of, consumers_of)
             if mm is not None and mm[0] == cur:
@@ -16170,6 +16233,20 @@ def apply_structured_pruning_qdq(
     keep-set between the two, mirroring
     :func:`apply_structured_pruning_matmul_nbits`'s own identical
     precedent.
+
+    One narrow exception on the Conv/``ConvTranspose`` producer side: a
+    producer whose logical output feeds ``GlobalAveragePool ->
+    Flatten(axis=1) -> {MatMul, vanilla Gemm}`` directly (the canonical
+    classifier head this shape's own docstring,
+    :func:`_match_gap_flatten_matmul_consumer`, proves is a trivial 1:1
+    channel relabeling) is also matched even though that consumer is never
+    itself QDQ-quantized -- mirroring the plain-float Conv chain's own
+    identical `recognize_gap_flatten_matmul_consumer` hop (see
+    :func:`_walk_to_conv_consumer`'s own docstring). Only reached via a
+    Conv/``ConvTranspose`` producer (:func:`_walk_to_consumer_qdq`'s own
+    `is_conv` family) -- a MatMul/Gemm producer has no equivalent shape to
+    recognize, since `GlobalAveragePool` itself requires a Conv-shaped 4-D
+    tensor upstream.
 
     Also handles the gated (SwiGLU/GeGLU) FFN pair
     (:func:`_find_qdq_gated_chains`, the QDQ analogue of
@@ -35052,13 +35129,26 @@ def _slice_conv_integer_consumer(w: _ConvIntegerConv, keep: np.ndarray) -> None:
 class _ConvIntegerChain:
     producer: _ConvIntegerConv
     chain_ops: Tuple[onnx.NodeProto, ...]
-    consumer: _ConvIntegerConv
+    # Exactly one of `consumer`/`matmul_consumer` is ever set. `consumer` is
+    # the ordinary same-family (`ConvInteger`-based) consumer role; a
+    # non-``None`` `matmul_consumer` instead means the walk terminated at the
+    # narrowly-scoped ``GlobalAveragePool -> Flatten(axis=1) -> {MatMul,
+    # vanilla Gemm}`` classifier-head shape (see
+    # :func:`_match_gap_flatten_matmul_consumer`'s own docstring and this
+    # module's plain-float :func:`_walk_to_conv_consumer`'s identical
+    # `recognize_gap_flatten_matmul_consumer` hop, which this one mirrors) --
+    # that consumer is always plain float (the matcher only ever matches a
+    # constant, plain-float weight), never a `_ConvIntegerConv`, so it is
+    # sliced via the ordinary :func:`_slice_consumer_weight`, not this
+    # section's own int8-aware consumer slicer.
+    consumer: Optional[_ConvIntegerConv]
     n_channels: int
     # Depthwise ConvInteger hops the chain walk crossed transparently between
     # the real producer and the real consumer (see
     # :class:`_ConvIntegerPassThrough`); empty for the common case of no
     # depthwise mid-chain hop.
     conv_pass_through: Tuple[_ConvIntegerPassThrough, ...] = ()
+    matmul_consumer: Optional[_ConsumerMatch] = None
 
 
 def _walk_to_conv_integer_consumer(
@@ -35071,9 +35161,10 @@ def _walk_to_conv_integer_consumer(
     max_hops: int,
 ) -> Optional[
     Tuple[
-        _ConvIntegerConv,
+        Optional[_ConvIntegerConv],
         Tuple[onnx.NodeProto, ...],
         Tuple[_ConvIntegerPassThrough, ...],
+        Optional[_ConsumerMatch],
     ]
 ]:
     """From tensor `start` (a matched ``ConvInteger`` Conv layer's own
@@ -35095,9 +35186,29 @@ def _walk_to_conv_integer_consumer(
     ``QLinearConv``-only walk, DELIBERATELY narrower than
     :func:`_walk_to_dynquant_consumer`'s own quantized-or-plain-float union
     (see this section's own top comment for why the plain-float-Conv-peer
-    case is a deliberate scope narrowing, not attempted here). Returns
-    ``None`` if the walk runs out of hops, hits a branch, or never reaches
-    such a consumer.
+    case is a deliberate scope narrowing, not attempted here).
+
+    As one narrow exception to that same-family-only restriction -- mirroring
+    the plain-float Conv chain walk's own `recognize_gap_flatten_matmul_consumer`
+    hop (see :func:`_walk_to_conv_consumer`'s own docstring) -- a
+    `GlobalAveragePool` node hit mid-walk is additionally checked for the
+    ``-> Flatten(axis=1) -> {MatMul, vanilla Gemm}`` shape
+    :func:`_match_gap_flatten_matmul_consumer` describes (reused here
+    verbatim: it is domain/quantization-agnostic, and by this point in the
+    walk `cur` is always already a plain float tensor -- `ConvInteger`'s own
+    rescale ``Mul``/``Cast`` pair, matched by :func:`_match_conv_integer`
+    before this walk's own `start` is even chosen, already produced a plain
+    float logical output). A match ends the walk there, returned as this
+    function's own 4th value (`_ConsumerMatch`-shaped: ``(node, weight,
+    weight_transposed)``) instead of the ordinary `_ConvIntegerConv`
+    consumer -- mutually exclusive with it, exactly like the plain-float
+    walk's own `matmul_consumer`. A `GlobalAveragePool` feeding anything else
+    (no recognized `Flatten`/matmul-consumer right after it) simply ends the
+    walk undeclined -- this walker has no other, unconditional use for a
+    pooling hop the way the plain-float Conv-chain walker does.
+
+    Returns ``None`` if the walk runs out of hops, hits a branch, or never
+    reaches either kind of consumer.
     """
     chain_ops: List[onnx.NodeProto] = []
     conv_pass_through: List[_ConvIntegerPassThrough] = []
@@ -35121,7 +35232,7 @@ def _walk_to_conv_integer_consumer(
                     ci_node, initializer_map, consumers_of, producers_of
                 )
                 if m is not None and m.dq_node is nxt and m.K == n_channels:
-                    return m, tuple(chain_ops), tuple(conv_pass_through)
+                    return m, tuple(chain_ops), tuple(conv_pass_through), None
                 depthwise = _match_conv_integer_depthwise_pass_through(
                     ci_node,
                     initializer_map,
@@ -35157,6 +35268,34 @@ def _walk_to_conv_integer_consumer(
             cur = out2
             continue
 
+        if (
+            nxt.op_type == "GlobalAveragePool"
+            and nxt.domain == ""
+            and list(nxt.input) == [cur]
+            and len(nxt.output) == 1
+        ):
+            gap_flatten_match = _match_gap_flatten_matmul_consumer(
+                nxt.output[0], consumers_of, initializer_map, graph_outputs, n_channels
+            )
+            if gap_flatten_match is not None:
+                flatten_node, mm_node, mm_weight, mm_weight_transposed = (
+                    gap_flatten_match
+                )
+                chain_ops.append(nxt)
+                chain_ops.append(flatten_node)
+                return (
+                    None,
+                    tuple(chain_ops),
+                    tuple(conv_pass_through),
+                    (mm_node, mm_weight, mm_weight_transposed),
+                )
+            # No recognized Flatten(axis=1) -> {MatMul, vanilla Gemm} right
+            # after this GlobalAveragePool -- this walker has no other,
+            # unconditional use for a pooling hop (unlike the plain-float
+            # Conv-chain walker's own `_CONV_POOL_PASS_THROUGH` membership),
+            # so decline outright, same as any other unmatched topology.
+            return None
+
         if not (
             nxt.op_type in _UNARY_PASS_THROUGH
             and list(nxt.input) == [cur]
@@ -35175,8 +35314,12 @@ def _find_conv_integer_chains(graph: onnx.GraphProto) -> List[_ConvIntegerChain]
     """Every ``ConvInteger``-based producer/consumer pair connected by
     :func:`_walk_to_conv_integer_consumer` -- both sides always
     ``ConvInteger``-based here (see this section's own top comment for why,
-    unlike :func:`_find_dynquant_chains`, there is no plain-float-peer union
-    to consider at all).
+    unlike :func:`_find_dynquant_chains`, there is no general plain-float-peer
+    union to consider), with one narrow exception: a producer whose logical
+    output reaches the classifier-head ``GlobalAveragePool -> Flatten(axis=1)
+    -> {MatMul, vanilla Gemm}`` shape instead surfaces as `matmul_consumer`
+    on the returned :class:`_ConvIntegerChain` (see
+    :func:`_walk_to_conv_integer_consumer`'s own docstring).
     """
     initializer_map = _constant_map(graph)
     consumers_of = _consumers_of(graph)
@@ -35208,10 +35351,15 @@ def _find_conv_integer_chains(graph: onnx.GraphProto) -> List[_ConvIntegerChain]
         )
         if found is None:
             continue
-        consumer, chain_ops, conv_pass_through = found
+        consumer, chain_ops, conv_pass_through, matmul_consumer = found
         chains.append(
             _ConvIntegerChain(
-                m, chain_ops, consumer, m.N, conv_pass_through=conv_pass_through
+                m,
+                chain_ops,
+                consumer,
+                m.N,
+                conv_pass_through=conv_pass_through,
+                matmul_consumer=matmul_consumer,
             )
         )
     return chains
@@ -35270,6 +35418,20 @@ def apply_structured_pruning_dynamic_quantize_conv(
     merge, or ``Concat``-merged branch group is matched either -- only the
     plain single-producer/single-consumer topology above.
 
+    One narrow exception to the same-family-only consumer rule: a producer
+    whose logical output feeds ``GlobalAveragePool -> Flatten(axis=1) ->
+    {MatMul, vanilla Gemm}`` directly (the canonical dynamically-quantized
+    classifier head this shape's own docstring, :func:`_match_gap_flatten_matmul_consumer`,
+    proves is a trivial 1:1 channel relabeling) is also matched, pruning the
+    producer's output channels together with the matching input channels of
+    that plain-float MatMul/Gemm consumer's weight -- mirroring the
+    plain-float Conv chain's own identical `recognize_gap_flatten_matmul_consumer`
+    hop (see :func:`_walk_to_conv_consumer`'s own docstring). That consumer
+    is never itself quantized (the matcher only ever matches a constant,
+    plain-float weight), so it is sliced by the ordinary
+    :func:`_slice_consumer_weight`, not this section's own int8-aware
+    consumer slicer.
+
     :param model: onnx ModelProto object or file path
     :param sparsity: fraction of each eligible producer's output channels to
             drop (rounded, at least one channel is always kept)
@@ -35297,14 +35459,22 @@ def apply_structured_pruning_dynamic_quantize_conv(
         if not chains:
             continue
 
+        initializer_map = _constant_map(graph)
         producer_touched: Set[str] = set()
         consumer_touched: Set[str] = set()
         stale_value_info: Set[str] = set()
 
         for chain in chains:
             p, c = chain.producer, chain.consumer
+            mm = chain.matmul_consumer
             p_key = p.w_init.name
-            c_key = c.w_init.name
+            # Exactly one of `c`/`mm` is ever set -- see
+            # :class:`_ConvIntegerChain`'s own docstring.
+            if c is not None:
+                c_key = c.w_init.name
+            else:
+                assert mm is not None
+                c_key = mm[1]  # the matched MatMul/Gemm consumer's weight name
             if p_key == c_key:
                 continue  # degenerate (the same weight in both roles)
             if p_key in producer_touched or c_key in consumer_touched:
@@ -35322,7 +35492,23 @@ def apply_structured_pruning_dynamic_quantize_conv(
             keep = np.sort(np.argsort(-importance, kind="stable")[:keep_count])
 
             _slice_conv_integer_producer(p, keep)
-            _slice_conv_integer_consumer(c, keep)
+            if c is not None:
+                _slice_conv_integer_consumer(c, keep)
+            else:
+                # The classifier-head hop's matched consumer is always a
+                # plain float MatMul/vanilla-Gemm (never a `ConvInteger`) --
+                # see :class:`_ConvIntegerChain`'s own `matmul_consumer`
+                # comment -- sliced by the ordinary
+                # :func:`_slice_consumer_weight`, not this section's own
+                # int8-aware `_slice_conv_integer_consumer`.
+                assert mm is not None
+                _, mm_weight, mm_weight_transposed = mm
+                _slice_consumer_weight(
+                    initializer_map[mm_weight],
+                    weight_transposed=mm_weight_transposed,
+                    keep=keep,
+                    is_conv=False,
+                )
 
             for hop in chain.conv_pass_through:
                 # Mirrors _apply_conv_pass_through_hop's identical
@@ -41540,7 +41726,14 @@ def _conv_integer_not_eligible(
     matched_ids: Set[int] = set()
     for chain in chains:
         matched_ids.add(id(chain.producer.node))
-        matched_ids.add(id(chain.consumer.node))
+        # `chain.consumer` is only ever `None` for the classifier-head hop
+        # (`chain.matmul_consumer` set instead -- see
+        # :class:`_ConvIntegerChain`'s own docstring), whose consumer is a
+        # plain MatMul/Gemm, never itself a `ConvInteger` -- so it could
+        # never appear in the `graph.node` filter below anyway, and needs
+        # no entry here.
+        if chain.consumer is not None:
+            matched_ids.add(id(chain.consumer.node))
     not_eligible = []
     for node in graph.node:
         if node.op_type != "ConvInteger":
@@ -41602,8 +41795,15 @@ def _analyze_structured_pruning_dynamic_quantize_conv(
 
         for chain in chains:
             p, c = chain.producer, chain.consumer
+            mm = chain.matmul_consumer
             p_key = p.w_init.name
-            c_key = c.w_init.name
+            # Exactly one of `c`/`mm` is ever set -- see
+            # :class:`_ConvIntegerChain`'s own docstring.
+            if c is not None:
+                c_key = c.w_init.name
+            else:
+                assert mm is not None
+                c_key = mm[1]
             if p_key == c_key:
                 continue  # degenerate (the same weight in both roles) -- no report row
 

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -30210,6 +30210,234 @@ def test_qdq_structured_pruning_conv_both_sides_qdq_matches_oracle():
     np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
 
 
+def _quantize_static_conv_weight(W, spatial=8):
+    """Runs the REAL ``onnxsim.quantize_static`` tool on a minimal
+    ``Y = Conv(X, W)`` wrapper model and returns the genuine per-channel
+    symmetric int8 ``(Wq[M,C,kH,kW], Wscale[M])`` pair it emits for `W` --
+    never a hand-rolled re-implementation. ``zero_point`` is never emitted
+    for a QDQ weight by this repo's own ``quantize_static`` (always
+    symmetric -- see this module's own "QDQ" section top comment), so this
+    returns only the two-tuple. Mirrors
+    `_quantize_dynamic_conv_weight` (this file's own ConvInteger-section
+    analogue) exactly, just against the static tool.
+    """
+    m, c, kh, kw = W.shape
+    pad_h, pad_w = (kh - 1) // 2, (kw - 1) // 2
+    src = _model(
+        f"""
+        g (float[1,{c},{spatial},{spatial}] X) => (float[1,{m},{spatial},{spatial}] Y)
+        {{
+          Y = Conv<kernel_shape=[{kh},{kw}], pads=[{pad_h},{pad_w},{pad_h},{pad_w}]>(X, W)
+        }}
+        """,
+        initializer=[_f32(W, "W")],
+    )
+    src = onnx.shape_inference.infer_shapes(src)
+    q = onnxsim.quantize_static(src)
+    conv_node = next(n for n in q.graph.node if n.op_type == "Conv")
+    w_name = conv_node.input[1]
+    dq = next(
+        n
+        for n in q.graph.node
+        if n.op_type == "DequantizeLinear" and n.output[0] == w_name
+    )
+    assert len(dq.input) == 2  # symmetric -- no zero_point, see above
+    inits = {t.name: t for t in q.graph.initializer}
+    Wq = onnx.numpy_helper.to_array(inits[dq.input[0]]).copy()
+    Wscale = onnx.numpy_helper.to_array(inits[dq.input[1]]).copy()
+    return Wq, Wscale
+
+
+def test_qdq_structured_pruning_conv_global_average_pool_flatten_gemm_pass_through_matches_oracle():
+    # The classifier-head hop `_walk_to_consumer_qdq`'s own `is_conv` branch
+    # gained, mirroring the plain-float walker's own
+    # `recognize_gap_flatten_matmul_consumer`: a QDQ Conv's own logical
+    # output feeding `GlobalAveragePool -> Flatten(axis=1) -> Gemm` directly
+    # is matched and pruned, with the matched Gemm consumer (plain,
+    # constant float, never itself quantized) sliced via the ordinary
+    # `_slice_consumer_weight`. Both Conv layers' weights are quantized via
+    # the REAL ``onnxsim.quantize_static`` tool (`_quantize_static_conv_weight`,
+    # never a hand-rolled re-implementation) -- per this repo's own
+    # CLAUDE.md convention, only the fixture weights come from the real
+    # tool, while the surrounding graph structure is assembled via
+    # `onnx.parser`.
+    #
+    # This model matches BOTH chains at once, exactly like
+    # `test_qdq_structured_pruning_conv_both_sides_qdq_matches_oracle`'s own
+    # topology extended with the classifier head: the ordinary same-family
+    # Conv->Conv chain (w1 producer / w2 consumer) AND the new
+    # classifier-head chain (w2 producer / Gemm consumer) -- w2 legitimately
+    # plays both roles, its own underlying `q_init` mutated in place by
+    # chain 1's consumer-role slice before chain 2's producer-role
+    # importance is ranked from it.
+    Cin, C1, C2, Out = 4, 6, 5, 3
+    rng = np.random.default_rng(60)
+    w1f = (rng.standard_normal((C1, Cin, 3, 3)) * 0.3).astype(np.float32)
+    w2f = (rng.standard_normal((C2, C1, 3, 3)) * 0.3).astype(np.float32)
+    w3f = (rng.standard_normal((Out, C2)) * 0.3).astype(np.float32)
+    w1q, w1s = _quantize_static_conv_weight(w1f)
+    w2q, w2s = _quantize_static_conv_weight(w2f)
+
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{Out}] Y)
+        {{
+          Wq1dq = DequantizeLinear<axis=0>(Wq1, Wscale1)
+          h0 = Conv<kernel_shape=[3,3]>(X, Wq1dq)
+          h0a = Relu(h0)
+          Wq2dq = DequantizeLinear<axis=0>(Wq2, Wscale2)
+          h1 = Conv<kernel_shape=[3,3]>(h0a, Wq2dq)
+          p = GlobalAveragePool(h1)
+          f = Flatten<axis=1>(p)
+          Y = Gemm<transB=1>(f, W3)
+        }}
+        """,
+        initializer=[
+            _i8(w1q, "Wq1"),
+            _f32(w1s, "Wscale1"),
+            _i8(w2q, "Wq2"),
+            _f32(w2s, "Wscale2"),
+            _f32(w3f, "W3"),
+        ],
+    )
+    onnx.checker.check_model(model)
+
+    chains = onnxsim.pruning._find_qdq_chains(model.graph)
+    assert len(chains) == 2
+    gap_chain = next(ch for ch in chains if not ch.consumer.is_conv)
+    assert gap_chain.consumer.node.op_type == "Gemm"
+    assert not gap_chain.consumer.ref.is_qdq  # plain float, never quantized
+    assert gap_chain.n_channels == C2
+
+    pruned = onnxsim.apply_structured_pruning_qdq(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    keep_count1 = C1 - round(C1 * 0.5)
+    keep_count2 = C2 - round(C2 * 0.5)
+    assert list(inits["Wq1"].dims) == [keep_count1, Cin, 3, 3]
+    assert list(inits["Wq2"].dims) == [keep_count2, keep_count1, 3, 3]
+    assert list(inits["Wscale2"].dims) == [keep_count2]
+    assert list(inits["W3"].dims) == [Out, keep_count2]
+
+    w1_dequant = _qdq_dequant(w1q, w1s, None, axis=0)
+    keep1 = _oracle_keep_indices_conv(w1_dequant, keep_count1)
+    # w2's own consumer-role (input-axis) slice by `keep1` happens before
+    # its producer-role importance is ranked -- see this test's own comment
+    # above.
+    w2_dequant_after_consumer_slice = _qdq_dequant(w2q, w2s, None, axis=0)[:, keep1]
+    keep2 = _oracle_keep_indices_conv(w2_dequant_after_consumer_slice, keep_count2)
+
+    rng2 = np.random.default_rng(61)
+    x = rng2.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run_unfused(pruned, {"X": x})
+
+    oracle = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{Out}] Y)
+        {{
+          h0 = Conv<kernel_shape=[3,3]>(X, W1)
+          h0a = Relu(h0)
+          h1 = Conv<kernel_shape=[3,3]>(h0a, W2)
+          p = GlobalAveragePool(h1)
+          f = Flatten<axis=1>(p)
+          Y = Gemm<transB=1>(f, W3)
+        }}
+        """,
+        initializer=[
+            onnx.numpy_helper.from_array(
+                w1_dequant[keep1].astype(np.float32), name="W1"
+            ),
+            onnx.numpy_helper.from_array(
+                w2_dequant_after_consumer_slice[keep2].astype(np.float32), name="W2"
+            ),
+            _f32(w3f[:, keep2], "W3"),
+        ],
+    )
+    (y_oracle,) = onnx.reference.ReferenceEvaluator(oracle).run(None, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_qdq_structured_pruning_conv_global_average_pool_flatten_gemm_real_quantize_static_pipeline_end_to_end():
+    # The full end-to-end pipeline counterpart: runs the REAL, whole-model
+    # ``onnxsim.quantize_static`` (real calibration + QDQ insertion) on a
+    # plain float `Conv -> Relu -> Conv -> GlobalAveragePool ->
+    # Flatten(axis=1) -> Gemm` model. `quantize_static` quantizes every
+    # Conv/MatMul/Gemm whose weight is constant (see its own docstring), so
+    # the classifier `Gemm` is deliberately given a NON-constant weight (a
+    # plain graph input) here -- keeping it out of `quantize_static`'s own
+    # scope, matching the shape this hop targets (a classifier head
+    # deliberately kept in float, common in real mixed-precision
+    # deployments) -- then that weight is supplied as a genuine constant
+    # AFTER quantization, the one piece `quantize_static` itself never
+    # touches. Confirmed empirically (this round's own investigation) that
+    # `quantize_static` wraps EVERY quantized node's own activation input in
+    # its own QuantizeLinear/DequantizeLinear pair -- so a constant-weight
+    # Gemm here would ALSO get its own Flatten-output activation wrapped,
+    # breaking this hop's own exact-adjacency requirement; leaving it
+    # non-constant during quantization (never touched by the quantizer,
+    # then genuinely populated) is the correct, not merely convenient, way
+    # to reproduce this scope with the real tool on a full model.
+    Cin, C1, C2, Out = 4, 6, 5, 3
+    rng = np.random.default_rng(62)
+    w1f = (rng.standard_normal((C1, Cin, 3, 3)) * 0.3).astype(np.float32)
+    w2f = (rng.standard_normal((C2, C1, 3, 3)) * 0.3).astype(np.float32)
+    w3f = (rng.standard_normal((Out, C2)) * 0.3).astype(np.float32)
+
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X, float[{Out},{C2}] W3) => (float[N,{Out}] Y)
+        {{
+          h0 = Conv<kernel_shape=[3,3]>(X, W1)
+          h0a = Relu(h0)
+          h1 = Conv<kernel_shape=[3,3]>(h0a, W2)
+          p = GlobalAveragePool(h1)
+          f = Flatten<axis=1>(p)
+          Y = Gemm<transB=1>(f, W3)
+        }}
+        """,
+        initializer=[_f32(w1f, "W1"), _f32(w2f, "W2")],
+    )
+    model = onnx.shape_inference.infer_shapes(model)
+    quantized = onnxsim.quantize_static(model)
+
+    # Post-hoc: the classifier Gemm's own weight was deliberately kept a
+    # graph input above (see this test's own comment) -- swap it for a
+    # genuine constant now, after quantization.
+    quantized.graph.initializer.append(_f32(w3f, "W3"))
+    remaining_inputs = [i for i in quantized.graph.input if i.name != "W3"]
+    del quantized.graph.input[:]
+    quantized.graph.input.extend(remaining_inputs)
+    onnx.checker.check_model(quantized)
+
+    op_types = [n.op_type for n in quantized.graph.node]
+    assert op_types.count("Conv") == 2
+    assert op_types.count("Gemm") == 1
+    # The classifier Gemm's own activation input (Flatten's output) is
+    # never wrapped in its own QuantizeLinear/DequantizeLinear pair, since
+    # its weight was never constant at quantization time -- confirming the
+    # exact-adjacency shape this hop needs really is present.
+    gemm_node = next(n for n in quantized.graph.node if n.op_type == "Gemm")
+    flatten_node = next(n for n in quantized.graph.node if n.op_type == "Flatten")
+    assert gemm_node.input[0] == flatten_node.output[0]
+
+    chains = onnxsim.pruning._find_qdq_chains(quantized.graph)
+    gap_chains = [ch for ch in chains if not ch.consumer.is_conv]
+    assert len(gap_chains) == 1
+    assert gap_chains[0].consumer.node.op_type == "Gemm"
+    assert gap_chains[0].n_channels == C2
+
+    pruned = onnxsim.apply_structured_pruning_qdq(quantized, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: list(t.dims) for t in pruned.graph.initializer}
+    keep_count2 = C2 - round(C2 * 0.5)
+    assert inits["W3"][1] == keep_count2
+
+    x = rng.standard_normal((1, Cin, 10, 10)).astype(np.float32)
+    (y_pruned,) = _run_unfused(pruned, {"X": x})
+    assert y_pruned.shape == (1, Out)
+    assert np.all(np.isfinite(y_pruned))
+
+
 # --- QDQ ConvTranspose -------------------------------------------------
 #
 # Mirrors tests/test_pruning.py's own plain-float
@@ -46222,6 +46450,91 @@ def _dqconv_model_from_weights(
     }
 
 
+def _dqconv_gap_flatten_gemm_model_from_weights(
+    c, m1, m2, out, w1f, w2f, w3f, b1f=None, spatial=8, activation="Relu", seed=0
+):
+    """The `_dqconv_model_from_weights` analogue exercising the classifier-
+    head hop `_walk_to_conv_integer_consumer` gained: ``ConvInteger ->
+    {activation} -> ConvInteger -> GlobalAveragePool -> Flatten(axis=1) ->
+    Gemm`` -- the SECOND ``ConvInteger``'s own logical output feeds
+    `GlobalAveragePool` directly (no activation in between, the canonical
+    classifier-head shape), with a plain, constant-float ``Gemm``
+    (``transB=1``) as the matched matmul consumer -- never itself
+    quantized, exactly like the plain-float walker's own identical hop (see
+    `_match_gap_flatten_matmul_consumer`'s own docstring). `w3f` is the
+    Gemm's own ``[out, m2]`` float weight. Returns ``(model, info)`` like
+    `_dqconv_model_from_weights`, with `W3f` added.
+    """
+    w1q, w1s, w1zp = _quantize_dynamic_conv_weight(w1f, spatial=spatial)
+    w2q, w2s, w2zp = _quantize_dynamic_conv_weight(w2f, spatial=spatial)
+
+    kh1, kw1 = w1f.shape[2], w1f.shape[3]
+    kh2, kw2 = w2f.shape[2], w2f.shape[3]
+    ph1, pw1 = (kh1 - 1) // 2, (kw1 - 1) // 2
+    ph2, pw2 = (kh2 - 1) // 2, (kw2 - 1) // 2
+
+    if b1f is not None:
+        bias_ops = """
+          b1r = Reshape(b1, b1_shape)
+          c1 = Add(c1s, b1r)
+        """
+        c1_out = "c1"
+    else:
+        bias_ops = ""
+        c1_out = "c1s"
+
+    body = f"""
+    g (float[1,{c},{spatial},{spatial}] x) => (float[1,{out}] y)
+    {{
+      xq, x_scale, x_zero_point = DynamicQuantizeLinear(x)
+      combined_scale1 = Mul(x_scale, w1_scale)
+      c1i = ConvInteger<kernel_shape=[{kh1},{kw1}], pads=[{ph1},{pw1},{ph1},{pw1}]>(xq, w1_quantized, x_zero_point, w1_zero_point)
+      c1f = Cast<to=1>(c1i)
+      c1s = Mul(c1f, combined_scale1)
+      {bias_ops}
+      h1 = {activation}({c1_out})
+      rq, r_scale, r_zero_point = DynamicQuantizeLinear(h1)
+      combined_scale2 = Mul(r_scale, w2_scale)
+      c2i = ConvInteger<kernel_shape=[{kh2},{kw2}], pads=[{ph2},{pw2},{ph2},{pw2}]>(rq, w2_quantized, r_zero_point, w2_zero_point)
+      c2f = Cast<to=1>(c2i)
+      h2 = Mul(c2f, combined_scale2)
+      p = GlobalAveragePool(h2)
+      f = Flatten<axis=1>(p)
+      y = Gemm<transB=1>(f, w3)
+    }}
+    """
+    inits = [
+        onnx.numpy_helper.from_array(w1q, "w1_quantized"),
+        onnx.numpy_helper.from_array(w1s, "w1_scale"),
+        onnx.numpy_helper.from_array(w1zp, "w1_zero_point"),
+        onnx.numpy_helper.from_array(w2q, "w2_quantized"),
+        onnx.numpy_helper.from_array(w2s, "w2_scale"),
+        onnx.numpy_helper.from_array(w2zp, "w2_zero_point"),
+        _f32(w3f, "w3"),
+    ]
+    if b1f is not None:
+        inits.append(_f32(b1f, "b1"))
+        inits.append(
+            onnx.numpy_helper.from_array(
+                np.array([1, -1, 1, 1], dtype=np.int64), "b1_shape"
+            )
+        )
+    model = _model(body, initializer=inits, opset=21)
+    return model, {
+        "W1f": w1f,
+        "W2f": w2f,
+        "W3f": w3f,
+        "B1f": b1f,
+        "W1q": w1q,
+        "W1s": w1s,
+        "W1zp": w1zp,
+        "W2q": w2q,
+        "W2s": w2s,
+        "W2zp": w2zp,
+        "spatial": spatial,
+    }
+
+
 def _dqconv_clip_model_from_weights(
     c, m1, m2, w1f, w2f, b1f=None, spatial=8, min_val=0.0, max_val=6.0, seed=0
 ):
@@ -47023,6 +47336,202 @@ def test_dynamic_quantize_conv_real_quantize_dynamic_pipeline_end_to_end():
     x = rng.standard_normal((1, c, spatial, spatial)).astype(np.float32)
     (y_pruned,) = _run(pruned, {"x": x})
     assert y_pruned.shape == (1, m2, spatial, spatial)
+    assert np.all(np.isfinite(y_pruned))
+
+
+def test_dynamic_quantize_conv_global_average_pool_flatten_gemm_pass_through_matches_oracle():
+    # The classifier-head hop `_walk_to_conv_integer_consumer` gained,
+    # mirroring the plain-float walker's own `recognize_gap_flatten_matmul_consumer`:
+    # a `ConvInteger`'s own logical output feeding `GlobalAveragePool ->
+    # Flatten(axis=1) -> Gemm` directly is matched and pruned, with the
+    # matched Gemm consumer (plain, constant float, never quantized) sliced
+    # via the ordinary `_slice_consumer_weight`. Both `ConvInteger` layers'
+    # weights are quantized via the REAL `onnxruntime.quantization
+    # .quantize_dynamic` tool (`_quantize_dynamic_conv_weight`, never a
+    # hand-rolled re-implementation) -- per this repo's own CLAUDE.md
+    # convention, only the fixture weights come from the real tool, while
+    # the surrounding graph structure is assembled via `onnx.parser`.
+    #
+    # This model matches BOTH chains at once: the ordinary same-family
+    # ConvInteger->ConvInteger chain (w1 producer / w2 consumer) AND the new
+    # classifier-head chain (w2 producer / Gemm consumer) -- w2 legitimately
+    # plays both roles across the two chains, exactly like a middle MLP
+    # layer already does in the plain-float sections (see `_apply_chains`'s
+    # own comment). The independent oracle below replicates that same
+    # sequential "w2's consumer-role (input-axis) slice happens before its
+    # own producer-role (output-axis) importance is ranked" order, since
+    # `apply_structured_pruning_dynamic_quantize_conv` mutates `w2` in place
+    # while processing chains in `graph.node` order.
+    c, m1, m2, out = 4, 6, 5, 3
+    rng = np.random.default_rng(50)
+    w1f = (rng.standard_normal((m1, c, 3, 3)) * 0.3).astype(np.float32)
+    w2f = (rng.standard_normal((m2, m1, 3, 3)) * 0.3).astype(np.float32)
+    w3f = (rng.standard_normal((out, m2)) * 0.3).astype(np.float32)
+    model, info = _dqconv_gap_flatten_gemm_model_from_weights(
+        c, m1, m2, out, w1f, w2f, w3f, seed=50
+    )
+    onnx.checker.check_model(model)
+
+    chains = onnxsim.pruning._find_conv_integer_chains(model.graph)
+    assert len(chains) == 2
+    gap_chain = next(ch for ch in chains if ch.matmul_consumer is not None)
+    assert gap_chain.consumer is None
+    assert gap_chain.matmul_consumer[1] == "w3"
+    assert gap_chain.n_channels == m2
+
+    keep_count1 = m1 - round(m1 * 0.5)
+    keep_count2 = m2 - round(m2 * 0.5)
+    keep1 = _dqconv_importance_keep(info["W1q"], info["W1s"], info["W1zp"], keep_count1)
+    # w2's own consumer-role (input-axis) slice by `keep1` is applied before
+    # its producer-role importance is ranked -- see this test's own comment
+    # above.
+    w2q_after_consumer_slice = info["W2q"][:, keep1, :, :]
+    keep2 = _dqconv_importance_keep(
+        w2q_after_consumer_slice, info["W2s"], info["W2zp"], keep_count2
+    )
+
+    pruned = onnxsim.apply_structured_pruning_dynamic_quantize_conv(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["w1_quantized"].dims) == [keep_count1, c, 3, 3]
+    assert list(inits["w2_quantized"].dims) == [keep_count2, keep_count1, 3, 3]
+    assert list(inits["w2_scale"].dims) == []  # always per-tensor, untouched
+    assert list(inits["w3"].dims) == [out, keep_count2]
+
+    w2q_final = info["W2q"][keep2][:, keep1, :, :]
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["w1_quantized"]), info["W1q"][keep1]
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["w2_quantized"]), w2q_final
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["w3"]), w3f[:, keep2]
+    )
+
+    # Independently reconstructed "already pruned" reference model: the
+    # SAME model-builder helper, called with pre-sliced float weights (for
+    # the correct, already-reduced graph shapes) and then patched with the
+    # exact pre-sliced quantized codes (never a fresh re-quantization of the
+    # sliced float weight, which could calibrate a different scale) --
+    # mirrors `test_dynamic_quantize_conv_producer_matches_independent_oracle_via_real_inference_session`'s
+    # own identical pattern.
+    ref_model, _ = _dqconv_gap_flatten_gemm_model_from_weights(
+        c,
+        keep_count1,
+        keep_count2,
+        out,
+        info["W1f"][keep1],
+        info["W2f"][keep2][:, keep1],
+        w3f[:, keep2],
+        seed=987654,
+    )
+    ref_inits = {t.name: t for t in ref_model.graph.initializer}
+    ref_inits["w1_quantized"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W1q"][keep1], "w1_quantized")
+    )
+    ref_inits["w1_scale"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W1s"], "w1_scale")
+    )
+    ref_inits["w1_zero_point"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W1zp"], "w1_zero_point")
+    )
+    ref_inits["w2_quantized"].CopyFrom(
+        onnx.numpy_helper.from_array(w2q_final, "w2_quantized")
+    )
+    ref_inits["w2_scale"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W2s"], "w2_scale")
+    )
+    ref_inits["w2_zero_point"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W2zp"], "w2_zero_point")
+    )
+
+    rng2 = np.random.default_rng(51)
+    x = rng2.standard_normal((1, c, info["spatial"], info["spatial"])).astype(
+        np.float32
+    )
+    (y_pruned,) = _run(pruned, {"x": x})
+    (y_ref,) = _run(ref_model, {"x": x})
+    np.testing.assert_array_equal(y_pruned, y_ref)
+
+
+def test_dynamic_quantize_conv_global_average_pool_flatten_gemm_real_quantize_dynamic_pipeline_end_to_end():
+    # The full end-to-end pipeline counterpart to
+    # `test_dynamic_quantize_conv_real_quantize_dynamic_pipeline_end_to_end`,
+    # extended with the classifier head: runs the REAL `quantize_dynamic`
+    # tool on a plain float `Conv -> Relu -> Conv -> GlobalAveragePool ->
+    # Flatten(axis=1) -> Gemm` model (only `Conv` requested for
+    # quantization, so the classifier `Gemm`'s own weight is never touched
+    # by the quantizer, exactly the shape this hop targets) and a real
+    # `InferenceSession`'s default graph optimization on the result, then
+    # confirms the LAST `ConvInteger` (feeding the classifier head) is
+    # matched and prunable -- the exact gap this round's task fixes.
+    from onnxruntime.quantization import quantize_dynamic
+
+    c, m1, m2, out = 4, 6, 5, 3
+    spatial = 8
+    rng = np.random.default_rng(15)
+    w0 = (rng.standard_normal((m1, c, 3, 3)) * 0.3).astype(np.float32)
+    w1 = (rng.standard_normal((m2, m1, 3, 3)) * 0.3).astype(np.float32)
+    w2 = (rng.standard_normal((out, m2)) * 0.3).astype(np.float32)
+    float_model = _model(
+        f"""
+        g (float[1,{c},{spatial},{spatial}] x) => (float[1,{out}] y)
+        {{
+          h0 = Conv<kernel_shape=[3,3], pads=[1,1,1,1]>(x, W0)
+          h0a = Relu(h0)
+          h1 = Conv<kernel_shape=[3,3], pads=[1,1,1,1]>(h0a, W1)
+          p = GlobalAveragePool(h1)
+          f = Flatten<axis=1>(p)
+          y = Gemm<transB=1>(f, W2)
+        }}
+        """,
+        initializer=[_f32(w0, "W0"), _f32(w1, "W1"), _f32(w2, "W2")],
+        opset=21,
+    )
+
+    with tempfile.TemporaryDirectory() as d:
+        src_path = os.path.join(d, "src.onnx")
+        quant_path = os.path.join(d, "quant.onnx")
+        opt_path = os.path.join(d, "opt.onnx")
+        onnx.save(float_model, src_path)
+        quantize_dynamic(src_path, quant_path, op_types_to_quantize=["Conv"])
+        so = ort.SessionOptions()
+        so.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
+        so.optimized_model_filepath = opt_path
+        ort.InferenceSession(
+            quant_path, sess_options=so, providers=["CPUExecutionProvider"]
+        )
+        fused = onnx.load(opt_path)
+
+    op_types = [n.op_type for n in fused.graph.node]
+    assert op_types.count("ConvInteger") == 2  # both Conv layers quantized
+    assert op_types.count("Gemm") + op_types.count("MatMul") == 1  # Gemm/MatMul
+    # left completely untouched -- only "Conv" was requested for
+    # quantization.
+
+    chains = onnxsim.pruning._find_conv_integer_chains(fused.graph)
+    assert len(chains) == 2
+    gap_chain = next(ch for ch in chains if ch.matmul_consumer is not None)
+    assert gap_chain.consumer is None
+    assert gap_chain.n_channels == m2
+
+    pruned = onnxsim.apply_structured_pruning_dynamic_quantize_conv(fused, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    pruned_inits = {t.name: list(t.dims) for t in pruned.graph.initializer}
+    # The LAST ConvInteger's own weight (feeding the classifier head) has
+    # its output-channel axis pruned.
+    ci_nodes = [n for n in pruned.graph.node if n.op_type == "ConvInteger"]
+    last_ci_weight = ci_nodes[-1].input[1]
+    assert pruned_inits[last_ci_weight][0] == m2 - round(m2 * 0.5)
+    gemm_weight = next(
+        n.input[1] for n in pruned.graph.node if n.op_type in ("Gemm", "MatMul")
+    )
+    assert pruned_inits[gemm_weight][1] == m2 - round(m2 * 0.5)
+
+    x = rng.standard_normal((1, c, spatial, spatial)).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"x": x})
+    assert y_pruned.shape == (1, out)
     assert np.all(np.isfinite(y_pruned))
 
 


### PR DESCRIPTION
## Summary

A previous PR added a narrowly-scoped `GlobalAveragePool -> Flatten(axis=1) -> {MatMul, vanilla Gemm}` classifier-head pass-through hop to the plain-float Conv chain walker (`_walk_to_conv_consumer`, via `_match_gap_flatten_matmul_consumer`) — recognizing that `GlobalAveragePool`'s output always collapses every trailing spatial axis to size 1 per channel, so a `Flatten(axis=1)` reading directly off it is a provably trivial 1:1 channel relabeling. This hop was wired into `_find_conv_chains` only, leaving the same classifier-head shape unbridged in two of the quantized-Conv walkers.

## Empirically confirmed facts

- **ConvInteger/DynamicQuantizeConv**: built a real `Conv->Relu->Conv->GlobalAveragePool->Flatten(axis=1)->Gemm` model, weights quantized via the real `onnxruntime.quantization.quantize_dynamic` tool: `_find_conv_integer_chains` found only the first `Conv->Conv` chain — the last `ConvInteger` (feeding the classifier head) was never treated as a producer, structurally unprunable.
- **QDQ Conv**: same model shape, quantized via this repo's own `onnxsim.quantize_static`: `_find_qdq_chains` found the `h0->h1` chain but never treated `h1` (feeding GAP->Flatten->Gemm) as a producer.
- Both gaps were pure **wiring** gaps, not matcher deficiencies — `_match_gap_flatten_matmul_consumer` is domain/quantization-agnostic and needed no changes.
- (`QLinearMatMul`/`QGemm`'s `_walk_to_qop_consumer` also lacks this, but that's already documented elsewhere as deliberately out of scope for an unrelated, structural reason — untouched here.)

## What's added

- **`_walk_to_conv_integer_consumer`**: added the same `GlobalAveragePool` hop, reusing `_match_gap_flatten_matmul_consumer` verbatim (by this point in the walk, `cur` is already a plain float tensor — `ConvInteger`'s own rescale `Mul`/`Cast` pair already produced it). `_ConvIntegerChain.consumer` became `Optional`, with a new `matmul_consumer: Optional[_ConsumerMatch]` field — exactly one of the two is ever set. `apply_structured_pruning_dynamic_quantize_conv` (plus its `not_eligible` and dry-run-analysis mirrors) branches accordingly, slicing the matched plain-float MatMul/Gemm consumer via the ordinary `_slice_consumer_weight` (never the int8-aware ConvInteger consumer slicer, since this consumer is never itself quantized).
- **`_walk_to_consumer_qdq`** (`is_conv` branch only): the identical hop. No new dataclass field needed here — `_QDQChain`/`_QDQConsumer` already support a plain-float consumer via the existing `_WeightRef` union, and `_slice_consumer_weight_qdq` already has a `ref.float_init` branch that delegates to `_slice_consumer_weight`.
- `tests/test_pruning.py`: 4 new tests (2 per walker — a hand-built oracle-exact model plus a full real-tool end-to-end pipeline test, mirroring each section's existing patterns).

## Test plan

- [x] All 4 new tests fail on the pre-fix code and pass after the fix (verified independently via a before/after checkout)
- [x] `pytest tests/test_pruning.py -k "conv_integer or dynamic_quantize_conv"` — 21 passed
- [x] `pytest tests/test_pruning.py -k "qdq"` — 46 passed, 1 pre-existing unrelated failure (`prune_magnitude` stale-compiled-extension signature mismatch, confirmed identical on the pre-change commit)
- [x] `pytest tests/test_pruning.py -q` (full suite) — 836 passed (832 baseline + 4 new), same 103 pre-existing failures
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — no new issues

## Risks for reviewer

- `_ConvIntegerChain.consumer` becoming `Optional` touches every existing reader of that field (`apply_structured_pruning_dynamic_quantize_conv`, `_conv_integer_not_eligible`, `_analyze_structured_pruning_dynamic_quantize_conv`) — each now branches on `consumer is not None` vs. `matmul_consumer`; mypy confirms no unsafe `Optional` access remains.
- `_walk_to_qop_consumer` (QOperator) is untouched by design, per its own existing documented scope boundary.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_