### PR TITLE
Add Celu to _UNARY_PASS_THROUGH

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -3333,6 +3333,14 @@ _UNARY_PASS_THROUGH = {
     "LeakyRelu",
     "Elu",
     "Selu",
+    # ai.onnx (domain "") Celu(X) -> Y, opset 12+ -- confirmed live via
+    # `onnx.defs.get_schema("Celu")`: single required input `X`, single
+    # output `Y`, one scalar float `alpha` attribute (default 1.0).
+    # Structurally identical to `Elu`/`Selu` immediately above (same
+    # per-element `x > 0 ? x : f(alpha, x)` shape, no cross-channel mixing,
+    # no second tensor operand to slice) -- it belongs here for the same
+    # reason those two do.
+    "Celu",
     "Sigmoid",
     "Tanh",
     "Softplus",

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -5259,6 +5259,41 @@ def test_structured_pruning_conv_chain_hardswish_matches_oracle_exactly():
     np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
 
 
+def test_structured_pruning_conv_chain_celu_matches_oracle_exactly():
+    # ai.onnx (domain "") Celu(X) -> Y, opset 12+ -- single input, single
+    # output, one scalar float `alpha` attribute, structurally identical to
+    # `Elu`/`Selu` (both already in `_UNARY_PASS_THROUGH`). Was previously
+    # missing from that set entirely -- confirmed empirically that this
+    # exact Conv -> Celu -> Conv chain was left completely untouched (0
+    # chains matched) before `Celu` was added. Same oracle bar as the
+    # Swish/HardSwish tests above: exact equivalence to deleting the same
+    # output filters by hand.
+    Cin, C1, C2 = 3, 16, 8
+    rng = np.random.default_rng(238)
+    w1 = rng.standard_normal((C1, Cin, 3, 3)).astype(np.float32)
+    b1 = rng.standard_normal((C1,)).astype(np.float32)
+    w2 = rng.standard_normal((C2, C1, 3, 3)).astype(np.float32)
+    model = _conv_pair_model(w1, w2, b1=b1, activation="Celu<alpha=1.0>", opset=17)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["W1"].dims) == [C1 // 2, Cin, 3, 3]
+    assert list(inits["W2"].dims) == [C2, C1 // 2, 3, 3]
+
+    keep = _oracle_keep_indices_conv(w1, C1 // 2)
+    oracle = _conv_pair_model(
+        w1[keep], w2[:, keep], b1=b1[keep], activation="Celu<alpha=1.0>", opset=17
+    )
+
+    rng_x = np.random.default_rng(239)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    assert np.isfinite(y).all()
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
 # --- Self-gated activation decomposition (SiLU/erf-GELU, unfused) --------
 #
 # A raw `torch.onnx.export` of `nn.SiLU()`/`nn.GELU()` -- at any opset below
@@ -30731,6 +30766,82 @@ def test_qdq_structured_pruning_conv_both_sides_qdq_matches_oracle():
             [
                 onnx.helper.make_node("Conv", ["X", "W1"], ["h"]),
                 onnx.helper.make_node("Conv", ["h", "W2"], ["Y"]),
+            ],
+            "oracle",
+            [onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, None)],
+            [onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, None)],
+            initializer=[
+                onnx.numpy_helper.from_array(
+                    w1_dequant[keep].astype(np.float32), name="W1"
+                ),
+                onnx.numpy_helper.from_array(
+                    w2_dequant[:, keep].astype(np.float32), name="W2"
+                ),
+            ],
+        ),
+        opset_imports=[onnx.helper.make_opsetid("", 21)],
+        ir_version=10,
+    )
+    (y_oracle,) = onnx.reference.ReferenceEvaluator(ref_model).run(None, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def test_qdq_structured_pruning_conv_celu_activation_matches_oracle():
+    # Same both-sides-QDQ topology as
+    # test_qdq_structured_pruning_conv_both_sides_qdq_matches_oracle, with a
+    # `Celu` activation node (now in `_UNARY_PASS_THROUGH`, see that set's
+    # own comment) sitting between the producer Conv and the consumer Conv
+    # -- confirming the QDQ walker (`_walk_to_consumer_qdq`), which consults
+    # the very same shared set, is fixed by the same one-entry addition.
+    Cin, Cmid, Cout = 4, 8, 4
+    rng = np.random.default_rng(9)
+    Wq1 = rng.integers(-100, 100, size=(Cmid, Cin, 1, 1)).astype(np.int8)
+    Wscale1 = np.abs(rng.standard_normal(Cmid)).astype(np.float32) * 0.02 + 0.001
+    Wq2 = rng.integers(-100, 100, size=(Cout, Cmid, 1, 1)).astype(np.int8)
+    Wscale2 = np.abs(rng.standard_normal(Cout)).astype(np.float32) * 0.02 + 0.001
+    model = _model(
+        f"""
+        g (float[1,{Cin},4,4] X) => (float[1,{Cout},4,4] Y)
+        {{
+          W1dq = DequantizeLinear<axis=0>(Wq1, Wscale1)
+          h = Conv(X, W1dq)
+          hact = Celu<alpha=1.0>(h)
+          W2dq = DequantizeLinear<axis=0>(Wq2, Wscale2)
+          Y = Conv(hact, W2dq)
+        }}
+        """,
+        initializer=[
+            _i8(Wq1, "Wq1"),
+            _f32(Wscale1, "Wscale1"),
+            _i8(Wq2, "Wq2"),
+            _f32(Wscale2, "Wscale2"),
+        ],
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_qdq(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    inits = {t.name: t for t in pruned.graph.initializer}
+    assert list(inits["Wq1"].dims) == [Cmid // 2, Cin, 1, 1]
+    assert list(inits["Wscale1"].dims) == [Cmid // 2]
+    assert list(inits["Wq2"].dims) == [Cout, Cmid // 2, 1, 1]
+    assert list(inits["Wscale2"].dims) == [Cout]  # consumer's own scale untouched
+
+    w1_dequant = _qdq_dequant(Wq1, Wscale1, None, axis=0)
+    w2_dequant = _qdq_dequant(Wq2, Wscale2, None, axis=0)
+    w1_nk = w1_dequant.reshape(Cmid, -1)
+    keep = _oracle_keep_indices(w1_nk.T, Cmid // 2)
+
+    rng2 = np.random.default_rng(12)
+    x = rng2.standard_normal((1, Cin, 4, 4)).astype(np.float32)
+    (y,) = _run_unfused(pruned, {"X": x})
+
+    ref_model = onnx.helper.make_model(
+        onnx.helper.make_graph(
+            [
+                onnx.helper.make_node("Conv", ["X", "W1"], ["h"]),
+                onnx.helper.make_node("Celu", ["h"], ["hact"], alpha=1.0),
+                onnx.helper.make_node("Conv", ["hact", "W2"], ["Y"]),
             ],
             "oracle",
             [onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, None)],


### PR DESCRIPTION
## Summary

`Celu` (ONNX opset 12+, single input `X`, single output `Y`, one scalar float `alpha` attribute) was missing from the shared `_UNARY_PASS_THROUGH` set even though its structural siblings `Elu`/`Selu` are already members. Because EVERY chain walker across every family (`_walk_to_consumer`, `_walk_to_conv_consumer`, both backward counterparts, the gate-activation matcher used by gated-FFN-pair finders, and all the QDQ/MatMulNBits/MatMulBnb4/FP8/FP4/QOperator/DynamicQuantizeMatMul/ConvInteger walkers) consults this one shared set, this single missing entry silently blocked pruning in every one of them whenever `Celu` sat between a prunable producer and consumer — a module-wide gap, not a per-family one.

## Empirically confirmed facts

- `onnx.defs.get_schema("Celu")` confirms it's structurally identical to `Elu`/`Selu`: single input/output, one scalar attribute, no cross-channel mixing, no second tensor operand to slice.
- A real `torch.onnx.export` of `Conv(4→8) -> nn.CELU(alpha=1.0) -> Conv(8→4)` emits `Celu` directly (undecomposed) between the two Conv nodes.
- On the pre-fix code, `apply_structured_pruning` left this chain's weights completely unchanged (silently declined); swapping only the activation to `Elu` (already in the set) on the otherwise-identical model pruned correctly — isolating `Celu`'s absence as the sole cause.
- Grepped the whole file: `Elu`/`Selu` appear only inside `_UNARY_PASS_THROUGH` itself, confirming there's no other duplicated "safe unary activation" list that also needed updating.

## What's added

- `"Celu"` added to `_UNARY_PASS_THROUGH` (`onnxsim/pruning.py`), with a schema-fact comment matching the style of neighboring entries. No other code changes needed — every walker already derives its behavior generically from this set's membership.

## Test plan

- New regression tests: a plain-float `Conv -> Celu -> Conv` match+prune test (oracle-exact), and a QDQ-family test confirming the same fix applies there too (given the shared-set nature of the bug).
- Verified via a stash-based before/after check: reverting `onnxsim/pruning.py` to the pre-fix commit while keeping the new tests reproduces the bug (both tests fail with genuine shape mismatches — e.g. `[16,3,3,3]` instead of the pruned `[8,3,3,3]`); restoring the fix makes both pass.
- `pytest tests/test_pruning.py -k celu` → 2 passed.
- `ruff format --check`, `ruff check`, `mypy onnxsim/pruning.py` — all clean on the two changed files.
- Full suite: 164 failed (pre-existing, unrelated — stale-compiled-C++-extension test failures from concurrent unrelated automation porting Python functions to C++, confirmed identical failure set before and after this change), 830 passed.

## Risks for reviewer

- Minimal, additive, one-entry change to a well-established shared constant — the lowest-risk PR in this series so far.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_