### PR TITLE
Recognize QLinearGlobalAveragePool as QOperator classifier-head hop

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -33047,27 +33047,62 @@ def apply_structured_pruning_matmul_block_quantized_fp4(
 # a ``QLinearMatMul``/``QGemm`` producer only ever pairs with a
 # ``QLinearMatMul``/``QGemm`` consumer, either combination) whose `K`
 # matches the producer's own `N`. This is a REAL, confirmed gap, not an
-# oversight: the empirical ``quantize_static(quant_format=QOperator)`` round
-# trip this section's own top comment quotes verbatim
+# oversight, for the *general* case: the empirical
+# ``quantize_static(quant_format=QOperator)`` round trip this section's own
+# top comment quotes verbatim
 # (``QuantizeLinear -> QLinearConv -> Flatten -> QLinearMatMul ->
 # DequantizeLinear``) is EXACTLY the cross-family (Conv-then-MatMul, via a
-# `Flatten` reshape) shape this section does NOT match -- the same real,
-# common CNN-classifier-head topology the QDQ section's own identical
-# same-family-only walk already declines for the QDQ pattern (neither
-# walker recognizes `Flatten`/`Reshape` as a hop at all, unlike the
-# plain-float :func:`_walk_to_conv_consumer`'s own pooling/`Resize`/`Pad`
-# hops, none of which apply here either since they're never emitted between
-# two QOperator-format compute nodes by anything this investigation found).
+# `Flatten` reshape reading real, un-pooled spatial extent) shape this
+# section does NOT match -- the same real, common CNN-classifier-head
+# topology the QDQ section's own identical same-family-only walk already
+# declines for the QDQ pattern (neither walker recognizes an arbitrary
+# `Flatten`/`Reshape` as a hop, unlike the plain-float
+# :func:`_walk_to_conv_consumer`'s own pooling/`Resize`/`Pad` hops, none of
+# which apply here either since they're never emitted between two
+# QOperator-format compute nodes by anything this investigation found).
 # Extending either walker to cross the Conv/MatMul family boundary through a
-# `Flatten`/`Reshape` reinterpretation is a real, tractable-looking follow-up
-# this section deliberately leaves out of scope rather than bolt onto a
-# same-family walker that was never designed for it -- consistent with, not
-# a new gap beyond, this module's own existing QDQ precedent. What IS
-# reached: a real multi-layer QOperator MLP/attention-projection stack (every
+# GENERAL `Flatten`/`Reshape` reinterpretation -- one reading a Conv's own
+# real, un-pooled spatial output, where a surviving channel set would need
+# to be re-derived through the reshape's exact memory layout -- is a real,
+# tractable-looking follow-up this section deliberately leaves out of scope
+# rather than bolt onto a same-family walker that was never designed for
+# it, consistent with, not a new gap beyond, this module's own existing QDQ
+# precedent.
+#
+# One NARROW exception to that same-family-only restriction IS matched,
+# though -- mirroring this module's own plain-float Conv chain's identical
+# carve-out (see this module's own top docstring's
+# ``GlobalAveragePool -> Flatten -> Gemm`` paragraph and
+# :func:`_match_gap_flatten_matmul_consumer`'s own docstring) and the
+# ``ConvInteger`` section's own analogous hop (:func:`_walk_to_conv_integer_consumer`):
+# a ``QLinearConv`` producer's logical output feeding
+# ``com.microsoft::QLinearGlobalAveragePool -> {Flatten(axis=1), Reshape to
+# [batch, -1], Squeeze-of-trailing-axes} -> {QLinearMatMul, QGemm}``
+# directly -- confirmed live as the REAL shape
+# ``quantize_static(quant_format=QOperator)`` emits for exactly this
+# topology (a `Conv -> ... -> Conv -> GlobalAveragePool -> Flatten ->
+# Gemm` classifier head): ORT's own QOperator quantizer replaces the plain
+# `GlobalAveragePool` with `QLinearGlobalAveragePool`
+# (``X, x_scale, x_zero_point, y_scale, y_zero_point -> Y``, plus a
+# `channels_last` attribute this investigation's own real round trip
+# confirms is always emitted `0`), never leaving a plain, unquantized
+# `GlobalAveragePool` node behind. See :func:`_match_qlinear_gap_pass_through`/
+# :func:`_match_qop_gap_flatten_consumer` for the exact match and why it's
+# safe: `GlobalAveragePool`'s own per-channel-independent reduction to size
+# 1 (unchanged by quantization -- confirmed against
+# `QLinearGlobalAveragePool`'s own live schema/doc text, which describes the
+# identical "average pooling across the values in the same channel"
+# computation) makes the `Flatten`/`Reshape`/`Squeeze` that follows a
+# *trivial* 1:1 channel relabeling, not a real memory-layout re-derivation
+# -- the exact same proof this module's plain-float family already
+# established, just applied to the quantized op. What IS reached, in total:
+# a real multi-layer QOperator MLP/attention-projection stack (every
 # ``QLinearMatMul``/``QGemm`` layer feeding the next directly or through an
-# activation), and a multi-layer QOperator CNN backbone (every ``QLinearConv``
-# feeding the next the same way) -- just not the point where a CNN backbone's
-# spatial output gets flattened into its classifier head's first ``MatMul``.
+# activation), a multi-layer QOperator CNN backbone (every ``QLinearConv``
+# feeding the next the same way), and now a CNN backbone's LAST Conv layer
+# feeding its classifier head through a global-average-pool -- just not the
+# general case of a CNN backbone's real, un-pooled spatial output getting
+# flattened directly into a classifier head's first ``MatMul``.
 #
 # What's declined, deliberately, rather than guessed at (mirroring this
 # module's own conservative "decline anything ambiguous" bar everywhere
@@ -33145,6 +33180,17 @@ def apply_structured_pruning_matmul_block_quantized_fp4(
 #     `MatMulNBits` mixing) -- so a QOperator node feeding, or fed by, any of
 #     those is simply never matched as either role here (its own producer or
 #     consumer search only ever tries the other two QOperator ops).
+#   * A ``com.microsoft::QLinearGlobalAveragePool`` with `channels_last != 0`
+#     (NHWC -- never confirmed emitted by any real exporter, see
+#     :func:`_match_qlinear_gap_pass_through`), a non-scalar `x_scale`/
+#     `x_zero_point`/`y_scale`/`y_zero_point`, more than one non-`Shape`
+#     consumer of its own output, or a `Flatten`/`Reshape`/`Squeeze` right
+#     after it that doesn't match one of the three narrow shapes
+#     :func:`_match_qop_gap_flatten_consumer` recognizes (the general
+#     `Flatten`-off-real-spatial-extent case above) -- any of these simply
+#     ends that hop's own chain unmatched, the same "no other unconditional
+#     use for a pooling hop" bar the `ConvInteger` section's own identical
+#     hop already holds.
 #
 # Sensitivity-report family strings: ``"qoperator_conv"`` for a
 # ``QLinearConv`` producer, ``"qoperator_matmul"`` for a ``QLinearMatMul``/
@@ -33548,6 +33594,194 @@ def _slice_qop_consumer(w: _QOpWeight, keep: np.ndarray) -> None:
     )
 
 
+def _match_qlinear_gap_pass_through(
+    node: onnx.NodeProto,
+    cur: str,
+    initializer_map: Dict[str, onnx.TensorProto],
+) -> bool:
+    """True iff `node` is a ``com.microsoft::QLinearGlobalAveragePool``
+    reading `cur` as its own `X` input, with `channels_last == 0` (the only
+    layout value any real exporter this investigation found ever emits --
+    confirmed live: `onnxruntime.quantization`'s own quantizer for
+    `GlobalAveragePool` always hardcodes `channels_last=0` on the emitted
+    `QLinearGlobalAveragePool`, regardless of the source node's own
+    attributes) and every one of its four activation scale/zero-point
+    operands (`x_scale`/`x_zero_point`/`y_scale`/`y_zero_point`) a constant
+    scalar -- the same scalar-activation-only bar this section's own top
+    comment already holds every other QOperator activation input to.
+
+    `x_scale`/`x_zero_point` are never checked against the producing
+    ``QLinearConv``'s own `y_scale`/`y_zero_point` -- confirmed unnecessary,
+    not merely unchecked (a real exporter round trip does tie them to the
+    exact same initializers, but nothing here depends on that): like every
+    other hop this module's QOperator section matches, channel-slicing
+    safety rests entirely on the op treating every channel completely
+    independently (`QLinearGlobalAveragePool`'s own doc text: "applies
+    Average pooling across the values in the same channel", the identical
+    per-channel reduction plain `GlobalAveragePool` performs, confirmed live
+    via `onnxruntime`'s own operator schema registry), which holds
+    regardless of what `x_scale`/`x_zero_point`/`y_scale`/`y_zero_point`
+    actually equal -- exactly the same "never touched by either role, so
+    never needing to match anything" reasoning this section's own top
+    comment already gives for every other QOperator activation scale/
+    zero-point pair.
+    """
+    if node.op_type != "QLinearGlobalAveragePool" or node.domain != "com.microsoft":
+        return False
+    if len(node.input) != 5 or len(node.output) != 1:
+        return False
+    if node.input[0] != cur:
+        return False
+    channels_last = _matmul_nbits_int_attr(node, "channels_last", 0)
+    if channels_last != 0:
+        return False  # NHWC layout -- axis 1 wouldn't be the channel axis;
+        # never confirmed emitted by any real exporter, declined outright
+        # rather than guessed at, see this function's own docstring
+    for name in node.input[1:]:
+        if not name:
+            return False
+        t = initializer_map.get(name)
+        if t is None or not _qop_scalar_dims_ok(t.dims):
+            return False
+    return True
+
+
+def _match_qop_gap_flatten_consumer(
+    gap_out: str,
+    consumers_of: Dict[str, List[onnx.NodeProto]],
+    initializer_map: Dict[str, onnx.TensorProto],
+    graph_outputs: Set[str],
+    n_channels: int,
+    producers_of: Optional[Dict[str, onnx.NodeProto]] = None,
+) -> Optional[Tuple[Tuple[onnx.NodeProto, ...], _QOpWeight]]:
+    """The QOperator analogue of the plain-float chain's own
+    :func:`_match_gap_flatten_matmul_consumer`, for the
+    ``QLinearGlobalAveragePool -> {Flatten(axis=1), Reshape to [batch, -1],
+    Squeeze-of-trailing-axes} -> {QLinearMatMul, QGemm}`` classifier-head
+    shape. Reuses that function's own reshape/Squeeze matchers verbatim --
+    :func:`_match_flatten_axis1_pass_through`,
+    :func:`_match_reshape_batch_neg1_pass_through`,
+    :func:`_gap_squeeze_axes`/:func:`_squeeze_axis_is_trailing_spatial` --
+    since every one of those looks only at the `Flatten`/`Reshape`/
+    `Squeeze` node's own shape, never at what feeds or consumes it, so the
+    identical trivial 1:1 channel-relabeling proof
+    `_match_gap_flatten_matmul_consumer`'s own docstring gives for a
+    plain-float `GlobalAveragePool`'s ``[N, C, 1, ..., 1]`` output applies
+    UNCHANGED to `QLinearGlobalAveragePool`'s own identically-shaped
+    quantized output (same per-channel reduction, `channels_last=0`
+    unconditionally so axis 1 is always the channel axis -- see
+    :func:`_match_qlinear_gap_pass_through`).
+
+    Only the FINAL consumer match differs from the plain-float function:
+    `QLinearMatMul`/`QGemm` (:func:`_match_qlinearmatmul`/
+    :func:`_match_qgemm`) instead of a plain float `MatMul`/vanilla `Gemm`
+    (`_match_matmul_like`), since the tensor reaching it is still quantized
+    int8/uint8 throughout here -- unlike the `ConvInteger` section's own
+    identical hop (which reuses `_match_gap_flatten_matmul_consumer`
+    verbatim, because that section's own producer chain is always rescaled
+    back to plain float before this point), a QOperator producer's logical
+    output never is (see :func:`_walk_to_qop_consumer`'s own docstring for
+    why). Returns ``(reshape_chain, consumer)`` -- `consumer` a
+    `_QOpWeight`, exactly the shape :func:`_match_qlinearmatmul`/
+    :func:`_match_qgemm` already return for an ordinary same-family
+    consumer, so callers need no dedicated `matmul_consumer`-style side
+    channel the way the `ConvInteger` section's own :class:`_ConvIntegerChain`
+    does -- or ``None`` for the identical reasons
+    `_match_gap_flatten_matmul_consumer` documents (no exactly-one consumer
+    off `gap_out`, none of the three reshape shapes matches, the final 2-D
+    tensor isn't singly-consumed or is itself a graph output, that consumer
+    isn't a same-family `QLinearMatMul`/`QGemm` node reading it directly, or
+    its own match's `K` doesn't equal `n_channels`).
+
+    `producers_of`, when given, is threaded straight through to
+    :func:`_match_reshape_batch_neg1_pass_through` to resolve a
+    ``Concat``-produced ``Reshape`` shape, mirroring that function's own
+    optional parameter exactly.
+    """
+    if gap_out in graph_outputs:
+        return None
+    gap_consumers = consumers_of.get(gap_out, [])
+    first: onnx.NodeProto
+    if len(gap_consumers) == 1:
+        first = gap_consumers[0]
+    elif len(gap_consumers) == 2:
+        # The `x.view(x.size(0), -1)`/`x.reshape(x.shape[0], -1)` shape's own
+        # root tensor read twice (once as `Reshape` data, once by a `Shape`
+        # feeding the dynamic batch-size computation) -- mirrors
+        # `_match_gap_flatten_matmul_consumer`'s own identical carve-out, see
+        # that function's own docstring for why.
+        reshape_candidates = [c for c in gap_consumers if c.op_type == "Reshape"]
+        shape_candidates = [
+            c for c in gap_consumers if c.op_type == "Shape" and c.domain == ""
+        ]
+        if len(reshape_candidates) != 1 or len(shape_candidates) != 1:
+            return None
+        first = reshape_candidates[0]
+    else:
+        return None
+
+    reshape_chain: Tuple[onnx.NodeProto, ...]
+    final_out: str
+
+    if _match_flatten_axis1_pass_through(first, gap_out):
+        reshape_chain = (first,)
+        final_out = first.output[0]
+    elif _match_reshape_batch_neg1_pass_through(
+        first, gap_out, initializer_map, producers_of
+    ):
+        reshape_chain = (first,)
+        final_out = first.output[0]
+    else:
+        squeeze_chain: List[onnx.NodeProto] = []
+        cand: Optional[onnx.NodeProto] = first
+        cur = gap_out
+        while cand is not None:
+            if (
+                cand.op_type != "Squeeze"
+                or cand.domain != ""
+                or not cand.input
+                or cand.input[0] != cur
+                or len(cand.output) != 1
+            ):
+                break
+            axes = _gap_squeeze_axes(cand, initializer_map)
+            if not axes or not all(
+                _squeeze_axis_is_trailing_spatial(a, n_channels) for a in axes
+            ):
+                break
+            out2 = cand.output[0]
+            if out2 in graph_outputs:
+                break
+            squeeze_chain.append(cand)
+            cur = out2
+            next_consumers = consumers_of.get(cur, [])
+            cand = next_consumers[0] if len(next_consumers) == 1 else None
+        if not squeeze_chain:
+            return None
+        reshape_chain = tuple(squeeze_chain)
+        final_out = cur
+
+    if final_out in graph_outputs:
+        return None
+    final_consumers = consumers_of.get(final_out, [])
+    if len(final_consumers) != 1:
+        return None
+    mm_node = final_consumers[0]
+
+    m: Optional[_QOpWeight] = None
+    if (
+        mm_node.op_type == "QLinearMatMul"
+        and mm_node.input
+        and mm_node.input[0] == final_out
+    ):
+        m = _match_qlinearmatmul(mm_node, initializer_map, consumers_of)
+    elif mm_node.op_type == "QGemm" and mm_node.input and mm_node.input[0] == final_out:
+        m = _match_qgemm(mm_node, initializer_map, consumers_of)
+    if m is None or m.K != n_channels:
+        return None
+    return reshape_chain, m
+
+
 @dataclass(frozen=True)
 class _QOpChain:
     producer: _QOpWeight
@@ -33564,15 +33798,41 @@ def _walk_to_qop_consumer(
     graph_outputs: Set[str],
     n_channels: int,
     max_hops: int,
+    producers_of: Optional[Dict[str, onnx.NodeProto]] = None,
 ) -> Optional[Tuple[_QOpWeight, Tuple[onnx.NodeProto, ...]]]:
     """From tensor `start`, walks forward through shape-preserving unary
     activations (`_UNARY_PASS_THROUGH`) with no other consumer anywhere
     along the way, until a same-family (``QLinearConv``-only when `is_conv`,
     ``QLinearMatMul``/``QGemm``-only otherwise) consumer is found whose own
     `K` matches `n_channels`. Mirrors :func:`_walk_to_consumer_qdq` closely
-    -- see this section's own top comment for why no `Flatten`/`Reshape`
-    cross-family hop is recognized. Returns ``None`` if the walk runs out of
-    hops, hits a branch, or never reaches such a consumer.
+    -- see this section's own top comment for why no GENERAL `Flatten`/
+    `Reshape` cross-family hop is recognized. Returns ``None`` if the walk
+    runs out of hops, hits a branch, or never reaches such a consumer.
+
+    One NARROW exception to the same-family-only restriction, only on the
+    Conv side (`is_conv`) -- mirroring the `ConvInteger` section's own
+    analogous hop (:func:`_walk_to_conv_integer_consumer`'s own
+    `GlobalAveragePool` branch) and this module's plain-float Conv chain's
+    own `recognize_gap_flatten_matmul_consumer` hop: a
+    ``com.microsoft::QLinearGlobalAveragePool`` hit mid-walk
+    (:func:`_match_qlinear_gap_pass_through`) is additionally checked for
+    the ``-> {Flatten(axis=1), Reshape to [batch, -1],
+    Squeeze-of-trailing-axes} -> {QLinearMatMul, QGemm}`` shape
+    :func:`_match_qop_gap_flatten_consumer` describes. A match ends the walk
+    there, returning that function's own matched `_QOpWeight` consumer
+    directly -- unlike the `ConvInteger` section's own `matmul_consumer`
+    side channel, no dedicated return shape is needed here, since the
+    classifier-head consumer this narrow shape reaches is itself always a
+    `_QOpWeight` (`QLinearMatMul`/`QGemm`), exactly like the ordinary
+    same-family case above. A `QLinearGlobalAveragePool` feeding anything
+    else (no recognized `Flatten`/`Reshape`/`Squeeze`-then-matmul-consumer
+    shape right after it) simply ends the walk undeclined -- this walker
+    has no other, unconditional use for a pooling hop the way the
+    plain-float Conv-chain walker does. `producers_of`, when given, is
+    threaded straight through to :func:`_match_qop_gap_flatten_consumer` to
+    resolve a ``Concat``-produced ``Reshape`` shape; left ``None`` (the
+    default), only the whole-constant-initializer `Reshape` shape is
+    matched, never a hard failure.
 
     UNLIKE :func:`_walk_to_consumer_qdq`/:func:`_walk_to_dynquant_consumer`/
     :func:`_walk_to_matmul_nbits_consumer`, this walker deliberately does
@@ -33620,6 +33880,22 @@ def _walk_to_qop_consumer(
                 if m is None or m.K != n_channels:
                     return None
                 return m, tuple(chain_ops)
+            if _match_qlinear_gap_pass_through(nxt, cur, initializer_map):
+                gap_match = _match_qop_gap_flatten_consumer(
+                    nxt.output[0],
+                    consumers_of,
+                    initializer_map,
+                    graph_outputs,
+                    n_channels,
+                    producers_of,
+                )
+                if gap_match is None:
+                    return None  # no other unconditional use for a pooling
+                    # hop here -- see this function's own docstring
+                reshape_chain, consumer_match = gap_match
+                chain_ops.append(nxt)
+                chain_ops.extend(reshape_chain)
+                return consumer_match, tuple(chain_ops)
         else:
             if nxt.op_type == "QLinearMatMul" and nxt.input and nxt.input[0] == cur:
                 m = _match_qlinearmatmul(nxt, initializer_map, consumers_of)
@@ -33649,13 +33925,19 @@ def _walk_to_qop_consumer(
 def _find_qop_chains(graph: onnx.GraphProto) -> List[_QOpChain]:
     """The QOperator analogue of :func:`_find_qdq_chains`, restricted to the
     single-producer/single-consumer/unary-hops-only, same-family-only
-    topology :func:`_walk_to_qop_consumer` matches. Tries a ``QLinearConv``
+    topology :func:`_walk_to_qop_consumer` matches -- with one narrow
+    exception on the Conv side: a ``QLinearConv`` producer whose logical
+    output reaches the classifier-head ``QLinearGlobalAveragePool ->
+    {Flatten(axis=1), Reshape to [batch, -1], Squeeze-of-trailing-axes} ->
+    {QLinearMatMul, QGemm}`` shape is also matched (see
+    :func:`_walk_to_qop_consumer`'s own docstring). Tries a ``QLinearConv``
     producer, then a ``QLinearMatMul`` producer, then a ``QGemm`` producer --
     the three matchers' own `op_type` checks are mutually exclusive, so this
     is never ambiguous.
     """
     initializer_map = _constant_map(graph)
     consumers_of = _consumers_of(graph)
+    producers_of = _producers_of(graph)
     graph_outputs = {o.name for o in graph.output}
 
     def _is_internal(name: str) -> bool:
@@ -33689,6 +33971,7 @@ def _find_qop_chains(graph: onnx.GraphProto) -> List[_QOpChain]:
             graph_outputs,
             m.N,
             _MAX_CHAIN_HOPS,
+            producers_of,
         )
         if found is None:
             continue
@@ -33740,10 +34023,30 @@ def apply_structured_pruning_qoperator(
     is matched -- only the plain single-producer/single-consumer topology
     above (see this module's own "QOperator" section comment for the full
     scope-boundary list, including why a `QLinearConv` producer feeding a
-    `QLinearMatMul`/`QGemm` consumer through a `Flatten` reshape -- the real
-    shape a Conv-backbone classifier head takes -- is declined outright, the
-    same known gap the QDQ section's own identical same-family-only walk
-    already has).
+    `QLinearMatMul`/`QGemm` consumer through a GENERAL `Flatten`/`Reshape`
+    reading real, un-pooled spatial extent is declined outright, the same
+    known gap the QDQ section's own identical same-family-only walk already
+    has).
+
+    One narrow exception to the same-family-only consumer rule IS matched,
+    though: a ``QLinearConv`` producer's logical output feeding
+    ``com.microsoft::QLinearGlobalAveragePool -> {Flatten(axis=1), Reshape
+    to [batch, -1], Squeeze-of-trailing-axes} -> {QLinearMatMul, QGemm}``
+    directly (the canonical statically-quantized CNN classifier head --
+    confirmed live as the real shape
+    ``quantize_static(quant_format=QuantFormat.QOperator)`` emits for a
+    ``Conv -> ... -> GlobalAveragePool -> Flatten -> Gemm`` model) is also
+    matched (:func:`_match_qlinear_gap_pass_through`/
+    :func:`_match_qop_gap_flatten_consumer`), pruning the producer's output
+    channels together with the matching input channels of that
+    ``QLinearMatMul``/``QGemm`` consumer's own quantized weight -- mirroring
+    the plain-float Conv chain's own identical
+    `recognize_gap_flatten_matmul_consumer` hop and the ``ConvInteger``
+    section's own analogous one. `GlobalAveragePool`'s per-channel-
+    independent reduction to size 1 (unchanged by quantization) makes the
+    reshape in between a *trivial* 1:1 channel relabeling, not the real
+    memory-layout re-derivation the general `Flatten`/`Reshape` case above
+    still declines.
 
     :param model: onnx ModelProto object or file path
     :param sparsity: fraction of each eligible producer's output channels to

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -40186,6 +40186,436 @@ def test_apply_structured_pruning_qoperator_registered_in_sensitivity_analyzers(
     )
 
 
+# --- QLinearConv -> QLinearGlobalAveragePool -> classifier head -----------
+#
+# The classifier-head hop `_walk_to_qop_consumer` gained, mirroring the
+# plain-float Conv chain's own `recognize_gap_flatten_matmul_consumer` hop
+# and the `ConvInteger` section's own analogous one: a `QLinearConv`
+# producer's logical output feeding
+# `com.microsoft::QLinearGlobalAveragePool -> {Flatten(axis=1), Reshape to
+# [batch, -1], Squeeze-of-trailing-axes} -> {QLinearMatMul, QGemm}` directly
+# is now matched and pruned. Unlike the `ConvInteger` section's identical
+# hop (whose matched classifier consumer is always plain float, since that
+# section's own rescale `Mul`/`Cast` pair already produced a plain float
+# logical output before this point), the tensor reaching
+# `QLinearGlobalAveragePool` here is still quantized int8/uint8 throughout,
+# so the matched consumer is a real `QLinearMatMul`/`QGemm` -- a `_QOpWeight`
+# exactly like this section's own ordinary same-family consumer, needing no
+# dedicated side-channel field on `_QOpChain` at all.
+
+
+def _qlinear_gap_node(x, x_scale, x_zp, y_scale, y_zp, y, name="gap", **attrs):
+    return onnx.helper.make_node(
+        "QLinearGlobalAveragePool",
+        [x, x_scale, x_zp, y_scale, y_zp],
+        [y],
+        domain="com.microsoft",
+        name=name,
+        **attrs,
+    )
+
+
+def _qlinearconv_gap_flatten_qgemm_model(
+    N1=6, C1=3, N2=4, Out=5, kh=3, kw=3, spatial=8, seed=0
+):
+    """Builds ``QLinearConv(n1) -> QLinearConv(n2) ->
+    QLinearGlobalAveragePool -> Flatten(axis=1) -> QGemm`` -- the real shape
+    ``onnxruntime.quantization.quantize_static(quant_format=QuantFormat
+    .QOperator)`` emits for a ``Conv -> Conv -> GlobalAveragePool ->
+    Flatten -> Gemm`` classifier head (confirmed live -- see this section's
+    own top comment). `n2`'s own logical output (`y2_q`) feeds
+    `QLinearGlobalAveragePool` directly, whose own `x_scale`/`x_zero_point`
+    are the SAME `y2_scale`/`y2_zero_point` initializers `n2` itself
+    produces -- exactly the tied-initializer shape a real exporter emits
+    (`QGlobalAveragePool`'s own quantizer source just reuses its input's
+    existing quantized-value scale/zero-point when none is calibrated
+    separately for the pooled output)."""
+    rng = np.random.default_rng(seed)
+    W1 = rng.standard_normal((N1, C1, kh, kw)).astype(np.float32) * 0.3
+    W2 = rng.standard_normal((N2, N1, 1, 1)).astype(np.float32) * 0.3
+    Wfc = rng.standard_normal((Out, N2)).astype(np.float32) * 0.3
+    Bfc = rng.standard_normal(Out).astype(np.float32) * 0.05
+
+    x_scale = np.float32(0.02)
+    x_zp = np.uint8(120)
+    W1q, W1s, W1zp = _qop_quantize_per_channel_i8(W1, axis=0)
+    W2q, W2s, W2zp = _qop_quantize_per_channel_i8(W2, axis=0)
+    y1_scale = np.float32(0.03)
+    y1_zp = np.uint8(120)
+    y2_scale = np.float32(0.04)
+    y2_zp = np.uint8(120)
+    gap_scale = np.float32(0.05)
+    gap_zp = np.uint8(118)
+    y_scale = np.float32(0.06)
+    y_zp = np.uint8(120)
+
+    # QGemm's own `B` is stored `[K, N]` here (transB=0), matching this
+    # section's own `_qgemm_chain_model` default convention.
+    WfcT = Wfc.T  # (N2, Out) == (K, Out)
+    Wfcq, Wfcs, Wfczp = _qop_quantize_per_channel_i8(WfcT, axis=1)
+    Cfc_dequant_scale = gap_scale.astype(np.float64) * Wfcs.astype(np.float64)
+    Cfcq = np.round(Bfc.astype(np.float64) / Cfc_dequant_scale).astype(np.int32)
+
+    inits = [
+        _f32(np.array(x_scale), "x_scale"),
+        _u8(np.array(x_zp), "x_zp"),
+        onnx.numpy_helper.from_array(W1q, "W1"),
+        _f32(np.atleast_1d(W1s), "W1_scale"),
+        _i8(np.atleast_1d(W1zp), "W1_zp"),
+        _f32(np.array(y1_scale), "y1_scale"),
+        _u8(np.array(y1_zp), "y1_zp"),
+        onnx.numpy_helper.from_array(W2q, "W2"),
+        _f32(np.atleast_1d(W2s), "W2_scale"),
+        _i8(np.atleast_1d(W2zp), "W2_zp"),
+        _f32(np.array(y2_scale), "y2_scale"),
+        _u8(np.array(y2_zp), "y2_zp"),
+        _f32(np.array(gap_scale), "gap_scale"),
+        _u8(np.array(gap_zp), "gap_zp"),
+        onnx.numpy_helper.from_array(Wfcq, "Wfc"),
+        _f32(Wfcs, "Wfc_scale"),
+        _i8(Wfczp, "Wfc_zp"),
+        _i32(Cfcq, "Cfc"),
+        _f32(np.array(y_scale), "y_scale"),
+        _u8(np.array(y_zp), "y_zp"),
+    ]
+    n1 = _qlinearconv_node(
+        "n1",
+        "x_q",
+        "y1_q",
+        "W1",
+        "W1_scale",
+        "W1_zp",
+        "y1_scale",
+        "y1_zp",
+        None,
+        kernel_shape=[kh, kw],
+        pads=[0, 0, 0, 0],
+    )
+    n2 = _qlinearconv_node(
+        "n2",
+        "y1_q",
+        "y2_q",
+        "W2",
+        "W2_scale",
+        "W2_zp",
+        "y2_scale",
+        "y2_zp",
+        None,
+        x_scale="y1_scale",
+        x_zp="y1_zp",
+        kernel_shape=[1, 1],
+        pads=[0, 0, 0, 0],
+    )
+    gap = _qlinear_gap_node("y2_q", "y2_scale", "y2_zp", "gap_scale", "gap_zp", "gap_q")
+    flatten = onnx.helper.make_node("Flatten", ["gap_q"], ["flat_q"], axis=1)
+    gemm = _qgemm_node(
+        "mm", "flat_q", "y_q", "Wfc", "Wfc_scale", "Wfc_zp", "Cfc", "y_scale", "y_zp"
+    )
+    # `_qgemm_node` hardcodes its own `a_scale`/`a_zero_point` inputs to the
+    # literal names ``"a_scale"``/``"a_zp"`` -- overridden here to this
+    # consumer's real `a` operand's own scale/zero-point (`gap_scale`/
+    # `gap_zp`, the `QLinearGlobalAveragePool`'s own output pair), mirroring
+    # `_qgemm_chain_model`'s own identical post-hoc override for its second
+    # `QGemm` node.
+    gemm.input[1] = "gap_scale"
+    gemm.input[2] = "gap_zp"
+    graph = onnx.helper.make_graph(
+        [n1, n2, gap, flatten, gemm],
+        "g",
+        [
+            onnx.helper.make_tensor_value_info(
+                "x_q", onnx.TensorProto.UINT8, [1, C1, spatial, spatial]
+            )
+        ],
+        [onnx.helper.make_tensor_value_info("y_q", onnx.TensorProto.UINT8, [1, Out])],
+        initializer=inits,
+    )
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 17),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    model.ir_version = 10
+    return model, {
+        "W1": W1q,
+        "W1_scale": W1s,
+        "W1_zp": W1zp,
+        "W2": W2q,
+        "W2_scale": W2s,
+        "W2_zp": W2zp,
+        "Wfc": Wfcq,
+        "Wfc_scale": Wfcs,
+        "Wfc_zp": Wfczp,
+        "Cfc": Cfcq,
+        "spatial": spatial,
+        "C1": C1,
+        "N1": N1,
+        "N2": N2,
+        "Out": Out,
+    }
+
+
+def test_qlinear_gap_flatten_qgemm_is_matched_and_prunes():
+    N1, C1, N2, Out = 6, 3, 8, 5
+    model, info = _qlinearconv_gap_flatten_qgemm_model(
+        N1=N1, C1=C1, N2=N2, Out=Out, seed=60
+    )
+    onnx.checker.check_model(model)
+
+    chains = onnxsim.pruning._find_qop_chains(model.graph)
+    assert len(chains) == 2
+    gap_chain = next(ch for ch in chains if ch.consumer.op_kind == "gemm")
+    assert gap_chain.producer.node.name == "n2"
+    assert gap_chain.n_channels == N2
+    assert [n.op_type for n in gap_chain.chain_ops] == [
+        "QLinearGlobalAveragePool",
+        "Flatten",
+    ]
+
+    # `n2` legitimately plays BOTH roles across the two chains -- consumer
+    # (its own `K`/`N1` axis, sliced first, in `graph.node` order) of the
+    # `n1` producer chain, then producer (its own `N`/`N2` axis, importance
+    # ranked on the ALREADY consumer-sliced array) of this new classifier-
+    # head chain -- exactly the same sequential mutation order this
+    # section's `ConvInteger` analogue's own identical test documents.
+    w1_dequant = _qop_dequant(info["W1"], info["W1_scale"], info["W1_zp"], axis=0)
+    keep1 = np.sort(
+        np.argsort(-np.linalg.norm(w1_dequant.reshape(N1, -1), axis=1))[: N1 // 2]
+    )
+    w2_after_consumer_slice = info["W2"][:, keep1]
+    w2_dequant = _qop_dequant(
+        w2_after_consumer_slice, info["W2_scale"], info["W2_zp"], axis=0
+    )
+    keep2 = np.sort(
+        np.argsort(-np.linalg.norm(w2_dequant.reshape(N2, -1), axis=1))[: N2 // 2]
+    )
+    w2_final = w2_after_consumer_slice[keep2]
+
+    pruned = onnxsim.apply_structured_pruning_qoperator(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+
+    # byte-identity: "slice, don't recompute" -- the second QLinearConv's own
+    # output-channel axis and the QGemm's own matching input (reduction)
+    # axis are both an exact hand-slice of the originals.
+    np.testing.assert_array_equal(onnx.numpy_helper.to_array(inits["W2"]), w2_final)
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["W2_scale"]), info["W2_scale"][keep2]
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["W2_zp"]), info["W2_zp"][keep2]
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Wfc"]), info["Wfc"][keep2, :]
+    )
+    # QGemm's own consumer-role slicing never touches scale/zero-point/bias
+    # -- none of them are indexed by the reduction axis (see this module's
+    # own "QOperator" section top comment).
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Wfc_scale"]), info["Wfc_scale"]
+    )
+    np.testing.assert_array_equal(onnx.numpy_helper.to_array(inits["Cfc"]), info["Cfc"])
+
+    # Independently reconstructed "already pruned" reference model, run
+    # through a real InferenceSession alongside the pruned one -- mirrors
+    # `test_qlinearconv_producer_matches_independent_oracle_via_real_inference_session`'s
+    # own identical pattern.
+    ref_model, _ = _qlinearconv_gap_flatten_qgemm_model(
+        N1=len(keep1), C1=C1, N2=len(keep2), Out=Out, seed=999
+    )
+    ref_inits = {t.name: t for t in ref_model.graph.initializer}
+    ref_inits["W1"].CopyFrom(onnx.numpy_helper.from_array(info["W1"][keep1], "W1"))
+    ref_inits["W1_scale"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W1_scale"][keep1], "W1_scale")
+    )
+    ref_inits["W1_zp"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W1_zp"][keep1], "W1_zp")
+    )
+    ref_inits["W2"].CopyFrom(onnx.numpy_helper.from_array(w2_final, "W2"))
+    ref_inits["W2_scale"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W2_scale"][keep2], "W2_scale")
+    )
+    ref_inits["W2_zp"].CopyFrom(
+        onnx.numpy_helper.from_array(info["W2_zp"][keep2], "W2_zp")
+    )
+    ref_inits["Wfc"].CopyFrom(
+        onnx.numpy_helper.from_array(info["Wfc"][keep2, :], "Wfc")
+    )
+    ref_inits["Wfc_scale"].CopyFrom(
+        onnx.numpy_helper.from_array(info["Wfc_scale"], "Wfc_scale")
+    )
+    ref_inits["Wfc_zp"].CopyFrom(onnx.numpy_helper.from_array(info["Wfc_zp"], "Wfc_zp"))
+    ref_inits["Cfc"].CopyFrom(onnx.numpy_helper.from_array(info["Cfc"], "Cfc"))
+
+    rng = np.random.default_rng(61)
+    xq = rng.integers(0, 255, size=(1, C1, info["spatial"], info["spatial"])).astype(
+        np.uint8
+    )
+    (y_pruned,) = _run(pruned, {"x_q": xq})
+    (y_ref,) = _run(ref_model, {"x_q": xq})
+    np.testing.assert_array_equal(y_pruned, y_ref)
+
+
+def test_qlinear_gap_non_scalar_activation_scale_is_declined():
+    # A non-scalar `x_scale` on `QLinearGlobalAveragePool` -- never confirmed
+    # emitted by any real exporter (see this section's own top comment) --
+    # is declined outright, ending that hop's own chain unmatched rather
+    # than guessed at.
+    N1, C1, N2, Out = 6, 3, 4, 5
+    model, _info = _qlinearconv_gap_flatten_qgemm_model(N1=N1, C1=C1, N2=N2, Out=Out)
+    gap_node = next(n for n in model.graph.node if n.name == "gap")
+    bad_scale = onnx.numpy_helper.from_array(
+        np.array([0.05, 0.05], dtype=np.float32), "y2_scale_bad"
+    )
+    model.graph.initializer.append(bad_scale)
+    gap_node.input[1] = "y2_scale_bad"
+
+    chains = onnxsim.pruning._find_qop_chains(model.graph)
+    assert len(chains) == 1  # only the ordinary QLinearConv->QLinearConv chain
+    assert chains[0].producer.node.name == "n1"
+
+
+def test_qlinear_gap_channels_last_nonzero_is_declined():
+    # `channels_last=1` (NHWC) is never confirmed emitted by any real
+    # exporter -- declined outright rather than assumed safe.
+    N1, C1, N2, Out = 6, 3, 4, 5
+    model, _info = _qlinearconv_gap_flatten_qgemm_model(N1=N1, C1=C1, N2=N2, Out=Out)
+    gap_node = next(n for n in model.graph.node if n.name == "gap")
+    gap_node.attribute.append(onnx.helper.make_attribute("channels_last", 1))
+
+    chains = onnxsim.pruning._find_qop_chains(model.graph)
+    assert len(chains) == 1
+    assert chains[0].producer.node.name == "n1"
+
+
+def test_qlinear_gap_flatten_wrong_axis_is_declined():
+    # `Flatten` with a non-default `axis` merges more than one non-batch
+    # axis (or part of the batch axis) into the channel one -- the *general*
+    # Flatten problem this hop doesn't attempt (mirrors the plain-float/
+    # ConvInteger sections' own identical decline).
+    N1, C1, N2, Out = 6, 3, 4, 5
+    model, _info = _qlinearconv_gap_flatten_qgemm_model(N1=N1, C1=C1, N2=N2, Out=Out)
+    flatten_node = next(n for n in model.graph.node if n.op_type == "Flatten")
+    for attr in list(flatten_node.attribute):
+        flatten_node.attribute.remove(attr)
+    flatten_node.attribute.append(onnx.helper.make_attribute("axis", 0))
+
+    chains = onnxsim.pruning._find_qop_chains(model.graph)
+    assert len(chains) == 1
+    assert chains[0].producer.node.name == "n1"
+
+
+def test_qlinear_gap_flatten_qgemm_real_quantize_static_pipeline_end_to_end():
+    # The full end-to-end pipeline: runs the REAL
+    # ``onnxruntime.quantization.quantize_static(quant_format=QuantFormat
+    # .QOperator)`` tool on a plain float `Conv -> Relu -> Conv -> Relu ->
+    # GlobalAveragePool -> Flatten(axis=1) -> Gemm` model, then confirms the
+    # SECOND (widest) Conv layer -- the one feeding the classifier head
+    # through `QLinearGlobalAveragePool` -- is matched and prunable, together
+    # with the QGemm classifier consumer's matching input channels. This is
+    # the exact real-world gap this round's task fixes: before this change,
+    # `_find_qop_chains` matched only the FIRST QLinearConv->QLinearConv
+    # chain, leaving the last, widest backbone layer completely untouched.
+    from onnxruntime.quantization import (
+        CalibrationDataReader,
+        QuantFormat,
+        QuantType,
+        quantize_static,
+    )
+
+    N, c, spatial = 1, 3, 8
+    m1, m2, out = 6, 8, 5
+    rng = np.random.default_rng(70)
+    w0 = (rng.standard_normal((m1, c, 3, 3)) * 0.3).astype(np.float32)
+    w1 = (rng.standard_normal((m2, m1, 3, 3)) * 0.3).astype(np.float32)
+    w2 = (rng.standard_normal((out, m2)) * 0.3).astype(np.float32)
+    float_model = _model(
+        f"""
+        g (float[{N},{c},{spatial},{spatial}] x) => (float[{N},{out}] y)
+        {{
+          h0 = Conv<kernel_shape=[3,3], pads=[1,1,1,1]>(x, W0)
+          h0a = Relu(h0)
+          h1 = Conv<kernel_shape=[3,3], pads=[1,1,1,1]>(h0a, W1)
+          h1a = Relu(h1)
+          p = GlobalAveragePool(h1a)
+          f = Flatten<axis=1>(p)
+          y = Gemm<transB=1>(f, W2)
+        }}
+        """,
+        initializer=[_f32(w0, "W0"), _f32(w1, "W1"), _f32(w2, "W2")],
+        opset=17,
+    )
+
+    class _CDR(CalibrationDataReader):
+        def __init__(self):
+            rng2 = np.random.default_rng(71)
+            self._data = iter(
+                [
+                    {
+                        "x": rng2.standard_normal((N, c, spatial, spatial)).astype(
+                            np.float32
+                        )
+                    }
+                    for _ in range(5)
+                ]
+            )
+
+        def get_next(self):
+            return next(self._data, None)
+
+    with tempfile.TemporaryDirectory() as d:
+        src_path = os.path.join(d, "src.onnx")
+        quant_path = os.path.join(d, "quant.onnx")
+        onnx.save(float_model, src_path)
+        quantize_static(
+            src_path,
+            quant_path,
+            _CDR(),
+            quant_format=QuantFormat.QOperator,
+            weight_type=QuantType.QInt8,
+            activation_type=QuantType.QUInt8,
+        )
+        quantized = onnx.load(quant_path)
+
+    op_types = [n.op_type for n in quantized.graph.node]
+    assert op_types.count("QLinearConv") == 2
+    assert "QLinearGlobalAveragePool" in op_types
+    assert op_types.count("QGemm") == 1
+
+    chains = onnxsim.pruning._find_qop_chains(quantized.graph)
+    assert len(chains) == 2
+    gap_chain = next(ch for ch in chains if ch.consumer.op_kind == "gemm")
+    assert gap_chain.n_channels == m2
+    assert [n.op_type for n in gap_chain.chain_ops] == [
+        "QLinearGlobalAveragePool",
+        "Flatten",
+    ]
+
+    pruned = onnxsim.apply_structured_pruning_qoperator(quantized, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    pruned_inits = {t.name: list(t.dims) for t in pruned.graph.initializer}
+    conv_nodes = [n for n in pruned.graph.node if n.op_type == "QLinearConv"]
+    # The SECOND (widest) QLinearConv's own output-channel axis is pruned --
+    # the last, widest backbone layer a human would most want prunable.
+    last_conv_weight = conv_nodes[-1].input[3]
+    assert pruned_inits[last_conv_weight][0] == m2 - round(m2 * 0.5)
+    gemm_node = next(n for n in pruned.graph.node if n.op_type == "QGemm")
+    gemm_weight = gemm_node.input[3]
+    trans_b = any(a.name == "transB" and a.i for a in gemm_node.attribute)
+    k_axis = 1 if trans_b else 0  # QGemm stores B [N, K] when transB else [K, N]
+    assert pruned_inits[gemm_weight][k_axis] == m2 - round(m2 * 0.5)
+
+    # The pruned graph's own top-level input is still the original float
+    # graph input `x` (`QuantizeLinear`'s own first input) -- a real
+    # end-to-end numeric sanity check through the full quantized pipeline.
+    x = rng.standard_normal((N, c, spatial, spatial)).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"x": x})
+    assert y_pruned.shape == (N, out)
+    assert np.all(np.isfinite(y_pruned))
+
+
 # --- DynamicQuantizeMatMul / MatMulIntegerToFloat --------------------------
 #
 # ``com.microsoft::DynamicQuantizeMatMul``/``MatMulIntegerToFloat`` are ONNX


### PR DESCRIPTION
## Summary

The QOperator (`QLinearConv`/`QLinearMatMul`/`QGemm`) chain walker only matched same-family consumers, deliberately declining the general `Flatten`/`Reshape` cross-family case (a real, harder problem — a flattened column mixing multiple channels of real spatial extent). But a real CNN classifier head's `GlobalAveragePool` layer, when quantized via `quantize_static(quant_format=QOperator)`, doesn't stay a plain `GlobalAveragePool` — ORT's own quantizer replaces it with `com.microsoft::QLinearGlobalAveragePool`, an op this module never recognized anywhere. This silently left the last, widest backbone Conv layer (the one feeding the classifier head) unprunable.

## Empirically confirmed facts

- Built a real `Conv->ReLU->Conv->ReLU->GlobalAveragePool->Flatten->Linear` model, quantized via the real `onnxruntime.quantization.quantize_static(quant_format=QuantFormat.QOperator)` tool: the first Conv→Conv chain pruned correctly, but the second (widest) Conv — feeding the classifier head through `QLinearGlobalAveragePool -> Flatten -> QGemm` — was left completely untouched before this change.
- `QLinearGlobalAveragePool`'s own schema/doc text describes the identical "average pooling across the values in the same channel" computation as plain `GlobalAveragePool`, unchanged by quantization — the same per-channel-independent reduction that makes the reshape following it a *trivial* 1:1 channel relabeling, not the general (harder) case this module correctly still declines.
- ORT's quantizer always emits `channels_last=0` regardless of the source node's own attributes (confirmed live) — declined outright if ever found otherwise, never guessed at.

## What's added

- `_match_qlinear_gap_pass_through`/`_match_qop_gap_flatten_consumer` (new matchers), recognizing `QLinearConv -> QLinearGlobalAveragePool -> {Flatten(axis=1), Reshape([batch,-1]), Squeeze-of-trailing-axes} -> {QLinearMatMul, QGemm}` as a narrow, safe exception to the family's same-family-only restriction — mirroring the identical hop already landed in the plain-float and ConvInteger families.
- Reuses the existing `_match_flatten_axis1_pass_through`/`_match_reshape_batch_neg1_pass_through`/`_gap_squeeze_axes`/`_squeeze_axis_is_trailing_spatial` matchers verbatim (they only look at the reshape node's own shape, never at what feeds/consumes it, so the proof applies unchanged to a quantized producer). Only the final consumer match differs from the plain-float/ConvInteger case: `QLinearMatMul`/`QGemm` (via the existing `_match_qlinearmatmul`/`_match_qgemm` helpers) instead of a plain float `MatMul`/Gemm, since the tensor stays quantized throughout this family (unlike ConvInteger, which rescales back to float before this point).
- The general "Flatten/Reshape off real, un-pooled spatial extent" case remains correctly excluded — untouched.
- `tests/test_pruning.py`: 5 new tests (match+prune, non-scalar-activation-scale decline, `channels_last!=0` decline, wrong-axis Flatten decline, and a full real-`quantize_static` end-to-end pipeline test).

## Test plan

- [x] Both non-trivial new tests fail on the pre-fix code and pass after the fix (verified independently via a before/after checkout; the 3 decline tests pass either way as expected)
- [x] `pytest tests/test_pruning.py -k "qlinear or qop or qgemm"` — 26 passed
- [x] `pytest tests/test_pruning.py -q` (full suite) — 806 passed, same 154 pre-existing failures (stale compiled C++ extension noise, unrelated, confirmed identical on the pre-change commit)
- [x] `ruff format --check` / `ruff check` — clean
- [x] `mypy onnxsim/pruning.py` — no new issues

## Risks for reviewer

- `_match_qlinear_gap_pass_through` deliberately never checks `x_scale`/`x_zero_point` against the producing `QLinearConv`'s own output scale/zero-point — this is safe (not merely unchecked) because channel-slicing safety rests entirely on `QLinearGlobalAveragePool` treating every channel independently, regardless of what those operands equal.
- Scoped strictly to QOperator; the QDQ family (a separate, larger gap involving quantized bias and activation-requantization pass-through) is being addressed in a parallel PR.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_