### PR TITLE
Test real subgraph decomposition: extraction works, doesn't localize diffs

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -1104,17 +1104,21 @@ bytes. Both diffs are real and structured, not wholesale rewrites --
 confirming the technique generalizes past a single op, at least for this
 shape.
 
-**Real, new content shows up that the one-op case never had.** Comparing
-the "vary conv1" diff against the earlier single-`Conv` dilation diff
-(same shape, same technique): the familiar 94-byte/60-byte
-per-engine-template blocks and the periodic 4-repeats/7-byte-stride field
-are both still present, structurally unchanged -- but a *new* diff
-pattern shows up around byte offset 858-876 (four single-byte changes at
-a regular 6-byte stride) that has no counterpart at all in the one-op
-mcode. This is a real, plausible candidate for exactly the thing this
-experiment was designed to find: addressing or sizing information for the
-intermediate buffer conv1 hands to conv2, which only exists to encode at
-all once there's a second, real downstream consumer.
+**Correction (see "Is mcode deterministic?" below): the offset-858-876
+claim originally made here was wrong.** This section first reported a
+"new" diff pattern at byte offset 858-876 (four single-byte changes at a
+6-byte stride) as a candidate for the intermediate buffer's own
+addressing. Directly rebuilding the *identical* config three times (no
+parameter changed at all) later confirmed that exact byte region is
+**non-deterministic noise**, not a dilation-dependent signal -- rebuilding
+the very same `two_conv_d2` model three times in a row produced three
+different mcode blobs, differing only at these same 4-6 byte positions
+each time. That fully explains the "new content" that seemed to appear
+here: it was never caused by chaining two ops, it was present (and just
+as spurious) even with nothing changed between builds. Left in place with
+this correction rather than silently rewritten, since it's a real example
+of a finding this project got wrong before checking determinism -- see
+below for what's actually confirmed stable.
 
 **An unexpected, genuinely new finding: an op's own command bytes are not
 independent of *downstream* ops.** Varying the *second* conv's dilation
@@ -1140,14 +1144,110 @@ graph-wide resource (plausibly the 4-way spatial-tiling table this
 README's `resnet18d` profiling already found evidence for) rather than
 something scoped to one specific op's own command.
 
-None of this newly-isolated content is decoded at the bit level yet --
-these are real, precisely-located regions for future work, in the same
-spirit as the single-op periodic field above, not solved encodings. But
-the experiment answers its own motivating question directly: yes,
-connecting two ops surfaces genuinely new mcode content tied to real data
-transfer between them, distinguishable by comparing against the
-already-characterized single-op case, and it surfaces a real,
-previously-unknown cross-op dependency in mcode's encoding along the way.
+The periodic field and the cross-op coupling finding are both confirmed
+stable under repeated identical builds (see below) -- real, precisely-
+located targets for future work, not solved encodings, but not noise
+either. Whether connecting two ops surfaces genuinely *new* content tied
+specifically to the intermediate buffer's own addressing remains an open
+question -- the one candidate found here didn't hold up.
+
+### Is `.axmodel` deterministic? No -- and that correction above is why this matters
+
+Every differential-analysis finding in this whole investigation assumes
+that rebuilding the *same* model with the *same* config twice produces
+the *same* bytes, so any observed diff is caused by the one thing that
+changed. That assumption was never directly checked until it produced a
+wrong finding (immediately above). Checked properly now, by rebuilding
+one exact model/config three separate times with no changes at all:
+
+- **`Wbt` (`npu_params`) is fully deterministic**: byte-identical
+  (matching SHA-256) across three independent builds, every time tested.
+- **`mcode` is *not* fully deterministic**: three rebuilds of the
+  identical `two_conv_d2` model produced three different mcode blobs
+  (same length, 3,920 bytes, every time -- only the *content* differs).
+  The non-determinism is small and localized, not pervasive: 3-4 bytes
+  differ per pair of runs, always at the same handful of positions (byte
+  offsets 858/864/870/876 in that specific build), cycling through what
+  looks like a small fixed set of values (`0x10`/`0x20`/`0x30`/`0x40`) in
+  different orders each time -- consistent with a non-deterministic
+  assignment of interchangeable resource/job IDs (which of several
+  equivalent parallel slots gets which label) rather than genuinely
+  random data corruption. The same experiment on the single-`Conv`
+  dilation model (from earlier in this README) found the same thing, in
+  the same relative region (offsets ~859-882), plus one additional
+  isolated stray byte elsewhere (offset 3232, differing in only one of
+  two run-pairs) -- confirming the non-determinism isn't confined to one
+  specific model shape.
+- **The overall `.axmodel` file is never byte-identical across rebuilds**
+  even though `Wbt` alone is -- three rebuilds of the same config gave
+  three different file SHA-256 hashes at the same file size, entirely
+  because of `mcode`'s non-determinism above (nothing else in the file
+  differed).
+
+**Practical impact, checked directly rather than assumed**: the two
+already-committed regression tests that depend on comparing mcode across
+builds (the periodic 4-repeats/7-byte field, and the cross-op coupling
+finding) were both re-examined against the confirmed noisy byte ranges
+above and neither overlaps with them -- the periodic field sits at a
+completely different offset range in every build tested, and the cross-op
+coupling test only inspects the first 800 bytes, entirely below where the
+noise was ever observed to start (858+ in every model tested so far).
+Both findings hold up. The one finding that *did* turn out to be an
+artifact (the "new content at 858-876" claim above) is the one case where
+this wasn't checked before publishing it -- corrected in place rather
+than removed, as a real example of why this check matters for any future
+differential-analysis claim in this space: a same-length, structured-
+looking diff is not automatically signal, and this non-determinism is
+exactly the kind of thing that can masquerade as one.
+
+### What a real, profiled two-conv chain's trace.json actually shows
+
+Following up on "does data transfer between the two convs show up as its
+own event," the `two_conv_d2` model was rebuilt with `--profile` to check
+directly rather than infer from mcode bytes alone. The real trace (17
+events total, comparable in structure to the `resnet18d` profiling
+elsewhere in this README) shows:
+
+- **No separate event for the inter-op transfer at all.** The first
+  `Conv`'s last scheduled event on the `conv1` engine ends at the exact
+  timestamp the second `Conv`'s first event on `conv1` begins (`0.63475 +
+  0.575 = 1.20975`, matching to the fifth decimal place in the raw trace).
+  There is no gap, no separate "copy"/"transfer"/"sync" event between
+  them. The hand-off is either free (same engine, same OCM location,
+  nothing to move) or its cost is folded into one of the adjacent events
+  rather than broken out on its own.
+- **Asymmetric engine usage between the two convs**: the first `Conv` runs
+  on *both* `conv0` and `conv1` in parallel (matching pairs of events at
+  identical timestamps on each); the second `Conv` runs on `conv1` alone
+  -- `conv0` does nothing after the first `Conv` finishes. Not every op in
+  a chain gets the same 2-engine split this README's `resnet18d` profiling
+  showed for that model's convs; whether an op is split across both engines
+  or run on just one is itself a real scheduling decision with no
+  visible cost model exposed here. This asymmetry is also a plausible
+  partial explanation for the mcode size non-linearity this README's
+  op-count sweep found earlier (a 32-byte-unit delta per added op, but not
+  a *constant* one) -- not every op costs the same number of engine-command
+  copies.
+- **Both weight-load events happen up front, at `ts=0`**, one per real
+  weight tensor (`ld:xxh128:...` on `cv3` and `sdma4`) -- not interleaved
+  between the two convs' execution the way a naive "load weights right
+  before you need them" schedule might. Confirms weight loading is
+  planned globally ahead of compute, consistent with the content-addressed
+  weight-load-dominates-the-schedule finding from the `resnet18d`
+  profiling elsewhere in this README, just at a much smaller scale (2
+  distinct real tensors here, nothing to deduplicate against each other).
+- **RTV events fire for both the graph input and the graph output**
+  (`__rtv_x`, `__rtv_y`) -- consistent with, and now confirmed for a
+  genuinely multi-op graph (not just the single-op case checked
+  previously), the finding that RTV isn't scoped to ISP/CV use cases.
+
+Net effect: the profiler confirms there's no dedicated, separately-timed
+"transfer" step to go looking for in mcode -- if the intermediate buffer's
+address/size needs to be encoded anywhere (and it must, since the two
+ops' reads and writes have to agree on where it lives), it's folded into
+one of the two convs' own commands rather than existing as its own
+identifiable unit, which is a real, useful negative constraint on where
+to look next.
 
 ## LLMs: a separate pipeline onnxsim has no hook into
 

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -1200,6 +1200,44 @@ differential-analysis claim in this space: a same-length, structured-
 looking diff is not automatically signal, and this non-determinism is
 exactly the kind of thing that can masquerade as one.
 
+**Where does the non-determinism actually come from -- metadata, or the
+mcode generation algorithm itself?** Checked directly rather than
+guessed, by looking at *which* values appear at the noisy positions, not
+just that they differ. For the clean `two_conv_d2` case (four single-byte
+positions, offsets 858/864/870/876), the exact values seen across all
+three rebuilds are:
+
+```
+run1: 858=0x10  864=0x30  870=0x20  876=0x40
+run2: 858=0x30  864=0x20  870=0x40  876=0x10
+run3: 858=0x20  864=0x40  870=0x30  876=0x10
+```
+
+**Every single run has the identical multiset `{0x10, 0x20, 0x30,
+0x40}`** at these four positions -- only *which position gets which
+value* changes. This is decisive: it's the unmistakable signature of a
+fixed, small set of interchangeable labels (plausibly per-tile or
+per-job identifiers, given this project's other evidence for 4-way
+spatial tiling) being assigned to four equivalent slots in a
+non-deterministic *order* -- consistent with iteration over an unordered
+container (hash-map/hash-set bucket order depending on pointer values or
+ASLR) or parallel-task completion order in the compiler, not with
+embedded metadata. A real timestamp, build UUID, PID, or similar tracking
+value would need to reproduce the *exact same four values* across three
+independent builds run at different wall-clock times, just shuffled --
+astronomically unlikely for anything resembling real metadata, and
+trivially expected for a label-assignment race. The messier single-`Conv`
+case (a wider, ~24-byte noisy region rather than four isolated bytes)
+didn't resolve to as clean a single-byte permutation on inspection, but
+occupies the same narrow relative region and is consistent with the same
+underlying mechanism at a different granularity (e.g. multi-byte records
+being reordered rather than single label bytes) rather than a second,
+unrelated source. No timestamp-like field (a large, monotonically
+distinct value) was found anywhere in either the noisy region or the rest
+of the file across any of the rebuilds -- the file's own metadata-shaped
+fields (`version`, `neu_name`, the JSON attributes) were separately
+confirmed identical across every rebuild in this section.
+
 ### What a real, profiled two-conv chain's trace.json actually shows
 
 Following up on "does data transfer between the two convs show up as its

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -1083,6 +1083,72 @@ same-length localization in favor of mining un-localized diffs directly
 (as the resnet18d self-similarity scan above did, successfully, without
 needing localization at all).
 
+### Chaining two real convs: genuine inter-op data transfer, and a real cross-op coupling finding
+
+Every experiment up to this point used a *single* op -- no genuine
+inter-op data transfer, since the one op's input/output are both graph
+boundaries, addressed through the tensor I/O offset table this README
+already decoded. Chaining two ops introduces a real, so-far-unexamined
+piece: the intermediate activation between them lives entirely inside the
+compiled program's own OCM/DDR addressing, with no external name to look
+up. Testing this directly: two chained `Conv`s (`cin=cout=mid=4`, the one
+shape combination confirmed to give same-length pairs) with data
+genuinely flowing from the first op's output into the second op's input.
+
+**The same-length trick survives the jump from one op to two, at this
+shape.** Varying only the first `Conv`'s dilation (2 vs 3, padding
+compensated to hold every shape downstream constant) gave two builds at
+an identical 3,920 bytes; varying only the *second* `Conv`'s dilation
+(first held completely fixed) gave two builds at an identical 3,952
+bytes. Both diffs are real and structured, not wholesale rewrites --
+confirming the technique generalizes past a single op, at least for this
+shape.
+
+**Real, new content shows up that the one-op case never had.** Comparing
+the "vary conv1" diff against the earlier single-`Conv` dilation diff
+(same shape, same technique): the familiar 94-byte/60-byte
+per-engine-template blocks and the periodic 4-repeats/7-byte-stride field
+are both still present, structurally unchanged -- but a *new* diff
+pattern shows up around byte offset 858-876 (four single-byte changes at
+a regular 6-byte stride) that has no counterpart at all in the one-op
+mcode. This is a real, plausible candidate for exactly the thing this
+experiment was designed to find: addressing or sizing information for the
+intermediate buffer conv1 hands to conv2, which only exists to encode at
+all once there's a second, real downstream consumer.
+
+**An unexpected, genuinely new finding: an op's own command bytes are not
+independent of *downstream* ops.** Varying the *second* conv's dilation
+while leaving the first conv's own attributes completely untouched still
+changes bytes in the region corresponding to the *first* conv's own
+per-op command (the same relative area the 94-byte/60-byte templates
+occupy) -- not just adding new bytes near the second conv. An op that
+didn't itself change still gets re-encoded because something later in the
+graph did. This sharpens (and partly explains) the earlier "mcode isn't
+append-only" finding: it's not only that changing a graph's *topology*
+forces a wholesale re-serialization -- even within a fixed, matching-size
+two-op program, one op's encoding depends on what happens after it, not
+just on its own attributes and its own inputs.
+
+**The periodic field looks genuinely global, not per-op.** The same
+4-repeats/7-byte-stride signature appears in *both* experiments --
+varying conv1's dilation and varying conv2's -- landing at different
+absolute offsets (2727 vs 2759) simply because the two builds have
+different overall sizes, but with the identical shape otherwise. A field
+that reacts to a dilation change no matter which of the two convs it
+belongs to is further, independent evidence for this being a shared,
+graph-wide resource (plausibly the 4-way spatial-tiling table this
+README's `resnet18d` profiling already found evidence for) rather than
+something scoped to one specific op's own command.
+
+None of this newly-isolated content is decoded at the bit level yet --
+these are real, precisely-located regions for future work, in the same
+spirit as the single-op periodic field above, not solved encodings. But
+the experiment answers its own motivating question directly: yes,
+connecting two ops surfaces genuinely new mcode content tied to real data
+transfer between them, distinguishable by comparing against the
+already-characterized single-op case, and it surfaces a real,
+previously-unknown cross-op dependency in mcode's encoding along the way.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -1004,6 +1004,85 @@ amount of genuinely distinct content anyone would need to decode to cover
 the rest: on this evidence, well under 49,080 bytes' worth of *distinct*
 templates, not 49,080 bytes of independent unique data.
 
+### Decomposing a real model into a few real ops at a time: real extraction works, but doesn't restore localization on its own
+
+A natural idea, given the last section's negative result: rather than
+editing the whole 22-`Conv` `resnet18d` at once, cut *real* subgraphs
+(genuine topology and trained weights, via `onnx.utils.Extractor`) out of
+it -- small enough, hopefully, for the clean same-length diffing that
+worked on a synthetic single-`Conv` model to work again, while still using
+representative real weights and shapes instead of made-up ones.
+
+**Real subgraph extraction itself works cleanly**: `Extractor(model)
+.extract_model([input_name], [output_name])` on a shape-inferred
+`resnet18d` produces valid, checker-passing standalone ONNX graphs for any
+internal cut -- confirmed for a single real stem `Conv` alone
+(`/conv1/conv1.0/Conv`, real 3->32-channel trained weights) and a full real
+5-op residual block (`Conv`/`Relu`/`Conv`/`Add`/`Relu`, real 64-channel
+weights, real skip-connection `Add`) with only real, existing tensor names
+as new inputs/outputs. Both compile through the real toolchain
+unmodified.
+
+**But five separate attempts at reproducing the clean, same-length
+dilation trick on real-weight single-`Conv` slices all failed**, each
+ruling out one plausible cause: the real stem `Conv` (cin=3, cout=32) at
+its real 224x224 input size (4568 -> 4600 bytes, off by 32); the *same*
+real `Conv` resized down to 16x16 -- matching the earlier tractable
+synthetic test's spatial scale exactly -- to rule out spatial size (3632 ->
+3664, still off by 32, still a wholesale-rewrite-scale diff underneath);
+a different real layer's `Conv` (cin=cout=64, both powers of two, clear of
+the tiling-boundary behavior the `cout` sweep found near 32) to rule out
+channel-count "unfriendliness" (3440 -> 4152, off by 712); the same, with
+its bias input stripped entirely, to rule out bias presence (identical
+result, 3440 -> 4152); and the same cin=cout=64 slice compared at dilation
+2 vs 3 specifically (not 1 vs 2), to exactly match the earlier synthetic
+test's own dilation transition rather than assuming any transition is
+equivalent (4152 -> 4888, off by 736). **None matched.**
+
+**A sixth, decisive test ruled out weight values too, and points back to
+shape after all.** Before concluding it was about real-vs-random weight
+*values*, that was tested directly: the cin=cout=64 slice, same dilation
+2-vs-3 transition, but with its real trained weights replaced by i.i.d.
+random Gaussian weights (matching the one synthetic test that *did* work,
+same generation code, different shape). Result: **4152 -> 4888 bytes,
+byte-for-byte the same sizes as the real-weight version of the same
+shape.** Weight values -- real or random -- made no difference whatsoever
+at this shape. That rules out the weight-values explanation cleanly: it's
+the shape itself (cin=cout=64) that reliably produces a mismatched pair,
+independent of what's actually in the tensors.
+
+**So the honest conclusion is narrower than either single-cause story**:
+whether a same-length pair exists is a property of *shape* (channel
+counts, at least, since spatial size, bias presence, and weight values
+were all ruled out above) -- but not in a simple "friendly vs. unfriendly
+channel count" way either. Of the three distinct channel-count
+combinations tested for this exact question, only the original synthetic
+test's cin=cout=4 produced a match; cin=3/cout=32 and cin=cout=64 both did
+not, across six separate real dilation-pair experiments in this section
+alone. On the evidence gathered so far, a matching pair looks like a coincidental
+alignment of whatever tiling arithmetic the compiler runs for that
+specific shape, not a systematically reachable property -- there may be a
+real, discoverable rule underneath (the earlier `cout`/`cin`
+tiling-granularity sweeps found real structure in a related question, just
+not this one), but it wasn't found here.
+
+**Bottom line for "decompose into a few ops to expand coverage"**: the
+*technique* (real subgraph extraction) is validated and reusable --
+`Extractor` cleanly produces small, real, checker-valid, toolchain-
+buildable slices of any real model, letting future differential analysis
+target real ops with real weights instead of only synthetic ones. But "few
+ops" alone does not by itself restore the localized-diff property that
+made the earlier decoding progress possible -- across every real shape
+tried from `resnet18d` (six separate dilation-pair experiments), none
+reproduced a same-length pair the way the one tiny synthetic shape
+happened to. Making
+further progress this way would need either a systematic shape sweep large
+enough to find which specific `(cin, cout, ...)` combinations do produce
+matching pairs (if any beyond the one already found), or abandoning
+same-length localization in favor of mining un-localized diffs directly
+(as the resnet18d self-similarity scan above did, successfully, without
+needing localization at all).
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -485,3 +485,36 @@ def test_wbt_is_deterministic_mcode_has_small_bounded_nondeterminism(tmp_path):
         mcode_diff_count,
         "expected only a small, bounded amount of run-to-run mcode noise",
     )
+
+
+def test_mcode_nondeterminism_is_a_label_permutation_not_metadata(tmp_path):
+    """Confirmed real (see the README's "Where does the non-determinism
+    actually come from" section): the noisy positions found by rebuilding
+    an identical two-Conv model always carry the *same multiset* of
+    values across independent rebuilds -- only which position gets which
+    value changes. That's the signature of a small set of interchangeable
+    labels (plausibly per-tile job/resource IDs) being assigned to
+    equivalent slots in a non-deterministic order (e.g. unordered-
+    container iteration order), not embedded metadata like a timestamp or
+    build ID -- real metadata could never coincidentally reproduce the
+    exact same value set across independent builds run at different
+    times, only a fixed label set being reshuffled could.
+    """
+    model = _two_conv_model(vary_first=True, dilation=2, pad=2)
+    _, mcode_a = _build_and_get_wbt_and_mcode_bytes(
+        os.path.join(str(tmp_path), "run1"), model, (1, 4, 16, 16)
+    )
+    _, mcode_b = _build_and_get_wbt_and_mcode_bytes(
+        os.path.join(str(tmp_path), "run2"), model, (1, 4, 16, 16)
+    )
+    assert len(mcode_a) == len(mcode_b)
+
+    noisy = [i for i in range(len(mcode_a)) if mcode_a[i] != mcode_b[i]]
+    assert noisy, "expected the known small amount of run-to-run mcode noise"
+
+    multiset_a = sorted(mcode_a[i] for i in noisy)
+    multiset_b = sorted(mcode_b[i] for i in noisy)
+    assert multiset_a == multiset_b, (
+        (multiset_a, multiset_b),
+        "expected the same multiset of values at the noisy positions, just reordered",
+    )

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -202,6 +202,52 @@ def _build_and_get_mcode_bytes(work_dir, model, input_shape):
     return bytes(inits[mcode_key].raw_data)
 
 
+def _build_and_get_wbt_and_mcode_bytes(work_dir, model, input_shape):
+    os.makedirs(work_dir, exist_ok=True)
+    onnx.save(model, os.path.join(work_dir, "model.onnx"))
+    rng = np.random.RandomState(0)
+    os.makedirs(os.path.join(work_dir, "dataset"), exist_ok=True)
+    samples = [rng.randn(*input_shape).astype(np.float32) for _ in range(4)]
+    pulsar2_docker.make_numpy_calibration_tar(
+        os.path.join(work_dir, "dataset", "calib_x.tar"), samples
+    )
+    cfg = {
+        "model_type": "ONNX",
+        "npu_mode": "NPU1",
+        "quant": {
+            "input_configs": [
+                {
+                    "tensor_name": "x",
+                    "calibration_dataset": "./dataset/calib_x.tar",
+                    "calibration_format": "Numpy",
+                    "calibration_size": 4,
+                }
+            ],
+            "calibration_method": "MinMax",
+            "precision_analysis": False,
+        },
+        "compiler": {"check": 0},
+    }
+    os.makedirs(os.path.join(work_dir, "config"), exist_ok=True)
+    with open(os.path.join(work_dir, "config", "cfg.json"), "w") as f:
+        json.dump(cfg, f)
+    result = pulsar2_docker.build(
+        work_dir, "model.onnx", "output", config_path="config/cfg.json"
+    )
+    assert result.success, result.error
+    compiled = onnx.load(result.axmodel_path)
+    inits = {i.name: i for i in compiled.graph.initializer}
+    neu_node = next(nd for nd in compiled.graph.node if nd.op_type == "neu mode")
+    info = None
+    for attr in neu_node.attribute:
+        if attr.name == "npu_graph_info":
+            info = json.loads(attr.s.decode())
+    dotneu = info["dotneus"][0]
+    wbt_key = dotneu["extra_inputs"][0]["const_data_key"]
+    mcode_key = dotneu["neu_key"]
+    return bytes(inits[wbt_key].raw_data), bytes(inits[mcode_key].raw_data)
+
+
 def _build_and_get_blob_sizes_for_model(work_dir, model, input_name, input_shape):
     os.makedirs(work_dir, exist_ok=True)
     onnx.save(model, os.path.join(work_dir, "model.onnx"))
@@ -405,4 +451,37 @@ def test_downstream_conv_dilation_perturbs_upstream_conv_bytes(tmp_path):
     assert upstream_diffs > 0, (
         "expected the unchanged first Conv's own bytes to still be perturbed "
         "by a downstream-only dilation change"
+    )
+
+
+def test_wbt_is_deterministic_mcode_has_small_bounded_nondeterminism(tmp_path):
+    """Confirmed real (see the README's "Is .axmodel deterministic?"
+    section): rebuilding the *identical* model/config is not fully
+    reproducible. Wbt (npu_params) is byte-identical across rebuilds every
+    time tested; mcode is not, but the non-determinism is small (a
+    handful of bytes) and bounded (same total length every time), not
+    pervasive. This underpins every other differential-analysis test in
+    this file -- a same-length pair with more than a token handful of
+    byte differences is real signal, not noise, but this test exists to
+    catch it if that ever stops being true (e.g. a toolchain regression
+    that makes mcode non-determinism much larger or Wbt non-deterministic
+    at all).
+    """
+    model = _dilation_conv_model(2, 2)
+    wbt_a, mcode_a = _build_and_get_wbt_and_mcode_bytes(
+        os.path.join(str(tmp_path), "run1"), model, (1, 4, 16, 16)
+    )
+    wbt_b, mcode_b = _build_and_get_wbt_and_mcode_bytes(
+        os.path.join(str(tmp_path), "run2"), model, (1, 4, 16, 16)
+    )
+
+    assert wbt_a == wbt_b, "Wbt should be byte-identical across identical rebuilds"
+
+    assert len(mcode_a) == len(mcode_b), (
+        "mcode should serialize to the same length across identical rebuilds"
+    )
+    mcode_diff_count = sum(1 for i in range(len(mcode_a)) if mcode_a[i] != mcode_b[i])
+    assert mcode_diff_count < 50, (
+        mcode_diff_count,
+        "expected only a small, bounded amount of run-to-run mcode noise",
     )

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -116,6 +116,48 @@ def _dilation_conv_model(dilation, pad, cin=4, cout=4, k=3, insz=16):
     return model
 
 
+def _two_conv_model(vary_first, dilation, pad, cin=4, mid=4, cout=4, k=3, insz=16):
+    """Two chained `Conv`s with a real intermediate activation flowing
+    between them (not a graph-boundary tensor) -- `vary_first` selects
+    which of the two gets the dilation/padding override, the other stays
+    fixed at dilation=1/pad=1."""
+    rng = np.random.RandomState(0)
+    w1 = (rng.randn(mid, cin, k, k) * 0.1).astype(np.float32)
+    w2 = (rng.randn(cout, mid, k, k) * 0.1).astype(np.float32)
+    d1, p1 = (dilation, pad) if vary_first else (1, 1)
+    d2, p2 = (1, 1) if vary_first else (dilation, pad)
+    mid_sz = insz + 2 * p1 - d1 * (k - 1) - 1 + 1
+    out_sz = mid_sz + 2 * p2 - d2 * (k - 1) - 1 + 1
+    graph = helper.make_graph(
+        [
+            helper.make_node(
+                "Conv", ["x", "w1"], ["mid"], dilations=[d1, d1], pads=[p1, p1, p1, p1]
+            ),
+            helper.make_node(
+                "Conv", ["mid", "w2"], ["y"], dilations=[d2, d2], pads=[p2, p2, p2, p2]
+            ),
+        ],
+        f"g_two_conv_vary{'1' if vary_first else '2'}_{dilation}",
+        [
+            helper.make_tensor_value_info(
+                "x", onnx.TensorProto.FLOAT, [1, cin, insz, insz]
+            )
+        ],
+        [
+            helper.make_tensor_value_info(
+                "y", onnx.TensorProto.FLOAT, [1, cout, out_sz, out_sz]
+            )
+        ],
+        initializer=[
+            numpy_helper.from_array(w1, name="w1"),
+            numpy_helper.from_array(w2, name="w2"),
+        ],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    onnx.checker.check_model(model)
+    return model
+
+
 def _build_and_get_mcode_bytes(work_dir, model, input_shape):
     os.makedirs(work_dir, exist_ok=True)
     onnx.save(model, os.path.join(work_dir, "model.onnx"))
@@ -331,3 +373,36 @@ def test_axquantizedconv_command_has_a_real_periodic_4x_field(tmp_path):
         "expected exactly 4 repeats",
     )
     assert all(s == 7 for s in strides), (strides, "expected a constant 7-byte stride")
+
+
+def test_downstream_conv_dilation_perturbs_upstream_conv_bytes(tmp_path):
+    """Confirmed real (see the README's "Chaining two real convs" section):
+    a genuinely new, previously-unknown cross-op coupling. Two chained
+    `Conv`s at the one shape (cin=cout=mid=4) confirmed to give
+    same-length pairs; varying only the *second* conv's dilation, with the
+    *first* conv's own attributes completely untouched, still perturbs
+    bytes within the first ~800 bytes of mcode -- the same relative region
+    the single-op experiments already showed holds the first conv's own
+    per-op command template. An op's encoding is not independent of what
+    happens downstream of it, even at fixed total mcode length.
+    """
+    a = _build_and_get_mcode_bytes(
+        os.path.join(str(tmp_path), "vary2_d2"),
+        _two_conv_model(vary_first=False, dilation=2, pad=2),
+        (1, 4, 16, 16),
+    )
+    b = _build_and_get_mcode_bytes(
+        os.path.join(str(tmp_path), "vary2_d3"),
+        _two_conv_model(vary_first=False, dilation=3, pad=3),
+        (1, 4, 16, 16),
+    )
+    assert len(a) == len(b), (
+        "this dilation/padding pair should serialize to the same length"
+    )
+
+    UPSTREAM_REGION = 800
+    upstream_diffs = sum(1 for i in range(UPSTREAM_REGION) if a[i] != b[i])
+    assert upstream_diffs > 0, (
+        "expected the unchanged first Conv's own bytes to still be perturbed "
+        "by a downstream-only dilation change"
+    )


### PR DESCRIPTION
## Summary

Answers "how about decomposing models to few ops per each and expand coverage?" with a direct experiment rather than speculation, following up on #1128's finding that editing one real layer in resnet18d re-serializes the whole mcode blob.

**Real ONNX subgraph extraction works cleanly**: `onnx.utils.Extractor(model).extract_model([input], [output])` on a shape-inferred `resnet18d` produces valid, checker-passing, toolchain-buildable standalone graphs for any internal cut -- confirmed for a single real stem `Conv` alone (real 3->32-channel trained weights) and a full real 5-op residual block (`Conv`/`Relu`/`Conv`/`Add`/`Relu`, real 64-channel weights, real skip-connection `Add`).

**But it doesn't restore the localized-diff property on its own.** Six separate real dilation-pair experiments -- varying spatial size (224 vs 16), channel count (3/32 vs 64/64), bias presence, the exact dilation transition (1-vs-2 vs 2-vs-3, to exactly match the one synthetic test that worked), and finally real vs. random weight *values* at a fixed shape -- all failed to reproduce the clean same-length diffing that worked on the earlier tiny synthetic model. The decisive last test (random weights at the exact shape/transition that failed with real weights) produced byte-for-byte identical sizes to the real-weight case, cleanly ruling out weight values as the cause.

**Honest conclusion**: whether a same-length pair exists looks like it's tied to shape specifically, but not in any simple "friendly channel count" way -- only the original synthetic test's cin=cout=4 produced a match, out of three distinct channel-count combinations tested. Subgraph extraction is a validated, reusable technique for future work, but "few ops" alone doesn't unlock the localization trick -- corrected here after ruling out several plausible-sounding explanations (spatial size, channel-count friendliness, bias, weight randomness) one at a time.

## Test plan
- Real builds: 12 total (6 pairs) against the real `pulsar2:6.0-lite` image, covering stem-conv extraction at two spatial scales, a residual-block extraction, and 4 shape/weight variants of a single real layer's dilation transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UC8vhJgE71RLFF4DgdSP9P

## Update: chaining two real convs to get genuine inter-op data transfer

Answers "how about connecting two conv layers instead of single to get actual data transfer?" Every experiment up to now used a single op, with no genuine inter-op transfer -- both its input/output are graph boundaries addressed through the already-decoded tensor I/O offset table.

Chained two `Conv`s at the one shape (`cin=cout=mid=4`) already confirmed to give same-length pairs. **The technique survives the jump from one op to two**: varying either conv's dilation independently (padding compensated to hold shape) both gave same-length pairs.

Real findings:
- **New content with no counterpart in the one-op case**: a diff pattern at byte offset 858-876 (four single-byte changes at a regular 6-byte stride) that doesn't exist when there's no downstream consumer -- a real candidate for the intermediate buffer's own addressing/sizing.
- **A genuinely new, previously-unknown cross-op coupling**: varying only the *second* conv's dilation, with the first conv's own attributes completely untouched, still perturbs bytes in the first conv's own per-op command region. An op's encoding depends on what happens downstream of it, not just its own attributes -- sharpens the earlier "mcode isn't append-only" finding.
- **The periodic 4x/7-byte-stride field persists regardless of which conv's dilation changes**, landing at different absolute offsets only because of the different overall builds' sizes -- further evidence it's a shared, graph-wide resource (the 4-way spatial tiling table found earlier) rather than scoped to one specific op.

None of this is decoded at the bit level yet, but it's a real, precisely-located extension of the single-op findings, and directly confirms the experiment's own premise: connecting two ops does surface genuinely new content tied to real data transfer between them.

- [x] `python -m pytest tests/test_axera_mcode_structure.py -v` -- 4 passed (131s total), for real against the real `pulsar2:6.0-lite` image.


## Update: discovered real mcode non-determinism, and it corrects a prior finding

Answers "is the axmodel result deterministic?" and "did you get any findings with profiled result?" directly.

**Determinism, checked properly for the first time this whole investigation**: rebuilt one exact model/config three separate times.

- `Wbt` (`npu_params`) is byte-identical across every rebuild tested.
- `mcode` is **not** fully deterministic: same total length every time, but 3-4 bytes differ per run pair, always at the same handful of positions, cycling through a small fixed set of values -- consistent with non-deterministic assignment of interchangeable resource/job IDs, not random corruption. Confirmed on two different model shapes.
- The whole `.axmodel` file is never byte-identical across rebuilds (different SHA-256 at the same file size) purely because of mcode's non-determinism.

**This directly explains and corrects a wrong finding from the previous commit in this PR**: the "genuine new content at offset 858-876" claim in the two-conv chaining section was this exact non-determinism, not a real dilation-dependent signal. Corrected in place in the README rather than silently rewritten -- it's a real example of why checking this matters. The good news: the two already-committed regression tests that depend on comparing mcode across builds (the periodic field, the cross-op coupling finding) were both re-checked against the confirmed noisy byte ranges and **neither overlaps** -- both findings hold up.

**Profiling findings**: rebuilt the two-conv chain with `--profile`. No separate scheduled event exists for the inter-op transfer at all -- the second conv's first event starts at the exact timestamp the first conv's last event on the shared engine ends (matching to 5 decimal places). Asymmetric engine usage is real and visible: the first conv splits across both compute engines, the second uses only one. Weight loads for both layers happen up front at t=0, not interleaved with compute. RTV fires for both graph input and output, confirmed again on a genuinely multi-op graph.

- [x] `python -m pytest tests/test_axera_mcode_structure.py -v` -- 5 passed (160s total), for real against the real `pulsar2:6.0-lite` image.


## Update: the non-determinism is a label permutation, not metadata

Answers "does the non-determinism come from metadata or the mcode generation algorithm itself?" -- checked which *values* appear at the noisy positions, not just that they differ.

For the clean two-`Conv` case (4 single-byte noisy positions), every one of 3 independent rebuilds carries the **exact same multiset of values** (`{0x10, 0x20, 0x30, 0x40}`) at those positions -- only which position gets which value changes:

```
run1: 858=0x10  864=0x30  870=0x20  876=0x40
run2: 858=0x30  864=0x20  870=0x40  876=0x10
run3: 858=0x20  864=0x40  870=0x30  876=0x10
```

This is decisive: it's the signature of a small set of interchangeable labels (plausibly per-tile job/resource IDs, given this project's other evidence for 4-way spatial tiling) being assigned to equivalent slots in a non-deterministic *order* -- consistent with unordered-container iteration order or parallel-task completion order in the compiler. It is **not** consistent with embedded metadata: a real timestamp, build UUID, or PID could never coincidentally reproduce the exact same value set across independent builds run at different wall-clock times -- only a fixed label set being reshuffled could. No timestamp-like field was found anywhere in the file across any rebuild (the file's other metadata-shaped fields -- `version`, `neu_name`, the JSON attributes -- were all separately confirmed identical).

Added a regression test asserting this multiset-permutation property directly, sharper than the existing "a few bytes differ" check.

- [x] `python -m pytest tests/test_axera_mcode_structure.py -v` -- 6 passed, for real against the real `pulsar2:6.0-lite` image.
