### PR TITLE
Update mcode coverage status with everything found since it was written

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -1446,6 +1446,47 @@ isn't reproduced by noise alone) before being trusted, not just a check
 against the two zones already known -- this project got this exact kind
 of false positive twice now, at two different locations.
 
+### Expanding past Conv: MaxPool, the real residual Add, and GlobalAveragePool, cross-checked against `--profile`
+
+Every mcode structural finding so far came from `Conv`. Directly
+extending coverage to three of `resnet18d`'s other real primitive
+families found in its own `trace.json` profiling earlier in this
+README -- `AxMaxPool`, `AxQuantizedAdd` (the real residual add of two
+activations, not the old constant-broadcast `Add` tested early in this
+investigation), and `AxQuantizedGlobAvgPool` -- using small controlled
+models and, per the user's suggestion, checking `--profile` metadata
+alongside mcode bytes this time rather than bytes alone.
+
+**A real, clean architectural split by execution engine, confirmed
+directly**: `AxMaxPool`, the real residual `AxQuantizedAdd`, and
+`AxQuantizedGlobAvgPool` all schedule on **`teng2`** (the same engine
+`AxQuantizedNormalize` used in the `resnet18d` profiling earlier) --
+never on `conv0`/`conv1`, which are reserved for `AxQuantizedConv` and
+`Gemm`-family MAC work. A clean, real, generalizable rule confirmed
+across four distinct primitive types now: **non-MAC ops run on `teng2`;
+MAC ops run on the conv engines.** `Pre_AxTranspose`'s own engine
+placement is context-dependent -- `cv3` when it wraps a `MaxPool` or
+`GlobalAvgPool`, `teng2` when it wraps a `Conv` in the residual-block
+test -- a real difference not chased down further here.
+
+**`MaxPool`'s `ceil_mode` is a third confirmed false lead, same
+signature as before.** Comparing `ceil_mode=0` vs `ceil_mode=1` on a
+shape where both give the identical output size produced a same-length
+pair with 5 differing bytes -- but a determinism check (rebuilding the
+`ceil_mode=0` config alone, twice) reproduced the same positions and the
+same exact multiset of values (`{0x13, 0x20, 0x23, 0x30, 0x40}`) already
+seen in the `auto_pad` false lead. **This is the same noise signature
+appearing a third time, now confirmed on a completely different op type
+and model** -- strong, direct evidence this non-determinism is a global
+property of mcode generation, not tied to Conv, to any one model shape,
+or to any one byte region.
+
+**`MaxPool`'s kernel size behaves like Conv's did**: comparing a `2x2`
+kernel against a `4x4` kernel with padding chosen to hold the same output
+shape gives *different* total mcode lengths (2,408 vs 2,440 bytes, a
+32-byte-unit-consistent delta) -- real, but not a same-length pair, so no
+clean localized diff was possible here the way the dilation experiments
+allowed for Conv.
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -1487,6 +1487,58 @@ shape gives *different* total mcode lengths (2,408 vs 2,440 bytes, a
 32-byte-unit-consistent delta) -- real, but not a same-length pair, so no
 clean localized diff was possible here the way the dilation experiments
 allowed for Conv.
+
+### `Gemm` joins the MAC engines, and a real, substantial signal from `transB`
+
+Continuing to work through resnet18d's remaining real primitives: `Gemm`
+(the final FC layer, 3.3% of resnet18d's real schedule) and
+`AveragePool` (distinct from `GlobalAveragePool`, used 3x in
+`resnet18d`'s real downsample paths).
+
+**`Gemm` schedules on `conv1`** -- joining `Conv` in the MAC-engine
+category rather than `teng2`'s non-MAC group, extending the same clean
+split found above to a second op type. Its trace events keep the output
+tensor's own name (`y_0_0`, `y_0_1`, `y_0_2`) rather than being renamed to
+an `AxQuantized*`-style primitive the way `Conv`/`Pool`/`Add` are --
+matching, exactly, the un-renamed `"/fc/Gemm_*"` event names already seen
+in this README's real `resnet18d` profiling. **`AveragePool` schedules on
+`teng2`**, joining `MaxPool`/`Add`/`GlobalAvgPool`/`Normalize` in the
+non-MAC category, but with a real difference from `MaxPool` at the same
+input size: two sub-events (`AxQuantizedAvgPool_0_0` and
+`_1_0`) rather than one -- plausibly a real two-pass sum-then-divide
+structure specific to averaging, not investigated further here.
+
+**Correction, caught the same way the `auto_pad` false lead was**: this
+section first reported this `Gemm` shape as showing *zero*
+non-deterministic noise across a rebuild, based on a single rebuild pair.
+That turned out to be a lucky draw, not a real property of the shape --
+a second, independent pair of rebuilds (done while writing an automated
+regression test for this finding, which caught the discrepancy) showed
+the familiar ~6-byte noise at the same `~301-325` zone already confirmed
+for `Conv`/`MaxPool`/`auto_pad`/`ceil_mode`. This shape is not
+noise-free after all; it has the same known noise as everything else
+tested so far.
+
+**`transB=0` vs `transB=1` still produces a real, substantial signal, net
+of that noise.** Of the 95 originally-reported differing bytes, the two
+at offsets 319/325 fall inside the confirmed noisy zone and are not
+trustworthy as `transB`-specific signal on their own (this exact
+`gemm_base` config's own noise realization could easily land differently
+there by chance alone, independent of `transB`). The remaining ~93 bytes
+sit well outside any confirmed noise zone and hold up as real: a large,
+clean 85-byte contiguous block (offset 1620-1705, containing non-trivial
+repeated structure -- `f129ff3b81` and `f5852513c8` each appearing three
+times) plus smaller diffs at 1617, 1708, and 1712. Consistent with a real
+per-tile or per-output-column memory-access-pattern encoding that has to
+change because `transB` genuinely changes whether the weight matrix is
+traversed row-major or column-major. This remains, net of the correction,
+by a wide margin the largest and cleanest real signal isolated in this
+whole investigation -- a strong, well-motivated, precisely-located target
+(offset 1620, 85 bytes) for whoever attempts the next level of decoding.
+Also a second, independent confirmation of the broader determinism
+lesson: a single rebuild pair is not enough to call something noise-free,
+and this project has now made and caught that exact mistake twice.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -1402,6 +1402,50 @@ rather than smoothly. Not chased further here, but a real, precisely
 reproducible lead (two exact offsets, two exact dilation thresholds) for
 future work.
 
+### Two more Conv attributes tried: a real asymmetry, and a second non-determinism zone found by a false lead
+
+Continuing to work through Conv's remaining untested attributes:
+
+**Asymmetric kernel shape (`3x1` vs `1x3`) reveals a real, new asymmetry.**
+Same total weight count either way (`cin*cout*3*1 == cin*cout*1*3`), so
+`Wbt` came out byte-identical in size (1,320 bytes both) as expected --
+but mcode did *not*: 3,528 bytes for `3x1` vs 3,208 bytes for `1x3`, a
+real 320-byte (10-unit) difference driven by orientation alone, not by
+how much weight data there is. A genuine, real finding: the compiler
+treats a "tall" and a "wide" kernel of otherwise identical size
+differently, plausibly because how it scans/tiles the input differs by
+row vs. column direction. Not further decoded (no same-length pair here
+to diff cleanly), but a real, motivated target for whoever chases the
+scanning-order encoding next.
+
+**`auto_pad="SAME_UPPER"` vs. the numerically-equivalent explicit `pads`
+looked at first like a real, tiny signal -- and turned out to be a false
+lead that found something else useful instead.** Both compiled to the
+identical 2,984-byte mcode length, and diffing them found only 4 bytes
+different, at a location (offsets 301/303/323/325) never seen in any
+prior section of this README -- a plausible candidate for auto_pad
+leaving some small trace even after normalization. **Checked properly
+before believing it**: rebuilding the *`auto_pad="NOTSET"` config alone*,
+twice, with nothing changed, reproduced a nearly identical diff pattern
+(5 bytes, offsets 301/303/317/319/325, same multiset-of-values signature
+as the already-confirmed non-determinism elsewhere in this README). The
+"auto_pad signal" was never real -- it was this project's second
+encounter with the same class of non-deterministic label noise, just at
+a location not seen before. **Real, useful takeaway**: `auto_pad` appears
+to fully normalize to its explicit-padding equivalent before
+quantization, with no detectable functional difference in mcode --  a
+clean negative result, now that the false positive has been ruled out.
+
+**More importantly, methodologically**: this confirms mcode's
+non-determinism is not confined to the one zone (offsets ~858-882)
+characterized earlier -- there are at least two independent noisy
+regions (~301-325 as well), and likely more not yet stumbled into. Any
+future same-length-diff finding in this space needs its own determinism
+check (rebuild the *unchanged* config and confirm the observed diff
+isn't reproduced by noise alone) before being trusted, not just a check
+against the two zones already known -- this project got this exact kind
+of false positive twice now, at two different locations.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -892,6 +892,44 @@ byte-diffing technique demonstrated for Conv's bias, scaled up to cover
 and critically, `AxQuantizedConv`'s dominant weight/compute payload itself
 -- each a real, well-scoped, but separately time-consuming target.
 
+**Update, after the further mcode-focused sections below**: the ~1% figure
+above is unchanged for raw "exact meaning known" bytes -- Conv's bias
+lives in Wbt, not mcode, so none of that work adds to mcode's own count --
+but the *map* of mcode is now materially more complete than "1% known,
+99% blank":
+
+- **Two distinct periodic fields are now precisely located inside a real
+  `AxQuantizedConv` command** (not just Wbt) -- the original 4-repeats/
+  7-byte-stride field, confirmed real and dilation/groups-sensitive across
+  six independent experiments, plus a second, similarly-shaped field that
+  only activates once dilation reaches 4. Neither is decoded at the bit
+  level, but both are now real, reproducible targets with exact byte
+  offsets, not part of the undifferentiated opaque mass.
+- **The confirmed non-deterministic region needs no further decoding at
+  all** -- it's understood to be a functionally-inert internal label
+  permutation (bit-identical real device output regardless of which
+  permutation a build lands on), not an encoded parameter. That's a small
+  but real subtraction from the "mystery" pile: bytes whose *role* is now
+  fully explained, even without knowing the exact label values' meaning.
+- **A real, quantified bound on how much of mcode is even distinct**: the
+  43.4%-of-bytes-are-exact-duplicates finding (from the self-similarity
+  scan elsewhere in this README) means the effective amount of *unique*
+  content to decode in a real model is well under its raw byte count --
+  most of what's left unexamined is copies of a smaller number of real
+  templates, not independent unique data.
+- **A negative result narrows where to keep looking**: profiling a real
+  two-op chain found no separately-scheduled "transfer" event for
+  inter-op data movement, meaning whatever addressing the intermediate
+  buffer needs is folded into the existing per-op command bytes rather
+  than existing as its own, separately-findable region -- ruling out one
+  plausible place further decoding might have focused on.
+
+None of this changes the honest headline (still roughly 1% exactly
+decoded, for a real model, and the dominant `AxQuantizedConv` payload
+itself still opaque) -- but "what's left to figure out" is now a
+materially smaller, better-characterized target than when this section
+was first written.
+
 ### A first real crack at `AxQuantizedConv`'s command encoding
 
 Taking up that target directly: since Conv's actual *weight values* live

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -577,7 +577,7 @@ def test_mcode_nondeterminism_is_a_label_permutation_not_metadata(tmp_path):
     )
 
 
-def _build_axmodel(work_dir, model, input_shape):
+def _build_axmodel(work_dir, model, input_shape, profile=False):
     os.makedirs(work_dir, exist_ok=True)
     onnx.save(model, os.path.join(work_dir, "model.onnx"))
     rng = np.random.RandomState(0)
@@ -607,10 +607,59 @@ def _build_axmodel(work_dir, model, input_shape):
     with open(os.path.join(work_dir, "config", "cfg.json"), "w") as f:
         json.dump(cfg, f)
     result = pulsar2_docker.build(
-        work_dir, "model.onnx", "output", config_path="config/cfg.json"
+        work_dir, "model.onnx", "output", config_path="config/cfg.json", profile=profile
     )
     assert result.success, result.error
+    if profile:
+        return result.axmodel_path, result.trace_path
     return result.axmodel_path
+
+
+def _mcode_from_axmodel(axmodel_path):
+    compiled = onnx.load(axmodel_path)
+    inits = {i.name: i for i in compiled.graph.initializer}
+    neu_node = next(nd for nd in compiled.graph.node if nd.op_type == "neu mode")
+    info = None
+    for attr in neu_node.attribute:
+        if attr.name == "npu_graph_info":
+            info = json.loads(attr.s.decode())
+    mcode_key = info["dotneus"][0]["neu_key"]
+    return bytes(inits[mcode_key].raw_data)
+
+
+def _maxpool_model(k, stride, pad, ceil_mode=0, cin=4, insz=16):
+    import math
+
+    if ceil_mode:
+        out = math.ceil((insz + 2 * pad - k) / stride) + 1
+    else:
+        out = math.floor((insz + 2 * pad - k) / stride) + 1
+    node = helper.make_node(
+        "MaxPool",
+        ["x"],
+        ["y"],
+        kernel_shape=[k, k],
+        strides=[stride, stride],
+        pads=[pad, pad, pad, pad],
+        ceil_mode=ceil_mode,
+    )
+    graph = helper.make_graph(
+        [node],
+        f"g_maxpool_k{k}_s{stride}_p{pad}_ceil{ceil_mode}",
+        [
+            helper.make_tensor_value_info(
+                "x", onnx.TensorProto.FLOAT, [1, cin, insz, insz]
+            )
+        ],
+        [
+            helper.make_tensor_value_info(
+                "y", onnx.TensorProto.FLOAT, [1, cin, out, out]
+            )
+        ],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    onnx.checker.check_model(model)
+    return model
 
 
 def test_mcode_nondeterminism_does_not_change_real_device_output(tmp_path):
@@ -705,3 +754,66 @@ def test_autopad_normalizes_with_no_signal_beyond_known_noise(tmp_path):
         "auto_pad-vs-explicit diff should not exceed identical-rebuild noise "
         "by more than a token amount",
     )
+
+
+def test_maxpool_ceil_mode_is_a_third_confirmed_false_lead(tmp_path):
+    """Confirmed real (see the README's "Expanding past Conv" section):
+    MaxPool's `ceil_mode=0` vs `ceil_mode=1`, on a shape where both give
+    the identical output size, produces a same-length pair with a few
+    differing bytes -- but rebuilding `ceil_mode=0` alone, twice,
+    reproduces the same diff. This is the same non-deterministic label
+    noise confirmed on Conv/auto_pad, now shown on a completely different
+    op type: mcode's non-determinism is a global property, not tied to
+    any one op or model.
+    """
+    model_off = _maxpool_model(2, 2, 0, ceil_mode=0)
+    model_on = _maxpool_model(2, 2, 0, ceil_mode=1)
+
+    mcode_off_a = _mcode_from_axmodel(
+        _build_axmodel(os.path.join(str(tmp_path), "off_a"), model_off, (1, 4, 16, 16))
+    )
+    mcode_off_b = _mcode_from_axmodel(
+        _build_axmodel(os.path.join(str(tmp_path), "off_b"), model_off, (1, 4, 16, 16))
+    )
+    mcode_on = _mcode_from_axmodel(
+        _build_axmodel(os.path.join(str(tmp_path), "on"), model_on, (1, 4, 16, 16))
+    )
+    assert len(mcode_off_a) == len(mcode_off_b) == len(mcode_on)
+
+    noise_diff = sum(
+        1 for i in range(len(mcode_off_a)) if mcode_off_a[i] != mcode_off_b[i]
+    )
+    cross_diff = sum(
+        1 for i in range(len(mcode_off_a)) if mcode_off_a[i] != mcode_on[i]
+    )
+    assert cross_diff <= noise_diff + 2, (
+        (cross_diff, noise_diff),
+        "ceil_mode-vs-off diff should not exceed identical-rebuild noise "
+        "by more than a token amount",
+    )
+
+
+def test_non_mac_ops_schedule_on_teng2_not_conv_engines(tmp_path):
+    """Confirmed real via --profile (see the README's "Expanding past
+    Conv" section): AxMaxPool, the real residual AxQuantizedAdd, and
+    AxQuantizedGlobAvgPool all schedule on the `teng2` engine, never on
+    `conv0`/`conv1` (reserved for AxQuantizedConv/Gemm MAC work) --
+    extending the same finding already confirmed for AxQuantizedNormalize
+    in this project's resnet18d profiling to three more real primitive
+    families.
+    """
+    model = _maxpool_model(2, 2, 0)
+    _, trace_path = _build_axmodel(
+        os.path.join(str(tmp_path), "maxpool_profiled"),
+        model,
+        (1, 4, 16, 16),
+        profile=True,
+    )
+    trace = json.load(open(trace_path))
+    events = trace["traceEvents"] if isinstance(trace, dict) else trace
+    maxpool_events = [
+        e for e in events if e.get("ph") == "X" and "AxMaxPool" in e.get("name", "")
+    ]
+    assert maxpool_events, "expected at least one AxMaxPool event in the trace"
+    for e in maxpool_events:
+        assert e["tid"] == "teng2", (e, "expected AxMaxPool to schedule on teng2")

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -79,6 +79,63 @@ def _single_conv_model(cin, cout, k):
     return model
 
 
+def _asym_kernel_model(kh, kw, cin=4, cout=4, insz=16):
+    """One `Conv` with an asymmetric `kh x kw` kernel -- same total weight
+    count regardless of orientation (`kh * kw` is the same for `(3,1)` and
+    `(1,3)`), isolating orientation from raw weight data size."""
+    rng = np.random.RandomState(0)
+    w = (rng.randn(cout, cin, kh, kw) * 0.1).astype(np.float32)
+    ph, pw = kh // 2, kw // 2
+    graph = helper.make_graph(
+        [helper.make_node("Conv", ["x", "w"], ["y"], pads=[ph, pw, ph, pw])],
+        f"g_kernel_{kh}x{kw}",
+        [
+            helper.make_tensor_value_info(
+                "x", onnx.TensorProto.FLOAT, [1, cin, insz, insz]
+            )
+        ],
+        [
+            helper.make_tensor_value_info(
+                "y", onnx.TensorProto.FLOAT, [1, cout, insz, insz]
+            )
+        ],
+        initializer=[numpy_helper.from_array(w, name="w")],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    onnx.checker.check_model(model)
+    return model
+
+
+def _autopad_model(use_auto_pad, cin=4, cout=4, k=3, insz=16):
+    """One `Conv`, either using `auto_pad="SAME_UPPER"` or the numerically
+    equivalent explicit `pads` -- to check whether auto_pad leaves any
+    trace in mcode after normalization."""
+    rng = np.random.RandomState(0)
+    w = (rng.randn(cout, cin, k, k) * 0.1).astype(np.float32)
+    if use_auto_pad:
+        node = helper.make_node("Conv", ["x", "w"], ["y"], auto_pad="SAME_UPPER")
+    else:
+        node = helper.make_node("Conv", ["x", "w"], ["y"], pads=[1, 1, 1, 1])
+    graph = helper.make_graph(
+        [node],
+        f"g_autopad_{use_auto_pad}",
+        [
+            helper.make_tensor_value_info(
+                "x", onnx.TensorProto.FLOAT, [1, cin, insz, insz]
+            )
+        ],
+        [
+            helper.make_tensor_value_info(
+                "y", onnx.TensorProto.FLOAT, [1, cout, insz, insz]
+            )
+        ],
+        initializer=[numpy_helper.from_array(w, name="w")],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    onnx.checker.check_model(model)
+    return model
+
+
 def _dilation_conv_model(dilation, pad, cin=4, cout=4, k=3, insz=16):
     """One `Conv` with a specific dilation/padding -- padding chosen by the
     caller so output shape (and thus mcode's total serialized length) stays
@@ -585,3 +642,66 @@ def test_mcode_nondeterminism_does_not_change_real_device_output(tmp_path):
 
     for out in outputs[1:]:
         assert np.array_equal(outputs[0], out), "expected bit-identical device output"
+
+
+def test_kernel_orientation_changes_mcode_size_despite_equal_weight_count(tmp_path):
+    """Confirmed real (see the README's "Two more Conv attributes tried"
+    section): a `3x1` and a `1x3` kernel hold the exact same number of
+    weight values (`cin*cout*3*1 == cin*cout*1*3`), so Wbt comes out the
+    same size either way -- but mcode does not. A real, new asymmetry:
+    the compiler encodes a "tall" and a "wide" kernel of identical size
+    differently, plausibly due to a real difference in how it scans/tiles
+    the input by row vs. column.
+    """
+    wbt_h, mcode_h = _build_and_get_wbt_and_mcode_bytes(
+        os.path.join(str(tmp_path), "k3x1"), _asym_kernel_model(3, 1), (1, 4, 16, 16)
+    )
+    wbt_w, mcode_w = _build_and_get_wbt_and_mcode_bytes(
+        os.path.join(str(tmp_path), "k1x3"), _asym_kernel_model(1, 3), (1, 4, 16, 16)
+    )
+    assert len(wbt_h) == len(wbt_w), "same weight count should give the same Wbt size"
+    assert len(mcode_h) != len(mcode_w), (
+        "expected kernel orientation to produce a real mcode size difference"
+    )
+
+
+def test_autopad_normalizes_with_no_signal_beyond_known_noise(tmp_path):
+    """Confirmed real (see the README's "Two more Conv attributes tried"
+    section): `auto_pad="SAME_UPPER"` vs. the numerically-equivalent
+    explicit `pads` first looked like a real signal (a same-length pair
+    with a 4-byte diff at a location not seen before), but rebuilding the
+    identical `auto_pad=NOTSET` config alone, twice, reproduced a nearly
+    identical diff -- confirming it was this project's second encounter
+    with non-deterministic label noise, not a real auto_pad-specific
+    encoding. auto_pad appears to fully normalize away before
+    quantization. This test locks in the *correct*, determinism-checked
+    conclusion: the auto_pad-vs-explicit diff should be no bigger than
+    what an identical rebuild alone already produces.
+    """
+    same_model = _autopad_model(use_auto_pad=True)
+    explicit_model = _autopad_model(use_auto_pad=False)
+
+    _, mcode_same = _build_and_get_wbt_and_mcode_bytes(
+        os.path.join(str(tmp_path), "same"), same_model, (1, 4, 16, 16)
+    )
+    _, mcode_explicit_a = _build_and_get_wbt_and_mcode_bytes(
+        os.path.join(str(tmp_path), "explicit_a"), explicit_model, (1, 4, 16, 16)
+    )
+    _, mcode_explicit_b = _build_and_get_wbt_and_mcode_bytes(
+        os.path.join(str(tmp_path), "explicit_b"), explicit_model, (1, 4, 16, 16)
+    )
+    assert len(mcode_same) == len(mcode_explicit_a) == len(mcode_explicit_b)
+
+    cross_diff = sum(
+        1 for i in range(len(mcode_same)) if mcode_same[i] != mcode_explicit_a[i]
+    )
+    noise_diff = sum(
+        1
+        for i in range(len(mcode_explicit_a))
+        if mcode_explicit_a[i] != mcode_explicit_b[i]
+    )
+    assert cross_diff <= noise_diff + 2, (
+        (cross_diff, noise_diff),
+        "auto_pad-vs-explicit diff should not exceed identical-rebuild noise "
+        "by more than a token amount",
+    )

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -13,6 +13,7 @@ tests/test_pulsar2_hf_to_axmodel.py.
 
 import json
 import os
+import re
 import sys
 
 import numpy as np
@@ -627,6 +628,30 @@ def _mcode_from_axmodel(axmodel_path):
     return bytes(inits[mcode_key].raw_data)
 
 
+def _gemm_model(transb, m=1, k=16, n=8):
+    """One `Gemm(x, w, b)` -- `transb` selects whether `w` is stored as
+    `[k,n]` (transB=0) or `[n,k]` (transB=1), same logical matrix either
+    way."""
+    rng = np.random.RandomState(0)
+    w_shape = (n, k) if transb else (k, n)
+    w = (rng.randn(*w_shape) * 0.1).astype(np.float32)
+    b = (rng.randn(n) * 0.1).astype(np.float32)
+    node = helper.make_node("Gemm", ["x", "w", "b"], ["y"], transB=transb)
+    graph = helper.make_graph(
+        [node],
+        f"g_gemm_transb{transb}",
+        [helper.make_tensor_value_info("x", onnx.TensorProto.FLOAT, [m, k])],
+        [helper.make_tensor_value_info("y", onnx.TensorProto.FLOAT, [m, n])],
+        initializer=[
+            numpy_helper.from_array(w, name="w"),
+            numpy_helper.from_array(b, name="b"),
+        ],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    onnx.checker.check_model(model)
+    return model
+
+
 def _maxpool_model(k, stride, pad, ceil_mode=0, cin=4, insz=16):
     import math
 
@@ -817,3 +842,61 @@ def test_non_mac_ops_schedule_on_teng2_not_conv_engines(tmp_path):
     assert maxpool_events, "expected at least one AxMaxPool event in the trace"
     for e in maxpool_events:
         assert e["tid"] == "teng2", (e, "expected AxMaxPool to schedule on teng2")
+
+
+def test_gemm_schedules_on_conv_engine_like_conv_does(tmp_path):
+    """Confirmed real via --profile (see the README's "Gemm joins the MAC
+    engines" section): Gemm schedules on `conv1`, joining Conv in the
+    MAC-engine category rather than teng2's non-MAC group.
+    """
+    model = _gemm_model(transb=0)
+    _, trace_path = _build_axmodel(
+        os.path.join(str(tmp_path), "gemm_profiled"), model, (1, 16), profile=True
+    )
+    trace = json.load(open(trace_path))
+    events = trace["traceEvents"] if isinstance(trace, dict) else trace
+    gemm_events = [
+        e
+        for e in events
+        if e.get("ph") == "X" and re.fullmatch(r"y_\d+_\d+", e.get("name", ""))
+    ]
+    assert gemm_events, "expected at least one Gemm output event in the trace"
+    for e in gemm_events:
+        assert e["tid"] in ("conv0", "conv1"), (
+            e,
+            "expected Gemm to schedule on a conv engine",
+        )
+
+
+def test_gemm_transb_produces_a_real_substantial_signal_beyond_noise(tmp_path):
+    """Confirmed real (see the README's "Gemm joins the MAC engines"
+    section): this Gemm shape has the same small, known non-deterministic
+    noise as Conv/MaxPool (confirmed here by rebuilding `transb=0` twice --
+    an *initial* single rebuild pair happened to show zero diffs, which
+    turned out to be a lucky draw, not a real "this shape is noise-free"
+    property; corrected after a second rebuild pair showed the familiar
+    ~6-byte noise). Even accounting for that, transB produces a real,
+    substantial signal far beyond noise scale: dozens of differing bytes,
+    including a large contiguous block, at a completely different scale
+    than the small periodic fields found for Conv's attributes.
+    """
+    model_a = _gemm_model(transb=0)
+    model_b = _gemm_model(transb=1)
+
+    mcode_a1 = _mcode_from_axmodel(
+        _build_axmodel(os.path.join(str(tmp_path), "a1"), model_a, (1, 16))
+    )
+    mcode_a2 = _mcode_from_axmodel(
+        _build_axmodel(os.path.join(str(tmp_path), "a2"), model_a, (1, 16))
+    )
+    mcode_b = _mcode_from_axmodel(
+        _build_axmodel(os.path.join(str(tmp_path), "b"), model_b, (1, 16))
+    )
+    assert len(mcode_a1) == len(mcode_a2) == len(mcode_b)
+
+    noise_diff = sum(1 for i in range(len(mcode_a1)) if mcode_a1[i] != mcode_a2[i])
+    transb_diff = sum(1 for i in range(len(mcode_a1)) if mcode_a1[i] != mcode_b[i])
+    assert transb_diff > noise_diff + 50, (
+        (transb_diff, noise_diff),
+        "expected a real, substantial transB signal well beyond noise scale",
+    )


### PR DESCRIPTION
## Summary

Answers "how many mcode are covered now?" by updating the existing "How much of mcode do we actually understand, for a real model?" section rather than leaving it stale relative to everything found since.

The raw headline is unchanged: still roughly **1% exactly decoded** for a real model (Conv's bias array lives in Wbt, not mcode, so that work never added to mcode's own count), and `AxQuantizedConv`'s dominant compute payload (69.5% of all scheduled work) is still opaque.

But the *map* of what's left is materially more complete now:

- **Two distinct periodic fields precisely located inside a real `AxQuantizedConv` command itself** (not Wbt) -- the original 4-repeats/7-byte-stride field, confirmed dilation/groups-sensitive across six independent experiments, plus a second field that only activates once dilation reaches 4. Neither decoded at the bit level, but both are now real, reproducible targets with exact byte offsets.
- **The confirmed non-deterministic region needs no further decoding at all** -- it's a functionally-inert internal label permutation (bit-identical real device output regardless of which permutation a build lands on), not an encoded parameter. A real subtraction from the mystery pile.
- **A quantified bound on how much of mcode is even distinct**: the 43.4%-of-bytes-are-exact-duplicates finding means the effective amount of unique content to decode in a real model is well under its raw byte count.
- **A negative result that narrows where to look next**: profiling a real two-op chain found no separately-scheduled transfer event for inter-op data movement, ruling out one plausible place further decoding might have focused.

## Test plan
- Documentation-only change (no code). Verified section structure renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UC8vhJgE71RLFF4DgdSP9P

## Update: two more Conv attributes tried, one real finding, one important false lead

Continues the differential analysis into Conv attributes not yet tried.

**Real finding**: a `3x1` and a `1x3` kernel hold the exact same weight count, so Wbt comes out byte-identical in size either way -- but mcode does not (3,528 bytes vs 3,208 bytes). A genuine asymmetry: the compiler encodes a "tall" and a "wide" kernel of identical size differently, plausibly due to how it scans/tiles the input by row vs. column.

**A false lead, caught before being trusted**: `auto_pad="SAME_UPPER"` vs. the numerically-equivalent explicit `pads` first looked like a real signal -- same mcode length, only 4 bytes different, at a location never seen in any prior section. Rebuilding the identical `auto_pad=NOTSET` config alone, twice, reproduced a nearly identical diff pattern -- the same multiset-of-values non-determinism signature already confirmed elsewhere, just at a **second, previously-unknown noise zone** (~301-325, distinct from the ~858-882 zone found earlier). `auto_pad` appears to fully normalize away before quantization, with no real functional difference.

**Methodologically important**: this confirms mcode's non-determinism isn't confined to a single zone -- there are now at least two independent noisy regions found, both stumbled into by the same "found a tiny diff, got excited before checking determinism" mistake. Any future same-length-diff finding in this space needs its own rebuild-and-recheck before being trusted, not just a check against the zones already known.

Added regression tests for both findings.

- [x] `python -m pytest tests/test_axera_mcode_structure.py -v` -- 9 tests total in the file now (2 new ones individually confirmed passing, 73s), for real against the real `pulsar2:6.0-lite` image.


## Update: expanding coverage past Conv, using --profile metadata this time

Continues increasing resnet18d's real coverage by extending past `Conv` for the first time -- targeting `AxMaxPool`, the real residual `AxQuantizedAdd` (two real activation inputs, not the old constant-broadcast case), and `AxQuantizedGlobAvgPool`, three of resnet18d's own real primitive families from its own profiling. Per feedback mid-session, this round also checks `--profile` trace metadata directly, not just mcode bytes.

**A real, clean architectural split by execution engine**: all three ops schedule on **`teng2`**, never on `conv0`/`conv1` (reserved for `AxQuantizedConv`/`Gemm` MAC work) -- extending the same pattern already found for `AxQuantizedNormalize` in the `resnet18d` profiling to three more real primitive types. A clean rule confirmed across four distinct ops now: non-MAC work runs on `teng2`, MAC work runs on the conv engines. `Pre_AxTranspose`'s own placement is context-dependent (`cv3` wrapping `MaxPool`/`GlobalAvgPool`, `teng2` wrapping `Conv`).

**A third confirmed false lead, same signature as before**: `MaxPool`'s `ceil_mode=0` vs `ceil_mode=1` (on a shape where it doesn't change output size) produced a same-length pair with a few differing bytes -- rebuilding `ceil_mode=0` alone, twice, reproduced the same diff. The exact same non-deterministic label-noise signature already found on `Conv`/`auto_pad`, now confirmed on a completely different op type -- direct evidence the non-determinism is global, not Conv-specific.

`MaxPool`'s kernel size behaves like `Conv`'s did: a real, 32-byte-unit-consistent length change, but not a same-length pair, so no clean localized diff.

- [x] `python -m pytest tests/test_axera_mcode_structure.py -v` -- 11 tests total in the file now (2 new ones individually confirmed passing, 60s), for real against the real `pulsar2:6.0-lite` image.


## Update: Gemm confirmed, plus a second corrected noise-free claim

Extends coverage to `Gemm` (resnet18d's final FC layer, 3.3% of its real schedule) and `AveragePool` (distinct from `GlobalAveragePool`, used 3x in resnet18d's real downsample paths).

**Real finding**: `Gemm` schedules on `conv1`, joining `Conv` in the MAC-engine category. Its trace events keep the output tensor's own name rather than being renamed to an `AxQuantized*`-style primitive -- matching the un-renamed `"/fc/Gemm_*"` names already seen in this project's real `resnet18d` profiling. `AveragePool` schedules on `teng2`, joining the non-MAC group, with two sub-events at the same input size where `MaxPool` only needed one.

**A second corrected premature claim, caught while writing the regression test for it**: this round initially reported the `Gemm` shape as noise-free based on a single rebuild pair. A second, independent rebuild pair (surfaced while building the automated test) showed the same `~301-325` noise zone already confirmed on Conv/MaxPool/auto_pad/ceil_mode -- this shape isn't noise-free after all. The core `transB` finding survives the correction: of 95 originally-reported differing bytes, only 2 fall inside the confirmed noisy zone; the remaining ~93, including a clean 85-byte contiguous block, sit well outside any known noise zone and hold up as real -- still the largest, cleanest signal isolated in this whole investigation.

Also fixed a real bug in the Gemm-engine test itself: a `startswith("y_")` filter accidentally matched `"y_DequantizeLinear_0_0"` alongside the real Gemm compute events, causing a false failure -- tightened to an exact `y_\d+_\d+` pattern.

**Note**: one existing device-dependent test (`test_mcode_nondeterminism_does_not_change_real_device_output`) couldn't be re-verified in this run -- the AXCL PCIe card is still detected by the OS but its kernel driver module isn't currently loaded, an environment issue outside this change's scope. All 12 other tests in the file pass.

- [x] `python -m pytest tests/test_axera_mcode_structure.py -v` -- 12/13 passed (1 skipped-equivalent failure due to the device driver being unloaded, unrelated to this change), for real against the real `pulsar2:6.0-lite` image.
