### PR TITLE
Add Any-Precision LLM: nested bit-plane weight quantization

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -92,6 +92,7 @@ from onnxsim.norm_tweaking import apply_norm_tweaking
 from onnxsim.olive import quantize_weight_only_olive
 from onnxsim.omniquant import apply_omniquant
 from onnxsim.onnx_simplifier import (
+    apply_any_precision_llm_cpp,
     apply_attention_head_pruning_cpp,
     apply_attention_head_wanda_pruning_cpp,
     apply_double_quantization_cpp,
@@ -252,6 +253,7 @@ __all__ = [
     "apply_quip_sharp",
     "apply_quarot",
     "apply_quarot_cpp",
+    "apply_any_precision_llm_cpp",
     "apply_duquant",
     "apply_easyquant",
     "apply_zeroquant",

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -13,6 +13,7 @@ from onnxsim.adaquant import apply_adaquant
 from onnxsim.adaround import apply_adaround
 from onnxsim.adpq import quantize_weight_only_adpq
 from onnxsim.affinequant import apply_affinequant
+from onnxsim.any_precision_llm import apply_any_precision_llm
 from onnxsim.aqlm import quantize_weight_only_aqlm
 from onnxsim.attention_quantization import apply_attention_quantization
 from onnxsim.autoquant import AutoQuantResult, auto_quantize_int4
@@ -259,6 +260,7 @@ __all__ = [
     "apply_rotatekv",
     "apply_omniquant",
     "apply_affinequant",
+    "apply_any_precision_llm",
     "apply_magnitude_pruning",
     "prune_magnitude_cpp",
     "apply_wanda_pruning",

--- a/onnxsim/any_precision_llm.py
+++ b/onnxsim/any_precision_llm.py
@@ -1,0 +1,221 @@
+"""Any-Precision LLM (Park, Hyun, Cho, Sung, Choi, 2024, ICML 2024,
+"Any-Precision LLM: Low-Cost Deployment of Multiple, Different-Sized
+LLMs", https://arxiv.org/abs/2402.10517). onnxsim ports the algorithm, not
+any framework's code, per the same rationale as :mod:`onnxsim.awq`/
+:mod:`onnxsim.gptq` (the paper's own reference implementation quantizes
+live PyTorch weights with a custom CUDA kernel serving the packed
+multi-precision format, with no ONNX export path).
+
+Every other weight-only quantizer in onnxsim picks **one bit-width** and
+quantizes independently for it: asking for both a 4-bit and a 6-bit
+version of the same model means running the quantizer twice, from
+scratch, with no relationship between the two results beyond sharing the
+same float source. Any-Precision LLM's own idea: quantize **once**, to the
+*highest* bit-width ever needed, using a scheme where every lower
+bit-width's own quantization is recoverable *exactly* by discarding the
+highest-order... no, by discarding the *lowest*-order refinement bits of
+that single quantization -- a **nested / incremental bit-plane**
+construction, not independent per-bit-width quantization. Concretely, for
+one value in one channel: start from a 1-bit code (which half of the
+value's own local range it falls in), then repeatedly **bisect** -- at each
+step, split every *existing* bin into two halves using that bin's own
+member values only, appending one more bit to every code -- until reaching
+the target maximum bit-width. Because a bin is only ever refined, never
+merged or reassigned across an old bin boundary, the code built this way
+has an exact algebraic nesting property: the ``b``-bit code, for *any*
+``b`` up to the maximum, is recoverable from the max-bit-width code by a
+plain integer right-shift (``code_at_max_bits >> (max_bits - b)``) -- one
+quantization pass serves every precision level up to its own maximum, the
+paper's own "any precision" deployment story (a single stored artifact,
+truncate bit-planes for a cheaper/smaller version, keep them all for the
+most accurate one).
+
+This module's own version of the per-bin split rule (a good-faith
+reproduction of the paper's own described "incremental upgrade" mechanism,
+not a transcription of its own exact seed/split procedure, which this
+module does not claim to reproduce exactly): each bisection step splits a
+bin at the **midpoint of that bin's own current member values**
+(``0.5 * (bin.min() + bin.max())``) -- simple, deterministic, and
+sufficient to demonstrate the nesting property exactly (verified directly
+in this module's own test file: the algebraic right-shift relationship
+holds bit-for-bit, not just approximately). After the code tree is built
+once (to ``max_bits``), materializing any single precision level ``bits``
+is: right-shift the max-depth code down to a ``bits``-wide code, then
+reconstruct each element as **the mean of its own bin's own original
+values** -- the maximum-likelihood constant reconstruction for a fixed
+partition. This module's first implementation instead fit one global
+affine map (``value ~= code * scale + zero``) per block, by analogy with
+every *uniform* quantizer elsewhere in this repo -- but this scheme's own
+bins are not laid out on any fixed linear grid (each bisection's own split
+point comes from that specific bin's own local data), so a straight-line
+fit across all codes is not guaranteed to improve as bins get refined, and
+empirically did not (caught by this module's own
+reconstruction-improves-with-more-bits test, which failed under the
+affine version and passes under the per-bin-mean version below). Per-bin
+mean reconstruction, by contrast, *is* guaranteed monotonically
+non-increasing in squared error as bins are refined further -- splitting a
+bin can only reduce or preserve the variance it contributes (the law of
+total variance), never increase it.
+
+**What this module does not claim.** The paper's own reported gains are
+about *deployment infrastructure* (one download serves many precisions,
+with a real packed-bit-plane storage format and a custom serving kernel);
+this module verifies the *nesting property* holds exactly, and that
+reconstruction error at any single materialized precision is *competitive
+with* (not necessarily better than) an ordinary independent quantizer at
+that same precision -- being constrained to reuse a lower level's own bin
+boundaries is a real constraint an independent quantizer doesn't have, so
+this module does not claim nested quantization always wins on raw
+accuracy at a fixed bit-width, only that it wins on not needing to
+re-quantize from scratch for every precision level. As with several other
+modules in this repo (:mod:`onnxsim.ibert_gelu`, :mod:`onnxsim.ibert_softmax`),
+onnxsim has no lower-than-float32, arbitrary-bit-width ONNX tensor type to
+express genuine packed sub-8-bit storage in (only INT4 and INT8 are
+native) -- this module represents every materialized precision level as an
+ordinary float32 quantize-dequantize round trip (the same simplification
+:mod:`onnxsim.easyquant` already makes for its own W8A8 weights), not a
+literal packed multi-bit-plane binary format.
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+
+from onnxsim.llm_int8 import _match_matmul_like
+
+
+def _nested_bitplane_codes(values: np.ndarray, max_bits: int) -> np.ndarray:
+    """Returns integer codes in ``[0, 2**max_bits - 1]`` for the 1-D array
+    ``values``, built by repeated within-bin bisection (see this module's
+    own docstring) -- with the exact property that, for every
+    ``1 <= bits <= max_bits``, ``codes >> (max_bits - bits)`` is that
+    ``bits``-wide nested quantization's own code.
+    """
+    codes = np.zeros(values.shape[0], dtype=np.int64)
+    for _ in range(max_bits):
+        new_codes = codes.copy()
+        for bin_id in np.unique(codes):
+            mask = codes == bin_id
+            bin_values = values[mask]
+            if bin_values.size <= 1:
+                new_codes[mask] = codes[mask] * 2
+                continue
+            split = 0.5 * (float(bin_values.min()) + float(bin_values.max()))
+            new_codes[mask] = codes[mask] * 2 + (bin_values >= split).astype(np.int64)
+        codes = new_codes
+    return codes
+
+
+def _dequantize_by_bin_mean(values: np.ndarray, codes: np.ndarray) -> np.ndarray:
+    # Reconstructs each element as the mean of its own bin's own original
+    # values -- the maximum-likelihood constant reconstruction for a fixed
+    # partition, and (by the law of total variance -- splitting a bin can
+    # only ever reduce or preserve its own contributed squared error,
+    # never increase it) the choice that makes reconstruction error
+    # monotonically non-increasing as bins get refined. A single global
+    # affine fit (`value ~= code * scale + zero`) does NOT have this
+    # property here: this module's own bisection splits are chosen from
+    # each bin's own local data, not laid out on any fixed linear grid, so
+    # a straight-line fit across all codes can fit *worse* after a split
+    # than before one (verified empirically -- an earlier version of this
+    # module used exactly that affine fit and failed its own reconstruction-
+    # improves-with-more-bits test).
+    out = np.empty_like(values)
+    for code in np.unique(codes):
+        mask = codes == code
+        out[mask] = values[mask].mean()
+    return out
+
+
+def _quantize_channel_nested(
+    row: np.ndarray, bits: int, max_bits: int, block_size: int
+) -> np.ndarray:
+    k = row.shape[0]
+    out = np.empty_like(row)
+    for start in range(0, k, block_size):
+        end = min(start + block_size, k)
+        block = row[start:end].astype(np.float64)
+        max_codes = _nested_bitplane_codes(block, max_bits)
+        codes_b = max_codes >> (max_bits - bits)
+        out[start:end] = _dequantize_by_bin_mean(block, codes_b)
+    return out
+
+
+def apply_any_precision_llm(
+    float_model: Union[str, onnx.ModelProto],
+    bits: int = 4,
+    max_bits: int = 8,
+    block_size: int = 32,
+) -> onnx.ModelProto:
+    """Weight-only quantizes every matched MatMul/"vanilla" Gemm layer to
+    ``bits`` bits per element, using Any-Precision LLM's own nested
+    bit-plane code construction (built once, to ``max_bits``, then
+    right-shifted down to ``bits``) -- see this module's own docstring.
+    Calling this again with a *different* ``bits`` (holding ``max_bits``
+    and ``block_size`` fixed) reuses the exact same underlying code tree
+    for every shared block, the paper's own "quantize once, deploy at any
+    precision up to ``max_bits``" property.
+
+    :param float_model: the original (unquantized) onnx ModelProto or file
+            path
+    :param bits: the precision level to materialize, ``1 <= bits <=
+            max_bits``
+    :param max_bits: the highest bit-width the nested code tree is built
+            to -- the ceiling every ``bits`` value shares a common code
+            tree with
+    :param block_size: elements per (output-channel, K-block) affine fit,
+            matching :func:`onnxsim.quantize_weight_only_int4`'s own
+            default block size convention
+    :returns: ``float_model`` with every matched layer's weight replaced
+            by its ``bits``-bit nested-quantization float32
+            quantize-dequantize round trip. Layers with a non-constant,
+            non-2-D weight are left untouched.
+    """
+    if not (1 <= bits <= max_bits):
+        raise ValueError(f"bits ({bits}) must be in [1, max_bits={max_bits}]")
+    if isinstance(float_model, str):
+        float_model = onnx.load(float_model, load_external_data=False)
+
+    initializer_map = {t.name: t for t in float_model.graph.initializer}
+    candidates = []  # (w_init, weight_transposed)
+    for node in float_model.graph.node:
+        match = _match_matmul_like(node)
+        if match is None:
+            continue
+        _x_name, w_name, _bias_name, weight_transposed = match
+        w_init = initializer_map.get(w_name)
+        if (
+            w_init is None
+            or w_init.data_type != onnx.TensorProto.FLOAT
+            or len(w_init.dims) != 2
+        ):
+            continue
+        candidates.append((w_init, weight_transposed))
+    if not candidates:
+        return float_model
+
+    out = onnx.ModelProto()
+    out.CopyFrom(float_model)
+    out_initializer_map = {t.name: t for t in out.graph.initializer}
+
+    for w_init, weight_transposed in candidates:
+        w = onnx.numpy_helper.to_array(w_init).astype(np.float64)
+        w_nk = w if weight_transposed else w.T  # [N, K], output-channel first
+
+        quant_nk = np.empty_like(w_nk)
+        for i in range(w_nk.shape[0]):
+            quant_nk[i, :] = _quantize_channel_nested(
+                w_nk[i, :], bits, max_bits, block_size
+            )
+        quant = quant_nk if weight_transposed else quant_nk.T
+
+        out_init = out_initializer_map[w_init.name]
+        out_init.CopyFrom(
+            onnx.numpy_helper.from_array(quant.astype(np.float32), name=w_init.name)
+        )
+
+    return out

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -1050,6 +1050,25 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
       "model_bytes"_a, "sparsity"_a = 0.5, "protect_token_ids"_a.none(),
       "input_name"_a.none());
 
+  // Any-Precision LLM (Park et al., 2024, ICML 2024): nested bit-plane
+  // weight-only quantization, one quantization pass serving any bit-width
+  // up to max_bits. See ApplyAnyPrecisionLlm in onnxsim.h.
+  m.def(
+      "apply_any_precision_llm",
+      [](const py::bytes& model_proto_bytes, int64_t bits, int64_t max_bits,
+         int64_t block_size) -> py::bytes {
+        InitEnv();
+        ONNX_NAMESPACE::ModelProto model;
+        ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
+                            model_proto_bytes.size());
+        const auto result =
+            ApplyAnyPrecisionLlm(model, bits, max_bits, block_size);
+        std::string out;
+        result.SerializeToString(&out);
+        return py::bytes(out.data(), out.size());
+      },
+      "model_bytes"_a, "bits"_a = 4, "max_bits"_a = 8, "block_size"_a = 32);
+
   // QuaRot (Ashkboos et al., 2024): rotation preprocessing plus INT4
   // round-to-nearest quantization of both the weight and the activation of
   // every MatMul/vanilla-Gemm layer. Data-free. See ApplyQuarot in

--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "onnxoptimizer/optimize.h"
+#include "passes/any_precision_llm.h"
 #include "passes/cross_layer_equalization.h"
 #include "passes/defuse_matmul_integer_to_float.h"
 #include "passes/double_quantization.h"
@@ -111,6 +112,7 @@ void RegisterCustomOptimizerPasses() {
     auto& registry = ONNX_NAMESPACE::optimization::Optimizer::passes;
 
     // onnxsim-only rewrites (no built-in of the same name today).
+    RegisterOrReplace<p::AnyPrecisionLlm>(registry);
     RegisterOrReplace<p::CrossLayerEqualization>(registry);
     RegisterOrReplace<p::DefuseMatMulIntegerToFloat>(registry);
     RegisterOrReplace<p::DoubleQuantization>(registry);

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -2601,6 +2601,60 @@ def apply_embedding_vocab_magnitude_pruning_cpp(
     return _embedding_pruning_result_from_cpp(*result)
 
 
+def apply_any_precision_llm_cpp(
+    model: Union[str, onnx.ModelProto],
+    bits: int = 4,
+    max_bits: int = 8,
+    block_size: int = 32,
+) -> onnx.ModelProto:
+    """
+    C++-backed port of :func:`onnxsim.apply_any_precision_llm`: weight-only
+    quantizes every MatMul/vanilla-Gemm layer with a constant 2-D float32
+    weight to ``bits`` bits per element, per (output channel, ``block_size``
+    -element K-block), via a nested bit-plane code built once to
+    ``max_bits`` (repeated within-bin bisection at each bin's own current
+    min/max midpoint) and truncated down to ``bits`` by a plain integer
+    right-shift -- see :func:`onnxsim.apply_any_precision_llm`'s own
+    docstring for the full rationale (Park et al., 2024, ICML 2024,
+    "Any-Precision LLM: Low-Cost Deployment of Multiple, Different-Sized
+    LLMs"). One quantization pass serves any precision up to ``max_bits``
+    instead of re-quantizing from scratch per bit-width.
+
+    Every matched element is replaced by its own quantize-dequantize
+    (per-bin-mean reconstruction) round trip; the result stays float32
+    (same shape/dtype as the original weight) -- this is a compute-only
+    rewrite, not a compressed storage format, since no ONNX tensor type
+    below INT4 exists to store 3/5/6/7-bit codes natively.
+
+    Unlike that pure-Python implementation, this port's per-bin bisection
+    groups indices via a hash map rather than numpy's own reduction order,
+    so results are not expected to match bit-for-bit -- only to be
+    similarly accurate (both satisfy the same exact nesting invariant and
+    the same monotonically-improving-with-more-bits property; see
+    :func:`onnxsim.apply_any_precision_llm`'s own docstring for why an
+    earlier, affine-fit-based reconstruction did NOT have that property).
+
+    This is a single, self-contained graph rewrite: unlike :func:`simplify`,
+    it does not run shape inference, constant folding, or any other pass.
+    Layers with a non-constant, non-2-D weight are left untouched. Consider
+    calling :func:`simplify` before and/or after to clean up the graph.
+
+    :param model: the original (unquantized) onnx ModelProto or file path
+    :param bits: the precision level to materialize, ``1 <= bits <=
+            max_bits``
+    :param max_bits: the highest bit-width the nested code tree is built to
+    :param block_size: elements per (output-channel, K-block) reconstruction
+            group, matching :func:`onnxsim.quantize_weight_only_int4`'s own
+            default block size convention
+    :returns: the quantized onnx ModelProto
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    return onnx.load_from_string(
+        C.apply_any_precision_llm(model.SerializeToString(), bits, max_bits, block_size)
+    )
+
+
 def apply_quarot_cpp(
     model: Union[str, onnx.ModelProto],
     seed: int = 0,

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -530,6 +530,37 @@ onnx::ModelProto PruneMagnitude(const onnx::ModelProto& model, double sparsity,
                                 const std::optional<int64_t>& m = std::nullopt,
                                 bool global_sparsity = false);
 
+// Any-Precision LLM (Park et al., 2024, ICML 2024, "Any-Precision LLM:
+// Low-Cost Deployment of Multiple, Different-Sized LLMs") -- C++ port of
+// any_precision_llm.py's own apply_any_precision_llm. Weight-only quantizes
+// every MatMul/vanilla-Gemm layer with a constant 2-D float32 weight to
+// ``bits`` bits per element, per (output channel, ``block_size``-element
+// K-block), via a nested bit-plane code built once to ``max_bits`` (repeated
+// within-bin bisection at each bin's own current min/max midpoint) and
+// truncated down to ``bits`` by a plain integer right-shift -- see
+// ``passes/any_precision_llm.h`` for the exact rewrite and rationale. Every
+// element is replaced by its own quantize-dequantize (per-bin-mean
+// reconstruction) round trip; the result stays float32 (same shape/dtype as
+// the original weight) -- this is a compute-only rewrite, not a compressed
+// storage format (see that header's own scope note on why: no ONNX tensor
+// type below INT4 exists to store 3/5/6/7-bit codes natively).
+//
+// Throws ``std::invalid_argument`` if ``max_bits < 1`` or ``bits`` is not in
+// ``[1, max_bits]``. Unlike ``Simplify``, this does not run shape inference,
+// constant folding or any other simplification pass. A layer with a
+// non-constant, non-2-D weight is left untouched.
+//
+// ACCEPTED, PERMANENT DIVERGENCE from the pure-Python
+// ``apply_any_precision_llm`` (``any_precision_llm.py``): floating-point
+// summation/iteration order differs (this port groups bin members via an
+// ``std::unordered_map``, not numpy's own reduction order), so results can
+// differ in the last ULP or two -- the same "independently correct, not
+// required to be bit-for-bit identical" contract ``ApplyQuarot``/
+// ``apply_quarot_cpp`` already established for their own pair.
+onnx::ModelProto ApplyAnyPrecisionLlm(const onnx::ModelProto& model,
+                                      int64_t bits, int64_t max_bits,
+                                      int64_t block_size);
+
 // QuaRot (Ashkboos et al., 2024) rotation preprocessing plus INT4
 // round-to-nearest quantization of *both* the weight and the activation of
 // every MatMul/vanilla-Gemm layer with a constant 2-D float32 weight whose

--- a/onnxsim/passes/any_precision_llm.h
+++ b/onnxsim/passes/any_precision_llm.h
@@ -1,0 +1,240 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+// Any-Precision LLM (Park et al., 2024, ICML 2024, "Any-Precision LLM:
+// Low-Cost Deployment of Multiple, Different-Sized LLMs") -- C++ port of
+// any_precision_llm.py's own apply_any_precision_llm. See that module's
+// docstring for the full rationale (a nested bit-plane code, built once to
+// a maximum bit-width via repeated within-bin bisection, where every lower
+// bit-width's own code is exactly recoverable from the max-depth code by a
+// plain integer right-shift -- one quantization pass serves any precision
+// up to its own ceiling).
+//
+// Before (illustrated for MatMul; a "vanilla" Gemm -- transA=0, alpha=1,
+// beta=1 -- is handled the same way, its bias C left untouched):
+//   Y = MatMul(X, W) [+ bias]      W constant, [K, N], float32
+// After:
+//   Y = MatMul(X, W') [+ bias]     W' same shape/dtype as W, every element
+//                                   replaced by its own (channel, K-block)
+//                                   nested-bit-plane quantize-dequantize
+//                                   round trip at AnyPrecisionLlmBits() bits
+//
+// Only the common, unambiguous shape is handled: a MatMul, or a Gemm with
+// transA=0, alpha=1 and beta=1, whose weight (input 1) is a constant 2-D
+// float32 tensor. Everything else is left alone.
+//
+// ACCEPTED, PERMANENT DIVERGENCE FROM any_precision_llm.py: this port's own
+// per-bin bisection groups indices by current code using an
+// std::unordered_map (iteration order over bins is therefore
+// hash-order-dependent, not numerically significant since each bin's own
+// split only ever looks at that bin's own min/max) -- ties at a bin's exact
+// split threshold, and floating-point summation order inside a per-bin mean,
+// can each differ in the last ULP or two from the Python port's own numpy
+// reduction order. As with apply_quarot/apply_quarot_cpp, this port and
+// any_precision_llm.py's apply_any_precision_llm are independently-correct,
+// non-interchangeable entry points -- not required to be bit-for-bit
+// identical, only similarly accurate (verified in this pass's own Python
+// test file: both satisfy the same exact nesting invariant, and both
+// improve reconstruction error monotonically with more bits).
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+#include "passes/quantize_matmul_common.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+// Read/written by ApplyAnyPrecisionLlm (quantize_entry.cpp) immediately
+// before invoking OptimizeFixed, the same "global mutable reference,
+// reconfigured per call" pattern QuarotSeed()/QuarotBlockSize() already use
+// for their own pass.
+inline int64_t& AnyPrecisionLlmBits() {
+  static int64_t bits = 4;
+  return bits;
+}
+inline int64_t& AnyPrecisionLlmMaxBits() {
+  static int64_t max_bits = 8;
+  return max_bits;
+}
+inline int64_t& AnyPrecisionLlmBlockSize() {
+  static int64_t block_size = 32;
+  return block_size;
+}
+
+namespace any_precision_llm_detail {
+
+// Mirrors any_precision_llm.py's own _nested_bitplane_codes exactly: at
+// each of `max_bits` steps, every *existing* bin (grouped by its own
+// current code) is bisected at the midpoint of that bin's own current
+// member values, appending one more low-order bit to every code in it. A
+// singleton bin (no member left to compare against) just gets a trailing
+// zero bit -- the same as the Python port's own `bin_values.size() <= 1`
+// case.
+inline std::vector<int64_t> NestedBitplaneCodes(
+    const std::vector<double>& values, int64_t max_bits) {
+  const size_t n = values.size();
+  std::vector<int64_t> codes(n, 0);
+  for (int64_t bit = 0; bit < max_bits; ++bit) {
+    std::unordered_map<int64_t, std::vector<size_t>> bins;
+    for (size_t i = 0; i < n; ++i) {
+      bins[codes[i]].push_back(i);
+    }
+    for (const auto& kv : bins) {
+      const std::vector<size_t>& idxs = kv.second;
+      if (idxs.size() <= 1) {
+        for (size_t i : idxs) {
+          codes[i] = codes[i] * 2;
+        }
+        continue;
+      }
+      double lo = values[idxs[0]];
+      double hi = values[idxs[0]];
+      for (size_t i : idxs) {
+        lo = std::min(lo, values[i]);
+        hi = std::max(hi, values[i]);
+      }
+      const double split = 0.5 * (lo + hi);
+      for (size_t i : idxs) {
+        codes[i] = codes[i] * 2 + (values[i] >= split ? 1 : 0);
+      }
+    }
+  }
+  return codes;
+}
+
+// Mirrors any_precision_llm.py's own _dequantize_by_bin_mean: reconstructs
+// every element as the mean of its own bin's own original values (a proper
+// vector-quantizer reconstruction, not a linear/uniform-grid one -- see
+// that module's docstring for why a single affine fit does not have the
+// "monotonically improves with more bits" property this scheme relies on).
+inline std::vector<double> DequantizeByBinMean(
+    const std::vector<double>& values, const std::vector<int64_t>& codes) {
+  std::unordered_map<int64_t, std::pair<double, int64_t>> sums;
+  for (size_t i = 0; i < values.size(); ++i) {
+    auto& entry = sums[codes[i]];
+    entry.first += values[i];
+    entry.second += 1;
+  }
+  std::vector<double> out(values.size());
+  for (size_t i = 0; i < values.size(); ++i) {
+    const auto& entry = sums[codes[i]];
+    out[i] = entry.first / static_cast<double>(entry.second);
+  }
+  return out;
+}
+
+}  // namespace any_precision_llm_detail
+
+struct AnyPrecisionLlm final : public PredicateBasedPass {
+  explicit AnyPrecisionLlm()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+  std::string getPassName() const override { return "any_precision_llm"; }
+
+  bool patternMatchPredicate(Node* n) override {
+    MatMulLikeInfo info;
+    if (!MatchMatMulLike(n, info)) {
+      return false;
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    return w_t != nullptr && w_t->elem_type() == TensorProto_DataType_FLOAT &&
+           w_t->sizes().size() == 2;
+  }
+
+  bool runTransform(Node* n, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    // This pass only ever replaces `n`'s weight input, never `n` itself.
+    destroy_current = NodeDestroyType::DestroyZero;
+    MatMulLikeInfo info;
+    if (!MatchMatMulLike(n, info)) {
+      return false;
+    }
+    const Tensor* w_t = FetchConstantTensor(info.w);
+    if (w_t == nullptr || w_t->elem_type() != TensorProto_DataType_FLOAT ||
+        w_t->sizes().size() != 2) {
+      return false;
+    }
+
+    const int64_t bits = AnyPrecisionLlmBits();
+    const int64_t max_bits = AnyPrecisionLlmMaxBits();
+    const int64_t block_size = std::max<int64_t>(1, AnyPrecisionLlmBlockSize());
+
+    const auto& sizes = w_t->sizes();
+    const int64_t dim0 = sizes[0];
+    const int64_t dim1 = sizes[1];
+    // Logical [N, K] (output-channel-first) view, matching
+    // any_precision_llm.py's own `w_nk` convention.
+    const int64_t N = info.weight_transposed ? dim0 : dim1;
+    const int64_t K = info.weight_transposed ? dim1 : dim0;
+
+    const std::vector<float> data = ReadFloatMatrix(*w_t);
+    // Element (row, k) of the logical [N, K] weight, regardless of storage
+    // layout: `weight_transposed` means W is already stored [N, K]
+    // (dim0=N, dim1=K); otherwise W is [K, N] (dim0=K, dim1=N).
+    auto at = [&](int64_t row, int64_t k) -> double {
+      return info.weight_transposed ? static_cast<double>(data[row * dim1 + k])
+                                    : static_cast<double>(data[k * dim1 + row]);
+    };
+
+    using any_precision_llm_detail::DequantizeByBinMean;
+    using any_precision_llm_detail::NestedBitplaneCodes;
+
+    std::vector<float> out_data(static_cast<size_t>(dim0 * dim1));
+    auto set_at = [&](int64_t row, int64_t k, float v) {
+      if (info.weight_transposed) {
+        out_data[static_cast<size_t>(row * dim1 + k)] = v;
+      } else {
+        out_data[static_cast<size_t>(k * dim1 + row)] = v;
+      }
+    };
+
+    for (int64_t row = 0; row < N; ++row) {
+      for (int64_t start = 0; start < K; start += block_size) {
+        const int64_t end = std::min(start + block_size, K);
+        std::vector<double> block(static_cast<size_t>(end - start));
+        for (int64_t k = start; k < end; ++k) {
+          block[static_cast<size_t>(k - start)] = at(row, k);
+        }
+        const std::vector<int64_t> max_codes =
+            NestedBitplaneCodes(block, max_bits);
+        std::vector<int64_t> codes_b(block.size());
+        for (size_t i = 0; i < block.size(); ++i) {
+          codes_b[i] = max_codes[i] >> (max_bits - bits);
+        }
+        const std::vector<double> recon = DequantizeByBinMean(block, codes_b);
+        for (int64_t k = start; k < end; ++k) {
+          set_at(row, k,
+                 static_cast<float>(recon[static_cast<size_t>(k - start)]));
+        }
+      }
+    }
+
+    Tensor w_out;
+    w_out.elem_type() = TensorProto_DataType_FLOAT;
+    w_out.sizes() = sizes;
+    w_out.floats() = std::move(out_data);
+
+    Value* w_out_v = graph.addInitializerAndCreateValue(w_out);
+    n->replaceInput(1, w_out_v);
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/quantize_entry.cpp
+++ b/onnxsim/quantize_entry.cpp
@@ -10,6 +10,7 @@
 #include "model_prep.h"
 #include "onnx/common/ir_pb_converter.h"
 #include "onnxoptimizer/optimize.h"
+#include "passes/any_precision_llm.h"
 #include "passes/dynamic_quantize_matmul_integer_to_float.h"
 #include "passes/qoperator_quantize_gemm.h"
 #include "passes/qoperator_quantize_pool.h"
@@ -127,6 +128,32 @@ onnx::ModelProto ApplyDoubleQuantization(const onnx::ModelProto& model) {
   onnxsim::RegisterCustomOptimizerPasses();
   return onnx::optimization::OptimizeFixed(
       model, std::vector<std::string>{"double_quantization"});
+}
+
+onnx::ModelProto ApplyAnyPrecisionLlm(const onnx::ModelProto& model,
+                                      int64_t bits, int64_t max_bits,
+                                      int64_t block_size) {
+  if (max_bits < 1) {
+    throw std::invalid_argument(
+        "ApplyAnyPrecisionLlm: max_bits must be >= 1, got " +
+        std::to_string(max_bits));
+  }
+  if (bits < 1 || bits > max_bits) {
+    throw std::invalid_argument(
+        "ApplyAnyPrecisionLlm: bits (" + std::to_string(bits) +
+        ") must be in [1, max_bits=" + std::to_string(max_bits) + "]");
+  }
+  PrepareSchemasForDebug(model);
+  // Registers any_precision_llm (idempotent) into onnxoptimizer's registry
+  // so OptimizeFixed can find it by name below.
+  onnxsim::RegisterCustomOptimizerPasses();
+  // any_precision_llm reads these the same way quarot reads QuarotSeed() --
+  // OptimizeFixed's pass-name list has no way to carry a parameter directly.
+  onnx::optimization::onnxsim_passes::AnyPrecisionLlmBits() = bits;
+  onnx::optimization::onnxsim_passes::AnyPrecisionLlmMaxBits() = max_bits;
+  onnx::optimization::onnxsim_passes::AnyPrecisionLlmBlockSize() = block_size;
+  return onnx::optimization::OptimizeFixed(
+      model, std::vector<std::string>{"any_precision_llm"});
 }
 
 onnx::ModelProto ApplyQuarot(const onnx::ModelProto& model, uint64_t seed,

--- a/onnxsim/quantize_entry.h
+++ b/onnxsim/quantize_entry.h
@@ -76,5 +76,8 @@ onnx::ModelProto QuantizeFp8(const onnx::ModelProto& model,
                              const std::string& format, bool keep_io_types);
 
 onnx::ModelProto ApplyDoubleQuantization(const onnx::ModelProto& model);
+onnx::ModelProto ApplyAnyPrecisionLlm(const onnx::ModelProto& model,
+                                      int64_t bits, int64_t max_bits,
+                                      int64_t block_size);
 onnx::ModelProto ApplyQuarot(const onnx::ModelProto& model, uint64_t seed,
                              int64_t block_size, float epsilon);

--- a/tests/test_any_precision_llm.py
+++ b/tests/test_any_precision_llm.py
@@ -1,0 +1,160 @@
+"""Tests for ``onnxsim.apply_any_precision_llm`` (Any-Precision LLM, see
+``onnxsim/any_precision_llm.py``) -- a nested bit-plane weight
+quantization where every lower bit-width's own code is recoverable from
+the highest bit-width's code by a plain integer right-shift.
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+from onnxsim.any_precision_llm import _dequantize_by_bin_mean, _nested_bitplane_codes
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(body, initializer=(), opset=13, ir_version=8):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _matmul_model(w, K, N, batch="batch"):
+    return _model(
+        f"""
+        g (float[{batch},{K}] X) => (float[{batch},{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [_f32(w, "W")],
+    )
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-9)
+
+
+def test_nested_codes_satisfy_exact_shift_invariant():
+    # The core algebraic claim: for every bit-width up to max_bits, that
+    # bit-width's own code is exactly recoverable from the max-bit-width
+    # code by a plain right-shift -- verified bit-for-bit, not just
+    # approximately.
+    rng = np.random.default_rng(0)
+    values = rng.standard_normal(500)
+    max_bits = 6
+
+    max_codes = _nested_bitplane_codes(values, max_bits)
+    assert max_codes.min() >= 0
+    assert max_codes.max() < 2**max_bits
+
+    for bits in range(1, max_bits + 1):
+        codes_b = _nested_bitplane_codes(values, bits)
+        shifted = max_codes >> (max_bits - bits)
+        np.testing.assert_array_equal(codes_b, shifted)
+
+
+def test_dequantize_by_bin_mean_reconstructs_each_bins_own_average():
+    codes = np.array([0, 0, 1, 1, 1, 2], dtype=np.int64)
+    values = np.array([1.0, 3.0, 10.0, 20.0, 30.0, 100.0])
+    recon = _dequantize_by_bin_mean(values, codes)
+    np.testing.assert_allclose(recon, [2.0, 2.0, 20.0, 20.0, 20.0, 100.0])
+
+
+def test_reconstruction_error_improves_with_more_bits():
+    rng = np.random.default_rng(1)
+    w = rng.standard_normal((64, 16)).astype(np.float32) * 0.5
+    model = _matmul_model(w, K=64, N=16)
+
+    errors = []
+    for bits in (2, 4, 6, 8):
+        q = onnxsim.apply_any_precision_llm(model, bits=bits, max_bits=8)
+        new_w = onnx.numpy_helper.to_array(q.graph.initializer[0])
+        errors.append(
+            float(np.linalg.norm(new_w.astype(np.float64) - w.astype(np.float64)))
+        )
+
+    # Strictly non-increasing (each additional bit only ever refines an
+    # existing bin further, never coarsens it), and 8 bits should be
+    # dramatically better than 2 bits.
+    for a, b in zip(errors, errors[1:]):
+        assert b <= a + 1e-6
+    assert errors[-1] < errors[0] * 0.3
+
+
+def test_low_bit_reconstruction_matches_direct_low_bit_call():
+    # Materializing bits=3 directly must equal what you get by building
+    # the max_bits=8 tree and truncating -- the "quantize once, deploy at
+    # any precision" property, checked end-to-end through the public API.
+    rng = np.random.default_rng(2)
+    w = rng.standard_normal((32, 8)).astype(np.float32)
+    model = _matmul_model(w, K=32, N=8)
+
+    direct = onnxsim.apply_any_precision_llm(model, bits=3, max_bits=3)
+    via_tree = onnxsim.apply_any_precision_llm(model, bits=3, max_bits=8)
+    w_direct = onnx.numpy_helper.to_array(direct.graph.initializer[0])
+    w_tree = onnx.numpy_helper.to_array(via_tree.graph.initializer[0])
+    # Same code assignment either way (both are 3-bit prefixes of the same
+    # per-value split history), so the per-bin-mean reconstruction (which
+    # only depends on the codes and the original values within each block)
+    # is identical too.
+    np.testing.assert_allclose(w_direct, w_tree, rtol=1e-5, atol=1e-6)
+
+
+def test_output_stays_close_to_float_via_onnxruntime():
+    rng = np.random.default_rng(3)
+    w = rng.standard_normal((64, 16)).astype(np.float32) * 0.5
+    model = _matmul_model(w, K=64, N=16)
+    q = onnxsim.apply_any_precision_llm(model, bits=6, max_bits=8)
+    onnx.checker.check_model(q)
+
+    x = rng.standard_normal((4, 64)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x})
+    (q_y,) = _run(q, {"X": x})
+    assert np.all(np.isfinite(q_y))
+    assert _rel_l2(float_y, q_y) < 0.1
+
+
+def test_rejects_bits_outside_range():
+    model = _matmul_model(np.zeros((8, 4), dtype=np.float32), K=8, N=4)
+    with pytest.raises(ValueError):
+        onnxsim.apply_any_precision_llm(model, bits=9, max_bits=8)
+    with pytest.raises(ValueError):
+        onnxsim.apply_any_precision_llm(model, bits=0, max_bits=8)
+
+
+def test_noop_when_no_matmul_gemm_present():
+    model = _model(
+        """
+        g (float[4,4] X) => (float[4,4] Y)
+        {
+          Y = Relu(X)
+        }
+        """
+    )
+    result = onnxsim.apply_any_precision_llm(model)
+    assert result.SerializeToString() == model.SerializeToString()

--- a/tests/test_any_precision_llm_cpp.py
+++ b/tests/test_any_precision_llm_cpp.py
@@ -1,0 +1,201 @@
+"""Tests for ``onnxsim.apply_any_precision_llm_cpp`` -- the C++-backed port
+of ``onnxsim.apply_any_precision_llm`` (see
+``onnxsim/passes/any_precision_llm.h``). Floating-point iteration order
+differs from the pure-Python port (grouping by hash map, not numpy's own
+reduction order), so these tests check the same structural/algebraic
+properties the Python port's own tests check (exact nesting invariant,
+monotonically improving reconstruction with more bits) rather than
+bit-for-bit equality with the Python port.
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(body, initializer=(), opset=13, ir_version=8):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _matmul_model(w, K, N, batch="batch"):
+    return _model(
+        f"""
+        g (float[{batch},{K}] X) => (float[{batch},{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [_f32(w, "W")],
+    )
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-9)
+
+
+def _current_weight(model, weight_input_index=1):
+    # The C++ pass (like weight_only_quantize_matmul.h's own pattern)
+    # rewires the matched node's weight input to a freshly created
+    # initializer, leaving the original one dangling unused in the graph --
+    # so the *node's own current input name* is the only reliable way to
+    # find the actual (post-quantization) weight, not initializer list
+    # position.
+    node = next(n for n in model.graph.node if n.op_type in ("MatMul", "Gemm"))
+    w_name = node.input[weight_input_index]
+    w_init = next(t for t in model.graph.initializer if t.name == w_name)
+    return onnx.numpy_helper.to_array(w_init)
+
+
+def test_cpp_any_precision_llm_replaces_weight_with_same_shape_float():
+    rng = np.random.default_rng(0)
+    w = rng.standard_normal((32, 8)).astype(np.float32)
+    model = _matmul_model(w, K=32, N=8)
+
+    q = onnxsim.apply_any_precision_llm_cpp(model, bits=4, max_bits=8)
+    onnx.checker.check_model(q)
+    new_w = _current_weight(q)
+    assert new_w.shape == w.shape
+    assert new_w.dtype == np.float32
+    assert not np.array_equal(new_w, w)
+
+
+def test_cpp_any_precision_llm_reconstruction_error_improves_with_more_bits():
+    rng = np.random.default_rng(1)
+    w = rng.standard_normal((64, 16)).astype(np.float32) * 0.5
+    model = _matmul_model(w, K=64, N=16)
+
+    errors = []
+    for bits in (2, 4, 6, 8):
+        q = onnxsim.apply_any_precision_llm_cpp(model, bits=bits, max_bits=8)
+        new_w = _current_weight(q)
+        errors.append(
+            float(np.linalg.norm(new_w.astype(np.float64) - w.astype(np.float64)))
+        )
+
+    for a, b in zip(errors, errors[1:]):
+        assert b <= a + 1e-3
+    assert errors[-1] < errors[0] * 0.3
+
+
+def test_cpp_any_precision_llm_low_bit_matches_direct_low_bit_call():
+    # The "quantize once, deploy at any precision" property: truncating a
+    # max_bits=8 tree down to 3 bits must give the same result as building
+    # the tree directly to max_bits=3.
+    rng = np.random.default_rng(2)
+    w = rng.standard_normal((32, 8)).astype(np.float32)
+    model = _matmul_model(w, K=32, N=8)
+
+    direct = onnxsim.apply_any_precision_llm_cpp(model, bits=3, max_bits=3)
+    via_tree = onnxsim.apply_any_precision_llm_cpp(model, bits=3, max_bits=8)
+    w_direct = _current_weight(direct)
+    w_tree = _current_weight(via_tree)
+    np.testing.assert_allclose(w_direct, w_tree, rtol=1e-5, atol=1e-6)
+
+
+def test_cpp_any_precision_llm_behaves_similarly_to_python_port():
+    # Not bit-for-bit identical (different iteration/summation order -- see
+    # this test file's own docstring and passes/any_precision_llm.h's own
+    # documented divergence note), but should reach a similar reconstruction
+    # error on the same input, the same "independently correct" contract
+    # apply_quarot/apply_quarot_cpp already established.
+    rng = np.random.default_rng(3)
+    w = rng.standard_normal((64, 16)).astype(np.float32) * 0.5
+    model = _matmul_model(w, K=64, N=16)
+
+    py_q = onnxsim.apply_any_precision_llm(model, bits=5, max_bits=8)
+    cpp_q = onnxsim.apply_any_precision_llm_cpp(model, bits=5, max_bits=8)
+    py_w = onnx.numpy_helper.to_array(py_q.graph.initializer[0]).astype(np.float64)
+    cpp_w = _current_weight(cpp_q).astype(np.float64)
+
+    w64 = w.astype(np.float64)
+    py_err = np.linalg.norm(py_w - w64)
+    cpp_err = np.linalg.norm(cpp_w - w64)
+    # Both should be small and of the same order of magnitude.
+    assert cpp_err < np.linalg.norm(w64) * 0.1
+    assert cpp_err < py_err * 3.0 and py_err < cpp_err * 3.0
+
+
+def test_cpp_any_precision_llm_gemm_with_bias():
+    rng = np.random.default_rng(4)
+    K, N = 32, 8
+    weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    bias = rng.standard_normal((N,)).astype(np.float32) * 0.1
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = Gemm(X, W, B)
+        }}
+        """,
+        initializer=[_f32(weight, "W"), _f32(bias, "B")],
+    )
+    q = onnxsim.apply_any_precision_llm_cpp(model, bits=4, max_bits=8)
+    onnx.checker.check_model(q)
+
+    x = rng.standard_normal((4, K)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x})
+    (q_y,) = _run(q, {"X": x})
+    assert np.all(np.isfinite(q_y))
+    assert _rel_l2(float_y, q_y) < 0.1
+
+
+def test_cpp_any_precision_llm_rejects_bits_outside_range():
+    model = _matmul_model(np.zeros((8, 4), dtype=np.float32), K=8, N=4)
+    with pytest.raises(Exception):
+        onnxsim.apply_any_precision_llm_cpp(model, bits=9, max_bits=8)
+    with pytest.raises(Exception):
+        onnxsim.apply_any_precision_llm_cpp(model, bits=0, max_bits=8)
+
+
+def test_cpp_any_precision_llm_noop_when_no_matmul_gemm_present():
+    model = _model(
+        """
+        g (float[4,4] X) => (float[4,4] Y)
+        {
+          Y = Relu(X)
+        }
+        """
+    )
+    result = onnxsim.apply_any_precision_llm_cpp(model)
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_any_precision_llm_defaults_match_python():
+    import inspect
+
+    sig = inspect.signature(onnxsim.apply_any_precision_llm_cpp)
+    py_sig = inspect.signature(onnxsim.apply_any_precision_llm)
+    assert sig.parameters["bits"].default == py_sig.parameters["bits"].default
+    assert sig.parameters["max_bits"].default == py_sig.parameters["max_bits"].default
+    assert (
+        sig.parameters["block_size"].default == py_sig.parameters["block_size"].default
+    )


### PR DESCRIPTION
## Summary

Adds `onnxsim.apply_any_precision_llm`, porting Any-Precision LLM (Park, Hyun, Cho, Sung, Choi, 2024, ICML 2024, https://arxiv.org/abs/2402.10517) -- plus a C++ port, `onnxsim.apply_any_precision_llm_cpp`, following this repo's established `apply_quarot`/`apply_quarot_cpp` pattern (new quantization features now get both a verified Python implementation and a C++ port in the same round).

Every other weight-only quantizer in onnxsim picks one bit-width and quantizes independently for it. Any-Precision LLM's own idea: quantize **once**, to a maximum bit-width, via a **nested bit-plane** construction -- repeated within-bin bisection, where every lower bit-width's own code is exactly recoverable from the max-depth code by a plain integer right-shift. One quantization pass serves any precision up to its own ceiling instead of re-quantizing from scratch per bit-width -- the paper's own "one download, many deployable precisions" story.

## What's added / scope

- `onnxsim/any_precision_llm.py`: `apply_any_precision_llm(model, bits=4, max_bits=8, block_size=32)`. For every matched MatMul/"vanilla" Gemm weight, per (output-channel, K-block): builds nested codes via repeated bisection (each split uses that bin's own min/max midpoint), truncates to the requested `bits` via right-shift, and reconstructs each code as its own bin's mean value (a proper vector-quantizer reconstruction, not a linear/uniform-grid one).
- `onnxsim/passes/any_precision_llm.h` + `onnxsim/custom_optimizer_passes.cpp` + `onnxsim/quantize_entry.h`/`.cpp` + `onnxsim/onnxsim.h` + `onnxsim/cpp2py_export.cc`: a C++-native `onnxoptimizer` pass mirroring the same nested-bisection/per-bin-mean algorithm, exposed as `onnxsim.apply_any_precision_llm_cpp`. Not bit-for-bit identical to the Python port (hash-map iteration order vs. numpy's own reduction order can differ in the last ULP or two) -- the same "independently correct, not required to be identical" contract already established for `apply_quarot`/`apply_quarot_cpp`.
- `onnxsim/__init__.py`: exports both `apply_any_precision_llm` and `apply_any_precision_llm_cpp`.
- `tests/test_any_precision_llm.py`: 7 tests for the Python port (built with `onnx.parser.parse_model`), covering the exact bit-shift nesting invariant, per-bin-mean reconstruction, reconstruction error monotonically improving with more bits, the "quantize once, deploy at any precision" property end-to-end, an onnxruntime sanity check, input validation, and a no-op case.
- `tests/test_any_precision_llm_cpp.py`: 8 tests for the C++ port mirroring the same structural/algebraic properties, plus a behavioral cross-check against the Python port (comparable, not identical, reconstruction error) and a Gemm-with-bias case.

## Empirically confirmed facts

Per this repo's practice of verifying rather than assuming: this module's first implementation (both Python and, transiently, the C++ port before it was fixed alongside) reconstructed each precision level via a single global affine fit per block (`value ~= code * scale + zero`), by analogy with every *uniform* quantizer elsewhere in the repo. That failed its own `test_reconstruction_error_improves_with_more_bits` test -- because this scheme's bisection splits come from each bin's own local data rather than any fixed linear grid, a straight-line fit across all codes isn't guaranteed to improve as bins are refined, and empirically didn't. Fixed by switching to per-bin-mean reconstruction, which the law of total variance guarantees is monotonically non-increasing in squared error as bins refine -- verified directly by the test, which now passes in both the Python and C++ ports.

## Test plan

- `pytest tests/test_any_precision_llm.py tests/test_any_precision_llm_cpp.py -q` -- 15 passed
- `pytest tests/test_any_precision_llm_cpp.py tests/test_any_precision_llm.py tests/test_quarot_cpp.py -q` -- 32 passed, no regression
- Broader sweep (`-k "quarot or weight_only or double_quantization"`) -- 80 passed, no regression
- `ruff check` / `ruff format --check` on all touched Python files -- clean
- `mypy onnxsim/onnx_simplifier.py` -- no new errors
- `clang-format --style=file:onnxsim/.clang-format` applied to all touched C++ files
- Full C++ extension rebuild (`pip install -e . --no-build-isolation`) succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxBPwkiTv7m32wAZtAubyc