### PR TITLE
Add DeepSeek-V3-style fine-grained block FP8 quantization

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -40,6 +40,7 @@ from onnxsim.calibration import (
 )
 from onnxsim.coreml_export import export_coreml
 from onnxsim.d2quant import apply_dac, apply_dsq
+from onnxsim.deepseek_fp8 import apply_deepseek_fp8, quantize_dequantize_block_fp8
 from onnxsim.diffusion_export import export_diffusion_model
 from onnxsim.double_quantization import apply_double_quantization
 from onnxsim.drop_by_drop import (
@@ -243,6 +244,8 @@ __all__ = [
     "apply_outlier_suppression",
     "apply_dsq",
     "apply_dac",
+    "apply_deepseek_fp8",
+    "quantize_dequantize_block_fp8",
     "apply_llm_int8",
     "apply_low_rank_compensation",
     "apply_svdquant",

--- a/onnxsim/deepseek_fp8.py
+++ b/onnxsim/deepseek_fp8.py
@@ -1,0 +1,257 @@
+"""DeepSeek-V3-style fine-grained block FP8 quantization (DeepSeek-AI,
+2024, "DeepSeek-V3 Technical Report", https://arxiv.org/abs/2412.19437,
+Section 3.3's low-precision scheme). onnxsim ports the *quantization
+scheme* as a post-training pass -- not the paper's own FP8 *training*
+recipe, which this module makes no claim to reproduce -- the same
+rationale :mod:`onnxsim.awq`/:mod:`onnxsim.gptq` give for porting an
+algorithm rather than a framework's training code. This exact scheme
+(FP8 E4M3, weight scaled per 128x128 block, activation scaled per-token
+per-128-channel-group) is also the serving format both SGLang and vLLM
+ship for DeepSeek-V3/R1 checkpoints (commonly labelled ``fp8_w8a8`` /
+"DeepSeek block-quantized FP8" in their own docs).
+
+Every FP8 pass already in onnxsim (:func:`onnxsim.quantize_fp8`) is a
+whole-tensor, calibration-free, **unscaled** cast -- every value maps
+directly onto FP8's own native dynamic range, with no separate scale
+factor at all. That is fine for a format with FP8's own wide dynamic
+range when the *whole* tensor's values are already reasonably close to
+FP8's own representable magnitudes, but a large weight matrix or
+activation tensor routinely has very different typical magnitudes in
+different regions (different output channels, different token positions)
+-- an unscaled cast wastes FP8's scarce 3-bit E4M3 mantissa on whichever
+region happens to dominate. DeepSeek-V3's own fix is the opposite of
+onnxsim's existing per-tensor `quantize_fp8`: quantize in small, scaled
+**blocks**, each with its own scale chosen so that block's own values
+actually use FP8's full range, at much finer granularity than a typical
+per-tensor or per-channel INT8/FP8 scheme:
+
+- **Weight**: one scale per **128x128 block** (tiling both the reduction
+  and output-channel axes) -- finer than :func:`onnxsim.quantize_weight_only_int4`'s
+  own 32-element-per-*row* blocks are wide, but tiled in *two* dimensions
+  instead of one, matching the paper's own choice for a large GEMM weight.
+- **Activation**: one scale per **token, per 128-element channel group**
+  (i.e. grouping the feature dimension into contiguous chunks of 128, a
+  separate scale for each chunk of each token) -- finer than this
+  repo's own existing per-token dynamic INT8 schemes
+  (:mod:`onnxsim.quarot`/:mod:`onnxsim.zeroquant`/:mod:`onnxsim.duquant`),
+  which use one scale for a whole token's row.
+
+Both operands are quantized via a **real** ONNX ``Cast`` to
+``FLOAT8E4M3FN`` and back (opset 19+, when the ONNX ``Cast`` operator
+gained float8 support) -- not a manually-simulated round-to-nearest the
+way this repo's other float-round-trip passes approximate a bit-width
+ONNX has no native tensor type for (:mod:`onnxsim.easyquant`,
+:mod:`onnxsim.any_precision_llm`, ...). FP8 E4M3 *is* a native ONNX
+tensor type, so the actual hardware rounding behavior is reproduced
+exactly by delegating to the same ``Cast`` semantics a real runtime
+would use, rather than approximating it.
+
+Per-block/per-group **scale** itself is the ordinary choice for any
+floating-point quantization format: ``scale = max(abs(block)) / 448``
+(``448`` is E4M3's own largest finite magnitude), floored to avoid a
+divide-by-zero on an all-zero block/group. Weight scales are folded
+directly into a new float32 initializer (no calibration data needed,
+same as every other onnxsim weight-only pass); activation scales are
+computed at graph-run time via ``Reshape``/``Abs``/``ReduceMax``, since
+the activation is a runtime tensor, not a constant.
+
+**Scope**: only ``MatMul`` and "vanilla" ``Gemm`` (via
+:func:`onnxsim.llm_int8._match_matmul_like`) with a constant 2-D float32
+weight are matched; ``Conv`` is left untouched (a scope decision several
+other onnxsim modules already make). Needs opset 19+ (``Cast``'s float8
+support); an older-opset model is left unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Optional, Union
+
+import ml_dtypes
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+
+from onnxsim.bias_correction import _all_names, _unique_name
+from onnxsim.llm_int8 import _match_matmul_like
+
+_FP8_MAX = 448.0  # FLOAT8E4M3FN's own largest finite magnitude
+
+
+def _fp8_round_trip(values: np.ndarray) -> np.ndarray:
+    # The real ONNX FLOAT8E4M3FN cast semantics -- ml_dtypes is the same
+    # library onnx.helper.tensor_dtype_to_np_dtype itself maps
+    # FLOAT8E4M3FN to internally, not a new/unverified dependency.
+    clipped = np.clip(values, -_FP8_MAX, _FP8_MAX)
+    return clipped.astype(ml_dtypes.float8_e4m3fn).astype(np.float64)
+
+
+def quantize_dequantize_block_fp8(
+    values: np.ndarray, block_size: int = 128
+) -> np.ndarray:
+    """FP8 E4M3 quantize-dequantize round trip over a 2-D array, one scale
+    per ``block_size`` x ``block_size`` tile (DeepSeek-V3's own weight
+    scheme). Padded with zeros up to whole tiles before quantizing (the
+    padding is quantized along with the real data but discarded before
+    returning, so it cannot change any real value, only -- very slightly
+    -- a boundary tile's own chosen scale, when a dimension isn't itself a
+    multiple of ``block_size``).
+
+    :param values: 2-D float array
+    :param block_size: tile size along both axes
+    :returns: same shape as ``values``, float64
+    """
+    values = np.asarray(values, dtype=np.float64)
+    rows, cols = values.shape
+    padded_rows = -(-rows // block_size) * block_size
+    padded_cols = -(-cols // block_size) * block_size
+    padded = np.zeros((padded_rows, padded_cols), dtype=np.float64)
+    padded[:rows, :cols] = values
+
+    out = np.empty_like(padded)
+    for r in range(0, padded_rows, block_size):
+        for c in range(0, padded_cols, block_size):
+            block = padded[r : r + block_size, c : c + block_size]
+            scale = max(float(np.max(np.abs(block))), 1e-12) / _FP8_MAX
+            out[r : r + block_size, c : c + block_size] = (
+                _fp8_round_trip(block / scale) * scale
+            )
+    return out[:rows, :cols]
+
+
+def apply_deepseek_fp8(
+    float_model: Union[str, onnx.ModelProto],
+    weight_block_size: int = 128,
+    act_group_size: int = 128,
+    skip_names: Optional[Iterable[str]] = None,
+) -> onnx.ModelProto:
+    """W8A8-quantizes every matched MatMul/"vanilla" Gemm layer to
+    DeepSeek-V3's own block-wise FP8 E4M3 scheme -- see this module's own
+    docstring for the technique. Needs no calibration data: every weight
+    quantization decision comes from the weight tensor's own values, and
+    every activation scale is computed fresh at graph-run time.
+
+    :param float_model: the original (unquantized) onnx ModelProto or file
+            path
+    :param weight_block_size: weight tile size along both axes (K and N)
+    :param act_group_size: activation channel-group size (one scale per
+            token per this many contiguous feature-dimension elements)
+    :param skip_names: weight initializer names to leave unquantized even
+            if otherwise eligible
+    :returns: ``float_model`` with every matched layer's weight replaced
+            by its block-FP8 round trip and a Cast-based FP8 round trip
+            inserted before its activation input. Layers with a
+            non-constant, non-2-D weight are left untouched; a model with
+            an opset below 19 is returned unchanged.
+    """
+    if isinstance(float_model, str):
+        float_model = onnx.load(float_model, load_external_data=False)
+    skip_names = set(skip_names) if skip_names is not None else frozenset()
+
+    out = onnx.ModelProto()
+    out.CopyFrom(float_model)
+    graph = out.graph
+
+    opset_ge_19 = any(
+        o.domain in ("", "ai.onnx") and o.version >= 19 for o in out.opset_import
+    )
+    if not opset_ge_19:
+        return out  # Cast's FLOAT8E4M3FN support needs opset >= 19
+
+    initializer_map = {t.name: t for t in graph.initializer}
+    candidates = []  # (node, x_name, w_name, weight_transposed)
+    for node in graph.node:
+        match = _match_matmul_like(node)
+        if match is None:
+            continue
+        x_name, w_name, _bias_name, weight_transposed = match
+        if w_name in skip_names:
+            continue
+        w_init = initializer_map.get(w_name)
+        if (
+            w_init is None
+            or w_init.data_type != onnx.TensorProto.FLOAT
+            or len(w_init.dims) != 2
+        ):
+            continue
+        candidates.append((node, x_name, w_init, weight_transposed))
+    if not candidates:
+        return out
+
+    taken_names = _all_names(graph)
+
+    fp8_dtype = onnx.TensorProto.FLOAT8E4M3FN
+
+    for node, x_name, w_init, weight_transposed in candidates:
+        w = onnx.numpy_helper.to_array(w_init).astype(np.float64)
+        w_nk = w if weight_transposed else w.T  # [N, K], output-channel first
+        w_quant_nk = quantize_dequantize_block_fp8(w_nk, weight_block_size)
+        w_quant = w_quant_nk if weight_transposed else w_quant_nk.T
+
+        new_w_name = _unique_name(f"{w_init.name}_deepseek_fp8", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(w_quant.astype(np.float32), name=new_w_name)
+        )
+        node.input[1] = new_w_name
+
+        prefix = _unique_name(f"{node.output[0]}_deepseek_fp8", taken_names)
+        k = w_nk.shape[1]
+        num_groups = -(-k // act_group_size)
+
+        new_nodes: List[onnx.NodeProto] = []
+
+        def _op(op_type, inputs, tag, **attrs):
+            out_name = _unique_name(f"{prefix}_{tag}", taken_names)
+            n = onnx.helper.make_node(
+                op_type,
+                inputs,
+                [out_name],
+                name=_unique_name(f"{prefix}_{tag}_node", taken_names),
+                **attrs,
+            )
+            new_nodes.append(n)
+            return out_name
+
+        def _const(value: np.ndarray, tag: str) -> str:
+            name = _unique_name(f"{prefix}_{tag}", taken_names)
+            graph.initializer.append(onnx.numpy_helper.from_array(value, name=name))
+            return name
+
+        # Group the activation's last dimension into `num_groups` chunks of
+        # `act_group_size` (zero-padding the last, ragged group is not
+        # attempted here -- act_group_size is expected to divide K evenly,
+        # documented as a scope decision; a non-dividing K is left
+        # unquantized on the activation side, matching this repo's own
+        # "decline rather than guess" convention -- checked below).
+        if k % act_group_size != 0:
+            continue
+
+        shape_grouped = _const(
+            np.asarray([-1, num_groups, act_group_size], dtype=np.int64), "shape_grp"
+        )
+        shape_flat = _const(np.asarray([-1, k], dtype=np.int64), "shape_flat")
+        eps_name = _const(np.asarray(1e-12, dtype=np.float32), "eps")
+        fp8_max_name = _const(np.asarray(_FP8_MAX, dtype=np.float32), "fp8_max")
+        # ReduceMax's `axes` is an input (not an attribute) from opset 18
+        # onwards -- this pass requires opset >= 19 already (Cast's float8
+        # support), so always use the input form.
+        axes_name = _const(np.asarray([-1], dtype=np.int64), "axes")
+
+        grouped = _op("Reshape", [x_name, shape_grouped], "grouped")
+        abs_grouped = _op("Abs", [grouped], "abs")
+        max_grouped = _op("ReduceMax", [abs_grouped, axes_name], "max", keepdims=1)
+        safe_max = _op("Clip", [max_grouped, eps_name], "safe_max")
+        act_scale = _op("Div", [safe_max, fp8_max_name], "scale")
+        scaled = _op("Div", [grouped, act_scale], "scaled")
+        fp8 = _op("Cast", [scaled], "fp8", to=fp8_dtype)
+        dequant_fp8 = _op("Cast", [fp8], "dequant_fp8", to=onnx.TensorProto.FLOAT)
+        dequant_grouped = _op("Mul", [dequant_fp8, act_scale], "dequant_grouped")
+        dequant_flat = _op("Reshape", [dequant_grouped, shape_flat], "dequant_flat")
+        node.input[0] = dequant_flat
+
+        insertion_point = next(i for i, n in enumerate(graph.node) if n is node)
+        for new_node in new_nodes:
+            graph.node.insert(insertion_point, new_node)
+            insertion_point += 1
+
+    return out

--- a/tests/test_deepseek_fp8.py
+++ b/tests/test_deepseek_fp8.py
@@ -1,0 +1,211 @@
+"""Tests for ``onnxsim.apply_deepseek_fp8``/``onnxsim.quantize_dequantize_block_fp8``
+(see ``onnxsim/deepseek_fp8.py``) -- DeepSeek-V3-style fine-grained block
+FP8 quantization (128x128 weight blocks, per-token-per-128-channel-group
+activation scaling), the format SGLang/vLLM both ship as their own
+"fp8_w8a8" DeepSeek-V3/R1 serving format.
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _matmul_model(w, K, N, batch="batch", opset=21):
+    return _model(
+        f"""
+        g (float[{batch},{K}] X) => (float[{batch},{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [_f32(w, "W")],
+        opset=opset,
+    )
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _rel_l2(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-9)
+
+
+def _current_weight(model, weight_input_index=1):
+    node = next(n for n in model.graph.node if n.op_type in ("MatMul", "Gemm"))
+    w_name = node.input[weight_input_index]
+    w_init = next(t for t in model.graph.initializer if t.name == w_name)
+    return onnx.numpy_helper.to_array(w_init)
+
+
+def test_block_fp8_round_trip_has_at_most_one_scale_per_128_block():
+    rng = np.random.default_rng(0)
+    # Two very different magnitude regimes in different 128x128 blocks --
+    # one shared per-tensor scale would badly under-resolve one of them.
+    w = np.zeros((256, 256))
+    w[:128, :128] = rng.standard_normal((128, 128)) * 0.01
+    w[128:, 128:] = rng.standard_normal((128, 128)) * 100.0
+
+    dequant = onnxsim.quantize_dequantize_block_fp8(w, block_size=128)
+    assert dequant.shape == w.shape
+    # The small-magnitude block should still resolve to non-zero, distinct
+    # values -- if a single global scale (sized for the 100x block) were
+    # used instead, this block would quantize to all-zero.
+    assert np.any(dequant[:128, :128] != 0.0)
+    assert len(np.unique(dequant[:128, :128])) > 4
+
+
+def test_block_fp8_beats_naive_per_tensor_fp8_on_mixed_magnitude_weight():
+    # The core empirical claim: block-wise scaling reduces reconstruction
+    # error vs. a single per-tensor FP8 scale, on a weight whose magnitude
+    # varies a lot block-to-block (exactly DeepSeek-V3's own motivation).
+    from onnxsim.deepseek_fp8 import _fp8_round_trip
+
+    rng = np.random.default_rng(1)
+    w = np.zeros((256, 256))
+    for i in range(2):
+        for j in range(2):
+            scale = rng.uniform(0.01, 50.0)
+            w[i * 128 : (i + 1) * 128, j * 128 : (j + 1) * 128] = (
+                rng.standard_normal((128, 128)) * scale
+            )
+
+    block_dequant = onnxsim.quantize_dequantize_block_fp8(w, block_size=128)
+    per_tensor_scale = max(float(np.max(np.abs(w))), 1e-12) / 448.0
+    naive_dequant = _fp8_round_trip(w / per_tensor_scale) * per_tensor_scale
+
+    block_err = np.linalg.norm(w - block_dequant)
+    naive_err = np.linalg.norm(w - naive_dequant)
+    assert block_err < naive_err
+
+
+def test_block_fp8_padding_does_not_change_already_aligned_values():
+    rng = np.random.default_rng(2)
+    aligned = rng.standard_normal((128, 128))
+    padded = np.zeros((150, 140))
+    padded[:128, :128] = aligned
+
+    dequant_aligned = onnxsim.quantize_dequantize_block_fp8(aligned, block_size=128)
+    dequant_padded = onnxsim.quantize_dequantize_block_fp8(padded, block_size=128)
+    np.testing.assert_array_equal(dequant_padded[:128, :128], dequant_aligned)
+
+
+def test_apply_deepseek_fp8_replaces_weight_and_inserts_activation_cast():
+    rng = np.random.default_rng(3)
+    K, N = 128, 128
+    w = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    model = _matmul_model(w, K, N)
+
+    q = onnxsim.apply_deepseek_fp8(model)
+    onnx.checker.check_model(q)
+
+    new_w = _current_weight(q)
+    assert new_w.shape == w.shape
+    assert not np.array_equal(new_w, w)
+
+    cast_nodes = [n for n in q.graph.node if n.op_type == "Cast"]
+    assert len(cast_nodes) == 2
+    to_attrs = {a.i for n in cast_nodes for a in n.attribute if a.name == "to"}
+    assert onnx.TensorProto.FLOAT8E4M3FN in to_attrs
+
+
+def test_apply_deepseek_fp8_output_stays_close_to_float_via_onnxruntime():
+    rng = np.random.default_rng(4)
+    K, N = 256, 128
+    w = rng.standard_normal((K, N)).astype(np.float32) * 0.3
+    model = _matmul_model(w, K, N)
+
+    q = onnxsim.apply_deepseek_fp8(model)
+    onnx.checker.check_model(q)
+
+    x = rng.standard_normal((4, K)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x})
+    (q_y,) = _run(q, {"X": x})
+    assert np.all(np.isfinite(q_y))
+    assert _rel_l2(float_y, q_y) < 0.2
+
+
+def test_apply_deepseek_fp8_gemm_with_bias():
+    rng = np.random.default_rng(5)
+    K, N = 128, 64
+    weight = rng.standard_normal((K, N)).astype(np.float32) * 0.4
+    bias = rng.standard_normal((N,)).astype(np.float32) * 0.1
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = Gemm(X, W, B)
+        }}
+        """,
+        initializer=[_f32(weight, "W"), _f32(bias, "B")],
+    )
+    q = onnxsim.apply_deepseek_fp8(model)
+    onnx.checker.check_model(q)
+
+    x = rng.standard_normal((4, K)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x})
+    (q_y,) = _run(q, {"X": x})
+    assert np.all(np.isfinite(q_y))
+    assert _rel_l2(float_y, q_y) < 0.2
+
+
+def test_apply_deepseek_fp8_respects_skip_names():
+    rng = np.random.default_rng(6)
+    K, N = 128, 128
+    w = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    model = _matmul_model(w, K, N)
+
+    result = onnxsim.apply_deepseek_fp8(model, skip_names={"W"})
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_apply_deepseek_fp8_noop_below_opset19():
+    rng = np.random.default_rng(7)
+    K, N = 128, 128
+    w = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    model = _matmul_model(w, K, N, opset=13)
+
+    result = onnxsim.apply_deepseek_fp8(model)
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_apply_deepseek_fp8_noop_when_no_matmul_gemm_present():
+    model = _model(
+        """
+        g (float[4,4] X) => (float[4,4] Y)
+        {
+          Y = Relu(X)
+        }
+        """
+    )
+    result = onnxsim.apply_deepseek_fp8(model)
+    assert result.SerializeToString() == model.SerializeToString()


### PR DESCRIPTION
## Summary

Adds `onnxsim.apply_deepseek_fp8`, porting DeepSeek-V3's own fine-grained block FP8 quantization scheme (DeepSeek-AI, 2024, "DeepSeek-V3 Technical Report", https://arxiv.org/abs/2412.19437, Section 3.3's low-precision scheme) as a post-training pass. This exact scheme is also the serving format both SGLang and vLLM ship for DeepSeek-V3/R1 checkpoints (commonly labelled `fp8_w8a8` / "DeepSeek block-quantized FP8" in their own docs) -- continuing this round's focus on techniques supported by unsloth/vllm/sglang/llama.cpp.

Every FP8 pass already in onnxsim (`onnxsim.quantize_fp8`) is a whole-tensor, calibration-free, **unscaled** cast -- every value maps directly onto FP8's own native dynamic range, with no separate scale factor. DeepSeek-V3's own fix quantizes in small, scaled blocks instead, at much finer granularity than a typical per-tensor/per-channel scheme:

- **Weight**: one scale per **128x128 block** (tiling both the reduction and output-channel axes).
- **Activation**: one scale per **token, per 128-element channel group**.

Both operands are quantized via a **real** ONNX `Cast` to `FLOAT8E4M3FN` and back (opset 19+) rather than a manually-simulated round-to-nearest -- FP8 E4M3 is a native ONNX tensor type, so `Cast` reproduces the actual rounding behavior exactly instead of approximating it.

## What's added / scope

- `onnxsim/deepseek_fp8.py`: `apply_deepseek_fp8(model, weight_block_size=128, act_group_size=128, ...)` and `quantize_dequantize_block_fp8(values, block_size=128)`. Weight quantization folds directly into a new float32 initializer (no calibration data needed); activation quantization inserts `Reshape`/`Abs`/`ReduceMax`/`Clip`/`Div`/`Cast`/`Mul` nodes at graph-run time (ReduceMax's `axes` passed as an input, matching opset 18+'s form). Only `MatMul`/"vanilla" `Gemm` are matched (via the shared `_match_matmul_like` helper); `Conv` is left untouched. Needs opset 19+; an older-opset model is returned unchanged.
- `onnxsim/__init__.py`: exports `apply_deepseek_fp8` and `quantize_dequantize_block_fp8`.
- `tests/test_deepseek_fp8.py`: 9 tests (built with `onnx.parser.parse_model`), covering per-block scale resolution on a mixed-magnitude weight, an empirical comparison against a naive per-tensor FP8 baseline, padding correctness, weight/graph-structure checks, an onnxruntime end-to-end sanity check, Gemm-with-bias, `skip_names`, and opset/no-op guards.

**Scope note on the C++ port**: this round's other new module (`onnxsim.apply_any_precision_llm`, merged in #1148) shipped with a paired C++ port following the `apply_quarot`/`apply_quarot_cpp` pattern. This module's C++ port is deferred to a follow-up: reproducing FP8 E4M3's bit-level encode/decode correctly in C++ needs either a fresh, carefully cross-verified codec or reusing/extending `onnxsim/passes/quantize_fp8.h`'s own existing (encode-only) `FloatToFloat8Bits` with a new decode counterpart -- worth doing properly in its own round rather than rushing given the real risk of a subtle rounding/NaN-pattern bug, rather than reusing this module's already-verified Python `ml_dtypes`-based round trip. The Q4_K GGUF encoder merged earlier this round (#1149) took the same Python-first, C++-deferred approach for the same reason.

## Test plan

- `pytest tests/test_deepseek_fp8.py -q` -- 9 passed
- `pytest tests/test_deepseek_fp8.py tests/test_llm_int8.py tests/test_zeroquant.py -q` -- 29 passed, no regression
- `ruff check` / `ruff format --check` -- clean
- `mypy onnxsim/deepseek_fp8.py` -- no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxBPwkiTv7m32wAZtAubyc

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxBPwkiTv7m32wAZtAubyc)_