### PR TITLE
Fix WandaCalibrationStats rank bug and alias apply_wanda_pruning; port core decomposed GQA/MQA/MHA attention chain

### DIFF
--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -1920,24 +1920,27 @@ def apply_wanda_pruning_cpp(
     ``ConvGroupRelativeNorm`` -- see ``structured_pruning_entry.h``'s own
     ``ApplyWandaPruning`` declaration comment for the full mechanism).
 
-    Despite that Conv parity, :func:`onnxsim.apply_wanda_pruning` (the
-    pure-Python name) is DELIBERATELY NOT an alias of this function: a
+    TRUE parity now also covers a prior gap unrelated to Conv: a
     full-regression check (every existing MatMul/Gemm/Attention candidate's
-    live output against the pure-Python reference, not just the new Conv
-    coverage) surfaced a genuine, pre-existing divergence unrelated to
-    Conv -- this port's own calibration statistic (``WandaCalibrationStats``,
-    shared with :func:`onnxsim.apply_structured_wanda_pruning_cpp`/
-    ``ApplyAttentionHeadWandaPruning``) computes a real per-channel-axis
-    activation norm for a MatMul/Gemm candidate's activation at ANY rank,
-    whereas the pure-Python reference requires exactly rank 2 for that same
-    statistic and falls back to plain magnitude for anything else (e.g. a
-    rank-3, batched/sequence activation feeding a plain 2-D MatMul weight).
-    See ``structured_pruning_entry.h``'s own ``ApplyWandaPruning``
-    declaration comment for the full writeup of this separate, out-of-scope
-    gap (it touches calibration infrastructure two other, independently-
-    verified passes also depend on) and
+    live output against the pure-Python reference, not just Conv coverage)
+    once surfaced a genuine, pre-existing divergence -- this port's own
+    calibration statistic (``WandaCalibrationStats``, shared with
+    :func:`onnxsim.apply_structured_wanda_pruning_cpp`/
+    ``ApplyAttentionHeadWandaPruning``) used to compute a real
+    per-channel-axis activation norm for a MatMul/Gemm candidate's
+    activation at ANY rank, whereas the pure-Python reference requires
+    exactly rank 2 for that same statistic and falls back to plain
+    magnitude for anything else (e.g. a rank-3, batched/sequence activation
+    feeding a plain 2-D MatMul weight). That gap is now closed --
+    ``WandaCalibrationStats`` takes a ``require_rank2`` set (this pass'
+    plain MatMul/Gemm candidates only; its Attention candidates keep the
+    any-rank->=2 treatment the pure-Python reference's own separate
+    ``attn_act_norm`` statistic always gave them, and the other two callers
+    above pass no such set at all, matching their own Python references'
+    complete lack of a rank restriction) -- see ``structured_pruning_entry.h``'s
+    own ``ApplyWandaPruning`` declaration comment for the full writeup and
     ``tests/test_wanda_pruning_cpp.py``'s own module docstring for the
-    regression test that caught it.
+    regression test that caught the original gap.
 
     Unlike :func:`onnxsim.apply_sparsegpt_pruning_cpp` (which has no data-
     free fallback at all -- its entire mechanism IS the Hessian), a matched

--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -2910,99 +2910,59 @@ def apply_wanda_pruning(
     :returns: ``model`` with every matched layer's weight zeroed in place
             to the target pattern; a MatMul/Gemm layer with a non-constant
             or non-2-D weight, a Conv layer with a non-4-D weight, or any
-            matched layer whose activation input isn't usable (not a plain
-            2-D tensor for MatMul/Gemm; not a rank-2+ tensor for Attention
+            matched layer whose activation input isn't usable (EXACTLY a
+            2-D tensor for MatMul/Gemm -- a rank-3+ batched/sequence
+            activation is treated as "no activation observed" for this
+            layer, not reduced down to 2-D; a rank-2+ tensor for Attention
             (its own ``X`` input is always rank-3 in practice, reduced over
-            every leading axis); not a 4-D NCHW tensor, or a malformed Conv
-            attribute combination :func:`_conv_spatial_attrs` declines --
-            e.g. a `kernel_shape` disagreeing with the weight's own shape --
-            for Conv; `auto_pad`/non-unit `dilations` are handled, not
-            declined) falls back to plain magnitude pruning (no activation
-            norm was ever observed)
+            every leading axis -- no such rank-2-only restriction here);
+            not a 4-D NCHW tensor, or a malformed Conv attribute combination
+            :func:`_conv_spatial_attrs` declines -- e.g. a `kernel_shape`
+            disagreeing with the weight's own shape -- for Conv;
+            `auto_pad`/non-unit `dilations` are handled, not declined)
+            falls back to plain magnitude pruning (no activation norm was
+            ever observed)
+
+    This pure-Python implementation has been retired in favor of the
+    verified-full-parity C++ port -- this is now a thin alias for
+    :func:`onnxsim.apply_wanda_pruning_cpp`
+    (``onnxsim/structured_pruning_entry.cpp``'s own ``ApplyWandaPruning``),
+    forwarding every argument unchanged. The rank-2-only restriction the
+    ``:returns:`` paragraph above describes for MatMul/Gemm (but not
+    Attention) was, for a time, a genuine scope gap between this function
+    and that C++ port -- ``WandaCalibrationStats`` (shared with
+    :func:`apply_structured_wanda_pruning`/
+    :func:`apply_attention_head_wanda_pruning`'s own C++ ports, neither of
+    which has any such restriction in its own Python reference) used to
+    observe a MatMul/Gemm candidate's activation at any rank, not just rank
+    2 -- now closed via that function's own ``require_rank2`` parameter,
+    populated only with this pass' own plain MatMul/Gemm candidates' `x_name`s
+    (never Attention's) -- see ``structured_pruning_entry.h``'s own
+    ``ApplyWandaPruning`` declaration comment for the full writeup, and
+    :func:`_wanda_unstructured_calibration_stats`/:func:`_wanda_norm_for_candidate`/
+    :func:`_wanda_importance` above (kept, unlike this function's own former
+    mutating body, since :func:`_analyze_wanda_pruning`'s dry-run report
+    still reuses them directly) for this rank-2-only restriction's own
+    pure-Python reference. Imported lazily (inside the function body, not at
+    module scope) to avoid a circular import: ``onnxsim.onnx_simplifier``
+    already imports from this module (:class:`EmbeddingPruningResult`), so
+    importing it back at module load time here would deadlock the import
+    machinery.
     """
-    _validate_pattern(sparsity, n, m)
-    if global_sparsity and n is not None:
-        raise ValueError(
-            "global_sparsity is not supported together with N:M pruning "
-            "(n/m) -- see apply_wanda_pruning's own docstring"
-        )
-    if isinstance(model, str):
-        model = onnx.load(model, load_external_data=False)
-    if calibration_data is None:
-        calibration_data = generate_random_calibration_data(
-            model, num_samples=num_samples, seed=seed
-        )
+    from onnxsim.onnx_simplifier import apply_wanda_pruning_cpp
 
-    out = onnx.ModelProto()
-    out.CopyFrom(model)
-    graph = out.graph
-    initializer_map = _constant_map(graph)
-
-    candidates = _candidates(graph)
-    if not candidates:
-        return out
-
-    act_norm, conv_act_norm, attn_act_norm = _wanda_unstructured_calibration_stats(
-        out, candidates, calibration_data, providers
+    return apply_wanda_pruning_cpp(
+        model,
+        calibration_data=calibration_data,
+        num_samples=num_samples,
+        seed=seed,
+        sparsity=sparsity,
+        n=n,
+        m=m,
+        epsilon=epsilon,
+        global_sparsity=global_sparsity,
+        providers=providers,
     )
-
-    if global_sparsity:
-        entries = []
-        for node, x_name, w_name, weight_transposed, is_conv in candidates:
-            w_init = initializer_map[w_name]
-            w = _to_f64(w_init)
-            w_nk = _weight_to_nk(w, weight_transposed, is_conv)
-            norm = _wanda_norm_for_candidate(
-                node,
-                x_name,
-                w_name,
-                is_conv,
-                w_init,
-                act_norm,
-                conv_act_norm,
-                attn_act_norm,
-            )
-            importance = _wanda_importance(w_nk, norm, epsilon)
-            entries.append(
-                (w_init, weight_transposed, is_conv, w.shape, w_nk, importance)
-            )
-        _apply_global_unstructured_pruning(entries, sparsity)
-        return out
-
-    for node, x_name, w_name, weight_transposed, is_conv in candidates:
-        w_init = initializer_map[w_name]
-        # `norm` is always kept 2-D here, broadcastable elementwise against
-        # `w_nk` ([out_channels, K]) inside importance_of_nk below: shape
-        # (1, K) for a MatMul/Gemm layer (one shared norm row for every
-        # output channel, the same broadcast the plain
-        # ``norm[np.newaxis, :]`` used to do directly), or -- for Conv --
-        # shape (out_channels, K), already expanded per output filter's own
-        # group by :func:`_conv_group_relative_norm` (trivially identical
-        # across every row when ``group=1``, genuinely different per group
-        # otherwise -- see that function's own docstring for why a single
-        # shared row would be wrong for a grouped/depthwise Conv).
-        norm = _wanda_norm_for_candidate(
-            node,
-            x_name,
-            w_name,
-            is_conv,
-            w_init,
-            act_norm,
-            conv_act_norm,
-            attn_act_norm,
-        )
-
-        def importance_of_nk(w_nk, norm=norm, n=n, m=m, sparsity=sparsity):
-            importance = _wanda_importance(w_nk, norm, epsilon)
-            return (
-                _nm_mask(importance, n, m)
-                if n is not None
-                else _sparsity_mask(importance, sparsity)
-            )
-
-        _prune_weight(w_init, weight_transposed, importance_of_nk, is_conv=is_conv)
-
-    return out
 
 
 def weight_sparsity(model: Union[str, onnx.ModelProto]) -> float:

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -21942,6 +21942,1190 @@ onnx::ModelProto ApplyStructuredWandaPruning(
   return out;
 }
 
+// --- Decomposed (un-fused) GQA/MQA/plain-MHA attention head pruning,
+// mirroring pruning.py's own "Decomposed (un-fused) attention head pruning"
+// section (_find_decomposed_gqa_chains/_apply_one_decomposed_gqa_chain) --
+// -------------------------------------------------------------------------
+//
+// Matches the eager/un-fused attention shape a plain torch.onnx.export()
+// (no ONNX Runtime transformer-fusion pass, no com.microsoft::GroupQuery
+// Attention emitted) produces: separate Q/K/V MatMul/vanilla-Gemm
+// projections, each reshaped+transposed into its own [batch, H, seq,
+// head_size] head-split, K's/V's own optional HuggingFace `repeat_kv`
+// broadcast (Unsqueeze(axis=[2]) -> Expand -> Reshape) for GQA/MQA, a plain
+// MatMul QK^T product, Softmax, a plain MatMul AV product, and a final
+// Transpose+Reshape combining the head axis back into the hidden dimension
+// before the output projection.
+//
+// DELIBERATELY NARROWER than pruning.py's own matcher, the same kind of
+// documented, accepted scope gap this port already carries for the fused-op
+// families above (see e.g. MatchMultiHeadAttentionProducer's own comment on
+// declining rather than reproducing pruning.py's own dynamic-bias slicing,
+// and ApplyOneGqaChain's own comment on having no MQA fast path at all):
+//
+//   - No additive mask (`attn_mask`/causal bias) of any kind is recognized
+//     here -- pruning.py's own `_resolve_decomposed_qk_root` matches an
+//     optional `Add(mask) -> [Mul/Div(scale) ->] MatMul` prefix; this port's
+//     `ResolveDecomposedQkRoot` only ever matches `[Mul/Div(scale) ->]
+//     MatMul`, so a graph with a real mask `Add` node between the QK^T
+//     product and Softmax simply fails to match at all here (the `Add`
+//     node's own op_type is never `Mul`/`Div`/`MatMul`) -- a decline, never
+//     a mis-slice.
+//   - No decomposed RoPE (`_DecomposedRopePassThrough`) or decomposed
+//     Q/K-norm (`_DecomposedQKNormPassThrough`) pass-through is recognized
+//     between a branch's own head-split `Reshape`/`Transpose` and the QK^T
+//     product -- either one sitting there breaks this port's own fixed
+//     `Reshape -> Transpose` adjacency check, so the whole chain simply
+//     fails to match (declines), the same safe fallback.
+//   - No `Einsum`-based QK^T/AV product (`_einsum_equation_is_batched_
+//     matmul`) -- `MatMul` only, mirroring this port's existing
+//     Attention-family scope everywhere else.
+//   - No packed-QKV-then-`Split` producer (`_match_decomposed_packed_qkv_
+//     producer`) -- Q's, K's, and V's own raw projection outputs must come
+//     from three independent MatMul/Gemm nodes; a shared producer declines
+//     the whole chain (the same "degenerate -- can't independently slice"
+//     decline pruning.py's own matcher gives a shape it can't resolve
+//     either way).
+//   - No true-MQA (`kv_num_heads == 1`) fast path -- mirrors ApplyOneGqaChain's
+//     own identical, already-accepted gap for the fused-op families: with
+//     only one KV group, `keep_count >= h` is always true, so this is a
+//     permanent no-op for that block (never mis-slices, just never prunes
+//     it), exactly like every other chain kind here already does for MQA.
+//   - Consumer (output-projection) weight dtype is plain FLOAT32 only,
+//     mirroring WalkToAttentionConsumer's own identical restriction for
+//     every other chain kind in this file (not pruning.py's own broader
+//     `_is_supported_float_dtype`, which additionally allows FLOAT16/
+//     BFLOAT16).
+//
+// What IS matched, closing the real gap this section exists for: both of
+// K's own real dot-product-transpose shapes (the combined
+// `Transpose(perm=[0,2,3,1])` PyTorch's own `fuseConsecutiveTransposes`
+// peephole emits when nothing sits between the head-split and the QK^T
+// "swap", and the ordinary separate-`Transpose` shape otherwise), K's/V's
+// own optional `repeat_kv` GQA/MQA broadcast, an optional global scalar
+// scale (`Mul`/`Div` by a constant), and -- the genuinely novel part this
+// family was deferred for -- rewriting every `Reshape`/`Expand` shape
+// constant this chain owns to its new post-pruning head count, safely: in
+// place when every one of that constant's real (freshly recomputed at apply
+// time) readers is owned by this chain, or, when a genuinely unrelated
+// extra reader exists (this pass's own onnxsim CSE routinely merges two
+// textually identical shape constants from different chains/layers onto one
+// shared tensor), by cloning a fresh tensor holding the current value and
+// rewiring only this chain's own owning node(s) onto it -- see
+// RewriteDecomposedShapeDim's own comment below for the exact mechanism,
+// mirroring pruning.py's own `_rewrite_shape_dim` local helper.
+
+struct DecomposedGqaChain {
+  struct RepeatKv {
+    onnx::NodeProto* unsqueeze = nullptr;
+    onnx::NodeProto* expand = nullptr;
+    std::string expand_shape;
+    onnx::NodeProto* merge_reshape = nullptr;
+    std::string merge_reshape_shape;
+  };
+
+  std::string q_weight, k_weight, v_weight;
+  bool q_weight_transposed = false;
+  bool k_weight_transposed = false;
+  bool v_weight_transposed = false;
+  std::optional<std::string> q_bias, k_bias, v_bias;
+  int64_t num_heads = 0;
+  int64_t kv_num_heads = 0;
+  int64_t head_size = 0;
+  int64_t v_head_size = 0;
+
+  onnx::NodeProto* q_transpose = nullptr;
+  onnx::NodeProto* q_reshape = nullptr;
+  std::string q_reshape_shape;
+
+  // K's own dot-product-transpose node -- either the combined
+  // perm=[0,2,3,1] head-split+swap (k_headsplit_transpose is then nullptr)
+  // or the separate perm=[0,1,3,2] swap alone (k_headsplit_transpose then
+  // names K's own actual head-split Transpose, a distinct node).
+  onnx::NodeProto* k_transpose = nullptr;
+  onnx::NodeProto* k_headsplit_transpose = nullptr;
+  onnx::NodeProto* k_reshape = nullptr;
+  std::string k_reshape_shape;
+  std::optional<RepeatKv> k_repeat_kv;
+
+  onnx::NodeProto* v_transpose = nullptr;
+  onnx::NodeProto* v_reshape = nullptr;
+  std::string v_reshape_shape;
+  std::optional<RepeatKv> v_repeat_kv;
+
+  onnx::NodeProto* qk_matmul = nullptr;
+  onnx::NodeProto* scale_node = nullptr;
+  onnx::NodeProto* softmax_node = nullptr;
+  onnx::NodeProto* av_matmul = nullptr;
+  onnx::NodeProto* out_transpose = nullptr;
+  onnx::NodeProto* out_reshape = nullptr;
+  // nullopt exactly when the combine-back Reshape's own target shape's last
+  // entry is already a wildcard (-1/0) -- never a rewrite candidate then,
+  // mirrors pruning.py's own identical `out_reshape_shape` field.
+  std::optional<std::string> out_reshape_shape;
+
+  onnx::NodeProto* consumer_node = nullptr;
+  std::string consumer_weight;
+  bool consumer_weight_transposed = false;
+};
+
+// Resolves `name` (already confirmed internal by the caller) backward
+// through the fixed 2-node `Reshape -> Transpose(perm)` head-split sequence
+// -- mirrors pruning.py's own `_match_decomposed_head_split` (this port's
+// scope: no `allow_qk_norm` hop -- see this section's own top comment).
+struct HeadSplitMatch {
+  onnx::NodeProto* transpose;
+  onnx::NodeProto* reshape;
+  int64_t num_heads;
+  int64_t head_size;
+  std::string reshape_shape;
+  std::string proj_out;
+};
+
+std::optional<HeadSplitMatch> MatchDecomposedHeadSplit(
+    const std::string& name, const ConsumerMap& consumers_of,
+    const std::unordered_set<std::string>& graph_outputs,
+    const std::unordered_map<std::string, onnx::NodeProto*>& node_by_output,
+    const InitMap& init_map, const std::vector<int64_t>& perm) {
+  auto is_internal = [&](const std::string& n) {
+    return ConsumerCount(consumers_of, n) == 1 && !graph_outputs.count(n);
+  };
+  auto tit = node_by_output.find(name);
+  if (tit == node_by_output.end()) {
+    return std::nullopt;
+  }
+  onnx::NodeProto* transpose = tit->second;
+  if (transpose->domain() != "" || transpose->op_type() != "Transpose" ||
+      transpose->input_size() != 1 || transpose->input(0).empty() ||
+      transpose->output_size() != 1 || transpose->output(0) != name) {
+    return std::nullopt;
+  }
+  std::vector<int64_t> found_perm;
+  bool has_perm = false;
+  for (const auto& attr : transpose->attribute()) {
+    if (attr.name() == "perm") {
+      found_perm.assign(attr.ints().begin(), attr.ints().end());
+      has_perm = true;
+    }
+  }
+  if (!has_perm || found_perm != perm) {
+    return std::nullopt;
+  }
+
+  const std::string reshaped_name = transpose->input(0);
+  if (!is_internal(reshaped_name)) {
+    return std::nullopt;
+  }
+  auto rit = node_by_output.find(reshaped_name);
+  if (rit == node_by_output.end()) {
+    return std::nullopt;
+  }
+  onnx::NodeProto* reshape = rit->second;
+  if (reshape->domain() != "" || reshape->op_type() != "Reshape" ||
+      reshape->input_size() != 2 || reshape->input(0).empty() ||
+      reshape->input(1).empty() || reshape->output_size() != 1 ||
+      reshape->output(0) != reshaped_name) {
+    return std::nullopt;
+  }
+  auto sit = init_map.find(reshape->input(1));
+  if (sit == init_map.end() ||
+      sit->second->data_type() != onnx::TensorProto::INT64 ||
+      sit->second->dims_size() != 1 || sit->second->dims(0) != 4) {
+    return std::nullopt;
+  }
+  std::vector<int64_t> dims = ReadInt64Tensor(*sit->second);
+  if (dims.size() != 4) {
+    return std::nullopt;
+  }
+  const int64_t num_heads = dims[2];
+  const int64_t head_size = dims[3];
+  if (num_heads <= 0 || head_size <= 0) {
+    return std::nullopt;
+  }
+
+  const std::string proj_out = reshape->input(0);
+  if (!is_internal(proj_out)) {
+    return std::nullopt;
+  }
+
+  return HeadSplitMatch{transpose, reshape,           num_heads,
+                        head_size, reshape->input(1), proj_out};
+}
+
+// Resolves `name` (already confirmed internal by the caller) backward
+// through the standard HuggingFace `repeat_kv` broadcast -- `Unsqueeze
+// (axis=[2]) -> Expand -> Reshape` -- mirrors pruning.py's own
+// `_match_decomposed_repeat_kv` exactly.
+struct RepeatKvMatch {
+  DecomposedGqaChain::RepeatKv branch;
+  std::string raw_name;
+  int64_t kv_num_heads;
+  int64_t n_rep;
+};
+
+std::optional<RepeatKvMatch> MatchDecomposedRepeatKv(
+    const std::string& name, const ConsumerMap& consumers_of,
+    const std::unordered_set<std::string>& graph_outputs,
+    const std::unordered_map<std::string, onnx::NodeProto*>& node_by_output,
+    const InitMap& init_map) {
+  auto is_internal = [&](const std::string& n) {
+    return ConsumerCount(consumers_of, n) == 1 && !graph_outputs.count(n);
+  };
+  auto rit = node_by_output.find(name);
+  if (rit == node_by_output.end()) {
+    return std::nullopt;
+  }
+  onnx::NodeProto* reshape = rit->second;
+  if (reshape->domain() != "" || reshape->op_type() != "Reshape" ||
+      reshape->input_size() != 2 || reshape->input(0).empty() ||
+      reshape->input(1).empty() || reshape->output_size() != 1 ||
+      reshape->output(0) != name) {
+    return std::nullopt;
+  }
+  auto mit = init_map.find(reshape->input(1));
+  if (mit == init_map.end() ||
+      mit->second->data_type() != onnx::TensorProto::INT64 ||
+      mit->second->dims_size() != 1 || mit->second->dims(0) != 4) {
+    return std::nullopt;
+  }
+  std::vector<int64_t> merge_dims = ReadInt64Tensor(*mit->second);
+  if (merge_dims.size() != 4) {
+    return std::nullopt;
+  }
+  const int64_t merged_heads = merge_dims[1];
+  if (merged_heads <= 0) {
+    return std::nullopt;
+  }
+
+  const std::string expand_out = reshape->input(0);
+  if (!is_internal(expand_out)) {
+    return std::nullopt;
+  }
+  auto eit = node_by_output.find(expand_out);
+  if (eit == node_by_output.end()) {
+    return std::nullopt;
+  }
+  onnx::NodeProto* expand = eit->second;
+  if (expand->domain() != "" || expand->op_type() != "Expand" ||
+      expand->input_size() != 2 || expand->input(0).empty() ||
+      expand->input(1).empty() || expand->output_size() != 1 ||
+      expand->output(0) != expand_out) {
+    return std::nullopt;
+  }
+  auto exit_ = init_map.find(expand->input(1));
+  if (exit_ == init_map.end() ||
+      exit_->second->data_type() != onnx::TensorProto::INT64 ||
+      exit_->second->dims_size() != 1 || exit_->second->dims(0) != 5) {
+    return std::nullopt;
+  }
+  std::vector<int64_t> expand_dims = ReadInt64Tensor(*exit_->second);
+  if (expand_dims.size() != 5) {
+    return std::nullopt;
+  }
+  const int64_t kv_num_heads = expand_dims[1];
+  const int64_t n_rep = expand_dims[2];
+  if (kv_num_heads <= 0 || n_rep <= 0 || kv_num_heads * n_rep != merged_heads) {
+    return std::nullopt;
+  }
+
+  const std::string unsqueeze_out = expand->input(0);
+  if (!is_internal(unsqueeze_out)) {
+    return std::nullopt;
+  }
+  auto uit = node_by_output.find(unsqueeze_out);
+  if (uit == node_by_output.end()) {
+    return std::nullopt;
+  }
+  onnx::NodeProto* unsqueeze = uit->second;
+  if (unsqueeze->domain() != "" || unsqueeze->op_type() != "Unsqueeze" ||
+      unsqueeze->input_size() != 2 || unsqueeze->input(0).empty() ||
+      unsqueeze->input(1).empty() || unsqueeze->output_size() != 1 ||
+      unsqueeze->output(0) != unsqueeze_out) {
+    return std::nullopt;
+  }
+  auto axit = init_map.find(unsqueeze->input(1));
+  if (axit == init_map.end() ||
+      axit->second->data_type() != onnx::TensorProto::INT64 ||
+      axit->second->dims_size() != 1 || axit->second->dims(0) != 1) {
+    return std::nullopt;
+  }
+  std::vector<int64_t> axes = ReadInt64Tensor(*axit->second);
+  if (axes.size() != 1 || axes[0] != 2) {
+    return std::nullopt;
+  }
+
+  const std::string raw_name = unsqueeze->input(0);
+  if (!is_internal(raw_name)) {
+    return std::nullopt;
+  }
+
+  RepeatKvMatch m;
+  m.branch.unsqueeze = unsqueeze;
+  m.branch.expand = expand;
+  m.branch.expand_shape = expand->input(1);
+  m.branch.merge_reshape = reshape;
+  m.branch.merge_reshape_shape = reshape->input(1);
+  m.raw_name = raw_name;
+  m.kv_num_heads = kv_num_heads;
+  m.n_rep = n_rep;
+  return m;
+}
+
+// Resolves a Softmax's own input backward through the optional
+// `[Mul/Div(scalar scale) ->] MatMul` prefix -- mirrors pruning.py's own
+// `_resolve_decomposed_qk_root`, narrowed to this port's own scope (no mask
+// `Add`, no `Einsum` -- see this section's own top comment).
+struct QkRootMatch {
+  onnx::NodeProto* qk_matmul;
+  onnx::NodeProto* scale_node;  // nullptr when absent.
+};
+
+std::optional<QkRootMatch> ResolveDecomposedQkRoot(
+    const std::string& smax_input, const ConsumerMap& consumers_of,
+    const std::unordered_set<std::string>& graph_outputs,
+    const std::unordered_map<std::string, onnx::NodeProto*>& node_by_output,
+    const InitMap& init_map) {
+  auto is_internal = [&](const std::string& n) {
+    return ConsumerCount(consumers_of, n) == 1 && !graph_outputs.count(n);
+  };
+  auto is_scalar_const = [&](const std::string& n) {
+    auto it = init_map.find(n);
+    if (it == init_map.end()) {
+      return false;
+    }
+    int64_t prod = 1;
+    for (int64_t d : it->second->dims()) {
+      prod *= d;
+    }
+    return prod == 1;
+  };
+
+  std::string cur = smax_input;
+  onnx::NodeProto* scale_node = nullptr;
+  if (is_internal(cur)) {
+    auto pit = node_by_output.find(cur);
+    if (pit != node_by_output.end()) {
+      onnx::NodeProto* probe = pit->second;
+      if ((probe->op_type() == "Mul" || probe->op_type() == "Div") &&
+          probe->domain() == "" && probe->input_size() == 2 &&
+          !probe->input(0).empty() && !probe->input(1).empty() &&
+          probe->output_size() == 1 && probe->output(0) == cur) {
+        const std::string& a = probe->input(0);
+        const std::string& b = probe->input(1);
+        if (a != b && is_scalar_const(b)) {
+          scale_node = probe;
+          cur = a;
+        } else if (a != b && probe->op_type() == "Mul" && is_scalar_const(a)) {
+          scale_node = probe;
+          cur = b;
+        }
+      }
+    }
+  }
+
+  if (!is_internal(cur)) {
+    return std::nullopt;
+  }
+  auto qit = node_by_output.find(cur);
+  if (qit == node_by_output.end()) {
+    return std::nullopt;
+  }
+  onnx::NodeProto* qk_matmul = qit->second;
+  if (qk_matmul->domain() != "" || qk_matmul->op_type() != "MatMul" ||
+      qk_matmul->input_size() != 2 || qk_matmul->output_size() != 1 ||
+      qk_matmul->output(0) != cur) {
+    return std::nullopt;
+  }
+  return QkRootMatch{qk_matmul, scale_node};
+}
+
+// Every tensor/node name already live in `graph` -- mirrors pruning.py's own
+// `_existing_graph_names`, the seed set MintUniqueName grows from so a
+// freshly cloned shape constant (RewriteDecomposedShapeDim's own "foreign
+// reader" branch) can never collide with anything already in the graph.
+std::unordered_set<std::string> ExistingGraphNames(
+    const onnx::GraphProto& graph) {
+  std::unordered_set<std::string> names;
+  for (const auto& vi : graph.input()) {
+    names.insert(vi.name());
+  }
+  for (const auto& vi : graph.output()) {
+    names.insert(vi.name());
+  }
+  for (const auto& vi : graph.value_info()) {
+    names.insert(vi.name());
+  }
+  for (const auto& t : graph.initializer()) {
+    names.insert(t.name());
+  }
+  for (const auto& node : graph.node()) {
+    if (!node.name().empty()) {
+      names.insert(node.name());
+    }
+    for (const auto& n : node.input()) {
+      if (!n.empty()) {
+        names.insert(n);
+      }
+    }
+    for (const auto& n : node.output()) {
+      if (!n.empty()) {
+        names.insert(n);
+      }
+    }
+  }
+  return names;
+}
+
+// `base`, or `base` with a numeric suffix appended until it no longer
+// collides with anything in `used` -- and reserves the result before
+// returning it. Mirrors pruning.py's own `_mint_unique_name`.
+std::string MintUniqueName(const std::string& base,
+                           std::unordered_set<std::string>& used) {
+  std::string name = base;
+  int suffix = 0;
+  while (used.count(name)) {
+    ++suffix;
+    name = base + "_" + std::to_string(suffix);
+  }
+  used.insert(name);
+  return name;
+}
+
+// Anchored on each plain (default-domain) `Softmax(axis=-1)` node in `graph`
+// -- a far rarer, more specific anchor than a MatMul/Gemm -- mirrors
+// pruning.py's own `_find_decomposed_gqa_chains` (this port's own narrower
+// scope: see this section's own top comment).
+std::vector<DecomposedGqaChain> FindDecomposedGqaChains(
+    onnx::GraphProto* graph) {
+  InitMap init_map;
+  for (const auto& t : graph->initializer()) {
+    init_map[t.name()] = &t;
+  }
+  ConsumerMap consumers_of = ConsumersOf(graph);
+  std::unordered_set<std::string> graph_outputs;
+  for (const auto& o : graph->output()) {
+    graph_outputs.insert(o.name());
+  }
+  std::unordered_map<std::string, onnx::NodeProto*> node_by_output;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    for (const auto& out : node->output()) {
+      if (!out.empty()) {
+        node_by_output[out] = node;
+      }
+    }
+  }
+  auto is_internal = [&](const std::string& n) {
+    return ConsumerCount(consumers_of, n) == 1 && !graph_outputs.count(n);
+  };
+
+  const std::vector<int64_t> kPermBhsd{0, 2, 1, 3};      // ordinary head-split
+  const std::vector<int64_t> kPermCombined{0, 2, 3, 1};  // K's fused swap
+  const std::vector<int64_t> kPermSwap{0, 1, 3, 2};      // K's separate swap
+  const std::vector<int64_t> kPermOut{0, 2, 1, 3};       // combine-back
+
+  std::vector<DecomposedGqaChain> chains;
+  for (int ni = 0; ni < graph->node_size(); ++ni) {
+    onnx::NodeProto* node = graph->mutable_node(ni);
+    if (node->domain() != "" || node->op_type() != "Softmax") {
+      continue;
+    }
+    int64_t axis = -1;
+    for (const auto& attr : node->attribute()) {
+      if (attr.name() == "axis") {
+        axis = attr.i();
+      }
+    }
+    if (axis != -1) {
+      continue;
+    }
+    if (node->input_size() != 1 || node->input(0).empty() ||
+        node->output_size() != 1) {
+      continue;
+    }
+    const std::string& smax_out = node->output(0);
+    if (!is_internal(smax_out)) {
+      continue;
+    }
+
+    auto root = ResolveDecomposedQkRoot(
+        node->input(0), consumers_of, graph_outputs, node_by_output, init_map);
+    if (!root) {
+      continue;
+    }
+    onnx::NodeProto* qk_matmul = root->qk_matmul;
+    onnx::NodeProto* scale_node = root->scale_node;
+
+    const std::string q_bhsd_name = qk_matmul->input(0);
+    const std::string k_operand = qk_matmul->input(1);
+    if (!is_internal(q_bhsd_name) || !is_internal(k_operand)) {
+      continue;
+    }
+
+    // ---- K's own dot-product transpose: combined or separate form ----
+    onnx::NodeProto* k_transpose = nullptr;
+    onnx::NodeProto* k_headsplit_transpose = nullptr;
+    onnx::NodeProto* k_reshape = nullptr;
+    std::string k_reshape_shape;
+    std::string k_proj_out;
+    std::optional<DecomposedGqaChain::RepeatKv> k_repeat_kv;
+    int64_t kv_num_heads = -1;
+    int64_t head_size_k = -1;
+
+    auto kt_it = node_by_output.find(k_operand);
+    if (kt_it == node_by_output.end()) {
+      continue;
+    }
+    k_transpose = kt_it->second;
+    if (k_transpose->domain() != "" || k_transpose->op_type() != "Transpose") {
+      continue;
+    }
+    std::vector<int64_t> k_perm;
+    bool k_has_perm = false;
+    for (const auto& attr : k_transpose->attribute()) {
+      if (attr.name() == "perm") {
+        k_perm.assign(attr.ints().begin(), attr.ints().end());
+        k_has_perm = true;
+      }
+    }
+    if (!k_has_perm) {
+      continue;
+    }
+
+    if (k_perm == kPermCombined) {
+      auto k_split =
+          MatchDecomposedHeadSplit(k_operand, consumers_of, graph_outputs,
+                                   node_by_output, init_map, kPermCombined);
+      if (!k_split) {
+        continue;
+      }
+      k_reshape = k_split->reshape;
+      kv_num_heads = k_split->num_heads;
+      head_size_k = k_split->head_size;
+      k_reshape_shape = k_split->reshape_shape;
+      k_proj_out = k_split->proj_out;
+      k_headsplit_transpose = nullptr;
+    } else if (k_perm == kPermSwap) {
+      if (k_transpose->input_size() != 1 || k_transpose->input(0).empty()) {
+        continue;
+      }
+      const std::string k_bhsd_name = k_transpose->input(0);
+      if (!is_internal(k_bhsd_name)) {
+        continue;
+      }
+      std::string k_raw_name = k_bhsd_name;
+      auto repeat = MatchDecomposedRepeatKv(
+          k_bhsd_name, consumers_of, graph_outputs, node_by_output, init_map);
+      if (repeat) {
+        k_repeat_kv = repeat->branch;
+        k_raw_name = repeat->raw_name;
+        kv_num_heads = repeat->kv_num_heads;
+      }
+      auto k_split =
+          MatchDecomposedHeadSplit(k_raw_name, consumers_of, graph_outputs,
+                                   node_by_output, init_map, kPermBhsd);
+      if (!k_split) {
+        continue;
+      }
+      k_headsplit_transpose = k_split->transpose;
+      k_reshape = k_split->reshape;
+      const int64_t resolved_kv_heads = k_split->num_heads;
+      head_size_k = k_split->head_size;
+      k_reshape_shape = k_split->reshape_shape;
+      k_proj_out = k_split->proj_out;
+      if (kv_num_heads < 0) {
+        kv_num_heads = resolved_kv_heads;
+      } else if (kv_num_heads != resolved_kv_heads) {
+        continue;
+      }
+    } else {
+      continue;
+    }
+
+    // ---- Q's own branch: plain head-split, never repeat_kv ----
+    auto q_split =
+        MatchDecomposedHeadSplit(q_bhsd_name, consumers_of, graph_outputs,
+                                 node_by_output, init_map, kPermBhsd);
+    if (!q_split) {
+      continue;
+    }
+    onnx::NodeProto* q_transpose = q_split->transpose;
+    onnx::NodeProto* q_reshape = q_split->reshape;
+    const int64_t num_heads = q_split->num_heads;
+    const int64_t head_size = q_split->head_size;
+    const std::string q_reshape_shape = q_split->reshape_shape;
+    const std::string q_proj_out = q_split->proj_out;
+    if (head_size != head_size_k || num_heads <= 0 || kv_num_heads <= 0) {
+      continue;
+    }
+    if (num_heads % kv_num_heads != 0) {
+      continue;
+    }
+
+    // ---- forward: AV MatMul, output Transpose, combine-back Reshape ----
+    auto avit = consumers_of.find(smax_out);
+    if (avit == consumers_of.end() || avit->second.size() != 1) {
+      continue;
+    }
+    onnx::NodeProto* av_matmul = avit->second[0];
+    if (av_matmul->domain() != "" || av_matmul->op_type() != "MatMul" ||
+        av_matmul->input_size() != 2 || av_matmul->output_size() != 1) {
+      continue;
+    }
+    const bool attn_is_first = av_matmul->input(0) == smax_out;
+    if (!attn_is_first && av_matmul->input(1) != smax_out) {
+      continue;
+    }
+    const std::string v_bhsd_name =
+        attn_is_first ? av_matmul->input(1) : av_matmul->input(0);
+    if (v_bhsd_name == smax_out || !is_internal(v_bhsd_name)) {
+      continue;
+    }
+    const std::string av_out = av_matmul->output(0);
+    if (!is_internal(av_out)) {
+      continue;
+    }
+
+    auto otit = consumers_of.find(av_out);
+    if (otit == consumers_of.end() || otit->second.size() != 1) {
+      continue;
+    }
+    onnx::NodeProto* out_transpose = otit->second[0];
+    if (out_transpose->op_type() != "Transpose" ||
+        out_transpose->domain() != "" || out_transpose->input_size() != 1) {
+      continue;
+    }
+    std::vector<int64_t> out_perm;
+    bool out_has_perm = false;
+    for (const auto& attr : out_transpose->attribute()) {
+      if (attr.name() == "perm") {
+        out_perm.assign(attr.ints().begin(), attr.ints().end());
+        out_has_perm = true;
+      }
+    }
+    if (!out_has_perm || out_perm != kPermOut) {
+      continue;
+    }
+    const std::string out_t_name = out_transpose->output(0);
+    if (!is_internal(out_t_name)) {
+      continue;
+    }
+
+    auto orit = consumers_of.find(out_t_name);
+    if (orit == consumers_of.end() || orit->second.size() != 1) {
+      continue;
+    }
+    onnx::NodeProto* out_reshape = orit->second[0];
+    if (out_reshape->op_type() != "Reshape" || out_reshape->domain() != "" ||
+        out_reshape->input_size() != 2 || out_reshape->input(0) != out_t_name ||
+        out_reshape->output_size() != 1) {
+      continue;
+    }
+    auto osit = init_map.find(out_reshape->input(1));
+    if (osit == init_map.end() ||
+        osit->second->data_type() != onnx::TensorProto::INT64 ||
+        osit->second->dims_size() != 1) {
+      continue;
+    }
+    std::vector<int64_t> out_dims = ReadInt64Tensor(*osit->second);
+    if (out_dims.empty()) {
+      continue;
+    }
+    const int64_t out_last = out_dims.back();
+    const std::string out_reshape_out = out_reshape->output(0);
+    if (!is_internal(out_reshape_out)) {
+      continue;
+    }
+
+    auto cnit = consumers_of.find(out_reshape_out);
+    if (cnit == consumers_of.end() || cnit->second.size() != 1) {
+      continue;
+    }
+    onnx::NodeProto* consumer_node = cnit->second[0];
+    auto cm = MatchMatMulLikeRaw(*consumer_node);
+    if (!cm || cm->x_name != out_reshape_out) {
+      continue;
+    }
+    auto cwit = init_map.find(cm->w_name);
+    if (cwit == init_map.end() ||
+        cwit->second->data_type() != onnx::TensorProto::FLOAT ||
+        cwit->second->dims_size() != 2) {
+      continue;
+    }
+    const onnx::TensorProto* cw_init = cwit->second;
+
+    // ---- V's own branch: optional repeat_kv, then plain head-split ----
+    std::string v_raw_name = v_bhsd_name;
+    std::optional<DecomposedGqaChain::RepeatKv> v_repeat_kv;
+    int64_t v_kv_num_heads = -1;
+    auto v_repeat = MatchDecomposedRepeatKv(
+        v_bhsd_name, consumers_of, graph_outputs, node_by_output, init_map);
+    if (v_repeat) {
+      v_repeat_kv = v_repeat->branch;
+      v_raw_name = v_repeat->raw_name;
+      v_kv_num_heads = v_repeat->kv_num_heads;
+    }
+    auto v_split =
+        MatchDecomposedHeadSplit(v_raw_name, consumers_of, graph_outputs,
+                                 node_by_output, init_map, kPermBhsd);
+    if (!v_split) {
+      continue;
+    }
+    onnx::NodeProto* v_transpose = v_split->transpose;
+    onnx::NodeProto* v_reshape = v_split->reshape;
+    const int64_t resolved_v_kv_heads = v_split->num_heads;
+    const int64_t v_head_size = v_split->head_size;
+    const std::string v_reshape_shape = v_split->reshape_shape;
+    const std::string v_proj_out = v_split->proj_out;
+    if (v_kv_num_heads < 0) {
+      v_kv_num_heads = resolved_v_kv_heads;
+    } else if (v_kv_num_heads != resolved_v_kv_heads) {
+      continue;
+    }
+    if (v_kv_num_heads != kv_num_heads || v_head_size <= 0) {
+      continue;
+    }
+
+    const int64_t raw_out_width = num_heads * v_head_size;
+    if (out_last > 0 && out_last != raw_out_width) {
+      continue;
+    }
+    const int64_t k_dim =
+        cm->weight_transposed ? cw_init->dims(1) : cw_init->dims(0);
+    if (k_dim != raw_out_width) {
+      continue;
+    }
+
+    // ---- Q/K/V's own real Linear producers -- three independent
+    // MatMul/Gemm nodes only, no packed-QKV-then-Split (this port's own
+    // scope, see this section's own top comment) ----
+    auto qpit = node_by_output.find(q_proj_out);
+    auto kpit = node_by_output.find(k_proj_out);
+    auto vpit = node_by_output.find(v_proj_out);
+    if (qpit == node_by_output.end() || kpit == node_by_output.end() ||
+        vpit == node_by_output.end()) {
+      continue;
+    }
+    onnx::NodeProto* q_prod_node = qpit->second;
+    onnx::NodeProto* k_prod_node = kpit->second;
+    onnx::NodeProto* v_prod_node = vpit->second;
+    if (q_prod_node == k_prod_node || q_prod_node == v_prod_node ||
+        k_prod_node == v_prod_node) {
+      continue;  // Shared producer -- declined (no packed-QKV support here).
+    }
+    auto q_info = MatchProducer(*q_prod_node, init_map);
+    auto k_info = MatchProducer(*k_prod_node, init_map);
+    auto v_info = MatchProducer(*v_prod_node, init_map);
+    if (!q_info || !k_info || !v_info) {
+      continue;
+    }
+    if (q_info->weight == k_info->weight || q_info->weight == v_info->weight ||
+        k_info->weight == v_info->weight) {
+      continue;
+    }
+    if (q_info->n_channels != num_heads * head_size ||
+        k_info->n_channels != kv_num_heads * head_size ||
+        v_info->n_channels != kv_num_heads * v_head_size) {
+      continue;
+    }
+
+    const std::optional<std::string> out_reshape_shape_opt =
+        out_last > 0 ? std::optional<std::string>(out_reshape->input(1))
+                     : std::nullopt;
+
+    DecomposedGqaChain chain;
+    chain.q_weight = q_info->weight;
+    chain.q_bias = q_info->bias;
+    chain.q_weight_transposed = q_info->weight_transposed;
+    chain.k_weight = k_info->weight;
+    chain.k_bias = k_info->bias;
+    chain.k_weight_transposed = k_info->weight_transposed;
+    chain.v_weight = v_info->weight;
+    chain.v_bias = v_info->bias;
+    chain.v_weight_transposed = v_info->weight_transposed;
+    chain.num_heads = num_heads;
+    chain.kv_num_heads = kv_num_heads;
+    chain.head_size = head_size;
+    chain.v_head_size = v_head_size;
+    chain.q_transpose = q_transpose;
+    chain.q_reshape = q_reshape;
+    chain.q_reshape_shape = q_reshape_shape;
+    chain.k_transpose = k_transpose;
+    chain.k_headsplit_transpose = k_headsplit_transpose;
+    chain.k_reshape = k_reshape;
+    chain.k_reshape_shape = k_reshape_shape;
+    chain.k_repeat_kv = k_repeat_kv;
+    chain.v_transpose = v_transpose;
+    chain.v_reshape = v_reshape;
+    chain.v_reshape_shape = v_reshape_shape;
+    chain.v_repeat_kv = v_repeat_kv;
+    chain.qk_matmul = qk_matmul;
+    chain.scale_node = scale_node;
+    chain.softmax_node = node;
+    chain.av_matmul = av_matmul;
+    chain.out_transpose = out_transpose;
+    chain.out_reshape = out_reshape;
+    chain.out_reshape_shape = out_reshape_shape_opt;
+    chain.consumer_node = consumer_node;
+    chain.consumer_weight = cm->w_name;
+    chain.consumer_weight_transposed = cm->weight_transposed;
+    chains.push_back(std::move(chain));
+  }
+  return chains;
+}
+
+struct AppliedDecomposedGqa {
+  std::unordered_set<std::string> producer_weights;
+  std::string consumer_weight;
+  std::unordered_set<std::string> stale;
+};
+
+// Applies whole-KV-group pruning to one matched decomposed attention block
+// in place -- mirrors pruning.py's own `_apply_one_decomposed_gqa_chain`
+// (this port's own scope: no MQA fast path, no packed-QKV branch, no mask
+// rewrite -- see this section's own top comment). `graph`/`init_map`/
+// `used_names` are mutated directly: `init_map` gains an entry for every
+// freshly cloned shape constant, `used_names` for every freshly minted name.
+std::optional<AppliedDecomposedGqa> ApplyOneDecomposedGqaChain(
+    onnx::GraphProto* graph,
+    std::unordered_map<std::string, onnx::TensorProto*>& init_map,
+    std::unordered_set<std::string>& used_names, DecomposedGqaChain& chain,
+    double sparsity,
+    const std::unordered_map<std::string, std::vector<double>>* act_norm,
+    double epsilon, ImportanceNorm importance_norm) {
+  const int64_t h = chain.kv_num_heads;
+  const int64_t keep_count =
+      std::max<int64_t>(1, h - std::llround(static_cast<double>(h) * sparsity));
+  if (keep_count >= h) {
+    return std::nullopt;  // Also the permanent no-op outcome for true MQA
+                          // (h == 1) -- mirrors ApplyOneGqaChain's own
+                          // identical, already-accepted gap.
+  }
+
+  const int64_t d = chain.head_size;
+  const int64_t dv = chain.v_head_size;
+  const int64_t group_size = chain.num_heads / chain.kv_num_heads;
+
+  onnx::TensorProto* wq_init = init_map.at(chain.q_weight);
+  onnx::TensorProto* wk_init = init_map.at(chain.k_weight);
+  onnx::TensorProto* wv_init = init_map.at(chain.v_weight);
+  const std::vector<int64_t> wq_dims(wq_init->dims().begin(),
+                                     wq_init->dims().end());
+  const std::vector<int64_t> wk_dims(wk_init->dims().begin(),
+                                     wk_init->dims().end());
+  const std::vector<int64_t> wv_dims(wv_init->dims().begin(),
+                                     wv_init->dims().end());
+  std::vector<float> wq = ReadFloatTensor(*wq_init);
+  std::vector<float> wk = ReadFloatTensor(*wk_init);
+  std::vector<float> wv = ReadFloatTensor(*wv_init);
+
+  const int64_t Nq = wq_dims[chain.q_weight_transposed ? 0 : 1];
+  const int64_t Nk = wk_dims[chain.k_weight_transposed ? 0 : 1];
+  const int64_t Nv = wv_dims[chain.v_weight_transposed ? 0 : 1];
+  std::vector<float> wq_kn = chain.q_weight_transposed
+                                 ? TransposeFlat(wq, wq_dims[0], wq_dims[1])
+                                 : wq;
+  std::vector<float> wk_kn = chain.k_weight_transposed
+                                 ? TransposeFlat(wk, wk_dims[0], wk_dims[1])
+                                 : wk;
+  std::vector<float> wv_kn = chain.v_weight_transposed
+                                 ? TransposeFlat(wv, wv_dims[0], wv_dims[1])
+                                 : wv;
+  const int64_t Kq = chain.q_weight_transposed ? wq_dims[1] : wq_dims[0];
+  const int64_t Kk = chain.k_weight_transposed ? wk_dims[1] : wk_dims[0];
+  const int64_t Kv = chain.v_weight_transposed ? wv_dims[1] : wv_dims[0];
+
+  // Combined importance of each KV group's own Q+K+V weight block -- mirrors
+  // pruning.py's own `_gqa_group_importance` exactly, including its own
+  // "sum of per-block squared Frobenius norms" form (rather than
+  // concatenation) that stays well-defined even when Q's own row count
+  // (`Kq`) differs from K's/V's own (cross-attention).
+  std::vector<double> importance(static_cast<size_t>(chain.kv_num_heads), 0.0);
+  for (int64_t kv = 0; kv < chain.kv_num_heads; ++kv) {
+    double acc = 0.0;
+    for (int64_t r = 0; r < Kq; ++r) {
+      for (int64_t g = kv * group_size; g < (kv + 1) * group_size; ++g) {
+        for (int64_t c = g * d; c < (g + 1) * d; ++c) {
+          const double v = wq_kn[static_cast<size_t>(r * Nq + c)];
+          acc += importance_norm == ImportanceNorm::kL1 ? std::abs(v) : v * v;
+        }
+      }
+    }
+    for (int64_t r = 0; r < Kk; ++r) {
+      for (int64_t c = kv * d; c < (kv + 1) * d; ++c) {
+        const double v = wk_kn[static_cast<size_t>(r * Nk + c)];
+        acc += importance_norm == ImportanceNorm::kL1 ? std::abs(v) : v * v;
+      }
+    }
+    for (int64_t r = 0; r < Kv; ++r) {
+      for (int64_t c = kv * dv; c < (kv + 1) * dv; ++c) {
+        const double v = wv_kn[static_cast<size_t>(r * Nv + c)];
+        acc += importance_norm == ImportanceNorm::kL1 ? std::abs(v) : v * v;
+      }
+    }
+    importance[static_cast<size_t>(kv)] =
+        importance_norm == ImportanceNorm::kL1 ? acc : std::sqrt(acc);
+  }
+
+  if (act_norm != nullptr) {
+    auto it = act_norm->find(chain.consumer_node->input(0));
+    if (it != act_norm->end() &&
+        it->second.size() == static_cast<size_t>(chain.num_heads * dv)) {
+      for (int64_t kv = 0; kv < chain.kv_num_heads; ++kv) {
+        double sq = 0.0;
+        for (int64_t c = kv * group_size * dv; c < (kv + 1) * group_size * dv;
+             ++c) {
+          const double v = it->second[static_cast<size_t>(c)];
+          sq += v * v;
+        }
+        importance[static_cast<size_t>(kv)] *= std::max(std::sqrt(sq), epsilon);
+      }
+    }
+  }
+
+  std::vector<int64_t> keep_groups =
+      TopKIndicesAscending(importance, keep_count);
+  std::vector<int64_t> keep_q_heads;
+  keep_q_heads.reserve(keep_groups.size() * static_cast<size_t>(group_size));
+  for (int64_t g : keep_groups) {
+    for (int64_t hh = g * group_size; hh < (g + 1) * group_size; ++hh) {
+      keep_q_heads.push_back(hh);
+    }
+  }
+  std::vector<int64_t> q_idx = HeadColumnIndices(keep_q_heads, d);
+  std::vector<int64_t> k_idx = HeadColumnIndices(keep_groups, d);
+  std::vector<int64_t> v_idx = HeadColumnIndices(keep_groups, dv);
+  std::vector<int64_t> y_idx = HeadColumnIndices(keep_q_heads, dv);
+
+  SliceProducerWeight(wq_init, chain.q_weight_transposed, q_idx, false);
+  SliceProducerWeight(wk_init, chain.k_weight_transposed, k_idx, false);
+  SliceProducerWeight(wv_init, chain.v_weight_transposed, v_idx, false);
+  if (chain.q_bias) {
+    SliceLastAxis(init_map.at(*chain.q_bias), q_idx);
+  }
+  if (chain.k_bias) {
+    SliceLastAxis(init_map.at(*chain.k_bias), k_idx);
+  }
+  if (chain.v_bias) {
+    SliceLastAxis(init_map.at(*chain.v_bias), v_idx);
+  }
+  SliceConsumerWeight(init_map.at(chain.consumer_weight),
+                      chain.consumer_weight_transposed, y_idx, false);
+
+  const int64_t new_num_heads = static_cast<int64_t>(keep_q_heads.size());
+  const int64_t new_kv_num_heads = keep_count;
+
+  // Every `Reshape`/`Expand` target-shape constant this chain owns is
+  // rewritten to its new post-pruning head count -- recomputing consumers
+  // fresh HERE (not once per whole pass) since an earlier chain applied in
+  // this same pass may already have rewired some of a shared constant's
+  // readers away. Mirrors pruning.py's own `_rewrite_shape_dim` local
+  // helper exactly: in place when every remaining reader is one of THIS
+  // chain's own owning node(s) (including when K's and V's own branches
+  // legitimately share one constant), or, when a genuinely unrelated extra
+  // reader exists (onnxsim's own CSE routinely merges two textually
+  // identical shape constants from different chains/layers onto one shared
+  // tensor), by cloning a fresh tensor holding the current value and
+  // rewiring only this chain's own owning node(s) onto it -- the original is
+  // left byte-for-byte untouched for whatever else still reads it.
+  ConsumerMap consumers_of = ConsumersOf(graph);
+  auto rewrite_shape_dim =
+      [&](const std::string& shape_name,
+          const std::vector<onnx::NodeProto*>& owner_nodes,
+          const std::vector<std::pair<int64_t, int64_t>>& edits) {
+        onnx::TensorProto* shape_init = init_map.at(shape_name);
+        std::vector<int64_t> dims = ReadInt64Tensor(*shape_init);
+        std::unordered_set<onnx::NodeProto*> owner_set(owner_nodes.begin(),
+                                                       owner_nodes.end());
+        bool foreign = false;
+        auto cit = consumers_of.find(shape_name);
+        if (cit != consumers_of.end()) {
+          for (onnx::NodeProto* c : cit->second) {
+            if (!owner_set.count(c)) {
+              foreign = true;
+              break;
+            }
+          }
+        }
+        auto apply_edits = [&](std::vector<int64_t>& d) {
+          for (const auto& [index, value] : edits) {
+            const int64_t idx =
+                index < 0 ? static_cast<int64_t>(d.size()) + index : index;
+            d[static_cast<size_t>(idx)] = value;
+          }
+        };
+        if (foreign) {
+          const std::string new_name =
+              MintUniqueName(shape_name + "_pruned", used_names);
+          std::vector<int64_t> new_dims = dims;
+          apply_edits(new_dims);
+          onnx::TensorProto* new_init = graph->add_initializer();
+          new_init->set_name(new_name);
+          SetInt64TensorData(new_init, {static_cast<int64_t>(new_dims.size())},
+                             new_dims);
+          init_map[new_name] = new_init;
+          for (onnx::NodeProto* owner : owner_nodes) {
+            for (int i = 0; i < owner->input_size(); ++i) {
+              if (owner->input(i) == shape_name) {
+                owner->set_input(i, new_name);
+              }
+            }
+          }
+        } else {
+          apply_edits(dims);
+          SetInt64TensorData(shape_init, {static_cast<int64_t>(dims.size())},
+                             dims);
+        }
+      };
+
+  rewrite_shape_dim(chain.q_reshape_shape, {chain.q_reshape},
+                    {{2, new_num_heads}});
+  if (chain.k_reshape_shape == chain.v_reshape_shape) {
+    rewrite_shape_dim(chain.k_reshape_shape, {chain.k_reshape, chain.v_reshape},
+                      {{2, new_kv_num_heads}});
+  } else {
+    rewrite_shape_dim(chain.k_reshape_shape, {chain.k_reshape},
+                      {{2, new_kv_num_heads}});
+    rewrite_shape_dim(chain.v_reshape_shape, {chain.v_reshape},
+                      {{2, new_kv_num_heads}});
+  }
+  const std::vector<std::pair<int64_t, int64_t>> expand_edits{
+      {1, new_kv_num_heads}};
+  if (chain.k_repeat_kv && chain.v_repeat_kv &&
+      chain.k_repeat_kv->expand_shape == chain.v_repeat_kv->expand_shape) {
+    rewrite_shape_dim(chain.k_repeat_kv->expand_shape,
+                      {chain.k_repeat_kv->expand, chain.v_repeat_kv->expand},
+                      expand_edits);
+  } else {
+    if (chain.k_repeat_kv) {
+      rewrite_shape_dim(chain.k_repeat_kv->expand_shape,
+                        {chain.k_repeat_kv->expand}, expand_edits);
+    }
+    if (chain.v_repeat_kv) {
+      rewrite_shape_dim(chain.v_repeat_kv->expand_shape,
+                        {chain.v_repeat_kv->expand}, expand_edits);
+    }
+  }
+  if (chain.k_repeat_kv && chain.v_repeat_kv &&
+      chain.k_repeat_kv->merge_reshape_shape ==
+          chain.v_repeat_kv->merge_reshape_shape) {
+    rewrite_shape_dim(
+        chain.k_repeat_kv->merge_reshape_shape,
+        {chain.k_repeat_kv->merge_reshape, chain.v_repeat_kv->merge_reshape},
+        {{1, new_num_heads}});
+  } else {
+    if (chain.k_repeat_kv) {
+      rewrite_shape_dim(chain.k_repeat_kv->merge_reshape_shape,
+                        {chain.k_repeat_kv->merge_reshape},
+                        {{1, new_num_heads}});
+    }
+    if (chain.v_repeat_kv) {
+      rewrite_shape_dim(chain.v_repeat_kv->merge_reshape_shape,
+                        {chain.v_repeat_kv->merge_reshape},
+                        {{1, new_num_heads}});
+    }
+  }
+  if (chain.out_reshape_shape) {
+    rewrite_shape_dim(*chain.out_reshape_shape, {chain.out_reshape},
+                      {{-1, new_num_heads * dv}});
+  }
+
+  AppliedDecomposedGqa out;
+  out.producer_weights = {chain.q_weight, chain.k_weight, chain.v_weight};
+  out.consumer_weight = chain.consumer_weight;
+  for (onnx::NodeProto* n :
+       {chain.q_transpose, chain.q_reshape, chain.k_transpose,
+        chain.k_headsplit_transpose, chain.k_reshape, chain.v_transpose,
+        chain.v_reshape, chain.qk_matmul, chain.scale_node, chain.softmax_node,
+        chain.av_matmul, chain.out_transpose, chain.out_reshape}) {
+    if (n != nullptr) {
+      for (const auto& o : n->output()) {
+        out.stale.insert(o);
+      }
+    }
+  }
+  for (const auto& branch : {chain.k_repeat_kv, chain.v_repeat_kv}) {
+    if (branch) {
+      for (const auto& o : branch->unsqueeze->output()) {
+        out.stale.insert(o);
+      }
+      for (const auto& o : branch->expand->output()) {
+        out.stale.insert(o);
+      }
+      for (const auto& o : branch->merge_reshape->output()) {
+        out.stale.insert(o);
+      }
+    }
+  }
+  return out;
+}
+
+// Shared body dispatching every matched decomposed-GQA chain -- mirrors
+// ApplyAttentionChains' own cross-chain touched-role bookkeeping and stale
+// value_info cleanup, but with its own dedicated producer/consumer-touched
+// namespace, never shared with ApplyAttentionChains's own: a decomposed
+// chain's Q/K/V producer weight is always resolved via MatchProducer on a
+// plain MatMul/Gemm node feeding a Reshape (never a fused Attention/GQA/
+// MultiHeadAttention-family node's own input), so it can never collide with
+// a fused-op chain's own separately-matched producer weight -- the same
+// "structurally different node/weight shapes, always safe" reasoning this
+// file's own MatMulNBitsQkv section already documents for its identical
+// choice.
+void ApplyDecomposedGqaChains(
+    onnx::GraphProto* graph, std::vector<DecomposedGqaChain>& chains,
+    double sparsity,
+    const std::unordered_map<std::string, std::vector<double>>* act_norm =
+        nullptr,
+    double epsilon = 1e-8,
+    ImportanceNorm importance_norm = ImportanceNorm::kL2) {
+  std::unordered_map<std::string, onnx::TensorProto*> init_map;
+  for (int i = 0; i < graph->initializer_size(); ++i) {
+    onnx::TensorProto* t = graph->mutable_initializer(i);
+    init_map[t->name()] = t;
+  }
+  std::unordered_set<std::string> used_names = ExistingGraphNames(*graph);
+  std::unordered_set<std::string> producer_touched, consumer_touched,
+      stale_value_info;
+
+  for (auto& chain : chains) {
+    bool conflict = consumer_touched.count(chain.consumer_weight) != 0;
+    for (const std::string& w :
+         {chain.q_weight, chain.k_weight, chain.v_weight}) {
+      if (producer_touched.count(w)) {
+        conflict = true;
+      }
+    }
+    if (conflict) {
+      continue;
+    }
+
+    std::optional<AppliedDecomposedGqa> applied =
+        ApplyOneDecomposedGqaChain(graph, init_map, used_names, chain, sparsity,
+                                   act_norm, epsilon, importance_norm);
+    if (!applied) {
+      continue;
+    }
+
+    for (const auto& w : applied->producer_weights) {
+      producer_touched.insert(w);
+    }
+    consumer_touched.insert(applied->consumer_weight);
+    for (const auto& s : applied->stale) {
+      stale_value_info.insert(s);
+    }
+  }
+
+  if (!stale_value_info.empty()) {
+    google::protobuf::RepeatedPtrField<onnx::ValueInfoProto> kept;
+    for (const auto& vi : graph->value_info()) {
+      if (!stale_value_info.count(vi.name())) {
+        *kept.Add() = vi;
+      }
+    }
+    graph->mutable_value_info()->Swap(&kept);
+  }
+}
+
 onnx::ModelProto ApplyAttentionHeadPruning(const onnx::ModelProto& model,
                                            double sparsity,
                                            const std::string& importance_norm) {
@@ -21976,12 +23160,7 @@ onnx::ModelProto ApplyAttentionHeadPruning(const onnx::ModelProto& model,
     // FindSeparateQkvChains/ApplyOneGqaChain machinery GQA/OnnxAttention
     // already use above (see each Find*Chains function's own comment for
     // what's matched and this port's deliberate, narrower-than-pruning.py
-    // scope decisions). The fully decomposed (un-fused, "eager SDPA export")
-    // shape pruning.py's own `_find_decomposed_gqa_chains` additionally
-    // matches has no C++ port yet -- a topology-based match rewriting
-    // multiple Reshape/Expand shape constants in lock-step, genuinely more
-    // novel than any of the six fused-op families here, deliberately left
-    // unmatched (a decline, not a crash) rather than guessed at.
+    // scope decisions).
     std::vector<AttnChain> mha_chains = FindMhaChains(graph);
     std::vector<AttnChain> packed_mha_chains = FindPackedMhaChains(graph);
     std::vector<AttnChain> dmmha_chains = FindDecoderMaskedMhaChains(graph);
@@ -22012,6 +23191,25 @@ onnx::ModelProto ApplyAttentionHeadPruning(const onnx::ModelProto& model,
                   std::make_move_iterator(sparse_attn_chains.end()));
     if (!chains.empty()) {
       ApplyAttentionChains(graph, chains, sparsity, nullptr, 1e-8, norm);
+    }
+    // The fully decomposed (un-fused, "eager SDPA export") shape
+    // pruning.py's own `_find_decomposed_gqa_chains` additionally matches --
+    // see the "Decomposed (un-fused) GQA/MQA/plain-MHA attention head
+    // pruning" section comment above FindDecomposedGqaChains for this port's
+    // own scope (deliberately narrower than pruning.py's: no mask/RoPE/
+    // Q-K-norm/Einsum/packed-QKV/MQA-fast-path support yet -- every one of
+    // those shapes declines to match here, rather than being mis-sliced,
+    // and is still pruned by pruning.py's own pure-Python
+    // apply_attention_head_pruning). Its own dedicated producer/consumer-
+    // touched bookkeeping (inside ApplyDecomposedGqaChains) is never shared
+    // with ApplyAttentionChains's own above, the same "structurally
+    // different node/weight shapes, always safe" reasoning this section's
+    // own MatMulNBitsQkv handling below already documents.
+    std::vector<DecomposedGqaChain> decomposed_gqa_chains =
+        FindDecomposedGqaChains(graph);
+    if (!decomposed_gqa_chains.empty()) {
+      ApplyDecomposedGqaChains(graph, decomposed_gqa_chains, sparsity, nullptr,
+                               1e-8, norm);
     }
     // The fused `com.microsoft::MatMulNBitsQkv` variant -- see the
     // "MatMulNBitsMlp/MatMulNBitsQkv (fused block-quantized weight)
@@ -22100,7 +23298,18 @@ onnx::ModelProto ApplyAttentionHeadWandaPruning(
                 std::make_move_iterator(sparse_attn_chains.begin()),
                 std::make_move_iterator(sparse_attn_chains.end()));
 
-  if (chains.empty()) {
+  // The fully decomposed (un-fused, "eager SDPA export") shape -- see the
+  // "Decomposed (un-fused) GQA/MQA/plain-MHA attention head pruning" section
+  // comment above FindDecomposedGqaChains for this port's own scope. Kept in
+  // its own vector (never merged into `chains`, an `AttnChain` list) since
+  // its own DecomposedGqaChain struct has no relation to AttnChain at all --
+  // ranked/sliced/probed entirely separately below, mirroring pruning.py's
+  // own `chains: List[_AttnLikeChain]` union, which this port instead keeps
+  // as two differently-typed collections threaded through in parallel.
+  std::vector<DecomposedGqaChain> decomposed_gqa_chains =
+      FindDecomposedGqaChains(graph);
+
+  if (chains.empty() && decomposed_gqa_chains.empty()) {
     return out;  // Mirrors pruning.py's own early return.
   }
 
@@ -22108,19 +23317,32 @@ onnx::ModelProto ApplyAttentionHeadWandaPruning(
   // (never a Conv channel axis 1, unlike ApplyStructuredWandaPruning's own
   // `probe_axis`): WalkToAttentionConsumer only ever matches a
   // MatMul/vanilla-Gemm consumer (MatchMatMulLikeRaw), never a Conv, for
-  // every one of the three attention chain families above. Mirrors
-  // pruning.py's own `probe_names = {chain.consumer_node.input[0] for
-  // chain in chains}` in `_wanda_attention_calibration_stats` (there
-  // implicitly axis -1 too, via `reduce_axes = range(x.ndim - 1)`).
+  // every one of the three attention chain families above -- and
+  // FindDecomposedGqaChains' own consumer_node is resolved via the
+  // identical MatchMatMulLikeRaw check, so it shares this exact probe-point
+  // convention too. Mirrors pruning.py's own `probe_names = {chain.
+  // consumer_node.input[0] for chain in chains}` in
+  // `_wanda_attention_calibration_stats` (there implicitly axis -1 too, via
+  // `reduce_axes = range(x.ndim - 1)`), where `chains` already includes
+  // `_DecomposedGQAChain` entries from the same shared list.
   std::unordered_map<std::string, int64_t> probe_axis;
   for (const auto& chain : chains) {
+    probe_axis[chain.consumer_node->input(0)] = -1;
+  }
+  for (const auto& chain : decomposed_gqa_chains) {
     probe_axis[chain.consumer_node->input(0)] = -1;
   }
 
   const std::unordered_map<std::string, std::vector<double>> act_norm =
       WandaCalibrationStats(executor, out, probe_axis, calibration_data);
 
-  ApplyAttentionChains(graph, chains, sparsity, &act_norm, epsilon, norm);
+  if (!chains.empty()) {
+    ApplyAttentionChains(graph, chains, sparsity, &act_norm, epsilon, norm);
+  }
+  if (!decomposed_gqa_chains.empty()) {
+    ApplyDecomposedGqaChains(graph, decomposed_gqa_chains, sparsity, &act_norm,
+                             epsilon, norm);
+  }
   return out;
 }
 

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -20059,11 +20059,32 @@ std::vector<double> EmbeddingVocabImportance(const EmbeddingChain& chain,
 // declared axis) is simply absent from the result, which is exactly the
 // "no matching activation observed" condition ApplyChains/ApplyConcatChains
 // fall back to plain weight-only importance on.
+//
+// `require_rank2` (default empty -- every pre-existing caller
+// (ApplyStructuredWandaPruning/ApplyAttentionHeadWandaPruning) is completely
+// unaffected, since neither's own Python reference
+// (`_wanda_structured_calibration_stats`/`_wanda_attention_calibration_stats`)
+// has any rank restriction at all) names the subset of probe names that
+// must be observed at EXACTLY rank 2 to count for a given batch, mirroring
+// pruning.py's own `_wanda_unstructured_calibration_stats`'s plain
+// (non-Attention, non-Conv) MatMul/Gemm probe: `if x.ndim != 2: continue`.
+// Unlike this function's own generic "sum of squares over every axis but
+// the channel one" reduction (correct at any rank, and what every OTHER
+// probe name still gets), a batch where a `require_rank2` probe's own
+// activation isn't rank-2 contributes NOTHING to that probe's accumulator
+// for that batch -- checked before the axis/dtype bookkeeping below, same
+// as pruning.py's own early-continue. ApplyWandaPruning is the only caller
+// that ever passes a non-empty set here, and only for its plain MatMul/Gemm
+// candidates' own `x_name`s -- never its `com.microsoft::Attention`
+// candidates' (pruning.py's own `attn_act_norm` allows any rank >= 2 there)
+// nor Conv's (a wholly separate function, ConvWandaCalibrationStats) -- see
+// ApplyWandaPruning's own call site comment for how that set is built.
 std::unordered_map<std::string, std::vector<double>> WandaCalibrationStats(
     const ModelExecutor& executor, const onnx::ModelProto& model,
     const std::unordered_map<std::string, int64_t>& probe_axis,
     const std::vector<std::unordered_map<std::string, onnx::TensorProto>>&
-        calibration_data) {
+        calibration_data,
+    const std::unordered_set<std::string>& require_rank2 = {}) {
   std::unordered_map<std::string, std::vector<double>> result;
   if (probe_axis.empty()) {
     // Nothing to probe (e.g. only split_gated_chains matched -- never
@@ -20164,6 +20185,12 @@ std::unordered_map<std::string, std::vector<double>> WandaCalibrationStats(
         continue;
       }
       const int64_t ndim = tp.dims_size();
+      if (require_rank2.count(name) != 0 && ndim != 2) {
+        continue;  // Mirrors pruning.py's own
+                   // `_wanda_unstructured_calibration_stats`'s plain
+                   // MatMul/Gemm probe: `if x.ndim != 2: continue` -- see
+                   // this function's own `require_rank2` doc comment above.
+      }
       int64_t axis = axis_raw;
       if (axis < 0) {
         axis += ndim;
@@ -24050,6 +24077,16 @@ onnx::ModelProto ApplyWandaPruning(
     bool weight_transposed;
     bool is_conv;
     int64_t conv_group = 1;  // only meaningful when is_conv
+    // `com.microsoft::Attention`'s merged QKV weight, as opposed to a plain
+    // MatMul/Gemm candidate -- only meaningful when `!is_conv`. Distinguishes
+    // the two `x_name`-keyed, probe-axis -1 candidate families below so the
+    // rank-2-only restriction pruning.py's own `_wanda_unstructured_
+    // calibration_stats` applies to its plain MatMul/Gemm probe (`act_norm`)
+    // -- but NOT to its separately-accumulated Attention probe
+    // (`attn_act_norm`, any rank >= 2) -- can be reproduced here too. See the
+    // `require_rank2` set built right before the WandaCalibrationStats call
+    // below.
+    bool is_attention = false;
   };
   std::vector<Candidate> candidates;
   // Conv attributes are per-node (two Convs can share an input tensor with
@@ -24084,7 +24121,7 @@ onnx::ModelProto ApplyWandaPruning(
       // is already [K, N]-shaped by construction (see
       // MatchAttentionProducer's own comment), so it is matched exactly
       // like a non-transposed MatMul weight.
-      candidates.push_back({node.input(0), am->weight, false, false});
+      candidates.push_back({node.input(0), am->weight, false, false, 1, true});
     }
   }
   if (candidates.empty()) {
@@ -24101,14 +24138,40 @@ onnx::ModelProto ApplyWandaPruning(
   // leading axis by WandaCalibrationStats' own "every axis but the channel
   // one" reduction, exactly mirroring pruning.py's own
   // `x.reshape(-1, x.shape[-1])`.
+  //
+  // `require_rank2`: mirrors pruning.py's own
+  // `_wanda_unstructured_calibration_stats`'s split between its plain
+  // MatMul/Gemm probe (`act_norm`, `x.ndim != 2: continue` -- exactly rank
+  // 2 required) and its separate Attention probe (`attn_act_norm`,
+  // `x.ndim < 2: continue` -- any rank >= 2 accepted, since that candidate's
+  // own activation is rank-3 `[batch, seq, hidden]` by construction). Built
+  // from every MatMul/Gemm (`!is_conv && !is_attention`) candidate's own
+  // `x_name`, MINUS any name also used by an Attention candidate -- the
+  // same "two candidate families sharing one activation tensor name is a
+  // purely theoretical edge case, not worth distinguishing further" call
+  // this file's own keyed-by-`x_name` simplification (just above) already
+  // makes: in that edge case, staying unrestricted (as before this fix)
+  // rather than newly restricting the shared name is the conservative
+  // choice.
   std::unordered_map<std::string, int64_t> probe_axis;
+  std::unordered_set<std::string> matmul_x_names;
+  std::unordered_set<std::string> attention_x_names;
   for (const auto& c : candidates) {
-    if (!c.is_conv) {
-      probe_axis[c.x_name] = -1;
+    if (c.is_conv) {
+      continue;
+    }
+    probe_axis[c.x_name] = -1;
+    (c.is_attention ? attention_x_names : matmul_x_names).insert(c.x_name);
+  }
+  std::unordered_set<std::string> require_rank2;
+  for (const auto& name : matmul_x_names) {
+    if (attention_x_names.find(name) == attention_x_names.end()) {
+      require_rank2.insert(name);
     }
   }
   const std::unordered_map<std::string, std::vector<double>> act_norm =
-      WandaCalibrationStats(executor, out, probe_axis, calibration_data);
+      WandaCalibrationStats(executor, out, probe_axis, calibration_data,
+                            require_rank2);
 
   // Conv's own im2col-unfolded per-(in_channel, kh, kw)-tap calibration
   // statistic -- a genuinely different reduction than WandaCalibrationStats'

--- a/onnxsim/structured_pruning_entry.h
+++ b/onnxsim/structured_pruning_entry.h
@@ -584,34 +584,31 @@ onnx::ModelProto ApplySparseGptPruning(
 // and general grouped (`1 < group < in_channels`) Conv alike, with real
 // calibration data.
 //
-// Despite that Conv parity, `apply_wanda_pruning` in pruning.py is
-// DELIBERATELY NOT an alias of this function -- a full-regression check
-// (every existing MatMul/Gemm/Attention candidate's live output against the
-// pure-Python reference, not just the new Conv coverage) surfaced a
-// genuine, PRE-EXISTING divergence unrelated to Conv: WandaCalibrationStats
-// below computes a per-channel-axis activation norm for a MatMul/Gemm
-// candidate's own activation at ANY rank >= 1 (probe axis -1, the same
-// "reduce over every leading axis" treatment it gives a rank-3 Attention
-// activation), whereas pruning.py's own
-// `_wanda_unstructured_calibration_stats` explicitly requires `x.ndim == 2`
-// for that same (non-Attention, non-Conv) statistic and falls back to
-// plain magnitude importance for anything else -- e.g. a rank-3 activation
-// feeding a plain 2-D MatMul weight, exactly the shape a batched/sequence
-// MatMul input takes in practice. So this port gives such a layer a REAL
-// (but, per the Python reference's own narrower scope, not-yet-earned)
-// activation-weighted importance instead of the Python reference's
-// plain-magnitude fallback. This predates this round's Conv work entirely
-// (in code this round never touched) and was only exposed once
-// `apply_wanda_pruning` was tentatively aliased here to verify that Conv
-// work; fixing WandaCalibrationStats' own rank handling touches shared,
-// independently-verified infrastructure ApplyStructuredWandaPruning/
-// ApplyAttentionHeadWandaPruning also depend on, so it is deliberately left
-// undone and undocumented-as-fixed here -- the conservative choice over a
-// subtly-wrong alias. See tests/test_wanda_pruning_cpp.py's own module
-// docstring for the full writeup and
-// tests/test_pruning.py's own
-// test_wanda_pruning_falls_back_to_magnitude_without_matching_activation
-// for the regression that caught it.
+// A prior round's full-regression check (every existing MatMul/Gemm/
+// Attention candidate's live output against the pure-Python reference, not
+// just this function's own Conv coverage) surfaced a genuine, PRE-EXISTING
+// divergence unrelated to Conv: WandaCalibrationStats below used to compute
+// a per-channel-axis activation norm for a MatMul/Gemm candidate's own
+// activation at ANY rank >= 1 (probe axis -1, the same "reduce over every
+// leading axis" treatment it gives a rank-3 Attention activation), whereas
+// pruning.py's own `_wanda_unstructured_calibration_stats` explicitly
+// requires `x.ndim == 2` for that same (non-Attention, non-Conv) statistic
+// and falls back to plain magnitude importance for anything else -- e.g. a
+// rank-3 activation feeding a plain 2-D MatMul weight, exactly the shape a
+// batched/sequence MatMul input takes in practice. That gap blocked
+// aliasing `apply_wanda_pruning` in pruning.py to this function for a time
+// (see tests/test_pruning.py's own
+// test_wanda_pruning_falls_back_to_magnitude_without_matching_activation,
+// which caught it). It is now closed: WandaCalibrationStats below takes an
+// additional `require_rank2` set (default empty, so
+// ApplyStructuredWandaPruning/ApplyAttentionHeadWandaPruning below -- whose
+// own Python references have no rank restriction at all -- are completely
+// unaffected), and this function passes it the `x_name` of every matched
+// plain MatMul/Gemm candidate (never an Attention candidate's, which keeps
+// the same any-rank->=2 treatment as before, matching pruning.py's own
+// `attn_act_norm`) -- see WandaCalibrationStats' own `require_rank2` doc
+// comment and this function's own call site comment for the exact rule.
+// `apply_wanda_pruning` in pruning.py is now a thin alias of this function.
 //
 // Conv's own im2col per-receptive-field-offset activation norm --
 // `X_j` for a Conv column is not "input feature `j`" but "receptive-field
@@ -650,18 +647,26 @@ onnx::ModelProto ApplySparseGptPruning(
 // Wanda's own calibration statistic for the MatMul/Gemm/Attention candidate
 // families -- one shared per-reduction-channel activation L2-norm per
 // matched layer's own input, reduced over every leading axis (so a rank-3
-// `com.microsoft::Attention` input is handled exactly like a rank-2
-// MatMul/Gemm one, mirroring pruning.py's own `x.reshape(-1,
-// x.shape[-1])`) -- is exactly WandaCalibrationStats' own output shape,
-// reused verbatim: probe axis -1 for every non-Conv candidate, keyed by
-// each candidate's own activation tensor name (`x_name`) rather than by
-// weight name the way pruning.py's own `attn_act_norm` is keyed for
-// Attention -- mirroring ApplyAttentionHeadWandaPruning's own already-
-// established simplification of that same distinction (two distinct
-// Attention nodes sharing one activation tensor name is a purely
-// theoretical edge case neither C++ port bothers distinguishing). See
-// structured_pruning_entry.cpp's own "Wanda unstructured (element-wise)
-// pruning" section comment for the masking mechanics.
+// `com.microsoft::Attention` input's own leading axes are reduced away
+// exactly as pruning.py's own `x.reshape(-1, x.shape[-1])` does for its
+// separate `attn_act_norm` statistic) -- is exactly WandaCalibrationStats'
+// own output shape, reused verbatim: probe axis -1 for every non-Conv
+// candidate, keyed by each candidate's own activation tensor name (`x_name`)
+// rather than by weight name the way pruning.py's own `attn_act_norm` is
+// keyed for Attention -- mirroring ApplyAttentionHeadWandaPruning's own
+// already-established simplification of that same distinction (two
+// distinct Attention nodes sharing one activation tensor name is a purely
+// theoretical edge case neither C++ port bothers distinguishing). Unlike
+// Attention, a plain MatMul/Gemm candidate's own activation must be
+// EXACTLY rank 2 to be observed at all here -- mirroring pruning.py's own
+// `act_norm` (as opposed to `attn_act_norm`) probe -- via
+// WandaCalibrationStats' own `require_rank2` parameter, passed the `x_name`
+// of every MatMul/Gemm (never Attention) candidate here (see that
+// function's own doc comment and this file's own call site comment in
+// structured_pruning_entry.cpp for the exact set-construction rule,
+// including its handling of the theoretical shared-`x_name` edge case just
+// mentioned). See structured_pruning_entry.cpp's own "Wanda unstructured
+// (element-wise) pruning" section comment for the masking mechanics.
 //
 // `n`/`m` (both std::nullopt, or both given together: N:M semi-structured
 // pruning, `0 < n <= m`) and `sparsity` (target unstructured-sparsity

--- a/tests/test_attention_head_pruning_cpp.py
+++ b/tests/test_attention_head_pruning_cpp.py
@@ -14,15 +14,22 @@ of pruning.py's own ten matched op families: plain ``com.microsoft::Attention``
 ``com.microsoft::PagedAttention``, the plain ``ai.onnx::LinearAttention`` op
 (opset 27+, "linear" update_rule only), and ``com.microsoft::SparseAttention``.
 The tenth family, the fully decomposed (un-fused, "eager SDPA export") shape
-pruning.py's own ``_find_decomposed_gqa_chains`` matches, has no C++ port at
-all yet -- a topology-based match rewriting multiple Reshape/Expand shape
-constants in lock-step, deliberately left unmatched (a decline, not a crash)
-as genuinely more novel than any of the nine fused-op families above; see
-``structured_pruning_entry.cpp``'s own comment at
-``ApplyAttentionHeadPruning``'s chain-finding call sites. The six newer
-families (everything past plain ``Attention``/``GroupQueryAttention``/the
-plain ``ai.onnx::Attention`` op) share one deliberate, narrower-than-
-pruning.py scope choice throughout: this port has no analogue of pruning.py's
+pruning.py's own ``_find_decomposed_gqa_chains`` matches, now HAS a C++ port
+(``FindDecomposedGqaChains``/``ApplyOneDecomposedGqaChain`` in
+``structured_pruning_entry.cpp`` -- see that section's own comment) --
+covered by its own dedicated "Decomposed (un-fused) GQA/MQA/plain-MHA
+attention head pruning" test section below -- but DELIBERATELY NARROWER in
+scope than pruning.py's own matcher: no additive mask, no decomposed
+RoPE/Q-K-norm pass-through, no ``Einsum``-based QK^T/AV product, no
+packed-QKV-then-``Split`` producer, and no true-MQA fast path. Every one of
+those shapes still declines to match in this C++ port (never mis-sliced),
+so ``apply_attention_head_pruning``/``apply_attention_head_wanda_pruning``
+remain pure-Python (NOT yet aliased to this port) -- see that section's own
+tests for the exact, explicit divergence each narrowing produces. The six
+newer fused-op families (everything past plain ``Attention``/
+``GroupQueryAttention``/the plain ``ai.onnx::Attention`` op) share one more
+deliberate, narrower-than-pruning.py scope choice throughout: this port has
+no analogue of pruning.py's
 own dynamic-attention-bias-Gather-insertion machinery
 (``_head_bias_input_is_safe``/``_slice_or_gather_head_bias``) at all -- a
 pre-existing, already-accepted gap for the three original families too -- so
@@ -2673,3 +2680,563 @@ def test_cpp_sparse_attention_pruning_num_layout_divisibility_declined_matches_p
     onnx.checker.check_model(pruned_cpp)
     assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
     assert pruned_cpp.SerializeToString() == model.SerializeToString()
+
+
+# --- Decomposed (un-fused) GQA/MQA/plain-MHA attention head pruning --------
+#
+# `apply_attention_head_pruning_cpp` now also matches this shape, via a
+# genuinely new, dedicated matcher/rewriter (FindDecomposedGqaChains/
+# ApplyOneDecomposedGqaChain in structured_pruning_entry.cpp) -- NOT the
+# FindSeparateQkvChains/ApplyOneGqaChain machinery every family above shares,
+# since there is no single fused node whose `num_heads`/`kv_num_heads`
+# *attribute* records the head count here; instead it is baked, redundantly,
+# into up to six `Reshape`/`Expand` target-shape `Constant` tensors, every
+# one of which is rewritten in lock-step post-pruning -- in place, or by
+# cloning a fresh tensor when some genuinely unrelated node also reads the
+# same (CSE-shared) constant. See structured_pruning_entry.cpp's own
+# "Decomposed (un-fused) GQA/MQA/plain-MHA attention head pruning" section
+# comment for the exact scope this port matches -- deliberately narrower
+# than pruning.py's own `_find_decomposed_gqa_chains`: no additive mask, no
+# decomposed RoPE/Q-K-norm pass-through, no `Einsum`-based QK^T/AV product,
+# no packed-QKV-then-`Split` producer, and no true-MQA fast path (mirrors
+# ApplyOneGqaChain's own identical, already-accepted MQA gap) -- every one
+# of those shapes simply declines to match here (never mis-sliced) and is
+# still fully handled by pruning.py's own pure-Python
+# `apply_attention_head_pruning`, so this tenth family is NOT yet aliased.
+
+
+def _decomposed_gqa_model(
+    K=32,
+    H=4,
+    KVH=2,
+    D=8,
+    Dv=None,
+    Out=16,
+    batch=1,
+    seq=4,
+    seed=0,
+    bias=True,
+    masked=False,
+    wq=None,
+    wk=None,
+    wv=None,
+    wout=None,
+    bq=None,
+    bk=None,
+    bv=None,
+    bout=None,
+    out_reshape_wildcard=False,
+    share_kv_reshape_shape=True,
+    extra_foreign_q_reshape_consumer=False,
+    extra_foreign_repeat_kv_consumer=False,
+):
+    """Builds the decomposed-attention graph FindDecomposedGqaChains matches:
+    ``Linear(Q/K/V) -> Reshape(to heads) -> Transpose(to BHSD) -> [repeat_kv:
+    Unsqueeze -> Expand -> Reshape, only when KVH < H] -> MatMul(Q, K^T) ->
+    scale -> [+mask] -> Softmax -> MatMul(., V) -> Transpose(back) ->
+    Reshape(back to hidden) -> Linear(O)`` -- mirrors
+    ``tests/test_pruning.py``'s own ``_decomposed_gqa_model`` (trimmed to
+    this port's own scope: no ``rope``/``qk_norm`` params at all, since this
+    C++ port never matches either -- see this section's own comment above).
+
+    K's own dot-product transpose is built in whichever of the two real
+    shapes a real export uses: the single, pre-composed ``perm=[0, 2, 3,
+    1]`` form when ``KVH == H`` (no ``repeat_kv``), or the ordinary separate
+    ``perm=[0, 2, 1, 3]`` head-split followed later by its own ``perm=[0, 1,
+    3, 2]`` swap when ``KVH < H`` (``repeat_kv`` present).
+
+    ``masked`` (default ``False``) adds a constant additive mask before
+    ``Softmax`` -- this port's own matcher never recognizes an additive mask
+    of any kind (see this section's own comment above), so this exists
+    purely to build a DECLINE test case: the whole chain fails to match,
+    leaving the block completely untouched by the C++ port, while
+    pruning.py's own pure-Python implementation still prunes it (a
+    documented, intentional divergence -- not a bug).
+
+    ``extra_foreign_q_reshape_consumer``/``extra_foreign_repeat_kv_consumer``
+    each add a second, wholly unrelated node reading the same shape constant
+    as Q's own head-split ``Reshape``/K's own ``repeat_kv`` ``Expand``
+    (simulating cross-layer CSE) -- exercising
+    ``ApplyOneDecomposedGqaChain``'s own clone-rather-than-edit-in-place
+    path (``RewriteDecomposedShapeDim``'s C++ mirror of pruning.py's own
+    ``_rewrite_shape_dim``).
+    """
+    if Dv is None:
+        Dv = D
+    rng = np.random.default_rng(seed)
+    Nq, Nk, Nv = H * D, KVH * D, KVH * Dv
+    if wq is None:
+        wq = rng.standard_normal((K, Nq)).astype(np.float32)
+    if wk is None:
+        wk = rng.standard_normal((K, Nk)).astype(np.float32)
+    if wv is None:
+        wv = rng.standard_normal((K, Nv)).astype(np.float32)
+    if wout is None:
+        wout = rng.standard_normal((H * Dv, Out)).astype(np.float32)
+
+    def _i64(arr, name):
+        return onnx.numpy_helper.from_array(np.array(arr, dtype=np.int64), name)
+
+    initializer = [_f32(wq, "Wq"), _f32(wk, "Wk"), _f32(wv, "Wv"), _f32(wout, "Wout")]
+
+    # Gemm requires a rank-2 input -- flattening `X` to `[batch*seq, K]`
+    # first, exactly the shape onnxsim's own `fuse_matmul_add_bias_into_gemm`
+    # optimizer pass produces for a real export-then-simplify pipeline (see
+    # ``tests/test_pruning.py``'s own ``_decomposed_gqa_model`` docstring),
+    # keeping this hand-built model runnable through a real
+    # ``onnxruntime.InferenceSession`` regardless of ``bias``.
+    initializer.append(_i64([batch * seq, K], "XFlatShape"))
+    lines = ["xf = Reshape(X, XFlatShape)"]
+    q_op, k_op, v_op, o_op = (
+        "MatMul(xf, Wq)",
+        "MatMul(xf, Wk)",
+        "MatMul(xf, Wv)",
+        "MatMul(ctx2, Wout)",
+    )
+    if bias:
+        if bq is None:
+            bq = rng.standard_normal((Nq,)).astype(np.float32)
+        if bk is None:
+            bk = rng.standard_normal((Nk,)).astype(np.float32)
+        if bv is None:
+            bv = rng.standard_normal((Nv,)).astype(np.float32)
+        if bout is None:
+            bout = rng.standard_normal((Out,)).astype(np.float32)
+        initializer += [
+            _f32(bq, "Bq"),
+            _f32(bk, "Bk"),
+            _f32(bv, "Bv"),
+            _f32(bout, "Bout"),
+        ]
+        q_op, k_op, v_op = "Gemm(xf, Wq, Bq)", "Gemm(xf, Wk, Bk)", "Gemm(xf, Wv, Bv)"
+        o_op = "Gemm(ctx2, Wout, Bout)"
+
+    initializer.append(_i64([batch, seq, H, D], "Sq"))
+    lines += [
+        "q0 = " + q_op,
+        "qr = Reshape(q0, Sq)",
+        "qt = Transpose<perm=[0,2,1,3]>(qr)",
+    ]
+
+    if extra_foreign_q_reshape_consumer:
+        # A second, wholly unrelated Reshape reading the SAME shape
+        # constant as Q's own head-split -- simulates cross-layer CSE
+        # merging two textually-identical `[batch, seq, H, D]` shape
+        # constants. Reshapes `xf` itself (always exactly
+        # `batch*seq*K == batch*seq*H*D` elements since callers of this
+        # scenario keep `K == H * D`).
+        lines.append("foreign_out = Reshape(xf, Sq)")
+
+    kv_shape_name = "Skv" if share_kv_reshape_shape and Dv == D else None
+    if kv_shape_name:
+        initializer.append(_i64([batch, seq, KVH, D], kv_shape_name))
+        sk_name = sv_name = kv_shape_name
+    else:
+        initializer.append(_i64([batch, seq, KVH, D], "Sk"))
+        initializer.append(_i64([batch, seq, KVH, Dv], "Sv"))
+        sk_name, sv_name = "Sk", "Sv"
+
+    lines += ["k0 = " + k_op, f"kr = Reshape(k0, {sk_name})"]
+    lines += ["v0 = " + v_op, f"vr = Reshape(v0, {sv_name})"]
+
+    n_rep = H // KVH
+    needs_repeat_kv = KVH < H
+    if needs_repeat_kv:
+        assert H % KVH == 0
+        initializer.append(_i64([2], "Ax2"))
+        initializer.append(_i64([batch, KVH, n_rep, seq, D], "KExpandShape"))
+        initializer.append(_i64([batch, H, seq, D], "KMergeShape"))
+        initializer.append(_i64([batch, KVH, n_rep, seq, Dv], "VExpandShape"))
+        initializer.append(_i64([batch, H, seq, Dv], "VMergeShape"))
+        lines.append("kt0 = Transpose<perm=[0,2,1,3]>(kr)")
+        lines += [
+            "ku = Unsqueeze(kt0, Ax2)",
+            "ke = Expand(ku, KExpandShape)",
+            "kre = Reshape(ke, KMergeShape)",
+            "kt = Transpose<perm=[0,1,3,2]>(kre)",
+        ]
+        if extra_foreign_repeat_kv_consumer:
+            # A second, wholly unrelated Expand reading the SAME
+            # `KExpandShape` constant as K's own `repeat_kv` broadcast --
+            # simulates cross-layer CSE merging two textually-identical
+            # 5-D expand targets. A fresh size-[1] data operand (rather
+            # than reusing any real tensor) trivially broadcasts to any
+            # target shape, so this stays a valid, runnable (if unused)
+            # node.
+            initializer.append(
+                _f32(np.zeros((1,), dtype=np.float32), "ForeignExpandData")
+            )
+            lines.append("foreign_expand_out = Expand(ForeignExpandData, KExpandShape)")
+        lines += [
+            "vt0 = Transpose<perm=[0,2,1,3]>(vr)",
+            "vu = Unsqueeze(vt0, Ax2)",
+            "ve = Expand(vu, VExpandShape)",
+            "vt = Reshape(ve, VMergeShape)",
+        ]
+    else:
+        lines.append("kt = Transpose<perm=[0,2,3,1]>(kr)")
+        lines.append("vt = Transpose<perm=[0,2,1,3]>(vr)")
+
+    initializer.append(_f32(np.array(D**-0.5, dtype=np.float32), "Scale"))
+    lines += ["qk = MatMul(qt, kt)", "scaled = Mul(qk, Scale)"]
+
+    if masked:
+        mask = np.triu(np.full((seq, seq), -1e4, dtype=np.float32), k=1)[
+            None, None, :, :
+        ]
+        initializer.append(_f32(mask, "Mask"))
+        lines.append("premask = Add(scaled, Mask)")
+        smax_in = "premask"
+    else:
+        smax_in = "scaled"
+    lines.append(f"attn = Softmax<axis=-1>({smax_in})")
+    lines.append("ctx0 = MatMul(attn, vt)")
+    lines.append("ctx1 = Transpose<perm=[0,2,1,3]>(ctx0)")
+
+    if out_reshape_wildcard:
+        initializer.append(_i64([batch * seq, -1], "OutShape"))
+    else:
+        initializer.append(_i64([batch * seq, H * Dv], "OutShape"))
+    initializer.append(_i64([batch, seq, Out], "YShape"))
+    lines.append("ctx2 = Reshape(ctx1, OutShape)")
+    lines.append("y0 = " + o_op)
+    lines.append("Y = Reshape(y0, YShape)")
+
+    body_lines = "\n          ".join(lines)
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17]
+        >
+        g (float[{batch},{seq},{K}] X) => (float[{batch},{seq},{Out}] Y)
+        {{
+          {body_lines}
+        }}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model, dict(
+        K=K,
+        H=H,
+        KVH=KVH,
+        D=D,
+        Dv=Dv,
+        Out=Out,
+        batch=batch,
+        seq=seq,
+        wq=wq,
+        wk=wk,
+        wv=wv,
+        wout=wout,
+        bq=bq,
+        bk=bk,
+        bv=bv,
+        bout=bout,
+    )
+
+
+def _decomposed_weight_shapes(model):
+    inits = {t.name: t for t in model.graph.initializer}
+    return (
+        onnx.numpy_helper.to_array(inits["Wq"]),
+        onnx.numpy_helper.to_array(inits["Wk"]),
+        onnx.numpy_helper.to_array(inits["Wv"]),
+        onnx.numpy_helper.to_array(inits["Wout"]),
+    )
+
+
+def test_cpp_decomposed_gqa_pruning_matches_oracle_and_python_reference_exactly():
+    model, cfg = _decomposed_gqa_model(K=32, H=8, KVH=2, D=8, Out=16, seed=1)
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    onnx.checker.check_model(pruned_py)
+    # This basic decomposed-GQA shape is fully within this C++ port's own
+    # scope (no mask/RoPE/Q-K-norm/Einsum/packed-QKV, genuine GQA so no MQA
+    # fast-path gap either) -- both ports must agree byte-for-byte, the
+    # strongest possible parity check.
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    wq_new, wk_new, wv_new, wo_new = _decomposed_weight_shapes(pruned_cpp)
+    group_size = cfg["H"] // cfg["KVH"]
+    new_kv = cfg["KVH"] - round(cfg["KVH"] * 0.5)
+    assert wk_new.shape[1] == new_kv * cfg["D"]
+    assert wq_new.shape[1] == new_kv * group_size * cfg["D"]
+
+    keep_groups = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], cfg["H"], cfg["KVH"], cfg["D"], new_kv
+    )
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    d = cfg["D"]
+    q_idx, kv_idx = _head_idx(keep_q_heads, d), _head_idx(keep_groups, d)
+    np.testing.assert_array_equal(wq_new, cfg["wq"][:, q_idx])
+    np.testing.assert_array_equal(wk_new, cfg["wk"][:, kv_idx])
+    np.testing.assert_array_equal(wv_new, cfg["wv"][:, kv_idx])
+    np.testing.assert_array_equal(wo_new, cfg["wout"][q_idx, :])
+
+    oracle, _ = _decomposed_gqa_model(
+        K=cfg["K"],
+        H=len(keep_q_heads),
+        KVH=new_kv,
+        D=d,
+        Out=cfg["Out"],
+        seed=1,
+        wq=cfg["wq"][:, q_idx],
+        wk=cfg["wk"][:, kv_idx],
+        wv=cfg["wv"][:, kv_idx],
+        wout=cfg["wout"][q_idx, :],
+        bq=cfg["bq"][q_idx],
+        bk=cfg["bk"][kv_idx],
+        bv=cfg["bv"][kv_idx],
+        bout=cfg["bout"],
+        batch=cfg["batch"],
+        seq=cfg["seq"],
+    )
+    rng = np.random.default_rng(2)
+    x = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    (y_pruned,) = _run(pruned_cpp, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_cpp_decomposed_plain_attention_pruning_matches_python_reference_exactly():
+    # KVH == H -- the no-GQA, single pre-composed `perm=[0,2,3,1]`
+    # dot-product-transpose form. Every "group" is exactly one query head
+    # wide.
+    model, cfg = _decomposed_gqa_model(K=32, H=4, KVH=4, D=8, Out=16, seed=3)
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    wq_new, wk_new, wv_new, _ = _decomposed_weight_shapes(pruned_cpp)
+    assert wq_new.shape[1] == 2 * cfg["D"]
+    assert wk_new.shape[1] == 2 * cfg["D"]
+    assert wv_new.shape[1] == 2 * cfg["D"]
+
+
+def test_cpp_decomposed_gqa_pruning_shared_kv_reshape_shape_edits_in_place_matches_python():
+    # `share_kv_reshape_shape=True` (the default, and the common,
+    # empirically-confirmed onnxsim-CSE outcome): K's and V's own head-split
+    # `Reshape` reference the *same* shape-constant tensor -- exercises
+    # RewriteDecomposedShapeDim's own "edit in place, no cloning needed"
+    # fast path for a jointly-owned constant.
+    model, cfg = _decomposed_gqa_model(
+        K=32, H=8, KVH=2, D=8, Out=16, seed=5, share_kv_reshape_shape=True
+    )
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    inits = {t.name: t for t in pruned_cpp.graph.initializer}
+    # Exactly one `Skv`-named shape constant remains (no `_pruned` clone) --
+    # both K's and V's own `Reshape` still share it, edited in place.
+    skv_names = [n for n in inits if n.startswith("Skv")]
+    assert skv_names == ["Skv"]
+    new_kv = cfg["KVH"] - round(cfg["KVH"] * 0.5)
+    dims = onnx.numpy_helper.to_array(inits["Skv"])
+    assert dims[2] == new_kv
+
+
+def test_cpp_decomposed_gqa_pruning_clones_shape_constant_shared_with_foreign_reader():
+    # A wholly unrelated `Reshape` reads Q's own head-split shape constant
+    # (`Sq`) -- ApplyOneDecomposedGqaChain must clone a fresh tensor for
+    # Q's own edit rather than mutate `Sq` in place, or the foreign
+    # `Reshape` would silently see the pruned (wrong) shape too.
+    model, cfg = _decomposed_gqa_model(
+        K=64,  # == H * D, so `foreign_out`'s own Reshape(xf, Sq) is valid.
+        H=8,
+        KVH=2,
+        D=8,
+        Out=16,
+        seed=7,
+        extra_foreign_q_reshape_consumer=True,
+    )
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    onnx.checker.check_model(pruned_py)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    inits = {
+        t.name: onnx.numpy_helper.to_array(t) for t in pruned_cpp.graph.initializer
+    }
+    # The original `Sq` is left COMPLETELY untouched (still [batch, seq, H,
+    # D] with the original, pre-pruning H) -- the foreign `Reshape` (whose
+    # own output is unused but still present) still reads it.
+    np.testing.assert_array_equal(
+        inits["Sq"], [cfg["batch"], cfg["seq"], cfg["H"], cfg["D"]]
+    )
+    # A freshly minted `Sq_pruned` now holds the new post-pruning head
+    # count, and only Q's own head-split `Reshape` was rewired onto it.
+    assert "Sq_pruned" in inits
+    new_kv = cfg["KVH"] - round(cfg["KVH"] * 0.5)
+    group_size = cfg["H"] // cfg["KVH"]
+    new_num_heads = new_kv * group_size
+    assert inits["Sq_pruned"][2] == new_num_heads
+
+    q_reshape = next(
+        n for n in pruned_cpp.graph.node if n.output and n.output[0] == "qr"
+    )
+    assert q_reshape.input[1] == "Sq_pruned"
+    foreign_reshape = next(
+        n for n in pruned_cpp.graph.node if n.output and n.output[0] == "foreign_out"
+    )
+    assert foreign_reshape.input[1] == "Sq"
+
+    # Functional correctness too: the foreign branch (dead code, feeds
+    # nothing) doesn't affect `Y`, and pruning still computes the right
+    # answer.
+    rng = np.random.default_rng(8)
+    x = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    (y,) = _run(pruned_cpp, {"X": x})
+    assert y.shape == (cfg["batch"], cfg["seq"], cfg["Out"])
+
+
+def test_cpp_decomposed_gqa_pruning_clones_repeat_kv_expand_shape_shared_with_foreign_reader():
+    # A wholly unrelated `Expand` reads K's own `repeat_kv` broadcast target
+    # shape (`KExpandShape`) -- must be cloned, not edited in place, exactly
+    # like the head-split-Reshape case above but for the `repeat_kv` shape
+    # plumbing this family's own section comment calls out as the genuinely
+    # novel part of this port.
+    model, cfg = _decomposed_gqa_model(
+        K=32,
+        H=8,
+        KVH=2,
+        D=8,
+        Out=16,
+        seed=9,
+        extra_foreign_repeat_kv_consumer=True,
+    )
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    onnx.checker.check_model(pruned_py)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    inits = {
+        t.name: onnx.numpy_helper.to_array(t) for t in pruned_cpp.graph.initializer
+    }
+    n_rep = cfg["H"] // cfg["KVH"]
+    np.testing.assert_array_equal(
+        inits["KExpandShape"],
+        [cfg["batch"], cfg["KVH"], n_rep, cfg["seq"], cfg["D"]],
+    )
+    assert "KExpandShape_pruned" in inits
+    new_kv = cfg["KVH"] - round(cfg["KVH"] * 0.5)
+    assert inits["KExpandShape_pruned"][1] == new_kv
+
+    real_expand = next(
+        n for n in pruned_cpp.graph.node if n.output and n.output[0] == "ke"
+    )
+    assert real_expand.input[1] == "KExpandShape_pruned"
+    foreign_expand = next(
+        n
+        for n in pruned_cpp.graph.node
+        if n.output and n.output[0] == "foreign_expand_out"
+    )
+    assert foreign_expand.input[1] == "KExpandShape"
+
+
+def test_cpp_decomposed_gqa_pruning_out_reshape_wildcard_still_prunes_matches_python():
+    # The combine-back Reshape's own target shape's last entry is already a
+    # wildcard (-1) -- `Reshape` auto-infers it, so
+    # ApplyOneDecomposedGqaChain never needs to (and doesn't) touch it at
+    # all; pruning still proceeds normally otherwise.
+    model, cfg = _decomposed_gqa_model(
+        K=32, H=8, KVH=2, D=8, Out=16, seed=11, out_reshape_wildcard=True
+    )
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    wq_new, _, _, _ = _decomposed_weight_shapes(pruned_cpp)
+    new_kv = cfg["KVH"] - round(cfg["KVH"] * 0.5)
+    group_size = cfg["H"] // cfg["KVH"]
+    assert wq_new.shape[1] == new_kv * group_size * cfg["D"]
+
+    rng = np.random.default_rng(12)
+    x = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    (y,) = _run(pruned_cpp, {"X": x})
+    assert y.shape == (cfg["batch"], cfg["seq"], cfg["Out"])
+
+
+def test_cpp_decomposed_gqa_pruning_zero_sparsity_is_a_no_op():
+    model, _ = _decomposed_gqa_model(K=32, H=8, KVH=2, D=8, Out=16, seed=13)
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.0)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_decomposed_gqa_pruning_unsupported_transpose_perm_is_declined_matches_python():
+    # A non-standard perm on Q's own head-split Transpose -- this pass only
+    # ever recognizes the exact perms real exports use; anything else must
+    # decline outright, never guessed at. A genuinely invalid topology, so
+    # BOTH ports must agree it's a no-op, not merely a documented scope
+    # divergence.
+    model, _ = _decomposed_gqa_model(K=32, H=4, KVH=4, D=8, Out=16, seed=19)
+    for n in model.graph.node:
+        if n.output and n.output[0] == "qt":
+            n.ClearField("attribute")
+            n.attribute.append(onnx.helper.make_attribute("perm", [0, 1, 2, 3]))
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    assert pruned_cpp.SerializeToString() == model.SerializeToString()
+    assert pruned_py.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_decomposed_gqa_pruning_with_constant_mask_is_declined_but_python_still_prunes():
+    # This C++ port's own documented, accepted scope gap (see this section's
+    # own comment above `_decomposed_gqa_model`): an additive mask `Add`
+    # before `Softmax` is never recognized here at all -- `ResolveDecomposed
+    # QkRoot` only ever matches `[Mul/Div(scale) ->] MatMul`, so the `Add`
+    # node (whose own op_type is never `Mul`/`Div`/`MatMul`) makes the whole
+    # chain fail to match -- a decline, not a mis-slice. pruning.py's own
+    # pure-Python `apply_attention_head_pruning` DOES recognize a constant
+    # mask (`_head_bias_input_is_safe`) and still prunes this block, so the
+    # two ports intentionally diverge here -- this is exactly why the family
+    # is not aliased yet, not a bug in either.
+    model, _ = _decomposed_gqa_model(
+        K=32, H=8, KVH=2, D=8, Out=16, seed=21, masked=True
+    )
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    onnx.checker.check_model(pruned_py)
+    assert pruned_cpp.SerializeToString() == model.SerializeToString()
+    assert pruned_py.SerializeToString() != model.SerializeToString()
+
+
+def test_cpp_decomposed_mqa_pruning_is_a_permanent_no_op_unlike_python():
+    # True decomposed MQA (kv_num_heads == 1): this C++ port has no MQA
+    # fast path (mirrors ApplyOneGqaChain's own identical, already-accepted
+    # gap for every fused-op family) -- with only one KV group, the
+    # ordinary group-granularity formula (`max(1, 1 - round(1*sparsity))`)
+    # is always `1 == kv_num_heads`, so `ApplyOneDecomposedGqaChain` always
+    # declines as a no-op for this block, no matter how many query heads
+    # share the one KV head. pruning.py's own pure-Python implementation
+    # DOES have this fast path (individual query heads ranked/dropped
+    # directly, KV head untouched) and so still prunes something here -- an
+    # intentional, documented divergence.
+    model, _ = _decomposed_gqa_model(K=32, H=8, KVH=1, D=8, Out=16, seed=201)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    onnx.checker.check_model(pruned_py)
+    assert pruned_cpp.SerializeToString() == model.SerializeToString()
+    assert pruned_py.SerializeToString() != model.SerializeToString()

--- a/tests/test_attention_head_wanda_pruning_cpp.py
+++ b/tests/test_attention_head_wanda_pruning_cpp.py
@@ -18,15 +18,21 @@ the plain ``ai.onnx::Attention`` op, ``com.microsoft::MultiHeadAttention``,
 ``com.microsoft::PackedMultiHeadAttention``,
 ``com.microsoft::DecoderMaskedMultiHeadAttention``,
 ``com.microsoft::PagedAttention``, the plain ``ai.onnx::LinearAttention`` op,
-and ``com.microsoft::SparseAttention``), minus the fused
+``com.microsoft::SparseAttention``, and the tenth, decomposed (un-fused,
+"eager SDPA export") shape -- ``FindDecomposedGqaChains``/
+``ApplyOneDecomposedGqaChain``, threaded through with a real calibrated
+``act_norm`` map here exactly like every other family), minus the fused
 ``com.microsoft::MatMulNBitsQkv`` variant that port also matches -- this
 Wanda port has no quantized-weight counterpart, mirroring the pure-Python
 ``onnxsim.apply_attention_head_wanda_pruning`` exactly (see
 ``structured_pruning_entry.h``'s own ``ApplyAttentionHeadWandaPruning``
 declaration comment). See ``test_attention_head_pruning_cpp.py``'s own
 docstring for this port's shared narrower-than-pruning.py scope decisions
-across the six newer families (no dynamic-attention-bias-Gather-insertion
-machinery), and for the tenth, still-unported decomposed-GQA family.
+across the six newer fused-op families (no dynamic-attention-bias-Gather-
+insertion machinery) and across the decomposed-GQA family (no mask/RoPE/
+Q-K-norm/Einsum/packed-QKV, no true-MQA fast path) -- every one of those
+narrowings means ``apply_attention_head_wanda_pruning`` is NOT yet aliased
+to this port either.
 """
 
 import os
@@ -1324,3 +1330,352 @@ def test_cpp_sparse_attention_wanda_pruning_empty_calibration_data_matches_pytho
     assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
     plain = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
     assert pruned_cpp.SerializeToString() == plain.SerializeToString()
+
+
+# --- Decomposed (un-fused) GQA/MQA/plain-MHA attention head pruning --------
+#
+# `apply_attention_head_wanda_pruning_cpp` now also matches this shape, via
+# the same genuinely new, dedicated FindDecomposedGqaChains/
+# ApplyOneDecomposedGqaChain machinery `apply_attention_head_pruning_cpp`
+# uses (threaded through with a real calibrated `act_norm` map, exactly like
+# every other family here) -- see
+# ``test_attention_head_pruning_cpp.py``'s own "Decomposed (un-fused)
+# GQA/MQA/plain-MHA attention head pruning" section comment for the exact
+# scope this port matches (deliberately narrower than pruning.py's own
+# ``_find_decomposed_gqa_chains``: no mask/RoPE/Q-K-norm/Einsum/packed-QKV,
+# no true-MQA fast path) -- so this tenth family is NOT yet aliased either.
+
+
+def _decomposed_gqa_model(
+    K=32,
+    H=4,
+    KVH=2,
+    D=8,
+    Dv=None,
+    Out=16,
+    batch=1,
+    seq=4,
+    seed=0,
+    bias=True,
+    masked=False,
+    wq=None,
+    wk=None,
+    wv=None,
+    wout=None,
+    bq=None,
+    bk=None,
+    bv=None,
+    bout=None,
+    share_kv_reshape_shape=True,
+    extra_foreign_q_reshape_consumer=False,
+):
+    """Builds the decomposed-attention graph FindDecomposedGqaChains matches
+    -- mirrors ``test_attention_head_pruning_cpp.py``'s own
+    ``_decomposed_gqa_model`` (trimmed further: no ``out_reshape_wildcard``/
+    ``extra_foreign_repeat_kv_consumer`` params, not needed by this file's
+    own coverage -- see that copy's own docstring for the full shape and
+    every other parameter's meaning)."""
+    if Dv is None:
+        Dv = D
+    rng = np.random.default_rng(seed)
+    Nq, Nk, Nv = H * D, KVH * D, KVH * Dv
+    if wq is None:
+        wq = rng.standard_normal((K, Nq)).astype(np.float32)
+    if wk is None:
+        wk = rng.standard_normal((K, Nk)).astype(np.float32)
+    if wv is None:
+        wv = rng.standard_normal((K, Nv)).astype(np.float32)
+    if wout is None:
+        wout = rng.standard_normal((H * Dv, Out)).astype(np.float32)
+
+    def _i64(arr, name):
+        return onnx.numpy_helper.from_array(np.array(arr, dtype=np.int64), name)
+
+    initializer = [_f32(wq, "Wq"), _f32(wk, "Wk"), _f32(wv, "Wv"), _f32(wout, "Wout")]
+
+    initializer.append(_i64([batch * seq, K], "XFlatShape"))
+    lines = ["xf = Reshape(X, XFlatShape)"]
+    q_op, k_op, v_op, o_op = (
+        "MatMul(xf, Wq)",
+        "MatMul(xf, Wk)",
+        "MatMul(xf, Wv)",
+        "MatMul(ctx2, Wout)",
+    )
+    if bias:
+        if bq is None:
+            bq = rng.standard_normal((Nq,)).astype(np.float32)
+        if bk is None:
+            bk = rng.standard_normal((Nk,)).astype(np.float32)
+        if bv is None:
+            bv = rng.standard_normal((Nv,)).astype(np.float32)
+        if bout is None:
+            bout = rng.standard_normal((Out,)).astype(np.float32)
+        initializer += [
+            _f32(bq, "Bq"),
+            _f32(bk, "Bk"),
+            _f32(bv, "Bv"),
+            _f32(bout, "Bout"),
+        ]
+        q_op, k_op, v_op = "Gemm(xf, Wq, Bq)", "Gemm(xf, Wk, Bk)", "Gemm(xf, Wv, Bv)"
+        o_op = "Gemm(ctx2, Wout, Bout)"
+
+    initializer.append(_i64([batch, seq, H, D], "Sq"))
+    lines += [
+        "q0 = " + q_op,
+        "qr = Reshape(q0, Sq)",
+        "qt = Transpose<perm=[0,2,1,3]>(qr)",
+    ]
+
+    if extra_foreign_q_reshape_consumer:
+        lines.append("foreign_out = Reshape(xf, Sq)")
+
+    kv_shape_name = "Skv" if share_kv_reshape_shape and Dv == D else None
+    if kv_shape_name:
+        initializer.append(_i64([batch, seq, KVH, D], kv_shape_name))
+        sk_name = sv_name = kv_shape_name
+    else:
+        initializer.append(_i64([batch, seq, KVH, D], "Sk"))
+        initializer.append(_i64([batch, seq, KVH, Dv], "Sv"))
+        sk_name, sv_name = "Sk", "Sv"
+
+    lines += ["k0 = " + k_op, f"kr = Reshape(k0, {sk_name})"]
+    lines += ["v0 = " + v_op, f"vr = Reshape(v0, {sv_name})"]
+
+    n_rep = H // KVH
+    needs_repeat_kv = KVH < H
+    if needs_repeat_kv:
+        assert H % KVH == 0
+        initializer.append(_i64([2], "Ax2"))
+        initializer.append(_i64([batch, KVH, n_rep, seq, D], "KExpandShape"))
+        initializer.append(_i64([batch, H, seq, D], "KMergeShape"))
+        initializer.append(_i64([batch, KVH, n_rep, seq, Dv], "VExpandShape"))
+        initializer.append(_i64([batch, H, seq, Dv], "VMergeShape"))
+        lines.append("kt0 = Transpose<perm=[0,2,1,3]>(kr)")
+        lines += [
+            "ku = Unsqueeze(kt0, Ax2)",
+            "ke = Expand(ku, KExpandShape)",
+            "kre = Reshape(ke, KMergeShape)",
+            "kt = Transpose<perm=[0,1,3,2]>(kre)",
+            "vt0 = Transpose<perm=[0,2,1,3]>(vr)",
+            "vu = Unsqueeze(vt0, Ax2)",
+            "ve = Expand(vu, VExpandShape)",
+            "vt = Reshape(ve, VMergeShape)",
+        ]
+    else:
+        lines.append("kt = Transpose<perm=[0,2,3,1]>(kr)")
+        lines.append("vt = Transpose<perm=[0,2,1,3]>(vr)")
+
+    initializer.append(_f32(np.array(D**-0.5, dtype=np.float32), "Scale"))
+    lines += ["qk = MatMul(qt, kt)", "scaled = Mul(qk, Scale)"]
+
+    if masked:
+        mask = np.triu(np.full((seq, seq), -1e4, dtype=np.float32), k=1)[
+            None, None, :, :
+        ]
+        initializer.append(_f32(mask, "Mask"))
+        lines.append("premask = Add(scaled, Mask)")
+        smax_in = "premask"
+    else:
+        smax_in = "scaled"
+    lines.append(f"attn = Softmax<axis=-1>({smax_in})")
+    lines.append("ctx0 = MatMul(attn, vt)")
+    lines.append("ctx1 = Transpose<perm=[0,2,1,3]>(ctx0)")
+
+    initializer.append(_i64([batch * seq, H * Dv], "OutShape"))
+    initializer.append(_i64([batch, seq, Out], "YShape"))
+    lines.append("ctx2 = Reshape(ctx1, OutShape)")
+    lines.append("y0 = " + o_op)
+    lines.append("Y = Reshape(y0, YShape)")
+
+    body_lines = "\n          ".join(lines)
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17]
+        >
+        g (float[{batch},{seq},{K}] X) => (float[{batch},{seq},{Out}] Y)
+        {{
+          {body_lines}
+        }}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model, dict(
+        K=K,
+        H=H,
+        KVH=KVH,
+        D=D,
+        Dv=Dv,
+        Out=Out,
+        batch=batch,
+        seq=seq,
+        wq=wq,
+        wk=wk,
+        wv=wv,
+        wout=wout,
+        bq=bq,
+        bk=bk,
+        bv=bv,
+        bout=bout,
+    )
+
+
+def _decomposed_weight_shapes(model):
+    inits = {t.name: t for t in model.graph.initializer}
+    return (
+        onnx.numpy_helper.to_array(inits["Wq"]),
+        onnx.numpy_helper.to_array(inits["Wk"]),
+        onnx.numpy_helper.to_array(inits["Wv"]),
+        onnx.numpy_helper.to_array(inits["Wout"]),
+    )
+
+
+def test_cpp_decomposed_gqa_wanda_pruning_matches_oracle_exactly():
+    model, cfg = _decomposed_gqa_model(K=32, H=8, KVH=2, D=8, Out=16, seed=101)
+    rng = np.random.default_rng(102)
+    x_cal = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    calibration_data = [{"X": x_cal}]
+
+    act_norm = _probe_act_norm(model, "ctx2", {"X": x_cal})
+    new_kv = 1  # KVH=2, sparsity=0.5 -> keep_count = max(1, 2 - round(1)) == 1
+    keep_groups = _wanda_gqa_keep_groups(
+        cfg["wq"],
+        cfg["wk"],
+        cfg["wv"],
+        cfg["H"],
+        cfg["KVH"],
+        cfg["D"],
+        act_norm,
+        new_kv,
+    )
+    group_size = cfg["H"] // cfg["KVH"]
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    d = cfg["D"]
+    q_idx, kv_idx = _head_idx(keep_q_heads, d), _head_idx(keep_groups, d)
+
+    pruned = onnxsim.apply_attention_head_wanda_pruning_cpp(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned)
+    wq_new, wk_new, wv_new, wo_new = _decomposed_weight_shapes(pruned)
+    np.testing.assert_array_equal(wq_new, cfg["wq"][:, q_idx])
+    np.testing.assert_array_equal(wk_new, cfg["wk"][:, kv_idx])
+    np.testing.assert_array_equal(wv_new, cfg["wv"][:, kv_idx])
+    np.testing.assert_array_equal(wo_new, cfg["wout"][q_idx, :])
+
+
+def test_cpp_decomposed_gqa_wanda_pruning_matches_python_reference_exactly():
+    model, cfg = _decomposed_gqa_model(K=32, H=8, KVH=2, D=8, Out=16, seed=103)
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+
+    rng = np.random.default_rng(104)
+    calibration_data = [
+        {
+            "X": rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(
+                np.float32
+            )
+        }
+        for _ in range(3)
+    ]
+    pruned_cpp = onnxsim.apply_attention_head_wanda_pruning_cpp(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    pruned_py = onnxsim.apply_attention_head_wanda_pruning(
+        model_for_py, calibration_data=calibration_data, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned_cpp)
+    onnx.checker.check_model(pruned_py)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+
+def test_cpp_decomposed_gqa_wanda_pruning_clones_shape_constant_shared_with_foreign_reader():
+    model, cfg = _decomposed_gqa_model(
+        K=64,  # == H * D, so `foreign_out`'s own Reshape(xf, Sq) is valid.
+        H=8,
+        KVH=2,
+        D=8,
+        Out=16,
+        seed=105,
+        extra_foreign_q_reshape_consumer=True,
+    )
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+
+    rng = np.random.default_rng(106)
+    calibration_data = [
+        {
+            "X": rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(
+                np.float32
+            )
+        }
+    ]
+    pruned_cpp = onnxsim.apply_attention_head_wanda_pruning_cpp(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    pruned_py = onnxsim.apply_attention_head_wanda_pruning(
+        model_for_py, calibration_data=calibration_data, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned_cpp)
+    onnx.checker.check_model(pruned_py)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    inits = {
+        t.name: onnx.numpy_helper.to_array(t) for t in pruned_cpp.graph.initializer
+    }
+    np.testing.assert_array_equal(
+        inits["Sq"], [cfg["batch"], cfg["seq"], cfg["H"], cfg["D"]]
+    )
+    assert "Sq_pruned" in inits
+
+
+def test_cpp_decomposed_gqa_wanda_pruning_with_constant_mask_is_declined_but_python_still_prunes():
+    # Mirrors test_attention_head_pruning_cpp.py's own identical (data-free)
+    # test -- this C++ port never recognizes an additive mask at all, so the
+    # whole chain declines to match here regardless of whether calibration
+    # data is supplied, while pruning.py's own pure-Python
+    # apply_attention_head_wanda_pruning still prunes it.
+    model, cfg = _decomposed_gqa_model(
+        K=32, H=8, KVH=2, D=8, Out=16, seed=107, masked=True
+    )
+    rng = np.random.default_rng(108)
+    calibration_data = [
+        {
+            "X": rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(
+                np.float32
+            )
+        }
+    ]
+    pruned_cpp = onnxsim.apply_attention_head_wanda_pruning_cpp(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    pruned_py = onnxsim.apply_attention_head_wanda_pruning(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned_cpp)
+    onnx.checker.check_model(pruned_py)
+    assert pruned_cpp.SerializeToString() == model.SerializeToString()
+    assert pruned_py.SerializeToString() != model.SerializeToString()
+
+
+def test_cpp_decomposed_mqa_wanda_pruning_is_a_permanent_no_op_unlike_python():
+    model, cfg = _decomposed_gqa_model(K=32, H=8, KVH=1, D=8, Out=16, seed=109)
+    rng = np.random.default_rng(110)
+    calibration_data = [
+        {
+            "X": rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(
+                np.float32
+            )
+        }
+    ]
+    pruned_cpp = onnxsim.apply_attention_head_wanda_pruning_cpp(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    pruned_py = onnxsim.apply_attention_head_wanda_pruning(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned_cpp)
+    onnx.checker.check_model(pruned_py)
+    assert pruned_cpp.SerializeToString() == model.SerializeToString()
+    assert pruned_py.SerializeToString() != model.SerializeToString()

--- a/tests/test_wanda_pruning_cpp.py
+++ b/tests/test_wanda_pruning_cpp.py
@@ -18,53 +18,60 @@ recomputed).
 Scope: this port matches plain ``MatMul``/vanilla-``Gemm`` (not
 ``com.microsoft::FusedGemm``/``GemmFastGelu``), ``com.microsoft::
 Attention``'s merged QKV weight, each with a constant 2-D (1-D merged bias,
-for Attention) FLOAT32/FLOAT16/BFLOAT16 weight, AND (as of this round) every
-2-D ``Conv`` node's constant 4-D FLOAT32/FLOAT16/BFLOAT16 weight -- ordinary
+for Attention) FLOAT32/FLOAT16/BFLOAT16 weight, and every 2-D ``Conv``
+node's constant 4-D FLOAT32/FLOAT16/BFLOAT16 weight -- ordinary
 (``group=1``), fully depthwise (``group == in_channels == out_channels``),
 and general grouped (``1 < group < in_channels``) alike -- via a
 from-scratch im2col per-``(in_channel, kh, kw)``-tap activation norm
 (``ConvPatchSqSum``/``ConvWandaCalibrationStats``) and a grouped/depthwise
 group-relative norm expansion (``ConvGroupRelativeNorm``), mirroring
 pruning.py's own ``_conv_patch_sq_sum``/``_conv_group_relative_norm``
-exactly -- TRUE parity with the pure-Python ``onnxsim.apply_wanda_pruning``
-verified on all three Conv `group` shapes (see the Conv tests below).
+exactly.
 
-Despite that, ``onnxsim.apply_wanda_pruning`` (the pure-Python name) is
-DELIBERATELY NOT aliased to this C++ port -- unlike, e.g.,
-``apply_transformer_block_pruning``/``apply_magnitude_pruning`` -- because
-this round's own full-regression check (comparing every existing candidate
-family's live output against the pure-Python reference, not just the new
-Conv coverage) surfaced a genuine, PRE-EXISTING divergence unrelated to
-Conv: this port's own ``WandaCalibrationStats`` (shared with
-``ApplyStructuredWandaPruning``/``ApplyAttentionHeadWandaPruning``) computes
-a per-channel-axis activation L2-norm for a MatMul/Gemm candidate's
-activation at ANY rank >= 1 (probe axis -1, the same "reduce over every
-leading axis" handling it gives a rank-3 Attention activation), whereas
-pruning.py's own ``_wanda_unstructured_calibration_stats`` explicitly
-requires ``x.ndim == 2`` for its own (non-Attention, non-Conv) activation
-statistic and falls back to plain magnitude importance for anything else
-(e.g. a rank-3 activation feeding a plain 2-D MatMul weight, which is
-exactly the shape a batched/sequence MatMul input takes in practice). So a
-MatMul/Gemm layer fed a rank-3+ activation gets a REAL (but, per the Python
-reference's own narrower scope, not-yet-earned) activation-weighted
-importance from this C++ port instead of the Python reference's plain-
-magnitude fallback -- a real behavioral difference, caught by
+TRUE parity with the pure-Python ``onnxsim.apply_wanda_pruning`` (all three
+candidate families, all three Conv `group` shapes) is now fully verified,
+including a prior gap unrelated to Conv: this port's own
+``WandaCalibrationStats`` (shared with ``ApplyStructuredWandaPruning``/
+``ApplyAttentionHeadWandaPruning``) used to compute a per-channel-axis
+activation L2-norm for a MatMul/Gemm candidate's activation at ANY rank >= 1
+(probe axis -1, the same "reduce over every leading axis" handling it gives
+a rank-3 Attention activation), whereas pruning.py's own
+``_wanda_unstructured_calibration_stats`` explicitly requires ``x.ndim ==
+2`` for its own (non-Attention, non-Conv) activation statistic and falls
+back to plain magnitude importance for anything else (e.g. a rank-3
+activation feeding a plain 2-D MatMul weight, which is exactly the shape a
+batched/sequence MatMul input takes in practice) -- caught by
 ``test_wanda_pruning_falls_back_to_magnitude_without_matching_activation``
-in ``tests/test_pruning.py`` once ``apply_wanda_pruning`` was tentatively
-aliased to this port to verify the Conv work below. This is orthogonal to
-Conv entirely (present before this round's Conv work, in code this round
-never touched) and touches ``WandaCalibrationStats``, shared, independently-
-verified infrastructure two OTHER passes also depend on -- fixing it safely
-is out of scope here; the safe, conservative choice is to leave
-``apply_wanda_pruning`` un-aliased and document this gap rather than risk a
-subtly-wrong alias. The Conv tests below therefore still compare against a
-LIVE call to the pure-Python ``onnxsim.apply_wanda_pruning`` (not a frozen
-golden fixture -- unnecessary since that function keeps its own real
-implementation), exactly like every other test in this file. The
-FLOAT16/BFLOAT16 tests confirm those dtypes are matched, pruned, and
-written back with their own exact original bit pattern preserved for every
-surviving entry -- not merely "not crashed on".
+in ``tests/test_pruning.py``, still present below as
+``test_wanda_pruning_cpp_matmul_rank3_activation_falls_back_to_plain_
+magnitude``. That gap is now closed: ``WandaCalibrationStats`` takes a
+``require_rank2`` set, populated (only by ``ApplyWandaPruning``, only for
+its plain MatMul/Gemm candidates -- never Attention's, never the other two
+callers') with exactly the probe names that must need `ndim == 2` --
+mirroring pruning.py's own `act_norm`/`attn_act_norm` split exactly (see
+``structured_pruning_entry.h``'s own ``ApplyWandaPruning`` declaration
+comment for the full writeup).
+
+``onnxsim.apply_wanda_pruning`` (the pure-Python name) is now itself a thin
+alias for :func:`onnxsim.apply_wanda_pruning_cpp` (full parity verified --
+see pruning.py's own "Wanda unstructured (element-wise) pruning" section
+comment), exactly like ``apply_transformer_block_pruning``/
+``apply_magnitude_pruning`` before it. Every test below that used to call
+BOTH entry points and compare their live outputs would be tautological
+(literally the same code path twice) if left as-is -- those now instead
+compare the C++ port's output against a golden fixture captured from the
+real pure-Python implementation *before* its own mutating body was replaced
+by the alias -- see ``_GOLDEN_*`` below (base64-encoded serialized
+``ModelProto`` bytes, inlined directly, mirroring
+``test_transformer_block_pruning_cpp.py``'s own established convention --
+see that file's own module docstring for why inline base64 rather than a
+checked-in ``.onnx`` fixture file). The FLOAT16/BFLOAT16 tests confirm
+those dtypes are matched, pruned, and written back with their own exact
+original bit pattern preserved for every surviving entry -- not merely "not
+crashed on".
 """
+
+import base64
 
 import ml_dtypes
 import numpy as np
@@ -78,6 +85,10 @@ from onnx import parser
 import onnxsim
 
 ort = pytest.importorskip("onnxruntime")
+
+
+def _golden(b64):
+    return onnx.load_from_string(base64.b64decode(b64))
 
 
 def _model(body, initializer=(), opset=21):
@@ -148,6 +159,355 @@ def _assert_bytewise_close(actual, expected, rtol=1e-5, atol=1e-6):
     )
 
 
+# Frozen from onnxsim.apply_wanda_pruning's own real pure-Python
+# implementation, on the exact model + calibration seed each corresponding
+# test below builds, before that implementation's own mutating body was
+# replaced by the thin C++ alias (see this file's own module docstring).
+_GOLDEN_MATMUL_UNSTRUCTURED = (
+    "CAo62wgKEwoBWAoBVxIBWSIGTWF0TXVsOgASAWcqjAgIIAgIEAFCAVdKgAgAAAAAAAAAANdZqz7e"
+    "kjG/1TtVPwAAAAAAAAAAAAAAAAAAAAAAAAAADLkrvwAAAAAAAAAAAAAAAKzJrL8vU0e/AAAAAAAA"
+    "AAAAAAAA7P0Mv/LDl74AAAAAgLHDvwAAAACPA8O+AAAAAAAAAACnwxC/AAAAAAAAAAAAAAAAAAAA"
+    "AClsBj8VSYA/AAAAAF/oz74AAAAA9uuFPwAAAAAAAAAA3cyjvhN+Cb99Lgy/wzi3P9Wptb5a3Bi/"
+    "AAAAALNIvT59Qwu/AAAAAAAAAAAAAAAAPd0evwAAAAA9bmc/AAAAAJD6Fr8AAAAAK0W5PgAAAAAA"
+    "AAAAAAAAAAAAAAAAAAAALHDPPioTZ78AAAAAAAAAAAAAAAAAAAAAsJ5XPwAAAAAAAAAAAAAAABFK"
+    "2D4AAAAAbqUPv0tB3r4AAAAAo2dkPwVbwL64wNk+/msov18qzj4AAAAAAAAAAFJVNT+mPY0/AAAA"
+    "AFRe9L4KrNa+AAAAAAAAAAAAAAAAD+TgvgAAAAAAAAAAi4cUPwAAAABi2EU/hN8BP5sH5T4AAAAA"
+    "pGIdv46e6j6yOiw/AAAAAJ+FJ782Ng+/X6j5vlziDr/CqFw/AAAAAGn6Dj8H/La+k4X2PkTLoT6N"
+    "CAU/AAAAAAAAAABgDt6+e9JFv4N3GL8AAAAAAAAAAK+l7r4AAAAAbUToPgAAAAAAAAAAAAAAAAAA"
+    "AABBewI/AAAAAAAAAAAAAAAAjFW9PgAAAAAAAAAAdKAJvwAAAAAAAAAAOl47P3vfBL8AAAAASeFc"
+    "PwYfiz+Rdpa/AAAAAAAFRr8AAAAAAAAAAAAAAACuqZQ/AAAAAAAAAAAebK0+6B75PgAAAAAiaRE/"
+    "d5ohvwAAAAAAAAAAAAAAAAAAAAAAAAAAAACAP36OFb8AAAAAAAAAAA6tor+9SSy/AAAAAAAAAABg"
+    "gTG/AAAAAAAAAAAAAAAAAAAAAAAAAADv8j4/kJEfv24rIj+Kww4/AAAAAOZwNj9FG5e+eVb5PuJS"
+    "9j71vTK/AAAAANdrJb8AAAAARuTxvqiklb4eNNa+gNfPPppXqj4TAAw/jMTaPufq4L4AAAAAAAAA"
+    "AAAAAAAAAAAAAAAAAAAAAABWLvg+VyPqvnRgNT8AAAAAAAAAAAAAAAAAAAAAAAAAAPqJQD8AAAAA"
+    "AAAAAAu/1z4AAAAAvTk9vxkAVz8AAAAAhbgPPwAAAABsHac/AAAAAFIGxT6VMVc/XiyePgmIQL8A"
+    "AAAAI0DLvgAAAAAAAAAA8U8MvwAAAACGsoQ/ka6SPwAAAADPpuI+AAAAAMaZEb8AAAAA0QXFvqzl"
+    "pD437Qs/AAAAAGjgyD78OyM/fuwQvwAAAAAAAAAAAAAAAG0UXT8AAAAAWhgKAVgSEwoRCAESDQoH"
+    "EgViYXRjaAoCCCBiGAoBWRITChEIARINCgcSBWJhdGNoCgIICEIECgAQFQ=="
+)
+
+_GOLDEN_GEMM_TRANSB = (
+    "CAo6zgUKIwoBWAoBVwoBQhIBWSIER2VtbSoNCgZ0cmFuc0IYAaABAjoAEgFnKswECAYIGBABQgFX"
+    "SsAEAAAAANjPfr4AAAAA0EAAPwAAAADdneG+uZSjvtECNj8AAAAAC2jyvgAAAAAAAAAAAAAAADvG"
+    "Pj8AAAAALUYev9yBGj8AAAAAAAAAAMEQi74LGdS+7d4hPwZqG7/jAH6+3+DqvpfVEz8AAAAA/g2R"
+    "vrMPkj4FHkc/ESvFvp/+tr4AAAAAAAAAAC+h6L4AAAAAAAAAAHX4sD6KSRi/AAAAAAAAAADP1FI/"
+    "r3l1vwAAAAAAAAAAvXUdP2rO8b4AAAAAAAAAAAAAAAAAAAAA2O4EvwxTTD8Pgo6+AAAAAEeLyz4A"
+    "AAAAkHlmPoabHb8AAAAAAAAAACbxIb+ebpG+RcvavmmCyD5hN7C+pwUmvwAAAAAAAAAAZ4mJP6f9"
+    "Pj8AAAAAL7aqvrh4dT8AAAAAEo85vwAAAABHwTq/zm0FPwAAAAC9bP6+R1aKvsoLcr+bHjk/AAAA"
+    "AC9giz7dxws/AAAAAAEZhb4AAAAAAAAAAN5iwb4AAAAAAAAAAAAAAADvZIa+Qhj6vgAAAAAAAAAA"
+    "KM8PPzgj9z4AAAAA7UeJPgAAAACruCM/xXeyvpU3Aj8AAAAAAAAAAJxbiT9rDkw/oa0svwAAAAAA"
+    "AAAAYFD5PpAsBr8AAAAAAAAAAEkqrL4bmbE+GjJqvgAAAADd8tm+X5pNPrWqXT6pbA6+nEq/vgAA"
+    "AAAAAAAAAAAAAAAAAADgu+E+PqoavgAAAABTfS4/N9+9vgAAAAAAAAAAFwuqvtPiGr9ar9q+HdRv"
+    "vwAAAAAAAAAAKiEIBhABQgFCShjT05s924xSPkqkljzGRq888O9ZPaOnX71aGAoBWBITChEIARIN"
+    "CgcSBWJhdGNoCgIIGGIYCgFZEhMKEQgBEg0KBxIFYmF0Y2gKAggGQgQKABAV"
+)
+
+_GOLDEN_NM_PATTERN = (
+    "CAo62wgKEwoBWAoBVxIBWSIGTWF0TXVsOgASAWcqjAgIIAgIEAFCAVdKgAgAAAAAAAAAAAAAAAAA"
+    "AAAAAAAAAAAAAAAAAAAAAAAAAM2TEb+O+5M+kqkmvsFu/T5pFig/+vlQvyc2Kj+3VK6+2c8EvwAA"
+    "AABhLhk++yMBP0+itD/+UDu/AAAAAIeeQD4AAAAAtRRcvwAAAAAAAAAAAAAAAAAAAABMzyw/AAAA"
+    "ACleyz5dzgO/qkqjv43Txz4AAAAAnxqzPgAAAAAAAAAAAAAAAPygAz8AAAAAAAAAAAAAAAAAAAAA"
+    "w+ONPxjhgr4veaI/AAAAAAAAAAAAAAAAS1jvPq6VWT9tzN6+AAAAAAAAAAAAAAAA5jf4vsuEaz4W"
+    "lMc+AAAAAAAAAACAHwc+e6MBP8HEfD7eEQQ/AAAAAJaz3D44FrY+AAAAAAAAAAAAAAAAAAAAAAAA"
+    "AAAAAAAAAAAAAAAAAAAAAAAAqYIJvwAAAAAElJC/QET7vsEbuj4AAAAAAAAAACgo7b7djj+/uOQH"
+    "vwAAAAAAAAAApVtgPyhmcT88i90+JB/QvgAAAAC7aWa+AAAAAAAAAAAAAAAAAAAAAAAAAACzKmq/"
+    "AAAAAObeqj4AAAAAXkgmvwCD/D0AAAAAxPQgvwAAAAAAAAAAAAAAAAc1Wz8AAAAA9orcPbUbZj4A"
+    "AAAARrx4vkqiej4AAAAAXE2TP9bAJj8AAAAA/nIsP6hx8r4AAAAAes9MPwYKbr8igAY/AAAAACeD"
+    "oL6+Gtc+lmgZv10a6j4AAAAAAAAAAJMZFb8AAAAAsuDQPgAAAADEE00/AAAAAFAciD8MKoA/AAAA"
+    "AF7MVD8AAAAAAAAAAAAAAAASyl2/AAAAAAAAAAAAAAAAutiMvwAAAABlTwE/AAAAAAAAAACqXJA+"
+    "AAAAAAAAAACS1Ng+WApEvwAAAAAAAAAAAAAAAAAAAAB7UJC+QMSyPgAAAAAAAAAAeItQv8UpPD4q"
+    "YX8+79p9P1ztr74AAAAAAAAAALcpqr8AAAAA5q1cPq+Fqr6wC1Q/AAAAADdtKr5BYAc/AAAAAI8K"
+    "BT8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAT6VjPwAAAAAAAAAA5466PgAAAAA+VkI/AAAA"
+    "APRgyr4AAAAA9vIIvwAAAAC9UMI+k5hkvwAAAABxmHO+AAAAAAAAAAAAAAAA/kmcPgAAAADlLTA/"
+    "aLBlPrTNcr/6pCQ/3EEhv2Q5GD9qwvK+AAAAAPkbDT8AAAAAsM43PgJZnz7K1mO/HShuPwAAAAAA"
+    "AAAAAAAAADRY6j4AAAAAsrsbvwAAAAAwt5G/xmDmPvKFXb+2dw4/AAAAAAAAAAAAAAAAAAAAAAAA"
+    "AADdYKU+AAAAAAAAAABg3uS+ZT+gvgAAAABMC36/AAAAAAAAAACx6CA/WhgKAVgSEwoRCAESDQoH"
+    "EgViYXRjaAoCCCBiGAoBWRITChEIARINCgcSBWJhdGNoCgIICEIECgAQFQ=="
+)
+
+_GOLDEN_ATTENTION_MERGED_QKV = (
+    "CAo6jg4KRwoBWAoEV3FrdgoEQnFrdhIBWRIHcHJlc2VudCIJQXR0ZW50aW9uKhAKCW51bV9oZWFk"
+    "cxgCoAECOg1jb20ubWljcm9zb2Z0EgFnKo8MCBAIGBABQgRXcWt2SoAMAAAAAAAAAAAAAAAAG6CO"
+    "vkZwrr4AAAAAL5vKPjP3wz5fONA+AAAAAAAAAACtijE+AAAAAAAAAAAAAAAAAAAAAAAAAABJebG+"
+    "AAAAAHDtur4FXwg/7lVaPgAAAAAzWZI+AAAAAAAAAAAAAAAAAAAAADDXiz9VbJe+yd9Vv3V6az7I"
+    "uMu+I+HWvsda0D7aHom+3jjLvgAAAABRXcK+AAAAAGfLc74AAAAA8lznPkImGz/ANS6/hscZvgAA"
+    "AACRAoM+AAAAAPAKj74ra+g+uvDNPgAAAABAFSS/AAAAAIr+176HLx8/Y7sdPgAAAACz8Ik+wpVh"
+    "PkGNvb4AAAAAAAAAAKx0SL+DrLk+AAAAAAAAAAAAAAAAPhWBvmyHpj4AAAAALaHGvl+9Ij8AAAAA"
+    "AAAAAAAAAACa2Sw+h0HsPv8sbj7939w+cqNJviywZL4AAAAAAAAAAAAAAAALgYG+AAAAALqGjj69"
+    "84M+UOG0vvplhD4AAAAAAAAAAJ+WlT4AAAAAVNAKPwAAAAAAAAAAAAAAAAAAAADcRaO+AAAAAAAA"
+    "AAAAAAAAAAAAALiMrj7VtZo+kh+ovj/WeD4AAAAAztwoPwAAAAAAAAAAqtXyvijPsj4AAAAAAAAA"
+    "AAAAAAAAAAAAkBwwvtDmPj4AAAAAalCuvW8aaD8AAAAAAAAAAAAAAAAAAAAAAAAAAOgDz76DgWY+"
+    "AAAAAAAAAABuWa++GZWTPjlT2L4AAAAAxEFXvqXZ3L6d+e8+nDzcPkquxT4AAAAAg6WIvgAAAAAA"
+    "AAAACxwMv5r4uD6ng4A+AAAAAA+8n74AAAAAAAAAADCuKD8AAAAADK6evnPvSj4cLL2+tq2hvgAA"
+    "AAAAAAAANcLevgAAAAAAAAAAFH2hvlhiF74AAAAAAAAAAIQsh76252Q+oCHzPuqXhz6VN6i+n1x8"
+    "vgAAAAAAAAAASISSvgAAAAAAAAAAKB69vgQqCL8AAAAAL+FNvryOFj884pG+hB44vo+1WT8GA7W+"
+    "aWWfPgAAAAAAAAAAhB2mvgAAAAD+jfI+UwuJPgAAAAA2cJA+AAAAAAAAAADaobo+AAAAAAAAAAAA"
+    "AAAAGm6hvqCvzj4AAAAAAsLSPmxqqT62Sd8+Ec93PgAAAAAAAAAAAAAAAAAAAACWXqQ+tE3+vgAA"
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAqtDLvgAAAAAAAAAAAAAAAJ3yOT7esL4+EFXL"
+    "PgAAAAAAAAAAAAAAAAAAAAATKq8+YAfwPms+Zj52ejI+7uKBvgAAAAAAAAAAD/4yvwAAAAAAAAAA"
+    "hKUOPwAAAABxZgC/AAAAAAAAAAAAAAAAlHCqvgAAAAChiQm/AAAAAAAAAACUIC+/AAAAAMNxqT60"
+    "0bU+2/RgPh0KNL7wklu+AAAAAHpUsD6Nn1g/AAAAAJNDBr8AAAAAbzGFPn7dSz6+mqU+z4KIvgAA"
+    "AAAXnVw+AAAAAAAAAAAAAAAAAAAAAAAAAABrl40+94/DvgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    "AH9MtD7hDsS+AAAAAOXbsr4AAAAAAAAAAPA4o74AAAAAP7mBPqrxtT4AAAAAAAAAAAAAAAAAAAAA"
+    "AAAAABKyGj8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABhYkW+AAAAAAAAAACDfgu/AAAAAAAAAAAA"
+    "AAAAAAAAAAAAAAAht7O+AAAAAAaGVD87fQM+10ePvpkhOT4hsZg++1JoPgAAAAAAAAAAAAAAAJbI"
+    "eD8W2xG/AAAAAAAAAAAAAAAAAAAAAKzvrj7+j8C+AAAAAJmMl76d8z4+bAEQP8glmr4AAAAAAAAA"
+    "AMv2k74AAAAAAAAAAOfWxb4AAAAA8xuQvpXPJr8AAAAAAAAAAAAAAAAAAAAAAAAAAH7lIz6vf8G+"
+    "pQDsPk8zjT6B9rk+XrpivgAAAAAAAAAAm/nQvgAAAAAAAAAAxcYaPgAAAABifaU+AAAAAAAAAAAB"
+    "qXk+AAAAAAAAAABe3n0+AAAAAAAAAABR+OC+AAAAADaLBr9EHD++KmwIGBABQgRCcWt2SmDTaSC8"
+    "A3L4PVo5UrxTSBs9GGXmvPNCfLzfX6i9lTJdPeKj5jzPjCI9W9+bPFCNcLsQTfw8RbFVuwfhlT0K"
+    "Vug8tHyQvPAIbb0/OhW8g3FivcMbsDwAW3K7zSyqveg1bz1aHwoBWBIaChgIARIUCgcSBWJhdGNo"
+    "CgUSA3NlcQoCCBBiHwoBWRIaChgIARIUCgcSBWJhdGNoCgUSA3NlcQoCCAhCBAoAEBVCEQoNY29t"
+    "Lm1pY3Jvc29mdBAB"
+)
+
+_GOLDEN_MULTIPLE_LAYERS_SHARING_INPUT = (
+    "CAo6nScKFAoBWAoCV3ESAVEiBk1hdE11bDoAChQKAVgKAldrEgFLIgZNYXRNdWw6AAoUCgFYCgJX"
+    "dhIBViIGTWF0TXVsOgASAWcqzQwIFAgUEAFCAldxSsAMXy6VvgAAAACPO78+QE8GPwAAAADW8MY+"
+    "Lh4uvgAAAACuz6Q+AAAAAJ82Nj+bq0K/AAAAAGAEeb4AAAAAAAAAAI3V9r6X2q0+irW9vhs5MD62"
+    "aZY+7/utvhDkrD4AAAAAAAAAAKNrez6sTPU+DU7TPgAAAAAAAAAA/jIxvreLaj4AAAAABo4ovvPg"
+    "Vb5Zhpi+Mw5svjXG6T2WH4y+hb+uvhQrX74NZp2+rFKevrYQiT4sCw8/AAAAAE/K2D0AAAAAhzsi"
+    "Pj6MtL4AAAAA07TdPneanL4AAAAAAAAAAP1lkb4iS1M+Kx/NvVoj1T4AAAAAThE8vgAAAAA8qbe+"
+    "AsdTPgAAAAAINvg+AAAAAAAAAADSlxc+dDPLvnM9WT4AAAAAeVtivgAAAAAAAAAAAAAAANIEKj6V"
+    "dA8+iTy7PgAAAAAAAAAAAAAAAAAAAAB4qD++x9C+vuMdu754c74+AAAAAIdKwz4AAAAAAAAAAIdX"
+    "7z4VZMA+4GkgP6amur7xz0m+AAAAAOhwHL8AAAAAba2bvrx1ab5rG8W+zMuWPgAAAAB9reW+hwYN"
+    "v1qNjz5llos+AAAAAFWGBT8AAAAAAAAAAC5HVz6bmCS+KHSavkJNhz4AAAAAAAAAABy7rz4AAAAA"
+    "EQTAvgAAAAAAAAAAAAAAAAAAAADvItU+AAAAAKDSDT87SIk+AAAAAHEI9D6UavI+AAAAAOfbNr4A"
+    "AAAAAAAAAOMkw76sikY/VGesvqRbrz4AAAAAAAAAAAAAAAAAAAAAAIf4vvHb675ybsU+AAAAAHqW"
+    "9T4AAAAAAAAAAAAAAAAAAAAAUtO6vgAAAADMfoA+xrZdPsgxLL4VM5Q+AAAAAAAAAABJtmq/AAAA"
+    "AAAAAACDQYG+qXFmPjKkG78AAAAAAAAAAP4HrD5/S4a+AAAAAISCX74AAAAAAAAAAAAAAAAAAAAA"
+    "AAAAAKjEvD599sq+qmI9Pk+ay77nI32+unKkvqFFez4FMYm+qFcbPwAAAAACtm0+AAAAAOGojD6T"
+    "+rW+2LMBPgAAAAC34ic/X2Gcvsxdfr9thf0+AAAAADiSbr6pIVI+AAAAAAAAAABhjhG/AAAAAAAA"
+    "AACu2gW/u8KAvgAAAACiFJG+1y87vhxe1D4AAAAAX/C4Pg7nUT5Az/O+AAAAAAAAAABTSCm/OdFi"
+    "vjGow77G6x0/f6CrvgAAAAAAAAAAAAAAAAAAAABQvqa+AAAAAAS4Hz8mezA+9deXPnvFx75BrVs+"
+    "nO1BvgAAAAAAAAAA1toJPy+eAr8G9Rk/+uXLvgAAAADeViq/fKQcv+muAT8AAAAA4ol7vtC1JD/6"
+    "LpS+AAAAAL7Hij7h58Q9cKgDPgAAAAAAAAAAQbyUvkJy3D4AAAAAAAAAACgLhj4AAAAAy1oAv2ZO"
+    "J78AAAAAsUNgPgAAAAAAAAAAvBQJvocp3T2hgew+AAAAAAm+yz4AAAAAAAAAAPBcwr4AAAAAWSU/"
+    "PilU3r0AAAAAAAAAAC1k3b4oUxC/N1HDPpfutL6N8qU+ZPa8vgAAAAAx0YS+nFmePlBNUz4AAAAA"
+    "AAAAAFrlbr4AAAAAWbiYvgAAAAAAAAAA8XJ5vgAAAAAAAAAAAAAAAAAAAAAAAAAAYeijvlcMa74A"
+    "AAAAgblfPvuxmj4AAAAAdF4wvgAAAAAAAAAAZ68oPyCaRz7DGtY+AAAAAAAAAAAAAAAA5feTPgAA"
+    "AAAAAAAAnB5aPgAAAAAAAAAAj1E3P5TFrL4AAAAAof5GvnhmMT4AAAAAe/6UvtrvAL4AAAAAzzXN"
+    "vgfL9L2A3c2+WG0Jv7n4wD6fukC/90cYPwAAAADxuZG+BcV+PpYlDD8AAAAAAAAAAAAAAAD0CZU+"
+    "NtKzvURuOr7OmRS+AAAAAF28174AAAAAomK0PiVDQz9FJMG+AAAAAAAAAACqpgq/AAAAAAuZbr4A"
+    "AAAAKplXvrtH2z4AAAAAlL2lvgAAAAAAAAAA/2YfPpxOGz9pGQu+a0Tqvg5dpz6d4ZQ+pLyyPqRJ"
+    "rL4AAAAAAAAAAAAAAACk5hW+OGTjPl/Qxz4zE52+AAAAAHFHsD4AAAAAfqWhvgAAAAA8ZlE+AAAA"
+    "AAAAAAAAAAAA/xDNvgAAAADA73k+AAAAAAAAAAAAAAAAGTN/virNDAgUCBQQAUICV2tKwAwAAAAA"
+    "g1GKvgAAAADvTpI+/hGHvlczrT4w8w8/2MZUPgAAAAAAAAAAAAAAAAAAAABEKbI+vNgyPk7tkL7r"
+    "/1m+AAAAANbYMD4AAAAAXraDPgAAAAD0krw+EgZCvwAAAAB3Dge/8UUCPwAAAAAAAAAALPybvnL1"
+    "c75I5Yu+ZPOnPnErgL7H1Nc+kNKovmX4QD71zKw+AAAAAGOoND63Bfm+CewHP+jbtr5eja09Czcr"
+    "PgAAAAAAAAAAAAAAAAAAAAAN/sm+49qXvn7CPr5d+c6+su9fPipYWL58Tbs+AAAAAL8zoj7CzKm+"
+    "NgigvjtB6j1yiL++0KVNPn8bWz4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADeJoq+AAAAAAAAAAAA"
+    "AAAAAAAAAAcCgD4AAAAAQCP7vom2V76bhdI+AAAAAHGkTj8AKjk+AAAAAAAAAADsnpa+sRAdPwAA"
+    "AABKXc4+1HANvwAAAAARgfM+AAAAAAAAAAAAAAAAAAAAAAAAAACpM3++AAAAAAAAAACF45A+AAAA"
+    "AJ9ZIz50DpG+AAAAAFroHb8AAAAAAAAAAAAAAAAAAAAALpQ0PwAAAAAAAAAAAAAAAAAAAABUioA+"
+    "Os5lvseFab4Lid8+AAAAAAAAAADLEOU+AAAAAFf1777RPVE+AAAAAA+V6L6Pyvc+uyzRPndGhD6N"
+    "vGI+I0cVP0VwhD4AAAAAAAAAACsJ774+iyk+AAAAAAAAAACtod2+AAAAAAAAAAAAAAAAAAAAAAAA"
+    "AACAlcm+SvWjPgAAAAD77Ce+kM2xPgAAAAAAAAAAyYKZPmlZ8z4AAAAAAAAAAAAAAAAsYKK+AAAA"
+    "AJjpYb6npVW+CBegPuD4GD8AAAAAfktcvgAAAABmrm8+/MYNPj393b3Rvrc+KjGLPgAAAAAAAAAA"
+    "TP/lvgAAAAAAAAAADscgPk1SBT8AAAAAAAAAAHgZqD547/C+168VPgAAAAAAAAAAAAAAAAAAAABx"
+    "9z++Rm/6PQ0n7j4AAAAAy+psPrsHKD8AAAAArQMivozylL5Z9R0+AAAAALU4oj4AAAAAp94OPgAA"
+    "AACUPMC+tzKCvgU6Cb4JTwq/eispvu0sCr/ZT5m+AAAAAAAAAAAAAAAAFHCKvsZYzz67/JO+AAAA"
+    "AAAAAAAAAAAAqG8YPg4ZPz6/2t6+AAAAAAAAAAAAAAAAAAAAAI05jb4AWSy+lBSrvgAAAAAVk6K+"
+    "cSm5viJAgr4AAAAA4CpVPjwSur67tVs+sHc0PgAAAADkEAa/+FS4vgAAAABde/u+AAAAAGMCiz7z"
+    "V+u+AAAAAAAAAADyf4y+T1RbPl4r8j4AAAAAAAAAAAAAAAAAAAAADfbqPhpDQr7ETcG+AAAAABrH"
+    "Tr4AAAAA79KEvrRL174AAAAA4AADvwAAAABaj58+AAAAAKJoeL4eDzU+OSGMPsH4pb4EwV4+NKZk"
+    "vo8DC78pSUY+C6kivwAAAAB+ZdG+AAAAAPbqAL4AAAAAEZaOPgAAAACSoOs+RQD9vlJVqz4AAAAA"
+    "XqH0PgAAAADYaK6+kxgPv4fTKb8PiY6+AAAAAGU8kz4AAAAAQnPfvgAAAAAAAAAA59yCvjx3Ur7O"
+    "HZC+V5xkPn9x6r5BzdG9Vn4nP6N6tL4AAAAAsopVvgAAAAAM4dC+eRgUv6b1mz7amZC+wY6KPgAA"
+    "AABJQt4+AAAAAIit2T52L2M+igg1vgAAAAAAAAAAhdy1Pt0Zgj7uAoY+AAAAAFy6Ur5Bmg8/AAAA"
+    "AAAAAADcONw+AAAAAAMFqD4AAAAAuVBgvgAAAADxGnq+BZiwPqNm274AAAAAAAAAAL6wd74AAAAA"
+    "DCmLPgAAAAABNz4+AAAAAAAAAAAAAAAA5e7LPuoDd77KTOA+OnWTvgAAAAAAAAAAAAAAAGz/Sr5I"
+    "bO89AAAAAAAAAAAvTTy/xKh9PgAAAAAOMhO/xD2uvu++xj6BWlc/AAAAAAAAAABD8GQ+FfC/Pv1A"
+    "Aj8AAAAAkn+CvgAAAABLRxY+zxdbPon17T4AAAAAAAAAAClivD4AAAAANK1fviI4I74AAAAAr3on"
+    "v/fQsT7RJwW+07S2vgAAAAAAAAAAxf5fvutKc747rm0+OY29vnR8b76l5Ta/AAAAAEQPLD49kmY+"
+    "Ks0MCBQIFBABQgJXdkrADAAAAADsijQ/4HsJPwAAAABpXLg+ThZuPkcokj7E4Mi+AAAAAAAAAACG"
+    "4Ss+8ay1vgAAAABvNl6+AAAAAAhTuz4AAAAAtBEevoFfIj788gm+XJr9vXxcbL4AAAAAOj6jvgAA"
+    "AADbP4U/MyGNPmFefL4AAAAA6auXPgAAAACCyBK+KSqivoflyb4AAAAAyKR/vgAAAAAAAAAAvweS"
+    "PgAAAAAAAAAAatmSvgAAAAAAAAAAL+xSvti/Hj6sAx++2L4Zvn9Sh77d3+++AAAAAEb3+T4AAAAA"
+    "NmALvgk3zb68CiA+Cf/KvYHIjb4Ie/a+AAAAAFVkA74AAAAAAAAAAAA3Qb4AAAAAAAAAACt30D4A"
+    "AAAA1MiFvmWtbj4AAAAAdIgvP3k5tb4Gwyq/AAAAAP7Jbb4AAAAALmXcPgAAAAAAAAAAJ64Iv4B5"
+    "fr7GNX++Wu45vgAAAABCwIC+sp1dvgAAAADSIlU+AAAAAAAAAAAAAAAAEqFCvwAAAABVzEE+AAAA"
+    "AAAAAAB6p2q+I34Sv74XTr4AAAAAAAAAANIThj6fHVG/3u2VvgAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    "e0ZsPgAAAADICwK/Y2CbvgAAAAAAAAAAw0iAPo+Y7D5d62c+AAAAAIauiL6LvkA+X4hVvuGO577c"
+    "EX6+uZjfPoCSWz4AAAAAdq0zP2SYJT9qSjc+w4ggPzEmOr4AAAAAlbpGvgAAAAAAAAAAwnGqvrY8"
+    "bD8AAAAA2P87PwAAAAAGCLA+ADrtPgAAAAAAAAAAAAAAAK8kSj4AAAAAAAAAAMDqfj6KQqU+oaYV"
+    "vzsgGT4AAAAAKZhYvtzP7j6tgDY+AAAAAL3e8D4AAAAAAAAAAAAAAACdkic+AAAAANpPVr4AAAAA"
+    "irdRPjfxDr9C67O+AAAAAAAAAACsYWq+AAAAAAfDOL4AAAAAAAAAAAAAAAAAAAAAAAAAAH1pi74A"
+    "AAAAZgUIP8v9Bj/s/6E+AAAAAGxih77xk1E+6y19PgAAAADSGIc/a6vjvgAAAAAh0z8+TUnqPgAA"
+    "AAAAAAAAAAAAAAAAAACz9gI/9JAWPs1PXL4AAAAAAAAAAMBjEr9qvSq/AAAAAKShAj8AAAAAAAAA"
+    "AGbOgb46Gq2+cJSXvgAAAAAVWkS+I6suPh9Kpb7ZWPm+/fLgvs1Mxr4AAAAAoeojvhs+Mb4nvXi/"
+    "AAAAAAAAAAAAAAAAT78kv2AUrT7hhWY+GFEzvwFHnD68L2u+AAAAAJVw474AAAAA/FY+PgAAAAAA"
+    "AAAA603RvsA7Pz7yEw+/AAAAAHbpUD6L7nA+AAAAAL8X3j7buTI+AAAAAA402r4AAAAAAAAAAAAA"
+    "AABWS7o+vG0svwAAAAA7fVi+enjGvtePmb4AAAAAB26MPgAAAACba/C9AAAAANmViz5iqhe/DP1n"
+    "vggaiT4AAAAAOk5ivgAAAAAAAAAAAAAAAJTqMr6bRc2+Hi+vvgAAAAA/W6Y+AAAAAGjaPb4zL7s+"
+    "V7kKPwAAAAAAAAAAAAAAAAAAAAB1khK/AAAAAG1Ch76e0p8+AAAAAB8JiD71CWO/AAAAAGqy174D"
+    "G2U+LaYFvwAAAAAAAAAAqsCmvgAAAAC9r46+oZsSvgAAAADV8UW+2QETP26lmj4AAAAATrqsvltm"
+    "Rb6S+Dm+AAAAAHadJz6lD+O+AAAAAGM1dL66ODo+AAAAAEhSKD8G8mS+AAAAAAAAAAA34hA/AAAA"
+    "AAAAAABDPzO+GAFGPid1yL4AAAAAAAAAAGCo0D5PkV2+AAAAAAAAAAAAAAAArxNMP64+vD7bpYe+"
+    "2RWKvnhxVD6vTqC+wjddvqI3Bj/p5BU+LVO1PoIUSj8AAAAAAAAAANwwZb7PW3Y+DSKJvhqTrL4A"
+    "AAAAzuMgv8H4ST9WtK8+3RKRvgAAAACdp0m/AAAAANnAOD7FoAc+AAAAAAAAAABX27q+dF9DvwAA"
+    "AADl1x6/3ShXPoKRYb43sCU+AAAAAAAAAABLlSi+yCiavgAAAADgLBu+/XaIvgAAAADrChy+AAAA"
+    "AAAAAABSug0+70AiPr+/gD8AAAAAAAAAAAAAAABCJSu+AAAAAJlPoT4AAAAAZqkiPwAAAAAAAAAA"
+    "HFa6Pie6N74AAAAA1Y4hPsLp6D5aGAoBWBITChEIARINCgcSBWJhdGNoCgIIFGIYCgFREhMKEQgB"
+    "Eg0KBxIFYmF0Y2gKAggUYhgKAUsSEwoRCAESDQoHEgViYXRjaAoCCBRiGAoBVhITChEIARINCgcS"
+    "BWJhdGNoCgIIFEIECgAQFQ=="
+)
+
+_GOLDEN_GLOBAL_SPARSITY = (
+    "CAo6vwUKFgoCWDEKAlcxEgJZMSIGTWF0TXVsOgAKFgoCWDIKAlcyEgJZMiIGTWF0TXVsOgASAWcq"
+    "zQIIFAgEEAFCAlcxSsACAAAAAAAAAAAAAAAAAAAAAGm/Mz8Jczu/AAAAAAAAAAAAAAAAAAAAAAAA"
+    "AAB2MUI/vvMOvwAAAADuSgU/AAAAAJfGQj8AAAAAAAAAAAAAAAAAAAAA2N8OPwAAAAAAAAAAdlk/"
+    "PwAAAAAAAAAAAAAAAIrjTr8AAAAAAAAAAAAAAABZalm/AAAAAAAAAADagSA/AAAAAAAAAAAAAAAA"
+    "AAAAAAAAAADIoSs/AAAAAAAAAACX0C6/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHuFQj+X"
+    "mgy/AAAAAAAAAAD4uSm/AAAAAAAAAABmiY4/AAAAAAAAAADqxwO/r54aPwAAAAA1eiS/AAAAAAAA"
+    "AAAAAAAAM9YjvzVoKD8AAAAA0PNJvzrv3L4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAqzQEICAgG"
+    "EAFCAlcySsABDZwSwFwtXr8AAAAA4cQJwNZlaEAAAAAAnjsjQOrK6T+tI5tAaIKWv5lnRj8AAAAA"
+    "KEtIv/puEUDpOw9AzgU/vwXpnD8v2iTAENjoP3gEvr9CC6q/JuZSQJ+rab+kyg8/PMENQAAAAAAA"
+    "AAAAaaW5vwAAAACVc9M/AAAAAAoUJ8DHzt6/iWQfQBRgNcDjLXo/6vv7Pqbg0D/DceA/vptBP76j"
+    "QL+2S1jAL3fBP8LItb+OVCi/zYRBPwAAAAA8DsK/WhkKAlgxEhMKEQgBEg0KBxIFYmF0Y2gKAggU"
+    "WhkKAlgyEhMKEQgBEg0KBxIFYmF0Y2gKAggIYhkKAlkxEhMKEQgBEg0KBxIFYmF0Y2gKAggEYhkK"
+    "AlkyEhMKEQgBEg0KBxIFYmF0Y2gKAggGQgQKABAV"
+)
+
+_GOLDEN_CONV_ORDINARY_GROUP1 = (
+    "CAo69w4KWwoBWAoBVxIBWSIEQ29udioVCgxrZXJuZWxfc2hhcGVAA0ADoAEHKhEKBHBhZHNAAUAB"
+    "QAFAAaABByoQCgdzdHJpZGVzQAFAAaABByoMCgVncm91cBgBoAECOgASAWcq0A0ICAgGCAMIAxAB"
+    "QgFXSsANAAAAAAAAAAAAAAAAAAAAAIKnzz4AAAAAAAAAAMskGL+DDp++AAAAABsw7D4tKVq/AAAA"
+    "AAAAAAAAAAAAX61EvwAAAAAAAAAAAAAAACdgwD4AAAAAAAAAAA4bBL8AAAAAAAAAAAAAAAAcHJ0/"
+    "AAAAAMk4lz4AAAAAIk6sPsRSlj6X5li/AAAAAJ/WKL8WsSC/4APkPgAAAACLb/i+UfwEvwAAAAAn"
+    "Fke/xRsiP4NUoD6aedw+W5QIPwBezj5gYBE/AAAAAAAAAACKc56+G/1LPwAAAAAAAAAAAAAAAAAA"
+    "AAAAAAAAai+qvqjf1r5Ye9Q+AAAAAAAAAAAAAAAAAAAAAAAAAABde6s+AAAAAE3e2b7xgbK+AAAA"
+    "AG210b6BvgY/AAAAAD4FLj8AAAAAAAAAAMhEaj9pgBW/AAAAADRHyL4AAAAAAAAAAICeyz532eQ+"
+    "AAAAAAAAAAAPhhC/AAAAAFOOIr+p5x4/i81RvwAAAAAAAAAArVXMvut4XD8AAAAA30FkPwAAAAAA"
+    "AAAA0zFivwAAAAAAAAAAJsyvvs9zn75fD/q+AAAAAERjlr6RfYk/F1axvgAAAAAAAAAAAAAAAAAA"
+    "AAALjwO/s6fAvp34+77mwji/D9CVPgAAAACa+pK/AAAAAC//6T4AAAAAAAAAAAAAAAAAAAAAs2nd"
+    "vjDwoL4AAAAAHbe0PgAAAAAbW0i/AAAAAAAAAAAAAAAAAAAAALqS1j4AAAAAAAAAAAAAAAAAAAAA"
+    "8osTv0xWjL8AAAAAh/kSPwB/V79XXEO/d8TzvgAAAAAAAAAADyYuvwAAAABcF8o+Kz3qvnnovD4S"
+    "/+W+4Y2KvgAAAAAAAAAAV3BTvxVEwz4AAAAAK6cKP18KAL+ApgM/AAAAADM0ZT/wh+C+ZAGevgAA"
+    "AABy7uO+PUiaPgAAAADdyF6/AAAAAAAAAAAAAAAAZWrLvgAAAAAAAAAAAAAAAAAAAABKcca+5Ve2"
+    "PgAAAABgw+s+rU6IvwAAAAAAAAAAAAAAAKDxub6h05c+AAAAAAAAAAB2h64+QbKgPgAAAAAAAAAA"
+    "AAAAADHehj4AAAAAJZvZvgAAAACDXB+/AAAAAAAAAAAAAAAAAAAAACjNlr4CtTc/X6YEvwAAAADt"
+    "iJo+M4qXvgAAAAAtrbk+AAAAAAAAAABhF6O+AAAAAD0Gcz98C5a+AAAAAHp+Aj+PBNW+AAAAAAAA"
+    "AAAAAAAAcod5vlA9RD8AAAAA9jKFPgAAAAAHMDU/oqEJvz8OIr8AAAAAJxiwvgAAAAAAAAAAAAAA"
+    "AJIH374AAAAAAAAAAP9K/b4AAAAAAAAAAIMtMj/7GKk+AAAAAAAAAAAAAAAAAAAAAFVk/D5bPkK/"
+    "z8yzPgAAAAAAAAAAe8n7vgAAAAAAAAAAQj+WPrYYsz66Qs++QoPoPmJ6e74AAAAAGkRpvwAAAAC/"
+    "b96+AAAAAAAAAAAAAAAAAAAAAJuqE7+rwIG+L84+v+y8ML90LEc/AAAAAJomoD4AAAAALe2fPuhv"
+    "UL8vEHg+qSggP+UYBj8AAAAAlTbOPlB0rL4UnRg//86svmsHRL8AAAAAuuv1vgAAAAAAAAAAAAAA"
+    "AAAAAAA/cce+k/JJPwAAAABgzNk+AAAAACsxQL8AAAAAAAAAAAAAAAC3NJ6+AAAAAAAAAAAAAAAA"
+    "AAAAAAAAAAAAAAAA3M0wv37ksD6tCzM/AAAAAHaKk74AAAAAfnqiPgAAAAAAAAAAAAAAANd6Dz/P"
+    "NSq/AAAAAAAAAADfgzM/6VkqPxulCz8AAAAAAAAAAAAAAAAAAAAA61v1vs3dJT8AAAAAj3oCvy8I"
+    "uD5fTPQ+2RYov3RxEz8AAAAAUtwmvwAAAAC1lP6+0BzPPgAAAAAAAAAAqpTlvls/y77L69w+iy7j"
+    "PgAAAACLR+Q+AAAAAAAAAAAAAAAAcgpgPxY4ID8AAAAAz2KzvgAAAAAAAAAAAAAAAKcPCD8AAAAA"
+    "AAAAAAAAAAB3pME+AAAAAAAAAAAAAAAAw+DCPgWgAr8AAAAAAAAAAHvAqz7P2vK+AAAAAChU6T5a"
+    "MKM+NzMDPwAAAAAAAAAAW2sCP7Un674AAAAAAAAAACi90b4AAAAA+airvgAAAAAkEwu/MFbivoPK"
+    "r74AAAAAAAAAAG/5Nb8AAAAAAAAAAAAAAAAAAAAAu9G2PoZ4CL9YiSI/AAAAAAAAAADTot++AAAA"
+    "AAAAAAAAAAAAYwojv3cANL9d+0M/AAAAAAAAAAAAAAAABxs1PwAAAAAiJJG/Z6bJvgAAAACuk0C/"
+    "AAAAAKU32T5wUM6+AAAAAAAAAADtrfc+Wh8KAVgSGgoYCAESFAoEEgJOYgoCCAYKAxIBSAoDEgFX"
+    "YiEKAVkSHAoaCAESFgoEEgJOYgoCCAgKBBICSDIKBBICVzJCBAoAEBU="
+)
+
+_GOLDEN_CONV_FULLY_DEPTHWISE = (
+    "CAo61wMKWwoBWAoBVxIBWSIEQ29udioVCgxrZXJuZWxfc2hhcGVAA0ADoAEHKhEKBHBhZHNAAUAB"
+    "QAFAAaABByoQCgdzdHJpZGVzQAFAAaABByoMCgVncm91cBgIoAECOgASAWcqsAIICAgBCAMIAxAB"
+    "QgFXSqACdYZFPwAAAABaJFS/+wukvtPVMD8AAAAAAAAAAAAAAAAAAAAAbSXNPgAAAAD7uQY/AAAA"
+    "AAAAAAAAAAAAAAAAACI1Uz9zJCy/XDAevwAAAACVsec+AAAAAAAAAAAAAAAA/rsRvyCX+b4AAAAA"
+    "AAAAAAAAAAAAAAAAioQFPwAAAAAYBA4/AAAAAAMFZz/V8xW/EChcvwAAAAAAAAAAAAAAANS/sD7G"
+    "cRu/AAAAAPgVhD8AAAAAHx8zPwAAAAAAAAAAB2fhvgAAAAACbiW/I6AnPwAAAAAAAAAA3OfDPpd+"
+    "zL4AAAAAAAAAAIdl4T4AAAAAZ4AXPwAAAAAAAAAAkxEZPwAAAAAAAAAA/ax7vwAAAAAAAAAAAAAA"
+    "AA3r6T5jHWY/Wh8KAVgSGgoYCAESFAoEEgJOYgoCCAgKAxIBSAoDEgFXYiEKAVkSHAoaCAESFgoE"
+    "EgJOYgoCCAgKBBICSDIKBBICVzJCBAoAEBU="
+)
+
+_GOLDEN_CONV_GENERAL_GROUPED = (
+    "CAo6lwgKWwoBWAoBVxIBWSIEQ29udioVCgxrZXJuZWxfc2hhcGVAA0ADoAEHKhEKBHBhZHNAAUAB"
+    "QAFAAaABByoQCgdzdHJpZGVzQAFAAaABByoMCgVncm91cBgEoAECOgASAWcq8AYIDAgCCAMIAxAB"
+    "QgFXSuAGKoU5PwAAAAAYVt6+AAAAAAoN7L40cRo/HzS0PgAAAADuXhA/AAAAAB6RBr8AAAAAAAAA"
+    "AAI2r74AAAAAkL0WPwAAAAAAAAAAAAAAAAAAAACqfdE+AAAAAD1TDz//8KW+AAAAAMHgpz4AAAAA"
+    "AAAAAAAAAAAAAAAAAAAAAOf0cj5uFg4/d7s2v7spar9nNJo+fxajvgwhFT8P6pI/AAAAACogHb4A"
+    "AAAAAAAAAAAAAADTGLm+AAAAACLCTr8AAAAAAAAAAMT2BT8AAAAAVs5GPvLPwb4AAAAA0CCfPtAa"
+    "0T4AAAAAKVgiP+ybAj8AAAAA8rB8v83H4L4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABw11m/AAAA"
+    "AFV/0D5WQa6+zgCDPgAAAAAAAAAAAAAAAMTou74AAAAAE6AZPwAAAAAnwuG+1+MVP+BoC79hLSk/"
+    "AAAAAP8ofT4AAAAAAAAAAMjc3D4AAAAAYmenvgAAAACrqzK/AAAAAAZrNb8AAAAA2mSVPgAAAAAA"
+    "AAAA+uqJvwAAAAA0iAM/AAAAAAAAAADIzYS+kosjP2quVb8AAAAAAAAAAAAAAAAAAAAAAAAAAEj7"
+    "aL93eUw/AAAAAKYtgL53sA4/UybjvgAAAAA1Ac8+e7agPgAAAAAAAAAAsTHLvgAAAADEqwG/f/nc"
+    "PoGftD4AAAAAw+dBvwAAAAAAAAAAGjPYvgAAAAAAAAAAAAAAAAAAAAAicaO+AAAAAA/zwb5fiDc/"
+    "NOI9P+jjTr8AAAAAFnEhP4vlED9xiEo/VBcCPwAAAAAAAAAAMhsQPwAAAADRbCa/AAAAAMkcNL+J"
+    "r6s+AAAAAAAAAAAAAAAAlsAuvwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPkiDb+DAfq+5+bnPlf8"
+    "q74AAAAAieGkPgAAAABIcF4/cfa6vgAAAACya06/lKSsPgAAAAAAAAAAAAAAAFP8eT8AAAAAAAAA"
+    "AAAAAAAAAAAAx4pCvwAAAABXAh2/Y1XFvue+9T6IHLq+AAAAAMfTqz48hx2/AAAAAF9u9b4AAAAA"
+    "AAAAAPP1zj4AAAAAAAAAAF7YEz8AAAAAuWkJP+WQkz7fC78+U8KRvgAAAAAAAAAAKMqaPj2F6T4A"
+    "IdI+AAAAAAAAAAAAAAAAWh8KAVgSGgoYCAESFAoEEgJOYgoCCAgKAxIBSAoDEgFXYiEKAVkSHAoa"
+    "CAESFgoEEgJOYgoCCAwKBBICSDIKBBICVzJCBAoAEBU="
+)
+
+_GOLDEN_CONV_GENERAL_GROUPED_NM = (
+    "CAo6lwgKWwoBWAoBVxIBWSIEQ29udioVCgxrZXJuZWxfc2hhcGVAA0ADoAEHKhEKBHBhZHNAAUAB"
+    "QAFAAaABByoQCgdzdHJpZGVzQAFAAaABByoMCgVncm91cBgEoAECOgASAWcq8AYIDAgCCAMIAxAB"
+    "QgFXSuAGAAAAAAAAAACgD8E+9WInPxOPwL46smY/AAAAAAAAAAAUm7C+AAAAAAAAAABY0xq/g2ZR"
+    "vwAAAAAAAAAAgLMfP8V/WT8AAAAA3zoRPwAAAAA3yks/AAAAAOfINb84QHK+AAAAAAAAAAAAAAAA"
+    "BN9FvwAAAAAZU5c/AAAAAJNwmr4AAAAAvCEKvxljmz4AAAAAAAAAACJ26j67xk8/AAAAAAAAAAAI"
+    "fkG/33HePgAAAAArRkU+AAAAAAAAAAD12dw+mnaBvQAAAABPv/C9AAAAADaypz4AAAAAOPJTvtDJ"
+    "mb4AAAAAAAAAAAAAAAAAAAAAOHqnPi9ejb6yUnC+X4O+PgAAAAAAAAAAbKULvwAAAAAQmm0/AAAA"
+    "AAAAAABbcvU92t7Vvtt3tr4AAAAAAAAAABhoYb+HiGg/AAAAAAAAAADlMXe/y2QBvwAAAAAAAAAA"
+    "11INv6UAIL8AAAAAAAAAAAAAAADHaro+AAAAAAVsIT+V1XQ+AAAAAEecsL6g/9k+AAAAAAAAAAAq"
+    "6Ac/AAAAAL7ajD4AAAAAAAAAANqh3b4AAAAAF6APP9YFAT4AAAAAAAAAAAAAAADrDCk/ap7VPrvf"
+    "qD0AAAAAWPOfPgAAAAAnBck+AAAAAOot3j4AAAAAj+/XvqxSJD8AAAAAAAAAAAAAAAAojlU+AAAA"
+    "AAAAAAAKhfe+zyf2vu5ZiL4yUH8+AAAAAAAAAADbE6A+AAAAAAAAAACN94e+AAAAAHDYWr4AAAAA"
+    "GyCuvlW+K74AAAAAeDkgvrhyTj4AAAAAAAAAAAAAAAAAAAAARF8CP3AWHL8AAAAAPwoHP4oUID8A"
+    "AAAAYLazPg4VwD4AAAAAAAAAAPMgwj4AAAAAAAAAAMD8/z0AAAAAphkRPxmAk74AAAAAQ8afPgAA"
+    "AAATVa6+AAAAAAAAAABYb+A+E9fUvko8Rr4AAAAAAAAAAADNZT4AAAAAAAAAAG8S7b4AAAAAu3go"
+    "P0cMDj8AAAAAtvDAvgAAAAAfx8A+794evwAAAAAAAAAAO/VBvwAAAAAAAAAACkJePwAAAAABE4E+"
+    "AAAAAFxmKz8AAAAAWqBSPhVcT77DQyC/AAAAAAAAAABM84S+v8WzvgAAAAAAAAAAAAAAAEJRiD8A"
+    "AAAAiBPwPgAAAADHfyQ/Wh8KAVgSGgoYCAESFAoEEgJOYgoCCAgKAxIBSAoDEgFXYiEKAVkSHAoa"
+    "CAESFgoEEgJOYgoCCAwKBBICSDIKBBICVzJCBAoAEBU="
+)
+
+_GOLDEN_CONV_DEPTHWISE_FLOAT16 = (
+    "CAo6iQIKSQoBWAoBVxIBWSIEQ29udioVCgxrZXJuZWxfc2hhcGVAA0ADoAEHKhEKBHBhZHNAAUAB"
+    "QAFAAaABByoMCgVncm91cBgGoAECOgASAWcqewgGCAEIAwgDEApCAVdKbAQ2AAAvOwQ3AAAAAAAA"
+    "AAArugAAMbgAAAAAEzcAAJA58zUAAAAAAABZO8u1AADdtgAALDgAAKU1SDcAAFy1AAAAAAAAVboA"
+    "AAAAAAAAAI+4SjV7NwAAAABUuDA5AAAAAJw6AAAIugAAAAAXOlodCgFYEhgKFggKEhIKBBICTmIK"
+    "AggGCgIICgoCCApiHQoBWRIYChYIChISCgQSAk5iCgIIBgoCCAoKAggKQgQKABAV"
+)
+
+_GOLDEN_MATMUL_FLOAT16 = (
+    "CAo62wEKEwoBWAoBVxIBWSIGTWF0TXVsOgASAWcqjAEIEAgEEApCAVdKgAGJtDq4QDiEuB67AAC7"
+    "Npi3hrSPPRK4AAC3OPc1cjoAAAAAAABntAAAAADsuAAAAAAAAAAAAAAxvQAAsbmwOLu4JbSutQAA"
+    "PTgAAAAAAAAAAAAAAAAAAOM5eDjSugAAAAAAAAAAAAAQOFY4AADeNgAAnzIAAA26AAAAAMQ4AAA1"
+    "PFoYCgFYEhMKEQgKEg0KBxIFYmF0Y2gKAggQYhgKAVkSEwoRCAoSDQoHEgViYXRjaAoCCARCBAoA"
+    "EBU="
+)
+
+_GOLDEN_MATMUL_BFLOAT16 = (
+    "CAo62wEKEwoBWAoBVxIBWSIGTWF0TXVsOgASAWcqjAEIEAgEEBBCAVdKgAEDvz2/AAAAAAAAAAAA"
+    "AIS/Gb8AAAe/AAAtPwa/AAAAAAAAAAB4Psy+xj8AALg+AABFv5M+AADxPgAAAADKvgAAAAAAAAAA"
+    "Ij8AAAAAQT8AAIk/AACGPgAAAADgPgAAXL8AAMe+AACGvwAAeT4AAAAAIj9DP90+Az8TPxe/jb8D"
+    "v1oYCgFYEhMKEQgQEg0KBxIFYmF0Y2gKAggQYhgKAVkSEwoRCBASDQoHEgViYXRjaAoCCARCBAoA"
+    "EBU="
+)
+
+_GOLDEN_ATTENTION_MERGED_QKV_FLOAT16 = (
+    "CAo63gcKRwoBWAoEV3FrdgoEQnFrdhIBWRIHcHJlc2VudCIJQXR0ZW50aW9uKhAKCW51bV9oZWFk"
+    "cxgCoAECOg1jb20ubWljcm9zb2Z0EgFnKo8GCBAIGBAKQgRXcWt2SoAG1jKTOfi3AADrNSE1wDYA"
+    "AAAAyjmANGU2AACuuAAAAACZNQAAAAAAAA44AAAAAAAAAAAAAAAAPzg9NQAAKTQAAAAAAAAAAAAA"
+    "AAAAAAAAt7cAAAAAozYAAAAAAAAAAAAAYzIAAAAAAAAAAJm2AAAAAAAAizRBNw4zAAAAACw42LIA"
+    "APsxNLQxOxU2AACBswAAAAAGtQQ0qDZltgAAFDSXtwAAAAA2uwAATrcAAAAAMbYAAB43AAAAAAA3"
+    "ajQAAAAAAACDtOs3VzRltQAAgrd4tTc5nzLjNiC2AABsuc6xAAAyt8UyAAANtY80AAD+Mwm0vLUA"
+    "tgAAAAAAAAg0/7bbMwAAAAAAAAAAbrUAAHO5AAAAAAAAAAAAAAAA77XUNrgzAAAAAAAA3jQAAPmy"
+    "AADmtPc1sTQAAAAARDVlOQAA9TQAAAAACTXftke0AACJNFC1vDMAAAAAcbYAAAAAAAAAAAq46LNl"
+    "tAAA+TUAAAAAAAA1NlO4c7MAAAAAErLNtdSyAAAAAAAAAAAAAAAAAABktEC5+bUAAAAAhrcuOeS1"
+    "OrUAAAAAAAAiNUm3AAAAAAAAAAAoNQAAAAC5MQAAAAAAAAAAAjTDOFq4sTYAANkyLjUAAAAAAAAA"
+    "AAAAA7ZmtQAAg7i2tgAAAADqtls4xTQAAAAAAAAAAHW1J7oAAAAAAACaNNkwAAAAAAAA2DMAAAAA"
+    "AAArtC60vTMAACcxBbbptWQ5PrgAABa2AAAAAPmyAACqsgAAjDaKM7E0f7gzNS02AADttMG73rgA"
+    "AAAAAAAAAAAAAACfNgAAPznONwAAAAAAAAAAZzhdtAAAAAAAAPQ3lrMAAB01AAAAAHc5AAAAAEe4"
+    "AABptgAAAABUNcoxAADzO6ewHrbJs9G1wzJGOwAAfLYAAPC3AADAtAAAibUeNKA4AAAAAEg3AAAL"
+    "tQAAkLSRtAAxAAAAAAAAAAAAAHG1bLQAADg03jQUs94xAAAUMey4AAAAABWxAACXOF0x/7F9tt00"
+    "9rcutwAAxDQAAKQ4KjwIGBAKQgRCcWt2SjD/Jo6mHaUkrOYpDakXLF8rtiUDr0sp6KQ+LJuYWCnB"
+    "nbMiO6W5omQrEag0qQgtKydaHwoBWBIaChgIChIUCgcSBWJhdGNoCgUSA3NlcQoCCBBiHwoBWRIa"
+    "ChgIChIUCgcSBWJhdGNoCgUSA3NlcQoCCAhCBAoAEBVCEQoNY29tLm1pY3Jvc29mdBAB"
+)
+
+
 # --- Core: matches the pure-Python reference exactly ----------------------
 
 
@@ -157,14 +517,12 @@ def test_wanda_pruning_cpp_matmul_unstructured_matches_python_reference():
     rng = np.random.default_rng(150)
     x_cal = rng.standard_normal((48, K)).astype(np.float32)
 
-    expected = onnxsim.apply_wanda_pruning(
-        model, calibration_data=[{"X": x_cal}], sparsity=0.5
-    )
+    golden = _golden(_GOLDEN_MATMUL_UNSTRUCTURED)
     actual = onnxsim.apply_wanda_pruning_cpp(
         model, calibration_data=[{"X": x_cal}], sparsity=0.5
     )
     onnx.checker.check_model(actual)
-    _assert_bytewise_close(_weight(actual), _weight(expected))
+    _assert_bytewise_close(_weight(actual), _weight(golden))
     assert not np.array_equal(_weight(actual), _weight(model))
 
 
@@ -199,14 +557,12 @@ def test_wanda_pruning_cpp_gemm_transb_matches_python_reference():
     )
     x_cal = rng.standard_normal((40, K)).astype(np.float32)
 
-    expected = onnxsim.apply_wanda_pruning(
-        model, calibration_data=[{"X": x_cal}], sparsity=0.4
-    )
+    golden = _golden(_GOLDEN_GEMM_TRANSB)
     actual = onnxsim.apply_wanda_pruning_cpp(
         model, calibration_data=[{"X": x_cal}], sparsity=0.4
     )
     onnx.checker.check_model(actual)
-    _assert_bytewise_close(_weight(actual), _weight(expected))
+    _assert_bytewise_close(_weight(actual), _weight(golden))
     assert not np.array_equal(_weight(actual), w)
 
 
@@ -216,14 +572,12 @@ def test_wanda_pruning_cpp_nm_pattern_matches_python_reference():
     rng = np.random.default_rng(152)
     x_cal = rng.standard_normal((48, K)).astype(np.float32)
 
-    expected = onnxsim.apply_wanda_pruning(
-        model, calibration_data=[{"X": x_cal}], n=2, m=4
-    )
+    golden = _golden(_GOLDEN_NM_PATTERN)
     actual = onnxsim.apply_wanda_pruning_cpp(
         model, calibration_data=[{"X": x_cal}], n=2, m=4
     )
     onnx.checker.check_model(actual)
-    _assert_bytewise_close(_weight(actual), _weight(expected))
+    _assert_bytewise_close(_weight(actual), _weight(golden))
 
     # Exactly 2 of every 4 consecutive columns survive, per output row --
     # the actual N:M structural guarantee, not merely "matches Python".
@@ -256,14 +610,12 @@ def test_wanda_pruning_cpp_attention_merged_qkv_matches_python_reference():
     rng2 = np.random.default_rng(153)
     x_cal = rng2.standard_normal((3, 5, hidden)).astype(np.float32)
 
-    expected = onnxsim.apply_wanda_pruning(
-        model, calibration_data=[{"X": x_cal}], sparsity=0.5
-    )
+    golden = _golden(_GOLDEN_ATTENTION_MERGED_QKV)
     actual = onnxsim.apply_wanda_pruning_cpp(
         model, calibration_data=[{"X": x_cal}], sparsity=0.5
     )
     onnx.checker.check_model(actual)
-    _assert_bytewise_close(_weight(actual), _weight(expected))
+    _assert_bytewise_close(_weight(actual), _weight(golden))
     assert not np.array_equal(_weight(actual), w_qkv)
     np.testing.assert_array_equal(_weight(actual, index=1), bias)
     assert onnxsim.weight_sparsity(actual) == pytest.approx(0.5, abs=0.1)
@@ -294,15 +646,13 @@ def test_wanda_pruning_cpp_multiple_layers_sharing_one_input_matches_python_refe
     rng2 = np.random.default_rng(154)
     x_cal = rng2.standard_normal((40, hidden)).astype(np.float32)
 
-    expected = onnxsim.apply_wanda_pruning(
-        model, calibration_data=[{"X": x_cal}], sparsity=0.4
-    )
+    golden = _golden(_GOLDEN_MULTIPLE_LAYERS_SHARING_INPUT)
     actual = onnxsim.apply_wanda_pruning_cpp(
         model, calibration_data=[{"X": x_cal}], sparsity=0.4
     )
     onnx.checker.check_model(actual)
     for i in range(3):
-        _assert_bytewise_close(_weight(actual, i), _weight(expected, i))
+        _assert_bytewise_close(_weight(actual, i), _weight(golden, i))
         assert not np.array_equal(_weight(actual, i), _weight(model, i))
 
 
@@ -329,12 +679,7 @@ def test_wanda_pruning_cpp_global_sparsity_matches_python_reference():
     x1_cal = rng2.standard_normal((40, K1)).astype(np.float32)
     x2_cal = rng2.standard_normal((40, K2)).astype(np.float32)
 
-    expected = onnxsim.apply_wanda_pruning(
-        model,
-        calibration_data=[{"X1": x1_cal, "X2": x2_cal}],
-        sparsity=0.5,
-        global_sparsity=True,
-    )
+    golden = _golden(_GOLDEN_GLOBAL_SPARSITY)
     actual = onnxsim.apply_wanda_pruning_cpp(
         model,
         calibration_data=[{"X1": x1_cal, "X2": x2_cal}],
@@ -342,8 +687,8 @@ def test_wanda_pruning_cpp_global_sparsity_matches_python_reference():
         global_sparsity=True,
     )
     onnx.checker.check_model(actual)
-    _assert_bytewise_close(_weight(actual, 0), _weight(expected, 0))
-    _assert_bytewise_close(_weight(actual, 1), _weight(expected, 1))
+    _assert_bytewise_close(_weight(actual, 0), _weight(golden, 0))
+    _assert_bytewise_close(_weight(actual, 1), _weight(golden, 1))
     # The whole-model pooled sparsity target is reached exactly at the
     # element count level (no per-row floor), matching the Python original.
     total = w1.size + w2.size
@@ -380,6 +725,117 @@ def test_wanda_pruning_cpp_no_calibration_batches_falls_back_to_plain_magnitude(
     np.testing.assert_array_equal(_weight(pruned), _magnitude_weight(magnitude_pruned))
     # Actually pruned, not a no-op.
     assert not np.array_equal(_weight(pruned), w)
+
+
+# --- Rank-2-only MatMul/Gemm activation gate --------------------------------
+#
+# pruning.py's own `_wanda_unstructured_calibration_stats` requires a plain
+# (non-Attention, non-Conv) MatMul/Gemm candidate's own activation to be
+# EXACTLY rank 2 (`if x.ndim != 2: continue`) before it counts as an
+# observed calibration activation at all -- a rank-3 batched/sequence
+# activation feeding a plain 2-D MatMul weight is exactly as "unobserved" as
+# no calibration_data at all, and falls back to plain magnitude. This is
+# NOT a universal rule: pruning.py's own separate `attn_act_norm` statistic
+# for `com.microsoft::Attention`'s merged QKV weight accepts any rank >= 2
+# (its own `X` is always rank-3 `[batch, seq, hidden]` by construction), and
+# neither `apply_structured_wanda_pruning`'s nor
+# `apply_attention_head_wanda_pruning`'s own calibration statistics have any
+# rank restriction at all. `WandaCalibrationStats`' own `require_rank2` set
+# (structured_pruning_entry.cpp) reproduces exactly this MatMul/Gemm-only
+# restriction -- these two tests cross-check both sides of that distinction
+# directly against `onnxsim.apply_magnitude_pruning` (a real oracle
+# independent of the Wanda calibration machinery itself, now that
+# `onnxsim.apply_wanda_pruning` is this same C++ port).
+
+
+def test_wanda_pruning_cpp_matmul_rank3_activation_falls_back_to_plain_magnitude():
+    # Mirrors tests/test_pruning.py's own
+    # test_wanda_pruning_falls_back_to_magnitude_without_matching_activation
+    # -- the regression that originally caught WandaCalibrationStats
+    # observing a MatMul/Gemm candidate's activation at any rank, not just
+    # rank 2. The graph input itself is declared rank 3 (`[batch, seq, K]`)
+    # -- a real batched/sequence MatMul input, not merely an
+    # oddly-shaped calibration array fed to a rank-2-declared graph.
+    K, N = 32, 8
+    rng = np.random.default_rng(90)
+    w = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    model = _model(
+        f"""
+        g (float[batch,seq,{K}] X) => (float[batch,seq,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[_f32(w, "W")],
+    )
+    rng2 = np.random.default_rng(190)
+    x_cal = rng2.standard_normal((2, 4, K)).astype(np.float32)  # rank 3, not 2
+
+    pruned = onnxsim.apply_wanda_pruning_cpp(
+        model, calibration_data=[{"X": x_cal}], sparsity=0.5
+    )
+    magnitude_pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.5)
+    np.testing.assert_array_equal(_weight(pruned), _magnitude_weight(magnitude_pruned))
+    # Actually pruned, not a no-op.
+    assert not np.array_equal(_weight(pruned), w)
+
+
+def test_wanda_pruning_cpp_attention_rank3_activation_is_not_gated_like_matmul():
+    # Contrast case: `com.microsoft::Attention`'s own rank-3 activation must
+    # NOT be gated by the same rank-2-only restriction the test above
+    # exercises for plain MatMul/Gemm -- it should still get a REAL
+    # activation-weighted importance (differing from plain magnitude), never
+    # the plain-magnitude fallback, confirming `require_rank2` was built
+    # from only the MatMul/Gemm candidates' own `x_name`s, never the
+    # Attention candidate's.
+    hidden = 8
+    nq = nk = nv = 4
+    total_n = nq + nk + nv
+    num_heads = 1
+    salient = (0, 3)
+    rng = np.random.default_rng(91)
+    # Every non-salient entry's |W| is bounded well away from zero (>= 0.2)
+    # and every salient entry's |W| is a full order of magnitude smaller
+    # (~0.01, jittered so no two entries exactly tie at the plain-magnitude
+    # pruning threshold) -- constructed with an explicit magnitude floor on
+    # each side, rather than relying on a random draw happening to keep them
+    # separated, so plain-magnitude pruning is GUARANTEED to drop every
+    # salient entry first regardless of random seed.
+    signs = rng.choice([-1.0, 1.0], size=(hidden, total_n))
+    w_qkv = (signs * (0.2 + rng.random((hidden, total_n)) * 0.1)).astype(np.float32)
+    w_qkv[salient, :] = (
+        signs[salient, :] * (0.01 + rng.random((len(salient), total_n)) * 0.001)
+    ).astype(np.float32)
+    bias = rng.standard_normal((total_n,)).astype(np.float32) * 0.05
+    model = _model(
+        f"""
+        g (float[batch,seq,{hidden}] X) => (float[batch,seq,{nv}] Y)
+        {{
+          Y, present = com.microsoft.Attention <num_heads={num_heads}>(X, Wqkv, Bqkv)
+        }}
+        """,
+        initializer=[_f32(w_qkv, "Wqkv"), _f32(bias, "Bqkv")],
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+    x_cal = rng.standard_normal((2, 5, hidden)).astype(np.float32)  # rank 3
+    # ...but scale those same input channels' own activation up massively,
+    # so Wanda should keep at least one of their entries despite the small
+    # |W|, exactly like test_wanda_pruning_cpp_activation_weighting_differs_
+    # from_plain_magnitude's plain-MatMul version of this same check.
+    for c in salient:
+        x_cal[:, :, c] *= 1000.0
+
+    wanda_pruned = onnxsim.apply_wanda_pruning_cpp(
+        model, calibration_data=[{"X": x_cal}], sparsity=0.5
+    )
+    magnitude_pruned = onnxsim.apply_magnitude_pruning(model, sparsity=0.5)
+
+    w_wanda = _weight(wanda_pruned)
+    w_magnitude = _magnitude_weight(magnitude_pruned)
+    assert not np.array_equal(w_wanda, w_magnitude)
+    for c in salient:
+        assert np.count_nonzero(w_magnitude[c, :]) == 0
+        assert np.count_nonzero(w_wanda[c, :]) > 0
 
 
 def test_wanda_pruning_cpp_zero_sparsity_is_a_noop():
@@ -463,16 +919,15 @@ def test_wanda_pruning_cpp_activation_weighting_differs_from_plain_magnitude():
 
 # --- Conv: ordinary / depthwise / general grouped, all TRUE parity --------
 #
-# 2-D Conv is now matched exactly like pruning.py's own `apply_wanda_pruning`
-# -- ordinary (`group=1`), fully depthwise (`group == in_channels ==
+# 2-D Conv is matched exactly like pruning.py's own `apply_wanda_pruning`
+# used to -- ordinary (`group=1`), fully depthwise (`group == in_channels ==
 # out_channels`), and general grouped (`1 < group < in_channels`) alike --
 # via a from-scratch im2col per-`(in_channel, kh, kw)`-tap activation norm
 # (ConvPatchSqSum) and a grouped/depthwise group-relative norm expansion
 # (ConvGroupRelativeNorm), see structured_pruning_entry.h's own
-# ApplyWandaPruning declaration comment. `apply_wanda_pruning` itself is NOT
-# aliased to this port (see this file's own module docstring for the
-# unrelated, pre-existing MatMul-family gap that blocks it), so these still
-# compare against a LIVE call to it, exactly like every other test above.
+# ApplyWandaPruning declaration comment. Since `apply_wanda_pruning` is now
+# an alias of this port, these compare against a frozen golden fixture
+# (see this file's own module docstring), same as every other test above.
 
 
 def _conv_model(
@@ -500,12 +955,12 @@ def test_wanda_pruning_cpp_conv_ordinary_group1_matches_python_reference():
     x_cal = [rng.standard_normal((2, Cin, 10, 10)).astype(np.float32) for _ in range(2)]
     calib = [{"X": b} for b in x_cal]
 
-    expected = onnxsim.apply_wanda_pruning(model, calibration_data=calib, sparsity=0.5)
+    golden = _golden(_GOLDEN_CONV_ORDINARY_GROUP1)
     actual = onnxsim.apply_wanda_pruning_cpp(
         model, calibration_data=calib, sparsity=0.5
     )
     onnx.checker.check_model(actual)
-    np.testing.assert_array_equal(_weight(actual), _weight(expected))
+    np.testing.assert_array_equal(_weight(actual), _weight(golden))
     assert not np.array_equal(_weight(actual), w)
     assert onnxsim.weight_sparsity(actual) == pytest.approx(0.5, abs=0.1)
 
@@ -517,12 +972,12 @@ def test_wanda_pruning_cpp_conv_fully_depthwise_matches_python_reference():
     x_cal = [rng.standard_normal((2, Cin, 10, 10)).astype(np.float32) for _ in range(2)]
     calib = [{"X": b} for b in x_cal]
 
-    expected = onnxsim.apply_wanda_pruning(model, calibration_data=calib, sparsity=0.5)
+    golden = _golden(_GOLDEN_CONV_FULLY_DEPTHWISE)
     actual = onnxsim.apply_wanda_pruning_cpp(
         model, calibration_data=calib, sparsity=0.5
     )
     onnx.checker.check_model(actual)
-    np.testing.assert_array_equal(_weight(actual), _weight(expected))
+    np.testing.assert_array_equal(_weight(actual), _weight(golden))
     assert not np.array_equal(_weight(actual), w)
     assert onnxsim.weight_sparsity(actual) == pytest.approx(0.5, abs=0.1)
 
@@ -537,12 +992,12 @@ def test_wanda_pruning_cpp_conv_general_grouped_matches_python_reference():
     x_cal = [rng.standard_normal((2, Cin, 10, 10)).astype(np.float32) for _ in range(2)]
     calib = [{"X": b} for b in x_cal]
 
-    expected = onnxsim.apply_wanda_pruning(model, calibration_data=calib, sparsity=0.5)
+    golden = _golden(_GOLDEN_CONV_GENERAL_GROUPED)
     actual = onnxsim.apply_wanda_pruning_cpp(
         model, calibration_data=calib, sparsity=0.5
     )
     onnx.checker.check_model(actual)
-    np.testing.assert_array_equal(_weight(actual), _weight(expected))
+    np.testing.assert_array_equal(_weight(actual), _weight(golden))
     assert not np.array_equal(_weight(actual), w)
     assert onnxsim.weight_sparsity(actual) == pytest.approx(0.5, abs=0.1)
 
@@ -554,10 +1009,10 @@ def test_wanda_pruning_cpp_conv_general_grouped_nm_pattern_matches_python_refere
     x_cal = [rng.standard_normal((2, Cin, 10, 10)).astype(np.float32) for _ in range(2)]
     calib = [{"X": b} for b in x_cal]
 
-    expected = onnxsim.apply_wanda_pruning(model, calibration_data=calib, n=2, m=4)
+    golden = _golden(_GOLDEN_CONV_GENERAL_GROUPED_NM)
     actual = onnxsim.apply_wanda_pruning_cpp(model, calibration_data=calib, n=2, m=4)
     onnx.checker.check_model(actual)
-    np.testing.assert_array_equal(_weight(actual), _weight(expected))
+    np.testing.assert_array_equal(_weight(actual), _weight(golden))
 
     # Exactly 2 of every 4 consecutive columns survive, per output filter row
     # (the reshaped [out_channels, cin_per_group*kh*kw] view).
@@ -592,14 +1047,14 @@ def test_wanda_pruning_cpp_conv_depthwise_float16_matches_python_reference():
     ]
     calib = [{"X": b} for b in x_cal]
 
-    expected = onnxsim.apply_wanda_pruning(model, calibration_data=calib, sparsity=0.5)
+    golden = _golden(_GOLDEN_CONV_DEPTHWISE_FLOAT16)
     actual = onnxsim.apply_wanda_pruning_cpp(
         model, calibration_data=calib, sparsity=0.5
     )
     onnx.checker.check_model(actual)
     assert actual.graph.initializer[0].data_type == onnx.TensorProto.FLOAT16
     np.testing.assert_array_equal(
-        _weight(actual).view(np.uint16), _weight(expected).view(np.uint16)
+        _weight(actual).view(np.uint16), _weight(golden).view(np.uint16)
     )
     assert not np.array_equal(_weight(actual).view(np.uint16), w.view(np.uint16))
     assert onnxsim.weight_sparsity(actual) == pytest.approx(0.5, abs=0.1)
@@ -632,9 +1087,7 @@ def test_wanda_pruning_cpp_matmul_float16_matches_python_reference():
     rng2 = np.random.default_rng(161)
     x_cal = rng2.standard_normal((16, K)).astype(np.float16)
 
-    expected = onnxsim.apply_wanda_pruning(
-        model, calibration_data=[{"X": x_cal}], sparsity=0.5
-    )
+    golden = _golden(_GOLDEN_MATMUL_FLOAT16)
     actual = onnxsim.apply_wanda_pruning_cpp(
         model, calibration_data=[{"X": x_cal}], sparsity=0.5
     )
@@ -644,7 +1097,7 @@ def test_wanda_pruning_cpp_matmul_float16_matches_python_reference():
     # assert_allclose): both round-trip through float64 and mask, never
     # recompute, a surviving entry's own value.
     np.testing.assert_array_equal(
-        _weight(actual).view(np.uint16), _weight(expected).view(np.uint16)
+        _weight(actual).view(np.uint16), _weight(golden).view(np.uint16)
     )
     assert not np.array_equal(_weight(actual).view(np.uint16), w.view(np.uint16))
     assert onnxsim.weight_sparsity(actual) == pytest.approx(0.5, abs=0.1)
@@ -679,12 +1132,12 @@ def test_wanda_pruning_cpp_matmul_bfloat16_matches_python_reference():
     )
     onnx.checker.check_model(model)
 
-    expected = onnxsim.apply_wanda_pruning(model, calibration_data=[], sparsity=0.5)
+    golden = _golden(_GOLDEN_MATMUL_BFLOAT16)
     actual = onnxsim.apply_wanda_pruning_cpp(model, calibration_data=[], sparsity=0.5)
     onnx.checker.check_model(actual)
     assert actual.graph.initializer[0].data_type == onnx.TensorProto.BFLOAT16
     np.testing.assert_array_equal(
-        _weight(actual).view(np.uint16), _weight(expected).view(np.uint16)
+        _weight(actual).view(np.uint16), _weight(golden).view(np.uint16)
     )
     assert not np.array_equal(_weight(actual).view(np.uint16), w.view(np.uint16))
     assert onnxsim.weight_sparsity(actual) == pytest.approx(0.5, abs=0.1)
@@ -716,16 +1169,14 @@ def test_wanda_pruning_cpp_attention_merged_qkv_float16_matches_python_reference
     rng2 = np.random.default_rng(163)
     x_cal = rng2.standard_normal((3, 5, hidden)).astype(np.float16)
 
-    expected = onnxsim.apply_wanda_pruning(
-        model, calibration_data=[{"X": x_cal}], sparsity=0.5
-    )
+    golden = _golden(_GOLDEN_ATTENTION_MERGED_QKV_FLOAT16)
     actual = onnxsim.apply_wanda_pruning_cpp(
         model, calibration_data=[{"X": x_cal}], sparsity=0.5
     )
     onnx.checker.check_model(actual)
     assert actual.graph.initializer[0].data_type == onnx.TensorProto.FLOAT16
     np.testing.assert_array_equal(
-        _weight(actual).view(np.uint16), _weight(expected).view(np.uint16)
+        _weight(actual).view(np.uint16), _weight(golden).view(np.uint16)
     )
     assert not np.array_equal(_weight(actual).view(np.uint16), w_qkv.view(np.uint16))
     # Bias is never touched by unstructured/N:M pruning -- byte-identical.


### PR DESCRIPTION
## Summary

Seventeenth round, continuing the effort (started in #1071) to close scope gaps between onnxsim's pure-Python implementations and their C++ ports. Two pieces of work, done in parallel, closing the two gaps documented at the end of round 16.

### Fully closed and aliased

- **`apply_wanda_pruning`** — fixed the pre-existing `WandaCalibrationStats` rank-mismatch bug flagged in round 16. The Python reference's rank restriction turns out to be MatMul/Gemm-specific, not universal: `apply_wanda_pruning`'s own plain (non-Attention) probe requires the activation to be exactly rank 2 before it counts as observed, falling back to plain-magnitude importance otherwise, while `com.microsoft::Attention`'s merged-QKV probe accepts any rank ≥ 2 (reduced over leading axes), and the other two `WandaCalibrationStats` callers (`ApplyStructuredWandaPruning`, `ApplyAttentionHeadWandaPruning`) have no such restriction at all in their own Python references. Added a `require_rank2` parameter to the shared helper, populated only by `ApplyWandaPruning`'s own plain MatMul/Gemm candidates (never Attention's, never the other two callers'). Verified via a trial alias against the full `tests/test_pruning.py` suite (confirming the previously-failing `test_wanda_pruning_falls_back_to_magnitude_without_matching_activation` now passes) and explicit no-regression checks on the other two callers' own test suites. Now fully aliased.

### Real, verified progress — not yet aliased

- **`apply_attention_head_pruning` / `apply_attention_head_wanda_pruning`** — ported the core "decomposed (un-fused) GQA/MQA/MHA" attention chain family (separate Q/K/V projections → `Reshape`/`Transpose` head-split → optional HuggingFace `repeat_kv` → QK^T/Softmax/AV → combine-back → output projection), the tenth and last family originally deferred across 16 prior rounds specifically for its novel graph-rewriting need: up to six `Reshape`/`Expand` shape constants encode the head/KV-group count redundantly and must be rewritten in lock-step post-pruning — in place when safe, or by **cloning** a fresh initializer when the same CSE-shared constant is also read by an unrelated node. This clone-vs-in-place machinery (mirroring pruning.py's own `_rewrite_shape_dim` exactly) is new to this file and is now available for future rounds to build on.

  **Deliberately narrower than pruning.py's own decomposed-GQA matcher** (discovered only once this core shape was actually implemented and compared line-by-line against the Python reference): no additive mask, no decomposed RoPE/Q-K-norm pass-through, no `Einsum`-based QK^T/AV product, no packed-QKV-then-`Split` producer, and no true-MQA fast path — each real, verified scope the Python original covers that this round's C++ port declines rather than mis-handles. Because these remain open, neither function is aliased; both attention functions stay pure-Python.

## Testing

- `pip install --no-build-isolation -ve .`
- Full suite (vendor-backend-dependent modules excluded, matching this repo's own CI ignore list) — **2733 passed, 99 skipped**, no regressions
- `apply_wanda_pruning`: trial-alias verification against the full `test_pruning.py` suite (941 passed), plus explicit no-regression runs of `test_structured_wanda_pruning_cpp.py`/`test_attention_head_wanda_pruning_cpp.py` (the other two `WandaCalibrationStats` callers); 2 new tests for the rank-3-activation fallback and the Attention-is-not-gated contrast case
- Decomposed GQA: 16 new tests (byte-for-byte `SerializeToString()` comparisons against the Python reference) covering basic GQA/MHA, shared-constant clone-vs-in-place for both a head-split `Reshape` and a `repeat_kv` `Expand` target, a genuinely-invalid-topology decline, and explicit divergence-documentation cases (constant mask, true MQA) where C++ declines but Python still prunes
- `clang-format --dry-run --Werror` / `ruff format --check` / `ruff check` / `mypy` all clean

## Scope / follow-up

With `apply_wanda_pruning` now aliased, the pruning-parity effort's remaining open items are narrower and more specific: closing the decomposed-GQA family's own remaining sub-shapes (mask, RoPE/Q-K-norm pass-through, Einsum-based product, packed-QKV, true MQA) — each independently addable to the matcher skeleton this round built, without needing to touch the core clone-vs-in-place machinery already verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4t6ntCm72RfFf64W9GYB1

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4t6ntCm72RfFf64W9GYB1)_