### PR TITLE
Add gated (SwiGLU/GeGLU) FFN pair support to MatMulBnb4 structured pruning

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -18860,17 +18860,20 @@ def apply_structured_pruning_matmul_nbits(
 #     ``MatMulNBits``'s own identical-shaped decline for its own analogous
 #     alignment failure. See
 #     ``test_matmul_bnb4_pruning_declines_k_not_multiple_of_block_size``.
-#   * No grouped/gated (SwiGLU/GeGLU) pair, residual/skip-connection merge,
-#     or Concat-merged branch group is matched -- only the plain single
-#     producer -> [zero or more shape-preserving unary activations,
-#     `_UNARY_PASS_THROUGH`] -> single plain-float consumer topology,
-#     mirroring ``MatMulNBits``'s own identical scope decision (and, in
-#     turn, the QDQ section's own ``_walk_to_consumer_qdq``) for the same
-#     reason: this module's existing gated-MLP detection
-#     (:func:`_find_gated_chains`) is plain-float-chain machinery that does
-#     not apply to a block-quantized producer's own packed operands without
-#     the same kind of dedicated extension ``MatMulNBits`` itself never
-#     attempted either.
+#   * The gated (SwiGLU/GeGLU) FFN pair IS matched
+#     (:func:`_find_matmul_bnb4_gated_chains`), mirroring ``MatMulNBits``'s
+#     own :func:`_find_matmul_nbits_gated_chains`: gate_proj/up_proj, each
+#     independently either a ``MatMulBnb4`` node or a plain-float
+#     MatMul/vanilla-Gemm peer, combined by an elementwise ``Mul`` (each
+#     branch optionally through one `_UNARY_PASS_THROUGH` activation first)
+#     or ONNX's native fused ``SwiGLU`` node, feeding one plain-float
+#     down_proj consumer -- with at least one of gate_proj/up_proj a
+#     ``MatMulBnb4`` node (an all-plain-float triple stays
+#     :func:`_find_gated_chains`'s own job). No residual/skip-connection
+#     merge or Concat-merged branch group is matched beyond that -- only the
+#     plain single producer -> [zero or more shape-preserving unary
+#     activations, `_UNARY_PASS_THROUGH`] -> single plain-float consumer
+#     topology, or the one gated-pair composition above.
 #   * A shared/tied ``B``/``absmax`` tensor (read by more than one node) is
 #     declined by the matcher itself, the same bar every other matcher in
 #     this module is held to.
@@ -18953,6 +18956,9 @@ class _MatMulBnb4Weight:
     quant_type: int
     blocks_per_row: int
     row_bytes: int
+
+
+_MatMulBnb4ChainSide = Union[_MatMulBnb4Weight, _PlainMatMulNBitsPeer]
 
 
 def _match_matmul_bnb4_producer(
@@ -19079,6 +19085,54 @@ def _slice_matmul_bnb4_producer_rows(w: _MatMulBnb4Weight, keep: np.ndarray) -> 
     )
 
     _set_matmul_nbits_int_attr(w.node, "N", len(keep))
+
+
+def _matmul_bnb4_chain_side_key(side: _MatMulBnb4ChainSide) -> str:
+    """A name uniquely identifying the underlying weight tensor `side`
+    resolves to -- ``b_init``'s own name for a ``MatMulBnb4`` side,
+    ``w_init``'s own name for a plain-float peer -- used by the gated-chain
+    application loop to detect a shared/tied weight playing the same role
+    (producer or consumer) in more than one chain. Mirrors
+    :func:`_matmul_nbits_chain_side_key`.
+    """
+    if isinstance(side, _MatMulBnb4Weight):
+        return side.b_init.name
+    return side.w_init.name
+
+
+def _matmul_bnb4_chain_producer_weight_nk(side: _MatMulBnb4ChainSide) -> np.ndarray:
+    """``[N, K]`` float64 view of one gated-chain PRODUCER's own weight, for
+    IMPORTANCE RANKING ONLY (:func:`_qdq_channel_importance`/
+    :func:`_matmul_bnb4_gated_channel_importance`) -- never written back to
+    the graph. A ``MatMulBnb4`` side dequantizes via
+    :func:`_matmul_bnb4_dequantized`; a plain-float peer is read directly,
+    transposed only when NOT already stored ``[N, K]``. Mirrors
+    :func:`_matmul_nbits_chain_producer_weight_nk`.
+    """
+    if isinstance(side, _MatMulBnb4Weight):
+        return _matmul_bnb4_dequantized(side)
+    w = _to_f64(side.w_init)
+    return w if side.weight_transposed else w.T
+
+
+def _slice_matmul_bnb4_chain_producer(
+    side: _MatMulBnb4ChainSide, keep: np.ndarray
+) -> None:
+    """Slices one gated-chain PRODUCER's own output channels to `keep`
+    (ascending indices) -- dispatches to
+    :func:`_slice_matmul_bnb4_producer_rows` for a ``MatMulBnb4`` side, or a
+    direct :func:`_slice_producer_weight` (plus its own bias, if present)
+    for a plain-float peer. Mirrors :func:`_slice_matmul_nbits_chain_producer`.
+    """
+    if isinstance(side, _MatMulBnb4Weight):
+        _slice_matmul_bnb4_producer_rows(side, keep)
+        return
+    _slice_producer_weight(side.w_init, side.weight_transposed, keep, is_conv=False)
+    if side.bias_init is not None:
+        bias = onnx.numpy_helper.to_array(side.bias_init)
+        side.bias_init.CopyFrom(
+            onnx.numpy_helper.from_array(bias[keep], name=side.bias_init.name)
+        )
 
 
 @dataclass(frozen=True)
@@ -19297,6 +19351,230 @@ def _find_matmul_bnb4_chains(
     return chains
 
 
+def _trace_gate_producer_backward_bnb4(
+    tensor_name: str,
+    node_by_output: Dict[str, onnx.NodeProto],
+    producer_infos: Dict[str, Tuple[onnx.NodeProto, _MatMulBnb4ChainSide, int]],
+    consumers_of: Dict[str, List[onnx.NodeProto]],
+    graph_outputs: Set[str],
+    max_hops: int,
+) -> Optional[
+    Tuple[Tuple[onnx.NodeProto, _MatMulBnb4ChainSide, int], Tuple[onnx.NodeProto, ...]]
+]:
+    """The ``MatMulBnb4`` analogue of
+    :func:`_trace_gate_producer_backward_matmul_nbits` (itself the
+    ``MatMulNBits`` analogue of :func:`_trace_gate_producer_backward`/
+    :func:`_trace_gate_producer_backward_qdq`): walks backward from
+    `tensor_name` through unary activation ops until it resolves to a
+    ``MatMulBnb4``-or-plain-float MatMul/vanilla-Gemm producer's raw output
+    (`producer_infos`, built from :func:`_match_matmul_bnb4_producer`/
+    :func:`_match_plain_matmul_nbits_peer` -- see
+    :func:`_find_matmul_bnb4_gated_chains`). Duplicated rather than shared
+    with the ``MatMulNBits`` section's own walker, for the identical reason
+    that section gives its own duplicate of the QDQ section's walker
+    (structurally different `producer_infos` value types).
+    """
+    pre_ops: List[onnx.NodeProto] = []
+    cur = tensor_name
+    for _ in range(max_hops):
+        if len(consumers_of.get(cur, [])) != 1 or cur in graph_outputs:
+            return None
+        if cur in producer_infos:
+            return producer_infos[cur], tuple(reversed(pre_ops))
+        producer_node = node_by_output.get(cur)
+        if producer_node is None:
+            return None
+        if not (
+            producer_node.op_type in _UNARY_PASS_THROUGH
+            and len(producer_node.input) == 1
+            and len(producer_node.output) == 1
+        ):
+            return None
+        pre_ops.append(producer_node)
+        cur = producer_node.input[0]
+    return None
+
+
+def _matmul_bnb4_gated_channel_importance(
+    w_a_nk: np.ndarray, w_b_nk: np.ndarray, importance_norm: _ImportanceNorm
+) -> np.ndarray:
+    """Combined importance across a ``MatMulBnb4`` gated pair's two
+    producers -- root-sum-square (L2) or plain sum (L1) of each producer's
+    own per-channel dequantized-or-plain row norm, mirroring
+    :func:`_matmul_nbits_gated_channel_importance`'s own identical
+    combination (duplicated rather than shared for this section's own
+    established "self-contained" reason -- see its own top comment).
+    """
+    if importance_norm == "l1":
+        return _qdq_channel_importance(w_a_nk, "l1") + _qdq_channel_importance(
+            w_b_nk, "l1"
+        )
+    return np.sqrt(
+        np.square(_qdq_channel_importance(w_a_nk, "l2"))
+        + np.square(_qdq_channel_importance(w_b_nk, "l2"))
+    )
+
+
+@dataclass(frozen=True)
+class _MatMulBnb4GatedChain:
+    """The ``MatMulBnb4`` analogue of :class:`_MatMulNBitsGatedChain` -- two
+    producers (`producer_a`/`producer_b`, gate_proj/up_proj, each EITHER a
+    ``MatMulBnb4`` node OR a plain-float peer -- see
+    :data:`_MatMulBnb4ChainSide`) combined by an elementwise product,
+    feeding one `consumer` (down_proj), with at least one of `producer_a`/
+    `producer_b` a ``MatMulBnb4`` node. `consumer` is always a plain-float
+    peer -- unlike ``MatMulNBits``'s own bidirectional consumer matching, a
+    ``MatMulBnb4`` node is never matched as a chain's CONSUMER at all (see
+    this section's own top comment for why). `producer_a_pre_ops`/
+    `producer_b_pre_ops` carry each branch's own activation nodes between
+    its raw output and the combine point, mirroring
+    :attr:`_MatMulNBitsGatedChain.producer_a_pre_ops`/
+    :attr:`_MatMulNBitsGatedChain.producer_b_pre_ops`. See
+    :func:`_find_matmul_bnb4_gated_chains`.
+    """
+
+    producer_a: _MatMulBnb4ChainSide
+    producer_a_pre_ops: Tuple[onnx.NodeProto, ...]
+    producer_b: _MatMulBnb4ChainSide
+    producer_b_pre_ops: Tuple[onnx.NodeProto, ...]
+    chain_ops: Tuple[Tuple[onnx.NodeProto, Optional[str]], ...]
+    consumer: _PlainMatMulNBitsPeer
+    n_channels: int
+
+
+def _find_matmul_bnb4_gated_chains(
+    graph: onnx.GraphProto,
+    value_info_by_name: Optional[Dict[str, onnx.ValueInfoProto]] = None,
+) -> List[_MatMulBnb4GatedChain]:
+    """The ``MatMulBnb4`` analogue of :func:`_find_matmul_nbits_gated_chains`
+    (and, ultimately, of :func:`_find_gated_chains` itself): recognizes the
+    same gated (SwiGLU/GeGLU) MatMul/vanilla-Gemm pair -- gate_proj/up_proj
+    sharing one input, combined via a plain elementwise ``Mul`` of two
+    non-constant operands (each optionally through its own
+    `_UNARY_PASS_THROUGH` activation) or ONNX's native fused ``SwiGLU``
+    node, feeding into exactly one downstream plain-float consumer whose
+    input-channel count matches (:func:`_walk_to_matmul_bnb4_consumer`) --
+    except gate_proj/up_proj may now each independently be EITHER a
+    ``MatMulBnb4`` node OR a plain-float MatMul/vanilla-Gemm peer
+    (:func:`_match_matmul_bnb4_producer`/:func:`_match_plain_matmul_nbits_peer`,
+    the exact same resolution :func:`_find_matmul_bnb4_chains`'s own
+    single-producer case uses), requiring at least one of the two to
+    actually be ``MatMulBnb4`` (an all-plain-float triple is
+    :func:`_find_gated_chains`'s own job, not duplicated here). down_proj
+    (the consumer) is always plain-float, exactly like the non-gated case
+    above -- see this section's own top comment for why a ``MatMulBnb4``
+    node is never matched as a chain's CONSUMER at all.
+
+    `value_info_by_name`, when given, is threaded straight through to
+    :func:`_walk_to_matmul_bnb4_consumer` -- see its own identical
+    parameter.
+    """
+    initializer_map = _constant_map(graph)
+    consumers_of = _consumers_of(graph)
+    graph_outputs = {o.name for o in graph.output}
+    node_by_output = {out: node for node in graph.node for out in node.output}
+
+    def _is_internal(name: str) -> bool:
+        return len(consumers_of.get(name, [])) == 1 and name not in graph_outputs
+
+    producer_infos: Dict[str, Tuple[onnx.NodeProto, _MatMulBnb4ChainSide, int]] = {}
+    for node in graph.node:
+        bnb4 = _match_matmul_bnb4_producer(node, initializer_map, consumers_of)
+        if bnb4 is not None:
+            producer_infos[node.output[0]] = (node, bnb4, bnb4.N)
+            continue
+        peer = _match_plain_matmul_nbits_peer(node, initializer_map, consumers_of)
+        if peer is not None:
+            producer_infos[node.output[0]] = (node, peer, peer.out_channels)
+
+    chains: List[_MatMulBnb4GatedChain] = []
+    for node in graph.node:
+        if node.op_type == "Mul" and len(node.input) == 2 and len(node.output) == 1:
+            a_name, b_name = node.input
+            if (
+                a_name == b_name
+                or a_name in initializer_map
+                or b_name in initializer_map
+            ):
+                continue
+            trace_a = _trace_gate_producer_backward_bnb4(
+                a_name,
+                node_by_output,
+                producer_infos,
+                consumers_of,
+                graph_outputs,
+                _MAX_CHAIN_HOPS,
+            )
+            trace_b = _trace_gate_producer_backward_bnb4(
+                b_name,
+                node_by_output,
+                producer_infos,
+                consumers_of,
+                graph_outputs,
+                _MAX_CHAIN_HOPS,
+            )
+            if trace_a is None or trace_b is None:
+                continue
+            info_a, pre_a = trace_a
+            info_b, pre_b = trace_b
+        elif (
+            node.op_type == "SwiGLU" and len(node.input) == 2 and len(node.output) == 1
+        ):
+            a_name, b_name = node.input
+            if a_name in initializer_map or b_name in initializer_map:
+                continue
+            if not (_is_internal(a_name) and _is_internal(b_name)):
+                continue
+            info_a_lookup = producer_infos.get(a_name)
+            info_b_lookup = producer_infos.get(b_name)
+            if info_a_lookup is None or info_b_lookup is None:
+                continue
+            info_a, pre_a = info_a_lookup, ()
+            info_b, pre_b = info_b_lookup, ()
+        else:
+            continue
+
+        node_a, side_a, n_a = info_a
+        node_b, side_b, n_b = info_b
+        if node_a is node_b or n_a != n_b:
+            continue
+
+        out_name = node.output[0]
+        if not _is_internal(out_name):
+            continue
+
+        found = _walk_to_matmul_bnb4_consumer(
+            out_name,
+            initializer_map,
+            consumers_of,
+            graph_outputs,
+            n_a,
+            _MAX_CHAIN_HOPS,
+            value_info_by_name,
+        )
+        if found is None:
+            continue
+        consumer, chain_ops = found
+
+        if isinstance(side_a, _PlainMatMulNBitsPeer) and isinstance(
+            side_b, _PlainMatMulNBitsPeer
+        ):
+            continue  # all plain float -- _find_gated_chains's own job
+
+        chains.append(
+            _MatMulBnb4GatedChain(
+                producer_a=side_a,
+                producer_a_pre_ops=pre_a,
+                producer_b=side_b,
+                producer_b_pre_ops=pre_b,
+                chain_ops=chain_ops,
+                consumer=consumer,
+                n_channels=n_a,
+            )
+        )
+    return chains
+
+
 def apply_structured_pruning_matmul_bnb4(
     model: Union[str, onnx.ModelProto],
     sparsity: float = 0.5,
@@ -19333,6 +19611,27 @@ def apply_structured_pruning_matmul_bnb4(
     real quantizer round-trip both) and
     ``test_matmul_bnb4_pruning_declines_k_not_multiple_of_block_size``.
 
+    Also handles the gated (SwiGLU/GeGLU) FFN pair
+    (:func:`_find_matmul_bnb4_gated_chains`, the ``MatMulBnb4`` analogue of
+    :func:`_find_matmul_nbits_gated_chains`) -- gate_proj/up_proj (two
+    producers sharing one input, EACH independently either a ``MatMulBnb4``
+    node or a plain-float MatMul/vanilla-Gemm peer, combined by an
+    elementwise ``Mul`` with gate_proj's output optionally passed through
+    one of the same unary activations first, or ONNX's native fused
+    ``SwiGLU`` op) feeding one down_proj consumer -- always plain-float,
+    exactly like the non-gated case above -- with at least one of
+    gate_proj/up_proj a ``MatMulBnb4`` node. Both producers are ranked by
+    combined (root-sum-square, or plain sum for L1) importance of their own
+    dequantized-or-plain rows (:func:`_matmul_bnb4_gated_channel_importance`)
+    and cut to the *same* surviving channel-index set, since they're about
+    to be multiplied elementwise -- each producer sliced by the same
+    per-role helper an ordinary chain's producer already uses
+    (:func:`_slice_matmul_bnb4_chain_producer`). down_proj is sliced on its
+    input axis exactly like an ordinary consumer above, with no block
+    structure to worry about (it's always plain-float). Gated pairs are
+    MatMul/Gemm-only, mirroring :func:`_find_gated_chains`'s own
+    restriction.
+
     :param model: onnx ModelProto object or file path
     :param sparsity: fraction of each eligible producer's output channels to
             drop (rounded, at least one channel is always kept)
@@ -19362,7 +19661,8 @@ def apply_structured_pruning_matmul_bnb4(
         )
         initializer_map = _constant_map(graph)
         chains = _find_matmul_bnb4_chains(graph, value_info_by_name)
-        if not chains:
+        gated_chains = _find_matmul_bnb4_gated_chains(graph, value_info_by_name)
+        if not chains and not gated_chains:
             continue
 
         producer_touched: Set[str] = set()
@@ -19410,6 +19710,58 @@ def apply_structured_pruning_matmul_bnb4(
             const_touched.update(consts)
             stale_value_info.add(p.node.output[0])
             stale_value_info.update(op.output[0] for op, _ in chain.chain_ops)
+
+        for gchain in gated_chains:
+            pa, pb, c = gchain.producer_a, gchain.producer_b, gchain.consumer
+            pa_key = _matmul_bnb4_chain_side_key(pa)
+            pb_key = _matmul_bnb4_chain_side_key(pb)
+            c_key = c.w_init.name
+            gconsts = {
+                const_name
+                for _, const_name in gchain.chain_ops
+                if const_name is not None
+            }
+            if pa_key == pb_key or pa_key == c_key or pb_key == c_key:
+                continue  # degenerate (a weight tied across two roles)
+            if (
+                pa_key in producer_touched
+                or pb_key in producer_touched
+                or c_key in consumer_touched
+                or (gconsts & const_touched)
+            ):
+                continue  # a shared/tied weight another chain already resized
+
+            n = gchain.n_channels
+            keep_count = max(1, n - round(n * sparsity))
+            if keep_count >= n:
+                continue  # rounds down to nothing for this layer -- no-op
+
+            w_a_nk = _matmul_bnb4_chain_producer_weight_nk(pa)
+            w_b_nk = _matmul_bnb4_chain_producer_weight_nk(pb)
+            importance = _matmul_bnb4_gated_channel_importance(
+                w_a_nk, w_b_nk, importance_norm
+            )
+            # `kind="stable"` for the same cross-platform-determinism reason
+            # the single-producer loop above documents on its own identical
+            # line.
+            keep = np.sort(np.argsort(-importance, kind="stable")[:keep_count])
+
+            _slice_matmul_bnb4_chain_producer(pa, keep)
+            _slice_matmul_bnb4_chain_producer(pb, keep)
+            _slice_consumer_weight(c.w_init, c.weight_transposed, keep, is_conv=False)
+            for _, const_name in gchain.chain_ops:
+                if const_name is not None:
+                    _slice_last_axis(initializer_map[const_name], keep)
+
+            producer_touched.add(pa_key)
+            producer_touched.add(pb_key)
+            consumer_touched.add(c_key)
+            const_touched.update(gconsts)
+            stale_value_info.add(pa.node.output[0])
+            stale_value_info.update(op.output[0] for op in gchain.producer_a_pre_ops)
+            stale_value_info.add(pb.node.output[0])
+            stale_value_info.update(op.output[0] for op in gchain.producer_b_pre_ops)
+            stale_value_info.update(op.output[0] for op, _ in gchain.chain_ops)
 
         if stale_value_info:
             kept = [vi for vi in graph.value_info if vi.name not in stale_value_info]

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -34979,6 +34979,231 @@ def test_matmul_bnb4_dequantized_matches_real_inference_session(quant_type):
     np.testing.assert_allclose(dequant_mine.T, dequant_ort, atol=1e-6)
 
 
+# --- apply_structured_pruning_matmul_bnb4: gated (SwiGLU/GeGLU) FFN pair ---
+#
+# The ``MatMulBnb4`` analogue of the ``MatMulNBits`` section's own
+# ``test_matmul_nbits_pruning_gated_ffn_matches_oracle`` and friends (see
+# ``onnxsim/pruning.py``'s own ``_find_matmul_bnb4_gated_chains``): a
+# gate_proj/up_proj pair -- each independently either a real, quantizer-
+# produced ``MatMulBnb4`` node or a plain-float peer -- combined by an
+# elementwise ``Mul`` (gate_proj through one activation first), feeding a
+# plain-float down_proj consumer. Unlike the ``MatMulNBits`` gated case,
+# down_proj is always plain-float here (a ``MatMulBnb4`` node is never
+# matched as a chain's CONSUMER at all -- see this module's own section
+# comment), so there is no block-alignment question on the consumer side.
+
+
+def _bnb4_gated_model(
+    K, H, Out, block_size, quant_type, W_gate, W_up, W_down, gate_activation="Sigmoid"
+):
+    """Builds ``X -> gate=MatMulBnb4(Bg) -[gate_activation]-> gate_act,
+    up=MatMulBnb4(Bu) -> Mul(gate_act, up) -> Y=MatMul(W_down)`` -- the real
+    ``com.microsoft::MatMulBnb4`` gated (SwiGLU/GeGLU) FFN pair, both
+    producers quantized via the REAL
+    ``onnxruntime.quantization.matmul_bnb4_quantizer.MatMulBnb4Quantizer``
+    (:func:`_bnb4_quantize`), feeding a plain-float down_proj consumer.
+    """
+    Bg, absmax_g = _bnb4_quantize(W_gate, quant_type, block_size)
+    Bu, absmax_u = _bnb4_quantize(W_up, quant_type, block_size)
+    model = _model(
+        f"""
+        g (float[3,{K}] X) => (float[3,{Out}] Y)
+        {{
+          gate = com.microsoft.MatMulBnb4 <K={K}, N={H}, block_size={block_size}, quant_type={quant_type}> (X, Bg, absmax_g)
+          gate_act = {gate_activation}(gate)
+          up = com.microsoft.MatMulBnb4 <K={K}, N={H}, block_size={block_size}, quant_type={quant_type}> (X, Bu, absmax_u)
+          h = Mul(gate_act, up)
+          Y = MatMul(h, W_down)
+        }}
+        """,
+        initializer=[
+            onnx.numpy_helper.from_array(Bg, name="Bg"),
+            onnx.numpy_helper.from_array(absmax_g, name="absmax_g"),
+            onnx.numpy_helper.from_array(Bu, name="Bu"),
+            onnx.numpy_helper.from_array(absmax_u, name="absmax_u"),
+            _f32(W_down, "W_down"),
+        ],
+        opset=21,
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+    return model
+
+
+def test_matmul_bnb4_pruning_gated_ffn_matches_oracle():
+    # Both gate_proj/up_proj are real MatMulBnb4 nodes -- the exact topology
+    # the confirmed gap's repro script built (gate -> Sigmoid -> Mul(with
+    # up) -> plain-float down_proj), quantized via the real
+    # MatMulBnb4Quantizer. Front 16-of-32 channels scaled up so the combined
+    # (root-sum-square) L2 importance keep-set is unambiguous.
+    K, H, Out, block_size = 64, 32, 8, 16
+    quant_type = 1  # NF4
+    rng = np.random.default_rng(300)
+    W_gate = (rng.standard_normal((K, H)) * 0.2).astype(np.float32)
+    W_gate[:, :16] *= 10.0
+    W_up = (rng.standard_normal((K, H)) * 0.2).astype(np.float32)
+    W_up[:, :16] *= 10.0
+    W_down = (rng.standard_normal((H, Out)) * 0.2).astype(np.float32)
+
+    model = _bnb4_gated_model(K, H, Out, block_size, quant_type, W_gate, W_up, W_down)
+    onnx.checker.check_model(model)
+
+    chains = onnxsim.pruning._find_matmul_bnb4_gated_chains(model.graph)
+    assert len(chains) == 1
+    # The plain single-producer finder must never also match either half of
+    # a gated pair (mirrors the MatMulNBits section's own identical
+    # non-overlap invariant).
+    assert onnxsim.pruning._find_matmul_bnb4_chains(model.graph) == []
+
+    pruned = onnxsim.apply_structured_pruning_matmul_bnb4(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep = np.arange(16)
+    mm_gate = next(n for n in pruned.graph.node if n.output[0] == "gate")
+    mm_up = next(n for n in pruned.graph.node if n.output[0] == "up")
+    assert next(a.i for a in mm_gate.attribute if a.name == "N") == 16
+    assert next(a.i for a in mm_up.attribute if a.name == "N") == 16
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W_down"].dims) == [16, Out]
+
+    # "Slice, don't recompute": each pruned producer's own packed bytes must
+    # be byte-identical to independently re-quantizing that row subset
+    # directly (the same invariant the non-gated section's own
+    # ``test_matmul_bnb4_pruning_producer_bytes_are_byte_identical_to_requantized_subset``
+    # establishes).
+    Bg_ref, absmax_g_ref = _bnb4_quantize(W_gate[:, keep], quant_type, block_size)
+    Bu_ref, absmax_u_ref = _bnb4_quantize(W_up[:, keep], quant_type, block_size)
+    np.testing.assert_array_equal(onnx.numpy_helper.to_array(inits["Bg"]), Bg_ref)
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["absmax_g"]), absmax_g_ref
+    )
+    np.testing.assert_array_equal(onnx.numpy_helper.to_array(inits["Bu"]), Bu_ref)
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["absmax_u"]), absmax_u_ref
+    )
+
+    # End-to-end: the pruned model's real output must match a reference
+    # built by independently re-quantizing/re-slicing each side directly --
+    # exact byte-level equality, not float tolerance (mirrors the non-gated
+    # section's own identical-strength check).
+    ref_model = _bnb4_gated_model(
+        K,
+        len(keep),
+        Out,
+        block_size,
+        quant_type,
+        W_gate[:, keep],
+        W_up[:, keep],
+        W_down[keep, :],
+    )
+    X = rng.uniform(-1, 1, size=(3, K)).astype(np.float32)
+    pruned_out = _run(pruned, {"X": X})[0]
+    ref_out = _run(ref_model, {"X": X})[0]
+    np.testing.assert_array_equal(pruned_out, ref_out)
+
+
+def test_matmul_bnb4_pruning_gated_ffn_mixed_plain_float_peer_matches_oracle():
+    # gate_proj is a real MatMulBnb4 node, up_proj is a plain-float peer --
+    # the "at least one side MatMulBnb4" mixed case
+    # _find_matmul_bnb4_gated_chains must also recognize (mirrors
+    # MatMulNBits's own identical either/or gated-producer flexibility).
+    K, H, Out, block_size = 64, 32, 8, 16
+    quant_type = 0  # FP4
+    rng = np.random.default_rng(302)
+    W_gate = (rng.standard_normal((K, H)) * 0.2).astype(np.float32)
+    W_gate[:, :16] *= 10.0
+    W_up = (rng.standard_normal((K, H)) * 0.2).astype(np.float32)
+    W_up[:, :16] *= 10.0
+    W_down = (rng.standard_normal((H, Out)) * 0.2).astype(np.float32)
+
+    Bg, absmax_g = _bnb4_quantize(W_gate, quant_type, block_size)
+    model = _model(
+        f"""
+        g (float[3,{K}] X) => (float[3,{Out}] Y)
+        {{
+          gate = com.microsoft.MatMulBnb4 <K={K}, N={H}, block_size={block_size}, quant_type={quant_type}> (X, Bg, absmax_g)
+          gate_act = Sigmoid(gate)
+          up = MatMul(X, W_up)
+          h = Mul(gate_act, up)
+          Y = MatMul(h, W_down)
+        }}
+        """,
+        initializer=[
+            onnx.numpy_helper.from_array(Bg, name="Bg"),
+            onnx.numpy_helper.from_array(absmax_g, name="absmax_g"),
+            _f32(W_up, "W_up"),
+            _f32(W_down, "W_down"),
+        ],
+        opset=21,
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+    onnx.checker.check_model(model)
+
+    chains = onnxsim.pruning._find_matmul_bnb4_gated_chains(model.graph)
+    assert len(chains) == 1
+
+    pruned = onnxsim.apply_structured_pruning_matmul_bnb4(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep = np.arange(16)
+    mm_gate = next(n for n in pruned.graph.node if n.output[0] == "gate")
+    assert next(a.i for a in mm_gate.attribute if a.name == "N") == 16
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W_up"].dims) == [K, 16]
+    assert list(inits["W_down"].dims) == [16, Out]
+
+    Bg_ref, absmax_g_ref = _bnb4_quantize(W_gate[:, keep], quant_type, block_size)
+    np.testing.assert_array_equal(onnx.numpy_helper.to_array(inits["Bg"]), Bg_ref)
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["absmax_g"]), absmax_g_ref
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["W_up"]), W_up[:, keep]
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["W_down"]), W_down[keep, :]
+    )
+
+
+def test_matmul_bnb4_pruning_gated_ffn_declines_shared_weight():
+    # gate_proj/up_proj sharing the identical B/absmax tensor pair -- the
+    # matcher itself (_match_matmul_bnb4_producer's own shared/tied-tensor
+    # bar) must decline BOTH nodes as producers, so no gated chain is found
+    # at all and the whole model is left byte-unchanged. Mirrors the
+    # non-gated section's own ``test_matmul_bnb4_pruning_declines_shared_weight``.
+    K, H, Out, block_size = 64, 32, 8, 16
+    quant_type = 1
+    rng = np.random.default_rng(301)
+    W_gate = rng.uniform(-1, 1, size=(K, H)).astype(np.float32)
+    W_down = rng.uniform(-1, 1, size=(H, Out)).astype(np.float32)
+    Bg, absmax_g = _bnb4_quantize(W_gate, quant_type, block_size)
+
+    model = _model(
+        f"""
+        g (float[3,{K}] X) => (float[3,{Out}] Y)
+        {{
+          gate = com.microsoft.MatMulBnb4 <K={K}, N={H}, block_size={block_size}, quant_type={quant_type}> (X, Bg, absmax_g)
+          gate_act = Sigmoid(gate)
+          up = com.microsoft.MatMulBnb4 <K={K}, N={H}, block_size={block_size}, quant_type={quant_type}> (X, Bg, absmax_g)
+          h = Mul(gate_act, up)
+          Y = MatMul(h, W_down)
+        }}
+        """,
+        initializer=[
+            onnx.numpy_helper.from_array(Bg, name="Bg"),
+            onnx.numpy_helper.from_array(absmax_g, name="absmax_g"),
+            _f32(W_down, "W_down"),
+        ],
+        opset=21,
+    )
+    model.opset_import.append(onnx.helper.make_opsetid("com.microsoft", 1))
+    onnx.checker.check_model(model)
+
+    assert onnxsim.pruning._find_matmul_bnb4_gated_chains(model.graph) == []
+
+    pruned = onnxsim.apply_structured_pruning_matmul_bnb4(model, sparsity=0.5)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
 def test_analyze_structured_pruning_matmul_bnb4_matches_real_call():
     K, N1, N2, block_size = 64, 32, 8, 16
     rng = np.random.default_rng(21)


### PR DESCRIPTION
## Summary

`com.microsoft::MatMulBnb4` (bitsandbytes FP4/NF4 weight-only quantization)
structured pruning had NO gated (SwiGLU/GeGLU) FFN pair support, while its
closest sibling family, `MatMulNBits`, already has this exact feature via a
dedicated finder function. Since SwiGLU-style gated MLPs are the standard
block in essentially every modern open LLM (Llama, Mistral, Qwen, Gemma,
Phi, ...) and bitsandbytes 4-bit is a common weight-only quantization
scheme applied to exactly these models, this was a real, high-impact gap: a
bnb4-quantized SwiGLU MLP's `gate_proj`/`up_proj` pair was never pruned at
all.

## Empirically confirmed facts

- Built with the real `onnxruntime.quantization.matmul_bnb4_quantizer.MatMulBnb4Quantizer`
  (NF4/FP4) against a hand-built SwiGLU-shaped MLP
  (`x -> gate_proj -> Sigmoid -> combine_mul(with up_proj) -> down_proj -> y`),
  quantizing only `gate_proj`/`up_proj` and leaving `down_proj` plain-float
  (the one consumer shape already in scope for the non-gated case).
- On the pre-fix code: `_find_matmul_bnb4_chains(graph)` → 0 chains;
  `hasattr(pruning, "_find_matmul_bnb4_gated_chains")` → `False`;
  `apply_structured_pruning_matmul_bnb4(model, sparsity=0.5)` → complete
  no-op (initializer shapes unchanged).
- The byte-identical float source graph, quantized instead with
  `MatMulNBitsQuantizer`, gives `_find_matmul_nbits_gated_chains(graph)` →
  1 chain found — confirming the sibling family already handles this exact
  topology correctly, which is what made the Bnb4 gap detectable.
- The pre-existing top-of-section comment in `onnxsim/pruning.py` claiming
  gated-MLP support was omitted "mirroring `MatMulNBits`'s own identical
  scope decision... `MatMulNBits` itself never attempted [gated-MLP
  support] either" was itself factually wrong: per git history,
  `MatMulNBits` gated-chain support (`0b9c1dc`) landed *before* `MatMulBnb4`
  support (`9f212f9`), same day, ~14h apart — so the stated rationale for
  the gap was already false when it was written. This PR corrects that
  comment.

## What's added

- `_find_matmul_bnb4_gated_chains`, mirroring `_find_matmul_nbits_gated_chains`
  exactly: recognizes gate_proj/up_proj (each independently a real
  `MatMulBnb4` node or a plain-float MatMul/vanilla-Gemm peer via
  `_match_matmul_bnb4_producer`/`_match_plain_matmul_nbits_peer`), combined
  by an elementwise `Mul` (each branch optionally through one
  `_UNARY_PASS_THROUGH` activation) or ONNX's native fused `SwiGLU` node,
  feeding one plain-float down_proj consumer, requiring at least one of the
  two producers to actually be `MatMulBnb4` (an all-plain-float triple
  stays `_find_gated_chains`'s own job).
- Supporting dispatch helpers (`_MatMulBnb4ChainSide`,
  `_matmul_bnb4_chain_side_key`, `_matmul_bnb4_chain_producer_weight_nk`,
  `_slice_matmul_bnb4_chain_producer`) so both producer variants (a real
  `MatMulBnb4` node vs. a plain-float peer) are ranked/sliced through one
  shared codepath, following the same pattern `MatMulNBits`'s own gated
  section already established.
- `apply_structured_pruning_matmul_bnb4` now applies gated pairs with
  combined (root-sum-square L2, or plain sum L1) importance across both
  producers' own dequantized-or-plain rows, cutting both to the *same*
  surviving channel-index set (since they're about to be multiplied
  elementwise), then slicing the plain-float down_proj consumer on its
  input axis.
- `down_proj` (the consumer) stays plain-float-only, exactly like the
  existing non-gated case — the pre-existing restriction that `MatMulBnb4`
  is never matched as a chain's *consumer* at all (K-axis pruning of its
  packed layout is a separately-scoped, harder problem) is untouched.

## Test plan

- New regression tests: `test_matmul_bnb4_pruning_gated_ffn_matches_oracle`
  (both producers real `MatMulBnb4`-quantized, exact byte-identical-to-
  requantized-subset check plus exact end-to-end output equality),
  `test_matmul_bnb4_pruning_gated_ffn_mixed_plain_float_peer_matches_oracle`
  (one side `MatMulBnb4`, other plain-float), and
  `test_matmul_bnb4_pruning_gated_ffn_declines_shared_weight` (tied
  gate/up tensor correctly declined, model left byte-unchanged).
- Verified via a stash-based before/after check: reverting
  `onnxsim/pruning.py` to the pre-fix commit while keeping the new tests
  reproduces the bug (`AttributeError: no attribute
  '_find_matmul_bnb4_gated_chains'`); restoring the fix makes all 3 new
  tests pass, plus all pre-existing bnb4/nbits gated tests still pass.
- `pytest tests/test_pruning.py -k bnb4` → 18 passed.
- `ruff format --check`, `ruff check`, `mypy onnxsim/pruning.py` — all
  clean on the two changed files.
- Full suite: 164 failed (pre-existing, unrelated — stale-compiled-C++-
  extension test failures from concurrent unrelated automation porting
  Python functions to C++, confirmed identical failure set on the
  pre-change commit), 802 passed.

## Risks for reviewer

- None beyond the pre-existing, already-documented restriction that
  `MatMulBnb4` is never matched as a chain's consumer — this PR does not
  change that restriction, only extends the producer side to support the
  gated-pair topology.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_