### PR TITLE
Add gated (SwiGLU/GeGLU/ReGLU) FFN pair support to QOperator structured pruning

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -33997,16 +33997,75 @@ def apply_structured_pruning_matmul_block_quantized_fp4(
 #     "QDQ" section top comment never gives its own rank restriction a
 #     wider justification either; both sections draw the same first-cut
 #     line).
-#   * Any residual/skip-connection merge, `Concat`-merged branch group, or
-#     gated (SwiGLU/GeGLU) pair -- only the plain single-producer/single-
-#     consumer/unary-hops-only topology above is matched, mirroring the
-#     `MatMulBlockQuantizedFp4Weight`/`Fp8Weight` section's own identical
-#     scope (and, for the residual/`Concat` case, the QDQ section's own).
-#     Unlike the QDQ section, this section does NOT add gated-pair support
-#     either -- a genuine, deliberately-left follow-up (the QDQ gated
-#     matcher's own backward walk could plausibly generalize the same way
-#     :func:`_find_qop_chains` generalizes the QDQ section's own ordinary
-#     chain walk, but doing so correctly was not attempted here).
+#   * Any residual/skip-connection merge, or `Concat`-merged branch group --
+#     only the plain single-producer/single-consumer/unary-hops-only
+#     topology above, or the gated pair just below, is matched, mirroring
+#     the `MatMulBlockQuantizedFp4Weight`/`Fp8Weight` section's own identical
+#     scope for those two shapes (and, for the residual/`Concat` case, the
+#     QDQ section's own).
+#   * A gated (SwiGLU/GeGLU/ReGLU) pair IS now matched
+#     (:func:`_find_qop_gated_chains`/:func:`_trace_gate_producer_backward_qop`),
+#     mirroring the QDQ section's own :func:`_find_qdq_gated_chains` --
+#     gate_proj/up_proj (two `QLinearMatMul`/`QGemm` producers, never
+#     `QLinearConv`, sharing one input) combined by
+#     `com.microsoft::QLinearMul`, feeding one down_proj consumer
+#     (:func:`_walk_to_qop_consumer`). Confirmed against a real
+#     ``onnxruntime.quantization.quantize_static(..., quant_format=
+#     QuantFormat.QOperator, per_channel=True)`` round trip on a ReGLU FFN
+#     (`gate_proj = QLinearMatMul`, `Relu`, `up_proj = QLinearMatMul`, `Mul`
+#     combine, `down_proj = QLinearMatMul`; the default `op_types_to_quantize`
+#     fuses the elementwise `Mul` straight into `QLinearMul`), which produces
+#     this exact node sequence::
+#
+#       x_quantized = QuantizeLinear(x, x_scale, x_zero_point)
+#       gate_out_quantized = QLinearMatMul(x_quantized, x_scale, x_zero_point,
+#           gate_w_quantized, gate_w_scale, gate_w_zero_point,
+#           gate_out_scale, gate_out_zero_point)
+#       up_out_quantized = QLinearMatMul(x_quantized, x_scale, x_zero_point,
+#           up_w_quantized, up_w_scale, up_w_zero_point,
+#           up_out_scale, up_out_zero_point)
+#       gate_out = DequantizeLinear(gate_out_quantized, gate_out_scale,
+#           gate_out_zero_point)
+#       gate_act = Relu(gate_out)
+#       gate_act_quantized = QuantizeLinear(gate_act, gate_act_scale,
+#           gate_act_zero_point)
+#       combined_quantized = com.microsoft.QLinearMul(
+#           gate_act_quantized, gate_act_scale, gate_act_zero_point,
+#           up_out_quantized, up_out_scale, up_out_zero_point,
+#           combined_scale, combined_zero_point)
+#       y_quantized = QLinearMatMul(combined_quantized, combined_scale,
+#           combined_zero_point, down_w_quantized, down_w_scale,
+#           down_w_zero_point, y_scale, y_zero_point)
+#
+#     The KEY asymmetric detail this shape forces: ORT has no `QLinearRelu`
+#     (or any other fused `QLinear<Activation>` op), so gate_proj's own raw
+#     `QLinearMatMul` output gets an explicit `DequantizeLinear -> Relu ->
+#     QuantizeLinear` sandwich (rescale to float, apply the activation,
+#     requantize) before reaching `QLinearMul`, while up_proj -- unactivated
+#     -- feeds `QLinearMul` directly, zero hops. This is genuinely
+#     ASYMMETRIC, unlike the QDQ section's own gated matcher (where the
+#     whole pipeline is float throughout a MatMul's own compute, so an
+#     activation is always just one more `_UNARY_PASS_THROUGH` node, no
+#     rescale/requantize needed on either branch). Rather than generalizing
+#     the QDQ gated matcher's own backward walk (which only ever crosses
+#     `_UNARY_PASS_THROUGH` nodes, never a DQ/Q pair), this section adds a
+#     narrow, purpose-built recognizer for exactly this sandwich
+#     (:func:`_trace_gate_producer_backward_qop`): a
+#     `DequantizeLinear -> <one _UNARY_PASS_THROUGH op> -> QuantizeLinear`
+#     hop is only accepted when the `DequantizeLinear`'s own scale/
+#     zero-point inputs are, BY NAME, the exact same initializers as the
+#     upstream producer's own `y_scale`/`y_zero_point` (confirmed true in
+#     the real round trip above) -- i.e. it demonstrably reverses THAT
+#     producer's own quantization, not merely a rescale that happens to have
+#     a matching shape. A branch with no such sandwich (feeding `QLinearMul`
+#     directly) is handled as the trivial zero-hop case. A plain `Mul` of
+#     two already-dequantized float operands, re-quantized afterward by its
+#     own single `QuantizeLinear` -- the shape a real exporter emits instead
+#     when the `com.microsoft` domain isn't registered for op fusion -- is
+#     deliberately NOT matched: only the `QLinearMul`-fused shape above was
+#     confirmed as the default, common one; declined rather than guessed at,
+#     the same conservative bar this module holds every other unconfirmed
+#     topology to.
 #   * Mixing a QOperator node with a QDQ (`DequantizeLinear`-fed) node, an
 #     unquantized plain-float node, or a `MatMulNBits`/block-quantized
 #     Fp4/Fp8 node, on EITHER side of a chain -- every one of those is a
@@ -34823,6 +34882,333 @@ def _find_qop_chains(graph: onnx.GraphProto) -> List[_QOpChain]:
     return chains
 
 
+@dataclass(frozen=True)
+class _QOpGatedProducer:
+    """One producer (gate_proj or up_proj) of a QOperator gated pair -- see
+    :func:`_find_qop_gated_chains`. `pre_ops` is empty when this producer's
+    own raw quantized output feeds the combining ``com.microsoft::
+    QLinearMul`` node directly, or exactly ``(DequantizeLinear, <one
+    _UNARY_PASS_THROUGH activation>, QuantizeLinear)`` for the one
+    asymmetric rescale-activate-requantize sandwich a real exporter inserts
+    on whichever branch carries an activation ORT has no fused QLinear op
+    for (there is no ``QLinearRelu``/``QLinearSigmoid``/etc.) -- see
+    :func:`_trace_gate_producer_backward_qop`'s own docstring for the exact
+    shape, confirmed live.
+    """
+
+    weight: _QOpWeight
+    pre_ops: Tuple[onnx.NodeProto, ...] = ()
+
+
+@dataclass(frozen=True)
+class _QOpGatedChain:
+    """The QOperator analogue of a gated (SwiGLU/GeGLU/ReGLU) :class:`_Chain`
+    -- two producers (`producer_a`/`producer_b`, gate_proj/up_proj, both
+    ``QLinearMatMul``/``QGemm`` -- never ``QLinearConv``, mirroring
+    :func:`_find_qdq_gated_chains`'s own identical MatMul/Gemm-only scope)
+    combined by ``com.microsoft::QLinearMul``, feeding one downstream
+    same-family `consumer`. See :func:`_find_qop_gated_chains`.
+    """
+
+    producer_a: _QOpGatedProducer
+    producer_b: _QOpGatedProducer
+    combine_node: onnx.NodeProto
+    chain_ops: Tuple[onnx.NodeProto, ...]
+    consumer: _QOpWeight
+    n_channels: int
+
+
+def _qop_producer_y_scale_zp(
+    w: _QOpWeight,
+) -> Tuple[Optional[str], Optional[str]]:
+    """The ``(y_scale_name, y_zero_point_name)`` pair describing how
+    `w.node`'s own output tensor is quantized -- always present (input
+    indices 6/7) for ``QLinearConv``/``QLinearMatMul``, only OPTIONALLY
+    present for ``QGemm`` (mirroring :func:`_match_qgemm`'s own identical
+    optional-trailing-input unpacking: `y_scale`/`y_zero_point` are checked
+    independently, not as a tied pair) -- either or both come back ``None``
+    when a ``QGemm`` omits them.
+    """
+    node = w.node
+    if w.op_kind in ("conv", "matmul"):
+        return node.input[6], node.input[7]
+    y_scale_name = node.input[7] if len(node.input) > 7 and node.input[7] else None
+    y_zp_name = node.input[8] if len(node.input) > 8 and node.input[8] else None
+    return y_scale_name, y_zp_name
+
+
+def _trace_gate_producer_backward_qop(
+    tensor_name: str,
+    scale_name: str,
+    zero_point_name: str,
+    node_by_output: Dict[str, onnx.NodeProto],
+    producer_infos: Dict[str, _QOpWeight],
+    consumers_of: Dict[str, List[onnx.NodeProto]],
+    graph_outputs: Set[str],
+) -> Optional[Tuple[_QOpWeight, Tuple[onnx.NodeProto, ...]]]:
+    """Resolves one ``QLinearMul`` operand (`tensor_name`, quantized per
+    `scale_name`/`zero_point_name` -- that operand's own scale/zero-point
+    inputs on the ``QLinearMul`` node) back to a ``QLinearMatMul``/``QGemm``
+    producer (`producer_infos`, built the same way :func:`_find_qop_chains`
+    builds its own per-node match, keyed by each matched node's raw output
+    tensor name), tolerating the one real ASYMMETRIC shape a static
+    QOperator quantizer emits when a gate branch's activation has no fused
+    QLinear op of its own -- confirmed live via a real
+    ``onnxruntime.quantization.quantize_static(..., quant_format=
+    QuantFormat.QOperator, per_channel=True)`` round trip on a ReGLU FFN
+    (``gate_proj``/``up_proj`` = ``QLinearMatMul``, gate activation
+    ``Relu``, combined via ``com.microsoft::QLinearMul``, ``down_proj`` =
+    ``QLinearMatMul``; ORT has no ``QLinearRelu``, so the quantizer rescales
+    gate_proj's own raw output back to float, applies ``Relu``, then
+    requantizes)::
+
+        producer.raw_output -> DequantizeLinear -> <one _UNARY_PASS_THROUGH
+        activation> -> QuantizeLinear -> (this QLinearMul operand)
+
+    while the OTHER (unactivated) branch feeds `QLinearMul` directly, zero
+    hops. This function confirms the sandwich by NAME, not merely by shape
+    or value: the emitted ``DequantizeLinear``'s own scale/zero-point inputs
+    must be the EXACT SAME initializers as the producer node's own
+    `y_scale`/`y_zero_point` inputs (confirmed true in the real round trip
+    above) -- a real, distinct rescale using different scale/zero-point
+    tensors is never seen from any real exporter this investigation found,
+    so it's declined rather than assumed safe, the same "slice, don't
+    recompute, and don't assume what wasn't confirmed" bar this module holds
+    everywhere else. Likewise the zero-hop case requires `tensor_name`
+    itself to be the producer's own raw output AND the `scale_name`/
+    `zero_point_name` fed to this exact `QLinearMul` operand to be that same
+    producer's own `y_scale`/`y_zero_point` -- never assumed merely because
+    the tensor name matches.
+
+    Every tensor visited (`tensor_name` itself, and every intermediate hop
+    of the sandwich) must have EXACTLY one consumer and not be a graph
+    output -- mirroring :func:`_trace_gate_producer_backward_qdq`'s own
+    identical bar -- so a branch whose raw output, or whose sandwich's
+    intermediate float tensor, is reused anywhere else is declined outright
+    rather than silently corrupted.
+
+    Returns ``(producer, pre_ops)`` -- `pre_ops` is ``()`` for the zero-hop
+    case, or ``(dq_node, activation_node, q_node)`` for the sandwich -- or
+    ``None`` when `tensor_name` resolves to neither shape (more than one
+    activation node, an activation outside `_UNARY_PASS_THROUGH`, a
+    missing/mismatched DQ or Q scale/zero-point pair, any hop with more than
+    one consumer or itself a graph output, or `tensor_name` simply isn't
+    reachable from any matched producer at all): declined outright, the same
+    conservative bar this module holds every other ambiguous topology to.
+
+    A plain ``Mul`` of two already-dequantized float operands, re-quantized
+    afterward by its own single ``QuantizeLinear`` -- the shape a real
+    exporter emits instead when the ``com.microsoft`` domain isn't
+    registered for op fusion -- is NOT a shape this function (or its only
+    caller, :func:`_find_qop_gated_chains`) recognizes: this investigation
+    only confirmed the ``QLinearMul`` shape as the default, common one (see
+    this module's own "QOperator" section comment) -- declined rather than
+    guessed at.
+    """
+    if len(consumers_of.get(tensor_name, [])) != 1 or tensor_name in graph_outputs:
+        return None
+
+    direct = producer_infos.get(tensor_name)
+    if direct is not None:
+        y_scale_name, y_zp_name = _qop_producer_y_scale_zp(direct)
+        if y_scale_name == scale_name and y_zp_name == zero_point_name:
+            return direct, ()
+        return None  # this operand's own scale/zero-point don't describe
+        # `tensor_name` the way the producer's own output does -- declined
+        # rather than guessed at
+
+    q_node = node_by_output.get(tensor_name)
+    if (
+        q_node is None
+        or q_node.op_type != "QuantizeLinear"
+        or q_node.domain != ""
+        or len(q_node.input) != 3
+        or len(q_node.output) != 1
+    ):
+        return None
+    q_in, q_scale_name, q_zp_name = q_node.input
+    if q_scale_name != scale_name or q_zp_name != zero_point_name:
+        return None
+    if len(consumers_of.get(q_in, [])) != 1 or q_in in graph_outputs:
+        return None
+
+    act_node = node_by_output.get(q_in)
+    if (
+        act_node is None
+        or act_node.op_type not in _UNARY_PASS_THROUGH
+        or len(act_node.input) != 1
+        or len(act_node.output) != 1
+    ):
+        return None
+    act_in = act_node.input[0]
+    if len(consumers_of.get(act_in, [])) != 1 or act_in in graph_outputs:
+        return None
+
+    dq_node = node_by_output.get(act_in)
+    if (
+        dq_node is None
+        or dq_node.op_type != "DequantizeLinear"
+        or dq_node.domain != ""
+        or len(dq_node.input) != 3
+        or len(dq_node.output) != 1
+    ):
+        return None
+    dq_in, dq_scale_name, dq_zp_name = dq_node.input
+    if dq_in in graph_outputs or len(consumers_of.get(dq_in, [])) != 1:
+        return None
+    producer = producer_infos.get(dq_in)
+    if producer is None:
+        return None
+    y_scale_name, y_zp_name = _qop_producer_y_scale_zp(producer)
+    if dq_scale_name != y_scale_name or dq_zp_name != y_zp_name:
+        return None  # the DQ doesn't reverse THIS producer's own
+        # quantization -- declined rather than assumed safe
+    return producer, (dq_node, act_node, q_node)
+
+
+def _qop_gated_channel_importance(
+    w_a_nk: np.ndarray, w_b_nk: np.ndarray, importance_norm: str
+) -> np.ndarray:
+    """Combined importance across a QOperator gated pair's two producers --
+    root-sum-square (L2) or plain sum (L1) of each producer's own
+    per-channel dequantized-row norm, mirroring
+    :func:`_qdq_gated_channel_importance`'s own identical combination
+    exactly, restricted to the always-exactly-two-producer case a QOperator
+    gated chain matches.
+    """
+    if importance_norm == "l1":
+        return _qdq_channel_importance(w_a_nk, "l1") + _qdq_channel_importance(
+            w_b_nk, "l1"
+        )
+    return np.sqrt(
+        np.square(_qdq_channel_importance(w_a_nk, "l2"))
+        + np.square(_qdq_channel_importance(w_b_nk, "l2"))
+    )
+
+
+def _find_qop_gated_chains(graph: onnx.GraphProto) -> List[_QOpGatedChain]:
+    """Recognizes a gated (SwiGLU/GeGLU/ReGLU) FFN pair in QOperator format:
+    gate_proj/up_proj -- both ``QLinearMatMul``/``QGemm``, never
+    ``QLinearConv`` (mirroring :func:`_find_qdq_gated_chains`'s own
+    identical MatMul/Gemm-only restriction -- no gated-elementwise-product
+    convention for a Conv-family layer was found) -- combined by
+    ``com.microsoft::QLinearMul``, feeding exactly one downstream
+    same-family consumer (:func:`_walk_to_qop_consumer`, `is_conv=False`).
+    Each producer may feed the combine node either directly or through the
+    one real asymmetric rescale-activate-requantize sandwich a static
+    QOperator quantizer emits for a branch whose activation has no fused
+    QLinear op of its own (see :func:`_trace_gate_producer_backward_qop`'s
+    own docstring for the exact confirmed shape and why it's matched this
+    narrowly rather than as a general backward walk through
+    `_UNARY_PASS_THROUGH`). Confirmed live against a real
+    ``onnxruntime.quantization.quantize_static(..., quant_format=
+    QuantFormat.QOperator, per_channel=True)`` round trip on a ReGLU FFN
+    (default `op_types_to_quantize` fuses the elementwise ``Mul`` into
+    ``QLinearMul`` automatically) -- see this module's own "QOperator"
+    section comment for the full node sequence and why the plain-``Mul``
+    (non-fused) shape is deliberately NOT matched here.
+    """
+    initializer_map = _constant_map(graph)
+    consumers_of = _consumers_of(graph)
+    producers_of = _producers_of(graph)
+    graph_outputs = {o.name for o in graph.output}
+    node_by_output = {out: node for node in graph.node for out in node.output}
+
+    def _is_internal(name: str) -> bool:
+        return len(consumers_of.get(name, [])) == 1 and name not in graph_outputs
+
+    producer_infos: Dict[str, _QOpWeight] = {}
+    for node in graph.node:
+        m: Optional[_QOpWeight]
+        if node.op_type == "QLinearMatMul":
+            m = _match_qlinearmatmul(node, initializer_map, consumers_of)
+        elif node.op_type == "QGemm":
+            m = _match_qgemm(node, initializer_map, consumers_of)
+        else:
+            continue
+        if m is not None:
+            producer_infos[node.output[0]] = m
+
+    chains: List[_QOpGatedChain] = []
+    for node in graph.node:
+        if (
+            node.op_type != "QLinearMul"
+            or node.domain != "com.microsoft"
+            or len(node.input) != 8
+            or len(node.output) != 1
+        ):
+            continue
+        (
+            a_name,
+            a_scale_name,
+            a_zp_name,
+            b_name,
+            b_scale_name,
+            b_zp_name,
+            _out_scale_name,
+            _out_zp_name,
+        ) = node.input
+        if not all((a_name, a_scale_name, a_zp_name, b_name, b_scale_name, b_zp_name)):
+            continue
+        if a_name == b_name:
+            continue
+
+        trace_a = _trace_gate_producer_backward_qop(
+            a_name,
+            a_scale_name,
+            a_zp_name,
+            node_by_output,
+            producer_infos,
+            consumers_of,
+            graph_outputs,
+        )
+        trace_b = _trace_gate_producer_backward_qop(
+            b_name,
+            b_scale_name,
+            b_zp_name,
+            node_by_output,
+            producer_infos,
+            consumers_of,
+            graph_outputs,
+        )
+        if trace_a is None or trace_b is None:
+            continue
+        info_a, pre_a = trace_a
+        info_b, pre_b = trace_b
+        if info_a.node is info_b.node or info_a.N != info_b.N:
+            continue
+
+        out_name = node.output[0]
+        if not _is_internal(out_name):
+            continue
+
+        found = _walk_to_qop_consumer(
+            out_name,
+            False,
+            initializer_map,
+            consumers_of,
+            graph_outputs,
+            info_a.N,
+            _MAX_CHAIN_HOPS,
+            producers_of,
+        )
+        if found is None:
+            continue
+        consumer, chain_ops = found
+
+        chains.append(
+            _QOpGatedChain(
+                producer_a=_QOpGatedProducer(info_a, pre_a),
+                producer_b=_QOpGatedProducer(info_b, pre_b),
+                combine_node=node,
+                chain_ops=chain_ops,
+                consumer=consumer,
+                n_channels=info_a.N,
+            )
+        )
+    return chains
+
+
 def apply_structured_pruning_qoperator(
     model: Union[str, onnx.ModelProto],
     sparsity: float = 0.5,
@@ -34857,15 +35243,46 @@ def apply_structured_pruning_qoperator(
     scale/zero-point/bias are never touched -- none of the three ops'
     schemas index them by the reduction axis).
 
-    Unlike :func:`apply_structured_pruning_qdq`, no gated (SwiGLU/GeGLU)
-    pair, residual/skip-connection merge, or ``Concat``-merged branch group
-    is matched -- only the plain single-producer/single-consumer topology
-    above (see this module's own "QOperator" section comment for the full
-    scope-boundary list, including why a `QLinearConv` producer feeding a
-    `QLinearMatMul`/`QGemm` consumer through a GENERAL `Flatten`/`Reshape`
-    reading real, un-pooled spatial extent is declined outright, the same
-    known gap the QDQ section's own identical same-family-only walk already
-    has).
+    No residual/skip-connection merge or ``Concat``-merged branch group is
+    matched -- only the plain single-producer/single-consumer topology
+    above, or the gated pair just below (see this module's own "QOperator"
+    section comment for the full scope-boundary list, including why a
+    `QLinearConv` producer feeding a `QLinearMatMul`/`QGemm` consumer through
+    a GENERAL `Flatten`/`Reshape` reading real, un-pooled spatial extent is
+    declined outright, the same known gap the QDQ section's own identical
+    same-family-only walk already has).
+
+    Also handles the gated (SwiGLU/GeGLU/ReGLU) FFN pair
+    (:func:`_find_qop_gated_chains`, the QOperator analogue of
+    :func:`_find_qdq_gated_chains`) -- gate_proj/up_proj (two
+    ``QLinearMatMul``/``QGemm`` producers sharing one input, never
+    ``QLinearConv``) combined by ``com.microsoft::QLinearMul``, feeding one
+    down_proj consumer. Each producer may feed the combine node either
+    directly, or through the one real asymmetric sandwich a static
+    QOperator quantizer emits for a branch whose activation has no fused
+    QLinear op of its own (there is no ``QLinearRelu``/``QLinearSigmoid``/
+    etc.): ``producer's raw output -> DequantizeLinear -> <one unary
+    activation> -> QuantizeLinear -> QLinearMul`` -- confirmed live against
+    a real ``onnxruntime.quantization.quantize_static(..., quant_format=
+    QuantFormat.QOperator, per_channel=True)`` round trip on a ReGLU FFN
+    (see :func:`_trace_gate_producer_backward_qop`'s own docstring for the
+    exact node sequence and the by-name scale/zero-point identity check
+    that confirms the sandwich reverses THAT producer's own quantization,
+    not merely one that happens to have a matching shape). Both producers
+    are ranked by combined (root-sum-square, or plain sum for L1) importance
+    of their own dequantized rows (:func:`_qop_gated_channel_importance`)
+    and cut to the *same* surviving channel-index set, since they're about
+    to be multiplied elementwise -- each producer's own quantized codes/
+    scale/zero-point/bias co-sliced in lockstep exactly like an ordinary
+    QOperator producer's above, using the very same per-role slicing
+    helpers (:func:`_slice_qop_producer`); down_proj is sliced on its input
+    axis exactly like an ordinary QOperator consumer above
+    (:func:`_slice_qop_consumer`). A plain ``Mul`` of two already-
+    dequantized float operands, re-quantized by its own single
+    ``QuantizeLinear`` afterward -- the shape a real exporter emits instead
+    when the ``com.microsoft`` domain isn't registered for op fusion -- is
+    NOT matched here: only the ``QLinearMul``-fused shape was confirmed as
+    the default, common one.
 
     One narrow exception to the same-family-only consumer rule IS matched,
     though: a ``QLinearConv`` producer's logical output feeding
@@ -34911,7 +35328,8 @@ def apply_structured_pruning_qoperator(
 
     for graph in _iter_subgraphs(out.graph):
         chains = _find_qop_chains(graph)
-        if not chains:
+        gated_chains = _find_qop_gated_chains(graph)
+        if not chains and not gated_chains:
             continue
 
         producer_touched: Set[str] = set()
@@ -34946,6 +35364,46 @@ def apply_structured_pruning_qoperator(
             consumer_touched.add(c_key)
             stale_value_info.add(p.node.output[0])
             stale_value_info.update(op.output[0] for op in chain.chain_ops)
+
+        for gchain in gated_chains:
+            pa, pb, c = gchain.producer_a, gchain.producer_b, gchain.consumer
+            pa_key = pa.weight.w_init.name
+            pb_key = pb.weight.w_init.name
+            c_key = c.w_init.name
+            if pa_key == pb_key or pa_key == c_key or pb_key == c_key:
+                continue  # degenerate (a weight tied across two roles)
+            if (
+                pa_key in producer_touched
+                or pb_key in producer_touched
+                or c_key in consumer_touched
+            ):
+                continue  # a shared/tied weight another chain already resized
+
+            n = gchain.n_channels
+            keep_count = max(1, n - round(n * sparsity))
+            if keep_count >= n:
+                continue  # rounds down to nothing for this layer -- no-op
+
+            w_a_nk = _qop_dequantized_nk(pa.weight)
+            w_b_nk = _qop_dequantized_nk(pb.weight)
+            importance = _qop_gated_channel_importance(w_a_nk, w_b_nk, importance_norm)
+            # `kind="stable"` for the identical determinism reason documented
+            # above.
+            keep = np.sort(np.argsort(-importance, kind="stable")[:keep_count])
+
+            _slice_qop_producer(pa.weight, keep)
+            _slice_qop_producer(pb.weight, keep)
+            _slice_qop_consumer(c, keep)
+
+            producer_touched.add(pa_key)
+            producer_touched.add(pb_key)
+            consumer_touched.add(c_key)
+            stale_value_info.add(pa.weight.node.output[0])
+            stale_value_info.update(op.output[0] for op in pa.pre_ops)
+            stale_value_info.add(pb.weight.node.output[0])
+            stale_value_info.update(op.output[0] for op in pb.pre_ops)
+            stale_value_info.add(gchain.combine_node.output[0])
+            stale_value_info.update(op.output[0] for op in gchain.chain_ops)
 
         if stale_value_info:
             kept = [vi for vi in graph.value_info if vi.name not in stale_value_info]
@@ -42850,11 +43308,19 @@ def _analyze_structured_pruning_matmul_block_quantized_fp4(
 # --- QOperator (QLinearConv/QLinearMatMul/QGemm) family ---------------------
 
 
-def _qop_not_eligible(graph: onnx.GraphProto, chains: List[_QOpChain]) -> List[str]:
+def _qop_not_eligible(
+    graph: onnx.GraphProto,
+    chains: List[_QOpChain],
+    gated_chains: List[_QOpGatedChain],
+) -> List[str]:
     matched_ids: Set[int] = set()
     for chain in chains:
         matched_ids.add(id(chain.producer.node))
         matched_ids.add(id(chain.consumer.node))
+    for gchain in gated_chains:
+        matched_ids.add(id(gchain.producer_a.weight.node))
+        matched_ids.add(id(gchain.producer_b.weight.node))
+        matched_ids.add(id(gchain.consumer.node))
     not_eligible = []
     for node in graph.node:
         if node.op_type not in ("QLinearConv", "QLinearMatMul", "QGemm"):
@@ -42886,6 +43352,16 @@ def _analyze_structured_pruning_qoperator(
     consumer role gets no report row at all, mirroring
     :func:`_analyze_structured_pruning_qdq`'s own identical treatment.
 
+    Also mirrors the real call's own gated (SwiGLU/GeGLU/ReGLU) pair support
+    (:func:`_find_qop_gated_chains`, `family="qoperator_matmul_gated"`) --
+    same touched-role/keep-count treatment as an ordinary QOperator chain
+    above, just against the combined (root-sum-square, or plain sum for L1)
+    importance of both producers (:func:`_qop_gated_channel_importance`),
+    and reported as one row per gated pair (`label` joining both producers'
+    own labels, mirroring :func:`_chain_label`'s own plain-float convention
+    and :func:`_analyze_structured_pruning_qdq`'s own identical gated-pair
+    treatment).
+
     Subgraph-aware (:func:`_iter_subgraphs`, see this module's own
     "Subgraph recursion" section comment), the dry-run mirror of
     :func:`apply_structured_pruning_qoperator`'s own subgraph awareness:
@@ -42903,8 +43379,9 @@ def _analyze_structured_pruning_qoperator(
 
     for graph in _iter_subgraphs(model.graph):
         chains = _find_qop_chains(graph)
-        not_eligible.extend(_qop_not_eligible(graph, chains))
-        if not chains:
+        gated_chains = _find_qop_gated_chains(graph)
+        not_eligible.extend(_qop_not_eligible(graph, chains, gated_chains))
+        if not chains and not gated_chains:
             continue
 
         producer_touched: Set[str] = set()
@@ -42969,6 +43446,74 @@ def _analyze_structured_pruning_qoperator(
             )
 
             producer_touched.add(p_key)
+            consumer_touched.add(c_key)
+
+        for gchain in gated_chains:
+            pa, pb, c = gchain.producer_a, gchain.producer_b, gchain.consumer
+            pa_key = pa.weight.w_init.name
+            pb_key = pb.weight.w_init.name
+            c_key = c.w_init.name
+            if pa_key == pb_key or pa_key == c_key or pb_key == c_key:
+                continue  # degenerate (a weight tied across two roles) -- no report row
+
+            label = f"{_node_label(pa.weight.node)} + {_node_label(pb.weight.node)}"
+            family = "qoperator_matmul_gated"
+            n = gchain.n_channels
+
+            if (
+                pa_key in producer_touched
+                or pb_key in producer_touched
+                or c_key in consumer_touched
+            ):
+                layers.append(
+                    PruningLayerSensitivity(
+                        label=label,
+                        family=family,
+                        total=n,
+                        would_drop=0,
+                        margin=None,
+                        importance_min=0.0,
+                        importance_max=0.0,
+                    )
+                )
+                continue  # a shared/tied weight another chain already claimed
+
+            keep_count = max(1, n - round(n * sparsity))
+            if keep_count >= n:
+                layers.append(
+                    PruningLayerSensitivity(
+                        label=label,
+                        family=family,
+                        total=n,
+                        would_drop=0,
+                        margin=None,
+                        importance_min=0.0,
+                        importance_max=0.0,
+                    )
+                )
+                continue  # rounds down to nothing for this chain -- no-op
+
+            w_a_nk = _qop_dequantized_nk(pa.weight)
+            w_b_nk = _qop_dequantized_nk(pb.weight)
+            importance = _qop_gated_channel_importance(w_a_nk, w_b_nk, importance_norm)
+            keep = np.sort(np.argsort(-importance, kind="stable")[:keep_count])
+            keep_mask = np.zeros(n, dtype=bool)
+            keep_mask[keep] = True
+
+            layers.append(
+                PruningLayerSensitivity(
+                    label=label,
+                    family=family,
+                    total=n,
+                    would_drop=int(n - keep_count),
+                    margin=_normalized_margin(importance, keep_mask),
+                    importance_min=float(importance.min()),
+                    importance_max=float(importance.max()),
+                )
+            )
+
+            producer_touched.add(pa_key)
+            producer_touched.add(pb_key)
             consumer_touched.add(c_key)
 
     return PruningSensitivityReport(layers=layers, not_eligible=not_eligible)

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -41265,6 +41265,494 @@ def test_qgemm_ambiguous_bias_shape_is_declined():
     assert chains == []
 
 
+# --- QOperator gated (ReGLU/SwiGLU/GeGLU) FFN pair -------------------------
+#
+# gate_proj/up_proj -- both real, per-channel INT8 ``QLinearMatMul`` --
+# combined by ``com.microsoft::QLinearMul``, feeding a ``QLinearMatMul``
+# down_proj consumer. Mirrors ``_qlinearmatmul_chain_model``'s own
+# hand-built-via-``onnx.helper`` convention (real int8/scale/zero-point
+# arrays a parser text literal can't spell out -- see this file's own
+# comment above the QOperator section).
+#
+# The gate branch optionally carries the real asymmetric
+# ``DequantizeLinear -> <activation> -> QuantizeLinear`` sandwich a real
+# ``onnxruntime.quantization.quantize_static(..., quant_format=
+# QuantFormat.QOperator)`` round trip emits for an activation with no fused
+# QLinear op of its own (there is no ``QLinearRelu``) -- confirmed live by
+# ``test_qop_gated_ffn_real_quantize_static_pipeline_end_to_end`` below,
+# which runs the actual tool rather than merely asserting this hand-built
+# shape matches it.
+
+
+def _qop_gated_mlp_model(K=8, H=16, Out=4, gate_activation="Relu", seed=0):
+    """Builds the QOperator gated FFN shape :func:`_find_qop_gated_chains`
+    matches. `gate_activation` (e.g. ``"Relu"``), when given, puts the real
+    asymmetric ``DequantizeLinear -> <activation> -> QuantizeLinear``
+    sandwich on the gate branch (see this section's own comment above);
+    ``None`` feeds gate_proj's own raw output directly into ``QLinearMul``
+    instead (zero hops, the shape a real exporter emits for an unactivated
+    gate) -- both branches are always real, independently per-channel
+    INT8-quantized ``QLinearMatMul`` producers either way.
+    """
+    rng = np.random.default_rng(seed)
+    Wg = rng.standard_normal((K, H)).astype(np.float32) * 0.3
+    Wu = rng.standard_normal((K, H)).astype(np.float32) * 0.3
+    Wd = rng.standard_normal((H, Out)).astype(np.float32) * 0.3
+    Wgq, Wgs, Wgzp = _qop_quantize_per_channel_i8(Wg, axis=1)
+    Wuq, Wus, Wuzp = _qop_quantize_per_channel_i8(Wu, axis=1)
+    Wdq, Wds, Wdzp = _qop_quantize_per_channel_i8(Wd, axis=1)
+
+    inits = [
+        _f32(np.array(0.02), "x_scale"),
+        _i8(np.array(0), "x_zp"),
+        onnx.numpy_helper.from_array(Wgq, "Wg"),
+        _f32(Wgs, "Wg_scale"),
+        _i8(Wgzp, "Wg_zp"),
+        _f32(np.array(0.015), "gate_out_scale"),
+        _i8(np.array(0), "gate_out_zp"),
+        onnx.numpy_helper.from_array(Wuq, "Wu"),
+        _f32(Wus, "Wu_scale"),
+        _i8(Wuzp, "Wu_zp"),
+        _f32(np.array(0.018), "up_out_scale"),
+        _i8(np.array(0), "up_out_zp"),
+        _f32(np.array(0.01), "combined_scale"),
+        _i8(np.array(0), "combined_zp"),
+        onnx.numpy_helper.from_array(Wdq, "Wd"),
+        _f32(Wds, "Wd_scale"),
+        _i8(Wdzp, "Wd_zp"),
+        _f32(np.array(0.02), "y_scale"),
+        _i8(np.array(0), "y_zp"),
+    ]
+
+    nodes = [
+        _qlinearmatmul_node(
+            "gate_proj_quant",
+            "x_q",
+            "gate_out_q",
+            "Wg",
+            "Wg_scale",
+            "Wg_zp",
+            "gate_out_scale",
+            "gate_out_zp",
+            a_scale="x_scale",
+            a_zp="x_zp",
+        ),
+        _qlinearmatmul_node(
+            "up_proj_quant",
+            "x_q",
+            "up_out_q",
+            "Wu",
+            "Wu_scale",
+            "Wu_zp",
+            "up_out_scale",
+            "up_out_zp",
+            a_scale="x_scale",
+            a_zp="x_zp",
+        ),
+    ]
+
+    if gate_activation is not None:
+        inits.extend(
+            [_f32(np.array(0.012), "gate_act_scale"), _i8(np.array(0), "gate_act_zp")]
+        )
+        nodes.extend(
+            [
+                onnx.helper.make_node(
+                    "DequantizeLinear",
+                    ["gate_out_q", "gate_out_scale", "gate_out_zp"],
+                    ["gate_out_f"],
+                    name="gate_out_DequantizeLinear",
+                ),
+                onnx.helper.make_node(
+                    gate_activation, ["gate_out_f"], ["gate_act_f"], name="gate_act"
+                ),
+                onnx.helper.make_node(
+                    "QuantizeLinear",
+                    ["gate_act_f", "gate_act_scale", "gate_act_zp"],
+                    ["gate_act_q"],
+                    name="gate_act_QuantizeLinear",
+                ),
+            ]
+        )
+        gate_operand, gate_scale, gate_zp = (
+            "gate_act_q",
+            "gate_act_scale",
+            "gate_act_zp",
+        )
+    else:
+        gate_operand, gate_scale, gate_zp = (
+            "gate_out_q",
+            "gate_out_scale",
+            "gate_out_zp",
+        )
+
+    nodes.append(
+        onnx.helper.make_node(
+            "QLinearMul",
+            [
+                gate_operand,
+                gate_scale,
+                gate_zp,
+                "up_out_q",
+                "up_out_scale",
+                "up_out_zp",
+                "combined_scale",
+                "combined_zp",
+            ],
+            ["combined_q"],
+            domain="com.microsoft",
+            name="combine_quant",
+        )
+    )
+    nodes.append(
+        _qlinearmatmul_node(
+            "down_proj_quant",
+            "combined_q",
+            "y_q",
+            "Wd",
+            "Wd_scale",
+            "Wd_zp",
+            "y_scale",
+            "y_zp",
+            a_scale="combined_scale",
+            a_zp="combined_zp",
+        )
+    )
+
+    graph = onnx.helper.make_graph(
+        nodes,
+        "g",
+        [onnx.helper.make_tensor_value_info("x_q", onnx.TensorProto.INT8, [1, K])],
+        [onnx.helper.make_tensor_value_info("y_q", onnx.TensorProto.INT8, [1, Out])],
+        initializer=inits,
+    )
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 17),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    model.ir_version = 10
+    return model, {
+        "Wg": Wgq,
+        "Wg_scale": Wgs,
+        "Wg_zp": Wgzp,
+        "Wu": Wuq,
+        "Wu_scale": Wus,
+        "Wu_zp": Wuzp,
+        "Wd": Wdq,
+        "Wd_scale": Wds,
+        "Wd_zp": Wdzp,
+    }
+
+
+def test_qop_gated_ffn_relu_asymmetric_matches_oracle():
+    # THE primary real repro shape: gate_proj carries the real asymmetric
+    # DequantizeLinear -> Relu -> QuantizeLinear sandwich (ORT has no
+    # QLinearRelu), up_proj feeds QLinearMul directly with zero hops.
+    K, H, Out = 8, 16, 4
+    model, info = _qop_gated_mlp_model(K, H, Out, gate_activation="Relu", seed=60)
+    onnx.checker.check_model(model)
+
+    gated = onnxsim.pruning._find_qop_gated_chains(model.graph)
+    assert len(gated) == 1
+    g = gated[0]
+    assert [n.op_type for n in g.producer_a.pre_ops] == [
+        "DequantizeLinear",
+        "Relu",
+        "QuantizeLinear",
+    ]
+    assert g.producer_b.pre_ops == ()
+    assert g.n_channels == H
+
+    wg_dequant = _qop_dequant(info["Wg"], info["Wg_scale"], info["Wg_zp"], axis=1)
+    wu_dequant = _qop_dequant(info["Wu"], info["Wu_scale"], info["Wu_zp"], axis=1)
+    keep = _combined_keep_indices(wg_dequant, wu_dequant, H // 2)
+
+    pruned = onnxsim.apply_structured_pruning_qoperator(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+
+    # Exact co-slice: both producers' own int8 codes AND per-channel scale/
+    # zero-point sliced by the identical `keep` set, never re-derived.
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Wg"]), info["Wg"][:, keep]
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Wg_scale"]), info["Wg_scale"][keep]
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Wu"]), info["Wu"][:, keep]
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Wd"]), info["Wd"][keep, :]
+    )
+
+    ref_model, _ = _qop_gated_mlp_model(
+        K, len(keep), Out, gate_activation="Relu", seed=999
+    )
+    ref_inits = {t.name: t for t in ref_model.graph.initializer}
+    ref_inits["Wg"].CopyFrom(onnx.numpy_helper.from_array(info["Wg"][:, keep], "Wg"))
+    ref_inits["Wg_scale"].CopyFrom(
+        onnx.numpy_helper.from_array(info["Wg_scale"][keep], "Wg_scale")
+    )
+    ref_inits["Wg_zp"].CopyFrom(
+        onnx.numpy_helper.from_array(info["Wg_zp"][keep], "Wg_zp")
+    )
+    ref_inits["Wu"].CopyFrom(onnx.numpy_helper.from_array(info["Wu"][:, keep], "Wu"))
+    ref_inits["Wu_scale"].CopyFrom(
+        onnx.numpy_helper.from_array(info["Wu_scale"][keep], "Wu_scale")
+    )
+    ref_inits["Wu_zp"].CopyFrom(
+        onnx.numpy_helper.from_array(info["Wu_zp"][keep], "Wu_zp")
+    )
+    ref_inits["Wd"].CopyFrom(onnx.numpy_helper.from_array(info["Wd"][keep, :], "Wd"))
+    ref_inits["Wd_scale"].CopyFrom(
+        onnx.numpy_helper.from_array(info["Wd_scale"], "Wd_scale")
+    )
+    ref_inits["Wd_zp"].CopyFrom(onnx.numpy_helper.from_array(info["Wd_zp"], "Wd_zp"))
+
+    rng = np.random.default_rng(61)
+    xq = rng.integers(-100, 100, size=(1, K)).astype(np.int8)
+    (y_pruned,) = _run(pruned, {"x_q": xq})
+    (y_ref,) = _run(ref_model, {"x_q": xq})
+    np.testing.assert_array_equal(y_pruned, y_ref)
+
+
+def test_qop_gated_ffn_no_activation_symmetric_matches_oracle():
+    # Symmetric case: both branches feed QLinearMul directly (zero hops) --
+    # a plain (unactivated) Gated Linear Unit.
+    K, H, Out = 8, 16, 4
+    model, info = _qop_gated_mlp_model(K, H, Out, gate_activation=None, seed=62)
+    onnx.checker.check_model(model)
+
+    gated = onnxsim.pruning._find_qop_gated_chains(model.graph)
+    assert len(gated) == 1
+    assert gated[0].producer_a.pre_ops == ()
+    assert gated[0].producer_b.pre_ops == ()
+
+    wg_dequant = _qop_dequant(info["Wg"], info["Wg_scale"], info["Wg_zp"], axis=1)
+    wu_dequant = _qop_dequant(info["Wu"], info["Wu_scale"], info["Wu_zp"], axis=1)
+    keep = _combined_keep_indices(wg_dequant, wu_dequant, H // 2)
+
+    pruned = onnxsim.apply_structured_pruning_qoperator(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Wg"]), info["Wg"][:, keep]
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Wu"]), info["Wu"][:, keep]
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(inits["Wd"]), info["Wd"][keep, :]
+    )
+
+    rng = np.random.default_rng(63)
+    xq = rng.integers(-100, 100, size=(1, K)).astype(np.int8)
+    (y_pruned,) = _run(pruned, {"x_q": xq})
+    assert y_pruned.shape == (1, Out)
+
+
+def test_qop_gated_ffn_tied_weight_is_declined():
+    # gate_proj and up_proj both reading the SAME quantized weight
+    # initializer -- a tied/reused tensor, can't be independently sliced for
+    # each role. Naturally declined: `_match_qlinearmatmul`'s own
+    # single-consumer check on `b`/`b_scale`/`b_zero_point` fails for BOTH
+    # nodes once the tensor has two readers, so neither ever enters
+    # `producer_infos` in the first place.
+    K, H, Out = 8, 16, 4
+    model, _info = _qop_gated_mlp_model(K, H, Out, gate_activation=None, seed=64)
+    for node in model.graph.node:
+        if node.name == "up_proj_quant":
+            node.input[3] = "Wg"
+            node.input[4] = "Wg_scale"
+            node.input[5] = "Wg_zp"
+    gated = onnxsim.pruning._find_qop_gated_chains(model.graph)
+    assert gated == []
+
+    pruned = onnxsim.apply_structured_pruning_qoperator(model, sparsity=0.5)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Wg"].dims) == [K, H]  # untouched
+
+
+def test_qop_gated_ffn_mismatched_dq_scale_is_declined():
+    # The gate branch's own DequantizeLinear rescales using a DIFFERENT
+    # scale/zero-point pair than gate_proj's own y_scale/y_zero_point --
+    # doesn't actually reverse THAT producer's own quantization, so the
+    # sandwich is declined by name rather than assumed safe merely because
+    # the shape (DQ -> activation -> Q) matches.
+    K, H, Out = 8, 16, 4
+    model, _info = _qop_gated_mlp_model(K, H, Out, gate_activation="Relu", seed=65)
+    inits = {t.name: t for t in model.graph.initializer}
+    # An unrelated scale/zero-point pair with the identical value but a
+    # different identity.
+    inits["gate_out_scale"]  # sanity: exists
+    other_scale = _f32(np.array(0.015), "other_scale")
+    other_zp = _i8(np.array(0), "other_zp")
+    model.graph.initializer.extend([other_scale, other_zp])
+    for node in model.graph.node:
+        if node.name == "gate_out_DequantizeLinear":
+            node.input[1] = "other_scale"
+            node.input[2] = "other_zp"
+    gated = onnxsim.pruning._find_qop_gated_chains(model.graph)
+    assert gated == []
+
+
+def test_qop_gated_ffn_real_quantize_static_pipeline_end_to_end():
+    # Runs the REAL onnxruntime.quantization.quantize_static(...,
+    # quant_format=QuantFormat.QOperator, per_channel=True) tool on a real
+    # ReGLU FFN (gate_proj = MatMul, Relu, up_proj = MatMul, Mul combine,
+    # down_proj = MatMul). The default `op_types_to_quantize` fuses the
+    # elementwise Mul into `com.microsoft::QLinearMul` automatically,
+    # producing exactly the asymmetric
+    # DequantizeLinear -> Relu -> QuantizeLinear gate sandwich this
+    # section's own top comment documents.
+    from onnxruntime.quantization import (
+        CalibrationDataReader,
+        QuantFormat,
+        QuantType,
+        quantize_static,
+    )
+
+    K, H, Out = 8, 16, 6
+    rng = np.random.default_rng(70)
+    Wg = (rng.standard_normal((K, H)) * 0.3).astype(np.float32)
+    Wu = (rng.standard_normal((K, H)) * 0.3).astype(np.float32)
+    Wd = (rng.standard_normal((H, Out)) * 0.3).astype(np.float32)
+    float_model = _model(
+        f"""
+        reglu (float[1,{K}] x) => (float[1,{Out}] y)
+        {{
+          gate_out = MatMul(x, Wg)
+          gate_act = Relu(gate_out)
+          up_out = MatMul(x, Wu)
+          combined = Mul(gate_act, up_out)
+          y = MatMul(combined, Wd)
+        }}
+        """,
+        initializer=[_f32(Wg, "Wg"), _f32(Wu, "Wu"), _f32(Wd, "Wd")],
+        opset=17,
+    )
+    onnx.checker.check_model(float_model)
+
+    class _CDR(CalibrationDataReader):
+        def __init__(self):
+            self._data = iter(
+                [
+                    {"x": rng.standard_normal((1, K)).astype(np.float32)}
+                    for _ in range(8)
+                ]
+            )
+
+        def get_next(self):
+            return next(self._data, None)
+
+    with tempfile.TemporaryDirectory() as d:
+        src_path = os.path.join(d, "src.onnx")
+        quant_path = os.path.join(d, "quant.onnx")
+        onnx.save(float_model, src_path)
+        quantize_static(
+            src_path,
+            quant_path,
+            calibration_data_reader=_CDR(),
+            quant_format=QuantFormat.QOperator,
+            per_channel=True,
+            weight_type=QuantType.QInt8,
+            activation_type=QuantType.QInt8,
+            extra_options={"ActivationSymmetric": True},
+        )
+        quantized = onnx.load(quant_path)
+    onnx.checker.check_model(quantized)
+
+    # Confirm the real tool actually emitted the shape this section targets,
+    # not merely assumed.
+    op_types = [n.op_type for n in quantized.graph.node]
+    assert op_types.count("QLinearMatMul") == 3
+    assert any(
+        n.op_type == "QLinearMul" and n.domain == "com.microsoft"
+        for n in quantized.graph.node
+    )
+    assert op_types.count("DequantizeLinear") >= 2  # the gate rescale + final output
+
+    gated = onnxsim.pruning._find_qop_gated_chains(quantized.graph)
+    assert len(gated) == 1
+    assert [n.op_type for n in gated[0].producer_a.pre_ops] == [
+        "DequantizeLinear",
+        "Relu",
+        "QuantizeLinear",
+    ]
+    assert gated[0].producer_b.pre_ops == ()
+
+    init_map = {
+        t.name: onnx.numpy_helper.to_array(t) for t in quantized.graph.initializer
+    }
+    wg_name = gated[0].producer_a.weight.w_init.name
+    wu_name = gated[0].producer_b.weight.w_init.name
+    wg_scale_name = gated[0].producer_a.weight.w_scale_init.name
+    wu_scale_name = gated[0].producer_b.weight.w_scale_init.name
+    wg_zp_name = gated[0].producer_a.weight.w_zero_point_init.name
+    wu_zp_name = gated[0].producer_b.weight.w_zero_point_init.name
+    wd_name = gated[0].consumer.w_init.name
+
+    wg_dequant = _qop_dequant(
+        init_map[wg_name], init_map[wg_scale_name], init_map[wg_zp_name], axis=1
+    )
+    wu_dequant = _qop_dequant(
+        init_map[wu_name], init_map[wu_scale_name], init_map[wu_zp_name], axis=1
+    )
+    keep = _combined_keep_indices(wg_dequant, wu_dequant, H // 2)
+
+    pruned = onnxsim.apply_structured_pruning_qoperator(quantized, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    pruned_inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(pruned_inits[wg_name].dims) == [K, H // 2]
+    assert list(pruned_inits[wu_name].dims) == [K, H // 2]
+    assert list(pruned_inits[wd_name].dims) == [H // 2, Out]
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(pruned_inits[wg_name]),
+        init_map[wg_name][:, keep],
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(pruned_inits[wu_name]),
+        init_map[wu_name][:, keep],
+    )
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(pruned_inits[wd_name]),
+        init_map[wd_name][keep, :],
+    )
+
+    sess = ort.InferenceSession(
+        pruned.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    x = rng.standard_normal((1, K)).astype(np.float32)
+    (y_pruned,) = sess.run(None, {"x": x})
+    assert y_pruned.shape == (1, Out)
+    assert np.all(np.isfinite(y_pruned))
+
+
+def test_analyze_structured_pruning_qoperator_gated_matches_real_call():
+    K, H, Out = 8, 16, 4
+    model, _info = _qop_gated_mlp_model(K, H, Out, gate_activation="Relu", seed=71)
+
+    report = onnxsim.analyze_pruning_sensitivity(
+        model, onnxsim.apply_structured_pruning_qoperator, sparsity=0.5
+    )
+    assert len(report.layers) == 1
+    layer = report.layers[0]
+    assert layer.family == "qoperator_matmul_gated"
+    assert layer.total == H
+    assert report.not_eligible == []
+
+    pruned = onnxsim.apply_structured_pruning_qoperator(model, sparsity=0.5)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    kept = H - layer.would_drop
+    assert inits["Wg"].dims[1] == kept
+    assert inits["Wu"].dims[1] == kept
+    assert inits["Wd"].dims[0] == kept
+
+
 # --- Dry-run parity / registry --------------------------------------------
 
 


### PR DESCRIPTION
## Summary

The QOperator (`QLinearConv`/`QLinearMatMul`/`QGemm`) structured-pruning
family had NO gated (SwiGLU/GeGLU/ReGLU) FFN pair support, unlike the QDQ
family (which already has `_find_qdq_gated_chains`) and, as of the last two
rounds, MatMulNBits/MatMulBnb4/DynamicQuantizeMatMul. The section's own top
comment explicitly, deliberately declined this: "Unlike the QDQ section,
this section does NOT add gated-pair support either -- a genuine,
deliberately-left follow-up... but doing so correctly was not attempted
here."

This is a genuinely harder case than the prior three gated-pair rounds: the
QOperator format keeps the tensor quantized throughout (unlike
MatMulNBits/Bnb4/DynamicQuantizeMatMul, which dequantize to float at some
point), and ORT's static QOperator quantizer has no fused `QLinear<Activation>`
op (no `QLinearRelu`, `QLinearSigmoid`, etc.), so an activated gate branch
gets an explicit rescale-activate-requantize sandwich the unactivated branch
doesn't — a genuinely asymmetric shape the other three families never had
to handle.

## Empirically confirmed facts

- Built a float ReGLU FFN (`gate_proj = MatMul`, `Relu`, `up_proj = MatMul`,
  `Mul` combine, `down_proj = MatMul`), quantized via the real
  `onnxruntime.quantization.quantize_static(..., quant_format=
  QuantFormat.QOperator, per_channel=True, activation_type=QuantType.QInt8,
  weight_type=QuantType.QInt8, extra_options={"ActivationSymmetric": True})`.
  Default `op_types_to_quantize` fuses the elementwise `Mul` into
  `com.microsoft::QLinearMul` automatically. The real emitted topology:
  `QuantizeLinear(x)` -> two `QLinearMatMul` (gate/up) -> gate_proj's own
  output gets `DequantizeLinear -> Relu -> QuantizeLinear` (the rescale
  sandwich, since there's no `QLinearRelu`) while up_proj feeds the combine
  node directly -> `com.microsoft::QLinearMul` -> `QLinearMatMul` (down_proj)
  -> `DequantizeLinear`.
- On the pre-fix code: `hasattr(pruning, '_find_qop_gated_chains')` → False;
  `apply_structured_pruning_qoperator(model, sparsity=0.5)` → complete no-op
  on this topology.
- Sanity check: the sibling QDQ family already handles the analogous
  elementwise-Mul gated-pair shape (`_find_qdq_gated_chains` → 1 chain
  found on an equivalent QDQ-format model) — proving the "two producers →
  elementwise Mul → one consumer" recognition machinery already exists and
  works generally in this codebase; it simply was never extended to
  QOperator's `QLinearMatMul`/`QLinearMul` combo.

## What's added

- `_QOpGatedProducer`/`_QOpGatedChain` dataclasses, `_qop_producer_y_scale_zp`
  helper, `_trace_gate_producer_backward_qop`, `_qop_gated_channel_importance`,
  and `_find_qop_gated_chains`, recognizing gate_proj/up_proj (both
  `QLinearMatMul`/`QGemm`, never `QLinearConv` — mirroring the QDQ family's
  own MatMul/Gemm-only gated scope) combined by `com.microsoft::QLinearMul`,
  feeding one downstream `QLinearMatMul`/`QGemm` consumer via the existing
  `_walk_to_qop_consumer`.
- The asymmetric sandwich is matched **narrowly and conservatively, by
  name, not by shape**: a `DequantizeLinear -> <one _UNARY_PASS_THROUGH
  activation> -> QuantizeLinear` hop between a producer and the combine
  node is only accepted when the `DequantizeLinear`'s own scale/zero-point
  inputs are literally the same initializers as the producer's own
  `y_scale`/`y_zero_point` — i.e. it demonstrably reverses *that specific*
  producer's own quantization, not merely a rescale that happens to have a
  matching shape. A branch with no sandwich (feeding `QLinearMul` directly)
  is the trivial zero-hop case, also checked by name.
- Deliberately NOT matched (declined rather than guessed at, since this
  investigation didn't confirm them as real-tool output): a plain `Mul` of
  two already-dequantized float operands re-quantized by its own single
  `QuantizeLinear` (the shape a quantizer would emit if `com.microsoft`
  weren't registered for fusion), and the `QLinearSigmoid`+self-multiply
  SiLU decomposition.
- Wired into `apply_structured_pruning_qoperator` (new gated-pair pruning
  loop, using the existing per-role `_slice_qop_producer`/
  `_slice_qop_consumer` helpers) and `_analyze_structured_pruning_qoperator`/
  `_qop_not_eligible` (sensitivity-report dry-run mirror, new family string
  `"qoperator_matmul_gated"`), following exactly how the QDQ family combines
  its own plain and gated finders/analyzers.
- Updated the section's own top comment to document the real confirmed
  shape and drop the "deliberately declines" framing.

## Test plan

- New regression tests: `test_qop_gated_ffn_relu_asymmetric_matches_oracle`
  (the primary real-repro shape — asymmetric sandwich on the gate branch),
  `test_qop_gated_ffn_no_activation_symmetric_matches_oracle` (symmetric
  zero-hop case), `test_qop_gated_ffn_tied_weight_is_declined` (shared/tied
  weight decline), `test_qop_gated_ffn_mismatched_dq_scale_is_declined`
  (the by-name scale/zero-point identity check — a DQ using a *different*
  scale/zero-point than the producer's own output is correctly declined,
  not assumed safe), `test_qop_gated_ffn_real_quantize_static_pipeline_end_to_end`
  (a genuine `quantize_static(quant_format=QuantFormat.QOperator)` round
  trip on a real ReGLU FFN), and `test_analyze_structured_pruning_qoperator_gated_matches_real_call`
  (sensitivity-report parity).
- Verified via a stash-based before/after check: reverting
  `onnxsim/pruning.py` to the pre-fix commit while keeping the new tests
  reproduces the bug (`AttributeError: no attribute
  '_find_qop_gated_chains'` on all 5 match/decline tests); restoring the
  fix makes all 6 new tests pass.
- `pytest tests/test_pruning.py -k "qop_gated or qop or qlinear or qoperator"`
  → 24 passed.
- `ruff format --check`, `ruff check`, `mypy onnxsim/pruning.py` — all
  clean on the two changed files.
- Full suite: 164 failed (pre-existing, unrelated — stale-compiled-C++-
  extension test failures from concurrent unrelated automation porting
  Python functions to C++, confirmed identical failure set before and
  after this change), 816 passed.

## Risks for reviewer

- The asymmetric DQ/activation/Q sandwich recognition is the most
  structurally novel piece of this change (none of the three prior
  gated-pair rounds needed it). It's deliberately conservative: matched
  only by exact scale/zero-point tensor-name identity, never by shape or
  value alone, and any topology outside the two confirmed shapes (direct
  feed, or exactly this sandwich) is declined rather than guessed at.
- A plain (non-`QLinearMul`-fused) `Mul` gated-combine shape, and the
  `QLinearSigmoid`+self-multiply SiLU decomposition, are both confirmed-real
  possibilities this PR does *not* attempt to match — left as documented,
  deliberate follow-ups, consistent with this module's existing scope-note
  conventions.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_