### PR TITLE
Port true-MQA fast path to the C++ fused-attention pruner (ApplyOneGqaChain)

### DIFF
--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -6307,7 +6307,27 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
   const int64_t h = chain.kv_num_heads;
   const int64_t keep_count =
       std::max<int64_t>(1, h - std::llround(static_cast<double>(h) * sparsity));
-  if (keep_count >= h) {
+  // True MQA (`chain.kv_num_heads == 1`) -- mirrors pruning.py's own
+  // `_apply_one_gqa_chain` docstring exactly (and ApplyOneDecomposedGqaChain's
+  // own `is_mqa` handling for the sibling decomposed-attention chain kind):
+  // with exactly one KV group, the ordinary group-granularity formula above
+  // is always `1 == kv_num_heads`, so it can never drop anything no matter
+  // how many query heads (`chain.num_heads`) share that one KV head. This
+  // path instead ranks and drops individual *query* heads directly, leaving
+  // the single shared KV head -- and both its own K/V producer weights and
+  // `kv_num_heads` itself -- completely untouched: `keep_groups` stays fixed
+  // at the sole surviving group (`{0}`, an identity slice of a size-1 axis),
+  // and only `keep_q_heads`/`new_num_heads` are computed differently.
+  const bool is_mqa = h == 1 && chain.num_heads > 1;
+  int64_t q_keep_count = 0;
+  if (is_mqa) {
+    const int64_t nq_total = chain.num_heads;
+    q_keep_count = std::max<int64_t>(
+        1, nq_total - std::llround(static_cast<double>(nq_total) * sparsity));
+    if (q_keep_count >= nq_total) {
+      return std::nullopt;  // no query heads prunable at this sparsity either
+    }
+  } else if (keep_count >= h) {
     return std::nullopt;
   }
 
@@ -6324,11 +6344,11 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
   // outright (the same "sparsity rounds to no groups dropped" no-op outcome
   // the `keep_count >= h` check above already gives the caller) rather than
   // emitting an invalid node. Mirrors pruning.py's own `_apply_one_gqa_chain`
-  // `is_sparse_attention` branch -- this port has no MQA (kv_num_heads == 1)
-  // fast path (a pre-existing, already-accepted scope gap: `keep_count >= h`
-  // above already turns that case into a no-op for every chain kind), so
-  // `new_num_heads` here is always exactly `keep_count * group_size`, never
-  // pruning.py's own `q_keep_count` MQA-path alternative.
+  // `is_sparse_attention` branch. Uses `q_keep_count` (the true post-pruning
+  // query head count) rather than `keep_count * group_size` for the MQA fast
+  // path -- that formula assumes every surviving group keeps all
+  // `group_size` heads, which no longer holds once individual query heads
+  // are pruned independently of KV groups.
   const bool is_sparse_attention =
       chain.node->domain() == kComMicrosoftDomain &&
       chain.node->op_type() == "SparseAttention";
@@ -6336,7 +6356,8 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
     auto row_it = init_map.find(chain.node->input(5));
     if (row_it != init_map.end() && row_it->second->dims_size() > 0) {
       const int64_t num_layout = row_it->second->dims(0);
-      const int64_t new_q_heads = keep_count * group_size;
+      const int64_t new_q_heads =
+          is_mqa ? q_keep_count : keep_count * group_size;
       if (num_layout != 0 && new_q_heads % num_layout != 0) {
         return std::nullopt;
       }
@@ -6373,64 +6394,113 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
                                  ? TransposeFlat(wv, wv_dims[0], wv_dims[1])
                                  : wv;
 
-  // Combined importance of each KV group's own Q+K+V weight block -- for L2
-  // that's the block's own Frobenius norm; for L1 the sum of every entry's
-  // own absolute value instead, with no square/sqrt anywhere -- mirrors
-  // pruning.py's own `_gqa_group_importance` exactly (see that function's
-  // own comment for why summing every entry, rather than concatenating, is
-  // used -- it stays well-defined even when Q's own row count differs from
-  // K/V's, the cross-attention shape this port also matches).
-  std::vector<double> importance(static_cast<size_t>(chain.kv_num_heads), 0.0);
-  for (int64_t kv = 0; kv < chain.kv_num_heads; ++kv) {
-    double acc = 0.0;
-    for (int64_t r = 0; r < K; ++r) {
-      for (int64_t g = kv * group_size; g < (kv + 1) * group_size; ++g) {
-        for (int64_t c = g * d; c < (g + 1) * d; ++c) {
+  // Importance: per-*query*-head (true MQA -- mirrors pruning.py's own
+  // `_gqa_query_head_importance`, ranking each query head by its own Q
+  // weight block alone, the shared K/V block deliberately omitted since it
+  // is a constant term identical across every candidate query head here) or
+  // combined per-KV-group Q+K+V weight block -- for L2 that's the block's
+  // own Frobenius norm; for L1 the sum of every entry's own absolute value
+  // instead, with no square/sqrt anywhere -- mirrors pruning.py's own
+  // `_gqa_group_importance` exactly (see that function's own comment for why
+  // summing every entry, rather than concatenating, is used -- it stays
+  // well-defined even when Q's own row count differs from K/V's, the
+  // cross-attention shape this port also matches).
+  std::vector<double> importance;
+  if (is_mqa) {
+    importance.assign(static_cast<size_t>(chain.num_heads), 0.0);
+    for (int64_t qh = 0; qh < chain.num_heads; ++qh) {
+      double acc = 0.0;
+      for (int64_t r = 0; r < K; ++r) {
+        for (int64_t c = qh * d; c < (qh + 1) * d; ++c) {
           const double v = wq_kn[static_cast<size_t>(r * Nq + c)];
           acc += importance_norm == ImportanceNorm::kL1 ? std::abs(v) : v * v;
         }
       }
-      for (int64_t c = kv * d; c < (kv + 1) * d; ++c) {
-        const double v = wk_kn[static_cast<size_t>(r * Nk + c)];
-        acc += importance_norm == ImportanceNorm::kL1 ? std::abs(v) : v * v;
-      }
-      for (int64_t c = kv * d; c < (kv + 1) * d; ++c) {
-        const double v = wv_kn[static_cast<size_t>(r * Nv + c)];
-        acc += importance_norm == ImportanceNorm::kL1 ? std::abs(v) : v * v;
-      }
+      importance[static_cast<size_t>(qh)] =
+          importance_norm == ImportanceNorm::kL1 ? acc : std::sqrt(acc);
     }
-    importance[static_cast<size_t>(kv)] =
-        importance_norm == ImportanceNorm::kL1 ? acc : std::sqrt(acc);
+  } else {
+    importance.assign(static_cast<size_t>(chain.kv_num_heads), 0.0);
+    for (int64_t kv = 0; kv < chain.kv_num_heads; ++kv) {
+      double acc = 0.0;
+      for (int64_t r = 0; r < K; ++r) {
+        for (int64_t g = kv * group_size; g < (kv + 1) * group_size; ++g) {
+          for (int64_t c = g * d; c < (g + 1) * d; ++c) {
+            const double v = wq_kn[static_cast<size_t>(r * Nq + c)];
+            acc += importance_norm == ImportanceNorm::kL1 ? std::abs(v) : v * v;
+          }
+        }
+        for (int64_t c = kv * d; c < (kv + 1) * d; ++c) {
+          const double v = wk_kn[static_cast<size_t>(r * Nk + c)];
+          acc += importance_norm == ImportanceNorm::kL1 ? std::abs(v) : v * v;
+        }
+        for (int64_t c = kv * d; c < (kv + 1) * d; ++c) {
+          const double v = wv_kn[static_cast<size_t>(r * Nv + c)];
+          acc += importance_norm == ImportanceNorm::kL1 ? std::abs(v) : v * v;
+        }
+      }
+      importance[static_cast<size_t>(kv)] =
+          importance_norm == ImportanceNorm::kL1 ? acc : std::sqrt(acc);
+    }
   }
 
-  // Wanda upgrade: multiply each KV group's plain ||W||_F by its own
+  // Wanda upgrade: multiply each candidate's plain ||W||_F by its own
   // combined (root-sum-square) slice of the calibrated output-projection
-  // input activation, summed over every query head the group owns --
-  // mirrors pruning.py's own `_wanda_gqa_group_importance` exactly (see
-  // this function's own doc comment above).
+  // input activation -- for true MQA, each *query* head's own `d`-wide slice
+  // at its own head index (mirrors pruning.py's own
+  // `_wanda_gqa_query_head_importance`: the per-head activation term scales
+  // `_gqa_query_head_importance`'s weight-only score instead of
+  // `_wanda_gqa_group_importance`'s combined-per-group one); otherwise summed
+  // over every query head the group owns, mirroring pruning.py's own
+  // `_wanda_gqa_group_importance` exactly (see this function's own doc
+  // comment above).
   if (act_norm != nullptr) {
     auto it = act_norm->find(chain.consumer_node->input(0));
     if (it != act_norm->end() &&
         it->second.size() == static_cast<size_t>(chain.num_heads * d)) {
-      for (int64_t kv = 0; kv < chain.kv_num_heads; ++kv) {
-        double sq = 0.0;
-        for (int64_t c = kv * group_size * d; c < (kv + 1) * group_size * d;
-             ++c) {
-          const double v = it->second[static_cast<size_t>(c)];
-          sq += v * v;
+      if (is_mqa) {
+        for (int64_t qh = 0; qh < chain.num_heads; ++qh) {
+          double sq = 0.0;
+          for (int64_t c = qh * d; c < (qh + 1) * d; ++c) {
+            const double v = it->second[static_cast<size_t>(c)];
+            sq += v * v;
+          }
+          importance[static_cast<size_t>(qh)] *=
+              std::max(std::sqrt(sq), epsilon);
         }
-        importance[static_cast<size_t>(kv)] *= std::max(std::sqrt(sq), epsilon);
+      } else {
+        for (int64_t kv = 0; kv < chain.kv_num_heads; ++kv) {
+          double sq = 0.0;
+          for (int64_t c = kv * group_size * d; c < (kv + 1) * group_size * d;
+               ++c) {
+            const double v = it->second[static_cast<size_t>(c)];
+            sq += v * v;
+          }
+          importance[static_cast<size_t>(kv)] *=
+              std::max(std::sqrt(sq), epsilon);
+        }
       }
     }
   }
 
-  std::vector<int64_t> keep_groups =
-      TopKIndicesAscending(importance, keep_count);
+  std::vector<int64_t> keep_groups;
   std::vector<int64_t> keep_q_heads;
-  keep_q_heads.reserve(keep_groups.size() * static_cast<size_t>(group_size));
-  for (int64_t g : keep_groups) {
-    for (int64_t hh = g * group_size; hh < (g + 1) * group_size; ++hh) {
-      keep_q_heads.push_back(hh);
+  if (is_mqa) {
+    // Fixed at the sole surviving KV group -- HeadColumnIndices below turns
+    // this into an identity slice of K's/V's own size-`kv_num_heads * d`
+    // axis (`kv_num_heads == 1`), so K/V stay byte-for-byte untouched;
+    // ranked per query head instead (above), rather than expanding whichever
+    // groups the ordinary group-granularity path would have kept
+    // (meaningless here -- there is only ever one group).
+    keep_groups = {0};
+    keep_q_heads = TopKIndicesAscending(importance, q_keep_count);
+  } else {
+    keep_groups = TopKIndicesAscending(importance, keep_count);
+    keep_q_heads.reserve(keep_groups.size() * static_cast<size_t>(group_size));
+    for (int64_t g : keep_groups) {
+      for (int64_t hh = g * group_size; hh < (g + 1) * group_size; ++hh) {
+        keep_q_heads.push_back(hh);
+      }
     }
   }
   std::vector<int64_t> q_idx = HeadColumnIndices(keep_q_heads, d);
@@ -6477,7 +6547,14 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
   }
 
   const int64_t new_kv_num_heads = keep_count;
-  const int64_t new_num_heads = keep_count * group_size;
+  // `keep_q_heads.size()` rather than `keep_count * group_size`: identical
+  // for the ordinary group-pruning path (`keep_q_heads` is built there as
+  // exactly `keep_count` groups of `group_size` heads each), but the only
+  // correct count for the MQA fast path above, where `keep_q_heads` is an
+  // arbitrary top-`q_keep_count` subset of individual query heads with no
+  // group structure to multiply out. Mirrors ApplyOneDecomposedGqaChain's
+  // own identical `new_num_heads` computation.
+  const int64_t new_num_heads = static_cast<int64_t>(keep_q_heads.size());
   for (auto& attr : *chain.node->mutable_attribute()) {
     if (attr.name() == chain.num_heads_attr) {
       attr.set_i(new_num_heads);
@@ -21987,8 +22064,7 @@ onnx::ModelProto ApplyStructuredWandaPruning(
 // DELIBERATELY NARROWER than pruning.py's own matcher, the same kind of
 // documented, accepted scope gap this port already carries for the fused-op
 // families above (see e.g. MatchMultiHeadAttentionProducer's own comment on
-// declining rather than reproducing pruning.py's own dynamic-bias slicing,
-// and ApplyOneGqaChain's own comment on having no MQA fast path at all):
+// declining rather than reproducing pruning.py's own dynamic-bias slicing):
 //
 //   - An additive mask (`attn_mask`/causal bias), when present, IS matched
 //     and pruned -- `ResolveDecomposedQkRoot` recognizes the identical

--- a/tests/test_attention_head_pruning_cpp.py
+++ b/tests/test_attention_head_pruning_cpp.py
@@ -623,6 +623,136 @@ def test_cpp_gqa_pruning_dynamic_past_kv_input_is_still_pruned():
     assert num_heads == group_size
 
 
+# --- True MQA (kv_num_heads == 1) fused GroupQueryAttention fast path ------
+#
+# Regression coverage for the bug the Python reference (pruning.py's own
+# `_apply_one_gqa_chain`) fixed and this C++ port (`ApplyOneGqaChain` in
+# structured_pruning_entry.cpp) now mirrors: with `kv_num_heads == 1`, the
+# ordinary KV-*group* formula (`max(1, kv_num_heads - round(kv_num_heads *
+# sparsity))`) is always `1 == kv_num_heads` for every `sparsity` in
+# `[0, 1)`, so `ApplyOneGqaChain` used to hit its own "nothing to prune"
+# early exit and leave the whole fused block byte-for-byte untouched no
+# matter how many query heads (`num_heads`) shared that one KV head -- a
+# complete no-op for every real-world MQA export (Falcon-7B/StarCoder/
+# PaLM-family-style `kv_num_heads=1`). `ApplyOneGqaChain` now has a
+# dedicated fast path for this case: individual query heads are ranked and
+# dropped directly, leaving the sole KV head -- and both its own K/V
+# producer weights and `kv_num_heads` itself -- completely untouched.
+
+
+def _oracle_keep_fused_mqa_query_heads(wq, num_heads, head_size, keep_count):
+    importance = np.zeros(num_heads)
+    for h in range(num_heads):
+        importance[h] = np.linalg.norm(wq[:, h * head_size : (h + 1) * head_size])
+    return np.sort(np.argsort(-importance)[:keep_count])
+
+
+def test_cpp_mqa_pruning_shrinks_query_heads_kv_fully_untouched():
+    model, cfg = _gqa_model(K=8, H=8, KVH=1, D=8, Out=6, seed=5)
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    node = _gqa_node(pruned)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    assert kv_num_heads == 1  # untouched -- true MQA always has exactly one
+    assert num_heads == 4  # max(1, 8 - round(8*0.5)) query heads dropped directly
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    assert inits["Wq"].shape == (cfg["K"], 4 * cfg["D"])
+    assert inits["Wout"].shape == (4 * cfg["D"], cfg["Out"])
+    # K/V producer weights completely untouched -- same shape AND same
+    # values as the original, unpruned model (the confirmed-fixed bug's own
+    # "byte-identical in/out" no-op signature, but now scoped to just K/V,
+    # not the whole block).
+    np.testing.assert_array_equal(inits["Wk"], cfg["wk"])
+    np.testing.assert_array_equal(inits["Wv"], cfg["wv"])
+
+
+def test_cpp_mqa_pruning_is_not_a_complete_no_op():
+    # The confirmed bug itself: before this fix, this call was byte-identical
+    # to `model` for any `sparsity` (since `kv_num_heads == 1` always forced
+    # the group formula's early exit). It must not be anymore.
+    model, cfg = _gqa_model(K=8, H=8, KVH=1, D=8, Out=6, seed=6)
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.75)
+    assert pruned.SerializeToString() != model.SerializeToString()
+
+    node = _gqa_node(pruned)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    assert kv_num_heads == 1
+    assert num_heads == 2  # max(1, 8 - round(8*0.75)) < original 8
+
+
+def test_cpp_mqa_pruning_zero_sparsity_is_a_no_op():
+    model, cfg = _gqa_model(K=8, H=8, KVH=1, D=8, Out=6, seed=7)
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.0)
+    node = _gqa_node(pruned)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    assert num_heads == cfg["H"]
+    assert kv_num_heads == cfg["KVH"]
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["Wq"], cfg["wq"])
+    np.testing.assert_array_equal(inits["Wk"], cfg["wk"])
+    np.testing.assert_array_equal(inits["Wv"], cfg["wv"])
+
+
+def test_cpp_mqa_pruning_matches_oracle_exactly():
+    model, cfg = _gqa_model(K=8, H=8, KVH=1, D=8, Out=6, seed=9)
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    node = _gqa_node(pruned)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    assert kv_num_heads == 1
+    assert num_heads == 4
+
+    d = cfg["D"]
+    keep_q_heads = _oracle_keep_fused_mqa_query_heads(cfg["wq"], cfg["H"], d, num_heads)
+    q_idx = _head_idx(keep_q_heads, d)
+
+    oracle, _ = _gqa_model(
+        K=cfg["K"],
+        H=num_heads,
+        KVH=kv_num_heads,
+        D=d,
+        Out=cfg["Out"],
+        seed=9,
+        wq=cfg["wq"][:, q_idx],
+        wk=cfg["wk"],
+        wv=cfg["wv"],
+        wout=cfg["wout"][q_idx, :],
+        batch=cfg["batch"],
+        seq=cfg["seq"],
+    )
+
+    rng = np.random.default_rng(10)
+    x = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_cpp_mqa_pruning_slices_bias_when_producer_has_one():
+    model, cfg = _gqa_model(K=8, H=4, KVH=1, D=8, Out=6, seed=14, bias=True)
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+
+    node = _gqa_node(pruned)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    assert kv_num_heads == 1
+    assert num_heads == 2  # max(1, 4 - round(4*0.5))
+
+    d = cfg["D"]
+    keep_q_heads = _oracle_keep_fused_mqa_query_heads(cfg["wq"], cfg["H"], d, num_heads)
+    q_idx = _head_idx(keep_q_heads, d)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["Wq"], cfg["wq"][:, q_idx])
+    np.testing.assert_array_equal(inits["Wk"], cfg["wk"])
+    np.testing.assert_array_equal(inits["Wv"], cfg["wv"])
+    np.testing.assert_array_equal(inits["Bq"], cfg["bq"][q_idx])
+    np.testing.assert_array_equal(inits["Bk"], cfg["bk"])
+    np.testing.assert_array_equal(inits["Bv"], cfg["bv"])
+
+
 def test_cpp_attention_head_pruning_group_query_attention_missing_required_inputs_is_left_untouched():
     K, H, D, Out = 8, 4, 4, 6
     Nqkv = H * D

--- a/tests/test_attention_head_wanda_pruning_cpp.py
+++ b/tests/test_attention_head_wanda_pruning_cpp.py
@@ -519,6 +519,77 @@ def test_cpp_gqa_wanda_pruning_empty_calibration_data_matches_plain():
     assert wanda_empty.SerializeToString() == plain.SerializeToString()
 
 
+# --- True MQA (kv_num_heads == 1) fused GroupQueryAttention Wanda fast path -
+#
+# Wanda-calibrated counterpart of test_attention_head_pruning_cpp.py's own
+# true-MQA `GroupQueryAttention` fast-path coverage: `ApplyOneGqaChain`'s own
+# `act_norm` branch is shared, unmodified, between the plain and Wanda entry
+# points (`apply_attention_head_pruning_cpp` passes `nullptr`,
+# `apply_attention_head_wanda_pruning_cpp` a real calibrated map), so the
+# same `is_mqa` fix that closes the plain no-op bug for `kv_num_heads == 1`
+# closes it here too, ranking each query head by its own weight norm scaled
+# by its own `d`-wide slice of the calibrated activation (mirroring
+# pruning.py's own `_wanda_gqa_query_head_importance`).
+
+
+def _oracle_wanda_keep_query_heads(wq, num_heads, head_size, act_norm, keep_count):
+    importance = np.zeros(num_heads)
+    for h in range(num_heads):
+        block_norm = np.linalg.norm(wq[:, h * head_size : (h + 1) * head_size])
+        act_head = np.linalg.norm(act_norm[h * head_size : (h + 1) * head_size])
+        importance[h] = block_norm * max(act_head, 1e-8)
+    return np.sort(np.argsort(-importance)[:keep_count])
+
+
+def test_cpp_mqa_wanda_pruning_matches_oracle_exactly():
+    model, cfg = _gqa_model(K=8, H=8, KVH=1, D=8, Out=6, seed=15)
+
+    rng = np.random.default_rng(16)
+    x_cal = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    calibration_data = [{"X": x_cal}]
+
+    act_norm = _probe_act_norm(model, "ctx", {"X": x_cal})
+    keep_q_heads = _oracle_wanda_keep_query_heads(
+        cfg["wq"], cfg["H"], cfg["D"], act_norm, 4
+    )
+
+    pruned = onnxsim.apply_attention_head_wanda_pruning_cpp(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned)
+
+    node = _gqa_node(pruned)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    assert kv_num_heads == 1
+    assert num_heads == len(keep_q_heads)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["Wk"], cfg["wk"])
+    np.testing.assert_array_equal(inits["Wv"], cfg["wv"])
+
+    d = cfg["D"]
+    q_idx = _head_idx(keep_q_heads, d)
+    oracle, _ = _gqa_model(
+        K=cfg["K"],
+        H=len(keep_q_heads),
+        KVH=1,
+        D=d,
+        Out=cfg["Out"],
+        seed=15,
+        wq=cfg["wq"][:, q_idx],
+        wk=cfg["wk"],
+        wv=cfg["wv"],
+        wout=cfg["wout"][q_idx, :],
+        batch=cfg["batch"],
+        seq=cfg["seq"],
+    )
+
+    x = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    (y_pruned,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
 # --- Cross-check against the pure-Python reference --------------------------
 
 


### PR DESCRIPTION
## Summary

This ports a Python-side fix to its C++ counterpart. `onnxsim/pruning.py`'s `_apply_one_gqa_chain` (fused-attention structured pruning, `GroupQueryAttention`/`SparseAttention`/`Attention`/`MultiHeadAttention`) has a true-MQA (`kv_num_heads == 1`) fast path that ranks and drops individual query heads directly, since the ordinary per-KV-group pruning formula is always a no-op when there's only one KV group. The C++ implementation of this same function, `ApplyOneGqaChain` (`onnxsim/structured_pruning_entry.cpp:6300`), never had this fast path — its own comment explicitly documented the gap as "a pre-existing, already-accepted scope gap." Meanwhile, the sibling DECOMPOSED-attention C++ path (`ApplyOneDecomposedGqaChain`) already has the equivalent `is_mqa` fast path (ported in an earlier round), so this fix brings the fused path to parity with both its own Python reference and its own C++ sibling.

## What's added

- `ApplyOneGqaChain` (`structured_pruning_entry.cpp:6300`) now branches on `is_mqa = (kv_num_heads == 1 && num_heads > 1)`:
  - Query-head keep-count computed independently of the (always-1) KV group count.
  - Per-query-head importance ranking (weight-only and Wanda-calibrated variants both covered — the `act_norm` block gained a per-query-head branch alongside the existing per-group one, so this also fixes `apply_attention_head_wanda_pruning_cpp`).
  - `keep_groups` stays fixed at the sole surviving group (an identity slice of the size-1 KV axis, leaving the shared K/V producer weights and `kv_num_heads` completely untouched); `keep_q_heads` becomes an arbitrary top-`q_keep_count` subset of individual query heads.
  - `new_num_heads` now uses `keep_q_heads.size()` (correct for both the ordinary and MQA cases) instead of `keep_count * group_size` (which silently assumed every surviving group keeps all its heads — true for ordinary GQA pruning, false once individual query heads are pruned independently).
  - `SparseAttention`'s `num_layout` divisibility check uses the true post-pruning query-head count in the MQA case.
- Removed the now-stale "no MQA fast path" comments (both in `ApplyOneGqaChain` itself and a cross-reference from the decomposed-attention section).

## Test plan

- New tests in `tests/test_attention_head_pruning_cpp.py` (5) and `tests/test_attention_head_wanda_pruning_cpp.py` (1), mirroring the existing Python-reference true-MQA test suite: shrinks-query-heads-with-KV-untouched, confirmed-not-a-complete-no-op (the exact confirmed bug — before this fix, pruning a `kv_num_heads=1` chain at any sparsity was byte-identical to the input model), zero-sparsity-no-op, matches-independent-oracle-exactly, bias-slicing, and a Wanda-calibrated oracle-match test.
- Full local rebuild (`pip install -e . --no-build-isolation`, `-DONNXSIM_BUILTIN_ORT=OFF` — no ONNX Runtime compiled, per this repo's own `CLAUDE.md`) and independent re-verification of the resulting `.so`.
- `pytest tests/test_attention_head_pruning_cpp.py tests/test_attention_head_wanda_pruning_cpp.py` → 108 passed (81+27 baseline, all new tests included).
- Broader regression check: `tests/test_structured_pruning_cpp.py`, `test_transformer_block_pruning_cpp.py`, `test_wanda_pruning_cpp.py`, `test_sparsegpt_pruning_cpp.py`, `test_structured_wanda_pruning_cpp.py`, `test_fuse_gqa.py` → 286 passed, no regressions.
- `clang-format --style=file:onnxsim/.clang-format --dry-run --Werror onnxsim/structured_pruning_entry.cpp` → clean. `ruff format --check`/`ruff check` on the two test files → clean.

## Risks for reviewer

- This only touches the fused-attention C++ path (`ApplyOneGqaChain`); the decomposed-attention path already had this fix in an earlier round and is unchanged here.
- The `act_norm`/Wanda branch is shared, unmodified code between the plain and Wanda call sites, so this PR closes the identical bug for both `apply_attention_head_pruning_cpp` and `apply_attention_head_wanda_pruning_cpp` in one change — confirmed via the dedicated Wanda regression test.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_