### PR TITLE
Port per-channel bias Add/Mul hop to MatMulNBits/Bnb4/Fp8/Fp4 C++ walkers

### DIFF
--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -9149,18 +9149,23 @@ void SliceNBitsSideConsumer(
 
 // From tensor `start` (a `MatMulNBits` OR plain-float MatMul/Gemm
 // producer's own output), walks forward through shape-preserving unary
-// activations (UnaryPassThroughOps) with no other consumer anywhere along
-// the way, until EITHER a `MatMulNBits` consumer OR a plain-float MatMul/
-// vanilla-Gemm consumer (MatchPlainMatMulNBitsPeer) is found whose
-// input-channel count matches `n_channels`. No per-channel Add/Mul/
-// BiasGelu/PRelu/Clip hop, no decomposed-LayerNorm/self-gated-activation
-// recognition, no branch -- narrower than WalkToConsumer above, mirroring
-// pruning.py's own `_walk_to_matmul_nbits_consumer` exactly (see this
-// section's own top comment). Returns `nullopt` if the walk runs out of
-// hops, hits a branch, or never reaches such a consumer.
+// activations (UnaryPassThroughOps) or a per-channel bias/scale `Add`/`Mul`
+// against a flat constant whose last dim equals `n_channels` (mirrors
+// WalkToConsumer's own identical hop -- the real shape a
+// `MatMulNBitsQuantizer` round trip commonly emits as a separate trailing
+// bias node, before any later ORT graph-optimizer bias-folding pass, since
+// `MatMulNBits`'s own schema has no bias input of its own), with no other
+// consumer anywhere along the way, until EITHER a `MatMulNBits` consumer OR
+// a plain-float MatMul/vanilla-Gemm consumer (MatchPlainMatMulNBitsPeer) is
+// found whose input-channel count matches `n_channels`. No BiasGelu/PRelu/
+// Clip hop, no decomposed-LayerNorm/self-gated-activation recognition, no
+// branch -- narrower than WalkToConsumer above, mirroring pruning.py's own
+// `_walk_to_matmul_nbits_consumer` exactly (see this section's own top
+// comment). Returns `nullopt` if the walk runs out of hops, hits a branch,
+// or never reaches such a consumer.
 struct MatMulNBitsWalkResult {
   NBitsSide consumer;
-  std::vector<onnx::NodeProto*> chain_ops;
+  std::vector<ChainOp> chain_ops;
 };
 
 std::optional<MatMulNBitsWalkResult> WalkToMatMulNBitsConsumer(
@@ -9168,7 +9173,7 @@ std::optional<MatMulNBitsWalkResult> WalkToMatMulNBitsConsumer(
     const ConsumerMap& consumers_of,
     const std::unordered_set<std::string>& graph_outputs, int64_t n_channels,
     int max_hops) {
-  std::vector<onnx::NodeProto*> chain_ops;
+  std::vector<ChainOp> chain_ops;
   std::string cur = start;
   for (int hop = 0; hop < max_hops; ++hop) {
     auto cit = consumers_of.find(cur);
@@ -9195,9 +9200,47 @@ std::optional<MatMulNBitsWalkResult> WalkToMatMulNBitsConsumer(
       return MatMulNBitsWalkResult{NBitsSide(*peer), std::move(chain_ops)};
     }
 
-    if (!(UnaryPassThroughOps().count(nxt->op_type()) != 0 &&
-          nxt->input_size() == 1 && nxt->input(0) == cur &&
-          nxt->output_size() == 1)) {
+    std::optional<std::string> const_name;
+    if (UnaryPassThroughOps().count(nxt->op_type()) != 0 &&
+        nxt->input_size() == 1 && nxt->input(0) == cur &&
+        nxt->output_size() == 1) {
+      // No constant operand.
+    } else if ((nxt->op_type() == "Add" || nxt->op_type() == "Mul") &&
+               nxt->input_size() == 2 && nxt->output_size() == 1 &&
+               (nxt->input(0) == cur || nxt->input(1) == cur)) {
+      // A separate trailing bias/scale `Add`/`Mul` against a flat
+      // per-channel constant -- mirrors WalkToConsumer's own identical hop.
+      // This is the real shape a `MatMulNBitsQuantizer` round trip commonly
+      // emits (before any later ORT graph-optimizer bias-folding pass),
+      // since `MatMulNBits`'s own schema has no bias input of its own.
+      const std::string& other =
+          (nxt->input(0) == cur) ? nxt->input(1) : nxt->input(0);
+      auto oit = init_map.find(other);
+      bool valid = false;
+      if (oit != init_map.end()) {
+        const onnx::TensorProto* c = oit->second;
+        int64_t prod = 1;
+        for (int64_t d : c->dims()) {
+          prod *= d;
+        }
+        valid =
+            c->data_type() == onnx::TensorProto::FLOAT && c->dims_size() > 0 &&
+            c->dims(c->dims_size() - 1) == n_channels && prod == n_channels &&
+            // Tied/shared-tensor bar -- unlike a MatMulNBits/plain-Gemm
+            // producer's own bias (checked once, at match time, by
+            // MatchMatMulNBits/MatchPlainMatMulNBitsPeer via this same
+            // `consumers_of`), a mid-chain hop's constant isn't tied to
+            // any single node's match, so it's checked here instead: a
+            // bias/scale read by more than one node would have a second
+            // reader silently left with a wrong-sized tensor once this
+            // chain's own keep-set slices it in place.
+            ConsumerCount(consumers_of, other) == 1;
+      }
+      if (!valid) {
+        return std::nullopt;
+      }
+      const_name = other;
+    } else {
       return std::nullopt;
     }
     const std::string& out2 = nxt->output(0);
@@ -9206,7 +9249,7 @@ std::optional<MatMulNBitsWalkResult> WalkToMatMulNBitsConsumer(
         graph_outputs.count(out2)) {
       return std::nullopt;
     }
-    chain_ops.push_back(nxt);
+    chain_ops.push_back(ChainOp{nxt, const_name});
     cur = out2;
   }
   return std::nullopt;
@@ -9214,7 +9257,7 @@ std::optional<MatMulNBitsWalkResult> WalkToMatMulNBitsConsumer(
 
 struct MatMulNBitsChain {
   NBitsSide producer;
-  std::vector<onnx::NodeProto*> chain_ops;
+  std::vector<ChainOp> chain_ops;
   NBitsSide consumer;
   int64_t n_channels;
 };
@@ -9332,7 +9375,7 @@ struct MatMulNBitsGatedChain {
   std::vector<onnx::NodeProto*> producer_a_pre_ops;
   NBitsSide producer_b;
   std::vector<onnx::NodeProto*> producer_b_pre_ops;
-  std::vector<onnx::NodeProto*> chain_ops;
+  std::vector<ChainOp> chain_ops;
   NBitsSide consumer;
   int64_t n_channels;
 };
@@ -9504,10 +9547,24 @@ void ApplyMatMulNBitsChains(onnx::GraphProto* graph,
   for (auto& chain : chains) {
     const std::string p_key = NBitsSideKey(chain.producer);
     const std::string c_key = NBitsSideKey(chain.consumer);
+    std::unordered_set<std::string> consts;
+    for (const auto& co : chain.chain_ops) {
+      if (co.const_name) {
+        consts.insert(*co.const_name);
+      }
+    }
     if (p_key == c_key) {
       continue;  // Degenerate (the same weight in both roles).
     }
-    if (touched.producer.count(p_key) || touched.consumer.count(c_key)) {
+    bool const_conflict = false;
+    for (const auto& c : consts) {
+      if (touched.const_names.count(c)) {
+        const_conflict = true;
+        break;
+      }
+    }
+    if (touched.producer.count(p_key) || touched.consumer.count(c_key) ||
+        const_conflict) {
       continue;  // A shared/tied weight another chain already resized.
     }
 
@@ -9541,12 +9598,20 @@ void ApplyMatMulNBitsChains(onnx::GraphProto* graph,
 
     SliceNBitsSideProducer(chain.producer, init_map, keep);
     SliceNBitsSideConsumer(chain.consumer, init_map, consumer_keep);
+    for (const auto& co : chain.chain_ops) {
+      if (co.const_name) {
+        SliceLastAxis(init_map.at(*co.const_name), keep);
+      }
+    }
 
     touched.producer.insert(p_key);
     touched.consumer.insert(c_key);
+    for (const auto& c : consts) {
+      touched.const_names.insert(c);
+    }
     touched.stale_value_info.insert(NBitsSideNode(chain.producer)->output(0));
-    for (auto* op : chain.chain_ops) {
-      touched.stale_value_info.insert(op->output(0));
+    for (auto& op : chain.chain_ops) {
+      touched.stale_value_info.insert(op.node->output(0));
     }
   }
 
@@ -9554,11 +9619,24 @@ void ApplyMatMulNBitsChains(onnx::GraphProto* graph,
     const std::string pa_key = NBitsSideKey(gchain.producer_a);
     const std::string pb_key = NBitsSideKey(gchain.producer_b);
     const std::string c_key = NBitsSideKey(gchain.consumer);
+    std::unordered_set<std::string> gconsts;
+    for (const auto& co : gchain.chain_ops) {
+      if (co.const_name) {
+        gconsts.insert(*co.const_name);
+      }
+    }
     if (pa_key == pb_key || pa_key == c_key || pb_key == c_key) {
       continue;  // Degenerate (a weight tied across two roles).
     }
+    bool gconst_conflict = false;
+    for (const auto& c : gconsts) {
+      if (touched.const_names.count(c)) {
+        gconst_conflict = true;
+        break;
+      }
+    }
     if (touched.producer.count(pa_key) || touched.producer.count(pb_key) ||
-        touched.consumer.count(c_key)) {
+        touched.consumer.count(c_key) || gconst_conflict) {
       continue;  // A shared/tied weight another chain already resized.
     }
 
@@ -9602,10 +9680,18 @@ void ApplyMatMulNBitsChains(onnx::GraphProto* graph,
     SliceNBitsSideProducer(gchain.producer_a, init_map, keep);
     SliceNBitsSideProducer(gchain.producer_b, init_map, keep);
     SliceNBitsSideConsumer(gchain.consumer, init_map, consumer_keep);
+    for (const auto& co : gchain.chain_ops) {
+      if (co.const_name) {
+        SliceLastAxis(init_map.at(*co.const_name), keep);
+      }
+    }
 
     touched.producer.insert(pa_key);
     touched.producer.insert(pb_key);
     touched.consumer.insert(c_key);
+    for (const auto& c : gconsts) {
+      touched.const_names.insert(c);
+    }
     touched.stale_value_info.insert(
         NBitsSideNode(gchain.producer_a)->output(0));
     for (auto* op : gchain.producer_a_pre_ops) {
@@ -9616,8 +9702,8 @@ void ApplyMatMulNBitsChains(onnx::GraphProto* graph,
     for (auto* op : gchain.producer_b_pre_ops) {
       touched.stale_value_info.insert(op->output(0));
     }
-    for (auto* op : gchain.chain_ops) {
-      touched.stale_value_info.insert(op->output(0));
+    for (auto& op : gchain.chain_ops) {
+      touched.stale_value_info.insert(op.node->output(0));
     }
   }
 }
@@ -9872,7 +9958,7 @@ MatMulNBitsWeight MlpBranchWeight(const MatMulNBitsMlpWeight& p, bool gate) {
 
 struct MatMulNBitsMlpChain {
   MatMulNBitsMlpWeight producer;
-  std::vector<onnx::NodeProto*> chain_ops;
+  std::vector<ChainOp> chain_ops;
   NBitsSide consumer;
   int64_t n_channels;
 };
@@ -9960,11 +10046,25 @@ void ApplyMatMulNBitsMlpChains(onnx::GraphProto* graph,
   for (auto& chain : chains) {
     auto& p = chain.producer;
     const std::string c_key = NBitsSideKey(chain.consumer);
+    std::unordered_set<std::string> consts;
+    for (const auto& co : chain.chain_ops) {
+      if (co.const_name) {
+        consts.insert(*co.const_name);
+      }
+    }
     if (p.gate_b_name == c_key || p.up_b_name == c_key) {
       continue;  // Degenerate (the same weight in both roles).
     }
+    bool const_conflict = false;
+    for (const auto& c : consts) {
+      if (touched.const_names.count(c)) {
+        const_conflict = true;
+        break;
+      }
+    }
     if (touched.producer.count(p.gate_b_name) ||
-        touched.producer.count(p.up_b_name) || touched.consumer.count(c_key)) {
+        touched.producer.count(p.up_b_name) || touched.consumer.count(c_key) ||
+        const_conflict) {
       continue;  // A shared/tied weight another chain already resized.
     }
 
@@ -10010,13 +10110,21 @@ void ApplyMatMulNBitsMlpChains(onnx::GraphProto* graph,
                              p.block_size, p.bits, p.k_blocks, init_map, keep);
     SetOrAddIntAttr(p.node, "N", static_cast<int64_t>(keep.size()));
     SliceNBitsSideConsumer(chain.consumer, init_map, consumer_keep);
+    for (const auto& co : chain.chain_ops) {
+      if (co.const_name) {
+        SliceLastAxis(init_map.at(*co.const_name), keep);
+      }
+    }
 
     touched.producer.insert(p.gate_b_name);
     touched.producer.insert(p.up_b_name);
     touched.consumer.insert(c_key);
+    for (const auto& c : consts) {
+      touched.const_names.insert(c);
+    }
     touched.stale_value_info.insert(p.node->output(0));
-    for (auto* op : chain.chain_ops) {
-      touched.stale_value_info.insert(op->output(0));
+    for (auto& op : chain.chain_ops) {
+      touched.stale_value_info.insert(op.node->output(0));
     }
   }
 }
@@ -12702,29 +12810,34 @@ void SliceMatMulBnb4ProducerRows(
 
 struct MatMulBnb4Chain {
   MatMulBnb4Weight producer;
-  std::vector<onnx::NodeProto*> chain_ops;
+  std::vector<ChainOp> chain_ops;
   PlainMatMulNBitsPeer consumer;
   int64_t n_channels = 0;
 };
 
 // From tensor `start` (a `MatMulBnb4` producer's own output), walks forward
-// through shape-preserving unary activations (UnaryPassThroughOps) with no
-// other consumer anywhere along the way, until a plain-float (directly-
-// constant weight) `MatMul`/vanilla-`Gemm` consumer
-// (MatchPlainMatMulNBitsPeer -- reused directly here, fully generic despite
-// its name) is found whose input-channel count matches `n_channels`. Unlike
+// through shape-preserving unary activations (UnaryPassThroughOps) or a
+// per-channel bias/scale `Add`/`Mul` against a flat constant whose last dim
+// equals `n_channels` (mirrors WalkToConsumer's own identical hop --
+// `MatMulBnb4`'s own live 3-input schema (`A, B, absmax`) has no bias slot
+// at all, so this separate-`Add` shape is the ONLY way a biased
+// `MatMulBnb4` layer is ever representable), with no other consumer
+// anywhere along the way, until a plain-float (directly-constant weight)
+// `MatMul`/vanilla-`Gemm` consumer (MatchPlainMatMulNBitsPeer -- reused
+// directly here, fully generic despite its name) is found whose
+// input-channel count matches `n_channels`. Unlike
 // WalkToMatMulNBitsConsumer's own `MatMulNBits`/plain-float union, a
 // `MatMulBnb4` CONSUMER is never matched here at all -- see this section's
 // own top comment for why K-axis pruning of a `MatMulBnb4` weight remains
 // out of scope. Returns `nullopt` if the walk runs out of hops, hits a
 // branch, or never reaches such a consumer. Mirrors pruning.py's own
 // `_walk_to_matmul_bnb4_consumer`.
-std::optional<std::pair<PlainMatMulNBitsPeer, std::vector<onnx::NodeProto*>>>
+std::optional<std::pair<PlainMatMulNBitsPeer, std::vector<ChainOp>>>
 WalkToMatMulBnb4Consumer(const std::string& start, const InitMap& init_map,
                          const ConsumerMap& consumers_of,
                          const std::unordered_set<std::string>& graph_outputs,
                          int64_t n_channels, int max_hops) {
-  std::vector<onnx::NodeProto*> chain_ops;
+  std::vector<ChainOp> chain_ops;
   std::string cur = start;
   for (int hop = 0; hop < max_hops; ++hop) {
     auto cit = consumers_of.find(cur);
@@ -12742,9 +12855,40 @@ WalkToMatMulBnb4Consumer(const std::string& start, const InitMap& init_map,
       return std::make_pair(*peer, std::move(chain_ops));
     }
 
-    if (!(UnaryPassThroughOps().count(nxt->op_type()) != 0 &&
-          nxt->input_size() == 1 && nxt->input(0) == cur &&
-          nxt->output_size() == 1)) {
+    std::optional<std::string> const_name;
+    if (UnaryPassThroughOps().count(nxt->op_type()) != 0 &&
+        nxt->input_size() == 1 && nxt->input(0) == cur &&
+        nxt->output_size() == 1) {
+      // No constant operand.
+    } else if ((nxt->op_type() == "Add" || nxt->op_type() == "Mul") &&
+               nxt->input_size() == 2 && nxt->output_size() == 1 &&
+               (nxt->input(0) == cur || nxt->input(1) == cur)) {
+      // A separate trailing bias/scale `Add`/`Mul` against a flat
+      // per-channel constant -- mirrors WalkToConsumer's own identical hop.
+      const std::string& other =
+          (nxt->input(0) == cur) ? nxt->input(1) : nxt->input(0);
+      auto oit = init_map.find(other);
+      bool valid = false;
+      if (oit != init_map.end()) {
+        const onnx::TensorProto* c = oit->second;
+        int64_t prod = 1;
+        for (int64_t d : c->dims()) {
+          prod *= d;
+        }
+        valid =
+            c->data_type() == onnx::TensorProto::FLOAT && c->dims_size() > 0 &&
+            c->dims(c->dims_size() - 1) == n_channels && prod == n_channels &&
+            // Tied/shared-tensor bar -- see
+            // WalkToMatMulNBitsConsumer's own identical check on this
+            // same hop for why a mid-chain hop's constant needs this
+            // checked here, not left to a producer/consumer match.
+            ConsumerCount(consumers_of, other) == 1;
+      }
+      if (!valid) {
+        return std::nullopt;
+      }
+      const_name = other;
+    } else {
       return std::nullopt;
     }
     const std::string& out2 = nxt->output(0);
@@ -12753,7 +12897,7 @@ WalkToMatMulBnb4Consumer(const std::string& start, const InitMap& init_map,
         graph_outputs.count(out2)) {
       return std::nullopt;
     }
-    chain_ops.push_back(nxt);
+    chain_ops.push_back(ChainOp{nxt, const_name});
     cur = out2;
   }
   return std::nullopt;
@@ -12821,7 +12965,21 @@ void ApplyMatMulBnb4Chains(onnx::GraphProto* graph,
   for (auto& chain : chains) {
     const std::string& p_key = chain.producer.b_name;
     const std::string& c_key = chain.consumer.w_name;
-    if (touched.producer.count(p_key) || touched.consumer.count(c_key)) {
+    std::unordered_set<std::string> consts;
+    for (const auto& co : chain.chain_ops) {
+      if (co.const_name) {
+        consts.insert(*co.const_name);
+      }
+    }
+    bool const_conflict = false;
+    for (const auto& c : consts) {
+      if (touched.const_names.count(c)) {
+        const_conflict = true;
+        break;
+      }
+    }
+    if (touched.producer.count(p_key) || touched.consumer.count(c_key) ||
+        const_conflict) {
       continue;  // A shared/tied weight another chain already resized.
     }
 
@@ -12842,12 +13000,20 @@ void ApplyMatMulBnb4Chains(onnx::GraphProto* graph,
     SliceMatMulBnb4ProducerRows(chain.producer, init_map, keep);
     SliceConsumerWeight(init_map.at(chain.consumer.w_name),
                         chain.consumer.weight_transposed, keep, false);
+    for (const auto& co : chain.chain_ops) {
+      if (co.const_name) {
+        SliceLastAxis(init_map.at(*co.const_name), keep);
+      }
+    }
 
     touched.producer.insert(p_key);
     touched.consumer.insert(c_key);
+    for (const auto& c : consts) {
+      touched.const_names.insert(c);
+    }
     touched.stale_value_info.insert(chain.producer.node->output(0));
-    for (onnx::NodeProto* op : chain.chain_ops) {
-      touched.stale_value_info.insert(op->output(0));
+    for (auto& op : chain.chain_ops) {
+      touched.stale_value_info.insert(op.node->output(0));
     }
   }
 }
@@ -16319,23 +16485,26 @@ void SliceFp4SideConsumer(
 
 struct Fp8WalkResult {
   Fp8ChainSide consumer;
-  std::vector<onnx::NodeProto*> chain_ops;
+  std::vector<ChainOp> chain_ops;
 };
 
 // From tensor `start` (a `Fp8Weight` OR plain-float MatMul/Gemm producer's
-// own output), walks forward through shape-preserving unary activations
-// with no other consumer anywhere along the way, until EITHER a
-// `MatMulBlockQuantizedFp8Weight` consumer OR a plain-float MatMul/vanilla-
-// Gemm consumer (MatchPlainMatMulNBitsPeer) is found whose input-channel
-// count matches `n_channels`. No gated pair, no branch, never a `Fp4Weight`/
-// `MatMulNBits`/QDQ consumer -- mirrors pruning.py's own `_walk_to_fp8_
-// consumer` exactly.
+// own output), walks forward through shape-preserving unary activations or
+// a per-channel bias/scale `Add`/`Mul` against a flat constant whose last
+// dim equals `n_channels` (mirrors WalkToConsumer's own identical hop --
+// mechanically mirrored from the MatMulNBits/Bnb4 fix, not independently
+// verified against a live FP8 quantizer), with no other consumer anywhere
+// along the way, until EITHER a `MatMulBlockQuantizedFp8Weight` consumer OR
+// a plain-float MatMul/vanilla-Gemm consumer (MatchPlainMatMulNBitsPeer) is
+// found whose input-channel count matches `n_channels`. No gated pair, no
+// branch, never a `Fp4Weight`/`MatMulNBits`/QDQ consumer -- mirrors
+// pruning.py's own `_walk_to_fp8_consumer` exactly.
 std::optional<Fp8WalkResult> WalkToFp8Consumer(
     const std::string& start, const InitMap& init_map,
     const ConsumerMap& consumers_of,
     const std::unordered_set<std::string>& graph_outputs, int64_t n_channels,
     int max_hops) {
-  std::vector<onnx::NodeProto*> chain_ops;
+  std::vector<ChainOp> chain_ops;
   std::string cur = start;
   for (int hop = 0; hop < max_hops; ++hop) {
     auto cit = consumers_of.find(cur);
@@ -16363,9 +16532,42 @@ std::optional<Fp8WalkResult> WalkToFp8Consumer(
       return Fp8WalkResult{Fp8ChainSide(*peer), std::move(chain_ops)};
     }
 
-    if (!(UnaryPassThroughOps().count(nxt->op_type()) != 0 &&
-          nxt->input_size() == 1 && nxt->input(0) == cur &&
-          nxt->output_size() == 1)) {
+    std::optional<std::string> const_name;
+    if (UnaryPassThroughOps().count(nxt->op_type()) != 0 &&
+        nxt->input_size() == 1 && nxt->input(0) == cur &&
+        nxt->output_size() == 1) {
+      // No constant operand.
+    } else if ((nxt->op_type() == "Add" || nxt->op_type() == "Mul") &&
+               nxt->input_size() == 2 && nxt->output_size() == 1 &&
+               (nxt->input(0) == cur || nxt->input(1) == cur)) {
+      // A separate trailing bias/scale `Add`/`Mul` against a flat
+      // per-channel constant -- mirrors WalkToConsumer's own identical hop
+      // (mechanically mirrored from the MatMulNBits/Bnb4 fix, not
+      // independently verified against a live FP8 quantizer).
+      const std::string& other =
+          (nxt->input(0) == cur) ? nxt->input(1) : nxt->input(0);
+      auto oit = init_map.find(other);
+      bool valid = false;
+      if (oit != init_map.end()) {
+        const onnx::TensorProto* c = oit->second;
+        int64_t prod = 1;
+        for (int64_t d : c->dims()) {
+          prod *= d;
+        }
+        valid =
+            c->data_type() == onnx::TensorProto::FLOAT && c->dims_size() > 0 &&
+            c->dims(c->dims_size() - 1) == n_channels && prod == n_channels &&
+            // Tied/shared-tensor bar -- see
+            // WalkToMatMulNBitsConsumer's own identical check on this
+            // same hop for why a mid-chain hop's constant needs this
+            // checked here, not left to a producer/consumer match.
+            ConsumerCount(consumers_of, other) == 1;
+      }
+      if (!valid) {
+        return std::nullopt;
+      }
+      const_name = other;
+    } else {
       return std::nullopt;
     }
     const std::string& out2 = nxt->output(0);
@@ -16374,7 +16576,7 @@ std::optional<Fp8WalkResult> WalkToFp8Consumer(
         graph_outputs.count(out2)) {
       return std::nullopt;
     }
-    chain_ops.push_back(nxt);
+    chain_ops.push_back(ChainOp{nxt, const_name});
     cur = out2;
   }
   return std::nullopt;
@@ -16382,7 +16584,7 @@ std::optional<Fp8WalkResult> WalkToFp8Consumer(
 
 struct Fp4WalkResult {
   Fp4ChainSide consumer;
-  std::vector<onnx::NodeProto*> chain_ops;
+  std::vector<ChainOp> chain_ops;
 };
 
 // `Fp4Weight` analogue of WalkToFp8Consumer -- see that function's own
@@ -16392,7 +16594,7 @@ std::optional<Fp4WalkResult> WalkToFp4Consumer(
     const ConsumerMap& consumers_of,
     const std::unordered_set<std::string>& graph_outputs, int64_t n_channels,
     int max_hops) {
-  std::vector<onnx::NodeProto*> chain_ops;
+  std::vector<ChainOp> chain_ops;
   std::string cur = start;
   for (int hop = 0; hop < max_hops; ++hop) {
     auto cit = consumers_of.find(cur);
@@ -16420,9 +16622,42 @@ std::optional<Fp4WalkResult> WalkToFp4Consumer(
       return Fp4WalkResult{Fp4ChainSide(*peer), std::move(chain_ops)};
     }
 
-    if (!(UnaryPassThroughOps().count(nxt->op_type()) != 0 &&
-          nxt->input_size() == 1 && nxt->input(0) == cur &&
-          nxt->output_size() == 1)) {
+    std::optional<std::string> const_name;
+    if (UnaryPassThroughOps().count(nxt->op_type()) != 0 &&
+        nxt->input_size() == 1 && nxt->input(0) == cur &&
+        nxt->output_size() == 1) {
+      // No constant operand.
+    } else if ((nxt->op_type() == "Add" || nxt->op_type() == "Mul") &&
+               nxt->input_size() == 2 && nxt->output_size() == 1 &&
+               (nxt->input(0) == cur || nxt->input(1) == cur)) {
+      // A separate trailing bias/scale `Add`/`Mul` against a flat
+      // per-channel constant -- mirrors WalkToConsumer's own identical hop
+      // (mechanically mirrored from the MatMulNBits/Bnb4 fix, not
+      // independently verified against a live FP4 quantizer).
+      const std::string& other =
+          (nxt->input(0) == cur) ? nxt->input(1) : nxt->input(0);
+      auto oit = init_map.find(other);
+      bool valid = false;
+      if (oit != init_map.end()) {
+        const onnx::TensorProto* c = oit->second;
+        int64_t prod = 1;
+        for (int64_t d : c->dims()) {
+          prod *= d;
+        }
+        valid =
+            c->data_type() == onnx::TensorProto::FLOAT && c->dims_size() > 0 &&
+            c->dims(c->dims_size() - 1) == n_channels && prod == n_channels &&
+            // Tied/shared-tensor bar -- see
+            // WalkToMatMulNBitsConsumer's own identical check on this
+            // same hop for why a mid-chain hop's constant needs this
+            // checked here, not left to a producer/consumer match.
+            ConsumerCount(consumers_of, other) == 1;
+      }
+      if (!valid) {
+        return std::nullopt;
+      }
+      const_name = other;
+    } else {
       return std::nullopt;
     }
     const std::string& out2 = nxt->output(0);
@@ -16431,7 +16666,7 @@ std::optional<Fp4WalkResult> WalkToFp4Consumer(
         graph_outputs.count(out2)) {
       return std::nullopt;
     }
-    chain_ops.push_back(nxt);
+    chain_ops.push_back(ChainOp{nxt, const_name});
     cur = out2;
   }
   return std::nullopt;
@@ -16439,14 +16674,14 @@ std::optional<Fp4WalkResult> WalkToFp4Consumer(
 
 struct Fp8Chain {
   Fp8ChainSide producer;
-  std::vector<onnx::NodeProto*> chain_ops;
+  std::vector<ChainOp> chain_ops;
   Fp8ChainSide consumer;
   int64_t n_channels;
 };
 
 struct Fp4Chain {
   Fp4ChainSide producer;
-  std::vector<onnx::NodeProto*> chain_ops;
+  std::vector<ChainOp> chain_ops;
   Fp4ChainSide consumer;
   int64_t n_channels;
 };
@@ -16603,10 +16838,24 @@ void ApplyFp8BlockQuantizedChains(onnx::GraphProto* graph,
   for (auto& chain : chains) {
     const std::string p_key = Fp8ChainSideKey(chain.producer);
     const std::string c_key = Fp8ChainSideKey(chain.consumer);
+    std::unordered_set<std::string> consts;
+    for (const auto& co : chain.chain_ops) {
+      if (co.const_name) {
+        consts.insert(*co.const_name);
+      }
+    }
     if (p_key == c_key) {
       continue;  // Degenerate (the same weight in both roles).
     }
-    if (touched.producer.count(p_key) || touched.consumer.count(c_key)) {
+    bool const_conflict = false;
+    for (const auto& c : consts) {
+      if (touched.const_names.count(c)) {
+        const_conflict = true;
+        break;
+      }
+    }
+    if (touched.producer.count(p_key) || touched.consumer.count(c_key) ||
+        const_conflict) {
       continue;  // A shared/tied weight another chain already resized.
     }
 
@@ -16638,13 +16887,21 @@ void ApplyFp8BlockQuantizedChains(onnx::GraphProto* graph,
 
     SliceFp8SideProducer(chain.producer, init_map, keep);
     SliceFp8SideConsumer(chain.consumer, init_map, consumer_keep);
+    for (const auto& co : chain.chain_ops) {
+      if (co.const_name) {
+        SliceLastAxis(init_map.at(*co.const_name), keep);
+      }
+    }
 
     touched.producer.insert(p_key);
     touched.consumer.insert(c_key);
+    for (const auto& c : consts) {
+      touched.const_names.insert(c);
+    }
     touched.stale_value_info.insert(
         Fp8ChainSideNode(chain.producer)->output(0));
-    for (auto* op : chain.chain_ops) {
-      touched.stale_value_info.insert(op->output(0));
+    for (auto& op : chain.chain_ops) {
+      touched.stale_value_info.insert(op.node->output(0));
     }
   }
 }
@@ -16680,10 +16937,24 @@ void ApplyFp4BlockQuantizedChains(onnx::GraphProto* graph,
   for (auto& chain : chains) {
     const std::string p_key = Fp4ChainSideKey(chain.producer);
     const std::string c_key = Fp4ChainSideKey(chain.consumer);
+    std::unordered_set<std::string> consts;
+    for (const auto& co : chain.chain_ops) {
+      if (co.const_name) {
+        consts.insert(*co.const_name);
+      }
+    }
     if (p_key == c_key) {
       continue;
     }
-    if (touched.producer.count(p_key) || touched.consumer.count(c_key)) {
+    bool const_conflict = false;
+    for (const auto& c : consts) {
+      if (touched.const_names.count(c)) {
+        const_conflict = true;
+        break;
+      }
+    }
+    if (touched.producer.count(p_key) || touched.consumer.count(c_key) ||
+        const_conflict) {
       continue;
     }
 
@@ -16715,13 +16986,21 @@ void ApplyFp4BlockQuantizedChains(onnx::GraphProto* graph,
 
     SliceFp4SideProducer(chain.producer, init_map, keep);
     SliceFp4SideConsumer(chain.consumer, init_map, consumer_keep);
+    for (const auto& co : chain.chain_ops) {
+      if (co.const_name) {
+        SliceLastAxis(init_map.at(*co.const_name), keep);
+      }
+    }
 
     touched.producer.insert(p_key);
     touched.consumer.insert(c_key);
+    for (const auto& c : consts) {
+      touched.const_names.insert(c);
+    }
     touched.stale_value_info.insert(
         Fp4ChainSideNode(chain.producer)->output(0));
-    for (auto* op : chain.chain_ops) {
-      touched.stale_value_info.insert(op->output(0));
+    for (auto& op : chain.chain_ops) {
+      touched.stale_value_info.insert(op.node->output(0));
     }
   }
 }

--- a/tests/test_structured_pruning_cpp.py
+++ b/tests/test_structured_pruning_cpp.py
@@ -5905,6 +5905,120 @@ def test_cpp_structured_pruning_matmul_nbits_matches_python_reference_output():
     np.testing.assert_allclose(y_py, y_cpp, rtol=1e-5, atol=1e-5)
 
 
+def test_cpp_structured_pruning_matmul_nbits_separate_bias_add_hop_matches_oracle():
+    # Regression test for the per-channel bias/scale `Add`/`Mul`
+    # pass-through hop (`_BINARY_CHANNEL_OPS` in pruning.py,
+    # WalkToConsumer's own identical hop in structured_pruning_entry.cpp)
+    # newly ported into WalkToMatMulNBitsConsumer: a SEPARATE trailing bias
+    # `Add` node (not MatMulNBits's own fused `bias` input) between the
+    # producer and the plain Relu/consumer -- the real shape a
+    # ``MatMulNBitsQuantizer`` round trip commonly emits before any later
+    # ORT graph-optimizer bias-folding pass. Before this hop was ported, the
+    # walk would decline at the `Add` node entirely (an unrecognized
+    # mid-chain op), leaving both `MatMulNBits` nodes byte-unchanged; with
+    # it, the chain is found, the bias is co-sliced, and the producer/
+    # consumer N/K axes are still pruned exactly as
+    # test_cpp_structured_pruning_matmul_nbits_plain_chain_matches_oracle
+    # confirms for the fused-bias case.
+    N1, K1, N2, block_size = 32, 64, 8, 16
+    rng = np.random.default_rng(9101)
+    w1 = rng.standard_normal((N1, K1)).astype(np.float32) * 0.2
+    w1[:16] *= 6.0  # rows 0-15 large (kept), 16-31 small (dropped)
+    w2 = rng.standard_normal((N2, N1)).astype(np.float32) * 0.2
+    bias1 = (rng.standard_normal(N1) * 0.05).astype(np.float32)
+
+    inits1, info1 = _nbits_weight_initializers(w1, block_size, "sb_w1")
+    inits2, info2 = _nbits_weight_initializers(w2, block_size, "sb_w2")
+
+    model = _nbits_model(
+        f"""
+        g (float[batch,{K1}] A) => (float[batch,{N2}] Y)
+        {{
+          h1 = com.microsoft.MatMulNBits<K={K1},N={N1},bits=4,block_size={block_size}>(A, {info1["b_name"]}, {info1["scales_name"]}, {info1["zp_name"]})
+          hb = Add(h1, Bias1)
+          h1a = Relu(hb)
+          Y = com.microsoft.MatMulNBits<K={N1},N={N2},bits=4,block_size={block_size}>(h1a, {info2["b_name"]}, {info2["scales_name"]}, {info2["zp_name"]})
+        }}
+        """,
+        initializer=[*inits1, *inits2, _f32(bias1, "Bias1")],
+    )
+    onnx.checker.check_model(model)
+
+    pruned_cpp = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_structured_pruning_matmul_nbits(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    onnx.checker.check_model(pruned_py)
+
+    keep = np.arange(16)
+    inits = {t.name: t for t in pruned_cpp.graph.initializer}
+    # The chain must actually be found and pruned (not silently declined):
+    # both N-axes and the separate Bias1 all shrink to the same keep_count.
+    assert list(inits["Bias1"].dims) == [16]
+    assert list(inits[info1["b_name"]].dims) == [
+        16,
+        info1["k_blocks"],
+        block_size * 4 // 8,
+    ]
+    assert list(inits[info2["b_name"]].dims) == [N2, 1, block_size * 4 // 8]
+    np.testing.assert_allclose(onnx.numpy_helper.to_array(inits["Bias1"]), bias1[keep])
+
+    # Byte-for-byte parity with the (already-correct) Python reference.
+    py_bytes = {t.name: t.SerializeToString() for t in pruned_py.graph.initializer}
+    cpp_bytes = {t.name: t.SerializeToString() for t in pruned_cpp.graph.initializer}
+    assert py_bytes == cpp_bytes
+
+    rng2 = np.random.default_rng(9102)
+    x = rng2.standard_normal((3, K1)).astype(np.float32)
+    (y_pruned,) = _run(pruned_cpp, {"A": x})
+    w1_dequant = _nbits_dequant(
+        info1["qcodes"], info1["scales"], info1["zp"], block_size
+    )
+    w2_dequant = _nbits_dequant(
+        info2["qcodes"], info2["scales"], info2["zp"], block_size
+    )
+    h1 = np.maximum(x.astype(np.float64) @ w1_dequant[keep].T + bias1[keep], 0.0)
+    y_oracle = h1 @ w2_dequant[:, keep].T
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-3, atol=1e-3)
+
+
+def test_cpp_structured_pruning_matmul_nbits_separate_bias_add_tied_declines():
+    # Bias1 (the mid-chain Add's own per-channel constant) is ALSO read by a
+    # second, unrelated Add elsewhere in the graph -- the tied/shared-tensor
+    # bar this hop's own C++ comment documents (mirrors
+    # `len(consumers_of.get(other, [])) == 1` in pruning.py): slicing Bias1
+    # in place would silently corrupt that second reader, so the walk must
+    # decline the Add hop (and hence the whole chain) entirely, leaving the
+    # model byte-unchanged. `h1` itself keeps exactly one consumer (`hb`),
+    # so this exercises the Add-hop's own tied-constant check specifically,
+    # not the ordinary "more than one consumer" top-of-loop dispatch.
+    N1, K1, N2, block_size = 32, 64, 8, 16
+    rng = np.random.default_rng(9111)
+    w1 = rng.standard_normal((N1, K1)).astype(np.float32) * 0.2
+    w2 = rng.standard_normal((N2, N1)).astype(np.float32) * 0.2
+    bias1 = (rng.standard_normal(N1) * 0.05).astype(np.float32)
+
+    inits1, info1 = _nbits_weight_initializers(w1, block_size, "td_w1")
+    inits2, info2 = _nbits_weight_initializers(w2, block_size, "td_w2")
+
+    model = _nbits_model(
+        f"""
+        g (float[batch,{K1}] A, float[batch,{N1}] B) => (float[batch,{N2}] Y, float[batch,{N1}] Y2)
+        {{
+          h1 = com.microsoft.MatMulNBits<K={K1},N={N1},bits=4,block_size={block_size}>(A, {info1["b_name"]}, {info1["scales_name"]}, {info1["zp_name"]})
+          hb = Add(h1, Bias1)
+          h1a = Relu(hb)
+          Y = com.microsoft.MatMulNBits<K={N1},N={N2},bits=4,block_size={block_size}>(h1a, {info2["b_name"]}, {info2["scales_name"]}, {info2["zp_name"]})
+          Y2 = Add(B, Bias1)
+        }}
+        """,
+        initializer=[*inits1, *inits2, _f32(bias1, "Bias1")],
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
 # --- MatMulNBitsMlp (com.microsoft, fused gated-MLP block-quantized weight)
 # --- structured pruning ---------------------------------------------------
 #
@@ -7228,6 +7342,149 @@ def test_cpp_structured_pruning_matmul_bnb4_matches_python_reference_output():
     np.testing.assert_array_equal(y_py, y_cpp)
 
 
+def test_cpp_structured_pruning_matmul_bnb4_separate_bias_add_hop_matches_oracle():
+    # Regression test for the per-channel bias/scale `Add`/`Mul`
+    # pass-through hop newly ported into WalkToMatMulBnb4Consumer: a
+    # SEPARATE trailing bias `Add` node between the `MatMulBnb4` producer
+    # and the plain-float `MatMul` consumer -- the ONLY way a biased
+    # `MatMulBnb4` layer is representable at all, since the op's own live
+    # 3-input schema (`A, B, absmax`) has no bias slot of its own. Before
+    # this hop was ported, the walk would decline at the `Add` node
+    # entirely, leaving the producer byte-unchanged; with it, the chain is
+    # found, the bias is co-sliced, and `N` is still pruned exactly as
+    # test_cpp_structured_pruning_matmul_bnb4_plain_chain_matches_oracle
+    # confirms for the no-bias case.
+    K, N1, N2, block_size, quant_type = 64, 32, 8, 16, 1
+    rng = np.random.default_rng(31200)
+    W1 = rng.uniform(-1, 1, size=(K, N1)).astype(np.float32)
+    # Column-scale W1 so the top-16-by-L2-norm keep-set is unambiguous.
+    W1 = W1 * np.linspace(0.1, 3.0, N1, dtype=np.float32)[None, :]
+    W2 = rng.uniform(-1, 1, size=(N1, N2)).astype(np.float32)
+    bias1 = (rng.standard_normal(N1) * 0.05).astype(np.float32)
+    B1, absmax1 = _bnb4_quantize(W1, quant_type, block_size)
+
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 21, "com.microsoft": 1]
+        >
+        g (float[3,{K}] A) => (float[3,{N2}] Y)
+        {{
+          h1 = com.microsoft.MatMulBnb4 <K={K}, N={N1}, block_size={block_size}, quant_type={quant_type}> (A, B1, absmax1)
+          hb = Add(h1, Bias1)
+          h1a = Relu(hb)
+          Y = MatMul(h1a, W2)
+        }}
+        """
+    )
+    model.graph.initializer.extend(
+        [
+            onnx.numpy_helper.from_array(B1, name="B1"),
+            onnx.numpy_helper.from_array(absmax1, name="absmax1"),
+            _f32(W2, "W2"),
+            _f32(bias1, "Bias1"),
+        ]
+    )
+    onnx.checker.check_model(model)
+
+    pruned_cpp = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_structured_pruning_matmul_bnb4(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    onnx.checker.check_model(pruned_py)
+
+    mm1 = next(n for n in pruned_cpp.graph.node if n.op_type == "MatMulBnb4")
+    assert {a.name: a.i for a in mm1.attribute}["N"] == 16
+
+    col_norms = np.linalg.norm(W1, axis=0)
+    keep = np.sort(np.argsort(-col_norms, kind="stable")[:16])
+
+    pruned_inits = {t.name: t for t in pruned_cpp.graph.initializer}
+    B1_pruned = onnx.numpy_helper.to_array(pruned_inits[mm1.input[1]])
+    absmax1_pruned = onnx.numpy_helper.to_array(pruned_inits[mm1.input[2]])
+    B1_ref, absmax1_ref = _bnb4_quantize(W1[:, keep], quant_type, block_size)
+    np.testing.assert_array_equal(B1_pruned, B1_ref)
+    np.testing.assert_array_equal(absmax1_pruned, absmax1_ref)
+    np.testing.assert_allclose(
+        onnx.numpy_helper.to_array(pruned_inits["Bias1"]), bias1[keep]
+    )
+
+    # Byte-for-byte parity with the (already-correct) Python reference.
+    py_bytes = {t.name: t.SerializeToString() for t in pruned_py.graph.initializer}
+    cpp_bytes = {t.name: t.SerializeToString() for t in pruned_cpp.graph.initializer}
+    assert py_bytes == cpp_bytes
+
+    ref_model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 21, "com.microsoft": 1]
+        >
+        g (float[3,{K}] A) => (float[3,{N2}] Y)
+        {{
+          h1 = com.microsoft.MatMulBnb4 <K={K}, N={len(keep)}, block_size={block_size}, quant_type={quant_type}> (A, B1r, absmax1r)
+          hb = Add(h1, Bias1r)
+          h1a = Relu(hb)
+          Y = MatMul(h1a, W2r)
+        }}
+        """
+    )
+    ref_model.graph.initializer.extend(
+        [
+            onnx.numpy_helper.from_array(B1_ref, name="B1r"),
+            onnx.numpy_helper.from_array(absmax1_ref, name="absmax1r"),
+            _f32(W2[keep, :], "W2r"),
+            _f32(bias1[keep], "Bias1r"),
+        ]
+    )
+    A = rng.uniform(-1, 1, size=(3, K)).astype(np.float32)
+    (pruned_out,) = _run(pruned_cpp, {"A": A})
+    (ref_out,) = _run(ref_model, {"A": A})
+    np.testing.assert_array_equal(pruned_out, ref_out)
+
+
+def test_cpp_structured_pruning_matmul_bnb4_separate_bias_add_tied_declines():
+    # Bias1 is ALSO read by a second, unrelated Add -- the tied/shared-
+    # tensor bar this hop's own C++ comment documents: slicing Bias1 in
+    # place would silently corrupt that second reader, so the walk must
+    # decline the Add hop (and hence the whole chain) entirely.
+    K, N1, N2, block_size, quant_type = 64, 32, 8, 16, 1
+    rng = np.random.default_rng(31210)
+    W1 = rng.uniform(-1, 1, size=(K, N1)).astype(np.float32)
+    W2 = rng.uniform(-1, 1, size=(N1, N2)).astype(np.float32)
+    bias1 = (rng.standard_normal(N1) * 0.05).astype(np.float32)
+    B1, absmax1 = _bnb4_quantize(W1, quant_type, block_size)
+
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 21, "com.microsoft": 1]
+        >
+        g (float[3,{K}] A, float[3,{N1}] B) => (float[3,{N2}] Y, float[3,{N1}] Y2)
+        {{
+          h1 = com.microsoft.MatMulBnb4 <K={K}, N={N1}, block_size={block_size}, quant_type={quant_type}> (A, B1, absmax1)
+          hb = Add(h1, Bias1)
+          h1a = Relu(hb)
+          Y = MatMul(h1a, W2)
+          Y2 = Add(B, Bias1)
+        }}
+        """
+    )
+    model.graph.initializer.extend(
+        [
+            onnx.numpy_helper.from_array(B1, name="B1"),
+            onnx.numpy_helper.from_array(absmax1, name="absmax1"),
+            _f32(W2, "W2"),
+            _f32(bias1, "Bias1"),
+        ]
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
 # --- MatMulBlockQuantizedFp4Weight/MatMulBlockQuantizedFp8Weight -----------
 # --- (NVFP4/FP8 block-quantized weight) structured pruning ----------------
 #
@@ -7525,6 +7782,119 @@ def test_cpp_structured_pruning_matmul_block_quantized_fp8_matches_python_refere
     assert py_bytes == cpp_bytes
 
 
+def test_cpp_structured_pruning_matmul_block_quantized_fp8_separate_bias_add_hop_matches_python_reference():
+    # Regression test for the per-channel bias/scale `Add`/`Mul`
+    # pass-through hop newly ported into WalkToFp8Consumer: a separate bias
+    # `Add` node between the first `MatMulBlockQuantizedFp8Weight` producer
+    # and the second consumer. Before this hop was ported, the walk would
+    # decline at the `Add` node entirely, leaving both nodes byte-unchanged;
+    # with it, the chain is found and both N-axes are pruned. As
+    # pruning.py's own comment on this exact hop notes, it was "mechanically
+    # mirrored from the MatMulNBits/Bnb4 fix, not independently verified
+    # against a live FP8 quantizer" (neither `MatMulBlockQuantizedFp8Weight`
+    # nor `Add(float16, float32)` has a real CPU kernel/strict type-checker
+    # opinion in this environment either way -- see this section's own top
+    # comment), so byte-for-byte parity with that Python reference
+    # implementation -- not a real onnxruntime kernel run -- is the
+    # correctness bar this test applies, mirroring the plain-chain
+    # matches_python_reference test above.
+    N1, K1, N2, block_size = 16, 32, 8, 8
+    rng = np.random.default_rng(41200)
+    W1 = (rng.standard_normal((N1, K1)) * 0.2).astype(np.float32)
+    W1[:8] *= 6.0
+    W2 = (rng.standard_normal((N2, N1)) * 0.2).astype(np.float32)
+    bias1 = (rng.standard_normal(N1) * 0.05).astype(np.float32)
+    b1, s1, _dq1 = _fp8bq_quantize(W1, block_size)
+    b2, s2, _dq2 = _fp8bq_quantize(W2, block_size)
+
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 21, "com.microsoft": 1]
+        >
+        g (float16[3,{K1}] A) => (float16[3,{N2}] Y)
+        {{
+          h1 = com.microsoft.MatMulBlockQuantizedFp8Weight <block_size={block_size}> (A, B1, S1)
+          hb = Add(h1, Bias1)
+          h1a = Relu(hb)
+          Y = com.microsoft.MatMulBlockQuantizedFp8Weight <block_size={block_size}> (h1a, B2, S2)
+        }}
+        """
+    )
+    model.graph.initializer.extend(
+        [
+            onnx.numpy_helper.from_array(b1, name="B1"),
+            _f32(s1, "S1"),
+            _f32(bias1, "Bias1"),
+            onnx.numpy_helper.from_array(b2, name="B2"),
+            _f32(s2, "S2"),
+        ]
+    )
+    onnx.checker.check_model(model)
+
+    pruned_py = onnxsim.apply_structured_pruning_matmul_block_quantized_fp8(
+        model, sparsity=0.5
+    )
+    pruned_cpp = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_py)
+    onnx.checker.check_model(pruned_cpp)
+
+    # The chain must actually be found and pruned (not silently declined).
+    inits = {t.name: t for t in pruned_cpp.graph.initializer}
+    assert onnx.numpy_helper.to_array(inits["B1"]).shape == (8, K1)
+    assert onnx.numpy_helper.to_array(inits["Bias1"]).shape == (8,)
+    np.testing.assert_allclose(onnx.numpy_helper.to_array(inits["Bias1"]), bias1[:8])
+
+    py_bytes = {t.name: t.SerializeToString() for t in pruned_py.graph.initializer}
+    cpp_bytes = {t.name: t.SerializeToString() for t in pruned_cpp.graph.initializer}
+    assert py_bytes == cpp_bytes
+
+
+def test_cpp_structured_pruning_matmul_block_quantized_fp8_separate_bias_add_tied_declines():
+    # Bias1 is ALSO read by a second, unrelated Add -- the tied/shared-
+    # tensor bar this hop's own C++ comment documents: slicing Bias1 in
+    # place would silently corrupt that second reader, so the walk must
+    # decline the Add hop (and hence the whole chain) entirely.
+    N1, K1, N2, block_size = 16, 32, 8, 8
+    rng = np.random.default_rng(41210)
+    W1 = (rng.standard_normal((N1, K1)) * 0.2).astype(np.float32)
+    W2 = (rng.standard_normal((N2, N1)) * 0.2).astype(np.float32)
+    bias1 = (rng.standard_normal(N1) * 0.05).astype(np.float32)
+    b1, s1, _dq1 = _fp8bq_quantize(W1, block_size)
+    b2, s2, _dq2 = _fp8bq_quantize(W2, block_size)
+
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 21, "com.microsoft": 1]
+        >
+        g (float16[3,{K1}] A, float16[3,{N1}] B) => (float16[3,{N2}] Y, float16[3,{N1}] Y2)
+        {{
+          h1 = com.microsoft.MatMulBlockQuantizedFp8Weight <block_size={block_size}> (A, B1, S1)
+          hb = Add(h1, Bias1)
+          h1a = Relu(hb)
+          Y = com.microsoft.MatMulBlockQuantizedFp8Weight <block_size={block_size}> (h1a, B2, S2)
+          Y2 = Add(B, Bias1)
+        }}
+        """
+    )
+    model.graph.initializer.extend(
+        [
+            onnx.numpy_helper.from_array(b1, name="B1"),
+            _f32(s1, "S1"),
+            _f32(bias1, "Bias1"),
+            onnx.numpy_helper.from_array(b2, name="B2"),
+            _f32(s2, "S2"),
+        ]
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    assert pruned.SerializeToString() == model.SerializeToString()
+
+
 def _fp4bq_chain_model(N1, K1, N2, block_size, W1, gs1, W2, gs2):
     """``Fp4Weight`` analogue of :func:`_fp8bq_chain_model`."""
     p1, ws1, dq1 = _fp4bq_quantize(W1, gs1, block_size)
@@ -7771,6 +8141,114 @@ def test_cpp_structured_pruning_matmul_block_quantized_fp4_matches_python_refere
     py_bytes = {t.name: t.SerializeToString() for t in pruned_py.graph.initializer}
     cpp_bytes = {t.name: t.SerializeToString() for t in pruned_cpp.graph.initializer}
     assert py_bytes == cpp_bytes
+
+
+def test_cpp_structured_pruning_matmul_block_quantized_fp4_separate_bias_add_hop_matches_python_reference():
+    # `Fp4Weight` analogue of
+    # test_cpp_structured_pruning_matmul_block_quantized_fp8_separate_bias_
+    # add_hop_matches_python_reference -- see that test's own docstring for
+    # why byte-for-byte parity with the Python reference implementation
+    # (rather than a real onnxruntime kernel run) is the correctness bar
+    # here too.
+    N1, K1, N2, block_size = 16, 32, 8, 8
+    rng = np.random.default_rng(41250)
+    W1 = (rng.standard_normal((N1, K1)) * 1.0).astype(np.float32)
+    W1[:8] *= 6.0
+    W2 = (rng.standard_normal((N2, N1)) * 1.0).astype(np.float32)
+    bias1 = (rng.standard_normal(N1) * 0.05).astype(np.float32)
+    p1, ws1, _dq1 = _fp4bq_quantize(W1, 1.0, block_size)
+    p2, ws2, _dq2 = _fp4bq_quantize(W2, 1.0, block_size)
+
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 21, "com.microsoft": 1]
+        >
+        g (float16[3,{K1}] A) => (float16[3,{N2}] Y)
+        {{
+          h1 = com.microsoft.MatMulBlockQuantizedFp4Weight <block_size={block_size}> (A, B1, WS1, WS21)
+          hb = Add(h1, Bias1)
+          h1a = Relu(hb)
+          Y = com.microsoft.MatMulBlockQuantizedFp4Weight <block_size={block_size}> (h1a, B2, WS2, WS22)
+        }}
+        """
+    )
+    model.graph.initializer.extend(
+        [
+            onnx.numpy_helper.from_array(p1, name="B1"),
+            onnx.numpy_helper.from_array(ws1, name="WS1"),
+            _f32(np.array([1.0], dtype=np.float32), "WS21"),
+            _f32(bias1, "Bias1"),
+            onnx.numpy_helper.from_array(p2, name="B2"),
+            onnx.numpy_helper.from_array(ws2, name="WS2"),
+            _f32(np.array([1.0], dtype=np.float32), "WS22"),
+        ]
+    )
+    onnx.checker.check_model(model)
+
+    pruned_py = onnxsim.apply_structured_pruning_matmul_block_quantized_fp4(
+        model, sparsity=0.5
+    )
+    pruned_cpp = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_py)
+    onnx.checker.check_model(pruned_cpp)
+
+    # The chain must actually be found and pruned (not silently declined).
+    inits = {t.name: t for t in pruned_cpp.graph.initializer}
+    assert onnx.numpy_helper.to_array(inits["B1"]).shape == (8, K1 // 2)
+    assert onnx.numpy_helper.to_array(inits["Bias1"]).shape == (8,)
+    np.testing.assert_allclose(onnx.numpy_helper.to_array(inits["Bias1"]), bias1[:8])
+
+    py_bytes = {t.name: t.SerializeToString() for t in pruned_py.graph.initializer}
+    cpp_bytes = {t.name: t.SerializeToString() for t in pruned_cpp.graph.initializer}
+    assert py_bytes == cpp_bytes
+
+
+def test_cpp_structured_pruning_matmul_block_quantized_fp4_separate_bias_add_tied_declines():
+    # Bias1 is ALSO read by a second, unrelated Add -- the tied/shared-
+    # tensor bar this hop's own C++ comment documents: slicing Bias1 in
+    # place would silently corrupt that second reader, so the walk must
+    # decline the Add hop (and hence the whole chain) entirely.
+    N1, K1, N2, block_size = 16, 32, 8, 8
+    rng = np.random.default_rng(41260)
+    W1 = (rng.standard_normal((N1, K1)) * 1.0).astype(np.float32)
+    W2 = (rng.standard_normal((N2, N1)) * 1.0).astype(np.float32)
+    bias1 = (rng.standard_normal(N1) * 0.05).astype(np.float32)
+    p1, ws1, _dq1 = _fp4bq_quantize(W1, 1.0, block_size)
+    p2, ws2, _dq2 = _fp4bq_quantize(W2, 1.0, block_size)
+
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 21, "com.microsoft": 1]
+        >
+        g (float16[3,{K1}] A, float16[3,{N1}] B) => (float16[3,{N2}] Y, float16[3,{N1}] Y2)
+        {{
+          h1 = com.microsoft.MatMulBlockQuantizedFp4Weight <block_size={block_size}> (A, B1, WS1, WS21)
+          hb = Add(h1, Bias1)
+          h1a = Relu(hb)
+          Y = com.microsoft.MatMulBlockQuantizedFp4Weight <block_size={block_size}> (h1a, B2, WS2, WS22)
+          Y2 = Add(B, Bias1)
+        }}
+        """
+    )
+    model.graph.initializer.extend(
+        [
+            onnx.numpy_helper.from_array(p1, name="B1"),
+            onnx.numpy_helper.from_array(ws1, name="WS1"),
+            _f32(np.array([1.0], dtype=np.float32), "WS21"),
+            _f32(bias1, "Bias1"),
+            onnx.numpy_helper.from_array(p2, name="B2"),
+            onnx.numpy_helper.from_array(ws2, name="WS2"),
+            _f32(np.array([1.0], dtype=np.float32), "WS22"),
+        ]
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning_cpp(model, sparsity=0.5)
+    assert pruned.SerializeToString() == model.SerializeToString()
 
 
 # --- QOperator (QLinearConv/QLinearMatMul/QGemm static-quantization) -------


### PR DESCRIPTION
## Summary

This ports a Python-side fix to its C++ counterpart. `onnxsim/pruning.py`'s per-channel bias `Add`/`Mul` pass-through hop (`_BINARY_CHANNEL_OPS`) is wired into `_walk_to_matmul_nbits_consumer`/`_walk_to_matmul_bnb4_consumer`/`_walk_to_fp8_consumer`/`_walk_to_fp4_consumer`, but the C++ implementations of these same four walkers (`WalkToMatMulNBitsConsumer`/`WalkToMatMulBnb4Consumer`/`WalkToFp8Consumer`/`WalkToFp4Consumer`, `onnxsim/structured_pruning_entry.cpp`) never had it — each function's own comment self-documented the gap. The identical hop is already correctly implemented in C++ for the plain-float walker (`WalkToConsumer`), which served as the direct template for this port.

## What's added

- The per-channel bias `Add`/`Mul` hop (FLOAT dtype, last-dim/total-element-count both equal to the channel count, plus a tied/shared-tensor guard via the existing `ConsumerCount` helper) added to all four C++ walkers, mirroring `WalkToConsumer`'s own implementation.
- Each walker's `chain_ops` changed from a bare node-pointer vector to a `vector<ChainOp>` (the existing `{node, optional<const_name>}` struct already used elsewhere in this file), cascading through `MatMulNBitsChain`/`MatMulNBitsGatedChain`/`MatMulNBitsMlpChain` (reuses the NBits walker verbatim), `MatMulBnb4Chain`, `Fp8Chain`, `Fp4Chain`.
- The corresponding `Apply*Chains` functions (plain and gated loops) now slice the mid-chain constant via `SliceLastAxis` and track/check it against a `touched.const_names` set, mirroring `pruning.py`'s own `consts & const_touched` tied-tensor pattern.

## Test plan

- 8 new regression tests in `tests/test_structured_pruning_cpp.py`: a positive "separate trailing bias Add" match+prune test per family (`MatMulNBits`/`MatMulBnb4` verified via a real `onnxruntime` inference run plus byte-parity against the Python reference; FP8/FP4 verified via byte-parity against the Python reference, per this file's established practice since those ops have no real CPU execution kernel), plus a tied/shared-bias decline test per family.
- Full local rebuild (`pip install -e . --no-build-isolation`, isolated venv, `-DONNXSIM_BUILTIN_ORT=OFF`) and independent re-verification of the resulting `.so`.
- This branch was rebased against the latest `master` (which had, in the meantime, merged the sibling fused-GQA true-MQA C++ port touching a different region of the same file) — merged cleanly with no conflicts, rebuilt, and re-verified.
- `pytest tests/test_structured_pruning_cpp.py tests/test_structured_wanda_pruning_cpp.py tests/test_attention_head_pruning_cpp.py tests/test_attention_head_wanda_pruning_cpp.py` → 329 passed.
- Broader regression check: `test_sparsegpt_pruning_cpp.py`, `test_transformer_block_pruning_cpp.py`, `test_wanda_pruning_cpp.py` → 68 passed, no regressions.
- Relevant Python-side tests (`pytest tests/test_pruning.py -k "nbits or bnb4 or fp8 or fp4"`) unaffected.
- `clang-format --style=file:onnxsim/.clang-format --dry-run --Werror onnxsim/structured_pruning_entry.cpp` → clean. `ruff format`/`ruff check` on the test file → clean.

## Risks for reviewer

- This is a mechanical, closely-templated port (same pattern applied identically across four functions) — the main risk is a copy/adapt error in one of the four, which the per-family positive+decline test pairs are specifically designed to catch.
- FP8/FP4 tests are verified via byte-parity against the Python reference rather than real inference, consistent with this file's own established convention for those two families (no real CPU execution kernel exists for them in this environment).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_